### PR TITLE
Remove DCO check from makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ install:
 script:
   - export GOOS=$TRAVIS_GOOS
   - export CGO_ENABLED=$TRAVIS_CGO_ENABLED
-  - GIT_CHECK_EXCLUDE="./vendor" TRAVIS_COMMIT_RANGE="${TRAVIS_COMMIT_RANGE/.../..}" make dco
+  - DCO_VERBOSITY=-q script/validate/dco
   - GOOS=linux script/setup/install-dev-tools
   - go build -i .
   - make check

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ endif
 TESTFLAGS ?= -v $(TESTFLAGS_RACE)
 TESTFLAGS_PARALLEL ?= 8
 
-.PHONY: clean all AUTHORS fmt vet lint dco build binaries test integration generate protos checkprotos coverage ci check help install uninstall vendor release
+.PHONY: clean all AUTHORS build binaries test integration generate protos checkprotos coverage ci check help install uninstall vendor release
 .DEFAULT: default
 
 all: binaries
@@ -105,14 +105,6 @@ proto-fmt: ## check format of proto files
 		(echo "$(ONI) please indent proto files with tabs only" && false)
 	@test -z "$$(find . -path ./vendor -prune -o -name '*.proto' -type f -exec grep -Hn "Meta meta = " {} \; | grep -v '(gogoproto.nullable) = false' | tee /dev/stderr)" || \
 		(echo "$(ONI) meta fields in proto files must have option (gogoproto.nullable) = false" && false)
-
-dco: ## dco check
-	@which git-validation > /dev/null 2>/dev/null || (echo "ERROR: git-validation not found" && false)
-ifdef TRAVIS_COMMIT_RANGE
-	git-validation -q -run DCO,short-subject,dangling-whitespace
-else
-	git-validation -v -run DCO,short-subject,dangling-whitespace -range $(EPOCH_TEST_COMMIT)..HEAD
-endif
 
 build: ## build the go packages
 	@echo "$(WHALE) $@"

--- a/script/validate/dco
+++ b/script/validate/dco
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+if ! command -v git-validation; then
+    >&2 echo "ERROR: git-validation not found. Install with:"
+    >&2 echo "    go get -u github.com/vbatts/git-validation"
+    exit 1
+fi
+
+GIT_CHECK_EXCLUDE="./vendor"
+verbosity="${DCO_VERBOSITY--v}"
+git-validation "$verbosity" -run DCO,short-subject,dangling-whitespace


### PR DESCRIPTION
The DCO check is only relevant as part of CI, so it doesn't need to be in the Makefile. A contributor looking to validate their commits can run `script/validate/dco`.  The goal is keep the Makefile smaller and easier to read.

Similar in spirit to #1811
cc @crosbymichael 