### PR TITLE
Revert "Merge pull request #853 from AkihiroSuda/check-rootfs"

### DIFF
--- a/linux/runtime.go
+++ b/linux/runtime.go
@@ -123,9 +123,6 @@ func (r *Runtime) Create(ctx context.Context, id string, opts plugin.CreateOpts)
 			Options: m.Options,
 		})
 	}
-	if len(sopts.Rootfs) == 0 {
-		return nil, fmt.Errorf("no rootfs was specified for id %s", id)
-	}
 	if _, err = s.Create(ctx, sopts); err != nil {
 		os.RemoveAll(path)
 		return nil, err

--- a/linux/shim/init.go
+++ b/linux/shim/init.go
@@ -11,7 +11,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 
 	"github.com/containerd/console"
@@ -37,9 +36,6 @@ type initProcess struct {
 }
 
 func newInitProcess(context context.Context, path string, r *shimapi.CreateRequest) (*initProcess, error) {
-	if len(r.Rootfs) == 0 {
-		return nil, errors.New("no rootfs was specified")
-	}
 	for _, rm := range r.Rootfs {
 		m := &containerd.Mount{
 			Type:    rm.Type,


### PR DESCRIPTION
This reverts commit c1530b5b76c0c8efd804a4a36d8808b6763e1703, reversing
changes made to 3695ba77bb006f0b0e0974a75c5127dadcde5446.

-- 

We don't enforce the use of the snapshotters. Client that decides to do without should be able to start a container just by specifying a correct Root path within the runtime spec.