### PR TITLE
Change default subreaper setting

### DIFF
--- a/cmd/containerd/config_linux.go
+++ b/cmd/containerd/config_linux.go
@@ -12,7 +12,7 @@ func defaultConfig() *server.Config {
 		GRPC: server.GRPCConfig{
 			Address: defaults.DefaultAddress,
 		},
-		Subreaper: true,
+		NoSubreaper: false,
 		Debug: server.Debug{
 			Level:   "info",
 			Address: defaults.DefaultDebugAddress,

--- a/server/config.go
+++ b/server/config.go
@@ -23,8 +23,8 @@ type Config struct {
 	Metrics MetricsConfig `toml:"metrics"`
 	// Plugins provides plugin specific configuration for the initialization of a plugin
 	Plugins map[string]toml.Primitive `toml:"plugins"`
-	// Enable containerd as a subreaper
-	Subreaper bool `toml:"subreaper"`
+	// NoSubreaper disables containerd as a subreaper
+	NoSubreaper bool `toml:"no_subreaper"`
 	// OOMScore adjust the containerd's oom score
 	OOMScore int `toml:"oom_score"`
 	// Cgroup specifies cgroup information for the containerd daemon process

--- a/server/server_linux.go
+++ b/server/server_linux.go
@@ -12,7 +12,7 @@ import (
 
 // apply sets config settings on the server process
 func apply(ctx context.Context, config *Config) error {
-	if config.Subreaper {
+	if !config.NoSubreaper {
 		log.G(ctx).Info("setting subreaper...")
 		if err := sys.SetSubreaper(1); err != nil {
 			return err


### PR DESCRIPTION
This subreaper should always be turned on for containerd unless
explicitly needed for it to be off.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>