### PR TITLE
containerd --version: print version.Revision

### DIFF
--- a/cmd/containerd/main.go
+++ b/cmd/containerd/main.go
@@ -39,7 +39,7 @@ func init() {
 	grpclog.SetLogger(golog.New(ioutil.Discard, "", golog.LstdFlags))
 
 	cli.VersionPrinter = func(c *cli.Context) {
-		fmt.Println(c.App.Name, version.Package, c.App.Version)
+		fmt.Println(c.App.Name, version.Package, c.App.Version, version.Revision)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>


Currently, `docker info` producing weird result because `containerd --version` does not include revision:
```
$ docker info
...
Runtimes: runc                                       
Default Runtime: runc                                
Init Binary: docker-init                             
containerd version: v1.0.0-beta.2-53-g992280e8 (expected: 992280e8e265f491f7a624ab82f3e238be086e49)       
runc version: 0351df1c5a66838d0c392b4ac4cf9450de844e2d                                                    
init version: 949e6fa 
...
```

This PR adds `version.Revision` to `containerd --version`:

```
$ containerd --version
containerd github.com/containerd/containerd v1.0.0-beta.2-129-gdfdcd4de dfdcd4decb90a51f45b3bf4e2ab51e30fcf7532b
```


@mlaventure 