### PR TITLE
[release/1.1] Update cri to b9c06fd1410f1e6699a83277887af399a1342736.

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -44,11 +44,11 @@ github.com/gotestyourself/gotestyourself 44dbf532bbf5767611f6f2a61bded572e337010
 github.com/google/go-cmp v0.1.0
 
 # cri dependencies
-github.com/containerd/cri f0b5665a959119b6a6234001e6d55206d9200e95 # release/1.0
+github.com/containerd/cri b9c06fd1410f1e6699a83277887af399a1342736 # release/1.0
 github.com/containerd/go-cni 40bcf8ec8acd7372be1d77031d585d5d8e561c90
 github.com/blang/semver v3.1.0
 github.com/containernetworking/cni v0.6.0
-github.com/containernetworking/plugins v0.7.0
+github.com/containernetworking/plugins v0.7.5
 github.com/davecgh/go-spew v1.1.0
 github.com/docker/distribution b38e5838b7b2f2ad48e06ec4b500011976080621
 github.com/docker/docker 86f080cff0914e9694068ed78d503701667c4c00

--- a/vendor/github.com/containerd/cri/pkg/server/container_stop.go
+++ b/vendor/github.com/containerd/cri/pkg/server/container_stop.go
@@ -111,8 +111,9 @@ func (c *criService) stopContainer(ctx context.Context, container containerstore
 			return errors.Wrapf(err, "failed to stop container %q", id)
 		}
 
-		if err = c.waitContainerStop(ctx, container, timeout); err == nil {
-			return nil
+		if err = c.waitContainerStop(ctx, container, timeout); err == nil || errors.Cause(err) == ctx.Err() {
+			// Do not SIGKILL container if the context is cancelled.
+			return err
 		}
 		logrus.WithError(err).Errorf("An error occurs during waiting for container %q to be stopped", id)
 	}
@@ -156,7 +157,7 @@ func (c *criService) waitContainerStop(ctx context.Context, container containers
 	defer timeoutTimer.Stop()
 	select {
 	case <-ctx.Done():
-		return errors.Errorf("wait container %q is cancelled", container.ID)
+		return errors.Wrapf(ctx.Err(), "wait container %q is cancelled", container.ID)
 	case <-timeoutTimer.C:
 		return errors.Errorf("wait container %q stop timeout", container.ID)
 	case <-container.Stopped():

--- a/vendor/github.com/containerd/cri/pkg/server/helpers.go
+++ b/vendor/github.com/containerd/cri/pkg/server/helpers.go
@@ -414,7 +414,7 @@ func checkSelinuxLevel(level string) (bool, error) {
 // isInCRIMounts checks whether a destination is in CRI mount list.
 func isInCRIMounts(dst string, mounts []*runtime.Mount) bool {
 	for _, m := range mounts {
-		if m.ContainerPath == dst {
+		if filepath.Clean(m.ContainerPath) == filepath.Clean(dst) {
 			return true
 		}
 	}

--- a/vendor/github.com/containerd/cri/pkg/server/sandbox_run.go
+++ b/vendor/github.com/containerd/cri/pkg/server/sandbox_run.go
@@ -384,6 +384,7 @@ func (c *criService) generateSandboxContainerSpec(id string, config *runtime.Pod
 	nsOptions := securityContext.GetNamespaceOptions()
 	if nsOptions.GetNetwork() == runtime.NamespaceMode_NODE {
 		g.RemoveLinuxNamespace(string(runtimespec.NetworkNamespace)) // nolint: errcheck
+		g.RemoveLinuxNamespace(string(runtimespec.UTSNamespace))     // nolint: errcheck
 	} else {
 		//TODO(Abhi): May be move this to containerd spec opts (WithLinuxSpaceOption)
 		g.AddOrReplaceLinuxNamespace(string(runtimespec.NetworkNamespace), nsPath) // nolint: errcheck

--- a/vendor/github.com/containerd/cri/pkg/server/sandbox_stop.go
+++ b/vendor/github.com/containerd/cri/pkg/server/sandbox_stop.go
@@ -129,7 +129,7 @@ func (c *criService) waitSandboxStop(ctx context.Context, sandbox sandboxstore.S
 	defer timeoutTimer.Stop()
 	select {
 	case <-ctx.Done():
-		return errors.Errorf("wait sandbox container %q is cancelled", sandbox.ID)
+		return errors.Wrapf(ctx.Err(), "wait sandbox container %q is cancelled", sandbox.ID)
 	case <-timeoutTimer.C:
 		return errors.Errorf("wait sandbox container %q stop timeout", sandbox.ID)
 	case <-sandbox.Stopped():

--- a/vendor/github.com/containerd/cri/vendor.conf
+++ b/vendor/github.com/containerd/cri/vendor.conf
@@ -4,14 +4,14 @@ github.com/boltdb/bolt e9cf4fae01b5a8ff89d0ec6b32f0d9c9f79aefdd
 github.com/BurntSushi/toml a368813c5e648fee92e5f6c30e3944ff9d5e8895
 github.com/containerd/cgroups fe281dd265766145e943a034aa41086474ea6130
 github.com/containerd/console 4d8a41f4ce5b9bae77c41786ea2458330f43f081
-github.com/containerd/containerd 57508dcb0b5776efaacd0828ed42f819fab5ba07
-github.com/containerd/continuity a60600ad77f38aaa70165825f61e2ea72e51c9b1
+github.com/containerd/containerd 878924b9b5b2d5fc22a3bdbe93ac736f31618f44
+github.com/containerd/continuity 7f53d412b9eb1cbf744c2063185d703a0ee34700
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c
 github.com/containerd/go-cni 40bcf8ec8acd7372be1d77031d585d5d8e561c90
 github.com/containerd/go-runc bcb223a061a3dd7de1a89c0b402a60f4dd9bd307
 github.com/containerd/typeurl f6943554a7e7e88b3c14aad190bf05932da84788
 github.com/containernetworking/cni v0.6.0
-github.com/containernetworking/plugins v0.7.0
+github.com/containernetworking/plugins v0.7.5
 github.com/coreos/go-systemd 48702e0da86bd25e76cfef347e2adeb434a0d0a6
 github.com/davecgh/go-spew v1.1.0
 github.com/docker/distribution b38e5838b7b2f2ad48e06ec4b500011976080621
@@ -37,7 +37,7 @@ github.com/Microsoft/go-winio v0.4.5
 github.com/Microsoft/hcsshim v0.6.7
 github.com/opencontainers/go-digest 21dfd564fd89c944783d00d069f33e3e7123c448
 github.com/opencontainers/image-spec v1.0.1
-github.com/opencontainers/runc 69663f0bd4b60df09991c08812a60108003fa340
+github.com/opencontainers/runc 6635b4f0c6af3810594d2770f662f34ddc15b40d
 github.com/opencontainers/runtime-spec v1.0.1
 github.com/opencontainers/runtime-tools 6073aff4ac61897f75895123f7e24135204a404d
 github.com/opencontainers/selinux b6fa367ed7f534f9ba25391cc2d467085dbb445a
@@ -58,7 +58,7 @@ github.com/urfave/cli 7bc6a0acffa589f415f88aca16cc1de5ffd66f9c
 golang.org/x/crypto 49796115aa4b964c318aad4f3084fdb41e9aa067
 golang.org/x/net 7dcfb8076726a3fdd9353b6b8a1f1b6be6811bd6
 golang.org/x/sync 450f422ab23cf9881c94e2db30cac0eb1b7cf80c
-golang.org/x/sys 314a259e304ff91bd6985da2a7149bbf91237993 https://github.com/golang/sys
+golang.org/x/sys 41f3e6584952bb034a481797859f6ab34b6803bd https://github.com/golang/sys
 golang.org/x/text 19e51611da83d6be54ddafce4a4af510cb3e9ea4
 golang.org/x/time f51c12702a4d776e4c1fa9b0fabab841babae631
 google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944


### PR DESCRIPTION
* Fix a bug that pod can't get started when the same volume is defined differently in the image and the pod spec. https://github.com/containerd/cri/issues/1059
* Fix a bug that causes container start failure after in-place upgrade containerd to 1.2.4+ or 1.1.6+. https://github.com/containerd/cri/issues/1082
* Fix a bug that containers being gracefully stopped are SIGKILLed when kubelet is restarted. https://github.com/containerd/cri/issues/1098
* Fix a bug that pod UTS namespace is used for host network. https://github.com/containerd/cri/pull/1111
* Update CNI plugins to v0.7.5 for [CVE-2019-9946](https://nvd.nist.gov/vuln/detail/CVE-2019-9946).

Signed-off-by: Lantao Liu <lantaol@google.com>