### PR TITLE
prepareStdio: use named return for err

### DIFF
--- a/cmd/ctr/utils_unix.go
+++ b/cmd/ctr/utils_unix.go
@@ -21,8 +21,8 @@ import (
 	"google.golang.org/grpc/grpclog"
 )
 
-func prepareStdio(stdin, stdout, stderr string, console bool) (*sync.WaitGroup, error) {
-	var wg sync.WaitGroup
+func prepareStdio(stdin, stdout, stderr string, console bool) (wg *sync.WaitGroup, err error) {
+	wg = &sync.WaitGroup{}
 	ctx := gocontext.Background()
 
 	f, err := fifo.OpenFifo(ctx, stdin, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700)
@@ -73,7 +73,7 @@ func prepareStdio(stdin, stdout, stderr string, console bool) (*sync.WaitGroup, 
 		}(f)
 	}
 
-	return &wg, nil
+	return wg, nil
 }
 
 func getGRPCConnection(context *cli.Context) (*grpc.ClientConn, error) {


### PR DESCRIPTION
This avoids issues with the various deferred error handlers in the event that
`err` is shadowed or named differently, which this function currently avoids
but which is an easy trap to fall into.

Since named return values are all or nothing we need to name the waitGroup too
and adjust the code to suite.

Thanks to Aaron Lehmann for the suggestion, see also
https://github.com/docker/swarmkit/pull/1965#discussion_r118137410

Signed-off-by: Ian Campbell <ian.campbell@docker.com>

/cc @mlaventure @aaronlehmann 