### PR TITLE
Do not claim to be loading a plugin which we aren't.

### DIFF
--- a/cmd/containerd/main.go
+++ b/cmd/containerd/main.go
@@ -117,10 +117,11 @@ func main() {
 		)
 		for _, init := range plugin.Graph() {
 			id := init.URI()
-			log.G(global).WithField("type", init.Type).Infof("loading plugin %q...", id)
 			if !shouldLoad(init) {
+				log.G(global).WithField("type", init.Type).Infof("skipping plugin %q...", id)
 				continue
 			}
+			log.G(global).WithField("type", init.Type).Infof("loading plugin %q...", id)
 			ic := plugin.NewContext(plugins)
 			ic.Root = filepath.Join(conf.Root, id)
 			ic.Context = log.WithModule(global, id)


### PR DESCRIPTION
I had forgotten to update my config.toml after #994 and was very confused by:

```
INFO[0000] starting containerd boot...                   module=containerd
INFO[0000] starting debug API...                         debug="/run/containerd/debug.sock" module=containerd
INFO[0000] loading plugin "io.containerd.content.v1.content"...  module=containerd type=io.containerd.content.v1
INFO[0000] loading plugin "io.containerd.snapshotter.v1.btrfs"...  module=containerd type=io.containerd.snapshotter.v1
INFO[0000] loading plugin "io.containerd.snapshotter.v1.overlayfs"...  module=containerd type=io.containerd.snapshotter.v1
INFO[0000] loading plugin "io.containerd.differ.v1.base-diff"...  module=containerd type=io.containerd.differ.v1
containerd: no plugins registered for io.containerd.snapshotter.v1
```

Where apparently two candidates for `io.containerd.snapshotter.v1` had been
loaded but the error claimed (correctly, it turns out) that none were. With
this change instead I see:

```
INFO[0000] starting containerd boot...                   module=containerd
INFO[0000] starting debug API...                         debug="/run/containerd/debug.sock" module=containerd
INFO[0000] loading plugin "io.containerd.content.v1.content"...  module=containerd type=io.containerd.content.v1
INFO[0000] skipping plugin "io.containerd.snapshotter.v1.btrfs"...  module=containerd type=io.containerd.snapshotter.v1
INFO[0000] skipping plugin "io.containerd.snapshotter.v1.overlayfs"...  module=containerd type=io.containerd.snapshotter.v1
INFO[0000] loading plugin "io.containerd.differ.v1.base-diff"...  module=containerd type=io.containerd.differ.v1
containerd: no plugins registered for io.containerd.snapshotter.v1
```

Signed-off-by: Ian Campbell <ian.campbell@docker.com>