### PR TITLE
Better error recovery in device mapper

### DIFF
--- a/snapshots/devmapper/device_info.go
+++ b/snapshots/devmapper/device_info.go
@@ -56,6 +56,8 @@ const (
 	Removing
 	// Removed means that device successfully removed but not yet deleted from meta store
 	Removed
+	// Faulty means that the device is errored and the snapshotter failed to rollback it
+	Faulty
 )
 
 func (s DeviceState) String() string {
@@ -84,6 +86,8 @@ func (s DeviceState) String() string {
 		return "Removing"
 	case Removed:
 		return "Removed"
+	case Faulty:
+		return "Faulty"
 	default:
 		return fmt.Sprintf("unknown %d", s)
 	}

--- a/snapshots/devmapper/metadata.go
+++ b/snapshots/devmapper/metadata.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	bolt "go.etcd.io/bbolt"
 )
@@ -38,6 +39,7 @@ type deviceIDState byte
 const (
 	deviceFree deviceIDState = iota
 	deviceTaken
+	deviceFaulty
 )
 
 // Bucket names
@@ -92,11 +94,14 @@ func (m *PoolMetadata) ensureDatabaseInitialized() error {
 
 // AddDevice saves device info to database.
 func (m *PoolMetadata) AddDevice(ctx context.Context, info *DeviceInfo) error {
-	return m.db.Update(func(tx *bolt.Tx) error {
+	err := m.db.Update(func(tx *bolt.Tx) error {
 		devicesBucket := tx.Bucket(devicesBucketName)
 
-		// Make sure device name is unique
-		if err := getObject(devicesBucket, info.Name, nil); err == nil {
+		// Make sure device name is unique. If there is already a device with the same name,
+		// but in Faulty state, give it a try with another devmapper device ID.
+		// See https://github.com/containerd/containerd/pull/3436 for more context.
+		var existing DeviceInfo
+		if err := getObject(devicesBucket, info.Name, &existing); err == nil && existing.State != Faulty {
 			return ErrAlreadyExists
 		}
 
@@ -108,8 +113,37 @@ func (m *PoolMetadata) AddDevice(ctx context.Context, info *DeviceInfo) error {
 
 		info.DeviceID = deviceID
 
-		return putObject(devicesBucket, info.Name, info, false)
+		return putObject(devicesBucket, info.Name, info, true)
 	})
+
+	if err != nil {
+		return errors.Wrapf(err, "failed to save metadata for device %q (parent: %q)", info.Name, info.ParentName)
+	}
+
+	return nil
+}
+
+// MarkFaulty marks the given device and corresponding devmapper device ID as faulty.
+// The snapshotter might attempt to recreate a device in 'Faulty' state with another devmapper ID in
+// subsequent calls, and in case of success it's status will be changed to 'Created' or 'Activated'.
+// The devmapper dev ID will remain in 'deviceFaulty' state until manually handled by a user.
+func (m *PoolMetadata) MarkFaulty(ctx context.Context, info *DeviceInfo) error {
+	var result error
+
+	if err := m.UpdateDevice(ctx, info.Name, func(deviceInfo *DeviceInfo) error {
+		deviceInfo.State = Faulty
+		return nil
+	}); err != nil {
+		result = multierror.Append(result, err)
+	}
+
+	if err := m.db.Update(func(tx *bolt.Tx) error {
+		return markDeviceID(tx, info.DeviceID, deviceFaulty)
+	}); err != nil {
+		result = multierror.Append(result, err)
+	}
+
+	return result
 }
 
 // getNextDeviceID finds the next free device ID by taking a cursor

--- a/snapshots/devmapper/metadata_test.go
+++ b/snapshots/devmapper/metadata_test.go
@@ -162,7 +162,7 @@ func TestPoolMetadata_MarkFaulty(t *testing.T) {
 	err := store.AddDevice(testCtx, info)
 	assert.NilError(t, err)
 
-	err = store.MarkFaulty(testCtx, info)
+	err = store.MarkFaulty(testCtx, "test")
 	assert.NilError(t, err)
 
 	saved, err := store.GetDevice(testCtx, info.Name)

--- a/snapshots/devmapper/pool_device.go
+++ b/snapshots/devmapper/pool_device.go
@@ -132,7 +132,7 @@ func (p *PoolDevice) CreateThinDevice(ctx context.Context, deviceName string, vi
 			if delErr != nil {
 				// Failed to rollback, mark the device as faulty and keep metadata in order to
 				// preserve the faulty device ID
-				retErr = multierror.Append(retErr, delErr, p.metadata.MarkFaulty(ctx, info))
+				retErr = multierror.Append(retErr, delErr, p.metadata.MarkFaulty(ctx, info.Name))
 				return
 			}
 
@@ -147,7 +147,7 @@ func (p *PoolDevice) CreateThinDevice(ctx context.Context, deviceName string, vi
 
 		// We're unable to create the devmapper device, most likely something wrong with the deviceID
 		if devErr != nil {
-			retErr = multierror.Append(retErr, p.metadata.MarkFaulty(ctx, info))
+			retErr = multierror.Append(retErr, p.metadata.MarkFaulty(ctx, info.Name))
 			return
 		}
 	}()
@@ -223,7 +223,7 @@ func (p *PoolDevice) CreateSnapshotDevice(ctx context.Context, deviceName string
 			if delErr != nil {
 				// Failed to rollback, mark the device as faulty and keep metadata in order to
 				// preserve the faulty device ID
-				retErr = multierror.Append(retErr, delErr, p.metadata.MarkFaulty(ctx, snapInfo))
+				retErr = multierror.Append(retErr, delErr, p.metadata.MarkFaulty(ctx, snapInfo.Name))
 				return
 			}
 
@@ -238,7 +238,7 @@ func (p *PoolDevice) CreateSnapshotDevice(ctx context.Context, deviceName string
 
 		// We're unable to create the devmapper device, most likely something wrong with the deviceID
 		if devErr != nil {
-			retErr = multierror.Append(retErr, p.metadata.MarkFaulty(ctx, snapInfo))
+			retErr = multierror.Append(retErr, p.metadata.MarkFaulty(ctx, snapInfo.Name))
 			return
 		}
 	}()

--- a/snapshots/devmapper/pool_device.go
+++ b/snapshots/devmapper/pool_device.go
@@ -364,7 +364,7 @@ func (p *PoolDevice) RemoveDevice(ctx context.Context, deviceName string) error 
 		return errors.Wrapf(err, "can't query metadata for device %q", deviceName)
 	}
 
-	if err := p.DeactivateDevice(ctx, deviceName, true, true); err != nil {
+	if err := p.DeactivateDevice(ctx, deviceName, false, true); err != nil {
 		return err
 	}
 

--- a/snapshots/testsuite/testsuite.go
+++ b/snapshots/testsuite/testsuite.go
@@ -501,7 +501,6 @@ func checkRemoveIntermediateSnapshot(ctx context.Context, t *testing.T, snapshot
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer testutil.Unmount(t, base)
 
 	committedBase := filepath.Join(work, "committed-base")
 	if err = snapshotter.Commit(ctx, committedBase, base, opt); err != nil {
@@ -540,6 +539,7 @@ func checkRemoveIntermediateSnapshot(ctx context.Context, t *testing.T, snapshot
 	if err != nil {
 		t.Fatal(err)
 	}
+	testutil.Unmount(t, base)
 	err = snapshotter.Remove(ctx, committedBase)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This PR attempts to mitigate some cases described in https://github.com/containerd/containerd/pull/3436

It introduces faulty state for devices and devmapper device ID.

A device that is failed to create/activate and failed to rollback (delete back), will be marked as faulty in metadata store (instead of cleaning up the metadata and ending up in an inconsistent state). The snapshotter will try to recreate this device with a different devID in a subsequent call. This would allow us to move on and prevent the snapshotter to entirely stuck on a first faulty ID. 

A faulty device ID means that the snapshotter could not handle it (nor create nor rollback), and it needs manual handling. It'll be marked in metadata store and won't be reused by snapshotter until addressed and manually marked as ok.

@renzhengeek @jiazhiguang Could you please give it a try on your env.