### PR TITLE
fix typo in ResolverOptions.Credentials documentation

### DIFF
--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -75,7 +75,7 @@ type ResolverOptions struct {
 
 	// Credentials provides username and secret given a host.
 	// If username is empty but a secret is given, that secret
-	// is interpretted as a long lived token.
+	// is interpreted as a long lived token.
 	// Deprecated: use Authorizer
 	Credentials func(string) (string, string, error)
 


### PR DESCRIPTION
Fixes a small typo in `ResolverOptions.Credentials` documentation.

Signed-off-by: Charles Kenney <charlesc.kenney@gmail.com>