### PR TITLE
Windows:NewDirectIOFromFIFOSet

### DIFF
--- a/cio/io.go
+++ b/cio/io.go
@@ -275,3 +275,7 @@ func Load(set *FIFOSet) (IO, error) {
 		closers: []io.Closer{set},
 	}, nil
 }
+
+func (p *pipes) closers() []io.Closer {
+	return []io.Closer{p.Stdin, p.Stdout, p.Stderr}
+}

--- a/cio/io_unix.go
+++ b/cio/io_unix.go
@@ -152,7 +152,3 @@ func NewDirectIO(ctx context.Context, fifos *FIFOSet) (*DirectIO, error) {
 		},
 	}, err
 }
-
-func (p *pipes) closers() []io.Closer {
-	return []io.Closer{p.Stdin, p.Stdout, p.Stderr}
-}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Adds ability to create a new `DirectIO` from a FIFOSet. This is needed for the work to get moby on Windows to use containerd for the runtime. This PR replaces https://github.com/containerd/containerd/pull/2928. You can see a working version of this PR hacked in my moby WIP PR at https://github.com/moby/moby/pull/38541.

@jterry75 FYI