### PR TITLE
Simplify mount.Lookup.

### DIFF
--- a/mount/lookup_unix.go
+++ b/mount/lookup_unix.go
@@ -3,22 +3,16 @@
 package mount
 
 import (
-	"fmt"
 	"path/filepath"
 	"sort"
 	"strings"
-	"syscall"
 
 	"github.com/pkg/errors"
 )
 
 // Lookup returns the mount info corresponds to the path.
 func Lookup(dir string) (Info, error) {
-	var dirStat syscall.Stat_t
 	dir = filepath.Clean(dir)
-	if err := syscall.Stat(dir, &dirStat); err != nil {
-		return Info{}, errors.Wrapf(err, "failed to access %q", dir)
-	}
 
 	mounts, err := Self()
 	if err != nil {
@@ -26,21 +20,18 @@ func Lookup(dir string) (Info, error) {
 	}
 
 	// Sort descending order by Info.Mountpoint
-	sort.Slice(mounts, func(i, j int) bool {
+	sort.SliceStable(mounts, func(i, j int) bool {
 		return mounts[j].Mountpoint < mounts[i].Mountpoint
 	})
 	for _, m := range mounts {
 		// Note that m.{Major, Minor} are generally unreliable for our purpose here
 		// https://www.spinics.net/lists/linux-btrfs/msg58908.html
-		var st syscall.Stat_t
-		if err := syscall.Stat(m.Mountpoint, &st); err != nil {
-			// may fail; ignore err
-			continue
-		}
-		if st.Dev == dirStat.Dev && strings.HasPrefix(dir, m.Mountpoint) {
+		// Note that device number is not checked here, because for overlayfs files
+		// may have different device number with the mountpoint.
+		if strings.HasPrefix(dir, m.Mountpoint) {
 			return m, nil
 		}
 	}
 
-	return Info{}, fmt.Errorf("failed to find the mount info for %q", dir)
+	return Info{}, errors.Errorf("failed to find the mount info for %q", dir)
 }


### PR DESCRIPTION
In cri-containerd we do encountered an problem that `/etc/xxx` is on a different device with `/etc`, when `/etc` is mounted as overlayfs.

It seems fine to purely reply on the path, like what docker is doing https://github.com/moby/moby/blob/master/daemon/oci_linux.go#L387

@AkihiroSuda @miaoyq 
Signed-off-by: Lantao Liu <lantaol@google.com>