### PR TITLE
ctr run: support using an existing snapshot

### DIFF
--- a/cmd/ctr/commands/run/run.go
+++ b/cmd/ctr/commands/run/run.go
@@ -119,7 +119,7 @@ func replaceOrAppendEnvValues(defaults, overrides []string) []string {
 var Command = cli.Command{
 	Name:      "run",
 	Usage:     "run a container",
-	ArgsUsage: "[flags] Image|RootFS ID [COMMAND] [ARG...]",
+	ArgsUsage: "[flags] Image|Snapshot|Dir ID [COMMAND] [ARG...]",
 	Flags: append([]cli.Flag{
 		cli.BoolFlag{
 			Name:  "tty,t",


### PR DESCRIPTION
STATUS: we should wait for `ctr container create` and `ctr container start` first: https://github.com/containerd/containerd/pull/1828#issuecomment-356428744 https://github.com/containerd/containerd/pull/1790

- - -
e.g. `ctr snapshot prepare foo parent; ctr run --rootfs-type=snapshot foo foo sh`

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>