### PR TITLE
Use conf value when killing loaded container

### DIFF
--- a/linux/runtime.go
+++ b/linux/runtime.go
@@ -274,8 +274,8 @@ func (r *Runtime) loadContainer(path string) (*Task, error) {
 func (r *Runtime) killContainer(ctx context.Context, id string) {
 	log.G(ctx).Debug("terminating container after failed load")
 	runtime := &runc.Runc{
-		// TODO: get Command provided for initial container creation
-		//	Command:      r.Runtime,
+		// TODO: should we get Command provided for initial container creation?
+		Command:      r.runtime,
 		LogFormat:    runc.JSON,
 		PdeathSignal: unix.SIGKILL,
 	}


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

---

I'm still not sure what to do about that `TODO`. Should we store the runtime path into the Container object?