### PR TITLE
Type alias spec in oci package

### DIFF
--- a/container.go
+++ b/container.go
@@ -28,9 +28,9 @@ import (
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/oci"
 	"github.com/containerd/typeurl"
 	prototypes "github.com/gogo/protobuf/types"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 )
 
@@ -45,7 +45,7 @@ type Container interface {
 	// NewTask creates a new task based on the container metadata
 	NewTask(context.Context, cio.Creator, ...NewTaskOpts) (Task, error)
 	// Spec returns the OCI runtime specification
-	Spec(context.Context) (*specs.Spec, error)
+	Spec(context.Context) (*oci.Spec, error)
 	// Task returns the current task for the container
 	//
 	// If cio.Attach options are passed the client will reattach to the IO for the running
@@ -126,12 +126,12 @@ func (c *container) SetLabels(ctx context.Context, labels map[string]string) (ma
 }
 
 // Spec returns the current OCI specification for the container
-func (c *container) Spec(ctx context.Context) (*specs.Spec, error) {
+func (c *container) Spec(ctx context.Context) (*oci.Spec, error) {
 	r, err := c.get(ctx)
 	if err != nil {
 		return nil, err
 	}
-	var s specs.Spec
+	var s oci.Spec
 	if err := json.Unmarshal(r.Spec.Value, &s); err != nil {
 		return nil, err
 	}

--- a/container_opts.go
+++ b/container_opts.go
@@ -26,7 +26,6 @@ import (
 	"github.com/containerd/typeurl"
 	"github.com/gogo/protobuf/types"
 	"github.com/opencontainers/image-spec/identity"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 )
 
@@ -196,7 +195,7 @@ func WithNewSpec(opts ...oci.SpecOpts) NewContainerOpts {
 }
 
 // WithSpec sets the provided spec on the container
-func WithSpec(s *specs.Spec, opts ...oci.SpecOpts) NewContainerOpts {
+func WithSpec(s *oci.Spec, opts ...oci.SpecOpts) NewContainerOpts {
 	return func(ctx context.Context, client *Client, c *containers.Container) error {
 		for _, o := range opts {
 			if err := o(ctx, client, c, s); err != nil {

--- a/oci/spec.go
+++ b/oci/spec.go
@@ -23,9 +23,13 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
+// Spec is a type alias to the OCI runtime spec to allow third part SpecOpts
+// to be created without the "issues" with go vendoring and package imports
+type Spec = specs.Spec
+
 // GenerateSpec will generate a default spec from the provided image
 // for use as a containerd container
-func GenerateSpec(ctx context.Context, client Client, c *containers.Container, opts ...SpecOpts) (*specs.Spec, error) {
+func GenerateSpec(ctx context.Context, client Client, c *containers.Container, opts ...SpecOpts) (*Spec, error) {
 	s, err := createDefaultSpec(ctx, c.ID)
 	if err != nil {
 		return nil, err

--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -25,11 +25,11 @@ import (
 )
 
 // SpecOpts sets spec specific information to a newly generated OCI spec
-type SpecOpts func(context.Context, Client, *containers.Container, *specs.Spec) error
+type SpecOpts func(context.Context, Client, *containers.Container, *Spec) error
 
 // Compose converts a sequence of spec operations into a single operation
 func Compose(opts ...SpecOpts) SpecOpts {
-	return func(ctx context.Context, client Client, c *containers.Container, s *specs.Spec) error {
+	return func(ctx context.Context, client Client, c *containers.Container, s *Spec) error {
 		for _, o := range opts {
 			if err := o(ctx, client, c, s); err != nil {
 				return err
@@ -40,7 +40,7 @@ func Compose(opts ...SpecOpts) SpecOpts {
 }
 
 // setProcess sets Process to empty if unset
-func setProcess(s *specs.Spec) {
+func setProcess(s *Spec) {
 	if s.Process == nil {
 		s.Process = &specs.Process{}
 	}
@@ -48,7 +48,7 @@ func setProcess(s *specs.Spec) {
 
 // WithProcessArgs replaces the args on the generated spec
 func WithProcessArgs(args ...string) SpecOpts {
-	return func(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec) error {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 		setProcess(s)
 		s.Process.Args = args
 		return nil
@@ -57,7 +57,7 @@ func WithProcessArgs(args ...string) SpecOpts {
 
 // WithProcessCwd replaces the current working directory on the generated spec
 func WithProcessCwd(cwd string) SpecOpts {
-	return func(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec) error {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 		setProcess(s)
 		s.Process.Cwd = cwd
 		return nil
@@ -66,7 +66,7 @@ func WithProcessCwd(cwd string) SpecOpts {
 
 // WithHostname sets the container's hostname
 func WithHostname(name string) SpecOpts {
-	return func(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec) error {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 		s.Hostname = name
 		return nil
 	}
@@ -74,7 +74,7 @@ func WithHostname(name string) SpecOpts {
 
 // WithEnv appends environment variables
 func WithEnv(environmentVariables []string) SpecOpts {
-	return func(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec) error {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 		if len(environmentVariables) > 0 {
 			setProcess(s)
 			s.Process.Env = replaceOrAppendEnvValues(s.Process.Env, environmentVariables)
@@ -85,7 +85,7 @@ func WithEnv(environmentVariables []string) SpecOpts {
 
 // WithMounts appends mounts
 func WithMounts(mounts []specs.Mount) SpecOpts {
-	return func(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec) error {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 		s.Mounts = append(s.Mounts, mounts...)
 		return nil
 	}

--- a/oci/spec_opts_test.go
+++ b/oci/spec_opts_test.go
@@ -25,7 +25,7 @@ import (
 func TestWithEnv(t *testing.T) {
 	t.Parallel()
 
-	s := specs.Spec{}
+	s := Spec{}
 	s.Process = &specs.Process{
 		Env: []string{"DEFAULT=test"},
 	}
@@ -59,7 +59,7 @@ func TestWithMounts(t *testing.T) {
 
 	t.Parallel()
 
-	s := specs.Spec{
+	s := Spec{
 		Mounts: []specs.Mount{
 			{
 				Source:      "default-source",

--- a/oci/spec_opts_unix.go
+++ b/oci/spec_opts_unix.go
@@ -42,7 +42,7 @@ import (
 
 // WithTTY sets the information on the spec as well as the environment variables for
 // using a TTY
-func WithTTY(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec) error {
+func WithTTY(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 	setProcess(s)
 	s.Process.Terminal = true
 	s.Process.Env = append(s.Process.Env, "TERM=xterm")
@@ -50,21 +50,21 @@ func WithTTY(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec
 }
 
 // setRoot sets Root to empty if unset
-func setRoot(s *specs.Spec) {
+func setRoot(s *Spec) {
 	if s.Root == nil {
 		s.Root = &specs.Root{}
 	}
 }
 
 // setLinux sets Linux to empty if unset
-func setLinux(s *specs.Spec) {
+func setLinux(s *Spec) {
 	if s.Linux == nil {
 		s.Linux = &specs.Linux{}
 	}
 }
 
 // setCapabilities sets Linux Capabilities to empty if unset
-func setCapabilities(s *specs.Spec) {
+func setCapabilities(s *Spec) {
 	setProcess(s)
 	if s.Process.Capabilities == nil {
 		s.Process.Capabilities = &specs.LinuxCapabilities{}
@@ -73,7 +73,7 @@ func setCapabilities(s *specs.Spec) {
 
 // WithHostNamespace allows a task to run inside the host's linux namespace
 func WithHostNamespace(ns specs.LinuxNamespaceType) SpecOpts {
-	return func(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec) error {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 		setLinux(s)
 		for i, n := range s.Linux.Namespaces {
 			if n.Type == ns {
@@ -88,7 +88,7 @@ func WithHostNamespace(ns specs.LinuxNamespaceType) SpecOpts {
 // WithLinuxNamespace uses the passed in namespace for the spec. If a namespace of the same type already exists in the
 // spec, the existing namespace is replaced by the one provided.
 func WithLinuxNamespace(ns specs.LinuxNamespace) SpecOpts {
-	return func(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec) error {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 		setLinux(s)
 		for i, n := range s.Linux.Namespaces {
 			if n.Type == ns.Type {
@@ -106,7 +106,7 @@ func WithLinuxNamespace(ns specs.LinuxNamespace) SpecOpts {
 
 // WithImageConfig configures the spec to from the configuration of an Image
 func WithImageConfig(image Image) SpecOpts {
-	return func(ctx context.Context, client Client, c *containers.Container, s *specs.Spec) error {
+	return func(ctx context.Context, client Client, c *containers.Container, s *Spec) error {
 		ic, err := image.Config(ctx)
 		if err != nil {
 			return err
@@ -148,7 +148,7 @@ func WithImageConfig(image Image) SpecOpts {
 
 // WithRootFSPath specifies unmanaged rootfs path.
 func WithRootFSPath(path string) SpecOpts {
-	return func(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec) error {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 		setRoot(s)
 		s.Root.Path = path
 		// Entrypoint is not set here (it's up to caller)
@@ -158,7 +158,7 @@ func WithRootFSPath(path string) SpecOpts {
 
 // WithRootFSReadonly sets specs.Root.Readonly to true
 func WithRootFSReadonly() SpecOpts {
-	return func(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec) error {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 		setRoot(s)
 		s.Root.Readonly = true
 		return nil
@@ -166,14 +166,14 @@ func WithRootFSReadonly() SpecOpts {
 }
 
 // WithNoNewPrivileges sets no_new_privileges on the process for the container
-func WithNoNewPrivileges(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec) error {
+func WithNoNewPrivileges(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 	setProcess(s)
 	s.Process.NoNewPrivileges = true
 	return nil
 }
 
 // WithHostHostsFile bind-mounts the host's /etc/hosts into the container as readonly
-func WithHostHostsFile(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec) error {
+func WithHostHostsFile(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 	s.Mounts = append(s.Mounts, specs.Mount{
 		Destination: "/etc/hosts",
 		Type:        "bind",
@@ -184,7 +184,7 @@ func WithHostHostsFile(_ context.Context, _ Client, _ *containers.Container, s *
 }
 
 // WithHostResolvconf bind-mounts the host's /etc/resolv.conf into the container as readonly
-func WithHostResolvconf(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec) error {
+func WithHostResolvconf(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 	s.Mounts = append(s.Mounts, specs.Mount{
 		Destination: "/etc/resolv.conf",
 		Type:        "bind",
@@ -195,7 +195,7 @@ func WithHostResolvconf(_ context.Context, _ Client, _ *containers.Container, s 
 }
 
 // WithHostLocaltime bind-mounts the host's /etc/localtime into the container as readonly
-func WithHostLocaltime(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec) error {
+func WithHostLocaltime(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 	s.Mounts = append(s.Mounts, specs.Mount{
 		Destination: "/etc/localtime",
 		Type:        "bind",
@@ -208,7 +208,7 @@ func WithHostLocaltime(_ context.Context, _ Client, _ *containers.Container, s *
 // WithUserNamespace sets the uid and gid mappings for the task
 // this can be called multiple times to add more mappings to the generated spec
 func WithUserNamespace(container, host, size uint32) SpecOpts {
-	return func(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec) error {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 		var hasUserns bool
 		setLinux(s)
 		for _, ns := range s.Linux.Namespaces {
@@ -235,7 +235,7 @@ func WithUserNamespace(container, host, size uint32) SpecOpts {
 
 // WithCgroup sets the container's cgroup path
 func WithCgroup(path string) SpecOpts {
-	return func(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec) error {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 		setLinux(s)
 		s.Linux.CgroupsPath = path
 		return nil
@@ -245,7 +245,7 @@ func WithCgroup(path string) SpecOpts {
 // WithNamespacedCgroup uses the namespace set on the context to create a
 // root directory for containers in the cgroup with the id as the subcgroup
 func WithNamespacedCgroup() SpecOpts {
-	return func(ctx context.Context, _ Client, c *containers.Container, s *specs.Spec) error {
+	return func(ctx context.Context, _ Client, c *containers.Container, s *Spec) error {
 		namespace, err := namespaces.NamespaceRequired(ctx)
 		if err != nil {
 			return err
@@ -260,7 +260,7 @@ func WithNamespacedCgroup() SpecOpts {
 // It accepts a valid user string in OCI Image Spec v1.0.0:
 //   user, uid, user:group, uid:gid, uid:group, user:gid
 func WithUser(userstr string) SpecOpts {
-	return func(ctx context.Context, client Client, c *containers.Container, s *specs.Spec) error {
+	return func(ctx context.Context, client Client, c *containers.Container, s *Spec) error {
 		setProcess(s)
 		parts := strings.Split(userstr, ":")
 		switch len(parts) {
@@ -338,7 +338,7 @@ func WithUser(userstr string) SpecOpts {
 
 // WithUIDGID allows the UID and GID for the Process to be set
 func WithUIDGID(uid, gid uint32) SpecOpts {
-	return func(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec) error {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 		setProcess(s)
 		s.Process.User.UID = uid
 		s.Process.User.GID = gid
@@ -351,7 +351,7 @@ func WithUIDGID(uid, gid uint32) SpecOpts {
 // or uid is not found in /etc/passwd, it sets gid to be the same with
 // uid, and not returns error.
 func WithUserID(uid uint32) SpecOpts {
-	return func(ctx context.Context, client Client, c *containers.Container, s *specs.Spec) (err error) {
+	return func(ctx context.Context, client Client, c *containers.Container, s *Spec) (err error) {
 		setProcess(s)
 		if c.Snapshotter == "" && c.SnapshotKey == "" {
 			if !isRootfsAbs(s.Root.Path) {
@@ -404,7 +404,7 @@ func WithUserID(uid uint32) SpecOpts {
 // does not exist, or the username is not found in /etc/passwd,
 // it returns error.
 func WithUsername(username string) SpecOpts {
-	return func(ctx context.Context, client Client, c *containers.Container, s *specs.Spec) (err error) {
+	return func(ctx context.Context, client Client, c *containers.Container, s *Spec) (err error) {
 		setProcess(s)
 		if c.Snapshotter == "" && c.SnapshotKey == "" {
 			if !isRootfsAbs(s.Root.Path) {
@@ -445,7 +445,7 @@ func WithUsername(username string) SpecOpts {
 
 // WithCapabilities sets Linux capabilities on the process
 func WithCapabilities(caps []string) SpecOpts {
-	return func(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec) error {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 		setCapabilities(s)
 
 		s.Process.Capabilities.Bounding = caps
@@ -518,7 +518,7 @@ func isRootfsAbs(root string) bool {
 
 // WithMaskedPaths sets the masked paths option
 func WithMaskedPaths(paths []string) SpecOpts {
-	return func(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec) error {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 		setLinux(s)
 		s.Linux.MaskedPaths = paths
 		return nil
@@ -527,7 +527,7 @@ func WithMaskedPaths(paths []string) SpecOpts {
 
 // WithReadonlyPaths sets the read only paths option
 func WithReadonlyPaths(paths []string) SpecOpts {
-	return func(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec) error {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 		setLinux(s)
 		s.Linux.ReadonlyPaths = paths
 		return nil
@@ -535,7 +535,7 @@ func WithReadonlyPaths(paths []string) SpecOpts {
 }
 
 // WithWriteableSysfs makes any sysfs mounts writeable
-func WithWriteableSysfs(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec) error {
+func WithWriteableSysfs(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 	for i, m := range s.Mounts {
 		if m.Type == "sysfs" {
 			var options []string
@@ -552,7 +552,7 @@ func WithWriteableSysfs(_ context.Context, _ Client, _ *containers.Container, s 
 }
 
 // WithWriteableCgroupfs makes any cgroup mounts writeable
-func WithWriteableCgroupfs(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec) error {
+func WithWriteableCgroupfs(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 	for i, m := range s.Mounts {
 		if m.Type == "cgroup" {
 			var options []string
@@ -570,7 +570,7 @@ func WithWriteableCgroupfs(_ context.Context, _ Client, _ *containers.Container,
 
 // WithSelinuxLabel sets the process SELinux label
 func WithSelinuxLabel(label string) SpecOpts {
-	return func(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec) error {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 		setProcess(s)
 		s.Process.SelinuxLabel = label
 		return nil
@@ -579,7 +579,7 @@ func WithSelinuxLabel(label string) SpecOpts {
 
 // WithApparmorProfile sets the Apparmor profile for the process
 func WithApparmorProfile(profile string) SpecOpts {
-	return func(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec) error {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 		setProcess(s)
 		s.Process.ApparmorProfile = profile
 		return nil
@@ -587,7 +587,7 @@ func WithApparmorProfile(profile string) SpecOpts {
 }
 
 // WithSeccompUnconfined clears the seccomp profile
-func WithSeccompUnconfined(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec) error {
+func WithSeccompUnconfined(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 	setLinux(s)
 	s.Linux.Seccomp = nil
 	return nil

--- a/oci/spec_opts_windows.go
+++ b/oci/spec_opts_windows.go
@@ -32,7 +32,7 @@ import (
 
 // WithImageConfig configures the spec to from the configuration of an Image
 func WithImageConfig(image Image) SpecOpts {
-	return func(ctx context.Context, client Client, _ *containers.Container, s *specs.Spec) error {
+	return func(ctx context.Context, client Client, _ *containers.Container, s *Spec) error {
 		setProcess(s)
 		ic, err := image.Config(ctx)
 		if err != nil {
@@ -67,7 +67,7 @@ func WithImageConfig(image Image) SpecOpts {
 // WithTTY sets the information on the spec as well as the environment variables for
 // using a TTY
 func WithTTY(width, height int) SpecOpts {
-	return func(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec) error {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 		setProcess(s)
 		s.Process.Terminal = true
 		if s.Process.ConsoleSize == nil {
@@ -81,7 +81,7 @@ func WithTTY(width, height int) SpecOpts {
 
 // WithUsername sets the username on the process
 func WithUsername(username string) SpecOpts {
-	return func(ctx context.Context, client Client, c *containers.Container, s *specs.Spec) error {
+	return func(ctx context.Context, client Client, c *containers.Container, s *Spec) error {
 		setProcess(s)
 		s.Process.User.Username = username
 		return nil

--- a/oci/spec_unix.go
+++ b/oci/spec_unix.go
@@ -76,12 +76,12 @@ func defaultNamespaces() []specs.LinuxNamespace {
 	}
 }
 
-func createDefaultSpec(ctx context.Context, id string) (*specs.Spec, error) {
+func createDefaultSpec(ctx context.Context, id string) (*Spec, error) {
 	ns, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {
 		return nil, err
 	}
-	s := &specs.Spec{
+	s := &Spec{
 		Version: specs.Version,
 		Root: &specs.Root{
 			Path: defaultRootfsPath,

--- a/oci/spec_windows.go
+++ b/oci/spec_windows.go
@@ -22,8 +22,8 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-func createDefaultSpec(ctx context.Context, id string) (*specs.Spec, error) {
-	return &specs.Spec{
+func createDefaultSpec(ctx context.Context, id string) (*Spec, error) {
+	return &Spec{
 		Version: specs.Version,
 		Root:    &specs.Root{},
 		Process: &specs.Process{


### PR DESCRIPTION
This allows Go to build third party packages correctly without vendoring
issues what want to create their own SpecOpts.

Fixes #2289

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>