### PR TITLE
Fix container CreatedAt and UpdatedAt.

### DIFF
--- a/containerstore.go
+++ b/containerstore.go
@@ -117,6 +117,8 @@ func containerFromProto(containerpb *containersapi.Container) containers.Contain
 		Spec:        containerpb.Spec,
 		Snapshotter: containerpb.Snapshotter,
 		SnapshotKey: containerpb.SnapshotKey,
+		CreatedAt:   containerpb.CreatedAt,
+		UpdatedAt:   containerpb.UpdatedAt,
 		Extensions:  containerpb.Extensions,
 	}
 }

--- a/services/containers/helpers.go
+++ b/services/containers/helpers.go
@@ -27,6 +27,8 @@ func containerToProto(container *containers.Container) api.Container {
 		Spec:        container.Spec,
 		Snapshotter: container.Snapshotter,
 		SnapshotKey: container.SnapshotKey,
+		CreatedAt:   container.CreatedAt,
+		UpdatedAt:   container.UpdatedAt,
 		Extensions:  container.Extensions,
 	}
 }


### PR DESCRIPTION
Currently container `CreatedAt` and `UpdatedAt` are not properly exposed:
```
    "CreatedAt": "0001-01-01T00:00:00Z",
    "UpdatedAt": "0001-01-01T00:00:00Z",
```

This PR fixes it:
```
    "CreatedAt": "2017-09-22T05:54:41.351119711Z",
    "UpdatedAt": "2017-09-22T05:54:41.351119711Z",
```

Signed-off-by: Lantao Liu <lantaol@google.com>