### PR TITLE
Create socket parent directory with correct permissions

### DIFF
--- a/sys/socket_unix.go
+++ b/sys/socket_unix.go
@@ -23,6 +23,11 @@ func CreateUnixSocket(path string) (net.Listener, error) {
 
 // GetLocalListener returns a listerner out of a unix socket.
 func GetLocalListener(path string, uid, gid int) (net.Listener, error) {
+	// Ensure parent directory is created
+	if err := mkdirAs(filepath.Dir(path), uid, gid); err != nil {
+		return nil, err
+	}
+
 	l, err := CreateUnixSocket(path)
 	if err != nil {
 		return l, err
@@ -39,4 +44,16 @@ func GetLocalListener(path string, uid, gid int) (net.Listener, error) {
 	}
 
 	return l, nil
+}
+
+func mkdirAs(path string, uid, gid int) error {
+	if _, err := os.Stat(path); err == nil || !os.IsNotExist(err) {
+		return err
+	}
+
+	if err := os.Mkdir(path, 0770); err != nil {
+		return err
+	}
+
+	return os.Chown(path, uid, gid)
 }


### PR DESCRIPTION
Often the socket is put into the directory `/run/containerd`. When this directory does not exist, it gets created with the default uid/gid and permission `0660`. When the user has specified a uid or gid, this should be used to set the ownership of that parent directory and the permissions should be `0770`. This worked in a previous version of containerd but regressed after a refactor.