### PR TITLE
ctr: make ctr shim command easy to use

### DIFF
--- a/cmd/ctr/commands/shim/shim.go
+++ b/cmd/ctr/commands/shim/shim.go
@@ -23,9 +23,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"path/filepath"
 
 	"github.com/containerd/console"
 	"github.com/containerd/containerd/cmd/ctr/commands"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/runtime/v2/shim"
 	"github.com/containerd/containerd/runtime/v2/task"
 	"github.com/containerd/ttrpc"
 	"github.com/containerd/typeurl"
@@ -61,8 +64,8 @@ var Command = cli.Command{
 	Usage: "interact with a shim directly",
 	Flags: []cli.Flag{
 		cli.StringFlag{
-			Name:  "socket",
-			Usage: "socket on which to connect to the shim",
+			Name:  "id",
+			Usage: "container id",
 		},
 	},
 	Subcommands: []cli.Command{
@@ -116,7 +119,7 @@ var stateCommand = cli.Command{
 			return err
 		}
 		r, err := service.State(gocontext.Background(), &task.StateRequest{
-			ID: context.Args().First(),
+			ID: context.GlobalString("id"),
 		})
 		if err != nil {
 			return err
@@ -226,20 +229,30 @@ var execCommand = cli.Command{
 }
 
 func getTaskService(context *cli.Context) (task.TaskService, error) {
-	bindSocket := context.GlobalString("socket")
-	if bindSocket == "" {
-		return nil, errors.New("socket path must be specified")
+	id := context.GlobalString("id")
+	if id == "" {
+		return nil, fmt.Errorf("container id must be specified")
+	}
+	ns := context.GlobalString("namespace")
+
+	// /containerd-shim/ns/id/shim.sock is the old way to generate shim socket,
+	// compatible it
+	s1 := filepath.Join(string(filepath.Separator), "containerd-shim", ns, id, "shim.sock")
+	// this should not error, ctr always get a default ns
+	ctx := namespaces.WithNamespace(gocontext.Background(), ns)
+	s2, _ := shim.SocketAddress(ctx, id)
+
+	for _, socket := range []string{s1, s2} {
+		conn, err := net.Dial("unix", "\x00"+socket)
+		if err == nil {
+			client := ttrpc.NewClient(conn)
+
+			// TODO(stevvooe): This actually leaks the connection. We were leaking it
+			// before, so may not be a huge deal.
+
+			return task.NewTaskClient(client), nil
+		}
 	}
 
-	conn, err := net.Dial("unix", "\x00"+bindSocket)
-	if err != nil {
-		return nil, err
-	}
-
-	client := ttrpc.NewClient(conn)
-
-	// TODO(stevvooe): This actually leaks the connection. We were leaking it
-	// before, so may not be a huge deal.
-
-	return task.NewTaskClient(client), nil
+	return nil, fmt.Errorf("fail to connect to container %s's shim", id)
 }


### PR DESCRIPTION
make ctr shim command easy to use for user, shim socket is generated
through sha256, and it can not get directly, change socket flag to id
command, generated socket in code.
It also avoid fail to connect shim v2, since shim v2 have multiple
containers, `ctr shim --socket state` should specify container id, or
get error `rpc error: code = NotFound desc = container not created: not
found`

Signed-off-by: Ace-Tang <aceapril@126.com>