### PR TITLE
[release/1.1] native: set '/' permission to 0755

### DIFF
--- a/snapshots/native/native.go
+++ b/snapshots/native/native.go
@@ -251,6 +251,9 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create temp dir")
 		}
+		if err := os.Chmod(td, 0755); err != nil {
+			return nil, errors.Wrapf(err, "failed to chmod %s to 0755", td)
+		}
 		defer func() {
 			if err != nil {
 				if td != "" {


### PR DESCRIPTION
Unlike other snapshotters, the permission was previously set to 0700
unexpectedly.

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

---

Cherry-pick https://github.com/containerd/containerd/pull/2485
