### PR TITLE
content/local: don't open file with sync

### DIFF
--- a/content/local/store.go
+++ b/content/local/store.go
@@ -499,7 +499,7 @@ func (s *store) writer(ctx context.Context, ref string, total int64, expected di
 		}
 	}
 
-	fp, err := os.OpenFile(data, os.O_WRONLY|os.O_CREATE|os.O_SYNC, 0666)
+	fp, err := os.OpenFile(data, os.O_WRONLY|os.O_CREATE, 0666)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to open data file")
 	}


### PR DESCRIPTION
After running into performance issues when sending in certain kinds of
content, synchronous writes for content have been removed. Content is
still synced on commit, so this shouldn't be necessary.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

cc @tonistiigi 