### PR TITLE
decode spec in `ctr c info`

### DIFF
--- a/cmd/ctr/commands/containers/containers.go
+++ b/cmd/ctr/commands/containers/containers.go
@@ -28,7 +28,9 @@ import (
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/cmd/ctr/commands/run"
+	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/typeurl"
 	"github.com/urfave/cli"
 )
 
@@ -261,8 +263,22 @@ var infoCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		commands.PrintAsJSON(info)
 
+		if info.Spec != nil && info.Spec.Value != nil {
+			v, err := typeurl.UnmarshalAny(info.Spec)
+			if err != nil {
+				return err
+			}
+			commands.PrintAsJSON(struct {
+				containers.Container
+				Spec interface{} `json:"Spec,omitempty"`
+			}{
+				Container: info,
+				Spec:      v,
+			})
+			return nil
+		}
+		commands.PrintAsJSON(info)
 		return nil
 	},
 }


### PR DESCRIPTION
Closes #2568

Signed-off-by: Lifubang <lifubang@aliyun.com>

Before this commit, the Spec.value field  are incomprehensible:
```
root@dockerdemo:/opt/runctest/redis# ctr c info busybox
{
    "ID": "busybox",
    "Labels": null,
    "Image": "docker.acmcoder.com/public/busybox:latest",
    "Runtime": {
        "Name": "io.containerd.runtime.v1.linux",
        "Options": null
    },
    "Spec": {
        "type_url": "types.containerd.io/opencontainers/runtime-spec/1/Spec",
        "value": "eyJvY2lWZXJzaW9uIjoiM*************"
    },
    "SnapshotKey": "busybox",
    "Snapshotter": "overlayfs",
    "CreatedAt": "2018-08-23T05:16:17.371767147Z",
    "UpdatedAt": "2018-08-23T05:16:17.371767147Z",
    "Extensions": null
}
```

After the commit, there are some useful information for us:
```
root@dockerdemo:/opt/runctest/redis# ~/gocode/src/github.com/containerd/containerd/bin/ctr c info busybox
{
    "ID": "busybox",
    "Labels": null,
    "Image": "docker.acmcoder.com/public/busybox:latest",
    "Runtime": {
        "Name": "io.containerd.runtime.v1.linux",
        "Options": null
    },
    "SnapshotKey": "busybox",
    "Snapshotter": "overlayfs",
    "CreatedAt": "2018-08-23T05:16:17.371767147Z",
    "UpdatedAt": "2018-08-23T05:16:17.371767147Z",
    "Extensions": null,
    "Spec": {
        "type_url": "types.containerd.io/opencontainers/runtime-spec/1/Spec",
        "value": {
            "linux": {
                "cgroupsPath": "/default/busybox",
                "maskedPaths": [
                    "/proc/acpi",
                    "/proc/kcore",
                    "/proc/keys",
                    "/proc/latency_stats",
                    "/proc/timer_list",
                    "/proc/timer_stats",
                    "/proc/sched_debug",
                    "/sys/firmware",
                    "/proc/scsi"
                ],
                "namespaces": [
                    {
                        "type": "pid"
                    },
                    {
                        "type": "ipc"
                    },
                    {
                        "type": "uts"
                    },
                    {
                        "type": "mount"
                    },
                    {
                        "type": "network"
                    }
                ],
                "readonlyPaths": [
                    "/proc/asound",
                    "/proc/bus",
                    "/proc/fs",
                    "/proc/irq",
                    "/proc/sys",
                    "/proc/sysrq-trigger"
                ],
                "resources": {
                    "devices": [
                        {
                            "access": "rwm",
                            "allow": false
                        }
                    ]
                }
            },
            "mounts": [
                {
                    "destination": "/proc",
                    "source": "proc",
                    "type": "proc"
                },
                {
                    "destination": "/dev",
                    "options": [
                        "nosuid",
                        "strictatime",
                        "mode=755",
                        "size=65536k"
                    ],
                    "source": "tmpfs",
                    "type": "tmpfs"
                },
                {
                    "destination": "/dev/pts",
                    "options": [
                        "nosuid",
                        "noexec",
                        "newinstance",
                        "ptmxmode=0666",
                        "mode=0620",
                        "gid=5"
                    ],
                    "source": "devpts",
                    "type": "devpts"
                },
                {
                    "destination": "/dev/shm",
                    "options": [
                        "nosuid",
                        "noexec",
                        "nodev",
                        "mode=1777",
                        "size=65536k"
                    ],
                    "source": "shm",
                    "type": "tmpfs"
                },
                {
                    "destination": "/dev/mqueue",
                    "options": [
                        "nosuid",
                        "noexec",
                        "nodev"
                    ],
                    "source": "mqueue",
                    "type": "mqueue"
                },
                {
                    "destination": "/sys",
                    "options": [
                        "nosuid",
                        "noexec",
                        "nodev",
                        "ro"
                    ],
                    "source": "sysfs",
                    "type": "sysfs"
                },
                {
                    "destination": "/run",
                    "options": [
                        "nosuid",
                        "strictatime",
                        "mode=755",
                        "size=65536k"
                    ],
                    "source": "tmpfs",
                    "type": "tmpfs"
                }
            ],
            "ociVersion": "1.0.1",
            "process": {
                "args": [
                    "sh"
                ],
                "capabilities": {
                    "bounding": [
                        "CAP_CHOWN",
                        "CAP_DAC_OVERRIDE",
                        "CAP_FSETID",
                        "CAP_FOWNER",
                        "CAP_MKNOD",
                        "CAP_NET_RAW",
                        "CAP_SETGID",
                        "CAP_SETUID",
                        "CAP_SETFCAP",
                        "CAP_SETPCAP",
                        "CAP_NET_BIND_SERVICE",
                        "CAP_SYS_CHROOT",
                        "CAP_KILL",
                        "CAP_AUDIT_WRITE"
                    ],
                    "effective": [
                        "CAP_CHOWN",
                        "CAP_DAC_OVERRIDE",
                        "CAP_FSETID",
                        "CAP_FOWNER",
                        "CAP_MKNOD",
                        "CAP_NET_RAW",
                        "CAP_SETGID",
                        "CAP_SETUID",
                        "CAP_SETFCAP",
                        "CAP_SETPCAP",
                        "CAP_NET_BIND_SERVICE",
                        "CAP_SYS_CHROOT",
                        "CAP_KILL",
                        "CAP_AUDIT_WRITE"
                    ],
                    "inheritable": [
                        "CAP_CHOWN",
                        "CAP_DAC_OVERRIDE",
                        "CAP_FSETID",
                        "CAP_FOWNER",
                        "CAP_MKNOD",
                        "CAP_NET_RAW",
                        "CAP_SETGID",
                        "CAP_SETUID",
                        "CAP_SETFCAP",
                        "CAP_SETPCAP",
                        "CAP_NET_BIND_SERVICE",
                        "CAP_SYS_CHROOT",
                        "CAP_KILL",
                        "CAP_AUDIT_WRITE"
                    ],
                    "permitted": [
                        "CAP_CHOWN",
                        "CAP_DAC_OVERRIDE",
                        "CAP_FSETID",
                        "CAP_FOWNER",
                        "CAP_MKNOD",
                        "CAP_NET_RAW",
                        "CAP_SETGID",
                        "CAP_SETUID",
                        "CAP_SETFCAP",
                        "CAP_SETPCAP",
                        "CAP_NET_BIND_SERVICE",
                        "CAP_SYS_CHROOT",
                        "CAP_KILL",
                        "CAP_AUDIT_WRITE"
                    ]
                },
                "cwd": "/",
                "env": [
                    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
                    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
                    "TERM=xterm"
                ],
                "noNewPrivileges": true,
                "rlimits": [
                    {
                        "hard": 1024,
                        "soft": 1024,
                        "type": "RLIMIT_NOFILE"
                    }
                ],
                "terminal": true,
                "user": {
                    "gid": 0,
                    "uid": 0
                }
            },
            "root": {
                "path": "rootfs"
            }
        }
    }
}
```