### PR TITLE
makefile: remove emoji

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -14,6 +14,8 @@
 
 
 #linux specific settings
+WHALE="+"
+ONI="-"
 COMMANDS += containerd-shim containerd-shim-runc-v1
 
 # check GOOS for cross compile builds


### PR DESCRIPTION
These break the build on i386 in some very specific circumstances (where
/bin/sh breaks when handling unicode), and are completely useless when
it comes to actually building the project.

Signed-off-by: Aleksa Sarai <asarai@suse.de>