### PR TITLE
Print default plugin config.

### DIFF
--- a/cmd/containerd/config.go
+++ b/cmd/containerd/config.go
@@ -1,10 +1,25 @@
 package main
 
 import (
+	"io"
 	"os"
 
+	"github.com/BurntSushi/toml"
+	"github.com/containerd/containerd/server"
 	"github.com/urfave/cli"
 )
+
+// Config is a wrapper of server config for printing out.
+type Config struct {
+	*server.Config
+	// Plugins overrides `Plugins map[string]toml.Primitive` in server config.
+	Plugins map[string]interface{} `toml:"plugins"`
+}
+
+// WriteTo marshals the config to the provided writer
+func (c *Config) WriteTo(w io.Writer) (int64, error) {
+	return 0, toml.NewEncoder(w).Encode(c)
+}
 
 var configCommand = cli.Command{
 	Name:  "config",
@@ -14,7 +29,23 @@ var configCommand = cli.Command{
 			Name:  "default",
 			Usage: "see the output of the default config",
 			Action: func(context *cli.Context) error {
-				_, err := defaultConfig().WriteTo(os.Stdout)
+				config := &Config{
+					Config: defaultConfig(),
+				}
+				plugins, err := server.LoadPlugins(config.Config)
+				if err != nil {
+					return err
+				}
+				if len(plugins) != 0 {
+					config.Plugins = make(map[string]interface{})
+					for _, p := range plugins {
+						if p.Config == nil {
+							continue
+						}
+						config.Plugins[p.ID] = p.Config
+					}
+				}
+				_, err = config.WriteTo(os.Stdout)
 				return err
 			},
 		},

--- a/server/config.go
+++ b/server/config.go
@@ -1,9 +1,6 @@
 package server
 
 import (
-	"bytes"
-	"io"
-
 	"github.com/BurntSushi/toml"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/pkg/errors"
@@ -67,16 +64,6 @@ func (c *Config) Decode(id string, v interface{}) (interface{}, error) {
 		return nil, err
 	}
 	return v, nil
-}
-
-// WriteTo marshals the config to the provided writer
-func (c *Config) WriteTo(w io.Writer) (int64, error) {
-	buf := bytes.NewBuffer(nil)
-	e := toml.NewEncoder(buf)
-	if err := e.Encode(c); err != nil {
-		return 0, err
-	}
-	return io.Copy(w, buf)
 }
 
 // LoadConfig loads the containerd server config from the provided path

--- a/server/server.go
+++ b/server/server.go
@@ -45,7 +45,7 @@ func New(ctx context.Context, config *Config) (*Server, error) {
 	if err := apply(ctx, config); err != nil {
 		return nil, err
 	}
-	plugins, err := loadPlugins(config)
+	plugins, err := LoadPlugins(config)
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +158,9 @@ func (s *Server) Stop() {
 	s.rpc.Stop()
 }
 
-func loadPlugins(config *Config) ([]*plugin.Registration, error) {
+// LoadPlugins loads all plugins into containerd and generates an ordered graph
+// of all plugins.
+func LoadPlugins(config *Config) ([]*plugin.Registration, error) {
 	// load all plugins into containerd
 	if err := plugin.Load(filepath.Join(config.Root, "plugins")); err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes https://github.com/containerd/containerd/issues/2027.

@containerd/containerd-maintainers Does this make sense to you?

The output:
```console
$ containerd config default
root = "/var/lib/containerd"
state = "/run/containerd"
oom_score = 0

[grpc]
  address = "/run/containerd/containerd.sock"
  uid = 0
  gid = 0

[debug]
  address = "/run/containerd/debug.sock"
  uid = 0
  gid = 0
  level = "info"

[metrics]
  address = ""
  grpc_histogram = false

[cgroup]
  path = ""

[plugins]
  [plugins.cgroups]
    no_prometheus = false
  [plugins.diff]
    default = ["walking"]
  [plugins.linux]
    shim = "containerd-shim"
    runtime = "runc"
    runtime_root = ""
    no_shim = false
    shim_debug = false
  [plugins.scheduler]
    pause_threshold = 0.02
    deletion_threshold = 0
    mutation_threshold = 100
    schedule_delay = 0
    startup_delay = 100000000
```
Signed-off-by: Lantao Liu <lantaol@google.com>