### PR TITLE
Cancel event subscribe context in Wait.

### DIFF
--- a/process.go
+++ b/process.go
@@ -69,7 +69,9 @@ func (p *process) Kill(ctx context.Context, s syscall.Signal) error {
 }
 
 func (p *process) Wait(ctx context.Context) (uint32, error) {
-	eventstream, err := p.task.client.EventService().Subscribe(ctx, &eventsapi.SubscribeRequest{
+	cancellable, cancel := context.WithCancel(ctx)
+	defer cancel()
+	eventstream, err := p.task.client.EventService().Subscribe(cancellable, &eventsapi.SubscribeRequest{
 		Filters: []string{"topic==" + runtime.TaskExitEventTopic},
 	})
 	if err != nil {

--- a/task.go
+++ b/task.go
@@ -167,7 +167,9 @@ func (t *task) Status(ctx context.Context) (Status, error) {
 }
 
 func (t *task) Wait(ctx context.Context) (uint32, error) {
-	eventstream, err := t.client.EventService().Subscribe(ctx, &eventsapi.SubscribeRequest{
+	cancellable, cancel := context.WithCancel(ctx)
+	defer cancel()
+	eventstream, err := t.client.EventService().Subscribe(cancellable, &eventsapi.SubscribeRequest{
 		Filters: []string{"topic==" + runtime.TaskExitEventTopic},
 	})
 	if err != nil {


### PR DESCRIPTION
We never know whether the user will cancel the context or not. If not cancelled, this will cause go-routine leakage on the server.

We'd better cancel it inside the client ourselves. /cc @menghanl

Signed-off-by: Lantao Liu <lantaol@google.com>