### PR TITLE
Validate that root and state paths are different

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -39,12 +39,15 @@ import (
 
 // New creates and initializes a new containerd server
 func New(ctx context.Context, config *Config) (*Server, error) {
-	if config.Root == "" {
+	switch {
+	case config.Root == "":
 		return nil, errors.New("root must be specified")
-	}
-	if config.State == "" {
+	case config.State == "":
 		return nil, errors.New("state must be specified")
+	case config.Root == config.State:
+		return nil, errors.New("root and state must be different paths")
 	}
+
 	if err := os.MkdirAll(config.Root, 0711); err != nil {
 		return nil, err
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,17 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+)
+
+func TestNewErrorsWithSamePathForRootAndState(t *testing.T) {
+	path := "/tmp/path/for/testing"
+	_, err := New(context.Background(), &Config{
+		Root:  path,
+		State: path,
+	})
+	assert.EqualError(t, err, "root and state must be different paths")
+}


### PR DESCRIPTION
Using the same path for both results in confusing errors when `runtime.newBundle()`
attempts to create the directories for the Task.

The reported error is:

```
mkdir /tmp/dockerdev/containerd/daemon/io.containerd.runtime.v1.linux/moby/898d8ece786c8f3ed59d77a6982afd047377d24c43b12ebdbd47d56638c13f89: file exists: already exists
```
which is not helpful, because that path does not actually exist. It is removed by `newBundle()` on error.

It seems reasonable to require that these paths be different, so instead of fixing the `mkdir` I've added validation that the paths are different.