### PR TITLE
Add with block and fail on non-temp dial error

### DIFF
--- a/client.go
+++ b/client.go
@@ -65,9 +65,11 @@ func New(address string, opts ...ClientOpt) (*Client, error) {
 	}
 
 	gopts := []grpc.DialOption{
+		grpc.WithBlock(),
 		grpc.WithInsecure(),
 		grpc.WithTimeout(100 * time.Second),
 		grpc.WithDialer(dialer),
+		grpc.FailOnNonTempDialError(true),
 	}
 	if copts.defaultns != "" {
 		unary, stream := newNSInterceptors(copts.defaultns)


### PR DESCRIPTION
This guarantees that grpc requests will fail quickly when the service is not started or does not have permission. Without the `FailOnNonTempDialError`, the `WithBlock` will cause the client to wait until the timeout before failing.

Fixes #989