### PR TITLE
Revert "Only build shim on Linux"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ SNAPSHOT_PACKAGES=$(shell go list ./snapshot/...)
 
 # Project binaries.
 COMMANDS=ctr containerd protoc-gen-gogoctrd dist ctrd-protobuild
-ifeq ("$(GOOS)", "linux")
+ifneq ("$(GOOS)", "windows")
 	COMMANDS += containerd-shim
 endif
 BINARIES=$(addprefix bin/,$(COMMANDS))


### PR DESCRIPTION
This reverts commit 296ad66d2dc30d59f92e236cf32de0206a08e3aa.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>