### PR TITLE
Update snapshot command in ctr

### DIFF
--- a/cmd/ctr/snapshot.go
+++ b/cmd/ctr/snapshot.go
@@ -1,21 +1,36 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"os"
+	"text/tabwriter"
 
+	"github.com/containerd/containerd/progress"
 	"github.com/containerd/containerd/rootfs"
+	"github.com/containerd/containerd/snapshot"
 	"github.com/urfave/cli"
 )
 
 var snapshotCommand = cli.Command{
-	Name:      "snapshot",
-	Usage:     "snapshot a container into an archive",
-	ArgsUsage: "",
+	Name:  "snapshot",
+	Usage: "snapshot management",
+	Subcommands: cli.Commands{
+		archiveSnapshotCommand,
+		listSnapshotCommand,
+		usageSnapshotCommand,
+	},
+}
+
+var archiveSnapshotCommand = cli.Command{
+	Name:      "archive",
+	Usage:     "Create an archive of a snapshot",
+	ArgsUsage: "[flags] id",
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "id",
-			Usage: "id of the container",
+			Usage: "id of the container or snapshot",
 		},
 	},
 	Action: func(clicontext *cli.Context) error {
@@ -48,5 +63,105 @@ var snapshotCommand = cli.Command{
 		fmt.Printf("%s %s\n", d.MediaType, d.Digest)
 
 		return nil
+	},
+}
+
+var listSnapshotCommand = cli.Command{
+	Name:    "list",
+	Aliases: []string{"ls"},
+	Usage:   "List snapshots",
+	Action: func(clicontext *cli.Context) error {
+		ctx, cancel := appContext(clicontext)
+		defer cancel()
+
+		client, err := newClient(clicontext)
+		if err != nil {
+			return err
+		}
+
+		snapshotter := client.SnapshotService()
+
+		tw := tabwriter.NewWriter(os.Stdout, 1, 8, 1, ' ', 0)
+		fmt.Fprintln(tw, "ID\tParent\tState\tReadonly\t")
+
+		if err := snapshotter.Walk(ctx, func(ctx context.Context, info snapshot.Info) error {
+			fmt.Fprintf(tw, "%v\t%v\t%v\t%t\t\n", info.Name, info.Parent, state(info.Kind), info.Readonly)
+			return nil
+		}); err != nil {
+			return err
+		}
+
+		return tw.Flush()
+	},
+}
+
+func state(k snapshot.Kind) string {
+	switch k {
+	case snapshot.KindActive:
+		return "active"
+	case snapshot.KindCommitted:
+		return "committed"
+	default:
+		return ""
+	}
+}
+
+var usageSnapshotCommand = cli.Command{
+	Name:      "usage",
+	Usage:     "Usage snapshots",
+	ArgsUsage: "[flags] [id] ...",
+	Flags: []cli.Flag{
+		cli.BoolFlag{
+			Name:  "b",
+			Usage: "display size in bytes",
+		},
+	},
+	Action: func(clicontext *cli.Context) error {
+		ctx, cancel := appContext(clicontext)
+		defer cancel()
+
+		client, err := newClient(clicontext)
+		if err != nil {
+			return err
+		}
+
+		var displaySize func(int64) string
+		if clicontext.Bool("b") {
+			displaySize = func(s int64) string {
+				return fmt.Sprintf("%d", s)
+			}
+		} else {
+			displaySize = func(s int64) string {
+				return progress.Bytes(s).String()
+			}
+		}
+
+		snapshotter := client.SnapshotService()
+
+		tw := tabwriter.NewWriter(os.Stdout, 1, 8, 1, ' ', 0)
+		fmt.Fprintln(tw, "ID\tSize\tInodes\t")
+
+		if clicontext.NArg() == 0 {
+			if err := snapshotter.Walk(ctx, func(ctx context.Context, info snapshot.Info) error {
+				usage, err := snapshotter.Usage(ctx, info.Name)
+				if err != nil {
+					return err
+				}
+				fmt.Fprintf(tw, "%v\t%s\t%d\t\n", info.Name, displaySize(usage.Size), usage.Inodes)
+				return nil
+			}); err != nil {
+				return err
+			}
+		} else {
+			for _, id := range clicontext.Args() {
+				usage, err := snapshotter.Usage(ctx, id)
+				if err != nil {
+					return err
+				}
+				fmt.Fprintf(tw, "%v\t%s\t%d\t\n", id, displaySize(usage.Size), usage.Inodes)
+			}
+		}
+
+		return tw.Flush()
 	},
 }


### PR DESCRIPTION
Move existing snapshot command to archive subcommand of snapshot.
Add list command for listing snapshots.
Add usage command for showing snapshot disk usage.

Usage example
```
$ctr snapshot usage -b 
ID                                                                      Size     Inodes 
sha256:4ac69ce655ab8aa97362915793348d31361fb3c047e223c2b58be706e89c48fc 6753896  2339   
sha256:ba2cc2690e31f63847e4bc0d266b354f8f11dc04474d45d44312ff70edae9c98 4813139  453    
sha256:bfe0b04fc169b94099b29dbf5a527f6a11db627cd0a6126803edf8f42bd7b4b3 22780075 3      
sha256:d959def87dadbb9ba85070c09e99b46d994967b12f5748f617c377073b8d1e39 349      5      
sha256:dc22a13eb565d14bfe2b16f6fa731a05da0eeff02a52059c7b59cdc2c232a2b2 181      2    
$ ctr snapshot usage sha256:ba2cc2690e31f63847e4bc0d266b354f8f11dc04474d45d44312ff70edae9c98
ID                                                                      Size    Inodes 
sha256:ba2cc2690e31f63847e4bc0d266b354f8f11dc04474d45d44312ff70edae9c98 4.6 MiB 453   
$ ctr snapshot usage sha256:ba2cc2690e31f63847e4bc0d266b354f8f11dc04474d45d44312ff70edae9c98 sha256:bfe0b04fc169b94099b29dbf5a527f6a11db627cd0a6126803edf8f42bd7b4b3
ID                                                                      Size     Inodes 
sha256:ba2cc2690e31f63847e4bc0d266b354f8f11dc04474d45d44312ff70edae9c98 4.6 MiB  453    
sha256:bfe0b04fc169b94099b29dbf5a527f6a11db627cd0a6126803edf8f42bd7b4b3 21.7 MiB 3   
```