### PR TITLE
trim code path in stack trace.

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -3,7 +3,7 @@ COMMANDS += containerd-shim
 
 # check GOOS for cross compile builds
 ifeq ($(GOOS),linux)
-	GO_GCFLAGS= -buildmode=pie
+	GO_GCFLAGS += -buildmode=pie
 endif
 
 # amd64 supports go test -race


### PR DESCRIPTION
Added -trimpath flag in -gcflags to reduce codepath in stack trace.
Fixes #2000

Signed-off-by: Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>