### PR TITLE
add init function to proxy snapshotter

### DIFF
--- a/snapshots/proxy/proxy.go
+++ b/snapshots/proxy/proxy.go
@@ -20,13 +20,35 @@ import (
 	"context"
 	"io"
 
+	grpc "google.golang.org/grpc"
+
 	snapshotsapi "github.com/containerd/containerd/api/services/snapshots/v1"
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/platforms"
+	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/snapshots"
 	protobuftypes "github.com/gogo/protobuf/types"
 )
+
+func init() {
+	plugin.Register(&plugin.Registration{
+		Type: plugin.SnapshotPlugin,
+		ID:   "proxy",
+		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
+			ic.Meta.Platforms = append(ic.Meta.Platforms, platforms.DefaultSpec())
+			ic.Meta.Exports["root"] = ic.Root
+
+			conn, err := grpc.Dial(":50051", grpc.WithInsecure())
+			if err != nil {
+				return nil, err
+			}
+			client := snapshotsapi.NewSnapshotsClient(conn)
+			return NewSnapshotter(client, "proxy"), nil
+		},
+	})
+}
 
 // NewSnapshotter returns a new Snapshotter which communicates over a GRPC
 // connection using the containerd snapshot GRPC API.


### PR DESCRIPTION
I am not quite sure if you guys simply forget this one or if there are deeper reasons why the `init` is not yet inside the codebase.

Please do not merge it yet since I am not sure how to manage the insecure flag.

I am thinking about getting as input the port and simply connect only to localhost at that port, so that we may not need the TLS.

Not sure how to manage the possibilities to have more proxy...