### PR TITLE
client: Add helper function which checks if an image is unpacked

### DIFF
--- a/cmd/ctr/commands/images/images.go
+++ b/cmd/ctr/commands/images/images.go
@@ -177,8 +177,9 @@ var setLabelsCommand = cli.Command{
 var checkCommand = cli.Command{
 	Name:        "check",
 	Usage:       "check that an image has all content available locally",
-	ArgsUsage:   "<ref> [<ref>, ...]",
+	ArgsUsage:   "[flags] <ref> [<ref>, ...]",
 	Description: "check that an image has all content available locally",
+	Flags:       commands.SnapshotterFlags,
 	Action: func(context *cli.Context) error {
 		var (
 			exitErr error
@@ -189,14 +190,13 @@ var checkCommand = cli.Command{
 		}
 		defer cancel()
 		var (
-			imageStore   = client.ImageService()
 			contentStore = client.ContentStore()
 			tw           = tabwriter.NewWriter(os.Stdout, 1, 8, 1, ' ', 0)
 		)
-		fmt.Fprintln(tw, "REF\tTYPE\tDIGEST\tSTATUS\tSIZE\t")
+		fmt.Fprintln(tw, "REF\tTYPE\tDIGEST\tSTATUS\tSIZE\tUNPACKED\t")
 
 		args := []string(context.Args())
-		imageList, err := imageStore.List(ctx, args...)
+		imageList, err := client.ListImages(ctx, args...)
 		if err != nil {
 			return errors.Wrap(err, "failed listing images")
 		}
@@ -209,12 +209,12 @@ var checkCommand = cli.Command{
 				presentSize  int64
 			)
 
-			available, required, present, missing, err := images.Check(ctx, contentStore, image.Target, platforms.Default())
+			available, required, present, missing, err := images.Check(ctx, contentStore, image.Target(), platforms.Default())
 			if err != nil {
 				if exitErr == nil {
-					exitErr = errors.Wrapf(err, "unable to check %v", image.Name)
+					exitErr = errors.Wrapf(err, "unable to check %v", image.Name())
 				}
-				log.G(ctx).WithError(err).Errorf("unable to check %v", image.Name)
+				log.G(ctx).WithError(err).Errorf("unable to check %v", image.Name())
 				status = "error"
 			}
 
@@ -242,12 +242,21 @@ var checkCommand = cli.Command{
 				size = "-"
 			}
 
-			fmt.Fprintf(tw, "%v\t%v\t%v\t%v\t%v\t\n",
-				image.Name,
-				image.Target.MediaType,
-				image.Target.Digest,
+			unpacked, err := image.IsUnpacked(ctx, context.String("snapshotter"))
+			if err != nil {
+				if exitErr == nil {
+					exitErr = errors.Wrapf(err, "unable to check unpack for %v", image.Name())
+				}
+				log.G(ctx).WithError(err).Errorf("unable to check unpack for %v", image.Name())
+			}
+
+			fmt.Fprintf(tw, "%v\t%v\t%v\t%v\t%v\t%t\n",
+				image.Name(),
+				image.Target().MediaType,
+				image.Target().Digest,
 				status,
-				size)
+				size,
+				unpacked)
 		}
 		tw.Flush()
 

--- a/image_test.go
+++ b/image_test.go
@@ -1,0 +1,58 @@
+package containerd
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/containerd/containerd/errdefs"
+)
+
+func TestImageIsUnpacked(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+
+	const imageName = "docker.io/library/busybox:latest"
+	ctx, cancel := testContext()
+	defer cancel()
+
+	client, err := newClient(t, address)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	// Cleanup
+	err = client.ImageService().Delete(ctx, imageName)
+	if err != nil && !errdefs.IsNotFound(err) {
+		t.Fatal(err)
+	}
+
+	// By default pull does not unpack an image
+	image, err := client.Pull(ctx, imageName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that image is not unpacked
+	unpacked, err := image.IsUnpacked(ctx, DefaultSnapshotter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unpacked {
+		t.Fatalf("image should not be unpacked")
+	}
+
+	// Check that image is unpacked
+	err = image.Unpack(ctx, DefaultSnapshotter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unpacked, err = image.IsUnpacked(ctx, DefaultSnapshotter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !unpacked {
+		t.Fatalf("image should be unpacked")
+	}
+}


### PR DESCRIPTION
Check if an image has been unpacked. (see last column)
```# ctr images check
REF                             TYPE                                                      DIGEST                                                                  STATUS           SIZE                UNPACKED
docker.io/library/mysql:latest  application/vnd.docker.distribution.manifest.list.v2+json sha256:eb9a3bca059ee178b5a69a2443462d156ff5b3d3f739c516b62d9d902ba49132 complete (12/12) 137.5 MiB/137.5 MiB true
docker.io/library/redis:latest  application/vnd.docker.distribution.manifest.list.v2+json sha256:07e7b6cb753f8d06a894e22af30f94e04844461ab6cb002c688841873e5e5116 complete (7/7)   37.6 MiB/37.6 MiB   false

# ctr rootfs unpack sha256:07e7b6cb753f8d06a894e22af30f94e04844461ab6cb002c688841873e5e5116
unpacking sha256:07e7b6cb753f8d06a894e22af30f94e04844461ab6cb002c688841873e5e5116 (application/vnd.docker.distribution.manifest.list.v2+json)...done

# ctr images check
REF                             TYPE                                                      DIGEST                                                                  STATUS           SIZE                UNPACKED
docker.io/library/mysql:latest  application/vnd.docker.distribution.manifest.list.v2+json sha256:eb9a3bca059ee178b5a69a2443462d156ff5b3d3f739c516b62d9d902ba49132 complete (12/12) 137.5 MiB/137.5 MiB true
docker.io/library/redis:latest  application/vnd.docker.distribution.manifest.list.v2+json sha256:07e7b6cb753f8d06a894e22af30f94e04844461ab6cb002c688841873e5e5116 complete (7/7)   37.6 MiB/37.6 MiB   true
```
Closes #1572.

Signed-off-by: Jess Valarezo <valarezo.jessica@gmail.com>