### PR TITLE
Fix potential panic for task in unknown state.

### DIFF
--- a/cio/io_unix.go
+++ b/cio/io_unix.go
@@ -72,17 +72,19 @@ func copyIO(fifos *FIFOSet, ioset *Streams) (*cio, error) {
 	}
 
 	var wg = &sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		p := bufPool.Get().(*[]byte)
-		defer bufPool.Put(p)
+	if fifos.Stdout != "" {
+		wg.Add(1)
+		go func() {
+			p := bufPool.Get().(*[]byte)
+			defer bufPool.Put(p)
 
-		io.CopyBuffer(ioset.Stdout, pipes.Stdout, *p)
-		pipes.Stdout.Close()
-		wg.Done()
-	}()
+			io.CopyBuffer(ioset.Stdout, pipes.Stdout, *p)
+			pipes.Stdout.Close()
+			wg.Done()
+		}()
+	}
 
-	if !fifos.Terminal {
+	if !fifos.Terminal && fifos.Stderr != "" {
 		wg.Add(1)
 		go func() {
 			p := bufPool.Get().(*[]byte)

--- a/container.go
+++ b/container.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/containerd/containerd/api/services/tasks/v1"
 	"github.com/containerd/containerd/api/types"
+	tasktypes "github.com/containerd/containerd/api/types/task"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/errdefs"
@@ -382,7 +383,9 @@ func (c *container) loadTask(ctx context.Context, ioAttach cio.Attach) (Task, er
 		return nil, err
 	}
 	var i cio.IO
-	if ioAttach != nil {
+	if ioAttach != nil && response.Process.Status != tasktypes.StatusUnknown {
+		// Do not attach IO for task in unknown state, because there
+		// are no fifo paths anyway.
 		if i, err = attachExistingIO(response, ioAttach); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
We added unknown state support for task in https://github.com/containerd/containerd/commit/101d4b78eb7fc0ef2be6dea1cfe2e5cf277df622. And task in unknown state will have empty fifos path.

However, we continue attach IO for task in unknown state https://github.com/containerd/containerd/blob/master/container.go#L386, which will potentially trigger a panic, because `copyIO` tries access nil `stdout`.

This PR:
1) Avoids attaching IO if task is in unknown state;
2) Fix io attaching helper to tolerant empty stdout fifo path.

Signed-off-by: Lantao Liu <lantaol@google.com>