### PR TITLE
Bump to Go 1.11.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.10
+    - GO_VERSION: 1.11
 
 before_build:
   - choco install -y mingw

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 language: go
 
 go:
-  - "1.10.x"
+  - "1.11.x"
 
 go_import_path: github.com/containerd/containerd
 

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -7,19 +7,19 @@
 #
 
 # Install proto3
-FROM golang:1.10 AS proto3
+FROM golang:1.11 AS proto3
 RUN apt-get update && apt-get install -y autoconf automake g++ libtool unzip
 COPY script/setup/install-protobuf install-protobuf
 RUN ./install-protobuf
 
 # Install runc
-FROM golang:1.10 AS runc
+FROM golang:1.11 AS runc
 RUN apt-get update && apt-get install -y curl libseccomp-dev
 COPY vendor.conf /go/src/github.com/containerd/containerd/vendor.conf
 COPY script/setup/install-runc install-runc
 RUN ./install-runc
 
-FROM golang:1.10
+FROM golang:1.11
 RUN apt-get update && apt-get install -y btrfs-tools gcc git libseccomp-dev make xfsprogs
 
 COPY --from=proto3 /usr/local/bin/protoc /usr/local/bin/protoc


### PR DESCRIPTION
Already saw some breakage in https://github.com/moby/moby/pull/37358, so lets run it here as well

Changelog: https://tip.golang.org/doc/go1.11