### PR TITLE
[release/1.1 backport] fix: SCHILY.xattrs should be SCHILY.xattr

### DIFF
--- a/archive/tar.go
+++ b/archive/tar.go
@@ -100,7 +100,7 @@ const (
 	// readdir calls to this directory do not follow to lower layers.
 	whiteoutOpaqueDir = whiteoutMetaPrefix + ".opq"
 
-	paxSchilyXattr = "SCHILY.xattrs."
+	paxSchilyXattr = "SCHILY.xattr."
 )
 
 // Apply applies a tar stream of an OCI style diff tar.

--- a/archive/tar_test.go
+++ b/archive/tar_test.go
@@ -22,6 +22,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -32,6 +33,7 @@ import (
 
 	_ "crypto/sha256"
 
+	"github.com/containerd/containerd/testutil"
 	"github.com/containerd/continuity/fs"
 	"github.com/containerd/continuity/fs/fstest"
 	"github.com/pkg/errors"
@@ -179,6 +181,50 @@ func TestSymlinks(t *testing.T) {
 		if err := testDiffApply(l[0], l[1]); err != nil {
 			t.Fatalf("Test[%d] apply failed: %+v", i+1, err)
 		}
+	}
+}
+
+func TestTarWithXattr(t *testing.T) {
+	testutil.RequiresRoot(t)
+
+	fileXattrExist := func(f1, xattrKey, xattrValue string) func(string) error {
+		return func(root string) error {
+			values, err := getxattr(filepath.Join(root, f1), xattrKey)
+			if err != nil {
+				return err
+			}
+			if xattrValue != string(values) {
+				return fmt.Errorf("file xattrs expect to be %s, actually get %s", xattrValue, values)
+			}
+			return nil
+		}
+	}
+
+	tests := []struct {
+		name  string
+		key   string
+		value string
+		err   error
+	}{
+		{
+			name:  "WithXattrsUser",
+			key:   "user.key",
+			value: "value",
+		},
+		{
+			// security related xattrs need root permission to test
+			name:  "WithXattrSelinux",
+			key:   "security.selinux",
+			value: "unconfined_u:object_r:default_t:s0\x00",
+		},
+	}
+	for _, at := range tests {
+		tc := TarContext{}.WithUIDGID(os.Getuid(), os.Getgid()).WithModTime(time.Now().UTC()).WithXattrs(map[string]string{
+			at.key: at.value,
+		})
+		w := TarAll(tc.File("/file", []byte{}, 0755))
+		validator := fileXattrExist("file", at.key, at.value)
+		t.Run(at.name, makeWriterToTarTest(w, nil, validator, at.err))
 	}
 }
 


### PR DESCRIPTION
backport of https://github.com/containerd/containerd/pull/2873 for 1.1. Relates to https://github.com/containerd/containerd/issues/2942


**cherry-pick was not clean** conflicts in archive/tar_test.go, due to https://github.com/containerd/containerd/commit/b6107dca86c9755599071e0ac817dd4e8a7251d6 (https://github.com/containerd/containerd/pull/2696) missing, which moved some things to `archive/tartest`. I resolved those conflicts by removing the `tartest.` package name from the test, and removed the import.



from golang code
https://github.com/golang/go/blob/bad6b6fa9190e9079a6d6958859856a66f0fab87/src/archive/tar/common.go#L110

add unit test for tar xattr

Fixes: #2863

Signed-off-by: Ace-Tang <aceapril@126.com>
(cherry picked from commit 6f944e41909625e90540585c0032a33c9b5be801)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>