### PR TITLE
ctr: add `ctr snapshot info <key>`

### DIFF
--- a/cmd/ctr/info.go
+++ b/cmd/ctr/info.go
@@ -1,10 +1,6 @@
 package main
 
 import (
-	"encoding/json"
-
-	"fmt"
-
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
@@ -31,11 +27,9 @@ var containerInfoCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		cjson, err := json.MarshalIndent(container.Info(), "", "    ")
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(cjson))
+
+		printAsJSON(container.Info())
+
 		return nil
 	},
 }

--- a/cmd/ctr/shim.go
+++ b/cmd/ctr/shim.go
@@ -3,12 +3,9 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net"
-	"os"
 	"time"
 
 	gocontext "context"
@@ -185,15 +182,7 @@ var shimStateCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		data, err := json.Marshal(r)
-		if err != nil {
-			return err
-		}
-		buf := bytes.NewBuffer(nil)
-		if err := json.Indent(buf, data, " ", "    "); err != nil {
-			return err
-		}
-		buf.WriteTo(os.Stdout)
+		printAsJSON(r)
 		return nil
 	},
 }

--- a/cmd/ctr/snapshot.go
+++ b/cmd/ctr/snapshot.go
@@ -27,6 +27,7 @@ var snapshotCommand = cli.Command{
 		treeSnapshotCommand,
 		mountSnapshotCommand,
 		commitSnapshotCommand,
+		infoSnapshotCommand,
 	},
 }
 
@@ -307,6 +308,36 @@ var treeSnapshotCommand = cli.Command{
 		}
 
 		printTree(tree)
+
+		return nil
+	},
+}
+
+var infoSnapshotCommand = cli.Command{
+	Name:      "info",
+	Usage:     "get info about a snapshot",
+	ArgsUsage: "<key>",
+	Action: func(clicontext *cli.Context) error {
+		ctx, cancel := appContext(clicontext)
+		defer cancel()
+
+		if clicontext.NArg() != 1 {
+			return cli.ShowSubcommandHelp(clicontext)
+		}
+
+		key := clicontext.Args().Get(0)
+
+		snapshotter, err := getSnapshotter(clicontext)
+		if err != nil {
+			return err
+		}
+
+		info, err := snapshotter.Stat(ctx, key)
+		if err != nil {
+			return err
+		}
+
+		printAsJSON(info)
 
 		return nil
 	},

--- a/cmd/ctr/utils.go
+++ b/cmd/ctr/utils.go
@@ -417,3 +417,11 @@ func labelArgs(labelStrings []string) map[string]string {
 
 	return labels
 }
+
+func printAsJSON(x interface{}) {
+	b, err := json.MarshalIndent(x, "", "    ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "can't marshal %+v as a JSON string: %v\n", x, err)
+	}
+	fmt.Println(string(b))
+}


### PR DESCRIPTION
e.g.

``` bash
$ ctr snapshot info sha256:cb5450c7bb149c39829e9ae4a83540c701196754746e547d9439d9cc59afe798
{
    "Kind": 3,
    "Name": "sha256:cb5450c7bb149c39829e9ae4a83540c701196754746e547d9439d9cc59afe798",
    "Parent": "sha256:364dc483ed8e64e16064dc1ecf3c4a8de82fe7f8ed757978f8b0f9df125d67b3",
    "Labels": null,
    "Created": "2017-08-15T05:49:15.176580165Z",
    "Updated": "2017-08-15T05:49:15.176580165Z"
}
```
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>