### PR TITLE
Use exe for default shim binary on windows

### DIFF
--- a/runtime/v2/shim/util.go
+++ b/runtime/v2/shim/util.go
@@ -30,8 +30,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const shimBinaryFormat = "containerd-shim-%s-%s"
-
 // Command returns the shim command with the provided args and configuration
 func Command(ctx context.Context, runtime, containerdAddress, path string, cmdArgs ...string) (*exec.Cmd, error) {
 	ns, err := namespaces.NamespaceRequired(ctx)

--- a/runtime/v2/shim/util_unix.go
+++ b/runtime/v2/shim/util_unix.go
@@ -31,6 +31,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const shimBinaryFormat = "containerd-shim-%s-%s"
+
 func getSysProcAttr() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{
 		Setpgid: true,

--- a/runtime/v2/shim/util_windows.go
+++ b/runtime/v2/shim/util_windows.go
@@ -29,6 +29,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const shimBinaryFormat = "containerd-shim-%s-%s.exe"
+
 func getSysProcAttr() *syscall.SysProcAttr {
 	return nil
 }


### PR DESCRIPTION
This changes the default shim binary format to append `.exe`.