### PR TITLE
Normalize arm64 to an empty variant

### DIFF
--- a/platforms/database.go
+++ b/platforms/database.go
@@ -92,8 +92,8 @@ func normalizeArch(arch, variant string) (string, string) {
 	case "aarch64", "arm64":
 		arch = "arm64"
 		switch variant {
-		case "", "8":
-			variant = "v8"
+		case "8", "v8":
+			variant = ""
 		}
 	case "armhf":
 		arch = "arm"
@@ -111,16 +111,4 @@ func normalizeArch(arch, variant string) (string, string) {
 	}
 
 	return arch, variant
-}
-
-// defaultVariant detects default variants on normalized arch/variant
-func defaultVariant(arch, variant string) bool {
-	switch arch {
-	case "arm64":
-		return variant == "v8"
-	case "arm":
-		return variant == "v7"
-	default:
-		return true
-	}
 }

--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -197,7 +197,7 @@ func Parse(specifier string) (specs.Platform, error) {
 		}
 
 		p.Architecture, p.Variant = normalizeArch(parts[0], "")
-		if defaultVariant(p.Architecture, p.Variant) {
+		if p.Architecture == "arm" && p.Variant == "v7" {
 			p.Variant = ""
 		}
 		if isKnownArch(p.Architecture) {
@@ -211,7 +211,7 @@ func Parse(specifier string) (specs.Platform, error) {
 		// about whether or not we know of the platform.
 		p.OS = normalizeOS(parts[0])
 		p.Architecture, p.Variant = normalizeArch(parts[1], "")
-		if defaultVariant(p.Architecture, p.Variant) {
+		if p.Architecture == "arm" && p.Variant == "v7" {
 			p.Variant = ""
 		}
 
@@ -220,6 +220,9 @@ func Parse(specifier string) (specs.Platform, error) {
 		// we have a fully specified variant, this is rare
 		p.OS = normalizeOS(parts[0])
 		p.Architecture, p.Variant = normalizeArch(parts[1], parts[2])
+		if p.Architecture == "arm64" && p.Variant == "" {
+			p.Variant = "v8"
+		}
 
 		return p, nil
 	}


### PR DESCRIPTION
Updates arm64 normalization to match what is described in https://github.com/golang/go/wiki/GoArm

The output of `Parse` should remain the same, the `Normalize` function should now have an empty variant for `arm64`.