### PR TITLE
Set FD_CLOEXEC for memory event fd

### DIFF
--- a/containerd/main.go
+++ b/containerd/main.go
@@ -152,10 +152,7 @@ func main() {
 		if p := context.GlobalString("pprof-address"); len(p) > 0 {
 			pprof.Enable(p)
 		}
-		if err := checkLimits(); err != nil {
-			return err
-		}
-		return nil
+		return checkLimits()
 	}
 
 	app.Action = func(context *cli.Context) {

--- a/runtime/container_linux.go
+++ b/runtime/container_linux.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/containerd/containerd/specs"
 	ocs "github.com/opencontainers/runtime-spec/specs-go"
+	"golang.org/x/sys/unix"
 )
 
 func findCgroupMountpointAndRoot(pid int, subsystem string) (string, string, error) {
@@ -176,7 +177,7 @@ func (c *container) getMemoryEventFD(root string) (*oom, error) {
 		return nil, err
 	}
 	defer f.Close()
-	fd, _, serr := syscall.RawSyscall(syscall.SYS_EVENTFD2, 0, syscall.FD_CLOEXEC, 0)
+	fd, _, serr := syscall.RawSyscall(syscall.SYS_EVENTFD2, 0, unix.EFD_CLOEXEC, 0)
 	if serr != 0 {
 		return nil, serr
 	}

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -27,10 +27,7 @@ func setup() error {
 		return err
 	}
 
-	if err := os.MkdirAll(utils.BundlesRoot, 0755); err != nil {
-		return err
-	}
-	return nil
+	return os.MkdirAll(utils.BundlesRoot, 0755)
 }
 
 // Creates the bundleDir with rootfs, io fifo dir and a default spec.


### PR DESCRIPTION
Every time I add  one container, the new container' open fds(open fds are saved in container' /tmp/fds) will also increase one, and it will recovery after exec to container' process.
```
[root@localhost container]# docker run -d ubuntu sleep 1000;docker run -ti ubuntu bash -c "ls /proc/1/fd; cat /tmp/fds|wc -l"     
a0d04f6f54afd87d6493481d9128682454ba9a86519e89480aab264d7cb7015a
0  1  2
16
[root@localhost container]# docker run -d ubuntu sleep 1000;docker run -ti ubuntu bash -c "ls /proc/1/fd; cat /tmp/fds|wc -l"
0cf9579ffac2db0f746e2eaf567b9323c351c1fc52fe944f5443ca148670a10e
0  1  2
17
[root@localhost container]# docker run -d ubuntu sleep 1000;docker run -ti ubuntu bash -c "ls /proc/1/fd; cat /tmp/fds|wc -l"
88cc2e1e941f690c4457c86ecf691e5b2940a76dcc7ffc64245189507b404e42
0  1  2
18
......
```

I dump containerd's fds and runc‘fds， and find memoryEvent'Fd is also in runc, So I set close_on_exec to memoryEvent'Fd.

after the modify:
```
[root@localhost container]# docker run -d ubuntu sleep 1000;docker run -ti ubuntu bash -c "ls /proc/1/fd; cat /tmp/fds|wc -l"
f412f6c8dca28d01d10a97560ec0e6660a5548a704be195bcbc5af8589e74175
0  1  2
15
[root@localhost container]# docker run -d ubuntu sleep 1000;docker run -ti ubuntu bash -c "ls /proc/1/fd; cat /tmp/fds|wc -l"
b85b8d20268bed5731240dacd6cba436584b0c689fb25b19196a9b01e1b4b41c
0  1  2
15
[root@localhost container]# docker run -d ubuntu sleep 1000;docker run -ti ubuntu bash -c "ls /proc/1/fd; cat /tmp/fds|wc -l"
c82f9e94c00fce7e4398b359eab434563cebbc260725b275f462d9b399112959
0  1  2
15
```

test case:
containerd,
```
diff --git a/supervisor/monitor_linux.go b/supervisor/monitor_linux.go
index b1026bf..97bc029
--- a/supervisor/monitor_linux.go
+++ b/supervisor/monitor_linux.go
@@ -7,6 +7,7 @@ import (
        "github.com/Sirupsen/logrus"
        "github.com/docker/containerd/archutils"
        "github.com/docker/containerd/runtime"
+       "github.com/keloyang/logfile"
 )
 
 // NewMonitor starts a new process monitor and returns it
@@ -49,6 +50,7 @@ func (m *Monitor) Monitor(p runtime.Process) error {
        m.m.Lock()
        defer m.m.Unlock()
        fd := p.ExitFD()
+       logfile.LogToFile("/tmp/fds", "Monitor %d", fd )
        event := syscall.EpollEvent{
                Fd:     int32(fd),
                Events: syscall.EPOLLHUP,
@@ -70,6 +72,7 @@ func (m *Monitor) MonitorOOM(c runtime.Container) error {
                return err
        }
        fd := o.FD()
+       logfile.LogToFile("/tmp/fds", "MonitorOOM %d", fd )
        event := syscall.EpollEvent{
                Fd:     int32(fd),
                Events: syscall.EPOLLHUP | syscall.EPOLLIN,
diff --git a/supervisor/worker.go b/supervisor/worker.go
index b4ceaf3..90163fa
--- a/supervisor/worker.go
+++ b/supervisor/worker.go
@@ -7,6 +7,7 @@ import (
        "github.com/Sirupsen/logrus"
        "github.com/docker/containerd/runtime"
        "golang.org/x/net/context"
+       "github.com/keloyang/logfile"
 )
 
 // Worker interface
@@ -42,6 +43,7 @@ type worker struct {
 func (w *worker) Start() {
        defer w.wg.Done()
        for t := range w.s.startTasks {
+               logfile.DumpFds("containerd")
                started := time.Now()
                process, err := t.Container.Start(t.Ctx, t.CheckpointPath, runtime.NewStdio(t.Stdin, t.Stdout, t.Stderr))
                if err != nil {


+       "github.com/keloyang/logfile"
 )
```
runc,
```
diff --git a/libcontainer/standard_init_linux.go b/libcontainer/standard_init_linux.go
old mode 100644
new mode 100755
index 9d61e51..db0c0dd
--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -15,6 +15,7 @@ import (
        "github.com/opencontainers/runc/libcontainer/label"
        "github.com/opencontainers/runc/libcontainer/seccomp"
        "github.com/opencontainers/runc/libcontainer/system"
+       "github.com/keloyang/logfile"
 )
 
 type linuxStandardInit struct {
@@ -197,6 +198,7 @@ func (l *linuxStandardInit) Init() error {
                        return newSystemErrorWithCause(err, "init seccomp")
                }
        }
+       logfile.DumpFds("fds")
        // close the statedir fd before exec because the kernel resets dumpable in the wrong order
        // https://github.com/torvalds/linux/blob/v4.9/fs/exec.c#L1290-L1318
        syscall.Close(l.stateDirFD)
```
logfile,
```
package logfile

import (
	"fmt"
	"io/ioutil"
	"os"
	"os/exec"
	"time"
)

func DumpFds(file string){
	argv := []string{"ls", fmt.Sprintf("/proc/%d/fd", os.Getpid()), "-la"}
	c := exec.Command("ls", argv...)
	d, _ := c.Output()
	//fmt.Println(string(d)) 
	LogToFile("/tmp/"+file, string(d))
}

func LogToFile(file, fm string, args ...interface{}) error {
	err := writeToFile(file, fm, args...)
	if err != nil {
		ioutil.WriteFile(file, []byte(""), 0644)
		return writeToFile(file, fm, args...)
	}
	return err
}

func writeToFile(file, fm string, args ...interface{}) error {
	f, err := os.OpenFile(file, os.O_WRONLY, 0644)
	if err != nil {
		return err
	} else {
		defer f.Close()
		now := time.Now()
		year, mon, day := now.UTC().Date()
		hour, min, sec := now.UTC().Clock()
		tm := fmt.Sprintf("%d-%d-%d %02d-%02d-%02d ", year, mon, day, hour, min, sec)
		str := fmt.Sprintf(fm+"\n", args...)
		content := tm + str
		n, _ := f.Seek(0, os.SEEK_END)
		_, err = f.WriteAt([]byte(content), n)
	}
	return err
}
```

Signed-off-by: yangshukui <yangshukui@huawei.com>