### PR TITLE
defaults: add package to contain server defaults

### DIFF
--- a/cmd/containerd/config_linux.go
+++ b/cmd/containerd/config_linux.go
@@ -1,20 +1,21 @@
 package main
 
 import (
+	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/server"
 )
 
 func defaultConfig() *server.Config {
 	return &server.Config{
-		Root:  server.DefaultRootDir,
-		State: server.DefaultStateDir,
+		Root:  defaults.DefaultRootDir,
+		State: defaults.DefaultStateDir,
 		GRPC: server.GRPCConfig{
-			Address: server.DefaultAddress,
+			Address: defaults.DefaultAddress,
 		},
 		Subreaper: true,
 		Debug: server.Debug{
 			Level:   "info",
-			Address: server.DefaultDebugAddress,
+			Address: defaults.DefaultDebugAddress,
 		},
 	}
 }

--- a/cmd/ctr/commands/pprof/pprof.go
+++ b/cmd/ctr/commands/pprof/pprof.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/containerd/containerd/server"
+	"github.com/containerd/containerd/defaults"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
@@ -25,7 +25,7 @@ var Command = cli.Command{
 		cli.StringFlag{
 			Name:  "debug-socket, d",
 			Usage: "socket path for containerd's debug server",
-			Value: server.DefaultDebugAddress,
+			Value: defaults.DefaultDebugAddress,
 		},
 	},
 	Subcommands: []cli.Command{

--- a/cmd/ctr/main.go
+++ b/cmd/ctr/main.go
@@ -17,8 +17,8 @@ import (
 	"github.com/containerd/containerd/cmd/ctr/commands/snapshot"
 	"github.com/containerd/containerd/cmd/ctr/commands/tasks"
 	versionCmd "github.com/containerd/containerd/cmd/ctr/commands/version"
+	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/namespaces"
-	"github.com/containerd/containerd/server"
 	"github.com/containerd/containerd/version"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -57,7 +57,7 @@ containerd CLI
 		cli.StringFlag{
 			Name:  "address, a",
 			Usage: "address for containerd's GRPC server",
-			Value: server.DefaultAddress,
+			Value: defaults.DefaultAddress,
 		},
 		cli.DurationFlag{
 			Name:  "timeout",

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -1,0 +1,16 @@
+// Package defaults provides several common defaults for interacting wtih
+// containerd. These can be used on the client-side or server-side.
+package defaults
+
+const (
+	// DefaultRootDir is the default location used by containerd to store
+	// persistent data
+	DefaultRootDir = "/var/lib/containerd"
+	// DefaultStateDir is the default location used by containerd to store
+	// transient data
+	DefaultStateDir = "/run/containerd"
+	// DefaultAddress is the default unix socket address
+	DefaultAddress = "/run/containerd/containerd.sock"
+	// DefaultDebugAddress is the default unix socket address for pprof data
+	DefaultDebugAddress = "/run/containerd/debug.sock"
+)

--- a/server/server_linux.go
+++ b/server/server_linux.go
@@ -10,19 +10,6 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-const (
-	// DefaultRootDir is the default location used by containerd to store
-	// persistent data
-	DefaultRootDir = "/var/lib/containerd"
-	// DefaultStateDir is the default location used by containerd to store
-	// transient data
-	DefaultStateDir = "/run/containerd"
-	// DefaultAddress is the default unix socket address
-	DefaultAddress = "/run/containerd/containerd.sock"
-	// DefaultDebugAddress is the default unix socket address for pprof data
-	DefaultDebugAddress = "/run/containerd/debug.sock"
-)
-
 // apply sets config settings on the server process
 func apply(ctx context.Context, config *Config) error {
 	if config.Subreaper {


### PR DESCRIPTION
To reduce the binary size of containerd, we no longer import the
`server` package for only a few defaults. This reduces the size of `ctr`
by 2MB. There are probably other gains elsewhere.

Signed-off-by: Stephen J Day <stephen.day@docker.com>