### PR TITLE
solve some bug for unmount and improve 

### DIFF
--- a/mount/mount.go
+++ b/mount/mount.go
@@ -1,5 +1,13 @@
 package mount
 
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/containerd/containerd/log"
+	"github.com/pkg/errors"
+)
+
 // Mount is the lingua franca of containerd. A mount represents a
 // serialized mount syscall. Components either emit or consume mounts.
 type Mount struct {
@@ -19,6 +27,47 @@ func All(mounts []Mount, target string) error {
 		if err := m.Mount(target); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// WithTempMount mounts the provided mounts to a temp dir, and pass the temp dir to f.
+// The mounts are valid during the call to the f.
+// Finally we will unmount and remove the temp dir regardless of the result of f.
+func WithTempMount(mounts []Mount, f func(root string) error) (err error) {
+	root, uerr := ioutil.TempDir("", "containerd-WithTempMount")
+	if uerr != nil {
+		return errors.Wrapf(uerr, "failed to create temp dir for %v", mounts)
+	}
+	// We use Remove here instead of RemoveAll.
+	// The RemoveAll will delete the temp dir and all children it contains.
+	// When the Unmount fails, if we use RemoveAll, We will incorrectly delete data from mounted dir.
+	// if we use Remove,even though we won't successfully delete the temp dir,
+	// but we only leak a temp dir, we don't loss data from mounted dir.
+	// For details, please refer to #1868 #1785.
+	defer func() {
+		if uerr = os.Remove(root); uerr != nil {
+			log.L.Errorf("Failed to remove the temp dir %s: %v", root, uerr)
+		}
+	}()
+
+	// We should do defer first, if not we will not do Unmount when only a part of Mounts are failed.
+	defer func() {
+		if uerr = UnmountAll(root, 0); uerr != nil {
+			uerr = errors.Wrapf(uerr, "failed to unmount %s", root)
+			if err == nil {
+				err = uerr
+			} else {
+				err = errors.Wrap(err, uerr.Error())
+			}
+		}
+	}()
+	if uerr = All(mounts, root); uerr != nil {
+		return errors.Wrapf(uerr, "failed to mount %s", root)
+	}
+
+	if uerr = f(root); uerr != nil {
+		return errors.Wrapf(uerr, "failed to f(%s)", root)
 	}
 	return nil
 }

--- a/oci/spec_opts_unix.go
+++ b/oci/spec_opts_unix.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -271,49 +270,35 @@ func WithUserID(uid uint32) SpecOpts {
 		if err != nil {
 			return err
 		}
-		root, err := ioutil.TempDir("", "ctd-username")
-		if err != nil {
-			return err
-		}
-		defer os.Remove(root)
-		for _, m := range mounts {
-			if err := m.Mount(root); err != nil {
+
+		return mount.WithTempMount(mounts, func(root string) error {
+			ppath, err := fs.RootPath(root, "/etc/passwd")
+			if err != nil {
 				return err
 			}
-		}
-		defer func() {
-			if uerr := mount.Unmount(root, 0); uerr != nil {
-				if err == nil {
-					err = uerr
+			f, err := os.Open(ppath)
+			if err != nil {
+				if os.IsNotExist(err) {
+					s.Process.User.UID, s.Process.User.GID = uid, uid
+					return nil
 				}
+				return err
 			}
-		}()
-		ppath, err := fs.RootPath(root, "/etc/passwd")
-		if err != nil {
-			return err
-		}
-		f, err := os.Open(ppath)
-		if err != nil {
-			if os.IsNotExist(err) {
+			defer f.Close()
+			users, err := user.ParsePasswdFilter(f, func(u user.User) bool {
+				return u.Uid == int(uid)
+			})
+			if err != nil {
+				return err
+			}
+			if len(users) == 0 {
 				s.Process.User.UID, s.Process.User.GID = uid, uid
 				return nil
 			}
-			return err
-		}
-		defer f.Close()
-		users, err := user.ParsePasswdFilter(f, func(u user.User) bool {
-			return u.Uid == int(uid)
-		})
-		if err != nil {
-			return err
-		}
-		if len(users) == 0 {
-			s.Process.User.UID, s.Process.User.GID = uid, uid
+			u := users[0]
+			s.Process.User.UID, s.Process.User.GID = uint32(u.Uid), uint32(u.Gid)
 			return nil
-		}
-		u := users[0]
-		s.Process.User.UID, s.Process.User.GID = uint32(u.Uid), uint32(u.Gid)
-		return nil
+		})
 	}
 }
 
@@ -334,43 +319,28 @@ func WithUsername(username string) SpecOpts {
 		if err != nil {
 			return err
 		}
-		root, err := ioutil.TempDir("", "ctd-username")
-		if err != nil {
-			return err
-		}
-		defer os.Remove(root)
-		for _, m := range mounts {
-			if err := m.Mount(root); err != nil {
+		return mount.WithTempMount(mounts, func(root string) error {
+			ppath, err := fs.RootPath(root, "/etc/passwd")
+			if err != nil {
 				return err
 			}
-		}
-		defer func() {
-			if uerr := mount.Unmount(root, 0); uerr != nil {
-				if err == nil {
-					err = uerr
-				}
+			f, err := os.Open(ppath)
+			if err != nil {
+				return err
 			}
-		}()
-		ppath, err := fs.RootPath(root, "/etc/passwd")
-		if err != nil {
-			return err
-		}
-		f, err := os.Open(ppath)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-		users, err := user.ParsePasswdFilter(f, func(u user.User) bool {
-			return u.Name == username
+			defer f.Close()
+			users, err := user.ParsePasswdFilter(f, func(u user.User) bool {
+				return u.Name == username
+			})
+			if err != nil {
+				return err
+			}
+			if len(users) == 0 {
+				return errors.Errorf("no users found for %s", username)
+			}
+			u := users[0]
+			s.Process.User.UID, s.Process.User.GID = uint32(u.Uid), uint32(u.Gid)
+			return nil
 		})
-		if err != nil {
-			return err
-		}
-		if len(users) == 0 {
-			return errors.Errorf("no users found for %s", username)
-		}
-		u := users[0]
-		s.Process.User.UID, s.Process.User.GID = uint32(u.Uid), uint32(u.Gid)
-		return nil
 	}
 }


### PR DESCRIPTION
Signed-off-by: yason <yan.xuean@zte.com.cn>
ref #1785 

goals:
1. when the other place is error in diff.Apply, the error message of unmount cann't be outputed
2. solve some bug for unmount.  and  improve maintainability. 
   for example:  
   We will not do Unmount when only partful Mount fail.
```
func remapRootFS(mounts []mount.Mount, uid, gid uint32) error {
	root, err := ioutil.TempDir("", "ctd-remap")
	if err != nil {
		return err
	}
	defer os.Remove(root)
	for _, m := range mounts {
		if err := m.Mount(root); err != nil {
			return err
		}
	}
	err = filepath.Walk(root, incrementFS(root, uid, gid))
	if uerr := mount.Unmount(root, 0); err == nil {
		err = uerr
	}
	return err
}
```
 