### PR TITLE
Namespace tasks within runtime

### DIFF
--- a/linux/runtime.go
+++ b/linux/runtime.go
@@ -5,12 +5,14 @@ package linux
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/containerd/containerd/api/services/shim"
@@ -23,6 +25,11 @@ import (
 	runc "github.com/containerd/go-runc"
 
 	"golang.org/x/sys/unix"
+)
+
+var (
+	ErrTaskNotExists     = errors.New("task does not exist")
+	ErrTaskAlreadyExists = errors.New("task already exists")
 )
 
 const (
@@ -54,6 +61,71 @@ type Config struct {
 	NoShim bool `toml:"no_shim,omitempty"`
 }
 
+func newTaskList() *taskList {
+	return &taskList{
+		tasks: make(map[string]map[string]*Task),
+	}
+}
+
+type taskList struct {
+	mu    sync.Mutex
+	tasks map[string]map[string]*Task
+}
+
+func (l *taskList) get(ctx context.Context, id string) (*Task, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	namespace, err := namespaces.NamespaceRequired(ctx)
+	if err != nil {
+		return nil, err
+	}
+	tasks, ok := l.tasks[namespace]
+	if !ok {
+		return nil, ErrTaskNotExists
+	}
+	t, ok := tasks[id]
+	if !ok {
+		return nil, ErrTaskNotExists
+	}
+	return t, nil
+}
+
+func (l *taskList) add(ctx context.Context, t *Task) error {
+	namespace, err := namespaces.NamespaceRequired(ctx)
+	if err != nil {
+		return err
+	}
+	return l.addWithNamespace(namespace, t)
+}
+
+func (l *taskList) addWithNamespace(namespace string, t *Task) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	id := t.containerID
+	if _, ok := l.tasks[namespace]; !ok {
+		l.tasks[namespace] = make(map[string]*Task)
+	}
+	if _, ok := l.tasks[namespace][id]; ok {
+		return ErrTaskAlreadyExists
+	}
+	l.tasks[namespace][id] = t
+	return nil
+}
+
+func (l *taskList) delete(ctx context.Context, t *Task) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	namespace, err := namespaces.NamespaceRequired(ctx)
+	if err != nil {
+		return
+	}
+	tasks, ok := l.tasks[namespace]
+	if ok {
+		delete(tasks, t.containerID)
+	}
+}
+
 func New(ic *plugin.InitContext) (interface{}, error) {
 	path := filepath.Join(ic.State, runtimeName)
 	if err := os.MkdirAll(path, 0700); err != nil {
@@ -70,9 +142,20 @@ func New(ic *plugin.InitContext) (interface{}, error) {
 		eventsContext: c,
 		eventsCancel:  cancel,
 		monitor:       ic.Monitor,
+		tasks:         newTaskList(),
 	}
 	// set the events output for a monitor if it generates events
 	ic.Monitor.Events(r.events)
+	tasks, err := r.loadAllTasks(ic.Context)
+	if err != nil {
+		return nil, err
+	}
+	for _, t := range tasks {
+		if err := r.tasks.addWithNamespace(t.namespace, t); err != nil {
+			return nil, err
+		}
+	}
+	// load all tasks from disk
 	return r, nil
 }
 
@@ -86,6 +169,7 @@ type Runtime struct {
 	eventsContext context.Context
 	eventsCancel  func()
 	monitor       plugin.TaskMonitor
+	tasks         *taskList
 }
 
 func (r *Runtime) Create(ctx context.Context, id string, opts plugin.CreateOpts) (t plugin.Task, err error) {
@@ -134,6 +218,9 @@ func (r *Runtime) Create(ctx context.Context, id string, opts plugin.CreateOpts)
 		return nil, err
 	}
 	c := newTask(id, namespace, opts.Spec, s)
+	if err := r.tasks.add(ctx, c); err != nil {
+		return nil, err
+	}
 	// after the task is created, add it to the monitor
 	if err = r.monitor.Monitor(c); err != nil {
 		return nil, err
@@ -160,6 +247,7 @@ func (r *Runtime) Delete(ctx context.Context, c plugin.Task) (*plugin.Exit, erro
 		return nil, err
 	}
 	lc.shim.Exit(ctx, &shim.ExitRequest{})
+	r.tasks.delete(ctx, lc)
 	return &plugin.Exit{
 		Status:    rsp.ExitStatus,
 		Timestamp: rsp.ExitedAt,
@@ -167,11 +255,27 @@ func (r *Runtime) Delete(ctx context.Context, c plugin.Task) (*plugin.Exit, erro
 }
 
 func (r *Runtime) Tasks(ctx context.Context) ([]plugin.Task, error) {
-	dir, err := ioutil.ReadDir(r.root)
+	namespace, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {
 		return nil, err
 	}
 	var o []plugin.Task
+	tasks, ok := r.tasks.tasks[namespace]
+	if !ok {
+		return o, nil
+	}
+	for _, t := range tasks {
+		o = append(o, t)
+	}
+	return o, nil
+}
+
+func (r *Runtime) loadAllTasks(ctx context.Context) ([]*Task, error) {
+	dir, err := ioutil.ReadDir(r.root)
+	if err != nil {
+		return nil, err
+	}
+	var o []*Task
 	for _, fi := range dir {
 		if !fi.IsDir() {
 			continue
@@ -186,19 +290,15 @@ func (r *Runtime) Tasks(ctx context.Context) ([]plugin.Task, error) {
 }
 
 func (r *Runtime) Get(ctx context.Context, id string) (plugin.Task, error) {
-	namespace, err := namespaces.NamespaceRequired(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return r.loadTask(ctx, filepath.Join(r.root, namespace, id))
+	return r.tasks.get(ctx, id)
 }
 
-func (r *Runtime) loadTasks(ctx context.Context, ns string) ([]plugin.Task, error) {
+func (r *Runtime) loadTasks(ctx context.Context, ns string) ([]*Task, error) {
 	dir, err := ioutil.ReadDir(filepath.Join(r.root, ns))
 	if err != nil {
 		return nil, err
 	}
-	var o []plugin.Task
+	var o []*Task
 	for _, fi := range dir {
 		if !fi.IsDir() {
 			continue
@@ -206,7 +306,7 @@ func (r *Runtime) loadTasks(ctx context.Context, ns string) ([]plugin.Task, erro
 		id := fi.Name()
 		// TODO: optimize this if it is call frequently to list all containers
 		// i.e. dont' reconnect to the the shim's ever time
-		c, err := r.loadTask(ctx, filepath.Join(r.root, ns, id))
+		c, err := r.loadTask(ns, filepath.Join(r.root, ns, id))
 		if err != nil {
 			log.G(ctx).WithError(err).Warnf("failed to load container %s/%s", ns, id)
 			// if we fail to load the container, connect to the shim, make sure if the shim has
@@ -291,11 +391,7 @@ func (r *Runtime) deleteBundle(namespace, id string) error {
 	return os.RemoveAll(filepath.Join(r.root, namespace, id))
 }
 
-func (r *Runtime) loadTask(ctx context.Context, path string) (*Task, error) {
-	namespace, err := namespaces.NamespaceRequired(ctx)
-	if err != nil {
-		return nil, err
-	}
+func (r *Runtime) loadTask(namespace, path string) (*Task, error) {
 	id := filepath.Base(path)
 	s, err := loadShim(path, namespace, r.remote)
 	if err != nil {

--- a/linux/task.go
+++ b/linux/task.go
@@ -16,13 +16,15 @@ type Task struct {
 	containerID string
 	spec        []byte
 	shim        shim.ShimClient
+	namespace   string
 }
 
-func newTask(id string, spec []byte, shim shim.ShimClient) *Task {
+func newTask(id, namespace string, spec []byte, shim shim.ShimClient) *Task {
 	return &Task{
 		containerID: id,
 		shim:        shim,
 		spec:        spec,
+		namespace:   namespace,
 	}
 }
 
@@ -32,6 +34,7 @@ func (c *Task) Info() plugin.TaskInfo {
 		ContainerID: c.containerID,
 		Runtime:     runtimeName,
 		Spec:        c.spec,
+		Namespace:   c.namespace,
 	}
 }
 

--- a/metrics/cgroups/cgroups.go
+++ b/metrics/cgroups/cgroups.go
@@ -3,6 +3,7 @@
 package cgroups
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/containerd/cgroups"
@@ -45,8 +46,12 @@ type cgroupsMonitor struct {
 	events    chan<- *plugin.Event
 }
 
+func getID(t plugin.Task) string {
+	return fmt.Sprintf("%s-%s", t.Info().ID, t.Info().Namespace)
+}
+
 func (m *cgroupsMonitor) Monitor(c plugin.Task) error {
-	id := c.Info().ID
+	id := getID(c)
 	state, err := c.State(m.context)
 	if err != nil {
 		return err
@@ -62,7 +67,7 @@ func (m *cgroupsMonitor) Monitor(c plugin.Task) error {
 }
 
 func (m *cgroupsMonitor) Stop(c plugin.Task) error {
-	m.collector.Remove(c.Info().ID)
+	m.collector.Remove(getID(c))
 	return nil
 }
 

--- a/metrics/cgroups/cgroups.go
+++ b/metrics/cgroups/cgroups.go
@@ -47,7 +47,7 @@ type cgroupsMonitor struct {
 }
 
 func getID(t plugin.Task) string {
-	return fmt.Sprintf("%s-%s", t.Info().ID, t.Info().Namespace)
+	return fmt.Sprintf("%s-%s", t.Info().Namespace, t.Info().ID)
 }
 
 func (m *cgroupsMonitor) Monitor(c plugin.Task) error {

--- a/plugin/container.go
+++ b/plugin/container.go
@@ -7,6 +7,7 @@ type TaskInfo struct {
 	ContainerID string
 	Runtime     string
 	Spec        []byte
+	Namespace   string
 }
 
 type Task interface {

--- a/plugin/runtime.go
+++ b/plugin/runtime.go
@@ -34,6 +34,8 @@ type Exit struct {
 type Runtime interface {
 	// Create creates a container with the provided id and options
 	Create(ctx context.Context, id string, opts CreateOpts) (Task, error)
+	// Get returns a container
+	Get(context.Context, string) (Task, error)
 	// Containers returns all the current containers for the runtime
 	Tasks(context.Context) ([]Task, error)
 	// Delete removes the container in the runtime

--- a/spec_unix.go
+++ b/spec_unix.go
@@ -155,6 +155,7 @@ func createDefaultSpec() (*specs.Spec, error) {
 			},
 		},
 		Linux: &specs.Linux{
+			// TODO (@crosbymichael) make sure we don't have have two containers in the same cgroup
 			Resources: &specs.LinuxResources{
 				Devices: []specs.LinuxDeviceCgroup{
 					{

--- a/windows/runtime.go
+++ b/windows/runtime.go
@@ -34,7 +34,6 @@ func init() {
 }
 
 func New(ic *plugin.InitContext) (interface{}, error) {
-
 	rootDir := filepath.Join(ic.Root, runtimeName)
 	if err := os.MkdirAll(rootDir, 0755); err != nil {
 		return nil, errors.Wrapf(err, "could not create state directory at %s", rootDir)
@@ -152,8 +151,17 @@ func (r *Runtime) Tasks(ctx context.Context) ([]plugin.Task, error) {
 			list = append(list, c)
 		}
 	}
-
 	return list, nil
+}
+
+func (r *Runtime) Get(ctx context.Context, id string) (plugin.Task, error) {
+	r.Lock()
+	defer r.Unlock()
+	c, ok := r.containers[id]
+	if !ok {
+		return fmt.Errorf("container %s does not exit", id)
+	}
+	return c, nil
 }
 
 func (r *Runtime) Events(ctx context.Context) <-chan *plugin.Event {

--- a/windows/runtime.go
+++ b/windows/runtime.go
@@ -159,7 +159,7 @@ func (r *Runtime) Get(ctx context.Context, id string) (plugin.Task, error) {
 	defer r.Unlock()
 	c, ok := r.containers[id]
 	if !ok {
-		return fmt.Errorf("container %s does not exit", id)
+		return nil, fmt.Errorf("container %s does not exit", id)
 	}
 	return c, nil
 }


### PR DESCRIPTION
This finishes the work of namespaces tasks for the cgroups monitor and also moving the in memory map of all tasks into the runtime where they can be properly namespaced. 