### PR TITLE
containerd: compile tags to exclude btrfs

### DIFF
--- a/cmd/containerd/builtins_btrfs_linux.go
+++ b/cmd/containerd/builtins_btrfs_linux.go
@@ -1,0 +1,5 @@
+// +build !containerd_no_btrfs
+
+package main
+
+import _ "github.com/containerd/containerd/snapshot/btrfs"

--- a/cmd/containerd/builtins_linux.go
+++ b/cmd/containerd/builtins_linux.go
@@ -3,6 +3,5 @@ package main
 import (
 	_ "github.com/containerd/containerd/linux"
 	_ "github.com/containerd/containerd/metrics/cgroups"
-	_ "github.com/containerd/containerd/snapshot/btrfs"
 	_ "github.com/containerd/containerd/snapshot/overlay"
 )


### PR DESCRIPTION
Leave in btrfs by default, but add go build tags to exclude it.
`go build -tags containerd_no_btrfs` will leave that driver out.
As the current containerd/btrfs code needs link to libbtrfs*.so, but not
all distros provide it.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>