### PR TITLE
Add support to detect ARM variant on Windows

### DIFF
--- a/platforms/cpuinfo.go
+++ b/platforms/cpuinfo.go
@@ -74,6 +74,22 @@ func getCPUInfo(pattern string) (info string, err error) {
 }
 
 func getCPUVariant() string {
+	if runtime.GOOS == "windows" {
+		// Windows only supports v7 for ARM32 and v8 for ARM64 and so we can use
+		// runtime.GOARCH to determine the variants
+		var variant string
+		switch runtime.GOARCH {
+		case "arm64":
+			variant = "v8"
+		case "arm":
+			variant = "v7"
+		default:
+			variant = "unknown"
+		}
+
+		return variant
+	}
+
 	variant, err := getCPUInfo("Cpu architecture")
 	if err != nil {
 		log.L.WithError(err).Error("failure getting variant")


### PR DESCRIPTION
Opening PR as per https://github.com/containerd/containerd/issues/2693.

We are working on enabling support for ARM on Windows. As part of that, we have hit an issue when getCPUVariant gets called. getCPUVariant calls into getCPUInfo which expects Linux OS and as such it fails for Windows. This change uses GOARM global for Windows and Linux path is unaltered.

@estesp FYI

