### PR TITLE
.maimap: update Akihiro Suda's email address

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,6 +1,7 @@
 Abhinandan Prativadi <abhi@docker.com> Abhinandan Prativadi <aprativadi@gmail.com>
 Abhinandan Prativadi <abhi@docker.com> abhi <abhi@docker.com>
-Akihiro Suda <suda.akihiro@lab.ntt.co.jp> Akihiro Suda <suda.kyoto@gmail.com>
+Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp> Akihiro Suda <suda.kyoto@gmail.com>
+Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp> Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
 Andrei Vagin <avagin@virtuozzo.com> Andrei Vagin <avagin@openvz.org>
 Brent Baude <bbaude@redhat.com> baude <bbaude@redhat.com>
 Frank Yang <yyb196@gmail.com> frank yang <yyb196@gmail.com>


### PR DESCRIPTION
No affiliation change (NTT).

The former email address will continue to be available for the time being.

For daily communication, I still prefer to use my gmail.com address.

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>