### PR TITLE
Use limited reader for some `ReadAll` cases.

### DIFF
--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/textproto"
@@ -498,7 +499,7 @@ func (r *dockerBase) fetchTokenWithOAuth(ctx context.Context, to tokenOptions) (
 	if (resp.StatusCode == 405 && r.username != "") || resp.StatusCode == 404 {
 		return r.getToken(ctx, to)
 	} else if resp.StatusCode < 200 || resp.StatusCode >= 400 {
-		b, _ := ioutil.ReadAll(resp.Body)
+		b, _ := ioutil.ReadAll(io.LimitReader(resp.Body, 64000)) // 64KB
 		log.G(ctx).WithFields(logrus.Fields{
 			"status": resp.Status,
 			"body":   string(b),

--- a/remotes/docker/schema1/converter.go
+++ b/remotes/docker/schema1/converter.go
@@ -26,6 +26,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const manifestSizeLimit = 8e6 // 8MB
+
 var (
 	mediaTypeManifest = "application/vnd.docker.distribution.manifest.v1+json"
 )
@@ -177,7 +179,7 @@ func (c *Converter) fetchManifest(ctx context.Context, desc ocispec.Descriptor) 
 		return err
 	}
 
-	b, err := ioutil.ReadAll(rc)
+	b, err := ioutil.ReadAll(io.LimitReader(rc, manifestSizeLimit)) // limit to 8MB
 	rc.Close()
 	if err != nil {
 		return err


### PR DESCRIPTION
Prevents a server from sending a large response causing containerd to
allocate too much RAM and potentially OOM.