### PR TITLE
Add LoadProcess api to Task

### DIFF
--- a/container.go
+++ b/container.go
@@ -245,19 +245,7 @@ func (c *container) loadTask(ctx context.Context, ioAttach IOAttach) (Task, erro
 	}
 	var i IO
 	if ioAttach != nil {
-		// get the existing fifo paths from the task information stored by the daemon
-		paths := &FIFOSet{
-			Dir: getFifoDir([]string{
-				response.Process.Stdin,
-				response.Process.Stdout,
-				response.Process.Stderr,
-			}),
-			In:       response.Process.Stdin,
-			Out:      response.Process.Stdout,
-			Err:      response.Process.Stderr,
-			Terminal: response.Process.Terminal,
-		}
-		if i, err = ioAttach(paths); err != nil {
+		if i, err = attachExistingIO(response, ioAttach); err != nil {
 			return nil, err
 		}
 	}
@@ -268,6 +256,22 @@ func (c *container) loadTask(ctx context.Context, ioAttach IOAttach) (Task, erro
 		pid:    response.Process.Pid,
 	}
 	return t, nil
+}
+
+func attachExistingIO(response *tasks.GetResponse, ioAttach IOAttach) (IO, error) {
+	// get the existing fifo paths from the task information stored by the daemon
+	paths := &FIFOSet{
+		Dir: getFifoDir([]string{
+			response.Process.Stdin,
+			response.Process.Stdout,
+			response.Process.Stderr,
+		}),
+		In:       response.Process.Stdin,
+		Out:      response.Process.Stdout,
+		Err:      response.Process.Stderr,
+		Terminal: response.Process.Terminal,
+	}
+	return ioAttach(paths)
 }
 
 // getFifoDir looks for any non-empty path for a stdio fifo

--- a/process.go
+++ b/process.go
@@ -11,7 +11,6 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/runtime"
 	"github.com/containerd/containerd/typeurl"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 )
 
@@ -77,7 +76,6 @@ type process struct {
 	task *task
 	pid  uint32
 	io   IO
-	spec *specs.Process
 }
 
 func (p *process) ID() string {


### PR DESCRIPTION
Fixes #1374

This adds a `LoadProcess` api to load existing exec'd processes from a
task.  It allows reattaching of IO and waiting on the process.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>