### PR TITLE
Remove the process default ENV

### DIFF
--- a/oci/spec.go
+++ b/oci/spec.go
@@ -141,7 +141,6 @@ func populateDefaultUnixSpec(ctx context.Context, s *Spec, id string) error {
 			Path: defaultRootfsPath,
 		},
 		Process: &specs.Process{
-			Env:             defaultUnixEnv,
 			Cwd:             "/",
 			NoNewPrivileges: true,
 			User: specs.User{

--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -151,6 +151,13 @@ func WithEnv(environmentVariables []string) SpecOpts {
 	}
 }
 
+// WithDefaultPathEnv sets the $PATH environment variable to the
+// default PATH defined in this package.
+func WithDefaultPathEnv(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
+	s.Process.Env = replaceOrAppendEnvValues(s.Process.Env, defaultUnixEnv)
+	return nil
+}
+
 // replaceOrAppendEnvValues returns the defaults with the overrides either
 // replaced by env key or appended to the list
 func replaceOrAppendEnvValues(defaults, overrides []string) []string {


### PR DESCRIPTION
With the change in #3542 it breaks $PATH handling for images becuase our
default spec always sets a PATH on the process's .Env.

This removes the default and adds an Opt to add this back.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>