### PR TITLE
Add KillOpts for killing all processes

### DIFF
--- a/cmd/ctr/run.go
+++ b/cmd/ctr/run.go
@@ -21,7 +21,7 @@ type resizer interface {
 }
 
 type killer interface {
-	Kill(gocontext.Context, syscall.Signal) error
+	Kill(gocontext.Context, syscall.Signal, ...containerd.KillOpts) error
 }
 
 func withEnv(context *cli.Context) containerd.SpecOpts {

--- a/task.go
+++ b/task.go
@@ -163,10 +163,17 @@ func (t *task) Start(ctx context.Context) error {
 	return errdefs.FromGRPC(err)
 }
 
-func (t *task) Kill(ctx context.Context, s syscall.Signal) error {
+func (t *task) Kill(ctx context.Context, s syscall.Signal, opts ...KillOpts) error {
+	var i KillInfo
+	for _, o := range opts {
+		if err := o(ctx, t, &i); err != nil {
+			return err
+		}
+	}
 	_, err := t.client.TaskService().Kill(ctx, &tasks.KillRequest{
 		Signal:      uint32(s),
 		ContainerID: t.id,
+		All:         i.All,
 	})
 	if err != nil {
 		return errdefs.FromGRPC(err)

--- a/task_opts.go
+++ b/task_opts.go
@@ -51,3 +51,17 @@ func WithProcessKill(ctx context.Context, p Process) error {
 	<-s
 	return nil
 }
+
+type KillInfo struct {
+	// All kills all processes inside the task
+	// only valid on tasks, ignored on processes
+	All bool
+}
+
+type KillOpts func(context.Context, Process, *KillInfo) error
+
+// WithKillAll kills all processes for a task
+func WithKillAll(ctx context.Context, p Process, i *KillInfo) error {
+	i.All = true
+	return nil
+}


### PR DESCRIPTION
Fixes #1431

This adds KillOpts so that a client can specify when they want to kill a
single process or all the processes inside a container.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>