### PR TITLE
Bump runc 1.0.0-rc8, opencontainers/selinux v1.2.2

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -20,7 +20,7 @@ github.com/gogo/protobuf v1.2.1
 github.com/gogo/googleapis v1.2.0
 github.com/golang/protobuf v1.2.0
 github.com/opencontainers/runtime-spec 29686dbc5559d93fb1ef402eeda3e35c38d75af4 # v1.0.1-59-g29686db
-github.com/opencontainers/runc 029124da7af7360afa781a0234d1b083550f797c
+github.com/opencontainers/runc v1.0.0-rc8
 github.com/konsorten/go-windows-terminal-sequences v1.0.1
 github.com/sirupsen/logrus v1.4.1
 github.com/urfave/cli 7bc6a0acffa589f415f88aca16cc1de5ffd66f9c

--- a/vendor.conf
+++ b/vendor.conf
@@ -59,7 +59,7 @@ github.com/hashicorp/go-multierror ed905158d87462226a13fe39ddf685ea65f1c11f
 github.com/json-iterator/go 1.1.5
 github.com/modern-go/reflect2 1.0.1
 github.com/modern-go/concurrent 1.0.3
-github.com/opencontainers/selinux v1.2.1
+github.com/opencontainers/selinux v1.2.2
 github.com/seccomp/libseccomp-golang 32f571b70023028bd57d9288c20efbcb237f3ce0
 github.com/tchap/go-patricia v2.2.6
 golang.org/x/crypto 88737f569e3a9c7ab309cdc09a07fe7fc87233c3

--- a/vendor/github.com/opencontainers/runc/vendor.conf
+++ b/vendor/github.com/opencontainers/runc/vendor.conf
@@ -5,7 +5,7 @@ github.com/opencontainers/runtime-spec 29686dbc5559d93fb1ef402eeda3e35c38d75af4
 # Core libcontainer functionality.
 github.com/checkpoint-restore/go-criu v3.11
 github.com/mrunalp/fileutils ed869b029674c0e9ce4c0dfa781405c2d9946d08
-github.com/opencontainers/selinux v1.2.1
+github.com/opencontainers/selinux v1.2.2
 github.com/seccomp/libseccomp-golang 84e90a91acea0f4e51e62bc1a75de18b1fc0790f
 github.com/sirupsen/logrus a3f95b5c423586578a4e099b11a46c2479628cac
 github.com/syndtr/gocapability db04d3cc01c8b54962a58ec7e491717d06cfcc16

--- a/vendor/github.com/opencontainers/selinux/go-selinux/selinux_linux.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/selinux_linux.go
@@ -406,7 +406,14 @@ func SocketLabel() (string, error) {
 // SetKeyLabel takes a process label and tells the kernel to assign the
 // label to the next kernel keyring that gets created
 func SetKeyLabel(label string) error {
-	return writeCon("/proc/self/attr/keycreate", label)
+	err := writeCon("/proc/self/attr/keycreate", label)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if label == "" && os.IsPermission(err) && !GetEnabled() {
+		return nil
+	}
+	return err
 }
 
 // KeyLabel retrieves the current kernel keyring label setting


### PR DESCRIPTION
~runc v1.0.0-rc8 wasn't tagged yet, but took the commit of the version bump~


- runc diff: https://github.com/opencontainers/runc/compare/029124da7af7360afa781a0234d1b083550f797c...425e105d5a03fabd737a126ad93d62a9eeede87f
  - opencontainers/runc#2043 Vendor in latest selinux code for keycreate errors
- selinux diff: https://github.com/opencontainers/selinux/compare/v1.2.1...v1.2.2
  - opencontainers/selinux#51 Older kernels do not support keyring labeling