### PR TITLE
Lock `KillAll`.

### DIFF
--- a/runtime/v1/linux/proc/init.go
+++ b/runtime/v1/linux/proc/init.go
@@ -356,6 +356,9 @@ func (p *Init) kill(ctx context.Context, signal uint32, all bool) error {
 
 // KillAll processes belonging to the init process
 func (p *Init) KillAll(ctx context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	err := p.runtime.Kill(ctx, p.id, int(syscall.SIGKILL), &runc.KillOpts{
 		All: true,
 	})


### PR DESCRIPTION
`KillAll` should be locked.

Previously, it was called in [`delete` (process state locked)](https://github.com/containerd/containerd/blob/release/1.1/linux/proc/init.go#L293) and [`checkProcesses` (shim locked)](https://github.com/containerd/containerd/blob/release/1.1/linux/shim/service.go#L470), both are locked.

However, recently we optimized the locks. [`checkProcesses` doesn't hold a shim lock for process operations any more](https://github.com/containerd/containerd/commit/665815b62730523666a80d68f8fbb27e6fe7425e#diff-35a5ec8c1a43230b5166d81b6727db13).

In release/1.2 and HEAD, `KillAll` is not called in `delete` any more, so we can simply hold a lock in `KillAll` directly.
In release/1.1, since `KillAll` is still called in `delete` (process state locked), we need a private `killAll` function without process state lock for `delete`, and a public `KillAll` function with lock for `checkProcesses`.

I'll chery-pick this into supported branches once LGTM.

Signed-off-by: Lantao Liu <lantaol@google.com>