### PR TITLE
Move ContainerFlags to "commands" package

### DIFF
--- a/cmd/ctr/commands/commands.go
+++ b/cmd/ctr/commands/commands.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/containerd/containerd"
@@ -61,6 +62,67 @@ var (
 		cli.StringFlag{
 			Name:  "refresh",
 			Usage: "refresh token for authorization server",
+		},
+	}
+
+	// ContainerFlags are cli flags specifying container options
+	ContainerFlags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "config,c",
+			Usage: "path to the runtime-specific spec config file",
+		},
+		cli.StringFlag{
+			Name:  "checkpoint",
+			Usage: "provide the checkpoint digest to restore the container",
+		},
+		cli.StringFlag{
+			Name:  "cwd",
+			Usage: "specify the working directory of the process",
+		},
+		cli.StringSliceFlag{
+			Name:  "env",
+			Usage: "specify additional container environment variables (i.e. FOO=bar)",
+		},
+		cli.StringSliceFlag{
+			Name:  "label",
+			Usage: "specify additional labels (i.e. foo=bar)",
+		},
+		cli.StringSliceFlag{
+			Name:  "mount",
+			Usage: "specify additional container mount (ex: type=bind,src=/tmp,dst=/host,options=rbind:ro)",
+		},
+		cli.BoolFlag{
+			Name:  "net-host",
+			Usage: "enable host networking for the container",
+		},
+		cli.BoolFlag{
+			Name:  "privileged",
+			Usage: "run privileged container",
+		},
+		cli.BoolFlag{
+			Name:  "read-only",
+			Usage: "set the containers filesystem as readonly",
+		},
+		cli.StringFlag{
+			Name:  "runtime",
+			Usage: "runtime name (io.containerd.runtime.v1.linux, io.containerd.runtime.v1.windows, io.containerd.runtime.v1.com.vmware.linux)",
+			Value: fmt.Sprintf("io.containerd.runtime.v1.%s", runtime.GOOS),
+		},
+		cli.BoolFlag{
+			Name:  "tty,t",
+			Usage: "allocate a TTY for the container",
+		},
+		cli.StringSliceFlag{
+			Name:  "with-ns",
+			Usage: "specify existing Linux namespaces to join at container runtime (format '<nstype>:<path>')",
+		},
+		cli.StringFlag{
+			Name:  "pid-file",
+			Usage: "file path to write the task's pid",
+		},
+		cli.IntFlag{
+			Name:  "gpus",
+			Usage: "add gpus to the container",
 		},
 	}
 )

--- a/cmd/ctr/commands/commands_unix.go
+++ b/cmd/ctr/commands/commands_unix.go
@@ -1,0 +1,33 @@
+// +build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package commands
+
+import (
+	"github.com/urfave/cli"
+)
+
+func init() {
+	ContainerFlags = append(ContainerFlags, cli.BoolFlag{
+		Name:  "rootfs",
+		Usage: "use custom rootfs that is not managed by containerd snapshotter",
+	}, cli.BoolFlag{
+		Name:  "no-pivot",
+		Usage: "disable use of pivot-root (linux only)",
+	})
+}

--- a/cmd/ctr/commands/containers/containers.go
+++ b/cmd/ctr/commands/containers/containers.go
@@ -49,7 +49,7 @@ var createCommand = cli.Command{
 	Name:      "create",
 	Usage:     "create container",
 	ArgsUsage: "[flags] Image|RootFS CONTAINER",
-	Flags:     append(commands.SnapshotterFlags, run.ContainerFlags...),
+	Flags:     append(commands.SnapshotterFlags, commands.ContainerFlags...),
 	Action: func(context *cli.Context) error {
 		var (
 			id  = context.Args().Get(1)

--- a/cmd/ctr/commands/run/run.go
+++ b/cmd/ctr/commands/run/run.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"runtime"
 	"strings"
 
 	"github.com/containerd/console"
@@ -37,67 +36,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
-
-// ContainerFlags are cli flags specifying container options
-var ContainerFlags = []cli.Flag{
-	cli.StringFlag{
-		Name:  "config,c",
-		Usage: "path to the runtime-specific spec config file",
-	},
-	cli.StringFlag{
-		Name:  "checkpoint",
-		Usage: "provide the checkpoint digest to restore the container",
-	},
-	cli.StringFlag{
-		Name:  "cwd",
-		Usage: "specify the working directory of the process",
-	},
-	cli.StringSliceFlag{
-		Name:  "env",
-		Usage: "specify additional container environment variables (i.e. FOO=bar)",
-	},
-	cli.StringSliceFlag{
-		Name:  "label",
-		Usage: "specify additional labels (i.e. foo=bar)",
-	},
-	cli.StringSliceFlag{
-		Name:  "mount",
-		Usage: "specify additional container mount (ex: type=bind,src=/tmp,dst=/host,options=rbind:ro)",
-	},
-	cli.BoolFlag{
-		Name:  "net-host",
-		Usage: "enable host networking for the container",
-	},
-	cli.BoolFlag{
-		Name:  "privileged",
-		Usage: "run privileged container",
-	},
-	cli.BoolFlag{
-		Name:  "read-only",
-		Usage: "set the containers filesystem as readonly",
-	},
-	cli.StringFlag{
-		Name:  "runtime",
-		Usage: "runtime name (io.containerd.runtime.v1.linux, io.containerd.runtime.v1.windows, io.containerd.runtime.v1.com.vmware.linux)",
-		Value: fmt.Sprintf("io.containerd.runtime.v1.%s", runtime.GOOS),
-	},
-	cli.BoolFlag{
-		Name:  "tty,t",
-		Usage: "allocate a TTY for the container",
-	},
-	cli.StringSliceFlag{
-		Name:  "with-ns",
-		Usage: "specify existing Linux namespaces to join at container runtime (format '<nstype>:<path>')",
-	},
-	cli.StringFlag{
-		Name:  "pid-file",
-		Usage: "file path to write the task's pid",
-	},
-	cli.IntFlag{
-		Name:  "gpus",
-		Usage: "add gpus to the container",
-	},
-}
 
 func loadSpec(path string, s *specs.Spec) error {
 	raw, err := ioutil.ReadFile(path)
@@ -181,7 +119,7 @@ var Command = cli.Command{
 			Name:  "fifo-dir",
 			Usage: "directory used for storing IO FIFOs",
 		},
-	}, append(commands.SnapshotterFlags, ContainerFlags...)...),
+	}, append(commands.SnapshotterFlags, commands.ContainerFlags...)...),
 	Action: func(context *cli.Context) error {
 		var (
 			err error

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -31,16 +31,6 @@ import (
 	"github.com/urfave/cli"
 )
 
-func init() {
-	ContainerFlags = append(ContainerFlags, cli.BoolFlag{
-		Name:  "rootfs",
-		Usage: "use custom rootfs that is not managed by containerd snapshotter",
-	}, cli.BoolFlag{
-		Name:  "no-pivot",
-		Usage: "disable use of pivot-root (linux only)",
-	})
-}
-
 // NewContainer creates a new container
 func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli.Context) (containerd.Container, error) {
 	var (


### PR DESCRIPTION
Commit 05513284e7f7559a9064acf25b302a28f5f040cf exposed the "rootfs"
and "no-pivot" flags for the "containers" command, but it accidentally
removed them for "run" since package-level variables are initialized
before package-level init functions in golang. Hoisting these flags to
a package imported by both commands solves the problem.

Signed-off-by: Felix Abecassis <fabecassis@nvidia.com>