### PR TITLE
Don't provide IO when it's not set

### DIFF
--- a/cio/io.go
+++ b/cio/io.go
@@ -141,6 +141,15 @@ func NewCreator(opts ...Opt) Creator {
 		if err != nil {
 			return nil, err
 		}
+		if streams.Stdin == nil {
+			fifos.Stdin = ""
+		}
+		if streams.Stdout == nil {
+			fifos.Stdout = ""
+		}
+		if streams.Stderr == nil {
+			fifos.Stderr = ""
+		}
 		return copyIO(fifos, streams)
 	}
 }

--- a/runtime/v1/linux/proc/exec.go
+++ b/runtime/v1/linux/proc/exec.go
@@ -147,7 +147,7 @@ func (e *execProcess) start(ctx context.Context) (err error) {
 			return errors.Wrap(err, "creating new NULL IO")
 		}
 	} else {
-		if e.io, err = runc.NewPipeIO(e.parent.IoUID, e.parent.IoGID); err != nil {
+		if e.io, err = runc.NewPipeIO(e.parent.IoUID, e.parent.IoGID, withConditionalIO(e.stdio)); err != nil {
 			return errors.Wrap(err, "failed to create runc io pipes")
 		}
 	}

--- a/runtime/v1/linux/proc/init.go
+++ b/runtime/v1/linux/proc/init.go
@@ -123,7 +123,7 @@ func (p *Init) Create(ctx context.Context, r *CreateConfig) error {
 			return errors.Wrap(err, "creating new NULL IO")
 		}
 	} else {
-		if p.io, err = runc.NewPipeIO(p.IoUID, p.IoGID); err != nil {
+		if p.io, err = runc.NewPipeIO(p.IoUID, p.IoGID, withConditionalIO(p.stdio)); err != nil {
 			return errors.Wrap(err, "failed to create OCI runtime io pipes")
 		}
 	}
@@ -397,5 +397,13 @@ func (p *Init) runtimeError(rErr error, msg string) error {
 		return errors.Wrap(rErr, msg)
 	default:
 		return errors.Errorf("%s: %s", msg, rMsg)
+	}
+}
+
+func withConditionalIO(c proc.Stdio) runc.IOOpt {
+	return func(o *runc.IOOption) {
+		o.OpenStdin = c.Stdin != ""
+		o.OpenStdout = c.Stdout != ""
+		o.OpenStderr = c.Stderr != ""
 	}
 }

--- a/runtime/v1/linux/proc/io.go
+++ b/runtime/v1/linux/proc/io.go
@@ -109,7 +109,6 @@ func copyPipes(ctx context.Context, rio runc.IO, stdin, stdout, stderr string, w
 		i.dest(fw, fr)
 	}
 	if stdin == "" {
-		rio.Stdin().Close()
 		return nil
 	}
 	f, err := fifo.OpenFifo(ctx, stdin, syscall.O_RDONLY|syscall.O_NONBLOCK, 0)

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,4 +1,4 @@
-github.com/containerd/go-runc acb7c88cac264acca9b5eae187a117f4d77a1292
+github.com/containerd/go-runc 5a6d9f37cfa36b15efba46dc7ea349fa9b7143c3
 github.com/containerd/console c12b1e7919c14469339a5d38f2f8ed9b64a9de23
 github.com/containerd/cgroups 5e610833b72089b37d0e615de9a92dfc043757c2
 github.com/containerd/typeurl a93fcdb778cd272c6e9b3028b2f42d813e785d40

--- a/vendor/github.com/containerd/go-runc/io_windows.go
+++ b/vendor/github.com/containerd/go-runc/io_windows.go
@@ -19,8 +19,15 @@
 package runc
 
 // NewPipeIO creates pipe pairs to be used with runc
-func NewPipeIO() (i IO, err error) {
-	var pipes []*pipe
+func NewPipeIO(opts ...IOOpt) (i IO, err error) {
+	option := defaultIOOption()
+	for _, o := range opts {
+		o(option)
+	}
+	var (
+		pipes                 []*pipe
+		stdin, stdout, stderr *pipe
+	)
 	// cleanup in case of an error
 	defer func() {
 		if err != nil {
@@ -29,24 +36,24 @@ func NewPipeIO() (i IO, err error) {
 			}
 		}
 	}()
-	stdin, err := newPipe()
-	if err != nil {
-		return nil, err
+	if option.OpenStdin {
+		if stdin, err = newPipe(); err != nil {
+			return nil, err
+		}
+		pipes = append(pipes, stdin)
 	}
-	pipes = append(pipes, stdin)
-
-	stdout, err := newPipe()
-	if err != nil {
-		return nil, err
+	if option.OpenStdout {
+		if stdout, err = newPipe(); err != nil {
+			return nil, err
+		}
+		pipes = append(pipes, stdout)
 	}
-	pipes = append(pipes, stdout)
-
-	stderr, err := newPipe()
-	if err != nil {
-		return nil, err
+	if option.OpenStderr {
+		if stderr, err = newPipe(); err != nil {
+			return nil, err
+		}
+		pipes = append(pipes, stderr)
 	}
-	pipes = append(pipes, stderr)
-
 	return &pipeIO{
 		in:  stdin,
 		out: stdout,

--- a/vendor/github.com/containerd/go-runc/runc.go
+++ b/vendor/github.com/containerd/go-runc/runc.go
@@ -608,9 +608,8 @@ func parseVersion(data []byte) (Version, error) {
 	var v Version
 	parts := strings.Split(strings.TrimSpace(string(data)), "\n")
 	if len(parts) != 3 {
-		return v, ErrParseRuncVersion
+		return v, nil
 	}
-
 	for i, p := range []struct {
 		dest  *string
 		split string


### PR DESCRIPTION
This makes sure that runc does not get any valid IO for the pipe.  Some
builds and other containers will be stuck if they inspect stdin
expecially and its a pipe but not connected to any user input.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>