### PR TITLE
Clean up dependency output

### DIFF
--- a/cmd/containerd-release/main.go
+++ b/cmd/containerd-release/main.go
@@ -19,6 +19,8 @@ package main
 import (
 	"fmt"
 	"os"
+	"sort"
+	"text/tabwriter"
 	"text/template"
 
 	"github.com/sirupsen/logrus"
@@ -115,6 +117,11 @@ This tool should be ran from the root of the project repository for a new releas
 		if err != nil {
 			return err
 		}
+
+		sort.Slice(updatedDeps, func(i, j int) bool {
+			return updatedDeps[i].Name < updatedDeps[j].Name
+		})
+
 		// update the release fields with generated data
 		r.Contributors = contributors
 		r.Dependencies = updatedDeps
@@ -131,7 +138,12 @@ This tool should be ran from the root of the project repository for a new releas
 			if err != nil {
 				return err
 			}
-			return t.Execute(os.Stdout, r)
+
+			w := tabwriter.NewWriter(os.Stdout, 8, 8, 2, ' ', 0)
+			if err := t.Execute(w, r); err != nil {
+				return err
+			}
+			return w.Flush()
 		}
 		logrus.Info("release complete!")
 		return nil

--- a/cmd/containerd-release/template.go
+++ b/cmd/containerd-release/template.go
@@ -48,7 +48,7 @@ https://github.com/{{.GithubRepo}}/issues.
 
 Previous release can be found at [{{.Previous}}](https://github.com/{{.GithubRepo}}/releases/tag/{{.Previous}})
 {{range $dep := .Dependencies}}
-* {{$dep.Previous}} -> {{$dep.Commit}} **{{$dep.Name}}**
+* **{{$dep.Name}}**	{{if $dep.Previous}}{{$dep.Previous}} -> {{$dep.Commit}}{{else}}{{$dep.Commit}} **_new_**{{end}}
 {{- end}}
 `
 )


### PR DESCRIPTION
Show new tag when dependencies don't have a previous version.
Align dependencies into columns. (does not show up with formatted markdown)
Sort dependencies by name.

Example from 1.1 (raw + formatted)
**NEW**
```
* **github.com/BurntSushi/toml**                v0.2.0-21-g9906417 -> a368813c5e648fee92e5f6c30e3944ff9d5e8895
* **github.com/Microsoft/go-winio**             v0.4.4 -> v0.4.5
* **github.com/blang/semver**                   v3.1.0 **_new_**
* **github.com/containerd/aufs**                a7fbd554da7a9eafbe5a460a421313a9fd18d988 **_new_**
* **github.com/containerd/btrfs**               cc52c4dea2ce11a44e6639e561bb5c2af9ada9e3 -> 2e1aa0ddf94f91fa282b6ed87c23bf0d64911244
* **github.com/containerd/cgroups**             29da22c6171a4316169f9205ab6c49f59b5b852f -> fe281dd265766145e943a034aa41086474ea6130
* **github.com/containerd/console**             84eeaae905fa414d03e07bcd6c8d3f19e7cf180e -> cb7008ab3d8359b78c5f464cb7cf160107ad5925
* **github.com/containerd/continuity**          cf279e6ac893682272b4479d4c67fd3abf878b4e -> 3e8f2ea4b190484acb976a5b378d373429639a1a
* **github.com/containerd/cri**                 v1.0.0-rc.2 **_new_**
* **github.com/containerd/fifo**                fbfb6a11ec671efbe94ad1c12c2e98773f19e1e6 -> 3d5202aec260678c48179c56f40e6f38a095738c
* **github.com/containerd/go-cni**              f2d7272f12d045b16ed924f50e91f9f9cecc55a7 **_new_**
* **github.com/containerd/go-runc**             ed1cbe1fc31f5fb2359d3a54b6330d1a097858b7 -> bcb223a061a3dd7de1a89c0b402a60f4dd9bd307
* **github.com/containerd/zfs**                 9a0b8b8b5982014b729cd34eb7cd7a11062aa6ec **_new_**
* **github.com/containernetworking/cni**        v0.6.0 **_new_**
* **github.com/containernetworking/plugins**    v0.7.0 **_new_**
* **github.com/docker/distribution**            b38e5838b7b2f2ad48e06ec4b500011976080621 **_new_**
* **github.com/docker/docker**                  86f080cff0914e9694068ed78d503701667c4c00 **_new_**
* **github.com/docker/go-metrics**              8fd5772bf1584597834c6f7961a530f06cbfbb87 -> 4ea375f7759c82740c893fc030bc37088d2ec098
* **github.com/docker/spdystream**              449fdfce4d962303d702fec724ef0ad181c92528 **_new_**
* **github.com/emicklei/go-restful**            ff4f55a206334ef123e4f79bbf348980da81ca46 **_new_**
* **github.com/ghodss/yaml**                    73d445a93680fa1a78ae23a5839bad48f32ba1ee **_new_**
* **github.com/gogo/googleapis**                08a7655d27152912db7aaf4f983275eaf8d128ef **_new_**
* **github.com/gogo/protobuf**                  v0.5 -> v1.0.0
* **github.com/golang/glog**                    44145f04b68cf362d9c4df2182967c2275eaefed **_new_**
* **github.com/google/go-cmp**                  v0.1.0 **_new_**
* **github.com/google/gofuzz**                  44d81051d367757e1c7c6a5a86423ece9afcf63c **_new_**
* **github.com/gotestyourself/gotestyourself**  44dbf532bbf5767611f6f2a61bded572e337010a **_new_**
* **github.com/hashicorp/errwrap**              7554cd9344cec97297fa6649b055a8c98c2a1e55 **_new_**
* **github.com/hashicorp/go-multierror**        ed905158d87462226a13fe39ddf685ea65f1c11f **_new_**
* **github.com/json-iterator/go**               1.0.4 **_new_**
* **github.com/mistifyio/go-zfs**               166add352731e515512690329794ee593f1aaff2 **_new_**
* **github.com/opencontainers/image-spec**      v1.0.0 -> v1.0.1
* **github.com/opencontainers/runc**            74a17296470088de3805e138d3d87c62e613dfc4 -> 69663f0bd4b60df09991c08812a60108003fa340
* **github.com/opencontainers/runtime-spec**    v1.0.0 -> v1.0.1
* **github.com/opencontainers/runtime-tools**   6073aff4ac61897f75895123f7e24135204a404d **_new_**
* **github.com/opencontainers/selinux**         4a2974bf1ee960774ffd517717f1f45325af0206 **_new_**
* **github.com/pborman/uuid**                   c65b2f87fee37d1c7854c9164a450713c28d50cd **_new_**
* **github.com/prometheus/client_golang**       v0.8.0 -> f4fb1b73fb099f396a7f0036bf86aa8def4ed823
* **github.com/prometheus/client_model**        fa8ad6fec33561be4280a8f0514318c79d7f6cb6 -> 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
* **github.com/prometheus/common**              195bde7883f7c39ea62b0d92ab7359b5327065cb -> 89604d197083d4781071d3c65855d24ecfb0a563
* **github.com/prometheus/procfs**              fcdb11ccb4389efb1b210b7ffb623ab71c5fdd60 -> cb4147076ac75738c9a7d279075a253c0cc5acbd
* **github.com/seccomp/libseccomp-golang**      32f571b70023028bd57d9288c20efbcb237f3ce0 **_new_**
* **github.com/spf13/pflag**                    v1.0.0 **_new_**
* **github.com/stevvooe/ttrpc**                 76e68349ad9ab4d03d764c713826d31216715e4f -> d4528379866b0ce7e9d71f3eb96f0582fc374577
* **github.com/syndtr/gocapability**            db04d3cc01c8b54962a58ec7e491717d06cfcc16 **_new_**
* **github.com/tchap/go-patricia**              5ad6cdb7538b0097d5598c7e57f0a24072adf7dc **_new_**
* **golang.org/x/crypto**                       49796115aa4b964c318aad4f3084fdb41e9aa067 **_new_**
* **golang.org/x/time**                         f51c12702a4d776e4c1fa9b0fabab841babae631 **_new_**
* **google.golang.org/grpc**                    v1.7.2 -> v1.10.1
* **gopkg.in/inf.v0**                           3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4 **_new_**
* **gopkg.in/yaml.v2**                          53feefa2559fb8dfa8d81baad31be332c97d6c77 **_new_**
* **k8s.io/api**                                7e796de92438aede7cb5d6bcf6c10f4fa65db560 **_new_**
* **k8s.io/apimachinery**                       fcb9a12f7875d01f8390b28faedc37dcf2e713b9 **_new_**
* **k8s.io/apiserver**                          4a8377c547bbff4576a35b5b5bf4026d9b5aa763 **_new_**
* **k8s.io/client-go**                          b9a0cf870f239c4a4ecfd3feb075a50e7cbe1473 **_new_**
* **k8s.io/kubernetes**                         v1.10.0 **_new_**
* **k8s.io/utils**                              258e2a2fa64568210fbd6267cf1d8fd87c3cb86e **_new_**
```
* **github.com/BurntSushi/toml**                v0.2.0-21-g9906417 -> a368813c5e648fee92e5f6c30e3944ff9d5e8895
* **github.com/Microsoft/go-winio**             v0.4.4 -> v0.4.5
* **github.com/blang/semver**                   v3.1.0 **_new_**
* **github.com/containerd/aufs**                a7fbd554da7a9eafbe5a460a421313a9fd18d988 **_new_**
* **github.com/containerd/btrfs**               cc52c4dea2ce11a44e6639e561bb5c2af9ada9e3 -> 2e1aa0ddf94f91fa282b6ed87c23bf0d64911244
* **github.com/containerd/cgroups**             29da22c6171a4316169f9205ab6c49f59b5b852f -> fe281dd265766145e943a034aa41086474ea6130
* **github.com/containerd/console**             84eeaae905fa414d03e07bcd6c8d3f19e7cf180e -> cb7008ab3d8359b78c5f464cb7cf160107ad5925
* **github.com/containerd/continuity**          cf279e6ac893682272b4479d4c67fd3abf878b4e -> 3e8f2ea4b190484acb976a5b378d373429639a1a
* **github.com/containerd/cri**                 v1.0.0-rc.2 **_new_**
* **github.com/containerd/fifo**                fbfb6a11ec671efbe94ad1c12c2e98773f19e1e6 -> 3d5202aec260678c48179c56f40e6f38a095738c
* **github.com/containerd/go-cni**              f2d7272f12d045b16ed924f50e91f9f9cecc55a7 **_new_**
* **github.com/containerd/go-runc**             ed1cbe1fc31f5fb2359d3a54b6330d1a097858b7 -> bcb223a061a3dd7de1a89c0b402a60f4dd9bd307
* **github.com/containerd/zfs**                 9a0b8b8b5982014b729cd34eb7cd7a11062aa6ec **_new_**
* **github.com/containernetworking/cni**        v0.6.0 **_new_**
* **github.com/containernetworking/plugins**    v0.7.0 **_new_**
* **github.com/docker/distribution**            b38e5838b7b2f2ad48e06ec4b500011976080621 **_new_**
* **github.com/docker/docker**                  86f080cff0914e9694068ed78d503701667c4c00 **_new_**
* **github.com/docker/go-metrics**              8fd5772bf1584597834c6f7961a530f06cbfbb87 -> 4ea375f7759c82740c893fc030bc37088d2ec098
* **github.com/docker/spdystream**              449fdfce4d962303d702fec724ef0ad181c92528 **_new_**
* **github.com/emicklei/go-restful**            ff4f55a206334ef123e4f79bbf348980da81ca46 **_new_**
* **github.com/ghodss/yaml**                    73d445a93680fa1a78ae23a5839bad48f32ba1ee **_new_**
* **github.com/gogo/googleapis**                08a7655d27152912db7aaf4f983275eaf8d128ef **_new_**
* **github.com/gogo/protobuf**                  v0.5 -> v1.0.0
* **github.com/golang/glog**                    44145f04b68cf362d9c4df2182967c2275eaefed **_new_**
* **github.com/google/go-cmp**                  v0.1.0 **_new_**
* **github.com/google/gofuzz**                  44d81051d367757e1c7c6a5a86423ece9afcf63c **_new_**
* **github.com/gotestyourself/gotestyourself**  44dbf532bbf5767611f6f2a61bded572e337010a **_new_**
* **github.com/hashicorp/errwrap**              7554cd9344cec97297fa6649b055a8c98c2a1e55 **_new_**
* **github.com/hashicorp/go-multierror**        ed905158d87462226a13fe39ddf685ea65f1c11f **_new_**
* **github.com/json-iterator/go**               1.0.4 **_new_**
* **github.com/mistifyio/go-zfs**               166add352731e515512690329794ee593f1aaff2 **_new_**
* **github.com/opencontainers/image-spec**      v1.0.0 -> v1.0.1
* **github.com/opencontainers/runc**            74a17296470088de3805e138d3d87c62e613dfc4 -> 69663f0bd4b60df09991c08812a60108003fa340
* **github.com/opencontainers/runtime-spec**    v1.0.0 -> v1.0.1
* **github.com/opencontainers/runtime-tools**   6073aff4ac61897f75895123f7e24135204a404d **_new_**
* **github.com/opencontainers/selinux**         4a2974bf1ee960774ffd517717f1f45325af0206 **_new_**
* **github.com/pborman/uuid**                   c65b2f87fee37d1c7854c9164a450713c28d50cd **_new_**
* **github.com/prometheus/client_golang**       v0.8.0 -> f4fb1b73fb099f396a7f0036bf86aa8def4ed823
* **github.com/prometheus/client_model**        fa8ad6fec33561be4280a8f0514318c79d7f6cb6 -> 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
* **github.com/prometheus/common**              195bde7883f7c39ea62b0d92ab7359b5327065cb -> 89604d197083d4781071d3c65855d24ecfb0a563
* **github.com/prometheus/procfs**              fcdb11ccb4389efb1b210b7ffb623ab71c5fdd60 -> cb4147076ac75738c9a7d279075a253c0cc5acbd
* **github.com/seccomp/libseccomp-golang**      32f571b70023028bd57d9288c20efbcb237f3ce0 **_new_**
* **github.com/spf13/pflag**                    v1.0.0 **_new_**
* **github.com/stevvooe/ttrpc**                 76e68349ad9ab4d03d764c713826d31216715e4f -> d4528379866b0ce7e9d71f3eb96f0582fc374577
* **github.com/syndtr/gocapability**            db04d3cc01c8b54962a58ec7e491717d06cfcc16 **_new_**
* **github.com/tchap/go-patricia**              5ad6cdb7538b0097d5598c7e57f0a24072adf7dc **_new_**
* **golang.org/x/crypto**                       49796115aa4b964c318aad4f3084fdb41e9aa067 **_new_**
* **golang.org/x/time**                         f51c12702a4d776e4c1fa9b0fabab841babae631 **_new_**
* **google.golang.org/grpc**                    v1.7.2 -> v1.10.1
* **gopkg.in/inf.v0**                           3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4 **_new_**
* **gopkg.in/yaml.v2**                          53feefa2559fb8dfa8d81baad31be332c97d6c77 **_new_**
* **k8s.io/api**                                7e796de92438aede7cb5d6bcf6c10f4fa65db560 **_new_**
* **k8s.io/apimachinery**                       fcb9a12f7875d01f8390b28faedc37dcf2e713b9 **_new_**
* **k8s.io/apiserver**                          4a8377c547bbff4576a35b5b5bf4026d9b5aa763 **_new_**
* **k8s.io/client-go**                          b9a0cf870f239c4a4ecfd3feb075a50e7cbe1473 **_new_**
* **k8s.io/kubernetes**                         v1.10.0 **_new_**
* **k8s.io/utils**                              258e2a2fa64568210fbd6267cf1d8fd87c3cb86e **_new_**

**OLD**
```
*  -> ed905158d87462226a13fe39ddf685ea65f1c11f **github.com/hashicorp/go-multierror**
*  -> 9a0b8b8b5982014b729cd34eb7cd7a11062aa6ec **github.com/containerd/zfs**
*  -> 166add352731e515512690329794ee593f1aaff2 **github.com/mistifyio/go-zfs**
* cc52c4dea2ce11a44e6639e561bb5c2af9ada9e3 -> 2e1aa0ddf94f91fa282b6ed87c23bf0d64911244 **github.com/containerd/btrfs**
* 76e68349ad9ab4d03d764c713826d31216715e4f -> d4528379866b0ce7e9d71f3eb96f0582fc374577 **github.com/stevvooe/ttrpc**
*  -> f2d7272f12d045b16ed924f50e91f9f9cecc55a7 **github.com/containerd/go-cni**
*  -> 44145f04b68cf362d9c4df2182967c2275eaefed **github.com/golang/glog**
*  -> 7e796de92438aede7cb5d6bcf6c10f4fa65db560 **k8s.io/api**
*  -> fcb9a12f7875d01f8390b28faedc37dcf2e713b9 **k8s.io/apimachinery**
*  -> 258e2a2fa64568210fbd6267cf1d8fd87c3cb86e **k8s.io/utils**
* 29da22c6171a4316169f9205ab6c49f59b5b852f -> fe281dd265766145e943a034aa41086474ea6130 **github.com/containerd/cgroups**
*  -> v3.1.0 **github.com/blang/semver**
*  -> c65b2f87fee37d1c7854c9164a450713c28d50cd **github.com/pborman/uuid**
*  -> a7fbd554da7a9eafbe5a460a421313a9fd18d988 **github.com/containerd/aufs**
* v0.5 -> v1.0.0 **github.com/gogo/protobuf**
* v1.0.0 -> v1.0.1 **github.com/opencontainers/runtime-spec**
* v1.0.0 -> v1.0.1 **github.com/opencontainers/image-spec**
*  -> db04d3cc01c8b54962a58ec7e491717d06cfcc16 **github.com/syndtr/gocapability**
*  -> 6073aff4ac61897f75895123f7e24135204a404d **github.com/opencontainers/runtime-tools**
* fcdb11ccb4389efb1b210b7ffb623ab71c5fdd60 -> cb4147076ac75738c9a7d279075a253c0cc5acbd **github.com/prometheus/procfs**
* v1.7.2 -> v1.10.1 **google.golang.org/grpc**
*  -> 73d445a93680fa1a78ae23a5839bad48f32ba1ee **github.com/ghodss/yaml**
* v0.8.0 -> f4fb1b73fb099f396a7f0036bf86aa8def4ed823 **github.com/prometheus/client_golang**
* fa8ad6fec33561be4280a8f0514318c79d7f6cb6 -> 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c **github.com/prometheus/client_model**
*  -> v0.6.0 **github.com/containernetworking/cni**
*  -> 1.0.4 **github.com/json-iterator/go**
*  -> 32f571b70023028bd57d9288c20efbcb237f3ce0 **github.com/seccomp/libseccomp-golang**
*  -> b9a0cf870f239c4a4ecfd3feb075a50e7cbe1473 **k8s.io/client-go**
*  -> 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4 **gopkg.in/inf.v0**
* 84eeaae905fa414d03e07bcd6c8d3f19e7cf180e -> cb7008ab3d8359b78c5f464cb7cf160107ad5925 **github.com/containerd/console**
*  -> v0.1.0 **github.com/google/go-cmp**
*  -> 86f080cff0914e9694068ed78d503701667c4c00 **github.com/docker/docker**
* 8fd5772bf1584597834c6f7961a530f06cbfbb87 -> 4ea375f7759c82740c893fc030bc37088d2ec098 **github.com/docker/go-metrics**
* v0.2.0-21-g9906417 -> a368813c5e648fee92e5f6c30e3944ff9d5e8895 **github.com/BurntSushi/toml**
*  -> b38e5838b7b2f2ad48e06ec4b500011976080621 **github.com/docker/distribution**
*  -> 53feefa2559fb8dfa8d81baad31be332c97d6c77 **gopkg.in/yaml.v2**
* ed1cbe1fc31f5fb2359d3a54b6330d1a097858b7 -> bcb223a061a3dd7de1a89c0b402a60f4dd9bd307 **github.com/containerd/go-runc**
*  -> 08a7655d27152912db7aaf4f983275eaf8d128ef **github.com/gogo/googleapis**
*  -> v0.7.0 **github.com/containernetworking/plugins**
*  -> f51c12702a4d776e4c1fa9b0fabab841babae631 **golang.org/x/time**
* cf279e6ac893682272b4479d4c67fd3abf878b4e -> 3e8f2ea4b190484acb976a5b378d373429639a1a **github.com/containerd/continuity**
*  -> 4a2974bf1ee960774ffd517717f1f45325af0206 **github.com/opencontainers/selinux**
*  -> 44d81051d367757e1c7c6a5a86423ece9afcf63c **github.com/google/gofuzz**
*  -> 7554cd9344cec97297fa6649b055a8c98c2a1e55 **github.com/hashicorp/errwrap**
*  -> 4a8377c547bbff4576a35b5b5bf4026d9b5aa763 **k8s.io/apiserver**
*  -> v1.10.0 **k8s.io/kubernetes**
*  -> 449fdfce4d962303d702fec724ef0ad181c92528 **github.com/docker/spdystream**
*  -> ff4f55a206334ef123e4f79bbf348980da81ca46 **github.com/emicklei/go-restful**
*  -> 49796115aa4b964c318aad4f3084fdb41e9aa067 **golang.org/x/crypto**
* 74a17296470088de3805e138d3d87c62e613dfc4 -> 69663f0bd4b60df09991c08812a60108003fa340 **github.com/opencontainers/runc**
*  -> v1.0.0 **github.com/spf13/pflag**
*  -> 5ad6cdb7538b0097d5598c7e57f0a24072adf7dc **github.com/tchap/go-patricia**
* 195bde7883f7c39ea62b0d92ab7359b5327065cb -> 89604d197083d4781071d3c65855d24ecfb0a563 **github.com/prometheus/common**
*  -> v1.0.0-rc.2 **github.com/containerd/cri**
* v0.4.4 -> v0.4.5 **github.com/Microsoft/go-winio**
*  -> 44dbf532bbf5767611f6f2a61bded572e337010a **github.com/gotestyourself/gotestyourself**
* fbfb6a11ec671efbe94ad1c12c2e98773f19e1e6 -> 3d5202aec260678c48179c56f40e6f38a095738c **github.com/containerd/fifo**
```
*  -> ed905158d87462226a13fe39ddf685ea65f1c11f **github.com/hashicorp/go-multierror**
*  -> 9a0b8b8b5982014b729cd34eb7cd7a11062aa6ec **github.com/containerd/zfs**
*  -> 166add352731e515512690329794ee593f1aaff2 **github.com/mistifyio/go-zfs**
* cc52c4dea2ce11a44e6639e561bb5c2af9ada9e3 -> 2e1aa0ddf94f91fa282b6ed87c23bf0d64911244 **github.com/containerd/btrfs**
* 76e68349ad9ab4d03d764c713826d31216715e4f -> d4528379866b0ce7e9d71f3eb96f0582fc374577 **github.com/stevvooe/ttrpc**
*  -> f2d7272f12d045b16ed924f50e91f9f9cecc55a7 **github.com/containerd/go-cni**
*  -> 44145f04b68cf362d9c4df2182967c2275eaefed **github.com/golang/glog**
*  -> 7e796de92438aede7cb5d6bcf6c10f4fa65db560 **k8s.io/api**
*  -> fcb9a12f7875d01f8390b28faedc37dcf2e713b9 **k8s.io/apimachinery**
*  -> 258e2a2fa64568210fbd6267cf1d8fd87c3cb86e **k8s.io/utils**
* 29da22c6171a4316169f9205ab6c49f59b5b852f -> fe281dd265766145e943a034aa41086474ea6130 **github.com/containerd/cgroups**
*  -> v3.1.0 **github.com/blang/semver**
*  -> c65b2f87fee37d1c7854c9164a450713c28d50cd **github.com/pborman/uuid**
*  -> a7fbd554da7a9eafbe5a460a421313a9fd18d988 **github.com/containerd/aufs**
* v0.5 -> v1.0.0 **github.com/gogo/protobuf**
* v1.0.0 -> v1.0.1 **github.com/opencontainers/runtime-spec**
* v1.0.0 -> v1.0.1 **github.com/opencontainers/image-spec**
*  -> db04d3cc01c8b54962a58ec7e491717d06cfcc16 **github.com/syndtr/gocapability**
*  -> 6073aff4ac61897f75895123f7e24135204a404d **github.com/opencontainers/runtime-tools**
* fcdb11ccb4389efb1b210b7ffb623ab71c5fdd60 -> cb4147076ac75738c9a7d279075a253c0cc5acbd **github.com/prometheus/procfs**
* v1.7.2 -> v1.10.1 **google.golang.org/grpc**
*  -> 73d445a93680fa1a78ae23a5839bad48f32ba1ee **github.com/ghodss/yaml**
* v0.8.0 -> f4fb1b73fb099f396a7f0036bf86aa8def4ed823 **github.com/prometheus/client_golang**
* fa8ad6fec33561be4280a8f0514318c79d7f6cb6 -> 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c **github.com/prometheus/client_model**
*  -> v0.6.0 **github.com/containernetworking/cni**
*  -> 1.0.4 **github.com/json-iterator/go**
*  -> 32f571b70023028bd57d9288c20efbcb237f3ce0 **github.com/seccomp/libseccomp-golang**
*  -> b9a0cf870f239c4a4ecfd3feb075a50e7cbe1473 **k8s.io/client-go**
*  -> 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4 **gopkg.in/inf.v0**
* 84eeaae905fa414d03e07bcd6c8d3f19e7cf180e -> cb7008ab3d8359b78c5f464cb7cf160107ad5925 **github.com/containerd/console**
*  -> v0.1.0 **github.com/google/go-cmp**
*  -> 86f080cff0914e9694068ed78d503701667c4c00 **github.com/docker/docker**
* 8fd5772bf1584597834c6f7961a530f06cbfbb87 -> 4ea375f7759c82740c893fc030bc37088d2ec098 **github.com/docker/go-metrics**
* v0.2.0-21-g9906417 -> a368813c5e648fee92e5f6c30e3944ff9d5e8895 **github.com/BurntSushi/toml**
*  -> b38e5838b7b2f2ad48e06ec4b500011976080621 **github.com/docker/distribution**
*  -> 53feefa2559fb8dfa8d81baad31be332c97d6c77 **gopkg.in/yaml.v2**
* ed1cbe1fc31f5fb2359d3a54b6330d1a097858b7 -> bcb223a061a3dd7de1a89c0b402a60f4dd9bd307 **github.com/containerd/go-runc**
*  -> 08a7655d27152912db7aaf4f983275eaf8d128ef **github.com/gogo/googleapis**
*  -> v0.7.0 **github.com/containernetworking/plugins**
*  -> f51c12702a4d776e4c1fa9b0fabab841babae631 **golang.org/x/time**
* cf279e6ac893682272b4479d4c67fd3abf878b4e -> 3e8f2ea4b190484acb976a5b378d373429639a1a **github.com/containerd/continuity**
*  -> 4a2974bf1ee960774ffd517717f1f45325af0206 **github.com/opencontainers/selinux**
*  -> 44d81051d367757e1c7c6a5a86423ece9afcf63c **github.com/google/gofuzz**
*  -> 7554cd9344cec97297fa6649b055a8c98c2a1e55 **github.com/hashicorp/errwrap**
*  -> 4a8377c547bbff4576a35b5b5bf4026d9b5aa763 **k8s.io/apiserver**
*  -> v1.10.0 **k8s.io/kubernetes**
*  -> 449fdfce4d962303d702fec724ef0ad181c92528 **github.com/docker/spdystream**
*  -> ff4f55a206334ef123e4f79bbf348980da81ca46 **github.com/emicklei/go-restful**
*  -> 49796115aa4b964c318aad4f3084fdb41e9aa067 **golang.org/x/crypto**
* 74a17296470088de3805e138d3d87c62e613dfc4 -> 69663f0bd4b60df09991c08812a60108003fa340 **github.com/opencontainers/runc**
*  -> v1.0.0 **github.com/spf13/pflag**
*  -> 5ad6cdb7538b0097d5598c7e57f0a24072adf7dc **github.com/tchap/go-patricia**
* 195bde7883f7c39ea62b0d92ab7359b5327065cb -> 89604d197083d4781071d3c65855d24ecfb0a563 **github.com/prometheus/common**
*  -> v1.0.0-rc.2 **github.com/containerd/cri**
* v0.4.4 -> v0.4.5 **github.com/Microsoft/go-winio**
*  -> 44dbf532bbf5767611f6f2a61bded572e337010a **github.com/gotestyourself/gotestyourself**
* fbfb6a11ec671efbe94ad1c12c2e98773f19e1e6 -> 3d5202aec260678c48179c56f40e6f38a095738c **github.com/containerd/fifo**