### PR TITLE
Vendor go-runc ed1cbe1fc31f5fb2359d3a54b6330d1a097858b7

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,5 +1,5 @@
 github.com/coreos/go-systemd 48702e0da86bd25e76cfef347e2adeb434a0d0a6
-github.com/containerd/go-runc 633fd07c086ff591adaa2849278764771d791f6f
+github.com/containerd/go-runc ed1cbe1fc31f5fb2359d3a54b6330d1a097858b7
 github.com/containerd/console 84eeaae905fa414d03e07bcd6c8d3f19e7cf180e
 github.com/containerd/cgroups 38a61430f7ceb01581fba6dd7ead48e92fe77513
 github.com/containerd/typeurl f6943554a7e7e88b3c14aad190bf05932da84788

--- a/vendor/github.com/containerd/go-runc/runc.go
+++ b/vendor/github.com/containerd/go-runc/runc.go
@@ -243,7 +243,7 @@ func (r *Runc) Run(context context.Context, id, bundle string, opts *CreateOpts)
 		args = append(args, oargs...)
 	}
 	cmd := r.command(context, append(args, id)...)
-	if opts != nil {
+	if opts != nil && opts.IO != nil {
 		opts.Set(cmd)
 	}
 	ec, err := Monitor.Start(cmd)
@@ -513,7 +513,7 @@ func (r *Runc) Restore(context context.Context, id, bundle string, opts *Restore
 	}
 	args = append(args, "--bundle", bundle)
 	cmd := r.command(context, append(args, id)...)
-	if opts != nil {
+	if opts != nil && opts.IO != nil {
 		opts.Set(cmd)
 	}
 	ec, err := Monitor.Start(cmd)


### PR DESCRIPTION
This fixes possible panics in Run & Restore when done without IOs

Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>