### PR TITLE
native: set '/' permission to 0755

### DIFF
--- a/snapshots/native/native.go
+++ b/snapshots/native/native.go
@@ -251,6 +251,9 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create temp dir")
 		}
+		if err := os.Chmod(td, 0755); err != nil {
+			return nil, errors.Wrapf(err, "failed to chmod %s to 0755", td)
+		}
 		defer func() {
 			if err != nil {
 				if td != "" {

--- a/snapshots/testsuite/testsuite.go
+++ b/snapshots/testsuite/testsuite.go
@@ -62,6 +62,7 @@ func SnapshotterSuite(t *testing.T, name string, snapshotterFn func(ctx context.
 
 	t.Run("StatInWalk", makeTest(name, snapshotterFn, checkStatInWalk))
 	t.Run("CloseTwice", makeTest(name, snapshotterFn, closeTwice))
+	t.Run("RootPermission", makeTest(name, snapshotterFn, checkRootPermission))
 }
 
 func makeTest(name string, snapshotterFn func(ctx context.Context, root string) (snapshots.Snapshotter, func() error, error), fn func(ctx context.Context, t *testing.T, snapshotter snapshots.Snapshotter, work string)) func(t *testing.T) {
@@ -842,5 +843,20 @@ func closeTwice(ctx context.Context, t *testing.T, snapshotter snapshots.Snapsho
 	}
 	if err := snapshotter.Close(); err != nil {
 		t.Fatalf("The second close failed: %+v", err)
+	}
+}
+
+func checkRootPermission(ctx context.Context, t *testing.T, snapshotter snapshots.Snapshotter, work string) {
+	preparing, err := snapshotterPrepareMount(ctx, snapshotter, "preparing", "", work)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer testutil.Unmount(t, preparing)
+	st, err := os.Stat(preparing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode := st.Mode() & 0777; mode != 0755 {
+		t.Fatalf("expected 0755, got 0%o", mode)
 	}
 }


### PR DESCRIPTION
Unlike other snapshotters, the permission was previously set to 0700
unexpectedly.

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>


Fix https://github.com/moby/buildkit/issues/520#issuecomment-406329609
