### PR TITLE
mount: clean up error logs and messages in temp mount

### DIFF
--- a/container_opts_unix.go
+++ b/container_opts_unix.go
@@ -165,7 +165,7 @@ func withRemappedSnapshotBase(id string, i Image, uid, gid uint32, readonly bool
 		if err != nil {
 			return err
 		}
-		if err := remapRootFS(mounts, uid, gid); err != nil {
+		if err := remapRootFS(ctx, mounts, uid, gid); err != nil {
 			snapshotter.Remove(ctx, usernsID)
 			return err
 		}
@@ -186,8 +186,8 @@ func withRemappedSnapshotBase(id string, i Image, uid, gid uint32, readonly bool
 	}
 }
 
-func remapRootFS(mounts []mount.Mount, uid, gid uint32) error {
-	return mount.WithTempMount(mounts, func(root string) error {
+func remapRootFS(ctx context.Context, mounts []mount.Mount, uid, gid uint32) error {
+	return mount.WithTempMount(ctx, mounts, func(root string) error {
 		return filepath.Walk(root, incrementFS(root, uid, gid))
 	})
 }

--- a/diff/walking/differ.go
+++ b/diff/walking/differ.go
@@ -90,7 +90,7 @@ func (s *walkingDiff) Apply(ctx context.Context, desc ocispec.Descriptor, mounts
 	}
 
 	var ocidesc ocispec.Descriptor
-	if err := mount.WithTempMount(mounts, func(root string) error {
+	if err := mount.WithTempMount(ctx, mounts, func(root string) error {
 		ra, err := s.store.ReaderAt(ctx, desc.Digest)
 		if err != nil {
 			return errors.Wrap(err, "failed to get reader from content store")
@@ -158,8 +158,8 @@ func (s *walkingDiff) DiffMounts(ctx context.Context, lower, upper []mount.Mount
 	}
 
 	var ocidesc ocispec.Descriptor
-	if err := mount.WithTempMount(lower, func(lowerRoot string) error {
-		return mount.WithTempMount(upper, func(upperRoot string) error {
+	if err := mount.WithTempMount(ctx, lower, func(lowerRoot string) error {
+		return mount.WithTempMount(ctx, upper, func(upperRoot string) error {
 			var newReference bool
 			if config.Reference == "" {
 				newReference = true

--- a/oci/spec_opts_unix.go
+++ b/oci/spec_opts_unix.go
@@ -271,7 +271,7 @@ func WithUserID(uid uint32) SpecOpts {
 			return err
 		}
 
-		return mount.WithTempMount(mounts, func(root string) error {
+		return mount.WithTempMount(ctx, mounts, func(root string) error {
 			ppath, err := fs.RootPath(root, "/etc/passwd")
 			if err != nil {
 				return err
@@ -319,7 +319,7 @@ func WithUsername(username string) SpecOpts {
 		if err != nil {
 			return err
 		}
-		return mount.WithTempMount(mounts, func(root string) error {
+		return mount.WithTempMount(ctx, mounts, func(root string) error {
 			ppath, err := fs.RootPath(root, "/etc/passwd")
 			if err != nil {
 				return err


### PR DESCRIPTION
Adds context to the WithTempMount to provide a better error log when removal fails. Removed wrapping of the passed in closure error and clarified a comment.