### PR TITLE
[v0.2.x] containerd: ignore SIGPIPE

### DIFF
--- a/containerd/main.go
+++ b/containerd/main.go
@@ -208,6 +208,8 @@ func daemon(context *cli.Context) error {
 	}
 	for ss := range s {
 		switch ss {
+		case syscall.SIGPIPE:
+			continue
 		default:
 			logrus.Infof("stopping containerd after receiving %s", ss)
 			server.Stop()


### PR DESCRIPTION
Fix https://github.com/containerd/containerd/issues/580

As already stated in https://github.com/moby/moby/issues/19728, this is meant as a temporary workaround cause it's far worse to have dockerd/containerd silently go away. We have people working on a proper fix though.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>