### PR TITLE
Prevent push by tag for sub-manifests

### DIFF
--- a/client.go
+++ b/client.go
@@ -403,6 +403,11 @@ func (c *Client) Push(ctx context.Context, ref string, desc ocispec.Descriptor, 
 		}
 	}
 
+	// Annotate ref with digest to push only push tag for single digest
+	if !strings.Contains(ref, "@") {
+		ref = ref + "@" + desc.Digest.String()
+	}
+
 	pusher, err := pushCtx.Resolver.Pusher(ctx, ref)
 	if err != nil {
 		return err

--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -399,13 +399,6 @@ func (r *dockerResolver) Pusher(ctx context.Context, ref string) (remotes.Pusher
 		return nil, err
 	}
 
-	// Manifests can be pushed by digest like any other object, but the passed in
-	// reference cannot take a digest without the associated content. A tag is allowed
-	// and will be used to tag pushed manifests.
-	if refspec.Object != "" && strings.Contains(refspec.Object, "@") {
-		return nil, errors.New("cannot use digest reference for push locator")
-	}
-
 	base, err := r.base(refspec)
 	if err != nil {
 		return nil, err
@@ -413,7 +406,7 @@ func (r *dockerResolver) Pusher(ctx context.Context, ref string) (remotes.Pusher
 
 	return dockerPusher{
 		dockerBase: base,
-		tag:        refspec.Object,
+		object:     refspec.Object,
 		tracker:    r.tracker,
 	}, nil
 }


### PR DESCRIPTION
When pushing a manifest list, all manifests should be pushed by digest and only the final manifest pushed by tag. The Pusher was preventing this by mistakenly disallowing objects to contain a digest. When objects have a digest, only push tags associated with that digest.

Fixes #2639 