### PR TITLE
Fix backwards compat with v2 containerd configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,11 +74,6 @@ script:
   - go build -i .
   - make check
   - if [ "$GOOS" = "linux" ]; then make check-protos check-api-descriptors; fi
-  - |
-    sudo mkdir -p /etc/containerd
-    sudo bash -c "cat > /etc/containerd/config.toml <<EOF
-    version = 1
-    EOF"
   - make build
   - make binaries
   - if [ "$TRAVIS_GOOS" = "linux" ]; then sudo make install ; fi
@@ -91,7 +86,6 @@ script:
     if [ "$TRAVIS_GOOS" = "linux" ]; then
       sudo mkdir -p /etc/containerd
       sudo bash -c "cat > /etc/containerd/config.toml <<EOF
-      version = 1
       [plugins.cri.containerd.default_runtime]
         runtime_type = \"${TEST_RUNTIME}\"
     EOF"

--- a/cmd/containerd/command/config.go
+++ b/cmd/containerd/command/config.go
@@ -50,6 +50,11 @@ var configCommand = cli.Command{
 				config := &Config{
 					Config: defaultConfig(),
 				}
+				// for the time being, keep the defaultConfig's version set at 1 so that
+				// when a config without a version is loaded from disk and has no version
+				// set, we assume it's a v1 config.  But when generating new configs via
+				// this command, generate the v2 config
+				config.Config.Version = 2
 				plugins, err := server.LoadPlugins(gocontext.Background(), config.Config)
 				if err != nil {
 					return err

--- a/cmd/containerd/command/config_linux.go
+++ b/cmd/containerd/command/config_linux.go
@@ -23,7 +23,7 @@ import (
 
 func defaultConfig() *srvconfig.Config {
 	return &srvconfig.Config{
-		Version: 2,
+		Version: 1,
 		Root:    defaults.DefaultRootDir,
 		State:   defaults.DefaultStateDir,
 		GRPC: srvconfig.GRPCConfig{

--- a/cmd/containerd/command/config_unsupported.go
+++ b/cmd/containerd/command/config_unsupported.go
@@ -25,7 +25,7 @@ import (
 
 func defaultConfig() *srvconfig.Config {
 	return &srvconfig.Config{
-		Version: 2,
+		Version: 1,
 		Root:    defaults.DefaultRootDir,
 		State:   defaults.DefaultStateDir,
 		GRPC: srvconfig.GRPCConfig{

--- a/cmd/containerd/command/config_windows.go
+++ b/cmd/containerd/command/config_windows.go
@@ -23,7 +23,7 @@ import (
 
 func defaultConfig() *srvconfig.Config {
 	return &srvconfig.Config{
-		Version: 2,
+		Version: 1,
 		Root:    defaults.DefaultRootDir,
 		State:   defaults.DefaultStateDir,
 		GRPC: srvconfig.GRPCConfig{


### PR DESCRIPTION
Closes #3336 

The fix here is when `containerd config default` is called, generate a new v2 config, however, keep the default code set at v1 so that when the containerd main loads, it merges the default config with what is loaded from disk causing a backwards incompat change. 

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>