### PR TITLE
ctr: use NewDockerAuthorizer instead of deprecated NewAuthorizer

### DIFF
--- a/cmd/ctr/commands/resolver.go
+++ b/cmd/ctr/commands/resolver.go
@@ -103,7 +103,8 @@ func GetResolver(ctx gocontext.Context, clicontext *cli.Context) (remotes.Resolv
 		// Only one host
 		return username, secret, nil
 	}
-	options.Authorizer = docker.NewAuthorizer(options.Client, credentials)
+	authOpts := []docker.AuthorizerOpt{docker.WithAuthClient(options.Client), docker.WithAuthCreds(credentials)}
+	options.Authorizer = docker.NewDockerAuthorizer(authOpts...)
 
 	return docker.NewResolver(options), nil
 }


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>