### PR TITLE
optimize shim lock in exec to avoid exec hang

### DIFF
--- a/runtime/v1/shim/service.go
+++ b/runtime/v1/shim/service.go
@@ -246,14 +246,13 @@ func (s *Service) DeleteProcess(ctx context.Context, r *shimapi.DeleteProcessReq
 // Exec an additional process inside the container
 func (s *Service) Exec(ctx context.Context, r *shimapi.ExecProcessRequest) (*ptypes.Empty, error) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	if p := s.processes[r.ID]; p != nil {
-		s.mu.Unlock()
 		return nil, errdefs.ToGRPCf(errdefs.ErrAlreadyExists, "id %s", r.ID)
 	}
 
 	p := s.processes[s.id]
-	s.mu.Unlock()
 	if p == nil {
 		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
 	}
@@ -269,9 +268,7 @@ func (s *Service) Exec(ctx context.Context, r *shimapi.ExecProcessRequest) (*pty
 	if err != nil {
 		return nil, errdefs.ToGRPC(err)
 	}
-	s.mu.Lock()
 	s.processes[r.ID] = process
-	s.mu.Unlock()
 	return empty, nil
 }
 

--- a/runtime/v2/runc/service.go
+++ b/runtime/v2/runc/service.go
@@ -412,8 +412,9 @@ func (s *service) Delete(ctx context.Context, r *taskAPI.DeleteRequest) (*taskAP
 // Exec an additional process inside the container
 func (s *service) Exec(ctx context.Context, r *taskAPI.ExecProcessRequest) (*ptypes.Empty, error) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	p := s.processes[r.ExecID]
-	s.mu.Unlock()
 	if p != nil {
 		return nil, errdefs.ToGRPCf(errdefs.ErrAlreadyExists, "id %s", r.ExecID)
 	}
@@ -432,9 +433,7 @@ func (s *service) Exec(ctx context.Context, r *taskAPI.ExecProcessRequest) (*pty
 	if err != nil {
 		return nil, errdefs.ToGRPC(err)
 	}
-	s.mu.Lock()
 	s.processes[r.ExecID] = process
-	s.mu.Unlock()
 
 	s.send(&eventstypes.TaskExecAdded{
 		ContainerID: s.id,


### PR DESCRIPTION
Exec shim lock optimize before may cause two exec operations can enter to process.Exec area with the same exec id. (With small probability)
Please see:
https://github.com/containerd/containerd/blob/c206da79576925aaf1d675a8204570ccbfeb86aa/runtime/v1/shim/service.go#L247-L276
They can both enter here:
https://github.com/containerd/containerd/blob/c206da79576925aaf1d675a8204570ccbfeb86aa/runtime/v1/shim/service.go#L261
Because the exec id has not been added to s.processes:
https://github.com/containerd/containerd/blob/c206da79576925aaf1d675a8204570ccbfeb86aa/runtime/v1/shim/service.go#L273

This will cause one of exec hang when exit:
This one can exit succ:
```
root@dockerdemo:/opt/runctest/redis# ctr --address /run/docker/containerd/containerd.sock t exec --exec-id test -t redis1 sh
/data # ls /
bin    dev    home   media  proc   run    srv    tmp    var
data   etc    lib    mnt    root   sbin   sys    usr
/data # root@dockerdemo:/opt/runctest/redis#
```
This one can't exit:
```
root@dockerdemo:~# ctr --address /run/docker/containerd/containerd.sock t exec --exec-id test -t redis1 sh
/data # ls /
bin    dev    home   media  proc   run    srv    tmp    var
data   etc    lib    mnt    root   sbin   sys    usr
/data # 
^C
```

So, I think this lock should be for the whole func, and just one exec can run succ, the other one should return an error.

But this is not important for docker, because each exec id in docker are different.
If maintainers feel it's not really important because of some other factors, this can be ignored. Because it's really a very small probability.