### PR TITLE
metadata: image removal triggers GC

### DIFF
--- a/metadata/buckets.go
+++ b/metadata/buckets.go
@@ -106,13 +106,8 @@ func imagesBucketPath(namespace string) [][]byte {
 	return [][]byte{bucketKeyVersion, []byte(namespace), bucketKeyObjectImages}
 }
 
-func withImagesBucket(tx *bolt.Tx, namespace string, fn func(bkt *bolt.Bucket) error) error {
-	bkt, err := createBucketIfNotExists(tx, imagesBucketPath(namespace)...)
-	if err != nil {
-		return err
-	}
-
-	return fn(bkt)
+func createImagesBucket(tx *bolt.Tx, namespace string) (*bolt.Bucket, error) {
+	return createBucketIfNotExists(tx, imagesBucketPath(namespace)...)
 }
 
 func getImagesBucket(tx *bolt.Tx, namespace string) *bolt.Bucket {
@@ -141,6 +136,10 @@ func createSnapshotterBucket(tx *bolt.Tx, namespace, snapshotter string) (*bolt.
 		return nil, err
 	}
 	return bkt, nil
+}
+
+func getSnapshottersBucket(tx *bolt.Tx, namespace string) *bolt.Bucket {
+	return getBucket(tx, bucketKeyVersion, []byte(namespace), bucketKeyObjectSnapshots)
 }
 
 func getSnapshotterBucket(tx *bolt.Tx, namespace, snapshotter string) *bolt.Bucket {


### PR DESCRIPTION
Currently an image removal with the sync flag will not by itself cause a GC to run the same way removal of content or snapshots would.  This fixes this by refactoring the image store to have access to the metadata store to mark the content dirty flag.

To do this...
The boltdb image store now manages its own transactions when one is not provided, but allows the caller to pass in a transaction through the context. This makes the image store more similar to the content and snapshot stores. Additionally, use the reference to the metadata database to mark the content store as dirty after an image has been deleted. The deletion of an image means a reference to a piece of content is gone  and therefore garbage collection should be run to check if any resources can be cleaned up as a result.

The namespace empty check logic also needed to be updated since it was relying on using a transaction to initialize the container and image stores. Now the transaction is just directly used to check whether the buckets are empty, saving unnecessarily loading all the content into memory just to check whether or not a key exists under the buckets.

Credit to @tonistiigi for finding image removal not triggering gc without sync
  
  