### PR TITLE
runtime/v1/linux/proc/io: io race

### DIFF
--- a/runtime/v1/linux/proc/io.go
+++ b/runtime/v1/linux/proc/io.go
@@ -29,6 +29,7 @@ import (
 	"sync"
 	"syscall"
 
+	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/runtime/proc"
 	"github.com/containerd/fifo"
@@ -136,7 +137,9 @@ func copyPipes(ctx context.Context, rio runc.IO, stdin, stdout, stderr string, w
 					cwg.Done()
 					p := bufPool.Get().(*[]byte)
 					defer bufPool.Put(p)
-					io.CopyBuffer(wc, rio.Stdout(), *p)
+					if _, err := io.CopyBuffer(wc, rio.Stdout(), *p); err != nil {
+						log.G(ctx).Warn("error copying stdout")
+					}
 					wg.Done()
 					wc.Close()
 					if rc != nil {
@@ -153,7 +156,9 @@ func copyPipes(ctx context.Context, rio runc.IO, stdin, stdout, stderr string, w
 					cwg.Done()
 					p := bufPool.Get().(*[]byte)
 					defer bufPool.Put(p)
-					io.CopyBuffer(wc, rio.Stderr(), *p)
+					if _, err := io.CopyBuffer(wc, rio.Stderr(), *p); err != nil {
+						log.G(ctx).Warn("error copying stderr")
+					}
 					wg.Done()
 					wc.Close()
 					if rc != nil {


### PR DESCRIPTION
This resolves #3118 by introducing synchronization to the `wc.Close()` calls.

- [x] log the IO error at `Warn` level
- [x] fix the IO error by waiting for the last `WriteCloser` to `Close()`