### PR TITLE
[release/1.1] Set rc.0 on version

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -21,7 +21,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.1.1+unknown"
+	Version = "1.1.1-rc.0+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Correction from prepare branch, normally the rc is put on the version for rc releases.