### PR TITLE
[release/1.0] archive, cio, cmd, linux: use buffer pools

### DIFF
--- a/archive/tar.go
+++ b/archive/tar.go
@@ -19,7 +19,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var bufferPool = &sync.Pool{
+var bufPool = &sync.Pool{
 	New: func() interface{} {
 		buffer := make([]byte, 32*1024)
 		return &buffer
@@ -423,9 +423,7 @@ func (cw *changeWriter) HandleChange(k fs.ChangeKind, p string, f os.FileInfo, e
 			}
 			defer file.Close()
 
-			buf := bufferPool.Get().(*[]byte)
-			n, err := io.CopyBuffer(cw.tw, file, *buf)
-			bufferPool.Put(buf)
+			n, err := copyBuffered(context.TODO(), cw.tw, file)
 			if err != nil {
 				return errors.Wrap(err, "failed to copy")
 			}
@@ -578,8 +576,8 @@ func (cw *changeWriter) includeParents(hdr *tar.Header) error {
 }
 
 func copyBuffered(ctx context.Context, dst io.Writer, src io.Reader) (written int64, err error) {
-	buf := bufferPool.Get().(*[]byte)
-	defer bufferPool.Put(buf)
+	buf := bufPool.Get().(*[]byte)
+	defer bufPool.Put(buf)
 
 	for {
 		select {

--- a/cio/io.go
+++ b/cio/io.go
@@ -8,7 +8,14 @@ import (
 	"sync"
 )
 
-// Config holds the io configurations.
+var bufPool = sync.Pool{
+	New: func() interface{} {
+		buffer := make([]byte, 32<<10)
+		return &buffer
+	},
+}
+
+// Config holds the IO configurations.
 type Config struct {
 	// Terminal is true if one has been allocated
 	Terminal bool

--- a/cio/io_windows.go
+++ b/cio/io_windows.go
@@ -46,7 +46,11 @@ func copyIO(fifos *FIFOSet, ioset *ioSet, tty bool) (_ *wgCloser, err error) {
 				log.L.WithError(err).Errorf("failed to accept stdin connection on %s", fifos.In)
 				return
 			}
-			io.Copy(c, ioset.in)
+
+			p := bufPool.Get().(*[]byte)
+			defer bufPool.Put(p)
+
+			io.CopyBuffer(c, ioset.in, *p)
 			c.Close()
 			l.Close()
 		}()
@@ -72,7 +76,10 @@ func copyIO(fifos *FIFOSet, ioset *ioSet, tty bool) (_ *wgCloser, err error) {
 				log.L.WithError(err).Errorf("failed to accept stdout connection on %s", fifos.Out)
 				return
 			}
-			io.Copy(ioset.out, c)
+			p := bufPool.Get().(*[]byte)
+			defer bufPool.Put(p)
+
+			io.CopyBuffer(ioset.out, c, *p)
 			c.Close()
 			l.Close()
 		}()
@@ -98,7 +105,10 @@ func copyIO(fifos *FIFOSet, ioset *ioSet, tty bool) (_ *wgCloser, err error) {
 				log.L.WithError(err).Errorf("failed to accept stderr connection on %s", fifos.Err)
 				return
 			}
-			io.Copy(ioset.err, c)
+			p := bufPool.Get().(*[]byte)
+			defer bufPool.Put(p)
+
+			io.CopyBuffer(ioset.err, c, *p)
 			c.Close()
 			l.Close()
 		}()

--- a/cmd/containerd/main.go
+++ b/cmd/containerd/main.go
@@ -10,10 +10,6 @@ import (
 	"os/signal"
 	"time"
 
-	"google.golang.org/grpc/grpclog"
-
-	gocontext "golang.org/x/net/context"
-
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/server"
 	"github.com/containerd/containerd/sys"
@@ -21,6 +17,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
+	gocontext "golang.org/x/net/context"
+	"google.golang.org/grpc/grpclog"
 )
 
 const usage = `

--- a/cmd/containerd/main_unix.go
+++ b/cmd/containerd/main_unix.go
@@ -7,11 +7,10 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
-
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/server"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 )
 
 const defaultConfigPath = "/etc/containerd/config.toml"

--- a/linux/bundle.go
+++ b/linux/bundle.go
@@ -3,9 +3,8 @@
 package linux
 
 import (
-	"bytes"
 	"context"
-	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -52,12 +51,7 @@ func newBundle(id, path, workDir string, spec []byte) (b *bundle, err error) {
 	if err := os.Mkdir(filepath.Join(path, "rootfs"), 0711); err != nil {
 		return nil, err
 	}
-	f, err := os.Create(filepath.Join(path, configFilename))
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-	_, err = io.Copy(f, bytes.NewReader(spec))
+	err = ioutil.WriteFile(filepath.Join(path, configFilename), spec, 0666)
 	return &bundle{
 		id:      id,
 		path:    path,

--- a/linux/proc/utils.go
+++ b/linux/proc/utils.go
@@ -66,7 +66,10 @@ func copyFile(to, from string) error {
 		return err
 	}
 	defer tt.Close()
-	_, err = io.Copy(tt, ff)
+
+	p := bufPool.Get().(*[]byte)
+	defer bufPool.Put(p)
+	_, err = io.CopyBuffer(tt, ff, *p)
 	return err
 }
 

--- a/linux/shim/service.go
+++ b/linux/shim/service.go
@@ -29,7 +29,15 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-var empty = &ptypes.Empty{}
+var (
+	empty   = &ptypes.Empty{}
+	bufPool = sync.Pool{
+		New: func() interface{} {
+			buffer := make([]byte, 32<<10)
+			return &buffer
+		},
+	}
+)
 
 // Config contains shim specific configuration
 type Config struct {

--- a/linux/shim/service_linux.go
+++ b/linux/shim/service_linux.go
@@ -33,7 +33,9 @@ func (p *linuxPlatform) CopyConsole(ctx context.Context, console console.Console
 		cwg.Add(1)
 		go func() {
 			cwg.Done()
-			io.Copy(epollConsole, in)
+			p := bufPool.Get().(*[]byte)
+			defer bufPool.Put(p)
+			io.CopyBuffer(epollConsole, in, *p)
 		}()
 	}
 
@@ -49,7 +51,9 @@ func (p *linuxPlatform) CopyConsole(ctx context.Context, console console.Console
 	cwg.Add(1)
 	go func() {
 		cwg.Done()
-		io.Copy(outw, epollConsole)
+		p := bufPool.Get().(*[]byte)
+		defer bufPool.Put(p)
+		io.CopyBuffer(outw, epollConsole, *p)
 		epollConsole.Close()
 		outr.Close()
 		outw.Close()

--- a/linux/shim/service_unix.go
+++ b/linux/shim/service_unix.go
@@ -24,7 +24,10 @@ func (p *unixPlatform) CopyConsole(ctx context.Context, console console.Console,
 		cwg.Add(1)
 		go func() {
 			cwg.Done()
-			io.Copy(console, in)
+			p := bufPool.Get().(*[]byte)
+			defer bufPool.Put(p)
+
+			io.CopyBuffer(console, in, *p)
 		}()
 	}
 	outw, err := fifo.OpenFifo(ctx, stdout, syscall.O_WRONLY, 0)
@@ -39,7 +42,10 @@ func (p *unixPlatform) CopyConsole(ctx context.Context, console console.Console,
 	cwg.Add(1)
 	go func() {
 		cwg.Done()
-		io.Copy(outw, console)
+		p := bufPool.Get().(*[]byte)
+		defer bufPool.Put(p)
+
+		io.CopyBuffer(outw, console, *p)
 		console.Close()
 		outr.Close()
 		outw.Close()


### PR DESCRIPTION
To avoid buffer bloat in long running processes, we try to use buffer
pools where possible. This is meant to address shim memory usage issues,
but may not be the root cause.

Signed-off-by: Stephen J Day <stephen.day@docker.com>
(cherry picked from commit cd72819b53ff30976570d0a8b80e1a4cf96f2095)
Signed-off-by: Stephen J Day <stephen.day@docker.com>