### PR TITLE
btrfs: improve an error string

### DIFF
--- a/snapshot/btrfs/btrfs.go
+++ b/snapshot/btrfs/btrfs.go
@@ -54,7 +54,7 @@ func NewSnapshotter(root string) (snapshot.Snapshotter, error) {
 		return nil, err
 	}
 	if mnt.FSType != "btrfs" {
-		return nil, fmt.Errorf("expected btrfs, got %s", mnt.FSType)
+		return nil, fmt.Errorf("path %s must be a btrfs filesystem to be used with the btrfs snapshotter", root)
 	}
 	var (
 		active    = filepath.Join(root, "active")


### PR DESCRIPTION
Before: `WARN[0000] failed to load plugin io.containerd.snapshotter.v1.btrfs  error="expected btrfs, got ext4" module=containerd`

After: `WARN[0000] failed to load plugin io.containerd.snapshotter.v1.btrfs  error="expected /var/lib/containerd/io.containerd.snapshotter.v1.btrfs to be mounted as btrfs, got ext4" module=containerd`

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>