### PR TITLE
ctr: Properly delete snapshot if run is called with --rm

### DIFF
--- a/cmd/ctr/run.go
+++ b/cmd/ctr/run.go
@@ -111,7 +111,7 @@ var runCommand = cli.Command{
 			return err
 		}
 		if context.Bool("rm") {
-			defer container.Delete(ctx)
+			defer container.Delete(ctx, containerd.WithRootFSDeletion)
 		}
 		task, err := newTask(ctx, container, checkpointIndex, tty)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>