### PR TITLE
set a default timeout to containerd-shim operations

### DIFF
--- a/runtime/v1/shim/client/client.go
+++ b/runtime/v1/shim/client/client.go
@@ -157,7 +157,7 @@ func newSocket(address string) (*net.UnixListener, error) {
 }
 
 func connect(address string, d func(string, time.Duration) (net.Conn, error)) (net.Conn, error) {
-	return d(address, 100*time.Second)
+	return d(address, 10*time.Second)
 }
 
 func annonDialer(address string, timeout time.Duration) (net.Conn, error) {


### PR DESCRIPTION
Signed-off-by: Jie Zhang <iamkadisi@163.com>
about issue #2578

set the connect default timeout to 10 second. 