### PR TITLE
Set gid 0 when no group is specified

### DIFF
--- a/oci/spec_opts_unix.go
+++ b/oci/spec_opts_unix.go
@@ -371,7 +371,7 @@ func WithUserID(uid uint32) SpecOpts {
 			})
 			if err != nil {
 				if os.IsNotExist(err) || err == errNoUsersFound {
-					s.Process.User.UID, s.Process.User.GID = uid, uid
+					s.Process.User.UID, s.Process.User.GID = uid, 0
 					return nil
 				}
 				return err
@@ -397,7 +397,7 @@ func WithUserID(uid uint32) SpecOpts {
 			})
 			if err != nil {
 				if os.IsNotExist(err) || err == errNoUsersFound {
-					s.Process.User.UID, s.Process.User.GID = uid, uid
+					s.Process.User.UID, s.Process.User.GID = uid, 0
 					return nil
 				}
 				return err


### PR DESCRIPTION
This change is to match Docker's implementaion of setting gid and groups
to 0 when no gid is specified but an explicit uid is set.

Fixes #2527

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>