### PR TITLE
docker registry: add support for mounts

### DIFF
--- a/remotes/docker/authorizer.go
+++ b/remotes/docker/authorizer.go
@@ -131,7 +131,11 @@ func (a *dockerAuthorizer) setTokenAuth(ctx context.Context, host string, params
 		service: params["service"],
 	}
 
-	to.scopes = getTokenScopes(ctx, params)
+	to.scopes, err = getTokenScopes(ctx, params)
+	if err != nil {
+		return errors.Wrap(err, "invalid token scopes")
+	}
+
 	if len(to.scopes) == 0 {
 		return errors.Errorf("no scope specified for token auth challenge")
 	}

--- a/remotes/docker/mount_test.go
+++ b/remotes/docker/mount_test.go
@@ -1,3 +1,19 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package docker
 
 import (

--- a/remotes/docker/mount_test.go
+++ b/remotes/docker/mount_test.go
@@ -1,0 +1,61 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/containerd/containerd/reference"
+	"gotest.tools/assert"
+)
+
+func TestOriginMatch(t *testing.T) {
+	cases := []struct {
+		name      string
+		targetRef string
+		origins   []string
+		expected  []string
+	}{
+		{
+			name:      "nil-origin",
+			targetRef: "docker.io/some/repo@sha256:1b19eb80fc8e5c84ff912d75c228d968b30a6b7553ea44de94acc1958e320268",
+			origins:   nil,
+			expected:  nil,
+		},
+		{
+			name:      "no-match",
+			targetRef: "docker.io/some/repo@sha256:1b19eb80fc8e5c84ff912d75c228d968b30a6b7553ea44de94acc1958e320268",
+			origins:   []string{"some-registry/some/repo"},
+			expected:  nil,
+		},
+		{
+			name:      "some-matches",
+			targetRef: "docker.io/some/repo@sha256:1b19eb80fc8e5c84ff912d75c228d968b30a6b7553ea44de94acc1958e320268",
+			origins:   []string{"some-registry/some/repo", "docker.io/other/repo", "docker.io/some/otherrepo"},
+			expected:  []string{"docker.io/other/repo", "docker.io/some/otherrepo"},
+		},
+		{
+			name:      "different-ports",
+			targetRef: "some-registry:5000/some/repo@sha256:1b19eb80fc8e5c84ff912d75c228d968b30a6b7553ea44de94acc1958e320268",
+			origins:   []string{"some-registry:5001/some/differentport"},
+			expected:  nil,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			targetRef, err := reference.Parse(c.targetRef)
+			assert.NilError(t, err)
+			var origins []reference.Spec
+			for _, o := range c.origins {
+				ref, err := reference.Parse(o)
+				assert.NilError(t, err)
+				origins = append(origins, ref)
+			}
+			actualSpecs := findMatchingOrigins(targetRef, origins)
+			var actual []string
+			for _, spec := range actualSpecs {
+				actual = append(actual, spec.String())
+			}
+			assert.DeepEqual(t, c.expected, actual)
+		})
+	}
+}

--- a/remotes/docker/pusher.go
+++ b/remotes/docker/pusher.go
@@ -184,7 +184,7 @@ func (p dockerPusher) Push(ctx context.Context, desc ocispec.Descriptor) (conten
 				},
 			})
 			// mount succeeded, returning a nil writer, without error
-			return nil, nil
+			return nil, errors.Wrapf(errdefs.ErrAlreadyExists, "content %v mounted from %s", desc.Digest, mountCandidate)
 		}
 		// no mount candidates found, or mount failure, fallback to real push
 

--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -99,7 +99,7 @@ type ResolverOptions struct {
 
 	// OriginProvider returns a slice of refspecs where the Pusher may find candidates for mounting
 	// instead of pushing from local store.
-	// When the Pusher succeeds by mounting, it returns a nil writer.
+	// When the Pusher succeeds by mounting, it returns an AlreadyExists error
 	OriginProvider func(ocispec.Descriptor) []reference.Spec
 }
 

--- a/remotes/docker/scope.go
+++ b/remotes/docker/scope.go
@@ -18,6 +18,7 @@ package docker
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"sort"
 	"strings"
@@ -53,24 +54,70 @@ func contextWithRepositoryScope(ctx context.Context, refspec reference.Spec, pus
 	return context.WithValue(ctx, tokenScopesKey{}, []string{s}), nil
 }
 
+type tokenScope struct {
+	resource string
+	actions  map[string]interface{}
+}
+
+func (ts tokenScope) String() string {
+	var actionSlice []string
+	for k := range ts.actions {
+		actionSlice = append(actionSlice, k)
+	}
+	sort.Strings(actionSlice)
+	return fmt.Sprintf("%s:%s", ts.resource, strings.Join(actionSlice, ","))
+}
+
+func parseTokenScope(s string) (tokenScope, error) {
+	lastSep := strings.LastIndex(s, ":")
+	if lastSep == -1 {
+		return tokenScope{}, fmt.Errorf("%q is not a valid token scope", s)
+	}
+	actions := make(map[string]interface{})
+	for _, a := range strings.Split(s[lastSep+1:], ",") {
+		actions[a] = nil
+	}
+	return tokenScope{
+		resource: s[:lastSep],
+		actions:  actions,
+	}, nil
+}
+
+// mergeTokenScope add a scope to an existing scope collection, ensuring deduplication
+func mergeTokenScope(existing map[string]tokenScope, newElem tokenScope) {
+	match, ok := existing[newElem.resource]
+	if !ok {
+		existing[newElem.resource] = newElem
+		return
+	}
+	for k := range newElem.actions {
+		match.actions[k] = nil
+	}
+	existing[newElem.resource] = match
+}
+
 // getTokenScopes returns deduplicated and sorted scopes from ctx.Value(tokenScopesKey{}) and params["scope"].
-func getTokenScopes(ctx context.Context, params map[string]string) []string {
-	var scopes []string
+func getTokenScopes(ctx context.Context, params map[string]string) ([]string, error) {
+	var rawScopes []string
 	if x := ctx.Value(tokenScopesKey{}); x != nil {
-		scopes = append(scopes, x.([]string)...)
+		rawScopes = x.([]string)
 	}
-	if scope, ok := params["scope"]; ok {
-		for _, s := range scopes {
-			// Note: this comparison is unaware of the scope grammar (https://docs.docker.com/registry/spec/auth/scope/)
-			// So, "repository:foo/bar:pull,push" != "repository:foo/bar:push,pull", although semantically they are equal.
-			if s == scope {
-				// already appended
-				goto Sort
-			}
+	if paramScopesFlat, ok := params["scope"]; ok {
+		paramScopes := strings.Split(paramScopesFlat, " ")
+		rawScopes = append(rawScopes, paramScopes...)
+	}
+	tokenScopes := map[string]tokenScope{}
+	for _, rawScope := range rawScopes {
+		parsedScope, err := parseTokenScope(rawScope)
+		if err != nil {
+			return nil, err
 		}
-		scopes = append(scopes, scope)
+		mergeTokenScope(tokenScopes, parsedScope)
 	}
-Sort:
+	var scopes []string
+	for _, s := range tokenScopes {
+		scopes = append(scopes, s.String())
+	}
 	sort.Strings(scopes)
-	return scopes
+	return scopes, nil
 }

--- a/remotes/docker/scope.go
+++ b/remotes/docker/scope.go
@@ -18,6 +18,7 @@ package docker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"sort"
@@ -38,12 +39,6 @@ func (scopes tokenScopes) add(ts tokenScope) {
 		match.actions[k] = nil
 	}
 	scopes[ts.resource] = match
-}
-
-func (scopes tokenScopes) merge(other tokenScopes) {
-	for _, v := range other {
-		scopes.add(v)
-	}
 }
 
 func (scopes tokenScopes) contains(other tokenScopes) bool {
@@ -108,7 +103,7 @@ func repositoryScope(refspec reference.Spec, push bool) (tokenScope, error) {
 }
 
 // tokenScopesKey is used for the key for context.WithValue().
-// value: []string (e.g. {"registry:foo/bar:pull"})
+// value: tokenScopes{}
 type tokenScopesKey struct{}
 
 // contextWithRepositoryScope returns a context with tokenScopesKey{} and the repository scope value.
@@ -172,9 +167,13 @@ func parseTokenScope(s string) (tokenScope, error) {
 	}, nil
 }
 
-// getTokenScopes returns a map of resource -> tokenScope from ctx.Value(tokenScopesKey{}) and params["scope"].
-func getTokenScopes(ctx context.Context, params map[string]string) (tokenScopes, error) {
-	tokenScopes := tokenScopes{}
+// mergeChallengeScopesIntoContextScopes merges scopes returned by an authentication challenge into the current context tokenScopes
+// it returns the mergedTokenScope
+func mergeChallengeScopesIntoContextScopes(ctx context.Context, params map[string]string) (tokenScopes, error) {
+	tokenScopes := getContextScopes(ctx)
+	if tokenScopes == nil {
+		return nil, errors.New("context has no attached tokenScopes")
+	}
 	if params != nil {
 		if paramScopesFlat, ok := params["scope"]; ok {
 			paramScopes := strings.Split(paramScopesFlat, " ")
@@ -186,9 +185,6 @@ func getTokenScopes(ctx context.Context, params map[string]string) (tokenScopes,
 				tokenScopes.add(parsedScope)
 			}
 		}
-	}
-	if contextScopes := getContextScopes(ctx); contextScopes != nil {
-		tokenScopes.merge(contextScopes)
 	}
 	return tokenScopes, nil
 }

--- a/remotes/docker/scope_test.go
+++ b/remotes/docker/scope_test.go
@@ -51,7 +51,7 @@ func TestRepositoryScope(t *testing.T) {
 		t.Run(x.refspec.String(), func(t *testing.T) {
 			actual, err := repositoryScope(x.refspec, x.push)
 			assert.NilError(t, err)
-			assert.Equal(t, x.expected, actual)
+			assert.Equal(t, x.expected, actual.String())
 		})
 	}
 }
@@ -85,7 +85,7 @@ func TestGetTokenScopes(t *testing.T) {
 				"scope": c.scopesFlat,
 			})
 			assert.NilError(t, err)
-			assert.DeepEqual(t, scopes, c.expected)
+			assert.DeepEqual(t, scopes.flatten(), c.expected)
 		})
 	}
 }

--- a/remotes/docker/tokencache.go
+++ b/remotes/docker/tokencache.go
@@ -1,0 +1,114 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package docker
+
+import (
+	"sync"
+	"time"
+)
+
+type token struct {
+	scopes  tokenScopes
+	expires time.Time
+	token   string
+}
+
+func (t *token) expired() bool {
+	return t.expires.Before(time.Now())
+}
+
+func (t *token) satisfies(scopes tokenScopes) bool {
+	return t.scopes.contains(scopes)
+}
+
+type hostTokens struct {
+	mut    sync.RWMutex
+	tokens []token
+}
+
+func (ht *hostTokens) removeExpiredNoLock() {
+	valid := 0
+	for _, t := range ht.tokens {
+		if !t.expired() {
+			ht.tokens[valid] = t
+			valid++
+		}
+	}
+	ht.tokens = ht.tokens[:valid]
+}
+
+func (ht *hostTokens) removeExpired() {
+	ht.mut.Lock()
+	defer ht.mut.Unlock()
+	ht.removeExpiredNoLock()
+}
+
+func (ht *hostTokens) getForScopes(scopes tokenScopes) string {
+	ht.removeExpired()
+	ht.mut.RLock()
+	defer ht.mut.RUnlock()
+	for _, t := range ht.tokens {
+		if t.satisfies(scopes) {
+			return t.token
+		}
+	}
+	return ""
+}
+
+func (ht *hostTokens) add(scopes tokenScopes, expires time.Time, t string) {
+	ht.mut.Lock()
+	defer ht.mut.Unlock()
+	ht.removeExpiredNoLock()
+	// the new token is likely to be the next one to use. prepending it then
+	ht.tokens = append([]token{{scopes: scopes, expires: expires, token: t}}, ht.tokens...)
+}
+
+func newTokenCache() *tokenCache {
+	return &tokenCache{
+		tokens: make(map[string]*hostTokens),
+	}
+}
+
+type tokenCache struct {
+	mut    sync.RWMutex
+	tokens map[string]*hostTokens
+}
+
+func (c *tokenCache) get(host string, scopes tokenScopes) string {
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+	if ht, ok := c.tokens[host]; ok {
+		return ht.getForScopes(scopes)
+	}
+	return ""
+}
+
+func (c *tokenCache) getOrCreateHostTokens(host string) *hostTokens {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+	if ht, ok := c.tokens[host]; ok {
+		return ht
+	}
+	ht := &hostTokens{}
+	c.tokens[host] = ht
+	return ht
+}
+
+func (c *tokenCache) add(host string, scopes tokenScopes, expires time.Time, token string) {
+	ht := c.getOrCreateHostTokens(host)
+	ht.add(scopes, expires, token)
+}

--- a/remotes/docker/tokencache_test.go
+++ b/remotes/docker/tokencache_test.go
@@ -1,0 +1,133 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package docker
+
+import (
+	"testing"
+	"time"
+
+	"gotest.tools/assert"
+)
+
+func (c *tokenCache) withEntry(host string, scopes tokenScopes, expires time.Time, token string) *tokenCache {
+	c.add(host, scopes, expires, token)
+	return c
+}
+
+func (s tokenScopes) withEntry(resource string, actions ...string) tokenScopes {
+	actionsMap := map[string]interface{}{}
+	for _, a := range actions {
+		actionsMap[a] = nil
+	}
+	s.add(tokenScope{
+		resource: resource,
+		actions:  actionsMap,
+	})
+	return s
+}
+
+func TestTokenCache(t *testing.T) {
+	cases := []struct {
+		name            string
+		cacheState      *tokenCache
+		requestedHost   string
+		requestedScopes tokenScopes
+		expected        string
+	}{
+		{
+			name:          "empty",
+			cacheState:    newTokenCache(),
+			requestedHost: "test",
+			expected:      "",
+		},
+		{
+			name:            "exact-match",
+			cacheState:      newTokenCache().withEntry("host1", tokenScopes{}.withEntry("resource", "action"), time.Now().Add(time.Hour), "token"),
+			requestedHost:   "host1",
+			requestedScopes: tokenScopes{}.withEntry("resource", "action"),
+			expected:        "token",
+		},
+		{
+			name:            "contains-more-actions",
+			cacheState:      newTokenCache().withEntry("host1", tokenScopes{}.withEntry("resource", "action", "action2"), time.Now().Add(time.Hour), "token"),
+			requestedHost:   "host1",
+			requestedScopes: tokenScopes{}.withEntry("resource", "action"),
+			expected:        "token",
+		},
+		{
+			name:            "contains-more-resources",
+			cacheState:      newTokenCache().withEntry("host1", tokenScopes{}.withEntry("resource", "action").withEntry("resource2", "action"), time.Now().Add(time.Hour), "token"),
+			requestedHost:   "host1",
+			requestedScopes: tokenScopes{}.withEntry("resource", "action"),
+			expected:        "token",
+		},
+		{
+			name:            "host-not-match",
+			cacheState:      newTokenCache().withEntry("host1", tokenScopes{}.withEntry("resource", "action"), time.Now().Add(time.Hour), "token"),
+			requestedHost:   "host2",
+			requestedScopes: tokenScopes{}.withEntry("resource", "action"),
+			expected:        "",
+		},
+		{
+			name:            "expired",
+			cacheState:      newTokenCache().withEntry("host1", tokenScopes{}.withEntry("resource", "action"), time.Now().Add(-time.Hour), "token"),
+			requestedHost:   "host1",
+			requestedScopes: tokenScopes{}.withEntry("resource", "action"),
+			expected:        "",
+		},
+		{
+			name:            "scope-mismatch",
+			cacheState:      newTokenCache().withEntry("host1", tokenScopes{}.withEntry("resource", "action2"), time.Now().Add(time.Hour), "token"),
+			requestedHost:   "host1",
+			requestedScopes: tokenScopes{}.withEntry("resource", "action"),
+			expected:        "",
+		},
+		{
+			name: "multiple-candidates",
+			cacheState: newTokenCache().withEntry("host1", tokenScopes{}.withEntry("resource", "action"), time.Now().Add(time.Hour), "token").
+				withEntry("host1", tokenScopes{}.withEntry("resource2", "action"), time.Now().Add(time.Hour), "token2"),
+			requestedHost:   "host1",
+			requestedScopes: tokenScopes{}.withEntry("resource", "action"),
+			expected:        "token",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := c.cacheState.get(c.requestedHost, c.requestedScopes)
+			assert.Equal(t, result, c.expected)
+		})
+	}
+}
+
+func TestRemoveExpiredTokens(t *testing.T) {
+	tokens := []token{
+		{token: "1", expires: time.Now().Add(time.Hour)},
+		{token: "2", expires: time.Now().Add(-time.Hour)},
+		{token: "3", expires: time.Now().Add(-time.Hour)},
+		{token: "4", expires: time.Now().Add(time.Hour)},
+	}
+
+	ht := hostTokens{
+		tokens: tokens,
+	}
+
+	ht.removeExpired()
+	assert.Check(t, len(ht.tokens) == 2)
+	assert.Equal(t, "1", ht.tokens[0].token)
+	assert.Equal(t, "4", ht.tokens[1].token)
+}


### PR DESCRIPTION
Based on #3052 

Following @dmcgowan advice (https://github.com/containerd/containerd/pull/3045#issuecomment-467181558), I wrote support for mounting blobs in a way that does not require a new interface, by just adding an OriginProvider field in the Resolver Options.

On the PRO side, it requires less changes to calling code to add mount capabilities.
~On the CON side, `Pusher.Push` can now return a nil writer (in cases where the Push has been replaced by a mount) with no error.~ <-mitigated that by returning a ErrAlreadyExist error. Would love to have feedback on this.

I slightly prefer my previous design as the new one can provoke nil-dereferences panics in existing callers code.