### PR TITLE
Revert "Fix mingw version back to working version with Golang"

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,7 +15,7 @@ environment:
     - GO_VERSION: 1.12.5
 
 before_build:
-  - choco install -y mingw --version 5.3.0
+  - choco install -y mingw
   # Install Go
   - rd C:\Go /s /q
   - appveyor DownloadFile https://storage.googleapis.com/golang/go%GO_VERSION%.windows-amd64.zip


### PR DESCRIPTION
This reverts commit 2bb7da8431adf035a137baaed9ac7897f1d85cf6 (https://github.com/containerd/containerd/pull/2760).


CI was green on the release/1.2 branch (which is using Go 1.11), so I _think_ this is no longer needed 🤞 