### PR TITLE
fixes: pid reuse attack when kill a exec process

### DIFF
--- a/runtime/v1/linux/proc/exec.go
+++ b/runtime/v1/linux/proc/exec.go
@@ -97,6 +97,7 @@ func (e *execProcess) setExited(status int) {
 	e.status = status
 	e.exited = time.Now()
 	e.parent.Platform.ShutdownConsole(context.Background(), e.console)
+	e.pid = -1
 	close(e.waitBlock)
 }
 
@@ -144,7 +145,7 @@ func (e *execProcess) Kill(ctx context.Context, sig uint32, _ bool) error {
 
 func (e *execProcess) kill(ctx context.Context, sig uint32, _ bool) error {
 	pid := e.pid
-	if pid != 0 {
+	if pid > 0 {
 		if err := unix.Kill(pid, syscall.Signal(sig)); err != nil {
 			return errors.Wrapf(checkKillError(err), "exec kill error")
 		}
@@ -242,9 +243,13 @@ func (e *execProcess) Status(ctx context.Context) (string, error) {
 	}
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	// if we don't have a pid then the exec process has just been created
+	// if we don't have a pid(pid=0) then the exec process has just been created
 	if e.pid == 0 {
 		return "created", nil
+	}
+	// if we have a pid=-1 then the exec process has just been stopped
+	if e.pid == -1 {
+		return "stopped", nil
 	}
 	// if we have a pid and it can be signaled, the process is running
 	if err := unix.Kill(e.pid, 0); err == nil {

--- a/runtime/v1/linux/proc/init.go
+++ b/runtime/v1/linux/proc/init.go
@@ -264,6 +264,7 @@ func (p *Init) setExited(status int) {
 	p.exited = time.Now()
 	p.status = status
 	p.Platform.ShutdownConsole(context.Background(), p.console)
+	p.pid = -1
 	close(p.waitBlock)
 }
 


### PR DESCRIPTION
Because of we use unix.Kill to kill a exec process, but after a exec process has been stopped, the pid in `execProcess` has not been deleted, we also can use `execProcess.Kill` to kill the process with the same pid.

**use unix.Kill** https://github.com/lifubang/containerd/blob/831a41b9585fc021c1036da17afa1513e7b4f908/runtime/v1/linux/proc/exec.go#L145-L153 

**don't delete pid in execProcess** https://github.com/lifubang/containerd/blob/831a41b9585fc021c1036da17afa1513e7b4f908/runtime/v1/linux/proc/exec.go#L96-L101 

**can recall execProcess.Kill** https://github.com/lifubang/containerd/blob/831a41b9585fc021c1036da17afa1513e7b4f908/runtime/v1/linux/proc/exec_state.go#L153-L155 

So, if the pid is reused, the wrong process will be killed.

Signed-off-by: Lifubang <lifubang@acmcoder.com>