### PR TITLE
BinaryIO/LogFile creator bug fixing

### DIFF
--- a/cio/io.go
+++ b/cio/io.go
@@ -258,10 +258,11 @@ func BinaryIO(binary string, args map[string]string) Creator {
 			q.Set(k, v)
 		}
 		uri.RawQuery = q.Encode()
+		res := uri.String()
 		return &logURI{
 			config: Config{
-				Stdout: uri.String(),
-				Stderr: uri.String(),
+				Stdout: res,
+				Stderr: res,
 			},
 		}, nil
 	}
@@ -271,14 +272,19 @@ func BinaryIO(binary string, args map[string]string) Creator {
 // If the log file already exists, the logs will be appended to the file.
 func LogFile(path string) Creator {
 	return func(_ string) (IO, error) {
+		path = filepath.Clean(path)
+		if !strings.HasPrefix(path, "/") {
+			return nil, errors.New("absolute path needed")
+		}
 		uri := &url.URL{
 			Scheme: "file",
-			Host:   path,
+			Path:   path,
 		}
+		res := uri.String()
 		return &logURI{
 			config: Config{
-				Stdout: uri.String(),
-				Stderr: uri.String(),
+				Stdout: res,
+				Stderr: res,
 			},
 		}, nil
 	}

--- a/cio/io_test.go
+++ b/cio/io_test.go
@@ -177,3 +177,21 @@ func TestBinaryIOFailOnRelativePath(t *testing.T) {
 	_, err := BinaryIO("./bin", nil)("!")
 	assert.Error(t, err, "absolute path needed")
 }
+
+func TestLogFileAbsolutePath(t *testing.T) {
+	res, err := LogFile("/full/path/file.txt")("!")
+	assert.NilError(t, err)
+	assert.Equal(t, "file:///full/path/file.txt", res.Config().Stdout)
+	assert.Equal(t, "file:///full/path/file.txt", res.Config().Stderr)
+
+	// Test parse back
+	parsed, err := url.Parse(res.Config().Stdout)
+	assert.NilError(t, err)
+	assert.Equal(t, "file", parsed.Scheme)
+	assert.Equal(t, "/full/path/file.txt", parsed.Path)
+}
+
+func TestLogFileFailOnRelativePath(t *testing.T) {
+	_, err := LogFile("./file.txt")("!")
+	assert.Error(t, err, "absolute path needed")
+}

--- a/runtime/v1/linux/proc/io.go
+++ b/runtime/v1/linux/proc/io.go
@@ -265,7 +265,7 @@ func NewBinaryIO(ctx context.Context, id string, uri *url.URL) (runc.IO, error) 
 		}
 	}
 	ctx, cancel := context.WithCancel(ctx)
-	cmd := exec.CommandContext(ctx, uri.Host, args...)
+	cmd := exec.CommandContext(ctx, uri.Path, args...)
 	cmd.Env = append(cmd.Env,
 		"CONTAINER_ID="+id,
 		"CONTAINER_NAMESPACE="+ns,

--- a/runtime/v1/linux/proc/io.go
+++ b/runtime/v1/linux/proc/io.go
@@ -103,11 +103,11 @@ func createIO(ctx context.Context, id string, ioUID, ioGID int, stdio proc.Stdio
 	case "binary":
 		pio.io, err = NewBinaryIO(ctx, id, u)
 	case "file":
-		if err := os.MkdirAll(filepath.Dir(u.Host), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(u.Path), 0755); err != nil {
 			return nil, err
 		}
 		var f *os.File
-		f, err = os.OpenFile(u.Host, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		f, err = os.OpenFile(u.Path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
There are a few problems with `cio.BinaryIO` creator:

1. It loses arguments:

```go
res, err := BinaryIO("/file.bin", map[string]string{"id": "1"})("!")
res.Config().Stdout // Returns 'binary://%2Ffile.bin'
```

2. `url.Parse` is unable to parse the output of `BinaryIO` function:

```go
res, _ := BinaryIO("/full/path/bin", nil)("!")
parsed, err := url.Parse(res.Config().Stdout)
// err = Unable to parse %2F
```

According to the file URL [scheme](https://en.wikipedia.org/wiki/File_URI_scheme) an absolute file path URL can be represented as
`file://localhost/etc/fstab`
or with localhost omitted.
`file:///etc/fstab`

But not as `file://etc/fstab` (which breaks into host+path)

3. There is no way to specify a relative path in a way to be recognized by `url.Parse`.

This PR addresses the issues above and adds unit tests to verify behavior.


Signed-off-by: Maksym Pavlenko <makpav@amazon.com>