### PR TITLE
Reference actual versions for specs in vendor.conf

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -14,7 +14,7 @@ github.com/docker/go-units v0.3.1
 github.com/gogo/protobuf d2e1ade2d719b78fe5b061b4c18a9f7111b5bdc8
 github.com/golang/protobuf 8ee79997227bf9b34611aee7946ae64735e6fd93
 github.com/opencontainers/runc 50401b5b4c2e01e4f1372b73a021742deeaf4e2d
-github.com/opencontainers/runtime-spec 035da1dca3dfbb00d752eb58b0b158d6129f3776
+github.com/opencontainers/runtime-spec v1.0.0-rc5
 github.com/Sirupsen/logrus v0.11.0
 github.com/containerd/btrfs e9c546f46bccffefe71a6bc137e4c21b5503cc18
 github.com/stretchr/testify v1.1.4
@@ -28,7 +28,7 @@ github.com/pkg/errors v0.8.0
 github.com/nightlyone/lockfile 1d49c987357a327b5b03aa84cbddd582c328615d
 github.com/opencontainers/go-digest 21dfd564fd89c944783d00d069f33e3e7123c448
 golang.org/x/sys f3918c30c5c2cb527c0b071a27c35120a6c0719a
-github.com/opencontainers/image-spec a431dbcf6a74fca2e0e040b819a836dbe3fb23ca
+github.com/opencontainers/image-spec v1.0.0-rc5
 github.com/containerd/continuity f4ad4294c92f596c9241947c416d1297f9faf3ea
 golang.org/x/sync 450f422ab23cf9881c94e2db30cac0eb1b7cf80c
 github.com/BurntSushi/toml v0.2.0-21-g9906417

--- a/vendor/github.com/opencontainers/image-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/version.go
@@ -25,7 +25,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc4-dev"
+	VersionDev = "-rc5"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
For runtime and image spec from OCI, reference the actual versions
instead of a git hash for clarity on versions in use.

Actual impact was zero; runtime spec was the exact hash of the released
rc5 already, image spec was one commit behind the tagged release, but
made no code changes other than version string.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>