### PR TITLE
bugfix: return the context error during event subscribe

### DIFF
--- a/events.go
+++ b/events.go
@@ -110,6 +110,9 @@ func (e *eventRemote) Subscribe(ctx context.Context, filters ...string) (ch <-ch
 				Event:     ev.Event,
 			}:
 			case <-ctx.Done():
+				if cerr := ctx.Err(); cerr != context.Canceled {
+					errq <- cerr
+				}
 				return
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Wei Fu <fuweid89@gmail.com>

> NOTE: This is edge case raised in the testing. But it is hard to reproduce. That is why I don't add case for this.