### PR TITLE
[release/1.2] Update cri to d928a4dd337fd2a992dbe72380eff2063c3ec62f.

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -43,7 +43,7 @@ github.com/google/go-cmp v0.1.0
 go.etcd.io/bbolt v1.3.1-etcd.8
 
 # cri dependencies
-github.com/containerd/cri 49ca74043390bc2eeea7a45a46005fbec58a3f88 # release/1.2 branch
+github.com/containerd/cri d928a4dd337fd2a992dbe72380eff2063c3ec62f # release/1.2 branch
 github.com/containerd/go-cni 40bcf8ec8acd7372be1d77031d585d5d8e561c90
 github.com/blang/semver v3.1.0
 github.com/containernetworking/cni v0.6.0

--- a/vendor/github.com/containerd/cri/pkg/config/config.go
+++ b/vendor/github.com/containerd/cri/pkg/config/config.go
@@ -142,6 +142,9 @@ type PluginConfig struct {
 	// Log line longer than the limit will be split into multiple lines. Non-positive
 	// value means no limit.
 	MaxContainerLogLineSize int `toml:"max_container_log_line_size" json:"maxContainerLogSize"`
+	// DisableProcMount disables Kubernetes ProcMount support. This MUST be set to `true`
+	// when using containerd with Kubernetes <=1.11.
+	DisableProcMount bool `toml:"disable_proc_mount" json:"disableProcMount"`
 }
 
 // X509KeyPairStreaming contains the x509 configuration for streaming
@@ -203,6 +206,7 @@ func DefaultConfig() PluginConfig {
 				},
 			},
 		},
+		DisableProcMount: false,
 	}
 }
 

--- a/vendor/github.com/containerd/cri/pkg/server/container_create.go
+++ b/vendor/github.com/containerd/cri/pkg/server/container_create.go
@@ -118,6 +118,10 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to resolve image %q", config.GetImage().GetImage())
 	}
+	containerdImage, err := c.toContainerdImage(ctx, image)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get image from containerd %q", image.ID)
+	}
 
 	// Run container using the same runtime with sandbox.
 	sandboxInfo, err := sandbox.Container.Info(ctx)
@@ -176,7 +180,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 		// the runtime (runc) a chance to modify (e.g. to create mount
 		// points corresponding to spec.Mounts) before making the
 		// rootfs readonly (requested by spec.Root.Readonly).
-		customopts.WithNewSnapshot(id, image.Image),
+		customopts.WithNewSnapshot(id, containerdImage),
 	}
 
 	if len(volumeMounts) > 0 {
@@ -365,18 +369,16 @@ func (c *criService) generateContainerSpec(id string, sandboxID string, sandboxP
 		return nil, errors.Wrapf(err, "failed to set OCI bind mounts %+v", mounts)
 	}
 
-	// Apply masked paths if specified.
-	// When `MaskedPaths` is not specified, keep runtime default for backward compatibility;
-	// When `MaskedPaths` is specified, but length is zero, clear masked path list.
-	if securityContext.GetMaskedPaths() != nil {
+	if !c.config.DisableProcMount {
+		// Apply masked paths if specified.
+		// Note: If the container is privileged, then we clear any masked paths later on in the call to setOCIPrivileged()
 		g.Config.Linux.MaskedPaths = nil
 		for _, path := range securityContext.GetMaskedPaths() {
 			g.AddLinuxMaskedPaths(path)
 		}
-	}
 
-	// Apply readonly paths if specified.
-	if securityContext.GetReadonlyPaths() != nil {
+		// Apply readonly paths if specified.
+		// Note: If the container is privileged, then we clear any readonly paths later on in the call to setOCIPrivileged()
 		g.Config.Linux.ReadonlyPaths = nil
 		for _, path := range securityContext.GetReadonlyPaths() {
 			g.AddLinuxReadonlyPaths(path)

--- a/vendor/github.com/containerd/cri/pkg/server/helpers.go
+++ b/vendor/github.com/containerd/cri/pkg/server/helpers.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
+	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/runtime/linux/runctypes"
 	runcoptions "github.com/containerd/containerd/runtime/v2/runc/options"
@@ -283,6 +284,15 @@ func (c *criService) localResolve(refOrID string) (imagestore.Image, error) {
 		imageID = refOrID
 	}
 	return c.imageStore.Get(imageID)
+}
+
+// toContainerdImage converts an image object in image store to containerd image handler.
+func (c *criService) toContainerdImage(ctx context.Context, image imagestore.Image) (containerd.Image, error) {
+	// image should always have at least one reference.
+	if len(image.References) == 0 {
+		return nil, errors.Errorf("invalid image with no reference %q", image.ID)
+	}
+	return c.client.GetImage(ctx, image.References[0])
 }
 
 // getUserFromImage gets uid or user name of the image user.

--- a/vendor/github.com/containerd/cri/pkg/server/sandbox_run.go
+++ b/vendor/github.com/containerd/cri/pkg/server/sandbox_run.go
@@ -91,6 +91,11 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get sandbox image %q", c.config.SandboxImage)
 	}
+	containerdImage, err := c.toContainerdImage(ctx, *image)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get image from containerd %q", image.ID)
+	}
+
 	securityContext := config.GetLinux().GetSecurityContext()
 	//Create Network Namespace if it is not in host network
 	hostNet := securityContext.GetNamespaceOptions().GetNetwork() == runtime.NamespaceMode_NODE
@@ -179,7 +184,7 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	}
 	opts := []containerd.NewContainerOpts{
 		containerd.WithSnapshotter(c.config.ContainerdConfig.Snapshotter),
-		customopts.WithNewSnapshot(id, image.Image),
+		customopts.WithNewSnapshot(id, containerdImage),
 		containerd.WithSpec(spec, specOpts...),
 		containerd.WithContainerLabels(sandboxLabels),
 		containerd.WithContainerExtension(sandboxMetadataExtension, &sandbox.Metadata),

--- a/vendor/github.com/containerd/cri/pkg/store/image/image.go
+++ b/vendor/github.com/containerd/cri/pkg/store/image/image.go
@@ -47,8 +47,6 @@ type Image struct {
 	Size int64
 	// ImageSpec is the oci image structure which describes basic information about the image.
 	ImageSpec imagespec.Image
-	// Containerd image reference
-	Image containerd.Image
 }
 
 // Store stores all images.
@@ -152,7 +150,6 @@ func getImage(ctx context.Context, i containerd.Image) (*Image, error) {
 		ChainID:    chainID.String(),
 		Size:       size,
 		ImageSpec:  ociimage,
-		Image:      i,
 	}, nil
 }
 

--- a/vendor/github.com/containerd/cri/vendor.conf
+++ b/vendor/github.com/containerd/cri/vendor.conf
@@ -49,7 +49,7 @@ github.com/prometheus/client_golang f4fb1b73fb099f396a7f0036bf86aa8def4ed823
 github.com/prometheus/client_model 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
 github.com/prometheus/common 89604d197083d4781071d3c65855d24ecfb0a563
 github.com/prometheus/procfs cb4147076ac75738c9a7d279075a253c0cc5acbd
-github.com/seccomp/libseccomp-golang 32f571b70023028bd57d9288c20efbcb237f3ce0
+github.com/seccomp/libseccomp-golang v0.9.1
 github.com/sirupsen/logrus v1.0.0
 github.com/stretchr/testify v1.1.4
 github.com/syndtr/gocapability db04d3cc01c8b54962a58ec7e491717d06cfcc16


### PR DESCRIPTION
* CRI: Fix a bug that if an image is deleted immediately after being pulled, the image may still exist after the deletion finishes successfully. (https://github.com/containerd/cri/issues/1161)
* CRI: Updated libseccomp-golang to v0.9.1. ***NOTE: The minimum requirement of libseccomp is bumped to 2.3.0.*** (https://github.com/containerd/cri/pull/1191)
* CRI: Fix a bug that `runc` and `crictl` binaries shipped in https://storage.googleapis.com/cri-containerd-release are versioned with the containerd version. (https://github.com/containerd/cri/pull/1193)
* CRI: Fix a bug that the images become unusable if 2 images have the same image ID and RepoTag, but different RepoDigests. (https://github.com/containerd/containerd/issues/3401)
* CRI: Fix [ProcMount](https://stupefied-goodall-e282f7.netlify.com/contributors/design-proposals/auth/proc-mount-type/) support (https://github.com/containerd/cri/pull/1216). ***NOTE: To use containerd 1.2.8+ with Kubernetes 1.11 or below, you MUST set `disable_proc_mount=true` in the cri plugin config.*** (https://github.com/containerd/cri/issues/1208)
* CRI: Fix a bug that containerd tries to connect image registry with `https` even if the `http` endpoint is configured. (https://github.com/containerd/cri/issues/1201)

Signed-off-by: Lantao Liu <lantaol@google.com>