### PR TITLE
[release/1.1] fix pipe in broken may cause shim lock forever for runtime v1

### DIFF
--- a/linux/shim/service_linux.go
+++ b/linux/shim/service_linux.go
@@ -49,9 +49,11 @@ func (p *linuxPlatform) CopyConsole(ctx context.Context, console console.Console
 		cwg.Add(1)
 		go func() {
 			cwg.Done()
-			p := bufPool.Get().(*[]byte)
-			defer bufPool.Put(p)
-			io.CopyBuffer(epollConsole, in, *p)
+			bp := bufPool.Get().(*[]byte)
+			defer bufPool.Put(bp)
+			io.CopyBuffer(epollConsole, in, *bp)
+			// we need to shutdown epollConsole when pipe broken
+			epollConsole.Shutdown(p.epoller.CloseConsole)
 		}()
 	}
 


### PR DESCRIPTION
backport of https://github.com/containerd/containerd/pull/2807 for the 1.1 branch (only the V1 changes)
relates to https://github.com/moby/moby/issues/38064

```
git checkout -b 1.1_backport_shimlockwhenstdinclose upstream/release/1.1
git cherry-pick -s -S -x e76a8879eb10594113d70556c80dd2e456202e22
git push -u origin
```

cherry-pick wasn't clean because the `v1` commit contained a comment-only
change in a `v2` file, but trivial to resolve
