### PR TITLE
Remove a TODO from the code comments that is complete

### DIFF
--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -149,9 +149,8 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 
 	cOpts = append(cOpts, spec)
 
-	// oci.WithImageConfig (WithUsername, WithUserID) depends on rootfs snapshot for resolving /etc/passwd.
-	// So cOpts needs to have precedence over opts.
-	// TODO: WithUsername, WithUserID should additionally support non-snapshot rootfs
+	// oci.WithImageConfig (WithUsername, WithUserID) depends on access to rootfs for resolving via
+	// the /etc/{passwd,group} files. So cOpts needs to have precedence over opts.
 	return client.NewContainer(ctx, id, cOpts...)
 }
 


### PR DESCRIPTION
WithUser... helpers **do** support non-snapshot rootfs now.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>