### PR TITLE
Align platform.MatchComparer behavior between fetch and other methods

### DIFF
--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -108,7 +108,7 @@ command. As part of this process, we do the following:
 
 		for _, platform := range p {
 			fmt.Printf("unpacking %s %s...\n", platforms.Format(platform), img.Target.Digest)
-			i := containerd.NewImageWithPlatform(client, img, platforms.Only(platform))
+			i := containerd.NewImageWithPlatform(client, img, platforms.Any(platform))
 			err = i.Unpack(ctx, context.String("snapshotter"))
 			if err != nil {
 				return err

--- a/images/handlers.go
+++ b/images/handlers.go
@@ -222,22 +222,66 @@ func LimitManifests(f HandlerFunc, m platforms.MatchComparer, n int) HandlerFunc
 
 		switch desc.MediaType {
 		case ocispec.MediaTypeImageIndex, MediaTypeDockerSchema2ManifestList:
-			sort.SliceStable(children, func(i, j int) bool {
-				if children[i].Platform == nil {
-					return false
-				}
-				if children[j].Platform == nil {
-					return true
-				}
-				return m.Less(*children[i].Platform, *children[j].Platform)
-			})
-
-			if n > 0 && len(children) > n {
-				children = children[:n]
-			}
+			children = limitChildren(children, m, n)
 		default:
 			// only limit manifests from an index
 		}
+		return children, nil
+	}
+}
+
+func limitChildren(children []ocispec.Descriptor, m platforms.MatchComparer, n int) []ocispec.Descriptor {
+	sort.SliceStable(children, func(i, j int) bool {
+		if children[i].Platform == nil {
+			return false
+		}
+		if children[j].Platform == nil {
+			return true
+		}
+		return m.Less(*children[i].Platform, *children[j].Platform)
+	})
+
+	if n > 0 && len(children) > n {
+		children = children[:n]
+	}
+
+	return children
+}
+
+type PlatformCapture struct {
+	requested platforms.MatchComparer
+	platforms []ocispec.Platform
+}
+
+func NewPlatformCapture(comparer platforms.MatchComparer) *PlatformCapture {
+	return &PlatformCapture{
+		requested: comparer,
+	}
+}
+
+func (p *PlatformCapture) MatchComparer() platforms.MatchComparer {
+	if len(p.platforms) == 0 {
+		return p.requested
+	}
+	return platforms.Any(p.platforms...)
+}
+
+func (p *PlatformCapture) Handler(f HandlerFunc) HandlerFunc {
+	return func(ctx context.Context, desc ocispec.Descriptor) (subdescs []ocispec.Descriptor, err error) {
+		children, err := f(ctx, desc)
+		if err != nil {
+			return children, err
+		}
+
+		switch desc.MediaType {
+		case ocispec.MediaTypeImageIndex, MediaTypeDockerSchema2ManifestList:
+			for _, child := range children {
+				if child.Platform != nil {
+					p.platforms = append(p.platforms, *child.Platform)
+				}
+			}
+		}
+
 		return children, nil
 	}
 }

--- a/images/image.go
+++ b/images/image.go
@@ -119,7 +119,7 @@ func (image *Image) Size(ctx context.Context, provider content.Provider, platfor
 		}
 		size += desc.Size
 		return nil, nil
-	}), FilterPlatforms(ChildrenHandler(provider), platform)), image.Target)
+	}), LimitManifests(FilterPlatforms(ChildrenHandler(provider), platform), platform, 1)), image.Target)
 }
 
 type platformManifest struct {
@@ -209,6 +209,9 @@ func Manifest(ctx context.Context, provider content.Provider, image ocispec.Desc
 					descs = append(descs, d)
 				}
 			}
+
+			// mimic behavior of client.Pull which limits to 1 manifest list child
+			descs = limitChildren(descs, platform, 1)
 
 			wasIndex = true
 


### PR DESCRIPTION
These are the hacks I did to address https://github.com/containerd/containerd/issues/2991.  The PR is based on the release branch so obviously not mergeable.  Also I don't expect you to accept this, just letting you know what I did to make it work locally for me.