### PR TITLE
fail on file not found for shim reconnect on containerd restart

### DIFF
--- a/runtime/v2/binary.go
+++ b/runtime/v2/binary.go
@@ -74,7 +74,7 @@ func (b *binary) Start(ctx context.Context, opts *types.Any, onClose func()) (_ 
 	if err != nil {
 		return nil, err
 	}
-	f, err := openShimLog(ctx, b.bundle)
+	f, err := openShimLog(ctx, b.bundle, client.AnonDialer)
 	if err != nil {
 		return nil, errors.Wrap(err, "open shim log pipe")
 	}

--- a/runtime/v2/shim.go
+++ b/runtime/v2/shim.go
@@ -67,7 +67,7 @@ func loadShim(ctx context.Context, bundle *Bundle, events *exchange.Exchange, rt
 	if err != nil {
 		return nil, err
 	}
-	conn, err := client.Connect(address, client.AnonDialer)
+	conn, err := client.Connect(address, client.AnonReconnectDialer)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func loadShim(ctx context.Context, bundle *Bundle, events *exchange.Exchange, rt
 			conn.Close()
 		}
 	}()
-	f, err := openShimLog(ctx, bundle)
+	f, err := openShimLog(ctx, bundle, client.AnonReconnectDialer)
 	if err != nil {
 		return nil, errors.Wrap(err, "open shim log pipe")
 	}

--- a/runtime/v2/shim/util_unix.go
+++ b/runtime/v2/shim/util_unix.go
@@ -78,6 +78,10 @@ func AnonDialer(address string, timeout time.Duration) (net.Conn, error) {
 	return net.DialTimeout("unix", "\x00"+address, timeout)
 }
 
+func AnonReconnectDialer(address string, timeout time.Duration) (net.Conn, error) {
+	return AnonDialer(address, timeout)
+}
+
 // NewSocket returns a new socket
 func NewSocket(address string) (*net.UnixListener, error) {
 	if len(address) > 106 {

--- a/runtime/v2/shim_unix.go
+++ b/runtime/v2/shim_unix.go
@@ -21,13 +21,15 @@ package v2
 import (
 	"context"
 	"io"
+	"net"
 	"path/filepath"
+	"time"
 
 	"github.com/containerd/fifo"
 	"golang.org/x/sys/unix"
 )
 
-func openShimLog(ctx context.Context, bundle *Bundle) (io.ReadCloser, error) {
+func openShimLog(ctx context.Context, bundle *Bundle, _ func(string, time.Duration) (net.Conn, error)) (io.ReadCloser, error) {
 	return fifo.OpenFifo(ctx, filepath.Join(bundle.Path, "log"), unix.O_RDONLY|unix.O_CREAT|unix.O_NONBLOCK, 0700)
 }
 


### PR DESCRIPTION
Previously for windows, when containerd restarts and attempts to reconnect to shim pipes, if the pipe file is not found for a shim, containerd would wait up to 5 seconds before returning a failure. If containerd is still attempting to connect to shims after 30 seconds, the windows service manager will kill containerd. This work breaks up the cases of connecting to shims into two cases: shim starting and shim reconnecting. In the former, containerd will still wait up to 5 seconds for a pipe to be served by a starting shim. In the latter, containerd will return file not found immediately when attempting to connect to a nonexistent or dead shim.  

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>