### PR TITLE
Reduce image pull race.

### DIFF
--- a/client.go
+++ b/client.go
@@ -250,19 +250,19 @@ func (c *Client) Pull(ctx context.Context, ref string, opts ...RemoteOpt) (Image
 	}
 
 	is := c.ImageService()
-	if updated, err := is.Update(ctx, imgrec, "target"); err != nil {
-		if !errdefs.IsNotFound(err) {
+	if created, err := is.Create(ctx, imgrec); err != nil {
+		if !errdefs.IsAlreadyExists(err) {
 			return nil, err
 		}
 
-		created, err := is.Create(ctx, imgrec)
+		updated, err := is.Update(ctx, imgrec)
 		if err != nil {
 			return nil, err
 		}
 
-		imgrec = created
-	} else {
 		imgrec = updated
+	} else {
+		imgrec = created
 	}
 
 	img := &image{


### PR DESCRIPTION
Fix https://github.com/containerd/containerd/issues/1639.

When there are multiple concurrent pulling, each of them may see `NotExist` from `Update` and then try to `Create`. Only the first one successfully creates and others will fail.

The root cause is that we don't have a transnational `CreateOrUpdate` function. This PR changes the logic to try `Create` first and then `Update`, which will avoid race in most cases.

If there is someone remove the image after `Create` but before `Update`, there may still be a problem. However, that should be rare case.

Signed-off-by: Lantao Liu <lantaol@google.com>