### PR TITLE
v1:Respect the `shim_debug` flag when load tasks

### DIFF
--- a/runtime/v1/linux/runtime.go
+++ b/runtime/v1/linux/runtime.go
@@ -372,7 +372,11 @@ func (r *Runtime) loadTasks(ctx context.Context, ns string) ([]*Task, error) {
 			}).Error("opening shim stdout log pipe")
 			continue
 		}
-		go io.Copy(os.Stdout, shimStdoutLog)
+		if r.config.ShimDebug {
+			go io.Copy(os.Stdout, shimStdoutLog)
+		} else {
+			go io.Copy(ioutil.Discard, shimStdoutLog)
+		}
 
 		shimStderrLog, err := v1.OpenShimStderrLog(ctx, logDirPath)
 		if err != nil {
@@ -383,7 +387,11 @@ func (r *Runtime) loadTasks(ctx context.Context, ns string) ([]*Task, error) {
 			}).Error("opening shim stderr log pipe")
 			continue
 		}
-		go io.Copy(os.Stderr, shimStderrLog)
+		if r.config.ShimDebug {
+			go io.Copy(os.Stderr, shimStderrLog)
+		} else {
+			go io.Copy(ioutil.Discard, shimStderrLog)
+		}
 
 		t, err := newTask(id, ns, pid, s, r.events, r.tasks, bundle)
 		if err != nil {


### PR DESCRIPTION
Currently when we restart containerd it will load all tasks with shim
logs whether the `shim_debug` is set or not.

Signed-off-by: Li Yuxuan <liyuxuan04@baidu.com>