### PR TITLE
Fix CC-BY license reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,4 +205,4 @@ is released under the Apache 2.0 license. The README.md file, and files in the
 "docs" folder are licensed under the Creative Commons Attribution 4.0
 International License under the terms and conditions set forth in the file
 "LICENSE.docs". You may obtain a duplicate copy of the same license, titled
-CC-BY-SA-4.0, at http://creativecommons.org/licenses/by/4.0/.
+CC-BY-4.0, at http://creativecommons.org/licenses/by/4.0/.


### PR DESCRIPTION
Fixes: #1700 

Fix the reference to the shortname of the correct license already being
linked to in the README.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>