### PR TITLE
Close chan with errDeferredResponse

### DIFF
--- a/supervisor/stats.go
+++ b/supervisor/stats.go
@@ -27,6 +27,7 @@ func (s *Supervisor) stats(t *StatsTask) error {
 			return
 		}
 		t.ErrorCh() <- nil
+		close(t.ErrorCh())
 		t.Stat <- s
 		ContainerStatsTimer.UpdateSince(start)
 	}()

--- a/supervisor/worker.go
+++ b/supervisor/worker.go
@@ -50,6 +50,7 @@ func (w *worker) Start() {
 				"id":    t.Container.ID(),
 			}).Error("containerd: start container")
 			t.Err <- err
+			close(t.Err)
 			evt := &DeleteTask{
 				ID:      t.Container.ID(),
 				NoEvent: true,
@@ -67,6 +68,7 @@ func (w *worker) Start() {
 		if err := w.s.monitorProcess(process); err != nil {
 			logrus.WithField("error", err).Error("containerd: add process to monitor")
 			t.Err <- err
+			close(t.Err)
 			evt := &DeleteTask{
 				ID:      t.Container.ID(),
 				NoEvent: true,
@@ -82,6 +84,7 @@ func (w *worker) Start() {
 			if err := process.Start(); err != nil {
 				logrus.WithField("error", err).Error("containerd: start init process")
 				t.Err <- err
+				close(t.Err)
 				evt := &DeleteTask{
 					ID:      t.Container.ID(),
 					NoEvent: true,
@@ -95,6 +98,7 @@ func (w *worker) Start() {
 		ContainerStartTimer.UpdateSince(started)
 		w.s.newExecSyncMap(t.Container.ID())
 		t.Err <- nil
+		close(t.Err)
 		t.StartResponse <- StartResponse{
 			Container: t.Container,
 		}


### PR DESCRIPTION
We close chan which is not errDeferredResponse, and I think errDeferredResponse is missing.
```
	if err != errDeferredResponse {
		i.ErrorCh() <- err
		close(i.ErrorCh())
	}
```
Signed-off-by: Shukui Yang <yangshukui@huawei.com>