### PR TITLE
Benchmark container create and task start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,10 @@ integration: ## run integration tests
 	@echo "$(WHALE) $@"
 	@go test ${TESTFLAGS}
 
+benchmark: ## run benchmarks tests
+	@echo "$(WHALE) $@"
+	@go test ${TESTFLAGS} -bench . -run Benchmark
+
 FORCE:
 
 # Build a binary from a cmd.

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,111 @@
+package containerd
+
+import (
+	"fmt"
+	"testing"
+)
+
+func BenchmarkContainerCreate(b *testing.B) {
+	if testing.Short() {
+		b.Skip()
+	}
+	client, err := New(address)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer client.Close()
+
+	ctx, cancel := testContext()
+	defer cancel()
+
+	image, err := client.GetImage(ctx, testImage)
+	if err != nil {
+		b.Error(err)
+		return
+	}
+	spec, err := GenerateSpec(WithImageConfig(ctx, image), WithProcessArgs("true"))
+	if err != nil {
+		b.Error(err)
+		return
+	}
+	var containers []Container
+	defer func() {
+		for _, c := range containers {
+			if err := c.Delete(ctx); err != nil {
+				b.Error(err)
+			}
+		}
+	}()
+
+	// reset the timer before creating containers
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		id := fmt.Sprintf("%s-%d", b.Name(), i)
+		container, err := client.NewContainer(ctx, id, WithSpec(spec), WithImage(image), WithNewRootFS(id, image))
+		if err != nil {
+			b.Error(err)
+			return
+		}
+		containers = append(containers, container)
+	}
+	b.StopTimer()
+}
+
+func BenchmarkContainerStart(b *testing.B) {
+	if testing.Short() {
+		b.Skip()
+	}
+	client, err := New(address)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer client.Close()
+
+	ctx, cancel := testContext()
+	defer cancel()
+
+	image, err := client.GetImage(ctx, testImage)
+	if err != nil {
+		b.Error(err)
+		return
+	}
+	spec, err := GenerateSpec(WithImageConfig(ctx, image), WithProcessArgs("true"))
+	if err != nil {
+		b.Error(err)
+		return
+	}
+	var containers []Container
+	defer func() {
+		for _, c := range containers {
+			if err := c.Delete(ctx); err != nil {
+				b.Error(err)
+			}
+		}
+	}()
+
+	for i := 0; i < b.N; i++ {
+		id := fmt.Sprintf("%s-%d", b.Name(), i)
+		container, err := client.NewContainer(ctx, id, WithSpec(spec), WithImage(image), WithNewRootFS(id, image))
+		if err != nil {
+			b.Error(err)
+			return
+		}
+		containers = append(containers, container)
+
+	}
+	// reset the timer before starting tasks
+	b.ResetTimer()
+	for _, c := range containers {
+		task, err := c.NewTask(ctx, empty())
+		if err != nil {
+			b.Error(err)
+			return
+		}
+		defer task.Delete(ctx)
+		if err := task.Start(ctx); err != nil {
+			b.Error(err)
+			return
+		}
+	}
+	b.StopTimer()
+}


### PR DESCRIPTION
This adds simple benchmarks for containers and task creation/start.  We can enable this in the CI if we have a way to identify regressions in terms of performance on PRs. 

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>