### PR TITLE
[v1.0.x] BACKPORT: server: only warn on failed OOM score adjust

### DIFF
--- a/server/server_linux.go
+++ b/server/server_linux.go
@@ -19,9 +19,9 @@ func apply(ctx context.Context, config *Config) error {
 		}
 	}
 	if config.OOMScore != 0 {
-		log.G(ctx).Infof("changing OOM score to %d", config.OOMScore)
+		log.G(ctx).Debugf("changing OOM score to %d", config.OOMScore)
 		if err := sys.SetOOMScore(os.Getpid(), config.OOMScore); err != nil {
-			return err
+			log.G(ctx).WithError(err).Errorf("failed to change OOM score to %d", config.OOMScore)
 		}
 	}
 	if config.Cgroup.Path != "" {


### PR DESCRIPTION
Signed-off-by: Stephen J Day <stephen.day@docker.com>