### PR TITLE
Some performance optimization when there are lots of containers to list

### DIFF
--- a/client.go
+++ b/client.go
@@ -203,9 +203,15 @@ func (c *Client) IsServing(ctx context.Context) (bool, error) {
 	return r.Status == grpc_health_v1.HealthCheckResponse_SERVING, nil
 }
 
+// ContainersInfo returns all containers created in containerd
+func (c *Client) ContainersInfo(ctx context.Context, filters ...string) ([]containers.Container, error) {
+	r, err := c.ContainerService().List(ctx, filters...)
+	return r, err
+}
+
 // Containers returns all containers created in containerd
 func (c *Client) Containers(ctx context.Context, filters ...string) ([]Container, error) {
-	r, err := c.ContainerService().List(ctx, filters...)
+	r, err := c.ContainersInfo(ctx, filters...)
 	if err != nil {
 		return nil, err
 	}
@@ -243,7 +249,7 @@ func (c *Client) NewContainer(ctx context.Context, id string, opts ...NewContain
 	return containerFromRecord(c, r), nil
 }
 
-// LoadContainer loads an existing container from metadata
+// LoadContainerInfo loads an existing container from metadata
 func (c *Client) LoadContainerInfo(ctx context.Context, id string) (containers.Container, error) {
 	r, err := c.ContainerService().Get(ctx, id)
 

--- a/client.go
+++ b/client.go
@@ -244,8 +244,15 @@ func (c *Client) NewContainer(ctx context.Context, id string, opts ...NewContain
 }
 
 // LoadContainer loads an existing container from metadata
-func (c *Client) LoadContainer(ctx context.Context, id string) (Container, error) {
+func (c *Client) LoadContainerInfo(ctx context.Context, id string) (containers.Container, error) {
 	r, err := c.ContainerService().Get(ctx, id)
+
+	return r, err
+}
+
+// LoadContainer loads an existing container from metadata
+func (c *Client) LoadContainer(ctx context.Context, id string) (Container, error) {
+	r, err := c.LoadContainerInfo(ctx, id)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/ctr/commands/containers/containers.go
+++ b/cmd/ctr/commands/containers/containers.go
@@ -242,15 +242,12 @@ var infoCommand = cli.Command{
 			return err
 		}
 		defer cancel()
-		container, err := client.LoadContainer(ctx, id)
+		container, err := client.LoadContainerInfo(ctx, id)
 		if err != nil {
 			return err
 		}
-		info, err := container.Info(ctx)
-		if err != nil {
-			return err
-		}
-		commands.PrintAsJSON(info)
+
+		commands.PrintAsJSON(container)
 
 		return nil
 	},

--- a/cmd/ctr/commands/containers/containers.go
+++ b/cmd/ctr/commands/containers/containers.go
@@ -96,29 +96,26 @@ var listCommand = cli.Command{
 			return err
 		}
 		defer cancel()
-		containers, err := client.Containers(ctx, filters...)
+		containers, err := client.ContainersInfo(ctx, filters...)
 		if err != nil {
 			return err
 		}
 		if quiet {
 			for _, c := range containers {
-				fmt.Printf("%s\n", c.ID())
+				fmt.Printf("%s\n", c.ID)
 			}
 			return nil
 		}
 		w := tabwriter.NewWriter(os.Stdout, 4, 8, 4, ' ', 0)
 		fmt.Fprintln(w, "CONTAINER\tIMAGE\tRUNTIME\t")
 		for _, c := range containers {
-			info, err := c.Info(ctx)
-			if err != nil {
-				return err
-			}
+			info := c
 			imageName := info.Image
 			if imageName == "" {
 				imageName = "-"
 			}
 			if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t\n",
-				c.ID(),
+				c.ID,
 				imageName,
 				info.Runtime.Name,
 			); err != nil {


### PR DESCRIPTION
When use 'ctr c info <containerid>':
The result of api named Get contains all container info, we don't need to call Get API again.

When use 'ctr c ls':
The result of api named List contains all container's info, we don't need to call Get API for each container.

This is useful when there are lots of containers to list.

Please check it, thanks.