### PR TITLE
Correct the usage of containerd --config

### DIFF
--- a/cmd/containerd/main.go
+++ b/cmd/containerd/main.go
@@ -61,7 +61,7 @@ func main() {
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "config,c",
-			Usage: "path to the configuration file (Use 'default' to output the default toml)",
+			Usage: "path to the configuration file",
 			Value: defaultConfigPath,
 		},
 		cli.StringFlag{


### PR DESCRIPTION
for [pr711](https://github.com/containerd/containerd/pull/711)
use `containerd config default` instead of `containerd --config default`

Signed-off-by: CuiHaozhi <cuihz@wise2c.com>