### PR TITLE
Fix race condition in IO test (TestNewAttach)

### DIFF
--- a/cio/io_test.go
+++ b/cio/io_test.go
@@ -87,8 +87,8 @@ func TestNewAttach(t *testing.T) {
 	actualStdin, err := ioutil.ReadAll(producers.Stdin)
 	require.NoError(t, err)
 
-	io.Cancel()
 	io.Wait()
+	io.Cancel()
 	assert.NoError(t, io.Close())
 
 	assert.Equal(t, expectedStdout, stdout.String())


### PR DESCRIPTION
Moved `io.Wait()` before `io.Cancel()` in [`TestNewAttach`](https://github.com/containerd/containerd/blob/master/cio/io_test.go#L59) to fix a race condition which would cause the `stderr` and `stdout` FIFOs to be closed prematurely (through the [context cancel](https://github.com/containerd/fifo/blob/master/fifo.go#L77) `io.Cancel()` function) resulting in:

```
=== RUN   TestNewAttach
--- FAIL: TestNewAttach (0.01s)
	Error Trace:	io_test.go:95
	Error:		Not equal: "this is the stderr" (expected)
			        != "" (actual)
		
FAIL
coverage: 63.0% of statements
```

There is an [ongoing discussion](https://github.com/containerd/containerd/pull/1930#pullrequestreview-84275817) of whether `io.Cancel()` should be called at all, but what seems clear is that canceling before waiting for the copy operations to finish will always create a race scenario.

This error has already been seen in some PR (see [1](https://github.com/containerd/containerd/pull/1930#discussion_r157605777), [2](https://github.com/containerd/containerd/pull/1746#issuecomment-352929669)) so it would be nice to fix this before deciding how the IO API should operate exactly.