### PR TITLE
fix container cmd args may parsed as ctr args

### DIFF
--- a/cmd/ctr/commands/run/run.go
+++ b/cmd/ctr/commands/run/run.go
@@ -86,9 +86,10 @@ func parseMountFlag(m string) (specs.Mount, error) {
 
 // Command runs a container
 var Command = cli.Command{
-	Name:      "run",
-	Usage:     "run a container",
-	ArgsUsage: "[flags] Image|RootFS ID [COMMAND] [ARG...]",
+	Name:           "run",
+	Usage:          "run a container",
+	ArgsUsage:      "[flags] Image|RootFS ID [COMMAND] [ARG...]",
+	SkipArgReorder: true,
 	Flags: append([]cli.Flag{
 		cli.BoolFlag{
 			Name:  "rm",

--- a/cmd/ctr/commands/tasks/exec.go
+++ b/cmd/ctr/commands/tasks/exec.go
@@ -28,9 +28,10 @@ import (
 
 //TODO:(jessvalarezo) exec-id is optional here, update to required arg
 var execCommand = cli.Command{
-	Name:      "exec",
-	Usage:     "execute additional processes in an existing container",
-	ArgsUsage: "[flags] CONTAINER CMD [ARG...]",
+	Name:           "exec",
+	Usage:          "execute additional processes in an existing container",
+	ArgsUsage:      "[flags] CONTAINER CMD [ARG...]",
+	SkipArgReorder: true,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "cwd",


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

For ctr t exec:
```
root@dockerdemo:~/gocode/src/github.com/containerd/containerd# bin/ctr t exec redis echo -e "test"
Incorrect Usage: flag provided but not defined: -e
```

For ctr run:
```
root@dockerdemo:~/gocode/src/github.com/containerd/containerd# bin/ctr run docker.acmcoder.com/public/redis:latest redist echo -e "test"
Incorrect Usage: flag provided but not defined: -e
```

Set SkipArgReorder to true can resolve this problem.