### PR TITLE
oci/spec_unix: add cgroup mount by default

### DIFF
--- a/oci/spec_unix.go
+++ b/oci/spec_unix.go
@@ -145,6 +145,12 @@ func createDefaultSpec(ctx context.Context, id string) (*specs.Spec, error) {
 				Options:     []string{"nosuid", "noexec", "nodev", "ro"},
 			},
 			{
+				Destination: "/sys/fs/cgroup",
+				Type:        "cgroup",
+				Source:      "cgroup",
+				Options:     []string{"nosuid", "noexec", "nodev", "ro"},
+			},
+			{
 				Destination: "/run",
 				Type:        "tmpfs",
 				Source:      "tmpfs",

--- a/oci/spec_unix_test.go
+++ b/oci/spec_unix_test.go
@@ -168,9 +168,6 @@ func TestWithPrivileged(t *testing.T) {
 
 	s, err := GenerateSpec(ctx, nil, &containers.Container{ID: t.Name()},
 		WithCapabilities(nil),
-		WithMounts([]specs.Mount{
-			{Type: "cgroup", Destination: "/sys/fs/cgroup", Options: []string{"ro"}},
-		}),
 		WithPrivileged,
 	)
 	if err != nil {


### PR DESCRIPTION
By default, the /sys/fs/cgroup mount can provide visibility about resource inside the container, like memory/cpu and so on.

Signed-off-by: Wei Fu <fhfuwei@163.com>