### PR TITLE
[release/1.2 backport] Compute manifest metadata when not provided.

### DIFF
--- a/remotes/docker/authorizer.go
+++ b/remotes/docker/authorizer.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
-	"github.com/containerd/containerd/version"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context/ctxhttp"
@@ -41,7 +40,6 @@ type dockerAuthorizer struct {
 	credentials func(string) (string, string, error)
 
 	client *http.Client
-	ua     string
 	mu     sync.Mutex
 
 	auth map[string]string
@@ -56,7 +54,6 @@ func NewAuthorizer(client *http.Client, f func(string) (string, string, error)) 
 	return &dockerAuthorizer{
 		credentials: f,
 		client:      client,
-		ua:          "containerd/" + version.Version,
 		auth:        map[string]string{},
 	}
 }
@@ -197,16 +194,7 @@ func (a *dockerAuthorizer) fetchTokenWithOAuth(ctx context.Context, to tokenOpti
 		form.Set("password", to.secret)
 	}
 
-	req, err := http.NewRequest("POST", to.realm, strings.NewReader(form.Encode()))
-	if err != nil {
-		return "", err
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
-	if a.ua != "" {
-		req.Header.Set("User-Agent", a.ua)
-	}
-
-	resp, err := ctxhttp.Do(ctx, a.client, req)
+	resp, err := ctxhttp.PostForm(ctx, a.client, to.realm, form)
 	if err != nil {
 		return "", err
 	}
@@ -250,10 +238,6 @@ func (a *dockerAuthorizer) fetchToken(ctx context.Context, to tokenOptions) (str
 	req, err := http.NewRequest("GET", to.realm, nil)
 	if err != nil {
 		return "", err
-	}
-
-	if a.ua != "" {
-		req.Header.Set("User-Agent", a.ua)
 	}
 
 	reqParams := req.URL.Query()

--- a/remotes/docker/authorizer.go
+++ b/remotes/docker/authorizer.go
@@ -194,7 +194,11 @@ func (a *dockerAuthorizer) fetchTokenWithOAuth(ctx context.Context, to tokenOpti
 		form.Set("password", to.secret)
 	}
 
-	resp, err := ctxhttp.PostForm(ctx, a.client, to.realm, form)
+	resp, err := ctxhttp.Post(
+		ctx, a.client, to.realm,
+		"application/x-www-form-urlencoded; charset=utf-8",
+		strings.NewReader(form.Encode()),
+	)
 	if err != nil {
 		return "", err
 	}

--- a/remotes/docker/authorizer.go
+++ b/remotes/docker/authorizer.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/version"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context/ctxhttp"
@@ -40,6 +41,7 @@ type dockerAuthorizer struct {
 	credentials func(string) (string, string, error)
 
 	client *http.Client
+	ua     string
 	mu     sync.Mutex
 
 	auth map[string]string
@@ -54,6 +56,7 @@ func NewAuthorizer(client *http.Client, f func(string) (string, string, error)) 
 	return &dockerAuthorizer{
 		credentials: f,
 		client:      client,
+		ua:          "containerd/" + version.Version,
 		auth:        map[string]string{},
 	}
 }
@@ -194,11 +197,16 @@ func (a *dockerAuthorizer) fetchTokenWithOAuth(ctx context.Context, to tokenOpti
 		form.Set("password", to.secret)
 	}
 
-	resp, err := ctxhttp.Post(
-		ctx, a.client, to.realm,
-		"application/x-www-form-urlencoded; charset=utf-8",
-		strings.NewReader(form.Encode()),
-	)
+	req, err := http.NewRequest("POST", to.realm, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
+	if a.ua != "" {
+		req.Header.Set("User-Agent", a.ua)
+	}
+
+	resp, err := ctxhttp.Do(ctx, a.client, req)
 	if err != nil {
 		return "", err
 	}
@@ -242,6 +250,10 @@ func (a *dockerAuthorizer) fetchToken(ctx context.Context, to tokenOptions) (str
 	req, err := http.NewRequest("GET", to.realm, nil)
 	if err != nil {
 		return "", err
+	}
+
+	if a.ua != "" {
+		req.Header.Set("User-Agent", a.ua)
 	}
 
 	reqParams := req.URL.Query()

--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/reference"
 	"github.com/containerd/containerd/remotes"
+	"github.com/containerd/containerd/version"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -82,6 +83,9 @@ type ResolverOptions struct {
 	// Host provides the hostname given a namespace.
 	Host func(string) (string, error)
 
+	// Headers are the HTTP request header fields sent by the resolver
+	Headers http.Header
+
 	// PlainHTTP specifies to use plain http and not https
 	PlainHTTP bool
 
@@ -105,6 +109,7 @@ func DefaultHost(ns string) (string, error) {
 type dockerResolver struct {
 	auth      Authorizer
 	host      func(string) (string, error)
+	headers   http.Header
 	plainHTTP bool
 	client    *http.Client
 	tracker   StatusTracker
@@ -118,12 +123,27 @@ func NewResolver(options ResolverOptions) remotes.Resolver {
 	if options.Host == nil {
 		options.Host = DefaultHost
 	}
+	if options.Headers == nil {
+		options.Headers = make(http.Header)
+	}
+	if _, ok := options.Headers["Accept"]; !ok {
+		// set headers for all the types we support for resolution.
+		options.Headers.Set("Accept", strings.Join([]string{
+			images.MediaTypeDockerSchema2Manifest,
+			images.MediaTypeDockerSchema2ManifestList,
+			ocispec.MediaTypeImageManifest,
+			ocispec.MediaTypeImageIndex, "*"}, ", "))
+	}
+	if _, ok := options.Headers["User-Agent"]; !ok {
+		options.Headers.Set("User-Agent", "containerd/"+version.Version)
+	}
 	if options.Authorizer == nil {
 		options.Authorizer = NewAuthorizer(options.Client, options.Credentials)
 	}
 	return &dockerResolver{
 		auth:      options.Authorizer,
 		host:      options.Host,
+		headers:   options.Headers,
 		plainHTTP: options.PlainHTTP,
 		client:    options.Client,
 		tracker:   options.Tracker,
@@ -182,12 +202,7 @@ func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocisp
 			return "", ocispec.Descriptor{}, err
 		}
 
-		// set headers for all the types we support for resolution.
-		req.Header.Set("Accept", strings.Join([]string{
-			images.MediaTypeDockerSchema2Manifest,
-			images.MediaTypeDockerSchema2ManifestList,
-			ocispec.MediaTypeImageManifest,
-			ocispec.MediaTypeImageIndex, "*"}, ", "))
+		req.Header = r.headers
 
 		log.G(ctx).Debug("resolving")
 		resp, err := fetcher.doRequestWithRetries(ctx, req, nil)

--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -29,7 +29,6 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/reference"
 	"github.com/containerd/containerd/remotes"
-	"github.com/containerd/containerd/version"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -106,7 +105,6 @@ func DefaultHost(ns string) (string, error) {
 type dockerResolver struct {
 	auth      Authorizer
 	host      func(string) (string, error)
-	uagent    string
 	plainHTTP bool
 	client    *http.Client
 	tracker   StatusTracker
@@ -120,15 +118,12 @@ func NewResolver(options ResolverOptions) remotes.Resolver {
 	if options.Host == nil {
 		options.Host = DefaultHost
 	}
-	ua := "containerd/" + version.Version
 	if options.Authorizer == nil {
 		options.Authorizer = NewAuthorizer(options.Client, options.Credentials)
-		options.Authorizer.(*dockerAuthorizer).ua = ua
 	}
 	return &dockerResolver{
 		auth:      options.Authorizer,
 		host:      options.Host,
-		uagent:    ua,
 		plainHTTP: options.PlainHTTP,
 		client:    options.Client,
 		tracker:   options.Tracker,
@@ -298,7 +293,6 @@ func (r *dockerResolver) Pusher(ctx context.Context, ref string) (remotes.Pusher
 type dockerBase struct {
 	refspec reference.Spec
 	base    url.URL
-	uagent  string
 
 	client *http.Client
 	auth   Authorizer
@@ -330,7 +324,6 @@ func (r *dockerResolver) base(refspec reference.Spec) (*dockerBase, error) {
 	return &dockerBase{
 		refspec: refspec,
 		base:    base,
-		uagent:  r.uagent,
 		client:  r.client,
 		auth:    r.auth,
 	}, nil
@@ -356,7 +349,6 @@ func (r *dockerBase) authorize(ctx context.Context, req *http.Request) error {
 func (r *dockerBase) doRequest(ctx context.Context, req *http.Request) (*http.Response, error) {
 	ctx = log.WithLogger(ctx, log.G(ctx).WithField("url", req.URL.String()))
 	log.G(ctx).WithField("request.headers", req.Header).WithField("request.method", req.Method).Debug("do request")
-	req.Header.Set("User-Agent", r.uagent)
 	if err := r.authorize(ctx, req); err != nil {
 		return nil, errors.Wrap(err, "failed to authorize")
 	}

--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -110,6 +110,7 @@ type dockerResolver struct {
 	auth      Authorizer
 	host      func(string) (string, error)
 	headers   http.Header
+	uagent    string
 	plainHTTP bool
 	client    *http.Client
 	tracker   StatusTracker
@@ -134,16 +135,22 @@ func NewResolver(options ResolverOptions) remotes.Resolver {
 			ocispec.MediaTypeImageManifest,
 			ocispec.MediaTypeImageIndex, "*"}, ", "))
 	}
-	if _, ok := options.Headers["User-Agent"]; !ok {
-		options.Headers.Set("User-Agent", "containerd/"+version.Version)
+	ua := options.Headers.Get("User-Agent")
+	if ua != "" {
+		options.Headers.Del("User-Agent")
+	} else {
+		ua = "containerd/" + version.Version
 	}
+
 	if options.Authorizer == nil {
 		options.Authorizer = NewAuthorizer(options.Client, options.Credentials)
+		options.Authorizer.(*dockerAuthorizer).ua = ua
 	}
 	return &dockerResolver{
 		auth:      options.Authorizer,
 		host:      options.Host,
 		headers:   options.Headers,
+		uagent:    ua,
 		plainHTTP: options.PlainHTTP,
 		client:    options.Client,
 		tracker:   options.Tracker,
@@ -308,6 +315,7 @@ func (r *dockerResolver) Pusher(ctx context.Context, ref string) (remotes.Pusher
 type dockerBase struct {
 	refspec reference.Spec
 	base    url.URL
+	uagent  string
 
 	client *http.Client
 	auth   Authorizer
@@ -339,6 +347,7 @@ func (r *dockerResolver) base(refspec reference.Spec) (*dockerBase, error) {
 	return &dockerBase{
 		refspec: refspec,
 		base:    base,
+		uagent:  r.uagent,
 		client:  r.client,
 		auth:    r.auth,
 	}, nil
@@ -364,6 +373,7 @@ func (r *dockerBase) authorize(ctx context.Context, req *http.Request) error {
 func (r *dockerBase) doRequest(ctx context.Context, req *http.Request) (*http.Response, error) {
 	ctx = log.WithLogger(ctx, log.G(ctx).WithField("url", req.URL.String()))
 	log.G(ctx).WithField("request.headers", req.Header).WithField("request.method", req.Method).Debug("do request")
+	req.Header.Set("User-Agent", r.uagent)
 	if err := r.authorize(ctx, req); err != nil {
 		return nil, errors.Wrap(err, "failed to authorize")
 	}

--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -18,10 +18,10 @@ package docker
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
-	"strconv"
 	"strings"
 
 	"github.com/containerd/containerd/errdefs"
@@ -29,6 +29,7 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/reference"
 	"github.com/containerd/containerd/remotes"
+	"github.com/containerd/containerd/remotes/docker/schema1"
 	"github.com/containerd/containerd/version"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -157,6 +158,32 @@ func NewResolver(options ResolverOptions) remotes.Resolver {
 	}
 }
 
+func getManifestMediaType(resp *http.Response) string {
+	// Strip encoding data (manifests should always be ascii JSON)
+	contentType := resp.Header.Get("Content-Type")
+	if sp := strings.IndexByte(contentType, ';'); sp != -1 {
+		contentType = contentType[0:sp]
+	}
+
+	// As of Apr 30 2019 the registry.access.redhat.com registry does not specify
+	// the content type of any data but uses schema1 manifests.
+	if contentType == "text/plain" {
+		contentType = images.MediaTypeDockerSchema1Manifest
+	}
+	return contentType
+}
+
+type countingReader struct {
+	reader    io.Reader
+	bytesRead int64
+}
+
+func (r *countingReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	r.bytesRead += int64(n)
+	return n, err
+}
+
 var _ remotes.Resolver = &dockerResolver{}
 
 func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocispec.Descriptor, error) {
@@ -227,40 +254,56 @@ func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocisp
 			}
 			return "", ocispec.Descriptor{}, errors.Errorf("unexpected status code %v: %v", u, resp.Status)
 		}
+		size := resp.ContentLength
 
 		// this is the only point at which we trust the registry. we use the
 		// content headers to assemble a descriptor for the name. when this becomes
 		// more robust, we mostly get this information from a secure trust store.
 		dgstHeader := digest.Digest(resp.Header.Get("Docker-Content-Digest"))
+		contentType := getManifestMediaType(resp)
 
-		if dgstHeader != "" {
+		if dgstHeader != "" && size != -1 {
 			if err := dgstHeader.Validate(); err != nil {
 				return "", ocispec.Descriptor{}, errors.Wrapf(err, "%q in header not a valid digest", dgstHeader)
 			}
 			dgst = dgstHeader
-		}
+		} else {
+			log.G(ctx).Debug("no Docker-Content-Digest header, fetching manifest instead")
 
-		if dgst == "" {
-			return "", ocispec.Descriptor{}, errors.Errorf("could not resolve digest for %v", ref)
-		}
+			req, err := http.NewRequest(http.MethodGet, u, nil)
+			if err != nil {
+				return "", ocispec.Descriptor{}, err
+			}
+			req.Header = r.headers
 
-		var (
-			size       int64
-			sizeHeader = resp.Header.Get("Content-Length")
-		)
+			resp, err := fetcher.doRequestWithRetries(ctx, req, nil)
+			if err != nil {
+				return "", ocispec.Descriptor{}, err
+			}
+			defer resp.Body.Close()
 
-		size, err = strconv.ParseInt(sizeHeader, 10, 64)
-		if err != nil {
+			bodyReader := countingReader{reader: resp.Body}
 
-			return "", ocispec.Descriptor{}, errors.Wrapf(err, "invalid size header: %q", sizeHeader)
-		}
-		if size < 0 {
-			return "", ocispec.Descriptor{}, errors.Errorf("%q in header not a valid size", sizeHeader)
+			contentType = getManifestMediaType(resp)
+			if contentType == images.MediaTypeDockerSchema1Manifest {
+				b, err := schema1.ReadStripSignature(&bodyReader)
+				if err != nil {
+					return "", ocispec.Descriptor{}, err
+				}
+
+				dgst = digest.FromBytes(b)
+			} else {
+				dgst, err = digest.FromReader(&bodyReader)
+				if err != nil {
+					return "", ocispec.Descriptor{}, err
+				}
+			}
+			size = bodyReader.bytesRead
 		}
 
 		desc := ocispec.Descriptor{
 			Digest:    dgst,
-			MediaType: resp.Header.Get("Content-Type"), // need to strip disposition?
+			MediaType: contentType,
 			Size:      size,
 		}
 

--- a/remotes/docker/schema1/converter.go
+++ b/remotes/docker/schema1/converter.go
@@ -227,6 +227,17 @@ func (c *Converter) Convert(ctx context.Context, opts ...ConvertOpt) (ocispec.De
 	return desc, nil
 }
 
+// ReadStripSignature reads in a schema1 manifest and returns a byte array
+// with the "signatures" field stripped
+func ReadStripSignature(schema1Blob io.Reader) ([]byte, error) {
+	b, err := ioutil.ReadAll(io.LimitReader(schema1Blob, manifestSizeLimit)) // limit to 8MB
+	if err != nil {
+		return nil, err
+	}
+
+	return stripSignature(b)
+}
+
 func (c *Converter) fetchManifest(ctx context.Context, desc ocispec.Descriptor) error {
 	log.G(ctx).Debug("fetch schema 1")
 
@@ -235,13 +246,8 @@ func (c *Converter) fetchManifest(ctx context.Context, desc ocispec.Descriptor) 
 		return err
 	}
 
-	b, err := ioutil.ReadAll(io.LimitReader(rc, manifestSizeLimit)) // limit to 8MB
+	b, err := ReadStripSignature(rc)
 	rc.Close()
-	if err != nil {
-		return err
-	}
-
-	b, err = stripSignature(b)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
backport of https://github.com/containerd/containerd/pull/3245 for the 1.2 branch

Adds a fallback to manually compute the manifest digest when it is not presented as the Docker-Content-Digest header by the registry server. This is to address #3238.


closes #3238
addresses parts of https://github.com/containerd/containerd/issues/3291