### PR TITLE
images, containers: converge metadata API conventions

### DIFF
--- a/api/services/events/v1/container.pb.go
+++ b/api/services/events/v1/container.pb.go
@@ -22,6 +22,7 @@
 		ContentDelete
 		StreamEventsRequest
 		Envelope
+		ImageCreate
 		ImageUpdate
 		ImageDelete
 		NamespaceCreate

--- a/api/services/events/v1/image.pb.go
+++ b/api/services/events/v1/image.pb.go
@@ -19,6 +19,15 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+type ImageCreate struct {
+	Name   string            `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Labels map[string]string `protobuf:"bytes,2,rep,name=labels" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+}
+
+func (m *ImageCreate) Reset()                    { *m = ImageCreate{} }
+func (*ImageCreate) ProtoMessage()               {}
+func (*ImageCreate) Descriptor() ([]byte, []int) { return fileDescriptorImage, []int{0} }
+
 type ImageUpdate struct {
 	Name   string            `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	Labels map[string]string `protobuf:"bytes,2,rep,name=labels" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
@@ -26,7 +35,7 @@ type ImageUpdate struct {
 
 func (m *ImageUpdate) Reset()                    { *m = ImageUpdate{} }
 func (*ImageUpdate) ProtoMessage()               {}
-func (*ImageUpdate) Descriptor() ([]byte, []int) { return fileDescriptorImage, []int{0} }
+func (*ImageUpdate) Descriptor() ([]byte, []int) { return fileDescriptorImage, []int{1} }
 
 type ImageDelete struct {
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -34,12 +43,54 @@ type ImageDelete struct {
 
 func (m *ImageDelete) Reset()                    { *m = ImageDelete{} }
 func (*ImageDelete) ProtoMessage()               {}
-func (*ImageDelete) Descriptor() ([]byte, []int) { return fileDescriptorImage, []int{1} }
+func (*ImageDelete) Descriptor() ([]byte, []int) { return fileDescriptorImage, []int{2} }
 
 func init() {
+	proto.RegisterType((*ImageCreate)(nil), "containerd.services.images.v1.ImageCreate")
 	proto.RegisterType((*ImageUpdate)(nil), "containerd.services.images.v1.ImageUpdate")
 	proto.RegisterType((*ImageDelete)(nil), "containerd.services.images.v1.ImageDelete")
 }
+func (m *ImageCreate) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ImageCreate) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Name) > 0 {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintImage(dAtA, i, uint64(len(m.Name)))
+		i += copy(dAtA[i:], m.Name)
+	}
+	if len(m.Labels) > 0 {
+		for k, _ := range m.Labels {
+			dAtA[i] = 0x12
+			i++
+			v := m.Labels[k]
+			mapSize := 1 + len(k) + sovImage(uint64(len(k))) + 1 + len(v) + sovImage(uint64(len(v)))
+			i = encodeVarintImage(dAtA, i, uint64(mapSize))
+			dAtA[i] = 0xa
+			i++
+			i = encodeVarintImage(dAtA, i, uint64(len(k)))
+			i += copy(dAtA[i:], k)
+			dAtA[i] = 0x12
+			i++
+			i = encodeVarintImage(dAtA, i, uint64(len(v)))
+			i += copy(dAtA[i:], v)
+		}
+	}
+	return i, nil
+}
+
 func (m *ImageUpdate) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -132,6 +183,24 @@ func encodeVarintImage(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return offset + 1
 }
+func (m *ImageCreate) Size() (n int) {
+	var l int
+	_ = l
+	l = len(m.Name)
+	if l > 0 {
+		n += 1 + l + sovImage(uint64(l))
+	}
+	if len(m.Labels) > 0 {
+		for k, v := range m.Labels {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + sovImage(uint64(len(k))) + 1 + len(v) + sovImage(uint64(len(v)))
+			n += mapEntrySize + 1 + sovImage(uint64(mapEntrySize))
+		}
+	}
+	return n
+}
+
 func (m *ImageUpdate) Size() (n int) {
 	var l int
 	_ = l
@@ -173,6 +242,27 @@ func sovImage(x uint64) (n int) {
 func sozImage(x uint64) (n int) {
 	return sovImage(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+func (this *ImageCreate) String() string {
+	if this == nil {
+		return "nil"
+	}
+	keysForLabels := make([]string, 0, len(this.Labels))
+	for k, _ := range this.Labels {
+		keysForLabels = append(keysForLabels, k)
+	}
+	github_com_gogo_protobuf_sortkeys.Strings(keysForLabels)
+	mapStringForLabels := "map[string]string{"
+	for _, k := range keysForLabels {
+		mapStringForLabels += fmt.Sprintf("%v: %v,", k, this.Labels[k])
+	}
+	mapStringForLabels += "}"
+	s := strings.Join([]string{`&ImageCreate{`,
+		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`Labels:` + mapStringForLabels + `,`,
+		`}`,
+	}, "")
+	return s
+}
 func (this *ImageUpdate) String() string {
 	if this == nil {
 		return "nil"
@@ -211,6 +301,201 @@ func valueToStringImage(v interface{}) string {
 	}
 	pv := reflect.Indirect(rv).Interface()
 	return fmt.Sprintf("*%v", pv)
+}
+func (m *ImageCreate) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowImage
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ImageCreate: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ImageCreate: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowImage
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthImage
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Name = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Labels", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowImage
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthImage
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var keykey uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowImage
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				keykey |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			var stringLenmapkey uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowImage
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLenmapkey |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLenmapkey := int(stringLenmapkey)
+			if intStringLenmapkey < 0 {
+				return ErrInvalidLengthImage
+			}
+			postStringIndexmapkey := iNdEx + intStringLenmapkey
+			if postStringIndexmapkey > l {
+				return io.ErrUnexpectedEOF
+			}
+			mapkey := string(dAtA[iNdEx:postStringIndexmapkey])
+			iNdEx = postStringIndexmapkey
+			if m.Labels == nil {
+				m.Labels = make(map[string]string)
+			}
+			if iNdEx < postIndex {
+				var valuekey uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowImage
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					valuekey |= (uint64(b) & 0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				var stringLenmapvalue uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowImage
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLenmapvalue |= (uint64(b) & 0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLenmapvalue := int(stringLenmapvalue)
+				if intStringLenmapvalue < 0 {
+					return ErrInvalidLengthImage
+				}
+				postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+				if postStringIndexmapvalue > l {
+					return io.ErrUnexpectedEOF
+				}
+				mapvalue := string(dAtA[iNdEx:postStringIndexmapvalue])
+				iNdEx = postStringIndexmapvalue
+				m.Labels[mapkey] = mapvalue
+			} else {
+				var mapvalue string
+				m.Labels[mapkey] = mapvalue
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipImage(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthImage
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
 }
 func (m *ImageUpdate) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
@@ -596,21 +881,22 @@ func init() {
 }
 
 var fileDescriptorImage = []byte{
-	// 251 bytes of a gzipped FileDescriptorProto
+	// 263 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x72, 0x4e, 0xcf, 0x2c, 0xc9,
 	0x28, 0x4d, 0xd2, 0x4b, 0xce, 0xcf, 0xd5, 0x4f, 0xce, 0xcf, 0x2b, 0x49, 0xcc, 0xcc, 0x4b, 0x2d,
 	0x4a, 0x41, 0x66, 0x26, 0x16, 0x64, 0xea, 0x17, 0xa7, 0x16, 0x95, 0x65, 0x26, 0xa7, 0x16, 0xeb,
 	0xa7, 0x96, 0xa5, 0xe6, 0x95, 0x14, 0xeb, 0x97, 0x19, 0xea, 0x67, 0xe6, 0x26, 0xa6, 0xa7, 0xea,
 	0x15, 0x14, 0xe5, 0x97, 0xe4, 0x0b, 0xc9, 0x22, 0x94, 0xeb, 0xc1, 0x94, 0xea, 0x81, 0x15, 0x14,
-	0xeb, 0x95, 0x19, 0x2a, 0xad, 0x61, 0xe4, 0xe2, 0xf6, 0x04, 0xf1, 0x42, 0x0b, 0x52, 0x12, 0x4b,
+	0xeb, 0x95, 0x19, 0x2a, 0xad, 0x61, 0xe4, 0xe2, 0xf6, 0x04, 0xf1, 0x9c, 0x8b, 0x52, 0x13, 0x4b,
 	0x52, 0x85, 0x84, 0xb8, 0x58, 0xf2, 0x12, 0x73, 0x53, 0x25, 0x18, 0x15, 0x18, 0x35, 0x38, 0x83,
 	0xc0, 0x6c, 0x21, 0x3f, 0x2e, 0xb6, 0x9c, 0xc4, 0xa4, 0xd4, 0x9c, 0x62, 0x09, 0x26, 0x05, 0x66,
 	0x0d, 0x6e, 0x23, 0x33, 0x3d, 0xbc, 0x66, 0xea, 0x21, 0x99, 0xa7, 0xe7, 0x03, 0xd6, 0xe8, 0x9a,
 	0x57, 0x52, 0x54, 0x19, 0x04, 0x35, 0x45, 0xca, 0x92, 0x8b, 0x1b, 0x49, 0x58, 0x48, 0x80, 0x8b,
 	0x39, 0x3b, 0xb5, 0x12, 0x6a, 0x23, 0x88, 0x29, 0x24, 0xc2, 0xc5, 0x5a, 0x96, 0x98, 0x53, 0x9a,
-	0x2a, 0xc1, 0x04, 0x16, 0x83, 0x70, 0xac, 0x98, 0x2c, 0x18, 0x95, 0x14, 0xa1, 0xae, 0x75, 0x49,
-	0xcd, 0x49, 0xc5, 0xee, 0x5a, 0xa7, 0x88, 0x13, 0x0f, 0xe5, 0x18, 0x6e, 0x3c, 0x94, 0x63, 0x68,
-	0x78, 0x24, 0xc7, 0x78, 0xe2, 0x91, 0x1c, 0xe3, 0x85, 0x47, 0x72, 0x8c, 0x0f, 0x1e, 0xc9, 0x31,
-	0x46, 0xd9, 0x91, 0x19, 0x9e, 0xd6, 0x10, 0x56, 0x12, 0x1b, 0x38, 0x44, 0x8d, 0x01, 0x01, 0x00,
-	0x00, 0xff, 0xff, 0x0c, 0x2f, 0x4e, 0xf3, 0x98, 0x01, 0x00, 0x00,
+	0x2a, 0xc1, 0x04, 0x16, 0x83, 0x70, 0xac, 0x98, 0x2c, 0x18, 0x11, 0xce, 0x0d, 0x2d, 0x48, 0xa1,
+	0xaa, 0x73, 0x21, 0xe6, 0x51, 0xdb, 0xb9, 0x8a, 0x50, 0xd7, 0xba, 0xa4, 0xe6, 0xa4, 0x62, 0x77,
+	0xad, 0x53, 0xc4, 0x89, 0x87, 0x72, 0x0c, 0x37, 0x1e, 0xca, 0x31, 0x34, 0x3c, 0x92, 0x63, 0x3c,
+	0xf1, 0x48, 0x8e, 0xf1, 0xc2, 0x23, 0x39, 0xc6, 0x07, 0x8f, 0xe4, 0x18, 0xa3, 0xec, 0xc8, 0x8c,
+	0x7e, 0x6b, 0x08, 0x2b, 0x89, 0x0d, 0x9c, 0x00, 0x8c, 0x01, 0x01, 0x00, 0x00, 0xff, 0xff, 0x13,
+	0x7c, 0x2c, 0x4a, 0x47, 0x02, 0x00, 0x00,
 }

--- a/api/services/events/v1/image.proto
+++ b/api/services/events/v1/image.proto
@@ -4,6 +4,11 @@ package containerd.services.images.v1;
 
 option go_package = "github.com/containerd/containerd/api/services/events/v1;events";
 
+message ImageCreate {
+	string name = 1;
+	map<string, string> labels = 2;
+}
+
 message ImageUpdate {
 	string name = 1;
 	map<string, string> labels = 2;

--- a/api/services/images/v1/images.proto
+++ b/api/services/images/v1/images.proto
@@ -4,6 +4,8 @@ package containerd.services.images.v1;
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/empty.proto";
+import "google/protobuf/field_mask.proto";
+import "google/protobuf/timestamp.proto";
 import "github.com/containerd/containerd/api/types/descriptor.proto";
 
 option go_package = "github.com/containerd/containerd/api/services/images/v1;images";
@@ -26,6 +28,11 @@ service Images {
 	// List returns a list of all images known to containerd.
 	rpc List(ListImagesRequest) returns (ListImagesResponse);
 
+	// Create an image record in the metadata store.
+	//
+	// The name of the image must be unique.
+	rpc Create(CreateImageRequest) returns (CreateImageResponse);
+
 	// Update assigns the name to a given target image based on the provided
 	// image.
 	rpc Update(UpdateImageRequest) returns (UpdateImageResponse);
@@ -35,9 +42,25 @@ service Images {
 }
 
 message Image {
+	// Name provides a unique name for the image.
+	//
+	// Containerd treats this as the primary identifier.
 	string name = 1;
+
+	// Labels provides free form labels for the image. These are runtime only
+	// and do not get inherited into the package image in any way.
+	//
+	// Labels may be updated using the field mask.
 	map<string, string> labels = 2;
+
+	// Target describes the content entry point of the image.
 	containerd.types.Descriptor target = 3 [(gogoproto.nullable) = false];
+
+	// CreatedAt is the time the image was first created.
+	google.protobuf.Timestamp created_at = 7 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
+
+	// UpdatedAt is the last time the image was mutated.
+	google.protobuf.Timestamp updated_at = 8 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
 }
 
 message GetImageRequest {
@@ -48,8 +71,23 @@ message GetImageResponse {
 	Image image = 1;
 }
 
-message UpdateImageRequest {
+message CreateImageRequest {
 	Image image = 1 [(gogoproto.nullable) = false];
+}
+
+message CreateImageResponse {
+	Image image = 1 [(gogoproto.nullable) = false];
+}
+
+message UpdateImageRequest {
+	// Image provides a full or partial image for update.
+	//
+	// The name field must be set or an error will be returned.
+	Image image = 1 [(gogoproto.nullable) = false];
+
+	// UpdateMask specifies which fields to perform the update on. If empty,
+	// the operation applies to all fields.
+	google.protobuf.FieldMask update_mask = 2;
 }
 
 message UpdateImageResponse {
@@ -57,7 +95,17 @@ message UpdateImageResponse {
 }
 
 message ListImagesRequest {
-	string filter = 1;
+	// Filters contains one or more filters using the syntax defined in the
+	// containerd filter package.
+	//
+	// The returned result will be those that match any of the provided
+	// filters. Expanded, images that match the following will be
+	// returned:
+	//
+	//   filters[0] or filters[1] or ... or filters[n-1] or filters[n]
+	//
+	// If filters is zero-length or nil, all items will be returned.
+	repeated string filters = 1;
 }
 
 message ListImagesResponse {

--- a/containers/containers.go
+++ b/containers/containers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/containerd/containerd/filters"
 	"github.com/gogo/protobuf/types"
 )
 
@@ -32,9 +31,15 @@ type Store interface {
 	Get(ctx context.Context, id string) (Container, error)
 
 	// List returns containers that match one or more of the provided filters.
-	List(ctx context.Context, filters ...filters.Filter) ([]Container, error)
+	List(ctx context.Context, filters ...string) ([]Container, error)
 
 	Create(ctx context.Context, container Container) (Container, error)
-	Update(ctx context.Context, container Container) (Container, error)
+
+	// Update the container with the provided container object. ID must be set.
+	//
+	// If one or more fieldpaths are provided, only the field corresponding to
+	// the fieldpaths will be mutated.
+	Update(ctx context.Context, container Container, fieldpaths ...string) (Container, error)
+
 	Delete(ctx context.Context, id string) error
 }

--- a/filters/parser.go
+++ b/filters/parser.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"strconv"
 
+	"github.com/containerd/containerd/errdefs"
 	"github.com/pkg/errors"
 )
 
@@ -40,6 +41,28 @@ func Parse(s string) (Filter, error) {
 
 	p := parser{input: s}
 	return p.parse()
+}
+
+// ParseAll parses each filter in ss and returns a filter that will return true
+// if any filter matches the expression.
+//
+// If no fitlers are provided, the filter will match anything.
+func ParseAll(ss ...string) (Filter, error) {
+	if len(ss) == 0 {
+		return Always, nil
+	}
+
+	var fs []Filter
+	for _, s := range ss {
+		f, err := Parse(s)
+		if err != nil {
+			return nil, errors.Wrapf(errdefs.ErrInvalidArgument, err.Error())
+		}
+
+		fs = append(fs, f)
+	}
+
+	return Any(fs), nil
 }
 
 type parser struct {

--- a/images/image.go
+++ b/images/image.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"io/ioutil"
+	"time"
 
 	"github.com/containerd/containerd/content"
 	digest "github.com/opencontainers/go-digest"
@@ -13,14 +14,21 @@ import (
 
 // Image provides the model for how containerd views container images.
 type Image struct {
-	Name   string
-	Target ocispec.Descriptor
+	Name                 string
+	Labels               map[string]string
+	Target               ocispec.Descriptor
+	CreatedAt, UpdatedAt time.Time
 }
 
 type Store interface {
-	Update(ctx context.Context, name string, desc ocispec.Descriptor) error
 	Get(ctx context.Context, name string) (Image, error)
-	List(ctx context.Context) ([]Image, error)
+	List(ctx context.Context, filters ...string) ([]Image, error)
+	Create(ctx context.Context, image Image) (Image, error)
+
+	// Update will replace the data in the store with the provided image. If
+	// one or more fieldpaths are provided, only those fields will be updated.
+	Update(ctx context.Context, image Image, fieldpaths ...string) (Image, error)
+
 	Delete(ctx context.Context, name string) error
 }
 

--- a/metadata/adaptors.go
+++ b/metadata/adaptors.go
@@ -1,0 +1,79 @@
+package metadata
+
+import (
+	"strings"
+
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/filters"
+	"github.com/containerd/containerd/images"
+)
+
+func adaptImage(o interface{}) filters.Adaptor {
+	obj := o.(images.Image)
+	return filters.AdapterFunc(func(fieldpath []string) (string, bool) {
+		if len(fieldpath) == 0 {
+			return "", false
+		}
+
+		switch fieldpath[0] {
+		case "name":
+			return obj.Name, len(obj.Name) > 0
+		case "target":
+			if len(fieldpath) < 2 {
+				return "", false
+			}
+
+			switch fieldpath[1] {
+			case "digest":
+				return obj.Target.Digest.String(), len(obj.Target.Digest) > 0
+			case "mediatype":
+				return obj.Target.MediaType, len(obj.Target.MediaType) > 0
+			}
+		case "labels":
+			return checkMap(fieldpath[1:], obj.Labels)
+			// TODO(stevvooe): Greater/Less than filters would be awesome for
+			// size. Let's do it!
+		}
+
+		return "", false
+	})
+}
+func adaptContainer(o interface{}) filters.Adaptor {
+	obj := o.(containers.Container)
+	return filters.AdapterFunc(func(fieldpath []string) (string, bool) {
+		if len(fieldpath) == 0 {
+			return "", false
+		}
+
+		switch fieldpath[0] {
+		case "id":
+			return obj.ID, len(obj.ID) > 0
+		case "runtime":
+			if len(fieldpath) <= 1 {
+				return "", false
+			}
+
+			switch fieldpath[1] {
+			case "name":
+				return obj.Runtime.Name, len(obj.Runtime.Name) > 0
+			default:
+				return "", false
+			}
+		case "image":
+			return obj.Image, len(obj.Image) > 0
+		case "labels":
+			return checkMap(fieldpath[1:], obj.Labels)
+		}
+
+		return "", false
+	})
+}
+
+func checkMap(fieldpath []string, m map[string]string) (string, bool) {
+	if len(m) == 0 {
+		return "", false
+	}
+
+	value, ok := m[strings.Join(fieldpath, ".")]
+	return value, ok
+}

--- a/metadata/buckets.go
+++ b/metadata/buckets.go
@@ -44,6 +44,7 @@ var (
 	bucketKeyOptions   = []byte("options")
 	bucketKeySpec      = []byte("spec")
 	bucketKeyRootFS    = []byte("rootfs")
+	bucketKeyTarget    = []byte("target")
 	bucketKeyCreatedAt = []byte("createdat")
 	bucketKeyUpdatedAt = []byte("updatedat")
 )

--- a/metadata/containers.go
+++ b/metadata/containers.go
@@ -45,25 +45,23 @@ func (s *containerStore) Get(ctx context.Context, id string) (containers.Contain
 	return container, nil
 }
 
-func (s *containerStore) List(ctx context.Context, fs ...filters.Filter) ([]containers.Container, error) {
+func (s *containerStore) List(ctx context.Context, fs ...string) ([]containers.Container, error) {
 	namespace, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	var (
-		m      []containers.Container
-		filter = filters.Filter(filters.Any(fs))
-		bkt    = getContainersBucket(s.tx, namespace)
-	)
-
-	if len(fs) == 0 {
-		filter = filters.Always
+	filter, err := filters.ParseAll(fs...)
+	if err != nil {
+		return nil, errors.Wrapf(errdefs.ErrInvalidArgument, err.Error())
 	}
 
+	bkt := getContainersBucket(s.tx, namespace)
 	if bkt == nil {
-		return m, nil
+		return nil, nil
 	}
+
+	var m []containers.Container
 	if err := bkt.ForEach(func(k, v []byte) error {
 		cbkt := bkt.Bucket(k)
 		if cbkt == nil {
@@ -84,46 +82,6 @@ func (s *containerStore) List(ctx context.Context, fs ...filters.Filter) ([]cont
 	}
 
 	return m, nil
-}
-
-func adaptContainer(o interface{}) filters.Adaptor {
-	obj := o.(containers.Container)
-	return filters.AdapterFunc(func(fieldpath []string) (string, bool) {
-		if len(fieldpath) == 0 {
-			return "", false
-		}
-
-		switch fieldpath[0] {
-		case "id":
-			return obj.ID, len(obj.ID) > 0
-		case "runtime":
-			if len(fieldpath) <= 1 {
-				return "", false
-			}
-
-			switch fieldpath[1] {
-			case "name":
-				return obj.Runtime.Name, len(obj.Runtime.Name) > 0
-			default:
-				return "", false
-			}
-		case "image":
-			return obj.Image, len(obj.Image) > 0
-		case "labels":
-			return checkMap(fieldpath[1:], obj.Labels)
-		}
-
-		return "", false
-	})
-}
-
-func checkMap(fieldpath []string, m map[string]string) (string, bool) {
-	if len(m) == 0 {
-		return "", false
-	}
-
-	value, ok := m[strings.Join(fieldpath, ".")]
-	return value, ok
 }
 
 func (s *containerStore) Create(ctx context.Context, container containers.Container) (containers.Container, error) {
@@ -149,16 +107,16 @@ func (s *containerStore) Create(ctx context.Context, container containers.Contai
 		return containers.Container{}, err
 	}
 
-	container.CreatedAt = time.Now()
+	container.CreatedAt = time.Now().UTC()
 	container.UpdatedAt = container.CreatedAt
-	if err := writeContainer(&container, cbkt); err != nil {
+	if err := writeContainer(cbkt, &container); err != nil {
 		return containers.Container{}, errors.Wrap(err, "failed to write container")
 	}
 
 	return container, nil
 }
 
-func (s *containerStore) Update(ctx context.Context, container containers.Container) (containers.Container, error) {
+func (s *containerStore) Update(ctx context.Context, container containers.Container, fieldpaths ...string) (containers.Container, error) {
 	namespace, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {
 		return containers.Container{}, err
@@ -178,8 +136,50 @@ func (s *containerStore) Update(ctx context.Context, container containers.Contai
 		return containers.Container{}, errors.Wrapf(errdefs.ErrNotFound, "container %q", container.ID)
 	}
 
-	container.UpdatedAt = time.Now()
-	if err := writeContainer(&container, cbkt); err != nil {
+	var updated containers.Container
+	if err := readContainer(&updated, cbkt); err != nil {
+		return updated, errors.Wrapf(err, "failed to read container from bucket")
+	}
+	updated.ID = container.ID
+
+	// apply the field mask. If you update this code, you better follow the
+	// field mask rules in field_mask.proto. If you don't know what this
+	// is, do not update this code.
+	if len(fieldpaths) > 0 {
+		// TODO(stevvooe): Move this logic into the store itself.
+		for _, path := range fieldpaths {
+			if strings.HasPrefix(path, "labels.") {
+				if updated.Labels == nil {
+					updated.Labels = map[string]string{}
+				}
+				key := strings.TrimPrefix(path, "labels.")
+				updated.Labels[key] = container.Labels[key]
+				continue
+			}
+
+			switch path {
+			case "labels":
+				updated.Labels = container.Labels
+			case "image":
+				updated.Image = container.Image
+			case "runtime":
+				// TODO(stevvooe): Should this actually be allowed?
+				updated.Runtime = container.Runtime
+			case "spec":
+				updated.Spec = container.Spec
+			case "rootfs":
+				updated.RootFS = container.RootFS
+			default:
+				return containers.Container{}, errors.Wrapf(errdefs.ErrInvalidArgument, "cannot update %q field on %q", path, container.ID)
+			}
+		}
+	} else {
+		// no field mask present, just replace everything
+		updated = container
+	}
+
+	updated.UpdatedAt = time.Now().UTC()
+	if err := writeContainer(cbkt, &updated); err != nil {
 		return containers.Container{}, errors.Wrap(err, "failed to write container")
 	}
 
@@ -251,10 +251,8 @@ func readContainer(container *containers.Container, bkt *bolt.Bucket) error {
 				return nil
 			}
 			container.Labels = map[string]string{}
-			if err := lbkt.ForEach(func(k, v []byte) error {
-				container.Labels[string(k)] = string(v)
-				return nil
-			}); err != nil {
+
+			if err := readLabels(container.Labels, lbkt); err != nil {
 				return err
 			}
 		}
@@ -263,15 +261,11 @@ func readContainer(container *containers.Container, bkt *bolt.Bucket) error {
 	})
 }
 
-func writeContainer(container *containers.Container, bkt *bolt.Bucket) error {
-	createdAt, err := container.CreatedAt.MarshalBinary()
-	if err != nil {
+func writeContainer(bkt *bolt.Bucket, container *containers.Container) error {
+	if err := writeTimestamps(bkt, container.CreatedAt, container.UpdatedAt); err != nil {
 		return err
 	}
-	updatedAt, err := container.UpdatedAt.MarshalBinary()
-	if err != nil {
-		return err
-	}
+
 	spec, err := container.Spec.Marshal()
 	if err != nil {
 		return err
@@ -281,8 +275,6 @@ func writeContainer(container *containers.Container, bkt *bolt.Bucket) error {
 		{bucketKeyImage, []byte(container.Image)},
 		{bucketKeySpec, spec},
 		{bucketKeyRootFS, []byte(container.RootFS)},
-		{bucketKeyCreatedAt, createdAt},
-		{bucketKeyUpdatedAt, updatedAt},
 	} {
 		if err := bkt.Put(v[0], v[1]); err != nil {
 			return err
@@ -320,28 +312,5 @@ func writeContainer(container *containers.Container, bkt *bolt.Bucket) error {
 		}
 	}
 
-	// Remove existing labels to keep from merging
-	if lbkt := bkt.Bucket(bucketKeyLabels); lbkt != nil {
-		if err := bkt.DeleteBucket(bucketKeyLabels); err != nil {
-			return err
-		}
-	}
-
-	lbkt, err := bkt.CreateBucket(bucketKeyLabels)
-	if err != nil {
-		return err
-	}
-
-	for k, v := range container.Labels {
-		if v == "" {
-			delete(container.Labels, k) // remove since we don't actually set it
-			continue
-		}
-
-		if err := lbkt.Put([]byte(k), []byte(v)); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return writeLabels(bkt, container.Labels)
 }

--- a/metadata/helpers.go
+++ b/metadata/helpers.go
@@ -1,0 +1,86 @@
+package metadata
+
+import (
+	"time"
+
+	"github.com/boltdb/bolt"
+	"github.com/pkg/errors"
+)
+
+func readLabels(m map[string]string, bkt *bolt.Bucket) error {
+	return bkt.ForEach(func(k, v []byte) error {
+		m[string(k)] = string(v)
+		return nil
+	})
+}
+
+// writeLabels will write a new labels bucket to the provided bucket at key
+// bucketKeyLabels, replacing the contents of the bucket with the provided map.
+//
+// The provide map labels will be modified to have the final contents of the
+// bucket. Typically, this removes zero-value entries.
+func writeLabels(bkt *bolt.Bucket, labels map[string]string) error {
+	// Remove existing labels to keep from merging
+	if lbkt := bkt.Bucket(bucketKeyLabels); lbkt != nil {
+		if err := bkt.DeleteBucket(bucketKeyLabels); err != nil {
+			return err
+		}
+	}
+
+	lbkt, err := bkt.CreateBucket(bucketKeyLabels)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range labels {
+		if v == "" {
+			delete(labels, k) // remove since we don't actually set it
+			continue
+		}
+
+		if err := lbkt.Put([]byte(k), []byte(v)); err != nil {
+			return errors.Wrapf(err, "failed to set label %q=%q", k, v)
+		}
+	}
+
+	return nil
+}
+
+func readTimestamps(created, updated *time.Time, bkt *bolt.Bucket) error {
+	for _, f := range []struct {
+		b []byte
+		t *time.Time
+	}{
+		{bucketKeyCreatedAt, created},
+		{bucketKeyUpdatedAt, updated},
+	} {
+		v := bkt.Get(f.b)
+		if v != nil {
+			if err := f.t.UnmarshalBinary(v); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func writeTimestamps(bkt *bolt.Bucket, created, updated time.Time) error {
+	createdAt, err := created.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	updatedAt, err := updated.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	for _, v := range [][2][]byte{
+		{bucketKeyCreatedAt, createdAt},
+		{bucketKeyUpdatedAt, updatedAt},
+	} {
+		if err := bkt.Put(v[0], v[1]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/metadata/images.go
+++ b/metadata/images.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/boltdb/bolt"
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/filters"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/namespaces"
 	digest "github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -42,53 +44,21 @@ func (s *imageStore) Get(ctx context.Context, name string) (images.Image, error)
 
 	image.Name = name
 	if err := readImage(&image, ibkt); err != nil {
-		return images.Image{}, err
+		return images.Image{}, errors.Wrapf(err, "image %q", name)
 	}
 
 	return image, nil
 }
 
-func (s *imageStore) Update(ctx context.Context, name string, desc ocispec.Descriptor) error {
-	namespace, err := namespaces.NamespaceRequired(ctx)
-	if err != nil {
-		return err
-	}
-
-	return withImagesBucket(s.tx, namespace, func(bkt *bolt.Bucket) error {
-		ibkt, err := bkt.CreateBucketIfNotExists([]byte(name))
-		if err != nil {
-			return err
-		}
-
-		var (
-			buf         [binary.MaxVarintLen64]byte
-			sizeEncoded []byte = buf[:]
-		)
-		sizeEncoded = sizeEncoded[:binary.PutVarint(sizeEncoded, desc.Size)]
-
-		if len(sizeEncoded) == 0 {
-			return fmt.Errorf("failed encoding size = %v", desc.Size)
-		}
-
-		for _, v := range [][2][]byte{
-			{bucketKeyDigest, []byte(desc.Digest)},
-			{bucketKeyMediaType, []byte(desc.MediaType)},
-			{bucketKeySize, sizeEncoded},
-		} {
-			if err := ibkt.Put(v[0], v[1]); err != nil {
-				return err
-			}
-		}
-
-		return nil
-	})
-}
-
-func (s *imageStore) List(ctx context.Context) ([]images.Image, error) {
-	var m []images.Image
+func (s *imageStore) List(ctx context.Context, fs ...string) ([]images.Image, error) {
 	namespace, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {
 		return nil, err
+	}
+
+	filter, err := filters.ParseAll(fs...)
+	if err != nil {
+		return nil, errors.Wrapf(errdefs.ErrInvalidArgument, err.Error())
 	}
 
 	bkt := getImagesBucket(s.tx, namespace)
@@ -96,6 +66,7 @@ func (s *imageStore) List(ctx context.Context) ([]images.Image, error) {
 		return nil, nil // empty store
 	}
 
+	var m []images.Image
 	if err := bkt.ForEach(func(k, v []byte) error {
 		var (
 			image = images.Image{
@@ -108,13 +79,99 @@ func (s *imageStore) List(ctx context.Context) ([]images.Image, error) {
 			return err
 		}
 
-		m = append(m, image)
+		if filter.Match(adaptImage(image)) {
+			m = append(m, image)
+		}
 		return nil
 	}); err != nil {
 		return nil, err
 	}
 
 	return m, nil
+}
+
+func (s *imageStore) Create(ctx context.Context, image images.Image) (images.Image, error) {
+	namespace, err := namespaces.NamespaceRequired(ctx)
+	if err != nil {
+		return images.Image{}, err
+	}
+
+	if image.Name == "" {
+		return images.Image{}, errors.Wrapf(errdefs.ErrInvalidArgument, "image name is required for create")
+	}
+
+	return image, withImagesBucket(s.tx, namespace, func(bkt *bolt.Bucket) error {
+		ibkt, err := bkt.CreateBucket([]byte(image.Name))
+		if err != nil {
+			if err != bolt.ErrBucketExists {
+				return err
+			}
+
+			return errors.Wrapf(errdefs.ErrAlreadyExists, "image %q", image.Name)
+		}
+
+		image.CreatedAt = time.Now().UTC()
+		image.UpdatedAt = image.CreatedAt
+		return writeImage(ibkt, &image)
+	})
+}
+
+func (s *imageStore) Update(ctx context.Context, image images.Image, fieldpaths ...string) (images.Image, error) {
+	namespace, err := namespaces.NamespaceRequired(ctx)
+	if err != nil {
+		return images.Image{}, err
+	}
+
+	if image.Name == "" {
+		return images.Image{}, errors.Wrapf(errdefs.ErrInvalidArgument, "image name is required for update")
+	}
+
+	var updated images.Image
+	return updated, withImagesBucket(s.tx, namespace, func(bkt *bolt.Bucket) error {
+		ibkt := bkt.Bucket([]byte(image.Name))
+		if ibkt == nil {
+			return errors.Wrapf(errdefs.ErrNotFound, "image %q", image.Name)
+		}
+
+		if err := readImage(&updated, ibkt); err != nil {
+			return errors.Wrapf(err, "image %q", image.Name)
+		}
+		updated.Name = image.Name
+
+		if len(fieldpaths) > 0 {
+			for _, path := range fieldpaths {
+				if strings.HasPrefix(path, "labels.") {
+					if updated.Labels == nil {
+						updated.Labels = map[string]string{}
+					}
+
+					key := strings.TrimPrefix(path, "labels.")
+					updated.Labels[key] = image.Labels[key]
+					continue
+				}
+
+				switch path {
+				case "labels":
+					updated.Labels = image.Labels
+				case "target":
+					// NOTE(stevvooe): While we allow setting individual labels, we
+					// only support replacing the target as a unit, since that is
+					// commonly pulled as a unit from other sources. It often doesn't
+					// make sense to modify the size or digest without touching the
+					// mediatype, as well, for example.
+					updated.Target = image.Target
+				default:
+					return errors.Wrapf(errdefs.ErrInvalidArgument, "cannot update %q field on image %q", path, image.Name)
+				}
+			}
+		} else {
+			updated = image
+		}
+
+		// TODO(stevvooe): Should only mark as updated if we have actual changes.
+		updated.UpdatedAt = time.Now().UTC()
+		return writeImage(ibkt, &updated)
+	})
 }
 
 func (s *imageStore) Delete(ctx context.Context, name string) error {
@@ -133,7 +190,23 @@ func (s *imageStore) Delete(ctx context.Context, name string) error {
 }
 
 func readImage(image *images.Image, bkt *bolt.Bucket) error {
-	return bkt.ForEach(func(k, v []byte) error {
+	if err := readTimestamps(&image.CreatedAt, &image.UpdatedAt, bkt); err != nil {
+		return err
+	}
+
+	lbkt := bkt.Bucket(bucketKeyLabels)
+	if lbkt != nil {
+		image.Labels = map[string]string{}
+		if err := readLabels(image.Labels, lbkt); err != nil {
+			return err
+		}
+	}
+
+	tbkt := bkt.Bucket(bucketKeyTarget)
+	if tbkt == nil {
+		return errors.New("unable to read target bucket")
+	}
+	return tbkt.ForEach(func(k, v []byte) error {
 		if v == nil {
 			return nil // skip it? a bkt maybe?
 		}
@@ -151,4 +224,44 @@ func readImage(image *images.Image, bkt *bolt.Bucket) error {
 
 		return nil
 	})
+}
+
+func writeImage(bkt *bolt.Bucket, image *images.Image) error {
+	if err := writeTimestamps(bkt, image.CreatedAt, image.UpdatedAt); err != nil {
+		return err
+	}
+
+	if len(image.Labels) > 0 {
+		if err := writeLabels(bkt, image.Labels); err != nil {
+			return errors.Wrapf(err, "writing labels for image %v", image.Name)
+		}
+	}
+
+	// write the target bucket
+	tbkt, err := bkt.CreateBucketIfNotExists([]byte(bucketKeyTarget))
+	if err != nil {
+		return err
+	}
+
+	var (
+		buf         [binary.MaxVarintLen64]byte
+		sizeEncoded []byte = buf[:]
+	)
+	sizeEncoded = sizeEncoded[:binary.PutVarint(sizeEncoded, image.Target.Size)]
+
+	if len(sizeEncoded) == 0 {
+		return fmt.Errorf("failed encoding size = %v", image.Target.Size)
+	}
+
+	for _, v := range [][2][]byte{
+		{bucketKeyDigest, []byte(image.Target.Digest)},
+		{bucketKeyMediaType, []byte(image.Target.MediaType)},
+		{bucketKeySize, sizeEncoded},
+	} {
+		if err := tbkt.Put(v[0], v[1]); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/services/images/helpers.go
+++ b/services/images/helpers.go
@@ -29,15 +29,21 @@ func imagesFromProto(imagespb []imagesapi.Image) []images.Image {
 
 func imageToProto(image *images.Image) imagesapi.Image {
 	return imagesapi.Image{
-		Name:   image.Name,
-		Target: descToProto(&image.Target),
+		Name:      image.Name,
+		Labels:    image.Labels,
+		Target:    descToProto(&image.Target),
+		CreatedAt: image.CreatedAt,
+		UpdatedAt: image.UpdatedAt,
 	}
 }
 
 func imageFromProto(imagepb *imagesapi.Image) images.Image {
 	return images.Image{
-		Name:   imagepb.Name,
-		Target: descFromProto(&imagepb.Target),
+		Name:      imagepb.Name,
+		Labels:    imagepb.Labels,
+		Target:    descFromProto(&imagepb.Target),
+		CreatedAt: imagepb.CreatedAt,
+		UpdatedAt: imagepb.UpdatedAt,
 	}
 }
 

--- a/services/images/service.go
+++ b/services/images/service.go
@@ -12,6 +12,8 @@ import (
 	"github.com/golang/protobuf/ptypes/empty"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func init() {
@@ -63,38 +65,88 @@ func (s *Service) Get(ctx context.Context, req *imagesapi.GetImageRequest) (*ima
 	}))
 }
 
-func (s *Service) Update(ctx context.Context, req *imagesapi.UpdateImageRequest) (*imagesapi.UpdateImageResponse, error) {
+func (s *Service) List(ctx context.Context, req *imagesapi.ListImagesRequest) (*imagesapi.ListImagesResponse, error) {
+	var resp imagesapi.ListImagesResponse
+
+	return &resp, errdefs.ToGRPC(s.withStoreView(ctx, func(ctx context.Context, store images.Store) error {
+		images, err := store.List(ctx, req.Filters...)
+		if err != nil {
+			return err
+		}
+
+		resp.Images = imagesToProto(images)
+		return nil
+	}))
+}
+
+func (s *Service) Create(ctx context.Context, req *imagesapi.CreateImageRequest) (*imagesapi.CreateImageResponse, error) {
+	if req.Image.Name == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "Image.Name required")
+	}
+
+	var (
+		image = imageFromProto(&req.Image)
+		resp  imagesapi.CreateImageResponse
+	)
 	if err := s.withStoreUpdate(ctx, func(ctx context.Context, store images.Store) error {
-		return store.Update(ctx, req.Image.Name, descFromProto(&req.Image.Target))
+		created, err := store.Create(ctx, image)
+		if err != nil {
+			return err
+		}
+
+		resp.Image = imageToProto(&created)
+		return nil
+	}); err != nil {
+		return nil, errdefs.ToGRPC(err)
+	}
+
+	if err := s.emit(ctx, "/images/create", &eventsapi.ImageCreate{
+		Name:   resp.Image.Name,
+		Labels: resp.Image.Labels,
+	}); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+
+}
+
+func (s *Service) Update(ctx context.Context, req *imagesapi.UpdateImageRequest) (*imagesapi.UpdateImageResponse, error) {
+	if req.Image.Name == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "Image.Name required")
+	}
+
+	var (
+		image = imageFromProto(&req.Image)
+		resp  imagesapi.UpdateImageResponse
+	)
+	if err := s.withStoreUpdate(ctx, func(ctx context.Context, store images.Store) error {
+		var fieldpaths []string
+		if req.UpdateMask != nil && len(req.UpdateMask.Paths) > 0 {
+			for _, path := range req.UpdateMask.Paths {
+				fieldpaths = append(fieldpaths, path)
+			}
+		}
+
+		updated, err := store.Update(ctx, image, fieldpaths...)
+		if err != nil {
+			return err
+		}
+
+		resp.Image = imageToProto(&updated)
+		return nil
 	}); err != nil {
 		return nil, errdefs.ToGRPC(err)
 	}
 
 	if err := s.emit(ctx, "/images/update", &eventsapi.ImageUpdate{
-		Name:   req.Image.Name,
-		Labels: req.Image.Labels,
+		Name:   resp.Image.Name,
+		Labels: resp.Image.Labels,
 	}); err != nil {
 		return nil, err
 	}
 
-	// TODO: get image back out to return
-	return &imagesapi.UpdateImageResponse{
-	//Image: nil,
-	}, nil
-}
-
-func (s *Service) List(ctx context.Context, _ *imagesapi.ListImagesRequest) (*imagesapi.ListImagesResponse, error) {
-	var resp imagesapi.ListImagesResponse
-
-	return &resp, s.withStoreView(ctx, func(ctx context.Context, store images.Store) error {
-		images, err := store.List(ctx)
-		if err != nil {
-			return errdefs.ToGRPC(err)
-		}
-
-		resp.Images = imagesToProto(images)
-		return nil
-	})
+	return &resp, nil
 }
 
 func (s *Service) Delete(ctx context.Context, req *imagesapi.DeleteImageRequest) (*empty.Empty, error) {


### PR DESCRIPTION
The primary feature we get with this PR is support for filters and
labels on the image metadata store. In the process of doing this, the
conventions for the API have been converged between containers and
images, providing a model for other services.

With images, `Put` (renamed to `Update` briefly) has been split into a
`Create` and `Update`, allowing one to control the behavior around these
operations. `Update` now includes support for masking fields at the
datastore-level across both the containers and image service. Filters
are now just string values to interpreted directly within the data
store. This should allow for some interesting future use cases in which
the datastore might use the syntax for more efficient query paths.

The containers service has been updated to follow these conventions as
closely as possible.

Signed-off-by: Stephen J Day <stephen.day@docker.com>