### PR TITLE
fix: modify lock location of exec delete avoid exec hang

### DIFF
--- a/runtime/v1/linux/proc/exec_state.go
+++ b/runtime/v1/linux/proc/exec_state.go
@@ -60,11 +60,11 @@ func (s *execCreatedState) Start(ctx context.Context) error {
 }
 
 func (s *execCreatedState) Delete(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
 	if err := s.p.delete(ctx); err != nil {
 		return err
 	}
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
 	return s.transition("deleted")
 }
 
@@ -168,11 +168,11 @@ func (s *execStoppedState) Start(ctx context.Context) error {
 }
 
 func (s *execStoppedState) Delete(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
 	if err := s.p.delete(ctx); err != nil {
 		return err
 	}
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
 	return s.transition("deleted")
 }
 

--- a/runtime/v1/shim/service.go
+++ b/runtime/v1/shim/service.go
@@ -224,19 +224,21 @@ func (s *Service) Delete(ctx context.Context, r *ptypes.Empty) (*shimapi.DeleteR
 
 // DeleteProcess deletes an exec'd process
 func (s *Service) DeleteProcess(ctx context.Context, r *shimapi.DeleteProcessRequest) (*shimapi.DeleteResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	if r.ID == s.id {
 		return nil, status.Errorf(codes.InvalidArgument, "cannot delete init process with DeleteProcess")
 	}
+	s.mu.Lock()
 	p := s.processes[r.ID]
+	s.mu.Unlock()
 	if p == nil {
 		return nil, errors.Wrapf(errdefs.ErrNotFound, "process %s", r.ID)
 	}
 	if err := p.Delete(ctx); err != nil {
 		return nil, err
 	}
+	s.mu.Lock()
 	delete(s.processes, r.ID)
+	s.mu.Unlock()
 	return &shimapi.DeleteResponse{
 		ExitStatus: uint32(p.ExitStatus()),
 		ExitedAt:   p.ExitedAt(),


### PR DESCRIPTION
func (e *execProcess) delete(ctx context.Context) error {
    e.wg.Wait()
...
}
delete exec process will wait for io copy finish, if wait here,
other process can not get lock of shim service.

1. add lock before and after p.Delete.
2. put lock after wait io copy in exec Delete.

Signed-off-by: Ace-Tang <aceapril@126.com>


## how to produce the problem 

1. run a container `sudo ctr run -d docker.io/library/busybox:latest b1 top`
2. create start.sh 
```
$ sudo ctr t exec --exec-id e1 -t b1 sh
/ # vi start.sh
/ # cat start.sh 
sleep 100 &

echo "ok"
/ # chmod +x start.sh 
/ # exit
```
3.   run start.sh which will wait for io .
```
$ sudo ctr t exec --exec-id e1 b1 sh -c '/start.sh'
ok

real	1m40.102s
user	0m0.024s
sys	0m0.040s

```
4.  run an other exec process will wait for `e1` finish.
```
$ time sudo ctr t exec --exec-id e1 b1 echo 1
1

real	1m30.652s
user	0m0.028s
sys	0m0.004s
```

also `ctr t ls` will also hang, since it also need acquire shim lock to get task status.

