### PR TITLE
Fix hardlinks in tars for unmodified files

### DIFF
--- a/archive/tar_test.go
+++ b/archive/tar_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"testing"
-	"time"
 
 	_ "crypto/sha256"
 
@@ -67,8 +66,6 @@ func TestDiffApply(t *testing.T) {
 			fstest.RemoveAll("/home"),
 			fstest.CreateDir("/home/derek", 0700),
 			fstest.CreateFile("/home/derek/.bashrc", []byte("#not going away\n"), 0640),
-			// "/etc/hosts" must be touched to be hardlinked in same layer
-			fstest.Chtime("/etc/hosts", time.Now()),
 			fstest.Link("/etc/hosts", "/etc/hosts.allow"),
 		),
 	}

--- a/fs/copy.go
+++ b/fs/copy.go
@@ -65,7 +65,7 @@ func copyDirectory(dst, src string, inodes map[uint64]string) error {
 			}
 			continue
 		case (fi.Mode() & os.ModeType) == 0:
-			link, err := GetLinkSource(target, fi, inodes)
+			link, err := getLinkSource(target, fi, inodes)
 			if err != nil {
 				return errors.Wrap(err, "failed to get hardlink")
 			}

--- a/fs/diff.go
+++ b/fs/diff.go
@@ -16,9 +16,13 @@ import (
 type ChangeKind int
 
 const (
+	// ChangeKindUnmodified represents an unmodified
+	// file
+	ChangeKindUnmodified = iota
+
 	// ChangeKindAdd represents an addition of
 	// a file
-	ChangeKindAdd = iota
+	ChangeKindAdd
 
 	// ChangeKindModify represents a change to
 	// an existing file
@@ -31,6 +35,8 @@ const (
 
 func (k ChangeKind) String() string {
 	switch k {
+	case ChangeKindUnmodified:
+		return "unmodified"
 	case ChangeKindAdd:
 		return "add"
 	case ChangeKindModify:
@@ -287,7 +293,10 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b string) (err 
 				f1 = nil
 				f2 = nil
 				if same {
-					continue
+					if !isLinked(f) {
+						continue
+					}
+					k = ChangeKindUnmodified
 				}
 			}
 			if err := changeFn(k, p, f, nil); err != nil {

--- a/fs/diff_linux.go
+++ b/fs/diff_linux.go
@@ -90,3 +90,11 @@ func compareCapabilities(p1, p2 string) (bool, error) {
 	}
 	return bytes.Equal(c1, c2), nil
 }
+
+func isLinked(f os.FileInfo) bool {
+	s, ok := f.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false
+	}
+	return !f.IsDir() && s.Nlink > 1
+}

--- a/fs/diff_windows.go
+++ b/fs/diff_windows.go
@@ -1,5 +1,7 @@
 package fs
 
+import "os"
+
 func detectDirDiff(upper, lower string) *diffDirOptions {
 	return nil
 }
@@ -12,4 +14,8 @@ func compareSysStat(s1, s2 interface{}) (bool, error) {
 func compareCapabilities(p1, p2 string) (bool, error) {
 	// TODO: Use windows equivalent
 	return true, nil
+}
+
+func isLinked(os.FileInfo) bool {
+	return false
 }

--- a/fs/hardlink.go
+++ b/fs/hardlink.go
@@ -2,11 +2,26 @@ package fs
 
 import "os"
 
-// GetLinkSource returns a path for the given name and
+// GetLinkID returns an identifier representing the node a hardlink is pointing
+// to. If the file is not hard linked then 0 will be returned.
+func GetLinkInfo(fi os.FileInfo) (uint64, bool) {
+	return getLinkInfo(fi)
+}
+
+// getLinkSource returns a path for the given name and
 // file info to its link source in the provided inode
 // map. If the given file name is not in the map and
 // has other links, it is added to the inode map
 // to be a source for other link locations.
-func GetLinkSource(name string, fi os.FileInfo, inodes map[uint64]string) (string, error) {
-	return getHardLink(name, fi, inodes)
+func getLinkSource(name string, fi os.FileInfo, inodes map[uint64]string) (string, error) {
+	inode, isHardlink := getLinkInfo(fi)
+	if !isHardlink {
+		return "", nil
+	}
+
+	path, ok := inodes[inode]
+	if !ok {
+		inodes[inode] = name
+	}
+	return path, nil
 }

--- a/fs/hardlink_unix.go
+++ b/fs/hardlink_unix.go
@@ -3,31 +3,15 @@
 package fs
 
 import (
-	"errors"
 	"os"
 	"syscall"
 )
 
-func getHardLink(name string, fi os.FileInfo, inodes map[uint64]string) (string, error) {
-	if fi.IsDir() {
-		return "", nil
-	}
-
+func getLinkInfo(fi os.FileInfo) (uint64, bool) {
 	s, ok := fi.Sys().(*syscall.Stat_t)
 	if !ok {
-		return "", errors.New("unsupported stat type")
+		return 0, false
 	}
 
-	// If inode is not hardlinked, no reason to lookup or save inode
-	if s.Nlink == 1 {
-		return "", nil
-	}
-
-	inode := uint64(s.Ino)
-
-	path, ok := inodes[inode]
-	if !ok {
-		inodes[inode] = name
-	}
-	return path, nil
+	return uint64(s.Ino), !fi.IsDir() && s.Nlink > 1
 }

--- a/fs/hardlink_windows.go
+++ b/fs/hardlink_windows.go
@@ -2,6 +2,6 @@ package fs
 
 import "os"
 
-func getHardLink(string, os.FileInfo, map[uint64]string) (string, error) {
-	return "", nil
+func getLinkInfo(fi os.FileInfo) (uint64, bool) {
+	return 0, false
 }


### PR DESCRIPTION
This fixes a problem with the current diff + tar process in which hardlinked files which were unmodified would not show up as hardlinked to the same files after the tar is applied. This was a problem when adding new hardlinks since none of the files being linked to are picked up as modified except for the new link. In this case we must not only include the new hardlinked file in the tar, but we also must include each of the file names it is hardlinked with. Since we are trying to do the diff and tar creation in a single pass, this created a problem for ordering. To solve this I set aside the desire for having all files ordered by name in the resulting tar and just added the seen link names for a new hardlinked file AFTER the file is added to the tar stream. This does not violate the current language of OCI. However I think we should make an update to OCI to make it specific that ordering by file name is not required, but ordering by application order is (link MUST always come after source). Additionally we should clarify that having one file in a hardlink group in a tar means that all files hardlinked to the same file should have link names, without this there is no way to guarantee that the hardlinks can be applied correctly.

Also for users of the fs diff interface, this unmodified change kind must be handled or ignored.

ping @tonistiigi @vbatts @unclejack 