### PR TITLE
Replace hardcoded debug address with const var

### DIFF
--- a/cmd/containerd/config_linux.go
+++ b/cmd/containerd/config_linux.go
@@ -12,7 +12,7 @@ func defaultConfig() *server.Config {
 		},
 		Debug: server.Debug{
 			Level:   "info",
-			Address: "/run/containerd/debug.sock",
+			Address: server.DefaultDebugAddress,
 		},
 	}
 }

--- a/cmd/containerd/config_unsupported.go
+++ b/cmd/containerd/config_unsupported.go
@@ -1,4 +1,4 @@
-// +build darwin freebsd
+// +build !linux,!windows
 
 package main
 
@@ -12,7 +12,7 @@ func defaultConfig() *server.Config {
 		},
 		Debug: server.Debug{
 			Level:   "info",
-			Address: "/run/containerd/debug.sock",
+			Address: server.DefaultDebugAddress,
 		},
 	}
 }

--- a/cmd/containerd/config_windows.go
+++ b/cmd/containerd/config_windows.go
@@ -11,11 +11,11 @@ func defaultConfig() *server.Config {
 	return &server.Config{
 		Root: filepath.Join(os.Getenv("programfiles"), "containerd", "root"),
 		GRPC: server.GRPCConfig{
-			Address: `\\.\pipe\containerd-containerd`,
+			Address: server.DefaultAddress,
 		},
 		Debug: server.Debug{
 			Level:   "info",
-			Address: `\\.\pipe\containerd-debug`,
+			Address: server.DefaultDebugAddress,
 		},
 	}
 }


### PR DESCRIPTION
Debug address in defaultConfig() doesn't have to be a hardcoded string,
instead it can be const var from package server, which is also a
platform dependent const. So it would be better to use
server.DefaultDebugAddress here.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>