### PR TITLE
Add S to PLATFORM in images list & plugins list

### DIFF
--- a/cmd/ctr/commands/images/images.go
+++ b/cmd/ctr/commands/images/images.go
@@ -70,7 +70,7 @@ var listCommand = cli.Command{
 			return nil
 		}
 		tw := tabwriter.NewWriter(os.Stdout, 1, 8, 1, ' ', 0)
-		fmt.Fprintln(tw, "REF\tTYPE\tDIGEST\tSIZE\tPLATFORM\tLABELS\t")
+		fmt.Fprintln(tw, "REF\tTYPE\tDIGEST\tSIZE\tPLATFORMS\tLABELS\t")
 		for _, image := range imageList {
 			size, err := image.Size(ctx, cs, platforms.Default())
 			if err != nil {

--- a/cmd/ctr/commands/plugins/plugins.go
+++ b/cmd/ctr/commands/plugins/plugins.go
@@ -93,7 +93,7 @@ var Command = cli.Command{
 			return w.Flush()
 		}
 
-		fmt.Fprintln(w, "TYPE\tID\tPLATFORM\tSTATUS\t")
+		fmt.Fprintln(w, "TYPE\tID\tPLATFORMS\tSTATUS\t")
 		for _, plugin := range response.Plugins {
 			status := "ok"
 


### PR DESCRIPTION
I believe PLATFORM should be PLATFORMS in `ctr image list` and `ctr plugins list` since it's possible to have multiple platforms.

```
$ ./bin/ctr images ls
REF                             TYPE                                                      DIGEST                                                                  SIZE    PLATFORM                                                                    LABELS
docker.io/library//redis:alpine application/vnd.docker.distribution.manifest.list.v2+json sha256:504cf109b4922e7cb8db839feb1a1ea6d434782e8be9822fbc0ef0a05ac64844 9.6 MiB linux/386,linux/amd64,linux/arm/v6,linux/arm64/v8,linux/ppc64le,linux/s390x -
```

@estesp WDYT ?