### PR TITLE
Allow specifying shim

### DIFF
--- a/linux/runtime.go
+++ b/linux/runtime.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/containerd/containerd"
@@ -192,7 +193,9 @@ func (r *Runtime) forward(events shim.Shim_EventsClient) {
 	for {
 		e, err := events.Recv()
 		if err != nil {
-			log.G(r.eventsContext).WithError(err).Error("get event from shim")
+			if !strings.HasSuffix(err.Error(), "transport is closing") {
+				log.G(r.eventsContext).WithError(err).Error("get event from shim")
+			}
 			return
 		}
 		var et containerd.EventType

--- a/linux/shim.go
+++ b/linux/shim.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func newShim(path string, remote bool) (shim.ShimClient, error) {
+func newShim(shimName string, path string, remote bool) (shim.ShimClient, error) {
 	if !remote {
 		return localShim.Client(path)
 	}
@@ -31,7 +31,7 @@ func newShim(path string, remote bool) (shim.ShimClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	cmd := exec.Command("containerd-shim")
+	cmd := exec.Command(shimName)
 	cmd.Dir = path
 	f, err := l.(*net.UnixListener).File()
 	if err != nil {


### PR DESCRIPTION
This allow specifying the shim binary name/path to be used.

For instance docker calls its shim `docker-containerd-shim`.