### PR TITLE
Create default config if not exists

### DIFF
--- a/cmd/containerd/main.go
+++ b/cmd/containerd/main.go
@@ -157,7 +157,8 @@ func main() {
 }
 
 func before(context *cli.Context) error {
-	if context.GlobalString("config") == "default" {
+	config := context.GlobalString("config")
+	if config == "default" {
 		fh, err := ioutil.TempFile("", "containerd-config.toml.")
 		if err != nil {
 			return err
@@ -170,12 +171,16 @@ func before(context *cli.Context) error {
 		log.G(global).Infof("containerd default config written to %q", fh.Name())
 		os.Exit(0)
 	}
-	err := loadConfig(context.GlobalString("config"))
+
+	err := loadConfig(config)
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	} else if err != nil && os.IsNotExist(err) {
-		log.G(global).Infof("config %q does not exist. Creating it.", context.GlobalString("config"))
-		fh, err := os.Create(context.GlobalString("config"))
+		log.G(global).Infof("config %q does not exist. Creating it.", config)
+		if err := os.MkdirAll(filepath.Dir(config), 0700); err != nil {
+			return err
+		}
+		fh, err := os.Create(config)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Otherwise we'll get error:
open /etc/containerd/config.toml: no such file or directory

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>