### PR TITLE
Various runhcs shim fixes

### DIFF
--- a/runtime/v2/binary.go
+++ b/runtime/v2/binary.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"io"
 	"os"
+	gruntime "runtime"
 	"strings"
 
 	eventstypes "github.com/containerd/containerd/api/events"
@@ -109,7 +110,23 @@ func (b *binary) Start(ctx context.Context) (_ *shim, err error) {
 
 func (b *binary) Delete(ctx context.Context) (*runtime.Exit, error) {
 	log.G(ctx).Info("cleaning up dead shim")
-	cmd, err := client.Command(ctx, b.runtime, b.containerdAddress, b.bundle.Path, "-id", b.bundle.ID, "delete")
+	var bundlePath string
+	if gruntime.GOOS == "windows" {
+		// Windows cannot delete the current working directory while an
+		// executable is in use with it. For the cleanup case we invoke with the
+		// deafult work dir and forward the bundle path on the cmdline.
+		bundlePath = ""
+	} else {
+		bundlePath = b.bundle.Path
+	}
+
+	cmd, err := client.Command(ctx,
+		b.runtime,
+		b.containerdAddress,
+		bundlePath,
+		"-id", b.bundle.ID,
+		"-bundle", b.bundle.Path,
+		"delete")
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/v2/binary.go
+++ b/runtime/v2/binary.go
@@ -110,13 +110,12 @@ func (b *binary) Start(ctx context.Context) (_ *shim, err error) {
 
 func (b *binary) Delete(ctx context.Context) (*runtime.Exit, error) {
 	log.G(ctx).Info("cleaning up dead shim")
+
+	// Windows cannot delete the current working directory while an
+	// executable is in use with it. For the cleanup case we invoke with the
+	// default work dir and forward the bundle path on the cmdline.
 	var bundlePath string
-	if gruntime.GOOS == "windows" {
-		// Windows cannot delete the current working directory while an
-		// executable is in use with it. For the cleanup case we invoke with the
-		// deafult work dir and forward the bundle path on the cmdline.
-		bundlePath = ""
-	} else {
+	if gruntime.GOOS != "windows" {
 		bundlePath = b.bundle.Path
 	}
 

--- a/runtime/v2/shim/shim.go
+++ b/runtime/v2/shim/shim.go
@@ -58,7 +58,8 @@ type OptsKey struct{}
 
 // Opts are context options associated with the shim invocation.
 type Opts struct {
-	Debug bool
+	BundlePath string
+	Debug      bool
 }
 
 var (
@@ -66,6 +67,7 @@ var (
 	idFlag               string
 	namespaceFlag        string
 	socketFlag           string
+	bundlePath           string
 	addressFlag          string
 	containerdBinaryFlag string
 	action               string
@@ -76,6 +78,7 @@ func parseFlags() {
 	flag.StringVar(&namespaceFlag, "namespace", "", "namespace that owns the shim")
 	flag.StringVar(&idFlag, "id", "", "id of the task")
 	flag.StringVar(&socketFlag, "socket", "", "abstract socket path to serve")
+	flag.StringVar(&bundlePath, "bundle", "", "path to the bundle if not workdir")
 
 	flag.StringVar(&addressFlag, "address", "", "grpc address back to main containerd")
 	flag.StringVar(&containerdBinaryFlag, "publish-binary", "containerd", "path to publish binary (used for publishing events)")
@@ -141,7 +144,7 @@ func run(id string, initFunc Init) error {
 		return fmt.Errorf("shim namespace cannot be empty")
 	}
 	ctx := namespaces.WithNamespace(context.Background(), namespaceFlag)
-	ctx = context.WithValue(ctx, OptsKey{}, Opts{Debug: debugFlag})
+	ctx = context.WithValue(ctx, OptsKey{}, Opts{BundlePath: bundlePath, Debug: debugFlag})
 	ctx = log.WithLogger(ctx, log.G(ctx).WithField("runtime", id))
 
 	service, err := initFunc(ctx, idFlag, publisher)

--- a/runtime/v2/shim/shim_windows.go
+++ b/runtime/v2/shim/shim_windows.go
@@ -129,7 +129,7 @@ func handleSignals(logger *logrus.Entry, signals chan os.Signal) error {
 // to reconnect to any shims. This means that the connection to the logger will
 // be severed but when containerd starts up it should reconnect and start
 // logging again. We abstract all of this logic behind what looks like a simple
-// `io.Writer` that can reconnect in the liftime and buffers logs while
+// `io.Writer` that can reconnect in the lifetime and buffers logs while
 // disconnected.
 type deferredShimWriteLogger struct {
 	mu sync.Mutex
@@ -193,7 +193,7 @@ func (dswl *deferredShimWriteLogger) Write(p []byte) (int, error) {
 	}
 
 	if dswl.connected {
-		// We have a connection. beginAccept would of drained the buffer so we just write our data to
+		// We have a connection. beginAccept would have drained the buffer so we just write our data to
 		// the connection directly.
 		written, err := dswl.c.Write(p)
 		if err != nil {

--- a/runtime/v2/shim/shim_windows_test.go
+++ b/runtime/v2/shim/shim_windows_test.go
@@ -1,0 +1,89 @@
+// +build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package shim
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	winio "github.com/Microsoft/go-winio"
+	"github.com/containerd/containerd/namespaces"
+)
+
+func readValueFrom(rdr io.Reader, expectedStr string, t *testing.T) {
+	expected := []byte(expectedStr)
+	actual := make([]byte, len(expected))
+	read, err := rdr.Read(actual)
+	if err != nil {
+		t.Fatalf("failed to read with: %v", err)
+	}
+	if read != len(expected) {
+		t.Fatalf("failed to read len %v bytes read: %v", len(expected), actual)
+	}
+	if !bytes.Equal(expected, actual) {
+		t.Fatalf("expected '%v' != actual '%v'", expected, actual)
+	}
+}
+
+func writeValueTo(wr io.Writer, value string, t *testing.T) {
+	expected := []byte(value)
+	written, err := wr.Write(expected)
+	if err != nil {
+		t.Fatalf("failed to write with: %v", err)
+	}
+	if len(expected) != written {
+		t.Fatalf("failed to write len %v bytes wrote: %v", len(expected), written)
+	}
+}
+
+func runOneTest(ns, id string, writer io.Writer, t *testing.T) {
+	// Write on closed
+	go writeValueTo(writer, "Hello World!", t)
+
+	// Connect
+	c, err := winio.DialPipe(fmt.Sprintf("\\\\.\\pipe\\containerd-shim-%s-%s-log", ns, id), nil)
+	if err != nil {
+		t.Fatal("should have successfully connected to log")
+	}
+	defer c.Close()
+
+	// Read the deferred buffer.
+	readValueFrom(c, "Hello World!", t)
+
+	go writeValueTo(writer, "Hello Next!", t)
+	readValueFrom(c, "Hello Next!", t)
+}
+
+func TestOpenLog(t *testing.T) {
+	ns := "openlognamespace"
+	id := "openlogid"
+	ctx := namespaces.WithNamespace(context.TODO(), ns)
+	writer, err := openLog(ctx, id)
+	if err != nil {
+		t.Fatalf("failed openLog with %v", err)
+	}
+
+	// Do three iterations of write/open/read/write/read/close
+	for i := 0; i < 3; i++ {
+		runOneTest(ns, id, writer, t)
+	}
+}

--- a/runtime/v2/shim/shim_windows_test.go
+++ b/runtime/v2/shim/shim_windows_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"testing"
+	"time"
 
 	winio "github.com/Microsoft/go-winio"
 	"github.com/containerd/containerd/namespaces"
@@ -37,27 +38,27 @@ func readValueFrom(rdr io.Reader, expectedStr string, t *testing.T) {
 		t.Fatalf("failed to read with: %v", err)
 	}
 	if read != len(expected) {
-		t.Fatalf("failed to read len %v bytes read: %v", len(expected), actual)
+		t.Fatalf("failed to read len %v bytes read: %v", len(expected), read)
 	}
 	if !bytes.Equal(expected, actual) {
 		t.Fatalf("expected '%v' != actual '%v'", expected, actual)
 	}
 }
 
-func writeValueTo(wr io.Writer, value string, t *testing.T) {
+func writeValueTo(wr io.Writer, value string) {
 	expected := []byte(value)
 	written, err := wr.Write(expected)
 	if err != nil {
-		t.Fatalf("failed to write with: %v", err)
+		panic(fmt.Sprintf("failed to write with: %v", err))
 	}
 	if len(expected) != written {
-		t.Fatalf("failed to write len %v bytes wrote: %v", len(expected), written)
+		panic(fmt.Sprintf("failed to write len %v bytes wrote: %v", len(expected), written))
 	}
 }
 
 func runOneTest(ns, id string, writer io.Writer, t *testing.T) {
 	// Write on closed
-	go writeValueTo(writer, "Hello World!", t)
+	go writeValueTo(writer, "Hello World!")
 
 	// Connect
 	c, err := winio.DialPipe(fmt.Sprintf("\\\\.\\pipe\\containerd-shim-%s-%s-log", ns, id), nil)
@@ -69,7 +70,7 @@ func runOneTest(ns, id string, writer io.Writer, t *testing.T) {
 	// Read the deferred buffer.
 	readValueFrom(c, "Hello World!", t)
 
-	go writeValueTo(writer, "Hello Next!", t)
+	go writeValueTo(writer, "Hello Next!")
 	readValueFrom(c, "Hello Next!", t)
 }
 
@@ -85,5 +86,77 @@ func TestOpenLog(t *testing.T) {
 	// Do three iterations of write/open/read/write/read/close
 	for i := 0; i < 3; i++ {
 		runOneTest(ns, id, writer, t)
+	}
+}
+
+func TestBlockingBufferWriteNotEnoughCapacity(t *testing.T) {
+	bb := newBlockingBuffer(5)
+	val := make([]byte, 10)
+	w, err := bb.Write(val)
+	if err == nil {
+		t.Fatal("write should of failed capacity check")
+	}
+	if w != 0 {
+		t.Fatal("write should of not written any bytes on failed capacity check")
+	}
+}
+
+func TestBlockingBufferLoop(t *testing.T) {
+	nameBytes := []byte(t.Name())
+	nameBytesLen := len(nameBytes)
+	bb := newBlockingBuffer(nameBytesLen)
+	for i := 0; i < 3; i++ {
+		writeValueTo(bb, t.Name())
+		if bb.Len() != nameBytesLen {
+			t.Fatalf("invalid buffer bytes len after write: (%d)", bb.buffer.Len())
+		}
+		buf := &bytes.Buffer{}
+		w, err := bb.WriteTo(buf)
+		if err != nil {
+			t.Fatalf("should not have failed WriteTo: (%v)", err)
+		}
+		if w != int64(nameBytesLen) {
+			t.Fatalf("should have written all bytes, wrote (%d)", w)
+		}
+		readValueFrom(buf, t.Name(), t)
+		if bb.Len() != 0 {
+			t.Fatalf("invalid buffer bytes len after read: (%d)", bb.buffer.Len())
+		}
+	}
+}
+func TestBlockingBuffer(t *testing.T) {
+	nameBytes := []byte(t.Name())
+	nameBytesLen := len(nameBytes)
+	bb := newBlockingBuffer(nameBytesLen)
+
+	// Write the first value
+	writeValueTo(bb, t.Name())
+	if bb.Len() != nameBytesLen {
+		t.Fatalf("buffer len != %d", nameBytesLen)
+	}
+
+	// We should now have filled capacity the next write should block
+	done := make(chan struct{})
+	go func() {
+		writeValueTo(bb, t.Name())
+		close(done)
+	}()
+	select {
+	case <-done:
+		t.Fatal("third write should of blocked")
+	case <-time.After(10 * time.Millisecond):
+		buff := &bytes.Buffer{}
+		_, err := bb.WriteTo(buff)
+		if err != nil {
+			t.Fatalf("failed to drain buffer with: %v", err)
+		}
+		if bb.Len() != 0 {
+			t.Fatalf("buffer len != %d", 0)
+		}
+		readValueFrom(buff, t.Name(), t)
+	}
+	<-done
+	if bb.Len() != nameBytesLen {
+		t.Fatalf("buffer len != %d", nameBytesLen)
 	}
 }


### PR DESCRIPTION
- Adds Windows shim reconnect logs support
- Decrease shim timeout on pipe not found
On Windows because of the way the log pipe is forwarded to the shim there is a
condition where the pipe listener may not yet be active when a client tries to
connect. To handle this case we allow polling on the file and retry on pipe not
found. This limits the pipe not found retry to 5 seconds but leaves the connect
timeout alone as if there is a listener we want to connect to it normally.
- Handle shim delete workdir on Windows