### PR TITLE
mount: fix CString memory leaks

### DIFF
--- a/mount/mountinfo_solaris.go
+++ b/mount/mountinfo_solaris.go
@@ -4,17 +4,24 @@ package mount
 
 /*
 #include <stdio.h>
+#include <stdlib.h>
 #include <sys/mnttab.h>
 */
 import "C"
 
 import (
 	"fmt"
+	"unsafe"
 )
 
 // Self retrieves a list of mounts for the current running process.
 func Self() ([]Info, error) {
-	mnttab := C.fopen(C.CString(C.MNTTAB), C.CString("r"))
+	path := C.CString(C.MNTTAB)
+	defer C.free(unsafe.Pointer(path))
+	mode := C.CString("r")
+	defer C.free(unsafe.Pointer(mode))
+
+	mnttab := C.fopen(path, mode)
 	if mnttab == nil {
 		return nil, fmt.Errorf("Failed to open %s", C.MNTTAB)
 	}


### PR DESCRIPTION
Make sure to call C.free on C strings allocated using C.CString.

C.CString allocates memory in the C heap using malloc. It is the callers
responsibility to free them. See
https://golang.org/cmd/cgo/#hdr-Go_references_to_C for details.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>