### PR TITLE
release: prepare 1.0.1

### DIFF
--- a/releases/v1.0.1.toml
+++ b/releases/v1.0.1.toml
@@ -1,0 +1,26 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+
+# previous release
+previous = "v1.0.0"
+
+pre_release = false
+
+preface = """\
+This is the first patch release for `containerd` in the 1.0 series. Several
+bugfixes surrounding tar, image handling, errant log messages and resource
+management are present. During the release candidate period, issues with layer
+whiteout files were fixed, in addition to logic adjustements to user resolution
+in OCI images.
+
+Note the daemon no longer shuts down when failing to adjust its own OOM score.
+Instead, a warning will be issued.
+"""
+
+# notable prs to include in the release notes, 1234 is the pr number
+[notes]
+
+[breaking]

--- a/version/version.go
+++ b/version/version.go
@@ -5,7 +5,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.0.1-rc.0+unknown"
+	Version = "1.0.1+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Signed-off-by: Stephen J Day <stephen.day@docker.com>