### PR TITLE
cmd/ctr/images: add `i` alias for images command

### DIFF
--- a/cmd/ctr/commands/images/images.go
+++ b/cmd/ctr/commands/images/images.go
@@ -36,7 +36,7 @@ import (
 // Command is the cli command for managing images
 var Command = cli.Command{
 	Name:    "images",
-	Aliases: []string{"image"},
+	Aliases: []string{"image", "i"},
 	Usage:   "manage images",
 	Subcommands: cli.Commands{
 		checkCommand,


### PR DESCRIPTION
Signed-off-by: Stephen J Day <stephen.day@docker.com>