### PR TITLE
kill the runtime process if the bundle is not exist

### DIFF
--- a/containerd-shim/process.go
+++ b/containerd-shim/process.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/containerd/containerd/osutils"
 	"github.com/containerd/containerd/specs"
 )
 
@@ -177,8 +178,8 @@ func (p *process) create() error {
 	cmd.Stdin = p.stdio.stdin
 	cmd.Stdout = p.stdio.stdout
 	cmd.Stderr = p.stdio.stderr
-	// Call out to setPDeathSig to set SysProcAttr as elements are platform specific
-	cmd.SysProcAttr = setPDeathSig()
+	// Call out to SetPDeathSig to set SysProcAttr as elements are platform specific
+	cmd.SysProcAttr = osutils.SetPDeathSig()
 
 	if err := cmd.Start(); err != nil {
 		if exErr, ok := err.(*exec.Error); ok {
@@ -220,7 +221,7 @@ func (p *process) pid() int {
 func (p *process) delete() error {
 	if !p.state.Exec {
 		cmd := exec.Command(p.runtime, append(p.state.RuntimeArgs, "delete", p.id)...)
-		cmd.SysProcAttr = setPDeathSig()
+		cmd.SysProcAttr = osutils.SetPDeathSig()
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("%s: %v", out, err)

--- a/containerd-shim/process_linux.go
+++ b/containerd-shim/process_linux.go
@@ -9,17 +9,10 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/containerd/containerd/osutils"
 	"github.com/tonistiigi/fifo"
 	"golang.org/x/net/context"
 )
-
-// setPDeathSig sets the parent death signal to SIGKILL so that if the
-// shim dies the container process also dies.
-func setPDeathSig() *syscall.SysProcAttr {
-	return &syscall.SysProcAttr{
-		Pdeathsig: syscall.SIGKILL,
-	}
-}
 
 // openIO opens the pre-created fifo's for use with the container
 // in RDWR so that they remain open if the other side stops listening
@@ -141,7 +134,7 @@ func (p *process) Wait() {
 func (p *process) killAll() error {
 	if !p.state.Exec {
 		cmd := exec.Command(p.runtime, append(p.state.RuntimeArgs, "kill", "--all", p.id, "SIGKILL")...)
-		cmd.SysProcAttr = setPDeathSig()
+		cmd.SysProcAttr = osutils.SetPDeathSig()
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("%s: %v", out, err)

--- a/containerd-shim/process_solaris.go
+++ b/containerd-shim/process_solaris.go
@@ -8,11 +8,6 @@ import (
 	"syscall"
 )
 
-// setPDeathSig is a no-op on Solaris as Pdeathsig is not defined.
-func setPDeathSig() *syscall.SysProcAttr {
-	return nil
-}
-
 // TODO: Update to using fifo's package in openIO. Need to
 // 1. Merge and vendor changes in the package to use sys/unix.
 // 2. Figure out why context.Background is timing out.

--- a/osutils/pdeathsig_linux.go
+++ b/osutils/pdeathsig_linux.go
@@ -1,0 +1,15 @@
+// +build !solaris
+
+package osutils
+
+import (
+	"syscall"
+)
+
+// SetPDeathSig sets the parent death signal to SIGKILL so that if the
+// shim dies the container process also dies.
+func SetPDeathSig() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		Pdeathsig: syscall.SIGKILL,
+	}
+}

--- a/osutils/pdeathsig_solaris.go
+++ b/osutils/pdeathsig_solaris.go
@@ -1,0 +1,8 @@
+// +build solaris
+
+package osutils
+
+// SetPDeathSig is a no-op on Solaris as Pdeathsig is not defined.
+func SetPDeathSig() *syscall.SysProcAttr {
+	return nil
+}

--- a/runtime/container.go
+++ b/runtime/container.go
@@ -193,6 +193,17 @@ func Load(root, id, shimName string, timeout time.Duration) (Container, error) {
 		}
 		c.processes[pid] = p
 	}
+
+	_, err = os.Stat(c.bundle)
+	if err != nil && !os.IsExist(err) {
+		for key, p := range c.processes {
+			if key == InitProcessID {
+				p.Delete()
+				break
+			}
+		}
+		return nil, fmt.Errorf("bundle dir %s don't exist", c.bundle)
+	}
 	return c, nil
 }
 

--- a/runtime/process.go
+++ b/runtime/process.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/containerd/containerd/osutils"
 	"github.com/containerd/containerd/specs"
 	"golang.org/x/sys/unix"
 )
@@ -455,6 +456,21 @@ func (p *process) Start() error {
 				return err
 			}
 		}
+	}
+	return nil
+}
+
+// Delete delete any resources held by the container
+func (p *process) Delete() error {
+	var (
+		args = append(p.container.runtimeArgs, "delete", "-f", p.container.id)
+		cmd  = exec.Command(p.container.runtime, args...)
+	)
+
+	cmd.SysProcAttr = osutils.SetPDeathSig()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %v", out, err)
 	}
 	return nil
 }


### PR DESCRIPTION
I find some anomalies due to the reboot of containerd(killed by docker daemon), it lead to docker-containerd-shim residue and shim process will not exit  except you kill it manually.
It can be reproduced by the following testcase:
### runc init block, details for https://github.com/opencontainers/runc/pull/1409
```
diff --git a/supervisor/worker.go b/supervisor/worker.go
index 242c5e9..735c636 100755
--- a/supervisor/worker.go
+++ b/supervisor/worker.go
@@ -77,6 +77,7 @@ func (w *worker) Start() {
                // only call process start if we aren't restoring from a checkpoint
                // if we have restored from a checkpoint then the process is already started
                if t.CheckpointPath == "" {
+                       os.Exit(-1)
                        if err := process.Start(); err != nil {
                                logrus.WithField("error", err).Error("containerd: start init process")
                                t.Err <- err
```
In the console, we can find /proc/self/init don't exit forever:
```
[root@localhost docker-bin]# date;ps -eaf|grep exe
Tue Apr 18 07:29:41 EDT 2017
root     17212 17197  2 07:29 pts/0    00:00:00 /proc/self/exe init
root     17231 23108  0 07:29 pts/2    00:00:00 grep --color=auto exe
[root@localhost docker-bin]# date;ps -eaf|grep exe
Tue Apr 18 07:31:26 EDT 2017
root     17212 17197  0 07:29 pts/0    00:00:00 /proc/self/exe init
root     17971 23108  0 07:31 pts/2    00:00:00 grep --color=auto exe
...
```
### runtime start successfully, but docker don't receive the notify.
because of the exit of containerd ,docker will receive a closing err, and  docker will remove the bundle.
using docker ps command, we can't see the contaier also.
```
diff --git a/supervisor/worker.go b/supervisor/worker.go
index 242c5e9..ccee141 100755
--- a/supervisor/worker.go
+++ b/supervisor/worker.go
@@ -89,6 +89,7 @@ func (w *worker) Start() {
                                continue
                        }
                }
+               os.Exit(-1)
                ContainerStartTimer.UpdateSince(started)
                w.s.newExecSyncMap(t.Container.ID())
                t.Err <- nil
```
In the console, we can find shim/bash don't exit forever:
```
V2R1C00-GUESTOS-VS-VMWARE-X64:~/workspace/docker-bin # ps -eaf|grep 25127
root     20132  8423  0 09:32 pts/3    00:00:00 grep --color=auto 25127
root     25127     1  0 Apr18 ?        00:00:02 docker-containerd-shim c927abb2261372568dd66d9b3458ab531f0d1e897a9ea74f50108625bdb1a81b /var/run/docker/libcontainerd/c927abb2261372568dd66d9b3458ab531f0d1e897a9ea74f50108625bdb1a81b docker-runc
root     25301 25127  0 Apr18 pts/0    00:00:02 /bin/bash
V2R1C00-GUESTOS-VS-VMWARE-X64:~/workspace/docker-bin # ls /var/run/docker/libcontainerd/c927abb2261372568dd66d9b3458ab531f0d1e897a9ea74f50108625bdb1a81b
ls: cannot access /var/run/docker/libcontainerd/c927abb2261372568dd66d9b3458ab531f0d1e897a9ea74f50108625bdb1a81b: No such file or directory
```

Signed-off-by: yangshukui <yangshukui@huawei.com>