### PR TITLE
Add time type conversions for 32bit Unix platforms

### DIFF
--- a/sys/stat_unix.go
+++ b/sys/stat_unix.go
@@ -24,5 +24,5 @@ func StatMtime(st *syscall.Stat_t) syscall.Timespec {
 
 // StatATimeAsTime returns st.Atim as a time.Time
 func StatATimeAsTime(st *syscall.Stat_t) time.Time {
-	return time.Unix(st.Atim.Sec, st.Atim.Nsec)
+	return time.Unix(int64(st.Atim.Sec), int64(st.Atim.Nsec)) // nolint: unconvert
 }


### PR DESCRIPTION
This ensures the `time.Unix` function is given int64 arguments so that a 32 bit Unix OS can run `make`. This fixes an issue when running `make` that I ran into on a Raspberry Pi with 32 bit Debian 9.1:
```
# github.com/containerd/containerd/sys
sys/stat_unix.go:27:26: cannot use st.Atim.Sec (type int32) as type int64 in argument to time.Unix
sys/stat_unix.go:27:39: cannot use st.Atim.Nsec (type int32) as type int64 in argument to time.Unix
Makefile:150: recipe for target 'bin/ctr' failed
make: *** [bin/ctr] Error 2
```

Seems like this happened after [this commit](https://github.com/containerd/containerd/commit/184bc256293eb7fba619514078c7b575b8a5f6aa) removed the `int64` type conversion for unix systems when the unconvert linter was added [in this PR.](https://github.com/containerd/containerd/pull/1975)