### PR TITLE
Fix for empty platform

### DIFF
--- a/client.go
+++ b/client.go
@@ -449,10 +449,7 @@ func (c *Client) GetImage(ctx context.Context, ref string) (Image, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &image{
-		client: c,
-		i:      i,
-	}, nil
+	return NewImage(c, i), nil
 }
 
 // ListImages returns all existing images
@@ -463,10 +460,7 @@ func (c *Client) ListImages(ctx context.Context, filters ...string) ([]Image, er
 	}
 	images := make([]Image, len(imgs))
 	for i, img := range imgs {
-		images[i] = &image{
-			client: c,
-			i:      img,
-		}
+		images[i] = NewImage(c, img)
 	}
 	return images, nil
 }

--- a/client_opts.go
+++ b/client_opts.go
@@ -18,6 +18,7 @@ package containerd
 
 import (
 	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/remotes"
 	"google.golang.org/grpc"
 )
@@ -76,6 +77,9 @@ type RemoteOpt func(*Client, *RemoteContext) error
 // WithPlatform allows the caller to specify a platform to retrieve
 // content for
 func WithPlatform(platform string) RemoteOpt {
+	if platform == "" {
+		platform = platforms.Default()
+	}
 	return func(_ *Client, c *RemoteContext) error {
 		for _, p := range c.Platforms {
 			if p == platform {

--- a/container.go
+++ b/container.go
@@ -173,10 +173,7 @@ func (c *container) Image(ctx context.Context) (Image, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get image %s for container", r.Image)
 	}
-	return &image{
-		client: c.client,
-		i:      i,
-	}, nil
+	return NewImage(c.client, i), nil
 }
 
 func (c *container) NewTask(ctx context.Context, ioCreate cio.Creator, opts ...NewTaskOpts) (_ Task, err error) {

--- a/import.go
+++ b/import.go
@@ -80,10 +80,7 @@ func (c *Client) Import(ctx context.Context, importer images.Importer, reader io
 			imgrec = updated
 		}
 
-		images = append(images, &image{
-			client: c,
-			i:      imgrec,
-		})
+		images = append(images, NewImage(c, imgrec))
 	}
 	return images, nil
 }

--- a/task.go
+++ b/task.go
@@ -458,10 +458,7 @@ func (t *task) Checkpoint(ctx context.Context, opts ...CheckpointTaskOpts) (Imag
 	if im, err = t.client.ImageService().Create(ctx, im); err != nil {
 		return nil, err
 	}
-	return &image{
-		client: t.client,
-		i:      im,
-	}, nil
+	return NewImage(t.client, im), nil
 }
 
 // UpdateTaskInfo allows updated specific settings to be changed on a task


### PR DESCRIPTION
The default platform had previously been provided using the empty string. This change ensures that the platforms field is always filled in correctly and empty string is properly interpreted.
Also replace manual image struct creation with the image constructor which is there to do just that.

Fixes image objects returned by the client using an empty platform because the platform was empty on the image struct.
Also fixes an unintentional break in client backwards compatibility used by some tests. These uses can also be updated to remove `WithPlatform` or explicitly set the default.