### PR TITLE
AppVeyor: Bump golang 1.12.6

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.12.5
+    - GO_VERSION: 1.12.6
 
 before_build:
   - choco install -y mingw --version 5.3.0


### PR DESCRIPTION
go1.12.6 (released 2019/06/11) includes fixes to the compiler, the linker,
the go command, and the crypto/x509, net/http, and os packages. See the
Go 1.12.6 milestone on the issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.12.6

full diff: https://github.com/golang/go/compare/go1.12.5...go1.12.6
