### PR TITLE
Set default log formatting to use RFC3339Nano with fixed width

### DIFF
--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -48,6 +48,11 @@ high performance container runtime
 `
 
 func init() {
+	logrus.SetFormatter(&logrus.TextFormatter{
+		TimestampFormat: log.RFC3339NanoFixed,
+		FullTimestamp:   true,
+	})
+
 	// Discard grpc logs so that they don't mess with our stdio
 	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
 

--- a/log/context.go
+++ b/log/context.go
@@ -42,6 +42,10 @@ type (
 // and is usually used to trace detailed behavior of the program.
 const TraceLevel = logrus.Level(uint32(logrus.DebugLevel + 1))
 
+// RFC3339NanoFixed is time.RFC3339Nano with nanoseconds padded using zeros to
+// ensure the formatted time is always the same number of characters.
+const RFC3339NanoFixed = "2006-01-02T15:04:05.000000000Z07:00"
+
 // ParseLevel takes a string level and returns the Logrus log level constant.
 // It supports trace level.
 func ParseLevel(lvl string) (logrus.Level, error) {


### PR DESCRIPTION
This patch changes the logs format to use a fixed-width timestamp, matching the format that's used in dockerd.

Before:

```bash
$ containerd
INFO[0000] starting containerd                           revision=a88b6319614de846458750ff882723479ca7b1a1 version=v1.1.0-202-ga88b6319
INFO[0000] loading plugin "io.containerd.content.v1.content"...  type=io.containerd.content.v1
INFO[0000] loading plugin "io.containerd.snapshotter.v1.btrfs"...  type=io.containerd.snapshotter.v1
WARN[0000] failed to load plugin io.containerd.snapshotter.v1.btrfs  error="path /var/lib/containerd/io.containerd.snapshotter.v1.btrfs must be a btrfs filesystem to be used with the btrfs snapshotter"
```

After:

```bash
$ containerd
INFO[2018-07-24T08:11:07.397856489Z] starting containerd                           revision=c3195155cacb361cd3549c4d78901b20aa19579a version=v1.1.0-203-gc3195155
INFO[2018-07-24T08:11:07.399264587Z] loading plugin "io.containerd.content.v1.content"...  type=io.containerd.content.v1
INFO[2018-07-24T08:11:07.399343959Z] loading plugin "io.containerd.snapshotter.v1.btrfs"...  type=io.containerd.snapshotter.v1
WARN[2018-07-24T08:11:07.399474423Z] failed to load plugin io.containerd.snapshotter.v1.btrfs  error="path /var/lib/containerd/io.containerd.snapshotter.v1.btrfs must be a btrfs filesystem to be used with the btrfs snapshotter"
```

Or, when running as child-process of dockerd:

Before:

```bash
$ dockerd --debug
DEBU[2018-07-24T08:15:16.946312436Z] Listener created for HTTP on unix (/var/run/docker.sock)
INFO[2018-07-24T08:15:16.947086499Z] libcontainerd: started new docker-containerd process  pid=231
INFO[2018-07-24T08:15:16.947137166Z] parsed scheme: "unix"                         module=grpc
INFO[2018-07-24T08:15:16.947235001Z] scheme "unix" not registered, fallback to default scheme  module=grpc
INFO[2018-07-24T08:15:16.947463403Z] ccResolverWrapper: sending new addresses to cc: [{unix:///var/run/docker/containerd/docker-containerd.sock 0  <nil>}]  module=grpc
INFO[2018-07-24T08:15:16.947505954Z] ClientConn switching balancer to "pick_first"  module=grpc
INFO[2018-07-24T08:15:16.947717368Z] pickfirstBalancer: HandleSubConnStateChange: 0xc420507ab0, CONNECTING  module=grpc
INFO[0000] starting containerd                           revision=d64c661f1d51c48782c9cec8fda7604785f93587 version=v1.1.1
DEBU[0000] changing OOM score to -500
INFO[0000] loading plugin "io.containerd.content.v1.content"...  type=io.containerd.content.v1
INFO[0000] loading plugin "io.containerd.snapshotter.v1.btrfs"...  type=io.containerd.snapshotter.v1
WARN[0000] failed to load plugin io.containerd.snapshotter.v1.btrfs  error="path /var/lib/docker/containerd/daemon/io.containerd.snapshotter.v1.btrfs must be a btrfs filesystem to be used with the btrfs snapshotter"
```

After:

```bash
$ dockerd --debug
DEBU[2018-07-24T08:21:33.441741970Z] Listener created for HTTP on unix (/var/run/docker.sock)
INFO[2018-07-24T08:21:33.442428017Z] libcontainerd: started new docker-containerd process  pid=232
INFO[2018-07-24T08:21:33.442510827Z] parsed scheme: "unix"                         module=grpc
INFO[2018-07-24T08:21:33.442598812Z] scheme "unix" not registered, fallback to default scheme  module=grpc
INFO[2018-07-24T08:21:33.442681006Z] ccResolverWrapper: sending new addresses to cc: [{unix:///var/run/docker/containerd/docker-containerd.sock 0  <nil>}]  module=grpc
INFO[2018-07-24T08:21:33.442770353Z] ClientConn switching balancer to "pick_first"  module=grpc
INFO[2018-07-24T08:21:33.442871502Z] pickfirstBalancer: HandleSubConnStateChange: 0xc42018bc30, CONNECTING  module=grpc
INFO[2018-07-24T08:21:33.457963804Z] starting containerd                           revision=597dd082e37f8bc6b6265ca05839d7a300861911 version=597dd082
DEBU[2018-07-24T08:21:33.458113301Z] changing OOM score to -500
INFO[2018-07-24T08:21:33.458474842Z] loading plugin "io.containerd.content.v1.content"...  type=io.containerd.content.v1
INFO[2018-07-24T08:21:33.458911054Z] loading plugin "io.containerd.snapshotter.v1.btrfs"...  type=io.containerd.snapshotter.v1
WARN[2018-07-24T08:21:33.459366268Z] failed to load plugin io.containerd.snapshotter.v1.btrfs  error="path /var/lib/docker/containerd/daemon/io.containerd.snapshotter.v1.btrfs must be a btrfs filesystem to be used with the btrfs snapshotter"
```