### PR TITLE
Prepare 1.1.1-rc.2

### DIFF
--- a/releases/v1.1.1-rc.2.toml
+++ b/releases/v1.1.1-rc.2.toml
@@ -1,0 +1,37 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+
+# previous release
+previous = "v1.1.0"
+
+pre_release = true
+
+preface = """\
+This is the first patch release for the `containerd` 1.1 release. This
+includes bug fixes related to CRI, image pull, and native snapshotter.
+
+## CRI Plugin
+Fixes for working set memory calculation, privileged container creation and
+image volume directory ownership.
+Fix a bug that container running as non-root will get capabilities added by
+user. This is fixed to keep the behavior consistent with Docker.
+Fix double mount of /dev/shm.
+Fix startup panic when overlayfs fails to load, now cri plugin will just fail.
+
+## Image Pull
+Fix for a size validation bug with some registries which impacts the
+CRI plugin and clients.
+
+## Native Snapshotter
+Fix for bug in layers containing large files.
+
+Please see the changelog for full details.
+"""
+
+# notable prs to include in the release notes, 1234 is the pr number
+[notes]
+
+[breaking]

--- a/vendor.conf
+++ b/vendor.conf
@@ -44,7 +44,7 @@ github.com/gotestyourself/gotestyourself 44dbf532bbf5767611f6f2a61bded572e337010
 github.com/google/go-cmp v0.1.0
 
 # cri dependencies
-github.com/containerd/cri v1.0.3
+github.com/containerd/cri 40007b34d36f81007087578a340c499e4b06c9bb # v1.0.3 + 2 commits
 github.com/containerd/go-cni f2d7272f12d045b16ed924f50e91f9f9cecc55a7
 github.com/blang/semver v3.1.0
 github.com/containernetworking/cni v0.6.0

--- a/vendor/github.com/containerd/cri/pkg/server/container_create.go
+++ b/vendor/github.com/containerd/cri/pkg/server/container_create.go
@@ -777,6 +777,10 @@ func defaultRuntimeSpec(id string) (*runtimespec.Spec, error) {
 		if mount.Destination == "/run" {
 			continue
 		}
+		// CRI plugin handles `/dev/shm` itself.
+		if mount.Destination == "/dev/shm" {
+			continue
+		}
 		mounts = append(mounts, mount)
 	}
 	spec.Mounts = mounts

--- a/vendor/github.com/containerd/cri/pkg/server/sandbox_run.go
+++ b/vendor/github.com/containerd/cri/pkg/server/sandbox_run.go
@@ -388,6 +388,14 @@ func (c *criService) generateSandboxContainerSpec(id string, config *runtime.Pod
 		g.RemoveLinuxNamespace(string(runtimespec.IPCNamespace)) // nolint: errcheck
 	}
 
+	// It's fine to generate the spec before the sandbox /dev/shm
+	// is actually created.
+	sandboxDevShm := c.getSandboxDevShm(id)
+	if nsOptions.GetIpc() == runtime.NamespaceMode_NODE {
+		sandboxDevShm = devShm
+	}
+	g.AddBindMount(sandboxDevShm, devShm, []string{"rbind", "ro"})
+
 	selinuxOpt := securityContext.GetSelinuxOptions()
 	processLabel, mountLabel, err := initSelinuxOpts(selinuxOpt)
 	if err != nil {

--- a/vendor/github.com/containerd/cri/pkg/server/service.go
+++ b/vendor/github.com/containerd/cri/pkg/server/service.go
@@ -128,6 +128,10 @@ func NewCRIService(config criconfig.Config, client *containerd.Client) (CRIServi
 		selinux.SetDisabled()
 	}
 
+	if client.SnapshotService(c.config.ContainerdConfig.Snapshotter) == nil {
+		return nil, errors.Errorf("failed to find snapshotter %q", c.config.ContainerdConfig.Snapshotter)
+	}
+
 	c.imageFSPath = imageFSPath(config.ContainerdRootDir, config.ContainerdConfig.Snapshotter)
 	logrus.Infof("Get image filesystem path %q", c.imageFSPath)
 

--- a/version/version.go
+++ b/version/version.go
@@ -21,7 +21,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.1.1-rc.1+unknown"
+	Version = "1.1.1-rc.2+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
This creates the release file for 1.1.1-rc.2 and updates the version.

The vendor change is included and the only change for this release. This fixes a startup panic when starting up containerd on a filesystem which does not have d_type support.

Note: this is vendoring against the cri release branch rather than a tag. For the final release the tag will be made in cri and used here.