### PR TITLE
cmd/snapshots: add gc.root to created snapshots

### DIFF
--- a/cmd/ctr/commands/snapshots/snapshots.go
+++ b/cmd/ctr/commands/snapshots/snapshots.go
@@ -304,7 +304,11 @@ var prepareCommand = cli.Command{
 		defer cancel()
 
 		snapshotter := client.SnapshotService(context.GlobalString("snapshotter"))
-		mounts, err := snapshotter.Prepare(ctx, key, parent)
+		labels := map[string]string{
+			"containerd.io/gc.root": time.Now().UTC().Format(time.RFC3339),
+		}
+
+		mounts, err := snapshotter.Prepare(ctx, key, parent, snapshots.WithLabels(labels))
 		if err != nil {
 			return err
 		}
@@ -404,7 +408,10 @@ var commitCommand = cli.Command{
 		}
 		defer cancel()
 		snapshotter := client.SnapshotService(context.GlobalString("snapshotter"))
-		return snapshotter.Commit(ctx, key, active)
+		labels := map[string]string{
+			"containerd.io/gc.root": time.Now().UTC().Format(time.RFC3339),
+		}
+		return snapshotter.Commit(ctx, key, active, snapshots.WithLabels(labels))
 	},
 }
 


### PR DESCRIPTION
This adds gc.root label to snapshots created with prepare and commit via
the CLI. WIthout this, created snapshots get immediately garbage
collected. There may be a better solution but this seems to be a solid
stop gap.

We may also need to add more functionality around snapshot labeling for
the CLI but current use cases are unclear.

Signed-off-by: Stephen J Day <stevvooe@gmail.com>