### PR TITLE
ctr images import: add --no-unpack option

### DIFF
--- a/cmd/ctr/commands/images/import.go
+++ b/cmd/ctr/commands/images/import.go
@@ -68,6 +68,10 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 			Name:  "all-platforms",
 			Usage: "imports content for all platforms, false by default",
 		},
+		cli.BoolFlag{
+			Name:  "no-unpack",
+			Usage: "skip unpacking the images, false by default",
+		},
 	}, commands.SnapshotterFlags...),
 
 	Action: func(context *cli.Context) error {
@@ -119,19 +123,21 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 			return closeErr
 		}
 
-		log.G(ctx).Debugf("unpacking %d images", len(imgs))
+		if !context.Bool("no-unpack") {
+			log.G(ctx).Debugf("unpacking %d images", len(imgs))
 
-		for _, img := range imgs {
-			// TODO: Allow configuration of the platform
-			image := containerd.NewImage(client, img)
+			for _, img := range imgs {
+				// TODO: Allow configuration of the platform
+				image := containerd.NewImage(client, img)
 
-			// TODO: Show unpack status
-			fmt.Printf("unpacking %s (%s)...", img.Name, img.Target.Digest)
-			err = image.Unpack(ctx, context.String("snapshotter"))
-			if err != nil {
-				return err
+				// TODO: Show unpack status
+				fmt.Printf("unpacking %s (%s)...", img.Name, img.Target.Digest)
+				err = image.Unpack(ctx, context.String("snapshotter"))
+				if err != nil {
+					return err
+				}
+				fmt.Println("done")
 			}
-			fmt.Println("done")
 		}
 		return nil
 	},


### PR DESCRIPTION
Implements https://github.com/containerd/containerd/issues/3258. `ctr images import ...`  with the new `--no-unpack` option will return after `Import`, skipping image `Unpack`. 

This can be used to import images into the content store for E.G. VM image baking without unpacking them to a snapshotter.

Signed-off-by: Benjamin Elder <bentheelder@google.com>