### PR TITLE
Handle restore with dead shim

### DIFF
--- a/linux/shim.go
+++ b/linux/shim.go
@@ -60,9 +60,6 @@ func loadShim(path string, remote bool) (shim.ShimClient, error) {
 	}
 	socket := filepath.Join(path, "shim.sock")
 	return connectShim(socket)
-	// TODO: failed to connect to the shim, check if it's alive
-	//   - if it is kill it
-	//   - in both case call runc killall and runc delete on the id
 }
 
 func connectShim(socket string) (shim.ShimClient, error) {

--- a/runtime.go
+++ b/runtime.go
@@ -24,7 +24,7 @@ type Runtime interface {
 	// Create creates a container with the provided id and options
 	Create(ctx context.Context, id string, opts CreateOpts) (Container, error)
 	// Containers returns all the current containers for the runtime
-	Containers() ([]Container, error)
+	Containers(context.Context) ([]Container, error)
 	// Delete removes the container in the runtime
 	Delete(context.Context, Container) (uint32, error)
 	// Events returns events for the runtime and all containers created by the runtime

--- a/services/execution/service.go
+++ b/services/execution/service.go
@@ -49,7 +49,7 @@ func (s *Service) Register(server *grpc.Server) error {
 	api.RegisterContainerServiceServer(server, s)
 	// load all containers
 	for _, r := range s.runtimes {
-		containers, err := r.Containers()
+		containers, err := r.Containers(context.Background())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Add functionality for restoring containers after containerd dies and is
restarted with terminated shims.

This ensures that on restore, if a container no longer has a running
shim, containerd will kill and cleanup the container.

Fixes #667

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>