### PR TITLE
[release/1.2] cherry-pick: Move ctr run --isolation to Windows only

### DIFF
--- a/cmd/ctr/commands/run/run.go
+++ b/cmd/ctr/commands/run/run.go
@@ -106,11 +106,7 @@ var Command = cli.Command{
 			Name:  "fifo-dir",
 			Usage: "directory used for storing IO FIFOs",
 		},
-		cli.BoolFlag{
-			Name:  "isolated",
-			Usage: "run the container with vm isolation",
-		},
-	}, append(commands.SnapshotterFlags, commands.ContainerFlags...)...),
+	}, append(platformRunFlags, append(commands.SnapshotterFlags, commands.ContainerFlags...)...)...),
 	Action: func(context *cli.Context) error {
 		var (
 			err error

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -32,6 +32,8 @@ import (
 	"github.com/urfave/cli"
 )
 
+var platformRunFlags []cli.Flag
+
 // NewContainer creates a new container
 func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli.Context) (containerd.Container, error) {
 	var (

--- a/cmd/ctr/commands/run/run_windows.go
+++ b/cmd/ctr/commands/run/run_windows.go
@@ -29,6 +29,13 @@ import (
 	"github.com/urfave/cli"
 )
 
+var platformRunFlags = []cli.Flag{
+	cli.BoolFlag{
+		Name:  "isolated",
+		Usage: "run the container with vm isolation",
+	},
+}
+
 // NewContainer creates a new container
 func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli.Context) (containerd.Container, error) {
 	var (


### PR DESCRIPTION
Cherry-pick #2828 since it is effectively a bug-fix as there is no use of the flag on non-Windows.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>