### PR TITLE
Update cri to f913714917d2456d7e65a0be84962b1ce8acb487.

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -43,8 +43,8 @@ github.com/google/go-cmp v0.1.0
 go.etcd.io/bbolt v1.3.1-etcd.8
 
 # cri dependencies
-github.com/containerd/cri 8506fe836677cc3bb23a16b68145128243d843b5 # release/1.2 branch
-github.com/containerd/go-cni 6d7b509a054a3cb1c35ed1865d4fde2f0cb547cd
+github.com/containerd/cri f913714917d2456d7e65a0be84962b1ce8acb487 # release/1.2 branch
+github.com/containerd/go-cni 40bcf8ec8acd7372be1d77031d585d5d8e561c90
 github.com/blang/semver v3.1.0
 github.com/containernetworking/cni v0.6.0
 github.com/containernetworking/plugins v0.7.0

--- a/vendor/github.com/containerd/cri/pkg/config/config.go
+++ b/vendor/github.com/containerd/cri/pkg/config/config.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package config
 
-import "github.com/containerd/containerd"
+import (
+	"github.com/BurntSushi/toml"
+	"github.com/containerd/containerd"
+)
 
 // Runtime struct to contain the type(ID), engine, and root variables for a default runtime
 // and a runtime for untrusted worload.
@@ -24,9 +27,16 @@ type Runtime struct {
 	// Type is the runtime type to use in containerd e.g. io.containerd.runtime.v1.linux
 	Type string `toml:"runtime_type" json:"runtimeType"`
 	// Engine is the name of the runtime engine used by containerd.
+	// This only works for runtime type "io.containerd.runtime.v1.linux".
+	// DEPRECATED: use Options instead. Remove when shim v1 is deprecated.
 	Engine string `toml:"runtime_engine" json:"runtimeEngine"`
 	// Root is the directory used by containerd for runtime state.
+	// DEPRECATED: use Options instead. Remove when shim v1 is deprecated.
+	// This only works for runtime type "io.containerd.runtime.v1.linux".
 	Root string `toml:"runtime_root" json:"runtimeRoot"`
+	// Options are config options for the runtime. If options is loaded
+	// from toml config, it will be toml.Primitive.
+	Options *toml.Primitive `toml:"options" json:"options"`
 }
 
 // ContainerdConfig contains toml config related to containerd
@@ -46,6 +56,8 @@ type ContainerdConfig struct {
 	// configurations, to the matching configurations.
 	Runtimes map[string]Runtime `toml:"runtimes" json:"runtimes"`
 	// NoPivot disables pivot-root (linux only), required when running a container in a RamDisk with runc
+	// This only works for runtime type "io.containerd.runtime.v1.linux".
+	// DEPRECATED: use Runtime.Options instead. Remove when shim v1 is deprecated.
 	NoPivot bool `toml:"no_pivot" json:"noPivot"`
 }
 
@@ -119,6 +131,8 @@ type PluginConfig struct {
 	// StatsCollectPeriod is the period (in seconds) of snapshots stats collection.
 	StatsCollectPeriod int `toml:"stats_collect_period" json:"statsCollectPeriod"`
 	// SystemdCgroup enables systemd cgroup support.
+	// This only works for runtime type "io.containerd.runtime.v1.linux".
+	// DEPRECATED: config runc runtime handler instead. Remove when shim v1 is deprecated.
 	SystemdCgroup bool `toml:"systemd_cgroup" json:"systemdCgroup"`
 	// EnableTLSStreaming indicates to enable the TLS streaming support.
 	EnableTLSStreaming bool `toml:"enable_tls_streaming" json:"enableTLSStreaming"`

--- a/vendor/github.com/containerd/cri/pkg/server/container_start.go
+++ b/vendor/github.com/containerd/cri/pkg/server/container_start.go
@@ -108,8 +108,14 @@ func (c *criService) startContainer(ctx context.Context,
 		return cntr.IO, nil
 	}
 
+	ctrInfo, err := container.Info(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to get container info")
+	}
+
 	var taskOpts []containerd.NewTaskOpts
-	if c.config.NoPivot {
+	// TODO(random-liu): Remove this after shim v1 is deprecated.
+	if c.config.NoPivot && ctrInfo.Runtime.Name == linuxRuntime {
 		taskOpts = append(taskOpts, containerd.WithNoPivotRoot)
 	}
 	task, err := container.NewTask(ctx, ioCreation, taskOpts...)

--- a/vendor/github.com/containerd/cri/pkg/server/helpers.go
+++ b/vendor/github.com/containerd/cri/pkg/server/helpers.go
@@ -25,8 +25,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/BurntSushi/toml"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/runtime/linux/runctypes"
+	runcoptions "github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/containerd/typeurl"
 	"github.com/docker/distribution/reference"
 	imagedigest "github.com/opencontainers/go-digest"
@@ -121,6 +123,14 @@ const (
 	// networkAttachCount is the minimum number of networks the PodSandbox
 	// attaches to
 	networkAttachCount = 2
+)
+
+// Runtime type strings for various runtimes.
+const (
+	// linuxRuntime is the legacy linux runtime for shim v1.
+	linuxRuntime = "io.containerd.runtime.v1.linux"
+	// runcRuntime is the runc runtime for shim v2.
+	runcRuntime = "io.containerd.runc.v1"
 )
 
 // makeSandboxName generates sandbox name from sandbox metadata. The name
@@ -390,26 +400,6 @@ func getPodCNILabels(id string, config *runtime.PodSandboxConfig) map[string]str
 	}
 }
 
-// getRuntimeConfigFromContainerInfo gets runtime configuration from containerd
-// container info.
-func getRuntimeConfigFromContainerInfo(c containers.Container) (criconfig.Runtime, error) {
-	r := criconfig.Runtime{
-		Type: c.Runtime.Name,
-	}
-	if c.Runtime.Options == nil {
-		// CRI plugin makes sure that runtime option is always set.
-		return criconfig.Runtime{}, errors.New("runtime options is nil")
-	}
-	data, err := typeurl.UnmarshalAny(c.Runtime.Options)
-	if err != nil {
-		return criconfig.Runtime{}, errors.Wrap(err, "failed to unmarshal runtime options")
-	}
-	runtimeOpts := data.(*runctypes.RuncOptions)
-	r.Engine = runtimeOpts.Runtime
-	r.Root = runtimeOpts.RuntimeRoot
-	return r, nil
-}
-
 // toRuntimeAuthConfig converts cri plugin auth config to runtime auth config.
 func toRuntimeAuthConfig(a criconfig.AuthConfig) *runtime.AuthConfig {
 	return &runtime.AuthConfig{
@@ -463,4 +453,46 @@ func parseImageReferences(refs []string) ([]string, []string) {
 		}
 	}
 	return tags, digests
+}
+
+// generateRuntimeOptions generates runtime options from cri plugin config.
+func generateRuntimeOptions(r criconfig.Runtime, c criconfig.Config) (interface{}, error) {
+	if r.Options == nil {
+		if r.Type != linuxRuntime {
+			return nil, nil
+		}
+		// This is a legacy config, generate runctypes.RuncOptions.
+		return &runctypes.RuncOptions{
+			Runtime:       r.Engine,
+			RuntimeRoot:   r.Root,
+			SystemdCgroup: c.SystemdCgroup,
+		}, nil
+	}
+	options := getRuntimeOptionsType(r.Type)
+	if err := toml.PrimitiveDecode(*r.Options, options); err != nil {
+		return nil, err
+	}
+	return options, nil
+}
+
+// getRuntimeOptionsType gets empty runtime options by the runtime type name.
+func getRuntimeOptionsType(t string) interface{} {
+	switch t {
+	case runcRuntime:
+		return &runcoptions.Options{}
+	default:
+		return &runctypes.RuncOptions{}
+	}
+}
+
+// getRuntimeOptions get runtime options from container metadata.
+func getRuntimeOptions(c containers.Container) (interface{}, error) {
+	if c.Runtime.Options == nil {
+		return nil, nil
+	}
+	opts, err := typeurl.UnmarshalAny(c.Runtime.Options)
+	if err != nil {
+		return nil, err
+	}
+	return opts, nil
 }

--- a/vendor/github.com/containerd/cri/pkg/server/image_pull.go
+++ b/vendor/github.com/containerd/cri/pkg/server/image_pull.go
@@ -261,9 +261,9 @@ func (c *criService) getResolver(ctx context.Context, ref string, cred func(stri
 			return nil, imagespec.Descriptor{}, errors.Wrapf(err, "parse registry endpoint %q", e)
 		}
 		resolver := docker.NewResolver(docker.ResolverOptions{
-			Credentials: cred,
-			Client:      http.DefaultClient,
-			Host:        func(string) (string, error) { return u.Host, nil },
+			Authorizer: docker.NewAuthorizer(http.DefaultClient, cred),
+			Client:     http.DefaultClient,
+			Host:       func(string) (string, error) { return u.Host, nil },
 			// By default use "https".
 			PlainHTTP: u.Scheme == "http",
 		})

--- a/vendor/github.com/containerd/cri/pkg/server/sandbox_status.go
+++ b/vendor/github.com/containerd/cri/pkg/server/sandbox_status.go
@@ -26,7 +26,6 @@ import (
 	"golang.org/x/net/context"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	criconfig "github.com/containerd/cri/pkg/config"
 	sandboxstore "github.com/containerd/cri/pkg/store/sandbox"
 )
 
@@ -100,8 +99,9 @@ func toCRISandboxStatus(meta sandboxstore.Metadata, status sandboxstore.Status, 
 	}
 }
 
+// SandboxInfo is extra information for sandbox.
 // TODO (mikebrow): discuss predefining constants structures for some or all of these field names in CRI
-type sandboxInfo struct {
+type SandboxInfo struct {
 	Pid            uint32                    `json:"pid"`
 	Status         string                    `json:"processStatus"`
 	NetNSClosed    bool                      `json:"netNamespaceClosed"`
@@ -109,7 +109,8 @@ type sandboxInfo struct {
 	SnapshotKey    string                    `json:"snapshotKey"`
 	Snapshotter    string                    `json:"snapshotter"`
 	RuntimeHandler string                    `json:"runtimeHandler"`
-	Runtime        *criconfig.Runtime        `json:"runtime"`
+	RuntimeType    string                    `json:"runtimeType"`
+	RuntimeOptions interface{}               `json:"runtimeOptions"`
 	Config         *runtime.PodSandboxConfig `json:"config"`
 	RuntimeSpec    *runtimespec.Spec         `json:"runtimeSpec"`
 }
@@ -132,7 +133,7 @@ func toCRISandboxInfo(ctx context.Context, sandbox sandboxstore.Sandbox) (map[st
 		processStatus = taskStatus.Status
 	}
 
-	si := &sandboxInfo{
+	si := &SandboxInfo{
 		Pid:            sandbox.Status.Get().Pid,
 		RuntimeHandler: sandbox.RuntimeHandler,
 		Status:         string(processStatus),
@@ -167,11 +168,12 @@ func toCRISandboxInfo(ctx context.Context, sandbox sandboxstore.Sandbox) (map[st
 	si.SnapshotKey = ctrInfo.SnapshotKey
 	si.Snapshotter = ctrInfo.Snapshotter
 
-	ociRuntime, err := getRuntimeConfigFromContainerInfo(ctrInfo)
+	runtimeOptions, err := getRuntimeOptions(ctrInfo)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get sandbox container runtime config")
+		return nil, errors.Wrap(err, "failed to get runtime options")
 	}
-	si.Runtime = &ociRuntime
+	si.RuntimeType = ctrInfo.Runtime.Name
+	si.RuntimeOptions = runtimeOptions
 
 	infoBytes, err := json.Marshal(si)
 	if err != nil {

--- a/vendor/github.com/containerd/cri/pkg/store/sandbox/netns.go
+++ b/vendor/github.com/containerd/cri/pkg/store/sandbox/netns.go
@@ -27,6 +27,13 @@ import (
 	osinterface "github.com/containerd/cri/pkg/os"
 )
 
+// The NetNS library assumes only containerd manages the lifecycle of the
+// network namespace mount. The only case that netns will be unmounted by
+// someone else is node reboot.
+// If this assumption is broken, NetNS won't be aware of the external
+// unmount, and there will be a state mismatch.
+// TODO(random-liu): Don't cache state, always load from the system.
+
 // ErrClosedNetNS is the error returned when network namespace is closed.
 var ErrClosedNetNS = errors.New("network namespace is closed")
 

--- a/vendor/github.com/containerd/cri/vendor.conf
+++ b/vendor/github.com/containerd/cri/vendor.conf
@@ -3,10 +3,10 @@ github.com/blang/semver v3.1.0
 github.com/BurntSushi/toml a368813c5e648fee92e5f6c30e3944ff9d5e8895
 github.com/containerd/cgroups 5e610833b72089b37d0e615de9a92dfc043757c2
 github.com/containerd/console c12b1e7919c14469339a5d38f2f8ed9b64a9de23
-github.com/containerd/containerd f88d3e5d6dfe9b7d7941ac5241649ad8240b9282
-github.com/containerd/continuity 7f53d412b9eb1cbf744c2063185d703a0ee34700
+github.com/containerd/containerd 15f19d7a67fa322e6de0ef4c6a1bf9da0f056554
+github.com/containerd/continuity bd77b46c8352f74eb12c85bdc01f4b90f69d66b4
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c
-github.com/containerd/go-cni 6d7b509a054a3cb1c35ed1865d4fde2f0cb547cd
+github.com/containerd/go-cni 40bcf8ec8acd7372be1d77031d585d5d8e561c90
 github.com/containerd/go-runc 5a6d9f37cfa36b15efba46dc7ea349fa9b7143c3
 github.com/containerd/ttrpc 2a805f71863501300ae1976d29f0454ae003e85a
 github.com/containerd/typeurl a93fcdb778cd272c6e9b3028b2f42d813e785d40
@@ -34,7 +34,7 @@ github.com/hashicorp/go-multierror ed905158d87462226a13fe39ddf685ea65f1c11f
 github.com/json-iterator/go 1.1.5
 github.com/matttproud/golang_protobuf_extensions v1.0.0
 github.com/Microsoft/go-winio v0.4.10
-github.com/Microsoft/hcsshim v0.7.4
+github.com/Microsoft/hcsshim v0.7.6
 github.com/modern-go/concurrent 1.0.3
 github.com/modern-go/reflect2 1.0.1
 github.com/opencontainers/go-digest c9281466c8b2f606084ac71339773efd177436e7


### PR DESCRIPTION
* Fixes https://github.com/containerd/cri/issues/942
* Fixes https://github.com/containerd/cri/issues/948
* Support runtime type specific configuration.

I also want https://github.com/containerd/cri/pull/950 in 1.2, but if we can't make it in time, I'm fine with adding it to a patch release.

Signed-off-by: Lantao Liu <lantaol@google.com>