### PR TITLE
Fix annotation typo error

### DIFF
--- a/archive/tartest/tar.go
+++ b/archive/tartest/tar.go
@@ -49,7 +49,7 @@ func TarAll(wt ...WriterToTar) WriterToTar {
 }
 
 // TarFromWriterTo is used to create a tar stream from a tar record
-// creator. This can be used to manifacture more specific tar records
+// creator. This can be used to manufacture more specific tar records
 // which allow testing specific tar cases which may be encountered
 // by the untar process.
 func TarFromWriterTo(wt WriterToTar) io.ReadCloser {


### PR DESCRIPTION
Fix typo in [tar.go](https://github.com/containerd/containerd/compare/master...JoeWrightss:patch-1?expand=1#diff-f43d3303b2192de8b02bb4a9a8bd2ab6) at line 52.