### PR TITLE
Fix potential containerd panic during graceful shutdown.

### DIFF
--- a/cmd/containerd/command/main_unix.go
+++ b/cmd/containerd/command/main_unix.go
@@ -58,6 +58,7 @@ func handleSignals(ctx context.Context, signals chan os.Signal, serverC chan *se
 					}
 					server.Stop()
 					close(done)
+					return
 				}
 			}
 		}


### PR DESCRIPTION
When containerd receives more than 1 terminate signal before shutdown, it may panic:
```
panic: close of closed channel

goroutine 10 [running]:
github.com/containerd/cri/vendor/github.com/containerd/containerd/cmd/containerd/command.handleSignals.func1(0xc00015dd40, 0xc00015dce0, 0x1fa21a0, 0xc0000420f0, 0xc0000a43c0)
        /usr/local/google/home/lantaol/workspace/src/github.com/containerd/cri/vendor/github.com/containerd/containerd/cmd/containerd/command/main_unix.go:60 +0x2e2
created by github.com/containerd/cri/vendor/github.com/containerd/containerd/cmd/containerd/command.handleSignals
        /usr/local/google/home/lantaol/workspace/src/github.com/containerd/cri/vendor/github.com/containerd/containerd/cmd/containerd/command/main_unix.go:41 +0x89
```
Signed-off-by: Lantao Liu <lantaol@google.com>