### PR TITLE
Ensure that the rootfs dir is created in the bundle

### DIFF
--- a/runtime/v1/linux/bundle.go
+++ b/runtime/v1/linux/bundle.go
@@ -65,6 +65,10 @@ func newBundle(id, path, workDir string, spec []byte) (b *bundle, err error) {
 			os.RemoveAll(workDir)
 		}
 	}()
+	rootfs := filepath.Join(path, "rootfs")
+	if err := os.MkdirAll(rootfs, 0711); err != nil {
+		return nil, err
+	}
 	err = ioutil.WriteFile(filepath.Join(path, configFilename), spec, 0666)
 	return &bundle{
 		id:      id,

--- a/runtime/v2/bundle.go
+++ b/runtime/v2/bundle.go
@@ -79,6 +79,11 @@ func NewBundle(ctx context.Context, root, state, id string, spec []byte) (b *Bun
 	if err := os.MkdirAll(filepath.Dir(work), 0711); err != nil {
 		return nil, err
 	}
+	rootfs := filepath.Join(b.Path, "rootfs")
+	if err := os.MkdirAll(rootfs, 0711); err != nil {
+		return nil, err
+	}
+	paths = append(paths, rootfs)
 	if err := os.Mkdir(work, 0711); err != nil {
 		if !os.IsExist(err) {
 			return nil, err


### PR DESCRIPTION
This fixes issues running gvisor on top of containerd without docker.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>