### PR TITLE
Update with preferred email address

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -276,7 +276,7 @@ example and you'll be fine".
 
 	[People.estesp]
 	Name = "Phil Estes"
-	Email = "estesp@linux.vnet.ibm.com"
+	Email = "estesp@gmail.com"
 	GitHub = "estesp"
 
 	[People.hqhq]


### PR DESCRIPTION
Update MAINTAINERS file with my preferred email address as others use
this to send mail, add to mailing lists, etc. My
contributor/Signed-off-by is a valid address, but not the one I use for
community interactions.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>