### PR TITLE
[release/1.0] linux/prox: timeout fifo creation

### DIFF
--- a/linux/proc/exec.go
+++ b/linux/proc/exec.go
@@ -147,7 +147,10 @@ func (e *execProcess) start(ctx context.Context) (err error) {
 		return e.parent.runtimeError(err, "OCI runtime exec failed")
 	}
 	if e.stdio.Stdin != "" {
-		sc, err := fifo.OpenFifo(ctx, e.stdio.Stdin, syscall.O_WRONLY|syscall.O_NONBLOCK, 0)
+		fifoCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		defer cancel()
+
+		sc, err := fifo.OpenFifo(fifoCtx, e.stdio.Stdin, syscall.O_WRONLY|syscall.O_NONBLOCK, 0)
 		if err != nil {
 			return errors.Wrapf(err, "failed to open stdin fifo %s", e.stdio.Stdin)
 		}
@@ -164,7 +167,10 @@ func (e *execProcess) start(ctx context.Context) (err error) {
 			return errors.Wrap(err, "failed to start console copy")
 		}
 	} else if !e.stdio.IsNull() {
-		if err := copyPipes(ctx, e.io, e.stdio.Stdin, e.stdio.Stdout, e.stdio.Stderr, &e.wg, &copyWaitGroup); err != nil {
+		fifoCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		defer cancel()
+
+		if err := copyPipes(fifoCtx, e.io, e.stdio.Stdin, e.stdio.Stdout, e.stdio.Stderr, &e.wg, &copyWaitGroup); err != nil {
 			return errors.Wrap(err, "failed to start io pipe copy")
 		}
 	}


### PR DESCRIPTION
Under certain conditions in the client, the fifo for a container may not
be created. A timeout has been added to this operation to ensure the
shim can recover when the client fails to open the fifos.

Signed-off-by: Stephen J Day <stephen.day@docker.com>
(cherry picked from commit 9754696ff53dd177a343615e6c6d7dbdc94e21a3)
Signed-off-by: Stephen J Day <stephen.day@docker.com>

Cherry pick of #2229 into release/1.0