### PR TITLE
[cherry-pick release/1.2] v1: Respect the `shim_debug` flag when load tasks

### DIFF
--- a/runtime/v1/linux/runtime.go
+++ b/runtime/v1/linux/runtime.go
@@ -364,7 +364,11 @@ func (r *Runtime) loadTasks(ctx context.Context, ns string) ([]*Task, error) {
 			}).Error("opening shim stdout log pipe")
 			continue
 		}
-		go io.Copy(os.Stdout, shimStdoutLog)
+		if r.config.ShimDebug {
+			go io.Copy(os.Stdout, shimStdoutLog)
+		} else {
+			go io.Copy(ioutil.Discard, shimStdoutLog)
+		}
 
 		shimStderrLog, err := v1.OpenShimStderrLog(ctx, logDirPath)
 		if err != nil {
@@ -375,7 +379,11 @@ func (r *Runtime) loadTasks(ctx context.Context, ns string) ([]*Task, error) {
 			}).Error("opening shim stderr log pipe")
 			continue
 		}
-		go io.Copy(os.Stderr, shimStderrLog)
+		if r.config.ShimDebug {
+			go io.Copy(os.Stderr, shimStderrLog)
+		} else {
+			go io.Copy(ioutil.Discard, shimStderrLog)
+		}
 
 		t, err := newTask(id, ns, pid, s, r.events, r.tasks, bundle)
 		if err != nil {


### PR DESCRIPTION
Currently when we restart containerd it will load all tasks with shim
logs whether the `shim_debug` is set or not.

Signed-off-by: Li Yuxuan <liyuxuan04@baidu.com>
(cherry picked from commit 66036d9206ceaef83005260700d7e0b13b057830)
Signed-off-by: Wei Fu <fuweid89@gmail.com>