### PR TITLE
wip: Fix potential dead lock in reaper

### DIFF
--- a/runtime/v2/shim/reaper_unix.go
+++ b/runtime/v2/shim/reaper_unix.go
@@ -78,13 +78,25 @@ func (m *Monitor) Start(c *exec.Cmd) (chan runc.Exit, error) {
 // User should rely on the value of the exit status to determine if the
 // command was successful or not.
 func (m *Monitor) Wait(c *exec.Cmd, ec chan runc.Exit) (int, error) {
-	for e := range ec {
-		if e.Pid == c.Process.Pid {
-			// make sure we flush all IO
-			c.Wait()
-			m.Unsubscribe(ec)
-			return e.Status, nil
+	var (
+		hasExit = make(chan bool, 1)
+		exit    runc.Exit
+	)
+
+	go func() {
+		for e := range ec {
+			if e.Pid == c.Process.Pid {
+				c.Wait()
+				exit = e
+				hasExit <- true
+			}
 		}
+		close(hasExit)
+	}()
+	if e := <-hasExit; e {
+		// make sure we flush all IO
+		m.Unsubscribe(ec)
+		return exit.Status, nil
 	}
 	// return no such process if the ec channel is closed and no more exit
 	// events will be sent


### PR DESCRIPTION
origin issue is #2709, detail dead lock information is in #2743.
This is long time issue, I wonder if the patch this can fix instead
of workaround it

Signed-off-by: Ace-Tang <aceapril@126.com>

I wrote a unit test for v2 reaper (also can be use for v1 reaper)
```
package shim

import (
	"fmt"
	"os"
	"os/exec"
	"os/signal"
	"testing"

	"golang.org/x/sys/unix"
)

func doSignals() error {
	signals := make(chan os.Signal, 32)
	signal.Notify(signals, unix.SIGTERM, unix.SIGINT, unix.SIGCHLD, unix.SIGPIPE)

	for {
		select {
		case s := <-signals:
			switch s {
			case unix.SIGCHLD:
				if err := Reap(); err != nil {
					fmt.Printf("reap get error %s\n", err)
				}
			default:
			}
		}
	}
}

func TestReap(t *testing.T) {
	end := make(chan bool, 10)
	go doSignals()
	num := 10
	for j := 0; j < num; j++ {
		go func() {
			for i := 0; i < 5; i++ {
				if err := makeCmd(); err != nil {
					fmt.Printf("makeCmd errr %s\n", err)
				}
			}
			end <- true
		}()
	}

	fin := 1
	for {
		select {
		case <-end:
			fin++
			fmt.Printf("finish %d test\n", fin-1)
		}

		if fin > num {
			fmt.Printf("test end\n")
			break
		}
	}
}

func makeCmd() error {
	cmd := exec.Command("echo", "1")
	c, err := Default.Start(cmd)
	if err != nil {
		return fmt.Errorf("error monitor start, %s\n", err)
	}
	_, err = Default.Wait(cmd, c)
	if err != nil {
		return fmt.Errorf("error monitor wait, %s\n", err)
	}
	return nil
}
```
