### PR TITLE
Return ErrNotFound when deleting a non-exist image.

### DIFF
--- a/images/storage.go
+++ b/images/storage.go
@@ -134,7 +134,11 @@ func (s *storage) List(ctx context.Context) ([]Image, error) {
 
 func (s *storage) Delete(ctx context.Context, name string) error {
 	return withImagesBucket(s.tx, func(bkt *bolt.Bucket) error {
-		return bkt.DeleteBucket([]byte(name))
+		err := bkt.DeleteBucket([]byte(name))
+		if err == bolt.ErrBucketNotFound {
+			return ErrNotFound
+		}
+		return err
 	})
 }
 


### PR DESCRIPTION
Return `ErrNotFound` when deleting a non-exist image. This will help the client to ignore the error if it doesn't care.

Signed-off-by: Random-Liu <lantaol@google.com>