### PR TITLE
remove field defaultns from struct Client

### DIFF
--- a/client.go
+++ b/client.go
@@ -100,10 +100,8 @@ func NewWithConn(conn *grpc.ClientConn, opts ...ClientOpt) (*Client, error) {
 // Client is the client to interact with containerd and its various services
 // using a uniform interface
 type Client struct {
-	conn *grpc.ClientConn
-
-	defaultns string
-	runtime   string
+	conn    *grpc.ClientConn
+	runtime string
 }
 
 // IsServing returns true if the client can successfully connect to the


### PR DESCRIPTION
I found that we did not use `defaultns` in Client struct. So I try to remove this.

And feel free to correct me if i was wrong.

Signed-off-by: Allen Sun <shlallen1990@gmail.com>