### PR TITLE
client: move snapshot client to containerd package

### DIFF
--- a/client.go
+++ b/client.go
@@ -37,7 +37,6 @@ import (
 	diffservice "github.com/containerd/containerd/services/diff"
 	imagesservice "github.com/containerd/containerd/services/images"
 	namespacesservice "github.com/containerd/containerd/services/namespaces"
-	snapshotservice "github.com/containerd/containerd/services/snapshot"
 	"github.com/containerd/containerd/snapshot"
 	"github.com/containerd/typeurl"
 	ptypes "github.com/gogo/protobuf/types"
@@ -441,7 +440,7 @@ func (c *Client) ContentStore() content.Store {
 
 // SnapshotService returns the underlying snapshotter for the provided snapshotter name
 func (c *Client) SnapshotService(snapshotterName string) snapshot.Snapshotter {
-	return snapshotservice.NewSnapshotterFromClient(snapshotapi.NewSnapshotsClient(c.conn), snapshotterName)
+	return NewSnapshotterFromClient(snapshotapi.NewSnapshotsClient(c.conn), snapshotterName)
 }
 
 // TaskService returns the underlying TasksClient

--- a/services/snapshot/service.go
+++ b/services/snapshot/service.go
@@ -293,3 +293,24 @@ func fromMounts(mounts []mount.Mount) []*types.Mount {
 	}
 	return out
 }
+
+func toInfo(info snapshotapi.Info) snapshot.Info {
+	return snapshot.Info{
+		Name:    info.Name,
+		Parent:  info.Parent,
+		Kind:    toKind(info.Kind),
+		Created: info.CreatedAt,
+		Updated: info.UpdatedAt,
+		Labels:  info.Labels,
+	}
+}
+
+func toKind(kind snapshotapi.Kind) snapshot.Kind {
+	if kind == snapshotapi.KindActive {
+		return snapshot.KindActive
+	}
+	if kind == snapshotapi.KindView {
+		return snapshot.KindView
+	}
+	return snapshot.KindCommitted
+}

--- a/snapshot.go
+++ b/snapshot.go
@@ -1,4 +1,4 @@
-package snapshot
+package containerd
 
 import (
 	"context"
@@ -205,4 +205,25 @@ func toMounts(mm []*types.Mount) []mount.Mount {
 		}
 	}
 	return mounts
+}
+
+func fromKind(kind snapshot.Kind) snapshotapi.Kind {
+	if kind == snapshot.KindActive {
+		return snapshotapi.KindActive
+	}
+	if kind == snapshot.KindView {
+		return snapshotapi.KindView
+	}
+	return snapshotapi.KindCommitted
+}
+
+func fromInfo(info snapshot.Info) snapshotapi.Info {
+	return snapshotapi.Info{
+		Name:      info.Name,
+		Parent:    info.Parent,
+		Kind:      fromKind(info.Kind),
+		CreatedAt: info.Created,
+		UpdatedAt: info.Updated,
+		Labels:    info.Labels,
+	}
 }


### PR DESCRIPTION
end goal:
- make the client consistent
- separate out client code from service packages (`service/<service_name>/`) so clients will not pull in service-specific dependencies. 

Signed-off-by: Jess Valarezo <valarezo.jessica@gmail.com>