### PR TITLE
Windows: Root/state create with right ACL and in right place

### DIFF
--- a/defaults/defaults_windows.go
+++ b/defaults/defaults_windows.go
@@ -26,10 +26,10 @@ import (
 var (
 	// DefaultRootDir is the default location used by containerd to store
 	// persistent data
-	DefaultRootDir = filepath.Join(os.Getenv("programfiles"), "containerd", "root")
+	DefaultRootDir = filepath.Join(os.Getenv("ProgramData"), "containerd", "root")
 	// DefaultStateDir is the default location used by containerd to store
 	// transient data
-	DefaultStateDir = filepath.Join(os.Getenv("programfiles"), "containerd", "state")
+	DefaultStateDir = filepath.Join(os.Getenv("ProgramData"), "containerd", "state")
 )
 
 const (

--- a/services/server/server.go
+++ b/services/server/server.go
@@ -43,6 +43,7 @@ import (
 	srvconfig "github.com/containerd/containerd/services/server/config"
 	"github.com/containerd/containerd/snapshots"
 	ssproxy "github.com/containerd/containerd/snapshots/proxy"
+	"github.com/containerd/containerd/sys"
 	metrics "github.com/docker/go-metrics"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/pkg/errors"
@@ -61,10 +62,10 @@ func CreateTopLevelDirectories(config *srvconfig.Config) error {
 		return errors.New("root and state must be different paths")
 	}
 
-	if err := os.MkdirAll(config.Root, 0711); err != nil {
+	if err := sys.MkdirAllWithACL(config.Root, 0711); err != nil {
 		return err
 	}
-	if err := os.MkdirAll(config.State, 0711); err != nil {
+	if err := sys.MkdirAllWithACL(config.State, 0711); err != nil {
 		return err
 	}
 	return nil

--- a/sys/filesys_unix.go
+++ b/sys/filesys_unix.go
@@ -24,3 +24,8 @@ import "os"
 func ForceRemoveAll(path string) error {
 	return os.RemoveAll(path)
 }
+
+// MkdirAllWithACL is a wrapper for os.MkdirAll on Unix systems.
+func MkdirAllWithACL(path string, perm os.FileMode) error {
+	return os.MkdirAll(path, perm)
+}

--- a/sys/filesys_windows.go
+++ b/sys/filesys_windows.go
@@ -30,6 +30,11 @@ import (
 	"github.com/Microsoft/hcsshim"
 )
 
+const (
+	// SddlAdministratorsLocalSystem is local administrators plus NT AUTHORITY\System
+	SddlAdministratorsLocalSystem = "D:P(A;OICI;GA;;;BA)(A;OICI;GA;;;SY)"
+)
+
 // MkdirAllWithACL is a wrapper for MkdirAll that creates a directory
 // ACL'd for Builtin Administrators and Local System.
 func MkdirAllWithACL(path string, perm os.FileMode) error {
@@ -78,7 +83,7 @@ func mkdirall(path string, adminAndLocalSystem bool) error {
 
 	if j > 1 {
 		// Create parent
-		err = mkdirall(path[0:j-1], false)
+		err = mkdirall(path[0:j-1], adminAndLocalSystem)
 		if err != nil {
 			return err
 		}
@@ -112,8 +117,7 @@ func mkdirall(path string, adminAndLocalSystem bool) error {
 // and Local System.
 func mkdirWithACL(name string) error {
 	sa := syscall.SecurityAttributes{Length: 0}
-	sddl := "D:P(A;OICI;GA;;;BA)(A;OICI;GA;;;SY)"
-	sd, err := winio.SddlToSecurityDescriptor(sddl)
+	sd, err := winio.SddlToSecurityDescriptor(SddlAdministratorsLocalSystem)
 	if err != nil {
 		return &os.PathError{Op: "mkdir", Path: name, Err: err}
 	}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@jterry75 PTAL. This: 

 - moves the default root to under programdata rather than `program files`;
 - creates the root/state directories ACL'd to administrators & localsystem
 - fixes a bug in the recursion of the previously unused `mkdirall` which wasn't passing the requested `adminAndLocalSystem`


After this change:
```
PS C:\programdata> icacls containerd
containerd BUILTIN\Administrators:(OI)(CI)(F)
           NT AUTHORITY\SYSTEM:(OI)(CI)(F)

Successfully processed 1 files; Failed processing 0 files
PS C:\programdata> icacls .\containerd\root\
.\containerd\root\ BUILTIN\Administrators:(OI)(CI)(F)
                   NT AUTHORITY\SYSTEM:(OI)(CI)(F)

Successfully processed 1 files; Failed processing 0 files
PS C:\programdata> icacls .\containerd\state\
.\containerd\state\ BUILTIN\Administrators:(OI)(CI)(F)
                    NT AUTHORITY\SYSTEM:(OI)(CI)(F)

Successfully processed 1 files; Failed processing 0 files
PS C:\programdata>
```