### PR TITLE
Handle kill shim while container is paused

### DIFF
--- a/runtime/process.go
+++ b/runtime/process.go
@@ -262,9 +262,26 @@ func (p *process) handleSigkilledShim(rst uint32, rerr error) (uint32, error) {
 		}
 		if ppid == "1" {
 			logrus.Warnf("containerd: %s:%s shim died, killing associated process", p.container.id, p.id)
+			// Before sending SIGKILL to container, we need to make sure
+			// the container is not in Paused state. If the container is
+			// Paused, the container will not response to any signal
+			// we should Resume it after sending SIGKILL
+			var (
+				s    State
+				err1 error
+			)
+			if p.container != nil {
+				s, err1 = p.container.Status()
+			}
+
 			unix.Kill(p.pid, syscall.SIGKILL)
 			if err != nil && err != syscall.ESRCH {
 				return UnknownStatus, fmt.Errorf("containerd: unable to SIGKILL %s:%s (pid %v): %v", p.container.id, p.id, p.pid, err)
+			}
+			if p.container != nil {
+				if err1 == nil && s == Paused {
+					p.container.Resume()
+				}
 			}
 
 			// wait for the process to die
@@ -287,6 +304,17 @@ func (p *process) handleSigkilledShim(rst uint32, rerr error) (uint32, error) {
 	e := unix.Kill(p.cmd.Process.Pid, 0)
 	if e != syscall.ESRCH {
 		return rst, rerr
+	}
+
+	// The shim was SIGKILLED
+	// We should get the container state first
+	// to make sure the container is not in
+	// Pause state, if it's Paused, we should resume it
+	// and it will exit immediately because shim will send sigkill to
+	// container when died.
+	s, err1 := p.container.Status()
+	if err1 == nil && s == Paused {
+		p.container.Resume()
 	}
 
 	// Ensure we got the shim ProcessState


### PR DESCRIPTION
kill shim will send SIGKILL to its children, but
if the container is paused, the container doesn't
response to the signal, this cause the containerd
block and fail to start next time.

Signed-off-by: Lei Jitang <leijitang@huawei.com>