### PR TITLE
[release/1.1] Fix arm platform matching

### DIFF
--- a/platforms/database.go
+++ b/platforms/database.go
@@ -92,8 +92,8 @@ func normalizeArch(arch, variant string) (string, string) {
 	case "aarch64", "arm64":
 		arch = "arm64"
 		switch variant {
-		case "", "8":
-			variant = "v8"
+		case "8", "v8":
+			variant = ""
 		}
 	case "armhf":
 		arch = "arm"
@@ -111,16 +111,4 @@ func normalizeArch(arch, variant string) (string, string) {
 	}
 
 	return arch, variant
-}
-
-// defaultVariant detects default variants on normalized arch/variant
-func defaultVariant(arch, variant string) bool {
-	switch arch {
-	case "arm64":
-		return variant == "v8"
-	case "arm":
-		return variant == "v7"
-	default:
-		return true
-	}
 }

--- a/platforms/database.go
+++ b/platforms/database.go
@@ -89,18 +89,21 @@ func normalizeArch(arch, variant string) (string, string) {
 	case "x86_64", "x86-64":
 		arch = "amd64"
 		variant = ""
-	case "aarch64":
+	case "aarch64", "arm64":
 		arch = "arm64"
-		variant = "" // v8 is implied
+		switch variant {
+		case "", "8":
+			variant = "v8"
+		}
 	case "armhf":
 		arch = "arm"
-		variant = ""
+		variant = "v7"
 	case "armel":
 		arch = "arm"
 		variant = "v6"
 	case "arm":
 		switch variant {
-		case "v7", "7":
+		case "", "7":
 			variant = "v7"
 		case "5", "6", "8":
 			variant = "v" + variant
@@ -108,4 +111,16 @@ func normalizeArch(arch, variant string) (string, string) {
 	}
 
 	return arch, variant
+}
+
+// defaultVariant detects default variants on normalized arch/variant
+func defaultVariant(arch, variant string) bool {
+	switch arch {
+	case "arm64":
+		return variant == "v8"
+	case "arm":
+		return variant == "v7"
+	default:
+		return true
+	}
 }

--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -197,7 +197,7 @@ func Parse(specifier string) (specs.Platform, error) {
 		}
 
 		p.Architecture, p.Variant = normalizeArch(parts[0], "")
-		if defaultVariant(p.Architecture, p.Variant) {
+		if p.Architecture == "arm" && p.Variant == "v7" {
 			p.Variant = ""
 		}
 		if isKnownArch(p.Architecture) {
@@ -211,7 +211,7 @@ func Parse(specifier string) (specs.Platform, error) {
 		// about whether or not we know of the platform.
 		p.OS = normalizeOS(parts[0])
 		p.Architecture, p.Variant = normalizeArch(parts[1], "")
-		if defaultVariant(p.Architecture, p.Variant) {
+		if p.Architecture == "arm" && p.Variant == "v7" {
 			p.Variant = ""
 		}
 
@@ -220,6 +220,9 @@ func Parse(specifier string) (specs.Platform, error) {
 		// we have a fully specified variant, this is rare
 		p.OS = normalizeOS(parts[0])
 		p.Architecture, p.Variant = normalizeArch(parts[1], parts[2])
+		if p.Architecture == "arm64" && p.Variant == "" {
+			p.Variant = "v8"
+		}
 
 		return p, nil
 	}

--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -135,7 +135,7 @@ type Matcher interface {
 // Applications should opt to use `Match` over directly parsing specifiers.
 func NewMatcher(platform specs.Platform) Matcher {
 	return &matcher{
-		Platform: platform,
+		Platform: Normalize(platform),
 	}
 }
 
@@ -197,6 +197,9 @@ func Parse(specifier string) (specs.Platform, error) {
 		}
 
 		p.Architecture, p.Variant = normalizeArch(parts[0], "")
+		if defaultVariant(p.Architecture, p.Variant) {
+			p.Variant = ""
+		}
 		if isKnownArch(p.Architecture) {
 			p.OS = runtime.GOOS
 			return p, nil
@@ -208,6 +211,9 @@ func Parse(specifier string) (specs.Platform, error) {
 		// about whether or not we know of the platform.
 		p.OS = normalizeOS(parts[0])
 		p.Architecture, p.Variant = normalizeArch(parts[1], "")
+		if defaultVariant(p.Architecture, p.Variant) {
+			p.Variant = ""
+		}
 
 		return p, nil
 	case 3:


### PR DESCRIPTION
The normalization was being inconsistently applied causing a failure to match some platforms in manifest lists. Fix the matcher and normalization to be more consistent and add changes to parser to prevent the defaulted variants from being set in the platform structure.

(cherry picked from commit 37ab93e2c89fd8bc1e08c914246926fabf902893)