### PR TITLE
Better default label handling

### DIFF
--- a/client.go
+++ b/client.go
@@ -332,7 +332,6 @@ func defaultRemoteContext() *RemoteContext {
 		Resolver: docker.NewResolver(docker.ResolverOptions{
 			Client: http.DefaultClient,
 		}),
-		Snapshotter: DefaultSnapshotter,
 	}
 }
 
@@ -672,7 +671,13 @@ func (c *Client) Version(ctx context.Context) (Version, error) {
 	}, nil
 }
 
-func (c *Client) getSnapshotter(name string) (snapshots.Snapshotter, error) {
+func (c *Client) getSnapshotter(ctx context.Context, name string) (snapshots.Snapshotter, error) {
+	if name == "" {
+		if err := c.GetLabel(ctx, defaults.DefaultSnapshotterNSLabel, &name, DefaultSnapshotter); err != nil {
+			return nil, err
+		}
+	}
+
 	s := c.SnapshotService(name)
 	if s == nil {
 		return nil, errors.Wrapf(errdefs.ErrNotFound, "snapshotter %s was not found", name)

--- a/cmd/ctr/commands/commands.go
+++ b/cmd/ctr/commands/commands.go
@@ -24,7 +24,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/containerd/containerd"
 	"github.com/urfave/cli"
 )
 
@@ -34,7 +33,6 @@ var (
 		cli.StringFlag{
 			Name:   "snapshotter",
 			Usage:  "snapshotter name. Empty value stands for the default value.",
-			Value:  containerd.DefaultSnapshotter,
 			EnvVar: "CONTAINERD_SNAPSHOTTER",
 		},
 	}

--- a/cmd/ctr/commands/namespaces/namespaces.go
+++ b/cmd/ctr/commands/namespaces/namespaces.go
@@ -33,7 +33,7 @@ import (
 // Command is the cli command for managing namespaces
 var Command = cli.Command{
 	Name:    "namespaces",
-	Aliases: []string{"namespace"},
+	Aliases: []string{"namespace", "ns"},
 	Usage:   "manage namespaces",
 	Subcommands: cli.Commands{
 		createCommand,
@@ -45,6 +45,7 @@ var Command = cli.Command{
 
 var createCommand = cli.Command{
 	Name:        "create",
+	Aliases:     []string{"c"},
 	Usage:       "create a new namespace",
 	ArgsUsage:   "<name> [<key>=<value]",
 	Description: "create a new namespace. it must be unique",

--- a/container.go
+++ b/container.go
@@ -233,7 +233,7 @@ func (c *container) NewTask(ctx context.Context, ioCreate cio.Creator, opts ...N
 		}
 
 		// get the rootfs from the snapshotter and add it to the request
-		s, err := c.client.getSnapshotter(r.Snapshotter)
+		s, err := c.client.getSnapshotter(ctx, r.Snapshotter)
 		if err != nil {
 			return nil, err
 		}

--- a/container_opts.go
+++ b/container_opts.go
@@ -117,6 +117,11 @@ func WithSnapshotter(name string) NewContainerOpts {
 func WithSnapshot(id string) NewContainerOpts {
 	return func(ctx context.Context, client *Client, c *containers.Container) error {
 		// check that the snapshot exists, if not, fail on creation
+		var err error
+		c.Snapshotter, err = client.resolveSnapshotterName(ctx, c.Snapshotter)
+		if err != nil {
+			return err
+		}
 		s, err := client.getSnapshotter(ctx, c.Snapshotter)
 		if err != nil {
 			return err
@@ -139,6 +144,10 @@ func WithNewSnapshot(id string, i Image, opts ...snapshots.Opt) NewContainerOpts
 		}
 
 		parent := identity.ChainID(diffIDs).String()
+		c.Snapshotter, err = client.resolveSnapshotterName(ctx, c.Snapshotter)
+		if err != nil {
+			return err
+		}
 		s, err := client.getSnapshotter(ctx, c.Snapshotter)
 		if err != nil {
 			return err
@@ -177,6 +186,10 @@ func WithNewSnapshotView(id string, i Image, opts ...snapshots.Opt) NewContainer
 		}
 
 		parent := identity.ChainID(diffIDs).String()
+		c.Snapshotter, err = client.resolveSnapshotterName(ctx, c.Snapshotter)
+		if err != nil {
+			return err
+		}
 		s, err := client.getSnapshotter(ctx, c.Snapshotter)
 		if err != nil {
 			return err

--- a/container_opts.go
+++ b/container_opts.go
@@ -20,9 +20,7 @@ import (
 	"context"
 
 	"github.com/containerd/containerd/containers"
-	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/snapshots"
@@ -118,9 +116,8 @@ func WithSnapshotter(name string) NewContainerOpts {
 // WithSnapshot uses an existing root filesystem for the container
 func WithSnapshot(id string) NewContainerOpts {
 	return func(ctx context.Context, client *Client, c *containers.Container) error {
-		setSnapshotterIfEmpty(ctx, client, c)
 		// check that the snapshot exists, if not, fail on creation
-		s, err := client.getSnapshotter(c.Snapshotter)
+		s, err := client.getSnapshotter(ctx, c.Snapshotter)
 		if err != nil {
 			return err
 		}
@@ -140,9 +137,9 @@ func WithNewSnapshot(id string, i Image, opts ...snapshots.Opt) NewContainerOpts
 		if err != nil {
 			return err
 		}
-		setSnapshotterIfEmpty(ctx, client, c)
+
 		parent := identity.ChainID(diffIDs).String()
-		s, err := client.getSnapshotter(c.Snapshotter)
+		s, err := client.getSnapshotter(ctx, c.Snapshotter)
 		if err != nil {
 			return err
 		}
@@ -161,7 +158,7 @@ func WithSnapshotCleanup(ctx context.Context, client *Client, c containers.Conta
 		if c.Snapshotter == "" {
 			return errors.Wrapf(errdefs.ErrInvalidArgument, "container.Snapshotter must be set to cleanup rootfs snapshot")
 		}
-		s, err := client.getSnapshotter(c.Snapshotter)
+		s, err := client.getSnapshotter(ctx, c.Snapshotter)
 		if err != nil {
 			return err
 		}
@@ -178,9 +175,9 @@ func WithNewSnapshotView(id string, i Image, opts ...snapshots.Opt) NewContainer
 		if err != nil {
 			return err
 		}
-		setSnapshotterIfEmpty(ctx, client, c)
+
 		parent := identity.ChainID(diffIDs).String()
-		s, err := client.getSnapshotter(c.Snapshotter)
+		s, err := client.getSnapshotter(ctx, c.Snapshotter)
 		if err != nil {
 			return err
 		}
@@ -190,21 +187,6 @@ func WithNewSnapshotView(id string, i Image, opts ...snapshots.Opt) NewContainer
 		c.SnapshotKey = id
 		c.Image = i.Name()
 		return nil
-	}
-}
-
-func setSnapshotterIfEmpty(ctx context.Context, client *Client, c *containers.Container) {
-	if c.Snapshotter == "" {
-		defaultSnapshotter := DefaultSnapshotter
-		namespaceService := client.NamespaceService()
-		if ns, err := namespaces.NamespaceRequired(ctx); err == nil {
-			if labels, err := namespaceService.Labels(ctx, ns); err == nil {
-				if snapshotLabel, ok := labels[defaults.DefaultSnapshotterNSLabel]; ok {
-					defaultSnapshotter = snapshotLabel
-				}
-			}
-		}
-		c.Snapshotter = defaultSnapshotter
 	}
 }
 

--- a/container_opts_unix.go
+++ b/container_opts_unix.go
@@ -54,6 +54,10 @@ func withRemappedSnapshotBase(id string, i Image, uid, gid uint32, readonly bool
 			parent   = identity.ChainID(diffIDs).String()
 			usernsID = fmt.Sprintf("%s-%d-%d", parent, uid, gid)
 		)
+		c.Snapshotter, err = client.resolveSnapshotterName(ctx, c.Snapshotter)
+		if err != nil {
+			return err
+		}
 		snapshotter, err := client.getSnapshotter(ctx, c.Snapshotter)
 		if err != nil {
 			return err

--- a/container_opts_unix.go
+++ b/container_opts_unix.go
@@ -50,13 +50,11 @@ func withRemappedSnapshotBase(id string, i Image, uid, gid uint32, readonly bool
 			return err
 		}
 
-		setSnapshotterIfEmpty(ctx, client, c)
-
 		var (
 			parent   = identity.ChainID(diffIDs).String()
 			usernsID = fmt.Sprintf("%s-%d-%d", parent, uid, gid)
 		)
-		snapshotter, err := client.getSnapshotter(c.Snapshotter)
+		snapshotter, err := client.getSnapshotter(ctx, c.Snapshotter)
 		if err != nil {
 			return err
 		}

--- a/image.go
+++ b/image.go
@@ -25,7 +25,7 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/rootfs"
-	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -149,6 +149,10 @@ func (i *image) Unpack(ctx context.Context, snapshotterName string) error {
 		chain    []digest.Digest
 		unpacked bool
 	)
+	snapshotterName, err = i.client.resolveSnapshotterName(ctx, snapshotterName)
+	if err != nil {
+		return err
+	}
 	sn, err := i.client.getSnapshotter(ctx, snapshotterName)
 	if err != nil {
 		return err

--- a/image.go
+++ b/image.go
@@ -108,7 +108,7 @@ func (i *image) Config(ctx context.Context) (ocispec.Descriptor, error) {
 }
 
 func (i *image) IsUnpacked(ctx context.Context, snapshotterName string) (bool, error) {
-	sn, err := i.client.getSnapshotter(snapshotterName)
+	sn, err := i.client.getSnapshotter(ctx, snapshotterName)
 	if err != nil {
 		return false, err
 	}
@@ -149,7 +149,7 @@ func (i *image) Unpack(ctx context.Context, snapshotterName string) error {
 		chain    []digest.Digest
 		unpacked bool
 	)
-	sn, err := i.client.getSnapshotter(snapshotterName)
+	sn, err := i.client.getSnapshotter(ctx, snapshotterName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- This PR slightly improves handling of default labels across containerd.
- Also respect `containerd.io/defaults/snapshotter` label in `ctr` pull/push and others
- Adds a few aliases for ctr namespace subcommand (`ctr ns ls` and `ctr ns c ...`)

ref: https://github.com/containerd/containerd/issues/2285