### PR TITLE
Fix fd leak of shim log

### DIFF
--- a/container_linux_test.go
+++ b/container_linux_test.go
@@ -330,7 +330,7 @@ func TestShimDoesNotLeakPipes(t *testing.T) {
 }
 
 func numPipes(pid int) (int, error) {
-	cmd := exec.Command("sh", "-c", fmt.Sprintf("lsof -p %d | grep pipe", pid))
+	cmd := exec.Command("sh", "-c", fmt.Sprintf("lsof -p %d | grep FIFO", pid))
 
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout

--- a/runtime/v1/shim/client/client.go
+++ b/runtime/v1/shim/client/client.go
@@ -98,9 +98,9 @@ func WithStart(binary, address, daemonAddress, cgroup string, debug bool, exitHa
 			cmd.Wait()
 			exitHandler()
 			if stdoutLog != nil {
-				stderrLog.Close()
+				stdoutLog.Close()
 			}
-			if stdoutLog != nil {
+			if stderrLog != nil {
 				stderrLog.Close()
 			}
 		}()

--- a/runtime/v2/shim_unix.go
+++ b/runtime/v2/shim_unix.go
@@ -28,5 +28,5 @@ import (
 )
 
 func openShimLog(ctx context.Context, bundle *Bundle) (io.ReadCloser, error) {
-	return fifo.OpenFifo(ctx, filepath.Join(bundle.Path, "log"), unix.O_RDWR|unix.O_CREAT, 0700)
+	return fifo.OpenFifo(ctx, filepath.Join(bundle.Path, "log"), unix.O_RDONLY|unix.O_CREAT|unix.O_NONBLOCK, 0700)
 }


### PR DESCRIPTION
Open shim log with the flag `O_RDWR` will cause the `Read()` block forever even if the pipe has been closed on the shim side. Then the `io.Copy()` would never return and lead to a fd leak.

It happens on both shim v1 and v2  but may only have effect on shim v2. Because when using shim v1 , the fd leak is on containerd-shim which will exit when the runtime shim exit. But under shim v2 the shim log is opened by the containerd process so the fd won't be closed until containerd exit.

Run a pod using shim v2 and `lsof` on containerd:
```
COMMAND     PID USER   FD   TYPE             DEVICE SIZE/OFF       NODE NAME
container 51419 root   12u  FIFO                8,8      0t0  351013697 /run/containerd/io.containerd.runtime.v2.task/k8s.io/cd7e64d216e7376e51463f3d9d20571ae2ae9eb009b13a315193bdf9b7133389/log
container 51419 root   13u  FIFO                8,8      0t0  351013697 /run/containerd/io.containerd.runtime.v2.task/k8s.io/cd7e64d216e7376e51463f3d9d20571ae2ae9eb009b13a315193bdf9b7133389/log
```

Then remove the pod, `lsof` again:
```
COMMAND     PID USER   FD   TYPE             DEVICE SIZE/OFF       NODE NAME
container 51419 root   12u  FIFO                8,8      0t0  351013697 /run/containerd/io.containerd.runtime.v2.task/k8s.io/.cd7e64d216e7376e51463f3d9d20571ae2ae9eb009b13a315193bdf9b7133389/log (deleted)
container 51419 root   13u  FIFO                8,8      0t0  351013697 /run/containerd/io.containerd.runtime.v2.task/k8s.io/.cd7e64d216e7376e51463f3d9d20571ae2ae9eb009b13a315193bdf9b7133389/log (deleted)
```

Signed-off-by: Li Yuxuan <liyuxuan04@baidu.com>