### PR TITLE
[release/1.1 backport] Update runc to v1.0.0-rc6

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -20,7 +20,7 @@ github.com/gogo/protobuf v1.0.0
 github.com/gogo/googleapis 08a7655d27152912db7aaf4f983275eaf8d128ef
 github.com/golang/protobuf 1643683e1b54a9e88ad26d98f81400c8c9d9f4f9
 github.com/opencontainers/runtime-spec v1.0.1
-github.com/opencontainers/runc 10d38b660a77168360df3522881e2dc2be5056bd
+github.com/opencontainers/runc v1.0.0-rc6
 github.com/sirupsen/logrus v1.0.0
 github.com/pmezard/go-difflib v1.0.0
 github.com/urfave/cli 7bc6a0acffa589f415f88aca16cc1de5ffd66f9c

--- a/vendor/github.com/opencontainers/runc/libcontainer/configs/config.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/configs/config.go
@@ -272,26 +272,23 @@ func (hooks Hooks) MarshalJSON() ([]byte, error) {
 	})
 }
 
-// HookState is the payload provided to a hook on execution.
-type HookState specs.State
-
 type Hook interface {
 	// Run executes the hook with the provided state.
-	Run(HookState) error
+	Run(*specs.State) error
 }
 
 // NewFunctionHook will call the provided function when the hook is run.
-func NewFunctionHook(f func(HookState) error) FuncHook {
+func NewFunctionHook(f func(*specs.State) error) FuncHook {
 	return FuncHook{
 		run: f,
 	}
 }
 
 type FuncHook struct {
-	run func(HookState) error
+	run func(*specs.State) error
 }
 
-func (f FuncHook) Run(s HookState) error {
+func (f FuncHook) Run(s *specs.State) error {
 	return f.run(s)
 }
 
@@ -314,7 +311,7 @@ type CommandHook struct {
 	Command
 }
 
-func (c Command) Run(s HookState) error {
+func (c Command) Run(s *specs.State) error {
 	b, err := json.Marshal(s)
 	if err != nil {
 		return err


### PR DESCRIPTION
Backport of https://github.com/containerd/containerd/pull/2838 for the 1.1 release branch

```
git checkout -b 1.1_backport_update_runc_1.0-rc6 upstream/release/1.1
git cherry-pick -s -S -x 97dd5df66fb70cf3ec0c6e4bdb17f01d1d6936d9
```

minor conflict in vendor.conf, but trivial to fix




Wasn't sure if you wanted to have this in the 1.1.x release, so feel free to close if it's not desirable