### PR TITLE
Various Windows fixes to support the runtime v2 shim workflow

### DIFF
--- a/cio/io_windows.go
+++ b/cio/io_windows.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"sync"
 
 	winio "github.com/Microsoft/go-winio"
 	"github.com/containerd/containerd/log"
@@ -41,7 +40,6 @@ func NewFIFOSetInDir(_, id string, terminal bool) (*FIFOSet, error) {
 
 func copyIO(fifos *FIFOSet, ioset *Streams) (*cio, error) {
 	var (
-		wg  sync.WaitGroup
 		set []io.Closer
 	)
 
@@ -85,9 +83,7 @@ func copyIO(fifos *FIFOSet, ioset *Streams) (*cio, error) {
 		}(l)
 		set = append(set, l)
 
-		wg.Add(1)
 		go func() {
-			defer wg.Done()
 			c, err := l.Accept()
 			if err != nil {
 				log.L.WithError(err).Errorf("failed to accept stdout connection on %s", fifos.Stdout)
@@ -115,9 +111,7 @@ func copyIO(fifos *FIFOSet, ioset *Streams) (*cio, error) {
 		}(l)
 		set = append(set, l)
 
-		wg.Add(1)
 		go func() {
-			defer wg.Done()
 			c, err := l.Accept()
 			if err != nil {
 				log.L.WithError(err).Errorf("failed to accept stderr connection on %s", fifos.Stderr)

--- a/cmd/ctr/commands/tasks/tasks_windows.go
+++ b/cmd/ctr/commands/tasks/tasks_windows.go
@@ -59,15 +59,16 @@ func HandleConsoleResize(ctx gocontext.Context, task resizer, con console.Consol
 
 // NewTask creates a new task
 func NewTask(ctx gocontext.Context, client *containerd.Client, container containerd.Container, _ string, tty, nullIO bool, ioOpts []cio.Opt, opts ...containerd.NewTaskOpts) (containerd.Task, error) {
-	ioCreator := cio.NewCreator(append([]cio.Opt{cio.WithStdio}, ioOpts...)...)
+	var ioCreator cio.Creator
 	if tty {
-		ioCreator = cio.NewCreator(append([]cio.Opt{cio.WithStdio, cio.WithTerminal}, ioOpts...)...)
-	}
-	if nullIO {
-		if tty {
+		if nullIO {
 			return nil, errors.New("tty and null-io cannot be used together")
 		}
+		ioCreator = cio.NewCreator(append([]cio.Opt{cio.WithStdio, cio.WithTerminal}, ioOpts...)...)
+	} else if nullIO {
 		ioCreator = cio.NullIO
+	} else {
+		ioCreator = cio.NewCreator(append([]cio.Opt{cio.WithStdio}, ioOpts...)...)
 	}
 	return container.NewTask(ctx, ioCreator)
 }


### PR DESCRIPTION
- Removes an unused and unneeded wait group.
- Reorders the code so that it doesnt overwrite the previous allocation
when creating a NewTask via ctr.exe
- Adds retry support to AnonDialer if the pipe does not exist. This will
retry up to the timeout for the pipe to exist and connect. This solves
the race between the containerd-shim-* start command and the
reinvocation.

FYI - @crosbymichael  @jhowardmsft 