### PR TITLE
Add license scanning badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![banner](/docs/images/containerd-dark.png?raw=true)
 
 [![Build Status](https://travis-ci.org/containerd/containerd.svg?branch=master)](https://travis-ci.org/containerd/containerd)
+[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fcontainerd%2Fcontainerd.svg?type=shield)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fcontainerd%2Fcontainerd?ref=badge_shield)
 
 containerd is an industry-standard container runtime with an emphasis on simplicity, robustness and portability. It is available as a daemon for Linux and Windows, which can manage the complete container lifecycle of its host system: image transfer and storage, container execution and supervision, low-level storage and network attachments, etc..
 


### PR DESCRIPTION
In CNCF, we are starting to experiment with automated license scanning across our projects to ensure compliance to the CNCF IP Policy. For now, we're experimenting with FOSSA: https://app.fossa.io/reports/50dc07d0-435f-4856-9549-33a5f41bef81