### PR TITLE
Close the inherited socket fd

### DIFF
--- a/cmd/containerd-shim/main_unix.go
+++ b/cmd/containerd-shim/main_unix.go
@@ -196,7 +196,9 @@ func serve(ctx context.Context, server *ttrpc.Server, path string) error {
 		err error
 	)
 	if path == "" {
-		l, err = net.FileListener(os.NewFile(3, "socket"))
+		f := os.NewFile(3, "socket")
+		l, err = net.FileListener(f)
+		f.Close()
 		path = "[inherited from parent]"
 	} else {
 		if len(path) > 106 {


### PR DESCRIPTION
containerd-shim has dup the fd 3, and it don't need fd 3 any more.

before this pr,
```
[root@centos3 containerd]# ps -eaf|grep shim   
root     26959 24846  0 19:31 ?        00:00:00 docker-containerd-shim -namespace moby -workdir /var/lib/docker/containerd/daemon/io.containerd.runtime.v1.linux/moby/b6faed158d9f22c3a47409714972affdb1af2d98363962f5e2fa9a3ef533ae52 -address /var/run/docker/containerd/docker-containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-kata-runtime -debug
[root@centos3 containerd]# ls /proc/26959/fd
lr-x------. 1 root root 64 Jun 20 19:24 0 -> /dev/null
lrwx------. 1 root root 64 Jun 20 19:24 1 -> socket:[198373]
lrwx------. 1 root root 64 Jun 20 19:24 10 -> socket:[459676]
lrwx------. 1 root root 64 Jun 20 19:24 11 -> socket:[462088]
l-wx------. 1 root root 64 Jun 20 19:24 12 -> /run/docker/containerd/d11114fec65d1c5b3cae0e49008d81f2034cd02af88fd3b5a8a18f2df8776f1c/init-stdin
l---------. 1 root root 64 Jun 20 19:24 13 -> /run/docker/containerd/d11114fec65d1c5b3cae0e49008d81f2034cd02af88fd3b5a8a18f2df8776f1c/init-stdin
l---------. 1 root root 64 Jun 20 19:24 14 -> /run/docker/containerd/d11114fec65d1c5b3cae0e49008d81f2034cd02af88fd3b5a8a18f2df8776f1c/init-stdin
lrwx------. 1 root root 64 Jun 20 19:24 15 -> /dev/pts/ptmx
lr-x------. 1 root root 64 Jun 20 19:24 16 -> /run/docker/containerd/d11114fec65d1c5b3cae0e49008d81f2034cd02af88fd3b5a8a18f2df8776f1c/init-stdin
l---------. 1 root root 64 Jun 20 19:24 17 -> /run/docker/containerd/d11114fec65d1c5b3cae0e49008d81f2034cd02af88fd3b5a8a18f2df8776f1c/init-stdout
l-wx------. 1 root root 64 Jun 20 19:24 18 -> /run/docker/containerd/d11114fec65d1c5b3cae0e49008d81f2034cd02af88fd3b5a8a18f2df8776f1c/init-stdout
l---------. 1 root root 64 Jun 20 19:24 19 -> /run/docker/containerd/d11114fec65d1c5b3cae0e49008d81f2034cd02af88fd3b5a8a18f2df8776f1c/init-stdout
lrwx------. 1 root root 64 Jun 20 19:24 2 -> socket:[198373]
lr-x------. 1 root root 64 Jun 20 19:24 20 -> /run/docker/containerd/d11114fec65d1c5b3cae0e49008d81f2034cd02af88fd3b5a8a18f2df8776f1c/init-stdout
lrwx------. 1 root root 64 Jun 20 19:24 3 -> socket:[459676]
l---------. 1 root root 64 Jun 20 19:24 4 -> /var/lib/docker/containerd/daemon/io.containerd.runtime.v1.linux/moby/d11114fec65d1c5b3cae0e49008d81f2034cd02af88fd3b5a8a18f2df8776f1c/shim.stdout.log
lrwx------. 1 root root 64 Jun 20 19:24 5 -> anon_inode:[eventpoll]
lrwx------. 1 root root 64 Jun 20 19:24 6 -> /var/lib/docker/containerd/daemon/io.containerd.runtime.v1.linux/moby/d11114fec65d1c5b3cae0e49008d81f2034cd02af88fd3b5a8a18f2df8776f1c/shim.stdout.log
l---------. 1 root root 64 Jun 20 19:24 7 -> /var/lib/docker/containerd/daemon/io.containerd.runtime.v1.linux/moby/d11114fec65d1c5b3cae0e49008d81f2034cd02af88fd3b5a8a18f2df8776f1c/shim.stderr.log
lrwx------. 1 root root 64 Jun 20 19:24 8 -> /var/lib/docker/containerd/daemon/io.containerd.runtime.v1.linux/moby/d11114fec65d1c5b3cae0e49008d81f2034cd02af88fd3b5a8a18f2df8776f1c/shim.stderr.log
lrwx------. 1 root root 64 Jun 20 19:24 9 -> anon_inode:[eventpoll]
```
after this pr,
```
[root@centos3 containerd]# ps -eaf|grep shim   
root     26979 24846  0 19:31 ?        00:00:00 docker-containerd-shim -namespace moby -workdir /var/lib/docker/containerd/daemon/io.containerd.runtime.v1.linux/moby/b6faed158d9f22c3a47409714972affdb1af2d98363962f5e2fa9a3ef533ae52 -address /var/run/docker/containerd/docker-containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-kata-runtime -debug
[root@centos3 containerd]# ls /proc/26979/fd
lr-x------. 1 root root 64 Jun 20 19:19 0 -> /dev/null
lrwx------. 1 root root 64 Jun 20 19:19 1 -> socket:[198373]
lrwx------. 1 root root 64 Jun 20 19:19 10 -> socket:[461345]
lrwx------. 1 root root 64 Jun 20 19:19 11 -> socket:[453351]
l---------. 1 root root 64 Jun 20 19:17 13 -> /run/docker/containerd/8fbd7e704d126f0970b64c87c3c1475009f393a673b44a7da6eb1e237f67bfec/init-stdin
l---------. 1 root root 64 Jun 20 19:17 14 -> /run/docker/containerd/8fbd7e704d126f0970b64c87c3c1475009f393a673b44a7da6eb1e237f67bfec/init-stdin
lrwx------. 1 root root 64 Jun 20 19:19 15 -> /dev/pts/ptmx
lr-x------. 1 root root 64 Jun 20 19:19 16 -> /run/docker/containerd/8fbd7e704d126f0970b64c87c3c1475009f393a673b44a7da6eb1e237f67bfec/init-stdin
l---------. 1 root root 64 Jun 20 19:17 17 -> /run/docker/containerd/8fbd7e704d126f0970b64c87c3c1475009f393a673b44a7da6eb1e237f67bfec/init-stdout
l-wx------. 1 root root 64 Jun 20 19:19 18 -> /run/docker/containerd/8fbd7e704d126f0970b64c87c3c1475009f393a673b44a7da6eb1e237f67bfec/init-stdout
l---------. 1 root root 64 Jun 20 19:17 19 -> /run/docker/containerd/8fbd7e704d126f0970b64c87c3c1475009f393a673b44a7da6eb1e237f67bfec/init-stdout
lrwx------. 1 root root 64 Jun 20 19:19 2 -> socket:[198373]
lr-x------. 1 root root 64 Jun 20 19:19 20 -> /run/docker/containerd/8fbd7e704d126f0970b64c87c3c1475009f393a673b44a7da6eb1e237f67bfec/init-stdout
l-wx------. 1 root root 64 Jun 20 19:19 21 -> /run/docker/containerd/8fbd7e704d126f0970b64c87c3c1475009f393a673b44a7da6eb1e237f67bfec/init-stdin
l---------. 1 root root 64 Jun 20 19:17 4 -> /var/lib/docker/containerd/daemon/io.containerd.runtime.v1.linux/moby/8fbd7e704d126f0970b64c87c3c1475009f393a673b44a7da6eb1e237f67bfec/shim.stdout.log
lrwx------. 1 root root 64 Jun 20 19:19 5 -> anon_inode:[eventpoll]
lrwx------. 1 root root 64 Jun 20 19:19 6 -> /var/lib/docker/containerd/daemon/io.containerd.runtime.v1.linux/moby/8fbd7e704d126f0970b64c87c3c1475009f393a673b44a7da6eb1e237f67bfec/shim.stdout.log
l---------. 1 root root 64 Jun 20 19:17 7 -> /var/lib/docker/containerd/daemon/io.containerd.runtime.v1.linux/moby/8fbd7e704d126f0970b64c87c3c1475009f393a673b44a7da6eb1e237f67bfec/shim.stderr.log
lrwx------. 1 root root 64 Jun 20 19:19 8 -> /var/lib/docker/containerd/daemon/io.containerd.runtime.v1.linux/moby/8fbd7e704d126f0970b64c87c3c1475009f393a673b44a7da6eb1e237f67bfec/shim.stderr.log
lrwx------. 1 root root 64 Jun 20 19:19 9 -> anon_inode:[eventpoll]
```
Signed-off-by: Shukui Yang <keloyangsk@gmail.com>