### PR TITLE
Remove host and image architecure check

### DIFF
--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -146,7 +146,6 @@ type matcher struct {
 func (m *matcher) Match(platform specs.Platform) bool {
 	normalized := Normalize(platform)
 	return m.OS == normalized.OS &&
-		m.Architecture == normalized.Architecture &&
 		m.Variant == normalized.Variant
 }
 


### PR DESCRIPTION
This check prevents failure when unpacking of images 
that were cross-built on x86 for non-x86 platforms.

Fixes: #2312

Signed-off-by: Nitesh Konkar <niteshkonkar@in.ibm.com>