### PR TITLE
Fix a containerd deadlock.

### DIFF
--- a/cmd/containerd/main.go
+++ b/cmd/containerd/main.go
@@ -78,7 +78,7 @@ func main() {
 		var (
 			start   = time.Now()
 			signals = make(chan os.Signal, 2048)
-			serverC = make(chan *server.Server)
+			serverC = make(chan *server.Server, 1)
 			ctx     = log.WithModule(gocontext.Background(), "containerd")
 			config  = defaultConfig()
 		)


### PR DESCRIPTION
I hit this issue during cluster bootstrapping.
If containerd is terminated with `pkill containerd` before it is fully bootstrapped, it may fall into a deadlock.
The reason is that the server channel size is 0. If `handleSignals` exits early, no one is going to consume the message in channel, and `serverC <- server` will stuck forever.

If this makes sense, we should cherrypick into 1.0. @crosbymichael 

Signed-off-by: Lantao Liu <lantaol@google.com>