### PR TITLE
Add /proc/acpi and /proc/keys to masked paths

### DIFF
--- a/oci/spec_unix.go
+++ b/oci/spec_unix.go
@@ -153,6 +153,7 @@ func createDefaultSpec(ctx context.Context, id string) (*Spec, error) {
 		},
 		Linux: &specs.Linux{
 			MaskedPaths: []string{
+				"/proc/acpi",
 				"/proc/kcore",
 				"/proc/latency_stats",
 				"/proc/timer_list",

--- a/oci/spec_unix.go
+++ b/oci/spec_unix.go
@@ -155,6 +155,7 @@ func createDefaultSpec(ctx context.Context, id string) (*Spec, error) {
 			MaskedPaths: []string{
 				"/proc/acpi",
 				"/proc/kcore",
+				"/proc/keys",
 				"/proc/latency_stats",
 				"/proc/timer_list",
 				"/proc/timer_stats",


### PR DESCRIPTION
relates to CVE-2018-10892

should probably be cherry-picked to release-branches