### PR TITLE
Update cri to 6d353571e64417d80c9478ffaea793714dd539d0.

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -44,7 +44,7 @@ github.com/google/go-cmp v0.1.0
 go.etcd.io/bbolt v1.3.2
 
 # cri dependencies
-github.com/containerd/cri 0e2afb63ac3a1c8e59abd6f2e9a6ce075135d5b0 # master
+github.com/containerd/cri 6d353571e64417d80c9478ffaea793714dd539d0 # master
 github.com/containerd/go-cni 40bcf8ec8acd7372be1d77031d585d5d8e561c90
 github.com/containernetworking/cni v0.6.0
 github.com/containernetworking/plugins v0.7.0
@@ -62,9 +62,6 @@ github.com/modern-go/concurrent 1.0.3
 github.com/opencontainers/selinux v1.2.1
 github.com/seccomp/libseccomp-golang 32f571b70023028bd57d9288c20efbcb237f3ce0
 github.com/tchap/go-patricia v2.2.6
-github.com/xeipuuv/gojsonpointer 4e3ac2762d5f479393488629ee9370b50873b3a6
-github.com/xeipuuv/gojsonreference bd5ef7bd5415a7ac448318e64f11a24cd21e594b
-github.com/xeipuuv/gojsonschema 1d523034197ff1f222f6429836dd36a2457a1874
 golang.org/x/crypto 49796115aa4b964c318aad4f3084fdb41e9aa067
 golang.org/x/oauth2 a6bd8cefa1811bd24b86f8902872e4e8225f74c4
 golang.org/x/time f51c12702a4d776e4c1fa9b0fabab841babae631

--- a/vendor/github.com/containerd/cri/pkg/server/helpers.go
+++ b/vendor/github.com/containerd/cri/pkg/server/helpers.go
@@ -122,8 +122,10 @@ const (
 const (
 	// linuxRuntime is the legacy linux runtime for shim v1.
 	linuxRuntime = "io.containerd.runtime.v1.linux"
-	// runcRuntime is the runc runtime for shim v2.
-	runcRuntime = "io.containerd.runc.v1"
+	// runcRuntimeV1 is the runc v1 runtime for shim v2.
+	runcRuntimeV1 = "io.containerd.runc.v1"
+	// runcRuntimeV2 is the runc v2 runtime for shim v2.
+	runcRuntimeV2 = "io.containerd.runc.v2"
 )
 
 // makeSandboxName generates sandbox name from sandbox metadata. The name
@@ -427,7 +429,9 @@ func generateRuntimeOptions(r criconfig.Runtime, c criconfig.Config) (interface{
 // getRuntimeOptionsType gets empty runtime options by the runtime type name.
 func getRuntimeOptionsType(t string) interface{} {
 	switch t {
-	case runcRuntime:
+	case runcRuntimeV1:
+		fallthrough
+	case runcRuntimeV2:
 		return &runcoptions.Options{}
 	case linuxRuntime:
 		return &runctypes.RuncOptions{}


### PR DESCRIPTION
The Kubernetes e2e test for containerd repository is failing:
* https://k8s-testgrid.appspot.com/sig-node-containerd#containerd-e2e-gci
* https://k8s-testgrid.appspot.com/sig-node-containerd#containerd-node-e2e
* https://k8s-testgrid.appspot.com/sig-node-containerd#containerd-node-e2e-features
* https://k8s-testgrid.appspot.com/sig-node-containerd#containerd-e2e-ubuntu

The test result for the `cri` repository is good.

This is because we enabled per-pod shim in https://github.com/containerd/cri/pull/1116, but the change is not in this repository yet.

Signed-off-by: Lantao Liu <lantaol@google.com>