### PR TITLE
Fix runtime v2 option handling

### DIFF
--- a/container.go
+++ b/container.go
@@ -229,7 +229,9 @@ func (c *container) NewTask(ctx context.Context, ioCreate cio.Creator, opts ...N
 			})
 		}
 	}
-	var info TaskInfo
+	info := TaskInfo{
+		runtime: r.Runtime.Name,
+	}
 	for _, o := range opts {
 		if err := o(ctx, c.client, &info); err != nil {
 			return nil, err

--- a/container_checkpoint_test.go
+++ b/container_checkpoint_test.go
@@ -485,7 +485,7 @@ func TestCRWithImagePath(t *testing.T) {
 	}
 	defer ncontainer.Delete(ctx, WithSnapshotCleanup)
 
-	ntask, err := ncontainer.NewTask(ctx, empty(), WithRestoreImagePath(client.runtime, imagePath))
+	ntask, err := ncontainer.NewTask(ctx, empty(), WithRestoreImagePath(imagePath))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/container_checkpoint_test.go
+++ b/container_checkpoint_test.go
@@ -461,7 +461,7 @@ func TestCRWithImagePath(t *testing.T) {
 	defer os.RemoveAll(crDir)
 	imagePath := filepath.Join(crDir, "cr")
 	// checkpoint task
-	if _, err := task.Checkpoint(ctx, WithCheckpointImagePath(client.runtime, imagePath)); err != nil {
+	if _, err := task.Checkpoint(ctx, WithCheckpointImagePath(imagePath)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/task.go
+++ b/task.go
@@ -43,7 +43,7 @@ import (
 	google_protobuf "github.com/gogo/protobuf/types"
 	digest "github.com/opencontainers/go-digest"
 	is "github.com/opencontainers/image-spec/specs-go"
-	"github.com/opencontainers/image-spec/specs-go/v1"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 )
@@ -131,6 +131,12 @@ type TaskInfo struct {
 	RootFS []mount.Mount
 	// Options hold runtime specific settings for task creation
 	Options interface{}
+	runtime string
+}
+
+// Runtime name for the container
+func (i *TaskInfo) Runtime() string {
+	return i.runtime
 }
 
 // Task is the executable object within containerd

--- a/task_opts.go
+++ b/task_opts.go
@@ -92,9 +92,9 @@ func WithCheckpointName(name string) CheckpointTaskOpts {
 }
 
 // WithCheckpointImagePath sets image path for checkpoint option
-func WithCheckpointImagePath(rt, path string) CheckpointTaskOpts {
+func WithCheckpointImagePath(path string) CheckpointTaskOpts {
 	return func(r *CheckpointTaskInfo) error {
-		if CheckRuntime(rt, "io.containerd.runc") {
+		if CheckRuntime(r.Runtime(), "io.containerd.runc") {
 			if r.Options == nil {
 				r.Options = &options.CheckpointOptions{}
 			}

--- a/task_opts.go
+++ b/task_opts.go
@@ -118,9 +118,9 @@ func WithCheckpointImagePath(rt, path string) CheckpointTaskOpts {
 }
 
 // WithRestoreImagePath sets image path for create option
-func WithRestoreImagePath(rt, path string) NewTaskOpts {
+func WithRestoreImagePath(path string) NewTaskOpts {
 	return func(ctx context.Context, c *Client, ti *TaskInfo) error {
-		if CheckRuntime(rt, "io.containerd.runc") {
+		if CheckRuntime(ti.Runtime(), "io.containerd.runc") {
 			if ti.Options == nil {
 				ti.Options = &options.Options{}
 			}

--- a/task_opts_unix.go
+++ b/task_opts_unix.go
@@ -22,36 +22,58 @@ import (
 	"context"
 
 	"github.com/containerd/containerd/runtime/linux/runctypes"
+	"github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/pkg/errors"
 )
 
 // WithNoNewKeyring causes tasks not to be created with a new keyring for secret storage.
 // There is an upper limit on the number of keyrings in a linux system
 func WithNoNewKeyring(ctx context.Context, c *Client, ti *TaskInfo) error {
-	if ti.Options == nil {
-		ti.Options = &runctypes.CreateOptions{}
+	if CheckRuntime(ti.Runtime(), "io.containerd.runc") {
+		if ti.Options == nil {
+			ti.Options = &options.Options{}
+		}
+		opts, ok := ti.Options.(*options.Options)
+		if !ok {
+			return errors.New("invalid v2 shim create options format")
+		}
+		opts.NoNewKeyring = true
+	} else {
+		if ti.Options == nil {
+			ti.Options = &runctypes.CreateOptions{}
+		}
+		opts, ok := ti.Options.(*runctypes.CreateOptions)
+		if !ok {
+			return errors.New("could not cast TaskInfo Options to CreateOptions")
+		}
+		opts.NoNewKeyring = true
 	}
-	opts, ok := ti.Options.(*runctypes.CreateOptions)
-	if !ok {
-		return errors.New("could not cast TaskInfo Options to CreateOptions")
-	}
-
-	opts.NoNewKeyring = true
 	return nil
 }
 
 // WithNoPivotRoot instructs the runtime not to you pivot_root
-func WithNoPivotRoot(_ context.Context, _ *Client, info *TaskInfo) error {
-	if info.Options == nil {
-		info.Options = &runctypes.CreateOptions{
-			NoPivotRoot: true,
+func WithNoPivotRoot(_ context.Context, _ *Client, ti *TaskInfo) error {
+	if CheckRuntime(ti.Runtime(), "io.containerd.runc") {
+		if ti.Options == nil {
+			ti.Options = &options.Options{}
 		}
-		return nil
+		opts, ok := ti.Options.(*options.Options)
+		if !ok {
+			return errors.New("invalid v2 shim create options format")
+		}
+		opts.NoPivotRoot = true
+	} else {
+		if ti.Options == nil {
+			ti.Options = &runctypes.CreateOptions{
+				NoPivotRoot: true,
+			}
+			return nil
+		}
+		opts, ok := ti.Options.(*runctypes.CreateOptions)
+		if !ok {
+			return errors.New("invalid options type, expected runctypes.CreateOptions")
+		}
+		opts.NoPivotRoot = true
 	}
-	opts, ok := info.Options.(*runctypes.CreateOptions)
-	if !ok {
-		return errors.New("invalid options type, expected runctypes.CreateOptions")
-	}
-	opts.NoPivotRoot = true
 	return nil
 }


### PR DESCRIPTION
This allows opts to handle the runtime better than requiring the client to pass the runtime information. 