### PR TITLE
vendor: bump go-runc

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,4 +1,4 @@
-github.com/containerd/go-runc 5a6d9f37cfa36b15efba46dc7ea349fa9b7143c3
+github.com/containerd/go-runc 9007c2405372fe28918845901a3276c0915689a1
 github.com/containerd/console 0650fd9eeb50bab4fc99dceb9f2e14cf58f36e7f
 github.com/containerd/cgroups 51b62d303d381950f7b51cf8ff52f1e9e49cc4f1
 github.com/containerd/typeurl a93fcdb778cd272c6e9b3028b2f42d813e785d40

--- a/vendor/github.com/containerd/go-runc/README.md
+++ b/vendor/github.com/containerd/go-runc/README.md
@@ -1,7 +1,7 @@
 # go-runc
 
 [![Build Status](https://travis-ci.org/containerd/go-runc.svg?branch=master)](https://travis-ci.org/containerd/go-runc)
-
+[![codecov](https://codecov.io/gh/containerd/go-runc/branch/master/graph/badge.svg)](https://codecov.io/gh/containerd/go-runc)
 
 This is a package for consuming the [runc](https://github.com/opencontainers/runc) binary in your Go applications.
 It tries to expose all the settings and features of the runc CLI.  If there is something missing then add it, its opensource!
@@ -12,3 +12,14 @@ or greater.
 ## Docs
 
 Docs can be found at [godoc.org](https://godoc.org/github.com/containerd/go-runc).
+
+## Project details
+
+The go-runc is a containerd sub-project, licensed under the [Apache 2.0 license](./LICENSE).
+As a containerd sub-project, you will find the:
+
+ * [Project governance](https://github.com/containerd/project/blob/master/GOVERNANCE.md),
+ * [Maintainers](https://github.com/containerd/project/blob/master/MAINTAINERS),
+ * and [Contributing guidelines](https://github.com/containerd/project/blob/master/CONTRIBUTING.md)
+
+information in our [`containerd/project`](https://github.com/containerd/project) repository.

--- a/vendor/github.com/containerd/go-runc/runc.go
+++ b/vendor/github.com/containerd/go-runc/runc.go
@@ -275,7 +275,11 @@ func (r *Runc) Run(context context.Context, id, bundle string, opts *CreateOpts)
 	if err != nil {
 		return -1, err
 	}
-	return Monitor.Wait(cmd, ec)
+	status, err := Monitor.Wait(cmd, ec)
+	if err == nil && status != 0 {
+		err = fmt.Errorf("%s did not terminate sucessfully", cmd.Args[0])
+	}
+	return status, err
 }
 
 type DeleteOpts struct {
@@ -570,7 +574,11 @@ func (r *Runc) Restore(context context.Context, id, bundle string, opts *Restore
 			}
 		}
 	}
-	return Monitor.Wait(cmd, ec)
+	status, err := Monitor.Wait(cmd, ec)
+	if err == nil && status != 0 {
+		err = fmt.Errorf("%s did not terminate sucessfully", cmd.Args[0])
+	}
+	return status, err
 }
 
 // Update updates the current container with the provided resource spec


### PR DESCRIPTION
bump go-runc to 9007c2405372fe28918845901a3276c0915689a1
in order to support get actually error log if checkpint fail, this
version get two new diff

Add common project content/checks:
https://github.com/containerd/go-runc/commit/8e51df421218b765f393e1fdf97fac668913a8f4
Fix Method of judging command execution
failure:https://github.com/containerd/go-runc/commit/4e99c72acdb052ba374135c009bbc8ac9dd68249

Signed-off-by: Ace-Tang <aceapril@126.com>