### PR TITLE
cmd/containerd-shim: set GOMAXPROCS to 2

### DIFF
--- a/cmd/containerd-shim/main_unix.go
+++ b/cmd/containerd-shim/main_unix.go
@@ -60,6 +60,13 @@ func main() {
 	if debugFlag {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
+
+	if os.Getenv("GOMAXPROCS") == "" {
+		// If GOMAXPROCS hasn't been set, we default to a value of 2 to reduce
+		// the number of Go stacks present in the shim.
+		runtime.GOMAXPROCS(2)
+	}
+
 	if err := executeShim(); err != nil {
 		fmt.Fprintf(os.Stderr, "containerd-shim: %s\n", err)
 		os.Exit(1)


### PR DESCRIPTION
The shim doesn't need massive concurrency and a bunch of CPUs to do its
job correctly. We can reduce the number of threads to save memory at
little cost to performance.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

Closes #1471