### PR TITLE
Supervisor should use the same num of goroutines as workers to handleTask

### DIFF
--- a/containerd/main.go
+++ b/containerd/main.go
@@ -17,15 +17,15 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/urfave/cli"
-	"github.com/cyberdelia/go-metrics-graphite"
 	"github.com/containerd/containerd"
 	grpcserver "github.com/containerd/containerd/api/grpc/server"
 	"github.com/containerd/containerd/api/grpc/types"
 	"github.com/containerd/containerd/api/http/pprof"
 	"github.com/containerd/containerd/supervisor"
+	"github.com/cyberdelia/go-metrics-graphite"
 	"github.com/docker/docker/pkg/listeners"
 	"github.com/rcrowley/go-metrics"
+	"github.com/urfave/cli"
 )
 
 const (
@@ -198,7 +198,7 @@ func daemon(context *cli.Context) error {
 	}
 	types.RegisterAPIServer(server, grpcserver.NewServer(sv))
 	wg := &sync.WaitGroup{}
-	for i := 0; i < 10; i++ {
+	for i := 0; i < supervisor.GetDefaultWorkersNum(); i++ {
 		wg.Add(1)
 		w := supervisor.NewWorker(sv, wg)
 		go w.Start()


### PR DESCRIPTION
When docker exec to a container which keep doing pause and unpause, the line "s.handleTask(i)"  in containerd maybe block two minutes. During this time，we can't use docker command to run a container.

### why?
when docker exec to a container, it will do:
```
d *Daemon
        getExecConfig
        container.AttachStreams
        d.containerd.AddProcess
                  (s *Supervisor) addProcess
                         ci.container.Exec (if the container is paused currently,  it may last two minutes, and you can't unpause it )
```
### how to reproduce ?
use the following scripts to reproduce.
```
#!/bin/bash
while true; do
        docker pause testone
        docker unpause testone
done
```

```
#!/bin/bash
while true; do
        echo "exec ${i}th times"
        docker exec -ti testone bash  -c "sleep 0.5 ;exit"
        ((i++))
done
```
 




Signed-off-by: yangshukui <yangshukui@huawei.com>