### PR TITLE
update images error (pt. 2)

### DIFF
--- a/image.go
+++ b/image.go
@@ -147,7 +147,7 @@ func (i *image) getLayers(ctx context.Context, platform string) ([]rootfs.Layer,
 
 	manifest, err := images.Manifest(ctx, cs, i.i.Target, platform)
 	if err != nil {
-		return nil, errors.Wrap(err, "")
+		return nil, err
 	}
 
 	diffIDs, err := i.i.RootFS(ctx, cs, platform)

--- a/images/image.go
+++ b/images/image.go
@@ -187,7 +187,7 @@ func Manifest(ctx context.Context, provider content.Provider, image ocispec.Desc
 			return descs, nil
 
 		}
-		return nil, errors.Wrapf(errdefs.ErrNotFound, "could not resolve manifest %v", desc.Digest)
+		return nil, errors.Wrapf(errdefs.ErrNotFound, "unexpected media type %v for %v", desc.MediaType, desc.Digest)
 	}), image); err != nil {
 		return ocispec.Manifest{}, err
 	}


### PR DESCRIPTION
See https://github.com/containerd/containerd/pull/1858#issuecomment-348626418
```
ctr: : manifest sha256:375718bf305a6e1a4a3e7014958ec5ea5ca52537f00dc70cde71be078fbbd64c: not found
```
becomes
```
ctr: manifest sha256:7a0097084ca8095f15290ba77546407228b461c23ae683ff9be3abb487785895: not found
```

Signed-off-by: Jess Valarezo <valarezo.jessica@gmail.com>