### PR TITLE
Add support for containerd shim activation's within the same folder not in PATH

### DIFF
--- a/runtime/v2/shim/util.go
+++ b/runtime/v2/shim/util.go
@@ -31,8 +31,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const shimBinaryFormat = "containerd-shim-%s-%s"
-
 var runtimePaths sync.Map
 
 // Command returns the shim command with the provided args and configuration

--- a/runtime/v2/shim/util_unix.go
+++ b/runtime/v2/shim/util_unix.go
@@ -31,6 +31,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const shimBinaryFormat = "containerd-shim-%s-%s"
+
 func getSysProcAttr() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{
 		Setpgid: true,

--- a/runtime/v2/shim/util_windows.go
+++ b/runtime/v2/shim/util_windows.go
@@ -29,6 +29,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const shimBinaryFormat = "containerd-shim-%s-%s.exe"
+
 func getSysProcAttr() *syscall.SysProcAttr {
 	return nil
 }

--- a/vendor.conf
+++ b/vendor.conf
@@ -33,7 +33,7 @@ golang.org/x/sync 450f422ab23cf9881c94e2db30cac0eb1b7cf80c
 github.com/BurntSushi/toml a368813c5e648fee92e5f6c30e3944ff9d5e8895
 github.com/grpc-ecosystem/go-grpc-prometheus 6b7015e65d366bf3f19b2b2a000a831940f0f7e0
 github.com/Microsoft/go-winio v0.4.11
-github.com/Microsoft/hcsshim v0.8.4
+github.com/Microsoft/hcsshim v0.8.5
 google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
 golang.org/x/text 19e51611da83d6be54ddafce4a4af510cb3e9ea4
 github.com/containerd/ttrpc f02858b1457c5ca3aaec3a0803eb0d59f96e41d6


### PR DESCRIPTION
Adds fallback support for `exec.LookPath` which will not find the executable next to `containerd.exe` if `containerd.exe` was started from a different folder than where it is currently running. This fix will use the `containerd` binary path as a last resort to locate the shim if the shim itself is not found in the PATH.