### PR TITLE
Place containerd inside cgroup

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -25,6 +25,8 @@ type Config struct {
 	Subreaper bool `toml:"subreaper"`
 	// OOMScore adjust the containerd's oom score
 	OOMScore int `toml:"oom_score"`
+	// Cgroup specifies cgroup information for the containerd daemon process
+	Cgroup CgroupConfig `toml:"cgroup"`
 
 	md toml.MetaData
 }
@@ -44,6 +46,10 @@ type Debug struct {
 
 type MetricsConfig struct {
 	Address string `toml:"address"`
+}
+
+type CgroupConfig struct {
+	Path string `toml:"path"`
 }
 
 // Decode unmarshals a plugin specific configuration by plugin id

--- a/server/server_linux.go
+++ b/server/server_linux.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"os"
 
+	"github.com/containerd/cgroups"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/sys"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 const (
@@ -32,6 +34,22 @@ func apply(ctx context.Context, config *Config) error {
 	if config.OOMScore != 0 {
 		log.G(ctx).Infof("changing OOM score to %d", config.OOMScore)
 		if err := sys.SetOOMScore(os.Getpid(), config.OOMScore); err != nil {
+			return err
+		}
+	}
+	if config.Cgroup.Path != "" {
+		cg, err := cgroups.Load(cgroups.V1, cgroups.StaticPath(config.Cgroup.Path))
+		if err != nil {
+			if err != cgroups.ErrCgroupDeleted {
+				return err
+			}
+			if cg, err = cgroups.New(cgroups.V1, cgroups.StaticPath(config.Cgroup.Path), &specs.LinuxResources{}); err != nil {
+				return err
+			}
+		}
+		if err := cg.Add(cgroups.Process{
+			Pid: os.Getpid(),
+		}); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This adds a config option to place the `containerd` daemon process into
a cgroup so that proper resource usage and accounting can be applied.

It defaults to not being place inside a cgroup and will create a new
cgroup if the `path` does not exist in the config or join an existing
`path` if it already exists.

```toml
[cgroup]
    path = "/containerd"
```

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>