### PR TITLE
Fix `runc state` error handling.

### DIFF
--- a/runtime/v1/linux/proc/init.go
+++ b/runtime/v1/linux/proc/init.go
@@ -228,7 +228,7 @@ func (p *Init) Status(ctx context.Context) (string, error) {
 	defer p.mu.Unlock()
 	c, err := p.runtime.State(ctx, p.id)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if strings.Contains(err.Error(), "does not exist") {
 			return "stopped", nil
 		}
 		return "", p.runtimeError(err, "OCI runtime state failed")


### PR DESCRIPTION
The error returned by `runtime.State` is a composed error [`fmt.Errorf("%s: %s", err, data)`](https://github.com/containerd/go-runc/blob/master/runc.go#L89). We can't use `os.IsNotExist` directly on it.

If the runc container is successfully deleted, but rootfs unmount fails [here](https://github.com/containerd/containerd/blob/master/runtime/v1/linux/proc/init.go#L272), we won't be able to load the task and retry deletion again, we'll keep getting:
```
failed to load task for sandbox: OCI runtime state failed: container "6a701add28f27c7e1442fa2c75354c86676ff22f3d9773b4d71f1014100c1205" does not exist: unknown
```

This is not urgent, because rootfs unmount won't fail in normal cases.

Signed-off-by: Lantao Liu <lantaol@google.com>