### PR TITLE
Skip items removed during walk

### DIFF
--- a/metadata/snapshot.go
+++ b/metadata/snapshot.go
@@ -481,6 +481,9 @@ func (s *snapshotter) Walk(ctx context.Context, fn func(context.Context, snapsho
 		for _, pair := range pairs {
 			info, err := s.Snapshotter.Stat(ctx, pair.bkey)
 			if err != nil {
+				if errdefs.IsNotFound(err) {
+					continue
+				}
 				return err
 			}
 


### PR DESCRIPTION
The walk is not done entirely in a single transaction, meaning items can get deleted between looking up the items and getting the stat used to call the walk function. When the item previously looked up no longer exists, the item should be skipped.