### PR TITLE
[release/1.0] Return a better error message is unix socket path is too long.

### DIFF
--- a/cmd/containerd-shim/main_unix.go
+++ b/cmd/containerd-shim/main_unix.go
@@ -146,6 +146,9 @@ func serve(server *ttrpc.Server, path string) error {
 		l, err = net.FileListener(os.NewFile(3, "socket"))
 		path = "[inherited from parent]"
 	} else {
+		if len(path) > 106 {
+			return errors.Errorf("%q: unix socket path too long (> 106)", path)
+		}
 		l, err = net.Listen("unix", "\x00"+path)
 	}
 	if err != nil {

--- a/linux/shim/client/client.go
+++ b/linux/shim/client/client.go
@@ -126,7 +126,7 @@ func newCommand(binary, daemonAddress string, debug bool, config shim.Config, so
 
 func newSocket(address string) (*net.UnixListener, error) {
 	if len(address) > 106 {
-		return nil, errors.Errorf("%q: unix socket path too long (limit 106)", address)
+		return nil, errors.Errorf("%q: unix socket path too long (> 106)", address)
 	}
 	l, err := net.Listen("unix", "\x00"+address)
 	if err != nil {

--- a/sys/socket_unix.go
+++ b/sys/socket_unix.go
@@ -7,11 +7,16 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 
 // CreateUnixSocket creates a unix socket and returns the listener
 func CreateUnixSocket(path string) (net.Listener, error) {
+	// BSDs have a 104 limit
+	if len(path) > 104 {
+		return nil, errors.Errorf("%q: unix socket path too long (> 106)", path)
+	}
 	if err := os.MkdirAll(filepath.Dir(path), 0660); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>
(cherry picked from commit 3c3a676490970dd759b940c9982130aa2f71da87)
Signed-off-by: Stephen J Day <stephen.day@docker.com>