### PR TITLE
remove container stat dir when no process found in restore

### DIFF
--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -333,8 +333,10 @@ func (s *Supervisor) restore() error {
 			continue
 		}
 		processes, err := container.Processes()
-		if err != nil {
-			return err
+		if err != nil || len(processes) == 0 {
+			logrus.WithFields(logrus.Fields{"error": err, "id": id}).Warnf("containerd: container has no process running,removing state directory.")
+			os.RemoveAll(filepath.Join(s.stateDir, id))
+			continue
 		}
 
 		ContainersCounter.Inc(1)


### PR DESCRIPTION
Under some abnormal cases, container state dir exist while pid file not.
containerd restore would print this error to log without handling this,
it will set container state to stopped without removing its state dir.

trying to start the container again will cause error:
`mkdir /var/run/docker/libcontainerd/containerd/xxx: file exists`

Signed-off-by: Deng Guangxing <dengguangxing@huawei.com>