### PR TITLE
[release/1.0] Fix typo in CreateUnixSocket error message

### DIFF
--- a/sys/socket_unix.go
+++ b/sys/socket_unix.go
@@ -15,7 +15,7 @@ import (
 func CreateUnixSocket(path string) (net.Listener, error) {
 	// BSDs have a 104 limit
 	if len(path) > 104 {
-		return nil, errors.Errorf("%q: unix socket path too long (> 106)", path)
+		return nil, errors.Errorf("%q: unix socket path too long (> 104)", path)
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0660); err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>
(cherry picked from commit 81feacd39359a6c7934219723c4468d03f1d4700)
Signed-off-by: Stephen J Day <stephen.day@docker.com>