### PR TITLE
containerd: rename FifoSet to FIFOSet

### DIFF
--- a/container.go
+++ b/container.go
@@ -184,7 +184,7 @@ func (c *container) loadTask(ctx context.Context, ioAttach IOAttach) (Task, erro
 	var i *IO
 	if ioAttach != nil {
 		// get the existing fifo paths from the task information stored by the daemon
-		paths := &FifoSet{
+		paths := &FIFOSet{
 			Dir: getFifoDir([]string{
 				response.Task.Stdin,
 				response.Task.Stdout,

--- a/io.go
+++ b/io.go
@@ -27,7 +27,7 @@ func (i *IO) Close() error {
 
 type IOCreation func() (*IO, error)
 
-type IOAttach func(*FifoSet) (*IO, error)
+type IOAttach func(*FIFOSet) (*IO, error)
 
 func NewIO(stdin io.Reader, stdout, stderr io.Writer) IOCreation {
 	return NewIOWithTerminal(stdin, stdout, stderr, false)
@@ -61,7 +61,7 @@ func NewIOWithTerminal(stdin io.Reader, stdout, stderr io.Writer, terminal bool)
 }
 
 func WithAttach(stdin io.Reader, stdout, stderr io.Writer) IOAttach {
-	return func(paths *FifoSet) (*IO, error) {
+	return func(paths *FIFOSet) (*IO, error) {
 		if paths == nil {
 			return nil, fmt.Errorf("cannot attach to existing fifos")
 		}
@@ -97,7 +97,7 @@ func StdioTerminal() (*IO, error) {
 }
 
 // NewFifos returns a new set of fifos for the task
-func NewFifos() (*FifoSet, error) {
+func NewFifos() (*FIFOSet, error) {
 	root := filepath.Join(os.TempDir(), "containerd")
 	if err := os.MkdirAll(root, 0700); err != nil {
 		return nil, err
@@ -106,7 +106,7 @@ func NewFifos() (*FifoSet, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &FifoSet{
+	return &FIFOSet{
 		Dir: dir,
 		In:  filepath.Join(dir, "stdin"),
 		Out: filepath.Join(dir, "stdout"),
@@ -114,7 +114,7 @@ func NewFifos() (*FifoSet, error) {
 	}, nil
 }
 
-type FifoSet struct {
+type FIFOSet struct {
 	// Dir is the directory holding the task fifos
 	Dir          string
 	In, Out, Err string

--- a/io_unix.go
+++ b/io_unix.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containerd/fifo"
 )
 
-func copyIO(fifos *FifoSet, ioset *ioSet, tty bool) (closer io.Closer, err error) {
+func copyIO(fifos *FIFOSet, ioset *ioSet, tty bool) (closer io.Closer, err error) {
 	var (
 		f   io.ReadWriteCloser
 		ctx = context.Background()

--- a/io_windows.go
+++ b/io_windows.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func copyIO(fifos *FifoSet, ioset *ioSet, tty bool) (closer io.Closer, err error) {
+func copyIO(fifos *FIFOSet, ioset *ioSet, tty bool) (closer io.Closer, err error) {
 	var wg sync.WaitGroup
 
 	if fifos.In != "" {


### PR DESCRIPTION
Per Go's style guidelines, `Fifo` should be `FIFO` since it is an
initialism.

Signed-off-by: Stephen J Day <stephen.day@docker.com>