### PR TITLE
Pass ttrpc address to shim via env

### DIFF
--- a/runtime/v2/runc/v1/service.go
+++ b/runtime/v2/runc/v1/service.go
@@ -119,7 +119,6 @@ func newCommand(ctx context.Context, id, containerdBinary, containerdAddress, co
 		"-namespace", ns,
 		"-id", id,
 		"-address", containerdAddress,
-		"-ttrpc-address", containerdTTRPCAddress,
 	}
 	cmd := exec.Command(self, args...)
 	cmd.Dir = cwd

--- a/runtime/v2/runc/v2/service.go
+++ b/runtime/v2/runc/v2/service.go
@@ -135,7 +135,6 @@ func newCommand(ctx context.Context, id, containerdBinary, containerdAddress, co
 		"-namespace", ns,
 		"-id", id,
 		"-address", containerdAddress,
-		"-ttrpc-address", containerdTTRPCAddress,
 	}
 	cmd := exec.Command(self, args...)
 	cmd.Dir = cwd

--- a/runtime/v2/shim/shim.go
+++ b/runtime/v2/shim/shim.go
@@ -89,9 +89,12 @@ var (
 	socketFlag           string
 	bundlePath           string
 	addressFlag          string
-	ttrpcAddressFlag     string
 	containerdBinaryFlag string
 	action               string
+)
+
+const (
+	ttrpcAddressEnv = "TTRPC_ADDRESS"
 )
 
 func parseFlags() {
@@ -102,7 +105,6 @@ func parseFlags() {
 	flag.StringVar(&bundlePath, "bundle", "", "path to the bundle if not workdir")
 
 	flag.StringVar(&addressFlag, "address", "", "grpc address back to main containerd")
-	flag.StringVar(&ttrpcAddressFlag, "ttrpc-address", "", "ttrpc address back to main containerd")
 	flag.StringVar(&containerdBinaryFlag, "publish-binary", "containerd", "path to publish binary (used for publishing events)")
 
 	flag.Parse()
@@ -165,7 +167,9 @@ func run(id string, initFunc Init, config Config) error {
 		}
 	}
 
-	publisher, err := newPublisher(ttrpcAddressFlag)
+	ttrpcAddress := os.Getenv(ttrpcAddressEnv)
+
+	publisher, err := newPublisher(ttrpcAddress)
 	if err != nil {
 		return err
 	}
@@ -204,7 +208,7 @@ func run(id string, initFunc Init, config Config) error {
 		}
 		return nil
 	case "start":
-		address, err := service.StartShim(ctx, idFlag, containerdBinaryFlag, addressFlag, ttrpcAddressFlag)
+		address, err := service.StartShim(ctx, idFlag, containerdBinaryFlag, addressFlag, ttrpcAddress)
 		if err != nil {
 			return err
 		}

--- a/runtime/v2/shim/util.go
+++ b/runtime/v2/shim/util.go
@@ -50,7 +50,6 @@ func Command(ctx context.Context, runtime, containerdAddress, containerdTTRPCAdd
 	args := []string{
 		"-namespace", ns,
 		"-address", containerdAddress,
-		"-ttrpc-address", containerdTTRPCAddress,
 		"-publish-binary", self,
 	}
 	args = append(args, cmdArgs...)
@@ -96,7 +95,11 @@ func Command(ctx context.Context, runtime, containerdAddress, containerdTTRPCAdd
 
 	cmd := exec.Command(cmdPath, args...)
 	cmd.Dir = path
-	cmd.Env = append(os.Environ(), "GOMAXPROCS=2")
+	cmd.Env = append(
+		os.Environ(),
+		"GOMAXPROCS=2",
+		fmt.Sprintf("%s=%s", ttrpcAddressEnv, containerdTTRPCAddress),
+	)
 	cmd.SysProcAttr = getSysProcAttr()
 	if opts != nil {
 		d, err := proto.Marshal(opts)


### PR DESCRIPTION
Because of the way go handles flags, passing a flag that is not defined
will cause an error. In our case, if we kept this as a flag, then
third-party shims would break when they see this new flag.  To fix this,
I moved this new configuration option to an env var.  We should use env
vars from here on out to avoid breaking shim compat.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>