### PR TITLE
devmapper: activate dm device if snap device marked as activated

### DIFF
--- a/snapshots/devmapper/pool_device_test.go
+++ b/snapshots/devmapper/pool_device_test.go
@@ -161,7 +161,9 @@ func TestPoolDeviceMarkFaulty(t *testing.T) {
 	err := store.AddDevice(testCtx, &DeviceInfo{Name: "1", State: Unknown})
 	assert.NilError(t, err)
 
-	err = store.AddDevice(testCtx, &DeviceInfo{Name: "2", State: Activated})
+	// Note: do not use 'Activated' here because pool.ensureDeviceStates() will
+	// try to activate the real dm device, which will fail on a faked device.
+	err = store.AddDevice(testCtx, &DeviceInfo{Name: "2", State: Deactivated})
 	assert.NilError(t, err)
 
 	pool := &PoolDevice{metadata: store}
@@ -177,7 +179,7 @@ func TestPoolDeviceMarkFaulty(t *testing.T) {
 			assert.Equal(t, Faulty, info.State)
 			assert.Equal(t, "1", info.Name)
 		case 2:
-			assert.Equal(t, Activated, info.State)
+			assert.Equal(t, Deactivated, info.State)
 			assert.Equal(t, "2", info.Name)
 		default:
 			t.Error("unexpected walk call")


### PR DESCRIPTION
- reproducer
 1. stop a container;
 2. reboot, or dmsetup remove its corresponding dm device;
 3. start the container, it will fail like:

 """
 Error: failed to start containers: {"message":"failed to create container(4f33d2760760c41518a84821153ccdf7f80980b797b783cdd75178fc6ca0bf4b) on containerd: failed to create task for container(4f33d2760760c41518a84821153ccdf7f80980b797b783cdd75178fc6ca0bf4b): failed to mount rootfs component &{ext4 /dev/mapper/vg0-mythinpool-snap-2 []}: no such file or directory: unknown"}
 """
- how the fix works
 activate the dm device if necessary, and give a warn msg:

 """
 time="2019-08-21T22:44:08.422695797+08:00" level=warning msg="devmapper device \"vg0-mythinpool-snap-2\" marked as \"Activated\" but not active, activating it"
 """

Signed-off-by: Eric Ren <renzhen@linux.alibaba.com>