### PR TITLE
running tests in a container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ addons:
   apt:
     packages:
       - btrfs-tools
-      - libseccomp-dev
       - libapparmor-dev
       - libnl-3-dev
       - libnet-dev
@@ -33,16 +32,17 @@ env:
 
 before_install:
   - uname -r
+  - sudo apt-get -q update
+  - sudo apt-get install -y libseccomp-dev/trusty-backports
 
 install:
-  - wget https://github.com/google/protobuf/releases/download/v3.5.0/protoc-3.5.0-linux-x86_64.zip -O /tmp/protoc-3.5.0-linux-x86_64.zip
-  - sudo unzip -o -d /usr/local /tmp/protoc-3.5.0-linux-x86_64.zip
+  - sudo PATH=$PATH GOPATH=$GOPATH script/setup/install-protobuf
   - sudo chmod +x /usr/local/bin/protoc
   - sudo chmod og+rx /usr/local/include/google /usr/local/include/google/protobuf /usr/local/include/google/protobuf/compiler
   - sudo chmod -R og+r /usr/local/include/google/protobuf/
   - protoc --version
   - go get -u github.com/vbatts/git-validation
-  - sudo wget https://github.com/crosbymichael/runc/releases/download/ctd-9/runc -O /bin/runc; sudo chmod +x /bin/runc
+  - sudo PATH=$PATH GOPATH=$GOPATH script/setup/install-runc
   - wget https://github.com/xemul/criu/archive/v3.0.tar.gz -O /tmp/criu.tar.gz
   - tar -C /tmp/ -zxf /tmp/criu.tar.gz
   - cd /tmp/criu-3.0 && sudo make install-criu

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -1,0 +1,31 @@
+# This dockerfile is used to test containerd within a container
+#
+# usage:
+# 1.) docker build -t containerd-test -f Dockerfile.test ../
+# 2.) docker run -it --privileged -v /tmp:/tmp --tmpfs /var/lib/containerd-test containerd-test  bash
+# 3.) $ make binaries install test
+#
+
+# Install proto3
+FROM golang:1.9.3 AS proto3
+RUN apt-get update && apt-get install -y autoconf automake g++ libtool unzip
+COPY script/setup/install-protobuf install-protobuf
+RUN ./install-protobuf
+
+# Install runc
+FROM golang:1.9.3 AS runc
+RUN apt-get update && apt-get install -y curl libapparmor-dev libseccomp-dev
+COPY vendor.conf /go/src/github.com/containerd/containerd/vendor.conf
+COPY script/setup/install-runc install-runc
+RUN ./install-runc
+
+FROM golang:1.9.3
+RUN apt-get update && apt-get install -y btrfs-tools gcc git libapparmor-dev libseccomp-dev make xfsprogs
+
+COPY --from=proto3 /usr/local/bin/protoc /usr/local/bin/protoc
+COPY --from=proto3 /usr/local/include/google /usr/local/include/google
+
+COPY --from=runc /usr/local/sbin/runc /usr/local/go/bin/runc
+COPY . /go/src/github.com/containerd/containerd
+
+WORKDIR /go/src/github.com/containerd/containerd

--- a/fs/dtype_linux_test.go
+++ b/fs/dtype_linux_test.go
@@ -20,7 +20,7 @@ func testSupportsDType(t *testing.T, expected bool, mkfs ...string) {
 	}
 	defer os.RemoveAll(mnt)
 
-	deviceName, cleanupDevice, err := testutil.NewLoopback(100 << 20) // 100 MB
+	deviceName, cleanupDevice, err := testutil.NewLoopback(150 << 20) // 150 MB
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/fs/dtype_linux_test.go
+++ b/fs/dtype_linux_test.go
@@ -20,16 +20,18 @@ func testSupportsDType(t *testing.T, expected bool, mkfs ...string) {
 	}
 	defer os.RemoveAll(mnt)
 
-	deviceName, cleanupDevice, err := testutil.NewLoopback(150 << 20) // 150 MB
+	deviceName, cleanupDevice, err := testutil.NewLoopback(100 << 20) // 100 MB
 	if err != nil {
 		t.Fatal(err)
 	}
 	if out, err := exec.Command(mkfs[0], append(mkfs[1:], deviceName)...).CombinedOutput(); err != nil {
 		// not fatal
+		cleanupDevice()
 		t.Skipf("could not mkfs (%v) %s: %v (out: %q)", mkfs, deviceName, err, string(out))
 	}
 	if out, err := exec.Command("mount", deviceName, mnt).CombinedOutput(); err != nil {
 		// not fatal
+		cleanupDevice()
 		t.Skipf("could not mount %s: %v (out: %q)", deviceName, err, string(out))
 	}
 	defer func() {

--- a/mount/lookup_test/lookup_linux_test.go
+++ b/mount/lookup_test/lookup_linux_test.go
@@ -39,7 +39,7 @@ func testLookup(t *testing.T, fsType string) {
 	}
 	defer os.RemoveAll(mnt)
 
-	deviceName, cleanupDevice, err := testutil.NewLoopback(100 << 20) // 100 MB
+	deviceName, cleanupDevice, err := testutil.NewLoopback(150 << 20) // 150 MB
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/mount/lookup_test/lookup_linux_test.go
+++ b/mount/lookup_test/lookup_linux_test.go
@@ -39,7 +39,7 @@ func testLookup(t *testing.T, fsType string) {
 	}
 	defer os.RemoveAll(mnt)
 
-	deviceName, cleanupDevice, err := testutil.NewLoopback(150 << 20) // 150 MB
+	deviceName, cleanupDevice, err := testutil.NewLoopback(100 << 20) // 100 MB
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/script/setup/install-protobuf
+++ b/script/setup/install-protobuf
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Downloads and installs protobuf
+#
+set -eux -o pipefail
+
+PROTOBUF_VERSION=3.5.1
+GOARCH=$(go env GOARCH)
+GOOS=$(go env GOOS)
+PROTOBUF_DIR=$(mktemp -d)
+
+case $GOARCH in
+
+arm64)
+	wget -O $PROTOBUF_DIR/protobuf "https://github.com/google/protobuf/releases/download/v$PROTOBUF_VERSION/protoc-$PROTOBUF_VERSION-linux-aarch64.zip"
+	unzip $PROTOBUF_DIR/protobuf -d /usr/local
+	;;
+
+amd64|386)
+	if [ $GOOS == "windows" ]; then
+		wget -O $PROTOBUF_DIR/protobuf "https://github.com/google/protobuf/releases/download/v$PROTOBUF_VERSION/protoc-$PROTOBUF_VERSION-win32.zip"
+	elif [ $GOOS == "linux" ]; then
+		wget -O $PROTOBUF_DIR/protobuf "https://github.com/google/protobuf/releases/download/v$PROTOBUF_VERSION/protoc-$PROTOBUF_VERSION-linux-x86_64.zip"
+	fi
+	unzip $PROTOBUF_DIR/protobuf -d /usr/local
+	;;
+
+*)
+	wget -O $PROTOBUF_DIR/protobuf "https://github.com/google/protobuf/releases/download/v$PROTOBUF_VERSION/protobuf-cpp-$PROTOBUF_VERSION.zip"
+	unzip $PROTOBUF_DIR/protobuf -d /usr/src/protobuf
+	cd /usr/src/protobuf/protobuf-$PROTOBUF_VERSION
+	./autogen.sh
+	./configure --disable-shared
+	make
+	make check
+	make install
+	ldconfig
+	;;
+esac
+rm -rf $PROTOBUF_DIR

--- a/script/setup/install-protobuf
+++ b/script/setup/install-protobuf
@@ -2,7 +2,7 @@
 #
 # Downloads and installs protobuf
 #
-set -eux -o pipefail
+set -eu -o pipefail
 
 PROTOBUF_VERSION=3.5.1
 GOARCH=$(go env GOARCH)

--- a/script/setup/install-runc
+++ b/script/setup/install-runc
@@ -3,7 +3,7 @@
 # Builds and installs runc to /usr/local/go/bin based off
 # the commit defined in vendor.conf
 #
-set -eux -o pipefail
+set -eu -o pipefail
 
 RUNC_COMMIT=$(grep opencontainers/runc ${GOPATH}/src/github.com/containerd/containerd/vendor.conf | cut -d " " -f 2)
 

--- a/script/setup/install-runc
+++ b/script/setup/install-runc
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# Builds and installs runc to /usr/local/go/bin based off
+# the commit defined in vendor.conf
+#
+set -eux -o pipefail
+
+RUNC_COMMIT=$(grep opencontainers/runc ${GOPATH}/src/github.com/containerd/containerd/vendor.conf | cut -d " " -f 2)
+
+go get -u github.com/opencontainers/runc
+cd $GOPATH/src/github.com/opencontainers/runc
+git checkout $RUNC_COMMIT
+make BUILDTAGS="apparmor seccomp" runc install

--- a/snapshots/btrfs/btrfs_test.go
+++ b/snapshots/btrfs/btrfs_test.go
@@ -29,7 +29,7 @@ func boltSnapshotter(t *testing.T) func(context.Context, string) (snapshots.Snap
 
 	return func(ctx context.Context, root string) (snapshots.Snapshotter, func() error, error) {
 
-		deviceName, cleanupDevice, err := testutil.NewLoopback(100 << 20) // 100 MB
+		deviceName, cleanupDevice, err := testutil.NewLoopback(150 << 20) // 150 MB
 		if err != nil {
 			return nil, nil, err
 		}

--- a/snapshots/btrfs/btrfs_test.go
+++ b/snapshots/btrfs/btrfs_test.go
@@ -29,20 +29,23 @@ func boltSnapshotter(t *testing.T) func(context.Context, string) (snapshots.Snap
 
 	return func(ctx context.Context, root string) (snapshots.Snapshotter, func() error, error) {
 
-		deviceName, cleanupDevice, err := testutil.NewLoopback(150 << 20) // 150 MB
+		deviceName, cleanupDevice, err := testutil.NewLoopback(650 << 20) // 650 MB
 		if err != nil {
 			return nil, nil, err
 		}
 
 		if out, err := exec.Command(mkbtrfs, deviceName).CombinedOutput(); err != nil {
+			cleanupDevice()
 			return nil, nil, errors.Wrapf(err, "failed to make btrfs filesystem (out: %q)", out)
 		}
 		if out, err := exec.Command("mount", deviceName, root).CombinedOutput(); err != nil {
+			cleanupDevice()
 			return nil, nil, errors.Wrapf(err, "failed to mount device %s (out: %q)", deviceName, out)
 		}
 
 		snapshotter, err := NewSnapshotter(root)
 		if err != nil {
+			cleanupDevice()
 			return nil, nil, errors.Wrap(err, "failed to create new snapshotter")
 		}
 

--- a/testutil/loopback_linux.go
+++ b/testutil/loopback_linux.go
@@ -21,6 +21,8 @@ func NewLoopback(size int64) (string, func() error, error) {
 	}
 
 	if err := file.Truncate(size); err != nil {
+		file.Close()
+		os.Remove(file.Name())
 		return "", nil, errors.Wrap(err, "failed to resize temp file")
 	}
 	file.Close()
@@ -29,6 +31,7 @@ func NewLoopback(size int64) (string, func() error, error) {
 	losetup := exec.Command("losetup", "--find", "--show", file.Name())
 	p, err := losetup.Output()
 	if err != nil {
+		os.Remove(file.Name())
 		return "", nil, errors.Wrap(err, "loopback setup failed")
 	}
 


### PR DESCRIPTION
This provides a dockerfile for building an image to run the containerd tests.

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>

few WIP issues:

- [X] optimize getting protobuf, which currently takes ~25minutes to build from source, which is done because google only provides amd64 downloads
- [X] `make integration` fails at the end because it tries to unmount the test dir which is a mounted vol
- [X] `make root-test` fails ~~because it runs of out of loop devices, this is~~ because previous tests devices are erroring out and not being freed because of :
```
failed to make btrfs filesystem (out: "ERROR: '/dev/loop3' is too small to make a usable filesystem\nERROR: minimum size for each btrfs device is 142606336\nbtrfs-progs v4.7.3\nSee http://btrfs.wiki.kernel.org for more information.\n\n")
```