### PR TITLE
Fix mingw version back to working version with Golang

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,7 +15,7 @@ environment:
     - GO_VERSION: 1.11
 
 before_build:
-  - choco install -y mingw
+  - choco install -y mingw --version 5.3.0
   # Install Go
   - rd C:\Go /s /q
   - appveyor DownloadFile https://storage.googleapis.com/golang/go%GO_VERSION%.windows-amd64.zip


### PR DESCRIPTION
Appveyor choco install updated to a newer version of mingw which at the
moment is breaking Golang 1.11 compiles.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>