### PR TITLE
api, linux/runcopts: ensure output is current

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,8 @@ before_install:
   - uname -r
 
 install:
-  - wget https://github.com/google/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -O /tmp/protoc-3.1.0-linux-x86_64.zip
-  - unzip -o -d /tmp/protobuf /tmp/protoc-3.1.0-linux-x86_64.zip
-  - export PATH=$PATH:/tmp/protobuf/bin/
+  - wget https://github.com/google/protobuf/releases/download/v3.3.0/protoc-3.3.0-linux-x86_64.zip -O /tmp/protoc-3.3.0-linux-x86_64.zip
+  - sudo unzip -o -d /usr/local /tmp/protoc-3.3.0-linux-x86_64.zip
   - go get -u github.com/vbatts/git-validation
   - sudo wget https://github.com/crosbymichael/runc/releases/download/ctd-4/runc -O /bin/runc; sudo chmod +x /bin/runc
   - wget https://github.com/xemul/criu/archive/v3.0.tar.gz -O /tmp/criu.tar.gz
@@ -57,6 +56,7 @@ script:
   - make setup
   - make vet
   - make ineffassign
+  - if [ "$GOOS" = "linux" ]; then make check-protos check-api-descriptors; fi
   - make build
   - make binaries
   - if [ "$GOOS" = "linux" ]; then sudo make install ; fi

--- a/Makefile
+++ b/Makefile
@@ -83,11 +83,17 @@ protos: bin/protoc-gen-gogoctrd ## generate protobuf
 	@echo "$(WHALE) $@"
 	@PATH=${ROOTDIR}/bin:${PATH} protobuild ${PACKAGES}
 
-checkprotos: protos ## check if protobufs needs to be generated again
+check-protos: protos ## check if protobufs needs to be generated again
 	@echo "$(WHALE) $@"
 	@test -z "$$(git status --short | grep ".pb.go" | tee /dev/stderr)" || \
 		((git diff | cat) && \
 		(echo "$(ONI) please run 'make generate' when making changes to proto files" && false))
+
+check-api-descriptors: protos ## check that protobuf changes aren't present.
+	@echo "$(WHALE) $@"
+	@test -z "$$(git status --short | grep ".pb.txt" | tee /dev/stderr)" || \
+		((git diff $$(find . -name '*.pb.txt') | cat) && \
+		(echo "$(ONI) please run 'make protos' when making changes to proto files and check-in the generated descriptor file changes" && false))
 
 # Depends on binaries because vet will silently fail if it can't load compiled
 # imports

--- a/api/next.pb.txt
+++ b/api/next.pb.txt
@@ -2888,6 +2888,7 @@ file {
   name: "github.com/containerd/containerd/api/types/task/task.proto"
   package: "containerd.v1.types"
   dependency: "gogoproto/gogo.proto"
+  dependency: "google/protobuf/timestamp.proto"
   message_type {
     name: "Process"
     field {
@@ -2953,6 +2954,18 @@ file {
       label: LABEL_OPTIONAL
       type: TYPE_UINT32
       json_name: "exitStatus"
+    }
+    field {
+      name: "exited_at"
+      number: 10
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.Timestamp"
+      options {
+        65010: 1
+        65001: 0
+      }
+      json_name: "exitedAt"
     }
   }
   enum_type {

--- a/linux/runcopts/next.pb.txt
+++ b/linux/runcopts/next.pb.txt
@@ -5,17 +5,31 @@ file {
   message_type {
     name: "RuncOptions"
     field {
-      name: "criu_path"
+      name: "runtime"
       number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "runtime"
+    }
+    field {
+      name: "runtime_root"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "runtimeRoot"
+    }
+    field {
+      name: "criu_path"
+      number: 3
       label: LABEL_OPTIONAL
       type: TYPE_STRING
       json_name: "criuPath"
     }
     field {
       name: "systemd_cgroup"
-      number: 2
+      number: 4
       label: LABEL_OPTIONAL
-      type: TYPE_STRING
+      type: TYPE_BOOL
       json_name: "systemdCgroup"
     }
   }


### PR DESCRIPTION
Ensure that the descriptors are re-generated on the CI and block merges
that don't include updates. We also enable the `check-protos` check as
part of this process.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

~~Don't merge till this is green!~~