### PR TITLE
[release/1.2 backport] Fix race and panic.

### DIFF
--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -733,7 +733,9 @@ func WithCapabilities(caps []string) SpecOpts {
 }
 
 // WithAllCapabilities sets all linux capabilities for the process
-var WithAllCapabilities = WithCapabilities(getAllCapabilities())
+var WithAllCapabilities = func(ctx context.Context, client Client, c *containers.Container, s *Spec) error {
+	return WithCapabilities(getAllCapabilities())(ctx, client, c, s)
+}
 
 func getAllCapabilities() []string {
 	last := capability.CAP_LAST_CAP

--- a/oci/spec_opts_test.go
+++ b/oci/spec_opts_test.go
@@ -39,25 +39,25 @@ func TestWithEnv(t *testing.T) {
 		Env: []string{"DEFAULT=test"},
 	}
 
-	WithEnv([]string{"env=1"})(nil, nil, nil, &s)
+	WithEnv([]string{"env=1"})(context.Background(), nil, nil, &s)
 
 	if len(s.Process.Env) != 2 {
 		t.Fatal("didn't append")
 	}
 
-	WithEnv([]string{"env2=1"})(nil, nil, nil, &s)
+	WithEnv([]string{"env2=1"})(context.Background(), nil, nil, &s)
 
 	if len(s.Process.Env) != 3 {
 		t.Fatal("didn't append")
 	}
 
-	WithEnv([]string{"env2=2"})(nil, nil, nil, &s)
+	WithEnv([]string{"env2=2"})(context.Background(), nil, nil, &s)
 
 	if s.Process.Env[2] != "env2=2" {
 		t.Fatal("couldn't update")
 	}
 
-	WithEnv([]string{"env2"})(nil, nil, nil, &s)
+	WithEnv([]string{"env2"})(context.Background(), nil, nil, &s)
 
 	if len(s.Process.Env) != 2 {
 		t.Fatal("couldn't unset")


### PR DESCRIPTION
This backports https://github.com/containerd/containerd/pull/3137 to fix the `WithAllCapabilities` race condition.

Signed-off-by: Lantao Liu <lantaol@google.com>