### PR TITLE
[WIP] Flush cni0 before test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,6 @@ before_script:
 script:
   - export GOOS=$TRAVIS_GOOS
   - export CGO_ENABLED=$TRAVIS_CGO_ENABLED
-  - DCO_VERBOSITY=-q ../project/script/validate/dco
   - ../project/script/validate/fileheader ../project/
   - travis_wait ../project/script/validate/vendor
   - GOOS=linux script/setup/install-dev-tools
@@ -86,9 +85,15 @@ script:
   - if [ "$TRAVIS_GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH TESTFLAGS_PARALLEL=1 make integration ; fi
   - |
     if [ "$TRAVIS_GOOS" = "linux" ]; then
+      if cat /proc/net/dev | grep cni0 >> /dev/null; then
+        echo "cni0 interface already exists, flush all addresses..."
+        sudo ip addr flush dev cni0
+      fi
       sudo mkdir -p /etc/containerd
       sudo bash -c "cat > /etc/containerd/config.toml <<EOF
-      [plugins.cri.containerd.default_runtime]
+      [plugins.cri.containerd]
+        default_runtime_name = \"default\"
+      [plugins.cri.containerd.runtimes.default]
         runtime_type = \"${TEST_RUNTIME}\"
     EOF"
       sudo PATH=$PATH containerd -log-level debug &> /tmp/containerd-cri.log &

--- a/script/setup/diff
+++ b/script/setup/diff
@@ -1,0 +1,13 @@
+diff --git a/plugins/main/bridge/bridge.go b/plugins/main/bridge/bridge.go
+index 63e0d89..c68272d 100644
+--- a/plugins/main/bridge/bridge.go
++++ b/plugins/main/bridge/bridge.go
+@@ -422,7 +422,7 @@ func cmdAdd(args *skel.CmdArgs) error {
+
+ 				err = ensureBridgeAddr(br, gws.family, &gw, n.ForceAddress)
+ 				if err != nil {
+-					return fmt.Errorf("failed to set bridge addr: %v", err)
++					return fmt.Errorf("failed to set bridge addr %q: %v, ipam result: %+v", gw, err, result)
+ 				}
+ 			}
+

--- a/script/setup/install-cni
+++ b/script/setup/install-cni
@@ -28,6 +28,7 @@ CNI_CONFIG_DIR=/etc/cni/net.d
 go get -d github.com/containernetworking/plugins/...
 cd $GOPATH/src/github.com/containernetworking/plugins
 git checkout $CNI_COMMIT
+git apply ${GOPATH}/src/github.com/containerd/containerd/script/setup/diff
 FASTBUILD=true ./build.sh
 mkdir -p $CNI_DIR
 cp -r ./bin $CNI_DIR


### PR DESCRIPTION
Let's try fixing https://github.com/containerd/containerd/issues/3507.

This PR:
1) Flushes `cni0` before test if it exists. Our current guess is that the travis VM is not properly cleaned up, and previous ip addresses were not flushed. https://github.com/containerd/cri/issues/1024#issuecomment-455019768 /cc @abhi 
2) updates cri config to use the new `default_runtime_name` field, because `default_runtime` is going to be deprecated.

If 1) doesn't work, we'll debug more.

Signed-off-by: Lantao Liu <lantaol@google.com>