### PR TITLE
Enable appveyor on release/1.2 branch

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,6 +7,7 @@ clone_folder: c:\gopath\src\github.com\containerd\containerd
 branches:
   only:
     - master
+    - release/1.2
 
 environment:
   GOPATH: C:\gopath
@@ -15,7 +16,7 @@ environment:
     - GO_VERSION: 1.10
 
 before_build:
-  - choco install -y mingw
+  - choco install -y mingw --version 5.3.0
   # Install Go
   - rd C:\Go /s /q
   - appveyor DownloadFile https://storage.googleapis.com/golang/go%GO_VERSION%.windows-amd64.zip


### PR DESCRIPTION
This will make sure windows is tested for release 1.2.x releases as well
as master.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>