### PR TITLE
[release/1.2] Update cri plugin to c3cf754321fc38c6af5dfd2552fdde0ad192b31d.

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -43,7 +43,7 @@ github.com/google/go-cmp v0.1.0
 go.etcd.io/bbolt v1.3.1-etcd.8
 
 # cri dependencies
-github.com/containerd/cri 0d5cabd006cb5319dc965046067b8432d9fa5ef8 # release/1.2 branch
+github.com/containerd/cri c3cf754321fc38c6af5dfd2552fdde0ad192b31d # release/1.2 branch
 github.com/containerd/go-cni 40bcf8ec8acd7372be1d77031d585d5d8e561c90
 github.com/blang/semver v3.1.0
 github.com/containernetworking/cni v0.6.0

--- a/vendor/github.com/containerd/cri/pkg/server/container_remove.go
+++ b/vendor/github.com/containerd/cri/pkg/server/container_remove.go
@@ -98,9 +98,12 @@ func (c *criService) RemoveContainer(ctx context.Context, r *runtime.RemoveConta
 // container will not be started or removed again.
 func setContainerRemoving(container containerstore.Container) error {
 	return container.Status.Update(func(status containerstore.Status) (containerstore.Status, error) {
-		// Do not remove container if it's still running.
+		// Do not remove container if it's still running or unknown.
 		if status.State() == runtime.ContainerState_CONTAINER_RUNNING {
-			return status, errors.New("container is still running")
+			return status, errors.New("container is still running, to stop first")
+		}
+		if status.State() == runtime.ContainerState_CONTAINER_UNKNOWN {
+			return status, errors.New("container state is unknown, to stop first")
 		}
 		if status.Removing {
 			return status, errors.New("container is already in removing state")

--- a/vendor/github.com/containerd/cri/pkg/server/container_status.go
+++ b/vendor/github.com/containerd/cri/pkg/server/container_status.go
@@ -60,6 +60,15 @@ func (c *criService) ContainerStatus(ctx context.Context, r *runtime.ContainerSt
 		}
 	}
 	status := toCRIContainerStatus(container, spec, imageRef)
+	if status.GetCreatedAt() == 0 {
+		// CRI doesn't allow CreatedAt == 0.
+		info, err := container.Container.Info(ctx)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get CreatedAt in %q state", status.State)
+		}
+		status.CreatedAt = info.CreatedAt.UnixNano()
+	}
+
 	info, err := toCRIContainerInfo(ctx, container, r.GetVerbose())
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get verbose container info")

--- a/vendor/github.com/containerd/cri/pkg/server/container_stop.go
+++ b/vendor/github.com/containerd/cri/pkg/server/container_stop.go
@@ -19,6 +19,8 @@ package server
 import (
 	"time"
 
+	"github.com/containerd/containerd"
+	eventtypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/docker/docker/pkg/signal"
 	"github.com/pkg/errors"
@@ -60,8 +62,9 @@ func (c *criService) stopContainer(ctx context.Context, container containerstore
 	// Return without error if container is not running. This makes sure that
 	// stop only takes real action after the container is started.
 	state := container.Status.Get().State()
-	if state != runtime.ContainerState_CONTAINER_RUNNING {
-		logrus.Infof("Container to stop %q is not running, current state %q",
+	if state != runtime.ContainerState_CONTAINER_RUNNING &&
+		state != runtime.ContainerState_CONTAINER_UNKNOWN {
+		logrus.Infof("Container to stop %q must be in running or unknown state, current state %q",
 			id, criContainerStateToString(state))
 		return nil
 	}
@@ -69,9 +72,39 @@ func (c *criService) stopContainer(ctx context.Context, container containerstore
 	task, err := container.Container.Task(ctx, nil)
 	if err != nil {
 		if !errdefs.IsNotFound(err) {
-			return errors.Wrapf(err, "failed to stop container, task not found for container %q", id)
+			return errors.Wrapf(err, "failed to get task for container %q", id)
 		}
-		return nil
+		// Don't return for unknown state, some cleanup needs to be done.
+		if state != runtime.ContainerState_CONTAINER_UNKNOWN {
+			return nil
+		}
+		// Task is an interface, explicitly set it to nil just in case.
+		task = nil
+	}
+
+	// Handle unknown state.
+	if state == runtime.ContainerState_CONTAINER_UNKNOWN {
+		status, err := getTaskStatus(ctx, task)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get task status for %q", id)
+		}
+		switch status.Status {
+		case containerd.Running, containerd.Created:
+			// The task is still running, continue stopping the task.
+		case containerd.Stopped:
+			// The task has exited. If the task exited after containerd
+			// started, the event monitor will receive its exit event; if it
+			// exited before containerd started, the event monitor will never
+			// receive its exit event.
+			// However, we can't tell that because the task state was not
+			// successfully loaded during containerd start (container is
+			// in UNKNOWN state).
+			// So always do cleanup here, just in case that we've missed the
+			// exit event.
+			return cleanupUnknownContainer(ctx, id, status, container)
+		default:
+			return errors.Wrapf(err, "unsupported task status %q", status.Status)
+		}
 	}
 
 	// We only need to kill the task. The event handler will Delete the
@@ -140,4 +173,22 @@ func (c *criService) waitContainerStop(ctx context.Context, container containers
 	case <-container.Stopped():
 		return nil
 	}
+}
+
+// cleanupUnknownContainer cleanup stopped container in unknown state.
+func cleanupUnknownContainer(ctx context.Context, id string, status containerd.Status,
+	cntr containerstore.Container) error {
+	// Reuse handleContainerExit to do the cleanup.
+	// NOTE(random-liu): If the task did exit after containerd started, both
+	// the event monitor and the cleanup function would update the container
+	// state. The final container state will be whatever being updated first.
+	// There is no way to completely avoid this race condition, and for best
+	// effort unknown state container cleanup, this seems acceptable.
+	return handleContainerExit(ctx, &eventtypes.TaskExit{
+		ContainerID: id,
+		ID:          id,
+		Pid:         0,
+		ExitStatus:  status.ExitStatus,
+		ExitedAt:    status.ExitTime,
+	}, cntr)
 }

--- a/vendor/github.com/containerd/cri/pkg/server/events.go
+++ b/vendor/github.com/containerd/cri/pkg/server/events.go
@@ -112,17 +112,17 @@ func convertEvent(e *gogotypes.Any) (string, interface{}, error) {
 		return "", nil, errors.Wrap(err, "failed to unmarshalany")
 	}
 
-	switch evt.(type) {
+	switch e := evt.(type) {
 	case *eventtypes.TaskExit:
-		id = evt.(*eventtypes.TaskExit).ContainerID
+		id = e.ContainerID
 	case *eventtypes.TaskOOM:
-		id = evt.(*eventtypes.TaskOOM).ContainerID
+		id = e.ContainerID
 	case *eventtypes.ImageCreate:
-		id = evt.(*eventtypes.ImageCreate).Name
+		id = e.Name
 	case *eventtypes.ImageUpdate:
-		id = evt.(*eventtypes.ImageUpdate).Name
+		id = e.Name
 	case *eventtypes.ImageDelete:
-		id = evt.(*eventtypes.ImageDelete).Name
+		id = e.Name
 	default:
 		return "", nil, errors.New("unsupported event")
 	}
@@ -200,13 +200,12 @@ func (em *eventMonitor) handleEvent(any interface{}) error {
 	ctx, cancel := context.WithTimeout(ctx, handleEventTimeout)
 	defer cancel()
 
-	switch any.(type) {
+	switch e := any.(type) {
 	// If containerd-shim exits unexpectedly, there will be no corresponding event.
 	// However, containerd could not retrieve container state in that case, so it's
 	// fine to leave out that case for now.
 	// TODO(random-liu): [P2] Handle containerd-shim exit.
 	case *eventtypes.TaskExit:
-		e := any.(*eventtypes.TaskExit)
 		logrus.Infof("TaskExit event %+v", e)
 		// Use ID instead of ContainerID to rule out TaskExit event for exec.
 		cntr, err := em.c.containerStore.Get(e.ID)
@@ -218,7 +217,7 @@ func (em *eventMonitor) handleEvent(any interface{}) error {
 		} else if err != store.ErrNotExist {
 			return errors.Wrap(err, "can't find container for TaskExit event")
 		}
-		// Use GetAll to include sandbox in unknown state.
+		// Use GetAll to include sandbox in init state.
 		sb, err := em.c.sandboxStore.GetAll(e.ID)
 		if err == nil {
 			if err := handleSandboxExit(ctx, e, sb); err != nil {
@@ -230,7 +229,6 @@ func (em *eventMonitor) handleEvent(any interface{}) error {
 		}
 		return nil
 	case *eventtypes.TaskOOM:
-		e := any.(*eventtypes.TaskOOM)
 		logrus.Infof("TaskOOM event %+v", e)
 		// For TaskOOM, we only care which container it belongs to.
 		cntr, err := em.c.containerStore.Get(e.ContainerID)
@@ -248,15 +246,12 @@ func (em *eventMonitor) handleEvent(any interface{}) error {
 			return errors.Wrap(err, "failed to update container status for TaskOOM event")
 		}
 	case *eventtypes.ImageCreate:
-		e := any.(*eventtypes.ImageCreate)
 		logrus.Infof("ImageCreate event %+v", e)
 		return em.c.updateImage(ctx, e.Name)
 	case *eventtypes.ImageUpdate:
-		e := any.(*eventtypes.ImageUpdate)
 		logrus.Infof("ImageUpdate event %+v", e)
 		return em.c.updateImage(ctx, e.Name)
 	case *eventtypes.ImageDelete:
-		e := any.(*eventtypes.ImageDelete)
 		logrus.Infof("ImageDelete event %+v", e)
 		return em.c.updateImage(ctx, e.Name)
 	}
@@ -269,7 +264,16 @@ func handleContainerExit(ctx context.Context, e *eventtypes.TaskExit, cntr conta
 	// Attach container IO so that `Delete` could cleanup the stream properly.
 	task, err := cntr.Container.Task(ctx,
 		func(*containerdio.FIFOSet) (containerdio.IO, error) {
-			return cntr.IO, nil
+			// We can't directly return cntr.IO here, because
+			// even if cntr.IO is nil, the cio.IO interface
+			// is not.
+			// See https://tour.golang.org/methods/12:
+			//   Note that an interface value that holds a nil
+			//   concrete value is itself non-nil.
+			if cntr.IO != nil {
+				return cntr.IO, nil
+			}
+			return nil, nil
 		},
 	)
 	if err != nil {
@@ -322,13 +326,13 @@ func handleSandboxExit(ctx context.Context, e *eventtypes.TaskExit, sb sandboxst
 		}
 	}
 	err = sb.Status.Update(func(status sandboxstore.Status) (sandboxstore.Status, error) {
-		// NOTE(random-liu): We SHOULD NOT change UNKNOWN state here.
-		// If sandbox state is UNKNOWN when event monitor receives an TaskExit event,
+		// NOTE(random-liu): We SHOULD NOT change INIT state here.
+		// If sandbox state is INIT when event monitor receives an TaskExit event,
 		// it means that sandbox start has failed. In that case, `RunPodSandbox` will
 		// cleanup everything immediately.
-		// Once sandbox state goes out of UNKNOWN, it becomes visable to the user, which
+		// Once sandbox state goes out of INIT, it becomes visable to the user, which
 		// is not what we want.
-		if status.State != sandboxstore.StateUnknown {
+		if status.State != sandboxstore.StateInit {
 			status.State = sandboxstore.StateNotReady
 		}
 		status.Pid = 0

--- a/vendor/github.com/containerd/cri/pkg/server/restart.go
+++ b/vendor/github.com/containerd/cri/pkg/server/restart.go
@@ -179,138 +179,128 @@ func (c *criService) loadContainer(ctx context.Context, cntr containerd.Containe
 		status = unknownContainerStatus()
 	}
 
-	// Load up-to-date status from containerd.
 	var containerIO *cio.ContainerIO
-	t, err := cntr.Task(ctx, func(fifos *containerdio.FIFOSet) (_ containerdio.IO, err error) {
-		stdoutWC, stderrWC, err := c.createContainerLoggers(meta.LogPath, meta.Config.GetTty())
-		if err != nil {
-			return nil, err
-		}
-		defer func() {
+	err = func() error {
+		// Load up-to-date status from containerd.
+		t, err := cntr.Task(ctx, func(fifos *containerdio.FIFOSet) (_ containerdio.IO, err error) {
+			stdoutWC, stderrWC, err := c.createContainerLoggers(meta.LogPath, meta.Config.GetTty())
 			if err != nil {
-				if stdoutWC != nil {
-					stdoutWC.Close()
-				}
-				if stderrWC != nil {
-					stderrWC.Close()
-				}
+				return nil, err
 			}
-		}()
-		containerIO, err = cio.NewContainerIO(id,
-			cio.WithFIFOs(fifos),
-		)
-		if err != nil {
-			return nil, err
-		}
-		containerIO.AddOutput("log", stdoutWC, stderrWC)
-		containerIO.Pipe()
-		return containerIO, nil
-	})
-	if err != nil && !errdefs.IsNotFound(err) {
-		return container, errors.Wrap(err, "failed to load task")
-	}
-	var s containerd.Status
-	var notFound bool
-	if errdefs.IsNotFound(err) {
-		// Task is not found.
-		notFound = true
-	} else {
-		// Task is found. Get task status.
-		s, err = t.Status(ctx)
-		if err != nil {
-			// It's still possible that task is deleted during this window.
-			if !errdefs.IsNotFound(err) {
-				return container, errors.Wrap(err, "failed to get task status")
-			}
-			notFound = true
-		}
-	}
-	if notFound {
-		// Task is not created or has been deleted, use the checkpointed status
-		// to generate container status.
-		switch status.State() {
-		case runtime.ContainerState_CONTAINER_CREATED:
-			// NOTE: Another possibility is that we've tried to start the container, but
-			// containerd got restarted during that. In that case, we still
-			// treat the container as `CREATED`.
+			defer func() {
+				if err != nil {
+					if stdoutWC != nil {
+						stdoutWC.Close()
+					}
+					if stderrWC != nil {
+						stderrWC.Close()
+					}
+				}
+			}()
 			containerIO, err = cio.NewContainerIO(id,
-				cio.WithNewFIFOs(volatileContainerDir, meta.Config.GetTty(), meta.Config.GetStdin()),
+				cio.WithFIFOs(fifos),
 			)
 			if err != nil {
-				return container, errors.Wrap(err, "failed to create container io")
+				return nil, err
 			}
-		case runtime.ContainerState_CONTAINER_RUNNING:
-			// Container was in running state, but its task has been deleted,
-			// set unknown exited state. Container io is not needed in this case.
-			status.FinishedAt = time.Now().UnixNano()
-			status.ExitCode = unknownExitCode
-			status.Reason = unknownExitReason
-		default:
-			// Container is in exited/unknown state, return the status as it is.
+			containerIO.AddOutput("log", stdoutWC, stderrWC)
+			containerIO.Pipe()
+			return containerIO, nil
+		})
+		if err != nil && !errdefs.IsNotFound(err) {
+			return errors.Wrap(err, "failed to load task")
 		}
-	} else {
-		// Task status is found. Update container status based on the up-to-date task status.
-		switch s.Status {
-		case containerd.Created:
-			// Task has been created, but not started yet. This could only happen if containerd
-			// gets restarted during container start.
-			// Container must be in `CREATED` state.
-			if _, err := t.Delete(ctx, containerd.WithProcessKill); err != nil && !errdefs.IsNotFound(err) {
-				return container, errors.Wrap(err, "failed to delete task")
+		var s containerd.Status
+		var notFound bool
+		if errdefs.IsNotFound(err) {
+			// Task is not found.
+			notFound = true
+		} else {
+			// Task is found. Get task status.
+			s, err = t.Status(ctx)
+			if err != nil {
+				// It's still possible that task is deleted during this window.
+				if !errdefs.IsNotFound(err) {
+					return errors.Wrap(err, "failed to get task status")
+				}
+				notFound = true
 			}
-			if status.State() != runtime.ContainerState_CONTAINER_CREATED {
-				return container, errors.Errorf("unexpected container state for created task: %q", status.State())
-			}
-		case containerd.Running:
-			// Task is running. Container must be in `RUNNING` state, based on our assuption that
-			// "task should not be started when containerd is down".
+		}
+		if notFound {
+			// Task is not created or has been deleted, use the checkpointed status
+			// to generate container status.
 			switch status.State() {
-			case runtime.ContainerState_CONTAINER_EXITED:
-				return container, errors.Errorf("unexpected container state for running task: %q", status.State())
+			case runtime.ContainerState_CONTAINER_CREATED:
+				// NOTE: Another possibility is that we've tried to start the container, but
+				// containerd got restarted during that. In that case, we still
+				// treat the container as `CREATED`.
+				containerIO, err = cio.NewContainerIO(id,
+					cio.WithNewFIFOs(volatileContainerDir, meta.Config.GetTty(), meta.Config.GetStdin()),
+				)
+				if err != nil {
+					return errors.Wrap(err, "failed to create container io")
+				}
 			case runtime.ContainerState_CONTAINER_RUNNING:
+				// Container was in running state, but its task has been deleted,
+				// set unknown exited state. Container io is not needed in this case.
+				status.FinishedAt = time.Now().UnixNano()
+				status.ExitCode = unknownExitCode
+				status.Reason = unknownExitReason
 			default:
-				// This may happen if containerd gets restarted after task is started, but
-				// before status is checkpointed.
-				status.StartedAt = time.Now().UnixNano()
-				status.Pid = t.Pid()
+				// Container is in exited/unknown state, return the status as it is.
 			}
-		case containerd.Stopped:
-			// Task is stopped. Updata status and delete the task.
-			if _, err := t.Delete(ctx, containerd.WithProcessKill); err != nil && !errdefs.IsNotFound(err) {
-				return container, errors.Wrap(err, "failed to delete task")
+		} else {
+			// Task status is found. Update container status based on the up-to-date task status.
+			switch s.Status {
+			case containerd.Created:
+				// Task has been created, but not started yet. This could only happen if containerd
+				// gets restarted during container start.
+				// Container must be in `CREATED` state.
+				if _, err := t.Delete(ctx, containerd.WithProcessKill); err != nil && !errdefs.IsNotFound(err) {
+					return errors.Wrap(err, "failed to delete task")
+				}
+				if status.State() != runtime.ContainerState_CONTAINER_CREATED {
+					return errors.Errorf("unexpected container state for created task: %q", status.State())
+				}
+			case containerd.Running:
+				// Task is running. Container must be in `RUNNING` state, based on our assuption that
+				// "task should not be started when containerd is down".
+				switch status.State() {
+				case runtime.ContainerState_CONTAINER_EXITED:
+					return errors.Errorf("unexpected container state for running task: %q", status.State())
+				case runtime.ContainerState_CONTAINER_RUNNING:
+				default:
+					// This may happen if containerd gets restarted after task is started, but
+					// before status is checkpointed.
+					status.StartedAt = time.Now().UnixNano()
+					status.Pid = t.Pid()
+				}
+			case containerd.Stopped:
+				// Task is stopped. Updata status and delete the task.
+				if _, err := t.Delete(ctx, containerd.WithProcessKill); err != nil && !errdefs.IsNotFound(err) {
+					return errors.Wrap(err, "failed to delete task")
+				}
+				status.FinishedAt = s.ExitTime.UnixNano()
+				status.ExitCode = int32(s.ExitStatus)
+			default:
+				return errors.Errorf("unexpected task status %q", s.Status)
 			}
-			status.FinishedAt = s.ExitTime.UnixNano()
-			status.ExitCode = int32(s.ExitStatus)
-		default:
-			return container, errors.Errorf("unexpected task status %q", s.Status)
 		}
+		return nil
+	}()
+	if err != nil {
+		logrus.WithError(err).Errorf("Failed to load container status for %q", id)
+		status = unknownContainerStatus()
 	}
 	opts := []containerstore.Opts{
 		containerstore.WithStatus(status, containerDir),
 		containerstore.WithContainer(cntr),
 	}
+	// containerIO could be nil for container in unknown state.
 	if containerIO != nil {
 		opts = append(opts, containerstore.WithContainerIO(containerIO))
 	}
 	return containerstore.NewContainer(*meta, opts...)
-}
-
-const (
-	// unknownExitCode is the exit code when exit reason is unknown.
-	unknownExitCode = 255
-	// unknownExitReason is the exit reason when exit reason is unknown.
-	unknownExitReason = "Unknown"
-)
-
-// unknownContainerStatus returns the default container status when its status is unknown.
-func unknownContainerStatus() containerstore.Status {
-	return containerstore.Status{
-		CreatedAt:  0,
-		StartedAt:  0,
-		FinishedAt: 0,
-		ExitCode:   unknownExitCode,
-		Reason:     unknownExitReason,
-	}
 }
 
 // loadSandbox loads sandbox from containerd.
@@ -333,61 +323,59 @@ func loadSandbox(ctx context.Context, cntr containerd.Container) (sandboxstore.S
 	}
 	meta := data.(*sandboxstore.Metadata)
 
-	// Load sandbox created timestamp.
-	info, err := cntr.Info(ctx)
-	if err != nil {
-		return sandbox, errors.Wrap(err, "failed to get sandbox container info")
-	}
-	createdAt := info.CreatedAt
-
-	// Load sandbox status.
-	t, err := cntr.Task(ctx, nil)
-	if err != nil && !errdefs.IsNotFound(err) {
-		return sandbox, errors.Wrap(err, "failed to load task")
-	}
-	var s containerd.Status
-	var notFound bool
-	if errdefs.IsNotFound(err) {
-		// Task is not found.
-		notFound = true
-	} else {
-		// Task is found. Get task status.
-		s, err = t.Status(ctx)
+	s, err := func() (sandboxstore.Status, error) {
+		status := unknownSandboxStatus()
+		// Load sandbox created timestamp.
+		info, err := cntr.Info(ctx)
 		if err != nil {
-			// It's still possible that task is deleted during this window.
-			if !errdefs.IsNotFound(err) {
-				return sandbox, errors.Wrap(err, "failed to get task status")
-			}
+			return status, errors.Wrap(err, "failed to get sandbox container info")
+		}
+		status.CreatedAt = info.CreatedAt
+
+		// Load sandbox state.
+		t, err := cntr.Task(ctx, nil)
+		if err != nil && !errdefs.IsNotFound(err) {
+			return status, errors.Wrap(err, "failed to load task")
+		}
+		var taskStatus containerd.Status
+		var notFound bool
+		if errdefs.IsNotFound(err) {
+			// Task is not found.
 			notFound = true
-		}
-	}
-	var state sandboxstore.State
-	var pid uint32
-	if notFound {
-		// Task does not exist, set sandbox state as NOTREADY.
-		state = sandboxstore.StateNotReady
-	} else {
-		if s.Status == containerd.Running {
-			// Task is running, set sandbox state as READY.
-			state = sandboxstore.StateReady
-			pid = t.Pid()
 		} else {
-			// Task is not running. Delete the task and set sandbox state as NOTREADY.
-			if _, err := t.Delete(ctx, containerd.WithProcessKill); err != nil && !errdefs.IsNotFound(err) {
-				return sandbox, errors.Wrap(err, "failed to delete task")
+			// Task is found. Get task status.
+			taskStatus, err = t.Status(ctx)
+			if err != nil {
+				// It's still possible that task is deleted during this window.
+				if !errdefs.IsNotFound(err) {
+					return status, errors.Wrap(err, "failed to get task status")
+				}
+				notFound = true
 			}
-			state = sandboxstore.StateNotReady
 		}
+		if notFound {
+			// Task does not exist, set sandbox state as NOTREADY.
+			status.State = sandboxstore.StateNotReady
+		} else {
+			if taskStatus.Status == containerd.Running {
+				// Task is running, set sandbox state as READY.
+				status.State = sandboxstore.StateReady
+				status.Pid = t.Pid()
+			} else {
+				// Task is not running. Delete the task and set sandbox state as NOTREADY.
+				if _, err := t.Delete(ctx, containerd.WithProcessKill); err != nil && !errdefs.IsNotFound(err) {
+					return status, errors.Wrap(err, "failed to delete task")
+				}
+				status.State = sandboxstore.StateNotReady
+			}
+		}
+		return status, nil
+	}()
+	if err != nil {
+		logrus.WithError(err).Errorf("Failed to load sandbox status for %q", cntr.ID())
 	}
 
-	sandbox = sandboxstore.NewSandbox(
-		*meta,
-		sandboxstore.Status{
-			Pid:       pid,
-			CreatedAt: createdAt,
-			State:     state,
-		},
-	)
+	sandbox = sandboxstore.NewSandbox(*meta, s)
 	sandbox.Container = cntr
 
 	// Load network namespace.

--- a/vendor/github.com/containerd/cri/pkg/server/sandbox_remove.go
+++ b/vendor/github.com/containerd/cri/pkg/server/sandbox_remove.go
@@ -46,8 +46,9 @@ func (c *criService) RemovePodSandbox(ctx context.Context, r *runtime.RemovePodS
 	// Use the full sandbox id.
 	id := sandbox.ID
 
-	// Return error if sandbox container is still running.
-	if sandbox.Status.Get().State == sandboxstore.StateReady {
+	// Return error if sandbox container is still running or unknown.
+	state := sandbox.Status.Get().State
+	if state == sandboxstore.StateReady || state == sandboxstore.StateUnknown {
 		return nil, errors.Errorf("sandbox container %q is not fully stopped", id)
 	}
 

--- a/vendor/github.com/containerd/cri/pkg/store/container/container.go
+++ b/vendor/github.com/containerd/cri/pkg/store/container/container.go
@@ -36,7 +36,8 @@ type Container struct {
 	Status StatusStorage
 	// Container is the containerd container client.
 	Container containerd.Container
-	// Container IO
+	// Container IO.
+	// IO could only be nil when the container is in unknown state.
 	IO *cio.ContainerIO
 	// StopCh is used to propagate the stop information of the container.
 	*store.StopCh

--- a/vendor/github.com/containerd/cri/pkg/store/container/status.go
+++ b/vendor/github.com/containerd/cri/pkg/store/container/status.go
@@ -28,6 +28,38 @@ import (
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 )
 
+// The container state machine in the CRI plugin:
+//
+//                         +              +
+//                         |              |
+//                         | Create       | Load
+//                         |              |
+//                    +----v----+         |
+//                    |         |         |
+//                    | CREATED <---------+-----------+
+//                    |         |         |           |
+//                    +----+-----         |           |
+//                         |              |           |
+//                         | Start        |           |
+//                         |              |           |
+//                    +----v----+         |           |
+//   Exec    +--------+         |         |           |
+//  Attach   |        | RUNNING <---------+           |
+// LogReopen +-------->         |         |           |
+//                    +----+----+         |           |
+//                         |              |           |
+//                         | Stop/Exit    |           |
+//                         |              |           |
+//                    +----v----+         |           |
+//                    |         <---------+      +----v----+
+//                    |  EXITED |                |         |
+//                    |         <----------------+ UNKNOWN |
+//                    +----+----+       Stop     |         |
+//                         |                     +---------+
+//                         | Remove
+//                         v
+//                      DELETED
+
 // statusVersion is current version of container status.
 const statusVersion = "v1" // nolint
 

--- a/vendor/github.com/containerd/cri/pkg/store/sandbox/sandbox.go
+++ b/vendor/github.com/containerd/cri/pkg/store/sandbox/sandbox.go
@@ -93,7 +93,7 @@ func (s *Store) Get(id string) (Sandbox, error) {
 	if err != nil {
 		return sb, err
 	}
-	if sb.Status.Get().State == StateUnknown {
+	if sb.Status.Get().State == StateInit {
 		return Sandbox{}, store.ErrNotExist
 	}
 	return sb, nil
@@ -123,7 +123,7 @@ func (s *Store) List() []Sandbox {
 	defer s.lock.RUnlock()
 	var sandboxes []Sandbox
 	for _, sb := range s.sandboxes {
-		if sb.Status.Get().State == StateUnknown {
+		if sb.Status.Get().State == StateInit {
 			continue
 		}
 		sandboxes = append(sandboxes, sb)

--- a/vendor/github.com/containerd/cri/pkg/store/sandbox/status.go
+++ b/vendor/github.com/containerd/cri/pkg/store/sandbox/status.go
@@ -21,16 +21,52 @@ import (
 	"time"
 )
 
+// The sandbox state machine in the CRI plugin:
+//                    +              +
+//                    |              |
+//                    | Create(Run)  | Load
+//                    |              |
+//      Start    +----v----+         |
+//     (failed)  |         |         |
+// +-------------+  INIT   |         +-----------+
+// |             |         |         |           |
+// |             +----+----+         |           |
+// |                  |              |           |
+// |                  | Start(Run)   |           |
+// |                  |              |           |
+// | PortForward +----v----+         |           |
+// |      +------+         |         |           |
+// |      |      |  READY  <---------+           |
+// |      +------>         |         |           |
+// |             +----+----+         |           |
+// |                  |              |           |
+// |                  | Stop/Exit    |           |
+// |                  |              |           |
+// |             +----v----+         |           |
+// |             |         <---------+      +----v----+
+// |             | NOTREADY|                |         |
+// |             |         <----------------+ UNKNOWN |
+// |             +----+----+       Stop     |         |
+// |                  |                     +---------+
+// |                  | Remove
+// |                  v
+// +-------------> DELETED
+
 // State is the sandbox state we use in containerd/cri.
-// It has unknown state defined.
+// It includes init and unknown, which are internal states not defined in CRI.
+// The state mapping from internal states to CRI states:
+// * ready -> ready
+// * not ready -> not ready
+// * init -> not exist
+// * unknown -> not ready
 type State uint32
 
 const (
-	// StateUnknown is unknown state of sandbox. Sandbox
-	// is in unknown state before its corresponding sandbox container
-	// is created. Sandbox in unknown state should be ignored by most
+	// StateInit is init state of sandbox. Sandbox
+	// is in init state before its corresponding sandbox container
+	// is created. Sandbox in init state should be ignored by most
 	// functions, unless the caller needs to update sandbox state.
-	StateUnknown State = iota
+	StateInit State = iota
 	// StateReady is ready state, it means sandbox container
 	// is running.
 	StateReady
@@ -40,6 +76,9 @@ const (
 	// cleanup resources other than sandbox container, e.g. network namespace.
 	// This is an assumption made in CRI.
 	StateNotReady
+	// StateUnknown is unknown state. Sandbox only goes
+	// into unknown state when its status fails to be loaded.
+	StateUnknown
 )
 
 // Status is the status of a sandbox.

--- a/vendor/github.com/containerd/cri/pkg/util/strings.go
+++ b/vendor/github.com/containerd/cri/pkg/util/strings.go
@@ -22,7 +22,7 @@ import "strings"
 // Comparison is case insensitive.
 func InStringSlice(ss []string, str string) bool {
 	for _, s := range ss {
-		if strings.ToLower(s) == strings.ToLower(str) {
+		if strings.EqualFold(s, str) {
 			return true
 		}
 	}
@@ -34,7 +34,7 @@ func InStringSlice(ss []string, str string) bool {
 func SubtractStringSlice(ss []string, str string) []string {
 	var res []string
 	for _, s := range ss {
-		if strings.ToLower(s) == strings.ToLower(str) {
+		if strings.EqualFold(s, str) {
 			continue
 		}
 		res = append(res, s)

--- a/vendor/github.com/containerd/cri/vendor.conf
+++ b/vendor/github.com/containerd/cri/vendor.conf
@@ -3,7 +3,7 @@ github.com/blang/semver v3.1.0
 github.com/BurntSushi/toml a368813c5e648fee92e5f6c30e3944ff9d5e8895
 github.com/containerd/cgroups 5e610833b72089b37d0e615de9a92dfc043757c2
 github.com/containerd/console c12b1e7919c14469339a5d38f2f8ed9b64a9de23
-github.com/containerd/containerd 4b284fa3ab61832b022ba428055f793a75ffc251
+github.com/containerd/containerd 0137339c8c1d55de5545ffdd723199dfba27cb24
 github.com/containerd/continuity bd77b46c8352f74eb12c85bdc01f4b90f69d66b4
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c
 github.com/containerd/go-cni 40bcf8ec8acd7372be1d77031d585d5d8e561c90
@@ -39,7 +39,7 @@ github.com/modern-go/concurrent 1.0.3
 github.com/modern-go/reflect2 1.0.1
 github.com/opencontainers/go-digest c9281466c8b2f606084ac71339773efd177436e7
 github.com/opencontainers/image-spec v1.0.1
-github.com/opencontainers/runc v1.0.0-rc6
+github.com/opencontainers/runc 12f6a991201fdb8f82579582d5e00e28fba06d0a
 github.com/opencontainers/runtime-spec eba862dc2470385a233c7507392675cbeadf7353
 github.com/opencontainers/runtime-tools v0.6.0
 github.com/opencontainers/selinux b6fa367ed7f534f9ba25391cc2d467085dbb445a


### PR DESCRIPTION
### Bug Fixes
* Fix a bug that the cri plugin adds an extra `\n` in the container log without an ending newline.
* Fix a bug that the cri plugin silently ignores containers/pods after load failure. Those containers/pods are now loaded as `Unknown` state.

Signed-off-by: Lantao Liu <lantaol@google.com>