### PR TITLE
Adding missing arguments to Wrapf

### DIFF
--- a/metadata/containers.go
+++ b/metadata/containers.go
@@ -34,7 +34,7 @@ func (s *containerStore) Get(ctx context.Context, id string) (containers.Contain
 
 	bkt := getContainerBucket(s.tx, namespace, id)
 	if bkt == nil {
-		return containers.Container{}, errors.Wrapf(errdefs.ErrNotFound, "bucket name %q")
+		return containers.Container{}, errors.Wrapf(errdefs.ErrNotFound, "bucket name %q:%q", namespace, id)
 	}
 
 	container := containers.Container{ID: id}
@@ -144,7 +144,7 @@ func (s *containerStore) Create(ctx context.Context, container containers.Contai
 	cbkt, err := bkt.CreateBucket([]byte(container.ID))
 	if err != nil {
 		if err == bolt.ErrBucketExists {
-			err = errors.Wrapf(errdefs.ErrAlreadyExists, "content %q")
+			err = errors.Wrapf(errdefs.ErrAlreadyExists, "content %q", container.ID)
 		}
 		return containers.Container{}, err
 	}

--- a/metadata/namespaces.go
+++ b/metadata/namespaces.go
@@ -32,7 +32,7 @@ func (s *namespaceStore) Create(ctx context.Context, namespace string, labels ma
 	bkt, err := topbkt.CreateBucket([]byte(namespace))
 	if err != nil {
 		if err == bolt.ErrBucketExists {
-			return errors.Wrapf(errdefs.ErrAlreadyExists, "namespace %q")
+			return errors.Wrapf(errdefs.ErrAlreadyExists, "namespace %q", namespace)
 		}
 
 		return err


### PR DESCRIPTION
I noticed some "%q!!missing!!" in my logs and found:

$ git grep 'f(.*, ".*%q.*")'
metadata/containers.go:         return containers.Container{}, errors.Wrapf(errdefs.ErrNotFound, "bucket name %q")
metadata/containers.go:                 err = errors.Wrapf(errdefs.ErrAlreadyExists, "content %q")
metadata/namespaces.go:                 return errors.Wrapf(errdefs.ErrAlreadyExists, "namespace %q")

Signed-off-by: Ian Campbell <ian.campbell@docker.com>

/cc @stevvooe I think these snuck in via a4fadc596b219ad75837d97a1be3bc40e06d97ce ("errdefs: centralize error handling").