### PR TITLE
Add initial containerd client package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /bin/
 **/coverage.txt
 **/coverage.out
+containerd.test

--- a/client.go
+++ b/client.go
@@ -156,9 +156,16 @@ func WithRuntime(name string) NewContainerOpts {
 	}
 }
 
+func WithImage(i Image) NewContainerOpts {
+	return func(ctx context.Context, client *Client, c *containers.Container) error {
+		c.Image = i.Name()
+		return nil
+	}
+}
+
 // NewContainer will create a new container in container with the provided id
 // the id must be unique within the namespace
-func (c *Client) NewContainer(ctx context.Context, id string, image Image, spec *specs.Spec, opts ...NewContainerOpts) (Container, error) {
+func (c *Client) NewContainer(ctx context.Context, id string, spec *specs.Spec, opts ...NewContainerOpts) (Container, error) {
 	data, err := json.Marshal(spec)
 	if err != nil {
 		return nil, err
@@ -170,7 +177,6 @@ func (c *Client) NewContainer(ctx context.Context, id string, image Image, spec 
 			TypeUrl: specs.Version,
 			Value:   data,
 		},
-		Image: image.Name(),
 	}
 	for _, o := range opts {
 		if err := o(ctx, c, &container); err != nil {

--- a/client.go
+++ b/client.go
@@ -2,11 +2,23 @@ package containerd
 
 import (
 	"context"
+	"encoding/json"
 	"io/ioutil"
 	"log"
 	"time"
 
 	"github.com/containerd/containerd/api/services/containers"
+	contentapi "github.com/containerd/containerd/api/services/content"
+	snapshotapi "github.com/containerd/containerd/api/services/snapshot"
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/images"
+	contentservice "github.com/containerd/containerd/services/content"
+	snapshotservice "github.com/containerd/containerd/services/snapshot"
+	"github.com/containerd/containerd/snapshot"
+	protobuf "github.com/gogo/protobuf/types"
+	"github.com/opencontainers/image-spec/identity"
+	"github.com/opencontainers/image-spec/specs-go/v1"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/grpclog"
@@ -51,6 +63,88 @@ func (c *Client) Containers(ctx context.Context) ([]*Container, error) {
 	return out, nil
 }
 
+type NewContainerOpts func(ctx context.Context, client *Client, c *containers.Container) error
+
+// NewContainerWithLables adds the provided labels to the container
+func NewContainerWithLables(labels map[string]string) NewContainerOpts {
+	return func(_ context.Context, _ *Client, c *containers.Container) error {
+		c.Labels = labels
+		return nil
+	}
+}
+
+// NewContainerWithExistingRootFS uses an existing root filesystem for the container
+func NewContainerWithExistingRootFS(id string) NewContainerOpts {
+	return func(ctx context.Context, client *Client, c *containers.Container) error {
+		// check that the snapshot exists, if not, fail on creation
+		if _, err := client.snapshotter().Mounts(ctx, id); err != nil {
+			return err
+		}
+		c.RootFS = id
+		return nil
+	}
+}
+
+// NewContainerWithNewRootFS allocates a new snapshot to be used by the container as the
+// root filesystem in read-write mode
+func NewContainerWithNewRootFS(id string, image v1.Descriptor) NewContainerOpts {
+	return func(ctx context.Context, client *Client, c *containers.Container) error {
+		diffIDs, err := images.RootFS(ctx, client.content(), image)
+		if err != nil {
+			return err
+		}
+		if _, err := client.snapshotter().Prepare(ctx, id, identity.ChainID(diffIDs).String()); err != nil {
+			return err
+		}
+		c.RootFS = id
+		return nil
+	}
+}
+
+// NewContainerWithNewReadonlyRootFS allocates a new snapshot to be used by the container as the
+// root filesystem in read-only mode
+func NewContainerWithNewReadonlyRootFS(id string, image v1.Descriptor) NewContainerOpts {
+	return func(ctx context.Context, client *Client, c *containers.Container) error {
+		diffIDs, err := images.RootFS(ctx, client.content(), image)
+		if err != nil {
+			return err
+		}
+		if _, err := client.snapshotter().View(ctx, id, identity.ChainID(diffIDs).String()); err != nil {
+			return err
+		}
+		c.RootFS = id
+		return nil
+	}
+}
+
+// NewContainer will create a new container in container with the provided id
+// the id must be unique within the namespace
+func (c *Client) NewContainer(ctx context.Context, id string, spec *specs.Spec, opts ...NewContainerOpts) (*Container, error) {
+	data, err := json.Marshal(spec)
+	if err != nil {
+		return nil, err
+	}
+	container := containers.Container{
+		ID: id,
+		Spec: &protobuf.Any{
+			TypeUrl: specs.Version,
+			Value:   data,
+		},
+	}
+	for _, o := range opts {
+		if err := o(ctx, c, &container); err != nil {
+			return nil, err
+		}
+	}
+	r, err := c.containers().Create(ctx, &containers.CreateContainerRequest{
+		Container: container,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return containerFromProto(c, r.Container), nil
+}
+
 // Close closes the clients connection to containerd
 func (c *Client) Close() error {
 	return c.conn.Close()
@@ -58,4 +152,12 @@ func (c *Client) Close() error {
 
 func (c *Client) containers() containers.ContainersClient {
 	return containers.NewContainersClient(c.conn)
+}
+
+func (c *Client) content() content.Store {
+	return contentservice.NewStoreFromClient(contentapi.NewContentClient(c.conn))
+}
+
+func (c *Client) snapshotter() snapshot.Snapshotter {
+	return snapshotservice.NewSnapshotterFromClient(snapshotapi.NewSnapshotClient(c.conn))
 }

--- a/client.go
+++ b/client.go
@@ -158,7 +158,7 @@ func WithRuntime(name string) NewContainerOpts {
 
 // NewContainer will create a new container in container with the provided id
 // the id must be unique within the namespace
-func (c *Client) NewContainer(ctx context.Context, id string, spec *specs.Spec, opts ...NewContainerOpts) (Container, error) {
+func (c *Client) NewContainer(ctx context.Context, id string, image Image, spec *specs.Spec, opts ...NewContainerOpts) (Container, error) {
 	data, err := json.Marshal(spec)
 	if err != nil {
 		return nil, err
@@ -170,6 +170,7 @@ func (c *Client) NewContainer(ctx context.Context, id string, spec *specs.Spec, 
 			TypeUrl: specs.Version,
 			Value:   data,
 		},
+		Image: image.Name(),
 	}
 	for _, o := range opts {
 		if err := o(ctx, c, &container); err != nil {

--- a/client.go
+++ b/client.go
@@ -44,7 +44,7 @@ type NewClientOpts func(c *Client) error
 
 func WithNamespace(namespace string) NewClientOpts {
 	return func(c *Client) error {
-		c.Namespace = namespace
+		c.namespace = namespace
 		return nil
 	}
 }
@@ -63,7 +63,7 @@ func New(address string, opts ...NewClientOpts) (*Client, error) {
 	}
 	c := &Client{
 		conn:    conn,
-		Runtime: runtime.GOOS,
+		runtime: runtime.GOOS,
 	}
 	for _, o := range opts {
 		if err := o(c); err != nil {
@@ -78,8 +78,8 @@ func New(address string, opts ...NewClientOpts) (*Client, error) {
 type Client struct {
 	conn *grpc.ClientConn
 
-	Runtime   string
-	Namespace string
+	runtime   string
+	namespace string
 }
 
 // Containers returns all containers created in containerd
@@ -97,8 +97,8 @@ func (c *Client) Containers(ctx context.Context) ([]*Container, error) {
 
 type NewContainerOpts func(ctx context.Context, client *Client, c *containers.Container) error
 
-// WithContainerLables adds the provided labels to the container
-func WithContainerLables(labels map[string]string) NewContainerOpts {
+// WithContainerLabels adds the provided labels to the container
+func WithContainerLabels(labels map[string]string) NewContainerOpts {
 	return func(_ context.Context, _ *Client, c *containers.Container) error {
 		c.Labels = labels
 		return nil
@@ -165,7 +165,7 @@ func (c *Client) NewContainer(ctx context.Context, id string, spec *specs.Spec, 
 	}
 	container := containers.Container{
 		ID:      id,
-		Runtime: c.Runtime,
+		Runtime: c.runtime,
 		Spec: &protobuf.Any{
 			TypeUrl: specs.Version,
 			Value:   data,

--- a/client.go
+++ b/client.go
@@ -1,0 +1,61 @@
+package containerd
+
+import (
+	"context"
+	"io/ioutil"
+	"log"
+	"time"
+
+	"github.com/containerd/containerd/api/services/containers"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/grpclog"
+)
+
+// New returns a new containerd client that is connected to the containerd
+// instance provided by address
+func New(address string) (*Client, error) {
+	// reset the grpc logger so that it does not output in the STDIO of the calling process
+	grpclog.SetLogger(log.New(ioutil.Discard, "", log.LstdFlags))
+
+	opts := []grpc.DialOption{
+		grpc.WithInsecure(),
+		grpc.WithTimeout(100 * time.Second),
+		grpc.WithDialer(dialer),
+	}
+	conn, err := grpc.Dial(dialAddress(address), opts...)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to dial %q", address)
+	}
+	return &Client{
+		conn: conn,
+	}, nil
+}
+
+// Client is the client to interact with containerd and its various services
+// using a uniform interface
+type Client struct {
+	conn *grpc.ClientConn
+}
+
+// Containers returns all containers created in containerd
+func (c *Client) Containers(ctx context.Context) ([]*Container, error) {
+	r, err := c.containers().List(ctx, &containers.ListContainersRequest{})
+	if err != nil {
+		return nil, err
+	}
+	var out []*Container
+	for _, container := range r.Containers {
+		out = append(out, containerFromProto(c, container))
+	}
+	return out, nil
+}
+
+// Close closes the clients connection to containerd
+func (c *Client) Close() error {
+	return c.conn.Close()
+}
+
+func (c *Client) containers() containers.ContainersClient {
+	return containers.NewContainersClient(c.conn)
+}

--- a/client.go
+++ b/client.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/containerd/containerd/api/services/containers"
 	contentapi "github.com/containerd/containerd/api/services/content"
+	"github.com/containerd/containerd/api/services/execution"
 	snapshotapi "github.com/containerd/containerd/api/services/snapshot"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
@@ -160,4 +161,8 @@ func (c *Client) content() content.Store {
 
 func (c *Client) snapshotter() snapshot.Snapshotter {
 	return snapshotservice.NewSnapshotterFromClient(snapshotapi.NewSnapshotClient(c.conn))
+}
+
+func (c *Client) tasks() execution.TasksClient {
+	return execution.NewTasksClient(c.conn)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,18 @@
+package containerd
+
+import "testing"
+
+const defaultAddress = "/run/containerd/containerd.sock"
+
+func TestNewClient(t *testing.T) {
+	client, err := New(defaultAddress)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client == nil {
+		t.Fatal("New() returned nil client")
+	}
+	if err := client.Close(); err != nil {
+		t.Errorf("client closed returned errror %v", err)
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -8,6 +8,9 @@ import (
 const defaultAddress = "/run/containerd/containerd.sock"
 
 func TestNewClient(t *testing.T) {
+	if testing.Short() {
+		return
+	}
 	client, err := New(defaultAddress)
 	if err != nil {
 		t.Fatal(err)
@@ -20,42 +23,10 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
-func TestNewContainer(t *testing.T) {
-	client, err := New(defaultAddress)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer client.Close()
-
-	id := "test"
-	spec, err := GenerateSpec(WithHostname(id))
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	container, err := client.NewContainer(context.Background(), id, spec)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	if container.ID() != id {
-		t.Errorf("expected container id %q but received %q", id, container.ID())
-	}
-	if spec, err = container.Spec(); err != nil {
-		t.Error(err)
-		return
-	}
-	if spec.Hostname != id {
-		t.Errorf("expected spec hostname id %q but received %q", id, container.ID())
-		return
-	}
-	if err := container.Delete(context.Background()); err != nil {
-		t.Error(err)
-		return
-	}
-}
-
 func TestImagePull(t *testing.T) {
+	if testing.Short() {
+		return
+	}
 	client, err := New(defaultAddress)
 	if err != nil {
 		t.Fatal(err)

--- a/client_test.go
+++ b/client_test.go
@@ -54,3 +54,18 @@ func TestNewContainer(t *testing.T) {
 		return
 	}
 }
+
+func TestImagePull(t *testing.T) {
+	client, err := New(defaultAddress)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	const ref = "docker.io/library/alpine:latest"
+	_, err = client.Pull(context.Background(), ref)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,9 @@
 package containerd
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 const defaultAddress = "/run/containerd/containerd.sock"
 
@@ -14,5 +17,40 @@ func TestNewClient(t *testing.T) {
 	}
 	if err := client.Close(); err != nil {
 		t.Errorf("client closed returned errror %v", err)
+	}
+}
+
+func TestNewContainer(t *testing.T) {
+	client, err := New(defaultAddress)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	id := "test"
+	spec, err := GenerateSpec(WithHostname(id))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	container, err := client.NewContainer(context.Background(), id, spec)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if container.ID() != id {
+		t.Errorf("expected container id %q but received %q", id, container.ID())
+	}
+	if spec, err = container.Spec(); err != nil {
+		t.Error(err)
+		return
+	}
+	if spec.Hostname != id {
+		t.Errorf("expected spec hostname id %q but received %q", id, container.ID())
+		return
+	}
+	if err := container.Delete(context.Background()); err != nil {
+		t.Error(err)
+		return
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -9,6 +9,7 @@ const defaultAddress = "/run/containerd/containerd.sock"
 
 func TestNewClient(t *testing.T) {
 	if testing.Short() {
+		t.Skip()
 		return
 	}
 	client, err := New(defaultAddress)
@@ -25,6 +26,7 @@ func TestNewClient(t *testing.T) {
 
 func TestImagePull(t *testing.T) {
 	if testing.Short() {
+		t.Skip()
 		return
 	}
 	client, err := New(defaultAddress)

--- a/client_test.go
+++ b/client_test.go
@@ -2,17 +2,22 @@ package containerd
 
 import (
 	"context"
+	"flag"
 	"testing"
 )
 
-const defaultAddress = "/run/containerd/containerd.sock"
+func init() {
+	flag.StringVar(&address, "address", "/run/containerd/containerd.sock", "The address to the containerd socket for use in the tests")
+	flag.Parse()
+}
+
+var address string
 
 func TestNewClient(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
-		return
 	}
-	client, err := New(defaultAddress)
+	client, err := New(address)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -27,9 +32,8 @@ func TestNewClient(t *testing.T) {
 func TestImagePull(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
-		return
 	}
-	client, err := New(defaultAddress)
+	client, err := New(address)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client_unix.go
+++ b/client_unix.go
@@ -1,0 +1,17 @@
+package containerd
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"time"
+)
+
+func dialer(address string, timeout time.Duration) (net.Conn, error) {
+	address = strings.TrimPrefix(address, "unix://")
+	return net.DialTimeout("unix", address, timeout)
+}
+
+func dialAddress(address string) string {
+	return fmt.Sprintf("unix://%s", address)
+}

--- a/client_windows.go
+++ b/client_windows.go
@@ -8,7 +8,7 @@ import (
 )
 
 func dialer(address string, timeout time.Duration) (net.Conn, error) {
-	return winio.DialPipe(bindAddress, &timeout)
+	return winio.DialPipe(address, &timeout)
 }
 
 func dialAddress(address string) string {

--- a/client_windows.go
+++ b/client_windows.go
@@ -1,0 +1,16 @@
+package containerd
+
+import (
+	"net"
+	"time"
+
+	winio "github.com/Microsoft/go-winio"
+)
+
+func dialer(address string, timeout time.Duration) (net.Conn, error) {
+	return winio.DialPipe(bindAddress, &timeout)
+}
+
+func dialAddress(address string) string {
+	return address
+}

--- a/container.go
+++ b/container.go
@@ -43,9 +43,13 @@ func (c *Container) Spec() (*specs.Spec, error) {
 func (c *Container) Delete(ctx context.Context) error {
 	// TODO: should the client be the one removing resources attached
 	// to the container at the moment before we have GC?
-	_, err := c.client.containers().Delete(ctx, &containers.DeleteContainerRequest{
+	err := c.client.snapshotter().Remove(ctx, c.c.RootFS)
+
+	if _, cerr := c.client.containers().Delete(ctx, &containers.DeleteContainerRequest{
 		ID: c.c.ID,
-	})
+	}); err == nil {
+		err = cerr
+	}
 	return err
 }
 

--- a/container.go
+++ b/container.go
@@ -1,21 +1,47 @@
 package containerd
 
-import "github.com/containerd/containerd/api/services/containers"
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/containerd/containerd/api/services/containers"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
 
 func containerFromProto(client *Client, c containers.Container) *Container {
 	return &Container{
 		client: client,
-		id:     c.ID,
+		c:      c,
 	}
 }
 
 type Container struct {
 	client *Client
 
-	id string
+	c containers.Container
 }
 
 // ID returns the container's unique id
 func (c *Container) ID() string {
-	return c.id
+	return c.c.ID
+}
+
+// Spec returns the current OCI specification for the container
+func (c *Container) Spec() (*specs.Spec, error) {
+	var s specs.Spec
+	if err := json.Unmarshal(c.c.Spec.Value, &s); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+// Delete deletes an existing container
+// an error is returned if the container has running tasks
+func (c *Container) Delete(ctx context.Context) error {
+	// TODO: should the client be the one removing resources attached
+	// to the container at the moment before we have GC?
+	_, err := c.client.containers().Delete(ctx, &containers.DeleteContainerRequest{
+		ID: c.c.ID,
+	})
+	return err
 }

--- a/container.go
+++ b/container.go
@@ -1,0 +1,21 @@
+package containerd
+
+import "github.com/containerd/containerd/api/services/containers"
+
+func containerFromProto(client *Client, c containers.Container) *Container {
+	return &Container{
+		client: client,
+		id:     c.ID,
+	}
+}
+
+type Container struct {
+	client *Client
+
+	id string
+}
+
+// ID returns the container's unique id
+func (c *Container) ID() string {
+	return c.id
+}

--- a/container.go
+++ b/container.go
@@ -53,9 +53,9 @@ func (c *container) Spec() (*specs.Spec, error) {
 func (c *container) Delete(ctx context.Context) error {
 	// TODO: should the client be the one removing resources attached
 	// to the container at the moment before we have GC?
-	err := c.client.snapshotter().Remove(ctx, c.c.RootFS)
+	err := c.client.SnapshotService().Remove(ctx, c.c.RootFS)
 
-	if _, cerr := c.client.containers().Delete(ctx, &containers.DeleteContainerRequest{
+	if _, cerr := c.client.ContainerService().Delete(ctx, &containers.DeleteContainerRequest{
 		ID: c.c.ID,
 	}); err == nil {
 		err = cerr
@@ -80,7 +80,7 @@ func (c *container) NewTask(ctx context.Context, ioCreate IOCreation) (Task, err
 		Stderr:      i.Stderr,
 	}
 	// get the rootfs from the snapshotter and add it to the request
-	mounts, err := c.client.snapshotter().Mounts(ctx, c.c.RootFS)
+	mounts, err := c.client.SnapshotService().Mounts(ctx, c.c.RootFS)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +91,7 @@ func (c *container) NewTask(ctx context.Context, ioCreate IOCreation) (Task, err
 			Options: m.Options,
 		})
 	}
-	response, err := c.client.tasks().Create(ctx, request)
+	response, err := c.client.TaskService().Create(ctx, request)
 	if err != nil {
 		return nil, err
 	}

--- a/container.go
+++ b/container.go
@@ -85,10 +85,12 @@ func (c *Container) NewTask(ctx context.Context, ioCreate IOCreation) (*Task, er
 	if err != nil {
 		return nil, err
 	}
-	return &Task{
+	t := &Task{
 		client:      c.client,
 		io:          i,
 		containerID: response.ContainerID,
 		pid:         response.Pid,
-	}, nil
+	}
+	c.task = t
+	return t, nil
 }

--- a/container_test.go
+++ b/container_test.go
@@ -7,6 +7,7 @@ import (
 
 func TestContainerList(t *testing.T) {
 	if testing.Short() {
+		t.Skip()
 		return
 	}
 	client, err := New(defaultAddress)
@@ -27,6 +28,7 @@ func TestContainerList(t *testing.T) {
 
 func TestNewContainer(t *testing.T) {
 	if testing.Short() {
+		t.Skip()
 		return
 	}
 	client, err := New(defaultAddress)

--- a/container_test.go
+++ b/container_test.go
@@ -6,6 +6,9 @@ import (
 )
 
 func TestContainerList(t *testing.T) {
+	if testing.Short() {
+		return
+	}
 	client, err := New(defaultAddress)
 	if err != nil {
 		t.Fatal(err)
@@ -19,5 +22,39 @@ func TestContainerList(t *testing.T) {
 	}
 	if len(containers) != 0 {
 		t.Errorf("expected 0 containers but received %d", len(containers))
+	}
+}
+
+func TestNewContainer(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+	client, err := New(defaultAddress)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	id := "test"
+	spec, err := GenerateSpec()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	container, err := client.NewContainer(context.Background(), id, spec)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if container.ID() != id {
+		t.Errorf("expected container id %q but received %q", id, container.ID())
+	}
+	if spec, err = container.Spec(); err != nil {
+		t.Error(err)
+		return
+	}
+	if err := container.Delete(context.Background()); err != nil {
+		t.Error(err)
+		return
 	}
 }

--- a/container_test.go
+++ b/container_test.go
@@ -1,0 +1,23 @@
+package containerd
+
+import (
+	"context"
+	"testing"
+)
+
+func TestContainerList(t *testing.T) {
+	client, err := New(defaultAddress)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	containers, err := client.Containers(context.Background())
+	if err != nil {
+		t.Errorf("container list returned error %v", err)
+		return
+	}
+	if len(containers) != 0 {
+		t.Errorf("expected 0 containers but received %d", len(containers))
+	}
+}

--- a/container_test.go
+++ b/container_test.go
@@ -8,9 +8,8 @@ import (
 func TestContainerList(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
-		return
 	}
-	client, err := New(defaultAddress)
+	client, err := New(address)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,9 +28,8 @@ func TestContainerList(t *testing.T) {
 func TestNewContainer(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
-		return
 	}
-	client, err := New(defaultAddress)
+	client, err := New(address)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/image.go
+++ b/image.go
@@ -3,5 +3,7 @@ package containerd
 import "github.com/containerd/containerd/images"
 
 type Image struct {
+	client *Client
+
 	i images.Image
 }

--- a/image.go
+++ b/image.go
@@ -3,6 +3,7 @@ package containerd
 import "github.com/containerd/containerd/images"
 
 type Image interface {
+	Name() string
 }
 
 var _ = (Image)(&image{})
@@ -11,4 +12,8 @@ type image struct {
 	client *Client
 
 	i images.Image
+}
+
+func (i *image) Name() string {
+	return i.i.Name
 }

--- a/image.go
+++ b/image.go
@@ -1,0 +1,7 @@
+package containerd
+
+import "github.com/containerd/containerd/images"
+
+type Image struct {
+	i images.Image
+}

--- a/image.go
+++ b/image.go
@@ -2,7 +2,12 @@ package containerd
 
 import "github.com/containerd/containerd/images"
 
-type Image struct {
+type Image interface {
+}
+
+var _ = (Image)(&image{})
+
+type image struct {
 	client *Client
 
 	i images.Image

--- a/spec.go
+++ b/spec.go
@@ -1,0 +1,44 @@
+package containerd
+
+import specs "github.com/opencontainers/runtime-spec/specs-go"
+
+type SpecOpts func(s *specs.Spec) error
+
+func WithImageRef(ref string) SpecOpts {
+	return func(s *specs.Spec) error {
+		if s.Annotations == nil {
+			s.Annotations = make(map[string]string)
+		}
+		s.Annotations["image"] = ref
+		return nil
+	}
+}
+
+func WithHostname(id string) SpecOpts {
+	return func(s *specs.Spec) error {
+		s.Hostname = id
+		return nil
+	}
+}
+
+func WithArgs(args ...string) SpecOpts {
+	return func(s *specs.Spec) error {
+		s.Process.Args = args
+		return nil
+	}
+}
+
+// GenerateSpec will generate a default spec from the provided image
+// for use as a containerd container
+func GenerateSpec(opts ...SpecOpts) (*specs.Spec, error) {
+	s, err := createDefaultSpec()
+	if err != nil {
+		return nil, err
+	}
+	for _, o := range opts {
+		if err := o(s); err != nil {
+			return nil, err
+		}
+	}
+	return s, nil
+}

--- a/spec.go
+++ b/spec.go
@@ -14,13 +14,6 @@ func WithImageRef(ref string) SpecOpts {
 	}
 }
 
-func WithHostname(id string) SpecOpts {
-	return func(s *specs.Spec) error {
-		s.Hostname = id
-		return nil
-	}
-}
-
 func WithArgs(args ...string) SpecOpts {
 	return func(s *specs.Spec) error {
 		s.Process.Args = args
@@ -30,8 +23,8 @@ func WithArgs(args ...string) SpecOpts {
 
 // GenerateSpec will generate a default spec from the provided image
 // for use as a containerd container
-func GenerateSpec(opts ...SpecOpts) (*specs.Spec, error) {
-	s, err := createDefaultSpec()
+func GenerateSpec(id string, opts ...SpecOpts) (*specs.Spec, error) {
+	s, err := createDefaultSpec(id)
 	if err != nil {
 		return nil, err
 	}

--- a/spec.go
+++ b/spec.go
@@ -23,8 +23,8 @@ func WithArgs(args ...string) SpecOpts {
 
 // GenerateSpec will generate a default spec from the provided image
 // for use as a containerd container
-func GenerateSpec(id string, opts ...SpecOpts) (*specs.Spec, error) {
-	s, err := createDefaultSpec(id)
+func GenerateSpec(opts ...SpecOpts) (*specs.Spec, error) {
+	s, err := createDefaultSpec()
 	if err != nil {
 		return nil, err
 	}

--- a/spec.go
+++ b/spec.go
@@ -4,17 +4,7 @@ import specs "github.com/opencontainers/runtime-spec/specs-go"
 
 type SpecOpts func(s *specs.Spec) error
 
-func WithImageRef(ref string) SpecOpts {
-	return func(s *specs.Spec) error {
-		if s.Annotations == nil {
-			s.Annotations = make(map[string]string)
-		}
-		s.Annotations["image"] = ref
-		return nil
-	}
-}
-
-func WithArgs(args ...string) SpecOpts {
+func WithProcessArgs(args ...string) SpecOpts {
 	return func(s *specs.Spec) error {
 		s.Process.Args = args
 		return nil

--- a/spec_unix.go
+++ b/spec_unix.go
@@ -183,8 +183,9 @@ func WithHostNamespace(ns specs.LinuxNamespaceType) SpecOpts {
 	}
 }
 
-func WithImage(ctx context.Context, image *Image) SpecOpts {
+func WithImage(ctx context.Context, i Image) SpecOpts {
 	return func(s *specs.Spec) error {
+		image := i.(*image)
 		store := image.client.content()
 		ic, err := image.i.Config(ctx, store)
 		if err != nil {

--- a/spec_unix.go
+++ b/spec_unix.go
@@ -183,7 +183,7 @@ func WithHostNamespace(ns specs.LinuxNamespaceType) SpecOpts {
 	}
 }
 
-func WithImage(ctx context.Context, i Image) SpecOpts {
+func WithImageConfig(ctx context.Context, i Image) SpecOpts {
 	return func(s *specs.Spec) error {
 		var (
 			image = i.(*image)

--- a/spec_unix.go
+++ b/spec_unix.go
@@ -57,7 +57,7 @@ func defaultNamespaces() []specs.LinuxNamespace {
 	}
 }
 
-func createDefaultSpec(id string) (*specs.Spec, error) {
+func createDefaultSpec() (*specs.Spec, error) {
 	s := &specs.Spec{
 		Version: specs.Version,
 		Platform: specs.Platform{
@@ -67,7 +67,6 @@ func createDefaultSpec(id string) (*specs.Spec, error) {
 		Root: specs.Root{
 			Path: defaultRootfsPath,
 		},
-		Hostname: id,
 		Process: specs.Process{
 			Cwd:             "/",
 			NoNewPrivileges: true,

--- a/spec_unix.go
+++ b/spec_unix.go
@@ -186,7 +186,7 @@ func WithHostNamespace(ns specs.LinuxNamespaceType) SpecOpts {
 func WithImage(ctx context.Context, i Image) SpecOpts {
 	return func(s *specs.Spec) error {
 		image := i.(*image)
-		store := image.client.content()
+		store := image.client.ContentStore()
 		ic, err := image.i.Config(ctx, store)
 		if err != nil {
 			return err

--- a/spec_unix.go
+++ b/spec_unix.go
@@ -1,0 +1,225 @@
+package containerd
+
+import (
+	"fmt"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/opencontainers/image-spec/specs-go/v1"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+const (
+	rwm               = "rwm"
+	defaultRootfsPath = "rootfs"
+)
+
+func defaltCaps() []string {
+	return []string{
+		"CAP_CHOWN",
+		"CAP_DAC_OVERRIDE",
+		"CAP_FSETID",
+		"CAP_FOWNER",
+		"CAP_MKNOD",
+		"CAP_NET_RAW",
+		"CAP_SETGID",
+		"CAP_SETUID",
+		"CAP_SETFCAP",
+		"CAP_SETPCAP",
+		"CAP_NET_BIND_SERVICE",
+		"CAP_SYS_CHROOT",
+		"CAP_KILL",
+		"CAP_AUDIT_WRITE",
+	}
+}
+
+func defaultNamespaces() []specs.LinuxNamespace {
+	return []specs.LinuxNamespace{
+		{
+			Type: specs.PIDNamespace,
+		},
+		{
+			Type: specs.IPCNamespace,
+		},
+		{
+			Type: specs.UTSNamespace,
+		},
+		{
+			Type: specs.MountNamespace,
+		},
+		{
+			Type: specs.NetworkNamespace,
+		},
+	}
+}
+
+func createDefaultSpec() (*specs.Spec, error) {
+	s := &specs.Spec{
+		Version: specs.Version,
+		Platform: specs.Platform{
+			OS:   runtime.GOOS,
+			Arch: runtime.GOARCH,
+		},
+		Root: specs.Root{
+			Path: defaultRootfsPath,
+		},
+		Process: specs.Process{
+			Cwd:             "/",
+			NoNewPrivileges: true,
+			User: specs.User{
+				UID: 0,
+				GID: 0,
+			},
+			Capabilities: &specs.LinuxCapabilities{
+				Bounding:    defaltCaps(),
+				Permitted:   defaltCaps(),
+				Inheritable: defaltCaps(),
+				Effective:   defaltCaps(),
+				Ambient:     defaltCaps(),
+			},
+			Rlimits: []specs.LinuxRlimit{
+				{
+					Type: "RLIMIT_NOFILE",
+					Hard: uint64(1024),
+					Soft: uint64(1024),
+				},
+			},
+		},
+		Mounts: []specs.Mount{
+			{
+				Destination: "/proc",
+				Type:        "proc",
+				Source:      "proc",
+			},
+			{
+				Destination: "/dev",
+				Type:        "tmpfs",
+				Source:      "tmpfs",
+				Options:     []string{"nosuid", "strictatime", "mode=755", "size=65536k"},
+			},
+			{
+				Destination: "/dev/pts",
+				Type:        "devpts",
+				Source:      "devpts",
+				Options:     []string{"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620", "gid=5"},
+			},
+			{
+				Destination: "/dev/shm",
+				Type:        "tmpfs",
+				Source:      "shm",
+				Options:     []string{"nosuid", "noexec", "nodev", "mode=1777", "size=65536k"},
+			},
+			{
+				Destination: "/dev/mqueue",
+				Type:        "mqueue",
+				Source:      "mqueue",
+				Options:     []string{"nosuid", "noexec", "nodev"},
+			},
+			{
+				Destination: "/sys",
+				Type:        "sysfs",
+				Source:      "sysfs",
+				Options:     []string{"nosuid", "noexec", "nodev", "ro"},
+			},
+			{
+				Destination: "/run",
+				Type:        "tmpfs",
+				Source:      "tmpfs",
+				Options:     []string{"nosuid", "strictatime", "mode=755", "size=65536k"},
+			},
+			{
+				Destination: "/etc/resolv.conf",
+				Type:        "bind",
+				Source:      "/etc/resolv.conf",
+				Options:     []string{"rbind", "ro"},
+			},
+			{
+				Destination: "/etc/hosts",
+				Type:        "bind",
+				Source:      "/etc/hosts",
+				Options:     []string{"rbind", "ro"},
+			},
+			{
+				Destination: "/etc/localtime",
+				Type:        "bind",
+				Source:      "/etc/localtime",
+				Options:     []string{"rbind", "ro"},
+			},
+		},
+		Linux: &specs.Linux{
+			Resources: &specs.LinuxResources{
+				Devices: []specs.LinuxDeviceCgroup{
+					{
+						Allow:  false,
+						Access: rwm,
+					},
+				},
+			},
+			Namespaces: defaultNamespaces(),
+		},
+	}
+	return s, nil
+}
+
+func WithTTY(s *specs.Spec) error {
+	s.Process.Terminal = true
+	s.Process.Env = append(s.Process.Env, "TERM=xterm")
+	return nil
+}
+
+func WithHostNamespace(ns specs.LinuxNamespaceType) SpecOpts {
+	return func(s *specs.Spec) error {
+		for i, n := range s.Linux.Namespaces {
+			if n.Type == ns {
+				s.Linux.Namespaces = append(s.Linux.Namespaces[:i], s.Linux.Namespaces[i+1:]...)
+				return nil
+			}
+		}
+		return nil
+	}
+}
+
+func WithImage(config *v1.ImageConfig) SpecOpts {
+	return func(s *specs.Spec) error {
+		env := []string{
+			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		}
+		s.Process.Env = append(env, config.Env...)
+		cmd := config.Cmd
+		var (
+			uid, gid uint32
+		)
+		s.Process.Args = append(config.Entrypoint, cmd...)
+		if config.User != "" {
+			parts := strings.Split(config.User, ":")
+			switch len(parts) {
+			case 1:
+				v, err := strconv.ParseUint(parts[0], 0, 10)
+				if err != nil {
+					return err
+				}
+				uid, gid = uint32(v), uint32(v)
+			case 2:
+				v, err := strconv.ParseUint(parts[0], 0, 10)
+				if err != nil {
+					return err
+				}
+				uid = uint32(v)
+				if v, err = strconv.ParseUint(parts[1], 0, 10); err != nil {
+					return err
+				}
+				gid = uint32(v)
+			default:
+				return fmt.Errorf("invalid USER value %s", config.User)
+			}
+		}
+		s.Process.User.UID, s.Process.User.GID = uid, gid
+		cwd := config.WorkingDir
+		if cwd == "" {
+			cwd = "/"
+		}
+		s.Process.Cwd = cwd
+		return nil
+	}
+}

--- a/spec_unix.go
+++ b/spec_unix.go
@@ -185,8 +185,10 @@ func WithHostNamespace(ns specs.LinuxNamespaceType) SpecOpts {
 
 func WithImage(ctx context.Context, i Image) SpecOpts {
 	return func(s *specs.Spec) error {
-		image := i.(*image)
-		store := image.client.ContentStore()
+		var (
+			image = i.(*image)
+			store = image.client.ContentStore()
+		)
 		ic, err := image.i.Config(ctx, store)
 		if err != nil {
 			return err

--- a/spec_unix_test.go
+++ b/spec_unix_test.go
@@ -1,0 +1,56 @@
+package containerd
+
+import "testing"
+
+func TestGenerateSpec(t *testing.T) {
+	s, err := GenerateSpec()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s == nil {
+		t.Fatal("GenerateSpec() returns a nil spec")
+	}
+
+	// check for matching caps
+	defaults := defaltCaps()
+	for _, cl := range [][]string{
+		s.Process.Capabilities.Ambient,
+		s.Process.Capabilities.Bounding,
+		s.Process.Capabilities.Permitted,
+		s.Process.Capabilities.Inheritable,
+		s.Process.Capabilities.Effective,
+	} {
+		for i := 0; i < len(defaults); i++ {
+			if cl[i] != defaults[i] {
+				t.Errorf("cap at %d does not match set %q != %q", i, defaults[i], cl[i])
+			}
+		}
+	}
+
+	// check default namespaces
+	defaultNS := defaultNamespaces()
+	for i, ns := range s.Linux.Namespaces {
+		if defaultNS[i] != ns {
+			t.Errorf("ns at %d does not match set %q != %q", i, defaultNS[i], ns)
+		}
+	}
+
+	// test that we don't have tty set
+	if s.Process.Terminal {
+		t.Error("terminal set on default process")
+	}
+}
+
+func TestSpecWithTTY(t *testing.T) {
+	s, err := GenerateSpec(WithTTY)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !s.Process.Terminal {
+		t.Error("terminal net set WithTTY()")
+	}
+	v := s.Process.Env[len(s.Process.Env)-1]
+	if v != "TERM=xterm" {
+		t.Errorf("xterm not set in env for TTY")
+	}
+}

--- a/spec_windows.go
+++ b/spec_windows.go
@@ -31,7 +31,7 @@ func createDefaultSpec() (*specs.Spec, error) {
 	}, nil
 }
 
-func WithImage(ctx context.Context, i Image) SpecOpts {
+func WithImageConfig(ctx context.Context, i Image) SpecOpts {
 	return func(s *specs.Spec) error {
 		var (
 			image = i.(*image)

--- a/spec_windows.go
+++ b/spec_windows.go
@@ -1,0 +1,79 @@
+package containerd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"runtime"
+
+	"github.com/containerd/containerd/images"
+	"github.com/opencontainers/image-spec/specs-go/v1"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+const pipeRoot = `\\.\pipe`
+
+func createDefaultSpec() (*specs.Spec, error) {
+	return &specs.Spec{
+		Version: specs.Version,
+		Platform: specs.Platform{
+			OS:   runtime.GOOS,
+			Arch: runtime.GOARCH,
+		},
+		Root: specs.Root{},
+		Process: specs.Process{
+			Env: config.Env,
+			ConsoleSize: specs.Box{
+				Width:  80,
+				Height: 20,
+			},
+		},
+	}, nil
+}
+
+func WithImage(ctx context.Context, i Image) SpecOpts {
+	return func(s *specs.Spec) error {
+		var (
+			image = i.(*image)
+			store = image.client.ContentStore()
+		)
+		ic, err := image.i.Config(ctx, store)
+		if err != nil {
+			return err
+		}
+		var (
+			ociimage v1.Image
+			config   v1.ImageConfig
+		)
+		switch ic.MediaType {
+		case v1.MediaTypeImageConfig, images.MediaTypeDockerSchema2Config:
+			r, err := store.Reader(ctx, ic.Digest)
+			if err != nil {
+				return err
+			}
+			if err := json.NewDecoder(r).Decode(&ociimage); err != nil {
+				r.Close()
+				return err
+			}
+			r.Close()
+			config = ociimage.Config
+		default:
+			return fmt.Errorf("unknown image config media type %s", ic.MediaType)
+		}
+		s.Process.Env = config.Env
+		s.Process.Args = append(config.Entrypoint, config.Cmd...)
+		s.Process.User = specs.User{
+			Username: config.User,
+		}
+		return nil
+	}
+}
+
+func WithTTY(width, height int) SpecOpts {
+	func(s *specs.Spec) error {
+		s.Process.Terminal = true
+		s.Process.ConsoleSize.Width = width
+		s.Process.ConsoleSize.Height = height
+		return nil
+	}
+}

--- a/task.go
+++ b/task.go
@@ -160,6 +160,16 @@ func (g *wgCloser) Close() error {
 	return nil
 }
 
+type TaskStatus string
+
+const (
+	Running TaskStatus = "running"
+	Created TaskStatus = "created"
+	Stopped TaskStatus = "stopped"
+	Paused  TaskStatus = "paused"
+	Pausing TaskStatus = "pausing"
+)
+
 type Task interface {
 	Delete(context.Context) (uint32, error)
 	Kill(context.Context, syscall.Signal) error
@@ -167,7 +177,7 @@ type Task interface {
 	Resume(context.Context) error
 	Pid() uint32
 	Start(context.Context) error
-	Status(context.Context) (string, error)
+	Status(context.Context) (TaskStatus, error)
 	Wait(context.Context) (uint32, error)
 }
 
@@ -218,14 +228,14 @@ func (t *task) Resume(ctx context.Context) error {
 	return err
 }
 
-func (t *task) Status(ctx context.Context) (string, error) {
+func (t *task) Status(ctx context.Context) (TaskStatus, error) {
 	r, err := t.client.TaskService().Info(ctx, &execution.InfoRequest{
 		ContainerID: t.containerID,
 	})
 	if err != nil {
 		return "", err
 	}
-	return r.Task.Status.String(), nil
+	return TaskStatus(r.Task.Status.String()), nil
 }
 
 // Wait is a blocking call that will wait for the task to exit and return the exit status

--- a/task.go
+++ b/task.go
@@ -1,0 +1,186 @@
+package containerd
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+
+	"github.com/containerd/containerd/api/services/execution"
+	"github.com/containerd/fifo"
+)
+
+type IO struct {
+	Terminal bool
+	Stdin    string
+	Stdout   string
+	Stderr   string
+
+	closer io.Closer
+}
+
+func (i *IO) Close() error {
+	if i.closer == nil {
+		return nil
+	}
+	return i.closer.Close()
+}
+
+type IOCreation func() (*IO, error)
+
+// STDIO returns an IO implementation to be used for a task
+// that outputs the container's IO as the current processes STDIO
+func STDIO() (*IO, error) {
+	paths, err := fifoPaths()
+	if err != nil {
+		return nil, err
+	}
+	set := &ioSet{
+		in:  os.Stdin,
+		out: os.Stdout,
+		err: os.Stderr,
+	}
+	closer, err := copyIO(paths, set, false)
+	if err != nil {
+		return nil, err
+	}
+	return &IO{
+		Terminal: false,
+		Stdin:    paths.in,
+		Stdout:   paths.out,
+		Stderr:   paths.err,
+		closer:   closer,
+	}, nil
+}
+
+func fifoPaths() (*fifoSet, error) {
+	dir, err := ioutil.TempDir(filepath.Join(os.TempDir(), "containerd"), "")
+	if err != nil {
+		return nil, err
+	}
+	return &fifoSet{
+		dir: dir,
+		in:  filepath.Join(dir, "stdin"),
+		out: filepath.Join(dir, "stdout"),
+		err: filepath.Join(dir, "stderr"),
+	}, nil
+}
+
+type fifoSet struct {
+	// dir is the directory holding the task fifos
+	dir          string
+	in, out, err string
+}
+
+type ioSet struct {
+	in       io.Reader
+	out, err io.Writer
+}
+
+func copyIO(fifos *fifoSet, ioset *ioSet, tty bool) (closer io.Closer, err error) {
+	var (
+		ctx = context.Background()
+		wg  = &sync.WaitGroup{}
+	)
+
+	f, err := fifo.OpenFifo(ctx, fifos.in, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700)
+	if err != nil {
+		return nil, err
+	}
+	defer func(c io.Closer) {
+		if err != nil {
+			c.Close()
+		}
+	}(f)
+	go func(w io.WriteCloser) {
+		io.Copy(w, ioset.in)
+		w.Close()
+	}(f)
+
+	f, err = fifo.OpenFifo(ctx, fifos.out, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700)
+	if err != nil {
+		return nil, err
+	}
+	defer func(c io.Closer) {
+		if err != nil {
+			c.Close()
+		}
+	}(f)
+	wg.Add(1)
+	go func(r io.ReadCloser) {
+		io.Copy(ioset.out, r)
+		r.Close()
+		wg.Done()
+	}(f)
+
+	f, err = fifo.OpenFifo(ctx, fifos.err, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700)
+	if err != nil {
+		return nil, err
+	}
+	defer func(c io.Closer) {
+		if err != nil {
+			c.Close()
+		}
+	}(f)
+
+	if !tty {
+		wg.Add(1)
+		go func(r io.ReadCloser) {
+			io.Copy(ioset.err, r)
+			r.Close()
+			wg.Done()
+		}(f)
+	}
+	return &wgCloser{
+		wg: wg,
+	}, nil
+}
+
+type wgCloser struct {
+	wg *sync.WaitGroup
+}
+
+func (g *wgCloser) Close() error {
+	g.wg.Wait()
+	return nil
+}
+
+type Task struct {
+	client *Client
+
+	io          *IO
+	containerID string
+	pid         uint32
+}
+
+// Pid returns the pid or process id for the task
+func (t *Task) Pid() uint32 {
+	return t.pid
+}
+
+func (t *Task) Kill(ctx context.Context, s os.Signal) error {
+	_, err := t.client.tasks().Kill(ctx, &execution.KillRequest{
+		ContainerID: t.containerID,
+		PidOrAll: &execution.KillRequest_All{
+			All: true,
+		},
+	})
+	return err
+}
+
+// Delete deletes the task and its runtime state
+// it returns the exit status of the task and any errors that were encountered
+// during cleanup
+func (t *Task) Delete(ctx context.Context) (uint32, error) {
+	cerr := t.io.Close()
+	r, err := t.client.tasks().Delete(ctx, &execution.DeleteRequest{
+		t.containerID,
+	})
+	if err != nil {
+		return 255, err
+	}
+	return r.ExitStatus, cerr
+}

--- a/task.go
+++ b/task.go
@@ -189,6 +189,30 @@ func (t *Task) Kill(ctx context.Context, s syscall.Signal) error {
 	return err
 }
 
+func (t *Task) Pause(ctx context.Context) error {
+	_, err := t.client.tasks().Pause(ctx, &execution.PauseRequest{
+		ContainerID: t.containerID,
+	})
+	return err
+}
+
+func (t *Task) Resume(ctx context.Context) error {
+	_, err := t.client.tasks().Resume(ctx, &execution.ResumeRequest{
+		ContainerID: t.containerID,
+	})
+	return err
+}
+
+func (t *Task) Status(ctx context.Context) (string, error) {
+	r, err := t.client.tasks().Info(ctx, &execution.InfoRequest{
+		ContainerID: t.containerID,
+	})
+	if err != nil {
+		return "", err
+	}
+	return r.Task.Status.String(), nil
+}
+
 // Wait is a blocking call that will wait for the task to exit and return the exit status
 func (t *Task) Wait(ctx context.Context) (uint32, error) {
 	events, err := t.client.tasks().Events(ctx, &execution.EventsRequest{})

--- a/task.go
+++ b/task.go
@@ -14,6 +14,8 @@ import (
 	"github.com/containerd/fifo"
 )
 
+const UnknownExitStatus = 255
+
 type IO struct {
 	Terminal bool
 	Stdin    string
@@ -230,12 +232,12 @@ func (t *task) Status(ctx context.Context) (string, error) {
 func (t *task) Wait(ctx context.Context) (uint32, error) {
 	events, err := t.client.TaskService().Events(ctx, &execution.EventsRequest{})
 	if err != nil {
-		return 255, err
+		return UnknownExitStatus, err
 	}
 	for {
 		e, err := events.Recv()
 		if err != nil {
-			return 255, err
+			return UnknownExitStatus, err
 		}
 		if e.Type != taskapi.Event_EXIT {
 			continue
@@ -255,7 +257,7 @@ func (t *task) Delete(ctx context.Context) (uint32, error) {
 		ContainerID: t.containerID,
 	})
 	if err != nil {
-		return 255, err
+		return UnknownExitStatus, err
 	}
 	return r.ExitStatus, cerr
 }

--- a/task.go
+++ b/task.go
@@ -185,14 +185,14 @@ func (t *task) Pid() uint32 {
 }
 
 func (t *task) Start(ctx context.Context) error {
-	_, err := t.client.tasks().Start(ctx, &execution.StartRequest{
+	_, err := t.client.TaskService().Start(ctx, &execution.StartRequest{
 		ContainerID: t.containerID,
 	})
 	return err
 }
 
 func (t *task) Kill(ctx context.Context, s syscall.Signal) error {
-	_, err := t.client.tasks().Kill(ctx, &execution.KillRequest{
+	_, err := t.client.TaskService().Kill(ctx, &execution.KillRequest{
 		Signal:      uint32(s),
 		ContainerID: t.containerID,
 		PidOrAll: &execution.KillRequest_All{
@@ -203,21 +203,21 @@ func (t *task) Kill(ctx context.Context, s syscall.Signal) error {
 }
 
 func (t *task) Pause(ctx context.Context) error {
-	_, err := t.client.tasks().Pause(ctx, &execution.PauseRequest{
+	_, err := t.client.TaskService().Pause(ctx, &execution.PauseRequest{
 		ContainerID: t.containerID,
 	})
 	return err
 }
 
 func (t *task) Resume(ctx context.Context) error {
-	_, err := t.client.tasks().Resume(ctx, &execution.ResumeRequest{
+	_, err := t.client.TaskService().Resume(ctx, &execution.ResumeRequest{
 		ContainerID: t.containerID,
 	})
 	return err
 }
 
 func (t *task) Status(ctx context.Context) (string, error) {
-	r, err := t.client.tasks().Info(ctx, &execution.InfoRequest{
+	r, err := t.client.TaskService().Info(ctx, &execution.InfoRequest{
 		ContainerID: t.containerID,
 	})
 	if err != nil {
@@ -228,7 +228,7 @@ func (t *task) Status(ctx context.Context) (string, error) {
 
 // Wait is a blocking call that will wait for the task to exit and return the exit status
 func (t *task) Wait(ctx context.Context) (uint32, error) {
-	events, err := t.client.tasks().Events(ctx, &execution.EventsRequest{})
+	events, err := t.client.TaskService().Events(ctx, &execution.EventsRequest{})
 	if err != nil {
 		return 255, err
 	}
@@ -251,7 +251,7 @@ func (t *task) Wait(ctx context.Context) (uint32, error) {
 // during cleanup
 func (t *task) Delete(ctx context.Context) (uint32, error) {
 	cerr := t.io.Close()
-	r, err := t.client.tasks().Delete(ctx, &execution.DeleteRequest{
+	r, err := t.client.TaskService().Delete(ctx, &execution.DeleteRequest{
 		ContainerID: t.containerID,
 	})
 	if err != nil {

--- a/task.go
+++ b/task.go
@@ -215,7 +215,7 @@ func (t *Task) Wait(ctx context.Context) (uint32, error) {
 func (t *Task) Delete(ctx context.Context) (uint32, error) {
 	cerr := t.io.Close()
 	r, err := t.client.tasks().Delete(ctx, &execution.DeleteRequest{
-		t.containerID,
+		ContainerID: t.containerID,
 	})
 	if err != nil {
 		return 255, err


### PR DESCRIPTION
This adds the initial containerd client package that consumers will use when working with containerd.  It also adds a start to the integration tests for the daemon based on the client.

You can see a full, working example of the client here:

```go
package main

import (
	"context"
	"fmt"
	"log"
	"syscall"
	"time"

	"github.com/containerd/containerd"
)

const (
	address = "/run/containerd/containerd.sock"
	redis   = "docker.io/library/redis:alpine"
)

func main() {
	if err := runRedis(); err != nil {
		log.Fatal(err)
	}
}

func runRedis() error {
	ctx := context.Background()

        // WithNamespace is a placeholder while we get namespace support in the daemon
	client, err := containerd.New(address, containerd.WithNamespace("scripts"))
	if err != nil {
		return err
	}
	defer client.Close()

	log.Printf("pulling image %s...\n", redis)
	// make sure we unpack the image for use after the pull
	image, err := client.Pull(ctx, redis, containerd.WithPullUnpack)
	if err != nil {
		return err
	}
	log.Println("finished pulling image...")

	spec, err := containerd.GenerateSpec(containerd.WithImage(ctx, image))
	if err != nil {
		return err
	}
	log.Println("generated spec from image...")

	container, err := client.NewContainer(ctx, "redis-master", spec, containerd.WithNewRootFS("redis-master", image))
	if err != nil {
		return err
	}
	defer container.Delete(ctx)
	log.Println("created new container...")

	// lets get the container's stdio in our current process
	task, err := container.NewTask(ctx, containerd.Stdio)
	if err != nil {
		return err
	}
	defer task.Delete(ctx)
	fmt.Printf("container pid %d\n", task.Pid())

	// you can do network namespace setup here or whatever you want without hooks

	if err := task.Start(ctx); err != nil {
		return err
	}

	// let it run for 5 seconds and then kill it
	go func() {
		time.Sleep(5 * time.Second)
		log.Println("killing task...")
		if err := task.Kill(ctx, syscall.SIGTERM); err != nil {
			log.Println(err)
		}
	}()

	status, err := task.Wait(ctx)
	if err != nil {
		return err
	}
	fmt.Printf("task exited with status %d\n", status)

	// all done
	return nil
}
```