### PR TITLE
[release/1.2 backport] Update ttrpc

### DIFF
--- a/runtime/v1/shim/client/client.go
+++ b/runtime/v1/shim/client/client.go
@@ -172,8 +172,7 @@ func WithConnect(address string, onClose func()) Opt {
 		if err != nil {
 			return nil, nil, err
 		}
-		client := ttrpc.NewClient(conn)
-		client.OnClose(onClose)
+		client := ttrpc.NewClient(conn, ttrpc.WithOnClose(onClose))
 		return shimapi.NewShimClient(client), conn, nil
 	}
 }

--- a/runtime/v2/binary.go
+++ b/runtime/v2/binary.go
@@ -97,8 +97,7 @@ func (b *binary) Start(ctx context.Context) (_ *shim, err error) {
 	if err != nil {
 		return nil, err
 	}
-	client := ttrpc.NewClient(conn)
-	client.OnClose(func() { conn.Close() })
+	client := ttrpc.NewClient(conn, ttrpc.WithOnClose(func() { _ = conn.Close() }))
 	return &shim{
 		bundle:  b.bundle,
 		client:  client,

--- a/runtime/v2/shim.go
+++ b/runtime/v2/shim.go
@@ -75,8 +75,7 @@ func loadShim(ctx context.Context, bundle *Bundle, events *exchange.Exchange, rt
 		}
 	}()
 
-	client := ttrpc.NewClient(conn)
-	client.OnClose(func() { conn.Close() })
+	client := ttrpc.NewClient(conn, ttrpc.WithOnClose(func() { _ = conn.Close() }))
 	s := &shim{
 		client:  client,
 		task:    task.NewTaskClient(client),

--- a/vendor.conf
+++ b/vendor.conf
@@ -36,7 +36,7 @@ github.com/Microsoft/go-winio v0.4.11
 github.com/Microsoft/hcsshim v0.8.1
 google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
 golang.org/x/text 19e51611da83d6be54ddafce4a4af510cb3e9ea4
-github.com/containerd/ttrpc 2a805f71863501300ae1976d29f0454ae003e85a
+github.com/containerd/ttrpc f02858b1457c5ca3aaec3a0803eb0d59f96e41d6
 github.com/syndtr/gocapability db04d3cc01c8b54962a58ec7e491717d06cfcc16
 gotest.tools v2.1.0
 github.com/google/go-cmp v0.1.0

--- a/vendor.conf
+++ b/vendor.conf
@@ -36,7 +36,7 @@ github.com/Microsoft/go-winio v0.4.11
 github.com/Microsoft/hcsshim v0.8.1
 google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
 golang.org/x/text 19e51611da83d6be54ddafce4a4af510cb3e9ea4
-github.com/containerd/ttrpc f02858b1457c5ca3aaec3a0803eb0d59f96e41d6
+github.com/containerd/ttrpc 699c4e40d1e7416e08bf7019c7ce2e9beced4636
 github.com/syndtr/gocapability db04d3cc01c8b54962a58ec7e491717d06cfcc16
 gotest.tools v2.1.0
 github.com/google/go-cmp v0.1.0

--- a/vendor/github.com/containerd/ttrpc/README.md
+++ b/vendor/github.com/containerd/ttrpc/README.md
@@ -50,3 +50,13 @@ TODO:
 - [ ] Document protocol layout
 - [ ] Add testing under concurrent load to ensure
 - [ ] Verify connection error handling
+
+# Project details
+
+ttrpc is a containerd sub-project, licensed under the [Apache 2.0 license](./LICENSE).
+As a containerd sub-project, you will find the:
+ * [Project governance](https://github.com/containerd/project/blob/master/GOVERNANCE.md),
+ * [Maintainers](https://github.com/containerd/project/blob/master/MAINTAINERS),
+ * and [Contributing guidelines](https://github.com/containerd/project/blob/master/CONTRIBUTING.md)
+
+information in our [`containerd/project`](https://github.com/containerd/project) repository.

--- a/vendor/github.com/containerd/ttrpc/client.go
+++ b/vendor/github.com/containerd/ttrpc/client.go
@@ -49,7 +49,15 @@ type Client struct {
 	err       error
 }
 
-func NewClient(conn net.Conn) *Client {
+type ClientOpts func(c *Client)
+
+func WithOnClose(onClose func()) ClientOpts {
+	return func(c *Client) {
+		c.closeFunc = onClose
+	}
+}
+
+func NewClient(conn net.Conn, opts ...ClientOpts) *Client {
 	c := &Client{
 		codec:     codec{},
 		conn:      conn,
@@ -58,6 +66,10 @@ func NewClient(conn net.Conn) *Client {
 		closed:    make(chan struct{}),
 		done:      make(chan struct{}),
 		closeFunc: func() {},
+	}
+
+	for _, o := range opts {
+		o(c)
 	}
 
 	go c.run()
@@ -139,11 +151,6 @@ func (c *Client) Close() error {
 	})
 
 	return nil
-}
-
-// OnClose allows a close func to be called when the server is closed
-func (c *Client) OnClose(closer func()) {
-	c.closeFunc = closer
 }
 
 type message struct {
@@ -255,7 +262,7 @@ func (c *Client) recv(resp *Response, msg *message) error {
 	}
 
 	if msg.Type != messageTypeResponse {
-		return errors.New("unkown message type received")
+		return errors.New("unknown message type received")
 	}
 
 	defer c.channel.putmbuf(msg.p)

--- a/vendor/github.com/containerd/ttrpc/services.go
+++ b/vendor/github.com/containerd/ttrpc/services.go
@@ -76,7 +76,7 @@ func (s *serviceSet) dispatch(ctx context.Context, serviceName, methodName strin
 		switch v := obj.(type) {
 		case proto.Message:
 			if err := proto.Unmarshal(p, v); err != nil {
-				return status.Errorf(codes.Internal, "ttrpc: error unmarshaling payload: %v", err.Error())
+				return status.Errorf(codes.Internal, "ttrpc: error unmarshalling payload: %v", err.Error())
 			}
 		default:
 			return status.Errorf(codes.Internal, "ttrpc: error unsupported request type: %T", v)

--- a/vendor/github.com/containerd/ttrpc/types.go
+++ b/vendor/github.com/containerd/ttrpc/types.go
@@ -23,9 +23,10 @@ import (
 )
 
 type Request struct {
-	Service string `protobuf:"bytes,1,opt,name=service,proto3"`
-	Method  string `protobuf:"bytes,2,opt,name=method,proto3"`
-	Payload []byte `protobuf:"bytes,3,opt,name=payload,proto3"`
+	Service     string `protobuf:"bytes,1,opt,name=service,proto3"`
+	Method      string `protobuf:"bytes,2,opt,name=method,proto3"`
+	Payload     []byte `protobuf:"bytes,3,opt,name=payload,proto3"`
+	TimeoutNano int64  `protobuf:"varint,4,opt,name=timeout_nano,proto3"`
 }
 
 func (r *Request) Reset()         { *r = Request{} }


### PR DESCRIPTION
backports of;

- https://github.com/containerd/containerd/pull/2930 Update ttrpc to support context timeout
- https://github.com/containerd/containerd/pull/3246 bump containerd/ttrpc 699c4e40d1e7416e08bf7019c7ce2e9beced4636
  - containerd/ttrpc#33 Fix returns error message
  - containerd/ttrpc#35 Make onclose an option


