### PR TITLE
appveyor: make CI happy 

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -129,10 +129,11 @@ func TestMain(m *testing.M) {
 	}).Info("running tests against containerd")
 
 	// pull a seed image
+	log.G(ctx).Info("start to pull seed image")
 	if _, err = client.Pull(ctx, testImage, WithPullUnpack); err != nil {
-		ctrd.Stop()
-		ctrd.Wait()
 		fmt.Fprintf(os.Stderr, "%s: %s\n", err, buf.String())
+		ctrd.Kill()
+		ctrd.Wait()
 		os.Exit(1)
 	}
 

--- a/client_windows_test.go
+++ b/client_windows_test.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	defaultAddress = `\\.\pipe\containerd-containerd-test`
-	testImage      = "docker.io/microsoft/nanoserver:latest"
+	testImage      = "mcr.microsoft.com/windows/nanoserver:1709"
 )
 
 var (


### PR DESCRIPTION
`microsoft/nanoserver:latest` is not found. We need to use existing tag
which doen't change frequently.

Fix: #3227

Signed-off-by: Wei Fu <fuweid89@gmail.com>