### PR TITLE
Set shim OOM scores to +1 containerd daemon score

### DIFF
--- a/runtime/v2/runc/v1/service.go
+++ b/runtime/v2/runc/v1/service.go
@@ -190,8 +190,8 @@ func (s *service) StartShim(ctx context.Context, id, containerdBinary, container
 			}
 		}
 	}
-	if err := shim.SetScore(cmd.Process.Pid); err != nil {
-		return "", errors.Wrap(err, "failed to set OOM Score on shim")
+	if err := shim.AdjustOOMScore(cmd.Process.Pid); err != nil {
+		return "", errors.Wrap(err, "failed to adjust OOM score for shim")
 	}
 	return address, nil
 }

--- a/runtime/v2/runc/v2/service.go
+++ b/runtime/v2/runc/v2/service.go
@@ -233,8 +233,8 @@ func (s *service) StartShim(ctx context.Context, id, containerdBinary, container
 			}
 		}
 	}
-	if err := shim.SetScore(cmd.Process.Pid); err != nil {
-		return "", errors.Wrap(err, "failed to set OOM Score on shim")
+	if err := shim.AdjustOOMScore(cmd.Process.Pid); err != nil {
+		return "", errors.Wrap(err, "failed to adjust OOM score for shim")
 	}
 	return address, nil
 }

--- a/runtime/v2/shim/util_unix.go
+++ b/runtime/v2/shim/util_unix.go
@@ -23,6 +23,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"net"
+	"os"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -44,6 +45,21 @@ func getSysProcAttr() *syscall.SysProcAttr {
 // SetScore sets the oom score for a process
 func SetScore(pid int) error {
 	return sys.SetOOMScore(pid, sys.OOMScoreMaxKillable)
+}
+
+// AdjustOOMScore sets the OOM score for the process to the parents OOM score +1
+// to ensure that they parent has a lower* score than the shim
+func AdjustOOMScore(pid int) error {
+	parent := os.Getppid()
+	score, err := sys.GetOOMScoreAdj(parent)
+	if err != nil {
+		return errors.Wrap(err, "get parent OOM score")
+	}
+	shimScore := score + 1
+	if err := sys.SetOOMScore(pid, shimScore); err != nil {
+		return errors.Wrap(err, "set shim OOM score")
+	}
+	return nil
 }
 
 // SocketAddress returns an abstract socket address

--- a/runtime/v2/shim/util_windows.go
+++ b/runtime/v2/shim/util_windows.go
@@ -40,6 +40,12 @@ func SetScore(pid int) error {
 	return nil
 }
 
+// AdjustOOMScore sets the OOM score for the process to the parents OOM score +1
+// to ensure that they parent has a lower* score than the shim
+func AdjustOOMScore(pid int) error {
+	return nil
+}
+
 // SocketAddress returns a npipe address
 func SocketAddress(ctx context.Context, id string) (string, error) {
 	ns, err := namespaces.NamespaceRequired(ctx)


### PR DESCRIPTION
This changes the shim's OOM score from a static max killable of -999 to
be +1 of the containerd daemon's score.  This should allow the shim's to
be killed first in an OOM condition but leave the daemon alone for a bit
to help cleanup and manage the containers during this situation.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>