### PR TITLE
Remove reaper from containerd daemon

### DIFF
--- a/cmd/containerd/config_linux.go
+++ b/cmd/containerd/config_linux.go
@@ -12,7 +12,6 @@ func defaultConfig() *server.Config {
 		GRPC: server.GRPCConfig{
 			Address: defaults.DefaultAddress,
 		},
-		NoSubreaper: false,
 		Debug: server.Debug{
 			Level:   "info",
 			Address: defaults.DefaultDebugAddress,

--- a/cmd/containerd/main_unix.go
+++ b/cmd/containerd/main_unix.go
@@ -11,7 +11,6 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/containerd/containerd/log"
-	"github.com/containerd/containerd/reaper"
 	"github.com/containerd/containerd/server"
 )
 
@@ -21,7 +20,6 @@ var handledSignals = []os.Signal{
 	unix.SIGTERM,
 	unix.SIGINT,
 	unix.SIGUSR1,
-	unix.SIGCHLD,
 	unix.SIGPIPE,
 }
 
@@ -36,10 +34,6 @@ func handleSignals(ctx context.Context, signals chan os.Signal, serverC chan *se
 			case s := <-signals:
 				log.G(ctx).WithField("signal", s).Debug("received signal")
 				switch s {
-				case unix.SIGCHLD:
-					if err := reaper.Reap(); err != nil {
-						log.G(ctx).WithError(err).Error("reap containerd processes")
-					}
 				case unix.SIGUSR1:
 					dumpStacks()
 				case unix.SIGPIPE:

--- a/linux/shim/client/client.go
+++ b/linux/shim/client/client.go
@@ -23,7 +23,6 @@ import (
 	"github.com/containerd/containerd/linux/shim"
 	shimapi "github.com/containerd/containerd/linux/shim/v1"
 	"github.com/containerd/containerd/log"
-	"github.com/containerd/containerd/reaper"
 	"github.com/containerd/containerd/sys"
 	ptypes "github.com/gogo/protobuf/types"
 )
@@ -51,8 +50,7 @@ func WithStart(binary, address, daemonAddress, cgroup string, debug bool, exitHa
 		if err != nil {
 			return nil, nil, err
 		}
-		ec, err := reaper.Default.Start(cmd)
-		if err != nil {
+		if err := cmd.Start(); err != nil {
 			return nil, nil, errors.Wrapf(err, "failed to start shim")
 		}
 		defer func() {
@@ -61,7 +59,7 @@ func WithStart(binary, address, daemonAddress, cgroup string, debug bool, exitHa
 			}
 		}()
 		go func() {
-			reaper.Default.Wait(cmd, ec)
+			cmd.Wait()
 			exitHandler()
 		}()
 		log.G(ctx).WithFields(logrus.Fields{

--- a/server/config.go
+++ b/server/config.go
@@ -23,8 +23,6 @@ type Config struct {
 	Metrics MetricsConfig `toml:"metrics"`
 	// Plugins provides plugin specific configuration for the initialization of a plugin
 	Plugins map[string]toml.Primitive `toml:"plugins"`
-	// NoSubreaper disables containerd as a subreaper
-	NoSubreaper bool `toml:"no_subreaper"`
 	// OOMScore adjust the containerd's oom score
 	OOMScore int `toml:"oom_score"`
 	// Cgroup specifies cgroup information for the containerd daemon process

--- a/server/server_linux.go
+++ b/server/server_linux.go
@@ -12,12 +12,6 @@ import (
 
 // apply sets config settings on the server process
 func apply(ctx context.Context, config *Config) error {
-	if !config.NoSubreaper {
-		log.G(ctx).Info("setting subreaper...")
-		if err := sys.SetSubreaper(1); err != nil {
-			return err
-		}
-	}
 	if config.OOMScore != 0 {
 		log.G(ctx).Debugf("changing OOM score to %d", config.OOMScore)
 		if err := sys.SetOOMScore(os.Getpid(), config.OOMScore); err != nil {


### PR DESCRIPTION
This allows other packages and plugins to easily exec things without
racing with the reaper.

The reaper is mostly needed in the shim but can be removed in containerd
in favor of the `exec.Cmd` apis

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>