### PR TITLE
fix RUNC.md vs vendor.conf mismatch

### DIFF
--- a/RUNC.md
+++ b/RUNC.md
@@ -1,8 +1,6 @@
 containerd is built with OCI support and with support for advanced features provided by [runc](https://github.com/opencontainers/runc).
 
-We depend on a specific `runc` version when dealing with advanced features.  You should have a specific runc build for development.  The current supported runc commit is:
-
-RUNC_COMMIT = a618ab5a0186905949ee463dbb762c3d23e12a80
+We depend on a specific `runc` version when dealing with advanced features.  You should have a specific runc build for development.  The current supported runc commit is described in [`vendor.conf`](vendor.conf). Please refer to the line that starts with `github.com/opencontainers/runc`.
 
 For more information on how to clone and build runc see the runc Building [documentation](https://github.com/opencontainers/runc#building).
 


### PR DESCRIPTION
Actually we have been testing containerd with the runc version that is defined
in vendor.conf rather than the one defined in RUNC.md. (`script/setup/install-runc`, https://github.com/containerd/containerd/pull/1957#discussion_r165016025).

This commit makes sure that the revision defined in vendor.conf is always the desired one.

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>