### PR TITLE
ctr: add `ctr images ls --quiet`

### DIFF
--- a/cmd/ctr/images.go
+++ b/cmd/ctr/images.go
@@ -34,10 +34,16 @@ var imagesListCommand = cli.Command{
 	Usage:       "list images known to containerd",
 	ArgsUsage:   "[flags] <ref>",
 	Description: `List images registered with containerd.`,
-	Flags:       []cli.Flag{},
+	Flags: []cli.Flag{
+		cli.BoolFlag{
+			Name:  "quiet, q",
+			Usage: "print only the image refs",
+		},
+	},
 	Action: func(clicontext *cli.Context) error {
 		var (
 			filters     = clicontext.Args()
+			quiet       = clicontext.Bool("quiet")
 			ctx, cancel = appContext(clicontext)
 		)
 		defer cancel()
@@ -54,7 +60,12 @@ var imagesListCommand = cli.Command{
 		if err != nil {
 			return errors.Wrap(err, "failed to list images")
 		}
-
+		if quiet {
+			for _, image := range imageList {
+				fmt.Println(image.Name)
+			}
+			return nil
+		}
 		tw := tabwriter.NewWriter(os.Stdout, 1, 8, 1, ' ', 0)
 		fmt.Fprintln(tw, "REF\tTYPE\tDIGEST\tSIZE\tPLATFORM\tLABELS\t")
 		for _, image := range imageList {


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

Before:
```console
$ ctr --namespace=k8s.io images ls
REF                                                                                                                          TYPE                                                      DIGEST                 SIZE      PLATFORM                                                                                              LABELS
docker.io/library/busybox:1.25.0                                                                                             application/vnd.docker.distribution.manifest.v2+json      sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6 653.9 KiB -                                                                                                     -
docker.io/library/busybox:latest                                                                                             application/vnd.docker.distribution.manifest.list.v2+json sha256:99ccecf3da28a93c063d5dddcdf69aeed44826d0db219aabc3d5178d47649dfa 703.0 KiB linux/386,linux/amd64,linux/arm/v5,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x -
docker.io/library/busybox@sha256:99ccecf3da28a93c063d5dddcdf69aeed44826d0db219aabc3d5178d47649dfa                            application/vnd.docker.distribution.manifest.list.v2+json sha256:99ccecf3da28a93c063d5dddcdf69aeed44826d0db219aabc3d5178d47649dfa 703.0 KiB linux/386,linux/amd64,linux/arm/v5,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x -
docker.io/library/busybox@sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6                            application/vnd.docker.distribution.manifest.v2+json      sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6 653.9 KiB -                                                                                                     -
docker.io/library/mysql:latest                                                                                               application/vnd.docker.distribution.manifest.list.v2+json sha256:0dc3dacb751ef46a6647234abdec2d47400f0dfbe77ab490b02bffdae57846ed 137.6 MiB linux/amd64                                                                                           -
docker.io/library/mysql@sha256:0dc3dacb751ef46a6647234abdec2d47400f0dfbe77ab490b02bffdae57846ed                              application/vnd.docker.distribution.manifest.list.v2+json sha256:0dc3dacb751ef46a6647234abdec2d47400f0dfbe77ab490b02bffdae57846ed 137.6 MiB linux/amd64                                                                                           -
gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.4                                                                  application/vnd.docker.distribution.manifest.v2+json      sha256:aeeb994acbc505eabc7415187cd9edb38cbb5364dc1c2fc748154576464b3dc2 10.8 MiB  linux/amd64                                                                                           -
gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64@sha256:aeeb994acbc505eabc7415187cd9edb38cbb5364dc1c2fc748154576464b3dc2 application/vnd.docker.distribution.manifest.v2+json      sha256:aeeb994acbc505eabc7415187cd9edb38cbb5364dc1c2fc748154576464b3dc2 10.8 MiB  linux/amd64                                                                                           -
gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.4                                                                       application/vnd.docker.distribution.manifest.v2+json      sha256:40790881bbe9ef4ae4ff7fe8b892498eecb7fe6dcc22661402f271e03f7de344 12.5 MiB  linux/amd64                                                                                           -
gcr.io/google_containers/k8s-dns-kube-dns-amd64@sha256:40790881bbe9ef4ae4ff7fe8b892498eecb7fe6dcc22661402f271e03f7de344      application/vnd.docker.distribution.manifest.v2+json      sha256:40790881bbe9ef4ae4ff7fe8b892498eecb7fe6dcc22661402f271e03f7de344 12.5 MiB  linux/amd64                                                                                           -
gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.4                                                                        application/vnd.docker.distribution.manifest.v2+json      sha256:97074c951046e37d3cbb98b82ae85ed15704a290cce66a8314e7f846404edde9 10.8 MiB  linux/amd64                                                                                           -
gcr.io/google_containers/k8s-dns-sidecar-amd64@sha256:97074c951046e37d3cbb98b82ae85ed15704a290cce66a8314e7f846404edde9       application/vnd.docker.distribution.manifest.v2+json      sha256:97074c951046e37d3cbb98b82ae85ed15704a290cce66a8314e7f846404edde9 10.8 MiB  linux/amd64                                                                                           -
gcr.io/google_containers/pause:3.0                                                                                           application/vnd.oci.image.manifest.v1+json                sha256:27865b15496841a89083c94d4c51ede5e77be8b837ab8eb737dd968453f147c5 304.9 KiB linux/amd64                                                                                           -
gcr.io/kubernetes-helm/tiller:v2.6.1                                                                                         application/vnd.docker.distribution.manifest.v2+json      sha256:6b561c3bb9fed1b028520cce3852e6c9a6a91161df9b92ca0c3a20ebecc0581a 18.5 MiB  -                                                                                                     -
gcr.io/kubernetes-helm/tiller@sha256:6b561c3bb9fed1b028520cce3852e6c9a6a91161df9b92ca0c3a20ebecc0581a                        application/vnd.docker.distribution.manifest.v2+json      sha256:6b561c3bb9fed1b028520cce3852e6c9a6a91161df9b92ca0c3a20ebecc0581a 18.5 MiB  -                                                                                                     -
sha256:0ebffe5ba8a7e05fb3ae7f53ee0103882ef6a0e078cb9a2f9d0fbdb36a604708                                                      application/vnd.docker.distribution.manifest.v2+json      sha256:6b561c3bb9fed1b028520cce3852e6c9a6a91161df9b92ca0c3a20ebecc0581a 18.5 MiB  -                                                                                                     -
sha256:2b8fd9751c4c0f5dd266fcae00707e67a2545ef34f9a29354585f93dac906749                                                      application/vnd.docker.distribution.manifest.v2+json      sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6 653.9 KiB -                                                                                                     -
sha256:320aedbfaad3d719b5e6a711834d2d06e2b0a172ce6fdadf84c640b6136914ed                                                      application/vnd.oci.image.manifest.v1+json                sha256:27865b15496841a89083c94d4c51ede5e77be8b837ab8eb737dd968453f147c5 304.9 KiB linux/amd64                                                                                           -
sha256:38bac66034a6217abfd44b4a8a763b1a4c973045cae2763f2cc857baa5c9a872                                                      application/vnd.docker.distribution.manifest.v2+json      sha256:97074c951046e37d3cbb98b82ae85ed15704a290cce66a8314e7f846404edde9 10.8 MiB  linux/amd64                                                                                           -
sha256:54511612f1c4d97e93430fc3d5dc2f05dfbe8fb7e6259b7351deeca95eaf2971                                                      application/vnd.docker.distribution.manifest.list.v2+json sha256:99ccecf3da28a93c063d5dddcdf69aeed44826d0db219aabc3d5178d47649dfa 703.0 KiB linux/386,linux/amd64,linux/arm/v5,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x -
sha256:a8e00546bcf3fc9ae1f33302c16a6d4c717d0a47a444581b5bcabc4757bcd79c                                                      application/vnd.docker.distribution.manifest.v2+json      sha256:40790881bbe9ef4ae4ff7fe8b892498eecb7fe6dcc22661402f271e03f7de344 12.5 MiB  linux/amd64                                                                                           -
sha256:b4e78b89bcf31a38eab47da1b2b36235462e83beebacb7479d725367e76572cf                                                      application/vnd.docker.distribution.manifest.list.v2+json sha256:0dc3dacb751ef46a6647234abdec2d47400f0dfbe77ab490b02bffdae57846ed 137.6 MiB linux/amd64                                                                                           -
sha256:f7f45b9cb733af946532240cf7e6cde1278b687cd7094cf043b768c800cfdafd                                                      application/vnd.docker.distribution.manifest.v2+json      sha256:aeeb994acbc505eabc7415187cd9edb38cbb5364dc1c2fc748154576464b3dc2 10.8 MiB  linux/amd64
```

After:
```
$ ctr --namespace=k8s.io images ls -q
docker.io/library/busybox:1.25.0
docker.io/library/busybox:latest
docker.io/library/busybox@sha256:99ccecf3da28a93c063d5dddcdf69aeed44826d0db219aabc3d5178d47649dfa
docker.io/library/busybox@sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6
docker.io/library/mysql:latest
docker.io/library/mysql@sha256:0dc3dacb751ef46a6647234abdec2d47400f0dfbe77ab490b02bffdae57846ed
gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.4
gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64@sha256:aeeb994acbc505eabc7415187cd9edb38cbb5364dc1c2fc748154576464b3dc2
gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.4
gcr.io/google_containers/k8s-dns-kube-dns-amd64@sha256:40790881bbe9ef4ae4ff7fe8b892498eecb7fe6dcc22661402f271e03f7de344
gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.4
gcr.io/google_containers/k8s-dns-sidecar-amd64@sha256:97074c951046e37d3cbb98b82ae85ed15704a290cce66a8314e7f846404edde9
gcr.io/google_containers/pause:3.0
gcr.io/kubernetes-helm/tiller:v2.6.1
gcr.io/kubernetes-helm/tiller@sha256:6b561c3bb9fed1b028520cce3852e6c9a6a91161df9b92ca0c3a20ebecc0581a
sha256:0ebffe5ba8a7e05fb3ae7f53ee0103882ef6a0e078cb9a2f9d0fbdb36a604708
sha256:2b8fd9751c4c0f5dd266fcae00707e67a2545ef34f9a29354585f93dac906749
sha256:320aedbfaad3d719b5e6a711834d2d06e2b0a172ce6fdadf84c640b6136914ed
sha256:38bac66034a6217abfd44b4a8a763b1a4c973045cae2763f2cc857baa5c9a872
sha256:54511612f1c4d97e93430fc3d5dc2f05dfbe8fb7e6259b7351deeca95eaf2971
sha256:a8e00546bcf3fc9ae1f33302c16a6d4c717d0a47a444581b5bcabc4757bcd79c
sha256:b4e78b89bcf31a38eab47da1b2b36235462e83beebacb7479d725367e76572cf
sha256:f7f45b9cb733af946532240cf7e6cde1278b687cd7094cf043b768c800cfdafd
```