### PR TITLE
fix when --config provided, don't need Image/RootFS

### DIFF
--- a/cmd/ctr/commands/containers/containers.go
+++ b/cmd/ctr/commands/containers/containers.go
@@ -53,11 +53,22 @@ var createCommand = cli.Command{
 	Flags:     append(commands.SnapshotterFlags, commands.ContainerFlags...),
 	Action: func(context *cli.Context) error {
 		var (
-			id  = context.Args().Get(1)
-			ref = context.Args().First()
+			id     string
+			ref    string
+			config = context.IsSet("config")
 		)
-		if ref == "" {
-			return errors.New("image ref must be provided")
+
+		if config {
+			id = context.Args().First()
+			if context.NArg() > 1 {
+				return errors.New("with spec config file, only container id should be provided")
+			}
+		} else {
+			id = context.Args().Get(1)
+			ref = context.Args().First()
+			if ref == "" {
+				return errors.New("image ref must be provided")
+			}
 		}
 		if id == "" {
 			return errors.New("container id must be provided")

--- a/cmd/ctr/commands/run/run.go
+++ b/cmd/ctr/commands/run/run.go
@@ -110,15 +110,26 @@ var Command = cli.Command{
 	Action: func(context *cli.Context) error {
 		var (
 			err error
+			id  string
+			ref string
 
-			id     = context.Args().Get(1)
-			ref    = context.Args().First()
 			tty    = context.Bool("tty")
 			detach = context.Bool("detach")
+			config = context.IsSet("config")
 		)
 
-		if ref == "" {
-			return errors.New("image ref must be provided")
+		if config {
+			id = context.Args().First()
+			if context.NArg() > 1 {
+				return errors.New("with spec config file, only container id should be provided")
+			}
+		} else {
+			id = context.Args().Get(1)
+			ref = context.Args().First()
+
+			if ref == "" {
+				return errors.New("image ref must be provided")
+			}
 		}
 		if id == "" {
 			return errors.New("container id must be provided")

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -35,9 +35,9 @@ import (
 func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli.Context) (containerd.Container, error) {
 	var (
 		id     string
-		Config = context.IsSet("config")
+		config = context.IsSet("config")
 	)
-	if Config {
+	if config {
 		id = context.Args().First()
 	} else {
 		id = context.Args().Get(1)
@@ -57,7 +57,7 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 		spec  containerd.NewContainerOpts
 	)
 
-	if Config {
+	if config {
 		opts = append(opts, oci.WithSpecFromFile(context.String("config")))
 	} else {
 		var (

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -34,10 +34,14 @@ import (
 // NewContainer creates a new container
 func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli.Context) (containerd.Container, error) {
 	var (
-		ref  = context.Args().First()
-		id   = context.Args().Get(1)
-		args = context.Args()[2:]
+		id     string
+		Config = context.IsSet("config")
 	)
+	if Config {
+		id = context.Args().First()
+	} else {
+		id = context.Args().Get(1)
+	}
 
 	if raw := context.String("checkpoint"); raw != "" {
 		im, err := client.GetImage(ctx, raw)
@@ -53,9 +57,14 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 		spec  containerd.NewContainerOpts
 	)
 
-	if context.IsSet("config") {
+	if Config {
 		opts = append(opts, oci.WithSpecFromFile(context.String("config")))
 	} else {
+		var (
+			ref = context.Args().First()
+			//for container's id is Args[1]
+			args = context.Args()[2:]
+		)
 		opts = append(opts, oci.WithDefaultSpec(), oci.WithDefaultUnixDevices)
 		opts = append(opts, oci.WithEnv(context.StringSlice("env")))
 		opts = append(opts, withMounts(context))


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@aliyun.com>

After Merged pull request #2544 
When run a command:
ctr run --config ./config.json --rootfs ./rootfs redis
or
ctr run --config ./config.json docker.io/library/redis:latest redis

The param Image/RootFS will be ignored. It will make the user puzzled when Image/RootFS's value is different from root.path in config.json.

I think pr #2544 may be can improved with a different solution, or if you accept pr #2544, you need to consider this PR.
Please check it. Thanks.

After this PR, more improves will be achieved, such as: ctr run --help, ctr c create --help.