### PR TITLE
Update runc to e775f0fba3ea329b8b766451c892c41a3d4

### DIFF
--- a/RUNC.md
+++ b/RUNC.md
@@ -2,7 +2,7 @@ containerd is built with OCI support and with support for advanced features prov
 
 We depend on a specific runc version when dealing with advanced features.  You should have a specific build for development.  The current supported runc commit is:
 
-RUNC_COMMIT = 429a5387123625040bacfbb60d96b1cbd02293ab
+RUNC_COMMIT = e775f0fba3ea329b8b766451c892c41a3d49594d
 
 ## building
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -14,8 +14,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.0
 github.com/docker/go-units v0.3.1
 github.com/gogo/protobuf d2e1ade2d719b78fe5b061b4c18a9f7111b5bdc8
 github.com/golang/protobuf 5a0f697c9ed9d68fef0116532c6e05cfeae00e55
-github.com/opencontainers/runtime-spec 96de01bbb42c7af89bff100e10a9f0fb62e75bfb
-github.com/opencontainers/runc 429a5387123625040bacfbb60d96b1cbd02293ab
+github.com/opencontainers/runtime-spec v1.0.0
+github.com/opencontainers/runc e775f0fba3ea329b8b766451c892c41a3d49594d
 github.com/sirupsen/logrus v1.0.0
 github.com/containerd/btrfs e9c546f46bccffefe71a6bc137e4c21b5503cc18
 github.com/stretchr/testify v1.1.4

--- a/vendor/github.com/opencontainers/runc/README.md
+++ b/vendor/github.com/opencontainers/runc/README.md
@@ -145,11 +145,33 @@ Your process field in the `config.json` should look like this below with `"termi
                         "TERM=xterm"
                 ],
                 "cwd": "/",
-                "capabilities": [
-                        "CAP_AUDIT_WRITE",
-                        "CAP_KILL",
-                        "CAP_NET_BIND_SERVICE"
-                ],
+                "capabilities": {
+                        "bounding": [
+                                "CAP_AUDIT_WRITE",
+                                "CAP_KILL",
+                                "CAP_NET_BIND_SERVICE"
+                        ],
+                        "effective": [
+                                "CAP_AUDIT_WRITE",
+                                "CAP_KILL",
+                                "CAP_NET_BIND_SERVICE"
+                        ],
+                        "inheritable": [
+                                "CAP_AUDIT_WRITE",
+                                "CAP_KILL",
+                                "CAP_NET_BIND_SERVICE"
+                        ],
+                        "permitted": [
+                                "CAP_AUDIT_WRITE",
+                                "CAP_KILL",
+                                "CAP_NET_BIND_SERVICE"
+                        ],
+                        "ambient": [
+                                "CAP_AUDIT_WRITE",
+                                "CAP_KILL",
+                                "CAP_NET_BIND_SERVICE"
+                        ]
+                },
                 "rlimits": [
                         {
                                 "type": "RLIMIT_NOFILE",
@@ -161,7 +183,7 @@ Your process field in the `config.json` should look like this below with `"termi
         },
 ```
 
-Now we can go though the lifecycle operations in your shell.
+Now we can go through the lifecycle operations in your shell.
 
 
 ```bash

--- a/vendor/github.com/opencontainers/runc/libcontainer/nsenter/nsexec.c
+++ b/vendor/github.com/opencontainers/runc/libcontainer/nsenter/nsexec.c
@@ -143,8 +143,7 @@ static int write_file(char *data, size_t data_len, char *pathfmt, ...)
 
 	fd = open(path, O_RDWR);
 	if (fd < 0) {
-		ret = -1;
-		goto out;
+		return -1;
 	}
 
 	len = write(fd, data, data_len);

--- a/vendor/github.com/opencontainers/runc/libcontainer/system/linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/system/linux.go
@@ -64,7 +64,7 @@ func Prlimit(pid, resource int, limit unix.Rlimit) error {
 }
 
 func SetParentDeathSignal(sig uintptr) error {
-	if _, _, err := unix.RawSyscall(unix.SYS_PRCTL, unix.PR_SET_PDEATHSIG, sig, 0); err != 0 {
+	if err := unix.Prctl(unix.PR_SET_PDEATHSIG, sig, 0, 0, 0); err != nil {
 		return err
 	}
 	return nil
@@ -72,15 +72,14 @@ func SetParentDeathSignal(sig uintptr) error {
 
 func GetParentDeathSignal() (ParentDeathSignal, error) {
 	var sig int
-	_, _, err := unix.RawSyscall(unix.SYS_PRCTL, unix.PR_GET_PDEATHSIG, uintptr(unsafe.Pointer(&sig)), 0)
-	if err != 0 {
+	if err := unix.Prctl(unix.PR_GET_PDEATHSIG, uintptr(unsafe.Pointer(&sig)), 0, 0, 0); err != nil {
 		return -1, err
 	}
 	return ParentDeathSignal(sig), nil
 }
 
 func SetKeepCaps() error {
-	if _, _, err := unix.RawSyscall(unix.SYS_PRCTL, unix.PR_SET_KEEPCAPS, 1, 0); err != 0 {
+	if err := unix.Prctl(unix.PR_SET_KEEPCAPS, 1, 0, 0, 0); err != nil {
 		return err
 	}
 
@@ -88,7 +87,7 @@ func SetKeepCaps() error {
 }
 
 func ClearKeepCaps() error {
-	if _, _, err := unix.RawSyscall(unix.SYS_PRCTL, unix.PR_SET_KEEPCAPS, 0, 0); err != 0 {
+	if err := unix.Prctl(unix.PR_SET_KEEPCAPS, 0, 0, 0, 0); err != nil {
 		return err
 	}
 
@@ -96,7 +95,7 @@ func ClearKeepCaps() error {
 }
 
 func Setctty() error {
-	if _, _, err := unix.RawSyscall(unix.SYS_IOCTL, 0, uintptr(unix.TIOCSCTTY), 0); err != 0 {
+	if err := unix.IoctlSetInt(0, unix.TIOCSCTTY, 0); err != nil {
 		return err
 	}
 	return nil

--- a/vendor/github.com/opencontainers/runc/vendor.conf
+++ b/vendor/github.com/opencontainers/runc/vendor.conf
@@ -1,13 +1,13 @@
 # OCI runtime-spec. When updating this, make sure you use a version tag rather
 # than a commit ID so it's much more obvious what version of the spec we are
 # using.
-github.com/opencontainers/runtime-spec 198f23f827eea397d4331d7eb048d9d4c7ff7bee
+github.com/opencontainers/runtime-spec v1.0.0
 # Core libcontainer functionality.
 github.com/mrunalp/fileutils ed869b029674c0e9ce4c0dfa781405c2d9946d08
 github.com/opencontainers/selinux v1.0.0-rc1
 github.com/seccomp/libseccomp-golang 32f571b70023028bd57d9288c20efbcb237f3ce0
-github.com/Sirupsen/logrus 26709e2714106fb8ad40b773b711ebce25b78914
-github.com/syndtr/gocapability e7cb7fa329f456b3855136a2642b197bad7366ba
+github.com/sirupsen/logrus a3f95b5c423586578a4e099b11a46c2479628cac
+github.com/syndtr/gocapability db04d3cc01c8b54962a58ec7e491717d06cfcc16
 github.com/vishvananda/netlink 1e2e08e8a2dcdacaae3f14ac44c5cfa31361f270
 # systemd integration.
 github.com/coreos/go-systemd v14
@@ -18,4 +18,4 @@ github.com/golang/protobuf 18c9bb3261723cd5401db4d0c9fbc5c3b6c70fe8
 github.com/docker/docker 0f5c9d301b9b1cca66b3ea0f9dec3b5317d3686d
 github.com/docker/go-units v0.2.0
 github.com/urfave/cli d53eb991652b1d438abdd34ce4bfa3ef1539108e
-golang.org/x/sys fb4cac33e3196ff7f507ab9b2d2a44b0142f5b5a https://github.com/golang/sys
+golang.org/x/sys 0e0164865330d5cf1c00247be08330bf96e2f87c https://github.com/golang/sys

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc6-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
This resolves logrus issues with containerd not being in sync with the
version runc is using.

This also updates the OCI runtime spec to v1.0.0

Closes #1266

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>