### PR TITLE
[release/1.0] archive/diff: fix consecutive directory removal bug

### DIFF
--- a/archive/tar_test.go
+++ b/archive/tar_test.go
@@ -988,6 +988,24 @@ func TestDiffTar(t *testing.T) {
 				fstest.RemoveAll("/d5"),
 			),
 		},
+		{
+			name: "WhiteoutParentRemoval",
+			validators: []tarEntryValidator{
+				whiteoutEntry("d1"),
+				whiteoutEntry("d2"),
+				dirEntry("d3/", 0755),
+			},
+			a: fstest.Apply(
+				fstest.CreateDir("/d1/", 0755),
+				fstest.CreateDir("/d2/", 0755),
+				fstest.CreateFile("/d2/f1", []byte("content"), 0644),
+			),
+			b: fstest.Apply(
+				fstest.RemoveAll("/d1"),
+				fstest.RemoveAll("/d2"),
+				fstest.CreateDir("/d3/", 0755),
+			),
+		},
 	}
 
 	for _, at := range tests {

--- a/fs/diff.go
+++ b/fs/diff.go
@@ -273,7 +273,7 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b string) (err 
 				if rmdir != "" && strings.HasPrefix(f1.path, rmdir) {
 					f1 = nil
 					continue
-				} else if rmdir == "" && f1.f.IsDir() {
+				} else if f1.f.IsDir() {
 					rmdir = f1.path + string(os.PathSeparator)
 				} else if rmdir != "" {
 					rmdir = ""

--- a/fs/diff_test.go
+++ b/fs/diff_test.go
@@ -56,6 +56,28 @@ func TestSimpleDiff(t *testing.T) {
 	}
 }
 
+func TestNestedDeletion(t *testing.T) {
+	skipDiffTestOnWindows(t)
+	l1 := fstest.Apply(
+		fstest.CreateDir("/d0", 0755),
+		fstest.CreateDir("/d1", 0755),
+		fstest.CreateDir("/d1/d2", 0755),
+		fstest.CreateFile("/d1/d2/f1", []byte("mydomain 10.0.0.1"), 0644),
+	)
+	l2 := fstest.Apply(
+		fstest.RemoveAll("/d0"),
+		fstest.RemoveAll("/d1"),
+	)
+	diff := []TestChange{
+		Delete("/d0"),
+		Delete("/d1"),
+	}
+
+	if err := testDiffWithBase(l1, l2, diff); err != nil {
+		t.Fatalf("Failed diff with base: %+v", err)
+	}
+}
+
 func TestDirectoryReplace(t *testing.T) {
 	skipDiffTestOnWindows(t)
 	l1 := fstest.Apply(


### PR DESCRIPTION
Cherry pick of #2126 

Since fs package was moved to continuity in master, this creates an identical fix for the fs package in the release/1.0 branch. There has been no functionality divergence since moving from master.