### PR TITLE
Resolve issues with signal handling and exec exit events

### DIFF
--- a/cmd/containerd-shim/shim_linux.go
+++ b/cmd/containerd-shim/shim_linux.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"os/signal"
+	"syscall"
 
 	"github.com/containerd/containerd/reaper"
 	"github.com/containerd/containerd/sys"
@@ -14,7 +15,7 @@ import (
 // sub-reaper so that the container processes are reparented
 func setupSignals() (chan os.Signal, error) {
 	signals := make(chan os.Signal, 2048)
-	signal.Notify(signals)
+	signal.Notify(signals, syscall.SIGTERM, syscall.SIGINT, syscall.SIGCHLD)
 	// make sure runc is setup to use the monitor
 	// for waiting on processes
 	runc.Monitor = reaper.Default

--- a/linux/proc/exec.go
+++ b/linux/proc/exec.go
@@ -143,6 +143,7 @@ func (e *execProcess) start(ctx context.Context) (err error) {
 		opts.ConsoleSocket = socket
 	}
 	if err := e.parent.runtime.Exec(ctx, e.parent.id, e.spec, opts); err != nil {
+		close(e.waitBlock)
 		return e.parent.runtimeError(err, "OCI runtime exec failed")
 	}
 	if e.stdio.Stdin != "" {

--- a/linux/shim/service.go
+++ b/linux/shim/service.go
@@ -148,7 +148,6 @@ func (s *Service) Delete(ctx context.Context, r *ptypes.Empty) (*shimapi.DeleteR
 	if p == nil {
 		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
 	}
-
 	if err := p.Delete(ctx); err != nil {
 		return nil, err
 	}
@@ -480,7 +479,7 @@ func (s *Service) getContainerPids(ctx context.Context, id string) ([]uint32, er
 func (s *Service) forward(publisher events.Publisher) {
 	for e := range s.events {
 		if err := publisher.Publish(s.context, getTopic(s.context, e), e); err != nil {
-			logrus.WithError(err).Error("post event")
+			log.G(s.context).WithError(err).Error("post event")
 		}
 	}
 }


### PR DESCRIPTION
Fixes #1813

First issues where when exec processes fail the wait block is not
released.

Second, you could not dump stacks if the reaper loop locks up.

Third, the publisher was not waiting on the correct pid.