### PR TITLE
Add cio.Load for loading io set

### DIFF
--- a/cio/io.go
+++ b/cio/io.go
@@ -255,3 +255,14 @@ func (l *logIO) Wait() {
 func (l *logIO) Close() error {
 	return nil
 }
+
+// Load the io for a container but do not attach
+//
+// Allows io to be loaded on the task for deletion without
+// starting copy routines
+func Load(set *FIFOSet) (IO, error) {
+	return &cio{
+		config:  set.Config,
+		closers: []io.Closer{set},
+	}, nil
+}

--- a/cmd/ctr/commands/containers/containers.go
+++ b/cmd/ctr/commands/containers/containers.go
@@ -25,6 +25,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/cmd/ctr/commands/run"
 	"github.com/containerd/containerd/log"
@@ -162,7 +163,6 @@ var deleteCommand = cli.Command{
 				log.G(ctx).WithError(err).Errorf("failed to delete container %q", arg)
 			}
 		}
-
 		return exitErr
 	},
 }
@@ -172,7 +172,7 @@ func deleteContainer(ctx context.Context, client *containerd.Client, id string, 
 	if err != nil {
 		return err
 	}
-	task, err := container.Task(ctx, nil)
+	task, err := container.Task(ctx, cio.Load)
 	if err != nil {
 		return container.Delete(ctx, opts...)
 	}

--- a/cmd/ctr/commands/tasks/delete.go
+++ b/cmd/ctr/commands/tasks/delete.go
@@ -18,6 +18,7 @@ package tasks
 
 import (
 	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/urfave/cli"
 )
@@ -42,8 +43,7 @@ var deleteCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-
-		task, err := container.Task(ctx, nil)
+		task, err := container.Task(ctx, cio.Load)
 		if err != nil {
 			return err
 		}

--- a/container.go
+++ b/container.go
@@ -307,6 +307,12 @@ func (c *container) get(ctx context.Context) (containers.Container, error) {
 
 // get the existing fifo paths from the task information stored by the daemon
 func attachExistingIO(response *tasks.GetResponse, ioAttach cio.Attach) (cio.IO, error) {
+	fifoSet := loadFifos(response)
+	return ioAttach(fifoSet)
+}
+
+// loadFifos loads the containers fifos
+func loadFifos(response *tasks.GetResponse) *cio.FIFOSet {
 	path := getFifoDir([]string{
 		response.Process.Stdin,
 		response.Process.Stdout,
@@ -315,13 +321,12 @@ func attachExistingIO(response *tasks.GetResponse, ioAttach cio.Attach) (cio.IO,
 	closer := func() error {
 		return os.RemoveAll(path)
 	}
-	fifoSet := cio.NewFIFOSet(cio.Config{
+	return cio.NewFIFOSet(cio.Config{
 		Stdin:    response.Process.Stdin,
 		Stdout:   response.Process.Stdout,
 		Stderr:   response.Process.Stderr,
 		Terminal: response.Process.Terminal,
 	}, closer)
-	return ioAttach(fifoSet)
 }
 
 // getFifoDir looks for any non-empty path for a stdio fifo


### PR DESCRIPTION
This adds a `Load` Opt for cio to load a tasks io/fifos without
attaching or starting the copy routines.

It adds the load method in `ctr` by default so that fifos or other IO
are removed from disk on delete methods inbetween command runs.  It is
not the default for all task loads for backwards compat. and a user may
want to keep io around to reuse or if log files are used.

Fixes #2421

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>