### PR TITLE
Partially revert the event discard change in #2748.

### DIFF
--- a/runtime/v1/shim/reaper.go
+++ b/runtime/v1/shim/reaper.go
@@ -26,7 +26,6 @@ import (
 	"github.com/containerd/containerd/sys"
 	runc "github.com/containerd/go-runc"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 // ErrNoSuchProcess is returned when the process no longer exists
@@ -42,18 +41,10 @@ func Reap() error {
 	Default.Lock()
 	for c := range Default.subscribers {
 		for _, e := range exits {
-			select {
-			case c <- runc.Exit{
+			c <- runc.Exit{
 				Timestamp: now,
 				Pid:       e.Pid,
 				Status:    e.Status,
-			}:
-			default:
-				logrus.WithFields(logrus.Fields{
-					"subscriber": c,
-					"pid":        e.Pid,
-					"status":     e.Status,
-				}).Warn("failed to send exit to subscriber")
 			}
 		}
 	}


### PR DESCRIPTION
Per discussion at https://github.com/containerd/containerd/pull/2762#issuecomment-436436146, we decided not to discard events, because it breaks the assumption that client can rely on `TaskExit` events to detect container stop.

If `TaskExit` events can be discarded, the client has to do periodically state check, which is not ideal.

Signed-off-by: Lantao Liu <lantaol@google.com>