### PR TITLE
BUILDING.md: update testing section

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -220,8 +220,7 @@ containerd --config config.toml
 During the automated CI the unit tests and integration tests are run as part of the PR validation. As a developer you can run these tests locally by using any of the following `Makefile` targets:
  - `make test`: run all non-integration tests that do not require `root` privileges
  - `make root-test`: run all non-integration tests which require `root`
- - `make integration`: run all tests, including integration tests and those which require `root`
- - `make integration-parallel`: run all tests (integration and root-required included) in parallel mode
+ - `make integration`: run all tests, including integration tests and those which require `root`. `TESTFLAGS_PARALLEL` can be used to control parallelism. For example, `TESTFLAGS_PARALLEL=1 make integration` will lead a non-parallel execution. The default value of `TESTFLAGS_PARALLEL` is **8**.
 
 To execute a specific test or set of tests you can use the `go test` capabilities
 without using the `Makefile` targets. The following examples show how to specify a test


### PR DESCRIPTION
The integration-parallel has been removed by https://github.com/containerd/containerd/pull/1759/commits/4df7075a740def1b68f345dd20bca73ff9fd04b0.
Update Makefile targets in BUILDING.md.

Signed-off-by: Li Yuxuan <liyuxuan04@baidu.com>