### PR TITLE
Implement the Runtime v2 Shim async task model for runhcs

### DIFF
--- a/runtime/v2/binary.go
+++ b/runtime/v2/binary.go
@@ -24,7 +24,6 @@ import (
 	gruntime "runtime"
 	"strings"
 
-	eventstypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/events/exchange"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/runtime"
@@ -152,13 +151,6 @@ func (b *binary) Delete(ctx context.Context) (*runtime.Exit, error) {
 	// remove self from the runtime task list
 	// this seems dirty but it cleans up the API across runtimes, tasks, and the service
 	b.rtTasks.Delete(ctx, b.bundle.ID)
-	// shim will send the exit event
-	b.events.Publish(ctx, runtime.TaskDeleteEventTopic, &eventstypes.TaskDelete{
-		ContainerID: b.bundle.ID,
-		ExitStatus:  response.ExitStatus,
-		ExitedAt:    response.ExitedAt,
-		Pid:         response.Pid,
-	})
 	return &runtime.Exit{
 		Status:    response.ExitStatus,
 		Timestamp: response.ExitedAt,

--- a/runtime/v2/process.go
+++ b/runtime/v2/process.go
@@ -19,7 +19,6 @@ package v2
 import (
 	"context"
 
-	eventstypes "github.com/containerd/containerd/api/events"
 	tasktypes "github.com/containerd/containerd/api/types/task"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/runtime"
@@ -114,18 +113,13 @@ func (p *process) CloseIO(ctx context.Context) error {
 
 // Start the process
 func (p *process) Start(ctx context.Context) error {
-	response, err := p.shim.task.Start(ctx, &task.StartRequest{
+	_, err := p.shim.task.Start(ctx, &task.StartRequest{
 		ID:     p.shim.ID(),
 		ExecID: p.id,
 	})
 	if err != nil {
 		return errdefs.FromGRPC(err)
 	}
-	p.shim.events.Publish(ctx, runtime.TaskExecStartedEventTopic, &eventstypes.TaskExecStarted{
-		ContainerID: p.shim.ID(),
-		Pid:         response.Pid,
-		ExecID:      p.id,
-	})
 	return nil
 }
 

--- a/runtime/v2/shim.go
+++ b/runtime/v2/shim.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"time"
 
-	eventstypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/api/types"
 	tasktypes "github.com/containerd/containerd/api/types/task"
 	"github.com/containerd/containerd/errdefs"
@@ -163,12 +162,6 @@ func (s *shim) Delete(ctx context.Context) (*runtime.Exit, error) {
 	// remove self from the runtime task list
 	// this seems dirty but it cleans up the API across runtimes, tasks, and the service
 	s.rtTasks.Delete(ctx, s.ID())
-	s.events.Publish(ctx, runtime.TaskDeleteEventTopic, &eventstypes.TaskDelete{
-		ContainerID: s.ID(),
-		ExitStatus:  response.ExitStatus,
-		ExitedAt:    response.ExitedAt,
-		Pid:         response.Pid,
-	})
 	return &runtime.Exit{
 		Status:    response.ExitStatus,
 		Timestamp: response.ExitedAt,
@@ -212,9 +205,6 @@ func (s *shim) Pause(ctx context.Context) error {
 	}); err != nil {
 		return errdefs.FromGRPC(err)
 	}
-	s.events.Publish(ctx, runtime.TaskPausedEventTopic, &eventstypes.TaskPaused{
-		ContainerID: s.ID(),
-	})
 	return nil
 }
 
@@ -224,9 +214,6 @@ func (s *shim) Resume(ctx context.Context) error {
 	}); err != nil {
 		return errdefs.FromGRPC(err)
 	}
-	s.events.Publish(ctx, runtime.TaskResumedEventTopic, &eventstypes.TaskResumed{
-		ContainerID: s.ID(),
-	})
 	return nil
 }
 
@@ -238,10 +225,6 @@ func (s *shim) Start(ctx context.Context) error {
 		return errdefs.FromGRPC(err)
 	}
 	s.taskPid = int(response.Pid)
-	s.events.Publish(ctx, runtime.TaskStartEventTopic, &eventstypes.TaskStart{
-		ContainerID: s.ID(),
-		Pid:         uint32(s.taskPid),
-	})
 	return nil
 }
 
@@ -340,9 +323,6 @@ func (s *shim) Checkpoint(ctx context.Context, path string, options *ptypes.Any)
 	if _, err := s.task.Checkpoint(ctx, request); err != nil {
 		return errdefs.FromGRPC(err)
 	}
-	s.events.Publish(ctx, runtime.TaskCheckpointedEventTopic, &eventstypes.TaskCheckpointed{
-		ContainerID: s.ID(),
-	})
 	return nil
 }
 


### PR DESCRIPTION
Changes the requirement of a Runtime v2 shim in order to avoid race conditions
between shim and shim client sending async events. Places a requirement of what
events and what order a shim must comply to.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>