### PR TITLE
Use a single custom annotation for export

### DIFF
--- a/images/annotations.go
+++ b/images/annotations.go
@@ -20,9 +20,4 @@ const (
 	// AnnotationImageName is an annotation on a Descriptor in an index.json
 	// containing the `Name` value as used by an `Image` struct
 	AnnotationImageName = "io.containerd.image.name"
-
-	// AnnotationImageNamePrefix is used the same way as AnnotationImageName
-	// but may be used to refer to additional names in the annotation map
-	// using user-defined suffixes (i.e. "extra.1")
-	AnnotationImageNamePrefix = AnnotationImageName + "."
 )

--- a/images/archive/importer.go
+++ b/images/archive/importer.go
@@ -181,7 +181,8 @@ func ImportIndex(ctx context.Context, store content.Store, reader io.Reader) (oc
 				}
 
 				mfstdesc.Annotations = map[string]string{
-					ocispec.AnnotationRefName: normalized,
+					images.AnnotationImageName: normalized,
+					ocispec.AnnotationRefName:  ociReferenceName(normalized),
 				}
 
 				idx.Manifests = append(idx.Manifests, mfstdesc)

--- a/import_test.go
+++ b/import_test.go
@@ -224,7 +224,7 @@ func TestImport(t *testing.T) {
 			},
 		},
 		{
-			Name: "OCIPrefixName",
+			Name: "OCIPrefixName2",
 			Writer: tartest.TarAll(
 				tc.Dir("blobs", 0755),
 				tc.Dir("blobs/sha256", 0755),


### PR DESCRIPTION
Remove annotation prefix and add multiple index records
for manifests with multiple image names. This makes the
custom annotation more consistent with the OCI ref name
annotation. Additionally, ensure the OCI image annotation
always represents the tag (partial image name) as recommended
by the specification. The containerd image name annotation
will always contain the full image name.
