### PR TITLE
Prevent panic from progress writer when console width is not available

### DIFF
--- a/progress/writer.go
+++ b/progress/writer.go
@@ -50,10 +50,14 @@ func (w *Writer) Flush() error {
 	if err != nil {
 		return fmt.Errorf("failed to get terminal width: %v", err)
 	}
+	width := int(ws.Width)
+	if width == 0 {
+		width = 80
+	}
 	strlines := strings.Split(w.buf.String(), "\n")
 	w.lines = -1
 	for _, line := range strlines {
-		w.lines += (len(stripLine(line))-1)/int(ws.Width) + 1
+		w.lines += (len(stripLine(line))-1)/width + 1
 	}
 
 	if _, err := w.w.Write(w.buf.Bytes()); err != nil {


### PR DESCRIPTION
Possible fix for #1974

The first commit is a small changes to just prevent the panic when console.Size()  reports 0.

The second commit does a little more work, and (effectively) skips the `clearLines()` when the console width can't be determined. Also removes a panic when stdin is not a file.

I'm not sure if there's a more appropriate way to fix this. 

