### PR TITLE
BUILDING.md: add netgo for static build

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -84,7 +84,7 @@ You can build static binaries by providing a few variables to `make`:
 ```sudo
 make EXTRA_FLAGS="-buildmode pie" \
 	EXTRA_LDFLAGS='-extldflags "-fno-PIC -static"' \
-	BUILDTAGS="static_build"
+	BUILDTAGS="static_build netgo"
 ```
 
 > *Note*:


### PR DESCRIPTION
When compiling containerd binaries statically, linker rightfully complains:

```
+ make BUILDTAGS=static_build 'EXTRA_FLAGS=-buildmode pie'
'EXTRA_LDFLAGS=-extldflags "-fno-PIC -static"'
🇩 bin/ctr
/tmp/go-link-343047789/000000.o: In function
`_cgo_b0c710f30cfd_C2func_getaddrinfo':
/tmp/go-build/net/_obj/cgo-gcc-prolog:46: warning: Using 'getaddrinfo'
in statically linked applications requires at runtime the shared
libraries from the glibc version used for linking
```

The same error appears for ctr, containerd, and containerd-stress binaries.

The fix is to use Go's own DNS resolver functions, rather than glibc's getaddrinfo() -- this option is turned on by `netgo` build tag.

See https://golang.org/pkg/net/ (look for "Name Resolution") for more details.

Related PR and `-installsuffix netgo` discussion: https://github.com/moby/moby/pull/35753