### PR TITLE
containerd: print some info on config missing

### DIFF
--- a/cmd/containerd/main.go
+++ b/cmd/containerd/main.go
@@ -148,10 +148,13 @@ func main() {
 }
 
 func before(context *cli.Context) error {
-	if err := loadConfig(context.GlobalString("config")); err != nil &&
-		!os.IsNotExist(err) {
+	err := loadConfig(context.GlobalString("config"))
+	if err != nil && !os.IsNotExist(err) {
 		return err
+	} else if err != nil && os.IsNotExist(err) {
+		log.G(global).Warnf("config %q does not exist to be loaded", context.GlobalString("config"))
 	}
+
 	// the order for config vs flag values is that flags will always override
 	// the config values if they are set
 	if err := setLevel(context); err != nil {


### PR DESCRIPTION
at least don't silently ignore the config file not existing.

```bash
sudo ./bin/containerd --config farts
WARN[0000] config "farts" does not exist to be loaded    module=containerd
INFO[0000] starting containerd boot...                   module=containerd
INFO[0000] starting debug API...                         debug="/run/containerd/debug.sock" module=containerd
INFO[0000] loading monitor plugin "cgroups"...           module=containerd
INFO[0000] loading runtime plugin "linux"...             module=containerd
INFO[0000] loading snapshot plugin "snapshot-overlay"...  module=containerd
INFO[0000] loading grpc service plugin "healthcheck-grpc"...  module=containerd
INFO[0000] loading grpc service plugin "rootfs-grpc"...  module=containerd
INFO[0000] loading grpc service plugin "content-grpc"...  module=containerd
INFO[0000] loading grpc service plugin "metrics-grpc"...  module=containerd
INFO[0000] loading grpc service plugin "runtime-grpc"...  module=containerd
INFO[0000] starting GRPC API server...                   module=containerd
INFO[0000] containerd successfully booted in 0.013086s   module=containerd
```

Unfortunately, this makes it the first thing printed, and by default `/etc/containerd/config.toml` does not exist.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>