### PR TITLE
Use namespace in default cgroup path

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -3,6 +3,8 @@ package containerd
 import (
 	"fmt"
 	"testing"
+
+	"github.com/containerd/containerd/containers"
 )
 
 func BenchmarkContainerCreate(b *testing.B) {
@@ -20,7 +22,7 @@ func BenchmarkContainerCreate(b *testing.B) {
 		b.Error(err)
 		return
 	}
-	spec, err := GenerateSpec(ctx, client, nil, WithImageConfig(image), withTrue())
+	spec, err := GenerateSpec(ctx, client, &containers.Container{ID: b.Name()}, WithImageConfig(image), withTrue())
 	if err != nil {
 		b.Error(err)
 		return
@@ -63,7 +65,7 @@ func BenchmarkContainerStart(b *testing.B) {
 		b.Error(err)
 		return
 	}
-	spec, err := GenerateSpec(ctx, client, nil, WithImageConfig(image), withTrue())
+	spec, err := GenerateSpec(ctx, client, &containers.Container{ID: b.Name()}, WithImageConfig(image), withTrue())
 	if err != nil {
 		b.Error(err)
 		return

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -196,18 +196,11 @@ func redisExample() error {
         }
         log.Printf("Successfully pulled %s image\n", image.Name())
 
-        spec, err := containerd.GenerateSpec(ctx, client, nil, containerd.WithImageConfig(image))
-        if err != nil {
-                return err
-        }
-        log.Printf("Successfully generate an OCI spec version %s based on %s image", spec.Version, image.Name())
-
         container, err := client.NewContainer(
                 ctx,
                 "redis-server",
-                containerd.WithSpec(spec),
-                containerd.WithImage(image),
                 containerd.WithNewSnapshot("redis-server-snapshot", image),
+                containerd.WithNewSpec(containerd.WithImageConfig(image)),
         )
         if err != nil {
                 return err

--- a/spec.go
+++ b/spec.go
@@ -10,7 +10,7 @@ import (
 // GenerateSpec will generate a default spec from the provided image
 // for use as a containerd container
 func GenerateSpec(ctx context.Context, client *Client, c *containers.Container, opts ...SpecOpts) (*specs.Spec, error) {
-	s, err := createDefaultSpec()
+	s, err := createDefaultSpec(ctx, c.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/spec_opts.go
+++ b/spec_opts.go
@@ -38,7 +38,7 @@ func WithHostname(name string) SpecOpts {
 // WithNewSpec generates a new spec for a new container
 func WithNewSpec(opts ...SpecOpts) NewContainerOpts {
 	return func(ctx context.Context, client *Client, c *containers.Container) error {
-		s, err := createDefaultSpec()
+		s, err := createDefaultSpec(ctx, c.ID)
 		if err != nil {
 			return err
 		}

--- a/spec_unix_test.go
+++ b/spec_unix_test.go
@@ -6,13 +6,16 @@ import (
 	"context"
 	"testing"
 
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/namespaces"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 func TestGenerateSpec(t *testing.T) {
 	t.Parallel()
 
-	s, err := GenerateSpec(context.Background(), nil, nil)
+	ctx := namespaces.WithNamespace(context.Background(), "testing")
+	s, err := GenerateSpec(ctx, nil, &containers.Container{ID: t.Name()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +55,8 @@ func TestGenerateSpec(t *testing.T) {
 func TestSpecWithTTY(t *testing.T) {
 	t.Parallel()
 
-	s, err := GenerateSpec(context.Background(), nil, nil, WithTTY)
+	ctx := namespaces.WithNamespace(context.Background(), "testing")
+	s, err := GenerateSpec(ctx, nil, &containers.Container{ID: t.Name()}, WithTTY)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,8 +72,10 @@ func TestSpecWithTTY(t *testing.T) {
 func TestWithLinuxNamespace(t *testing.T) {
 	t.Parallel()
 
+	ctx := namespaces.WithNamespace(context.Background(), "testing")
 	replacedNS := specs.LinuxNamespace{Type: specs.NetworkNamespace, Path: "/var/run/netns/test"}
-	s, err := GenerateSpec(context.Background(), nil, nil, WithLinuxNamespace(replacedNS))
+
+	s, err := GenerateSpec(ctx, nil, &containers.Container{ID: t.Name()}, WithLinuxNamespace(replacedNS))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/spec_windows.go
+++ b/spec_windows.go
@@ -1,8 +1,12 @@
 package containerd
 
-import specs "github.com/opencontainers/runtime-spec/specs-go"
+import (
+	"context"
 
-func createDefaultSpec() (*specs.Spec, error) {
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func createDefaultSpec(ctx context.Context, id string) (*specs.Spec, error) {
 	return &specs.Spec{
 		Version: specs.Version,
 		Root:    &specs.Root{},


### PR DESCRIPTION
By default, the generated spec will place containers in cgroups by their
ids, we need to use the namespace as the cgroup root to avoid
containers with the same name being placed in the same cgroup.

```
11:perf_event:/to/redis
10:freezer:/to/redis
9:memory:/to/redis
8:devices:/to/redis
7:net_cls,net_prio:/to/redis
6:pids:/to/redis
5:hugetlb:/to/redis
4:cpuset:/to/redis
3:blkio:/to/redis
2:cpu,cpuacct:/to/redis
1:name=systemd:/to/redis

11:perf_event:/te/redis
10:freezer:/te/redis
9:memory:/te/redis
8:devices:/te/redis
7:net_cls,net_prio:/te/redis
6:pids:/te/redis
5:hugetlb:/te/redis
4:cpuset:/te/redis
3:blkio:/te/redis
2:cpu,cpuacct:/te/redis
1:name=systemd:/te/redis
```

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>