### PR TITLE
oci-exporter: do not filter current platform on export

### DIFF
--- a/images/oci/exporter.go
+++ b/images/oci/exporter.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
-	"github.com/containerd/containerd/platforms"
 	ocispecs "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -58,7 +57,7 @@ func (oe *V1Exporter) Export(ctx context.Context, store content.Provider, desc o
 	}
 
 	handlers := images.Handlers(
-		images.FilterPlatforms(images.ChildrenHandler(store), platforms.Default()),
+		images.ChildrenHandler(store),
 		images.HandlerFunc(exportHandler),
 	)
 


### PR DESCRIPTION
OCI exporter should create tarball with all local data, not filter by the platform of the local machine. Possibly options for setting custom platforms can be added later but this should be the default behavior.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>