### PR TITLE
Makefile: simplify installation from tar file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,8 +172,9 @@ binaries: $(BINARIES) ## build binaries
 
 release: $(BINARIES)
 	@echo "$(WHALE) $@"
-	@mkdir -p releases/${RELEASE}
-	@cp $(BINARIES) releases/$(RELEASE)/
+	@rm -rf releases/$(RELEASE) releases/$(RELEASE).tar.gz
+	@install -d releases/$(RELEASE)/bin
+	@install $(BINARIES) releases/$(RELEASE)/bin
 	@cd releases/$(RELEASE) && tar -czf ../$(RELEASE).tar.gz *
 
 clean: ## clean up binaries


### PR DESCRIPTION
By moving the binaries to be rooted at `bin/` in the tar file,
installation can be done from a tar file in one fell swoop:

```console
$ make release
$ sudo tar -C /usr/local -xvf releases/containerd-1.0.0-alpha3-72-ge6ba48f2.m.linux-amd64.tar.gz
```

Signed-off-by: Stephen J Day <stephen.day@docker.com>