### PR TITLE
[release/1.1] Backport: Add flag to ctr for running with NoNewPrivileges: false

### DIFF
--- a/cmd/ctr/commands/commands.go
+++ b/cmd/ctr/commands/commands.go
@@ -124,6 +124,10 @@ var (
 			Name:  "gpus",
 			Usage: "add gpus to the container",
 		},
+		cli.BoolFlag{
+			Name:  "allow-new-privs",
+			Usage: "turn off OCI spec's NoNewPrivileges feature flag",
+		},
 	}
 )
 

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -113,6 +113,9 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 			Path: parts[1],
 		}))
 	}
+	if context.IsSet("allow-new-privs") {
+		opts = append(opts, oci.WithNewPrivileges)
+	}
 	if context.IsSet("config") {
 		var s specs.Spec
 		if err := loadSpec(context.String("config"), &s); err != nil {

--- a/oci/spec_opts_unix.go
+++ b/oci/spec_opts_unix.go
@@ -172,6 +172,14 @@ func WithNoNewPrivileges(_ context.Context, _ Client, _ *containers.Container, s
 	return nil
 }
 
+// WithNewPrivileges turns off the NoNewPrivileges feature flag in the spec
+func WithNewPrivileges(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec) error {
+	setProcess(s)
+	s.Process.NoNewPrivileges = false
+
+	return nil
+}
+
 // WithHostHostsFile bind-mounts the host's /etc/hosts into the container as readonly
 func WithHostHostsFile(_ context.Context, _ Client, _ *containers.Container, s *specs.Spec) error {
 	s.Mounts = append(s.Mounts, specs.Mount{


### PR DESCRIPTION
Add flag and With-helper to set NoNewPrivileges to false since it is on
by default in the default UNIX spec for containerd, but off by default
in Docker and CRI plugin use. This allows for easy testing with it off
for comparison.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>