### PR TITLE
Set ctx ns before publish

### DIFF
--- a/services/namespaces/service.go
+++ b/services/namespaces/service.go
@@ -187,7 +187,8 @@ func (s *Service) Delete(ctx context.Context, req *api.DeleteNamespaceRequest) (
 	}); err != nil {
 		return &empty.Empty{}, err
 	}
-
+	// set the namespace in the context before publishing the event
+	ctx = namespaces.WithNamespace(ctx, req.Name)
 	if err := s.publisher.Publish(ctx, "/namespaces/delete", &eventsapi.NamespaceDelete{
 		Name: req.Name,
 	}); err != nil {


### PR DESCRIPTION
Fixes #1497

This sets the namespace on the context when deleting a namespace so that
the publish event does not fail.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>