### PR TITLE
optimize for shim 

### DIFF
--- a/cmd/ctr/shim.go
+++ b/cmd/ctr/shim.go
@@ -78,7 +78,11 @@ var shimCreateCommand = cli.Command{
 		},
 	),
 	Action: func(context *cli.Context) error {
-		id := context.Args().First()
+		var (
+			id  = context.Args().First()
+			ctx = gocontext.Background()
+		)
+
 		if id == "" {
 			return errors.New("container id must be provided")
 		}
@@ -91,7 +95,7 @@ var shimCreateCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		r, err := service.Create(gocontext.Background(), &shim.CreateRequest{
+		r, err := service.Create(ctx, &shim.CreateRequest{
 			ID:       id,
 			Bundle:   context.String("bundle"),
 			Runtime:  context.String("runtime"),
@@ -115,7 +119,7 @@ var shimCreateCommand = cli.Command{
 				if err != nil {
 					return err
 				}
-				if _, err := service.Pty(gocontext.Background(), &shim.PtyRequest{
+				if _, err := service.Pty(ctx, &shim.PtyRequest{
 					Pid:    r.Pid,
 					Width:  uint32(size.Width),
 					Height: uint32(size.Height),
@@ -210,6 +214,7 @@ var shimExecCommand = cli.Command{
 	),
 	Action: func(context *cli.Context) error {
 		service, err := getShimService()
+		ctx := gocontext.Background()
 		if err != nil {
 			return err
 		}
@@ -235,7 +240,7 @@ var shimExecCommand = cli.Command{
 			Stderr:   context.String("stderr"),
 			Terminal: tty,
 		}
-		r, err := service.Exec(gocontext.Background(), rq)
+		r, err := service.Exec(ctx, rq)
 		if err != nil {
 			return err
 		}
@@ -252,7 +257,7 @@ var shimExecCommand = cli.Command{
 				if err != nil {
 					return err
 				}
-				if _, err := service.Pty(gocontext.Background(), &shim.PtyRequest{
+				if _, err := service.Pty(ctx, &shim.PtyRequest{
 					Pid:    r.Pid,
 					Width:  uint32(size.Width),
 					Height: uint32(size.Height),


### PR DESCRIPTION
Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>

1. Declare a var ctx  in place of gocontext.Background() in shimCreateCommand.
2. Use var group.