### PR TITLE
fixes: should no defer when detach

### DIFF
--- a/cmd/ctr/commands/tasks/exec.go
+++ b/cmd/ctr/commands/tasks/exec.go
@@ -94,7 +94,10 @@ var execCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		defer process.Delete(ctx)
+		// if detach, we should not call this defer
+		if !detach {
+			defer process.Delete(ctx)
+		}
 
 		statusC, err := process.Wait(ctx)
 		if err != nil {


### PR DESCRIPTION
For this PR: #2798 , `add flag -d for ctr t exec to run a service in container`.
There is a small error in Line 97: https://github.com/lifubang/containerd/blob/01f5aa3878cf153c36fcc1dcd3789d4e229c835f/cmd/ctr/commands/tasks/exec.go#L93-L99 , because when we use `detach`, we should not call `defer process.Delete(ctx)`. This is my fault.
But there is no error for ctr, because we don't print the error for `process.Delete(ctx)`. If we print, we will get an error: `process must be stopped before deletion: failed precondition`.

So, if this is not import, feel free to close this PR.

Signed-off-by: Lifubang <lifubang@acmcoder.com>