### PR TITLE
Introduce 'clean-test' target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,6 +231,20 @@ clean: ## clean up binaries
 	@echo "$(WHALE) $@"
 	@rm -f $(BINARIES)
 
+clean-test: ## clean up debris from previously failed tests
+	@echo "$(WHALE) $@"
+	$(eval containers=$(shell find /run/containerd/runc -mindepth 2 -maxdepth 3  -type d -exec basename {} \;))
+	$(shell pidof containerd containerd-shim runc | xargs -r -n 1 kill -9)
+	@( for container in $(containers); do \
+	    grep $$container /proc/self/mountinfo | while read -r mountpoint; do \
+		umount $$(echo $$mountpoint | awk '{print $$5}'); \
+	    done; \
+	    find /sys/fs/cgroup -name $$container -print0 | xargs -r -0 rmdir; \
+	done )
+	@rm -rf /run/containerd/runc/*
+	@rm -rf /run/containerd/fifo/*
+	@rm -rf /run/containerd-test/*
+
 install: ## install binaries
 	@echo "$(WHALE) $@ $(BINARIES)"
 	@mkdir -p $(DESTDIR)/bin


### PR DESCRIPTION
When tests fail they could leave debris behind such as
- overlay mounts
- cgroups
- metadata
These debris can cause subsequent tests to fail

Co-authored-by: Danail Branekov <danailster@gmail.com>
Signed-off-by: Georgi Sabev <georgethebeatle@gmail.com>