### PR TITLE
containerd: add access to default config

### DIFF
--- a/cmd/containerd/config.go
+++ b/cmd/containerd/config.go
@@ -1,6 +1,11 @@
 package main
 
-import "github.com/BurntSushi/toml"
+import (
+	"bytes"
+	"io"
+
+	"github.com/BurntSushi/toml"
+)
 
 func defaultConfig() *config {
 	return &config{
@@ -56,6 +61,15 @@ func (c *config) decodePlugin(name string, v interface{}) error {
 		return nil
 	}
 	return c.md.PrimitiveDecode(p, v)
+}
+
+func (c *config) WriteTo(w io.Writer) (int64, error) {
+	buf := bytes.NewBuffer(nil)
+	e := toml.NewEncoder(buf)
+	if err := e.Encode(c); err != nil {
+		return 0, err
+	}
+	return io.Copy(w, buf)
 }
 
 type grpcConfig struct {


### PR DESCRIPTION
when wanting to craft a custom config, but based on the default config,
add a route to output the containerd config to a tempfile.

Currently, the output would look like:
```
$ ./bin/containerd --config default
INFO[0000] containerd default config written to "/tmp/containerd-config.toml.889292416"  module=containerd
```

This fixes silently ignore the config file not existing as well.

```bash
sudo ./bin/containerd --config farts
$ sudo ./bin/containerd --config farts
INFO[0000] config "farts" does not exist. Creating it.   module=containerd
INFO[0000] starting containerd boot...                   module=containerd
INFO[0000] starting debug API...                         debug="/run/containerd/debug.sock" module=containerd
INFO[0000] loading monitor plugin "cgroups"...           module=containerd
INFO[0000] loading runtime plugin "linux"...             module=containerd
INFO[0000] loading snapshot plugin "snapshot-overlay"...  module=containerd
INFO[0000] loading grpc service plugin "content-grpc"...  module=containerd
INFO[0000] loading grpc service plugin "metrics-grpc"...  module=containerd
INFO[0000] loading grpc service plugin "runtime-grpc"...  module=containerd
INFO[0000] loading grpc service plugin "healthcheck-grpc"...  module=containerd
INFO[0000] loading grpc service plugin "rootfs-grpc"...  module=containerd
INFO[0000] starting GRPC API server...                   module=containerd
INFO[0000] containerd successfully booted in 0.001465s   module=containerd
^C$ cat farts
state = "/run/containerd"
root = "/var/lib/containerd"
snapshotter = "overlay"
subreaper = false

[grpc]
  socket = "/run/containerd/containerd.sock"
  uid = 0
  gid = 0

[debug]
  socket = "/run/containerd/debug.sock"
  level = "info"

[metrics]
  address = ""
```

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>