### PR TITLE
Update ctr to support deleting multiple tasks at a time

### DIFF
--- a/cmd/ctr/commands/tasks/delete.go
+++ b/cmd/ctr/commands/tasks/delete.go
@@ -17,16 +17,20 @@
 package tasks
 
 import (
+	gocontext "context"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/cmd/ctr/commands"
+	"github.com/containerd/containerd/log"
 	"github.com/urfave/cli"
 )
 
 var deleteCommand = cli.Command{
 	Name:      "delete",
-	Usage:     "[flags] delete a task",
-	ArgsUsage: "CONTAINER",
+	Usage:     "delete one or more tasks",
+	ArgsUsage: "CONTAINER [CONTAINER, ...]",
+	Aliases:   []string{"rm"},
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "force, f",
@@ -47,19 +51,16 @@ var deleteCommand = cli.Command{
 			return err
 		}
 		defer cancel()
-		container, err := client.LoadContainer(ctx, context.Args().First())
-		if err != nil {
-			return err
-		}
-		task, err := container.Task(ctx, cio.Load)
-		if err != nil {
-			return err
-		}
 		var opts []containerd.ProcessDeleteOpts
 		if force {
 			opts = append(opts, containerd.WithProcessKill)
 		}
+		var exitErr error
 		if execID != "" {
+			task, err := loadTask(ctx, client, context.Args().First())
+			if err != nil {
+				return err
+			}
 			p, err := task.LoadProcess(ctx, execID, nil)
 			if err != nil {
 				return err
@@ -72,14 +73,40 @@ var deleteCommand = cli.Command{
 				return cli.NewExitError("", int(ec))
 			}
 		} else {
-			status, err := task.Delete(ctx, opts...)
-			if err != nil {
-				return err
-			}
-			if ec := status.ExitCode(); ec != 0 {
-				return cli.NewExitError("", int(ec))
+			for _, target := range context.Args() {
+				task, err := loadTask(ctx, client, target)
+				if err != nil {
+					if exitErr == nil {
+						exitErr = err
+					}
+					log.G(ctx).WithError(err).Errorf("failed to load task from %v", target)
+					continue
+				}
+				status, err := task.Delete(ctx, opts...)
+				if err != nil {
+					if exitErr == nil {
+						exitErr = err
+					}
+					log.G(ctx).WithError(err).Errorf("unable to delete %v", task.ID())
+					continue
+				}
+				if ec := status.ExitCode(); ec != 0 {
+					log.G(ctx).Warnf("task %v exit with non-zero exit code %v", task.ID(), int(ec))
+				}
 			}
 		}
-		return nil
+		return exitErr
 	},
+}
+
+func loadTask(ctx gocontext.Context, client *containerd.Client, containerID string) (containerd.Task, error) {
+	container, err := client.LoadContainer(ctx, containerID)
+	if err != nil {
+		return nil, err
+	}
+	task, err := container.Task(ctx, cio.Load)
+	if err != nil {
+		return nil, err
+	}
+	return task, nil
 }


### PR DESCRIPTION
This pr include two things:
1. Add an aliase "rm" to task delete command
2. Update ctr to support deleting multiple tasks at a time
For the 2nd update now we can use "ctr task rm $(ctr task ls -q)" to quickly remove unused tasks.
The main body of the "exec-id" flag stays unchanged, which can only delete one exec at a time, the behavior of "exec-id" may need more discussion

Signed-off-by: BoWen Yan <loneybw@gmail.com>