### PR TITLE
Prepare 1.1.1-rc.0 release

### DIFF
--- a/releases/v1.1.1-rc.0.toml
+++ b/releases/v1.1.1-rc.0.toml
@@ -1,0 +1,32 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+
+# previous release
+previous = "v1.1.0"
+
+pre_release = true
+
+preface = """\
+This is the first patch release for the `containerd` 1.1 release. This
+includes bug fixes related to CRI, image pull, and native snapshotter.
+
+## CRI Plugin
+Fixes for working set memory calculation and privileged container creation.
+
+## Image Pull
+Fix for a size validation bug with some registries which impacts the
+CRI plugin and clients.
+
+## Native Snapshotter
+Fix for bug in layers containing large files.
+
+Please see the changelog for full details.
+"""
+
+# notable prs to include in the release notes, 1234 is the pr number
+[notes]
+
+[breaking]

--- a/version/version.go
+++ b/version/version.go
@@ -21,7 +21,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.1.0+unknown"
+	Version = "1.1.1+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
This is a relatively light release. I think it is important though to get these changes out there, especially the image pull issue since it is impacting cri users.