### PR TITLE
Update mount creation to only use btrfs subvolume id

### DIFF
--- a/snapshot/btrfs/btrfs.go
+++ b/snapshot/btrfs/btrfs.go
@@ -204,21 +204,21 @@ func (b *snapshotter) makeSnapshot(ctx context.Context, kind snapshot.Kind, key,
 		return nil, err
 	}
 
-	return b.mounts(target)
+	return b.mounts(target, s)
 }
 
-func (b *snapshotter) mounts(dir string) ([]mount.Mount, error) {
+func (b *snapshotter) mounts(dir string, s storage.Snapshot) ([]mount.Mount, error) {
 	var options []string
 
 	// get the subvolume id back out for the mount
-	info, err := btrfs.SubvolInfo(dir)
+	sid, err := btrfs.SubvolID(dir)
 	if err != nil {
 		return nil, err
 	}
 
-	options = append(options, fmt.Sprintf("subvolid=%d", info.ID))
+	options = append(options, fmt.Sprintf("subvolid=%d", sid))
 
-	if info.Readonly {
+	if s.Kind != snapshot.KindActive {
 		options = append(options, "ro")
 	}
 
@@ -291,7 +291,7 @@ func (b *snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, er
 	}
 
 	dir := filepath.Join(b.root, strings.ToLower(s.Kind.String()), s.ID)
-	return b.mounts(dir)
+	return b.mounts(dir, s)
 }
 
 // Remove abandons the transaction identified by key. All resources

--- a/vendor.conf
+++ b/vendor.conf
@@ -17,7 +17,7 @@ github.com/golang/protobuf 5a0f697c9ed9d68fef0116532c6e05cfeae00e55
 github.com/opencontainers/runtime-spec v1.0.0
 github.com/opencontainers/runc e775f0fba3ea329b8b766451c892c41a3d49594d
 github.com/sirupsen/logrus v1.0.0
-github.com/containerd/btrfs e9c546f46bccffefe71a6bc137e4c21b5503cc18
+github.com/containerd/btrfs cc52c4dea2ce11a44e6639e561bb5c2af9ada9e3
 github.com/stretchr/testify v1.1.4
 github.com/davecgh/go-spew v1.1.0
 github.com/pmezard/go-difflib v1.0.0

--- a/vendor/github.com/containerd/btrfs/btrfs.go
+++ b/vendor/github.com/containerd/btrfs/btrfs.go
@@ -3,8 +3,6 @@ package btrfs
 import "sort"
 
 /*
-#cgo LDFLAGS: -lbtrfs
-
 #include <stddef.h>
 #include <btrfs/ioctl.h>
 #include "btrfs.h"
@@ -20,7 +18,6 @@ static char* get_name_btrfs_ioctl_vol_args_v2(struct btrfs_ioctl_vol_args_v2* bt
 import "C"
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -47,6 +44,17 @@ func IsSubvolume(path string) error {
 	}
 
 	return isStatfsSubvol(&statfs)
+}
+
+// SubvolID returns the subvolume ID for the provided path
+func SubvolID(path string) (uint64, error) {
+	fp, err := openSubvolDir(path)
+	if err != nil {
+		return 0, err
+	}
+	defer fp.Close()
+
+	return subvolID(fp.Fd())
 }
 
 // SubvolInfo returns information about the subvolume at the provided path.
@@ -301,7 +309,6 @@ func SubvolSnapshot(dst, src string, readonly bool) error {
 
 // SubvolDelete deletes the subvolumes under the given path.
 func SubvolDelete(path string) error {
-	fmt.Println("delete", path)
 	dir, name := filepath.Split(path)
 	fp, err := openSubvolDir(dir)
 	if err != nil {


### PR DESCRIPTION
This is aimed at addressing the flaky btrfs tests. There appears to be a race between creating a subvolume and it showing up in the subvolume map. It is possible this is actually a race between creation and cleanup, but I have not discovered any place where this race occurs. If the flakiness still exists then we can rule out the not found errors. Either way, this change is valid as it avoids unnecessary metadata lookup.