### PR TITLE
Add `start` subcommand in `ctr`.

### DIFF
--- a/cmd/ctr/main.go
+++ b/cmd/ctr/main.go
@@ -81,6 +81,7 @@ containerd CLI
 		rootfsCommand,
 		runCommand,
 		snapshotCommand,
+		startCommand,
 		taskListCommand,
 		versionCommand,
 	}, extraCmds...)

--- a/cmd/ctr/start.go
+++ b/cmd/ctr/start.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"github.com/containerd/console"
+	"github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+)
+
+var startCommand = cli.Command{
+	Name:      "start",
+	Usage:     "start a container that have been created",
+	ArgsUsage: "CONTAINER",
+	Action: func(context *cli.Context) error {
+		var (
+			err error
+
+			ctx, cancel = appContext(context)
+			id          = context.Args().Get(0)
+		)
+
+		defer cancel()
+
+		if id == "" {
+			return errors.New("container id must be provided")
+		}
+		client, err := newClient(context)
+		if err != nil {
+			return err
+		}
+		container, err := client.LoadContainer(ctx, id)
+		if err != nil {
+			return err
+		}
+
+		spec, err := container.Spec()
+		if err != nil {
+			return err
+		}
+
+		tty := spec.Process.Terminal
+
+		task, err := newTask(ctx, container, digest.Digest(""), tty)
+		if err != nil {
+			return err
+		}
+		defer task.Delete(ctx)
+
+		statusC := make(chan uint32, 1)
+		go func() {
+			status, err := task.Wait(ctx)
+			if err != nil {
+				logrus.WithError(err).Error("wait process")
+			}
+			statusC <- status
+		}()
+		var con console.Console
+		if tty {
+			con = console.Current()
+			defer con.Reset()
+			if err := con.SetRaw(); err != nil {
+				return err
+			}
+		}
+		if err := task.Start(ctx); err != nil {
+			return err
+		}
+		if tty {
+			if err := handleConsoleResize(ctx, task, con); err != nil {
+				logrus.WithError(err).Error("console resize")
+			}
+		} else {
+			sigc := forwardAllSignals(ctx, task)
+			defer stopCatch(sigc)
+		}
+
+		status := <-statusC
+		if _, err := task.Delete(ctx); err != nil {
+			return err
+		}
+		if status != 0 {
+			return cli.NewExitError("", int(status))
+		}
+		return nil
+	},
+}


### PR DESCRIPTION
Related to #1272

How to test:
1. Create a container, and then exit
```
$ ctr run  docker.io/library/busybox:latest test top
Mem: 1035364K used, 4044028K free, 3680K shrd, 101184K buff, 684700K cached
CPU:  3.3% usr  3.3% sys  0.0% nic 93.3% idle  0.0% io  0.0% irq  0.0% sirq
Load average: 0.00 0.01 0.05 1/210 5
  PID  PPID USER     STAT   VSZ %VSZ CPU %CPU COMMAND
    1     0 root     R     1216  0.0   1  0.0 top
^C
```
2. Execute the `ctr start` command to start the container again
```
$ ctr start test
Mem: 1033492K used, 4045900K free, 3680K shrd, 101240K buff, 684700K cached
CPU:  3.3% usr  3.3% sys  0.0% nic 93.3% idle  0.0% io  0.0% irq  0.0% sirq
Load average: 0.00 0.01 0.05 1/211 6
  PID  PPID USER     STAT   VSZ %VSZ CPU %CPU COMMAND
    1     0 root     R     1216  0.0   1  0.0 top
```


Signed-off-by: Yanqiang Miao <miao.yanqiang@zte.com.cn>