### PR TITLE
Bump hashicorp deps

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -44,7 +44,7 @@ github.com/google/go-cmp v0.2.0
 go.etcd.io/bbolt v1.3.3
 github.com/hashicorp/errwrap v1.0.0
 github.com/hashicorp/go-multierror v1.0.0
-github.com/hashicorp/golang-lru v0.5.1
+github.com/hashicorp/golang-lru v0.5.3
 go.opencensus.io v0.22.0
 
 # cri dependencies

--- a/vendor.conf
+++ b/vendor.conf
@@ -43,7 +43,7 @@ gotest.tools v2.3.0
 github.com/google/go-cmp v0.2.0
 go.etcd.io/bbolt v1.3.3
 github.com/hashicorp/errwrap v1.0.0
-github.com/hashicorp/go-multierror ed905158d87462226a13fe39ddf685ea65f1c11f
+github.com/hashicorp/go-multierror v1.0.0
 github.com/hashicorp/golang-lru v0.5.1
 go.opencensus.io v0.22.0
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -42,7 +42,7 @@ github.com/syndtr/gocapability d98352740cb2c55f81556b63d4a1ec64c5a319c2
 gotest.tools v2.3.0
 github.com/google/go-cmp v0.2.0
 go.etcd.io/bbolt v1.3.3
-github.com/hashicorp/errwrap 7554cd9344cec97297fa6649b055a8c98c2a1e55
+github.com/hashicorp/errwrap v1.0.0
 github.com/hashicorp/go-multierror ed905158d87462226a13fe39ddf685ea65f1c11f
 github.com/hashicorp/golang-lru v0.5.1
 go.opencensus.io v0.22.0

--- a/vendor/github.com/hashicorp/errwrap/README.md
+++ b/vendor/github.com/hashicorp/errwrap/README.md
@@ -48,7 +48,7 @@ func main() {
 	// We can use the Contains helpers to check if an error contains
 	// another error. It is safe to do this with a nil error, or with
 	// an error that doesn't even use the errwrap package.
-	if errwrap.Contains(err, ErrNotExist) {
+	if errwrap.Contains(err, "does not exist") {
 		// Do something
 	}
 	if errwrap.ContainsType(err, new(os.PathError)) {

--- a/vendor/github.com/hashicorp/errwrap/go.mod
+++ b/vendor/github.com/hashicorp/errwrap/go.mod
@@ -1,0 +1,1 @@
+module github.com/hashicorp/errwrap

--- a/vendor/github.com/hashicorp/go-multierror/format.go
+++ b/vendor/github.com/hashicorp/go-multierror/format.go
@@ -13,7 +13,7 @@ type ErrorFormatFunc func([]error) string
 // that occurred along with a bullet point list of the errors.
 func ListFormatFunc(es []error) string {
 	if len(es) == 1 {
-		return fmt.Sprintf("1 error occurred:\n\n* %s", es[0])
+		return fmt.Sprintf("1 error occurred:\n\t* %s\n\n", es[0])
 	}
 
 	points := make([]string, len(es))
@@ -22,6 +22,6 @@ func ListFormatFunc(es []error) string {
 	}
 
 	return fmt.Sprintf(
-		"%d errors occurred:\n\n%s",
-		len(es), strings.Join(points, "\n"))
+		"%d errors occurred:\n\t%s\n\n",
+		len(es), strings.Join(points, "\n\t"))
 }

--- a/vendor/github.com/hashicorp/go-multierror/go.mod
+++ b/vendor/github.com/hashicorp/go-multierror/go.mod
@@ -1,0 +1,3 @@
+module github.com/hashicorp/go-multierror
+
+require github.com/hashicorp/errwrap v1.0.0

--- a/vendor/github.com/hashicorp/go-multierror/multierror.go
+++ b/vendor/github.com/hashicorp/go-multierror/multierror.go
@@ -40,11 +40,11 @@ func (e *Error) GoString() string {
 }
 
 // WrappedErrors returns the list of errors that this Error is wrapping.
-// It is an implementatin of the errwrap.Wrapper interface so that
+// It is an implementation of the errwrap.Wrapper interface so that
 // multierror.Error can be used with that library.
 //
 // This method is not safe to be called concurrently and is no different
-// than accessing the Errors field directly. It is implementd only to
+// than accessing the Errors field directly. It is implemented only to
 // satisfy the errwrap.Wrapper interface.
 func (e *Error) WrappedErrors() []error {
 	return e.Errors

--- a/vendor/github.com/hashicorp/go-multierror/sort.go
+++ b/vendor/github.com/hashicorp/go-multierror/sort.go
@@ -1,0 +1,16 @@
+package multierror
+
+// Len implements sort.Interface function for length
+func (err Error) Len() int {
+	return len(err.Errors)
+}
+
+// Swap implements sort.Interface function for swapping elements
+func (err Error) Swap(i, j int) {
+	err.Errors[i], err.Errors[j] = err.Errors[j], err.Errors[i]
+}
+
+// Less implements sort.Interface function for determining order
+func (err Error) Less(i, j int) bool {
+	return err.Errors[i].Error() < err.Errors[j].Error()
+}

--- a/vendor/github.com/hashicorp/golang-lru/go.mod
+++ b/vendor/github.com/hashicorp/golang-lru/go.mod
@@ -1,1 +1,3 @@
 module github.com/hashicorp/golang-lru
+
+go 1.12

--- a/vendor/github.com/hashicorp/golang-lru/simplelru/lru.go
+++ b/vendor/github.com/hashicorp/golang-lru/simplelru/lru.go
@@ -73,6 +73,9 @@ func (c *LRU) Add(key, value interface{}) (evicted bool) {
 func (c *LRU) Get(key interface{}) (value interface{}, ok bool) {
 	if ent, ok := c.items[key]; ok {
 		c.evictList.MoveToFront(ent)
+		if ent.Value.(*entry) == nil {
+			return nil, false
+		}
 		return ent.Value.(*entry).value, true
 	}
 	return
@@ -140,6 +143,19 @@ func (c *LRU) Keys() []interface{} {
 // Len returns the number of items in the cache.
 func (c *LRU) Len() int {
 	return c.evictList.Len()
+}
+
+// Resize changes the cache size.
+func (c *LRU) Resize(size int) (evicted int) {
+	diff := c.Len() - size
+	if diff < 0 {
+		diff = 0
+	}
+	for i := 0; i < diff; i++ {
+		c.removeOldest()
+	}
+	c.size = size
+	return diff
 }
 
 // removeOldest removes the oldest item from the cache.

--- a/vendor/github.com/hashicorp/golang-lru/simplelru/lru_interface.go
+++ b/vendor/github.com/hashicorp/golang-lru/simplelru/lru_interface.go
@@ -10,7 +10,7 @@ type LRUCache interface {
 	// updates the "recently used"-ness of the key. #value, isFound
 	Get(key interface{}) (value interface{}, ok bool)
 
-	// Check if a key exsists in cache without updating the recent-ness.
+	// Checks if a key exists in cache without updating the recent-ness.
 	Contains(key interface{}) (ok bool)
 
 	// Returns key's value without updating the "recently used"-ness of the key.
@@ -31,6 +31,9 @@ type LRUCache interface {
 	// Returns the number of items in the cache.
 	Len() int
 
-	// Clear all cache entries
+	// Clears all cache entries.
 	Purge()
+
+  // Resizes cache, returning number evicted
+  Resize(int) int
 }


### PR DESCRIPTION
These dependencies now do tagged releases, so let's vendor a tagged release

- https://github.com/hashicorp/errwrap/compare/7554cd9344cec97297fa6649b055a8c98c2a1e55...v1.0.0
- https://github.com/hashicorp/go-multierror/compare/ed905158d87462226a13fe39ddf685ea65f1c11f...v1.0.0
- https://github.com/hashicorp/golang-lru/compare/v0.5.1...v0.5.3
