### PR TITLE
[release/1.1 backport] Bump to Go 1.11.x

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.10
+    - GO_VERSION: 1.11
 
 before_build:
   - choco install -y mingw

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 language: go
 
 go:
-  - "1.10.x"
+  - "1.11.x"
 
 go_import_path: github.com/containerd/containerd
 

--- a/content/testsuite/testsuite.go
+++ b/content/testsuite/testsuite.go
@@ -401,6 +401,7 @@ func checkLabels(ctx context.Context, t *testing.T, cs content.Store) {
 	labels := map[string]string{
 		"k1": "v1",
 		"k2": "v2",
+
 		"containerd.io/gc.root": rootTime,
 	}
 
@@ -437,6 +438,7 @@ func checkLabels(ctx context.Context, t *testing.T, cs content.Store) {
 
 	info.Labels = map[string]string{
 		"k1": "v1",
+
 		"containerd.io/gc.root": rootTime,
 	}
 	preUpdate = time.Now()

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -7,19 +7,19 @@
 #
 
 # Install proto3
-FROM golang:1.10 AS proto3
+FROM golang:1.11 AS proto3
 RUN apt-get update && apt-get install -y autoconf automake g++ libtool unzip
 COPY script/setup/install-protobuf install-protobuf
 RUN ./install-protobuf
 
 # Install runc
-FROM golang:1.10 AS runc
+FROM golang:1.11 AS runc
 RUN apt-get update && apt-get install -y curl libseccomp-dev
 COPY vendor.conf /go/src/github.com/containerd/containerd/vendor.conf
 COPY script/setup/install-runc install-runc
 RUN ./install-runc
 
-FROM golang:1.10
+FROM golang:1.11
 RUN apt-get update && apt-get install -y btrfs-tools gcc git libseccomp-dev make xfsprogs
 
 COPY --from=proto3 /usr/local/bin/protoc /usr/local/bin/protoc

--- a/metadata/content_test.go
+++ b/metadata/content_test.go
@@ -130,7 +130,7 @@ func checkContentLeased(ctx context.Context, db *DB, dgst digest.Digest) error {
 	return db.View(func(tx *bolt.Tx) error {
 		bkt := getBucket(tx, bucketKeyVersion, []byte(ns), bucketKeyObjectLeases, []byte(lease), bucketKeyObjectContent)
 		if bkt == nil {
-			return errors.Wrapf(errdefs.ErrNotFound, "bucket not found", lease)
+			return errors.Wrapf(errdefs.ErrNotFound, "bucket not found %s", lease)
 		}
 		v := bkt.Get([]byte(dgst.String()))
 		if v == nil {

--- a/snapshots/testsuite/testsuite.go
+++ b/snapshots/testsuite/testsuite.go
@@ -687,6 +687,7 @@ func checkUpdate(ctx context.Context, t *testing.T, snapshotter snapshots.Snapsh
 		expected = map[string]string{
 			"l1": "updated",
 			"l3": "v3",
+
 			"containerd.io/gc.root": rootTime,
 		}
 		st.Labels = map[string]string{
@@ -701,6 +702,7 @@ func checkUpdate(ctx context.Context, t *testing.T, snapshotter snapshots.Snapsh
 
 		expected = map[string]string{
 			"l4": "v4",
+
 			"containerd.io/gc.root": rootTime,
 		}
 		st.Labels = expected


### PR DESCRIPTION
backport of https://github.com/containerd/containerd/pull/2420, https://github.com/containerd/containerd/pull/2436 and https://github.com/containerd/containerd/pull/2435

Go 1.12 was released, with which Go 1.10 reached end of support, so let's update this release branch to test against Go 1.11 (Go 1.12 still has some issues, but we could update to Go 1.12.1 once that's released)
