### PR TITLE
Remove Stdio usage in tests

### DIFF
--- a/container_linux_test.go
+++ b/container_linux_test.go
@@ -209,7 +209,7 @@ func TestDaemonRestart(t *testing.T) {
 	}
 	defer container.Delete(ctx, WithSnapshotCleanup)
 
-	task, err := container.NewTask(ctx, Stdio)
+	task, err := container.NewTask(ctx, empty())
 	if err != nil {
 		t.Error(err)
 		return

--- a/process.go
+++ b/process.go
@@ -190,16 +190,16 @@ func (p *process) Delete(ctx context.Context, opts ...ProcessDeleteOpts) (uint32
 	case Running, Paused, Pausing:
 		return UnknownExitStatus, errors.Wrapf(errdefs.ErrFailedPrecondition, "process must be stopped before deletion")
 	}
-	if p.io != nil {
-		p.io.Wait()
-		p.io.Close()
-	}
 	r, err := p.task.client.TaskService().DeleteProcess(ctx, &tasks.DeleteProcessRequest{
 		ContainerID: p.task.id,
 		ExecID:      p.id,
 	})
 	if err != nil {
 		return UnknownExitStatus, errdefs.FromGRPC(err)
+	}
+	if p.io != nil {
+		p.io.Wait()
+		p.io.Close()
 	}
 	return r.ExitStatus, nil
 }

--- a/windows/task.go
+++ b/windows/task.go
@@ -240,6 +240,13 @@ func (t *task) DeleteProcess(ctx context.Context, id string) (*runtime.Exit, err
 		if err != nil {
 			return nil, err
 		}
+
+		// If we never started the process close the pipes
+		if p.Status() == runtime.CreatedStatus {
+			p.io.Close()
+			ea = time.Now()
+		}
+
 		t.removeProcess(id)
 		return &runtime.Exit{
 			Pid:       p.pid,


### PR DESCRIPTION
This causes shims and containers to hang when they use the testing
process's IO.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>