### PR TITLE
cmd/containerd: resolve config relative binary location

### DIFF
--- a/cmd/containerd/main_linux.go
+++ b/cmd/containerd/main_linux.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"os"
+	"path/filepath"
 
 	"golang.org/x/sys/unix"
 
@@ -11,7 +12,7 @@ import (
 	"github.com/containerd/containerd/server"
 )
 
-const defaultConfigPath = "/etc/containerd/config.toml"
+var defaultConfigPath = "/etc/containerd/config.toml"
 
 var handledSignals = []os.Signal{
 	unix.SIGTERM,
@@ -36,4 +37,13 @@ func handleSignals(ctx context.Context, signals chan os.Signal, server *server.S
 		}
 	}
 	return nil
+}
+
+func init() {
+	// if we are installed in another root, tweak the default config path to be
+	// relative the binary location.
+	t, err := os.Readlink("/proc/self/exe")
+	if err == nil {
+		defaultConfigPath = filepath.Join(filepath.Dir(t), "../"+defaultConfigPath)
+	}
 }


### PR DESCRIPTION
The default configuration is now resolved relative to installation
location of the binary. For example, if the binary is run from
`/usr/local/bin/containerd`, it now will find the configuration in
`/usr/local/etc/containerd/config.toml`. Overriding the config still
works as normal.

Signed-off-by: Stephen J Day <stephen.day@docker.com>