### PR TITLE
Set the remote writer ref on writer creation

### DIFF
--- a/services/content/store.go
+++ b/services/content/store.go
@@ -115,6 +115,7 @@ func (rs *remoteStore) Writer(ctx context.Context, ref string, size int64, expec
 	}
 
 	return &remoteWriter{
+		ref:    ref,
 		client: wrclient,
 		offset: offset,
 	}, nil

--- a/services/content/writer.go
+++ b/services/content/writer.go
@@ -16,14 +16,6 @@ type remoteWriter struct {
 	digest digest.Digest
 }
 
-func newRemoteWriter(client contentapi.Content_WriteClient, ref string, offset int64) (*remoteWriter, error) {
-	return &remoteWriter{
-		ref:    ref,
-		client: client,
-		offset: offset,
-	}, nil
-}
-
 // send performs a synchronous req-resp cycle on the client.
 func (rw *remoteWriter) send(req *contentapi.WriteRequest) (*contentapi.WriteResponse, error) {
 	if err := rw.client.Send(req); err != nil {


### PR DESCRIPTION
Ensures that status calls to the remote writer correctly sets the ref.

Fixes an error message which shows the reference as empty