### PR TITLE
archive/diff: fix consecutive directory removal bug

### DIFF
--- a/archive/tar_test.go
+++ b/archive/tar_test.go
@@ -988,6 +988,24 @@ func TestDiffTar(t *testing.T) {
 				fstest.RemoveAll("/d5"),
 			),
 		},
+		{
+			name: "WhiteoutParentRemoval",
+			validators: []tarEntryValidator{
+				whiteoutEntry("d1"),
+				whiteoutEntry("d2"),
+				dirEntry("d3/", 0755),
+			},
+			a: fstest.Apply(
+				fstest.CreateDir("/d1/", 0755),
+				fstest.CreateDir("/d2/", 0755),
+				fstest.CreateFile("/d2/f1", []byte("content"), 0644),
+			),
+			b: fstest.Apply(
+				fstest.RemoveAll("/d1"),
+				fstest.RemoveAll("/d2"),
+				fstest.CreateDir("/d3/", 0755),
+			),
+		},
 	}
 
 	for _, at := range tests {

--- a/vendor.conf
+++ b/vendor.conf
@@ -28,7 +28,7 @@ github.com/pkg/errors v0.8.0
 github.com/opencontainers/go-digest 21dfd564fd89c944783d00d069f33e3e7123c448
 golang.org/x/sys 314a259e304ff91bd6985da2a7149bbf91237993 https://github.com/golang/sys
 github.com/opencontainers/image-spec v1.0.1
-github.com/containerd/continuity 1a794c0014a7b786879312d1dab309ba96ead8bc
+github.com/containerd/continuity 992a5f112bd2211d0983a1cc8562d2882848f3a3
 golang.org/x/sync 450f422ab23cf9881c94e2db30cac0eb1b7cf80c
 github.com/BurntSushi/toml a368813c5e648fee92e5f6c30e3944ff9d5e8895
 github.com/grpc-ecosystem/go-grpc-prometheus 6b7015e65d366bf3f19b2b2a000a831940f0f7e0

--- a/vendor/github.com/containerd/continuity/fs/diff.go
+++ b/vendor/github.com/containerd/continuity/fs/diff.go
@@ -273,7 +273,7 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b string) (err 
 				if rmdir != "" && strings.HasPrefix(f1.path, rmdir) {
 					f1 = nil
 					continue
-				} else if rmdir == "" && f1.f.IsDir() {
+				} else if f1.f.IsDir() {
 					rmdir = f1.path + string(os.PathSeparator)
 				} else if rmdir != "" {
 					rmdir = ""


### PR DESCRIPTION
Ensures the remove directory marker gets updated when a new directly delete is found right after an old one. This was causing a bug where deletion events were being sent under a removed directory, causing the archiver to error when attempting to include the parent of a removed file.

fixes #2119 