### PR TITLE
Move shim process code into subpackage

### DIFF
--- a/cmd/containerd-shim/main_unix.go
+++ b/cmd/containerd-shim/main_unix.go
@@ -18,6 +18,7 @@ import (
 	"github.com/containerd/containerd/dialer"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/events"
+	"github.com/containerd/containerd/linux/proc"
 	"github.com/containerd/containerd/linux/shim"
 	shimapi "github.com/containerd/containerd/linux/shim/v1"
 	"github.com/containerd/containerd/reaper"
@@ -56,7 +57,7 @@ func init() {
 	flag.StringVar(&socketFlag, "socket", "", "abstract socket path to serve")
 	flag.StringVar(&addressFlag, "address", "", "grpc address back to main containerd")
 	flag.StringVar(&workdirFlag, "workdir", "", "path used to storge large temporary data")
-	flag.StringVar(&runtimeRootFlag, "runtime-root", shim.RuncRoot, "root directory for the runtime")
+	flag.StringVar(&runtimeRootFlag, "runtime-root", proc.RuncRoot, "root directory for the runtime")
 	flag.StringVar(&criuFlag, "criu", "", "path to criu binary")
 	flag.BoolVar(&systemdCgroupFlag, "systemd-cgroup", false, "set runtime to use systemd-cgroup")
 	flag.Parse()

--- a/debug/debug.go
+++ b/debug/debug.go
@@ -1,0 +1,66 @@
+package debug
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Smaps prints the smaps to a file
+func Smaps(note, file string) error {
+	smaps, err := getMaps(os.Getpid())
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(file, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	fmt.Fprintf(f, "%s: rss %d\n", note, smaps["rss"])
+	fmt.Fprintf(f, "%s: pss %d\n", note, smaps["pss"])
+	return nil
+}
+
+func getMaps(pid int) (map[string]int, error) {
+	f, err := os.Open(fmt.Sprintf("/proc/%d/smaps", pid))
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var (
+		smaps = make(map[string]int)
+		s     = bufio.NewScanner(f)
+	)
+	for s.Scan() {
+		var (
+			fields = strings.Fields(s.Text())
+			name   = fields[0]
+		)
+		name = strings.TrimSuffix(strings.ToLower(name), ":")
+		if len(fields) < 2 {
+			continue
+		}
+		n, err := strconv.Atoi(fields[1])
+		if err != nil {
+			continue
+		}
+		smaps[name] += n
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+	return smaps, nil
+}
+
+func keys(smaps map[string]int) []string {
+	var o []string
+	for k := range smaps {
+		o = append(o, k)
+	}
+	sort.Strings(o)
+	return o
+}

--- a/errdefs/grpc.go
+++ b/errdefs/grpc.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -61,7 +60,7 @@ func FromGRPC(err error) error {
 
 	var cls error // divide these into error classes, becomes the cause
 
-	switch grpc.Code(err) {
+	switch code(err) {
 	case codes.InvalidArgument:
 		cls = ErrInvalidArgument
 	case codes.AlreadyExists:
@@ -94,7 +93,7 @@ func FromGRPC(err error) error {
 // Effectively, we just remove the string of cls from the end of err if it
 // appears there.
 func rebaseMessage(cls error, err error) string {
-	desc := grpc.ErrorDesc(err)
+	desc := errDesc(err)
 	clss := cls.Error()
 	if desc == clss {
 		return ""
@@ -106,4 +105,18 @@ func rebaseMessage(cls error, err error) string {
 func isGRPCError(err error) bool {
 	_, ok := status.FromError(err)
 	return ok
+}
+
+func code(err error) codes.Code {
+	if s, ok := status.FromError(err); ok {
+		return s.Code()
+	}
+	return codes.Unknown
+}
+
+func errDesc(err error) string {
+	if s, ok := status.FromError(err); ok {
+		return s.Message()
+	}
+	return err.Error()
 }

--- a/linux/proc/deleted_state.go
+++ b/linux/proc/deleted_state.go
@@ -6,7 +6,7 @@ import (
 	"context"
 
 	"github.com/containerd/console"
-	shimapi "github.com/containerd/containerd/linux/shim/v1"
+	google_protobuf "github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
 )
 
@@ -21,11 +21,11 @@ func (s *deletedState) Resume(ctx context.Context) error {
 	return errors.Errorf("cannot resume a deleted process")
 }
 
-func (s *deletedState) Update(context context.Context, r *shimapi.UpdateTaskRequest) error {
+func (s *deletedState) Update(context context.Context, r *google_protobuf.Any) error {
 	return errors.Errorf("cannot update a deleted process")
 }
 
-func (s *deletedState) Checkpoint(ctx context.Context, r *shimapi.CheckpointTaskRequest) error {
+func (s *deletedState) Checkpoint(ctx context.Context, r *CheckpointConfig) error {
 	return errors.Errorf("cannot checkpoint a deleted process")
 }
 

--- a/linux/proc/deleted_state.go
+++ b/linux/proc/deleted_state.go
@@ -1,6 +1,6 @@
 // +build !windows
 
-package shim
+package proc
 
 import (
 	"context"

--- a/linux/proc/exec.go
+++ b/linux/proc/exec.go
@@ -4,7 +4,6 @@ package proc
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -16,8 +15,6 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/containerd/console"
-	"github.com/containerd/containerd/identifiers"
-	shimapi "github.com/containerd/containerd/linux/shim/v1"
 	"github.com/containerd/fifo"
 	runc "github.com/containerd/go-runc"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -44,35 +41,6 @@ type execProcess struct {
 
 	parent    *Init
 	waitBlock chan struct{}
-}
-
-// NewExec returns a new exec'd process
-func NewExec(context context.Context, path string, r *shimapi.ExecProcessRequest, parent *Init, id string) (Process, error) {
-	if err := identifiers.Validate(id); err != nil {
-		return nil, errors.Wrapf(err, "invalid exec id")
-	}
-	// process exec request
-	var spec specs.Process
-	if err := json.Unmarshal(r.Spec.Value, &spec); err != nil {
-		return nil, err
-	}
-	spec.Terminal = r.Terminal
-
-	e := &execProcess{
-		id:     id,
-		path:   path,
-		parent: parent,
-		spec:   spec,
-		stdio: Stdio{
-			Stdin:    r.Stdin,
-			Stdout:   r.Stdout,
-			Stderr:   r.Stderr,
-			Terminal: r.Terminal,
-		},
-		waitBlock: make(chan struct{}),
-	}
-	e.State = &execCreatedState{p: e}
-	return e, nil
 }
 
 func (e *execProcess) Wait() {

--- a/linux/proc/exec_state.go
+++ b/linux/proc/exec_state.go
@@ -1,6 +1,6 @@
 // +build !windows
 
-package shim
+package proc
 
 import (
 	"context"
@@ -16,11 +16,11 @@ type execCreatedState struct {
 func (s *execCreatedState) transition(name string) error {
 	switch name {
 	case "running":
-		s.p.processState = &execRunningState{p: s.p}
+		s.p.State = &execRunningState{p: s.p}
 	case "stopped":
-		s.p.processState = &execStoppedState{p: s.p}
+		s.p.State = &execStoppedState{p: s.p}
 	case "deleted":
-		s.p.processState = &deletedState{}
+		s.p.State = &deletedState{}
 	default:
 		return errors.Errorf("invalid state transition %q to %q", stateName(s), name)
 	}
@@ -77,7 +77,7 @@ type execRunningState struct {
 func (s *execRunningState) transition(name string) error {
 	switch name {
 	case "stopped":
-		s.p.processState = &execStoppedState{p: s.p}
+		s.p.State = &execStoppedState{p: s.p}
 	default:
 		return errors.Errorf("invalid state transition %q to %q", stateName(s), name)
 	}
@@ -130,7 +130,7 @@ type execStoppedState struct {
 func (s *execStoppedState) transition(name string) error {
 	switch name {
 	case "deleted":
-		s.p.processState = &deletedState{}
+		s.p.State = &deletedState{}
 	default:
 		return errors.Errorf("invalid state transition %q to %q", stateName(s), name)
 	}

--- a/linux/proc/init.go
+++ b/linux/proc/init.go
@@ -29,6 +29,7 @@ import (
 // InitPidFile name of the file that contains the init pid
 const InitPidFile = "init.pid"
 
+// Init represents an initial process for a container
 type Init struct {
 	wg sync.WaitGroup
 	initState
@@ -217,30 +218,36 @@ func New(context context.Context, path, workDir, runtimeRoot, namespace, criu st
 	return p, nil
 }
 
+// Wait for the process to exit
 func (p *Init) Wait() {
 	<-p.waitBlock
 }
 
+// ID of the process
 func (p *Init) ID() string {
 	return p.id
 }
 
+// Pid of the process
 func (p *Init) Pid() int {
 	return p.pid
 }
 
+// ExitStatus of the process
 func (p *Init) ExitStatus() int {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.status
 }
 
+// ExitedAt at time when the process exited
 func (p *Init) ExitedAt() time.Time {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.exited
 }
 
+// Status of the process
 func (p *Init) Status(ctx context.Context) (string, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -321,6 +328,7 @@ func (p *Init) kill(context context.Context, signal uint32, all bool) error {
 	return checkKillError(err)
 }
 
+// KillAll processes belonging to the init process
 func (p *Init) KillAll(context context.Context) error {
 	err := p.runtime.Kill(context, p.id, int(syscall.SIGKILL), &runc.KillOpts{
 		All: true,
@@ -328,6 +336,7 @@ func (p *Init) KillAll(context context.Context) error {
 	return p.runtimeError(err, "OCI runtime killall failed")
 }
 
+// Stdin of the process
 func (p *Init) Stdin() io.Closer {
 	return p.stdin
 }
@@ -404,6 +413,7 @@ func (p *Init) update(context context.Context, r *shimapi.UpdateTaskRequest) err
 	return p.runtime.Update(context, p.id, &resources)
 }
 
+// Stdio of the process
 func (p *Init) Stdio() Stdio {
 	return p.stdio
 }

--- a/linux/proc/init_state.go
+++ b/linux/proc/init_state.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/containerd/console"
 	"github.com/containerd/containerd/errdefs"
-	shimapi "github.com/containerd/containerd/linux/shim/v1"
 	"github.com/containerd/fifo"
 	runc "github.com/containerd/go-runc"
+	google_protobuf "github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
 )
 
@@ -20,8 +20,8 @@ type initState interface {
 
 	Pause(context.Context) error
 	Resume(context.Context) error
-	Update(context.Context, *shimapi.UpdateTaskRequest) error
-	Checkpoint(context.Context, *shimapi.CheckpointTaskRequest) error
+	Update(context.Context, *google_protobuf.Any) error
+	Checkpoint(context.Context, *CheckpointConfig) error
 }
 
 type createdState struct {
@@ -56,14 +56,14 @@ func (s *createdState) Resume(ctx context.Context) error {
 	return errors.Errorf("cannot resume task in created state")
 }
 
-func (s *createdState) Update(context context.Context, r *shimapi.UpdateTaskRequest) error {
+func (s *createdState) Update(context context.Context, r *google_protobuf.Any) error {
 	s.p.mu.Lock()
 	defer s.p.mu.Unlock()
 
 	return s.p.update(context, r)
 }
 
-func (s *createdState) Checkpoint(context context.Context, r *shimapi.CheckpointTaskRequest) error {
+func (s *createdState) Checkpoint(context context.Context, r *CheckpointConfig) error {
 	s.p.mu.Lock()
 	defer s.p.mu.Unlock()
 
@@ -146,14 +146,14 @@ func (s *createdCheckpointState) Resume(ctx context.Context) error {
 	return errors.Errorf("cannot resume task in created state")
 }
 
-func (s *createdCheckpointState) Update(context context.Context, r *shimapi.UpdateTaskRequest) error {
+func (s *createdCheckpointState) Update(context context.Context, r *google_protobuf.Any) error {
 	s.p.mu.Lock()
 	defer s.p.mu.Unlock()
 
 	return s.p.update(context, r)
 }
 
-func (s *createdCheckpointState) Checkpoint(context context.Context, r *shimapi.CheckpointTaskRequest) error {
+func (s *createdCheckpointState) Checkpoint(context context.Context, r *CheckpointConfig) error {
 	s.p.mu.Lock()
 	defer s.p.mu.Unlock()
 
@@ -259,14 +259,14 @@ func (s *runningState) Resume(ctx context.Context) error {
 	return errors.Errorf("cannot resume a running process")
 }
 
-func (s *runningState) Update(context context.Context, r *shimapi.UpdateTaskRequest) error {
+func (s *runningState) Update(context context.Context, r *google_protobuf.Any) error {
 	s.p.mu.Lock()
 	defer s.p.mu.Unlock()
 
 	return s.p.update(context, r)
 }
 
-func (s *runningState) Checkpoint(ctx context.Context, r *shimapi.CheckpointTaskRequest) error {
+func (s *runningState) Checkpoint(ctx context.Context, r *CheckpointConfig) error {
 	s.p.mu.Lock()
 	defer s.p.mu.Unlock()
 
@@ -345,14 +345,14 @@ func (s *pausedState) Resume(ctx context.Context) error {
 	return s.transition("running")
 }
 
-func (s *pausedState) Update(context context.Context, r *shimapi.UpdateTaskRequest) error {
+func (s *pausedState) Update(context context.Context, r *google_protobuf.Any) error {
 	s.p.mu.Lock()
 	defer s.p.mu.Unlock()
 
 	return s.p.update(context, r)
 }
 
-func (s *pausedState) Checkpoint(ctx context.Context, r *shimapi.CheckpointTaskRequest) error {
+func (s *pausedState) Checkpoint(ctx context.Context, r *CheckpointConfig) error {
 	s.p.mu.Lock()
 	defer s.p.mu.Unlock()
 
@@ -427,14 +427,14 @@ func (s *stoppedState) Resume(ctx context.Context) error {
 	return errors.Errorf("cannot resume a stopped container")
 }
 
-func (s *stoppedState) Update(context context.Context, r *shimapi.UpdateTaskRequest) error {
+func (s *stoppedState) Update(context context.Context, r *google_protobuf.Any) error {
 	s.p.mu.Lock()
 	defer s.p.mu.Unlock()
 
 	return errors.Errorf("cannot update a stopped container")
 }
 
-func (s *stoppedState) Checkpoint(ctx context.Context, r *shimapi.CheckpointTaskRequest) error {
+func (s *stoppedState) Checkpoint(ctx context.Context, r *CheckpointConfig) error {
 	s.p.mu.Lock()
 	defer s.p.mu.Unlock()
 

--- a/linux/proc/io.go
+++ b/linux/proc/io.go
@@ -1,6 +1,6 @@
 // +build !windows
 
-package shim
+package proc
 
 import (
 	"context"

--- a/linux/proc/types.go
+++ b/linux/proc/types.go
@@ -1,0 +1,37 @@
+package proc
+
+import (
+	containerd_types "github.com/containerd/containerd/api/types"
+	google_protobuf "github.com/gogo/protobuf/types"
+)
+
+// CreateConfig hold task creation configuration
+type CreateConfig struct {
+	ID               string
+	Bundle           string
+	Runtime          string
+	Rootfs           []*containerd_types.Mount
+	Terminal         bool
+	Stdin            string
+	Stdout           string
+	Stderr           string
+	Checkpoint       string
+	ParentCheckpoint string
+	Options          *google_protobuf.Any
+}
+
+// ExecConfig holds exec creation configuration
+type ExecConfig struct {
+	ID       string
+	Terminal bool
+	Stdin    string
+	Stdout   string
+	Stderr   string
+	Spec     *google_protobuf.Any
+}
+
+// CheckpointConfig holds task checkpoint configuration
+type CheckpointConfig struct {
+	Path    string
+	Options *google_protobuf.Any
+}

--- a/linux/proc/utils.go
+++ b/linux/proc/utils.go
@@ -1,6 +1,6 @@
 // +build !windows
 
-package shim
+package proc
 
 import (
 	"encoding/json"

--- a/linux/proc/utils.go
+++ b/linux/proc/utils.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/errdefs"
-	shimapi "github.com/containerd/containerd/linux/shim/v1"
 	runc "github.com/containerd/go-runc"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
@@ -81,6 +80,6 @@ func checkKillError(err error) error {
 	return errors.Wrapf(err, "unknown error after kill")
 }
 
-func hasNoIO(r *shimapi.CreateTaskRequest) bool {
+func hasNoIO(r *CreateConfig) bool {
 	return r.Stdin == "" && r.Stdout == "" && r.Stderr == ""
 }

--- a/linux/process.go
+++ b/linux/process.go
@@ -5,6 +5,7 @@ package linux
 import (
 	"context"
 
+	eventsapi "github.com/containerd/containerd/api/services/events/v1"
 	"github.com/containerd/containerd/api/types/task"
 	"github.com/containerd/containerd/errdefs"
 	shim "github.com/containerd/containerd/linux/shim/v1"
@@ -96,12 +97,17 @@ func (p *Process) CloseIO(ctx context.Context) error {
 
 // Start the process
 func (p *Process) Start(ctx context.Context) error {
-	_, err := p.t.shim.Start(ctx, &shim.StartRequest{
+	r, err := p.t.shim.Start(ctx, &shim.StartRequest{
 		ID: p.id,
 	})
 	if err != nil {
 		return errdefs.FromGRPC(err)
 	}
+	p.t.events.Publish(ctx, runtime.TaskExecStartedEventTopic, &eventsapi.TaskExecStarted{
+		ContainerID: p.t.id,
+		Pid:         r.Pid,
+		ExecID:      p.id,
+	})
 	return nil
 }
 

--- a/linux/runtime.go
+++ b/linux/runtime.go
@@ -268,7 +268,8 @@ func (r *Runtime) Create(ctx context.Context, id string, opts runtime.CreateOpts
 	if err != nil {
 		return nil, errdefs.FromGRPC(err)
 	}
-	t, err := newTask(id, namespace, int(cr.Pid), s, r.monitor, r.events, proc.NewRunc(ropts.RuntimeRoot, sopts.Bundle, namespace, rt, ropts.CriuPath, ropts.SystemdCgroup))
+	t, err := newTask(id, namespace, int(cr.Pid), s, r.monitor, r.events,
+		proc.NewRunc(ropts.RuntimeRoot, sopts.Bundle, namespace, rt, ropts.CriuPath, ropts.SystemdCgroup))
 	if err != nil {
 		return nil, err
 	}
@@ -396,6 +397,7 @@ func (r *Runtime) loadTasks(ctx context.Context, ns string) ([]*Task, error) {
 			filepath.Join(r.state, ns, id),
 			filepath.Join(r.root, ns, id),
 		)
+		ctx = namespaces.WithNamespace(ctx, ns)
 		pid, _ := runc.ReadPidFile(filepath.Join(bundle.path, proc.InitPidFile))
 		s, err := bundle.NewShimClient(ctx, ns, ShimConnect(), nil)
 		if err != nil {
@@ -417,7 +419,8 @@ func (r *Runtime) loadTasks(ctx context.Context, ns string) ([]*Task, error) {
 			continue
 		}
 
-		t, err := newTask(id, ns, pid, s, r.monitor, r.events, proc.NewRunc(ropts.RuntimeRoot, bundle.path, ns, ropts.Runtime, ropts.CriuPath, ropts.SystemdCgroup))
+		t, err := newTask(id, ns, pid, s, r.monitor, r.events,
+			proc.NewRunc(ropts.RuntimeRoot, bundle.path, ns, ropts.Runtime, ropts.CriuPath, ropts.SystemdCgroup))
 		if err != nil {
 			log.G(ctx).WithError(err).Error("loading task type")
 			continue
@@ -543,5 +546,5 @@ func (r *Runtime) getRuncOptions(ctx context.Context, id string) (*runctypes.Run
 
 		return ropts, nil
 	}
-	return &runcopts.RuncOptions{}, nil
+	return &runctypes.RuncOptions{}, nil
 }

--- a/linux/runtime.go
+++ b/linux/runtime.go
@@ -17,8 +17,8 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/events/exchange"
 	"github.com/containerd/containerd/identifiers"
+	"github.com/containerd/containerd/linux/proc"
 	"github.com/containerd/containerd/linux/runctypes"
-	client "github.com/containerd/containerd/linux/shim"
 	shim "github.com/containerd/containerd/linux/shim/v1"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/metadata"
@@ -376,7 +376,7 @@ func (r *Runtime) loadTasks(ctx context.Context, ns string) ([]*Task, error) {
 			filepath.Join(r.state, ns, id),
 			filepath.Join(r.root, ns, id),
 		)
-		pid, _ := runc.ReadPidFile(filepath.Join(bundle.path, client.InitPidFile))
+		pid, _ := runc.ReadPidFile(filepath.Join(bundle.path, proc.InitPidFile))
 		s, err := bundle.NewShimClient(ctx, ns, ShimConnect(), nil)
 		if err != nil {
 			log.G(ctx).WithError(err).WithFields(logrus.Fields{
@@ -474,7 +474,7 @@ func (r *Runtime) getRuntime(ctx context.Context, ns, id string) (*runc.Runc, er
 
 	var (
 		cmd  = r.config.Runtime
-		root = client.RuncRoot
+		root = proc.RuncRoot
 	)
 	if ropts != nil {
 		if ropts.Runtime != "" {

--- a/linux/shim/service.go
+++ b/linux/shim/service.go
@@ -19,7 +19,6 @@ import (
 	"github.com/containerd/containerd/linux/runctypes"
 	shimapi "github.com/containerd/containerd/linux/shim/v1"
 	"github.com/containerd/containerd/log"
-	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/reaper"
 	"github.com/containerd/containerd/runtime"
 	runc "github.com/containerd/go-runc"
@@ -47,15 +46,15 @@ func NewService(config Config, publisher events.Publisher) (*Service, error) {
 	if config.Namespace == "" {
 		return nil, fmt.Errorf("shim namespace cannot be empty")
 	}
-	context := namespaces.WithNamespace(context.Background(), config.Namespace)
-	context = log.WithLogger(context, logrus.WithFields(logrus.Fields{
+	ctx := context.Background()
+	ctx = log.WithLogger(ctx, logrus.WithFields(logrus.Fields{
 		"namespace": config.Namespace,
 		"path":      config.Path,
 		"pid":       os.Getpid(),
 	}))
 	s := &Service{
 		config:    config,
-		context:   context,
+		context:   ctx,
 		processes: make(map[string]proc.Process),
 		events:    make(chan interface{}, 128),
 		ec:        reaper.Default.Subscribe(),

--- a/linux/shim/service.go
+++ b/linux/shim/service.go
@@ -218,7 +218,7 @@ func (s *Service) Exec(ctx context.Context, r *shimapi.ExecProcessRequest) (*goo
 		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
 	}
 
-	process, err := proc.NewExec(ctx, s.config.Path, r, p.(*proc.Init), r.ID)
+	process, err := p.(*proc.Init).Exec(ctx, s.config.Path, r)
 	if err != nil {
 		return nil, errdefs.ToGRPC(err)
 	}

--- a/linux/shim/service.go
+++ b/linux/shim/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/containerd/containerd/api/types/task"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/events"
+	"github.com/containerd/containerd/linux/proc"
 	"github.com/containerd/containerd/linux/runctypes"
 	shimapi "github.com/containerd/containerd/linux/shim/v1"
 	"github.com/containerd/containerd/log"
@@ -30,9 +31,6 @@ import (
 )
 
 var empty = &google_protobuf.Empty{}
-
-// RuncRoot is the path to the root runc state directory
-const RuncRoot = "/run/containerd/runc"
 
 // Config contains shim specific configuration
 type Config struct {
@@ -58,7 +56,7 @@ func NewService(config Config, publisher events.Publisher) (*Service, error) {
 	s := &Service{
 		config:    config,
 		context:   context,
-		processes: make(map[string]process),
+		processes: make(map[string]proc.Process),
 		events:    make(chan interface{}, 128),
 		ec:        reaper.Default.Subscribe(),
 	}
@@ -70,23 +68,15 @@ func NewService(config Config, publisher events.Publisher) (*Service, error) {
 	return s, nil
 }
 
-// platform handles platform-specific behavior that may differs across
-// platform implementations
-type platform interface {
-	copyConsole(ctx context.Context, console console.Console, stdin, stdout, stderr string, wg, cwg *sync.WaitGroup) (console.Console, error)
-	shutdownConsole(ctx context.Context, console console.Console) error
-	close() error
-}
-
 // Service is the shim implementation of a remote shim over GRPC
 type Service struct {
 	mu sync.Mutex
 
 	config    Config
 	context   context.Context
-	processes map[string]process
+	processes map[string]proc.Process
 	events    chan interface{}
-	platform  platform
+	platform  proc.Platform
 	ec        chan runc.Exit
 
 	// Filled by Create()
@@ -98,7 +88,17 @@ type Service struct {
 func (s *Service) Create(ctx context.Context, r *shimapi.CreateTaskRequest) (*shimapi.CreateTaskResponse, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	process, err := s.newInitProcess(ctx, r)
+	process, err := proc.New(
+		ctx,
+		s.config.Path,
+		s.config.WorkDir,
+		s.config.RuntimeRoot,
+		s.config.Namespace,
+		s.config.Criu,
+		s.config.SystemdCgroup,
+		s.platform,
+		r,
+	)
 	if err != nil {
 		return nil, errdefs.ToGRPC(err)
 	}
@@ -168,7 +168,7 @@ func (s *Service) Delete(ctx context.Context, r *google_protobuf.Empty) (*shimap
 		return nil, err
 	}
 	delete(s.processes, s.id)
-	s.platform.close()
+	s.platform.Close()
 	s.events <- &eventsapi.TaskDelete{
 		ContainerID: s.id,
 		ExitStatus:  uint32(p.ExitStatus()),
@@ -218,7 +218,7 @@ func (s *Service) Exec(ctx context.Context, r *shimapi.ExecProcessRequest) (*goo
 		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
 	}
 
-	process, err := newExecProcess(ctx, s.config.Path, r, p.(*initProcess), r.ID)
+	process, err := proc.NewExec(ctx, s.config.Path, r, p.(*proc.Init), r.ID)
 	if err != nil {
 		return nil, errdefs.ToGRPC(err)
 	}
@@ -283,10 +283,10 @@ func (s *Service) State(ctx context.Context, r *shimapi.StateRequest) (*shimapi.
 		Bundle:     s.bundle,
 		Pid:        uint32(p.Pid()),
 		Status:     status,
-		Stdin:      sio.stdin,
-		Stdout:     sio.stdout,
-		Stderr:     sio.stderr,
-		Terminal:   sio.terminal,
+		Stdin:      sio.Stdin,
+		Stdout:     sio.Stdout,
+		Stderr:     sio.Stderr,
+		Terminal:   sio.Terminal,
 		ExitStatus: uint32(p.ExitStatus()),
 		ExitedAt:   p.ExitedAt(),
 	}, nil
@@ -300,7 +300,7 @@ func (s *Service) Pause(ctx context.Context, r *google_protobuf.Empty) (*google_
 	if p == nil {
 		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
 	}
-	if err := p.(*initProcess).Pause(ctx); err != nil {
+	if err := p.(*proc.Init).Pause(ctx); err != nil {
 		return nil, err
 	}
 	s.events <- &eventsapi.TaskPaused{
@@ -317,7 +317,7 @@ func (s *Service) Resume(ctx context.Context, r *google_protobuf.Empty) (*google
 	if p == nil {
 		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
 	}
-	if err := p.(*initProcess).Resume(ctx); err != nil {
+	if err := p.(*proc.Init).Resume(ctx); err != nil {
 		return nil, err
 	}
 	s.events <- &eventsapi.TaskResumed{
@@ -406,7 +406,7 @@ func (s *Service) Checkpoint(ctx context.Context, r *shimapi.CheckpointTaskReque
 	if p == nil {
 		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
 	}
-	if err := p.(*initProcess).Checkpoint(ctx, r); err != nil {
+	if err := p.(*proc.Init).Checkpoint(ctx, r); err != nil {
 		return nil, errdefs.ToGRPC(err)
 	}
 	s.events <- &eventsapi.TaskCheckpointed{
@@ -430,7 +430,7 @@ func (s *Service) Update(ctx context.Context, r *shimapi.UpdateTaskRequest) (*go
 	if p == nil {
 		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
 	}
-	if err := p.(*initProcess).Update(ctx, r); err != nil {
+	if err := p.(*proc.Init).Update(ctx, r); err != nil {
 		return nil, errdefs.ToGRPC(err)
 	}
 	return empty, nil
@@ -463,9 +463,9 @@ func (s *Service) checkProcesses(e runc.Exit) {
 	defer s.mu.Unlock()
 	for _, p := range s.processes {
 		if p.Pid() == e.Pid {
-			if ip, ok := p.(*initProcess); ok {
+			if ip, ok := p.(*proc.Init); ok {
 				// Ensure all children are killed
-				if err := ip.killAll(s.context); err != nil {
+				if err := ip.KillAll(s.context); err != nil {
 					log.G(s.context).WithError(err).WithField("id", ip.ID()).
 						Error("failed to kill init's children")
 				}
@@ -491,7 +491,7 @@ func (s *Service) getContainerPids(ctx context.Context, id string) ([]uint32, er
 		return nil, errors.Wrapf(errdefs.ErrFailedPrecondition, "container must be created")
 	}
 
-	ps, err := p.(*initProcess).runtime.Ps(ctx, id)
+	ps, err := p.(*proc.Init).Runtime().Ps(ctx, id)
 	if err != nil {
 		return nil, err
 	}

--- a/linux/shim/service.go
+++ b/linux/shim/service.go
@@ -19,6 +19,7 @@ import (
 	"github.com/containerd/containerd/linux/runctypes"
 	shimapi "github.com/containerd/containerd/linux/shim/v1"
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/reaper"
 	"github.com/containerd/containerd/runtime"
 	runc "github.com/containerd/go-runc"
@@ -46,7 +47,7 @@ func NewService(config Config, publisher events.Publisher) (*Service, error) {
 	if config.Namespace == "" {
 		return nil, fmt.Errorf("shim namespace cannot be empty")
 	}
-	ctx := context.Background()
+	ctx := namespaces.WithNamespace(context.Background(), config.Namespace)
 	ctx = log.WithLogger(ctx, logrus.WithFields(logrus.Fields{
 		"namespace": config.Namespace,
 		"path":      config.Path,

--- a/linux/shim/service_linux.go
+++ b/linux/shim/service_linux.go
@@ -1,6 +1,7 @@
 package shim
 
 import (
+	"context"
 	"io"
 	"sync"
 	"syscall"
@@ -8,14 +9,13 @@ import (
 	"github.com/containerd/console"
 	"github.com/containerd/fifo"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 type linuxPlatform struct {
 	epoller *console.Epoller
 }
 
-func (p *linuxPlatform) copyConsole(ctx context.Context, console console.Console, stdin, stdout, stderr string, wg, cwg *sync.WaitGroup) (console.Console, error) {
+func (p *linuxPlatform) CopyConsole(ctx context.Context, console console.Console, stdin, stdout, stderr string, wg, cwg *sync.WaitGroup) (console.Console, error) {
 	if p.epoller == nil {
 		return nil, errors.New("uninitialized epoller")
 	}
@@ -58,7 +58,7 @@ func (p *linuxPlatform) copyConsole(ctx context.Context, console console.Console
 	return epollConsole, nil
 }
 
-func (p *linuxPlatform) shutdownConsole(ctx context.Context, cons console.Console) error {
+func (p *linuxPlatform) ShutdownConsole(ctx context.Context, cons console.Console) error {
 	if p.epoller == nil {
 		return errors.New("uninitialized epoller")
 	}
@@ -69,7 +69,7 @@ func (p *linuxPlatform) shutdownConsole(ctx context.Context, cons console.Consol
 	return epollConsole.Shutdown(p.epoller.CloseConsole)
 }
 
-func (p *linuxPlatform) close() error {
+func (p *linuxPlatform) Close() error {
 	return p.epoller.Close()
 }
 

--- a/linux/shim/service_unix.go
+++ b/linux/shim/service_unix.go
@@ -15,7 +15,7 @@ import (
 type unixPlatform struct {
 }
 
-func (p *unixPlatform) copyConsole(ctx context.Context, console console.Console, stdin, stdout, stderr string, wg, cwg *sync.WaitGroup) (console.Console, error) {
+func (p *unixPlatform) CopyConsole(ctx context.Context, console console.Console, stdin, stdout, stderr string, wg, cwg *sync.WaitGroup) (console.Console, error) {
 	if stdin != "" {
 		in, err := fifo.OpenFifo(ctx, stdin, syscall.O_RDONLY, 0)
 		if err != nil {
@@ -48,11 +48,11 @@ func (p *unixPlatform) copyConsole(ctx context.Context, console console.Console,
 	return console, nil
 }
 
-func (p *unixPlatform) shutdownConsole(ctx context.Context, cons console.Console) error {
+func (p *unixPlatform) ShutdownConsole(ctx context.Context, cons console.Console) error {
 	return nil
 }
 
-func (p *unixPlatform) close() error {
+func (p *unixPlatform) Close() error {
 	return nil
 }
 

--- a/linux/shim/service_unix.go
+++ b/linux/shim/service_unix.go
@@ -3,13 +3,13 @@
 package shim
 
 import (
+	"context"
 	"io"
 	"sync"
 	"syscall"
 
 	"github.com/containerd/console"
 	"github.com/containerd/fifo"
-	"golang.org/x/net/context"
 )
 
 type unixPlatform struct {

--- a/linux/task.go
+++ b/linux/task.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containerd/containerd/api/types/task"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/events/exchange"
+	"github.com/containerd/containerd/identifiers"
 	"github.com/containerd/containerd/linux/shim/client"
 	shim "github.com/containerd/containerd/linux/shim/v1"
 	"github.com/containerd/containerd/runtime"
@@ -167,6 +168,9 @@ func (t *Task) Kill(ctx context.Context, signal uint32, all bool) error {
 
 // Exec creates a new process inside the task
 func (t *Task) Exec(ctx context.Context, id string, opts runtime.ExecOpts) (runtime.Process, error) {
+	if err := identifiers.Validate(id); err != nil {
+		return nil, errors.Wrapf(err, "invalid exec id")
+	}
 	request := &shim.ExecProcessRequest{
 		ID:       id,
 		Stdin:    opts.IO.Stdin,

--- a/linux/task.go
+++ b/linux/task.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containerd/containerd/linux/shim/client"
 	shim "github.com/containerd/containerd/linux/shim/v1"
 	"github.com/containerd/containerd/runtime"
+	runc "github.com/containerd/go-runc"
 	"github.com/gogo/protobuf/types"
 )
 
@@ -29,9 +30,10 @@ type Task struct {
 	cg        cgroups.Cgroup
 	monitor   runtime.TaskMonitor
 	events    *exchange.Exchange
+	runtime   *runc.Runc
 }
 
-func newTask(id, namespace string, pid int, shim *client.Client, monitor runtime.TaskMonitor, events *exchange.Exchange) (*Task, error) {
+func newTask(id, namespace string, pid int, shim *client.Client, monitor runtime.TaskMonitor, events *exchange.Exchange, runtime *runc.Runc) (*Task, error) {
 	var (
 		err error
 		cg  cgroups.Cgroup
@@ -50,6 +52,7 @@ func newTask(id, namespace string, pid int, shim *client.Client, monitor runtime
 		cg:        cg,
 		monitor:   monitor,
 		events:    events,
+		runtime:   runtime,
 	}, nil
 }
 

--- a/reaper/reaper.go
+++ b/reaper/reaper.go
@@ -15,7 +15,7 @@ import (
 // ErrNoSuchProcess is returned when the process no longer exists
 var ErrNoSuchProcess = errors.New("no such process")
 
-const bufferSize = 2048
+const bufferSize = 1024
 
 // Reap should be called when the process receives an SIGCHLD.  Reap will reap
 // all exited processes and close their wait channels


### PR DESCRIPTION
This is for on going work of shrinking the shim down because grpc is adding a lot of bloat in terms of binary size and memory usage. 