### PR TITLE
bump up runc

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -20,7 +20,7 @@ github.com/gogo/protobuf v1.0.0
 github.com/gogo/googleapis 08a7655d27152912db7aaf4f983275eaf8d128ef
 github.com/golang/protobuf v1.1.0
 github.com/opencontainers/runtime-spec eba862dc2470385a233c7507392675cbeadf7353 # v1.0.1-45-geba862d
-github.com/opencontainers/runc 96ec2177ae841256168fcf76954f7177af9446eb
+github.com/opencontainers/runc 12f6a991201fdb8f82579582d5e00e28fba06d0a
 github.com/sirupsen/logrus v1.0.3
 github.com/urfave/cli 7bc6a0acffa589f415f88aca16cc1de5ffd66f9c
 golang.org/x/net b3756b4b77d7b13260a0a2ec658753cf48922eac


### PR DESCRIPTION
Changes: https://github.com/opencontainers/runc/compare/96ec2177ae841256168fcf76954f7177af9446eb...12f6a991201fdb8f82579582d5e00e28fba06d0a

Including critical security fix for `runc run --no-pivot` (`DOCKER_RAMDISK=1`): https://github.com/opencontainers/runc/pull/1962

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>