### PR TITLE
Move content.Fetch configuration to struct

### DIFF
--- a/cmd/ctr/commands/content/fetch.go
+++ b/cmd/ctr/commands/content/fetch.go
@@ -76,28 +76,61 @@ Most of this is experimental and there are few leaps to make this work.`,
 			return err
 		}
 		defer cancel()
-
-		_, err = Fetch(ctx, client, ref, clicontext)
+		config, err := NewFetchConfig(ctx, clicontext)
+		if err != nil {
+			return err
+		}
+		_, err = Fetch(ctx, client, ref, config)
 		return err
 	},
 }
 
-// Fetch loads all resources into the content store and returns the image
-func Fetch(ctx context.Context, client *containerd.Client, ref string, cliContext *cli.Context) (images.Image, error) {
-	resolver, err := commands.GetResolver(ctx, cliContext)
-	if err != nil {
-		return images.Image{}, err
-	}
+// FetchConfig for content fetch
+type FetchConfig struct {
+	// Resolver
+	Resolver remotes.Resolver
+	// ProgressOutput to display progress
+	ProgressOutput io.Writer
+	// Labels to set on the content
+	Labels []string
+	// Platforms to fetch
+	Platforms []string
+}
 
+// NewFetchConfig returns the default FetchConfig from cli flags
+func NewFetchConfig(ctx context.Context, clicontext *cli.Context) (*FetchConfig, error) {
+	resolver, err := commands.GetResolver(ctx, clicontext)
+	if err != nil {
+		return nil, err
+	}
+	config := &FetchConfig{
+		Resolver: resolver,
+		Labels:   clicontext.StringSlice("label"),
+	}
+	if !clicontext.GlobalBool("debug") {
+		config.ProgressOutput = os.Stdout
+	}
+	if !clicontext.Bool("all-platforms") {
+		p := clicontext.StringSlice("platform")
+		if len(p) == 0 {
+			p = append(p, platforms.Default())
+		}
+		config.Platforms = p
+	}
+	return config, nil
+}
+
+// Fetch loads all resources into the content store and returns the image
+func Fetch(ctx context.Context, client *containerd.Client, ref string, config *FetchConfig) (images.Image, error) {
 	ongoing := newJobs(ref)
 
 	pctx, stopProgress := context.WithCancel(ctx)
 	progress := make(chan struct{})
 
 	go func() {
-		if !cliContext.GlobalBool("debug") {
+		if config.ProgressOutput != nil {
 			// no progress bar, because it hides some debug logs
-			showProgress(pctx, ongoing, client.ContentStore(), os.Stdout)
+			showProgress(pctx, ongoing, client.ContentStore(), config.ProgressOutput)
 		}
 		close(progress)
 	}()
@@ -110,24 +143,16 @@ func Fetch(ctx context.Context, client *containerd.Client, ref string, cliContex
 	})
 
 	log.G(pctx).WithField("image", ref).Debug("fetching")
-	labels := commands.LabelArgs(cliContext.StringSlice("label"))
+	labels := commands.LabelArgs(config.Labels)
 	opts := []containerd.RemoteOpt{
 		containerd.WithPullLabels(labels),
-		containerd.WithResolver(resolver),
+		containerd.WithResolver(config.Resolver),
 		containerd.WithImageHandler(h),
 		containerd.WithSchema1Conversion,
 	}
-
-	if !cliContext.Bool("all-platforms") {
-		p := cliContext.StringSlice("platform")
-		if len(p) == 0 {
-			p = append(p, platforms.Default())
-		}
-		for _, platform := range p {
-			opts = append(opts, containerd.WithPlatform(platform))
-		}
+	for _, platform := range config.Platforms {
+		opts = append(opts, containerd.WithPlatform(platform))
 	}
-
 	img, err := client.Fetch(pctx, ref, opts...)
 	stopProgress()
 	if err != nil {

--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -73,7 +73,11 @@ command. As part of this process, we do the following:
 		}
 		defer done(ctx)
 
-		img, err := content.Fetch(ctx, client, ref, context)
+		config, err := content.NewFetchConfig(ctx, context)
+		if err != nil {
+			return err
+		}
+		img, err := content.Fetch(ctx, client, ref, config)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This makes it easier for callers to call this function and populate the
config without relying on specific flags across commands.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>