### PR TITLE
Ignore SIGPIPE

### DIFF
--- a/cmd/containerd/main_unix.go
+++ b/cmd/containerd/main_unix.go
@@ -20,6 +20,7 @@ var handledSignals = []os.Signal{
 	unix.SIGINT,
 	unix.SIGUSR1,
 	unix.SIGCHLD,
+	unix.SIGPIPE,
 }
 
 func handleSignals(ctx context.Context, signals chan os.Signal, server *server.Server) error {
@@ -32,6 +33,8 @@ func handleSignals(ctx context.Context, signals chan os.Signal, server *server.S
 			}
 		case unix.SIGUSR1:
 			dumpStacks()
+		case unix.SIGPIPE:
+			continue
 		default:
 			server.Stop()
 			return nil


### PR DESCRIPTION
Similar to code in the Docker daemon and containerd 0.2.x. Even if we
have a better deployment model in containerd 1.0 seems reasonable to
have this same fix in the rare case that it bites someone using
containerd 1.0.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>

See #930, #1104 for history in docker/containerd 0.2.x
cc: @runcom 