### PR TITLE
fix a potential panic when map is nil

### DIFF
--- a/image.go
+++ b/image.go
@@ -80,10 +80,10 @@ func (i *image) Unpack(ctx context.Context, snapshotterName string) error {
 			if err != nil {
 				return err
 			}
+			if info.Labels == nil {
+				info.Labels = map[string]string{}
+			}
 			if info.Labels["containerd.io/uncompressed"] != layer.Diff.Digest.String() {
-				if info.Labels == nil {
-					info.Labels = map[string]string{}
-				}
 				info.Labels["containerd.io/uncompressed"] = layer.Diff.Digest.String()
 				if _, err := cs.Update(ctx, info, "labels.containerd.io/uncompressed"); err != nil {
 					return err


### PR DESCRIPTION
When `info.Labels` is nil, I think it would panic when try to get a value via key.
This PR fixes the potential panic.

Signed-off-by: Allen Sun <shlallen1990@gmail.com>