### PR TITLE
Fix image pull after a failure

### DIFF
--- a/content/helpers.go
+++ b/content/helpers.go
@@ -77,7 +77,7 @@ func Copy(ctx context.Context, cw Writer, r io.Reader, size int64, expected dige
 		r, err = seekReader(r, ws.Offset, size)
 		if err != nil {
 			if !isUnseekable(err) {
-				return errors.Wrapf(err, "unabled to resume write to %v", ws.Ref)
+				return errors.Wrapf(err, "unable to resume write to %v", ws.Ref)
 			}
 
 			// reader is unseekable, try to move the writer back to the start.

--- a/content/local/writer.go
+++ b/content/local/writer.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -167,5 +168,8 @@ func (w *writer) Truncate(size int64) error {
 	}
 	w.offset = 0
 	w.digester.Hash().Reset()
+	if _, err := w.fp.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
 	return w.fp.Truncate(0)
 }


### PR DESCRIPTION
Fixes #1893

When resuming from a failed pull the local content store `Writer.Truncate()` was not seeking to the proper position in the file. This caused writes to happen after the previously written content, instead of at the start of the file. Ref https://golang.org/pkg/os/#File.Truncate ( It does not change the I/O offset)

`Truncate()` is called from https://github.com/containerd/containerd/blob/v1.0.0/services/content/service.go#L395-L399. 
