### PR TITLE
test: Check manifest.Platform before dereferencing

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -293,6 +293,9 @@ func TestImagePullSomePlatforms(t *testing.T) {
 
 		found := false
 		for _, matcher := range m {
+			if manifest.Platform == nil {
+				t.Fatal("manifest should have proper platform")
+			}
 			if matcher.Match(*manifest.Platform) {
 				count++
 				found = true


### PR DESCRIPTION
If the registry returns a manifest without platform info, the
`manifest.Platform` will be `nil` and cause panic when dereferencing. Such as:

```
=== RUN   TestImagePullSomePlatforms
--- FAIL: TestImagePullSomePlatforms (0.02s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1371cf3]
```

Signed-off-by: Li Yuxuan <liyuxuan04@baidu.com>