### PR TITLE
Remove duplicate integration target

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,7 +31,8 @@ test_script:
   # - GIT_CHECK_EXCLUDE="./vendor" TRAVIS_COMMIT_RANGE="${TRAVIS_COMMIT_RANGE/.../..}" C:\MinGW\bin\mingw32-make.exe dco
   - bash.exe -lc "export PATH=/c/tools/mingw64/bin:/c/gopath/src/github.com/containerd/containerd/bin:$PATH ; mingw32-make.exe coverage root-coverage"
   - bash.exe -elc "export PATH=/c/tools/mingw64/bin:/c/gopath/src/github.com/containerd/containerd/bin:$PATH ; mingw32-make.exe integration"
-  - bash.exe -elc "export PATH=/c/tools/mingw64/bin:/c/gopath/src/github.com/containerd/containerd/bin:$PATH ; mingw32-make.exe integration-parallel"
+  # Run the integration suite a second time. See discussion in github.com/containerd/containerd/pull/1759
+  - bash.exe -elc "export PATH=/c/tools/mingw64/bin:/c/gopath/src/github.com/containerd/containerd/bin:$PATH; TESTFLAGS_PARALLEL=1 mingw32-make.exe integration"
 
 on_success:
   codecov --flag windows -f coverage.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /bin/
-**/coverage.txt
-**/coverage.out
+coverage.txt
+profile.out
 containerd.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,8 @@ script:
   - if [ "$GOOS" = "linux" ]; then make coverage ; fi
   - if [ "$GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH make root-coverage ; fi
   - if [ "$GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH make integration ; fi
-  - if [ "$GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH make integration-parallel ; fi
+  # Run the integration suite a second time. See discussion in github.com/containerd/containerd/pull/1759
+  - if [ "$GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH TESTFLAGS_PARALLEL=1 make integration ; fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash) -F linux

--- a/Makefile
+++ b/Makefile
@@ -125,10 +125,6 @@ root-test: ## run tests, except integration tests
 
 integration: ## run integration tests
 	@echo "$(WHALE) $@"
-	@go test ${TESTFLAGS} -test.root -parallel 1
-
-integration-parallel: ## run integration tests
-	@echo "$(WHALE) $@"
 	@go test ${TESTFLAGS} -test.root -parallel ${TESTFLAGS_PARALLEL}
 
 benchmark: ## run benchmarks tests
@@ -194,10 +190,6 @@ root-coverage: ## generate coverage profiles for unit tests that require root
 			rm profile.out; \
 		fi; \
 	done )
-
-coverage-integration: ## generate coverprofiles from the integration tests
-	@echo "$(WHALE) $@"
-	go test ${TESTFLAGS} -test.short -coverprofile="../../../${INTEGRATION_PACKAGE}/coverage.txt" -covermode=atomic ${INTEGRATION_PACKAGE} -test.root
 
 vendor:
 	@echo "$(WHALE) $@"


### PR DESCRIPTION
Related to #1756

The integration test suite was being run twice. The behaviour of `parallel=1` can be accomplished with `TESTFLAGS_PARALLEL=1` without needing a second target.

Is there any reason to run this twice in CI?

Also cleanup `.gitignore` and move the installation of some dependencies into the Makefile so that they can be installed in other environments (like a local dev container).