### PR TITLE
Specify protocols in ctr encrypt recipients

### DIFF
--- a/cmd/ctr/commands/images/encrypt.go
+++ b/cmd/ctr/commands/images/encrypt.go
@@ -41,10 +41,15 @@ var encryptCommand = cli.Command{
 	This tool also allows management of the recipients of the image through changes
 	to the list of recipients.
 	Once the image has been encrypted it may be pushed to a registry.
+
+    Recipients are declared with the protocol prefix as follows:
+    - pgp:<email-address>
+    - jwe:<public-key-file-path>
+    - pkcs7:<x509-file-path>
 `,
 	Flags: append(append(commands.RegistryFlags, cli.StringSliceFlag{
 		Name:  "recipient",
-		Usage: "Recipient of the image is the person who can decrypt it",
+		Usage: "Recipient of the image is the person who can decrypt it in the form specified above (i.e. jwe:/path/to/key)",
 	}, cli.IntSliceFlag{
 		Name:  "layer",
 		Usage: "The layer to encrypt; this must be either the layer number or a negative number starting with -1 for topmost layer",

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -25,8 +25,8 @@ The option `--layer -1` specifies the layer filter for encryption, -1 indicating
 
 ```
 $ ctr images encrypt \
-    --recipient /tmp/tmp.AGrSDkaSad/mypubkey.pem \
-    --recipient /tmp/tmp.AGrSDkaSad/clientcert.pem \
+    --recipient jwe:/tmp/tmp.AGrSDkaSad/mypubkey.pem \
+    --recipient pkcs7:/tmp/tmp.AGrSDkaSad/clientcert.pem \
     --layer -1 \
     docker.io/library/alpine:latest docker.io/library/alpine:enc
 


### PR DESCRIPTION
Second part to address https://github.com/containerd/containerd/issues/3443. Modified `ctr images encrypt` command `--recipient` option to add a protocol prefix. i.e. `pgp:lumjjb@gmail.com`, `jwe:/path/to/pubkey`, `pkcs7:/path/to/x509`

Signed-off-by: Brandon Lum <lumjjb@gmail.com>