### PR TITLE
add flag -d for ctr t exec to run a service in container

### DIFF
--- a/cmd/ctr/commands/tasks/exec.go
+++ b/cmd/ctr/commands/tasks/exec.go
@@ -40,6 +40,10 @@ var execCommand = cli.Command{
 			Name:  "tty,t",
 			Usage: "allocate a TTY for the container",
 		},
+		cli.BoolFlag{
+			Name:  "detach,d",
+			Usage: "detach from the task after it has started execution",
+		},
 		cli.StringFlag{
 			Name:  "exec-id",
 			Usage: "exec specific id for the process",
@@ -51,9 +55,10 @@ var execCommand = cli.Command{
 	},
 	Action: func(context *cli.Context) error {
 		var (
-			id   = context.Args().First()
-			args = context.Args().Tail()
-			tty  = context.Bool("tty")
+			id     = context.Args().First()
+			args   = context.Args().Tail()
+			tty    = context.Bool("tty")
+			detach = context.Bool("detach")
 		)
 		if id == "" {
 			return errors.New("container id must be provided")
@@ -104,17 +109,22 @@ var execCommand = cli.Command{
 				return err
 			}
 		}
-		if tty {
-			if err := HandleConsoleResize(ctx, process, con); err != nil {
-				logrus.WithError(err).Error("console resize")
+		if !detach {
+			if tty {
+				if err := HandleConsoleResize(ctx, process, con); err != nil {
+					logrus.WithError(err).Error("console resize")
+				}
+			} else {
+				sigc := commands.ForwardAllSignals(ctx, process)
+				defer commands.StopCatch(sigc)
 			}
-		} else {
-			sigc := commands.ForwardAllSignals(ctx, process)
-			defer commands.StopCatch(sigc)
 		}
 
 		if err := process.Start(ctx); err != nil {
 			return err
+		}
+		if detach {
+			return nil
 		}
 		status := <-statusC
 		code, _, err := status.Result()


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

I think we should support `-d` flag when run `ctr t exec`.
For example:
```
root@dockerdemo:~/gocode/src/github.com/containerd/containerd# bin/ctr t exec --exec-id test2 -d redis sleep 1000
root@dockerdemo:~/gocode/src/github.com/containerd/containerd# bin/ctr t ps redis
PID     INFO
5851    &ProcessDetails{ExecID:redis,}
6279    &ProcessDetails{ExecID:test2,}
```