### PR TITLE
Cleanup workdirs on manager load

### DIFF
--- a/runtime/restart/monitor/monitor.go
+++ b/runtime/restart/monitor/monitor.go
@@ -168,7 +168,8 @@ func (m *monitor) reconcile(ctx context.Context) error {
 		ctx = namespaces.WithNamespace(ctx, name)
 		changes, err := m.monitor(ctx)
 		if err != nil {
-			return err
+			logrus.WithError(err).Error("monitor for changes")
+			continue
 		}
 		for _, c := range changes {
 			if err := c.apply(ctx, m.client); err != nil {


### PR DESCRIPTION
This cleans up persistent work dirs on TaskManager boot.  These dirs can
be left behind in a machine reboot.  The state in /run will not exist
but the work dir in the root does, we should cleanup work dirs when
tasks are not loaded.

This also improves error handling that would prevent the task manager
from loading when a single task fails to load or cleanup.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>