### PR TITLE
AppVeyor: update to go 1.12.7

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.12.6
+    - GO_VERSION: 1.12.7
 
 before_build:
   - choco install -y mingw --version 5.3.0


### PR DESCRIPTION
Use the latest Go release for testing on AppVeyor

> go1.12.7 (released 2019/07/08) includes fixes to cgo, the compiler,
> and the linker. See the Go 1.12.7 milestone on our issue tracker for details:
> 
> https://github.com/golang/go/issues?q=milestone%3AGo1.12.7
