### PR TITLE
Enable LVM based block snapshotter

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -102,6 +102,7 @@ make generate
 
 > *Note*: Several build tags are currently available:
 > * `no_btrfs`: A build tag disables building the btrfs snapshot driver.
+> * `no_lvm`: A build tag disables building the LVM block based snapshot driver.
 > * `no_cri`: A build tag disables building Kubernetes [CRI](http://blog.kubernetes.io/2016/12/container-runtime-interface-cri-in-kubernetes.html) support into containerd.
 > See [here](https://github.com/containerd/cri-containerd#build-tags) for build tags of CRI plugin.
 > * `no_devmapper`: A build tag disables building the device mapper snapshot driver.

--- a/cmd/containerd/builtins_lvm_linux.go
+++ b/cmd/containerd/builtins_lvm_linux.go
@@ -1,0 +1,21 @@
+// +build !no_lvm
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import _ "github.com/containerd/containerd/snapshots/lvm"

--- a/snapshots/lvm/README.md
+++ b/snapshots/lvm/README.md
@@ -1,0 +1,44 @@
+## LVM block based snapshotter
+
+This is a `containerd` snapshotter plugin which stores snapshots in `xfs` or an user preferred based filesystem format in a LVM thin pool creating sparse images.
+
+## Requirements
+LVM snapshotter requires `lvm2` set of tools which also support thin volume provisioning to be installed on the system. On ubuntu, it can be installed using `apt install lvm2 thin-provisioning-tools` command. On fedora/centos, it can be installed using `yum install lvm2` command.
+
+## Setup
+
+LVM snapshotter by default will format snapshots as `xfs` and depends on LVM thin provisioning tools. Make sure that the necessary components, `lvm`, `thin-provisioning-tools`(in case of Ubuntu) and `mkfs.xfs` are installed.
+
+To make this snapshotter work you will need to prepare a `volume-group` and a `thin-volume-pool` prior to start containerd and update the configuration file, Eg:
+
+```
+[plugins]
+  ...
+  [plugins.lvm]
+    vol_group = "vgcontainerd"
+    thin_pool = "lvthincontainerd"
+  ...
+```
+
+These commands are examples on how to create a volume group and a LVM thin pool. We will assume the disk is /dev/sdc
+
+```bash
+vgcreate vgcontainerd /dev/sdc
+lvcreate --thinpool lvthincontainerd -l 90%FREE vgcontainerd
+```
+
+The following configuration options are honored:
+* `vol_group` - a Logical volume group created using lvm tools. This is a mandatory argument.
+* `thin_pool` - a Logical thin pool created using lvm tools. This is a mandatory argument.
+* `root_path` - a directory where the metadata holding volume will be mounted (if empty, default location of `containerd` plugin will be used. If that does not exist `/mnt` is the final fallback).
+* `img_size` - size of the thin image created within the thin pool (if empty, default size if `10G`)
+* `fs_type` - filesystem type to format the image with (If empty, `xfs` filesystem will be used).
+
+
+## Run
+You can use this snapshotter with the below commands:
+
+```bash
+ctr images pull --snapshotter lvm docker.io/library/hello-world:latest
+ctr run --snapshotter lvm docker.io/library/hello-world:latest
+```

--- a/snapshots/lvm/config.go
+++ b/snapshots/lvm/config.go
@@ -1,0 +1,82 @@
+// +build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package lvm
+
+import (
+	"strings"
+
+	"github.com/docker/go-units"
+	"github.com/pkg/errors"
+)
+
+const (
+	defaultImgSize  = "10G"
+	defaultFsType   = "xfs"
+	defaultRootPath = "/mnt"
+)
+
+// SnapConfig will hold all the info to run the snapshotter
+type SnapConfig struct {
+	// Root directory of snapshotter
+	RootPath string `toml:"root_path"`
+
+	// Volume group that will hold all the thin volumes
+	VgName string `toml:"vol_group"`
+
+	// Logical volume thin pool to hold all the volumes
+	ThinPool string `toml:"thin_pool"`
+
+	// Characteristics of the volumes that we will create
+	ImageSize string `toml:"img_size"`
+	FsType    string `toml:"fs_type"`
+}
+
+// Validate all the necessary values exist and if not, the defaults are applied
+func (c *SnapConfig) Validate(crootpath string) error {
+	if c.VgName == "" || c.ThinPool == "" {
+		return errors.New("Need both vol_group and thin_pool to be set")
+	}
+
+	// Trim trailing suffix in volumegroup name
+	c.VgName = strings.TrimSuffix(c.VgName, "/")
+
+	if c.RootPath == "" {
+		if crootpath != "" {
+			c.RootPath = crootpath
+		} else {
+			c.RootPath = defaultRootPath
+		}
+	}
+
+	if c.ImageSize == "" {
+		c.ImageSize = defaultImgSize
+	} else {
+		// make sure it is a consumable value
+		if val, err := units.FromHumanSize(c.ImageSize); err == nil {
+			c.ImageSize = units.HumanSize(float64(val))
+		} else {
+			return err
+		}
+	}
+
+	if c.FsType == "" {
+		c.FsType = defaultFsType
+	}
+	return nil
+}

--- a/snapshots/lvm/config_test.go
+++ b/snapshots/lvm/config_test.go
@@ -1,0 +1,67 @@
+// +build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package lvm
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+const (
+	rootpath = "/tmp/test_root"
+)
+
+func TestValidateConfig(t *testing.T) {
+
+	c := SnapConfig{}
+	err := c.Validate("")
+	assert.Error(t, err, "Need both vol_group and thin_pool to be set")
+
+	expected := SnapConfig{
+		VgName:    "test_vg",
+		ThinPool:  "test_pool",
+		ImageSize: "10G",
+		FsType:    "xfs",
+		RootPath:  "/mnt",
+	}
+
+	c.VgName = "test_vg"
+	c.ThinPool = "test_pool"
+	err = c.Validate("")
+	assert.NilError(t, err)
+	assert.Equal(t, c, expected)
+
+	c = SnapConfig{
+		VgName:   "test_vg",
+		ThinPool: "test_pool",
+	}
+
+	expected = SnapConfig{
+		VgName:    "test_vg",
+		ThinPool:  "test_pool",
+		ImageSize: "10G",
+		FsType:    "xfs",
+		RootPath:  rootpath,
+	}
+
+	err = c.Validate(rootpath)
+	assert.NilError(t, err)
+	assert.Equal(t, c, expected)
+}

--- a/snapshots/lvm/lvm.go
+++ b/snapshots/lvm/lvm.go
@@ -1,0 +1,170 @@
+// +build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package lvm
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/containerd/containerd/snapshots"
+	"github.com/pkg/errors"
+)
+
+const retries = 10
+
+func formatVolume(vgname string, lvname string, fstype string) error {
+	var mkfsArgs []string
+	switch fstype {
+	case "ext4":
+		mkfsArgs = append(mkfsArgs, "-E", "nodiscard,lazy_itable_init=0,lazy_journal_init=0")
+	case "xfs":
+		mkfsArgs = append(mkfsArgs, "-K")
+	default:
+	}
+
+	cmd := "mkfs." + fstype
+	mkfsArgs = append(mkfsArgs, filepath.Join("/dev/", vgname, lvname))
+	_, err := runCommand(cmd, mkfsArgs)
+	return err
+}
+
+func unmountVolume(vgname string, lvname string) error {
+	cmd := "umount"
+	args := []string{"--lazy", "--force", "--all-targets", filepath.Join("/dev", vgname, lvname)}
+	var re = regexp.MustCompile(`not mounted|not found`)
+
+	output, err := runCommand(cmd, args)
+	if err != nil && !re.MatchString(output) {
+		return errors.Wrap(err, "Unable to remove volume mounts")
+	}
+	return nil
+}
+
+func createLVMVolume(lvname string, vgname string, lvpoolname string, size string, parent string, kind snapshots.Kind) (string, error) {
+	cmd := "lvcreate"
+	args := []string{}
+	out := ""
+	var err error
+
+	if parent != "" {
+		args = append(args, "--name", lvname, "--snapshot", vgname+"/"+parent)
+	} else {
+		// Create a new logical volume without a base snapshot
+		args = append(args, "--virtualsize", size, "--name", lvname, "--thin", vgname+"/"+lvpoolname)
+	}
+
+	// This change will prevent the volume from being mountable. Relying on the
+	// mount command to do read-only mounting.
+	//if kind == snapshots.KindView {
+	//	args = append(args, "-pr")
+	//}
+
+	//Let's go and create the volume
+	if out, err = runCommand(cmd, args); err != nil {
+		return out, errors.Wrap(err, "Unable to create volume")
+	}
+
+	return out, err
+}
+
+func removeLVMVolume(vgname string, lvname string) (string, error) {
+
+	cmd := "lvremove"
+	args := []string{"-y", vgname + "/" + lvname}
+
+	return runCommand(cmd, args)
+}
+
+func checkVG(vgname string) (string, error) {
+	var err error
+	output := ""
+	cmd := "vgs"
+	args := []string{vgname, "--options", "vg_name", "--no-headings"}
+	output, err = runCommand(cmd, args)
+	return output, err
+}
+
+func checkLV(vgname string, lvname string) (string, error) {
+	var err error
+	output := ""
+	cmd := "lvs"
+	args := []string{vgname + "/" + lvname, "--options", "lv_name", "--no-heading"}
+	output, err = runCommand(cmd, args)
+	return output, err
+}
+
+func toggleactivateLV(vgname string, lvname string, activate bool) (string, error) {
+	cmd := "lvchange"
+	args := []string{"-K", vgname + "/" + lvname, "-a"}
+	output := ""
+	var err error
+	ret := 0
+
+	if activate {
+		args = append(args, "y")
+	} else {
+		args = append(args, "n")
+	}
+	// This function is always called right after unmount of all volumes is
+	// invoked to make sure that all IO is complete and there will be no possible
+	// data corruption when the volume is hidden from the host. Adding delay here
+	// for IO completion and proper unmounting.
+	for ret < retries {
+		output, err = runCommand(cmd, args)
+		if err != nil {
+			ret++
+			time.Sleep(time.Duration(ret) * time.Second)
+		} else {
+			break
+		}
+	}
+	return output, err
+}
+
+func runCommand(cmd string, args []string) (string, error) {
+	var output []byte
+	ret := 0
+	var err error
+
+	// Pass context down and log into the tool instead of this.
+	fmt.Printf("Running command %s with args: %s\n", cmd, args)
+	for ret < retries {
+		c := exec.Command(cmd, args...)
+		c.Env = os.Environ()
+		c.SysProcAttr = &syscall.SysProcAttr{
+			Pdeathsig: syscall.SIGTERM,
+			Setpgid:   true,
+		}
+
+		output, err = c.CombinedOutput()
+		if err == nil {
+			break
+		}
+		ret++
+		time.Sleep(100000 * time.Nanosecond)
+	}
+
+	return strings.TrimSpace(string(output)), err
+}

--- a/snapshots/lvm/lvm.go
+++ b/snapshots/lvm/lvm.go
@@ -19,12 +19,12 @@
 package lvm
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -33,6 +33,13 @@ import (
 )
 
 const retries = 10
+
+// This global mutex is used only during volume group creation and deletion
+// which will be only executed during test code to mitigate
+// https://bugzilla.redhat.com/show_bug.cgi?id=1672336. This should have no
+// performance impact during production as the volume groups would have already
+// been created.
+var mutex sync.Mutex
 
 func formatVolume(vgname string, lvname string, fstype string) error {
 	var mkfsArgs []string
@@ -97,6 +104,35 @@ func removeLVMVolume(vgname string, lvname string) (string, error) {
 	return runCommand(cmd, args)
 }
 
+func createVolumeGroup(drive string, vgname string) (string, error) {
+	mutex.Lock()
+	defer mutex.Unlock()
+	cmd := "vgcreate"
+	args := []string{vgname, drive}
+
+	return runCommand(cmd, args)
+}
+
+func createLogicalThinPool(vgname string, lvpool string) (string, error) {
+	cmd := "lvcreate"
+	args := []string{"--thinpool", lvpool, "--extents", "90%FREE", vgname}
+
+	out, err := runCommand(cmd, args)
+	if err != nil && (err.Error() == "exit status 5") {
+		return out, nil
+	}
+	return out, err
+}
+
+func deleteVolumeGroup(vgname string) (string, error) {
+	mutex.Lock()
+	defer mutex.Unlock()
+	cmd := "vgremove"
+	args := []string{"-y", vgname}
+
+	return runCommand(cmd, args)
+}
+
 func checkVG(vgname string) (string, error) {
 	var err error
 	output := ""
@@ -143,13 +179,28 @@ func toggleactivateLV(vgname string, lvname string, activate bool) (string, erro
 	return output, err
 }
 
+func toggleactivateVG(vgname string, activate bool) (string, error) {
+	cmd := "vgchange"
+	args := []string{"-K", vgname, "-a"}
+	output := ""
+	var err error
+
+	if activate {
+		args = append(args, "y")
+	} else {
+		args = append(args, "n")
+	}
+	output, err = runCommand(cmd, args)
+	return output, err
+}
+
 func runCommand(cmd string, args []string) (string, error) {
 	var output []byte
 	ret := 0
 	var err error
 
 	// Pass context down and log into the tool instead of this.
-	fmt.Printf("Running command %s with args: %s\n", cmd, args)
+	// fmt.Printf("Running command %s with args: %s\n", cmd, args)
 	for ret < retries {
 		c := exec.Command(cmd, args...)
 		c.Env = os.Environ()

--- a/snapshots/lvm/snapshotter.go
+++ b/snapshots/lvm/snapshotter.go
@@ -1,0 +1,476 @@
+// +build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package lvm
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/platforms"
+	"github.com/containerd/containerd/plugin"
+	"github.com/containerd/containerd/snapshots"
+	"github.com/containerd/containerd/snapshots/storage"
+
+	"github.com/containerd/continuity/fs"
+	"github.com/pkg/errors"
+)
+
+const (
+	metaVolumeMountName = "contd-lvm-snapshotter-db-holder"
+	metavolume          = "contd-metadata-holder"
+)
+
+func init() {
+	plugin.Register(&plugin.Registration{
+		Type:   plugin.SnapshotPlugin,
+		ID:     "lvm",
+		Config: &SnapConfig{},
+		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
+			ic.Meta.Platforms = append(ic.Meta.Platforms, platforms.DefaultSpec())
+
+			config, ok := ic.Config.(*SnapConfig)
+			if !ok {
+				return nil, errors.New("invalid LVM config")
+			}
+			if err := config.Validate(ic.Root); err != nil {
+				return nil, errors.Wrap(err, "Unable to validate config")
+			}
+
+			return NewSnapshotter(ic.Context, config)
+		},
+	})
+}
+
+type snapshotter struct {
+	config      *SnapConfig
+	ms          *storage.MetaStore
+	metaVolPath string
+}
+
+// NewSnapshotter returns a Snapshotter which copies layers on the underlying
+// file system. A metadata file is stored under the root.
+func NewSnapshotter(ctx context.Context, config *SnapConfig) (snapshots.Snapshotter, error) {
+	var err error
+
+	if _, err = checkVG(config.VgName); err != nil {
+		return nil, errors.Wrap(err, "VG not found")
+	}
+
+	_, err = checkLV(config.VgName, config.ThinPool)
+	if err != nil {
+		return nil, errors.Wrap(err, "LV not found")
+	}
+
+	_, err = checkLV(config.VgName, metavolume)
+	if err != nil {
+		// Create a volume to hold the metadata.db file.
+		if _, err = createLVMVolume(metavolume, config.VgName, config.ThinPool, config.ImageSize, "", snapshots.KindUnknown); err != nil {
+			return nil, errors.Wrap(err, "Unable to create metadata holding volume")
+		}
+		if _, err := toggleactivateLV(config.VgName, metavolume, true); err != nil {
+			log.G(ctx).WithError(err).Warn("Unable to activate metavolume")
+			return nil, errors.Wrap(err, "Unable to create metadata holding volume")
+		}
+
+		if err := formatVolume(config.VgName, metavolume, config.FsType); err != nil {
+			log.G(ctx).WithError(err).Warn("Unable to format metavolume")
+			return nil, errors.Wrap(err, "Unable to create metadata holding volume")
+		}
+	} else {
+		if _, err = toggleactivateLV(config.VgName, metavolume, true); err != nil {
+			return nil, errors.Wrap(err, "Unable to activate metavolume")
+		}
+	}
+
+	metavolpath := filepath.Join(config.RootPath, metaVolumeMountName)
+	if errdir := os.MkdirAll(metavolpath, 0700); errdir != nil {
+		return nil, errors.Wrap(errdir, "Unable to find metavolume path")
+	}
+
+	metamount := []mount.Mount{
+		{
+			Source:  filepath.Join("/dev", config.VgName, metavolume),
+			Type:    config.FsType,
+			Options: []string{},
+		},
+	}
+
+	if err = mount.All(metamount, metavolpath); err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("unable to mount metavolume %+v", metamount))
+	}
+	ms, err := storage.NewMetaStore(filepath.Join(metavolpath, "metadata.db"))
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create new meta store")
+	}
+
+	return &snapshotter{
+		config:      config,
+		ms:          ms,
+		metaVolPath: metavolpath,
+	}, nil
+}
+
+// Stat returns the info for an active or committed snapshot by name or
+// key.
+//
+// Should be used for parent resolution, existence checks and to discern
+// the kind of snapshot.
+func (o *snapshotter) Stat(ctx context.Context, key string) (snapshots.Info, error) {
+	log.G(ctx).Debugf("Stat called for: %s", key)
+	ctx, t, err := o.ms.TransactionContext(ctx, false)
+	if err != nil {
+		return snapshots.Info{}, err
+	}
+	defer func() {
+		if rerr := t.Rollback(); rerr != nil {
+			log.G(ctx).WithError(rerr).Warn("Failed to rollback transaction")
+		}
+	}()
+	_, info, _, err := storage.GetInfo(ctx, key)
+	if err != nil {
+		return snapshots.Info{}, err
+	}
+
+	return info, nil
+}
+
+func (o *snapshotter) Update(ctx context.Context, info snapshots.Info, fieldpaths ...string) (snapshots.Info, error) {
+	log.G(ctx).Debugf("Update called for : %+v", info)
+	ctx, t, err := o.ms.TransactionContext(ctx, true)
+	if err != nil {
+		return snapshots.Info{}, err
+	}
+
+	info, err = storage.UpdateInfo(ctx, info, fieldpaths...)
+	if err != nil {
+		if rerr := t.Rollback(); rerr != nil {
+			log.G(ctx).WithError(rerr).Warn("Failed to rollback transaction")
+		}
+		return snapshots.Info{}, err
+	}
+
+	if err := t.Commit(); err != nil {
+		return snapshots.Info{}, err
+	}
+
+	return info, nil
+}
+
+func (o *snapshotter) Usage(ctx context.Context, key string) (snapshots.Usage, error) {
+	log.G(ctx).Debugf("Usage of key %+v", key)
+	ctx, t, err := o.ms.TransactionContext(ctx, false)
+	var s storage.Snapshot
+	var du fs.Usage
+	if err != nil {
+		return snapshots.Usage{}, err
+	}
+	defer func() {
+		if rerr := t.Rollback(); rerr != nil {
+			log.G(ctx).WithError(rerr).Warn("Failed to rollback transaction")
+		}
+	}()
+	_, info, usage, err := storage.GetInfo(ctx, key)
+	if err != nil {
+		return snapshots.Usage{}, err
+	}
+
+	if info.Kind == snapshots.KindActive {
+		if s, err = storage.GetSnapshot(ctx, key); err != nil {
+			return snapshots.Usage{}, err
+		}
+		mounts := o.mounts(s)
+		if err = mount.WithTempMount(ctx, mounts, func(root string) error {
+			if du, err = fs.DiskUsage(ctx, root); err != nil {
+				return err
+			}
+			usage = snapshots.Usage(du)
+			return nil
+		}); err != nil {
+			return snapshots.Usage{}, err
+		}
+	}
+
+	log.G(ctx).Debugf("Usage of key %s is %+v", key, usage)
+	return usage, nil
+}
+
+func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
+	log.G(ctx).Debugf("Preparing snapshot for key %s with parent %s", key, parent)
+	return o.createSnapshot(ctx, snapshots.KindActive, key, parent, opts)
+}
+
+func (o *snapshotter) View(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
+	log.G(ctx).Debugf("Viewing snapshot for key %s with parent %s", key, parent)
+	return o.createSnapshot(ctx, snapshots.KindView, key, parent, opts)
+}
+
+// Mounts returns the mounts for the transaction identified by key. Can be
+// called on an read-write or readonly transaction.
+//
+// This can be used to recover mounts after calling View or Prepare.
+func (o *snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, error) {
+	log.G(ctx).Debugf("Finding mounts for key %s", key)
+	ctx, t, err := o.ms.TransactionContext(ctx, false)
+	if err != nil {
+		return nil, err
+	}
+	s, err := storage.GetSnapshot(ctx, key)
+	if err != nil {
+		return []mount.Mount{}, err
+	}
+	defer func() {
+		if rerr := t.Rollback(); rerr != nil {
+			log.G(ctx).WithError(rerr).Warn("failed to rollback transaction")
+		}
+	}()
+	log.G(ctx).Debugf("Mounts for key %s is %+v", key, o.mounts(s))
+	return o.mounts(s), nil
+}
+
+func (o *snapshotter) Commit(ctx context.Context, name, key string, opts ...snapshots.Opt) error {
+	log.G(ctx).Debugf("Commit snapshot for key %s", key)
+	ctx, t, err := o.ms.TransactionContext(ctx, true)
+	var du fs.Usage
+	var usage snapshots.Usage
+	if err != nil {
+		return err
+	}
+
+	id, _, _, err := storage.GetInfo(ctx, key)
+	if err != nil {
+		return err
+	}
+
+	s, err := storage.GetSnapshot(ctx, key)
+	mounts := o.mounts(s)
+	if err = mount.WithTempMount(ctx, mounts, func(root string) error {
+		if du, err = fs.DiskUsage(ctx, root); err != nil {
+			return err
+		}
+		usage = snapshots.Usage(du)
+		return nil
+	}); err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil && t != nil {
+			if rerr := t.Rollback(); rerr != nil {
+				log.G(ctx).WithError(rerr).Warn("failed to rollback transaction")
+			}
+		}
+	}()
+
+	if _, err = storage.CommitActive(ctx, key, name, usage, opts...); err != nil {
+		return errors.Wrap(err, "failed to commit snapshot")
+	}
+
+	if err = unmountVolume(o.config.VgName, id); err != nil {
+		return errors.Wrap(err, "Unable to remove all the volume mounts")
+	}
+
+	// Deactivate the volume in LVM to free up /dev/dm-XX names on the host
+	if _, err = toggleactivateLV(o.config.VgName, id, false); err != nil {
+		return errors.Wrap(err, "Failed to change permissions on volume")
+	}
+
+	err = t.Commit()
+	if err != nil {
+		log.G(ctx).WithError(err).Warn("Transaction commit failed")
+		if derr := unmountVolume(o.config.VgName, id); derr != nil {
+			return errors.Wrap(err, "Unable to remove all the volume mounts")
+		}
+		if _, derr := removeLVMVolume(o.config.VgName, id); derr != nil {
+			log.G(ctx).WithError(derr).Warn("Unable to delete volume")
+		}
+		return err
+	}
+	return nil
+}
+
+// Remove abandons the transaction identified by key. All resources
+// associated with the key will be removed.
+func (o *snapshotter) Remove(ctx context.Context, key string) (err error) {
+	log.G(ctx).Debugf("Remove contents of key %s", key)
+	ctx, t, err := o.ms.TransactionContext(ctx, true)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil && t != nil {
+			if rerr := t.Rollback(); rerr != nil {
+				log.G(ctx).WithError(rerr).Warn("failed to rollback transaction")
+			}
+		}
+	}()
+
+	id, _, err := storage.Remove(ctx, key)
+	if err != nil {
+		return errors.Wrap(err, "failed to remove")
+	}
+
+	if err = unmountVolume(o.config.VgName, id); err != nil {
+		return errors.Wrap(err, "Unable to remove all the volume mounts")
+	}
+
+	if _, err = toggleactivateLV(o.config.VgName, id, false); err != nil {
+		return errors.Wrap(err, "Unable to deactivate metavolume")
+	}
+
+	_, err = removeLVMVolume(o.config.VgName, id)
+	if err != nil {
+		return errors.Wrap(err, "failed to delete LVM volume")
+	}
+
+	err = t.Commit()
+	if err != nil {
+		return errors.Wrap(err, "failed to commit")
+	}
+	t = nil
+	return nil
+}
+
+// Walk the committed snapshots.
+func (o *snapshotter) Walk(ctx context.Context, fn func(context.Context, snapshots.Info) error) error {
+	log.G(ctx).Debugf("Walk through %+v", ctx)
+	ctx, t, err := o.ms.TransactionContext(ctx, false)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if rerr := t.Rollback(); rerr != nil {
+			log.G(ctx).WithError(rerr).Warn("Failed to rollback transaction")
+		}
+	}()
+	return storage.WalkInfo(ctx, fn)
+}
+
+func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, key, parent string, opts []snapshots.Opt) (_ []mount.Mount, err error) {
+
+	pvol := ""
+	ctx, t, err := o.ms.TransactionContext(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil && t != nil {
+			if rerr := t.Rollback(); rerr != nil {
+				log.G(ctx).WithError(rerr).Warn("Failed to rollback transaction")
+			}
+		}
+	}()
+
+	s, err := storage.CreateSnapshot(ctx, kind, key, parent, opts...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create snapshot")
+	}
+
+	if len(s.ParentIDs) == 0 {
+		// Create a new logical volume without a base snapshot
+		pvol = ""
+	} else {
+		// Create a snapshot from the parent
+		pvol = s.ParentIDs[0]
+	}
+	if _, err := createLVMVolume(s.ID, o.config.VgName, o.config.ThinPool, o.config.ImageSize, pvol, kind); err != nil {
+		log.G(ctx).WithError(err).Warn("Unable to create volume")
+		return nil, errors.Wrap(err, "Unable to create volume")
+	}
+
+	if _, err := toggleactivateLV(o.config.VgName, s.ID, true); err != nil {
+		log.G(ctx).WithError(err).Warn("Unable to activate new volume")
+		return nil, errors.Wrap(err, "Unable to create volume")
+	}
+
+	if pvol == "" {
+		if err := formatVolume(o.config.VgName, s.ID, o.config.FsType); err != nil {
+			log.G(ctx).WithError(err).Warn("Unable to format new volume")
+			return nil, errors.Wrap(err, "Unable to create volume")
+		}
+	}
+
+	err = t.Commit()
+	if err != nil {
+		return nil, err
+	}
+	t = nil
+
+	log.G(ctx).Debugf("Mounts for key %s is %+v", key, o.mounts(s))
+	mounts := o.mounts(s)
+
+	// Ext4 creates a "lost+found" directory which messes up with difflayer.
+	// Clear it out prior to handing this over.
+	if o.config.FsType == "ext4" {
+		_ = mount.WithTempMount(ctx, mounts, func(root string) error {
+			return os.Remove(filepath.Join(root, "lost+found"))
+		})
+	}
+
+	return mounts, nil
+
+}
+
+func (o *snapshotter) getSnapshotDir(id string) string {
+	return filepath.Join("/dev", o.config.VgName, id)
+}
+
+func (o *snapshotter) mounts(s storage.Snapshot) []mount.Mount {
+	var (
+		source   string
+		moptions []string
+	)
+
+	if s.Kind == snapshots.KindView {
+		moptions = append(moptions, "ro")
+	}
+
+	//This will allow two filesystems with same UUID to be mounted on a machine.
+	if o.config.FsType == "xfs" {
+		moptions = append(moptions, "nouuid")
+	}
+
+	source = o.getSnapshotDir(s.ID)
+	return []mount.Mount{
+		{
+			Source:  source,
+			Type:    o.config.FsType,
+			Options: moptions,
+		},
+	}
+}
+
+// Close closes the snapshotter
+func (o *snapshotter) Close() error {
+	var err = o.ms.Close()
+	if err != nil {
+		return err
+	}
+	err = unmountVolume(o.config.VgName, metavolume)
+	if err != nil {
+		return err
+	}
+	_, err = toggleactivateLV(o.config.VgName, metavolume, false)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/snapshots/lvm/snapshotter_test.go
+++ b/snapshots/lvm/snapshotter_test.go
@@ -1,0 +1,92 @@
+// +build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package lvm
+
+import (
+	"context"
+	"runtime"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/pkg/testutil"
+	"github.com/containerd/containerd/snapshots"
+	"github.com/containerd/containerd/snapshots/testsuite"
+	"github.com/containerd/continuity/testutil/loopback"
+	"gotest.tools/assert"
+)
+
+const (
+	vgNamePrefix = "vgthin"
+	lvPoolPrefix = "lvthinpool"
+	loopbackSize = int64(10 << 30)
+)
+
+func TestLVMSnapshotterSuite(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Snapshotter only implemented for Linux")
+	}
+
+	testutil.RequiresRoot(t)
+
+	testLvmSnapshotter := func(ctx context.Context, root string) (snapshots.Snapshotter, func() error, error) {
+		var vgName string
+		var lvPool string
+		var err error
+		//imagePath, loopDevice, err = createSparseDrive(t, root)
+		loopDevice, loopCleanFn, err := loopback.New(loopbackSize)
+		assert.NilError(t, err)
+		//fmt.Printf("Using device %s", loopDevice)
+
+		//suffix := randString(10)
+		suffix := strconv.Itoa(time.Now().Nanosecond())
+
+		vgName = vgNamePrefix + suffix
+		lvPool = lvPoolPrefix + suffix
+
+		output, err := createVolumeGroup(loopDevice, vgName)
+		assert.NilError(t, err, output)
+
+		output, err = toggleactivateVG(vgName, true)
+		assert.NilError(t, err, output)
+
+		output, err = createLogicalThinPool(vgName, lvPool)
+		assert.NilError(t, err, output)
+
+		config := &SnapConfig{
+			VgName:   vgName,
+			ThinPool: lvPool,
+		}
+		err = config.Validate(root)
+		assert.NilError(t, err)
+
+		snap, err := NewSnapshotter(ctx, config)
+		assert.NilError(t, err)
+
+		return snap, func() error {
+			snap.Close()
+			deleteVolumeGroup(vgName)
+			loopCleanFn()
+			return nil
+		}, nil
+	}
+
+	testsuite.SnapshotterSuite(t, "LVM", testLvmSnapshotter)
+
+}


### PR DESCRIPTION
This is a block based snapshotter that uses LVM to create and manage
sparse block images. LVM support is available in cri-o and this change
provides feature compatibility.

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>