### PR TITLE
content: support manifest labeling on completed content ingests on the client

### DIFF
--- a/images/image.go
+++ b/images/image.go
@@ -102,7 +102,7 @@ func (image *Image) Size(ctx context.Context, provider content.Provider, platfor
 		}
 		size += desc.Size
 		return nil, nil
-	}), ChildrenHandler(provider, platform)), image.Target)
+	}), FilterPlatform(platform, ChildrenHandler(provider))), image.Target)
 }
 
 // Manifest resolves a manifest from the image for the given platform.
@@ -238,7 +238,7 @@ func Platforms(ctx context.Context, provider content.Provider, image ocispec.Des
 				platforms.Normalize(ocispec.Platform{OS: image.OS, Architecture: image.Architecture}))
 		}
 		return nil, nil
-	}), ChildrenHandler(provider, "")), image)
+	}), ChildrenHandler(provider)), image)
 }
 
 // Check returns nil if the all components of an image are available in the
@@ -285,7 +285,7 @@ func Check(ctx context.Context, provider content.Provider, image ocispec.Descrip
 }
 
 // Children returns the immediate children of content described by the descriptor.
-func Children(ctx context.Context, provider content.Provider, desc ocispec.Descriptor, platform string) ([]ocispec.Descriptor, error) {
+func Children(ctx context.Context, provider content.Provider, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 	var descs []ocispec.Descriptor
 	switch desc.MediaType {
 	case MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest:
@@ -314,21 +314,7 @@ func Children(ctx context.Context, provider content.Provider, desc ocispec.Descr
 			return nil, err
 		}
 
-		if platform != "" {
-			matcher, err := platforms.Parse(platform)
-			if err != nil {
-				return nil, err
-			}
-
-			for _, d := range index.Manifests {
-				if d.Platform == nil || matcher.Match(*d.Platform) {
-					descs = append(descs, d)
-				}
-			}
-		} else {
-			descs = append(descs, index.Manifests...)
-		}
-
+		descs = append(descs, index.Manifests...)
 	case MediaTypeDockerSchema2Layer, MediaTypeDockerSchema2LayerGzip,
 		MediaTypeDockerSchema2LayerForeign, MediaTypeDockerSchema2LayerForeignGzip,
 		MediaTypeDockerSchema2Config, ocispec.MediaTypeImageConfig,

--- a/images/oci/exporter.go
+++ b/images/oci/exporter.go
@@ -42,7 +42,7 @@ func (oe *V1Exporter) Export(ctx context.Context, store content.Store, desc ocis
 	}
 
 	handlers := images.Handlers(
-		images.ChildrenHandler(store, platforms.Default()),
+		images.FilterPlatform(platforms.Default(), images.ChildrenHandler(store)),
 		images.HandlerFunc(exportHandler),
 	)
 


### PR DESCRIPTION
Fix issue where manifest content must always be fetched even if it is already fully downloaded or shared locally. Simplify children label setting and platform filtering. Prevent getting a fetcher when content shared locally.

Note this makes the filtering and labeling more composable, so we could change the behavior more easily (such as if we only wanted to label content which was saved locally, the wrapping order could just be changed).

This is the first PR to support content sharing on the client side. This PR can be backported into 1.0.x to support content sharing in clients based on 1.0.x and containerd 1.1+. 