### PR TITLE
Update dist pull to use client

### DIFF
--- a/cmd/dist/pull.go
+++ b/cmd/dist/pull.go
@@ -1,23 +1,10 @@
 package main
 
 import (
-	"context"
-	"os"
-	"text/tabwriter"
-	"time"
+	"fmt"
 
-	diffapi "github.com/containerd/containerd/api/services/diff"
-	snapshotapi "github.com/containerd/containerd/api/services/snapshot"
-	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
-	"github.com/containerd/containerd/progress"
-	"github.com/containerd/containerd/remotes"
-	"github.com/containerd/containerd/rootfs"
-	diffservice "github.com/containerd/containerd/services/diff"
-	snapshotservice "github.com/containerd/containerd/services/snapshot"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/urfave/cli"
-	"golang.org/x/sync/errgroup"
 )
 
 var pullCommand = cli.Command{
@@ -42,175 +29,17 @@ command. As part of this process, we do the following:
 		ctx, cancel := appContext(clicontext)
 		defer cancel()
 
-		cs, err := resolveContentStore(clicontext)
+		img, err := fetch(ctx, ref, clicontext)
 		if err != nil {
 			return err
 		}
 
-		imageStore, err := resolveImageStore(clicontext)
-		if err != nil {
-			return err
-		}
+		log.G(ctx).WithField("image", ref).Debug("unpacking")
 
-		resolver, err := getResolver(ctx, clicontext)
-		if err != nil {
-			return err
-		}
-		ongoing := newJobs()
-
-		eg, ctx := errgroup.WithContext(ctx)
-
-		var resolvedImageName string
-		resolved := make(chan struct{})
-		eg.Go(func() error {
-			ongoing.add(ref)
-			name, desc, err := resolver.Resolve(ctx, ref)
-			if err != nil {
-				log.G(ctx).WithError(err).Error("failed to resolve")
-				return err
-			}
-			fetcher, err := resolver.Fetcher(ctx, name)
-			if err != nil {
-				return err
-			}
-
-			log.G(ctx).WithField("image", name).Debug("fetching")
-			resolvedImageName = name
-			close(resolved)
-
-			eg.Go(func() error {
-				return imageStore.Put(ctx, name, desc)
-			})
-
-			return images.Dispatch(ctx,
-				images.Handlers(images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-					ongoing.add(remotes.MakeRefKey(ctx, desc))
-					return nil, nil
-				}),
-					remotes.FetchHandler(cs, fetcher),
-					images.ChildrenHandler(cs)),
-				desc)
-
-		})
-
-		errs := make(chan error)
-		go func() {
-			defer close(errs)
-			errs <- eg.Wait()
-		}()
-
-		defer func() {
-			// we need new ctx here, since we run on return.
-			ctx, cancel := appContext(clicontext)
-			defer cancel()
-			image, err := imageStore.Get(ctx, resolvedImageName)
-			if err != nil {
-				log.G(ctx).WithError(err).Fatal("failed to get image")
-			}
-
-			layers, err := getImageLayers(ctx, image, cs)
-			if err != nil {
-				log.G(ctx).WithError(err).Fatal("failed to get rootfs layers")
-			}
-
-			conn, err := connectGRPC(clicontext)
-			if err != nil {
-				log.G(ctx).Fatal(err)
-			}
-			snapshotter := snapshotservice.NewSnapshotterFromClient(snapshotapi.NewSnapshotClient(conn))
-			applier := diffservice.NewDiffServiceFromClient(diffapi.NewDiffClient(conn))
-
-			log.G(ctx).Info("unpacking rootfs")
-
-			chainID, err := rootfs.ApplyLayers(ctx, layers, snapshotter, applier)
-			if err != nil {
-				log.G(ctx).Fatal(err)
-			}
-
-			log.G(ctx).Infof("Unpacked chain id: %s", chainID)
-		}()
-
-		var (
-			ticker = time.NewTicker(100 * time.Millisecond)
-			fw     = progress.NewWriter(os.Stdout)
-			start  = time.Now()
-			done   bool
-		)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ticker.C:
-				fw.Flush()
-
-				tw := tabwriter.NewWriter(fw, 1, 8, 1, ' ', 0)
-				js := ongoing.jobs()
-				statuses := map[string]statusInfo{}
-
-				activeSeen := map[string]struct{}{}
-				if !done {
-					active, err := cs.Status(ctx, "")
-					if err != nil {
-						log.G(ctx).WithError(err).Error("active check failed")
-						continue
-					}
-					// update status of active entries!
-					for _, active := range active {
-						statuses[active.Ref] = statusInfo{
-							Ref:       active.Ref,
-							Status:    "downloading",
-							Offset:    active.Offset,
-							Total:     active.Total,
-							StartedAt: active.StartedAt,
-							UpdatedAt: active.UpdatedAt,
-						}
-						activeSeen[active.Ref] = struct{}{}
-					}
-				}
-
-				// now, update the items in jobs that are not in active
-				for _, j := range js {
-					if _, ok := activeSeen[j]; ok {
-						continue
-					}
-					status := "done"
-
-					if j == ref {
-						select {
-						case <-resolved:
-							status = "resolved"
-						default:
-							status = "resolving"
-						}
-					}
-
-					statuses[j] = statusInfo{
-						Ref:    j,
-						Status: status, // for now!
-					}
-				}
-
-				var ordered []statusInfo
-				for _, j := range js {
-					ordered = append(ordered, statuses[j])
-				}
-
-				display(tw, ordered, start)
-				tw.Flush()
-
-				if done {
-					fw.Flush()
-					return nil
-				}
-			case err := <-errs:
-				if err != nil {
-					return err
-				}
-				done = true
-			case <-ctx.Done():
-				done = true // allow ui to update once more
-			}
-		}
-
+		// TODO: Show unpack status
+		fmt.Printf("unpacking %s...", img.Target().Digest)
+		err = img.Unpack(ctx)
+		fmt.Println("done")
+		return err
 	},
 }

--- a/image.go
+++ b/image.go
@@ -1,9 +1,22 @@
 package containerd
 
-import "github.com/containerd/containerd/images"
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/rootfs"
+	"github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
 
 type Image interface {
 	Name() string
+	Target() ocispec.Descriptor
+
+	Unpack(context.Context) error
 }
 
 var _ = (Image)(&image{})
@@ -16,4 +29,48 @@ type image struct {
 
 func (i *image) Name() string {
 	return i.i.Name
+}
+
+func (i *image) Target() ocispec.Descriptor {
+	return i.i.Target
+}
+
+func (i *image) Unpack(ctx context.Context) error {
+	layers, err := i.getLayers(ctx)
+	if err != nil {
+		return err
+	}
+	if _, err := rootfs.ApplyLayers(ctx, layers, i.client.SnapshotService(), i.client.DiffService()); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (i *image) getLayers(ctx context.Context) ([]rootfs.Layer, error) {
+	cs := i.client.ContentStore()
+	p, err := content.ReadBlob(ctx, cs, i.i.Target.Digest)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read manifest blob")
+	}
+	var manifest v1.Manifest
+	if err := json.Unmarshal(p, &manifest); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal manifest")
+	}
+	diffIDs, err := i.i.RootFS(ctx, cs)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to resolve rootfs")
+	}
+	if len(diffIDs) != len(manifest.Layers) {
+		return nil, errors.Errorf("mismatched image rootfs and manifest layers")
+	}
+	layers := make([]rootfs.Layer, len(diffIDs))
+	for i := range diffIDs {
+		layers[i].Diff = v1.Descriptor{
+			// TODO: derive media type from compressed type
+			MediaType: v1.MediaTypeImageLayer,
+			Digest:    diffIDs[i],
+		}
+		layers[i].Blob = manifest.Layers[i]
+	}
+	return layers, nil
 }


### PR DESCRIPTION
A few different changes involved with this update

- Replaced pull unpacker with boolean to call unpack
- Added unpack and target to image type
- Updated progress logic for pull, now handles exists, non-started and correctly shows total and rate
- Added list images to client
- Updated rootfs unpacker to use client

