### PR TITLE
Don't fatal on epoll wait

### DIFF
--- a/metrics/cgroups/oom.go
+++ b/metrics/cgroups/oom.go
@@ -116,7 +116,8 @@ func (o *oomCollector) start() {
 			if err == unix.EINTR {
 				continue
 			}
-			logrus.WithField("error", err).Fatal("cgroups: epoll wait")
+			logrus.WithError(err).Error("cgroups: epoll wait failed, OOM notifications disabled")
+			return
 		}
 		for i := 0; i < n; i++ {
 			o.process(uintptr(events[i].Fd), events[i].Events)


### PR DESCRIPTION
This removes a log fatal on epoll wait for OOM events.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>