### PR TITLE
cmd/ctr: add prepare subcommand to snapshot

### DIFF
--- a/cmd/dist/rootfs.go
+++ b/cmd/dist/rootfs.go
@@ -3,8 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"os"
-	"strings"
 
 	"github.com/containerd/containerd/log"
 	digest "github.com/opencontainers/go-digest"
@@ -16,7 +14,6 @@ var rootfsCommand = cli.Command{
 	Usage: "rootfs setups a rootfs",
 	Subcommands: []cli.Command{
 		rootfsUnpackCommand,
-		rootfsPrepareCommand,
 	},
 }
 
@@ -67,46 +64,6 @@ var rootfsUnpackCommand = cli.Command{
 
 		// TODO: Get rootfs from Image
 		//log.G(ctx).Infof("chain ID: %s", chainID.String())
-
-		return nil
-	},
-}
-
-var rootfsPrepareCommand = cli.Command{
-	Name:      "prepare",
-	Usage:     "prepare gets mount commands for digest",
-	ArgsUsage: "[flags] <digest> <target>",
-	Flags:     []cli.Flag{},
-	Action: func(clicontext *cli.Context) error {
-		ctx, cancel := appContext(clicontext)
-		defer cancel()
-
-		if clicontext.NArg() != 2 {
-			return cli.ShowSubcommandHelp(clicontext)
-		}
-
-		dgst, err := digest.Parse(clicontext.Args().Get(0))
-		if err != nil {
-			return err
-		}
-		target := clicontext.Args().Get(1)
-
-		log.G(ctx).Infof("preparing mounts %s", dgst.String())
-
-		client, err := getClient(clicontext)
-		if err != nil {
-			return err
-		}
-
-		snapshotter := client.SnapshotService()
-		mounts, err := snapshotter.Prepare(ctx, target, dgst.String())
-		if err != nil {
-			return err
-		}
-
-		for _, m := range mounts {
-			fmt.Fprintf(os.Stdout, "mount -t %s %s %s -o %s\n", m.Type, m.Source, target, strings.Join(m.Options, ","))
-		}
 
 		return nil
 	},


### PR DESCRIPTION
This changeset adds `prepare` subcommand to `ctr snapshot` and removes
`prepare` from `dist rootfs` to keep the basic snapshot operation commands
together.

Signed-off-by: Sunny Gogoi <me@darkowlzz.space>

Part of #1082 