### PR TITLE
Bump syndtr/gocapability d983527, containerd/console

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -38,7 +38,7 @@ github.com/Microsoft/hcsshim 8abdbb8205e4192c68b5f84c31197156f31be517
 google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
 golang.org/x/text 19e51611da83d6be54ddafce4a4af510cb3e9ea4
 github.com/containerd/ttrpc f02858b1457c5ca3aaec3a0803eb0d59f96e41d6
-github.com/syndtr/gocapability db04d3cc01c8b54962a58ec7e491717d06cfcc16
+github.com/syndtr/gocapability d98352740cb2c55f81556b63d4a1ec64c5a319c2
 gotest.tools v2.3.0
 github.com/google/go-cmp v0.2.0
 go.etcd.io/bbolt v1.3.2

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,5 +1,5 @@
 github.com/containerd/go-runc 5a6d9f37cfa36b15efba46dc7ea349fa9b7143c3
-github.com/containerd/console c12b1e7919c14469339a5d38f2f8ed9b64a9de23
+github.com/containerd/console 0650fd9eeb50bab4fc99dceb9f2e14cf58f36e7f
 github.com/containerd/cgroups 4994991857f9b0ae8dc439551e8bebdbb4bf66c1
 github.com/containerd/typeurl a93fcdb778cd272c6e9b3028b2f42d813e785d40
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c

--- a/vendor/github.com/containerd/console/LICENSE
+++ b/vendor/github.com/containerd/console/LICENSE
@@ -1,6 +1,7 @@
+
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -175,24 +176,13 @@
 
    END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
+   Copyright The containerd Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/vendor/github.com/containerd/console/README.md
+++ b/vendor/github.com/containerd/console/README.md
@@ -15,3 +15,13 @@ if err := current.SetRaw(); err != nil {
 ws, err := current.Size()
 current.Resize(ws)
 ```
+
+## Project details
+
+console is a containerd sub-project, licensed under the [Apache 2.0 license](./LICENSE).
+As a containerd sub-project, you will find the:
+ * [Project governance](https://github.com/containerd/project/blob/master/GOVERNANCE.md),
+ * [Maintainers](https://github.com/containerd/project/blob/master/MAINTAINERS),
+ * and [Contributing guidelines](https://github.com/containerd/project/blob/master/CONTRIBUTING.md)
+
+information in our [`containerd/project`](https://github.com/containerd/project) repository.

--- a/vendor/github.com/syndtr/gocapability/capability/capability.go
+++ b/vendor/github.com/syndtr/gocapability/capability/capability.go
@@ -60,13 +60,74 @@ type Capabilities interface {
 	Apply(kind CapType) error
 }
 
-// NewPid create new initialized Capabilities object for given pid when it
-// is nonzero, or for the current pid if pid is 0
+// NewPid initializes a new Capabilities object for given pid when
+// it is nonzero, or for the current process if pid is 0.
+//
+// Deprecated: Replace with NewPid2.  For example, replace:
+//
+//    c, err := NewPid(0)
+//    if err != nil {
+//      return err
+//    }
+//
+// with:
+//
+//    c, err := NewPid2(0)
+//    if err != nil {
+//      return err
+//    }
+//    err = c.Load()
+//    if err != nil {
+//      return err
+//    }
 func NewPid(pid int) (Capabilities, error) {
+	c, err := newPid(pid)
+	if err != nil {
+		return c, err
+	}
+	err = c.Load()
+	return c, err
+}
+
+// NewPid2 initializes a new Capabilities object for given pid when
+// it is nonzero, or for the current process if pid is 0.  This
+// does not load the process's current capabilities; to do that you
+// must call Load explicitly.
+func NewPid2(pid int) (Capabilities, error) {
 	return newPid(pid)
 }
 
-// NewFile create new initialized Capabilities object for given named file.
-func NewFile(name string) (Capabilities, error) {
-	return newFile(name)
+// NewFile initializes a new Capabilities object for given file path.
+//
+// Deprecated: Replace with NewFile2.  For example, replace:
+//
+//    c, err := NewFile(path)
+//    if err != nil {
+//      return err
+//    }
+//
+// with:
+//
+//    c, err := NewFile2(path)
+//    if err != nil {
+//      return err
+//    }
+//    err = c.Load()
+//    if err != nil {
+//      return err
+//    }
+func NewFile(path string) (Capabilities, error) {
+	c, err := newFile(path)
+	if err != nil {
+		return c, err
+	}
+	err = c.Load()
+	return c, err
+}
+
+// NewFile2 creates a new initialized Capabilities object for given
+// file path.  This does not load the process's current capabilities;
+// to do that you must call Load explicitly.
+func NewFile2(path string) (Capabilities, error) {
+	return newFile(path)
 }

--- a/vendor/github.com/syndtr/gocapability/capability/capability_linux.go
+++ b/vendor/github.com/syndtr/gocapability/capability/capability_linux.go
@@ -103,20 +103,16 @@ func newPid(pid int) (c Capabilities, err error) {
 	case linuxCapVer1:
 		p := new(capsV1)
 		p.hdr.version = capVers
-		p.hdr.pid = pid
+		p.hdr.pid = int32(pid)
 		c = p
 	case linuxCapVer2, linuxCapVer3:
 		p := new(capsV3)
 		p.hdr.version = capVers
-		p.hdr.pid = pid
+		p.hdr.pid = int32(pid)
 		c = p
 	default:
 		err = errUnknownVers
 		return
-	}
-	err = c.Load()
-	if err != nil {
-		c = nil
 	}
 	return
 }
@@ -492,10 +488,6 @@ func (c *capsV3) Apply(kind CapType) (err error) {
 
 func newFile(path string) (c Capabilities, err error) {
 	c = &capsFile{path: path}
-	err = c.Load()
-	if err != nil {
-		c = nil
-	}
 	return
 }
 

--- a/vendor/github.com/syndtr/gocapability/capability/syscall_linux.go
+++ b/vendor/github.com/syndtr/gocapability/capability/syscall_linux.go
@@ -13,7 +13,7 @@ import (
 
 type capHeader struct {
 	version uint32
-	pid     int
+	pid     int32
 }
 
 type capData struct {


### PR DESCRIPTION
full diff: https://github.com/syndtr/gocapability/compare/db04d3cc01c8b54962a58ec7e491717d06cfcc16...d98352740cb2c55f81556b63d4a1ec64c5a319c2

changes included:

  - syndtr/gocapability#14 capability: Deprecate NewPid and NewFile for NewPid2 and NewFile2
  - syndtr/gocapability#16 Fix capHeader.pid type

Also bumped containerd/console just to keep up, but no local changes were introduced