### PR TITLE
update containerd/console to fix race: lock Cond before Signal

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,5 +1,5 @@
 github.com/containerd/go-runc f271fa2021de855d4d918dbef83c5fe19db1bdd5
-github.com/containerd/console 9290d21dc56074581f619579c43d970b4514bc08
+github.com/containerd/console 5d1b48d6114b8c9666f0c8b916f871af97b0a761
 github.com/containerd/cgroups fe281dd265766145e943a034aa41086474ea6130
 github.com/containerd/typeurl a93fcdb778cd272c6e9b3028b2f42d813e785d40
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c

--- a/vendor/github.com/containerd/console/console_linux.go
+++ b/vendor/github.com/containerd/console/console_linux.go
@@ -262,10 +262,14 @@ func (ec *EpollConsole) Shutdown(close func(int) error) error {
 
 // signalRead signals that the console is readable.
 func (ec *EpollConsole) signalRead() {
+	ec.readc.L.Lock()
 	ec.readc.Signal()
+	ec.readc.L.Unlock()
 }
 
 // signalWrite signals that the console is writable.
 func (ec *EpollConsole) signalWrite() {
+	ec.writec.L.Lock()
 	ec.writec.Signal()
+	ec.writec.L.Unlock()
 }


### PR DESCRIPTION
Full diff: https://github.com/containerd/console/compare/9290d21dc56074581f619579c43d970b4514bc08...5d1b48d6114b8c9666f0c8b916f871af97b0a761

brings in https://github.com/containerd/console/pull/27 "console_linux: Fix race: lock Cond before Signal"

relates to https://github.com/moby/moby/issues/35865