### PR TITLE
Add option to compress blobs on import

### DIFF
--- a/cmd/ctr/commands/images/import.go
+++ b/cmd/ctr/commands/images/import.go
@@ -72,6 +72,10 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 			Name:  "no-unpack",
 			Usage: "skip unpacking the images, false by default",
 		},
+		cli.BoolFlag{
+			Name:  "compress-blobs",
+			Usage: "compress uncompressed blobs when creating manifest (Docker format only)",
+		},
 	}, commands.SnapshotterFlags...),
 
 	Action: func(context *cli.Context) error {
@@ -95,6 +99,10 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 
 		if idxName := context.String("index-name"); idxName != "" {
 			opts = append(opts, containerd.WithIndexName(idxName))
+		}
+
+		if context.Bool("compress-blobs") {
+			opts = append(opts, containerd.WithImportCompression())
 		}
 
 		opts = append(opts, containerd.WithAllPlatforms(context.Bool("all-platforms")))


### PR DESCRIPTION
Change the default back to leave uncompressed and add option to do the compression.

Fixes #3453

```
$ time ctr images import /tmp/kube-apiserver.tar                                                           
unpacking gcr.io/google-containers/kube-apiserver:v1.15.1 (sha256:91db5f34e0511159cb0eb24cd334f80be45561867f570b54b8aff9bcd3201073)...done
ctr images import /tmp/kube-apiserver.tar  0.85s user 0.17s system 15% cpu 6.537 total
$ time ctr images import --compress-blobs /tmp/kube-apiserver.tar
unpacking gcr.io/google-containers/kube-apiserver:v1.15.1 (sha256:2245106da92a70e3ed831b597641dcfefd5489a3e736598fb5598a14e37eb350)...done
ctr images import --compress-blobs /tmp/kube-apiserver.tar  18.03s user 6.20s system 81% cpu 29.866 total
```

As seen from above, the compression may add a non-trivial amount of time on import and therefore should not be the default. The option is useful when importing before a push or to reduce the size of the import blob. Note this only affects archives created through `docker save`, which does not compress today. Archives exported from containerd will preserve manifests and blobs.