### PR TITLE
enhance: update v1/v2 runtime

### DIFF
--- a/runtime/v1/shim/service.go
+++ b/runtime/v1/shim/service.go
@@ -493,16 +493,24 @@ func (s *Service) processExits() {
 	}
 }
 
-func (s *Service) checkProcesses(e runc.Exit) {
+func (s *Service) allProcesses() []rproc.Process {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	res := make([]rproc.Process, 0, len(s.processes))
+	for _, p := range s.processes {
+		res = append(res, p)
+	}
+	return res
+}
+
+func (s *Service) checkProcesses(e runc.Exit) {
 	shouldKillAll, err := shouldKillAllOnExit(s.bundle)
 	if err != nil {
 		log.G(s.context).WithError(err).Error("failed to check shouldKillAll")
 	}
 
-	for _, p := range s.processes {
+	for _, p := range s.allProcesses() {
 		if p.Pid() == e.Pid {
 
 			if shouldKillAll {

--- a/runtime/v2/runc/service.go
+++ b/runtime/v2/runc/service.go
@@ -692,6 +692,8 @@ func shouldKillAllOnExit(bundlePath string) (bool, error) {
 func (s *service) allProcesses() (o []rproc.Process) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	o = make([]rproc.Process, 0, len(s.processes)+1)
 	for _, p := range s.processes {
 		o = append(o, p)
 	}

--- a/runtime/v2/shim/shim_unix.go
+++ b/runtime/v2/shim/shim_unix.go
@@ -87,7 +87,7 @@ func handleSignals(logger *logrus.Entry, signals chan os.Signal) error {
 }
 
 func openLog(ctx context.Context, _ string) (io.Writer, error) {
-	return fifo.OpenFifo(context.Background(), "log", unix.O_WRONLY, 0700)
+	return fifo.OpenFifo(ctx, "log", unix.O_WRONLY, 0700)
 }
 
 func (l *remoteEventsPublisher) Publish(ctx context.Context, topic string, event events.Event) error {


### PR DESCRIPTION
1. avoid dead lock during kill, fetch allProcesses before handle events
2. use argu's ctx instead of context.Backgroud() in openlog

Signed-off-by: Wei Fu <fuweid89@gmail.com>