### PR TITLE
ctr: Remove getTempDir

### DIFF
--- a/cmd/ctr/utils.go
+++ b/cmd/ctr/utils.go
@@ -4,10 +4,8 @@ import (
 	gocontext "context"
 	"encoding/csv"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -129,18 +127,6 @@ func getVersionService(context *cli.Context) (versionservice.VersionClient, erro
 		return nil, err
 	}
 	return versionservice.NewVersionClient(conn), nil
-}
-
-func getTempDir(id string) (string, error) {
-	err := os.MkdirAll(filepath.Join(os.TempDir(), "ctr"), 0700)
-	if err != nil {
-		return "", err
-	}
-	tmpDir, err := ioutil.TempDir(filepath.Join(os.TempDir(), "ctr"), fmt.Sprintf("%s-", id))
-	if err != nil {
-		return "", err
-	}
-	return tmpDir, nil
 }
 
 func waitContainer(events execution.Tasks_EventsClient, id string, pid uint32) (uint32, error) {


### PR DESCRIPTION
It is unused since 4c1af8fdd82c ("Port ctr to use client") and leaving it
around will just tempt people into writing code with security holes.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>