### PR TITLE
[release/1.2 backport] shim service event blocked when waiting for IO finished

### DIFF
--- a/runtime/v1/linux/proc/deleted_state.go
+++ b/runtime/v1/linux/proc/deleted_state.go
@@ -69,3 +69,7 @@ func (s *deletedState) SetExited(status int) {
 func (s *deletedState) Exec(ctx context.Context, path string, r *ExecConfig) (proc.Process, error) {
 	return nil, errors.Errorf("cannot exec in a deleted state")
 }
+
+func (s *deletedState) Pid() int {
+	return -1
+}

--- a/runtime/v1/linux/proc/exec.go
+++ b/runtime/v1/linux/proc/exec.go
@@ -69,8 +69,10 @@ func (e *execProcess) ID() string {
 }
 
 func (e *execProcess) Pid() int {
-	e.mu.Lock()
-	defer e.mu.Unlock()
+	return e.execState.Pid()
+}
+
+func (e *execProcess) pidv() int {
 	return e.pid
 }
 

--- a/runtime/v1/linux/proc/exec_state.go
+++ b/runtime/v1/linux/proc/exec_state.go
@@ -31,6 +31,7 @@ type execState interface {
 	Delete(context.Context) error
 	Kill(context.Context, uint32, bool) error
 	SetExited(int)
+	Pid() int
 }
 
 type execCreatedState struct {
@@ -82,6 +83,12 @@ func (s *execCreatedState) SetExited(status int) {
 	}
 }
 
+func (s *execCreatedState) Pid() int {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+	return s.p.pidv()
+}
+
 type execRunningState struct {
 	p *execProcess
 }
@@ -120,6 +127,12 @@ func (s *execRunningState) SetExited(status int) {
 	}
 }
 
+func (s *execRunningState) Pid() int {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+	return s.p.pidv()
+}
+
 type execStoppedState struct {
 	p *execProcess
 }
@@ -156,4 +169,8 @@ func (s *execStoppedState) Kill(ctx context.Context, sig uint32, all bool) error
 
 func (s *execStoppedState) SetExited(status int) {
 	// no op
+}
+
+func (s *execStoppedState) Pid() int {
+	return s.p.pidv()
 }


### PR DESCRIPTION
I think release 1.2 may need #2826 .

Backport of #2826  for the 1.2 release branch
```
git cherry-pick -xsS bbc2a995f97c84670ba47126a2bbba1b302c4211
```
(cherry picked from commit bbc2a995f97c84670ba47126a2bbba1b302c4211)

Signed-off-by: Lifubang <lifubang@acmcoder.com>