### PR TITLE
[release/1.2 backport] Skip rootfs unmount when no mounts are provided

### DIFF
--- a/runtime/v1/linux/proc/init.go
+++ b/runtime/v1/linux/proc/init.go
@@ -298,10 +298,12 @@ func (p *Init) delete(ctx context.Context) error {
 		}
 		p.io.Close()
 	}
-	if err2 := mount.UnmountAll(p.Rootfs, 0); err2 != nil {
-		log.G(ctx).WithError(err2).Warn("failed to cleanup rootfs mount")
-		if err == nil {
-			err = errors.Wrap(err2, "failed rootfs umount")
+	if p.Rootfs != "" {
+		if err2 := mount.UnmountAll(p.Rootfs, 0); err2 != nil {
+			log.G(ctx).WithError(err2).Warn("failed to cleanup rootfs mount")
+			if err == nil {
+				err = errors.Wrap(err2, "failed rootfs umount")
+			}
 		}
 	}
 	return err


### PR DESCRIPTION
backport of #3148 for the 1.2 branch

Co-authored-by: Julia Nedialkova <julianedialkova@hotmail.com>
Signed-off-by: Georgi Sabev <georgethebeatle@gmail.com>