### PR TITLE
LCOW runtime implementation

### DIFF
--- a/windows/common.go
+++ b/windows/common.go
@@ -1,0 +1,68 @@
+// +build windows
+
+package windows
+
+import (
+	"context"
+	"time"
+
+	"github.com/Microsoft/hcsshim"
+	"github.com/boltdb/bolt"
+	"github.com/containerd/containerd/log"
+)
+
+const (
+	layerFolderStoreID       = "windowsLayerStore"
+	defaultTerminateDuration = 5 * time.Minute
+)
+
+type cleanupFunc func(context.Context, string) error
+
+func cleanupRunningContainers(ctx context.Context, db *bolt.DB, owner string, cleanup cleanupFunc) {
+	cp, err := hcsshim.GetContainers(hcsshim.ComputeSystemQuery{
+		Types:  []string{"Container"},
+		Owners: []string{owner},
+	})
+	if err != nil {
+		log.G(ctx).Warn("failed to retrieve running containers")
+		return
+	}
+
+	for _, p := range cp {
+		container, err := hcsshim.OpenContainer(p.ID)
+		if err != nil {
+			log.G(ctx).Warnf("failed open container %s", p.ID)
+			continue
+		}
+
+		err = container.Terminate()
+		if err == nil || hcsshim.IsPending(err) || hcsshim.IsAlreadyStopped(err) {
+			container.Wait()
+		}
+		container.Close()
+
+		// TODO: remove this once we have a windows snapshotter
+		var layerFolderPath string
+		if err := db.View(func(tx *bolt.Tx) error {
+			s := newLayerFolderStore(tx)
+			l, e := s.Get(p.ID)
+			if err == nil {
+				layerFolderPath = l
+			}
+			return e
+		}); err == nil && layerFolderPath != "" {
+			cleanup(ctx, layerFolderPath)
+			if dbErr := db.Update(func(tx *bolt.Tx) error {
+				s := newLayerFolderStore(tx)
+				return s.Delete(p.ID)
+			}); dbErr != nil {
+				log.G(ctx).WithField("id", p.ID).
+					Error("failed to remove key from metadata")
+			}
+		} else {
+			log.G(ctx).WithField("id", p.ID).
+				Debug("key not found in metadata, R/W layer may be leaked")
+		}
+
+	}
+}

--- a/windows/io.go
+++ b/windows/io.go
@@ -20,7 +20,7 @@ type pipeSet struct {
 	stderr net.Conn
 }
 
-// NewIO connects to the provided pipe addresses
+// newPipeSet connects to the provided pipe addresses
 func newPipeSet(ctx context.Context, io runtime.IO) (*pipeSet, error) {
 	var (
 		err    error

--- a/windows/lcow_runtime.go
+++ b/windows/lcow_runtime.go
@@ -1,0 +1,355 @@
+// +build windows
+
+package windows
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/Microsoft/hcsshim"
+	"github.com/boltdb/bolt"
+	eventsapi "github.com/containerd/containerd/api/services/events/v1"
+	containerdtypes "github.com/containerd/containerd/api/types"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/events"
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/plugin"
+	"github.com/containerd/containerd/runtime"
+	"github.com/containerd/containerd/typeurl"
+	"github.com/containerd/containerd/windows/hcsshimopts"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+)
+
+const (
+	lcowRuntimeName = "lcow"
+)
+
+var (
+	lcowPluginID = fmt.Sprintf("%s.%s", plugin.RuntimePlugin, lcowRuntimeName)
+)
+
+var _ = (runtime.Runtime)(&LCOWRuntime{})
+
+func init() {
+	plugin.Register(&plugin.Registration{
+		ID:   lcowRuntimeName,
+		Type: plugin.RuntimePlugin,
+		Init: NewLCOWPlugin,
+		Requires: []plugin.PluginType{
+			plugin.MetadataPlugin,
+		},
+	})
+}
+
+func NewLCOWPlugin(ic *plugin.InitContext) (interface{}, error) {
+	if err := os.MkdirAll(ic.Root, 0700); err != nil {
+		return nil, errors.Wrapf(err, "could not create root directory at %s", ic.Root)
+	}
+
+	m, err := ic.Get(plugin.MetadataPlugin)
+	if err != nil {
+		return nil, err
+	}
+
+	cd := filepath.Join(ic.Root, cacheDirectory)
+	sd := filepath.Join(ic.Root, scratchDirectory)
+
+	// Make sure the scratch directory is created under dataRoot
+	if err := os.MkdirAll(sd, 0700); err != nil {
+		return nil, errors.Wrapf(err, "could not create scratch directory at %s", ic.Root)
+	}
+
+	// Make sure the cache directory is created under dataRoot
+	if err := os.MkdirAll(cd, 0700); err != nil {
+		return nil, errors.Wrapf(err, "could not create cache directory at %s", ic.Root)
+	}
+
+	r := &LCOWRuntime{
+		root:    ic.Root,
+		pidPool: newPidPool(),
+
+		events:    make(chan interface{}, 4096),
+		publisher: ic.Events,
+		// TODO(mlaventure): lcow needs a stat monitor
+		monitor: nil,
+		tasks:   runtime.NewTaskList(),
+		db:      m.(*bolt.DB),
+
+		cachedSandboxFile: filepath.Join(cd, sandboxFilename),
+		cachedScratchFile: filepath.Join(cd, scratchFilename),
+		cache:             make(map[string]*cacheItem),
+		serviceVms:        make(map[string]*serviceVMItem),
+		globalMode:        false,
+	}
+
+	// Load our existing containers and kill/delete them. We don't support
+	// reattaching to them
+	r.cleanup(ic.Context)
+
+	return r, nil
+}
+
+type LCOWRuntime struct {
+	sync.Mutex
+
+	root    string
+	pidPool *pidPool
+
+	publisher events.Publisher
+	events    chan interface{}
+
+	monitor runtime.TaskMonitor
+	tasks   *runtime.TaskList
+	db      *bolt.DB
+
+	cachedSandboxFile  string                    // Location of the local default-sized cached sandbox.
+	cachedSandboxMutex sync.Mutex                // Protects race conditions from multiple threads creating the cached sandbox.
+	cachedScratchFile  string                    // Location of the local cached empty scratch space. This is used as temporary diesk space by the utility VM.
+	cachedScratchMutex sync.Mutex                // Protects race conditions from multiple threads creating the cached scratch.
+	serviceVmsMutex    sync.Mutex                // Protects add/updates/delete to the serviceVMs map.
+	serviceVms         map[string]*serviceVMItem // Map of the configs representing the service VM(s) we are running.
+	globalMode         bool                      // Indicates if running in an unsafe/global service VM mode.
+
+	// NOTE: It is OK to use a cache here because Windows does not support
+	// restoring containers when the daemon dies.
+
+	cacheMutex sync.Mutex            // Protects add/update/deletes to cache.
+	cache      map[string]*cacheItem // Map holding a cache of all the IDs we've mounted/unmounted.
+}
+
+func (r *LCOWRuntime) ID() string {
+	return lcowPluginID
+}
+
+func (r *LCOWRuntime) Create(ctx context.Context, id string, opts runtime.CreateOpts) (runtime.Task, error) {
+	namespace, err := namespaces.NamespaceRequired(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := typeurl.UnmarshalAny(opts.Spec)
+	if err != nil {
+		return nil, err
+	}
+	spec := s.(*specs.Spec)
+
+	var createOpts *hcsshimopts.CreateOptions
+	if opts.Options != nil {
+		o, err := typeurl.UnmarshalAny(opts.Options)
+		if err != nil {
+			return nil, err
+		}
+		createOpts = o.(*hcsshimopts.CreateOptions)
+	} else {
+		createOpts = &hcsshimopts.CreateOptions{}
+	}
+
+	if createOpts.TerminateDuration == 0 {
+		createOpts.TerminateDuration = defaultTerminateDuration
+	}
+
+	return r.newTask(ctx, namespace, id, spec, opts.IO, createOpts)
+}
+
+func (r *LCOWRuntime) Get(ctx context.Context, id string) (runtime.Task, error) {
+	return r.tasks.Get(ctx, id)
+}
+
+func (r *LCOWRuntime) Tasks(ctx context.Context) ([]runtime.Task, error) {
+	return r.tasks.GetAll(ctx)
+}
+
+func (r *LCOWRuntime) Delete(ctx context.Context, t runtime.Task) (*runtime.Exit, error) {
+	wt, ok := t.(*task)
+	if !ok {
+		return nil, errors.Wrap(errdefs.ErrInvalidArgument, "not an LCOW task")
+	}
+
+	// TODO(mlaventure): stop monitor on this task
+
+	var (
+		err      error
+		state, _ = wt.State(ctx)
+	)
+	switch state.Status {
+	case runtime.StoppedStatus:
+		fallthrough
+	case runtime.CreatedStatus:
+		// if it's stopped or in created state, we need to shutdown the
+		// container before removing it
+		if err = wt.stop(ctx); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, errors.Wrap(errdefs.ErrFailedPrecondition,
+			"cannot delete a non-stopped task")
+	}
+
+	var rtExit *runtime.Exit
+	if p := wt.getProcess(t.ID()); p != nil {
+		ec, ea, err := p.ExitCode()
+		if err != nil {
+			return nil, err
+		}
+		rtExit = &runtime.Exit{
+			Pid:       wt.pid,
+			Status:    ec,
+			Timestamp: ea,
+		}
+	} else {
+		rtExit = &runtime.Exit{
+			Pid:       wt.pid,
+			Status:    255,
+			Timestamp: time.Now(),
+		}
+	}
+
+	wt.cleanup()
+	r.tasks.Delete(ctx, t)
+
+	r.publisher.Publish(ctx,
+		runtime.TaskDeleteEventTopic,
+		&eventsapi.TaskDelete{
+			ContainerID: wt.id,
+			Pid:         wt.pid,
+			ExitStatus:  rtExit.Status,
+			ExitedAt:    rtExit.Timestamp,
+		})
+
+	// We were never started, return failure
+	return rtExit, nil
+}
+
+func (r *LCOWRuntime) newTask(ctx context.Context, namespace, id string, spec *specs.Spec, io runtime.IO, createOpts *hcsshimopts.CreateOptions) (*task, error) {
+	var (
+		err  error
+		pset *pipeSet
+	)
+
+	if pset, err = newPipeSet(ctx, io); err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			pset.Close()
+		}
+	}()
+
+	var pid uint32
+	if pid, err = r.pidPool.Get(); err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			r.pidPool.Put(pid)
+		}
+	}()
+
+	var (
+		conf *hcsshim.ContainerConfig
+		nsid = namespace + "-" + id
+	)
+	if conf, err = newLinuxConfig(ctx, lcowPluginID, nsid, spec); err != nil {
+		return nil, err
+	}
+
+	if err := r.CreateRWLayer(ctx, id, spec.Windows.LayerFolders[0]); err != nil {
+		return nil, err
+	}
+	conf.LayerFolderPath = r.containerLayerDir(id)
+	defer func() {
+		if err != nil {
+			removeLinuxLayer(ctx, conf.LayerFolderPath)
+		}
+	}()
+
+	// TODO: remove this once we have an LCOW snapshotter
+	// Store the LayerFolder in the db so we can clean it if we die
+	if err = r.db.Update(func(tx *bolt.Tx) error {
+		s := newLayerFolderStore(tx)
+		return s.Create(nsid, conf.LayerFolderPath)
+	}); err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			if dbErr := r.db.Update(func(tx *bolt.Tx) error {
+				s := newLayerFolderStore(tx)
+				return s.Delete(nsid)
+			}); dbErr != nil {
+				log.G(ctx).WithField("id", id).
+					Error("failed to remove key from metadata")
+			}
+		}
+	}()
+
+	ctr, err := hcsshim.CreateContainer(nsid, conf)
+	if err != nil {
+		time.Sleep(15 * time.Second)
+		return nil, errors.Wrapf(err, "hcsshim failed to create task")
+	}
+	defer func() {
+		if err != nil {
+			ctr.Terminate()
+			ctr.Wait()
+			ctr.Close()
+		}
+	}()
+
+	if err = ctr.Start(); err != nil {
+		return nil, errors.Wrap(err, "hcsshim failed to spawn task")
+	}
+
+	t := &task{
+		id:                id,
+		namespace:         namespace,
+		pid:               pid,
+		io:                pset,
+		status:            runtime.CreatedStatus,
+		spec:              spec,
+		processes:         make(map[string]*process),
+		publisher:         r.publisher,
+		rwLayer:           conf.LayerFolderPath,
+		pidPool:           r.pidPool,
+		isWindows:         false,
+		hyperV:            true,
+		hcsContainer:      ctr,
+		terminateDuration: createOpts.TerminateDuration,
+	}
+	r.tasks.Add(ctx, t)
+
+	var rootfs []*containerdtypes.Mount
+	for _, l := range append([]string{t.rwLayer}, spec.Windows.LayerFolders...) {
+		rootfs = append(rootfs, &containerdtypes.Mount{
+			Type:   "lcow-layer",
+			Source: l,
+		})
+	}
+
+	r.publisher.Publish(ctx,
+		runtime.TaskCreateEventTopic,
+		&eventsapi.TaskCreate{
+			ContainerID: id,
+			IO: &eventsapi.TaskIO{
+				Stdin:    io.Stdin,
+				Stdout:   io.Stdout,
+				Stderr:   io.Stderr,
+				Terminal: io.Terminal,
+			},
+			Pid:    t.pid,
+			Rootfs: rootfs,
+			// TODO: what should be in Bundle for windows?
+		})
+
+	return t, nil
+}
+
+func (r *LCOWRuntime) cleanup(ctx context.Context) {
+	cleanupRunningContainers(ctx, r.db, lcowPluginID, removeLayer)
+}

--- a/windows/lcow_sandbox.go
+++ b/windows/lcow_sandbox.go
@@ -1,0 +1,411 @@
+// +build windows
+
+package windows
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/Microsoft/hcsshim"
+	opengcs "github.com/Microsoft/opengcs/client"
+	"github.com/containerd/containerd/log"
+	"github.com/pkg/errors"
+)
+
+// TODO(darrenstahlmsft) most of the functions in this file belong in the snapshotter.
+// This is a temporary location, and this should all be moved when the snapshotter is implemented.
+
+const (
+	// sandboxFilename is the name of the file containing a layer's sandbox (read-write layer).
+	sandboxFilename = "sandbox.vhdx"
+
+	// scratchFilename is the name of the scratch-space used by an SVM to avoid running out of memory.
+	scratchFilename = "scratch.vhdx"
+
+	// layerFilename is the name of the file containing a layer's read-only contents.
+	// Note this really is VHD format, not VHDX.
+	layerFilename = "layer.vhd"
+
+	// toolsScratchPath is a location in a service utility VM that the tools can use as a
+	// scratch space to avoid running out of memory.
+	toolsScratchPath = "/tmp/scratch"
+
+	// svmGlobalID is the ID used in the serviceVMs map for the global service VM when running in "global" mode.
+	svmGlobalID = "_lcow_global_svm_"
+
+	// cacheDirectory is the sub-folder under the driver's data-root used to cache blank sandbox and scratch VHDs.
+	cacheDirectory = "cache"
+
+	// scratchDirectory is the sub-folder under the driver's data-root used for scratch VHDs in service VMs
+	scratchDirectory = "scratch"
+)
+
+// cacheItem is our internal structure representing an item in our local cache
+// of things that have been mounted.
+type cacheItem struct {
+	sync.Mutex        // Protects operations performed on this item
+	uvmPath    string // Path in utility VM
+	hostPath   string // Path on host
+	refCount   int    // How many times its been mounted
+	isSandbox  bool   // True if a sandbox
+	isMounted  bool   // True when mounted in a service VM
+}
+
+// setIsMounted is a helper function for a cacheItem which does exactly what it says
+func (ci *cacheItem) setIsMounted() {
+	ci.Lock()
+	defer ci.Unlock()
+	ci.isMounted = true
+}
+
+// incrementRefCount is a helper function for a cacheItem which does exactly what it says
+func (ci *cacheItem) incrementRefCount() {
+	ci.Lock()
+	defer ci.Unlock()
+	ci.refCount++
+}
+
+// decrementRefCount is a helper function for a cacheItem which does exactly what it says
+func (ci *cacheItem) decrementRefCount() int {
+	ci.Lock()
+	defer ci.Unlock()
+	ci.refCount--
+	return ci.refCount
+}
+
+// serviceVMItem is our internal structure representing an item in our
+// map of service VMs we are maintaining.
+type serviceVMItem struct {
+	sync.Mutex                      // Serialises operations being performed in this service VM.
+	scratchAttached bool            // Has a scratch been attached?
+	config          *opengcs.Config // Represents the service VM item.
+}
+
+// startServiceVM starts a service utility VM if it is not currently running.
+// It can optionally be started with a mapped virtual disk.
+func (r *LCOWRuntime) startServiceVM(ctx context.Context, id string, mvdToAdd *hcsshim.MappedVirtualDisk, context string) (*serviceVMItem, error) {
+	// Use the global ID if in global mode
+	if r.globalMode {
+		id = svmGlobalID
+	}
+
+	title := fmt.Sprintf("lcowdriver: startServiceVM %s:", id)
+
+	// Make sure thread-safe when interrogating the map
+	log.G(ctx).Debugf("%s taking serviceVmsMutex", title)
+	r.serviceVmsMutex.Lock()
+
+	// Nothing to do if it's already running except add the mapped drive if supplied.
+	if svm, ok := r.serviceVms[id]; ok {
+		log.G(ctx).Debugf("%s exists, releasing serviceVmsMutex", title)
+		r.serviceVmsMutex.Unlock()
+
+		if mvdToAdd != nil {
+			log.G(ctx).Debugf("hot-adding %s to %s", mvdToAdd.HostPath, mvdToAdd.ContainerPath)
+
+			// Ensure the item is locked while doing this
+			log.G(ctx).Debugf("%s locking serviceVmItem %s", title, svm.config.Name)
+			svm.Lock()
+			defer svm.Unlock()
+
+			if err := svm.config.HotAddVhd(mvdToAdd.HostPath, mvdToAdd.ContainerPath, false, true); err != nil {
+				log.G(ctx).Debugf("%s releasing serviceVmItem %s on hot-add failure %s", title, svm.config.Name, err)
+				return nil, errors.Wrapf(err, "hot add vhd %s to %s failed", mvdToAdd.HostPath, mvdToAdd.ContainerPath)
+			}
+
+			log.G(ctx).Debugf("%s releasing serviceVmItem %s", title, svm.config.Name)
+		}
+		return svm, nil
+	}
+
+	// Release the lock early
+	log.G(ctx).Debugf("%s releasing serviceVmsMutex", title)
+	r.serviceVmsMutex.Unlock()
+
+	// So we are starting one. First need an enpty structure.
+	svm := &serviceVMItem{
+		config: &opengcs.Config{},
+	}
+
+	//TODO(darrenstahlmsft) add LCOW options
+	// Generate a default configuration
+	if err := svm.config.GenerateDefault(nil); err != nil {
+		return nil, fmt.Errorf("%s failed to generate default gogcs configuration for global svm (%s): %s", title, context, err)
+	}
+
+	// For the name, we deliberately suffix if safe-mode to ensure that it doesn't
+	// clash with another utility VM which may be running for the container itself.
+	// This also makes it easier to correlate through Get-ComputeProcess.
+	if id == svmGlobalID {
+		svm.config.Name = svmGlobalID
+	} else {
+		svm.config.Name = fmt.Sprintf("%s_svm", id)
+	}
+
+	// Ensure we take the cached scratch mutex around the check to ensure the file is complete
+	// and not in the process of being created by another thread.
+	scratchTargetFile := filepath.Join(r.root, scratchDirectory, fmt.Sprintf("%s.vhdx", id))
+
+	log.G(ctx).Debugf("%s locking cachedScratchMutex", title)
+	r.cachedScratchMutex.Lock()
+	if _, err := os.Stat(r.cachedScratchFile); err == nil {
+		// Make a copy of cached scratch to the scratch directory
+		log.G(ctx).Debugf("lcowdriver: startServiceVM: (%s) cloning cached scratch for mvd", context)
+		if err := opengcs.CopyFile(r.cachedScratchFile, scratchTargetFile, true); err != nil {
+			log.G(ctx).Debugf("%s releasing cachedScratchMutex on err: %s", title, err)
+			r.cachedScratchMutex.Unlock()
+			return nil, err
+		}
+
+		// Add the cached clone as a mapped virtual disk
+		log.G(ctx).Debugf("lcowdriver: startServiceVM: (%s) adding cloned scratch as mvd", context)
+		mvd := hcsshim.MappedVirtualDisk{
+			HostPath:          scratchTargetFile,
+			ContainerPath:     toolsScratchPath,
+			CreateInUtilityVM: true,
+		}
+		svm.config.MappedVirtualDisks = append(svm.config.MappedVirtualDisks, mvd)
+		svm.scratchAttached = true
+	}
+	log.G(ctx).Debugf("%s releasing cachedScratchMutex", title)
+	r.cachedScratchMutex.Unlock()
+
+	// If requested to start it with a mapped virtual disk, add it now.
+	if mvdToAdd != nil {
+		svm.config.MappedVirtualDisks = append(svm.config.MappedVirtualDisks, *mvdToAdd)
+	}
+
+	// Start it.
+	log.G(ctx).Debugf("lcowdriver: startServiceVM: (%s) starting %s", context, svm.config.Name)
+	if err := svm.config.StartUtilityVM(); err != nil {
+		return nil, fmt.Errorf("failed to start service utility VM (%s): %s", context, err)
+	}
+
+	// As it's now running, add it to the map, checking for a race where another
+	// thread has simultaneously tried to start it.
+	log.G(ctx).Debugf("%s locking serviceVmsMutex for insertion", title)
+	r.serviceVmsMutex.Lock()
+	if svm, ok := r.serviceVms[id]; ok {
+		log.G(ctx).Debugf("%s releasing serviceVmsMutex after insertion but exists", title)
+		r.serviceVmsMutex.Unlock()
+		return svm, nil
+	}
+	r.serviceVms[id] = svm
+	log.G(ctx).Debugf("%s releasing serviceVmsMutex after insertion", title)
+	r.serviceVmsMutex.Unlock()
+
+	// Now we have a running service VM, we can create the cached scratch file if it doesn't exist.
+	log.G(ctx).Debugf("%s locking cachedScratchMutex", title)
+	r.cachedScratchMutex.Lock()
+	if !svm.scratchAttached {
+		log.G(ctx).Debugf("%s (%s): creating an SVM scratch - locking serviceVM", title, context)
+		svm.Lock()
+		if err := svm.config.CreateExt4Vhdx(scratchTargetFile, opengcs.DefaultVhdxSizeGB, r.cachedScratchFile); err != nil {
+			log.G(ctx).Debugf("%s (%s): releasing serviceVM on error path from CreateExt4Vhdx: %s", title, context, err)
+			svm.Unlock()
+			log.G(ctx).Debugf("%s (%s): releasing cachedScratchMutex on error path", title, context)
+			r.cachedScratchMutex.Unlock()
+
+			// Do a force terminate and remove it from the map on failure, ignoring any errors
+			if err2 := r.terminateServiceVM(ctx, id, "error path from CreateExt4Vhdx", true); err2 != nil {
+				log.G(ctx).Warnf("failed to terminate service VM on error path from CreateExt4Vhdx: %s", err2)
+			}
+
+			return nil, fmt.Errorf("failed to create SVM scratch VHDX (%s): %s", context, err)
+		}
+		log.G(ctx).Debugf("%s (%s): releasing serviceVM after %s created and cached to %s", title, context, scratchTargetFile, r.cachedScratchFile)
+		svm.Unlock()
+	}
+	log.G(ctx).Debugf("%s (%s): releasing cachedScratchMutex", title, context)
+	r.cachedScratchMutex.Unlock()
+
+	// Hot-add the scratch-space if not already attached
+	if !svm.scratchAttached {
+		log.G(ctx).Debugf("lcowdriver: startServiceVM: (%s) hot-adding scratch %s - locking serviceVM", context, scratchTargetFile)
+		svm.Lock()
+		if err := svm.config.HotAddVhd(scratchTargetFile, toolsScratchPath, false, true); err != nil {
+			log.G(ctx).Debugf("%s (%s): releasing serviceVM on error path of HotAddVhd: %s", title, context, err)
+			svm.Unlock()
+
+			// Do a force terminate and remove it from the map on failure, ignoring any errors
+			if err2 := r.terminateServiceVM(ctx, id, "error path from HotAddVhd", true); err2 != nil {
+				log.G(ctx).Warnf("failed to terminate service VM on error path from HotAddVhd: %s", err2)
+			}
+
+			return nil, fmt.Errorf("failed to hot-add %s failed: %s", scratchTargetFile, err)
+		}
+		log.G(ctx).Debugf("%s (%s): releasing serviceVM", title, context)
+		svm.scratchAttached = true
+		svm.Unlock()
+	}
+
+	log.G(ctx).Debugf("lcowdriver: startServiceVM: (%s) success", context)
+	return svm, nil
+}
+
+// getServiceVM returns the appropriate service utility VM instance, optionally
+// deleting it from the map (but not the global one)
+func (r *LCOWRuntime) getServiceVM(ctx context.Context, id string, deleteFromMap bool) *serviceVMItem {
+	log.G(ctx).Debugf("lcowdriver: getservicevm:locking serviceVmsMutex")
+	r.serviceVmsMutex.Lock()
+	defer func() {
+		log.G(ctx).Debugf("lcowdriver: getservicevm:releasing serviceVmsMutex")
+		r.serviceVmsMutex.Unlock()
+	}()
+	if r.globalMode {
+		id = svmGlobalID
+	}
+	if _, ok := r.serviceVms[id]; !ok {
+		return nil
+	}
+	svm := r.serviceVms[id]
+	if deleteFromMap && id != svmGlobalID {
+		log.G(ctx).Debugf("lcowdriver: getservicevm: removing %s from map", id)
+		delete(r.serviceVms, id)
+	}
+	return svm
+}
+
+// terminateServiceVM terminates a service utility VM if its running, but does nothing
+// when in global mode as it's lifetime is limited to that of the daemon.
+func (r *LCOWRuntime) terminateServiceVM(ctx context.Context, id, context string, force bool) error {
+
+	// We don't do anything in safe mode unless the force flag has been passed, which
+	// is only the case for cleanup at driver termination.
+	if r.globalMode {
+		if !force {
+			log.G(ctx).Debugf("lcowdriver: terminateservicevm: %s (%s) - doing nothing as in global mode", id, context)
+			return nil
+		}
+		id = svmGlobalID
+	}
+
+	// Get the service VM and delete it from the map
+	svm := r.getServiceVM(ctx, id, true)
+	if svm == nil {
+		return errors.New("unable to get service VM")
+	}
+
+	// We run the deletion of the scratch as a deferred function to at least attempt
+	// clean-up in case of errors.
+	defer func() {
+		if svm.scratchAttached {
+			scratchTargetFile := filepath.Join(r.root, scratchDirectory, fmt.Sprintf("%s.vhdx", id))
+			log.G(ctx).Debugf("lcowdriver: terminateservicevm: %s (%s) - deleting scratch %s", id, context, scratchTargetFile)
+			if err := os.Remove(scratchTargetFile); err != nil {
+				log.G(ctx).Warnf("failed to remove scratch file %s (%s): %s", scratchTargetFile, context, err)
+			}
+		}
+	}()
+
+	// Nothing to do if it's not running
+	if svm.config.Uvm != nil {
+		log.G(ctx).Debugf("lcowdriver: terminateservicevm: %s (%s) - calling terminate", id, context)
+		if err := svm.config.Uvm.Terminate(); err != nil {
+			return fmt.Errorf("failed to terminate utility VM (%s): %s", context, err)
+		}
+
+		log.G(ctx).Debugf("lcowdriver: terminateservicevm: %s (%s) - waiting for utility VM to terminate", id, context)
+		if err := svm.config.Uvm.WaitTimeout(time.Duration(svm.config.UvmTimeoutSeconds) * time.Second); err != nil {
+			return fmt.Errorf("failed waiting for utility VM to terminate (%s): %s", context, err)
+		}
+	}
+
+	log.G(ctx).Debugf("lcowdriver: terminateservicevm: %s (%s) - success", id, context)
+	return nil
+}
+
+// CreateRWLayer creates a layer that is writable for use as a container
+// file system. That equates to creating a sandbox.
+func (r *LCOWRuntime) CreateRWLayer(ctx context.Context, id, parent string) error {
+	title := fmt.Sprintf("lcowdriver: CreateRWLayer: id %s", id)
+	log.G(ctx).Debugf(title)
+
+	// First we need to create the folder
+	if err := r.CreateLayerFolder(id, parent); err != nil {
+		return err
+	}
+
+	// Look for an explicit sandbox size option.
+	sandboxSize := uint64(opengcs.DefaultVhdxSizeGB)
+
+	// Massive perf optimisation here. If we know that the RW layer is the default size,
+	// and that the cached sandbox already exists, and we are running in safe mode, we
+	// can just do a simple copy into the layers sandbox file without needing to start a
+	// unique service VM. For a global service VM, it doesn't really matter. Of course,
+	// this is only the case where the sandbox is the default size.
+	//
+	// Make sure we have the sandbox mutex taken while we are examining it.
+	if sandboxSize == opengcs.DefaultVhdxSizeGB {
+		log.G(ctx).Debugf("%s: locking cachedSandboxMutex", title)
+		r.cachedSandboxMutex.Lock()
+		_, err := os.Stat(r.cachedSandboxFile)
+		log.G(ctx).Debugf("%s: releasing cachedSandboxMutex", title)
+		r.cachedSandboxMutex.Unlock()
+		if err == nil {
+			log.G(ctx).Debugf("%s: using cached sandbox to populate", title)
+			if err := opengcs.CopyFile(r.cachedSandboxFile, filepath.Join(r.containerLayerDir(id), sandboxFilename), true); err != nil {
+				return err
+			}
+			return nil
+		}
+	}
+
+	log.G(ctx).Debugf("%s: creating SVM to create sandbox", title)
+	svm, err := r.startServiceVM(ctx, id, nil, "CreateRWLayer")
+	if err != nil {
+		return err
+	}
+	defer r.terminateServiceVM(ctx, id, "CreateRWLayer", false)
+
+	// So the sandbox needs creating. If default size ensure we are the only thread populating the cache.
+	// Non-default size we don't store, just create them one-off so no need to lock the cachedSandboxMutex.
+	if sandboxSize == opengcs.DefaultVhdxSizeGB {
+		log.G(ctx).Debugf("%s: locking cachedSandboxMutex for creation", title)
+		r.cachedSandboxMutex.Lock()
+		defer func() {
+			log.G(ctx).Debugf("%s: releasing cachedSandboxMutex for creation", title)
+			r.cachedSandboxMutex.Unlock()
+		}()
+	}
+
+	// Synchronise the operation in the service VM.
+	log.G(ctx).Debugf("%s: locking svm for sandbox creation", title)
+	svm.Lock()
+	defer func() {
+		log.G(ctx).Debugf("%s: releasing svm for sandbox creation", title)
+		svm.Unlock()
+	}()
+
+	// Make sure we don't write to our local cached copy if this is for a non-default size request.
+	targetCacheFile := r.cachedSandboxFile
+	if sandboxSize != opengcs.DefaultVhdxSizeGB {
+		targetCacheFile = ""
+	}
+
+	// Actually do the creation.
+	if err := svm.config.CreateExt4Vhdx(filepath.Join(r.containerLayerDir(id), sandboxFilename), uint32(sandboxSize), targetCacheFile); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// dir returns the absolute path to the layer.
+func (r *LCOWRuntime) containerLayerDir(id string) string {
+	return filepath.Join(r.root, filepath.Base(id))
+}
+
+// CreateLayerFolder creates the folder for the layer with the given id, and
+// adds it to the layer chain.
+func (r *LCOWRuntime) CreateLayerFolder(id, parent string) error {
+	layerPath := r.containerLayerDir(id)
+	if err := mkdirAllWithACL(layerPath, 755, sddlNtvmAdministratorsLocalSystem); err != nil {
+		return err
+	}
+	return nil
+}

--- a/windows/meta.go
+++ b/windows/meta.go
@@ -19,9 +19,9 @@ type layerFolderStore struct {
 }
 
 func (s *layerFolderStore) Create(id, layer string) error {
-	bkt, err := s.tx.CreateBucketIfNotExists([]byte(pluginID))
+	bkt, err := s.tx.CreateBucketIfNotExists([]byte(layerFolderStoreID))
 	if err != nil {
-		return errors.Wrapf(err, "failed to create bucket %s", pluginID)
+		return errors.Wrapf(err, "failed to create bucket %s", layerFolderStoreID)
 	}
 	err = bkt.Put([]byte(id), []byte(layer))
 	if err != nil {
@@ -32,18 +32,18 @@ func (s *layerFolderStore) Create(id, layer string) error {
 }
 
 func (s *layerFolderStore) Get(id string) (string, error) {
-	bkt := s.tx.Bucket([]byte(pluginID))
+	bkt := s.tx.Bucket([]byte(layerFolderStoreID))
 	if bkt == nil {
-		return "", errors.Wrapf(errdefs.ErrNotFound, "bucket %s", pluginID)
+		return "", errors.Wrapf(errdefs.ErrNotFound, "bucket %s", layerFolderStoreID)
 	}
 
 	return string(bkt.Get([]byte(id))), nil
 }
 
 func (s *layerFolderStore) Delete(id string) error {
-	bkt := s.tx.Bucket([]byte(pluginID))
+	bkt := s.tx.Bucket([]byte(layerFolderStoreID))
 	if bkt == nil {
-		return errors.Wrapf(errdefs.ErrNotFound, "bucket %s", pluginID)
+		return errors.Wrapf(errdefs.ErrNotFound, "bucket %s", layerFolderStoreID)
 	}
 
 	if err := bkt.Delete([]byte(id)); err != nil {


### PR DESCRIPTION
This implements the first version of Linux Container on Windows runtime. It shares much of the code with the Windows runtime, but is registered as a separate runtime in order to avoid collision between the Windows runtime and the LCOW runtime.

`lcow_sandbox.go` is almost all temporary code due to the lack of a snapshotter for LCOW/Windows. I'll work on a snapshotter soon and delete almost all of the code there.

This PR covers basic container run scenario, but does not currently support Exec nor many options. This is mostly to prove API is sufficient to further expand and finish implementation without breaking changes.

With https://github.com/containerd/containerd/pull/1426 the following works pointing to the Docker busybox image:
```
PS H:\bin\containerd> .\ctr run --platform linux --runtime io.containerd.runtime.v1.lcow --layer "C:\\lcow\\lcow\\b9d90a4c74763f8da02ebeb93d4408e70c523eb1227fd634eb6c8dd7e881
7fe0" test test ls
bin
dev
etc
home
proc
root
run
sys
tmp
usr
var
```

closes https://github.com/containerd/containerd/issues/1355

@jhowardmsft @dmcgowan @mlaventure @stevvooe 

Signed-off-by: Darren Stahl <darst@microsoft.com>