### PR TITLE
Support --log-uri in exec subcommand

### DIFF
--- a/cmd/ctr/commands/tasks/exec.go
+++ b/cmd/ctr/commands/tasks/exec.go
@@ -98,6 +98,15 @@ var execCommand = cli.Command{
 			if err != nil {
 				return err
 			}
+
+			if dir := context.String("fifo-dir"); dir != "" {
+				return errors.New("can't use log-uri with fifo-dir")
+			}
+
+			if tty {
+				return errors.New("can't use log-uri with tty")
+			}
+
 			ioCreator = cio.LogURI(uri)
 		} else {
 			cioOpts := []cio.Opt{cio.WithStdio, cio.WithFIFODir(context.String("fifo-dir"))}

--- a/cmd/ctr/commands/tasks/exec.go
+++ b/cmd/ctr/commands/tasks/exec.go
@@ -18,6 +18,7 @@ package tasks
 
 import (
 	"errors"
+	"net/url"
 
 	"github.com/containerd/console"
 	"github.com/containerd/containerd/cio"
@@ -53,6 +54,10 @@ var execCommand = cli.Command{
 			Name:  "fifo-dir",
 			Usage: "directory used for storing IO FIFOs",
 		},
+		cli.StringFlag{
+			Name:  "log-uri",
+			Usage: "log uri for custom shim logging",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		var (
@@ -86,11 +91,22 @@ var execCommand = cli.Command{
 		pspec.Terminal = tty
 		pspec.Args = args
 
-		cioOpts := []cio.Opt{cio.WithStdio, cio.WithFIFODir(context.String("fifo-dir"))}
-		if tty {
-			cioOpts = append(cioOpts, cio.WithTerminal)
+		var ioCreator cio.Creator
+
+		if logURI := context.String("log-uri"); logURI != "" {
+			uri, err := url.Parse(logURI)
+			if err != nil {
+				return err
+			}
+			ioCreator = cio.LogURI(uri)
+		} else {
+			cioOpts := []cio.Opt{cio.WithStdio, cio.WithFIFODir(context.String("fifo-dir"))}
+			if tty {
+				cioOpts = append(cioOpts, cio.WithTerminal)
+			}
+			ioCreator = cio.NewCreator(cioOpts...)
 		}
-		ioCreator := cio.NewCreator(cioOpts...)
+
 		process, err := task.Exec(ctx, context.String("exec-id"), pspec, ioCreator)
 		if err != nil {
 			return err


### PR DESCRIPTION
This PR adds `--log-uri` flag for exec
`sudo ctr t exec --log-uri="file:///tmp/1.txt" ...`

Signed-off-by: Maksym Pavlenko <makpav@amazon.com>