### PR TITLE
implement ctr --connect-timeout

### DIFF
--- a/cmd/ctr/commands/client.go
+++ b/cmd/ctr/commands/client.go
@@ -47,6 +47,8 @@ func AppContext(context *cli.Context) (gocontext.Context, gocontext.CancelFunc) 
 
 // NewClient returns a new containerd client
 func NewClient(context *cli.Context, opts ...containerd.ClientOpt) (*containerd.Client, gocontext.Context, gocontext.CancelFunc, error) {
+	timeoutOpt := containerd.WithTimeout(context.GlobalDuration("connect-timeout"))
+	opts = append(opts, timeoutOpt)
 	client, err := containerd.New(context.GlobalString("address"), opts...)
 	if err != nil {
 		return nil, nil, nil, err


### PR DESCRIPTION
the `connect-timeout` global flag was already defined, but not used.