### PR TITLE
Add Exec to process states

### DIFF
--- a/linux/proc/deleted_state.go
+++ b/linux/proc/deleted_state.go
@@ -48,3 +48,7 @@ func (s *deletedState) Kill(ctx context.Context, sig uint32, all bool) error {
 func (s *deletedState) SetExited(status int) {
 	// no op
 }
+
+func (s *deletedState) Exec(ctx context.Context, path string, r *ExecConfig) (Process, error) {
+	return nil, errors.Errorf("cannot exec in a deleted state")
+}

--- a/linux/proc/init.go
+++ b/linux/proc/init.go
@@ -346,8 +346,8 @@ func (p *Init) Runtime() *runc.Runc {
 	return p.runtime
 }
 
-// Exec returns a new exec'd process
-func (p *Init) Exec(context context.Context, path string, r *ExecConfig) (Process, error) {
+// exec returns a new exec'd process
+func (p *Init) exec(context context.Context, path string, r *ExecConfig) (Process, error) {
 	// process exec request
 	var spec specs.Process
 	if err := json.Unmarshal(r.Spec.Value, &spec); err != nil {


### PR DESCRIPTION
This moves the exec call to the state patter so that this does not get called when there is no way to create an additional process in the container. 

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>