### PR TITLE
Add constrains to namespace size

### DIFF
--- a/identifiers/validate_test.go
+++ b/identifiers/validate_test.go
@@ -1,8 +1,13 @@
 package identifiers
 
 import (
+	"fmt"
+	"math/rand"
 	"testing"
+	"time"
 )
+
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-")
 
 func TestValidIdentifiers(t *testing.T) {
 	for _, input := range []string{
@@ -15,6 +20,9 @@ func TestValidIdentifiers(t *testing.T) {
 		"foo.boo",
 		"swarmkit.docker.io",
 		"zn--e9.org", // or something like it!
+		fmt.Sprintf("a0%s", randStringRunes(maxSizeLabel-2)), // length maxSizeLabel of label
+		fmt.Sprintf("a0%s.a0%s.a0%s.a0%s", randStringRunes(maxSizeLabel-2), randStringRunes(maxSizeLabel-2),
+			randStringRunes(maxSizeLabel-2), randStringRunes(maxSizeLabel-2)), // length maxSizeName of name
 	} {
 		t.Run(input, func(t *testing.T) {
 			if err := Validate(input); err != nil {
@@ -27,13 +35,19 @@ func TestValidIdentifiers(t *testing.T) {
 func TestInvalidIdentifiers(t *testing.T) {
 	for _, input := range []string{
 		".foo..foo",
+		"foo.boo.",
+		"foo.foo",
 		"foo/foo",
+		"foo_boo",
 		"foo/..",
 		"foo..foo",
 		"foo.-boo",
 		"-foo.boo",
 		"foo.boo-",
-		"foo_foo.boo_underscores", // boo-urns?
+		"foo_foo.boo_underscores",                            // boo-urns?
+		fmt.Sprintf("ab%s", randStringRunes(maxSizeLabel-1)), // length maxSizeLabel+1 of label
+		fmt.Sprintf("a0%s.a0%s.a0%s.a0%s.io", randStringRunes(maxSizeLabel-2), randStringRunes(maxSizeLabel-2),
+			randStringRunes(maxSizeLabel-2), randStringRunes(maxSizeLabel-2)), // length maxSizeName+3 of name
 	} {
 
 		t.Run(input, func(t *testing.T) {
@@ -44,4 +58,16 @@ func TestInvalidIdentifiers(t *testing.T) {
 			}
 		})
 	}
+}
+
+func randStringRunes(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
+}
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
 }


### PR DESCRIPTION
Fix issue #1094.

This adds constrains size of namespace, following rfc1035 2.3.4. That
limits labels less than 63 and name less than 255 characters.

Current golang version doesn't support zero-width assertion of reg-exp.
So I have to use `len()` to verify.

Signed-off-by: xiekeyang <xiekeyang@huawei.com>