### PR TITLE
Update snapshots docs with garbage collector label

### DIFF
--- a/snapshots/snapshotter.go
+++ b/snapshots/snapshotter.go
@@ -160,9 +160,13 @@ func (u *Usage) Add(other Usage) {
 //	layerPath, tmpDir := getLayerPath(), mkTmpDir() // just a path to layer tar file.
 //
 // We start by using a Snapshotter to Prepare a new snapshot transaction, using a
-// key and descending from the empty parent "":
+// key and descending from the empty parent "". To prevent our layer from being
+// garbage collected during unpacking, we add the `containerd.io/gc.root` label:
 //
-//	mounts, err := snapshotter.Prepare(ctx, key, "")
+//	noGcOpt := snapshotter.WithLabels(map[string]string{
+//		"containerd.io/gc.root": time.Now().UTC().Format(time.RFC3339),
+//	})
+//	mounts, err := snapshotter.Prepare(ctx, key, "", noGcOpt)
 // 	if err != nil { ... }
 //
 // We get back a list of mounts from Snapshotter.Prepare, with the key identifying
@@ -191,15 +195,13 @@ func (u *Usage) Add(other Usage) {
 //
 // Now that we've verified and unpacked our layer, we commit the active
 // snapshot to a name. For this example, we are just going to use the layer
-// digest, but in practice, this will probably be the ChainID:
+// digest, but in practice, this will probably be the ChainID. This also removes
+// the active snapshot:
 //
-//	if err := snapshotter.Commit(ctx, digest.String(), key); err != nil { ... }
+//	if err := snapshotter.Commit(ctx, digest.String(), key, noGcOpt); err != nil { ... }
 //
 // Now, we have a layer in the Snapshotter that can be accessed with the digest
-// provided during commit. Once you have committed the snapshot, the active
-// snapshot can be removed with the following:
-//
-// 	snapshotter.Remove(ctx, key)
+// provided during commit.
 //
 // Importing the Next Layer
 //
@@ -207,7 +209,7 @@ func (u *Usage) Add(other Usage) {
 // above except that the parent is provided as parent when calling
 // Manager.Prepare, assuming a clean, unique key identifier:
 //
-// 	mounts, err := snapshotter.Prepare(ctx, key, parentDigest)
+// 	mounts, err := snapshotter.Prepare(ctx, key, parentDigest, noGcOpt)
 //
 // We then mount, apply and commit, as we did above. The new snapshot will be
 // based on the content of the previous one.


### PR DESCRIPTION
Fixes #2941. When following the normal snapshots tutorial, any delay or unpacking large layers lets the garbage collector delete the snapshot in use. Add a no garbage collector label to the docs to make that clear.
Also, calling `Commit` should [remove the active snapshot](https://github.com/containerd/containerd/blob/f35c3527b24b728bb87788f647fbe7f205c20c7d/snapshots/snapshotter.go#L299) so no need to do that in the tutorial.

Signed-off-by: Oliver Stenbom <oliver@stenbom.eu>