### PR TITLE
Client reconnect fix

### DIFF
--- a/client.go
+++ b/client.go
@@ -67,7 +67,7 @@ func New(address string, opts ...ClientOpt) (*Client, error) {
 		grpc.WithTimeout(60 * time.Second),
 		grpc.FailOnNonTempDialError(true),
 		grpc.WithBackoffMaxDelay(3 * time.Second),
-		grpc.WithDialer(dialer),
+		grpc.WithDialer(Dialer),
 	}
 	if len(copts.dialOptions) > 0 {
 		gopts = copts.dialOptions
@@ -79,7 +79,7 @@ func New(address string, opts ...ClientOpt) (*Client, error) {
 			grpc.WithStreamInterceptor(stream),
 		)
 	}
-	conn, err := grpc.Dial(dialAddress(address), gopts...)
+	conn, err := grpc.Dial(DialAddress(address), gopts...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to dial %q", address)
 	}

--- a/client.go
+++ b/client.go
@@ -64,8 +64,9 @@ func New(address string, opts ...ClientOpt) (*Client, error) {
 	gopts := []grpc.DialOption{
 		grpc.WithBlock(),
 		grpc.WithInsecure(),
-		grpc.WithTimeout(100 * time.Second),
+		grpc.WithTimeout(60 * time.Second),
 		grpc.FailOnNonTempDialError(true),
+		grpc.WithBackoffMaxDelay(3 * time.Second),
 		grpc.WithDialer(dialer),
 	}
 	if len(copts.dialOptions) > 0 {

--- a/client_unix.go
+++ b/client_unix.go
@@ -5,13 +5,68 @@ package containerd
 import (
 	"fmt"
 	"net"
+	"os"
 	"strings"
+	"syscall"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
+func isNoent(err error) bool {
+	if err != nil {
+		if nerr, ok := err.(*net.OpError); ok {
+			if serr, ok := nerr.Err.(*os.SyscallError); ok {
+				if serr.Err == syscall.ENOENT {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+type dialResult struct {
+	c   net.Conn
+	err error
+}
+
 func dialer(address string, timeout time.Duration) (net.Conn, error) {
+	var (
+		stopC = make(chan struct{})
+		synC  = make(chan *dialResult)
+	)
 	address = strings.TrimPrefix(address, "unix://")
-	return net.DialTimeout("unix", address, timeout)
+	go func() {
+		defer close(synC)
+		for {
+			select {
+			case <-stopC:
+				return
+			default:
+				c, err := net.DialTimeout("unix", address, timeout)
+				if isNoent(err) {
+					<-time.After(10 * time.Millisecond)
+					continue
+				}
+				synC <- &dialResult{c, err}
+				return
+			}
+		}
+	}()
+	select {
+	case dr := <-synC:
+		return dr.c, dr.err
+	case <-time.After(timeout):
+		close(stopC)
+		go func() {
+			dr := <-synC
+			if dr != nil {
+				dr.c.Close()
+			}
+		}()
+		return nil, errors.Errorf("dial %s: no such file or directory", address)
+	}
 }
 
 func dialAddress(address string) string {

--- a/client_unix.go
+++ b/client_unix.go
@@ -31,7 +31,7 @@ type dialResult struct {
 	err error
 }
 
-func dialer(address string, timeout time.Duration) (net.Conn, error) {
+func Dialer(address string, timeout time.Duration) (net.Conn, error) {
 	var (
 		stopC = make(chan struct{})
 		synC  = make(chan *dialResult)
@@ -69,6 +69,6 @@ func dialer(address string, timeout time.Duration) (net.Conn, error) {
 	}
 }
 
-func dialAddress(address string) string {
+func DialAddress(address string) string {
 	return fmt.Sprintf("unix://%s", address)
 }

--- a/client_windows.go
+++ b/client_windows.go
@@ -7,10 +7,10 @@ import (
 	winio "github.com/Microsoft/go-winio"
 )
 
-func dialer(address string, timeout time.Duration) (net.Conn, error) {
+func Dialer(address string, timeout time.Duration) (net.Conn, error) {
 	return winio.DialPipe(address, &timeout)
 }
 
-func dialAddress(address string) string {
+func DialAddress(address string) string {
 	return address
 }

--- a/cmd/containerd-shim/main_unix.go
+++ b/cmd/containerd-shim/main_unix.go
@@ -80,7 +80,7 @@ func main() {
 		if err != nil {
 			return err
 		}
-		server := grpc.NewServer()
+		server := newServer()
 		e, err := connectEvents(context.GlobalString("address"))
 		if err != nil {
 			return err
@@ -182,9 +182,10 @@ func connect(address string, d func(string, time.Duration) (net.Conn, error)) (*
 	gopts := []grpc.DialOption{
 		grpc.WithBlock(),
 		grpc.WithInsecure(),
-		grpc.WithTimeout(100 * time.Second),
+		grpc.WithTimeout(60 * time.Second),
 		grpc.WithDialer(d),
 		grpc.FailOnNonTempDialError(true),
+		grpc.WithBackoffMaxDelay(3 * time.Second),
 	}
 	conn, err := grpc.Dial(dialAddress(address), gopts...)
 	if err != nil {

--- a/cmd/containerd-shim/shim_linux.go
+++ b/cmd/containerd-shim/shim_linux.go
@@ -33,7 +33,7 @@ func setupSignals() (chan os.Signal, error) {
 }
 
 func newServer() *grpc.Server {
-	return grpc.NewServer(grpc.Creds(NewUnixSocketCredentils(0, 0)))
+	return grpc.NewServer(grpc.Creds(NewUnixSocketCredentials(0, 0)))
 }
 
 type unixSocketCredentials struct {
@@ -42,7 +42,7 @@ type unixSocketCredentials struct {
 	serverName string
 }
 
-func NewUnixSocketCredentils(uid, gid int) credentials.TransportCredentials {
+func NewUnixSocketCredentials(uid, gid int) credentials.TransportCredentials {
 	return &unixSocketCredentials{uid, gid, "locahost"}
 }
 

--- a/daemon_test.go
+++ b/daemon_test.go
@@ -1,0 +1,115 @@
+package containerd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type daemon struct {
+	sync.Mutex
+	addr string
+	cmd  *exec.Cmd
+}
+
+func (d *daemon) start(name, address string, args []string, stdout, stderr io.Writer) error {
+	d.Lock()
+	defer d.Unlock()
+	if d.cmd != nil {
+		return errors.New("daemon is already running")
+	}
+	args = append(args, []string{"--address", address}...)
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Start(); err != nil {
+		cmd.Wait()
+		return errors.Wrap(err, "failed to start daemon")
+	}
+	d.addr = address
+	d.cmd = cmd
+	return nil
+}
+
+func (d *daemon) waitForStart(ctx context.Context) (*Client, error) {
+	var (
+		client  *Client
+		serving bool
+		err     error
+	)
+
+	for i := 0; i < 20; i++ {
+		if client == nil {
+			client, err = New(d.addr)
+		}
+		if err == nil {
+			serving, err = client.IsServing(ctx)
+			if serving {
+				return client, nil
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return nil, fmt.Errorf("containerd did not start within 2s: %v", err)
+}
+
+func (d *daemon) Stop() error {
+	d.Lock()
+	d.Unlock()
+	if d.cmd == nil {
+		return errors.New("daemon is not running")
+	}
+	return d.cmd.Process.Signal(syscall.SIGTERM)
+}
+
+func (d *daemon) Kill() error {
+	d.Lock()
+	d.Unlock()
+	if d.cmd == nil {
+		return errors.New("daemon is not running")
+	}
+	return d.cmd.Process.Kill()
+}
+
+func (d *daemon) Wait() error {
+	d.Lock()
+	d.Unlock()
+	if d.cmd == nil {
+		return errors.New("daemon is not running")
+	}
+	return d.cmd.Wait()
+}
+
+func (d *daemon) Restart() error {
+	d.Lock()
+	d.Unlock()
+	if d.cmd == nil {
+		return errors.New("daemon is not running")
+	}
+
+	var err error
+	if err = d.cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		return errors.Wrap(err, "failed to signal daemon")
+	}
+
+	d.cmd.Wait()
+
+	<-time.After(1 * time.Second)
+
+	cmd := exec.Command(d.cmd.Path, d.cmd.Args[1:]...)
+	cmd.Stdout = d.cmd.Stdout
+	cmd.Stderr = d.cmd.Stderr
+	if err := cmd.Start(); err != nil {
+		cmd.Wait()
+		return errors.Wrap(err, "failed to start new daemon instance")
+	}
+	d.cmd = cmd
+
+	return nil
+}

--- a/linux/bundle.go
+++ b/linux/bundle.go
@@ -17,10 +17,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-func loadBundle(path, workdir, namespace string, events *events.Exchange) *bundle {
+func loadBundle(path, workdir, namespace, id string, events *events.Exchange) *bundle {
 	return &bundle{
 		path:      path,
 		namespace: namespace,
+		id:        id,
 		events:    events,
 		workDir:   workdir,
 	}

--- a/linux/runtime.go
+++ b/linux/runtime.go
@@ -215,6 +215,7 @@ func (r *Runtime) Delete(ctx context.Context, c runtime.Task) (*runtime.Exit, er
 		filepath.Join(r.state, namespace, lc.id),
 		filepath.Join(r.root, namespace, lc.id),
 		namespace,
+		lc.id,
 		r.events,
 	)
 	if err := bundle.Delete(); err != nil {
@@ -267,7 +268,8 @@ func (r *Runtime) loadTasks(ctx context.Context, ns string) ([]*Task, error) {
 			continue
 		}
 		id := path.Name()
-		bundle := loadBundle(filepath.Join(r.state, ns, id), filepath.Join(r.root, ns, id), ns, r.events)
+		bundle := loadBundle(filepath.Join(r.state, ns, id),
+			filepath.Join(r.root, ns, id), ns, id, r.events)
 
 		s, err := bundle.Connect(ctx, r.remote)
 		if err != nil {

--- a/task.go
+++ b/task.go
@@ -220,7 +220,7 @@ func (t *task) Wait(ctx context.Context) (uint32, error) {
 	for {
 		evt, err := eventstream.Recv()
 		if err != nil {
-			return UnknownExitStatus, err
+			return UnknownExitStatus, errdefs.FromGRPC(err)
 		}
 		if typeurl.Is(evt.Event, &eventsapi.TaskExit{}) {
 			v, err := typeurl.UnmarshalAny(evt.Event)


### PR DESCRIPTION
Closes #1076

-- 
I separated it in several commits to make the review easier. 
 - 24aac336f3ad82b05f391dca9a9287ad698b30d5 Update unix dialer to keep retrying if socket is gone
 - 587a811d0941142329b4e6beb1a3cb1181a4d23c Check credentials when connecting to shim
 - 7ac351cdfe9181768d2a494cdf62edb164618bf8 Share Dialer and DialAddress between client and shim
 - e661be6a9ca832a71aa06eedda3d77da02d2d55c Fix failure to connect to shim on daemon restart
 - 5f36ac20931381366ef5003f7afcbdfb2141b9ab Add test to ensure we can access tasks on restart
