### PR TITLE
Limit default matrix to runc v2 runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ go:
   - "1.12.x"
 
 env:
-  - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v2 TRAVIS_CGO_ENABLED=1
 
 matrix:
@@ -23,6 +22,8 @@ matrix:
       env: TRAVIS_GOOS=darwin TRAVIS_CGO_ENABLED=0
     - os: linux
       env: TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runtime.v1.linux TRAVIS_CGO_ENABLED=1
+    - os: linux
+      env: TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1
 
 go_import_path: github.com/containerd/containerd
 


### PR DESCRIPTION
Explicitly add runc v1 runtime test on Linux.

Attempt at fixing slowness and flakiness from ppc64le before completely disabling.