### PR TITLE
Remove go 1.7 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: required
 language: go
 
 go:
-  - 1.7.x
   - 1.8.x
   - tip
 


### PR DESCRIPTION
Support for go 1.7 is no longer targeted. Remove to allow features added since go 1.7. This may also fix some go vet cases which were blocking us from turning it on with Travis.