### PR TITLE
Ensure all init children are dead when it exits 

### DIFF
--- a/linux/runtime.go
+++ b/linux/runtime.go
@@ -364,7 +364,10 @@ func (r *Runtime) loadTasks(ctx context.Context, ns string) ([]*Task, error) {
 func (r *Runtime) cleanupAfterDeadShim(ctx context.Context, bundle *bundle, ns, id string, pid int, ec chan runc.Exit) error {
 	ctx = namespaces.WithNamespace(ctx, ns)
 	if err := r.terminate(ctx, bundle, ns, id); err != nil {
-		return errors.New("failed to terminate task, leaving bundle for debugging")
+		if r.config.ShimDebug {
+			return errors.Wrap(err, "failed to terminate task, leaving bundle for debugging")
+		}
+		log.G(ctx).WithError(err).Warn("failed to terminate task")
 	}
 
 	if ec != nil {

--- a/reaper/reaper.go
+++ b/reaper/reaper.go
@@ -90,6 +90,9 @@ func (m *Monitor) Wait(c *exec.Cmd, ec chan runc.Exit) (int, error) {
 			// make sure we flush all IO
 			c.Wait()
 			m.Unsubscribe(ec)
+			if e.Status != 0 {
+				return e.Status, errors.New("unsucessful command")
+			}
 			return e.Status, nil
 		}
 	}

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,5 +1,5 @@
 github.com/coreos/go-systemd 48702e0da86bd25e76cfef347e2adeb434a0d0a6
-github.com/containerd/go-runc e103f453ff3db23ec69d31371cadc1ea0ce87ec0
+github.com/containerd/go-runc ba22f6a82e52be3be4eb4a00000fe816f4b41c2e
 github.com/containerd/console 76d18fd1d66972718ab2284449591db0b3cdb4de
 github.com/containerd/cgroups e6d1aa8c71c6103624b2c6e6f4be0863b67027f1
 github.com/docker/go-metrics 8fd5772bf1584597834c6f7961a530f06cbfbb87

--- a/vendor/github.com/containerd/go-runc/monitor.go
+++ b/vendor/github.com/containerd/go-runc/monitor.go
@@ -22,26 +22,11 @@ type Exit struct {
 // These methods should match the methods exposed by exec.Cmd to provide
 // a consistent experience for the caller
 type ProcessMonitor interface {
-	Output(*exec.Cmd) ([]byte, error)
-	CombinedOutput(*exec.Cmd) ([]byte, error)
-	Run(*exec.Cmd) error
 	Start(*exec.Cmd) (chan Exit, error)
 	Wait(*exec.Cmd, chan Exit) (int, error)
 }
 
 type defaultMonitor struct {
-}
-
-func (m *defaultMonitor) Output(c *exec.Cmd) ([]byte, error) {
-	return c.Output()
-}
-
-func (m *defaultMonitor) CombinedOutput(c *exec.Cmd) ([]byte, error) {
-	return c.CombinedOutput()
-}
-
-func (m *defaultMonitor) Run(c *exec.Cmd) error {
-	return c.Run()
 }
 
 func (m *defaultMonitor) Start(c *exec.Cmd) (chan Exit, error) {


### PR DESCRIPTION
This ensure that when using the host pid, we don't let process alive,
preventing Wait() to return until they all die.

-- 

@crosbymichael I've used option 2 in this PR. Let me know which way you wanna go, this one or https://github.com/containerd/go-runc/pull/26. Or if you have an alternative I'm all ears :smile_cat: 