### PR TITLE
Close FIFOs on failure.

### DIFF
--- a/container.go
+++ b/container.go
@@ -162,11 +162,17 @@ func (c *container) Image(ctx context.Context) (Image, error) {
 	}, nil
 }
 
-func (c *container) NewTask(ctx context.Context, ioCreate cio.Creation, opts ...NewTaskOpts) (Task, error) {
+func (c *container) NewTask(ctx context.Context, ioCreate cio.Creation, opts ...NewTaskOpts) (_ Task, err error) {
 	i, err := ioCreate(c.id)
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if err != nil && i != nil {
+			i.Cancel()
+			i.Close()
+		}
+	}()
 	cfg := i.Config()
 	request := &tasks.CreateTaskRequest{
 		ContainerID: c.id,


### PR DESCRIPTION
For https://github.com/containerd/containerd/issues/1843.

Close FIFOs on task creation failure. We don't `Wait` here, because the shim side hasn't open the fifos yet, it seems that `Wait` will wait forever.

Signed-off-by: Lantao Liu <lantaol@google.com>