### PR TITLE
supervisor: fix memory leak

### DIFF
--- a/supervisor/delete.go
+++ b/supervisor/delete.go
@@ -27,11 +27,14 @@ func (s *Supervisor) delete(t *DeleteTask) error {
 			t.Process.Wait()
 		}
 		if !t.NoEvent {
-			execMap := s.getExecSyncMap(t.ID)
 			go func() {
 				// Wait for all exec processe events to be sent (we seem
 				// to sometimes receive them after the init event)
-				for _, ch := range execMap {
+				for {
+					ch := s.getExecSyncOneChannel(t.ID)
+					if ch == nil {
+						break
+					}
 					<-ch
 				}
 				s.deleteExecSyncMap(t.ID)

--- a/supervisor/exit.go
+++ b/supervisor/exit.go
@@ -89,6 +89,7 @@ func (s *Supervisor) execExit(t *ExecExitTask) error {
 			PID:       t.PID,
 			Status:    t.Status,
 		})
+		s.deleteExecSyncChannel(t.ID, t.PID)
 		close(synCh)
 	}()
 	return nil

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -451,10 +451,14 @@ func (s *Supervisor) getExecSyncChannel(containerID, pid string) chan struct{} {
 	return ch
 }
 
-func (s *Supervisor) getExecSyncMap(containerID string) map[string]chan struct{} {
+func (s *Supervisor) getExecSyncOneChannel(containerID string) chan struct{} {
 	s.containerExecSyncLock.Lock()
 	defer s.containerExecSyncLock.Unlock()
-	return s.containerExecSync[containerID]
+
+	for _, ch := range s.containerExecSync[containerID] {
+		return ch
+	}
+	return nil
 }
 
 func (s *Supervisor) deleteExecSyncMap(containerID string) {


### PR DESCRIPTION
Containerd don't deleteExecSyncChannel when exec command exit, and it lead  to the memory leak of containerd.

Use the following case, it can let containerd/system out of memory.
```
#!/bin/bash

num=100000000 

docker run -d --name memleak busybox sleep 100000000 

for(( i = 1; i < num; i++ ))  
do  
     docker exec -ti memleak  echo $i 
done 
```
use top -p pid-of-containerd, we can see containerd' RES increase.
```
[root@localhost test]# top -p 13984
top - 12:03:17 up 6 days, 16:16,  7 users,  load average: 2.42, 2.16, 2.07
Tasks:   1 total,   0 running,   1 sleeping,   0 stopped,   0 zombie
%Cpu(s):  7.5 us,  9.6 sy,  0.0 ni, 82.5 id,  0.0 wa,  0.0 hi,  0.3 si,  0.2 st
KiB Mem :  3864784 total,  1553916 free,   221500 used,  2089368 buff/cache
KiB Swap:        0 total,        0 free,        0 used.  3288152 avail Mem 

  PID USER      PR  NI    VIRT    RES    SHR S  %CPU %MEM     TIME+ COMMAND                                                                                                                                                                 
13984 root      20   0  684104  106588   4548 S  14.3  0.4   7:01.13 docker-containe
```

Signed-off-by: Shukui Yang <yangshukui@huawei.com>