### PR TITLE
correct container "/" ownership with userns

### DIFF
--- a/spec_unix.go
+++ b/spec_unix.go
@@ -171,9 +171,6 @@ func incrementFS(root string, uidInc, gidInc uint32) filepath.WalkFunc {
 		if err != nil {
 			return err
 		}
-		if root == path {
-			return nil
-		}
 		var (
 			stat = info.Sys().(*syscall.Stat_t)
 			u, g = int(stat.Uid + uidInc), int(stat.Gid + gidInc)


### PR DESCRIPTION
Previously "`/`" in a container was always owned by `root:root` (0/0), even if
`withRemappedSnapshot` had been used. Meaning that if `withUserNamespace` is
used then `/` can be remapped to `nobody:nogroup` (65534/65534).

The fix is is twofold:

- incrementFS should operate on the root of the tree.
- when creating a new snapshot we must propagate the ownership of the topmost
  "lower" directory into the new "upper".

Signed-off-by: Ian Campbell <ian.campbell@docker.com>