### PR TITLE
Update cri plugin to v1.0.1.

### DIFF
--- a/script/setup/install-critools
+++ b/script/setup/install-critools
@@ -21,7 +21,7 @@
 set -eu -o pipefail
 
 go get -u github.com/onsi/ginkgo/ginkgo
-CRITEST_COMMIT=f37a5a1edb69ee742c6e42c57413fe6b63788085
+CRITEST_COMMIT=v1.0.0-beta.1
 go get -d github.com/kubernetes-incubator/cri-tools/...
 cd $GOPATH/src/github.com/kubernetes-incubator/cri-tools
 git checkout $CRITEST_COMMIT

--- a/vendor.conf
+++ b/vendor.conf
@@ -44,7 +44,7 @@ github.com/gotestyourself/gotestyourself 44dbf532bbf5767611f6f2a61bded572e337010
 github.com/google/go-cmp v0.1.0
 
 # cri dependencies
-github.com/containerd/cri v1.0.0
+github.com/containerd/cri v1.0.1
 github.com/containerd/go-cni f2d7272f12d045b16ed924f50e91f9f9cecc55a7
 github.com/blang/semver v3.1.0
 github.com/containernetworking/cni v0.6.0

--- a/vendor/github.com/containerd/cri/README.md
+++ b/vendor/github.com/containerd/cri/README.md
@@ -1,7 +1,7 @@
 # cri
 <p align="center">
-<img src="https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png" width="50" height="50">
-<img src="https://github.com/containerd/containerd/blob/master/docs/images/containerd-dark.png" width="200" >
+<img src="https://kubernetes.io/images/favicon.png" width="50" height="50">
+<img src="https://containerd.io/img/containerd-dark.png" width="200" >
 </p>
 
 *Note: The standalone `cri-containerd` binary is end-of-life. `cri-containerd` is

--- a/vendor/github.com/containerd/cri/pkg/server/container_create.go
+++ b/vendor/github.com/containerd/cri/pkg/server/container_create.go
@@ -523,7 +523,7 @@ func clearReadOnly(m *runtimespec.Mount) {
 			opt = append(opt, o)
 		}
 	}
-	m.Options = opt
+	m.Options = append(opt, "rw")
 }
 
 // addDevices set device mapping without privilege.

--- a/vendor/github.com/containerd/cri/vendor.conf
+++ b/vendor/github.com/containerd/cri/vendor.conf
@@ -4,7 +4,7 @@ github.com/boltdb/bolt e9cf4fae01b5a8ff89d0ec6b32f0d9c9f79aefdd
 github.com/BurntSushi/toml a368813c5e648fee92e5f6c30e3944ff9d5e8895
 github.com/containerd/cgroups fe281dd265766145e943a034aa41086474ea6130
 github.com/containerd/console cb7008ab3d8359b78c5f464cb7cf160107ad5925
-github.com/containerd/containerd 1381f8fddc4f826e12b48d46c9def347d5aa338a
+github.com/containerd/containerd 01a0741488487779a95035cd85504589034d2e91
 github.com/containerd/continuity 3e8f2ea4b190484acb976a5b378d373429639a1a
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c
 github.com/containerd/go-cni f2d7272f12d045b16ed924f50e91f9f9cecc55a7


### PR DESCRIPTION
Update `cri` plugin to v1.0.1 in release/1.1 branch.

I'm not sure why my `vndr` deleted some non-go files.

Release note: https://github.com/containerd/cri/releases/tag/v1.0.1

Signed-off-by: Lantao Liu <lantaol@google.com>