### PR TITLE
[release/1.0 backport] Set shim max procs via env var

### DIFF
--- a/linux/shim/client/client.go
+++ b/linux/shim/client/client.go
@@ -117,6 +117,7 @@ func newCommand(binary, daemonAddress string, debug bool, config shim.Config, so
 	// will be mounted by the shim
 	cmd.SysProcAttr = getSysProcAttr()
 	cmd.ExtraFiles = append(cmd.ExtraFiles, socket)
+	cmd.Env = append(os.Environ(), "GOMAXPROCS=2")
 	if debug {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr


### PR DESCRIPTION
Backport of https://github.com/containerd/containerd/pull/2423 for the 1.0 branch


```
git checkout -b 1.0_backport_shim_procs upstream/release/1.0
git cherry-pick -s -S -x 68e144c63791fc4982afedc0fe6fcbf924b5d59b
```

cherry-pick was clean; no conflicts

This sets the shim's max procs to 2, like we already have hard coded in
the shim, with the env var so that it is set at go runtime boot.
