### PR TITLE
Fix vendor validation

### DIFF
--- a/script/validate/vendor
+++ b/script/validate/vendor
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
 
-vndr 2>&1 | grep -v -i clone
+rm -rf vendor/
+vndr |& grep -v -i clone
 
 DIFF_PATH="vendor/"
 DIFF=$(git status --porcelain -- "$DIFF_PATH")


### PR DESCRIPTION
vendor/ must be removed first, otherwise files added to vendor/ that aren't added to
vendor.conf will not cause the validation to fail.