### PR TITLE
Add config for exporting container metrics to prom

### DIFF
--- a/metrics/cgroups/blkio.go
+++ b/metrics/cgroups/blkio.go
@@ -3,6 +3,8 @@
 package cgroups
 
 import (
+	"strconv"
+
 	"github.com/containerd/cgroups"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
@@ -100,4 +102,15 @@ var blkioMetrics = []*metric{
 			return blkioValues(stats.Blkio.SectorsRecursive)
 		},
 	},
+}
+
+func blkioValues(l []*cgroups.BlkIOEntry) []value {
+	var out []value
+	for _, e := range l {
+		out = append(out, value{
+			v: float64(e.Value),
+			l: []string{e.Op, e.Device, strconv.FormatUint(e.Major, 10), strconv.FormatUint(e.Minor, 10)},
+		})
+	}
+	return out
 }

--- a/metrics/cgroups/oom.go
+++ b/metrics/cgroups/oom.go
@@ -19,12 +19,18 @@ func NewOOMCollector(ns *metrics.Namespace) (*OOMCollector, error) {
 	if err != nil {
 		return nil, err
 	}
+	var desc *prometheus.Desc
+	if ns != nil {
+		desc = ns.NewDesc("memory_oom", "The number of times a container has received an oom event", metrics.Total, "container_id", "namespace")
+	}
 	c := &OOMCollector{
 		fd:   fd,
-		desc: ns.NewDesc("memory_oom", "The number of times a container has received an oom event", metrics.Total, "container_id", "namespace"),
+		desc: desc,
 		set:  make(map[uintptr]*oom),
 	}
-	ns.Add(c)
+	if ns != nil {
+		ns.Add(c)
+	}
 	go c.start()
 	return c, nil
 }


### PR DESCRIPTION
This adds an option for the cgroups monitor to include container metrics
in the prometheus output.  We will have to use the plugin to emit oom
events via the events service but when the `no_prometheus` setting is set for
the plugin container metrics will not be included in the prom output.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>