### PR TITLE
Set shim max procs via env var

### DIFF
--- a/runtime/shim/client/client.go
+++ b/runtime/shim/client/client.go
@@ -136,6 +136,7 @@ func newCommand(binary, daemonAddress string, debug bool, config shim.Config, so
 	// will be mounted by the shim
 	cmd.SysProcAttr = getSysProcAttr()
 	cmd.ExtraFiles = append(cmd.ExtraFiles, socket)
+	cmd.Env = append(os.Environ(), "GOMAXPROCS=2")
 	if debug {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr


### PR DESCRIPTION
This sets the shim's max procs to 2, like we already have hard coded in
the shim, with the env var so that it is set at go runtime boot.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>