### PR TITLE
lint: fix go vet failure

### DIFF
--- a/snapshot/testsuite/testsuite.go
+++ b/snapshot/testsuite/testsuite.go
@@ -600,7 +600,7 @@ func checkUpdate(ctx context.Context, t *testing.T, snapshotter snapshot.Snapsho
 			continue
 		}
 		if st.Kind != tc.kind {
-			t.Errorf("(%s) unexpected kind %s, expected %s", tc.name, st.Kind, tc.kind)
+			t.Errorf("(%s) unexpected kind %s, expected %s", tc.name, st.Kind.String(), tc.kind.String())
 			continue
 		}
 		if st.Parent != tc.parent {
@@ -636,7 +636,7 @@ func checkUpdate(ctx context.Context, t *testing.T, snapshotter snapshot.Snapsho
 			continue
 		}
 		if st.Kind != tc.kind {
-			t.Errorf("(%s) unexpected kind %s, expected %s", tc.name, st.Kind, tc.kind)
+			t.Errorf("(%s) unexpected kind %s, expected %s", tc.name, st.Kind.String(), tc.kind.String())
 			continue
 		}
 		if st.Parent != tc.parent {


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>


```
$ make check                                                                     
🇩 proto-fmt                                                                                                                             
🇩 check                                                                                                                                 
gometalinter --config .gometalinter.json ./...                                                                                          
snapshot/testsuite/testsuite.go:603::error: arg st.Kind for printf verb %s of wrong type: github.com/containerd/containerd/snapshot.Kind
 (vet)                                                                                                                                  
snapshot/testsuite/testsuite.go:639::error: arg st.Kind for printf verb %s of wrong type: github.com/containerd/containerd/snapshot.Kind
 (vet)                                                                                                                                  
Makefile:64: recipe for target 'check' failed                                                                                           
make: *** [check] Error 1                          
```

(go: 1.9.2 linux/amd64)

Not sure why it had not been caught in CI
