### PR TITLE
[carry] Mount Windows layers as volumes on the host

### DIFF
--- a/mount/mount_windows.go
+++ b/mount/mount_windows.go
@@ -18,11 +18,15 @@ package mount
 
 import (
 	"encoding/json"
+	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/Microsoft/hcsshim"
 	"github.com/pkg/errors"
+	"golang.org/x/sys/windows"
 )
 
 var (
@@ -31,7 +35,7 @@ var (
 )
 
 // Mount to the provided target
-func (m *Mount) Mount(target string) error {
+func (m *Mount) Mount(target string) (retErr error) {
 	if m.Type != "windows-layer" {
 		return errors.Errorf("invalid windows mount type: '%s'", m.Type)
 	}
@@ -51,13 +55,69 @@ func (m *Mount) Mount(target string) error {
 		return errors.Wrapf(err, "failed to activate layer %s", m.Source)
 	}
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			hcsshim.DeactivateLayer(di, layerID)
 		}
 	}()
 
 	if err = hcsshim.PrepareLayer(di, layerID, parentLayerPaths); err != nil {
 		return errors.Wrapf(err, "failed to prepare layer %s", m.Source)
+	}
+	layerPath, err := hcsshim.GetLayerMountPath(di, layerID)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get mount path for layer %s", m.Source)
+	}
+
+	// Check if the returned path is a new mounted volume, or the path of the expanded
+	// layer on disk.
+	// TODO: Is there a better way to check this than looking for \\?\Volume{*?
+	if !strings.HasPrefix(layerPath, `\\?\Volume{`) {
+		layerPath = filepath.Join(layerPath, "Files")
+		if _, err := os.Lstat(layerPath); err != nil {
+			if !os.IsNotExist(err) {
+				return errors.Wrapf(err, "failed to find Files dir")
+			}
+			if err := os.Mkdir(layerPath, 0755); err != nil {
+				return errors.Wrap(err, "failed to create Files dir")
+			}
+		}
+		if err := os.Remove(target); err != nil {
+			return errors.Wrapf(err, "remove target prior to mounting %q", target)
+		}
+		if err := os.Symlink(layerPath, target); err != nil {
+			return errors.Wrapf(err, "failed to mount layer %q at %q", m.Source, target)
+		}
+	} else {
+		target = filepath.Clean(target) + string(filepath.Separator)
+		targetp, err := syscall.UTF16PtrFromString(target)
+		if err != nil {
+			return err
+		}
+
+		volName := filepath.Clean(layerPath) + string(filepath.Separator)
+		volNamep, err := syscall.UTF16PtrFromString(volName)
+		if err != nil {
+			return err
+		}
+
+		if err := windows.SetVolumeMountPoint(targetp, volNamep); err != nil {
+			return errors.Wrapf(err, "failed to mount layer %q at %q, volume: %q", m.Source, target, volName)
+		}
+	}
+
+	// Remove any trailing slashes in preparation to add an Alternate Data Stream for the layerid,
+	// see https://blogs.technet.microsoft.com/askcore/2013/03/24/alternate-data-streams-in-ntfs/
+	// for details on Alternate Data Streams.
+	target = filepath.Clean(target)
+	idf, err := os.Create(target + ":layerid")
+	if err != nil {
+		return err
+	}
+	defer idf.Close()
+
+	_, err = idf.Write([]byte(m.Source))
+	if err != nil {
+		return err
 	}
 	return nil
 }
@@ -82,12 +142,50 @@ func (m *Mount) GetParentPaths() ([]string, error) {
 
 // Unmount the mount at the provided path
 func Unmount(mount string, flags int) error {
+	fi, err := os.Lstat(mount)
+	if err != nil {
+		return errors.Wrapf(err, "unable to find mounted volume %s", mount)
+	}
+
+	// Remove any trailing slashes
+	mount = filepath.Clean(mount)
+	dir, file := filepath.Split(mount)
+	layerPathb, err := ioutil.ReadFile(filepath.Join(dir, file+":layerid"))
+	if err != nil {
+		return err
+	}
+	layerPath := string(layerPathb)
+
 	var (
-		home, layerID = filepath.Split(mount)
+		home, layerID = filepath.Split(layerPath)
 		di            = hcsshim.DriverInfo{
 			HomeDir: home,
 		}
 	)
+
+	if fi.Mode()&os.ModeSymlink != 0 {
+		if err := os.Remove(mount); err != nil {
+			return errors.Wrap(err, "failed to delete mount")
+		}
+	} else {
+		mount = filepath.Clean(mount) + string(filepath.Separator)
+		mountp, err := syscall.UTF16PtrFromString(mount)
+		if err != nil {
+			return err
+		}
+
+		const volumeNameLen = 50
+		volumeNamep := make([]uint16, volumeNameLen)
+		volumeNamep[0] = 0
+
+		if err := windows.GetVolumeNameForVolumeMountPoint(mountp, &volumeNamep[0], volumeNameLen); err != nil {
+			return errors.Wrapf(err, "unable to find mounted volume %s", mount)
+		}
+
+		if err := windows.DeleteVolumeMountPoint(&volumeNamep[0]); err != nil {
+			return errors.Wrapf(err, "unable to delete mounted volume %s", mount)
+		}
+	}
 
 	if err := hcsshim.UnprepareLayer(di, layerID); err != nil {
 		return errors.Wrapf(err, "failed to unprepare layer %s", mount)

--- a/pkg/testutil/helpers.go
+++ b/pkg/testutil/helpers.go
@@ -17,6 +17,7 @@
 package testutil
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -24,6 +25,11 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
+
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/snapshots"
+	"github.com/pkg/errors"
+	"gotest.tools/assert"
 )
 
 var rootEnabled bool
@@ -79,4 +85,17 @@ func DumpDirOnFailure(t *testing.T, root string) {
 	if t.Failed() {
 		DumpDir(t, root)
 	}
+}
+
+// Unmount unmounts a given mountPoint and sets t.Error if it fails
+func Unmount(t testing.TB, mountPoint string) {
+	t.Log("unmount", mountPoint)
+	err := mount.UnmountAll(mountPoint, umountflags)
+	assert.NilError(t, errors.Wrap(err, "failed to unmount"))
+}
+
+// RemoveSnapshot removes the snapshot from the snapshotter and sets t.Error if it fails
+func RemoveSnapshot(ctx context.Context, t testing.TB, sn snapshots.Snapshotter, snapshot string) {
+	err := sn.Remove(ctx, snapshot)
+	assert.NilError(t, errors.Wrap(err, "failed to remove snapshot"))
 }

--- a/pkg/testutil/helpers_unix.go
+++ b/pkg/testutil/helpers_unix.go
@@ -23,16 +23,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/containerd/containerd/mount"
 	"gotest.tools/assert"
 )
-
-// Unmount unmounts a given mountPoint and sets t.Error if it fails
-func Unmount(t testing.TB, mountPoint string) {
-	t.Log("unmount", mountPoint)
-	err := mount.UnmountAll(mountPoint, umountflags)
-	assert.NilError(t, err)
-}
 
 // RequiresRoot skips tests that require root, unless the test.root flag has
 // been set

--- a/pkg/testutil/helpers_windows.go
+++ b/pkg/testutil/helpers_windows.go
@@ -25,8 +25,3 @@ func RequiresRoot(t testing.TB) {
 // RequiresRootM is similar to RequiresRoot but intended to be called from *testing.M.
 func RequiresRootM() {
 }
-
-// Unmount unmounts a given mountPoint and sets t.Error if it fails
-// Does nothing on Windows
-func Unmount(t *testing.T, mountPoint string) {
-}

--- a/pkg/testutil/mount_other.go
+++ b/pkg/testutil/mount_other.go
@@ -1,4 +1,4 @@
-// +build !linux,!windows
+// +build !linux
 
 /*
    Copyright The containerd Authors.

--- a/snapshots/testsuite/testsuite.go
+++ b/snapshots/testsuite/testsuite.go
@@ -23,6 +23,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -123,7 +124,17 @@ func checkSnapshotterBasic(ctx context.Context, t *testing.T, snapshotter snapsh
 		fstest.CreateDir("/a", 0755),
 		fstest.CreateDir("/a/b", 0755),
 		fstest.CreateDir("/a/b/c", 0755),
+		fstest.Base(),
 	)
+
+	if runtime.GOOS == "windows" {
+		initialApplier = fstest.Apply(
+			initialApplier,
+			// Workaround for a Windows RS1 bug: Create a file inside /a/b/c
+			// in order to initialize the empty folder in the filesystem filter
+			fstest.CreateFile("/a/b/c/foo", []byte("bar\n"), 0777),
+		)
+	}
 
 	diffApplier := fstest.Apply(
 		fstest.CreateFile("/bar", []byte("bar\n"), 0777),
@@ -149,10 +160,19 @@ func checkSnapshotterBasic(ctx context.Context, t *testing.T, snapshotter snapsh
 	if err := mount.All(mounts, preparing); err != nil {
 		t.Fatalf("failure reason: %+v", err)
 	}
-	defer testutil.Unmount(t, preparing)
+	preparingMounted := true
+	defer func() {
+		if preparingMounted {
+			testutil.Unmount(t, preparing)
+		}
+	}()
 
 	if err := initialApplier.Apply(preparing); err != nil {
 		t.Fatalf("failure reason: %+v", err)
+	}
+
+	if err := setupBaseSnapshot(ctx, snapshotter, preparing); err != nil {
+		t.Fatalf("failed to set up base snapshot: %+v", err)
 	}
 
 	committed := filepath.Join(work, "committed")
@@ -173,6 +193,9 @@ func checkSnapshotterBasic(ctx context.Context, t *testing.T, snapshotter snapsh
 		t.Fatalf("%s should no longer be available after Commit", preparing)
 	}
 
+	testutil.Unmount(t, preparing)
+	preparingMounted = false
+
 	next := filepath.Join(work, "nextlayer")
 	if err := os.MkdirAll(next, 0777); err != nil {
 		t.Fatalf("failure reason: %+v", err)
@@ -185,7 +208,12 @@ func checkSnapshotterBasic(ctx context.Context, t *testing.T, snapshotter snapsh
 	if err := mount.All(mounts, next); err != nil {
 		t.Fatalf("failure reason: %+v", err)
 	}
-	defer testutil.Unmount(t, next)
+	nextMounted := true
+	defer func() {
+		if nextMounted {
+			testutil.Unmount(t, next)
+		}
+	}()
 
 	if err := fstest.CheckDirectoryEqualWithApplier(next, initialApplier); err != nil {
 		t.Fatalf("failure reason: %+v", err)
@@ -220,6 +248,9 @@ func checkSnapshotterBasic(ctx context.Context, t *testing.T, snapshotter snapsh
 	if err == nil {
 		t.Fatalf("%s should no longer be available after Commit", next)
 	}
+
+	testutil.Unmount(t, next)
+	nextMounted = false
 
 	expected := map[string]snapshots.Info{
 		si.Name:  si,
@@ -368,6 +399,12 @@ func checkSnapshotterTransitivity(ctx context.Context, t *testing.T, snapshotter
 		t.Fatal(err)
 	}
 	defer testutil.Unmount(t, preparing)
+	if err := fstest.Base().Apply(preparing); err != nil {
+		t.Fatalf("failure reason: %+v", err)
+	}
+	if err := setupBaseSnapshot(ctx, snapshotter, preparing); err != nil {
+		t.Fatalf("failed to set up base snapshot: %+v", err)
+	}
 
 	if err = ioutil.WriteFile(filepath.Join(preparing, "foo"), []byte("foo\n"), 0777); err != nil {
 		t.Fatal(err)
@@ -422,6 +459,12 @@ func checkSnapshotterPrepareView(ctx context.Context, t *testing.T, snapshotter 
 		t.Fatal(err)
 	}
 	defer testutil.Unmount(t, preparing)
+	if err := fstest.Base().Apply(preparing); err != nil {
+		t.Fatalf("failure reason: %+v", err)
+	}
+	if err := setupBaseSnapshot(ctx, snapshotter, preparing); err != nil {
+		t.Fatalf("failed to set up base snapshot: %+v", err)
+	}
 
 	snapA := filepath.Join(work, "snapA")
 	if err = snapshotter.Commit(ctx, snapA, preparing, opt); err != nil {
@@ -475,10 +518,14 @@ func checkSnapshotterPrepareView(ctx context.Context, t *testing.T, snapshotter 
 
 // Deletion of files/folder of base layer in new layer, On Commit, those files should not be visible.
 func checkDeletedFilesInChildSnapshot(ctx context.Context, t *testing.T, snapshotter snapshots.Snapshotter, work string) {
+	if runtime.GOOS == "windows" {
+		t.Skip("currently unclear why this fails on Windows")
+	}
 
 	l1Init := fstest.Apply(
 		fstest.CreateFile("/foo", []byte("foo\n"), 0777),
 		fstest.CreateFile("/foobar", []byte("foobar\n"), 0777),
+		fstest.Base(),
 	)
 	l2Init := fstest.Apply(
 		fstest.RemoveAll("/foobar"),
@@ -493,12 +540,28 @@ func checkDeletedFilesInChildSnapshot(ctx context.Context, t *testing.T, snapsho
 
 //Create three layers. Deleting intermediate layer must fail.
 func checkRemoveIntermediateSnapshot(ctx context.Context, t *testing.T, snapshotter snapshots.Snapshotter, work string) {
-
 	base, err := snapshotterPrepareMount(ctx, snapshotter, "base", "", work)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer testutil.Unmount(t, base)
+	baseMounted := true
+	unmountBaseOnce := func() {
+		if baseMounted {
+			testutil.Unmount(t, base)
+			baseMounted = false
+		}
+	}
+	defer unmountBaseOnce()
+
+	if err := fstest.Base().Apply(base); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := setupBaseSnapshot(ctx, snapshotter, base); err != nil {
+		t.Fatalf("failed to set up base snapshot: %+v", err)
+	}
+
+	unmountBaseOnce()
 
 	committedBase := filepath.Join(work, "committed-base")
 	if err = snapshotter.Commit(ctx, committedBase, base, opt); err != nil {
@@ -528,7 +591,7 @@ func checkRemoveIntermediateSnapshot(ctx context.Context, t *testing.T, snapshot
 		t.Fatal("intermediate layer removal should fail.")
 	}
 
-	//Removal from toplayer to base should not fail.
+	// Removal from toplayer to base should not fail.
 	err = snapshotter.Remove(ctx, topLayer)
 	if err != nil {
 		t.Fatal(err)
@@ -551,11 +614,19 @@ func checkRemoveIntermediateSnapshot(ctx context.Context, t *testing.T, snapshot
 //  a1 - active snapshot, no parent
 //  v1 - view snapshot, v1 is parent
 //  v2 - view snapshot, no parent
-func baseTestSnapshots(ctx context.Context, snapshotter snapshots.Snapshotter) error {
-	if _, err := snapshotter.Prepare(ctx, "c1-a", "", opt); err != nil {
-		return err
+func baseTestSnapshots(ctx context.Context, t *testing.T, snapshotter snapshots.Snapshotter, work string) error {
+	c1a, err := snapshotterPrepareMount(ctx, snapshotter, "c1-a", "", work)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if err := snapshotter.Commit(ctx, "c1", "c1-a", opt); err != nil {
+	defer testutil.Unmount(t, c1a)
+	if err := fstest.Base().Apply(c1a); err != nil {
+		t.Fatalf("failure reason: %+v", err)
+	}
+	if err := setupBaseSnapshot(ctx, snapshotter, c1a); err != nil {
+		t.Fatalf("failed to set up base snapshot: %+v", err)
+	}
+	if err := snapshotter.Commit(ctx, "c1", c1a, opt); err != nil {
 		return err
 	}
 	if _, err := snapshotter.Prepare(ctx, "c2-a", "c1", opt); err != nil {
@@ -581,7 +652,7 @@ func baseTestSnapshots(ctx context.Context, snapshotter snapshots.Snapshotter) e
 
 func checkUpdate(ctx context.Context, t *testing.T, snapshotter snapshots.Snapshotter, work string) {
 	t1 := time.Now().UTC()
-	if err := baseTestSnapshots(ctx, snapshotter); err != nil {
+	if err := baseTestSnapshots(ctx, t, snapshotter, work); err != nil {
 		t.Fatalf("Failed to create base snapshots: %v", err)
 	}
 	t2 := time.Now().UTC()
@@ -738,10 +809,26 @@ func assertLabels(t *testing.T, actual, expected map[string]string) {
 }
 
 func checkRemove(ctx context.Context, t *testing.T, snapshotter snapshots.Snapshotter, work string) {
-	if _, err := snapshotter.Prepare(ctx, "committed-a", "", opt); err != nil {
+	committedA, err := snapshotterPrepareMount(ctx, snapshotter, "committed-a", "", work)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if err := snapshotter.Commit(ctx, "committed-1", "committed-a", opt); err != nil {
+	mounted := true
+	unmountCommittedA := func() {
+		if mounted {
+			testutil.Unmount(t, committedA)
+			mounted = false
+		}
+	}
+	defer unmountCommittedA()
+	if err := fstest.Base().Apply(committedA); err != nil {
+		t.Fatalf("failure reason: %+v", err)
+	}
+	if err := setupBaseSnapshot(ctx, snapshotter, committedA); err != nil {
+		t.Fatalf("failed to set up base snapshot: %+v", err)
+	}
+	unmountCommittedA()
+	if err := snapshotter.Commit(ctx, "committed-1", committedA, opt); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := snapshotter.Prepare(ctx, "reuse-1", "committed-1", opt); err != nil {
@@ -770,11 +857,21 @@ func checkRemove(ctx context.Context, t *testing.T, snapshotter snapshots.Snapsh
 // checkSnapshotterViewReadonly ensures a KindView snapshot to be mounted as a read-only filesystem.
 // This function is called only when WithTestViewReadonly is true.
 func checkSnapshotterViewReadonly(ctx context.Context, t *testing.T, snapshotter snapshots.Snapshotter, work string) {
-	preparing := filepath.Join(work, "preparing")
-	if _, err := snapshotter.Prepare(ctx, preparing, "", opt); err != nil {
+	if runtime.GOOS == "windows" {
+		t.Skip("the mounted filesystem cannot be marked read only on Windows")
+	}
+	preparing, err := snapshotterPrepareMount(ctx, snapshotter, "preparing", "", work)
+	if err != nil {
 		t.Fatal(err)
 	}
-	committed := filepath.Join(work, "committed")
+	defer testutil.Unmount(t, preparing)
+	if err := fstest.Base().Apply(preparing); err != nil {
+		t.Fatalf("failure reason: %+v", err)
+	}
+	if err := setupBaseSnapshot(ctx, snapshotter, preparing); err != nil {
+		t.Fatalf("failed to set up base snapshot: %+v", err)
+	}
+	committed := filepath.Join(work, "commited")
 	if err := snapshotter.Commit(ctx, committed, preparing, opt); err != nil {
 		t.Fatal(err)
 	}
@@ -812,6 +909,7 @@ func checkFileFromLowerLayer(ctx context.Context, t *testing.T, snapshotter snap
 		fstest.CreateFile("/dir1/f1", []byte("Hello"), 0644),
 		fstest.CreateDir("dir2", 0700),
 		fstest.CreateFile("dir2/f2", []byte("..."), 0644),
+		fstest.Base(),
 	)
 	l2Init := fstest.Apply(
 		fstest.CreateDir("/dir3", 0700),

--- a/snapshots/testsuite/testsuite_unix.go
+++ b/snapshots/testsuite/testsuite_unix.go
@@ -18,11 +18,21 @@
 
 package testsuite
 
-import "syscall"
+import (
+	"context"
+	"syscall"
+
+	"github.com/containerd/containerd/snapshots"
+)
 
 func clearMask() func() {
 	oldumask := syscall.Umask(0)
 	return func() {
 		syscall.Umask(oldumask)
 	}
+}
+
+// setupBaseSnapshot is a no-op
+func setupBaseSnapshot(ctx context.Context, snapshotter snapshots.Snapshotter, key string) error {
+	return nil
 }

--- a/snapshots/windows/windows.go
+++ b/snapshots/windows/windows.go
@@ -184,10 +184,7 @@ func (s *snapshotter) Commit(ctx context.Context, name, key string, opts ...snap
 		return errors.Wrap(err, "failed to commit snapshot")
 	}
 
-	if err := t.Commit(); err != nil {
-		return err
-	}
-	return nil
+	return t.Commit()
 }
 
 // Remove abandons the transaction identified by key. All resources
@@ -297,19 +294,15 @@ func (s *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 		return nil, errors.Wrap(err, "failed to create snapshot")
 	}
 
-	if kind == snapshots.KindActive {
-		parentLayerPaths := s.parentIDsToParentPaths(newSnapshot.ParentIDs)
+	parentLayerPaths := s.parentIDsToParentPaths(newSnapshot.ParentIDs)
 
-		var parentPath string
-		if len(parentLayerPaths) != 0 {
-			parentPath = parentLayerPaths[0]
-		}
+	var parentPath string
+	if len(parentLayerPaths) != 0 {
+		parentPath = parentLayerPaths[0]
+	}
 
-		if err := hcsshim.CreateSandboxLayer(s.info, newSnapshot.ID, parentPath, parentLayerPaths); err != nil {
-			return nil, errors.Wrap(err, "failed to create sandbox layer")
-		}
-
-		// TODO(darrenstahlmsft): Allow changing sandbox size
+	if err := hcsshim.CreateSandboxLayer(s.info, newSnapshot.ID, parentPath, parentLayerPaths); err != nil {
+		return nil, errors.Wrap(err, "failed to create sandbox layer")
 	}
 
 	if err := t.Commit(); err != nil {

--- a/snapshots/windows/windows_test.go
+++ b/snapshots/windows/windows_test.go
@@ -1,3 +1,5 @@
+// +build windows
+
 /*
    Copyright The containerd Authors.
 
@@ -14,27 +16,25 @@
    limitations under the License.
 */
 
-package testsuite
+package windows
 
 import (
 	"context"
+	"testing"
 
-	"github.com/Microsoft/hcsshim"
 	"github.com/containerd/containerd/snapshots"
+	"github.com/containerd/containerd/snapshots/testsuite"
 )
 
-func clearMask() func() {
-	return func() {}
+func newSnapshotter(ctx context.Context, root string) (snapshots.Snapshotter, func() error, error) {
+	snapshotter, err := NewSnapshotter(root)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return snapshotter, func() error { return snapshotter.Close() }, nil
 }
 
-func setupBaseSnapshot(ctx context.Context, snapshotter snapshots.Snapshotter, key string) error {
-	mounts, err := snapshotter.Mounts(ctx, key)
-	if err != nil {
-		return err
-	}
-
-	if err := hcsshim.ProcessBaseLayer(mounts[0].Source); err != nil {
-		return err
-	}
-	return nil
+func TestWindows(t *testing.T) {
+	testsuite.SnapshotterSuite(t, "Windows", newSnapshotter)
 }

--- a/windows/task.go
+++ b/windows/task.go
@@ -49,9 +49,10 @@ type task struct {
 	processes map[string]*process
 	hyperV    bool
 
-	publisher events.Publisher
-	rwLayer   string
-	rootfs    []mount.Mount
+	publisher     events.Publisher
+	rwLayer       string
+	mountLocation string
+	rootfs        []mount.Mount
 
 	pidPool           *pidPool
 	hcsContainer      hcsshim.Container


### PR DESCRIPTION
Carry and rebase of #2287

Closes #2287

Squashed commit of the following:

commit 126a6eafe8ec9e9e04ba5865ada3ccc0b77f5602
Merge: 7f800e0a a12b0823
Author: Michael Crosby <crosbymichael@gmail.com>
Date:   Tue May 29 10:55:18 2018 -0400

    Merge branch 'MountVol' of https://github.com/darstahl/containerd into darstahl-MountVol

    Signed-off-by: Michael Crosby <crosbymichael@gmail.com>

commit a12b0823c3d57068e6a61a9f423116117256150a
Author: Darren Stahl <darst@microsoft.com>
Date:   Thu May 10 17:04:09 2018 -0700

    Fix vendoring

    Signed-off-by: Darren Stahl <darst@microsoft.com>

commit 4844ea13579009f413608505e9ebc340b954fcf6
Author: Darren Stahl <darst@microsoft.com>
Date:   Wed May 9 15:51:30 2018 -0700

    More cleanup

    Signed-off-by: Darren Stahl <darst@microsoft.com>

commit 845b2b34db33f6954431c151f6dc4f1edf174ef2
Author: Darren Stahl <darst@microsoft.com>
Date:   Wed May 9 12:03:20 2018 -0700

    cleanup

    Signed-off-by: Darren Stahl <darst@microsoft.com>

commit 8cb63cc77f620932bfb4f019d81cf3ff06905fe4
Author: Darren Stahl <darst@microsoft.com>
Date:   Tue May 8 18:34:44 2018 -0700

    Use final version of continuity changes

    Signed-off-by: Darren Stahl <darst@microsoft.com>

commit b36adf291100caa99241eec3ff70886fbeb6828b
Author: Darren Stahl <darst@microsoft.com>
Date:   Tue May 8 16:14:09 2018 -0700

    Mark windows_test.go as Windows only

    Signed-off-by: Darren Stahl <darst@microsoft.com>

commit 796e60a58e21fbed0ec11f7f4dff4f30ceb9c8ce
Author: Darren Stahl <darst@microsoft.com>
Date:   Tue May 8 11:29:30 2018 -0700

    Fix building on Linux

    Signed-off-by: Darren Stahl <darst@microsoft.com>

commit c3730f35d8157e8807c0c8e97dfcc73f82846d0f
Author: Darren Stahl <darst@microsoft.com>
Date:   Mon May 7 18:27:28 2018 -0700

    revert test

    Signed-off-by: Darren Stahl <darst@microsoft.com>

commit e87ba1f352b29f51a4b96389652f3d9fa19994e9
Author: Darren Stahl <darst@microsoft.com>
Date:   Mon May 7 18:10:37 2018 -0700

    test

    Signed-off-by: Darren Stahl <darst@microsoft.com>

commit 6a1bf21601746193cd89d1fdfd382eca00e0f72a
Author: Darren Stahl <darst@microsoft.com>
Date:   Mon May 7 17:52:48 2018 -0700

    fix build constraints

    Signed-off-by: Darren Stahl <darst@microsoft.com>

commit df0d9cff2f8c66108ac512dc51a009b284305d1e
Author: Darren Stahl <darst@microsoft.com>
Date:   Mon May 7 17:29:03 2018 -0700

    fix unmount

    Signed-off-by: Darren Stahl <darst@microsoft.com>

commit f1ca1f957004cb5ae2d8f25d6f396807b5162361
Author: Darren Stahl <darst@microsoft.com>
Date:   Mon May 7 17:10:21 2018 -0700

    fix containers

    Signed-off-by: Darren Stahl <darst@microsoft.com>

commit f34d796e4751be3ae74686ca27dc73b9c8d0af75
Author: Darren Stahl <darst@microsoft.com>
Date:   Mon May 7 17:01:27 2018 -0700

    Fix Linux build?

    Signed-off-by: Darren Stahl <darst@microsoft.com>

commit 36e773a9a54fc9b3906950c4abe77bfde3692d35
Author: Darren Stahl <darst@microsoft.com>
Date:   Mon May 7 16:41:33 2018 -0700

    Workaround for CI failure due to empty folder

    Signed-off-by: Darren Stahl <darst@microsoft.com>

commit 0089489c6002cec2714d32e643b88610ebf82f23
Author: Darren Stahl <darst@microsoft.com>
Date:   Mon May 7 16:41:18 2018 -0700

    Add TODO for recycle bin contents

    Signed-off-by: Darren Stahl <darst@microsoft.com>

commit 22c981ddb677633cfce25c4824be5edb65fe76cc
Author: Darren Stahl <darst@microsoft.com>
Date:   Fri May 4 15:08:48 2018 -0700

    Removed unused forked code

    Signed-off-by: Darren Stahl <darst@microsoft.com>

commit 03279135be068aaae10a31df5d5d9d6adb707dd6
Author: Darren Stahl <darst@microsoft.com>
Date:   Fri May 4 15:05:42 2018 -0700

    WIP: Forked ReadLink and EvalSymlinks

    Signed-off-by: Darren Stahl <darst@microsoft.com>

commit 249f2d553ddd9c367ea3b6169ad2dfe4e0ecb9aa
Author: Darren Stahl <darst@microsoft.com>
Date:   Wed Apr 18 17:07:22 2018 -0700

    Add TODOs

    Signed-off-by: Darren Stahl <darst@microsoft.com>

commit c264ea23b6a3810c28beda1ac4c751de036c5f57
Author: Darren Stahl <darst@microsoft.com>
Date:   Wed Apr 18 11:56:35 2018 -0700

    WIP: Enable more snapshotter tests on Windows

    Signed-off-by: Darren Stahl <darst@microsoft.com>

commit 699f2d2c30f0e6b5e5689be78b6ca3121b8fe551
Author: Darren Stahl <darst@microsoft.com>
Date:   Wed Apr 18 11:56:18 2018 -0700

    WIP: fixing view layers to create a new sandbox

    Signed-off-by: Darren Stahl <darst@microsoft.com>

commit edec71c0cc532a39f18715f654e5087945319a4b
Author: Darren Stahl <darst@microsoft.com>
Date:   Wed Apr 18 11:54:45 2018 -0700

    Use filepath.Clean to remove trailing slashes

    Signed-off-by: Darren Stahl <darst@microsoft.com>

commit f216d8a494625e8c2e84a035a81bd2dc9aaea076
Author: Darren Stahl <darst@microsoft.com>
Date:   Wed Apr 18 11:54:08 2018 -0700

    Ignore Windows layer metadata in tests

    Signed-off-by: Darren Stahl <darst@microsoft.com>

commit bcb73e8af6d0d8d5fdfb3a8bed4c5869b0a1712d
Author: Darren Stahl <darst@microsoft.com>
Date:   Wed Apr 18 11:52:41 2018 -0700

    Fork filepath.Walk to follow symlinks on the root

    Signed-off-by: Darren Stahl <darst@microsoft.com>

commit 2126d648ca2d816919a3928a2e9117b7bb4fb236
Author: Darren Stahl <darst@microsoft.com>
Date:   Wed Apr 11 18:07:09 2018 -0700

    WIP: mounting Windows volumes using SetVolumeMountPath

    Signed-off-by: Darren Stahl <darst@microsoft.com>

commit e10a628651cb66995172bb0480c24636c7c7bde5
Author: Darren Stahl <darst@microsoft.com>
Date:   Wed Feb 14 12:40:42 2018 -0800

    Update /x/sys/windows vendor to include volume mounting

    Signed-off-by: Darren Stahl <darst@microsoft.com>

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>