### PR TITLE
[contrib] bump golang

### DIFF
--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -7,19 +7,19 @@
 #
 
 # Install proto3
-FROM golang:1.9.3 AS proto3
+FROM golang:1.9 AS proto3
 RUN apt-get update && apt-get install -y autoconf automake g++ libtool unzip
 COPY script/setup/install-protobuf install-protobuf
 RUN ./install-protobuf
 
 # Install runc
-FROM golang:1.9.3 AS runc
+FROM golang:1.9 AS runc
 RUN apt-get update && apt-get install -y curl libapparmor-dev libseccomp-dev
 COPY vendor.conf /go/src/github.com/containerd/containerd/vendor.conf
 COPY script/setup/install-runc install-runc
 RUN ./install-runc
 
-FROM golang:1.9.3
+FROM golang:1.9
 RUN apt-get update && apt-get install -y btrfs-tools gcc git libapparmor-dev libseccomp-dev make xfsprogs
 
 COPY --from=proto3 /usr/local/bin/protoc /usr/local/bin/protoc


### PR DESCRIPTION
Use golang:latest instead of a specific version.

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>