### PR TITLE
Update snapshot mkdir to check for directory exist

### DIFF
--- a/snapshot/btrfs/btrfs.go
+++ b/snapshot/btrfs/btrfs.go
@@ -46,6 +46,10 @@ type snapshotter struct {
 // device and root directory for snapshots and stores the metadata in
 // a file in the provided root.
 func NewSnapshotter(device, root string) (snapshot.Snapshotter, error) {
+	if err := os.MkdirAll(root, 0700); err != nil {
+		return nil, err
+	}
+
 	var (
 		active    = filepath.Join(root, "active")
 		snapshots = filepath.Join(root, "snapshots")
@@ -55,7 +59,7 @@ func NewSnapshotter(device, root string) (snapshot.Snapshotter, error) {
 		active,
 		snapshots,
 	} {
-		if err := os.MkdirAll(path, 0755); err != nil {
+		if err := os.Mkdir(path, 0755); err != nil && !os.IsExist(err) {
 			return nil, err
 		}
 	}

--- a/snapshot/naive/naive.go
+++ b/snapshot/naive/naive.go
@@ -40,7 +40,7 @@ func NewSnapshotter(root string) (snapshot.Snapshotter, error) {
 		return nil, err
 	}
 
-	if err := os.Mkdir(filepath.Join(root, "snapshots"), 0700); err != nil {
+	if err := os.Mkdir(filepath.Join(root, "snapshots"), 0700); err != nil && !os.IsExist(err) {
 		return nil, err
 	}
 

--- a/snapshot/overlay/overlay.go
+++ b/snapshot/overlay/overlay.go
@@ -49,7 +49,7 @@ func NewSnapshotter(root string) (snapshot.Snapshotter, error) {
 		return nil, err
 	}
 
-	if err := os.MkdirAll(filepath.Join(root, "snapshots"), 0700); err != nil {
+	if err := os.Mkdir(filepath.Join(root, "snapshots"), 0700); err != nil && !os.IsExist(err) {
 		return nil, err
 	}
 


### PR DESCRIPTION
When starting up a snapshot driver on subsequent runs the mkdir call will return an exist error, this can be safely ignored.