### PR TITLE
Fix typo in metadata test typeurl string

### DIFF
--- a/metadata/containers_test.go
+++ b/metadata/containers_test.go
@@ -39,7 +39,7 @@ import (
 )
 
 func init() {
-	typeurl.Register(&specs.Spec{}, "types.contianerd.io/opencontainers/runtime-spec", "v1", "Spec")
+	typeurl.Register(&specs.Spec{}, "types.containerd.io/opencontainers/runtime-spec", "v1", "Spec")
 }
 
 func TestContainersList(t *testing.T) {


### PR DESCRIPTION
Incorrectly spelled "containerd" in test string.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>