### PR TITLE
Fix loss of CRI test failure status in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,8 +74,10 @@ script:
       sudo PATH=$PATH containerd -log-level debug &> /tmp/containerd-cri.log &
       sudo ctr version ;
       sudo PATH=$PATH GOPATH=$GOPATH critest --runtime-endpoint=/var/run/containerd/containerd.sock --parallel=8 ;
-      test $? -ne 0 && cat /tmp/containerd-cri.log ;
+      TEST_RC=$? ;
+      test $TEST_RC -ne 0 && cat /tmp/containerd-cri.log ;
       sudo pkill containerd ;
+      test $TEST_RC -eq 0 || /bin/false ;
     fi
 
 after_success:


### PR DESCRIPTION
Prior PR fixed the wrong use of `exit` built-in within a Travis script,
but lost the reporting of a failure result of CRI testing in the process.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>

Fixes: #2515 