### PR TITLE
[release/1.2] Update cri to a92c40017473cbe0239ce180125f12669757e44f.

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -43,7 +43,7 @@ github.com/google/go-cmp v0.1.0
 go.etcd.io/bbolt v1.3.1-etcd.8
 
 # cri dependencies
-github.com/containerd/cri 8e7ca12f411d65de58ca672e8e4a0c1464b4fe34 # release/1.2 branch
+github.com/containerd/cri a92c40017473cbe0239ce180125f12669757e44f # release/1.2 branch
 github.com/containerd/go-cni 40bcf8ec8acd7372be1d77031d585d5d8e561c90
 github.com/blang/semver v3.1.0
 github.com/containernetworking/cni v0.6.0


### PR DESCRIPTION
Bug fixes:
* Fix a bug causes container start failure after in-place upgrade to containerd 1.2.4+ or 1.1.6+.

Signed-off-by: Lantao Liu <lantaol@google.com>