### PR TITLE
Update reaper for multiple subscribers

### DIFF
--- a/linux/shim/client.go
+++ b/linux/shim/client.go
@@ -44,7 +44,8 @@ func WithStart(binary, address string, debug bool, exitHandler func()) ClientOpt
 		defer f.Close()
 
 		cmd := newCommand(binary, address, debug, config, f)
-		if err := reaper.Default.Start(cmd); err != nil {
+		ec, err := reaper.Default.Start(cmd)
+		if err != nil {
 			return nil, nil, errors.Wrapf(err, "failed to start shim")
 		}
 		defer func() {
@@ -53,8 +54,7 @@ func WithStart(binary, address string, debug bool, exitHandler func()) ClientOpt
 			}
 		}()
 		go func() {
-			reaper.Default.Wait(cmd)
-			reaper.Default.Delete(cmd.Process.Pid)
+			reaper.Default.Wait(cmd, ec)
 			exitHandler()
 		}()
 		log.G(ctx).WithFields(logrus.Fields{

--- a/linux/shim/init_state.go
+++ b/linux/shim/init_state.go
@@ -6,6 +6,7 @@ import (
 	"context"
 
 	"github.com/containerd/console"
+	"github.com/containerd/containerd/errdefs"
 	shimapi "github.com/containerd/containerd/linux/shim/v1"
 	"github.com/pkg/errors"
 )
@@ -345,10 +346,7 @@ func (s *stoppedState) Delete(ctx context.Context) error {
 }
 
 func (s *stoppedState) Kill(ctx context.Context, sig uint32, all bool) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
-	return s.p.kill(ctx, sig, all)
+	return errdefs.ToGRPCf(errdefs.ErrNotFound, "process %s not found", s.p.id)
 }
 
 func (s *stoppedState) SetExited(status int) {

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,5 +1,5 @@
 github.com/coreos/go-systemd 48702e0da86bd25e76cfef347e2adeb434a0d0a6
-github.com/containerd/go-runc b85ac701de5065a66918203dd18f057433290807
+github.com/containerd/go-runc e103f453ff3db23ec69d31371cadc1ea0ce87ec0
 github.com/containerd/console 76d18fd1d66972718ab2284449591db0b3cdb4de
 github.com/containerd/cgroups e6d1aa8c71c6103624b2c6e6f4be0863b67027f1
 github.com/docker/go-metrics 8fd5772bf1584597834c6f7961a530f06cbfbb87


### PR DESCRIPTION
Depends on https://github.com/containerd/go-runc/pull/24

The is currently a race with the reaper where you could miss some exit
events from processes.

The problem before and why the reaper was so complex was because
processes could fork, getting a pid, and then fail on an execve before
we would have time to register the process with the reaper.  This could
cause pids to fill up in a map as a way to reduce the race.

This changes makes the reaper handle multiple subscribers so that the
caller can handle locking, for when they want to wait for a specific
pid, without affecting other callers using the reaper code.

Exit events are broadcast to multiple subscribers, in the case, the runc
commands and container pids that we get from a pid-file.  Locking while
the entire container stats no longs affects runc commands where you want
to call `runc create` and wait until that has been completed.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>