### PR TITLE
Correct import path and PusherFunc signature

### DIFF
--- a/remotes/resolver.go
+++ b/remotes/resolver.go
@@ -72,9 +72,9 @@ func (fn FetcherFunc) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.Re
 
 // PusherFunc allows package users to implement a Pusher with just a
 // function.
-type PusherFunc func(ctx context.Context, desc ocispec.Descriptor, r io.Reader) error
+type PusherFunc func(ctx context.Context, desc ocispec.Descriptor) (content.Writer, error)
 
 // Push content
-func (fn PusherFunc) Push(ctx context.Context, desc ocispec.Descriptor, r io.Reader) error {
-	return fn(ctx, desc, r)
+func (fn PusherFunc) Push(ctx context.Context, desc ocispec.Descriptor) (content.Writer, error) {
+	return fn(ctx, desc)
 }

--- a/services/server/server_solaris.go
+++ b/services/server/server_solaris.go
@@ -19,7 +19,7 @@ package server
 import (
 	"context"
 
-	srvconfig "github.com/containerd/containerd/server/config"
+	srvconfig "github.com/containerd/containerd/services/server/config"
 )
 
 func apply(_ context.Context, _ *srvconfig.Config) error {


### PR DESCRIPTION
Fixes #3212.

This PR corrects an import statement in `services/server/server_solaris.go` and updates the `PusherFunc` type's function signature in the `containerd/remotes` package to match the `Pusher` interface.