### PR TITLE
ignore coverage.out for git submit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /bin/
 **/coverage.txt
+**/coverage.out


### PR DESCRIPTION
coverage.out should be ignored when git submitting as well.

Signed-off-by: xiekeyang <xiekeyang@huawei.com>