### PR TITLE
image: add support for pulling manifest lists/oci indexes

### DIFF
--- a/remotes/handlers.go
+++ b/remotes/handlers.go
@@ -20,10 +20,13 @@ func MakeRefKey(ctx context.Context, desc ocispec.Descriptor) string {
 	// product of the context, which may include information about the ongoing
 	// fetch process.
 	switch desc.MediaType {
-	case images.MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest,
-		images.MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
+	case images.MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest:
 		return "manifest-" + desc.Digest.String()
-	case images.MediaTypeDockerSchema2Layer, images.MediaTypeDockerSchema2LayerGzip:
+	case images.MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
+		return "index-" + desc.Digest.String()
+	case images.MediaTypeDockerSchema2Layer, images.MediaTypeDockerSchema2LayerGzip,
+		ocispec.MediaTypeImageLayer, ocispec.MediaTypeImageLayerGzip,
+		ocispec.MediaTypeImageLayerNonDistributable, ocispec.MediaTypeImageLayerNonDistributableGzip:
 		return "layer-" + desc.Digest.String()
 	case images.MediaTypeDockerSchema2Config, ocispec.MediaTypeImageConfig:
 		return "config-" + desc.Digest.String()
@@ -45,8 +48,6 @@ func FetchHandler(ingester content.Ingester, fetcher Fetcher) images.HandlerFunc
 		}))
 
 		switch desc.MediaType {
-		case images.MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
-			return nil, fmt.Errorf("%v not yet supported", desc.MediaType)
 		case images.MediaTypeDockerSchema1Manifest:
 			return nil, fmt.Errorf("%v not supported", desc.MediaType)
 		default:


### PR DESCRIPTION
This PR ensures that we can pull images with manifest lists, aka OCI
indexes. After this change, when pulling such an image, the resources
will all be available for creating the image.

Further support is required to do platform based selection for rootfs
creation, so such images may not yet be runnable. This is mostly useful
for checkpoint transfers, which use an OCI index for assembling the
component set.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

PTAL @crosbymichael 