### PR TITLE
client: fix multi-platform pull test

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -240,7 +240,7 @@ func TestImagePullSomePlatforms(t *testing.T) {
 	defer cancel()
 
 	cs := client.ContentStore()
-	platformList := []string{"linux/arm64/v8", "linux/386"}
+	platformList := []string{"linux/amd64", "linux/arm64/v8", "linux/s390x"}
 	m := make(map[string]platforms.Matcher)
 	var opts []RemoteOpt
 


### PR DESCRIPTION
Remove architecture not included in buysbox image and ensures amd64 is included since it may already exist in the content store. (Using a separate namespace just for this test might be more difficult).