### PR TITLE
Update Parse to return a Platform spec

### DIFF
--- a/images/handlers.go
+++ b/images/handlers.go
@@ -193,10 +193,11 @@ func FilterPlatform(platform string, f HandlerFunc) HandlerFunc {
 
 		var descs []ocispec.Descriptor
 		if platform != "" && isMultiPlatform(desc.MediaType) {
-			matcher, err := platforms.Parse(platform)
+			p, err := platforms.Parse(platform)
 			if err != nil {
 				return nil, err
 			}
+			matcher := platforms.NewMatcher(p)
 
 			for _, d := range children {
 				if d.Platform == nil || matcher.Match(*d.Platform) {

--- a/images/image.go
+++ b/images/image.go
@@ -131,13 +131,13 @@ func Manifest(ctx context.Context, provider content.Provider, image ocispec.Desc
 	var (
 		matcher platforms.Matcher
 		m       *ocispec.Manifest
-		err     error
 	)
 	if platform != "" {
-		matcher, err = platforms.Parse(platform)
+		p, err := platforms.Parse(platform)
 		if err != nil {
 			return ocispec.Manifest{}, err
 		}
+		matcher = platforms.NewMatcher(p)
 	}
 
 	if err := Walk(ctx, HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {

--- a/platforms/platforms_test.go
+++ b/platforms/platforms_test.go
@@ -191,14 +191,16 @@ func TestParseSelector(t *testing.T) {
 			if testcase.skip {
 				t.Skip("this case is not yet supported")
 			}
-			m, err := Parse(testcase.input)
+			p, err := Parse(testcase.input)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if !reflect.DeepEqual(m.Spec(), testcase.expected) {
-				t.Fatalf("platform did not match expected: %#v != %#v", m.Spec(), testcase.expected)
+			if !reflect.DeepEqual(p, testcase.expected) {
+				t.Fatalf("platform did not match expected: %#v != %#v", p, testcase.expected)
 			}
+
+			m := NewMatcher(p)
 
 			// ensure that match works on the input to the output.
 			if ok := m.Match(testcase.expected); !ok {
@@ -209,7 +211,7 @@ func TestParseSelector(t *testing.T) {
 				t.Fatalf("unexpected matcher string:  %q != %q", fmt.Sprint(m), testcase.formatted)
 			}
 
-			formatted := Format(m.Spec())
+			formatted := Format(p)
 			if formatted != testcase.formatted {
 				t.Fatalf("unexpected format: %q != %q", formatted, testcase.formatted)
 			}
@@ -220,8 +222,8 @@ func TestParseSelector(t *testing.T) {
 				t.Fatalf("error parsing formatted output: %v", err)
 			}
 
-			if Format(reparsed.Spec()) != formatted {
-				t.Fatalf("normalized output did not survive the round trip: %v != %v", Format(reparsed.Spec()), formatted)
+			if Format(reparsed) != formatted {
+				t.Fatalf("normalized output did not survive the round trip: %v != %v", Format(reparsed), formatted)
 			}
 		})
 	}


### PR DESCRIPTION
This PR is the first step in a solution for #2029, handling multi-arch images.

Here the `Parse` function now returns a Platform spec, which allows us to decouple the matcher.

Signed-off-by: Jess Valarezo <valarezo.jessica@gmail.com>