### PR TITLE
Update vendor/ with new required vndr go.mod files

### DIFF
--- a/vendor/github.com/gogo/googleapis/go.mod
+++ b/vendor/github.com/gogo/googleapis/go.mod
@@ -1,0 +1,5 @@
+module github.com/gogo/googleapis
+
+go 1.12
+
+require github.com/gogo/protobuf v1.2.1

--- a/vendor/github.com/gogo/protobuf/go.mod
+++ b/vendor/github.com/gogo/protobuf/go.mod
@@ -1,0 +1,3 @@
+module github.com/gogo/protobuf
+
+require github.com/kisielk/errcheck v1.1.0 // indirect

--- a/vendor/github.com/google/uuid/go.mod
+++ b/vendor/github.com/google/uuid/go.mod
@@ -1,0 +1,1 @@
+module github.com/google/uuid

--- a/vendor/github.com/konsorten/go-windows-terminal-sequences/go.mod
+++ b/vendor/github.com/konsorten/go-windows-terminal-sequences/go.mod
@@ -1,0 +1,1 @@
+module github.com/konsorten/go-windows-terminal-sequences

--- a/vendor/github.com/sirupsen/logrus/go.mod
+++ b/vendor/github.com/sirupsen/logrus/go.mod
@@ -1,0 +1,10 @@
+module github.com/sirupsen/logrus
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.1.1 // indirect
+	github.com/stretchr/testify v1.2.2
+	golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33
+)

--- a/vendor/golang.org/x/crypto/go.mod
+++ b/vendor/golang.org/x/crypto/go.mod
@@ -1,0 +1,3 @@
+module golang.org/x/crypto
+
+require golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e

--- a/vendor/golang.org/x/sys/go.mod
+++ b/vendor/golang.org/x/sys/go.mod
@@ -1,0 +1,1 @@
+module golang.org/x/sys

--- a/vendor/gopkg.in/yaml.v2/go.mod
+++ b/vendor/gopkg.in/yaml.v2/go.mod
@@ -1,0 +1,5 @@
+module "gopkg.in/yaml.v2"
+
+require (
+	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
+)

--- a/vendor/gotest.tools/go.mod
+++ b/vendor/gotest.tools/go.mod
@@ -1,0 +1,8 @@
+module gotest.tools
+
+require (
+	github.com/google/go-cmp v0.2.0
+	github.com/pkg/errors v0.8.0
+	github.com/spf13/pflag v1.0.3
+	golang.org/x/tools v0.0.0-20180810170437-e96c4e24768d
+)


### PR DESCRIPTION
As @thajeztah in Slack `vndr` recently updated and now creates additional `go.mod` files that need to be included to pass the CI vendor checks.

See https://github.com/LK4D4/vndr/pull/75 for the recently merged change.