### PR TITLE
fs: add directory permission tests

### DIFF
--- a/fs/diff_test.go
+++ b/fs/diff_test.go
@@ -108,6 +108,31 @@ func TestFileReplace(t *testing.T) {
 	}
 }
 
+func TestParentDirectoryPermission(t *testing.T) {
+	l1 := fstest.Apply(
+		fstest.CreateDir("/dir1", 0700),
+		fstest.CreateDir("/dir2", 0751),
+		fstest.CreateDir("/dir3", 0777),
+	)
+	l2 := fstest.Apply(
+		fstest.CreateDir("/dir1/d", 0700),
+		fstest.CreateFile("/dir1/d/f", []byte("irrelevant"), 0644),
+		fstest.CreateFile("/dir1/f", []byte("irrelevant"), 0644),
+		fstest.CreateFile("/dir2/f", []byte("irrelevant"), 0644),
+		fstest.CreateFile("/dir3/f", []byte("irrelevant"), 0644),
+	)
+	diff := []TestChange{
+		Add("/dir1/d"),
+		Add("/dir1/d/f"),
+		Add("/dir1/f"),
+		Add("/dir2/f"),
+		Add("/dir3/f"),
+	}
+
+	if err := testDiffWithBase(l1, l2, diff); err != nil {
+		t.Fatalf("Failed diff with base: %+v", err)
+	}
+}
 func TestUpdateWithSameTime(t *testing.T) {
 	tt := time.Now().Truncate(time.Second)
 	t1 := tt.Add(5 * time.Nanosecond)

--- a/fs/fstest/testsuite.go
+++ b/fs/fstest/testsuite.go
@@ -18,6 +18,7 @@ func FSSuite(t *testing.T, a TestApplier) {
 	t.Run("Basic", makeTest(t, a, basicTest))
 	t.Run("Deletion", makeTest(t, a, deletionTest))
 	t.Run("Update", makeTest(t, a, updateTest))
+	t.Run("DirectoryPermission", makeTest(t, a, directoryPermissionsTest))
 	t.Run("HardlinkUnmodified", makeTest(t, a, hardlinkUnmodified))
 	t.Run("HardlinkBeforeUnmodified", makeTest(t, a, hardlinkBeforeUnmodified))
 	t.Run("HardlinkBeforeModified", makeTest(t, a, hardlinkBeforeModified))
@@ -139,6 +140,22 @@ var (
 			CreateFile("/d1/f3", []byte("updated content"), 0664),
 			Chmod("/d1/f2", 0766),
 			Chmod("/d2", 0777),
+		),
+	}
+
+	// directoryPermissionsTest covers directory permissions on update
+	directoryPermissionsTest = []Applier{
+		Apply(
+			CreateDir("/d1", 0700),
+			CreateDir("/d2", 0751),
+			CreateDir("/d3", 0777),
+		),
+		Apply(
+			CreateFile("/d1/f", []byte("irrelevant"), 0644),
+			CreateDir("/d1/d", 0700),
+			CreateFile("/d1/d/f", []byte("irrelevant"), 0644),
+			CreateFile("/d2/f", []byte("irrelevant"), 0644),
+			CreateFile("/d3/f", []byte("irrelevant"), 0644),
 		),
 	}
 


### PR DESCRIPTION
Adds tests for verifying parent directory permissions.
Currently an issue exists in extracting into some Docker graph
drivers. Supporting these graph drivers may require changes to
the diff logic, these tests clarify the existing behavior and
that extraction within containerd works.

Signed-off-by: Derek McGowan <derek@mcgstyle.net>