### PR TITLE
runtime-v2: add validation for runtime name

### DIFF
--- a/runtime/v2/shim/util.go
+++ b/runtime/v2/shim/util.go
@@ -49,6 +49,9 @@ func Command(ctx context.Context, runtime, containerdAddress, path string, cmdAr
 	}
 	args = append(args, cmdArgs...)
 	name := BinaryName(runtime)
+	if name == "" {
+		return nil, fmt.Errorf("invalid runtime name %s, correct runtime name should format like io.containerd.runc.v1", runtime)
+	}
 	var cmdPath string
 	var lerr error
 	if cmdPath, lerr = exec.LookPath(name); lerr != nil {
@@ -69,10 +72,15 @@ func Command(ctx context.Context, runtime, containerdAddress, path string, cmdAr
 	return cmd, nil
 }
 
-// BinaryName returns the shim binary name from the runtime name
+// BinaryName returns the shim binary name from the runtime name,
+// empty string returns means runtime name is invalid
 func BinaryName(runtime string) string {
+	// runtime name should format like $prefix.name.version
 	parts := strings.Split(runtime, ".")
-	// TODO: add validation for runtime
+	if len(parts) < 2 {
+		return ""
+	}
+
 	return fmt.Sprintf(shimBinaryFormat, parts[len(parts)-2], parts[len(parts)-1])
 }
 


### PR DESCRIPTION
add validation for runtime name, if runtime name is invalid,
containerd will got panic.

Signed-off-by: Ace-Tang <aceapril@126.com>

The problem is found when I test with kata-shim, and write the wrong runtime
```
#ctr run --runtime containerd-shim-kata-v2 -d reg.docker.alibaba-inc.com/base/busybox:latest c1 top
ctr: transport is closing: unavailable
```

containerd panic log
```
panic: runtime error: index out of range

goroutine 129 [running]:
github.com/containerd/containerd/runtime/v2/shim.BinaryName(0xc42003f4e0, 0x17, 0x3, 0x6)
    /home/ace/gosrc/src/github.com/containerd/containerd/runtime/v2/shim/util.go:76 +0x157
github.com/containerd/containerd/runtime/v2/shim.Command(0x7fcfef4c4f60, 0xc4205232c0, 0xc42003f4e0, 0x17, 0xc42035a000, 0x1f, 0xc4203cc640, 0x38, 0xc420315ac0, 0x3, ...)
    /home/ace/gosrc/src/github.com/containerd/containerd/runtime/v2/shim/util.go:51 +0x1af
github.com/containerd/containerd/runtime/v2.(*binary).Start(0xc42083d560, 0x7fcfef4c4f60, 0xc4205232c0, 0x0, 0x0, 0x0)
    /home/ace/gosrc/src/github.com/containerd/containerd/runtime/v2/binary.go:63 +0x155
github.com/containerd/containerd/runtime/v2.(*TaskManager).Create(0xc4203c7180, 0x7fcfef4c4f60, 0xc4205232c0, 0xc420157e08, 0x2, 0xc420523380, 0xc420315a80, 0x1, 0x1, 0xc420374210, ...)
```

