### PR TITLE
Allow specification of rootfs in ctr

### DIFF
--- a/cmd/ctr/run.go
+++ b/cmd/ctr/run.go
@@ -35,6 +35,10 @@ var runCommand = cli.Command{
 			Usage: "allocate a TTY for the container",
 		},
 		cli.StringFlag{
+			Name:  "rootfs",
+			Usage: "path to rootfs",
+		},
+		cli.StringFlag{
 			Name:  "runtime",
 			Usage: "runtime name (linux, windows, vmware-linux)",
 			Value: "linux",
@@ -89,7 +93,7 @@ var runCommand = cli.Command{
 			return errors.Wrap(err, "failed resolving image store")
 		}
 
-		if runtime.GOOS != "windows" {
+		if runtime.GOOS != "windows" && context.String("rootfs") == "" {
 			ref := context.Args().First()
 
 			image, err := imageStore.Get(ctx, ref)
@@ -141,7 +145,7 @@ var runCommand = cli.Command{
 			// TODO: get the image / rootfs through the API once windows has a snapshotter
 		}
 
-		create, err := newCreateRequest(context, &imageConfig.Config, id, tmpDir)
+		create, err := newCreateRequest(context, &imageConfig.Config, id, tmpDir, context.String("rootfs"))
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/run_windows.go
+++ b/cmd/ctr/run_windows.go
@@ -85,7 +85,7 @@ func spec(id string, config *ocispec.ImageConfig, context *cli.Context) *specs.S
 	}
 }
 
-func customSpec(context *cli.Context, configPath string) (*specs.Spec, error) {
+func customSpec(context *cli.Context, configPath, rootfs string) (*specs.Spec, error) {
 	b, err := ioutil.ReadFile(configPath)
 	if err != nil {
 		return nil, err
@@ -96,7 +96,6 @@ func customSpec(context *cli.Context, configPath string) (*specs.Spec, error) {
 		return nil, err
 	}
 
-	rootfs := context.String("rootfs")
 	if rootfs != "" && s.Root.Path != rootfs {
 		logrus.Warnf("ignoring config Root.Path %q, setting %q forcibly", s.Root.Path, rootfs)
 		s.Root.Path = rootfs
@@ -104,21 +103,21 @@ func customSpec(context *cli.Context, configPath string) (*specs.Spec, error) {
 	return &s, nil
 }
 
-func getConfig(context *cli.Context, imageConfig *ocispec.ImageConfig) (*specs.Spec, error) {
+func getConfig(context *cli.Context, imageConfig *ocispec.ImageConfig, rootfs string) (*specs.Spec, error) {
 	if config := context.String("runtime-config"); config != "" {
-		return customSpec(context, config)
+		return customSpec(context, config, rootfs)
 	}
 
 	s := spec(context.String("id"), imageConfig, context)
-	if rootfs := context.String("rootfs"); rootfs != "" {
+	if rootfs != "" {
 		s.Root.Path = rootfs
 	}
 
 	return s, nil
 }
 
-func newCreateRequest(context *cli.Context, imageConfig *ocispec.ImageConfig, id, tmpDir string) (*execution.CreateRequest, error) {
-	spec, err := getConfig(context, imageConfig)
+func newCreateRequest(context *cli.Context, imageConfig *ocispec.ImageConfig, id, tmpDir, rootfs string) (*execution.CreateRequest, error) {
+	spec, err := getConfig(context, imageConfig, rootfs)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
carry: justincormack/containerd@ffe684b017252262431e157741406d4e1fb22831

Originally, this fix was considered to be temporary hack (https://github.com/linuxkit/linuxkit/issues/1390), but I think this is generally useful.
My motivation is to support 3rd party providers (e.g. https://github.com/AkihiroSuda/filegrain).

Signed-off-by: Justin Cormack <justin.cormack@docker.com>
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>