### PR TITLE
better image config parse error.

### DIFF
--- a/cmd/ctr/commands/run/run.go
+++ b/cmd/ctr/commands/run/run.go
@@ -97,7 +97,7 @@ func loadSpec(path string, s *specs.Spec) error {
 		return errors.New("cannot load spec config file")
 	}
 	if err := json.Unmarshal(raw, s); err != nil {
-		return errors.New("decoding spec config file failed")
+		return errors.Errorf("decoding spec config file failed, current supported OCI runtime-spec : v%s", specs.Version)
 	}
 	return nil
 }


### PR DESCRIPTION
compatible oci runtime version printed along with parse error.
Should fix #925

Signed-off-by: Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>