### PR TITLE
Rename Runtime to PlatformRuntime

### DIFF
--- a/linux/runtime.go
+++ b/linux/runtime.go
@@ -79,7 +79,7 @@ func init() {
 	})
 }
 
-var _ = (runtime.Runtime)(&Runtime{})
+var _ = (runtime.PlatformRuntime)(&Runtime{})
 
 // Config options for the runtime
 type Config struct {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -53,9 +53,9 @@ type Exit struct {
 	Timestamp time.Time
 }
 
-// Runtime is responsible for the creation of containers for a certain platform,
-// arch, or custom usage.
-type Runtime interface {
+// PlatformRuntime is responsible for the creation and management of
+// tasks and processes for a platform.
+type PlatformRuntime interface {
 	// ID of the runtime
 	ID() string
 	// Create creates a task with the provided id and options.

--- a/services/tasks/local.go
+++ b/services/tasks/local.go
@@ -79,14 +79,14 @@ func initFunc(ic *plugin.InitContext) (interface{}, error) {
 		return nil, err
 	}
 	cs := m.(*metadata.DB).ContentStore()
-	runtimes := make(map[string]runtime.Runtime)
+	runtimes := make(map[string]runtime.PlatformRuntime)
 	for _, rr := range rt {
 		ri, err := rr.Instance()
 		if err != nil {
 			log.G(ic.Context).WithError(err).Warn("could not load runtime instance due to initialization error")
 			continue
 		}
-		r := ri.(runtime.Runtime)
+		r := ri.(runtime.PlatformRuntime)
 		runtimes[r.ID()] = r
 	}
 
@@ -102,7 +102,7 @@ func initFunc(ic *plugin.InitContext) (interface{}, error) {
 }
 
 type local struct {
-	runtimes  map[string]runtime.Runtime
+	runtimes  map[string]runtime.PlatformRuntime
 	db        *metadata.DB
 	store     content.Store
 	publisher events.Publisher
@@ -625,7 +625,7 @@ func (l *local) getTaskFromContainer(ctx context.Context, container *containers.
 	return t, nil
 }
 
-func (l *local) getRuntime(name string) (runtime.Runtime, error) {
+func (l *local) getRuntime(name string) (runtime.PlatformRuntime, error) {
 	runtime, ok := l.runtimes[name]
 	if !ok {
 		return nil, status.Errorf(codes.NotFound, "unknown runtime %q", name)

--- a/windows/runtime.go
+++ b/windows/runtime.go
@@ -53,7 +53,7 @@ var (
 	pluginID = fmt.Sprintf("%s.%s", plugin.RuntimePlugin, runtimeName)
 )
 
-var _ = (runtime.Runtime)(&windowsRuntime{})
+var _ = (runtime.PlatformRuntime)(&windowsRuntime{})
 
 func init() {
 	plugin.Register(&plugin.Registration{


### PR DESCRIPTION
This renames the runtime interface to PlatformRuntime to denote the
layer at which the runtime is being abstracted.  This should be used to
abstract different platforms that vary greatly and do not have full
compat with OCI based binary runtimes.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>