### PR TITLE
Add a test for #828

### DIFF
--- a/integration-test/check_test.go
+++ b/integration-test/check_test.go
@@ -211,7 +211,7 @@ func (cs *ContainerdSuite) SetUpSuite(c *check.C) {
 	cs.grpcSocket = "unix://" + filepath.Join(cs.outputDir, "containerd-master", "containerd.sock")
 	cdLogFile := filepath.Join(cs.outputDir, "containerd-master", "containerd.log")
 
-	f, err := os.OpenFile(cdLogFile, os.O_CREATE|os.O_TRUNC|os.O_RDWR|os.O_SYNC, 0777)
+	f, err := os.OpenFile(cdLogFile, os.O_CREATE|os.O_APPEND|os.O_RDWR|os.O_SYNC, 0777)
 	if err != nil {
 		c.Fatalf("Failed to create master containerd log file: %v", err)
 	}
@@ -222,7 +222,6 @@ func (cs *ContainerdSuite) SetUpSuite(c *check.C) {
 }
 
 func (cs *ContainerdSuite) TearDownSuite(c *check.C) {
-
 	// tell containerd to stop
 	if cs.cd != nil {
 		cs.cd.Process.Signal(os.Interrupt)

--- a/integration-test/restore_test.go
+++ b/integration-test/restore_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/containerd/containerd/api/grpc/types"
+	"github.com/containerd/containerd/runtime"
+	"github.com/docker/docker/pkg/integration/checker"
+	"github.com/go-check/check"
+)
+
+func (cs *ContainerdSuite) TestRestoreWithNoPRocessDir(t *check.C) {
+	bundleName := "busybox-top"
+	if err := CreateBusyboxBundle(bundleName, []string{"top"}); err != nil {
+		t.Fatal(err)
+	}
+
+	containerID := "temp-top"
+	c, err := cs.StartContainer(containerID, bundleName)
+	t.Assert(err, checker.Equals, nil)
+
+	ch := c.GetEventsChannel()
+	select {
+	case e := <-ch:
+		t.Assert(*e, checker.Equals, types.Event{
+			Type:      "start-container",
+			Id:        containerID,
+			Status:    0,
+			Pid:       "",
+			Timestamp: e.Timestamp,
+		})
+	case <-time.After(2 * time.Second):
+		t.Fatal("Container took more than 2 seconds to start")
+	}
+
+	// Kill containerd
+	cs.StopDaemon(true)
+
+	// Kill Top
+	err = exec.Command("pkill", "-9", "top").Run()
+	t.Assert(err, checker.Equals, nil)
+
+	// Delete the init process directory
+	err = os.RemoveAll(filepath.Join(cs.stateDir, containerID, runtime.InitProcessID))
+	t.Assert(err, checker.Equals, nil)
+
+	// restart daemon and make sure we get an exit event
+	cs.StartDaemon()
+
+	containers, err := cs.ListRunningContainers()
+	t.Assert(err, checker.Equals, nil)
+	t.Assert(len(containers), checker.Equals, 0)
+}


### PR DESCRIPTION
This test that the daemon can restart if it was killed before all a process
state dir could be removed.

Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>