### PR TITLE
Add containerd_binary to shim config

### DIFF
--- a/cmd/containerd-shim/main_unix.go
+++ b/cmd/containerd-shim/main_unix.go
@@ -146,12 +146,13 @@ func executeShim() error {
 	}
 	sv, err := shim.NewService(
 		shim.Config{
-			Path:          path,
-			Namespace:     namespaceFlag,
-			WorkDir:       workdirFlag,
-			Criu:          criuFlag,
-			SystemdCgroup: systemdCgroupFlag,
-			RuntimeRoot:   runtimeRootFlag,
+			Path:             path,
+			Namespace:        namespaceFlag,
+			WorkDir:          workdirFlag,
+			Criu:             criuFlag,
+			SystemdCgroup:    systemdCgroupFlag,
+			RuntimeRoot:      runtimeRootFlag,
+			ContainerdBinary: containerdBinaryFlag,
 		},
 		&remoteEventsPublisher{address: addressFlag},
 	)

--- a/runtime/v1/linux/bundle.go
+++ b/runtime/v1/linux/bundle.go
@@ -145,12 +145,13 @@ func (b *bundle) shimConfig(namespace string, c *Config, runcOptions *runctypes.
 		}
 	}
 	return shim.Config{
-		Path:          b.path,
-		WorkDir:       b.workDir,
-		Namespace:     namespace,
-		Criu:          criuPath,
-		RuntimeRoot:   runtimeRoot,
-		SystemdCgroup: systemdCgroup,
+		Path:             b.path,
+		WorkDir:          b.workDir,
+		Namespace:        namespace,
+		Criu:             criuPath,
+		RuntimeRoot:      runtimeRoot,
+		SystemdCgroup:    systemdCgroup,
+		ContainerdBinary: c.ContainerdBinary,
 	}
 }
 

--- a/runtime/v1/linux/runtime.go
+++ b/runtime/v1/linux/runtime.go
@@ -90,6 +90,8 @@ type Config struct {
 	Runtime string `toml:"runtime"`
 	// RuntimeRoot is the path that shall be used by the OCI runtime for its data
 	RuntimeRoot string `toml:"runtime_root"`
+	// ContainerdBinary is the path to the containerd binary
+	ContainerdBinary string `toml:"containerd_binary"`
 	// NoShim calls runc directly from within the pkg
 	NoShim bool `toml:"no_shim"`
 	// Debug enable debug on the shim

--- a/runtime/v1/shim/client/client.go
+++ b/runtime/v1/shim/client/client.go
@@ -129,17 +129,21 @@ func WithStart(binary, address, daemonAddress, cgroup string, debug bool, exitHa
 }
 
 func newCommand(binary, daemonAddress string, debug bool, config shim.Config, socket *os.File, stdout, stderr io.Writer) (*exec.Cmd, error) {
-	selfExe, err := os.Executable()
-	if err != nil {
-		return nil, err
-	}
 	args := []string{
 		"-namespace", config.Namespace,
 		"-workdir", config.WorkDir,
 		"-address", daemonAddress,
-		"-containerd-binary", selfExe,
 	}
 
+	if config.ContainerdBinary != "" {
+		args = append(args, "-containerd-binary", config.ContainerdBinary)
+	} else {
+		selfExe, err := os.Executable()
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, "-containerd-binary", selfExe)
+	}
 	if config.Criu != "" {
 		args = append(args, "-criu-path", config.Criu)
 	}

--- a/runtime/v1/shim/service.go
+++ b/runtime/v1/shim/service.go
@@ -62,12 +62,13 @@ var (
 
 // Config contains shim specific configuration
 type Config struct {
-	Path          string
-	Namespace     string
-	WorkDir       string
-	Criu          string
-	RuntimeRoot   string
-	SystemdCgroup bool
+	Path             string
+	Namespace        string
+	WorkDir          string
+	Criu             string
+	RuntimeRoot      string
+	ContainerdBinary string
+	SystemdCgroup    bool
 }
 
 // NewService returns a new shim service that can be used via GRPC


### PR DESCRIPTION
When using `musl` and `gcompat` to run `containerd`, the shim command has the value `/lib/libc.so` for the `-containerd-binary` flag. This is due to the use of `os.Executable` when building the shim command. This PR introduces a new item in the shim config (`containerd_binary`) to set the path to containerd explicitly.

See https://github.com/AdelieLinux/gcompat/blob/master/loader/loader.c#L75-L81 for details on why it is this way with `gcompat`.