### PR TITLE
Update containerd encrypted layer mediatypes

### DIFF
--- a/images/image.go
+++ b/images/image.go
@@ -359,7 +359,8 @@ func Children(ctx context.Context, provider content.Provider, desc ocispec.Descr
 
 		descs = append(descs, index.Manifests...)
 	case MediaTypeDockerSchema2Layer, MediaTypeDockerSchema2LayerGzip,
-		MediaTypeDockerSchema2LayerEnc, MediaTypeDockerSchema2LayerGzipEnc,
+		MediaTypeOCILayerEnc, MediaTypeOCILayerGzipEnc,
+		MediaTypeOCINonDistributableLayerEnc, MediaTypeOCINonDistributableLayerGzipEnc,
 		MediaTypeDockerSchema2LayerForeign, MediaTypeDockerSchema2LayerForeignGzip,
 		MediaTypeDockerSchema2Config, ocispec.MediaTypeImageConfig,
 		ocispec.MediaTypeImageLayer, ocispec.MediaTypeImageLayerGzip,
@@ -439,7 +440,7 @@ func GetImageLayerDescriptors(ctx context.Context, cs content.Store, desc ocispe
 			switch child.MediaType {
 			case MediaTypeDockerSchema2LayerGzip, MediaTypeDockerSchema2Layer,
 				ocispec.MediaTypeImageLayerGzip, ocispec.MediaTypeImageLayer,
-				MediaTypeDockerSchema2LayerGzipEnc, MediaTypeDockerSchema2LayerEnc:
+				MediaTypeOCILayerGzipEnc, MediaTypeOCILayerEnc:
 				tdesc := child
 				tdesc.Platform = platform
 				tmp = append(tmp, tdesc)

--- a/images/mediatypes.go
+++ b/images/mediatypes.go
@@ -22,14 +22,21 @@ package images
 // here for clarity.
 const (
 	MediaTypeDockerSchema2Layer            = "application/vnd.docker.image.rootfs.diff.tar"
-	MediaTypeDockerSchema2LayerEnc         = "application/vnd.docker.image.rootfs.diff.tar+enc"
 	MediaTypeDockerSchema2LayerForeign     = "application/vnd.docker.image.rootfs.foreign.diff.tar"
 	MediaTypeDockerSchema2LayerGzip        = "application/vnd.docker.image.rootfs.diff.tar.gzip"
-	MediaTypeDockerSchema2LayerGzipEnc     = "application/vnd.docker.image.rootfs.diff.tar.gzip+enc"
 	MediaTypeDockerSchema2LayerForeignGzip = "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip"
 	MediaTypeDockerSchema2Config           = "application/vnd.docker.container.image.v1+json"
 	MediaTypeDockerSchema2Manifest         = "application/vnd.docker.distribution.manifest.v2+json"
 	MediaTypeDockerSchema2ManifestList     = "application/vnd.docker.distribution.manifest.list.v2+json"
+
+	// Proposed encryption media types for the OCI image-spec (opencontainers/image-spec#775)
+	// Once there is an accepted/released OCI spec with these included they can be removed here and used from
+	// the image-spec imports where needed.
+	MediaTypeOCILayerEnc                     = "application/vnd.oci.image.layer.v1.tar+enc"
+	MediaTypeOCILayerGzipEnc                 = "application/vnd.oci.image.layer.v1.tar+gzip+enc"
+	MediaTypeOCINonDistributableLayerEnc     = "application/vnd.oci.image.layer.nondistributable.v1.tar+enc"
+	MediaTypeOCINonDistributableLayerGzipEnc = "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip+enc"
+
 	// Checkpoint/Restore Media Types
 	MediaTypeContainerd1Checkpoint               = "application/vnd.containerd.container.criu.checkpoint.criu.tar"
 	MediaTypeContainerd1CheckpointPreDump        = "application/vnd.containerd.container.criu.checkpoint.predump.tar"

--- a/remotes/handlers.go
+++ b/remotes/handlers.go
@@ -49,7 +49,8 @@ func MakeRefKey(ctx context.Context, desc ocispec.Descriptor) string {
 		images.MediaTypeDockerSchema2LayerForeign, images.MediaTypeDockerSchema2LayerForeignGzip,
 		ocispec.MediaTypeImageLayer, ocispec.MediaTypeImageLayerGzip,
 		ocispec.MediaTypeImageLayerNonDistributable, ocispec.MediaTypeImageLayerNonDistributableGzip,
-		images.MediaTypeDockerSchema2LayerEnc, images.MediaTypeDockerSchema2LayerGzipEnc:
+		images.MediaTypeOCILayerEnc, images.MediaTypeOCILayerGzipEnc,
+		images.MediaTypeOCINonDistributableLayerEnc, images.MediaTypeOCINonDistributableLayerGzipEnc:
 		return "layer-" + desc.Digest.String()
 	case images.MediaTypeDockerSchema2Config, ocispec.MediaTypeImageConfig:
 		return "config-" + desc.Digest.String()

--- a/unpacker.go
+++ b/unpacker.go
@@ -233,7 +233,8 @@ func (u *unpacker) handlerWrapper(uctx context.Context, unpacks *int32) (func(im
 				images.MediaTypeDockerSchema2LayerForeign, images.MediaTypeDockerSchema2LayerForeignGzip,
 				ocispec.MediaTypeImageLayer, ocispec.MediaTypeImageLayerGzip,
 				ocispec.MediaTypeImageLayerNonDistributable, ocispec.MediaTypeImageLayerNonDistributableGzip,
-				images.MediaTypeDockerSchema2LayerEnc, images.MediaTypeDockerSchema2LayerGzipEnc:
+				images.MediaTypeOCILayerEnc, images.MediaTypeOCILayerGzipEnc,
+				images.MediaTypeOCINonDistributableLayerEnc, images.MediaTypeOCINonDistributableLayerGzipEnc:
 				lock.Lock()
 				update := !schema1
 				lock.Unlock()


### PR DESCRIPTION
Match our self-defined encrypted layer media types to the current OCI
proposal (PR #775 in opencontainers/image-spec). This is temporary until
a released image-spec is available with these definitions and can be
used from the image-spec imports.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>