### PR TITLE
Enable grpc timing histograms

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -50,7 +50,8 @@ type Debug struct {
 
 // MetricsConfig provides metrics configuration
 type MetricsConfig struct {
-	Address string `toml:"address"`
+	Address       string `toml:"address"`
+	GRPCHistogram bool   `toml:"grpc_histogram"`
 }
 
 // CgroupConfig provides cgroup configuration


### PR DESCRIPTION
This enables the grpc timing histograms via a config option as they are
metrics of high cardinality.

This is useful for perf testing and debugging but should not be the
default on production systems unless needed.

```toml
[metrics]
	grpc_histogram = true

```

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>