### PR TITLE
fix: should get runtime name from container info

### DIFF
--- a/cmd/ctr/commands/tasks/checkpoint.go
+++ b/cmd/ctr/commands/tasks/checkpoint.go
@@ -18,7 +18,6 @@ package tasks
 
 import (
 	"fmt"
-	"runtime"
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cmd/ctr/commands"
@@ -36,11 +35,6 @@ var checkpointCommand = cli.Command{
 		cli.BoolFlag{
 			Name:  "exit",
 			Usage: "stop the container after the checkpoint",
-		},
-		cli.StringFlag{
-			Name:  "runtime",
-			Usage: "runtime name",
-			Value: fmt.Sprintf("io.containerd.runtime.v1.%s", runtime.GOOS),
 		},
 	},
 	Action: func(context *cli.Context) error {
@@ -61,9 +55,13 @@ var checkpointCommand = cli.Command{
 		if err != nil {
 			return err
 		}
+		info, err := container.Info(ctx)
+		if err != nil {
+			return err
+		}
 		var opts []containerd.CheckpointTaskOpts
 		if context.Bool("exit") {
-			opts = append(opts, withExit(context.String("runtime")))
+			opts = append(opts, withExit(info.Runtime.Name))
 		}
 		checkpoint, err := task.Checkpoint(ctx, opts...)
 		if err != nil {


### PR DESCRIPTION
when use `ctr t checkpoint`, runtime name should get from container
info, but not passed by flag, since task has already running with
specified runtime

remove flag `ctr task checkpoint --runtime`

Signed-off-by: Ace-Tang <aceapril@126.com>