### PR TITLE
fs: update nanosecond diff comparison

### DIFF
--- a/fs/diff_test.go
+++ b/fs/diff_test.go
@@ -161,27 +161,36 @@ func TestUpdateWithSameTime(t *testing.T) {
 		fstest.CreateFile("/file-same-time", []byte("1"), 0644),
 		fstest.Chtimes("/file-same-time", t1, t1),
 		fstest.CreateFile("/file-truncated-time-1", []byte("1"), 0644),
-		fstest.Chtimes("/file-truncated-time-1", t1, t1),
+		fstest.Chtimes("/file-truncated-time-1", tt, tt),
 		fstest.CreateFile("/file-truncated-time-2", []byte("1"), 0644),
 		fstest.Chtimes("/file-truncated-time-2", tt, tt),
+		fstest.CreateFile("/file-truncated-time-3", []byte("1"), 0644),
+		fstest.Chtimes("/file-truncated-time-3", t1, t1),
 	)
 	l2 := fstest.Apply(
 		fstest.CreateFile("/file-modified-time", []byte("2"), 0644),
 		fstest.Chtimes("/file-modified-time", t2, t2),
 		fstest.CreateFile("/file-no-change", []byte("1"), 0644),
-		fstest.Chtimes("/file-no-change", tt, tt), // use truncated time, should be regarded as no change
+		fstest.Chtimes("/file-no-change", t1, t1),
 		fstest.CreateFile("/file-same-time", []byte("2"), 0644),
 		fstest.Chtimes("/file-same-time", t1, t1),
-		fstest.CreateFile("/file-truncated-time-1", []byte("2"), 0644),
-		fstest.Chtimes("/file-truncated-time-1", tt, tt),
+		fstest.CreateFile("/file-truncated-time-1", []byte("1"), 0644),
+		fstest.Chtimes("/file-truncated-time-1", t1, t1),
 		fstest.CreateFile("/file-truncated-time-2", []byte("2"), 0644),
 		fstest.Chtimes("/file-truncated-time-2", tt, tt),
+		fstest.CreateFile("/file-truncated-time-3", []byte("1"), 0644),
+		fstest.Chtimes("/file-truncated-time-3", tt, tt),
 	)
 	diff := []TestChange{
-		// "/file-same-time" excluded because matching non-zero nanosecond values
 		Modify("/file-modified-time"),
+		// Include changes with truncated timestamps. Comparing newly
+		// extracted tars which have truncated timestamps will be
+		// expected to produce changes. The expectation is that diff
+		// archives are generated once and kept, newly generated diffs
+		// will not consider cases where only one side is truncated.
 		Modify("/file-truncated-time-1"),
 		Modify("/file-truncated-time-2"),
+		Modify("/file-truncated-time-3"),
 	}
 
 	if err := testDiffWithBase(l1, l2, diff); err != nil {

--- a/fs/path.go
+++ b/fs/path.go
@@ -71,9 +71,9 @@ func sameFile(f1, f2 *currentPath) (bool, error) {
 			return false, nil
 		}
 
-		// If the timestamp may have been truncated in one of the
+		// If the timestamp may have been truncated in both of the
 		// files, check content of file to determine difference
-		if t1.Nanosecond() == 0 || t2.Nanosecond() == 0 {
+		if t1.Nanosecond() == 0 && t2.Nanosecond() == 0 {
 			var eq bool
 			if (f1.f.Mode() & os.ModeSymlink) == os.ModeSymlink {
 				eq, err = compareSymlinkTarget(f1.fullPath, f2.fullPath)


### PR DESCRIPTION
Only check content of files if both files have zero nanosecond times.
A zero nanosecond time is considered ambiguous as to whether or
not the timestamp has been truncated by tar. Previously the diff
algorithm was attempting to account for comparisons from a source
to a directory with an applied tar. This condition is no longer
relevant since there is no support for recreating tars directories
which have had a tar extracted. In the case where the older directory
has a truncated timestamp and the newer one does not, this may always
be considered a change. In the case where both are zero, treat the
timestamp as ambiguous and compare content.