### PR TITLE
archive: truncate modification time

### DIFF
--- a/archive/tar.go
+++ b/archive/tar.go
@@ -504,6 +504,12 @@ func (cw *changeWriter) HandleChange(k fs.ChangeKind, p string, f os.FileInfo, e
 
 		hdr.Mode = int64(chmodTarEntry(os.FileMode(hdr.Mode)))
 
+		// truncate timestamp for compatibility. without PAX stdlib rounds timestamps instead
+		hdr.Format = tar.FormatPAX
+		hdr.ModTime = hdr.ModTime.Truncate(time.Second)
+		hdr.AccessTime = time.Time{}
+		hdr.ChangeTime = time.Time{}
+
 		name := p
 		if strings.HasPrefix(name, string(filepath.Separator)) {
 			name, err = filepath.Rel(string(filepath.Separator), name)


### PR DESCRIPTION
fixes https://github.com/moby/buildkit/issues/1153

Currently differ rounds timestamps, causing issues and incompatibility with previous differ when timestamps are rounded up.

In the future, the best solution should be to always force `PAX` headers and add nanoseconds into the tar but wanted to just fix the issue with this PR without introducing new changes.

AccessTime/ChangeTime are also cleared to match the docker differ.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>