### PR TITLE
containerd: make a config subcommand

### DIFF
--- a/cmd/containerd/config.go
+++ b/cmd/containerd/config.go
@@ -3,9 +3,26 @@ package main
 import (
 	"bytes"
 	"io"
+	"os"
 
 	"github.com/BurntSushi/toml"
+	"github.com/urfave/cli"
 )
+
+var configCommand = cli.Command{
+	Name:  "config",
+	Usage: "information on the containerd config",
+	Subcommands: []cli.Command{
+		{
+			Name:  "default",
+			Usage: "see the output of the default config",
+			Action: func(context *cli.Context) error {
+				_, err := conf.WriteTo(os.Stdout)
+				return err
+			},
+		},
+	},
+}
 
 // loadConfig loads the config from the provided path
 func loadConfig(path string) error {

--- a/cmd/containerd/main.go
+++ b/cmd/containerd/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	_ "expvar"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -82,6 +81,9 @@ func main() {
 			Usage: "containerd root directory",
 		},
 	}
+	app.Commands = []cli.Command{
+		configCommand,
+	}
 	app.Before = before
 	app.Action = func(context *cli.Context) error {
 		start := time.Now()
@@ -152,19 +154,6 @@ func main() {
 }
 
 func before(context *cli.Context) error {
-	if context.GlobalString("config") == "default" {
-		fh, err := ioutil.TempFile("", "containerd-config.toml.")
-		if err != nil {
-			return err
-		}
-		if _, err := conf.WriteTo(fh); err != nil {
-			fh.Close()
-			return err
-		}
-		fh.Close()
-		log.G(global).Infof("containerd default config written to %q", fh.Name())
-		os.Exit(0)
-	}
 	err := loadConfig(context.GlobalString("config"))
 	if err != nil && !os.IsNotExist(err) {
 		return err

--- a/cmd/containerd/main.go
+++ b/cmd/containerd/main.go
@@ -157,19 +157,7 @@ func before(context *cli.Context) error {
 	err := loadConfig(context.GlobalString("config"))
 	if err != nil && !os.IsNotExist(err) {
 		return err
-	} else if err != nil && os.IsNotExist(err) {
-		log.G(global).Infof("config %q does not exist. Creating it.", context.GlobalString("config"))
-		fh, err := os.Create(context.GlobalString("config"))
-		if err != nil {
-			return err
-		}
-		if _, err := conf.WriteTo(fh); err != nil {
-			fh.Close()
-			return err
-		}
-		fh.Close()
 	}
-
 	// the order for config vs flag values is that flags will always override
 	// the config values if they are set
 	if err := setLevel(context); err != nil {


### PR DESCRIPTION
For the purpose of reviewing the default config. Also fixes the mkdir issue (cherry-pick #701)

Fixes #709 