### PR TITLE
Fix proxy plugin config validation

### DIFF
--- a/services/server/config/config.go
+++ b/services/server/config/config.go
@@ -107,11 +107,6 @@ func (c *Config) ValidateV2() error {
 			return errors.Errorf("invalid plugin key URI %q expect io.containerd.x.vx", p)
 		}
 	}
-	for p := range c.ProxyPlugins {
-		if len(strings.Split(p, ".")) < 4 {
-			return errors.Errorf("invalid proxy plugin key URI %q expect io.containerd.x.vx", p)
-		}
-	}
 	return nil
 }
 


### PR DESCRIPTION
Proxy plugins are keyed only on the identifier, the type is specified within the proxy plugin configuration which maps to the full URI. The proxy plugin configuration is not passed to the plugin for configuration like other plugins.

Fixes a compatibility error with proxy plugins from v1 configs. Fixing the validation caused the proxy plugin ID to be wrong since "io.containerd.snapshotter.v1" or "io.containerd.content.v1" is always added based on the type.