### PR TITLE
metadata: disallow changing the runtime of an existing container

### DIFF
--- a/metadata/containers.go
+++ b/metadata/containers.go
@@ -164,9 +164,6 @@ func (s *containerStore) Update(ctx context.Context, container containers.Contai
 				updated.Labels = container.Labels
 			case "image":
 				updated.Image = container.Image
-			case "runtime":
-				// TODO(stevvooe): Should this actually be allowed?
-				updated.Runtime = container.Runtime
 			case "spec":
 				updated.Spec = container.Spec
 			case "rootfs":


### PR DESCRIPTION
This could render tasks for a container unresolvalbe. If there is a use
case for changing the runtime of a container, we should think it through
carefully.

Signed-off-by: Stephen J Day <stephen.day@docker.com>