### PR TITLE
Update ctr tasks list usage for quiet flag

### DIFF
--- a/cmd/ctr/commands/tasks/list.go
+++ b/cmd/ctr/commands/tasks/list.go
@@ -34,7 +34,7 @@ var listCommand = cli.Command{
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "quiet, q",
-			Usage: "print only the task id & pid",
+			Usage: "print only the task id",
 		},
 	},
 	Action: func(context *cli.Context) error {


### PR DESCRIPTION
Removed, from `ctr tasks list` help usage for quiet flag, the text `& pid` as no pid is displayed as shown in the [line](https://github.com/containerd/containerd/blob/1381f8fddc4f826e12b48d46c9def347d5aa338a/cmd/ctr/commands/tasks/list.go#L54)
