### PR TITLE
Close stdin on create if it wasn't requested and there's no terminal

### DIFF
--- a/linux/shim/io.go
+++ b/linux/shim/io.go
@@ -83,6 +83,7 @@ func copyPipes(ctx context.Context, rio runc.IO, stdin, stdout, stderr string, w
 		dest(fw, fr)
 	}
 	if stdin == "" {
+		rio.Stdin().Close()
 		return nil
 	}
 	f, err := fifo.OpenFifo(ctx, stdin, syscall.O_RDONLY, 0)


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

-- 
This was causing for a shell not to exit if created without stdin and without a terminal