### PR TITLE
Fix annotation typo errors

### DIFF
--- a/content/testsuite/testsuite.go
+++ b/content/testsuite/testsuite.go
@@ -997,7 +997,7 @@ var contentSeed int64
 
 func createContent(size int64) ([]byte, digest.Digest) {
 	// each time we call this, we want to get a different seed, but it should
-	// be related to the intitialization order and fairly consistent between
+	// be related to the initialization order and fairly consistent between
 	// test runs. An atomic integer works just good enough for this.
 	seed := atomic.AddInt64(&contentSeed, 1)
 

--- a/identifiers/validate.go
+++ b/identifiers/validate.go
@@ -45,7 +45,7 @@ var (
 // Validate return nil if the string s is a valid identifier.
 //
 // identifiers must be valid domain names according to RFC 1035, section 2.3.1.  To
-// enforce case insensitvity, all characters must be lower case.
+// enforce case insensitivity, all characters must be lower case.
 //
 // In general, identifiers that pass this validation, should be safe for use as
 // a domain names or filesystem path component.


### PR DESCRIPTION
1. "intitialization" to "initialization" in line 1000.
2. "insensitvity" to "insensitivity" in line 48.