### PR TITLE
Skip cleanup in travis deploy and avoid gcs race condition.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,6 +131,7 @@ deploy:
       tags: true
   - provider: script
     script: bash script/release/deploy-cri
+    skip_cleanup: true
     on:
       repo: containerd/containerd
       # TODO: switch `tags: true` after validating on master

--- a/script/release/deploy-cri
+++ b/script/release/deploy-cri
@@ -31,5 +31,11 @@ gcloud version
 openssl aes-256-cbc -K $encrypted_5a565171e51f_key -iv $encrypted_5a565171e51f_iv -in "${ROOT}/script/release/gcp-secret.json.enc" -out gcp-secret.json -d
 gcloud auth activate-service-account --key-file gcp-secret.json --project=k8s-cri-containerd
 
-gsutil cp "${ROOT}/releases/cri/*.tar.gz" "${BUCKET}"
-gsutil cp "${ROOT}/releases/cri/*.tar.gz.sha256" "${BUCKET}"
+for file in $(ls "${ROOT}"/releases/cri/*.tar.gz.sha256); do
+  output="$(gsutil cp -n "${file}" "${BUCKET}" 2>&1)"
+  if [[ "$output" =~ "Skipping existing item" ]];then
+    echo "$(basename ${file}) already exists, skip the release tarball"
+    continue
+  fi
+  gsutil cp "${file%.sha256}" "${BUCKET}"
+done


### PR DESCRIPTION
This PR:
1) Add `skip_clean: true`, so that release tarballs won't be cleaned up before deploy. See the following log without such change:
```
Cleaning up git repository with `git stash --all`. If you need build artifacts for deployment, set `deploy.skip_cleanup: true`. See https://docs.travis-ci.com/user/deployment#Uploading-Files-and-skip_cleanup.
```
2) Skip tarball upload if it already exists. This is important because we have builds for shim v1 and v2. It is possible that shim v1 build uploads the eventual tarball, but shim v2 build uploads the eventual sha256 file.

Signed-off-by: Lantao Liu <lantaol@google.com>