### PR TITLE
Pull from all registries

### DIFF
--- a/cmd/dist/common.go
+++ b/cmd/dist/common.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"bufio"
 	"context"
+	"crypto/tls"
+	"fmt"
 	"net"
+	"net/http"
 	"path/filepath"
+	"strings"
 	"time"
 
 	imagesapi "github.com/containerd/containerd/api/services/images"
@@ -12,9 +17,30 @@ import (
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	imagesservice "github.com/containerd/containerd/services/images"
+	"github.com/crosbymichael/console"
+	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 	"google.golang.org/grpc"
 )
+
+var registryFlags = []cli.Flag{
+	cli.BoolFlag{
+		Name:  "skip-verify,k",
+		Usage: "Skip SSL certificate validation",
+	},
+	cli.BoolFlag{
+		Name:  "plain-http",
+		Usage: "Allow connections using plain HTTP",
+	},
+	cli.StringFlag{
+		Name:  "user,u",
+		Usage: "user[:password] Registry user and password",
+	},
+	cli.StringFlag{
+		Name:  "refresh",
+		Usage: "Refresh token for authorization server",
+	},
+}
 
 func resolveContentStore(context *cli.Context) (*content.Store, error) {
 	root := filepath.Join(context.GlobalString("root"), "content")
@@ -50,6 +76,71 @@ func connectGRPC(context *cli.Context) (*grpc.ClientConn, error) {
 }
 
 // getResolver prepares the resolver from the environment and options.
-func getResolver(ctx context.Context) (remotes.Resolver, error) {
-	return docker.NewResolver(), nil
+func getResolver(ctx context.Context, clicontext *cli.Context) (remotes.Resolver, error) {
+	username := clicontext.String("user")
+	var secret string
+	if i := strings.IndexByte(username, ':'); i > 0 {
+		secret = username[i+1:]
+		username = username[0:i]
+	}
+	options := docker.ResolverOptions{
+		PlainHTTP: clicontext.Bool("plain-http"),
+	}
+	if username != "" {
+		if secret == "" {
+			fmt.Printf("Password: ")
+
+			var err error
+			secret, err = passwordPrompt()
+			if err != nil {
+				return nil, err
+			}
+
+			fmt.Print("\n")
+		}
+	} else if rt := clicontext.String("refresh"); rt != "" {
+		secret = rt
+	}
+
+	options.Credentials = func(host string) (string, string, error) {
+		// Only one host
+		return username, secret, nil
+	}
+
+	tr := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:        10,
+		IdleConnTimeout:     30 * time.Second,
+		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: clicontext.Bool("insecure"),
+		},
+		ExpectContinueTimeout: 5 * time.Second,
+	}
+
+	options.Client = &http.Client{
+		Transport: tr,
+	}
+
+	return docker.NewResolver(options), nil
+}
+
+func passwordPrompt() (string, error) {
+	c := console.Current()
+	defer c.Reset()
+
+	if err := c.DisableEcho(); err != nil {
+		return "", errors.Wrap(err, "failed to disable echo")
+	}
+
+	line, _, err := bufio.NewReader(c).ReadLine()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to read line")
+	}
+	return string(line), nil
 }

--- a/cmd/dist/fetch.go
+++ b/cmd/dist/fetch.go
@@ -39,7 +39,7 @@ not use this implementation as a guide. The end goal should be having metadata,
 content and snapshots ready for a direct use via the 'ctr run'.
 
 Most of this is experimental and there are few leaps to make this work.`,
-	Flags: []cli.Flag{},
+	Flags: registryFlags,
 	Action: func(clicontext *cli.Context) error {
 		var (
 			ctx = background
@@ -51,7 +51,7 @@ Most of this is experimental and there are few leaps to make this work.`,
 			return err
 		}
 
-		resolver, err := getResolver(ctx)
+		resolver, err := getResolver(ctx, clicontext)
 		if err != nil {
 			return err
 		}

--- a/cmd/dist/fetchobject.go
+++ b/cmd/dist/fetchobject.go
@@ -18,13 +18,13 @@ var fetchObjectCommand = cli.Command{
 	Usage:       "retrieve objects from a remote",
 	ArgsUsage:   "[flags] <remote> <object> [<hint>, ...]",
 	Description: `Fetch objects by identifier from a remote.`,
-	Flags: []cli.Flag{
+	Flags: append([]cli.Flag{
 		cli.DurationFlag{
 			Name:   "timeout",
 			Usage:  "total timeout for fetch",
 			EnvVar: "CONTAINERD_FETCH_TIMEOUT",
 		},
-	},
+	}, registryFlags...),
 	Action: func(context *cli.Context) error {
 		var (
 			ctx     = background
@@ -38,7 +38,7 @@ var fetchObjectCommand = cli.Command{
 			defer cancel()
 		}
 
-		resolver, err := getResolver(ctx)
+		resolver, err := getResolver(ctx, context)
 		if err != nil {
 			return err
 		}

--- a/cmd/dist/pull.go
+++ b/cmd/dist/pull.go
@@ -35,7 +35,7 @@ command. As part of this process, we do the following:
 2. Prepare the snapshot filesystem with the pulled resources.
 3. Register metadata for the image.
 `,
-	Flags: []cli.Flag{},
+	Flags: registryFlags,
 	Action: func(clicontext *cli.Context) error {
 		var (
 			ctx = background
@@ -52,7 +52,7 @@ command. As part of this process, we do the following:
 			return err
 		}
 
-		resolver, err := getResolver(ctx)
+		resolver, err := getResolver(ctx, clicontext)
 		if err != nil {
 			return err
 		}
@@ -75,6 +75,7 @@ command. As part of this process, we do the following:
 			ongoing.add(ref)
 			name, desc, fetcher, err := resolver.Resolve(ctx, ref)
 			if err != nil {
+				log.G(ctx).WithError(err).Error("failed to resolve")
 				return err
 			}
 			log.G(ctx).WithField("image", name).Debug("fetching")

--- a/remotes/docker/auth.go
+++ b/remotes/docker/auth.go
@@ -1,0 +1,182 @@
+package docker
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+)
+
+type authenticationScheme byte
+
+const (
+	basicAuth  authenticationScheme = 1 << iota // Defined in RFC 7617
+	digestAuth                                  // Defined in RFC 7616
+	bearerAuth                                  // Defined in RFC 6750
+)
+
+// challenge carries information from a WWW-Authenticate response header.
+// See RFC 2617.
+type challenge struct {
+	// scheme is the auth-scheme according to RFC 2617
+	scheme authenticationScheme
+
+	// parameters are the auth-params according to RFC 2617
+	parameters map[string]string
+}
+
+type byScheme []challenge
+
+func (bs byScheme) Len() int      { return len(bs) }
+func (bs byScheme) Swap(i, j int) { bs[i], bs[j] = bs[j], bs[i] }
+
+// Sort in priority order: token > digest > basic
+func (bs byScheme) Less(i, j int) bool { return bs[i].scheme > bs[j].scheme }
+
+// Octet types from RFC 2616.
+type octetType byte
+
+var octetTypes [256]octetType
+
+const (
+	isToken octetType = 1 << iota
+	isSpace
+)
+
+func init() {
+	// OCTET      = <any 8-bit sequence of data>
+	// CHAR       = <any US-ASCII character (octets 0 - 127)>
+	// CTL        = <any US-ASCII control character (octets 0 - 31) and DEL (127)>
+	// CR         = <US-ASCII CR, carriage return (13)>
+	// LF         = <US-ASCII LF, linefeed (10)>
+	// SP         = <US-ASCII SP, space (32)>
+	// HT         = <US-ASCII HT, horizontal-tab (9)>
+	// <">        = <US-ASCII double-quote mark (34)>
+	// CRLF       = CR LF
+	// LWS        = [CRLF] 1*( SP | HT )
+	// TEXT       = <any OCTET except CTLs, but including LWS>
+	// separators = "(" | ")" | "<" | ">" | "@" | "," | ";" | ":" | "\" | <">
+	//              | "/" | "[" | "]" | "?" | "=" | "{" | "}" | SP | HT
+	// token      = 1*<any CHAR except CTLs or separators>
+	// qdtext     = <any TEXT except <">>
+
+	for c := 0; c < 256; c++ {
+		var t octetType
+		isCtl := c <= 31 || c == 127
+		isChar := 0 <= c && c <= 127
+		isSeparator := strings.IndexRune(" \t\"(),/:;<=>?@[]\\{}", rune(c)) >= 0
+		if strings.IndexRune(" \t\r\n", rune(c)) >= 0 {
+			t |= isSpace
+		}
+		if isChar && !isCtl && !isSeparator {
+			t |= isToken
+		}
+		octetTypes[c] = t
+	}
+}
+
+func parseAuthHeader(header http.Header) []challenge {
+	challenges := []challenge{}
+	for _, h := range header[http.CanonicalHeaderKey("WWW-Authenticate")] {
+		v, p := parseValueAndParams(h)
+		var s authenticationScheme
+		switch v {
+		case "basic":
+			s = basicAuth
+		case "digest":
+			s = digestAuth
+		case "bearer":
+			s = bearerAuth
+		default:
+			continue
+		}
+		challenges = append(challenges, challenge{scheme: s, parameters: p})
+	}
+	sort.Stable(byScheme(challenges))
+	return challenges
+}
+
+func parseValueAndParams(header string) (value string, params map[string]string) {
+	params = make(map[string]string)
+	value, s := expectToken(header)
+	if value == "" {
+		return
+	}
+	value = strings.ToLower(value)
+	for {
+		var pkey string
+		pkey, s = expectToken(skipSpace(s))
+		if pkey == "" {
+			return
+		}
+		if !strings.HasPrefix(s, "=") {
+			return
+		}
+		var pvalue string
+		pvalue, s = expectTokenOrQuoted(s[1:])
+		if pvalue == "" {
+			return
+		}
+		pkey = strings.ToLower(pkey)
+		params[pkey] = pvalue
+		s = skipSpace(s)
+		if !strings.HasPrefix(s, ",") {
+			return
+		}
+		s = s[1:]
+	}
+}
+
+func skipSpace(s string) (rest string) {
+	i := 0
+	for ; i < len(s); i++ {
+		if octetTypes[s[i]]&isSpace == 0 {
+			break
+		}
+	}
+	return s[i:]
+}
+
+func expectToken(s string) (token, rest string) {
+	i := 0
+	for ; i < len(s); i++ {
+		if octetTypes[s[i]]&isToken == 0 {
+			break
+		}
+	}
+	return s[:i], s[i:]
+}
+
+func expectTokenOrQuoted(s string) (value string, rest string) {
+	if !strings.HasPrefix(s, "\"") {
+		return expectToken(s)
+	}
+	s = s[1:]
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '"':
+			return s[:i], s[i+1:]
+		case '\\':
+			p := make([]byte, len(s)-1)
+			j := copy(p, s[:i])
+			escape := true
+			for i = i + 1; i < len(s); i++ {
+				b := s[i]
+				switch {
+				case escape:
+					escape = false
+					p[j] = b
+					j++
+				case b == '\\':
+					escape = true
+				case b == '"':
+					return string(p[:j]), s[i+1:]
+				default:
+					p[j] = b
+					j++
+				}
+			}
+			return "", ""
+		}
+	}
+	return "", ""
+}

--- a/remotes/docker/resolver_test.go
+++ b/remotes/docker/resolver_test.go
@@ -1,0 +1,388 @@
+package docker
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/containerd/containerd/remotes"
+	digest "github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+func TestHTTPResolver(t *testing.T) {
+	s := func(h http.Handler) (string, ResolverOptions, func()) {
+		s := httptest.NewServer(h)
+
+		options := ResolverOptions{
+			PlainHTTP: true,
+		}
+		base := s.URL[7:] // strip "http://"
+		return base, options, s.Close
+	}
+
+	runBasicTest(t, "testname", s)
+}
+
+func TestHTTPSResolver(t *testing.T) {
+	runBasicTest(t, "testname", tlsServer)
+}
+
+func TestBasicResolver(t *testing.T) {
+	basicAuth := func(h http.Handler) (string, ResolverOptions, func()) {
+		// Wrap with basic auth
+		wrapped := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			username, password, ok := r.BasicAuth()
+			if !ok || username != "user1" || password != "password1" {
+				rw.Header().Set("WWW-Authenticate", "Basic realm=localhost")
+				rw.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			h.ServeHTTP(rw, r)
+		})
+
+		base, options, close := tlsServer(wrapped)
+		options.Credentials = func(string) (string, string, error) {
+			return "user1", "password1", nil
+		}
+		return base, options, close
+	}
+	runBasicTest(t, "testname", basicAuth)
+}
+
+func TestAnonymousTokenResolver(t *testing.T) {
+	th := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			rw.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		rw.Header().Set("Content-Type", "application/json")
+		rw.WriteHeader(http.StatusOK)
+		rw.Write([]byte(`{"access_token":"perfectlyvalidopaquetoken"}`))
+	})
+
+	runBasicTest(t, "testname", withTokenServer(th, nil))
+}
+
+func TestBasicAuthTokenResolver(t *testing.T) {
+	th := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			rw.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		rw.Header().Set("Content-Type", "application/json")
+		rw.WriteHeader(http.StatusOK)
+		username, password, ok := r.BasicAuth()
+		if !ok || username != "user1" || password != "password1" {
+			rw.Write([]byte(`{"access_token":"insufficientscope"}`))
+		} else {
+			rw.Write([]byte(`{"access_token":"perfectlyvalidopaquetoken"}`))
+		}
+	})
+	creds := func(string) (string, string, error) {
+		return "user1", "password1", nil
+	}
+
+	runBasicTest(t, "testname", withTokenServer(th, creds))
+}
+
+func TestRefreshTokenResolver(t *testing.T) {
+	th := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			rw.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		rw.Header().Set("Content-Type", "application/json")
+		rw.WriteHeader(http.StatusOK)
+
+		r.ParseForm()
+		if r.PostForm.Get("grant_type") != "refresh_token" || r.PostForm.Get("refresh_token") != "somerefreshtoken" {
+			rw.Write([]byte(`{"access_token":"insufficientscope"}`))
+		} else {
+			rw.Write([]byte(`{"access_token":"perfectlyvalidopaquetoken"}`))
+		}
+	})
+	creds := func(string) (string, string, error) {
+		return "", "somerefreshtoken", nil
+	}
+
+	runBasicTest(t, "testname", withTokenServer(th, creds))
+}
+
+func TestPostBasicAuthTokenResolver(t *testing.T) {
+	th := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			rw.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		rw.Header().Set("Content-Type", "application/json")
+		rw.WriteHeader(http.StatusOK)
+
+		r.ParseForm()
+		if r.PostForm.Get("grant_type") != "password" || r.PostForm.Get("username") != "user1" || r.PostForm.Get("password") != "password1" {
+			rw.Write([]byte(`{"access_token":"insufficientscope"}`))
+		} else {
+			rw.Write([]byte(`{"access_token":"perfectlyvalidopaquetoken"}`))
+		}
+	})
+	creds := func(string) (string, string, error) {
+		return "user1", "password1", nil
+	}
+
+	runBasicTest(t, "testname", withTokenServer(th, creds))
+}
+
+func TestBadTokenResolver(t *testing.T) {
+	th := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			rw.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		rw.Header().Set("Content-Type", "application/json")
+		rw.WriteHeader(http.StatusOK)
+		rw.Write([]byte(`{"access_token":"insufficientscope"}`))
+	})
+	creds := func(string) (string, string, error) {
+		return "", "somerefreshtoken", nil
+	}
+
+	ctx := context.Background()
+	h := content(ocispec.MediaTypeImageManifest, []byte("not anything parse-able"))
+
+	base, ro, close := withTokenServer(th, creds)(logHandler{t, h})
+	defer close()
+
+	resolver := NewResolver(ro)
+	image := fmt.Sprintf("%s/doesntmatter:sometatg", base)
+
+	_, _, _, err := resolver.Resolve(ctx, image)
+	if err == nil {
+		t.Fatal("Expected error getting token with inssufficient scope")
+	}
+	if errors.Cause(err) != ErrInvalidAuthorization {
+		t.Fatal(err)
+	}
+}
+
+func withTokenServer(th http.Handler, creds func(string) (string, string, error)) func(h http.Handler) (string, ResolverOptions, func()) {
+	return func(h http.Handler) (string, ResolverOptions, func()) {
+		s := httptest.NewUnstartedServer(th)
+		s.StartTLS()
+
+		cert, _ := x509.ParseCertificate(s.TLS.Certificates[0].Certificate[0])
+		tokenBase := s.URL + "/token"
+
+		// Wrap with token auth
+		wrapped := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			auth := strings.ToLower(r.Header.Get("Authorization"))
+			if auth != "bearer perfectlyvalidopaquetoken" {
+				authHeader := fmt.Sprintf("Bearer realm=%q,service=registry,scope=\"repository:testname:pull,pull\"", tokenBase)
+				if strings.HasPrefix(auth, "bearer ") {
+					authHeader = authHeader + ",error=" + auth[7:]
+				}
+				rw.Header().Set("WWW-Authenticate", authHeader)
+				rw.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			h.ServeHTTP(rw, r)
+		})
+
+		base, options, close := tlsServer(wrapped)
+		options.Credentials = creds
+		options.Client.Transport.(*http.Transport).TLSClientConfig.RootCAs.AddCert(cert)
+		return base, options, func() {
+			s.Close()
+			close()
+		}
+	}
+}
+
+func tlsServer(h http.Handler) (string, ResolverOptions, func()) {
+	s := httptest.NewUnstartedServer(h)
+	s.StartTLS()
+
+	capool := x509.NewCertPool()
+	cert, _ := x509.ParseCertificate(s.TLS.Certificates[0].Certificate[0])
+	capool.AddCert(cert)
+
+	options := ResolverOptions{
+		Client: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					RootCAs: capool,
+				},
+			},
+		},
+	}
+	base := s.URL[8:] // strip "https://"
+	return base, options, s.Close
+}
+
+type logHandler struct {
+	t       *testing.T
+	handler http.Handler
+}
+
+func (h logHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	h.t.Logf("%s %s", r.Method, r.URL.String())
+	h.handler.ServeHTTP(rw, r)
+}
+
+func runBasicTest(t *testing.T, name string, sf func(h http.Handler) (string, ResolverOptions, func())) {
+	var (
+		ctx = context.Background()
+		tag = "latest"
+		r   = http.NewServeMux()
+	)
+
+	m := newManifest(
+		content(ocispec.MediaTypeImageConfig, []byte("1")),
+		content(ocispec.MediaTypeImageLayerGzip, []byte("2")),
+	)
+	mc := content(ocispec.MediaTypeImageManifest, m.OCIManifest())
+	m.RegisterHandler(r, name)
+	r.Handle(fmt.Sprintf("/v2/%s/manifests/%s", name, tag), mc)
+	r.Handle(fmt.Sprintf("/v2/%s/manifests/%s", name, mc.Digest()), mc)
+
+	base, ro, close := sf(logHandler{t, r})
+	defer close()
+
+	resolver := NewResolver(ro)
+	image := fmt.Sprintf("%s/%s:%s", base, name, tag)
+
+	_, d, f, err := resolver.Resolve(ctx, image)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	refs, err := testocimanifest(ctx, f, d)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(refs) != 2 {
+		t.Fatalf("Unexpected number of references: %d, expected 2", len(refs))
+	}
+
+	for _, ref := range refs {
+		if err := testFetch(ctx, f, ref); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func testFetch(ctx context.Context, f remotes.Fetcher, desc ocispec.Descriptor) error {
+	r, err := f.Fetch(ctx, desc)
+	if err != nil {
+		return err
+	}
+	dgstr := desc.Digest.Algorithm().Digester()
+	io.Copy(dgstr.Hash(), r)
+	if dgstr.Digest() != desc.Digest {
+		return errors.Errorf("content mismatch: %s != %s", dgstr.Digest(), desc.Digest)
+	}
+
+	return nil
+}
+
+func testocimanifest(ctx context.Context, f remotes.Fetcher, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+	r, err := f.Fetch(ctx, desc)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to fetch %s", desc.Digest)
+	}
+	p, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	if dgst := desc.Digest.Algorithm().FromBytes(p); dgst != desc.Digest {
+		return nil, errors.Errorf("digest mismatch: %s != %s", dgst, desc.Digest)
+	}
+
+	var manifest ocispec.Manifest
+	if err := json.Unmarshal(p, &manifest); err != nil {
+		return nil, err
+	}
+
+	var descs []ocispec.Descriptor
+
+	descs = append(descs, manifest.Config)
+	descs = append(descs, manifest.Layers...)
+
+	return descs, nil
+}
+
+type testContent struct {
+	mediaType string
+	content   []byte
+}
+
+func content(mediaType string, b []byte) testContent {
+	return testContent{
+		mediaType: mediaType,
+		content:   b,
+	}
+}
+
+func (tc testContent) Descriptor() ocispec.Descriptor {
+	return ocispec.Descriptor{
+		MediaType: tc.mediaType,
+		Digest:    digest.FromBytes(tc.content),
+		Size:      int64(len(tc.content)),
+	}
+}
+
+func (tc testContent) Digest() digest.Digest {
+	return digest.FromBytes(tc.content)
+}
+
+func (tc testContent) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Add("Content-Type", tc.mediaType)
+	w.Header().Add("Content-Length", strconv.Itoa(len(tc.content)))
+	w.Header().Add("Docker-Content-Digest", tc.Digest().String())
+	w.WriteHeader(http.StatusOK)
+	w.Write(tc.content)
+}
+
+type testManifest struct {
+	config     testContent
+	references []testContent
+}
+
+func newManifest(config testContent, refs ...testContent) testManifest {
+	return testManifest{
+		config:     config,
+		references: refs,
+	}
+}
+
+func (m testManifest) OCIManifest() []byte {
+	manifest := ocispec.Manifest{
+		Versioned: specs.Versioned{
+			SchemaVersion: 1,
+		},
+		Config: m.config.Descriptor(),
+		Layers: make([]ocispec.Descriptor, len(m.references)),
+	}
+	for i, c := range append(m.references) {
+		manifest.Layers[i] = c.Descriptor()
+	}
+	b, _ := json.Marshal(manifest)
+	return b
+}
+
+func (m testManifest) RegisterHandler(r *http.ServeMux, name string) {
+	for _, c := range append(m.references, m.config) {
+		r.Handle(fmt.Sprintf("/v2/%s/blobs/%s", name, c.Digest()), c)
+	}
+}

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,6 +1,6 @@
 github.com/coreos/go-systemd 48702e0da86bd25e76cfef347e2adeb434a0d0a6
 github.com/crosbymichael/go-runc 65847bfc51952703ca24b564d10de50d3f2db6e7
-github.com/crosbymichael/console f13f890e20a94bdec6c328cdf9410b7158f0cfa4
+github.com/crosbymichael/console 2a5cbd32a84cd1268c20c69bd090ec49e37009f8
 github.com/crosbymichael/cgroups e950a27f3faf567abbf995bfbec90eaddc766d25
 github.com/docker/go-metrics 8fd5772bf1584597834c6f7961a530f06cbfbb87
 github.com/godbus/dbus c7fdd8b5cd55e87b4e1f4e372cdb1db61dd6c66f

--- a/vendor/github.com/crosbymichael/console/console.go
+++ b/vendor/github.com/crosbymichael/console/console.go
@@ -20,6 +20,8 @@ type Console interface {
 	ResizeFrom(Console) error
 	// SetRaw sets the console in raw mode
 	SetRaw() error
+	// DisableEcho disables echo on the console
+	DisableEcho() error
 	// Reset restores the console to its orignal state
 	Reset() error
 	// Size returns the window size of the console

--- a/vendor/github.com/crosbymichael/console/console_windows.go
+++ b/vendor/github.com/crosbymichael/console/console_windows.go
@@ -126,6 +126,18 @@ func (m *master) ResizeFrom(c Console) error {
 	return ErrNotImplemented
 }
 
+func (m *master) DisableEcho() error {
+	mode := m.inMode &^ winterm.ENABLE_ECHO_INPUT
+	mode |= winterm.ENABLE_PROCESSED_INPUT
+	mode |= winterm.ENABLE_LINE_INPUT
+
+	if err := winterm.SetConsoleMode(m.in, mode); err != nil {
+		return errors.Wrap(err, "unable to set console to disable echo")
+	}
+
+	return nil
+}
+
 func (m *master) Close() error {
 	return nil
 }

--- a/vendor/github.com/crosbymichael/console/tc_darwin.go
+++ b/vendor/github.com/crosbymichael/console/tc_darwin.go
@@ -1,0 +1,51 @@
+package console
+
+import (
+	"fmt"
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func tcget(fd uintptr, p *unix.Termios) error {
+	return ioctl(fd, unix.TIOCGETA, uintptr(unsafe.Pointer(p)))
+}
+
+func tcset(fd uintptr, p *unix.Termios) error {
+	return ioctl(fd, unix.TIOCSETA, uintptr(unsafe.Pointer(p)))
+}
+
+func ioctl(fd, flag, data uintptr) error {
+	if _, _, err := unix.Syscall(unix.SYS_IOCTL, fd, flag, data); err != 0 {
+		return err
+	}
+	return nil
+}
+
+// unlockpt unlocks the slave pseudoterminal device corresponding to the master pseudoterminal referred to by f.
+// unlockpt should be called before opening the slave side of a pty.
+func unlockpt(f *os.File) error {
+	var u int32
+	return ioctl(f.Fd(), unix.TIOCPTYUNLK, uintptr(unsafe.Pointer(&u)))
+}
+
+// ptsname retrieves the name of the first available pts for the given master.
+func ptsname(f *os.File) (string, error) {
+	var n int32
+	if err := ioctl(f.Fd(), unix.TIOCPTYGNAME, uintptr(unsafe.Pointer(&n))); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("/dev/pts/%d", n), nil
+}
+
+func saneTerminal(f *os.File) error {
+	// Go doesn't have a wrapper for any of the termios ioctls.
+	var termios unix.Termios
+	if err := tcget(f.Fd(), &termios); err != nil {
+		return err
+	}
+	// Set -onlcr so we don't have to deal with \r.
+	termios.Oflag &^= unix.ONLCR
+	return tcset(f.Fd(), &termios)
+}

--- a/vendor/github.com/crosbymichael/console/tc_freebsd.go
+++ b/vendor/github.com/crosbymichael/console/tc_freebsd.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package console
 
 import (
@@ -11,11 +9,11 @@ import (
 )
 
 func tcget(fd uintptr, p *unix.Termios) error {
-	return ioctl(fd, unix.TCGETS, uintptr(unsafe.Pointer(p)))
+	return ioctl(fd, unix.TIOCGETA, uintptr(unsafe.Pointer(p)))
 }
 
 func tcset(fd uintptr, p *unix.Termios) error {
-	return ioctl(fd, unix.TCSETS, uintptr(unsafe.Pointer(p)))
+	return ioctl(fd, unix.TIOCSETA, uintptr(unsafe.Pointer(p)))
 }
 
 func ioctl(fd, flag, data uintptr) error {
@@ -27,9 +25,9 @@ func ioctl(fd, flag, data uintptr) error {
 
 // unlockpt unlocks the slave pseudoterminal device corresponding to the master pseudoterminal referred to by f.
 // unlockpt should be called before opening the slave side of a pty.
+// This does not exist on FreeBSD, it does not allocate controlling terminals on open
 func unlockpt(f *os.File) error {
-	var u int32
-	return ioctl(f.Fd(), unix.TIOCSPTLCK, uintptr(unsafe.Pointer(&u)))
+	return nil
 }
 
 // ptsname retrieves the name of the first available pts for the given master.

--- a/vendor/github.com/crosbymichael/console/tc_linux.go
+++ b/vendor/github.com/crosbymichael/console/tc_linux.go
@@ -1,0 +1,51 @@
+package console
+
+import (
+	"fmt"
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func tcget(fd uintptr, p *unix.Termios) error {
+	return ioctl(fd, unix.TCGETS, uintptr(unsafe.Pointer(p)))
+}
+
+func tcset(fd uintptr, p *unix.Termios) error {
+	return ioctl(fd, unix.TCSETS, uintptr(unsafe.Pointer(p)))
+}
+
+func ioctl(fd, flag, data uintptr) error {
+	if _, _, err := unix.Syscall(unix.SYS_IOCTL, fd, flag, data); err != 0 {
+		return err
+	}
+	return nil
+}
+
+// unlockpt unlocks the slave pseudoterminal device corresponding to the master pseudoterminal referred to by f.
+// unlockpt should be called before opening the slave side of a pty.
+func unlockpt(f *os.File) error {
+	var u int32
+	return ioctl(f.Fd(), unix.TIOCSPTLCK, uintptr(unsafe.Pointer(&u)))
+}
+
+// ptsname retrieves the name of the first available pts for the given master.
+func ptsname(f *os.File) (string, error) {
+	var n int32
+	if err := ioctl(f.Fd(), unix.TIOCGPTN, uintptr(unsafe.Pointer(&n))); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("/dev/pts/%d", n), nil
+}
+
+func saneTerminal(f *os.File) error {
+	// Go doesn't have a wrapper for any of the termios ioctls.
+	var termios unix.Termios
+	if err := tcget(f.Fd(), &termios); err != nil {
+		return err
+	}
+	// Set -onlcr so we don't have to deal with \r.
+	termios.Oflag &^= unix.ONLCR
+	return tcset(f.Fd(), &termios)
+}


### PR DESCRIPTION
Support for pulling from any registries and support for registry authentication. This change does not add support for schema2 images, schema1 images will still fail to be pulled.

### Tested with:
- gcr.io
- Docker hub (private repositories)
- Local private registry using token auth

### Remaining to be tested:
- Private registry with basic auth
- Private registry with refresh token

### Does not work:
- quay.io (authentication works, but Quay.io still doesn't support schema 2)