### PR TITLE
bugfix: override image.Env with process.Env, rather than be contrary

### DIFF
--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -326,7 +326,7 @@ func WithImageConfigArgs(image Image, args []string) SpecOpts {
 
 		setProcess(s)
 		if s.Linux != nil {
-			s.Process.Env = replaceOrAppendEnvValues(s.Process.Env, config.Env)
+			s.Process.Env = replaceOrAppendEnvValues(config.Env, s.Process.Env)
 			cmd := config.Cmd
 			if len(args) > 0 {
 				cmd = args
@@ -348,7 +348,7 @@ func WithImageConfigArgs(image Image, args []string) SpecOpts {
 			// even if there is no specified user in the image config
 			return WithAdditionalGIDs("root")(ctx, client, c, s)
 		} else if s.Windows != nil {
-			s.Process.Env = replaceOrAppendEnvValues(s.Process.Env, config.Env)
+			s.Process.Env = replaceOrAppendEnvValues(config.Env, s.Process.Env)
 			cmd := config.Cmd
 			if len(args) > 0 {
 				cmd = args

--- a/oci/spec_opts_test.go
+++ b/oci/spec_opts_test.go
@@ -406,7 +406,7 @@ func TestWithImageConfigArgs(t *testing.T) {
 		WithImageConfigArgs(img, []string{"--boo", "bar"}),
 	}
 
-	expectedEnv := []string{"x=foo", "y=baz", "z=bar"}
+	expectedEnv := []string{"z=bar", "y=boo", "x=foo"}
 	expectedArgs := []string{"create", "--namespace=test", "--boo", "bar"}
 
 	for _, opt := range opts {


### PR DESCRIPTION
the Env in image should be default value, it should has override by the Env in process. otherwise the Env in image is immutable,  setting the Env in process will be meaningless


