### PR TITLE
implement btrfs.Usage

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -18,7 +18,8 @@ github.com/golang/protobuf 1643683e1b54a9e88ad26d98f81400c8c9d9f4f9
 github.com/opencontainers/runtime-spec v1.0.0
 github.com/opencontainers/runc 74a17296470088de3805e138d3d87c62e613dfc4
 github.com/sirupsen/logrus v1.0.0
-github.com/containerd/btrfs cc52c4dea2ce11a44e6639e561bb5c2af9ada9e3
+# containerd/btrfs#14
+github.com/containerd/btrfs 5a190e3e2845b9951d6334b2b097f6c8285687 https://github.com/AkihiroSuda/go-btrfs
 github.com/stretchr/testify v1.1.4
 github.com/davecgh/go-spew v1.1.0
 github.com/pmezard/go-difflib v1.0.0

--- a/vendor/github.com/containerd/btrfs/info.go
+++ b/vendor/github.com/containerd/btrfs/info.go
@@ -27,3 +27,15 @@ type infosByID []Info
 func (b infosByID) Len() int           { return len(b) }
 func (b infosByID) Less(i, j int) bool { return b[i].ID < b[j].ID }
 func (b infosByID) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
+
+// QGroupInfoItem corresponds to btrfs_group_info_item.
+type QGroupInfoItem struct {
+	QGroupIDHigh         uint16 // 16 bits, aka "level"
+	QGroupIDLow          uint64 // 48 bits (16+48=64)
+	Generation           uint64
+	Referenced           uint64
+	ReferencedCompressed uint64
+	Exclusive            uint64
+	ExclusiveCompressed  uint64
+	// TODO(AkihiroSuda): add limit
+}


### PR DESCRIPTION
- For active snapshot, the `excl` value of L0 QGroup is used, and
committed on Commit.
- For view snapshot, always 0 is returned.
- For committed snapshot, the committed value is returned.

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

Close #1801 
Depends on containerd/btrfs#14

Result after `ctr images pull docker.io/library/ubuntu:latest` on btrfs:
```
root@ws01:~# export CONTAINERD_SNAPSHOTTER=btrfs 
root@ws01:~# ctr snapshot tree                                                                 
\_ sha256:788ce2310e2fdbbf81fe21cbcc8a44da4cf648b0339b09c221abacb4cd5fd136                     
  \_ sha256:2eb2bdc452f61ae4703cb67be52a4d595265cecb257f3210647ea1d0bf84a549                   
    \_ sha256:289566599b45e8e2a7264923d3481c6e0e7460232a4e0ed1512528272fb15c70                 
      \_ sha256:1f7b04df09e72e9b94e923567a168b438d195c4c610a335ed7320cc6dea93c3f                                                                                                               
        \_ sha256:928cadf24454047a7a1b8e8d034a539e882ed904d6627b343e2abcd338ae0123                                                                                                             
root@ws01:~# ctr snapshot usage                                                                                                                                                                
KEY                                                                     SIZE      INODES                                                                                                       
sha256:1f7b04df09e72e9b94e923567a168b438d195c4c610a335ed7320cc6dea93c3f 68.0 KiB  -1                                                                                                           
sha256:289566599b45e8e2a7264923d3481c6e0e7460232a4e0ed1512528272fb15c70 80.0 KiB  -1                                                                                                           
sha256:2eb2bdc452f61ae4703cb67be52a4d595265cecb257f3210647ea1d0bf84a549 208.0 KiB -1                                                                                                           
sha256:788ce2310e2fdbbf81fe21cbcc8a44da4cf648b0339b09c221abacb4cd5fd136 123.7 MiB -1                                                                                                           
sha256:928cadf24454047a7a1b8e8d034a539e882ed904d6627b343e2abcd338ae0123 48.0 KiB  -1  
```

on overlayfs:
```
root@ws01:~# export CONTAINERD_SNAPSHOTTER=overlayfs
root@ws01:~# ctr snapshot tree
\_ sha256:788ce2310e2fdbbf81fe21cbcc8a44da4cf648b0339b09c221abacb4cd5fd136                     
  \_ sha256:2eb2bdc452f61ae4703cb67be52a4d595265cecb257f3210647ea1d0bf84a549                   
    \_ sha256:289566599b45e8e2a7264923d3481c6e0e7460232a4e0ed1512528272fb15c70                 
      \_ sha256:1f7b04df09e72e9b94e923567a168b438d195c4c610a335ed7320cc6dea93c3f               
        \_ sha256:928cadf24454047a7a1b8e8d034a539e882ed904d6627b343e2abcd338ae0123             
root@ws01:~# ctr snapshot usage                
KEY                                                                     SIZE      INODES       
sha256:1f7b04df09e72e9b94e923567a168b438d195c4c610a335ed7320cc6dea93c3f 14.7 KiB  4            
sha256:289566599b45e8e2a7264923d3481c6e0e7460232a4e0ed1512528272fb15c70 20.0 KiB  22           
sha256:2eb2bdc452f61ae4703cb67be52a4d595265cecb257f3210647ea1d0bf84a549 48.7 KiB  21           
sha256:788ce2310e2fdbbf81fe21cbcc8a44da4cf648b0339b09c221abacb4cd5fd136 119.8 MiB 5518         
sha256:928cadf24454047a7a1b8e8d034a539e882ed904d6627b343e2abcd338ae0123 12.0 KiB  4
```

The results are slightly different but should not hurt.