### PR TITLE
remotes/docker: expand allowed status codes on push

### DIFF
--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -313,9 +313,11 @@ func (r *dockerBase) doRequestWithRetries(ctx context.Context, req *http.Request
 	responses = append(responses, resp)
 	req, err = r.retryRequest(ctx, req, responses)
 	if err != nil {
+		resp.Body.Close()
 		return nil, err
 	}
 	if req != nil {
+		resp.Body.Close()
 		return r.doRequestWithRetries(ctx, req, responses)
 	}
 	return resp, err


### PR DESCRIPTION
Support registries returning 204 or 200 in place of 201/202. GCR in one case returns a 200 where a 201 was expected, causing upload completion to fail.

Ensure body is closed when request is retried.

Related to #1318