### PR TITLE
release: prepare for v1.0.0-alpha2

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -5,7 +5,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.0.0-alpha1+unknown"
+	Version = "1.0.0-alpha2+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Signed-off-by: Stephen J Day <stephen.day@docker.com>

Closes https://github.com/containerd/containerd/milestone/11.