### PR TITLE
Remove omitempty from toml tags

### DIFF
--- a/linux/runtime.go
+++ b/linux/runtime.go
@@ -67,15 +67,15 @@ var _ = (runtime.Runtime)(&Runtime{})
 
 type Config struct {
 	// Shim is a path or name of binary implementing the Shim GRPC API
-	Shim string `toml:"shim,omitempty"`
+	Shim string `toml:"shim"`
 	// Runtime is a path or name of an OCI runtime used by the shim
-	Runtime string `toml:"runtime,omitempty"`
+	Runtime string `toml:"runtime"`
 	// RuntimeRoot is the path that shall be used by the OCI runtime for its data
-	RuntimeRoot string `toml:"runtime_root,omitempty"`
+	RuntimeRoot string `toml:"runtime_root"`
 	// NoShim calls runc directly from within the pkg
-	NoShim bool `toml:"no_shim,omitempty"`
+	NoShim bool `toml:"no_shim"`
 	// Debug enable debug on the shim
-	ShimDebug bool `toml:"shim_debug,omitempty"`
+	ShimDebug bool `toml:"shim_debug"`
 }
 
 func New(ic *plugin.InitContext) (interface{}, error) {

--- a/services/diff/service.go
+++ b/services/diff/service.go
@@ -19,7 +19,7 @@ type config struct {
 	// respected for which is choosen. Each differ should return the same
 	// correct output, allowing any ordering to be used to prefer
 	// more optimimal implementations.
-	Order []string `toml:"default,omitempty"`
+	Order []string `toml:"default"`
 }
 
 func init() {


### PR DESCRIPTION
The encoder only support changing the name of the key.

Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>