### PR TITLE
Switching from crypto/rand to math/rand to avoid blocking

### DIFF
--- a/diff/walking/differ.go
+++ b/diff/walking/differ.go
@@ -18,10 +18,10 @@ package walking
 
 import (
 	"context"
-	"crypto/rand"
 	"encoding/base64"
 	"fmt"
 	"io"
+	"math/rand"
 	"time"
 
 	"github.com/containerd/containerd/archive"

--- a/rootfs/apply.go
+++ b/rootfs/apply.go
@@ -18,9 +18,9 @@ package rootfs
 
 import (
 	"context"
-	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"math/rand"
 	"time"
 
 	"github.com/containerd/containerd/diff"

--- a/services/leases/local.go
+++ b/services/leases/local.go
@@ -18,9 +18,9 @@ package leases
 
 import (
 	"context"
-	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"math/rand"
 	"time"
 
 	"google.golang.org/grpc"


### PR DESCRIPTION
Addresses at least part of #2451...

In early-boot situations on systems without HWRNGs, `containerd` will hang on start until enough entropy has been gathered for `crypto/rand`'s `Read` to unblock. In these cases, `math/rand`'s `Read` is a more ideal choice since it's non-blocking.

Note that this is a much bigger deal than it was before patches for [CVE-2018-1108](https://nvd.nist.gov/vuln/detail/CVE-2018-1108) landed in the Linux kernel.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>