### PR TITLE
Fix containerd on windows.

### DIFF
--- a/services/tasks/local_unix.go
+++ b/services/tasks/local_unix.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 /*
    Copyright The containerd Authors.
 

--- a/services/tasks/local_windows.go
+++ b/services/tasks/local_windows.go
@@ -1,4 +1,4 @@
-// +build ignore
+// +build windows
 
 /*
    Copyright The containerd Authors.
@@ -23,8 +23,6 @@ import (
 	"github.com/containerd/containerd/runtime"
 )
 
-// TODO: JTERRY75 - When Windows V1 runtime is removed change this to only build
-// on Windows.
 var tasksServiceRequires = []plugin.Type{
 	plugin.RuntimePluginV2,
 	plugin.MetadataPlugin,


### PR DESCRIPTION
Containerd on windows doesn't work now, because task service can't start because of the missing `io.containerd.runtime.v1`.

/cc @jterry75 

Signed-off-by: Lantao Liu <lantaol@google.com>