### PR TITLE
Avoid creating snapshots repeatedly

### DIFF
--- a/rootfs/apply.go
+++ b/rootfs/apply.go
@@ -69,7 +69,7 @@ func ApplyLayer(snapshots snapshot.Snapshotter, mounter Mounter, rd io.Reader, p
 	digester := digest.Canonical.Digester() // used to calculate diffID.
 	rd = io.TeeReader(rd, digester.Hash())
 
-	if _, err := archive.Apply(context.Background(), key, rd); err != nil {
+	if _, err := archive.Apply(context.Background(), dir, rd); err != nil {
 		return "", err
 	}
 
@@ -80,7 +80,7 @@ func ApplyLayer(snapshots snapshot.Snapshotter, mounter Mounter, rd io.Reader, p
 		chainID = identity.ChainID([]digest.Digest{parent, chainID})
 	}
 	if _, err := snapshots.Stat(ctx, chainID.String()); err == nil {
-		return diffID, nil //TODO: call snapshots.Remove(ctx, key) once implemented
+		return diffID, snapshots.Remove(ctx, key)
 	}
 
 	return diffID, snapshots.Commit(ctx, chainID.String(), key)


### PR DESCRIPTION
Signed-off-by: Yanqiang Miao <miao.yanqiang@zte.com.cn>

- If a snapshot already exists, the newly created snapshot of the same name should be deleted.
- Fix an incorrect parameter transfer.
