### PR TITLE
Update to sha-specific nanoserver image reference to fix AppVeyor CI runs

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -129,10 +129,11 @@ func TestMain(m *testing.M) {
 	}).Info("running tests against containerd")
 
 	// pull a seed image
+	log.G(ctx).Info("start to pull seed image")
 	if _, err = client.Pull(ctx, testImage, WithPullUnpack); err != nil {
-		ctrd.Stop()
-		ctrd.Wait()
 		fmt.Fprintf(os.Stderr, "%s: %s\n", err, buf.String())
+		ctrd.Kill()
+		ctrd.Wait()
 		os.Exit(1)
 	}
 

--- a/client_windows_test.go
+++ b/client_windows_test.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	defaultAddress = `\\.\pipe\containerd-containerd-test`
-	testImage      = "docker.io/microsoft/nanoserver:latest"
+	testImage      = "docker.io/microsoft/nanoserver@sha256:8f78a4a7da4464973a5cd239732626141aec97e69ba3e4023357628630bc1ee2"
 )
 
 var (


### PR DESCRIPTION
~~Testing whether there is an actual problem running `make integration` on Windows, or whether AppVeyor is just extremely slow...~~

Updating nanoserver image with available exact tag; fix from @fuweid to not have CI hang in the future when this (or another image pull transient failure) happens.

Fixes: #3227

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>