### PR TITLE
ctr: allow for force kill when deleting task process

### DIFF
--- a/cmd/ctr/commands/tasks/delete.go
+++ b/cmd/ctr/commands/tasks/delete.go
@@ -17,14 +17,21 @@
 package tasks
 
 import (
+	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/urfave/cli"
 )
 
 var deleteCommand = cli.Command{
 	Name:      "delete",
-	Usage:     "delete a task",
+	Usage:     "[flags] delete a task",
 	ArgsUsage: "CONTAINER",
+	Flags: []cli.Flag{
+		cli.BoolFlag{
+			Name:  "force, f",
+			Usage: "force delete task process",
+		},
+	},
 	Action: func(context *cli.Context) error {
 		client, ctx, cancel, err := commands.NewClient(context)
 		if err != nil {
@@ -35,11 +42,16 @@ var deleteCommand = cli.Command{
 		if err != nil {
 			return err
 		}
+
 		task, err := container.Task(ctx, nil)
 		if err != nil {
 			return err
 		}
-		status, err := task.Delete(ctx)
+		var opts []containerd.ProcessDeleteOpts
+		if context.Bool("force") {
+			opts = append(opts, containerd.WithProcessKill)
+		}
+		status, err := task.Delete(ctx, opts...)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
when using `ctr`, it is not possible to delete a `PAUSED` or `RUNNING` task: 

``` ctr t resume test
/go/src/github.com/containerd/containerd # ctr t ls
TASK    PID     STATUS
test    6543    RUNNING
/go/src/github.com/containerd/containerd # ctr t delete test
ctr: task must be stopped before deletion: running: failed precondition
/go/src/github.com/containerd/containerd # ctr t pause test
/go/src/github.com/containerd/containerd # ctr t delete test
ctr: task must be stopped before deletion: paused: failed precondition
/go/src/github.com/containerd/containerd # ctr t ls
TASK    PID     STATUS
test    6543    PAUSED
```

add a `--force` flag which will kill the task process, and successfully delete the task.

Signed-off-by: Jess Valarezo <valarezo.jessica@gmail.com>