### PR TITLE
docs: Add NAME section in all manpages

### DIFF
--- a/docs/man/containerd-config.1.md
+++ b/docs/man/containerd-config.1.md
@@ -1,5 +1,9 @@
 # containerd-config 1 01/30/2018
 
+## NAME
+
+containerd-config - information on the containerd config
+
 ## SYNOPSIS
 
 containerd config [command]

--- a/docs/man/containerd-config.toml.5.md
+++ b/docs/man/containerd-config.toml.5.md
@@ -1,5 +1,9 @@
 # /etc/containerd/config.toml 5 08/08/2018
 
+## NAME
+
+containerd-config.toml - configuration file for containerd
+
 ## SYNOPSIS
 
 The **config.toml** file is a configuration file for the containerd daemon. The

--- a/docs/man/containerd.1.md
+++ b/docs/man/containerd.1.md
@@ -1,5 +1,10 @@
 # containerd 1 01/29/2018
 
+## NAME
+
+containerd - an industry-standard container runtime with an emphasis on simplicity,
+robustness and portability
+
 ## SYNOPSIS
 
 containerd [global options] command [command options] [arguments...]

--- a/docs/man/ctr.1.md
+++ b/docs/man/ctr.1.md
@@ -1,5 +1,9 @@
 # ctr 1 01/30/2018
 
+## NAME
+
+ctr - command line for containerd
+
 ## SYNOPSIS
 
 **ctr [global options] command [command options] [arguments...]**


### PR DESCRIPTION
As described in https://lintian.debian.org/tags/manpage-has-bad-whatis-entry.html
each manual page should start with a "NAME" section.

Signed-off-by: Shengjing Zhu <zhsj@debian.org>