### PR TITLE
Update release script

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -3,6 +3,8 @@ Abhinandan Prativadi <abhi@docker.com> abhi <abhi@docker.com>
 Akihiro Suda <suda.akihiro@lab.ntt.co.jp> Akihiro Suda <suda.kyoto@gmail.com>
 Andrei Vagin <avagin@virtuozzo.com> Andrei Vagin <avagin@openvz.org>
 Frank Yang <yyb196@gmail.com> frank yang <yyb196@gmail.com>
+Jie Zhang <iamkadisi@163.com> kadisi <iamkadisi@163.com>
+John Howard <john.howard@microsoft.com> John Howard <jhoward@microsoft.com>
 Justin Terry <juterry@microsoft.com> Justin Terry (VM) <juterry@microsoft.com>
 Justin Terry <juterry@microsoft.com> Justin <jterry75@users.noreply.github.com>
 Kenfe-Mickaël Laventure <mickael.laventure@gmail.com> Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

--- a/cmd/containerd-release/template.go
+++ b/cmd/containerd-release/template.go
@@ -18,8 +18,10 @@ package main
 
 const (
 	defaultTemplateFile = "TEMPLATE"
-	releaseNotes        = `Welcome to the {{.Version}} release of {{.ProjectName}}!
-{{if .PreRelease -}}
+	releaseNotes        = `{{.ProjectName}} {{.Version}}
+
+Welcome to the {{.Tag}} release of {{.ProjectName}}!
+{{- if .PreRelease }}
 *This is a pre-release of {{.ProjectName}}*
 {{- end}}
 


### PR DESCRIPTION
Saves a step of adding the first line when creating a tag, this gets us a step close to auto tag creation in the release script.

Added option to create links in the changelog. This ensures that the links both exist in the git tag and in the Github release notes, additionally this ensures that the dependencies on Github are also linked, avoiding the creation of incorrect PR links for subprojects.

Updated mailmap to deduplicate John and use a real name for @kadisi (let me know if you would prefer to not have this here or I am using the wrong name)