### PR TITLE
Make Wait() async

### DIFF
--- a/cmd/containerd-stress/main.go
+++ b/cmd/containerd-stress/main.go
@@ -208,30 +208,22 @@ func (w *worker) runContainer(ctx context.Context, id string) error {
 		return err
 	}
 	defer task.Delete(ctx, containerd.WithProcessKill)
-	var (
-		start  sync.WaitGroup
-		status = make(chan uint32, 1)
-	)
-	start.Add(1)
-	go func() {
-		start.Done()
-		s, err := task.Wait(w.waitContext)
-		if err != nil {
-			if err == context.DeadlineExceeded ||
-				err == context.Canceled {
-				close(status)
-				return
-			}
-			w.failures++
-			logrus.WithError(err).Errorf("wait task %s", id)
-		}
-		status <- s
-	}()
-	start.Wait()
+
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		return err
+	}
+
 	if err := task.Start(ctx); err != nil {
 		return err
 	}
-	<-status
+	status := <-statusC
+	if status.Err != nil {
+		if status.Err == context.DeadlineExceeded || status.Err == context.Canceled {
+			return nil
+		}
+		w.failures++
+	}
 	return nil
 }
 

--- a/cmd/containerd-stress/main.go
+++ b/cmd/containerd-stress/main.go
@@ -218,8 +218,9 @@ func (w *worker) runContainer(ctx context.Context, id string) error {
 		return err
 	}
 	status := <-statusC
-	if status.Err != nil {
-		if status.Err == context.DeadlineExceeded || status.Err == context.Canceled {
+	_, _, err = status.Result()
+	if err != nil {
+		if err == context.DeadlineExceeded || err == context.Canceled {
 			return nil
 		}
 		w.failures++

--- a/cmd/ctr/attach.go
+++ b/cmd/ctr/attach.go
@@ -44,6 +44,12 @@ var taskAttachCommand = cli.Command{
 			return err
 		}
 		defer task.Delete(ctx)
+
+		statusC, err := task.Wait(ctx)
+		if err != nil {
+			return err
+		}
+
 		if tty {
 			if err := handleConsoleResize(ctx, task, con); err != nil {
 				logrus.WithError(err).Error("console resize")
@@ -52,12 +58,13 @@ var taskAttachCommand = cli.Command{
 			sigc := forwardAllSignals(ctx, task)
 			defer stopCatch(sigc)
 		}
-		status, err := task.Wait(ctx)
-		if err != nil {
+
+		ec := <-statusC
+		if ec.Err != nil {
 			return err
 		}
-		if status != 0 {
-			return cli.NewExitError("", int(status))
+		if ec.Code != 0 {
+			return cli.NewExitError("", int(ec.Code))
 		}
 		return nil
 	},

--- a/cmd/ctr/attach.go
+++ b/cmd/ctr/attach.go
@@ -60,11 +60,12 @@ var taskAttachCommand = cli.Command{
 		}
 
 		ec := <-statusC
-		if ec.Err != nil {
+		code, _, err := ec.Result()
+		if err != nil {
 			return err
 		}
-		if ec.Code != 0 {
-			return cli.NewExitError("", int(ec.Code))
+		if code != 0 {
+			return cli.NewExitError("", int(code))
 		}
 		return nil
 	},

--- a/cmd/ctr/exec.go
+++ b/cmd/ctr/exec.go
@@ -95,11 +95,12 @@ var taskExecCommand = cli.Command{
 			defer stopCatch(sigc)
 		}
 		status := <-statusC
-		if status.Err != nil {
-			return status.Err
+		code, _, err := status.Result()
+		if err != nil {
+			return err
 		}
-		if status.Code != 0 {
-			return cli.NewExitError("", int(status.Code))
+		if code != 0 {
+			return cli.NewExitError("", int(code))
 		}
 		return nil
 	},

--- a/cmd/ctr/run.go
+++ b/cmd/ctr/run.go
@@ -155,15 +155,16 @@ var runCommand = cli.Command{
 		}
 
 		status := <-statusC
-		if status.Err != nil {
-			return status.Err
+		code, _, err := status.Result()
+		if err != nil {
+			return err
 		}
 
 		if _, err := task.Delete(ctx); err != nil {
 			return err
 		}
-		if status.Code != 0 {
-			return cli.NewExitError("", int(status.Code))
+		if code != 0 {
+			return cli.NewExitError("", int(code))
 		}
 		return nil
 	},

--- a/cmd/ctr/run.go
+++ b/cmd/ctr/run.go
@@ -129,14 +129,11 @@ var runCommand = cli.Command{
 		}
 		defer task.Delete(ctx)
 
-		statusC := make(chan uint32, 1)
-		go func() {
-			status, err := task.Wait(ctx)
-			if err != nil {
-				logrus.WithError(err).Error("wait process")
-			}
-			statusC <- status
-		}()
+		statusC, err := task.Wait(ctx)
+		if err != nil {
+			return err
+		}
+
 		var con console.Console
 		if tty {
 			con = console.Current()
@@ -158,11 +155,15 @@ var runCommand = cli.Command{
 		}
 
 		status := <-statusC
+		if status.Err != nil {
+			return status.Err
+		}
+
 		if _, err := task.Delete(ctx); err != nil {
 			return err
 		}
-		if status != 0 {
-			return cli.NewExitError("", int(status))
+		if status.Code != 0 {
+			return cli.NewExitError("", int(status.Code))
 		}
 		return nil
 	},

--- a/cmd/ctr/start.go
+++ b/cmd/ctr/start.go
@@ -73,14 +73,15 @@ var taskStartCommand = cli.Command{
 		}
 
 		status := <-statusC
-		if status.Err != nil {
+		code, _, err := status.Result()
+		if err != nil {
 			return err
 		}
 		if _, err := task.Delete(ctx); err != nil {
 			return err
 		}
-		if status.Code != 0 {
-			return cli.NewExitError("", int(status.Code))
+		if code != 0 {
+			return cli.NewExitError("", int(code))
 		}
 		return nil
 	},

--- a/container_checkpoint_test.go
+++ b/container_checkpoint_test.go
@@ -47,14 +47,11 @@ func TestCheckpointRestore(t *testing.T) {
 	}
 	defer task.Delete(ctx)
 
-	statusC := make(chan uint32, 1)
-	go func() {
-		status, err := task.Wait(ctx)
-		if err != nil {
-			t.Error(err)
-		}
-		statusC <- status
-	}()
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
 	if err := task.Start(ctx); err != nil {
 		t.Error(err)
@@ -79,13 +76,11 @@ func TestCheckpointRestore(t *testing.T) {
 	}
 	defer task.Delete(ctx)
 
-	go func() {
-		status, err := task.Wait(ctx)
-		if err != nil {
-			t.Error(err)
-		}
-		statusC <- status
-	}()
+	statusC, err = task.Wait(ctx)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
 	if err := task.Start(ctx); err != nil {
 		t.Error(err)
@@ -137,14 +132,11 @@ func TestCheckpointRestoreNewContainer(t *testing.T) {
 	}
 	defer task.Delete(ctx)
 
-	statusC := make(chan uint32, 1)
-	go func() {
-		status, err := task.Wait(ctx)
-		if err != nil {
-			t.Error(err)
-		}
-		statusC <- status
-	}()
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
 	if err := task.Start(ctx); err != nil {
 		t.Error(err)
@@ -177,13 +169,11 @@ func TestCheckpointRestoreNewContainer(t *testing.T) {
 	}
 	defer task.Delete(ctx)
 
-	go func() {
-		status, err := task.Wait(ctx)
-		if err != nil {
-			t.Error(err)
-		}
-		statusC <- status
-	}()
+	statusC, err = task.Wait(ctx)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
 	if err := task.Start(ctx); err != nil {
 		t.Error(err)
@@ -240,14 +230,11 @@ func TestCheckpointLeaveRunning(t *testing.T) {
 	}
 	defer task.Delete(ctx)
 
-	statusC := make(chan uint32, 1)
-	go func() {
-		status, err := task.Wait(ctx)
-		if err != nil {
-			t.Error(err)
-		}
-		statusC <- status
-	}()
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
 	if err := task.Start(ctx); err != nil {
 		t.Error(err)

--- a/container_linux_test.go
+++ b/container_linux_test.go
@@ -232,7 +232,8 @@ func TestDaemonRestart(t *testing.T) {
 	}
 
 	status := <-statusC
-	if status.Err == nil {
+	_, _, err = status.Result()
+	if err == nil {
 		t.Errorf(`first task.Wait() should have failed with "transport is closing"`)
 	}
 

--- a/container_linux_test.go
+++ b/container_linux_test.go
@@ -57,14 +57,11 @@ func TestContainerUpdate(t *testing.T) {
 	}
 	defer task.Delete(ctx)
 
-	statusC := make(chan uint32, 1)
-	go func() {
-		status, err := task.Wait(ctx)
-		if err != nil {
-			t.Error(err)
-		}
-		statusC <- status
-	}()
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
 	// check that the task has a limit of 32mb
 	cgroup, err := cgroups.Load(cgroups.V1, cgroups.PidPath(int(task.Pid())))
@@ -157,14 +154,12 @@ func TestShimInCgroup(t *testing.T) {
 	}
 	defer task.Delete(ctx)
 
-	statusC := make(chan uint32, 1)
-	go func() {
-		status, err := task.Wait(ctx)
-		if err != nil {
-			t.Error(err)
-		}
-		statusC <- status
-	}()
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
 	// check to see if the shim is inside the cgroup
 	processes, err := cg.Processes(cgroups.Devices, false)
 	if err != nil {
@@ -221,17 +216,11 @@ func TestDaemonRestart(t *testing.T) {
 	}
 	defer task.Delete(ctx)
 
-	synC := make(chan struct{})
-	statusC := make(chan uint32, 1)
-	go func() {
-		synC <- struct{}{}
-		status, err := task.Wait(ctx)
-		if err == nil {
-			t.Errorf(`first task.Wait() should have failed with "transport is closing"`)
-		}
-		statusC <- status
-	}()
-	<-synC
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
 	if err := task.Start(ctx); err != nil {
 		t.Error(err)
@@ -242,7 +231,10 @@ func TestDaemonRestart(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	<-statusC
+	status := <-statusC
+	if status.Err == nil {
+		t.Errorf(`first task.Wait() should have failed with "transport is closing"`)
+	}
 
 	waitCtx, waitCancel := context.WithTimeout(ctx, 2*time.Second)
 	serving, err := client.IsServing(waitCtx)
@@ -251,15 +243,11 @@ func TestDaemonRestart(t *testing.T) {
 		t.Fatalf("containerd did not start within 2s: %v", err)
 	}
 
-	go func() {
-		synC <- struct{}{}
-		status, err := task.Wait(ctx)
-		if err != nil {
-			t.Error(err)
-		}
-		statusC <- status
-	}()
-	<-synC
+	statusC, err = task.Wait(ctx)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
 	if err := task.Kill(ctx, syscall.SIGKILL); err != nil {
 		t.Fatal(err)

--- a/container_test.go
+++ b/container_test.go
@@ -124,14 +124,11 @@ func TestContainerStart(t *testing.T) {
 	}
 	defer task.Delete(ctx)
 
-	statusC := make(chan uint32, 1)
-	go func() {
-		status, err := task.Wait(ctx)
-		if err != nil {
-			t.Error(err)
-		}
-		statusC <- status
-	}()
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
 	if pid := task.Pid(); pid <= 0 {
 		t.Errorf("invalid task pid %d", pid)
@@ -142,15 +139,21 @@ func TestContainerStart(t *testing.T) {
 		return
 	}
 	status := <-statusC
-	if status != 7 {
-		t.Errorf("expected status 7 from wait but received %d", status)
-	}
-	if status, err = task.Delete(ctx); err != nil {
+	if status.Err != nil {
 		t.Error(err)
 		return
 	}
-	if status != 7 {
-		t.Errorf("expected status 7 from delete but received %d", status)
+	if status.Code != 7 {
+		t.Errorf("expected status 7 from wait but received %d", status.Code)
+	}
+
+	deleteStatus, err := task.Delete(ctx)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if deleteStatus != 7 {
+		t.Errorf("expected status 7 from delete but received %d", deleteStatus)
 	}
 }
 
@@ -199,14 +202,11 @@ func TestContainerOutput(t *testing.T) {
 	}
 	defer task.Delete(ctx)
 
-	statusC := make(chan uint32, 1)
-	go func() {
-		status, err := task.Wait(ctx)
-		if err != nil {
-			t.Error(err)
-		}
-		statusC <- status
-	}()
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
 	if err := task.Start(ctx); err != nil {
 		t.Error(err)
@@ -214,7 +214,7 @@ func TestContainerOutput(t *testing.T) {
 	}
 
 	status := <-statusC
-	if status != 0 {
+	if status.Code != 0 {
 		t.Errorf("expected status 0 but received %d", status)
 	}
 	if _, err := task.Delete(ctx); err != nil {
@@ -273,13 +273,11 @@ func TestContainerExec(t *testing.T) {
 	}
 	defer task.Delete(ctx)
 
-	finished := make(chan struct{}, 1)
-	go func() {
-		if _, err := task.Wait(ctx); err != nil {
-			t.Error(err)
-		}
-		close(finished)
-	}()
+	finishedC, err := task.Wait(ctx)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
 	if err := task.Start(ctx); err != nil {
 		t.Error(err)
@@ -295,14 +293,11 @@ func TestContainerExec(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	processStatusC := make(chan uint32, 1)
-	go func() {
-		status, err := process.Wait(ctx)
-		if err != nil {
-			t.Error(err)
-		}
-		processStatusC <- status
-	}()
+	processStatusC, err := process.Wait(ctx)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
 	if err := process.Start(ctx); err != nil {
 		t.Error(err)
@@ -311,9 +306,13 @@ func TestContainerExec(t *testing.T) {
 
 	// wait for the exec to return
 	status := <-processStatusC
+	if status.Err != nil {
+		t.Error(err)
+		return
+	}
 
-	if status != 6 {
-		t.Errorf("expected exec exit code 6 but received %d", status)
+	if status.Code != 6 {
+		t.Errorf("expected exec exit code 6 but received %d", status.Code)
 	}
 	deleteStatus, err := process.Delete(ctx)
 	if err != nil {
@@ -326,7 +325,7 @@ func TestContainerExec(t *testing.T) {
 	if err := task.Kill(ctx, syscall.SIGKILL); err != nil {
 		t.Error(err)
 	}
-	<-finished
+	<-finishedC
 }
 
 func TestContainerPids(t *testing.T) {
@@ -372,14 +371,11 @@ func TestContainerPids(t *testing.T) {
 	}
 	defer task.Delete(ctx)
 
-	statusC := make(chan uint32, 1)
-	go func() {
-		status, err := task.Wait(ctx)
-		if err != nil {
-			t.Error(err)
-		}
-		statusC <- status
-	}()
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
 	if err := task.Start(ctx); err != nil {
 		t.Error(err)
@@ -462,14 +458,11 @@ func TestContainerCloseIO(t *testing.T) {
 	}
 	defer task.Delete(ctx)
 
-	statusC := make(chan uint32, 1)
-	go func() {
-		status, err := task.Wait(ctx)
-		if err != nil {
-			t.Error(err)
-		}
-		statusC <- status
-	}()
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
 	if err := task.Start(ctx); err != nil {
 		t.Error(err)
@@ -576,14 +569,10 @@ func TestContainerAttach(t *testing.T) {
 	defer task.Delete(ctx)
 	originalIO := task.IO()
 
-	statusC := make(chan uint32, 1)
-	go func() {
-		status, err := task.Wait(ctx)
-		if err != nil {
-			t.Error(err)
-		}
-		statusC <- status
-	}()
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		t.Error(err)
+	}
 
 	if err := task.Start(ctx); err != nil {
 		t.Error(err)
@@ -620,7 +609,11 @@ func TestContainerAttach(t *testing.T) {
 		t.Error(err)
 	}
 
-	<-statusC
+	status := <-statusC
+	if status.Err != nil {
+		t.Error(err)
+		return
+	}
 
 	originalIO.Close()
 	if _, err := task.Delete(ctx); err != nil {
@@ -681,14 +674,11 @@ func TestDeleteRunningContainer(t *testing.T) {
 	}
 	defer task.Delete(ctx)
 
-	statusC := make(chan uint32, 1)
-	go func() {
-		status, err := task.Wait(ctx)
-		if err != nil {
-			t.Error(err)
-		}
-		statusC <- status
-	}()
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
 	if err := task.Start(ctx); err != nil {
 		t.Error(err)
@@ -752,14 +742,11 @@ func TestContainerKill(t *testing.T) {
 	}
 	defer task.Delete(ctx)
 
-	statusC := make(chan uint32, 1)
-	go func() {
-		status, err := task.Wait(ctx)
-		if err != nil {
-			t.Error(err)
-		}
-		statusC <- status
-	}()
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
 	if err := task.Start(ctx); err != nil {
 		t.Error(err)
@@ -878,18 +865,14 @@ func TestContainerExecNoBinaryExists(t *testing.T) {
 	}
 	defer task.Delete(ctx)
 
+	finishedC, err := task.Wait(ctx)
+	if err != nil {
+		t.Error(err)
+	}
 	if err := task.Start(ctx); err != nil {
 		t.Error(err)
 		return
 	}
-
-	finished := make(chan struct{}, 1)
-	go func() {
-		if _, err := task.Wait(ctx); err != nil {
-			t.Error(err)
-		}
-		close(finished)
-	}()
 
 	// start an exec process without running the original container process
 	processSpec := spec.Process
@@ -909,7 +892,7 @@ func TestContainerExecNoBinaryExists(t *testing.T) {
 	if err := task.Kill(ctx, syscall.SIGKILL); err != nil {
 		t.Error(err)
 	}
-	<-finished
+	<-finishedC
 }
 
 func TestUserNamespaces(t *testing.T) {
@@ -962,14 +945,11 @@ func TestUserNamespaces(t *testing.T) {
 	}
 	defer task.Delete(ctx)
 
-	statusC := make(chan uint32, 1)
-	go func() {
-		status, err := task.Wait(ctx)
-		if err != nil {
-			t.Error(err)
-		}
-		statusC <- status
-	}()
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
 	if pid := task.Pid(); pid <= 0 {
 		t.Errorf("invalid task pid %d", pid)
@@ -980,15 +960,20 @@ func TestUserNamespaces(t *testing.T) {
 		return
 	}
 	status := <-statusC
-	if status != 7 {
-		t.Errorf("expected status 7 from wait but received %d", status)
-	}
-	if status, err = task.Delete(ctx); err != nil {
+	if status.Err != nil {
 		t.Error(err)
 		return
 	}
-	if status != 7 {
-		t.Errorf("expected status 7 from delete but received %d", status)
+	if status.Code != 7 {
+		t.Errorf("expected status 7 from wait but received %d", status.Code)
+	}
+	deleteStatus, err := task.Delete(ctx)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if deleteStatus != 7 {
+		t.Errorf("expected status 7 from delete but received %d", deleteStatus)
 	}
 }
 
@@ -1035,14 +1020,11 @@ func TestWaitStoppedTask(t *testing.T) {
 	}
 	defer task.Delete(ctx)
 
-	statusC := make(chan uint32, 1)
-	go func() {
-		status, err := task.Wait(ctx)
-		if err != nil {
-			t.Error(err)
-		}
-		statusC <- status
-	}()
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
 	if pid := task.Pid(); pid <= 0 {
 		t.Errorf("invalid task pid %d", pid)
@@ -1052,15 +1034,21 @@ func TestWaitStoppedTask(t *testing.T) {
 		task.Delete(ctx)
 		return
 	}
+
 	// wait for the task to stop then call wait again
 	<-statusC
-	status, err := task.Wait(ctx)
+	statusC, err = task.Wait(ctx)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	if status != 7 {
-		t.Errorf("exit status from stopped task should be 7 but received %d", status)
+	status := <-statusC
+	if status.Err != nil {
+		t.Error(status.Err)
+		return
+	}
+	if status.Code != 7 {
+		t.Errorf("exit status from stopped task should be 7 but received %d", status.Code)
 	}
 }
 
@@ -1107,13 +1095,10 @@ func TestWaitStoppedProcess(t *testing.T) {
 	}
 	defer task.Delete(ctx)
 
-	finished := make(chan struct{}, 1)
-	go func() {
-		if _, err := task.Wait(ctx); err != nil {
-			t.Error(err)
-		}
-		close(finished)
-	}()
+	finishedC, err := task.Wait(ctx)
+	if err != nil {
+		t.Error(err)
+	}
 
 	if err := task.Start(ctx); err != nil {
 		t.Error(err)
@@ -1130,14 +1115,12 @@ func TestWaitStoppedProcess(t *testing.T) {
 		return
 	}
 	defer process.Delete(ctx)
-	processStatusC := make(chan uint32, 1)
-	go func() {
-		status, err := process.Wait(ctx)
-		if err != nil {
-			t.Error(err)
-		}
-		processStatusC <- status
-	}()
+
+	statusC, err := process.Wait(ctx)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
 	if err := process.Start(ctx); err != nil {
 		t.Error(err)
@@ -1145,20 +1128,27 @@ func TestWaitStoppedProcess(t *testing.T) {
 	}
 
 	// wait for the exec to return
-	<-processStatusC
+	<-statusC
+
 	// try to wait on the process after it has stopped
-	status, err := process.Wait(ctx)
+	statusC, err = process.Wait(ctx)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	if status != 6 {
-		t.Errorf("exit status from stopped process should be 6 but received %d", status)
+	status := <-statusC
+	if status.Err != nil {
+		t.Error(err)
+		return
 	}
+	if status.Code != 6 {
+		t.Errorf("exit status from stopped process should be 6 but received %d", status.Code)
+	}
+
 	if err := task.Kill(ctx, syscall.SIGKILL); err != nil {
 		t.Error(err)
 	}
-	<-finished
+	<-finishedC
 }
 
 func TestTaskForceDelete(t *testing.T) {
@@ -1256,14 +1246,11 @@ func TestProcessForceDelete(t *testing.T) {
 	}
 	defer task.Delete(ctx)
 
-	statusC := make(chan uint32, 1)
-	go func() {
-		status, err := task.Wait(ctx)
-		if err != nil {
-			t.Error(err)
-		}
-		statusC <- status
-	}()
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
 	// task must be started on windows
 	if err := task.Start(ctx); err != nil {
@@ -1344,14 +1331,11 @@ func TestContainerHostname(t *testing.T) {
 	}
 	defer task.Delete(ctx)
 
-	statusC := make(chan uint32, 1)
-	go func() {
-		status, err := task.Wait(ctx)
-		if err != nil {
-			t.Error(err)
-		}
-		statusC <- status
-	}()
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
 	if err := task.Start(ctx); err != nil {
 		t.Error(err)
@@ -1359,7 +1343,11 @@ func TestContainerHostname(t *testing.T) {
 	}
 
 	status := <-statusC
-	if status != 0 {
+	if status.Err != nil {
+		t.Error(status.Err)
+		return
+	}
+	if status.Code != 0 {
 		t.Errorf("expected status 0 but received %d", status)
 	}
 	if _, err := task.Delete(ctx); err != nil {
@@ -1420,14 +1408,10 @@ func TestContainerExitedAtSet(t *testing.T) {
 	}
 	defer task.Delete(ctx)
 
-	statusC := make(chan uint32, 1)
-	go func() {
-		status, err := task.Wait(ctx)
-		if err != nil {
-			t.Error(err)
-		}
-		statusC <- status
-	}()
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		t.Error(err)
+	}
 
 	startTime := time.Now()
 	if err := task.Start(ctx); err != nil {
@@ -1436,7 +1420,7 @@ func TestContainerExitedAtSet(t *testing.T) {
 	}
 
 	status := <-statusC
-	if status != 0 {
+	if status.Code != 0 {
 		t.Errorf("expected status 0 but received %d", status)
 	}
 
@@ -1495,13 +1479,10 @@ func TestDeleteContainerExecCreated(t *testing.T) {
 	}
 	defer task.Delete(ctx)
 
-	finished := make(chan struct{}, 1)
-	go func() {
-		if _, err := task.Wait(ctx); err != nil {
-			t.Error(err)
-		}
-		close(finished)
-	}()
+	finished, err := task.Wait(ctx)
+	if err != nil {
+		t.Error(err)
+	}
 
 	if err := task.Start(ctx); err != nil {
 		t.Error(err)

--- a/container_test.go
+++ b/container_test.go
@@ -139,12 +139,13 @@ func TestContainerStart(t *testing.T) {
 		return
 	}
 	status := <-statusC
-	if status.Err != nil {
+	code, _, err := status.Result()
+	if err != nil {
 		t.Error(err)
 		return
 	}
-	if status.Code != 7 {
-		t.Errorf("expected status 7 from wait but received %d", status.Code)
+	if code != 7 {
+		t.Errorf("expected status 7 from wait but received %d", code)
 	}
 
 	deleteStatus, err := task.Delete(ctx)
@@ -214,8 +215,9 @@ func TestContainerOutput(t *testing.T) {
 	}
 
 	status := <-statusC
-	if status.Code != 0 {
-		t.Errorf("expected status 0 but received %d", status)
+	code, _, _ := status.Result()
+	if code != 0 {
+		t.Errorf("expected status 0 but received %d", code)
 	}
 	if _, err := task.Delete(ctx); err != nil {
 		t.Error(err)
@@ -306,13 +308,14 @@ func TestContainerExec(t *testing.T) {
 
 	// wait for the exec to return
 	status := <-processStatusC
-	if status.Err != nil {
+	code, _, err := status.Result()
+	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	if status.Code != 6 {
-		t.Errorf("expected exec exit code 6 but received %d", status.Code)
+	if code != 6 {
+		t.Errorf("expected exec exit code 6 but received %d", code)
 	}
 	deleteStatus, err := process.Delete(ctx)
 	if err != nil {
@@ -610,7 +613,8 @@ func TestContainerAttach(t *testing.T) {
 	}
 
 	status := <-statusC
-	if status.Err != nil {
+	_, _, err = status.Result()
+	if err != nil {
 		t.Error(err)
 		return
 	}
@@ -960,12 +964,13 @@ func TestUserNamespaces(t *testing.T) {
 		return
 	}
 	status := <-statusC
-	if status.Err != nil {
+	code, _, err := status.Result()
+	if err != nil {
 		t.Error(err)
 		return
 	}
-	if status.Code != 7 {
-		t.Errorf("expected status 7 from wait but received %d", status.Code)
+	if code != 7 {
+		t.Errorf("expected status 7 from wait but received %d", code)
 	}
 	deleteStatus, err := task.Delete(ctx)
 	if err != nil {
@@ -1043,12 +1048,13 @@ func TestWaitStoppedTask(t *testing.T) {
 		return
 	}
 	status := <-statusC
-	if status.Err != nil {
-		t.Error(status.Err)
+	code, _, err := status.Result()
+	if err != nil {
+		t.Error(err)
 		return
 	}
-	if status.Code != 7 {
-		t.Errorf("exit status from stopped task should be 7 but received %d", status.Code)
+	if code != 7 {
+		t.Errorf("exit status from stopped task should be 7 but received %d", code)
 	}
 }
 
@@ -1137,12 +1143,13 @@ func TestWaitStoppedProcess(t *testing.T) {
 		return
 	}
 	status := <-statusC
-	if status.Err != nil {
+	code, _, err := status.Result()
+	if err != nil {
 		t.Error(err)
 		return
 	}
-	if status.Code != 6 {
-		t.Errorf("exit status from stopped process should be 6 but received %d", status.Code)
+	if code != 6 {
+		t.Errorf("exit status from stopped process should be 6 but received %d", code)
 	}
 
 	if err := task.Kill(ctx, syscall.SIGKILL); err != nil {
@@ -1343,12 +1350,13 @@ func TestContainerHostname(t *testing.T) {
 	}
 
 	status := <-statusC
-	if status.Err != nil {
-		t.Error(status.Err)
+	code, _, err := status.Result()
+	if err != nil {
+		t.Error(err)
 		return
 	}
-	if status.Code != 0 {
-		t.Errorf("expected status 0 but received %d", status)
+	if code != 0 {
+		t.Errorf("expected status 0 but received %d", code)
 	}
 	if _, err := task.Delete(ctx); err != nil {
 		t.Error(err)
@@ -1420,8 +1428,9 @@ func TestContainerExitedAtSet(t *testing.T) {
 	}
 
 	status := <-statusC
-	if status.Code != 0 {
-		t.Errorf("expected status 0 but received %d", status)
+	code, _, _ := status.Result()
+	if code != 0 {
+		t.Errorf("expected status 0 but received %d", code)
 	}
 
 	if s, err := task.Status(ctx); err != nil {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -188,10 +188,11 @@ To do this we will simply call `Kill` on the task after waiting a couple of seco
 	}
 
 	status := <-exitStatusC
-	if status.Err != nil {
-		return status.Err
+	code, exitedAt, err := status.Result()
+	if err != nil {
+		return err
 	}
-	fmt.Printf("redis-server exited with status: %d\n", status.Code)
+	fmt.Printf("redis-server exited with status: %d\n", code)
 ```
 
 We wait on our exit status channel that we setup to ensure the task has fully exited and we get the exit status.
@@ -291,10 +292,11 @@ func redisExample() error {
 	// wait for the process to fully exit and print out the exit status
 
 	status := <-exitStatusC
-	if status.Err != nil {
+	code, _, err := status.Result()
+	if err != nil {
 		return err
 	}
-	fmt.Printf("redis-server exited with status: %d\n", status.Code)
+	fmt.Printf("redis-server exited with status: %d\n", code)
 
 	return nil
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -163,14 +163,10 @@ You always want to make sure you `Wait` before calling `Start` on a task.
 This makes sure that you do not encounter any races if the task has a simple program like `/bin/true` that exits promptly after calling start.
 
 ```go
-	exitStatusC := make(chan uint32, 1)
-	go func() {
-		status, err := task.Wait(ctx)
-		if err != nil {
-			fmt.Println(err)
-		}
-		exitStatusC <- status
-	}()
+	exitStatusC, err := task.Wait(ctx)
+	if err != nil {
+		return err
+	}
 
 	if err := task.Start(ctx); err != nil {
 		return err
@@ -192,7 +188,10 @@ To do this we will simply call `Kill` on the task after waiting a couple of seco
 	}
 
 	status := <-exitStatusC
-	fmt.Printf("redis-server exited with status: %d\n", status)
+	if status.Err != nil {
+		return status.Err
+	}
+	fmt.Printf("redis-server exited with status: %d\n", status.Code)
 ```
 
 We wait on our exit status channel that we setup to ensure the task has fully exited and we get the exit status.
@@ -271,14 +270,10 @@ func redisExample() error {
 	defer task.Delete(ctx)
 
 	// make sure we wait before calling start
-	exitStatusC := make(chan uint32, 1)
-	go func() {
-		status, err := task.Wait(ctx)
-		if err != nil {
-			fmt.Println(err)
-		}
-		exitStatusC <- status
-	}()
+	exitStatusC, err := task.Wait(ctx)
+	if err != nil {
+		fmt.Println(err)
+	}
 
 	// call start on the task to execute the redis server
 	if err := task.Start(ctx); err != nil {
@@ -296,7 +291,10 @@ func redisExample() error {
 	// wait for the process to fully exit and print out the exit status
 
 	status := <-exitStatusC
-	fmt.Printf("redis-server exited with status: %d\n", status)
+	if status.Err != nil {
+		return err
+	}
+	fmt.Printf("redis-server exited with status: %d\n", status.Code)
 
 	return nil
 }

--- a/task.go
+++ b/task.go
@@ -225,7 +225,7 @@ func (t *task) Wait(ctx context.Context) (<-chan ExitStatus, error) {
 		}
 		if status.Status == Stopped {
 			cancel()
-			chStatus <- ExitStatus{Code: status.ExitStatus, ExitedAt: status.ExitTime}
+			chStatus <- ExitStatus{code: status.ExitStatus, exitedAt: status.ExitTime}
 			return chStatus, nil
 		}
 	}
@@ -236,18 +236,18 @@ func (t *task) Wait(ctx context.Context) (<-chan ExitStatus, error) {
 		for {
 			evt, err := eventstream.Recv()
 			if err != nil {
-				chStatus <- ExitStatus{Code: UnknownExitStatus, Err: errdefs.FromGRPC(err)}
+				chStatus <- ExitStatus{code: UnknownExitStatus, err: errdefs.FromGRPC(err)}
 				return
 			}
 			if typeurl.Is(evt.Event, &eventsapi.TaskExit{}) {
 				v, err := typeurl.UnmarshalAny(evt.Event)
 				if err != nil {
-					chStatus <- ExitStatus{Code: UnknownExitStatus, Err: err}
+					chStatus <- ExitStatus{code: UnknownExitStatus, err: err}
 					return
 				}
 				e := v.(*eventsapi.TaskExit)
 				if e.ContainerID == t.id && e.Pid == t.pid {
-					chStatus <- ExitStatus{Code: e.ExitStatus, ExitedAt: e.ExitedAt}
+					chStatus <- ExitStatus{code: e.ExitStatus, exitedAt: e.ExitedAt}
 					return
 				}
 			}

--- a/task.go
+++ b/task.go
@@ -201,15 +201,18 @@ func (t *task) Status(ctx context.Context) (Status, error) {
 	}, nil
 }
 
-func (t *task) Wait(ctx context.Context) (uint32, error) {
+func (t *task) Wait(ctx context.Context) (<-chan ExitStatus, error) {
 	cancellable, cancel := context.WithCancel(ctx)
-	defer cancel()
 	eventstream, err := t.client.EventService().Subscribe(cancellable, &eventsapi.SubscribeRequest{
 		Filters: []string{"topic==" + runtime.TaskExitEventTopic},
 	})
 	if err != nil {
-		return UnknownExitStatus, errdefs.FromGRPC(err)
+		cancel()
+		return nil, errdefs.FromGRPC(err)
 	}
+
+	chStatus := make(chan ExitStatus, 1)
+
 	t.mu.Lock()
 	checkpoint := t.deferred != nil
 	t.mu.Unlock()
@@ -217,28 +220,42 @@ func (t *task) Wait(ctx context.Context) (uint32, error) {
 		// first check if the task has exited
 		status, err := t.Status(ctx)
 		if err != nil {
-			return UnknownExitStatus, errdefs.FromGRPC(err)
+			cancel()
+			return nil, errdefs.FromGRPC(err)
 		}
 		if status.Status == Stopped {
-			return status.ExitStatus, nil
+			cancel()
+			chStatus <- ExitStatus{Code: status.ExitStatus, ExitedAt: status.ExitTime}
+			return chStatus, nil
 		}
 	}
-	for {
-		evt, err := eventstream.Recv()
-		if err != nil {
-			return UnknownExitStatus, errdefs.FromGRPC(err)
-		}
-		if typeurl.Is(evt.Event, &eventsapi.TaskExit{}) {
-			v, err := typeurl.UnmarshalAny(evt.Event)
+
+	go func() {
+		defer cancel()
+		chStatus <- ExitStatus{} // signal that goroutine is running
+		for {
+			evt, err := eventstream.Recv()
 			if err != nil {
-				return UnknownExitStatus, err
+				chStatus <- ExitStatus{Code: UnknownExitStatus, Err: errdefs.FromGRPC(err)}
+				return
 			}
-			e := v.(*eventsapi.TaskExit)
-			if e.ContainerID == t.id && e.Pid == t.pid {
-				return e.ExitStatus, nil
+			if typeurl.Is(evt.Event, &eventsapi.TaskExit{}) {
+				v, err := typeurl.UnmarshalAny(evt.Event)
+				if err != nil {
+					chStatus <- ExitStatus{Code: UnknownExitStatus, Err: err}
+					return
+				}
+				e := v.(*eventsapi.TaskExit)
+				if e.ContainerID == t.id && e.Pid == t.pid {
+					chStatus <- ExitStatus{Code: e.ExitStatus, ExitedAt: e.ExitedAt}
+					return
+				}
 			}
 		}
-	}
+	}()
+
+	<-chStatus // wait for the goroutine to be running
+	return chStatus, nil
 }
 
 // Delete deletes the task and its runtime state

--- a/task_opts.go
+++ b/task_opts.go
@@ -33,15 +33,14 @@ type ProcessDeleteOpts func(context.Context, Process) error
 
 // WithProcessKill will forcefully kill and delete a process
 func WithProcessKill(ctx context.Context, p Process) error {
-	s := make(chan struct{}, 1)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	// ignore errors to wait and kill as we are forcefully killing
 	// the process and don't care about the exit status
-	go func() {
-		p.Wait(ctx)
-		close(s)
-	}()
+	s, err := p.Wait(ctx)
+	if err != nil {
+		return err
+	}
 	if err := p.Kill(ctx, syscall.SIGKILL); err != nil {
 		if errdefs.IsFailedPrecondition(err) || errdefs.IsNotFound(err) {
 			return nil


### PR DESCRIPTION
In all of the examples, its recommended to call `Wait()` before starting
a process/task.
Since `Wait()` is a blocking call, this means it must be called from a
goroutine like so:

```go
statusC := make(chan uint32)
go func() {
  status, err := task.Wait(ctx)
  if err != nil {
    // handle async err
  }

  statusC <- status
}()

task.Start(ctx)
<-statusC
```

This means there is a race here where there is no guarentee when the
goroutine is going to be scheduled, and even a bit more since this
requires an RPC call to be made.
In addition, this code is very messy and a common pattern for any caller
using Wait+Start.

Instead, this changes `Wait()` to use an async model having `Wait()`
return a channel instead of the code itself.
This ensures that when `Wait()` returns that the client has a handle on
the event stream (already made the RPC request) before returning and
reduces any sort of race to how the stream is handled by grpc since we
can't guarentee that we have a goroutine running and blocked on
`Recv()`.

Making `Wait()` async also cleans up the code in the caller drastically:

```go
statusC, err := task.Wait(ctx)
if err != nil {
  return err
}

task.Start(ctx)

status := <-statusC
if status.Err != nil {
  return err
}
```

No more spinning up goroutines and more natural error
handling for the caller.