### PR TITLE
Make hcsshim layerwriter close a fatal error

### DIFF
--- a/archive/tar_windows.go
+++ b/archive/tar_windows.go
@@ -35,7 +35,6 @@ import (
 
 	"github.com/Microsoft/go-winio"
 	"github.com/Microsoft/hcsshim"
-	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/sys"
 )
 
@@ -180,8 +179,12 @@ func applyWindowsLayer(ctx context.Context, root string, tr *tar.Reader, options
 		return 0, err
 	}
 	defer func() {
-		if err := w.Close(); err != nil {
-			log.G(ctx).Errorf("failed to close layer writer: %v", err)
+		if err2 := w.Close(); err2 != nil {
+			// This error should not be discarded as a failure here
+			// could result in an invalid layer on disk
+			if err == nil {
+				err = err2
+			}
 		}
 	}()
 


### PR DESCRIPTION
hcsshim's `LayerWriter.Close` method does some necessary post processing on the layer during layer apply, so an error closing the layer should be considered a fatal error. Priority is given to errors encountered in the rest of the function, but if the function would otherwise not fail, a `Close` failure should be returned to the caller.

Signed-off-by: Darren Stahl <darst@microsoft.com>