### PR TITLE
Fixes: shim service event blocked when waiting for IO finished

### DIFF
--- a/runtime/v1/linux/proc/deleted_state.go
+++ b/runtime/v1/linux/proc/deleted_state.go
@@ -69,3 +69,7 @@ func (s *deletedState) SetExited(status int) {
 func (s *deletedState) Exec(ctx context.Context, path string, r *ExecConfig) (proc.Process, error) {
 	return nil, errors.Errorf("cannot exec in a deleted state")
 }
+
+func (s *deletedState) Pid() int {
+	return -1
+}

--- a/runtime/v1/linux/proc/exec.go
+++ b/runtime/v1/linux/proc/exec.go
@@ -69,8 +69,10 @@ func (e *execProcess) ID() string {
 }
 
 func (e *execProcess) Pid() int {
-	e.mu.Lock()
-	defer e.mu.Unlock()
+	return e.execState.Pid()
+}
+
+func (e *execProcess) pidv() int {
 	return e.pid
 }
 

--- a/runtime/v1/linux/proc/exec_state.go
+++ b/runtime/v1/linux/proc/exec_state.go
@@ -31,6 +31,7 @@ type execState interface {
 	Delete(context.Context) error
 	Kill(context.Context, uint32, bool) error
 	SetExited(int)
+	Pid() int
 }
 
 type execCreatedState struct {
@@ -82,6 +83,12 @@ func (s *execCreatedState) SetExited(status int) {
 	}
 }
 
+func (s *execCreatedState) Pid() int {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+	return s.p.pidv()
+}
+
 type execRunningState struct {
 	p *execProcess
 }
@@ -120,6 +127,12 @@ func (s *execRunningState) SetExited(status int) {
 	}
 }
 
+func (s *execRunningState) Pid() int {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+	return s.p.pidv()
+}
+
 type execStoppedState struct {
 	p *execProcess
 }
@@ -156,4 +169,8 @@ func (s *execStoppedState) Kill(ctx context.Context, sig uint32, all bool) error
 
 func (s *execStoppedState) SetExited(status int) {
 	// no op
+}
+
+func (s *execStoppedState) Pid() int {
+	return s.p.pidv()
 }


### PR DESCRIPTION
@crosbymichael As I mentioned in #2823 , there will be a process locking state when waiting for one exec process IO finished.
I'm so sorry to say that I think this is because of your PR #2803 , you modify the location of process lock in delete func(#2624 ).

The correct location: https://github.com/Ace-Tang/containerd/blob/079292e3fc20b7319b6e7c35dcda6864bb128f1c/runtime/v1/linux/proc/exec_state.go#L170-L177 

After your modify: https://github.com/containerd/containerd/blob/release/1.2/runtime/v1/linux/proc/exec.go#L103-L108 

So, when exec proc A is waiting for it's IO finished, it will hold A's process lock.
When at this time, exec proc B is finished, shim service will trigger `checkProcesses(e runc.Exit)`, it will call A.Pid(), but A.Pid() need A's process lock, so it is stucked, and every event in shim service is blocked, I think it's very dangerous if the event buffer is full. Please see:  https://github.com/crosbymichael/containerd/blob/4c72befe097fb5d9e99ede3536c884608d0af474/runtime/v1/shim/service.go#L523-L532 

But the PR #2624 is not perfect, because `execCreatedState` should lock the whole func, or it will cause race situation.

So, I think we should fix this problem.
There are two solutions:
1. #2823 , let waiting IO completed parallelly.
2. this PR, use state machine management. Just lock in `execCreatedState` and `execRunningState` when call `exec.Pid`.

Signed-off-by: Lifubang <lifubang@acmcoder.com>