### PR TITLE
Update containerd/fifo for race fix

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -21,7 +21,7 @@ github.com/containerd/btrfs e9c546f46bccffefe71a6bc137e4c21b5503cc18
 github.com/stretchr/testify v1.1.4
 github.com/davecgh/go-spew v1.1.0
 github.com/pmezard/go-difflib v1.0.0
-github.com/containerd/fifo 69b99525e472735860a5269b75af1970142b3062
+github.com/containerd/fifo fbfb6a11ec671efbe94ad1c12c2e98773f19e1e6
 github.com/urfave/cli 8ba6f23b6e36d03666a14bd9421f5e3efcb59aca
 golang.org/x/net 7dcfb8076726a3fdd9353b6b8a1f1b6be6811bd6
 google.golang.org/grpc v1.3.0


### PR DESCRIPTION
Re-vendor containerd/fifo to pick up PR containerd/fifo#13 to fix data race.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>

Allows #1181 to drop the WIP commit and get merged