### PR TITLE
Fix trace level support.

### DIFF
--- a/log/context.go
+++ b/log/context.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"context"
+	"sync/atomic"
 
 	"github.com/sirupsen/logrus"
 )
@@ -54,14 +55,16 @@ func GetLogger(ctx context.Context) *logrus.Entry {
 
 // Trace logs a message at level Trace with the log entry passed-in.
 func Trace(e *logrus.Entry, args ...interface{}) {
-	if e.Level >= TraceLevel {
+	level := logrus.Level(atomic.LoadUint32((*uint32)(&e.Logger.Level)))
+	if level >= TraceLevel {
 		e.Debug(args...)
 	}
 }
 
 // Tracef logs a message at level Trace with the log entry passed-in.
 func Tracef(e *logrus.Entry, format string, args ...interface{}) {
-	if e.Level >= TraceLevel {
+	level := logrus.Level(atomic.LoadUint32((*uint32)(&e.Logger.Level)))
+	if level >= TraceLevel {
 		e.Debugf(format, args...)
 	}
 }


### PR DESCRIPTION
When trying to update and use this in cri-containerd, I find this error.

This is a bit confusing:
* `entry.Level` is only set when actually outputs log (see [here](https://github.com/sirupsen/logrus/blob/master/entry.go#L94)). It's just Level of a particular log entry.
* `entry.Logger.Level` is the thing we should use. Note that we need `atomic` to avoid race condition. (see [here](https://github.com/sirupsen/logrus/blob/master/logger.go#L316)).

Signed-off-by: Lantao Liu <lantaol@google.com>