### PR TITLE
Add an option to prevent putting the shim in a new mount namespace

### DIFF
--- a/container_test.go
+++ b/container_test.go
@@ -1216,9 +1216,9 @@ func TestContainerExitedAtSet(t *testing.T) {
 	}
 
 	status := <-statusC
-	code, _, _ := status.Result()
+	code, _, err := status.Result()
 	if code != 0 {
-		t.Errorf("expected status 0 but received %d", code)
+		t.Errorf("expected status 0 but received %d (err: %v)", code, err)
 	}
 
 	if s, err := task.Status(ctx); err != nil {

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -212,4 +212,7 @@ The linux runtime allows a few options to be set to configure the shim and the r
 	no_shim = false
 	# display shim logs in the containerd daemon's log output
 	shim_debug = true
+	# do not put the shim in its own mount namespace
+	# (this only need to be set on kernel < 3.18)
+	shim_no_newns = true
 ```

--- a/linux/bundle.go
+++ b/linux/bundle.go
@@ -73,10 +73,10 @@ type bundle struct {
 type shimOpt func(*bundle, string, *runcopts.RuncOptions) (client.Config, client.ClientOpt)
 
 // ShimRemote is a shimOpt for connecting and starting a remote shim
-func ShimRemote(shim, daemonAddress, cgroup string, debug bool, exitHandler func()) shimOpt {
+func ShimRemote(shim, daemonAddress, cgroup string, nonewns, debug bool, exitHandler func()) shimOpt {
 	return func(b *bundle, ns string, ropts *runcopts.RuncOptions) (client.Config, client.ClientOpt) {
 		return b.shimConfig(ns, ropts),
-			client.WithStart(shim, b.shimAddress(ns), daemonAddress, cgroup, debug, exitHandler)
+			client.WithStart(shim, b.shimAddress(ns), daemonAddress, cgroup, nonewns, debug, exitHandler)
 	}
 }
 

--- a/linux/shim/client_linux.go
+++ b/linux/shim/client_linux.go
@@ -10,9 +10,14 @@ import (
 	"github.com/pkg/errors"
 )
 
-var atter = syscall.SysProcAttr{
-	Cloneflags: syscall.CLONE_NEWNS,
-	Setpgid:    true,
+func getSysProcAttr(nonewns bool) *syscall.SysProcAttr {
+	attr := syscall.SysProcAttr{
+		Setpgid: true,
+	}
+	if !nonewns {
+		attr.Cloneflags = syscall.CLONE_NEWNS
+	}
+	return &attr
 }
 
 func setCgroup(cgroupPath string, cmd *exec.Cmd) error {

--- a/linux/shim/client_unix.go
+++ b/linux/shim/client_unix.go
@@ -7,8 +7,10 @@ import (
 	"syscall"
 )
 
-var atter = syscall.SysProcAttr{
-	Setpgid: true,
+func getSysProcAttr(nonewns bool) *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		Setpgid: true,
+	}
 }
 
 func setCgroup(cgroupPath string, cmd *exec.Cmd) error {


### PR DESCRIPTION
This is needed for users on kernel older than 3.18 so they can avoid EBUSY
errors when trying to unlink, rename or remove a mountpoint that is present in
a shim namespace.

Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>