### PR TITLE
[release/1.0] Fix options ordering in proto api txt files

### DIFF
--- a/api/next.pb.txt
+++ b/api/next.pb.txt
@@ -181,8 +181,8 @@ file {
       label: LABEL_OPTIONAL
       type: TYPE_STRING
       options {
-        65003: "github.com/opencontainers/go-digest.Digest"
         65001: 0
+        65003: "github.com/opencontainers/go-digest.Digest"
       }
       json_name: "digest"
     }
@@ -622,8 +622,8 @@ file {
       type: TYPE_MESSAGE
       type_name: ".google.protobuf.Timestamp"
       options {
-        65010: 1
         65001: 0
+        65010: 1
       }
       json_name: "exitedAt"
     }
@@ -696,8 +696,8 @@ file {
       type: TYPE_MESSAGE
       type_name: ".google.protobuf.Timestamp"
       options {
-        65010: 1
         65001: 0
+        65010: 1
       }
       json_name: "exitedAt"
     }
@@ -907,8 +907,8 @@ file {
       type: TYPE_MESSAGE
       type_name: ".google.protobuf.Timestamp"
       options {
-        65010: 1
         65001: 0
+        65010: 1
       }
       json_name: "createdAt"
     }
@@ -919,8 +919,8 @@ file {
       type: TYPE_MESSAGE
       type_name: ".google.protobuf.Timestamp"
       options {
-        65010: 1
         65001: 0
+        65010: 1
       }
       json_name: "updatedAt"
     }
@@ -1166,8 +1166,8 @@ file {
       label: LABEL_OPTIONAL
       type: TYPE_STRING
       options {
-        65003: "github.com/opencontainers/go-digest.Digest"
         65001: 0
+        65003: "github.com/opencontainers/go-digest.Digest"
       }
       json_name: "digest"
     }
@@ -1185,8 +1185,8 @@ file {
       type: TYPE_MESSAGE
       type_name: ".google.protobuf.Timestamp"
       options {
-        65010: 1
         65001: 0
+        65010: 1
       }
       json_name: "createdAt"
     }
@@ -1197,8 +1197,8 @@ file {
       type: TYPE_MESSAGE
       type_name: ".google.protobuf.Timestamp"
       options {
-        65010: 1
         65001: 0
+        65010: 1
       }
       json_name: "updatedAt"
     }
@@ -1239,8 +1239,8 @@ file {
       label: LABEL_OPTIONAL
       type: TYPE_STRING
       options {
-        65003: "github.com/opencontainers/go-digest.Digest"
         65001: 0
+        65003: "github.com/opencontainers/go-digest.Digest"
       }
       json_name: "digest"
     }
@@ -1327,8 +1327,8 @@ file {
       label: LABEL_OPTIONAL
       type: TYPE_STRING
       options {
-        65003: "github.com/opencontainers/go-digest.Digest"
         65001: 0
+        65003: "github.com/opencontainers/go-digest.Digest"
       }
       json_name: "digest"
     }
@@ -1341,8 +1341,8 @@ file {
       label: LABEL_OPTIONAL
       type: TYPE_STRING
       options {
-        65003: "github.com/opencontainers/go-digest.Digest"
         65001: 0
+        65003: "github.com/opencontainers/go-digest.Digest"
       }
       json_name: "digest"
     }
@@ -1387,8 +1387,8 @@ file {
       type: TYPE_MESSAGE
       type_name: ".google.protobuf.Timestamp"
       options {
-        65010: 1
         65001: 0
+        65010: 1
       }
       json_name: "startedAt"
     }
@@ -1399,8 +1399,8 @@ file {
       type: TYPE_MESSAGE
       type_name: ".google.protobuf.Timestamp"
       options {
-        65010: 1
         65001: 0
+        65010: 1
       }
       json_name: "updatedAt"
     }
@@ -1431,8 +1431,8 @@ file {
       label: LABEL_OPTIONAL
       type: TYPE_STRING
       options {
-        65003: "github.com/opencontainers/go-digest.Digest"
         65001: 0
+        65003: "github.com/opencontainers/go-digest.Digest"
       }
       json_name: "expected"
     }
@@ -1512,8 +1512,8 @@ file {
       label: LABEL_OPTIONAL
       type: TYPE_STRING
       options {
-        65003: "github.com/opencontainers/go-digest.Digest"
         65001: 0
+        65003: "github.com/opencontainers/go-digest.Digest"
       }
       json_name: "expected"
     }
@@ -1577,8 +1577,8 @@ file {
       type: TYPE_MESSAGE
       type_name: ".google.protobuf.Timestamp"
       options {
-        65010: 1
         65001: 0
+        65010: 1
       }
       json_name: "startedAt"
     }
@@ -1589,8 +1589,8 @@ file {
       type: TYPE_MESSAGE
       type_name: ".google.protobuf.Timestamp"
       options {
-        65010: 1
         65001: 0
+        65010: 1
       }
       json_name: "updatedAt"
     }
@@ -1614,8 +1614,8 @@ file {
       label: LABEL_OPTIONAL
       type: TYPE_STRING
       options {
-        65003: "github.com/opencontainers/go-digest.Digest"
         65001: 0
+        65003: "github.com/opencontainers/go-digest.Digest"
       }
       json_name: "digest"
     }
@@ -1735,8 +1735,8 @@ file {
       label: LABEL_OPTIONAL
       type: TYPE_STRING
       options {
-        65003: "github.com/opencontainers/go-digest.Digest"
         65001: 0
+        65003: "github.com/opencontainers/go-digest.Digest"
       }
       json_name: "digest"
     }
@@ -1937,8 +1937,8 @@ file {
       type: TYPE_MESSAGE
       type_name: ".google.protobuf.Timestamp"
       options {
-        65010: 1
         65001: 0
+        65010: 1
       }
       json_name: "timestamp"
     }
@@ -2037,8 +2037,8 @@ file {
       type: TYPE_MESSAGE
       type_name: ".google.protobuf.Timestamp"
       options {
-        65010: 1
         65001: 0
+        65010: 1
       }
       json_name: "createdAt"
     }
@@ -2049,8 +2049,8 @@ file {
       type: TYPE_MESSAGE
       type_name: ".google.protobuf.Timestamp"
       options {
-        65010: 1
         65001: 0
+        65010: 1
       }
       json_name: "updatedAt"
     }
@@ -2454,8 +2454,8 @@ file {
       type: TYPE_MESSAGE
       type_name: ".google.protobuf.Timestamp"
       options {
-        65010: 1
         65001: 0
+        65010: 1
       }
       json_name: "createdAt"
     }
@@ -3071,8 +3071,8 @@ file {
       type: TYPE_MESSAGE
       type_name: ".google.protobuf.Timestamp"
       options {
-        65010: 1
         65001: 0
+        65010: 1
       }
       json_name: "createdAt"
     }
@@ -3083,8 +3083,8 @@ file {
       type: TYPE_MESSAGE
       type_name: ".google.protobuf.Timestamp"
       options {
-        65010: 1
         65001: 0
+        65010: 1
       }
       json_name: "updatedAt"
     }
@@ -3337,8 +3337,8 @@ file {
       type: TYPE_MESSAGE
       type_name: ".google.protobuf.Timestamp"
       options {
-        65010: 1
         65001: 0
+        65010: 1
       }
       json_name: "timestamp"
     }
@@ -3443,8 +3443,8 @@ file {
       type: TYPE_MESSAGE
       type_name: ".google.protobuf.Timestamp"
       options {
-        65010: 1
         65001: 0
+        65010: 1
       }
       json_name: "exitedAt"
     }
@@ -3676,8 +3676,8 @@ file {
       type: TYPE_MESSAGE
       type_name: ".google.protobuf.Timestamp"
       options {
-        65010: 1
         65001: 0
+        65010: 1
       }
       json_name: "exitedAt"
     }
@@ -3946,8 +3946,8 @@ file {
       label: LABEL_OPTIONAL
       type: TYPE_STRING
       options {
-        65003: "github.com/opencontainers/go-digest.Digest"
         65001: 0
+        65003: "github.com/opencontainers/go-digest.Digest"
       }
       json_name: "parentCheckpoint"
     }
@@ -4043,8 +4043,8 @@ file {
       type: TYPE_MESSAGE
       type_name: ".google.protobuf.Timestamp"
       options {
-        65010: 1
         65001: 0
+        65010: 1
       }
       json_name: "exitedAt"
     }

--- a/windows/hcsshimtypes/next.pb.txt
+++ b/windows/hcsshimtypes/next.pb.txt
@@ -75,8 +75,8 @@ file {
       type: TYPE_MESSAGE
       type_name: ".google.protobuf.Duration"
       options {
-        65011: 1
         65001: 0
+        65011: 1
       }
       json_name: "terminateDuration"
     }
@@ -97,8 +97,8 @@ file {
       type: TYPE_MESSAGE
       type_name: ".google.protobuf.Timestamp"
       options {
-        65010: 1
         65001: 0
+        65010: 1
       }
       json_name: "createdAt"
     }


### PR DESCRIPTION
Backport of https://github.com/containerd/containerd/pull/2470 for the release/1.0 branch;

```
git checkout -b 1.0_backport_fix_checkprotos upstream/release/1.0
git cherry-pick -s -S -x d3cd5f1d015da1f8a9107f0b58b9c614c4b153cf
```

cherry-pick was clean; no conflicts

An upstream change caused the options to now be ordered
