### PR TITLE
style: move definition for consistency

### DIFF
--- a/container.go
+++ b/container.go
@@ -17,9 +17,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// DeleteOpts allows the caller to set options for the deletion of a container
-type DeleteOpts func(context.Context, *Client, containers.Container) error
-
 // Container is a metadata object for container resources and task creation
 type Container interface {
 	// ID identifies the container

--- a/container_opts.go
+++ b/container_opts.go
@@ -12,6 +12,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// DeleteOpts allows the caller to set options for the deletion of a container
+type DeleteOpts func(ctx context.Context, client *Client, c containers.Container) error
+
 // NewContainerOpts allows the caller to set additional options when creating a container
 type NewContainerOpts func(ctx context.Context, client *Client, c *containers.Container) error
 


### PR DESCRIPTION
Stupid little patch.  I refrained from renaming `DeleteOpts` to `DeleteContainerOpts` and explore the `*containers.Container` vs `containers.Container` thingy.
