### PR TITLE
[release/1.2 backport] update to go 1.12.8 (CVE-2019-9512, CVE-2019-9514)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.12.6
+    - GO_VERSION: 1.12.7
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.12.7
+    - GO_VERSION: 1.12.8
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,20 +6,22 @@
 # 3.) $ make binaries install test
 #
 
+ARG GOLANG_VERSION=1.11
+
 # Install proto3
-FROM golang:1.11 AS proto3
+FROM golang:${GOLANG_VERSION} AS proto3
 RUN apt-get update && apt-get install -y autoconf automake g++ libtool unzip
 COPY script/setup/install-protobuf install-protobuf
 RUN ./install-protobuf
 
 # Install runc
-FROM golang:1.11 AS runc
+FROM golang:${GOLANG_VERSION} AS runc
 RUN apt-get update && apt-get install -y curl libseccomp-dev
 COPY vendor.conf /go/src/github.com/containerd/containerd/vendor.conf
 COPY script/setup/install-runc install-runc
 RUN ./install-runc
 
-FROM golang:1.11
+FROM golang:${GOLANG_VERSION} AS dev
 RUN apt-get update && apt-get install -y btrfs-tools gcc git libseccomp-dev make xfsprogs
 
 COPY --from=proto3 /usr/local/bin/protoc /usr/local/bin/protoc

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -8,8 +8,12 @@
 
 ARG GOLANG_VERSION=1.11
 
+FROM golang:${GOLANG_VERSION} AS golang-base
+RUN mkdir -p /go/src/github.com/containerd/containerd
+WORKDIR /go/src/github.com/containerd/containerd
+
 # Install proto3
-FROM golang:${GOLANG_VERSION} AS proto3
+FROM golang-base AS proto3
 RUN apt-get update && apt-get install -y \
    autoconf \
    automake \
@@ -22,17 +26,17 @@ COPY script/setup/install-protobuf install-protobuf
 RUN ./install-protobuf
 
 # Install runc
-FROM golang:${GOLANG_VERSION} AS runc
+FROM golang-base AS runc
 RUN apt-get update && apt-get install -y \
     curl \
     libseccomp-dev \
   --no-install-recommends
 
-COPY vendor.conf /go/src/github.com/containerd/containerd/vendor.conf
+COPY vendor.conf vendor.conf
 COPY script/setup/install-runc install-runc
 RUN ./install-runc
 
-FROM golang:${GOLANG_VERSION} AS dev
+FROM golang-base AS dev
 RUN apt-get update && apt-get install -y \
     btrfs-tools \
     gcc \
@@ -46,6 +50,4 @@ COPY --from=proto3 /usr/local/bin/protoc     /usr/local/bin/protoc
 COPY --from=proto3 /usr/local/include/google /usr/local/include/google
 COPY --from=runc   /usr/local/sbin/runc      /usr/local/go/bin/runc
 
-COPY . /go/src/github.com/containerd/containerd
-
-WORKDIR /go/src/github.com/containerd/containerd
+COPY . .

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.11
+ARG GOLANG_VERSION=1.12
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -10,24 +10,42 @@ ARG GOLANG_VERSION=1.11
 
 # Install proto3
 FROM golang:${GOLANG_VERSION} AS proto3
-RUN apt-get update && apt-get install -y autoconf automake g++ libtool unzip
+RUN apt-get update && apt-get install -y \
+   autoconf \
+   automake \
+   g++ \
+   libtool \
+   unzip \
+ --no-install-recommends
+
 COPY script/setup/install-protobuf install-protobuf
 RUN ./install-protobuf
 
 # Install runc
 FROM golang:${GOLANG_VERSION} AS runc
-RUN apt-get update && apt-get install -y curl libseccomp-dev
+RUN apt-get update && apt-get install -y \
+    curl \
+    libseccomp-dev \
+  --no-install-recommends
+
 COPY vendor.conf /go/src/github.com/containerd/containerd/vendor.conf
 COPY script/setup/install-runc install-runc
 RUN ./install-runc
 
 FROM golang:${GOLANG_VERSION} AS dev
-RUN apt-get update && apt-get install -y btrfs-tools gcc git libseccomp-dev make xfsprogs
+RUN apt-get update && apt-get install -y \
+    btrfs-tools \
+    gcc \
+    git \
+    libseccomp-dev \
+    make \
+    xfsprogs \
+  --no-install-recommends
 
-COPY --from=proto3 /usr/local/bin/protoc /usr/local/bin/protoc
+COPY --from=proto3 /usr/local/bin/protoc     /usr/local/bin/protoc
 COPY --from=proto3 /usr/local/include/google /usr/local/include/google
+COPY --from=runc   /usr/local/sbin/runc      /usr/local/go/bin/runc
 
-COPY --from=runc /usr/local/sbin/runc /usr/local/go/bin/runc
 COPY . /go/src/github.com/containerd/containerd
 
 WORKDIR /go/src/github.com/containerd/containerd


### PR DESCRIPTION
backports of:

- https://github.com/containerd/containerd/pull/3185 Update contrib/Dockerfile.test 
- https://github.com/containerd/containerd/pull/3523 AppVeyor: update to go 1.12.7
- https://github.com/containerd/containerd/pull/3531 AppVeyor: update to go 1.12.8 (CVE-2019-9512, CVE-2019-9514)