### PR TITLE
Start of day configuration of shim debug setting

### DIFF
--- a/linux/bundle.go
+++ b/linux/bundle.go
@@ -56,8 +56,8 @@ type bundle struct {
 }
 
 // NewShim connects to the shim managing the bundle and tasks
-func (b *bundle) NewShim(ctx context.Context, binary, grpcAddress string, remote bool) (*client.Client, error) {
-	opt := client.WithStart(binary, grpcAddress)
+func (b *bundle) NewShim(ctx context.Context, binary, grpcAddress string, remote, debug bool) (*client.Client, error) {
+	opt := client.WithStart(binary, grpcAddress, debug)
 	if !remote {
 		opt = client.WithLocal
 	}


### PR DESCRIPTION
This makes it possible to enable shim debug by adding the following to
`config.toml`:

    [plugins.linux]
    shim_debug = true

I moved the debug setting from the `client.Config struct` to an argument to
`client.WithStart` since this is the only place it would be used.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>