### PR TITLE
Provide better error context on resolve failures

### DIFF
--- a/client.go
+++ b/client.go
@@ -222,11 +222,11 @@ func (c *Client) Pull(ctx context.Context, ref string, opts ...RemoteOpt) (Image
 
 	name, desc, err := pullCtx.Resolver.Resolve(ctx, ref)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to resolve reference %q", ref)
 	}
 	fetcher, err := pullCtx.Resolver.Fetcher(ctx, name)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to get fetcher for %q", name)
 	}
 
 	var (
@@ -281,7 +281,7 @@ func (c *Client) Pull(ctx context.Context, ref string, opts ...RemoteOpt) (Image
 	}
 	if pullCtx.Unpack {
 		if err := img.Unpack(ctx, pullCtx.Snapshotter); err != nil {
-			return nil, err
+			errors.Wrapf(err, "failed to unpack image on snapshotter %s", pullCtx.Snapshotter)
 		}
 	}
 	return img, nil


### PR DESCRIPTION
While debugging a failure to resolve Windows multi-manifested images, I found more context on the errors in resolve to be necessary. This adds that context on which operation is failing.

for example:
```
$ ctr images pull docker.io/library/go:nanoserver
<snip>
ctr: failed to resolve reference "docker.io/library/go:nanoserver": server message: insufficient_scope: authorization failed
```

Signed-off-by: Darren Stahl <darst@microsoft.com>