### PR TITLE
Avoid fetch call to registry when blob already exists

### DIFF
--- a/remotes/handlers.go
+++ b/remotes/handlers.go
@@ -56,11 +56,22 @@ func FetchHandler(ingester content.Ingester, fetcher Fetcher) images.HandlerFunc
 func fetch(ctx context.Context, ingester content.Ingester, fetcher Fetcher, desc ocispec.Descriptor) error {
 	log.G(ctx).Debug("fetch")
 	ref := MakeRefKey(ctx, desc)
+
+	cw, err := ingester.Writer(ctx, ref, desc.Size, desc.Digest)
+	if err != nil {
+		if !content.IsExists(err) {
+			return err
+		}
+
+		return nil
+	}
+	defer cw.Close()
+
 	rc, err := fetcher.Fetch(ctx, desc)
 	if err != nil {
 		return err
 	}
 	defer rc.Close()
 
-	return content.WriteBlob(ctx, ingester, ref, rc, desc.Size, desc.Digest)
+	return content.Copy(cw, rc, desc.Size, desc.Digest)
 }


### PR DESCRIPTION
Open up content store writer with expected digest before opening up the fetch call to the registry. Add Copy method to content store helpers to allow content copy to take advantage of seeking helper code.

Alternative to #881