### PR TITLE
Less verbose test suite

### DIFF
--- a/content/local/store_test.go
+++ b/content/local/store_test.go
@@ -85,7 +85,7 @@ func TestContent(t *testing.T) {
 func TestContentWriter(t *testing.T) {
 	ctx, tmpdir, cs, cleanup := contentStoreEnv(t)
 	defer cleanup()
-	defer testutil.DumpDir(t, tmpdir)
+	defer testutil.DumpDirOnFailure(t, tmpdir)
 
 	if _, err := os.Stat(filepath.Join(tmpdir, "ingest")); os.IsNotExist(err) {
 		t.Fatal("ingest dir should be created", err)

--- a/content/testsuite/testsuite.go
+++ b/content/testsuite/testsuite.go
@@ -47,7 +47,7 @@ func makeTest(t *testing.T, name string, storeFn func(ctx context.Context, root 
 			}
 		}()
 
-		defer testutil.DumpDir(t, tmpDir)
+		defer testutil.DumpDirOnFailure(t, tmpDir)
 		fn(ctx, t, cs)
 	}
 }

--- a/filters/filter_test.go
+++ b/filters/filter_test.go
@@ -258,7 +258,6 @@ func TestFilters(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
-			t.Logf("testcase: %q", testcase.input)
 			filter, err := Parse(testcase.input)
 			if testcase.errString != "" {
 				if err == nil {
@@ -278,7 +277,6 @@ func TestFilters(t *testing.T) {
 				t.Fatal("filter should not be nil")
 			}
 
-			t.Log("filter", filter)
 			var results []interface{}
 			for _, item := range corpus {
 				adaptor := adapt(item)

--- a/filters/scanner_test.go
+++ b/filters/scanner_test.go
@@ -2,7 +2,6 @@ package filters
 
 import (
 	"fmt"
-	"strconv"
 	"testing"
 )
 
@@ -260,7 +259,6 @@ func TestScanner(t *testing.T) {
 		t.Run(testcase.name, func(t *testing.T) {
 			var sc scanner
 			sc.init(testcase.input)
-			t.Logf("scan %q", testcase.input)
 
 			// If you leave the expected empty, the test case will just print
 			// out the token stream, which you can paste into the testcase when
@@ -271,7 +269,6 @@ func TestScanner(t *testing.T) {
 
 			for i := 0; ; i++ {
 				pos, tok, s := sc.scan()
-				t.Log("token", pos, tok, strconv.Quote(s))
 				if len(testcase.expected) == 0 {
 					if len(s) > 0 {
 						fmt.Printf("{pos: %v, token: %#v, text: %q},\n", pos, tok, s)

--- a/remotes/docker/resolver_test.go
+++ b/remotes/docker/resolver_test.go
@@ -235,7 +235,6 @@ type logHandler struct {
 }
 
 func (h logHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
-	h.t.Logf("%s %s", r.Method, r.URL.String())
 	h.handler.ServeHTTP(rw, r)
 }
 

--- a/snapshots/testsuite/testsuite.go
+++ b/snapshots/testsuite/testsuite.go
@@ -87,7 +87,7 @@ func makeTest(name string, snapshotterFn func(ctx context.Context, root string) 
 			t.Fatal(err)
 		}
 
-		defer testutil.DumpDir(t, tmpDir)
+		defer testutil.DumpDirOnFailure(t, tmpDir)
 		fn(ctx, t, snapshotter, work)
 	}
 }

--- a/testutil/helpers.go
+++ b/testutil/helpers.go
@@ -16,10 +16,9 @@ func init() {
 	flag.BoolVar(&rootEnabled, "test.root", false, "enable tests that require root")
 }
 
-// DumpDir will log out all of the contents of the provided directory to
-// testing logger.
+// DumpDir prints the contents of the directory to the testing logger.
 //
-// Use this in a defer statement within tests that may allocate and exercise a
+// Use this in a defer statement from a test that may allocate and exercise a
 // temporary directory. Immensely useful for sanity checking and debugging
 // failing tests.
 //
@@ -55,5 +54,13 @@ func DumpDir(t *testing.T, root string) {
 		return nil
 	}); err != nil {
 		t.Fatalf("error dumping directory: %v", err)
+	}
+}
+
+// DumpDirOnFailure prints the contents of the directory to the testing logger if
+// the test has failed.
+func DumpDirOnFailure(t *testing.T, root string) {
+	if t.Failed() {
+		DumpDir(t, root)
 	}
 }


### PR DESCRIPTION
Add `DumpDirOnFailre()` to only print directory structure on failure.

Remove some extraneous logging from the test suite.