### PR TITLE
content.Fetch: better error when auth fails

### DIFF
--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -136,6 +136,9 @@ func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocisp
 		log.G(ctx).Debug("resolving")
 		resp, err := fetcher.doRequestWithRetries(ctx, req, nil)
 		if err != nil {
+			if errors.Cause(err) == ErrInvalidAuthorization {
+				err = errors.Wrapf(err, "pull access denied, repository does not exist or may require authorization")
+			}
 			return "", ocispec.Descriptor{}, err
 		}
 		resp.Body.Close() // don't care about body contents.


### PR DESCRIPTION
I was debugging why I was getting a token auth failure when attempting to pull an image, @jessvalarezo realized that the image was just misspelled.

This adds extra error context when the failure is caused by failed auth to indicate that the repository just might not exist.

```
PS H:\bin\containerd> .\ctr images pull docker.io/image/doesnotexist:latest
docker.io/image/doesnotexist:latest: resolving      |--------------------------------------|
elapsed: 0.8 s                       total:   0.0 B (0.0 B/s)
ctr: failed to resolve reference "docker.io/image/doesnotexist:latest": pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
```

cc @stevvooe FYI this was what I thought was a failed token auth. Just a misunderstanding 😄 

Signed-off-by: Darren Stahl <darst@microsoft.com>