### PR TITLE
Add template filepath for release tool

### DIFF
--- a/cmd/containerd-release/main.go
+++ b/cmd/containerd-release/main.go
@@ -61,6 +61,11 @@ This tool should be ran from the root of the project repository for a new releas
 			Name:  "dry,n",
 			Usage: "run the release tooling as a dry run to print the release notes to stdout",
 		},
+		cli.StringFlag{
+			Name:  "template,t",
+			Usage: "template filepath to use in place of the default",
+			Value: defaultTemplateFile,
+		},
 	}
 	app.Action = func(context *cli.Context) error {
 		var (
@@ -100,8 +105,13 @@ This tool should be ran from the root of the project repository for a new releas
 		r.Changes = changes
 		r.Version = tag
 
+		tmpl, err := getTemplate(context)
+		if err != nil {
+			return err
+		}
+
 		if context.Bool("dry") {
-			t, err := template.New("release-notes").Parse(releaseNotes)
+			t, err := template.New("release-notes").Parse(tmpl)
 			if err != nil {
 				return err
 			}

--- a/cmd/containerd-release/template.go
+++ b/cmd/containerd-release/template.go
@@ -1,6 +1,8 @@
 package main
 
-const releaseNotes = `Welcome to the release of {{.ProjectName}} {{.Version}}!
+const (
+	defaultTemplateFile = "TEMPLATE"
+	releaseNotes        = `Welcome to the release of {{.ProjectName}} {{.Version}}!
 {{if .PreRelease}}
 *This is a pre-release of {{.ProjectName}}*
 {{- end}}
@@ -33,3 +35,4 @@ Previous release can be found at [{{.Previous}}](https://github.com/{{.GithubRep
 * {{$dep.Previous}} -> {{$dep.Commit}} **{{$dep.Name}}**
 {{- end}}
 `
+)


### PR DESCRIPTION
This allows a project to have a TEMPLATE file in the root of the repo to
be used with the release tool.  If they don't have this file and did not
specify a custom file then it will use the compiled in template in the
release tool.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>