### PR TITLE
ctr couldn't exit when the grpc containerd server is not running

### DIFF
--- a/cmd/ctr/utils.go
+++ b/cmd/ctr/utils.go
@@ -100,7 +100,7 @@ func forwardAllSignals(containers execution.ContainerServiceClient, id string) c
 			}
 			_, err := containers.Kill(gocontext.Background(), killRequest)
 			if err != nil {
-				logrus.WithError(err).Error("grpc event from kill")
+				logrus.Fatalln(err)
 			}
 		}
 	}()


### PR DESCRIPTION
to replicate: 
`bin/ctr run -id=name docker.io/library/redis:latest /usr/local/bin/redis-server`

kill `containerd`

can't  exit `bin/ctr` with `ctrl+c`,`ctrl+z`

Signed-off-by: Krasi Georgiev <krasi.root@gmail.com>