### PR TITLE
Print host version in appveyor setup steps

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,6 +21,8 @@ before_build:
   - 7z x go%GO_VERSION%.windows-amd64.zip -oC:\ >nul
   - go version
   - choco install codecov
+  # Print host version. TODO: Remove this when containerd has a way to get host version
+  - ps: $psversiontable
 
 build_script:
   - bash.exe -elc "export PATH=/c/tools/mingw64/bin:/c/gopath/bin:$PATH;


### PR DESCRIPTION
This adds `$psversiontables` to the appveyor setup script as a way to get the host version. I'd like to remove this in favour of a way to get host version (and more info) directly from containerd. I'm considering doing so over the plugin exports for the runtime, but open to other ideas.

Signed-off-by: Darren Stahl <darst@microsoft.com>