### PR TITLE
[release/1.2 backporting] bugfix: unpack should always set the snapshot gc label

### DIFF
--- a/image.go
+++ b/image.go
@@ -170,26 +170,22 @@ func (i *image) Unpack(ctx context.Context, snapshotterName string) error {
 		chain = append(chain, layer.Diff.Digest)
 	}
 
-	if unpacked {
-		desc, err := i.i.Config(ctx, cs, i.platform)
-		if err != nil {
-			return err
-		}
-
-		rootfs := identity.ChainID(chain).String()
-
-		cinfo := content.Info{
-			Digest: desc.Digest,
-			Labels: map[string]string{
-				fmt.Sprintf("containerd.io/gc.ref.snapshot.%s", snapshotterName): rootfs,
-			},
-		}
-		if _, err := cs.Update(ctx, cinfo, fmt.Sprintf("labels.containerd.io/gc.ref.snapshot.%s", snapshotterName)); err != nil {
-			return err
-		}
+	desc, err := i.i.Config(ctx, cs, i.platform)
+	if err != nil {
+		return err
 	}
 
-	return nil
+	rootfs := identity.ChainID(chain).String()
+
+	cinfo := content.Info{
+		Digest: desc.Digest,
+		Labels: map[string]string{
+			fmt.Sprintf("containerd.io/gc.ref.snapshot.%s", snapshotterName): rootfs,
+		},
+	}
+
+	_, err = cs.Update(ctx, cinfo, fmt.Sprintf("labels.containerd.io/gc.ref.snapshot.%s", snapshotterName))
+	return err
 }
 
 func (i *image) getLayers(ctx context.Context, platform platforms.MatchComparer) ([]rootfs.Layer, error) {


### PR DESCRIPTION
There are two images, A and B. A is based on B. If user pulls A first,
then user pulls B. containerd already has the unpacked snapshots in the
backend. During unpacking B, the client doesn't set gc snapshot
reference label to the config descriptor. That is the problem.

The gc module cannot reach the snapshot from the config descriptor. If
user removes the image B, the snapshot will be deleted by gc module.
That is why we should always set the snapshot gc label to config
descriptor.

Signed-off-by: Wei Fu <fhfuwei@163.com>
(cherry picked from commit 2d96aad771b3a0ea70e9d057c8d00aa734b55c40)
Signed-off-by: Wei Fu <fuweid89@gmail.com>