### PR TITLE
ctr shim exec: fix cli flag

### DIFF
--- a/cmd/ctr/shim.go
+++ b/cmd/ctr/shim.go
@@ -207,6 +207,10 @@ var shimExecCommand = cli.Command{
 			Name:  "cwd",
 			Usage: "current working directory",
 		},
+		cli.StringFlag{
+			Name:  "spec",
+			Usage: "runtime spec",
+		},
 	),
 	Action: func(context *cli.Context) error {
 		service, err := getShimService()


### PR DESCRIPTION
`--spec` was required but not defined in the CLI.


Note that exec is still broken (https://github.com/containerd/containerd/issues/869)


Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>