### PR TITLE
Use bolt correctly to avoid deadlock.

### DIFF
--- a/snapshot/storage/metastore.go
+++ b/snapshot/storage/metastore.go
@@ -63,7 +63,7 @@ type transactionKey struct{}
 // TransactionContext creates a new transaction context. The writable value
 // should be set to true for transactions which are expected to mutate data.
 func (ms *MetaStore) TransactionContext(ctx context.Context, writable bool) (context.Context, Transactor, error) {
-	db, err := bolt.Open(ms.dbfile, 0600, nil)
+	db, err := bolt.Open(ms.dbfile, 0600, &bolt.Options{ReadOnly: !writable})
 	if err != nil {
 		return ctx, nil, errors.Wrap(err, "failed to open database file")
 	}


### PR DESCRIPTION
Fixes https://github.com/containerd/containerd/issues/1694.

In cri-containerd, to get disk usage of all snapshots, we `Walk` all snapshots and call `Usage` for each snapshot in the walk function. Because both `Walk` and `Usage` are read only function, I thought it should work.

However, we open bolt without `Readonly` option, so [`flock`](https://github.com/boltdb/bolt/blob/master/db.go#L186) is still exclusive. Thus calling `Usage` inside `Walk` will cause a deadlock.

If we expect concurrent read-only operation to work, we should specify `Readonly`. And this will also eliminates this deadlock.

Signed-off-by: Lantao Liu <lantaol@google.com>