### PR TITLE
Reduce shim size by reducing imports

### DIFF
--- a/client.go
+++ b/client.go
@@ -22,6 +22,7 @@ import (
 	versionservice "github.com/containerd/containerd/api/services/version/v1"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/dialer"
 	"github.com/containerd/containerd/diff"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
@@ -72,7 +73,7 @@ func New(address string, opts ...ClientOpt) (*Client, error) {
 		grpc.WithTimeout(60 * time.Second),
 		grpc.FailOnNonTempDialError(true),
 		grpc.WithBackoffMaxDelay(3 * time.Second),
-		grpc.WithDialer(Dialer),
+		grpc.WithDialer(dialer.Dialer),
 	}
 	if len(copts.dialOptions) > 0 {
 		gopts = copts.dialOptions
@@ -84,7 +85,7 @@ func New(address string, opts ...ClientOpt) (*Client, error) {
 			grpc.WithStreamInterceptor(stream),
 		)
 	}
-	conn, err := grpc.Dial(DialAddress(address), gopts...)
+	conn, err := grpc.Dial(dialer.DialAddress(address), gopts...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to dial %q", address)
 	}

--- a/cmd/containerd-shim/main_unix.go
+++ b/cmd/containerd-shim/main_unix.go
@@ -13,8 +13,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/containerd/containerd"
 	eventsapi "github.com/containerd/containerd/api/services/events/v1"
+	"github.com/containerd/containerd/dialer"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/events"
 	"github.com/containerd/containerd/linux/shim"
@@ -212,7 +212,7 @@ func dumpStacks(logger *logrus.Entry) {
 }
 
 func connectEvents(address string) (eventsapi.EventsClient, error) {
-	conn, err := connect(address, containerd.Dialer)
+	conn, err := connect(address, dialer.Dialer)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to dial %q", address)
 	}
@@ -228,7 +228,7 @@ func connect(address string, d func(string, time.Duration) (net.Conn, error)) (*
 		grpc.FailOnNonTempDialError(true),
 		grpc.WithBackoffMaxDelay(3 * time.Second),
 	}
-	conn, err := grpc.Dial(containerd.DialAddress(address), gopts...)
+	conn, err := grpc.Dial(dialer.DialAddress(address), gopts...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to dial %q", address)
 	}

--- a/cmd/containerd-shim/main_unix.go
+++ b/cmd/containerd-shim/main_unix.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"net"
 	"os"
@@ -20,12 +21,10 @@ import (
 	"github.com/containerd/containerd/linux/shim"
 	shimapi "github.com/containerd/containerd/linux/shim/v1"
 	"github.com/containerd/containerd/reaper"
-	"github.com/containerd/containerd/version"
 	"github.com/containerd/typeurl"
 	google_protobuf "github.com/golang/protobuf/ptypes/empty"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
 )
@@ -40,99 +39,81 @@ const usage = `
 shim for container lifecycle and reconnection
 `
 
+var (
+	debugFlag         bool
+	namespaceFlag     string
+	socketFlag        string
+	addressFlag       string
+	workdirFlag       string
+	runtimeRootFlag   string
+	criuFlag          string
+	systemdCgroupFlag bool
+)
+
+func init() {
+	flag.BoolVar(&debugFlag, "debug", false, "enable debug output in logs")
+	flag.StringVar(&namespaceFlag, "namespace", "", "namespace that owns the shim")
+	flag.StringVar(&socketFlag, "socket", "", "abstract socket path to serve")
+	flag.StringVar(&addressFlag, "address", "", "grpc address back to main containerd")
+	flag.StringVar(&workdirFlag, "workdir", "", "path used to storge large temporary data")
+	flag.StringVar(&runtimeRootFlag, "runtime-root", shim.RuncRoot, "root directory for the runtime")
+	flag.StringVar(&criuFlag, "criu", "", "path to criu binary")
+	flag.BoolVar(&systemdCgroupFlag, "systemd-cgroup", false, "set runtime to use systemd-cgroup")
+	flag.Parse()
+}
+
 func main() {
-	app := cli.NewApp()
-	app.Name = "containerd-shim"
-	app.Version = version.Version
-	app.Usage = usage
-	app.Flags = []cli.Flag{
-		cli.BoolFlag{
-			Name:  "debug",
-			Usage: "enable debug output in logs",
-		},
-		cli.StringFlag{
-			Name:  "namespace,n",
-			Usage: "namespace that owns the task",
-		},
-		cli.StringFlag{
-			Name:  "socket,s",
-			Usage: "abstract socket path to serve on",
-		},
-		cli.StringFlag{
-			Name:  "address,a",
-			Usage: "grpc address back to containerd",
-		},
-		cli.StringFlag{
-			Name:  "workdir,w",
-			Usage: "path used to store large temporary data",
-		},
-		cli.StringFlag{
-			Name:  "runtime-root",
-			Usage: "root directory for the runtime",
-			Value: shim.RuncRoot,
-		},
-		cli.StringFlag{
-			Name:  "criu,c",
-			Usage: "path to criu",
-		},
-		cli.BoolFlag{
-			Name:  "systemd-cgroup",
-			Usage: "set runtime to use systemd-cgroup",
-		},
+	if debugFlag {
+		logrus.SetLevel(logrus.DebugLevel)
 	}
-	app.Before = func(context *cli.Context) error {
-		if context.GlobalBool("debug") {
-			logrus.SetLevel(logrus.DebugLevel)
-		}
-		return nil
-	}
-	app.Action = func(context *cli.Context) error {
-		// start handling signals as soon as possible so that things are properly reaped
-		// or if runtime exits before we hit the handler
-		signals, err := setupSignals()
-		if err != nil {
-			return err
-		}
-		path, err := os.Getwd()
-		if err != nil {
-			return err
-		}
-		server := newServer()
-		e, err := connectEvents(context.GlobalString("address"))
-		if err != nil {
-			return err
-		}
-		sv, err := shim.NewService(
-			shim.Config{
-				Path:          path,
-				Namespace:     context.GlobalString("namespace"),
-				WorkDir:       context.GlobalString("workdir"),
-				Criu:          context.GlobalString("criu"),
-				SystemdCgroup: context.GlobalBool("systemd-cgroup"),
-				RuntimeRoot:   context.GlobalString("runtime-root"),
-			},
-			&remoteEventsPublisher{client: e},
-		)
-		if err != nil {
-			return err
-		}
-		logrus.Debug("registering grpc server")
-		shimapi.RegisterShimServer(server, sv)
-		socket := context.GlobalString("socket")
-		if err := serve(server, socket); err != nil {
-			return err
-		}
-		logger := logrus.WithFields(logrus.Fields{
-			"pid":       os.Getpid(),
-			"path":      path,
-			"namespace": context.GlobalString("namespace"),
-		})
-		return handleSignals(logger, signals, server, sv)
-	}
-	if err := app.Run(os.Args); err != nil {
+	if err := executeShim(); err != nil {
 		fmt.Fprintf(os.Stderr, "containerd-shim: %s\n", err)
 		os.Exit(1)
 	}
+}
+
+func executeShim() error {
+	// start handling signals as soon as possible so that things are properly reaped
+	// or if runtime exits before we hit the handler
+	signals, err := setupSignals()
+	if err != nil {
+		return err
+	}
+	path, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	server := newServer()
+	e, err := connectEvents(addressFlag)
+	if err != nil {
+		return err
+	}
+	sv, err := shim.NewService(
+		shim.Config{
+			Path:          path,
+			Namespace:     namespaceFlag,
+			WorkDir:       workdirFlag,
+			Criu:          criuFlag,
+			SystemdCgroup: systemdCgroupFlag,
+			RuntimeRoot:   runtimeRootFlag,
+		},
+		&remoteEventsPublisher{client: e},
+	)
+	if err != nil {
+		return err
+	}
+	logrus.Debug("registering grpc server")
+	shimapi.RegisterShimServer(server, sv)
+	socket := socketFlag
+	if err := serve(server, socket); err != nil {
+		return err
+	}
+	logger := logrus.WithFields(logrus.Fields{
+		"pid":       os.Getpid(),
+		"path":      path,
+		"namespace": namespaceFlag,
+	})
+	return handleSignals(logger, signals, server, sv)
 }
 
 // serve serves the grpc API over a unix socket at the provided path

--- a/dialer/dialer.go
+++ b/dialer/dialer.go
@@ -1,7 +1,6 @@
 package dialer
 
 import (
-	"fmt"
 	"net"
 	"time"
 
@@ -11,12 +10,6 @@ import (
 type dialResult struct {
 	c   net.Conn
 	err error
-}
-
-// DialAddress returns the address with unix:// prepended to the
-// provided address
-func DialAddress(address string) string {
-	return fmt.Sprintf("unix://%s", address)
 }
 
 // Dialer returns a GRPC net.Conn connected to the provided address

--- a/dialer/dialer.go
+++ b/dialer/dialer.go
@@ -1,6 +1,7 @@
-package containerd
+package dialer
 
 import (
+	"fmt"
 	"net"
 	"time"
 
@@ -10,6 +11,12 @@ import (
 type dialResult struct {
 	c   net.Conn
 	err error
+}
+
+// DialAddress returns the address with unix:// prepended to the
+// provided address
+func DialAddress(address string) string {
+	return fmt.Sprintf("unix://%s", address)
 }
 
 // Dialer returns a GRPC net.Conn connected to the provided address

--- a/dialer/dialer_unix.go
+++ b/dialer/dialer_unix.go
@@ -3,12 +3,19 @@
 package dialer
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"strings"
 	"syscall"
 	"time"
 )
+
+// DialAddress returns the address with unix:// prepended to the
+// provided address
+func DialAddress(address string) string {
+	return fmt.Sprintf("unix://%s", address)
+}
 
 func isNoent(err error) bool {
 	if err != nil {

--- a/dialer/dialer_unix.go
+++ b/dialer/dialer_unix.go
@@ -1,9 +1,8 @@
 // +build !windows
 
-package containerd
+package dialer
 
 import (
-	"fmt"
 	"net"
 	"os"
 	"strings"
@@ -27,10 +26,4 @@ func isNoent(err error) bool {
 func dialer(address string, timeout time.Duration) (net.Conn, error) {
 	address = strings.TrimPrefix(address, "unix://")
 	return net.DialTimeout("unix", address, timeout)
-}
-
-// DialAddress returns the address with unix:// prepended to the
-// provided address
-func DialAddress(address string) string {
-	return fmt.Sprintf("unix://%s", address)
 }

--- a/dialer/dialer_windows.go
+++ b/dialer/dialer_windows.go
@@ -1,4 +1,4 @@
-package containerd
+package dialer
 
 import (
 	"net"

--- a/events/exchange/exchange_test.go
+++ b/events/exchange/exchange_test.go
@@ -71,7 +71,7 @@ func TestExchangeBasic(t *testing.T) {
 			cancel: cancel2,
 		},
 	} {
-		var received []Event
+		var received []events.Event
 	subscribercheck:
 		for {
 			select {

--- a/events/exchange/exchange_test.go
+++ b/events/exchange/exchange_test.go
@@ -1,4 +1,4 @@
-package events
+package exchange
 
 import (
 	"context"
@@ -8,8 +8,9 @@ import (
 	"testing"
 	"time"
 
-	events "github.com/containerd/containerd/api/services/events/v1"
+	v1 "github.com/containerd/containerd/api/services/events/v1"
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/events"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/typeurl"
 	"github.com/pkg/errors"
@@ -17,10 +18,10 @@ import (
 
 func TestExchangeBasic(t *testing.T) {
 	ctx := namespaces.WithNamespace(context.Background(), t.Name())
-	testevents := []Event{
-		&events.ContainerCreate{ID: "asdf"},
-		&events.ContainerCreate{ID: "qwer"},
-		&events.ContainerCreate{ID: "zxcv"},
+	testevents := []events.Event{
+		&v1.ContainerCreate{ID: "asdf"},
+		&v1.ContainerCreate{ID: "qwer"},
+		&v1.ContainerCreate{ID: "zxcv"},
 	}
 	exchange := NewExchange()
 
@@ -55,7 +56,7 @@ func TestExchangeBasic(t *testing.T) {
 	wg.Wait()
 
 	for _, subscriber := range []struct {
-		eventq <-chan *events.Envelope
+		eventq <-chan *v1.Envelope
 		errq   <-chan error
 		cancel func()
 	}{
@@ -79,7 +80,7 @@ func TestExchangeBasic(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				received = append(received, ev.(*events.ContainerCreate))
+				received = append(received, ev.(*v1.ContainerCreate))
 			case err := <-subscriber.errq:
 				if err != nil {
 					t.Fatal(err)
@@ -117,7 +118,7 @@ func TestExchangeValidateTopic(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.input, func(t *testing.T) {
-			event := &events.ContainerCreate{ID: t.Name()}
+			event := &v1.ContainerCreate{ID: t.Name()}
 			if err := exchange.Publish(ctx, testcase.input, event); errors.Cause(err) != testcase.err {
 				if err == nil {
 					t.Fatalf("expected error %v, received nil", testcase.err)
@@ -131,7 +132,7 @@ func TestExchangeValidateTopic(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			envelope := events.Envelope{
+			envelope := v1.Envelope{
 				Timestamp: time.Now().UTC(),
 				Namespace: namespace,
 				Topic:     testcase.input,

--- a/linux/bundle.go
+++ b/linux/bundle.go
@@ -11,7 +11,8 @@ import (
 
 	"github.com/containerd/containerd/events/exchange"
 	"github.com/containerd/containerd/linux/runcopts"
-	client "github.com/containerd/containerd/linux/shim"
+	"github.com/containerd/containerd/linux/shim"
+	"github.com/containerd/containerd/linux/shim/client"
 	"github.com/pkg/errors"
 )
 
@@ -71,26 +72,26 @@ type bundle struct {
 }
 
 // ShimOpt specifies shim options for initialization and connection
-type ShimOpt func(*bundle, string, *runcopts.RuncOptions) (client.Config, client.ClientOpt)
+type ShimOpt func(*bundle, string, *runcopts.RuncOptions) (shim.Config, client.ClientOpt)
 
 // ShimRemote is a ShimOpt for connecting and starting a remote shim
-func ShimRemote(shim, daemonAddress, cgroup string, nonewns, debug bool, exitHandler func()) ShimOpt {
-	return func(b *bundle, ns string, ropts *runcopts.RuncOptions) (client.Config, client.ClientOpt) {
+func ShimRemote(shimBinary, daemonAddress, cgroup string, nonewns, debug bool, exitHandler func()) ShimOpt {
+	return func(b *bundle, ns string, ropts *runcopts.RuncOptions) (shim.Config, client.ClientOpt) {
 		return b.shimConfig(ns, ropts),
-			client.WithStart(shim, b.shimAddress(ns), daemonAddress, cgroup, nonewns, debug, exitHandler)
+			client.WithStart(shimBinary, b.shimAddress(ns), daemonAddress, cgroup, nonewns, debug, exitHandler)
 	}
 }
 
 // ShimLocal is a ShimOpt for using an in process shim implementation
 func ShimLocal(exchange *exchange.Exchange) ShimOpt {
-	return func(b *bundle, ns string, ropts *runcopts.RuncOptions) (client.Config, client.ClientOpt) {
+	return func(b *bundle, ns string, ropts *runcopts.RuncOptions) (shim.Config, client.ClientOpt) {
 		return b.shimConfig(ns, ropts), client.WithLocal(exchange)
 	}
 }
 
 // ShimConnect is a ShimOpt for connecting to an existing remote shim
 func ShimConnect() ShimOpt {
-	return func(b *bundle, ns string, ropts *runcopts.RuncOptions) (client.Config, client.ClientOpt) {
+	return func(b *bundle, ns string, ropts *runcopts.RuncOptions) (shim.Config, client.ClientOpt) {
 		return b.shimConfig(ns, ropts), client.WithConnect(b.shimAddress(ns))
 	}
 }
@@ -119,7 +120,7 @@ func (b *bundle) shimAddress(namespace string) string {
 	return filepath.Join(string(filepath.Separator), "containerd-shim", namespace, b.id, "shim.sock")
 }
 
-func (b *bundle) shimConfig(namespace string, runcOptions *runcopts.RuncOptions) client.Config {
+func (b *bundle) shimConfig(namespace string, runcOptions *runcopts.RuncOptions) shim.Config {
 	var (
 		criuPath      string
 		runtimeRoot   string
@@ -130,7 +131,7 @@ func (b *bundle) shimConfig(namespace string, runcOptions *runcopts.RuncOptions)
 		systemdCgroup = runcOptions.SystemdCgroup
 		runtimeRoot = runcOptions.RuntimeRoot
 	}
-	return client.Config{
+	return shim.Config{
 		Path:          b.path,
 		WorkDir:       b.workDir,
 		Namespace:     namespace,

--- a/linux/bundle.go
+++ b/linux/bundle.go
@@ -72,11 +72,11 @@ type bundle struct {
 }
 
 // ShimOpt specifies shim options for initialization and connection
-type ShimOpt func(*bundle, string, *runcopts.RuncOptions) (shim.Config, client.ClientOpt)
+type ShimOpt func(*bundle, string, *runcopts.RuncOptions) (shim.Config, client.Opt)
 
 // ShimRemote is a ShimOpt for connecting and starting a remote shim
 func ShimRemote(shimBinary, daemonAddress, cgroup string, nonewns, debug bool, exitHandler func()) ShimOpt {
-	return func(b *bundle, ns string, ropts *runcopts.RuncOptions) (shim.Config, client.ClientOpt) {
+	return func(b *bundle, ns string, ropts *runcopts.RuncOptions) (shim.Config, client.Opt) {
 		return b.shimConfig(ns, ropts),
 			client.WithStart(shimBinary, b.shimAddress(ns), daemonAddress, cgroup, nonewns, debug, exitHandler)
 	}
@@ -84,14 +84,14 @@ func ShimRemote(shimBinary, daemonAddress, cgroup string, nonewns, debug bool, e
 
 // ShimLocal is a ShimOpt for using an in process shim implementation
 func ShimLocal(exchange *exchange.Exchange) ShimOpt {
-	return func(b *bundle, ns string, ropts *runcopts.RuncOptions) (shim.Config, client.ClientOpt) {
+	return func(b *bundle, ns string, ropts *runcopts.RuncOptions) (shim.Config, client.Opt) {
 		return b.shimConfig(ns, ropts), client.WithLocal(exchange)
 	}
 }
 
 // ShimConnect is a ShimOpt for connecting to an existing remote shim
 func ShimConnect() ShimOpt {
-	return func(b *bundle, ns string, ropts *runcopts.RuncOptions) (shim.Config, client.ClientOpt) {
+	return func(b *bundle, ns string, ropts *runcopts.RuncOptions) (shim.Config, client.Opt) {
 		return b.shimConfig(ns, ropts), client.WithConnect(b.shimAddress(ns))
 	}
 }

--- a/linux/bundle.go
+++ b/linux/bundle.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/containerd/containerd/events"
+	"github.com/containerd/containerd/events/exchange"
 	"github.com/containerd/containerd/linux/runcopts"
 	client "github.com/containerd/containerd/linux/shim"
 	"github.com/pkg/errors"
@@ -82,7 +82,7 @@ func ShimRemote(shim, daemonAddress, cgroup string, nonewns, debug bool, exitHan
 }
 
 // ShimLocal is a ShimOpt for using an in process shim implementation
-func ShimLocal(exchange *events.Exchange) ShimOpt {
+func ShimLocal(exchange *exchange.Exchange) ShimOpt {
 	return func(b *bundle, ns string, ropts *runcopts.RuncOptions) (client.Config, client.ClientOpt) {
 		return b.shimConfig(ns, ropts), client.WithLocal(exchange)
 	}

--- a/linux/runtime.go
+++ b/linux/runtime.go
@@ -15,7 +15,7 @@ import (
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/events"
+	"github.com/containerd/containerd/events/exchange"
 	"github.com/containerd/containerd/identifiers"
 	"github.com/containerd/containerd/linux/runcopts"
 	client "github.com/containerd/containerd/linux/shim"
@@ -143,7 +143,7 @@ type Runtime struct {
 	monitor runtime.TaskMonitor
 	tasks   *runtime.TaskList
 	db      *metadata.DB
-	events  *events.Exchange
+	events  *exchange.Exchange
 
 	config *Config
 }

--- a/linux/shim/client.go
+++ b/linux/shim/client.go
@@ -86,22 +86,22 @@ func WithStart(binary, address, daemonAddress, cgroup string, nonewns, debug boo
 
 func newCommand(binary, daemonAddress string, nonewns, debug bool, config Config, socket *os.File) *exec.Cmd {
 	args := []string{
-		"--namespace", config.Namespace,
-		"--workdir", config.WorkDir,
-		"--address", daemonAddress,
+		"-namespace", config.Namespace,
+		"-workdir", config.WorkDir,
+		"-address", daemonAddress,
 	}
 
 	if config.Criu != "" {
-		args = append(args, "--criu-path", config.Criu)
+		args = append(args, "-criu-path", config.Criu)
 	}
 	if config.RuntimeRoot != "" {
-		args = append(args, "--runtime-root", config.RuntimeRoot)
+		args = append(args, "-runtime-root", config.RuntimeRoot)
 	}
 	if config.SystemdCgroup {
-		args = append(args, "--systemd-cgroup")
+		args = append(args, "-systemd-cgroup")
 	}
 	if debug {
-		args = append(args, "--debug")
+		args = append(args, "-debug")
 	}
 
 	cmd := exec.Command(binary, args...)

--- a/linux/shim/client/client.go
+++ b/linux/shim/client/client.go
@@ -31,11 +31,11 @@ import (
 
 var empty = &google_protobuf.Empty{}
 
-// ClientOpt is an option for a shim client configuration
-type ClientOpt func(context.Context, shim.Config) (shimapi.ShimClient, io.Closer, error)
+// Opt is an option for a shim client configuration
+type Opt func(context.Context, shim.Config) (shimapi.ShimClient, io.Closer, error)
 
 // WithStart executes a new shim process
-func WithStart(binary, address, daemonAddress, cgroup string, nonewns, debug bool, exitHandler func()) ClientOpt {
+func WithStart(binary, address, daemonAddress, cgroup string, nonewns, debug bool, exitHandler func()) Opt {
 	return func(ctx context.Context, config shim.Config) (_ shimapi.ShimClient, _ io.Closer, err error) {
 		socket, err := newSocket(address)
 		if err != nil {
@@ -164,7 +164,7 @@ func dialAddress(address string) string {
 }
 
 // WithConnect connects to an existing shim
-func WithConnect(address string) ClientOpt {
+func WithConnect(address string) Opt {
 	return func(ctx context.Context, config shim.Config) (shimapi.ShimClient, io.Closer, error) {
 		conn, err := connect(address, annonDialer)
 		if err != nil {
@@ -186,7 +186,7 @@ func WithLocal(publisher events.Publisher) func(context.Context, shim.Config) (s
 }
 
 // New returns a new shim client
-func New(ctx context.Context, config shim.Config, opt ClientOpt) (*Client, error) {
+func New(ctx context.Context, config shim.Config, opt Opt) (*Client, error) {
 	s, c, err := opt(ctx, config)
 	if err != nil {
 		return nil, err

--- a/linux/shim/client/client.go
+++ b/linux/shim/client/client.go
@@ -1,6 +1,6 @@
 // +build !windows
 
-package shim
+package client
 
 import (
 	"context"
@@ -20,19 +20,23 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/containerd/containerd/events"
-	shim "github.com/containerd/containerd/linux/shim/v1"
+	"github.com/containerd/containerd/linux/shim"
+	shimapi "github.com/containerd/containerd/linux/shim/v1"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/reaper"
 	"github.com/containerd/containerd/sys"
+	google_protobuf "github.com/golang/protobuf/ptypes/empty"
 	"google.golang.org/grpc"
 )
 
+var empty = &google_protobuf.Empty{}
+
 // ClientOpt is an option for a shim client configuration
-type ClientOpt func(context.Context, Config) (shim.ShimClient, io.Closer, error)
+type ClientOpt func(context.Context, shim.Config) (shimapi.ShimClient, io.Closer, error)
 
 // WithStart executes a new shim process
 func WithStart(binary, address, daemonAddress, cgroup string, nonewns, debug bool, exitHandler func()) ClientOpt {
-	return func(ctx context.Context, config Config) (_ shim.ShimClient, _ io.Closer, err error) {
+	return func(ctx context.Context, config shim.Config) (_ shimapi.ShimClient, _ io.Closer, err error) {
 		socket, err := newSocket(address)
 		if err != nil {
 			return nil, nil, err
@@ -84,7 +88,7 @@ func WithStart(binary, address, daemonAddress, cgroup string, nonewns, debug boo
 	}
 }
 
-func newCommand(binary, daemonAddress string, nonewns, debug bool, config Config, socket *os.File) *exec.Cmd {
+func newCommand(binary, daemonAddress string, nonewns, debug bool, config shim.Config, socket *os.File) *exec.Cmd {
 	args := []string{
 		"-namespace", config.Namespace,
 		"-workdir", config.WorkDir,
@@ -161,38 +165,28 @@ func dialAddress(address string) string {
 
 // WithConnect connects to an existing shim
 func WithConnect(address string) ClientOpt {
-	return func(ctx context.Context, config Config) (shim.ShimClient, io.Closer, error) {
+	return func(ctx context.Context, config shim.Config) (shimapi.ShimClient, io.Closer, error) {
 		conn, err := connect(address, annonDialer)
 		if err != nil {
 			return nil, nil, err
 		}
-		return shim.NewShimClient(conn), conn, nil
+		return shimapi.NewShimClient(conn), conn, nil
 	}
 }
 
 // WithLocal uses an in process shim
-func WithLocal(publisher events.Publisher) func(context.Context, Config) (shim.ShimClient, io.Closer, error) {
-	return func(ctx context.Context, config Config) (shim.ShimClient, io.Closer, error) {
-		service, err := NewService(config, publisher)
+func WithLocal(publisher events.Publisher) func(context.Context, shim.Config) (shimapi.ShimClient, io.Closer, error) {
+	return func(ctx context.Context, config shim.Config) (shimapi.ShimClient, io.Closer, error) {
+		service, err := shim.NewService(config, publisher)
 		if err != nil {
 			return nil, nil, err
 		}
-		return NewLocal(service), nil, nil
+		return shim.NewLocal(service), nil, nil
 	}
 }
 
-// Config contains shim specific configuration
-type Config struct {
-	Path          string
-	Namespace     string
-	WorkDir       string
-	Criu          string
-	RuntimeRoot   string
-	SystemdCgroup bool
-}
-
 // New returns a new shim client
-func New(ctx context.Context, config Config, opt ClientOpt) (*Client, error) {
+func New(ctx context.Context, config shim.Config, opt ClientOpt) (*Client, error) {
 	s, c, err := opt(ctx, config)
 	if err != nil {
 		return nil, err
@@ -206,7 +200,7 @@ func New(ctx context.Context, config Config, opt ClientOpt) (*Client, error) {
 
 // Client is a shim client containing the connection to a shim
 type Client struct {
-	shim.ShimClient
+	shimapi.ShimClient
 
 	c        io.Closer
 	exitCh   chan struct{}

--- a/linux/shim/client/client_linux.go
+++ b/linux/shim/client/client_linux.go
@@ -1,6 +1,6 @@
 // +build linux
 
-package shim
+package client
 
 import (
 	"os/exec"

--- a/linux/shim/client/client_unix.go
+++ b/linux/shim/client/client_unix.go
@@ -1,6 +1,6 @@
 // +build !linux,!windows
 
-package shim
+package client
 
 import (
 	"os/exec"

--- a/linux/shim/init.go
+++ b/linux/shim/init.go
@@ -98,12 +98,16 @@ func (s *Service) newInitProcess(context context.Context, r *shimapi.CreateTaskR
 			return nil, errors.Wrapf(err, "failed to mount rootfs component %v", m)
 		}
 	}
+	root := s.config.RuntimeRoot
+	if root == "" {
+		root = RuncRoot
+	}
 	runtime := &runc.Runc{
 		Command:       r.Runtime,
 		Log:           filepath.Join(s.config.Path, "log.json"),
 		LogFormat:     runc.JSON,
 		PdeathSignal:  syscall.SIGKILL,
-		Root:          filepath.Join(s.config.RuntimeRoot, s.config.Namespace),
+		Root:          filepath.Join(root, s.config.Namespace),
 		Criu:          s.config.Criu,
 		SystemdCgroup: s.config.SystemdCgroup,
 	}

--- a/linux/shim/service.go
+++ b/linux/shim/service.go
@@ -32,6 +32,16 @@ var empty = &google_protobuf.Empty{}
 // RuncRoot is the path to the root runc state directory
 const RuncRoot = "/run/containerd/runc"
 
+// Config contains shim specific configuration
+type Config struct {
+	Path          string
+	Namespace     string
+	WorkDir       string
+	Criu          string
+	RuntimeRoot   string
+	SystemdCgroup bool
+}
+
 // NewService returns a new shim service that can be used via GRPC
 func NewService(config Config, publisher events.Publisher) (*Service, error) {
 	if config.Namespace == "" {

--- a/linux/task.go
+++ b/linux/task.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containerd/cgroups"
 	"github.com/containerd/containerd/api/types/task"
 	"github.com/containerd/containerd/errdefs"
-	client "github.com/containerd/containerd/linux/shim"
+	"github.com/containerd/containerd/linux/shim/client"
 	shim "github.com/containerd/containerd/linux/shim/v1"
 	"github.com/containerd/containerd/runtime"
 	"github.com/gogo/protobuf/types"

--- a/plugin/context.go
+++ b/plugin/context.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/events"
+	"github.com/containerd/containerd/events/exchange"
 	"github.com/containerd/containerd/log"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -18,7 +18,7 @@ type InitContext struct {
 	State   string
 	Config  interface{}
 	Address string
-	Events  *events.Exchange
+	Events  *exchange.Exchange
 
 	Meta *Meta // plugins can fill in metadata at init.
 

--- a/server/server.go
+++ b/server/server.go
@@ -22,7 +22,7 @@ import (
 	version "github.com/containerd/containerd/api/services/version/v1"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/content/local"
-	"github.com/containerd/containerd/events"
+	"github.com/containerd/containerd/events/exchange"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/metadata"
 	"github.com/containerd/containerd/plugin"
@@ -65,7 +65,7 @@ func New(ctx context.Context, config *Config) (*Server, error) {
 		services []plugin.Service
 		s        = &Server{
 			rpc:    rpc,
-			events: events.NewExchange(),
+			events: exchange.NewExchange(),
 		}
 		initialized = plugin.NewPluginSet()
 	)
@@ -122,7 +122,7 @@ func New(ctx context.Context, config *Config) (*Server, error) {
 // Server is the containerd main daemon
 type Server struct {
 	rpc    *grpc.Server
-	events *events.Exchange
+	events *exchange.Exchange
 }
 
 // ServeGRPC provides the containerd grpc APIs on the provided listener

--- a/services/events/service.go
+++ b/services/events/service.go
@@ -3,7 +3,7 @@ package events
 import (
 	api "github.com/containerd/containerd/api/services/events/v1"
 	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/events"
+	"github.com/containerd/containerd/events/exchange"
 	"github.com/containerd/containerd/plugin"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/pkg/errors"
@@ -22,11 +22,11 @@ func init() {
 }
 
 type service struct {
-	events *events.Exchange
+	events *exchange.Exchange
 }
 
 // NewService returns the GRPC events server
-func NewService(events *events.Exchange) api.EventsServer {
+func NewService(events *exchange.Exchange) api.EventsServer {
 	return &service{events: events}
 }
 


### PR DESCRIPTION
This breaks out some shared functions and types into smaller packages to reduce what the shim imports.

It goes from 30mb to 12mb, saving 18mb with these changes alone. 

It's a start.