### PR TITLE
shim: support non-default binary name

### DIFF
--- a/cmd/containerd-shim/main_unix.go
+++ b/cmd/containerd-shim/main_unix.go
@@ -40,14 +40,15 @@ shim for container lifecycle and reconnection
 `
 
 var (
-	debugFlag         bool
-	namespaceFlag     string
-	socketFlag        string
-	addressFlag       string
-	workdirFlag       string
-	runtimeRootFlag   string
-	criuFlag          string
-	systemdCgroupFlag bool
+	debugFlag            bool
+	namespaceFlag        string
+	socketFlag           string
+	addressFlag          string
+	workdirFlag          string
+	runtimeRootFlag      string
+	criuFlag             string
+	systemdCgroupFlag    bool
+	containerdBinaryFlag string
 )
 
 func init() {
@@ -59,6 +60,9 @@ func init() {
 	flag.StringVar(&runtimeRootFlag, "runtime-root", proc.RuncRoot, "root directory for the runtime")
 	flag.StringVar(&criuFlag, "criu", "", "path to criu binary")
 	flag.BoolVar(&systemdCgroupFlag, "systemd-cgroup", false, "set runtime to use systemd-cgroup")
+	// currently, the `containerd publish` utility is embedded in the daemon binary.
+	// The daemon invokes `containerd-shim -containerd-binary ...` with its own os.Executable() path.
+	flag.StringVar(&containerdBinaryFlag, "containerd-binary", "containerd", "path to containerd binary (used for `containerd publish`)")
 	flag.Parse()
 }
 
@@ -202,7 +206,7 @@ func (l *remoteEventsPublisher) Publish(ctx context.Context, topic string, event
 	if err != nil {
 		return err
 	}
-	cmd := exec.CommandContext(ctx, "containerd", "--address", l.address, "publish", "--topic", topic, "--namespace", ns)
+	cmd := exec.CommandContext(ctx, containerdBinaryFlag, "--address", l.address, "publish", "--topic", topic, "--namespace", ns)
 	cmd.Stdin = bytes.NewReader(data)
 	c, err := reaper.Default.Start(cmd)
 	if err != nil {

--- a/linux/shim/client/client.go
+++ b/linux/shim/client/client.go
@@ -89,10 +89,15 @@ func WithStart(binary, address, daemonAddress, cgroup string, nonewns, debug boo
 }
 
 func newCommand(binary, daemonAddress string, nonewns, debug bool, config shim.Config, socket *os.File) *exec.Cmd {
+	selfExe, err := os.Executable()
+	if err != nil {
+		panic(err)
+	}
 	args := []string{
 		"-namespace", config.Namespace,
 		"-workdir", config.WorkDir,
 		"-address", daemonAddress,
+		"-containerd-binary", selfExe,
 	}
 
 	if config.Criu != "" {


### PR DESCRIPTION
The binary name used for executing "containerd publish" (#1764) was hard-coded
in the shim code, and hence it did not work with customized daemon
binary name. (e.g. `docker-containerd`)

This commit allows specifying custom daemon binary via `containerd-shim
--util-binary ...`.
The daemon invokes this command with `os.Executable()` path.

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>