### PR TITLE
Fixing return error on run command

### DIFF
--- a/cmd/ctr/run.go
+++ b/cmd/ctr/run.go
@@ -47,7 +47,7 @@ func withMounts(context *cli.Context) containerd.SpecOpts {
 var runCommand = cli.Command{
 	Name:      "run",
 	Usage:     "run a container",
-	ArgsUsage: "IMAGE ID [COMMAND] [ARG...]",
+	ArgsUsage: "IMAGE CONTAINER [COMMAND] [ARG...]",
 	Flags: append([]cli.Flag{
 		cli.BoolFlag{
 			Name:  "tty,t",
@@ -94,10 +94,14 @@ var runCommand = cli.Command{
 
 			ctx, cancel = appContext(context)
 			id          = context.Args().Get(1)
+			imageRef    = context.Args().First()
 			tty         = context.Bool("tty")
 		)
 		defer cancel()
 
+		if imageRef == "" {
+			return errors.New("image ref must be provided")
+		}
 		if id == "" {
 			return errors.New("container id must be provided")
 		}


### PR DESCRIPTION
When we run sudo ctr run command
Usage is saying about IMAGE ID
USAGE:
   ctr run [command options] IMAGE ID [COMMAND] [ARG...]
When we run 
sudo ctr run
Error is returning as 
ctr: container id must be provided
As ctr takes image ID as argument, changed the error type to image id instead of container id

Signed-off-by: rajasec <rajasec79@gmail.com>