### PR TITLE
Revert temp image reference change/fix WithCheckpoint()

### DIFF
--- a/client_unix_test.go
+++ b/client_unix_test.go
@@ -33,7 +33,6 @@ func init() {
 	case "s390x":
 		testImage = "docker.io/s390x/alpine:latest"
 	default:
-		// FIXME: change this back after multiplatform support is added to pull
-		testImage = "docker.io/amd64/alpine:latest"
+		testImage = "docker.io/library/alpine:latest"
 	}
 }

--- a/container_linux_test.go
+++ b/container_linux_test.go
@@ -730,9 +730,7 @@ func TestShimSigkilled(t *testing.T) {
 	defer cancel()
 
 	// redis unset its PDeathSignal making it a good candidate
-	//
-	// FIXME: change this back after multiplatform support is added to pull
-	image, err = client.Pull(ctx, "docker.io/amd64/redis:alpine", WithPullUnpack)
+	image, err = client.Pull(ctx, "docker.io/library/redis:alpine", WithPullUnpack)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/container_opts_unix.go
+++ b/container_opts_unix.go
@@ -38,7 +38,7 @@ func WithCheckpoint(desc v1.Descriptor, snapshotKey string) NewContainerOpts {
 			case v1.MediaTypeImageLayer:
 				fk := m
 				rw = &fk
-			case images.MediaTypeDockerSchema2Manifest:
+			case images.MediaTypeDockerSchema2Manifest, images.MediaTypeDockerSchema2ManifestList:
 				config, err := images.Config(ctx, store, m, platforms.Default())
 				if err != nil {
 					return err


### PR DESCRIPTION
Reverts #1502; fixes `WithCheckpoint()` to work with manifest list-based image references.