### PR TITLE
Add direct unpack support for overlay and aufs

### DIFF
--- a/archive/tar_linux_test.go
+++ b/archive/tar_linux_test.go
@@ -1,0 +1,122 @@
+// +build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package archive
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/containerd/aufs"
+	"github.com/containerd/containerd/archive/tartest"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/pkg/testutil"
+	"github.com/containerd/containerd/snapshots/overlay"
+	"github.com/containerd/continuity/fs/fstest"
+)
+
+func runWriterToTarTest(t *testing.T, name string, wt tartest.WriterToTar, a fstest.Applier, validate func(string) error, applyErr error) {
+	t.Run(name, makeWriterToTarNaiveTest(wt, a, validate, applyErr))
+	t.Run(name+"Overlay", makeWriterToTarOverlayTest(wt, a, validate, applyErr))
+	t.Run(name+"Aufs", makeWriterToTarAufsTest(wt, a, validate, applyErr))
+}
+
+func makeWriterToTarOverlayTest(wt tartest.WriterToTar, a fstest.Applier, validate func(string) error, applyErr error) func(*testing.T) {
+	return func(t *testing.T) {
+		testutil.RequiresRoot(t)
+		if err := overlay.Supported("/"); err != nil {
+			t.Skipf("skipping because overlay is not supported %v", err)
+		}
+		ud, err := ioutil.TempDir("", "test-writer-to-tar-overlay-upper")
+		if err != nil {
+			t.Fatalf("Failed to create temp dir: %v", err)
+		}
+		defer os.RemoveAll(ud)
+		wd, err := ioutil.TempDir("", "test-writer-to-tar-overlay-work")
+		if err != nil {
+			t.Fatalf("Failed to create temp dir: %v", err)
+		}
+		defer os.RemoveAll(wd)
+
+		apply := func(ctx context.Context, _ string, tr io.Reader) error {
+			_, err := Apply(ctx, ud, tr, WithConvertWhiteout(OverlayConvertWhiteout))
+			return err
+		}
+
+		validate := func(td string) error {
+			mounts := []mount.Mount{
+				{
+					Type:   "overlay",
+					Source: "overlay",
+					Options: []string{
+						fmt.Sprintf("workdir=%s", wd),
+						fmt.Sprintf("upperdir=%s", ud),
+						fmt.Sprintf("lowerdir=%s", td),
+					},
+				},
+			}
+
+			return mount.WithTempMount(context.Background(), mounts, func(root string) error {
+				return validate(root)
+			})
+		}
+
+		makeWriterToTarTest(wt, a, apply, validate, applyErr)(t)
+	}
+}
+
+func makeWriterToTarAufsTest(wt tartest.WriterToTar, a fstest.Applier, validate func(string) error, applyErr error) func(*testing.T) {
+	return func(t *testing.T) {
+		testutil.RequiresRoot(t)
+		if err := aufs.Supported(); err != nil {
+			t.Skipf("skipping because aufs is not supported %v", err)
+		}
+		d, err := ioutil.TempDir("", "test-writer-to-tar-aufs-rw")
+		if err != nil {
+			t.Fatalf("Failed to create temp dir: %v", err)
+		}
+		defer os.RemoveAll(d)
+
+		apply := func(ctx context.Context, _ string, tr io.Reader) error {
+			_, err := Apply(ctx, d, tr, WithConvertWhiteout(AufsConvertWhiteout))
+			return err
+		}
+
+		validate := func(td string) error {
+			mounts := []mount.Mount{
+				{
+					Type:   "aufs",
+					Source: "none",
+					Options: []string{
+						fmt.Sprintf("br:%s=rw:%s=ro+wh", d, td),
+					},
+				},
+			}
+
+			return mount.WithTempMount(context.Background(), mounts, func(root string) error {
+				return validate(root)
+			})
+		}
+
+		makeWriterToTarTest(wt, a, apply, validate, applyErr)(t)
+	}
+}

--- a/archive/tar_opts.go
+++ b/archive/tar_opts.go
@@ -24,6 +24,9 @@ type ApplyOpt func(options *ApplyOptions) error
 // Filter specific files from the archive
 type Filter func(*tar.Header) (bool, error)
 
+// ConvertWhiteout converts whiteout files from the archive
+type ConvertWhiteout func(*tar.Header, string) (bool, error)
+
 // all allows all files
 func all(_ *tar.Header) (bool, error) {
 	return true, nil
@@ -33,6 +36,14 @@ func all(_ *tar.Header) (bool, error) {
 func WithFilter(f Filter) ApplyOpt {
 	return func(options *ApplyOptions) error {
 		options.Filter = f
+		return nil
+	}
+}
+
+// WithConvertWhiteout uses the convert function to convert the whiteout files.
+func WithConvertWhiteout(c ConvertWhiteout) ApplyOpt {
+	return func(options *ApplyOptions) error {
+		options.ConvertWhiteout = c
 		return nil
 	}
 }

--- a/archive/tar_opts_linux.go
+++ b/archive/tar_opts_linux.go
@@ -1,0 +1,65 @@
+// +build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package archive
+
+import (
+	"archive/tar"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// ApplyOptions provides additional options for an Apply operation
+type ApplyOptions struct {
+	Filter          Filter          // Filter tar headers
+	ConvertWhiteout ConvertWhiteout // Convert whiteout files
+}
+
+// AufsConvertWhiteout converts whiteout files for aufs.
+func AufsConvertWhiteout(_ *tar.Header, _ string) (bool, error) {
+	return true, nil
+}
+
+// OverlayConvertWhiteout converts whiteout files for overlay.
+func OverlayConvertWhiteout(hdr *tar.Header, path string) (bool, error) {
+	base := filepath.Base(path)
+	dir := filepath.Dir(path)
+
+	// if a directory is marked as opaque, we need to translate that to overlay
+	if base == whiteoutOpaqueDir {
+		// don't write the file itself
+		return false, unix.Setxattr(dir, "trusted.overlay.opaque", []byte{'y'}, 0)
+	}
+
+	// if a file was deleted and we are using overlay, we need to create a character device
+	if strings.HasPrefix(base, whiteoutPrefix) {
+		originalBase := base[len(whiteoutPrefix):]
+		originalPath := filepath.Join(dir, originalBase)
+
+		if err := unix.Mknod(originalPath, unix.S_IFCHR, 0); err != nil {
+			return false, err
+		}
+		// don't write the file itself
+		return false, os.Chown(originalPath, hdr.Uid, hdr.Gid)
+	}
+
+	return true, nil
+}

--- a/archive/tar_opts_other.go
+++ b/archive/tar_opts_other.go
@@ -1,0 +1,25 @@
+// +build !linux,!windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package archive
+
+// ApplyOptions provides additional options for an Apply operation
+type ApplyOptions struct {
+	Filter          Filter          // Filter tar headers
+	ConvertWhiteout ConvertWhiteout // Convert whiteout files
+}

--- a/archive/tar_opts_windows.go
+++ b/archive/tar_opts_windows.go
@@ -20,9 +20,10 @@ package archive
 
 // ApplyOptions provides additional options for an Apply operation
 type ApplyOptions struct {
-	ParentLayerPaths        []string // Parent layer paths used for Windows layer apply
-	IsWindowsContainerLayer bool     // True if the tar stream to be applied is a Windows Container Layer
-	Filter                  Filter   // Filter tar headers
+	ParentLayerPaths        []string        // Parent layer paths used for Windows layer apply
+	IsWindowsContainerLayer bool            // True if the tar stream to be applied is a Windows Container Layer
+	Filter                  Filter          // Filter tar headers
+	ConvertWhiteout         ConvertWhiteout // Convert whiteout files
 }
 
 // WithParentLayers adds parent layers to the apply process this is required

--- a/archive/tar_other_test.go
+++ b/archive/tar_other_test.go
@@ -1,0 +1,30 @@
+// +build !linux,!windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package archive
+
+import (
+	"testing"
+
+	"github.com/containerd/containerd/archive/tartest"
+	"github.com/containerd/continuity/fs/fstest"
+)
+
+func runWriterToTarTest(t *testing.T, name string, wt tartest.WriterToTar, a fstest.Applier, validate func(string) error, applyErr error) {
+	t.Run(name, makeWriterToTarNaiveTest(wt, a, validate, applyErr))
+}

--- a/diff/apply/apply_linux.go
+++ b/diff/apply/apply_linux.go
@@ -1,0 +1,90 @@
+// +build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package apply
+
+import (
+	"context"
+	"io"
+	"strings"
+
+	"github.com/containerd/containerd/archive"
+	"github.com/containerd/containerd/mount"
+	"github.com/pkg/errors"
+)
+
+func apply(ctx context.Context, mounts []mount.Mount, r io.Reader) error {
+	switch {
+	case len(mounts) == 1 && mounts[0].Type == "overlay":
+		path, err := getOverlayPath(mounts[0].Options)
+		if err != nil {
+			return err
+		}
+		_, err = archive.Apply(ctx, path, r,
+			archive.WithConvertWhiteout(archive.OverlayConvertWhiteout))
+		return err
+	case len(mounts) == 1 && mounts[0].Type == "aufs":
+		path, err := getAufsPath(mounts[0].Options)
+		if err != nil {
+			return err
+		}
+		_, err = archive.Apply(ctx, path, r,
+			archive.WithConvertWhiteout(archive.AufsConvertWhiteout))
+		return err
+	default:
+		return mount.WithTempMount(ctx, mounts, func(root string) error {
+			_, err := archive.Apply(ctx, root, r)
+			return err
+		})
+	}
+}
+
+func getOverlayPath(options []string) (string, error) {
+	const upperdirPrefix = "upperdir="
+	for _, o := range options {
+		if strings.HasPrefix(o, upperdirPrefix) {
+			return strings.TrimPrefix(o, upperdirPrefix), nil
+		}
+	}
+	return "", errors.New("upperdir not found")
+}
+
+func getAufsPath(options []string) (string, error) {
+	const (
+		sep       = ":"
+		brPrefix1 = "br:"
+		brPrefix2 = "br="
+		rwSuffix  = "=rw"
+	)
+	for _, o := range options {
+		if strings.HasPrefix(o, brPrefix1) {
+			o = strings.TrimPrefix(o, brPrefix1)
+		} else if strings.HasPrefix(o, brPrefix2) {
+			o = strings.TrimPrefix(o, brPrefix2)
+		} else {
+			continue
+		}
+		for _, b := range strings.Split(o, sep) {
+			if strings.HasSuffix(b, rwSuffix) {
+				return strings.TrimSuffix(b, rwSuffix), nil
+			}
+		}
+		break
+	}
+	return "", errors.New("rw branch not found")
+}

--- a/diff/apply/apply_linux_test.go
+++ b/diff/apply/apply_linux_test.go
@@ -1,0 +1,79 @@
+// +build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package apply
+
+import (
+	"testing"
+)
+
+func TestGetOverlayPath(t *testing.T) {
+	good := []string{"upperdir=/test/upper", "lowerdir=/test/lower", "workdir=/test/work"}
+	path, err := getOverlayPath(good)
+	if err != nil {
+		t.Fatalf("Get overlay path failed: %v", err)
+	}
+	if path != "/test/upper" {
+		t.Fatalf("Unexpected upperdir: %q", path)
+	}
+
+	bad := []string{"lowerdir=/test/lower"}
+	_, err = getOverlayPath(bad)
+	if err == nil {
+		t.Fatalf("An error is expected")
+	}
+}
+
+func TestGetAufsPath(t *testing.T) {
+	rwDir := "/test/rw"
+	for _, test := range []struct {
+		options   []string
+		expectErr bool
+	}{
+		{
+			options:   []string{"random:option", "br:" + rwDir + "=rw:/test/ro=ro+wh"},
+			expectErr: false,
+		},
+		{
+			options:   []string{"random:option", "br=" + rwDir + "=rw:/test/ro=ro+wh"},
+			expectErr: false,
+		},
+		{
+			options:   []string{"random:option"},
+			expectErr: true,
+		},
+		{
+			options:   []string{"br:/test/ro=ro+wh"},
+			expectErr: true,
+		},
+	} {
+		path, err := getAufsPath(test.options)
+		if test.expectErr {
+			if err == nil {
+				t.Fatalf("An error is expected")
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("Get aufs path failed: %v", err)
+		}
+		if path != rwDir {
+			t.Fatalf("Unexpected rw dir: %q", path)
+		}
+	}
+}

--- a/diff/apply/apply_other.go
+++ b/diff/apply/apply_other.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !linux
 
 /*
    Copyright The containerd Authors.
@@ -16,9 +16,19 @@
    limitations under the License.
 */
 
-package archive
+package apply
 
-// ApplyOptions provides additional options for an Apply operation
-type ApplyOptions struct {
-	Filter Filter // Filter tar headers
+import (
+	"context"
+	"io"
+
+	"github.com/containerd/containerd/archive"
+	"github.com/containerd/containerd/mount"
+)
+
+func apply(ctx context.Context, mounts []mount.Mount, r io.Reader) error {
+	return mount.WithTempMount(ctx, mounts, func(root string) error {
+		_, err := archive.Apply(ctx, root, r)
+		return err
+	})
 }

--- a/vendor.conf
+++ b/vendor.conf
@@ -86,4 +86,4 @@ github.com/mistifyio/go-zfs 166add352731e515512690329794ee593f1aaff2
 github.com/pborman/uuid c65b2f87fee37d1c7854c9164a450713c28d50cd
 
 # aufs dependencies
-github.com/containerd/aufs da3cf16bfbe68ba8f114f1536a05c01528a25434
+github.com/containerd/aufs 334db59fccc979591f503fc651836f406b0fac07 https://github.com/Random-Liu/aufs

--- a/vendor/github.com/containerd/aufs/README.md
+++ b/vendor/github.com/containerd/aufs/README.md
@@ -21,3 +21,13 @@ import (
 	_ "github.com/containerd/containerd/snapshot/overlay"
 )
 ```
+
+## Project details
+
+aufs is a containerd sub-project, licensed under the [Apache 2.0 license](./LICENSE).
+As a containerd sub-project, you will find the:
+ * [Project governance](https://github.com/containerd/project/blob/master/GOVERNANCE.md),
+ * [Maintainers](https://github.com/containerd/project/blob/master/MAINTAINERS),
+ * and [Contributing guidelines](https://github.com/containerd/project/blob/master/CONTRIBUTING.md)
+
+information in our [`containerd/project`](https://github.com/containerd/project) repository.

--- a/vendor/github.com/containerd/aufs/aufs.go
+++ b/vendor/github.com/containerd/aufs/aufs.go
@@ -1,3 +1,19 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package aufs
 
 import (
@@ -49,7 +65,7 @@ type snapshotter struct {
 
 // New creates a new snapshotter using aufs
 func New(root string) (snapshots.Snapshotter, error) {
-	if err := supported(); err != nil {
+	if err := Supported(); err != nil {
 		return nil, errors.Wrap(plugin.ErrSkipPlugin, err.Error())
 	}
 	if err := os.MkdirAll(root, 0700); err != nil {
@@ -384,7 +400,7 @@ func (o *snapshotter) upperPath(id string) string {
 	return filepath.Join(o.root, "snapshots", id, "fs")
 }
 
-func supported() error {
+func Supported() error {
 	// modprobe the aufs module before checking
 	cmd := exec.Command("modprobe", "aufs")
 	out, err := cmd.CombinedOutput()


### PR DESCRIPTION
For https://github.com/containerd/containerd/issues/2886.

This PR:
1) Added direct unpack support for overlay and aufs;
2) Remove the `.wh..wh.plnk` related logic. It is not defined in the OCI spec; it shouldn't be included in docker image any more; and [Docker overlay2 doesn't handle it](https://github.com/moby/moby/blob/de640c9f4932d851316a0a72470c4d3446f6f5ac/pkg/archive/archive_linux.go#L71).
3) Update some unit test cases correspondingly, please check [this comment](https://github.com/containerd/containerd/issues/2886#issuecomment-450053995) to see why the test update is needed.

Time consumed to pull `k8s.gcr.io/kube-cross:v1.10.3-1` on my machine:
* Containerd HEAD: 40.347s
* Containerd HEAD + this change: 35.65s

Signed-off-by: Lantao Liu <lantaol@google.com>