### PR TITLE
containerd: ensure directory exists

### DIFF
--- a/cmd/containerd/main.go
+++ b/cmd/containerd/main.go
@@ -175,6 +175,9 @@ func before(context *cli.Context) error {
 		return err
 	} else if err != nil && os.IsNotExist(err) {
 		log.G(global).Infof("config %q does not exist. Creating it.", context.GlobalString("config"))
+		if err := os.MkdirAll(filepath.Dir(context.GlobalString("config")), os.FileMode(0750)); err != nil {
+			return err
+		}
 		fh, err := os.Create(context.GlobalString("config"))
 		if err != nil {
 			return err


### PR DESCRIPTION
The file create fails by default because `/etc/containerd` may not exist.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>