### PR TITLE
Introduce the rawblock snapshotter

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -104,6 +104,7 @@ make generate
 
 > *Note*: Several build tags are currently available:
 > * `no_btrfs`: A build tag disables building the btrfs snapshot driver.
+> * `no_rawblock`: A build tag disables building the rawblock snapshot driver.
 > * `no_cri`: A build tag disables building Kubernetes [CRI](http://blog.kubernetes.io/2016/12/container-runtime-interface-cri-in-kubernetes.html) support into containerd.
 > See [here](https://github.com/containerd/cri-containerd#build-tags) for build tags of CRI plugin.
 > * `no_devmapper`: A build tag disables building the device mapper snapshot driver.

--- a/cmd/containerd/builtins_rawblock_linux.go
+++ b/cmd/containerd/builtins_rawblock_linux.go
@@ -1,0 +1,21 @@
+// +build !no_rawblock
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import _ "github.com/containerd/containerd/snapshots/rawblock"

--- a/mount/losetup_linux.go
+++ b/mount/losetup_linux.go
@@ -1,0 +1,178 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package mount
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"strings"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	loopControlPath = "/dev/loop-control"
+	loopDevFormat   = "/dev/loop%d"
+
+	// According to util-linux/include/loopdev.h
+	ioctlSetFd       = 0x4C00
+	ioctlClrFd       = 0x4C01
+	ioctlSetStatus64 = 0x4C04
+	ioctlGetFree     = 0x4C82
+
+	loFlagsReadonly = 1
+	//loFlagsUseAops   = 2
+	loFlagsAutoclear = 4
+	//loFlagsPartScan  = 8
+	loFlagsDirectIO = 16
+
+	ebusyString = "device or resource busy"
+)
+
+// struct loop_info64 in util-linux/include/loopdev.h
+type loopInfo struct {
+	/*
+		device         uint64
+		inode          uint64
+		rdevice        uint64
+		offset         uint64
+		sizelimit      uint64
+		number         uint32
+		encryptType    uint32
+		encryptKeySize uint32
+	*/
+	_        [13]uint32
+	flags    uint32
+	fileName [64]byte
+	/*
+		cryptName  [64]byte
+		encryptKey [32]byte
+		init       [2]uint64
+	*/
+	_ [112]byte
+}
+
+func ioctl(fd, req, args uintptr) (uintptr, uintptr, error) {
+	r1, r2, errno := syscall.Syscall(syscall.SYS_IOCTL, fd, req, args)
+	if errno != 0 {
+		return 0, 0, errno
+	}
+
+	return r1, r2, nil
+}
+
+func getFreeLoopDev() (uint32, error) {
+	ctrl, err := os.OpenFile(loopControlPath, os.O_RDWR, 0)
+	if err != nil {
+		return 0, errors.Errorf("could not open %v: %v", loopControlPath, err)
+	}
+	defer ctrl.Close()
+	num, _, err := ioctl(ctrl.Fd(), ioctlGetFree, 0)
+	if err != nil {
+		return 0, errors.Wrap(err, "could not get free loop device")
+	}
+	return uint32(num), nil
+}
+
+func setupLoopDev(backingFile, loopDev string, ro bool) (devFile *os.File, err error) {
+	// 1. Open backing file and loop device
+	oflags := os.O_RDWR
+	if ro {
+		oflags = os.O_RDONLY
+	}
+	back, err := os.OpenFile(backingFile, oflags, 0)
+	if err != nil {
+		return nil, errors.Errorf("could not open backing file: %v", err)
+	}
+	defer back.Close()
+
+	loopFile, err := os.OpenFile(loopDev, oflags, 0)
+	if err != nil {
+		return nil, errors.Errorf("could not open loop device: %v", err)
+	}
+	defer func() {
+		if err != nil {
+			loopFile.Close()
+		}
+	}()
+
+	// 2. Set FD
+	if _, _, err = ioctl(loopFile.Fd(), ioctlSetFd, back.Fd()); err != nil {
+		return nil, errors.Errorf("could not set loop fd: %v", err)
+	}
+
+	// 3. Set Info
+	info := loopInfo{}
+	copy(info.fileName[:], []byte(backingFile))
+	// Always set autoclear flag so that the device goes away upon umount.
+	// Always set direct IO flag to avoid double caching.
+	info.flags = loFlagsAutoclear | loFlagsDirectIO
+	if ro {
+		info.flags |= loFlagsReadonly
+	}
+	if _, _, err := ioctl(loopFile.Fd(), ioctlSetStatus64, uintptr(unsafe.Pointer(&info))); err != nil {
+		// Retry w/o direct IO flag in case kernel does not support it. The downside is that
+		// it will suffer from double cache problem.
+		info.flags &= ^(uint32(loFlagsDirectIO))
+		if _, _, err := ioctl(loopFile.Fd(), ioctlSetStatus64, uintptr(unsafe.Pointer(&info))); err != nil {
+			ioctl(loopFile.Fd(), ioctlClrFd, 0)
+			return nil, errors.Errorf("cannot set loop info:%v", err)
+		}
+	}
+
+	return loopFile, nil
+}
+
+// setupLoop looks for (and possibly creates) a free loop device, and
+// then attaches backingFile to it.
+//
+// Upon success, the file handle to the loop device is also returned.
+// Caller should take care to close it when done with the loop device
+// The loop device file handle keeps loFlagsAutoclear in effect and we
+// rely on it to clean up the loop device. If caller closes the file
+// handle after mounting the device, kernel will clear the loop device
+// after it is umounted. Otherwise the loop device is cleared when the
+// file handle is closed.
+func setupLoop(backingFile string, ro bool) (string, *os.File, error) {
+	var loopDev string
+
+	for retry := 1; ; retry++ {
+		num, err := getFreeLoopDev()
+		if err != nil {
+			return "", nil, err
+		}
+
+		loopDev = fmt.Sprintf(loopDevFormat, num)
+		loopFile, err := setupLoopDev(backingFile, loopDev, ro)
+		if err != nil {
+			// Per util-linux/sys-utils/losetup.c:create_loop(),
+			// free loop device can race and we end up failing
+			// with EBUSY when trying to set it up.
+			if strings.Contains(err.Error(), ebusyString) {
+				// Fallback a bit to avoid live lock
+				time.Sleep(time.Millisecond * time.Duration(rand.Intn(retry*10)))
+				continue
+			}
+			return "", nil, err
+		}
+		return loopDev, loopFile, nil
+	}
+}

--- a/mount/mount_linux.go
+++ b/mount/mount_linux.go
@@ -42,7 +42,7 @@ func init() {
 //
 // If m.Type starts with "fuse." or "fuse3.", "mount.fuse" or "mount.fuse3"
 // helper binary is called.
-func (m *Mount) Mount(target string) error {
+func (m *Mount) Mount(target string) (err error) {
 	for _, helperBinary := range allowedHelperBinaries {
 		// helperBinary = "mount.fuse", typePrefix = "fuse."
 		typePrefix := strings.TrimPrefix(helperBinary, "mount.") + "."
@@ -62,7 +62,7 @@ func (m *Mount) Mount(target string) error {
 		chdir, options = compactLowerdirOption(options)
 	}
 
-	flags, data := parseMountOptions(options)
+	flags, data, losetup := parseMountOptions(options)
 	if len(data) > pagesize {
 		return errors.Errorf("mount options is too long")
 	}
@@ -77,7 +77,17 @@ func (m *Mount) Mount(target string) error {
 	if flags&unix.MS_REMOUNT == 0 || data != "" {
 		// Initial call applying all non-propagation flags for mount
 		// or remount with changed data
-		if err := mountAt(chdir, m.Source, target, m.Type, uintptr(oflags), data); err != nil {
+		source := m.Source
+		if losetup {
+			dev, devFile, err := setupLoop(m.Source, oflags&unix.MS_RDONLY == unix.MS_RDONLY)
+			if err != nil {
+				return err
+			}
+			defer devFile.Close()
+			// Mount the loop device instead
+			source = dev
+		}
+		if err := mountAt(chdir, source, target, m.Type, uintptr(oflags|unix.MS_MGC_VAL), data); err != nil {
 			return err
 		}
 	}
@@ -175,11 +185,13 @@ func UnmountAll(mount string, flags int) error {
 
 // parseMountOptions takes fstab style mount options and parses them for
 // use with a standard mount() syscall
-func parseMountOptions(options []string) (int, string) {
+func parseMountOptions(options []string) (int, string, bool) {
 	var (
-		flag int
-		data []string
+		flag    int
+		losetup bool
+		data    []string
 	)
+	loopOpt := "loop"
 	flags := map[string]struct {
 		clear bool
 		flag  int
@@ -220,11 +232,13 @@ func parseMountOptions(options []string) (int, string) {
 			} else {
 				flag |= f.flag
 			}
+		} else if o == loopOpt {
+			losetup = true
 		} else {
 			data = append(data, o)
 		}
 	}
-	return flag, strings.Join(data, ",")
+	return flag, strings.Join(data, ","), losetup
 }
 
 // compactLowerdirOption updates overlay lowdir option and returns the common

--- a/snapshots/rawblock/README.md
+++ b/snapshots/rawblock/README.md
@@ -1,0 +1,47 @@
+## Rawblock snapshotter
+
+Rawblock is a `containerd` snapshotter plugin that stores snapshots as block files on the local file system. It makes
+use of the local file system's [reflink cow capability](http://man7.org/linux/man-pages/man1/cp.1.html) when it is
+avaialbe to share file data among snapshots and save disk space.
+
+## Setup
+
+Rawblock snapshotter formats the snapshots as `ext4`(default) or `xfs` file systems. Make sure you have corresponding
+mkfs binary (`mkfs.ext4` or `mkfs.xfs`) installed.
+
+It is also possible to configure the rawblock snapshotter options in containerd's configuration file,
+like `/etc/containerd/config.toml`. E.g,
+
+```
+[plugins]
+  ...
+  [plugins.rawblock]
+    root_path = "/mnt/images"
+    size_MB = 2048
+    fs_type = "xfs"
+    options = ["nouuid","noatime"]
+  ...
+```
+
+The following configuration flags are supported:
+* `root_path` - a directory where the snapshots are saved (if unset,
+  default location for `containerd` plugins will be used).
+* `size_mb` - size of the base snapshot file (if unset, default to `1024` MB).
+* `fs_type` - the snapshot file will be formated with the specified file system type, only "ext4"
+  and "xfs" are currently supported (if unset, default to `ext4`).
+* `options` - extra slice of string options to mount the snapshot file as a local file system.
+
+## Run
+Give it a try with the following commands:
+
+```bash
+ctr images pull --snapshotter rawblock docker.io/library/hello-world:latest
+ctr run --snapshotter rawblock docker.io/library/hello-world:latest test
+```
+
+## Requirements
+* To format snapshot images, corresponding mkfs binary is required per `fs_type` option.
+* To mount snapshot images, corresponding file system kernel module is required per `fs_type` option.
+* To make loopback device use direct IO, kernel version (>= 4.4) is required for the `LOOP_SET_DIRECT_IO` ioctl, otherwise
+  it falls back to buffer IO and loopback mounts suffer from double cache problem.
+* To support loopback device auto clearing, kenrel version (>= v2.6.25) is required for the `LO_FLAGS_AUTOCLEAR` ioctl.

--- a/snapshots/rawblock/config.go
+++ b/snapshots/rawblock/config.go
@@ -1,0 +1,80 @@
+// +build linux,!no_rawblock
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package rawblock
+
+import (
+	"os/exec"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	defaultImageSizeMB = 1024
+	defaultFsType      = "ext4"
+)
+
+// SnapshotterConfig allows users to set rawblock snapshotter options.
+type SnapshotterConfig struct {
+	RootPath string   `toml:"root_path"`
+	SizeMB   uint32   `toml:"size_mb"`
+	FsType   string   `toml:"fs_type"`
+	Options  []string `toml:"options"`
+}
+
+func (c *SnapshotterConfig) setDefaults(contextRootPath string) {
+	if c.RootPath == "" {
+		c.RootPath = contextRootPath
+	}
+
+	if c.SizeMB == 0 {
+		c.SizeMB = defaultImageSizeMB
+	}
+
+	if c.FsType == "" {
+		c.FsType = defaultFsType
+	}
+
+	// XFS needs nouuid or it can't mount filesystems with the same fs uuid
+	if c.FsType == "xfs" {
+		var found bool
+		for _, opt := range c.Options {
+			if opt == "nouuid" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			c.Options = append(c.Options, "nouuid")
+		}
+	}
+}
+
+func (c *SnapshotterConfig) validate() error {
+	if c.FsType != "ext4" && c.FsType != "xfs" {
+		return errors.New("rawblock snapshotter only supports ext4 and xfs image fstype")
+	}
+
+	mkfsBin := "mkfs." + c.FsType
+	_, err := exec.LookPath(mkfsBin)
+	if err != nil {
+		return errors.Wrapf(err, "cannot find mkfs binary %s", mkfsBin)
+	}
+
+	return nil
+}

--- a/snapshots/rawblock/config_test.go
+++ b/snapshots/rawblock/config_test.go
@@ -1,0 +1,73 @@
+// +build linux,!no_rawblock
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package rawblock
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConfigSetDefaults(t *testing.T) {
+	c := &SnapshotterConfig{}
+	c.setDefaults("foo")
+
+	if c.RootPath != "foo" {
+		t.Errorf("default config rootpath expect %s found %s", "foo", c.RootPath)
+	}
+
+	if c.SizeMB != defaultImageSizeMB {
+		t.Errorf("default config image size expect %d found %d", defaultImageSizeMB, c.SizeMB)
+	}
+
+	if c.FsType != defaultFsType {
+		t.Errorf("default config image fstype expect %s found %s", defaultFsType, c.FsType)
+	}
+
+	c.FsType = "xfs"
+	c.RootPath = "bar"
+
+	c.setDefaults("foo")
+
+	if c.RootPath != "bar" {
+		t.Errorf("default config rootpath expect %s found %s", "bar", c.RootPath)
+	}
+
+	if c.FsType != "xfs" {
+		t.Errorf("default config image fstype expect %s found %s", "xfs", c.FsType)
+	}
+
+	if !strings.Contains(strings.Join(c.Options, ","), "nouuid") {
+		t.Errorf("default config image mount option missing %s", "nouuid")
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	c := &SnapshotterConfig{}
+
+	err := c.validate()
+	if err == nil {
+		t.Errorf("empty snapshotter config should fail validation")
+	}
+
+	c.setDefaults("")
+	err = c.validate()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/snapshots/rawblock/rawblock.go
+++ b/snapshots/rawblock/rawblock.go
@@ -1,0 +1,583 @@
+// +build linux,!no_rawblock
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package rawblock
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/platforms"
+	"github.com/containerd/containerd/plugin"
+	"github.com/containerd/containerd/snapshots"
+	"github.com/containerd/containerd/snapshots/storage"
+	"golang.org/x/sys/unix"
+
+	"github.com/containerd/continuity/fs"
+	"github.com/pkg/errors"
+)
+
+const (
+	snapshotRoot = "snapshots"
+	snapshotMeta = "metadata.db"
+	snapshotBase = "baseimage"
+)
+
+func init() {
+	plugin.Register(&plugin.Registration{
+		Type:   plugin.SnapshotPlugin,
+		ID:     "rawblock",
+		Config: &SnapshotterConfig{},
+		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
+			ic.Meta.Platforms = append(ic.Meta.Platforms, platforms.DefaultSpec())
+
+			config, ok := ic.Config.(*SnapshotterConfig)
+			if !ok {
+				return nil, errors.New("invalid rawblock config")
+			}
+			config.setDefaults(ic.Root)
+
+			if err := config.validate(); err != nil {
+				return nil, errors.Wrap(err, "invalid rawblock config")
+			}
+
+			return NewSnapshotter(ic.Context, config)
+		},
+	})
+}
+
+type snapshotter struct {
+	root    string
+	base    string
+	sizeMB  uint32
+	fstype  string
+	options []string
+	ms      *storage.MetaStore
+}
+
+func testCopyFileReflink(source, target string) error {
+	src, err := os.Open(source)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open source %s", source)
+	}
+	defer src.Close()
+	tgt, err := os.Create(target)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open target %s", target)
+	}
+	defer tgt.Close()
+
+	st, err := src.Stat()
+	if err != nil {
+		return errors.Wrap(err, "unable to stat source")
+	}
+	_, err = unix.CopyFileRange(int(src.Fd()), nil, int(tgt.Fd()), nil, int(st.Size()), 0)
+
+	return err
+}
+
+func testReflinkCapability(dir string) (bool, error) {
+	file1 := filepath.Join(dir, "test-reflink-support-src")
+	file2 := filepath.Join(dir, "test-reflink-support-dst")
+	if out, err := exec.Command("truncate", "--size=1024", file1).CombinedOutput(); err != nil {
+		return false, errors.Errorf("%s:%v", string(out), err)
+	}
+	defer os.RemoveAll(file1)
+	defer os.RemoveAll(file2)
+	if err := testCopyFileReflink(file1, file2); err != nil {
+		return false, nil
+	}
+	return true, nil
+}
+
+// NewSnapshotter returns a Snapshotter which copies layers on the underlying
+// file system. A metadata file is stored under the root.
+//
+// Rawblock snapshot layout: all snapshots lives in the same directory.
+// root dir -> metadata.db
+//          -> snapshots
+func NewSnapshotter(ctx context.Context, config *SnapshotterConfig) (snapshots.Snapshotter, error) {
+	if err := os.MkdirAll(config.RootPath, 0755); err != nil {
+		return nil, err
+	}
+
+	snapshots := filepath.Join(config.RootPath, snapshotRoot)
+	if err := os.Mkdir(snapshots, 0755); err != nil && !os.IsExist(err) {
+		return nil, err
+	}
+
+	if supported, err := testReflinkCapability(snapshots); err != nil {
+		return nil, errors.Wrap(err, "failed to check host file system reflink capability")
+	} else if !supported {
+		log.G(ctx).Infof("%s doesn't support copy reflink. Snapshot creation can be SLOW!", config.RootPath)
+	}
+
+	ms, err := storage.NewMetaStore(filepath.Join(config.RootPath, snapshotMeta))
+	if err != nil {
+		return nil, err
+	}
+
+	return &snapshotter{
+		root:    config.RootPath,
+		base:    filepath.Join(config.RootPath, snapshotRoot, snapshotBase),
+		sizeMB:  config.SizeMB,
+		fstype:  config.FsType,
+		options: config.Options,
+		ms:      ms,
+	}, nil
+}
+
+// Stat returns the info for an active or committed snapshot by name or
+// key.
+//
+// Should be used for parent resolution, existence checks and to discern
+// the kind of snapshot.
+func (o *snapshotter) Stat(ctx context.Context, key string) (snapshots.Info, error) {
+	ctx, t, err := o.ms.TransactionContext(ctx, false)
+	if err != nil {
+		return snapshots.Info{}, err
+	}
+	defer t.Rollback()
+	_, info, _, err := storage.GetInfo(ctx, key)
+	if err != nil {
+		return snapshots.Info{}, err
+	}
+
+	return info, nil
+}
+
+// Update updates the info for a snapshot.
+//
+// Only mutable properties of a snapshot may be updated.
+func (o *snapshotter) Update(ctx context.Context, info snapshots.Info, fieldpaths ...string) (snapshots.Info, error) {
+	ctx, t, err := o.ms.TransactionContext(ctx, true)
+	if err != nil {
+		return snapshots.Info{}, err
+	}
+
+	info, err = storage.UpdateInfo(ctx, info, fieldpaths...)
+	if err != nil {
+		t.Rollback()
+		return snapshots.Info{}, err
+	}
+
+	if err := t.Commit(); err != nil {
+		return snapshots.Info{}, err
+	}
+
+	return info, nil
+}
+
+// Usage returns the resource usage of an active or committed snapshot
+// excluding the usage of parent snapshots.
+//
+// The running time of this call for active snapshots is dependent on
+// implementation, but may be proportional to the size of the resource.
+// Callers should take this into consideration. Implementations should
+// attempt to honer context cancellation and avoid taking locks when making
+// the calculation.
+func (o *snapshotter) Usage(ctx context.Context, key string) (snapshots.Usage, error) {
+	ctx, t, err := o.ms.TransactionContext(ctx, false)
+	if err != nil {
+		return snapshots.Usage{}, err
+	}
+	defer t.Rollback()
+
+	id, info, usage, err := storage.GetInfo(ctx, key)
+	if err != nil {
+		return snapshots.Usage{}, err
+	}
+
+	if info.Kind == snapshots.KindActive {
+		du, err := fs.DiskUsage(ctx, o.getSnapshotPath(id))
+		if err != nil {
+			return snapshots.Usage{}, err
+		}
+		usage = snapshots.Usage(du)
+	}
+
+	return usage, nil
+}
+
+// Prepare creates an active snapshot identified by key descending from the
+// provided parent.  The returned mounts can be used to mount the snapshot
+// to capture changes.
+//
+// If a parent is provided, after performing the mounts, the destination
+// will start with the content of the parent. The parent must be a
+// committed snapshot. Changes to the mounted destination will be captured
+// in relation to the parent. The default parent, "", is an empty
+// directory.
+//
+// The changes may be saved to a committed snapshot by calling Commit. When
+// one is done with the transaction, Remove should be called on the key.
+//
+// Multiple calls to Prepare or View with the same key should fail.
+func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
+	return o.createSnapshot(ctx, snapshots.KindActive, key, parent, opts)
+}
+
+// View behaves identically to Prepare except the result may not be
+// committed back to the snapshot snapshotter. View returns a readonly view on
+// the parent, with the active snapshot being tracked by the given key.
+//
+// This method operates identically to Prepare, except that Mounts returned
+// may have the readonly flag set. Any modifications to the underlying
+// filesystem will be ignored. Implementations may perform this in a more
+// efficient manner that differs from what would be attempted with
+// `Prepare`.
+//
+// Commit may not be called on the provided key and will return an error.
+// To collect the resources associated with key, Remove must be called with
+// key as the argument.
+func (o *snapshotter) View(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
+	return o.createSnapshot(ctx, snapshots.KindView, key, parent, opts)
+}
+
+// Mounts returns the mounts for the active snapshot transaction identified
+// by key. Can be called on an read-write or readonly transaction. This is
+// available only for active snapshots.
+//
+// This can be used to recover mounts after calling View or Prepare.
+func (o *snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, error) {
+	ctx, t, err := o.ms.TransactionContext(ctx, false)
+	if err != nil {
+		return nil, err
+	}
+	s, err := storage.GetSnapshot(ctx, key)
+	t.Rollback()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get snapshot mount")
+	}
+	if s.Kind != snapshots.KindView && s.Kind != snapshots.KindActive {
+		return nil, errors.Wrapf(err, "Mounts not allowed on %s snapshots", s.Kind)
+	}
+	return o.mounts(s), nil
+}
+
+// Commit captures the changes between key and its parent into a snapshot
+// identified by name.  The name can then be used with the snapshotter's other
+// methods to create subsequent snapshots.
+//
+// A committed snapshot will be created under name with the parent of the
+// active snapshot.
+//
+// After commit, the snapshot identified by key is removed.
+func (o *snapshotter) Commit(ctx context.Context, name, key string, opts ...snapshots.Opt) (err error) {
+	ctx, t, err := o.ms.TransactionContext(ctx, true)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil && t != nil {
+			t.Rollback()
+		}
+	}()
+
+	id, info, _, err := storage.GetInfo(ctx, key)
+	if err != nil {
+		return err
+	}
+	if info.Kind != snapshots.KindActive {
+		return errors.Errorf("Commit called with %s snapshots", info.Kind)
+	}
+
+	source := o.getSnapshotPath(id)
+
+	usage, err := fs.DiskUsage(ctx, source)
+	if err != nil {
+		return err
+	}
+
+	if _, err := storage.CommitActive(ctx, key, name, snapshots.Usage(usage), opts...); err != nil {
+		return errors.Wrap(err, "failed to commit snapshot")
+	}
+
+	err = t.Commit()
+	t = nil
+	return err
+}
+
+// Remove the committed or active snapshot by the provided key.
+//
+// All resources associated with the key will be removed.
+//
+// If the snapshot is a parent of another snapshot, its children must be
+// removed before proceeding.
+func (o *snapshotter) Remove(ctx context.Context, key string) (err error) {
+	ctx, t, err := o.ms.TransactionContext(ctx, true)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil && t != nil {
+			if rerr := t.Rollback(); rerr != nil {
+				log.G(ctx).WithError(rerr).Warn("failed to rollback transaction")
+			}
+		}
+	}()
+
+	id, _, err := storage.Remove(ctx, key)
+	if err != nil {
+		return errors.Wrap(err, "failed to remove")
+	}
+
+	path := o.getSnapshotPath(id)
+	renamed := o.getSnapshotPath("rm-" + id)
+	if err := os.Rename(path, renamed); err != nil {
+		if !os.IsNotExist(err) {
+			return errors.Wrap(err, "failed to rename")
+		}
+		renamed = ""
+	}
+
+	err = t.Commit()
+	t = nil
+	if err != nil {
+		if renamed != "" {
+			if err1 := os.Rename(renamed, path); err1 != nil {
+				// May cause inconsistent data on disk
+				log.G(ctx).WithError(err1).WithField("path", renamed).Errorf("failed to rename after failed commit")
+			}
+		}
+		return errors.Wrap(err, "failed to commit")
+	}
+	if renamed != "" {
+		if err := os.RemoveAll(renamed); err != nil {
+			// Must be cleaned up, any "rm-*" could be removed if no active transactions
+			log.G(ctx).WithError(err).WithField("path", renamed).Warnf("failed to remove snapshot file")
+		}
+	}
+
+	return nil
+}
+
+// Walk all snapshots in the snapshotter. For each snapshot in the
+// snapshotter, the function will be called.
+func (o *snapshotter) Walk(ctx context.Context, fn snapshots.WalkFunc, fs ...string) error {
+	ctx, t, err := o.ms.TransactionContext(ctx, false)
+	if err != nil {
+		return err
+	}
+	defer t.Rollback()
+	return storage.WalkInfo(ctx, fn, fs...)
+}
+
+func (o *snapshotter) createBaseImage(ctx context.Context) (_ string, err error) {
+	var base string
+	f, err := ioutil.TempFile(filepath.Join(o.root, snapshotRoot), "new-")
+	if err != nil {
+		return "", err
+	}
+	base = f.Name()
+	f.Close()
+	defer func() {
+		if err != nil {
+			if err1 := os.Remove(base); err1 != nil {
+				log.G(ctx).WithError(err1).Warnf("failed to remove temp file %s after base image creation failure", base)
+			}
+		}
+	}()
+	if err := os.Chmod(base, 0755); err != nil {
+		return "", err
+	}
+	if err := os.Truncate(base, int64(o.sizeMB<<20)); err != nil {
+		return "", err
+	}
+	switch o.fstype {
+	case "xfs":
+		if out, err := exec.Command("mkfs.xfs", "-f", base).CombinedOutput(); err != nil {
+			return "", errors.Errorf("Failed to create %s file system on %s: %v:%s", o.fstype, base, err, string(out))
+		}
+	case "ext4":
+		args := []string{
+			base,
+			"-F",
+			"-O",
+			"^uninit_bg",
+			"-E",
+			"nodiscard,lazy_itable_init=0,lazy_journal_init=0",
+		}
+		if out, err := exec.Command("mkfs.ext4", args...).CombinedOutput(); err != nil {
+			return "", errors.Errorf("Failed to create %s file system on %s: %v:%s", o.fstype, base, err, string(out))
+		}
+		// Remove ext4's lost+found as we want an empty directory instead
+		mount.WithTempMount(ctx, []mount.Mount{{Source: base, Type: o.fstype, Options: []string{"loop"}}},
+			func(root string) error {
+				return os.Remove(filepath.Join(root, "lost+found"))
+			})
+	default:
+		return "", errors.Errorf("unsupported fstype %s", o.fstype)
+	}
+
+	return base, err
+}
+
+func (o *snapshotter) copyReflinkImage(source, target string) error {
+	if err := fs.CopyFile(target, source); err != nil {
+		return errors.Wrapf(err, "Failed to copy from %s to %s", source, target)
+	}
+
+	return nil
+}
+
+func (o *snapshotter) createSnapshotBase(ctx context.Context) (_ string, err error) {
+	// make sure root base exists
+	if _, err = os.Stat(o.base); err != nil {
+		// create new base
+		rootBase, err := o.createBaseImage(ctx)
+		if err != nil {
+			return "", err
+		}
+		if err = os.Rename(rootBase, o.base); err != nil {
+			// failed race, just return new base
+			return rootBase, nil
+		}
+		// root base now exists
+	}
+
+	// create from root base image
+	f, err := ioutil.TempFile(filepath.Join(o.root, snapshotRoot), "new-")
+	if err != nil {
+		return "", err
+	}
+	target := f.Name()
+	f.Close()
+
+	if err := o.copyReflinkImage(o.base, target); err != nil {
+		os.Remove(target)
+		return "", err
+	}
+
+	return target, nil
+}
+
+func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, key, parent string, opts []snapshots.Opt) (m []mount.Mount, err error) {
+	var base string
+
+	if len(parent) == 0 {
+		base, err = o.createSnapshotBase(ctx)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create base image")
+		}
+		defer func() {
+			if err != nil {
+				if base != "" {
+					if err1 := os.Remove(base); err1 != nil {
+						err = errors.Wrapf(err, "remove failed: %v", err1)
+					}
+				}
+			}
+		}()
+	}
+
+	ctx, t, err := o.ms.TransactionContext(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil && t != nil {
+			if rerr := t.Rollback(); rerr != nil {
+				log.G(ctx).WithError(rerr).Warn("failed to rollback transaction")
+			}
+		}
+	}()
+
+	// CreateSnapshot ensures that parent is committed if provided.
+	s, err := storage.CreateSnapshot(ctx, kind, key, parent, opts...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create snapshot")
+	}
+
+	current := o.getSnapshotPath(s.ID)
+	if len(s.ParentIDs) > 0 {
+		parentPath := o.getSnapshotPath(s.ParentIDs[0])
+		if err := o.copyReflinkImage(parentPath, current); err != nil {
+			return nil, errors.Wrapf(err, "failed to copy image parent(%s):current(%s)", parentPath, current)
+		}
+	} else {
+		if err := os.Rename(base, current); err != nil {
+			return nil, errors.Wrap(err, "failed to rename")
+		}
+		base = ""
+	}
+	// Rollback current on failure
+	defer func() {
+		if err != nil {
+			if err1 := os.Remove(current); err1 != nil {
+				err = errors.Wrapf(err, "remove new snapshot file failed: %v", err1)
+			}
+		}
+	}()
+
+	// bergwolf: what if parent is removed before we do commit?
+	err = t.Commit()
+	t = nil
+	if err != nil {
+		return nil, errors.Wrap(err, "commit failed")
+	}
+
+	return o.mounts(s), nil
+}
+
+func (o *snapshotter) getSnapshotPath(id string) string {
+	return filepath.Join(o.root, snapshotRoot, id)
+}
+
+func (o *snapshotter) mounts(s storage.Snapshot) []mount.Mount {
+	var (
+		roFlag string
+		source string
+	)
+
+	if s.Kind == snapshots.KindView || s.Kind == snapshots.KindCommitted {
+		roFlag = "ro"
+	} else {
+		roFlag = "rw"
+	}
+
+	source = o.getSnapshotPath(s.ID)
+
+	opts := []string{roFlag, "loop"}
+	if len(o.options) != 0 {
+		opts = append(opts, o.options...)
+	}
+
+	return []mount.Mount{
+		{
+			Source:  source,
+			Type:    o.fstype,
+			Options: opts,
+		},
+	}
+}
+
+// Close releases the internal resources.
+//
+// Close is expected to be called on the end of the lifecycle of the snapshotter,
+// but not mandatory.
+//
+// Close returns nil when it is already closed.
+func (o *snapshotter) Close() error {
+	return o.ms.Close()
+}

--- a/snapshots/rawblock/rawblock_test.go
+++ b/snapshots/rawblock/rawblock_test.go
@@ -1,0 +1,95 @@
+// +build linux,!no_rawblock
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package rawblock
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/pkg/testutil"
+	"github.com/containerd/containerd/snapshots"
+	"github.com/containerd/containerd/snapshots/testsuite"
+	"github.com/containerd/continuity/testutil/loopback"
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+const mkfsBin = "mkfs.btrfs"
+
+func boltSnapshotter(t *testing.T) func(context.Context, string) (snapshots.Snapshotter, func() error, error) {
+	mkfs, err := exec.LookPath(mkfsBin)
+	if err != nil {
+		t.Skipf("could not find %s: %v", mkfsBin, err)
+	}
+
+	return func(ctx context.Context, root string) (snapshots.Snapshotter, func() error, error) {
+
+		loopbackSize := int64(512 << 20) // 512 MB
+		loop, err := loopback.New(loopbackSize)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if out, err := exec.Command(mkfs, loop.Device).CombinedOutput(); err != nil {
+			loop.Close()
+			return nil, nil, errors.Wrapf(err, "failed to make filesystem (out: %q)", out)
+		}
+		// sync after a mkfs on the loopback before trying to mount the device
+		unix.Sync()
+
+		if out, err := exec.Command("mount", loop.Device, root).CombinedOutput(); err != nil {
+			loop.Close()
+			return nil, nil, errors.Wrapf(err, "failed to mount device %s (out: %q)", loop.Device, out)
+		}
+
+		config := &SnapshotterConfig{
+			SizeMB: 50,
+		}
+		config.setDefaults(root)
+
+		snapshotter, err := NewSnapshotter(ctx, config)
+		if err != nil {
+			mount.UnmountAll(root, 0)
+			loop.Close()
+			return nil, nil, errors.Wrap(err, "failed to create new snapshotter")
+		}
+
+		return snapshotter, func() error {
+			if err := snapshotter.Close(); err != nil {
+				return err
+			}
+			err := mount.UnmountAll(root, 0)
+			if cerr := loop.Close(); cerr != nil {
+				err = errors.Wrap(cerr, "device cleanup failed")
+			}
+			if err == nil {
+				err = os.RemoveAll(root)
+			}
+			return err
+		}, nil
+	}
+}
+
+func TestRawblock(t *testing.T) {
+	testutil.RequiresRoot(t)
+	testsuite.SnapshotterSuite(t, "Rawblock", boltSnapshotter(t))
+}


### PR DESCRIPTION
Hello,

The PR introduces a new snapshotter for containerd named `rawblock`, based on the original work from @laijs in [hyperhq/hyperd](https://github.com/hyperhq/hyperd/pull/522). It is a file based block storage snapshotter. Each snapshot is a file on the host file system and can be mounted via loopback device to provide a file system view. Child snapshots are created via local file system's reflink capability (when available). The reflink capability is implemented in several Linux kernel file systems such as btrfs, xfs and NFSv4.2. With it, the `rawblock` snapshotter can be pretty space efficient and convenient to use.

A few interesting questions people might ask:
1. Does it share page cache among different layers?
- No, currently not. Different layers are mounted as different file systems and each will maintain its own page cache. But it is possible to bypass the page cache completely if the host file system providing reflink capability also supports DAX at the same time. Of course one would need fast storage (e.g., nvme) to gain performance back.

2. How many layers of page cache are involved?
- One. Loopback device double cache problem is the past. The loopback device is configured to use direct IO and thus it avoids page cache on the host file system.

3. Can it be used to implement other types of file based block storage snapshotter, like qcow2?
- Yes, it can. The only difference of different types of file based block storage snapshotter is the methods of creating new snapshot files. We can add a type field in the snapshotter config to specify which method to use. But let's add things one at a time ;)

4. What are the advantages and disadvantages compared to devmapper?

To compare them is to compare dm-thin vs. file system snapshots. Here are what I can find/think of so far:
- Pros:
   - Simplicity. dm-thin requires an additional block(btree) mapping from the thin device to the blocks in the data file, and needs a userspace daemon to monitor and increase the size of the thin-pool data file automatically. Rawblock does not have such complexity, -- the snapshot functionality is handled by host file system together with file block mapping. Free disk space is also managed by host file system internally.
    - dm-thin data file did not return disk spaces back to host file system after deleting thin provisionings/snapshots. There is a long standing moby issue for it moby/moby#3182. In theory it can be fixed by fallocate(2) `FALLOC_FL_PUNCH_HOLE` so I'm not sure if it is still the case.
- Cons:
    - If host file system does not support reflink, rawblock snapshot creation falls back to plain data copy and can be very slow.
    - dm-thin allows to put metadata and data files separately. So it is possible to put metadata file on a fast storage (e.g., nvme) to gain better metadata performance.
    - dm-thin pool metadata and data files can be raw block devices and thus removing the extra layer of host file system, making it possible to be faster than rawblock snapshotter due to one less file system layer.

/cc @laijs @lifupan