### PR TITLE
[WIP] Set up identifiers to ContainerIDs and TaskIDs

### DIFF
--- a/cmd/ctr/run.go
+++ b/cmd/ctr/run.go
@@ -7,9 +7,9 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/containerd/console"
 	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/identifiers"
 	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
 
@@ -94,8 +94,8 @@ var runCommand = cli.Command{
 		)
 		defer cancel()
 
-		if id == "" {
-			return errors.New("container id must be provided")
+		if err := identifiers.ValidateContainerId(id); err != nil {
+			return err
 		}
 		if raw := context.String("checkpoint"); raw != "" {
 			if checkpointIndex, err = digest.Parse(raw); err != nil {

--- a/identifiers/validate.go
+++ b/identifiers/validate.go
@@ -18,6 +18,8 @@ import (
 
 const (
 	label = `[A-Za-z][A-Za-z0-9]+(?:[-]+[A-Za-z0-9]+)*`
+
+	containerIdLable = `[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}`
 )
 
 var (
@@ -28,11 +30,19 @@ var (
 	identifierRe = regexp.MustCompile(reAnchor(label + reGroup("[.]"+reGroup(label)) + "*"))
 
 	errIdentifierInvalid = errors.Errorf("invalid, must match %v", identifierRe)
+
+	// containerIdRe validates that a identifier matches valid container and task id.
+	//
+	// TODO(xiekeyang): Current rules for container and task id, following up Docker
+	// container name.
+	containerIdRe = regexp.MustCompile(reAnchor(containerIdLable))
+
+	errContainerIdInvalid = errors.Errorf("invalid container and task id, must match %v", containerIdRe)
 )
 
 // IsInvalid return true if the error was due to an invalid identifer.
 func IsInvalid(err error) bool {
-	return errors.Cause(err) == errIdentifierInvalid
+	return errors.Cause(err) == errIdentifierInvalid || errors.Cause(err) == errContainerIdInvalid
 }
 
 // Validate return nil if the string s is a valid identifier.
@@ -45,6 +55,14 @@ func IsInvalid(err error) bool {
 func Validate(s string) error {
 	if !identifierRe.MatchString(s) {
 		return errors.Wrapf(errIdentifierInvalid, "identifier %q", s)
+	}
+	return nil
+}
+
+// ValidateContainerId return nil if the string s is a valid container and task ID.
+func ValidateContainerId(s string) error {
+	if !containerIdRe.MatchString(s) {
+		return errors.Wrapf(errContainerIdInvalid, "identifier %q", s)
 	}
 	return nil
 }

--- a/identifiers/validate_test.go
+++ b/identifiers/validate_test.go
@@ -1,8 +1,13 @@
 package identifiers
 
 import (
+	"fmt"
+	"math/rand"
 	"testing"
+	"time"
 )
+
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-")
 
 func TestValidIdentifiers(t *testing.T) {
 	for _, input := range []string{
@@ -44,4 +49,59 @@ func TestInvalidIdentifiers(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidContainerId(t *testing.T) {
+	for _, input := range []string{
+		"default",
+		"Default",
+		"default-default",
+		"default--default",
+		"containerd.io",
+		"foo.boo..",
+		"foo_-.boo",
+		"foo_-.",
+		"swarmkit.docker.io",
+		"zn--e9.org",
+		fmt.Sprintf("a%s", randStringRunes(127)),
+	} {
+		t.Run(input, func(t *testing.T) {
+			if err := ValidateContainerId(input); err != nil {
+				t.Fatalf("unexpected error: %v != nil", err)
+			}
+		})
+	}
+}
+
+func TestInvalidContainerId(t *testing.T) {
+	for _, input := range []string{
+		"",
+		".foo..foo",
+		"foo/foo",
+		"foo/..",
+		"-foo.boo",
+		"_foo-boo",
+		fmt.Sprintf("a%s", randStringRunes(128)),
+	} {
+
+		t.Run(input, func(t *testing.T) {
+			if err := ValidateContainerId(input); err == nil {
+				t.Fatal("expected invalid error")
+			} else if !IsInvalid(err) {
+				t.Fatal("error should be an invalid identifier error")
+			}
+		})
+	}
+}
+
+func randStringRunes(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
+}
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
 }


### PR DESCRIPTION
fix issue #1061.

This constrains ContainerIDs and TaskIDs following to Docker container
name. And the max length is limited to 128 bytes.

Signed-off-by: xiekeyang <xiekeyang@huawei.com>

@stevvooe #1061  shows that constraints should follow namespace, but considering your comment https://github.com/containerd/containerd/issues/1046#issue-237650061, it might should follow Docker container name. After determine, I will change in the commit.