### PR TITLE
docs: remove website leftovers

### DIFF
--- a/docs/.dockerignore
+++ b/docs/.dockerignore
@@ -1,5 +1,0 @@
-.dockerignore
-.git
-.gitignore
-Dockerfile
-docker-compose.yml

--- a/docs/.editorconfig
+++ b/docs/.editorconfig
@@ -1,13 +1,8 @@
-[*]
+[*.md]
 end_of_line = lf
 charset = utf-8
 max_line_length = 80
 trim_trailing_whitespace = true
 insert_final_newline = false
-
-[*.{html,js,sh,sass,md,mmark}]
 indent_style = space
 indent_size = 2
-
-[Makefile]
-indent_style = tab

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,6 +1,0 @@
-**/.DS_Store
-**/desktop.ini
-CNAME
-
-# Hugo-generated content
-public/


### PR DESCRIPTION
The website content moved to the github.com/containerd/containerd.io repository.

Commit da1fba00503610dce2e9f8a835cf0f1668fc4328 (https://github.com/containerd/containerd/pull/2572) removed all website-related content, but there were some stray files left behind. This patch removes those files, and updates the `.editorconfig` file to only match Markdown files.

@estesp 