### PR TITLE
Allow setting runtime options when using WithRuntime()

### DIFF
--- a/cmd/ctr/run_unix.go
+++ b/cmd/ctr/run_unix.go
@@ -99,7 +99,7 @@ func newContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 			cOpts = append(cOpts, containerd.WithNewSnapshot(id, image))
 		}
 	}
-	cOpts = append(cOpts, containerd.WithRuntime(context.String("runtime")))
+	cOpts = append(cOpts, containerd.WithRuntime(context.String("runtime"), nil))
 
 	opts = append(opts, withEnv(context), withMounts(context))
 	if len(args) > 0 {

--- a/cmd/ctr/run_windows.go
+++ b/cmd/ctr/run_windows.go
@@ -111,7 +111,7 @@ func newContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 	return client.NewContainer(ctx, id,
 		containerd.WithNewSpec(opts...),
 		containerd.WithContainerLabels(labels),
-		containerd.WithRuntime(context.String("runtime")),
+		containerd.WithRuntime(context.String("runtime"), nil),
 		// TODO(mlaventure): containerd.WithImage(image),
 	)
 }

--- a/container_opts.go
+++ b/container_opts.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/typeurl"
+	"github.com/gogo/protobuf/types"
 	"github.com/opencontainers/image-spec/identity"
 	"github.com/pkg/errors"
 )
@@ -14,10 +16,21 @@ type NewContainerOpts func(ctx context.Context, client *Client, c *containers.Co
 
 // WithRuntime allows a user to specify the runtime name and additional options that should
 // be used to create tasks for the container
-func WithRuntime(name string) NewContainerOpts {
+func WithRuntime(name string, options interface{}) NewContainerOpts {
 	return func(ctx context.Context, client *Client, c *containers.Container) error {
+		var (
+			any *types.Any
+			err error
+		)
+		if options != nil {
+			any, err = typeurl.MarshalAny(options)
+			if err != nil {
+				return err
+			}
+		}
 		c.Runtime = containers.RuntimeInfo{
-			Name: name,
+			Name:    name,
+			Options: any,
 		}
 		return nil
 	}


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

-- 

Will be needed by docker to set `system-cgroup` on the runc binary