### PR TITLE
Use force to delete runtime

### DIFF
--- a/runtime/container.go
+++ b/runtime/container.go
@@ -262,7 +262,7 @@ func (c *container) readSpec() (*specs.Spec, error) {
 
 func (c *container) Delete() error {
 	var err error
-	args := append(c.runtimeArgs, "delete", c.id)
+	args := append(c.runtimeArgs, "delete", "--force", c.id)
 	if b, derr := exec.Command(c.runtime, args...).CombinedOutput(); derr != nil && !strings.Contains(string(b), "does not exist") {
 		err = fmt.Errorf("%s: %q", derr, string(b))
 	}


### PR DESCRIPTION
Under some abnormal operating conditions, containerd can't delete runtime. 
e.g.
```
#!/bin/bash
docker rm aaa
id=`docker run -tid --name aaa ubuntu`
for ((i=0; i<10000; i++)); do
        kill -9 $(docker top aaa | awk 'NR==2{print $2}')
        sleep 0.02
        echo FROZEN > /sys/fs/cgroup/freezer/docker/$id/freezer.state 
        docker start aaa
        if [ $? -ne 0 ]; then
                break
        fi
done
```

with the shell, we can see,
```
[root@localhost pause]# ./test.sh 
Error response from daemon: No such container: aaa
./test3.sh: line 7: /sys/fs/cgroup/freezer/docker/b18d84077f792f4454722ce87520ec39395f1029f41ad73ad531d9d1eadd2923/freezer.state: No such file or directory
aaa
aaa
Error response from daemon: oci runtime error: container with id exists: b18d84077f792f4454722ce87520ec39395f1029f41ad73ad531d9d1eadd2923
Error: failed to start containers: aaa
[root@localhost pause]# docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
[root@localhost pause]# docker ps -a
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS                        PORTS               NAMES
b18d84077f79        ubuntu              "/bin/bash"         14 seconds ago      Exited (137) 10 seconds ago                       aaa
[root@localhost pause]# docker-runc list
ID                                                                 PID         STATUS      BUNDLE                                                                                       CREATED
b18d84077f792f4454722ce87520ec39395f1029f41ad73ad531d9d1eadd2923   4263        paused      /run/docker/libcontainerd/b18d84077f792f4454722ce87520ec39395f1029f41ad73ad531d9d1eadd2923   2017-09-08T17:14:40.626060962Z
[root@localhost pause]# ps -eaf|grep 4263
root      4905  2831  0 13:15 pts/1    00:00:00 grep --color=auto 4263
[root@localhost pause]# docker start aaa
Error response from daemon: oci runtime error: container with id exists: b18d84077f792f4454722ce87520ec39395f1029f41ad73ad531d9d1eadd2923
Error: failed to start containers: aaa
```

I think it's not a problem that the state is not the same between docker(exited) and docker-runc(pause),because we set it directly use cgroup interface(not docker pause),but it lead to  start the container fail because of exist id.

on the other hand, if the conteiner's init process exit, containerd need runc delete sucessfull,otherwise it will cause residual runc'files(like /var/runc/containid).

Signed-off-by: yangshukui <yangshukui@huawei.com>