### PR TITLE
[release/1.2 backport] fix killall when use pidnamespace

### DIFF
--- a/runtime/v1/shim/service.go
+++ b/runtime/v1/shim/service.go
@@ -545,7 +545,7 @@ func shouldKillAllOnExit(bundlePath string) (bool, error) {
 
 	if bundleSpec.Linux != nil {
 		for _, ns := range bundleSpec.Linux.Namespaces {
-			if ns.Type == specs.PIDNamespace {
+			if ns.Type == specs.PIDNamespace && ns.Path == "" {
 				return false, nil
 			}
 		}


### PR DESCRIPTION
Backport of https://github.com/containerd/containerd/pull/3149 for the 1.2 branch (only the first commit (cherry picked from commit fa5f744a790356472d4649b9ad1d955e36d0c7c0))

addresses https://github.com/moby/moby/issues/38978 
