### PR TITLE
[release/1.0] archive: fix duplicate directories entries on metadata change

### DIFF
--- a/archive/tar.go
+++ b/archive/tar.go
@@ -572,6 +572,9 @@ func (cw *changeWriter) includeParents(hdr *tar.Header) error {
 			}
 		}
 	}
+	if hdr.Typeflag == tar.TypeDir {
+		cw.addedDirs[name] = struct{}{}
+	}
 	return nil
 }
 


### PR DESCRIPTION
cherry-pick of #2054

Fixes a regression to diff behavior in 1.0.1 affecting builders