### PR TITLE
[WIP] Implement Windows snapshotter and differ

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -61,6 +61,8 @@ func TestMain(m *testing.M) {
 	)
 	defer cancel()
 
+	fmt.Println("About to start daemon")
+
 	if !noDaemon {
 		os.RemoveAll(defaultRoot)
 
@@ -75,6 +77,8 @@ func TestMain(m *testing.M) {
 		}
 	}
 
+	fmt.Println("Waiting for dameon to start")
+
 	waitCtx, waitCancel := context.WithTimeout(ctx, 2*time.Second)
 	client, err := ctrd.waitForStart(waitCtx)
 	waitCancel()
@@ -84,6 +88,8 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "%s: %s\n", err, buf.String())
 		os.Exit(1)
 	}
+
+	fmt.Println("Daemon started")
 
 	// print out the version in information
 	version, err := client.Version(ctx)
@@ -99,17 +105,10 @@ func TestMain(m *testing.M) {
 	}).Info("running tests against containerd")
 
 	// pull a seed image
-	if runtime.GOOS != "windows" { // TODO: remove once pull is supported on windows
-		if _, err = client.Pull(ctx, testImage, WithPullUnpack); err != nil {
-			ctrd.Stop()
-			ctrd.Wait()
-			fmt.Fprintf(os.Stderr, "%s: %s\n", err, buf.String())
-			os.Exit(1)
-		}
-	}
-
-	if err := platformTestSetup(client); err != nil {
-		fmt.Fprintln(os.Stderr, "platform test setup failed", err)
+	if _, err = client.Pull(ctx, testImage, WithPullUnpack); err != nil {
+		ctrd.Stop()
+		ctrd.Wait()
+		fmt.Fprintf(os.Stderr, "%s: %s\n", err, buf.String())
 		os.Exit(1)
 	}
 

--- a/client_unix_test.go
+++ b/client_unix_test.go
@@ -16,10 +16,6 @@ var (
 	testImage string
 )
 
-func platformTestSetup(client *Client) error {
-	return nil
-}
-
 func init() {
 	switch runtime.GOARCH {
 	case "386":

--- a/client_windows_test.go
+++ b/client_windows_test.go
@@ -1,12 +1,8 @@
 package containerd
 
 import (
-	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -15,74 +11,6 @@ const (
 )
 
 var (
-	dockerLayerFolders []string
-
 	defaultRoot  = filepath.Join(os.Getenv("programfiles"), "containerd", "root-test")
 	defaultState = filepath.Join(os.Getenv("programfiles"), "containerd", "state-test")
 )
-
-func platformTestSetup(client *Client) error {
-	var (
-		roots       []string
-		layerChains = make(map[string]string)
-	)
-	// Since we can't pull images yet, we'll piggyback on the default
-	// docker's images
-	wfPath := `C:\ProgramData\docker\windowsfilter`
-	wf, err := os.Open(wfPath)
-	if err != nil {
-		return errors.Wrapf(err, "failed to access docker layers @ %s", wfPath)
-	}
-	defer wf.Close()
-	entries, err := wf.Readdirnames(0)
-	if err != nil {
-		return errors.Wrapf(err, "failed to read %s entries", wfPath)
-	}
-
-	for _, fn := range entries {
-		layerChainPath := filepath.Join(wfPath, fn, "layerchain.json")
-		lfi, err := os.Stat(layerChainPath)
-		switch {
-		case err == nil && lfi.Mode().IsRegular():
-			f, err := os.OpenFile(layerChainPath, os.O_RDONLY, 0660)
-			if err != nil {
-				fmt.Fprintln(os.Stderr,
-					errors.Wrapf(err, "failed to open %s", layerChainPath))
-				continue
-			}
-			defer f.Close()
-			l := make([]string, 0)
-			if err := json.NewDecoder(f).Decode(&l); err != nil {
-				fmt.Fprintln(os.Stderr,
-					errors.Wrapf(err, "failed to decode %s", layerChainPath))
-				continue
-			}
-			switch {
-			case len(l) == 1:
-				layerChains[l[0]] = filepath.Join(wfPath, fn)
-			case len(l) > 1:
-				fmt.Fprintf(os.Stderr, "Too many entries in %s: %d", layerChainPath, len(l))
-			case len(l) == 0:
-				roots = append(roots, filepath.Join(wfPath, fn))
-			}
-		case os.IsNotExist(err):
-			// keep on going
-		default:
-			return errors.Wrapf(err, "error trying to access %s", layerChainPath)
-		}
-	}
-
-	// They'll be 2 roots, just take the first one
-	l := roots[0]
-	dockerLayerFolders = append(dockerLayerFolders, l)
-	for {
-		l = layerChains[l]
-		if l == "" {
-			break
-		}
-
-		dockerLayerFolders = append([]string{l}, dockerLayerFolders...)
-	}
-
-	return nil
-}

--- a/cmd/containerd/builtins_windows.go
+++ b/cmd/containerd/builtins_windows.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	_ "github.com/containerd/containerd/differ/windowsdiffer"
 	_ "github.com/containerd/containerd/snapshot/windows"
 	_ "github.com/containerd/containerd/windows"
 )

--- a/cmd/ctr/run_windows.go
+++ b/cmd/ctr/run_windows.go
@@ -7,34 +7,14 @@ import (
 	"github.com/containerd/console"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/containers"
-	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
 	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
 const pipeRoot = `\\.\pipe`
-
-func init() {
-	runCommand.Flags = append(runCommand.Flags, cli.StringSliceFlag{
-		Name:  "layer",
-		Usage: "HCSSHIM Layers to be used",
-	})
-}
-
-func withLayers(context *cli.Context) containerd.SpecOpts {
-	return func(ctx gocontext.Context, client *containerd.Client, c *containers.Container, s *specs.Spec) error {
-		l := context.StringSlice("layer")
-		if l == nil {
-			return errors.Wrap(errdefs.ErrInvalidArgument, "base layers must be specified with `--layer`")
-		}
-		s.Windows.LayerFolders = l
-		return nil
-	}
-}
 
 func handleConsoleResize(ctx gocontext.Context, task resizer, con console.Console) error {
 	// do an initial resize of the console
@@ -86,7 +66,7 @@ func setHostNetworking() containerd.SpecOpts {
 
 func newContainer(ctx gocontext.Context, client *containerd.Client, context *cli.Context) (containerd.Container, error) {
 	var (
-		// ref          = context.Args().First()
+		ref          = context.Args().First()
 		id           = context.Args().Get(1)
 		args         = context.Args()[2:]
 		tty          = context.Bool("tty")
@@ -95,11 +75,13 @@ func newContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 
 	labels := labelArgs(labelStrings)
 
-	// TODO(mlaventure): get base image once we have a snapshotter
+	image, err := client.GetImage(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
 
 	opts := []containerd.SpecOpts{
-		// TODO(mlaventure): use containerd.WithImageConfig once we have a snapshotter
-		withLayers(context),
+		containerd.WithImageConfig(image),
 		withEnv(context),
 		withMounts(context),
 		withTTY(tty),
@@ -114,7 +96,9 @@ func newContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 		containerd.WithNewSpec(opts...),
 		containerd.WithContainerLabels(labels),
 		containerd.WithRuntime(context.String("runtime"), nil),
-		// TODO(mlaventure): containerd.WithImage(image),
+		containerd.WithImage(image),
+		containerd.WithSnapshotter(context.String("snapshotter")),
+		containerd.WithNewSnapshot(id, image),
 	)
 }
 

--- a/container_linux_test.go
+++ b/container_linux_test.go
@@ -198,7 +198,7 @@ func TestDaemonRestart(t *testing.T) {
 		return
 	}
 
-	container, err := client.NewContainer(ctx, id, WithNewSpec(withImageConfig(image), withProcessArgs("sleep", "30")), withNewSnapshot(id, image))
+	container, err := client.NewContainer(ctx, id, WithNewSpec(WithImageConfig(image), withProcessArgs("sleep", "30")), WithNewSnapshot(id, image))
 	if err != nil {
 		t.Error(err)
 		return
@@ -283,7 +283,7 @@ func TestContainerAttach(t *testing.T) {
 		return
 	}
 
-	container, err := client.NewContainer(ctx, id, WithNewSpec(withImageConfig(image), withCat()), withNewSnapshot(id, image))
+	container, err := client.NewContainer(ctx, id, WithNewSpec(WithImageConfig(image), withCat()), WithNewSnapshot(id, image))
 	if err != nil {
 		t.Error(err)
 		return
@@ -405,8 +405,8 @@ func TestContainerUsername(t *testing.T) {
 
 	// squid user in the alpine image has a uid of 31
 	container, err := client.NewContainer(ctx, id,
-		withNewSnapshot(id, image),
-		WithNewSpec(withImageConfig(image), WithUsername("squid"), WithProcessArgs("id", "-u")),
+		WithNewSnapshot(id, image),
+		WithNewSpec(WithImageConfig(image), WithUsername("squid"), WithProcessArgs("id", "-u")),
 	)
 	if err != nil {
 		t.Error(err)
@@ -470,7 +470,7 @@ func TestContainerAttachProcess(t *testing.T) {
 		return
 	}
 
-	container, err := client.NewContainer(ctx, id, WithNewSpec(withImageConfig(image), withProcessArgs("sleep", "100")), withNewSnapshot(id, image))
+	container, err := client.NewContainer(ctx, id, WithNewSpec(WithImageConfig(image), withProcessArgs("sleep", "100")), WithNewSnapshot(id, image))
 	if err != nil {
 		t.Error(err)
 		return
@@ -614,8 +614,8 @@ func TestContainerUserID(t *testing.T) {
 
 	// adm user in the alpine image has a uid of 3 and gid of 4.
 	container, err := client.NewContainer(ctx, id,
-		withNewSnapshot(id, image),
-		WithNewSpec(withImageConfig(image), WithUserID(3), WithProcessArgs("sh", "-c", "echo $(id -u):$(id -g)")),
+		WithNewSnapshot(id, image),
+		WithNewSpec(WithImageConfig(image), WithUserID(3), WithProcessArgs("sh", "-c", "echo $(id -u):$(id -g)")),
 	)
 	if err != nil {
 		t.Error(err)
@@ -673,8 +673,8 @@ func TestContainerKillAll(t *testing.T) {
 	}
 
 	container, err := client.NewContainer(ctx, id,
-		withNewSnapshot(id, image),
-		WithNewSpec(withImageConfig(image),
+		WithNewSnapshot(id, image),
+		WithNewSpec(WithImageConfig(image),
 			withProcessArgs("sh", "-c", "top"),
 			WithHostNamespace(specs.PIDNamespace),
 		),
@@ -734,7 +734,7 @@ func TestShimSigkilled(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	container, err := client.NewContainer(ctx, id, WithNewSpec(WithImageConfig(image)), withNewSnapshot(id, image))
+	container, err := client.NewContainer(ctx, id, WithNewSpec(WithImageConfig(image)), WithNewSnapshot(id, image))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -798,7 +798,7 @@ func TestDaemonRestartWithRunningShim(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	container, err := client.NewContainer(ctx, id, WithNewSpec(WithImageConfig(image), WithProcessArgs("sleep", "100")), withNewSnapshot(id, image))
+	container, err := client.NewContainer(ctx, id, WithNewSpec(WithImageConfig(image), WithProcessArgs("sleep", "100")), WithNewSnapshot(id, image))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -883,8 +883,8 @@ func TestContainerRuntimeOptions(t *testing.T) {
 
 	container, err := client.NewContainer(
 		ctx, id,
-		WithNewSpec(withImageConfig(image), withExitStatus(7)),
-		withNewSnapshot(id, image),
+		WithNewSpec(WithImageConfig(image), withExitStatus(7)),
+		WithNewSnapshot(id, image),
 		WithRuntime("io.containerd.runtime.v1.linux", &runcopts.RuncOptions{Runtime: "no-runc"}),
 	)
 	if err != nil {
@@ -925,8 +925,8 @@ func TestContainerKillInitPidHost(t *testing.T) {
 	}
 
 	container, err := client.NewContainer(ctx, id,
-		withNewSnapshot(id, image),
-		WithNewSpec(withImageConfig(image),
+		WithNewSnapshot(id, image),
+		WithNewSpec(WithImageConfig(image),
 			withProcessArgs("sh", "-c", "sleep 42; echo hi"),
 			WithHostNamespace(specs.PIDNamespace),
 		),
@@ -1007,7 +1007,7 @@ func testUserNamespaces(t *testing.T, readonlyRootFS bool) {
 		return
 	}
 
-	opts := []NewContainerOpts{WithNewSpec(withImageConfig(image),
+	opts := []NewContainerOpts{WithNewSpec(WithImageConfig(image),
 		withExitStatus(7),
 		WithUserNamespace(0, 1000, 10000),
 	)}

--- a/container_test.go
+++ b/container_test.go
@@ -98,14 +98,12 @@ func TestContainerStart(t *testing.T) {
 	)
 	defer cancel()
 
-	if runtime.GOOS != "windows" {
-		image, err = client.GetImage(ctx, testImage)
-		if err != nil {
-			t.Error(err)
-			return
-		}
+	image, err = client.GetImage(ctx, testImage)
+	if err != nil {
+		t.Error(err)
+		return
 	}
-	container, err := client.NewContainer(ctx, id, WithNewSpec(withImageConfig(image), withExitStatus(7)), withNewSnapshot(id, image))
+	container, err := client.NewContainer(ctx, id, WithNewSpec(WithImageConfig(image), withExitStatus(7)), WithNewSnapshot(id, image))
 	if err != nil {
 		t.Error(err)
 		return
@@ -170,14 +168,12 @@ func TestContainerOutput(t *testing.T) {
 	)
 	defer cancel()
 
-	if runtime.GOOS != "windows" {
-		image, err = client.GetImage(ctx, testImage)
-		if err != nil {
-			t.Error(err)
-			return
-		}
+	image, err = client.GetImage(ctx, testImage)
+	if err != nil {
+		t.Error(err)
+		return
 	}
-	container, err := client.NewContainer(ctx, id, WithNewSpec(withImageConfig(image), withProcessArgs("echo", expected)), withNewSnapshot(id, image))
+	container, err := client.NewContainer(ctx, id, WithNewSpec(WithImageConfig(image), withProcessArgs("echo", expected)), WithNewSnapshot(id, image))
 	if err != nil {
 		t.Error(err)
 		return
@@ -237,15 +233,13 @@ func TestContainerExec(t *testing.T) {
 	)
 	defer cancel()
 
-	if runtime.GOOS != "windows" {
-		image, err = client.GetImage(ctx, testImage)
-		if err != nil {
-			t.Error(err)
-			return
-		}
+	image, err = client.GetImage(ctx, testImage)
+	if err != nil {
+		t.Error(err)
+		return
 	}
 
-	container, err := client.NewContainer(ctx, id, WithNewSpec(withImageConfig(image), withProcessArgs("sleep", "100")), withNewSnapshot(id, image))
+	container, err := client.NewContainer(ctx, id, WithNewSpec(WithImageConfig(image), withProcessArgs("sleep", "100")), WithNewSnapshot(id, image))
 	if err != nil {
 		t.Error(err)
 		return
@@ -336,15 +330,13 @@ func TestContainerPids(t *testing.T) {
 	)
 	defer cancel()
 
-	if runtime.GOOS != "windows" {
-		image, err = client.GetImage(ctx, testImage)
-		if err != nil {
-			t.Error(err)
-			return
-		}
+	image, err = client.GetImage(ctx, testImage)
+	if err != nil {
+		t.Error(err)
+		return
 	}
 
-	container, err := client.NewContainer(ctx, id, WithNewSpec(withImageConfig(image), withProcessArgs("sleep", "100")), withNewSnapshot(id, image))
+	container, err := client.NewContainer(ctx, id, WithNewSpec(WithImageConfig(image), withProcessArgs("sleep", "100")), WithNewSnapshot(id, image))
 	if err != nil {
 		t.Error(err)
 		return
@@ -421,15 +413,13 @@ func TestContainerCloseIO(t *testing.T) {
 	)
 	defer cancel()
 
-	if runtime.GOOS != "windows" {
-		image, err = client.GetImage(ctx, testImage)
-		if err != nil {
-			t.Error(err)
-			return
-		}
+	image, err = client.GetImage(ctx, testImage)
+	if err != nil {
+		t.Error(err)
+		return
 	}
 
-	container, err := client.NewContainer(ctx, id, WithNewSpec(withImageConfig(image), withCat()), withNewSnapshot(id, image))
+	container, err := client.NewContainer(ctx, id, WithNewSpec(WithImageConfig(image), withCat()), WithNewSnapshot(id, image))
 	if err != nil {
 		t.Error(err)
 		return
@@ -486,15 +476,13 @@ func TestDeleteRunningContainer(t *testing.T) {
 	)
 	defer cancel()
 
-	if runtime.GOOS != "windows" {
-		image, err = client.GetImage(ctx, testImage)
-		if err != nil {
-			t.Error(err)
-			return
-		}
+	image, err = client.GetImage(ctx, testImage)
+	if err != nil {
+		t.Error(err)
+		return
 	}
 
-	container, err := client.NewContainer(ctx, id, WithNewSpec(withImageConfig(image), withProcessArgs("sleep", "100")), withNewSnapshot(id, image))
+	container, err := client.NewContainer(ctx, id, WithNewSpec(WithImageConfig(image), withProcessArgs("sleep", "100")), WithNewSnapshot(id, image))
 	if err != nil {
 		t.Error(err)
 		return
@@ -549,15 +537,13 @@ func TestContainerKill(t *testing.T) {
 	)
 	defer cancel()
 
-	if runtime.GOOS != "windows" {
-		image, err = client.GetImage(ctx, testImage)
-		if err != nil {
-			t.Error(err)
-			return
-		}
+	image, err = client.GetImage(ctx, testImage)
+	if err != nil {
+		t.Error(err)
+		return
 	}
 
-	container, err := client.NewContainer(ctx, id, WithNewSpec(withImageConfig(image), withProcessArgs("sleep", "10")), withNewSnapshot(id, image))
+	container, err := client.NewContainer(ctx, id, WithNewSpec(WithImageConfig(image), withProcessArgs("sleep", "10")), WithNewSnapshot(id, image))
 	if err != nil {
 		t.Error(err)
 		return
@@ -613,15 +599,13 @@ func TestContainerNoBinaryExists(t *testing.T) {
 	)
 	defer cancel()
 
-	if runtime.GOOS != "windows" {
-		image, err = client.GetImage(ctx, testImage)
-		if err != nil {
-			t.Error(err)
-			return
-		}
+	image, err = client.GetImage(ctx, testImage)
+	if err != nil {
+		t.Error(err)
+		return
 	}
 
-	container, err := client.NewContainer(ctx, id, WithNewSpec(withImageConfig(image), WithProcessArgs("nothing")), withNewSnapshot(id, image))
+	container, err := client.NewContainer(ctx, id, WithNewSpec(WithImageConfig(image), WithProcessArgs("nothing")), WithNewSnapshot(id, image))
 	if err != nil {
 		t.Error(err)
 		return
@@ -662,15 +646,13 @@ func TestContainerExecNoBinaryExists(t *testing.T) {
 	)
 	defer cancel()
 
-	if runtime.GOOS != "windows" {
-		image, err = client.GetImage(ctx, testImage)
-		if err != nil {
-			t.Error(err)
-			return
-		}
+	image, err = client.GetImage(ctx, testImage)
+	if err != nil {
+		t.Error(err)
+		return
 	}
 
-	container, err := client.NewContainer(ctx, id, WithNewSpec(withImageConfig(image), withProcessArgs("sleep", "100")), withNewSnapshot(id, image))
+	container, err := client.NewContainer(ctx, id, WithNewSpec(WithImageConfig(image), withProcessArgs("sleep", "100")), WithNewSnapshot(id, image))
 	if err != nil {
 		t.Error(err)
 		return
@@ -735,15 +717,13 @@ func TestWaitStoppedTask(t *testing.T) {
 	)
 	defer cancel()
 
-	if runtime.GOOS != "windows" {
-		image, err = client.GetImage(ctx, testImage)
-		if err != nil {
-			t.Error(err)
-			return
-		}
+	image, err = client.GetImage(ctx, testImage)
+	if err != nil {
+		t.Error(err)
+		return
 	}
 
-	container, err := client.NewContainer(ctx, id, WithNewSpec(withImageConfig(image), withExitStatus(7)), withNewSnapshot(id, image))
+	container, err := client.NewContainer(ctx, id, WithNewSpec(WithImageConfig(image), withExitStatus(7)), WithNewSnapshot(id, image))
 	if err != nil {
 		t.Error(err)
 		return
@@ -806,15 +786,13 @@ func TestWaitStoppedProcess(t *testing.T) {
 	)
 	defer cancel()
 
-	if runtime.GOOS != "windows" {
-		image, err = client.GetImage(ctx, testImage)
-		if err != nil {
-			t.Error(err)
-			return
-		}
+	image, err = client.GetImage(ctx, testImage)
+	if err != nil {
+		t.Error(err)
+		return
 	}
 
-	container, err := client.NewContainer(ctx, id, WithNewSpec(withImageConfig(image), withProcessArgs("sleep", "100")), withNewSnapshot(id, image))
+	container, err := client.NewContainer(ctx, id, WithNewSpec(WithImageConfig(image), withProcessArgs("sleep", "100")), WithNewSnapshot(id, image))
 	if err != nil {
 		t.Error(err)
 		return
@@ -906,14 +884,12 @@ func TestTaskForceDelete(t *testing.T) {
 	)
 	defer cancel()
 
-	if runtime.GOOS != "windows" {
-		image, err = client.GetImage(ctx, testImage)
-		if err != nil {
-			t.Error(err)
-			return
-		}
+	image, err = client.GetImage(ctx, testImage)
+	if err != nil {
+		t.Error(err)
+		return
 	}
-	container, err := client.NewContainer(ctx, id, WithNewSpec(withImageConfig(image), withProcessArgs("sleep", "30")), withNewSnapshot(id, image))
+	container, err := client.NewContainer(ctx, id, WithNewSpec(WithImageConfig(image), withProcessArgs("sleep", "30")), WithNewSnapshot(id, image))
 	if err != nil {
 		t.Error(err)
 		return
@@ -954,14 +930,12 @@ func TestProcessForceDelete(t *testing.T) {
 	)
 	defer cancel()
 
-	if runtime.GOOS != "windows" {
-		image, err = client.GetImage(ctx, testImage)
-		if err != nil {
-			t.Error(err)
-			return
-		}
+	image, err = client.GetImage(ctx, testImage)
+	if err != nil {
+		t.Error(err)
+		return
 	}
-	container, err := client.NewContainer(ctx, id, WithNewSpec(withImageConfig(image), withProcessArgs("sleep", "30")), withNewSnapshot(id, image))
+	container, err := client.NewContainer(ctx, id, WithNewSpec(WithImageConfig(image), withProcessArgs("sleep", "30")), WithNewSnapshot(id, image))
 	if err != nil {
 		t.Error(err)
 		return
@@ -1034,19 +1008,17 @@ func TestContainerHostname(t *testing.T) {
 	)
 	defer cancel()
 
-	if runtime.GOOS != "windows" {
-		image, err = client.GetImage(ctx, testImage)
-		if err != nil {
-			t.Error(err)
-			return
-		}
+	image, err = client.GetImage(ctx, testImage)
+	if err != nil {
+		t.Error(err)
+		return
 	}
 
-	container, err := client.NewContainer(ctx, id, WithNewSpec(withImageConfig(image),
+	container, err := client.NewContainer(ctx, id, WithNewSpec(WithImageConfig(image),
 		withProcessArgs("hostname"),
 		WithHostname(expected),
 	),
-		withNewSnapshot(id, image))
+		WithNewSnapshot(id, image))
 	if err != nil {
 		t.Error(err)
 		return
@@ -1112,15 +1084,13 @@ func TestContainerExitedAtSet(t *testing.T) {
 	)
 	defer cancel()
 
-	if runtime.GOOS != "windows" {
-		image, err = client.GetImage(ctx, testImage)
-		if err != nil {
-			t.Error(err)
-			return
-		}
+	image, err = client.GetImage(ctx, testImage)
+	if err != nil {
+		t.Error(err)
+		return
 	}
 
-	container, err := client.NewContainer(ctx, id, WithNewSpec(withImageConfig(image), withTrue()), withNewSnapshot(id, image))
+	container, err := client.NewContainer(ctx, id, WithNewSpec(WithImageConfig(image), withTrue()), WithNewSnapshot(id, image))
 	if err != nil {
 		t.Error(err)
 		return
@@ -1179,15 +1149,13 @@ func TestDeleteContainerExecCreated(t *testing.T) {
 	)
 	defer cancel()
 
-	if runtime.GOOS != "windows" {
-		image, err = client.GetImage(ctx, testImage)
-		if err != nil {
-			t.Error(err)
-			return
-		}
+	image, err = client.GetImage(ctx, testImage)
+	if err != nil {
+		t.Error(err)
+		return
 	}
 
-	container, err := client.NewContainer(ctx, id, WithNewSpec(withImageConfig(image), withProcessArgs("sleep", "100")), withNewSnapshot(id, image))
+	container, err := client.NewContainer(ctx, id, WithNewSpec(WithImageConfig(image), withProcessArgs("sleep", "100")), WithNewSnapshot(id, image))
 	if err != nil {
 		t.Error(err)
 		return
@@ -1258,14 +1226,12 @@ func TestContainerMetrics(t *testing.T) {
 	)
 	defer cancel()
 
-	if runtime.GOOS != "windows" {
-		image, err = client.GetImage(ctx, testImage)
-		if err != nil {
-			t.Error(err)
-			return
-		}
+	image, err = client.GetImage(ctx, testImage)
+	if err != nil {
+		t.Error(err)
+		return
 	}
-	container, err := client.NewContainer(ctx, id, WithNewSpec(withImageConfig(image), WithProcessArgs("sleep", "30")), withNewSnapshot(id, image))
+	container, err := client.NewContainer(ctx, id, WithNewSpec(WithImageConfig(image), WithProcessArgs("sleep", "30")), WithNewSnapshot(id, image))
 	if err != nil {
 		t.Error(err)
 		return
@@ -1319,16 +1285,14 @@ func TestDeletedContainerMetrics(t *testing.T) {
 	)
 	defer cancel()
 
-	if runtime.GOOS != "windows" {
-		image, err = client.GetImage(ctx, testImage)
-		if err != nil {
-			t.Error(err)
-			return
-		}
+	image, err = client.GetImage(ctx, testImage)
+	if err != nil {
+		t.Error(err)
+		return
 	}
 	container, err := client.NewContainer(ctx, id,
-		WithNewSpec(withImageConfig(image), withExitStatus(0)),
-		withNewSnapshot(id, image),
+		WithNewSpec(WithImageConfig(image), withExitStatus(0)),
+		WithNewSnapshot(id, image),
 	)
 	if err != nil {
 		t.Error(err)

--- a/differ/windowsdiffer/differ_windows.go
+++ b/differ/windowsdiffer/differ_windows.go
@@ -1,0 +1,472 @@
+package windowsdiffer
+
+import (
+	"bufio"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/Microsoft/go-winio/archive/tar"
+	"github.com/Microsoft/go-winio/backuptar"
+	"github.com/Microsoft/hcsshim"
+	"github.com/containerd/containerd/archive/compression"
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/diff"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/metadata"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/plugin"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+)
+
+func init() {
+	plugin.Register(&plugin.Registration{
+		Type: plugin.DiffPlugin,
+		ID:   "windows",
+		Requires: []plugin.Type{
+			plugin.ContentPlugin,
+			plugin.MetadataPlugin,
+		},
+		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
+			md, err := ic.Get(plugin.MetadataPlugin)
+			if err != nil {
+				return nil, err
+			}
+			return NewWindowsDiff(md.(*metadata.DB).ContentStore())
+		},
+	})
+}
+
+type windowsDiff struct {
+	store content.Store
+}
+
+var (
+	emptyDesc = ocispec.Descriptor{}
+
+	// mutatedFiles is a list of files that are mutated by the import process
+	// and must be backed up and restored.
+	mutatedFiles = map[string]string{
+		"UtilityVM/Files/EFI/Microsoft/Boot/BCD":      "bcd.bak",
+		"UtilityVM/Files/EFI/Microsoft/Boot/BCD.LOG":  "bcd.log.bak",
+		"UtilityVM/Files/EFI/Microsoft/Boot/BCD.LOG1": "bcd.log1.bak",
+		"UtilityVM/Files/EFI/Microsoft/Boot/BCD.LOG2": "bcd.log2.bak",
+	}
+)
+
+// NewWindowsDiff is the Windows container implementation of diff.Differ.
+func NewWindowsDiff(store content.Store) (diff.Differ, error) {
+	return &windowsDiff{
+		store: store,
+	}, nil
+}
+
+// Apply applies the content associated with the provided digests onto the
+// provided mounts. Archive content will be extracted and decompressed if
+// necessary.
+func (s *windowsDiff) Apply(ctx context.Context, desc ocispec.Descriptor, mounts []mount.Mount) (ocispec.Descriptor, error) {
+	var isCompressed bool
+	switch desc.MediaType {
+	case ocispec.MediaTypeImageLayer, images.MediaTypeDockerSchema2Layer:
+	case ocispec.MediaTypeImageLayerGzip, images.MediaTypeDockerSchema2LayerGzip:
+		isCompressed = true
+	default:
+		// Still apply all generic media types *.tar[.+]gzip and *.tar
+		if strings.HasSuffix(desc.MediaType, ".tar.gzip") || strings.HasSuffix(desc.MediaType, ".tar+gzip") {
+			isCompressed = true
+		} else if !strings.HasSuffix(desc.MediaType, ".tar") {
+			return emptyDesc, errors.Wrapf(errdefs.ErrNotImplemented, "unsupported diff media type: %v", desc.MediaType)
+		}
+	}
+
+	dir, err := ioutil.TempDir("", "extract-")
+	if err != nil {
+		return emptyDesc, errors.Wrap(err, "failed to create temporary directory")
+	}
+	defer os.RemoveAll(dir)
+
+	ra, err := s.store.ReaderAt(ctx, desc.Digest)
+	if err != nil {
+		return emptyDesc, errors.Wrap(err, "failed to get reader from content store")
+	}
+	defer ra.Close()
+
+	r := content.NewReader(ra)
+	if isCompressed {
+		ds, err := compression.DecompressStream(r)
+		if err != nil {
+			return emptyDesc, err
+		}
+		defer ds.Close()
+		r = ds
+	}
+
+	digester := digest.Canonical.Digester()
+	rc := &readCounter{
+		r: io.TeeReader(r, digester.Hash()),
+	}
+
+	layer, parentLayerPaths, err := mountsToLayerAndParents(mounts)
+	if err != nil {
+		return emptyDesc, err
+	}
+
+	size, err := writeLayer(rc, filepath.Dir(mounts[0].Source), layer, parentLayerPaths...)
+	if err != nil {
+		return emptyDesc, errors.Wrap(err, "failed to write layer")
+	}
+
+	// TODO (darrenstahlmsft) use archiver instead of writelayer here. Need parent layer context
+	//if _, err := archive.Apply(ctx, dir, rc); err != nil {
+	//	return emptyDesc, err
+	//}
+
+	// Read any trailing data
+	if _, err := io.Copy(ioutil.Discard, rc); err != nil {
+		return emptyDesc, err
+	}
+
+	return ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageLayer,
+		Size:      size,
+		Digest:    digester.Digest(),
+	}, nil
+}
+
+// writeLayer writes a layer from a tar file.
+func writeLayer(layerData io.Reader, home string, layer string, parentLayerPaths ...string) (int64, error) {
+	// TODO (darrenstahlmsft): Make this a re-exec to prevent escalating privilege in main containerd.exe process
+	err := winio.EnableProcessPrivileges([]string{winio.SeBackupPrivilege, winio.SeRestorePrivilege})
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		if err := winio.DisableProcessPrivileges([]string{winio.SeBackupPrivilege, winio.SeRestorePrivilege}); err != nil {
+			// This should never happen, but just in case when in debugging mode.
+			// See https://github.com/docker/docker/pull/28002#discussion_r86259241 for rationale.
+			panic("Failed to disable process privileges while in non re-exec mode")
+		}
+	}()
+
+	info := hcsshim.DriverInfo{
+		Flavour: 1,
+		HomeDir: home,
+	}
+
+	w, err := hcsshim.NewLayerWriter(info, filepath.Base(layer), parentLayerPaths)
+	if err != nil {
+		return 0, err
+	}
+
+	size, err := writeLayerFromTar(layerData, w, layer)
+	if err != nil {
+		return 0, err
+	}
+
+	err = w.Close()
+	if err != nil {
+		return 0, err
+	}
+
+	return size, nil
+}
+
+func writeLayerFromTar(r io.Reader, w hcsshim.LayerWriter, root string) (int64, error) {
+	t := tar.NewReader(r)
+	hdr, err := t.Next()
+	totalSize := int64(0)
+	buf := bufio.NewWriter(nil)
+	for err == nil {
+		base := path.Base(hdr.Name)
+		if strings.HasPrefix(base, whiteoutPrefix) {
+			name := path.Join(path.Dir(hdr.Name), base[len(whiteoutPrefix):])
+			err = w.Remove(filepath.FromSlash(name))
+			if err != nil {
+				return 0, err
+			}
+			hdr, err = t.Next()
+		} else if hdr.Typeflag == tar.TypeLink {
+			err = w.AddLink(filepath.FromSlash(hdr.Name), filepath.FromSlash(hdr.Linkname))
+			if err != nil {
+				return 0, err
+			}
+			hdr, err = t.Next()
+		} else {
+			var (
+				name     string
+				size     int64
+				fileInfo *winio.FileBasicInfo
+			)
+			name, size, fileInfo, err = backuptar.FileInfoFromHeader(hdr)
+			if err != nil {
+				return 0, err
+			}
+			err = w.Add(filepath.FromSlash(name), fileInfo)
+			if err != nil {
+				return 0, err
+			}
+			hdr, err = tarToBackupStreamWithMutatedFiles(buf, w, t, hdr, root)
+			totalSize += size
+		}
+	}
+	if err != io.EOF {
+		return 0, err
+	}
+	return totalSize, nil
+}
+
+// tarToBackupStreamWithMutatedFiles reads data from a tar stream and
+// writes it to a backup stream, and also saves any files that will be mutated
+// by the import layer process to a backup location.
+func tarToBackupStreamWithMutatedFiles(buf *bufio.Writer, w io.Writer, t *tar.Reader, hdr *tar.Header, root string) (nextHdr *tar.Header, err error) {
+	var (
+		bcdBackup       *os.File
+		bcdBackupWriter *winio.BackupFileWriter
+	)
+	if backupPath, ok := mutatedFiles[hdr.Name]; ok {
+		bcdBackup, err = os.Create(filepath.Join(root, backupPath))
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			cerr := bcdBackup.Close()
+			if err == nil {
+				err = cerr
+			}
+		}()
+
+		bcdBackupWriter = winio.NewBackupFileWriter(bcdBackup, false)
+		defer func() {
+			cerr := bcdBackupWriter.Close()
+			if err == nil {
+				err = cerr
+			}
+		}()
+
+		buf.Reset(io.MultiWriter(w, bcdBackupWriter))
+	} else {
+		buf.Reset(w)
+	}
+
+	defer func() {
+		ferr := buf.Flush()
+		if err == nil {
+			err = ferr
+		}
+	}()
+
+	return backuptar.WriteBackupStreamFromTarFile(buf, t, hdr)
+}
+
+// DiffMounts creates a diff between the given mounts and uploads the result
+// to the content store.
+func (s *windowsDiff) DiffMounts(ctx context.Context, lower, upper []mount.Mount, opts ...diff.Opt) (ocispec.Descriptor, error) {
+
+	var config diff.Config
+	for _, opt := range opts {
+		if err := opt(&config); err != nil {
+			return emptyDesc, err
+		}
+	}
+
+	if config.MediaType == "" {
+		config.MediaType = ocispec.MediaTypeImageLayerGzip
+	}
+
+	var isCompressed bool
+	switch config.MediaType {
+	case ocispec.MediaTypeImageLayer:
+	case ocispec.MediaTypeImageLayerGzip:
+		isCompressed = true
+	default:
+		return emptyDesc, errors.Wrapf(errdefs.ErrNotImplemented, "unsupported diff media type: %v", config.MediaType)
+	}
+
+	var newReference bool
+	if config.Reference == "" {
+		newReference = true
+		config.Reference = uniqueRef()
+	}
+
+	cw, err := s.store.Writer(ctx, config.Reference, 0, "")
+	if err != nil {
+		return emptyDesc, errors.Wrap(err, "failed to open writer")
+	}
+	defer func() {
+		if err != nil {
+			cw.Close()
+			if newReference {
+				if err := s.store.Abort(ctx, config.Reference); err != nil {
+					log.G(ctx).WithField("ref", config.Reference).Warnf("failed to delete diff upload")
+				}
+			}
+		}
+	}()
+	if !newReference {
+		if err := cw.Truncate(0); err != nil {
+			return emptyDesc, err
+		}
+	}
+
+	layer, parentLayerPaths, err := mountsToLayerAndParents(upper)
+	if err != nil {
+		return emptyDesc, errors.Wrap(err, "failed to get layer and parent paths from mounts")
+	}
+	if lower[0].Source != parentLayerPaths[0] {
+		return emptyDesc, errors.Wrapf(errdefs.ErrInvalidArgument, "lower mounts must be the direct child of the upper mounts %v != %v", lower[0].Source, parentLayerPaths[0])
+	}
+
+	if isCompressed {
+		dgstr := digest.SHA256.Digester()
+		compressed, err := compression.CompressStream(cw, compression.Gzip)
+		if err != nil {
+			return emptyDesc, errors.Wrap(err, "failed to get compressed stream")
+		}
+		err = s.writeDiff(ctx, io.MultiWriter(compressed, dgstr.Hash()), layer, parentLayerPaths)
+		compressed.Close()
+		if err != nil {
+			return emptyDesc, errors.Wrap(err, "failed to write compressed diff")
+		}
+
+		if config.Labels == nil {
+			config.Labels = map[string]string{}
+		}
+		config.Labels["containerd.io/uncompressed"] = dgstr.Digest().String()
+	} else {
+		if err = s.writeDiff(ctx, cw, layer, parentLayerPaths); err != nil {
+			return emptyDesc, errors.Wrap(err, "failed to write diff")
+		}
+	}
+
+	var commitopts []content.Opt
+	if config.Labels != nil {
+		commitopts = append(commitopts, content.WithLabels(config.Labels))
+	}
+
+	dgst := cw.Digest()
+	if err := cw.Commit(ctx, 0, dgst, commitopts...); err != nil {
+		return emptyDesc, errors.Wrap(err, "failed to commit")
+	}
+
+	info, err := s.store.Info(ctx, dgst)
+	if err != nil {
+		return emptyDesc, errors.Wrap(err, "failed to get info from content store")
+	}
+
+	return ocispec.Descriptor{
+		MediaType: config.MediaType,
+		Size:      info.Size,
+		Digest:    info.Digest,
+	}, nil
+}
+
+func mountsToLayerAndParents(mounts []mount.Mount) (string, []string, error) {
+	if len(mounts) == 0 {
+		return "", nil, errors.Wrap(errdefs.ErrInvalidArgument, "number of mounts should not be 0")
+	}
+	layer := mounts[0].Source
+
+	var parents []string
+	for _, mount := range mounts[1:] {
+		parents = append(parents, mount.Source)
+	}
+
+	return layer, parents, nil
+}
+
+// WriteDiff writes a tar stream of the computed difference between the
+// provided directories.
+//
+// Produces a tar using OCI style file markers for deletions. Deleted
+// files will be prepended with the prefix ".wh.". This style is
+// based off AUFS whiteouts.
+// See https://github.com/opencontainers/image-spec/blob/master/layer.md
+func (s *windowsDiff) writeDiff(ctx context.Context, w io.Writer, layer string, parentLayerPaths []string) error {
+	info := hcsshim.DriverInfo{
+		Flavour: hcsshim.FilterDriver,
+		HomeDir: filepath.Dir(layer),
+	}
+	id := filepath.Base(layer)
+	err := winio.RunWithPrivilege(winio.SeBackupPrivilege, func() error {
+		r, err := hcsshim.NewLayerReader(info, id, parentLayerPaths)
+		if err != nil {
+			return err
+		}
+
+		err = writeTarFromLayer(r, w)
+		cerr := r.Close()
+		if err == nil {
+			err = cerr
+		}
+		return err
+	})
+	return err
+}
+
+const (
+	// whiteoutPrefix prefix means file is a whiteout. If this is followed by a
+	// filename this means that file has been removed from the base layer.
+	// See https://github.com/opencontainers/image-spec/blob/master/layer.md#whiteouts
+	whiteoutPrefix = ".wh."
+)
+
+func writeTarFromLayer(r hcsshim.LayerReader, w io.Writer) error {
+	t := tar.NewWriter(w)
+	for {
+		name, size, fileInfo, err := r.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if fileInfo == nil {
+			// Write a whiteout file.
+			hdr := &tar.Header{
+				Name: filepath.ToSlash(filepath.Join(filepath.Dir(name), whiteoutPrefix+filepath.Base(name))),
+			}
+			err := t.WriteHeader(hdr)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = backuptar.WriteTarFileFromBackupStream(t, r, name, size, fileInfo)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return t.Close()
+}
+
+type readCounter struct {
+	r io.Reader
+	c int64
+}
+
+func (rc *readCounter) Read(p []byte) (n int, err error) {
+	n, err = rc.r.Read(p)
+	rc.c += int64(n)
+	return
+}
+
+func uniqueRef() string {
+	t := time.Now()
+	var b [3]byte
+	// Ignore read failures, just decreases uniqueness
+	rand.Read(b[:])
+	return fmt.Sprintf("%d-%s", t.UnixNano(), base64.URLEncoding.EncodeToString(b[:]))
+}

--- a/helpers_unix_test.go
+++ b/helpers_unix_test.go
@@ -42,6 +42,4 @@ func withExecArgs(s *specs.Process, args ...string) {
 var (
 	withRemappedSnapshot     = WithRemappedSnapshot
 	withRemappedSnapshotView = WithRemappedSnapshotView
-	withNewSnapshot          = WithNewSnapshot
-	withImageConfig          = WithImageConfig
 )

--- a/helpers_windows_test.go
+++ b/helpers_windows_test.go
@@ -39,18 +39,8 @@ func withExecArgs(s *specs.Process, args ...string) {
 	s.Args = append([]string{"powershell", "-noprofile"}, args...)
 }
 
-func withImageConfig(i Image) SpecOpts {
-	return func(_ context.Context, _ *Client, _ *containers.Container, s *specs.Spec) error {
-		s.Windows.LayerFolders = dockerLayerFolders
-		return nil
-	}
-}
-
-func withNewSnapshot(id string, i Image) NewContainerOpts {
-	// TODO: when windows has a snapshotter remove the withNewSnapshot helper
-	return func(ctx context.Context, client *Client, c *containers.Container) error {
-		return nil
-	}
+func withUserNamespace(u, g, s uint32) SpecOpts {
+	return withNoop
 }
 
 func withRemappedSnapshot(id string, i Image, u, g uint32) NewContainerOpts {

--- a/mount/mount.go
+++ b/mount/mount.go
@@ -12,13 +12,3 @@ type Mount struct {
 	// these are platform specific.
 	Options []string
 }
-
-// All mounts all the provided mounts to the provided target
-func All(mounts []Mount, target string) error {
-	for _, m := range mounts {
-		if err := m.Mount(target); err != nil {
-			return err
-		}
-	}
-	return nil
-}

--- a/mount/mount_linux.go
+++ b/mount/mount_linux.go
@@ -41,6 +41,16 @@ func (m *Mount) Mount(target string) error {
 	return nil
 }
 
+// All mounts all the provided mounts to the provided target
+func All(mounts []Mount, target string) error {
+	for _, m := range mounts {
+		if err := m.Mount(target); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Unmount the provided mount path with the flags
 func Unmount(mount string, flags int) error {
 	return unix.Unmount(mount, flags)

--- a/mount/mount_solaris.go
+++ b/mount/mount_solaris.go
@@ -59,6 +59,16 @@ func (m *Mount) Mount(target string) error {
 	return err
 }
 
+// All mounts all the provided mounts to the provided target
+func All(mounts []Mount, target string) error {
+	for _, m := range mounts {
+		if err := m.Mount(target); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func Unmount(mount string, flags int) error {
 	return unix.Unmount(mount, flags)
 }

--- a/mount/mount_unix.go
+++ b/mount/mount_unix.go
@@ -12,6 +12,16 @@ func (m *Mount) Mount(target string) error {
 	return ErrNotImplementOnUnix
 }
 
+// All mounts all the provided mounts to the provided target
+func All(mounts []Mount, target string) error {
+	for _, m := range mounts {
+		if err := m.Mount(target); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func Unmount(mount string, flags int) error {
 	return ErrNotImplementOnUnix
 }

--- a/mount/mount_windows.go
+++ b/mount/mount_windows.go
@@ -1,13 +1,56 @@
 package mount
 
-import "github.com/pkg/errors"
+import (
+	"path/filepath"
+
+	"github.com/Microsoft/hcsshim"
+	"github.com/pkg/errors"
+)
 
 var (
 	ErrNotImplementOnWindows = errors.New("not implemented under windows")
 )
 
 func (m *Mount) Mount(target string) error {
+	// Windows cannot mount an indvidual layer, as the filesystem
+	// filter requires all underlying layers to mount.
 	return ErrNotImplementOnWindows
+}
+
+// All mounts all the provided mounts to the provided target
+func All(mounts []Mount, target string) error {
+	layerFolderPath := mounts[0].Source
+	layerID := filepath.Base(layerFolderPath)
+
+	var layerFolders []string
+	for _, m := range mounts[1:] {
+		layerFolders = append(layerFolders, m.Source)
+	}
+
+	var di = hcsshim.DriverInfo{
+		Flavour: hcsshim.FilterDriver,
+		HomeDir: filepath.Dir(layerFolderPath),
+	}
+
+	var err error
+	if err = hcsshim.ActivateLayer(di, layerID); err != nil {
+		return errors.Wrapf(err, "failed to activate layer %s", layerFolderPath)
+	}
+	defer func() {
+		if err != nil {
+			hcsshim.DeactivateLayer(di, layerID)
+		}
+	}()
+
+	if err = hcsshim.PrepareLayer(di, layerID, layerFolders); err != nil {
+		return errors.Wrapf(err, "failed to prepare layer %s", layerFolderPath)
+	}
+	defer func() {
+		if err != nil {
+			hcsshim.UnprepareLayer(di, layerID)
+		}
+	}()
+	return nil
 }
 
 func Unmount(mount string, flags int) error {
@@ -15,5 +58,20 @@ func Unmount(mount string, flags int) error {
 }
 
 func UnmountAll(mount string, flags int) error {
-	return ErrNotImplementOnWindows
+	layerID := filepath.Base(mount)
+
+	var di = hcsshim.DriverInfo{
+		Flavour: 1, // filter driver
+		HomeDir: filepath.Dir(mount),
+	}
+
+	var err error
+	if err = hcsshim.UnprepareLayer(di, layerID); err != nil {
+		return errors.Wrapf(err, "failed to unprepare layer %s", mount)
+	}
+	if err = hcsshim.DeactivateLayer(di, layerID); err != nil {
+		return errors.Wrapf(err, "failed to deactivate layer %s", mount)
+	}
+
+	return nil
 }

--- a/services/diff/service.go
+++ b/services/diff/service.go
@@ -30,9 +30,7 @@ func init() {
 		Requires: []plugin.Type{
 			plugin.DiffPlugin,
 		},
-		Config: &config{
-			Order: []string{"walking"},
-		},
+		Config: defaultDifferConfig,
 		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
 			differs, err := ic.GetByType(plugin.DiffPlugin)
 			if err != nil {

--- a/services/diff/service_unix.go
+++ b/services/diff/service_unix.go
@@ -1,0 +1,7 @@
+// +build !windows
+
+package diff
+
+var defaultDifferConfig = &config{
+	Order: []string{"walking"},
+}

--- a/services/diff/service_windows.go
+++ b/services/diff/service_windows.go
@@ -1,0 +1,7 @@
+// +build windows
+
+package diff
+
+var defaultDifferConfig = &config{
+	Order: []string{"windows"},
+}

--- a/snapshot/windows/utilities.go
+++ b/snapshot/windows/utilities.go
@@ -1,0 +1,14 @@
+package windows
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/snapshot/storage"
+)
+
+func rollbackWithLogging(ctx context.Context, t storage.Transactor) {
+	if err := t.Rollback(); err != nil {
+		log.G(ctx).WithError(err).Warn("failed to rollback transaction")
+	}
+}

--- a/snapshot/windows/windows.go
+++ b/snapshot/windows/windows.go
@@ -4,15 +4,23 @@ package windows
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"unsafe"
 
+	"golang.org/x/sys/windows"
+
+	"github.com/Microsoft/hcsshim"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/fs"
+	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/snapshot"
+	"github.com/containerd/containerd/snapshot/storage"
 	"github.com/pkg/errors"
-)
-
-var (
-	ErrNotImplemented = errors.New("not implemented")
 )
 
 func init() {
@@ -25,13 +33,41 @@ func init() {
 	})
 }
 
-type Snapshotter struct {
+type snapshotter struct {
 	root string
+	info hcsshim.DriverInfo
+	ms   *storage.MetaStore
 }
 
+// NewSnapshotter returns a Snapshotter which uses the Windows filter driver.
 func NewSnapshotter(root string) (snapshot.Snapshotter, error) {
-	return &Snapshotter{
+	fsType, err := getFileSystemType(string(root[0]))
+	if err != nil {
+		return nil, err
+	}
+	if strings.ToLower(fsType) == "refs" {
+		return nil, errors.Wrapf(errdefs.ErrInvalidArgument, "%s is on an ReFS volume - ReFS volumes are not supported", root)
+	}
+
+	if err := os.MkdirAll(root, 0700); err != nil {
+		return nil, err
+	}
+	ms, err := storage.NewMetaStore(filepath.Join(root, "metadata.db"))
+	if err != nil {
+		return nil, err
+	}
+
+	if err := os.Mkdir(filepath.Join(root, "snapshots"), 0700); err != nil && !os.IsExist(err) {
+		return nil, err
+	}
+
+	return &snapshotter{
+		info: hcsshim.DriverInfo{
+			HomeDir: filepath.Join(root, "snapshots"),
+			Flavour: hcsshim.FilterDriver,
+		},
 		root: root,
+		ms:   ms,
 	}, nil
 }
 
@@ -40,45 +76,295 @@ func NewSnapshotter(root string) (snapshot.Snapshotter, error) {
 //
 // Should be used for parent resolution, existence checks and to discern
 // the kind of snapshot.
-func (o *Snapshotter) Stat(ctx context.Context, key string) (snapshot.Info, error) {
-	panic("not implemented")
+func (s *snapshotter) Stat(ctx context.Context, key string) (snapshot.Info, error) {
+	ctx, t, err := s.ms.TransactionContext(ctx, false)
+	if err != nil {
+		return snapshot.Info{}, err
+	}
+	defer t.Rollback()
+
+	_, info, _, err := storage.GetInfo(ctx, key)
+	if err != nil {
+		return snapshot.Info{}, err
+	}
+
+	return info, nil
 }
 
-func (o *Snapshotter) Update(ctx context.Context, info snapshot.Info, fieldpaths ...string) (snapshot.Info, error) {
-	panic("not implemented")
+func (s *snapshotter) Update(ctx context.Context, info snapshot.Info, fieldpaths ...string) (snapshot.Info, error) {
+	ctx, t, err := s.ms.TransactionContext(ctx, true)
+	if err != nil {
+		return snapshot.Info{}, err
+	}
+
+	var committed bool
+	defer func() {
+		if committed == false {
+			rollbackWithLogging(ctx, t)
+		}
+	}()
+
+	info, err = storage.UpdateInfo(ctx, info, fieldpaths...)
+	if err != nil {
+		return snapshot.Info{}, err
+	}
+
+	if err := t.Commit(); err != nil {
+		return snapshot.Info{}, err
+	}
+	committed = true
+
+	return info, nil
 }
 
-func (o *Snapshotter) Usage(ctx context.Context, key string) (snapshot.Usage, error) {
-	panic("not implemented")
+func (s *snapshotter) Usage(ctx context.Context, key string) (snapshot.Usage, error) {
+	ctx, t, err := s.ms.TransactionContext(ctx, false)
+	if err != nil {
+		return snapshot.Usage{}, err
+	}
+	defer t.Rollback()
+
+	_, info, usage, err := storage.GetInfo(ctx, key)
+	if err != nil {
+		return snapshot.Usage{}, err
+	}
+
+	if info.Kind == snapshot.KindActive {
+		du := fs.Usage{
+			Size: 0,
+		}
+		usage = snapshot.Usage(du)
+	}
+
+	return usage, nil
 }
 
-func (o *Snapshotter) Prepare(ctx context.Context, key, parent string, opts ...snapshot.Opt) ([]mount.Mount, error) {
-	panic("not implemented")
+func (s *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...snapshot.Opt) ([]mount.Mount, error) {
+	return s.createSnapshot(ctx, snapshot.KindActive, key, parent, opts)
 }
 
-func (o *Snapshotter) View(ctx context.Context, key, parent string, opts ...snapshot.Opt) ([]mount.Mount, error) {
-	panic("not implemented")
+func (s *snapshotter) View(ctx context.Context, key, parent string, opts ...snapshot.Opt) ([]mount.Mount, error) {
+	return s.createSnapshot(ctx, snapshot.KindView, key, parent, opts)
 }
 
 // Mounts returns the mounts for the transaction identified by key. Can be
 // called on an read-write or readonly transaction.
 //
 // This can be used to recover mounts after calling View or Prepare.
-func (o *Snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, error) {
-	panic("not implemented")
+func (s *snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, error) {
+	ctx, t, err := s.ms.TransactionContext(ctx, false)
+	if err != nil {
+		return nil, err
+	}
+	defer t.Rollback()
+	snapshot, err := storage.GetSnapshot(ctx, key)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get snapshot mount")
+	}
+	return s.mounts(snapshot), nil
 }
 
-func (o *Snapshotter) Commit(ctx context.Context, name, key string, opts ...snapshot.Opt) error {
-	panic("not implemented")
+func (s *snapshotter) Commit(ctx context.Context, name, key string, opts ...snapshot.Opt) error {
+	ctx, t, err := s.ms.TransactionContext(ctx, true)
+	if err != nil {
+		return err
+	}
+
+	var committed bool
+	defer func() {
+		if committed == false {
+			rollbackWithLogging(ctx, t)
+		}
+	}()
+	usage := fs.Usage{
+		Size: 0,
+	}
+
+	if _, err = storage.CommitActive(ctx, key, name, snapshot.Usage(usage), opts...); err != nil {
+		return errors.Wrap(err, "failed to commit snapshot")
+	}
+
+	if err := t.Commit(); err != nil {
+		return err
+	}
+	committed = true
+	return nil
 }
 
 // Remove abandons the transaction identified by key. All resources
 // associated with the key will be removed.
-func (o *Snapshotter) Remove(ctx context.Context, key string) error {
-	panic("not implemented")
+func (s *snapshotter) Remove(ctx context.Context, key string) error {
+	ctx, t, err := s.ms.TransactionContext(ctx, true)
+	if err != nil {
+		return err
+	}
+
+	var committed bool
+	defer func() {
+		if committed == false {
+			rollbackWithLogging(ctx, t)
+		}
+	}()
+
+	id, _, err := storage.Remove(ctx, key)
+	if err != nil {
+		return errors.Wrap(err, "failed to remove")
+	}
+
+	path := s.getSnapshotDir(id)
+	renamedID := "rm-" + id
+	renamed := filepath.Join(s.root, "snapshots", "rm-"+id)
+	if err := os.Rename(path, renamed); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	err = t.Commit()
+	if err != nil {
+		if err1 := os.Rename(renamed, path); err1 != nil {
+			// May cause inconsistent data on disk
+			log.G(ctx).WithError(err1).WithField("path", renamed).Errorf("Failed to rename after failed commit")
+		}
+		return errors.Wrap(err, "failed to commit")
+	}
+	committed = true
+
+	if err := hcsshim.DestroyLayer(s.info, renamedID); err != nil {
+		// Must be cleaned up, any "rm-*" could be removed if no active transactions
+		log.G(ctx).WithError(err).WithField("path", renamed).Warnf("Failed to remove root filesystem")
+	}
+
+	return nil
 }
 
 // Walk the committed snapshots.
-func (o *Snapshotter) Walk(ctx context.Context, fn func(context.Context, snapshot.Info) error) error {
-	panic("not implemented")
+func (s *snapshotter) Walk(ctx context.Context, fn func(context.Context, snapshot.Info) error) error {
+	ctx, t, err := s.ms.TransactionContext(ctx, false)
+	if err != nil {
+		return err
+	}
+	defer t.Rollback()
+	return storage.WalkInfo(ctx, fn)
+}
+
+func (s *snapshotter) mounts(sn storage.Snapshot) []mount.Mount {
+	var (
+		roFlag string
+	)
+
+	if sn.Kind == snapshot.KindView {
+		roFlag = "ro"
+	} else {
+		roFlag = "rw"
+	}
+
+	var mounts []mount.Mount
+
+	mounts = append(mounts, mount.Mount{
+		Source: s.getSnapshotDir(sn.ID),
+		Type:   "windows-layer",
+		Options: []string{
+			roFlag,
+		},
+	})
+
+	for _, ID := range sn.ParentIDs {
+		mounts = append(mounts, mount.Mount{
+			Source: s.getSnapshotDir(ID),
+			Type:   "windows-layer",
+		})
+	}
+
+	return mounts
+}
+
+func (s *snapshotter) getSnapshotDir(id string) string {
+	return filepath.Join(s.root, "snapshots", id)
+}
+
+func (s *snapshotter) createSnapshot(ctx context.Context, kind snapshot.Kind, key, parent string, opts []snapshot.Opt) ([]mount.Mount, error) {
+	ctx, t, err := s.ms.TransactionContext(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+
+	var committed bool
+	defer func() {
+		if committed == false {
+			rollbackWithLogging(ctx, t)
+		}
+	}()
+
+	newSnapshot, err := storage.CreateSnapshot(ctx, kind, key, parent, opts...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create snapshot")
+	}
+
+	switch kind {
+	case snapshot.KindView:
+		var parentID string
+		if len(newSnapshot.ParentIDs) != 0 {
+			parentID = newSnapshot.ParentIDs[0]
+		}
+		if err := hcsshim.CreateLayer(s.info, newSnapshot.ID, parentID); err != nil {
+			return nil, errors.Wrap(err, "failed to create layer")
+		}
+	case snapshot.KindActive:
+		layerChain := s.parentIDsToLayerChain(newSnapshot.ParentIDs)
+
+		var parentPath string
+		if len(layerChain) != 0 {
+			parentPath = layerChain[0]
+		}
+
+		if err := hcsshim.CreateSandboxLayer(s.info, newSnapshot.ID, parentPath, layerChain); err != nil {
+			return nil, errors.Wrap(err, "failed to create sandbox layer")
+		}
+
+		// TODO(darrenstahlmsft): Allow changing sandbox size
+	}
+
+	if err := t.Commit(); err != nil {
+		return nil, errors.Wrap(err, "commit failed")
+	}
+	committed = true
+
+	return s.mounts(newSnapshot), nil
+}
+
+func (s *snapshotter) parentIDsToLayerChain(parentIDs []string) []string {
+	var layerChain []string
+	for _, ID := range parentIDs {
+		layerChain = append(layerChain, s.getSnapshotDir(ID))
+	}
+	return layerChain
+}
+
+// getFileSystemType obtains the type of a file system through GetVolumeInformation
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa364993(v=vs.85).aspx
+func getFileSystemType(drive string) (fsType string, hr error) {
+	var (
+		modkernel32              = windows.NewLazySystemDLL("kernel32.dll")
+		procGetVolumeInformation = modkernel32.NewProc("GetVolumeInformationW")
+		buf                      = make([]uint16, 255)
+		size                     = windows.MAX_PATH + 1
+	)
+	if len(drive) != 1 {
+		return "", errors.New("getFileSystemType must be called with a drive letter")
+	}
+	drive += `:\`
+	n := uintptr(unsafe.Pointer(nil))
+	r0, _, _ := syscall.Syscall9(procGetVolumeInformation.Addr(), 8, uintptr(unsafe.Pointer(windows.StringToUTF16Ptr(drive))), n, n, n, n, n, uintptr(unsafe.Pointer(&buf[0])), uintptr(size), 0)
+	if int32(r0) < 0 {
+		hr = syscall.Errno(win32FromHresult(r0))
+	}
+	fsType = windows.UTF16ToString(buf)
+	return
+}
+
+// win32FromHresult is a helper function to get the win32 error code from an HRESULT
+func win32FromHresult(hr uintptr) uintptr {
+	if hr&0x1fff0000 == 0x00070000 {
+		return hr & 0xffff
+	}
+	return hr
 }

--- a/vendor/github.com/Microsoft/go-winio/archive/tar/LICENSE
+++ b/vendor/github.com/Microsoft/go-winio/archive/tar/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/Microsoft/go-winio/archive/tar/common.go
+++ b/vendor/github.com/Microsoft/go-winio/archive/tar/common.go
@@ -1,0 +1,344 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package tar implements access to tar archives.
+// It aims to cover most of the variations, including those produced
+// by GNU and BSD tars.
+//
+// References:
+//   http://www.freebsd.org/cgi/man.cgi?query=tar&sektion=5
+//   http://www.gnu.org/software/tar/manual/html_node/Standard.html
+//   http://pubs.opengroup.org/onlinepubs/9699919799/utilities/pax.html
+package tar
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"time"
+)
+
+const (
+	blockSize = 512
+
+	// Types
+	TypeReg           = '0'    // regular file
+	TypeRegA          = '\x00' // regular file
+	TypeLink          = '1'    // hard link
+	TypeSymlink       = '2'    // symbolic link
+	TypeChar          = '3'    // character device node
+	TypeBlock         = '4'    // block device node
+	TypeDir           = '5'    // directory
+	TypeFifo          = '6'    // fifo node
+	TypeCont          = '7'    // reserved
+	TypeXHeader       = 'x'    // extended header
+	TypeXGlobalHeader = 'g'    // global extended header
+	TypeGNULongName   = 'L'    // Next file has a long name
+	TypeGNULongLink   = 'K'    // Next file symlinks to a file w/ a long name
+	TypeGNUSparse     = 'S'    // sparse file
+)
+
+// A Header represents a single header in a tar archive.
+// Some fields may not be populated.
+type Header struct {
+	Name         string    // name of header file entry
+	Mode         int64     // permission and mode bits
+	Uid          int       // user id of owner
+	Gid          int       // group id of owner
+	Size         int64     // length in bytes
+	ModTime      time.Time // modified time
+	Typeflag     byte      // type of header entry
+	Linkname     string    // target name of link
+	Uname        string    // user name of owner
+	Gname        string    // group name of owner
+	Devmajor     int64     // major number of character or block device
+	Devminor     int64     // minor number of character or block device
+	AccessTime   time.Time // access time
+	ChangeTime   time.Time // status change time
+	CreationTime time.Time // creation time
+	Xattrs       map[string]string
+	Winheaders   map[string]string
+}
+
+// File name constants from the tar spec.
+const (
+	fileNameSize       = 100 // Maximum number of bytes in a standard tar name.
+	fileNamePrefixSize = 155 // Maximum number of ustar extension bytes.
+)
+
+// FileInfo returns an os.FileInfo for the Header.
+func (h *Header) FileInfo() os.FileInfo {
+	return headerFileInfo{h}
+}
+
+// headerFileInfo implements os.FileInfo.
+type headerFileInfo struct {
+	h *Header
+}
+
+func (fi headerFileInfo) Size() int64        { return fi.h.Size }
+func (fi headerFileInfo) IsDir() bool        { return fi.Mode().IsDir() }
+func (fi headerFileInfo) ModTime() time.Time { return fi.h.ModTime }
+func (fi headerFileInfo) Sys() interface{}   { return fi.h }
+
+// Name returns the base name of the file.
+func (fi headerFileInfo) Name() string {
+	if fi.IsDir() {
+		return path.Base(path.Clean(fi.h.Name))
+	}
+	return path.Base(fi.h.Name)
+}
+
+// Mode returns the permission and mode bits for the headerFileInfo.
+func (fi headerFileInfo) Mode() (mode os.FileMode) {
+	// Set file permission bits.
+	mode = os.FileMode(fi.h.Mode).Perm()
+
+	// Set setuid, setgid and sticky bits.
+	if fi.h.Mode&c_ISUID != 0 {
+		// setuid
+		mode |= os.ModeSetuid
+	}
+	if fi.h.Mode&c_ISGID != 0 {
+		// setgid
+		mode |= os.ModeSetgid
+	}
+	if fi.h.Mode&c_ISVTX != 0 {
+		// sticky
+		mode |= os.ModeSticky
+	}
+
+	// Set file mode bits.
+	// clear perm, setuid, setgid and sticky bits.
+	m := os.FileMode(fi.h.Mode) &^ 07777
+	if m == c_ISDIR {
+		// directory
+		mode |= os.ModeDir
+	}
+	if m == c_ISFIFO {
+		// named pipe (FIFO)
+		mode |= os.ModeNamedPipe
+	}
+	if m == c_ISLNK {
+		// symbolic link
+		mode |= os.ModeSymlink
+	}
+	if m == c_ISBLK {
+		// device file
+		mode |= os.ModeDevice
+	}
+	if m == c_ISCHR {
+		// Unix character device
+		mode |= os.ModeDevice
+		mode |= os.ModeCharDevice
+	}
+	if m == c_ISSOCK {
+		// Unix domain socket
+		mode |= os.ModeSocket
+	}
+
+	switch fi.h.Typeflag {
+	case TypeSymlink:
+		// symbolic link
+		mode |= os.ModeSymlink
+	case TypeChar:
+		// character device node
+		mode |= os.ModeDevice
+		mode |= os.ModeCharDevice
+	case TypeBlock:
+		// block device node
+		mode |= os.ModeDevice
+	case TypeDir:
+		// directory
+		mode |= os.ModeDir
+	case TypeFifo:
+		// fifo node
+		mode |= os.ModeNamedPipe
+	}
+
+	return mode
+}
+
+// sysStat, if non-nil, populates h from system-dependent fields of fi.
+var sysStat func(fi os.FileInfo, h *Header) error
+
+// Mode constants from the tar spec.
+const (
+	c_ISUID  = 04000   // Set uid
+	c_ISGID  = 02000   // Set gid
+	c_ISVTX  = 01000   // Save text (sticky bit)
+	c_ISDIR  = 040000  // Directory
+	c_ISFIFO = 010000  // FIFO
+	c_ISREG  = 0100000 // Regular file
+	c_ISLNK  = 0120000 // Symbolic link
+	c_ISBLK  = 060000  // Block special file
+	c_ISCHR  = 020000  // Character special file
+	c_ISSOCK = 0140000 // Socket
+)
+
+// Keywords for the PAX Extended Header
+const (
+	paxAtime        = "atime"
+	paxCharset      = "charset"
+	paxComment      = "comment"
+	paxCtime        = "ctime" // please note that ctime is not a valid pax header.
+	paxCreationTime = "LIBARCHIVE.creationtime"
+	paxGid          = "gid"
+	paxGname        = "gname"
+	paxLinkpath     = "linkpath"
+	paxMtime        = "mtime"
+	paxPath         = "path"
+	paxSize         = "size"
+	paxUid          = "uid"
+	paxUname        = "uname"
+	paxXattr        = "SCHILY.xattr."
+	paxWindows      = "MSWINDOWS."
+	paxNone         = ""
+)
+
+// FileInfoHeader creates a partially-populated Header from fi.
+// If fi describes a symlink, FileInfoHeader records link as the link target.
+// If fi describes a directory, a slash is appended to the name.
+// Because os.FileInfo's Name method returns only the base name of
+// the file it describes, it may be necessary to modify the Name field
+// of the returned header to provide the full path name of the file.
+func FileInfoHeader(fi os.FileInfo, link string) (*Header, error) {
+	if fi == nil {
+		return nil, errors.New("tar: FileInfo is nil")
+	}
+	fm := fi.Mode()
+	h := &Header{
+		Name:    fi.Name(),
+		ModTime: fi.ModTime(),
+		Mode:    int64(fm.Perm()), // or'd with c_IS* constants later
+	}
+	switch {
+	case fm.IsRegular():
+		h.Mode |= c_ISREG
+		h.Typeflag = TypeReg
+		h.Size = fi.Size()
+	case fi.IsDir():
+		h.Typeflag = TypeDir
+		h.Mode |= c_ISDIR
+		h.Name += "/"
+	case fm&os.ModeSymlink != 0:
+		h.Typeflag = TypeSymlink
+		h.Mode |= c_ISLNK
+		h.Linkname = link
+	case fm&os.ModeDevice != 0:
+		if fm&os.ModeCharDevice != 0 {
+			h.Mode |= c_ISCHR
+			h.Typeflag = TypeChar
+		} else {
+			h.Mode |= c_ISBLK
+			h.Typeflag = TypeBlock
+		}
+	case fm&os.ModeNamedPipe != 0:
+		h.Typeflag = TypeFifo
+		h.Mode |= c_ISFIFO
+	case fm&os.ModeSocket != 0:
+		h.Mode |= c_ISSOCK
+	default:
+		return nil, fmt.Errorf("archive/tar: unknown file mode %v", fm)
+	}
+	if fm&os.ModeSetuid != 0 {
+		h.Mode |= c_ISUID
+	}
+	if fm&os.ModeSetgid != 0 {
+		h.Mode |= c_ISGID
+	}
+	if fm&os.ModeSticky != 0 {
+		h.Mode |= c_ISVTX
+	}
+	// If possible, populate additional fields from OS-specific
+	// FileInfo fields.
+	if sys, ok := fi.Sys().(*Header); ok {
+		// This FileInfo came from a Header (not the OS). Use the
+		// original Header to populate all remaining fields.
+		h.Uid = sys.Uid
+		h.Gid = sys.Gid
+		h.Uname = sys.Uname
+		h.Gname = sys.Gname
+		h.AccessTime = sys.AccessTime
+		h.ChangeTime = sys.ChangeTime
+		if sys.Xattrs != nil {
+			h.Xattrs = make(map[string]string)
+			for k, v := range sys.Xattrs {
+				h.Xattrs[k] = v
+			}
+		}
+		if sys.Typeflag == TypeLink {
+			// hard link
+			h.Typeflag = TypeLink
+			h.Size = 0
+			h.Linkname = sys.Linkname
+		}
+	}
+	if sysStat != nil {
+		return h, sysStat(fi, h)
+	}
+	return h, nil
+}
+
+var zeroBlock = make([]byte, blockSize)
+
+// POSIX specifies a sum of the unsigned byte values, but the Sun tar uses signed byte values.
+// We compute and return both.
+func checksum(header []byte) (unsigned int64, signed int64) {
+	for i := 0; i < len(header); i++ {
+		if i == 148 {
+			// The chksum field (header[148:156]) is special: it should be treated as space bytes.
+			unsigned += ' ' * 8
+			signed += ' ' * 8
+			i += 7
+			continue
+		}
+		unsigned += int64(header[i])
+		signed += int64(int8(header[i]))
+	}
+	return
+}
+
+type slicer []byte
+
+func (sp *slicer) next(n int) (b []byte) {
+	s := *sp
+	b, *sp = s[0:n], s[n:]
+	return
+}
+
+func isASCII(s string) bool {
+	for _, c := range s {
+		if c >= 0x80 {
+			return false
+		}
+	}
+	return true
+}
+
+func toASCII(s string) string {
+	if isASCII(s) {
+		return s
+	}
+	var buf bytes.Buffer
+	for _, c := range s {
+		if c < 0x80 {
+			buf.WriteByte(byte(c))
+		}
+	}
+	return buf.String()
+}
+
+// isHeaderOnlyType checks if the given type flag is of the type that has no
+// data section even if a size is specified.
+func isHeaderOnlyType(flag byte) bool {
+	switch flag {
+	case TypeLink, TypeSymlink, TypeChar, TypeBlock, TypeDir, TypeFifo:
+		return true
+	default:
+		return false
+	}
+}

--- a/vendor/github.com/Microsoft/go-winio/archive/tar/reader.go
+++ b/vendor/github.com/Microsoft/go-winio/archive/tar/reader.go
@@ -1,0 +1,1002 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tar
+
+// TODO(dsymonds):
+//   - pax extensions
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/ioutil"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var (
+	ErrHeader = errors.New("archive/tar: invalid tar header")
+)
+
+const maxNanoSecondIntSize = 9
+
+// A Reader provides sequential access to the contents of a tar archive.
+// A tar archive consists of a sequence of files.
+// The Next method advances to the next file in the archive (including the first),
+// and then it can be treated as an io.Reader to access the file's data.
+type Reader struct {
+	r       io.Reader
+	err     error
+	pad     int64           // amount of padding (ignored) after current file entry
+	curr    numBytesReader  // reader for current file entry
+	hdrBuff [blockSize]byte // buffer to use in readHeader
+}
+
+type parser struct {
+	err error // Last error seen
+}
+
+// A numBytesReader is an io.Reader with a numBytes method, returning the number
+// of bytes remaining in the underlying encoded data.
+type numBytesReader interface {
+	io.Reader
+	numBytes() int64
+}
+
+// A regFileReader is a numBytesReader for reading file data from a tar archive.
+type regFileReader struct {
+	r  io.Reader // underlying reader
+	nb int64     // number of unread bytes for current file entry
+}
+
+// A sparseFileReader is a numBytesReader for reading sparse file data from a
+// tar archive.
+type sparseFileReader struct {
+	rfr   numBytesReader // Reads the sparse-encoded file data
+	sp    []sparseEntry  // The sparse map for the file
+	pos   int64          // Keeps track of file position
+	total int64          // Total size of the file
+}
+
+// A sparseEntry holds a single entry in a sparse file's sparse map.
+//
+// Sparse files are represented using a series of sparseEntrys.
+// Despite the name, a sparseEntry represents an actual data fragment that
+// references data found in the underlying archive stream. All regions not
+// covered by a sparseEntry are logically filled with zeros.
+//
+// For example, if the underlying raw file contains the 10-byte data:
+//	var compactData = "abcdefgh"
+//
+// And the sparse map has the following entries:
+//	var sp = []sparseEntry{
+//		{offset: 2,  numBytes: 5} // Data fragment for [2..7]
+//		{offset: 18, numBytes: 3} // Data fragment for [18..21]
+//	}
+//
+// Then the content of the resulting sparse file with a "real" size of 25 is:
+//	var sparseData = "\x00"*2 + "abcde" + "\x00"*11 + "fgh" + "\x00"*4
+type sparseEntry struct {
+	offset   int64 // Starting position of the fragment
+	numBytes int64 // Length of the fragment
+}
+
+// Keywords for GNU sparse files in a PAX extended header
+const (
+	paxGNUSparseNumBlocks = "GNU.sparse.numblocks"
+	paxGNUSparseOffset    = "GNU.sparse.offset"
+	paxGNUSparseNumBytes  = "GNU.sparse.numbytes"
+	paxGNUSparseMap       = "GNU.sparse.map"
+	paxGNUSparseName      = "GNU.sparse.name"
+	paxGNUSparseMajor     = "GNU.sparse.major"
+	paxGNUSparseMinor     = "GNU.sparse.minor"
+	paxGNUSparseSize      = "GNU.sparse.size"
+	paxGNUSparseRealSize  = "GNU.sparse.realsize"
+)
+
+// Keywords for old GNU sparse headers
+const (
+	oldGNUSparseMainHeaderOffset               = 386
+	oldGNUSparseMainHeaderIsExtendedOffset     = 482
+	oldGNUSparseMainHeaderNumEntries           = 4
+	oldGNUSparseExtendedHeaderIsExtendedOffset = 504
+	oldGNUSparseExtendedHeaderNumEntries       = 21
+	oldGNUSparseOffsetSize                     = 12
+	oldGNUSparseNumBytesSize                   = 12
+)
+
+// NewReader creates a new Reader reading from r.
+func NewReader(r io.Reader) *Reader { return &Reader{r: r} }
+
+// Next advances to the next entry in the tar archive.
+//
+// io.EOF is returned at the end of the input.
+func (tr *Reader) Next() (*Header, error) {
+	if tr.err != nil {
+		return nil, tr.err
+	}
+
+	var hdr *Header
+	var extHdrs map[string]string
+
+	// Externally, Next iterates through the tar archive as if it is a series of
+	// files. Internally, the tar format often uses fake "files" to add meta
+	// data that describes the next file. These meta data "files" should not
+	// normally be visible to the outside. As such, this loop iterates through
+	// one or more "header files" until it finds a "normal file".
+loop:
+	for {
+		tr.err = tr.skipUnread()
+		if tr.err != nil {
+			return nil, tr.err
+		}
+
+		hdr = tr.readHeader()
+		if tr.err != nil {
+			return nil, tr.err
+		}
+
+		// Check for PAX/GNU special headers and files.
+		switch hdr.Typeflag {
+		case TypeXHeader:
+			extHdrs, tr.err = parsePAX(tr)
+			if tr.err != nil {
+				return nil, tr.err
+			}
+			continue loop // This is a meta header affecting the next header
+		case TypeGNULongName, TypeGNULongLink:
+			var realname []byte
+			realname, tr.err = ioutil.ReadAll(tr)
+			if tr.err != nil {
+				return nil, tr.err
+			}
+
+			// Convert GNU extensions to use PAX headers.
+			if extHdrs == nil {
+				extHdrs = make(map[string]string)
+			}
+			var p parser
+			switch hdr.Typeflag {
+			case TypeGNULongName:
+				extHdrs[paxPath] = p.parseString(realname)
+			case TypeGNULongLink:
+				extHdrs[paxLinkpath] = p.parseString(realname)
+			}
+			if p.err != nil {
+				tr.err = p.err
+				return nil, tr.err
+			}
+			continue loop // This is a meta header affecting the next header
+		default:
+			mergePAX(hdr, extHdrs)
+
+			// Check for a PAX format sparse file
+			sp, err := tr.checkForGNUSparsePAXHeaders(hdr, extHdrs)
+			if err != nil {
+				tr.err = err
+				return nil, err
+			}
+			if sp != nil {
+				// Current file is a PAX format GNU sparse file.
+				// Set the current file reader to a sparse file reader.
+				tr.curr, tr.err = newSparseFileReader(tr.curr, sp, hdr.Size)
+				if tr.err != nil {
+					return nil, tr.err
+				}
+			}
+			break loop // This is a file, so stop
+		}
+	}
+	return hdr, nil
+}
+
+// checkForGNUSparsePAXHeaders checks the PAX headers for GNU sparse headers. If they are found, then
+// this function reads the sparse map and returns it. Unknown sparse formats are ignored, causing the file to
+// be treated as a regular file.
+func (tr *Reader) checkForGNUSparsePAXHeaders(hdr *Header, headers map[string]string) ([]sparseEntry, error) {
+	var sparseFormat string
+
+	// Check for sparse format indicators
+	major, majorOk := headers[paxGNUSparseMajor]
+	minor, minorOk := headers[paxGNUSparseMinor]
+	sparseName, sparseNameOk := headers[paxGNUSparseName]
+	_, sparseMapOk := headers[paxGNUSparseMap]
+	sparseSize, sparseSizeOk := headers[paxGNUSparseSize]
+	sparseRealSize, sparseRealSizeOk := headers[paxGNUSparseRealSize]
+
+	// Identify which, if any, sparse format applies from which PAX headers are set
+	if majorOk && minorOk {
+		sparseFormat = major + "." + minor
+	} else if sparseNameOk && sparseMapOk {
+		sparseFormat = "0.1"
+	} else if sparseSizeOk {
+		sparseFormat = "0.0"
+	} else {
+		// Not a PAX format GNU sparse file.
+		return nil, nil
+	}
+
+	// Check for unknown sparse format
+	if sparseFormat != "0.0" && sparseFormat != "0.1" && sparseFormat != "1.0" {
+		return nil, nil
+	}
+
+	// Update hdr from GNU sparse PAX headers
+	if sparseNameOk {
+		hdr.Name = sparseName
+	}
+	if sparseSizeOk {
+		realSize, err := strconv.ParseInt(sparseSize, 10, 0)
+		if err != nil {
+			return nil, ErrHeader
+		}
+		hdr.Size = realSize
+	} else if sparseRealSizeOk {
+		realSize, err := strconv.ParseInt(sparseRealSize, 10, 0)
+		if err != nil {
+			return nil, ErrHeader
+		}
+		hdr.Size = realSize
+	}
+
+	// Set up the sparse map, according to the particular sparse format in use
+	var sp []sparseEntry
+	var err error
+	switch sparseFormat {
+	case "0.0", "0.1":
+		sp, err = readGNUSparseMap0x1(headers)
+	case "1.0":
+		sp, err = readGNUSparseMap1x0(tr.curr)
+	}
+	return sp, err
+}
+
+// mergePAX merges well known headers according to PAX standard.
+// In general headers with the same name as those found
+// in the header struct overwrite those found in the header
+// struct with higher precision or longer values. Esp. useful
+// for name and linkname fields.
+func mergePAX(hdr *Header, headers map[string]string) error {
+	for k, v := range headers {
+		switch k {
+		case paxPath:
+			hdr.Name = v
+		case paxLinkpath:
+			hdr.Linkname = v
+		case paxGname:
+			hdr.Gname = v
+		case paxUname:
+			hdr.Uname = v
+		case paxUid:
+			uid, err := strconv.ParseInt(v, 10, 0)
+			if err != nil {
+				return err
+			}
+			hdr.Uid = int(uid)
+		case paxGid:
+			gid, err := strconv.ParseInt(v, 10, 0)
+			if err != nil {
+				return err
+			}
+			hdr.Gid = int(gid)
+		case paxAtime:
+			t, err := parsePAXTime(v)
+			if err != nil {
+				return err
+			}
+			hdr.AccessTime = t
+		case paxMtime:
+			t, err := parsePAXTime(v)
+			if err != nil {
+				return err
+			}
+			hdr.ModTime = t
+		case paxCtime:
+			t, err := parsePAXTime(v)
+			if err != nil {
+				return err
+			}
+			hdr.ChangeTime = t
+		case paxCreationTime:
+			t, err := parsePAXTime(v)
+			if err != nil {
+				return err
+			}
+			hdr.CreationTime = t
+		case paxSize:
+			size, err := strconv.ParseInt(v, 10, 0)
+			if err != nil {
+				return err
+			}
+			hdr.Size = int64(size)
+		default:
+			if strings.HasPrefix(k, paxXattr) {
+				if hdr.Xattrs == nil {
+					hdr.Xattrs = make(map[string]string)
+				}
+				hdr.Xattrs[k[len(paxXattr):]] = v
+			} else if strings.HasPrefix(k, paxWindows) {
+				if hdr.Winheaders == nil {
+					hdr.Winheaders = make(map[string]string)
+				}
+				hdr.Winheaders[k[len(paxWindows):]] = v
+			}
+		}
+	}
+	return nil
+}
+
+// parsePAXTime takes a string of the form %d.%d as described in
+// the PAX specification.
+func parsePAXTime(t string) (time.Time, error) {
+	buf := []byte(t)
+	pos := bytes.IndexByte(buf, '.')
+	var seconds, nanoseconds int64
+	var err error
+	if pos == -1 {
+		seconds, err = strconv.ParseInt(t, 10, 0)
+		if err != nil {
+			return time.Time{}, err
+		}
+	} else {
+		seconds, err = strconv.ParseInt(string(buf[:pos]), 10, 0)
+		if err != nil {
+			return time.Time{}, err
+		}
+		nano_buf := string(buf[pos+1:])
+		// Pad as needed before converting to a decimal.
+		// For example .030 -> .030000000 -> 30000000 nanoseconds
+		if len(nano_buf) < maxNanoSecondIntSize {
+			// Right pad
+			nano_buf += strings.Repeat("0", maxNanoSecondIntSize-len(nano_buf))
+		} else if len(nano_buf) > maxNanoSecondIntSize {
+			// Right truncate
+			nano_buf = nano_buf[:maxNanoSecondIntSize]
+		}
+		nanoseconds, err = strconv.ParseInt(string(nano_buf), 10, 0)
+		if err != nil {
+			return time.Time{}, err
+		}
+	}
+	ts := time.Unix(seconds, nanoseconds)
+	return ts, nil
+}
+
+// parsePAX parses PAX headers.
+// If an extended header (type 'x') is invalid, ErrHeader is returned
+func parsePAX(r io.Reader) (map[string]string, error) {
+	buf, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	sbuf := string(buf)
+
+	// For GNU PAX sparse format 0.0 support.
+	// This function transforms the sparse format 0.0 headers into sparse format 0.1 headers.
+	var sparseMap bytes.Buffer
+
+	headers := make(map[string]string)
+	// Each record is constructed as
+	//     "%d %s=%s\n", length, keyword, value
+	for len(sbuf) > 0 {
+		key, value, residual, err := parsePAXRecord(sbuf)
+		if err != nil {
+			return nil, ErrHeader
+		}
+		sbuf = residual
+
+		keyStr := string(key)
+		if keyStr == paxGNUSparseOffset || keyStr == paxGNUSparseNumBytes {
+			// GNU sparse format 0.0 special key. Write to sparseMap instead of using the headers map.
+			sparseMap.WriteString(value)
+			sparseMap.Write([]byte{','})
+		} else {
+			// Normal key. Set the value in the headers map.
+			headers[keyStr] = string(value)
+		}
+	}
+	if sparseMap.Len() != 0 {
+		// Add sparse info to headers, chopping off the extra comma
+		sparseMap.Truncate(sparseMap.Len() - 1)
+		headers[paxGNUSparseMap] = sparseMap.String()
+	}
+	return headers, nil
+}
+
+// parsePAXRecord parses the input PAX record string into a key-value pair.
+// If parsing is successful, it will slice off the currently read record and
+// return the remainder as r.
+//
+// A PAX record is of the following form:
+//	"%d %s=%s\n" % (size, key, value)
+func parsePAXRecord(s string) (k, v, r string, err error) {
+	// The size field ends at the first space.
+	sp := strings.IndexByte(s, ' ')
+	if sp == -1 {
+		return "", "", s, ErrHeader
+	}
+
+	// Parse the first token as a decimal integer.
+	n, perr := strconv.ParseInt(s[:sp], 10, 0) // Intentionally parse as native int
+	if perr != nil || n < 5 || int64(len(s)) < n {
+		return "", "", s, ErrHeader
+	}
+
+	// Extract everything between the space and the final newline.
+	rec, nl, rem := s[sp+1:n-1], s[n-1:n], s[n:]
+	if nl != "\n" {
+		return "", "", s, ErrHeader
+	}
+
+	// The first equals separates the key from the value.
+	eq := strings.IndexByte(rec, '=')
+	if eq == -1 {
+		return "", "", s, ErrHeader
+	}
+	return rec[:eq], rec[eq+1:], rem, nil
+}
+
+// parseString parses bytes as a NUL-terminated C-style string.
+// If a NUL byte is not found then the whole slice is returned as a string.
+func (*parser) parseString(b []byte) string {
+	n := 0
+	for n < len(b) && b[n] != 0 {
+		n++
+	}
+	return string(b[0:n])
+}
+
+// parseNumeric parses the input as being encoded in either base-256 or octal.
+// This function may return negative numbers.
+// If parsing fails or an integer overflow occurs, err will be set.
+func (p *parser) parseNumeric(b []byte) int64 {
+	// Check for base-256 (binary) format first.
+	// If the first bit is set, then all following bits constitute a two's
+	// complement encoded number in big-endian byte order.
+	if len(b) > 0 && b[0]&0x80 != 0 {
+		// Handling negative numbers relies on the following identity:
+		//	-a-1 == ^a
+		//
+		// If the number is negative, we use an inversion mask to invert the
+		// data bytes and treat the value as an unsigned number.
+		var inv byte // 0x00 if positive or zero, 0xff if negative
+		if b[0]&0x40 != 0 {
+			inv = 0xff
+		}
+
+		var x uint64
+		for i, c := range b {
+			c ^= inv // Inverts c only if inv is 0xff, otherwise does nothing
+			if i == 0 {
+				c &= 0x7f // Ignore signal bit in first byte
+			}
+			if (x >> 56) > 0 {
+				p.err = ErrHeader // Integer overflow
+				return 0
+			}
+			x = x<<8 | uint64(c)
+		}
+		if (x >> 63) > 0 {
+			p.err = ErrHeader // Integer overflow
+			return 0
+		}
+		if inv == 0xff {
+			return ^int64(x)
+		}
+		return int64(x)
+	}
+
+	// Normal case is base-8 (octal) format.
+	return p.parseOctal(b)
+}
+
+func (p *parser) parseOctal(b []byte) int64 {
+	// Because unused fields are filled with NULs, we need
+	// to skip leading NULs. Fields may also be padded with
+	// spaces or NULs.
+	// So we remove leading and trailing NULs and spaces to
+	// be sure.
+	b = bytes.Trim(b, " \x00")
+
+	if len(b) == 0 {
+		return 0
+	}
+	x, perr := strconv.ParseUint(p.parseString(b), 8, 64)
+	if perr != nil {
+		p.err = ErrHeader
+	}
+	return int64(x)
+}
+
+// skipUnread skips any unread bytes in the existing file entry, as well as any
+// alignment padding. It returns io.ErrUnexpectedEOF if any io.EOF is
+// encountered in the data portion; it is okay to hit io.EOF in the padding.
+//
+// Note that this function still works properly even when sparse files are being
+// used since numBytes returns the bytes remaining in the underlying io.Reader.
+func (tr *Reader) skipUnread() error {
+	dataSkip := tr.numBytes()      // Number of data bytes to skip
+	totalSkip := dataSkip + tr.pad // Total number of bytes to skip
+	tr.curr, tr.pad = nil, 0
+
+	// If possible, Seek to the last byte before the end of the data section.
+	// Do this because Seek is often lazy about reporting errors; this will mask
+	// the fact that the tar stream may be truncated. We can rely on the
+	// io.CopyN done shortly afterwards to trigger any IO errors.
+	var seekSkipped int64 // Number of bytes skipped via Seek
+	if sr, ok := tr.r.(io.Seeker); ok && dataSkip > 1 {
+		// Not all io.Seeker can actually Seek. For example, os.Stdin implements
+		// io.Seeker, but calling Seek always returns an error and performs
+		// no action. Thus, we try an innocent seek to the current position
+		// to see if Seek is really supported.
+		pos1, err := sr.Seek(0, os.SEEK_CUR)
+		if err == nil {
+			// Seek seems supported, so perform the real Seek.
+			pos2, err := sr.Seek(dataSkip-1, os.SEEK_CUR)
+			if err != nil {
+				tr.err = err
+				return tr.err
+			}
+			seekSkipped = pos2 - pos1
+		}
+	}
+
+	var copySkipped int64 // Number of bytes skipped via CopyN
+	copySkipped, tr.err = io.CopyN(ioutil.Discard, tr.r, totalSkip-seekSkipped)
+	if tr.err == io.EOF && seekSkipped+copySkipped < dataSkip {
+		tr.err = io.ErrUnexpectedEOF
+	}
+	return tr.err
+}
+
+func (tr *Reader) verifyChecksum(header []byte) bool {
+	if tr.err != nil {
+		return false
+	}
+
+	var p parser
+	given := p.parseOctal(header[148:156])
+	unsigned, signed := checksum(header)
+	return p.err == nil && (given == unsigned || given == signed)
+}
+
+// readHeader reads the next block header and assumes that the underlying reader
+// is already aligned to a block boundary.
+//
+// The err will be set to io.EOF only when one of the following occurs:
+//	* Exactly 0 bytes are read and EOF is hit.
+//	* Exactly 1 block of zeros is read and EOF is hit.
+//	* At least 2 blocks of zeros are read.
+func (tr *Reader) readHeader() *Header {
+	header := tr.hdrBuff[:]
+	copy(header, zeroBlock)
+
+	if _, tr.err = io.ReadFull(tr.r, header); tr.err != nil {
+		return nil // io.EOF is okay here
+	}
+
+	// Two blocks of zero bytes marks the end of the archive.
+	if bytes.Equal(header, zeroBlock[0:blockSize]) {
+		if _, tr.err = io.ReadFull(tr.r, header); tr.err != nil {
+			return nil // io.EOF is okay here
+		}
+		if bytes.Equal(header, zeroBlock[0:blockSize]) {
+			tr.err = io.EOF
+		} else {
+			tr.err = ErrHeader // zero block and then non-zero block
+		}
+		return nil
+	}
+
+	if !tr.verifyChecksum(header) {
+		tr.err = ErrHeader
+		return nil
+	}
+
+	// Unpack
+	var p parser
+	hdr := new(Header)
+	s := slicer(header)
+
+	hdr.Name = p.parseString(s.next(100))
+	hdr.Mode = p.parseNumeric(s.next(8))
+	hdr.Uid = int(p.parseNumeric(s.next(8)))
+	hdr.Gid = int(p.parseNumeric(s.next(8)))
+	hdr.Size = p.parseNumeric(s.next(12))
+	hdr.ModTime = time.Unix(p.parseNumeric(s.next(12)), 0)
+	s.next(8) // chksum
+	hdr.Typeflag = s.next(1)[0]
+	hdr.Linkname = p.parseString(s.next(100))
+
+	// The remainder of the header depends on the value of magic.
+	// The original (v7) version of tar had no explicit magic field,
+	// so its magic bytes, like the rest of the block, are NULs.
+	magic := string(s.next(8)) // contains version field as well.
+	var format string
+	switch {
+	case magic[:6] == "ustar\x00": // POSIX tar (1003.1-1988)
+		if string(header[508:512]) == "tar\x00" {
+			format = "star"
+		} else {
+			format = "posix"
+		}
+	case magic == "ustar  \x00": // old GNU tar
+		format = "gnu"
+	}
+
+	switch format {
+	case "posix", "gnu", "star":
+		hdr.Uname = p.parseString(s.next(32))
+		hdr.Gname = p.parseString(s.next(32))
+		devmajor := s.next(8)
+		devminor := s.next(8)
+		if hdr.Typeflag == TypeChar || hdr.Typeflag == TypeBlock {
+			hdr.Devmajor = p.parseNumeric(devmajor)
+			hdr.Devminor = p.parseNumeric(devminor)
+		}
+		var prefix string
+		switch format {
+		case "posix", "gnu":
+			prefix = p.parseString(s.next(155))
+		case "star":
+			prefix = p.parseString(s.next(131))
+			hdr.AccessTime = time.Unix(p.parseNumeric(s.next(12)), 0)
+			hdr.ChangeTime = time.Unix(p.parseNumeric(s.next(12)), 0)
+		}
+		if len(prefix) > 0 {
+			hdr.Name = prefix + "/" + hdr.Name
+		}
+	}
+
+	if p.err != nil {
+		tr.err = p.err
+		return nil
+	}
+
+	nb := hdr.Size
+	if isHeaderOnlyType(hdr.Typeflag) {
+		nb = 0
+	}
+	if nb < 0 {
+		tr.err = ErrHeader
+		return nil
+	}
+
+	// Set the current file reader.
+	tr.pad = -nb & (blockSize - 1) // blockSize is a power of two
+	tr.curr = &regFileReader{r: tr.r, nb: nb}
+
+	// Check for old GNU sparse format entry.
+	if hdr.Typeflag == TypeGNUSparse {
+		// Get the real size of the file.
+		hdr.Size = p.parseNumeric(header[483:495])
+		if p.err != nil {
+			tr.err = p.err
+			return nil
+		}
+
+		// Read the sparse map.
+		sp := tr.readOldGNUSparseMap(header)
+		if tr.err != nil {
+			return nil
+		}
+
+		// Current file is a GNU sparse file. Update the current file reader.
+		tr.curr, tr.err = newSparseFileReader(tr.curr, sp, hdr.Size)
+		if tr.err != nil {
+			return nil
+		}
+	}
+
+	return hdr
+}
+
+// readOldGNUSparseMap reads the sparse map as stored in the old GNU sparse format.
+// The sparse map is stored in the tar header if it's small enough. If it's larger than four entries,
+// then one or more extension headers are used to store the rest of the sparse map.
+func (tr *Reader) readOldGNUSparseMap(header []byte) []sparseEntry {
+	var p parser
+	isExtended := header[oldGNUSparseMainHeaderIsExtendedOffset] != 0
+	spCap := oldGNUSparseMainHeaderNumEntries
+	if isExtended {
+		spCap += oldGNUSparseExtendedHeaderNumEntries
+	}
+	sp := make([]sparseEntry, 0, spCap)
+	s := slicer(header[oldGNUSparseMainHeaderOffset:])
+
+	// Read the four entries from the main tar header
+	for i := 0; i < oldGNUSparseMainHeaderNumEntries; i++ {
+		offset := p.parseNumeric(s.next(oldGNUSparseOffsetSize))
+		numBytes := p.parseNumeric(s.next(oldGNUSparseNumBytesSize))
+		if p.err != nil {
+			tr.err = p.err
+			return nil
+		}
+		if offset == 0 && numBytes == 0 {
+			break
+		}
+		sp = append(sp, sparseEntry{offset: offset, numBytes: numBytes})
+	}
+
+	for isExtended {
+		// There are more entries. Read an extension header and parse its entries.
+		sparseHeader := make([]byte, blockSize)
+		if _, tr.err = io.ReadFull(tr.r, sparseHeader); tr.err != nil {
+			return nil
+		}
+		isExtended = sparseHeader[oldGNUSparseExtendedHeaderIsExtendedOffset] != 0
+		s = slicer(sparseHeader)
+		for i := 0; i < oldGNUSparseExtendedHeaderNumEntries; i++ {
+			offset := p.parseNumeric(s.next(oldGNUSparseOffsetSize))
+			numBytes := p.parseNumeric(s.next(oldGNUSparseNumBytesSize))
+			if p.err != nil {
+				tr.err = p.err
+				return nil
+			}
+			if offset == 0 && numBytes == 0 {
+				break
+			}
+			sp = append(sp, sparseEntry{offset: offset, numBytes: numBytes})
+		}
+	}
+	return sp
+}
+
+// readGNUSparseMap1x0 reads the sparse map as stored in GNU's PAX sparse format
+// version 1.0. The format of the sparse map consists of a series of
+// newline-terminated numeric fields. The first field is the number of entries
+// and is always present. Following this are the entries, consisting of two
+// fields (offset, numBytes). This function must stop reading at the end
+// boundary of the block containing the last newline.
+//
+// Note that the GNU manual says that numeric values should be encoded in octal
+// format. However, the GNU tar utility itself outputs these values in decimal.
+// As such, this library treats values as being encoded in decimal.
+func readGNUSparseMap1x0(r io.Reader) ([]sparseEntry, error) {
+	var cntNewline int64
+	var buf bytes.Buffer
+	var blk = make([]byte, blockSize)
+
+	// feedTokens copies data in numBlock chunks from r into buf until there are
+	// at least cnt newlines in buf. It will not read more blocks than needed.
+	var feedTokens = func(cnt int64) error {
+		for cntNewline < cnt {
+			if _, err := io.ReadFull(r, blk); err != nil {
+				if err == io.EOF {
+					err = io.ErrUnexpectedEOF
+				}
+				return err
+			}
+			buf.Write(blk)
+			for _, c := range blk {
+				if c == '\n' {
+					cntNewline++
+				}
+			}
+		}
+		return nil
+	}
+
+	// nextToken gets the next token delimited by a newline. This assumes that
+	// at least one newline exists in the buffer.
+	var nextToken = func() string {
+		cntNewline--
+		tok, _ := buf.ReadString('\n')
+		return tok[:len(tok)-1] // Cut off newline
+	}
+
+	// Parse for the number of entries.
+	// Use integer overflow resistant math to check this.
+	if err := feedTokens(1); err != nil {
+		return nil, err
+	}
+	numEntries, err := strconv.ParseInt(nextToken(), 10, 0) // Intentionally parse as native int
+	if err != nil || numEntries < 0 || int(2*numEntries) < int(numEntries) {
+		return nil, ErrHeader
+	}
+
+	// Parse for all member entries.
+	// numEntries is trusted after this since a potential attacker must have
+	// committed resources proportional to what this library used.
+	if err := feedTokens(2 * numEntries); err != nil {
+		return nil, err
+	}
+	sp := make([]sparseEntry, 0, numEntries)
+	for i := int64(0); i < numEntries; i++ {
+		offset, err := strconv.ParseInt(nextToken(), 10, 64)
+		if err != nil {
+			return nil, ErrHeader
+		}
+		numBytes, err := strconv.ParseInt(nextToken(), 10, 64)
+		if err != nil {
+			return nil, ErrHeader
+		}
+		sp = append(sp, sparseEntry{offset: offset, numBytes: numBytes})
+	}
+	return sp, nil
+}
+
+// readGNUSparseMap0x1 reads the sparse map as stored in GNU's PAX sparse format
+// version 0.1. The sparse map is stored in the PAX headers.
+func readGNUSparseMap0x1(extHdrs map[string]string) ([]sparseEntry, error) {
+	// Get number of entries.
+	// Use integer overflow resistant math to check this.
+	numEntriesStr := extHdrs[paxGNUSparseNumBlocks]
+	numEntries, err := strconv.ParseInt(numEntriesStr, 10, 0) // Intentionally parse as native int
+	if err != nil || numEntries < 0 || int(2*numEntries) < int(numEntries) {
+		return nil, ErrHeader
+	}
+
+	// There should be two numbers in sparseMap for each entry.
+	sparseMap := strings.Split(extHdrs[paxGNUSparseMap], ",")
+	if int64(len(sparseMap)) != 2*numEntries {
+		return nil, ErrHeader
+	}
+
+	// Loop through the entries in the sparse map.
+	// numEntries is trusted now.
+	sp := make([]sparseEntry, 0, numEntries)
+	for i := int64(0); i < numEntries; i++ {
+		offset, err := strconv.ParseInt(sparseMap[2*i], 10, 64)
+		if err != nil {
+			return nil, ErrHeader
+		}
+		numBytes, err := strconv.ParseInt(sparseMap[2*i+1], 10, 64)
+		if err != nil {
+			return nil, ErrHeader
+		}
+		sp = append(sp, sparseEntry{offset: offset, numBytes: numBytes})
+	}
+	return sp, nil
+}
+
+// numBytes returns the number of bytes left to read in the current file's entry
+// in the tar archive, or 0 if there is no current file.
+func (tr *Reader) numBytes() int64 {
+	if tr.curr == nil {
+		// No current file, so no bytes
+		return 0
+	}
+	return tr.curr.numBytes()
+}
+
+// Read reads from the current entry in the tar archive.
+// It returns 0, io.EOF when it reaches the end of that entry,
+// until Next is called to advance to the next entry.
+//
+// Calling Read on special types like TypeLink, TypeSymLink, TypeChar,
+// TypeBlock, TypeDir, and TypeFifo returns 0, io.EOF regardless of what
+// the Header.Size claims.
+func (tr *Reader) Read(b []byte) (n int, err error) {
+	if tr.err != nil {
+		return 0, tr.err
+	}
+	if tr.curr == nil {
+		return 0, io.EOF
+	}
+
+	n, err = tr.curr.Read(b)
+	if err != nil && err != io.EOF {
+		tr.err = err
+	}
+	return
+}
+
+func (rfr *regFileReader) Read(b []byte) (n int, err error) {
+	if rfr.nb == 0 {
+		// file consumed
+		return 0, io.EOF
+	}
+	if int64(len(b)) > rfr.nb {
+		b = b[0:rfr.nb]
+	}
+	n, err = rfr.r.Read(b)
+	rfr.nb -= int64(n)
+
+	if err == io.EOF && rfr.nb > 0 {
+		err = io.ErrUnexpectedEOF
+	}
+	return
+}
+
+// numBytes returns the number of bytes left to read in the file's data in the tar archive.
+func (rfr *regFileReader) numBytes() int64 {
+	return rfr.nb
+}
+
+// newSparseFileReader creates a new sparseFileReader, but validates all of the
+// sparse entries before doing so.
+func newSparseFileReader(rfr numBytesReader, sp []sparseEntry, total int64) (*sparseFileReader, error) {
+	if total < 0 {
+		return nil, ErrHeader // Total size cannot be negative
+	}
+
+	// Validate all sparse entries. These are the same checks as performed by
+	// the BSD tar utility.
+	for i, s := range sp {
+		switch {
+		case s.offset < 0 || s.numBytes < 0:
+			return nil, ErrHeader // Negative values are never okay
+		case s.offset > math.MaxInt64-s.numBytes:
+			return nil, ErrHeader // Integer overflow with large length
+		case s.offset+s.numBytes > total:
+			return nil, ErrHeader // Region extends beyond the "real" size
+		case i > 0 && sp[i-1].offset+sp[i-1].numBytes > s.offset:
+			return nil, ErrHeader // Regions can't overlap and must be in order
+		}
+	}
+	return &sparseFileReader{rfr: rfr, sp: sp, total: total}, nil
+}
+
+// readHole reads a sparse hole ending at endOffset.
+func (sfr *sparseFileReader) readHole(b []byte, endOffset int64) int {
+	n64 := endOffset - sfr.pos
+	if n64 > int64(len(b)) {
+		n64 = int64(len(b))
+	}
+	n := int(n64)
+	for i := 0; i < n; i++ {
+		b[i] = 0
+	}
+	sfr.pos += n64
+	return n
+}
+
+// Read reads the sparse file data in expanded form.
+func (sfr *sparseFileReader) Read(b []byte) (n int, err error) {
+	// Skip past all empty fragments.
+	for len(sfr.sp) > 0 && sfr.sp[0].numBytes == 0 {
+		sfr.sp = sfr.sp[1:]
+	}
+
+	// If there are no more fragments, then it is possible that there
+	// is one last sparse hole.
+	if len(sfr.sp) == 0 {
+		// This behavior matches the BSD tar utility.
+		// However, GNU tar stops returning data even if sfr.total is unmet.
+		if sfr.pos < sfr.total {
+			return sfr.readHole(b, sfr.total), nil
+		}
+		return 0, io.EOF
+	}
+
+	// In front of a data fragment, so read a hole.
+	if sfr.pos < sfr.sp[0].offset {
+		return sfr.readHole(b, sfr.sp[0].offset), nil
+	}
+
+	// In a data fragment, so read from it.
+	// This math is overflow free since we verify that offset and numBytes can
+	// be safely added when creating the sparseFileReader.
+	endPos := sfr.sp[0].offset + sfr.sp[0].numBytes // End offset of fragment
+	bytesLeft := endPos - sfr.pos                   // Bytes left in fragment
+	if int64(len(b)) > bytesLeft {
+		b = b[:bytesLeft]
+	}
+
+	n, err = sfr.rfr.Read(b)
+	sfr.pos += int64(n)
+	if err == io.EOF {
+		if sfr.pos < endPos {
+			err = io.ErrUnexpectedEOF // There was supposed to be more data
+		} else if sfr.pos < sfr.total {
+			err = nil // There is still an implicit sparse hole at the end
+		}
+	}
+
+	if sfr.pos == endPos {
+		sfr.sp = sfr.sp[1:] // We are done with this fragment, so pop it
+	}
+	return n, err
+}
+
+// numBytes returns the number of bytes left to read in the sparse file's
+// sparse-encoded data in the tar archive.
+func (sfr *sparseFileReader) numBytes() int64 {
+	return sfr.rfr.numBytes()
+}

--- a/vendor/github.com/Microsoft/go-winio/archive/tar/stat_atim.go
+++ b/vendor/github.com/Microsoft/go-winio/archive/tar/stat_atim.go
@@ -1,0 +1,20 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux dragonfly openbsd solaris
+
+package tar
+
+import (
+	"syscall"
+	"time"
+)
+
+func statAtime(st *syscall.Stat_t) time.Time {
+	return time.Unix(st.Atim.Unix())
+}
+
+func statCtime(st *syscall.Stat_t) time.Time {
+	return time.Unix(st.Ctim.Unix())
+}

--- a/vendor/github.com/Microsoft/go-winio/archive/tar/stat_atimespec.go
+++ b/vendor/github.com/Microsoft/go-winio/archive/tar/stat_atimespec.go
@@ -1,0 +1,20 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin freebsd netbsd
+
+package tar
+
+import (
+	"syscall"
+	"time"
+)
+
+func statAtime(st *syscall.Stat_t) time.Time {
+	return time.Unix(st.Atimespec.Unix())
+}
+
+func statCtime(st *syscall.Stat_t) time.Time {
+	return time.Unix(st.Ctimespec.Unix())
+}

--- a/vendor/github.com/Microsoft/go-winio/archive/tar/stat_unix.go
+++ b/vendor/github.com/Microsoft/go-winio/archive/tar/stat_unix.go
@@ -1,0 +1,32 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux darwin dragonfly freebsd openbsd netbsd solaris
+
+package tar
+
+import (
+	"os"
+	"syscall"
+)
+
+func init() {
+	sysStat = statUnix
+}
+
+func statUnix(fi os.FileInfo, h *Header) error {
+	sys, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return nil
+	}
+	h.Uid = int(sys.Uid)
+	h.Gid = int(sys.Gid)
+	// TODO(bradfitz): populate username & group.  os/user
+	// doesn't cache LookupId lookups, and lacks group
+	// lookup functions.
+	h.AccessTime = statAtime(sys)
+	h.ChangeTime = statCtime(sys)
+	// TODO(bradfitz): major/minor device numbers?
+	return nil
+}

--- a/vendor/github.com/Microsoft/go-winio/archive/tar/writer.go
+++ b/vendor/github.com/Microsoft/go-winio/archive/tar/writer.go
@@ -1,0 +1,444 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tar
+
+// TODO(dsymonds):
+// - catch more errors (no first header, etc.)
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var (
+	ErrWriteTooLong    = errors.New("archive/tar: write too long")
+	ErrFieldTooLong    = errors.New("archive/tar: header field too long")
+	ErrWriteAfterClose = errors.New("archive/tar: write after close")
+	errInvalidHeader   = errors.New("archive/tar: header field too long or contains invalid values")
+)
+
+// A Writer provides sequential writing of a tar archive in POSIX.1 format.
+// A tar archive consists of a sequence of files.
+// Call WriteHeader to begin a new file, and then call Write to supply that file's data,
+// writing at most hdr.Size bytes in total.
+type Writer struct {
+	w          io.Writer
+	err        error
+	nb         int64 // number of unwritten bytes for current file entry
+	pad        int64 // amount of padding to write after current file entry
+	closed     bool
+	usedBinary bool            // whether the binary numeric field extension was used
+	preferPax  bool            // use pax header instead of binary numeric header
+	hdrBuff    [blockSize]byte // buffer to use in writeHeader when writing a regular header
+	paxHdrBuff [blockSize]byte // buffer to use in writeHeader when writing a pax header
+}
+
+type formatter struct {
+	err error // Last error seen
+}
+
+// NewWriter creates a new Writer writing to w.
+func NewWriter(w io.Writer) *Writer { return &Writer{w: w, preferPax: true} }
+
+// Flush finishes writing the current file (optional).
+func (tw *Writer) Flush() error {
+	if tw.nb > 0 {
+		tw.err = fmt.Errorf("archive/tar: missed writing %d bytes", tw.nb)
+		return tw.err
+	}
+
+	n := tw.nb + tw.pad
+	for n > 0 && tw.err == nil {
+		nr := n
+		if nr > blockSize {
+			nr = blockSize
+		}
+		var nw int
+		nw, tw.err = tw.w.Write(zeroBlock[0:nr])
+		n -= int64(nw)
+	}
+	tw.nb = 0
+	tw.pad = 0
+	return tw.err
+}
+
+// Write s into b, terminating it with a NUL if there is room.
+func (f *formatter) formatString(b []byte, s string) {
+	if len(s) > len(b) {
+		f.err = ErrFieldTooLong
+		return
+	}
+	ascii := toASCII(s)
+	copy(b, ascii)
+	if len(ascii) < len(b) {
+		b[len(ascii)] = 0
+	}
+}
+
+// Encode x as an octal ASCII string and write it into b with leading zeros.
+func (f *formatter) formatOctal(b []byte, x int64) {
+	s := strconv.FormatInt(x, 8)
+	// leading zeros, but leave room for a NUL.
+	for len(s)+1 < len(b) {
+		s = "0" + s
+	}
+	f.formatString(b, s)
+}
+
+// fitsInBase256 reports whether x can be encoded into n bytes using base-256
+// encoding. Unlike octal encoding, base-256 encoding does not require that the
+// string ends with a NUL character. Thus, all n bytes are available for output.
+//
+// If operating in binary mode, this assumes strict GNU binary mode; which means
+// that the first byte can only be either 0x80 or 0xff. Thus, the first byte is
+// equivalent to the sign bit in two's complement form.
+func fitsInBase256(n int, x int64) bool {
+	var binBits = uint(n-1) * 8
+	return n >= 9 || (x >= -1<<binBits && x < 1<<binBits)
+}
+
+// Write x into b, as binary (GNUtar/star extension).
+func (f *formatter) formatNumeric(b []byte, x int64) {
+	if fitsInBase256(len(b), x) {
+		for i := len(b) - 1; i >= 0; i-- {
+			b[i] = byte(x)
+			x >>= 8
+		}
+		b[0] |= 0x80 // Highest bit indicates binary format
+		return
+	}
+
+	f.formatOctal(b, 0) // Last resort, just write zero
+	f.err = ErrFieldTooLong
+}
+
+var (
+	minTime = time.Unix(0, 0)
+	// There is room for 11 octal digits (33 bits) of mtime.
+	maxTime = minTime.Add((1<<33 - 1) * time.Second)
+)
+
+// WriteHeader writes hdr and prepares to accept the file's contents.
+// WriteHeader calls Flush if it is not the first header.
+// Calling after a Close will return ErrWriteAfterClose.
+func (tw *Writer) WriteHeader(hdr *Header) error {
+	return tw.writeHeader(hdr, true)
+}
+
+// WriteHeader writes hdr and prepares to accept the file's contents.
+// WriteHeader calls Flush if it is not the first header.
+// Calling after a Close will return ErrWriteAfterClose.
+// As this method is called internally by writePax header to allow it to
+// suppress writing the pax header.
+func (tw *Writer) writeHeader(hdr *Header, allowPax bool) error {
+	if tw.closed {
+		return ErrWriteAfterClose
+	}
+	if tw.err == nil {
+		tw.Flush()
+	}
+	if tw.err != nil {
+		return tw.err
+	}
+
+	// a map to hold pax header records, if any are needed
+	paxHeaders := make(map[string]string)
+
+	// TODO(shanemhansen): we might want to use PAX headers for
+	// subsecond time resolution, but for now let's just capture
+	// too long fields or non ascii characters
+
+	var f formatter
+	var header []byte
+
+	// We need to select which scratch buffer to use carefully,
+	// since this method is called recursively to write PAX headers.
+	// If allowPax is true, this is the non-recursive call, and we will use hdrBuff.
+	// If allowPax is false, we are being called by writePAXHeader, and hdrBuff is
+	// already being used by the non-recursive call, so we must use paxHdrBuff.
+	header = tw.hdrBuff[:]
+	if !allowPax {
+		header = tw.paxHdrBuff[:]
+	}
+	copy(header, zeroBlock)
+	s := slicer(header)
+
+	// Wrappers around formatter that automatically sets paxHeaders if the
+	// argument extends beyond the capacity of the input byte slice.
+	var formatString = func(b []byte, s string, paxKeyword string) {
+		needsPaxHeader := paxKeyword != paxNone && len(s) > len(b) || !isASCII(s)
+		if needsPaxHeader {
+			paxHeaders[paxKeyword] = s
+			return
+		}
+		f.formatString(b, s)
+	}
+	var formatNumeric = func(b []byte, x int64, paxKeyword string) {
+		// Try octal first.
+		s := strconv.FormatInt(x, 8)
+		if len(s) < len(b) {
+			f.formatOctal(b, x)
+			return
+		}
+
+		// If it is too long for octal, and PAX is preferred, use a PAX header.
+		if paxKeyword != paxNone && tw.preferPax {
+			f.formatOctal(b, 0)
+			s := strconv.FormatInt(x, 10)
+			paxHeaders[paxKeyword] = s
+			return
+		}
+
+		tw.usedBinary = true
+		f.formatNumeric(b, x)
+	}
+	var formatTime = func(b []byte, t time.Time, paxKeyword string) {
+		var unixTime int64
+		if !t.Before(minTime) && !t.After(maxTime) {
+			unixTime = t.Unix()
+		}
+		formatNumeric(b, unixTime, paxNone)
+
+		// Write a PAX header if the time didn't fit precisely.
+		if paxKeyword != "" && tw.preferPax && allowPax && (t.Nanosecond() != 0 || !t.Before(minTime) || !t.After(maxTime)) {
+			paxHeaders[paxKeyword] = formatPAXTime(t)
+		}
+	}
+
+	// keep a reference to the filename to allow to overwrite it later if we detect that we can use ustar longnames instead of pax
+	pathHeaderBytes := s.next(fileNameSize)
+
+	formatString(pathHeaderBytes, hdr.Name, paxPath)
+
+	f.formatOctal(s.next(8), hdr.Mode)               // 100:108
+	formatNumeric(s.next(8), int64(hdr.Uid), paxUid) // 108:116
+	formatNumeric(s.next(8), int64(hdr.Gid), paxGid) // 116:124
+	formatNumeric(s.next(12), hdr.Size, paxSize)     // 124:136
+	formatTime(s.next(12), hdr.ModTime, paxMtime)    // 136:148
+	s.next(8)                                        // chksum (148:156)
+	s.next(1)[0] = hdr.Typeflag                      // 156:157
+
+	formatString(s.next(100), hdr.Linkname, paxLinkpath)
+
+	copy(s.next(8), []byte("ustar\x0000"))          // 257:265
+	formatString(s.next(32), hdr.Uname, paxUname)   // 265:297
+	formatString(s.next(32), hdr.Gname, paxGname)   // 297:329
+	formatNumeric(s.next(8), hdr.Devmajor, paxNone) // 329:337
+	formatNumeric(s.next(8), hdr.Devminor, paxNone) // 337:345
+
+	// keep a reference to the prefix to allow to overwrite it later if we detect that we can use ustar longnames instead of pax
+	prefixHeaderBytes := s.next(155)
+	formatString(prefixHeaderBytes, "", paxNone) // 345:500  prefix
+
+	// Use the GNU magic instead of POSIX magic if we used any GNU extensions.
+	if tw.usedBinary {
+		copy(header[257:265], []byte("ustar  \x00"))
+	}
+
+	_, paxPathUsed := paxHeaders[paxPath]
+	// try to use a ustar header when only the name is too long
+	if !tw.preferPax && len(paxHeaders) == 1 && paxPathUsed {
+		prefix, suffix, ok := splitUSTARPath(hdr.Name)
+		if ok {
+			// Since we can encode in USTAR format, disable PAX header.
+			delete(paxHeaders, paxPath)
+
+			// Update the path fields
+			formatString(pathHeaderBytes, suffix, paxNone)
+			formatString(prefixHeaderBytes, prefix, paxNone)
+		}
+	}
+
+	// The chksum field is terminated by a NUL and a space.
+	// This is different from the other octal fields.
+	chksum, _ := checksum(header)
+	f.formatOctal(header[148:155], chksum) // Never fails
+	header[155] = ' '
+
+	// Check if there were any formatting errors.
+	if f.err != nil {
+		tw.err = f.err
+		return tw.err
+	}
+
+	if allowPax {
+		if !hdr.AccessTime.IsZero() {
+			paxHeaders[paxAtime] = formatPAXTime(hdr.AccessTime)
+		}
+		if !hdr.ChangeTime.IsZero() {
+			paxHeaders[paxCtime] = formatPAXTime(hdr.ChangeTime)
+		}
+		if !hdr.CreationTime.IsZero() {
+			paxHeaders[paxCreationTime] = formatPAXTime(hdr.CreationTime)
+		}
+		for k, v := range hdr.Xattrs {
+			paxHeaders[paxXattr+k] = v
+		}
+		for k, v := range hdr.Winheaders {
+			paxHeaders[paxWindows+k] = v
+		}
+	}
+
+	if len(paxHeaders) > 0 {
+		if !allowPax {
+			return errInvalidHeader
+		}
+		if err := tw.writePAXHeader(hdr, paxHeaders); err != nil {
+			return err
+		}
+	}
+	tw.nb = int64(hdr.Size)
+	tw.pad = (blockSize - (tw.nb % blockSize)) % blockSize
+
+	_, tw.err = tw.w.Write(header)
+	return tw.err
+}
+
+func formatPAXTime(t time.Time) string {
+	sec := t.Unix()
+	usec := t.Nanosecond()
+	s := strconv.FormatInt(sec, 10)
+	if usec != 0 {
+		s = fmt.Sprintf("%s.%09d", s, usec)
+	}
+	return s
+}
+
+// splitUSTARPath splits a path according to USTAR prefix and suffix rules.
+// If the path is not splittable, then it will return ("", "", false).
+func splitUSTARPath(name string) (prefix, suffix string, ok bool) {
+	length := len(name)
+	if length <= fileNameSize || !isASCII(name) {
+		return "", "", false
+	} else if length > fileNamePrefixSize+1 {
+		length = fileNamePrefixSize + 1
+	} else if name[length-1] == '/' {
+		length--
+	}
+
+	i := strings.LastIndex(name[:length], "/")
+	nlen := len(name) - i - 1 // nlen is length of suffix
+	plen := i                 // plen is length of prefix
+	if i <= 0 || nlen > fileNameSize || nlen == 0 || plen > fileNamePrefixSize {
+		return "", "", false
+	}
+	return name[:i], name[i+1:], true
+}
+
+// writePaxHeader writes an extended pax header to the
+// archive.
+func (tw *Writer) writePAXHeader(hdr *Header, paxHeaders map[string]string) error {
+	// Prepare extended header
+	ext := new(Header)
+	ext.Typeflag = TypeXHeader
+	// Setting ModTime is required for reader parsing to
+	// succeed, and seems harmless enough.
+	ext.ModTime = hdr.ModTime
+	// The spec asks that we namespace our pseudo files
+	// with the current pid.  However, this results in differing outputs
+	// for identical inputs.  As such, the constant 0 is now used instead.
+	// golang.org/issue/12358
+	dir, file := path.Split(hdr.Name)
+	fullName := path.Join(dir, "PaxHeaders.0", file)
+
+	ascii := toASCII(fullName)
+	if len(ascii) > 100 {
+		ascii = ascii[:100]
+	}
+	ext.Name = ascii
+	// Construct the body
+	var buf bytes.Buffer
+
+	// Keys are sorted before writing to body to allow deterministic output.
+	var keys []string
+	for k := range paxHeaders {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		fmt.Fprint(&buf, formatPAXRecord(k, paxHeaders[k]))
+	}
+
+	ext.Size = int64(len(buf.Bytes()))
+	if err := tw.writeHeader(ext, false); err != nil {
+		return err
+	}
+	if _, err := tw.Write(buf.Bytes()); err != nil {
+		return err
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// formatPAXRecord formats a single PAX record, prefixing it with the
+// appropriate length.
+func formatPAXRecord(k, v string) string {
+	const padding = 3 // Extra padding for ' ', '=', and '\n'
+	size := len(k) + len(v) + padding
+	size += len(strconv.Itoa(size))
+	record := fmt.Sprintf("%d %s=%s\n", size, k, v)
+
+	// Final adjustment if adding size field increased the record size.
+	if len(record) != size {
+		size = len(record)
+		record = fmt.Sprintf("%d %s=%s\n", size, k, v)
+	}
+	return record
+}
+
+// Write writes to the current entry in the tar archive.
+// Write returns the error ErrWriteTooLong if more than
+// hdr.Size bytes are written after WriteHeader.
+func (tw *Writer) Write(b []byte) (n int, err error) {
+	if tw.closed {
+		err = ErrWriteAfterClose
+		return
+	}
+	overwrite := false
+	if int64(len(b)) > tw.nb {
+		b = b[0:tw.nb]
+		overwrite = true
+	}
+	n, err = tw.w.Write(b)
+	tw.nb -= int64(n)
+	if err == nil && overwrite {
+		err = ErrWriteTooLong
+		return
+	}
+	tw.err = err
+	return
+}
+
+// Close closes the tar archive, flushing any unwritten
+// data to the underlying writer.
+func (tw *Writer) Close() error {
+	if tw.err != nil || tw.closed {
+		return tw.err
+	}
+	tw.Flush()
+	tw.closed = true
+	if tw.err != nil {
+		return tw.err
+	}
+
+	// trailer: two zero blocks
+	for i := 0; i < 2; i++ {
+		_, tw.err = tw.w.Write(zeroBlock)
+		if tw.err != nil {
+			break
+		}
+	}
+	return tw.err
+}

--- a/vendor/github.com/Microsoft/go-winio/backuptar/noop.go
+++ b/vendor/github.com/Microsoft/go-winio/backuptar/noop.go
@@ -1,0 +1,4 @@
+// +build !windows
+// This file only exists to allow go get on non-Windows platforms.
+
+package backuptar

--- a/vendor/github.com/Microsoft/go-winio/backuptar/tar.go
+++ b/vendor/github.com/Microsoft/go-winio/backuptar/tar.go
@@ -1,0 +1,353 @@
+// +build windows
+
+package backuptar
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/Microsoft/go-winio/archive/tar" // until archive/tar supports pax extensions in its interface
+)
+
+const (
+	c_ISUID  = 04000   // Set uid
+	c_ISGID  = 02000   // Set gid
+	c_ISVTX  = 01000   // Save text (sticky bit)
+	c_ISDIR  = 040000  // Directory
+	c_ISFIFO = 010000  // FIFO
+	c_ISREG  = 0100000 // Regular file
+	c_ISLNK  = 0120000 // Symbolic link
+	c_ISBLK  = 060000  // Block special file
+	c_ISCHR  = 020000  // Character special file
+	c_ISSOCK = 0140000 // Socket
+)
+
+const (
+	hdrFileAttributes        = "fileattr"
+	hdrSecurityDescriptor    = "sd"
+	hdrRawSecurityDescriptor = "rawsd"
+	hdrMountPoint            = "mountpoint"
+)
+
+func writeZeroes(w io.Writer, count int64) error {
+	buf := make([]byte, 8192)
+	c := len(buf)
+	for i := int64(0); i < count; i += int64(c) {
+		if int64(c) > count-i {
+			c = int(count - i)
+		}
+		_, err := w.Write(buf[:c])
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func copySparse(t *tar.Writer, br *winio.BackupStreamReader) error {
+	curOffset := int64(0)
+	for {
+		bhdr, err := br.Next()
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
+		if err != nil {
+			return err
+		}
+		if bhdr.Id != winio.BackupSparseBlock {
+			return fmt.Errorf("unexpected stream %d", bhdr.Id)
+		}
+
+		// archive/tar does not support writing sparse files
+		// so just write zeroes to catch up to the current offset.
+		err = writeZeroes(t, bhdr.Offset-curOffset)
+		if bhdr.Size == 0 {
+			break
+		}
+		n, err := io.Copy(t, br)
+		if err != nil {
+			return err
+		}
+		curOffset = bhdr.Offset + n
+	}
+	return nil
+}
+
+// BasicInfoHeader creates a tar header from basic file information.
+func BasicInfoHeader(name string, size int64, fileInfo *winio.FileBasicInfo) *tar.Header {
+	hdr := &tar.Header{
+		Name:         filepath.ToSlash(name),
+		Size:         size,
+		Typeflag:     tar.TypeReg,
+		ModTime:      time.Unix(0, fileInfo.LastWriteTime.Nanoseconds()),
+		ChangeTime:   time.Unix(0, fileInfo.ChangeTime.Nanoseconds()),
+		AccessTime:   time.Unix(0, fileInfo.LastAccessTime.Nanoseconds()),
+		CreationTime: time.Unix(0, fileInfo.CreationTime.Nanoseconds()),
+		Winheaders:   make(map[string]string),
+	}
+	hdr.Winheaders[hdrFileAttributes] = fmt.Sprintf("%d", fileInfo.FileAttributes)
+
+	if (fileInfo.FileAttributes & syscall.FILE_ATTRIBUTE_DIRECTORY) != 0 {
+		hdr.Mode |= c_ISDIR
+		hdr.Size = 0
+		hdr.Typeflag = tar.TypeDir
+	}
+	return hdr
+}
+
+// WriteTarFileFromBackupStream writes a file to a tar writer using data from a Win32 backup stream.
+//
+// This encodes Win32 metadata as tar pax vendor extensions starting with MSWINDOWS.
+//
+// The additional Win32 metadata is:
+//
+// MSWINDOWS.fileattr: The Win32 file attributes, as a decimal value
+//
+// MSWINDOWS.rawsd: The Win32 security descriptor, in raw binary format
+//
+// MSWINDOWS.mountpoint: If present, this is a mount point and not a symlink, even though the type is '2' (symlink)
+func WriteTarFileFromBackupStream(t *tar.Writer, r io.Reader, name string, size int64, fileInfo *winio.FileBasicInfo) error {
+	name = filepath.ToSlash(name)
+	hdr := BasicInfoHeader(name, size, fileInfo)
+	br := winio.NewBackupStreamReader(r)
+	var dataHdr *winio.BackupHeader
+	for dataHdr == nil {
+		bhdr, err := br.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		switch bhdr.Id {
+		case winio.BackupData:
+			hdr.Mode |= c_ISREG
+			dataHdr = bhdr
+		case winio.BackupSecurity:
+			sd, err := ioutil.ReadAll(br)
+			if err != nil {
+				return err
+			}
+			hdr.Winheaders[hdrRawSecurityDescriptor] = base64.StdEncoding.EncodeToString(sd)
+
+		case winio.BackupReparseData:
+			hdr.Mode |= c_ISLNK
+			hdr.Typeflag = tar.TypeSymlink
+			reparseBuffer, err := ioutil.ReadAll(br)
+			rp, err := winio.DecodeReparsePoint(reparseBuffer)
+			if err != nil {
+				return err
+			}
+			if rp.IsMountPoint {
+				hdr.Winheaders[hdrMountPoint] = "1"
+			}
+			hdr.Linkname = rp.Target
+		case winio.BackupEaData, winio.BackupLink, winio.BackupPropertyData, winio.BackupObjectId, winio.BackupTxfsData:
+			// ignore these streams
+		default:
+			return fmt.Errorf("%s: unknown stream ID %d", name, bhdr.Id)
+		}
+	}
+
+	err := t.WriteHeader(hdr)
+	if err != nil {
+		return err
+	}
+
+	if dataHdr != nil {
+		// A data stream was found. Copy the data.
+		if (dataHdr.Attributes & winio.StreamSparseAttributes) == 0 {
+			if size != dataHdr.Size {
+				return fmt.Errorf("%s: mismatch between file size %d and header size %d", name, size, dataHdr.Size)
+			}
+			_, err = io.Copy(t, br)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = copySparse(t, br)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	// Look for streams after the data stream. The only ones we handle are alternate data streams.
+	// Other streams may have metadata that could be serialized, but the tar header has already
+	// been written. In practice, this means that we don't get EA or TXF metadata.
+	for {
+		bhdr, err := br.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		switch bhdr.Id {
+		case winio.BackupAlternateData:
+			altName := bhdr.Name
+			if strings.HasSuffix(altName, ":$DATA") {
+				altName = altName[:len(altName)-len(":$DATA")]
+			}
+			if (bhdr.Attributes & winio.StreamSparseAttributes) == 0 {
+				hdr = &tar.Header{
+					Name:       name + altName,
+					Mode:       hdr.Mode,
+					Typeflag:   tar.TypeReg,
+					Size:       bhdr.Size,
+					ModTime:    hdr.ModTime,
+					AccessTime: hdr.AccessTime,
+					ChangeTime: hdr.ChangeTime,
+				}
+				err = t.WriteHeader(hdr)
+				if err != nil {
+					return err
+				}
+				_, err = io.Copy(t, br)
+				if err != nil {
+					return err
+				}
+
+			} else {
+				// Unsupported for now, since the size of the alternate stream is not present
+				// in the backup stream until after the data has been read.
+				return errors.New("tar of sparse alternate data streams is unsupported")
+			}
+		case winio.BackupEaData, winio.BackupLink, winio.BackupPropertyData, winio.BackupObjectId, winio.BackupTxfsData:
+			// ignore these streams
+		default:
+			return fmt.Errorf("%s: unknown stream ID %d after data", name, bhdr.Id)
+		}
+	}
+	return nil
+}
+
+// FileInfoFromHeader retrieves basic Win32 file information from a tar header, using the additional metadata written by
+// WriteTarFileFromBackupStream.
+func FileInfoFromHeader(hdr *tar.Header) (name string, size int64, fileInfo *winio.FileBasicInfo, err error) {
+	name = hdr.Name
+	if hdr.Typeflag == tar.TypeReg || hdr.Typeflag == tar.TypeRegA {
+		size = hdr.Size
+	}
+	fileInfo = &winio.FileBasicInfo{
+		LastAccessTime: syscall.NsecToFiletime(hdr.AccessTime.UnixNano()),
+		LastWriteTime:  syscall.NsecToFiletime(hdr.ModTime.UnixNano()),
+		ChangeTime:     syscall.NsecToFiletime(hdr.ChangeTime.UnixNano()),
+		CreationTime:   syscall.NsecToFiletime(hdr.CreationTime.UnixNano()),
+	}
+	if attrStr, ok := hdr.Winheaders[hdrFileAttributes]; ok {
+		attr, err := strconv.ParseUint(attrStr, 10, 32)
+		if err != nil {
+			return "", 0, nil, err
+		}
+		fileInfo.FileAttributes = uintptr(attr)
+	} else {
+		if hdr.Typeflag == tar.TypeDir {
+			fileInfo.FileAttributes |= syscall.FILE_ATTRIBUTE_DIRECTORY
+		}
+	}
+	return
+}
+
+// WriteBackupStreamFromTarFile writes a Win32 backup stream from the current tar file. Since this function may process multiple
+// tar file entries in order to collect all the alternate data streams for the file, it returns the next
+// tar file that was not processed, or io.EOF is there are no more.
+func WriteBackupStreamFromTarFile(w io.Writer, t *tar.Reader, hdr *tar.Header) (*tar.Header, error) {
+	bw := winio.NewBackupStreamWriter(w)
+	var sd []byte
+	var err error
+	// Maintaining old SDDL-based behavior for backward compatibility.  All new tar headers written
+	// by this library will have raw binary for the security descriptor.
+	if sddl, ok := hdr.Winheaders[hdrSecurityDescriptor]; ok {
+		sd, err = winio.SddlToSecurityDescriptor(sddl)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if sdraw, ok := hdr.Winheaders[hdrRawSecurityDescriptor]; ok {
+		sd, err = base64.StdEncoding.DecodeString(sdraw)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(sd) != 0 {
+		bhdr := winio.BackupHeader{
+			Id:   winio.BackupSecurity,
+			Size: int64(len(sd)),
+		}
+		err := bw.WriteHeader(&bhdr)
+		if err != nil {
+			return nil, err
+		}
+		_, err = bw.Write(sd)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if hdr.Typeflag == tar.TypeSymlink {
+		_, isMountPoint := hdr.Winheaders[hdrMountPoint]
+		rp := winio.ReparsePoint{
+			Target:       filepath.FromSlash(hdr.Linkname),
+			IsMountPoint: isMountPoint,
+		}
+		reparse := winio.EncodeReparsePoint(&rp)
+		bhdr := winio.BackupHeader{
+			Id:   winio.BackupReparseData,
+			Size: int64(len(reparse)),
+		}
+		err := bw.WriteHeader(&bhdr)
+		if err != nil {
+			return nil, err
+		}
+		_, err = bw.Write(reparse)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if hdr.Typeflag == tar.TypeReg || hdr.Typeflag == tar.TypeRegA {
+		bhdr := winio.BackupHeader{
+			Id:   winio.BackupData,
+			Size: hdr.Size,
+		}
+		err := bw.WriteHeader(&bhdr)
+		if err != nil {
+			return nil, err
+		}
+		_, err = io.Copy(bw, t)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// Copy all the alternate data streams and return the next non-ADS header.
+	for {
+		ahdr, err := t.Next()
+		if err != nil {
+			return nil, err
+		}
+		if ahdr.Typeflag != tar.TypeReg || !strings.HasPrefix(ahdr.Name, hdr.Name+":") {
+			return ahdr, nil
+		}
+		bhdr := winio.BackupHeader{
+			Id:   winio.BackupAlternateData,
+			Size: ahdr.Size,
+			Name: ahdr.Name[len(hdr.Name):] + ":$DATA",
+		}
+		err = bw.WriteHeader(&bhdr)
+		if err != nil {
+			return nil, err
+		}
+		_, err = io.Copy(bw, t)
+		if err != nil {
+			return nil, err
+		}
+	}
+}

--- a/vendor/github.com/Microsoft/hcsshim/layerutils.go
+++ b/vendor/github.com/Microsoft/hcsshim/layerutils.go
@@ -32,6 +32,9 @@ type driverInfo struct {
 	HomeDirp *uint16
 }
 
+// FilterDriver is the constant to define using the Windows Filter Driver
+const FilterDriver = 1
+
 func convertDriverInfo(info DriverInfo) (driverInfo, error) {
 	homedirp, err := syscall.UTF16PtrFromString(info.HomeDir)
 	if err != nil {

--- a/windows/hcsshim.go
+++ b/windows/hcsshim.go
@@ -4,7 +4,6 @@ package windows
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,7 +11,6 @@ import (
 	"github.com/Microsoft/hcsshim"
 	"github.com/Microsoft/opengcs/client"
 	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/log"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 )
@@ -50,14 +48,14 @@ func newWindowsContainerConfig(ctx context.Context, owner, id string, spec *spec
 	}
 	conf.IgnoreFlushesDuringBoot = spec.Windows.IgnoreFlushesDuringBoot
 
-	if len(spec.Windows.LayerFolders) < 1 {
+	if len(spec.Windows.LayerFolders) < 2 {
 		return nil, errors.Wrap(errdefs.ErrInvalidArgument,
-			"spec.Windows.LayerFolders must have at least 1 layers")
+			"spec.Windows.LayerFolders must have at least 2 layers")
 	}
 	var (
-		layerFolders    = spec.Windows.LayerFolders
-		homeDir         = filepath.Dir(layerFolders[0])
-		layerFolderPath = filepath.Join(homeDir, id)
+		layerFolderPath = spec.Windows.LayerFolders[0]
+		layerFolders    = spec.Windows.LayerFolders[1:]
+		layerID         = filepath.Base(layerFolderPath)
 	)
 
 	// TODO: use the create request Mount for those
@@ -72,41 +70,16 @@ func newWindowsContainerConfig(ctx context.Context, owner, id string, spec *spec
 			Path: layerPath,
 		})
 	}
-
-	var (
-		di = hcsshim.DriverInfo{
-			Flavour: 1, // filter driver
-			HomeDir: homeDir,
-		}
-	)
 	conf.LayerFolderPath = layerFolderPath
 
-	// TODO: Once there is a snapshotter for windows, this can be deleted.
-	// The R/W Layer should come from the Rootfs Mounts provided
-	//
-	// Windows doesn't support creating a container with a readonly
-	// filesystem, so always create a RW one
-	if err = hcsshim.CreateSandboxLayer(di, id, layerFolders[0], layerFolders); err != nil {
-		return nil, errors.Wrapf(err, "failed to create sandbox layer for %s: layers: %#v, driverInfo: %#v",
-			id, layerFolders, di)
-	}
-	defer func() {
-		if err != nil {
-			removeLayer(ctx, conf.LayerFolderPath)
-		}
-	}()
-
-	if err = hcsshim.ActivateLayer(di, id); err != nil {
-		return nil, errors.Wrapf(err, "failed to activate layer %s", conf.LayerFolderPath)
+	var di = hcsshim.DriverInfo{
+		Flavour: 1, // filter driver
+		HomeDir: filepath.Dir(layerFolderPath),
 	}
 
-	if err = hcsshim.PrepareLayer(di, id, layerFolders); err != nil {
-		return nil, errors.Wrapf(err, "failed to prepare layer %s", conf.LayerFolderPath)
-	}
-
-	conf.VolumePath, err = hcsshim.GetLayerMountPath(di, id)
+	conf.VolumePath, err = hcsshim.GetLayerMountPath(di, layerID)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to getmount path for layer %s: driverInfo: %#v", id, di)
+		return nil, errors.Wrapf(err, "failed to getmount path for layer %s: driverInfo: %#v", layerID, di)
 	}
 
 	if spec.Windows.HyperV != nil {
@@ -192,41 +165,6 @@ func newLinuxConfig(ctx context.Context, owner, id string, spec *specs.Spec) (*h
 	}
 
 	return conf, nil
-}
-
-// removeLayer deletes the given layer, all associated containers must have
-// been shutdown for this to succeed.
-func removeLayer(ctx context.Context, path string) error {
-	var (
-		err        error
-		layerID    = filepath.Base(path)
-		parentPath = filepath.Dir(path)
-		di         = hcsshim.DriverInfo{
-			Flavour: 1, // filter driver
-			HomeDir: parentPath,
-		}
-	)
-
-	if err = hcsshim.UnprepareLayer(di, layerID); err != nil {
-		log.G(ctx).WithError(err).Warnf("failed to unprepare layer %s for removal", path)
-	}
-
-	if err = hcsshim.DeactivateLayer(di, layerID); err != nil {
-		log.G(ctx).WithError(err).Warnf("failed to deactivate layer %s for removal", path)
-	}
-
-	removePath := filepath.Join(parentPath, fmt.Sprintf("%s-removing", layerID))
-	if err = os.Rename(path, removePath); err != nil {
-		log.G(ctx).WithError(err).Warnf("failed to rename container layer %s for removal", path)
-		removePath = path
-	}
-
-	if err = hcsshim.DestroyLayer(di, removePath); err != nil {
-		log.G(ctx).WithError(err).Errorf("failed to remove container layer %s", removePath)
-		return err
-	}
-
-	return nil
 }
 
 func newProcessConfig(processSpec *specs.Process, pset *pipeSet) *hcsshim.ProcessConfig {

--- a/windows/runtime.go
+++ b/windows/runtime.go
@@ -10,13 +10,11 @@ import (
 	"time"
 
 	"github.com/Microsoft/hcsshim"
-	"github.com/boltdb/bolt"
 	eventsapi "github.com/containerd/containerd/api/services/events/v1"
-	containerdtypes "github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/events"
 	"github.com/containerd/containerd/log"
-	"github.com/containerd/containerd/metadata"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/runtime"
@@ -55,11 +53,6 @@ func New(ic *plugin.InitContext) (interface{}, error) {
 		return nil, errors.Wrapf(err, "could not create state directory at %s", ic.Root)
 	}
 
-	m, err := ic.Get(plugin.MetadataPlugin)
-	if err != nil {
-		return nil, err
-	}
-
 	r := &windowsRuntime{
 		root:    ic.Root,
 		pidPool: newPidPool(),
@@ -69,7 +62,6 @@ func New(ic *plugin.InitContext) (interface{}, error) {
 		// TODO(mlaventure): windows needs a stat monitor
 		monitor: nil,
 		tasks:   runtime.NewTaskList(),
-		db:      m.(*metadata.DB),
 	}
 
 	// Load our existing containers and kill/delete them. We don't support
@@ -90,7 +82,6 @@ type windowsRuntime struct {
 
 	monitor runtime.TaskMonitor
 	tasks   *runtime.TaskList
-	db      *metadata.DB
 }
 
 func (r *windowsRuntime) ID() string {
@@ -124,7 +115,11 @@ func (r *windowsRuntime) Create(ctx context.Context, id string, opts runtime.Cre
 		createOpts.TerminateDuration = defaultTerminateDuration
 	}
 
-	return r.newTask(ctx, namespace, id, spec, opts.IO, createOpts)
+	for _, m := range opts.Rootfs {
+		spec.Windows.LayerFolders = append(spec.Windows.LayerFolders, m.Source)
+	}
+
+	return r.newTask(ctx, namespace, id, opts.Rootfs, spec, opts.IO, createOpts)
 }
 
 func (r *windowsRuntime) Get(ctx context.Context, id string) (runtime.Task, error) {
@@ -208,14 +203,19 @@ func (r *windowsRuntime) Delete(ctx context.Context, t runtime.Task) (*runtime.E
 		ns, _ := namespaces.Namespace(ctx)
 		serviceCtx := log.WithLogger(context.Background(), log.GetLogger(ctx))
 		serviceCtx = namespaces.WithNamespace(serviceCtx, ns)
-		r.serviceTask(serviceCtx, ns, wt.id+"_servicing", wt.spec)
+		r.serviceTask(serviceCtx, ns, wt.id+"_servicing", wt.rootfs, wt.spec)
+	}
+
+	if err := mount.UnmountAll(wt.rootfs[0].Source, 0); err != nil {
+		log.G(ctx).WithError(err).WithField("path", wt.rootfs[0].Source).
+			Warn("failed to unmount rootfs on failure")
 	}
 
 	// We were never started, return failure
 	return rtExit, nil
 }
 
-func (r *windowsRuntime) newTask(ctx context.Context, namespace, id string, spec *specs.Spec, io runtime.IO, createOpts *hcsshimtypes.CreateOptions) (*task, error) {
+func (r *windowsRuntime) newTask(ctx context.Context, namespace, id string, rootfs []mount.Mount, spec *specs.Spec, io runtime.IO, createOpts *hcsshimtypes.CreateOptions) (*task, error) {
 	var (
 		err  error
 		pset *pipeSet
@@ -240,6 +240,18 @@ func (r *windowsRuntime) newTask(ctx context.Context, namespace, id string, spec
 		}
 	}()
 
+	if err := mount.All(rootfs, ""); err != nil {
+		return nil, errors.Wrap(err, "failed to mount rootfs")
+	}
+	defer func() {
+		if err != nil {
+			if err := mount.UnmountAll(rootfs[0].Source, 0); err != nil {
+				log.G(ctx).WithError(err).WithField("path", rootfs[0].Source).
+					Warn("failed to unmount rootfs on failure")
+			}
+		}
+	}()
+
 	var (
 		conf *hcsshim.ContainerConfig
 		nsid = namespace + "-" + id
@@ -247,31 +259,6 @@ func (r *windowsRuntime) newTask(ctx context.Context, namespace, id string, spec
 	if conf, err = newWindowsContainerConfig(ctx, hcsshimOwner, nsid, spec); err != nil {
 		return nil, err
 	}
-	defer func() {
-		if err != nil {
-			removeLayer(ctx, conf.LayerFolderPath)
-		}
-	}()
-
-	// TODO: remove this once we have a windows snapshotter
-	// Store the LayerFolder in the db so we can clean it if we die
-	if err = r.db.Update(func(tx *bolt.Tx) error {
-		s := newLayerFolderStore(tx)
-		return s.Create(nsid, conf.LayerFolderPath)
-	}); err != nil {
-		return nil, err
-	}
-	defer func() {
-		if err != nil {
-			if dbErr := r.db.Update(func(tx *bolt.Tx) error {
-				s := newLayerFolderStore(tx)
-				return s.Delete(nsid)
-			}); dbErr != nil {
-				log.G(ctx).WithField("id", id).
-					Error("failed to remove key from metadata")
-			}
-		}
-	}()
 
 	ctr, err := hcsshim.CreateContainer(nsid, conf)
 	if err != nil {
@@ -300,6 +287,7 @@ func (r *windowsRuntime) newTask(ctx context.Context, namespace, id string, spec
 		hyperV:            spec.Windows.HyperV != nil,
 		publisher:         r.publisher,
 		rwLayer:           conf.LayerFolderPath,
+		rootfs:            rootfs,
 		pidPool:           r.pidPool,
 		hcsContainer:      ctr,
 		terminateDuration: createOpts.TerminateDuration,
@@ -311,14 +299,6 @@ func (r *windowsRuntime) newTask(ctx context.Context, namespace, id string, spec
 	}
 	r.tasks.Add(ctx, t)
 
-	var rootfs []*containerdtypes.Mount
-	for _, l := range append([]string{t.rwLayer}, spec.Windows.LayerFolders...) {
-		rootfs = append(rootfs, &containerdtypes.Mount{
-			Type:   "windows-layer",
-			Source: l,
-		})
-	}
-
 	r.publisher.Publish(ctx,
 		runtime.TaskCreateEventTopic,
 		&eventsapi.TaskCreate{
@@ -329,8 +309,8 @@ func (r *windowsRuntime) newTask(ctx context.Context, namespace, id string, spec
 				Stderr:   io.Stderr,
 				Terminal: io.Terminal,
 			},
-			Pid:    t.pid,
-			Rootfs: rootfs,
+			Pid: t.pid,
+			//Rootfs: rootfs,
 			// TODO: what should be in Bundle for windows?
 		})
 
@@ -359,34 +339,10 @@ func (r *windowsRuntime) cleanup(ctx context.Context) {
 			container.Wait()
 		}
 		container.Close()
-
-		// TODO: remove this once we have a windows snapshotter
-		var layerFolderPath string
-		if err := r.db.View(func(tx *bolt.Tx) error {
-			s := newLayerFolderStore(tx)
-			l, e := s.Get(p.ID)
-			if err == nil {
-				layerFolderPath = l
-			}
-			return e
-		}); err == nil && layerFolderPath != "" {
-			removeLayer(ctx, layerFolderPath)
-			if dbErr := r.db.Update(func(tx *bolt.Tx) error {
-				s := newLayerFolderStore(tx)
-				return s.Delete(p.ID)
-			}); dbErr != nil {
-				log.G(ctx).WithField("id", p.ID).
-					Error("failed to remove key from metadata")
-			}
-		} else {
-			log.G(ctx).WithField("id", p.ID).
-				Debug("key not found in metadata, R/W layer may be leaked")
-		}
-
 	}
 }
 
-func (r *windowsRuntime) serviceTask(ctx context.Context, namespace, id string, spec *specs.Spec) {
+func (r *windowsRuntime) serviceTask(ctx context.Context, namespace, id string, rootfs []mount.Mount, spec *specs.Spec) {
 	var (
 		err        error
 		t          *task
@@ -396,7 +352,7 @@ func (r *windowsRuntime) serviceTask(ctx context.Context, namespace, id string, 
 		}
 	)
 
-	t, err = r.newTask(ctx, namespace, id, spec, io, createOpts)
+	t, err = r.newTask(ctx, namespace, id, rootfs, spec, io, createOpts)
 	if err != nil {
 		log.G(ctx).WithError(err).WithField("id", id).
 			Warn("failed to created servicing task")

--- a/windows/task.go
+++ b/windows/task.go
@@ -11,6 +11,7 @@ import (
 	eventsapi "github.com/containerd/containerd/api/services/events/v1"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/events"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/runtime"
 	"github.com/containerd/containerd/windows/hcsshimtypes"
 	"github.com/containerd/typeurl"
@@ -33,6 +34,7 @@ type task struct {
 
 	publisher events.Publisher
 	rwLayer   string
+	rootfs    []mount.Mount
 
 	pidPool           *pidPool
 	hcsContainer      hcsshim.Container
@@ -394,7 +396,6 @@ func (t *task) cleanup() {
 	for _, p := range t.processes {
 		t.removeProcessNL(p.id)
 	}
-	removeLayer(context.Background(), t.rwLayer)
 	t.Unlock()
 }
 


### PR DESCRIPTION
This is a work in progress (nearly finished) implementation of snapshotter and differ on Windows and the corresponding changes in ctr and Windows runtime to use the new snapshotter/differ.

```
PS H:\git\go\src\github.com\containerd\containerd> ctr.exe pull docker.io/microsoft/nanoserver:latest
docker.io/microsoft/nanoserver:latest:                                            resolved       |++++++++++++++++++++++++++++++++++++++|
manifest-sha256:8b4ab2db6fd93063b50233a17fc0084015a3fcc774d7b17528bb4baf97aa7949: done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:5cd49617cf500abea7b9f47d82b70455d816ae6b497cabc1fc86a9522d19a828:    done           |++++++++++++++++++++++++++++++++++++++|
config-sha256:00f2c6e8b100efb59b4febf77b09b2588b3fc55f45e2e035e8208e1cceb94339:   done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:bce2fbc256ea437a87dadac2f69aabd25bed4f56255549090056c1131fad0277:    done           |++++++++++++++++++++++++++++++++++++++|
elapsed: 25.0s                                                                    total:  374.8  (15.0 MiB/s)
unpacking sha256:8b4ab2db6fd93063b50233a17fc0084015a3fcc774d7b17528bb4baf97aa7949...
done
PS H:\git\go\src\github.com\containerd\containerd> ctr.exe run --rm docker.io/microsoft/nanoserver:latest test
Microsoft Windows [Version 10.0.14393]
(c) 2016 Microsoft Corporation. All rights reserved.

C:\>exit
exit
PS H:\git\go\src\github.com\containerd\containerd>
```

Work left to be done is as follows:

- [x] Implement snapshotter to manage Windows sandbox layers
- [x] Implement Apply in the differ to enable pulling of images
- [x] Implement mount.All/mount.UnmountAll on Windows. mount.Mount is left unimplemented, as the concept of mounting an individual layer does not make sense in the context of Windows. Also target is ignored as it is not specifiable on Windows
- [x] Remove runtime image management and remove the assumptions made using Docker layers (including removing the db from the Windows runtime)
- [x] Enable tests removing the shims used on Windows
- [ ] Get Diff to work, currently untested
- [ ] Validate and pass tests without using Docker created layers
- [ ] Allow configuration of sandbox size during snapshot create (or update). May be a followup
- [ ] Merge layer extraction and diffing with archiver. The current interface does not have enough context to use on Windows. This needs to be reworked. Some code will likely move to hcsshim as part of this
- [ ] Move layer extraction to a re-exec model to prevent elevating privilege in the main containerd.exe process. This will take some designing with the above archive integration.
- [ ] Figure out how to make the snapshotter work for non-container purposes as well. The current implementation creates a Sandbox, which I think is needed, but that means that if a container is not run (or a diff applied) into the current layer, a new layer cannot be created. This breaks the idea that the snapshotter can be used for non-container operations.
- [ ] Implement snapshot disk usage on Windows. Currently hard-coded to 0, as the existing disk usage methods attempt to read the raw layers, which is not permitted on Windows

cc @mlaventure @dmcgowan @stevvooe @crosbymichael 

Signed-off-by: Darren Stahl <darst@microsoft.com>