### PR TITLE
Update client to pass go lint

### DIFF
--- a/client.go
+++ b/client.go
@@ -406,42 +406,52 @@ func (c *Client) Close() error {
 	return c.conn.Close()
 }
 
+// NamespaceService returns the underlying NamespacesClient
 func (c *Client) NamespaceService() namespacesapi.NamespacesClient {
 	return namespacesapi.NewNamespacesClient(c.conn)
 }
 
+// ContainerService returns the underlying container Store
 func (c *Client) ContainerService() containers.Store {
 	return NewRemoteContainerStore(containersapi.NewContainersClient(c.conn))
 }
 
+// ContentStore returns the underlying content Store
 func (c *Client) ContentStore() content.Store {
 	return contentservice.NewStoreFromClient(contentapi.NewContentClient(c.conn))
 }
 
+// SnapshotService returns the underlying snapshotter for the provided snapshotter name
 func (c *Client) SnapshotService(snapshotterName string) snapshot.Snapshotter {
 	return snapshotservice.NewSnapshotterFromClient(snapshotapi.NewSnapshotsClient(c.conn), snapshotterName)
 }
 
+// TaskService returns the underlying TasksClient
 func (c *Client) TaskService() tasks.TasksClient {
 	return tasks.NewTasksClient(c.conn)
 }
 
+// ImageService returns the underlying image Store
 func (c *Client) ImageService() images.Store {
 	return imagesservice.NewStoreFromClient(imagesapi.NewImagesClient(c.conn))
 }
 
+// DiffService returns the underlying DiffService
 func (c *Client) DiffService() diff.DiffService {
 	return diffservice.NewDiffServiceFromClient(diffapi.NewDiffClient(c.conn))
 }
 
+// HealthService returns the underlying GRPC HealthClient
 func (c *Client) HealthService() grpc_health_v1.HealthClient {
 	return grpc_health_v1.NewHealthClient(c.conn)
 }
 
+// EventService returns the underlying EventsClient
 func (c *Client) EventService() eventsapi.EventsClient {
 	return eventsapi.NewEventsClient(c.conn)
 }
 
+// VersionService returns the underlying VersionClient
 func (c *Client) VersionService() versionservice.VersionClient {
 	return versionservice.NewVersionClient(c.conn)
 }

--- a/containerstore.go
+++ b/containerstore.go
@@ -15,6 +15,7 @@ type remoteContainers struct {
 
 var _ containers.Store = &remoteContainers{}
 
+// NewRemoteContainerStore returns the container Store connected with the provided client
 func NewRemoteContainerStore(client containersapi.ContainersClient) containers.Store {
 	return &remoteContainers{
 		client: client,

--- a/dialer.go
+++ b/dialer.go
@@ -13,6 +13,7 @@ type dialResult struct {
 	err error
 }
 
+// Dialer returns a GRPC net.Conn connected to the provided address
 func Dialer(address string, timeout time.Duration) (net.Conn, error) {
 	var (
 		stopC = make(chan struct{})

--- a/dialer_unix.go
+++ b/dialer_unix.go
@@ -27,6 +27,8 @@ func dialer(address string, timeout time.Duration) (net.Conn, error) {
 	return net.DialTimeout("unix", address, timeout)
 }
 
+// DialAddress returns the address with unix:// prepended to the
+// provided address
 func DialAddress(address string) string {
 	return fmt.Sprintf("unix://%s", address)
 }

--- a/io_unix.go
+++ b/io_unix.go
@@ -119,6 +119,7 @@ func NewDirectIO(ctx context.Context, terminal bool) (*DirectIO, error) {
 	return f, nil
 }
 
+// DirectIO allows task IO to be handled externally by the caller
 type DirectIO struct {
 	Stdin  io.WriteCloser
 	Stdout io.ReadCloser
@@ -128,14 +129,17 @@ type DirectIO struct {
 	terminal bool
 }
 
+// IOCreate returns IO avaliable for use with task creation
 func (f *DirectIO) IOCreate(id string) (IO, error) {
 	return f, nil
 }
 
+// IOAttach returns IO avaliable for use with task attachment
 func (f *DirectIO) IOAttach(set *FIFOSet) (IO, error) {
 	return f, nil
 }
 
+// Config returns the IOConfig
 func (f *DirectIO) Config() IOConfig {
 	return IOConfig{
 		Terminal: f.terminal,
@@ -145,14 +149,21 @@ func (f *DirectIO) Config() IOConfig {
 	}
 }
 
+// Cancel stops any IO copy operations
+//
+// Not applicable for DirectIO
 func (f *DirectIO) Cancel() {
 	// nothing to cancel as all operations are handled externally
 }
 
+// Wait on any IO copy operations
+//
+// Not applicable for DirectIO
 func (f *DirectIO) Wait() {
 	// nothing to wait on as all operations are handled externally
 }
 
+// Close closes all open fds
 func (f *DirectIO) Close() error {
 	err := f.Stdin.Close()
 	if err2 := f.Stdout.Close(); err == nil {
@@ -164,6 +175,7 @@ func (f *DirectIO) Close() error {
 	return err
 }
 
+// Delete removes the underlying directory containing fifos
 func (f *DirectIO) Delete() error {
 	if f.set.Dir == "" {
 		return nil

--- a/spec_opts_unix.go
+++ b/spec_opts_unix.go
@@ -302,8 +302,8 @@ func WithNamespacedCgroup() SpecOpts {
 	}
 }
 
-// WithUidGid allows the UID and GID for the Process to be set
-func WithUidGid(uid, gid uint32) SpecOpts {
+// WithUIDGID allows the UID and GID for the Process to be set
+func WithUIDGID(uid, gid uint32) SpecOpts {
 	return func(_ context.Context, _ *Client, _ *containers.Container, s *specs.Spec) error {
 		s.Process.User.UID = uid
 		s.Process.User.GID = gid

--- a/task.go
+++ b/task.go
@@ -41,6 +41,7 @@ type Status struct {
 	ExitTime time.Time
 }
 
+// ProcessStatus returns a human readable status for the Process representing its current status
 type ProcessStatus string
 
 const (

--- a/task_opts.go
+++ b/task_opts.go
@@ -52,12 +52,14 @@ func WithProcessKill(ctx context.Context, p Process) error {
 	return nil
 }
 
+// KillInfo contains information on how to process a Kill action
 type KillInfo struct {
 	// All kills all processes inside the task
 	// only valid on tasks, ignored on processes
 	All bool
 }
 
+// KillOpts allows options to be set for the killing of a process
 type KillOpts func(context.Context, Process, *KillInfo) error
 
 // WithKillAll kills all processes for a task


### PR DESCRIPTION
There is one breaking change with the function naming of UidGid to
UIDGID

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>