### PR TITLE
Only use race flag on amd64

### DIFF
--- a/Makefile.darwin
+++ b/Makefile.darwin
@@ -1,5 +1,7 @@
 #darwin specific settings
 COMMANDS += containerd-shim
 
-# supports go test -race
-TESTFLAGS_RACE= -race
+# amd64 supports go test -race
+ifeq ("amd64", $(GOARCH))
+	TESTFLAGS_RACE= -race
+endif

--- a/Makefile.freebsd
+++ b/Makefile.freebsd
@@ -1,5 +1,7 @@
 #freebsd specific settings
 COMMANDS += containerd-shim
 
-# supports go test -race
-TESTFLAGS_RACE= -race
+# amd64 supports go test -race
+ifeq ("amd64", $(GOARCH))
+	TESTFLAGS_RACE= -race
+endif

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -1,5 +1,7 @@
 #linux specific settings
 COMMANDS += containerd-shim
 
-# supports go test -race
-TESTFLAGS_RACE= -race
+# amd64 supports go test -race
+ifeq ("amd64", $(GOARCH))
+	TESTFLAGS_RACE= -race
+endif

--- a/Makefile.windows
+++ b/Makefile.windows
@@ -5,5 +5,7 @@ FIX_PATH = $(subst /,\,$1)
 
 BINARY_SUFFIX=".exe"
 
-# supports go test -race
-TESTFLAGS_RACE= -race
+# amd64 supports go test -race
+ifeq ("amd64", $(GOARCH))
+	TESTFLAGS_RACE= -race
+endif


### PR DESCRIPTION
Race is only supported on amd64, so only run if GOARCH is amd64

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>