### PR TITLE
Ensure proper types for arguments to `time.Unix`.

### DIFF
--- a/content/store_unix.go
+++ b/content/store_unix.go
@@ -10,7 +10,7 @@ import (
 
 func getStartTime(fi os.FileInfo) time.Time {
 	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
-		return time.Unix(st.Ctim.Sec, st.Ctim.Nsec)
+		return time.Unix(int64(st.Ctim.Sec), int64(st.Ctim.Nsec))
 	}
 
 	return fi.ModTime()


### PR DESCRIPTION
It looks like this was once fixed by #644 but may have been lost in a refactor.