### PR TITLE
Fix incorrect reference to the gRPC runtime name as a binary

### DIFF
--- a/linux/runtime.go
+++ b/linux/runtime.go
@@ -434,7 +434,9 @@ func (r *Runtime) getRuntime(ctx context.Context, ns, id string) (*runc.Runc, er
 		return nil, err
 	}
 	return &runc.Runc{
-		Command:      c.Runtime.Name,
+		// TODO: until we have a way to store/retrieve the original command
+		// we can only rely on runc from the default $PATH
+		Command:      runc.DefaultCommand,
 		LogFormat:    runc.JSON,
 		PdeathSignal: unix.SIGKILL,
 		Root:         filepath.Join(client.RuncRoot, ns),


### PR DESCRIPTION
Until we have a way to preserve the initial command used to start the
container, we have to default to the default `runc` found on the $PATH.
This code after the last refactor of shim/API is incorrectly using the
gRPC object reference of the v1 runtime as a binary name which causes
os.Exec() errors.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>