### PR TITLE
enhance: support specific duration for profile collection

### DIFF
--- a/cmd/ctr/commands/pprof/pprof.go
+++ b/cmd/ctr/commands/pprof/pprof.go
@@ -89,10 +89,18 @@ var pprofHeapCommand = cli.Command{
 var pprofProfileCommand = cli.Command{
 	Name:  "profile",
 	Usage: "CPU profile",
+	Flags: []cli.Flag{
+		cli.DurationFlag{
+			Name:  "seconds,s",
+			Usage: "duration for collection (seconds)",
+			Value: 30 * time.Second,
+		},
+	},
 	Action: func(context *cli.Context) error {
 		client := getPProfClient(context)
 
-		output, err := httpGetRequest(client, "/debug/pprof/profile")
+		seconds := context.Duration("seconds").Seconds()
+		output, err := httpGetRequest(client, fmt.Sprintf("/debug/pprof/profile?seconds=%v", seconds))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The default duration of cpu profile collection in net/http/pprof is 30
seconds. User should have chance to set the specific duration for the
collection.

Signed-off-by: Wei Fu <fuweid89@gmail.com>