### PR TITLE
ctr: add some metric item

### DIFF
--- a/cmd/ctr/commands/tasks/metrics.go
+++ b/cmd/ctr/commands/tasks/metrics.go
@@ -90,9 +90,12 @@ var metricsCommand = cli.Command{
 
 			fmt.Fprintf(w, "METRIC\tVALUE\t\n")
 			fmt.Fprintf(w, "memory.usage_in_bytes\t%d\t\n", data.Memory.Usage.Usage)
+			fmt.Fprintf(w, "memory.limit_in_bytes\t%d\t\n", data.Memory.Usage.Limit)
 			fmt.Fprintf(w, "memory.stat.cache\t%d\t\n", data.Memory.TotalCache)
 			fmt.Fprintf(w, "cpuacct.usage\t%d\t\n", data.CPU.Usage.Total)
 			fmt.Fprintf(w, "cpuacct.usage_percpu\t%v\t\n", data.CPU.Usage.PerCPU)
+			fmt.Fprintf(w, "pids.current\t%v\t\n", data.Pids.Current)
+			fmt.Fprintf(w, "pids.limit\t%v\t\n", data.Pids.Limit)
 			return w.Flush()
 		case formatJSON:
 			marshaledJSON, err := json.MarshalIndent(data, "", "  ")


### PR DESCRIPTION
add memory limit, pid info into metric subcommand, since moby also
show them. As blkio read/write IO need more calculation，not add them.

Signed-off-by: Ace-Tang <aceapril@126.com>

after this patch, format like:
```
$ sudo bin/ctr t metric vv2
ID     TIMESTAMP                                  
vv2    2018-10-16 08:59:13.749647292 +0000 UTC    

METRIC                   VALUE                               
memory.usage_in_bytes    376832                              
memory.limit_in_bytes    9223372036854771712                 
memory.stat.cache        331776                              
cpuacct.usage            12810199                            
cpuacct.usage_percpu     [1712085 2246486 437550 8414078]    
pids.current             1                                   
pids.limit               0      
```
Seems the table format only show some needed item, I just think to add some item which moby also show with `docker stats`. As blkio read/write IO need more calculation，not add them follow the logic here.