### PR TITLE
Handle layers with the same digest in unpacker.

### DIFF
--- a/unpacker.go
+++ b/unpacker.go
@@ -113,6 +113,12 @@ func (u *unpacker) unpack(ctx context.Context, config ocispec.Descriptor, layers
 			if states[i].layer.Blob.Digest != layer.Digest {
 				continue
 			}
+			// Different layers may have the same digest. When that
+			// happens, we should continue marking the next layer
+			// as downloaded.
+			if states[i].downloaded {
+				continue
+			}
 			states[i].downloaded = true
 			break
 		}


### PR DESCRIPTION
Layers can have the same digest when they have the same content. With the current unpacker implementation, the image pull will block forever.

This PR handles layers with the same digest in unpacker.

One example image `gcr.io/kubernetes-e2e-test-images/volume/gluster:1.0`:
```
ctr -n=k8s.io content get sha256:9d3b9a854e77307e37836faa29746bfdd97a47520e4548ae9c3522db537b2dcb
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
   "config": {
      "mediaType": "application/vnd.docker.container.image.v1+json",
      "size": 3708,
      "digest": "sha256:44ca1c9511e83e6a893aac2b4de0b254ecd42ae97855175432a001a01425fd29"
   },
   "layers": [
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 86579087,
         "digest": "sha256:e71c36a80ba912dd7a5a9f2f2d6136c148afa19bc7d024bd616b74a0bc7a2774"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 25188875,
         "digest": "sha256:3ca451129f299af2e9d69d2a1da3b283f09bfa1df5b0bfed33bdf8c6bfdd02c9"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 403,
         "digest": "sha256:7adde741dd0e0e7b0c69f74ee10d6a83f44dcccecd207018626c37d92ebfad9b"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 800,
         "digest": "sha256:2e54e958a695e06a26590f55d4fd2e289efadc5945e2ec96d777c3dff3e16dd3"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 163,
         "digest": "sha256:1904e6778a3129040af536f2b36d38f3452b78ebecb3bb6d9a60c5b05f26bd64"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 163,
         "digest": "sha256:1904e6778a3129040af536f2b36d38f3452b78ebecb3bb6d9a60c5b05f26bd64"
      }
   ]
}l
```
Signed-off-by: Lantao Liu <lantaol@google.com>