### PR TITLE
Add --with-ns flag to ctr run/create

### DIFF
--- a/cmd/ctr/commands/run/run.go
+++ b/cmd/ctr/commands/run/run.go
@@ -65,6 +65,10 @@ var ContainerFlags = []cli.Flag{
 		Name:  "tty,t",
 		Usage: "allocate a TTY for the container",
 	},
+	cli.StringSliceFlag{
+		Name:  "with-ns",
+		Usage: "specify existing Linux namespaces to join at container runtime (format '<nstype>:<path>')",
+	},
 }
 
 func loadSpec(path string, s *specs.Spec) error {


### PR DESCRIPTION
Adds a useful flag to `ctr` to enable joining any existing Linux
namespaces for any namespace types (network, pid, ipc, etc.) using the
existing With helper in the oci package.

This is useful for simple use cases, for example: network namespaces are created outside containerd and the user wants to test this out without having to manage/assemble an entire `config.json` with the unique namespace path set.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>