### PR TITLE
Revert "[tmp] Use amd64 test image"

### DIFF
--- a/client_unix_test.go
+++ b/client_unix_test.go
@@ -33,7 +33,6 @@ func init() {
 	case "s390x":
 		testImage = "docker.io/s390x/alpine:latest"
 	default:
-		// FIXME: change this back after multiplatform support is added to pull
-		testImage = "docker.io/amd64/alpine:latest"
+		testImage = "docker.io/library/alpine:latest"
 	}
 }

--- a/container_linux_test.go
+++ b/container_linux_test.go
@@ -730,9 +730,7 @@ func TestShimSigkilled(t *testing.T) {
 	defer cancel()
 
 	// redis unset its PDeathSignal making it a good candidate
-	//
-	// FIXME: change this back after multiplatform support is added to pull
-	image, err = client.Pull(ctx, "docker.io/amd64/redis:alpine", WithPullUnpack)
+	image, err = client.Pull(ctx, "docker.io/library/redis:alpine", WithPullUnpack)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Reverts containerd/containerd#1502 now that all the key multi-platform image handling fixes are merged. Will be a good test that the last couple PRs are working properly :)