### PR TITLE
client/pull: fix label being put on snapshot instead of content

### DIFF
--- a/image.go
+++ b/image.go
@@ -25,7 +25,6 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/rootfs"
-	"github.com/containerd/containerd/snapshots"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -124,13 +123,23 @@ func (i *image) Unpack(ctx context.Context, snapshotterName string) error {
 		unpacked bool
 	)
 	for _, layer := range layers {
-		labels := map[string]string{
-			"containerd.io/uncompressed": layer.Diff.Digest.String(),
-		}
-
-		unpacked, err = rootfs.ApplyLayer(ctx, layer, chain, sn, a, snapshots.WithLabels(labels))
+		unpacked, err = rootfs.ApplyLayer(ctx, layer, chain, sn, a)
 		if err != nil {
 			return err
+		}
+
+		if unpacked {
+			// Set the uncompressed label after the uncompressed
+			// digest has been verified through apply.
+			cinfo := content.Info{
+				Digest: layer.Blob.Digest,
+				Labels: map[string]string{
+					"containerd.io/uncompressed": layer.Diff.Digest.String(),
+				},
+			}
+			if _, err := cs.Update(ctx, cinfo, "labels.containerd.io/uncompressed"); err != nil {
+				return err
+			}
 		}
 
 		chain = append(chain, layer.Diff.Digest)


### PR DESCRIPTION
The uncompressed label should be placed on content instead of snapshots. Currently the uncompressed label is getting passed into as a label option for apply, which is used to commit snapshots. The content is already committed, but after apply the uncompressed diff digest is verified and can be reliably used to update the content with the label.
