### PR TITLE
Rename "content" gRPC plugin to "content-grpc"

### DIFF
--- a/services/content/service.go
+++ b/services/content/service.go
@@ -27,7 +27,7 @@ import (
 func init() {
 	plugin.Register(&plugin.Registration{
 		Type: plugin.GRPCPlugin,
-		ID:   "content",
+		ID:   "content-grpc",
 		Requires: []plugin.Type{
 			plugin.ServicePlugin,
 		},


### PR DESCRIPTION
Fixes part of the issue described in #3210.

The ability to disable plugins introduced in #2105 assumes there is
only one plugin with a given ID (it break's from ranging over registered
plugins after finding an ID match). However, nothing about plugin
registration enforces uniqueness of the ID. Until that is changed,
it is useful to distinguish between the GRPCPlugin and ContentPlugin
which are both named "content".

Signed-off-by: Jared Cordasco <jcordasc@coglib.com>