### PR TITLE
[WIP] Makefile: simplify vet check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ script:
   - export CGO_ENABLED=$TRAVIS_CGO_ENABLED
   - GIT_CHECK_EXCLUDE="./vendor" TRAVIS_COMMIT_RANGE="${TRAVIS_COMMIT_RANGE/.../..}" make dco
   - make fmt
+  - which go vet
+  - sha256sum /home/travis/.gimme/versions/go1.8.1.linux.amd64/pkg/tool/linux_amd64/vet
   - make vet
   - make binaries
   - if [ "$GOOS" != "windows" ]; then make coverage ; fi

--- a/Makefile
+++ b/Makefile
@@ -78,9 +78,9 @@ checkprotos: protos ## check if protobufs needs to be generated again
 
 # Depends on binaries because vet will silently fail if it can't load compiled
 # imports
-vet: binaries ## run go vet
+vet: ## run go vet
 	@echo "$(WHALE) $@"
-	@test -z "$$(go vet ${PACKAGES} 2>&1 | grep -v 'constant [0-9]* not a string in call to Errorf' | grep -v 'unrecognized printf verb 'r'' | egrep -v '(timestamp_test.go|duration_test.go|fetch.go|exit status 1)' | tee /dev/stderr)"
+	@test -z "$$(go vet ${PACKAGES} 2>&1 | tee /dev/stderr)"
 
 fmt: ## run go fmt
 	@echo "$(WHALE) $@"


### PR DESCRIPTION
Building of binaries is not required to run `go vet`. We also remove the
load of exceptions that aren't needed for Go 1.8.

This will cause Go 1.7 to fail `go vet`.

Signed-off-by: Stephen J Day <stephen.day@docker.com>