### PR TITLE
Updates the execution service to include ContainerID in tasks

### DIFF
--- a/cmd/ctr/run.go
+++ b/cmd/ctr/run.go
@@ -241,7 +241,7 @@ var runCommand = cli.Command{
 			}
 		}
 
-		createContainer, err := newCreateContainerRequest(context, id, id, spec)
+		createContainer, err := newCreateContainerRequest(context, id, id, ref, spec)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/run_unix.go
+++ b/cmd/ctr/run_unix.go
@@ -282,10 +282,11 @@ func newContainerSpec(context *cli.Context, config *ocispec.ImageConfig, imageRe
 	return json.Marshal(s)
 }
 
-func newCreateContainerRequest(context *cli.Context, id, snapshot string, spec []byte) (*containersapi.CreateContainerRequest, error) {
+func newCreateContainerRequest(context *cli.Context, id, snapshot, image string, spec []byte) (*containersapi.CreateContainerRequest, error) {
 	create := &containersapi.CreateContainerRequest{
 		Container: containersapi.Container{
-			ID: id,
+			ID:    id,
+			Image: image,
 			Spec: &protobuf.Any{
 				TypeUrl: specs.Version,
 				Value:   spec,

--- a/cmd/ctr/run_windows.go
+++ b/cmd/ctr/run_windows.go
@@ -139,10 +139,11 @@ func newContainerSpec(context *cli.Context, config *ocispec.ImageConfig, imageRe
 	return json.Marshal(rtSpec)
 }
 
-func newCreateContainerRequest(context *cli.Context, id, snapshot string, spec []byte) (*containersapi.CreateContainerRequest, error) {
+func newCreateContainerRequest(context *cli.Context, id, snapshot, image string, spec []byte) (*containersapi.CreateContainerRequest, error) {
 	create := &containersapi.CreateContainerRequest{
 		Container: containersapi.Container{
-			ID: id,
+			ID:    id,
+			Image: image,
 			Spec: &protobuf.Any{
 				TypeUrl: specs.Version,
 				Value:   spec,

--- a/linux/task.go
+++ b/linux/task.go
@@ -41,6 +41,7 @@ func newTask(id string, spec []byte, shim shim.ShimClient) *Task {
 
 func (c *Task) Info() plugin.TaskInfo {
 	return plugin.TaskInfo{
+		ID:          c.containerID,
 		ContainerID: c.containerID,
 		Runtime:     runtimeName,
 		Spec:        c.spec,

--- a/services/execution/service.go
+++ b/services/execution/service.go
@@ -220,9 +220,10 @@ func taskFromContainerd(ctx context.Context, c plugin.Task) (*task.Task, error) 
 		log.G(ctx).WithField("status", state.Status()).Warn("unknown status")
 	}
 	return &task.Task{
-		ID:     c.Info().ID,
-		Pid:    state.Pid(),
-		Status: status,
+		ID:          c.Info().ID,
+		ContainerID: c.Info().ContainerID,
+		Pid:         state.Pid(),
+		Status:      status,
 		Spec: &protobuf.Any{
 			TypeUrl: specs.Version,
 			Value:   c.Info().Spec,


### PR DESCRIPTION
This updates the execution service to include `ContainerID` in the task info.  This also updates the `ctr run` request to include the image ID so it is in the container config to be properly returned.

This makes `ctr list` happy again:

```
ID        IMAGE                             PID       STATUS
shell     docker.io/library/alpine:latest   3509      RUNNING
```

Fixes #906 
Fixes #907