### PR TITLE
Add push object

### DIFF
--- a/cmd/dist/fetch.go
+++ b/cmd/dist/fetch.go
@@ -72,7 +72,11 @@ Most of this is experimental and there are few leaps to make this work.`,
 		resolved := make(chan struct{})
 		eg.Go(func() error {
 			ongoing.add(ref)
-			name, desc, fetcher, err := resolver.Resolve(ctx, ref)
+			name, desc, err := resolver.Resolve(ctx, ref)
+			if err != nil {
+				return err
+			}
+			fetcher, err := resolver.Fetcher(ctx, name)
 			if err != nil {
 				return err
 			}

--- a/cmd/dist/fetchobject.go
+++ b/cmd/dist/fetchobject.go
@@ -33,7 +33,11 @@ var fetchObjectCommand = cli.Command{
 		ctx = log.WithLogger(ctx, log.G(ctx).WithField("ref", ref))
 
 		log.G(ctx).Infof("resolving")
-		_, desc, fetcher, err := resolver.Resolve(ctx, ref)
+		name, desc, err := resolver.Resolve(ctx, ref)
+		if err != nil {
+			return err
+		}
+		fetcher, err := resolver.Fetcher(ctx, name)
 		if err != nil {
 			return err
 		}

--- a/cmd/dist/main.go
+++ b/cmd/dist/main.go
@@ -77,6 +77,7 @@ distribution tool
 		fetchObjectCommand,
 		applyCommand,
 		rootfsCommand,
+		pushObjectCommand,
 	}
 	app.Before = func(context *cli.Context) error {
 		timeout = context.GlobalDuration("timeout")

--- a/cmd/dist/pull.go
+++ b/cmd/dist/pull.go
@@ -64,11 +64,16 @@ command. As part of this process, we do the following:
 		resolved := make(chan struct{})
 		eg.Go(func() error {
 			ongoing.add(ref)
-			name, desc, fetcher, err := resolver.Resolve(ctx, ref)
+			name, desc, err := resolver.Resolve(ctx, ref)
 			if err != nil {
 				log.G(ctx).WithError(err).Error("failed to resolve")
 				return err
 			}
+			fetcher, err := resolver.Fetcher(ctx, name)
+			if err != nil {
+				return err
+			}
+
 			log.G(ctx).WithField("image", name).Debug("fetching")
 			resolvedImageName = name
 			close(resolved)

--- a/cmd/dist/pushobject.go
+++ b/cmd/dist/pushobject.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/containerd/containerd/log"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/urfave/cli"
+)
+
+var pushObjectCommand = cli.Command{
+	Name:        "push-object",
+	Usage:       "pushes an object to a remote",
+	ArgsUsage:   "[flags] <remote> <object> <type>",
+	Description: `Push objects by identifier to a remote.`,
+	Flags:       registryFlags,
+	Action: func(clicontext *cli.Context) error {
+		var (
+			ref    = clicontext.Args().Get(0)
+			object = clicontext.Args().Get(1)
+			media  = clicontext.Args().Get(2)
+		)
+		dgst, err := digest.Parse(object)
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := appContext()
+		defer cancel()
+
+		resolver, err := getResolver(ctx, clicontext)
+		if err != nil {
+			return err
+		}
+
+		ctx = log.WithLogger(ctx, log.G(ctx).WithField("ref", ref))
+
+		log.G(ctx).Infof("resolving")
+		pusher, err := resolver.Pusher(ctx, ref)
+		if err != nil {
+			return err
+		}
+
+		cs, err := resolveContentStore(clicontext)
+		if err != nil {
+			return err
+		}
+
+		info, err := cs.Info(ctx, dgst)
+		if err != nil {
+			return err
+		}
+		desc := ocispec.Descriptor{
+			MediaType: media,
+			Digest:    dgst,
+			Size:      info.Size,
+		}
+
+		rc, err := cs.Reader(ctx, dgst)
+		if err != nil {
+			return err
+		}
+		defer rc.Close()
+
+		// TODO: Progress reader
+		if err = pusher.Push(ctx, desc, rc); err != nil {
+			return err
+		}
+
+		fmt.Printf("Pushed %s %s\n", desc.Digest, desc.MediaType)
+
+		return nil
+	},
+}

--- a/reference/reference_test.go
+++ b/reference/reference_test.go
@@ -78,9 +78,14 @@ func TestReferenceParser(t *testing.T) {
 			Err:   ErrHostnameRequired,
 		},
 		{
-			Name:  "ErrObjectRequired",
-			Input: "docker.io/library/redis?fooo=asdf",
-			Err:   ErrObjectRequired,
+			Name:       "ErrObjectRequired",
+			Input:      "docker.io/library/redis?fooo=asdf",
+			Hostname:   "docker.io",
+			Normalized: "docker.io/library/redis",
+			Expected: Spec{
+				Locator: "docker.io/library/redis",
+				Object:  "",
+			},
 		},
 		{
 			Name:     "Subdomain",

--- a/remotes/docker/fetcher.go
+++ b/remotes/docker/fetcher.go
@@ -1,0 +1,78 @@
+package docker
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"path"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/log"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+type dockerFetcher struct {
+	*dockerBase
+}
+
+func (r dockerFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.ReadCloser, error) {
+	ctx = log.WithLogger(ctx, log.G(ctx).WithFields(
+		logrus.Fields{
+			"base":   r.base.String(),
+			"digest": desc.Digest,
+		},
+	))
+
+	paths, err := getV2URLPaths(desc)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, path := range paths {
+		u := r.url(path)
+
+		req, err := http.NewRequest(http.MethodGet, u, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		req.Header.Set("Accept", strings.Join([]string{desc.MediaType, `*`}, ", "))
+		resp, err := r.doRequestWithRetries(ctx, req, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode > 299 {
+			if resp.StatusCode == http.StatusNotFound {
+				continue // try one of the other urls.
+			}
+			resp.Body.Close()
+			return nil, errors.Errorf("unexpected status code %v: %v", u, resp.Status)
+		}
+
+		return resp.Body, nil
+	}
+
+	return nil, errors.New("not found")
+}
+
+// getV2URLPaths generates the candidate urls paths for the object based on the
+// set of hints and the provided object id. URLs are returned in the order of
+// most to least likely succeed.
+func getV2URLPaths(desc ocispec.Descriptor) ([]string, error) {
+	var urls []string
+
+	switch desc.MediaType {
+	case images.MediaTypeDockerSchema2Manifest, images.MediaTypeDockerSchema2ManifestList,
+		ocispec.MediaTypeImageManifest, ocispec.MediaTypeImageIndex:
+		urls = append(urls, path.Join("manifests", desc.Digest.String()))
+	}
+
+	// always fallback to attempting to get the object out of the blobs store.
+	urls = append(urls, path.Join("blobs", desc.Digest.String()))
+
+	return urls, nil
+}

--- a/remotes/docker/pusher.go
+++ b/remotes/docker/pusher.go
@@ -1,0 +1,144 @@
+package docker
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"path"
+	"strings"
+
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/log"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+type dockerPusher struct {
+	*dockerBase
+	tag string
+}
+
+func (p dockerPusher) Push(ctx context.Context, desc ocispec.Descriptor, r io.Reader) error {
+	var (
+		isManifest bool
+		existCheck string
+	)
+
+	switch desc.MediaType {
+	case images.MediaTypeDockerSchema2Manifest, images.MediaTypeDockerSchema2ManifestList,
+		ocispec.MediaTypeImageManifest, ocispec.MediaTypeImageIndex:
+		isManifest = true
+		existCheck = path.Join("manifests", desc.Digest.String())
+	default:
+		existCheck = path.Join("blobs", desc.Digest.String())
+	}
+
+	req, err := http.NewRequest(http.MethodHead, p.url(existCheck), nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Accept", strings.Join([]string{desc.MediaType, `*`}, ", "))
+	resp, err := p.doRequestWithRetries(ctx, req, nil)
+	if err != nil {
+		if errors.Cause(err) != ErrInvalidAuthorization {
+			return err
+		}
+		log.G(ctx).WithError(err).Debugf("Unable to check existence, continuing with push")
+	} else {
+		if resp.StatusCode == http.StatusOK {
+			return nil
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			// TODO: log error
+			return errors.Errorf("unexpected response: %s", resp.Status)
+		}
+	}
+
+	// TODO: Lookup related objects for cross repository push
+
+	if isManifest {
+		// Read all to use bytes.Reader for using GetBody
+		b, err := ioutil.ReadAll(r)
+		if err != nil {
+			return errors.Wrap(err, "failed to read manifest")
+		}
+		var putPath string
+		if p.tag != "" {
+			putPath = path.Join("manifests", p.tag)
+		} else {
+			putPath = path.Join("manifests", desc.Digest.String())
+		}
+
+		req, err := http.NewRequest(http.MethodPut, p.url(putPath), nil)
+		if err != nil {
+			return err
+		}
+		req.ContentLength = int64(len(b))
+		req.Body = ioutil.NopCloser(bytes.NewReader(b))
+		req.GetBody = func() (io.ReadCloser, error) {
+			return ioutil.NopCloser(bytes.NewReader(b)), nil
+		}
+		req.Header.Add("Content-Type", desc.MediaType)
+
+		resp, err := p.doRequestWithRetries(ctx, req, nil)
+		if err != nil {
+			return err
+		}
+		if resp.StatusCode != http.StatusCreated {
+			// TODO: log error
+			return errors.Errorf("unexpected response: %s", resp.Status)
+		}
+	} else {
+		// TODO: Do monolithic upload if size is small
+
+		// TODO: Turn multi-request blob uploader into ingester
+
+		// Start upload request
+		req, err := http.NewRequest(http.MethodPost, p.url("blobs", "uploads")+"/", nil)
+		if err != nil {
+			return err
+		}
+
+		resp, err := p.doRequestWithRetries(ctx, req, nil)
+		if err != nil {
+			return err
+		}
+		if resp.StatusCode != http.StatusAccepted {
+			// TODO: log error
+			return errors.Errorf("unexpected response: %s", resp.Status)
+		}
+
+		location := resp.Header.Get("Location")
+		// Support paths without host in location
+		if strings.HasPrefix(location, "/") {
+			u := p.base
+			u.Path = location
+			location = u.String()
+		}
+
+		// TODO: Support chunked upload
+		req, err = http.NewRequest(http.MethodPut, location, r)
+		if err != nil {
+			return err
+		}
+		q := req.URL.Query()
+		q.Add("digest", desc.Digest.String())
+		req.URL.RawQuery = q.Encode()
+		req.ContentLength = desc.Size
+
+		resp, err = p.doRequest(ctx, req)
+		if err != nil {
+			return err
+		}
+		if resp.StatusCode != http.StatusCreated {
+			// TODO: log error
+			return errors.Errorf("unexpected response: %s", resp.Status)
+		}
+
+	}
+
+	return nil
+}

--- a/remotes/docker/resolver_test.go
+++ b/remotes/docker/resolver_test.go
@@ -166,7 +166,7 @@ func TestBadTokenResolver(t *testing.T) {
 	resolver := NewResolver(ro)
 	image := fmt.Sprintf("%s/doesntmatter:sometatg", base)
 
-	_, _, _, err := resolver.Resolve(ctx, image)
+	_, _, err := resolver.Resolve(ctx, image)
 	if err == nil {
 		t.Fatal("Expected error getting token with inssufficient scope")
 	}
@@ -261,7 +261,11 @@ func runBasicTest(t *testing.T, name string, sf func(h http.Handler) (string, Re
 	resolver := NewResolver(ro)
 	image := fmt.Sprintf("%s/%s:%s", base, name, tag)
 
-	_, d, f, err := resolver.Resolve(ctx, image)
+	_, d, err := resolver.Resolve(ctx, image)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := resolver.Fetcher(ctx, image)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Split resolver to only return a name with separate methods for getting a fetcher and pusher. Add implementation for push.

There will be a couple follow ups to this PR.
- Handler for pushing a manifest and a manifest's contents
- Implementation of registry uploaded using `content.Ingester` interface.