### PR TITLE
check task existence before new task

### DIFF
--- a/services/tasks/local.go
+++ b/services/tasks/local.go
@@ -173,11 +173,14 @@ func (l *local) Create(ctx context.Context, r *api.CreateTaskRequest, _ ...grpc.
 			Options: m.Options,
 		})
 	}
-	runtime, err := l.getRuntime(container.Runtime.Name)
+	rtime, err := l.getRuntime(container.Runtime.Name)
 	if err != nil {
 		return nil, err
 	}
-	c, err := runtime.Create(ctx, r.ContainerID, opts)
+	if _, err := rtime.Get(ctx, r.ContainerID); err != runtime.ErrTaskNotExists {
+		return nil, errdefs.ToGRPC(fmt.Errorf("task %s already exists", r.ContainerID))
+	}
+	c, err := rtime.Create(ctx, r.ContainerID, opts)
 	if err != nil {
 		return nil, errdefs.ToGRPC(err)
 	}


### PR DESCRIPTION
make user know correct error when start a non created status container.

Signed-off-by: Ace-Tang <aceapril@126.com>

Before this patch, if we start a non created container, we will get error 
```
$ sudo ctr t start vv2
ctr: mkdir /var/run/containerd/io.containerd.runtime.v2.task/default/vv2: file exists: unknown
```

After the patch , we can get more exact error message
```
$ sudo ctr t start -d s3
ctr: cannot start a non created status container s3
```