### PR TITLE
experimental support for rootless mode

### DIFF
--- a/cio/io.go
+++ b/cio/io.go
@@ -121,6 +121,9 @@ func WithStreams(stdin io.Reader, stdout, stderr io.Writer) Opt {
 
 // WithFIFODir sets the fifo directory.
 // e.g. "/run/containerd/fifo", "/run/users/1001/containerd/fifo"
+//
+// For rootless execution, specifying WithFIFODir is required in most setup.
+// If WithFIFODir is not specified, NewCreator sets the directory to defaults.DefaultFIFODir.
 func WithFIFODir(dir string) Opt {
 	return func(opt *Streams) {
 		opt.FIFODir = dir

--- a/cmd/containerd-shim/main_unix.go
+++ b/cmd/containerd-shim/main_unix.go
@@ -65,7 +65,7 @@ func init() {
 	flag.StringVar(&socketFlag, "socket", "", "abstract socket path to serve")
 	flag.StringVar(&addressFlag, "address", "", "grpc address back to main containerd")
 	flag.StringVar(&workdirFlag, "workdir", "", "path used to storge large temporary data")
-	flag.StringVar(&runtimeRootFlag, "runtime-root", proc.RuncRoot, "root directory for the runtime")
+	flag.StringVar(&runtimeRootFlag, "runtime-root", proc.RuncRoot(), "root directory for the runtime")
 	flag.StringVar(&criuFlag, "criu", "", "path to criu binary")
 	flag.BoolVar(&systemdCgroupFlag, "systemd-cgroup", false, "set runtime to use systemd-cgroup")
 	// currently, the `containerd publish` utility is embedded in the daemon binary.

--- a/cmd/containerd/command/config_linux.go
+++ b/cmd/containerd/command/config_linux.go
@@ -18,11 +18,12 @@ package command
 
 import (
 	"github.com/containerd/containerd/defaults"
+	"github.com/containerd/containerd/rootless"
 	"github.com/containerd/containerd/services/server"
 )
 
 func defaultConfig() *server.Config {
-	return &server.Config{
+	c := &server.Config{
 		Root:  defaults.DefaultRootDir,
 		State: defaults.DefaultStateDir,
 		GRPC: server.GRPCConfig{
@@ -31,4 +32,10 @@ func defaultConfig() *server.Config {
 			MaxSendMsgSize: defaults.DefaultMaxSendMsgSize,
 		},
 	}
+	if rootless.RunningWithNonRootUsername {
+		c.Root = defaults.UserRootDir
+		c.State = defaults.UserStateDir
+		c.GRPC.Address = defaults.UserAddress
+	}
+	return c
 }

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -114,8 +114,12 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 			Path: parts[1],
 		}))
 	}
+
 	if context.IsSet("gpus") {
 		opts = append(opts, nvidia.WithGPUs(nvidia.WithDevices(context.Int("gpus")), nvidia.WithAllCapabilities))
+	}
+	if context.Bool("rootless") {
+		opts = append(opts, oci.WithRootless())
 	}
 	if context.IsSet("config") {
 		var s specs.Spec

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -24,3 +24,23 @@ const (
 	// sending protobufs passed over the GRPC API.
 	DefaultMaxSendMsgSize = 16 << 20
 )
+
+// User directories are used if $USER != "" && $USER != "root".
+var (
+	// UserRootDir is typically set to "/home/$USER/.local/share/containerd" on Linux during init().
+	UserRootDir = DefaultRootDir
+
+	// UserStateDir is typically set to "/run/user/$UID/containerd" on Linux.
+	// Typically this directory needs to be created with sticky bit.
+	// See https://github.com/opencontainers/runc/issues/1694
+	UserStateDir = DefaultStateDir
+
+	// UserAddress is typically set to "/run/user/$UID/containerd/containerd.sock" on Linux during init().
+	UserAddress = DefaultAddress
+
+	// UserDebugAddress is typically set to "/run/user/$UID/containerd/debug.sock" on Linux during init().
+	UserDebugAddress = DefaultDebugAddress
+
+	// UserFIFODir is typically set to "/run/user/$UID/containerd/fifo" on Linux during init().
+	UserFIFODir = DefaultFIFODir
+)

--- a/defaults/defaults_unix.go
+++ b/defaults/defaults_unix.go
@@ -18,6 +18,12 @@
 
 package defaults
 
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
 const (
 	// DefaultRootDir is the default location used by containerd to store
 	// persistent data
@@ -33,3 +39,20 @@ const (
 	// to store FIFOs.
 	DefaultFIFODir = "/run/containerd/fifo"
 )
+
+func init() {
+	//  pam_systemd sets XDG_RUNTIME_DIR but not other dirs.
+	if xdgDataHome := os.Getenv("XDG_DATA_HOME"); xdgDataHome != "" {
+		dirs := strings.Split(xdgDataHome, ":")
+		UserRootDir = filepath.Join(dirs[0], "containerd")
+	} else if home := os.Getenv("HOME"); home != "" {
+		UserRootDir = filepath.Join(home, ".local", "share", "containerd")
+	}
+	if xdgRuntimeDir := os.Getenv("XDG_RUNTIME_DIR"); xdgRuntimeDir != "" {
+		dirs := strings.Split(xdgRuntimeDir, ":")
+		UserStateDir = filepath.Join(dirs[0], "containerd")
+		UserAddress = filepath.Join(UserStateDir, "containerd.sock")
+		UserDebugAddress = filepath.Join(UserStateDir, "debug.sock")
+		UserFIFODir = filepath.Join(UserStateDir, "fifo")
+	}
+}

--- a/docs/rootless.md
+++ b/docs/rootless.md
@@ -1,0 +1,84 @@
+# Rootless mode (Experimental)
+
+Requirements:
+- [runc (May 30, 2018)](https://github.com/opencontainers/runc/commit/ecd55a4135e0a26de884ce436442914f945b1e76) or later
+- Some distros such as Debian (excluding Ubuntu) and Arch Linux require `echo 1 > /proc/sys/kernel/unprivileged_userns_clone`
+- `newuidmap` and `newgidmap` need to be installed on the host. These commands are provided by the `uidmap` package on most distros.
+- `/etc/subuid` and `/etc/subgid` should contain >= 65536 sub-IDs. e.g. `penguin:231072:65536`.
+- To run in a Docker container with non-root `USER`, `docker run --privileged` is still required. See also Jessie's blog: https://blog.jessfraz.com/post/building-container-images-securely-on-kubernetes/
+
+Daemon-side remarks:
+
+* The data dir will be set to `/home/$USER/.local/share/containerd` by default.
+* The address will be set to `/run/user/$UID/containerd/containerd.sock` by default.
+* CRI plugin is not supported yet.
+* `overlayfs` snapshotter is not supported except on [Ubuntu-flavored kernel](http://kernel.ubuntu.com/git/ubuntu/ubuntu-artful.git/commit/fs/overlayfs?h=Ubuntu-4.13.0-25.29&id=0a414bdc3d01f3b61ed86cfe3ce8b63a9240eba7). `native` snapshotter should work on non-Ubuntu kernel.
+
+Go client library remarks:
+* `oci.WithRootless()` removes Cgroups configuration. However, you can still set Cgroups configurations after calling `oci.WithRootless()`, if the permission bits are preconfigured on cgroup filesystems.
+
+Network namespace remarks:
+* To set up NAT across the host and the containers, you need to use either a TAP with a usermode network stack (slirp) or a SUID helper. See [RootlessKit](https://github.com/rootless-containers/rootlesskit).
+
+## Usage
+
+### Terminal 1:
+
+```
+$ unshare -U -m
+unshared$ echo $$ > /tmp/pid
+```
+
+Unsharing mountns (and userns) is required for mounting filesystems without real root privileges.
+
+### Terminal 2:
+
+```
+$ id -u
+1001
+$ grep $(whoami) /etc/subuid
+penguin:231072:65536
+$ grep $(whoami) /etc/subgid
+penguin:231072:65536
+$ newuidmap $(cat /tmp/pid) 0 1001 1 1 231072 65536
+$ newgidmap $(cat /tmp/pid) 0 1001 1 1 231072 65536
+```
+
+### Terminal 1:
+
+```
+unshared# containerd
+```
+
+### Terminal 2:
+
+```
+$ nsenter -U -m -t $(cat /tmp/pid)
+unshared# ctr -a /run/user/1001/containerd/containerd.sock images pull docker.io/library/debian:latest
+unshared# ctr -a /run/user/1001/containerd/containerd.sock run -t --rm --rootless --net-host docker.io/library/debian:latest foo
+foo#
+```
+
+## Usage ([RootlessKit](https://github.com/rootless-containers/rootlesskit))
+
+RootlessKit can be used for executing `unshare` and `newuidmap/newgidmap` at once.
+RootlessKit also supports unsharing the network namespace with usermode NAT such as [VPNKit](https://github.com/moby/vpnkit)
+and [libvdeplug_slirp](https://github.com/moby/vpnkit).
+
+
+### Terminal 1:
+
+The following example is tested with RootlessKit [`20b0fc24b305b031a61ef1a1ca456aadafaf5e77`](https://github.com/rootless-containers/rootlesskit/tree/20b0fc24b305b031a61ef1a1ca456aadafaf5e77).
+
+```
+$ rootlesskit --state-dir=/tmp/foo --net=vpnkit --copy-up=/etc containerd
+```
+
+### Terminal 2:
+
+```
+$ nsenter -U -m -n -t $(cat /tmp/foo/child_pid)
+unshared# ctr -a /run/user/1001/containerd/containerd.sock images pull docker.io/library/debian:latest
+unshared# ctr -a /run/user/1001/containerd/containerd.sock run -t --rm --rootless --net-host docker.io/library/debian:latest foo
+foo#
+```

--- a/oci/spec_opts_linux.go
+++ b/oci/spec_opts_linux.go
@@ -1,0 +1,32 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package oci
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/rootless/specconv"
+)
+
+// WithRootless applies github.com/containerd/containerd/rootless/specconv.ToRootless().
+// WithRootless needs to be called in the daemon's user namespace.
+func WithRootless() SpecOpts {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
+		return specconv.ToRootless(s)
+	}
+}

--- a/oci/spec_opts_nolinux.go
+++ b/oci/spec_opts_nolinux.go
@@ -1,0 +1,34 @@
+// +build !linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package oci
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/errdefs"
+)
+
+// WithRootless is unsupported on non-Linux but defined so as to
+// keep `ctr` compilable on Darwin.
+func WithRootless() SpecOpts {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
+		return errdefs.ErrNotImplemented
+	}
+}

--- a/rootless/rootless.go
+++ b/rootless/rootless.go
@@ -1,0 +1,38 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package rootless
+
+import (
+	"os"
+)
+
+var (
+	// RunningWithNonRootUsername is set to true if we $USER is set to a non-root value.
+	// Note that this variable is set to true even when EUID is 0, typically when
+	// running in a user namespace.
+	//
+	// The value of this variable is mostly used for configuring default paths.
+	// If the value is true, $HOME and $XDG_RUNTIME_DIR should be honored for setting up the default paths.
+	// If false (not only EUID==0 but also $USER==root), $HOME and $XDG_RUNTIME_DIR should be ignored
+	// even if we are in a user namespace.
+	RunningWithNonRootUsername bool
+)
+
+func init() {
+	u := os.Getenv("USER")
+	RunningWithNonRootUsername = u != "" && u != "root"
+}

--- a/rootless/specconv/specconv_linux.go
+++ b/rootless/specconv/specconv_linux.go
@@ -1,0 +1,130 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package specconv was ported over from https://github.com/moby/buildkit/pull/486
+package specconv
+
+import (
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/opencontainers/runc/libcontainer/system"
+	"github.com/opencontainers/runc/libcontainer/user"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+)
+
+// ToRootless converts spec to be compatible with "rootless" runc.
+// * Adds userns (Note: since we are already in userns, ideally we should not need to do this. runc-side issue is tracked at https://github.com/opencontainers/runc/issues/1837)
+// * Fix up mount flags (same as above)
+// * Replace /sys with bind-mount (FIXME: we don't need to do this if netns is unshared)
+func ToRootless(spec *specs.Spec) error {
+	if !system.RunningInUserNS() {
+		return errors.New("needs to be in user namespace")
+	}
+	uidMap, err := user.CurrentProcessUIDMap()
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	gidMap, err := user.CurrentProcessUIDMap()
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return toRootless(spec, uidMap, gidMap)
+}
+
+// toRootless was forked from github.com/opencontainers/runc/libcontainer/specconv
+func toRootless(spec *specs.Spec, uidMap, gidMap []user.IDMap) error {
+	if err := configureUserNS(spec, uidMap, gidMap); err != nil {
+		return err
+	}
+	if err := configureMounts(spec); err != nil {
+		return err
+	}
+
+	// Remove cgroup settings.
+	spec.Linux.Resources = nil
+	spec.Linux.CgroupsPath = ""
+	return nil
+}
+
+// configureUserNS add suserns and the current ID map to the spec.
+// Since we are already in userns, ideally we should not need to add userns.
+// However, currently rootless runc always requires userns to be added.
+// https://github.com/opencontainers/runc/issues/1837
+func configureUserNS(spec *specs.Spec, uidMap, gidMap []user.IDMap) error {
+	spec.Linux.Namespaces = append(spec.Linux.Namespaces, specs.LinuxNamespace{
+		Type: specs.UserNamespace,
+	})
+
+	sort.Slice(uidMap, func(i, j int) bool { return uidMap[i].ID < uidMap[j].ID })
+	uNextContainerID := int64(0)
+	for _, u := range uidMap {
+		spec.Linux.UIDMappings = append(spec.Linux.UIDMappings,
+			specs.LinuxIDMapping{
+				HostID:      uint32(u.ID),
+				ContainerID: uint32(uNextContainerID),
+				Size:        uint32(u.Count),
+			})
+		uNextContainerID += u.Count
+	}
+	sort.Slice(gidMap, func(i, j int) bool { return gidMap[i].ID < gidMap[j].ID })
+	gNextContainerID := int64(0)
+	for _, g := range gidMap {
+		spec.Linux.GIDMappings = append(spec.Linux.GIDMappings,
+			specs.LinuxIDMapping{
+				HostID:      uint32(g.ID),
+				ContainerID: uint32(gNextContainerID),
+				Size:        uint32(g.Count),
+			})
+		gNextContainerID += g.Count
+	}
+	return nil
+}
+
+func configureMounts(spec *specs.Spec) error {
+	var mounts []specs.Mount
+	for _, mount := range spec.Mounts {
+		// Ignore all mounts that are under /sys, because we add /sys later.
+		if strings.HasPrefix(mount.Destination, "/sys") {
+			continue
+		}
+
+		// Remove all gid= and uid= mappings.
+		// Since we are already in userns, ideally we should not need to do this.
+		// https://github.com/opencontainers/runc/issues/1837
+		var options []string
+		for _, option := range mount.Options {
+			if !strings.HasPrefix(option, "gid=") && !strings.HasPrefix(option, "uid=") {
+				options = append(options, option)
+			}
+		}
+		mount.Options = options
+		mounts = append(mounts, mount)
+	}
+
+	// Add the sysfs mount as an rbind, because we can't mount /sys unless we have netns.
+	// TODO: keep original /sys mount when we have netns.
+	mounts = append(mounts, specs.Mount{
+		Source:      "/sys",
+		Destination: "/sys",
+		Type:        "none",
+		Options:     []string{"rbind", "nosuid", "noexec", "nodev", "ro"},
+	})
+	spec.Mounts = mounts
+	return nil
+}

--- a/rootless/specconv/specconv_linux_test.go
+++ b/rootless/specconv/specconv_linux_test.go
@@ -1,0 +1,59 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package specconv
+
+import (
+	"testing"
+
+	"github.com/opencontainers/runc/libcontainer/specconv"
+	"github.com/opencontainers/runc/libcontainer/user"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
+)
+
+func TestToRootless(t *testing.T) {
+	spec := specconv.Example()
+	uidMap := []user.IDMap{
+		{
+			ID:       0,
+			ParentID: 4242,
+			Count:    1,
+		},
+		{
+			ID:       1,
+			ParentID: 231072,
+			Count:    65536,
+		},
+	}
+	gidMap := uidMap
+	expectedUIDMappings := []specs.LinuxIDMapping{
+		{
+			HostID:      0,
+			ContainerID: 0,
+			Size:        1,
+		},
+		{
+			HostID:      1,
+			ContainerID: 1,
+			Size:        65536,
+		},
+	}
+	err := toRootless(spec, uidMap, gidMap)
+	assert.NilError(t, err)
+	assert.Assert(t, is.DeepEqual(expectedUIDMappings, spec.Linux.UIDMappings))
+}

--- a/runtime/linux/proc/init.go
+++ b/runtime/linux/proc/init.go
@@ -81,7 +81,7 @@ type Init struct {
 // NewRunc returns a new runc instance for a process
 func NewRunc(root, path, namespace, runtime, criu string, systemd bool) *runc.Runc {
 	if root == "" {
-		root = RuncRoot
+		root = RuncRoot()
 	}
 	return &runc.Runc{
 		Command:       runtime,

--- a/runtime/linux/proc/process.go
+++ b/runtime/linux/proc/process.go
@@ -19,11 +19,20 @@
 package proc
 
 import (
+	"path/filepath"
+
+	"github.com/containerd/containerd/defaults"
+	"github.com/containerd/containerd/rootless"
 	"github.com/pkg/errors"
 )
 
 // RuncRoot is the path to the root runc state directory
-const RuncRoot = "/run/containerd/runc"
+func RuncRoot() string {
+	if rootless.RunningWithNonRootUsername {
+		return filepath.Join(defaults.UserStateDir, "runc")
+	}
+	return filepath.Join(defaults.DefaultStateDir, "runc")
+}
 
 func stateName(v interface{}) string {
 	switch v.(type) {

--- a/runtime/linux/runtime.go
+++ b/runtime/linux/runtime.go
@@ -494,7 +494,7 @@ func (r *Runtime) getRuntime(ctx context.Context, ns, id string) (*runc.Runc, er
 
 	var (
 		cmd  = r.config.Runtime
-		root = proc.RuncRoot
+		root = proc.RuncRoot()
 	)
 	if ropts != nil {
 		if ropts.Runtime != "" {

--- a/vendor.conf
+++ b/vendor.conf
@@ -20,7 +20,7 @@ github.com/gogo/protobuf v1.0.0
 github.com/gogo/googleapis 08a7655d27152912db7aaf4f983275eaf8d128ef
 github.com/golang/protobuf v1.1.0
 github.com/opencontainers/runtime-spec v1.0.1
-github.com/opencontainers/runc 69663f0bd4b60df09991c08812a60108003fa340
+github.com/opencontainers/runc 2c632d1a2de0192c3f18a2542ccb6f30a8719b1f
 github.com/sirupsen/logrus v1.0.0
 github.com/urfave/cli 7bc6a0acffa589f415f88aca16cc1de5ffd66f9c
 golang.org/x/net b3756b4b77d7b13260a0a2ec658753cf48922eac

--- a/vendor/github.com/opencontainers/runc/libcontainer/configs/config.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/configs/config.go
@@ -141,9 +141,10 @@ type Config struct {
 
 	// OomScoreAdj specifies the adjustment to be made by the kernel when calculating oom scores
 	// for a process. Valid values are between the range [-1000, '1000'], where processes with
-	// higher scores are preferred for being killed.
+	// higher scores are preferred for being killed. If it is unset then we don't touch the current
+	// value.
 	// More information about kernel oom score calculation here: https://lwn.net/Articles/317814/
-	OomScoreAdj int `json:"oom_score_adj"`
+	OomScoreAdj *int `json:"oom_score_adj,omitempty"`
 
 	// UidMappings is an array of User ID mappings for User Namespaces
 	UidMappings []IDMap `json:"uid_mappings"`

--- a/vendor/github.com/opencontainers/runc/libcontainer/devices/devices.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/devices/devices.go
@@ -30,8 +30,9 @@ func DeviceFromPath(path, permissions string) (*configs.Device, error) {
 	}
 
 	var (
-		devNumber = stat.Rdev
+		devNumber = uint64(stat.Rdev)
 		major     = unix.Major(devNumber)
+		minor     = unix.Minor(devNumber)
 	)
 	if major == 0 {
 		return nil, ErrNotADevice
@@ -51,7 +52,7 @@ func DeviceFromPath(path, permissions string) (*configs.Device, error) {
 		Type:        devType,
 		Path:        path,
 		Major:       int64(major),
-		Minor:       int64(unix.Minor(devNumber)),
+		Minor:       int64(minor),
 		Permissions: permissions,
 		FileMode:    os.FileMode(mode),
 		Uid:         stat.Uid,

--- a/vendor/github.com/opencontainers/runc/libcontainer/nsenter/nsexec.c
+++ b/vendor/github.com/opencontainers/runc/libcontainer/nsenter/nsexec.c
@@ -505,7 +505,8 @@ void join_namespaces(char *nslist)
 
 		ns->fd = fd;
 		ns->ns = nsflag(namespace);
-		strncpy(ns->path, path, PATH_MAX);
+		strncpy(ns->path, path, PATH_MAX - 1);
+		ns->path[PATH_MAX - 1] = '\0';
 	} while ((namespace = strtok_r(NULL, ",", &saveptr)) != NULL);
 
 	/*
@@ -678,17 +679,15 @@ void nsexec(void)
 					/*
 					 * Enable setgroups(2) if we've been asked to. But we also
 					 * have to explicitly disable setgroups(2) if we're
-					 * creating a rootless container (this is required since
-					 * Linux 3.19).
+					 * creating a rootless container for single-entry mapping.
+					 * i.e. config.is_setgroup == false.
+					 * (this is required since Linux 3.19).
+					 *
+					 * For rootless multi-entry mapping, config.is_setgroup shall be true and
+					 * newuidmap/newgidmap shall be used.
 					 */
-					if (config.is_rootless && config.is_setgroup) {
-						kill(child, SIGKILL);
-						bail("cannot allow setgroup in an unprivileged user namespace setup");
-					}
 
-					if (config.is_setgroup)
-						update_setgroups(child, SETGROUPS_ALLOW);
-					if (config.is_rootless)
+					if (config.is_rootless && !config.is_setgroup)
 						update_setgroups(child, SETGROUPS_DENY);
 
 					/* Set up mappings. */
@@ -810,24 +809,29 @@ void nsexec(void)
 				join_namespaces(config.namespaces);
 
 			/*
-			 * Unshare all of the namespaces. Now, it should be noted that this
-			 * ordering might break in the future (especially with rootless
-			 * containers). But for now, it's not possible to split this into
-			 * CLONE_NEWUSER + [the rest] because of some RHEL SELinux issues.
-			 *
-			 * Note that we don't merge this with clone() because there were
-			 * some old kernel versions where clone(CLONE_PARENT | CLONE_NEWPID)
-			 * was broken, so we'll just do it the long way anyway.
-			 */
-			if (unshare(config.cloneflags) < 0)
-				bail("failed to unshare namespaces");
-
-			/*
 			 * Deal with user namespaces first. They are quite special, as they
 			 * affect our ability to unshare other namespaces and are used as
 			 * context for privilege checks.
+			 *
+			 * We don't unshare all namespaces in one go. The reason for this
+			 * is that, while the kernel documentation may claim otherwise,
+			 * there are certain cases where unsharing all namespaces at once
+			 * will result in namespace objects being owned incorrectly.
+			 * Ideally we should just fix these kernel bugs, but it's better to
+			 * be safe than sorry, and fix them separately.
+			 *
+			 * A specific case of this is that the SELinux label of the
+			 * internal kern-mount that mqueue uses will be incorrect if the
+			 * UTS namespace is cloned before the USER namespace is mapped.
+			 * I've also heard of similar problems with the network namespace
+			 * in some scenarios. This also mirrors how LXC deals with this
+			 * problem.
 			 */
 			if (config.cloneflags & CLONE_NEWUSER) {
+				if (unshare(CLONE_NEWUSER) < 0)
+					bail("failed to unshare user namespace");
+				config.cloneflags &= ~CLONE_NEWUSER;
+
 				/*
 				 * We don't have the privileges to do any mapping here (see the
 				 * clone_parent rant). So signal our parent to hook us up.
@@ -853,7 +857,20 @@ void nsexec(void)
 					if (prctl(PR_SET_DUMPABLE, 0, 0, 0, 0) < 0)
 						bail("failed to set process as dumpable");
 				}
+
+				/* Become root in the namespace proper. */
+				if (setresuid(0, 0, 0) < 0)
+					bail("failed to become root in user namespace");
 			}
+
+			/*
+			 * Unshare all of the namespaces. Note that we don't merge this
+			 * with clone() because there were some old kernel versions where
+			 * clone(CLONE_PARENT | CLONE_NEWPID) was broken, so we'll just do
+			 * it the long way.
+			 */
+			if (unshare(config.cloneflags) < 0)
+				bail("failed to unshare namespaces");
 
 			/*
 			 * TODO: What about non-namespace clone flags that we're dropping here?

--- a/vendor/github.com/opencontainers/runc/libcontainer/specconv/example.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/specconv/example.go
@@ -1,0 +1,221 @@
+package specconv
+
+import (
+	"os"
+	"strings"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// Example returns an example spec file, with many options set so a user can
+// see what a standard spec file looks like.
+func Example() *specs.Spec {
+	return &specs.Spec{
+		Version: specs.Version,
+		Root: &specs.Root{
+			Path:     "rootfs",
+			Readonly: true,
+		},
+		Process: &specs.Process{
+			Terminal: true,
+			User:     specs.User{},
+			Args: []string{
+				"sh",
+			},
+			Env: []string{
+				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+				"TERM=xterm",
+			},
+			Cwd:             "/",
+			NoNewPrivileges: true,
+			Capabilities: &specs.LinuxCapabilities{
+				Bounding: []string{
+					"CAP_AUDIT_WRITE",
+					"CAP_KILL",
+					"CAP_NET_BIND_SERVICE",
+				},
+				Permitted: []string{
+					"CAP_AUDIT_WRITE",
+					"CAP_KILL",
+					"CAP_NET_BIND_SERVICE",
+				},
+				Inheritable: []string{
+					"CAP_AUDIT_WRITE",
+					"CAP_KILL",
+					"CAP_NET_BIND_SERVICE",
+				},
+				Ambient: []string{
+					"CAP_AUDIT_WRITE",
+					"CAP_KILL",
+					"CAP_NET_BIND_SERVICE",
+				},
+				Effective: []string{
+					"CAP_AUDIT_WRITE",
+					"CAP_KILL",
+					"CAP_NET_BIND_SERVICE",
+				},
+			},
+			Rlimits: []specs.POSIXRlimit{
+				{
+					Type: "RLIMIT_NOFILE",
+					Hard: uint64(1024),
+					Soft: uint64(1024),
+				},
+			},
+		},
+		Hostname: "runc",
+		Mounts: []specs.Mount{
+			{
+				Destination: "/proc",
+				Type:        "proc",
+				Source:      "proc",
+				Options:     nil,
+			},
+			{
+				Destination: "/dev",
+				Type:        "tmpfs",
+				Source:      "tmpfs",
+				Options:     []string{"nosuid", "strictatime", "mode=755", "size=65536k"},
+			},
+			{
+				Destination: "/dev/pts",
+				Type:        "devpts",
+				Source:      "devpts",
+				Options:     []string{"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620", "gid=5"},
+			},
+			{
+				Destination: "/dev/shm",
+				Type:        "tmpfs",
+				Source:      "shm",
+				Options:     []string{"nosuid", "noexec", "nodev", "mode=1777", "size=65536k"},
+			},
+			{
+				Destination: "/dev/mqueue",
+				Type:        "mqueue",
+				Source:      "mqueue",
+				Options:     []string{"nosuid", "noexec", "nodev"},
+			},
+			{
+				Destination: "/sys",
+				Type:        "sysfs",
+				Source:      "sysfs",
+				Options:     []string{"nosuid", "noexec", "nodev", "ro"},
+			},
+			{
+				Destination: "/sys/fs/cgroup",
+				Type:        "cgroup",
+				Source:      "cgroup",
+				Options:     []string{"nosuid", "noexec", "nodev", "relatime", "ro"},
+			},
+		},
+		Linux: &specs.Linux{
+			MaskedPaths: []string{
+				"/proc/kcore",
+				"/proc/latency_stats",
+				"/proc/timer_list",
+				"/proc/timer_stats",
+				"/proc/sched_debug",
+				"/sys/firmware",
+				"/proc/scsi",
+			},
+			ReadonlyPaths: []string{
+				"/proc/asound",
+				"/proc/bus",
+				"/proc/fs",
+				"/proc/irq",
+				"/proc/sys",
+				"/proc/sysrq-trigger",
+			},
+			Resources: &specs.LinuxResources{
+				Devices: []specs.LinuxDeviceCgroup{
+					{
+						Allow:  false,
+						Access: "rwm",
+					},
+				},
+			},
+			Namespaces: []specs.LinuxNamespace{
+				{
+					Type: "pid",
+				},
+				{
+					Type: "network",
+				},
+				{
+					Type: "ipc",
+				},
+				{
+					Type: "uts",
+				},
+				{
+					Type: "mount",
+				},
+			},
+		},
+	}
+}
+
+// ToRootless converts the given spec file into one that should work with
+// rootless containers, by removing incompatible options and adding others that
+// are needed.
+func ToRootless(spec *specs.Spec) {
+	var namespaces []specs.LinuxNamespace
+
+	// Remove networkns from the spec.
+	for _, ns := range spec.Linux.Namespaces {
+		switch ns.Type {
+		case specs.NetworkNamespace, specs.UserNamespace:
+			// Do nothing.
+		default:
+			namespaces = append(namespaces, ns)
+		}
+	}
+	// Add userns to the spec.
+	namespaces = append(namespaces, specs.LinuxNamespace{
+		Type: specs.UserNamespace,
+	})
+	spec.Linux.Namespaces = namespaces
+
+	// Add mappings for the current user.
+	spec.Linux.UIDMappings = []specs.LinuxIDMapping{{
+		HostID:      uint32(os.Geteuid()),
+		ContainerID: 0,
+		Size:        1,
+	}}
+	spec.Linux.GIDMappings = []specs.LinuxIDMapping{{
+		HostID:      uint32(os.Getegid()),
+		ContainerID: 0,
+		Size:        1,
+	}}
+
+	// Fix up mounts.
+	var mounts []specs.Mount
+	for _, mount := range spec.Mounts {
+		// Ignore all mounts that are under /sys.
+		if strings.HasPrefix(mount.Destination, "/sys") {
+			continue
+		}
+
+		// Remove all gid= and uid= mappings.
+		var options []string
+		for _, option := range mount.Options {
+			if !strings.HasPrefix(option, "gid=") && !strings.HasPrefix(option, "uid=") {
+				options = append(options, option)
+			}
+		}
+
+		mount.Options = options
+		mounts = append(mounts, mount)
+	}
+	// Add the sysfs mount as an rbind.
+	mounts = append(mounts, specs.Mount{
+		Source:      "/sys",
+		Destination: "/sys",
+		Type:        "none",
+		Options:     []string{"rbind", "nosuid", "noexec", "nodev", "ro"},
+	})
+	spec.Mounts = mounts
+
+	// Remove cgroup settings.
+	spec.Linux.Resources = nil
+}

--- a/vendor/github.com/opencontainers/runc/libcontainer/specconv/spec_linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/specconv/spec_linux.go
@@ -1,0 +1,836 @@
+// +build linux
+
+// Package specconv implements conversion of specifications to libcontainer
+// configurations
+package specconv
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runc/libcontainer/seccomp"
+	libcontainerUtils "github.com/opencontainers/runc/libcontainer/utils"
+	"github.com/opencontainers/runtime-spec/specs-go"
+
+	"golang.org/x/sys/unix"
+)
+
+const wildcard = -1
+
+var namespaceMapping = map[specs.LinuxNamespaceType]configs.NamespaceType{
+	specs.PIDNamespace:     configs.NEWPID,
+	specs.NetworkNamespace: configs.NEWNET,
+	specs.MountNamespace:   configs.NEWNS,
+	specs.UserNamespace:    configs.NEWUSER,
+	specs.IPCNamespace:     configs.NEWIPC,
+	specs.UTSNamespace:     configs.NEWUTS,
+}
+
+var mountPropagationMapping = map[string]int{
+	"rprivate":    unix.MS_PRIVATE | unix.MS_REC,
+	"private":     unix.MS_PRIVATE,
+	"rslave":      unix.MS_SLAVE | unix.MS_REC,
+	"slave":       unix.MS_SLAVE,
+	"rshared":     unix.MS_SHARED | unix.MS_REC,
+	"shared":      unix.MS_SHARED,
+	"runbindable": unix.MS_UNBINDABLE | unix.MS_REC,
+	"unbindable":  unix.MS_UNBINDABLE,
+	"":            0,
+}
+
+var allowedDevices = []*configs.Device{
+	// allow mknod for any device
+	{
+		Type:        'c',
+		Major:       wildcard,
+		Minor:       wildcard,
+		Permissions: "m",
+		Allow:       true,
+	},
+	{
+		Type:        'b',
+		Major:       wildcard,
+		Minor:       wildcard,
+		Permissions: "m",
+		Allow:       true,
+	},
+	{
+		Type:        'c',
+		Path:        "/dev/null",
+		Major:       1,
+		Minor:       3,
+		Permissions: "rwm",
+		Allow:       true,
+	},
+	{
+		Type:        'c',
+		Path:        "/dev/random",
+		Major:       1,
+		Minor:       8,
+		Permissions: "rwm",
+		Allow:       true,
+	},
+	{
+		Type:        'c',
+		Path:        "/dev/full",
+		Major:       1,
+		Minor:       7,
+		Permissions: "rwm",
+		Allow:       true,
+	},
+	{
+		Type:        'c',
+		Path:        "/dev/tty",
+		Major:       5,
+		Minor:       0,
+		Permissions: "rwm",
+		Allow:       true,
+	},
+	{
+		Type:        'c',
+		Path:        "/dev/zero",
+		Major:       1,
+		Minor:       5,
+		Permissions: "rwm",
+		Allow:       true,
+	},
+	{
+		Type:        'c',
+		Path:        "/dev/urandom",
+		Major:       1,
+		Minor:       9,
+		Permissions: "rwm",
+		Allow:       true,
+	},
+	{
+		Path:        "/dev/console",
+		Type:        'c',
+		Major:       5,
+		Minor:       1,
+		Permissions: "rwm",
+		Allow:       true,
+	},
+	// /dev/pts/ - pts namespaces are "coming soon"
+	{
+		Path:        "",
+		Type:        'c',
+		Major:       136,
+		Minor:       wildcard,
+		Permissions: "rwm",
+		Allow:       true,
+	},
+	{
+		Path:        "",
+		Type:        'c',
+		Major:       5,
+		Minor:       2,
+		Permissions: "rwm",
+		Allow:       true,
+	},
+	// tuntap
+	{
+		Path:        "",
+		Type:        'c',
+		Major:       10,
+		Minor:       200,
+		Permissions: "rwm",
+		Allow:       true,
+	},
+}
+
+type CreateOpts struct {
+	CgroupName       string
+	UseSystemdCgroup bool
+	NoPivotRoot      bool
+	NoNewKeyring     bool
+	Spec             *specs.Spec
+	Rootless         bool
+}
+
+// CreateLibcontainerConfig creates a new libcontainer configuration from a
+// given specification and a cgroup name
+func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
+	// runc's cwd will always be the bundle path
+	rcwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	cwd, err := filepath.Abs(rcwd)
+	if err != nil {
+		return nil, err
+	}
+	spec := opts.Spec
+	if spec.Root == nil {
+		return nil, fmt.Errorf("Root must be specified")
+	}
+	rootfsPath := spec.Root.Path
+	if !filepath.IsAbs(rootfsPath) {
+		rootfsPath = filepath.Join(cwd, rootfsPath)
+	}
+	labels := []string{}
+	for k, v := range spec.Annotations {
+		labels = append(labels, fmt.Sprintf("%s=%s", k, v))
+	}
+	config := &configs.Config{
+		Rootfs:       rootfsPath,
+		NoPivotRoot:  opts.NoPivotRoot,
+		Readonlyfs:   spec.Root.Readonly,
+		Hostname:     spec.Hostname,
+		Labels:       append(labels, fmt.Sprintf("bundle=%s", cwd)),
+		NoNewKeyring: opts.NoNewKeyring,
+		Rootless:     opts.Rootless,
+	}
+
+	exists := false
+	for _, m := range spec.Mounts {
+		config.Mounts = append(config.Mounts, createLibcontainerMount(cwd, m))
+	}
+	if err := createDevices(spec, config); err != nil {
+		return nil, err
+	}
+	c, err := createCgroupConfig(opts)
+	if err != nil {
+		return nil, err
+	}
+	config.Cgroups = c
+	// set linux-specific config
+	if spec.Linux != nil {
+		if config.RootPropagation, exists = mountPropagationMapping[spec.Linux.RootfsPropagation]; !exists {
+			return nil, fmt.Errorf("rootfsPropagation=%v is not supported", spec.Linux.RootfsPropagation)
+		}
+		if config.NoPivotRoot && (config.RootPropagation&unix.MS_PRIVATE != 0) {
+			return nil, fmt.Errorf("rootfsPropagation of [r]private is not safe without pivot_root")
+		}
+
+		for _, ns := range spec.Linux.Namespaces {
+			t, exists := namespaceMapping[ns.Type]
+			if !exists {
+				return nil, fmt.Errorf("namespace %q does not exist", ns)
+			}
+			if config.Namespaces.Contains(t) {
+				return nil, fmt.Errorf("malformed spec file: duplicated ns %q", ns)
+			}
+			config.Namespaces.Add(t, ns.Path)
+		}
+		if config.Namespaces.Contains(configs.NEWNET) && config.Namespaces.PathOf(configs.NEWNET) == "" {
+			config.Networks = []*configs.Network{
+				{
+					Type: "loopback",
+				},
+			}
+		}
+		if config.Namespaces.Contains(configs.NEWUSER) {
+			if err := setupUserNamespace(spec, config); err != nil {
+				return nil, err
+			}
+		}
+		config.MaskPaths = spec.Linux.MaskedPaths
+		config.ReadonlyPaths = spec.Linux.ReadonlyPaths
+		config.MountLabel = spec.Linux.MountLabel
+		config.Sysctl = spec.Linux.Sysctl
+		if spec.Linux.Seccomp != nil {
+			seccomp, err := SetupSeccomp(spec.Linux.Seccomp)
+			if err != nil {
+				return nil, err
+			}
+			config.Seccomp = seccomp
+		}
+	}
+	if spec.Process.SelinuxLabel != "" {
+		config.ProcessLabel = spec.Process.SelinuxLabel
+	}
+	if spec.Process != nil {
+		config.OomScoreAdj = spec.Process.OOMScoreAdj
+	}
+	if spec.Process.Capabilities != nil {
+		config.Capabilities = &configs.Capabilities{
+			Bounding:    spec.Process.Capabilities.Bounding,
+			Effective:   spec.Process.Capabilities.Effective,
+			Permitted:   spec.Process.Capabilities.Permitted,
+			Inheritable: spec.Process.Capabilities.Inheritable,
+			Ambient:     spec.Process.Capabilities.Ambient,
+		}
+	}
+	createHooks(spec, config)
+	config.Version = specs.Version
+	if spec.Linux.IntelRdt != nil {
+		config.IntelRdt = &configs.IntelRdt{}
+		if spec.Linux.IntelRdt.L3CacheSchema != "" {
+			config.IntelRdt.L3CacheSchema = spec.Linux.IntelRdt.L3CacheSchema
+		}
+	}
+	return config, nil
+}
+
+func createLibcontainerMount(cwd string, m specs.Mount) *configs.Mount {
+	flags, pgflags, data, ext := parseMountOptions(m.Options)
+	source := m.Source
+	device := m.Type
+	if flags|unix.MS_BIND != 0 {
+		if device == "" {
+			device = "bind"
+		}
+		if !filepath.IsAbs(source) {
+			source = filepath.Join(cwd, m.Source)
+		}
+	}
+	return &configs.Mount{
+		Device:           device,
+		Source:           source,
+		Destination:      m.Destination,
+		Data:             data,
+		Flags:            flags,
+		PropagationFlags: pgflags,
+		Extensions:       ext,
+	}
+}
+
+func createCgroupConfig(opts *CreateOpts) (*configs.Cgroup, error) {
+	var (
+		myCgroupPath string
+
+		spec             = opts.Spec
+		useSystemdCgroup = opts.UseSystemdCgroup
+		name             = opts.CgroupName
+	)
+
+	c := &configs.Cgroup{
+		Resources: &configs.Resources{},
+	}
+
+	if spec.Linux != nil && spec.Linux.CgroupsPath != "" {
+		myCgroupPath = libcontainerUtils.CleanPath(spec.Linux.CgroupsPath)
+		if useSystemdCgroup {
+			myCgroupPath = spec.Linux.CgroupsPath
+		}
+	}
+
+	if useSystemdCgroup {
+		if myCgroupPath == "" {
+			c.Parent = "system.slice"
+			c.ScopePrefix = "runc"
+			c.Name = name
+		} else {
+			// Parse the path from expected "slice:prefix:name"
+			// for e.g. "system.slice:docker:1234"
+			parts := strings.Split(myCgroupPath, ":")
+			if len(parts) != 3 {
+				return nil, fmt.Errorf("expected cgroupsPath to be of format \"slice:prefix:name\" for systemd cgroups")
+			}
+			c.Parent = parts[0]
+			c.ScopePrefix = parts[1]
+			c.Name = parts[2]
+		}
+	} else {
+		if myCgroupPath == "" {
+			c.Name = name
+		}
+		c.Path = myCgroupPath
+	}
+
+	// In rootless containers, any attempt to make cgroup changes will fail.
+	// libcontainer will validate this and we shouldn't add any cgroup options
+	// the user didn't specify.
+	if !opts.Rootless {
+		c.Resources.AllowedDevices = allowedDevices
+	}
+	if spec.Linux != nil {
+		r := spec.Linux.Resources
+		if r == nil {
+			return c, nil
+		}
+		for i, d := range spec.Linux.Resources.Devices {
+			var (
+				t     = "a"
+				major = int64(-1)
+				minor = int64(-1)
+			)
+			if d.Type != "" {
+				t = d.Type
+			}
+			if d.Major != nil {
+				major = *d.Major
+			}
+			if d.Minor != nil {
+				minor = *d.Minor
+			}
+			if d.Access == "" {
+				return nil, fmt.Errorf("device access at %d field cannot be empty", i)
+			}
+			dt, err := stringToCgroupDeviceRune(t)
+			if err != nil {
+				return nil, err
+			}
+			dd := &configs.Device{
+				Type:        dt,
+				Major:       major,
+				Minor:       minor,
+				Permissions: d.Access,
+				Allow:       d.Allow,
+			}
+			c.Resources.Devices = append(c.Resources.Devices, dd)
+		}
+		if r.Memory != nil {
+			if r.Memory.Limit != nil {
+				c.Resources.Memory = *r.Memory.Limit
+			}
+			if r.Memory.Reservation != nil {
+				c.Resources.MemoryReservation = *r.Memory.Reservation
+			}
+			if r.Memory.Swap != nil {
+				c.Resources.MemorySwap = *r.Memory.Swap
+			}
+			if r.Memory.Kernel != nil {
+				c.Resources.KernelMemory = *r.Memory.Kernel
+			}
+			if r.Memory.KernelTCP != nil {
+				c.Resources.KernelMemoryTCP = *r.Memory.KernelTCP
+			}
+			if r.Memory.Swappiness != nil {
+				c.Resources.MemorySwappiness = r.Memory.Swappiness
+			}
+			if r.Memory.DisableOOMKiller != nil {
+				c.Resources.OomKillDisable = *r.Memory.DisableOOMKiller
+			}
+		}
+		if r.CPU != nil {
+			if r.CPU.Shares != nil {
+				c.Resources.CpuShares = *r.CPU.Shares
+			}
+			if r.CPU.Quota != nil {
+				c.Resources.CpuQuota = *r.CPU.Quota
+			}
+			if r.CPU.Period != nil {
+				c.Resources.CpuPeriod = *r.CPU.Period
+			}
+			if r.CPU.RealtimeRuntime != nil {
+				c.Resources.CpuRtRuntime = *r.CPU.RealtimeRuntime
+			}
+			if r.CPU.RealtimePeriod != nil {
+				c.Resources.CpuRtPeriod = *r.CPU.RealtimePeriod
+			}
+			if r.CPU.Cpus != "" {
+				c.Resources.CpusetCpus = r.CPU.Cpus
+			}
+			if r.CPU.Mems != "" {
+				c.Resources.CpusetMems = r.CPU.Mems
+			}
+		}
+		if r.Pids != nil {
+			c.Resources.PidsLimit = r.Pids.Limit
+		}
+		if r.BlockIO != nil {
+			if r.BlockIO.Weight != nil {
+				c.Resources.BlkioWeight = *r.BlockIO.Weight
+			}
+			if r.BlockIO.LeafWeight != nil {
+				c.Resources.BlkioLeafWeight = *r.BlockIO.LeafWeight
+			}
+			if r.BlockIO.WeightDevice != nil {
+				for _, wd := range r.BlockIO.WeightDevice {
+					var weight, leafWeight uint16
+					if wd.Weight != nil {
+						weight = *wd.Weight
+					}
+					if wd.LeafWeight != nil {
+						leafWeight = *wd.LeafWeight
+					}
+					weightDevice := configs.NewWeightDevice(wd.Major, wd.Minor, weight, leafWeight)
+					c.Resources.BlkioWeightDevice = append(c.Resources.BlkioWeightDevice, weightDevice)
+				}
+			}
+			if r.BlockIO.ThrottleReadBpsDevice != nil {
+				for _, td := range r.BlockIO.ThrottleReadBpsDevice {
+					rate := td.Rate
+					throttleDevice := configs.NewThrottleDevice(td.Major, td.Minor, rate)
+					c.Resources.BlkioThrottleReadBpsDevice = append(c.Resources.BlkioThrottleReadBpsDevice, throttleDevice)
+				}
+			}
+			if r.BlockIO.ThrottleWriteBpsDevice != nil {
+				for _, td := range r.BlockIO.ThrottleWriteBpsDevice {
+					rate := td.Rate
+					throttleDevice := configs.NewThrottleDevice(td.Major, td.Minor, rate)
+					c.Resources.BlkioThrottleWriteBpsDevice = append(c.Resources.BlkioThrottleWriteBpsDevice, throttleDevice)
+				}
+			}
+			if r.BlockIO.ThrottleReadIOPSDevice != nil {
+				for _, td := range r.BlockIO.ThrottleReadIOPSDevice {
+					rate := td.Rate
+					throttleDevice := configs.NewThrottleDevice(td.Major, td.Minor, rate)
+					c.Resources.BlkioThrottleReadIOPSDevice = append(c.Resources.BlkioThrottleReadIOPSDevice, throttleDevice)
+				}
+			}
+			if r.BlockIO.ThrottleWriteIOPSDevice != nil {
+				for _, td := range r.BlockIO.ThrottleWriteIOPSDevice {
+					rate := td.Rate
+					throttleDevice := configs.NewThrottleDevice(td.Major, td.Minor, rate)
+					c.Resources.BlkioThrottleWriteIOPSDevice = append(c.Resources.BlkioThrottleWriteIOPSDevice, throttleDevice)
+				}
+			}
+		}
+		for _, l := range r.HugepageLimits {
+			c.Resources.HugetlbLimit = append(c.Resources.HugetlbLimit, &configs.HugepageLimit{
+				Pagesize: l.Pagesize,
+				Limit:    l.Limit,
+			})
+		}
+		if r.Network != nil {
+			if r.Network.ClassID != nil {
+				c.Resources.NetClsClassid = *r.Network.ClassID
+			}
+			for _, m := range r.Network.Priorities {
+				c.Resources.NetPrioIfpriomap = append(c.Resources.NetPrioIfpriomap, &configs.IfPrioMap{
+					Interface: m.Name,
+					Priority:  int64(m.Priority),
+				})
+			}
+		}
+	}
+	if !opts.Rootless {
+		// append the default allowed devices to the end of the list
+		c.Resources.Devices = append(c.Resources.Devices, allowedDevices...)
+	}
+	return c, nil
+}
+
+func stringToCgroupDeviceRune(s string) (rune, error) {
+	switch s {
+	case "a":
+		return 'a', nil
+	case "b":
+		return 'b', nil
+	case "c":
+		return 'c', nil
+	default:
+		return 0, fmt.Errorf("invalid cgroup device type %q", s)
+	}
+}
+
+func stringToDeviceRune(s string) (rune, error) {
+	switch s {
+	case "p":
+		return 'p', nil
+	case "u":
+		return 'u', nil
+	case "b":
+		return 'b', nil
+	case "c":
+		return 'c', nil
+	default:
+		return 0, fmt.Errorf("invalid device type %q", s)
+	}
+}
+
+func createDevices(spec *specs.Spec, config *configs.Config) error {
+	// add whitelisted devices
+	config.Devices = []*configs.Device{
+		{
+			Type:     'c',
+			Path:     "/dev/null",
+			Major:    1,
+			Minor:    3,
+			FileMode: 0666,
+			Uid:      0,
+			Gid:      0,
+		},
+		{
+			Type:     'c',
+			Path:     "/dev/random",
+			Major:    1,
+			Minor:    8,
+			FileMode: 0666,
+			Uid:      0,
+			Gid:      0,
+		},
+		{
+			Type:     'c',
+			Path:     "/dev/full",
+			Major:    1,
+			Minor:    7,
+			FileMode: 0666,
+			Uid:      0,
+			Gid:      0,
+		},
+		{
+			Type:     'c',
+			Path:     "/dev/tty",
+			Major:    5,
+			Minor:    0,
+			FileMode: 0666,
+			Uid:      0,
+			Gid:      0,
+		},
+		{
+			Type:     'c',
+			Path:     "/dev/zero",
+			Major:    1,
+			Minor:    5,
+			FileMode: 0666,
+			Uid:      0,
+			Gid:      0,
+		},
+		{
+			Type:     'c',
+			Path:     "/dev/urandom",
+			Major:    1,
+			Minor:    9,
+			FileMode: 0666,
+			Uid:      0,
+			Gid:      0,
+		},
+	}
+	// merge in additional devices from the spec
+	if spec.Linux != nil {
+		for _, d := range spec.Linux.Devices {
+			var uid, gid uint32
+			var filemode os.FileMode = 0666
+
+			if d.UID != nil {
+				uid = *d.UID
+			}
+			if d.GID != nil {
+				gid = *d.GID
+			}
+			dt, err := stringToDeviceRune(d.Type)
+			if err != nil {
+				return err
+			}
+			if d.FileMode != nil {
+				filemode = *d.FileMode
+			}
+			device := &configs.Device{
+				Type:     dt,
+				Path:     d.Path,
+				Major:    d.Major,
+				Minor:    d.Minor,
+				FileMode: filemode,
+				Uid:      uid,
+				Gid:      gid,
+			}
+			config.Devices = append(config.Devices, device)
+		}
+	}
+	return nil
+}
+
+func setupUserNamespace(spec *specs.Spec, config *configs.Config) error {
+	create := func(m specs.LinuxIDMapping) configs.IDMap {
+		return configs.IDMap{
+			HostID:      int(m.HostID),
+			ContainerID: int(m.ContainerID),
+			Size:        int(m.Size),
+		}
+	}
+	if spec.Linux != nil {
+		for _, m := range spec.Linux.UIDMappings {
+			config.UidMappings = append(config.UidMappings, create(m))
+		}
+		for _, m := range spec.Linux.GIDMappings {
+			config.GidMappings = append(config.GidMappings, create(m))
+		}
+	}
+	rootUID, err := config.HostRootUID()
+	if err != nil {
+		return err
+	}
+	rootGID, err := config.HostRootGID()
+	if err != nil {
+		return err
+	}
+	for _, node := range config.Devices {
+		node.Uid = uint32(rootUID)
+		node.Gid = uint32(rootGID)
+	}
+	return nil
+}
+
+// parseMountOptions parses the string and returns the flags, propagation
+// flags and any mount data that it contains.
+func parseMountOptions(options []string) (int, []int, string, int) {
+	var (
+		flag     int
+		pgflag   []int
+		data     []string
+		extFlags int
+	)
+	flags := map[string]struct {
+		clear bool
+		flag  int
+	}{
+		"acl":           {false, unix.MS_POSIXACL},
+		"async":         {true, unix.MS_SYNCHRONOUS},
+		"atime":         {true, unix.MS_NOATIME},
+		"bind":          {false, unix.MS_BIND},
+		"defaults":      {false, 0},
+		"dev":           {true, unix.MS_NODEV},
+		"diratime":      {true, unix.MS_NODIRATIME},
+		"dirsync":       {false, unix.MS_DIRSYNC},
+		"exec":          {true, unix.MS_NOEXEC},
+		"iversion":      {false, unix.MS_I_VERSION},
+		"lazytime":      {false, unix.MS_LAZYTIME},
+		"loud":          {true, unix.MS_SILENT},
+		"mand":          {false, unix.MS_MANDLOCK},
+		"noacl":         {true, unix.MS_POSIXACL},
+		"noatime":       {false, unix.MS_NOATIME},
+		"nodev":         {false, unix.MS_NODEV},
+		"nodiratime":    {false, unix.MS_NODIRATIME},
+		"noexec":        {false, unix.MS_NOEXEC},
+		"noiversion":    {true, unix.MS_I_VERSION},
+		"nolazytime":    {true, unix.MS_LAZYTIME},
+		"nomand":        {true, unix.MS_MANDLOCK},
+		"norelatime":    {true, unix.MS_RELATIME},
+		"nostrictatime": {true, unix.MS_STRICTATIME},
+		"nosuid":        {false, unix.MS_NOSUID},
+		"rbind":         {false, unix.MS_BIND | unix.MS_REC},
+		"relatime":      {false, unix.MS_RELATIME},
+		"remount":       {false, unix.MS_REMOUNT},
+		"ro":            {false, unix.MS_RDONLY},
+		"rw":            {true, unix.MS_RDONLY},
+		"silent":        {false, unix.MS_SILENT},
+		"strictatime":   {false, unix.MS_STRICTATIME},
+		"suid":          {true, unix.MS_NOSUID},
+		"sync":          {false, unix.MS_SYNCHRONOUS},
+	}
+	propagationFlags := map[string]int{
+		"private":     unix.MS_PRIVATE,
+		"shared":      unix.MS_SHARED,
+		"slave":       unix.MS_SLAVE,
+		"unbindable":  unix.MS_UNBINDABLE,
+		"rprivate":    unix.MS_PRIVATE | unix.MS_REC,
+		"rshared":     unix.MS_SHARED | unix.MS_REC,
+		"rslave":      unix.MS_SLAVE | unix.MS_REC,
+		"runbindable": unix.MS_UNBINDABLE | unix.MS_REC,
+	}
+	extensionFlags := map[string]struct {
+		clear bool
+		flag  int
+	}{
+		"tmpcopyup": {false, configs.EXT_COPYUP},
+	}
+	for _, o := range options {
+		// If the option does not exist in the flags table or the flag
+		// is not supported on the platform,
+		// then it is a data value for a specific fs type
+		if f, exists := flags[o]; exists && f.flag != 0 {
+			if f.clear {
+				flag &= ^f.flag
+			} else {
+				flag |= f.flag
+			}
+		} else if f, exists := propagationFlags[o]; exists && f != 0 {
+			pgflag = append(pgflag, f)
+		} else if f, exists := extensionFlags[o]; exists && f.flag != 0 {
+			if f.clear {
+				extFlags &= ^f.flag
+			} else {
+				extFlags |= f.flag
+			}
+		} else {
+			data = append(data, o)
+		}
+	}
+	return flag, pgflag, strings.Join(data, ","), extFlags
+}
+
+func SetupSeccomp(config *specs.LinuxSeccomp) (*configs.Seccomp, error) {
+	if config == nil {
+		return nil, nil
+	}
+
+	// No default action specified, no syscalls listed, assume seccomp disabled
+	if config.DefaultAction == "" && len(config.Syscalls) == 0 {
+		return nil, nil
+	}
+
+	newConfig := new(configs.Seccomp)
+	newConfig.Syscalls = []*configs.Syscall{}
+
+	if len(config.Architectures) > 0 {
+		newConfig.Architectures = []string{}
+		for _, arch := range config.Architectures {
+			newArch, err := seccomp.ConvertStringToArch(string(arch))
+			if err != nil {
+				return nil, err
+			}
+			newConfig.Architectures = append(newConfig.Architectures, newArch)
+		}
+	}
+
+	// Convert default action from string representation
+	newDefaultAction, err := seccomp.ConvertStringToAction(string(config.DefaultAction))
+	if err != nil {
+		return nil, err
+	}
+	newConfig.DefaultAction = newDefaultAction
+
+	// Loop through all syscall blocks and convert them to libcontainer format
+	for _, call := range config.Syscalls {
+		newAction, err := seccomp.ConvertStringToAction(string(call.Action))
+		if err != nil {
+			return nil, err
+		}
+
+		for _, name := range call.Names {
+			newCall := configs.Syscall{
+				Name:   name,
+				Action: newAction,
+				Args:   []*configs.Arg{},
+			}
+			// Loop through all the arguments of the syscall and convert them
+			for _, arg := range call.Args {
+				newOp, err := seccomp.ConvertStringToOperator(string(arg.Op))
+				if err != nil {
+					return nil, err
+				}
+
+				newArg := configs.Arg{
+					Index:    arg.Index,
+					Value:    arg.Value,
+					ValueTwo: arg.ValueTwo,
+					Op:       newOp,
+				}
+
+				newCall.Args = append(newCall.Args, &newArg)
+			}
+			newConfig.Syscalls = append(newConfig.Syscalls, &newCall)
+		}
+	}
+
+	return newConfig, nil
+}
+
+func createHooks(rspec *specs.Spec, config *configs.Config) {
+	config.Hooks = &configs.Hooks{}
+	if rspec.Hooks != nil {
+
+		for _, h := range rspec.Hooks.Prestart {
+			cmd := createCommandHook(h)
+			config.Hooks.Prestart = append(config.Hooks.Prestart, configs.NewCommandHook(cmd))
+		}
+		for _, h := range rspec.Hooks.Poststart {
+			cmd := createCommandHook(h)
+			config.Hooks.Poststart = append(config.Hooks.Poststart, configs.NewCommandHook(cmd))
+		}
+		for _, h := range rspec.Hooks.Poststop {
+			cmd := createCommandHook(h)
+			config.Hooks.Poststop = append(config.Hooks.Poststop, configs.NewCommandHook(cmd))
+		}
+	}
+}
+
+func createCommandHook(h specs.Hook) configs.Command {
+	cmd := configs.Command{
+		Path: h.Path,
+		Args: h.Args,
+		Env:  h.Env,
+	}
+	if h.Timeout != nil {
+		d := time.Duration(*h.Timeout) * time.Second
+		cmd.Timeout = &d
+	}
+	return cmd
+}

--- a/vendor/github.com/opencontainers/runc/libcontainer/system/unsupported.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/system/unsupported.go
@@ -2,8 +2,26 @@
 
 package system
 
+import (
+	"os"
+
+	"github.com/opencontainers/runc/libcontainer/user"
+)
+
 // RunningInUserNS is a stub for non-Linux systems
 // Always returns false
 func RunningInUserNS() bool {
 	return false
+}
+
+// UIDMapInUserNS is a stub for non-Linux systems
+// Always returns false
+func UIDMapInUserNS(uidmap []user.IDMap) bool {
+	return false
+}
+
+// GetParentNSeuid returns the euid within the parent user namespace
+// Always returns os.Geteuid on non-linux
+func GetParentNSeuid() int {
+	return os.Geteuid()
 }

--- a/vendor/github.com/opencontainers/runc/libcontainer/user/lookup_unix.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/user/lookup_unix.go
@@ -114,3 +114,29 @@ func CurrentUser() (User, error) {
 func CurrentGroup() (Group, error) {
 	return LookupGid(unix.Getgid())
 }
+
+func CurrentUserSubUIDs() ([]SubID, error) {
+	u, err := CurrentUser()
+	if err != nil {
+		return nil, err
+	}
+	return ParseSubIDFileFilter("/etc/subuid",
+		func(entry SubID) bool { return entry.Name == u.Name })
+}
+
+func CurrentGroupSubGIDs() ([]SubID, error) {
+	g, err := CurrentGroup()
+	if err != nil {
+		return nil, err
+	}
+	return ParseSubIDFileFilter("/etc/subgid",
+		func(entry SubID) bool { return entry.Name == g.Name })
+}
+
+func CurrentProcessUIDMap() ([]IDMap, error) {
+	return ParseIDMapFile("/proc/self/uid_map")
+}
+
+func CurrentProcessGIDMap() ([]IDMap, error) {
+	return ParseIDMapFile("/proc/self/gid_map")
+}

--- a/vendor/github.com/opencontainers/runc/libcontainer/user/user.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/user/user.go
@@ -75,12 +75,29 @@ func groupFromOS(g *user.Group) (Group, error) {
 	return newGroup, nil
 }
 
+// SubID represents an entry in /etc/sub{u,g}id
+type SubID struct {
+	Name  string
+	SubID int64
+	Count int64
+}
+
+// IDMap represents an entry in /proc/PID/{u,g}id_map
+type IDMap struct {
+	ID       int64
+	ParentID int64
+	Count    int64
+}
+
 func parseLine(line string, v ...interface{}) {
-	if line == "" {
+	parseParts(strings.Split(line, ":"), v...)
+}
+
+func parseParts(parts []string, v ...interface{}) {
+	if len(parts) == 0 {
 		return
 	}
 
-	parts := strings.Split(line, ":")
 	for i, p := range parts {
 		// Ignore cases where we don't have enough fields to populate the arguments.
 		// Some configuration files like to misbehave.
@@ -96,6 +113,8 @@ func parseLine(line string, v ...interface{}) {
 		case *int:
 			// "numbers", with conversion errors ignored because of some misbehaving configuration files.
 			*e, _ = strconv.Atoi(p)
+		case *int64:
+			*e, _ = strconv.ParseInt(p, 10, 64)
 		case *[]string:
 			// Comma-separated lists.
 			if p != "" {
@@ -105,7 +124,7 @@ func parseLine(line string, v ...interface{}) {
 			}
 		default:
 			// Someone goof'd when writing code using this function. Scream so they can hear us.
-			panic(fmt.Sprintf("parseLine only accepts {*string, *int, *[]string} as arguments! %#v is not a pointer!", e))
+			panic(fmt.Sprintf("parseLine only accepts {*string, *int, *int64, *[]string} as arguments! %#v is not a pointer!", e))
 		}
 	}
 }
@@ -478,4 +497,112 @@ func GetAdditionalGroupsPath(additionalGroups []string, groupPath string) ([]int
 		defer groupFile.Close()
 	}
 	return GetAdditionalGroups(additionalGroups, group)
+}
+
+func ParseSubIDFile(path string) ([]SubID, error) {
+	subid, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer subid.Close()
+	return ParseSubID(subid)
+}
+
+func ParseSubID(subid io.Reader) ([]SubID, error) {
+	return ParseSubIDFilter(subid, nil)
+}
+
+func ParseSubIDFileFilter(path string, filter func(SubID) bool) ([]SubID, error) {
+	subid, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer subid.Close()
+	return ParseSubIDFilter(subid, filter)
+}
+
+func ParseSubIDFilter(r io.Reader, filter func(SubID) bool) ([]SubID, error) {
+	if r == nil {
+		return nil, fmt.Errorf("nil source for subid-formatted data")
+	}
+
+	var (
+		s   = bufio.NewScanner(r)
+		out = []SubID{}
+	)
+
+	for s.Scan() {
+		if err := s.Err(); err != nil {
+			return nil, err
+		}
+
+		line := strings.TrimSpace(s.Text())
+		if line == "" {
+			continue
+		}
+
+		// see: man 5 subuid
+		p := SubID{}
+		parseLine(line, &p.Name, &p.SubID, &p.Count)
+
+		if filter == nil || filter(p) {
+			out = append(out, p)
+		}
+	}
+
+	return out, nil
+}
+
+func ParseIDMapFile(path string) ([]IDMap, error) {
+	r, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	return ParseIDMap(r)
+}
+
+func ParseIDMap(r io.Reader) ([]IDMap, error) {
+	return ParseIDMapFilter(r, nil)
+}
+
+func ParseIDMapFileFilter(path string, filter func(IDMap) bool) ([]IDMap, error) {
+	r, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	return ParseIDMapFilter(r, filter)
+}
+
+func ParseIDMapFilter(r io.Reader, filter func(IDMap) bool) ([]IDMap, error) {
+	if r == nil {
+		return nil, fmt.Errorf("nil source for idmap-formatted data")
+	}
+
+	var (
+		s   = bufio.NewScanner(r)
+		out = []IDMap{}
+	)
+
+	for s.Scan() {
+		if err := s.Err(); err != nil {
+			return nil, err
+		}
+
+		line := strings.TrimSpace(s.Text())
+		if line == "" {
+			continue
+		}
+
+		// see: man 7 user_namespaces
+		p := IDMap{}
+		parseParts(strings.Fields(line), &p.ID, &p.ParentID, &p.Count)
+
+		if filter == nil || filter(p) {
+			out = append(out, p)
+		}
+	}
+
+	return out, nil
 }

--- a/vendor/github.com/opencontainers/runc/libcontainer/utils/cmsg.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/utils/cmsg.go
@@ -1,0 +1,93 @@
+// +build linux
+
+package utils
+
+/*
+ * Copyright 2016, 2017 SUSE LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// MaxSendfdLen is the maximum length of the name of a file descriptor being
+// sent using SendFd. The name of the file handle returned by RecvFd will never
+// be larger than this value.
+const MaxNameLen = 4096
+
+// oobSpace is the size of the oob slice required to store a single FD. Note
+// that unix.UnixRights appears to make the assumption that fd is always int32,
+// so sizeof(fd) = 4.
+var oobSpace = unix.CmsgSpace(4)
+
+// RecvFd waits for a file descriptor to be sent over the given AF_UNIX
+// socket. The file name of the remote file descriptor will be recreated
+// locally (it is sent as non-auxiliary data in the same payload).
+func RecvFd(socket *os.File) (*os.File, error) {
+	// For some reason, unix.Recvmsg uses the length rather than the capacity
+	// when passing the msg_controllen and other attributes to recvmsg.  So we
+	// have to actually set the length.
+	name := make([]byte, MaxNameLen)
+	oob := make([]byte, oobSpace)
+
+	sockfd := socket.Fd()
+	n, oobn, _, _, err := unix.Recvmsg(int(sockfd), name, oob, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	if n >= MaxNameLen || oobn != oobSpace {
+		return nil, fmt.Errorf("recvfd: incorrect number of bytes read (n=%d oobn=%d)", n, oobn)
+	}
+
+	// Truncate.
+	name = name[:n]
+	oob = oob[:oobn]
+
+	scms, err := unix.ParseSocketControlMessage(oob)
+	if err != nil {
+		return nil, err
+	}
+	if len(scms) != 1 {
+		return nil, fmt.Errorf("recvfd: number of SCMs is not 1: %d", len(scms))
+	}
+	scm := scms[0]
+
+	fds, err := unix.ParseUnixRights(&scm)
+	if err != nil {
+		return nil, err
+	}
+	if len(fds) != 1 {
+		return nil, fmt.Errorf("recvfd: number of fds is not 1: %d", len(fds))
+	}
+	fd := uintptr(fds[0])
+
+	return os.NewFile(fd, string(name)), nil
+}
+
+// SendFd sends a file descriptor over the given AF_UNIX socket. In
+// addition, the file.Name() of the given file will also be sent as
+// non-auxiliary data in the same payload (allowing to send contextual
+// information for a file descriptor).
+func SendFd(socket *os.File, name string, fd uintptr) error {
+	if len(name) >= MaxNameLen {
+		return fmt.Errorf("sendfd: filename too long: %s", name)
+	}
+	oob := unix.UnixRights(int(fd))
+	return unix.Sendmsg(int(socket.Fd()), []byte(name), oob, nil, 0)
+}

--- a/vendor/github.com/opencontainers/runc/libcontainer/utils/utils.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/utils/utils.go
@@ -1,0 +1,127 @@
+package utils
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	exitSignalOffset = 128
+)
+
+// GenerateRandomName returns a new name joined with a prefix.  This size
+// specified is used to truncate the randomly generated value
+func GenerateRandomName(prefix string, size int) (string, error) {
+	id := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, id); err != nil {
+		return "", err
+	}
+	if size > 64 {
+		size = 64
+	}
+	return prefix + hex.EncodeToString(id)[:size], nil
+}
+
+// ResolveRootfs ensures that the current working directory is
+// not a symlink and returns the absolute path to the rootfs
+func ResolveRootfs(uncleanRootfs string) (string, error) {
+	rootfs, err := filepath.Abs(uncleanRootfs)
+	if err != nil {
+		return "", err
+	}
+	return filepath.EvalSymlinks(rootfs)
+}
+
+// ExitStatus returns the correct exit status for a process based on if it
+// was signaled or exited cleanly
+func ExitStatus(status unix.WaitStatus) int {
+	if status.Signaled() {
+		return exitSignalOffset + int(status.Signal())
+	}
+	return status.ExitStatus()
+}
+
+// WriteJSON writes the provided struct v to w using standard json marshaling
+func WriteJSON(w io.Writer, v interface{}) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	return err
+}
+
+// CleanPath makes a path safe for use with filepath.Join. This is done by not
+// only cleaning the path, but also (if the path is relative) adding a leading
+// '/' and cleaning it (then removing the leading '/'). This ensures that a
+// path resulting from prepending another path will always resolve to lexically
+// be a subdirectory of the prefixed path. This is all done lexically, so paths
+// that include symlinks won't be safe as a result of using CleanPath.
+func CleanPath(path string) string {
+	// Deal with empty strings nicely.
+	if path == "" {
+		return ""
+	}
+
+	// Ensure that all paths are cleaned (especially problematic ones like
+	// "/../../../../../" which can cause lots of issues).
+	path = filepath.Clean(path)
+
+	// If the path isn't absolute, we need to do more processing to fix paths
+	// such as "../../../../<etc>/some/path". We also shouldn't convert absolute
+	// paths to relative ones.
+	if !filepath.IsAbs(path) {
+		path = filepath.Clean(string(os.PathSeparator) + path)
+		// This can't fail, as (by definition) all paths are relative to root.
+		path, _ = filepath.Rel(string(os.PathSeparator), path)
+	}
+
+	// Clean the path again for good measure.
+	return filepath.Clean(path)
+}
+
+// SearchLabels searches a list of key-value pairs for the provided key and
+// returns the corresponding value. The pairs must be separated with '='.
+func SearchLabels(labels []string, query string) string {
+	for _, l := range labels {
+		parts := strings.SplitN(l, "=", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		if parts[0] == query {
+			return parts[1]
+		}
+	}
+	return ""
+}
+
+// Annotations returns the bundle path and user defined annotations from the
+// libcontainer state.  We need to remove the bundle because that is a label
+// added by libcontainer.
+func Annotations(labels []string) (bundle string, userAnnotations map[string]string) {
+	userAnnotations = make(map[string]string)
+	for _, l := range labels {
+		parts := strings.SplitN(l, "=", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		if parts[0] == "bundle" {
+			bundle = parts[1]
+		} else {
+			userAnnotations[parts[0]] = parts[1]
+		}
+	}
+	return
+}
+
+func GetIntSize() int {
+	return int(unsafe.Sizeof(1))
+}

--- a/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/utils/utils_unix.go
@@ -1,0 +1,44 @@
+// +build !windows
+
+package utils
+
+import (
+	"io/ioutil"
+	"os"
+	"strconv"
+
+	"golang.org/x/sys/unix"
+)
+
+func CloseExecFrom(minFd int) error {
+	fdList, err := ioutil.ReadDir("/proc/self/fd")
+	if err != nil {
+		return err
+	}
+	for _, fi := range fdList {
+		fd, err := strconv.Atoi(fi.Name())
+		if err != nil {
+			// ignore non-numeric file names
+			continue
+		}
+
+		if fd < minFd {
+			// ignore descriptors lower than our specified minimum
+			continue
+		}
+
+		// intentionally ignore errors from unix.CloseOnExec
+		unix.CloseOnExec(fd)
+		// the cases where this might fail are basically file descriptors that have already been closed (including and especially the one that was created when ioutil.ReadDir did the "opendir" syscall)
+	}
+	return nil
+}
+
+// NewSockPair returns a new unix socket pair
+func NewSockPair(name string) (parent *os.File, child *os.File, err error) {
+	fds, err := unix.Socketpair(unix.AF_LOCAL, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	return os.NewFile(uintptr(fds[1]), name+"-p"), os.NewFile(uintptr(fds[0]), name+"-c"), nil
+}


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

The changes are mostly for setting up default paths under `$HOME` and providing rootless OCI spec generator.
Substantially no change on the daemon.

---

# Rootless mode (Experimental)

Requirements:
- [runc (May 30, 2018)](https://github.com/opencontainers/runc/commit/ecd55a4135e0a26de884ce436442914f945b1e76) or later
- Some distros such as Debian (excluding Ubuntu) and Arch Linux require `echo 1 > /proc/sys/kernel/unprivileged_userns_clone`
- `newuidmap` and `newgidmap` need to be installed on the host. These commands are provided by the `uidmap` package on most distros.
- `/etc/subuid` and `/etc/subgid` should contain >= 65536 sub-IDs. e.g. `penguin:231072:65536`.
- To run in a Docker container with non-root `USER`, `docker run --privileged` is still required. See also Jessie's blog: https://blog.jessfraz.com/post/building-container-images-securely-on-kubernetes/

Daemon-side remarks:

* The data dir will be set to `/home/$USER/.local/share/containerd` by default.
* The address will be set to `/run/user/$UID/containerd/containerd.sock` by default.
* CRI plugin is not supported yet.
* `overlayfs` snapshotter is not supported except on [Ubuntu-flavored kernel](http://kernel.ubuntu.com/git/ubuntu/ubuntu-artful.git/commit/fs/overlayfs?h=Ubuntu-4.13.0-25.29&id=0a414bdc3d01f3b61ed86cfe3ce8b63a9240eba7). `native` snapshotter should work on non-Ubuntu kernel.

Go client library remarks:
* `oci.WithRootless()` removes Cgroups configuration. However, you can still set Cgroups configurations after calling `oci.WithRootless()`, if the permission bits are preconfigured on cgroup filesystems.

Network namespace remarks:
* To set up NAT across the host and the containers, you need to use either a TAP with a usermode network stack (slirp) or a SUID helper. See [RootlessKit](https://github.com/rootless-containers/rootlesskit).

## Usage

### Terminal 1:

```
$ unshare -U -m
unshared$ echo $$ > /tmp/pid
```

Unsharing mountns (and userns) is required for mounting filesystems without real root privileges.

### Terminal 2:

```
$ id -u
1001
$ grep $(whoami) /etc/subuid
penguin:231072:65536
$ grep $(whoami) /etc/subgid
penguin:231072:65536
$ newuidmap $(cat /tmp/pid) 0 1001 1 1 231072 65536
$ newgidmap $(cat /tmp/pid) 0 1001 1 1 231072 65536
```

### Terminal 1:

```
unshared# containerd
```

### Terminal 2:

```
$ nsenter -U -m -t $(cat /tmp/pid)
unshared# ctr -a /run/user/1001/containerd/containerd.sock images pull docker.io/library/debian:latest
unshared# ctr -a /run/user/1001/containerd/containerd.sock run -t --rm --rootless --net-host docker.io/library/debian:latest foo
foo#
```

## Usage ([RootlessKit](https://github.com/rootless-containers/rootlesskit))

RootlessKit can be used for executing `unshare` and `newuidmap/newgidmap` at once.
RootlessKit also supports unsharing the network namespace with usermode NAT such as [VPNKit](https://github.com/moby/vpnkit)
and [libvdeplug_slirp](https://github.com/moby/vpnkit).


### Terminal 1:

The following example is tested with RootlessKit [`20b0fc24b305b031a61ef1a1ca456aadafaf5e77`](https://github.com/rootless-containers/rootlesskit/tree/20b0fc24b305b031a61ef1a1ca456aadafaf5e77).

```
$ rootlesskit --state-dir=/tmp/foo --net=vpnkit --copy-up=/etc containerd
```

### Terminal 2:

```
$ nsenter -U -m -n -t $(cat /tmp/foo/child_pid)
unshared# ctr -a /run/user/1001/containerd/containerd.sock images pull docker.io/library/debian:latest
unshared# ctr -a /run/user/1001/containerd/containerd.sock run -t --rm --rootless --net-host docker.io/library/debian:latest foo
foo#
```