### PR TITLE
MemoryLimit can be negative

### DIFF
--- a/api/grpc/server/server.go
+++ b/api/grpc/server/server.go
@@ -276,19 +276,19 @@ func (s *apiServer) UpdateContainer(ctx context.Context, r *types.UpdateContaine
 			e.Resources.CpusetMems = rs.CpusetMems
 		}
 		if rs.KernelMemoryLimit != 0 {
-			e.Resources.KernelMemory = int64(rs.KernelMemoryLimit)
+			e.Resources.KernelMemory = rs.KernelMemoryLimit
 		}
 		if rs.KernelTCPMemoryLimit != 0 {
 			e.Resources.KernelTCPMemory = int64(rs.KernelTCPMemoryLimit)
 		}
 		if rs.MemoryLimit != 0 {
-			e.Resources.Memory = int64(rs.MemoryLimit)
+			e.Resources.Memory = rs.MemoryLimit
 		}
 		if rs.MemoryReservation != 0 {
-			e.Resources.MemoryReservation = int64(rs.MemoryReservation)
+			e.Resources.MemoryReservation = rs.MemoryReservation
 		}
 		if rs.MemorySwap != 0 {
-			e.Resources.MemorySwap = int64(rs.MemorySwap)
+			e.Resources.MemorySwap = rs.MemorySwap
 		}
 	}
 	s.sv.SendTask(e)

--- a/api/grpc/types/api.pb.go
+++ b/api/grpc/types/api.pb.go
@@ -1040,10 +1040,10 @@ type UpdateResource struct {
 	CpuQuota                     uint64            `protobuf:"varint,4,opt,name=cpuQuota" json:"cpuQuota,omitempty"`
 	CpusetCpus                   string            `protobuf:"bytes,5,opt,name=cpusetCpus" json:"cpusetCpus,omitempty"`
 	CpusetMems                   string            `protobuf:"bytes,6,opt,name=cpusetMems" json:"cpusetMems,omitempty"`
-	MemoryLimit                  int64             `protobuf:"varint,7,opt,name=memoryLimit" json:"memoryLimit,omitempty"`
-	MemorySwap                   int64             `protobuf:"varint,8,opt,name=memorySwap" json:"memorySwap,omitempty"`
-	MemoryReservation            int64             `protobuf:"varint,9,opt,name=memoryReservation" json:"memoryReservation,omitempty"`
-	KernelMemoryLimit            int64             `protobuf:"varint,10,opt,name=kernelMemoryLimit" json:"kernelMemoryLimit,omitempty"`
+	MemoryLimit                  uint64            `protobuf:"varint,7,opt,name=memoryLimit" json:"memoryLimit,omitempty"`
+	MemorySwap                   uint64            `protobuf:"varint,8,opt,name=memorySwap" json:"memorySwap,omitempty"`
+	MemoryReservation            uint64            `protobuf:"varint,9,opt,name=memoryReservation" json:"memoryReservation,omitempty"`
+	KernelMemoryLimit            uint64            `protobuf:"varint,10,opt,name=kernelMemoryLimit" json:"kernelMemoryLimit,omitempty"`
 	KernelTCPMemoryLimit         int64             `protobuf:"varint,11,opt,name=kernelTCPMemoryLimit" json:"kernelTCPMemoryLimit,omitempty"`
 	BlkioLeafWeight              uint64            `protobuf:"varint,12,opt,name=blkioLeafWeight" json:"blkioLeafWeight,omitempty"`
 	BlkioWeightDevice            []*WeightDevice   `protobuf:"bytes,13,rep,name=blkioWeightDevice" json:"blkioWeightDevice,omitempty"`
@@ -1128,7 +1128,7 @@ func (m *UpdateResource) GetKernelMemoryLimit() uint64 {
 	return 0
 }
 
-func (m *UpdateResource) GetKernelTCPMemoryLimit() uint64 {
+func (m *UpdateResource) GetKernelTCPMemoryLimit() int64 {
 	if m != nil {
 		return m.KernelTCPMemoryLimit
 	}

--- a/api/grpc/types/api.pb.go
+++ b/api/grpc/types/api.pb.go
@@ -1040,11 +1040,11 @@ type UpdateResource struct {
 	CpuQuota                     uint64            `protobuf:"varint,4,opt,name=cpuQuota" json:"cpuQuota,omitempty"`
 	CpusetCpus                   string            `protobuf:"bytes,5,opt,name=cpusetCpus" json:"cpusetCpus,omitempty"`
 	CpusetMems                   string            `protobuf:"bytes,6,opt,name=cpusetMems" json:"cpusetMems,omitempty"`
-	MemoryLimit                  uint64            `protobuf:"varint,7,opt,name=memoryLimit" json:"memoryLimit,omitempty"`
-	MemorySwap                   uint64            `protobuf:"varint,8,opt,name=memorySwap" json:"memorySwap,omitempty"`
-	MemoryReservation            uint64            `protobuf:"varint,9,opt,name=memoryReservation" json:"memoryReservation,omitempty"`
-	KernelMemoryLimit            uint64            `protobuf:"varint,10,opt,name=kernelMemoryLimit" json:"kernelMemoryLimit,omitempty"`
-	KernelTCPMemoryLimit         uint64            `protobuf:"varint,11,opt,name=kernelTCPMemoryLimit" json:"kernelTCPMemoryLimit,omitempty"`
+	MemoryLimit                  int64             `protobuf:"varint,7,opt,name=memoryLimit" json:"memoryLimit,omitempty"`
+	MemorySwap                   int64             `protobuf:"varint,8,opt,name=memorySwap" json:"memorySwap,omitempty"`
+	MemoryReservation            int64             `protobuf:"varint,9,opt,name=memoryReservation" json:"memoryReservation,omitempty"`
+	KernelMemoryLimit            int64             `protobuf:"varint,10,opt,name=kernelMemoryLimit" json:"kernelMemoryLimit,omitempty"`
+	KernelTCPMemoryLimit         int64             `protobuf:"varint,11,opt,name=kernelTCPMemoryLimit" json:"kernelTCPMemoryLimit,omitempty"`
 	BlkioLeafWeight              uint64            `protobuf:"varint,12,opt,name=blkioLeafWeight" json:"blkioLeafWeight,omitempty"`
 	BlkioWeightDevice            []*WeightDevice   `protobuf:"bytes,13,rep,name=blkioWeightDevice" json:"blkioWeightDevice,omitempty"`
 	BlkioThrottleReadBpsDevice   []*ThrottleDevice `protobuf:"bytes,14,rep,name=blkioThrottleReadBpsDevice" json:"blkioThrottleReadBpsDevice,omitempty"`

--- a/ctr/container.go
+++ b/ctr/container.go
@@ -647,16 +647,16 @@ var updateCommand = cli.Command{
 			Id: context.Args().First(),
 		}
 		req.Resources = &types.UpdateResource{}
-		req.Resources.MemoryLimit = getUpdateCommandInt64Flag(context, "memory-limit")
-		req.Resources.MemoryReservation = getUpdateCommandInt64Flag(context, "memory-reservation")
-		req.Resources.MemorySwap = getUpdateCommandInt64Flag(context, "memory-swap")
+		req.Resources.MemoryLimit = getUpdateCommandUInt64Flag(context, "memory-limit")
+		req.Resources.MemoryReservation = getUpdateCommandUInt64Flag(context, "memory-reservation")
+		req.Resources.MemorySwap = getUpdateCommandUInt64Flag(context, "memory-swap")
 		req.Resources.BlkioWeight = getUpdateCommandUInt64Flag(context, "blkio-weight")
 		req.Resources.CpuPeriod = getUpdateCommandUInt64Flag(context, "cpu-period")
 		req.Resources.CpuQuota = getUpdateCommandUInt64Flag(context, "cpu-quota")
 		req.Resources.CpuShares = getUpdateCommandUInt64Flag(context, "cpu-shares")
 		req.Resources.CpusetCpus = context.String("cpuset-cpus")
 		req.Resources.CpusetMems = context.String("cpuset-mems")
-		req.Resources.KernelMemoryLimit = getUpdateCommandInt64Flag(context, "kernel-limit")
+		req.Resources.KernelMemoryLimit = getUpdateCommandUInt64Flag(context, "kernel-limit")
 		req.Resources.KernelTCPMemoryLimit = getUpdateCommandInt64Flag(context, "kernel-tcp-limit")
 		c := getClient(context)
 		if _, err := c.UpdateContainer(netcontext.Background(), req); err != nil {

--- a/ctr/container.go
+++ b/ctr/container.go
@@ -579,13 +579,27 @@ var statsCommand = cli.Command{
 	},
 }
 
-func getUpdateCommandInt64Flag(context *cli.Context, name string) uint64 {
+func getUpdateCommandUInt64Flag(context *cli.Context, name string) uint64 {
 	str := context.String(name)
 	if str == "" {
 		return 0
 	}
 
 	val, err := strconv.ParseUint(str, 0, 64)
+	if err != nil {
+		fatal(err.Error(), 1)
+	}
+
+	return val
+}
+
+func getUpdateCommandInt64Flag(context *cli.Context, name string) int64 {
+	str := context.String(name)
+	if str == "" {
+		return 0
+	}
+
+	val, err := strconv.ParseInt(str, 0, 64)
 	if err != nil {
 		fatal(err.Error(), 1)
 	}
@@ -636,10 +650,10 @@ var updateCommand = cli.Command{
 		req.Resources.MemoryLimit = getUpdateCommandInt64Flag(context, "memory-limit")
 		req.Resources.MemoryReservation = getUpdateCommandInt64Flag(context, "memory-reservation")
 		req.Resources.MemorySwap = getUpdateCommandInt64Flag(context, "memory-swap")
-		req.Resources.BlkioWeight = getUpdateCommandInt64Flag(context, "blkio-weight")
-		req.Resources.CpuPeriod = getUpdateCommandInt64Flag(context, "cpu-period")
-		req.Resources.CpuQuota = getUpdateCommandInt64Flag(context, "cpu-quota")
-		req.Resources.CpuShares = getUpdateCommandInt64Flag(context, "cpu-shares")
+		req.Resources.BlkioWeight = getUpdateCommandUInt64Flag(context, "blkio-weight")
+		req.Resources.CpuPeriod = getUpdateCommandUInt64Flag(context, "cpu-period")
+		req.Resources.CpuQuota = getUpdateCommandUInt64Flag(context, "cpu-quota")
+		req.Resources.CpuShares = getUpdateCommandUInt64Flag(context, "cpu-shares")
 		req.Resources.CpusetCpus = context.String("cpuset-cpus")
 		req.Resources.CpusetMems = context.String("cpuset-mems")
 		req.Resources.KernelMemoryLimit = getUpdateCommandInt64Flag(context, "kernel-limit")

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -14,7 +14,7 @@ clone git github.com/docker/go-units 5d2041e26a699eaca682e2ea41c8f891e1060444
 clone git github.com/godbus/dbus e2cf28118e66a6a63db46cf6088a35d2054d3bb0
 clone git github.com/golang/glog 23def4e6c14b4da8ac2ed8007337bc5eb5007998
 clone git github.com/golang/protobuf 8ee79997227bf9b34611aee7946ae64735e6fd93
-clone git github.com/opencontainers/runc 51371867a01c467f08af739783b8beafc154c4d7 https://github.com/docker/runc.git
+clone git github.com/opencontainers/runc 6b1d0e76f239ffb435445e5ae316d2676c07c6e3 https://github.com/docker/runc.git
 clone git github.com/opencontainers/runtime-spec 1c7c27d043c2a5e513a44084d2b10d77d1402b8c
 clone git github.com/rcrowley/go-metrics eeba7bd0dd01ace6e690fa833b3f22aaec29af43
 clone git github.com/satori/go.uuid f9ab0dce87d815821e221626b772e3475a0d2749

--- a/runtime/container_linux.go
+++ b/runtime/container_linux.go
@@ -107,6 +107,7 @@ func (c *container) Pids() ([]int, error) {
 }
 
 func u64Ptr(i uint64) *uint64 { return &i }
+func i64Ptr(i int64) *int64   { return &i }
 
 func (c *container) UpdateResources(r *Resource) error {
 	sr := ocs.Resources{

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -90,11 +90,11 @@ type Resource struct {
 	CPUQuota          int64
 	CpusetCpus        string
 	CpusetMems        string
-	KernelMemory      int64
 	KernelTCPMemory   int64
-	Memory            int64
-	MemoryReservation int64
-	MemorySwap        int64
+	KernelMemory      uint64
+	Memory            uint64
+	MemoryReservation uint64
+	MemorySwap        uint64
 }
 
 // Possible container states


### PR DESCRIPTION
-1 can unset memory limit in Kernel, these changes allow negative
numbers for MemoryLimit. Kernel sets limits to unlimited if it's set to -1.

Related to: https://github.com/opencontainers/runc/pull/1127
and: https://github.com/docker/docker/pull/22578

Signed-off-by: Mohammad Arab <boynux@gmail.com>