### PR TITLE
OCI Modifiers for Windows

### DIFF
--- a/cmd/ctr/commands/run/run_windows.go
+++ b/cmd/ctr/commands/run/run_windows.go
@@ -64,6 +64,8 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 			opts = append(opts, oci.WithRootFSPath(""))
 		} else {
 			opts = append(opts, oci.WithDefaultSpec())
+			opts = append(opts, oci.WithWindowNetworksAllowUnqualifiedDNSQuery())
+			opts = append(opts, oci.WithWindowsIgnoreFlushesDuringBoot())
 		}
 		opts = append(opts, oci.WithEnv(context.StringSlice("env")))
 		opts = append(opts, withMounts(context))

--- a/oci/spec.go
+++ b/oci/spec.go
@@ -247,17 +247,8 @@ func populateDefaultWindowsSpec(ctx context.Context, s *Spec, id string) error {
 		Root:    &specs.Root{},
 		Process: &specs.Process{
 			Cwd: `C:\`,
-			ConsoleSize: &specs.Box{
-				Width:  80,
-				Height: 20,
-			},
 		},
-		Windows: &specs.Windows{
-			IgnoreFlushesDuringBoot: true,
-			Network: &specs.WindowsNetwork{
-				AllowUnqualifiedDNSQuery: true,
-			},
-		},
+		Windows: &specs.Windows{},
 	}
 	return nil
 }

--- a/oci/spec_opts_windows.go
+++ b/oci/spec_opts_windows.go
@@ -39,3 +39,29 @@ func WithWindowsCPUCount(count uint64) SpecOpts {
 		return nil
 	}
 }
+
+// WithWindowsIgnoreFlushesDuringBoot sets `Windows.IgnoreFlushesDuringBoot`.
+func WithWindowsIgnoreFlushesDuringBoot() SpecOpts {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
+		if s.Windows == nil {
+			s.Windows = &specs.Windows{}
+		}
+		s.Windows.IgnoreFlushesDuringBoot = true
+		return nil
+	}
+}
+
+// WithWindowNetworksAllowUnqualifiedDNSQuery sets `Windows.IgnoreFlushesDuringBoot`.
+func WithWindowNetworksAllowUnqualifiedDNSQuery() SpecOpts {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
+		if s.Windows == nil {
+			s.Windows = &specs.Windows{}
+		}
+		if s.Windows.Network == nil {
+			s.Windows.Network = &specs.WindowsNetwork{}
+		}
+
+		s.Windows.Network.AllowUnqualifiedDNSQuery = true
+		return nil
+	}
+}

--- a/oci/spec_opts_windows_test.go
+++ b/oci/spec_opts_windows_test.go
@@ -56,3 +56,57 @@ func TestWithCPUCount(t *testing.T) {
 		}
 	}
 }
+
+func TestWithWindowsIgnoreFlushesDuringBoot(t *testing.T) {
+	var (
+		ctx = namespaces.WithNamespace(context.Background(), "testing")
+		c   = containers.Container{ID: t.Name()}
+		o   = WithWindowsIgnoreFlushesDuringBoot()
+	)
+	// Test with all supported scenarios
+	platforms := []string{"", "windows/amd64"}
+	for _, p := range platforms {
+		var spec *Spec
+		var err error
+		if p == "" {
+			t.Log("Testing GenerateSpec default platform")
+			spec, err = GenerateSpec(ctx, nil, &c, o)
+		} else {
+			t.Logf("Testing GenerateSpecWithPlatform with platform: '%s'", p)
+			spec, err = GenerateSpecWithPlatform(ctx, nil, p, &c, o)
+		}
+		if err != nil {
+			t.Fatalf("failed to generate spec with: %v", err)
+		}
+		if spec.Windows.IgnoreFlushesDuringBoot != true {
+			t.Fatalf("spec.Windows.IgnoreFlushesDuringBoot expected: true")
+		}
+	}
+}
+
+func TestWithWindowNetworksAllowUnqualifiedDNSQuery(t *testing.T) {
+	var (
+		ctx = namespaces.WithNamespace(context.Background(), "testing")
+		c   = containers.Container{ID: t.Name()}
+		o   = WithWindowNetworksAllowUnqualifiedDNSQuery()
+	)
+	// Test with all supported scenarios
+	platforms := []string{"", "windows/amd64"}
+	for _, p := range platforms {
+		var spec *Spec
+		var err error
+		if p == "" {
+			t.Log("Testing GenerateSpec default platform")
+			spec, err = GenerateSpec(ctx, nil, &c, o)
+		} else {
+			t.Logf("Testing GenerateSpecWithPlatform with platform: '%s'", p)
+			spec, err = GenerateSpecWithPlatform(ctx, nil, p, &c, o)
+		}
+		if err != nil {
+			t.Fatalf("failed to generate spec with: %v", err)
+		}
+		if spec.Windows.Network.AllowUnqualifiedDNSQuery != true {
+			t.Fatalf("spec.Windows.Network.AllowUnqualifiedDNSQuery expected: true")
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

No longer sets defaults for
 - .Process.ConsoleSize
 - .Windows.IgnoreFlushesDuringBoot
 - .Windows.Network.AllowUnqualifiedDNSQuery

Adds helper functions and tests for
 - WithWindowsIgnoreFlushesDuringBoot
 - WithWindowNetworksAllowUnqualifiedDNSQuery

Updates `ctr run` on Windows to use the new helper functions,
ConsoleSize is already handled.
