### PR TITLE
dist cli reorganized into sub-commands

### DIFF
--- a/cmd/dist/images.go
+++ b/cmd/dist/images.go
@@ -13,8 +13,9 @@ import (
 	"github.com/urfave/cli"
 )
 
-var imagesCommand = cli.Command{
-	Name:        "images",
+var imagesListCommand = cli.Command{
+	Name:        "list",
+	Aliases:     []string{"images"},
 	Usage:       "list images known to containerd",
 	ArgsUsage:   "[flags] <ref>",
 	Description: `List images registered with containerd.`,

--- a/cmd/dist/main.go
+++ b/cmd/dist/main.go
@@ -61,16 +61,11 @@ distribution tool
 		},
 	}
 	app.Commands = []cli.Command{
-		imagesCommand,
-		rmiCommand,
+		imageCommand,
+		contentCommand,
 		pullCommand,
 		fetchCommand,
 		fetchObjectCommand,
-		ingestCommand,
-		activeCommand,
-		getCommand,
-		deleteCommand,
-		listCommand,
 		applyCommand,
 		rootfsCommand,
 	}
@@ -92,4 +87,25 @@ distribution tool
 		fmt.Fprintf(os.Stderr, "dist: %s\n", err)
 		os.Exit(1)
 	}
+}
+
+var imageCommand = cli.Command{
+	Name:  "image",
+	Usage: "image management",
+	Subcommands: cli.Commands{
+		imagesListCommand,
+		rmiCommand,
+	},
+}
+
+var contentCommand = cli.Command{
+	Name:  "content",
+	Usage: "content management",
+	Subcommands: cli.Commands{
+		listCommand,
+		ingestCommand,
+		activeCommand,
+		getCommand,
+		deleteCommand,
+	},
 }


### PR DESCRIPTION
few dist commands reorganized into subcommands "image" and "content".
Fix for #689 

Signed-off-by: Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>