### PR TITLE
Automate CRI tarball release.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,14 +117,30 @@ before_deploy:
   - make release
 
 deploy:
-  provider: releases
-  api_key:
-    secure: HO+WSIVVUMMsbU74x+YyFsTP3ahqnR4xjwKAziedJ5lZXKJszQBhiYTFmcTeVBoouNjTISd07GQzpoLChuGC20U3+1NbT+CkK8xWR/x1ao2D3JY3Ds6AD9ubWRNWRLptt/xOn5Vq3F8xZyUYchwvDMl4zKCuTKxQGVdHKsINb2DehKcP5cVL6MMvqzEdfj2g99vqXAqs8uuo6dOmvxmHV43bfzDaAJSabjZZs6TKlWTqCQMet8uxyx2Dmjl2lxLwdqv12oJdrszacasn41NYuEyHI2bXyef1mhWGYN4n9bU/Y5winctZ8DOSOZvYg/2ziAaUN0+CTn1IESwVesrPz23P2Sy7wdLxu8dSIZ2yUHl7OsA5T5a5rDchAGguRVNBWvoGtuepEhdRacxTQUo1cMFZsEXjgRKKjdfc1emYQPVdN8mBv8GJwndty473ZXdvFt5R0kNVFtvWuYCa6UYJD2cKrsPSAfbZCDC/LiR3FOoTaUPMZUVkR2ACEO7Dn4+KlmBajqT40Osk/A7k1XA/TzVhMIpLtE0Vk2DfPmGsjCv8bC+MFd+R2Sc8SFdE92oEWRdoPQY5SxMYQtGxA+cbKVlT1kSw6y80yEbx5JZsBnT6+NTHwmDO3kVU9ztLdawOozTElKNAK8HoAyFmzIZ3wL64oThuDrv/TUuY8Iyn814=
-  file_glob: true
-  file:
-    - releases/*.tar.gz
-    - releases/*.tar.gz.sha256sum
-  skip_cleanup: true
-  on:
-    repo: containerd/containerd
-    tags: true
+  - provider: releases
+    api_key:
+      secure: HO+WSIVVUMMsbU74x+YyFsTP3ahqnR4xjwKAziedJ5lZXKJszQBhiYTFmcTeVBoouNjTISd07GQzpoLChuGC20U3+1NbT+CkK8xWR/x1ao2D3JY3Ds6AD9ubWRNWRLptt/xOn5Vq3F8xZyUYchwvDMl4zKCuTKxQGVdHKsINb2DehKcP5cVL6MMvqzEdfj2g99vqXAqs8uuo6dOmvxmHV43bfzDaAJSabjZZs6TKlWTqCQMet8uxyx2Dmjl2lxLwdqv12oJdrszacasn41NYuEyHI2bXyef1mhWGYN4n9bU/Y5winctZ8DOSOZvYg/2ziAaUN0+CTn1IESwVesrPz23P2Sy7wdLxu8dSIZ2yUHl7OsA5T5a5rDchAGguRVNBWvoGtuepEhdRacxTQUo1cMFZsEXjgRKKjdfc1emYQPVdN8mBv8GJwndty473ZXdvFt5R0kNVFtvWuYCa6UYJD2cKrsPSAfbZCDC/LiR3FOoTaUPMZUVkR2ACEO7Dn4+KlmBajqT40Osk/A7k1XA/TzVhMIpLtE0Vk2DfPmGsjCv8bC+MFd+R2Sc8SFdE92oEWRdoPQY5SxMYQtGxA+cbKVlT1kSw6y80yEbx5JZsBnT6+NTHwmDO3kVU9ztLdawOozTElKNAK8HoAyFmzIZ3wL64oThuDrv/TUuY8Iyn814=
+    file_glob: true
+    file:
+      - releases/*.tar.gz
+      - releases/*.tar.gz.sha256sum
+    skip_cleanup: true
+    on:
+      repo: containerd/containerd
+      tags: true
+  - provider: gcs
+    access_key_id: GOOG1EJPAMPUV4MOGUSPRFM427Q5QOTNODQTMJYPXJFDF46IZLX2NGUQX3T7Q
+    secret_access_key:
+      secure: l3ITadMltGpYXShigdyRfpA7VuNcpGNrY9adB/1dQ5UVp0ZyRyimWX5+ea45JArh95iQCp11kY/7gKgL3tKAPsOXa9Lbt59n3XtlrVk5sqmd4S5+ZaI4Za4cRnkhkIAqro/IYsnzdLHqhCFYEmEDyMiI45RBkYYea+fnZFAGaTePmGwnD2LOn7A1z+dDGHt5g1Rpmdj1kB/AsHG6Wr8oGhMg9RlzSkAw2EAc1X3/9ofjOVM0AyB/hAgm/vmgisnqRSKzILqhL04d5b3gavrFn2YjrSEqP102BgYksn7EsJd1NMjA6Hj/qfVNCTn+rL8M85IE6JIAjrBog/HFv8Ez1bl1kSbB9UmAYZizEi7VD/fcxukYOPgqjDUoLrNaS3q+K0DkE1jzzcr72iMM+I8WJga7Vh4+MYjXadD5V96i2QDpthkEMvy1EpWvwQSl/fexaz2nJA5/CiX/V9GnWVsZiWlq/qMxji/ZbWsB04zRDfk9JneI7tubTNYj5FHrzhCQ7jrZYnXY/pb0sQkF1qczpH4PaXXgLnN00xffNudhsA6xZe/d22Yq+LELXeEmfOKD5j/DGdJGINgMj8RcngyKK6znBlBZ7nF3yqhLg4fHrCk9iOivGUXvKqdruqH+Yl7DUAp1Y0sySFlPF4I8RzMPHGPFqAJ9Q+rN2BNslClHAuA=
+    # TODO: use cri-containerd-release after testing.
+    #bucket: cri-containerd-release
+    bucket: cri-containerd-staging
+    skip_cleanup: true
+    acl: public-read
+    file:
+    - releases/cri/*.tar.gz
+    - releases/cri/*.tar.gz.sha256
+    # TODO: only deploy on tag after testing.
+    #on:
+    #  repo: containerd/containerd
+    #  tags: true

--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,7 @@ release: $(BINARIES)
 	@install $(BINARIES) releases/$(RELEASE)/bin
 	@cd releases/$(RELEASE) && tar -czf ../$(RELEASE).tar.gz *
 	@cd releases && sha256sum $(RELEASE).tar.gz >$(RELEASE).tar.gz.sha256sum
+	@VERSION=$(VERSION) script/release/release-cri
 
 clean: ## clean up binaries
 	@echo "$(WHALE) $@"

--- a/script/release/release-cri
+++ b/script/release/release-cri
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+#
+# Releases and publishes cri-containerd release tarball.
+#
+set -eu -o pipefail
+
+if [[ -z "${VERSION:-}" ]]; then
+  echo "VERSION is not set"
+  exit 1
+fi
+
+ROOT=${GOPATH}/src/github.com/containerd/containerd
+CRI_COMMIT=$(grep github.com/containerd/cri ${ROOT}/vendor.conf | cut -d " " -f 2)
+
+go get -d github.com/containerd/cri/...
+cd $GOPATH/src/github.com/containerd/cri
+git checkout $CRI_COMMIT
+make clean
+make release TARBALL_PREFIX=cri-containerd LOCAL_RELEASE=true VERSION=${VERSION}
+make release TARBALL_PREFIX=cri-containerd-cni LOCAL_RELEASE=true INCLUDE_CNI=true VERSION=${VERSION}
+
+mkdir -p ${ROOT}/releases/cri
+cp _output/*.tar.gz ${ROOT}/releases/cri
+cp _output/*.tar.gz.sha256 ${ROOT}/releases/cri

--- a/vendor.conf
+++ b/vendor.conf
@@ -49,7 +49,7 @@ go.opencensus.io v0.22.0
 github.com/imdario/mergo v0.3.7
 
 # cri dependencies
-github.com/containerd/cri 0165d516161e25e52b4ab52a404a00823f8f0ef6 # master
+github.com/containerd/cri f4d75d321c89b8d89bae570a7d2da1b3846c096f # release/1.3
 github.com/containerd/go-cni 49fbd9b210f3c8ee3b7fd3cd797aabaf364627c1
 github.com/containernetworking/cni v0.7.1
 github.com/containernetworking/plugins v0.7.6

--- a/vendor/github.com/containerd/cri/pkg/server/io/helpers.go
+++ b/vendor/github.com/containerd/cri/pkg/server/io/helpers.go
@@ -120,17 +120,21 @@ func newStdioPipes(fifos *cio.FIFOSet) (_ *stdioPipes, _ *wgCloser, err error) {
 		set = append(set, f)
 	}
 
-	if f, err = fifo.OpenFifo(ctx, fifos.Stdout, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
-		return nil, nil, err
+	if fifos.Stdout != "" {
+		if f, err = fifo.OpenFifo(ctx, fifos.Stdout, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
+			return nil, nil, err
+		}
+		p.stdout = f
+		set = append(set, f)
 	}
-	p.stdout = f
-	set = append(set, f)
 
-	if f, err = fifo.OpenFifo(ctx, fifos.Stderr, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
-		return nil, nil, err
+	if fifos.Stderr != "" {
+		if f, err = fifo.OpenFifo(ctx, fifos.Stderr, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
+			return nil, nil, err
+		}
+		p.stderr = f
+		set = append(set, f)
 	}
-	p.stderr = f
-	set = append(set, f)
 
 	return p, &wgCloser{
 		wg:     &sync.WaitGroup{},


### PR DESCRIPTION
For https://github.com/containerd/containerd/issues/3627

This depends on https://github.com/containerd/cri/pull/1267.

Currently this should be triggered every build and deploy to `cri-containerd-staging`. After testing that this works, I'll change it to only build on new tag and deploy to `cri-containerd-release`.

@dmcgowan 

Signed-off-by: Lantao Liu <lantaol@google.com>