### PR TITLE
Move push handler from dist to remotes

### DIFF
--- a/images/handlers.go
+++ b/images/handlers.go
@@ -11,9 +11,17 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var SkipDesc = fmt.Errorf("skip descriptor")
+var (
+	// SkipDesc is used to skip processing of a descriptor and
+	// its descendants.
+	SkipDesc = fmt.Errorf("skip descriptor")
 
-var StopHandler = fmt.Errorf("stop handler")
+	// StopHandler is used to signify that the descriptor
+	// has been handled and should not be handled further.
+	// This applies only to a single descriptor in a handler
+	// chain and does not apply to descendant descriptors.
+	StopHandler = fmt.Errorf("stop handler")
+)
 
 type Handler interface {
 	Handle(ctx context.Context, desc ocispec.Descriptor) (subdescs []ocispec.Descriptor, err error)


### PR DESCRIPTION
Simple refactor to make integration with the client easier.

Addresses feedback related to `var` for the stop handler, added documentation to clarify those types.