### PR TITLE
Fix compilation failures on Go 1.11

### DIFF
--- a/windows/process.go
+++ b/windows/process.go
@@ -121,7 +121,7 @@ func (p *process) HcsPid() uint32 {
 
 func (p *process) ExitCode() (uint32, time.Time, error) {
 	if s := p.Status(); s != runtime.StoppedStatus && s != runtime.CreatedStatus {
-		return 255, time.Time{}, errors.Wrapf(errdefs.ErrFailedPrecondition, "process is not stopped: %s", s)
+		return 255, time.Time{}, errors.Wrapf(errdefs.ErrFailedPrecondition, "process is not stopped: %d", s)
 	}
 	return p.exitCode, p.exitTime, nil
 }

--- a/windows/task.go
+++ b/windows/task.go
@@ -284,7 +284,7 @@ func (t *task) Update(ctx context.Context, resources *types.Any) error {
 func (t *task) Process(ctx context.Context, id string) (p runtime.Process, err error) {
 	p = t.getProcess(id)
 	if p == nil {
-		err = errors.Wrapf(errdefs.ErrNotFound, "no such process %d", id)
+		err = errors.Wrapf(errdefs.ErrNotFound, "no such process %s", id)
 	}
 
 	return p, err
@@ -297,7 +297,7 @@ func (t *task) Stats(ctx context.Context) (*types.Any, error) {
 func (t *task) Wait(ctx context.Context) (*runtime.Exit, error) {
 	p := t.getProcess(t.id)
 	if p == nil {
-		return nil, errors.Wrapf(errdefs.ErrNotFound, "no such process %d", t.id)
+		return nil, errors.Wrapf(errdefs.ErrNotFound, "no such process %s", t.id)
 	}
 	return p.Wait(ctx)
 }


### PR DESCRIPTION
Compilation failed;

    windows\process.go:124: Wrapf format %s has arg s of wrong type github.com/containerd/containerd/runtime.Status
    windows\task.go:287: Wrapf format %d has arg id of wrong type string
    windows\task.go:300: Wrapf format %d has arg t.id of wrong type string
