### PR TITLE
Fix CI due to Golang 1.10.6 / 1.11.3 regressions (workaround)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,9 @@ all: binaries
 
 check: proto-fmt ## run all linters
 	@echo "$(WHALE) $@"
-	gometalinter --config .gometalinter.json ./...
+	# FIXME temporarily disabled due to a regression in Go 1.10.6 / 1.11.3 (https://github.com/golang/go/issues/29241)
+	# gometalinter --config .gometalinter.json ./...
+	gometalinter --config .gometalinter.json $(go list ./... | grep -v /vendor/)
 
 ci: check binaries checkprotos coverage coverage-integration ## to be used by the CI
 

--- a/script/setup/install-cni
+++ b/script/setup/install-cni
@@ -25,7 +25,12 @@ CNI_COMMIT=$(grep containernetworking/plugins ${GOPATH}/src/github.com/container
 CNI_DIR=/opt/cni
 CNI_CONFIG_DIR=/etc/cni/net.d
 
-go get -d github.com/containernetworking/plugins/...
+# FIXME temporarily disabled due to a regression in Go 1.10.6 / 1.11.3 (https://github.com/golang/go/issues/29241)
+# go get -d github.com/containernetworking/plugins/...
+go get -d github.com/containernetworking/plugins || true
+PACKAGES=$(go list github.com/containernetworking/plugins/... | grep -v /vendor/)
+go get -d ${PACKAGES}
+
 cd $GOPATH/src/github.com/containernetworking/plugins
 git checkout $CNI_COMMIT
 FASTBUILD=true ./build.sh

--- a/script/setup/install-critools
+++ b/script/setup/install-critools
@@ -22,7 +22,13 @@ set -eu -o pipefail
 
 go get -u github.com/onsi/ginkgo/ginkgo
 CRITEST_COMMIT=v1.12.0
-go get -d github.com/kubernetes-incubator/cri-tools/...
+
+# FIXME temporarily disabled due to a regression in Go 1.10.6 / 1.11.3 (https://github.com/golang/go/issues/29241)
+# go get -d github.com/kubernetes-incubator/cri-tools/...
+go get -d github.com/kubernetes-incubator/cri-tools || true
+PACKAGES=$(go list github.com/kubernetes-incubator/cri-tools/... | grep -v /vendor/)
+go get -d ${PACKAGES}
+
 cd $GOPATH/src/github.com/kubernetes-incubator/cri-tools
 git checkout $CRITEST_COMMIT
 make


### PR DESCRIPTION
Attempt to fix CI is failing due to a regression in Go 1.10.6 / 1.11.3 (see https://github.com/golang/go/issues/29241)

```
package github.com/containernetworking/plugins/...: github.com/containernetworking/plugins/...: invalid import path: malformed import path "github.com/containernetworking/plugins/...": double dot
```
