### PR TITLE
ctr: update task kill to take exec-id

### DIFF
--- a/process.go
+++ b/process.go
@@ -104,7 +104,7 @@ func (p *process) Start(ctx context.Context) error {
 func (p *process) Kill(ctx context.Context, s syscall.Signal, opts ...KillOpts) error {
 	var i KillInfo
 	for _, o := range opts {
-		if err := o(ctx, p, &i); err != nil {
+		if err := o(ctx, &i); err != nil {
 			return err
 		}
 	}

--- a/task.go
+++ b/task.go
@@ -175,13 +175,14 @@ func (t *task) Start(ctx context.Context) error {
 func (t *task) Kill(ctx context.Context, s syscall.Signal, opts ...KillOpts) error {
 	var i KillInfo
 	for _, o := range opts {
-		if err := o(ctx, t, &i); err != nil {
+		if err := o(ctx, &i); err != nil {
 			return err
 		}
 	}
 	_, err := t.client.TaskService().Kill(ctx, &tasks.KillRequest{
 		Signal:      uint32(s),
 		ContainerID: t.id,
+		ExecID:      i.ExecID,
 		All:         i.All,
 	})
 	if err != nil {

--- a/task_opts.go
+++ b/task_opts.go
@@ -65,13 +65,23 @@ type KillInfo struct {
 	// All kills all processes inside the task
 	// only valid on tasks, ignored on processes
 	All bool
+	// ExecID is the ID of a process to kill
+	ExecID string
 }
 
 // KillOpts allows options to be set for the killing of a process
-type KillOpts func(context.Context, Process, *KillInfo) error
+type KillOpts func(context.Context, *KillInfo) error
 
 // WithKillAll kills all processes for a task
-func WithKillAll(ctx context.Context, p Process, i *KillInfo) error {
+func WithKillAll(ctx context.Context, i *KillInfo) error {
 	i.All = true
 	return nil
+}
+
+// WithKillExecID specifies the process ID
+func WithKillExecID(execID string) KillOpts {
+	return func(ctx context.Context, i *KillInfo) error {
+		i.ExecID = execID
+		return nil
+	}
 }


### PR DESCRIPTION
Before, `ctr task kill` took the flag `pid` which was never used. The `task.Kill` request cares about the `exec-id`.

Note: in `task.go` and `process.go`, `KillRequest` never utilized `KillInfo`'s `Process` so I removed it

Signed-off-by: Jess Valarezo <valarezo.jessica@gmail.com>