### PR TITLE
Introduce plugins/list subcommand

### DIFF
--- a/cmd/ctr/commands/plugins/plugins.go
+++ b/cmd/ctr/commands/plugins/plugins.go
@@ -37,6 +37,15 @@ var Command = cli.Command{
 	Name:    "plugins",
 	Aliases: []string{"plugin"},
 	Usage:   "provides information about containerd plugins",
+	Subcommands: []cli.Command{
+		listCommand,
+	},
+}
+
+var listCommand = cli.Command{
+	Name:    "list",
+	Aliases: []string{"ls"},
+	Usage:   "lists containerd plugins",
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "quiet,q",


### PR DESCRIPTION
`Ctr` interface follows the pattern `ctr <command> <subcommand>` except
for the `plugins` command which does not have subcommands. This feels
unnatural to certain users and they would expect that they can list
containerd plugins via `ctr plugins list`.

This commit implements their expectation so that `plugins` becomes a
command "group" and its `list` subcommand actually lists the plugins.

Signed-off-by: Danail Branekov <danailster@gmail.com>