### PR TITLE
[release/1.2] Update runc to 96ec2177ae841256168fcf76954f7177af 

### DIFF
--- a/runtime/v1/linux/proc/utils.go
+++ b/runtime/v1/linux/proc/utils.go
@@ -93,7 +93,9 @@ func checkKillError(err error) error {
 	if err == nil {
 		return nil
 	}
-	if strings.Contains(err.Error(), "os: process already finished") || err == unix.ESRCH {
+	if strings.Contains(err.Error(), "os: process already finished") ||
+		strings.Contains(err.Error(), "container not running") ||
+		err == unix.ESRCH {
 		return errors.Wrapf(errdefs.ErrNotFound, "process already finished")
 	}
 	return errors.Wrapf(err, "unknown error after kill")

--- a/vendor.conf
+++ b/vendor.conf
@@ -20,7 +20,7 @@ github.com/gogo/protobuf v1.0.0
 github.com/gogo/googleapis 08a7655d27152912db7aaf4f983275eaf8d128ef
 github.com/golang/protobuf v1.1.0
 github.com/opencontainers/runtime-spec eba862dc2470385a233c7507392675cbeadf7353 # v1.0.1-45-geba862d
-github.com/opencontainers/runc v1.0.0-rc6
+github.com/opencontainers/runc 96ec2177ae841256168fcf76954f7177af9446eb
 github.com/sirupsen/logrus v1.0.0
 github.com/urfave/cli 7bc6a0acffa589f415f88aca16cc1de5ffd66f9c
 golang.org/x/net b3756b4b77d7b13260a0a2ec658753cf48922eac

--- a/vendor/github.com/opencontainers/runc/libcontainer/configs/intelrdt.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/configs/intelrdt.go
@@ -5,7 +5,9 @@ type IntelRdt struct {
 	// Format: "L3:<cache_id0>=<cbm0>;<cache_id1>=<cbm1>;..."
 	L3CacheSchema string `json:"l3_cache_schema,omitempty"`
 
-	// The schema of memory bandwidth percentage per L3 cache id
+	// The schema of memory bandwidth per L3 cache id
 	// Format: "MB:<cache_id0>=bandwidth0;<cache_id1>=bandwidth1;..."
+	// The unit of memory bandwidth is specified in "percentages" by
+	// default, and in "MBps" if MBA Software Controller is enabled.
 	MemBwSchema string `json:"memBwSchema,omitempty"`
 }


### PR DESCRIPTION
This fixes a regression in runc that didn't allow signals being sent to
paused containers.