### PR TITLE
Fix ctr run bug when snapshotter is provided

### DIFF
--- a/cmd/ctr/run_unix.go
+++ b/cmd/ctr/run_unix.go
@@ -92,12 +92,12 @@ func newContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 		}
 		opts = append(opts, containerd.WithImageConfig(ctx, image))
 		cOpts = append(cOpts, containerd.WithImage(image))
+		cOpts = append(cOpts, containerd.WithSnapshotter(context.String("snapshotter")))
 		if context.Bool("readonly") {
 			cOpts = append(cOpts, containerd.WithNewSnapshotView(id, image))
 		} else {
 			cOpts = append(cOpts, containerd.WithNewSnapshot(id, image))
 		}
-		cOpts = append(cOpts, containerd.WithSnapshotter(context.String("snapshotter")))
 	}
 
 	opts = append(opts, withEnv(context), withMounts(context))


### PR DESCRIPTION
Snapshotters for run must be created with requested snapshotter. The order of the options is important to ensure that the snapshotter is set before the snapshots are created.

The bug caused the run to fail due to the snapshotter not being found, subsequent runs would fail to create the snapshot since it already existed. `ctr snapshot ls` showed the snapshots were being created with the wrong snapshotter.