### PR TITLE
Add 'ArgsUsage' for ctr sub-cmds

### DIFF
--- a/cmd/ctr/checkpoint.go
+++ b/cmd/ctr/checkpoint.go
@@ -9,8 +9,9 @@ import (
 )
 
 var checkpointCommand = cli.Command{
-	Name:  "checkpoint",
-	Usage: "checkpoint a container",
+	Name:      "checkpoint",
+	Usage:     "checkpoint a container",
+	ArgsUsage: "CONTAINER",
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "exit",

--- a/cmd/ctr/exec.go
+++ b/cmd/ctr/exec.go
@@ -10,8 +10,9 @@ import (
 )
 
 var execCommand = cli.Command{
-	Name:  "exec",
-	Usage: "execute additional processes in an existing container",
+	Name:      "exec",
+	Usage:     "execute additional processes in an existing container",
+	ArgsUsage: "CONTAINER CMD [ARG...]",
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "cwd",

--- a/cmd/ctr/info.go
+++ b/cmd/ctr/info.go
@@ -10,8 +10,9 @@ import (
 )
 
 var infoCommand = cli.Command{
-	Name:  "info",
-	Usage: "get info about a container",
+	Name:      "info",
+	Usage:     "get info about a container",
+	ArgsUsage: "CONTAINER",
 	Action: func(context *cli.Context) error {
 		var (
 			ctx, cancel = appContext(context)

--- a/cmd/ctr/kill.go
+++ b/cmd/ctr/kill.go
@@ -6,8 +6,9 @@ import (
 )
 
 var killCommand = cli.Command{
-	Name:  "kill",
-	Usage: "signal a container (default: SIGTERM)",
+	Name:      "kill",
+	Usage:     "signal a container (default: SIGTERM)",
+	ArgsUsage: "CONTAINER",
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "signal, s",

--- a/cmd/ctr/ps.go
+++ b/cmd/ctr/ps.go
@@ -10,8 +10,9 @@ import (
 )
 
 var psCommand = cli.Command{
-	Name:  "ps",
-	Usage: "list processes for container",
+	Name:      "ps",
+	Usage:     "list processes for container",
+	ArgsUsage: "CONTAINER",
 	Action: func(context *cli.Context) error {
 		var (
 			id          = context.Args().First()


### PR DESCRIPTION
Add the 'ArgsUsage' for `ctr` sub-cmds in order to better guide users.


Signed-off-by: Yanqiang Miao <miao.yanqiang@zte.com.cn>