### PR TITLE
fix: SCHILY.xattrs should be SCHILY.xattr

### DIFF
--- a/archive/tar.go
+++ b/archive/tar.go
@@ -100,7 +100,7 @@ const (
 	// readdir calls to this directory do not follow to lower layers.
 	whiteoutOpaqueDir = whiteoutMetaPrefix + ".opq"
 
-	paxSchilyXattr = "SCHILY.xattrs."
+	paxSchilyXattr = "SCHILY.xattr."
 )
 
 // Apply applies a tar stream of an OCI style diff tar.


### PR DESCRIPTION
from golang code
https://github.com/golang/go/blob/bad6b6fa9190e9079a6d6958859856a66f0fab87/src/archive/tar/common.go#L110

Signed-off-by: Ace-Tang <aceapril@126.com>