### PR TITLE
Make default platform configurable in the client

### DIFF
--- a/client.go
+++ b/client.go
@@ -99,6 +99,12 @@ func New(address string, opts ...ClientOpt) (*Client, error) {
 		c.runtime = defaults.DefaultRuntime
 	}
 
+	if copts.defaultPlatform != nil {
+		c.platform = copts.defaultPlatform
+	} else {
+		c.platform = platforms.Default()
+	}
+
 	if copts.services != nil {
 		c.services = *copts.services
 	}
@@ -193,6 +199,7 @@ type Client struct {
 	conn      *grpc.ClientConn
 	runtime   string
 	defaultns string
+	platform  platforms.MatchComparer
 	connector func() (*grpc.ClientConn, error)
 }
 

--- a/client_opts.go
+++ b/client_opts.go
@@ -26,11 +26,12 @@ import (
 )
 
 type clientOpts struct {
-	defaultns      string
-	defaultRuntime string
-	services       *services
-	dialOptions    []grpc.DialOption
-	timeout        time.Duration
+	defaultns       string
+	defaultRuntime  string
+	defaultPlatform platforms.MatchComparer
+	services        *services
+	dialOptions     []grpc.DialOption
+	timeout         time.Duration
 }
 
 // ClientOpt allows callers to set options on the containerd client
@@ -51,6 +52,14 @@ func WithDefaultNamespace(ns string) ClientOpt {
 func WithDefaultRuntime(rt string) ClientOpt {
 	return func(c *clientOpts) error {
 		c.defaultRuntime = rt
+		return nil
+	}
+}
+
+// WithDefaultPlatform sets the default platform matcher on the client
+func WithDefaultPlatform(platform platforms.MatchComparer) ClientOpt {
+	return func(c *clientOpts) error {
+		c.defaultPlatform = platform
 		return nil
 	}
 }

--- a/container_opts.go
+++ b/container_opts.go
@@ -22,7 +22,6 @@ import (
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/oci"
-	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/typeurl"
 	"github.com/gogo/protobuf/types"
@@ -190,7 +189,7 @@ func WithSnapshotCleanup(ctx context.Context, client *Client, c containers.Conta
 // root filesystem in read-only mode
 func WithNewSnapshotView(id string, i Image, opts ...snapshots.Opt) NewContainerOpts {
 	return func(ctx context.Context, client *Client, c *containers.Container) error {
-		diffIDs, err := i.(*image).i.RootFS(ctx, client.ContentStore(), platforms.Default())
+		diffIDs, err := i.(*image).i.RootFS(ctx, client.ContentStore(), client.platform)
 		if err != nil {
 			return err
 		}

--- a/container_opts_unix.go
+++ b/container_opts_unix.go
@@ -28,7 +28,6 @@ import (
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/mount"
-	"github.com/containerd/containerd/platforms"
 	"github.com/opencontainers/image-spec/identity"
 )
 
@@ -45,7 +44,7 @@ func WithRemappedSnapshotView(id string, i Image, uid, gid uint32) NewContainerO
 
 func withRemappedSnapshotBase(id string, i Image, uid, gid uint32, readonly bool) NewContainerOpts {
 	return func(ctx context.Context, client *Client, c *containers.Container) error {
-		diffIDs, err := i.(*image).i.RootFS(ctx, client.ContentStore(), platforms.Default())
+		diffIDs, err := i.(*image).i.RootFS(ctx, client.ContentStore(), client.platform)
 		if err != nil {
 			return err
 		}

--- a/container_restore_opts.go
+++ b/container_restore_opts.go
@@ -22,7 +22,6 @@ import (
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
-	"github.com/containerd/containerd/platforms"
 	"github.com/gogo/protobuf/proto"
 	ptypes "github.com/gogo/protobuf/types"
 	"github.com/opencontainers/image-spec/identity"
@@ -58,7 +57,7 @@ func WithRestoreImage(ctx context.Context, id string, client *Client, checkpoint
 			return err
 		}
 
-		diffIDs, err := i.(*image).i.RootFS(ctx, client.ContentStore(), platforms.Default())
+		diffIDs, err := i.(*image).i.RootFS(ctx, client.ContentStore(), client.platform)
 		if err != nil {
 			return err
 		}

--- a/image.go
+++ b/image.go
@@ -110,7 +110,7 @@ func NewImage(client *Client, i images.Image) Image {
 	return &image{
 		client:   client,
 		i:        i,
-		platform: platforms.Default(),
+		platform: client.platform,
 	}
 }
 

--- a/import.go
+++ b/import.go
@@ -125,7 +125,7 @@ func (c *Client) Import(ctx context.Context, reader io.Reader, opts ...ImportOpt
 	}
 	var platformMatcher = platforms.All
 	if !iopts.allPlatforms {
-		platformMatcher = platforms.Default()
+		platformMatcher = c.platform
 	}
 
 	var handler images.HandlerFunc = func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {

--- a/install.go
+++ b/install.go
@@ -27,7 +27,6 @@ import (
 	"github.com/containerd/containerd/archive/compression"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
-	"github.com/containerd/containerd/platforms"
 	"github.com/pkg/errors"
 )
 
@@ -43,7 +42,7 @@ func (c *Client) Install(ctx context.Context, image Image, opts ...InstallOpts) 
 	}
 	var (
 		cs       = image.ContentStore()
-		platform = platforms.Default()
+		platform = c.platform
 	)
 	manifest, err := images.Manifest(ctx, cs, image.Target(), platform)
 	if err != nil {

--- a/pull.go
+++ b/pull.go
@@ -44,7 +44,7 @@ func (c *Client) Pull(ctx context.Context, ref string, opts ...RemoteOpt) (_ Ima
 		if len(pullCtx.Platforms) > 1 {
 			return nil, errors.New("cannot pull multiplatform image locally, try Fetch")
 		} else if len(pullCtx.Platforms) == 0 {
-			pullCtx.PlatformMatcher = platforms.Default()
+			pullCtx.PlatformMatcher = c.platform
 		} else {
 			p, err := platforms.Parse(pullCtx.Platforms[0])
 			if err != nil {


### PR DESCRIPTION
For https://github.com/containerd/cri/issues/1257

The default platform may not always work, we should have getters for users to specify platforms.

In the CRI plugin, our first planned milestone for windows support is WCOW with process isolation only ([previous discussion](https://docs.google.com/document/d/1PKlmTIh0-qSzGDPhYmc_5BJjdD9GRdMGIATzvlhUAwM/edit)). And the [default platform matcher](https://github.com/containerd/containerd/blob/master/platforms/defaults_windows.go#L27) in containerd won't work for that, because LCOW is included.

Signed-off-by: Lantao Liu <lantaol@google.com>