### PR TITLE
checkSnapshotterBasic: fix umount

### DIFF
--- a/snapshot/testsuite/testsuite.go
+++ b/snapshot/testsuite/testsuite.go
@@ -181,13 +181,14 @@ func checkSnapshotterBasic(ctx context.Context, t *testing.T, snapshotter snapsh
 	if err := mount.MountAll(mounts, nextnext); err != nil {
 		t.Fatalf("failure reason: %+v", err)
 	}
-	defer testutil.Unmount(t, nextnext)
 
 	if err := fstest.CheckDirectoryEqualWithApplier(nextnext,
 		fstest.Apply(initialApplier, diffApplier)); err != nil {
+		testutil.Unmount(t, nextnext)
 		t.Fatalf("failure reason: %+v", err)
 	}
 
+	testutil.Unmount(t, nextnext)
 	assert.NoError(t, snapshotter.Remove(ctx, nextnext))
 	assert.Error(t, snapshotter.Remove(ctx, committed))
 	assert.NoError(t, snapshotter.Remove(ctx, nextCommitted))


### PR DESCRIPTION
The "nextnext" snapshot is being removed at the end of the function.
So umount is needed before removing the snapshot.

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>