### PR TITLE
docs: Fix typo to some markdown files in /docs.

### DIFF
--- a/docs/client-opts.md
+++ b/docs/client-opts.md
@@ -19,7 +19,7 @@ func (c *Client) NewContainer(ctx context.Context, id string, opts ...NewContain
 
 ## Extending the Client
 
-As a consumer of the containerd client you need to be able add your domain specific functionality.
+As a consumer of the containerd client you need to be able to add your domain specific functionality.
 There are a few ways of doing this, changing the client code, submitting a PR to the containerd client, or forking the client.
 These ways of extending the client should only be considered after every other method has been tried.
 

--- a/docs/man/containerd.1.md
+++ b/docs/man/containerd.1.md
@@ -13,7 +13,7 @@ containerd [global options] command [command options] [arguments...]
 
 **containerd** is a high performance container runtime whose daemon can be started
 by using this command. If none of the *config*, *publish*, or *help* commands
-are specified the default action of the **containerd** command is to start the
+are specified, the default action of the **containerd** command is to start the
 containerd daemon in the foreground.
 
 A default configuration is used if no TOML configuration is specified or located

--- a/docs/man/ctr.1.md
+++ b/docs/man/ctr.1.md
@@ -12,7 +12,7 @@ ctr - command line for containerd
 
 **ctr** is an unsupported debug and administrative client for interacting
 with the containerd daemon. Because it is unsupported, the commands,
-options, and operation are not guaranteed to be backward compatible or
+options, and operations are not guaranteed to be backward compatible or
 stable from release to release of the containerd project.
 
 ## OPTIONS


### PR DESCRIPTION
Signed-off-by: BoWen Yan <loneybw@gmail.com>