### PR TITLE
Restrict shim build to linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ SNAPSHOT_PACKAGES=$(shell go list ./snapshot/...)
 
 # Project binaries.
 COMMANDS=ctr containerd protoc-gen-gogoctrd dist ctrd-protobuild
-ifneq ("$(GOOS)", "windows")
+ifeq ($(filter-out "linux","$(GOOS)"),)
 	COMMANDS += containerd-shim
 endif
 BINARIES=$(addprefix bin/,$(COMMANDS))


### PR DESCRIPTION
Default to building shim if $GOOS is empty or "linux"