### PR TITLE
Return NotFound error for kill and delete in deleted state.

### DIFF
--- a/runtime/v1/linux/proc/deleted_state.go
+++ b/runtime/v1/linux/proc/deleted_state.go
@@ -22,6 +22,7 @@ import (
 	"context"
 
 	"github.com/containerd/console"
+	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/runtime/proc"
 	google_protobuf "github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
@@ -55,11 +56,11 @@ func (s *deletedState) Start(ctx context.Context) error {
 }
 
 func (s *deletedState) Delete(ctx context.Context) error {
-	return errors.Errorf("cannot delete a deleted process")
+	return errors.Wrap(errdefs.ErrNotFound, "cannot delete a deleted process")
 }
 
 func (s *deletedState) Kill(ctx context.Context, sig uint32, all bool) error {
-	return errors.Errorf("cannot kill a deleted process")
+	return errors.Wrap(errdefs.ErrNotFound, "cannot kill a deleted process")
 }
 
 func (s *deletedState) SetExited(status int) {

--- a/runtime/v1/linux/task.go
+++ b/runtime/v1/linux/task.go
@@ -87,7 +87,7 @@ func (t *Task) Namespace() string {
 // Delete the task and return the exit status
 func (t *Task) Delete(ctx context.Context) (*runtime.Exit, error) {
 	rsp, err := t.shim.Delete(ctx, empty)
-	if err != nil {
+	if err != nil && !errdefs.IsNotFound(err) {
 		return nil, errdefs.FromGRPC(err)
 	}
 	t.tasks.Delete(ctx, t.id)

--- a/runtime/v2/shim.go
+++ b/runtime/v2/shim.go
@@ -152,7 +152,7 @@ func (s *shim) Delete(ctx context.Context) (*runtime.Exit, error) {
 	response, err := s.task.Delete(ctx, &task.DeleteRequest{
 		ID: s.ID(),
 	})
-	if err != nil {
+	if err != nil && errdefs.IsNotFound(err) {
 		return nil, errdefs.FromGRPC(err)
 	}
 	if err := s.waitShutdown(ctx); err != nil {


### PR DESCRIPTION
We've seen this issue in a Kubernetes benchmark test https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-cri-containerd-node-e2e-benchmark/1120454833061498892.

The initial container deletion hit a timeout, and returned at https://github.com/containerd/containerd/blob/v1.2.6/runtime/v1/linux/task.go#L89. I guess because we are stopping >200 containers at the same time:
```
Apr 22 22:50:40 n1-standard-1-cos-stable-60-9592-90-0-81227dd7 containerd[1037]: time="2019-04-22T22:50:40.732760213Z" level=error msg="Failed to handle exit event &TaskExit{ContainerID:fdab5da3258b6cf5488148cb9e4295e0fe5d1a3fe4fb6f64b7091a78c74504d9,ID:fdab5da3258b6cf5488148cb9e4295e0fe5d1a3fe4fb6f64b7091a78c74504d9,Pid:1466,ExitStatus:0,ExitedAt:2019-04-22 22:50:30.720718714 +0000 UTC,XXX_unrecognized:[],} for fdab5da3258b6cf5488148cb9e4295e0fe5d1a3fe4fb6f64b7091a78c74504d9" error="failed to handle container TaskExit event: failed to stop container: context deadline exceeded: unknown"
```

However, the shim actually already deleted the container, thus went into [`deleted state`](https://github.com/containerd/containerd/blob/6b25c1e45c2b8246dba17de3b1d574f6720ce79f/runtime/v1/linux/proc/deleted_state.go).

After this point, all future kill and deletion won't be able to cleanup the container any more:
```
Apr 22 22:50:42 n1-standard-1-cos-stable-60-9592-90-0-81227dd7 containerd[1037]: time="2019-04-22T22:50:42.382318462Z" level=error msg="Failed to handle backOff event &TaskExit{ContainerID:fdab5da3258b6cf5488148cb9e4295e0fe5d1a3fe4fb6f64b7091a78c74504d9,ID:fdab5da3258b6cf5488148cb9e4295e0fe5d1a3fe4fb6f64b7091a78c74504d9,Pid:1466,ExitStatus:0,ExitedAt:2019-04-22 22:50:30.720718714 +0000 UTC,XXX_unrecognized:[],} for fdab5da3258b6cf5488148cb9e4295e0fe5d1a3fe4fb6f64b7091a78c74504d9" error="failed to handle container TaskExit event: failed to stop container: cannot kill a deleted process: unknown"
...
Apr 22 22:50:44 n1-standard-1-cos-stable-60-9592-90-0-81227dd7 containerd[1037]: time="2019-04-22T22:50:44.453285825Z" level=error msg="Failed to handle backOff event &TaskExit{ContainerID:fdab5da3258b6cf5488148cb9e4295e0fe5d1a3fe4fb6f64b7091a78c74504d9,ID:fdab5da3258b6cf5488148cb9e4295e0fe5d1a3fe4fb6f64b7091a78c74504d9,Pid:1466,ExitStatus:0,ExitedAt:2019-04-22 22:50:30.720718714 +0000 UTC,XXX_unrecognized:[],} for fdab5da3258b6cf5488148cb9e4295e0fe5d1a3fe4fb6f64b7091a78c74504d9" error="failed to handle container TaskExit event: failed to stop container: cannot kill a deleted process: unknown"
...
```
Signed-off-by: Lantao Liu <lantaol@google.com>