### PR TITLE
Publish cri release to gs://cri-containerd-release.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -134,6 +134,5 @@ deploy:
     skip_cleanup: true
     on:
       repo: containerd/containerd
-      # TODO: switch `tags: true` after validating on master
-      branch: master
+      tags: true
       condition: $TRAVIS_GOOS = linux

--- a/script/release/deploy-cri
+++ b/script/release/deploy-cri
@@ -20,8 +20,7 @@
 set -eu -o pipefail
 
 ROOT=${GOPATH}/src/github.com/containerd/containerd
-# TODO: Change cri-containerd-release after tested.
-BUCKET="gs://cri-containerd-staging"
+BUCKET="gs://cri-containerd-release"
 
 rm -rf "${HOME}/google-cloud-sdk"
 export CLOUDSDK_CORE_DISABLE_PROMPTS=1


### PR DESCRIPTION
Fixes https://github.com/containerd/containerd/issues/3627

The build is green now: https://travis-ci.org/containerd/containerd/builds/583928600

Let's switch to the actual release bucket.

Signed-off-by: Lantao Liu <lantaol@google.com>