### PR TITLE
Skip rootfs unmount when no mounts are provided

### DIFF
--- a/mount/mount_linux.go
+++ b/mount/mount_linux.go
@@ -112,6 +112,9 @@ func unmount(target string, flags int) error {
 // are no mounts remaining (EINVAL is returned by mount), which is
 // useful for undoing a stack of mounts on the same mount point.
 func UnmountAll(mount string, flags int) error {
+	if _, err := os.Stat(mount); err != nil {
+		return nil
+	}
 	for {
 		if err := unmount(mount, flags); err != nil {
 			// EINVAL is returned if the target is not a

--- a/mount/mount_linux.go
+++ b/mount/mount_linux.go
@@ -111,10 +111,18 @@ func unmount(target string, flags int) error {
 // UnmountAll repeatedly unmounts the given mount point until there
 // are no mounts remaining (EINVAL is returned by mount), which is
 // useful for undoing a stack of mounts on the same mount point.
+// UnmountAll all is noop when the first argument is an empty string.
+// This is done when the containerd client did not specify any rootfs
+// mounts (e.g. because the rootfs is managed outside containerd)
+// UnmountAll is noop when the mount path does not exist.
 func UnmountAll(mount string, flags int) error {
-	if _, err := os.Stat(mount); err != nil {
+	if mount == "" {
 		return nil
 	}
+	if _, err := os.Stat(mount); os.IsNotExist(err) {
+		return nil
+	}
+
 	for {
 		if err := unmount(mount, flags); err != nil {
 			// EINVAL is returned if the target is not a

--- a/runtime/v1/linux/bundle.go
+++ b/runtime/v1/linux/bundle.go
@@ -65,9 +65,6 @@ func newBundle(id, path, workDir string, spec []byte) (b *bundle, err error) {
 			os.RemoveAll(workDir)
 		}
 	}()
-	if err := os.Mkdir(filepath.Join(path, "rootfs"), 0711); err != nil {
-		return nil, err
-	}
 	err = ioutil.WriteFile(filepath.Join(path, configFilename), spec, 0666)
 	return &bundle{
 		id:      id,

--- a/runtime/v1/linux/proc/init.go
+++ b/runtime/v1/linux/proc/init.go
@@ -304,12 +304,10 @@ func (p *Init) delete(ctx context.Context) error {
 		}
 		p.io.Close()
 	}
-	if p.Rootfs != "" {
-		if err2 := mount.UnmountAll(p.Rootfs, 0); err2 != nil {
-			log.G(ctx).WithError(err2).Warn("failed to cleanup rootfs mount")
-			if err == nil {
-				err = errors.Wrap(err2, "failed rootfs umount")
-			}
+	if err2 := mount.UnmountAll(p.Rootfs, 0); err2 != nil {
+		log.G(ctx).WithError(err2).Warn("failed to cleanup rootfs mount")
+		if err == nil {
+			err = errors.Wrap(err2, "failed rootfs umount")
 		}
 	}
 	return err

--- a/runtime/v1/linux/proc/init.go
+++ b/runtime/v1/linux/proc/init.go
@@ -304,10 +304,12 @@ func (p *Init) delete(ctx context.Context) error {
 		}
 		p.io.Close()
 	}
-	if err2 := mount.UnmountAll(p.Rootfs, 0); err2 != nil {
-		log.G(ctx).WithError(err2).Warn("failed to cleanup rootfs mount")
-		if err == nil {
-			err = errors.Wrap(err2, "failed rootfs umount")
+	if p.Rootfs != "" {
+		if err2 := mount.UnmountAll(p.Rootfs, 0); err2 != nil {
+			log.G(ctx).WithError(err2).Warn("failed to cleanup rootfs mount")
+			if err == nil {
+				err = errors.Wrap(err2, "failed rootfs umount")
+			}
 		}
 	}
 	return err

--- a/runtime/v1/shim/service.go
+++ b/runtime/v1/shim/service.go
@@ -138,13 +138,13 @@ func (s *Service) Create(ctx context.Context, r *shimapi.CreateTaskRequest) (_ *
 		Options:          r.Options,
 	}
 	rootfs := filepath.Join(r.Bundle, "rootfs")
-	defer func() {
+	defer func(rootfs string) {
 		if err != nil {
 			if err2 := mount.UnmountAll(rootfs, 0); err2 != nil {
 				log.G(ctx).WithError(err2).Warn("Failed to cleanup rootfs mount")
 			}
 		}
-	}()
+	}(rootfs)
 	for _, rm := range mounts {
 		m := &mount.Mount{
 			Type:    rm.Type,
@@ -159,6 +159,10 @@ func (s *Service) Create(ctx context.Context, r *shimapi.CreateTaskRequest) (_ *
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if len(mounts) == 0 {
+		rootfs = ""
+	}
+
 	process, err := newInit(
 		ctx,
 		s.config.Path,
@@ -169,6 +173,7 @@ func (s *Service) Create(ctx context.Context, r *shimapi.CreateTaskRequest) (_ *
 		s.config.SystemdCgroup,
 		s.platform,
 		config,
+		rootfs,
 	)
 	if err != nil {
 		return nil, errdefs.ToGRPC(err)
@@ -632,7 +637,7 @@ func getTopic(ctx context.Context, e interface{}) string {
 	return runtime.TaskUnknownTopic
 }
 
-func newInit(ctx context.Context, path, workDir, runtimeRoot, namespace, criu string, systemdCgroup bool, platform rproc.Platform, r *proc.CreateConfig) (*proc.Init, error) {
+func newInit(ctx context.Context, path, workDir, runtimeRoot, namespace, criu string, systemdCgroup bool, platform rproc.Platform, r *proc.CreateConfig, rootfs string) (*proc.Init, error) {
 	var options runctypes.CreateOptions
 	if r.Options != nil {
 		v, err := typeurl.UnmarshalAny(r.Options)
@@ -642,7 +647,6 @@ func newInit(ctx context.Context, path, workDir, runtimeRoot, namespace, criu st
 		options = *v.(*runctypes.CreateOptions)
 	}
 
-	rootfs := filepath.Join(path, "rootfs")
 	runtime := proc.NewRunc(runtimeRoot, path, namespace, r.Runtime, criu, systemdCgroup)
 	p := proc.New(r.ID, runtime, rproc.Stdio{
 		Stdin:    r.Stdin,

--- a/runtime/v2/bundle.go
+++ b/runtime/v2/bundle.go
@@ -89,10 +89,6 @@ func NewBundle(ctx context.Context, root, state, id string, spec []byte) (b *Bun
 		}
 	}
 	paths = append(paths, work)
-	// create rootfs dir
-	if err := os.Mkdir(filepath.Join(b.Path, "rootfs"), 0711); err != nil {
-		return nil, err
-	}
 	// symlink workdir
 	if err := os.Symlink(work, filepath.Join(b.Path, "work")); err != nil {
 		return nil, err


### PR DESCRIPTION
We (Cloud Foundry Garden) are trying to run containerd as a non-root user for extra security. We have our own component for creating container images so we are not using a snapshotter. While this mostly works we hit the following problem:

- Currently when you create a new task, the [client](https://github.com/containerd/containerd/blob/c80dd7929ee7600ab2684e9ab02ef427cf40c0b9/container.go#L214-L231) will ask the snapshotter (if any) about any mount points that containerd should make and pass them on with the request so that they are performed by the shim [over here](https://github.com/containerd/containerd/blob/c80dd7929ee7600ab2684e9ab02ef427cf40c0b9/runtime/v1/shim/service.go#L148-L157). If there is no snapshotter the request will contain an empty list of mounts and the shim will not perform any mounts
- When you destroy the task, however, the shim will try to [unconditionally unmount](https://github.com/containerd/containerd/blob/e7b6fea572badfceb0596c2cb5aad9c5728944ea/runtime/v1/linux/proc/init.go#L307-L312) those mountpoints which were persisted in a filed of the process struct.

As of today this works because containerd is usually run as uid 0 in its respective user namespace, but honestly it feels a bit asymmetric and is breaking our approach to rootless containers which is to run the containerd daemon as a non-root user. 

We have no issues with task creation because we are not using a snapshotter, so as mentioned above no mount calls are performed by the shim. However, when we attempt a destroy we hit the unconditional unmount call and as you can imagine this results in an `operation not permitted` error.

This PR suggests a fix which makes sure that the shim will not do any unmount calls when there is nothing to unmount (no rootfs mounts were passed in to the request, because no snapshotter was used). 

Any comments and suggestions are welcome.

Co-authored-by: Julia Nedialkova <julianedialkova@hotmail.com>
Signed-off-by:  Julia Nedialkova <julianedialkova@hotmail.com>