### PR TITLE
Ignore sockets when creating a tar stream of a layer

### DIFF
--- a/archive/tar.go
+++ b/archive/tar.go
@@ -465,7 +465,10 @@ func (cw *changeWriter) HandleChange(k fs.ChangeKind, p string, f os.FileInfo, e
 			source = filepath.Join(cw.source, p)
 		)
 
-		if f.Mode()&os.ModeSymlink != 0 {
+		switch {
+		case f.Mode()&os.ModeSocket != 0:
+			return nil // ignore sockets
+		case f.Mode()&os.ModeSymlink != 0:
 			if link, err = os.Readlink(source); err != nil {
 				return err
 			}

--- a/archive/tar_test.go
+++ b/archive/tar_test.go
@@ -1022,6 +1022,22 @@ func TestDiffTar(t *testing.T) {
 				fstest.CreateDir("/d3/", 0755),
 			),
 		},
+		{
+			name: "IgnoreSockets",
+			validators: []tarEntryValidator{
+				fileEntry("f2", []byte("content"), 0644),
+				// There should be _no_ socket here, despite the fstest.CreateSocket below
+				fileEntry("f3", []byte("content"), 0644),
+			},
+			a: fstest.Apply(
+				fstest.CreateFile("/f1", []byte("content"), 0644),
+			),
+			b: fstest.Apply(
+				fstest.CreateFile("/f2", []byte("content"), 0644),
+				fstest.CreateSocket("/s0", 0644),
+				fstest.CreateFile("/f3", []byte("content"), 0644),
+			),
+		},
 	}
 
 	for _, at := range tests {

--- a/vendor.conf
+++ b/vendor.conf
@@ -4,7 +4,7 @@ github.com/containerd/cgroups fe281dd265766145e943a034aa41086474ea6130
 github.com/containerd/typeurl f6943554a7e7e88b3c14aad190bf05932da84788
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c
 github.com/containerd/btrfs 2e1aa0ddf94f91fa282b6ed87c23bf0d64911244
-github.com/containerd/continuity d8fb8589b0e8e85b8c8bbaa8840226d0dfeb7371
+github.com/containerd/continuity 3e8f2ea4b190484acb976a5b378d373429639a1a
 github.com/coreos/go-systemd 48702e0da86bd25e76cfef347e2adeb434a0d0a6
 github.com/docker/go-metrics 4ea375f7759c82740c893fc030bc37088d2ec098
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9

--- a/vendor/github.com/containerd/continuity/fs/fstest/file.go
+++ b/vendor/github.com/containerd/continuity/fs/fstest/file.go
@@ -2,6 +2,7 @@ package fstest
 
 import (
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 	"time"
@@ -106,6 +107,18 @@ func Link(oldname, newname string) Applier {
 //		return return syscall.Mknod(path, mode, dev)
 //	}
 //}
+
+func CreateSocket(name string, perm os.FileMode) Applier {
+	return applyFn(func(root string) error {
+		fullPath := filepath.Join(root, name)
+		ln, err := net.Listen("unix", fullPath)
+		if err != nil {
+			return err
+		}
+		defer ln.Close()
+		return os.Chmod(fullPath, perm)
+	})
+}
 
 // Apply returns a new applier from the given appliers
 func Apply(appliers ...Applier) Applier {

--- a/vendor/github.com/containerd/continuity/fs/fstest/testsuite.go
+++ b/vendor/github.com/containerd/continuity/fs/fstest/testsuite.go
@@ -74,6 +74,7 @@ var (
 		Symlink("libnothing.so", "/usr/local/lib/libnothing.so.2"),
 		CreateDir("/home", 0755),
 		CreateDir("/home/derek", 0700),
+		CreateDir("/var/run/socket", 0700),
 	)
 
 	// basicTest covers basic operations


### PR DESCRIPTION
The go-tar implementation which is used cannot handle sockets.

There's no good reason to preserve a socket, they are basically useless without
the process which made them.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>

I discovered this with https://github.com/dotnet/dotnet-docker-samples/tree/master/aspnetapp and buildkit's dockerfile frontend which gave:
```
aspnetapp$ sudo $(which buildctl) build --frontend=dockerfile.v0 --local context=. --local dockerfile=. --exporter=image --exporter-opt=name=foo --frontend-opt target=build-env
[...]
=> ERROR exporting to image                                                                               1.0s
=> => exporting layers                                                                                    4.0s
------
> exporting to image:
------
error: failed to solve: rpc error: code = Unknown desc = failed calculaing diff pairs for exported snapshot: rpc error: code = Unknown desc = failed to write compressed diff: failed to create diff tar stream: tar: sockets not supported
```
While a `docker build` works.