### PR TITLE
readme: fix example for checkpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,11 +172,9 @@ checkpoint, err := task.Checkpoint(context)
 err := client.Push(context, "myregistry/checkpoints/redis:master", checkpoint)
 
 // on a new machine pull the checkpoint and restore the redis container
-image, err := client.Pull(context, "myregistry/checkpoints/redis:master")
+checkpoint, err := client.Pull(context, "myregistry/checkpoints/redis:master")
 
-checkpoint := image.Target()
-
-redis, err = client.NewContainer(context, "redis-master", containerd.WithCheckpoint(checkpoint, "redis-rootfs"))
+redis, err = client.NewContainer(context, "redis-master", containerd.WithNewSnapshot("redis-rootfs", checkpoint))
 defer container.Delete(context)
 
 task, err = redis.NewTask(context, cio.Stdio, containerd.WithTaskCheckpoint(checkpoint))


### PR DESCRIPTION
fix example for checkpoint usage.
1) change `containerd.WithCheckpoint(checkpoint, "redis-rootfs")` to `containerd.WithNewSnapshot("redis-rootfs", checkpoint)`
2) `containerd.WithTaskCheckpoint(checkpoint)` , checkpint should be type `Image`