### PR TITLE
Convert errors returned by task service to errdefs error.

### DIFF
--- a/container.go
+++ b/container.go
@@ -221,7 +221,7 @@ func (c *container) NewTask(ctx context.Context, ioCreate IOCreation, opts ...Ne
 	} else {
 		response, err := c.client.TaskService().Create(ctx, request)
 		if err != nil {
-			return nil, err
+			return nil, errdefs.FromGRPC(err)
 		}
 		t.pid = response.Pid
 	}

--- a/process.go
+++ b/process.go
@@ -64,7 +64,7 @@ func (p *process) Start(ctx context.Context) error {
 		p.io.Cancel()
 		p.io.Wait()
 		p.io.Close()
-		return err
+		return errdefs.FromGRPC(err)
 	}
 	p.pid = r.Pid
 	return nil
@@ -76,7 +76,7 @@ func (p *process) Kill(ctx context.Context, s syscall.Signal) error {
 		ContainerID: p.task.id,
 		ExecID:      p.id,
 	})
-	return err
+	return errdefs.FromGRPC(err)
 }
 
 func (p *process) Wait(ctx context.Context) (uint32, error) {
@@ -125,7 +125,7 @@ func (p *process) CloseIO(ctx context.Context, opts ...IOCloserOpts) error {
 	}
 	r.Stdin = i.Stdin
 	_, err := p.task.client.TaskService().CloseIO(ctx, r)
-	return err
+	return errdefs.FromGRPC(err)
 }
 
 func (p *process) IO() IO {
@@ -139,7 +139,7 @@ func (p *process) Resize(ctx context.Context, w, h uint32) error {
 		Height:      h,
 		ExecID:      p.id,
 	})
-	return err
+	return errdefs.FromGRPC(err)
 }
 
 func (p *process) Delete(ctx context.Context, opts ...ProcessDeleteOpts) (uint32, error) {
@@ -164,7 +164,7 @@ func (p *process) Delete(ctx context.Context, opts ...ProcessDeleteOpts) (uint32
 		ExecID:      p.id,
 	})
 	if err != nil {
-		return UnknownExitStatus, err
+		return UnknownExitStatus, errdefs.FromGRPC(err)
 	}
 	return r.ExitStatus, nil
 }

--- a/task.go
+++ b/task.go
@@ -143,7 +143,7 @@ func (t *task) Start(ctx context.Context) error {
 		t.mu.Unlock()
 		if err != nil {
 			t.io.Close()
-			return err
+			return errdefs.FromGRPC(err)
 		}
 		t.pid = response.Pid
 		return nil
@@ -154,7 +154,7 @@ func (t *task) Start(ctx context.Context) error {
 	if err != nil {
 		t.io.Close()
 	}
-	return err
+	return errdefs.FromGRPC(err)
 }
 
 func (t *task) Kill(ctx context.Context, s syscall.Signal) error {
@@ -262,7 +262,7 @@ func (t *task) Delete(ctx context.Context, opts ...ProcessDeleteOpts) (uint32, e
 		ContainerID: t.id,
 	})
 	if err != nil {
-		return UnknownExitStatus, err
+		return UnknownExitStatus, errdefs.FromGRPC(err)
 	}
 	return r.ExitStatus, nil
 }
@@ -293,7 +293,7 @@ func (t *task) Exec(ctx context.Context, id string, spec *specs.Process, ioCreat
 		i.Cancel()
 		i.Wait()
 		i.Close()
-		return nil, err
+		return nil, errdefs.FromGRPC(err)
 	}
 	return &process{
 		id:   id,
@@ -308,7 +308,7 @@ func (t *task) Pids(ctx context.Context) ([]uint32, error) {
 		ContainerID: t.id,
 	})
 	if err != nil {
-		return nil, err
+		return nil, errdefs.FromGRPC(err)
 	}
 	return response.Pids, nil
 }
@@ -323,7 +323,7 @@ func (t *task) CloseIO(ctx context.Context, opts ...IOCloserOpts) error {
 	}
 	r.Stdin = i.Stdin
 	_, err := t.client.TaskService().CloseIO(ctx, r)
-	return err
+	return errdefs.FromGRPC(err)
 }
 
 func (t *task) IO() IO {
@@ -336,7 +336,7 @@ func (t *task) Resize(ctx context.Context, w, h uint32) error {
 		Width:       w,
 		Height:      h,
 	})
-	return err
+	return errdefs.FromGRPC(err)
 }
 
 func (t *task) Checkpoint(ctx context.Context, opts ...CheckpointTaskOpts) (d v1.Descriptor, err error) {
@@ -408,13 +408,13 @@ func (t *task) Update(ctx context.Context, opts ...UpdateTaskOpts) error {
 		request.Resources = any
 	}
 	_, err := t.client.TaskService().Update(ctx, request)
-	return err
+	return errdefs.FromGRPC(err)
 }
 
 func (t *task) checkpointTask(ctx context.Context, index *v1.Index, request *tasks.CheckpointTaskRequest) error {
 	response, err := t.client.TaskService().Checkpoint(ctx, request)
 	if err != nil {
-		return err
+		return errdefs.FromGRPC(err)
 	}
 	// add the checkpoint descriptors to the index
 	for _, d := range response.Descriptors {


### PR DESCRIPTION
In cri-containerd, we found that `task.Kill` doesn't return the errdefs NotFoundError when process already exits, which is not expected.

This PR converts all task service returned error from grpc error to errdef error, which also aligns with what we are doing in remote container store.

Signed-off-by: Lantao Liu <lantaol@google.com>