### PR TITLE
Add support for required plugins.

### DIFF
--- a/cmd/containerd/command/config_linux.go
+++ b/cmd/containerd/command/config_linux.go
@@ -30,5 +30,7 @@ func defaultConfig() *srvconfig.Config {
 			MaxRecvMsgSize: defaults.DefaultMaxRecvMsgSize,
 			MaxSendMsgSize: defaults.DefaultMaxSendMsgSize,
 		},
+		DisabledPlugins: []string{},
+		RequiredPlugins: []string{},
 	}
 }

--- a/cmd/containerd/command/config_unsupported.go
+++ b/cmd/containerd/command/config_unsupported.go
@@ -34,5 +34,7 @@ func defaultConfig() *srvconfig.Config {
 			Level:   "info",
 			Address: defaults.DefaultDebugAddress,
 		},
+		DisabledPlugins: []string{},
+		RequiredPlugins: []string{},
 	}
 }

--- a/cmd/containerd/command/config_windows.go
+++ b/cmd/containerd/command/config_windows.go
@@ -30,5 +30,7 @@ func defaultConfig() *srvconfig.Config {
 			MaxRecvMsgSize: defaults.DefaultMaxRecvMsgSize,
 			MaxSendMsgSize: defaults.DefaultMaxSendMsgSize,
 		},
+		DisabledPlugins: []string{},
+		RequiredPlugins: []string{},
 	}
 }

--- a/services/server/config/config.go
+++ b/services/server/config/config.go
@@ -39,6 +39,9 @@ type Config struct {
 	// DisabledPlugins are IDs of plugins to disable. Disabled plugins won't be
 	// initialized and started.
 	DisabledPlugins []string `toml:"disabled_plugins"`
+	// RequiredPlugins are IDs of required plugins. Containerd exits if any
+	// required plugin doesn't exist or fails to be initialized or started.
+	RequiredPlugins []string `toml:"required_plugins"`
 	// Plugins provides plugin specific configuration for the initialization of a plugin
 	Plugins map[string]toml.Primitive `toml:"plugins"`
 	// OOMScore adjust the containerd's oom score

--- a/services/server/server.go
+++ b/services/server/server.go
@@ -100,7 +100,11 @@ func New(ctx context.Context, config *srvconfig.Config) (*Server, error) {
 			config: config,
 		}
 		initialized = plugin.NewPluginSet()
+		required    = make(map[string]struct{})
 	)
+	for _, r := range config.RequiredPlugins {
+		required[r] = struct{}{}
+	}
 	for _, p := range plugins {
 		id := p.URI()
 		log.G(ctx).WithField("type", p.Type).Infof("loading plugin %q...", id)
@@ -135,14 +139,26 @@ func New(ctx context.Context, config *srvconfig.Config) (*Server, error) {
 			} else {
 				log.G(ctx).WithError(err).Warnf("failed to load plugin %s", id)
 			}
+			if _, ok := required[p.ID]; ok {
+				return nil, errors.Wrapf(err, "load required plugin %s", id)
+			}
 			continue
 		}
+		delete(required, p.ID)
 		// check for grpc services that should be registered with the server
 		if service, ok := instance.(plugin.Service); ok {
 			services = append(services, service)
 		}
 		s.plugins = append(s.plugins, result)
 	}
+	if len(required) != 0 {
+		var missing []string
+		for id := range required {
+			missing = append(missing, id)
+		}
+		return nil, errors.Errorf("required plugin %s not included", missing)
+	}
+
 	// register services after all plugins have been initialized
 	for _, service := range services {
 		if err := service.Register(rpc); err != nil {


### PR DESCRIPTION
By default, containerd keeps running when a plugin fails to be initialized. However, some users may require some plugins for their use case, e.g. the `cri` plugin is critical for Kubernetes users.

This is even worse when we add more and more config validations in the CRI plugin, e.g. https://github.com/containerd/cri/pull/1125. If a bad CRI config is given, containerd will continue running without the CRI plugin, which makes it very hard to figure out what is wrong.

This PR added the `required_plugins` config. If a required plugin is missing or fails to be loaded/started, containerd will exit directly.

Signed-off-by: Lantao Liu <lantaol@google.com>