### PR TITLE
[release/1.2] cherry-pick: archive: truncate modification time

### DIFF
--- a/archive/tar.go
+++ b/archive/tar.go
@@ -493,6 +493,12 @@ func (cw *changeWriter) HandleChange(k fs.ChangeKind, p string, f os.FileInfo, e
 
 		hdr.Mode = int64(chmodTarEntry(os.FileMode(hdr.Mode)))
 
+		// truncate timestamp for compatibility. without PAX stdlib rounds timestamps instead
+		hdr.Format = tar.FormatPAX
+		hdr.ModTime = hdr.ModTime.Truncate(time.Second)
+		hdr.AccessTime = time.Time{}
+		hdr.ChangeTime = time.Time{}
+
 		name := p
 		if strings.HasPrefix(name, string(filepath.Separator)) {
 			name, err = filepath.Rel(string(filepath.Separator), name)


### PR DESCRIPTION
Cherry-pick commit 372472b5f648bccb7c3045ccd5921b0082fd87bb from master PR #3589 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>