### PR TITLE
support relative rootfs path in ctr

### DIFF
--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -20,7 +20,6 @@ package run
 
 import (
 	gocontext "context"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -63,18 +62,9 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 		opts = append(opts, withMounts(context))
 
 		if context.Bool("rootfs") {
-			rootfs := ref;
-			if !filepath.IsAbs(rootfs) {
-				ctrwd, err := os.Getwd()
-				if err != nil {
-					return nil, err
-				}
-				cwd, err := filepath.Abs(ctrwd)
-				if err != nil {
-					return nil, err
-				}
-				
-				rootfs = filepath.Join(cwd, rootfs)
+			rootfs, err := filepath.Abs(ref)
+			if err != nil {
+				return nil, err
 			}
 			opts = append(opts, oci.WithRootFSPath(rootfs))
 		} else {

--- a/oci/spec_opts_unix.go
+++ b/oci/spec_opts_unix.go
@@ -143,6 +143,7 @@ func WithImageConfigArgs(image Image, args []string) SpecOpts {
 			cmd = args
 		}
 		s.Process.Args = append(config.Entrypoint, cmd...)
+
 		cwd := config.WorkingDir
 		if cwd == "" {
 			cwd = "/"


### PR DESCRIPTION
When use --rootfs in ctr run command, rootfs path can't support relative path.
I think we should support relative path, but not only absolute path.

Fail **When use relative path**:
root@dockerdemo:/opt/runctest/redis# ~/gocode/src/github.com/containerd/containerd-v-1-1-3/bin/ctr run -c ./config.json -t --rootfs ./rootfs redis
ctr: OCI runtime create failed: container_linux.go:336: starting container process caused "exec: \"/usr/local/bin/redis-server\": stat /usr/local/bin/redis-server: no such file or directory": unknown

Succ **When use absolute path**:
root@dockerdemo:/opt/runctest/redis# ~/gocode/src/github.com/containerd/containerd-v-1-1-3/bin/ctr run -c ./config.json -t --rootfs /opt/runctest/redis/rootfs redis
1:C 23 Aug 01:36:37.246 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo

Succ **After fix**:
root@dockerdemo:/opt/runctest/redis# ~/gocode/src/github.com/containerd/containerd-lifubang/bin/ctr run -c ./config.json -t --rootfs ./rootfs redis
1:C 23 Aug 02:59:44.549 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
