### PR TITLE
Move snapshotters benchmark to a separate package

### DIFF
--- a/contrib/aws/snapshotter_bench_readme.md
+++ b/contrib/aws/snapshotter_bench_readme.md
@@ -47,7 +47,7 @@ make
 
 ```bash
 sudo su -
-cd snapshots/testsuite/
+cd snapshots/benchsuite/
 go test -bench . \
     -dm.thinPoolDev=bench-docker--pool \
     -dm.rootPath=/mnt/disk1/data \

--- a/snapshots/benchsuite/benchmark.go
+++ b/snapshots/benchsuite/benchmark.go
@@ -1,0 +1,19 @@
+// +build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package benchsuite

--- a/snapshots/benchsuite/benchmark_test.go
+++ b/snapshots/benchsuite/benchmark_test.go
@@ -16,7 +16,7 @@
    limitations under the License.
 */
 
-package testsuite
+package benchsuite
 
 import (
 	"context"


### PR DESCRIPTION
Addressing @dmcgowan 's [comment](https://github.com/containerd/containerd/pull/3152#issuecomment-478762805) and moving benchmark code to a separate package.

Its not quite possible to split bench tests and still run them simultaneously in one command (as benchmarks complain about cli args of each other), so agreed to move it to a separate package instead.

Signed-off-by: Maksym Pavlenko <makpav@amazon.com>