### PR TITLE
Support Blob Mounts

### DIFF
--- a/remotes/docker/scope.go
+++ b/remotes/docker/scope.go
@@ -18,6 +18,7 @@ package docker
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"sort"
 	"strings"
@@ -53,24 +54,85 @@ func contextWithRepositoryScope(ctx context.Context, refspec reference.Spec, pus
 	return context.WithValue(ctx, tokenScopesKey{}, []string{s}), nil
 }
 
+func contextWithMountScope(ctx context.Context, from, to reference.Spec) (context.Context, error) {
+	sFrom, err := repositoryScope(from, false)
+	if err != nil {
+		return nil, err
+	}
+	sTo, err := repositoryScope(to, true)
+	if err != nil {
+		return nil, err
+	}
+	return context.WithValue(ctx, tokenScopesKey{}, []string{sFrom, sTo}), nil
+}
+
+type tokenScope struct {
+	resource string
+	actions  map[string]interface{}
+}
+
+func (ts tokenScope) String() string {
+	var actionSlice []string
+	for k := range ts.actions {
+		actionSlice = append(actionSlice, k)
+	}
+	sort.Strings(actionSlice)
+	return fmt.Sprintf("%s:%s", ts.resource, strings.Join(actionSlice, ","))
+}
+
+func parseTokenScope(s string) (tokenScope, error) {
+	lastSep := strings.LastIndex(s, ":")
+	if lastSep == -1 {
+		return tokenScope{}, fmt.Errorf("%q is not a valid token scope", s)
+	}
+	actions := make(map[string]interface{})
+	for _, a := range strings.Split(s[lastSep+1:], ",") {
+		actions[a] = nil
+	}
+	return tokenScope{
+		resource: s[:lastSep],
+		actions:  actions,
+	}, nil
+}
+
+func mergeTokenScope(existing map[string]tokenScope, newElem tokenScope) {
+	match, ok := existing[newElem.resource]
+	if !ok {
+		existing[newElem.resource] = newElem
+		return
+	}
+	for k := range newElem.actions {
+		match.actions[k] = nil
+	}
+	existing[newElem.resource] = match
+}
+
 // getTokenScopes returns deduplicated and sorted scopes from ctx.Value(tokenScopesKey{}) and params["scope"].
-func getTokenScopes(ctx context.Context, params map[string]string) []string {
-	var scopes []string
+func getTokenScopes(ctx context.Context, params map[string]string) ([]string, error) {
+	tokenScopes := map[string]tokenScope{}
 	if x := ctx.Value(tokenScopesKey{}); x != nil {
-		scopes = append(scopes, x.([]string)...)
-	}
-	if scope, ok := params["scope"]; ok {
-		for _, s := range scopes {
-			// Note: this comparison is unaware of the scope grammar (https://docs.docker.com/registry/spec/auth/scope/)
-			// So, "repository:foo/bar:pull,push" != "repository:foo/bar:push,pull", although semantically they are equal.
-			if s == scope {
-				// already appended
-				goto Sort
+		for _, scope := range x.([]string) {
+			ts, err := parseTokenScope(scope)
+			if err != nil {
+				return nil, err
 			}
+			mergeTokenScope(tokenScopes, ts)
 		}
-		scopes = append(scopes, scope)
 	}
-Sort:
+	if paramScopesFlat, ok := params["scope"]; ok {
+		paramScopes := strings.Split(paramScopesFlat, " ")
+		for _, scope := range paramScopes {
+			ts, err := parseTokenScope(scope)
+			if err != nil {
+				return nil, err
+			}
+			mergeTokenScope(tokenScopes, ts)
+		}
+	}
+	var scopes []string
+	for _, s := range tokenScopes {
+		scopes = append(scopes, s.String())
+	}
 	sort.Strings(scopes)
-	return scopes
+	return scopes, nil
 }


### PR DESCRIPTION
Containerd has a fantastic support for manipulating images in a registry (manifest walkers in particular are very powerful). This is why we chose to use it in github.com/docker/cnab-to-oci.

However, it is missing a very important feature for our use case: mounting blobs from one repository to another.

This PR adds support for a blob-mount operation in the remotes/docker package.
It also fixes support for multiple token scopes in the same request (which was currently broken, but not used).