### PR TITLE
readonly: pass RW rootfs to runtime, and let the runtime remount it as RO

### DIFF
--- a/spec_opts_unix.go
+++ b/spec_opts_unix.go
@@ -138,13 +138,24 @@ func WithImageConfig(i Image) SpecOpts {
 }
 
 // WithRootFSPath specifies unmanaged rootfs path.
-func WithRootFSPath(path string, readonly bool) SpecOpts {
+func WithRootFSPath(path string) SpecOpts {
 	return func(_ context.Context, _ *Client, _ *containers.Container, s *specs.Spec) error {
-		s.Root = &specs.Root{
-			Path:     path,
-			Readonly: readonly,
+		if s.Root == nil {
+			s.Root = &specs.Root{}
 		}
+		s.Root.Path = path
 		// Entrypoint is not set here (it's up to caller)
+		return nil
+	}
+}
+
+// WithRootFSReadonly sets specs.Root.Readonly to true
+func WithRootFSReadonly() SpecOpts {
+	return func(_ context.Context, _ *Client, _ *containers.Container, s *specs.Spec) error {
+		if s.Root == nil {
+			s.Root = &specs.Root{}
+		}
+		s.Root.Readonly = true
 		return nil
 	}
 }


### PR DESCRIPTION
This allows the runtime to creating extra mount points before remounting the rootfs as read-only.

Fix #1495 

cc @Random-Liu @crosbymichael @dmcgowan @stevvooe 

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>