### PR TITLE
Set runtime on container from ctr

### DIFF
--- a/cmd/ctr/run.go
+++ b/cmd/ctr/run.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	gocontext "context"
+	"fmt"
+	"runtime"
 	"syscall"
 
 	"github.com/containerd/console"
@@ -56,7 +58,7 @@ var runCommand = cli.Command{
 		cli.StringFlag{
 			Name:  "runtime",
 			Usage: "runtime name (io.containerd.runtime.v1.linux, io.containerd.runtime.v1.windows, io.containerd.runtime.v1.com.vmware.linux)",
-			Value: "io.containerd.runtime.v1.linux",
+			Value: fmt.Sprintf("io.containerd.runtime.v1.%s", runtime.GOOS),
 		},
 		cli.BoolFlag{
 			Name:  "readonly",

--- a/cmd/ctr/run_unix.go
+++ b/cmd/ctr/run_unix.go
@@ -99,6 +99,7 @@ func newContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 			cOpts = append(cOpts, containerd.WithNewSnapshot(id, image))
 		}
 	}
+	cOpts = append(cOpts, containerd.WithRuntime(context.String("runtime")))
 
 	opts = append(opts, withEnv(context), withMounts(context))
 	if len(args) > 0 {

--- a/cmd/ctr/run_windows.go
+++ b/cmd/ctr/run_windows.go
@@ -117,6 +117,7 @@ func newContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 	return client.NewContainer(ctx, id,
 		containerd.WithSpec(spec),
 		containerd.WithContainerLabels(labels),
+		containerd.WithRuntime(context.String("runtime")),
 		// TODO(mlaventure): containerd.WithImage(image),
 	)
 }


### PR DESCRIPTION
Set the missing `--runtime` flag when using ctr for new containers

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>