### PR TITLE
Handle sigkilled shim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ checkprotos: protos ## check if protobufs needs to be generated again
 
 # Depends on binaries because vet will silently fail if it can't load compiled
 # imports
-vet: binaries ## run go vet
+vet: ## run go vet
 	@echo "$(WHALE) $@"
 	@test -z "$$(go vet ${PACKAGES} 2>&1 | grep -v 'constant [0-9]* not a string in call to Errorf' | grep -v 'unrecognized printf verb 'r'' | egrep -v '(timestamp_test.go|duration_test.go|fetch.go|exit status 1)' | tee /dev/stderr)"
 

--- a/client_test.go
+++ b/client_test.go
@@ -66,6 +66,7 @@ func TestMain(m *testing.M) {
 
 		err := ctrd.start("containerd", address, []string{
 			"--root", defaultRoot,
+			"--state", defaultState,
 			"--log-level", "debug",
 		}, buf, buf)
 		if err != nil {

--- a/client_unix_test.go
+++ b/client_unix_test.go
@@ -8,6 +8,7 @@ import (
 
 const (
 	defaultRoot    = "/var/lib/containerd-test"
+	defaultState   = "/run/containerd-test"
 	defaultAddress = "/run/containerd-test/containerd.sock"
 )
 

--- a/client_windows_test.go
+++ b/client_windows_test.go
@@ -17,7 +17,8 @@ const (
 var (
 	dockerLayerFolders []string
 
-	defaultRoot = filepath.Join(os.Getenv("programfiles"), "containerd", "root-test")
+	defaultRoot  = filepath.Join(os.Getenv("programfiles"), "containerd", "root-test")
+	defaultState = filepath.Join(os.Getenv("programfiles"), "containerd", "state-test")
 )
 
 func platformTestSetup(client *Client) error {

--- a/cmd/containerd/main.go
+++ b/cmd/containerd/main.go
@@ -66,6 +66,10 @@ func main() {
 			Name:  "root",
 			Usage: "containerd root directory",
 		},
+		cli.StringFlag{
+			Name:  "state",
+			Usage: "containerd state directory",
+		},
 	}
 	app.Commands = []cli.Command{
 		configCommand,
@@ -155,6 +159,10 @@ func applyFlags(context *cli.Context, config *server.Config) error {
 		{
 			name: "root",
 			d:    &config.Root,
+		},
+		{
+			name: "state",
+			d:    &config.State,
 		},
 		{
 			name: "address",

--- a/events/exchange.go
+++ b/events/exchange.go
@@ -185,11 +185,11 @@ func validateTopic(topic string) error {
 	}
 
 	if topic[0] != '/' {
-		return errors.Wrapf(errdefs.ErrInvalidArgument, "must start with '/'", topic)
+		return errors.Wrapf(errdefs.ErrInvalidArgument, "must start with '/'")
 	}
 
 	if len(topic) == 1 {
-		return errors.Wrapf(errdefs.ErrInvalidArgument, "must have at least one component", topic)
+		return errors.Wrapf(errdefs.ErrInvalidArgument, "must have at least one component")
 	}
 
 	components := strings.Split(topic[1:], "/")

--- a/linux/bundle.go
+++ b/linux/bundle.go
@@ -28,7 +28,7 @@ func loadBundle(path, workdir, namespace, id string, events *events.Exchange) *b
 }
 
 // newBundle creates a new bundle on disk at the provided path for the given id
-func newBundle(path, namespace, workDir, id string, spec []byte, events *events.Exchange) (b *bundle, err error) {
+func newBundle(namespace, id, path, workDir string, spec []byte, events *events.Exchange) (b *bundle, err error) {
 	if err := os.MkdirAll(path, 0711); err != nil {
 		return nil, err
 	}
@@ -78,8 +78,8 @@ type bundle struct {
 }
 
 // NewShim connects to the shim managing the bundle and tasks
-func (b *bundle) NewShim(ctx context.Context, binary, grpcAddress string, remote, debug bool, createOpts runtime.CreateOpts) (*client.Client, error) {
-	opt := client.WithStart(binary, grpcAddress, debug)
+func (b *bundle) NewShim(ctx context.Context, binary, grpcAddress string, remote, debug bool, createOpts runtime.CreateOpts, exitHandler func()) (*client.Client, error) {
+	opt := client.WithStart(binary, grpcAddress, debug, exitHandler)
 	if !remote {
 		opt = client.WithLocal(b.events)
 	}

--- a/linux/runtime.go
+++ b/linux/runtime.go
@@ -405,9 +405,7 @@ func (r *Runtime) getRuntime(ctx context.Context, ns, id string) (*runc.Runc, er
 		return nil, err
 	}
 	return &runc.Runc{
-		// TODO: until we have a way to store/retrieve the original command
-		// we can only rely on runc from the default $PATH
-		Command:      runc.DefaultCommand,
+		Command:      r.runtime,
 		LogFormat:    runc.JSON,
 		PdeathSignal: unix.SIGKILL,
 		Root:         filepath.Join(client.RuncRoot, ns),

--- a/linux/runtime.go
+++ b/linux/runtime.go
@@ -185,6 +185,7 @@ func (r *Runtime) Create(ctx context.Context, id string, opts runtime.CreateOpts
 	}
 	// after the task is created, add it to the monitor
 	if err = r.monitor.Monitor(t); err != nil {
+		r.tasks.Delete(ctx, t)
 		return nil, err
 	}
 	return t, nil

--- a/linux/shim/init.go
+++ b/linux/shim/init.go
@@ -27,6 +27,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const InitPidFile = "init.pid"
+
 type initProcess struct {
 	sync.WaitGroup
 	initState
@@ -131,7 +133,7 @@ func newInitProcess(context context.Context, plat platform, path, namespace, wor
 			return nil, errors.Wrap(err, "failed to create OCI runtime io pipes")
 		}
 	}
-	pidFile := filepath.Join(path, "init.pid")
+	pidFile := filepath.Join(path, InitPidFile)
 	if r.Checkpoint != "" {
 		opts := &runc.RestoreOpts{
 			CheckpointOpts: runc.CheckpointOpts{

--- a/linux/shim/service.go
+++ b/linux/shim/service.go
@@ -58,7 +58,6 @@ type platform interface {
 }
 
 type Service struct {
-	initProcess   *initProcess
 	path          string
 	id            string
 	bundle        string
@@ -83,7 +82,6 @@ func (s *Service) Create(ctx context.Context, r *shimapi.CreateTaskRequest) (*sh
 	// save the main task id and bundle to the shim for additional requests
 	s.id = r.ID
 	s.bundle = r.Bundle
-	s.initProcess = process
 	pid := process.Pid()
 	s.processes[r.ID] = process
 	s.mu.Unlock()
@@ -111,8 +109,8 @@ func (s *Service) Create(ctx context.Context, r *shimapi.CreateTaskRequest) (*sh
 }
 
 func (s *Service) Start(ctx context.Context, r *shimapi.StartRequest) (*shimapi.StartResponse, error) {
-	p, ok := s.processes[r.ID]
-	if !ok {
+	p := s.getProcess(r.ID)
+	if p == nil {
 		return nil, errdefs.ToGRPCf(errdefs.ErrNotFound, "process %s not found", r.ID)
 	}
 	if err := p.Start(ctx); err != nil {
@@ -121,7 +119,7 @@ func (s *Service) Start(ctx context.Context, r *shimapi.StartRequest) (*shimapi.
 	if r.ID == s.id {
 		s.events <- &eventsapi.TaskStart{
 			ContainerID: s.id,
-			Pid:         uint32(s.initProcess.Pid()),
+			Pid:         uint32(p.Pid()),
 		}
 	} else {
 		pid := p.Pid()
@@ -143,16 +141,15 @@ func (s *Service) Start(ctx context.Context, r *shimapi.StartRequest) (*shimapi.
 }
 
 func (s *Service) Delete(ctx context.Context, r *google_protobuf.Empty) (*shimapi.DeleteResponse, error) {
-	if s.initProcess == nil {
+	p := s.getProcess(s.id)
+	if p == nil {
 		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
 	}
-	p := s.initProcess
+
 	if err := p.Delete(ctx); err != nil {
 		return nil, err
 	}
-	s.mu.Lock()
-	delete(s.processes, p.ID())
-	s.mu.Unlock()
+	s.deleteProcess(p.ID())
 	s.events <- &eventsapi.TaskDelete{
 		ContainerID: s.id,
 		ExitStatus:  uint32(p.ExitStatus()),
@@ -167,24 +164,17 @@ func (s *Service) Delete(ctx context.Context, r *google_protobuf.Empty) (*shimap
 }
 
 func (s *Service) DeleteProcess(ctx context.Context, r *shimapi.DeleteProcessRequest) (*shimapi.DeleteResponse, error) {
-	if s.initProcess == nil {
-		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
-	}
-	if r.ID == s.initProcess.id {
+	if r.ID == s.id {
 		return nil, grpc.Errorf(codes.InvalidArgument, "cannot delete init process with DeleteProcess")
 	}
-	s.mu.Lock()
-	p, ok := s.processes[r.ID]
-	s.mu.Unlock()
-	if !ok {
-		return nil, errors.Wrapf(errdefs.ErrNotFound, "process %s not found", r.ID)
+	p := s.getProcess(r.ID)
+	if p == nil {
+		return nil, errors.Wrapf(errdefs.ErrNotFound, "process %s", r.ID)
 	}
 	if err := p.Delete(ctx); err != nil {
 		return nil, err
 	}
-	s.mu.Lock()
-	delete(s.processes, p.ID())
-	s.mu.Unlock()
+	s.deleteProcess(r.ID)
 	return &shimapi.DeleteResponse{
 		ExitStatus: uint32(p.ExitStatus()),
 		ExitedAt:   p.ExitedAt(),
@@ -193,13 +183,19 @@ func (s *Service) DeleteProcess(ctx context.Context, r *shimapi.DeleteProcessReq
 }
 
 func (s *Service) Exec(ctx context.Context, r *shimapi.ExecProcessRequest) (*google_protobuf.Empty, error) {
-	if s.initProcess == nil {
-		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
-	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	process, err := newExecProcess(ctx, s.path, r, s.initProcess, r.ID)
+	if p := s.processes[r.ID]; p != nil {
+		return nil, errdefs.ToGRPCf(errdefs.ErrAlreadyExists, "id %s", r.ID)
+	}
+
+	p := s.processes[s.id]
+	if p == nil {
+		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
+	}
+
+	process, err := newExecProcess(ctx, s.path, r, p.(*initProcess), r.ID)
 	if err != nil {
 		return nil, errdefs.ToGRPC(err)
 	}
@@ -220,10 +216,8 @@ func (s *Service) ResizePty(ctx context.Context, r *shimapi.ResizePtyRequest) (*
 		Width:  uint16(r.Width),
 		Height: uint16(r.Height),
 	}
-	s.mu.Lock()
-	p, ok := s.processes[r.ID]
-	s.mu.Unlock()
-	if !ok {
+	p := s.getProcess(r.ID)
+	if p == nil {
 		return nil, errors.Errorf("process does not exist %s", r.ID)
 	}
 	if err := p.Resize(ws); err != nil {
@@ -233,8 +227,8 @@ func (s *Service) ResizePty(ctx context.Context, r *shimapi.ResizePtyRequest) (*
 }
 
 func (s *Service) State(ctx context.Context, r *shimapi.StateRequest) (*shimapi.StateResponse, error) {
-	p, ok := s.processes[r.ID]
-	if !ok {
+	p := s.getProcess(r.ID)
+	if p == nil {
 		return nil, errdefs.ToGRPCf(errdefs.ErrNotFound, "process id %s not found", r.ID)
 	}
 	st, err := p.Status(ctx)
@@ -270,10 +264,11 @@ func (s *Service) State(ctx context.Context, r *shimapi.StateRequest) (*shimapi.
 }
 
 func (s *Service) Pause(ctx context.Context, r *google_protobuf.Empty) (*google_protobuf.Empty, error) {
-	if s.initProcess == nil {
+	p := s.getProcess(s.id)
+	if p == nil {
 		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
 	}
-	if err := s.initProcess.Pause(ctx); err != nil {
+	if err := p.(*initProcess).Pause(ctx); err != nil {
 		return nil, err
 	}
 	s.events <- &eventsapi.TaskPaused{
@@ -283,10 +278,11 @@ func (s *Service) Pause(ctx context.Context, r *google_protobuf.Empty) (*google_
 }
 
 func (s *Service) Resume(ctx context.Context, r *google_protobuf.Empty) (*google_protobuf.Empty, error) {
-	if s.initProcess == nil {
+	p := s.getProcess(s.id)
+	if p == nil {
 		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
 	}
-	if err := s.initProcess.Resume(ctx); err != nil {
+	if err := p.(*initProcess).Resume(ctx); err != nil {
 		return nil, err
 	}
 	s.events <- &eventsapi.TaskResumed{
@@ -296,17 +292,19 @@ func (s *Service) Resume(ctx context.Context, r *google_protobuf.Empty) (*google
 }
 
 func (s *Service) Kill(ctx context.Context, r *shimapi.KillRequest) (*google_protobuf.Empty, error) {
-	if s.initProcess == nil {
-		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
-	}
 	if r.ID == "" {
-		if err := s.initProcess.Kill(ctx, r.Signal, r.All); err != nil {
+		p := s.getProcess(s.id)
+		if p == nil {
+			return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
+		}
+		if err := p.Kill(ctx, r.Signal, r.All); err != nil {
 			return nil, errdefs.ToGRPC(err)
 		}
 		return empty, nil
 	}
-	p, ok := s.processes[r.ID]
-	if !ok {
+
+	p := s.getProcess(r.ID)
+	if p == nil {
 		return nil, errdefs.ToGRPCf(errdefs.ErrNotFound, "process id %s not found", r.ID)
 	}
 	if err := p.Kill(ctx, r.Signal, r.All); err != nil {
@@ -326,8 +324,8 @@ func (s *Service) ListPids(ctx context.Context, r *shimapi.ListPidsRequest) (*sh
 }
 
 func (s *Service) CloseIO(ctx context.Context, r *shimapi.CloseIORequest) (*google_protobuf.Empty, error) {
-	p, ok := s.processes[r.ID]
-	if !ok {
+	p := s.getProcess(r.ID)
+	if p == nil {
 		return nil, errdefs.ToGRPCf(errdefs.ErrNotFound, "process does not exist %s", r.ID)
 	}
 	if err := p.Stdin().Close(); err != nil {
@@ -337,10 +335,11 @@ func (s *Service) CloseIO(ctx context.Context, r *shimapi.CloseIORequest) (*goog
 }
 
 func (s *Service) Checkpoint(ctx context.Context, r *shimapi.CheckpointTaskRequest) (*google_protobuf.Empty, error) {
-	if s.initProcess == nil {
+	p := s.getProcess(s.id)
+	if p == nil {
 		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
 	}
-	if err := s.initProcess.Checkpoint(ctx, r); err != nil {
+	if err := p.(*initProcess).Checkpoint(ctx, r); err != nil {
 		return nil, errdefs.ToGRPC(err)
 	}
 	s.events <- &eventsapi.TaskCheckpointed{
@@ -356,13 +355,33 @@ func (s *Service) ShimInfo(ctx context.Context, r *google_protobuf.Empty) (*shim
 }
 
 func (s *Service) Update(ctx context.Context, r *shimapi.UpdateTaskRequest) (*google_protobuf.Empty, error) {
-	if s.initProcess == nil {
+	p := s.getProcess(s.id)
+	if p == nil {
 		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
 	}
-	if err := s.initProcess.Update(ctx, r); err != nil {
+	if err := p.(*initProcess).Update(ctx, r); err != nil {
 		return nil, errdefs.ToGRPC(err)
 	}
 	return empty, nil
+}
+
+func (s *Service) addProcess(id string, p process) {
+	s.mu.Lock()
+	s.processes[id] = p
+	s.mu.Unlock()
+}
+
+func (s *Service) getProcess(id string) process {
+	s.mu.Lock()
+	p := s.processes[id]
+	s.mu.Unlock()
+	return p
+}
+
+func (s *Service) deleteProcess(id string) {
+	s.mu.Lock()
+	delete(s.processes, id)
+	s.mu.Unlock()
 }
 
 func (s *Service) waitExit(p process, pid int, cmd *reaper.Cmd) {
@@ -380,12 +399,17 @@ func (s *Service) waitExit(p process, pid int, cmd *reaper.Cmd) {
 }
 
 func (s *Service) getContainerPids(ctx context.Context, id string) ([]uint32, error) {
-	p, err := s.initProcess.runtime.Ps(ctx, id)
+	p := s.getProcess(s.id)
+	if p == nil {
+		return nil, errors.Wrapf(errdefs.ErrFailedPrecondition, "container must be created")
+	}
+
+	ps, err := p.(*initProcess).runtime.Ps(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	pids := make([]uint32, 0, len(p))
-	for _, pid := range p {
+	pids := make([]uint32, 0, len(ps))
+	for _, pid := range ps {
 		pids = append(pids, uint32(pid))
 	}
 	return pids, nil

--- a/linux/task.go
+++ b/linux/task.go
@@ -15,13 +15,15 @@ import (
 
 type Task struct {
 	id        string
+	pid       int
 	shim      *client.Client
 	namespace string
 }
 
-func newTask(id, namespace string, shim *client.Client) *Task {
+func newTask(id, namespace string, pid int, shim *client.Client) *Task {
 	return &Task{
 		id:        id,
+		pid:       pid,
 		shim:      shim,
 		namespace: namespace,
 	}

--- a/runtime/events.go
+++ b/runtime/events.go
@@ -7,7 +7,9 @@ const (
 	TaskExitEventTopic         = "/tasks/exit"
 	TaskDeleteEventTopic       = "/tasks/delete"
 	TaskExecAddedEventTopic    = "/tasks/exec-added"
+	TaskExecStartedEventTopic  = "/tasks/exec-started"
 	TaskPausedEventTopic       = "/tasks/paused"
 	TaskResumedEventTopic      = "/tasks/resumed"
 	TaskCheckpointedEventTopic = "/tasks/checkpointed"
+	TaskUnknownTopic           = "/tasks/?"
 )

--- a/runtime/task_list.go
+++ b/runtime/task_list.go
@@ -2,10 +2,10 @@ package runtime
 
 import (
 	"context"
-	"errors"
 	"sync"
 
 	"github.com/containerd/containerd/namespaces"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -75,7 +75,7 @@ func (l *TaskList) AddWithNamespace(namespace string, t Task) error {
 		l.tasks[namespace] = make(map[string]Task)
 	}
 	if _, ok := l.tasks[namespace][id]; ok {
-		return ErrTaskAlreadyExists
+		return errors.Wrap(ErrTaskAlreadyExists, id)
 	}
 	l.tasks[namespace][id] = t
 	return nil


### PR DESCRIPTION
If a shim were to be killed or crashed while the daemon is active, we are currently unable to handle it properly (especially with process that reset their `PDeathHandler`).

This is an attempt at doing so.