### PR TITLE
Add a Windows section for Linux oci on LCOW

### DIFF
--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -23,7 +23,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 
@@ -91,10 +90,7 @@ func setCapabilities(s *Spec) {
 // Use as the first option to clear the spec, then apply options afterwards.
 func WithDefaultSpec() SpecOpts {
 	return func(ctx context.Context, _ Client, c *containers.Container, s *Spec) error {
-		if runtime.GOOS == "windows" {
-			return populateDefaultWindowsSpec(ctx, s, c.ID)
-		}
-		return populateDefaultUnixSpec(ctx, s, c.ID)
+		return generateDefaultSpecWithPlatform(ctx, platforms.DefaultString(), c.ID, s)
 	}
 }
 
@@ -104,15 +100,7 @@ func WithDefaultSpec() SpecOpts {
 // Use as the first option to clear the spec, then apply options afterwards.
 func WithDefaultSpecForPlatform(platform string) SpecOpts {
 	return func(ctx context.Context, _ Client, c *containers.Container, s *Spec) error {
-		plat, err := platforms.Parse(platform)
-		if err != nil {
-			return err
-		}
-
-		if plat.OS == "windows" {
-			return populateDefaultWindowsSpec(ctx, s, c.ID)
-		}
-		return populateDefaultUnixSpec(ctx, s, c.ID)
+		return generateDefaultSpecWithPlatform(ctx, platform, c.ID, s)
 	}
 }
 

--- a/runtime/v2/runhcs/service.go
+++ b/runtime/v2/runhcs/service.go
@@ -314,6 +314,14 @@ func writeMountsToConfig(bundle string, mounts []*containerd_types.Mount) error 
 		return errors.Wrap(err, "failed to seek to 0 in config.json")
 	}
 
+	// If we are creating LCOW make sure that spec.Windows is filled out before
+	// appending layer folders.
+	if m.Type == "lcow-layer" && spec.Windows == nil {
+		spec.Windows = &oci.Windows{
+			HyperV: &oci.WindowsHyperV{},
+		}
+	}
+
 	// Append the parents
 	spec.Windows.LayerFolders = append(spec.Windows.LayerFolders, parentLayerPaths...)
 	// Append the scratch


### PR DESCRIPTION
When creating a default OCI spec on Windows that is targeting the LCOW
platform it needs to contain a Windows section as well. This adds the
Windows section by default. It also protects against this case for all
OCI creation that doesnt use the OCI package in the runhcs-shim.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>