### PR TITLE
oci: Update docs for `oci.WithUserID`

### DIFF
--- a/oci/spec_opts_unix.go
+++ b/oci/spec_opts_unix.go
@@ -357,8 +357,8 @@ func WithUIDGID(uid, gid uint32) SpecOpts {
 
 // WithUserID sets the correct UID and GID for the container based
 // on the image's /etc/passwd contents. If /etc/passwd does not exist,
-// or uid is not found in /etc/passwd, it sets gid to be the same with
-// uid, and not returns error.
+// or uid is not found in /etc/passwd, it sets the requested uid,
+// additionally sets the gid to 0, and does not return an error.
 func WithUserID(uid uint32) SpecOpts {
 	return func(ctx context.Context, client Client, c *containers.Container, s *Spec) (err error) {
 		setProcess(s)


### PR DESCRIPTION
The behaviour was changed in 99df1a9e11f3 ("Set gid 0 when no group is
specified"), part of #2529.

Take the opportunity to tighten up the grammar a bit too.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>