### PR TITLE
cli: add "manual invocation is unsupported" to internal commands

### DIFF
--- a/cmd/containerd-shim/main_unix.go
+++ b/cmd/containerd-shim/main_unix.go
@@ -36,7 +36,7 @@ const usage = `
 / /__/ /_/ / / / / /_/ /_/ / / / / /  __/ /  / /_/ /_____(__  ) / / / / / / / / /
 \___/\____/_/ /_/\__/\__,_/_/_/ /_/\___/_/   \__,_/     /____/_/ /_/_/_/ /_/ /_/
 
-shim for container lifecycle and reconnection
+shim for container lifecycle and reconnection (manual invocation is unsupported)
 `
 
 var (

--- a/cmd/containerd/publish.go
+++ b/cmd/containerd/publish.go
@@ -20,7 +20,7 @@ import (
 
 var publishCommand = cli.Command{
 	Name:  "publish",
-	Usage: "binary to publish events to containerd",
+	Usage: "binary to publish events to containerd (manual invocation is unsupported)",
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "namespace",

--- a/cmd/ctr/main.go
+++ b/cmd/ctr/main.go
@@ -47,7 +47,7 @@ func main() {
 / /__/ /_/ /
 \___/\__/_/
 
-containerd CLI
+containerd CLI (unsupported)
 `
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{


### PR DESCRIPTION
`containerd publish` is implementation-detail and we never support
compatibility of this command across releases.
So users should not be aware of this subcommand.

~~`containerd --help` no longer shows the help of this subcommand but
`containerd publish --help` can still be printed.~~
EDIT: I updated PR to just add "manual invocation is unsupported" to `--help` of internal commands

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>