### PR TITLE
Add --net-host for testing host networking

### DIFF
--- a/cmd/ctr/run.go
+++ b/cmd/ctr/run.go
@@ -51,6 +51,10 @@ var runCommand = cli.Command{
 			Name:  "readonly",
 			Usage: "set the containers filesystem as readonly",
 		},
+		cli.BoolFlag{
+			Name:  "net-host",
+			Usage: "enable host networking for the container",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		var (

--- a/cmd/ctr/run_unix.go
+++ b/cmd/ctr/run_unix.go
@@ -92,7 +92,7 @@ func spec(id string, config *ocispec.ImageConfig, context *cli.Context) (*specs.
 	if cwd == "" {
 		cwd = "/"
 	}
-	return &specs.Spec{
+	s := &specs.Spec{
 		Version: specs.Version,
 		Platform: specs.Platform{
 			OS:   runtime.GOOS,
@@ -211,12 +211,15 @@ func spec(id string, config *ocispec.ImageConfig, context *cli.Context) (*specs.
 				{
 					Type: "mount",
 				},
-				{
-					Type: "network",
-				},
 			},
 		},
-	}, nil
+	}
+	if !context.Bool("net-host") {
+		s.Linux.Namespaces = append(s.Linux.Namespaces, specs.LinuxNamespace{
+			Type: "network",
+		})
+	}
+	return s, nil
 }
 
 func customSpec(configPath string, rootfs string) (*specs.Spec, error) {


### PR DESCRIPTION
Add `--net-host` to `ctr run` to test containers running in host
networking.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>