### PR TITLE
Add Evan Hazlett as a reviewer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -223,6 +223,7 @@ containerd defers to the [Technical Steering Committee](https://github.com/moby/
 	[Org.Reviewers]
 		people = [
 			"dnephin",
+			"ehazlett",
 			"jessvalarezo",
 			"yanxuean",
 			"miaoyq",
@@ -249,6 +250,11 @@ containerd defers to the [Technical Steering Committee](https://github.com/moby/
 	Name = "Derek McGowan"
 	Email = "derek@mcgstyle.net"
 	GitHub = "dmcgowan"
+
+	[people.ehazlett]
+	Name = "Evan Hazlett"
+	Email = "ejhazlett@gmail.com"
+	Github = "ehazlett"
 
 	[People.estesp]
 	Name = "Phil Estes"


### PR DESCRIPTION
Evan is an active contributor and been contributing for awhile now. He has been gaining expertise in the runtime code and has been helping review PRs. I think we should add him as a reviewer.