### PR TITLE
Move Mount into mount pkg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,8 +131,6 @@ FORCE:
 
 # Build a binary from a cmd.
 bin/%: cmd/% FORCE
-	@test $$(go list) = "${PKG}" || \
-		(echo "$(ONI) Please correctly set up your Go build environment. This project must be located at <GOPATH>/src/${PKG}" && false)
 	@echo "$(WHALE) $@${BINARY_SUFFIX}"
 	@go build -i -o $@${BINARY_SUFFIX} ${GO_LDFLAGS} ${GO_TAGS} ${GO_GCFLAGS} ./$<
 

--- a/cmd/ctr/run.go
+++ b/cmd/ctr/run.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/containerd/console"
-	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/api/services/execution"
 	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/snapshot"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
@@ -71,7 +71,7 @@ var runCommand = cli.Command{
 	Action: func(context *cli.Context) error {
 		var (
 			err         error
-			mounts      []containerd.Mount
+			mounts      []mount.Mount
 			imageConfig ocispec.Image
 
 			ctx = gocontext.Background()

--- a/cmd/ctr/run_unix.go
+++ b/cmd/ctr/run_unix.go
@@ -18,10 +18,10 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/containerd/console"
-	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/api/services/execution"
 	"github.com/containerd/containerd/api/types/descriptor"
 	"github.com/containerd/containerd/api/types/mount"
+	mountt "github.com/containerd/containerd/mount"
 	protobuf "github.com/gogo/protobuf/types"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -277,7 +277,7 @@ func newSpec(context *cli.Context, config *ocispec.ImageConfig, imageRef string)
 	return json.Marshal(s)
 }
 
-func newCreateRequest(context *cli.Context, id, tmpDir string, checkpoint *ocispec.Descriptor, mounts []containerd.Mount, spec []byte) (*execution.CreateRequest, error) {
+func newCreateRequest(context *cli.Context, id, tmpDir string, checkpoint *ocispec.Descriptor, mounts []mountt.Mount, spec []byte) (*execution.CreateRequest, error) {
 	create := &execution.CreateRequest{
 		ID: id,
 		Spec: &protobuf.Any{

--- a/cmd/ctr/run_windows.go
+++ b/cmd/ctr/run_windows.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/containerd/console"
-	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/api/services/execution"
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/windows"
 	"github.com/containerd/containerd/windows/hcs"
 	protobuf "github.com/gogo/protobuf/types"
@@ -136,7 +136,7 @@ func newSpec(context *cli.Context, config *ocispec.ImageConfig, imageRef string)
 	return json.Marshal(rtSpec)
 }
 
-func newCreateRequest(context *cli.Context, id, tmpDir string, checkpoint *ocispec.Descriptor, mounts []containerd.Mount, spec []byte) (*execution.CreateRequest, error) {
+func newCreateRequest(context *cli.Context, id, tmpDir string, checkpoint *ocispec.Descriptor, mounts []mount.Mount, spec []byte) (*execution.CreateRequest, error) {
 	create := &execution.CreateRequest{
 		ID: id,
 		Spec: &protobuf.Any{

--- a/linux/shim/init.go
+++ b/linux/shim/init.go
@@ -16,9 +16,9 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/containerd/console"
-	"github.com/containerd/containerd"
 	shimapi "github.com/containerd/containerd/api/services/shim"
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/fifo"
 	runc "github.com/containerd/go-runc"
 )
@@ -45,7 +45,7 @@ type initProcess struct {
 
 func newInitProcess(context context.Context, path string, r *shimapi.CreateRequest) (*initProcess, error) {
 	for _, rm := range r.Rootfs {
-		m := &containerd.Mount{
+		m := &mount.Mount{
 			Type:    rm.Type,
 			Source:  rm.Source,
 			Options: rm.Options,

--- a/mount/mount.go
+++ b/mount/mount.go
@@ -1,4 +1,4 @@
-package containerd
+package mount
 
 // Mount is the lingua franca of containerd. A mount represents a
 // serialized mount syscall. Components either emit or consume mounts.

--- a/mount/mount_linux.go
+++ b/mount/mount_linux.go
@@ -1,4 +1,4 @@
-package containerd
+package mount
 
 import (
 	"strings"

--- a/mount/mount_unix.go
+++ b/mount/mount_unix.go
@@ -1,6 +1,6 @@
 // +build darwin freebsd
 
-package containerd
+package mount
 
 import "github.com/pkg/errors"
 

--- a/mount/mount_windows.go
+++ b/mount/mount_windows.go
@@ -1,4 +1,4 @@
-package containerd
+package mount
 
 import "github.com/pkg/errors"
 

--- a/mount/mountinfo.go
+++ b/mount/mountinfo.go
@@ -1,4 +1,4 @@
-package mountinfo
+package mount
 
 // Info reveals information about a particular mounted filesystem. This
 // struct is populated from the content in the /proc/<pid>/mountinfo file.

--- a/mount/mountinfo_freebsd.go
+++ b/mount/mountinfo_freebsd.go
@@ -1,4 +1,4 @@
-package mountinfo
+package mount
 
 /*
 #include <sys/param.h>

--- a/mount/mountinfo_linux.go
+++ b/mount/mountinfo_linux.go
@@ -1,6 +1,6 @@
 // +build linux
 
-package mountinfo
+package mount
 
 import (
 	"bufio"

--- a/mount/mountinfo_linux_test.go
+++ b/mount/mountinfo_linux_test.go
@@ -1,6 +1,6 @@
 // +build linux
 
-package mountinfo
+package mount
 
 import (
 	"bytes"

--- a/mount/mountinfo_solaris.go
+++ b/mount/mountinfo_solaris.go
@@ -1,6 +1,6 @@
 // +build solaris,cgo
 
-package mountinfo
+package mount
 
 /*
 #include <stdio.h>

--- a/mount/mountinfo_unsupported.go
+++ b/mount/mountinfo_unsupported.go
@@ -1,6 +1,6 @@
 // +build !linux,!freebsd,!solaris freebsd,!cgo solaris,!cgo
 
-package mountinfo
+package mount
 
 import (
 	"fmt"

--- a/plugin/runtime.go
+++ b/plugin/runtime.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/mount"
 )
 
 type IO struct {
@@ -18,7 +18,7 @@ type CreateOpts struct {
 	// Spec is the OCI runtime spec
 	Spec []byte
 	// Rootfs mounts to perform to gain access to the container's filesystem
-	Rootfs []containerd.Mount
+	Rootfs []mount.Mount
 	// IO for the container's main process
 	IO         IO
 	Checkpoint string

--- a/rootfs/apply.go
+++ b/rootfs/apply.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/snapshot"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
@@ -14,7 +14,7 @@ import (
 )
 
 type Applier interface {
-	Apply(context.Context, ocispec.Descriptor, []containerd.Mount) (ocispec.Descriptor, error)
+	Apply(context.Context, ocispec.Descriptor, []mount.Mount) (ocispec.Descriptor, error)
 }
 
 type Layer struct {

--- a/rootfs/diff.go
+++ b/rootfs/diff.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/snapshot"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 type MountDiffer interface {
-	DiffMounts(ctx context.Context, lower, upper []containerd.Mount, media, ref string) (ocispec.Descriptor, error)
+	DiffMounts(ctx context.Context, lower, upper []mount.Mount, media, ref string) (ocispec.Descriptor, error)
 }
 
 type DiffOptions struct {
@@ -33,7 +33,7 @@ func Diff(ctx context.Context, snapshotID, contentRef string, sn snapshot.Snapsh
 	}
 	defer sn.Remove(ctx, lowerKey)
 
-	var upper []containerd.Mount
+	var upper []mount.Mount
 	if info.Kind == snapshot.KindActive {
 		upper, err = sn.Mounts(ctx, snapshotID)
 		if err != nil {

--- a/rootfs/init.go
+++ b/rootfs/init.go
@@ -6,8 +6,8 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/snapshot"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
@@ -20,11 +20,11 @@ var (
 type initializerFunc func(string) error
 
 type Mounter interface {
-	Mount(target string, mounts ...containerd.Mount) error
+	Mount(target string, mounts ...mount.Mount) error
 	Unmount(target string) error
 }
 
-func InitRootFS(ctx context.Context, name string, parent digest.Digest, readonly bool, snapshotter snapshot.Snapshotter, mounter Mounter) ([]containerd.Mount, error) {
+func InitRootFS(ctx context.Context, name string, parent digest.Digest, readonly bool, snapshotter snapshot.Snapshotter, mounter Mounter) ([]mount.Mount, error) {
 	_, err := snapshotter.Stat(ctx, name)
 	if err == nil {
 		return nil, errors.Errorf("rootfs already exists")

--- a/services/diff/client.go
+++ b/services/diff/client.go
@@ -3,10 +3,10 @@ package diff
 import (
 	"context"
 
-	"github.com/containerd/containerd"
 	diffapi "github.com/containerd/containerd/api/services/diff"
 	"github.com/containerd/containerd/api/types/descriptor"
 	mounttypes "github.com/containerd/containerd/api/types/mount"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/rootfs"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -28,7 +28,7 @@ type remote struct {
 	client diffapi.DiffClient
 }
 
-func (r *remote) Apply(ctx context.Context, diff ocispec.Descriptor, mounts []containerd.Mount) (ocispec.Descriptor, error) {
+func (r *remote) Apply(ctx context.Context, diff ocispec.Descriptor, mounts []mount.Mount) (ocispec.Descriptor, error) {
 	req := &diffapi.ApplyRequest{
 		Diff:   fromDescriptor(diff),
 		Mounts: fromMounts(mounts),
@@ -40,7 +40,7 @@ func (r *remote) Apply(ctx context.Context, diff ocispec.Descriptor, mounts []co
 	return toDescriptor(resp.Applied), nil
 }
 
-func (r *remote) DiffMounts(ctx context.Context, a, b []containerd.Mount, media, ref string) (ocispec.Descriptor, error) {
+func (r *remote) DiffMounts(ctx context.Context, a, b []mount.Mount, media, ref string) (ocispec.Descriptor, error) {
 	req := &diffapi.DiffRequest{
 		Left:      fromMounts(a),
 		Right:     fromMounts(b),
@@ -62,7 +62,7 @@ func fromDescriptor(d ocispec.Descriptor) *descriptor.Descriptor {
 	}
 }
 
-func fromMounts(mounts []containerd.Mount) []*mounttypes.Mount {
+func fromMounts(mounts []mount.Mount) []*mounttypes.Mount {
 	apiMounts := make([]*mounttypes.Mount, len(mounts))
 	for i, m := range mounts {
 		apiMounts[i] = &mounttypes.Mount{

--- a/services/diff/service.go
+++ b/services/diff/service.go
@@ -5,13 +5,13 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/containerd/containerd"
 	diffapi "github.com/containerd/containerd/api/services/diff"
 	"github.com/containerd/containerd/api/types/descriptor"
 	mounttypes "github.com/containerd/containerd/api/types/mount"
 	"github.com/containerd/containerd/archive"
 	"github.com/containerd/containerd/archive/compression"
 	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/snapshot"
 	digest "github.com/opencontainers/go-digest"
@@ -59,10 +59,10 @@ func (s *service) Apply(ctx context.Context, er *diffapi.ApplyRequest) (*diffapi
 	}
 	defer os.RemoveAll(dir)
 
-	if err := containerd.MountAll(mounts, dir); err != nil {
+	if err := mount.MountAll(mounts, dir); err != nil {
 		return nil, errors.Wrap(err, "failed to mount")
 	}
-	defer containerd.Unmount(dir, 0)
+	defer mount.Unmount(dir, 0)
 
 	r, err := s.store.Reader(ctx, desc.Digest)
 	if err != nil {
@@ -118,15 +118,15 @@ func (s *service) Diff(ctx context.Context, dr *diffapi.DiffRequest) (*diffapi.D
 	}
 	defer os.RemoveAll(bDir)
 
-	if err := containerd.MountAll(aMounts, aDir); err != nil {
+	if err := mount.MountAll(aMounts, aDir); err != nil {
 		return nil, errors.Wrap(err, "failed to mount")
 	}
-	defer containerd.Unmount(aDir, 0)
+	defer mount.Unmount(aDir, 0)
 
-	if err := containerd.MountAll(bMounts, bDir); err != nil {
+	if err := mount.MountAll(bMounts, bDir); err != nil {
 		return nil, errors.Wrap(err, "failed to mount")
 	}
-	defer containerd.Unmount(bDir, 0)
+	defer mount.Unmount(bDir, 0)
 
 	cw, err := s.store.Writer(ctx, dr.Ref, 0, "")
 	if err != nil {
@@ -190,10 +190,10 @@ func toDescriptor(d *descriptor.Descriptor) ocispec.Descriptor {
 	}
 }
 
-func toMounts(apim []*mounttypes.Mount) []containerd.Mount {
-	mounts := make([]containerd.Mount, len(apim))
+func toMounts(apim []*mounttypes.Mount) []mount.Mount {
+	mounts := make([]mount.Mount, len(apim))
 	for i, m := range apim {
-		mounts[i] = containerd.Mount{
+		mounts[i] = mount.Mount{
 			Type:    m.Type,
 			Source:  m.Source,
 			Options: m.Options,

--- a/services/execution/service.go
+++ b/services/execution/service.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/containerd/containerd"
 	api "github.com/containerd/containerd/api/services/execution"
 	"github.com/containerd/containerd/api/types/container"
 	"github.com/containerd/containerd/api/types/descriptor"
@@ -17,6 +16,7 @@ import (
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/plugin"
 	protobuf "github.com/gogo/protobuf/types"
 	google_protobuf "github.com/golang/protobuf/ptypes/empty"
@@ -108,7 +108,7 @@ func (s *Service) Create(ctx context.Context, r *api.CreateRequest) (*api.Create
 		Checkpoint: checkpointPath,
 	}
 	for _, m := range r.Rootfs {
-		opts.Rootfs = append(opts.Rootfs, containerd.Mount{
+		opts.Rootfs = append(opts.Rootfs, mount.Mount{
 			Type:    m.Type,
 			Source:  m.Source,
 			Options: m.Options,

--- a/services/snapshot/client.go
+++ b/services/snapshot/client.go
@@ -8,8 +8,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
-	"github.com/containerd/containerd"
 	snapshotapi "github.com/containerd/containerd/api/services/snapshot"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/snapshot"
 	"github.com/pkg/errors"
 )
@@ -42,7 +42,7 @@ func (r *remoteSnapshotter) Usage(ctx context.Context, key string) (snapshot.Usa
 	return toUsage(resp), nil
 }
 
-func (r *remoteSnapshotter) Mounts(ctx context.Context, key string) ([]containerd.Mount, error) {
+func (r *remoteSnapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, error) {
 	resp, err := r.client.Mounts(ctx, &snapshotapi.MountsRequest{Key: key})
 	if err != nil {
 		return nil, rewriteGRPCError(err)
@@ -50,7 +50,7 @@ func (r *remoteSnapshotter) Mounts(ctx context.Context, key string) ([]container
 	return toMounts(resp), nil
 }
 
-func (r *remoteSnapshotter) Prepare(ctx context.Context, key, parent string) ([]containerd.Mount, error) {
+func (r *remoteSnapshotter) Prepare(ctx context.Context, key, parent string) ([]mount.Mount, error) {
 	resp, err := r.client.Prepare(ctx, &snapshotapi.PrepareRequest{Key: key, Parent: parent})
 	if err != nil {
 		return nil, rewriteGRPCError(err)
@@ -58,7 +58,7 @@ func (r *remoteSnapshotter) Prepare(ctx context.Context, key, parent string) ([]
 	return toMounts(resp), nil
 }
 
-func (r *remoteSnapshotter) View(ctx context.Context, key, parent string) ([]containerd.Mount, error) {
+func (r *remoteSnapshotter) View(ctx context.Context, key, parent string) ([]mount.Mount, error) {
 	resp, err := r.client.View(ctx, &snapshotapi.PrepareRequest{Key: key, Parent: parent})
 	if err != nil {
 		return nil, rewriteGRPCError(err)
@@ -145,10 +145,10 @@ func toUsage(resp *snapshotapi.UsageResponse) snapshot.Usage {
 	}
 }
 
-func toMounts(resp *snapshotapi.MountsResponse) []containerd.Mount {
-	mounts := make([]containerd.Mount, len(resp.Mounts))
+func toMounts(resp *snapshotapi.MountsResponse) []mount.Mount {
+	mounts := make([]mount.Mount, len(resp.Mounts))
 	for i, m := range resp.Mounts {
-		mounts[i] = containerd.Mount{
+		mounts[i] = mount.Mount{
 			Type:    m.Type,
 			Source:  m.Source,
 			Options: m.Options,

--- a/services/snapshot/service.go
+++ b/services/snapshot/service.go
@@ -3,10 +3,10 @@ package snapshot
 import (
 	gocontext "context"
 
-	"github.com/containerd/containerd"
 	snapshotapi "github.com/containerd/containerd/api/services/snapshot"
 	mounttypes "github.com/containerd/containerd/api/types/mount"
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/snapshot"
 	protoempty "github.com/golang/protobuf/ptypes/empty"
@@ -189,7 +189,7 @@ func fromUsage(usage snapshot.Usage) *snapshotapi.UsageResponse {
 	}
 }
 
-func fromMounts(mounts []containerd.Mount) *snapshotapi.MountsResponse {
+func fromMounts(mounts []mount.Mount) *snapshotapi.MountsResponse {
 	resp := &snapshotapi.MountsResponse{
 		Mounts: make([]*mounttypes.Mount, len(mounts)),
 	}

--- a/snapshot/btrfs/btrfs_test.go
+++ b/snapshot/btrfs/btrfs_test.go
@@ -11,8 +11,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/mountinfo"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/snapshot"
 	"github.com/containerd/containerd/snapshot/testsuite"
 	"github.com/containerd/containerd/testutil"
@@ -86,7 +85,7 @@ func TestBtrfsMounts(t *testing.T) {
 	if err := os.MkdirAll(target, 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := containerd.MountAll(mounts, target); err != nil {
+	if err := mount.MountAll(mounts, target); err != nil {
 		t.Fatal(err)
 	}
 	defer testutil.Unmount(t, target)
@@ -116,7 +115,7 @@ func TestBtrfsMounts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := containerd.MountAll(mounts, target); err != nil {
+	if err := mount.MountAll(mounts, target); err != nil {
 		t.Fatal(err)
 	}
 	defer testutil.Unmount(t, target)
@@ -222,12 +221,12 @@ func TestGetBtrfsDevice(t *testing.T) {
 		expectedDevice string
 		expectedError  string
 		root           string
-		mounts         []mountinfo.Info
+		mounts         []mount.Info
 	}{
 		{
 			expectedDevice: "/dev/loop0",
 			root:           "/var/lib/containerd/snapshot/btrfs",
-			mounts: []mountinfo.Info{
+			mounts: []mount.Info{
 				{Root: "/", Mountpoint: "/", FSType: "ext4", Source: "/dev/sda1"},
 				{Root: "/", Mountpoint: "/var/lib/containerd/snapshot/btrfs", FSType: "btrfs", Source: "/dev/loop0"},
 			},
@@ -235,21 +234,21 @@ func TestGetBtrfsDevice(t *testing.T) {
 		{
 			expectedError: "/var/lib/containerd/snapshot/btrfs is not mounted as btrfs",
 			root:          "/var/lib/containerd/snapshot/btrfs",
-			mounts: []mountinfo.Info{
+			mounts: []mount.Info{
 				{Root: "/", Mountpoint: "/", FSType: "ext4", Source: "/dev/sda1"},
 			},
 		},
 		{
 			expectedDevice: "/dev/sda1",
 			root:           "/var/lib/containerd/snapshot/btrfs",
-			mounts: []mountinfo.Info{
+			mounts: []mount.Info{
 				{Root: "/", Mountpoint: "/", FSType: "btrfs", Source: "/dev/sda1"},
 			},
 		},
 		{
 			expectedDevice: "/dev/sda2",
 			root:           "/var/lib/containerd/snapshot/btrfs",
-			mounts: []mountinfo.Info{
+			mounts: []mount.Info{
 				{Root: "/", Mountpoint: "/", FSType: "btrfs", Source: "/dev/sda1"},
 				{Root: "/", Mountpoint: "/var/lib/containerd/snapshot/btrfs", FSType: "btrfs", Source: "/dev/sda2"},
 			},
@@ -257,7 +256,7 @@ func TestGetBtrfsDevice(t *testing.T) {
 		{
 			expectedDevice: "/dev/sda2",
 			root:           "/var/lib/containerd/snapshot/btrfs",
-			mounts: []mountinfo.Info{
+			mounts: []mount.Info{
 				{Root: "/", Mountpoint: "/var/lib/containerd/snapshot/btrfs", FSType: "btrfs", Source: "/dev/sda2"},
 				{Root: "/", Mountpoint: "/var/lib/foooooooooooooooooooo/baaaaaaaaaaaaaaaaaaaar", FSType: "btrfs", Source: "/dev/sda3"}, // mountpoint length longer than /var/lib/containerd/snapshot/btrfs
 				{Root: "/", Mountpoint: "/", FSType: "btrfs", Source: "/dev/sda1"},

--- a/snapshot/naive/naive.go
+++ b/snapshot/naive/naive.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/fs"
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/snapshot"
 	"github.com/containerd/containerd/snapshot/storage"
@@ -92,11 +92,11 @@ func (o *snapshotter) Usage(ctx context.Context, key string) (snapshot.Usage, er
 	return usage, nil
 }
 
-func (o *snapshotter) Prepare(ctx context.Context, key, parent string) ([]containerd.Mount, error) {
+func (o *snapshotter) Prepare(ctx context.Context, key, parent string) ([]mount.Mount, error) {
 	return o.createActive(ctx, key, parent, false)
 }
 
-func (o *snapshotter) View(ctx context.Context, key, parent string) ([]containerd.Mount, error) {
+func (o *snapshotter) View(ctx context.Context, key, parent string) ([]mount.Mount, error) {
 	return o.createActive(ctx, key, parent, true)
 }
 
@@ -104,7 +104,7 @@ func (o *snapshotter) View(ctx context.Context, key, parent string) ([]container
 // called on an read-write or readonly transaction.
 //
 // This can be used to recover mounts after calling View or Prepare.
-func (o *snapshotter) Mounts(ctx context.Context, key string) ([]containerd.Mount, error) {
+func (o *snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, error) {
 	ctx, t, err := o.ms.TransactionContext(ctx, false)
 	if err != nil {
 		return nil, err
@@ -202,7 +202,7 @@ func (o *snapshotter) Walk(ctx context.Context, fn func(context.Context, snapsho
 	return storage.WalkInfo(ctx, fn)
 }
 
-func (o *snapshotter) createActive(ctx context.Context, key, parent string, readonly bool) ([]containerd.Mount, error) {
+func (o *snapshotter) createActive(ctx context.Context, key, parent string, readonly bool) ([]mount.Mount, error) {
 	var (
 		err      error
 		path, td string
@@ -271,7 +271,7 @@ func (o *snapshotter) getSnapshotDir(id string) string {
 	return filepath.Join(o.root, "snapshots", id)
 }
 
-func (o *snapshotter) mounts(active storage.Active) []containerd.Mount {
+func (o *snapshotter) mounts(active storage.Active) []mount.Mount {
 	var (
 		roFlag string
 		source string
@@ -289,7 +289,7 @@ func (o *snapshotter) mounts(active storage.Active) []containerd.Mount {
 		source = o.getSnapshotDir(active.ParentIDs[0])
 	}
 
-	return []containerd.Mount{
+	return []mount.Mount{
 		{
 			Source: source,
 			Type:   "bind",

--- a/snapshot/overlay/overlay_test.go
+++ b/snapshot/overlay/overlay_test.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/snapshot"
 	"github.com/containerd/containerd/snapshot/storage"
 	"github.com/containerd/containerd/snapshot/testsuite"
@@ -221,7 +221,7 @@ func TestOverlayOverlayRead(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	if err := containerd.MountAll(mounts, dest); err != nil {
+	if err := mount.MountAll(mounts, dest); err != nil {
 		t.Error(err)
 		return
 	}

--- a/snapshot/snapshotter.go
+++ b/snapshot/snapshotter.go
@@ -3,7 +3,7 @@ package snapshot
 import (
 	"context"
 
-	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/mount"
 )
 
 // Kind identifies the kind of snapshot.
@@ -179,7 +179,7 @@ type Snapshotter interface {
 	// available only for active snapshots.
 	//
 	// This can be used to recover mounts after calling View or Prepare.
-	Mounts(ctx context.Context, key string) ([]containerd.Mount, error)
+	Mounts(ctx context.Context, key string) ([]mount.Mount, error)
 
 	// Prepare creates an active snapshot identified by key descending from the
 	// provided parent.  The returned mounts can be used to mount the snapshot
@@ -195,7 +195,7 @@ type Snapshotter interface {
 	// one is done with the transaction, Remove should be called on the key.
 	//
 	// Multiple calls to Prepare or View with the same key should fail.
-	Prepare(ctx context.Context, key, parent string) ([]containerd.Mount, error)
+	Prepare(ctx context.Context, key, parent string) ([]mount.Mount, error)
 
 	// View behaves identically to Prepare except the result may not be
 	// committed back to the snapshot snapshotter. View returns a readonly view on
@@ -210,7 +210,7 @@ type Snapshotter interface {
 	// Commit may not be called on the provided key and will return an error.
 	// To collect the resources associated with key, Remove must be called with
 	// key as the argument.
-	View(ctx context.Context, key, parent string) ([]containerd.Mount, error)
+	View(ctx context.Context, key, parent string) ([]mount.Mount, error)
 
 	// Commit captures the changes between key and its parent into a snapshot
 	// identified by name.  The name can then be used with the snapshotter's other

--- a/snapshot/testsuite/testsuite.go
+++ b/snapshot/testsuite/testsuite.go
@@ -9,8 +9,8 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/fs/fstest"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/snapshot"
 	"github.com/containerd/containerd/testutil"
 	"github.com/stretchr/testify/assert"
@@ -93,7 +93,7 @@ func checkSnapshotterBasic(ctx context.Context, t *testing.T, snapshotter snapsh
 		t.Fatal("expected mounts to have entries")
 	}
 
-	if err := containerd.MountAll(mounts, preparing); err != nil {
+	if err := mount.MountAll(mounts, preparing); err != nil {
 		t.Fatalf("failure reason: %+v", err)
 	}
 	defer testutil.Unmount(t, preparing)
@@ -124,7 +124,7 @@ func checkSnapshotterBasic(ctx context.Context, t *testing.T, snapshotter snapsh
 	if err != nil {
 		t.Fatalf("failure reason: %+v", err)
 	}
-	if err := containerd.MountAll(mounts, next); err != nil {
+	if err := mount.MountAll(mounts, next); err != nil {
 		t.Fatalf("failure reason: %+v", err)
 	}
 	defer testutil.Unmount(t, next)
@@ -179,7 +179,7 @@ func checkSnapshotterBasic(ctx context.Context, t *testing.T, snapshotter snapsh
 	if err != nil {
 		t.Fatalf("failure reason: %+v", err)
 	}
-	if err := containerd.MountAll(mounts, nextnext); err != nil {
+	if err := mount.MountAll(mounts, nextnext); err != nil {
 		t.Fatalf("failure reason: %+v", err)
 	}
 	defer testutil.Unmount(t, nextnext)
@@ -211,7 +211,7 @@ func checkSnapshotterStatActive(ctx context.Context, t *testing.T, snapshotter s
 		t.Fatal("expected mounts to have entries")
 	}
 
-	if err = containerd.MountAll(mounts, preparing); err != nil {
+	if err = mount.MountAll(mounts, preparing); err != nil {
 		t.Fatal(err)
 	}
 	defer testutil.Unmount(t, preparing)
@@ -245,7 +245,7 @@ func checkSnapshotterStatCommitted(ctx context.Context, t *testing.T, snapshotte
 		t.Fatal("expected mounts to have entries")
 	}
 
-	if err = containerd.MountAll(mounts, preparing); err != nil {
+	if err = mount.MountAll(mounts, preparing); err != nil {
 		t.Fatal(err)
 	}
 	defer testutil.Unmount(t, preparing)
@@ -284,7 +284,7 @@ func snapshotterPrepareMount(ctx context.Context, snapshotter snapshot.Snapshott
 		return "", fmt.Errorf("expected mounts to have entries")
 	}
 
-	if err = containerd.MountAll(mounts, preparing); err != nil {
+	if err = mount.MountAll(mounts, preparing); err != nil {
 		return "", err
 	}
 	return preparing, nil

--- a/snapshot/windows/windows.go
+++ b/snapshot/windows/windows.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"path/filepath"
 
-	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/snapshot"
 	"github.com/pkg/errors"
@@ -48,11 +48,11 @@ func (o *Snapshotter) Usage(ctx context.Context, key string) (snapshot.Usage, er
 	panic("not implemented")
 }
 
-func (o *Snapshotter) Prepare(ctx context.Context, key, parent string) ([]containerd.Mount, error) {
+func (o *Snapshotter) Prepare(ctx context.Context, key, parent string) ([]mount.Mount, error) {
 	panic("not implemented")
 }
 
-func (o *Snapshotter) View(ctx context.Context, key, parent string) ([]containerd.Mount, error) {
+func (o *Snapshotter) View(ctx context.Context, key, parent string) ([]mount.Mount, error) {
 	panic("not implemented")
 }
 
@@ -60,7 +60,7 @@ func (o *Snapshotter) View(ctx context.Context, key, parent string) ([]container
 // called on an read-write or readonly transaction.
 //
 // This can be used to recover mounts after calling View or Prepare.
-func (o *Snapshotter) Mounts(ctx context.Context, key string) ([]containerd.Mount, error) {
+func (o *Snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, error) {
 	panic("not implemented")
 }
 


### PR DESCRIPTION
This moves both the Mount type and mountinfo into a single mount
package.

This also opens up the root of the repo to hold the containerd client
implementation.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>