### PR TITLE
differ: fix deadlock on commit error

### DIFF
--- a/content/local/writer.go
+++ b/content/local/writer.go
@@ -74,6 +74,9 @@ func (w *writer) Write(p []byte) (n int, err error) {
 }
 
 func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest, opts ...content.Opt) error {
+	// Ensure even on error the writer is fully closed
+	defer unlock(w.ref)
+
 	var base content.Info
 	for _, opt := range opts {
 		if err := opt(&base); err != nil {
@@ -81,8 +84,6 @@ func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest,
 		}
 	}
 
-	// Ensure even on error the writer is fully closed
-	defer unlock(w.ref)
 	fp := w.fp
 	w.fp = nil
 

--- a/diff/walking/differ.go
+++ b/diff/walking/differ.go
@@ -106,14 +106,15 @@ func (s *walkingDiff) Compare(ctx context.Context, lower, upper []mount.Mount, o
 				}
 			}()
 			if !newReference {
-				if err := cw.Truncate(0); err != nil {
+				if err = cw.Truncate(0); err != nil {
 					return err
 				}
 			}
 
 			if isCompressed {
 				dgstr := digest.SHA256.Digester()
-				compressed, err := compression.CompressStream(cw, compression.Gzip)
+				var compressed io.WriteCloser
+				compressed, err = compression.CompressStream(cw, compression.Gzip)
 				if err != nil {
 					return errors.Wrap(err, "failed to get compressed stream")
 				}


### PR DESCRIPTION
In https://github.com/moby/buildkit/issues/960 differ error is produced that was fixed in https://github.com/containerd/continuity/pull/140 . When this error was reached the writer was not properly released resulting a "locked" message for next invocations. This PR fixes the line involved so the error does not get masked, and two other cases where errors would have also been swallowed previously.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>