### PR TITLE
[wip] Add support for snapshot mount type

### DIFF
--- a/services/diff/service.go
+++ b/services/diff/service.go
@@ -5,6 +5,7 @@ import (
 	mounttypes "github.com/containerd/containerd/api/types/mount"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/plugin"
+	"github.com/containerd/containerd/snapshot"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
@@ -15,21 +16,28 @@ func init() {
 		ID:   "diff",
 		Requires: []plugin.PluginType{
 			plugin.DiffPlugin,
+			plugin.SnapshotPlugin,
 		},
 		Init: func(ic *plugin.InitContext) (interface{}, error) {
 			d, err := ic.Get(plugin.DiffPlugin)
 			if err != nil {
 				return nil, err
 			}
+			sn, err := ic.Get(plugin.SnapshotPlugin)
+			if err != nil {
+				return nil, err
+			}
 			return &service{
-				diff: d.(plugin.Differ),
+				diff:        d.(plugin.Differ),
+				snapshotter: sn.(snapshot.Snapshotter),
 			}, nil
 		},
 	})
 }
 
 type service struct {
-	diff plugin.Differ
+	diff        plugin.Differ
+	snapshotter snapshot.Snapshotter
 }
 
 func (s *service) Register(gs *grpc.Server) error {
@@ -42,6 +50,11 @@ func (s *service) Apply(ctx context.Context, er *diffapi.ApplyRequest) (*diffapi
 	// TODO: Check for supported media types
 
 	mounts := toMounts(er.Mounts)
+
+	mounts, err := s.resolveMounts(ctx, mounts)
+	if err != nil {
+		return nil, err
+	}
 
 	ocidesc, err := s.diff.Apply(ctx, desc, mounts)
 	if err != nil {
@@ -58,6 +71,15 @@ func (s *service) Diff(ctx context.Context, dr *diffapi.DiffRequest) (*diffapi.D
 	aMounts := toMounts(dr.Left)
 	bMounts := toMounts(dr.Right)
 
+	aMounts, err := s.resolveMounts(ctx, aMounts)
+	if err != nil {
+		return nil, err
+	}
+	bMounts, err = s.resolveMounts(ctx, bMounts)
+	if err != nil {
+		return nil, err
+	}
+
 	ocidesc, err := s.diff.DiffMounts(ctx, aMounts, bMounts, dr.MediaType, dr.Ref)
 	if err != nil {
 		return nil, err
@@ -66,6 +88,22 @@ func (s *service) Diff(ctx context.Context, dr *diffapi.DiffRequest) (*diffapi.D
 	return &diffapi.DiffResponse{
 		Diff: fromDescriptor(ocidesc),
 	}, nil
+}
+
+func (s *service) resolveMounts(ctx context.Context, mounts []mount.Mount) ([]mount.Mount, error) {
+	resolved := make([]mount.Mount, 0, len(mounts))
+	for _, m := range mounts {
+		if m.Type == "snapshot" {
+			snMounts, err := s.snapshotter.Mounts(ctx, m.Source)
+			if err != nil {
+				return nil, err
+			}
+			resolved = append(resolved, snMounts...)
+		} else {
+			resolved = append(resolved, m)
+		}
+	}
+	return resolved, nil
 }
 
 func toMounts(apim []*mounttypes.Mount) []mount.Mount {

--- a/snapshot.go
+++ b/snapshot.go
@@ -1,0 +1,54 @@
+package containerd
+
+import (
+	"context"
+
+	snapshotapi "github.com/containerd/containerd/api/services/snapshot"
+	"github.com/containerd/containerd/mount"
+	snapshotservice "github.com/containerd/containerd/services/snapshot"
+	"github.com/containerd/containerd/snapshot"
+)
+
+// SnapshotService returns a snapshotter which connects to the containerd
+// snapshotter through GRPC.
+func (c *Client) SnapshotService() snapshot.Snapshotter {
+	// If client has requests server mounts, wrap to return snapshot mounts
+	snapshotter := snapshotservice.NewSnapshotterFromClient(snapshotapi.NewSnapshotClient(c.conn))
+	if c.ssmount {
+		snapshotter = ssmountSnapshotter{Snapshotter: snapshotter}
+	}
+	return snapshotter
+}
+
+type ssmountSnapshotter struct {
+	snapshot.Snapshotter
+}
+
+func (s ssmountSnapshotter) mounts(key string) []mount.Mount {
+	return []mount.Mount{
+		{
+			Source: key,
+			Type:   "snapshot",
+		},
+	}
+}
+
+func (s ssmountSnapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, error) {
+	return s.mounts(key), nil
+}
+
+func (s ssmountSnapshotter) Prepare(ctx context.Context, key, parent string) ([]mount.Mount, error) {
+	_, err := s.Snapshotter.Prepare(ctx, key, parent)
+	if err != nil {
+		return nil, err
+	}
+	return s.mounts(key), nil
+}
+
+func (s ssmountSnapshotter) View(ctx context.Context, key, parent string) ([]mount.Mount, error) {
+	_, err := s.Snapshotter.View(ctx, key, parent)
+	if err != nil {
+		return nil, err
+	}
+	return s.mounts(key), nil
+}


### PR DESCRIPTION
Snapshot mount type allows clients which do not have mount permission to use mounts with the snapshot
type. Additionally the api server can enforce mount namespace doing a mount lookup on the snapshot type without relying on the client to pass in correct mounts. This could be useful to API proxies enforcing namespace boundaries from clients.

This method can be used to simplify clients which never intend to mount snapshots locally. The clients can keep the same interface as passing around `[]Mount` but also able to determine if the mounts are snapshots and which id is associated with that snapshot.

Marked as WIP to review for feedback on this approach.