### PR TITLE
[release/1.2 backport] Correct import path and PusherFunc signature

### DIFF
--- a/remotes/resolver.go
+++ b/remotes/resolver.go
@@ -72,9 +72,9 @@ func (fn FetcherFunc) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.Re
 
 // PusherFunc allows package users to implement a Pusher with just a
 // function.
-type PusherFunc func(ctx context.Context, desc ocispec.Descriptor, r io.Reader) error
+type PusherFunc func(ctx context.Context, desc ocispec.Descriptor) (content.Writer, error)
 
 // Push content
-func (fn PusherFunc) Push(ctx context.Context, desc ocispec.Descriptor, r io.Reader) error {
-	return fn(ctx, desc, r)
+func (fn PusherFunc) Push(ctx context.Context, desc ocispec.Descriptor) (content.Writer, error) {
+	return fn(ctx, desc)
 }

--- a/services/server/server_solaris.go
+++ b/services/server/server_solaris.go
@@ -19,7 +19,7 @@ package server
 import (
 	"context"
 
-	srvconfig "github.com/containerd/containerd/server/config"
+	srvconfig "github.com/containerd/containerd/services/server/config"
 )
 
 func apply(_ context.Context, _ *srvconfig.Config) error {


### PR DESCRIPTION
This backports #3213 to fix an import path (in `services/server/server_solaris.go`) and `PusherFunc` signature.

Signed-off-by: Jared Cordasco <jcordasc@coglib.com>