### PR TITLE
Convert oom metric to const

### DIFF
--- a/metrics/cgroups/metrics.go
+++ b/metrics/cgroups/metrics.go
@@ -21,7 +21,7 @@ var (
 
 // Trigger will be called when an event happens and provides the cgroup
 // where the event originated from
-type Trigger func(string, cgroups.Cgroup)
+type Trigger func(string, string, cgroups.Cgroup)
 
 // New registers the Collector with the provided namespace and returns it so
 // that cgroups can be added for collection


### PR DESCRIPTION
Convert the oom metric to a const that is generated on demand.  This reduces memory as more containers are running during a stress test by not keeping all the namespace and id pairs for metric labels. 

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>