### PR TITLE
metadata/gc: remove the noop-loop for snapshot reference

### DIFF
--- a/metadata/gc.go
+++ b/metadata/gc.go
@@ -296,10 +296,6 @@ func references(ctx context.Context, tx *bolt.Tx, node gc.Node, fn func(gc.Node)
 
 		bkt := getBucket(tx, bucketKeyVersion, []byte(node.Namespace), bucketKeyObjectSnapshots, []byte(ss), []byte(name))
 		if bkt == nil {
-			getBucket(tx, bucketKeyVersion, []byte(node.Namespace), bucketKeyObjectSnapshots).ForEach(func(k, v []byte) error {
-				return nil
-			})
-
 			// Node may be created from dead edge
 			return nil
 		}


### PR DESCRIPTION
The noop-loop does nothing.

The containerd doesn't have any snapshotter buckets at the beginning.
If user uses specific dir as rootfs to create container, and sets
`snapshotter` key to the container, like `overlayfs` by mistake,
the gc scheduler will try to scan the snapshotter and panic.

In order to avoid this case, remove the noop-loop here.

Signed-off-by: Wei Fu <fuweid89@gmail.com>

for example, 

![image](https://user-images.githubusercontent.com/17510957/51904637-1e614c80-23fa-11e9-9216-15eec780f93d.png)
