### PR TITLE
Save default namespace in the client.

### DIFF
--- a/client.go
+++ b/client.go
@@ -89,7 +89,9 @@ func New(address string, opts ...ClientOpt) (*Client, error) {
 		copts.timeout = 10 * time.Second
 	}
 
-	c := &Client{}
+	c := &Client{
+		defaultns: copts.defaultns,
+	}
 
 	if copts.defaultRuntime != "" {
 		c.runtime = copts.defaultRuntime
@@ -142,9 +144,8 @@ func New(address string, opts ...ClientOpt) (*Client, error) {
 	}
 
 	// check namespace labels for default runtime
-	if copts.defaultRuntime == "" && copts.defaultns != "" {
-		ctx := namespaces.WithNamespace(context.Background(), copts.defaultns)
-		if label, err := c.GetLabel(ctx, defaults.DefaultRuntimeNSLabel); err != nil {
+	if copts.defaultRuntime == "" && c.defaultns != "" {
+		if label, err := c.GetLabel(context.Background(), defaults.DefaultRuntimeNSLabel); err != nil {
 			return nil, err
 		} else if label != "" {
 			c.runtime = label
@@ -164,14 +165,14 @@ func NewWithConn(conn *grpc.ClientConn, opts ...ClientOpt) (*Client, error) {
 		}
 	}
 	c := &Client{
-		conn:    conn,
-		runtime: fmt.Sprintf("%s.%s", plugin.RuntimePlugin, runtime.GOOS),
+		defaultns: copts.defaultns,
+		conn:      conn,
+		runtime:   fmt.Sprintf("%s.%s", plugin.RuntimePlugin, runtime.GOOS),
 	}
 
 	// check namespace labels for default runtime
-	if copts.defaultRuntime == "" && copts.defaultns != "" {
-		ctx := namespaces.WithNamespace(context.Background(), copts.defaultns)
-		if label, err := c.GetLabel(ctx, defaults.DefaultRuntimeNSLabel); err != nil {
+	if copts.defaultRuntime == "" && c.defaultns != "" {
+		if label, err := c.GetLabel(context.Background(), defaults.DefaultRuntimeNSLabel); err != nil {
 			return nil, err
 		} else if label != "" {
 			c.runtime = label
@@ -191,6 +192,7 @@ type Client struct {
 	connMu    sync.Mutex
 	conn      *grpc.ClientConn
 	runtime   string
+	defaultns string
 	connector func() (*grpc.ClientConn, error)
 }
 
@@ -497,7 +499,10 @@ func writeIndex(ctx context.Context, index *ocispec.Index, client *Client, ref s
 func (c *Client) GetLabel(ctx context.Context, label string) (string, error) {
 	ns, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {
-		return "", err
+		if c.defaultns == "" {
+			return "", err
+		}
+		ns = c.defaultns
 	}
 
 	srv := c.NamespaceService()


### PR DESCRIPTION
This is a regression introduced by https://github.com/containerd/containerd/issues/2285.

The CRI integration test [stops passing](https://github.com/containerd/cri/pull/1227) after upgrading containerd:
```
        Error Trace:    containerd_image_test.go:47
        Error:		Received unexpected error failed precondition
        	github.com/containerd/cri/vendor/github.com/containerd/containerd/errdefs.init.ializers
        		/usr/local/google/home/lantaol/workspace/src/github.com/containerd/cri/vendor/github.com/containerd/containerd/errdefs/errors.go:47
        	runtime.main
        		/usr/local/go/src/runtime/proc.go:188
        	runtime.goexit
        		/usr/local/go/src/runtime/asm_amd64.s:1337
        	namespace is required
        	github.com/containerd/cri/vendor/github.com/containerd/containerd/namespaces.NamespaceRequired
        		/usr/local/google/home/lantaol/workspace/src/github.com/containerd/cri/vendor/github.com/containerd/containerd/namespaces/context.go:71
        	github.com/containerd/cri/vendor/github.com/containerd/containerd.(*Client).GetLabel
        		/usr/local/google/home/lantaol/workspace/src/github.com/containerd/cri/vendor/github.com/containerd/containerd/client.go:492
        	github.com/containerd/cri/vendor/github.com/containerd/containerd.(*Client).resolveSnapshotterName
        		/usr/local/google/home/lantaol/workspace/src/github.com/containerd/cri/vendor/github.com/containerd/containerd/client.go:678
        	github.com/containerd/cri/vendor/github.com/containerd/containerd.(*image).Unpack
        		/usr/local/google/home/lantaol/workspace/src/github.com/containerd/cri/vendor/github.com/containerd/containerd/image.go:152
        	github.com/containerd/cri/vendor/github.com/containerd/containerd.(*Client).Pull
        		/usr/local/google/home/lantaol/workspace/src/github.com/containerd/cri/vendor/github.com/containerd/containerd/pull.go:72
        	github.com/containerd/cri/integration.TestContainerdImage
        		/usr/local/google/home/lantaol/workspace/src/github.com/containerd/cri/integration/containerd_image_test.go:46
        	testing.tRunner
        		/usr/local/go/src/testing/testing.go:865
        	runtime.goexit
        		/usr/local/go/src/runtime/asm_amd64.s:1337
        	failed to unpack image on snapshotter 
        	github.com/containerd/cri/vendor/github.com/containerd/containerd.(*Client).Pull
        		/usr/local/google/home/lantaol/workspace/src/github.com/containerd/cri/vendor/github.com/containerd/containerd/pull.go:73
        	github.com/containerd/cri/integration.TestContainerdImage
        		/usr/local/google/home/lantaol/workspace/src/github.com/containerd/cri/integration/containerd_image_test.go:46
        	testing.tRunner
        		/usr/local/go/src/testing/testing.go:865
        	runtime.goexit
        		/usr/local/go/src/runtime/asm_amd64.s:1337
```

Previously, only the server side requires namespace, so we can simply add namespace to the grpc interceptor.

However, `GetLabel` now requires namespace on the client side, `containerd.WithDefaultNamespace` doesn't work anymore.

This PR stores the default namespace in the client, so that when the namespace is required on the client side, we can default to it.

Signed-off-by: Lantao Liu <lantaol@google.com>