### PR TITLE
go vet: v1/linux/proc unused cancel function

### DIFF
--- a/runtime/v1/linux/proc/io.go
+++ b/runtime/v1/linux/proc/io.go
@@ -264,6 +264,7 @@ func newBinaryIO(ctx context.Context, id string, uri *url.URL) (runc.IO, error) 
 		}
 	}
 	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	cmd := exec.CommandContext(ctx, uri.Host, args...)
 	cmd.Env = append(cmd.Env,
 		"CONTAINER_ID="+id,


### PR DESCRIPTION
this was added in https://github.com/containerd/containerd/pull/3085

```
go vet ./...

runtime/v1/linux/proc/io.go:266:2: the cancel function is not used on all paths (possible context leak)
runtime/v1/linux/proc/io.go:274:3: this return statement may be reached without using the cancel var defined on line 266
```
