### PR TITLE
remotes/docker/schema1: back off on locked ref

### DIFF
--- a/remotes/handlers.go
+++ b/remotes/handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand"
 	"time"
 
 	"github.com/containerd/containerd/content"
@@ -84,7 +85,7 @@ func fetch(ctx context.Context, ingester content.Ingester, fetcher Fetcher, desc
 			// of writer and abort if not updated recently.
 
 			select {
-			case <-time.After(time.Millisecond * time.Duration(retry)):
+			case <-time.After(time.Millisecond * time.Duration(rand.Intn(retry))):
 				if retry < 2048 {
 					retry = retry << 1
 				}


### PR DESCRIPTION
To allow concurrent pull of images of the v1 persuasion, we need to
backoff when multiple pullers are trying to operate on the same
resource. The back off logic is ported to v1 pull to match the behavior
for other images.

A little randomness is also added to the backoff to prevent thundering
herd and to reduce expected recovery time.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

Closes #1545