### PR TITLE
Update mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -17,3 +17,9 @@ Stephen J Day <stevvooe@gmail.com> Stephen Day <stevvooe@users.noreply.github.co
 Stephen J Day <stevvooe@gmail.com> Stephen Day <stephen.day@getcruise.com>
 Sudeesh John <sudeesh@linux.vnet.ibm.com> sudeesh john <sudeesh@linux.vnet.ibm.com>
 Tõnis Tiigi <tonistiigi@gmail.com> Tonis Tiigi <tonistiigi@gmail.com>
+Lifubang <lifubang@aliyun.com> Lifubang <lifubang@acmcoder.com>
+Xiaodong Zhang <a4012017@sina.com> nashasha1 <a4012017@sina.com>
+Jian Liao <jliao@alauda.io> liaoj <jliao@alauda.io>
+Jian Liao <jliao@alauda.io> liaojian <liaojian@Dabllo.local>
+Rui Cao <ruicao@alauda.io> ruicao <ruicao@alauda.io>
+Yan Xuean <yan.xuean@zte.com.cn> yanxuean <yan.xuean@zte.com.cn>


### PR DESCRIPTION
Add consistent contributor names and emails
before cleanup https://gist.github.com/dmcgowan/20bc5d9e19fd91136135586465e31e81

ping @nashasha1 @lifubang @jianliao82 @yanxuean @mirake please let me know if this is not how you want your name displayed in the release notes (name on the left is what gets used).