### PR TITLE
Add missing return statement on pull unpack

### DIFF
--- a/client.go
+++ b/client.go
@@ -366,7 +366,7 @@ func (c *Client) Pull(ctx context.Context, ref string, opts ...RemoteOpt) (Image
 	}
 	if pullCtx.Unpack {
 		if err := img.Unpack(ctx, pullCtx.Snapshotter); err != nil {
-			errors.Wrapf(err, "failed to unpack image on snapshotter %s", pullCtx.Snapshotter)
+			return nil, errors.Wrapf(err, "failed to unpack image on snapshotter %s", pullCtx.Snapshotter)
 		}
 	}
 	return img, nil


### PR DESCRIPTION
The error return is missing. This went out in 1.1 but currently the cri plugin and ctr tool do not use the unpack option. Marking this for backport but not critical.