### PR TITLE
[CI] remove extra testing on older Ubuntu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,15 +24,7 @@ matrix:
     - if: type != pull_request
       os: linux
       dist: xenial
-      env: TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=xenial
-    - if: type != pull_request
-      os: linux
-      dist: xenial
       env: TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v2 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=xenial
-    - if: type != pull_request
-      os: linux
-      dist: xenial
-      env: TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runtime.v1.linux TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=xenial
 
 go_import_path: github.com/containerd/containerd
 


### PR DESCRIPTION
Currently only 5 parallel Travis tests are done, the older LTS testing the full matrix is not necessary and worth the cost of the increased build time. Just run the test the latest supported runtime.
