### PR TITLE
Only set socket on non-nil type creation

### DIFF
--- a/linux/shim/exec.go
+++ b/linux/shim/exec.go
@@ -59,12 +59,13 @@ func newExecProcess(context context.Context, path string, r *shimapi.ExecRequest
 		e.io = io
 	}
 	opts := &runc.ExecOpts{
-		PidFile:       pidfile,
-		ConsoleSocket: socket,
-		IO:            io,
-		Detach:        true,
+		PidFile: pidfile,
+		IO:      io,
+		Detach:  true,
 	}
-
+	if socket != nil {
+		opts.ConsoleSocket = socket
+	}
 	// process exec request
 	var spec specs.Process
 	if err := json.Unmarshal(r.Spec.Value, &spec); err != nil {

--- a/linux/shim/init.go
+++ b/linux/shim/init.go
@@ -73,10 +73,12 @@ func newInitProcess(context context.Context, path string, r *shimapi.CreateReque
 		p.io = io
 	}
 	opts := &runc.CreateOpts{
-		PidFile:       filepath.Join(path, "init.pid"),
-		ConsoleSocket: socket,
-		IO:            io,
-		NoPivot:       r.NoPivot,
+		PidFile: filepath.Join(path, "init.pid"),
+		IO:      io,
+		NoPivot: r.NoPivot,
+	}
+	if socket != nil {
+		opts.ConsoleSocket = socket
 	}
 	if err := p.runc.Create(context, r.ID, r.Bundle, opts); err != nil {
 		return nil, err


### PR DESCRIPTION
Because of go interface unpacking we need to only set the interface on
the opts when we actually have a socket.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>