### PR TITLE
Correct 'go vet' errors

### DIFF
--- a/containerd-shim/main.go
+++ b/containerd-shim/main.go
@@ -156,7 +156,6 @@ func start(log *os.File) error {
 			}
 		}
 	}
-	return nil
 }
 
 func writeInt(path string, i int) error {

--- a/runtime/container.go
+++ b/runtime/container.go
@@ -544,7 +544,6 @@ func (c *container) createCmd(ctx context.Context, pid string, cmd *exec.Cmd, p 
 	case err := <-ch:
 		return err
 	}
-	return nil
 }
 
 func hostIDFromMap(id uint32, mp []ocs.LinuxIDMapping) int {

--- a/runtime/process.go
+++ b/runtime/process.go
@@ -233,7 +233,7 @@ func (p *process) updateExitStatusFile(status uint32) (uint32, error) {
 	p.stateLock.Lock()
 	p.state = Stopped
 	p.stateLock.Unlock()
-	err := ioutil.WriteFile(filepath.Join(p.root, ExitStatusFile), []byte(fmt.Sprintf("%u", status)), 0644)
+	err := ioutil.WriteFile(filepath.Join(p.root, ExitStatusFile), []byte(fmt.Sprintf("%d", status)), 0644)
 	return status, err
 }
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -157,7 +157,7 @@ func BenchmarkBusyboxSh(b *testing.B) {
 		})
 
 		if err != nil {
-			b.Fatalf("Error creating a New container: ", err)
+			b.Fatalf("Error creating a New container: %v", err)
 		}
 
 		benchmarkStartContainer(b, c, s, bundleName)

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -36,7 +36,7 @@ func untarRootfs(source string, destination string) error {
 	rootfs := filepath.Join(destination, "rootfs")
 
 	if err := os.MkdirAll(rootfs, 0755); err != nil {
-		fmt.Println("untarRootfs os.MkdirAll failed with err %v", err)
+		fmt.Printf("untarRootfs os.MkdirAll failed with err %v", err)
 		return nil
 	}
 	tar := exec.Command("tar", "-C", rootfs, "-xf", source)


### PR DESCRIPTION
Use command 'go vet' to find errors:
```
go vet ./...
```
Correct all errors except these in vendor dir.

Signed-off-by: Fengtu Wang <wangfengtu@huawei.com>