### PR TITLE
Cleanup dead v2 shim.

### DIFF
--- a/runtime/v2/shim.go
+++ b/runtime/v2/shim.go
@@ -24,18 +24,21 @@ import (
 	"path/filepath"
 	"time"
 
+	eventstypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/api/types"
 	tasktypes "github.com/containerd/containerd/api/types/task"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/events/exchange"
 	"github.com/containerd/containerd/identifiers"
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/runtime"
 	client "github.com/containerd/containerd/runtime/v2/shim"
 	"github.com/containerd/containerd/runtime/v2/task"
 	"github.com/containerd/ttrpc"
 	ptypes "github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 func loadAddress(path string) (string, error) {
@@ -46,7 +49,7 @@ func loadAddress(path string) (string, error) {
 	return string(data), nil
 }
 
-func loadShim(ctx context.Context, bundle *Bundle, events *exchange.Exchange, rt *runtime.TaskList) (_ *shim, err error) {
+func loadShim(ctx context.Context, bundle *Bundle, events *exchange.Exchange, rt *runtime.TaskList, onClose func()) (_ *shim, err error) {
 	address, err := loadAddress(filepath.Join(bundle.Path, "address"))
 	if err != nil {
 		return nil, err
@@ -55,6 +58,11 @@ func loadShim(ctx context.Context, bundle *Bundle, events *exchange.Exchange, rt
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if err != nil {
+			conn.Close()
+		}
+	}()
 	f, err := openShimLog(ctx, bundle)
 	if err != nil {
 		return nil, errors.Wrap(err, "open shim log pipe")
@@ -74,7 +82,12 @@ func loadShim(ctx context.Context, bundle *Bundle, events *exchange.Exchange, rt
 		}
 	}()
 
-	client := ttrpc.NewClient(conn, ttrpc.WithOnClose(func() { _ = conn.Close() }))
+	client := ttrpc.NewClient(conn, ttrpc.WithOnClose(onClose))
+	defer func() {
+		if err != nil {
+			client.Close()
+		}
+	}()
 	s := &shim{
 		client:  client,
 		task:    task.NewTaskClient(client),
@@ -86,6 +99,52 @@ func loadShim(ctx context.Context, bundle *Bundle, events *exchange.Exchange, rt
 		return nil, err
 	}
 	return s, nil
+}
+
+func cleanupAfterDeadShim(ctx context.Context, id, ns string, events *exchange.Exchange, binaryCall *binary) {
+	ctx = namespaces.WithNamespace(ctx, ns)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	log.G(ctx).WithFields(logrus.Fields{
+		"id":        id,
+		"namespace": ns,
+	}).Warn("cleaning up after shim disconnected")
+	response, err := binaryCall.Delete(ctx)
+	if err != nil {
+		log.G(ctx).WithError(err).WithFields(logrus.Fields{
+			"id":        id,
+			"namespace": ns,
+		}).Warn("failed to clean up after shim disconnected")
+	}
+
+	var (
+		pid        uint32
+		exitStatus uint32
+		exitedAt   time.Time
+	)
+	if response != nil {
+		pid = response.Pid
+		exitStatus = response.Status
+		exitedAt = response.Timestamp
+	} else {
+		exitStatus = 255
+		exitedAt = time.Now()
+	}
+	events.Publish(ctx, runtime.TaskExitEventTopic, &eventstypes.TaskExit{
+		ContainerID: id,
+		ID:          id,
+		Pid:         pid,
+		ExitStatus:  exitStatus,
+		ExitedAt:    exitedAt,
+	})
+
+	events.Publish(ctx, runtime.TaskDeleteEventTopic, &eventstypes.TaskDelete{
+		ContainerID: id,
+		Pid:         pid,
+		ExitStatus:  exitStatus,
+		ExitedAt:    exitedAt,
+	})
 }
 
 type shim struct {
@@ -119,19 +178,9 @@ func (s *shim) Shutdown(ctx context.Context) error {
 }
 
 func (s *shim) waitShutdown(ctx context.Context) error {
-	dead := make(chan struct{})
-	go func() {
-		if err := s.Shutdown(ctx); err != nil {
-			log.G(ctx).WithError(err).Error("shim shutdown error")
-		}
-		close(dead)
-	}()
-	select {
-	case <-time.After(3 * time.Second):
-		return errors.New("failed to shutdown shim in time")
-	case <-dead:
-		return nil
-	}
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	return s.Shutdown(ctx)
 }
 
 // ID of the shim/task
@@ -154,15 +203,15 @@ func (s *shim) Delete(ctx context.Context) (*runtime.Exit, error) {
 	if err != nil {
 		return nil, errdefs.FromGRPC(err)
 	}
-	if err := s.waitShutdown(ctx); err != nil {
-		return nil, err
-	}
-	if err := s.bundle.Delete(); err != nil {
-		return nil, err
-	}
 	// remove self from the runtime task list
 	// this seems dirty but it cleans up the API across runtimes, tasks, and the service
 	s.rtTasks.Delete(ctx, s.ID())
+	if err := s.waitShutdown(ctx); err != nil {
+		log.G(ctx).WithError(err).Error("failed to shutdown shim")
+	}
+	if err := s.bundle.Delete(); err != nil {
+		log.G(ctx).WithError(err).Error("failed to delete bundle")
+	}
 	return &runtime.Exit{
 		Status:    response.ExitStatus,
 		Timestamp: response.ExitedAt,


### PR DESCRIPTION
Fixes https://github.com/containerd/containerd/issues/3199
Depends on https://github.com/containerd/ttrpc/pull/35.

When containerd-shim is killed when containerd is running:
```
INFO[2019-04-11T10:39:37.413880563-07:00] shim disconnected                             id=753143c31aa85fe7f1424f1e13cf1891510d377bbc86b8daa520c72b084051b6
WARN[2019-04-11T10:39:37.414006366-07:00] cleaning up after shim disconnected           id=753143c31aa85fe7f1424f1e13cf1891510d377bbc86b8daa520c72b084051b6 namespace=k8s.io
INFO[2019-04-11T10:39:37.414034377-07:00] cleaning up dead shim                        
WARN[2019-04-11T10:39:37.581877377-07:00] cleanup warnings time="2019-04-11T10:39:37-07:00" level=info msg="starting signal loop" namespace=k8s.io pid=75143 
DEBU[2019-04-11T10:39:37.582387101-07:00] event published                               ns=k8s.io topic=/tasks/exit type=containerd.events.TaskExit
DEBU[2019-04-11T10:39:37.582505707-07:00] event published                               ns=k8s.io topic=/tasks/delete type=containerd.events.TaskDelete
```

When containerd-shim is killed when containerd is down, after containerd restarts:
```
DEBU[2019-04-11T10:40:35.507193010-07:00] loading tasks in namespace                    namespace=k8s.io
WARN[2019-04-11T10:40:35.507404450-07:00] cleaning up after shim disconnected           id=63d6638d17014c040f4a979bfd854fb541deb116e785c7e1332c1c7bd47b783e namespace=k8s.io
INFO[2019-04-11T10:40:35.507420039-07:00] cleaning up dead shim                        
DEBU[2019-04-11T10:40:35.611805828-07:00] garbage collected                             d=4.998416ms
WARN[2019-04-11T10:40:35.676519575-07:00] cleanup warnings time="2019-04-11T10:40:35-07:00" level=info msg="starting signal loop" namespace=k8s.io pid=75740 
DEBU[2019-04-11T10:40:35.677121491-07:00] event published                               ns=k8s.io topic=/tasks/exit type=containerd.events.TaskExit
DEBU[2019-04-11T10:40:35.677203935-07:00] event published                               ns=k8s.io topic=/tasks/delete type=containerd.events.TaskDelete
```

I'll add integration test in the CRI plugin for the above 2 cases. Not sure whether we want these kind of tests in the containerd integration test, given that we may need to `pgrep containerd-shim` and `pkill containerd-shim`.

Signed-off-by: Lantao Liu <lantaol@google.com>