### PR TITLE
cmd/ctr: info marshal Container proto struct

### DIFF
--- a/cmd/ctr/info.go
+++ b/cmd/ctr/info.go
@@ -31,7 +31,7 @@ var infoCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		cjson, err := json.MarshalIndent(container, "", "    ")
+		cjson, err := json.MarshalIndent(container.Proto(), "", "    ")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Marshaling Container interface resulted in empty json. Use Container proto
struct to get proper container attributes.

Signed-off-by: Sunny Gogoi <me@darkowlzz.space>

Fixes #1092 