### PR TITLE
fix pipe in broken may cause shim lock forever

### DIFF
--- a/runtime/v1/shim/service_linux.go
+++ b/runtime/v1/shim/service_linux.go
@@ -49,9 +49,11 @@ func (p *linuxPlatform) CopyConsole(ctx context.Context, console console.Console
 		cwg.Add(1)
 		go func() {
 			cwg.Done()
-			p := bufPool.Get().(*[]byte)
-			defer bufPool.Put(p)
-			io.CopyBuffer(epollConsole, in, *p)
+			bp := bufPool.Get().(*[]byte)
+			defer bufPool.Put(bp)
+			io.CopyBuffer(epollConsole, in, *bp)
+			// we need to shutdown epollConsole when pipe broken
+			epollConsole.Shutdown(p.epoller.CloseConsole)
 		}()
 	}
 

--- a/runtime/v2/runc/service_linux.go
+++ b/runtime/v2/runc/service_linux.go
@@ -52,6 +52,7 @@ func (p *linuxPlatform) CopyConsole(ctx context.Context, console console.Console
 			bp := bufPool.Get().(*[]byte)
 			defer bufPool.Put(bp)
 			io.CopyBuffer(epollConsole, in, *bp)
+			// we need to shutdown epollConsole when pipe broken
 			epollConsole.Shutdown(p.epoller.CloseConsole)
 		}()
 	}

--- a/runtime/v2/runc/service_linux.go
+++ b/runtime/v2/runc/service_linux.go
@@ -49,9 +49,10 @@ func (p *linuxPlatform) CopyConsole(ctx context.Context, console console.Console
 		cwg.Add(1)
 		go func() {
 			cwg.Done()
-			p := bufPool.Get().(*[]byte)
-			defer bufPool.Put(p)
-			io.CopyBuffer(epollConsole, in, *p)
+			bp := bufPool.Get().(*[]byte)
+			defer bufPool.Put(bp)
+			io.CopyBuffer(epollConsole, in, *bp)
+			epollConsole.Shutdown(p.epoller.CloseConsole)
 		}()
 	}
 


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

There is an issue in moby:  https://github.com/moby/moby/issues/38064
It's hard to reproduce, but if you are lucky, you'll reproduce it successfully with probability about 0.1. Wish you success. If someone can write a go program with libcontainerd to reproduce it, it will help for us to debug it.

For container in created state, if pipe in broken, moby will call DeleteTask, and it will cause a wait in: 
 https://github.com/containerd/containerd/blob/e76a8879eb10594113d70556c80dd2e456202e22/runtime/v1/linux/proc/init.go#L252 

Because in https://github.com/containerd/containerd/blob/e76a8879eb10594113d70556c80dd2e456202e22/runtime/v1/shim/service_linux.go#L78  , if pipe out broken, it will set wg done.
But in  https://github.com/containerd/containerd/blob/e76a8879eb10594113d70556c80dd2e456202e22/runtime/v1/shim/service_linux.go#L54 , when pipe in broken, pipe out broken can't be detected, so it will not set wg done, it will cause shim lock.

@fuweid I know your team are working on shim lock improvement, PTAL.
