### PR TITLE
oci: allocate process if not already set

### DIFF
--- a/oci/spec_opts_unix.go
+++ b/oci/spec_opts_unix.go
@@ -89,6 +89,11 @@ func WithImageConfig(image Image) SpecOpts {
 		default:
 			return fmt.Errorf("unknown image config media type %s", ic.MediaType)
 		}
+
+		if s.Process == nil {
+			s.Process = &specs.Process{}
+		}
+
 		s.Process.Env = append(s.Process.Env, config.Env...)
 		cmd := config.Cmd
 		s.Process.Args = append(config.Entrypoint, cmd...)


### PR DESCRIPTION
Signed-off-by: Stephen J Day <stephen.day@docker.com>

@jessvalarezo had a client-side panic and this was the example fix. There may be other cases, as well.