### PR TITLE
[WIP] add netgo build tag

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -84,7 +84,7 @@ You can build static binaries by providing a few variables to `make`:
 ```sudo
 make EXTRA_FLAGS="-buildmode pie" \
 	EXTRA_LDFLAGS='-extldflags "-fno-PIC -static"' \
-	BUILDTAGS="static_build"
+	BUILDTAGS="static_build netgo"
 ```
 
 > *Note*:

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ BINARIES=$(addprefix bin/,$(COMMANDS))
 
 GO_TAGS=$(if $(BUILDTAGS),-tags "$(BUILDTAGS)",)
 GO_LDFLAGS=-ldflags '-s -w -X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PKG) $(EXTRA_LDFLAGS)'
-SHIM_GO_LDFLAGS=-ldflags '-s -w -X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PKG) -extldflags "-static"'
+SHIM_GO_LDFLAGS=-ldflags '-linkmode=external -s -w -X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PKG) -extldflags "-static"'
 
 TESTFLAGS_RACE=
 GO_GCFLAGS=


### PR DESCRIPTION
## containerd-shim: link with GNU ld

This change adds `-linkmode=external` option to `go build -ldflags`, so GNU linker is used instead of Go's own. The change is done so the resulting binary will have `.note.gnu.build-id` which is now required by Fedora 27 rpm-build system (and will most probably be required in RHEL 8).

Unfortunately this results in size increase; here's `size` output before and after the change:

 5043206	 126020	 165248	5334474	 5165ca	./bin/containerd-shim-new
 4191140	 117552	 139392	4448084	 43df54	./bin/containerd-shim-old

I tried a few options to make the size smaller (like `-Wl,--as-needed` and a few others) to no avail.

## BUILDING.md: add netgo for static build

When compiling containerd binaries statically, linker rightfully complains:

```
+ make BUILDTAGS=static_build 'EXTRA_FLAGS=-buildmode pie' \
'EXTRA_LDFLAGS=-extldflags "-fno-PIC -static"'
🇩 bin/ctr
/tmp/go-link-343047789/000000.o: In function
`_cgo_b0c710f30cfd_C2func_getaddrinfo':
/tmp/go-build/net/_obj/cgo-gcc-prolog:46: warning: Using 'getaddrinfo'
in statically linked applications requires at runtime the shared
libraries from the glibc version used for linking
```

The same error appears for `ctr`, `containerd`, and `containerd-stress` binaries.

The fix is to use Go's own DNS resolver functions, rather than glibc's `getaddrinfo()` -- this option is turned on by `netgo` build tag.

See https://golang.org/pkg/net/ (look for "Name Resolution") for more details.