### PR TITLE
Fixes a default config bug of gc scheduler

### DIFF
--- a/gc/scheduler/scheduler.go
+++ b/gc/scheduler/scheduler.go
@@ -91,6 +91,10 @@ func (d *duration) UnmarshalText(text []byte) error {
 	return nil
 }
 
+func (d duration) MarshalText() (text []byte, err error) {
+	return []byte(time.Duration(d).String()), nil
+}
+
 func init() {
 	plugin.Register(&plugin.Registration{
 		Type: plugin.GCPlugin,


### PR DESCRIPTION
I ran the `containerd` service with the default config, the service failed when loading config file with error log:
```
containerd[10993]: containerd: time: missing unit in duration 100000000
```
That's because `toml.Decode` can not decode `100000000` to `time.Duration` variable.

We should encode `time.Duration` variable to string with unit (e.g.: `100000000`  -> `"100ms"`) when print the the default config with `containerd config default`.

This pr fixes the bug.



Signed-off-by: Yanqiang Miao <miao.yanqiang@zte.com.cn>