### PR TITLE
Fix output on ctr images rm to show actual feedback

### DIFF
--- a/cmd/ctr/commands/images/images.go
+++ b/cmd/ctr/commands/images/images.go
@@ -291,9 +291,11 @@ var removeCommand = cli.Command{
 					log.G(ctx).WithError(err).Errorf("unable to delete %v", target)
 					continue
 				}
+				// image ref not found in metadata store; log not found condition
+				log.G(ctx).Warnf("%v: image not found", target)
+			} else {
+				fmt.Println(target)
 			}
-
-			fmt.Println(target)
 		}
 
 		return exitErr


### PR DESCRIPTION
Currently the output for a non-existent image reference and a valid
image reference is exactly the same on `ctr images remove`. Instead of
outputting the target ref input, if it is "not found" we should alert
the user in case of a mispelling, but continue not to make it a failure
for the command (given it supports multiple ref entries)

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>