### PR TITLE
Bump to Go 1.10

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,7 +11,9 @@ branches:
 environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
-  GO_VERSION: 1.9
+  matrix:
+    - GO_VERSION: 1.9
+    - GO_VERSION: 1.10
 
 before_build:
   - choco install -y mingw

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ services:
 language: go
 
 go:
-  - 1.9.x
+  - "1.9.x"
+  - "1.10"
 
 go_import_path: github.com/containerd/containerd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ script:
   - script/validate/vendor
   - go build -i .
   - make check
-  - if [ "$GOOS" = "linux" ]; then make check-protos check-api-descriptors; fi
+  - if [[ "$GOOS" = "linux" && "$TRAVIS_GO_VERSION" != "1.9"* ]]; then make check-protos check-api-descriptors; fi
   - make build
   - make binaries
   - if [ "$GOOS" = "linux" ]; then sudo make install ; fi

--- a/api/events/container.pb.go
+++ b/api/events/container.pb.go
@@ -158,9 +158,7 @@ func (m *ContainerCreate_Runtime) Field(fieldpath []string) (string, bool) {
 			return "", false
 		}
 
-		adaptor, ok := decoded.(interface {
-			Field([]string) (string, bool)
-		})
+		adaptor, ok := decoded.(interface{ Field([]string) (string, bool) })
 		if !ok {
 			return "", false
 		}

--- a/api/services/events/v1/events.pb.go
+++ b/api/services/events/v1/events.pb.go
@@ -115,9 +115,7 @@ func (m *Envelope) Field(fieldpath []string) (string, bool) {
 			return "", false
 		}
 
-		adaptor, ok := decoded.(interface {
-			Field([]string) (string, bool)
-		})
+		adaptor, ok := decoded.(interface{ Field([]string) (string, bool) })
 		if !ok {
 			return "", false
 		}


### PR DESCRIPTION
Given that containerd states Go 1.9 "and up", it's probably a good thing to have a pr checking if CI is successful on Go 1.10 now that it is in beta

To find out what has changed in Go 1.10, read the draft release notes:
https://beta.golang.org/doc/go1.10

Documentation for Go 1.10 is available at:
https://beta.golang.org/