### PR TITLE
[release/1.2] Prepare 1.2.1

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -21,7 +21,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.2.1-rc.0+unknown"
+	Version = "1.2.1+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Prepares release 1.2.1 with no updates to the release notes necessary this time

The RC has been tested and verified and there have been 3 changes since the RC that I don't believe warrant another RC.
- #2847 Updates mask in default OCI configuration
- #2842 Updates runc to a tagged version, no functional changes
- #2845 Fixes issue introduced since last release

Added 
- #2856 Fixes kill in stopped state
- #2860 Updated CRI to fix stopped state
- #2861 Fixes regression related to signals to paused containers