### PR TITLE
Remove tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ language: go
 
 go:
   - 1.8.x
-  - tip
 
 go_import_path: github.com/containerd/containerd
 


### PR DESCRIPTION
Go tip test runners are 2x as slow as everything else.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>