### PR TITLE
runtime: allow specifying supported platforms with config

### DIFF
--- a/runtime/v2/manager_unix.go
+++ b/runtime/v2/manager_unix.go
@@ -20,9 +20,8 @@ package v2
 
 import (
 	"github.com/containerd/containerd/platforms"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-func supportedPlatforms() []ocispec.Platform {
-	return []ocispec.Platform{platforms.DefaultSpec()}
+func defaultPlatforms() []string {
+	return []string{platforms.DefaultString()}
 }

--- a/runtime/v2/manager_windows.go
+++ b/runtime/v2/manager_windows.go
@@ -20,15 +20,11 @@ package v2
 
 import (
 	"github.com/containerd/containerd/platforms"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-func supportedPlatforms() []ocispec.Platform {
-	return []ocispec.Platform{
-		platforms.DefaultSpec(),
-		{
-			OS:           "linux",
-			Architecture: "amd64",
-		},
+func defaultPlatforms() []string {
+	return []string{
+		platforms.DefaultString(),
+		"linux/amd64",
 	}
 }


### PR DESCRIPTION
Allow defining supported runtime platforms list from config as a node may support multiple.

@crosbymichael @dmcgowan 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>