### PR TITLE
Unpack should set 0755 when the parent directory doesn't exist.

### DIFF
--- a/archive/tar.go
+++ b/archive/tar.go
@@ -194,7 +194,7 @@ func applyNaive(ctx context.Context, root string, tr *tar.Reader, options ApplyO
 				parentPath = filepath.Dir(path)
 			}
 			if _, err := os.Lstat(parentPath); err != nil && os.IsNotExist(err) {
-				err = mkdirAll(parentPath, 0700)
+				err = mkdirAll(parentPath, 0755)
 				if err != nil {
 					return 0, err
 				}


### PR DESCRIPTION
Fixes #3017 

This keeps consistent behavior with docker. :)

Signed-off-by: Lantao Liu <lantaol@google.com>