### PR TITLE
Allow exec process to be deleted in created state

### DIFF
--- a/process.go
+++ b/process.go
@@ -152,7 +152,8 @@ func (p *process) Delete(ctx context.Context, opts ...ProcessDeleteOpts) (uint32
 	if err != nil {
 		return UnknownExitStatus, err
 	}
-	if status.Status != Stopped {
+	switch status.Status {
+	case Running, Paused, Pausing:
 		return UnknownExitStatus, errors.Wrapf(errdefs.ErrFailedPrecondition, "process must be stopped before deletion")
 	}
 	if p.io != nil {

--- a/windows/process.go
+++ b/windows/process.go
@@ -59,6 +59,9 @@ func (p *process) Status() runtime.Status {
 	case <-p.exitCh:
 		status = runtime.StoppedStatus
 	default:
+		if p.hcs == nil {
+			return runtime.CreatedStatus
+		}
 		status = runtime.RunningStatus
 	}
 	return status
@@ -83,8 +86,8 @@ func (p *process) Pid() uint32 {
 }
 
 func (p *process) ExitCode() (uint32, time.Time, error) {
-	if p.Status() != runtime.StoppedStatus {
-		return 255, time.Time{}, errors.Wrap(errdefs.ErrFailedPrecondition, "process is not stopped")
+	if s := p.Status(); s != runtime.StoppedStatus && s != runtime.CreatedStatus {
+		return 255, time.Time{}, errors.Wrapf(errdefs.ErrFailedPrecondition, "process is not stopped: %s", s)
 	}
 	return p.exitCode, p.exitTime, nil
 }


### PR DESCRIPTION
Fixes #1376

This allows an exec process to be deleted in the created state.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>