### PR TITLE
Fix NPE in dialer

### DIFF
--- a/dialer/dialer.go
+++ b/dialer/dialer.go
@@ -42,7 +42,7 @@ func Dialer(address string, timeout time.Duration) (net.Conn, error) {
 		close(stopC)
 		go func() {
 			dr := <-synC
-			if dr != nil {
+			if dr != nil && dr.c != nil {
 				dr.c.Close()
 			}
 		}()


### PR DESCRIPTION
Signed-off-by: Li Yi <denverdino@gmail.com>

In one testing with Docker Engine 17.12, I found the NPE in dialer of containerd. The log of docker engine is as following:
```
Jan 16 11:55:18 iZbp12bxxhtwowgjmozk40Z dockerd[10893]: time="2018-01-16T11:55:17.970922424+08:00" level=error msg="Handler for GET /containers/json returned error: write unix /var/run/docker.sock->@: write: broken pipe"
Jan 16 11:55:19 iZbp12bxxhtwowgjmozk40Z dockerd[10893]: panic: runtime error: invalid memory address or nil pointer dereference
Jan 16 11:55:19 iZbp12bxxhtwowgjmozk40Z dockerd[10893]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x1c09b69]
Jan 16 11:55:19 iZbp12bxxhtwowgjmozk40Z dockerd[10893]: goroutine 36453382 [running]:
Jan 16 11:55:19 iZbp12bxxhtwowgjmozk40Z dockerd[10893]: github.com/docker/docker/vendor/github.com/containerd/containerd/dialer.Dialer.func2(0xc44bb1aba0)
Jan 16 11:55:19 iZbp12bxxhtwowgjmozk40Z dockerd[10893]:         /go/src/github.com/docker/docker/vendor/github.com/containerd/containerd/dialer/dialer.go:46 +0x59
Jan 16 11:55:19 iZbp12bxxhtwowgjmozk40Z dockerd[10893]: created by github.com/docker/docker/vendor/github.com/containerd/containerd/dialer.Dialer
Jan 16 11:55:19 iZbp12bxxhtwowgjmozk40Z dockerd[10893]:         /go/src/github.com/docker/docker/vendor/github.com/containerd/containerd/dialer/dialer.go:43 +0x1c7
Jan 16 11:55:19 iZbp12bxxhtwowgjmozk40Z systemd[1]: docker.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
Jan 16 11:55:19 iZbp12bxxhtwowgjmozk40Z systemd[1]: docker.service: Unit entered failed state.
Jan 16 11:55:19 iZbp12bxxhtwowgjmozk40Z systemd[1]: docker.service: Failed with result 'exit-code'.
Jan 16 11:55:19 iZbp12bxxhtwowgjmozk40Z systemd[1]: docker.service: Service hold-off time over, scheduling restart.
Jan 16 11:55:19 iZbp12bxxhtwowgjmozk40Z systemd[1]: Stopped Docker Application Container Engine.
```
