### PR TITLE
Fix freebsd build

### DIFF
--- a/cmd/containerd-shim/shim_freebsd.go
+++ b/cmd/containerd-shim/shim_freebsd.go
@@ -1,4 +1,4 @@
-// +build !linux,!windows,!darwin
+// +build freebsd
 
 /*
    Copyright The containerd Authors.
@@ -39,5 +39,8 @@ func setupSignals() (chan os.Signal, error) {
 }
 
 func newServer() (*ttrpc.Server, error) {
-	return ttrpc.NewServer(ttrpc.WithServerHandshaker(ttrpc.UnixSocketRequireSameUser()))
+	// for freebsd, we omit the socket credentials because these syscalls are
+	// slightly different. since we don't have freebsd support yet, this can be
+	// implemented later and the build can continue without issue.
+	return ttrpc.NewServer()
 }

--- a/cmd/containerd-stress/rlimit_freebsd.go
+++ b/cmd/containerd-stress/rlimit_freebsd.go
@@ -1,4 +1,4 @@
-// +build !windows,!freebsd
+// +build freebsd
 
 /*
    Copyright The containerd Authors.
@@ -23,7 +23,7 @@ import (
 )
 
 func setRlimit() error {
-	rlimit := uint64(100000)
+	rlimit := int64(100000)
 	if rlimit > 0 {
 		var limit syscall.Rlimit
 		if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {

--- a/runtime/v2/shim/shim_freebsd.go
+++ b/runtime/v2/shim/shim_freebsd.go
@@ -1,4 +1,4 @@
-// +build !windows,!freebsd
+// +build freebsd
 
 /*
    Copyright The containerd Authors.
@@ -16,25 +16,14 @@
    limitations under the License.
 */
 
-package main
+package shim
 
-import (
-	"syscall"
-)
+import "github.com/containerd/ttrpc"
 
-func setRlimit() error {
-	rlimit := uint64(100000)
-	if rlimit > 0 {
-		var limit syscall.Rlimit
-		if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
-			return err
-		}
-		if limit.Cur < rlimit {
-			limit.Cur = rlimit
-			if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
-				return err
-			}
-		}
-	}
+func newServer() (*ttrpc.Server, error) {
+	return ttrpc.NewServer()
+}
+
+func subreaper() error {
 	return nil
 }


### PR DESCRIPTION
This brings freebsd in line with Darwin, ie it builds, but some parts may not yet
be fully functional. There is now a WIP `runc` port for FreeBSD at
https://github.com/clovertrail/runc/tree/1501-SupportOnFreeBSD so should be able
to test further.

Signed-off-by: Justin Cormack <justin@specialbusservice.com>