### PR TITLE
cmd/{ctr,dist}: move images command to ctr

### DIFF
--- a/cmd/ctr/images.go
+++ b/cmd/ctr/images.go
@@ -39,7 +39,7 @@ var imagesListCommand = cli.Command{
 		)
 		defer cancel()
 
-		client, err := getClient(clicontext)
+		client, err := newClient(clicontext)
 		if err != nil {
 			return err
 		}
@@ -95,7 +95,7 @@ var imagesSetLabelsCommand = cli.Command{
 		)
 		defer cancel()
 
-		client, err := getClient(clicontext)
+		client, err := newClient(clicontext)
 		if err != nil {
 			return err
 		}
@@ -148,7 +148,7 @@ var imageRemoveCommand = cli.Command{
 		ctx, cancel := appContext(clicontext)
 		defer cancel()
 
-		client, err := getClient(clicontext)
+		client, err := newClient(clicontext)
 		if err != nil {
 			return err
 		}
@@ -171,31 +171,4 @@ var imageRemoveCommand = cli.Command{
 
 		return exitErr
 	},
-}
-
-// TODO(stevvooe): These helpers should go away when we merge dist and ctr.
-
-func objectWithLabelArgs(clicontext *cli.Context) (string, map[string]string) {
-	var (
-		name         = clicontext.Args().First()
-		labelStrings = clicontext.Args().Tail()
-	)
-
-	return name, labelArgs(labelStrings)
-}
-
-func labelArgs(labelStrings []string) map[string]string {
-	labels := make(map[string]string, len(labelStrings))
-	for _, label := range labelStrings {
-		parts := strings.SplitN(label, "=", 2)
-		key := parts[0]
-		value := "true"
-		if len(parts) > 1 {
-			value = parts[1]
-		}
-
-		labels[key] = value
-	}
-
-	return labels
 }

--- a/cmd/ctr/main.go
+++ b/cmd/ctr/main.go
@@ -46,6 +46,10 @@ containerd CLI
 			Name:  "timeout",
 			Usage: "total timeout for ctr commands",
 		},
+		cli.DurationFlag{
+			Name:  "connect-timeout",
+			Usage: "timeout for connecting to containerd",
+		},
 		cli.StringFlag{
 			Name:   "namespace, n",
 			Usage:  "namespace to use with commands",
@@ -54,13 +58,14 @@ containerd CLI
 		},
 	}
 	app.Commands = append([]cli.Command{
-		attachCommand,
+		imageCommand,
+		containersCommand,
 		checkpointCommand,
 		runCommand,
+		attachCommand,
 		deleteCommand,
 		namespacesCommand,
 		eventsCommand,
-		containersCommand,
 		taskListCommand,
 		infoCommand,
 		killCommand,

--- a/cmd/dist/labels.go
+++ b/cmd/dist/labels.go
@@ -9,7 +9,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-var labelCommand = cli.Command{
+var labelContentCommand = cli.Command{
 	Name:        "label",
 	Usage:       "adds labels to content",
 	ArgsUsage:   "[flags] <digest> [<label>=<value> ...]",
@@ -64,4 +64,29 @@ var labelCommand = cli.Command{
 
 		return nil
 	},
+}
+
+func objectWithLabelArgs(clicontext *cli.Context) (string, map[string]string) {
+	var (
+		namespace    = clicontext.Args().First()
+		labelStrings = clicontext.Args().Tail()
+	)
+
+	return namespace, labelArgs(labelStrings)
+}
+
+func labelArgs(labelStrings []string) map[string]string {
+	labels := make(map[string]string, len(labelStrings))
+	for _, label := range labelStrings {
+		parts := strings.SplitN(label, "=", 2)
+		key := parts[0]
+		value := "true"
+		if len(parts) > 1 {
+			value = parts[1]
+		}
+
+		labels[key] = value
+	}
+
+	return labels
 }

--- a/cmd/dist/main.go
+++ b/cmd/dist/main.go
@@ -45,17 +45,6 @@ distribution tool
 			Name:  "timeout",
 			Usage: "total timeout for dist commands",
 		},
-		cli.DurationFlag{
-			Name:  "connect-timeout",
-			Usage: "timeout for connecting to containerd",
-		},
-		cli.StringFlag{
-			// TODO(stevvooe): for now, we allow circumventing the GRPC. Once
-			// we have clear separation, this will likely go away.
-			Name:  "root",
-			Usage: "path to content store root",
-			Value: "/var/lib/containerd",
-		},
 		cli.StringFlag{
 			Name:  "address, a",
 			Usage: "address for containerd's GRPC server",
@@ -69,7 +58,6 @@ distribution tool
 		},
 	}
 	app.Commands = []cli.Command{
-		imageCommand,
 		contentCommand,
 		pullCommand,
 		fetchCommand,
@@ -101,6 +89,6 @@ var contentCommand = cli.Command{
 		getCommand,
 		editCommand,
 		deleteCommand,
-		labelCommand,
+		labelContentCommand,
 	},
 }


### PR DESCRIPTION
Rather than make a large PR, we can move parts of the dist commands over
piece by piece. This first step moves over the images command. Others
will follow.

Signed-off-by: Stephen J Day <stephen.day@docker.com>