### PR TITLE
Convert file not exists to status not found

### DIFF
--- a/content/local/store.go
+++ b/content/local/store.go
@@ -206,11 +206,17 @@ func (s *store) status(ingestPath string) (content.Status, error) {
 	dp := filepath.Join(ingestPath, "data")
 	fi, err := os.Stat(dp)
 	if err != nil {
+		if os.IsNotExist(err) {
+			err = errors.Wrap(errdefs.ErrNotFound, err.Error())
+		}
 		return content.Status{}, err
 	}
 
 	ref, err := readFileString(filepath.Join(ingestPath, "ref"))
 	if err != nil {
+		if os.IsNotExist(err) {
+			err = errors.Wrap(errdefs.ErrNotFound, err.Error())
+		}
 		return content.Status{}, err
 	}
 


### PR DESCRIPTION
Fixes message on pull about a statuses not being found.
These statuses can just be ignored since they are no longer valid and holding the database lock while reading statuses is not necessary.