### PR TITLE
removing unused "fmt" package from import

### DIFF
--- a/container_test.go
+++ b/container_test.go
@@ -2,7 +2,6 @@ package containerd
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"runtime"


### PR DESCRIPTION
`make integration` reports this error.

Signed-off-by: Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>