### PR TITLE
v2: Close ttrpc connection when Delete()

### DIFF
--- a/runtime/v2/shim.go
+++ b/runtime/v2/shim.go
@@ -221,6 +221,7 @@ func (s *shim) Delete(ctx context.Context) (*runtime.Exit, error) {
 	if err := s.waitShutdown(ctx); err != nil {
 		log.G(ctx).WithError(err).Error("failed to shutdown shim")
 	}
+	s.Close()
 	if err := s.bundle.Delete(); err != nil {
 		log.G(ctx).WithError(err).Error("failed to delete bundle")
 	}


### PR DESCRIPTION
This avoids potential socket leak when the connected v2 shim of runtime
serving multiple containers.

Signed-off-by: Li Yuxuan <liyuxuan04@baidu.com>