### PR TITLE
set `containerd.io/image.remote.ref` label to images and snapshots

### DIFF
--- a/client.go
+++ b/client.go
@@ -244,6 +244,13 @@ func (c *Client) Pull(ctx context.Context, ref string, opts ...RemoteOpts) (Imag
 	imgrec := images.Image{
 		Name:   name,
 		Target: desc,
+		// image.remote.* labels are propagated to the snapshotter. The snapshotter plugin MAY use this label.
+		// Future version MAY set "containerd.io/image.remote.resolver" explicitly as well.
+		// Note that we never set any credential here. (That is up to snapshotter implementation.)
+		Labels: map[string]string{
+			// NOTE: ref != name, see godoc for remotes.Resolver.Resolve()
+			"containerd.io/image.remote.ref": ref,
+		},
 	}
 
 	is := c.ImageService()

--- a/cmd/ctr/images.go
+++ b/cmd/ctr/images.go
@@ -32,12 +32,12 @@ var imagesListCommand = cli.Command{
 	Name:        "list",
 	Aliases:     []string{"ls"},
 	Usage:       "list images known to containerd",
-	ArgsUsage:   "[flags] <ref>",
+	ArgsUsage:   "[flags] <name>",
 	Description: `List images registered with containerd.`,
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "quiet, q",
-			Usage: "print only the image refs",
+			Usage: "print only the image names",
 		},
 	},
 	Action: func(clicontext *cli.Context) error {
@@ -67,7 +67,7 @@ var imagesListCommand = cli.Command{
 			return nil
 		}
 		tw := tabwriter.NewWriter(os.Stdout, 1, 8, 1, ' ', 0)
-		fmt.Fprintln(tw, "REF\tTYPE\tDIGEST\tSIZE\tPLATFORM\tLABELS\t")
+		fmt.Fprintln(tw, "NAME\tTYPE\tDIGEST\tSIZE\tPLATFORM\tLABELS\t")
 		for _, image := range imageList {
 			size, err := image.Size(ctx, cs, platforms.Default())
 			if err != nil {
@@ -180,7 +180,7 @@ var imageRemoveCommand = cli.Command{
 	Name:        "remove",
 	Aliases:     []string{"rm"},
 	Usage:       "Remove one or more images by reference.",
-	ArgsUsage:   "[flags] <ref> [<ref>, ...]",
+	ArgsUsage:   "[flags] <name> [<name>, ...]",
 	Description: `Remove one or more images by reference.`,
 	Flags:       []cli.Flag{},
 	Action: func(clicontext *cli.Context) error {

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -67,6 +67,8 @@ Some components are implemented on the client side for flexibility:
 
 - __*Distribution*__: Functions for pulling and pushing images
 
+See also [`client.md`](client.md).
+
 ## Data Flow
 
 As discussed above, the concept of a _bundle_ is central to containerd. Below

--- a/design/client.md
+++ b/design/client.md
@@ -1,0 +1,16 @@
+# Client
+
+Since containerd uses gRPC, it should be easy to implement 3rd-party containerd client in almost any language.
+However, 3rd-party client would need to reimplement pull&push interactions with remote registries, as these are not implemented on the daemon side.
+
+## Label conventions
+
+Client implementations SHOULD follow this labeling convention so as to promote compatibility across different implementations.
+
+Label                              | Object                       | Description
+-----------------------------------|------------------------------|--------------------------------------------------
+`containerd.io/uncompressed`       | Blob (compressed layer)      | Digest of uncompressed layer blob
+`containerd.io/image.remote.ref`   | Image, Snapshot              | Image reference string such as `docker.io/library/alpine:latest`. Snapshotter MAY utilize this for lazy-pulling some blobs.
+
+Future version MAY set `containerd.io/image.remote.resolver` explicitly as well.
+Note that we never set any credential here. (That is up to snapshotter implementation.)


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

This commit sets `containerd.io/image.remote.ref` label to images and corresponding snapshots.
e.g. `docker.io/library/alpine:latest`.
(Note that "image reference" differs from "image name": https://godoc.org/github.com/containerd/containerd/remotes#Resolver)

Future version MAY set `containerd.io/image.remote.resolver` explicitly as well, although we haven't decided any convention for resolver identifier string.
Note that we won't set any registry credential as labels.

## Usecase: continuity snapshotter plugin with lazy-pull feature

I'm working on a project that uses continuity manifest (== info for `getdents(2)` and `stat(2)`) as an image layer, instead of legacy tar balls.
On initial `client.Pull()` and `image.Unpack()`, only the continuity manifest is pulled and unpacked.
This enables running containers without pulling the whole rootfs blobs, and lazily pulling blobs on demand.

- POC (raw rootfs mounter without any containerd stuff): https://github.com/akihirosuda/filegrain
- Presentation at ContainerCon (OpenSource Summit) North America 2017: https://www.slideshare.net/AkihiroSuda/filegrain-transportagnostic-finegrained-contentaddressable-container-image-layout

@stevvooe suggested me to implement this as a containerd snapshotter (and differ and contentstore) plugin, and I found that such a plugin would need to get remote reference information  (`containerd.io/image.remote.ref`) from the client.

Note that the plugin can resolve the registry credential by itself in its own way, probably via plugin-specific entries in `/etc/containerd/config.toml`:
```toml
# executes `docker-crendial-foobar get` for resolving the credential
[plugins.continuity]
    dockerAuthResolvingMethod = "docker-credential-plugin"
    dockerConfigJSON = "/root/.docker/config.json"
```


cc @stevvooe @dmcgowan @tonistiigi
