### PR TITLE
Add missing return when failing to write tar header

### DIFF
--- a/archive/tar.go
+++ b/archive/tar.go
@@ -314,7 +314,7 @@ func (cw *changeWriter) HandleChange(k fs.ChangeKind, p string, f os.FileInfo, e
 			ChangeTime: cw.whiteoutT,
 		}
 		if err := cw.tw.WriteHeader(hdr); err != nil {
-			errors.Wrap(err, "failed to write whiteout header")
+			return errors.Wrap(err, "failed to write whiteout header")
 		}
 	} else {
 		var (


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

-- 

Just noticed this one randomly (I opened the wrong file :sweat_smile:)