### PR TITLE
snapshot: run test suite for metadata and client implementations

### DIFF
--- a/metadata/snapshot_test.go
+++ b/metadata/snapshot_test.go
@@ -1,0 +1,42 @@
+package metadata
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/boltdb/bolt"
+	"github.com/containerd/containerd/snapshot"
+	"github.com/containerd/containerd/snapshot/naive"
+	"github.com/containerd/containerd/snapshot/testsuite"
+	"github.com/containerd/containerd/testutil"
+)
+
+func newSnapshotter(ctx context.Context, root string) (snapshot.Snapshotter, func(), error) {
+	naiveRoot := filepath.Join(root, "naive")
+	if err := os.Mkdir(naiveRoot, 0770); err != nil {
+		return nil, nil, err
+	}
+	snapshotter, err := naive.NewSnapshotter(naiveRoot)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	db, err := bolt.Open(filepath.Join(root, "metadata.db"), 0660, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sn := NewSnapshotter(db, "naive", snapshotter)
+
+	return sn, func() {
+		db.Close()
+	}, nil
+}
+
+func TestMetadata(t *testing.T) {
+	// Snapshot tests require mounting, still requires root
+	testutil.RequiresRoot(t)
+	testsuite.SnapshotterSuite(t, "Metadata", newSnapshotter)
+}

--- a/snapshot/testsuite/testsuite.go
+++ b/snapshot/testsuite/testsuite.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/containerd/containerd/fs/fstest"
 	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/snapshot"
 	"github.com/containerd/containerd/testutil"
 	"github.com/stretchr/testify/assert"
@@ -27,6 +28,7 @@ func SnapshotterSuite(t *testing.T, name string, snapshotterFn func(ctx context.
 func makeTest(t *testing.T, name string, snapshotterFn func(ctx context.Context, root string) (snapshot.Snapshotter, func(), error), fn func(ctx context.Context, t *testing.T, snapshotter snapshot.Snapshotter, work string)) func(t *testing.T) {
 	return func(t *testing.T) {
 		ctx := context.Background()
+		ctx = namespaces.WithNamespace(ctx, "testsuite")
 		restoreMask := clearMask()
 		defer restoreMask()
 		// Make two directories: a snapshotter root and a play area for the tests:

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -2,6 +2,7 @@ package containerd
 
 import (
 	"context"
+	"runtime"
 	"testing"
 
 	"github.com/containerd/containerd/snapshot"
@@ -24,6 +25,9 @@ func newSnapshotter(ctx context.Context, root string) (snapshot.Snapshotter, fun
 func TestSnapshotterClient(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("snapshots not yet supported on Windows")
 	}
 	testsuite.SnapshotterSuite(t, "SnapshotterClient", newSnapshotter)
 }

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -1,0 +1,29 @@
+package containerd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/containerd/containerd/snapshot"
+	"github.com/containerd/containerd/snapshot/testsuite"
+)
+
+func newSnapshotter(ctx context.Context, root string) (snapshot.Snapshotter, func(), error) {
+	client, err := New(address)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sn := client.SnapshotService("")
+
+	return sn, func() {
+		client.Close()
+	}, nil
+}
+
+func TestSnapshotterClient(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	testsuite.SnapshotterSuite(t, "SnapshotterClient", newSnapshotter)
+}


### PR DESCRIPTION
The snapshot test suite is designed to run against the snapshotter interface, run the test suite for metadata and client implementations of the snapshotter interface.
