### PR TITLE
Ignore `./vendor` content in travis git-validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,9 @@ install:
 script:
   - export GOOS=$TRAVIS_GOOS
   - export CGO_ENABLED=$TRAVIS_CGO_ENABLED
+  - GIT_CHECK_EXCLUDE="./vendor" TRAVIS_COMMIT_RANGE="${TRAVIS_COMMIT_RANGE/.../..}" make dco
   - make fmt
   - make binaries
-  - TRAVIS_COMMIT_RANGE="${TRAVIS_COMMIT_RANGE/.../..}" make dco
   - if [ "$GOOS" != "windows" ]; then make coverage ; fi
   - if [ "$GOOS" != "windows" ]; then sudo PATH=$PATH GOPATH=$GOPATH make root-coverage ; fi
 


### PR DESCRIPTION
Ignores vendor content for `make dco` use of git-validation tool.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>