### PR TITLE
Don't fail containerd start in case of corrupted events.log

### DIFF
--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -132,8 +132,11 @@ func readEventLog(s *Supervisor) error {
 		if err := dec.Decode(&e); err != nil {
 			if err == io.EOF {
 				break
+			} else {
+				// We dont want to prevent containerd from starting if the events.log was corrupted
+				logrus.WithField("error", err).Warnf("containerd: Cannot parse event. Skipping.")
+				break
 			}
-			return err
 		}
 
 		// We need to take care of -1 Status for backward compatibility


### PR DESCRIPTION
Some host crash scenarious might cause a corruption at the end of the
events.log. In those cases, the file ends with multiple 0x00 (assuming
that were created for journaling of an event prior the crash).
In such case, there is no meaning of preventing containerd from starting.
This commit add a logic of ignoring the rest of the file (it should be a single event
that is missing anyhow) and proceed with those that were succesfully parsed so far.

Tested using the corrupted log attached to the github issue.

Signed-off-by: Rom Freiman <rom@stratoscale.com>