### PR TITLE
Change bufferSize back to 32

### DIFF
--- a/sys/reaper/reaper_unix.go
+++ b/sys/reaper/reaper_unix.go
@@ -31,7 +31,7 @@ import (
 // ErrNoSuchProcess is returned when the process no longer exists
 var ErrNoSuchProcess = errors.New("no such process")
 
-const bufferSize = 2048
+const bufferSize = 32
 
 type subscriber struct {
 	sync.Mutex


### PR DESCRIPTION
Shim use non-blocking send now, there is no need to set bufferSize to 2048,
it's a waste.

link to https://github.com/containerd/containerd/pull/3540

Signed-off-by: Shukui Yang <keloyangsk@gmail.com>