### PR TITLE
snapshots/devmapper: fix thinpool metadata rollback issue

### DIFF
--- a/snapshots/devmapper/pool_device.go
+++ b/snapshots/devmapper/pool_device.go
@@ -124,7 +124,7 @@ func (p *PoolDevice) CreateThinDevice(ctx context.Context, deviceName string, vi
 	}
 
 	defer func() {
-		if retErr == nil {
+		if err == nil {
 			return
 		}
 
@@ -138,7 +138,7 @@ func (p *PoolDevice) CreateThinDevice(ctx context.Context, deviceName string, vi
 	}
 
 	defer func() {
-		if retErr == nil {
+		if err == nil {
 			return
 		}
 
@@ -204,7 +204,7 @@ func (p *PoolDevice) CreateSnapshotDevice(ctx context.Context, deviceName string
 	}
 
 	defer func() {
-		if retErr == nil {
+		if err == nil {
 			return
 		}
 
@@ -218,7 +218,7 @@ func (p *PoolDevice) CreateSnapshotDevice(ctx context.Context, deviceName string
 	}
 
 	defer func() {
-		if retErr == nil {
+		if err == nil {
 			return
 		}
 


### PR DESCRIPTION
The issue is that thinpool metadata change cannot be rollbacked
when creating thin snapshot fails, because "retErr" is always
equal with "nil" so that rollback call won't be reached.

Signed-off-by: Eric Ren <renzhen@linux.alibaba.com>