### PR TITLE
Update 1.3 release notes and mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -9,6 +9,7 @@ Carlos Eduardo <me@carlosedp.com> CarlosEDP <me@carlosedp.com>
 Eric Ren <renzhen.rz@alibaba-linux.com> renzhen.rz <renzhen.rz@alibaba-inc.com>
 Frank Yang <yyb196@gmail.com> frank yang <yyb196@gmail.com>
 Georgia Panoutsakopoulou <gpanoutsak@gmail.com> gpanouts <gpanoutsak@gmail.com>
+Guangming Wang <guangming.wang@daocloud.io> ethan <guangming.wang@daocloud.io>
 Haiyan Meng <haiyanmeng@google.com> haiyanmeng <haiyanmeng@google.com>
 Jian Liao <jliao@alauda.io> liaojian <liaojian@Dabllo.local>
 Jian Liao <jliao@alauda.io> liaoj <jliao@alauda.io>

--- a/releases/v1.3.0-rc.toml
+++ b/releases/v1.3.0-rc.toml
@@ -21,8 +21,9 @@ API. For clients, there are many new features and improvements completely
 implemented in the client libraries without requiring daemon upgrade.
 
 ### Runtime
-* **New Windows V2 runtime using [hcsshim](https://github.com/microsoft/hcsshim/tree/master/cmd/containerd-shim-runhcs-v1)**
+* **New Windows V2 runtime using shim API.** Adds support for the Windows runtime shims in containerd. *NOTE: while containerd's runtime is stable in this release, running Windows containers are not yet fully supported until the [runhcs shim](https://github.com/microsoft/hcsshim/tree/master/cmd/containerd-shim-runhcs-v1) is fully supported.*
 * **Improvements to ttrpc.** For better daemon to shim communication (https://github.com/containerd/containerd/pull/3341)
+* **Removed experimental Windows V1 runtime**
 
 ### Snapshots
 * **New Devmapper snapshotter** (https://github.com/containerd/containerd/pull/3022)


### PR DESCRIPTION
The beta period has ended, start preparing rc release notes.

Updated note about Windows runtime, please advice here on what our messaging should be (ping @jterry75). As far as I understand it, we will accept backports to 1.3 related to the Windows runtime , which is our criteria for support.