### PR TITLE
add ctr delete --exec-id to help debug DeleteProcess

### DIFF
--- a/cmd/ctr/commands/tasks/delete.go
+++ b/cmd/ctr/commands/tasks/delete.go
@@ -32,8 +32,16 @@ var deleteCommand = cli.Command{
 			Name:  "force, f",
 			Usage: "force delete task process",
 		},
+		cli.StringFlag{
+			Name:  "exec-id",
+			Usage: "process ID to kill",
+		},
 	},
 	Action: func(context *cli.Context) error {
+		var (
+			execID = context.String("exec-id")
+			force  = context.Bool("force")
+		)
 		client, ctx, cancel, err := commands.NewClient(context)
 		if err != nil {
 			return err
@@ -48,15 +56,29 @@ var deleteCommand = cli.Command{
 			return err
 		}
 		var opts []containerd.ProcessDeleteOpts
-		if context.Bool("force") {
+		if force {
 			opts = append(opts, containerd.WithProcessKill)
 		}
-		status, err := task.Delete(ctx, opts...)
-		if err != nil {
-			return err
-		}
-		if ec := status.ExitCode(); ec != 0 {
-			return cli.NewExitError("", int(ec))
+		if execID != "" {
+			p, err := task.LoadProcess(ctx, execID, nil)
+			if err != nil {
+				return err
+			}
+			status, err := p.Delete(ctx, opts...)
+			if err != nil {
+				return err
+			}
+			if ec := status.ExitCode(); ec != 0 {
+				return cli.NewExitError("", int(ec))
+			}
+		} else {
+			status, err := task.Delete(ctx, opts...)
+			if err != nil {
+				return err
+			}
+			if ec := status.ExitCode(); ec != 0 {
+				return cli.NewExitError("", int(ec))
+			}
 		}
 		return nil
 	},


### PR DESCRIPTION
After we kill an exec task, we can't rerun a new exec with the same name. For example:
```
root@dockerdemo:~/containerd# bin/ctr t exec -d --exec-id test1000 redis sleep 1000
root@dockerdemo:~/containerd# bin/ctr t ps redis
PID     INFO
1703    &ProcessDetails{ExecID:redis,}
6448    &ProcessDetails{ExecID:test1000,}
root@dockerdemo:~/containerd# bin/ctr t kill --exec-id test1000 -s 9 redis
root@dockerdemo:~/containerd# bin/ctr t ps redis
PID     INFO
1703    &ProcessDetails{ExecID:redis,}
root@dockerdemo:~/containerd# bin/ctr t exec -d --exec-id test1000 redis sleep 1000
ctr: id test1000: already exists
```

We have a interface `DeleteProcess`, so we can use it in ctr, for example(After this patch).
```
root@dockerdemo:~/containerd# bin/ctr t delete --exec-id test1000 redis
root@dockerdemo:~/containerd# bin/ctr t exec -d --exec-id test1000 redis sleep 1000
root@dockerdemo:~/containerd# bin/ctr t ps redis
PID     INFO
1703    &ProcessDetails{ExecID:redis,}
6692    &ProcessDetails{ExecID:test1000,}
root@dockerdemo:~/containerd# bin/ctr t delete -f --exec-id test1000 redis
root@dockerdemo:~/containerd# bin/ctr t ps redis
PID     INFO
1703    &ProcessDetails{ExecID:redis,}
root@dockerdemo:~/containerd# bin/ctr t exec -d --exec-id test1000 redis sleep 1000
root@dockerdemo:~/containerd# bin/ctr t ps redis
PID     INFO
1703    &ProcessDetails{ExecID:redis,}
6875    &ProcessDetails{ExecID:test1000,}
```

I think this maybe a required feature that ctr should support to help us debug libcontainerd.

Signed-off-by: Lifubang <lifubang@acmcoder.com>