### PR TITLE
images: only fetch the best matched manifest info

### DIFF
--- a/images/image.go
+++ b/images/image.go
@@ -142,6 +142,7 @@ type platformManifest struct {
 // this direction because this abstraction is not needed.`
 func Manifest(ctx context.Context, provider content.Provider, image ocispec.Descriptor, platform platforms.MatchComparer) (ocispec.Manifest, error) {
 	var (
+		limit    = 1
 		m        []platformManifest
 		wasIndex bool
 	)
@@ -210,10 +211,22 @@ func Manifest(ctx context.Context, provider content.Provider, image ocispec.Desc
 				}
 			}
 
+			sort.SliceStable(descs, func(i, j int) bool {
+				if descs[i].Platform == nil {
+					return false
+				}
+				if descs[j].Platform == nil {
+					return true
+				}
+				return platform.Less(*descs[i].Platform, *descs[j].Platform)
+			})
+
 			wasIndex = true
 
+			if len(descs) > limit {
+				return descs[:limit], nil
+			}
 			return descs, nil
-
 		}
 		return nil, errors.Wrapf(errdefs.ErrNotFound, "unexpected media type %v for %v", desc.MediaType, desc.Digest)
 	}), image); err != nil {
@@ -227,17 +240,6 @@ func Manifest(ctx context.Context, provider content.Provider, image ocispec.Desc
 		}
 		return ocispec.Manifest{}, err
 	}
-
-	sort.SliceStable(m, func(i, j int) bool {
-		if m[i].p == nil {
-			return false
-		}
-		if m[j].p == nil {
-			return true
-		}
-		return platform.Less(*m[i].p, *m[j].p)
-	})
-
 	return *m[0].m, nil
 }
 


### PR DESCRIPTION
When client uses Pull action to pull image, it will limit the number of
manifest as one. But Unpack action will call Manifest to traverse all
the manifests including non-dowloaded one. If the platform has more than
one manifest, the Pull with unpack action will fail. And also, there is
no need to read non-best matched manifest. Therefore, the Manifest can
do the sort earlier.

Signed-off-by: Wei Fu <fuweid89@gmail.com>