### PR TITLE
Add back the runtime-config flag in ctr run

### DIFF
--- a/cmd/ctr/run.go
+++ b/cmd/ctr/run.go
@@ -42,6 +42,10 @@ var runCommand = cli.Command{
 			Usage: "runtime name (linux, windows, vmware-linux)",
 			Value: "linux",
 		},
+		cli.StringFlag{
+			Name:  "runtime-config",
+			Usage: "set the OCI config file for the container",
+		},
 		cli.BoolFlag{
 			Name:  "readonly",
 			Usage: "set the containers filesystem as readonly",


### PR DESCRIPTION
This flag was already implemented but could not be specified any more.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>