### PR TITLE
fs: remove fsutils package

### DIFF
--- a/fs/dtype_linux.go
+++ b/fs/dtype_linux.go
@@ -1,6 +1,6 @@
 // +build linux
 
-package fsutils
+package fs
 
 import (
 	"fmt"

--- a/fs/dtype_linux_test.go
+++ b/fs/dtype_linux_test.go
@@ -1,6 +1,6 @@
 // +build linux
 
-package fsutils
+package fs
 
 import (
 	"io/ioutil"

--- a/snapshot/overlay/overlay.go
+++ b/snapshot/overlay/overlay.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/fs"
-	"github.com/containerd/containerd/fs/fsutils"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/snapshot"
@@ -48,7 +47,7 @@ func NewSnapshotter(root string) (snapshot.Snapshotter, error) {
 	if err := os.MkdirAll(root, 0700); err != nil {
 		return nil, err
 	}
-	supportsDType, err := fsutils.SupportsDType(root)
+	supportsDType, err := fs.SupportsDType(root)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
No need to have a util package under a package... er, package.

We should move most of this functionality to continuity.

Signed-off-by: Stephen J Day <stephen.day@docker.com>