### PR TITLE
Update continuity vendor to d8fb85

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -28,7 +28,7 @@ github.com/pkg/errors v0.8.0
 github.com/opencontainers/go-digest 21dfd564fd89c944783d00d069f33e3e7123c448
 golang.org/x/sys 314a259e304ff91bd6985da2a7149bbf91237993 https://github.com/golang/sys
 github.com/opencontainers/image-spec v1.0.1
-github.com/containerd/continuity 992a5f112bd2211d0983a1cc8562d2882848f3a3
+github.com/containerd/continuity d8fb8589b0e8e85b8c8bbaa8840226d0dfeb7371
 golang.org/x/sync 450f422ab23cf9881c94e2db30cac0eb1b7cf80c
 github.com/BurntSushi/toml a368813c5e648fee92e5f6c30e3944ff9d5e8895
 github.com/grpc-ecosystem/go-grpc-prometheus 6b7015e65d366bf3f19b2b2a000a831940f0f7e0

--- a/vendor/github.com/containerd/continuity/fs/stat_linux.go
+++ b/vendor/github.com/containerd/continuity/fs/stat_linux.go
@@ -22,5 +22,6 @@ func StatMtime(st *syscall.Stat_t) syscall.Timespec {
 
 // StatATimeAsTime returns st.Atim as a time.Time
 func StatATimeAsTime(st *syscall.Stat_t) time.Time {
-	return time.Unix(st.Atim.Sec, st.Atim.Nsec)
+	// The int64 conversions ensure the line compiles for 32-bit systems as well.
+	return time.Unix(int64(st.Atim.Sec), int64(st.Atim.Nsec)) // nolint: unconvert
 }

--- a/vendor/github.com/containerd/continuity/sysx/xattr_openbsd.go
+++ b/vendor/github.com/containerd/continuity/sysx/xattr_openbsd.go
@@ -1,0 +1,7 @@
+package sysx
+
+import (
+	"errors"
+)
+
+var unsupported = errors.New("extended attributes unsupported on OpenBSD")

--- a/vendor/github.com/containerd/continuity/sysx/xattr_unsupported.go
+++ b/vendor/github.com/containerd/continuity/sysx/xattr_unsupported.go
@@ -1,4 +1,4 @@
-// +build freebsd solaris
+// +build freebsd openbsd solaris
 
 package sysx
 


### PR DESCRIPTION
Needed for building `containerd` on 32bit systems

Includes the following PR's:
* https://github.com/containerd/continuity/pull/107
* https://github.com/containerd/continuity/pull/105
* https://github.com/containerd/continuity/pull/104

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>