### PR TITLE
Add optional install path

### DIFF
--- a/cmd/ctr/commands/install/install.go
+++ b/cmd/ctr/commands/install/install.go
@@ -37,6 +37,10 @@ var Command = cli.Command{
 			Name:  "replace,r",
 			Usage: "replace any binaries or libs in the opt directory",
 		},
+		cli.StringFlag{
+			Name:  "path",
+			Usage: "set an optional install path other than the managed opt directory",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		client, ctx, cancel, err := commands.NewClient(context)
@@ -55,6 +59,9 @@ var Command = cli.Command{
 		}
 		if context.Bool("replace") {
 			opts = append(opts, containerd.WithInstallReplace)
+		}
+		if path := context.String("path"); path != "" {
+			opts = append(opts, containerd.WithInstallPath(path))
 		}
 		return client.Install(ctx, image, opts...)
 	},

--- a/install_opts.go
+++ b/install_opts.go
@@ -25,6 +25,8 @@ type InstallConfig struct {
 	Libs bool
 	// Replace will overwrite existing binaries or libs in the opt directory
 	Replace bool
+	// Path to install libs and binaries to
+	Path string
 }
 
 // WithInstallLibs installs libs from the image
@@ -35,4 +37,11 @@ func WithInstallLibs(c *InstallConfig) {
 // WithInstallReplace will replace existing files
 func WithInstallReplace(c *InstallConfig) {
 	c.Replace = true
+}
+
+// WithInstallPath sets the optional install path
+func WithInstallPath(path string) InstallOpts {
+	return func(c *InstallConfig) {
+		c.Path = path
+	}
 }


### PR DESCRIPTION
This allows users to consume the install functionality but also install
to other areas instead of the managed `/opt` dir.

```bash
> ctr install --path /usr/local
```

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>