### PR TITLE
 Fix a small probability panic for containerd.

### DIFF
--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -48,9 +48,6 @@ func New(stateDir string, runtimeName, shimName string, runtimeArgs []string, ti
 	}
 	go s.exitHandler()
 	go s.oomHandler()
-	if err := s.restore(); err != nil {
-		return nil, err
-	}
 	return s, nil
 }
 
@@ -268,6 +265,9 @@ func (s *Supervisor) notifySubscribers(e Event) {
 // therefore it is save to do operations in the handlers that modify state of the system or
 // state of the Supervisor
 func (s *Supervisor) Start() error {
+	if err := s.restore(); err != nil {
+		return err
+	}
 	logrus.WithFields(logrus.Fields{
 		"stateDir":    s.stateDir,
 		"runtime":     s.runtime,


### PR DESCRIPTION
When I do stability test for docker，I run/rm container（with a shell, do it repeatedly），at the same time， I kill containerd every 5 seconds. In this  process, I see a containerd' core file, by searching logs,
I find container panic one times.
![d68421e2-4567-4210-92a3-7e5fcff0621f](https://user-images.githubusercontent.com/11223367/28149646-cf51cef8-67c1-11e7-8489-8bffba1db64d.png)

![default](https://user-images.githubusercontent.com/11223367/28149700-3045dc36-67c2-11e7-9b63-bc71b2acd111.JPG)


Signed-off-by: yangshukui <yangshukui@huawei.com>