### PR TITLE
Proposal: Replace test.root flag with $ENABLE_ROOT_TESTS

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,7 @@ build_script:
 test_script:
   # TODO: need an equivalent of TRAVIS_COMMIT_RANGE
   # - GIT_CHECK_EXCLUDE="./vendor" TRAVIS_COMMIT_RANGE="${TRAVIS_COMMIT_RANGE/.../..}" C:\MinGW\bin\mingw32-make.exe dco
-  - bash.exe -lc "export PATH=/c/tools/mingw64/bin:/c/gopath/src/github.com/containerd/containerd/bin:$PATH ; mingw32-make.exe coverage root-coverage"
+  - bash.exe -lc "export PATH=/c/tools/mingw64/bin:/c/gopath/src/github.com/containerd/containerd/bin:$PATH ; export ENABLE_ROOT_TESTS=1; mingw32-make.exe coverage"
   - bash.exe -elc "export PATH=/c/tools/mingw64/bin:/c/gopath/src/github.com/containerd/containerd/bin:$PATH ; mingw32-make.exe integration"
   - bash.exe -elc "export PATH=/c/tools/mingw64/bin:/c/gopath/src/github.com/containerd/containerd/bin:$PATH ; mingw32-make.exe integration-parallel"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,8 +59,9 @@ script:
   - make build
   - make binaries
   - if [ "$GOOS" = "linux" ]; then sudo make install ; fi
-  - if [ "$GOOS" = "linux" ]; then make coverage ; fi
-  - if [ "$GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH make root-coverage ; fi
+  - |
+      if [ "$GOOS" != "linux" ]; then exit 0; fi
+      sudo PATH=$PATH GOPATH=$GOPATH ENABLE_ROOT_TESTS=1 make coverage
   - if [ "$GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH make integration ; fi
   - if [ "$GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH make integration-parallel ; fi
 

--- a/testutil/helpers.go
+++ b/testutil/helpers.go
@@ -1,7 +1,6 @@
 package testutil
 
 import (
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -9,12 +8,6 @@ import (
 	"strconv"
 	"testing"
 )
-
-var rootEnabled bool
-
-func init() {
-	flag.BoolVar(&rootEnabled, "test.root", false, "enable tests that require root")
-}
 
 // DumpDir will log out all of the contents of the provided directory to
 // testing logger.

--- a/testutil/helpers_unix.go
+++ b/testutil/helpers_unix.go
@@ -19,11 +19,13 @@ func Unmount(t *testing.T, mountPoint string) {
 	}
 }
 
+const enableRootTestsEnvVar = "ENABLE_ROOT_TESTS"
+
 // RequiresRoot skips tests that require root, unless the test.root flag has
 // been set
 func RequiresRoot(t testing.TB) {
-	if !rootEnabled {
-		t.Skip("skipping test that requires root")
+	if os.Getenv(enableRootTestsEnvVar) == "" {
+		t.Skipf("test requires root, set %s=1 to run this test", enableRootTestsEnvVar)
 		return
 	}
 	assert.Equal(t, 0, os.Getuid(), "This test must be run as root.")
@@ -31,8 +33,8 @@ func RequiresRoot(t testing.TB) {
 
 // RequiresRootM is similar to RequiresRoot but intended to be called from *testing.M.
 func RequiresRootM() {
-	if !rootEnabled {
-		fmt.Fprintln(os.Stderr, "skipping test that requires root")
+	if os.Getenv(enableRootTestsEnvVar) == "" {
+		fmt.Fprintf(os.Stderr, "test requires root, set %s=1 to run this test\n", enableRootTestsEnvVar)
 		os.Exit(0)
 	}
 	if 0 != os.Getuid() {


### PR DESCRIPTION
Tests that require root privileged are disabled by default. 

Currently to enable those tests a `-test.root` flag must be set on the `go test` command. Other options for enabling these tests include: build tags (which would force the tests to be moved into different files), or environment variables.

The problem with a command line flag is that it breaks the homogeneity of test packages. The problem can be seen in the diff of this PR. The root test packages become a special case that can not be run along with the rest of the packages in the project.

This PR changes the enable toggle from a command line flag to an environment variable. The environment variable can be discovered by users from the skip message output by `go test`. This change removes the special casing require to run some tests, and allows all tests to be run in the same loop.

The Makefile targets keep their existing behaviour, but I would be in favor of changing both `test`, and `coverage` to use `ENABLE_ROOT_TESTS` by default, like all the integration targets.

Part of #1756