### PR TITLE
Copy byte slices contained in bolt db objects

### DIFF
--- a/metadata/containers.go
+++ b/metadata/containers.go
@@ -120,7 +120,8 @@ func readContainer(container *containers.Container, bkt *bolt.Bucket) error {
 		case string(bucketKeyRuntime):
 			container.Runtime = string(v)
 		case string(bucketKeySpec):
-			container.Spec = v
+			container.Spec = make([]byte, len(v))
+			copy(container.Spec, v)
 		case string(bucketKeyRootFS):
 			container.RootFS = string(v)
 		case string(bucketKeyLabels):


### PR DESCRIPTION
Copy container.Spec when reading.

In `execution.Create()` I was seeing `opts.Spec` unexpectedly becoming a slice
full of nulls instead of the expected data (often this occurred at the
`s.mu.Lock()`)

https://github.com/boltdb/bolt#caveats--limitations says:

> Byte slices returned from Bolt are only valid during a transaction. Once the
> transaction has been committed or rolled back then the memory they point to
> can be reused by a new page or can be unmapped from virtual memory and you'll
> see an unexpected fault address panic when accessing it.

Since `opts.Spec` = `container.Spec` where the latter is a byte slice returned
from Bolt we must copy it. The best place to do this is when reading, so that
callers need not worry about this.

I also checked metadata/*.go for similar issues and found no others.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>
