### PR TITLE
[ctr] add --null-io and --detach 

### DIFF
--- a/cmd/ctr/run.go
+++ b/cmd/ctr/run.go
@@ -92,6 +92,10 @@ var runCommand = cli.Command{
 			Name:  "cwd",
 			Usage: "specify the working directory of the process",
 		},
+		cli.BoolFlag{
+			Name:  "null-io",
+			Usage: "send all IO to /dev/null",
+		},
 	}, snapshotterFlags...),
 	Action: func(context *cli.Context) error {
 		var (
@@ -121,7 +125,7 @@ var runCommand = cli.Command{
 		if context.Bool("rm") {
 			defer container.Delete(ctx, containerd.WithSnapshotCleanup)
 		}
-		task, err := newTask(ctx, client, container, context.String("checkpoint"), tty)
+		task, err := newTask(ctx, container, context.String("checkpoint"), tty, context.Bool("null-io"))
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/run.go
+++ b/cmd/ctr/run.go
@@ -96,6 +96,10 @@ var runCommand = cli.Command{
 			Name:  "null-io",
 			Usage: "send all IO to /dev/null",
 		},
+		cli.BoolFlag{
+			Name:  "detach,d",
+			Usage: "detach from the task after it has started execution",
+		},
 	}, snapshotterFlags...),
 	Action: func(context *cli.Context) error {
 		var (
@@ -105,6 +109,7 @@ var runCommand = cli.Command{
 			id          = context.Args().Get(1)
 			imageRef    = context.Args().First()
 			tty         = context.Bool("tty")
+			detach      = context.Bool("detach")
 		)
 		defer cancel()
 
@@ -122,20 +127,20 @@ var runCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		if context.Bool("rm") {
+		if context.Bool("rm") && !detach {
 			defer container.Delete(ctx, containerd.WithSnapshotCleanup)
 		}
-		task, err := newTask(ctx, container, context.String("checkpoint"), tty, context.Bool("null-io"))
+		task, err := newTask(ctx, client, container, context.String("checkpoint"), tty, context.Bool("null-io"))
 		if err != nil {
 			return err
 		}
-		defer task.Delete(ctx)
-
-		statusC, err := task.Wait(ctx)
-		if err != nil {
-			return err
+		var statusC <-chan containerd.ExitStatus
+		if !detach {
+			defer task.Delete(ctx)
+			if statusC, err = task.Wait(ctx); err != nil {
+				return err
+			}
 		}
-
 		var con console.Console
 		if tty {
 			con = console.Current()
@@ -147,6 +152,9 @@ var runCommand = cli.Command{
 		if err := task.Start(ctx); err != nil {
 			return err
 		}
+		if detach {
+			return nil
+		}
 		if tty {
 			if err := handleConsoleResize(ctx, task, con); err != nil {
 				logrus.WithError(err).Error("console resize")
@@ -155,7 +163,6 @@ var runCommand = cli.Command{
 			sigc := forwardAllSignals(ctx, task)
 			defer stopCatch(sigc)
 		}
-
 		status := <-statusC
 		code, _, err := status.Result()
 		if err != nil {

--- a/cmd/ctr/run_unix.go
+++ b/cmd/ctr/run_unix.go
@@ -114,11 +114,14 @@ func newContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 	return client.NewContainer(ctx, id, cOpts...)
 }
 
-func newTask(ctx gocontext.Context, client *containerd.Client, container containerd.Container, checkpoint string, tty bool) (containerd.Task, error) {
+func newTask(ctx gocontext.Context, client *containerd.Client, container containerd.Container, checkpoint string, tty, nullIO bool) (containerd.Task, error) {
 	if checkpoint == "" {
 		io := containerd.Stdio
 		if tty {
 			io = containerd.StdioTerminal
+		}
+		if nullIO {
+			io = containerd.NullIO
 		}
 		return container.NewTask(ctx, io)
 	}

--- a/cmd/ctr/run_windows.go
+++ b/cmd/ctr/run_windows.go
@@ -117,10 +117,13 @@ func newContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 	)
 }
 
-func newTask(ctx gocontext.Context, client *containerd.Client, container containerd.Container, _ string, tty bool) (containerd.Task, error) {
+func newTask(ctx gocontext.Context, client *containerd.Client, container containerd.Container, _ string, tty, nullIO bool) (containerd.Task, error) {
 	io := containerd.Stdio
 	if tty {
 		io = containerd.StdioTerminal
+	}
+	if nullIO {
+		io = containerd.NullIO
 	}
 	return container.NewTask(ctx, io)
 }

--- a/cmd/ctr/start.go
+++ b/cmd/ctr/start.go
@@ -46,7 +46,7 @@ var taskStartCommand = cli.Command{
 
 		tty := spec.Process.Terminal
 
-		task, err := newTask(ctx, container, "", tty, context.Bool("null-io"))
+		task, err := newTask(ctx, client, container, "", tty, context.Bool("null-io"))
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/start.go
+++ b/cmd/ctr/start.go
@@ -11,6 +11,12 @@ var taskStartCommand = cli.Command{
 	Name:      "start",
 	Usage:     "start a container that have been created",
 	ArgsUsage: "CONTAINER",
+	Flags: []cli.Flag{
+		cli.BoolFlag{
+			Name:  "null-io",
+			Usage: "send all IO to /dev/null",
+		},
+	},
 	Action: func(context *cli.Context) error {
 		var (
 			err error
@@ -40,7 +46,7 @@ var taskStartCommand = cli.Command{
 
 		tty := spec.Process.Terminal
 
-		task, err := newTask(ctx, client, container, "", tty)
+		task, err := newTask(ctx, container, "", tty, context.Bool("null-io"))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This adds the ability to start and detach from a task with ctr.  It also adds an option to redirect all task io to /dev/null. 

