### PR TITLE
Extend adaptImage function with annotations case

### DIFF
--- a/metadata/adaptors.go
+++ b/metadata/adaptors.go
@@ -51,6 +51,8 @@ func adaptImage(o interface{}) filters.Adaptor {
 			return checkMap(fieldpath[1:], obj.Labels)
 			// TODO(stevvooe): Greater/Less than filters would be awesome for
 			// size. Let's do it!
+		case "annotations":
+			return checkMap(fieldpath[1:], obj.Target.Annotations)
 		}
 
 		return "", false


### PR DESCRIPTION
Extend the adaptImage function with a case for handling the annotations
so they can be used in the filter adaptors for fieldpaths.

This PR addresses issue #3121.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>