### PR TITLE
Remove stray entry for Azure/go-ansiterm from vendor.conf

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -38,7 +38,6 @@ github.com/Microsoft/go-winio v0.4.4
 github.com/Microsoft/hcsshim v0.6.3
 github.com/Microsoft/opengcs v0.3.2
 github.com/boltdb/bolt e9cf4fae01b5a8ff89d0ec6b32f0d9c9f79aefdd
-github.com/Azure/go-ansiterm 19f72df4d05d31cbe1c56bfc8045c96babff6c7e
 google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
 golang.org/x/text 19e51611da83d6be54ddafce4a4af510cb3e9ea4
 github.com/dmcgowan/go-tar 2e2c51242e8993c50445dab7c03c8e7febddd0cf


### PR DESCRIPTION
go-ansiterm is no longer used since commit cf2c4609bdc2 ("Bump runc with
console change for ONLCR") but for some reason there was a second entry
in vendor.conf. Remove it as well.

This fixes the following warning when running vndr:

  WARNING: package github.com/Azure/go-ansiterm is unused, consider removing it from vendor.conf

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>