### PR TITLE
[release/1.2] fix pipe in broken may cause shim lock forever

### DIFF
--- a/runtime/v1/shim/service_linux.go
+++ b/runtime/v1/shim/service_linux.go
@@ -49,9 +49,11 @@ func (p *linuxPlatform) CopyConsole(ctx context.Context, console console.Console
 		cwg.Add(1)
 		go func() {
 			cwg.Done()
-			p := bufPool.Get().(*[]byte)
-			defer bufPool.Put(p)
-			io.CopyBuffer(epollConsole, in, *p)
+			bp := bufPool.Get().(*[]byte)
+			defer bufPool.Put(bp)
+			io.CopyBuffer(epollConsole, in, *bp)
+			// we need to shutdown epollConsole when pipe broken
+			epollConsole.Shutdown(p.epoller.CloseConsole)
 		}()
 	}
 

--- a/runtime/v2/runc/service_linux.go
+++ b/runtime/v2/runc/service_linux.go
@@ -52,6 +52,7 @@ func (p *linuxPlatform) CopyConsole(ctx context.Context, console console.Console
 			bp := bufPool.Get().(*[]byte)
 			defer bufPool.Put(bp)
 			io.CopyBuffer(epollConsole, in, *bp)
+			// we need to shutdown epollConsole when pipe broken
 			epollConsole.Shutdown(p.epoller.CloseConsole)
 		}()
 	}

--- a/runtime/v2/runc/service_linux.go
+++ b/runtime/v2/runc/service_linux.go
@@ -49,9 +49,10 @@ func (p *linuxPlatform) CopyConsole(ctx context.Context, console console.Console
 		cwg.Add(1)
 		go func() {
 			cwg.Done()
-			p := bufPool.Get().(*[]byte)
-			defer bufPool.Put(p)
-			io.CopyBuffer(epollConsole, in, *p)
+			bp := bufPool.Get().(*[]byte)
+			defer bufPool.Put(bp)
+			io.CopyBuffer(epollConsole, in, *bp)
+			epollConsole.Shutdown(p.epoller.CloseConsole)
 		}()
 	}
 


### PR DESCRIPTION
backport of https://github.com/containerd/containerd/pull/2807 for the 1.2 branch
relates to https://github.com/moby/moby/issues/38064

```
git checkout -b 1.2_backport_shimlockwhenstdinclose upstream/release/1.2
git cherry-pick -s -S -x b3438f7a6f63849d2179a2a76b804aea460affd9
git cherry-pick -s -S -x e76a8879eb10594113d70556c80dd2e456202e22
git push -u origin
```

cherry-pick was clean; no conflicts
