### PR TITLE
Allow timeouts to be configured in config

### DIFF
--- a/cmd/containerd/command/config.go
+++ b/cmd/containerd/command/config.go
@@ -22,6 +22,7 @@ import (
 	"os"
 
 	"github.com/BurntSushi/toml"
+	"github.com/containerd/containerd/pkg/timeout"
 	"github.com/containerd/containerd/services/server"
 	srvconfig "github.com/containerd/containerd/services/server/config"
 	"github.com/urfave/cli"
@@ -68,6 +69,12 @@ var configCommand = cli.Command{
 						config.Plugins[p.URI()] = p.Config
 					}
 				}
+				timeouts := timeout.All()
+				config.Timeouts = make(map[string]string)
+				for k, v := range timeouts {
+					config.Timeouts[k] = v.String()
+				}
+
 				_, err = config.WriteTo(os.Stdout)
 				return err
 			},

--- a/pkg/timeout/timeout.go
+++ b/pkg/timeout/timeout.go
@@ -1,0 +1,66 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package timeout
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+var (
+	mu       sync.Mutex
+	timeouts = make(map[string]time.Duration)
+
+	// DefaultTimeout of the timeout package
+	DefaultTimeout = 1 * time.Second
+)
+
+// Set the timeout for the key
+func Set(key string, t time.Duration) {
+	mu.Lock()
+	timeouts[key] = t
+	mu.Unlock()
+}
+
+// Get returns the timeout for the provided key
+func Get(key string) time.Duration {
+	mu.Lock()
+	t, ok := timeouts[key]
+	mu.Unlock()
+	if !ok {
+		t = DefaultTimeout
+	}
+	return t
+}
+
+// WithContext returns a context with the specified timeout for the provided key
+func WithContext(ctx context.Context, key string) (context.Context, func()) {
+	t := Get(key)
+	return context.WithTimeout(ctx, t)
+}
+
+// All returns all keys and their timeouts
+func All() map[string]time.Duration {
+	out := make(map[string]time.Duration)
+	mu.Lock()
+	defer mu.Unlock()
+	for k, v := range timeouts {
+		out[k] = v
+	}
+	return out
+}

--- a/services/server/config/config.go
+++ b/services/server/config/config.go
@@ -55,6 +55,8 @@ type Config struct {
 	Cgroup CgroupConfig `toml:"cgroup"`
 	// ProxyPlugins configures plugins which are communicated to over GRPC
 	ProxyPlugins map[string]ProxyPlugin `toml:"proxy_plugins"`
+	// Timeouts specified as a duration
+	Timeouts map[string]string `toml:"timeouts"`
 
 	StreamProcessors []StreamProcessor `toml:"stream_processors"`
 

--- a/services/server/server.go
+++ b/services/server/server.go
@@ -40,6 +40,7 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/metadata"
 	"github.com/containerd/containerd/pkg/dialer"
+	"github.com/containerd/containerd/pkg/timeout"
 	"github.com/containerd/containerd/plugin"
 	srvconfig "github.com/containerd/containerd/services/server/config"
 	"github.com/containerd/containerd/snapshots"
@@ -76,6 +77,13 @@ func CreateTopLevelDirectories(config *srvconfig.Config) error {
 func New(ctx context.Context, config *srvconfig.Config) (*Server, error) {
 	if err := apply(ctx, config); err != nil {
 		return nil, err
+	}
+	for key, sec := range config.Timeouts {
+		d, err := time.ParseDuration(sec)
+		if err != nil {
+			return nil, errors.Errorf("unable to parse %s into a time duration", sec)
+		}
+		timeout.Set(key, d)
 	}
 	plugins, err := LoadPlugins(ctx, config)
 	if err != nil {


### PR DESCRIPTION
This adds a singleton `timeout` package that will allow services and user
to configure timeouts in the daemon.  When a service wants to use a
timeout, it should declare a const and register it's default value
inside an `init()` function for that package.  When the default config
is generated, we can use the `timeout` package to provide the available
timeout keys so that a user knows that they can configure.

These show up in the config as follows:

```toml
[timeouts]
  "io.containerd.timeout.shim.cleanup" = "5s"
  "io.containerd.timeout.shim.load" = "5s"
  "io.containerd.timeout.shim.shutdown" = "300ms"
  "io.containerd.timeout.task.state" = "100ms"

```

Timeouts in the config are specified as a string and parsed as a duration.

Timeouts are very hard to get right and giving this power to the user to
configure things is a huge improvement.  Machines can be faster and
slower and depending on the CPU or load of the machine, a timeout may
need to be adjusted.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>