### PR TITLE
Add a vendor check to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ script:
   - export CGO_ENABLED=$TRAVIS_CGO_ENABLED
   - DCO_VERBOSITY=-q script/validate/dco
   - GOOS=linux script/setup/install-dev-tools
+  - script/validate/vendor
   - go build -i .
   - make check
   - if [ "$GOOS" = "linux" ]; then make check-protos check-api-descriptors; fi

--- a/script/validate/vendor
+++ b/script/validate/vendor
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+vndr 2>&1 | grep -v -i clone
+
+DIFF_PATH="vendor/"
+DIFF=$(git status --porcelain -- "$DIFF_PATH")
+
+if [ "$DIFF" ]; then
+    echo
+    echo "These files were modified:"
+    echo
+    echo "$DIFF"
+    echo
+    exit 1
+else
+    echo "$DIFF_PATH is correct"
+fi


### PR DESCRIPTION
Fixes #1898

As part of CI, check that all vendored files are exactly the same after running `vndr`.