### PR TITLE
[release/1.1] Backport: modify lock location of exec delete avoid exec hang

### DIFF
--- a/linux/proc/exec_state.go
+++ b/linux/proc/exec_state.go
@@ -60,11 +60,11 @@ func (s *execCreatedState) Start(ctx context.Context) error {
 }
 
 func (s *execCreatedState) Delete(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
 	if err := s.p.delete(ctx); err != nil {
 		return err
 	}
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
 	return s.transition("deleted")
 }
 
@@ -168,11 +168,11 @@ func (s *execStoppedState) Start(ctx context.Context) error {
 }
 
 func (s *execStoppedState) Delete(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
 	if err := s.p.delete(ctx); err != nil {
 		return err
 	}
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
 	return s.transition("deleted")
 }
 


### PR DESCRIPTION
Backport https://github.com/containerd/containerd/pull/2624 to release/1.1.

For issues like https://github.com/containerd/containerd/issues/2438.

Exec deletion can take forever if the exec leaks processes in the container. This will cause:
1) Process leakage in the system;
2) Goroutine leakage in `containerd-shim` and `cri`;
3) containerd-shim hangs forever.

This doesn't fix 1) and 2), but it does fix 3).

In any case, `containerd-shim` shouldn't hang, so that users can at least stop the bad container.

@lbernail @Ace-Tang