### PR TITLE
Runtime name printed correctly for containers listing.

### DIFF
--- a/cmd/ctr/list.go
+++ b/cmd/ctr/list.go
@@ -167,7 +167,7 @@ func containerListFn(context *cli.Context) error {
 			if _, err := fmt.Fprintf(cl, "%s\t%s\t%s\t%d\n",
 				c.ID(),
 				imageName,
-				proto.Runtime,
+				proto.Runtime.Name,
 				proto.Size(),
 			); err != nil {
 				return err


### PR DESCRIPTION
Runtime is not printed while container listing due to typo introduced
in #935.
This fixes the Typo.

Signed-off-by: Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>