### PR TITLE
[release/1.2 backport] update opencontainers/runc v1.0.0-rc7

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -20,7 +20,7 @@ github.com/gogo/protobuf v1.0.0
 github.com/gogo/googleapis 08a7655d27152912db7aaf4f983275eaf8d128ef
 github.com/golang/protobuf v1.1.0
 github.com/opencontainers/runtime-spec eba862dc2470385a233c7507392675cbeadf7353 # v1.0.1-45-geba862d
-github.com/opencontainers/runc 2b18fe1d885ee5083ef9f0838fee39b62d653e30
+github.com/opencontainers/runc v1.0.0-rc7
 github.com/sirupsen/logrus v1.0.0
 github.com/urfave/cli 7bc6a0acffa589f415f88aca16cc1de5ffd66f9c
 golang.org/x/net b3756b4b77d7b13260a0a2ec658753cf48922eac

--- a/vendor/github.com/opencontainers/runc/libcontainer/nsenter/cloned_binary.c
+++ b/vendor/github.com/opencontainers/runc/libcontainer/nsenter/cloned_binary.c
@@ -249,7 +249,7 @@ static int make_execfd(int *fdtype)
 {
 	int fd = -1;
 	char template[PATH_MAX] = {0};
-	char *prefix = secure_getenv("_LIBCONTAINER_STATEDIR");
+	char *prefix = getenv("_LIBCONTAINER_STATEDIR");
 
 	if (!prefix || *prefix != '/')
 		prefix = "/tmp";
@@ -351,7 +351,7 @@ static int try_bindfd(void)
 {
 	int fd, ret = -1;
 	char template[PATH_MAX] = {0};
-	char *prefix = secure_getenv("_LIBCONTAINER_STATEDIR");
+	char *prefix = getenv("_LIBCONTAINER_STATEDIR");
 
 	if (!prefix || *prefix != '/')
 		prefix = "/tmp";

--- a/vendor/github.com/opencontainers/runc/vendor.conf
+++ b/vendor/github.com/opencontainers/runc/vendor.conf
@@ -5,7 +5,7 @@ github.com/opencontainers/runtime-spec 29686dbc5559d93fb1ef402eeda3e35c38d75af4
 # Core libcontainer functionality.
 github.com/checkpoint-restore/go-criu v3.11
 github.com/mrunalp/fileutils ed869b029674c0e9ce4c0dfa781405c2d9946d08
-github.com/opencontainers/selinux v1.0.0-rc1
+github.com/opencontainers/selinux v1.2
 github.com/seccomp/libseccomp-golang 84e90a91acea0f4e51e62bc1a75de18b1fc0790f
 github.com/sirupsen/logrus a3f95b5c423586578a4e099b11a46c2479628cac
 github.com/syndtr/gocapability db04d3cc01c8b54962a58ec7e491717d06cfcc16


### PR DESCRIPTION
backport of https://github.com/containerd/containerd/pull/3139 for the 1.2 release branch

full diff: https://github.com/opencontainers/runc/compare/2b18fe1d885ee5083ef9f0838fee39b62d653e30...v1.0.0-rc7

changes included:

- opencontainers/runc#2012 Need to setup labeling of kernel keyrings
- opencontainers/runc#2014 Add $RUNC_USE_SYSTEMD to run tests using systemd cgroup driver
- opencontainers/runc#2015 Use getenv not secure_getenv
  - fixes opencontainers/runc#2013 build fails with musl libc
- opencontainers/runc#2023 Fixes regression causing zombie runc:[1:CHILD] processes
  - fixes https://github.com/opencontainers/runc/pull/1966 ensure we call wait() on children created by nsenter
