### PR TITLE
Remove Go version check in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ script:
   - script/validate/vendor
   - go build -i .
   - make check
-  - if [[ "$GOOS" = "linux" && "$TRAVIS_GO_VERSION" != "1.9"* ]]; then make check-protos check-api-descriptors; fi
+  - if [ "$GOOS" = "linux" ]; then make check-protos check-api-descriptors; fi
   - make build
   - make binaries
   - if [ "$GOOS" = "linux" ]; then sudo make install ; fi


### PR DESCRIPTION
containerd now only supports Go 1.10+, and travis is not configured to run on older versions, so this check became redundant.
