### PR TITLE
Revert two changes to IO and cgroup handling

### DIFF
--- a/linux/shim/client.go
+++ b/linux/shim/client.go
@@ -49,7 +49,6 @@ func WithStart(binary, address string, debug bool) ClientOpt {
 			if err != nil {
 				terminate(cmd)
 			}
-			reaper.Default.Delete(cmd.Process.Pid)
 		}()
 		log.G(ctx).WithFields(logrus.Fields{
 			"pid":     cmd.Process.Pid,

--- a/metrics/cgroups/cgroups.go
+++ b/metrics/cgroups/cgroups.go
@@ -65,7 +65,6 @@ func (m *cgroupsMonitor) Monitor(c runtime.Task) error {
 func (m *cgroupsMonitor) Stop(c runtime.Task) error {
 	info := c.Info()
 	m.collector.Remove(info.ID, info.Namespace)
-	m.oom.Remove(info.ID, info.Namespace)
 	return nil
 }
 

--- a/runtime/task.go
+++ b/runtime/task.go
@@ -9,6 +9,7 @@ import (
 type TaskInfo struct {
 	ID        string
 	Runtime   string
+	Spec      []byte
 	Namespace string
 }
 


### PR DESCRIPTION
This reverts commit 06dc87ae59cca1536a3a98741a267af687b6dcdd.

Revert "Change oom metric to const"

This reverts commit e800f08f9f56485ef4d0363159d1ffa973727f23.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>

Reverting full right now to get out tests running again.

The OOM change seems to break when starting a container and trying to connect to the cgroup.  It will take more looking into to find out the root cause.