### PR TITLE
Track Go 1.10 point releases in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 language: go
 
 go:
-  - "1.10"
+  - "1.10.x"
 
 go_import_path: github.com/containerd/containerd
 


### PR DESCRIPTION
I assume we don't want to lock to Go 1.10.0.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>