### PR TITLE
linux: Ensure count is 64bits aligned for proper atomic use on 32bits machines

### DIFF
--- a/metrics/cgroups/oom.go
+++ b/metrics/cgroups/oom.go
@@ -44,11 +44,14 @@ type oomCollector struct {
 }
 
 type oom struct {
+	// count needs to stay the first member of this struct to ensure 64bits
+	// alignment on a 32bits machine (e.g. arm32). This is necessary as we use
+	// the sync/atomic operations on this field.
+	count     int64
 	id        string
 	namespace string
 	c         cgroups.Cgroup
 	triggers  []Trigger
-	count     int64
 }
 
 func (o *oomCollector) Add(id, namespace string, cg cgroups.Cgroup, triggers ...Trigger) error {


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

--

From `sync/atomic` [godoc](https://golang.org/pkg/sync/atomic/#pkg-note-BUG):

> On both ARM and x86-32, it is the caller's responsibility to arrange for 64-bit alignment of 64-bit words accessed atomically. The first word in a variable or in an allocated struct, array, or slice can be relied upon to be 64-bit aligned.