### PR TITLE
Fix close a nil chan err

### DIFF
--- a/supervisor/delete.go
+++ b/supervisor/delete.go
@@ -27,13 +27,14 @@ func (s *Supervisor) delete(t *DeleteTask) error {
 			t.Process.Wait()
 		}
 		if !t.NoEvent {
-			execMap := s.getDeleteExecSyncMap(t.ID)
+			execMap := s.getExecSyncMap(t.ID)
 			go func() {
 				// Wait for all exec processe events to be sent (we seem
 				// to sometimes receive them after the init event)
 				for _, ch := range execMap {
 					<-ch
 				}
+				s.deleteExecSyncMap(t.ID)
 				s.notifySubscribers(Event{
 					Type:      StateExit,
 					Timestamp: time.Now(),

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -439,10 +439,14 @@ func (s *Supervisor) getExecSyncChannel(containerID, pid string) chan struct{} {
 	return ch
 }
 
-func (s *Supervisor) getDeleteExecSyncMap(containerID string) map[string]chan struct{} {
+func (s *Supervisor) getExecSyncMap(containerID string) map[string]chan struct{} {
 	s.containerExecSyncLock.Lock()
-	chs := s.containerExecSync[containerID]
+	defer s.containerExecSyncLock.Unlock()
+	return s.containerExecSync[containerID]
+}
+
+func (s *Supervisor) deleteExecSyncMap(containerID string) {
+	s.containerExecSyncLock.Lock()
+	defer s.containerExecSyncLock.Unlock()
 	delete(s.containerExecSync, containerID)
-	s.containerExecSyncLock.Unlock()
-	return chs
 }


### PR DESCRIPTION
If docker exec to a container, and then kill the runtime's shim process,it will lead to close a nil chan in Supervisor' execExit interface.

### why ?
![default](https://cloud.githubusercontent.com/assets/11223367/26200527/1a9330ba-3c01-11e7-86eb-706b848f7939.PNG)
### what I do ?
split getDeleteExecSyncMap to getExecSyncMap and deleteExecSyncMap to make sure delete operation come after the chan's close.

### how to reproduce ?
following the steps below, the problem can reproduced every time.
first run a container,
```
docker run -ti busybox ash
```
secondly docker exec to the container,
```
docker exec -ti d2a397b12d19 ash 
```
then the kill the runtime's shim proccess,
```
 ps -eaf|grep shim
root      1180  1173  1 19:27 ?        00:00:00 docker-containerd -l unix:///var/run/docker/libcontainerd/docker-containerd.sock --shim docker-containerd-shim --start-timeout 2m --state-dir /var/run/docker/libcontainerd/containerd --runtime docker-runc --metrics-interval=0
root      1387  1180  1 19:28 ?        00:00:00 docker-containerd-shim d2a397b12d19113bb48284a451095b24d646d1941bd28d6d97cb886571327c73 /var/run/docker/libcontainerd/d2a397b12d19113bb48284a451095b24d646d1941bd28d6d97cb886571327c73 docker-runc
root      1552  1180  2 19:28 ?        00:00:00 docker-containerd-shim d2a397b12d19113bb48284a451095b24d646d1941bd28d6d97cb886571327c73 /var/run/docker/libcontainerd/d2a397b12d19113bb48284a451095b24d646d1941bd28d6d97cb886571327c73 docker-runc
root      1611  8696  0 19:28 pts/4    00:00:00 grep --color=auto shim
V2R1C00-GUESTOS-VS-VMWARE-X64:~/workspace/docker-bin # kill -9 1387    
```
and you will see the panic info from containerd like this,
```
panic: close of nil channel

goroutine 146 [running]:
panic(0x90a8c0, 0xc8204f4d90)
        /usr/local/go/src/runtime/panic.go:481 +0x3e6
github.com/docker/containerd/supervisor.(*Supervisor).execExit.func1(0xc820143450, 0xc8201a2f70, 0x0)
        /root/workspace/go/src/github.com/docker/containerd/supervisor/exit.go:95 +0x11d
created by github.com/docker/containerd/supervisor.(*Supervisor).execExit
        /root/workspace/go/src/github.com/docker/containerd/supervisor/exit.go:96 +0x2bf
```


Signed-off-by: yangshukui <yangshukui@huawei.com>