### PR TITLE
log: remove log "module" system

### DIFF
--- a/cmd/containerd/main.go
+++ b/cmd/containerd/main.go
@@ -79,7 +79,7 @@ func main() {
 			start   = time.Now()
 			signals = make(chan os.Signal, 2048)
 			serverC = make(chan *server.Server, 1)
-			ctx     = log.WithModule(gocontext.Background(), "containerd")
+			ctx     = gocontext.Background()
 			config  = defaultConfig()
 		)
 
@@ -114,21 +114,21 @@ func main() {
 			if err != nil {
 				return errors.Wrapf(err, "failed to get listener for debug endpoint")
 			}
-			serve(log.WithModule(ctx, "debug"), l, server.ServeDebug)
+			serve(ctx, l, server.ServeDebug)
 		}
 		if config.Metrics.Address != "" {
 			l, err := net.Listen("tcp", config.Metrics.Address)
 			if err != nil {
 				return errors.Wrapf(err, "failed to get listener for metrics endpoint")
 			}
-			serve(log.WithModule(ctx, "metrics"), l, server.ServeMetrics)
+			serve(ctx, l, server.ServeMetrics)
 		}
 
 		l, err := sys.GetLocalListener(address, config.GRPC.UID, config.GRPC.GID)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get listener for main endpoint")
 		}
-		serve(log.WithModule(ctx, "grpc"), l, server.ServeGRPC)
+		serve(ctx, l, server.ServeGRPC)
 
 		log.G(ctx).Infof("containerd successfully booted in %fs", time.Since(start).Seconds())
 		<-done

--- a/log/context.go
+++ b/log/context.go
@@ -2,7 +2,6 @@ package log
 
 import (
 	"context"
-	"path"
 
 	"github.com/sirupsen/logrus"
 )
@@ -20,7 +19,6 @@ var (
 
 type (
 	loggerKey struct{}
-	moduleKey struct{}
 )
 
 // WithLogger returns a new context with the provided logger. Use in
@@ -39,43 +37,4 @@ func GetLogger(ctx context.Context) *logrus.Entry {
 	}
 
 	return logger.(*logrus.Entry)
-}
-
-// WithModule adds the module to the context, appending it with a slash if a
-// module already exists. A module is just an roughly correlated defined by the
-// call tree for a given context.
-//
-// As an example, we might have a "node" module already part of a context. If
-// this function is called with "tls", the new value of module will be
-// "node/tls".
-//
-// Modules represent the call path. If the new module and last module are the
-// same, a new module entry will not be created. If the new module and old
-// older module are the same but separated by other modules, the cycle will be
-// represented by the module path.
-func WithModule(ctx context.Context, module string) context.Context {
-	parent := GetModulePath(ctx)
-
-	if parent != "" {
-		// don't re-append module when module is the same.
-		if path.Base(parent) == module {
-			return ctx
-		}
-
-		module = path.Join(parent, module)
-	}
-
-	ctx = WithLogger(ctx, GetLogger(ctx).WithField("module", module))
-	return context.WithValue(ctx, moduleKey{}, module)
-}
-
-// GetModulePath returns the module path for the provided context. If no module
-// is set, an empty string is returned.
-func GetModulePath(ctx context.Context) string {
-	module := ctx.Value(moduleKey{})
-	if module == nil {
-		return ""
-	}
-
-	return module.(string)
 }

--- a/log/context_test.go
+++ b/log/context_test.go
@@ -16,26 +16,3 @@ func TestLoggerContext(t *testing.T) {
 	assert.Equal(t, GetLogger(ctx).Data["test"], "one")
 	assert.Equal(t, G(ctx), GetLogger(ctx)) // these should be the same.
 }
-
-func TestModuleContext(t *testing.T) {
-	ctx := context.Background()
-	assert.Equal(t, GetModulePath(ctx), "")
-
-	ctx = WithModule(ctx, "a") // basic behavior
-	assert.Equal(t, GetModulePath(ctx), "a")
-	logger := GetLogger(ctx)
-	assert.Equal(t, logger.Data["module"], "a")
-
-	parent, ctx := ctx, WithModule(ctx, "a")
-	assert.Equal(t, ctx, parent) // should be a no-op
-	assert.Equal(t, GetModulePath(ctx), "a")
-	assert.Equal(t, GetLogger(ctx).Data["module"], "a")
-
-	ctx = WithModule(ctx, "b") // new module
-	assert.Equal(t, GetModulePath(ctx), "a/b")
-	assert.Equal(t, GetLogger(ctx).Data["module"], "a/b")
-
-	ctx = WithModule(ctx, "c") // new module
-	assert.Equal(t, GetModulePath(ctx), "a/b/c")
-	assert.Equal(t, GetLogger(ctx).Data["module"], "a/b/c")
-}

--- a/plugin/context.go
+++ b/plugin/context.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/events/exchange"
-	"github.com/containerd/containerd/log"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
@@ -28,7 +27,7 @@ type InitContext struct {
 // NewContext returns a new plugin InitContext
 func NewContext(ctx context.Context, r *Registration, plugins *Set, root, state string) *InitContext {
 	return &InitContext{
-		Context: log.WithModule(ctx, r.URI()),
+		Context: ctx,
 		Root:    filepath.Join(root, r.URI()),
 		State:   filepath.Join(state, r.URI()),
 		Meta: &Meta{


### PR DESCRIPTION
After comtemplation, the complexity of the logging module system
outweighs its usefulness. This changeset removes the system and restores
lighter weight code paths. As a concession, we can always provide more
context when necessary to log messages to understand them without having
to fork the context for a certain set of calls.

Signed-off-by: Stephen J Day <stephen.day@docker.com>