### PR TITLE
windows: define platform in runtime plugin init

### DIFF
--- a/windows/runtime.go
+++ b/windows/runtime.go
@@ -33,11 +33,13 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/runtime"
 	"github.com/containerd/containerd/windows/hcsshimtypes"
 	"github.com/containerd/typeurl"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 )
 
@@ -66,6 +68,8 @@ func init() {
 
 // New returns a new Windows runtime
 func New(ic *plugin.InitContext) (interface{}, error) {
+	ic.Meta.Platforms = []imagespec.Platform{platforms.DefaultSpec()}
+
 	if err := os.MkdirAll(ic.Root, 0700); err != nil {
 		return nil, errors.Wrapf(err, "could not create state directory at %s", ic.Root)
 	}
@@ -114,7 +118,7 @@ func (r *windowsRuntime) Create(ctx context.Context, id string, opts runtime.Cre
 	if err != nil {
 		return nil, err
 	}
-	spec := s.(*specs.Spec)
+	spec := s.(*runtimespec.Spec)
 
 	var createOpts *hcsshimtypes.CreateOptions
 	if opts.Options != nil {
@@ -218,7 +222,7 @@ func (r *windowsRuntime) Delete(ctx context.Context, t runtime.Task) (*runtime.E
 	return rtExit, nil
 }
 
-func (r *windowsRuntime) newTask(ctx context.Context, namespace, id string, rootfs []mount.Mount, spec *specs.Spec, io runtime.IO, createOpts *hcsshimtypes.CreateOptions) (*task, error) {
+func (r *windowsRuntime) newTask(ctx context.Context, namespace, id string, rootfs []mount.Mount, spec *runtimespec.Spec, io runtime.IO, createOpts *hcsshimtypes.CreateOptions) (*task, error) {
 	var (
 		err  error
 		pset *pipeSet


### PR DESCRIPTION
before, the windows runtime plugin had no platform defined. updated to add the default platform during initialization. 

before:
```
$ ctr plugins
TYPE                            ID                    PLATFORMS        STATUS
io.containerd.service.v1        snapshots-service     -                ok
io.containerd.runtime.v1        windows               -                ok
```

now:
```
$ ctr plugins
TYPE                            ID                    PLATFORMS        STATUS
io.containerd.service.v1        snapshots-service     -                ok
io.containerd.runtime.v1        windows               windows/amd64    ok
```

Signed-off-by: Jess Valarezo <valarezo.jessica@gmail.com>