### PR TITLE
fixes missing default permission

### DIFF
--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -399,7 +399,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 			Action: specs.ActAllow,
 			Args:   []specs.LinuxSeccompArg{},
 		})
-	case "amd", "x32":
+	case "amd64":
 		s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
 			Names: []string{
 				"arch_prctl",
@@ -408,7 +408,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 			Args:   []specs.LinuxSeccompArg{},
 		})
 		fallthrough
-	case "x86":
+	case "386":
 		s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
 			Names: []string{
 				"modify_ldt",


### PR DESCRIPTION
Fixes missing default permission to allow sys call arch_prctl when runtime.GOARCH == amd64, was testing for "amd" not "amd64"

runtime.GOARC: "amd64" maps to (amd)
runtime.GOARC: "386" maps to (x86)

Signed-off-by: Mike Brown <brownwm@us.ibm.com>