### PR TITLE
* Fix: Update snapshot label is still old data

### DIFF
--- a/metadata/snapshot.go
+++ b/metadata/snapshot.go
@@ -232,7 +232,7 @@ func overlayInfo(info, overlay snapshots.Info) snapshots.Info {
 		info.Labels = overlay.Labels
 	} else {
 		for k, v := range overlay.Labels {
-			overlay.Labels[k] = v
+			info.Labels[k] = v
 		}
 	}
 	return info


### PR DESCRIPTION
Add a label to the active snapshot:
ctr snapshot label key label=value

Get information about the snapshot but didn't find the added label:
ctr snapshot info key

Root cause:
overlayInfo function does not return the merged labels

Signed-off-by: Peng Wang <wang_peng168@163.com>