### PR TITLE
Move golangci-lint deadline to config file

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - errcheck
 
 run:
+  deadline: 2m
   skip-dirs:
     - api
     - design

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ all: binaries
 
 check: proto-fmt ## run all linters
 	@echo "$(WHALE) $@"
-	GOGC=75 golangci-lint run --deadline 2m
+	GOGC=75 golangci-lint run
 
 ci: check binaries checkprotos coverage coverage-integration ## to be used by the CI
 


### PR DESCRIPTION
As mentioned [here](https://github.com/containerd/containerd/pull/3660#issuecomment-532750302) might as well put it in our existing config file.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>