### PR TITLE
Extend Applier's Apply() method with an optional options parameter

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -45,9 +45,15 @@ type diffRemote struct {
 	client diffapi.DiffClient
 }
 
-func (r *diffRemote) Apply(ctx context.Context, diff ocispec.Descriptor, mounts []mount.Mount) (ocispec.Descriptor, error) {
+func (r *diffRemote) Apply(ctx context.Context, desc ocispec.Descriptor, mounts []mount.Mount, opts ...diff.ApplyOpt) (ocispec.Descriptor, error) {
+	var config diff.ApplyConfig
+	for _, opt := range opts {
+		if err := opt(&config); err != nil {
+			return ocispec.Descriptor{}, err
+		}
+	}
 	req := &diffapi.ApplyRequest{
-		Diff:   fromDescriptor(diff),
+		Diff:   fromDescriptor(desc),
 		Mounts: fromMounts(mounts),
 	}
 	resp, err := r.client.Apply(ctx, req)

--- a/diff/apply/apply.go
+++ b/diff/apply/apply.go
@@ -53,7 +53,7 @@ var emptyDesc = ocispec.Descriptor{}
 // Apply applies the content associated with the provided digests onto the
 // provided mounts. Archive content will be extracted and decompressed if
 // necessary.
-func (s *fsApplier) Apply(ctx context.Context, desc ocispec.Descriptor, mounts []mount.Mount) (d ocispec.Descriptor, err error) {
+func (s *fsApplier) Apply(ctx context.Context, desc ocispec.Descriptor, mounts []mount.Mount, opts ...diff.ApplyOpt) (d ocispec.Descriptor, err error) {
 	t1 := time.Now()
 	defer func() {
 		if err == nil {

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -51,6 +51,13 @@ type Comparer interface {
 	Compare(ctx context.Context, lower, upper []mount.Mount, opts ...Opt) (ocispec.Descriptor, error)
 }
 
+// ApplyConfig is used to hold parameters needed for a apply operation
+type ApplyConfig struct {
+}
+
+// ApplyOpt is used to configure an Apply operation
+type ApplyOpt func(*ApplyConfig) error
+
 // Applier allows applying diffs between mounts
 type Applier interface {
 	// Apply applies the content referred to by the given descriptor to
@@ -58,7 +65,7 @@ type Applier interface {
 	// implementation and content descriptor. For example, in the common
 	// case the descriptor is a file system difference in tar format,
 	// that tar would be applied on top of the mounts.
-	Apply(ctx context.Context, desc ocispec.Descriptor, mount []mount.Mount) (ocispec.Descriptor, error)
+	Apply(ctx context.Context, desc ocispec.Descriptor, mount []mount.Mount, opts ...ApplyOpt) (ocispec.Descriptor, error)
 }
 
 // WithMediaType sets the media type to use for creating the diff, without

--- a/diff/lcow/lcow.go
+++ b/diff/lcow/lcow.go
@@ -95,7 +95,7 @@ func NewWindowsLcowDiff(store content.Store) (CompareApplier, error) {
 // Apply applies the content associated with the provided digests onto the
 // provided mounts. Archive content will be extracted and decompressed if
 // necessary.
-func (s windowsLcowDiff) Apply(ctx context.Context, desc ocispec.Descriptor, mounts []mount.Mount) (d ocispec.Descriptor, err error) {
+func (s windowsLcowDiff) Apply(ctx context.Context, desc ocispec.Descriptor, mounts []mount.Mount, opts ...diff.ApplyOpt) (d ocispec.Descriptor, err error) {
 	t1 := time.Now()
 	defer func() {
 		if err == nil {

--- a/diff/windows/windows.go
+++ b/diff/windows/windows.go
@@ -87,7 +87,7 @@ func NewWindowsDiff(store content.Store) (CompareApplier, error) {
 // Apply applies the content associated with the provided digests onto the
 // provided mounts. Archive content will be extracted and decompressed if
 // necessary.
-func (s windowsDiff) Apply(ctx context.Context, desc ocispec.Descriptor, mounts []mount.Mount) (d ocispec.Descriptor, err error) {
+func (s windowsDiff) Apply(ctx context.Context, desc ocispec.Descriptor, mounts []mount.Mount, opts ...diff.ApplyOpt) (d ocispec.Descriptor, err error) {
 	t1 := time.Now()
 	defer func() {
 		if err == nil {

--- a/services/diff/local.go
+++ b/services/diff/local.go
@@ -99,8 +99,10 @@ func (l *local) Apply(ctx context.Context, er *diffapi.ApplyRequest, _ ...grpc.C
 		mounts  = toMounts(er.Mounts)
 	)
 
+	var opts []diff.ApplyOpt
+
 	for _, differ := range l.differs {
-		ocidesc, err = differ.Apply(ctx, desc, mounts)
+		ocidesc, err = differ.Apply(ctx, desc, mounts, opts...)
 		if !errdefs.IsNotImplemented(err) {
 			break
 		}


### PR DESCRIPTION
Extend the Applier interface's Apply method with an optional
options map[string]string.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>