### PR TITLE
add cli option to download all manifests

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -281,9 +281,6 @@ func TestImagePullSomePlatforms(t *testing.T) {
 	count := 0
 	for _, manifest := range manifests {
 		children, err := images.Children(ctx, cs, manifest)
-		if err != nil {
-			t.Fatal(err)
-		}
 
 		found := false
 		for _, matcher := range m {
@@ -306,6 +303,8 @@ func TestImagePullSomePlatforms(t *testing.T) {
 				}
 				ra.Close()
 			}
+		} else if err == nil {
+			t.Fatal("manifest should not have pulled children content")
 		}
 	}
 

--- a/cmd/ctr/commands/content/fetch.go
+++ b/cmd/ctr/commands/content/fetch.go
@@ -123,9 +123,9 @@ func NewFetchConfig(ctx context.Context, clicontext *cli.Context) (*FetchConfig,
 		}
 		config.Platforms = p
 	}
-	if clicontext.Bool("all-manifests") {
-		config.IsAllManifests = clicontext.Bool("all-manifests")
-	}
+
+	config.IsAllManifests = clicontext.Bool("all-manifests")
+
 	return config, nil
 }
 

--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -53,6 +53,10 @@ command. As part of this process, we do the following:
 			Name:  "all-platforms",
 			Usage: "pull content from all platforms",
 		},
+		cli.BoolFlag{
+			Name:  "all-manifests",
+			Usage: "Pull manifests from all platforms and layers for a specific platform",
+		},
 	),
 	Action: func(context *cli.Context) error {
 		var (
@@ -78,6 +82,10 @@ command. As part of this process, we do the following:
 		if err != nil {
 			return err
 		}
+		if context.Bool("all-manifests") {
+			config.IsAllManifests = context.Bool("all-manifests")
+		}
+
 		img, err := content.Fetch(ctx, client, ref, config)
 		if err != nil {
 			return err

--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -82,9 +82,6 @@ command. As part of this process, we do the following:
 		if err != nil {
 			return err
 		}
-		if context.Bool("all-manifests") {
-			config.IsAllManifests = context.Bool("all-manifests")
-		}
 
 		img, err := content.Fetch(ctx, client, ref, config)
 		if err != nil {

--- a/pull.go
+++ b/pull.go
@@ -112,9 +112,14 @@ func (c *Client) fetch(ctx context.Context, rCtx *RemoteContext, ref string, lim
 		childrenHandler := images.ChildrenHandler(store)
 		// Set any children labels for that content
 		childrenHandler = images.SetChildrenLabels(store, childrenHandler)
-		// Filter manifests by platforms but allow to handle manifest
-		// and configuration for not-target platforms
-		childrenHandler = remotes.FilterManifestByPlatformHandler(childrenHandler, rCtx.PlatformMatcher)
+		if rCtx.AppendDistributionSourceLabel {
+			// Filter manifests by platforms but allow to handle manifest
+			// and configuration for not-target platforms
+			childrenHandler = remotes.FilterManifestByPlatformHandler(childrenHandler, rCtx.PlatformMatcher)
+		} else {
+			// Filter children by platforms if specified.
+			childrenHandler = images.FilterPlatforms(childrenHandler, rCtx.PlatformMatcher)
+		}
 		// Sort and limit manifests if a finite number is needed
 		if limit > 0 {
 			childrenHandler = images.LimitManifests(childrenHandler, rCtx.PlatformMatcher, limit)


### PR DESCRIPTION
- Add `all-manifests` option to both `ctr content fetch` and `ctr images pull`. By default it is false.
- The`AppendDistributionSourceLabel` in `RemoteContext` will only works when this option is set.

Fixes #3126

Signed-off-by: Yu Yi <yiyu@google.com>