### PR TITLE
platforms: Add `MustParse`

### DIFF
--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -109,6 +109,7 @@ package platforms
 import (
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/containerd/containerd/errdefs"
@@ -228,6 +229,16 @@ func Parse(specifier string) (specs.Platform, error) {
 	}
 
 	return specs.Platform{}, errors.Wrapf(errdefs.ErrInvalidArgument, "%q: cannot parse platform specifier", specifier)
+}
+
+// MustParse is like Parses but panics if the specifier cannot be parsed.
+// Simplifies initialization of global variables.
+func MustParse(specifier string) specs.Platform {
+	p, err := Parse(specifier)
+	if err != nil {
+		panic("platform: Parse(" + strconv.Quote(specifier) + "): " + err.Error())
+	}
+	return p
 }
 
 // Format returns a string specifier from the provided platform specification.


### PR DESCRIPTION
This function is analogous to `regexp.MustCompile` and can simplify production
of a `Platform` from a hard-coded strings, e.g. for global variable
initialisation.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>