### PR TITLE
Refactor enum map range to slice range

### DIFF
--- a/containerd-shim/process_linux.go
+++ b/containerd-shim/process_linux.go
@@ -74,35 +74,44 @@ func (p *process) openIO() error {
 	}
 	p.shimIO = i
 	// non-tty
-	for name, dest := range map[string]func(wc io.WriteCloser, rc io.Closer){
-		p.state.Stdout: func(wc io.WriteCloser, rc io.Closer) {
-			p.Add(1)
-			go func() {
-				io.Copy(wc, i.Stdout)
-				p.Done()
-				wc.Close()
-				rc.Close()
-			}()
+	for _, pair := range []struct {
+		name string
+		dest func(wc io.WriteCloser, rc io.Closer)
+	}{
+		{
+			p.state.Stdout,
+			func(wc io.WriteCloser, rc io.Closer) {
+				p.Add(1)
+				go func() {
+					io.Copy(wc, i.Stdout)
+					p.Done()
+					wc.Close()
+					rc.Close()
+				}()
+			},
 		},
-		p.state.Stderr: func(wc io.WriteCloser, rc io.Closer) {
-			p.Add(1)
-			go func() {
-				io.Copy(wc, i.Stderr)
-				p.Done()
-				wc.Close()
-				rc.Close()
-			}()
+		{
+			p.state.Stderr,
+			func(wc io.WriteCloser, rc io.Closer) {
+				p.Add(1)
+				go func() {
+					io.Copy(wc, i.Stderr)
+					p.Done()
+					wc.Close()
+					rc.Close()
+				}()
+			},
 		},
 	} {
-		fw, err := fifo.OpenFifo(ctx, name, syscall.O_WRONLY, 0)
+		fw, err := fifo.OpenFifo(ctx, pair.name, syscall.O_WRONLY, 0)
 		if err != nil {
-			return fmt.Errorf("containerd-shim: opening %s failed: %s", name, err)
+			return fmt.Errorf("containerd-shim: opening %s failed: %s", pair.name, err)
 		}
-		fr, err := fifo.OpenFifo(ctx, name, syscall.O_RDONLY, 0)
+		fr, err := fifo.OpenFifo(ctx, pair.name, syscall.O_RDONLY, 0)
 		if err != nil {
-			return fmt.Errorf("containerd-shim: opening %s failed: %s", name, err)
+			return fmt.Errorf("containerd-shim: opening %s failed: %s", pair.name, err)
 		}
-		dest(fw, fr)
+		pair.dest(fw, fr)
 	}
 
 	f, err := fifo.OpenFifo(ctx, p.state.Stdin, syscall.O_RDONLY, 0)

--- a/ctr/container.go
+++ b/ctr/container.go
@@ -690,16 +690,19 @@ func createStdio() (s stdio, tmp string, err error) {
 		return s, tmp, err
 	}
 	// create fifo's for the process
-	for name, fd := range map[string]*string{
-		"stdin":  &s.stdin,
-		"stdout": &s.stdout,
-		"stderr": &s.stderr,
+	for _, pair := range []struct {
+		name string
+		fd   *string
+	}{
+		{"stdin", &s.stdin},
+		{"stdout", &s.stdout},
+		{"stderr", &s.stderr},
 	} {
-		path := filepath.Join(tmp, name)
+		path := filepath.Join(tmp, pair.name)
 		if err := unix.Mkfifo(path, 0755); err != nil && !os.IsExist(err) {
 			return s, tmp, err
 		}
-		*fd = path
+		*pair.fd = path
 	}
 	return s, tmp, nil
 }

--- a/integration-test/container_utils_test.go
+++ b/integration-test/container_utils_test.go
@@ -198,13 +198,16 @@ func NewContainerProcess(cs *ContainerdSuite, bundle *Bundle, cid, pid string) (
 		hasExited:   false,
 	}
 
-	for name, path := range map[string]*string{
-		"stdin":  &c.io.stdin,
-		"stdout": &c.io.stdout,
-		"stderr": &c.io.stderr,
+	for _, pair := range []struct {
+		name string
+		path *string
+	}{
+		{"stdin", &c.io.stdin},
+		{"stdout", &c.io.stdout},
+		{"stderr", &c.io.stderr},
 	} {
-		*path = filepath.Join(bundle.Path, "io", cid+"-"+pid+"-"+name)
-		if err = unix.Mkfifo(*path, 0755); err != nil && !os.IsExist(err) {
+		*pair.path = filepath.Join(bundle.Path, "io", cid+"-"+pid+"-"+pair.name)
+		if err = unix.Mkfifo(*pair.path, 0755); err != nil && !os.IsExist(err) {
 			return nil, err
 		}
 	}

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -65,13 +65,16 @@ func setupStdio(cwd string, bundlePath string, bundleName string) (Stdio, error)
 	s := NewStdio(devNull, devNull, devNull)
 
 	pid := "init"
-	for stdName, stdPath := range map[string]*string{
-		"stdin":  &s.Stdin,
-		"stdout": &s.Stdout,
-		"stderr": &s.Stderr,
+	for _, pair := range []struct {
+		stdName string
+		stdPath *string
+	}{
+		{"stdin", &s.Stdin},
+		{"stdout", &s.Stdout},
+		{"stderr", &s.Stderr},
 	} {
-		*stdPath = filepath.Join(cwd, bundlePath, "io", bundleName+"-"+pid+"-"+stdName)
-		if err := syscall.Mkfifo(*stdPath, 0755); err != nil && !os.IsExist(err) {
+		*pair.stdPath = filepath.Join(cwd, bundlePath, "io", bundleName+"-"+pid+"-"+pair.stdName)
+		if err := syscall.Mkfifo(*pair.stdPath, 0755); err != nil && !os.IsExist(err) {
 			fmt.Println("Mkfifo error: ", err)
 			return s, err
 		}


### PR DESCRIPTION
grep -r "range map" show 5 parts use map to range enum types,
use slice instead can get better performance and less memory usage.

Signed-off-by: Wang Long <long.wanglong@huawei.com>