### PR TITLE
Fix snapshot ctr command to use default

### DIFF
--- a/cmd/ctr/utils.go
+++ b/cmd/ctr/utils.go
@@ -52,6 +52,7 @@ var (
 		cli.StringFlag{
 			Name:  "snapshotter",
 			Usage: "Snapshotter name. Empty value stands for the daemon default value.",
+			Value: containerd.DefaultSnapshotter,
 		},
 	}
 


### PR DESCRIPTION
After the rework of server-side defaults, the `ctr snapshot` command
stopped working due to no default snapshotter.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>