### PR TITLE
runtime/opts: move WithNamespaceCgroupDeletion from containerd to its own package

### DIFF
--- a/cmd/ctr/commands/namespaces/namespaces_linux.go
+++ b/cmd/ctr/commands/namespaces/namespaces_linux.go
@@ -17,15 +17,15 @@
 package namespaces
 
 import (
-	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/runtime/opts"
 	"github.com/urfave/cli"
 )
 
 func deleteOpts(context *cli.Context) []namespaces.DeleteOpts {
-	var opts []namespaces.DeleteOpts
+	var delOpts []namespaces.DeleteOpts
 	if context.Bool("cgroup") {
-		opts = append(opts, containerd.WithNamespaceCgroupDeletion)
+		delOpts = append(delOpts, opts.WithNamespaceCgroupDeletion)
 	}
-	return opts
+	return delOpts
 }

--- a/runtime/opts/opts_linux.go
+++ b/runtime/opts/opts_linux.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package containerd
+package opts
 
 import (
 	"context"


### PR DESCRIPTION
The cgroup dependency brings in quite a lot only for WithNamespaceCgroupDeletion, which is a namespaces.DeleteOpt.

Signed-off-by: Tibor Vass <tibor@docker.com>