### PR TITLE
Small refactor due to CI linter changes

### DIFF
--- a/cmd/ctr/commands/events/events.go
+++ b/cmd/ctr/commands/events/events.go
@@ -42,8 +42,7 @@ var Command = cli.Command{
 		defer cancel()
 		eventsClient := client.EventService()
 		eventsCh, errCh := eventsClient.Subscribe(ctx, context.Args()...)
-		open := true
-		for open {
+		for {
 			var e *events.Envelope
 			select {
 			case e = <-eventsCh:
@@ -72,6 +71,5 @@ var Command = cli.Command{
 				}
 			}
 		}
-		return nil
 	},
 }


### PR DESCRIPTION
Without the open variable in use, no reason to define it or use it as the
for loop control.

cc: @fuweid 

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>