### PR TITLE
Hold shim lock during state

### DIFF
--- a/linux/shim/service.go
+++ b/linux/shim/service.go
@@ -235,8 +235,8 @@ func (s *Service) ResizePty(ctx context.Context, r *shimapi.ResizePtyRequest) (*
 // State returns runtime state information for a process
 func (s *Service) State(ctx context.Context, r *shimapi.StateRequest) (*shimapi.StateResponse, error) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	p := s.processes[r.ID]
-	s.mu.Unlock()
 	if p == nil {
 		return nil, errdefs.ToGRPCf(errdefs.ErrNotFound, "process id %s not found", r.ID)
 	}


### PR DESCRIPTION
Helps with #1935

This hold the shim lock during the state call to make sure that the task
does not get deleted during a state call.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>