### PR TITLE
service/content: fix logic error on storing extra data

### DIFF
--- a/services/content/reader.go
+++ b/services/content/reader.go
@@ -34,11 +34,9 @@ func (rr *remoteReader) Read(p []byte) (n int, err error) {
 		n += copied
 		p = p[copied:]
 
-		if copied < len(p) {
-			continue
+		if len(p) == 0 {
+			rr.extra = append(rr.extra, resp.Data[copied:]...)
 		}
-
-		rr.extra = append(rr.extra, resp.Data[copied:]...)
 	}
 
 	return


### PR DESCRIPTION
Clarify logic that extra data is stored when the target buffer is full. Existing logic allows for extra data to be stored even when more data will be read into buffer when the remaining space is less than what was copied from the last receive.
