### PR TITLE
Add flag to ctr for running with "NoNewPrivileges: false"

### DIFF
--- a/cmd/ctr/commands/commands.go
+++ b/cmd/ctr/commands/commands.go
@@ -124,6 +124,10 @@ var (
 			Name:  "gpus",
 			Usage: "add gpus to the container",
 		},
+		cli.BoolFlag{
+			Name:  "allow-new-privs",
+			Usage: "turn off OCI spec's NoNewPrivileges feature flag",
+		},
 	}
 )
 

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -136,6 +136,9 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 		if context.IsSet("gpus") {
 			opts = append(opts, nvidia.WithGPUs(nvidia.WithDevices(context.Int("gpus")), nvidia.WithAllCapabilities))
 		}
+		if context.IsSet("allow-new-privs") {
+			opts = append(opts, oci.WithNewPrivileges)
+		}
 	}
 
 	cOpts = append(cOpts, containerd.WithContainerLabels(commands.LabelArgs(context.StringSlice("label"))))

--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -268,6 +268,14 @@ func WithLinuxNamespace(ns specs.LinuxNamespace) SpecOpts {
 	}
 }
 
+// WithNewPrivileges turns off the NoNewPrivileges feature flag in the spec
+func WithNewPrivileges(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
+	setProcess(s)
+	s.Process.NoNewPrivileges = false
+
+	return nil
+}
+
 // WithImageConfig configures the spec to from the configuration of an Image
 func WithImageConfig(image Image) SpecOpts {
 	return WithImageConfigArgs(image, nil)


### PR DESCRIPTION
Add flag and With-helper to set NoNewPrivileges to false since it is on
by default in the default UNIX spec for containerd, but off by default
in Docker and CRI plugin use. This allows for easy testing with the feature
off for doing comparison.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>

Fixes: #2643