### PR TITLE
Add newline char to avoid mix of logs

### DIFF
--- a/cmd/ctr/pull.go
+++ b/cmd/ctr/pull.go
@@ -37,7 +37,7 @@ command. As part of this process, we do the following:
 		log.G(ctx).WithField("image", ref).Debug("unpacking")
 
 		// TODO: Show unpack status
-		fmt.Printf("unpacking %s...", img.Target().Digest)
+		fmt.Printf("unpacking %s...\n", img.Target().Digest)
 		err = img.Unpack(ctx, clicontext.String("snapshotter"))
 		fmt.Println("done")
 		return err


### PR DESCRIPTION
Add a '\n' after "unpacking xxx..." to avoid mix of logs such as:

```
unpacking sha256:a7776895af32e34b1fef997e26c79fa988b40c5cf2a3fb48dc22e0584b648d82...DEBU[0005] Extraction not needed, layer snapshot exists
DEBU[0005] Extraction not needed, layer snapshot exists
DEBU[0005] Extraction not needed, layer snapshot exists
DEBU[0005] Extraction not needed, layer snapshot exists
DEBU[0005] Extraction not needed, layer snapshot exists
DEBU[0005] Extraction not needed, layer snapshot exists
done
```

After this commit:

```
unpacking sha256:a7776895af32e34b1fef997e26c79fa988b40c5cf2a3fb48dc22e0584b648d82...
DEBU[0008] Extraction not needed, layer snapshot exists
DEBU[0008] Extraction not needed, layer snapshot exists
DEBU[0008] Extraction not needed, layer snapshot exists
DEBU[0008] Extraction not needed, layer snapshot exists
DEBU[0008] Extraction not needed, layer snapshot exists
DEBU[0008] Extraction not needed, layer snapshot exists
done
```

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>