### PR TITLE
switch shim log Windows client/server direction

### DIFF
--- a/runtime/v2/shim_windows.go
+++ b/runtime/v2/shim_windows.go
@@ -20,23 +20,68 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
+	"sync"
+	"time"
 
-	winio "github.com/Microsoft/go-winio"
 	"github.com/containerd/containerd/namespaces"
+	client "github.com/containerd/containerd/runtime/v2/shim"
+	"github.com/pkg/errors"
 )
 
+type deferredPipeConnection struct {
+	ctx context.Context
+
+	wg   sync.WaitGroup
+	once sync.Once
+
+	c      net.Conn
+	conerr error
+}
+
+func (dpc *deferredPipeConnection) Read(p []byte) (n int, err error) {
+	if dpc.c == nil {
+		dpc.wg.Wait()
+		if dpc.c == nil {
+			return 0, dpc.conerr
+		}
+	}
+	return dpc.c.Read(p)
+}
+func (dpc *deferredPipeConnection) Close() error {
+	var err error
+	dpc.once.Do(func() {
+		dpc.wg.Wait()
+		if dpc.c != nil {
+			err = dpc.c.Close()
+		} else if dpc.conerr != nil {
+			err = dpc.conerr
+		}
+	})
+	return err
+}
+
+// openShimLog on Windows acts as the client of the log pipe. In this way the
+// containerd daemon can reconnect to the shim log stream if it is restarted.
 func openShimLog(ctx context.Context, bundle *Bundle) (io.ReadCloser, error) {
 	ns, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {
 		return nil, err
 	}
-	l, err := winio.ListenPipe(fmt.Sprintf("\\\\.\\pipe\\containerd-shim-%s-%s-log", ns, bundle.ID), nil)
-	if err != nil {
-		return nil, err
+	dpc := &deferredPipeConnection{
+		ctx: ctx,
 	}
-	c, err := l.Accept()
-	if err != nil {
-		l.Close()
-	}
-	return c, nil
+	dpc.wg.Add(1)
+	go func() {
+		c, conerr := client.AnonDialer(
+			fmt.Sprintf("\\\\.\\pipe\\containerd-shim-%s-%s-log", ns, bundle.ID),
+			time.Second*10,
+		)
+		if conerr != nil {
+			dpc.conerr = errors.Wrap(err, "failed to connect to shim log")
+		}
+		dpc.c = c
+		dpc.wg.Done()
+	}()
+	return dpc, nil
 }


### PR DESCRIPTION
Switches the client/server direction of the shim-log pipe on Windows so
that the shim is the listener. This allows the containerd client to
reconnect as needed to the log streams.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>