### PR TITLE
Eliminate misuses of errors.Wrapf

### DIFF
--- a/errdefs/grpc.go
+++ b/errdefs/grpc.go
@@ -95,7 +95,7 @@ func FromGRPC(err error) error {
 
 	msg := rebaseMessage(cls, err)
 	if msg != "" {
-		err = errors.Wrapf(cls, msg)
+		err = errors.Wrap(cls, msg)
 	} else {
 		err = errors.WithStack(cls)
 	}

--- a/filters/parser.go
+++ b/filters/parser.go
@@ -71,7 +71,7 @@ func ParseAll(ss ...string) (Filter, error) {
 	for _, s := range ss {
 		f, err := Parse(s)
 		if err != nil {
-			return nil, errors.Wrapf(errdefs.ErrInvalidArgument, err.Error())
+			return nil, errors.Wrap(errdefs.ErrInvalidArgument, err.Error())
 		}
 
 		fs = append(fs, f)

--- a/metadata/containers.go
+++ b/metadata/containers.go
@@ -72,7 +72,7 @@ func (s *containerStore) List(ctx context.Context, fs ...string) ([]containers.C
 
 	filter, err := filters.ParseAll(fs...)
 	if err != nil {
-		return nil, errors.Wrapf(errdefs.ErrInvalidArgument, err.Error())
+		return nil, errors.Wrap(errdefs.ErrInvalidArgument, err.Error())
 	}
 
 	bkt := getContainersBucket(s.tx, namespace)

--- a/metadata/images.go
+++ b/metadata/images.go
@@ -84,7 +84,7 @@ func (s *imageStore) List(ctx context.Context, fs ...string) ([]images.Image, er
 
 	filter, err := filters.ParseAll(fs...)
 	if err != nil {
-		return nil, errors.Wrapf(errdefs.ErrInvalidArgument, err.Error())
+		return nil, errors.Wrap(errdefs.ErrInvalidArgument, err.Error())
 	}
 
 	var m []images.Image

--- a/metadata/leases.go
+++ b/metadata/leases.go
@@ -122,7 +122,7 @@ func (lm *LeaseManager) List(ctx context.Context, fs ...string) ([]leases.Lease,
 
 	filter, err := filters.ParseAll(fs...)
 	if err != nil {
-		return nil, errors.Wrapf(errdefs.ErrInvalidArgument, err.Error())
+		return nil, errors.Wrap(errdefs.ErrInvalidArgument, err.Error())
 	}
 
 	var ll []leases.Lease

--- a/windows/io.go
+++ b/windows/io.go
@@ -107,7 +107,7 @@ func newPipeSet(ctx context.Context, io runtime.IO) (*pipeSet, error) {
 				if err == nil {
 					err = e
 				} else {
-					err = errors.Wrapf(err, e.Error())
+					err = errors.Wrap(err, e.Error())
 				}
 			}
 		}


### PR DESCRIPTION
In many cases code is calling errors.Wrapf with an arbitrary string
instead of a format string. This causes confusing errors when the
wrapped error message contains '%' characters.

This change replaces such calls with calls to errors.Wrap.

Signed-off-by: John Starks <jostarks@microsoft.com>