### PR TITLE
Update cri plugin to v1.0.5.

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -44,7 +44,7 @@ github.com/gotestyourself/gotestyourself 44dbf532bbf5767611f6f2a61bded572e337010
 github.com/google/go-cmp v0.1.0
 
 # cri dependencies
-github.com/containerd/cri v1.0.4
+github.com/containerd/cri v1.0.5
 github.com/containerd/go-cni f2d7272f12d045b16ed924f50e91f9f9cecc55a7
 github.com/blang/semver v3.1.0
 github.com/containernetworking/cni v0.6.0

--- a/vendor/github.com/containerd/cri/pkg/config/config.go
+++ b/vendor/github.com/containerd/cri/pkg/config/config.go
@@ -37,6 +37,8 @@ type ContainerdConfig struct {
 	DefaultRuntime Runtime `toml:"default_runtime" json:"defaultRuntime"`
 	// UntrustedWorkloadRuntime is a runtime to run untrusted workloads on it.
 	UntrustedWorkloadRuntime Runtime `toml:"untrusted_workload_runtime" json:"untrustedWorkloadRuntime"`
+	// NoPivot disables pivot-root (linux only), required when running a container in a RamDisk with runc
+	NoPivot bool `toml:"no_pivot" json:"noPivot"`
 }
 
 // CniConfig contains toml config related to cni
@@ -132,6 +134,7 @@ func DefaultConfig() PluginConfig {
 				Engine: "",
 				Root:   "",
 			},
+			NoPivot: false,
 		},
 		StreamServerAddress:     "",
 		StreamServerPort:        "10010",

--- a/vendor/github.com/containerd/cri/pkg/server/container_start.go
+++ b/vendor/github.com/containerd/cri/pkg/server/container_start.go
@@ -108,7 +108,11 @@ func (c *criService) startContainer(ctx context.Context,
 		return cntr.IO, nil
 	}
 
-	task, err := container.NewTask(ctx, ioCreation)
+	var taskOpts []containerd.NewTaskOpts
+	if c.config.NoPivot {
+		taskOpts = append(taskOpts, containerd.WithNoPivotRoot)
+	}
+	task, err := container.NewTask(ctx, ioCreation, taskOpts...)
 	if err != nil {
 		return errors.Wrap(err, "failed to create containerd task")
 	}

--- a/vendor/github.com/containerd/cri/pkg/server/sandbox_run.go
+++ b/vendor/github.com/containerd/cri/pkg/server/sandbox_run.go
@@ -293,8 +293,13 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		// Create sandbox task in containerd.
 		log.Tracef("Create sandbox container (id=%q, name=%q).",
 			id, name)
+
+		var taskOpts []containerd.NewTaskOpts
+		if c.config.NoPivot {
+			taskOpts = append(taskOpts, containerd.WithNoPivotRoot)
+		}
 		// We don't need stdio for sandbox container.
-		task, err := container.NewTask(ctx, containerdio.NullIO)
+		task, err := container.NewTask(ctx, containerdio.NullIO, taskOpts...)
 		if err != nil {
 			return status, errors.Wrap(err, "failed to create containerd task")
 		}


### PR DESCRIPTION
Update `cri` to v1.0.5. Here is the release note https://github.com/containerd/cri/releases/tag/v1.0.5.

This is mainly for minikube support. See https://github.com/kubernetes/minikube/pull/3040.

Signed-off-by: Lantao Liu <lantaol@google.com>