### PR TITLE
Move install of dev tools from Makefile to a script

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,7 +23,9 @@ before_build:
   - choco install codecov
 
 build_script:
-  - bash.exe -elc "export PATH=/c/tools/mingw64/bin:/c/gopath/bin:$PATH ; mingw32-make.exe setup check"
+  - bash.exe -elc "export PATH=/c/tools/mingw64/bin:/c/gopath/bin:$PATH;
+        script/setup/install-dev-tools;
+        mingw32-make.exe check"
   - bash.exe -elc "export PATH=/c/tools/mingw64/bin:$PATH ; mingw32-make.exe build binaries"
 
 test_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ script:
   - export GOOS=$TRAVIS_GOOS
   - export CGO_ENABLED=$TRAVIS_CGO_ENABLED
   - GIT_CHECK_EXCLUDE="./vendor" TRAVIS_COMMIT_RANGE="${TRAVIS_COMMIT_RANGE/.../..}" make dco
-  - GOOS=linux make setup
+  - GOOS=linux script/setup/install-dev-tools
   - go build -i .
   - make check
   - if [ "$GOOS" = "linux" ]; then make check-protos check-api-descriptors; fi

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ include Makefile.$(target_os)
 TESTFLAGS ?= -v $(TESTFLAGS_RACE)
 TESTFLAGS_PARALLEL ?= 8
 
-.PHONY: clean all AUTHORS fmt vet lint dco build binaries test integration setup generate protos checkprotos coverage ci check help install uninstall vendor release
+.PHONY: clean all AUTHORS fmt vet lint dco build binaries test integration generate protos checkprotos coverage ci check help install uninstall vendor release
 .DEFAULT: default
 
 all: binaries
@@ -69,13 +69,6 @@ ci: check binaries checkprotos coverage coverage-integration ## to be used by th
 
 AUTHORS: .mailmap .git/HEAD
 	git log --format='%aN <%aE>' | sort -fu > $@
-
-setup: ## install dependencies
-	@echo "$(WHALE) $@"
-	# TODO(stevvooe): Install these from the vendor directory
-	@go get -u github.com/alecthomas/gometalinter
-	@gometalinter --install > /dev/null
-	@go get -u github.com/stevvooe/protobuild
 
 generate: protos
 	@echo "$(WHALE) $@"

--- a/script/setup/install-dev-tools
+++ b/script/setup/install-dev-tools
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Install developer tools to $GOBIN (or $GOPATH/bin if unset)
+#
+set -eu -o pipefail
+
+go get -u github.com/stevvooe/protobuild
+go get -u github.com/alecthomas/gometalinter
+gometalinter --install >/dev/null
+go get -u github.com/LK4D4/vndr


### PR DESCRIPTION
cc @crosbymichael 

With this change dependencies will be pinned to a specific sha instead of using latest.