### PR TITLE
gc.root: use RFC3339 format consistently

### DIFF
--- a/container_opts.go
+++ b/container_opts.go
@@ -94,7 +94,7 @@ func WithNewSnapshot(id string, i Image) NewContainerOpts {
 		}
 		setSnapshotterIfEmpty(c)
 		labels := map[string]string{
-			"containerd.io/gc.root": time.Now().String(),
+			"containerd.io/gc.root": time.Now().UTC().Format(time.RFC3339),
 		}
 		parent := identity.ChainID(diffIDs).String()
 		if _, err := client.SnapshotService(c.Snapshotter).Prepare(ctx, id, parent, snapshot.WithLabels(labels)); err != nil {
@@ -127,7 +127,7 @@ func WithNewSnapshotView(id string, i Image) NewContainerOpts {
 		}
 		setSnapshotterIfEmpty(c)
 		labels := map[string]string{
-			"containerd.io/gc.root": time.Now().String(),
+			"containerd.io/gc.root": time.Now().UTC().Format(time.RFC3339),
 		}
 		parent := identity.ChainID(diffIDs).String()
 		if _, err := client.SnapshotService(c.Snapshotter).View(ctx, id, parent, snapshot.WithLabels(labels)); err != nil {

--- a/metadata/db_test.go
+++ b/metadata/db_test.go
@@ -208,7 +208,7 @@ func TestMetadataCollector(t *testing.T) {
 			blob(bytesFor(1), true),
 			blob(bytesFor(2), false),
 			blob(bytesFor(3), true),
-			blob(bytesFor(4), false, "containerd.io/gc.root", time.Now().String()),
+			blob(bytesFor(4), false, "containerd.io/gc.root", time.Now().UTC().Format(time.RFC3339)),
 			newSnapshot("1", "", false, false),
 			newSnapshot("2", "1", false, false),
 			newSnapshot("3", "2", false, false),


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

Previously, Go-specific(?) `String()` format and RFC3339 format were mixed up
