### PR TITLE
Update banner URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![banner](https://github.com/containerd/containerd.io/blob/master/static/img/containerd-dark.png?raw=true)
+![containerd banner](https://raw.githubusercontent.com/cncf/artwork/master/containerd/horizontal/color/containerd-horizontal-color.png)
 
 [![GoDoc](https://godoc.org/github.com/containerd/containerd?status.svg)](https://godoc.org/github.com/containerd/containerd)
 [![Build Status](https://travis-ci.org/containerd/containerd.svg?branch=master)](https://travis-ci.org/containerd/containerd)


### PR DESCRIPTION
With the website assets now moved out of this repo, the URL for the README banner needs to be updated. This PR sets it to a URL from the repo for CNCF's visual assets (which will be stable indefinitely).