### PR TITLE
metadata: define content sharing policy

### DIFF
--- a/content/testsuite/testsuite.go
+++ b/content/testsuite/testsuite.go
@@ -38,8 +38,16 @@ import (
 	"gotest.tools/assert"
 )
 
+const (
+	emptyDigest = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+)
+
+// StoreInitFn initializes content store with given root and returns a function for
+// destroying the content store
+type StoreInitFn func(ctx context.Context, root string) (context.Context, content.Store, func() error, error)
+
 // ContentSuite runs a test suite on the content store given a factory function.
-func ContentSuite(t *testing.T, name string, storeFn func(ctx context.Context, root string) (context.Context, content.Store, func() error, error)) {
+func ContentSuite(t *testing.T, name string, storeFn StoreInitFn) {
 	t.Run("Writer", makeTest(t, name, storeFn, checkContentStoreWriter))
 	t.Run("UpdateStatus", makeTest(t, name, storeFn, checkUpdateStatus))
 	t.Run("CommitExists", makeTest(t, name, storeFn, checkCommitExists))
@@ -52,10 +60,18 @@ func ContentSuite(t *testing.T, name string, storeFn func(ctx context.Context, r
 	t.Run("SmallBlob", makeTest(t, name, storeFn, checkSmallBlob))
 	t.Run("Labels", makeTest(t, name, storeFn, checkLabels))
 
+	t.Run("CommitErrorState", makeTest(t, name, storeFn, checkCommitErrorState))
+}
+
+// ContentCrossNSSharedSuite runs a test suite under shared content policy
+func ContentCrossNSSharedSuite(t *testing.T, name string, storeFn StoreInitFn) {
 	t.Run("CrossNamespaceAppend", makeTest(t, name, storeFn, checkCrossNSAppend))
 	t.Run("CrossNamespaceShare", makeTest(t, name, storeFn, checkCrossNSShare))
+}
 
-	t.Run("CommitErrorState", makeTest(t, name, storeFn, checkCommitErrorState))
+// ContentCrossNSIsolatedSuite runs a test suite under isolated content policy
+func ContentCrossNSIsolatedSuite(t *testing.T, name string, storeFn StoreInitFn) {
+	t.Run("CrossNamespaceIsolate", makeTest(t, name, storeFn, checkCrossNSIsolate))
 }
 
 // ContextWrapper is used to decorate new context used inside the test
@@ -890,6 +906,38 @@ func checkCrossNSAppend(ctx context.Context, t *testing.T, cs content.Store) {
 
 }
 
+func checkCrossNSIsolate(ctx context.Context, t *testing.T, cs content.Store) {
+	wrap, ok := ctx.Value(wrapperKey{}).(ContextWrapper)
+	if !ok {
+		t.Skip("multiple contexts not supported")
+	}
+
+	var size int64 = 1000
+	b, d := createContent(size)
+	ref := fmt.Sprintf("ref-%d", size)
+	t1 := time.Now()
+
+	if err := content.WriteBlob(ctx, cs, ref, bytes.NewReader(b), ocispec.Descriptor{Size: size, Digest: d}); err != nil {
+		t.Fatal(err)
+	}
+	t2 := time.Now()
+
+	ctx2, done, err := wrap(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer done(ctx2)
+
+	t3 := time.Now()
+	w, err := cs.Writer(ctx2, content.WithRef(ref), content.WithDescriptor(ocispec.Descriptor{Size: size, Digest: d}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t4 := time.Now()
+
+	checkNewlyCreated(t, w, t1, t2, t3, t4)
+}
+
 func checkStatus(t *testing.T, w content.Writer, expected content.Status, d digest.Digest, preStart, postStart, preUpdate, postUpdate time.Time) {
 	t.Helper()
 	st, err := w.Status()
@@ -930,6 +978,29 @@ func checkStatus(t *testing.T, w content.Writer, expected content.Status, d dige
 		t.Logf("compare update %v against (%v, %v)", st.UpdatedAt, preUpdate, postUpdate)
 		if st.UpdatedAt.After(postUpdate) || st.UpdatedAt.Before(preUpdate) {
 			t.Fatalf("unexpected updated at time %s, expected between %s and %s", st.UpdatedAt, preUpdate, postUpdate)
+		}
+	}
+}
+
+func checkNewlyCreated(t *testing.T, w content.Writer, preStart, postStart, preUpdate, postUpdate time.Time) {
+	t.Helper()
+	st, err := w.Status()
+	if err != nil {
+		t.Fatalf("failed to get status: %v", err)
+	}
+
+	wd := w.Digest()
+	if wd != emptyDigest {
+		t.Fatalf("unexpected digest %v, expected %v", wd, emptyDigest)
+	}
+
+	if st.Offset != 0 {
+		t.Fatalf("unexpected offset %v", st.Offset)
+	}
+
+	if runtime.GOOS != "windows" {
+		if st.StartedAt.After(postUpdate) || st.StartedAt.Before(postStart) {
+			t.Fatalf("unexpected started at time %s, expected between %s and %s", st.StartedAt, postStart, postUpdate)
 		}
 	}
 }

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -220,3 +220,21 @@ The linux runtime allows a few options to be set to configure the shim and the r
 	# (this only need to be set on kernel < 3.18)
 	shim_no_newns = true
 ```
+
+### Bolt Metadata Plugin
+
+The bolt metadata plugin allows configuration of the content sharing policy between namespaces.
+
+The default mode "shared" will make blobs available in all namespaces once it is pulled into any namespace.
+The blob will be pulled into the namespace if a writer is opened with the "Expected" digest that is already present in the backend.
+
+The alternative mode, "isolated" requires that clients prove they have access to the content by providing all of the content to the ingest before the blob is added to the namespace.
+
+Both modes share backing data, while "shared" will reduce total bandwidth across namespaces, at the cost of allowing access to any blob just by knowing its digest.
+
+The default is "shared". While this is largely the most desired policy, one can change to "isolated" mode with the following configuration:
+
+```toml
+[plugins.bolt]
+	content_sharing_policy = "isolated"
+```

--- a/metadata/content.go
+++ b/metadata/content.go
@@ -38,16 +38,31 @@ import (
 
 type contentStore struct {
 	content.Store
-	db *DB
-	l  sync.RWMutex
+	db     *DB
+	shared bool
+	l      sync.RWMutex
 }
 
 // newContentStore returns a namespaced content store using an existing
 // content store interface.
-func newContentStore(db *DB, cs content.Store) *contentStore {
+// policy defines the sharing behavior for content between namespaces. Both
+// modes will result in shared storage in the backend for committed. Choose
+// "shared" to prevent separate namespaces from having to pull the same content
+// twice.  Choose "isolated" if the content must not be shared between
+// namespaces.
+//
+// If the policy is "shared", writes will try to resolve the "expected" digest
+// against the backend, allowing imports of content from other namespaces. In
+// "isolated" mode, the client must prove they have the content by providing
+// the entire blob before the content can be added to another namespace.
+//
+// Since we have only two policies right now, it's simpler using bool to
+// represent it internally.
+func newContentStore(db *DB, shared bool, cs content.Store) *contentStore {
 	return &contentStore{
-		Store: cs,
-		db:    db,
+		Store:  cs,
+		db:     db,
+		shared: shared,
 	}
 }
 
@@ -383,13 +398,15 @@ func (cs *contentStore) Writer(ctx context.Context, opts ...content.WriterOpt) (
 				return nil
 			}
 
-			if st, err := cs.Store.Info(ctx, wOpts.Desc.Digest); err == nil {
-				// Ensure the expected size is the same, it is likely
-				// an error if the size is mismatched but the caller
-				// must resolve this on commit
-				if wOpts.Desc.Size == 0 || wOpts.Desc.Size == st.Size {
-					shared = true
-					wOpts.Desc.Size = st.Size
+			if cs.shared {
+				if st, err := cs.Store.Info(ctx, wOpts.Desc.Digest); err == nil {
+					// Ensure the expected size is the same, it is likely
+					// an error if the size is mismatched but the caller
+					// must resolve this on commit
+					if wOpts.Desc.Size == 0 || wOpts.Desc.Size == st.Size {
+						shared = true
+						wOpts.Desc.Size = st.Size
+					}
 				}
 			}
 		}

--- a/metadata/db.go
+++ b/metadata/db.go
@@ -46,6 +46,19 @@ const (
 	dbVersion = 3
 )
 
+// DBOpt configures how we set up the DB
+type DBOpt func(*dbOptions)
+
+// WithPolicyIsolated isolates contents between namespaces
+func WithPolicyIsolated(o *dbOptions) {
+	o.shared = false
+}
+
+// dbOptions configure db options.
+type dbOptions struct {
+	shared bool
+}
+
 // DB represents a metadata database backed by a bolt
 // database. The database is fully namespaced and stores
 // image, container, namespace, snapshot, and content data
@@ -72,19 +85,28 @@ type DB struct {
 	// mutationCallbacks are called after each mutation with the flag
 	// set indicating whether any dirty flags are set
 	mutationCallbacks []func(bool)
+
+	dbopts dbOptions
 }
 
 // NewDB creates a new metadata database using the provided
 // bolt database, content store, and snapshotters.
-func NewDB(db *bolt.DB, cs content.Store, ss map[string]snapshots.Snapshotter) *DB {
+func NewDB(db *bolt.DB, cs content.Store, ss map[string]snapshots.Snapshotter, opts ...DBOpt) *DB {
 	m := &DB{
 		db:      db,
 		ss:      make(map[string]*snapshotter, len(ss)),
 		dirtySS: map[string]struct{}{},
+		dbopts: dbOptions{
+			shared: true,
+		},
+	}
+
+	for _, opt := range opts {
+		opt(&m.dbopts)
 	}
 
 	// Initialize data stores
-	m.cs = newContentStore(m, cs)
+	m.cs = newContentStore(m, m.dbopts.shared, cs)
 	for name, sn := range ss {
 		m.ss[name] = newSnapshotter(m, name, sn)
 	}


### PR DESCRIPTION
This changeset modifies the metadata store to allow one to set a
"content sharing policy" that defines how blobs are shared between
namespaces in the content store.

The default mode "shared" will make blobs available in all namespaces
once it is pulled into any namespace.  The blob will be pulled into
the namespace if a writer is opened with the "Expected" digest that
is already present in the backend.

The alternative mode, "isolated" requires that clients prove they have
access to the content by providing all of the content to the ingest
before the blob is added to the namespace.

Both modes share backing data, while "shared" will reduce total
bandwidth across namespaces, at the cost of allowing access to any
blob just by knowing its digest.

Note: Most functional codes and changelog of this commit originate from
Stephen J Day <stephen.day@docker.com>, see
https://github.com/containerd/containerd/pull/1709/commits/40455aade85f91967b22e7999dbfbfea58c63e26

Fixes #1713 Fixes #2865

Signed-off-by: Eric Lin <linxiulei@gmail.com>