### PR TITLE
[release/1.0] services/tasks, linux: ignore shutdown tasks

### DIFF
--- a/linux/shim/service.go
+++ b/linux/shim/service.go
@@ -129,7 +129,7 @@ func (s *Service) Start(ctx context.Context, r *shimapi.StartRequest) (*shimapi.
 	defer s.mu.Unlock()
 	p := s.processes[r.ID]
 	if p == nil {
-		return nil, errdefs.ToGRPCf(errdefs.ErrNotFound, "process %s not found", r.ID)
+		return nil, errdefs.ToGRPCf(errdefs.ErrNotFound, "process %s", r.ID)
 	}
 	if err := p.Start(ctx); err != nil {
 		return nil, err
@@ -238,7 +238,7 @@ func (s *Service) State(ctx context.Context, r *shimapi.StateRequest) (*shimapi.
 	defer s.mu.Unlock()
 	p := s.processes[r.ID]
 	if p == nil {
-		return nil, errdefs.ToGRPCf(errdefs.ErrNotFound, "process id %s not found", r.ID)
+		return nil, errdefs.ToGRPCf(errdefs.ErrNotFound, "process id %s", r.ID)
 	}
 	st, err := p.Status(ctx)
 	if err != nil {

--- a/linux/task.go
+++ b/linux/task.go
@@ -6,9 +6,6 @@ import (
 	"context"
 	"sync"
 
-	"github.com/pkg/errors"
-	"google.golang.org/grpc"
-
 	"github.com/containerd/cgroups"
 	eventstypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/api/types/task"
@@ -20,6 +17,8 @@ import (
 	"github.com/containerd/containerd/runtime"
 	runc "github.com/containerd/go-runc"
 	"github.com/gogo/protobuf/types"
+	"github.com/pkg/errors"
+	"github.com/stevvooe/ttrpc"
 )
 
 // Task on a linux based system
@@ -109,7 +108,7 @@ func (t *Task) State(ctx context.Context) (runtime.State, error) {
 		ID: t.id,
 	})
 	if err != nil {
-		if err != grpc.ErrServerStopped {
+		if errors.Cause(err) != ttrpc.ErrClosed {
 			return runtime.State{}, errdefs.FromGRPC(err)
 		}
 		return runtime.State{}, errdefs.ErrNotFound


### PR DESCRIPTION
Because tasks may be deleted while listing containers, we need to ignore
errors from state requests that are due to a closed error. All of these
get mapped to ErrNotFound, which can be used to filter the entries.

There may be a better fix that does a better job of keeping track of the
intended state of a backend task. The current condition of assuming that
a closed client is a shutdown task may be too naive.

Signed-off-by: Stephen J Day <stephen.day@docker.com>
(cherry picked from commit c80ca4f4a22244d6d7b3f061e8d30ad7cc272439)
Signed-off-by: Stephen J Day <stephen.day@docker.com>