### PR TITLE
AppVeyor: update to go 1.12.9

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.12.8
+    - GO_VERSION: 1.12.9
 
 before_build:
   - choco install -y mingw --version 5.3.0


### PR DESCRIPTION
Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>

go1.12.9 (released 2019/08/15) includes fixes to the linker,
and the <code>os</code> and <code>math/big</code> packages.
See the <a href="https://github.com/golang/go/issues?q=milestone%3AGo1.12.9+label%3ACherryPickApproved">Go
1.12.9 milestone</a> on our issue tracker for details.

Full diff https://github.com/golang/go/compare/go1.12.8...go1.12.9

Going ahead and filing this.  Follow #3531