### PR TITLE
Use a temp socket to receive the console from runc

### DIFF
--- a/linux/shim/exec.go
+++ b/linux/shim/exec.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"sync"
 	"syscall"
@@ -138,10 +137,10 @@ func (e *execProcess) Start(ctx context.Context) (err error) {
 		pidfile = filepath.Join(e.path, fmt.Sprintf("%s.pid", e.id))
 	)
 	if e.stdio.terminal {
-		if socket, err = runc.NewConsoleSocket(filepath.Join(e.path, "pty.sock")); err != nil {
+		if socket, err = runc.NewTempConsoleSocket(); err != nil {
 			return errors.Wrap(err, "failed to create runc console socket")
 		}
-		defer os.Remove(socket.Path())
+		defer socket.Close()
 	} else {
 		if io, err = runc.NewPipeIO(0, 0); err != nil {
 			return errors.Wrap(err, "failed to create runc io pipes")

--- a/linux/shim/init.go
+++ b/linux/shim/init.go
@@ -117,10 +117,10 @@ func newInitProcess(context context.Context, plat platform, path, namespace stri
 		io     runc.IO
 	)
 	if r.Terminal {
-		if socket, err = runc.NewConsoleSocket(filepath.Join(path, "pty.sock")); err != nil {
+		if socket, err = runc.NewTempConsoleSocket(); err != nil {
 			return nil, errors.Wrap(err, "failed to create OCI runtime console socket")
 		}
-		defer os.Remove(socket.Path())
+		defer socket.Close()
 	} else {
 		if io, err = runc.NewPipeIO(0, 0); err != nil {
 			return nil, errors.Wrap(err, "failed to create OCI runtime io pipes")


### PR DESCRIPTION
This greatly reduce the risk that we will hit the unix socket maximum path
length.

Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>
