### PR TITLE
Enable Go Lint in CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,6 +26,7 @@ before_build:
 build_script:
   - bash.exe -elc "export PATH=/c/tools/mingw64/bin:$PATH ; mingw32-make.exe setup"
   - bash.exe -elc "export PATH=/c/tools/mingw64/bin:$PATH ; mingw32-make.exe fmt"
+  - bash.exe -elc "export PATH=/c/tools/mingw64/bin:/c/gopath/bin:$PATH ; mingw32-make.exe lint"
   - bash.exe -elc "export PATH=/c/tools/mingw64/bin:$PATH ; mingw32-make.exe vet"
   - bash.exe -elc "export PATH=/c/tools/mingw64/bin:/c/gopath/bin:$PATH ; mingw32-make.exe ineffassign"
   - bash.exe -elc "export PATH=/c/tools/mingw64/bin:$PATH ; mingw32-make.exe build"

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,8 @@ script:
 # Note that `go build -i` requires write permission to GOROOT. (So it is not called in Makefile)
   - go build -i .
   - make setup
+  - make lint
   - make vet
-  - if [ "$GOOS" = "linux" ]; then make lint ; fi
   - make ineffassign
   - if [ "$GOOS" = "linux" ]; then make check-protos check-api-descriptors; fi
   - make build

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ script:
   - go build -i .
   - make setup
   - make vet
+  - if [ "$GOOS" = "linux" ]; then make lint ; fi
   - make ineffassign
   - if [ "$GOOS" = "linux" ]; then make check-protos check-api-descriptors; fi
   - make build

--- a/content/local/store_test.go
+++ b/content/local/store_test.go
@@ -137,7 +137,7 @@ func TestWalkBlobs(t *testing.T) {
 	)
 
 	var (
-		blobs    = populateBlobStore(t, ctx, cs, nblobs, maxsize)
+		blobs    = populateBlobStore(ctx, t, cs, nblobs, maxsize)
 		expected = map[digest.Digest]struct{}{}
 		found    = map[digest.Digest]struct{}{}
 	)
@@ -188,7 +188,7 @@ func BenchmarkIngests(b *testing.B) {
 			b.StartTimer()
 
 			for dgst, p := range blobs {
-				checkWrite(b, ctx, cs, dgst, p)
+				checkWrite(ctx, b, cs, dgst, p)
 			}
 		})
 	}
@@ -215,11 +215,11 @@ func generateBlobs(t checker, nblobs, maxsize int64) map[digest.Digest][]byte {
 	return blobs
 }
 
-func populateBlobStore(t checker, ctx context.Context, cs content.Store, nblobs, maxsize int64) map[digest.Digest][]byte {
+func populateBlobStore(ctx context.Context, t checker, cs content.Store, nblobs, maxsize int64) map[digest.Digest][]byte {
 	blobs := generateBlobs(t, nblobs, maxsize)
 
 	for dgst, p := range blobs {
-		checkWrite(t, ctx, cs, dgst, p)
+		checkWrite(ctx, t, cs, dgst, p)
 	}
 
 	return blobs
@@ -282,7 +282,7 @@ func checkBlobPath(t *testing.T, cs content.Store, dgst digest.Digest) string {
 	return path
 }
 
-func checkWrite(t checker, ctx context.Context, cs content.Store, dgst digest.Digest, p []byte) digest.Digest {
+func checkWrite(ctx context.Context, t checker, cs content.Store, dgst digest.Digest, p []byte) digest.Digest {
 	if err := content.WriteBlob(ctx, cs, dgst.String(), bytes.NewReader(p), int64(len(p)), dgst); err != nil {
 		t.Fatal(err)
 	}

--- a/dialer_windows.go
+++ b/dialer_windows.go
@@ -24,6 +24,7 @@ func dialer(address string, timeout time.Duration) (net.Conn, error) {
 	return winio.DialPipe(address, &timeout)
 }
 
+// DialAddress returns the dial address
 func DialAddress(address string) string {
 	return address
 }

--- a/fs/diff_test.go
+++ b/fs/diff_test.go
@@ -35,7 +35,7 @@ func TestSimpleDiff(t *testing.T) {
 		fstest.CreateFile("/root/.bashrc", []byte("PATH=/usr/sbin:/usr/bin"), 0644),
 		fstest.Remove("/etc/unexpected"),
 	)
-	diff := []testChange{
+	diff := []TestChange{
 		Modify("/etc/hosts"),
 		Modify("/etc/profile"),
 		Delete("/etc/unexpected"),
@@ -60,7 +60,7 @@ func TestDirectoryReplace(t *testing.T) {
 		fstest.RemoveAll("/dir1/f2"),
 		fstest.CreateFile("/dir1/f2", []byte("Now file"), 0666),
 	)
-	diff := []testChange{
+	diff := []TestChange{
 		Add("/dir1/f11"),
 		Modify("/dir1/f2"),
 	}
@@ -79,7 +79,7 @@ func TestRemoveDirectoryTree(t *testing.T) {
 	l2 := fstest.Apply(
 		fstest.RemoveAll("/dir1"),
 	)
-	diff := []testChange{
+	diff := []TestChange{
 		Delete("/dir1"),
 	}
 
@@ -97,7 +97,7 @@ func TestFileReplace(t *testing.T) {
 		fstest.CreateDir("/dir1/dir2", 0755),
 		fstest.CreateFile("/dir1/dir2/f1", []byte("also a file"), 0644),
 	)
-	diff := []testChange{
+	diff := []TestChange{
 		Modify("/dir1"),
 		Add("/dir1/dir2"),
 		Add("/dir1/dir2/f1"),
@@ -136,7 +136,7 @@ func TestUpdateWithSameTime(t *testing.T) {
 		fstest.CreateFile("/file-truncated-time-2", []byte("2"), 0644),
 		fstest.Chtime("/file-truncated-time-2", tt),
 	)
-	diff := []testChange{
+	diff := []TestChange{
 		// "/file-same-time" excluded because matching non-zero nanosecond values
 		Modify("/file-modified-time"),
 		Modify("/file-truncated-time-1"),
@@ -148,7 +148,7 @@ func TestUpdateWithSameTime(t *testing.T) {
 	}
 }
 
-func testDiffWithBase(base, diff fstest.Applier, expected []testChange) error {
+func testDiffWithBase(base, diff fstest.Applier, expected []TestChange) error {
 	t1, err := ioutil.TempDir("", "diff-with-base-lower-")
 	if err != nil {
 		return errors.Wrap(err, "failed to create temp dir")
@@ -188,7 +188,7 @@ func TestBaseDirectoryChanges(t *testing.T) {
 		fstest.CreateDir("/root", 0700),
 		fstest.CreateFile("/root/.bashrc", []byte("PATH=/usr/sbin:/usr/bin"), 0644),
 	)
-	changes := []testChange{
+	changes := []TestChange{
 		Add("/etc"),
 		Add("/etc/hosts"),
 		Add("/etc/profile"),
@@ -201,7 +201,7 @@ func TestBaseDirectoryChanges(t *testing.T) {
 	}
 }
 
-func testDiffWithoutBase(apply fstest.Applier, expected []testChange) error {
+func testDiffWithoutBase(apply fstest.Applier, expected []TestChange) error {
 	tmp, err := ioutil.TempDir("", "diff-without-base-")
 	if err != nil {
 		return errors.Wrap(err, "failed to create temp dir")
@@ -220,7 +220,7 @@ func testDiffWithoutBase(apply fstest.Applier, expected []testChange) error {
 	return checkChanges(tmp, changes, expected)
 }
 
-func checkChanges(root string, changes, expected []testChange) error {
+func checkChanges(root string, changes, expected []TestChange) error {
 	if len(changes) != len(expected) {
 		return errors.Errorf("Unexpected number of changes:\n%s", diffString(changes, expected))
 	}
@@ -253,20 +253,20 @@ func checkChanges(root string, changes, expected []testChange) error {
 	return nil
 }
 
-type testChange struct {
+type TestChange struct {
 	Kind     ChangeKind
 	Path     string
 	FileInfo os.FileInfo
 	Source   string
 }
 
-func collectChanges(a, b string) ([]testChange, error) {
-	changes := []testChange{}
+func collectChanges(a, b string) ([]TestChange, error) {
+	changes := []TestChange{}
 	err := Changes(context.Background(), a, b, func(k ChangeKind, p string, f os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-		changes = append(changes, testChange{
+		changes = append(changes, TestChange{
 			Kind:     k,
 			Path:     p,
 			FileInfo: f,
@@ -281,12 +281,12 @@ func collectChanges(a, b string) ([]testChange, error) {
 	return changes, nil
 }
 
-func diffString(c1, c2 []testChange) string {
+func diffString(c1, c2 []TestChange) string {
 	return fmt.Sprintf("got(%d):\n%s\nexpected(%d):\n%s", len(c1), changesString(c1), len(c2), changesString(c2))
 
 }
 
-func changesString(c []testChange) string {
+func changesString(c []TestChange) string {
 	strs := make([]string, len(c))
 	for i := range c {
 		strs[i] = fmt.Sprintf("\t%s\t%s", c[i].Kind, c[i].Path)
@@ -294,22 +294,22 @@ func changesString(c []testChange) string {
 	return strings.Join(strs, "\n")
 }
 
-func Add(p string) testChange {
-	return testChange{
+func Add(p string) TestChange {
+	return TestChange{
 		Kind: ChangeKindAdd,
 		Path: p,
 	}
 }
 
-func Delete(p string) testChange {
-	return testChange{
+func Delete(p string) TestChange {
+	return TestChange{
 		Kind: ChangeKindDelete,
 		Path: p,
 	}
 }
 
-func Modify(p string) testChange {
-	return testChange{
+func Modify(p string) TestChange {
+	return TestChange{
 		Kind: ChangeKindModify,
 		Path: p,
 	}

--- a/fs/path_test.go
+++ b/fs/path_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-type rootCheck struct {
+type RootCheck struct {
 	unresolved string
 	expected   string
 	scope      func(string) string
@@ -23,7 +23,7 @@ func TestRootPath(t *testing.T) {
 	tests := []struct {
 		name   string
 		apply  fstest.Applier
-		checks []rootCheck
+		checks []RootCheck
 		scope  func(string) (string, error)
 	}{
 		{
@@ -201,7 +201,7 @@ func testRootPathSymlinkEmpty(t *testing.T) {
 	}
 }
 
-func makeRootPathTest(t *testing.T, apply fstest.Applier, checks []rootCheck) func(t *testing.T) {
+func makeRootPathTest(t *testing.T, apply fstest.Applier, checks []RootCheck) func(t *testing.T) {
 	return func(t *testing.T) {
 		applyDir, err := ioutil.TempDir("", "test-root-path-")
 		if err != nil {
@@ -242,8 +242,8 @@ func makeRootPathTest(t *testing.T, apply fstest.Applier, checks []rootCheck) fu
 	}
 }
 
-func Check(unresolved, expected string) []rootCheck {
-	return []rootCheck{
+func Check(unresolved, expected string) []RootCheck {
+	return []RootCheck{
 		{
 			unresolved: unresolved,
 			expected:   expected,
@@ -251,8 +251,8 @@ func Check(unresolved, expected string) []rootCheck {
 	}
 }
 
-func CheckWithScope(unresolved, expected, scope string) []rootCheck {
-	return []rootCheck{
+func CheckWithScope(unresolved, expected, scope string) []RootCheck {
+	return []RootCheck{
 		{
 			unresolved: unresolved,
 			expected:   expected,
@@ -263,8 +263,8 @@ func CheckWithScope(unresolved, expected, scope string) []rootCheck {
 	}
 }
 
-func ErrorWithScope(unresolved, scope string, cause error) []rootCheck {
-	return []rootCheck{
+func ErrorWithScope(unresolved, scope string, cause error) []RootCheck {
+	return []RootCheck{
 		{
 			unresolved: unresolved,
 			cause:      cause,
@@ -275,8 +275,8 @@ func ErrorWithScope(unresolved, scope string, cause error) []rootCheck {
 	}
 }
 
-func CheckAll(checks ...[]rootCheck) []rootCheck {
-	all := make([]rootCheck, 0, len(checks))
+func CheckAll(checks ...[]RootCheck) []RootCheck {
+	all := make([]RootCheck, 0, len(checks))
 	for _, c := range checks {
 		all = append(all, c...)
 	}

--- a/gc/gc.go
+++ b/gc/gc.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 )
 
-// Resourcetype represents type of resource at a node
+// ResourceType represents type of resource at a node
 type ResourceType uint8
 
 // Node presents a resource which has a type and key,

--- a/metadata/db.go
+++ b/metadata/db.go
@@ -190,6 +190,7 @@ func (m *DB) Update(fn func(*bolt.Tx) error) error {
 	return m.db.Update(fn)
 }
 
+// GarbageCollect starts garbage collection
 func (m *DB) GarbageCollect(ctx context.Context) error {
 	lt1 := time.Now()
 	m.wlock.Lock()

--- a/metadata/gc.go
+++ b/metadata/gc.go
@@ -12,10 +12,15 @@ import (
 )
 
 const (
+	// ResourceUnknown specifies an unknown resource
 	ResourceUnknown gc.ResourceType = iota
+	// ResourceContent specifies a content resource
 	ResourceContent
+	// ResourceSnapshot specifies a snapshot resource
 	ResourceSnapshot
+	// ResourceContainer specifies a container resource
 	ResourceContainer
+	// ResourceTask specifies a task resource
 	ResourceTask
 )
 

--- a/mount/mount_windows.go
+++ b/mount/mount_windows.go
@@ -3,17 +3,21 @@ package mount
 import "github.com/pkg/errors"
 
 var (
+	// ErrNotImplementOnWindows is returned when an action is not implemented for windows
 	ErrNotImplementOnWindows = errors.New("not implemented under windows")
 )
 
+// Mount to the provided target
 func (m *Mount) Mount(target string) error {
 	return ErrNotImplementOnWindows
 }
 
+// Unmount the mount at the provided path
 func Unmount(mount string, flags int) error {
 	return ErrNotImplementOnWindows
 }
 
+// UnmountAll mounts at the provided path
 func UnmountAll(mount string, flags int) error {
 	return ErrNotImplementOnWindows
 }

--- a/plugin/context.go
+++ b/plugin/context.go
@@ -22,11 +22,11 @@ type InitContext struct {
 
 	Meta *Meta // plugins can fill in metadata at init.
 
-	plugins *PluginSet
+	plugins *Set
 }
 
 // NewContext returns a new plugin InitContext
-func NewContext(ctx context.Context, r *Registration, plugins *PluginSet, root, state string) *InitContext {
+func NewContext(ctx context.Context, r *Registration, plugins *Set, root, state string) *InitContext {
 	return &InitContext{
 		Context: log.WithModule(ctx, r.URI()),
 		Root:    filepath.Join(root, r.URI()),
@@ -72,26 +72,26 @@ func (p *Plugin) Instance() (interface{}, error) {
 	return p.instance, p.err
 }
 
-// PluginSet defines a plugin collection, used with InitContext.
+// Set defines a plugin collection, used with InitContext.
 //
 // This maintains ordering and unique indexing over the set.
 //
 // After iteratively instantiating plugins, this set should represent, the
 // ordered, initialization set of plugins for a containerd instance.
-type PluginSet struct {
+type Set struct {
 	ordered     []*Plugin // order of initialization
 	byTypeAndID map[Type]map[string]*Plugin
 }
 
 // NewPluginSet returns an initialized plugin set
-func NewPluginSet() *PluginSet {
-	return &PluginSet{
+func NewPluginSet() *Set {
+	return &Set{
 		byTypeAndID: make(map[Type]map[string]*Plugin),
 	}
 }
 
 // Add a plugin to the set
-func (ps *PluginSet) Add(p *Plugin) error {
+func (ps *Set) Add(p *Plugin) error {
 	if byID, typeok := ps.byTypeAndID[p.Registration.Type]; !typeok {
 		ps.byTypeAndID[p.Registration.Type] = map[string]*Plugin{
 			p.Registration.ID: p,
@@ -107,7 +107,7 @@ func (ps *PluginSet) Add(p *Plugin) error {
 }
 
 // Get returns the first plugin by its type
-func (ps *PluginSet) Get(t Type) (interface{}, error) {
+func (ps *Set) Get(t Type) (interface{}, error) {
 	for _, v := range ps.byTypeAndID[t] {
 		return v.Instance()
 	}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -64,7 +64,7 @@ type Registration struct {
 	ID string
 	// Config specific to the plugin
 	Config interface{}
-	// Requires is a list of plugins that the registered plugin requires to be avaliable
+	// Requires is a list of plugins that the registered plugin requires to be available
 	Requires []Type
 
 	// InitFn is called when initializing a plugin. The registration and

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -58,9 +58,13 @@ const (
 
 // Registration contains information for registering a plugin
 type Registration struct {
-	Type     Type
-	ID       string
-	Config   interface{}
+	// Type of the plugin
+	Type Type
+	// ID of the plugin
+	ID string
+	// Config specific to the plugin
+	Config interface{}
+	// Requires is a list of plugins that the registered plugin requires to be avaliable
 	Requires []Type
 
 	// InitFn is called when initializing a plugin. The registration and
@@ -69,6 +73,7 @@ type Registration struct {
 	InitFn func(*InitContext) (interface{}, error)
 }
 
+// Init the registered plugin
 func (r *Registration) Init(ic *InitContext) *Plugin {
 	p, err := r.InitFn(ic)
 	return &Plugin{

--- a/services/content/reader.go
+++ b/services/content/reader.go
@@ -44,6 +44,6 @@ func (ra *remoteReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
 	return n, nil
 }
 
-func (rr *remoteReaderAt) Close() error {
+func (ra *remoteReaderAt) Close() error {
 	return nil
 }

--- a/services/content/store.go
+++ b/services/content/store.go
@@ -15,6 +15,7 @@ type remoteStore struct {
 	client contentapi.ContentClient
 }
 
+// NewStoreFromClient returns a new content store
 func NewStoreFromClient(client contentapi.ContentClient) content.Store {
 	return &remoteStore{
 		client: client,

--- a/services/diff/client.go
+++ b/services/diff/client.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-// NewApplierFromClient returns a new Applier which communicates
+// NewDiffServiceFromClient returns a new diff service which communicates
 // over a GRPC connection.
 func NewDiffServiceFromClient(client diffapi.DiffClient) diff.Differ {
 	return &remote{

--- a/services/images/client.go
+++ b/services/images/client.go
@@ -13,6 +13,7 @@ type remoteStore struct {
 	client imagesapi.ImagesClient
 }
 
+// NewStoreFromClient returns a new image store client
 func NewStoreFromClient(client imagesapi.ImagesClient) images.Store {
 	return &remoteStore{
 		client: client,

--- a/services/namespaces/client.go
+++ b/services/namespaces/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gogo/protobuf/types"
 )
 
+// NewStoreFromClient returns a new namespace store
 func NewStoreFromClient(client api.NamespacesClient) namespaces.Store {
 	return &remote{client: client}
 }

--- a/snapshot/snapshotter.go
+++ b/snapshot/snapshotter.go
@@ -20,6 +20,9 @@ const (
 	KindCommitted
 )
 
+// ParseKind parses the provided string into a Kind
+//
+// If the string cannot be parsed KindUnknown is returned
 func ParseKind(s string) Kind {
 	s = strings.ToLower(s)
 	switch s {
@@ -34,6 +37,7 @@ func ParseKind(s string) Kind {
 	return KindUnknown
 }
 
+// String returns the string representation of the Kind
 func (k Kind) String() string {
 	switch k {
 	case KindView:
@@ -47,10 +51,12 @@ func (k Kind) String() string {
 	return "Unknown"
 }
 
+// MarshalJSON the Kind to JSON
 func (k Kind) MarshalJSON() ([]byte, error) {
 	return json.Marshal(k.String())
 }
 
+// UnmarshalJSON the Kind from JSON
 func (k *Kind) UnmarshalJSON(b []byte) error {
 	var s string
 	if err := json.Unmarshal(b, &s); err != nil {
@@ -81,6 +87,7 @@ type Usage struct {
 	Size   int64 // provides usage, in bytes, of snapshot
 }
 
+// Add the provided usage to the current usage
 func (u *Usage) Add(other Usage) {
 	u.Size += other.Size
 

--- a/snapshot/storage/bolt.go
+++ b/snapshot/storage/bolt.go
@@ -90,6 +90,7 @@ func GetInfo(ctx context.Context, key string) (string, snapshot.Info, snapshot.U
 	return fmt.Sprintf("%d", id), si, su, nil
 }
 
+// UpdateInfo updates an existing snapshot info's data
 func UpdateInfo(ctx context.Context, info snapshot.Info, fieldpaths ...string) (snapshot.Info, error) {
 	updated := snapshot.Info{
 		Name: info.Name,
@@ -131,11 +132,7 @@ func UpdateInfo(ctx context.Context, info snapshot.Info, fieldpaths ...string) (
 			return err
 		}
 
-		if err := boltutil.WriteLabels(sbkt, updated.Labels); err != nil {
-			return err
-		}
-
-		return nil
+		return boltutil.WriteLabels(sbkt, updated.Labels)
 	})
 	if err != nil {
 		return snapshot.Info{}, err
@@ -534,12 +531,7 @@ func putSnapshot(bkt *bolt.Bucket, id uint64, si snapshot.Info) error {
 	if err := boltutil.WriteTimestamps(bkt, si.Created, si.Updated); err != nil {
 		return err
 	}
-
-	if err := boltutil.WriteLabels(bkt, si.Labels); err != nil {
-		return err
-	}
-
-	return nil
+	return boltutil.WriteLabels(bkt, si.Labels)
 }
 
 func getUsage(bkt *bolt.Bucket, usage *snapshot.Usage) {
@@ -569,7 +561,7 @@ func putUsage(bkt *bolt.Bucket, usage snapshot.Usage) error {
 func encodeSize(size int64) ([]byte, error) {
 	var (
 		buf         [binary.MaxVarintLen64]byte
-		sizeEncoded []byte = buf[:]
+		sizeEncoded = buf[:]
 	)
 	sizeEncoded = sizeEncoded[:binary.PutVarint(sizeEncoded, size)]
 

--- a/snapshot/windows/windows.go
+++ b/snapshot/windows/windows.go
@@ -12,6 +12,7 @@ import (
 )
 
 var (
+	// ErrNotImplemented is returned when an action is not implemented
 	ErrNotImplemented = errors.New("not implemented")
 )
 
@@ -25,12 +26,13 @@ func init() {
 	})
 }
 
-type Snapshotter struct {
+type snapshotter struct {
 	root string
 }
 
+// NewSnapshotter returns a new windows snapshotter
 func NewSnapshotter(root string) (snapshot.Snapshotter, error) {
-	return &Snapshotter{
+	return &snapshotter{
 		root: root,
 	}, nil
 }
@@ -40,23 +42,23 @@ func NewSnapshotter(root string) (snapshot.Snapshotter, error) {
 //
 // Should be used for parent resolution, existence checks and to discern
 // the kind of snapshot.
-func (o *Snapshotter) Stat(ctx context.Context, key string) (snapshot.Info, error) {
+func (o *snapshotter) Stat(ctx context.Context, key string) (snapshot.Info, error) {
 	panic("not implemented")
 }
 
-func (o *Snapshotter) Update(ctx context.Context, info snapshot.Info, fieldpaths ...string) (snapshot.Info, error) {
+func (o *snapshotter) Update(ctx context.Context, info snapshot.Info, fieldpaths ...string) (snapshot.Info, error) {
 	panic("not implemented")
 }
 
-func (o *Snapshotter) Usage(ctx context.Context, key string) (snapshot.Usage, error) {
+func (o *snapshotter) Usage(ctx context.Context, key string) (snapshot.Usage, error) {
 	panic("not implemented")
 }
 
-func (o *Snapshotter) Prepare(ctx context.Context, key, parent string, opts ...snapshot.Opt) ([]mount.Mount, error) {
+func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...snapshot.Opt) ([]mount.Mount, error) {
 	panic("not implemented")
 }
 
-func (o *Snapshotter) View(ctx context.Context, key, parent string, opts ...snapshot.Opt) ([]mount.Mount, error) {
+func (o *snapshotter) View(ctx context.Context, key, parent string, opts ...snapshot.Opt) ([]mount.Mount, error) {
 	panic("not implemented")
 }
 
@@ -64,21 +66,21 @@ func (o *Snapshotter) View(ctx context.Context, key, parent string, opts ...snap
 // called on an read-write or readonly transaction.
 //
 // This can be used to recover mounts after calling View or Prepare.
-func (o *Snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, error) {
+func (o *snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, error) {
 	panic("not implemented")
 }
 
-func (o *Snapshotter) Commit(ctx context.Context, name, key string, opts ...snapshot.Opt) error {
+func (o *snapshotter) Commit(ctx context.Context, name, key string, opts ...snapshot.Opt) error {
 	panic("not implemented")
 }
 
 // Remove abandons the transaction identified by key. All resources
 // associated with the key will be removed.
-func (o *Snapshotter) Remove(ctx context.Context, key string) error {
+func (o *snapshotter) Remove(ctx context.Context, key string) error {
 	panic("not implemented")
 }
 
 // Walk the committed snapshots.
-func (o *Snapshotter) Walk(ctx context.Context, fn func(context.Context, snapshot.Info) error) error {
+func (o *snapshotter) Walk(ctx context.Context, fn func(context.Context, snapshot.Info) error) error {
 	panic("not implemented")
 }

--- a/spec_opts_windows.go
+++ b/spec_opts_windows.go
@@ -15,6 +15,7 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
+// WithImageConfig configures the spec to from the configuration of an Image
 func WithImageConfig(i Image) SpecOpts {
 	return func(ctx context.Context, client *Client, _ *containers.Container, s *specs.Spec) error {
 		var (
@@ -51,6 +52,8 @@ func WithImageConfig(i Image) SpecOpts {
 	}
 }
 
+// WithTTY sets the information on the spec as well as the environment variables for
+// using a TTY
 func WithTTY(width, height int) SpecOpts {
 	return func(_ context.Context, _ *Client, _ *containers.Container, s *specs.Spec) error {
 		s.Process.Terminal = true
@@ -63,6 +66,7 @@ func WithTTY(width, height int) SpecOpts {
 	}
 }
 
+// WithResources sets the provided resources on the spec for task updates
 func WithResources(resources *specs.WindowsResources) UpdateTaskOpts {
 	return func(ctx context.Context, client *Client, r *UpdateTaskInfo) error {
 		r.Resources = resources

--- a/sys/oom_windows.go
+++ b/sys/oom_windows.go
@@ -1,5 +1,8 @@
 package sys
 
+// SetOOMScore sets the oom score for the process
+//
+// Not implemented on Windows
 func SetOOMScore(pid, score int) error {
 	return nil
 }

--- a/sys/stat_unix.go
+++ b/sys/stat_unix.go
@@ -6,14 +6,17 @@ import (
 	"syscall"
 )
 
+// StatAtime returns the Atim
 func StatAtime(st *syscall.Stat_t) syscall.Timespec {
 	return st.Atim
 }
 
+// StatCtime returns the Ctim
 func StatCtime(st *syscall.Stat_t) syscall.Timespec {
 	return st.Ctim
 }
 
+// StatMtime returns the Mtim
 func StatMtime(st *syscall.Stat_t) syscall.Timespec {
 	return st.Mtim
 }

--- a/windows/runtime.go
+++ b/windows/runtime.go
@@ -50,6 +50,7 @@ func init() {
 	})
 }
 
+// New returns a new Windows runtime
 func New(ic *plugin.InitContext) (interface{}, error) {
 	if err := os.MkdirAll(ic.Root, 0700); err != nil {
 		return nil, errors.Wrapf(err, "could not create state directory at %s", ic.Root)


### PR DESCRIPTION
This PR finishes fixing all the remaining go lint issues and enables running go lint on the CI for windows and linux.

Closes #578