### PR TITLE
cmd/containerd-shim: aggressive memory reclamation

### DIFF
--- a/cmd/containerd-shim/main_unix.go
+++ b/cmd/containerd-shim/main_unix.go
@@ -12,9 +12,11 @@ import (
 	"os/exec"
 	"os/signal"
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/containerd/containerd/events"
 	"github.com/containerd/containerd/linux/proc"
@@ -58,6 +60,13 @@ func init() {
 }
 
 func main() {
+	debug.SetGCPercent(10)
+	go func() {
+		for range time.Tick(30 * time.Second) {
+			debug.FreeOSMemory()
+		}
+	}()
+
 	if debugFlag {
 		logrus.SetLevel(logrus.DebugLevel)
 	}


### PR DESCRIPTION
To avoid having the shim hold on to too much memory, we've made a few
adjustments to favor more aggressive reclamation of memory from the
operating system. Typically, this would be negligible, on the order of a
few megabytes, but this is impactful when running several containers.

The first fix is to lower the threshold used to determine when to run
the garbage collector. The second runs `runtime/debug.FreeOSMemory` at a
regular interval.

Under test, this result in a sustained memory usage of around 3.7 MB.

Fixes #2020

Signed-off-by: Stephen J Day <stephen.day@docker.com>