### PR TITLE
Don't write dumped stacks to file for ETW capture state

### DIFF
--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -278,7 +278,7 @@ func setLevel(context *cli.Context, config *srvconfig.Config) error {
 	return nil
 }
 
-func dumpStacks() {
+func dumpStacks(writeToFile bool) {
 	var (
 		buf       []byte
 		stackSize int
@@ -292,13 +292,15 @@ func dumpStacks() {
 	buf = buf[:stackSize]
 	logrus.Infof("=== BEGIN goroutine stack dump ===\n%s\n=== END goroutine stack dump ===", buf)
 
-	// Also write to file to aid gathering diagnostics
-	name := filepath.Join(os.TempDir(), fmt.Sprintf("containerd.%d.stacks.log", os.Getpid()))
-	f, err := os.Create(name)
-	if err != nil {
-		return
+	if writeToFile {
+		// Also write to file to aid gathering diagnostics
+		name := filepath.Join(os.TempDir(), fmt.Sprintf("containerd.%d.stacks.log", os.Getpid()))
+		f, err := os.Create(name)
+		if err != nil {
+			return
+		}
+		defer f.Close()
+		f.WriteString(string(buf))
+		logrus.Infof("goroutine stack dump written to %s", name)
 	}
-	defer f.Close()
-	f.WriteString(string(buf))
-	logrus.Infof("goroutine stack dump written to %s", name)
 }

--- a/cmd/containerd/command/main_unix.go
+++ b/cmd/containerd/command/main_unix.go
@@ -48,7 +48,7 @@ func handleSignals(ctx context.Context, signals chan os.Signal, serverC chan *se
 				log.G(ctx).WithField("signal", s).Debug("received signal")
 				switch s {
 				case unix.SIGUSR1:
-					dumpStacks()
+					dumpStacks(true)
 				case unix.SIGPIPE:
 					continue
 				default:

--- a/cmd/containerd/command/main_windows.go
+++ b/cmd/containerd/command/main_windows.go
@@ -88,14 +88,14 @@ func setupDumpStacks() {
 		logrus.Debugf("Stackdump - waiting signal at %s", event)
 		for {
 			windows.WaitForSingleObject(h, windows.INFINITE)
-			dumpStacks()
+			dumpStacks(true)
 		}
 	}()
 }
 
 func etwCallback(sourceID *guid.GUID, state etw.ProviderState, level etw.Level, matchAnyKeyword uint64, matchAllKeyword uint64, filterData uintptr) {
 	if state == etw.ProviderStateCaptureState {
-		dumpStacks()
+		dumpStacks(false)
 	}
 }
 


### PR DESCRIPTION
ETW provides its own retention mechanism, so don't need to write out dumped stacks to file when its triggered by ETW.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>