### PR TITLE
Fix task load.

### DIFF
--- a/metrics/cgroups/cgroups.go
+++ b/metrics/cgroups/cgroups.go
@@ -62,10 +62,14 @@ type cgroupsMonitor struct {
 func (m *cgroupsMonitor) Monitor(c runtime.Task) error {
 	info := c.Info()
 	t := c.(*linux.Task)
-	if err := m.collector.Add(info.ID, info.Namespace, t.Cgroup()); err != nil {
+	cg, err := t.Cgroup()
+	if err != nil {
 		return err
 	}
-	return m.oom.Add(info.ID, info.Namespace, t.Cgroup(), m.trigger)
+	if err := m.collector.Add(info.ID, info.Namespace, cg); err != nil {
+		return err
+	}
+	return m.oom.Add(info.ID, info.Namespace, cg, m.trigger)
 }
 
 func (m *cgroupsMonitor) Stop(c runtime.Task) error {

--- a/services/tasks/service.go
+++ b/services/tasks/service.go
@@ -519,7 +519,9 @@ func getTasksMetrics(ctx context.Context, filter filters.Filter, tasks []runtime
 		collected := time.Now()
 		metrics, err := tk.Metrics(ctx)
 		if err != nil {
-			log.G(ctx).WithError(err).Errorf("collecting metrics for %s", tk.ID())
+			if !errdefs.IsNotFound(err) {
+				log.G(ctx).WithError(err).Errorf("collecting metrics for %s", tk.ID())
+			}
 			continue
 		}
 		data, err := typeurl.MarshalAny(metrics)

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,7 +1,7 @@
 github.com/coreos/go-systemd 48702e0da86bd25e76cfef347e2adeb434a0d0a6
 github.com/containerd/go-runc b3c048c028ddd789c6f9510c597f8b9c62f25359
 github.com/containerd/console 84eeaae905fa414d03e07bcd6c8d3f19e7cf180e
-github.com/containerd/cgroups 5933ab4dc4f7caa3a73a1dc141bd11f42b5c9163
+github.com/containerd/cgroups 9c238e632e80d94f71a067c3deb9b34b1886ef18
 github.com/containerd/typeurl f6943554a7e7e88b3c14aad190bf05932da84788
 github.com/docker/go-metrics 8fd5772bf1584597834c6f7961a530f06cbfbb87
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9

--- a/vendor/github.com/containerd/cgroups/cgroup.go
+++ b/vendor/github.com/containerd/cgroups/cgroup.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
 )
 
 // New returns a new control via the cgroup cgroups interface
@@ -39,6 +40,9 @@ func Load(hierarchy Hierarchy, path Path) (Cgroup, error) {
 	for _, s := range pathers(subsystems) {
 		p, err := path(s.Name())
 		if err != nil {
+			if os.IsNotExist(errors.Cause(err)) {
+				return nil, ErrCgroupDeleted
+			}
 			return nil, err
 		}
 		if _, err := os.Lstat(s.Path(p)); err != nil {


### PR DESCRIPTION
Rely on https://github.com/containerd/cgroups/pull/30.

Currently, after runc container exits, the cgroups will be gone, and `cgroups.Load` will always return error.

This means that we'll never be able to reload a stopped `Task`:
```
ERRO[0000] loading task type                             error="parse cgroup file /proc/14651/cgroup: open /proc/14651/cgroup: no such file or directory" module="containerd/io.containerd.runtime.v1.linux"
ERRO[0000] loading task type                             error="parse cgroup file /proc/5311/cgroup: open /proc/5311/cgroup: no such file or directory" module="containerd/io.containerd.runtime.v1.linux"
```

This PR ignores `cgroups.ErrCgroupDeleted` and fixes other places correspondingly.

Actually, it would be ideal if `Metrics` could always return `ErrNotFound` after runc container dies, but that is not the case today even with this PR.

Signed-off-by: Lantao Liu <lantaol@google.com>