### PR TITLE
Reference new location for images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![banner](/docs/images/containerd-dark.png?raw=true)
+![banner](/docs/static/img/containerd-dark.png?raw=true)
 
 [![GoDoc](https://godoc.org/github.com/containerd/containerd?status.svg)](https://godoc.org/github.com/containerd/containerd)
 [![Build Status](https://travis-ci.org/containerd/containerd.svg?branch=master)](https://travis-ci.org/containerd/containerd)


### PR DESCRIPTION
containerd images moved based on website dir layout changes.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>