### PR TITLE
[release/1.2 backport] AppVeyor: update to go 1.12.9

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.12.8
+    - GO_VERSION: 1.12.9
 
 before_build:
   - choco install -y mingw --version 5.3.0


### PR DESCRIPTION
backport of https://github.com/containerd/containerd/pull/3541

(cherry picked from commit 7682acb9e7c97a1d8d2b0a56f61801dbfe1a1518)

Addresses https://github.com/containerd/containerd/issues/3481, https://github.com/golang/go/issues/33405
