### PR TITLE
[release/1.2 backport] bump containerd/cgroups 4994991857f9b0ae8dc439551e8bebdbb4bf66c1

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,6 +1,6 @@
 github.com/containerd/go-runc 5a6d9f37cfa36b15efba46dc7ea349fa9b7143c3
 github.com/containerd/console c12b1e7919c14469339a5d38f2f8ed9b64a9de23
-github.com/containerd/cgroups dbea6f2bd41658b84b00417ceefa416b979cbf10
+github.com/containerd/cgroups 4994991857f9b0ae8dc439551e8bebdbb4bf66c1
 github.com/containerd/typeurl a93fcdb778cd272c6e9b3028b2f42d813e785d40
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c
 github.com/containerd/btrfs 2e1aa0ddf94f91fa282b6ed87c23bf0d64911244

--- a/vendor/github.com/containerd/cgroups/cgroup.go
+++ b/vendor/github.com/containerd/cgroups/cgroup.go
@@ -105,6 +105,10 @@ func Load(hierarchy Hierarchy, path Path, opts ...InitOpts) (Cgroup, error) {
 		}
 		activeSubsystems = append(activeSubsystems, s)
 	}
+	// if we do not have any active systems then the cgroup is deleted
+	if len(activeSubsystems) == 0 {
+		return nil, ErrCgroupDeleted
+	}
 	return &cgroup{
 		path:       path,
 		subsystems: activeSubsystems,


### PR DESCRIPTION
backport of https://github.com/containerd/containerd/pull/3142 for the 1.2 release branch


full diff: https://github.com/containerd/cgroups/compare/dbea6f2bd41658b84b00417ceefa416b979cbf10...4994991857f9b0ae8dc439551e8bebdbb4bf66c1

brings in https://github.com/containerd/cgroups/pull/79 Return ErrCgroupDeleted when no subsystems
fixes https://github.com/containerd/containerd/issues/3133 Custom cgroup path does not work in containerd 1.2.5
