### PR TITLE
Makefile: `go build -i` -> `go build`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,9 @@ script:
   - export CGO_ENABLED=$TRAVIS_CGO_ENABLED
   - GIT_CHECK_EXCLUDE="./vendor" TRAVIS_COMMIT_RANGE="${TRAVIS_COMMIT_RANGE/.../..}" make dco
   - make fmt
-  - make vet
+# FIXME: For non-linux GOOS, without running `go build -i`, vet fails with `vet: import failed: can't find import: fmt`...
+# However, running `go build -i` requires root privilege. So let's skip vet for non-linux atm (#1179).
+  - if [ "$GOOS" = "linux" ]; then make vet; fi
   - make build
   - make binaries
   - if [ "$GOOS" = "linux" ]; then sudo make install ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,9 @@ script:
   - GIT_CHECK_EXCLUDE="./vendor" TRAVIS_COMMIT_RANGE="${TRAVIS_COMMIT_RANGE/.../..}" make dco
   - make fmt
 # FIXME: For non-linux GOOS, without running `go build -i`, vet fails with `vet: import failed: can't find import: fmt`...
-# However, running `go build -i` requires root privilege. So let's skip vet for non-linux atm (#1179).
-  - if [ "$GOOS" = "linux" ]; then make vet; fi
+# Note that `go build -i` requires write permission to GOROOT. (So it is not called in Makefile)
+  - go build -i .
+  - make vet
   - make build
   - make binaries
   - if [ "$GOOS" = "linux" ]; then sudo make install ; fi

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ ineffassign: ## run ineffassign
 
 build: ## build the go packages
 	@echo "$(WHALE) $@"
-	@go build -i -v ${EXTRA_FLAGS} ${GO_LDFLAGS} ${GO_GCFLAGS} ${PACKAGES}
+	@go build -v ${EXTRA_FLAGS} ${GO_LDFLAGS} ${GO_GCFLAGS} ${PACKAGES}
 
 test: ## run tests, except integration tests and tests that require root
 	@echo "$(WHALE) $@"
@@ -136,7 +136,7 @@ FORCE:
 # Build a binary from a cmd.
 bin/%: cmd/% FORCE
 	@echo "$(WHALE) $@${BINARY_SUFFIX}"
-	@go build -i -o $@${BINARY_SUFFIX} ${GO_LDFLAGS} ${GO_TAGS} ${GO_GCFLAGS} ./$<
+	@go build -o $@${BINARY_SUFFIX} ${GO_LDFLAGS} ${GO_TAGS} ${GO_GCFLAGS} ./$<
 
 binaries: $(BINARIES) ## build binaries
 	@echo "$(WHALE) $@"


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

Without this fix, `GOOS=windows make` could not be run under non-root Linux:
```console
$ GOOS=windows make
🇩 bin/ctr.exe
go install hash/fnv: open /usr/local/go/pkg/windows_amd64/hash/fnv.a: permission denied
go install runtime/debug: open /usr/local/go/pkg/windows_amd64/runtime/debug.a: permission denied
go install os/signal: mkdir /usr/local/go/pkg/windows_amd64/os/: permission denied
go install encoding/csv: open /usr/local/go/pkg/windows_amd64/encoding/csv.a: permission denied
go install net/http/httputil: open /usr/local/go/pkg/windows_amd64/net/http/httputil.a: permission denied
go install regexp/syntax: mkdir /usr/local/go/pkg/windows_amd64/regexp/: permission denied
Makefile:138: recipe for target 'bin/ctr' failed
make: *** [bin/ctr] Error 1

$ go env
GOARCH="amd64"
GOBIN="/home/suda/gopath/bin"
GOEXE=""
GOHOSTARCH="amd64"
GOHOSTOS="linux"
GOOS="linux"
GOPATH="/home/suda/gopath"
GORACE=""
GOROOT="/usr/local/go"
GOTOOLDIR="/usr/local/go/pkg/tool/linux_amd64"
GCCGO="gccgo"
CC="gcc"
GOGCCFLAGS="-fPIC -m64 -pthread -fmessage-length=0 -fdebug-prefix-map=/tmp/go-build372314054=/tmp/go-build -gno-record-gcc-switches"
CXX="g++"
CGO_ENABLED="1"
PKG_CONFIG="pkg-config"
CGO_CFLAGS="-g -O2"
CGO_CPPFLAGS=""
CGO_CXXFLAGS="-g -O2"
CGO_FFLAGS="-g -O2"
CGO_LDFLAGS="-g -O2"

$  go version
go version go1.8 linux/amd64
```