### PR TITLE
[release/1.2 backport] seccomp: whitelist statx syscall

### DIFF
--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -319,6 +319,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				"stat64",
 				"statfs",
 				"statfs64",
+				"statx",
 				"symlink",
 				"symlinkat",
 				"sync",


### PR DESCRIPTION
backport of https://github.com/containerd/containerd/pull/3111 for the release/1.2 branch

This whitelists the statx syscall; libseccomp-2.3.3 or up
is needed for this, older seccomp versions will ignore this.

Equivalent of https://github.com/moby/moby/pull/36417
addresses https://github.com/docker/for-linux/issues/616