### PR TITLE
ctr: fix image cmd ArgsUsage

### DIFF
--- a/cmd/ctr/commands/images/images.go
+++ b/cmd/ctr/commands/images/images.go
@@ -54,7 +54,7 @@ var listCommand = cli.Command{
 	Name:        "list",
 	Aliases:     []string{"ls"},
 	Usage:       "list images known to containerd",
-	ArgsUsage:   "[flags] <ref>",
+	ArgsUsage:   "[flags] [<filter>, ...]",
 	Description: "list images registered with containerd",
 	Flags: []cli.Flag{
 		cli.BoolFlag{
@@ -196,7 +196,7 @@ var setLabelsCommand = cli.Command{
 var checkCommand = cli.Command{
 	Name:        "check",
 	Usage:       "check that an image has all content available locally",
-	ArgsUsage:   "[flags] <ref> [<ref>, ...]",
+	ArgsUsage:   "[flags] [<filter>, ...]",
 	Description: "check that an image has all content available locally",
 	Flags:       commands.SnapshotterFlags,
 	Action: func(context *cli.Context) error {


### PR DESCRIPTION
ctr image list/check 's ArgsUsage should be filter, not ref

Signed-off-by: Ace-Tang <aceapril@126.com>