### PR TITLE
Setup plugin ids and dependencies

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package containerd
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -19,6 +20,7 @@ import (
 	versionservice "github.com/containerd/containerd/api/services/version"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	contentservice "github.com/containerd/containerd/services/content"
@@ -83,7 +85,7 @@ func New(address string, opts ...ClientOpt) (*Client, error) {
 	}
 	return &Client{
 		conn:    conn,
-		runtime: runtime.GOOS,
+		runtime: fmt.Sprintf("%s.%s", plugin.RuntimePlugin, runtime.GOOS),
 	}, nil
 }
 

--- a/cmd/containerd/config.go
+++ b/cmd/containerd/config.go
@@ -37,8 +37,6 @@ func loadConfig(path string) error {
 // config specifies the containerd configuration file in the TOML format.
 // It contains fields to configure various subsystems and containerd as a whole.
 type config struct {
-	// State is the path to a directory where containerd will store runtime state
-	State string `toml:"state"`
 	// Root is the path to a directory where containerd will store persistent data
 	Root string `toml:"root"`
 	// GRPC configuration settings

--- a/cmd/containerd/config_linux.go
+++ b/cmd/containerd/config_linux.go
@@ -2,8 +2,7 @@ package main
 
 func defaultConfig() *config {
 	return &config{
-		Root:  "/var/lib/containerd",
-		State: "/run/containerd",
+		Root: "/var/lib/containerd",
 		GRPC: grpcConfig{
 			Address: "/run/containerd/containerd.sock",
 		},
@@ -11,7 +10,7 @@ func defaultConfig() *config {
 			Level:   "info",
 			Address: "/run/containerd/debug.sock",
 		},
-		Snapshotter: "overlay",
-		Differ:      "base",
+		Snapshotter: "io.containerd.snapshotter.v1.overlayfs",
+		Differ:      "io.containerd.differ.v1.base-diff",
 	}
 }

--- a/cmd/containerd/config_unix.go
+++ b/cmd/containerd/config_unix.go
@@ -4,8 +4,7 @@ package main
 
 func defaultConfig() *config {
 	return &config{
-		Root:  "/var/lib/containerd",
-		State: "/run/containerd",
+		Root: "/var/lib/containerd",
 		GRPC: grpcConfig{
 			Address: "/run/containerd/containerd.sock",
 		},
@@ -13,7 +12,7 @@ func defaultConfig() *config {
 			Level:   "info",
 			Address: "/run/containerd/debug.sock",
 		},
-		Snapshotter: "naive",
-		Differ:      "base",
+		Snapshotter: "io.containerd.snapshotter.v1.naive",
+		Differ:      "io.containerd.differ.v1.base-diff",
 	}
 }

--- a/cmd/containerd/config_windows.go
+++ b/cmd/containerd/config_windows.go
@@ -7,8 +7,7 @@ import (
 
 func defaultConfig() *config {
 	return &config{
-		Root:  filepath.Join(os.Getenv("programfiles"), "containerd", "root"),
-		State: filepath.Join(os.Getenv("programfiles"), "containerd", "state"),
+		Root: filepath.Join(os.Getenv("programfiles"), "containerd", "root"),
 		GRPC: grpcConfig{
 			Address: `\\.\pipe\containerd-containerd`,
 		},
@@ -16,7 +15,7 @@ func defaultConfig() *config {
 			Level:   "info",
 			Address: `\\.\pipe\containerd-debug`,
 		},
-		Snapshotter: "windows",
-		Differ:      "base",
+		Snapshotter: "io.containerd.snapshotter.v1.windows",
+		Differ:      "io.containerd.differ.v1.base-diff",
 	}
 }

--- a/cmd/containerd/main_linux.go
+++ b/cmd/containerd/main_linux.go
@@ -12,13 +12,14 @@ import (
 	"google.golang.org/grpc"
 )
 
-const (
-	defaultConfigPath = "/etc/containerd/config.toml"
-)
+const defaultConfigPath = "/etc/containerd/config.toml"
 
-var (
-	handledSignals = []os.Signal{unix.SIGTERM, unix.SIGINT, unix.SIGUSR1, unix.SIGCHLD}
-)
+var handledSignals = []os.Signal{
+	unix.SIGTERM,
+	unix.SIGINT,
+	unix.SIGUSR1,
+	unix.SIGCHLD,
+}
 
 func platformInit(context *cli.Context) error {
 	if conf.Subreaper {
@@ -32,12 +33,6 @@ func platformInit(context *cli.Context) error {
 		if err := sys.SetOOMScore(os.Getpid(), conf.OOMScore); err != nil {
 			return err
 		}
-	}
-	if err := os.MkdirAll(conf.State, 0750); err != nil {
-		return err
-	}
-	if err := os.Chown(conf.State, conf.GRPC.Uid, conf.GRPC.Gid); err != nil {
-		return err
 	}
 	return nil
 }

--- a/cmd/containerd/main_unix.go
+++ b/cmd/containerd/main_unix.go
@@ -22,12 +22,6 @@ var (
 )
 
 func platformInit(context *cli.Context) error {
-	if err := os.MkdirAll(conf.State, 0750); err != nil {
-		return err
-	}
-	if err := os.Chown(conf.State, conf.GRPC.Uid, conf.GRPC.Gid); err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/cmd/ctr/run.go
+++ b/cmd/ctr/run.go
@@ -55,8 +55,8 @@ var runCommand = cli.Command{
 		},
 		cli.StringFlag{
 			Name:  "runtime",
-			Usage: "runtime name (linux, windows, vmware-linux)",
-			Value: "linux",
+			Usage: "runtime name (io.containerd.runtime.v1.linux, io.containerd.runtime.v1.windows, io.containerd.runtime.v1.com.vmware.linux)",
+			Value: "io.containerd.runtime.v1.linux",
 		},
 		cli.BoolFlag{
 			Name:  "readonly",

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -18,10 +18,23 @@ import (
 )
 
 func init() {
-	plugin.Register("diff-base", &plugin.Registration{
+	plugin.Register(&plugin.Registration{
 		Type: plugin.DiffPlugin,
+		ID:   "base-diff",
+		Requires: []plugin.PluginType{
+			plugin.ContentPlugin,
+			plugin.SnapshotPlugin,
+		},
 		Init: func(ic *plugin.InitContext) (interface{}, error) {
-			return newBaseDiff(ic.Content, ic.Snapshotter)
+			c, err := ic.Get(plugin.ContentPlugin)
+			if err != nil {
+				return nil, err
+			}
+			s, err := ic.Get(plugin.SnapshotPlugin)
+			if err != nil {
+				return nil, err
+			}
+			return newBaseDiff(c.(content.Store), s.(snapshot.Snapshotter))
 		},
 	})
 }

--- a/linux/task.go
+++ b/linux/task.go
@@ -35,7 +35,7 @@ func (c *Task) Info() plugin.TaskInfo {
 	return plugin.TaskInfo{
 		ID:          c.containerID,
 		ContainerID: c.containerID,
-		Runtime:     runtimeName,
+		Runtime:     pluginID,
 		Spec:        c.spec,
 		Namespace:   c.namespace,
 	}

--- a/metrics/cgroups/cgroups.go
+++ b/metrics/cgroups/cgroups.go
@@ -13,11 +13,10 @@ import (
 	"golang.org/x/net/context"
 )
 
-const name = "cgroups"
-
 func init() {
-	plugin.Register(name, &plugin.Registration{
+	plugin.Register(&plugin.Registration{
 		Type: plugin.TaskMonitorPlugin,
+		ID:   "cgroups",
 		Init: New,
 	})
 }

--- a/plugin/context.go
+++ b/plugin/context.go
@@ -1,0 +1,36 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+)
+
+func NewContext(plugins map[PluginType][]interface{}) *InitContext {
+	return &InitContext{
+		plugins: plugins,
+	}
+}
+
+type InitContext struct {
+	Root    string
+	Context context.Context
+	Config  interface{}
+
+	plugins map[PluginType][]interface{}
+}
+
+func (i *InitContext) Get(t PluginType) (interface{}, error) {
+	p := i.plugins[t]
+	if len(p) == 0 {
+		return nil, fmt.Errorf("no plugins registered for %s", t)
+	}
+	return p[0], nil
+}
+
+func (i *InitContext) GetAll(t PluginType) ([]interface{}, error) {
+	p, ok := i.plugins[t]
+	if !ok {
+		return nil, fmt.Errorf("no plugins registered for %s", t)
+	}
+	return p, nil
+}

--- a/plugin/errors.go
+++ b/plugin/errors.go
@@ -3,7 +3,6 @@ package plugin
 import "errors"
 
 var (
-	ErrUnknownRuntime    = errors.New("unknown runtime")
 	ErrContainerExists   = errors.New("container with id already exists")
 	ErrContainerNotExist = errors.New("container does not exist")
 	ErrRuntimeNotExist   = errors.New("runtime does not exist")

--- a/plugin/runtime.go
+++ b/plugin/runtime.go
@@ -32,6 +32,8 @@ type Exit struct {
 // Runtime is responsible for the creation of containers for a certain platform,
 // arch, or custom usage.
 type Runtime interface {
+	// ID of the runtime
+	ID() string
 	// Create creates a container with the provided id and options
 	Create(ctx context.Context, id string, opts CreateOpts) (Task, error)
 	// Get returns a container

--- a/services/containers/service.go
+++ b/services/containers/service.go
@@ -13,10 +13,18 @@ import (
 )
 
 func init() {
-	plugin.Register("containers-grpc", &plugin.Registration{
+	plugin.Register(&plugin.Registration{
 		Type: plugin.GRPCPlugin,
+		ID:   "containers",
+		Requires: []plugin.PluginType{
+			plugin.MetadataPlugin,
+		},
 		Init: func(ic *plugin.InitContext) (interface{}, error) {
-			return NewService(ic.Meta), nil
+			m, err := ic.Get(plugin.MetadataPlugin)
+			if err != nil {
+				return nil, err
+			}
+			return NewService(m.(*bolt.DB)), nil
 		},
 	})
 }

--- a/services/content/service.go
+++ b/services/content/service.go
@@ -30,15 +30,23 @@ var bufPool = sync.Pool{
 var _ api.ContentServer = &Service{}
 
 func init() {
-	plugin.Register("content-grpc", &plugin.Registration{
+	plugin.Register(&plugin.Registration{
 		Type: plugin.GRPCPlugin,
+		ID:   "content",
+		Requires: []plugin.PluginType{
+			plugin.ContentPlugin,
+		},
 		Init: NewService,
 	})
 }
 
 func NewService(ic *plugin.InitContext) (interface{}, error) {
+	c, err := ic.Get(plugin.ContentPlugin)
+	if err != nil {
+		return nil, err
+	}
 	return &Service{
-		store: ic.Content,
+		store: c.(content.Store),
 	}, nil
 }
 

--- a/services/diff/service.go
+++ b/services/diff/service.go
@@ -10,11 +10,19 @@ import (
 )
 
 func init() {
-	plugin.Register("diff-grpc", &plugin.Registration{
+	plugin.Register(&plugin.Registration{
 		Type: plugin.GRPCPlugin,
+		ID:   "diff",
+		Requires: []plugin.PluginType{
+			plugin.DiffPlugin,
+		},
 		Init: func(ic *plugin.InitContext) (interface{}, error) {
+			d, err := ic.Get(plugin.DiffPlugin)
+			if err != nil {
+				return nil, err
+			}
 			return &service{
-				diff: ic.Differ,
+				diff: d.(plugin.Differ),
 			}, nil
 		},
 	})

--- a/services/healthcheck/service.go
+++ b/services/healthcheck/service.go
@@ -13,8 +13,9 @@ type Service struct {
 }
 
 func init() {
-	plugin.Register("healthcheck-grpc", &plugin.Registration{
+	plugin.Register(&plugin.Registration{
 		Type: plugin.GRPCPlugin,
+		ID:   "healthcheck",
 		Init: NewService,
 	})
 }

--- a/services/images/service.go
+++ b/services/images/service.go
@@ -12,10 +12,18 @@ import (
 )
 
 func init() {
-	plugin.Register("images-grpc", &plugin.Registration{
+	plugin.Register(&plugin.Registration{
 		Type: plugin.GRPCPlugin,
+		ID:   "images",
+		Requires: []plugin.PluginType{
+			plugin.MetadataPlugin,
+		},
 		Init: func(ic *plugin.InitContext) (interface{}, error) {
-			return NewService(ic.Meta), nil
+			m, err := ic.Get(plugin.MetadataPlugin)
+			if err != nil {
+				return nil, err
+			}
+			return NewService(m.(*bolt.DB)), nil
 		},
 	})
 }

--- a/services/namespaces/service.go
+++ b/services/namespaces/service.go
@@ -15,10 +15,18 @@ import (
 )
 
 func init() {
-	plugin.Register("namespaces-grpc", &plugin.Registration{
+	plugin.Register(&plugin.Registration{
 		Type: plugin.GRPCPlugin,
+		ID:   "namespaces",
+		Requires: []plugin.PluginType{
+			plugin.MetadataPlugin,
+		},
 		Init: func(ic *plugin.InitContext) (interface{}, error) {
-			return NewService(ic.Meta), nil
+			m, err := ic.Get(plugin.MetadataPlugin)
+			if err != nil {
+				return nil, err
+			}
+			return NewService(m.(*bolt.DB)), nil
 		},
 	})
 }

--- a/services/snapshot/service.go
+++ b/services/snapshot/service.go
@@ -16,10 +16,18 @@ import (
 )
 
 func init() {
-	plugin.Register("snapshots-grpc", &plugin.Registration{
+	plugin.Register(&plugin.Registration{
 		Type: plugin.GRPCPlugin,
+		ID:   "snapshots",
+		Requires: []plugin.PluginType{
+			plugin.SnapshotPlugin,
+		},
 		Init: func(ic *plugin.InitContext) (interface{}, error) {
-			return newService(ic.Snapshotter)
+			s, err := ic.Get(plugin.SnapshotPlugin)
+			if err != nil {
+				return nil, err
+			}
+			return newService(s.(snapshot.Snapshotter))
 		},
 	})
 }

--- a/services/version/service.go
+++ b/services/version/service.go
@@ -12,8 +12,9 @@ import (
 var _ api.VersionServer = &Service{}
 
 func init() {
-	plugin.Register("version-grpc", &plugin.Registration{
+	plugin.Register(&plugin.Registration{
 		Type: plugin.GRPCPlugin,
+		ID:   "version",
 		Init: New,
 	})
 }

--- a/snapshot/btrfs/btrfs.go
+++ b/snapshot/btrfs/btrfs.go
@@ -20,11 +20,11 @@ import (
 )
 
 func init() {
-	plugin.Register("snapshot-btrfs", &plugin.Registration{
+	plugin.Register(&plugin.Registration{
+		ID:   "btrfs",
 		Type: plugin.SnapshotPlugin,
 		Init: func(ic *plugin.InitContext) (interface{}, error) {
-			root := filepath.Join(ic.Root, "snapshot", "btrfs")
-			return NewSnapshotter(root)
+			return NewSnapshotter(ic.Root)
 		},
 	})
 }

--- a/snapshot/naive/naive.go
+++ b/snapshot/naive/naive.go
@@ -16,10 +16,11 @@ import (
 )
 
 func init() {
-	plugin.Register("snapshot-naive", &plugin.Registration{
+	plugin.Register(&plugin.Registration{
 		Type: plugin.SnapshotPlugin,
+		ID:   "naive",
 		Init: func(ic *plugin.InitContext) (interface{}, error) {
-			return NewSnapshotter(filepath.Join(ic.Root, "snapshot", "naive"))
+			return NewSnapshotter(ic.Root)
 		},
 	})
 }

--- a/snapshot/overlay/overlay.go
+++ b/snapshot/overlay/overlay.go
@@ -20,10 +20,11 @@ import (
 )
 
 func init() {
-	plugin.Register("snapshot-overlay", &plugin.Registration{
+	plugin.Register(&plugin.Registration{
 		Type: plugin.SnapshotPlugin,
+		ID:   "overlayfs",
 		Init: func(ic *plugin.InitContext) (interface{}, error) {
-			return NewSnapshotter(filepath.Join(ic.Root, "snapshot", "overlay"))
+			return NewSnapshotter(ic.Root)
 		},
 	})
 }

--- a/snapshot/windows/windows.go
+++ b/snapshot/windows/windows.go
@@ -4,7 +4,6 @@ package windows
 
 import (
 	"context"
-	"path/filepath"
 
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/plugin"
@@ -17,10 +16,11 @@ var (
 )
 
 func init() {
-	plugin.Register("snapshot-windows", &plugin.Registration{
+	plugin.Register(&plugin.Registration{
 		Type: plugin.SnapshotPlugin,
+		ID:   "windows",
 		Init: func(ic *plugin.InitContext) (interface{}, error) {
-			return NewSnapshotter(filepath.Join(ic.Root, "snapshot", "windows"))
+			return NewSnapshotter(ic.Root)
 		},
 	})
 }

--- a/windows/runtime.go
+++ b/windows/runtime.go
@@ -27,14 +27,15 @@ const (
 var _ = (plugin.Runtime)(&Runtime{})
 
 func init() {
-	plugin.Register(runtimeName, &plugin.Registration{
+	plugin.Register(&plugin.Registration{
+		ID:   "windows",
 		Type: plugin.RuntimePlugin,
 		Init: New,
 	})
 }
 
 func New(ic *plugin.InitContext) (interface{}, error) {
-	rootDir := filepath.Join(ic.Root, runtimeName)
+	rootDir := filepath.Join(ic.Root)
 	if err := os.MkdirAll(rootDir, 0755); err != nil {
 		return nil, errors.Wrapf(err, "could not create state directory at %s", rootDir)
 	}
@@ -63,7 +64,7 @@ func New(ic *plugin.InitContext) (interface{}, error) {
 	}
 
 	// Try to delete the old state dir and recreate it
-	stateDir := filepath.Join(ic.State, runtimeName)
+	stateDir := filepath.Join(ic.Root, "state")
 	if err := os.RemoveAll(stateDir); err != nil {
 		log.G(c).WithError(err).Warnf("failed to cleanup old state directory at %s", stateDir)
 	}
@@ -97,6 +98,10 @@ type RuntimeSpec struct {
 
 	// HCS specific options
 	hcs.Configuration
+}
+
+func (r *Runtime) ID() string {
+	return fmt.Sprintf("%s.%s", plugin.RuntimePlugin, runtimeName)
 }
 
 func (r *Runtime) Create(ctx context.Context, id string, opts plugin.CreateOpts) (plugin.Task, error) {


### PR DESCRIPTION
This does a few things. It sets up plugin types and IDs for core components and plugins as well as creates a stable api for `/var/lib/containerd` using the type and ID of the plugins.

I havn't move plugin registration to containerd.main yet, wanted to get feedback on this first.

```bash
sudo containerd
INFO[0000] setting subreaper...                          module=containerd
INFO[0000] changing OOM score to -999                    module=containerd
INFO[0000] starting containerd boot...                   module=containerd
INFO[0000] starting debug API...                         debug="/run/containerd/debug.sock" module=containerd
INFO[0000] loading plugin "io.containerd.content.v1.content"...  module=containerd type=io.containerd.content.v1
INFO[0000] loading plugin "io.containerd.snapshotter.v1.btrfs"...  module=containerd type=io.containerd.snapshotter.v1
INFO[0000] loading plugin "io.containerd.snapshotter.v1.overlayfs"...  module=containerd type=io.containerd.snapshotter.v1
INFO[0000] loading plugin "io.containerd.differ.v1.base-diff"...  module=containerd type=io.containerd.differ.v1
INFO[0000] loading plugin "io.containerd.metadata.v1.bolt"...  module=containerd type=io.containerd.metadata.v1
INFO[0000] loading plugin "io.containerd.grpc.v1.containers"...  module=containerd type=io.containerd.grpc.v1
INFO[0000] loading plugin "io.containerd.grpc.v1.content"...  module=containerd type=io.containerd.grpc.v1
INFO[0000] loading plugin "io.containerd.grpc.v1.diff"...  module=containerd type=io.containerd.grpc.v1
INFO[0000] loading plugin "io.containerd.monitor.v1.cgroups"...  module=containerd type=io.containerd.monitor.v1
INFO[0000] loading plugin "io.containerd.runtime.v1.linux"...  module=containerd type=io.containerd.runtime.v1
INFO[0000] loading plugin "io.containerd.grpc.v1.tasks"...  module=containerd type=io.containerd.grpc.v1
INFO[0000] loading plugin "io.containerd.grpc.v1.healthcheck"...  module=containerd type=io.containerd.grpc.v1
INFO[0000] loading plugin "io.containerd.grpc.v1.images"...  module=containerd type=io.containerd.grpc.v1
INFO[0000] loading plugin "io.containerd.grpc.v1.metrics"...  module=containerd type=io.containerd.grpc.v1
INFO[0000] loading plugin "io.containerd.grpc.v1.namespaces"...  module=containerd type=io.containerd.grpc.v1
INFO[0000] loading plugin "io.containerd.grpc.v1.snapshots"...  module=containerd type=io.containerd.grpc.v1
INFO[0000] loading plugin "io.containerd.grpc.v1.version"...  module=containerd type=io.containerd.grpc.v1
INFO[0000] starting GRPC API server...                   module=containerd
INFO[0000] starting metrics API...                       metrics="127.0.0.1:1338" module=containerd
INFO[0000] containerd successfully booted in 0.010027s   module=containerd
```

```
/var/lib/containerd/
├── io.containerd.content.v1.content
│   └── ingest
├── io.containerd.metadata.v1.bolt
│   └── meta.db
├── io.containerd.runtime.v1.linux
└── io.containerd.snapshotter.v1.overlayfs
    └── snapshots

6 directories, 1 file

```

This also cleans up the initialization of components and lets them specify a dependency graph for that they need instead of having a mega `InitContext` with everything.  

FYI: you need to wipe out `/var/lib/containerd` after this change.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>