### PR TITLE
[release/1.2] Add new required vndr go.mod files

### DIFF
--- a/vendor/gopkg.in/yaml.v2/go.mod
+++ b/vendor/gopkg.in/yaml.v2/go.mod
@@ -1,0 +1,5 @@
+module "gopkg.in/yaml.v2"
+
+require (
+	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
+)


### PR DESCRIPTION
Similar to #3249, we need to commit the `go.mod` files produced by the latest version of vndr. For 1.2, only `gopkg.in/yaml.v2` has a vendored version that includes a `go.mod` file.

Signed-off-by: Jared Cordasco <jcordasc@coglib.com>