### PR TITLE
cannot exec in a created state

### DIFF
--- a/runtime/v1/linux/proc/init_state.go
+++ b/runtime/v1/linux/proc/init_state.go
@@ -110,7 +110,7 @@ func (s *createdState) SetExited(status int) {
 }
 
 func (s *createdState) Exec(ctx context.Context, path string, r *ExecConfig) (proc.Process, error) {
-	return s.p.exec(ctx, path, r)
+	return nil, errors.Errorf("cannot exec in a created state")
 }
 
 type createdCheckpointState struct {
@@ -225,7 +225,7 @@ func (s *createdCheckpointState) SetExited(status int) {
 }
 
 func (s *createdCheckpointState) Exec(ctx context.Context, path string, r *ExecConfig) (proc.Process, error) {
-	return nil, errors.Errorf("cannot exec in a created state")
+	return nil, errors.Errorf("cannot exec in a created checkpoint state")
 }
 
 type runningState struct {


### PR DESCRIPTION
I don't know why we can exec a command when a container is in a created state. If it is useful, please close this PR.
It is no harm to docker, except if we just use libcontainerd.
**For example:**
cat test.go
```
package main

import (
	"context"
	"fmt"
	"log"

	"github.com/containerd/containerd"
	"github.com/containerd/containerd/cio"
	"github.com/containerd/containerd/oci"
	"github.com/containerd/containerd/namespaces"
)

func main() {
	if err := redisExample(); err != nil {
		log.Fatal(err)
	}
}

func redisExample() error {
	// create a new client connected to the default socket path for containerd
	client, err := containerd.New("/run/containerd/containerd.sock")
	if err != nil {
		return err
	}
	defer client.Close()

	// create a new context with an "example" namespace
	ctx := namespaces.WithNamespace(context.Background(), "example")

	// pull the redis image from DockerHub
	image, err := client.Pull(ctx, "docker.io/library/redis:alpine", containerd.WithPullUnpack)
	if err != nil {
		return err
	}

	// create a container
	container, err := client.NewContainer(
		ctx,
		"test",
		containerd.WithImage(image),
		containerd.WithNewSnapshot("test-snapshot", image),
		containerd.WithNewSpec(oci.WithImageConfig(image)),
	)
	if err != nil {
		return err
	}
	//defer container.Delete(ctx, containerd.WithSnapshotCleanup)

	// create a task from the container
	task, err := container.NewTask(ctx, cio.NewCreator(cio.WithStdio))
	if err != nil {
		return err
	}
	//defer task.Delete(ctx)
	fmt.Println(task)
	fmt.Println("exited")
	return nil
}
```

**create a task**
```
root@iZ2ze1o61blvco5p5ducnnZ:/opt# go run test.go
&{0xc0000caa50 0xc00007a180 test 27166}
exited
```
```
root@iZ2ze1o61blvco5p5ducnnZ:/opt# ctr -n example t ls
TASK    PID      STATUS    
test    27166    CREATED
root@iZ2ze1o61blvco5p5ducnnZ:/opt# ctr -n example t exec --exec-id test1 test ls /proc/1/fd -lh
total 0
lr-x------    1 root     root          64 Feb 24 05:40 0 -> pipe:[1293194536]
l-wx------    1 root     root          64 Feb 24 05:40 1 -> pipe:[1293194537]
l-wx------    1 root     root          64 Feb 24 05:40 2 -> pipe:[1293194538]
l---------    1 root     root          64 Feb 24 05:40 4 -> /run/containerd/runc/example/test/exec.fifo
l-wx------    1 root     root          64 Feb 24 05:40 5 -> /null
lrwx------    1 root     root          64 Feb 24 05:40 6 -> anon_inode:[eventpoll]
root@iZ2ze1o61blvco5p5ducnnZ:/opt# ctr -n example t exec --exec-id test1 test ls /proc/1/exe -lh
lrwxrwxrwx    1 root     root           0 Feb 24 05:41 /proc/1/exe -> /usr/bin/runc
root@iZ2ze1o61blvco5p5ducnnZ:/opt#
```
Signed-off-by: Lifubang <lifubang@acmcoder.com>