### PR TITLE
[release/1.2] cherry-pick: Convert Windows CI to use Microsoft MCR image urls

### DIFF
--- a/client_windows_test.go
+++ b/client_windows_test.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	defaultAddress = `\\.\pipe\containerd-containerd-test`
-	testImage      = "docker.io/microsoft/nanoserver@sha256:8f78a4a7da4464973a5cd239732626141aec97e69ba3e4023357628630bc1ee2"
+	testImage      = "mcr.microsoft.com/windows/nanoserver:sac2016"
 )
 
 var (


### PR DESCRIPTION
Cherrypick #3230 commit (e6fc0ed22d3f670597c9a363810d5e1dbd7f192e)

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>
Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>