### PR TITLE
Adding a --load-kmods flag to the NVIDIA OCI hook

### DIFF
--- a/contrib/nvidia/nvidia.go
+++ b/contrib/nvidia/nvidia.go
@@ -90,6 +90,8 @@ func WithGPUs(opts ...Opts) oci.SpecOpts {
 				"oci-hook",
 				"--",
 				nvidiaPath,
+				// ensures the required kernel modules are properly loaded
+				"--load-kmods",
 			}, c.args()...),
 			Env: os.Environ(),
 		})


### PR DESCRIPTION
Otherwise the proper kernel mods might not be loaded when trying to
stand up a container with GPUs, resulting eg in the `nvidia-container-cli`
command failing because `/dev/nvidia-modeset` wasn't around.

There performance impact of having `nvidia-container-cli` check for kernel
modules being loaded every time is negligible.

Signed-off-by: Jean Rouge <jer329@cornell.edu>