### PR TITLE
Add metrics endpoint to stress test tool

### DIFF
--- a/cmd/containerd-stress/main.go
+++ b/cmd/containerd-stress/main.go
@@ -192,6 +192,10 @@ func test(c config) error {
 	if c.Exec {
 		args = oci.WithProcessArgs("sleep", "10")
 	}
+	v, err := client.Version(ctx)
+	if err != nil {
+		return err
+	}
 	// create the workers along with their spec
 	for i := 0; i < c.Concurrency; i++ {
 		wg.Add(1)
@@ -210,6 +214,7 @@ func test(c config) error {
 			image:  image,
 			client: client,
 			doExec: c.Exec,
+			commit: v.Revision,
 		}
 		workers = append(workers, w)
 	}

--- a/cmd/containerd-stress/main.go
+++ b/cmd/containerd-stress/main.go
@@ -6,20 +6,15 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"runtime"
-	"strconv"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
 
 	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -223,114 +218,6 @@ func test(c config) error {
 		}
 	}
 	return nil
-}
-
-type worker struct {
-	id       int
-	wg       *sync.WaitGroup
-	count    int
-	failures int
-
-	client *containerd.Client
-	image  containerd.Image
-	spec   *specs.Spec
-	doExec bool
-}
-
-func (w *worker) run(ctx, tctx context.Context) {
-	defer func() {
-		w.wg.Done()
-		logrus.Infof("worker %d finished", w.id)
-	}()
-	for {
-		select {
-		case <-tctx.Done():
-			return
-		default:
-		}
-
-		w.count++
-		id := w.getID()
-		logrus.Debugf("starting container %s", id)
-		if err := w.runContainer(ctx, id); err != nil {
-			if err != context.DeadlineExceeded ||
-				!strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
-				w.failures++
-				logrus.WithError(err).Errorf("running container %s", id)
-
-			}
-		}
-	}
-}
-
-func (w *worker) runContainer(ctx context.Context, id string) error {
-	// fix up cgroups path for a default config
-	w.spec.Linux.CgroupsPath = filepath.Join("/", "stress", id)
-	c, err := w.client.NewContainer(ctx, id,
-		containerd.WithNewSnapshot(id, w.image),
-		containerd.WithSpec(w.spec, oci.WithUsername("games")),
-	)
-	if err != nil {
-		return err
-	}
-	defer c.Delete(ctx, containerd.WithSnapshotCleanup)
-
-	task, err := c.NewTask(ctx, cio.NullIO)
-	if err != nil {
-		return err
-	}
-	defer task.Delete(ctx, containerd.WithProcessKill)
-
-	statusC, err := task.Wait(ctx)
-	if err != nil {
-		return err
-	}
-	if err := task.Start(ctx); err != nil {
-		return err
-	}
-	if w.doExec {
-		for i := 0; i < 256; i++ {
-			if err := w.exec(ctx, i, task); err != nil {
-				w.failures++
-				logrus.WithError(err).Error("exec failure")
-			}
-		}
-		if err := task.Kill(ctx, syscall.SIGKILL); err != nil {
-			return err
-		}
-	}
-	status := <-statusC
-	_, _, err = status.Result()
-	if err != nil {
-		if err == context.DeadlineExceeded || err == context.Canceled {
-			return nil
-		}
-		w.failures++
-	}
-	return nil
-}
-
-func (w *worker) exec(ctx context.Context, i int, t containerd.Task) error {
-	pSpec := *w.spec.Process
-	pSpec.Args = []string{"true"}
-	process, err := t.Exec(ctx, strconv.Itoa(i), &pSpec, cio.NullIO)
-	if err != nil {
-		return err
-	}
-	defer process.Delete(ctx)
-	status, err := process.Wait(ctx)
-	if err != nil {
-		return err
-	}
-	if err := process.Start(ctx); err != nil {
-		return err
-	}
-	<-status
-	return nil
-}
-
-func (w *worker) getID() string {
-	return fmt.Sprintf("%d-%d", w.id, w.count)
 }
 
 // cleanup cleans up any containers in the "stress" namespace before the test run

--- a/cmd/containerd-stress/worker.go
+++ b/cmd/containerd-stress/worker.go
@@ -18,13 +18,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var ct metrics.Timer
+var ct metrics.LabeledTimer
 
 func init() {
 	ns := metrics.NewNamespace("stress", "", nil)
 	// if you want more fine grained metrics then you can drill down with the metrics in prom that
 	// containerd is outputing
-	ct = ns.NewTimer("run", "Run time of a full container during the test")
+	ct = ns.NewLabeledTimer("run", "Run time of a full container during the test", "commit")
 	metrics.Register(ns)
 }
 
@@ -38,6 +38,7 @@ type worker struct {
 	image  containerd.Image
 	spec   *specs.Spec
 	doExec bool
+	commit string
 }
 
 func (w *worker) run(ctx, tctx context.Context) {
@@ -66,7 +67,7 @@ func (w *worker) run(ctx, tctx context.Context) {
 			continue
 		}
 		// only log times are success so we don't scew the results from failures that go really fast
-		ct.UpdateSince(start)
+		ct.WithValues(w.commit).UpdateSince(start)
 	}
 }
 

--- a/cmd/containerd-stress/worker.go
+++ b/cmd/containerd-stress/worker.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/cio"
+	"github.com/containerd/containerd/oci"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+type worker struct {
+	id       int
+	wg       *sync.WaitGroup
+	count    int
+	failures int
+
+	client *containerd.Client
+	image  containerd.Image
+	spec   *specs.Spec
+	doExec bool
+}
+
+func (w *worker) run(ctx, tctx context.Context) {
+	defer func() {
+		w.wg.Done()
+		logrus.Infof("worker %d finished", w.id)
+	}()
+	for {
+		select {
+		case <-tctx.Done():
+			return
+		default:
+		}
+
+		w.count++
+		id := w.getID()
+		logrus.Debugf("starting container %s", id)
+		if err := w.runContainer(ctx, id); err != nil {
+			if err != context.DeadlineExceeded ||
+				!strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
+				w.failures++
+				logrus.WithError(err).Errorf("running container %s", id)
+
+			}
+		}
+	}
+}
+
+func (w *worker) runContainer(ctx context.Context, id string) error {
+	// fix up cgroups path for a default config
+	w.spec.Linux.CgroupsPath = filepath.Join("/", "stress", id)
+	c, err := w.client.NewContainer(ctx, id,
+		containerd.WithNewSnapshot(id, w.image),
+		containerd.WithSpec(w.spec, oci.WithUsername("games")),
+	)
+	if err != nil {
+		return err
+	}
+	defer c.Delete(ctx, containerd.WithSnapshotCleanup)
+
+	task, err := c.NewTask(ctx, cio.NullIO)
+	if err != nil {
+		return err
+	}
+	defer task.Delete(ctx, containerd.WithProcessKill)
+
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		return err
+	}
+	if err := task.Start(ctx); err != nil {
+		return err
+	}
+	if w.doExec {
+		for i := 0; i < 256; i++ {
+			if err := w.exec(ctx, i, task); err != nil {
+				w.failures++
+				logrus.WithError(err).Error("exec failure")
+			}
+		}
+		if err := task.Kill(ctx, syscall.SIGKILL); err != nil {
+			return err
+		}
+	}
+	status := <-statusC
+	_, _, err = status.Result()
+	if err != nil {
+		if err == context.DeadlineExceeded || err == context.Canceled {
+			return nil
+		}
+		w.failures++
+	}
+	return nil
+}
+
+func (w *worker) exec(ctx context.Context, i int, t containerd.Task) error {
+	pSpec := *w.spec.Process
+	pSpec.Args = []string{"true"}
+	process, err := t.Exec(ctx, strconv.Itoa(i), &pSpec, cio.NullIO)
+	if err != nil {
+		return err
+	}
+	defer process.Delete(ctx)
+	status, err := process.Wait(ctx)
+	if err != nil {
+		return err
+	}
+	if err := process.Start(ctx); err != nil {
+		return err
+	}
+	<-status
+	return nil
+}
+
+func (w *worker) getID() string {
+	return fmt.Sprintf("%d-%d", w.id, w.count)
+}


### PR DESCRIPTION
This refactors the stress test tool to output metrics via prometheus.

This allows us to run stress tests 24/7 and monitor the results.  I have a server running that pulls master every hour and runs the stress tests for it.  Results are viewed on prometheus. 