### PR TITLE
Emit unmodified change events for directories

### DIFF
--- a/fs/diff.go
+++ b/fs/diff.go
@@ -222,8 +222,10 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b string) (err 
 		c1 = make(chan *currentPath)
 		c2 = make(chan *currentPath)
 
-		f1, f2 *currentPath
-		rmdir  string
+		f1, f2         *currentPath
+		rmdir          string
+		lastEmittedDir = string(filepath.Separator)
+		parents        []os.FileInfo
 	)
 	g.Go(func() error {
 		defer close(c1)
@@ -258,7 +260,10 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b string) (err 
 				continue
 			}
 
-			var f os.FileInfo
+			var (
+				f    os.FileInfo
+				emit = true
+			)
 			k, p := pathChange(f1, f2)
 			switch k {
 			case ChangeKindAdd:
@@ -294,17 +299,83 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b string) (err 
 				f2 = nil
 				if same {
 					if !isLinked(f) {
-						continue
+						emit = false
 					}
 					k = ChangeKindUnmodified
 				}
 			}
-			if err := changeFn(k, p, f, nil); err != nil {
-				return err
+			if emit {
+				emittedDir, emitParents := commonParents(lastEmittedDir, p, parents)
+				for _, pf := range emitParents {
+					p := filepath.Join(emittedDir, pf.Name())
+					if err := changeFn(ChangeKindUnmodified, p, pf, nil); err != nil {
+						return err
+					}
+					emittedDir = p
+				}
+
+				if err := changeFn(k, p, f, nil); err != nil {
+					return err
+				}
+
+				if f != nil && f.IsDir() {
+					lastEmittedDir = p
+				} else {
+					lastEmittedDir = emittedDir
+				}
+
+				parents = parents[:0]
+			} else if f.IsDir() {
+				lastEmittedDir, parents = commonParents(lastEmittedDir, p, parents)
+				parents = append(parents, f)
 			}
 		}
 		return nil
 	})
 
 	return g.Wait()
+}
+
+func commonParents(base, updated string, dirs []os.FileInfo) (string, []os.FileInfo) {
+	if basePrefix := makePrefix(base); strings.HasPrefix(updated, basePrefix) {
+		var (
+			parents []os.FileInfo
+			last    = base
+		)
+		for _, d := range dirs {
+			next := filepath.Join(last, d.Name())
+			if strings.HasPrefix(updated, makePrefix(last)) {
+				parents = append(parents, d)
+				last = next
+			} else {
+				break
+			}
+		}
+		return base, parents
+	}
+
+	baseS := strings.Split(base, string(filepath.Separator))
+	updatedS := strings.Split(updated, string(filepath.Separator))
+	commonS := []string{string(filepath.Separator)}
+
+	min := len(baseS)
+	if len(updatedS) < min {
+		min = len(updatedS)
+	}
+	for i := 0; i < min; i++ {
+		if baseS[i] == updatedS[i] {
+			commonS = append(commonS, baseS[i])
+		} else {
+			break
+		}
+	}
+
+	return filepath.Join(commonS...), []os.FileInfo{}
+}
+
+func makePrefix(d string) string {
+	if d == "" || d[len(d)-1] != filepath.Separator {
+		return d + string(filepath.Separator)
+	}
+	return d
 }

--- a/fs/fstest/testsuite.go
+++ b/fs/fstest/testsuite.go
@@ -19,6 +19,7 @@ func FSSuite(t *testing.T, a TestApplier) {
 	t.Run("Deletion", makeTest(t, a, deletionTest))
 	t.Run("Update", makeTest(t, a, updateTest))
 	t.Run("DirectoryPermission", makeTest(t, a, directoryPermissionsTest))
+	t.Run("ParentDirectoryPermission", makeTest(t, a, parentDirectoryPermissionsTest))
 	t.Run("HardlinkUnmodified", makeTest(t, a, hardlinkUnmodified))
 	t.Run("HardlinkBeforeUnmodified", makeTest(t, a, hardlinkBeforeUnmodified))
 	t.Run("HardlinkBeforeModified", makeTest(t, a, hardlinkBeforeModified))
@@ -156,6 +157,28 @@ var (
 			CreateFile("/d1/d/f", []byte("irrelevant"), 0644),
 			CreateFile("/d2/f", []byte("irrelevant"), 0644),
 			CreateFile("/d3/f", []byte("irrelevant"), 0644),
+		),
+	}
+
+	// parentDirectoryPermissionsTest covers directory permissions for updated
+	// files
+	parentDirectoryPermissionsTest = []Applier{
+		Apply(
+			CreateDir("/d1", 0700),
+			CreateDir("/d1/a", 0700),
+			CreateDir("/d1/a/b", 0700),
+			CreateDir("/d1/a/b/c", 0700),
+			CreateFile("/d1/a/b/f", []byte("content1"), 0644),
+			CreateDir("/d2", 0751),
+			CreateDir("/d2/a/b", 0751),
+			CreateDir("/d2/a/b/c", 0751),
+			CreateFile("/d2/a/b/f", []byte("content1"), 0644),
+		),
+		Apply(
+			CreateFile("/d1/a/b/f", []byte("content1"), 0644),
+			Chmod("/d1/a/b/c", 0700),
+			CreateFile("/d2/a/b/f", []byte("content2"), 0644),
+			Chmod("/d2/a/b/c", 0751),
 		),
 	}
 


### PR DESCRIPTION
When a file changes, emit events for the seen parent directories to ensure that those parents are included in change streams such as archives. The parents are needed accurately recreate diff representation apart from a parent (such as overlay and aufs graph driversin Docker).

I didn't want to include it in this PR but this can be verified using a diff subcommand on containers https://github.com/dmcgowan/containerd/commit/d6105cb6104454fc1c65f3f589a1e795f1d3579a

Note: 
The tests cannot hit the original issue associated with this image due to tar application always occurring on top of the parent rather than in isolation.

Fixes #1723
