### PR TITLE
Allow reuse client for external GRPC services

### DIFF
--- a/client.go
+++ b/client.go
@@ -622,6 +622,13 @@ func (c *Client) VersionService() versionservice.VersionClient {
 	return versionservice.NewVersionClient(c.conn)
 }
 
+// Conn returns the underlying GRPC connection object
+func (c *Client) Conn() *grpc.ClientConn {
+	c.connMu.Lock()
+	defer c.connMu.Unlock()
+	return c.conn
+}
+
 // Version of containerd
 type Version struct {
 	// Version number


### PR DESCRIPTION
In [firecracker-containerd](https://github.com/firecracker-microvm/firecracker-containerd) project we use GRPC plugins to extend containerd's functionality and we have to manage a separate client in order to make calls.
It would be great if we could reuse existing containerd's client (e.g. reuse connection object, namespace handling, reconnect logic, etc) to invoke external grpc services as well.

The proposed solution adds `ExternalService` and looks as follows:
```go
	client, err := containerd.New(...)
	if err != nil {
		panic(err)
	}

	var firecrackerClient proto.FirecrackerClient
	client.ExternalService(func(conn *grpc.ClientConn) {
		firecrackerClient = proto.NewFirecrackerClient(conn)
	})

	firecrackerClient.XXX();
```


Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>