### PR TITLE
Update go-runc to b85ac701de5065a66918203dd18f05

### DIFF
--- a/linux/shim/exec.go
+++ b/linux/shim/exec.go
@@ -142,7 +142,7 @@ func (e *execProcess) Start(ctx context.Context) (err error) {
 		}
 		defer socket.Close()
 	} else {
-		if io, err = runc.NewPipeIO(0, 0); err != nil {
+		if io, err = runc.NewPipeIO(); err != nil {
 			return errors.Wrap(err, "failed to create runc io pipes")
 		}
 		e.io = io

--- a/linux/shim/init.go
+++ b/linux/shim/init.go
@@ -125,7 +125,7 @@ func newInitProcess(context context.Context, plat platform, path, namespace, wor
 		}
 		defer socket.Close()
 	} else {
-		if io, err = runc.NewPipeIO(0, 0); err != nil {
+		if io, err = runc.NewPipeIO(); err != nil {
 			return nil, errors.Wrap(err, "failed to create OCI runtime io pipes")
 		}
 		p.io = io

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,5 +1,5 @@
 github.com/coreos/go-systemd 48702e0da86bd25e76cfef347e2adeb434a0d0a6
-github.com/containerd/go-runc 2774a2ea124a5c2d0aba13b5c2dd8a5a9a48775d
+github.com/containerd/go-runc b85ac701de5065a66918203dd18f057433290807
 github.com/containerd/console 76d18fd1d66972718ab2284449591db0b3cdb4de
 github.com/containerd/cgroups 4fd64a776f25b5540cddcb72eea6e35e58baca6e
 github.com/docker/go-metrics 8fd5772bf1584597834c6f7961a530f06cbfbb87

--- a/vendor/github.com/containerd/go-runc/io.go
+++ b/vendor/github.com/containerd/go-runc/io.go
@@ -4,8 +4,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-
-	"golang.org/x/sys/unix"
 )
 
 type IO interface {
@@ -21,7 +19,7 @@ type StartCloser interface {
 }
 
 // NewPipeIO creates pipe pairs to be used with runc
-func NewPipeIO(uid, gid int) (i IO, err error) {
+func NewPipeIO() (i IO, err error) {
 	var pipes []*pipe
 	// cleanup in case of an error
 	defer func() {
@@ -31,19 +29,19 @@ func NewPipeIO(uid, gid int) (i IO, err error) {
 			}
 		}
 	}()
-	stdin, err := newPipe(uid, gid)
+	stdin, err := newPipe()
 	if err != nil {
 		return nil, err
 	}
 	pipes = append(pipes, stdin)
 
-	stdout, err := newPipe(uid, gid)
+	stdout, err := newPipe()
 	if err != nil {
 		return nil, err
 	}
 	pipes = append(pipes, stdout)
 
-	stderr, err := newPipe(uid, gid)
+	stderr, err := newPipe()
 	if err != nil {
 		return nil, err
 	}
@@ -56,15 +54,9 @@ func NewPipeIO(uid, gid int) (i IO, err error) {
 	}, nil
 }
 
-func newPipe(uid, gid int) (*pipe, error) {
+func newPipe() (*pipe, error) {
 	r, w, err := os.Pipe()
 	if err != nil {
-		return nil, err
-	}
-	if err := unix.Fchown(int(r.Fd()), uid, gid); err != nil {
-		return nil, err
-	}
-	if err := unix.Fchown(int(w.Fd()), uid, gid); err != nil {
 		return nil, err
 	}
 	return &pipe{
@@ -162,4 +154,48 @@ func (s *stdio) Stdout() io.ReadCloser {
 
 func (s *stdio) Stderr() io.ReadCloser {
 	return os.Stderr
+}
+
+// NewNullIO returns IO setup for /dev/null use with runc
+func NewNullIO() (IO, error) {
+	f, err := os.Open(os.DevNull)
+	if err != nil {
+		return nil, err
+	}
+	return &nullIO{
+		devNull: f,
+	}, nil
+}
+
+type nullIO struct {
+	devNull *os.File
+}
+
+func (n *nullIO) Close() error {
+	// this should be closed after start but if not
+	// make sure we close the file but don't return the error
+	n.devNull.Close()
+	return nil
+}
+
+func (n *nullIO) Stdin() io.WriteCloser {
+	return nil
+}
+
+func (n *nullIO) Stdout() io.ReadCloser {
+	return nil
+}
+
+func (n *nullIO) Stderr() io.ReadCloser {
+	return nil
+}
+
+func (n *nullIO) Set(c *exec.Cmd) {
+	// don't set STDIN here
+	c.Stdout = n.devNull
+	c.Stderr = n.devNull
+}
+
+func (n *nullIO) CloseAfterStart() error {
+	return n.devNull.Close()
 }


### PR DESCRIPTION
This includes fixes for pipe ownership and NullIO options.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>