### PR TITLE
overlay: fix cleanup directory deletion race

### DIFF
--- a/snapshots/overlay/overlay.go
+++ b/snapshots/overlay/overlay.go
@@ -309,7 +309,9 @@ func (o *snapshotter) Cleanup(ctx context.Context) error {
 }
 
 func (o *snapshotter) cleanupDirectories(ctx context.Context) ([]string, error) {
-	ctx, t, err := o.ms.TransactionContext(ctx, false)
+	// Get a write transaction to ensure no other write transaction can be entered
+	// while the cleanup is scanning.
+	ctx, t, err := o.ms.TransactionContext(ctx, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes a bug where a writable transaction may create or make changes to a directory while the cleanup is running, leading to removal of a directory which will be referenced.

fixes #2210