### PR TITLE
[release/1.2 backport] fix: SCHILY.xattrs should be SCHILY.xattr

### DIFF
--- a/archive/tar.go
+++ b/archive/tar.go
@@ -100,7 +100,7 @@ const (
 	// readdir calls to this directory do not follow to lower layers.
 	whiteoutOpaqueDir = whiteoutMetaPrefix + ".opq"
 
-	paxSchilyXattr = "SCHILY.xattrs."
+	paxSchilyXattr = "SCHILY.xattr."
 )
 
 // Apply applies a tar stream of an OCI style diff tar.


### PR DESCRIPTION
backport of https://github.com/containerd/containerd/pull/2873 for 1.2. Relates to https://github.com/containerd/containerd/issues/2942



from golang code
https://github.com/golang/go/blob/bad6b6fa9190e9079a6d6958859856a66f0fab87/src/archive/tar/common.go#L110

add unit test for tar xattr

Fixes: #2863

Signed-off-by: Ace-Tang <aceapril@126.com>
(cherry picked from commit 6f944e41909625e90540585c0032a33c9b5be801)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>