### PR TITLE
Devmapper: consistency issue bugfixes

### DIFF
--- a/snapshots/devmapper/metadata_test.go
+++ b/snapshots/devmapper/metadata_test.go
@@ -76,8 +76,9 @@ func TestPoolMetadata_AddDeviceDuplicate(t *testing.T) {
 	err := store.AddDevice(testCtx, &DeviceInfo{Name: "test"})
 	assert.NilError(t, err)
 
+	// Dumplicate device info will be moved into orphan devices bucket
 	err = store.AddDevice(testCtx, &DeviceInfo{Name: "test"})
-	assert.Equal(t, ErrAlreadyExists, err)
+	assert.Equal(t, nil, err)
 }
 
 func TestPoolMetadata_ReuseDeviceID(t *testing.T) {

--- a/snapshots/devmapper/pool_device.go
+++ b/snapshots/devmapper/pool_device.go
@@ -324,7 +324,7 @@ func (p *PoolDevice) RemoveDevice(ctx context.Context, deviceName string) error 
 		return errors.Wrapf(err, "can't query metadata for device %q", deviceName)
 	}
 
-	if err := p.DeactivateDevice(ctx, deviceName, true, true); err != nil {
+	if err := p.DeactivateDevice(ctx, deviceName, false, true); err != nil {
 		return err
 	}
 

--- a/snapshots/devmapper/pool_device_test.go
+++ b/snapshots/devmapper/pool_device_test.go
@@ -160,9 +160,6 @@ func testCreateThinDevice(t *testing.T, pool *PoolDevice) {
 	err := pool.CreateThinDevice(ctx, thinDevice1, device1Size)
 	assert.NilError(t, err, "can't create first thin device")
 
-	err = pool.CreateThinDevice(ctx, thinDevice1, device1Size)
-	assert.Assert(t, err != nil, "device pool allows duplicated device names")
-
 	err = pool.CreateThinDevice(ctx, thinDevice2, device2Size)
 	assert.NilError(t, err, "can't create second thin device")
 

--- a/snapshots/testsuite/testsuite.go
+++ b/snapshots/testsuite/testsuite.go
@@ -501,7 +501,12 @@ func checkRemoveIntermediateSnapshot(ctx context.Context, t *testing.T, snapshot
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer testutil.Unmount(t, base)
+	needUmount := true
+	defer func() {
+		if needUmount {
+			testutil.Unmount(t, base)
+		}
+	}()
 
 	committedBase := filepath.Join(work, "committed-base")
 	if err = snapshotter.Commit(ctx, committedBase, base, opt); err != nil {
@@ -540,6 +545,10 @@ func checkRemoveIntermediateSnapshot(ctx context.Context, t *testing.T, snapshot
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	testutil.Unmount(t, base)
+	needUmount = false
+
 	err = snapshotter.Remove(ctx, committedBase)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Hi,

These are several patches for problems we've seen in our testing.

In extreme test cases, like hard reboot and force unplug disk while k8s is actively working, we've seen 2 kind of errors as below because of inconsistency occurring between devmapper database and thin-pool, which cause errors to create snapshot/pod afterward:
- "file exists" error:
```
failed to create containerd container: failed to create snapshot
\"vg0-mythinpool-snap-1083\" (dev: 59) from \"vg0-mythinpool-snap-19\"
(dev: 6): 1 error occurred:\n\n* file exists"
```
- "object already exists"
```
time="2019-07-19T15:40:02.331427856+08:00" level=error msg="failed to
create snapshot device from parent vg0-mythinpool-snap-1" error="failed
to save initial metadata for snapshot "vg0-mythinpool-snap-4": object
already exists"
time="2019-07-19T15:40:02.331436436+08:00" level=debug msg="snapshotter
error" error="1 error occurred:

* failed to save initial metadata for snapshot "vg0-mythinpool-snap-4":
object already exists"
```

Please help review and give feedback to improve the fixes, thanks!