### PR TITLE
Refactor cio package

### DIFF
--- a/cio/io.go
+++ b/cio/io.go
@@ -33,8 +33,8 @@ type IO interface {
 	Close() error
 }
 
-// Creation creates new IO sets for a task
-type Creation func(id string) (IO, error)
+// Creator creates new IO sets for a task
+type Creator func(id string) (IO, error)
 
 // Attach allows callers to reattach to running tasks
 //
@@ -61,13 +61,13 @@ func NewFIFOSet(config Config, close func() error) *FIFOSet {
 	return &FIFOSet{Config: config, close: close}
 }
 
-// NewIO returns an Creation that will provide IO sets without a terminal
-func NewIO(stdin io.Reader, stdout, stderr io.Writer) Creation {
+// NewIO returns an Creator that will provide IO sets without a terminal
+func NewIO(stdin io.Reader, stdout, stderr io.Writer) Creator {
 	return NewIOWithTerminal(stdin, stdout, stderr, false)
 }
 
 // NewIOWithTerminal creates a new io set with the provided io.Reader/Writers for use with a terminal
-func NewIOWithTerminal(stdin io.Reader, stdout, stderr io.Writer, terminal bool) Creation {
+func NewIOWithTerminal(stdin io.Reader, stdout, stderr io.Writer, terminal bool) Creator {
 	return func(id string) (IO, error) {
 		fifos, err := newFIFOSetInTempDir(id)
 		if err != nil {

--- a/cio/io_test.go
+++ b/cio/io_test.go
@@ -1,0 +1,132 @@
+// +build !windows
+
+package cio
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/containerd/fifo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func assertHasPrefix(t *testing.T, s, prefix string) {
+	t.Helper()
+	if !strings.HasPrefix(s, prefix) {
+		t.Fatalf("expected %s to start with %s", s, prefix)
+	}
+}
+
+func TestNewFIFOSetInDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("NewFIFOSetInDir has different behaviour on windows")
+	}
+
+	root, err := ioutil.TempDir("", "test-new-fifo-set")
+	require.NoError(t, err)
+	defer os.RemoveAll(root)
+
+	fifos, err := NewFIFOSetInDir(root, "theid", true)
+	require.NoError(t, err)
+
+	assertHasPrefix(t, fifos.Stdin, root)
+	assertHasPrefix(t, fifos.Stdout, root)
+	assertHasPrefix(t, fifos.Stderr, root)
+	assert.Equal(t, "theid-stdin", filepath.Base(fifos.Stdin))
+	assert.Equal(t, "theid-stdout", filepath.Base(fifos.Stdout))
+	assert.Equal(t, "theid-stderr", filepath.Base(fifos.Stderr))
+	assert.Equal(t, true, fifos.Terminal)
+
+	files, err := ioutil.ReadDir(root)
+	require.NoError(t, err)
+	assert.Len(t, files, 1)
+
+	require.NoError(t, fifos.Close())
+	files, err = ioutil.ReadDir(root)
+	require.NoError(t, err)
+	assert.Len(t, files, 0)
+}
+
+func TestNewAttach(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("setupFIFOProducers not yet implemented on windows")
+	}
+	var (
+		expectedStdin  = "this is the stdin"
+		expectedStdout = "this is the stdout"
+		expectedStderr = "this is the stderr"
+		stdin          = bytes.NewBufferString(expectedStdin)
+		stdout         = new(bytes.Buffer)
+		stderr         = new(bytes.Buffer)
+	)
+
+	withBytesBuffers := func(streams *Streams) {
+		*streams = Streams{Stdin: stdin, Stdout: stdout, Stderr: stderr}
+	}
+	attacher := NewAttach(withBytesBuffers)
+
+	fifos, err := NewFIFOSetInDir("", "theid", false)
+	require.NoError(t, err)
+
+	io, err := attacher(fifos)
+	require.NoError(t, err)
+	defer io.Close()
+
+	producers := setupFIFOProducers(t, io.Config())
+	initProducers(t, producers, expectedStdout, expectedStderr)
+
+	actualStdin, err := ioutil.ReadAll(producers.Stdin)
+	require.NoError(t, err)
+
+	io.Cancel()
+	io.Wait()
+	assert.NoError(t, io.Close())
+
+	assert.Equal(t, expectedStdout, stdout.String())
+	assert.Equal(t, expectedStderr, stderr.String())
+	assert.Equal(t, expectedStdin, string(actualStdin))
+}
+
+type producers struct {
+	Stdin  io.ReadCloser
+	Stdout io.WriteCloser
+	Stderr io.WriteCloser
+}
+
+func setupFIFOProducers(t *testing.T, fifos Config) producers {
+	var (
+		err   error
+		pipes producers
+		ctx   = context.Background()
+	)
+
+	pipes.Stdin, err = fifo.OpenFifo(ctx, fifos.Stdin, syscall.O_RDONLY, 0)
+	require.NoError(t, err)
+
+	pipes.Stdout, err = fifo.OpenFifo(ctx, fifos.Stdout, syscall.O_WRONLY, 0)
+	require.NoError(t, err)
+
+	pipes.Stderr, err = fifo.OpenFifo(ctx, fifos.Stderr, syscall.O_WRONLY, 0)
+	require.NoError(t, err)
+
+	return pipes
+}
+
+func initProducers(t *testing.T, producers producers, stdout, stderr string) {
+	_, err := producers.Stdout.Write([]byte(stdout))
+	require.NoError(t, err)
+	require.NoError(t, producers.Stdout.Close())
+
+	_, err = producers.Stderr.Write([]byte(stderr))
+	require.NoError(t, err)
+	require.NoError(t, producers.Stderr.Close())
+}

--- a/cio/io_unix.go
+++ b/cio/io_unix.go
@@ -15,11 +15,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-// newFIFOSetInTempDir returns a new set of fifos for the task
-func newFIFOSetInTempDir(id string) (*FIFOSet, error) {
-	root := "/run/containerd/fifo"
-	if err := os.MkdirAll(root, 0700); err != nil {
-		return nil, err
+// NewFIFOSetInDir returns a new FIFOSet with paths in a temporary directory under root
+func NewFIFOSetInDir(root, id string, terminal bool) (*FIFOSet, error) {
+	if root != "" {
+		if err := os.MkdirAll(root, 0700); err != nil {
+			return nil, err
+		}
 	}
 	dir, err := ioutil.TempDir(root, "")
 	if err != nil {
@@ -29,18 +30,15 @@ func newFIFOSetInTempDir(id string) (*FIFOSet, error) {
 		return os.RemoveAll(dir)
 	}
 	return NewFIFOSet(Config{
-		Stdin:  filepath.Join(dir, id+"-stdin"),
-		Stdout: filepath.Join(dir, id+"-stdout"),
-		Stderr: filepath.Join(dir, id+"-stderr"),
+		Stdin:    filepath.Join(dir, id+"-stdin"),
+		Stdout:   filepath.Join(dir, id+"-stdout"),
+		Stderr:   filepath.Join(dir, id+"-stderr"),
+		Terminal: terminal,
 	}, closer), nil
 }
 
-func copyIO(fifos *FIFOSet, ioset *ioSet) (*cio, error) {
-	var (
-		ctx, cancel = context.WithCancel(context.Background())
-		wg          = &sync.WaitGroup{}
-	)
-
+func copyIO(fifos *FIFOSet, ioset *Streams) (*cio, error) {
+	var ctx, cancel = context.WithCancel(context.Background())
 	pipes, err := openFifos(ctx, fifos)
 	if err != nil {
 		cancel()
@@ -49,14 +47,15 @@ func copyIO(fifos *FIFOSet, ioset *ioSet) (*cio, error) {
 
 	if fifos.Stdin != "" {
 		go func() {
-			io.Copy(pipes.Stdin, ioset.in)
+			io.Copy(pipes.Stdin, ioset.Stdin)
 			pipes.Stdin.Close()
 		}()
 	}
 
+	var wg = &sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
-		io.Copy(ioset.out, pipes.Stdout)
+		io.Copy(ioset.Stdout, pipes.Stdout)
 		pipes.Stdout.Close()
 		wg.Done()
 	}()
@@ -64,12 +63,13 @@ func copyIO(fifos *FIFOSet, ioset *ioSet) (*cio, error) {
 	if !fifos.Terminal {
 		wg.Add(1)
 		go func() {
-			io.Copy(ioset.err, pipes.Stderr)
+			io.Copy(ioset.Stderr, pipes.Stderr)
 			pipes.Stderr.Close()
 			wg.Done()
 		}()
 	}
 	return &cio{
+		config:  fifos.Config,
 		wg:      wg,
 		closers: append(pipes.closers(), fifos),
 		cancel:  cancel,
@@ -78,41 +78,38 @@ func copyIO(fifos *FIFOSet, ioset *ioSet) (*cio, error) {
 
 func openFifos(ctx context.Context, fifos *FIFOSet) (pipes, error) {
 	var err error
-	f := new(pipes)
-
 	defer func() {
 		if err != nil {
 			fifos.Close()
 		}
 	}()
 
+	var f pipes
 	if fifos.Stdin != "" {
 		if f.Stdin, err = fifo.OpenFifo(ctx, fifos.Stdin, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
-			return pipes{}, errors.Wrapf(err, "failed to open stdin fifo")
+			return f, errors.Wrapf(err, "failed to open stdin fifo")
 		}
 	}
-	if f.Stdout, err = fifo.OpenFifo(ctx, fifos.Stdout, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
-		f.Stdin.Close()
-		return pipes{}, errors.Wrapf(err, "failed to open stdout fifo")
+	if fifos.Stdout != "" {
+		if f.Stdout, err = fifo.OpenFifo(ctx, fifos.Stdout, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
+			f.Stdin.Close()
+			return f, errors.Wrapf(err, "failed to open stdout fifo")
+		}
 	}
-	if f.Stderr, err = fifo.OpenFifo(ctx, fifos.Stderr, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
-		f.Stdin.Close()
-		f.Stdout.Close()
-		return pipes{}, errors.Wrapf(err, "failed to open stderr fifo")
+	if fifos.Stderr != "" {
+		if f.Stderr, err = fifo.OpenFifo(ctx, fifos.Stderr, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
+			f.Stdin.Close()
+			f.Stdout.Close()
+			return f, errors.Wrapf(err, "failed to open stderr fifo")
+		}
 	}
-	return pipes{}, nil
+	return f, nil
 }
 
 // NewDirectIO returns an IO implementation that exposes the IO streams as io.ReadCloser
-// and io.WriteCloser. FIFOs are created in /run/containerd/fifo.
-func NewDirectIO(ctx context.Context, terminal bool) (*DirectIO, error) {
-	fifos, err := newFIFOSetInTempDir("")
-	if err != nil {
-		return nil, err
-	}
-	fifos.Terminal = terminal
-
-	ctx, cancel := context.WithCancel(context.Background())
+// and io.WriteCloser.
+func NewDirectIO(ctx context.Context, fifos *FIFOSet) (*DirectIO, error) {
+	ctx, cancel := context.WithCancel(ctx)
 	pipes, err := openFifos(ctx, fifos)
 	return &DirectIO{
 		pipes: pipes,
@@ -124,10 +121,6 @@ func NewDirectIO(ctx context.Context, terminal bool) (*DirectIO, error) {
 	}, err
 }
 
-// DirectIO allows task IO to be handled externally by the caller
-type DirectIO struct {
-	pipes
-	cio
+func (p *pipes) closers() []io.Closer {
+	return []io.Closer{p.Stdin, p.Stdout, p.Stderr}
 }
-
-var _ IO = &DirectIO{}

--- a/cio/io_unix.go
+++ b/cio/io_unix.go
@@ -12,10 +12,11 @@ import (
 	"syscall"
 
 	"github.com/containerd/fifo"
+	"github.com/pkg/errors"
 )
 
-// newFIFOSetTempDir returns a new set of fifos for the task
-func newFIFOSetTempDir(id string) (*FIFOSet, error) {
+// newFIFOSetInTempDir returns a new set of fifos for the task
+func newFIFOSetInTempDir(id string) (*FIFOSet, error) {
 	root := "/run/containerd/fifo"
 	if err := os.MkdirAll(root, 0700); err != nil {
 		return nil, err
@@ -34,142 +35,99 @@ func newFIFOSetTempDir(id string) (*FIFOSet, error) {
 	}, closer), nil
 }
 
-func copyIO(fifos *FIFOSet, ioset *ioSet, tty bool) (_ *wgCloser, err error) {
+func copyIO(fifos *FIFOSet, ioset *ioSet) (*cio, error) {
 	var (
-		f           io.ReadWriteCloser
 		ctx, cancel = context.WithCancel(context.Background())
 		wg          = &sync.WaitGroup{}
 	)
-	set := []io.Closer{fifos}
-	defer func() {
-		if err != nil {
-			for _, f := range set {
-				f.Close()
-			}
-			cancel()
-		}
+
+	pipes, err := openFifos(ctx, fifos)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	if fifos.Stdin != "" {
+		go func() {
+			io.Copy(pipes.Stdin, ioset.in)
+			pipes.Stdin.Close()
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		io.Copy(ioset.out, pipes.Stdout)
+		pipes.Stdout.Close()
+		wg.Done()
 	}()
 
-	if f, err = fifo.OpenFifo(ctx, fifos.Stdin, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
-		return nil, err
-	}
-	set = append(set, f)
-	go func(w io.WriteCloser) {
-		io.Copy(w, ioset.in)
-		w.Close()
-	}(f)
-
-	if f, err = fifo.OpenFifo(ctx, fifos.Stdout, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
-		return nil, err
-	}
-	set = append(set, f)
-	wg.Add(1)
-	go func(r io.ReadCloser) {
-		io.Copy(ioset.out, r)
-		r.Close()
-		wg.Done()
-	}(f)
-
-	if f, err = fifo.OpenFifo(ctx, fifos.Stderr, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
-		return nil, err
-	}
-	set = append(set, f)
-
-	if !tty {
+	if !fifos.Terminal {
 		wg.Add(1)
-		go func(r io.ReadCloser) {
-			io.Copy(ioset.err, r)
-			r.Close()
+		go func() {
+			io.Copy(ioset.err, pipes.Stderr)
+			pipes.Stderr.Close()
 			wg.Done()
-		}(f)
+		}()
 	}
-	return &wgCloser{
-		wg:     wg,
-		set:    set,
-		cancel: cancel,
+	return &cio{
+		wg:      wg,
+		closers: append(pipes.closers(), fifos),
+		cancel:  cancel,
 	}, nil
 }
 
-// NewDirectIO returns an IO implementation that exposes the pipes directly
-func NewDirectIO(ctx context.Context, terminal bool) (*DirectIO, error) {
-	set, err := newFIFOSetTempDir("")
-	if err != nil {
-		return nil, err
-	}
-	set.Terminal = terminal
-	f := &DirectIO{set: set}
+func openFifos(ctx context.Context, fifos *FIFOSet) (pipes, error) {
+	var err error
+	f := new(pipes)
 
 	defer func() {
 		if err != nil {
-			f.Delete()
+			fifos.Close()
 		}
 	}()
-	if f.Stdin, err = fifo.OpenFifo(ctx, set.Stdin, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
-		return nil, err
+
+	if fifos.Stdin != "" {
+		if f.Stdin, err = fifo.OpenFifo(ctx, fifos.Stdin, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
+			return pipes{}, errors.Wrapf(err, "failed to open stdin fifo")
+		}
 	}
-	if f.Stdout, err = fifo.OpenFifo(ctx, set.Stdout, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
+	if f.Stdout, err = fifo.OpenFifo(ctx, fifos.Stdout, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
 		f.Stdin.Close()
-		return nil, err
+		return pipes{}, errors.Wrapf(err, "failed to open stdout fifo")
 	}
-	if f.Stderr, err = fifo.OpenFifo(ctx, set.Stderr, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
+	if f.Stderr, err = fifo.OpenFifo(ctx, fifos.Stderr, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
 		f.Stdin.Close()
 		f.Stdout.Close()
+		return pipes{}, errors.Wrapf(err, "failed to open stderr fifo")
+	}
+	return pipes{}, nil
+}
+
+// NewDirectIO returns an IO implementation that exposes the IO streams as io.ReadCloser
+// and io.WriteCloser. FIFOs are created in /run/containerd/fifo.
+func NewDirectIO(ctx context.Context, terminal bool) (*DirectIO, error) {
+	fifos, err := newFIFOSetInTempDir("")
+	if err != nil {
 		return nil, err
 	}
-	return f, nil
+	fifos.Terminal = terminal
+
+	ctx, cancel := context.WithCancel(context.Background())
+	pipes, err := openFifos(ctx, fifos)
+	return &DirectIO{
+		pipes: pipes,
+		cio: cio{
+			config:  fifos.Config,
+			closers: append(pipes.closers(), fifos),
+			cancel:  cancel,
+		},
+	}, err
 }
 
 // DirectIO allows task IO to be handled externally by the caller
 type DirectIO struct {
-	Stdin  io.WriteCloser
-	Stdout io.ReadCloser
-	Stderr io.ReadCloser
-
-	set *FIFOSet
+	pipes
+	cio
 }
 
-// IOCreate returns IO avaliable for use with task creation
-func (f *DirectIO) IOCreate(id string) (IO, error) {
-	return f, nil
-}
-
-// IOAttach returns IO avaliable for use with task attachment
-func (f *DirectIO) IOAttach(set *FIFOSet) (IO, error) {
-	return f, nil
-}
-
-// Config returns the Config
-func (f *DirectIO) Config() Config {
-	return f.set.Config
-}
-
-// Cancel stops any IO copy operations
-//
-// Not applicable for DirectIO
-func (f *DirectIO) Cancel() {
-	// nothing to cancel as all operations are handled externally
-}
-
-// Wait on any IO copy operations
-//
-// Not applicable for DirectIO
-func (f *DirectIO) Wait() {
-	// nothing to wait on as all operations are handled externally
-}
-
-// Close closes all open fds
-func (f *DirectIO) Close() error {
-	err := f.Stdin.Close()
-	if err2 := f.Stdout.Close(); err == nil {
-		err = err2
-	}
-	if err2 := f.Stderr.Close(); err == nil {
-		err = err2
-	}
-	return err
-}
-
-// Delete removes the underlying directory containing fifos
-func (f *DirectIO) Delete() error {
-	return f.set.Close()
-}
+var _ IO = &DirectIO{}

--- a/cio/io_windows.go
+++ b/cio/io_windows.go
@@ -13,26 +13,26 @@ import (
 
 const pipeRoot = `\\.\pipe`
 
-// newFIFOSetInTempDir returns a new set of fifos for the task
-func newFIFOSetInTempDir(id string) (*FIFOSet, error) {
-	return &FIFOSet{
-		StdIn:  fmt.Sprintf(`%s\ctr-%s-stdin`, pipeRoot, id),
-		StdOut: fmt.Sprintf(`%s\ctr-%s-stdout`, pipeRoot, id),
-		StdErr: fmt.Sprintf(`%s\ctr-%s-stderr`, pipeRoot, id),
-	}, nil
+// NewFIFOSetInDir returns a new set of fifos for the task
+func NewFIFOSetInDir(_, id string, terminal bool) (*FIFOSet, error) {
+	return NewFIFOSet(Config{
+		Terminal: terminal,
+		Stdin:    fmt.Sprintf(`%s\ctr-%s-stdin`, pipeRoot, id),
+		Stdout:   fmt.Sprintf(`%s\ctr-%s-stdout`, pipeRoot, id),
+		Stderr:   fmt.Sprintf(`%s\ctr-%s-stderr`, pipeRoot, id),
+	}, nil), nil
 }
 
-func copyIO(fifos *FIFOSet, ioset *ioSet) (*cio, error) {
+func copyIO(fifos *FIFOSet, ioset *Streams) (*cio, error) {
 	var (
-		err error
 		wg  sync.WaitGroup
 		set []io.Closer
 	)
 
-	if fifos.StdIn != "" {
-		l, err := winio.ListenPipe(fifos.StdIn, nil)
+	if fifos.Stdin != "" {
+		l, err := winio.ListenPipe(fifos.Stdin, nil)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create stdin pipe %s", fifos.StdIn)
+			return nil, errors.Wrapf(err, "failed to create stdin pipe %s", fifos.Stdin)
 		}
 		defer func(l net.Listener) {
 			if err != nil {
@@ -44,45 +44,19 @@ func copyIO(fifos *FIFOSet, ioset *ioSet) (*cio, error) {
 		go func() {
 			c, err := l.Accept()
 			if err != nil {
-				log.L.WithError(err).Errorf("failed to accept stdin connection on %s", fifos.StdIn)
+				log.L.WithError(err).Errorf("failed to accept stdin connection on %s", fifos.Stdin)
 				return
 			}
-			io.Copy(c, ioset.in)
+			io.Copy(c, ioset.Stdin)
 			c.Close()
 			l.Close()
 		}()
 	}
 
-	if fifos.StdOut != "" {
-		l, err := winio.ListenPipe(fifos.StdOut, nil)
+	if fifos.Stdout != "" {
+		l, err := winio.ListenPipe(fifos.Stdout, nil)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create stdin pipe %s", fifos.StdOut)
-		}
-		defer func(l net.Listener) {
-			if err != nil {
-				l.Close()
-			}
-		}(l)
-		set = append(set, l)
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			c, err := l.Accept()
-			if err != nil {
-				log.L.WithError(err).Errorf("failed to accept stdout connection on %s", fifos.StdOut)
-				return
-			}
-			io.Copy(ioset.out, c)
-			c.Close()
-			l.Close()
-		}()
-	}
-
-	if !fifos.Terminal && fifos.StdErr != "" {
-		l, err := winio.ListenPipe(fifos.StdErr, nil)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create stderr pipe %s", fifos.StdErr)
+			return nil, errors.Wrapf(err, "failed to create stdin pipe %s", fifos.Stdout)
 		}
 		defer func(l net.Listener) {
 			if err != nil {
@@ -96,23 +70,55 @@ func copyIO(fifos *FIFOSet, ioset *ioSet) (*cio, error) {
 			defer wg.Done()
 			c, err := l.Accept()
 			if err != nil {
-				log.L.WithError(err).Errorf("failed to accept stderr connection on %s", fifos.StdErr)
+				log.L.WithError(err).Errorf("failed to accept stdout connection on %s", fifos.Stdout)
 				return
 			}
-			io.Copy(ioset.err, c)
+			io.Copy(ioset.Stdout, c)
 			c.Close()
 			l.Close()
 		}()
 	}
 
-	return &cio{
-		wg:  &wg,
-		dir: fifos.Dir,
-		set: set,
-		cancel: func() {
-			for _, l := range set {
+	if !fifos.Terminal && fifos.Stderr != "" {
+		l, err := winio.ListenPipe(fifos.Stderr, nil)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create stderr pipe %s", fifos.Stderr)
+		}
+		defer func(l net.Listener) {
+			if err != nil {
 				l.Close()
 			}
+		}(l)
+		set = append(set, l)
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c, err := l.Accept()
+			if err != nil {
+				log.L.WithError(err).Errorf("failed to accept stderr connection on %s", fifos.Stderr)
+				return
+			}
+			io.Copy(ioset.Stderr, c)
+			c.Close()
+			l.Close()
+		}()
+	}
+
+	return &cio{config: fifos.Config, closers: set}, nil
+}
+
+// NewDirectIO returns an IO implementation that exposes the IO streams as io.ReadCloser
+// and io.WriteCloser.
+func NewDirectIO(stdin io.WriteCloser, stdout, stderr io.ReadCloser, terminal bool) *DirectIO {
+	return &DirectIO{
+		pipes: pipes{
+			Stdin:  stdin,
+			Stdout: stdout,
+			Stderr: stderr,
 		},
-	}, nil
+		cio: cio{
+			config: Config{Terminal: terminal},
+		},
+	}
 }

--- a/cmd/ctr/commands/tasks/attach.go
+++ b/cmd/ctr/commands/tasks/attach.go
@@ -1,8 +1,6 @@
 package tasks
 
 import (
-	"os"
-
 	"github.com/containerd/console"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/cmd/ctr/commands"
@@ -39,7 +37,7 @@ var attachCommand = cli.Command{
 				return err
 			}
 		}
-		task, err := container.Task(ctx, cio.WithAttach(os.Stdin, os.Stdout, os.Stderr))
+		task, err := container.Task(ctx, cio.NewAttach(cio.WithStdio))
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/tasks/exec.go
+++ b/cmd/ctr/commands/tasks/exec.go
@@ -60,9 +60,9 @@ var execCommand = cli.Command{
 		pspec.Terminal = tty
 		pspec.Args = args
 
-		ioCreator := cio.Stdio
+		ioCreator := cio.NewCreator(cio.WithStdio)
 		if tty {
-			ioCreator = cio.StdioTerminal
+			ioCreator = cio.NewCreator(cio.WithStdio, cio.WithTerminal)
 		}
 		process, err := task.Exec(ctx, context.String("exec-id"), pspec, ioCreator)
 		if err != nil {

--- a/cmd/ctr/commands/tasks/tasks_unix.go
+++ b/cmd/ctr/commands/tasks/tasks_unix.go
@@ -44,10 +44,11 @@ func HandleConsoleResize(ctx gocontext.Context, task resizer, con console.Consol
 
 // NewTask creates a new task
 func NewTask(ctx gocontext.Context, client *containerd.Client, container containerd.Container, checkpoint string, tty, nullIO bool) (containerd.Task, error) {
+	stdio := cio.NewCreator(cio.WithStdio)
 	if checkpoint == "" {
-		ioCreator := cio.Stdio
+		ioCreator := stdio
 		if tty {
-			ioCreator = cio.StdioTerminal
+			ioCreator = cio.NewCreator(cio.WithStdio, cio.WithTerminal)
 		}
 		if nullIO {
 			if tty {
@@ -61,5 +62,5 @@ func NewTask(ctx gocontext.Context, client *containerd.Client, container contain
 	if err != nil {
 		return nil, err
 	}
-	return container.NewTask(ctx, cio.Stdio, containerd.WithTaskCheckpoint(im))
+	return container.NewTask(ctx, stdio, containerd.WithTaskCheckpoint(im))
 }

--- a/cmd/ctr/commands/tasks/tasks_windows.go
+++ b/cmd/ctr/commands/tasks/tasks_windows.go
@@ -42,9 +42,9 @@ func HandleConsoleResize(ctx gocontext.Context, task resizer, con console.Consol
 
 // NewTask creates a new task
 func NewTask(ctx gocontext.Context, client *containerd.Client, container containerd.Container, _ string, tty, nullIO bool) (containerd.Task, error) {
-	ioCreator := cio.Stdio
+	ioCreator := cio.NewCreator(cio.WithStdio)
 	if tty {
-		ioCreator = cio.StdioTerminal
+		ioCreator = cio.NewCreator(cio.WithStdio, cio.WithTerminal)
 	}
 	if nullIO {
 		if tty {

--- a/container.go
+++ b/container.go
@@ -27,7 +27,7 @@ type Container interface {
 	// Delete removes the container
 	Delete(context.Context, ...DeleteOpts) error
 	// NewTask creates a new task based on the container metadata
-	NewTask(context.Context, cio.Creation, ...NewTaskOpts) (Task, error)
+	NewTask(context.Context, cio.Creator, ...NewTaskOpts) (Task, error)
 	// Spec returns the OCI runtime specification
 	Spec(context.Context) (*specs.Spec, error)
 	// Task returns the current task for the container
@@ -163,7 +163,7 @@ func (c *container) Image(ctx context.Context) (Image, error) {
 	}, nil
 }
 
-func (c *container) NewTask(ctx context.Context, ioCreate cio.Creation, opts ...NewTaskOpts) (_ Task, err error) {
+func (c *container) NewTask(ctx context.Context, ioCreate cio.Creator, opts ...NewTaskOpts) (_ Task, err error) {
 	i, err := ioCreate(c.id)
 	if err != nil {
 		return nil, err

--- a/container_linux_test.go
+++ b/container_linux_test.go
@@ -298,7 +298,7 @@ func TestContainerAttach(t *testing.T) {
 
 	expected := "hello" + newLine
 
-	direct, err := cio.NewDirectIO(ctx, false)
+	direct, err := newDirectIO(ctx)
 	if err != nil {
 		t.Error(err)
 		return
@@ -372,6 +372,49 @@ func TestContainerAttach(t *testing.T) {
 	}
 }
 
+func newDirectIO(ctx context.Context) (*directIO, error) {
+	dio, err := cio.NewDirectIO(ctx, false)
+	if err != nil {
+		return nil, err
+	}
+	return &directIO{DirectIO: *dio}, nil
+}
+
+type directIO struct {
+	cio.DirectIO
+}
+
+// ioCreate returns IO avaliable for use with task creation
+func (f *directIO) IOCreate(id string) (cio.IO, error) {
+	return f, nil
+}
+
+// ioAttach returns IO avaliable for use with task attachment
+func (f *directIO) IOAttach(set *cio.FIFOSet) (cio.IO, error) {
+	return f, nil
+}
+
+func (f *directIO) Cancel() {
+	// nothing to cancel as all operations are handled externally
+}
+
+// Close closes all open fds
+func (f *directIO) Close() error {
+	err := f.Stdin.Close()
+	if err2 := f.Stdout.Close(); err == nil {
+		err = err2
+	}
+	if err2 := f.Stderr.Close(); err == nil {
+		err = err2
+	}
+	return err
+}
+
+// Delete removes the underlying directory containing fifos
+func (f *directIO) Delete() error {
+	return f.DirectIO.Close()
+}
+
 func TestContainerUsername(t *testing.T) {
 	t.Parallel()
 
@@ -393,7 +436,7 @@ func TestContainerUsername(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	direct, err := cio.NewDirectIO(ctx, false)
+	direct, err := newDirectIO(ctx)
 	if err != nil {
 		t.Error(err)
 		return
@@ -486,7 +529,7 @@ func TestContainerAttachProcess(t *testing.T) {
 	expected := "hello" + newLine
 
 	// creating IO early for easy resource cleanup
-	direct, err := cio.NewDirectIO(ctx, false)
+	direct, err := newDirectIO(ctx)
 	if err != nil {
 		t.Error(err)
 		return
@@ -602,7 +645,7 @@ func TestContainerUserID(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	direct, err := cio.NewDirectIO(ctx, false)
+	direct, err := newDirectIO(ctx)
 	if err != nil {
 		t.Error(err)
 		return

--- a/container_test.go
+++ b/container_test.go
@@ -23,7 +23,7 @@ import (
 	gogotypes "github.com/gogo/protobuf/types"
 )
 
-func empty() cio.Creation {
+func empty() cio.Creator {
 	// TODO (@mlaventure) windows searches for pipes
 	// when none are provided
 	if runtime.GOOS == "windows" {

--- a/task.go
+++ b/task.go
@@ -123,7 +123,7 @@ type Task interface {
 	// Resume the execution of the task
 	Resume(context.Context) error
 	// Exec creates a new process inside the task
-	Exec(context.Context, string, *specs.Process, cio.Creation) (Process, error)
+	Exec(context.Context, string, *specs.Process, cio.Creator) (Process, error)
 	// Pids returns a list of system specific process ids inside the task
 	Pids(context.Context) ([]ProcessInfo, error)
 	// Checkpoint serializes the runtime and memory information of a task into an
@@ -278,7 +278,7 @@ func (t *task) Delete(ctx context.Context, opts ...ProcessDeleteOpts) (*ExitStat
 	return &ExitStatus{code: r.ExitStatus, exitedAt: r.ExitedAt}, nil
 }
 
-func (t *task) Exec(ctx context.Context, id string, spec *specs.Process, ioCreate cio.Creation) (_ Process, err error) {
+func (t *task) Exec(ctx context.Context, id string, spec *specs.Process, ioCreate cio.Creator) (_ Process, err error) {
 	if id == "" {
 		return nil, errors.Wrapf(errdefs.ErrInvalidArgument, "exec id must not be empty")
 	}


### PR DESCRIPTION
There are a few changes here. I tried to keep them in separate commits but they are all related. The overall goal is:
* reduce the size of the interface
* make the exported types easier to use from consumers
* remove duplication in types

Changes:
* `FIFOSet` is now a struct of `Config` + `Close()`. The hardcoded path is no longer part of the main constructors. This allows it to be re-used by other projects, and makes the cleanup logic much cleaner. Instead of every consumer having to remove `Dir`, the constructor provides a cleanup method.
* rename `Creation` to `Creator`. This is purely for readability. Creator is a thing that creates an artifact, Creation is the artifact. In this case our type is a thing that creates an artifact (IO), so Creator seems more appropriate.
* Removed the 4 (NewIO[WithTerminal], Stdin[WithTerminal]) `Creator` constructors and replace them with a single `NewCreator()` which accepts `Opt` functions to customize the `Streams`.
* `Streams` replaces the `ioset` type
* Rename `WithAttach` to `NewAttach` to reflect this is a constructor for an `Attach` type.
* merge `wgClosers` into `cio`. 
* extract `openFifos` from `copyIO` so that it can be used for `DirectIO` as well
* accept a `FIFOSet` in the `NewDirectIO` constructor so that it can be re-used by moby/moby and cri-containerd

Related PRs:
* https://github.com/kubernetes-incubator/cri-containerd/pull/485
* https://github.com/moby/moby/pull/35748