### PR TITLE
Add /proc/scsi to masked paths

### DIFF
--- a/spec_unix.go
+++ b/spec_unix.go
@@ -151,6 +151,7 @@ func createDefaultSpec(ctx context.Context, id string) (*specs.Spec, error) {
 				"/proc/timer_stats",
 				"/proc/sched_debug",
 				"/sys/firmware",
+				"/proc/scsi",
 			},
 			ReadonlyPaths: []string{
 				"/proc/asound",


### PR DESCRIPTION
Port over https://github.com/moby/moby/pull/35399

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>