### PR TITLE
Update multi-arch image tests

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -201,7 +201,7 @@ func TestImagePullAllPlatforms(t *testing.T) {
 	defer cancel()
 
 	cs := client.ContentStore()
-	img, err := client.Fetch(ctx, testImage)
+	img, err := client.Fetch(ctx, "docker.io/library/busybox:latest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -249,7 +249,7 @@ func TestImagePullSomePlatforms(t *testing.T) {
 		opts = append(opts, WithPlatform(platform))
 	}
 
-	img, err := client.Fetch(ctx, "docker.io/library/busybox:latest", opts...)
+	img, err := client.Fetch(ctx, "k8s.gcr.io/pause:3.1", opts...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/image_test.go
+++ b/image_test.go
@@ -45,7 +45,7 @@ func TestImageIsUnpacked(t *testing.T) {
 	}
 
 	// By default pull does not unpack an image
-	image, err := client.Pull(ctx, imageName)
+	image, err := client.Pull(ctx, imageName, WithPlatform("linux/amd64"))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This updates the tests to be more resilient to problems with the official Docker hub images having a periodic incomplete set of architectures. The K8s pause container is a more stable choice for testing the pull of specific architectures. Continue using the busybox image for all platform pull test since the set of architectures does not need to be fixed. Update the pull test to be explicit about expecting to pull and unpack for linux/amd64.