### PR TITLE
oci: introduce WithSpecFromFile combinator

### DIFF
--- a/cmd/ctr/commands/run/run.go
+++ b/cmd/ctr/commands/run/run.go
@@ -19,9 +19,7 @@ package run
 import (
 	gocontext "context"
 	"encoding/csv"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"strings"
 
 	"github.com/containerd/console"
@@ -36,17 +34,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
-
-func loadSpec(path string, s *specs.Spec) error {
-	raw, err := ioutil.ReadFile(path)
-	if err != nil {
-		return errors.New("cannot load spec config file")
-	}
-	if err := json.Unmarshal(raw, s); err != nil {
-		return errors.Errorf("decoding spec config file failed, current supported OCI runtime-spec : v%s", specs.Version)
-	}
-	return nil
-}
 
 func withMounts(context *cli.Context) oci.SpecOpts {
 	return func(ctx gocontext.Context, client oci.Client, container *containers.Container, s *specs.Spec) error {

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -52,6 +52,13 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 		cOpts []containerd.NewContainerOpts
 		spec  containerd.NewContainerOpts
 	)
+
+	if context.IsSet("config") {
+		opts = append(opts, oci.WithSpecFromFile(context.String("config")))
+	} else {
+		opts = append(opts, oci.WithDefaultSpec())
+	}
+
 	opts = append(opts, oci.WithEnv(context.StringSlice("env")))
 	opts = append(opts, withMounts(context))
 	cOpts = append(cOpts, containerd.WithContainerLabels(commands.LabelArgs(context.StringSlice("label"))))
@@ -117,15 +124,10 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 	if context.IsSet("gpus") {
 		opts = append(opts, nvidia.WithGPUs(nvidia.WithDevices(context.Int("gpus")), nvidia.WithAllCapabilities))
 	}
-	if context.IsSet("config") {
-		var s specs.Spec
-		if err := loadSpec(context.String("config"), &s); err != nil {
-			return nil, err
-		}
-		spec = containerd.WithSpec(&s, opts...)
-	} else {
-		spec = containerd.WithNewSpec(opts...)
-	}
+
+	var s specs.Spec
+	spec = containerd.WithSpec(&s, opts...)
+
 	cOpts = append(cOpts, spec)
 
 	// oci.WithImageConfig (WithUsername, WithUserID) depends on rootfs snapshot for resolving /etc/passwd.

--- a/cmd/ctr/commands/run/run_windows.go
+++ b/cmd/ctr/commands/run/run_windows.go
@@ -63,6 +63,13 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 		cOpts []containerd.NewContainerOpts
 		spec  containerd.NewContainerOpts
 	)
+
+	if context.IsSet("config") {
+		opts = append(opts, oci.WithSpecFromFile(context.String("config")))
+	} else {
+		opts = append(opts, oci.WithDefaultSpec())
+	}
+
 	opts = append(opts, oci.WithImageConfig(image))
 	opts = append(opts, oci.WithEnv(context.StringSlice("env")))
 	opts = append(opts, withMounts(context))
@@ -74,15 +81,8 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 		opts = append(opts, oci.WithProcessCwd(cwd))
 	}
 
-	if context.IsSet("config") {
-		var s specs.Spec
-		if err := loadSpec(context.String("config"), &s); err != nil {
-			return nil, err
-		}
-		spec = containerd.WithSpec(&s, opts...)
-	} else {
-		spec = containerd.WithNewSpec(opts...)
-	}
+	var s specs.Spec
+	spec = containerd.WithSpec(&s, opts...)
 
 	cOpts = append(cOpts, containerd.WithContainerLabels(commands.LabelArgs(context.StringSlice("label"))))
 	cOpts = append(cOpts, containerd.WithImage(image))

--- a/container_opts.go
+++ b/container_opts.go
@@ -197,11 +197,10 @@ func WithNewSpec(opts ...oci.SpecOpts) NewContainerOpts {
 // WithSpec sets the provided spec on the container
 func WithSpec(s *oci.Spec, opts ...oci.SpecOpts) NewContainerOpts {
 	return func(ctx context.Context, client *Client, c *containers.Container) error {
-		for _, o := range opts {
-			if err := o(ctx, client, c, s); err != nil {
-				return err
-			}
+		if err := oci.ApplyOpts(ctx, client, c, s, opts...); err != nil {
+			return err
 		}
+
 		var err error
 		c.Spec, err = typeurl.MarshalAny(s)
 		return err

--- a/oci/spec.go
+++ b/oci/spec.go
@@ -34,10 +34,23 @@ func GenerateSpec(ctx context.Context, client Client, c *containers.Container, o
 	if err != nil {
 		return nil, err
 	}
+
+	return s, ApplyOpts(ctx, client, c, s, opts...)
+}
+
+// ApplyOpts applys the options to the given spec, injecting data from the
+// context, client and container instance.
+func ApplyOpts(ctx context.Context, client Client, c *containers.Container, s *Spec, opts ...SpecOpts) error {
 	for _, o := range opts {
 		if err := o(ctx, client, c, s); err != nil {
-			return nil, err
+			return err
 		}
 	}
-	return s, nil
+
+	return nil
+}
+
+func createDefaultSpec(ctx context.Context, id string) (*Spec, error) {
+	var s Spec
+	return &s, populateDefaultSpec(ctx, &s, id)
 }

--- a/oci/spec_unix.go
+++ b/oci/spec_unix.go
@@ -76,12 +76,13 @@ func defaultNamespaces() []specs.LinuxNamespace {
 	}
 }
 
-func createDefaultSpec(ctx context.Context, id string) (*Spec, error) {
+func populateDefaultSpec(ctx context.Context, s *Spec, id string) error {
 	ns, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	s := &Spec{
+
+	*s = Spec{
 		Version: specs.Version,
 		Root: &specs.Root{
 			Path: defaultRootfsPath,
@@ -183,5 +184,5 @@ func createDefaultSpec(ctx context.Context, id string) (*Spec, error) {
 			Namespaces: defaultNamespaces(),
 		},
 	}
-	return s, nil
+	return nil
 }

--- a/oci/spec_windows.go
+++ b/oci/spec_windows.go
@@ -22,8 +22,8 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-func createDefaultSpec(ctx context.Context, id string) (*Spec, error) {
-	return &Spec{
+func populateDefaultSpec(ctx context.Context, s *Spec, id string) error {
+	*s = Spec{
 		Version: specs.Version,
 		Root:    &specs.Root{},
 		Process: &specs.Process{
@@ -39,5 +39,6 @@ func createDefaultSpec(ctx context.Context, id string) (*Spec, error) {
 				AllowUnqualifiedDNSQuery: true,
 			},
 		},
-	}, nil
+	}
+	return nil
 }


### PR DESCRIPTION
We introduce a WithSpecFromFile option combinator to allow creation
simpler creation of OCI specs from a file name. Often used as the first
option in a `SpecOpts` slice, it simplifies choosing between a local
file and the built-in default.

The code in `ctr run` has been updated to use the new option, with out
changing the order of operations or functionality present there.

Signed-off-by: Stephen Day <stephen.day@getcruise.com>