### PR TITLE
Add error return for missing params in ctr images

### DIFF
--- a/cmd/ctr/commands/images/export.go
+++ b/cmd/ctr/commands/images/export.go
@@ -43,6 +43,9 @@ Currently, only OCI format is supported.
 			local = context.Args().Get(1)
 			desc  ocispec.Descriptor
 		)
+		if out == "" || local == "" {
+			return errors.New("please provide both an output filename and an image reference to export")
+		}
 		client, ctx, cancel, err := commands.NewClient(context)
 		if err != nil {
 			return err

--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -27,7 +27,9 @@ command. As part of this process, we do the following:
 		var (
 			ref = context.Args().First()
 		)
-
+		if ref == "" {
+			return fmt.Errorf("please provide an image reference to pull")
+		}
 		ctx, cancel := commands.AppContext(context)
 		defer cancel()
 

--- a/cmd/ctr/commands/images/push.go
+++ b/cmd/ctr/commands/images/push.go
@@ -49,6 +49,9 @@ var pushCommand = cli.Command{
 			local = context.Args().Get(1)
 			desc  ocispec.Descriptor
 		)
+		if ref == "" {
+			return errors.New("please provide a remote image reference to push")
+		}
 		client, ctx, cancel, err := commands.NewClient(context)
 		if err != nil {
 			return err


### PR DESCRIPTION
For missing required parameters adds error return before attempting any
actions to `ctr images` commands.

Fixes: #2064

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>