### PR TITLE
containerd-shim: Do not remount root MS_SLAVE

### DIFF
--- a/cmd/containerd-shim/main_unix.go
+++ b/cmd/containerd-shim/main_unix.go
@@ -67,9 +67,6 @@ func main() {
 		if err != nil {
 			return err
 		}
-		if err := setupRoot(); err != nil {
-			return err
-		}
 		path, err := os.Getwd()
 		if err != nil {
 			return err

--- a/cmd/containerd-shim/shim_linux.go
+++ b/cmd/containerd-shim/shim_linux.go
@@ -10,7 +10,6 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	"golang.org/x/net/context"
-	"golang.org/x/sys/unix"
 
 	"github.com/containerd/containerd/reaper"
 	"github.com/containerd/containerd/sys"
@@ -31,11 +30,6 @@ func setupSignals() (chan os.Signal, error) {
 		return nil, err
 	}
 	return signals, nil
-}
-
-// setupRoot sets up the root as the shim is started in its own mount namespace
-func setupRoot() error {
-	return unix.Mount("", "/", "", unix.MS_SLAVE|unix.MS_REC, "")
 }
 
 func newServer() *grpc.Server {

--- a/cmd/containerd-shim/shim_unix.go
+++ b/cmd/containerd-shim/shim_unix.go
@@ -23,11 +23,6 @@ func setupSignals() (chan os.Signal, error) {
 	return signals, nil
 }
 
-// setupRoot is a no op except on Linux
-func setupRoot() error {
-	return nil
-}
-
 func newServer() *grpc.Server {
 	return grpc.NewServer()
 }

--- a/mount/mount.go
+++ b/mount/mount.go
@@ -22,3 +22,19 @@ func MountAll(mounts []Mount, target string) error {
 	}
 	return nil
 }
+
+// UnmountN tries to unmount the given mount point nr times, which is
+// useful for undoing a stack of mounts on the same mount
+// point. Returns the first error encountered, but always attempts the
+// full nr umounts.
+func UnmountN(mount string, flags, nr int) error {
+	var err error
+	for i := 0; i < nr; i++ {
+		if err2 := Unmount(mount, flags); err2 != nil {
+			if err == nil {
+				err = err2
+			}
+		}
+	}
+	return err
+}

--- a/mount/mount.go
+++ b/mount/mount.go
@@ -22,19 +22,3 @@ func MountAll(mounts []Mount, target string) error {
 	}
 	return nil
 }
-
-// UnmountN tries to unmount the given mount point nr times, which is
-// useful for undoing a stack of mounts on the same mount
-// point. Returns the first error encountered, but always attempts the
-// full nr umounts.
-func UnmountN(mount string, flags, nr int) error {
-	var err error
-	for i := 0; i < nr; i++ {
-		if err2 := Unmount(mount, flags); err2 != nil {
-			if err == nil {
-				err = err2
-			}
-		}
-	}
-	return err
-}

--- a/mount/mount_unix.go
+++ b/mount/mount_unix.go
@@ -15,3 +15,7 @@ func (m *Mount) Mount(target string) error {
 func Unmount(mount string, flags int) error {
 	return ErrNotImplementOnUnix
 }
+
+func UnmountAll(mount string, flags int) error {
+	return ErrNotImplementOnUnix
+}

--- a/mount/mount_windows.go
+++ b/mount/mount_windows.go
@@ -13,3 +13,7 @@ func (m *Mount) Mount(target string) error {
 func Unmount(mount string, flags int) error {
 	return ErrNotImplementOnWindows
 }
+
+func UnmountAll(mount string, flags int) error {
+	return ErrNotImplementOnWindows
+}


### PR DESCRIPTION
Mounting as MS_SLAVE here breaks use cases which want to use
rootPropagation=shared in order to expose mounts to the host (and other
containers binding the same subtree).

Note that runc will also setup root as required by rootPropagation, defaulting
to MS_PRIVATE.

Fixes #1132.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>