### PR TITLE
Skip darwin deploy on release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,6 +129,7 @@ deploy:
     on:
       repo: containerd/containerd
       tags: true
+      condition: $TRAVIS_GOOS = linux
   - provider: script
     script: bash script/release/deploy-cri
     skip_cleanup: true


### PR DESCRIPTION
Currently removing this incomplete build is part of the release
process. Skip this deployment to make releases easier.