### PR TITLE
support relative rootfs path in ctr

### DIFF
--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -20,6 +20,7 @@ package run
 
 import (
 	gocontext "context"
+	"path/filepath"
 	"strings"
 
 	"github.com/containerd/containerd"
@@ -61,7 +62,11 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 		opts = append(opts, withMounts(context))
 
 		if context.Bool("rootfs") {
-			opts = append(opts, oci.WithRootFSPath(ref))
+			rootfs, err := filepath.Abs(ref)
+			if err != nil {
+				return nil, err
+			}
+			opts = append(opts, oci.WithRootFSPath(rootfs))
 		} else {
 			snapshotter := context.String("snapshotter")
 			image, err := client.GetImage(ctx, ref)


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@aliyun.com>

When use --rootfs in ctr run command, rootfs path can't support relative path.
I think we should support relative path, but not only absolute path.

Fail **When use relative path**:
root@dockerdemo:/opt/runctest/redis# ~/gocode/src/github.com/containerd/containerd-v-1-1-3/bin/ctr run -c ./config.json -t --rootfs ./rootfs redis
ctr: OCI runtime create failed: container_linux.go:336: starting container process caused "exec: \"/usr/local/bin/redis-server\": stat /usr/local/bin/redis-server: no such file or directory": unknown

Succ **When use absolute path**:
root@dockerdemo:/opt/runctest/redis# ~/gocode/src/github.com/containerd/containerd-v-1-1-3/bin/ctr run -c ./config.json -t --rootfs /opt/runctest/redis/rootfs redis
1:C 23 Aug 01:36:37.246 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo

Succ **After fix**:
root@dockerdemo:/opt/runctest/redis# ~/gocode/src/github.com/containerd/containerd-lifubang/bin/ctr run -c ./config.json -t --rootfs ./rootfs redis
1:C 23 Aug 02:59:44.549 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
