### PR TITLE
[WIP] Generate document for config

### DIFF
--- a/cmd/containerd/command/config.go
+++ b/cmd/containerd/command/config.go
@@ -19,11 +19,49 @@ package command
 import (
 	"io"
 	"os"
+	"sort"
+	"text/template"
 
 	"github.com/BurntSushi/toml"
 	"github.com/containerd/containerd/server"
 	"github.com/urfave/cli"
 )
+
+var commentedContainerdConfigTemplate = template.Must(template.New("containerd").Parse(
+	`# Root is the path to a directory where containerd will store persistent data
+root = "{{ .Root }}"
+
+# State is the path to a directory where containerd will store transient data
+state = "{{ .State }}"
+
+# OOMScore adjust the containerd's oom score
+oom_score = {{ .OOMScore }}
+
+# GRPC configuration settings
+[grpc]
+  address = "{{ .GRPC.Address }}"
+  uid = {{ .GRPC.UID }}
+  gid = {{ .GRPC.GID }}
+
+# Debug and profiling settings
+[debug]
+  address = "{{ .Debug.Address }}"
+  uid = {{ .Debug.UID }}
+  gid = {{ .Debug.GID }}
+  level = "{{ .Debug.Level }}"
+
+# Metrics and monitoring settings
+[metrics]
+  address = "{{ .Metrics.Address }}"
+  grpc_histogram = {{ .Metrics.GRPCHistogram }}
+
+# Cgroup specifies cgroup information for the containerd daemon process
+[cgroup]
+  path = "{{ .Cgroup.Path }}"
+
+# Plugins overrides "Plugins map[string]toml.Primitive" in server config.
+[Plugins]
+`))
 
 // Config is a wrapper of server config for printing out.
 type Config struct {
@@ -34,6 +72,7 @@ type Config struct {
 
 // WriteTo marshals the config to the provided writer
 func (c *Config) WriteTo(w io.Writer) (int64, error) {
+
 	return 0, toml.NewEncoder(w).Encode(c)
 }
 
@@ -44,24 +83,50 @@ var configCommand = cli.Command{
 		{
 			Name:  "default",
 			Usage: "see the output of the default config",
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "comment",
+					Usage: "Add comments or not for config items",
+				},
+			},
 			Action: func(context *cli.Context) error {
 				config := &Config{
 					Config: defaultConfig(),
 				}
+
+				if context.Bool("comment") {
+					err := commentedContainerdConfigTemplate.ExecuteTemplate(os.Stdout, "containerd", config)
+					if err != nil {
+						return err
+					}
+				}
+
 				plugins, err := server.LoadPlugins(config.Config)
 				if err != nil {
 					return err
 				}
+				sort.SliceStable(plugins, func(i, j int) bool {
+					return plugins[i].ID < plugins[j].ID
+				})
 				if len(plugins) != 0 {
 					config.Plugins = make(map[string]interface{})
 					for _, p := range plugins {
 						if p.Config == nil {
 							continue
 						}
+						if context.Bool("comment") && p.CommentedConfigTemplate != nil {
+							err := p.CommentedConfigTemplate.ExecuteTemplate(os.Stdout, p.ID, p.Config)
+							if err != nil {
+								return err
+							}
+						}
 						config.Plugins[p.ID] = p.Config
 					}
 				}
-				_, err = config.WriteTo(os.Stdout)
+
+				if !context.Bool("comment") {
+					_, err = config.WriteTo(os.Stdout)
+				}
 				return err
 			},
 		},

--- a/linux/runtime.go
+++ b/linux/runtime.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"text/template"
 	"time"
 
 	"github.com/boltdb/bolt"
@@ -57,6 +58,26 @@ var (
 	empty    = &ptypes.Empty{}
 )
 
+var commentedLinuxConfigTemplate = template.Must(template.New("linux").Parse(`
+# The "plugins.linux" contains options for the runtime
+[plugins.linux]
+
+  # Shim is a path or name of binary implementing the Shim GRPC API
+  shim = "{{ .Shim }}"
+
+  # Runtime is a path or name of an OCI runtime used by the shim
+  runtime = "{{ .Runtime }}"
+
+  # RuntimeRoot is the path that shall be used by the OCI runtime for its data
+  runtime_root = "{{ .RuntimeRoot }}"
+
+  # NoShim calls runc directly from within the pkg
+  no_shim = {{ .NoShim }}
+
+  # Debug enable debug on the shim
+  shim_debug = {{ .ShimDebug }}
+`))
+
 const (
 	configFilename = "config.json"
 	defaultRuntime = "runc"
@@ -76,6 +97,7 @@ func init() {
 			Shim:    defaultShim,
 			Runtime: defaultRuntime,
 		},
+		CommentedConfigTemplate: commentedLinuxConfigTemplate,
 	})
 }
 

--- a/metrics/cgroups/cgroups.go
+++ b/metrics/cgroups/cgroups.go
@@ -19,6 +19,8 @@
 package cgroups
 
 import (
+	"text/template"
+
 	"github.com/containerd/cgroups"
 	eventstypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/events"
@@ -33,6 +35,13 @@ import (
 	"golang.org/x/net/context"
 )
 
+var pluginID = "cgroups"
+var commentedCgroupsConfigTemplate = template.Must(template.New(pluginID).Parse(`
+# The "plugins.cgroups" configures the cgroups monitor.
+[plugins.cgroups]
+  no_prometheus = {{ .NoPrometheus }}
+`))
+
 // Config for the cgroups monitor
 type Config struct {
 	NoPrometheus bool `toml:"no_prometheus"`
@@ -40,10 +49,11 @@ type Config struct {
 
 func init() {
 	plugin.Register(&plugin.Registration{
-		Type:   plugin.TaskMonitorPlugin,
-		ID:     "cgroups",
-		InitFn: New,
-		Config: &Config{},
+		Type:                    plugin.TaskMonitorPlugin,
+		ID:                      pluginID,
+		InitFn:                  New,
+		Config:                  &Config{},
+		CommentedConfigTemplate: commentedCgroupsConfigTemplate,
 	})
 }
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -19,6 +19,7 @@ package plugin
 import (
 	"fmt"
 	"sync"
+	"text/template"
 
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
@@ -84,6 +85,8 @@ type Registration struct {
 	ID string
 	// Config specific to the plugin
 	Config interface{}
+	// CommentedConfigTemplate specific the template of commented toml config
+	CommentedConfigTemplate *template.Template
 	// Requires is a list of plugins that the registered plugin requires to be available
 	Requires []Type
 


### PR DESCRIPTION
This PR make containerd generate the commented config.
Also add a flag `--comment` for `containerd config default` command to control whether the command print commented config or not.

Related to https://github.com/containerd/cri/issues/664

/cc @Random-Liu 

Signed-off-by: Yanqiang Miao <miao.yanqiang@zte.com.cn>