### PR TITLE
[release/1.2] Update cri to ffd9a66034aee582db04cf4c59e9b2262fd4fc59.

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -43,11 +43,11 @@ github.com/google/go-cmp v0.1.0
 go.etcd.io/bbolt v1.3.1-etcd.8
 
 # cri dependencies
-github.com/containerd/cri a92c40017473cbe0239ce180125f12669757e44f # release/1.2 branch
+github.com/containerd/cri ffd9a66034aee582db04cf4c59e9b2262fd4fc59 # release/1.2 branch
 github.com/containerd/go-cni 40bcf8ec8acd7372be1d77031d585d5d8e561c90
 github.com/blang/semver v3.1.0
 github.com/containernetworking/cni v0.6.0
-github.com/containernetworking/plugins v0.7.0
+github.com/containernetworking/plugins v0.7.5
 github.com/davecgh/go-spew v1.1.0
 github.com/docker/distribution 0d3efadf0154c2b8a4e7b6621fff9809655cc580
 github.com/docker/docker 86f080cff0914e9694068ed78d503701667c4c00

--- a/vendor/github.com/containerd/cri/pkg/server/sandbox_run.go
+++ b/vendor/github.com/containerd/cri/pkg/server/sandbox_run.go
@@ -385,6 +385,7 @@ func (c *criService) generateSandboxContainerSpec(id string, config *runtime.Pod
 	nsOptions := securityContext.GetNamespaceOptions()
 	if nsOptions.GetNetwork() == runtime.NamespaceMode_NODE {
 		g.RemoveLinuxNamespace(string(runtimespec.NetworkNamespace)) // nolint: errcheck
+		g.RemoveLinuxNamespace(string(runtimespec.UTSNamespace))     // nolint: errcheck
 	} else {
 		//TODO(Abhi): May be move this to containerd spec opts (WithLinuxSpaceOption)
 		g.AddOrReplaceLinuxNamespace(string(runtimespec.NetworkNamespace), nsPath) // nolint: errcheck

--- a/vendor/github.com/containerd/cri/pkg/server/sandbox_stop.go
+++ b/vendor/github.com/containerd/cri/pkg/server/sandbox_stop.go
@@ -144,7 +144,7 @@ func (c *criService) waitSandboxStop(ctx context.Context, sandbox sandboxstore.S
 	defer timeoutTimer.Stop()
 	select {
 	case <-ctx.Done():
-		return errors.Errorf("wait sandbox container %q is cancelled", sandbox.ID)
+		return errors.Wrapf(ctx.Err(), "wait sandbox container %q is cancelled", sandbox.ID)
 	case <-timeoutTimer.C:
 		return errors.Errorf("wait sandbox container %q stop timeout", sandbox.ID)
 	case <-sandbox.Stopped():

--- a/vendor/github.com/containerd/cri/vendor.conf
+++ b/vendor/github.com/containerd/cri/vendor.conf
@@ -1,9 +1,9 @@
 github.com/beorn7/perks 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
 github.com/blang/semver v3.1.0
 github.com/BurntSushi/toml a368813c5e648fee92e5f6c30e3944ff9d5e8895
-github.com/containerd/cgroups 5e610833b72089b37d0e615de9a92dfc043757c2
+github.com/containerd/cgroups dbea6f2bd41658b84b00417ceefa416b979cbf10
 github.com/containerd/console c12b1e7919c14469339a5d38f2f8ed9b64a9de23
-github.com/containerd/containerd 583472f67a3d7c258f874347339688de05802790
+github.com/containerd/containerd v1.2.5
 github.com/containerd/continuity bd77b46c8352f74eb12c85bdc01f4b90f69d66b4
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c
 github.com/containerd/go-cni 40bcf8ec8acd7372be1d77031d585d5d8e561c90
@@ -11,7 +11,7 @@ github.com/containerd/go-runc 5a6d9f37cfa36b15efba46dc7ea349fa9b7143c3
 github.com/containerd/ttrpc 2a805f71863501300ae1976d29f0454ae003e85a
 github.com/containerd/typeurl a93fcdb778cd272c6e9b3028b2f42d813e785d40
 github.com/containernetworking/cni v0.6.0
-github.com/containernetworking/plugins v0.7.0
+github.com/containernetworking/plugins v0.7.5
 github.com/coreos/go-systemd v14
 github.com/davecgh/go-spew v1.1.0
 github.com/docker/distribution 0d3efadf0154c2b8a4e7b6621fff9809655cc580
@@ -39,7 +39,7 @@ github.com/modern-go/concurrent 1.0.3
 github.com/modern-go/reflect2 1.0.1
 github.com/opencontainers/go-digest c9281466c8b2f606084ac71339773efd177436e7
 github.com/opencontainers/image-spec v1.0.1
-github.com/opencontainers/runc 6635b4f0c6af3810594d2770f662f34ddc15b40d
+github.com/opencontainers/runc 2b18fe1d885ee5083ef9f0838fee39b62d653e30
 github.com/opencontainers/runtime-spec eba862dc2470385a233c7507392675cbeadf7353
 github.com/opencontainers/runtime-tools v0.6.0
 github.com/opencontainers/selinux b6fa367ed7f534f9ba25391cc2d467085dbb445a


### PR DESCRIPTION
* Fix a bug that containers being gracefully stopped are SIGKILLed when kubelet is restarted. https://github.com/containerd/cri/issues/1098
* Fix a bug that pod UTS namespace is used for host network. https://github.com/containerd/cri/pull/1111
* Update CNI plugins to v0.7.5 for [CVE-2019-9946](https://nvd.nist.gov/vuln/detail/CVE-2019-9946).

Signed-off-by: Lantao Liu <lantaol@google.com>