### PR TITLE
Export shim publisher functions 

### DIFF
--- a/runtime/v2/shim/shim.go
+++ b/runtime/v2/shim/shim.go
@@ -169,7 +169,7 @@ func run(id string, initFunc Init, config Config) error {
 
 	ttrpcAddress := os.Getenv(ttrpcAddressEnv)
 
-	publisher, err := newPublisher(ttrpcAddress)
+	publisher, err := NewPublisher(ttrpcAddress)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Our out of tree shim would like to publish events with ttrpc. These
functions should be exposed so our shim doesn't need to reimplement
publisher logic.

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>