### PR TITLE
Ensure grpc socket is group writable

### DIFF
--- a/cmd/containerd/main_unix.go
+++ b/cmd/containerd/main_unix.go
@@ -35,6 +35,12 @@ func platformInit(context *cli.Context) error {
 			return err
 		}
 	}
+	if err := os.MkdirAll(conf.State, 0750); err != nil {
+		return err
+	}
+	if err := os.Chown(conf.State, conf.GRPC.Uid, conf.GRPC.Gid); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/sys/socket_unix.go
+++ b/sys/socket_unix.go
@@ -28,6 +28,11 @@ func GetLocalListener(path string, uid, gid int) (net.Listener, error) {
 		return l, err
 	}
 
+	if err := os.Chmod(path, 0660); err != nil {
+		l.Close()
+		return nil, err
+	}
+
 	if err := os.Chown(path, uid, gid); err != nil {
 		l.Close()
 		return nil, err


### PR DESCRIPTION
Updates the file permissions on the GRPC socket to have group write
permission which is needed to perform GRPC. Additionally, ensure
the run directory has the specified group ownership and has group
read and enter permission.

Before this change (group set to `docker`)
```
$ sudo ls -ld /run/containerd
drw-r-----. 3 root root 100 Apr 24 15:26 /run/containerd
$ sudo ls -l /run/containerd 
total 0
srwxr-xr-x. 1 root docker  0 Apr 24 15:26 containerd.sock
srwxr-xr-x. 1 root docker  0 Apr 24 15:26 debug.sock
drwx------. 2 root root   40 Apr 24 15:26 linux
```

After
```
$ sudo ls -ld /run/containerd
drwxr-x---. 3 root docker 100 Apr 24 15:28 /run/containerd
$ sudo ls -l /run/containerd           
total 0
srwxrwx---. 1 root docker  0 Apr 24 15:28 containerd.sock
srwxrwx---. 1 root docker  0 Apr 24 15:28 debug.sock
drwx------. 2 root root   40 Apr 24 15:28 linux
```
