### PR TITLE
[release/1.1 backport] Makefile: allow overriding package name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ DESTDIR=/usr/local
 # Used to populate variables in version package.
 VERSION=$(shell git describe --match 'v[0-9]*' --dirty='.m' --always)
 REVISION=$(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi)
+PACKAGE=github.com/containerd/containerd
 
 ifneq "$(strip $(shell command -v go 2>/dev/null))" ""
 	GOOS ?= $(shell go env GOOS)
@@ -77,8 +78,8 @@ MANPAGES=ctr.1 containerd.1 config.toml.5 containerd-config.1
 # Build tags seccomp and apparmor are needed by CRI plugin.
 BUILDTAGS ?= seccomp apparmor
 GO_TAGS=$(if $(BUILDTAGS),-tags "$(BUILDTAGS)",)
-GO_LDFLAGS=-ldflags '-s -w -X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PKG) $(EXTRA_LDFLAGS)'
-SHIM_GO_LDFLAGS=-ldflags '-s -w -X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PKG) -extldflags "-static"'
+GO_LDFLAGS=-ldflags '-s -w -X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PACKAGE) $(EXTRA_LDFLAGS)'
+SHIM_GO_LDFLAGS=-ldflags '-s -w -X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PACKAGE) -extldflags "-static"'
 
 #Replaces ":" (*nix), ";" (windows) with newline for easy parsing
 GOPATHS=$(shell echo ${GOPATH} | tr ":" "\n" | tr ";" "\n")


### PR DESCRIPTION
backport of https://github.com/containerd/containerd/pull/3096 for the 1.1 release branch

With this patch applied, the package-name in the `--version` output can be overridden;

    make PACKAGE=containerd.io binaries

    ./bin/containerd --version
    containerd containerd.io v1.2.0-329-ga15b6e20.m a15b6e2097c48b632dbdc63254bad4c62b69e709.m

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
(cherry picked from commit b858cfb41b4f49d93990380faed2af5dd9269ffe)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>