### PR TITLE
add `ctr pull --workaround-ping-v2` for GCR

### DIFF
--- a/cmd/ctr/utils.go
+++ b/cmd/ctr/utils.go
@@ -72,6 +72,10 @@ var (
 			Name:  "refresh",
 			Usage: "Refresh token for authorization server",
 		},
+		cli.BoolFlag{
+			Name:  "workaround-ping-v2",
+			Usage: "Pings /v2/ first to get WWW-authenticate header. As of August 2017, GCR is known to require this. Will be removed in future releases.",
+		},
 	}
 )
 
@@ -235,8 +239,9 @@ func getResolver(ctx gocontext.Context, clicontext *cli.Context) (remotes.Resolv
 		username = username[0:i]
 	}
 	options := docker.ResolverOptions{
-		PlainHTTP: clicontext.Bool("plain-http"),
-		Tracker:   pushTracker,
+		PlainHTTP:        clicontext.Bool("plain-http"),
+		Tracker:          pushTracker,
+		WorkaroundPingV2: clicontext.Bool("workaround-ping-v2"),
 	}
 	if username != "" {
 		if secret == "" {

--- a/reference/reference.go
+++ b/reference/reference.go
@@ -110,6 +110,12 @@ func (r Spec) Hostname() string {
 	return r.Locator[:i]
 }
 
+// Path returns the path portion of the locator without the head slash.
+// e.g. "foo/bar" for "host/foo/bar:baz".
+func (r Spec) Path() string {
+	return strings.TrimPrefix(r.Locator, r.Hostname()+"/")
+}
+
 // Digest returns the digest portion of the reference spec. This may be a
 // partial or invalid digest, which may be used to lookup a complete digest.
 func (r Spec) Digest() digest.Digest {


### PR DESCRIPTION
This fix seems required for GCR.

```
$ echo asia.gcr.io | docker-credential-gcr get
{"ServerURL":"","Username":"oauth2accesstoken","Secret":"F00BarBa2"}
$ ctr pull --user oauth2accesstoken:F00BarBa2 asia.gcr.io/myproject/myimage:latest
ctr: unexpected status code https://asia.gcr.io/v2/myproject/myimage/manifests/latest: 403Forbidden
```

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>