### PR TITLE
Delay io closure until process exit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+dist: trusty
+sudo: required
+
+language: go
+
+go:
+  - 1.8.x
+  - tip
+
+go_import_path: github.com/containerd/containerd
+
+addons:
+  apt:
+    packages:
+      - apparmor
+      - libapparmor-dev
+      - curl
+
+env:
+  - SECCOMP_VERSION=2.3.1 RUNC_COMMIT=51371867a01c467f08af739783b8beafc154c4d7
+
+install:
+  - hack/install-seccomp.sh
+  - hack/install-runc.sh
+  - go get -u github.com/golang/lint/golint
+
+script:
+  - make all
+  - sudo make install
+  - sudo -E env "PATH=$PATH" "GOPATH=$GOPATH" make test
+  - sudo -E env "PATH=$PATH" "GOPATH=$GOPATH" make integration-test

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ DOCKER_RUN := docker run --privileged --rm -i $(DOCKER_FLAGS) "$(DOCKER_IMAGE)"
 
 export GOPATH:=$(CURDIR)/vendor:$(GOPATH)
 
+.PHONY: integration-test
+
 all: client daemon shim
 
 static: client-static daemon-static shim-static
@@ -93,6 +95,10 @@ ifneq ($(wildcard /.dockerenv), )
 	cd integration-test ; \
 go test -check.v -check.timeout=$(TEST_TIMEOUT) $(TESTFLAGS) timeout=$(TEST_SUITE_TIMEOUT) github.com/containerd/containerd/integration-test
 endif
+
+integration-test:
+	cd integration-test ; \
+go test -check.v -check.timeout=$(TEST_TIMEOUT) $(TESTFLAGS) timeout=$(TEST_SUITE_TIMEOUT) github.com/containerd/containerd/integration-test
 
 bench: shim validate install bundles-rootfs
 	go test -bench=. -v $(shell go list ./... | grep -v /vendor | grep -v /integration-test) -runtime=$(RUNTIME)

--- a/containerd-shim/process.go
+++ b/containerd-shim/process.go
@@ -64,6 +64,7 @@ type process struct {
 	consolePath    string
 	state          *processState
 	runtime        string
+	ioCleanupFn    func()
 }
 
 func newProcess(id, bundle, runtimeName string) (*process, error) {

--- a/hack/install-runc.sh
+++ b/hack/install-runc.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+export GOPATH="$(mktemp -d)"
+git clone git://github.com/docker/runc.git "$GOPATH/src/github.com/opencontainers/runc"
+cd "$GOPATH/src/github.com/opencontainers/runc"
+git checkout -q "$RUNC_COMMIT"
+make BUILDTAGS="seccomp apparmor selinux"
+sudo make install

--- a/hack/install-seccomp.sh
+++ b/hack/install-seccomp.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+set -x
+
+export SECCOMP_PATH="$(mktemp -d)"
+
+curl -fsSL "https://github.com/seccomp/libseccomp/releases/download/v${SECCOMP_VERSION}/libseccomp-${SECCOMP_VERSION}.tar.gz" \
+	| tar -xzC "$SECCOMP_PATH" --strip-components=1
+(
+    cd "$SECCOMP_PATH"
+	./configure --prefix=/usr/local
+	make
+	sudo make install
+	sudo ldconfig
+)
+rm -rf "$SECCOMP_PATH"


### PR DESCRIPTION
This helps ensuring that a client reconnecting to the FIFOs won't get stuck
if the container process happenned to have close both its stdout and stderr
descriptors.

Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

-- 
Addresses docker/docker#32640

This also add travis-ci support for the v0.2.x branch hence closing #736