### PR TITLE
Fix typo in contirb dir

### DIFF
--- a/contrib/nvidia/nvidia.go
+++ b/contrib/nvidia/nvidia.go
@@ -32,7 +32,7 @@ import (
 const nvidiaCLI = "nvidia-container-cli"
 
 // Capability specifies capabilities for the gpu inside the container
-// Detailed explaination of options can be found:
+// Detailed explanation of options can be found:
 // https://github.com/nvidia/nvidia-container-runtime#supported-driver-capabilities
 type Capability string
 

--- a/contrib/seccomp/seccomp.go
+++ b/contrib/seccomp/seccomp.go
@@ -30,7 +30,7 @@ import (
 )
 
 // WithProfile receives the name of a file stored on disk comprising a json
-// formated seccomp profile, as specified by the opencontainers/runtime-spec.
+// formatted seccomp profile, as specified by the opencontainers/runtime-spec.
 // The profile is read from the file, unmarshaled, and set to the spec.
 func WithProfile(profile string) oci.SpecOpts {
 	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {

--- a/remotes/docker/fetcher.go
+++ b/remotes/docker/fetcher.go
@@ -117,7 +117,7 @@ func (r dockerFetcher) open(ctx context.Context, u, mediatype string, offset int
 			}
 		} else {
 			// TODO: Should any cases where use of content range
-			// without the proper header be considerd?
+			// without the proper header be considered?
 			// 206 responses?
 
 			// Discard up to offset

--- a/remotes/docker/httpreadseeker.go
+++ b/remotes/docker/httpreadseeker.go
@@ -134,7 +134,7 @@ func (hrs *httpReadSeeker) reader() (io.Reader, error) {
 		// There is an edge case here where offset == size of the content. If
 		// we seek, we will probably get an error for content that cannot be
 		// sought (?). In that case, we should err on committing the content,
-		// as the length is already satisified but we just return the empty
+		// as the length is already satisfied but we just return the empty
 		// reader instead.
 
 		hrs.rc = ioutil.NopCloser(bytes.NewReader([]byte{}))


### PR DESCRIPTION
Fix type: 
./contrib/nvidia/nvidia.go (explaination -> explanation)
./contrib/seccomp/seccomp.go (formated -> formatted)
./remotes/docker/fetcher.go (considerd -> considered)
./remotes/docker/httpreadseeker.go (satisified -> satisfied)