### PR TITLE
cmd/{ctr,dist}: label can be a verb

### DIFF
--- a/cmd/ctr/labels.go
+++ b/cmd/ctr/labels.go
@@ -9,7 +9,7 @@ import (
 )
 
 var containersSetLabelsCommand = cli.Command{
-	Name:        "set-labels",
+	Name:        "label",
 	Usage:       "Set and clear labels for a container.",
 	ArgsUsage:   "[flags] <name> [<key>=<value>, ...]",
 	Description: "Set and clear labels for a container.",

--- a/cmd/ctr/namespaces.go
+++ b/cmd/ctr/namespaces.go
@@ -54,7 +54,7 @@ var namespacesCreateCommand = cli.Command{
 }
 
 var namespacesSetLabelsCommand = cli.Command{
-	Name:        "set-labels",
+	Name:        "label",
 	Usage:       "Set and clear labels for a namespace.",
 	ArgsUsage:   "[flags] <name> [<key>=<value>, ...]",
 	Description: "Set and clear labels for a namespace.",

--- a/cmd/dist/images.go
+++ b/cmd/dist/images.go
@@ -83,7 +83,7 @@ var imagesListCommand = cli.Command{
 }
 
 var imagesSetLabelsCommand = cli.Command{
-	Name:        "set-labels",
+	Name:        "label",
 	Usage:       "Set and clear labels for an image.",
 	ArgsUsage:   "[flags] <name> [<key>=<value>, ...]",
 	Description: "Set and clear labels for an image.",


### PR DESCRIPTION
Rather than using the more verbose `set-labels` command, we are changing
the command to set labels for various objects to `label`, as it can be
used as a verb. This matches changes in the content store labeling.

Signed-off-by: Stephen J Day <stephen.day@docker.com>