### PR TITLE
Fix windows build for client

### DIFF
--- a/client_unix.go
+++ b/client_unix.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package containerd
 
 import (

--- a/io.go
+++ b/io.go
@@ -2,15 +2,11 @@ package containerd
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
-	"syscall"
-
-	"github.com/containerd/fifo"
 )
 
 type IO struct {
@@ -109,65 +105,6 @@ type fifoSet struct {
 type ioSet struct {
 	in       io.Reader
 	out, err io.Writer
-}
-
-func copyIO(fifos *fifoSet, ioset *ioSet, tty bool) (closer io.Closer, err error) {
-	var (
-		f   io.ReadWriteCloser
-		ctx = context.Background()
-		wg  = &sync.WaitGroup{}
-	)
-
-	if f, err = fifo.OpenFifo(ctx, fifos.in, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
-		return nil, err
-	}
-	defer func(c io.Closer) {
-		if err != nil {
-			c.Close()
-		}
-	}(f)
-	go func(w io.WriteCloser) {
-		io.Copy(w, ioset.in)
-		w.Close()
-	}(f)
-
-	if f, err = fifo.OpenFifo(ctx, fifos.out, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
-		return nil, err
-	}
-	defer func(c io.Closer) {
-		if err != nil {
-			c.Close()
-		}
-	}(f)
-	wg.Add(1)
-	go func(r io.ReadCloser) {
-		io.Copy(ioset.out, r)
-		r.Close()
-		wg.Done()
-	}(f)
-
-	if f, err = fifo.OpenFifo(ctx, fifos.err, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
-		return nil, err
-	}
-	defer func(c io.Closer) {
-		if err != nil {
-			c.Close()
-		}
-	}(f)
-
-	if !tty {
-		wg.Add(1)
-		go func(r io.ReadCloser) {
-			io.Copy(ioset.err, r)
-			r.Close()
-			wg.Done()
-		}(f)
-	}
-
-	return &wgCloser{
-		wg:  wg,
-		dir: fifos.dir,
-	}, nil
 }
 
 type wgCloser struct {

--- a/io_unix.go
+++ b/io_unix.go
@@ -1,0 +1,71 @@
+// +build !windows
+
+package containerd
+
+import (
+	"context"
+	"io"
+	"sync"
+	"syscall"
+
+	"github.com/containerd/fifo"
+)
+
+func copyIO(fifos *fifoSet, ioset *ioSet, tty bool) (closer io.Closer, err error) {
+	var (
+		f   io.ReadWriteCloser
+		ctx = context.Background()
+		wg  = &sync.WaitGroup{}
+	)
+
+	if f, err = fifo.OpenFifo(ctx, fifos.in, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
+		return nil, err
+	}
+	defer func(c io.Closer) {
+		if err != nil {
+			c.Close()
+		}
+	}(f)
+	go func(w io.WriteCloser) {
+		io.Copy(w, ioset.in)
+		w.Close()
+	}(f)
+
+	if f, err = fifo.OpenFifo(ctx, fifos.out, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
+		return nil, err
+	}
+	defer func(c io.Closer) {
+		if err != nil {
+			c.Close()
+		}
+	}(f)
+	wg.Add(1)
+	go func(r io.ReadCloser) {
+		io.Copy(ioset.out, r)
+		r.Close()
+		wg.Done()
+	}(f)
+
+	if f, err = fifo.OpenFifo(ctx, fifos.err, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
+		return nil, err
+	}
+	defer func(c io.Closer) {
+		if err != nil {
+			c.Close()
+		}
+	}(f)
+
+	if !tty {
+		wg.Add(1)
+		go func(r io.ReadCloser) {
+			io.Copy(ioset.err, r)
+			r.Close()
+			wg.Done()
+		}(f)
+	}
+
+	return &wgCloser{
+		wg:  wg,
+		dir: fifos.dir,
+	}, nil
+}

--- a/io_windows.go
+++ b/io_windows.go
@@ -1,0 +1,93 @@
+package containerd
+
+import (
+	"io"
+	"net"
+	"sync"
+
+	winio "github.com/Microsoft/go-winio"
+	"github.com/containerd/containerd/log"
+	"github.com/pkg/errors"
+)
+
+func copyIO(fifos *fifoSet, ioset *ioSet, tty bool) (closer io.Closer, err error) {
+	var wg sync.WaitGroup
+
+	if fifos.in != "" {
+		l, err := winio.ListenPipe(fifos.in, nil)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create stdin pipe %s", fifos.in)
+		}
+		defer func(l net.Listener) {
+			if err != nil {
+				l.Close()
+			}
+		}(l)
+
+		go func() {
+			c, err := l.Accept()
+			if err != nil {
+				log.L.WithError(err).Errorf("failed to accept stdin connection on %s", fifos.in)
+				return
+			}
+			io.Copy(c, ioset.in)
+			c.Close()
+			l.Close()
+		}()
+	}
+
+	if fifos.out != "" {
+		l, err := winio.ListenPipe(fifos.out, nil)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create stdin pipe %s", fifos.out)
+		}
+		defer func(l net.Listener) {
+			if err != nil {
+				l.Close()
+			}
+		}(l)
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c, err := l.Accept()
+			if err != nil {
+				log.L.WithError(err).Errorf("failed to accept stdout connection on %s", fifos.out)
+				return
+			}
+			io.Copy(ioset.out, c)
+			c.Close()
+			l.Close()
+		}()
+	}
+
+	if !tty && fifos.err != "" {
+		l, err := winio.ListenPipe(fifos.err, nil)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create stderr pipe %s", fifos.err)
+		}
+		defer func(l net.Listener) {
+			if err != nil {
+				l.Close()
+			}
+		}(l)
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c, err := l.Accept()
+			if err != nil {
+				log.L.WithError(err).Errorf("failed to accept stderr connection on %s", fifos.err)
+				return
+			}
+			io.Copy(ioset.err, c)
+			c.Close()
+			l.Close()
+		}()
+	}
+
+	return &wgCloser{
+		wg:  &wg,
+		dir: fifos.dir,
+	}, nil
+}

--- a/spec_unix.go
+++ b/spec_unix.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package containerd
 
 import (

--- a/spec_unix_test.go
+++ b/spec_unix_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package containerd
 
 import "testing"

--- a/spec_windows.go
+++ b/spec_windows.go
@@ -22,7 +22,6 @@ func createDefaultSpec() (*specs.Spec, error) {
 		},
 		Root: specs.Root{},
 		Process: specs.Process{
-			Env: config.Env,
 			ConsoleSize: specs.Box{
 				Width:  80,
 				Height: 20,
@@ -70,10 +69,10 @@ func WithImageConfig(ctx context.Context, i Image) SpecOpts {
 }
 
 func WithTTY(width, height int) SpecOpts {
-	func(s *specs.Spec) error {
+	return func(s *specs.Spec) error {
 		s.Process.Terminal = true
-		s.Process.ConsoleSize.Width = width
-		s.Process.ConsoleSize.Height = height
+		s.Process.ConsoleSize.Width = uint(width)
+		s.Process.ConsoleSize.Height = uint(height)
 		return nil
 	}
 }


### PR DESCRIPTION
Move io copy logic from ctr utils to io_windows.go. Fix compilation errors on Windows.

Additonally, ensure all packages can be built in Travis, even those not yet imported by binaries.
