### PR TITLE
Allow tcp debug address

### DIFF
--- a/cmd/containerd/config_linux.go
+++ b/cmd/containerd/config_linux.go
@@ -12,9 +12,5 @@ func defaultConfig() *server.Config {
 		GRPC: server.GRPCConfig{
 			Address: defaults.DefaultAddress,
 		},
-		Debug: server.Debug{
-			Level:   "info",
-			Address: defaults.DefaultDebugAddress,
-		},
 	}
 }

--- a/cmd/containerd/config_windows.go
+++ b/cmd/containerd/config_windows.go
@@ -12,9 +12,5 @@ func defaultConfig() *server.Config {
 		GRPC: server.GRPCConfig{
 			Address: defaults.DefaultAddress,
 		},
-		Debug: server.Debug{
-			Level:   "info",
-			Address: defaults.DefaultDebugAddress,
-		},
 	}
 }


### PR DESCRIPTION
This uses a simple `IsAbs` check to see if we are using an on disk path
for a unix socket vs an address since we do not prefix addresses with
`unix://` or `tcp://`.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>