### PR TITLE
Change restart delay for Windows service to 15s

### DIFF
--- a/cmd/containerd/command/service_windows.go
+++ b/cmd/containerd/command/service_windows.go
@@ -270,8 +270,8 @@ func registerService() error {
 		Delay uint32
 	}
 	t := []scAction{
-		{Type: scActionRestart, Delay: uint32(60 * time.Second / time.Millisecond)},
-		{Type: scActionRestart, Delay: uint32(60 * time.Second / time.Millisecond)},
+		{Type: scActionRestart, Delay: uint32(15 * time.Second / time.Millisecond)},
+		{Type: scActionRestart, Delay: uint32(15 * time.Second / time.Millisecond)},
 		{Type: scActionNone},
 	}
 	lpInfo := serviceFailureActions{ResetPeriod: uint32(24 * time.Hour / time.Second), ActionsCount: uint32(3), Actions: uintptr(unsafe.Pointer(&t[0]))}


### PR DESCRIPTION
Previously we waited for 60 seconds after the service faults to restart
it. However, there isn't much benefit to waiting this long. We expect
15 seconds to be a more reasonable delay.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>