### PR TITLE
let provide to be one member of image

### DIFF
--- a/cmd/ctr/run.go
+++ b/cmd/ctr/run.go
@@ -95,9 +95,10 @@ var runCommand = cli.Command{
 			if err != nil {
 				return errors.Wrapf(err, "could not resolve %q", ref)
 			}
+			image.Provider = provider
 			// let's close out our db and tx so we don't hold the lock whilst running.
 
-			diffIDs, err := image.RootFS(ctx, provider)
+			diffIDs, err := image.RootFS(ctx)
 			if err != nil {
 				return err
 			}
@@ -118,7 +119,7 @@ var runCommand = cli.Command{
 				return err
 			}
 
-			ic, err := image.Config(ctx, provider)
+			ic, err := image.Config(ctx)
 			if err != nil {
 				return err
 			}

--- a/cmd/dist/images.go
+++ b/cmd/dist/images.go
@@ -44,7 +44,8 @@ var imagesCommand = cli.Command{
 		tw := tabwriter.NewWriter(os.Stdout, 1, 8, 1, ' ', 0)
 		fmt.Fprintln(tw, "REF\tTYPE\tDIGEST\tSIZE\t")
 		for _, image := range images {
-			size, err := image.Size(ctx, provider)
+			image.Provider = provider
+			size, err := image.Size(ctx)
 			if err != nil {
 				log.G(ctx).WithError(err).Errorf("failed calculating size for image %s", image.Name)
 			}

--- a/cmd/dist/pull.go
+++ b/cmd/dist/pull.go
@@ -115,6 +115,7 @@ command. As part of this process, we do the following:
 			}
 
 			provider := contentservice.NewProviderFromClient(contentapi.NewContentClient(conn))
+			image.Provider = provider
 
 			p, err := content.ReadBlob(ctx, provider, image.Target.Digest)
 			if err != nil {
@@ -134,7 +135,7 @@ command. As part of this process, we do the following:
 				log.G(ctx).Fatal(err)
 			}
 
-			diffIDs, err := image.RootFS(ctx, provider)
+			diffIDs, err := image.RootFS(ctx)
 			if err != nil {
 				log.G(ctx).WithError(err).Fatal("failed resolving rootfs")
 			}


### PR DESCRIPTION
`content.Provider`, which is mainly reading io stream, is a strong and
inside dependency field to container images, as struct `image.Image`. So
move this to `Image` member. It can bring benefit to reduce argument,
and show the relationship. As well, it may easy the possible refactor on this.

Signed-off-by: xiekeyang <xiekeyang@huawei.com>