### PR TITLE
test: Increase btrfs loopback device size to 128MB

### DIFF
--- a/snapshots/btrfs/btrfs_test.go
+++ b/snapshots/btrfs/btrfs_test.go
@@ -45,7 +45,7 @@ func boltSnapshotter(t *testing.T) func(context.Context, string) (snapshots.Snap
 
 	return func(ctx context.Context, root string) (snapshots.Snapshotter, func() error, error) {
 
-		loopbackSize := int64(100 << 20) // 100 MB
+		loopbackSize := int64(128 << 20) // 128 MB
 		// mkfs.btrfs creates a fs which has a blocksize equal to the system default pagesize. If that pagesize
 		// is > 4KB, mounting the fs will fail unless we increase the size of the file used by mkfs.btrfs
 		if os.Getpagesize() > 4096 {


### PR DESCRIPTION
With btrfs-prog 4.17 as shipped with Alpine 3.8 the btrfs tests
fail with:

  ERROR: '/dev/loop1' is too small to make a usable filesystem
  ERROR: minimum size for each btrfs device is 114294784

btrfs-prog commit 997f9977c243 ("btrfs-progs: mkfs: Prevent
temporary system chunk to use space in reserved 1M range")
changed the code to compute the minimum size for a btrfs size
and is the likely reason for this error.

Increase the size of the loop back device to 128MB for
the btrfs test.

With this fix, the containerd tests pass on Alpine 3.8,
tested in LinuxKit with kernel 4.14.53.

fixes #2447

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@gmail.com>