### PR TITLE
Update to Golang 1.13.4

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.12.13
+    - GO_VERSION: 1.13.4
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,13 @@ os:
 - linux
 
 go:
-  - "1.12.13"
+  - "1.13.4"
 
 env:
-  - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic
-  - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v2 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic TRAVIS_RELEASE=yes
-  - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runtime.v1.linux TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic
-  - TRAVIS_GOOS=darwin TRAVIS_CGO_ENABLED=0
+  - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct
+  - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v2 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic TRAVIS_RELEASE=yes GOPROXY=direct
+  - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runtime.v1.linux TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct
+  - TRAVIS_GOOS=darwin TRAVIS_CGO_ENABLED=0 GOPROXY=direct
 
 matrix:
   include:
@@ -24,7 +24,7 @@ matrix:
     - if: type != pull_request
       os: linux
       dist: xenial
-      env: TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v2 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=xenial
+      env: TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v2 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=xenial GOPROXY=direct
 
 go_import_path: github.com/containerd/containerd
 
@@ -73,7 +73,7 @@ script:
   - DCO_VERBOSITY=-q ../project/script/validate/dco
   - ../project/script/validate/fileheader ../project/
   - travis_wait ../project/script/validate/vendor
-  - GOOS=linux script/setup/install-dev-tools
+  - GOOS=linux GO111MODULE=off script/setup/install-dev-tools
   - go build -i .
   - make check
   - if [ "$GOOS" = "linux" ]; then make check-protos check-api-descriptors; fi

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.12.13
+ARG GOLANG_VERSION=1.13.4
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd
@@ -34,6 +34,8 @@ RUN apt-get update && apt-get install -y \
 
 COPY vendor.conf vendor.conf
 COPY script/setup/install-runc install-runc
+ARG GOPROXY=direct
+ARG GO111MODULE=off
 RUN ./install-runc
 
 FROM golang-base AS dev


### PR DESCRIPTION
go1.13.4 (released 2019/10/31) includes fixes to the net/http and syscall
packages. It also fixes an issue on macOS 10.15 Catalina where the non-
notarized installer and binaries were being rejected by Gatekeeper.
See the Go 1.13.4 milestone on the issue tracker for details:
https://github.com/golang/go/issues?q=milestone%3AGo1.13.4

#### Update to Golang 1.13.3:

go1.13.3 (released 2019/10/17) includes fixes to the go command, the toolchain,
the runtime, syscall, net, net/http, and crypto/ecdsa packages. See the Go
1.13.3 milestone on the issue tracker for details:
https://github.com/golang/go/issues?q=milestone%3AGo1.13.3

#### Update to Golang 1.13.2:

go1.13.2 (released 2019/10/17) includes security fixes to the crypto/dsa
package and the compiler. See the Go 1.13.2 milestone on the issue tracker
for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.13.2

#### update to Golang 1.13.1

go1.13.1 (released 2019/09/25) includes security fixes to the
net/http and net/textproto packages. See the Go 1.13.1 milestone
on the issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.13.1

#### update to Golang 1.13.0

Full diff: https://github.com/golang/go/compare/go1.12.9...go1.13
Milestone: https://github.com/golang/go/milestone/83?closed=1

Today the Go team is very happy to announce the release of Go 1.13. You can get it
from the download page.

Some of the highlights include:

- The go command now downloads and authenticates modules using the Go module
  mirror and Go checksum database by default (https://golang.org/doc/go1.13#introduction)
- Improvements to number literals (https://golang.org/doc/go1.13#language)
- Error wrapping (https://golang.org/doc/go1.13#error_wrapping)
- TLS 1.3 on by default (https://golang.org/doc/go1.13#tls_1_3)
- Improved modules support (https://golang.org/doc/go1.13#modules)

For the complete list of changes and more information about the improvements above,
see the Go 1.13 release notes: https://golang.org/doc/go1.13
