### PR TITLE
[testing] use smaller filesize on 4KB pagesize systems

### DIFF
--- a/snapshots/btrfs/btrfs_test.go
+++ b/snapshots/btrfs/btrfs_test.go
@@ -29,7 +29,14 @@ func boltSnapshotter(t *testing.T) func(context.Context, string) (snapshots.Snap
 
 	return func(ctx context.Context, root string) (snapshots.Snapshotter, func() error, error) {
 
-		deviceName, cleanupDevice, err := testutil.NewLoopback(650 << 20) // 650 MB
+		loopbackSize := int64(100 << 20) // 100 MB
+		// mkfs.btrfs creates a fs which has a blocksize equal to the system default pagesize. If that pagesize
+		// is > 4KB, mounting the fs will fail unless we increase the size of the file used by mkfs.btrfs
+		if os.Getpagesize() > 4096 {
+			loopbackSize = int64(650 << 20) // 650 MB
+		}
+		deviceName, cleanupDevice, err := testutil.NewLoopback(loopbackSize)
+
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
Uses a much smaller value when creating this file to be used
as a loopback device on non-ppc64le platforms.

This file has to be so large on ppc64le, because mkfs.btrfs
uses the default architecture pagesize as blocksize, which is 64KB
on ppc64le, but only 4KB on amd64 and s390x.

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>