### PR TITLE
README.md: add missing banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![banner](/docs/static/img/containerd-dark.png?raw=true)
+![banner](https://github.com/containerd/containerd.io/blob/master/static/img/containerd-dark.png?raw=true)
 
 [![GoDoc](https://godoc.org/github.com/containerd/containerd?status.svg)](https://godoc.org/github.com/containerd/containerd)
 [![Build Status](https://travis-ci.org/containerd/containerd.svg?branch=master)](https://travis-ci.org/containerd/containerd)


### PR DESCRIPTION
All the website files has been moved to the containerd.io. The banner
should use the containerd.io file.

Signed-off-by: Wei Fu <fhfuwei@163.com>