### PR TITLE
[release/1.1] Revert "Fix CI due to Golang 1.10.6 / 1.11.3 regressions (workaround)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,9 +107,7 @@ all: binaries
 
 check: proto-fmt ## run all linters
 	@echo "$(WHALE) $@"
-	# FIXME temporarily disabled due to a regression in Go 1.10.6 / 1.11.3 (https://github.com/golang/go/issues/29241)
-	# gometalinter --config .gometalinter.json ./...
-	gometalinter --config .gometalinter.json $(go list ./... | grep -v /vendor/)
+	gometalinter --config .gometalinter.json ./...
 
 ci: check binaries checkprotos coverage coverage-integration ## to be used by the CI
 

--- a/script/setup/install-cni
+++ b/script/setup/install-cni
@@ -25,12 +25,7 @@ CNI_COMMIT=$(grep containernetworking/plugins ${GOPATH}/src/github.com/container
 CNI_DIR=/opt/cni
 CNI_CONFIG_DIR=/etc/cni/net.d
 
-# FIXME temporarily disabled due to a regression in Go 1.10.6 / 1.11.3 (https://github.com/golang/go/issues/29241)
-# go get -d github.com/containernetworking/plugins/...
-go get -d github.com/containernetworking/plugins || true
-PACKAGES=$(go list github.com/containernetworking/plugins/... | grep -v /vendor/)
-go get -d ${PACKAGES}
-
+go get -d github.com/containernetworking/plugins/...
 cd $GOPATH/src/github.com/containernetworking/plugins
 git checkout $CNI_COMMIT
 FASTBUILD=true ./build.sh

--- a/script/setup/install-critools
+++ b/script/setup/install-critools
@@ -22,12 +22,7 @@ set -eu -o pipefail
 
 go get -u github.com/onsi/ginkgo/ginkgo
 CRITEST_COMMIT=v1.0.0-beta.1
-
-# FIXME temporarily disabled due to a regression in Go 1.10.6 / 1.11.3 (https://github.com/golang/go/issues/29241)
-# go get -d github.com/kubernetes-incubator/cri-tools/...
-go get -d github.com/kubernetes-incubator/cri-tools || true
-PACKAGES=$(go list github.com/kubernetes-incubator/cri-tools/... | grep -v /vendor/)
-go get -d ${PACKAGES}
+go get -d github.com/kubernetes-incubator/cri-tools/...
 cd $GOPATH/src/github.com/kubernetes-incubator/cri-tools
 git checkout $CRITEST_COMMIT
 make


### PR DESCRIPTION
This reverts commit 66a3eeb5b78ef409b7520dae64e17bc3aceb1ebc (https://github.com/containerd/containerd/pull/2880)

Golang 1.10.7 and 1.11.4 have been released, which address the regression, so we no longer need this temporary workaround