### PR TITLE
Update cri test to fix image reference test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,6 +129,11 @@ deploy:
       repo: containerd/containerd
       tags: true
   - provider: gcs
+    # Use master branch to work around https://github.com/travis-ci/dpl/issues/792.
+    # TODO: Remove this when the fix for https://github.com/travis-ci/dpl/issues/792
+    # is rolled out.
+    edge:
+      branch: master
     access_key_id: GOOG1EJPAMPUV4MOGUSPRFM427Q5QOTNODQTMJYPXJFDF46IZLX2NGUQX3T7Q
     secret_access_key:
       secure: l3ITadMltGpYXShigdyRfpA7VuNcpGNrY9adB/1dQ5UVp0ZyRyimWX5+ea45JArh95iQCp11kY/7gKgL3tKAPsOXa9Lbt59n3XtlrVk5sqmd4S5+ZaI4Za4cRnkhkIAqro/IYsnzdLHqhCFYEmEDyMiI45RBkYYea+fnZFAGaTePmGwnD2LOn7A1z+dDGHt5g1Rpmdj1kB/AsHG6Wr8oGhMg9RlzSkAw2EAc1X3/9ofjOVM0AyB/hAgm/vmgisnqRSKzILqhL04d5b3gavrFn2YjrSEqP102BgYksn7EsJd1NMjA6Hj/qfVNCTn+rL8M85IE6JIAjrBog/HFv8Ez1bl1kSbB9UmAYZizEi7VD/fcxukYOPgqjDUoLrNaS3q+K0DkE1jzzcr72iMM+I8WJga7Vh4+MYjXadD5V96i2QDpthkEMvy1EpWvwQSl/fexaz2nJA5/CiX/V9GnWVsZiWlq/qMxji/ZbWsB04zRDfk9JneI7tubTNYj5FHrzhCQ7jrZYnXY/pb0sQkF1qczpH4PaXXgLnN00xffNudhsA6xZe/d22Yq+LELXeEmfOKD5j/DGdJGINgMj8RcngyKK6znBlBZ7nF3yqhLg4fHrCk9iOivGUXvKqdruqH+Yl7DUAp1Y0sySFlPF4I8RzMPHGPFqAJ9Q+rN2BNslClHAuA=
@@ -138,8 +143,8 @@ deploy:
     skip_cleanup: true
     acl: public-read
     file:
-    - releases/cri/*.tar.gz
-    - releases/cri/*.tar.gz.sha256
+      - releases/cri/*.tar.gz
+      - releases/cri/*.tar.gz.sha256
     # TODO: only deploy on tag after testing.
     #on:
     #  repo: containerd/containerd

--- a/script/setup/install-critools
+++ b/script/setup/install-critools
@@ -21,7 +21,7 @@
 set -eu -o pipefail
 
 go get -u github.com/onsi/ginkgo/ginkgo
-CRITEST_COMMIT=v1.15.0
+CRITEST_COMMIT=427262054f59f3b849391310856a19474acb7e83
 go get -d github.com/kubernetes-incubator/cri-tools/...
 cd $GOPATH/src/github.com/kubernetes-incubator/cri-tools
 git checkout $CRITEST_COMMIT


### PR DESCRIPTION
Update cri validation test to fix the image reference test:
```
• Failure [1.718 seconds]
[k8s.io] Image Manager
/home/travis/gopath/src/github.com/kubernetes-sigs/cri-tools/pkg/framework/framework.go:72
  public image without tag should be pulled and removed [Conformance] [It]
  /home/travis/gopath/src/github.com/kubernetes-sigs/cri-tools/pkg/validate/image.go:47
  failed to pull image: rpc error: code = NotFound desc = failed to pull and unpack image "gcr.io/cri-tools/test-image-latest:latest": unpack: failed to prepare extraction snapshot "extract-151995760-DQ8D sha256:749539d5cc3b63b2fd60be0340a8e7ca88fd6fe0c639a605d46d3513778ac7f7": parent snapshot sha256:0d315111b4847e8cd50514ca19657d1e8d827f4e128d172ce8b2f76a04f3faea does not exist: not found
  Unexpected error:
      <*status.statusError | 0xc00024cfa0>: {
          Code: 5,
          Message: "failed to pull and unpack image \"gcr.io/cri-tools/test-image-latest:latest\": unpack: failed to prepare extraction snapshot \"extract-151995760-DQ8D sha256:749539d5cc3b63b2fd60be0340a8e7ca88fd6fe0c639a605d46d3513778ac7f7\": parent snapshot sha256:0d315111b4847e8cd50514ca19657d1e8d827f4e128d172ce8b2f76a04f3faea does not exist: not found",
          Details: nil,
          XXX_NoUnkeyedLiteral: {},
          XXX_unrecognized: nil,
          XXX_sizecache: 0,
      }
      rpc error: code = NotFound desc = failed to pull and unpack image "gcr.io/cri-tools/test-image-latest:latest": unpack: failed to prepare extraction snapshot "extract-151995760-DQ8D sha256:749539d5cc3b63b2fd60be0340a8e7ca88fd6fe0c639a605d46d3513778ac7f7": parent snapshot sha256:0d315111b4847e8cd50514ca19657d1e8d827f4e128d172ce8b2f76a04f3faea does not exist: not found
  occurred
  /home/travis/gopath/src/github.com/kubernetes-sigs/cri-tools/pkg/framework/util.go:328
```

The fix: https://github.com/kubernetes-sigs/cri-tools/pull/503

Signed-off-by: Lantao Liu <lantaol@google.com>