### PR TITLE
sync container metadata before operations

### DIFF
--- a/cmd/ctr/attach.go
+++ b/cmd/ctr/attach.go
@@ -24,7 +24,7 @@ var taskAttachCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		spec, err := container.Spec()
+		spec, err := container.Spec(ctx)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/containers.go
+++ b/cmd/ctr/containers.go
@@ -49,15 +49,18 @@ var containersCommand = cli.Command{
 		w := tabwriter.NewWriter(os.Stdout, 4, 8, 4, ' ', 0)
 		fmt.Fprintln(w, "CONTAINER\tIMAGE\tRUNTIME\t")
 		for _, c := range containers {
-			imageName := c.Info().Image
+			info, err := c.Info(ctx)
+			if err != nil {
+				return err
+			}
+			imageName := info.Image
 			if imageName == "" {
 				imageName = "-"
 			}
-			record := c.Info()
 			if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t\n",
 				c.ID(),
 				imageName,
-				record.Runtime.Name,
+				info.Runtime.Name,
 			); err != nil {
 				return err
 			}

--- a/cmd/ctr/exec.go
+++ b/cmd/ctr/exec.go
@@ -47,7 +47,7 @@ var taskExecCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		spec, err := container.Spec()
+		spec, err := container.Spec(ctx)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/info.go
+++ b/cmd/ctr/info.go
@@ -28,7 +28,11 @@ var containerInfoCommand = cli.Command{
 			return err
 		}
 
-		printAsJSON(container.Info())
+		info, err := container.Info(ctx)
+		if err != nil {
+			return err
+		}
+		printAsJSON(info)
 
 		return nil
 	},

--- a/cmd/ctr/start.go
+++ b/cmd/ctr/start.go
@@ -34,7 +34,7 @@ var taskStartCommand = cli.Command{
 			return err
 		}
 
-		spec, err := container.Spec()
+		spec, err := container.Spec(ctx)
 		if err != nil {
 			return err
 		}

--- a/container_linux_test.go
+++ b/container_linux_test.go
@@ -513,7 +513,7 @@ func TestContainerAttachProcess(t *testing.T) {
 		return
 	}
 
-	spec, err := container.Spec()
+	spec, err := container.Spec(ctx)
 	if err != nil {
 		t.Error(err)
 		return

--- a/container_test.go
+++ b/container_test.go
@@ -71,7 +71,7 @@ func TestNewContainer(t *testing.T) {
 	if container.ID() != id {
 		t.Errorf("expected container id %q but received %q", id, container.ID())
 	}
-	if _, err = container.Spec(); err != nil {
+	if _, err = container.Spec(ctx); err != nil {
 		t.Error(err)
 		return
 	}
@@ -268,7 +268,7 @@ func TestContainerExec(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	spec, err := container.Spec()
+	spec, err := container.Spec(ctx)
 	if err != nil {
 		t.Error(err)
 		return
@@ -679,7 +679,7 @@ func TestContainerExecNoBinaryExists(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	spec, err := container.Spec()
+	spec, err := container.Spec(ctx)
 	if err != nil {
 		t.Error(err)
 		return
@@ -910,7 +910,7 @@ func TestWaitStoppedProcess(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	spec, err := container.Spec()
+	spec, err := container.Spec(ctx)
 	if err != nil {
 		t.Error(err)
 		return
@@ -1059,7 +1059,7 @@ func TestProcessForceDelete(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	spec, err := container.Spec()
+	spec, err := container.Spec(ctx)
 	if err != nil {
 		t.Error(err)
 		return
@@ -1283,7 +1283,7 @@ func TestDeleteContainerExecCreated(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	spec, err := container.Spec()
+	spec, err := container.Spec(ctx)
 	if err != nil {
 		t.Error(err)
 		return
@@ -1460,7 +1460,11 @@ func TestContainerExtensions(t *testing.T) {
 	defer container.Delete(ctx)
 
 	checkExt := func(container Container) {
-		cExts := container.Extensions()
+		cExts, err := container.Extensions(ctx)
+		if err != nil {
+			t.Error(err)
+			return
+		}
 		if len(cExts) != 1 {
 			t.Errorf("expected 1 container extension")
 		}
@@ -1502,7 +1506,7 @@ func TestContainerUpdate(t *testing.T) {
 	}
 	defer container.Delete(ctx)
 
-	spec, err := container.Spec()
+	spec, err := container.Spec(ctx)
 	if err != nil {
 		t.Error(err)
 		return
@@ -1522,7 +1526,7 @@ func TestContainerUpdate(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	if spec, err = container.Spec(); err != nil {
+	if spec, err = container.Spec(ctx); err != nil {
 		t.Error(err)
 		return
 	}


### PR DESCRIPTION
This makes sure the client is always in sync with the server before
performing any type of operations on the container metadata.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>