### PR TITLE
Strip binaries in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ COMMANDS=ctr containerd containerd-stress containerd-release
 BINARIES=$(addprefix bin/,$(COMMANDS))
 
 GO_TAGS=$(if $(BUILDTAGS),-tags "$(BUILDTAGS)",)
-GO_LDFLAGS=-ldflags "-X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PKG) $(EXTRA_LDFLAGS)"
+GO_LDFLAGS=-ldflags "-s -w -X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PKG) $(EXTRA_LDFLAGS)"
 
 TESTFLAGS_RACE=
 GO_GCFLAGS=


### PR DESCRIPTION
This will make the binaries around 13MB smaller.


`containerd 34M->21M`

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>