### PR TITLE
Ensure ConsoleSize is not nil

### DIFF
--- a/spec_opts_windows.go
+++ b/spec_opts_windows.go
@@ -53,6 +53,9 @@ func WithImageConfig(i Image) SpecOpts {
 func WithTTY(width, height int) SpecOpts {
 	return func(_ context.Context, _ *Client, _ *containers.Container, s *specs.Spec) error {
 		s.Process.Terminal = true
+		if s.Process.ConsoleSize == nil {
+			s.Process.ConsoleSize = &specs.Box{}
+		}
 		s.Process.ConsoleSize.Width = uint(width)
 		s.Process.ConsoleSize.Height = uint(height)
 		return nil


### PR DESCRIPTION
With v1.0.0 of OCI runtime-spec ConsoleSize is a pointer. It may be nil and should be checked before setting the Height and Width values.

Signed-off-by: Darren Stahl <darst@microsoft.com>