### PR TITLE
fixes can't resume container when paused in runc

### DIFF
--- a/runtime/v1/linux/proc/deleted_state.go
+++ b/runtime/v1/linux/proc/deleted_state.go
@@ -69,3 +69,7 @@ func (s *deletedState) SetExited(status int) {
 func (s *deletedState) Exec(ctx context.Context, path string, r *ExecConfig) (proc.Process, error) {
 	return nil, errors.Errorf("cannot exec in a deleted state")
 }
+
+func (s *deletedState) CheckRuncState(ctx context.Context) error {
+	return nil
+}

--- a/runtime/v1/shim/service.go
+++ b/runtime/v1/shim/service.go
@@ -207,6 +207,9 @@ func (s *Service) Delete(ctx context.Context, r *ptypes.Empty) (*shimapi.DeleteR
 	if p == nil {
 		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
 	}
+	if err := p.(*proc.Init).CheckRuncState(ctx); err != nil {
+		return nil, err
+	}
 	if err := p.Delete(ctx); err != nil {
 		return nil, err
 	}
@@ -229,6 +232,9 @@ func (s *Service) DeleteProcess(ctx context.Context, r *shimapi.DeleteProcessReq
 	p := s.processes[r.ID]
 	if p == nil {
 		return nil, errors.Wrapf(errdefs.ErrNotFound, "process %s", r.ID)
+	}
+	if err := p.(*proc.Init).CheckRuncState(ctx); err != nil {
+		return nil, err
 	}
 	if err := p.Delete(ctx); err != nil {
 		return nil, err
@@ -253,6 +259,9 @@ func (s *Service) Exec(ctx context.Context, r *shimapi.ExecProcessRequest) (*pty
 	p := s.processes[s.id]
 	if p == nil {
 		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
+	}
+	if err := p.(*proc.Init).CheckRuncState(ctx); err != nil {
+		return nil, err
 	}
 
 	process, err := p.(*proc.Init).Exec(ctx, s.config.Path, &proc.ExecConfig{
@@ -339,6 +348,9 @@ func (s *Service) Pause(ctx context.Context, r *ptypes.Empty) (*ptypes.Empty, er
 	if p == nil {
 		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
 	}
+	if err := p.(*proc.Init).CheckRuncState(ctx); err != nil {
+		return nil, err
+	}
 	if err := p.(*proc.Init).Pause(ctx); err != nil {
 		return nil, err
 	}
@@ -352,6 +364,9 @@ func (s *Service) Resume(ctx context.Context, r *ptypes.Empty) (*ptypes.Empty, e
 	p := s.processes[s.id]
 	if p == nil {
 		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
+	}
+	if err := p.(*proc.Init).CheckRuncState(ctx); err != nil {
+		return nil, err
 	}
 	if err := p.(*proc.Init).Resume(ctx); err != nil {
 		return nil, err
@@ -367,6 +382,9 @@ func (s *Service) Kill(ctx context.Context, r *shimapi.KillRequest) (*ptypes.Emp
 		p := s.processes[s.id]
 		if p == nil {
 			return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
+		}
+		if err := p.(*proc.Init).CheckRuncState(ctx); err != nil {
+			return nil, err
 		}
 		if err := p.Kill(ctx, r.Signal, r.All); err != nil {
 			return nil, errdefs.ToGRPC(err)


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

After I paused a container in runc with command: `runc pause <containerid>`, I can't resume this container use command: `ctr t resume <containerid>`.

It may effect docker.

I think when run task command in ctr or from api, we should check runc's state first.

Please check it, thanks.

Command History:
**Start a container**
```
oot@dockerdemo:/opt/runctest/redis# docker start redis
redis
root@dockerdemo:/opt/runctest/redis# docker ps
CONTAINER ID        IMAGE                              COMMAND                  CREATED             STATUS              PORTS               NAMES
d5555192178f        docker.acmcoder.com/public/redis   "docker-entrypoint.s…"   2 days ago          Up 1 second         6379/tcp            redis
root@dockerdemo:/opt/runctest/redis# runc --root /var/run/docker/runtime-runc/moby list
ID                                                                 PID         STATUS      BUNDLE                                                                                                                               CREATED                          OWNER
d5555192178fbd9f912aece8f0894f7eac4393cb8d9863fb525ee54a34e83911   16199       running     /run/docker/containerd/daemon/io.containerd.runtime.v1.linux/moby/d5555192178fbd9f912aece8f0894f7eac4393cb8d9863fb525ee54a34e83911   2018-09-04T11:49:29.602661882Z   root
root@dockerdemo:/opt/runctest/redis# ctr --address /var/run/docker/containerd/docker-containerd.sock --namespace=moby t ls
TASK                                                                PID      STATUS     CONTAINER    
d5555192178fbd9f912aece8f0894f7eac4393cb8d9863fb525ee54a34e83911    16199    RUNNING
```

**Pause in runc:**
```
root@dockerdemo:/opt/runctest/redis# runc --root /var/run/docker/runtime-runc/moby pause d5555192178fbd9f912aece8f0894f7eac4393cb8d9863fb525ee54a34e83911
root@dockerdemo:/opt/runctest/redis# runc --root /var/run/docker/runtime-runc/moby list
ID                                                                 PID         STATUS      BUNDLE                                                                                                                               CREATED                          OWNER
d5555192178fbd9f912aece8f0894f7eac4393cb8d9863fb525ee54a34e83911   16199       paused      /run/docker/containerd/daemon/io.containerd.runtime.v1.linux/moby/d5555192178fbd9f912aece8f0894f7eac4393cb8d9863fb525ee54a34e83911   2018-09-04T11:49:29.602661882Z   root
root@dockerdemo:/opt/runctest/redis# docker ps
CONTAINER ID        IMAGE                              COMMAND                  CREATED             STATUS              PORTS               NAMES
d5555192178f        docker.acmcoder.com/public/redis   "docker-entrypoint.s…"   2 days ago          Up 2 minutes        6379/tcp            redis
```

**Resume in ctr:**
```
root@dockerdemo:/opt/runctest/redis# docker-containerd-ctr --address /var/run/docker/containerd/docker-containerd.sock --namespace=moby t ls
TASK                                                                PID      STATUS    
d5555192178fbd9f912aece8f0894f7eac4393cb8d9863fb525ee54a34e83911    16199    PAUSED
root@dockerdemo:/opt/runctest/redis# docker-containerd-ctr --address /var/run/docker/containerd/docker-containerd.sock --namespace=moby t resume d5555192178fbd9f912aece8f0894f7eac4393cb8d9863fb525ee54a34e83911
ctr: cannot resume a running process: unknown
```

**Resume in docker:**
```
root@dockerdemo:/opt/runctest/redis# docker unpause redis
Error response from daemon: Container d5555192178fbd9f912aece8f0894f7eac4393cb8d9863fb525ee54a34e83911 is not paused
```

And, docker stop redis is hang.