### PR TITLE
docs: man: rename config.toml(5) to be more descriptive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ TEST_REQUIRES_ROOT_PACKAGES=$(filter \
 
 # Project binaries.
 COMMANDS=ctr containerd containerd-stress containerd-release
-MANPAGES=ctr.1 containerd.1 config.toml.5 containerd-config.1
+MANPAGES=ctr.1 containerd.1 containerd-config.1 containerd-config.toml.5
 
 # Build tags seccomp and apparmor are needed by CRI plugin.
 BUILDTAGS ?= seccomp apparmor

--- a/docs/man/containerd-config.1.md
+++ b/docs/man/containerd-config.1.md
@@ -10,13 +10,13 @@ The *containerd config* command has one subcommand, named *default*, which
 will display on standard output the default containerd config for this version
 of the containerd daemon.
 
-This output can be piped to a __config.toml(5)__ file and placed in
+This output can be piped to a __containerd-config.toml(5)__ file and placed in
 **/etc/containerd** to be used as the configuration for containerd on daemon
 startup. The configuration can be placed in any filesystem location and used
 with the **--config** option to the containerd daemon as well.
 
-See __config.toml(5)__ for more information on the containerd configuration
-options.
+See __containerd-config.toml(5)__ for more information on the containerd
+configuration options.
 
 ## OPTIONS
 
@@ -34,4 +34,4 @@ Phil Estes <estesp@gmail.com>
 
 ## SEE ALSO
 
-ctr(1), config.toml(5), containerd(1)
+ctr(1), containerd(1), containerd-config.toml(5)

--- a/docs/man/containerd-config.toml.5.md
+++ b/docs/man/containerd-config.toml.5.md
@@ -1,13 +1,13 @@
-# config.toml 5 02/02/2018
+# /etc/containerd/config.toml 5 08/08/2018
 
 ## SYNOPSIS
 
 The **config.toml** file is a configuration file for the containerd daemon. The
-file must be placed in **/etc/containerd/** or used with the **--config**
-option of **containerd** to be used by the daemon. If the file does not exist
-at the appropriate location or is not provided via the **--config** option
-containerd uses its default configuration settings, which can be displayed
-with the **containerd config(1)** command.
+file must be placed at **/etc/containerd/config.toml** or specified with the
+**--config** option of **containerd** to be used by the daemon. If the file
+does not exist at the appropriate location or is not provided via the
+**--config** option containerd uses its default configuration settings, which
+can be displayed with the **containerd config(1)** command.
 
 ## DESCRIPTION
 

--- a/docs/man/containerd.1.md
+++ b/docs/man/containerd.1.md
@@ -53,4 +53,4 @@ Phil Estes <estesp@gmail.com>
 
 ## SEE ALSO
 
-ctr(1), config.toml(5), containerd-config(1)
+ctr(1), containerd-config(1), containerd-config.toml(5)

--- a/docs/man/ctr.1.md
+++ b/docs/man/ctr.1.md
@@ -91,4 +91,4 @@ Phil Estes <estesp@gmail.com>
 
 ## SEE ALSO
 
-containerd(1), config.toml(5), containerd-config(1)
+containerd(1), containerd-config(1), containerd-config.toml(5)


### PR DESCRIPTION
The man page namespace is global, so in order to avoid colliding with
other man pages named "config.toml" rename ours to be more descriptive.
This also helps with discoverability (now tab-completion of 'man
containerd<tab>' will return the config man page), as well as making it
much cleaner from the perspective of distributions that want to package
containerd.

Signed-off-by: Aleksa Sarai <asarai@suse.de>