### PR TITLE
Support disabling default setup of shim logger.

### DIFF
--- a/runtime/v2/shim/shim.go
+++ b/runtime/v2/shim/shim.go
@@ -78,6 +78,8 @@ type Config struct {
 	NoSubreaper bool
 	// NoReaper disables the shim binary from reaping any child process implicitly
 	NoReaper bool
+	// NoSetupLogger disables automatic configuration of logrus to use the shim FIFO
+	NoSetupLogger bool
 }
 
 var (
@@ -206,8 +208,10 @@ func run(id string, initFunc Init, config Config) error {
 		}
 		return nil
 	default:
-		if err := setLogger(ctx, idFlag); err != nil {
-			return err
+		if !config.NoSetupLogger {
+			if err := setLogger(ctx, idFlag); err != nil {
+				return err
+			}
 		}
 		client := NewShimClient(ctx, service, signals)
 		if err := client.Serve(); err != nil {


### PR DESCRIPTION
Before this change, the v2 runtime shim setup code was hardcoded to always
configure logrus to write logs to the "log" FIFO present in the current working
directory. This only happens in the "default" action codepath
(i.e. not shim start or shim delete).

This is problematic for shims that execute outside the current working
directory of a bundle. For example, it often doesn't make sense for shims that
manage multiple containers to execute in a single bundle directory. Additionally,
shim processes that require being pre-created, i.e. spun up before tasks they
will handle are actually created, won't have a log FIFO to write to until a task
is created.

This change leaves the default behavior as is but introduces a Binary Config
field that will optionally disable automatic configuration of logrus to use the
"log" FIFO. This allows shims to configure their own logger if necessary while
still re-using the rest of the shim helper code in containerd.

Signed-off-by: Erik Sipsma <sipsma@amazon.com>