### PR TITLE
Fix bug in setting request body

### DIFF
--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -495,6 +495,11 @@ func (r *request) do(ctx context.Context) (*http.Response, error) {
 	}
 	req.Header = r.header
 	if r.body != nil {
+		body, err := r.body()
+		if err != nil {
+			return nil, err
+		}
+		req.Body = body
 		req.GetBody = r.body
 		if r.size > 0 {
 			req.ContentLength = r.size


### PR DESCRIPTION
Go documentation says `Use of GetBody still requires setting Body`.
This change ensures the body is always set in addition to GetBody. This fixes a bug where sometimes the body is nil.

Fixes #3427