### PR TITLE
Add Akihiro as maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -247,6 +247,7 @@ example and you'll be fine".
 
 	[Org.Maintainers]
 	people = [
+		"akihirosuda",
 		"crosbymichael",
 		"dqminh",
 		"dmcgowan",
@@ -258,6 +259,11 @@ example and you'll be fine".
 	]
 
 [People]
+
+	[people.akihirosuda]
+	Name = "Akihiro Suda"
+	Email = "suda.akihiro@lab.ntt.co.jp"
+	GitHub = "AkihiroSuda"
 
 	[People.crosbymichael]
 	Name = "Michael Crosby"


### PR DESCRIPTION
Akihiro has proven himself as a valuable and dedicated contributor to Containerd. In addition he has also been maintaining moby core and buildkit. Having him as a maintainer makes sense and will be valuable in scaling review and maintenance of the project.

Maintainers:
- [x] @crosbymichael
- [ ] @dqminh
- [x] @dmcgowan (inferred)
- [x] @estesp
- [x] @hqhq
- [x] @jhowardmsft
- [x] @mlaventure
- [x] @stevvooe

BDFL:

- [x] @shykes