### PR TITLE
Update containerd/cgroups to f7dd103d3e4e696aa67152f6b4ddd1779a3455a9

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,7 +1,7 @@
 github.com/coreos/go-systemd 48702e0da86bd25e76cfef347e2adeb434a0d0a6
 github.com/containerd/go-runc ed1cbe1fc31f5fb2359d3a54b6330d1a097858b7
 github.com/containerd/console 84eeaae905fa414d03e07bcd6c8d3f19e7cf180e
-github.com/containerd/cgroups 38a61430f7ceb01581fba6dd7ead48e92fe77513
+github.com/containerd/cgroups f7dd103d3e4e696aa67152f6b4ddd1779a3455a9
 github.com/containerd/typeurl f6943554a7e7e88b3c14aad190bf05932da84788
 github.com/docker/go-metrics 8fd5772bf1584597834c6f7961a530f06cbfbb87
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9

--- a/vendor/github.com/containerd/cgroups/memory.go
+++ b/vendor/github.com/containerd/cgroups/memory.go
@@ -160,7 +160,7 @@ func (m *memoryController) OOMEventFD(path string) (uintptr, error) {
 		return 0, err
 	}
 	defer f.Close()
-	fd, _, serr := unix.RawSyscall(unix.SYS_EVENTFD2, 0, unix.FD_CLOEXEC, 0)
+	fd, _, serr := unix.RawSyscall(unix.SYS_EVENTFD2, 0, unix.EFD_CLOEXEC, 0)
 	if serr != 0 {
 		return 0, serr
 	}


### PR DESCRIPTION
This fixes a leak of the oom_control eventfd to child processes.

Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>