### PR TITLE
bump go.etcd.io/bbolt v1.3.3

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -41,7 +41,7 @@ github.com/containerd/ttrpc 1fb3814edf44a76e0ccf503decf726d994919a9a
 github.com/syndtr/gocapability d98352740cb2c55f81556b63d4a1ec64c5a319c2
 gotest.tools v2.3.0
 github.com/google/go-cmp v0.2.0
-go.etcd.io/bbolt 2eb7227adea1d5cf85f0bc2a82b7059b13c2fa68
+go.etcd.io/bbolt v1.3.3
 
 # cri dependencies
 github.com/containerd/cri b213648c5bd0a1d2ee42709c10dff63fbfee3ad7 # master

--- a/vendor/go.etcd.io/bbolt/freelist.go
+++ b/vendor/go.etcd.io/bbolt/freelist.go
@@ -349,6 +349,28 @@ func (f *freelist) reload(p *page) {
 	f.readIDs(a)
 }
 
+// noSyncReload reads the freelist from pgids and filters out pending items.
+func (f *freelist) noSyncReload(pgids []pgid) {
+	// Build a cache of only pending pages.
+	pcache := make(map[pgid]bool)
+	for _, txp := range f.pending {
+		for _, pendingID := range txp.ids {
+			pcache[pendingID] = true
+		}
+	}
+
+	// Check each page in the freelist and build a new available freelist
+	// with any pages not in the pending lists.
+	var a []pgid
+	for _, id := range pgids {
+		if !pcache[id] {
+			a = append(a, id)
+		}
+	}
+
+	f.readIDs(a)
+}
+
 // reindex rebuilds the free cache based on available and pending free lists.
 func (f *freelist) reindex() {
 	ids := f.getFreePageIDs()


### PR DESCRIPTION
this brings the dependency back to a released version:

full diff: go.etcd.io/bbolt https://github.com/etcd-io/bbolt/compare/2eb7227adea1d5cf85f0bc2a82b7059b13c2fa68...v1.3.3
- etcd-io/bbolt#153 fix rollback panic bug
  - fixes etcd-io/bbolt#152 Panic (index out of range) on writeable tx rollback with db.NoFreelistSync
