### PR TITLE
Prepare v1.1.6 release

### DIFF
--- a/releases/v1.1.6.toml
+++ b/releases/v1.1.6.toml
@@ -1,0 +1,36 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release
+previous = "v1.1.5"
+
+pre_release = false
+
+preface = """\
+This is the sixth patch release for the `containerd` 1.1 release. This
+release specifically re-vendors `runc` to capture the fix for the critical
+CVE-2019-5736 container escape. Several CRI fixes were also included in
+this release and are listed below.
+
+## Runtime
+* Update runc to 6635b4f0c6af3810594d2770f662f34ddc15b40d to fix CVE-2019-5736
+
+## CRI
+* containerd/cri#984 filter events for non k8s.io namespaces (resolves https://github.com/firecracker-microvm/firecracker-containerd/issues/35)
+* containerd/cri#991 Remove container lifecycle image dependency (fixes containerd/cri#990)
+* containerd/cri#1016 Specify platform for image pull (fixes containerd/cri#1015)
+* containerd/cri#1027 Fix the log ending newline handling (fixes containerd/cri#1026)
+* containerd/cri#1042 Set /etc/hostname (fixes containerd/cri#1041)
+* containerd/cri#1045 Fix env performance issue (fixes containerd/cri#1044)
+* Update cri to f0b5665a959119b6a6234001e6d55206d9200e95
+
+"""
+
+# notable prs to include in the release notes, 1234 is the pr number
+[notes]
+
+[breaking]

--- a/version/version.go
+++ b/version/version.go
@@ -21,7 +21,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.1.5+unknown"
+	Version = "1.1.6+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Create a new release to fix runc CVE-2019-5736

~~Requires #2999 to be merged before cutting a release.~~

Also includes several cherry-picked CRI fixes via #3015 

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>