### PR TITLE
[release/1.2] Update cri to 8e7ca12f411d65de58ca672e8e4a0c1464b4fe34.

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -43,7 +43,7 @@ github.com/google/go-cmp v0.1.0
 go.etcd.io/bbolt v1.3.1-etcd.8
 
 # cri dependencies
-github.com/containerd/cri da0c016c830b2ea97fd1d737c49a568a816bf964 # release/1.2 branch
+github.com/containerd/cri 8e7ca12f411d65de58ca672e8e4a0c1464b4fe34 # release/1.2 branch
 github.com/containerd/go-cni 40bcf8ec8acd7372be1d77031d585d5d8e561c90
 github.com/blang/semver v3.1.0
 github.com/containernetworking/cni v0.6.0

--- a/vendor/github.com/containerd/cri/pkg/annotations/annotations.go
+++ b/vendor/github.com/containerd/cri/pkg/annotations/annotations.go
@@ -32,6 +32,15 @@ const (
 	// SandboxID is the sandbox ID annotation
 	SandboxID = "io.kubernetes.cri.sandbox-id"
 
+	// SandboxLogDir is the pod log directory annotation.
+	// If the sandbox needs to generate any log, it will put it into this directory.
+	// Kubelet will be responsible for:
+	// 1) Monitoring the disk usage of the log, and including it as part of the pod
+	// ephemeral storage usage.
+	// 2) Cleaning up the logs when the pod is deleted.
+	// NOTE: Kubelet is not responsible for rotating the logs.
+	SandboxLogDir = "io.kubernetes.cri.sandbox-log-directory"
+
 	// UntrustedWorkload is the sandbox annotation for untrusted workload. Untrusted
 	// workload can only run on dedicated runtime for untrusted workload.
 	UntrustedWorkload = "io.kubernetes.cri.untrusted-workload"

--- a/vendor/github.com/containerd/cri/pkg/server/container_create.go
+++ b/vendor/github.com/containerd/cri/pkg/server/container_create.go
@@ -182,7 +182,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	if len(volumeMounts) > 0 {
 		mountMap := make(map[string]string)
 		for _, v := range volumeMounts {
-			mountMap[v.HostPath] = v.ContainerPath
+			mountMap[filepath.Clean(v.HostPath)] = v.ContainerPath
 		}
 		opts = append(opts, customopts.WithVolumes(mountMap))
 	}
@@ -191,7 +191,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 
 	// Get container log path.
 	if config.GetLogPath() != "" {
-		meta.LogPath = filepath.Join(sandbox.Config.GetLogDirectory(), config.GetLogPath())
+		meta.LogPath = filepath.Join(sandboxConfig.GetLogDirectory(), config.GetLogPath())
 	}
 
 	containerIO, err := cio.NewContainerIO(id,
@@ -740,7 +740,7 @@ func setOCIBindMountsPrivileged(g *generator) {
 	spec := g.Config
 	// clear readonly for /sys and cgroup
 	for i, m := range spec.Mounts {
-		if spec.Mounts[i].Destination == "/sys" {
+		if filepath.Clean(spec.Mounts[i].Destination) == "/sys" {
 			clearReadOnly(&spec.Mounts[i])
 		}
 		if m.Type == "cgroup" {
@@ -881,7 +881,7 @@ func defaultRuntimeSpec(id string) (*runtimespec.Spec, error) {
 	// TODO(random-liu): Mount tmpfs for /run and handle copy-up.
 	var mounts []runtimespec.Mount
 	for _, mount := range spec.Mounts {
-		if mount.Destination == "/run" {
+		if filepath.Clean(mount.Destination) == "/run" {
 			continue
 		}
 		mounts = append(mounts, mount)

--- a/vendor/github.com/containerd/cri/pkg/server/helpers.go
+++ b/vendor/github.com/containerd/cri/pkg/server/helpers.go
@@ -373,7 +373,7 @@ func checkSelinuxLevel(level string) (bool, error) {
 // isInCRIMounts checks whether a destination is in CRI mount list.
 func isInCRIMounts(dst string, mounts []*runtime.Mount) bool {
 	for _, m := range mounts {
-		if m.ContainerPath == dst {
+		if filepath.Clean(m.ContainerPath) == filepath.Clean(dst) {
 			return true
 		}
 	}

--- a/vendor/github.com/containerd/cri/pkg/server/sandbox_run.go
+++ b/vendor/github.com/containerd/cri/pkg/server/sandbox_run.go
@@ -435,6 +435,7 @@ func (c *criService) generateSandboxContainerSpec(id string, config *runtime.Pod
 
 	g.AddAnnotation(annotations.ContainerType, annotations.ContainerTypeSandbox)
 	g.AddAnnotation(annotations.SandboxID, id)
+	g.AddAnnotation(annotations.SandboxLogDir, config.GetLogDirectory())
 
 	return g.Config, nil
 }

--- a/vendor/github.com/containerd/cri/vendor.conf
+++ b/vendor/github.com/containerd/cri/vendor.conf
@@ -3,7 +3,7 @@ github.com/blang/semver v3.1.0
 github.com/BurntSushi/toml a368813c5e648fee92e5f6c30e3944ff9d5e8895
 github.com/containerd/cgroups 5e610833b72089b37d0e615de9a92dfc043757c2
 github.com/containerd/console c12b1e7919c14469339a5d38f2f8ed9b64a9de23
-github.com/containerd/containerd 0137339c8c1d55de5545ffdd723199dfba27cb24
+github.com/containerd/containerd 583472f67a3d7c258f874347339688de05802790
 github.com/containerd/continuity bd77b46c8352f74eb12c85bdc01f4b90f69d66b4
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c
 github.com/containerd/go-cni 40bcf8ec8acd7372be1d77031d585d5d8e561c90
@@ -14,7 +14,7 @@ github.com/containernetworking/cni v0.6.0
 github.com/containernetworking/plugins v0.7.0
 github.com/coreos/go-systemd v14
 github.com/davecgh/go-spew v1.1.0
-github.com/docker/distribution b38e5838b7b2f2ad48e06ec4b500011976080621
+github.com/docker/distribution 0d3efadf0154c2b8a4e7b6621fff9809655cc580
 github.com/docker/docker 86f080cff0914e9694068ed78d503701667c4c00
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/docker/go-metrics 4ea375f7759c82740c893fc030bc37088d2ec098
@@ -39,7 +39,7 @@ github.com/modern-go/concurrent 1.0.3
 github.com/modern-go/reflect2 1.0.1
 github.com/opencontainers/go-digest c9281466c8b2f606084ac71339773efd177436e7
 github.com/opencontainers/image-spec v1.0.1
-github.com/opencontainers/runc 12f6a991201fdb8f82579582d5e00e28fba06d0a
+github.com/opencontainers/runc 6635b4f0c6af3810594d2770f662f34ddc15b40d
 github.com/opencontainers/runtime-spec eba862dc2470385a233c7507392675cbeadf7353
 github.com/opencontainers/runtime-tools v0.6.0
 github.com/opencontainers/selinux b6fa367ed7f534f9ba25391cc2d467085dbb445a
@@ -63,7 +63,7 @@ golang.org/x/crypto 49796115aa4b964c318aad4f3084fdb41e9aa067
 golang.org/x/net b3756b4b77d7b13260a0a2ec658753cf48922eac
 golang.org/x/oauth2 a6bd8cefa1811bd24b86f8902872e4e8225f74c4
 golang.org/x/sync 450f422ab23cf9881c94e2db30cac0eb1b7cf80c
-golang.org/x/sys 1b2967e3c290b7c545b3db0deeda16e9be4f98a2 https://github.com/golang/sys
+golang.org/x/sys 41f3e6584952bb034a481797859f6ab34b6803bd https://github.com/golang/sys
 golang.org/x/text 19e51611da83d6be54ddafce4a4af510cb3e9ea4
 golang.org/x/time f51c12702a4d776e4c1fa9b0fabab841babae631
 google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944


### PR DESCRIPTION
* Fix a bug that pod can't get started when a volume is defined in both the image and the pod spec, but only one of them has a tailing `/`. https://github.com/containerd/cri/issues/1059
* CRI plugin now passes the pod log directory down to the OCI runtime with a new OCI annotation `io.kubernetes.cri.sandbox-log-directory`. Sandbox based runtime can generate sandbox level logs into the pod log directory, and kubelet will manage its disk usage and handle its cleanup.

Signed-off-by: Lantao Liu <lantaol@google.com>