### PR TITLE
Allow image and snapshotkey to be updated

### DIFF
--- a/metadata/containers.go
+++ b/metadata/containers.go
@@ -164,19 +164,11 @@ func (s *containerStore) Update(ctx context.Context, container containers.Contai
 
 	if len(fieldpaths) == 0 {
 		// only allow updates to these field on full replace.
-		fieldpaths = []string{"labels", "spec", "extensions"}
+		fieldpaths = []string{"labels", "spec", "extensions", "image", "snapshotkey"}
 
 		// Fields that are immutable must cause an error when no field paths
 		// are provided. This allows these fields to become mutable in the
 		// future.
-		if updated.Image != container.Image {
-			return containers.Container{}, errors.Wrapf(errdefs.ErrInvalidArgument, "container.Image field is immutable")
-		}
-
-		if updated.SnapshotKey != container.SnapshotKey {
-			return containers.Container{}, errors.Wrapf(errdefs.ErrInvalidArgument, "container.SnapshotKey field is immutable")
-		}
-
 		if updated.Snapshotter != container.Snapshotter {
 			return containers.Container{}, errors.Wrapf(errdefs.ErrInvalidArgument, "container.Snapshotter field is immutable")
 		}
@@ -215,6 +207,10 @@ func (s *containerStore) Update(ctx context.Context, container containers.Contai
 			updated.Spec = container.Spec
 		case "extensions":
 			updated.Extensions = container.Extensions
+		case "image":
+			updated.Image = container.Image
+		case "snapshotkey":
+			updated.SnapshotKey = container.SnapshotKey
 		default:
 			return containers.Container{}, errors.Wrapf(errdefs.ErrInvalidArgument, "cannot update %q field on %q", path, container.ID)
 		}

--- a/metadata/containers_test.go
+++ b/metadata/containers_test.go
@@ -264,29 +264,6 @@ func TestContainersCreateUpdateDelete(t *testing.T) {
 			cause:      errdefs.ErrInvalidArgument,
 		},
 		{
-			name: "UpdateFail",
-			original: containers.Container{
-				Spec:        encoded,
-				SnapshotKey: "test-snapshot-key",
-				Snapshotter: "snapshotter",
-
-				Runtime: containers.RuntimeInfo{
-					Name: "testruntime",
-				},
-				Image: "test image",
-			},
-			input: containers.Container{
-				Spec: encoded,
-				Runtime: containers.RuntimeInfo{
-					Name: "testruntime",
-				},
-				SnapshotKey: "test-snapshot-key",
-				Snapshotter: "snapshotter",
-				// try to clear image field
-			},
-			cause: errdefs.ErrInvalidArgument,
-		},
-		{
 			name: "UpdateSpec",
 			original: containers.Container{
 				Spec:        encoded,
@@ -309,6 +286,60 @@ func TestContainersCreateUpdateDelete(t *testing.T) {
 				SnapshotKey: "test-snapshot-key",
 				Snapshotter: "snapshotter",
 				Image:       "test image",
+			},
+		},
+		{
+			name: "UpdateSnapshot",
+			original: containers.Container{
+
+				Spec:        encoded,
+				SnapshotKey: "test-snapshot-key",
+				Snapshotter: "snapshotter",
+				Runtime: containers.RuntimeInfo{
+					Name: "testruntime",
+				},
+				Image: "test image",
+			},
+			input: containers.Container{
+				SnapshotKey: "test2-snapshot-key",
+			},
+			fieldpaths: []string{"snapshotkey"},
+			expected: containers.Container{
+
+				Spec:        encoded,
+				SnapshotKey: "test2-snapshot-key",
+				Snapshotter: "snapshotter",
+				Runtime: containers.RuntimeInfo{
+					Name: "testruntime",
+				},
+				Image: "test image",
+			},
+		},
+		{
+			name: "UpdateImage",
+			original: containers.Container{
+
+				Spec:        encoded,
+				SnapshotKey: "test-snapshot-key",
+				Snapshotter: "snapshotter",
+				Runtime: containers.RuntimeInfo{
+					Name: "testruntime",
+				},
+				Image: "test image",
+			},
+			input: containers.Container{
+				Image: "test2 image",
+			},
+			fieldpaths: []string{"image"},
+			expected: containers.Container{
+
+				Spec:        encoded,
+				SnapshotKey: "test-snapshot-key",
+				Snapshotter: "snapshotter",
+				Runtime: containers.RuntimeInfo{
+					Name: "testruntime",
+				},
+				Image: "test2 image",
 			},
 		},
 		{


### PR DESCRIPTION
This allows a container's image and snapshot key to be updated via the
Update APIs.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>