### PR TITLE
Fix bundle removal with the reappearance of state dir

### DIFF
--- a/linux/runtime.go
+++ b/linux/runtime.go
@@ -211,7 +211,7 @@ func (r *Runtime) Delete(ctx context.Context, c runtime.Task) (*runtime.Exit, er
 	}
 	r.tasks.Delete(ctx, lc)
 
-	bundle := loadBundle(filepath.Join(r.state, namespace, lc.id), namespace, r.events)
+	bundle := loadBundle(filepath.Join(r.state, namespace, lc.id), filepath.Join(r.root, namespace, lc.id), namespace, r.events)
 	if err := bundle.Delete(); err != nil {
 		return nil, err
 	}
@@ -262,7 +262,7 @@ func (r *Runtime) loadTasks(ctx context.Context, ns string) ([]*Task, error) {
 			continue
 		}
 		id := path.Name()
-		bundle := loadBundle(filepath.Join(r.state, ns, id), ns, r.events)
+		bundle := loadBundle(filepath.Join(r.state, ns, id), filepath.Join(r.root, ns, id), ns, r.events)
 
 		s, err := bundle.Connect(ctx, r.remote)
 		if err != nil {


### PR DESCRIPTION
Bundle removal now requires removing both workdir and path locations on
delete in shim.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>

ping @mlaventure ; feels ugly handling either/or errors from 2 delete calls; feel free to let me know a better way.