### PR TITLE
fix: use func args instead of build new one

### DIFF
--- a/snapshots/overlay/overlay.go
+++ b/snapshots/overlay/overlay.go
@@ -426,7 +426,7 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 }
 
 func (o *snapshotter) prepareDirectory(ctx context.Context, snapshotDir string, kind snapshots.Kind) (string, error) {
-	td, err := ioutil.TempDir(filepath.Join(o.root, "snapshots"), "new-")
+	td, err := ioutil.TempDir(snapshotDir, "new-")
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create temp dir")
 	}


### PR DESCRIPTION
Signed-off-by: zhangyue <zy675793960@yeah.net>
this func already send a func args about snapshotDir, no need to build a new one.