### PR TITLE
[release/1.1] cherry-pick: Ignore modprobe failures in ExecStartPre (systemd unit)

### DIFF
--- a/containerd.service
+++ b/containerd.service
@@ -4,7 +4,7 @@ Documentation=https://containerd.io
 After=network.target
 
 [Service]
-ExecStartPre=/sbin/modprobe overlay
+ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/local/bin/containerd
 Delegate=yes
 KillMode=process

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -49,7 +49,7 @@ Documentation=https://containerd.io
 After=network.target
 
 [Service]
-ExecStartPre=/sbin/modprobe overlay
+ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/local/bin/containerd
 Delegate=yes
 KillMode=process


### PR DESCRIPTION
Backport of https://github.com/containerd/containerd/pull/2776 for the 1.1 branch
fixes https://github.com/containerd/containerd/issues/2772 for the 1.1.x releases

```
git checkout -b 1.1_backport_ignore_modprobe_failures upstream/release/1.1
git cherry-pick -s -S -x 555ea3fb43505512bba51563183a80b2d4a1d028
```

cherry-pick was clean; no conflicts



When running containerd inside LXC, due to systemd being unable to execute
`modprobe overlay` inside the container (module is already loaded in host kernel).

This patch adds a `-` prefix to the `ExecStartPre` command, so that failures
are ignored, and the service can start as usual.
