### PR TITLE
mount: fix read-only bind 

### DIFF
--- a/helpers_unix_test.go
+++ b/helpers_unix_test.go
@@ -40,8 +40,9 @@ func withExecArgs(s *specs.Process, args ...string) {
 }
 
 var (
-	withUserNamespace    = WithUserNamespace
-	withRemappedSnapshot = WithRemappedSnapshot
-	withNewSnapshot      = WithNewSnapshot
-	withImageConfig      = WithImageConfig
+	withUserNamespace        = WithUserNamespace
+	withRemappedSnapshot     = WithRemappedSnapshot
+	withRemappedSnapshotView = WithRemappedSnapshotView
+	withNewSnapshot          = WithNewSnapshot
+	withImageConfig          = WithImageConfig
 )

--- a/helpers_windows_test.go
+++ b/helpers_windows_test.go
@@ -63,6 +63,12 @@ func withRemappedSnapshot(id string, i Image, u, g uint32) NewContainerOpts {
 	}
 }
 
+func withRemappedSnapshotView(id string, i Image, u, g uint32) NewContainerOpts {
+	return func(ctx context.Context, client *Client, c *containers.Container) error {
+		return nil
+	}
+}
+
 func withNoop(_ context.Context, _ *Client, _ *containers.Container, _ *specs.Spec) error {
 	return nil
 }


### PR DESCRIPTION
`ctr run --readonly` was not readonly.

Fix #1368 

Port over https://github.com/moby/moby/blob/3a1ab5b479ce843648cf676fbaaf2bec9e040dce/pkg/mount/mounter_linux.go