### PR TITLE
diff: set "containerd.io/empty-layer" label to an empty layer

### DIFF
--- a/archive/tar_opts.go
+++ b/archive/tar_opts.go
@@ -36,3 +36,24 @@ func WithFilter(f Filter) ApplyOpt {
 		return nil
 	}
 }
+
+// DiffOpt allows setting mutable archive diff properties on creation
+type DiffOpt func(options *DiffOptions) error
+
+// OnWriteDiffCompletion is called on a WriteDiff completion so as to notify
+// DiffStat to the caller.
+type OnWriteDiffCompletion func(st DiffStat)
+
+// DiffOptions provides additional options for a WriteDiff operation
+type DiffOptions struct {
+	// OnWriteDiffCompletion is called on a WriteDiff completion if set
+	OnWriteDiffCompletion
+}
+
+// WithOnWriteDiffCompletion sets OnDiffCompletion
+func WithOnWriteDiffCompletion(handler OnWriteDiffCompletion) DiffOpt {
+	return func(options *DiffOptions) error {
+		options.OnWriteDiffCompletion = handler
+		return nil
+	}
+}


### PR DESCRIPTION
This fix is intended to allow BuildKit to detect empty layers without
comparing the magic digest value.

https://github.com/moby/buildkit/blob/f1dac983fa3e64d98964dfb91a45ae0adde2c253/exporter/containerimage/writer.go#L30
https://github.com/moby/buildkit/blob/f1dac983fa3e64d98964dfb91a45ae0adde2c253/snapshot/imagerefchecker/checker.go#L19

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>