### PR TITLE
Add unit test logging hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ GO_GCFLAGS=$(shell				\
 BINARIES=$(addprefix bin/,$(COMMANDS))
 
 # Flags passed to `go test`
-TESTFLAGS ?= -v $(TESTFLAGS_RACE)
+TESTFLAGS ?= $(TESTFLAGS_RACE)
 TESTFLAGS_PARALLEL ?= 8
 
 .PHONY: clean all AUTHORS build binaries test integration generate protos checkprotos coverage ci check help install uninstall vendor release mandir install-man

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -31,7 +31,7 @@ func BenchmarkContainerCreate(b *testing.B) {
 	}
 	defer client.Close()
 
-	ctx, cancel := testContext()
+	ctx, cancel := testContext(b)
 	defer cancel()
 
 	image, err := client.GetImage(ctx, testImage)
@@ -74,7 +74,7 @@ func BenchmarkContainerStart(b *testing.B) {
 	}
 	defer client.Close()
 
-	ctx, cancel := testContext()
+	ctx, cancel := testContext(b)
 	defer cancel()
 
 	image, err := client.GetImage(ctx, testImage)

--- a/container_checkpoint_test.go
+++ b/container_checkpoint_test.go
@@ -53,7 +53,7 @@ func TestCheckpointRestorePTY(t *testing.T) {
 	}
 
 	var (
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -179,7 +179,7 @@ func TestCheckpointRestore(t *testing.T) {
 	}
 
 	var (
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -269,7 +269,7 @@ func TestCheckpointRestoreNewContainer(t *testing.T) {
 	}
 
 	id := t.Name()
-	ctx, cancel := testContext()
+	ctx, cancel := testContext(t)
 	defer cancel()
 
 	image, err := client.GetImage(ctx, testImage)
@@ -359,7 +359,7 @@ func TestCheckpointLeaveRunning(t *testing.T) {
 	}
 
 	var (
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -425,7 +425,7 @@ func TestCRWithImagePath(t *testing.T) {
 	defer client.Close()
 
 	var (
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name() + "-checkpoint"
 	)
 	defer cancel()

--- a/container_linux_test.go
+++ b/container_linux_test.go
@@ -58,7 +58,7 @@ func TestTaskUpdate(t *testing.T) {
 	defer client.Close()
 
 	var (
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -135,7 +135,7 @@ func TestShimInCgroup(t *testing.T) {
 	}
 	defer client.Close()
 	var (
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -192,7 +192,7 @@ func TestDaemonRestart(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -268,7 +268,7 @@ func TestShimDoesNotLeakPipes(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -341,7 +341,7 @@ func TestDaemonReconnectsToShimIOPipesOnRestart(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -471,7 +471,7 @@ func TestContainerPTY(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -548,7 +548,7 @@ func TestContainerAttach(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -693,7 +693,7 @@ func TestContainerUsername(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -768,7 +768,7 @@ func testContainerUser(t *testing.T, userstr, expectedOutput string) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = strings.Replace(t.Name(), "/", "_", -1)
 	)
 	defer cancel()
@@ -843,7 +843,7 @@ func TestContainerAttachProcess(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -960,7 +960,7 @@ func TestContainerUserID(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -1029,7 +1029,7 @@ func TestContainerKillAll(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -1086,7 +1086,7 @@ func TestDaemonRestartWithRunningShim(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -1167,7 +1167,7 @@ func TestContainerRuntimeOptionsv1(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -1210,7 +1210,7 @@ func TestContainerRuntimeOptionsv2(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -1251,7 +1251,7 @@ func initContainerAndCheckChildrenDieOnKill(t *testing.T, opts ...oci.SpecOpts) 
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -1350,7 +1350,7 @@ func testUserNamespaces(t *testing.T, readonlyRootFS bool) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = strings.Replace(t.Name(), "/", "-", -1)
 	)
 	defer cancel()
@@ -1439,7 +1439,7 @@ func TestTaskResize(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -1474,7 +1474,7 @@ func TestTaskResize(t *testing.T) {
 func TestContainerImage(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := testContext()
+	ctx, cancel := testContext(t)
 	defer cancel()
 	id := t.Name()
 
@@ -1507,7 +1507,7 @@ func TestContainerImage(t *testing.T) {
 func TestContainerNoImage(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := testContext()
+	ctx, cancel := testContext(t)
 	defer cancel()
 	id := t.Name()
 
@@ -1535,7 +1535,7 @@ func TestContainerNoImage(t *testing.T) {
 func TestUIDNoGID(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := testContext()
+	ctx, cancel := testContext(t)
 	defer cancel()
 	id := t.Name()
 
@@ -1578,7 +1578,7 @@ func TestBindLowPortNonRoot(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -1634,7 +1634,7 @@ func TestBindLowPortNonOpt(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -1695,7 +1695,7 @@ func TestContainerNoSTDIN(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -1748,7 +1748,7 @@ func TestShimOOMScore(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()

--- a/container_test.go
+++ b/container_test.go
@@ -60,7 +60,7 @@ func TestContainerList(t *testing.T) {
 	}
 	defer client.Close()
 
-	ctx, cancel := testContext()
+	ctx, cancel := testContext(t)
 	defer cancel()
 
 	containers, err := client.Containers(ctx)
@@ -82,7 +82,7 @@ func TestNewContainer(t *testing.T) {
 	}
 	defer client.Close()
 
-	ctx, cancel := testContext()
+	ctx, cancel := testContext(t)
 	defer cancel()
 
 	container, err := client.NewContainer(ctx, id, WithNewSpec())
@@ -112,7 +112,7 @@ func TestContainerStart(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -175,7 +175,7 @@ func TestContainerOutput(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 		expected    = "kingkoye"
 	)
@@ -244,7 +244,7 @@ func TestContainerExec(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -329,7 +329,7 @@ func TestContainerLargeExecArgs(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -405,7 +405,7 @@ func TestContainerPids(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -482,7 +482,7 @@ func TestContainerCloseIO(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -538,7 +538,7 @@ func TestDeleteRunningContainer(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -593,7 +593,7 @@ func TestContainerKill(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -648,7 +648,7 @@ func TestContainerNoBinaryExists(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -695,7 +695,7 @@ func TestContainerExecNoBinaryExists(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -760,7 +760,7 @@ func TestWaitStoppedTask(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -823,7 +823,7 @@ func TestWaitStoppedProcess(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -911,7 +911,7 @@ func TestTaskForceDelete(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -952,7 +952,7 @@ func TestProcessForceDelete(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -1020,7 +1020,7 @@ func TestContainerHostname(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 		expected    = "myhostname"
 	)
@@ -1089,7 +1089,7 @@ func TestContainerExitedAtSet(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -1149,7 +1149,7 @@ func TestDeleteContainerExecCreated(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -1219,7 +1219,7 @@ func TestContainerMetrics(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -1276,7 +1276,7 @@ func TestDeletedContainerMetrics(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()
@@ -1321,7 +1321,7 @@ func TestDeletedContainerMetrics(t *testing.T) {
 func TestContainerExtensions(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := testContext()
+	ctx, cancel := testContext(t)
 	defer cancel()
 	id := t.Name()
 
@@ -1366,7 +1366,7 @@ func TestContainerExtensions(t *testing.T) {
 func TestContainerUpdate(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := testContext()
+	ctx, cancel := testContext(t)
 	defer cancel()
 	id := t.Name()
 
@@ -1411,7 +1411,7 @@ func TestContainerUpdate(t *testing.T) {
 func TestContainerInfo(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := testContext()
+	ctx, cancel := testContext(t)
 	defer cancel()
 	id := t.Name()
 
@@ -1439,7 +1439,7 @@ func TestContainerInfo(t *testing.T) {
 func TestContainerLabels(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := testContext()
+	ctx, cancel := testContext(t)
 	defer cancel()
 	id := t.Name()
 
@@ -1484,7 +1484,7 @@ func TestContainerHook(t *testing.T) {
 
 	var (
 		image       Image
-		ctx, cancel = testContext()
+		ctx, cancel = testContext(t)
 		id          = t.Name()
 	)
 	defer cancel()

--- a/content/testsuite/testsuite.go
+++ b/content/testsuite/testsuite.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/log/logtest"
 	"github.com/containerd/containerd/pkg/testutil"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -101,6 +102,7 @@ func Name(ctx context.Context) string {
 func makeTest(t *testing.T, name string, storeFn func(ctx context.Context, root string) (context.Context, content.Store, func() error, error), fn func(ctx context.Context, t *testing.T, cs content.Store)) func(t *testing.T) {
 	return func(t *testing.T) {
 		ctx := context.WithValue(context.Background(), nameKey{}, name)
+		ctx = logtest.WithT(ctx, t)
 
 		tmpDir, err := ioutil.TempDir("", "content-suite-"+name+"-")
 		if err != nil {

--- a/daemon_config_linux_test.go
+++ b/daemon_config_linux_test.go
@@ -136,7 +136,7 @@ version = 1
 	client, _, cleanup := newDaemonWithConfig(t, configTOML)
 	defer cleanup()
 
-	ctx, cancel := testContext()
+	ctx, cancel := testContext(t)
 	defer cancel()
 	// FIXME(AkihiroSuda): import locally frozen image?
 	image, err := client.Pull(ctx, testImage, WithPullUnpack)

--- a/export_test.go
+++ b/export_test.go
@@ -33,7 +33,7 @@ func TestExport(t *testing.T) {
 	if testing.Short() || runtime.GOOS == "windows" {
 		t.Skip()
 	}
-	ctx, cancel := testContext()
+	ctx, cancel := testContext(t)
 	defer cancel()
 
 	client, err := New(address)

--- a/image_test.go
+++ b/image_test.go
@@ -35,7 +35,7 @@ func TestImageIsUnpacked(t *testing.T) {
 	}
 
 	const imageName = "docker.io/library/busybox:latest"
-	ctx, cancel := testContext()
+	ctx, cancel := testContext(t)
 	defer cancel()
 
 	client, err := newClient(t, address)
@@ -86,7 +86,7 @@ func TestImagePullWithDistSourceLabel(t *testing.T) {
 		tag      = "latest"
 	)
 
-	ctx, cancel := testContext()
+	ctx, cancel := testContext(t)
 	defer cancel()
 
 	client, err := newClient(t, address)

--- a/import_test.go
+++ b/import_test.go
@@ -43,7 +43,7 @@ func TestExportAndImport(t *testing.T) {
 	if testing.Short() || runtime.GOOS == "windows" {
 		t.Skip()
 	}
-	ctx, cancel := testContext()
+	ctx, cancel := testContext(t)
 	defer cancel()
 
 	client, err := New(address)
@@ -83,7 +83,7 @@ func TestExportAndImport(t *testing.T) {
 }
 
 func TestImport(t *testing.T) {
-	ctx, cancel := testContext()
+	ctx, cancel := testContext(t)
 	defer cancel()
 
 	client, err := New(address)

--- a/lease_test.go
+++ b/lease_test.go
@@ -32,7 +32,7 @@ func TestLeaseResources(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx, cancel := testContext()
+	ctx, cancel := testContext(t)
 	defer cancel()
 
 	client, err := newClient(t, address)

--- a/log/logtest/context.go
+++ b/log/logtest/context.go
@@ -1,0 +1,49 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package logtest
+
+import (
+	"context"
+	"io/ioutil"
+	"testing"
+
+	"github.com/containerd/containerd/log"
+	"github.com/sirupsen/logrus"
+)
+
+// WithT adds a logging hook for the given test
+// Changes debug level to debug, clears output, and
+// outputs all log messages as test logs.
+func WithT(ctx context.Context, t testing.TB) context.Context {
+	// Create a new logger to avoid adding hooks from multiple tests
+	l := logrus.New()
+
+	// Increase debug level for tests
+	l.SetLevel(logrus.DebugLevel)
+	l.SetOutput(ioutil.Discard)
+
+	// Add testing hook
+	l.AddHook(&testHook{
+		t: t,
+		fmt: &logrus.TextFormatter{
+			DisableColors:   true,
+			TimestampFormat: log.RFC3339NanoFixed,
+		},
+	})
+
+	return log.WithLogger(ctx, logrus.NewEntry(l))
+}

--- a/log/logtest/log_hook.go
+++ b/log/logtest/log_hook.go
@@ -1,0 +1,42 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package logtest
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+type testHook struct {
+	t   testing.TB
+	fmt logrus.Formatter
+}
+
+func (*testHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+func (h *testHook) Fire(e *logrus.Entry) error {
+	s, err := h.fmt.Format(e)
+	if err != nil {
+		return err
+	}
+	h.t.Log(string(bytes.TrimRight(s, "\n")))
+	return nil
+}

--- a/metadata/containers_test.go
+++ b/metadata/containers_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/filters"
+	"github.com/containerd/containerd/log/logtest"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/typeurl"
 	"github.com/gogo/protobuf/types"
@@ -748,6 +749,7 @@ func checkContainersEqual(t *testing.T, a, b *containers.Container, format strin
 func testEnv(t *testing.T) (context.Context, *bolt.DB, func()) {
 	ctx, cancel := context.WithCancel(context.Background())
 	ctx = namespaces.WithNamespace(ctx, "testing")
+	ctx = logtest.WithT(ctx, t)
 
 	dirname, err := ioutil.TempDir("", strings.Replace(t.Name(), "/", "_", -1)+"-")
 	if err != nil {

--- a/metadata/db_test.go
+++ b/metadata/db_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/gc"
 	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/log/logtest"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/containerd/snapshots/native"
@@ -330,7 +331,7 @@ func TestMetadataCollector(t *testing.T) {
 	defer cleanup()
 
 	var (
-		ctx = context.Background()
+		ctx = logtest.WithT(context.Background(), t)
 
 		objects = []object{
 			blob(bytesFor(1), true),

--- a/snapshots/testsuite/testsuite.go
+++ b/snapshots/testsuite/testsuite.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/log/logtest"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/pkg/testutil"
@@ -71,7 +72,7 @@ func makeTest(name string, snapshotterFn func(ctx context.Context, root string) 
 	return func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
+		ctx := logtest.WithT(context.Background(), t)
 		ctx = namespaces.WithNamespace(ctx, "testsuite")
 		// Make two directories: a snapshotter root and a play area for the tests:
 		//


### PR DESCRIPTION
Adds a function for configuring a context with logger which outputs to the test logs with debug level enabled. This allows for cleaner and more verbose test output with clearer ordering of logs along with failure conditions and time correlation for the daemon logs in integration tests.

Disables verbose logging by default in CI since this will cause more test log output by default. Verbose logging has little value as this output will always get shown now when the corresponding test fails.