### PR TITLE
remotes: avoid panic with default resolver conf

### DIFF
--- a/remotes/docker/authorizer.go
+++ b/remotes/docker/authorizer.go
@@ -81,7 +81,7 @@ func (a *dockerAuthorizer) AddResponses(ctx context.Context, responses []*http.R
 			// TODO(dmcg): Store challenge, not token
 			// Move token fetching to authorize
 			return a.setTokenAuth(ctx, host, c.parameters)
-		} else if c.scheme == basicAuth {
+		} else if c.scheme == basicAuth && a.credentials != nil {
 			// TODO: Resolve credentials on authorize
 			username, secret, err := a.credentials(host)
 			if err != nil {


### PR DESCRIPTION
Check if credentials function was passed with resolver config before calling it to avoid a panic when the server wants to do basic auth. The token variant already has this check.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>