### PR TITLE
add lock for start and delete

### DIFF
--- a/runtime/v1/shim/service.go
+++ b/runtime/v1/shim/service.go
@@ -192,6 +192,8 @@ func (s *Service) Start(ctx context.Context, r *shimapi.StartRequest) (*shimapi.
 	if err != nil {
 		return nil, err
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if err := p.Start(ctx); err != nil {
 		return nil, err
 	}
@@ -207,12 +209,12 @@ func (s *Service) Delete(ctx context.Context, r *ptypes.Empty) (*shimapi.DeleteR
 	if err != nil {
 		return nil, err
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if err := p.Delete(ctx); err != nil {
 		return nil, err
 	}
-	s.mu.Lock()
 	delete(s.processes, s.id)
-	s.mu.Unlock()
 	s.platform.Close()
 	return &shimapi.DeleteResponse{
 		ExitStatus: uint32(p.ExitStatus()),


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

I think PR #2743 is good for most of times. But will cause a small problem: Delete and Start run at the same time.
As mentioned in issue: #2805. So I think we need to let the lock return to the original state in Delete and Start func.

ping @Ace-Tang PTAL