### PR TITLE
Fix panics in cio/io_unix.go

### DIFF
--- a/cio/io_unix.go
+++ b/cio/io_unix.go
@@ -98,17 +98,24 @@ func openFifos(ctx context.Context, fifos *FIFOSet) (pipes, error) {
 		if f.Stdin, err = fifo.OpenFifo(ctx, fifos.Stdin, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
 			return f, errors.Wrapf(err, "failed to open stdin fifo")
 		}
+		defer func() {
+			if err != nil && f.Stdin != nil {
+				f.Stdin.Close()
+			}
+		}()
 	}
 	if fifos.Stdout != "" {
 		if f.Stdout, err = fifo.OpenFifo(ctx, fifos.Stdout, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
-			f.Stdin.Close()
 			return f, errors.Wrapf(err, "failed to open stdout fifo")
 		}
+		defer func() {
+			if err != nil && f.Stdout != nil {
+				f.Stdout.Close()
+			}
+		}()
 	}
 	if fifos.Stderr != "" {
 		if f.Stderr, err = fifo.OpenFifo(ctx, fifos.Stderr, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
-			f.Stdin.Close()
-			f.Stdout.Close()
 			return f, errors.Wrapf(err, "failed to open stderr fifo")
 		}
 	}

--- a/cio/io_unix_test.go
+++ b/cio/io_unix_test.go
@@ -1,0 +1,41 @@
+// +build !windows
+
+package cio
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/gotestyourself/gotestyourself/assert"
+)
+
+func TestOpenFifos(t *testing.T) {
+	scenarios := []*FIFOSet{
+		{
+			Config: Config{
+				Stdin:  "",
+				Stdout: filepath.Join("This/does/not/exist", "test-stdout"),
+				Stderr: filepath.Join("This/does/not/exist", "test-stderr"),
+			},
+		},
+		{
+			Config: Config{
+				Stdin:  filepath.Join("This/does/not/exist", "test-stdin"),
+				Stdout: "",
+				Stderr: filepath.Join("This/does/not/exist", "test-stderr"),
+			},
+		},
+		{
+			Config: Config{
+				Stdin:  "",
+				Stdout: "",
+				Stderr: filepath.Join("This/does/not/exist", "test-stderr"),
+			},
+		},
+	}
+	for _, scenario := range scenarios {
+		_, err := openFifos(context.Background(), scenario)
+		assert.Assert(t, err != nil, scenario)
+	}
+}


### PR DESCRIPTION
Add nil checks before closing fifos to avoid panic when fifo was never
opened.

Signed-off-by: Cody Roseborough <crrosebo@amazon.com>