### PR TITLE
ctr: fix `ctr snapshot commit`

### DIFF
--- a/cmd/ctr/snapshot.go
+++ b/cmd/ctr/snapshot.go
@@ -228,8 +228,8 @@ var commitSnapshotCommand = cli.Command{
 			return cli.ShowSubcommandHelp(clicontext)
 		}
 
-		key := clicontext.Args().Get(1)
-		active := clicontext.Args().Get(0)
+		key := clicontext.Args().Get(0)
+		active := clicontext.Args().Get(1)
 
 		snapshotter, err := getSnapshotter(clicontext)
 		if err != nil {


### PR DESCRIPTION
The code didn't match `ArgsUsage: "[flags] <key> <active>"`.

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>