### PR TITLE
Update console dep to 84eeaae905fa414d03e07bcd6c8d

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
   - wget https://github.com/google/protobuf/releases/download/v3.3.0/protoc-3.3.0-linux-x86_64.zip -O /tmp/protoc-3.3.0-linux-x86_64.zip
   - sudo unzip -o -d /usr/local /tmp/protoc-3.3.0-linux-x86_64.zip
   - go get -u github.com/vbatts/git-validation
-  - sudo wget https://github.com/crosbymichael/runc/releases/download/ctd-5/runc -O /bin/runc; sudo chmod +x /bin/runc
+  - sudo wget https://github.com/crosbymichael/runc/releases/download/ctd-6/runc -O /bin/runc; sudo chmod +x /bin/runc
   - wget https://github.com/xemul/criu/archive/v3.0.tar.gz -O /tmp/criu.tar.gz
   - tar -C /tmp/ -zxf /tmp/criu.tar.gz
   - cd /tmp/criu-3.0 && sudo make install-criu

--- a/RUNC.md
+++ b/RUNC.md
@@ -2,7 +2,7 @@ containerd is built with OCI support and with support for advanced features prov
 
 We depend on a specific `runc` version when dealing with advanced features.  You should have a specific runc build for development.  The current supported runc commit is:
 
-RUNC_COMMIT = 593914b8bd5448a93f7c3e4902a03408b6d5c0ce
+RUNC_COMMIT = 0351df1c5a66838d0c392b4ac4cf9450de844e2d
 
 For more information on how to clone and build runc see the runc Building [documentation](https://github.com/opencontainers/runc#building).
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,6 +1,6 @@
 github.com/coreos/go-systemd 48702e0da86bd25e76cfef347e2adeb434a0d0a6
 github.com/containerd/go-runc b3c048c028ddd789c6f9510c597f8b9c62f25359
-github.com/containerd/console b28c739c79ce69d017e3691ad3664568d68e95c6
+github.com/containerd/console 84eeaae905fa414d03e07bcd6c8d3f19e7cf180e
 github.com/containerd/cgroups 5933ab4dc4f7caa3a73a1dc141bd11f42b5c9163
 github.com/containerd/typeurl f6943554a7e7e88b3c14aad190bf05932da84788
 github.com/docker/go-metrics 8fd5772bf1584597834c6f7961a530f06cbfbb87

--- a/vendor.conf
+++ b/vendor.conf
@@ -16,7 +16,7 @@ github.com/docker/go-units v0.3.1
 github.com/gogo/protobuf d2e1ade2d719b78fe5b061b4c18a9f7111b5bdc8
 github.com/golang/protobuf 5a0f697c9ed9d68fef0116532c6e05cfeae00e55
 github.com/opencontainers/runtime-spec v1.0.0
-github.com/opencontainers/runc 593914b8bd5448a93f7c3e4902a03408b6d5c0ce
+github.com/opencontainers/runc 0351df1c5a66838d0c392b4ac4cf9450de844e2d
 github.com/sirupsen/logrus v1.0.0
 github.com/containerd/btrfs cc52c4dea2ce11a44e6639e561bb5c2af9ada9e3
 github.com/stretchr/testify v1.1.4

--- a/vendor/github.com/containerd/console/console.go
+++ b/vendor/github.com/containerd/console/console.go
@@ -44,7 +44,13 @@ type WinSize struct {
 
 // Current returns the current processes console
 func Current() Console {
-	return newMaster(os.Stdin)
+	c, err := ConsoleFromFile(os.Stdin)
+	if err != nil {
+		// stdin should always be a console for the design
+		// of this function
+		panic(err)
+	}
+	return c
 }
 
 // ConsoleFromFile returns a console using the provided file
@@ -52,5 +58,5 @@ func ConsoleFromFile(f *os.File) (Console, error) {
 	if err := checkConsole(f); err != nil {
 		return nil, err
 	}
-	return newMaster(f), nil
+	return newMaster(f)
 }

--- a/vendor/github.com/containerd/console/console_windows.go
+++ b/vendor/github.com/containerd/console/console_windows.go
@@ -190,13 +190,11 @@ func checkConsole(f *os.File) error {
 	return nil
 }
 
-func newMaster(f *os.File) Console {
+func newMaster(f *os.File) (Console, error) {
 	if f != os.Stdin && f != os.Stdout && f != os.Stderr {
-		panic("creating a console from a file is not supported on windows")
+		return nil, errors.New("creating a console from a file is not supported on windows")
 	}
-
 	m := &master{}
 	m.initStdios()
-
-	return m
+	return m, nil
 }

--- a/vendor/github.com/opencontainers/runc/vendor.conf
+++ b/vendor/github.com/opencontainers/runc/vendor.conf
@@ -18,9 +18,8 @@ github.com/golang/protobuf 18c9bb3261723cd5401db4d0c9fbc5c3b6c70fe8
 github.com/docker/docker 0f5c9d301b9b1cca66b3ea0f9dec3b5317d3686d
 github.com/docker/go-units v0.2.0
 github.com/urfave/cli d53eb991652b1d438abdd34ce4bfa3ef1539108e
-golang.org/x/sys 0e0164865330d5cf1c00247be08330bf96e2f87c https://github.com/golang/sys
+golang.org/x/sys 7ddbeae9ae08c6a06a59597f0c9edbc5ff2444ce https://github.com/golang/sys
 
 # console dependencies
-github.com/containerd/console 2ce1c681f3c3c0dfa7d0af289428d36567c9a6bc
-github.com/Azure/go-ansiterm fa152c58bc15761d0200cb75fe958b89a9d4888e
+github.com/containerd/console 84eeaae905fa414d03e07bcd6c8d3f19e7cf180e
 github.com/pkg/errors v0.8.0


### PR DESCRIPTION
This change removes the ClearONLCR from the console package providing
a console with the default settings from the console package.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>