### PR TITLE
Fix capability option race and panic.

### DIFF
--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -741,7 +741,9 @@ func WithCapabilities(caps []string) SpecOpts {
 }
 
 // WithAllCapabilities sets all linux capabilities for the process
-var WithAllCapabilities = WithCapabilities(GetAllCapabilities())
+var WithAllCapabilities = func(ctx context.Context, client Client, c *containers.Container, s *Spec) error {
+	return WithCapabilities(GetAllCapabilities())(ctx, client, c, s)
+}
 
 // GetAllCapabilities returns all caps up to CAP_LAST_CAP
 // or CAP_BLOCK_SUSPEND on RHEL6
@@ -771,12 +773,14 @@ func capsContain(caps []string, s string) bool {
 }
 
 func removeCap(caps *[]string, s string) {
-	for i, c := range *caps {
+	var newcaps []string
+	for _, c := range *caps {
 		if c == s {
-			*caps = append((*caps)[:i], (*caps)[i+1:]...)
-			return
+			continue
 		}
+		newcaps = append(newcaps, c)
 	}
+	*caps = newcaps
 }
 
 // WithAddedCapabilities adds the provided capabilities


### PR DESCRIPTION
# Race
With the following code:
```
var WithAllCapabilities = WithCapabilities(GetAllCapabilities())
```
All `WithAllCapabilities` option will share the same instance of capability list returned by GetAllCapabilities(). This means that dropping a cap will actually drop the cap for all `WithAllCapabilities` callers.

This is very bad, and we may want to cherry-pick this fix.

Without the fix, the newly added test will fail:
```
--- FAIL: TestDropCaps (0.00s)
    spec_opts_test.go:487: cap list 0 doesn't contain non-dropped cap
    spec_opts_test.go:487: cap list 1 doesn't contain non-dropped cap
    spec_opts_test.go:487: cap list 2 doesn't contain non-dropped cap
    spec_opts_test.go:487: cap list 3 doesn't contain non-dropped cap
FAIL
exit status 1
FAIL	github.com/containerd/containerd/oci	0.032s
```

# Panic
When pushing the change, I found https://github.com/containerd/containerd/pull/3117 has already handled the panic.

But it seems better not to assume there is no duplicated cap.

Without the fix, the newly added test will panic:
```
--- FAIL: TestDropCaps (0.00s)
panic: runtime error: slice bounds out of range [recovered]
	panic: runtime error: slice bounds out of range

goroutine 13 [running]:
testing.tRunner.func1(0xc0000bcc00)
	/usr/local/go/src/testing/testing.go:792 +0x387
panic(0x635e60, 0xa43ad0)
	/usr/local/go/src/runtime/panic.go:513 +0x1b9
github.com/containerd/containerd/oci.removeCap(0xc0000bb080, 0x67743b, 0x9)
	/usr/local/google/home/lantaol/workspace/src/github.com/containerd/containerd/oci/spec_opts.go:778 +0x24e
github.com/containerd/containerd/oci.WithDroppedCapabilities.func1(0x0, 0x0, 0x0, 0x0, 0x0, 0xc0000baf80, 0x0, 0x0)
	/usr/local/google/home/lantaol/workspace/src/github.com/containerd/containerd/oci/spec_opts.go:826 +0x8f
github.com/containerd/containerd/oci.TestDropCaps(0xc0000bcc00)
	/usr/local/google/home/lantaol/workspace/src/github.com/containerd/containerd/oci/spec_opts_test.go:494 +0x7a0
testing.tRunner(0xc0000bcc00, 0x684ed0)
	/usr/local/go/src/testing/testing.go:827 +0xbf
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:878 +0x353
exit status 2
FAIL	github.com/containerd/containerd/oci	0.035s
```



Signed-off-by: Lantao Liu <lantaol@google.com>