### PR TITLE
Remove go build option '-i' for native builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,9 @@ REVISION=$(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet 
 ifneq "$(strip $(shell command -v go 2>/dev/null))" ""
 	GOOS ?= $(shell go env GOOS)
 	GOARCH ?= $(shell go env GOARCH)
-	GOHOSTOS ?= $(shell go env GOHOSTOS)
 else
 	GOOS ?= $$GOOS
 	GOARCH ?= $$GOARCH
-	GOHOSTOS ?= $$GOHOSTOS
 endif
 
 WHALE = "🇩"
@@ -52,14 +50,6 @@ GO_BUILD_FLAGS=
 
 #include platform specific makefile
 -include Makefile.$(GOOS)
-
-# Add the "incremental" build option `-i` (installs the packages that are
-# dependencies of the target) to speed up future builds. Only for native builds,
-# otherwise it will try to install in the incorrect (not native) path and fail.
-# Note: this won't be necessary from 1.10 (https://tip.golang.org/doc/go1.10#build)
-ifeq ($(GOOS), $(GOHOSTOS))
-	GO_BUILD_FLAGS += -i
-endif
 
 # Flags passed to `go test`
 TESTFLAGS ?= -v $(TESTFLAGS_RACE)


### PR DESCRIPTION
The `-i` option added to `go build` in the [Makefile](https://github.com/containerd/containerd/pull/1937) is causing [build problems](https://github.com/containerd/containerd/issues/1961) because in some cases the dependencies are being installed in `GOROOT`.

An alternate solution to this problem would be to set the [`-pkgdir`](https://github.com/golang/go/commit/b2cb3b416c538406c52e8c83a8f833fae812b9fd#diff-9a7673701332f3ded83deb4c307eefc9R120) build flag to `GOPATH/pkg`, but that would keep adding complexity to the Makefile.

The `GO_BUILD_FLAGS` environment variable is left in place for the optional manual addition of `-i` or any other build option.

Reverts #1937
Fixes #1961
Closes #1938