### PR TITLE
ctr: add container create cmd and config flag

### DIFF
--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -22,7 +22,8 @@ func init() {
 	})
 }
 
-func newContainer(ctx gocontext.Context, client *containerd.Client, context *cli.Context) (containerd.Container, error) {
+// NewContainer creates a new container
+func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli.Context) (containerd.Container, error) {
 	var (
 		ref  = context.Args().First()
 		id   = context.Args().Get(1)
@@ -40,8 +41,12 @@ func newContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 	var (
 		opts  []oci.SpecOpts
 		cOpts []containerd.NewContainerOpts
+		spec  containerd.NewContainerOpts
 	)
+	opts = append(opts, oci.WithEnv(context.StringSlice("env")))
+	opts = append(opts, withMounts(context))
 	cOpts = append(cOpts, containerd.WithContainerLabels(commands.LabelArgs(context.StringSlice("label"))))
+	cOpts = append(cOpts, containerd.WithRuntime(context.String("runtime"), nil))
 	if context.Bool("rootfs") {
 		opts = append(opts, oci.WithRootFSPath(ref))
 	} else {
@@ -50,19 +55,17 @@ func newContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 			return nil, err
 		}
 		opts = append(opts, oci.WithImageConfig(image))
-		cOpts = append(cOpts, containerd.WithImage(image))
-		cOpts = append(cOpts, containerd.WithSnapshotter(context.String("snapshotter")))
-		// Even when "readonly" is set, we don't use KindView snapshot here. (#1495)
-		// We pass writable snapshot to the OCI runtime, and the runtime remounts it as read-only,
-		// after creating some mount points on demand.
-		cOpts = append(cOpts, containerd.WithNewSnapshot(id, image))
+		cOpts = append(cOpts,
+			containerd.WithImage(image),
+			containerd.WithSnapshotter(context.String("snapshotter")),
+			// Even when "readonly" is set, we don't use KindView snapshot here. (#1495)
+			// We pass writable snapshot to the OCI runtime, and the runtime remounts it as read-only,
+			// after creating some mount points on demand.
+			containerd.WithNewSnapshot(id, image))
 	}
 	if context.Bool("readonly") {
 		opts = append(opts, oci.WithRootFSReadonly())
 	}
-	cOpts = append(cOpts, containerd.WithRuntime(context.String("runtime"), nil))
-	opts = append(opts, oci.WithEnv(context.StringSlice("env")))
-	opts = append(opts, withMounts(context))
 	if len(args) > 0 {
 		opts = append(opts, oci.WithProcessArgs(args...))
 	}
@@ -75,10 +78,20 @@ func newContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 	if context.Bool("net-host") {
 		opts = append(opts, oci.WithHostNamespace(specs.NetworkNamespace), oci.WithHostHostsFile, oci.WithHostResolvconf)
 	}
+	if context.IsSet("config") {
+		var s specs.Spec
+		if err := loadSpec(context.String("config"), &s); err != nil {
+			return nil, err
+		}
+		spec = containerd.WithSpec(&s, opts...)
+	} else {
+		spec = containerd.WithNewSpec(opts...)
+	}
+	cOpts = append(cOpts, spec)
+
 	// oci.WithImageConfig (WithUsername, WithUserID) depends on rootfs snapshot for resolving /etc/passwd.
 	// So cOpts needs to have precedence over opts.
 	// TODO: WithUsername, WithUserID should additionally support non-snapshot rootfs
-	cOpts = append(cOpts, []containerd.NewContainerOpts{containerd.WithNewSpec(opts...)}...)
 	return client.NewContainer(ctx, id, cOpts...)
 }
 


### PR DESCRIPTION
1. Add `ctr c create` command which only creates a container (as opposed to run which creates and runs a container).
2. Add `--config` flag to `ctr c create` and `ctr run` 
~~which opens the given `config.toml` file. This file can define any flags used in creating a new container.~~
which opens given `config.json` file containing a oci runtime-spec

Signed-off-by: Jess Valarezo <valarezo.jessica@gmail.com>