### PR TITLE
Add FifoIO to expose fifos directly to client

### DIFF
--- a/io.go
+++ b/io.go
@@ -24,7 +24,6 @@ type IOConfig struct {
 type IO interface {
 	// Config returns the IO configuration.
 	Config() IOConfig
-
 	// Cancel aborts all current io operations
 	Cancel()
 	// Wait blocks until all io copy operations have completed


### PR DESCRIPTION
This allows clients an easier way to interact with the fifos for a
container without having to use the built in copyIO functions when
opening fifos.

It's nothing that clients could not have already coded but since we use
this type of functionality in the tests it makes sense to add an
implementation here.

Fixes #1402

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>