### PR TITLE
Fix broken tests; make sure we don't mask travis script exit codes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,10 +75,8 @@ script:
       sudo PATH=$PATH containerd -log-level debug &> /tmp/containerd-cri.log &
       sudo ctr version ;
       sudo PATH=$PATH GOPATH=$GOPATH critest --runtime-endpoint=/var/run/containerd/containerd.sock --parallel=8 ;
-      exit_code=$? ;
-      test $exit_code -ne 0 && cat /tmp/containerd-cri.log ;
+      test $? -ne 0 && cat /tmp/containerd-cri.log ;
       sudo pkill containerd ;
-      exit $exit_code ;
     fi
 
 after_success:

--- a/container_linux_test.go
+++ b/container_linux_test.go
@@ -493,7 +493,7 @@ func testContainerUser(t *testing.T, userstr, expectedOutput string) {
 	var (
 		image       Image
 		ctx, cancel = testContext()
-		id          = t.Name()
+		id          = strings.Replace(t.Name(), "/", "_", -1)
 	)
 	defer cancel()
 


### PR DESCRIPTION
Fix the tests that were using an invalid container ID and fix travis script to not mask error exit return codes.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>