### PR TITLE
Only build shim on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ SNAPSHOT_PACKAGES=$(shell go list ./snapshot/...)
 
 # Project binaries.
 COMMANDS=ctr containerd protoc-gen-gogoctrd dist ctrd-protobuild
-ifneq ("$(GOOS)", "windows")
+ifeq ("$(GOOS)", "linux")
 	COMMANDS += containerd-shim
 endif
 BINARIES=$(addprefix bin/,$(COMMANDS))


### PR DESCRIPTION
Currently does not build on any other platform, so add them in when
it builds.

With this Darwin builds without any errors.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>