### PR TITLE
Fix duplicate directories entries on metadata change

### DIFF
--- a/archive/tar.go
+++ b/archive/tar.go
@@ -583,6 +583,9 @@ func (cw *changeWriter) includeParents(hdr *tar.Header) error {
 			}
 		}
 	}
+	if hdr.Typeflag == tar.TypeDir {
+		cw.addedDirs[name] = struct{}{}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Currently directory changes are not added to the list of included directories, allowing those directories to receive duplicate entries where there is both a metadata change to the directory and a change to a file under that directory.

Adding this for cherry-pick, this could be considered a regression in 1.0.1 since 1.0 would have had the correct behavior by not including the directory as a parent. Note this only effects created content, the main consumer of which right now is buildkit or other build tools using containerd.

See https://github.com/moby/buildkit/issues/266