### PR TITLE
Use user-specific temp directory if set

### DIFF
--- a/archive/tar.go
+++ b/archive/tar.go
@@ -199,7 +199,7 @@ func applyNaive(ctx context.Context, root string, tr *tar.Reader, options ApplyO
 				basename := filepath.Base(hdr.Name)
 				aufsHardlinks[basename] = hdr
 				if aufsTempdir == "" {
-					if aufsTempdir, err = ioutil.TempDir("", "dockerplnk"); err != nil {
+					if aufsTempdir, err = ioutil.TempDir(os.Getenv("XDG_RUNTIME_DIR"), "dockerplnk"); err != nil {
 						return 0, err
 					}
 					defer os.RemoveAll(aufsTempdir)

--- a/cmd/ctr/commands/content/content.go
+++ b/cmd/ctr/commands/content/content.go
@@ -506,7 +506,7 @@ var (
 )
 
 func edit(rd io.Reader) (io.ReadCloser, error) {
-	tmp, err := ioutil.TempFile("", "edit-")
+	tmp, err := ioutil.TempFile(os.Getenv("XDG_RUNTIME_DIR"), "edit-")
 	if err != nil {
 		return nil, err
 	}

--- a/contrib/apparmor/apparmor.go
+++ b/contrib/apparmor/apparmor.go
@@ -53,7 +53,7 @@ func WithDefaultProfile(name string) oci.SpecOpts {
 		if err != nil {
 			return err
 		}
-		f, err := ioutil.TempFile("", p.Name)
+		f, err := ioutil.TempFile(os.Getenv("XDG_RUNTIME_DIR"), p.Name)
 		if err != nil {
 			return err
 		}

--- a/mount/temp.go
+++ b/mount/temp.go
@@ -25,7 +25,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var tempMountLocation = os.TempDir()
+var tempMountLocation = getTempDir()
 
 // WithTempMount mounts the provided mounts to a temp dir, and pass the temp dir to f.
 // The mounts are valid during the call to the f.
@@ -63,4 +63,11 @@ func WithTempMount(ctx context.Context, mounts []Mount, f func(root string) erro
 		return errors.Wrapf(uerr, "failed to mount %s", root)
 	}
 	return errors.Wrapf(f(root), "mount callback failed on %s", root)
+}
+
+func getTempDir() string {
+	if xdg := os.Getenv("XDG_RUNTIME_DIR"); xdg != "" {
+		return xdg
+	}
+	return os.TempDir()
 }

--- a/rootfs/init.go
+++ b/rootfs/init.go
@@ -75,7 +75,7 @@ func createInitLayer(ctx context.Context, parent, initName string, initFn func(s
 	// TODO: ensure not exist error once added to snapshot package
 
 	// Create tempdir
-	td, err := ioutil.TempDir("", "create-init-")
+	td, err := ioutil.TempDir(os.Getenv("XDG_RUNTIME_DIR"), "create-init-")
 	if err != nil {
 		return "", err
 	}

--- a/services/tasks/local.go
+++ b/services/tasks/local.go
@@ -114,7 +114,7 @@ func (l *local) Create(ctx context.Context, r *api.CreateTaskRequest, _ ...grpc.
 		err            error
 	)
 	if r.Checkpoint != nil {
-		checkpointPath, err = ioutil.TempDir("", "ctrd-checkpoint")
+		checkpointPath, err = ioutil.TempDir(os.Getenv("XDG_RUNTIME_DIR"), "ctrd-checkpoint")
 		if err != nil {
 			return nil, err
 		}
@@ -450,7 +450,7 @@ func (l *local) Checkpoint(ctx context.Context, r *api.CheckpointTaskRequest, _ 
 	if err != nil {
 		return nil, err
 	}
-	image, err := ioutil.TempDir("", "ctd-checkpoint")
+	image, err := ioutil.TempDir(os.Getenv("XDG_RUNTIME_DIR"), "ctd-checkpoint")
 	if err != nil {
 		return nil, errdefs.ToGRPC(err)
 	}


### PR DESCRIPTION
This allows non-privileged users to use containerd. This is part of a
larger track of work integrating containerd into Cloudfoundry's garden
with support for rootless.

Also, runc already supports the `XDG_RUNTIME_DIR` so supporting the variable here as well makes sense.

Here is a link to our tracker on the containerd work: https://www.pivotaltracker.com/n/projects/1158420/search?q=label%3A%22containerd%22

[#156343575]

Signed-off-by: Claudia Beresford <cberesford@pivotal.io>