### PR TITLE
containerd: fix issue of shimv2 log file descriptor leak

### DIFF
--- a/runtime/v2/shim_unix.go
+++ b/runtime/v2/shim_unix.go
@@ -28,5 +28,5 @@ import (
 )
 
 func openShimLog(ctx context.Context, bundle *Bundle) (io.ReadCloser, error) {
-	return fifo.OpenFifo(ctx, filepath.Join(bundle.Path, "log"), unix.O_RDWR|unix.O_CREAT, 0700)
+	return fifo.OpenFifo(ctx, filepath.Join(bundle.Path, "log"), unix.O_RDONLY|unix.O_CREAT|unix.O_NONBLOCK, 0700)
 }


### PR DESCRIPTION
Open the shim's log in RDONLY mode instead of RDWR, otherwise
the peer's close will not trigger an "EOF" event in read side,
thus the reader side will not get a chance to close it.

Fixes:#3268

Signed-off-by: lifupan <lifupan@gmail.com>