### PR TITLE
update the max if cur will be greater than max for setting the limit

### DIFF
--- a/cmd/containerd-stress/rlimit_unix.go
+++ b/cmd/containerd-stress/rlimit_unix.go
@@ -31,6 +31,9 @@ func setRlimit() error {
 		}
 		if limit.Cur < rlimit {
 			limit.Cur = rlimit
+			if limit.Max < limit.Cur {
+				limit.Max = limit.Cur
+			}
 			if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
 				return err
 			}


### PR DESCRIPTION
When we ran the containerd-stress command, we met that 
```
panic: invalid argument

goroutine 1 [running]:
main.init.0()
	/home/fesu/go/src/github.com/containerd/containerd/cmd/containerd-stress/main.go:59 +0x4aa
```
In our os, the value of nofile is 
```
RESOURCE   DESCRIPTION                             SOFT      HARD UNITS
NOFILE     max number of open files                1024      4096
```
It will cause EINVAL error if we set soft value is 100000 and keep the hard value is 4096