### PR TITLE
Add server option for MaxConnectionIdle

### DIFF
--- a/services/server/config/config.go
+++ b/services/server/config/config.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"strings"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/containerd/containerd/errdefs"
@@ -97,14 +98,15 @@ func (c *Config) ValidateV2() error {
 
 // GRPCConfig provides GRPC configuration for the socket
 type GRPCConfig struct {
-	Address        string `toml:"address"`
-	TCPAddress     string `toml:"tcp_address"`
-	TCPTLSCert     string `toml:"tcp_tls_cert"`
-	TCPTLSKey      string `toml:"tcp_tls_key"`
-	UID            int    `toml:"uid"`
-	GID            int    `toml:"gid"`
-	MaxRecvMsgSize int    `toml:"max_recv_message_size"`
-	MaxSendMsgSize int    `toml:"max_send_message_size"`
+	Address           string        `toml:"address"`
+	TCPAddress        string        `toml:"tcp_address"`
+	TCPTLSCert        string        `toml:"tcp_tls_cert"`
+	TCPTLSKey         string        `toml:"tcp_tls_key"`
+	UID               int           `toml:"uid"`
+	GID               int           `toml:"gid"`
+	MaxRecvMsgSize    int           `toml:"max_recv_message_size"`
+	MaxSendMsgSize    int           `toml:"max_send_message_size"`
+	MaxConnectionIdle time.Duration `toml:"max_connection_idle"`
 }
 
 // Debug provides debug configuration

--- a/services/server/server.go
+++ b/services/server/server.go
@@ -51,6 +51,7 @@ import (
 	bolt "go.etcd.io/bbolt"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 )
 
 // CreateTopLevelDirectories creates the top-level root and state directories.
@@ -89,6 +90,11 @@ func New(ctx context.Context, config *srvconfig.Config) (*Server, error) {
 	}
 	if config.GRPC.MaxSendMsgSize > 0 {
 		serverOpts = append(serverOpts, grpc.MaxSendMsgSize(config.GRPC.MaxSendMsgSize))
+	}
+	if config.GRPC.MaxConnectionIdle > 0 {
+		serverOpts = append(serverOpts, grpc.KeepaliveParams(keepalive.ServerParameters{
+			MaxConnectionIdle: config.GRPC.MaxConnectionIdle,
+		}))
 	}
 	ttrpcServer, err := newTTRPCServer()
 	if err != nil {


### PR DESCRIPTION
Seeing log lines of the form "rpc error: code = Unavailable desc = transport is closing" and it looks like this might fix it:
https://stackoverflow.com/questions/52993259/problem-with-grpc-setup-getting-an-intermittent-rpc-unavailable-error/54703234#54703234