### PR TITLE
Unmount rootfs with separate Remove() in bundle

### DIFF
--- a/runtime/v2/bundle.go
+++ b/runtime/v2/bundle.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 
 	"github.com/containerd/containerd/identifiers"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/pkg/errors"
 )
@@ -116,6 +117,13 @@ type Bundle struct {
 // Delete a bundle atomically
 func (b *Bundle) Delete() error {
 	work, werr := os.Readlink(filepath.Join(b.Path, "work"))
+	rootfs := filepath.Join(b.Path, "rootfs")
+	if err := mount.UnmountAll(rootfs, 0); err != nil {
+		return errors.Wrapf(err, "unmount rootfs %s", rootfs)
+	}
+	if err := os.Remove(rootfs); err != nil && os.IsNotExist(err) {
+		return errors.Wrap(err, "failed to remove bundle rootfs")
+	}
 	err := atomicDelete(b.Path)
 	if err == nil {
 		if werr == nil {


### PR DESCRIPTION
This ensures that a container does not have a mounted rootfs in the
bundle directory before RemoveAll is called.  Having the rootfs removed
first with a Remove ensures that the directory is not mounted and empty
before the bundle directory is removed.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>