### PR TITLE
Allow Kill in stopped state

### DIFF
--- a/runtime/v1/linux/proc/init_state.go
+++ b/runtime/v1/linux/proc/init_state.go
@@ -24,7 +24,6 @@ import (
 	"syscall"
 
 	"github.com/containerd/console"
-	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/runtime/proc"
 	"github.com/containerd/fifo"
 	runc "github.com/containerd/go-runc"
@@ -407,7 +406,7 @@ func (s *stoppedState) Delete(ctx context.Context) error {
 }
 
 func (s *stoppedState) Kill(ctx context.Context, sig uint32, all bool) error {
-	return errdefs.ToGRPCf(errdefs.ErrNotFound, "process %s not found", s.p.id)
+	return s.p.kill(ctx, sig, all)
 }
 
 func (s *stoppedState) SetExited(status int) {


### PR DESCRIPTION
For https://github.com/containerd/containerd/issues/2744.

For Kubernetes, https://github.com/containerd/containerd/pull/2597 is not enough, because besides host pid namespace and container pid namespace, we also have pod level pid namespace sharing. In that case `KillAll` should also be called, but pid namespace in OCI spec is set.

This is fine, because in the CRI plugin, we can use `task.Delete(ctx, WithProcessKill)` to do the final cleanup.

However, the problem is that once init process dies, the shim transits to stopped state , and following `kill --all` won't be called at all. https://github.com/containerd/containerd/blob/master/runtime/v1/shim/service.go#L525

This PR currently changes the state machine to allow kill no matter `all=true/false`:
1) When `all=true`, the `runc kill` is called, which is what we want;
2) When `all=false`, the `runc kill` is called but returns `ErrNotFound`, which is the same result with before.

Actually, I can change the code to only allow kill when `all=true`, but always send kill seems cleaner to me.

Signed-off-by: Lantao Liu <lantaol@google.com>