### PR TITLE
Update mailmap for cgroup authors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -2,7 +2,9 @@ Abhinandan Prativadi <abhi@docker.com> Abhinandan Prativadi <aprativadi@gmail.co
 Abhinandan Prativadi <abhi@docker.com> abhi <abhi@docker.com>
 Akihiro Suda <suda.akihiro@lab.ntt.co.jp> Akihiro Suda <suda.kyoto@gmail.com>
 Andrei Vagin <avagin@virtuozzo.com> Andrei Vagin <avagin@openvz.org>
+Brent Baude <bbaude@redhat.com> baude <bbaude@redhat.com>
 Frank Yang <yyb196@gmail.com> frank yang <yyb196@gmail.com>
+Georgia Panoutsakopoulou <gpanoutsak@gmail.com> gpanouts <gpanoutsak@gmail.com>
 Jie Zhang <iamkadisi@163.com> kadisi <iamkadisi@163.com>
 John Howard <john.howard@microsoft.com> John Howard <jhoward@microsoft.com>
 Justin Terry <juterry@microsoft.com> Justin Terry (VM) <juterry@microsoft.com>


### PR DESCRIPTION
Fix to show real names in contributor list, to be updated for 1.2.5 as well