### PR TITLE
Handle error for writeTimestampFile in content store.

### DIFF
--- a/content/local/store.go
+++ b/content/local/store.go
@@ -546,11 +546,11 @@ func (s *store) writer(ctx context.Context, ref string, total int64, expected di
 			return nil, err
 		}
 
-		if writeTimestampFile(filepath.Join(path, "startedat"), startedAt); err != nil {
+		if err := writeTimestampFile(filepath.Join(path, "startedat"), startedAt); err != nil {
 			return nil, err
 		}
 
-		if writeTimestampFile(filepath.Join(path, "updatedat"), startedAt); err != nil {
+		if err := writeTimestampFile(filepath.Join(path, "updatedat"), startedAt); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
Originated in https://github.com/containerd/containerd/commit/3e5e2ecc0a8c2bf6e89f6d4126bea813a6667d31#diff-452faa7a06dc2eab47d545a40a832b72 - either the error needs to be correctly ignored or consumed. Right now it's only checking `nil != nil`.

Signed-off-by: Eric Hotinger <ehotinger@gmail.com>