### PR TITLE
decode Spec value in command 'ctr c info <containerid>'

### DIFF
--- a/cmd/ctr/commands/containers/containers.go
+++ b/cmd/ctr/commands/containers/containers.go
@@ -252,14 +252,14 @@ var infoCommand = cli.Command{
 			return err
 		}
 
-		if (cc.Spec != nil && cc.Spec.Value != nil) {
+		if (info.Spec != nil && info.Spec.Value != nil) {
 			type c containers.Container
 			type SpecDecode struct {
 				TypeUrl string `json:"type_url,omitempty"`
 				Value *interface{} `json:"value,omitempty"`
 			}
 
-			cc := c(container)
+			cc := c(info)
 
 			var s interface{}
 			if err := json.Unmarshal(cc.Spec.Value, &s); err != nil {

--- a/cmd/ctr/commands/containers/containers.go
+++ b/cmd/ctr/commands/containers/containers.go
@@ -18,6 +18,7 @@ package containers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -250,7 +251,34 @@ var infoCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		commands.PrintAsJSON(info)
+
+		if (cc.Spec != nil && cc.Spec.Value != nil) {
+			type c containers.Container
+			type SpecDecode struct {
+				TypeUrl string `json:"type_url,omitempty"`
+				Value *interface{} `json:"value,omitempty"`
+			}
+
+			cc := c(container)
+
+			var s interface{}
+			if err := json.Unmarshal(cc.Spec.Value, &s); err != nil {
+				return nil
+			}
+
+			commands.PrintAsJSON(struct {
+				*c
+				Spec SpecDecode `json:"Spec,omitempty"`
+			}{
+				c: &cc,
+				Spec: SpecDecode {
+					TypeUrl: cc.Spec.TypeUrl,
+					Value: &s,
+				},
+			})
+		} else {
+			commands.PrintAsJSON(info)
+		}
 
 		return nil
 	},


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@aliyun.com>
Before this commit, the Spec.value field  are incomprehensible:
```
root@dockerdemo:/opt/runctest/redis# ctr c info busybox
{
    "ID": "busybox",
    "Labels": null,
    "Image": "docker.acmcoder.com/public/busybox:latest",
    "Runtime": {
        "Name": "io.containerd.runtime.v1.linux",
        "Options": null
    },
    "Spec": {
        "type_url": "types.containerd.io/opencontainers/runtime-spec/1/Spec",
        "value": "eyJvY2lWZXJzaW9uIjoiM*************"
    },
    "SnapshotKey": "busybox",
    "Snapshotter": "overlayfs",
    "CreatedAt": "2018-08-23T05:16:17.371767147Z",
    "UpdatedAt": "2018-08-23T05:16:17.371767147Z",
    "Extensions": null
}
```

After the commit, there are some useful information for us:
```
root@dockerdemo:/opt/runctest/redis# ~/gocode/src/github.com/containerd/containerd/bin/ctr c info busybox
{
    "ID": "busybox",
    "Labels": null,
    "Image": "docker.acmcoder.com/public/busybox:latest",
    "Runtime": {
        "Name": "io.containerd.runtime.v1.linux",
        "Options": null
    },
    "SnapshotKey": "busybox",
    "Snapshotter": "overlayfs",
    "CreatedAt": "2018-08-23T05:16:17.371767147Z",
    "UpdatedAt": "2018-08-23T05:16:17.371767147Z",
    "Extensions": null,
    "Spec": {
        "type_url": "types.containerd.io/opencontainers/runtime-spec/1/Spec",
        "value": {
            "linux": {
                "cgroupsPath": "/default/busybox",
                "maskedPaths": [
                    "/proc/acpi",
                    "/proc/kcore",
                    "/proc/keys",
                    "/proc/latency_stats",
                    "/proc/timer_list",
                    "/proc/timer_stats",
                    "/proc/sched_debug",
                    "/sys/firmware",
                    "/proc/scsi"
                ],
                "namespaces": [
                    {
                        "type": "pid"
                    },
                    {
                        "type": "ipc"
                    },
                    {
                        "type": "uts"
                    },
                    {
                        "type": "mount"
                    },
                    {
                        "type": "network"
                    }
                ],
                "readonlyPaths": [
                    "/proc/asound",
                    "/proc/bus",
                    "/proc/fs",
                    "/proc/irq",
                    "/proc/sys",
                    "/proc/sysrq-trigger"
                ],
                "resources": {
                    "devices": [
                        {
                            "access": "rwm",
                            "allow": false
                        }
                    ]
                }
            },
            "mounts": [
                {
                    "destination": "/proc",
                    "source": "proc",
                    "type": "proc"
                },
                {
                    "destination": "/dev",
                    "options": [
                        "nosuid",
                        "strictatime",
                        "mode=755",
                        "size=65536k"
                    ],
                    "source": "tmpfs",
                    "type": "tmpfs"
                },
                {
                    "destination": "/dev/pts",
                    "options": [
                        "nosuid",
                        "noexec",
                        "newinstance",
                        "ptmxmode=0666",
                        "mode=0620",
                        "gid=5"
                    ],
                    "source": "devpts",
                    "type": "devpts"
                },
                {
                    "destination": "/dev/shm",
                    "options": [
                        "nosuid",
                        "noexec",
                        "nodev",
                        "mode=1777",
                        "size=65536k"
                    ],
                    "source": "shm",
                    "type": "tmpfs"
                },
                {
                    "destination": "/dev/mqueue",
                    "options": [
                        "nosuid",
                        "noexec",
                        "nodev"
                    ],
                    "source": "mqueue",
                    "type": "mqueue"
                },
                {
                    "destination": "/sys",
                    "options": [
                        "nosuid",
                        "noexec",
                        "nodev",
                        "ro"
                    ],
                    "source": "sysfs",
                    "type": "sysfs"
                },
                {
                    "destination": "/run",
                    "options": [
                        "nosuid",
                        "strictatime",
                        "mode=755",
                        "size=65536k"
                    ],
                    "source": "tmpfs",
                    "type": "tmpfs"
                }
            ],
            "ociVersion": "1.0.1",
            "process": {
                "args": [
                    "sh"
                ],
                "capabilities": {
                    "bounding": [
                        "CAP_CHOWN",
                        "CAP_DAC_OVERRIDE",
                        "CAP_FSETID",
                        "CAP_FOWNER",
                        "CAP_MKNOD",
                        "CAP_NET_RAW",
                        "CAP_SETGID",
                        "CAP_SETUID",
                        "CAP_SETFCAP",
                        "CAP_SETPCAP",
                        "CAP_NET_BIND_SERVICE",
                        "CAP_SYS_CHROOT",
                        "CAP_KILL",
                        "CAP_AUDIT_WRITE"
                    ],
                    "effective": [
                        "CAP_CHOWN",
                        "CAP_DAC_OVERRIDE",
                        "CAP_FSETID",
                        "CAP_FOWNER",
                        "CAP_MKNOD",
                        "CAP_NET_RAW",
                        "CAP_SETGID",
                        "CAP_SETUID",
                        "CAP_SETFCAP",
                        "CAP_SETPCAP",
                        "CAP_NET_BIND_SERVICE",
                        "CAP_SYS_CHROOT",
                        "CAP_KILL",
                        "CAP_AUDIT_WRITE"
                    ],
                    "inheritable": [
                        "CAP_CHOWN",
                        "CAP_DAC_OVERRIDE",
                        "CAP_FSETID",
                        "CAP_FOWNER",
                        "CAP_MKNOD",
                        "CAP_NET_RAW",
                        "CAP_SETGID",
                        "CAP_SETUID",
                        "CAP_SETFCAP",
                        "CAP_SETPCAP",
                        "CAP_NET_BIND_SERVICE",
                        "CAP_SYS_CHROOT",
                        "CAP_KILL",
                        "CAP_AUDIT_WRITE"
                    ],
                    "permitted": [
                        "CAP_CHOWN",
                        "CAP_DAC_OVERRIDE",
                        "CAP_FSETID",
                        "CAP_FOWNER",
                        "CAP_MKNOD",
                        "CAP_NET_RAW",
                        "CAP_SETGID",
                        "CAP_SETUID",
                        "CAP_SETFCAP",
                        "CAP_SETPCAP",
                        "CAP_NET_BIND_SERVICE",
                        "CAP_SYS_CHROOT",
                        "CAP_KILL",
                        "CAP_AUDIT_WRITE"
                    ]
                },
                "cwd": "/",
                "env": [
                    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
                    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
                    "TERM=xterm"
                ],
                "noNewPrivileges": true,
                "rlimits": [
                    {
                        "hard": 1024,
                        "soft": 1024,
                        "type": "RLIMIT_NOFILE"
                    }
                ],
                "terminal": true,
                "user": {
                    "gid": 0,
                    "uid": 0
                }
            },
            "root": {
                "path": "rootfs"
            }
        }
    }
}
```