### PR TITLE
Add temp namespace to snapshots created by the client

### DIFF
--- a/client.go
+++ b/client.go
@@ -143,13 +143,17 @@ func WithExistingRootFS(id string) NewContainerOpts {
 }
 
 // WithNewRootFS allocates a new snapshot to be used by the container as the
-// root filesystem in read-write mode
+// root filesystem in read-write mode.
+// This newly created snapshot will be removed by the client when the container
+// is deleted. Use `WithExistingRootFS` to control the lifecycle of snapshot
+// separately from the container.
 func WithNewRootFS(id string, i Image) NewContainerOpts {
 	return func(ctx context.Context, client *Client, c *containers.Container) error {
 		diffIDs, err := i.(*image).i.RootFS(ctx, client.ContentStore())
 		if err != nil {
 			return err
 		}
+		id = fmt.Sprintf("containerd-client-tmp-%s", id)
 		if _, err := client.SnapshotService().Prepare(ctx, id, identity.ChainID(diffIDs).String()); err != nil {
 			return err
 		}
@@ -159,13 +163,17 @@ func WithNewRootFS(id string, i Image) NewContainerOpts {
 }
 
 // WithNewReadonlyRootFS allocates a new snapshot to be used by the container as the
-// root filesystem in read-only mode
+// root filesystem in read-only mode.
+// This newly created snapshot will be removed by the client when the container
+// is deleted. Use `WithExistingRootFS` to control the lifecycle of snapshot
+// separately from the container.
 func WithNewReadonlyRootFS(id string, i Image) NewContainerOpts {
 	return func(ctx context.Context, client *Client, c *containers.Container) error {
 		diffIDs, err := i.(*image).i.RootFS(ctx, client.ContentStore())
 		if err != nil {
 			return err
 		}
+		id = fmt.Sprintf("containerd-client-tmp-%s", id)
 		if _, err := client.SnapshotService().View(ctx, id, identity.ChainID(diffIDs).String()); err != nil {
 			return err
 		}

--- a/container.go
+++ b/container.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"google.golang.org/grpc"
@@ -71,7 +72,7 @@ func (c *container) Spec() (*specs.Spec, error) {
 func (c *container) Delete(ctx context.Context) (err error) {
 	// TODO: should the client be the one removing resources attached
 	// to the container at the moment before we have GC?
-	if c.c.RootFS != "" {
+	if c.c.RootFS != "" && strings.HasPrefix(c.c.RootFS, "containerd-client-tmp-") {
 		err = c.client.SnapshotService().Remove(ctx, c.c.RootFS)
 	}
 	if _, cerr := c.client.ContainerService().Delete(ctx, &containers.DeleteContainerRequest{


### PR DESCRIPTION
Allows removing snapshots created by the client without unintentionally removing existing rootfs when `WithExistingRootFS` is used.