### PR TITLE
Add OpenLab CI configuration for ARM64 build

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,0 +1,14 @@
+- project:
+    name: containerd/containerd
+    check:
+      jobs:
+        - containerd-build-arm64
+
+- job:
+    name: containerd-build-arm64
+    parent: init-test
+    description: |
+      Containerd build in openlab cluster.
+    run: .zuul/playbooks/containerd-build/run.yaml
+    nodeset: ubuntu-xenial-arm64
+    voting: false

--- a/.zuul/playbooks/containerd-build/run.yaml
+++ b/.zuul/playbooks/containerd-build/run.yaml
@@ -1,0 +1,20 @@
+- hosts: all
+  become: yes
+  roles:
+    - role: config-golang
+      arch: arm64
+  tasks:
+    - name: Build containerd
+      shell:
+        cmd: |
+          set -xe
+          apt-get update
+          apt-get install -y btrfs-tools libseccomp-dev git pkg-config
+
+          make | tee $LOGS_PATH/make.txt
+          make test | tee $LOGS_PATH/make_test.txt
+
+          cp -r ./bin $RESULTS_PATH
+        chdir: '{{ zuul.project.src_dir }}'
+        executable: /bin/bash
+      environment: '{{ global_env }}'


### PR DESCRIPTION
This patch adds the CI configuration to enable the support for arm build in OpenLab.

After this, each pull request in containerd will trigger the ``containerd-arm64-build`` job which verified the arm build on ARM cluster.

As the first version, we mark this job as non-voting job, that means the build job result is just a reference for developer and would not block the PR to be merged. Once we make sure the job can be executed stable, then we can mark it as normal "voting" job.

Related: https://github.com/containerd/containerd/issues/2901