### PR TITLE
Update recommended versions to Go 1.10

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -14,7 +14,7 @@ This doc includes:
 
 To build the `containerd` daemon, and the `ctr` simple test client, the following build system dependencies are required:
 
-* Go 1.9.x or above
+* Go 1.10.x or above
 * Protoc 3.x compiler and headers (download at the [Google protobuf releases page](https://github.com/google/protobuf/releases))
 * Btrfs headers and libraries for your distribution. Note that building the btrfs driver can be disabled via the build tag `no_btrfs`, removing this dependency.
 

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -7,19 +7,19 @@
 #
 
 # Install proto3
-FROM golang:1.9 AS proto3
+FROM golang:1.10 AS proto3
 RUN apt-get update && apt-get install -y autoconf automake g++ libtool unzip
 COPY script/setup/install-protobuf install-protobuf
 RUN ./install-protobuf
 
 # Install runc
-FROM golang:1.9 AS runc
+FROM golang:1.10 AS runc
 RUN apt-get update && apt-get install -y curl libapparmor-dev libseccomp-dev
 COPY vendor.conf /go/src/github.com/containerd/containerd/vendor.conf
 COPY script/setup/install-runc install-runc
 RUN ./install-runc
 
-FROM golang:1.9
+FROM golang:1.10
 RUN apt-get update && apt-get install -y btrfs-tools gcc git libapparmor-dev libseccomp-dev make xfsprogs
 
 COPY --from=proto3 /usr/local/bin/protoc /usr/local/bin/protoc


### PR DESCRIPTION
To match build requirements for containerd now that we are using 1.10.

Fixes: #2167

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>