### PR TITLE
BUILDING.md: add osusergo for static build

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -117,7 +117,7 @@ You can build static binaries by providing a few variables to `make`:
 ```sudo
 make EXTRA_FLAGS="-buildmode pie" \
 	EXTRA_LDFLAGS='-extldflags "-fno-PIC -static"' \
-	BUILDTAGS="static_build netgo"
+	BUILDTAGS="netgo osusergo static_build"
 ```
 
 > *Note*:


### PR DESCRIPTION
Go 1.11 includes a fix to os/user to be working in a static binary
(fixing https://github.com/golang/go/issues/23265). The fix requires
`osusergo` build tag to be set for static binaries, which is what
this commit documents.