### PR TITLE
client: add root mounts to task info

### DIFF
--- a/container.go
+++ b/container.go
@@ -198,6 +198,15 @@ func (c *container) NewTask(ctx context.Context, ioCreate IOCreation, opts ...Ne
 			return nil, err
 		}
 	}
+	if info.RootMounts != nil {
+		for _, m := range info.RootMounts {
+			request.Rootfs = append(request.Rootfs, &types.Mount{
+				Type:    m.Type,
+				Source:  m.Source,
+				Options: m.Options,
+			})
+		}
+	}
 	if info.Options != nil {
 		any, err := typeurl.MarshalAny(info.Options)
 		if err != nil {

--- a/task.go
+++ b/task.go
@@ -15,6 +15,7 @@ import (
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/linux/runcopts"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/rootfs"
 	"github.com/containerd/containerd/runtime"
 	"github.com/containerd/containerd/typeurl"
@@ -55,6 +56,7 @@ type CheckpointTaskOpts func(*CheckpointTaskInfo) error
 
 type TaskInfo struct {
 	Checkpoint *types.Descriptor
+	RootMounts []mount.Mount
 	Options    interface{}
 }
 


### PR DESCRIPTION
Add root mounts to task info and allow using root mounts on new task when specified.