### PR TITLE
containerd: nil-check before calling io.Close

### DIFF
--- a/task.go
+++ b/task.go
@@ -156,7 +156,10 @@ func (t *task) Wait(ctx context.Context) (uint32, error) {
 // it returns the exit status of the task and any errors that were encountered
 // during cleanup
 func (t *task) Delete(ctx context.Context) (uint32, error) {
-	cerr := t.io.Close()
+	var cerr error
+	if t.io != nil {
+		cerr = t.io.Close()
+	}
 	r, err := t.client.TaskService().Delete(ctx, &execution.DeleteRequest{
 		ContainerID: t.containerID,
 	})


### PR DESCRIPTION
Prevents this panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0xbcef12]

goroutine 1 [running]:
github.com/containerd/containerd.(*IO).Close(0x0, 0xc4200001a0, 0x0)
 /home/ec2-user/go/src/github.com/containerd/containerd/io.go:22 +0x22
github.com/containerd/containerd.(*task).Delete(0xc4202b4480, 0x11dfe40, 0xc4203284e0, 0x11dfe40, 0xc4203284e0, 0x0)
 /home/ec2-user/go/src/github.com/containerd/containerd/task.go:159 +0x44
```