### PR TITLE
Correct spelling of default.

### DIFF
--- a/spec_unix.go
+++ b/spec_unix.go
@@ -25,7 +25,7 @@ var (
 	}
 )
 
-func defaltCaps() []string {
+func defaultCaps() []string {
 	return []string{
 		"CAP_CHOWN",
 		"CAP_DAC_OVERRIDE",
@@ -79,10 +79,10 @@ func createDefaultSpec() (*specs.Spec, error) {
 				GID: 0,
 			},
 			Capabilities: &specs.LinuxCapabilities{
-				Bounding:    defaltCaps(),
-				Permitted:   defaltCaps(),
-				Inheritable: defaltCaps(),
-				Effective:   defaltCaps(),
+				Bounding:    defaultCaps(),
+				Permitted:   defaultCaps(),
+				Inheritable: defaultCaps(),
+				Effective:   defaultCaps(),
 			},
 			Rlimits: []specs.POSIXRlimit{
 				{

--- a/spec_unix_test.go
+++ b/spec_unix_test.go
@@ -21,7 +21,7 @@ func TestGenerateSpec(t *testing.T) {
 	}
 
 	// check for matching caps
-	defaults := defaltCaps()
+	defaults := defaultCaps()
 	for _, cl := range [][]string{
 		s.Process.Capabilities.Bounding,
 		s.Process.Capabilities.Permitted,


### PR DESCRIPTION
Signed-off-by: Ian Campbell <ian.campbell@docker.com>