### PR TITLE
check for threshold, not range

### DIFF
--- a/gc/scheduler/scheduler_test.go
+++ b/gc/scheduler/scheduler_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestPauseThreshold(t *testing.T) {
+
 	cfg := &config{
 		// With 100μs, gc should run about every 5ms
 		PauseThreshold: 0.02,
@@ -39,8 +40,9 @@ func TestPauseThreshold(t *testing.T) {
 	}()
 
 	time.Sleep(time.Millisecond * 15)
-	if c := tc.runCount(); c < 3 || c > 4 {
-		t.Fatalf("unexpected gc run count %d, expected between 5 and 6", c)
+
+	if c := tc.runCount(); c > 4 {
+		t.Fatalf("unexpected gc run count %d, expected less than 5", c)
 	}
 }
 


### PR DESCRIPTION
This test seems to fall apart on a loaded system. In actuality it
doesn't seem to be testing for a threshold, but a "sane" range.

Fixes issue #1911

Signed-off-by: Christy Perez <christy@linux.vnet.ibm.com>