### PR TITLE
Fix race with task checkpoint

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -132,7 +132,9 @@ func TestMain(m *testing.M) {
 			}
 		}
 		if err := cmd.Wait(); err != nil {
-			fmt.Fprintln(os.Stderr, "failed to wait for containerd", err)
+			if _, ok := err.(*exec.ExitError); !ok {
+				fmt.Fprintln(os.Stderr, "failed to wait for containerd", err)
+			}
 		}
 		if err := os.RemoveAll(defaultRoot); err != nil {
 			fmt.Fprintln(os.Stderr, "failed to remove test root dir", err)

--- a/linux/runtime.go
+++ b/linux/runtime.go
@@ -211,9 +211,14 @@ func (r *Runtime) Delete(ctx context.Context, c runtime.Task) (*runtime.Exit, er
 	}
 	r.tasks.Delete(ctx, lc)
 
-	bundle := loadBundle(filepath.Join(r.state, namespace, lc.id), filepath.Join(r.root, namespace, lc.id), namespace, r.events)
+	bundle := loadBundle(
+		filepath.Join(r.state, namespace, lc.id),
+		filepath.Join(r.root, namespace, lc.id),
+		namespace,
+		r.events,
+	)
 	if err := bundle.Delete(); err != nil {
-		return nil, err
+		log.G(ctx).WithError(err).Error("failed to delete bundle")
 	}
 	return &runtime.Exit{
 		Status:    rsp.ExitStatus,

--- a/linux/shim/service.go
+++ b/linux/shim/service.go
@@ -147,8 +147,9 @@ func (s *Service) Delete(ctx context.Context, r *google_protobuf.Empty) (*shimap
 		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
 	}
 	p := s.initProcess
-	// TODO (@crosbymichael): how to handle errors here
-	p.Delete(ctx)
+	if err := p.Delete(ctx); err != nil {
+		return nil, err
+	}
 	s.mu.Lock()
 	delete(s.processes, p.ID())
 	s.mu.Unlock()
@@ -178,8 +179,9 @@ func (s *Service) DeleteProcess(ctx context.Context, r *shimapi.DeleteProcessReq
 	if !ok {
 		return nil, errors.Wrapf(errdefs.ErrNotFound, "process %s not found", r.ID)
 	}
-	// TODO (@crosbymichael): how to handle errors here
-	p.Delete(ctx)
+	if err := p.Delete(ctx); err != nil {
+		return nil, err
+	}
 	s.mu.Lock()
 	delete(s.processes, p.ID())
 	s.mu.Unlock()


### PR DESCRIPTION
Because runc will delete a container after a successful checkpoint we
need to handle a NotFound error from runc on delete.

There is also a race between SIGKILL'ing the shim and it actually
exiting to unmount the tasks rootfs, we need to loop and wait for the
task to actually be reaped before trying to delete the rootfs+bundle.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>