### PR TITLE
Add image config function.

### DIFF
--- a/image.go
+++ b/image.go
@@ -20,10 +20,12 @@ type Image interface {
 	Target() ocispec.Descriptor
 	// Unpack unpacks the image's content into a snapshot
 	Unpack(context.Context, string) error
-	// RootFS returns the image digests
+	// RootFS returns the unpacked diffids that make up images rootfs.
 	RootFS(ctx context.Context) ([]digest.Digest, error)
-	// Size returns the image size
+	// Size returns the total size of the image's packed resources.
 	Size(ctx context.Context) (int64, error)
+	// Config descriptor for the image.
+	Config(ctx context.Context) (ocispec.Descriptor, error)
 }
 
 var _ = (Image)(&image{})
@@ -50,6 +52,11 @@ func (i *image) RootFS(ctx context.Context) ([]digest.Digest, error) {
 func (i *image) Size(ctx context.Context) (int64, error) {
 	provider := i.client.ContentStore()
 	return i.i.Size(ctx, provider)
+}
+
+func (i *image) Config(ctx context.Context) (ocispec.Descriptor, error) {
+	provider := i.client.ContentStore()
+	return i.i.Config(ctx, provider)
 }
 
 func (i *image) Unpack(ctx context.Context, snapshotterName string) error {


### PR DESCRIPTION
Add `Image.Config` to get image config.

The image config digest could be used as container id, based on the image spec definition.
The image config is used to stop container with specified stop signal etc.

/cc @abhinandanpb 
Signed-off-by: Lantao Liu <lantaol@google.com>