### PR TITLE
Add support for proxy plugins

### DIFF
--- a/cmd/containerd/command/config.go
+++ b/cmd/containerd/command/config.go
@@ -17,6 +17,7 @@
 package command
 
 import (
+	gocontext "context"
 	"io"
 	"os"
 
@@ -48,7 +49,7 @@ var configCommand = cli.Command{
 				config := &Config{
 					Config: defaultConfig(),
 				}
-				plugins, err := server.LoadPlugins(config.Config)
+				plugins, err := server.LoadPlugins(gocontext.Background(), config.Config)
 				if err != nil {
 					return err
 				}

--- a/services/server/config.go
+++ b/services/server/config.go
@@ -43,6 +43,8 @@ type Config struct {
 	OOMScore int `toml:"oom_score"`
 	// Cgroup specifies cgroup information for the containerd daemon process
 	Cgroup CgroupConfig `toml:"cgroup"`
+	// ProxyPlugins configures plugins which are communicated to over GRPC
+	ProxyPlugins map[string]ProxyPlugin `toml:"proxy_plugins"`
 
 	md toml.MetaData
 }
@@ -73,6 +75,12 @@ type MetricsConfig struct {
 // CgroupConfig provides cgroup configuration
 type CgroupConfig struct {
 	Path string `toml:"path"`
+}
+
+// ProxyPlugin provides a proxy plugin configuration
+type ProxyPlugin struct {
+	Type    string `toml:"type"`
+	Address string `toml:"address"`
 }
 
 // Decode unmarshals a plugin specific configuration by plugin id


### PR DESCRIPTION
Allows creation of proxy plugins by name, type, and address in the daemon configuration. If multiple plugins are using the same address, containerd will only use a single grpc client conn for that address.