### PR TITLE
[release/1.2] Update cri to 0d5cabd006cb5319dc965046067b8432d9fa5ef8

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -43,7 +43,7 @@ github.com/google/go-cmp v0.1.0
 go.etcd.io/bbolt v1.3.1-etcd.8
 
 # cri dependencies
-github.com/containerd/cri 0ca1e3c2b73b5c38e72f29bb76338d0078b23d6c # release/1.2 branch
+github.com/containerd/cri 0d5cabd006cb5319dc965046067b8432d9fa5ef8 # release/1.2 branch
 github.com/containerd/go-cni 40bcf8ec8acd7372be1d77031d585d5d8e561c90
 github.com/blang/semver v3.1.0
 github.com/containernetworking/cni v0.6.0

--- a/vendor/github.com/containerd/cri/pkg/server/container_create.go
+++ b/vendor/github.com/containerd/cri/pkg/server/container_create.go
@@ -187,6 +187,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 		opts = append(opts, customopts.WithVolumes(mountMap))
 	}
 	meta.ImageRef = image.ID
+	meta.StopSignal = image.ImageSpec.Config.StopSignal
 
 	// Get container log path.
 	if config.GetLogPath() != "" {

--- a/vendor/github.com/containerd/cri/pkg/store/container/metadata.go
+++ b/vendor/github.com/containerd/cri/pkg/store/container/metadata.go
@@ -27,7 +27,7 @@ import (
 // 1) Metadata is immutable after created.
 // 2) Metadata is checkpointed as containerd container label.
 
-// metadataVersion  is current version of container metadata.
+// metadataVersion is current version of container metadata.
 const metadataVersion = "v1" // nolint
 
 // versionedMetadata is the internal versioned container metadata.
@@ -58,6 +58,9 @@ type Metadata struct {
 	ImageRef string
 	// LogPath is the container log path.
 	LogPath string
+	// StopSignal is the system call signal that will be sent to the container to exit.
+	// TODO(random-liu): Add integration test for stop signal.
+	StopSignal string
 }
 
 // MarshalJSON encodes Metadata into bytes in json format.


### PR DESCRIPTION
1. Fix a bug that a container can't be stopped or inspected when its corresponding image is deleted;
2. Fix a bug that the cri plugin handles containerd event outside of `k8s.io` namespace.

Signed-off-by: Lantao Liu <lantaol@google.com>