### PR TITLE
plugins: don't compile for static build

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -43,6 +43,20 @@ You can move them in your global path with:
 sudo make install
 ```
 
+### Static binaries
+
+You can build static binaries by providing a few variables to `make`:
+
+```sudo
+make	EXTRA_FLAGS="-buildmode pie" \
+	EXTRA_LDFLAGS='-extldflags "-fno-PIC -static"' \
+	BUILDTAGS="static_build"
+```
+
+Note that
+ - static build is discouraged
+ - static containerd binary does not support plugins loading
+
 ## Via Docker Container
 
 ### Build containerd

--- a/plugin/plugin_go18.go
+++ b/plugin/plugin_go18.go
@@ -1,4 +1,4 @@
-// +build go1.8,!windows,amd64
+// +build go1.8,!windows,amd64,!static_build
 
 package plugin
 

--- a/plugin/plugin_other.go
+++ b/plugin/plugin_other.go
@@ -1,4 +1,4 @@
-// +build !go1.8 windows !amd64
+// +build !go1.8 windows !amd64 static_build
 
 package plugin
 


### PR DESCRIPTION
We can't really use `dlopen()` from a statically built binary, so
let's disable this functionality if `static_build` tag is used
(which is sort of a de-facto standard way of doing it).

This eliminates the following warning:

	🇩 bin/containerd
	# github.com/containerd/containerd/cmd/containerd
	/tmp/go-link-509179974/000004.o: In function `pluginOpen':
	/usr/local/go/src/plugin/plugin_dlopen.go:19: warning: Using 'dlopen' in
	statically linked applications requires at runtime the shared libraries
	from the glibc version used for linking

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>