### PR TITLE
Ignore modprobe failures in ExecStartPre (systemd unit)

### DIFF
--- a/containerd.service
+++ b/containerd.service
@@ -4,7 +4,7 @@ Documentation=https://containerd.io
 After=network.target
 
 [Service]
-ExecStartPre=/sbin/modprobe overlay
+ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/local/bin/containerd
 
 Delegate=yes

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -49,7 +49,7 @@ Documentation=https://containerd.io
 After=network.target
 
 [Service]
-ExecStartPre=/sbin/modprobe overlay
+ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/local/bin/containerd
 Delegate=yes
 KillMode=process


### PR DESCRIPTION
When running containerd inside LXC, due to systemd being unable to execute
`modprobe overlay` inside the container (module is already loaded in host kernel).

This patch adds a `-` prefix to the `ExecStartPre` command, so that failures
are ignored, and the service can start as usual.

fixes https://github.com/containerd/containerd/issues/2772