### PR TITLE
[release 1.0] Bump cgroups to c0710c92e8b3a44681d1321dcfd1360fc5

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,7 +1,7 @@
 github.com/coreos/go-systemd 48702e0da86bd25e76cfef347e2adeb434a0d0a6
 github.com/containerd/go-runc 4f6e87ae043f859a38255247b49c9abc262d002f
 github.com/containerd/console 84eeaae905fa414d03e07bcd6c8d3f19e7cf180e
-github.com/containerd/cgroups 29da22c6171a4316169f9205ab6c49f59b5b852f
+github.com/containerd/cgroups c0710c92e8b3a44681d1321dcfd1360fc5c6c089
 github.com/containerd/typeurl f6943554a7e7e88b3c14aad190bf05932da84788
 github.com/docker/go-metrics 8fd5772bf1584597834c6f7961a530f06cbfbb87
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9

--- a/vendor/github.com/containerd/cgroups/errors.go
+++ b/vendor/github.com/containerd/cgroups/errors.go
@@ -12,7 +12,7 @@ var (
 	ErrFreezerNotSupported      = errors.New("cgroups: freezer cgroup not supported on this system")
 	ErrMemoryNotSupported       = errors.New("cgroups: memory cgroup not supported on this system")
 	ErrCgroupDeleted            = errors.New("cgroups: cgroup deleted")
-	ErrNoCgroupMountDestination = errors.New("cgroups: cannot found cgroup mount destination")
+	ErrNoCgroupMountDestination = errors.New("cgroups: cannot find cgroup mount destination")
 )
 
 // ErrorHandler is a function that handles and acts on errors


### PR DESCRIPTION
This fixes performance issues with walking `/dev` to get device paths.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>