### PR TITLE
Makefile: no need to build protos binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ INTEGRATION_PACKAGE=${PKG}
 TEST_REQUIRES_ROOT_PACKAGES=$(shell for f in $$(git grep -l testutil.RequiresRoot | grep -v Makefile);do echo "${PKG}/$$(dirname $$f)"; done)
 
 # Project binaries.
-COMMANDS=ctr containerd protoc-gen-gogoctrd
+COMMANDS=ctr containerd
 ifneq ("$(GOOS)", "windows")
 	COMMANDS += containerd-shim
 endif


### PR DESCRIPTION
For the standard make target, there is no need to build the protoc
plugin binary. This can be built automatically in response to the `make
protos` target.

Signed-off-by: Stephen J Day <stephen.day@docker.com>