### PR TITLE
Add null io option

### DIFF
--- a/cmd/stress/main.go
+++ b/cmd/stress/main.go
@@ -1,10 +1,8 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"runtime"
@@ -205,7 +203,7 @@ func (w *worker) runContainer(ctx context.Context, id string) error {
 	}
 	defer c.Delete(ctx, containerd.WithSnapshotCleanup)
 
-	task, err := c.NewTask(ctx, containerd.NewIO(bytes.NewBuffer(nil), ioutil.Discard, ioutil.Discard))
+	task, err := c.NewTask(ctx, containerd.NullIO)
 	if err != nil {
 		return err
 	}

--- a/container_test.go
+++ b/container_test.go
@@ -19,8 +19,7 @@ import (
 )
 
 func empty() IOCreation {
-	null := ioutil.Discard
-	return NewIO(bytes.NewBuffer(nil), null, null)
+	return NullIO
 }
 
 func TestContainerList(t *testing.T) {

--- a/io.go
+++ b/io.go
@@ -126,6 +126,11 @@ func StdioTerminal(id string) (*IO, error) {
 	return NewIOWithTerminal(os.Stdin, os.Stdout, os.Stderr, true)(id)
 }
 
+// NullIO redirects the container's IO into /dev/null
+func NullIO(id string) (*IO, error) {
+	return &IO{}, nil
+}
+
 // FIFOSet is a set of fifos for use with tasks
 type FIFOSet struct {
 	// Dir is the directory holding the task fifos

--- a/linux/shim/process.go
+++ b/linux/shim/process.go
@@ -17,6 +17,10 @@ type stdio struct {
 	terminal bool
 }
 
+func (s stdio) isNull() bool {
+	return s.stdin == "" && s.stdout == "" && s.stderr == ""
+}
+
 type process interface {
 	// ID returns the id for the process
 	ID() string


### PR DESCRIPTION
This adds null IO option for efficient handling of IO.
It provides a container directly with `/dev/null` and does not require
any io.Copy within the shim whenever a user does not want the IO of the
container.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>