### PR TITLE
Use $TEST_RUNTIME for cri test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,14 +74,21 @@ script:
   - if [ "$GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH make integration ; fi
   # Run the integration suite a second time. See discussion in github.com/containerd/containerd/pull/1759
   - if [ "$GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH TESTFLAGS_PARALLEL=1 make integration ; fi
-  - if [ "$GOOS" = "linux" ]; then
+  - |
+    if [ "$GOOS" = "linux" ]; then
+      sudo mkdir -p /etc/containerd
+      sudo bash -c "cat > /etc/containerd/config.toml <<EOF
+      [plugins.cri.containerd.default_runtime]
+        runtime_type = \"${TEST_RUNTIME}\"
+    EOF"
       sudo PATH=$PATH containerd -log-level debug &> /tmp/containerd-cri.log &
-      sudo ctr version ;
-      sudo PATH=$PATH GOPATH=$GOPATH critest --runtime-endpoint=/var/run/containerd/containerd.sock --parallel=8 ;
-      TEST_RC=$? ;
-      test $TEST_RC -ne 0 && cat /tmp/containerd-cri.log ;
-      sudo pkill containerd ;
-      test $TEST_RC -eq 0 || /bin/false ;
+      sudo ctr version
+      sudo PATH=$PATH GOPATH=$GOPATH critest --runtime-endpoint=/var/run/containerd/containerd.sock --parallel=8
+      TEST_RC=$?
+      test $TEST_RC -ne 0 && cat /tmp/containerd-cri.log
+      sudo pkill containerd
+      sudo rm -rf /etc/containerd
+      test $TEST_RC -eq 0 || /bin/false
     fi
 
 after_success:


### PR DESCRIPTION
We should be testing runc.v1 and runc.v2 with cri test as well.

This can help us catch regressions like https://github.com/containerd/containerd/issues/3203.

Signed-off-by: Lantao Liu <lantaol@google.com>