### PR TITLE
[cherry-pick release/1.2] Unmount rootfs with separate Remove() in bundle

### DIFF
--- a/runtime/v1/linux/runtime.go
+++ b/runtime/v1/linux/runtime.go
@@ -290,6 +290,10 @@ func (r *Runtime) restoreTasks(ctx context.Context) ([]*Task, error) {
 			continue
 		}
 		name := namespace.Name()
+		// skip hidden directories
+		if len(name) > 0 && name[0] == '.' {
+			continue
+		}
 		log.G(ctx).WithField("namespace", name).Debug("loading tasks in namespace")
 		tasks, err := r.loadTasks(ctx, name)
 		if err != nil {

--- a/runtime/v2/manager.go
+++ b/runtime/v2/manager.go
@@ -155,6 +155,10 @@ func (m *TaskManager) loadExistingTasks(ctx context.Context) error {
 			continue
 		}
 		ns := nsd.Name()
+		// skip hidden directories
+		if len(ns) > 0 && ns[0] == '.' {
+			continue
+		}
 		log.G(ctx).WithField("namespace", ns).Debug("loading tasks in namespace")
 		if err := m.loadTasks(namespaces.WithNamespace(ctx, ns)); err != nil {
 			log.G(ctx).WithField("namespace", ns).WithError(err).Error("loading tasks in namespace")


### PR DESCRIPTION
This ensures that a container does not have a mounted rootfs in the
bundle directory before RemoveAll is called.  Having the rootfs removed
first with a Remove ensures that the directory is not mounted and empty
before the bundle directory is removed.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>
(cherry picked from commit ed308ea)
Signed-off-by: Wei Fu <fuweid89@gmail.com>