### PR TITLE
platforms: update known OS and arch values

### DIFF
--- a/platforms/database.go
+++ b/platforms/database.go
@@ -38,7 +38,7 @@ func isLinuxOS(os string) bool {
 // The OS value should be normalized before calling this function.
 func isKnownOS(os string) bool {
 	switch os {
-	case "android", "darwin", "dragonfly", "freebsd", "linux", "nacl", "netbsd", "openbsd", "plan9", "solaris", "windows", "zos":
+	case "aix", "android", "darwin", "dragonfly", "freebsd", "hurd", "illumos", "js", "linux", "nacl", "netbsd", "openbsd", "plan9", "solaris", "windows", "zos":
 		return true
 	}
 	return false
@@ -60,7 +60,7 @@ func isArmArch(arch string) bool {
 // The arch value should be normalized before being passed to this function.
 func isKnownArch(arch string) bool {
 	switch arch {
-	case "386", "amd64", "amd64p32", "arm", "armbe", "arm64", "arm64be", "ppc64", "ppc64le", "mips", "mipsle", "mips64", "mips64le", "mips64p32", "mips64p32le", "ppc", "s390", "s390x", "sparc", "sparc64":
+	case "386", "amd64", "amd64p32", "arm", "armbe", "arm64", "arm64be", "ppc64", "ppc64le", "mips", "mipsle", "mips64", "mips64le", "mips64p32", "mips64p32le", "ppc", "riscv", "riscv64", "s390", "s390x", "sparc", "sparc64", "wasm":
 		return true
 	}
 	return false


### PR DESCRIPTION
Update the lists in isKnownOS and isKnownOS according to goosList and
goarchList taken from Go 1.13, see
https://github.com/golang/go/blob/release-branch.go1.13/src/go/build/syslist.go

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>