### PR TITLE
Workaround for gofmt change in Go 1.11

### DIFF
--- a/content/testsuite/testsuite.go
+++ b/content/testsuite/testsuite.go
@@ -367,6 +367,7 @@ func checkLabels(ctx context.Context, t *testing.T, cs content.Store) {
 	labels := map[string]string{
 		"k1": "v1",
 		"k2": "v2",
+
 		"containerd.io/gc.root": rootTime,
 	}
 
@@ -403,6 +404,7 @@ func checkLabels(ctx context.Context, t *testing.T, cs content.Store) {
 
 	info.Labels = map[string]string{
 		"k1": "v1",
+
 		"containerd.io/gc.root": rootTime,
 	}
 	preUpdate = time.Now()

--- a/snapshots/testsuite/testsuite.go
+++ b/snapshots/testsuite/testsuite.go
@@ -684,6 +684,7 @@ func checkUpdate(ctx context.Context, t *testing.T, snapshotter snapshots.Snapsh
 		expected = map[string]string{
 			"l1": "updated",
 			"l3": "v3",
+
 			"containerd.io/gc.root": rootTime,
 		}
 		st.Labels = map[string]string{
@@ -698,6 +699,7 @@ func checkUpdate(ctx context.Context, t *testing.T, snapshotter snapshots.Snapsh
 
 		expected = map[string]string{
 			"l4": "v4",
+
 			"containerd.io/gc.root": rootTime,
 		}
 		st.Labels = expected


### PR DESCRIPTION
Go 1.11 uses a different formatting for maps, and now aligns values; running `gofmt -s -w` on this file resulted in this diff (see https://github.com/containerd/containerd/pull/2435);

```patch
diff --git a/content/testsuite/testsuite.go b/content/testsuite/testsuite.go
index 974c7cb8ed..d9ae9dc160 100644
--- a/content/testsuite/testsuite.go
+++ b/content/testsuite/testsuite.go
@@ -365,8 +365,8 @@ func checkLabels(ctx context.Context, t *testing.T, cs content.Store) {

 	rootTime := time.Now().UTC().Format(time.RFC3339)
 	labels := map[string]string{
-		"k1": "v1",
-		"k2": "v2",
+		"k1":                    "v1",
+		"k2":                    "v2",
 		"containerd.io/gc.root": rootTime,
 	}

@@ -402,7 +402,7 @@ func checkLabels(ctx context.Context, t *testing.T, cs content.Store) {
 	}

 	info.Labels = map[string]string{
-		"k1": "v1",
+		"k1":                    "v1",
 		"containerd.io/gc.root": rootTime,
 	}
 	preUpdate = time.Now()
```

Adding a whitespace before the long key to make it format the same on both Go 1.11 and older versions of Go.
