### PR TITLE
shim: create workdir if it does not exist

### DIFF
--- a/cmd/ctr/run.go
+++ b/cmd/ctr/run.go
@@ -89,6 +89,10 @@ var runCommand = cli.Command{
 			Name:  "checkpoint",
 			Usage: "provide the checkpoint digest to restore the container",
 		},
+		cli.StringFlag{
+			Name:  "workdir",
+			Usage: "working directory of the process",
+		},
 	}, snapshotterFlags...),
 	Action: func(context *cli.Context) error {
 		var (

--- a/cmd/ctr/run_unix.go
+++ b/cmd/ctr/run_unix.go
@@ -107,6 +107,9 @@ func newContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 	if len(args) > 0 {
 		opts = append(opts, containerd.WithProcessArgs(args...))
 	}
+	if workdir := context.String("workdir"); workdir != "" {
+		opts = append(opts, containerd.WithProcessCwd(workdir))
+	}
 	if context.Bool("tty") {
 		opts = append(opts, withTTY())
 	}

--- a/cmd/ctr/run_windows.go
+++ b/cmd/ctr/run_windows.go
@@ -107,7 +107,9 @@ func newContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 	if len(args) > 0 {
 		opts = append(opts, containerd.WithProcessArgs(args...))
 	}
-
+	if workdir := context.String("workdir"); workdir != "" {
+		opts = append(opts, containerd.WithProcessCwd(workdir))
+	}
 	return client.NewContainer(ctx, id,
 		containerd.WithNewSpec(opts...),
 		containerd.WithContainerLabels(labels),

--- a/spec_opts.go
+++ b/spec_opts.go
@@ -19,6 +19,14 @@ func WithProcessArgs(args ...string) SpecOpts {
 	}
 }
 
+// WithProcessCwd replaces the current working directory on the generated spec
+func WithProcessCwd(cwd string) SpecOpts {
+	return func(_ context.Context, _ *Client, _ *containers.Container, s *specs.Spec) error {
+		s.Process.Cwd = cwd
+		return nil
+	}
+}
+
 // WithHostname sets the container's hostname
 func WithHostname(name string) SpecOpts {
 	return func(_ context.Context, _ *Client, _ *containers.Container, s *specs.Spec) error {


### PR DESCRIPTION
This PR let shim to create the workdir when it does not exist, as in `docker run --workdir` and Dockerfile  `WORKDIR`.

BuildKit (https://github.com/moby/buildkit/issues/121) requires this.

How to test:
- `ctr run -t --rm --workdir /foobar  docker.io/library/alpine:latest foo pwd`
- `ctr run -t --rm --workdir /foobar --readonly  docker.io/library/alpine:latest foo pwd`
- `ctr run -t --rm --workdir /../../../../../../../../../../../../../HACKED  docker.io/library/alpine:latest foo ls -ld /HACKED` (Make sure it doesn't create `/HACKED` on the host)

cc @tonistiigi @crosbymichael @dmcgowan 