### PR TITLE
Formalize process for adding new projects

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -66,15 +66,16 @@ merged.
 	title = "How are sub projects added?"
 
 	text = """
-Similar to adding maintainers, new projects can be added to containerd GitHub
-organization. After a project has been announced on the maintainers mailing list,
-the existing maintainers are given five business days to discuss the new project,
-raise objections and cast their vote. Projects must be approved by at least 66%
-of the current maintainers by adding their vote on the mailing list.
+Similar to adding maintainers, new sub projects can be added to containerd
+GitHub organization as long as they adhere to the CNCF
+[charter](https://www.cncf.io/about/charter/) and mission. After a project
+proposal has been announced on a public forum (GitHub issue or mailing list),
+the existing maintainers are  given five business days to discuss the new
+project, raise objections and cast their vote. Projects must be approved by at
+least 66% of the current maintainers by adding their vote.
 
 If a project is approved, a maintainer will add the project to the containerd
-GitHub organization, add it to the MAINTAINERS file and make an announcement
-on the maintainers mailing list.
+GitHub organization, and make an announcement on a public forum.
 """
 
 	[Rules.stepping-down-policy]
@@ -254,11 +255,6 @@ example and you'll be fine".
 		"jhowardmsft",
 		"mlaventure",
 		"stevvooe",
-	]
-
-	[Org.Projects]
-	project = [
-		"containerd/containerd",
 	]
 
 [People]

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -61,6 +61,22 @@ MAINTAINERS file. The candidate becomes a maintainer once the pull request is
 merged.
 """
 
+	[Rules.adding-sub-projects]
+
+	title = "How are sub projects added?"
+
+	text = """
+Similar to adding maintainers, new projects can be added to containerd GitHub
+organization. After a project has been announced on the maintainers mailing list,
+the existing maintainers are given five business days to discuss the new project,
+raise objections and cast their vote. Projects must be approved by at least 66%
+of the current maintainers by adding their vote on the mailing list.
+
+If a project is approved, a maintainer will add the project to the containerd
+GitHub organization, add it to the MAINTAINERS file and make an announcement
+on the maintainers mailing list.
+"""
+
 	[Rules.stepping-down-policy]
 
 	title = "Stepping down policy"
@@ -238,6 +254,11 @@ example and you'll be fine".
 		"jhowardmsft",
 		"mlaventure",
 		"stevvooe",
+	]
+
+	[Org.Projects]
+	project = [
+		"containerd/containerd",
 	]
 
 [People]


### PR DESCRIPTION
There should be a lightweight process to add sub projects to
the containerd github organization. Closes #773

Signed-off-by: Chris Aniszczyk <caniszczyk@gmail.com>