### PR TITLE
Fix a bug in shim log on Windows that can cause 100% CPU utilization

### DIFF
--- a/runtime/v2/shim_windows.go
+++ b/runtime/v2/shim_windows.go
@@ -78,7 +78,7 @@ func openShimLog(ctx context.Context, bundle *Bundle) (io.ReadCloser, error) {
 			time.Second*10,
 		)
 		if conerr != nil {
-			dpc.conerr = errors.Wrap(err, "failed to connect to shim log")
+			dpc.conerr = errors.Wrap(conerr, "failed to connect to shim log")
 		}
 		dpc.c = c
 		dpc.wg.Done()


### PR DESCRIPTION
With the change to unified shims (ie: 1 shim per multiple tasks) the shimLog
on Windows for the 2nd-Nth worload containers will not have an associated
named pipe listener.

Due to a subtle bug in errors.Wrap passing a nil error we would unblock the
disconnected listener and return 0 byte successfull reads which would cause go
to continually read and cap the CPU.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>