### PR TITLE
Update content store garbage collection

### DIFF
--- a/metadata/db.go
+++ b/metadata/db.go
@@ -311,7 +311,7 @@ func (m *DB) cleanupContent() {
 		return
 	}
 
-	err := newContentStore(m, m.cs).garbageCollect(ctx)
+	err := m.cs.garbageCollect(ctx)
 	if err != nil {
 		log.G(ctx).WithError(err).Warn("content garbage collection failed")
 	}


### PR DESCRIPTION
Use single instance of content store instead of creating new one for each collection. Using new instance and wrapping causes failures.