### PR TITLE
content: change Writer/ReaderAt to take OCI descriptor

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -214,7 +214,7 @@ func TestImagePullAllPlatforms(t *testing.T) {
 		}
 		// check if childless data type has blob in content store
 		for _, desc := range children {
-			ra, err := cs.ReaderAt(ctx, desc.Digest)
+			ra, err := cs.ReaderAt(ctx, desc)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -275,7 +275,7 @@ func TestImagePullSomePlatforms(t *testing.T) {
 
 			// check if childless data type has blob in content store
 			for _, desc := range children {
-				ra, err := cs.ReaderAt(ctx, desc.Digest)
+				ra, err := cs.ReaderAt(ctx, desc)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/cmd/ctr/commands/content/content.go
+++ b/cmd/ctr/commands/content/content.go
@@ -72,7 +72,7 @@ var (
 			}
 			defer cancel()
 			cs := client.ContentStore()
-			ra, err := cs.ReaderAt(ctx, dgst)
+			ra, err := cs.ReaderAt(ctx, ocispec.Descriptor{Digest: dgst})
 			if err != nil {
 				return err
 			}
@@ -121,7 +121,7 @@ var (
 			// TODO(stevvooe): Allow ingest to be reentrant. Currently, we expect
 			// all data to be written in a single invocation. Allow multiple writes
 			// to the same transaction key followed by a commit.
-			return content.WriteBlob(ctx, cs, ref, os.Stdin, expectedSize, expectedDigest)
+			return content.WriteBlob(ctx, cs, ref, os.Stdin, ocispec.Descriptor{Size: expectedSize, Digest: expectedDigest})
 		},
 	}
 
@@ -314,7 +314,7 @@ var (
 			}
 			defer cancel()
 			cs := client.ContentStore()
-			ra, err := cs.ReaderAt(ctx, dgst)
+			ra, err := cs.ReaderAt(ctx, ocispec.Descriptor{Digest: dgst})
 			if err != nil {
 				return err
 			}
@@ -326,7 +326,7 @@ var (
 			}
 			defer nrc.Close()
 
-			wr, err := cs.Writer(ctx, "edit-"+object, 0, "") // TODO(stevvooe): Choose a better key?
+			wr, err := cs.Writer(ctx, content.WithRef("edit-"+object)) // TODO(stevvooe): Choose a better key?
 			if err != nil {
 				return err
 			}
@@ -482,7 +482,7 @@ var (
 				Size:      info.Size,
 			}
 
-			ra, err := cs.ReaderAt(ctx, dgst)
+			ra, err := cs.ReaderAt(ctx, desc)
 			if err != nil {
 				return err
 			}

--- a/cmd/ctr/commands/snapshots/snapshots.go
+++ b/cmd/ctr/commands/snapshots/snapshots.go
@@ -167,7 +167,7 @@ var diffCommand = cli.Command{
 			}
 		}
 
-		ra, err := client.ContentStore().ReaderAt(ctx, desc.Digest)
+		ra, err := client.ContentStore().ReaderAt(ctx, desc)
 		if err != nil {
 			return err
 		}

--- a/container_opts_unix.go
+++ b/container_opts_unix.go
@@ -36,9 +36,9 @@ import (
 	"github.com/containerd/containerd/runtime/linux/runctypes"
 	"github.com/gogo/protobuf/proto"
 	protobuf "github.com/gogo/protobuf/types"
-	digest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
 	"github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -50,10 +50,9 @@ func WithCheckpoint(im Image, snapshotKey string) NewContainerOpts {
 	return func(ctx context.Context, client *Client, c *containers.Container) error {
 		var (
 			desc  = im.Target()
-			id    = desc.Digest
 			store = client.ContentStore()
 		)
-		index, err := decodeIndex(ctx, store, id)
+		index, err := decodeIndex(ctx, store, desc)
 		if err != nil {
 			return err
 		}
@@ -80,7 +79,7 @@ func WithCheckpoint(im Image, snapshotKey string) NewContainerOpts {
 				}
 				c.Image = index.Annotations["image.name"]
 			case images.MediaTypeContainerd1CheckpointConfig:
-				data, err := content.ReadBlob(ctx, store, m.Digest)
+				data, err := content.ReadBlob(ctx, store, m)
 				if err != nil {
 					return errors.Wrap(err, "unable to read checkpoint config")
 				}
@@ -113,7 +112,7 @@ func WithTaskCheckpoint(im Image) NewTaskOpts {
 	return func(ctx context.Context, c *Client, info *TaskInfo) error {
 		desc := im.Target()
 		id := desc.Digest
-		index, err := decodeIndex(ctx, c.ContentStore(), id)
+		index, err := decodeIndex(ctx, c.ContentStore(), desc)
 		if err != nil {
 			return err
 		}
@@ -131,9 +130,9 @@ func WithTaskCheckpoint(im Image) NewTaskOpts {
 	}
 }
 
-func decodeIndex(ctx context.Context, store content.Provider, id digest.Digest) (*v1.Index, error) {
+func decodeIndex(ctx context.Context, store content.Provider, desc ocispec.Descriptor) (*v1.Index, error) {
 	var index v1.Index
-	p, err := content.ReadBlob(ctx, store, id)
+	p, err := content.ReadBlob(ctx, store, desc)
 	if err != nil {
 		return nil, err
 	}

--- a/content/content.go
+++ b/content/content.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // ReaderAt extends the standard io.ReaderAt interface with reporting of Size and io.Closer
@@ -33,12 +34,16 @@ type ReaderAt interface {
 
 // Provider provides a reader interface for specific content
 type Provider interface {
-	ReaderAt(ctx context.Context, dgst digest.Digest) (ReaderAt, error)
+	// ReaderAt only requires desc.Digest to be set.
+	// Other fields in the descriptor may be used internally for resolving
+	// the location of the actual data.
+	ReaderAt(ctx context.Context, dec ocispec.Descriptor) (ReaderAt, error)
 }
 
 // Ingester writes content
 type Ingester interface {
-	Writer(ctx context.Context, ref string, size int64, expected digest.Digest) (Writer, error)
+	// Some implementations require WithRef to be included in opts.
+	Writer(ctx context.Context, opts ...WriterOpt) (Writer, error)
 }
 
 // Info holds content specific information
@@ -139,6 +144,36 @@ type Opt func(*Info) error
 func WithLabels(labels map[string]string) Opt {
 	return func(info *Info) error {
 		info.Labels = labels
+		return nil
+	}
+}
+
+// WriterOpts is internally used by WriterOpt.
+type WriterOpts struct {
+	Ref  string
+	Desc ocispec.Descriptor
+}
+
+// WriterOpt is used for passing options to Ingester.Writer.
+type WriterOpt func(*WriterOpts) error
+
+// WithDescriptor specifies an OCI descriptor.
+// Writer may optionally use the descriptor internally for resolving
+// the location of the actual data.
+// Write does not require any field of desc to be set.
+// If the data size is unknown, desc.Size should be set to 0.
+// Some implementations may also accept negative values as "unknown".
+func WithDescriptor(desc ocispec.Descriptor) WriterOpt {
+	return func(opts *WriterOpts) error {
+		opts.Desc = desc
+		return nil
+	}
+}
+
+// WithRef specifies a ref string.
+func WithRef(ref string) WriterOpt {
+	return func(opts *WriterOpts) error {
+		opts.Ref = ref
 		return nil
 	}
 }

--- a/content/local/store.go
+++ b/content/local/store.go
@@ -34,6 +34,7 @@ import (
 	"github.com/containerd/containerd/filters"
 	"github.com/containerd/containerd/log"
 	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -119,15 +120,15 @@ func (s *store) info(dgst digest.Digest, fi os.FileInfo, labels map[string]strin
 }
 
 // ReaderAt returns an io.ReaderAt for the blob.
-func (s *store) ReaderAt(ctx context.Context, dgst digest.Digest) (content.ReaderAt, error) {
-	p := s.blobPath(dgst)
+func (s *store) ReaderAt(ctx context.Context, desc ocispec.Descriptor) (content.ReaderAt, error) {
+	p := s.blobPath(desc.Digest)
 	fi, err := os.Stat(p)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return nil, err
 		}
 
-		return nil, errors.Wrapf(errdefs.ErrNotFound, "blob %s expected at %s", dgst, p)
+		return nil, errors.Wrapf(errdefs.ErrNotFound, "blob %s expected at %s", desc.Digest, p)
 	}
 
 	fp, err := os.Open(p)
@@ -136,7 +137,7 @@ func (s *store) ReaderAt(ctx context.Context, dgst digest.Digest) (content.Reade
 			return nil, err
 		}
 
-		return nil, errors.Wrapf(errdefs.ErrNotFound, "blob %s expected at %s", dgst, p)
+		return nil, errors.Wrapf(errdefs.ErrNotFound, "blob %s expected at %s", desc.Digest, p)
 	}
 
 	return sizeReaderAt{size: fi.Size(), fp: fp}, nil
@@ -400,11 +401,22 @@ func (s *store) total(ingestPath string) int64 {
 // ref at a time.
 //
 // The argument `ref` is used to uniquely identify a long-lived writer transaction.
-func (s *store) Writer(ctx context.Context, ref string, total int64, expected digest.Digest) (content.Writer, error) {
+func (s *store) Writer(ctx context.Context, opts ...content.WriterOpt) (content.Writer, error) {
+	var wOpts content.WriterOpts
+	for _, opt := range opts {
+		if err := opt(&wOpts); err != nil {
+			return nil, err
+		}
+	}
+	// TODO(AkihiroSuda): we could create a random string or one calculated based on the context
+	// https://github.com/containerd/containerd/issues/2129#issuecomment-380255019
+	if wOpts.Ref == "" {
+		return nil, errors.Wrap(errdefs.ErrInvalidArgument, "ref must not be empty")
+	}
 	var lockErr error
 	for count := uint64(0); count < 10; count++ {
 		time.Sleep(time.Millisecond * time.Duration(rand.Intn(1<<count)))
-		if err := tryLock(ref); err != nil {
+		if err := tryLock(wOpts.Ref); err != nil {
 			if !errdefs.IsUnavailable(err) {
 				return nil, err
 			}
@@ -420,9 +432,9 @@ func (s *store) Writer(ctx context.Context, ref string, total int64, expected di
 		return nil, lockErr
 	}
 
-	w, err := s.writer(ctx, ref, total, expected)
+	w, err := s.writer(ctx, wOpts.Ref, wOpts.Desc.Size, wOpts.Desc.Digest)
 	if err != nil {
-		unlock(ref)
+		unlock(wOpts.Ref)
 		return nil, err
 	}
 

--- a/diff/apply/apply.go
+++ b/diff/apply/apply.go
@@ -73,7 +73,7 @@ func (s *fsApplier) Apply(ctx context.Context, desc ocispec.Descriptor, mounts [
 
 	var ocidesc ocispec.Descriptor
 	if err := mount.WithTempMount(ctx, mounts, func(root string) error {
-		ra, err := s.store.ReaderAt(ctx, desc.Digest)
+		ra, err := s.store.ReaderAt(ctx, desc)
 		if err != nil {
 			return errors.Wrap(err, "failed to get reader from content store")
 		}

--- a/diff/walking/differ.go
+++ b/diff/walking/differ.go
@@ -86,7 +86,11 @@ func (s *walkingDiff) Compare(ctx context.Context, lower, upper []mount.Mount, o
 				config.Reference = uniqueRef()
 			}
 
-			cw, err := s.store.Writer(ctx, config.Reference, 0, "")
+			cw, err := s.store.Writer(ctx,
+				content.WithRef(config.Reference),
+				content.WithDescriptor(ocispec.Descriptor{
+					MediaType: config.MediaType, // most contentstore implementations just ignore this
+				}))
 			if err != nil {
 				return errors.Wrap(err, "failed to open writer")
 			}

--- a/diff/windows/windows.go
+++ b/diff/windows/windows.go
@@ -105,7 +105,7 @@ func (s windowsDiff) Apply(ctx context.Context, desc ocispec.Descriptor, mounts 
 		return emptyDesc, errors.Wrapf(errdefs.ErrNotImplemented, "unsupported diff media type: %v", desc.MediaType)
 	}
 
-	ra, err := s.store.ReaderAt(ctx, desc.Digest)
+	ra, err := s.store.ReaderAt(ctx, desc)
 	if err != nil {
 		return emptyDesc, errors.Wrap(err, "failed to get reader from content store")
 	}

--- a/images/image.go
+++ b/images/image.go
@@ -143,7 +143,7 @@ func Manifest(ctx context.Context, provider content.Provider, image ocispec.Desc
 	if err := Walk(ctx, HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 		switch desc.MediaType {
 		case MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest:
-			p, err := content.ReadBlob(ctx, provider, desc.Digest)
+			p, err := content.ReadBlob(ctx, provider, desc)
 			if err != nil {
 				return nil, err
 			}
@@ -159,7 +159,7 @@ func Manifest(ctx context.Context, provider content.Provider, image ocispec.Desc
 				}
 
 				if desc.Platform == nil {
-					p, err := content.ReadBlob(ctx, provider, manifest.Config.Digest)
+					p, err := content.ReadBlob(ctx, provider, manifest.Config)
 					if err != nil {
 						return nil, err
 					}
@@ -180,7 +180,7 @@ func Manifest(ctx context.Context, provider content.Provider, image ocispec.Desc
 
 			return nil, nil
 		case MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
-			p, err := content.ReadBlob(ctx, provider, desc.Digest)
+			p, err := content.ReadBlob(ctx, provider, desc)
 			if err != nil {
 				return nil, err
 			}
@@ -240,7 +240,7 @@ func Platforms(ctx context.Context, provider content.Provider, image ocispec.Des
 
 		switch desc.MediaType {
 		case MediaTypeDockerSchema2Config, ocispec.MediaTypeImageConfig:
-			p, err := content.ReadBlob(ctx, provider, desc.Digest)
+			p, err := content.ReadBlob(ctx, provider, desc)
 			if err != nil {
 				return nil, err
 			}
@@ -283,7 +283,7 @@ func Check(ctx context.Context, provider content.Provider, image ocispec.Descrip
 	required = append([]ocispec.Descriptor{mfst.Config}, mfst.Layers...)
 
 	for _, desc := range required {
-		ra, err := provider.ReaderAt(ctx, desc.Digest)
+		ra, err := provider.ReaderAt(ctx, desc)
 		if err != nil {
 			if errdefs.IsNotFound(err) {
 				missing = append(missing, desc)
@@ -305,7 +305,7 @@ func Children(ctx context.Context, provider content.Provider, desc ocispec.Descr
 	var descs []ocispec.Descriptor
 	switch desc.MediaType {
 	case MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest:
-		p, err := content.ReadBlob(ctx, provider, desc.Digest)
+		p, err := content.ReadBlob(ctx, provider, desc)
 		if err != nil {
 			return nil, err
 		}
@@ -320,7 +320,7 @@ func Children(ctx context.Context, provider content.Provider, desc ocispec.Descr
 		descs = append(descs, manifest.Config)
 		descs = append(descs, manifest.Layers...)
 	case MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
-		p, err := content.ReadBlob(ctx, provider, desc.Digest)
+		p, err := content.ReadBlob(ctx, provider, desc)
 		if err != nil {
 			return nil, err
 		}
@@ -351,7 +351,7 @@ func Children(ctx context.Context, provider content.Provider, desc ocispec.Descr
 // These are used to verify that a set of layers unpacked to the expected
 // values.
 func RootFS(ctx context.Context, provider content.Provider, configDesc ocispec.Descriptor) ([]digest.Digest, error) {
-	p, err := content.ReadBlob(ctx, provider, configDesc.Digest)
+	p, err := content.ReadBlob(ctx, provider, configDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/images/oci/exporter.go
+++ b/images/oci/exporter.go
@@ -93,7 +93,7 @@ func blobRecord(cs content.Provider, desc ocispec.Descriptor) tarRecord {
 			Typeflag: tar.TypeReg,
 		},
 		CopyTo: func(ctx context.Context, w io.Writer) (int64, error) {
-			r, err := cs.ReaderAt(ctx, desc.Digest)
+			r, err := cs.ReaderAt(ctx, desc)
 			if err != nil {
 				return 0, err
 			}

--- a/images/oci/importer.go
+++ b/images/oci/importer.go
@@ -140,7 +140,7 @@ func onUntarBlob(ctx context.Context, r io.Reader, store content.Ingester, name 
 		return errors.Errorf("unsupported algorithm: %s", algo)
 	}
 	dgst := digest.NewDigestFromHex(algo.String(), split[2])
-	return content.WriteBlob(ctx, store, "unknown-"+dgst.String(), r, size, dgst)
+	return content.WriteBlob(ctx, store, "unknown-"+dgst.String(), r, ocispec.Descriptor{Size: size, Digest: dgst})
 }
 
 // GetChildrenDescriptors returns children blob descriptors for the following supported types:
@@ -175,7 +175,7 @@ func setGCRefContentLabels(ctx context.Context, store content.Store, desc ocispe
 		}
 		return err
 	}
-	ra, err := store.ReaderAt(ctx, desc.Digest)
+	ra, err := store.ReaderAt(ctx, desc)
 	if err != nil {
 		return err
 	}

--- a/metadata/content_test.go
+++ b/metadata/content_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/namespaces"
 	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -81,7 +82,8 @@ func TestContentLeased(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := content.WriteBlob(lctx, cs, "test-1", bytes.NewReader(blob), int64(len(blob)), expected); err != nil {
+	if err := content.WriteBlob(lctx, cs, "test-1", bytes.NewReader(blob),
+		ocispec.Descriptor{Size: int64(len(blob)), Digest: expected}); err != nil {
 		t.Fatal(err)
 	}
 	if err := checkContentLeased(lctx, db, expected); err != nil {
@@ -93,7 +95,9 @@ func TestContentLeased(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := cs.Writer(lctx, "test-2", int64(len(blob)), expected); err == nil {
+	if _, err := cs.Writer(lctx,
+		content.WithRef("test-2"),
+		content.WithDescriptor(ocispec.Descriptor{Size: int64(len(blob)), Digest: expected})); err == nil {
 		t.Fatal("expected already exist error")
 	} else if !errdefs.IsAlreadyExists(err) {
 		t.Fatal(err)

--- a/metadata/db_test.go
+++ b/metadata/db_test.go
@@ -506,7 +506,9 @@ func create(obj object, tx *bolt.Tx, is images.Store, cs content.Store, sn snaps
 	case testContent:
 		ctx := WithTransactionContext(ctx, tx)
 		expected := digest.FromBytes(v.data)
-		w, err := cs.Writer(ctx, "test-ref", int64(len(v.data)), expected)
+		w, err := cs.Writer(ctx,
+			content.WithRef("test-ref"),
+			content.WithDescriptor(ocispec.Descriptor{Size: int64(len(v.data)), Digest: expected}))
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create writer")
 		}

--- a/oci/spec_opts_unix.go
+++ b/oci/spec_opts_unix.go
@@ -117,7 +117,7 @@ func WithImageConfig(image Image) SpecOpts {
 		)
 		switch ic.MediaType {
 		case v1.MediaTypeImageConfig, images.MediaTypeDockerSchema2Config:
-			p, err := content.ReadBlob(ctx, image.ContentStore(), ic.Digest)
+			p, err := content.ReadBlob(ctx, image.ContentStore(), ic)
 			if err != nil {
 				return err
 			}

--- a/oci/spec_opts_windows.go
+++ b/oci/spec_opts_windows.go
@@ -44,7 +44,7 @@ func WithImageConfig(image Image) SpecOpts {
 		)
 		switch ic.MediaType {
 		case v1.MediaTypeImageConfig, images.MediaTypeDockerSchema2Config:
-			p, err := content.ReadBlob(ctx, image.ContentStore(), ic.Digest)
+			p, err := content.ReadBlob(ctx, image.ContentStore(), ic)
 			if err != nil {
 				return err
 			}

--- a/remotes/docker/schema1/converter.go
+++ b/remotes/docker/schema1/converter.go
@@ -211,12 +211,12 @@ func (c *Converter) Convert(ctx context.Context, opts ...ConvertOpt) (ocispec.De
 	}
 
 	ref := remotes.MakeRefKey(ctx, desc)
-	if err := content.WriteBlob(ctx, c.contentStore, ref, bytes.NewReader(mb), desc.Size, desc.Digest, content.WithLabels(labels)); err != nil {
+	if err := content.WriteBlob(ctx, c.contentStore, ref, bytes.NewReader(mb), desc, content.WithLabels(labels)); err != nil {
 		return ocispec.Descriptor{}, errors.Wrap(err, "failed to write config")
 	}
 
 	ref = remotes.MakeRefKey(ctx, config)
-	if err := content.WriteBlob(ctx, c.contentStore, ref, bytes.NewReader(b), config.Size, config.Digest); err != nil {
+	if err := content.WriteBlob(ctx, c.contentStore, ref, bytes.NewReader(b), config); err != nil {
 		return ocispec.Descriptor{}, errors.Wrap(err, "failed to write config")
 	}
 
@@ -265,7 +265,7 @@ func (c *Converter) fetchBlob(ctx context.Context, desc ocispec.Descriptor) erro
 		size = 0
 	}
 
-	cw, err := content.OpenWriter(ctx, c.contentStore, ref, size, desc.Digest)
+	cw, err := content.OpenWriter(ctx, c.contentStore, content.WithRef(ref), content.WithDescriptor(desc))
 	if err != nil {
 		if !errdefs.IsAlreadyExists(err) {
 			return err
@@ -274,7 +274,7 @@ func (c *Converter) fetchBlob(ctx context.Context, desc ocispec.Descriptor) erro
 		// TODO: Check if blob -> diff id mapping already exists
 		// TODO: Check if blob empty label exists
 
-		ra, err := c.contentStore.ReaderAt(ctx, desc.Digest)
+		ra, err := c.contentStore.ReaderAt(ctx, desc)
 		if err != nil {
 			return err
 		}

--- a/remotes/handlers.go
+++ b/remotes/handlers.go
@@ -81,7 +81,7 @@ func FetchHandler(ingester content.Ingester, fetcher Fetcher) images.HandlerFunc
 func fetch(ctx context.Context, ingester content.Ingester, fetcher Fetcher, desc ocispec.Descriptor) error {
 	log.G(ctx).Debug("fetch")
 
-	cw, err := content.OpenWriter(ctx, ingester, MakeRefKey(ctx, desc), desc.Size, desc.Digest)
+	cw, err := content.OpenWriter(ctx, ingester, content.WithRef(MakeRefKey(ctx, desc)), content.WithDescriptor(desc))
 	if err != nil {
 		if errdefs.IsAlreadyExists(err) {
 			return nil
@@ -141,7 +141,7 @@ func push(ctx context.Context, provider content.Provider, pusher Pusher, desc oc
 	}
 	defer cw.Close()
 
-	ra, err := provider.ReaderAt(ctx, desc.Digest)
+	ra, err := provider.ReaderAt(ctx, desc)
 	if err != nil {
 		return err
 	}

--- a/services/content/service.go
+++ b/services/content/service.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containerd/containerd/services"
 	ptypes "github.com/gogo/protobuf/types"
 	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -179,7 +180,7 @@ func (s *service) Read(req *api.ReadContentRequest, session api.Content_ReadServ
 		return errdefs.ToGRPC(err)
 	}
 
-	ra, err := s.store.ReaderAt(session.Context(), req.Digest)
+	ra, err := s.store.ReaderAt(session.Context(), ocispec.Descriptor{Digest: req.Digest})
 	if err != nil {
 		return errdefs.ToGRPC(err)
 	}
@@ -334,7 +335,9 @@ func (s *service) Write(session api.Content_WriteServer) (err error) {
 
 	log.G(ctx).Debug("(*service).Write started")
 	// this action locks the writer for the session.
-	wr, err := s.store.Writer(ctx, ref, total, expected)
+	wr, err := s.store.Writer(ctx,
+		content.WithRef(ref),
+		content.WithDescriptor(ocispec.Descriptor{Size: total, Digest: expected}))
 	if err != nil {
 		return errdefs.ToGRPC(err)
 	}

--- a/services/tasks/local.go
+++ b/services/tasks/local.go
@@ -45,6 +45,7 @@ import (
 	"github.com/containerd/containerd/services"
 	"github.com/containerd/typeurl"
 	ptypes "github.com/gogo/protobuf/types"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -121,7 +122,11 @@ func (l *local) Create(ctx context.Context, r *api.CreateTaskRequest, _ ...grpc.
 		if r.Checkpoint.MediaType != images.MediaTypeContainerd1Checkpoint {
 			return nil, fmt.Errorf("unsupported checkpoint type %q", r.Checkpoint.MediaType)
 		}
-		reader, err := l.store.ReaderAt(ctx, r.Checkpoint.Digest)
+		reader, err := l.store.ReaderAt(ctx, ocispec.Descriptor{
+			MediaType: r.Checkpoint.MediaType,
+			Digest:    r.Checkpoint.Digest,
+			Size:      r.Checkpoint.Size_,
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -573,7 +578,7 @@ func getTasksMetrics(ctx context.Context, filter filters.Filter, tasks []runtime
 }
 
 func (l *local) writeContent(ctx context.Context, mediaType, ref string, r io.Reader) (*types.Descriptor, error) {
-	writer, err := l.store.Writer(ctx, ref, 0, "")
+	writer, err := l.store.Writer(ctx, content.WithRef(ref), content.WithDescriptor(ocispec.Descriptor{MediaType: mediaType}))
 	if err != nil {
 		return nil, err
 	}

--- a/task.go
+++ b/task.go
@@ -597,7 +597,7 @@ func (t *task) writeIndex(ctx context.Context, index *v1.Index) (d v1.Descriptor
 }
 
 func writeContent(ctx context.Context, store content.Ingester, mediaType, ref string, r io.Reader, opts ...content.Opt) (d v1.Descriptor, err error) {
-	writer, err := store.Writer(ctx, ref, 0, "")
+	writer, err := store.Writer(ctx, content.WithRef(ref))
 	if err != nil {
 		return d, err
 	}

--- a/vendor.conf
+++ b/vendor.conf
@@ -43,8 +43,8 @@ github.com/syndtr/gocapability db04d3cc01c8b54962a58ec7e491717d06cfcc16
 github.com/gotestyourself/gotestyourself 44dbf532bbf5767611f6f2a61bded572e337010a
 github.com/google/go-cmp v0.1.0
 
-# cri dependencies
-github.com/containerd/cri b68fb075d49aa1c2885f45f2467142666c244f4a
+# #2135: cri is temporarily forked because of circular dependency. will be fixed immediately in a follow-up PR.
+github.com/containerd/cri 6e975823be192ad19f2ce7afcf6c57b88a991c30 https://github.com/AkihiroSuda/cri-containerd.git
 github.com/containerd/go-cni f2d7272f12d045b16ed924f50e91f9f9cecc55a7
 github.com/blang/semver v3.1.0
 github.com/containernetworking/cni v0.6.0

--- a/vendor/github.com/containerd/cri/pkg/server/helpers.go
+++ b/vendor/github.com/containerd/cri/pkg/server/helpers.go
@@ -345,7 +345,7 @@ func getImageInfo(ctx context.Context, image containerd.Image) (*imageInfo, erro
 	}
 	id := desc.Digest.String()
 
-	rb, err := content.ReadBlob(ctx, image.ContentStore(), desc.Digest)
+	rb, err := content.ReadBlob(ctx, image.ContentStore(), desc)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read image config from content store")
 	}

--- a/vendor/github.com/containerd/cri/vendor.conf
+++ b/vendor/github.com/containerd/cri/vendor.conf
@@ -4,7 +4,7 @@ github.com/boltdb/bolt e9cf4fae01b5a8ff89d0ec6b32f0d9c9f79aefdd
 github.com/BurntSushi/toml a368813c5e648fee92e5f6c30e3944ff9d5e8895
 github.com/containerd/cgroups fe281dd265766145e943a034aa41086474ea6130
 github.com/containerd/console cb7008ab3d8359b78c5f464cb7cf160107ad5925
-github.com/containerd/containerd 1e8b09cfc6825f7e6349884b5f76e86c1f04a5d4
+github.com/containerd/containerd 1f8c612a6c7ef2fc8328c953fb660adce2bf0a80 https://github.com/AkihiroSuda/containerd.git
 github.com/containerd/continuity 2d3749b4da569ac97ca63dccba5eee4f5ee2beab
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c
 github.com/containerd/go-cni f2d7272f12d045b16ed924f50e91f9f9cecc55a7


### PR DESCRIPTION
This change allows implementations to resolve the location of the actual
data using OCI descriptor fields such as MediaType.

No OCI descriptor field is written to the store.

No change on gRPC API.

~contrib/registrycontentstore is added as an example usecase of this.~ (EDIT: will be a separate PR)

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

- - -

Close https://github.com/containerd/containerd/issues/2129

@tonistiigi @dmcgowan 