### PR TITLE
Don't use WithBlock() on `dist` gRPC connection

### DIFF
--- a/cmd/dist/common.go
+++ b/cmd/dist/common.go
@@ -102,7 +102,6 @@ func connectGRPC(context *cli.Context) (*grpc.ClientConn, error) {
 	timeout := context.GlobalDuration("connect-timeout")
 	return grpc.Dial(address,
 		grpc.WithTimeout(timeout),
-		grpc.WithBlock(),
 		grpc.WithInsecure(),
 		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
 			return net.DialTimeout("unix", address, timeout)


### PR DESCRIPTION
When using WithBlock() on the dialer, the connection timeout must fully
expire before any status is provided to the user about whether they can
even connect to the socket. For example, if the containerd socket is
root-owned and the user tries `dist images ls` without `sudo`, the
default is 30 sec. of "hang" before the command returns.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>

// cc: @stevvooe per our discussion