### PR TITLE
Add support for removing leases on resource removal

### DIFF
--- a/metadata/content.go
+++ b/metadata/content.go
@@ -184,6 +184,9 @@ func (cs *contentStore) Delete(ctx context.Context, dgst digest.Digest) error {
 		if err := getBlobsBucket(tx, ns).DeleteBucket([]byte(dgst.String())); err != nil {
 			return err
 		}
+		if err := removeContentLease(ctx, tx, dgst); err != nil {
+			return err
+		}
 
 		// Mark content store as dirty for triggering garbage collection
 		cs.db.dirtyL.Lock()

--- a/metadata/leases.go
+++ b/metadata/leases.go
@@ -155,7 +155,7 @@ func addSnapshotLease(ctx context.Context, tx *bolt.Tx, snapshotter, key string)
 
 	namespace, ok := namespaces.Namespace(ctx)
 	if !ok {
-		panic("namespace must already be required")
+		panic("namespace must already be checked")
 	}
 
 	bkt := getBucket(tx, bucketKeyVersion, []byte(namespace), bucketKeyObjectLeases, []byte(lid))
@@ -174,6 +174,26 @@ func addSnapshotLease(ctx context.Context, tx *bolt.Tx, snapshotter, key string)
 	}
 
 	return bkt.Put([]byte(key), nil)
+}
+
+func removeSnapshotLease(ctx context.Context, tx *bolt.Tx, snapshotter, key string) error {
+	lid, ok := leases.Lease(ctx)
+	if !ok {
+		return nil
+	}
+
+	namespace, ok := namespaces.Namespace(ctx)
+	if !ok {
+		panic("namespace must already be checked")
+	}
+
+	bkt := getBucket(tx, bucketKeyVersion, []byte(namespace), bucketKeyObjectLeases, []byte(lid), bucketKeyObjectSnapshots, []byte(snapshotter))
+	if bkt == nil {
+		// Key does not exist so we return nil
+		return nil
+	}
+
+	return bkt.Delete([]byte(key))
 }
 
 func addContentLease(ctx context.Context, tx *bolt.Tx, dgst digest.Digest) error {
@@ -198,4 +218,24 @@ func addContentLease(ctx context.Context, tx *bolt.Tx, dgst digest.Digest) error
 	}
 
 	return bkt.Put([]byte(dgst.String()), nil)
+}
+
+func removeContentLease(ctx context.Context, tx *bolt.Tx, dgst digest.Digest) error {
+	lid, ok := leases.Lease(ctx)
+	if !ok {
+		return nil
+	}
+
+	namespace, ok := namespaces.Namespace(ctx)
+	if !ok {
+		panic("namespace must already be checked")
+	}
+
+	bkt := getBucket(tx, bucketKeyVersion, []byte(namespace), bucketKeyObjectLeases, []byte(lid), bucketKeyObjectContent)
+	if bkt == nil {
+		// Key does not exist so we return nil
+		return nil
+	}
+
+	return bkt.Delete([]byte(dgst.String()))
 }


### PR DESCRIPTION
Ensures that lease resources don't continue to grow if resources are being removed from the lease. Allows lease life cycles to remain undefined without them growing over time.

Fixes issue on snapshot commit where the committed snapshot was not getting added to the lease. Also removes previous key which was committed.