### PR TITLE
testing: cleanup loopback devices on test skip

### DIFF
--- a/mount/lookup_test/lookup_linux_test.go
+++ b/mount/lookup_test/lookup_linux_test.go
@@ -61,10 +61,12 @@ func testLookup(t *testing.T, fsType string) {
 	}
 	if out, err := exec.Command("mkfs", "-t", fsType, deviceName).CombinedOutput(); err != nil {
 		// not fatal
+		cleanupDevice()
 		t.Skipf("could not mkfs (%s) %s: %v (out: %q)", fsType, deviceName, err, string(out))
 	}
 	if out, err := exec.Command("mount", deviceName, mnt).CombinedOutput(); err != nil {
 		// not fatal
+		cleanupDevice()
 		t.Skipf("could not mount %s: %v (out: %q)", deviceName, err, string(out))
 	}
 	defer func() {

--- a/snapshots/overlay/check_test.go
+++ b/snapshots/overlay/check_test.go
@@ -41,10 +41,12 @@ func testOverlaySupported(t testing.TB, expected bool, mkfs ...string) {
 	}
 	if out, err := exec.Command(mkfs[0], append(mkfs[1:], deviceName)...).CombinedOutput(); err != nil {
 		// not fatal
+		cleanupDevice()
 		t.Skipf("could not mkfs (%v) %s: %v (out: %q)", mkfs, deviceName, err, string(out))
 	}
 	if out, err := exec.Command("mount", deviceName, mnt).CombinedOutput(); err != nil {
 		// not fatal
+		cleanupDevice()
 		t.Skipf("could not mount %s: %v (out: %q)", deviceName, err, string(out))
 	}
 	defer func() {


### PR DESCRIPTION
Fixes a case where loopback devices wouldn't get cleaned up
when a test was being skipped

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>