### PR TITLE
Update cri plugin to v1.0.0.

### DIFF
--- a/script/setup/install-critools
+++ b/script/setup/install-critools
@@ -21,7 +21,7 @@
 set -eu -o pipefail
 
 go get -u github.com/onsi/ginkgo/ginkgo
-CRITEST_COMMIT=207e773f72fde8d8aed1447692d8f800a6686d6c
+CRITEST_COMMIT=f37a5a1edb69ee742c6e42c57413fe6b63788085
 go get -d github.com/kubernetes-incubator/cri-tools/...
 cd $GOPATH/src/github.com/kubernetes-incubator/cri-tools
 git checkout $CRITEST_COMMIT

--- a/vendor.conf
+++ b/vendor.conf
@@ -44,7 +44,7 @@ github.com/gotestyourself/gotestyourself 44dbf532bbf5767611f6f2a61bded572e337010
 github.com/google/go-cmp v0.1.0
 
 # cri dependencies
-github.com/containerd/cri v1.0.0-rc.2
+github.com/containerd/cri v1.0.0
 github.com/containerd/go-cni f2d7272f12d045b16ed924f50e91f9f9cecc55a7
 github.com/blang/semver v3.1.0
 github.com/containernetworking/cni v0.6.0

--- a/vendor/github.com/containerd/cri/README.md
+++ b/vendor/github.com/containerd/cri/README.md
@@ -121,7 +121,7 @@ sudo containerd
 ```
 2. From the Kubernetes project directory startup a local cluster using `containerd`:
 ```bash
-CONTAINER_RUNTIME=remote CONTAINER_RUNTIME_ENDPOINT='/run/containerd/containerd.sock' ./hack/local-up-cluster.sh
+CONTAINER_RUNTIME=remote CONTAINER_RUNTIME_ENDPOINT='unix:///run/containerd/containerd.sock' ./hack/local-up-cluster.sh
 ```
 ### Test
 See [here](./docs/testing.md) for information about test.

--- a/vendor/github.com/containerd/cri/vendor.conf
+++ b/vendor/github.com/containerd/cri/vendor.conf
@@ -4,11 +4,11 @@ github.com/boltdb/bolt e9cf4fae01b5a8ff89d0ec6b32f0d9c9f79aefdd
 github.com/BurntSushi/toml a368813c5e648fee92e5f6c30e3944ff9d5e8895
 github.com/containerd/cgroups fe281dd265766145e943a034aa41086474ea6130
 github.com/containerd/console cb7008ab3d8359b78c5f464cb7cf160107ad5925
-github.com/containerd/containerd v1.1.0-rc.1
+github.com/containerd/containerd 1381f8fddc4f826e12b48d46c9def347d5aa338a
 github.com/containerd/continuity 3e8f2ea4b190484acb976a5b378d373429639a1a
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c
-github.com/containerd/go-runc bcb223a061a3dd7de1a89c0b402a60f4dd9bd307
 github.com/containerd/go-cni f2d7272f12d045b16ed924f50e91f9f9cecc55a7
+github.com/containerd/go-runc bcb223a061a3dd7de1a89c0b402a60f4dd9bd307
 github.com/containerd/typeurl f6943554a7e7e88b3c14aad190bf05932da84788
 github.com/containernetworking/cni v0.6.0
 github.com/containernetworking/plugins v0.7.0
@@ -23,7 +23,8 @@ github.com/docker/spdystream 449fdfce4d962303d702fec724ef0ad181c92528
 github.com/emicklei/go-restful ff4f55a206334ef123e4f79bbf348980da81ca46
 github.com/ghodss/yaml 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 github.com/godbus/dbus c7fdd8b5cd55e87b4e1f4e372cdb1db61dd6c66f
-github.com/gogo/protobuf v0.5
+github.com/gogo/googleapis 08a7655d27152912db7aaf4f983275eaf8d128ef
+github.com/gogo/protobuf v1.0.0
 github.com/golang/glog 44145f04b68cf362d9c4df2182967c2275eaefed
 github.com/golang/protobuf 1643683e1b54a9e88ad26d98f81400c8c9d9f4f9
 github.com/google/gofuzz 44d81051d367757e1c7c6a5a86423ece9afcf63c
@@ -54,14 +55,14 @@ github.com/stretchr/testify v1.1.4
 github.com/syndtr/gocapability db04d3cc01c8b54962a58ec7e491717d06cfcc16
 github.com/tchap/go-patricia 5ad6cdb7538b0097d5598c7e57f0a24072adf7dc
 github.com/urfave/cli 7bc6a0acffa589f415f88aca16cc1de5ffd66f9c
+golang.org/x/crypto 49796115aa4b964c318aad4f3084fdb41e9aa067
 golang.org/x/net 7dcfb8076726a3fdd9353b6b8a1f1b6be6811bd6
 golang.org/x/sync 450f422ab23cf9881c94e2db30cac0eb1b7cf80c
 golang.org/x/sys 314a259e304ff91bd6985da2a7149bbf91237993 https://github.com/golang/sys
 golang.org/x/text 19e51611da83d6be54ddafce4a4af510cb3e9ea4
 golang.org/x/time f51c12702a4d776e4c1fa9b0fabab841babae631
-golang.org/x/crypto 49796115aa4b964c318aad4f3084fdb41e9aa067
 google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
-google.golang.org/grpc v1.7.4
+google.golang.org/grpc v1.10.1
 gopkg.in/inf.v0 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 gopkg.in/yaml.v2 53feefa2559fb8dfa8d81baad31be332c97d6c77
 k8s.io/api 7e796de92438aede7cb5d6bcf6c10f4fa65db560


### PR DESCRIPTION
Update `cri` to v1.0.0.

`cri` v1.0.0 release note https://github.com/containerd/cri/releases/tag/v1.0.0.

Signed-off-by: Lantao Liu <lantaol@google.com>