### PR TITLE
runtime: add Add/Delete method in PlatformRuntime interface

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -69,4 +69,8 @@ type PlatformRuntime interface {
 	// Tasks returns all the current tasks for the runtime.
 	// Any container runs at most one task at a time.
 	Tasks(context.Context, bool) ([]Task, error)
+	// Add adds a task into runtime.
+	Add(context.Context, Task) error
+	// Delete remove a task.
+	Delete(context.Context, string)
 }

--- a/runtime/v1/linux/runtime.go
+++ b/runtime/v1/linux/runtime.go
@@ -305,6 +305,16 @@ func (r *Runtime) Get(ctx context.Context, id string) (runtime.Task, error) {
 	return r.tasks.Get(ctx, id)
 }
 
+// Add a runtime task
+func (r *Runtime) Add(ctx context.Context, task runtime.Task) error {
+	return r.tasks.Add(ctx, task)
+}
+
+// Delete a runtime task
+func (r *Runtime) Delete(ctx context.Context, id string) {
+	r.tasks.Delete(ctx, id)
+}
+
 func (r *Runtime) loadTasks(ctx context.Context, ns string) ([]*Task, error) {
 	dir, err := ioutil.ReadDir(filepath.Join(r.state, ns))
 	if err != nil {

--- a/runtime/v2/manager.go
+++ b/runtime/v2/manager.go
@@ -130,6 +130,16 @@ func (m *TaskManager) Get(ctx context.Context, id string) (runtime.Task, error) 
 	return m.tasks.Get(ctx, id)
 }
 
+// Add a runtime task
+func (m *TaskManager) Add(ctx context.Context, task runtime.Task) error {
+	return m.tasks.Add(ctx, task)
+}
+
+// Delete a runtime task
+func (m *TaskManager) Delete(ctx context.Context, id string) {
+	m.tasks.Delete(ctx, id)
+}
+
 // Tasks lists all tasks
 func (m *TaskManager) Tasks(ctx context.Context, all bool) ([]runtime.Task, error) {
 	return m.tasks.GetAll(ctx, all)

--- a/windows/runtime.go
+++ b/windows/runtime.go
@@ -153,6 +153,14 @@ func (r *windowsRuntime) Tasks(ctx context.Context, all bool) ([]runtime.Task, e
 	return r.tasks.GetAll(ctx, all)
 }
 
+func (r *windowsRuntime) Add(ctx context.Context, task runtime.Task) error {
+	return r.tasks.Add(ctx, task)
+}
+
+func (r *windowsRuntime) Delete(ctx context.Context, id string) {
+	r.tasks.Delete(ctx, id)
+}
+
 func (r *windowsRuntime) newTask(ctx context.Context, namespace, id string, rootfs []mount.Mount, spec *runtimespec.Spec, io runtime.IO, createOpts *hcsshimtypes.CreateOptions) (*task, error) {
 	var (
 		err  error


### PR DESCRIPTION
The two new method Add/Delete can allow custom plugin to add or migrate
existing task into major Runtime plugin.

close: #2888

Signed-off-by: Wei Fu <fuweid89@gmail.com>