### PR TITLE
cio: add WithFIFODir opt

### DIFF
--- a/cmd/ctr/commands/run/run.go
+++ b/cmd/ctr/commands/run/run.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/containerd/console"
 	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/cmd/ctr/commands/tasks"
 	"github.com/containerd/containerd/containers"
@@ -170,6 +171,10 @@ var Command = cli.Command{
 			Name:  "detach,d",
 			Usage: "detach from the task after it has started execution",
 		},
+		cli.StringFlag{
+			Name:  "fifo-dir",
+			Usage: "directory used for storing IO FIFOs",
+		},
 	}, commands.SnapshotterFlags...),
 	Action: func(context *cli.Context) error {
 		var (
@@ -200,7 +205,8 @@ var Command = cli.Command{
 			defer container.Delete(ctx, containerd.WithSnapshotCleanup)
 		}
 		opts := getNewTaskOpts(context)
-		task, err := tasks.NewTask(ctx, client, container, context.String("checkpoint"), tty, context.Bool("null-io"), opts...)
+		ioOpts := []cio.Opt{cio.WithFIFODir(context.String("fifo-dir"))}
+		task, err := tasks.NewTask(ctx, client, container, context.String("checkpoint"), tty, context.Bool("null-io"), ioOpts, opts...)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/tasks/exec.go
+++ b/cmd/ctr/commands/tasks/exec.go
@@ -28,6 +28,10 @@ var execCommand = cli.Command{
 			Name:  "exec-id",
 			Usage: "exec specific id for the process",
 		},
+		cli.StringFlag{
+			Name:  "fifo-dir",
+			Usage: "directory used for storing IO FIFOs",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		var (
@@ -60,10 +64,11 @@ var execCommand = cli.Command{
 		pspec.Terminal = tty
 		pspec.Args = args
 
-		ioCreator := cio.NewCreator(cio.WithStdio)
+		cioOpts := []cio.Opt{cio.WithStdio, cio.WithFIFODir(context.String("fifo-dir"))}
 		if tty {
-			ioCreator = cio.NewCreator(cio.WithStdio, cio.WithTerminal)
+			cioOpts = append(cioOpts, cio.WithTerminal)
 		}
+		ioCreator := cio.NewCreator(cioOpts...)
 		process, err := task.Exec(ctx, context.String("exec-id"), pspec, ioCreator)
 		if err != nil {
 			return err

--- a/cmd/ctr/commands/tasks/start.go
+++ b/cmd/ctr/commands/tasks/start.go
@@ -2,6 +2,7 @@ package tasks
 
 import (
 	"github.com/containerd/console"
+	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -16,6 +17,10 @@ var startCommand = cli.Command{
 		cli.BoolFlag{
 			Name:  "null-io",
 			Usage: "send all IO to /dev/null",
+		},
+		cli.StringFlag{
+			Name:  "fifo-dir",
+			Usage: "directory used for storing IO FIFOs",
 		},
 	},
 	Action: func(context *cli.Context) error {
@@ -42,10 +47,11 @@ var startCommand = cli.Command{
 		}
 
 		var (
-			tty  = spec.Process.Terminal
-			opts = getNewTaskOpts(context)
+			tty    = spec.Process.Terminal
+			opts   = getNewTaskOpts(context)
+			ioOpts = []cio.Opt{cio.WithFIFODir(context.String("fifo-dir"))}
 		)
-		task, err := NewTask(ctx, client, container, "", tty, context.Bool("null-io"), opts...)
+		task, err := NewTask(ctx, client, container, "", tty, context.Bool("null-io"), ioOpts, opts...)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/tasks/tasks_unix.go
+++ b/cmd/ctr/commands/tasks/tasks_unix.go
@@ -51,12 +51,12 @@ func HandleConsoleResize(ctx gocontext.Context, task resizer, con console.Consol
 }
 
 // NewTask creates a new task
-func NewTask(ctx gocontext.Context, client *containerd.Client, container containerd.Container, checkpoint string, tty, nullIO bool, opts ...containerd.NewTaskOpts) (containerd.Task, error) {
-	stdio := cio.NewCreator(cio.WithStdio)
+func NewTask(ctx gocontext.Context, client *containerd.Client, container containerd.Container, checkpoint string, tty, nullIO bool, ioOpts []cio.Opt, opts ...containerd.NewTaskOpts) (containerd.Task, error) {
+	stdio := cio.NewCreator(append([]cio.Opt{cio.WithStdio}, ioOpts...)...)
 	if checkpoint == "" {
 		ioCreator := stdio
 		if tty {
-			ioCreator = cio.NewCreator(cio.WithStdio, cio.WithTerminal)
+			ioCreator = cio.NewCreator(append([]cio.Opt{cio.WithStdio, cio.WithTerminal}, ioOpts...)...)
 		}
 		if nullIO {
 			if tty {

--- a/cmd/ctr/commands/tasks/tasks_windows.go
+++ b/cmd/ctr/commands/tasks/tasks_windows.go
@@ -42,10 +42,10 @@ func HandleConsoleResize(ctx gocontext.Context, task resizer, con console.Consol
 }
 
 // NewTask creates a new task
-func NewTask(ctx gocontext.Context, client *containerd.Client, container containerd.Container, _ string, tty, nullIO bool, opts ...containerd.NewTaskOpts) (containerd.Task, error) {
-	ioCreator := cio.NewCreator(cio.WithStdio)
+func NewTask(ctx gocontext.Context, client *containerd.Client, container containerd.Container, _ string, tty, nullIO bool, ioOpts []cio.Opt, opts ...containerd.NewTaskOpts) (containerd.Task, error) {
+	ioCreator := cio.NewCreator(append([]cio.Opt{cio.WithStdio}, ioOpts...)...)
 	if tty {
-		ioCreator = cio.NewCreator(cio.WithStdio, cio.WithTerminal)
+		ioCreator = cio.NewCreator(append([]cio.Opt{cio.WithStdio, cio.WithTerminal}, ioOpts...)...)
 	}
 	if nullIO {
 		if tty {

--- a/defaults/defaults_unix.go
+++ b/defaults/defaults_unix.go
@@ -13,4 +13,7 @@ const (
 	DefaultAddress = "/run/containerd/containerd.sock"
 	// DefaultDebugAddress is the default unix socket address for pprof data
 	DefaultDebugAddress = "/run/containerd/debug.sock"
+	// DefaultFIFODir is the default location used by client-side cio library
+	// to store FIFOs.
+	DefaultFIFODir = "/run/containerd/fifo"
 )

--- a/defaults/defaults_windows.go
+++ b/defaults/defaults_windows.go
@@ -21,4 +21,7 @@ const (
 	DefaultAddress = `\\.\pipe\containerd-containerd`
 	// DefaultDebugAddress is the default winpipe address for pprof data
 	DefaultDebugAddress = `\\.\pipe\containerd-debug`
+	// DefaultFIFODir is the default location used by client-side cio library
+	// to store FIFOs. Unused on Windows.
+	DefaultFIFODir = ""
 )


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

This PR also adds `--fifo-dir string` to `ctr run` and `ctr exec`.

Expected to be used for rootless execution (https://github.com/containerd/containerd/pull/2006)
