### PR TITLE
Add shim log pipe for log forwarding to the daemon

### DIFF
--- a/runtime/v2/README.md
+++ b/runtime/v2/README.md
@@ -157,6 +157,13 @@ If the shim collects Out of Memory events, it SHOULD also publish a `runtime.Tas
 
 If a shim does not or cannot implement an rpc call, it MUST return a `github.com/containerd/containerd/errdefs.ErrNotImplemented` error.
 
+#### Debugging and Shim Logs
+
+A fifo on unix or named pipe on Windows will be provided to the shim.
+It can be located inside the `cwd` of the shim named "log".
+The shims can use the existing `github.com/containerd/containerd/log` package to log debug messages.
+Messages will automatically be output in the containerd's daemon logs with the correct fields and runtime set.
+
 #### ttrpc
 
 [ttrpc](https://github.com/containerd/ttrpc) is the only currently supported protocol for shims.

--- a/runtime/v2/shim/shim_unix.go
+++ b/runtime/v2/shim/shim_unix.go
@@ -21,6 +21,7 @@ package shim
 import (
 	"bytes"
 	"context"
+	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -29,6 +30,7 @@ import (
 
 	"github.com/containerd/containerd/events"
 	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/fifo"
 	"github.com/containerd/typeurl"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -82,6 +84,10 @@ func handleSignals(logger *logrus.Entry, signals chan os.Signal) error {
 			}
 		}
 	}
+}
+
+func openLog(ctx context.Context, _ string) (io.Writer, error) {
+	return fifo.OpenFifo(context.Background(), "log", unix.O_WRONLY, 0700)
 }
 
 func (l *remoteEventsPublisher) Publish(ctx context.Context, topic string, event events.Event) error {

--- a/runtime/v2/shim/shim_windows.go
+++ b/runtime/v2/shim/shim_windows.go
@@ -21,6 +21,8 @@ package shim
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -77,6 +79,14 @@ func handleSignals(logger *logrus.Entry, signals chan os.Signal) error {
 			}
 		}
 	}
+}
+
+func openLog(ctx context.Context, id string) (io.Writer, error) {
+	ns, err := namespaces.NamespaceRequired(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return winio.DialPipe(fmt.Sprintf("\\\\.\\pipe\\containerd-shim-%s-%s-log", ns, id), nil)
 }
 
 func (l *remoteEventsPublisher) Publish(ctx context.Context, topic string, event events.Event) error {

--- a/runtime/v2/shim_unix.go
+++ b/runtime/v2/shim_unix.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build !windows
 
 /*
    Copyright The containerd Authors.
@@ -16,13 +16,17 @@
    limitations under the License.
 */
 
-package main
+package v2
 
 import (
-	"github.com/containerd/containerd/runtime/v2/runc"
-	"github.com/containerd/containerd/runtime/v2/shim"
+	"context"
+	"io"
+	"path/filepath"
+
+	"github.com/containerd/fifo"
+	"golang.org/x/sys/unix"
 )
 
-func main() {
-	shim.Run("io.containerd.runc.v1", runc.New)
+func openShimLog(ctx context.Context, bundle *Bundle) (io.ReadCloser, error) {
+	return fifo.OpenFifo(ctx, filepath.Join(bundle.Path, "log"), unix.O_RDONLY|unix.O_CREAT|unix.O_NONBLOCK, 0700)
 }


### PR DESCRIPTION
A fifo on unix or named pipe on Windows will be provided to the shim.
It can be located inside the `cwd` of the shim named "log".
The shims can use the existing `github.com/containerd/containerd/log` package to log debug messages.
Messages will automatically be output in the containerd's daemon logs with the correct fiels and runtime set.

Using a pipe allows containerd to reconnect after a reboot and collect logs from shims. 

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>