### PR TITLE
events: decouple events package from grpc

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -2,9 +2,18 @@ package events
 
 import (
 	"context"
+	"time"
 
-	events "github.com/containerd/containerd/api/services/events/v1"
+	"github.com/gogo/protobuf/types"
 )
+
+// Envelope provides the packaging for an event.
+type Envelope struct {
+	Timestamp time.Time
+	Namespace string
+	Topic     string
+	Event     *types.Any
+}
 
 // Event is a generic interface for any type of event
 type Event interface{}
@@ -16,16 +25,10 @@ type Publisher interface {
 
 // Forwarder forwards an event to the underlying event bus
 type Forwarder interface {
-	Forward(ctx context.Context, envelope *events.Envelope) error
-}
-
-type publisherFunc func(ctx context.Context, topic string, event Event) error
-
-func (fn publisherFunc) Publish(ctx context.Context, topic string, event Event) error {
-	return fn(ctx, topic, event)
+	Forward(ctx context.Context, envelope *Envelope) error
 }
 
 // Subscriber allows callers to subscribe to events
 type Subscriber interface {
-	Subscribe(ctx context.Context, filters ...string) (ch <-chan *events.Envelope, errs <-chan error)
+	Subscribe(ctx context.Context, filters ...string) (ch <-chan *Envelope, errs <-chan error)
 }

--- a/events/exchange/exchange_test.go
+++ b/events/exchange/exchange_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	eventstypes "github.com/containerd/containerd/api/events"
-	v1 "github.com/containerd/containerd/api/services/events/v1"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/events"
 	"github.com/containerd/containerd/namespaces"
@@ -57,7 +56,7 @@ func TestExchangeBasic(t *testing.T) {
 	wg.Wait()
 
 	for _, subscriber := range []struct {
-		eventq <-chan *v1.Envelope
+		eventq <-chan *events.Envelope
 		errq   <-chan error
 		cancel func()
 	}{
@@ -133,7 +132,7 @@ func TestExchangeValidateTopic(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			envelope := v1.Envelope{
+			envelope := events.Envelope{
 				Timestamp: time.Now().UTC(),
 				Namespace: namespace,
 				Topic:     testcase.input,


### PR DESCRIPTION
By defining a concrete, non-protobuf type for the events interface, we
can completely decouple it from the grpc packages that are expensive at
runtime. This does requires some allocation cost for converting between
types, but the saving for the size of the shim are worth it.

Signed-off-by: Stephen J Day <stephen.day@docker.com>