### PR TITLE
Replace t.Error(); return with t.Fatal()

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -184,7 +184,6 @@ func TestImagePull(t *testing.T) {
 	defer cancel()
 	_, err = client.Pull(ctx, testImage)
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 }

--- a/container_checkpoint_test.go
+++ b/container_checkpoint_test.go
@@ -27,66 +27,55 @@ func TestCheckpointRestore(t *testing.T) {
 
 	image, err := client.GetImage(ctx, testImage)
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	container, err := client.NewContainer(ctx, id, WithNewSpec(oci.WithImageConfig(image), oci.WithProcessArgs("sleep", "100")), WithNewSnapshot(id, image))
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	defer container.Delete(ctx, WithSnapshotCleanup)
 
 	task, err := container.NewTask(ctx, empty())
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	defer task.Delete(ctx)
 
 	statusC, err := task.Wait(ctx)
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	if err := task.Start(ctx); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	checkpoint, err := task.Checkpoint(ctx, WithExit)
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	<-statusC
 
 	if _, err := task.Delete(ctx); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	if task, err = container.NewTask(ctx, empty(), WithTaskCheckpoint(checkpoint)); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	defer task.Delete(ctx)
 
 	statusC, err = task.Wait(ctx)
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	if err := task.Start(ctx); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	if err := task.Kill(ctx, syscall.SIGKILL); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	<-statusC
 }
@@ -107,74 +96,61 @@ func TestCheckpointRestoreNewContainer(t *testing.T) {
 
 	image, err := client.GetImage(ctx, testImage)
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	container, err := client.NewContainer(ctx, id, WithNewSpec(oci.WithImageConfig(image), oci.WithProcessArgs("sleep", "100")), WithNewSnapshot(id, image))
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	defer container.Delete(ctx, WithSnapshotCleanup)
 
 	task, err := container.NewTask(ctx, empty())
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	defer task.Delete(ctx)
 
 	statusC, err := task.Wait(ctx)
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	if err := task.Start(ctx); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	checkpoint, err := task.Checkpoint(ctx, WithExit)
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	<-statusC
 
 	if _, err := task.Delete(ctx); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	if err := container.Delete(ctx, WithSnapshotCleanup); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	if container, err = client.NewContainer(ctx, id, WithCheckpoint(checkpoint, id)); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	if task, err = container.NewTask(ctx, empty(), WithTaskCheckpoint(checkpoint)); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	defer task.Delete(ctx)
 
 	statusC, err = task.Wait(ctx)
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	if err := task.Start(ctx); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	if err := task.Kill(ctx, syscall.SIGKILL); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	<-statusC
 }
@@ -200,52 +176,43 @@ func TestCheckpointLeaveRunning(t *testing.T) {
 
 	image, err := client.GetImage(ctx, testImage)
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	container, err := client.NewContainer(ctx, id, WithNewSpec(oci.WithImageConfig(image), oci.WithProcessArgs("sleep", "100")), WithNewSnapshot(id, image))
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	defer container.Delete(ctx, WithSnapshotCleanup)
 
 	task, err := container.NewTask(ctx, empty())
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	defer task.Delete(ctx)
 
 	statusC, err := task.Wait(ctx)
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	if err := task.Start(ctx); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	if _, err := task.Checkpoint(ctx); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	status, err := task.Status(ctx)
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	if status.Status != Running {
-		t.Errorf("expected status %q but received %q", Running, status)
-		return
+		t.Fatalf("expected status %q but received %q", Running, status)
 	}
 
 	if err := task.Kill(ctx, syscall.SIGKILL); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	<-statusC

--- a/metadata/gc_test.go
+++ b/metadata/gc_test.go
@@ -316,8 +316,7 @@ func checkNodesEqual(t *testing.T, n1, n2 []gc.Node) {
 	sort.Sort(nodeList(n2))
 
 	if len(n1) != len(n2) {
-		t.Errorf("Nodes do not match\n\tExpected:\n\t%v\n\tActual:\n\t%v", n2, n1)
-		return
+		t.Fatalf("Nodes do not match\n\tExpected:\n\t%v\n\tActual:\n\t%v", n2, n1)
 	}
 
 	for i := range n1 {

--- a/snapshots/overlay/overlay_test.go
+++ b/snapshots/overlay/overlay_test.go
@@ -41,13 +41,11 @@ func TestOverlayMounts(t *testing.T) {
 	defer os.RemoveAll(root)
 	o, _, err := newSnapshotter(ctx, root)
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	mounts, err := o.Prepare(ctx, "/tmp/test", "")
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	if len(mounts) != 1 {
 		t.Errorf("should only have 1 mount but received %d", len(mounts))
@@ -77,23 +75,19 @@ func TestOverlayCommit(t *testing.T) {
 	defer os.RemoveAll(root)
 	o, _, err := newSnapshotter(ctx, root)
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	key := "/tmp/test"
 	mounts, err := o.Prepare(ctx, key, "")
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	m := mounts[0]
 	if err := ioutil.WriteFile(filepath.Join(m.Source, "foo"), []byte("hi"), 0660); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	if err := o.Commit(ctx, "base", key); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 }
 
@@ -106,22 +100,18 @@ func TestOverlayOverlayMount(t *testing.T) {
 	defer os.RemoveAll(root)
 	o, _, err := newSnapshotter(ctx, root)
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	key := "/tmp/test"
 	if _, err = o.Prepare(ctx, key, ""); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	if err := o.Commit(ctx, "base", key); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	var mounts []mount.Mount
 	if mounts, err = o.Prepare(ctx, "/tmp/layer2", "base"); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	if len(mounts) != 1 {
 		t.Errorf("should only have 1 mount but received %d", len(mounts))
@@ -194,46 +184,37 @@ func TestOverlayOverlayRead(t *testing.T) {
 	defer os.RemoveAll(root)
 	o, _, err := newSnapshotter(ctx, root)
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	key := "/tmp/test"
 	mounts, err := o.Prepare(ctx, key, "")
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	m := mounts[0]
 	if err := ioutil.WriteFile(filepath.Join(m.Source, "foo"), []byte("hi"), 0660); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	if err := o.Commit(ctx, "base", key); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	if mounts, err = o.Prepare(ctx, "/tmp/layer2", "base"); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	dest := filepath.Join(root, "dest")
 	if err := os.Mkdir(dest, 0700); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	if err := mount.All(mounts, dest); err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	defer syscall.Unmount(dest, 0)
 	data, err := ioutil.ReadFile(filepath.Join(dest, "foo"))
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	if e := string(data); e != "hi" {
-		t.Errorf("expected file contents hi but got %q", e)
-		return
+		t.Fatalf("expected file contents hi but got %q", e)
 	}
 }
 


### PR DESCRIPTION
Cleanup some tests to use `t.Fatal()` instead of returning