### PR TITLE
Uses namespace labels for default options

### DIFF
--- a/client.go
+++ b/client.go
@@ -144,7 +144,7 @@ func New(address string, opts ...ClientOpt) (*Client, error) {
 		namespaces := c.NamespaceService()
 		ctx := context.Background()
 		if labels, err := namespaces.Labels(ctx, copts.defaultns); err == nil {
-			if defaultRuntime, ok := labels["containerd.io/defaults/runtime"]; ok {
+			if defaultRuntime, ok := labels[defaults.DefaultRuntimeNSLabel]; ok {
 				c.runtime = defaultRuntime
 			}
 		} else {
@@ -174,7 +174,7 @@ func NewWithConn(conn *grpc.ClientConn, opts ...ClientOpt) (*Client, error) {
 		namespaces := c.NamespaceService()
 		ctx := context.Background()
 		if labels, err := namespaces.Labels(ctx, copts.defaultns); err == nil {
-			if defaultRuntime, ok := labels["containerd.io/defaults/runtime"]; ok {
+			if defaultRuntime, ok := labels[defaults.DefaultRuntimeNSLabel]; ok {
 				c.runtime = defaultRuntime
 			}
 		} else {

--- a/client.go
+++ b/client.go
@@ -138,6 +138,22 @@ func New(address string, opts ...ClientOpt) (*Client, error) {
 	if copts.services == nil && c.conn == nil {
 		return nil, errors.New("no grpc connection or services is available")
 	}
+
+	// check namespace labels for default runtime
+	defaultns := "default"
+	if copts.defaultns != "" {
+		defaultns = copts.defaultns
+	}
+	namespaces := c.NamespaceService()
+	ctx := context.Background()
+	if labels, err := namespaces.Labels(ctx, defaultns); err == nil {
+		if defaultRuntime, ok := labels["runtime"]; ok {
+			c.runtime = defaultRuntime
+		}
+	} else {
+		return nil, err
+	}
+
 	return c, nil
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/namespaces"
@@ -405,7 +406,7 @@ func TestDefaultRuntimeWithNamespaceLabels(t *testing.T) {
 	defer cancel()
 	namespaces := client.NamespaceService()
 	testRuntime := "testRuntime"
-	runtimeLabel := "containerd.io/defaults/runtime"
+	runtimeLabel := defaults.DefaultRuntimeNSLabel
 	if err := namespaces.SetLabel(ctx, testNamespace, runtimeLabel, testRuntime); err != nil {
 		t.Fatal(err)
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -405,11 +405,12 @@ func TestDefaultRuntimeWithNamespaceLabels(t *testing.T) {
 	defer cancel()
 	namespaces := client.NamespaceService()
 	testRuntime := "testRuntime"
-	if err := namespaces.SetLabel(ctx, testNamespace, "runtime", testRuntime); err != nil {
+	runtimeLabel := "containerd.io/defaults/runtime"
+	if err := namespaces.SetLabel(ctx, testNamespace, runtimeLabel, testRuntime); err != nil {
 		t.Fatal(err)
 	}
 
-	testClient, err := newClient(t, address, WithDefaultNamespace(testNamespace))
+	testClient, err := New(address, WithDefaultNamespace(testNamespace))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -393,3 +393,28 @@ func createShimDebugConfig() string {
 
 	return f.Name()
 }
+
+func TestDefaultRuntimeWithNamespaceLabels(t *testing.T) {
+	client, err := newClient(t, address)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	ctx, cancel := testContext()
+	defer cancel()
+	namespaces := client.NamespaceService()
+	testRuntime := "testRuntime"
+	if err := namespaces.SetLabel(ctx, testNamespace, "runtime", testRuntime); err != nil {
+		t.Fatal(err)
+	}
+
+	testClient, err := newClient(t, address, WithDefaultNamespace(testNamespace))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer testClient.Close()
+	if testClient.runtime != testRuntime {
+		t.Error("failed to set default runtime from namespace labels")
+	}
+}

--- a/container_opts.go
+++ b/container_opts.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
@@ -172,7 +173,7 @@ func setSnapshotterIfEmpty(ctx context.Context, client *Client, c *containers.Co
 		namespaceService := client.NamespaceService()
 		if ns, err := namespaces.NamespaceRequired(ctx); err == nil {
 			if labels, err := namespaceService.Labels(ctx, ns); err == nil {
-				if snapshotLabel, ok := labels["containerd.io/defaults/snapshotter"]; ok {
+				if snapshotLabel, ok := labels[defaults.DefaultSnapshotterNSLabel]; ok {
 					defaultSnapshotter = snapshotLabel
 				}
 			}

--- a/container_opts.go
+++ b/container_opts.go
@@ -172,7 +172,7 @@ func setSnapshotterIfEmpty(ctx context.Context, client *Client, c *containers.Co
 		namespaceService := client.NamespaceService()
 		if ns, err := namespaces.NamespaceRequired(ctx); err == nil {
 			if labels, err := namespaceService.Labels(ctx, ns); err == nil {
-				if snapshotLabel, ok := labels["snapshotter"]; ok {
+				if snapshotLabel, ok := labels["containerd.io/defaults/snapshotter"]; ok {
 					defaultSnapshotter = snapshotLabel
 				}
 			}

--- a/container_opts_unix.go
+++ b/container_opts_unix.go
@@ -50,7 +50,7 @@ func withRemappedSnapshotBase(id string, i Image, uid, gid uint32, readonly bool
 			return err
 		}
 
-		setSnapshotterIfEmpty(c)
+		setSnapshotterIfEmpty(ctx, client, c)
 
 		var (
 			snapshotter = client.SnapshotService(c.Snapshotter)

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -23,4 +23,10 @@ const (
 	// DefaultMaxSendMsgSize defines the default maximum message size for
 	// sending protobufs passed over the GRPC API.
 	DefaultMaxSendMsgSize = 16 << 20
+	// DefaultRuntimeNSLabel defines the namespace label to check for
+	// default runtime
+	DefaultRuntimeNSLabel = "containerd.io/defaults/runtime"
+	// DefaultSnapshotterNSLabel defines the namespances label to check for
+	// default snapshotter
+	DefaultSnapshotterNSLabel = "containerd.io/defaults/snapshotter"
 )

--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -34,9 +34,7 @@ Filesystem paths, IDs, and other system level resources must be namespaced for a
 
 Simply create a new `context` and set your application's namespace on the `context`.
 Make sure to use a unique namespace for applications that does not conflict with existing namespaces. The namespaces
-API, or the `ctr namespaces` client command, can be used to query/list and create new namespaces. Note that namespaces
-can have a list of labels associated with the namespace. This can be useful for associating metadata with a particular
-namespace.
+API, or the `ctr namespaces` client command, can be used to query/list and create new namespaces.
 
 ```go
 ctx := context.Background()
@@ -48,6 +46,19 @@ var (
 	cri = namespaces.WithNamespace(ctx, "cri")
 )
 ```
+
+## Namespace Labels
+
+Namespaces can have a list of labels associated with the namespace. This can be useful for associating metadata with a particular namespace.
+Labels can also be used to configure the defaults for containerd, for example:
+
+```bash
+> sudo ctr namespaces label k8s.io containerd.io/defaults/snapshotter=btrfs
+> sudo ctr namespaces label k8s.io containerd.io/defaults/runtime=testRuntime
+```
+
+This will set the default snapshotter as `btrfs` and runtime as `testRuntime`.
+Note that currently only these two labels are used to configure the defaults and labels of `default` namespace are not considered for the same.
 
 ## Inspecting Namespaces
 


### PR DESCRIPTION
This is in reference to #2285. I tried to configure default runtime and snapshotter using namespace labels. Please suggest me the right approach if this is not the best way to do it.

Signed-off-by: Nikhil Soni <krsoninikhil@gmail.com>