### PR TITLE
Add v1 to metrics API endpoint

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -189,6 +189,15 @@ enumerating the support services and messages. See [api/](api) for details.
 Note that new services may be added in _minor_ releases. New service methods
 and new fields on messages may be added if they are optional.
 
+### Metrics API
+
+The metrics API that outputs prometheus style metrics will be versioned independently,
+prefixed with the API version. i.e. `/v1/metrics`, `/v2/metrics`.
+
+The metrics API version will be incremented when breaking changes are made to the prometheus
+output. New metrics can be added to the output in a backwards compatible manner without
+bumping the API version.
+
 #### Error Codes
 
 Error codes will not change in a patch release, unless a missing error code

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -257,7 +257,7 @@ Waiting on things like the container's exit status and cgroup metrics are setup 
 If you are familiar with prometheus you can curl the containerd metrics endpoint (in the `config.toml` that we created) to see your container's metrics:
 
 ```bash
-> curl 127.0.0.1:1338/metrics
+> curl 127.0.0.1:1338/v1/metrics
 ```
 
 Pretty cool right?

--- a/server/server.go
+++ b/server/server.go
@@ -136,7 +136,7 @@ func (s *Server) ServeGRPC(l net.Listener) error {
 // ServeMetrics provides a prometheus endpoint for exposing metrics
 func (s *Server) ServeMetrics(l net.Listener) error {
 	m := http.NewServeMux()
-	m.Handle("/metrics", metrics.Handler())
+	m.Handle("/v1/metrics", metrics.Handler())
 	return trapClosedConnErr(http.Serve(l, m))
 }
 


### PR DESCRIPTION
Fixes #1399

This versions the prometheus metrics API so we can manage backwards
incompatible changes in the future more easily.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>