### PR TITLE
DOCS ONLY: dest vs dst typo in ctr help output

### DIFF
--- a/cmd/ctr/run.go
+++ b/cmd/ctr/run.go
@@ -71,7 +71,7 @@ var runCommand = cli.Command{
 		},
 		cli.StringSliceFlag{
 			Name:  "mount",
-			Usage: "specify additional container mount (ex: type=bind,src=/tmp,dest=/host,options=rbind:ro)",
+			Usage: "specify additional container mount (ex: type=bind,src=/tmp,dst=/host,options=rbind:ro)",
 		},
 		cli.StringSliceFlag{
 			Name:  "env",


### PR DESCRIPTION
dest is not valid for --mount options, correct usage is `dst=/path`.