### PR TITLE
[tmp] Use amd64 test image

### DIFF
--- a/client_unix_test.go
+++ b/client_unix_test.go
@@ -33,6 +33,7 @@ func init() {
 	case "s390x":
 		testImage = "docker.io/s390x/alpine:latest"
 	default:
-		testImage = "docker.io/library/alpine:latest"
+		// FIXME: change this back after multiplatform support is added to pull
+		testImage = "docker.io/amd64/alpine:latest"
 	}
 }

--- a/container_linux_test.go
+++ b/container_linux_test.go
@@ -730,7 +730,9 @@ func TestShimSigkilled(t *testing.T) {
 	defer cancel()
 
 	// redis unset its PDeathSignal making it a good candidate
-	image, err = client.Pull(ctx, "docker.io/library/redis:alpine", WithPullUnpack)
+	//
+	// FIXME: change this back after multiplatform support is added to pull
+	image, err = client.Pull(ctx, "docker.io/amd64/redis:alpine", WithPullUnpack)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This is a workaround because official images were pushed with multi-arch
support recently and the current Pull code is not accounting for this.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>