### PR TITLE
[release/1.2 backport] update Go 1.12 and travis/appveyor changes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.11
+    - GO_VERSION: 1.12.5
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.12.5
+    - GO_VERSION: 1.12.6
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ script:
   - export CGO_ENABLED=$TRAVIS_CGO_ENABLED
   - DCO_VERBOSITY=-q ../project/script/validate/dco
   - ../project/script/validate/fileheader ../project/
-  - ../project/script/validate/vendor
+  - travis_wait ../project/script/validate/vendor
   - GOOS=linux script/setup/install-dev-tools
   - go build -i .
   - make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: required
 # setup travis so that we can run containers for integration tests
 services:
@@ -25,6 +25,7 @@ addons:
       - libprotobuf-c0-dev
       - libprotobuf-dev
       - socat
+      - libseccomp-dev
 
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1
@@ -33,8 +34,6 @@ env:
 
 before_install:
   - uname -r
-  - sudo apt-get -q update
-  - sudo apt-get install -y libseccomp-dev/trusty-backports
 
 install:
   - sudo PATH=$PATH GOPATH=$GOPATH script/setup/install-protobuf

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,16 @@ services:
 language: go
 
 go:
-  - "1.11.x"
+  - "1.12.x"
+os:
+  - "linux"
+  # TODO ppc64le is currently timing out on travis; see https://github.com/containerd/containerd/pull/2896
+  # - "linux-ppc64le"
+
+matrix:
+  include:
+    - os: "linux"
+      env: TRAVIS_GOOS=darwin TRAVIS_CGO_ENABLED=0
 
 go_import_path: github.com/containerd/containerd
 
@@ -30,7 +39,6 @@ addons:
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runtime.v1.linux TRAVIS_CGO_ENABLED=1
-  - TRAVIS_GOOS=darwin TRAVIS_CGO_ENABLED=0
 
 before_install:
   - uname -r
@@ -67,13 +75,13 @@ script:
   - if [ "$GOOS" = "linux" ]; then make check-protos check-api-descriptors; fi
   - make build
   - make binaries
-  - if [ "$GOOS" = "linux" ]; then sudo make install ; fi
-  - if [ "$GOOS" = "linux" ]; then make coverage ; fi
-  - if [ "$GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH make root-coverage ; fi
-  - if [ "$GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH make integration ; fi
+  - if [ "$TRAVIS_GOOS" = "linux" ]; then sudo make install ; fi
+  - if [ "$TRAVIS_GOOS" = "linux" ]; then make coverage ; fi
+  - if [ "$TRAVIS_GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH make root-coverage ; fi
+  - if [ "$TRAVIS_GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH make integration ; fi
   # Run the integration suite a second time. See discussion in github.com/containerd/containerd/pull/1759
-  - if [ "$GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH TESTFLAGS_PARALLEL=1 make integration ; fi
-  - if [ "$GOOS" = "linux" ]; then
+  - if [ "$TRAVIS_GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH TESTFLAGS_PARALLEL=1 make integration ; fi
+  - if [ "$TRAVIS_GOOS" = "linux" ]; then
       sudo PATH=$PATH containerd -log-level debug &> /tmp/containerd-cri.log &
       sudo ctr version ;
       sudo PATH=$PATH GOPATH=$GOPATH critest --runtime-endpoint=/var/run/containerd/containerd.sock --parallel=8 ;


### PR DESCRIPTION
[release/1.2 backport] update Go 1.12 and travis/appveyor changes

- https://github.com/containerd/containerd/pull/3040 Update travis to xenial worker
- https://github.com/containerd/containerd/pull/2896 Add Golang 1.12.5
- https://github.com/containerd/containerd/pull/3343 AppVeyor: Bump golang 1.12.6

**not included**

Travis;

- https://github.com/containerd/containerd/pull/3004 io.containerd.runc.v2 with Container Groups
- https://github.com/containerd/containerd/pull/3205 Use $TEST_RUNTIME for cri test

AppVeyor;
- https://github.com/containerd/containerd/pull/2760 Fix mingw version back to working version with Golang
- https://github.com/containerd/containerd/pull/3128 (https://github.com/containerd/containerd/commit/8710940165aa66e39700eb56a9bb8fe25bda7d40#diff-11c909939117928998b102a1fff7d363) Windows: appveyor: Build shim binary from Microsoft/hcsshim repo




```
# https://github.com/containerd/containerd/pull/3040 Update travis to xenial worker
git cherry-pick -s -S -x 5e8406984480ab81439103e2b95c1234006ddbe6

# https://github.com/containerd/containerd/pull/2896 Add Golang 1.12.5
git cherry-pick -s -S -x 00bc2f5cfd437625c376bd1f14a28249a12e403b
# some conflicts due to missing other commits (see below)
git cherry-pick -s -S -x 543d1e807fbbdbcd998052fa1955c18b0604f56e

# https://github.com/containerd/containerd/pull/3343 AppVeyor: Bump golang 1.12.6
git cherry-pick -s -S -x 67cf9f7f025cff3e928641eca9076dce98db1e47 
```


conflicts (due to https://github.com/containerd/containerd/pull/3205 not included);

<details>

```patch
diff --cc .appveyor.yml
index 739a8517,2cf40452..00000000
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@@ -13,7 -12,7 +13,11 @@@ environment
    GOPATH: C:\gopath
    CGO_ENABLED: 1
    matrix:
++<<<<<<< HEAD
 +    - GO_VERSION: 1.11
++=======
+     - GO_VERSION: 1.12.5
++>>>>>>> 00bc2f5c... Update to Golang 1.12, and prepare for ppc64le
  
  before_build:
    - choco install -y mingw --version 5.3.0
diff --cc .travis.yml
index ec01c66f,3fc80f6c..00000000
--- a/.travis.yml
+++ b/.travis.yml
@@@ -29,8 -38,8 +38,7 @@@ addons
  
  env:
    - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1
 -  - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v2 TRAVIS_CGO_ENABLED=1
    - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runtime.v1.linux TRAVIS_CGO_ENABLED=1
-   - TRAVIS_GOOS=darwin TRAVIS_CGO_ENABLED=0
  
  before_install:
    - uname -r
@@@ -67,20 -76,27 +75,31 @@@ script
    - if [ "$GOOS" = "linux" ]; then make check-protos check-api-descriptors; fi
    - make build
    - make binaries
-   - if [ "$GOOS" = "linux" ]; then sudo make install ; fi
-   - if [ "$GOOS" = "linux" ]; then make coverage ; fi
-   - if [ "$GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH make root-coverage ; fi
-   - if [ "$GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH make integration ; fi
+   - if [ "$TRAVIS_GOOS" = "linux" ]; then sudo make install ; fi
+   - if [ "$TRAVIS_GOOS" = "linux" ]; then make coverage ; fi
+   - if [ "$TRAVIS_GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH make root-coverage ; fi
+   - if [ "$TRAVIS_GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH make integration ; fi
    # Run the integration suite a second time. See discussion in github.com/containerd/containerd/pull/1759
++<<<<<<< HEAD
 +  - if [ "$GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH TESTFLAGS_PARALLEL=1 make integration ; fi
 +  - if [ "$GOOS" = "linux" ]; then
++=======
+   - if [ "$TRAVIS_GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH TESTFLAGS_PARALLEL=1 make integration ; fi
+   - |
+     if [ "$TRAVIS_GOOS" = "linux" ]; then
+       sudo mkdir -p /etc/containerd
+       sudo bash -c "cat > /etc/containerd/config.toml <<EOF
+       [plugins.cri.containerd.default_runtime]
+         runtime_type = \"${TEST_RUNTIME}\"
+     EOF"
++>>>>>>> 00bc2f5c... Update to Golang 1.12, and prepare for ppc64le
        sudo PATH=$PATH containerd -log-level debug &> /tmp/containerd-cri.log &
 -      sudo ctr version
 -      sudo PATH=$PATH GOPATH=$GOPATH critest --runtime-endpoint=/var/run/containerd/containerd.sock --parallel=8
 -      TEST_RC=$?
 -      test $TEST_RC -ne 0 && cat /tmp/containerd-cri.log
 -      sudo pkill containerd
 -      sudo rm -rf /etc/containerd
 -      test $TEST_RC -eq 0 || /bin/false
 +      sudo ctr version ;
 +      sudo PATH=$PATH GOPATH=$GOPATH critest --runtime-endpoint=/var/run/containerd/containerd.sock --parallel=8 ;
 +      TEST_RC=$? ;
 +      test $TEST_RC -ne 0 && cat /tmp/containerd-cri.log ;
 +      sudo pkill containerd ;
 +      test $TEST_RC -eq 0 || /bin/false ;
      fi
  
  after_success:
```

</details>
