### PR TITLE
make sure we decouple "image reference" from "image name"

### DIFF
--- a/client.go
+++ b/client.go
@@ -539,7 +539,7 @@ func WithRefObject(refObject string) ImportOpt {
 	}
 }
 
-func resolveImportOpt(ref string, opts ...ImportOpt) (importOpts, error) {
+func resolveImportOpt(name string, opts ...ImportOpt) (importOpts, error) {
 	var iopts importOpts
 	for _, o := range opts {
 		if err := o(&iopts); err != nil {
@@ -550,9 +550,9 @@ func resolveImportOpt(ref string, opts ...ImportOpt) (importOpts, error) {
 	if iopts.format == "" {
 		iopts.format = ociImageFormat
 	}
-	// if refObject is not explicitly specified, use the one specified in ref
+	// if refObject is not explicitly specified, use the one specified in the (ref-compatible) name string
 	if iopts.refObject == "" {
-		refSpec, err := reference.Parse(ref)
+		refSpec, err := reference.Parse(name)
 		if err != nil {
 			return iopts, err
 		}
@@ -565,14 +565,14 @@ func resolveImportOpt(ref string, opts ...ImportOpt) (importOpts, error) {
 // OCI format is assumed by default.
 //
 // Note that unreferenced blobs are imported to the content store as well.
-func (c *Client) Import(ctx context.Context, ref string, reader io.Reader, opts ...ImportOpt) (Image, error) {
-	iopts, err := resolveImportOpt(ref, opts...)
+func (c *Client) Import(ctx context.Context, name string, reader io.Reader, opts ...ImportOpt) (Image, error) {
+	iopts, err := resolveImportOpt(name, opts...)
 	if err != nil {
 		return nil, err
 	}
 	switch iopts.format {
 	case ociImageFormat:
-		return c.importFromOCITar(ctx, ref, reader, iopts)
+		return c.importFromOCITar(ctx, name, reader, iopts)
 	default:
 		return nil, errors.Errorf("unsupported format: %s", iopts.format)
 	}

--- a/cmd/ctr/images.go
+++ b/cmd/ctr/images.go
@@ -32,12 +32,12 @@ var imagesListCommand = cli.Command{
 	Name:        "list",
 	Aliases:     []string{"ls"},
 	Usage:       "list images known to containerd",
-	ArgsUsage:   "[flags] <ref>",
+	ArgsUsage:   "[flags] <name>",
 	Description: `List images registered with containerd.`,
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "quiet, q",
-			Usage: "print only the image refs",
+			Usage: "print only the image names",
 		},
 	},
 	Action: func(clicontext *cli.Context) error {
@@ -67,7 +67,7 @@ var imagesListCommand = cli.Command{
 			return nil
 		}
 		tw := tabwriter.NewWriter(os.Stdout, 1, 8, 1, ' ', 0)
-		fmt.Fprintln(tw, "REF\tTYPE\tDIGEST\tSIZE\tPLATFORM\tLABELS\t")
+		fmt.Fprintln(tw, "NAME\tTYPE\tDIGEST\tSIZE\tPLATFORM\tLABELS\t")
 		for _, image := range imageList {
 			size, err := image.Size(ctx, cs, platforms.Default())
 			if err != nil {
@@ -179,9 +179,9 @@ var imagesSetLabelsCommand = cli.Command{
 var imageRemoveCommand = cli.Command{
 	Name:        "remove",
 	Aliases:     []string{"rm"},
-	Usage:       "Remove one or more images by reference.",
-	ArgsUsage:   "[flags] <ref> [<ref>, ...]",
-	Description: `Remove one or more images by reference.`,
+	Usage:       "Remove one or more images.",
+	ArgsUsage:   "[flags] <name> [<name>, ...]",
+	Description: `Remove one or more images.`,
 	Flags:       []cli.Flag{},
 	Action: func(clicontext *cli.Context) error {
 		var (

--- a/import.go
+++ b/import.go
@@ -34,7 +34,7 @@ func resolveOCIIndex(idx ocispec.Index, refObject string) (*ocispec.Descriptor, 
 	return nil, errors.Errorf("not found: %q", refObject)
 }
 
-func (c *Client) importFromOCITar(ctx context.Context, ref string, reader io.Reader, iopts importOpts) (Image, error) {
+func (c *Client) importFromOCITar(ctx context.Context, name string, reader io.Reader, iopts importOpts) (Image, error) {
 	tr := tar.NewReader(reader)
 	store := c.ContentStore()
 	var desc *ocispec.Descriptor
@@ -66,7 +66,7 @@ func (c *Client) importFromOCITar(ctx context.Context, ref string, reader io.Rea
 		return nil, errors.Errorf("no descriptor found for reference object %q", iopts.refObject)
 	}
 	imgrec := images.Image{
-		Name:   ref,
+		Name:   name,
 		Target: *desc,
 		Labels: iopts.labels,
 	}


### PR DESCRIPTION
See godoc of `containerd/remotes.Resolver.Resolve()`
https://github.com/containerd/containerd/blob/5615b68f0697dfe5cbb50d58c1f403de224d3a2f/remotes/resolver.go#L13-L23

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>