### PR TITLE
Update client Image to have configurable platform

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -111,7 +111,7 @@ func TestMain(m *testing.M) {
 	}).Info("running tests against containerd")
 
 	// pull a seed image
-	if _, err = client.Pull(ctx, testImage, WithPullUnpack, WithPlatform(platforms.Default())); err != nil {
+	if _, err = client.Pull(ctx, testImage, WithPullUnpack); err != nil {
 		ctrd.Stop()
 		ctrd.Wait()
 		fmt.Fprintf(os.Stderr, "%s: %s\n", err, buf.String())
@@ -198,11 +198,11 @@ func TestImagePullAllPlatforms(t *testing.T) {
 	defer cancel()
 
 	cs := client.ContentStore()
-	img, err := client.Pull(ctx, testImage)
+	img, err := client.Fetch(ctx, testImage)
 	if err != nil {
 		t.Fatal(err)
 	}
-	index := img.Target()
+	index := img.Target
 	manifests, err := images.Children(ctx, cs, index)
 	if err != nil {
 		t.Fatal(err)
@@ -246,12 +246,12 @@ func TestImagePullSomePlatforms(t *testing.T) {
 		opts = append(opts, WithPlatform(platform))
 	}
 
-	img, err := client.Pull(ctx, "docker.io/library/busybox:latest", opts...)
+	img, err := client.Fetch(ctx, "docker.io/library/busybox:latest", opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	index := img.Target()
+	index := img.Target
 	manifests, err := images.Children(ctx, cs, index)
 	if err != nil {
 		t.Fatal(err)

--- a/export_test.go
+++ b/export_test.go
@@ -40,11 +40,11 @@ func TestOCIExport(t *testing.T) {
 	}
 	defer client.Close()
 
-	pulled, err := client.Pull(ctx, testImage)
+	pulled, err := client.Fetch(ctx, testImage)
 	if err != nil {
 		t.Fatal(err)
 	}
-	exportedStream, err := client.Export(ctx, &oci.V1Exporter{}, pulled.Target())
+	exportedStream, err := client.Export(ctx, &oci.V1Exporter{}, pulled.Target)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/import_test.go
+++ b/import_test.go
@@ -39,12 +39,12 @@ func TestOCIExportAndImport(t *testing.T) {
 	}
 	defer client.Close()
 
-	pulled, err := client.Pull(ctx, testImage)
+	pulled, err := client.Fetch(ctx, testImage)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	exported, err := client.Export(ctx, &oci.V1Exporter{}, pulled.Target())
+	exported, err := client.Export(ctx, &oci.V1Exporter{}, pulled.Target)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Separate Fetch and Pull commands in client to distinguish between platform specific and non-platform specific operations.
`ctr images pull` with all platforms will now unpack all platforms.
`ctr content fetch` now supports platform flags.

This enables using the client to unpack on a specified platform which is useful for cross compilation in buildkit or using the client to drive a container/filesystem on a different platform.

