### PR TITLE
identifiers: adjust requirements for identifiers

### DIFF
--- a/identifiers/validate_test.go
+++ b/identifiers/validate_test.go
@@ -1,6 +1,7 @@
 package identifiers
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -15,6 +16,9 @@ func TestValidIdentifiers(t *testing.T) {
 		"foo.boo",
 		"swarmkit.docker.io",
 		"zn--e9.org", // or something like it!
+		"0912341234",
+		"task.0.0123456789",
+		strings.Repeat("a", maxLength),
 	} {
 		t.Run(input, func(t *testing.T) {
 			if err := Validate(input); err != nil {
@@ -34,6 +38,7 @@ func TestInvalidIdentifiers(t *testing.T) {
 		"-foo.boo",
 		"foo.boo-",
 		"foo_foo.boo_underscores", // boo-urns?
+		strings.Repeat("a", maxLength+1),
 	} {
 
 		t.Run(input, func(t *testing.T) {


### PR DESCRIPTION
Based on feedback, a few adjustments have been made to the identifier
requirements. Identifiers that have components that start with a number
are now allowed. This violates RFC 1035 but does not do so for dns names
practically. A total length, of 76 characters is now also enforced. This
decision was completely arbitrary but satifies the requirement for a
maximum length. Often, this is used as the maximum length of a line in
editors, so it should be a good choice.

Signed-off-by: Stephen J Day <stephen.day@docker.com>