### PR TITLE
Collect cgroup stats one last time before exit

### DIFF
--- a/metrics/cgroups/cgroups.go
+++ b/metrics/cgroups/cgroups.go
@@ -71,7 +71,7 @@ func (m *cgroupsMonitor) Monitor(c runtime.Task) error {
 func (m *cgroupsMonitor) Stop(c runtime.Task) error {
 	info := c.Info()
 	t := c.(*linux.Task)
-	m.collector.collect(info.ID, info.Namespace, t.Cgroup(), m.collector.storedMetrics, nil)
+	m.collector.collect(info.ID, info.Namespace, t.Cgroup(), m.collector.storedMetrics, false, nil)
 	m.collector.Remove(info.ID, info.Namespace)
 	return nil
 }

--- a/metrics/cgroups/cgroups.go
+++ b/metrics/cgroups/cgroups.go
@@ -70,6 +70,8 @@ func (m *cgroupsMonitor) Monitor(c runtime.Task) error {
 
 func (m *cgroupsMonitor) Stop(c runtime.Task) error {
 	info := c.Info()
+	t := c.(*linux.Task)
+	m.collector.collect(info.ID, info.Namespace, t.Cgroup(), m.collector.storedMetrics, nil)
 	m.collector.Remove(info.ID, info.Namespace)
 	return nil
 }

--- a/metrics/cgroups/metric.go
+++ b/metrics/cgroups/metric.go
@@ -28,13 +28,18 @@ func (m *metric) desc(ns *metrics.Namespace) *prometheus.Desc {
 	return ns.NewDesc(m.name, m.help, m.unit, append([]string{"container_id", "namespace"}, m.labels...)...)
 }
 
-func (m *metric) collect(id, namespace string, stats *cgroups.Metrics, ns *metrics.Namespace, ch chan<- prometheus.Metric) {
+func (m *metric) collect(id, namespace string, stats *cgroups.Metrics, ns *metrics.Namespace, ch chan<- prometheus.Metric, block bool) {
 	values := m.getValues(stats)
 	for _, v := range values {
+		// block signals to block on the sending the metrics so none are missed
+		if block {
+			ch <- prometheus.MustNewConstMetric(m.desc(ns), m.vt, v.v, append([]string{id, namespace}, v.l...)...)
+			continue
+		}
+		// non-blocking metrics can be dropped if the chan is full
 		select {
 		case ch <- prometheus.MustNewConstMetric(m.desc(ns), m.vt, v.v, append([]string{id, namespace}, v.l...)...):
 		default:
-			break
 		}
 	}
 }

--- a/metrics/cgroups/metric.go
+++ b/metrics/cgroups/metric.go
@@ -31,6 +31,10 @@ func (m *metric) desc(ns *metrics.Namespace) *prometheus.Desc {
 func (m *metric) collect(id, namespace string, stats *cgroups.Metrics, ns *metrics.Namespace, ch chan<- prometheus.Metric) {
 	values := m.getValues(stats)
 	for _, v := range values {
-		ch <- prometheus.MustNewConstMetric(m.desc(ns), m.vt, v.v, append([]string{id, namespace}, v.l...)...)
+		select {
+		case ch <- prometheus.MustNewConstMetric(m.desc(ns), m.vt, v.v, append([]string{id, namespace}, v.l...)...):
+		default:
+			break
+		}
 	}
 }


### PR DESCRIPTION
This is in the same spirit as #782, but using the prometheus API and cgroups stats instead of rusage results.

This commit adds a collection step in the Stop() task handler which will retrieve the metrics available for this container at that time, and store them until the next prometheus Collect() cycle.

This allows short-lived containers to be visible in prometheus, which would otherwise be ignored (for example, running containerd-stress would show something like 2 or 3 containers in the end, while now we can see all of them). It also allows for more accurate collection when long-running containers end (for example CPU usage could spike in the last few seconds).

A simple case illustrating this with cpu usage would be:
`ctr run -t --rm docker.io/library/alpine:latest mycontainer sh -c 'yes > /dev/null & sleep 3 && pkill yes'`

Signed-off-by: Mathieu Pasquet <mathieu.pasquet@alterway.fr>