### PR TITLE
Create CryptoConfig constructors to replace dcparameters

### DIFF
--- a/cmd/ctr/commands/images/decrypt.go
+++ b/cmd/ctr/commands/images/decrypt.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	imgenc "github.com/containerd/containerd/images/encryption"
-	encconfig "github.com/containerd/containerd/pkg/encryption/config"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
@@ -83,14 +82,12 @@ var decryptCommand = cli.Command{
 			return nil
 		}
 
-		dcparameters, err := CreateDcParameters(context, descs)
+		cc, err := CreateDecryptCryptoConfig(context, descs)
 		if err != nil {
 			return err
 		}
 
-		cc := encconfig.InitDecryption(dcparameters)
-
-		_, err = decryptImage(client, ctx, local, newName, cc, layers32, context.StringSlice("platform"))
+		_, err = decryptImage(client, ctx, local, newName, &cc, layers32, context.StringSlice("platform"))
 
 		return err
 	},

--- a/images/encryption/encryption.go
+++ b/images/encryption/encryption.go
@@ -421,7 +421,7 @@ func CheckAuthorization(ctx context.Context, cs content.Store, desc ocispec.Desc
 		return true
 	}
 
-	_, _, err := cryptImage(ctx, cs, desc, cc, lf, cryptoOpUnwrapOnly)
+	_, _, err := cryptImage(ctx, cs, desc, &cc, lf, cryptoOpUnwrapOnly)
 	if err != nil {
 		return errors.Wrapf(err, "you are not authorized to use this image")
 	}

--- a/pkg/encryption/config/config.go
+++ b/pkg/encryption/config/config.go
@@ -61,3 +61,45 @@ func InitEncryption(parameters, dcparameters map[string][][]byte) *CryptoConfig 
 		},
 	}
 }
+
+// CombineCryptoConfigs takes a CryptoConfig list and creates a single CryptoConfig
+// containing the crypto configuration of all the key bundles
+func CombineCryptoConfigs(ccs []CryptoConfig) CryptoConfig {
+	ecparam := map[string][][]byte{}
+	ecdcparam := map[string][][]byte{}
+	dcparam := map[string][][]byte{}
+
+	for _, cc := range ccs {
+		if ec := cc.EncryptConfig; ec != nil {
+			addToMap(ecparam, ec.Parameters)
+			addToMap(ecdcparam, ec.DecryptConfig.Parameters)
+		}
+
+		if dc := cc.DecryptConfig; dc != nil {
+			addToMap(dcparam, dc.Parameters)
+		}
+	}
+
+	return CryptoConfig{
+		EncryptConfig: &EncryptConfig{
+			Parameters: ecparam,
+			DecryptConfig: DecryptConfig{
+				Parameters: ecdcparam,
+			},
+		},
+		DecryptConfig: &DecryptConfig{
+			Parameters: dcparam,
+		},
+	}
+
+}
+
+func addToMap(orig map[string][][]byte, add map[string][][]byte) {
+	for k, v := range add {
+		if ov, ok := orig[k]; ok {
+			orig[k] = append(ov, v...)
+		} else {
+			orig[k] = v
+		}
+	}
+}

--- a/pkg/encryption/config/config.go
+++ b/pkg/encryption/config/config.go
@@ -40,8 +40,8 @@ type CryptoConfig struct {
 }
 
 // InitDecryption initialized a CryptoConfig object with parameters used for decryption
-func InitDecryption(dcparameters map[string][][]byte) *CryptoConfig {
-	return &CryptoConfig{
+func InitDecryption(dcparameters map[string][][]byte) CryptoConfig {
+	return CryptoConfig{
 		DecryptConfig: &DecryptConfig{
 			Parameters: dcparameters,
 		},
@@ -51,8 +51,8 @@ func InitDecryption(dcparameters map[string][][]byte) *CryptoConfig {
 // InitEncryption initializes a CryptoConfig object with parameters used for encryption
 // It also takes dcparameters that may be needed for decryption when adding a recipient
 // to an already encrypted image
-func InitEncryption(parameters, dcparameters map[string][][]byte) *CryptoConfig {
-	return &CryptoConfig{
+func InitEncryption(parameters, dcparameters map[string][][]byte) CryptoConfig {
+	return CryptoConfig{
 		EncryptConfig: &EncryptConfig{
 			Parameters: parameters,
 			DecryptConfig: DecryptConfig{
@@ -92,6 +92,15 @@ func CombineCryptoConfigs(ccs []CryptoConfig) CryptoConfig {
 		},
 	}
 
+}
+
+// AttachDecryptConfig adds DecryptConfig to the field of EncryptConfig so that
+// the decryption parameters can be used to add recipients to an existing image
+// if the user is able to decrypt it.
+func (ec *EncryptConfig) AttachDecryptConfig(dc *DecryptConfig) {
+	if dc != nil {
+		addToMap(ec.DecryptConfig.Parameters, dc.Parameters)
+	}
 }
 
 func addToMap(orig map[string][][]byte, add map[string][][]byte) {

--- a/pkg/encryption/config/constructors.go
+++ b/pkg/encryption/config/constructors.go
@@ -16,30 +16,13 @@
 
 package config
 
-// NewJweCryptoConfig returns a CryptoConfig that contains the required configuration for using
-// the jwe keyunwrap interface
-func NewJweCryptoConfig(pubKey *[]byte, privKey *[]byte, privKeyPassword *string) CryptoConfig {
-	pubKeys := [][]byte{}
-	privKeys := [][]byte{}
-	privKeysPasswords := [][]byte{}
+import (
+	"github.com/pkg/errors"
+)
 
-	if pubKey != nil {
-		pubKeys = append(pubKeys, *pubKey)
-	}
-	if privKey != nil {
-		privKeys = append(privKeys, *privKey)
-	}
-	if privKeyPassword != nil {
-		privKeysPasswords = append(privKeysPasswords, []byte(*privKeyPassword))
-	}
-
-	dc := DecryptConfig{
-		Parameters: map[string][][]byte{
-			"privkeys":           privKeys,
-			"privkeys-passwords": privKeysPasswords,
-		},
-	}
-
+// EncryptWithJwe returns a CryptoConfig to encrypt with jwe public keys
+func EncryptWithJwe(pubKeys [][]byte) (CryptoConfig, error) {
+	dc := DecryptConfig{}
 	ep := map[string][][]byte{
 		"pubkeys": pubKeys,
 	}
@@ -50,32 +33,12 @@ func NewJweCryptoConfig(pubKey *[]byte, privKey *[]byte, privKeyPassword *string
 			DecryptConfig: dc,
 		},
 		DecryptConfig: &dc,
-	}
+	}, nil
 }
 
-// NewPkcs7CryptoConfig returns a CryptoConfig that contains the required configuration for using
-// the pkcs7 keyunwrap interface
-func NewPkcs7CryptoConfig(x509 *[]byte, privKey *[]byte, privKeyPassword *string) CryptoConfig {
-	x509s := [][]byte{}
-	privKeys := [][]byte{}
-	privKeysPasswords := [][]byte{}
-
-	if x509 != nil {
-		x509s = append(x509s, *x509)
-	}
-	if privKey != nil {
-		privKeys = append(privKeys, *privKey)
-	}
-	if privKeyPassword != nil {
-		privKeysPasswords = append(privKeysPasswords, []byte(*privKeyPassword))
-	}
-
-	dc := DecryptConfig{
-		Parameters: map[string][][]byte{
-			"privkeys":           privKeys,
-			"privkeys-passwords": privKeysPasswords,
-		},
-	}
+// EncryptWithPkcs7 returns a CryptoConfig to encrypt with pkcs7 x509 certs
+func EncryptWithPkcs7(x509s [][]byte) (CryptoConfig, error) {
+	dc := DecryptConfig{}
 
 	ep := map[string][][]byte{
 		"x509s": x509s,
@@ -87,5 +50,85 @@ func NewPkcs7CryptoConfig(x509 *[]byte, privKey *[]byte, privKeyPassword *string
 			DecryptConfig: dc,
 		},
 		DecryptConfig: &dc,
+	}, nil
+}
+
+// EncryptWithGpg returns a CryptoConfig to encrypt with configured gpg parameters
+func EncryptWithGpg(gpgRecipients [][]byte, gpgPubRingFile []byte) (CryptoConfig, error) {
+	dc := DecryptConfig{}
+	ep := map[string][][]byte{
+		"gpg-recipients":     gpgRecipients,
+		"gpg-pubkeyringfile": {gpgPubRingFile},
 	}
+
+	return CryptoConfig{
+		EncryptConfig: &EncryptConfig{
+			Parameters:    ep,
+			DecryptConfig: dc,
+		},
+		DecryptConfig: &dc,
+	}, nil
+}
+
+// DecryptWithPrivKeys returns a CryptoConfig to decrypt with configured private keys
+func DecryptWithPrivKeys(privKeys [][]byte, privKeysPasswords [][]byte) (CryptoConfig, error) {
+	if len(privKeys) != len(privKeysPasswords) {
+		return CryptoConfig{}, errors.New("Length of privKeys should match length of privKeysPasswords")
+	}
+
+	dc := DecryptConfig{
+		Parameters: map[string][][]byte{
+			"privkeys":           privKeys,
+			"privkeys-passwords": privKeysPasswords,
+		},
+	}
+
+	ep := map[string][][]byte{}
+
+	return CryptoConfig{
+		EncryptConfig: &EncryptConfig{
+			Parameters:    ep,
+			DecryptConfig: dc,
+		},
+		DecryptConfig: &dc,
+	}, nil
+}
+
+// DecryptWithX509s returns a CryptoConfig to decrypt with configured x509 certs
+func DecryptWithX509s(x509s [][]byte) (CryptoConfig, error) {
+	dc := DecryptConfig{
+		Parameters: map[string][][]byte{
+			"x509s": x509s,
+		},
+	}
+
+	ep := map[string][][]byte{}
+
+	return CryptoConfig{
+		EncryptConfig: &EncryptConfig{
+			Parameters:    ep,
+			DecryptConfig: dc,
+		},
+		DecryptConfig: &dc,
+	}, nil
+}
+
+// DecryptWithGpgPrivKeys returns a CryptoConfig to decrypt with configured gpg private keys
+func DecryptWithGpgPrivKeys(gpgPrivKeys, gpgPrivKeysPwds [][]byte) (CryptoConfig, error) {
+	dc := DecryptConfig{
+		Parameters: map[string][][]byte{
+			"gpg-privatekeys":           gpgPrivKeys,
+			"gpg-privatekeys-passwords": gpgPrivKeysPwds,
+		},
+	}
+
+	ep := map[string][][]byte{}
+
+	return CryptoConfig{
+		EncryptConfig: &EncryptConfig{
+			Parameters:    ep,
+			DecryptConfig: dc,
+		},
+		DecryptConfig: &dc,
+	}, nil
 }

--- a/pkg/encryption/config/constructors.go
+++ b/pkg/encryption/config/constructors.go
@@ -1,0 +1,91 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package config
+
+// NewJweCryptoConfig returns a CryptoConfig that contains the required configuration for using
+// the jwe keyunwrap interface
+func NewJweCryptoConfig(pubKey *[]byte, privKey *[]byte, privKeyPassword *string) CryptoConfig {
+	pubKeys := [][]byte{}
+	privKeys := [][]byte{}
+	privKeysPasswords := [][]byte{}
+
+	if pubKey != nil {
+		pubKeys = append(pubKeys, *pubKey)
+	}
+	if privKey != nil {
+		privKeys = append(privKeys, *privKey)
+	}
+	if privKeyPassword != nil {
+		privKeysPasswords = append(privKeysPasswords, []byte(*privKeyPassword))
+	}
+
+	dc := DecryptConfig{
+		Parameters: map[string][][]byte{
+			"privkeys":           privKeys,
+			"privkeys-passwords": privKeysPasswords,
+		},
+	}
+
+	ep := map[string][][]byte{
+		"pubkeys": pubKeys,
+	}
+
+	return CryptoConfig{
+		EncryptConfig: &EncryptConfig{
+			Parameters:    ep,
+			DecryptConfig: dc,
+		},
+		DecryptConfig: &dc,
+	}
+}
+
+// NewPkcs7CryptoConfig returns a CryptoConfig that contains the required configuration for using
+// the pkcs7 keyunwrap interface
+func NewPkcs7CryptoConfig(x509 *[]byte, privKey *[]byte, privKeyPassword *string) CryptoConfig {
+	x509s := [][]byte{}
+	privKeys := [][]byte{}
+	privKeysPasswords := [][]byte{}
+
+	if x509 != nil {
+		x509s = append(x509s, *x509)
+	}
+	if privKey != nil {
+		privKeys = append(privKeys, *privKey)
+	}
+	if privKeyPassword != nil {
+		privKeysPasswords = append(privKeysPasswords, []byte(*privKeyPassword))
+	}
+
+	dc := DecryptConfig{
+		Parameters: map[string][][]byte{
+			"privkeys":           privKeys,
+			"privkeys-passwords": privKeysPasswords,
+		},
+	}
+
+	ep := map[string][][]byte{
+		"x509s": x509s,
+	}
+
+	return CryptoConfig{
+		EncryptConfig: &EncryptConfig{
+			Parameters:    ep,
+			DecryptConfig: dc,
+		},
+		DecryptConfig: &dc,
+	}
+}


### PR DESCRIPTION
As a first step to https://github.com/containerd/containerd/issues/3443, we've provided interfaces via the encryption library to create the necessary `CryptoConfig` structures for encryption/decryption without the need to know internals of the encryption scheme..

We've implemented the following interfaces and updated `ctr` usage to use it. In addition, there is no longer any use of `dcparameters` in the codebase outside the encryption library - which uses its internals. 

```
func EncryptWithJwe(pubKeys [][]byte) (CryptoConfig, error) 
func EncryptWithPkcs7(x509s [][]byte) (CryptoConfig, error) 
func EncryptWithGpg(gpgRecipients [][]byte, gpgPubRingFile []byte) (CryptoConfig, error) 
func DecryptWithPrivKeys(privKeys [][]byte, privKeysPasswords [][]byte) (CryptoConfig, error) 
func DecryptWithX509s(x509s [][]byte) (CryptoConfig, error) 
func DecryptWithGpgPrivKeys(gpgPrivKeys, gpgPrivKeysPwds [][]byte) (CryptoConfig, error) 
```

We are thinking that when the OCI spec gets merged, an option is for the `pkg/encryption` library to be under the OCI repo. So this would be the interface provided to create the configurations.