### PR TITLE
Always IO.Cancel() before IO.Close()

### DIFF
--- a/cio/io.go
+++ b/cio/io.go
@@ -24,11 +24,12 @@ type Config struct {
 type IO interface {
 	// Config returns the IO configuration.
 	Config() Config
-	// Cancel aborts all current io operations
+	// Cancel aborts all current io operations.
 	Cancel()
-	// Wait blocks until all io copy operations have completed
+	// Wait blocks until all io copy operations have completed.
 	Wait()
-	// Close cleans up all open io resources
+	// Close cleans up all open io resources. Cancel() is always called before
+	// Close()
 	Close() error
 }
 

--- a/process.go
+++ b/process.go
@@ -191,6 +191,7 @@ func (p *process) Delete(ctx context.Context, opts ...ProcessDeleteOpts) (*ExitS
 		return nil, errdefs.FromGRPC(err)
 	}
 	if p.io != nil {
+		p.io.Cancel()
 		p.io.Wait()
 		p.io.Close()
 	}

--- a/task.go
+++ b/task.go
@@ -163,6 +163,7 @@ func (t *task) Start(ctx context.Context) error {
 		ContainerID: t.id,
 	})
 	if err != nil {
+		t.io.Cancel()
 		t.io.Close()
 		return errdefs.FromGRPC(err)
 	}


### PR DESCRIPTION
In most cases `IO.Cancel()` was called before `IO.Close()`, with two exceptions (see the diff). This meant that any implementation of `IO` would have to `Cancel()` itself in `Close()`.

This PR documents that `containerd` will always call `Cancel()` first, and fixes the two places where it was not already called.