### PR TITLE
Move task list to separate command

### DIFF
--- a/cmd/ctr/task.go
+++ b/cmd/ctr/task.go
@@ -14,12 +14,6 @@ var tasksCommand = cli.Command{
 	Name:    "tasks",
 	Usage:   "manage tasks",
 	Aliases: []string{"t"},
-	Flags: []cli.Flag{
-		cli.BoolFlag{
-			Name:  "quiet, q",
-			Usage: "print only the task id & pid",
-		},
-	},
 	Subcommands: []cli.Command{
 		taskAttachCommand,
 		taskCheckpointCommand,
@@ -30,6 +24,19 @@ var tasksCommand = cli.Command{
 		taskResumeCommand,
 		taskStartCommand,
 		taskDeleteCommand,
+		taskListCommand,
+	},
+}
+
+var taskListCommand = cli.Command{
+	Name:    "list",
+	Usage:   "list tasks",
+	Aliases: []string{"ls"},
+	Flags: []cli.Flag{
+		cli.BoolFlag{
+			Name:  "quiet, q",
+			Usage: "print only the task id & pid",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		quiet := context.Bool("quiet")


### PR DESCRIPTION
This keeps the semantics the same as the other commands to only list
containers, tasks, images by calling the list subcommand.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>