### PR TITLE
Use gometalinter for linting

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,11 +24,7 @@ before_build:
   #- choco install codecov
 
 build_script:
-  - bash.exe -elc "export PATH=/c/tools/mingw64/bin:$PATH ; mingw32-make.exe setup"
-  - bash.exe -elc "export PATH=/c/tools/mingw64/bin:$PATH ; mingw32-make.exe fmt"
-  - bash.exe -elc "export PATH=/c/tools/mingw64/bin:/c/gopath/bin:$PATH ; mingw32-make.exe lint"
-  - bash.exe -elc "export PATH=/c/tools/mingw64/bin:$PATH ; mingw32-make.exe vet"
-  - bash.exe -elc "export PATH=/c/tools/mingw64/bin:/c/gopath/bin:$PATH ; mingw32-make.exe ineffassign"
+  - bash.exe -elc "export PATH=/c/tools/mingw64/bin:/c/gopath/bin:$PATH ; mingw32-make.exe setup check"
   - bash.exe -elc "export PATH=/c/tools/mingw64/bin:$PATH ; mingw32-make.exe build"
   - bash.exe -elc "export PATH=/c/tools/mingw64/bin:$PATH ; mingw32-make.exe binaries"
 

--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -1,0 +1,19 @@
+{
+  "Vendor": true,
+  "Deadline": "2m",
+  "Sort": ["linter", "severity", "path", "line"],
+  "Exclude": [
+    ".*\\.pb\\.go",
+    "fetch\\.go:.*::error: unrecognized printf verb 'r'"
+  ],
+  "EnableGC": true,
+  "WarnUnmatchedDirective": true,
+
+  "Enable": [
+    "gofmt",
+    "goimports",
+    "golint",
+    "ineffassign",
+    "vet"
+  ]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,12 +48,9 @@ script:
   - export GOOS=$TRAVIS_GOOS
   - export CGO_ENABLED=$TRAVIS_CGO_ENABLED
   - GIT_CHECK_EXCLUDE="./vendor" TRAVIS_COMMIT_RANGE="${TRAVIS_COMMIT_RANGE/.../..}" make dco
-  - make fmt
+  - GOOS=linux make setup
   - go build -i .
-  - make setup
-  - make lint
-  - make vet
-  - make ineffassign
+  - make check
   - if [ "$GOOS" = "linux" ]; then make check-protos check-api-descriptors; fi
   - make build
   - make binaries

--- a/Makefile.windows
+++ b/Makefile.windows
@@ -1,7 +1,6 @@
 #Windows specific settings.
 WHALE = "+"
 ONI = "-"
-FIX_PATH = $(subst /,\,$1)
 
 BINARY_SUFFIX=".exe"
 

--- a/mount/mount_unix.go
+++ b/mount/mount_unix.go
@@ -5,17 +5,21 @@ package mount
 import "github.com/pkg/errors"
 
 var (
+	// ErrNotImplementOnUnix is returned for methods that are not implemented
 	ErrNotImplementOnUnix = errors.New("not implemented under unix")
 )
 
+// Mount is not implemented on this platform
 func (m *Mount) Mount(target string) error {
 	return ErrNotImplementOnUnix
 }
 
+// Unmount is not implemented on this platform
 func Unmount(mount string, flags int) error {
 	return ErrNotImplementOnUnix
 }
 
+// UnmountAll is not implemented on this platform
 func UnmountAll(mount string, flags int) error {
 	return ErrNotImplementOnUnix
 }

--- a/sys/stat_bsd.go
+++ b/sys/stat_bsd.go
@@ -6,14 +6,17 @@ import (
 	"syscall"
 )
 
+// StatAtime returns the access time from a stat struct
 func StatAtime(st *syscall.Stat_t) syscall.Timespec {
 	return st.Atimespec
 }
 
+// StatCtime returns the created time from a stat struct
 func StatCtime(st *syscall.Stat_t) syscall.Timespec {
 	return st.Ctimespec
 }
 
+// StatMtime returns the modified time from a stat struct
 func StatMtime(st *syscall.Stat_t) syscall.Timespec {
 	return st.Mtimespec
 }


### PR DESCRIPTION
If you're interested, this PR uses gometalinter to run all the existing linters.

[gometalinter](https://github.com/alecthomas/gometalinter)  provides:
* exits with non-zero on failure (currently being handled by `test -z`)
* uniform mechanisms for ignoring/whitelisting files or issues (`// nolint` in the source, or the `Exclude` list in the config)
* runs all the linters in parallel
* installs a vendored version of all the linters with one command
