### PR TITLE
Use MkdirAll when create snapshots directory

### DIFF
--- a/snapshot/overlay/overlay.go
+++ b/snapshot/overlay/overlay.go
@@ -49,7 +49,7 @@ func NewSnapshotter(root string) (snapshot.Snapshotter, error) {
 		return nil, err
 	}
 
-	if err := os.Mkdir(filepath.Join(root, "snapshots"), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Join(root, "snapshots"), 0700); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Otherwise we'll get:
```
mkdir /var/lib/containerd/snapshot/overlay/snapshots: file exists
```
when we already have snapshots there.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>