### PR TITLE
RELEASES.md: update components for 1.0 release

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -165,9 +165,9 @@ containerd versions:
 
 | Component     | Status   | Stablized Version | Links         |
 |---------------|----------|-------------------|---------------|
-| GRPC API      | Beta     | 1.0               | [api/](api) |
-| Metrics API   | Beta     | 1.0               | -
-| Go client API | Unstable | 1.1 tentative     | [godoc](https://godoc.org/github.com/containerd/containerd) |
+| GRPC API      | Stable     | 1.0               | [api/](api) |
+| Metrics API   | Stable     | 1.0               | -
+| Go client API | Unstable | 1.2 tentative     | [godoc](https://godoc.org/github.com/containerd/containerd) |
 | `ctr` tool    | Unstable | Out of scope      | -             |
 
 From the version stated in the above table, that component must adhere to the


### PR DESCRIPTION
This should have been updated at release time, but the GRPC API and the
metrics API is considered stable as of the 1.0 release. This means that
changes that break compatibility with previous versions of containerd
will no longer be accepted.

As part of this update, I am also proposing that we push out Go API
stability to 1.2 so that we can incorporate feedback from the Windows
integration in 1.1.

Signed-off-by: Stephen J Day <stephen.day@docker.com>