### PR TITLE
Not return error when rootfs already exists

### DIFF
--- a/runtime/v1/shim/service.go
+++ b/runtime/v1/shim/service.go
@@ -127,7 +127,7 @@ func (s *Service) Create(ctx context.Context, r *shimapi.CreateTaskRequest) (_ *
 	rootfs := ""
 	if len(mounts) > 0 {
 		rootfs = filepath.Join(r.Bundle, "rootfs")
-		if err := os.Mkdir(rootfs, 0711); err != nil {
+		if err := os.Mkdir(rootfs, 0711); err != nil && !os.IsExist(err) {
 			return nil, err
 		}
 	}

--- a/runtime/v2/runc/container.go
+++ b/runtime/v2/runc/container.go
@@ -68,7 +68,7 @@ func NewContainer(ctx context.Context, platform rproc.Platform, r *task.CreateTa
 	rootfs := ""
 	if len(mounts) > 0 {
 		rootfs = filepath.Join(r.Bundle, "rootfs")
-		if err := os.Mkdir(rootfs, 0711); err != nil {
+		if err := os.Mkdir(rootfs, 0711); err != nil && !os.IsExist(err) {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Not return error when rootfs already exists.

If we use the new containerd-shim with containerd 1.2, it will break. I know that we don't have guarantee for that kind of version skew, but it is still better not to break that when possible.
```
$ sudo ctr run --rm --tty docker.io/library/alpine:latest test
ctr: mkdir /run/containerd/io.containerd.runtime.v1.linux/default/test/rootfs: file exists: already exists
```

Signed-off-by: Lantao Liu <lantaol@google.com>