### PR TITLE
containerd: Add WithLinuxNamespace to replace namespace

### DIFF
--- a/spec_unix.go
+++ b/spec_unix.go
@@ -188,6 +188,24 @@ func WithHostNamespace(ns specs.LinuxNamespaceType) SpecOpts {
 	}
 }
 
+// WithLinuxNamespace uses the passed in namespace for the spec. If a namespace of the same type already exists in the
+// spec, the existing namespace is replaced by the one provided.
+func WithLinuxNamespace(ns specs.LinuxNamespace) SpecOpts {
+	return func(s *specs.Spec) error {
+		for i, n := range s.Linux.Namespaces {
+			if n.Type == ns.Type {
+				before := s.Linux.Namespaces[:i]
+				after := s.Linux.Namespaces[i+1:]
+				s.Linux.Namespaces = append(before, ns)
+				s.Linux.Namespaces = append(s.Linux.Namespaces, after...)
+				return nil
+			}
+		}
+		s.Linux.Namespaces = append(s.Linux.Namespaces, ns)
+		return nil
+	}
+}
+
 func WithImageConfig(ctx context.Context, i Image) SpecOpts {
 	return func(s *specs.Spec) error {
 		var (


### PR DESCRIPTION
`WithNamespace` can be used to replace existing namespaces in a spec. This is useful if you want to use the default generated spec, but swap out one of the namespaces.