### PR TITLE
Add procesStates for shim processes

### DIFF
--- a/linux/shim/deleted_state.go
+++ b/linux/shim/deleted_state.go
@@ -1,0 +1,50 @@
+// +build !windows
+
+package shim
+
+import (
+	"context"
+
+	"github.com/containerd/console"
+	shimapi "github.com/containerd/containerd/linux/shim/v1"
+	"github.com/pkg/errors"
+)
+
+type deletedState struct {
+}
+
+func (s *deletedState) Pause(ctx context.Context) error {
+	return errors.Errorf("cannot pause a deleted process")
+}
+
+func (s *deletedState) Resume(ctx context.Context) error {
+	return errors.Errorf("cannot resume a deleted process")
+}
+
+func (s *deletedState) Update(context context.Context, r *shimapi.UpdateTaskRequest) error {
+	return errors.Errorf("cannot update a deleted process")
+}
+
+func (s *deletedState) Checkpoint(ctx context.Context, r *shimapi.CheckpointTaskRequest) error {
+	return errors.Errorf("cannot checkpoint a deleted process")
+}
+
+func (s *deletedState) Resize(ws console.WinSize) error {
+	return errors.Errorf("cannot resize a deleted process")
+}
+
+func (s *deletedState) Start(ctx context.Context) error {
+	return errors.Errorf("cannot start a deleted process")
+}
+
+func (s *deletedState) Delete(ctx context.Context) error {
+	return errors.Errorf("cannot delete a deleted process")
+}
+
+func (s *deletedState) Kill(ctx context.Context, sig uint32, all bool) error {
+	return errors.Errorf("cannot kill a deleted process")
+}
+
+func (s *deletedState) SetExited(status int) {
+	// no op
+}

--- a/linux/shim/exec_state.go
+++ b/linux/shim/exec_state.go
@@ -1,0 +1,166 @@
+// +build !windows
+
+package shim
+
+import (
+	"context"
+
+	"github.com/containerd/console"
+	"github.com/pkg/errors"
+)
+
+type execCreatedState struct {
+	p *execProcess
+}
+
+func (s *execCreatedState) transition(name string) error {
+	switch name {
+	case "running":
+		s.p.processState = &execRunningState{p: s.p}
+	case "stopped":
+		s.p.processState = &execStoppedState{p: s.p}
+	case "deleted":
+		s.p.processState = &deletedState{}
+	default:
+		return errors.Errorf("invalid state transition %q to %q", stateName(s), name)
+	}
+	return nil
+}
+
+func (s *execCreatedState) Resize(ws console.WinSize) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return s.p.resize(ws)
+}
+
+func (s *execCreatedState) Start(ctx context.Context) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+	if err := s.p.start(ctx); err != nil {
+		return err
+	}
+	return s.transition("running")
+}
+
+func (s *execCreatedState) Delete(ctx context.Context) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+	return s.transition("deleted")
+}
+
+func (s *execCreatedState) Kill(ctx context.Context, sig uint32, all bool) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return s.p.kill(ctx, sig, all)
+}
+
+func (s *execCreatedState) SetExited(status int) {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	s.p.setExited(status)
+
+	if err := s.transition("stopped"); err != nil {
+		panic(err)
+	}
+}
+
+type execRunningState struct {
+	p *execProcess
+}
+
+func (s *execRunningState) transition(name string) error {
+	switch name {
+	case "stopped":
+		s.p.processState = &execStoppedState{p: s.p}
+	default:
+		return errors.Errorf("invalid state transition %q to %q", stateName(s), name)
+	}
+	return nil
+}
+
+func (s *execRunningState) Resize(ws console.WinSize) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return s.p.resize(ws)
+}
+
+func (s *execRunningState) Start(ctx context.Context) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return errors.Errorf("cannot start a running process")
+}
+
+func (s *execRunningState) Delete(ctx context.Context) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return errors.Errorf("cannot delete a running process")
+}
+
+func (s *execRunningState) Kill(ctx context.Context, sig uint32, all bool) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return s.p.kill(ctx, sig, all)
+}
+
+func (s *execRunningState) SetExited(status int) {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	s.p.setExited(status)
+
+	if err := s.transition("stopped"); err != nil {
+		panic(err)
+	}
+}
+
+type execStoppedState struct {
+	p *execProcess
+}
+
+func (s *execStoppedState) transition(name string) error {
+	switch name {
+	case "deleted":
+		s.p.processState = &deletedState{}
+	default:
+		return errors.Errorf("invalid state transition %q to %q", stateName(s), name)
+	}
+	return nil
+}
+
+func (s *execStoppedState) Resize(ws console.WinSize) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return errors.Errorf("cannot resize a stopped container")
+}
+
+func (s *execStoppedState) Start(ctx context.Context) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return errors.Errorf("cannot start a stopped process")
+}
+
+func (s *execStoppedState) Delete(ctx context.Context) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+	return s.transition("deleted")
+}
+
+func (s *execStoppedState) Kill(ctx context.Context, sig uint32, all bool) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return s.p.kill(ctx, sig, all)
+}
+
+func (s *execStoppedState) SetExited(status int) {
+	// no op
+}

--- a/linux/shim/init_state.go
+++ b/linux/shim/init_state.go
@@ -1,0 +1,356 @@
+// +build !windows
+
+package shim
+
+import (
+	"context"
+
+	"github.com/containerd/console"
+	shimapi "github.com/containerd/containerd/linux/shim/v1"
+	"github.com/pkg/errors"
+)
+
+type initState interface {
+	processState
+
+	Pause(context.Context) error
+	Resume(context.Context) error
+	Update(context.Context, *shimapi.UpdateTaskRequest) error
+	Checkpoint(context.Context, *shimapi.CheckpointTaskRequest) error
+}
+
+type createdState struct {
+	p *initProcess
+}
+
+func (s *createdState) transition(name string) error {
+	switch name {
+	case "running":
+		s.p.initState = &runningState{p: s.p}
+	case "stopped":
+		s.p.initState = &stoppedState{p: s.p}
+	case "deleted":
+		s.p.initState = &deletedState{}
+	default:
+		return errors.Errorf("invalid state transition %q to %q", stateName(s), name)
+	}
+	return nil
+}
+
+func (s *createdState) Pause(ctx context.Context) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return errors.Errorf("cannot pause task in created state")
+}
+
+func (s *createdState) Resume(ctx context.Context) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return errors.Errorf("cannot resume task in created state")
+}
+
+func (s *createdState) Update(context context.Context, r *shimapi.UpdateTaskRequest) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return s.p.update(context, r)
+}
+
+func (s *createdState) Checkpoint(context context.Context, r *shimapi.CheckpointTaskRequest) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return errors.Errorf("cannot checkpoint a task in created state")
+}
+
+func (s *createdState) Resize(ws console.WinSize) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return s.p.resize(ws)
+}
+
+func (s *createdState) Start(ctx context.Context) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+	if err := s.p.start(ctx); err != nil {
+		return err
+	}
+	return s.transition("running")
+}
+
+func (s *createdState) Delete(ctx context.Context) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+	if err := s.p.delete(ctx); err != nil {
+		return err
+	}
+	return s.transition("deleted")
+}
+
+func (s *createdState) Kill(ctx context.Context, sig uint32, all bool) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return s.p.kill(ctx, sig, all)
+}
+
+func (s *createdState) SetExited(status int) {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	s.p.setExited(status)
+
+	if err := s.transition("stopped"); err != nil {
+		panic(err)
+	}
+}
+
+type runningState struct {
+	p *initProcess
+}
+
+func (s *runningState) transition(name string) error {
+	switch name {
+	case "stopped":
+		s.p.initState = &stoppedState{p: s.p}
+	case "paused":
+		s.p.initState = &pausedState{p: s.p}
+	default:
+		return errors.Errorf("invalid state transition %q to %q", stateName(s), name)
+	}
+	return nil
+}
+
+func (s *runningState) Pause(ctx context.Context) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+	if err := s.p.pause(ctx); err != nil {
+		return err
+	}
+	return s.transition("paused")
+}
+
+func (s *runningState) Resume(ctx context.Context) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return errors.Errorf("cannot resume a running process")
+}
+
+func (s *runningState) Update(context context.Context, r *shimapi.UpdateTaskRequest) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return s.p.update(context, r)
+}
+
+func (s *runningState) Checkpoint(ctx context.Context, r *shimapi.CheckpointTaskRequest) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return s.p.checkpoint(ctx, r)
+}
+
+func (s *runningState) Resize(ws console.WinSize) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return s.p.resize(ws)
+}
+
+func (s *runningState) Start(ctx context.Context) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return errors.Errorf("cannot start a running process")
+}
+
+func (s *runningState) Delete(ctx context.Context) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return errors.Errorf("cannot delete a running process")
+}
+
+func (s *runningState) Kill(ctx context.Context, sig uint32, all bool) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return s.p.kill(ctx, sig, all)
+}
+
+func (s *runningState) SetExited(status int) {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	s.p.setExited(status)
+
+	if err := s.transition("stopped"); err != nil {
+		panic(err)
+	}
+}
+
+type pausedState struct {
+	p *initProcess
+}
+
+func (s *pausedState) transition(name string) error {
+	switch name {
+	case "running":
+		s.p.initState = &runningState{p: s.p}
+	case "stopped":
+		s.p.initState = &stoppedState{p: s.p}
+	default:
+		return errors.Errorf("invalid state transition %q to %q", stateName(s), name)
+	}
+	return nil
+}
+
+func (s *pausedState) Pause(ctx context.Context) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return errors.Errorf("cannot pause a paused container")
+}
+
+func (s *pausedState) Resume(ctx context.Context) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	if err := s.p.resume(ctx); err != nil {
+		return err
+	}
+	return s.transition("running")
+}
+
+func (s *pausedState) Update(context context.Context, r *shimapi.UpdateTaskRequest) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return s.p.update(context, r)
+}
+
+func (s *pausedState) Checkpoint(ctx context.Context, r *shimapi.CheckpointTaskRequest) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return s.p.checkpoint(ctx, r)
+}
+
+func (s *pausedState) Resize(ws console.WinSize) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return s.p.resize(ws)
+}
+
+func (s *pausedState) Start(ctx context.Context) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return errors.Errorf("cannot start a paused process")
+}
+
+func (s *pausedState) Delete(ctx context.Context) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return errors.Errorf("cannot delete a paused process")
+}
+
+func (s *pausedState) Kill(ctx context.Context, sig uint32, all bool) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return s.p.kill(ctx, sig, all)
+}
+
+func (s *pausedState) SetExited(status int) {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	s.p.setExited(status)
+
+	if err := s.transition("stopped"); err != nil {
+		panic(err)
+	}
+}
+
+type stoppedState struct {
+	p *initProcess
+}
+
+func (s *stoppedState) transition(name string) error {
+	switch name {
+	case "deleted":
+		s.p.initState = &deletedState{}
+	default:
+		return errors.Errorf("invalid state transition %q to %q", stateName(s), name)
+	}
+	return nil
+}
+
+func (s *stoppedState) Pause(ctx context.Context) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return errors.Errorf("cannot pause a stopped container")
+}
+
+func (s *stoppedState) Resume(ctx context.Context) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return errors.Errorf("cannot resume a stopped container")
+}
+
+func (s *stoppedState) Update(context context.Context, r *shimapi.UpdateTaskRequest) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return errors.Errorf("cannot update a stopped container")
+}
+
+func (s *stoppedState) Checkpoint(ctx context.Context, r *shimapi.CheckpointTaskRequest) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return errors.Errorf("cannot checkpoint a stopped container")
+}
+
+func (s *stoppedState) Resize(ws console.WinSize) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return errors.Errorf("cannot resize a stopped container")
+}
+
+func (s *stoppedState) Start(ctx context.Context) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return errors.Errorf("cannot start a stopped process")
+}
+
+func (s *stoppedState) Delete(ctx context.Context) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+	if err := s.p.delete(ctx); err != nil {
+		return err
+	}
+	return s.transition("deleted")
+}
+
+func (s *stoppedState) Kill(ctx context.Context, sig uint32, all bool) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+
+	return s.p.kill(ctx, sig, all)
+}
+
+func (s *stoppedState) SetExited(status int) {
+	// no op
+}

--- a/linux/shim/utils.go
+++ b/linux/shim/utils.go
@@ -1,0 +1,86 @@
+// +build !windows
+
+package shim
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/containerd/containerd/errdefs"
+	shimapi "github.com/containerd/containerd/linux/shim/v1"
+	runc "github.com/containerd/go-runc"
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+// TODO(mlaventure): move to runc package?
+func getLastRuntimeError(r *runc.Runc) (string, error) {
+	if r.Log == "" {
+		return "", nil
+	}
+
+	f, err := os.OpenFile(r.Log, os.O_RDONLY, 0400)
+	if err != nil {
+		return "", err
+	}
+
+	var (
+		errMsg string
+		log    struct {
+			Level string
+			Msg   string
+			Time  time.Time
+		}
+	)
+
+	dec := json.NewDecoder(f)
+	for err = nil; err == nil; {
+		if err = dec.Decode(&log); err != nil && err != io.EOF {
+			return "", err
+		}
+		if log.Level == "error" {
+			errMsg = strings.TrimSpace(log.Msg)
+		}
+	}
+
+	return errMsg, nil
+}
+
+// criuError returns only the first line of the error message from criu
+// it tries to add an invalid dump log location when returning the message
+func criuError(err error) string {
+	parts := strings.Split(err.Error(), "\n")
+	return parts[0]
+}
+
+func copyFile(to, from string) error {
+	ff, err := os.Open(from)
+	if err != nil {
+		return err
+	}
+	defer ff.Close()
+	tt, err := os.Create(to)
+	if err != nil {
+		return err
+	}
+	defer tt.Close()
+	_, err = io.Copy(tt, ff)
+	return err
+}
+
+func checkKillError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), "os: process already finished") || err == unix.ESRCH {
+		return errors.Wrapf(errdefs.ErrNotFound, "process already finished")
+	}
+	return errors.Wrapf(err, "unknown error after kill")
+}
+
+func hasNoIO(r *shimapi.CreateTaskRequest) bool {
+	return r.Stdin == "" && r.Stdout == "" && r.Stderr == ""
+}


### PR DESCRIPTION
Use the state pattern to handle process transitions from one state to
another and what actions can be performed on a process in a specific
state.

Fixes #1401

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>