### PR TITLE
snapshot: fix specification of Commit

### DIFF
--- a/snapshot/snapshotter.go
+++ b/snapshot/snapshotter.go
@@ -280,9 +280,7 @@ type Snapshotter interface {
 	// A committed snapshot will be created under name with the parent of the
 	// active snapshot.
 	//
-	// Commit may be called multiple times on the same key. Snapshots created
-	// in this manner will all reference the parent used to start the
-	// transaction.
+	// After commit, the snapshot identified by key is removed.
 	Commit(ctx context.Context, name, key string, opts ...Opt) error
 
 	// Remove the committed or active snapshot by the provided key.

--- a/snapshot/testsuite/testsuite.go
+++ b/snapshot/testsuite/testsuite.go
@@ -143,6 +143,11 @@ func checkSnapshotterBasic(ctx context.Context, t *testing.T, snapshotter snapsh
 	assert.Equal(t, "", si.Parent)
 	assert.Equal(t, snapshot.KindCommitted, si.Kind)
 
+	_, err = snapshotter.Stat(ctx, preparing)
+	if err == nil {
+		t.Fatalf("%s should no longer be available after Commit", preparing)
+	}
+
 	next := filepath.Join(work, "nextlayer")
 	if err := os.MkdirAll(next, 0777); err != nil {
 		t.Fatalf("failure reason: %+v", err)
@@ -185,6 +190,11 @@ func checkSnapshotterBasic(ctx context.Context, t *testing.T, snapshotter snapsh
 
 	assert.Equal(t, committed, si2.Parent)
 	assert.Equal(t, snapshot.KindCommitted, si2.Kind)
+
+	_, err = snapshotter.Stat(ctx, next)
+	if err == nil {
+		t.Fatalf("%s should no longer be available after Commit", next)
+	}
 
 	expected := map[string]snapshot.Info{
 		si.Name:  si,


### PR DESCRIPTION
The default implementations remove the key after Commit.
However, the specification had required implementations not to remove
the key.

ref: https://github.com/containerd/containerd/blob/f9933e9f96b342c4a8865482bd66b0a6f4bec348/snapshot/storage/bolt.go#L317-L324

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>