### PR TITLE
Snapshot namespaces

### DIFF
--- a/differ/differ.go
+++ b/differ/differ.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/snapshot"
+	"github.com/containerd/containerd/snapshot/namespaced"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -51,7 +52,7 @@ var emptyDesc = ocispec.Descriptor{}
 func newBaseDiff(store content.Store, snapshotter snapshot.Snapshotter) (*BaseDiff, error) {
 	return &BaseDiff{
 		store:       store,
-		snapshotter: snapshotter,
+		snapshotter: namespaced.NewSnapshotter(snapshotter),
 	}, nil
 }
 

--- a/services/snapshot/service.go
+++ b/services/snapshot/service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/snapshot"
+	"github.com/containerd/containerd/snapshot/namespaced"
 	protoempty "github.com/golang/protobuf/ptypes/empty"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -44,7 +45,7 @@ type service struct {
 
 func newService(snapshotter snapshot.Snapshotter, evts events.Poster) (*service, error) {
 	return &service{
-		snapshotter: snapshotter,
+		snapshotter: namespaced.NewSnapshotter(snapshotter),
 		emitter:     evts,
 	}, nil
 }

--- a/snapshot/btrfs/btrfs_test.go
+++ b/snapshot/btrfs/btrfs_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/containerd/containerd/mount"
-	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/snapshot"
 	"github.com/containerd/containerd/snapshot/testsuite"
 	"github.com/containerd/containerd/testutil"
@@ -51,7 +50,7 @@ func TestBtrfs(t *testing.T) {
 
 func TestBtrfsMounts(t *testing.T) {
 	testutil.RequiresRoot(t)
-	ctx := namespaces.WithNamespace(context.Background(), "snapshotter-btrfs-test")
+	ctx := context.Background()
 
 	// create temporary directory for mount point
 	mountPoint, err := ioutil.TempDir("", "containerd-btrfs-test")

--- a/snapshot/namespaced/namespaced.go
+++ b/snapshot/namespaced/namespaced.go
@@ -1,0 +1,177 @@
+package namespaced
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/snapshot"
+)
+
+type snapshotter struct {
+	snapshot.Snapshotter
+}
+
+// NewSnapshotter returns a new Snapshotter which namespaces the given snapshot
+// using the provided name and metadata store.
+func NewSnapshotter(sn snapshot.Snapshotter) snapshot.Snapshotter {
+	if _, ok := sn.(*snapshotter); ok {
+		// Do not support double wrapping of the namespace since
+		// the namespace keys are not a hierachy nor stripped from
+		// the context when passed along.
+		return sn
+	}
+	return &snapshotter{
+		Snapshotter: sn,
+	}
+}
+
+func snapshotKey(namespace, key string) string {
+	return fmt.Sprintf("%s/%s", url.PathEscape(namespace), key)
+}
+
+func trimNamespace(key string) string {
+	idx := strings.IndexRune(key, '/')
+	if idx < 0 {
+		return key
+	}
+	return key[idx+1:]
+}
+
+func splitNamespace(key string) (string, string, error) {
+	idx := strings.IndexRune(key, '/')
+	if idx < 0 {
+		return "", key, nil
+	}
+	namespace, err := url.PathUnescape(key[:idx])
+	if err != nil {
+		return "", "", err
+	}
+	key = key[idx+1:]
+	return namespace, key, nil
+}
+
+func resolveKey(ctx context.Context, key string) (string, error) {
+	namespace, err := namespaces.NamespaceRequired(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return snapshotKey(namespace, key), nil
+}
+
+func (s *snapshotter) Stat(ctx context.Context, key string) (snapshot.Info, error) {
+	key, err := resolveKey(ctx, key)
+	if err != nil {
+		return snapshot.Info{}, err
+	}
+	info, err := s.Snapshotter.Stat(ctx, key)
+	if err != nil {
+		return snapshot.Info{}, err
+	}
+	info.Name = trimNamespace(info.Name)
+	if info.Parent != "" {
+		info.Parent = trimNamespace(info.Parent)
+	}
+
+	return info, nil
+}
+
+func (s *snapshotter) Usage(ctx context.Context, key string) (snapshot.Usage, error) {
+	key, err := resolveKey(ctx, key)
+	if err != nil {
+		return snapshot.Usage{}, err
+	}
+	return s.Snapshotter.Usage(ctx, key)
+}
+
+func (s *snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, error) {
+	key, err := resolveKey(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	return s.Snapshotter.Mounts(ctx, key)
+}
+
+func (s *snapshotter) Prepare(ctx context.Context, key, parent string) ([]mount.Mount, error) {
+	namespace, err := namespaces.NamespaceRequired(ctx)
+	if err != nil {
+		return nil, err
+	}
+	key = snapshotKey(namespace, key)
+	if parent != "" {
+		parent = snapshotKey(namespace, parent)
+	}
+
+	return s.Snapshotter.Prepare(ctx, key, parent)
+}
+
+func (s *snapshotter) View(ctx context.Context, key, parent string) ([]mount.Mount, error) {
+	namespace, err := namespaces.NamespaceRequired(ctx)
+	if err != nil {
+		return nil, err
+	}
+	key = snapshotKey(namespace, key)
+	if parent != "" {
+		parent = snapshotKey(namespace, parent)
+	}
+
+	return s.Snapshotter.View(ctx, key, parent)
+}
+
+func (s *snapshotter) Commit(ctx context.Context, name, key string) error {
+	namespace, err := namespaces.NamespaceRequired(ctx)
+	if err != nil {
+		return err
+	}
+	name = snapshotKey(namespace, name)
+	key = snapshotKey(namespace, key)
+
+	return s.Snapshotter.Commit(ctx, name, key)
+}
+
+func (s *snapshotter) Remove(ctx context.Context, key string) error {
+	key, err := resolveKey(ctx, key)
+	if err != nil {
+		return err
+	}
+	return s.Snapshotter.Remove(ctx, key)
+}
+
+func (s *snapshotter) Walk(ctx context.Context, fn func(context.Context, snapshot.Info) error) error {
+	var wrapped func(context.Context, snapshot.Info) error
+	if namespace, ok := namespaces.Namespace(ctx); ok {
+		wrapped = func(ctx context.Context, info snapshot.Info) error {
+			ns, name, err := splitNamespace(info.Name)
+			if err != nil {
+				return err
+			}
+			if ns != namespace {
+				return nil
+			}
+			info.Name = name
+			if info.Parent != "" {
+				info.Parent = trimNamespace(info.Parent)
+			}
+
+			return fn(ctx, info)
+		}
+	} else {
+		wrapped = func(ctx context.Context, info snapshot.Info) error {
+			ns, name, err := splitNamespace(info.Name)
+			if err != nil {
+				return err
+			}
+			info.Name = name
+			if info.Parent != "" {
+				info.Parent = trimNamespace(info.Parent)
+			}
+
+			return fn(namespaces.WithNamespace(ctx, ns), info)
+		}
+	}
+	return s.Snapshotter.Walk(ctx, wrapped)
+}

--- a/snapshot/overlay/overlay_test.go
+++ b/snapshot/overlay/overlay_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/containerd/containerd/mount"
-	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/snapshot"
 	"github.com/containerd/containerd/snapshot/storage"
 	"github.com/containerd/containerd/snapshot/testsuite"
@@ -34,7 +33,7 @@ func TestOverlay(t *testing.T) {
 }
 
 func TestOverlayMounts(t *testing.T) {
-	ctx := namespaces.WithNamespace(context.Background(), "snapshotter-overlay-test")
+	ctx := context.TODO()
 	root, err := ioutil.TempDir("", "overlay")
 	if err != nil {
 		t.Fatal(err)
@@ -70,7 +69,7 @@ func TestOverlayMounts(t *testing.T) {
 }
 
 func TestOverlayCommit(t *testing.T) {
-	ctx := namespaces.WithNamespace(context.Background(), "snapshotter-overlay-test")
+	ctx := context.TODO()
 	root, err := ioutil.TempDir("", "overlay")
 	if err != nil {
 		t.Fatal(err)
@@ -99,7 +98,7 @@ func TestOverlayCommit(t *testing.T) {
 }
 
 func TestOverlayOverlayMount(t *testing.T) {
-	ctx := namespaces.WithNamespace(context.Background(), "snapshotter-overlay-test")
+	ctx := context.TODO()
 	root, err := ioutil.TempDir("", "overlay")
 	if err != nil {
 		t.Fatal(err)
@@ -187,7 +186,7 @@ func getParents(ctx context.Context, sn snapshot.Snapshotter, root, key string) 
 
 func TestOverlayOverlayRead(t *testing.T) {
 	testutil.RequiresRoot(t)
-	ctx := namespaces.WithNamespace(context.Background(), "snapshotter-overlay-test")
+	ctx := context.TODO()
 	root, err := ioutil.TempDir("", "overlay")
 	if err != nil {
 		t.Fatal(err)
@@ -239,7 +238,7 @@ func TestOverlayOverlayRead(t *testing.T) {
 }
 
 func TestOverlayView(t *testing.T) {
-	ctx := namespaces.WithNamespace(context.Background(), "snapshotter-overlay-test")
+	ctx := context.TODO()
 	root, err := ioutil.TempDir("", "overlay")
 	if err != nil {
 		t.Fatal(err)

--- a/snapshot/storage/bolt.go
+++ b/snapshot/storage/bolt.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/boltdb/bolt"
-	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/snapshot"
 	db "github.com/containerd/containerd/snapshot/storage/proto"
 	"github.com/gogo/protobuf/proto"
@@ -137,7 +136,7 @@ func CreateActive(ctx context.Context, key, parent string, readonly bool) (a Act
 			return snapshot.ErrSnapshotExist
 		}
 
-		id, err := nextSequence(ctx)
+		id, err := bkt.NextSequence()
 		if err != nil {
 			return errors.Wrap(err, "unable to get identifier")
 		}
@@ -310,68 +309,28 @@ func CommitActive(ctx context.Context, key, name string, usage snapshot.Usage) (
 	return
 }
 
-// nextSequence maintains the snapshot ids in the same space across namespaces
-// to avoid collisions on the filesystem, which is typically not namespace
-// aware. This will also be useful to ensure that snapshots can be used across
-// namespaces in the future, by projecting parent relationships into an
-// alternate namespace without fixing up identifiers.
-func nextSequence(ctx context.Context) (uint64, error) {
-	t, ok := ctx.Value(transactionKey{}).(*boltFileTransactor)
-	if !ok {
-		return 0, ErrNoTransaction
-	}
-
-	bkt := t.tx.Bucket(bucketKeyStorageVersion)
-	if bkt == nil {
-		return 0, errors.New("version bucket required for sequence")
-	}
-
-	return bkt.NextSequence()
-}
-
 func withBucket(ctx context.Context, fn func(context.Context, *bolt.Bucket, *bolt.Bucket) error) error {
-	namespace, err := namespaces.NamespaceRequired(ctx)
-	if err != nil {
-		return err
-	}
 	t, ok := ctx.Value(transactionKey{}).(*boltFileTransactor)
 	if !ok {
 		return ErrNoTransaction
 	}
-	nbkt := t.tx.Bucket(bucketKeyStorageVersion)
-	if nbkt == nil {
+	bkt := t.tx.Bucket(bucketKeyStorageVersion)
+	if bkt == nil {
 		return errors.Wrap(snapshot.ErrSnapshotNotExist, "bucket does not exist")
 	}
-
-	bkt := nbkt.Bucket([]byte(namespace))
-	if bkt == nil {
-		return errors.Wrap(snapshot.ErrSnapshotNotExist, "namespace not available in snapshotter")
-	}
-
 	return fn(ctx, bkt.Bucket(bucketKeySnapshot), bkt.Bucket(bucketKeyParents))
 }
 
 func createBucketIfNotExists(ctx context.Context, fn func(context.Context, *bolt.Bucket, *bolt.Bucket) error) error {
-	namespace, err := namespaces.NamespaceRequired(ctx)
-	if err != nil {
-		return err
-	}
-
 	t, ok := ctx.Value(transactionKey{}).(*boltFileTransactor)
 	if !ok {
 		return ErrNoTransaction
 	}
 
-	nbkt, err := t.tx.CreateBucketIfNotExists(bucketKeyStorageVersion)
+	bkt, err := t.tx.CreateBucketIfNotExists(bucketKeyStorageVersion)
 	if err != nil {
 		return errors.Wrap(err, "failed to create version bucket")
 	}
-
-	bkt, err := nbkt.CreateBucketIfNotExists([]byte(namespace))
-	if err != nil {
-		return err
-	}
-
 	sbkt, err := bkt.CreateBucketIfNotExists(bucketKeySnapshot)
 	if err != nil {
 		return errors.Wrap(err, "failed to create snapshots bucket")

--- a/snapshot/storage/metastore_test.go
+++ b/snapshot/storage/metastore_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/snapshot"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -45,7 +44,7 @@ func MetaStoreSuite(t *testing.T, name string, meta func(root string) (*MetaStor
 // makeTest creates a testsuite with a writable transaction
 func makeTest(t *testing.T, name string, metaFn metaFactory, fn testFunc) func(t *testing.T) {
 	return func(t *testing.T) {
-		ctx := namespaces.WithNamespace(context.Background(), "testing-snapshot-metadata")
+		ctx := context.Background()
 		tmpDir, err := ioutil.TempDir("", "metastore-test-"+name+"-")
 		if err != nil {
 			t.Fatal(err)

--- a/snapshot/testsuite/testsuite.go
+++ b/snapshot/testsuite/testsuite.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/containerd/containerd/fs/fstest"
 	"github.com/containerd/containerd/mount"
-	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/snapshot"
 	"github.com/containerd/containerd/testutil"
 	"github.com/stretchr/testify/assert"
@@ -27,7 +26,7 @@ func SnapshotterSuite(t *testing.T, name string, snapshotterFn func(ctx context.
 
 func makeTest(t *testing.T, name string, snapshotterFn func(ctx context.Context, root string) (snapshot.Snapshotter, func(), error), fn func(ctx context.Context, t *testing.T, snapshotter snapshot.Snapshotter, work string)) func(t *testing.T) {
 	return func(t *testing.T) {
-		ctx := namespaces.WithNamespace(context.Background(), "snapshotter-test")
+		ctx := context.Background()
 		restoreMask := clearMask()
 		defer restoreMask()
 		// Make two directories: a snapshotter root and a play area for the tests:


### PR DESCRIPTION
Moves snapshot namespacing to a wrapper which can be used by clients and plugins. This protects the implementations of snapshots from being required to use namespaces. Snapshotters should be considered individually useful apart from the rest of containerd, namespaces was tying it too closely.