### PR TITLE
Use golang 1.9 on CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,9 +11,15 @@ branches:
 environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
+  GO_VERSION: 1.9
 
 before_build:
   - choco install -y mingw
+  # Install Go
+  - rd C:\Go /s /q
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go%GO_VERSION%.windows-amd64.zip
+  - 7z x go%GO_VERSION%.windows-amd64.zip -oC:\ >nul
+  - go version
   # TODO: re-enable once the content unit-test have been updated to pass on windows
   #- choco install codecov
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 language: go
 
 go:
-  - 1.8.x
+  - 1.9.x
 
 go_import_path: github.com/containerd/containerd
 


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

-- 

Closes #1215

- For AppVeyor, I'm installing manually since I don't know when they'll update their env.
- For Travis, it won't work until https://github.com/travis-ci/travis-build/pull/1148/ is merged