### PR TITLE
[release/1.1] cherry-pick: Increase reaper buffer size

### DIFF
--- a/reaper/reaper.go
+++ b/reaper/reaper.go
@@ -26,7 +26,6 @@ import (
 	"github.com/containerd/containerd/sys"
 	runc "github.com/containerd/go-runc"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 // ErrNoSuchProcess is returned when the process no longer exists
@@ -42,18 +41,10 @@ func Reap() error {
 	Default.Lock()
 	for c := range Default.subscribers {
 		for _, e := range exits {
-			select {
-			case c <- runc.Exit{
+			c <- runc.Exit{
 				Timestamp: now,
 				Pid:       e.Pid,
 				Status:    e.Status,
-			}:
-			default:
-				logrus.WithFields(logrus.Fields{
-					"subscriber": c,
-					"pid":        e.Pid,
-					"status":     e.Status,
-				}).Warn("failed to send exit to subscriber")
 			}
 		}
 	}


### PR DESCRIPTION
Cherry-pick #2748
Cherry-pick #2770 

This increases the buffer size for process exit subscribers. ~It also
implements a non-blocking send on the subscriber channel.  It is better
to drop an exit even than it is to block a shim for one slow subscriber.~

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>
Signed-off-by: Lantao Liu <lantaol@google.com>
Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>