### PR TITLE
fix `make vet` failures, and enable `make vet` on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ script:
   - export CGO_ENABLED=$TRAVIS_CGO_ENABLED
   - GIT_CHECK_EXCLUDE="./vendor" TRAVIS_COMMIT_RANGE="${TRAVIS_COMMIT_RANGE/.../..}" make dco
   - make fmt
+  - make vet
   - make binaries
   - if [ "$GOOS" != "windows" ]; then make coverage ; fi
   - if [ "$GOOS" != "windows" ]; then sudo PATH=$PATH GOPATH=$GOPATH make root-coverage ; fi

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ checkprotos: protos ## check if protobufs needs to be generated again
 # imports
 vet: binaries ## run go vet
 	@echo "$(WHALE) $@"
-	@test -z "$$(go vet ${PACKAGES} 2>&1 | grep -v 'constant [0-9]* not a string in call to Errorf' | egrep -v '(timestamp_test.go|duration_test.go|exit status 1)' | tee /dev/stderr)"
+	@test -z "$$(go vet ${PACKAGES} 2>&1 | grep -v 'constant [0-9]* not a string in call to Errorf' | grep -v 'unrecognized printf verb 'r'' | egrep -v '(timestamp_test.go|duration_test.go|fetch.go|exit status 1)' | tee /dev/stderr)"
 
 fmt: ## run go fmt
 	@echo "$(WHALE) $@"

--- a/cmd/ctr/events.go
+++ b/cmd/ctr/events.go
@@ -42,6 +42,5 @@ var eventsCommand = cli.Command{
 				return err
 			}
 		}
-		return nil
 	},
 }

--- a/cmd/ctr/exec_windows.go
+++ b/cmd/ctr/exec_windows.go
@@ -29,11 +29,11 @@ func newExecRequest(context *cli.Context, tmpDir, id string) (*execution.ExecReq
 			Value:   data,
 		},
 		Terminal: context.Bool("tty"),
-		Stdin:    fmt.Sprintf(`%s\ctr-%s-stdin-`, pipeRoot, id, now),
-		Stdout:   fmt.Sprintf(`%s\ctr-%s-stdout-`, pipeRoot, id, now),
+		Stdin:    fmt.Sprintf(`%s\ctr-%s-stdin-%d`, pipeRoot, id, now),
+		Stdout:   fmt.Sprintf(`%s\ctr-%s-stdout-%d`, pipeRoot, id, now),
 	}
 	if !request.Terminal {
-		request.Stderr = fmt.Sprintf(`%s\ctr-%s-stderr-`, pipeRoot, id, now)
+		request.Stderr = fmt.Sprintf(`%s\ctr-%s-stderr-%d`, pipeRoot, id, now)
 	}
 
 	return request, nil

--- a/cmd/ctr/shim.go
+++ b/cmd/ctr/shim.go
@@ -285,7 +285,6 @@ var shimEventsCommand = cli.Command{
 			}
 			fmt.Printf("type=%s id=%s pid=%d status=%d\n", e.Type, e.ID, e.Pid, e.ExitStatus)
 		}
-		return nil
 	},
 }
 

--- a/cmd/dist/apply.go
+++ b/cmd/dist/apply.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	contextpkg "context"
 	"os"
 
 	"github.com/containerd/containerd/archive"
@@ -17,9 +16,10 @@ var applyCommand = cli.Command{
 	Flags:     []cli.Flag{},
 	Action: func(context *cli.Context) error {
 		var (
-			ctx = contextpkg.Background()
 			dir = context.Args().First()
 		)
+		ctx, cancel := appContext()
+		defer cancel()
 
 		log.G(ctx).Info("applying layer from stdin")
 

--- a/cmd/dist/delete.go
+++ b/cmd/dist/delete.go
@@ -22,10 +22,11 @@ var deleteCommand = cli.Command{
 	Flags: []cli.Flag{},
 	Action: func(context *cli.Context) error {
 		var (
-			ctx       = background
 			args      = []string(context.Args())
 			exitError error
 		)
+		ctx, cancel := appContext()
+		defer cancel()
 
 		conn, err := connectGRPC(context)
 		if err != nil {

--- a/cmd/dist/edit.go
+++ b/cmd/dist/edit.go
@@ -27,10 +27,11 @@ var editCommand = cli.Command{
 	},
 	Action: func(context *cli.Context) error {
 		var (
-			ctx      = background
 			validate = context.String("validate")
 			object   = context.Args().First()
 		)
+		ctx, cancel := appContext()
+		defer cancel()
 
 		if validate != "" {
 			return errors.New("validating the edit result not supported")

--- a/cmd/dist/fetch.go
+++ b/cmd/dist/fetch.go
@@ -42,9 +42,10 @@ Most of this is experimental and there are few leaps to make this work.`,
 	Flags: registryFlags,
 	Action: func(clicontext *cli.Context) error {
 		var (
-			ctx = background
 			ref = clicontext.Args().First()
 		)
+		ctx, cancel := appContext()
+		defer cancel()
 
 		conn, err := connectGRPC(clicontext)
 		if err != nil {
@@ -176,8 +177,6 @@ Most of this is experimental and there are few leaps to make this work.`,
 				done = true // allow ui to update once more
 			}
 		}
-
-		return nil
 	},
 }
 

--- a/cmd/dist/fetchobject.go
+++ b/cmd/dist/fetchobject.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	contextpkg "context"
 	"io"
 	"os"
 
@@ -18,25 +17,13 @@ var fetchObjectCommand = cli.Command{
 	Usage:       "retrieve objects from a remote",
 	ArgsUsage:   "[flags] <remote> <object> [<hint>, ...]",
 	Description: `Fetch objects by identifier from a remote.`,
-	Flags: append([]cli.Flag{
-		cli.DurationFlag{
-			Name:   "timeout",
-			Usage:  "total timeout for fetch",
-			EnvVar: "CONTAINERD_FETCH_TIMEOUT",
-		},
-	}, registryFlags...),
+	Flags:       registryFlags,
 	Action: func(context *cli.Context) error {
 		var (
-			ctx     = background
-			timeout = context.Duration("timeout")
-			ref     = context.Args().First()
+			ref = context.Args().First()
 		)
-
-		if timeout > 0 {
-			var cancel func()
-			ctx, cancel = contextpkg.WithTimeout(ctx, timeout)
-			defer cancel()
-		}
+		ctx, cancel := appContext()
+		defer cancel()
 
 		resolver, err := getResolver(ctx, context)
 		if err != nil {

--- a/cmd/dist/get.go
+++ b/cmd/dist/get.go
@@ -17,9 +17,8 @@ var getCommand = cli.Command{
 	Description: "Display the image object.",
 	Flags:       []cli.Flag{},
 	Action: func(context *cli.Context) error {
-		var (
-			ctx = background
-		)
+		ctx, cancel := appContext()
+		defer cancel()
 
 		dgst, err := digest.Parse(context.Args().First())
 		if err != nil {

--- a/cmd/dist/images.go
+++ b/cmd/dist/images.go
@@ -21,9 +21,8 @@ var imagesListCommand = cli.Command{
 	Description: `List images registered with containerd.`,
 	Flags:       []cli.Flag{},
 	Action: func(clicontext *cli.Context) error {
-		var (
-			ctx = background
-		)
+		ctx, cancel := appContext()
+		defer cancel()
 
 		imageStore, err := resolveImageStore(clicontext)
 		if err != nil {
@@ -66,9 +65,10 @@ var rmiCommand = cli.Command{
 	Flags:       []cli.Flag{},
 	Action: func(clicontext *cli.Context) error {
 		var (
-			ctx     = background
 			exitErr error
 		)
+		ctx, cancel := appContext()
+		defer cancel()
 
 		imageStore, err := resolveImageStore(clicontext)
 		if err != nil {

--- a/cmd/dist/ingest.go
+++ b/cmd/dist/ingest.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	contextpkg "context"
 	"os"
 
 	contentapi "github.com/containerd/containerd/api/services/content"
@@ -29,14 +28,12 @@ var ingestCommand = cli.Command{
 	},
 	Action: func(context *cli.Context) error {
 		var (
-			ctx            = background
-			cancel         func()
 			ref            = context.Args().First()
 			expectedSize   = context.Int64("expected-size")
 			expectedDigest = digest.Digest(context.String("expected-digest"))
 		)
 
-		ctx, cancel = contextpkg.WithCancel(ctx)
+		ctx, cancel := appContext()
 		defer cancel()
 
 		if err := expectedDigest.Validate(); expectedDigest != "" && err != nil {

--- a/cmd/dist/list.go
+++ b/cmd/dist/list.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	contextpkg "context"
 	"fmt"
 	"os"
 	"text/tabwriter"
@@ -28,10 +27,11 @@ var listCommand = cli.Command{
 	},
 	Action: func(context *cli.Context) error {
 		var (
-			ctx   = contextpkg.Background()
 			quiet = context.Bool("quiet")
 			args  = []string(context.Args())
 		)
+		ctx, cancel := appContext()
+		defer cancel()
 
 		cs, err := resolveContentStore(context)
 		if err != nil {

--- a/cmd/dist/pull.go
+++ b/cmd/dist/pull.go
@@ -38,9 +38,11 @@ command. As part of this process, we do the following:
 	Flags: registryFlags,
 	Action: func(clicontext *cli.Context) error {
 		var (
-			ctx = background
 			ref = clicontext.Args().First()
 		)
+
+		ctx, cancel := appContext()
+		defer cancel()
 
 		conn, err := connectGRPC(clicontext)
 		if err != nil {
@@ -104,8 +106,9 @@ command. As part of this process, we do the following:
 		}()
 
 		defer func() {
-			ctx := background
-
+			// we need new ctx here
+			ctx, cancel := appContext()
+			defer cancel()
 			// TODO(stevvooe): This section unpacks the layers and resolves the
 			// root filesystem chainid for the image. For now, we just print
 			// it, but we should keep track of this in the metadata storage.

--- a/cmd/dist/rootfs.go
+++ b/cmd/dist/rootfs.go
@@ -34,9 +34,8 @@ var rootfsUnpackCommand = cli.Command{
 	ArgsUsage: "[flags] <digest>",
 	Flags:     []cli.Flag{},
 	Action: func(clicontext *cli.Context) error {
-		var (
-			ctx = background
-		)
+		ctx, cancel := appContext()
+		defer cancel()
 
 		dgst, err := digest.Parse(clicontext.Args().First())
 		if err != nil {
@@ -74,9 +73,8 @@ var rootfsPrepareCommand = cli.Command{
 	ArgsUsage: "[flags] <digest> <target>",
 	Flags:     []cli.Flag{},
 	Action: func(clicontext *cli.Context) error {
-		var (
-			ctx = background
-		)
+		ctx, cancel := appContext()
+		defer cancel()
 
 		if clicontext.NArg() != 2 {
 			return cli.ShowSubcommandHelp(clicontext)

--- a/services/content/service.go
+++ b/services/content/service.go
@@ -324,8 +324,6 @@ func (s *Service) Write(session api.Content_WriteServer) (err error) {
 			return err
 		}
 	}
-
-	return nil
 }
 
 func (s *Service) Status(*api.StatusRequest, api.Content_StatusServer) error {

--- a/snapshot/storage/bolt.go
+++ b/snapshot/storage/bolt.go
@@ -363,8 +363,6 @@ func parents(bkt *bolt.Bucket, parent *db.Snapshot) (parents []string, err error
 		}
 		parent = &ps
 	}
-
-	return
 }
 
 func getSnapshot(bkt *bolt.Bucket, key string, ss *db.Snapshot) error {

--- a/snapshot/storage/metastore_test.go
+++ b/snapshot/storage/metastore_test.go
@@ -80,7 +80,7 @@ func inReadTransaction(fn testFunc, pf populateFunc) testFunc {
 
 		ctx, tx, err := ms.TransactionContext(ctx, false)
 		if err != nil {
-			t.Fatal("Failed start transaction: %+v", err)
+			t.Fatalf("Failed start transaction: %+v", err)
 		}
 		defer func() {
 			if err := tx.Rollback(); err != nil {
@@ -99,7 +99,7 @@ func inWriteTransaction(fn testFunc) testFunc {
 	return func(ctx context.Context, t *testing.T, ms *MetaStore) {
 		ctx, tx, err := ms.TransactionContext(ctx, true)
 		if err != nil {
-			t.Fatal("Failed to start transaction: %+v", err)
+			t.Fatalf("Failed to start transaction: %+v", err)
 		}
 		defer func() {
 			if t.Failed() {
@@ -108,7 +108,7 @@ func inWriteTransaction(fn testFunc) testFunc {
 				}
 			} else {
 				if err := tx.Commit(); err != nil {
-					t.Fatal("Commit failed: %+v", err)
+					t.Fatalf("Commit failed: %+v", err)
 				}
 			}
 		}()
@@ -311,7 +311,7 @@ func testGetActive(ctx context.Context, t *testing.T, ms *MetaStore) {
 		for key, expected := range activeMap {
 			active, err := GetActive(ctx, key)
 			if err != nil {
-				t.Fatal("Failed to get active: %+v", err)
+				t.Fatalf("Failed to get active: %+v", err)
 			}
 			assert.Equal(t, expected, active)
 		}
@@ -366,7 +366,7 @@ func testCreateActive(ctx context.Context, t *testing.T, ms *MetaStore) {
 		t.Fatal("Returned active identifiers must be unique")
 	}
 	if len(a3.ParentIDs) != 1 {
-		t.Fatal("Expected 1 parent, got %d", len(a3.ParentIDs))
+		t.Fatalf("Expected 1 parent, got %d", len(a3.ParentIDs))
 	}
 	if a3.ParentIDs[0] != commitID {
 		t.Fatal("Expected active parent to be same as commit ID")
@@ -383,7 +383,7 @@ func testCreateActive(ctx context.Context, t *testing.T, ms *MetaStore) {
 		t.Fatal("Returned active identifiers must be unique")
 	}
 	if len(a3.ParentIDs) != 1 {
-		t.Fatal("Expected 1 parent, got %d", len(a3.ParentIDs))
+		t.Fatalf("Expected 1 parent, got %d", len(a3.ParentIDs))
 	}
 	if a3.ParentIDs[0] != commitID {
 		t.Fatal("Expected active parent to be same as commit ID")
@@ -505,7 +505,7 @@ func testRemove(ctx context.Context, t *testing.T, ms *MetaStore) {
 		t.Fatal("Expected remove ID to match create ID")
 	}
 	if k3 != snapshot.KindActive {
-		t.Fatal("Expected active kind, got %v", k3)
+		t.Fatalf("Expected active kind, got %v", k3)
 	}
 
 	r2, k2, err := Remove(ctx, "active-2")
@@ -516,7 +516,7 @@ func testRemove(ctx context.Context, t *testing.T, ms *MetaStore) {
 		t.Fatal("Expected remove ID to match create ID")
 	}
 	if k2 != snapshot.KindActive {
-		t.Fatal("Expected active kind, got %v", k2)
+		t.Fatalf("Expected active kind, got %v", k2)
 	}
 
 	r1, k1, err := Remove(ctx, "committed-1")
@@ -527,7 +527,7 @@ func testRemove(ctx context.Context, t *testing.T, ms *MetaStore) {
 		t.Fatal("Expected remove ID to match commit ID")
 	}
 	if k1 != snapshot.KindCommitted {
-		t.Fatal("Expected committed kind, got %v", k1)
+		t.Fatalf("Expected committed kind, got %v", k1)
 	}
 }
 

--- a/windows/hcs/types.go
+++ b/windows/hcs/types.go
@@ -9,7 +9,7 @@ type Configuration struct {
 
 	Layers []string `json:"layers"`
 
-	TerminateDuration time.Duration `json:"terminateDuration",omitempty`
+	TerminateDuration time.Duration `json:"terminateDuration,omitempty"`
 
 	IgnoreFlushesDuringBoot bool `json:"ignoreFlushesDuringBoot,omitempty"`
 


### PR DESCRIPTION
`make vet` was failing

```
cmd/ctr/events.go:45: unreachable code                                    
cmd/ctr/shim.go:288: unreachable code         
cmd/dist/fetch.go:180: unreachable code                                           
cmd/dist/main.go:82: the cancel function returned by context.WithTimeout should be called, not di
scarded, to avoid a context leak                                                   
services/content/service.go:328: unreachable code                                  
snapshot/storage/bolt.go:367: unreachable code                                     
snapshot/storage/metastore_test.go:83: possible formatting directive in Fatal call 
snapshot/storage/metastore_test.go:102: possible formatting directive in Fatal call
snapshot/storage/metastore_test.go:111: possible formatting directive in Fatal call
snapshot/storage/metastore_test.go:314: possible formatting directive in Fatal call
snapshot/storage/metastore_test.go:369: possible formatting directive in Fatal call
snapshot/storage/metastore_test.go:386: possible formatting directive in Fatal call
snapshot/storage/metastore_test.go:508: possible formatting directive in Fatal call
snapshot/storage/metastore_test.go:519: possible formatting directive in Fatal call
snapshot/storage/metastore_test.go:530: possible formatting directive in Fatal call
```

on windows:
```
cmd/ctr/exec_windows.go:32: wrong number of args for format in Sprintf call: 2 needed but 3 args
cmd/ctr/exec_windows.go:33: wrong number of args for format in Sprintf call: 2 needed but 3 args
cmd/ctr/exec_windows.go:36: wrong number of args for format in Sprintf call: 2 needed but 3 args
windows/hcs/types.go:12: struct field tag `json:"terminateDuration",omitempty` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
```

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>