### PR TITLE
metadata: defer ingest lock to backend

### DIFF
--- a/content/local/store.go
+++ b/content/local/store.go
@@ -271,7 +271,7 @@ func (s *store) Writer(ctx context.Context, ref string, total int64, expected di
 	path, refp, data := s.ingestPaths(ref)
 
 	if err := tryLock(ref); err != nil {
-		return nil, errors.Wrapf(err, "locking %v failed", ref)
+		return nil, errors.Wrapf(err, "locking ref %v failed", ref)
 	}
 
 	var (


### PR DESCRIPTION
Because the lock on an ingest ref being held regardless of whether a
writer was in use, resuming an existing ingest proved impossible. We now
defer writer locking to the content store backend, where the lock will
be released automatically on closing the writer or on restarting
containerd.

There are still cases where a writer can be abandoned but not closed,
leaving an active ingest, but this is extremely rare and can be resolved
with a daemon restart.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

Closes #1232.