### PR TITLE
RFC: better gocmp.Option for comparing time.Time

### DIFF
--- a/snapshots/storage/metastore_test.go
+++ b/snapshots/storage/metastore_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
+	"github.com/gotestyourself/gotestyourself/assert/opt"
 	"github.com/pkg/errors"
 )
 
@@ -161,42 +162,59 @@ func basePopulate(ctx context.Context, ms *MetaStore) error {
 	return nil
 }
 
-var baseInfo = map[string]snapshots.Info{
-	"committed-1": {
-		Name:   "committed-1",
-		Parent: "",
-		Kind:   snapshots.KindCommitted,
-	},
-	"committed-2": {
-		Name:   "committed-2",
-		Parent: "committed-1",
-		Kind:   snapshots.KindCommitted,
-	},
-	"active-1": {
-		Name:   "active-1",
-		Parent: "",
-		Kind:   snapshots.KindActive,
-	},
-	"active-2": {
-		Name:   "active-2",
-		Parent: "committed-1",
-		Kind:   snapshots.KindActive,
-	},
-	"active-3": {
-		Name:   "active-3",
-		Parent: "committed-2",
-		Kind:   snapshots.KindActive,
-	},
-	"view-1": {
-		Name:   "view-1",
-		Parent: "",
-		Kind:   snapshots.KindView,
-	},
-	"view-2": {
-		Name:   "view-2",
-		Parent: "committed-2",
-		Kind:   snapshots.KindView,
-	},
+func baseInfo() map[string]snapshots.Info {
+	now := time.Now()
+	return map[string]snapshots.Info{
+		"committed-1": {
+			Name:    "committed-1",
+			Parent:  "",
+			Kind:    snapshots.KindCommitted,
+			Created: now,
+			Updated: now,
+		},
+		"committed-2": {
+			Name:    "committed-2",
+			Parent:  "committed-1",
+			Kind:    snapshots.KindCommitted,
+			Created: now,
+			Updated: now,
+		},
+		"active-1": {
+			Name:    "active-1",
+			Parent:  "",
+			Kind:    snapshots.KindActive,
+			Created: now,
+			Updated: now,
+		},
+		"active-2": {
+			Name:    "active-2",
+			Parent:  "committed-1",
+			Kind:    snapshots.KindActive,
+			Created: now,
+			Updated: now,
+		},
+		"active-3": {
+			Name:    "active-3",
+			Parent:  "committed-2",
+			Kind:    snapshots.KindActive,
+			Created: now,
+			Updated: now,
+		},
+		"view-1": {
+			Name:    "view-1",
+			Parent:  "",
+			Kind:    snapshots.KindView,
+			Created: now,
+			Updated: now,
+		},
+		"view-2": {
+			Name:    "view-2",
+			Parent:  "committed-2",
+			Kind:    snapshots.KindView,
+			Created: now,
+			Updated: now,
+		},
+	}
 }
 
 func assertNotExist(t *testing.T, err error) {
@@ -220,7 +238,7 @@ func assertExist(t *testing.T, err error) {
 }
 
 func testGetInfo(ctx context.Context, t *testing.T, _ *MetaStore) {
-	for key, expected := range baseInfo {
+	for key, expected := range baseInfo() {
 		_, info, _, err := GetInfo(ctx, key)
 		assert.NilError(t, err, "on key %v", key)
 		assert.Check(t, is.DeepEqual(expected, info, cmpSnapshotInfo), "on key %v", key)
@@ -229,25 +247,10 @@ func testGetInfo(ctx context.Context, t *testing.T, _ *MetaStore) {
 
 // compare snapshot.Info Updated and Created fields by checking they are
 // within a threshold of time.Now()
-var cmpSnapshotInfo = cmp.FilterPath(
-	func(path cmp.Path) bool {
-		field := path.Last().String()
-		return field == ".Created" || field == ".Updated"
-	},
-	cmp.Comparer(func(expected, actual time.Time) bool {
-		// cmp.Options must be symmetric, so swap the args
-		if actual.IsZero() {
-			actual, expected = expected, actual
-		}
-		if !expected.IsZero() {
-			return false
-		}
-		// actual value should be within a few seconds of now
-		now := time.Now()
-		delta := now.Sub(actual)
-		threshold := 10 * time.Second
-		return delta > -threshold && delta < threshold
-	}))
+var cmpSnapshotInfo = opt.Opts(
+	cmp.FilterPath(opt.PathString("Created"), opt.CmpTime(time.Second)),
+	cmp.FilterPath(opt.PathString("Updated"), opt.CmpTime(time.Second)),
+)
 
 func testGetInfoNotExist(ctx context.Context, t *testing.T, _ *MetaStore) {
 	_, _, _, err := GetInfo(ctx, "active-not-exist")
@@ -264,7 +267,7 @@ func testWalk(ctx context.Context, t *testing.T, _ *MetaStore) {
 		return nil
 	})
 	assert.NilError(t, err)
-	assert.Assert(t, is.DeepEqual(baseInfo, found, cmpSnapshotInfo))
+	assert.Assert(t, is.DeepEqual(baseInfo(), found, cmpSnapshotInfo))
 }
 
 func testGetSnapshot(ctx context.Context, t *testing.T, ms *MetaStore) {

--- a/vendor.conf
+++ b/vendor.conf
@@ -40,5 +40,5 @@ golang.org/x/text 19e51611da83d6be54ddafce4a4af510cb3e9ea4
 github.com/dmcgowan/go-tar go1.10
 github.com/stevvooe/ttrpc d4528379866b0ce7e9d71f3eb96f0582fc374577
 github.com/syndtr/gocapability db04d3cc01c8b54962a58ec7e491717d06cfcc16
-github.com/gotestyourself/gotestyourself 44dbf532bbf5767611f6f2a61bded572e337010a
+github.com/gotestyourself/gotestyourself 30d3101cee3cd17e03d1c962e70deca14bc827a5 https://github.com/dnephin/gotestyourself.git
 github.com/google/go-cmp v0.1.0

--- a/vendor/github.com/gotestyourself/gotestyourself/assert/assert.go
+++ b/vendor/github.com/gotestyourself/gotestyourself/assert/assert.go
@@ -37,10 +37,10 @@ The example below shows assert used with some common types.
 	    assert.Assert(t, os.IsNotExist(err), "got %+v", err)
 
 	    // complex types
+	    assert.DeepEqual(t, result, myStruct{Name: "title"})
 	    assert.Assert(t, is.Len(items, 3))
 	    assert.Assert(t, len(sequence) != 0) // NotEmpty
 	    assert.Assert(t, is.Contains(mapping, "key"))
-	    assert.Assert(t, is.DeepEqual(result, myStruct{Name: "title"}))
 
 	    // pointers and interface
 	    assert.Assert(t, is.Nil(ref))
@@ -71,6 +71,7 @@ import (
 	"go/ast"
 	"go/token"
 
+	gocmp "github.com/google/go-cmp/cmp"
 	"github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/gotestyourself/gotestyourself/internal/format"
 	"github.com/gotestyourself/gotestyourself/internal/source"
@@ -246,4 +247,14 @@ func Equal(t TestingT, x, y interface{}, msgAndArgs ...interface{}) {
 		ht.Helper()
 	}
 	assert(t, t.FailNow, filterExprExcludeFirst, cmp.Equal(x, y), msgAndArgs...)
+}
+
+// DeepEqual uses https://github.com/google/go-cmp/cmp to assert two values
+// are equal and fails the test if they are not equal.
+// This is equivalent to Assert(t, cmp.DeepEqual(x, y)).
+func DeepEqual(t TestingT, x, y interface{}, opts ...gocmp.Option) {
+	if ht, ok := t.(helperT); ok {
+		ht.Helper()
+	}
+	assert(t, t.FailNow, filterExprExcludeFirst, cmp.DeepEqual(x, y, opts...))
 }

--- a/vendor/github.com/gotestyourself/gotestyourself/assert/opt/opt.go
+++ b/vendor/github.com/gotestyourself/gotestyourself/assert/opt/opt.go
@@ -1,0 +1,68 @@
+package opt
+
+import (
+	"fmt"
+	"time"
+
+	gocmp "github.com/google/go-cmp/cmp"
+)
+
+// PathString is a gocmp.FilterPath filter that returns true when path.String()
+// matches the string.
+//
+// The path string is a `.` separated string where each segment is a field name.
+// Slices, Arrays, and Maps are always matched against every element in the
+// sequence.
+func PathString(pathspec string) func(gocmp.Path) bool {
+	return func(path gocmp.Path) bool {
+		return path.String() == pathspec
+	}
+}
+
+// nolint: unused,deadcode
+func debug(path gocmp.Path) bool {
+	fmt.Printf("\nPATH=%s, GoString=%s\n", path, path.GoString())
+	for _, step := range path {
+		fmt.Printf("STEP=(%T) %s\n", step, step)
+	}
+	return false
+}
+
+// CmpDuration returns a gocmp.Comparer for comparing time.Duration. The
+// comparer returns true if the two time.Duration values are within the threshold
+// and neither are zero.
+func CmpDuration(threshold time.Duration) gocmp.Option {
+	return gocmp.Comparer(cmpDuration(threshold))
+}
+
+func cmpDuration(threshold time.Duration) func(x, y time.Duration) bool {
+	return func(x, y time.Duration) bool {
+		if x == 0 || y == 0 {
+			return false
+		}
+		delta := x - y
+		return delta <= threshold && delta >= -threshold
+	}
+}
+
+// Opts is a convenience wrapper for creating a gocmp.Options.
+func Opts(opt ...gocmp.Option) gocmp.Options {
+	return gocmp.Options(opt)
+}
+
+// CmpTime returns a gocmp.Comparer for comparing time.Time. The
+// comparer returns true if the two time.Time values are within the threshold
+// and neither are zero.
+func CmpTime(threshold time.Duration) gocmp.Option {
+	return gocmp.Comparer(cmpTime(threshold))
+}
+
+func cmpTime(threshold time.Duration) func(x, y time.Time) bool {
+	return func(x, y time.Time) bool {
+		if x.IsZero() || y.IsZero() {
+			return false
+		}
+		delta := x.Sub(y)
+		return delta <= threshold && delta >= -threshold
+	}
+}


### PR DESCRIPTION
This is an attempt to address the second concern from https://github.com/containerd/containerd/pull/2024#issuecomment-365114440

This uses a WIP PR https://github.com/gotestyourself/gotestyourself/pull/62.

This PR makes 2 changes:
1. Return the expected `Info` from a function and set the time values to `Now`. This makes it easier to compare because we don't have to swap values to make the comparer function symmetric and can assert that neither are zero.
2. Use `assert/opt` to provide functions for common `gocmp.Option`. Duration and Time seem likely to be the most common cases. It also provides a more convenient way of creating the path filter for `gocmp.FilterPath`

cc @stevvooe 