### PR TITLE
Support disable plugins.

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -140,10 +140,19 @@ func Register(r *Registration) {
 	register.r = append(register.r, r)
 }
 
-// Graph returns an ordered list of registered plugins for initialization
-func Graph() (ordered []*Registration) {
+// Graph returns an ordered list of registered plugins for initialization.
+// Plugins in disableList specified by id will be disabled.
+func Graph(disableList []string) (ordered []*Registration) {
 	register.RLock()
 	defer register.RUnlock()
+	for _, d := range disableList {
+		for i, r := range register.r {
+			if r.ID == d {
+				register.r = append(register.r[:i], register.r[i+1:]...)
+				break
+			}
+		}
+	}
 
 	added := map[*Registration]bool{}
 	for _, r := range register.r {

--- a/server/config.go
+++ b/server/config.go
@@ -18,6 +18,9 @@ type Config struct {
 	Debug Debug `toml:"debug"`
 	// Metrics and monitoring settings
 	Metrics MetricsConfig `toml:"metrics"`
+	// DisabledPlugins are IDs of plugins to disable. Disabled plugins won't be
+	// initialized and started.
+	DisabledPlugins []string `toml:"disabled_plugins"`
 	// Plugins provides plugin specific configuration for the initialization of a plugin
 	Plugins map[string]toml.Primitive `toml:"plugins"`
 	// OOMScore adjust the containerd's oom score

--- a/server/server.go
+++ b/server/server.go
@@ -242,7 +242,7 @@ func LoadPlugins(config *Config) ([]*plugin.Registration, error) {
 	})
 
 	// return the ordered graph for plugins
-	return plugin.Graph(), nil
+	return plugin.Graph(config.DisabledPlugins), nil
 }
 
 func trapClosedConnErr(err error) error {


### PR DESCRIPTION
Fixes https://github.com/containerd/containerd/issues/2061.

With this PR, we can disable a `cri` and `healthcheck` plugin by adding following line in the containerd config file:
```
disable_plugins = ["cri", "healthcheck"]
```
Signed-off-by: Lantao Liu <lantaol@google.com>