### PR TITLE
Update releases doc for 1.1 release

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -77,8 +77,8 @@ Support horizons will be defined corresponding to a release branch, identified
 by `<major>.<minor>`. Releases branches will be in one of several states:
 
 - __*Next*__: The next planned release branch.
-- __*Active*__: The release is currently supported and accepting patches.
-- __*Extended*__: The release is only accepting security patches.
+- __*Active*__: The release branch is currently supported and accepting patches.
+- __*Extended*__: The release branch is only accepting security patches.
 - __*End of Life*__: The release branch is no longer supported and no new patches will be accepted.
 
 Releases will be supported up to one year after a _minor_ release. This means that
@@ -97,7 +97,7 @@ The current state is available in the following table:
 | [0.1](https://github.com/containerd/containerd/releases/tag/v0.1.0) | End of Life | Mar 21, 2016 | - |
 | [0.2](https://github.com/containerd/containerd/tree/v0.2.x)         | End of Life | Apr 21, 2016      | December 5, 2017 |
 | [1.0](https://github.com/containerd/containerd/releases/tag/v1.0.3) | End of Life | December 5, 2017  | December 5, 2018 |
-| [1.1](https://github.com/containerd/containerd/releases/tag/v1.1.7) | Active   | April 23, 2018  | July 23, 2019 (Active), October 23, 2019 (Extended) |
+| [1.1](https://github.com/containerd/containerd/releases/tag/v1.1.7) | Extended   | April 23, 2018  | October 23, 2019 |
 | [1.2](https://github.com/containerd/containerd/releases/tag/v1.2.6) | Active   | October 24, 2018 | max(October 24, 2019, release of 1.3.0 + 6 months) |
 | [1.3](https://github.com/containerd/containerd/milestone/20)        | Next   | TBD  | max(TBD+1 year, release of 1.4.0 + 6 months) |
 
@@ -275,9 +275,10 @@ We will try not break the tool in _patch_ releases.
 ### Daemon Configuration
 
 The daemon's configuration file, commonly located in `/etc/containerd/config.toml`
-is versioned and backwards compatible.  The `version = 2` field in the config
+is versioned and backwards compatible.  The `version` field in the config
 file specifies the config's version.  If no version number is specified inside
 the config file then it is assumed to be a version 1 config and parsed as such.
+Use `version = 2` to enable version 2 config.
 
 ### Not Covered
 


### PR DESCRIPTION
Fix some wording and status of 1.1 release.

Note we have some unreleased stuff on the 1.1 branch. We can do a 1.1.8 release when needed with more than just a security fixes. Also I think we should keep that branch open for in flight fixes and allow a last update from CRI if needed. However after 1.1.8, we should deny any non-security patch.

Note: do not merge until tomorrow.