### PR TITLE
refactor: no need so many defer in closeAll function

### DIFF
--- a/events/exchange/exchange.go
+++ b/events/exchange/exchange.go
@@ -138,10 +138,10 @@ func (e *Exchange) Subscribe(ctx context.Context, fs ...string) (ch <-chan *even
 	)
 
 	closeAll := func() {
-		defer close(errq)
-		defer e.broadcaster.Remove(dst)
-		defer queue.Close()
-		defer channel.Close()
+		channel.Close()
+		queue.Close()
+		e.broadcaster.Remove(dst)
+		close(errq)
 	}
 
 	ch = evch


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

I read the `Subscribe` function of `Exchange`, found there only have four `defer` in a function and also using a `defer` when calling the function. So I think deleting the `defer`  in the `closeAll` function   may make the code more beautiful.