### PR TITLE
ctr: make kill optionally use stop-signal

### DIFF
--- a/cmd/ctr/commands/signals.go
+++ b/cmd/ctr/commands/signals.go
@@ -18,11 +18,8 @@ package commands
 
 import (
 	gocontext "context"
-	"fmt"
 	"os"
 	"os/signal"
-	"strconv"
-	"strings"
 	"syscall"
 
 	"github.com/containerd/containerd"
@@ -52,24 +49,4 @@ func ForwardAllSignals(ctx gocontext.Context, task killer) chan os.Signal {
 func StopCatch(sigc chan os.Signal) {
 	signal.Stop(sigc)
 	close(sigc)
-}
-
-// ParseSignal parses a given string into a syscall.Signal
-// it checks that the signal exists in the platform-appropriate signalMap
-func ParseSignal(rawSignal string) (syscall.Signal, error) {
-	s, err := strconv.Atoi(rawSignal)
-	if err == nil {
-		sig := syscall.Signal(s)
-		for _, msig := range signalMap {
-			if sig == msig {
-				return sig, nil
-			}
-		}
-		return -1, fmt.Errorf("unknown signal %q", rawSignal)
-	}
-	signal, ok := signalMap[strings.TrimPrefix(strings.ToUpper(rawSignal), "SIG")]
-	if !ok {
-		return -1, fmt.Errorf("unknown signal %q", rawSignal)
-	}
-	return signal, nil
 }

--- a/cmd/ctr/commands/tasks/kill.go
+++ b/cmd/ctr/commands/tasks/kill.go
@@ -47,7 +47,7 @@ var killCommand = cli.Command{
 		if id == "" {
 			return errors.New("container id must be provided")
 		}
-		signal, err := commands.ParseSignal(context.String("signal"))
+		signal, err := containerd.ParseSignal(context.String("signal"))
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/tasks/kill.go
+++ b/cmd/ctr/commands/tasks/kill.go
@@ -23,6 +23,8 @@ import (
 	"github.com/urfave/cli"
 )
 
+const defaultSignal = "SIGTERM"
+
 var killCommand = cli.Command{
 	Name:      "kill",
 	Usage:     "signal a container (default: SIGTERM)",
@@ -30,7 +32,7 @@ var killCommand = cli.Command{
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "signal, s",
-			Value: "SIGTERM",
+			Value: "",
 			Usage: "signal to send to the container",
 		},
 		cli.StringFlag{
@@ -47,7 +49,7 @@ var killCommand = cli.Command{
 		if id == "" {
 			return errors.New("container id must be provided")
 		}
-		signal, err := containerd.ParseSignal(context.String("signal"))
+		signal, err := containerd.ParseSignal(defaultSignal)
 		if err != nil {
 			return err
 		}
@@ -73,6 +75,17 @@ var killCommand = cli.Command{
 		container, err := client.LoadContainer(ctx, id)
 		if err != nil {
 			return err
+		}
+		if context.String("signal") != "" {
+			signal, err = containerd.ParseSignal(context.String("signal"))
+			if err != nil {
+				return err
+			}
+		} else {
+			signal, err = containerd.GetStopSignal(ctx, container, signal)
+			if err != nil {
+				return err
+			}
 		}
 		task, err := container.Task(ctx, nil)
 		if err != nil {

--- a/container_opts.go
+++ b/container_opts.go
@@ -76,6 +76,23 @@ func WithContainerLabels(labels map[string]string) NewContainerOpts {
 	}
 }
 
+// WithImageStopSignal sets a well-known containerd label (StopSignalLabel)
+// on the container for storing the stop signal specified in the OCI image
+// config
+func WithImageStopSignal(image Image, defaultSignal string) NewContainerOpts {
+	return func(ctx context.Context, _ *Client, c *containers.Container) error {
+		if c.Labels == nil {
+			c.Labels = make(map[string]string)
+		}
+		stopSignal, err := GetOCIStopSignal(ctx, image, defaultSignal)
+		if err != nil {
+			return err
+		}
+		c.Labels[StopSignalLabel] = stopSignal
+		return nil
+	}
+}
+
 // WithSnapshotter sets the provided snapshotter for use by the container
 //
 // This option must appear before other snapshotter options to have an effect.

--- a/signal_map_linux.go
+++ b/signal_map_linux.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package commands
+package containerd
 
 import (
 	"syscall"

--- a/signal_map_unix.go
+++ b/signal_map_unix.go
@@ -16,7 +16,7 @@
    limitations under the License.
 */
 
-package commands
+package containerd
 
 import (
 	"syscall"

--- a/signal_map_windows.go
+++ b/signal_map_windows.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package commands
+package containerd
 
 import (
 	"syscall"

--- a/signals.go
+++ b/signals.go
@@ -1,0 +1,44 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package containerd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// ParseSignal parses a given string into a syscall.Signal
+// it checks that the signal exists in the platform-appropriate signalMap
+func ParseSignal(rawSignal string) (syscall.Signal, error) {
+	s, err := strconv.Atoi(rawSignal)
+	if err == nil {
+		sig := syscall.Signal(s)
+		for _, msig := range signalMap {
+			if sig == msig {
+				return sig, nil
+			}
+		}
+		return -1, fmt.Errorf("unknown signal %q", rawSignal)
+	}
+	signal, ok := signalMap[strings.TrimPrefix(strings.ToUpper(rawSignal), "SIG")]
+	if !ok {
+		return -1, fmt.Errorf("unknown signal %q", rawSignal)
+	}
+	return signal, nil
+}


### PR DESCRIPTION
The OCI image specification includes a StopSignal field in the image configuration, denoting the system call signal to be sent to the container to exit.  This commit adds an option to `ctr task kill` that reads the StopSignal from the image configuration and sends that signal.