### PR TITLE
Add concept of reviews and 2 new reviewers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -30,6 +30,19 @@ or the reliability of a release process. But those things distinguish a good
 project from a great one.
 """
 
+	[Rules.reviewer]
+
+	title = "What is a reviewer?"
+
+	text = """
+A reviewer is a core role within the project.
+They share in reviewing issues and pull requests and their LGTM count towards the
+required LGTM count to merge a code change into the project.
+
+Reviewers are part of the organization but do not have write access.
+Becoming a review is a core aspect in the journey to becoming a maintainer.
+"""
+
 	[Rules.adding-maintainers]
 
 	title = "How are maintainers added?"

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -40,7 +40,7 @@ They share in reviewing issues and pull requests and their LGTM count towards th
 required LGTM count to merge a code change into the project.
 
 Reviewers are part of the organization but do not have write access.
-Becoming a review is a core aspect in the journey to becoming a maintainer.
+Becoming a reviewer is a core aspect in the journey to becoming a maintainer.
 """
 
 	[Rules.adding-maintainers]
@@ -215,6 +215,11 @@ containerd defers to the [Technical Steering Committee](https://github.com/moby/
 			"mlaventure",
 			"stevvooe",
 		]
+	[Org.Reviewers]
+		people = [
+			"dnephin",
+			"jessvalarezo",
+		]
 
 [People]
 
@@ -262,3 +267,13 @@ containerd defers to the [Technical Steering Committee](https://github.com/moby/
 	Name = "Stephen Day"
 	Email = "stephen.day@docker.com"
 	GitHub = "stevvooe"
+
+	[People.jessvalarezo]
+	Name = "Jessica Valarezo"
+	Email = "valarezo.jessica@gmail.com"
+	GitHub = "jessvalarezo"
+
+	[People.dnephin]
+	Name = "Daniel Nephin"
+	Email = "dnephin@gmail.com"
+	GitHub = "dnephin"


### PR DESCRIPTION
This adds the concept of a reviewer to containerd.  These are people who are committed to improving containerd through contributions and reviews.

Reviewers may not meet the time requirements to become maintainers but are on the path.

By adding reviews to the org with read-only permissions, they can be assigned to issues/prs and displayed as members of the org when commenting on reviews.

Their LGTM can count towards the required LGTM count for code merges.  

---

This adds @jessvalarezo and @dnephin as the first reviewers for the project.  They have both been contributing code and reviews for a few months and are good candidates to set the standards for future reviewers. 

---

[edit: dmcgowan]
This is both a rules change and addition to maintainers file, we are going for unanimous support for the rules change. We also need LGTM from @jessvalarezo and @dnephin 

- [x] akihirosuda
- [x] crosbymichael
- [x] dqminh
- [x] dmcgowan
- [x] estesp
- [x] hqhq
- [x] jhowardmsft
- [x] mlaventure
- [x] stevvooe
- [x] jessvalarezo
- [x] dnephin
  