### PR TITLE
Fix FreeBSD compilation

### DIFF
--- a/archive/tar_unix.go
+++ b/archive/tar_unix.go
@@ -123,7 +123,7 @@ func handleLChmod(hdr *tar.Header, path string, hdrInfo os.FileInfo) error {
 
 func getxattr(path, attr string) ([]byte, error) {
 	b, err := sysx.LGetxattr(path, attr)
-	if err == unix.ENOTSUP || err == unix.ENODATA {
+	if err == unix.ENOTSUP || err == sysx.ENODATA {
 		return nil, nil
 	}
 	return b, err

--- a/fs/diff_unix.go
+++ b/fs/diff_unix.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/containerd/continuity/sysx"
 	"github.com/pkg/errors"
-	"golang.org/x/sys/unix"
 )
 
 // whiteouts are files with a special meaning for the layered filesystem.
@@ -84,11 +83,11 @@ func compareSysStat(s1, s2 interface{}) (bool, error) {
 
 func compareCapabilities(p1, p2 string) (bool, error) {
 	c1, err := sysx.LGetxattr(p1, "security.capability")
-	if err != nil && err != unix.ENODATA {
+	if err != nil && err != sysx.ENODATA {
 		return false, errors.Wrapf(err, "failed to get xattr for %s", p1)
 	}
 	c2, err := sysx.LGetxattr(p2, "security.capability")
-	if err != nil && err != unix.ENODATA {
+	if err != nil && err != sysx.ENODATA {
 		return false, errors.Wrapf(err, "failed to get xattr for %s", p2)
 	}
 	return bytes.Equal(c1, c2), nil


### PR DESCRIPTION
Corrects compile on FreeBSD by handling the lack of ENODATA on FreeBSD.
Since the continuity project has already handled this discrepancy, using their const is
simpler than separating a few extra files in containerd/containerd.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>

Fixes: #1422
After #1469 these were the only other changes necessary to get a successful compile on FreeBSD with master.