### PR TITLE
Do not touch grpc logger from within the packages

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
-	"log"
 	"net/http"
 	"runtime"
 	"strconv"
@@ -43,14 +41,10 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
 func init() {
-	// reset the grpc logger so that it does not output in the STDIO of the calling process
-	grpclog.SetLogger(log.New(ioutil.Discard, "", log.LstdFlags))
-
 	// register TypeUrls for commonly marshaled external types
 	major := strconv.Itoa(specs.VersionMajor)
 	typeurl.Register(&specs.Spec{}, "opencontainers/runtime-spec", major, "Spec")

--- a/client_test.go
+++ b/client_test.go
@@ -5,12 +5,16 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io/ioutil"
+	golog "log"
 	"os"
 	"os/exec"
 	"runtime"
 	"syscall"
 	"testing"
 	"time"
+
+	"google.golang.org/grpc/grpclog"
 
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/namespaces"
@@ -26,6 +30,9 @@ var (
 )
 
 func init() {
+	// Discard grpc logs so that they don't mess with our stdio
+	grpclog.SetLogger(golog.New(ioutil.Discard, "", golog.LstdFlags))
+
 	flag.StringVar(&address, "address", defaultAddress, "The address to the containerd socket for use in the tests")
 	flag.BoolVar(&noDaemon, "no-daemon", false, "Do not start a dedicated daemon for the tests")
 	flag.BoolVar(&noCriu, "no-criu", false, "Do not run the checkpoint tests")

--- a/cmd/containerd/main.go
+++ b/cmd/containerd/main.go
@@ -3,11 +3,15 @@ package main
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
+	golog "log"
 	"net"
 	"os"
 	"os/signal"
 	"runtime"
 	"time"
+
+	"google.golang.org/grpc/grpclog"
 
 	gocontext "golang.org/x/net/context"
 
@@ -31,6 +35,9 @@ high performance container runtime
 `
 
 func init() {
+	// Discard grpc logs so that they don't mess with our stdio
+	grpclog.SetLogger(golog.New(ioutil.Discard, "", golog.LstdFlags))
+
 	cli.VersionPrinter = func(c *cli.Context) {
 		fmt.Println(c.App.Name, version.Package, c.App.Version)
 	}

--- a/cmd/ctr/main.go
+++ b/cmd/ctr/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
+	"log"
 	"os"
 
 	"github.com/containerd/containerd/namespaces"
@@ -9,11 +11,15 @@ import (
 	"github.com/containerd/containerd/version"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
+	"google.golang.org/grpc/grpclog"
 )
 
 var extraCmds = []cli.Command{}
 
 func init() {
+	// Discard grpc logs so that they don't mess with our stdio
+	grpclog.SetLogger(log.New(ioutil.Discard, "", log.LstdFlags))
+
 	cli.VersionPrinter = func(c *cli.Context) {
 		fmt.Println(c.App.Name, version.Package, c.App.Version)
 	}

--- a/cmd/ctr/shim.go
+++ b/cmd/ctr/shim.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net"
 	"os"
 	"time"
@@ -15,7 +14,6 @@ import (
 	gocontext "context"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/grpclog"
 
 	"github.com/containerd/console"
 	shim "github.com/containerd/containerd/linux/shim/v1"
@@ -305,8 +303,6 @@ func getShimService(context *cli.Context) (shim.ShimClient, error) {
 		return nil, errors.New("socket path must be specified")
 	}
 
-	// reset the logger for grpc to log to dev/null so that it does not mess with our stdio
-	grpclog.SetLogger(log.New(ioutil.Discard, "", log.LstdFlags))
 	dialOpts := []grpc.DialOption{grpc.WithInsecure(), grpc.WithTimeout(100 * time.Second)}
 	dialOpts = append(dialOpts,
 		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {

--- a/cmd/ctr/utils_unix.go
+++ b/cmd/ctr/utils_unix.go
@@ -6,8 +6,6 @@ import (
 	gocontext "context"
 	"fmt"
 	"io"
-	"io/ioutil"
-	"log"
 	"net"
 	"os"
 	"sync"
@@ -18,7 +16,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/grpclog"
 )
 
 func prepareStdio(stdin, stdout, stderr string, console bool) (wg *sync.WaitGroup, err error) {
@@ -82,8 +79,6 @@ func getGRPCConnection(context *cli.Context) (*grpc.ClientConn, error) {
 	}
 
 	bindSocket := context.GlobalString("address")
-	// reset the logger for grpc to log to dev/null so that it does not mess with our stdio
-	grpclog.SetLogger(log.New(ioutil.Discard, "", log.LstdFlags))
 	dialOpts := []grpc.DialOption{grpc.WithInsecure(), grpc.WithTimeout(100 * time.Second)}
 	dialOpts = append(dialOpts,
 		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {

--- a/cmd/ctr/utils_windows.go
+++ b/cmd/ctr/utils_windows.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"io"
-	"io/ioutil"
-	"log"
 	"net"
 	"os"
 	"sync"
@@ -16,7 +14,6 @@ import (
 	"github.com/urfave/cli"
 	"golang.org/x/sys/windows"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/grpclog"
 )
 
 func getGRPCConnection(context *cli.Context) (*grpc.ClientConn, error) {
@@ -25,8 +22,6 @@ func getGRPCConnection(context *cli.Context) (*grpc.ClientConn, error) {
 	}
 
 	bindAddress := context.GlobalString("address")
-	// reset the logger for grpc to log to dev/null so that it does not mess with our stdio
-	grpclog.SetLogger(log.New(ioutil.Discard, "", log.LstdFlags))
 	dialOpts := []grpc.DialOption{grpc.WithInsecure(), grpc.WithTimeout(100 * time.Second)}
 	dialOpts = append(dialOpts,
 		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {


### PR DESCRIPTION
Libraries should not make process wide changes unless requested to.

Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>