### PR TITLE
Fix issue in runhcs shim CloseIO

### DIFF
--- a/runtime/v2/runhcs/io.go
+++ b/runtime/v2/runhcs/io.go
@@ -145,7 +145,7 @@ func (pr *pipeRelay) wait() {
 // closeIO closes stdin to unblock an waiters
 func (pr *pipeRelay) closeIO() {
 	if pr.ps.stdin != nil {
-		pr.ps.Close()
+		pr.ps.stdin.Close()
 		pr.io.Stdin().Close()
 	}
 }


### PR DESCRIPTION
The call was closing all upstream IO when a shim.CloseIO call was made rather
than just the Stdin as it is supposed to.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>