### PR TITLE
Implement btrfs usage

### DIFF
--- a/fs/du.go
+++ b/fs/du.go
@@ -1,5 +1,7 @@
 package fs
 
+import "context"
+
 // Usage of disk information
 type Usage struct {
 	Inodes int64
@@ -10,4 +12,11 @@ type Usage struct {
 // path.
 func DiskUsage(roots ...string) (Usage, error) {
 	return diskUsage(roots...)
+}
+
+// DiffUsage counts the numbers of inodes and disk usage in the
+// diff between the 2 directories. The first path is intended
+// as the base directory and the second as the changed directory.
+func DiffUsage(ctx context.Context, a, b string) (Usage, error) {
+	return diffUsage(ctx, a, b)
 }

--- a/fs/du_unix.go
+++ b/fs/du_unix.go
@@ -3,17 +3,19 @@
 package fs
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"syscall"
 )
 
+type inode struct {
+	// TODO(stevvooe): Can probably reduce memory usage by not tracking
+	// device, but we can leave this right for now.
+	dev, ino uint64
+}
+
 func diskUsage(roots ...string) (Usage, error) {
-	type inode struct {
-		// TODO(stevvooe): Can probably reduce memory usage by not tracking
-		// device, but we can leave this right for now.
-		dev, ino uint64
-	}
 
 	var (
 		size   int64
@@ -38,6 +40,40 @@ func diskUsage(roots ...string) (Usage, error) {
 		}); err != nil {
 			return Usage{}, err
 		}
+	}
+
+	return Usage{
+		Inodes: int64(len(inodes)),
+		Size:   size,
+	}, nil
+}
+
+func diffUsage(ctx context.Context, a, b string) (Usage, error) {
+	var (
+		size   int64
+		inodes = map[inode]struct{}{} // expensive!
+	)
+
+	if err := Changes(ctx, a, b, func(kind ChangeKind, _ string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if kind == ChangeKindAdd || kind == ChangeKindModify {
+			stat := fi.Sys().(*syscall.Stat_t)
+
+			inoKey := inode{dev: uint64(stat.Dev), ino: uint64(stat.Ino)}
+			if _, ok := inodes[inoKey]; !ok {
+				inodes[inoKey] = struct{}{}
+				size += fi.Size()
+			}
+
+			return nil
+
+		}
+		return nil
+	}); err != nil {
+		return Usage{}, err
 	}
 
 	return Usage{

--- a/fs/du_windows.go
+++ b/fs/du_windows.go
@@ -3,6 +3,7 @@
 package fs
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 )
@@ -25,6 +26,32 @@ func diskUsage(roots ...string) (Usage, error) {
 		}); err != nil {
 			return Usage{}, err
 		}
+	}
+
+	return Usage{
+		Size: size,
+	}, nil
+}
+
+func diffUsage(ctx context.Context, a, b string) (Usage, error) {
+	var (
+		size int64
+	)
+
+	if err := Changes(ctx, a, b, func(kind ChangeKind, _ string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if kind == ChangeKindAdd || kind == ChangeKindModify {
+			size += fi.Size()
+
+			return nil
+
+		}
+		return nil
+	}); err != nil {
+		return Usage{}, err
 	}
 
 	return Usage{


### PR DESCRIPTION
Implements btrfs usage using a double walking diff and counting the result. Walking gives the most accurate count and includes inode usage.

This is an alternative implementation to #1836 using our naive diff implementation instead of relying on btrfs quotas. The efficacy of btrfs quotas for filling in this usage has not been proven. There is still a use for quotas in implementing snapshot quotas in the future, but trusting the value is accurate and consistent on commit would require much more testing and research. The naive diff is slower but will always provide a consistent result.

Closes #1836