### PR TITLE
Update release tool

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,17 @@
+Abhinandan Prativadi <abhi@docker.com> Abhinandan Prativadi <aprativadi@gmail.com>
+Abhinandan Prativadi <abhi@docker.com> abhi <abhi@docker.com>
+Akihiro Suda <suda.akihiro@lab.ntt.co.jp> Akihiro Suda <suda.kyoto@gmail.com>
+Andrei Vagin <avagin@virtuozzo.com> Andrei Vagin <avagin@openvz.org>
+Frank Yang <yyb196@gmail.com> frank yang <yyb196@gmail.com>
+Justin Terry <juterry@microsoft.com> Justin Terry (VM) <juterry@microsoft.com>
+Justin Terry <juterry@microsoft.com> Justin <jterry75@users.noreply.github.com>
+Kenfe-Mickaël Laventure <mickael.laventure@gmail.com> Kenfe-Mickael Laventure <mickael.laventure@gmail.com>
+Kevin Xu <cming.xu@gmail.com> kevin.xu <cming.xu@gmail.com>
+Lu Jingxiao <lujingxiao@huawei.com> l00397676 <lujingxiao@huawei.com>
+Lantao Liu <lantaol@google.com> Lantao Liu <taotaotheripper@gmail.com>
+Phil Estes <estesp@gmail.com> Phil Estes <estesp@linux.vnet.ibm.com>
+Stephen J Day <stevvooe@gmail.com> Stephen J Day <stephen.day@docker.com>
+Stephen J Day <stevvooe@gmail.com> Stephen Day <stevvooe@users.noreply.github.com>
+Stephen J Day <stevvooe@gmail.com> Stephen Day <stephen.day@getcruise.com>
+Sudeesh John <sudeesh@linux.vnet.ibm.com> sudeesh john <sudeesh@linux.vnet.ibm.com>
+Tõnis Tiigi <tonistiigi@gmail.com> Tonis Tiigi <tonistiigi@gmail.com>

--- a/cmd/containerd-release/template.go
+++ b/cmd/containerd-release/template.go
@@ -28,7 +28,8 @@ const (
 Please try out the release binaries and report any issues at
 https://github.com/{{.GithubRepo}}/issues.
 
-{{range  $note := .Notes}}
+{{- range  $note := .Notes}}
+
 ### {{$note.Title}}
 
 {{$note.Description}}
@@ -37,11 +38,14 @@ https://github.com/{{.GithubRepo}}/issues.
 ### Contributors
 {{range $contributor := .Contributors}}
 * {{$contributor}}
-{{- end}}
+{{- end -}}
 
-### Changes
-{{range $change := .Changes}}
+{{range $project := .Changes}}
+
+### Changes{{if $project.Name}} from {{$project.Name}}{{end}}
+{{range $change := $project.Changes }}
 * {{$change.Commit}} {{$change.Description}}
+{{- end}}
 {{- end}}
 
 ### Dependency Changes


### PR DESCRIPTION
Updated the release tool to improve changes output to include sub-projects and automate the manual tasks which get done during the release. Currently the author remapping and including of subprojects is a time consuming process. This should make releasing much faster, making it easier to release the 1.2 betas and rcs.

 - Allow inclusion of sub-project changes
 - Order contributors by number of contributions
 - Add mailmap
 - Fix output formatting with extra new lines
