### PR TITLE
Fix deadlock in overlay snapshotter

### DIFF
--- a/snapshot/overlay/overlay.go
+++ b/snapshot/overlay/overlay.go
@@ -124,12 +124,13 @@ func (o *snapshotter) Usage(ctx context.Context, key string) (snapshot.Usage, er
 		return snapshot.Usage{}, err
 	}
 	id, info, usage, err := storage.GetInfo(ctx, key)
+	t.Rollback() // transaction no longer needed at this point.
+
 	if err != nil {
 		return snapshot.Usage{}, err
 	}
 
 	upperPath := o.upperPath(id)
-	t.Rollback() // transaction no longer needed at this point.
 
 	if info.Kind == snapshot.KindActive {
 		du, err := fs.DiskUsage(upperPath)


### PR DESCRIPTION
The `Usage` implementation in the overlay driver allowed returning before `Rollback` was called, leaving a transaction open and causing further operations to deadlock. This could occur if the usage call to the datastore returned an error, such as not found.

Fixes #1724

I checked to make sure there were no other cases in the overlay driver which could return with a transaction still open.