### PR TITLE
Ensure namespaced writer commit has correct namespace

### DIFF
--- a/metadata/content.go
+++ b/metadata/content.go
@@ -567,6 +567,8 @@ func (nw *namespacedWriter) createAndCopy(ctx context.Context, desc ocispec.Desc
 }
 
 func (nw *namespacedWriter) Commit(ctx context.Context, size int64, expected digest.Digest, opts ...content.Opt) error {
+	ctx = namespaces.WithNamespace(ctx, nw.namespace)
+
 	nw.l.RLock()
 	defer nw.l.RUnlock()
 


### PR DESCRIPTION
The namespaced writer Commit method must always have a
namespace in the context as checked by the removeIngestLease
function, resulting in a panic when not provided. Use the
namespace on the writer since it is always correct and supersedes
any other namespace provided on the Commit context.