### PR TITLE
Limit multiple platform manifests to one for size check

### DIFF
--- a/images/image.go
+++ b/images/image.go
@@ -119,7 +119,7 @@ func (image *Image) Size(ctx context.Context, provider content.Provider, platfor
 		}
 		size += desc.Size
 		return nil, nil
-	}), FilterPlatforms(ChildrenHandler(provider), platform)), image.Target)
+	}), LimitManifests(FilterPlatforms(ChildrenHandler(provider), platform), platform, 1)), image.Target)
 }
 
 type platformManifest struct {


### PR DESCRIPTION
client.Pull will only pull one matching platform by default.
When checking the size of image we match that behavior so that
we don't look for multiple platforms that might not exist on disk.

Fixes #3387 and #2991