### PR TITLE
check alive child process when delete task

### DIFF
--- a/errdefs/errors.go
+++ b/errdefs/errors.go
@@ -43,6 +43,7 @@ var (
 	ErrFailedPrecondition = errors.New("failed precondition")
 	ErrUnavailable        = errors.New("unavailable")
 	ErrNotImplemented     = errors.New("not implemented") // represents not supported and unimplemented
+	ErrChildProcessAlive  = errors.New("container has alive child process")
 )
 
 // IsInvalidArgument returns true if the error is due to an invalid argument


### PR DESCRIPTION
As there are still shim service lock exists, we may check the container whether has alive child process or not before really delete the task. If has, raise an error to the caller to remind the user to kill all the child processes. Then the delete method without `{all: true}` will not be stuck.

One shim service lock case in #3149 : ( I think there are may be other cases we have not find out. )
```
# we use busybox rootfs and /test1 to start container
root@demo:/opt/busybox.test# cat rootfs/test1
#!/bin/sh
sleep 100000&
while true; do
  wait || true
done

# start container test
root@demo:/opt/busybox.test# ctr run -d --rootfs ./rootfs test /test1
root@demo:/opt/busybox.test# ctr t ls
TASK    PID      STATUS    
test    17974    RUNNING
root@demo:/opt/busybox.test# ctr t ps test
PID      INFO
17974    &ProcessDetails{ExecID:test,}
17995    -

# start container test-id with pid ns of container test
root@demo:/opt/busybox.test# ctr run -d --with-ns "pid:/proc/17974/ns/pid" --rootfs ./rootfs test-pid /test1
root@demo:/opt/busybox.test# ctr t ls
TASK        PID      STATUS    
test        17974    RUNNING
test-pid    18067    RUNNING
root@demo:/opt/busybox.test# ctr t ps test-pid
PID      INFO
18067    &ProcessDetails{ExecID:test-pid,}
18088    -

# container test-id's init process is dead
root@demo:/opt/busybox.test# ctr t kill -s 9 test-pid
root@demo:/opt/busybox.test# ctr t ps test-pid
PID      INFO
18088    -
root@demo:/opt/busybox.test# ctr t ls
TASK        PID      STATUS    
test        17974    RUNNING
test-pid    18067    STOPPED

# try to delete the task test-pid, it causes shim service stuck
root@demo:/opt/busybox.test# ctr t delete test-pid
^C
root@demo:/opt/busybox.test# ctr t ls
^C
root@demo:/opt/busybox.test# ctr t ps test
PID      INFO
17974    &ProcessDetails{ExecID:test,}
17995    -
root@demo:/opt/busybox.test# ctr t ps test-pid
^C
root@demo:/opt/busybox.test#
```

Signed-off-by: lifubang <lifubang@acmcoder.com>