### PR TITLE
[release/1.2 backport] runtime/v1/linux/proc/io: io race

### DIFF
--- a/runtime/v1/linux/proc/io.go
+++ b/runtime/v1/linux/proc/io.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"os"
 	"sync"
+	"sync/atomic"
 	"syscall"
 
 	"github.com/containerd/containerd/log"
@@ -39,7 +40,7 @@ var bufPool = sync.Pool{
 }
 
 func copyPipes(ctx context.Context, rio runc.IO, stdin, stdout, stderr string, wg, cwg *sync.WaitGroup) error {
-	var sameFile io.WriteCloser
+	var sameFile *countingWriteCloser
 	for _, i := range []struct {
 		name string
 		dest func(wc io.WriteCloser, rc io.Closer)
@@ -101,6 +102,7 @@ func copyPipes(ctx context.Context, rio runc.IO, stdin, stdout, stderr string, w
 			}
 		} else {
 			if sameFile != nil {
+				sameFile.count++
 				i.dest(sameFile, nil)
 				continue
 			}
@@ -108,7 +110,10 @@ func copyPipes(ctx context.Context, rio runc.IO, stdin, stdout, stderr string, w
 				return fmt.Errorf("containerd-shim: opening %s failed: %s", i.name, err)
 			}
 			if stdout == stderr {
-				sameFile = fw
+				sameFile = &countingWriteCloser{
+					WriteCloser: fw,
+					count:       1,
+				}
 			}
 		}
 		i.dest(fw, fr)
@@ -131,6 +136,19 @@ func copyPipes(ctx context.Context, rio runc.IO, stdin, stdout, stderr string, w
 		f.Close()
 	}()
 	return nil
+}
+
+// countingWriteCloser masks io.Closer() until close has been invoked a certain number of times.
+type countingWriteCloser struct {
+	io.WriteCloser
+	count int64
+}
+
+func (c *countingWriteCloser) Close() error {
+	if atomic.AddInt64(&c.count, -1) > 0 {
+		return nil
+	}
+	return c.WriteCloser.Close()
 }
 
 // isFifo checks if a file is a fifo

--- a/runtime/v1/linux/proc/io.go
+++ b/runtime/v1/linux/proc/io.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"syscall"
 
+	"github.com/containerd/containerd/log"
 	"github.com/containerd/fifo"
 	runc "github.com/containerd/go-runc"
 )
@@ -52,7 +53,9 @@ func copyPipes(ctx context.Context, rio runc.IO, stdin, stdout, stderr string, w
 					cwg.Done()
 					p := bufPool.Get().(*[]byte)
 					defer bufPool.Put(p)
-					io.CopyBuffer(wc, rio.Stdout(), *p)
+					if _, err := io.CopyBuffer(wc, rio.Stdout(), *p); err != nil {
+						log.G(ctx).Warn("error copying stdout")
+					}
 					wg.Done()
 					wc.Close()
 					if rc != nil {
@@ -69,7 +72,9 @@ func copyPipes(ctx context.Context, rio runc.IO, stdin, stdout, stderr string, w
 					cwg.Done()
 					p := bufPool.Get().(*[]byte)
 					defer bufPool.Put(p)
-					io.CopyBuffer(wc, rio.Stderr(), *p)
+					if _, err := io.CopyBuffer(wc, rio.Stderr(), *p); err != nil {
+						log.G(ctx).Warn("error copying stderr")
+					}
 					wg.Done()
 					wc.Close()
 					if rc != nil {


### PR DESCRIPTION
Backport of for the release/1.2 branch

first commit didn't apply clean due to https://github.com/containerd/containerd/pull/3085 not being in the 1.2 branch