### PR TITLE
Small refactor of gc/scheduler to remove import of metadata

### DIFF
--- a/gc/gc.go
+++ b/gc/gc.go
@@ -8,6 +8,7 @@ package gc
 import (
 	"context"
 	"sync"
+	"time"
 )
 
 // ResourceType represents type of resource at a node
@@ -19,6 +20,11 @@ type Node struct {
 	Type      ResourceType
 	Namespace string
 	Key       string
+}
+
+// Stats about a garbage collection run
+type Stats interface {
+	Elapsed() time.Duration
 }
 
 // Tricolor implements basic, single-thread tri-color GC. Given the roots, the

--- a/gc/scheduler/scheduler.go
+++ b/gc/scheduler/scheduler.go
@@ -2,14 +2,14 @@ package scheduler
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 	"time"
 
+	"github.com/containerd/containerd/gc"
 	"github.com/containerd/containerd/log"
-	"github.com/containerd/containerd/metadata"
 	"github.com/containerd/containerd/plugin"
+	"github.com/pkg/errors"
 )
 
 // config configures the garbage collection policies.
@@ -95,7 +95,12 @@ func init() {
 				return nil, err
 			}
 
-			m := newScheduler(md.(*metadata.DB), ic.Config.(*config))
+			mdCollector, ok := md.(collector)
+			if !ok {
+				return nil, errors.Errorf("%s %T must implement collector", plugin.MetadataPlugin, md)
+			}
+
+			m := newScheduler(mdCollector, ic.Config.(*config))
 
 			ic.Meta.Exports = map[string]string{
 				"PauseThreshold":    fmt.Sprint(m.pauseThreshold),
@@ -119,7 +124,7 @@ type mutationEvent struct {
 
 type collector interface {
 	RegisterMutationCallback(func(bool))
-	GarbageCollect(context.Context) (metadata.GCStats, error)
+	GarbageCollect(context.Context) (gc.Stats, error)
 }
 
 type gcScheduler struct {
@@ -128,7 +133,7 @@ type gcScheduler struct {
 	eventC chan mutationEvent
 
 	waiterL sync.Mutex
-	waiters []chan metadata.GCStats
+	waiters []chan gc.Stats
 
 	pauseThreshold    float64
 	deletionThreshold int
@@ -171,12 +176,12 @@ func newScheduler(c collector, cfg *config) *gcScheduler {
 	return s
 }
 
-func (s *gcScheduler) ScheduleAndWait(ctx context.Context) (metadata.GCStats, error) {
+func (s *gcScheduler) ScheduleAndWait(ctx context.Context) (gc.Stats, error) {
 	return s.wait(ctx, true)
 }
 
-func (s *gcScheduler) wait(ctx context.Context, trigger bool) (metadata.GCStats, error) {
-	wc := make(chan metadata.GCStats, 1)
+func (s *gcScheduler) wait(ctx context.Context, trigger bool) (gc.Stats, error) {
+	wc := make(chan gc.Stats, 1)
 	s.waiterL.Lock()
 	s.waiters = append(s.waiters, wc)
 	s.waiterL.Unlock()
@@ -190,15 +195,15 @@ func (s *gcScheduler) wait(ctx context.Context, trigger bool) (metadata.GCStats,
 		}()
 	}
 
-	var gcStats metadata.GCStats
+	var gcStats gc.Stats
 	select {
 	case stats, ok := <-wc:
 		if !ok {
-			return metadata.GCStats{}, errors.New("gc failed")
+			return gcStats, errors.New("gc failed")
 		}
 		gcStats = stats
 	case <-ctx.Done():
-		return metadata.GCStats{}, ctx.Err()
+		return gcStats, ctx.Err()
 	}
 
 	return gcStats, nil
@@ -301,9 +306,9 @@ func (s *gcScheduler) run(ctx context.Context) {
 			continue
 		}
 
-		log.G(ctx).WithField("d", stats.MetaD).Debug("garbage collected")
+		log.G(ctx).WithField("d", stats.Elapsed()).Debug("garbage collected")
 
-		gcTime += stats.MetaD
+		gcTime += stats.Elapsed()
 		collections++
 		triggered = false
 		deletions = 0

--- a/services/images/service.go
+++ b/services/images/service.go
@@ -8,6 +8,7 @@ import (
 	imagesapi "github.com/containerd/containerd/api/services/images/v1"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/events"
+	"github.com/containerd/containerd/gc"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/metadata"
@@ -43,7 +44,7 @@ func init() {
 }
 
 type gcScheduler interface {
-	ScheduleAndWait(gocontext.Context) (metadata.GCStats, error)
+	ScheduleAndWait(gocontext.Context) (gc.Stats, error)
 }
 
 type service struct {


### PR DESCRIPTION
In the `gc/scheduler` package replace `metadata.GCStats` with an interface for exposing elapsed time. This change removes the need to import `metadata` from the `scheduler` package.

In the future the `Stats` interface can be expanded with a method to expose all of the stats, and the scheduler could be used with collections of things other than `metadata`.