### PR TITLE
Clear extra in content service reader after consumed

### DIFF
--- a/services/content/reader.go
+++ b/services/content/reader.go
@@ -19,6 +19,7 @@ func (rr *remoteReader) Read(p []byte) (n int, err error) {
 		}
 		return
 	}
+	rr.extra = rr.extra[:0]
 
 	p = p[n:]
 	for len(p) > 0 {


### PR DESCRIPTION
Avoid bugs where content can mistakenly be read from extra after an EOF is returned.
