### PR TITLE
Add flat GC label for leases

### DIFF
--- a/gc/gc.go
+++ b/gc/gc.go
@@ -30,6 +30,11 @@ import (
 // ResourceType represents type of resource at a node
 type ResourceType uint8
 
+// ResourceMax represents the max resource.
+// Upper bits are stripped out during the mark phase, allowing the upper 3 bits
+// to be used by the caller reference function.
+const ResourceMax = ResourceType(0x1F)
+
 // Node presents a resource which has a type and key,
 // this node can be used to lookup other nodes.
 type Node struct {
@@ -80,6 +85,8 @@ func Tricolor(roots []Node, refs func(ref Node) ([]Node, error)) (map[Node]struc
 			}
 		}
 
+		// strip bits above max resource type
+		id.Type = id.Type & ResourceMax
 		// mark as black when done
 		reachable[id] = struct{}{}
 	}

--- a/metadata/db_test.go
+++ b/metadata/db_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/gc"
 	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/log/logtest"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/snapshots"
@@ -345,6 +346,40 @@ func TestMetadataCollector(t *testing.T) {
 			newSnapshot("5", "3", false, true),
 			container("1", "4"),
 			image("image-1", digestFor(2)),
+
+			// Test lease preservation
+			blob(bytesFor(5), false, "containerd.io/gc.ref.content.0", digestFor(6).String()),
+			blob(bytesFor(6), false),
+			blob(bytesFor(7), false),
+			newSnapshot("6", "", false, false, "containerd.io/gc.ref.content.0", digestFor(7).String()),
+			lease("lease-1", []leases.Resource{
+				{
+					ID:   digestFor(5).String(),
+					Type: "content",
+				},
+				{
+					ID:   "6",
+					Type: "snapshots/native",
+				},
+			}, false),
+
+			// Test flat lease
+			blob(bytesFor(8), false, "containerd.io/gc.ref.content.0", digestFor(9).String()),
+			blob(bytesFor(9), true),
+			blob(bytesFor(10), true),
+			newSnapshot("7", "", false, false, "containerd.io/gc.ref.content.0", digestFor(10).String()),
+			newSnapshot("8", "7", false, false),
+			newSnapshot("9", "8", false, false),
+			lease("lease-2", []leases.Resource{
+				{
+					ID:   digestFor(8).String(),
+					Type: "content",
+				},
+				{
+					ID:   "9",
+					Type: "snapshots/native",
+				},
+			}, false, "containerd.io/gc.flat", time.Now().String()),
 		}
 		remaining []gc.Node
 	)
@@ -588,6 +623,26 @@ func create(obj object, tx *bolt.Tx, is images.Store, cs content.Store, sn snaps
 		if err != nil {
 			return nil, err
 		}
+	case testLease:
+		lm := NewLeaseManager(tx)
+		l, err := lm.Create(ctx, leases.WithID(v.id), leases.WithLabels(obj.labels))
+		if err != nil {
+			return nil, err
+		}
+
+		for _, ref := range v.refs {
+			if err := lm.AddResource(ctx, l, ref); err != nil {
+				return nil, err
+			}
+		}
+
+		if !obj.removed {
+			node = &gc.Node{
+				Type:      ResourceLease,
+				Namespace: namespace,
+				Key:       v.id,
+			}
+		}
 	}
 
 	return node, nil
@@ -641,6 +696,17 @@ func container(id, s string, l ...string) object {
 	}
 }
 
+func lease(id string, refs []leases.Resource, r bool, l ...string) object {
+	return object{
+		data: testLease{
+			id:   id,
+			refs: refs,
+		},
+		removed: r,
+		labels:  labelmap(l...),
+	}
+}
+
 type testContent struct {
 	data []byte
 }
@@ -659,6 +725,11 @@ type testImage struct {
 type testContainer struct {
 	id       string
 	snapshot string
+}
+
+type testLease struct {
+	id   string
+	refs []leases.Resource
 }
 
 func newStores(t testing.TB) (*DB, content.Store, snapshots.Snapshotter, func()) {


### PR DESCRIPTION
Provide a flag which configures a lease to only hold reference to its given references and ignore label references during garbage collection rooted from the lease.

This covers a use case to enable using longer lived leases which need to treat the references it is holding as immutable. Since labels are mutable, holding onto an object may cause the number of objects being referenced to grow even when the lease is only intending on keeping the original object. For example, a lease wants to keep a manifest, but not the blobs referred to within the manifest. When another process pulls in those blobs that lease now additionally holds those blobs even if the original process removed its reference to the manifest.

Also added higher level lease tests to test this case and normal leases.

cc @tonistiigi 