### PR TITLE
Fix panic in snapshotter client when connection fails

### DIFF
--- a/services/snapshot/client.go
+++ b/services/snapshot/client.go
@@ -105,7 +105,7 @@ func (r *remoteSnapshotter) Walk(ctx context.Context, fn func(context.Context, s
 		Snapshotter: r.snapshotterName,
 	})
 	if err != nil {
-		errdefs.FromGRPC(err)
+		return errdefs.FromGRPC(err)
 	}
 	for {
 		resp, err := sc.Recv()


### PR DESCRIPTION
Missed return statement allows `sc` to be called when nil