### PR TITLE
Remove ppc64le from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,22 +8,15 @@ language: go
 
 os:
 - linux
-- linux-ppc64le
 
 go:
   - "1.12.x"
 
 env:
+  - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v2 TRAVIS_CGO_ENABLED=1
-
-matrix:
-  include:
-    - os: linux
-      env: TRAVIS_GOOS=darwin TRAVIS_CGO_ENABLED=0
-    - os: linux
-      env: TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runtime.v1.linux TRAVIS_CGO_ENABLED=1
-    - os: linux
-      env: TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1
+  - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runtime.v1.linux TRAVIS_CGO_ENABLED=1
+  - TRAVIS_GOOS=darwin TRAVIS_CGO_ENABLED=0
 
 go_import_path: github.com/containerd/containerd
 


### PR DESCRIPTION
The tests run too slow and flaky. Once the flakiness and speed are addressed we can re-enable after the next release. Currently this is slowing down our release process.
