### PR TITLE
Refactors the TasksService requires per platform

### DIFF
--- a/services/tasks/local_unix.go
+++ b/services/tasks/local_unix.go
@@ -1,0 +1,56 @@
+// +build !windows_v2
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package tasks
+
+import (
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/plugin"
+	"github.com/containerd/containerd/runtime"
+	"github.com/pkg/errors"
+)
+
+var tasksServiceRequires = []plugin.Type{
+	plugin.RuntimePlugin,
+	plugin.RuntimePluginV2,
+	plugin.MetadataPlugin,
+	plugin.TaskMonitorPlugin,
+}
+
+func loadV1Runtimes(ic *plugin.InitContext) (map[string]runtime.PlatformRuntime, error) {
+	rt, err := ic.GetByType(plugin.RuntimePlugin)
+	if err != nil {
+		return nil, err
+	}
+
+	runtimes := make(map[string]runtime.PlatformRuntime)
+	for _, rr := range rt {
+		ri, err := rr.Instance()
+		if err != nil {
+			log.G(ic.Context).WithError(err).Warn("could not load runtime instance due to initialization error")
+			continue
+		}
+		r := ri.(runtime.PlatformRuntime)
+		runtimes[r.ID()] = r
+	}
+
+	if len(runtimes) == 0 {
+		return nil, errors.New("no runtimes available to create task service")
+	}
+	return runtimes, nil
+}

--- a/services/tasks/local_windows_v2.go
+++ b/services/tasks/local_windows_v2.go
@@ -1,0 +1,35 @@
+// +build windows,windows_v2
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package tasks
+
+import (
+	"github.com/containerd/containerd/plugin"
+	"github.com/containerd/containerd/runtime"
+)
+
+var tasksServiceRequires = []plugin.Type{
+	plugin.RuntimePluginV2,
+	plugin.MetadataPlugin,
+	plugin.TaskMonitorPlugin,
+}
+
+// loadV1Runtimes on Windows V2 returns an empty map. There are no v1 runtimes
+func loadV1Runtimes(ic *plugin.InitContext) (map[string]runtime.PlatformRuntime, error) {
+	return make(map[string]runtime.PlatformRuntime), nil
+}


### PR DESCRIPTION
Removes the start dependency on V1 runtimes in the TasksService for:
// +build windows_v2. For unix and windows (v1) this code remains to load all
v1 runtimes as expected.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>