### PR TITLE
fixes #744 no-shim will crash containerd with ctr list and ctr info

### DIFF
--- a/linux/shim.go
+++ b/linux/shim.go
@@ -24,7 +24,7 @@ import (
 
 func newShim(path string, remote bool) (shim.ShimClient, error) {
 	if !remote {
-		return localShim.Client(path), nil
+		return localShim.Client(path)
 	}
 	socket := filepath.Join(path, "shim.sock")
 	l, err := sys.CreateUnixSocket(socket)
@@ -59,7 +59,7 @@ func newShim(path string, remote bool) (shim.ShimClient, error) {
 
 func loadShim(path string, remote bool) (shim.ShimClient, error) {
 	if !remote {
-		return localShim.Client(path), nil
+		return localShim.Client(path)
 	}
 	socket := filepath.Join(path, "shim.sock")
 	return connectShim(socket)


### PR DESCRIPTION
fixes #744

that was a tough one for me 
so simple to solve,and so long to troubleshoot :stuck_out_tongue_winking_eye:


when running with a shim service the initProcess is created and persist during the lifetime cicle of the container , but without a shim the initProcess needs to be recreated when loading the containers.

Signed-off-by: Krasi Georgiev <krasi.root@gmail.com>