### PR TITLE
add -detach flag for 'ctr t start'

### DIFF
--- a/cmd/ctr/commands/tasks/start.go
+++ b/cmd/ctr/commands/tasks/start.go
@@ -18,6 +18,7 @@ package tasks
 
 import (
 	"github.com/containerd/console"
+	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/pkg/errors"
@@ -42,11 +43,16 @@ var startCommand = cli.Command{
 			Name:  "pid-file",
 			Usage: "file path to write the task's pid",
 		},
+		cli.BoolFlag{
+			Name:  "detach,d",
+			Usage: "detach from the task after it has started execution",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		var (
-			err error
-			id  = context.Args().Get(0)
+			err    error
+			id     = context.Args().Get(0)
+			detach = context.Bool("detach")
 		)
 		if id == "" {
 			return errors.New("container id must be provided")
@@ -83,19 +89,24 @@ var startCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		defer task.Delete(ctx)
+		var statusC <-chan containerd.ExitStatus
+		if !detach {
+			defer task.Delete(ctx)
+			if statusC, err = task.Wait(ctx); err != nil {
+				return err
+			}
+		}
 		if context.IsSet("pid-file") {
 			if err := commands.WritePidFile(context.String("pid-file"), int(task.Pid())); err != nil {
 				return err
 			}
 		}
-		statusC, err := task.Wait(ctx)
-		if err != nil {
-			return err
-		}
 
 		if err := task.Start(ctx); err != nil {
 			return err
+		}
+		if detach {
+			return nil
 		}
 		if tty {
 			if err := HandleConsoleResize(ctx, task, con); err != nil {


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@aliyun.com>

While 'ctr run' havs '-detach' flag.
But if I use 'ctr c create' create a container, there were no '-detach' flage to start the container.

Command history:
```
bin/ctr c create -t --rootfs /opt/runctest/redis/rootfs redis /usr/local/bin/redis-server /etc/redis.conf

bin/ctr t start -h
NAME:
   ctr tasks start - start a container that have been created

USAGE:
   ctr tasks start [command options] CONTAINER

OPTIONS:
   --null-io         send all IO to /dev/null
   --fifo-dir value  directory used for storing IO FIFOs
   --pid-file value  file path to write the task's pid
```

After this pr:
```
bin/ctr t start -h
NAME:
   ctr tasks start - start a container that have been created

USAGE:
   ctr tasks start [command options] CONTAINER

OPTIONS:
   --null-io         send all IO to /dev/null
   --fifo-dir value  directory used for storing IO FIFOs
   --pid-file value  file path to write the task's pid
   --detach, -d      detach from the task after it has started execution

bin/ctr t start -d redis
1:C 27 Aug 10:48:30.661 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
...........................
bin/ctr t ls
TASK     PID      STATUS    
redis    32604    RUNNING
```

The code is from 'cmd/ctr/commands/run/run.go'.