### PR TITLE
ctr: fix --mount help message

### DIFF
--- a/cmd/ctr/commands/run/run.go
+++ b/cmd/ctr/commands/run/run.go
@@ -62,7 +62,7 @@ var ContainerFlags = []cli.Flag{
 	},
 	cli.StringSliceFlag{
 		Name:  "mount",
-		Usage: "specify additional container mount (ex: type=bind,src=/tmp,dest=/host,options=rbind:ro)",
+		Usage: "specify additional container mount (ex: type=bind,src=/tmp,dst=/host,options=rbind:ro)",
 	},
 	cli.BoolFlag{
 		Name:  "net-host",


### PR DESCRIPTION
Small fix to `ctr run --mount` help message