### PR TITLE
fix race in exec delete and start(release/1.1)

### DIFF
--- a/linux/proc/exec_state.go
+++ b/linux/proc/exec_state.go
@@ -60,11 +60,11 @@ func (s *execCreatedState) Start(ctx context.Context) error {
 }
 
 func (s *execCreatedState) Delete(ctx context.Context) error {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
 	if err := s.p.delete(ctx); err != nil {
 		return err
 	}
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
 	return s.transition("deleted")
 }
 


### PR DESCRIPTION
I don't know whether the release/1.1 is still receiving new PR or not. If not, feel free to close this PR.

As mentioned in #2826
> But the PR #2624 is not perfect, because `execCreatedState` should lock the whole func, or it will cause race situation.

Of course, we will meet this race in a very small probability.
There is an example:
1. Add a time sleep in func 'delete' and 'start' in file exec.go;
https://github.com/acmcodercom/containerd/blob/raceexample/linux/proc/exec.go#L95-L108
https://github.com/acmcodercom/containerd/blob/raceexample/linux/proc/exec.go#L194-L202

2. Start a container;
`ctr --address /run/docker/containerd/containerd.sock run -d docker.io/library/redis:alpine redis`

3. create, delete and start a exec:
`go run testexecrace.go`
`cat testexecrace.go`
```
root@dockerdemo:~/testd# cat testexecrace.go 
package main

import (
	"context"
	"fmt"
	"log"
	"time"

	"github.com/containerd/containerd"
	"github.com/containerd/containerd/cio"
	"github.com/containerd/containerd/namespaces"
)

func main() {
	if err := redisExample(); err != nil {
		log.Fatal(err)
	}
}

func redisExample() error {
	// create a new client connected to the default socket path for containerd
	client, err := containerd.New("/run/docker/containerd/containerd.sock")
	if err != nil {
		return err
	}
	defer client.Close()

	// create a new context with an "example" namespace
	ctx := namespaces.WithNamespace(context.Background(), "default")

	// create a container
	container, err := client.LoadContainer(
		ctx,
		"redis",
	)
	if err != nil {
		return err
	}
	spec, err := container.Spec(ctx)
	if err != nil {
		return err
	}
	task, err := container.Task(ctx, nil)
	if err != nil {
		return err
	}

	pspec := spec.Process
	pspec.Terminal = false
	pspec.Args = []string{"sleep", "1000"}

	cioOpts := []cio.Opt{cio.WithStdio}
	ioCreator := cio.NewCreator(cioOpts...)

	// create aexec
	process, err := task.Exec(ctx, "testexec", pspec, ioCreator)
	if err != nil {
		return err
	}

	statusC, err := process.Wait(ctx)
	if err != nil {
		return err
	}

	// Two cases of simulation
	// First we call process.Delete
	go func() {
		fmt.Println("delete")
		if r, err := process.Delete(ctx); r != nil || err != nil {
			fmt.Println(r)
			fmt.Println(err)
		}
		fmt.Println("process.Delete")
	}()

	// Then, after 100ms, we start it
	time.Sleep(100 * time.Millisecond)
	go func() {
		fmt.Println("start")
		if err := process.Start(ctx); err != nil {
			fmt.Println(err)
		}
		fmt.Println("process.Start")
	}()

	// sleep for a lil bit to see the logs
	time.Sleep(2 * time.Second)

	// wait for the process to fully exit and print out the exit status

	status := <-statusC
	code, _, err := status.Result()
	if err != nil {
		return err
	}
	fmt.Printf("redis-server exited with status: %d\n", code)
	if r, err := process.Delete(ctx); r != nil || err != nil {
		fmt.Println(r)
		fmt.Println(err)
	}
	return nil
}
```

4. after run this go program, the exec process is still running, but it can't be managed by containerd:
```
root@dockerdemo:~# ctr --address /run/docker/containerd/containerd.sock t ps redis
PID      INFO
3757     &ProcessDetails{ExecID:redis,}
10272    - (Hear meas running but execProcess has been deleted)
```
in runc, it is also running:
```
root@dockerdemo:~# runc --root /run/docker/runc/default/ ps redis
UID        PID  PPID  C STIME TTY          TIME CMD
systemd+  3757  3734  0 13:13 ?        00:00:05 redis-server
root     10272  3734  0 14:49 ?        00:00:00 sleep 1000
```
testexec,pid is also be deleted:
```
root@dockerdemo:~# ls /run/docker/containerd/daemon/io.containerd.runtime.v1.linux/default/redis
config.json  init.pid  log.json  rootfs
```
and can't be killed:
```
root@dockerdemo:~# ctr --address /run/docker/containerd/containerd.sock t kill --exec-id testexec redis
ctr: process testexec does not exist: not found
```

I think we can move the lock location when the state of execProcess is execStoppedState, but cant' when the state is execCreatedState. So, we should revert it in `func (s *execCreatedState) Delete(ctx context.Context)`.

Signed-off-by: Lifubang <lifubang@acmcoder.com>