### PR TITLE
[WIP] server: export unique identifier for instance

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -40,6 +40,8 @@ func (t Type) String() string { return string(t) }
 const (
 	// AllPlugins declares that the plugin should be initialized after all others.
 	AllPlugins Type = "*"
+	// InstancePlugin is the parent of all plugins
+	InstancePlugin Type = "io.containerd"
 	// RuntimePlugin implements a runtime
 	RuntimePlugin Type = "io.containerd.runtime.v1"
 	// GRPCPlugin implements a grpc service
@@ -137,6 +139,9 @@ func Register(r *Registration) {
 		panic(ErrInvalidRequires)
 	}
 
+	if r.Type == InstancePlugin { // instance plugins are always first.
+		register.r = append([]*Registration{r}, register.r...)
+	}
 	register.r = append(register.r, r)
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -1,7 +1,12 @@
 package server
 
 import (
+	"crypto/rand"
 	"expvar"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/big"
 	"net"
 	"net/http"
 	"net/http/pprof"
@@ -57,6 +62,42 @@ func New(ctx context.Context, config *Config) (*Server, error) {
 	if err := apply(ctx, config); err != nil {
 		return nil, err
 	}
+
+	plugin.Register(&plugin.Registration{
+		Type: plugin.InstancePlugin,
+		ID:   "instance",
+		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
+			var (
+				idpath = filepath.Join(ic.Root, "id")
+				id     string
+			)
+			if _, err := os.Stat(idpath); err != nil {
+				if os.IsNotExist(err) {
+					id = newID()
+					if err := os.MkdirAll(ic.Root, 0777); err != nil {
+						return nil, err
+					}
+
+					if err := ioutil.WriteFile(idpath, []byte(id), 0666); err != nil {
+						return nil, err
+					}
+				} else {
+					return nil, err
+				}
+			} else {
+				p, err := ioutil.ReadFile(idpath)
+				if err != nil {
+					return nil, err
+				}
+
+				id = string(p)
+			}
+
+			ic.Meta.Exports["id"] = id
+			return nil, nil
+		},
+	})
+
 	plugins, err := loadPlugins(config)
 	if err != nil {
 		return nil, err
@@ -120,6 +161,7 @@ func New(ctx context.Context, config *Config) (*Server, error) {
 			return nil, err
 		}
 	}
+
 	return s, nil
 }
 
@@ -275,4 +317,49 @@ func trapClosedConnErr(err error) error {
 		return nil
 	}
 	return err
+}
+
+var (
+	// idReader is used for random id generation. This declaration allows us to
+	// replace it for testing.
+	idReader = rand.Reader
+)
+
+// parameters for random identifier generation. We can tweak this when there is
+// time for further analysis.
+const (
+	randomIDEntropyBytes = 17
+	randomIDBase         = 36
+
+	// To ensure that all identifiers are fixed length, we make sure they
+	// get padded out or truncated to 25 characters.
+	//
+	// For academics,  f5lxx1zz5pnorynqglhzmsp33  == 2^128 - 1. This value
+	// was calculated from floor(log(2^128-1, 36)) + 1.
+	//
+	// While 128 bits is the largest whole-byte size that fits into 25
+	// base-36 characters, we generate an extra byte of entropy to fill
+	// in the high bits, which would otherwise be 0. This gives us a more
+	// even distribution of the first character.
+	//
+	// See http://mathworld.wolfram.com/NumberLength.html for more information.
+	maxRandomIDLength = 25
+)
+
+// NewID generates a new identifier for use where random identifiers with low
+// collision probability are required.
+//
+// With the parameters in this package, the generated identifier will provide
+// ~129 bits of entropy encoded with base36. Leading padding is added if the
+// string is less 25 bytes. We do not intend to maintain this interface, so
+// identifiers should be treated opaquely.
+func newID() string {
+	var p [randomIDEntropyBytes]byte
+
+	if _, err := io.ReadFull(idReader, p[:]); err != nil {
+		panic(fmt.Errorf("failed to read random bytes: %v", err))
+	}
+
+	p[0] |= 0x80 // set high bit to avoid the need for padding
+	return (&big.Int{}).SetBytes(p[:]).Text(randomIDBase)[1 : maxRandomIDLength+1]
 }


### PR DESCRIPTION
The change provides a plugin for the containerd instance to export a
unique id for each containerd instance. The id is such that if the
entire root directory, such as `/var/lib/containerd`, is removed, the
instance will get a new id. This is also a solid place to export other
values that describe the configuration of the containerd instance.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

Closes #1862