### PR TITLE
container_test.go: fix compilation failure

### DIFF
--- a/container_test.go
+++ b/container_test.go
@@ -764,7 +764,7 @@ func TestContainerUpdate(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	limit := uint64(32 * 1024 * 1024)
+	limit := int64(32 * 1024 * 1024)
 	spec.Linux.Resources.Memory = &specs.LinuxMemory{
 		Limit: &limit,
 	}
@@ -802,7 +802,7 @@ func TestContainerUpdate(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	if stat.Memory.Usage.Limit != limit {
+	if int64(stat.Memory.Usage.Limit) != limit {
 		t.Errorf("expected memory limit to be set to %d but received %d", limit, stat.Memory.Usage.Limit)
 		return
 	}
@@ -819,7 +819,7 @@ func TestContainerUpdate(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	if stat.Memory.Usage.Limit != limit {
+	if int64(stat.Memory.Usage.Limit) != limit {
 		t.Errorf("expected memory limit to be set to %d but received %d", limit, stat.Memory.Usage.Limit)
 	}
 	if err := task.Kill(ctx, syscall.SIGKILL); err != nil {


### PR DESCRIPTION
Compilation was somehow failing
```
# github.com/containerd/containerd
./container_test.go:769: cannot use &limit (type *uint64) as type *int64 in field value
./container_test.go:812: cannot use &limit (type *uint64) as type *int64 in field value
```

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>