### PR TITLE
Close wait chan after sending status

### DIFF
--- a/process.go
+++ b/process.go
@@ -120,6 +120,7 @@ func (p *process) Kill(ctx context.Context, s syscall.Signal, opts ...KillOpts) 
 func (p *process) Wait(ctx context.Context) (<-chan ExitStatus, error) {
 	c := make(chan ExitStatus, 1)
 	go func() {
+		defer close(c)
 		r, err := p.task.client.TaskService().Wait(ctx, &tasks.WaitRequest{
 			ContainerID: p.task.id,
 			ExecID:      p.id,

--- a/task.go
+++ b/task.go
@@ -215,6 +215,7 @@ func (t *task) Status(ctx context.Context) (Status, error) {
 func (t *task) Wait(ctx context.Context) (<-chan ExitStatus, error) {
 	c := make(chan ExitStatus, 1)
 	go func() {
+		defer close(c)
 		r, err := t.client.TaskService().Wait(ctx, &tasks.WaitRequest{
 			ContainerID: t.id,
 		})


### PR DESCRIPTION
This allows the caller to receive multiple times without blocking after
the first call.

This can be useful in cases like this:
```go
  ch, _  := task.Wait(ctx)
  defer func() { <-ch } // don't return until task is done
  task.Start(ctx)

  if err := doSomething(task); err != nil {
    return err
  }

  status := <- ch
  // do stuff with status
```

Since this channel is created in the `Wait()` calls and never accessible
outside, this should be safe.