### PR TITLE
Revert part of 06dc87ae59cca1536a3a98741a267af687b6dcdd

### DIFF
--- a/io_unix.go
+++ b/io_unix.go
@@ -54,12 +54,10 @@ func copyIO(fifos *FIFOSet, ioset *ioSet, tty bool) (_ *wgCloser, err error) {
 	}
 	set = append(set, f)
 	cwg.Add(1)
-	wg.Add(1)
 	go func(w io.WriteCloser) {
 		cwg.Done()
 		io.Copy(w, ioset.in)
 		w.Close()
-		wg.Done()
 	}(f)
 
 	if f, err = fifo.OpenFifo(ctx, fifos.Out, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {


### PR DESCRIPTION
Fixes #1389

This reverts waiting on stdin to finish its IO copy before returning
out.

This was causing `ctr` to block for every container start/exit.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>