### PR TITLE
Remove default run dir.

### DIFF
--- a/spec_opts.go
+++ b/spec_opts.go
@@ -20,3 +20,17 @@ func WithHostname(name string) SpecOpts {
 		return nil
 	}
 }
+
+// WithMount adds passed in mount into the spec.
+func WithMount(mount specs.Mount) SpecOpts {
+	return func(s *specs.Spec) error {
+		mounts := s.Mounts
+		for i, m := range mounts {
+			if m.Destination == mount.Destination {
+				mounts = append(mounts[:i], mounts[i+1:]...)
+			}
+		}
+		s.Mounts = append(mounts, mount)
+		return nil
+	}
+}

--- a/spec_opts_test.go
+++ b/spec_opts_test.go
@@ -1,0 +1,23 @@
+package containerd
+
+import (
+	"reflect"
+	"testing"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func TestWithMount(t *testing.T) {
+	mount := specs.Mount{
+		Destination: "/test",
+		Type:        "sysfs",
+		Source:      "sysfs",
+	}
+	s, err := GenerateSpec(WithMount(mount))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(s.Mounts) == 0 || !reflect.DeepEqual(mount, s.Mounts[len(s.Mounts)-1]) {
+		t.Errorf("mount is not added")
+	}
+}

--- a/spec_unix.go
+++ b/spec_unix.go
@@ -128,12 +128,6 @@ func createDefaultSpec() (*specs.Spec, error) {
 				Source:      "sysfs",
 				Options:     []string{"nosuid", "noexec", "nodev", "ro"},
 			},
-			{
-				Destination: "/run",
-				Type:        "tmpfs",
-				Source:      "tmpfs",
-				Options:     []string{"nosuid", "strictatime", "mode=755", "size=65536k"},
-			},
 		},
 		Linux: &specs.Linux{
 			// TODO (@crosbymichael) make sure we don't have have two containers in the same cgroup


### PR DESCRIPTION
Per discussion with @crosbymichael, remove `/run` from the default container spec.
This PR also added `WithMount` to make it possible to specify extra mount.

Before remove:
```console
$ sudo ctr run -t docker.io/library/ubuntu:latest ubuntu ls run
```
After remove:
```console
$ sudo ctr run -t docker.io/library/ubuntu:latest ubuntu ls run
lock  mount  systemd  utmp
```

@crosbymichael
1) Generic `WithMount` or specific `WithTmpfsRunDirectory`, which is preferred? This PR goes with `WithMount` for now.
2) Should `ctr` add the tmpfs `/run` mount?

Signed-off-by: Lantao Liu <lantaol@google.com>