### PR TITLE
[rfc] rollback urfave/cli to tagged release v1.20.0

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -23,7 +23,7 @@ github.com/opencontainers/runtime-spec 29686dbc5559d93fb1ef402eeda3e35c38d75af4 
 github.com/opencontainers/runc 029124da7af7360afa781a0234d1b083550f797c
 github.com/konsorten/go-windows-terminal-sequences v1.0.1
 github.com/sirupsen/logrus v1.4.1
-github.com/urfave/cli 7bc6a0acffa589f415f88aca16cc1de5ffd66f9c
+github.com/urfave/cli v1.20.0
 golang.org/x/net b3756b4b77d7b13260a0a2ec658753cf48922eac
 google.golang.org/grpc v1.12.0
 github.com/pkg/errors v0.8.0

--- a/vendor/github.com/urfave/cli/README.md
+++ b/vendor/github.com/urfave/cli/README.md
@@ -33,7 +33,6 @@ applications in an expressive way.
     + [Ordering](#ordering)
     + [Values from the Environment](#values-from-the-environment)
     + [Values from alternate input sources (YAML, TOML, and others)](#values-from-alternate-input-sources-yaml-toml-and-others)
-    + [Precedence](#precedence)
   * [Subcommands](#subcommands)
   * [Subcommands categories](#subcommands-categories)
   * [Exit code](#exit-code)
@@ -657,15 +656,6 @@ func main() {
 }
 ```
 
-#### Precedence
-
-The precedence for flag value sources is as follows (highest to lowest):
-
-0. Command line flag value from user
-0. Environment variable (if specified)
-0. Configuration file (if specified)
-0. Default defined on the flag
-
 ### Subcommands
 
 Subcommands can be defined for a more git-like command line app.
@@ -761,11 +751,11 @@ func main() {
     },
     {
       Name:     "add",
-      Category: "Template actions",
+      Category: "template",
     },
     {
       Name:     "remove",
-      Category: "Template actions",
+      Category: "template",
     },
   }
 

--- a/vendor/github.com/urfave/cli/app.go
+++ b/vendor/github.com/urfave/cli/app.go
@@ -83,9 +83,6 @@ type App struct {
 	Writer io.Writer
 	// ErrWriter writes error output
 	ErrWriter io.Writer
-	// Execute this function to handle ExitErrors. If not provided, HandleExitCoder is provided to
-	// function as a default, so this is optional.
-	ExitErrHandler ExitErrHandlerFunc
 	// Other custom info
 	Metadata map[string]interface{}
 	// Carries a function which returns app specific info.
@@ -210,7 +207,7 @@ func (a *App) Run(arguments []string) (err error) {
 	if err != nil {
 		if a.OnUsageError != nil {
 			err := a.OnUsageError(context, err, false)
-			a.handleExitCoder(context, err)
+			HandleExitCoder(err)
 			return err
 		}
 		fmt.Fprintf(a.Writer, "%s %s\n\n", "Incorrect Usage.", err.Error())
@@ -243,9 +240,8 @@ func (a *App) Run(arguments []string) (err error) {
 	if a.Before != nil {
 		beforeErr := a.Before(context)
 		if beforeErr != nil {
-			fmt.Fprintf(a.Writer, "%v\n\n", beforeErr)
 			ShowAppHelp(context)
-			a.handleExitCoder(context, beforeErr)
+			HandleExitCoder(beforeErr)
 			err = beforeErr
 			return err
 		}
@@ -267,7 +263,7 @@ func (a *App) Run(arguments []string) (err error) {
 	// Run default Action
 	err = HandleAction(a.Action, context)
 
-	a.handleExitCoder(context, err)
+	HandleExitCoder(err)
 	return err
 }
 
@@ -334,7 +330,7 @@ func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 	if err != nil {
 		if a.OnUsageError != nil {
 			err = a.OnUsageError(context, err, true)
-			a.handleExitCoder(context, err)
+			HandleExitCoder(err)
 			return err
 		}
 		fmt.Fprintf(a.Writer, "%s %s\n\n", "Incorrect Usage.", err.Error())
@@ -356,7 +352,7 @@ func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 		defer func() {
 			afterErr := a.After(context)
 			if afterErr != nil {
-				a.handleExitCoder(context, err)
+				HandleExitCoder(err)
 				if err != nil {
 					err = NewMultiError(err, afterErr)
 				} else {
@@ -369,7 +365,7 @@ func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 	if a.Before != nil {
 		beforeErr := a.Before(context)
 		if beforeErr != nil {
-			a.handleExitCoder(context, beforeErr)
+			HandleExitCoder(beforeErr)
 			err = beforeErr
 			return err
 		}
@@ -387,7 +383,7 @@ func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 	// Run default Action
 	err = HandleAction(a.Action, context)
 
-	a.handleExitCoder(context, err)
+	HandleExitCoder(err)
 	return err
 }
 
@@ -468,14 +464,6 @@ func (a *App) appendFlag(flag Flag) {
 	}
 }
 
-func (a *App) handleExitCoder(context *Context, err error) {
-	if a.ExitErrHandler != nil {
-		a.ExitErrHandler(context, err)
-	} else {
-		HandleExitCoder(err)
-	}
-}
-
 // Author represents someone who has contributed to a cli project.
 type Author struct {
 	Name  string // The Authors name
@@ -503,7 +491,7 @@ func HandleAction(action interface{}, context *Context) (err error) {
 	} else if a, ok := action.(func(*Context)); ok { // deprecated function signature
 		a(context)
 		return nil
+	} else {
+		return errInvalidActionType
 	}
-
-	return errInvalidActionType
 }

--- a/vendor/github.com/urfave/cli/command.go
+++ b/vendor/github.com/urfave/cli/command.go
@@ -167,7 +167,7 @@ func (c Command) Run(ctx *Context) (err error) {
 	if err != nil {
 		if c.OnUsageError != nil {
 			err := c.OnUsageError(context, err, false)
-			context.App.handleExitCoder(context, err)
+			HandleExitCoder(err)
 			return err
 		}
 		fmt.Fprintln(context.App.Writer, "Incorrect Usage:", err.Error())
@@ -184,7 +184,7 @@ func (c Command) Run(ctx *Context) (err error) {
 		defer func() {
 			afterErr := c.After(context)
 			if afterErr != nil {
-				context.App.handleExitCoder(context, err)
+				HandleExitCoder(err)
 				if err != nil {
 					err = NewMultiError(err, afterErr)
 				} else {
@@ -198,7 +198,7 @@ func (c Command) Run(ctx *Context) (err error) {
 		err = c.Before(context)
 		if err != nil {
 			ShowCommandHelp(context, c.Name)
-			context.App.handleExitCoder(context, err)
+			HandleExitCoder(err)
 			return err
 		}
 	}
@@ -210,7 +210,7 @@ func (c Command) Run(ctx *Context) (err error) {
 	err = HandleAction(c.Action, context)
 
 	if err != nil {
-		context.App.handleExitCoder(context, err)
+		HandleExitCoder(err)
 	}
 	return err
 }

--- a/vendor/github.com/urfave/cli/context.go
+++ b/vendor/github.com/urfave/cli/context.go
@@ -73,7 +73,7 @@ func (c *Context) IsSet(name string) bool {
 		// change in version 2 to add `IsSet` to the Flag interface to push the
 		// responsibility closer to where the information required to determine
 		// whether a flag is set by non-standard means such as environment
-		// variables is available.
+		// variables is avaliable.
 		//
 		// See https://github.com/urfave/cli/issues/294 for additional discussion
 		flags := c.Command.Flags

--- a/vendor/github.com/urfave/cli/flag.go
+++ b/vendor/github.com/urfave/cli/flag.go
@@ -37,14 +37,6 @@ var HelpFlag Flag = BoolFlag{
 // to display a flag.
 var FlagStringer FlagStringFunc = stringifyFlag
 
-// FlagNamePrefixer converts a full flag name and its placeholder into the help
-// message flag prefix. This is used by the default FlagStringer.
-var FlagNamePrefixer FlagNamePrefixFunc = prefixedNames
-
-// FlagEnvHinter annotates flag help message with the environment variable
-// details. This is used by the default FlagStringer.
-var FlagEnvHinter FlagEnvHintFunc = withEnvHint
-
 // FlagsByName is a slice of Flag.
 type FlagsByName []Flag
 
@@ -718,13 +710,13 @@ func stringifyFlag(f Flag) string {
 
 	switch f.(type) {
 	case IntSliceFlag:
-		return FlagEnvHinter(fv.FieldByName("EnvVar").String(),
+		return withEnvHint(fv.FieldByName("EnvVar").String(),
 			stringifyIntSliceFlag(f.(IntSliceFlag)))
 	case Int64SliceFlag:
-		return FlagEnvHinter(fv.FieldByName("EnvVar").String(),
+		return withEnvHint(fv.FieldByName("EnvVar").String(),
 			stringifyInt64SliceFlag(f.(Int64SliceFlag)))
 	case StringSliceFlag:
-		return FlagEnvHinter(fv.FieldByName("EnvVar").String(),
+		return withEnvHint(fv.FieldByName("EnvVar").String(),
 			stringifyStringSliceFlag(f.(StringSliceFlag)))
 	}
 
@@ -752,8 +744,8 @@ func stringifyFlag(f Flag) string {
 
 	usageWithDefault := strings.TrimSpace(fmt.Sprintf("%s%s", usage, defaultValueString))
 
-	return FlagEnvHinter(fv.FieldByName("EnvVar").String(),
-		fmt.Sprintf("%s\t%s", FlagNamePrefixer(fv.FieldByName("Name").String(), placeholder), usageWithDefault))
+	return withEnvHint(fv.FieldByName("EnvVar").String(),
+		fmt.Sprintf("%s\t%s", prefixedNames(fv.FieldByName("Name").String(), placeholder), usageWithDefault))
 }
 
 func stringifyIntSliceFlag(f IntSliceFlag) string {
@@ -803,5 +795,5 @@ func stringifySliceFlag(usage, name string, defaultVals []string) string {
 	}
 
 	usageWithDefault := strings.TrimSpace(fmt.Sprintf("%s%s", usage, defaultVal))
-	return fmt.Sprintf("%s\t%s", FlagNamePrefixer(name, placeholder), usageWithDefault)
+	return fmt.Sprintf("%s\t%s", prefixedNames(name, placeholder), usageWithDefault)
 }

--- a/vendor/github.com/urfave/cli/funcs.go
+++ b/vendor/github.com/urfave/cli/funcs.go
@@ -23,19 +23,6 @@ type CommandNotFoundFunc func(*Context, string)
 // is displayed and the execution is interrupted.
 type OnUsageErrorFunc func(context *Context, err error, isSubcommand bool) error
 
-// ExitErrHandlerFunc is executed if provided in order to handle ExitError values
-// returned by Actions and Before/After functions.
-type ExitErrHandlerFunc func(context *Context, err error)
-
 // FlagStringFunc is used by the help generation to display a flag, which is
 // expected to be a single line.
 type FlagStringFunc func(Flag) string
-
-// FlagNamePrefixFunc is used by the default FlagStringFunc to create prefix
-// text for a flag's full name.
-type FlagNamePrefixFunc func(fullName, placeholder string) string
-
-// FlagEnvHintFunc is used by the default FlagStringFunc to annotate flag help
-// with the environment variable details.
-type FlagEnvHintFunc func(envVar, str string) string
-

--- a/vendor/github.com/urfave/cli/help.go
+++ b/vendor/github.com/urfave/cli/help.go
@@ -29,7 +29,6 @@ AUTHOR{{with $length := len .Authors}}{{if ne 1 $length}}S{{end}}{{end}}:
    {{end}}{{$author}}{{end}}{{end}}{{if .VisibleCommands}}
 
 COMMANDS:{{range .VisibleCategories}}{{if .Name}}
-
    {{.Name}}:{{end}}{{range .VisibleCommands}}
      {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{end}}{{end}}{{if .VisibleFlags}}
 


### PR DESCRIPTION
I noticed we bumped to some commit on master in https://github.com/containerd/containerd/pull/1688, and couldn't find a reference if there's specific things we needed that were not in v1.20.0. Given that people might be using `go mod`, they'll likely get the last tagged version, so perhaps it's good to use it in this repository as well (hoping they'll tag a new release at some point; https://github.com/urfave/cli/issues/728)

Full diff:
https://github.com/urfave/cli/compare/v1.20.0...7bc6a0acffa589f415f88aca16cc1de5ffd66f9c

pushing as a separate PR, because I wasn't sure we wanted to do this, or if there's any changes in the diff that are desirable; so also happy to close if we don't want to do this 😅 