### PR TITLE
Remove reference to WithExit in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ If you have [criu](https://criu.org/Main_Page) installed on your machine you can
 
 ```go
 // checkpoint the task then push it to a registry
-checkpoint, err := task.Checkpoint(context, containerd.WithExit)
+checkpoint, err := task.Checkpoint(context)
 
 err := client.Push(context, "myregistry/checkpoints/redis:master", checkpoint)
 


### PR DESCRIPTION
This function was removed from the containerd package in da1b5470cd26e9e2b4b1cd0100c876ce8db87471

Signed-off-by: Felix Abecassis <fabecassis@nvidia.com>