### PR TITLE
Create base path to config if missing

### DIFF
--- a/cmd/containerd/main.go
+++ b/cmd/containerd/main.go
@@ -175,6 +175,9 @@ func before(context *cli.Context) error {
 		return err
 	} else if err != nil && os.IsNotExist(err) {
 		log.G(global).Infof("config %q does not exist. Creating it.", context.GlobalString("config"))
+		if err := os.MkdirAll(filepath.Dir(context.GlobalString("config")), 0600); err != nil {
+			return err
+		}
 		fh, err := os.Create(context.GlobalString("config"))
 		if err != nil {
 			return err


### PR DESCRIPTION
If the preceding path to the default config does not exist, containerd will exit reporting it cannot find the default config:

```
INFO[0000] config "/etc/containerd/config.toml" does not exist. Creating it.  module=
containerd
open /etc/containerd/config.toml: no such file or directory

NAME:
   containerd - 
                    __        _                     __
  _________  ____  / /_____ _(_)___  ___  _________/ /
 / ___/ __ \/ __ \/ __/ __ `/ / __ \/ _ \/ ___/ __  /
/ /__/ /_/ / / / / /_/ /_/ / / / / /  __/ /  / /_/ /
\___/\____/_/ /_/\__/\__,_/_/_/ /_/\___/_/   \__,_/

high performance container runtime


USAGE:
   containerd [global options] command [command options] [arguments...]

VERSION:
   e5c8c56

COMMANDS:
     help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --config value, -c value     path to the configuration file (Use 'default' to outp
ut the default toml) (default: "/etc/containerd/config.toml")
   --log-level value, -l value  set the logging level [debug, info, warn, error, fata
l, panic]
   --state value                containerd state directory
   --socket value, -s value     socket path for containerd's GRPC server
   --root value                 containerd root directory
   --help, -h                   show help
   --version, -v                print the version
open /etc/containerd/config.toml: no such file or directory
```

This adds creation of the preceding path.