### PR TITLE
Write stack dump to `os.TempDir()` as well 

### DIFF
--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -291,4 +291,14 @@ func dumpStacks() {
 	}
 	buf = buf[:stackSize]
 	logrus.Infof("=== BEGIN goroutine stack dump ===\n%s\n=== END goroutine stack dump ===", buf)
+
+	// Also write to file to aid gathering diagnostics
+	name := filepath.Join(os.TempDir(), fmt.Sprintf("containerd.%d.stacks.log", os.Getpid()))
+	f, err := os.Create(name)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	f.WriteString(string(buf))
+	logrus.Infof("goroutine stack dump written to %s", name)
 }


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

As it says in the title. @jterry75 PTAL.