### PR TITLE
metadata: merge snapshot labels with metadata's labels

### DIFF
--- a/metadata/snapshot.go
+++ b/metadata/snapshot.go
@@ -232,7 +232,7 @@ func overlayInfo(info, overlay snapshots.Info) snapshots.Info {
 		info.Labels = overlay.Labels
 	} else {
 		for k, v := range overlay.Labels {
-			overlay.Labels[k] = v
+			info.Labels[k] = v
 		}
 	}
 	return info


### PR DESCRIPTION
fix the no-op issue.

Signed-off-by: Wei Fu <fuweid89@gmail.com>