### PR TITLE
Let Delete forcibly kill and delete task

### DIFF
--- a/linux/shim/init.go
+++ b/linux/shim/init.go
@@ -233,19 +233,12 @@ func (p *initProcess) Exited(status int) {
 }
 
 func (p *initProcess) Delete(context context.Context) error {
-	status, err := p.ContainerStatus(context)
-	if err != nil {
-		return err
-	}
-	if status != "stopped" {
-		return fmt.Errorf("cannot delete a running container")
-	}
 	p.killAll(context)
 	if err := p.platform.shutdownConsole(context, p.console); err != nil {
 		log.G(context).WithError(err).Warn("Failed to shutdown container console")
 	}
 	p.Wait()
-	err = p.runtime.Delete(context, p.id, nil)
+	err := p.runtime.Delete(context, p.id, nil)
 	if p.io != nil {
 		for _, c := range p.closers {
 			c.Close()


### PR DESCRIPTION
Let `Delete` kill and delete the task regardless of the state.

In https://github.com/containerd/containerd/pull/978, we changed `Delete` to only be able to delete task when it is stopped. However, in practice, I find that it's inconvenient not to have `Delete` forcibly cleanup everything.

For example, code like [this](https://github.com/containerd/containerd/blob/master/cmd/ctr/run.go#L128) and [this](https://github.com/kubernetes-incubator/cri-containerd/blob/master/pkg/server/sandbox_run.go#L202) will report error and fail to clean up if task is still in `started` or `created` state.

Should we add an option to indicate whether `Delete` should cleanup?
Or should we always wait->kill->delete?
Or should we go with this PR, just let `Delete` always forcibly cleanup everything?

Signed-off-by: Lantao Liu <lantaol@google.com>

/cc @crosbymichael @mlaventure 