### PR TITLE
fix: linter issue

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -10,7 +10,6 @@
 
   "Enable": [
     "structcheck",
-    "unused",
     "varcheck",
     "staticcheck",
     "unconvert",

--- a/archive/tar_test.go
+++ b/archive/tar_test.go
@@ -329,7 +329,7 @@ func TestBreakouts(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			if bytes.Compare(b, content) != 0 {
+			if !bytes.Equal(b, content) {
 				return errors.Errorf("content differs: expected %v, got %v", content, b)
 			}
 			return nil
@@ -1179,7 +1179,7 @@ func fileEntry(name string, expected []byte, mode int) tarEntryValidator {
 		if hdr.Mode != int64(mode) {
 			return errors.Errorf("wrong mode %o, expected %o", hdr.Mode, mode)
 		}
-		if bytes.Compare(b, expected) != 0 {
+		if !bytes.Equal(b, expected) {
 			return errors.Errorf("different file content")
 		}
 		return nil

--- a/archive/tar_windows.go
+++ b/archive/tar_windows.go
@@ -74,7 +74,7 @@ func tarName(p string) (string, error) {
 	// in file names, it is mostly safe to replace however we must
 	// check just in case
 	if strings.Contains(p, "/") {
-		return "", fmt.Errorf("Windows path contains forward slash: %s", p)
+		return "", fmt.Errorf("windows path contains forward slash: %s", p)
 	}
 
 	return strings.Replace(p, string(os.PathSeparator), "/", -1), nil
@@ -130,11 +130,7 @@ func skipFile(hdr *tar.Header) bool {
 	// specific or Linux-specific, this warning should be changed to an error
 	// to cater for the situation where someone does manage to upload a Linux
 	// image but have it tagged as Windows inadvertently.
-	if strings.Contains(hdr.Name, ":") {
-		return true
-	}
-
-	return false
+	return strings.Contains(hdr.Name, ":")
 }
 
 // handleTarTypeBlockCharFifo is an OS-specific helper function used by

--- a/cmd/containerd/command/service_windows.go
+++ b/cmd/containerd/command/service_windows.go
@@ -387,18 +387,16 @@ func (h *handler) Execute(_ []string, r <-chan svc.ChangeRequest, s chan<- svc.S
 	h.fromsvc <- nil
 
 	s <- svc.Status{State: svc.Running, Accepts: svc.AcceptStop | svc.AcceptShutdown | svc.Accepted(windows.SERVICE_ACCEPT_PARAMCHANGE)}
+
 Loop:
-	for {
-		select {
-		case c := <-r:
-			switch c.Cmd {
-			case svc.Interrogate:
-				s <- c.CurrentStatus
-			case svc.Stop, svc.Shutdown:
-				s <- svc.Status{State: svc.StopPending, Accepts: 0}
-				h.s.Stop()
-				break Loop
-			}
+	for c := range r {
+		switch c.Cmd {
+		case svc.Interrogate:
+			s <- c.CurrentStatus
+		case svc.Stop, svc.Shutdown:
+			s <- svc.Status{State: svc.StopPending, Accepts: 0}
+			h.s.Stop()
+			break Loop
 		}
 	}
 

--- a/container_linux_test.go
+++ b/container_linux_test.go
@@ -1120,7 +1120,7 @@ func TestDaemonRestartWithRunningShim(t *testing.T) {
 	}
 
 	pid := task.Pid()
-	if pid <= 0 {
+	if pid < 1 {
 		t.Fatalf("invalid task pid %d", pid)
 	}
 
@@ -1410,7 +1410,7 @@ func testUserNamespaces(t *testing.T, readonlyRootFS bool) {
 		t.Fatal(err)
 	}
 
-	if pid := task.Pid(); pid <= 0 {
+	if pid := task.Pid(); pid < 1 {
 		t.Errorf("invalid task pid %d", pid)
 	}
 	if err := task.Start(ctx); err != nil {

--- a/container_test.go
+++ b/container_test.go
@@ -136,7 +136,7 @@ func TestContainerStart(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if pid := task.Pid(); pid <= 0 {
+	if pid := task.Pid(); pid < 1 {
 		t.Errorf("invalid task pid %d", pid)
 	}
 	if err := task.Start(ctx); err != nil {
@@ -435,7 +435,7 @@ func TestContainerPids(t *testing.T) {
 	}
 
 	pid := task.Pid()
-	if pid <= 0 {
+	if pid < 1 {
 		t.Errorf("invalid task pid %d", pid)
 	}
 	processes, err := task.Pids(ctx)
@@ -785,7 +785,7 @@ func TestWaitStoppedTask(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if pid := task.Pid(); pid <= 0 {
+	if pid := task.Pid(); pid < 1 {
 		t.Errorf("invalid task pid %d", pid)
 	}
 	if err := task.Start(ctx); err != nil {

--- a/content/local/locks.go
+++ b/content/local/locks.go
@@ -47,7 +47,5 @@ func unlock(ref string) {
 	locksMu.Lock()
 	defer locksMu.Unlock()
 
-	if _, ok := locks[ref]; ok {
-		delete(locks, ref)
-	}
+	delete(locks, ref)
 }

--- a/diff/apply/apply.go
+++ b/diff/apply/apply.go
@@ -58,7 +58,7 @@ func (s *fsApplier) Apply(ctx context.Context, desc ocispec.Descriptor, mounts [
 	defer func() {
 		if err == nil {
 			log.G(ctx).WithFields(logrus.Fields{
-				"d":     time.Now().Sub(t1),
+				"d":     time.Since(t1),
 				"dgst":  desc.Digest,
 				"size":  desc.Size,
 				"media": desc.MediaType,

--- a/diff/lcow/lcow.go
+++ b/diff/lcow/lcow.go
@@ -99,7 +99,7 @@ func (s windowsLcowDiff) Apply(ctx context.Context, desc ocispec.Descriptor, mou
 	defer func() {
 		if err == nil {
 			log.G(ctx).WithFields(logrus.Fields{
-				"d":     time.Now().Sub(t1),
+				"d":     time.Since(t1),
 				"dgst":  desc.Digest,
 				"size":  desc.Size,
 				"media": desc.MediaType,

--- a/diff/windows/windows.go
+++ b/diff/windows/windows.go
@@ -92,7 +92,7 @@ func (s windowsDiff) Apply(ctx context.Context, desc ocispec.Descriptor, mounts 
 	defer func() {
 		if err == nil {
 			log.G(ctx).WithFields(logrus.Fields{
-				"d":     time.Now().Sub(t1),
+				"d":     time.Since(t1),
 				"dgst":  desc.Digest,
 				"size":  desc.Size,
 				"media": desc.MediaType,

--- a/filters/scanner.go
+++ b/filters/scanner.go
@@ -185,7 +185,6 @@ func (s *scanner) scanQuoted(quote rune) {
 			ch = s.next()
 		}
 	}
-	return
 }
 
 func (s *scanner) scanEscape(quote rune) rune {

--- a/import.go
+++ b/import.go
@@ -99,8 +99,7 @@ func (c *Client) Import(ctx context.Context, reader io.Reader, opts ...ImportOpt
 		})
 	}
 
-	var handler images.HandlerFunc
-	handler = func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+	var handler images.HandlerFunc = func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 		// Only save images at top level
 		if desc.Digest != index.Digest {
 			return images.Children(ctx, cs, desc)

--- a/metadata/content.go
+++ b/metadata/content.go
@@ -779,7 +779,7 @@ func (cs *contentStore) garbageCollect(ctx context.Context) (d time.Duration, er
 	t1 := time.Now()
 	defer func() {
 		if err == nil {
-			d = time.Now().Sub(t1)
+			d = time.Since(t1)
 		}
 		cs.l.Unlock()
 	}()

--- a/metadata/db.go
+++ b/metadata/db.go
@@ -176,7 +176,7 @@ func (m *DB) Init(ctx context.Context) error {
 				if err := m.migrate(tx); err != nil {
 					return errors.Wrapf(err, "failed to migrate to %s.%d", m.schema, m.version)
 				}
-				log.G(ctx).WithField("d", time.Now().Sub(t0)).Debugf("finished database migration to %s.%d", m.schema, m.version)
+				log.G(ctx).WithField("d", time.Since(t0)).Debugf("finished database migration to %s.%d", m.schema, m.version)
 			}
 		}
 
@@ -328,7 +328,7 @@ func (m *DB) GarbageCollect(ctx context.Context) (gc.Stats, error) {
 				m.cleanupSnapshotter(snapshotterName)
 
 				sl.Lock()
-				stats.SnapshotD[snapshotterName] = time.Now().Sub(st1)
+				stats.SnapshotD[snapshotterName] = time.Since(st1)
 				sl.Unlock()
 
 				wg.Done()
@@ -343,7 +343,7 @@ func (m *DB) GarbageCollect(ctx context.Context) (gc.Stats, error) {
 		go func() {
 			ct1 := time.Now()
 			m.cleanupContent()
-			stats.ContentD = time.Now().Sub(ct1)
+			stats.ContentD = time.Since(ct1)
 			wg.Done()
 		}()
 		m.dirtyCS = false
@@ -351,7 +351,7 @@ func (m *DB) GarbageCollect(ctx context.Context) (gc.Stats, error) {
 
 	m.dirtyL.Unlock()
 
-	stats.MetaD = time.Now().Sub(t1)
+	stats.MetaD = time.Since(t1)
 	m.wlock.Unlock()
 
 	wg.Wait()

--- a/metadata/snapshot.go
+++ b/metadata/snapshot.go
@@ -628,7 +628,7 @@ func (s *snapshotter) garbageCollect(ctx context.Context) (d time.Duration, err 
 			}
 		}
 		if err == nil {
-			d = time.Now().Sub(t1)
+			d = time.Since(t1)
 		}
 	}()
 

--- a/pkg/progress/escape.go
+++ b/pkg/progress/escape.go
@@ -19,6 +19,6 @@ package progress
 const (
 	escape = "\x1b"
 	reset  = escape + "[0m"
-	red    = escape + "[31m" // nolint: unused, varcheck
+	red    = escape + "[31m" // nolint: staticcheck, varcheck
 	green  = escape + "[32m"
 )

--- a/pkg/testutil/helpers_unix.go
+++ b/pkg/testutil/helpers_unix.go
@@ -49,7 +49,7 @@ func RequiresRootM() {
 		fmt.Fprintln(os.Stderr, "skipping test that requires root")
 		os.Exit(0)
 	}
-	if 0 != os.Getuid() {
+	if os.Getuid() != 0 {
 		fmt.Fprintln(os.Stderr, "This test must be run as root.")
 		os.Exit(1)
 	}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -42,10 +42,7 @@ var (
 
 // IsSkipPlugin returns true if the error is skipping the plugin
 func IsSkipPlugin(err error) bool {
-	if errors.Cause(err) == ErrSkipPlugin {
-		return true
-	}
-	return false
+	return errors.Cause(err) == ErrSkipPlugin
 }
 
 // Type is the type of the plugin

--- a/remotes/docker/auth.go
+++ b/remotes/docker/auth.go
@@ -79,8 +79,8 @@ func init() {
 		var t octetType
 		isCtl := c <= 31 || c == 127
 		isChar := 0 <= c && c <= 127
-		isSeparator := strings.IndexRune(" \t\"(),/:;<=>?@[]\\{}", rune(c)) >= 0
-		if strings.IndexRune(" \t\r\n", rune(c)) >= 0 {
+		isSeparator := strings.ContainsRune(" \t\"(),/:;<=>?@[]\\{}", rune(c))
+		if strings.ContainsRune(" \t\r\n", rune(c)) {
 			t |= isSpace
 		}
 		if isChar && !isCtl && !isSeparator {

--- a/runtime/v2/shim/shim_unix.go
+++ b/runtime/v2/shim/shim_unix.go
@@ -76,9 +76,9 @@ func serveListener(path string) (net.Listener, error) {
 
 func handleSignals(logger *logrus.Entry, signals chan os.Signal) error {
 	logger.Info("starting signal loop")
+
 	for {
-		select {
-		case s := <-signals:
+		for s := range signals {
 			switch s {
 			case unix.SIGCHLD:
 				if err := Reap(); err != nil {

--- a/runtime/v2/shim/shim_windows.go
+++ b/runtime/v2/shim/shim_windows.go
@@ -108,12 +108,11 @@ func serveListener(path string) (net.Listener, error) {
 
 func handleSignals(logger *logrus.Entry, signals chan os.Signal) error {
 	logger.Info("starting signal loop")
+
 	for {
-		select {
-		case s := <-signals:
+		for s := range signals {
 			switch s {
 			case os.Interrupt:
-				break
 			}
 		}
 	}

--- a/runtime/v2/shim/util_windows.go
+++ b/runtime/v2/shim/util_windows.go
@@ -54,7 +54,7 @@ func AnonDialer(address string, timeout time.Duration) (net.Conn, error) {
 	timedOutError := errors.Errorf("timed out waiting for npipe %s", address)
 	start := time.Now()
 	for {
-		remaining := timeout - time.Now().Sub(start)
+		remaining := timeout - time.Since(start)
 		if remaining <= 0 {
 			lastError = timedOutError
 			break
@@ -71,7 +71,7 @@ func AnonDialer(address string, timeout time.Duration) (net.Conn, error) {
 		// serve it within 5 seconds. We use the passed in timeout for the
 		// `DialPipe` timeout if the pipe exists however to give the pipe time
 		// to `Accept` the connection.
-		if time.Now().Sub(start) >= 5*time.Second {
+		if time.Since(start) >= 5*time.Second {
 			lastError = timedOutError
 			break
 		}

--- a/services/containers/local.go
+++ b/services/containers/local.go
@@ -147,9 +147,7 @@ func (l *local) Update(ctx context.Context, req *api.UpdateContainerRequest, _ .
 	if err := l.withStoreUpdate(ctx, func(ctx context.Context, store containers.Store) error {
 		var fieldpaths []string
 		if req.UpdateMask != nil && len(req.UpdateMask.Paths) > 0 {
-			for _, path := range req.UpdateMask.Paths {
-				fieldpaths = append(fieldpaths, path)
-			}
+			fieldpaths = append(fieldpaths, req.UpdateMask.Paths...)
 		}
 
 		updated, err := store.Update(ctx, container, fieldpaths...)

--- a/services/images/local.go
+++ b/services/images/local.go
@@ -137,9 +137,7 @@ func (l *local) Update(ctx context.Context, req *imagesapi.UpdateImageRequest, _
 	)
 
 	if req.UpdateMask != nil && len(req.UpdateMask.Paths) > 0 {
-		for _, path := range req.UpdateMask.Paths {
-			fieldpaths = append(fieldpaths, path)
-		}
+		fieldpaths = append(fieldpaths, req.UpdateMask.Paths...)
 	}
 
 	updated, err := l.store.Update(ctx, image, fieldpaths...)


### PR DESCRIPTION
megacheck, gosimple and unused has been deprecated and subsumed by
staticcheck. And staticcheck also has been upgraded. we need to update
code for the linter issue.

close: #2945

Signed-off-by: Wei Fu <fuweid89@gmail.com>