### PR TITLE
[release/1.1] update cri to v1.0.3.

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -44,7 +44,7 @@ github.com/gotestyourself/gotestyourself 44dbf532bbf5767611f6f2a61bded572e337010
 github.com/google/go-cmp v0.1.0
 
 # cri dependencies
-github.com/containerd/cri v1.0.2
+github.com/containerd/cri v1.0.3
 github.com/containerd/go-cni f2d7272f12d045b16ed924f50e91f9f9cecc55a7
 github.com/blang/semver v3.1.0
 github.com/containernetworking/cni v0.6.0

--- a/vendor/github.com/containerd/cri/pkg/containerd/opts/container.go
+++ b/vendor/github.com/containerd/cri/pkg/containerd/opts/container.go
@@ -53,7 +53,6 @@ func WithNewSnapshot(id string, i containerd.Image) containerd.NewContainerOpts 
 // WithVolumes copies ownership of volume in rootfs to its corresponding host path.
 // It doesn't update runtime spec.
 // The passed in map is a host path to container path map for all volumes.
-// TODO(random-liu): Figure out whether we need to copy volume content.
 func WithVolumes(volumeMounts map[string]string) containerd.NewContainerOpts {
 	return func(ctx context.Context, client *containerd.Client, c *containers.Container) (err error) {
 		if c.Snapshotter == "" {
@@ -108,14 +107,6 @@ func WithVolumes(volumeMounts map[string]string) containerd.NewContainerOpts {
 // copyExistingContents copies from the source to the destination and
 // ensures the ownership is appropriately set.
 func copyExistingContents(source, destination string) error {
-	srcList, err := ioutil.ReadDir(source)
-	if err != nil {
-		return err
-	}
-	if len(srcList) == 0 {
-		// Skip copying if source directory is empty.
-		return nil
-	}
 	dstList, err := ioutil.ReadDir(destination)
 	if err != nil {
 		return err

--- a/vendor/github.com/containerd/cri/pkg/server/container_create.go
+++ b/vendor/github.com/containerd/cri/pkg/server/container_create.go
@@ -372,6 +372,11 @@ func (c *criService) generateContainerSpec(id string, sandboxID string, sandboxP
 				securityContext.GetCapabilities())
 		}
 	}
+	// Clear all ambient capabilities. The implication of non-root + caps
+	// is not clearly defined in Kubernetes.
+	// See https://github.com/kubernetes/kubernetes/issues/56374
+	// Keep docker's behavior for now.
+	g.Spec().Process.Capabilities.Ambient = []string{}
 
 	g.SetProcessSelinuxLabel(processLabel)
 	g.SetLinuxMountLabel(mountLabel)


### PR DESCRIPTION
Update cri to v1.0.3 to fix 2 bugs.

Release note: https://github.com/containerd/cri/releases/tag/v1.0.3

Signed-off-by: Lantao Liu <lantaol@google.com>