### PR TITLE
containerd-shim: redirect output into stdout fifo

### DIFF
--- a/cmd/containerd-shim/main_unix.go
+++ b/cmd/containerd-shim/main_unix.go
@@ -110,6 +110,10 @@ func main() {
 		stderr.Close()
 	}()
 
+	// redirect the following output into fifo to make sure that containerd
+	// still can read the log after restart
+	logrus.SetOutput(stdout)
+
 	if err := executeShim(); err != nil {
 		fmt.Fprintf(os.Stderr, "containerd-shim: %s\n", err)
 		os.Exit(1)
@@ -119,7 +123,7 @@ func main() {
 // If containerd server process dies, we need the shim to keep stdout/err reader
 // FDs so that Linux does not SIGPIPE the shim process if it tries to use its end of
 // these pipes.
-func openStdioKeepAlivePipes(dir string) (io.ReadCloser, io.ReadCloser, error) {
+func openStdioKeepAlivePipes(dir string) (io.ReadWriteCloser, io.ReadWriteCloser, error) {
 	background := context.Background()
 	keepStdoutAlive, err := shimlog.OpenShimStdoutLog(background, dir)
 	if err != nil {


### PR DESCRIPTION
Redirect is used to make sure that containerd still can read the log of
shim after restart.

Signed-off-by: Wei Fu <fuweid89@gmail.com>