### PR TITLE
Metrics id -> container_id

### DIFF
--- a/metrics/cgroups/metric.go
+++ b/metrics/cgroups/metric.go
@@ -25,7 +25,7 @@ type metric struct {
 
 func (m *metric) desc(ns *metrics.Namespace) *prometheus.Desc {
 	// the namespace label is for containerd namespaces
-	return ns.NewDesc(m.name, m.help, m.unit, append([]string{"id", "namespace"}, m.labels...)...)
+	return ns.NewDesc(m.name, m.help, m.unit, append([]string{"container_id", "namespace"}, m.labels...)...)
 }
 
 func (m *metric) collect(id, namespace string, stats *cgroups.Stats, ns *metrics.Namespace, ch chan<- prometheus.Metric) {

--- a/metrics/cgroups/oom.go
+++ b/metrics/cgroups/oom.go
@@ -19,7 +19,7 @@ func NewOOMCollector(ns *metrics.Namespace) (*OOMCollector, error) {
 	}
 	c := &OOMCollector{
 		fd:        fd,
-		memoryOOM: ns.NewLabeledGauge("memory_oom", "The number of times a container received an oom event", metrics.Total, "id", "namespace"),
+		memoryOOM: ns.NewLabeledGauge("memory_oom", "The number of times a container received an oom event", metrics.Total, "container_id", "namespace"),
 		set:       make(map[uintptr]*oom),
 	}
 	go c.start()


### PR DESCRIPTION
Make sure we use container id as the id saved in the metrics labels

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>