### PR TITLE
[release/1.0] Update runc to 9f9c96235cc97674e935002fc3d78361b69

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
   - sudo chmod -R og+r /usr/local/include/google/protobuf/
   - protoc --version
   - go get -u github.com/vbatts/git-validation
-  - sudo wget https://github.com/crosbymichael/runc/releases/download/ctd-8/runc -O /bin/runc; sudo chmod +x /bin/runc
+  - sudo wget https://github.com/crosbymichael/runc/releases/download/ctd-9/runc -O /bin/runc; sudo chmod +x /bin/runc
   - wget https://github.com/xemul/criu/archive/v3.0.tar.gz -O /tmp/criu.tar.gz
   - tar -C /tmp/ -zxf /tmp/criu.tar.gz
   - cd /tmp/criu-3.0 && sudo make install-criu

--- a/RUNC.md
+++ b/RUNC.md
@@ -2,7 +2,7 @@ containerd is built with OCI support and with support for advanced features prov
 
 We depend on a specific `runc` version when dealing with advanced features.  You should have a specific runc build for development.  The current supported runc commit is:
 
-RUNC_COMMIT = 7f24b40cc5423969b4554ef04ba0b00e2b4ba010
+RUNC_COMMIT = 9f9c96235cc97674e935002fc3d78361b696a69e
 
 For more information on how to clone and build runc see the runc Building [documentation](https://github.com/opencontainers/runc#building).
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -16,7 +16,7 @@ github.com/docker/go-units v0.3.1
 github.com/gogo/protobuf v0.5
 github.com/golang/protobuf 1643683e1b54a9e88ad26d98f81400c8c9d9f4f9
 github.com/opencontainers/runtime-spec v1.0.0
-github.com/opencontainers/runc 7f24b40cc5423969b4554ef04ba0b00e2b4ba010
+github.com/opencontainers/runc 9f9c96235cc97674e935002fc3d78361b696a69e
 github.com/sirupsen/logrus v1.0.0
 github.com/containerd/btrfs cc52c4dea2ce11a44e6639e561bb5c2af9ada9e3
 github.com/stretchr/testify v1.1.4

--- a/vendor/github.com/opencontainers/runc/libcontainer/system/linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/system/linux.go
@@ -134,3 +134,14 @@ func RunningInUserNS() bool {
 func SetSubreaper(i int) error {
 	return unix.Prctl(PR_SET_CHILD_SUBREAPER, uintptr(i), 0, 0, 0)
 }
+
+// GetSubreaper returns the subreaper setting for the calling process
+func GetSubreaper() (int, error) {
+	var i uintptr
+
+	if err := unix.Prctl(unix.PR_GET_CHILD_SUBREAPER, uintptr(unsafe.Pointer(&i)), 0, 0, 0); err != nil {
+		return -1, err
+	}
+
+	return int(i), nil
+}


### PR DESCRIPTION
This fixes issues for init and exec hanging forever when an error
happends on start.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>