### PR TITLE
Add unconvert linter

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -7,13 +7,13 @@
     "fetch\\.go:.*::error: unrecognized printf verb 'r'"
   ],
   "EnableGC": true,
-  "WarnUnmatchedDirective": true,
 
   "Enable": [
     "structcheck",
     "unused",
     "varcheck",
     "staticcheck",
+    "unconvert",
 
     "gofmt",
     "goimports",

--- a/archive/strconv.go
+++ b/archive/strconv.go
@@ -46,7 +46,7 @@ func parsePAXTime(s string) (time.Time, error) {
 	}
 	nsecs, _ := strconv.ParseInt(sn, 10, 64) // Must succeed
 	if len(ss) > 0 && ss[0] == '-' {
-		return time.Unix(secs, -1*int64(nsecs)), nil // Negative correction
+		return time.Unix(secs, -nsecs), nil // Negative correction
 	}
-	return time.Unix(secs, int64(nsecs)), nil
+	return time.Unix(secs, nsecs), nil
 }

--- a/archive/tar_unix.go
+++ b/archive/tar_unix.go
@@ -29,11 +29,14 @@ func setHeaderForSpecialDevice(hdr *tar.Header, name string, fi os.FileInfo) err
 		return errors.New("unsupported stat type")
 	}
 
+	// Rdev is int32 on darwin/bsd, int64 on linux/solaris
+	rdev := uint64(s.Rdev) // nolint: unconvert
+
 	// Currently go does not fill in the major/minors
 	if s.Mode&syscall.S_IFBLK != 0 ||
 		s.Mode&syscall.S_IFCHR != 0 {
-		hdr.Devmajor = int64(unix.Major(uint64(s.Rdev)))
-		hdr.Devminor = int64(unix.Minor(uint64(s.Rdev)))
+		hdr.Devmajor = int64(unix.Major(rdev))
+		hdr.Devminor = int64(unix.Minor(rdev))
 	}
 
 	return nil

--- a/cmd/ctr/commands/pprof/pprof.go
+++ b/cmd/ctr/commands/pprof/pprof.go
@@ -93,7 +93,7 @@ var pprofTraceCommand = cli.Command{
 		cli.DurationFlag{
 			Name:  "seconds,s",
 			Usage: "trace time (seconds)",
-			Value: time.Duration(5 * time.Second),
+			Value: 5 * time.Second,
 		},
 	},
 	Action: func(context *cli.Context) error {

--- a/content/local/store_unix.go
+++ b/content/local/store_unix.go
@@ -12,8 +12,7 @@ import (
 
 func getATime(fi os.FileInfo) time.Time {
 	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
-		return time.Unix(int64(sys.StatAtime(st).Sec),
-			int64(sys.StatAtime(st).Nsec))
+		return sys.StatATimeAsTime(st)
 	}
 
 	return fi.ModTime()

--- a/events/events.go
+++ b/events/events.go
@@ -26,9 +26,9 @@ func (e *Envelope) Field(fieldpath []string) (string, bool) {
 	switch fieldpath[0] {
 	// unhandled: timestamp
 	case "namespace":
-		return string(e.Namespace), len(e.Namespace) > 0
+		return e.Namespace, len(e.Namespace) > 0
 	case "topic":
-		return string(e.Topic), len(e.Topic) > 0
+		return e.Topic, len(e.Topic) > 0
 	case "event":
 		decoded, err := typeurl.UnmarshalAny(e.Event)
 		if err != nil {

--- a/fs/hardlink_unix.go
+++ b/fs/hardlink_unix.go
@@ -13,5 +13,6 @@ func getLinkInfo(fi os.FileInfo) (uint64, bool) {
 		return 0, false
 	}
 
-	return uint64(s.Ino), !fi.IsDir() && s.Nlink > 1
+	// Ino is uint32 on bsd, uint64 on darwin/linux/solaris
+	return uint64(s.Ino), !fi.IsDir() && s.Nlink > 1 // nolint: unconvert
 }

--- a/images/image.go
+++ b/images/image.go
@@ -357,13 +357,5 @@ func RootFS(ctx context.Context, provider content.Provider, configDesc ocispec.D
 	if err := json.Unmarshal(p, &config); err != nil {
 		return nil, err
 	}
-
-	// TODO(stevvooe): Remove this bit when OCI structure uses correct type for
-	// rootfs.DiffIDs.
-	var diffIDs []digest.Digest
-	for _, diffID := range config.RootFS.DiffIDs {
-		diffIDs = append(diffIDs, digest.Digest(diffID))
-	}
-
-	return diffIDs, nil
+	return config.RootFS.DiffIDs, nil
 }

--- a/metadata/images.go
+++ b/metadata/images.go
@@ -275,7 +275,7 @@ func writeImage(bkt *bolt.Bucket, image *images.Image) error {
 	}
 
 	// write the target bucket
-	tbkt, err := bkt.CreateBucketIfNotExists([]byte(bucketKeyTarget))
+	tbkt, err := bkt.CreateBucketIfNotExists(bucketKeyTarget)
 	if err != nil {
 		return err
 	}

--- a/metrics/cgroups/oom.go
+++ b/metrics/cgroups/oom.go
@@ -89,7 +89,7 @@ func (o *oomCollector) Collect(ch chan<- prometheus.Metric) {
 
 // Close closes the epoll fd
 func (o *oomCollector) Close() error {
-	return unix.Close(int(o.fd))
+	return unix.Close(o.fd)
 }
 
 func (o *oomCollector) start() {

--- a/services/introspection/service.go
+++ b/services/introspection/service.go
@@ -73,9 +73,9 @@ func adaptPlugin(o interface{}) filters.Adaptor {
 
 		switch fieldpath[0] {
 		case "type":
-			return string(obj.Type), len(obj.Type) > 0
+			return obj.Type, len(obj.Type) > 0
 		case "id":
-			return string(obj.ID), len(obj.ID) > 0
+			return obj.ID, len(obj.ID) > 0
 		case "platforms":
 			// TODO(stevvooe): Another case here where have multiple values.
 			// May need to refactor the filter system to allow filtering by

--- a/sys/stat_bsd.go
+++ b/sys/stat_bsd.go
@@ -4,6 +4,7 @@ package sys
 
 import (
 	"syscall"
+	"time"
 )
 
 // StatAtime returns the access time from a stat struct
@@ -19,4 +20,9 @@ func StatCtime(st *syscall.Stat_t) syscall.Timespec {
 // StatMtime returns the modified time from a stat struct
 func StatMtime(st *syscall.Stat_t) syscall.Timespec {
 	return st.Mtimespec
+}
+
+// StatATimeAsTime returns the access time as a time.Time
+func StatATimeAsTime(st *syscall.Stat_t) time.Time {
+	return time.Unix(int64(st.Atimespec.Sec), int64(st.Atimespec.Nsec)) // nolint: unconvert
 }

--- a/sys/stat_unix.go
+++ b/sys/stat_unix.go
@@ -4,6 +4,7 @@ package sys
 
 import (
 	"syscall"
+	"time"
 )
 
 // StatAtime returns the Atim
@@ -19,4 +20,9 @@ func StatCtime(st *syscall.Stat_t) syscall.Timespec {
 // StatMtime returns the Mtim
 func StatMtime(st *syscall.Stat_t) syscall.Timespec {
 	return st.Mtim
+}
+
+// StatATimeAsTime returns st.Atim as a time.Time
+func StatATimeAsTime(st *syscall.Stat_t) time.Time {
+	return time.Unix(st.Atim.Sec, st.Atim.Nsec)
 }


### PR DESCRIPTION
[unconvert](https://github.com/mdempsky/unconvert) checks for unnecessary type conversions.

Some conversions are whitelisted because their type is different on 32bit platforms
