### PR TITLE
Drop libapparmor dependency from runc build docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ addons:
   apt:
     packages:
       - btrfs-tools
-      - libapparmor-dev
       - libnl-3-dev
       - libnet-dev
       - protobuf-c-compiler

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -142,11 +142,11 @@ We can build an image from this `Dockerfile`:
 FROM golang
 
 RUN apt-get update && \
-    apt-get install -y btrfs-tools libapparmor-dev libseccomp-dev
+    apt-get install -y btrfs-tools libseccomp-dev
 
 ```
 
-In our Docker container we will use a specific `runc` build which includes [seccomp](https://en.wikipedia.org/wiki/seccomp) and [apparmor](https://en.wikipedia.org/wiki/AppArmor) support. Hence why our Dockerfile includes these dependencies: `libapparmor-dev` `libseccomp-dev`. Please refer to [RUNC.md](/RUNC.md) for the currently supported version of `runc` that is used by containerd.
+In our Docker container we will use a specific `runc` build which includes [seccomp](https://en.wikipedia.org/wiki/seccomp) and [apparmor](https://en.wikipedia.org/wiki/AppArmor) support. Hence why our Dockerfile includes `libseccomp-dev` as a dependency (apparmor support doesn't require external libaries). Please refer to [RUNC.md](/RUNC.md) for the currently supported version of `runc` that is used by containerd.
 
 Let's suppose you build an image called `containerd/build` from the above Dockerfile. You can run the following command:
 

--- a/RUNC.md
+++ b/RUNC.md
@@ -6,7 +6,7 @@ RUNC_COMMIT = a618ab5a0186905949ee463dbb762c3d23e12a80
 
 For more information on how to clone and build runc see the runc Building [documentation](https://github.com/opencontainers/runc#building).
 
-Note: before building you may need to install additional support, which will vary by platform. For example, you may need to install `libseccomp` and `libapparmor` e.g. `libseccomp-dev` and `libapparmor-dev` for Ubuntu.
+Note: before building you may need to install additional support, which will vary by platform. For example, you may need to install `libseccomp` e.g. `libseccomp-dev` for Ubuntu.
 
 ## building
 

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -14,13 +14,13 @@ RUN ./install-protobuf
 
 # Install runc
 FROM golang:1.10 AS runc
-RUN apt-get update && apt-get install -y curl libapparmor-dev libseccomp-dev
+RUN apt-get update && apt-get install -y curl libseccomp-dev
 COPY vendor.conf /go/src/github.com/containerd/containerd/vendor.conf
 COPY script/setup/install-runc install-runc
 RUN ./install-runc
 
 FROM golang:1.10
-RUN apt-get update && apt-get install -y btrfs-tools gcc git libapparmor-dev libseccomp-dev make xfsprogs
+RUN apt-get update && apt-get install -y btrfs-tools gcc git libseccomp-dev make xfsprogs
 
 COPY --from=proto3 /usr/local/bin/protoc /usr/local/bin/protoc
 COPY --from=proto3 /usr/local/include/google /usr/local/include/google


### PR DESCRIPTION
As of opencontainers/runc@db093f621f4e6d40feafbe6d7b89a9bee6f6ff85 runc
no longer depends on libapparmor thus libapparmor-dev no longer needs to
be installed to build it. Adjust the documentation accordingly.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>