### PR TITLE
Fix a bug in cio.NewDirectIO on Windows

### DIFF
--- a/cio/io.go
+++ b/cio/io.go
@@ -216,6 +216,10 @@ type pipes struct {
 	Stderr io.ReadCloser
 }
 
+func (p *pipes) closers() []io.Closer {
+	return []io.Closer{p.Stdin, p.Stdout, p.Stderr}
+}
+
 // DirectIO allows task IO to be handled externally by the caller
 type DirectIO struct {
 	pipes

--- a/cio/io_unix.go
+++ b/cio/io_unix.go
@@ -152,7 +152,3 @@ func NewDirectIO(ctx context.Context, fifos *FIFOSet) (*DirectIO, error) {
 		},
 	}, err
 }
-
-func (p *pipes) closers() []io.Closer {
-	return []io.Closer{p.Stdin, p.Stdout, p.Stderr}
-}


### PR DESCRIPTION
The NewDirectIO was not properly setting up the io.Closers which can cause an
upstream caller to hang after the downstream pipes complete.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>