### PR TITLE
Implementation for diff service

### DIFF
--- a/cmd/ctr/main.go
+++ b/cmd/ctr/main.go
@@ -61,6 +61,7 @@ containerd client
 		execCommand,
 		pauseCommand,
 		resumeCommand,
+		snapshotCommand,
 		versionCommand,
 	}
 	app.Commands = append(app.Commands, extraCmds...)

--- a/cmd/ctr/run.go
+++ b/cmd/ctr/run.go
@@ -127,6 +127,14 @@ var runCommand = cli.Command{
 				if err != nil {
 					return err
 				}
+			} else {
+				defer func() {
+					if id != "" {
+						if err := snapshotter.Remove(ctx, id); err != nil {
+							logrus.WithError(err).Errorf("failed to remove snapshot %q", id)
+						}
+					}
+				}()
 			}
 
 			ic, err := image.Config(ctx, content)
@@ -206,6 +214,9 @@ var runCommand = cli.Command{
 			}); err != nil {
 				return err
 			}
+		} else {
+			// Don't remove snapshot
+			id = ""
 		}
 		if status != 0 {
 			return cli.NewExitError("", int(status))

--- a/cmd/ctr/run.go
+++ b/cmd/ctr/run.go
@@ -54,6 +54,10 @@ var runCommand = cli.Command{
 			Name:  "net-host",
 			Usage: "enable host networking for the container",
 		},
+		cli.BoolFlag{
+			Name:  "keep",
+			Usage: "keep container after running",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		var (
@@ -110,7 +114,11 @@ var runCommand = cli.Command{
 				return err
 			}
 
-			mounts, err = snapshotter.Prepare(ctx, id, identity.ChainID(diffIDs).String())
+			if context.Bool("readonly") {
+				mounts, err = snapshotter.View(ctx, id, identity.ChainID(diffIDs).String())
+			} else {
+				mounts, err = snapshotter.Prepare(ctx, id, identity.ChainID(diffIDs).String())
+			}
 			if err != nil {
 				if !snapshot.IsExist(err) {
 					return err
@@ -192,10 +200,12 @@ var runCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		if _, err := containers.Delete(ctx, &execution.DeleteRequest{
-			ID: response.ID,
-		}); err != nil {
-			return err
+		if !context.Bool("keep") {
+			if _, err := containers.Delete(ctx, &execution.DeleteRequest{
+				ID: response.ID,
+			}); err != nil {
+				return err
+			}
 		}
 		if status != 0 {
 			return cli.NewExitError("", int(status))

--- a/cmd/ctr/snapshot.go
+++ b/cmd/ctr/snapshot.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/containerd/containerd/rootfs"
+	"github.com/urfave/cli"
+)
+
+var snapshotCommand = cli.Command{
+	Name:      "snapshot",
+	Usage:     "snapshot a container into an archive",
+	ArgsUsage: "",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "id",
+			Usage: "id of the container",
+		},
+	},
+	Action: func(clicontext *cli.Context) error {
+		id := clicontext.String("id")
+		if id == "" {
+			return errors.New("container id must be provided")
+		}
+
+		snapshotter, err := getSnapshotter(clicontext)
+		if err != nil {
+			return err
+		}
+
+		differ, err := getDiffService(clicontext)
+		if err != nil {
+			return err
+		}
+
+		contentRef := fmt.Sprintf("diff-%s", id)
+
+		d, err := rootfs.Diff(context.TODO(), id, contentRef, snapshotter, differ)
+		if err != nil {
+			return err
+		}
+
+		// TODO: Track progress
+		fmt.Printf("%s %s\n", d.MediaType, d.Digest)
+
+		return nil
+	},
+}

--- a/cmd/ctr/utils.go
+++ b/cmd/ctr/utils.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	contentapi "github.com/containerd/containerd/api/services/content"
+	diffapi "github.com/containerd/containerd/api/services/diff"
 	"github.com/containerd/containerd/api/services/execution"
 	imagesapi "github.com/containerd/containerd/api/services/images"
 	snapshotapi "github.com/containerd/containerd/api/services/snapshot"
@@ -21,6 +22,7 @@ import (
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
 	contentservice "github.com/containerd/containerd/services/content"
+	"github.com/containerd/containerd/services/diff"
 	imagesservice "github.com/containerd/containerd/services/images"
 	snapshotservice "github.com/containerd/containerd/services/snapshot"
 	"github.com/containerd/containerd/snapshot"
@@ -60,6 +62,14 @@ func getImageStore(clicontext *cli.Context) (images.Store, error) {
 		return nil, err
 	}
 	return imagesservice.NewStoreFromClient(imagesapi.NewImagesClient(conn)), nil
+}
+
+func getDiffService(context *cli.Context) (diff.DiffService, error) {
+	conn, err := getGRPCConnection(context)
+	if err != nil {
+		return nil, err
+	}
+	return diff.NewDiffServiceFromClient(diffapi.NewDiffClient(conn)), nil
 }
 
 func getVersionService(context *cli.Context) (versionservice.VersionClient, error) {

--- a/cmd/dist/pull.go
+++ b/cmd/dist/pull.go
@@ -116,7 +116,7 @@ command. As part of this process, we do the following:
 				log.G(ctx).Fatal(err)
 			}
 			snapshotter := snapshotservice.NewSnapshotterFromClient(snapshotapi.NewSnapshotClient(conn))
-			applier := diffservice.NewApplierFromClient(diffapi.NewDiffClient(conn))
+			applier := diffservice.NewDiffServiceFromClient(diffapi.NewDiffClient(conn))
 
 			log.G(ctx).Info("unpacking rootfs")
 

--- a/cmd/dist/rootfs.go
+++ b/cmd/dist/rootfs.go
@@ -65,7 +65,7 @@ var rootfsUnpackCommand = cli.Command{
 		}
 
 		snapshotter := snapshotservice.NewSnapshotterFromClient(snapshotapi.NewSnapshotClient(conn))
-		applier := diffservice.NewApplierFromClient(diffapi.NewDiffClient(conn))
+		applier := diffservice.NewDiffServiceFromClient(diffapi.NewDiffClient(conn))
 
 		chainID, err := rootfs.ApplyLayers(ctx, layers, snapshotter, applier)
 		if err != nil {

--- a/rootfs/diff.go
+++ b/rootfs/diff.go
@@ -1,0 +1,52 @@
+package rootfs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/snapshot"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type MountDiffer interface {
+	DiffMounts(ctx context.Context, lower, upper []containerd.Mount, media, ref string) (ocispec.Descriptor, error)
+}
+
+type DiffOptions struct {
+	MountDiffer
+	content.Store
+	snapshot.Snapshotter
+}
+
+func Diff(ctx context.Context, snapshotID, contentRef string, sn snapshot.Snapshotter, md MountDiffer) (ocispec.Descriptor, error) {
+	info, err := sn.Stat(ctx, snapshotID)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	lowerKey := fmt.Sprintf("%s-parent-view", info.Parent)
+	lower, err := sn.View(ctx, lowerKey, info.Parent)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	defer sn.Remove(ctx, lowerKey)
+
+	var upper []containerd.Mount
+	if info.Kind == snapshot.KindActive {
+		upper, err = sn.Mounts(ctx, snapshotID)
+		if err != nil {
+			return ocispec.Descriptor{}, err
+		}
+	} else {
+		upperKey := fmt.Sprintf("%s-view", snapshotID)
+		upper, err = sn.View(ctx, upperKey, snapshotID)
+		if err != nil {
+			return ocispec.Descriptor{}, err
+		}
+		defer sn.Remove(ctx, lowerKey)
+	}
+
+	return md.DiffMounts(ctx, lower, upper, ocispec.MediaTypeImageLayer, contentRef)
+}


### PR DESCRIPTION
Add implementations for the diff method on the diff service. Initial implementation does not support compression. We can add compression support when we have a way to link compressed to uncompressed content. 

Added a `ctr snapshot` command which creates a diff of an RW layer and puts it in the content store. This can be used for creating new image configs and ultimately new manifests.

Added a `--keep` flag to `ctr run` which ensures the container and RW layer are kept after run. This can be used with a pattern `ctr run` -> `ctr snapshot` -> `ctr delete` to simulate creation of an RW layer using a run command. Along with this deletion of container should now delete the associated RW layer.