### PR TITLE
Add 1.3 beta release notes

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,28 +1,43 @@
-Abhinandan Prativadi <abhi@docker.com> Abhinandan Prativadi <aprativadi@gmail.com>
 Abhinandan Prativadi <abhi@docker.com> abhi <abhi@docker.com>
-Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp> Akihiro Suda <suda.kyoto@gmail.com>
+Abhinandan Prativadi <abhi@docker.com> Abhinandan Prativadi <aprativadi@gmail.com>
 Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp> Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
+Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp> Akihiro Suda <suda.kyoto@gmail.com>
 Andrei Vagin <avagin@virtuozzo.com> Andrei Vagin <avagin@openvz.org>
+Andrey Kolomentsev <andrey.kolomentsev@gmail.com> akolomentsev <andrey.kolomentsev@gmail.com>
 Brent Baude <bbaude@redhat.com> baude <bbaude@redhat.com>
+Carlos Eduardo <me@carlosedp.com> CarlosEDP <me@carlosedp.com>
+Eric Ren <renzhen.rz@alibaba-linux.com> renzhen.rz <renzhen.rz@alibaba-inc.com>
 Frank Yang <yyb196@gmail.com> frank yang <yyb196@gmail.com>
 Georgia Panoutsakopoulou <gpanoutsak@gmail.com> gpanouts <gpanoutsak@gmail.com>
+Jian Liao <jliao@alauda.io> liaojian <liaojian@Dabllo.local>
+Jian Liao <jliao@alauda.io> liaoj <jliao@alauda.io>
+Ji'an Liu <anthonyliu@zju.edu.cn> ZeroMagic <anthonyliu@zju.edu.cn>
 Jie Zhang <iamkadisi@163.com> kadisi <iamkadisi@163.com>
 John Howard <john.howard@microsoft.com> John Howard <jhoward@microsoft.com>
-Justin Terry <juterry@microsoft.com> Justin Terry (VM) <juterry@microsoft.com>
+Julien Balestra <julien.balestra@datadoghq.com> JulienBalestra <julien.balestra@datadoghq.com>
+Justin Cormack <justin.cormack@docker.com> Justin Cormack <justin@specialbusservice.com>
 Justin Terry <juterry@microsoft.com> Justin <jterry75@users.noreply.github.com>
+Justin Terry <juterry@microsoft.com> Justin Terry (VM) <juterry@microsoft.com>
 Kenfe-Mickaël Laventure <mickael.laventure@gmail.com> Kenfe-Mickael Laventure <mickael.laventure@gmail.com>
 Kevin Xu <cming.xu@gmail.com> kevin.xu <cming.xu@gmail.com>
-Lu Jingxiao <lujingxiao@huawei.com> l00397676 <lujingxiao@huawei.com>
 Lantao Liu <lantaol@google.com> Lantao Liu <taotaotheripper@gmail.com>
-Phil Estes <estesp@gmail.com> Phil Estes <estesp@linux.vnet.ibm.com>
-Stephen J Day <stevvooe@gmail.com> Stephen J Day <stephen.day@docker.com>
-Stephen J Day <stevvooe@gmail.com> Stephen Day <stevvooe@users.noreply.github.com>
-Stephen J Day <stevvooe@gmail.com> Stephen Day <stephen.day@getcruise.com>
-Sudeesh John <sudeesh@linux.vnet.ibm.com> sudeesh john <sudeesh@linux.vnet.ibm.com>
-Tõnis Tiigi <tonistiigi@gmail.com> Tonis Tiigi <tonistiigi@gmail.com>
 Lifubang <lifubang@aliyun.com> Lifubang <lifubang@acmcoder.com>
-Xiaodong Zhang <a4012017@sina.com> nashasha1 <a4012017@sina.com>
-Jian Liao <jliao@alauda.io> liaoj <jliao@alauda.io>
-Jian Liao <jliao@alauda.io> liaojian <liaojian@Dabllo.local>
+Lu Jingxiao <lujingxiao@huawei.com> l00397676 <lujingxiao@huawei.com>
+Maksym Pavlenko <makpav@amazon.com> Maksym Pavlenko <pavlenko.maksym@gmail.com>
+Mark Gordon <msg555@gmail.com> msg555 <msg555@gmail.com>
+Michael Katsoulis <michaelkatsoulis88@gmail.com> MichaelKatsoulis <michaelkatsoulis88@gmail.com>
+Phil Estes <estesp@gmail.com> Phil Estes <estesp@linux.vnet.ibm.com>
 Rui Cao <ruicao@alauda.io> ruicao <ruicao@alauda.io>
+Stephen J Day <stevvooe@gmail.com> Stephen Day <stephen.day@getcruise.com>
+Stephen J Day <stevvooe@gmail.com> Stephen Day <stevvooe@users.noreply.github.com>
+Stephen J Day <stevvooe@gmail.com> Stephen J Day <stephen.day@docker.com>
+Sudeesh John <sudeesh@linux.vnet.ibm.com> sudeesh john <sudeesh@linux.vnet.ibm.com>
+Su Fei  <fesu@ebay.com> fesu <fesu@ebay.com>
+Tõnis Tiigi <tonistiigi@gmail.com> Tonis Tiigi <tonistiigi@gmail.com>
+Wei Fu <fuweid89@gmail.com> Wei Fu <fhfuwei@163.com>
+Xiaodong Zhang <a4012017@sina.com> nashasha1 <a4012017@sina.com>
 Xuean Yan <yan.xuean@zte.com.cn> yanxuean <yan.xuean@zte.com.cn>
+Yuxing Liu <starnop@163.com> Starnop <starnop@163.com>
+zhenguang zhu <zhengguang.zhu@daocloud.io> dzzg <zhengguang.zhu@daocloud.io>
+zhoulin xie <zhoulin.xie@daocloud.io> JoeWrightss <42261994+JoeWrightss@users.noreply.github.com>
+zhoulin xie <zhoulin.xie@daocloud.io> JoeWrightss <zhoulin.xie@daocloud.io>

--- a/releases/v1.3.0-beta.toml
+++ b/releases/v1.3.0-beta.toml
@@ -1,0 +1,54 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release
+previous = "v1.2.0"
+
+pre_release = true
+
+preface = """\
+The fourth major release of containerd comes over 9 months after the previous
+major release and covers a period of both significant project growth and
+further stabilization. Similar to previous releases, the number of API changes
+are small and, as always, backwards compatible. The growing ecosystem of plugins
+and users have driven improvements to make containerd more configurable, usable,
+and pluggable. On Windows, this release brings a new runtime utilizing the shim
+API. For clients, there are many new features and improvements completely
+implemented in the client libraries without requiring daemon upgrade.
+
+## Runtime
+* New Windows runtime using hcsshim
+* Improvements to ttrpc for daemon to shim communication (https://github.com/containerd/containerd/pull/3341)
+
+## Snapshots
+* Devmapper snapshotter (https://github.com/containerd/containerd/pull/3022)
+* Improved label support for plugins
+
+## Plugins
+* Support for plugins registering as a TCP service
+* Configurable plugin directory
+
+## CRI
+
+## Client
+* Default handling from namespace labels (https://github.com/containerd/containerd/pull/3403)
+* Improved Docker resolver with mirroring support
+* Support for cross repository push (https://github.com/containerd/containerd/pull/3218)
+
+## Other
+* [API] Add support for direct resource management in leases (https://github.com/containerd/containerd/pull/3304)
+* [API] Add ttrpc service for shim event publishing
+* [API] Add annotations to descriptors in API
+* [API] Add id to TaskDelete event message to match exec id
+* Support additional garbage collection labels
+
+And many more improvements and bug fixes in the complete changelog"""
+
+# notable prs to include in the release notes, 1234 is the pr number
+[notes]
+
+[breaking]


### PR DESCRIPTION
First draft of 1.3 release notes under beta. Please feel free to recommend further updates to the notes now or after the 1.3 beta notes are merged. Targeting for this to be merged and beta on Wednesday, July 31st.

As with previous betas, the beta will be cut directly from master and the betas and rcs will continue to be released from master. There is no restriction on merging during the beta period, however if a feature is specifically not intended for 1.3, we should wait to merge it. Once the rc period has started, then merges into master should only be bug/stability fixes or low risk changes. We will cut the 1.3.0 tag directly from master.

View a test generation of the notes [here](https://gist.github.com/dmcgowan/faa870c4a0890e739fd1aaf0cfd76eff)