### PR TITLE
plugin: continue on plugin.Open() error

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -61,8 +61,9 @@ var register = struct {
 	r []*Registration
 }{}
 
-// Load loads all plugins at the provided path into containerd
-func Load(path string) (err error) {
+// Load loads all plugins at the provided directory path into containerd.
+// Load stops loading plugins and returns non-nil error if onError returns non-nil error.
+func Load(dir string, onError func(dllPath string, openErr error) error) (err error) {
 	defer func() {
 		if v := recover(); v != nil {
 			rerr, ok := v.(error)
@@ -72,7 +73,7 @@ func Load(path string) (err error) {
 			err = rerr
 		}
 	}()
-	return loadPlugins(path)
+	return loadPlugins(dir, onError)
 }
 
 func Register(r *Registration) {

--- a/plugin/plugin_go18.go
+++ b/plugin/plugin_go18.go
@@ -11,8 +11,8 @@ import (
 
 // loadPlugins loads all plugins for the OS and Arch
 // that containerd is built for inside the provided path
-func loadPlugins(path string) error {
-	abs, err := filepath.Abs(path)
+func loadPlugins(dir string, onError func(dllPath string, loadErr error) error) error {
+	abs, err := filepath.Abs(dir)
 	if err != nil {
 		return err
 	}
@@ -27,8 +27,10 @@ func loadPlugins(path string) error {
 		return err
 	}
 	for _, lib := range libs {
-		if _, err := plugin.Open(lib); err != nil {
-			return err
+		if _, loadErr := plugin.Open(lib); loadErr != nil {
+			if err := onError(lib, loadErr); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/plugin/plugin_other.go
+++ b/plugin/plugin_other.go
@@ -2,7 +2,7 @@
 
 package plugin
 
-func loadPlugins(path string) error {
+func loadPlugins(dir string, onError func(dllPath string, openErr error) error) error {
 	// plugins not supported until 1.8
 	return nil
 }


### PR DESCRIPTION
Previously, the daemon could not be started if it encounters an error.
Typically, an error is "plugin.Open: plugin was built with a different version of package github.com/foo/bar/..."

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>