### PR TITLE
rootfs: remove upper snapshot after use

### DIFF
--- a/rootfs/diff.go
+++ b/rootfs/diff.go
@@ -39,7 +39,7 @@ func Diff(ctx context.Context, snapshotID string, sn snapshots.Snapshotter, d di
 		if err != nil {
 			return ocispec.Descriptor{}, err
 		}
-		defer sn.Remove(ctx, lowerKey)
+		defer sn.Remove(ctx, upperKey)
 	}
 
 	return d.DiffMounts(ctx, lower, upper, opts...)


### PR DESCRIPTION
The remove function should take the generated `upperKey` instead of the `lowerKey` which has already been handled in L28.

Signed-off-by: Jess Valarezo <valarezo.jessica@gmail.com>