### PR TITLE
Clean up dist tool to use containerd client

### DIFF
--- a/cmd/dist/edit.go
+++ b/cmd/dist/edit.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"os/exec"
 
-	contentapi "github.com/containerd/containerd/api/services/content"
-	"github.com/containerd/containerd/services/content"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/urfave/cli"
 )
@@ -45,12 +43,12 @@ var editCommand = cli.Command{
 			return err
 		}
 
-		conn, err := connectGRPC(context)
+		client, err := getClient(context)
 		if err != nil {
 			return err
 		}
 
-		content := content.NewStoreFromClient(contentapi.NewContentClient(conn))
+		content := client.ContentStore()
 
 		rc, err := content.Reader(ctx, dgst)
 		if err != nil {

--- a/cmd/dist/images.go
+++ b/cmd/dist/images.go
@@ -32,15 +32,13 @@ var imagesListCommand = cli.Command{
 		ctx, cancel := appContext(clicontext)
 		defer cancel()
 
-		imageStore, err := resolveImageStore(clicontext)
+		client, err := getClient(clicontext)
 		if err != nil {
 			return err
 		}
 
-		cs, err := resolveContentStore(clicontext)
-		if err != nil {
-			return err
-		}
+		imageStore := client.ImageService()
+		cs := client.ContentStore()
 
 		images, err := imageStore.List(ctx)
 		if err != nil {
@@ -76,10 +74,12 @@ var imageRemoveCommand = cli.Command{
 		ctx, cancel := appContext(clicontext)
 		defer cancel()
 
-		imageStore, err := resolveImageStore(clicontext)
+		client, err := getClient(clicontext)
 		if err != nil {
 			return err
 		}
+
+		imageStore := client.ImageService()
 
 		for _, target := range clicontext.Args() {
 			if err := imageStore.Delete(ctx, target); err != nil {

--- a/cmd/dist/rootfs.go
+++ b/cmd/dist/rootfs.go
@@ -6,9 +6,7 @@ import (
 	"os"
 	"strings"
 
-	snapshotapi "github.com/containerd/containerd/api/services/snapshot"
 	"github.com/containerd/containerd/log"
-	snapshotservice "github.com/containerd/containerd/services/snapshot"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/urfave/cli"
 )
@@ -95,12 +93,12 @@ var rootfsPrepareCommand = cli.Command{
 
 		log.G(ctx).Infof("preparing mounts %s", dgst.String())
 
-		conn, err := connectGRPC(clicontext)
+		client, err := getClient(clicontext)
 		if err != nil {
 			return err
 		}
 
-		snapshotter := snapshotservice.NewSnapshotterFromClient(snapshotapi.NewSnapshotClient(conn))
+		snapshotter := client.SnapshotService()
 
 		mounts, err := snapshotter.Prepare(ctx, target, dgst.String())
 		if err != nil {


### PR DESCRIPTION
Remove direct use of grpc in dist tool

Incorporates the feedback from @estesp in #1007