### PR TITLE
Fix example using old GenerateSpec function

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -196,7 +196,7 @@ func redisExample() error {
         }
         log.Printf("Successfully pulled %s image\n", image.Name())
 
-        spec, err := containerd.GenerateSpec(containerd.WithImageConfig(ctx, image))
+        spec, err := containerd.GenerateSpec(ctx, client, nil, containerd.WithImageConfig(image))
         if err != nil {
                 return err
         }


### PR DESCRIPTION
This fixes the example in the getting started guide. The full example
was already correct; tested compilation and proper runtime on latest
master.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>

Fixes: #1521 thanks to @rutsky for finding/solving