### PR TITLE
Revert single back to double quotes in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ COMMANDS=ctr containerd containerd-stress containerd-release
 BINARIES=$(addprefix bin/,$(COMMANDS))
 
 GO_TAGS=$(if $(BUILDTAGS),-tags "$(BUILDTAGS)",)
-GO_LDFLAGS=-ldflags '-s -w -X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PKG) $(EXTRA_LDFLAGS)'
+GO_LDFLAGS=-ldflags "-s -w -X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PKG) $(EXTRA_LDFLAGS)"
 SHIM_GO_LDFLAGS=-ldflags '-s -w -X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PKG) -extldflags "-static"'
 
 TESTFLAGS_RACE=


### PR DESCRIPTION
This breaks builds of containerd embedded in Dockerfiles
which use/set EXTRA_LDFLAGS

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>

This was originally changed in 434f0e679f67ecdb3f389329fd4bb8504ca9cf4b without any clear reason as to why it needed to be single quoted. I found it by trying to update LinuxKit containerd to the new rc.0 here: https://github.com/linuxkit/linuxkit/blob/master/tools/alpine/Dockerfile#L48-L57

On that last line, the extldflags static gets misinterpreted as a flag to go build with the single quoted containerd Makefile.

// cc: @justincormack 