### PR TITLE
make root-test: support TESTFLAGS="-tags=no_btrfs"

### DIFF
--- a/snapshot/btrfs/btrfs.go
+++ b/snapshot/btrfs/btrfs.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,!no_btrfs
 
 package btrfs
 

--- a/snapshot/btrfs/btrfs_nobtrfs.go
+++ b/snapshot/btrfs/btrfs_nobtrfs.go
@@ -1,0 +1,3 @@
+// +build !linux no_btrfs
+
+package btrfs

--- a/snapshot/btrfs/btrfs_test.go
+++ b/snapshot/btrfs/btrfs_test.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,!no_btrfs
 
 package btrfs
 


### PR DESCRIPTION
Now btrfs test can be skipped by setting TESTFLAGS="-tags=no_btrfs"

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>