### PR TITLE
Add --mount option to ctr

### DIFF
--- a/cmd/ctr/run.go
+++ b/cmd/ctr/run.go
@@ -54,6 +54,10 @@ var runCommand = cli.Command{
 			Name:  "net-host",
 			Usage: "enable host networking for the container",
 		},
+		cli.StringSliceFlag{
+			Name:  "mount",
+			Usage: "specify additional container mount (ex: type=bind,src=/tmp,dest=/host,options=rbind:ro)",
+		},
 		cli.BoolFlag{
 			Name:  "keep",
 			Usage: "keep container after running",

--- a/cmd/ctr/run_unix.go
+++ b/cmd/ctr/run_unix.go
@@ -222,6 +222,14 @@ func spec(id string, config *ocispec.ImageConfig, context *cli.Context, rootfs s
 			Type: "network",
 		})
 	}
+	for _, mount := range context.StringSlice("mount") {
+		m, err := parseMountFlag(mount)
+		if err != nil {
+			return nil, err
+		}
+
+		s.Mounts = append(s.Mounts, m)
+	}
 	return s, nil
 }
 


### PR DESCRIPTION
This adds a `--mount` option for specifying binds, tmpfs, etc when debugging containers with `ctr`.

This defines a very simple syntax similar to the mount syntax for Docker:

`--mount type=bind,src=/var/tmp,dest=/host/tmp,options=rbind:ro`