### PR TITLE
spec: set MaskedPaths and ReadOnlyPaths by default

### DIFF
--- a/spec_unix.go
+++ b/spec_unix.go
@@ -136,6 +136,24 @@ func createDefaultSpec() (*specs.Spec, error) {
 			},
 		},
 		Linux: &specs.Linux{
+			// TODO (AkihiroSuda): unmask /sys/firmware on Windows daemon for LCOW support?
+			// https://github.com/moby/moby/pull/33241/files#diff-a1f5051ce84e711a2ee688ab9ded5e74R215
+			MaskedPaths: []string{
+				"/proc/kcore",
+				"/proc/latency_stats",
+				"/proc/timer_list",
+				"/proc/timer_stats",
+				"/proc/sched_debug",
+				"/sys/firmware",
+			},
+			ReadonlyPaths: []string{
+				"/proc/asound",
+				"/proc/bus",
+				"/proc/fs",
+				"/proc/irq",
+				"/proc/sys",
+				"/proc/sysrq-trigger",
+			},
 			// TODO (@crosbymichael) make sure we don't have have two containers in the same cgroup
 			Resources: &specs.LinuxResources{
 				Devices: []specs.LinuxDeviceCgroup{


### PR DESCRIPTION
The current containerd doesn't set `maskedPaths` and `readonlyPaths` on OCI spec generation by default, and causing some security issues:

- Containers can invoke `echo c > /proc/sysrq-trigger` (panic)
- Containers can steal firmware info (e.g. iSCSI credential, Windows OEM license keys) from `/sys/firmware`
- And more...


This PR adds `maskedPaths` and `readonlyPaths` by default, but generally client applications are responsible to generate appropriate spec, depending on their own security requirement.


The added values correspond to https://github.com/opencontainers/runc/blob/c795b8690b1afec38e4a3d3a96a4f45c0e2198b9/libcontainer/specconv/example.go and https://github.com/moby/moby/blob/285bc997311b75263bfac9e8ff7c4d60cdeca0bc/oci/defaults.go#L220


Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>