### PR TITLE
enable native (formerly naive) snapshotter by default

### DIFF
--- a/cmd/containerd/builtins_linux.go
+++ b/cmd/containerd/builtins_linux.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/containerd/aufs"
 	_ "github.com/containerd/containerd/linux"
 	_ "github.com/containerd/containerd/metrics/cgroups"
+	_ "github.com/containerd/containerd/snapshots/native"
 	_ "github.com/containerd/containerd/snapshots/overlay"
 	_ "github.com/containerd/zfs"
 )

--- a/cmd/containerd/builtins_unix.go
+++ b/cmd/containerd/builtins_unix.go
@@ -19,5 +19,5 @@
 package main
 
 import (
-	_ "github.com/containerd/containerd/snapshots/naive"
+	_ "github.com/containerd/containerd/snapshots/native"
 )

--- a/metadata/db_test.go
+++ b/metadata/db_test.go
@@ -39,7 +39,7 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/snapshots"
-	"github.com/containerd/containerd/snapshots/naive"
+	"github.com/containerd/containerd/snapshots/native"
 	"github.com/gogo/protobuf/types"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -55,7 +55,7 @@ func testDB(t *testing.T) (context.Context, *DB, func()) {
 		t.Fatal(err)
 	}
 
-	snapshotter, err := naive.NewSnapshotter(filepath.Join(dirname, "naive"))
+	snapshotter, err := native.NewSnapshotter(filepath.Join(dirname, "native"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +70,7 @@ func testDB(t *testing.T) (context.Context, *DB, func()) {
 		t.Fatal(err)
 	}
 
-	db := NewDB(bdb, cs, map[string]snapshots.Snapshotter{"naive": snapshotter})
+	db := NewDB(bdb, cs, map[string]snapshots.Snapshotter{"native": snapshotter})
 	if err := db.Init(ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -544,7 +544,7 @@ func create(obj object, tx *bolt.Tx, is images.Store, cs content.Store, sn snaps
 			node = &gc.Node{
 				Type:      ResourceSnapshot,
 				Namespace: namespace,
-				Key:       fmt.Sprintf("naive/%s", v.key),
+				Key:       fmt.Sprintf("native/%s", v.key),
 			}
 		}
 	case testImage:
@@ -563,7 +563,7 @@ func create(obj object, tx *bolt.Tx, is images.Store, cs content.Store, sn snaps
 		container := containers.Container{
 			ID:          v.id,
 			SnapshotKey: v.snapshot,
-			Snapshotter: "naive",
+			Snapshotter: "native",
 			Labels:      obj.labels,
 
 			Runtime: containers.RuntimeInfo{
@@ -658,7 +658,7 @@ func newStores(t testing.TB) (*DB, content.Store, snapshots.Snapshotter, func())
 		t.Fatal(err)
 	}
 
-	nsn, err := naive.NewSnapshotter(filepath.Join(td, "snapshots"))
+	nsn, err := native.NewSnapshotter(filepath.Join(td, "snapshots"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -668,9 +668,9 @@ func newStores(t testing.TB) (*DB, content.Store, snapshots.Snapshotter, func())
 		t.Fatal(err)
 	}
 
-	mdb := NewDB(db, lcs, map[string]snapshots.Snapshotter{"naive": nsn})
+	mdb := NewDB(db, lcs, map[string]snapshots.Snapshotter{"native": nsn})
 
-	return mdb, mdb.ContentStore(), mdb.Snapshotter("naive"), func() {
+	return mdb, mdb.ContentStore(), mdb.Snapshotter("native"), func() {
 		os.RemoveAll(td)
 	}
 }

--- a/metadata/snapshot_test.go
+++ b/metadata/snapshot_test.go
@@ -25,17 +25,17 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/containerd/containerd/snapshots"
-	"github.com/containerd/containerd/snapshots/naive"
+	"github.com/containerd/containerd/snapshots/native"
 	"github.com/containerd/containerd/snapshots/testsuite"
 	"github.com/containerd/containerd/testutil"
 )
 
 func newTestSnapshotter(ctx context.Context, root string) (snapshots.Snapshotter, func() error, error) {
-	naiveRoot := filepath.Join(root, "naive")
-	if err := os.Mkdir(naiveRoot, 0770); err != nil {
+	nativeRoot := filepath.Join(root, "native")
+	if err := os.Mkdir(nativeRoot, 0770); err != nil {
 		return nil, nil, err
 	}
-	snapshotter, err := naive.NewSnapshotter(naiveRoot)
+	snapshotter, err := native.NewSnapshotter(nativeRoot)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -45,7 +45,7 @@ func newTestSnapshotter(ctx context.Context, root string) (snapshots.Snapshotter
 		return nil, nil, err
 	}
 
-	sn := NewDB(db, nil, map[string]snapshots.Snapshotter{"naive": snapshotter}).Snapshotter("naive")
+	sn := NewDB(db, nil, map[string]snapshots.Snapshotter{"native": snapshotter}).Snapshotter("native")
 
 	return sn, func() error {
 		if err := sn.Close(); err != nil {

--- a/snapshots/native/native.go
+++ b/snapshots/native/native.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package naive
+package native
 
 import (
 	"context"
@@ -35,7 +35,7 @@ import (
 func init() {
 	plugin.Register(&plugin.Registration{
 		Type: plugin.SnapshotPlugin,
-		ID:   "naive",
+		ID:   "native",
 		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
 			ic.Meta.Platforms = append(ic.Meta.Platforms, platforms.DefaultSpec())
 			return NewSnapshotter(ic.Root)

--- a/snapshots/native/native_test.go
+++ b/snapshots/native/native_test.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package naive
+package native
 
 import (
 	"context"

--- a/snapshotter_default_unix.go
+++ b/snapshotter_default_unix.go
@@ -22,5 +22,5 @@ const (
 	// DefaultSnapshotter will set the default snapshotter for the platform.
 	// This will be based on the client compilation target, so take that into
 	// account when choosing this value.
-	DefaultSnapshotter = "naive"
+	DefaultSnapshotter = "native"
 )


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

Fix https://github.com/containerd/containerd/issues/830 https://github.com/containerd/containerd/issues/1883


The native (formerly naive) snapshotter should be useful for several cases such as:
- running containerd in unprivileged mountns (although Ubuntu also allows overlayfs https://github.com/containerd/containerd/pull/2006)
- running containerd in another container environment
- running apps that does not work well with overlayfs (e.g. opening RO fd and RW fd simultaneously for a single file moby/moby#10180)
- running containerd with an old kernel (https://github.com/containerd/containerd/issues/1883)

Other candidate names suggested in Slack:
- bob
- coe (copy on everything)
- copy
- copying
- generic
- java ( runs everywhere but with meh performance)
- noverlay
- reference
- silly
- simple

