### PR TITLE
snapshots/overlay: add overlay cleanup

### DIFF
--- a/metadata/snapshot.go
+++ b/metadata/snapshot.go
@@ -597,14 +597,23 @@ func validateSnapshot(info *snapshots.Info) error {
 	return nil
 }
 
+type cleaner interface {
+	Cleanup(ctx context.Context) error
+}
+
 func (s *snapshotter) garbageCollect(ctx context.Context) (d time.Duration, err error) {
 	s.l.Lock()
 	t1 := time.Now()
 	defer func() {
+		s.l.Unlock()
+		if err == nil {
+			if c, ok := s.Snapshotter.(cleaner); ok {
+				err = c.Cleanup(ctx)
+			}
+		}
 		if err == nil {
 			d = time.Now().Sub(t1)
 		}
-		s.l.Unlock()
 	}()
 
 	seen := map[string]struct{}{}

--- a/snapshots/storage/bolt.go
+++ b/snapshots/storage/bolt.go
@@ -389,6 +389,26 @@ func CommitActive(ctx context.Context, key, name string, usage snapshots.Usage, 
 	return fmt.Sprintf("%d", id), nil
 }
 
+// IDMap returns all the IDs mapped to their key
+func IDMap(ctx context.Context) (map[string]string, error) {
+	m := map[string]string{}
+	if err := withBucket(ctx, func(ctx context.Context, bkt, _ *bolt.Bucket) error {
+		return bkt.ForEach(func(k, v []byte) error {
+			// skip non buckets
+			if v != nil {
+				return nil
+			}
+			id := readID(bkt.Bucket(k))
+			m[fmt.Sprintf("%d", id)] = string(k)
+			return nil
+		})
+	}); err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
 func withSnapshotBucket(ctx context.Context, key string, fn func(context.Context, *bolt.Bucket, *bolt.Bucket) error) error {
 	tx, ok := ctx.Value(transactionKey{}).(*bolt.Tx)
 	if !ok {


### PR DESCRIPTION
Updates overlay remove to simply remove the reference and adds a cleanup method for discarding the directory. Updates snapshot create to setup the directory structure while in the transaction to prevent cleanup from removing directories which are part of a create.

This effectively adds a 3rd phase to the garbage collection which completes all the on disk snapshot cleanup. During this disk cleanup the snapshotter will be unlocked to allow for the management of snapshots. The garbage collection scheduler will still wait for the completion of this 3rd phase, however it will not consider it when calculating pause time.

Added options to overlay snapshotter to allow configuring the asynchronous removal of keeping remove synchronous