### PR TITLE
Add metrics type alias

### DIFF
--- a/metrics/cgroups/blkio.go
+++ b/metrics/cgroups/blkio.go
@@ -21,7 +21,7 @@ package cgroups
 import (
 	"strconv"
 
-	"github.com/containerd/cgroups"
+	v1 "github.com/containerd/containerd/metrics/types/v1"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -33,7 +33,7 @@ var blkioMetrics = []*metric{
 		unit:   metrics.Total,
 		vt:     prometheus.GaugeValue,
 		labels: []string{"op", "device", "major", "minor"},
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Blkio == nil {
 				return nil
 			}
@@ -46,7 +46,7 @@ var blkioMetrics = []*metric{
 		unit:   metrics.Total,
 		vt:     prometheus.GaugeValue,
 		labels: []string{"op", "device", "major", "minor"},
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Blkio == nil {
 				return nil
 			}
@@ -59,7 +59,7 @@ var blkioMetrics = []*metric{
 		unit:   metrics.Bytes,
 		vt:     prometheus.GaugeValue,
 		labels: []string{"op", "device", "major", "minor"},
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Blkio == nil {
 				return nil
 			}
@@ -72,7 +72,7 @@ var blkioMetrics = []*metric{
 		unit:   metrics.Total,
 		vt:     prometheus.GaugeValue,
 		labels: []string{"op", "device", "major", "minor"},
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Blkio == nil {
 				return nil
 			}
@@ -85,7 +85,7 @@ var blkioMetrics = []*metric{
 		unit:   metrics.Total,
 		vt:     prometheus.GaugeValue,
 		labels: []string{"op", "device", "major", "minor"},
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Blkio == nil {
 				return nil
 			}
@@ -98,7 +98,7 @@ var blkioMetrics = []*metric{
 		unit:   metrics.Total,
 		vt:     prometheus.GaugeValue,
 		labels: []string{"op", "device", "major", "minor"},
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Blkio == nil {
 				return nil
 			}
@@ -111,7 +111,7 @@ var blkioMetrics = []*metric{
 		unit:   metrics.Total,
 		vt:     prometheus.GaugeValue,
 		labels: []string{"op", "device", "major", "minor"},
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Blkio == nil {
 				return nil
 			}
@@ -120,7 +120,7 @@ var blkioMetrics = []*metric{
 	},
 }
 
-func blkioValues(l []*cgroups.BlkIOEntry) []value {
+func blkioValues(l []*v1.BlkIOEntry) []value {
 	var out []value
 	for _, e := range l {
 		out = append(out, value{

--- a/metrics/cgroups/cpu.go
+++ b/metrics/cgroups/cpu.go
@@ -21,7 +21,7 @@ package cgroups
 import (
 	"strconv"
 
-	"github.com/containerd/cgroups"
+	v1 "github.com/containerd/containerd/metrics/types/v1"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -32,7 +32,7 @@ var cpuMetrics = []*metric{
 		help: "The total cpu time",
 		unit: metrics.Nanoseconds,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.CPU == nil {
 				return nil
 			}
@@ -48,7 +48,7 @@ var cpuMetrics = []*metric{
 		help: "The total kernel cpu time",
 		unit: metrics.Nanoseconds,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.CPU == nil {
 				return nil
 			}
@@ -64,7 +64,7 @@ var cpuMetrics = []*metric{
 		help: "The total user cpu time",
 		unit: metrics.Nanoseconds,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.CPU == nil {
 				return nil
 			}
@@ -81,7 +81,7 @@ var cpuMetrics = []*metric{
 		unit:   metrics.Nanoseconds,
 		vt:     prometheus.GaugeValue,
 		labels: []string{"cpu"},
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.CPU == nil {
 				return nil
 			}
@@ -100,7 +100,7 @@ var cpuMetrics = []*metric{
 		help: "The total cpu throttle periods",
 		unit: metrics.Total,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.CPU == nil {
 				return nil
 			}
@@ -116,7 +116,7 @@ var cpuMetrics = []*metric{
 		help: "The total cpu throttled periods",
 		unit: metrics.Total,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.CPU == nil {
 				return nil
 			}
@@ -132,7 +132,7 @@ var cpuMetrics = []*metric{
 		help: "The total cpu throttled time",
 		unit: metrics.Nanoseconds,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.CPU == nil {
 				return nil
 			}

--- a/metrics/cgroups/hugetlb.go
+++ b/metrics/cgroups/hugetlb.go
@@ -19,7 +19,7 @@
 package cgroups
 
 import (
-	"github.com/containerd/cgroups"
+	v1 "github.com/containerd/containerd/metrics/types/v1"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -31,7 +31,7 @@ var hugetlbMetrics = []*metric{
 		unit:   metrics.Bytes,
 		vt:     prometheus.GaugeValue,
 		labels: []string{"page"},
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Hugetlb == nil {
 				return nil
 			}
@@ -51,7 +51,7 @@ var hugetlbMetrics = []*metric{
 		unit:   metrics.Total,
 		vt:     prometheus.GaugeValue,
 		labels: []string{"page"},
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Hugetlb == nil {
 				return nil
 			}
@@ -71,7 +71,7 @@ var hugetlbMetrics = []*metric{
 		unit:   metrics.Bytes,
 		vt:     prometheus.GaugeValue,
 		labels: []string{"page"},
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Hugetlb == nil {
 				return nil
 			}

--- a/metrics/cgroups/memory.go
+++ b/metrics/cgroups/memory.go
@@ -19,7 +19,7 @@
 package cgroups
 
 import (
-	"github.com/containerd/cgroups"
+	v1 "github.com/containerd/containerd/metrics/types/v1"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -30,7 +30,7 @@ var memoryMetrics = []*metric{
 		help: "The cache amount used",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -46,7 +46,7 @@ var memoryMetrics = []*metric{
 		help: "The rss amount used",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -62,7 +62,7 @@ var memoryMetrics = []*metric{
 		help: "The rss_huge amount used",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -78,7 +78,7 @@ var memoryMetrics = []*metric{
 		help: "The mapped_file amount used",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -94,7 +94,7 @@ var memoryMetrics = []*metric{
 		help: "The dirty amount",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -110,7 +110,7 @@ var memoryMetrics = []*metric{
 		help: "The writeback amount",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -126,7 +126,7 @@ var memoryMetrics = []*metric{
 		help: "The pgpgin amount",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -142,7 +142,7 @@ var memoryMetrics = []*metric{
 		help: "The pgpgout amount",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -158,7 +158,7 @@ var memoryMetrics = []*metric{
 		help: "The pgfault amount",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -174,7 +174,7 @@ var memoryMetrics = []*metric{
 		help: "The pgmajfault amount",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -190,7 +190,7 @@ var memoryMetrics = []*metric{
 		help: "The inactive_anon amount",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -206,7 +206,7 @@ var memoryMetrics = []*metric{
 		help: "The active_anon amount",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -222,7 +222,7 @@ var memoryMetrics = []*metric{
 		help: "The inactive_file amount",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -238,7 +238,7 @@ var memoryMetrics = []*metric{
 		help: "The active_file amount",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -254,7 +254,7 @@ var memoryMetrics = []*metric{
 		help: "The unevictable amount",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -270,7 +270,7 @@ var memoryMetrics = []*metric{
 		help: "The hierarchical_memory_limit amount",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -286,7 +286,7 @@ var memoryMetrics = []*metric{
 		help: "The hierarchical_memsw_limit amount",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -302,7 +302,7 @@ var memoryMetrics = []*metric{
 		help: "The total_cache amount used",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -318,7 +318,7 @@ var memoryMetrics = []*metric{
 		help: "The total_rss amount used",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -334,7 +334,7 @@ var memoryMetrics = []*metric{
 		help: "The total_rss_huge amount used",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -350,7 +350,7 @@ var memoryMetrics = []*metric{
 		help: "The total_mapped_file amount used",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -366,7 +366,7 @@ var memoryMetrics = []*metric{
 		help: "The total_dirty amount",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -382,7 +382,7 @@ var memoryMetrics = []*metric{
 		help: "The total_writeback amount",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -398,7 +398,7 @@ var memoryMetrics = []*metric{
 		help: "The total_pgpgin amount",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -414,7 +414,7 @@ var memoryMetrics = []*metric{
 		help: "The total_pgpgout amount",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -430,7 +430,7 @@ var memoryMetrics = []*metric{
 		help: "The total_pgfault amount",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -446,7 +446,7 @@ var memoryMetrics = []*metric{
 		help: "The total_pgmajfault amount",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -462,7 +462,7 @@ var memoryMetrics = []*metric{
 		help: "The total_inactive_anon amount",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -478,7 +478,7 @@ var memoryMetrics = []*metric{
 		help: "The total_active_anon amount",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -494,7 +494,7 @@ var memoryMetrics = []*metric{
 		help: "The total_inactive_file amount",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -510,7 +510,7 @@ var memoryMetrics = []*metric{
 		help: "The total_active_file amount",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -526,7 +526,7 @@ var memoryMetrics = []*metric{
 		help: "The total_unevictable amount",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -542,7 +542,7 @@ var memoryMetrics = []*metric{
 		help: "The usage failcnt",
 		unit: metrics.Total,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -558,7 +558,7 @@ var memoryMetrics = []*metric{
 		help: "The memory limit",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -574,7 +574,7 @@ var memoryMetrics = []*metric{
 		help: "The memory maximum usage",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -590,7 +590,7 @@ var memoryMetrics = []*metric{
 		help: "The memory usage",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -606,7 +606,7 @@ var memoryMetrics = []*metric{
 		help: "The swap failcnt",
 		unit: metrics.Total,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -622,7 +622,7 @@ var memoryMetrics = []*metric{
 		help: "The swap limit",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -638,7 +638,7 @@ var memoryMetrics = []*metric{
 		help: "The swap maximum usage",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -654,7 +654,7 @@ var memoryMetrics = []*metric{
 		help: "The swap usage",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -670,7 +670,7 @@ var memoryMetrics = []*metric{
 		help: "The kernel failcnt",
 		unit: metrics.Total,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -686,7 +686,7 @@ var memoryMetrics = []*metric{
 		help: "The kernel limit",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -702,7 +702,7 @@ var memoryMetrics = []*metric{
 		help: "The kernel maximum usage",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -718,7 +718,7 @@ var memoryMetrics = []*metric{
 		help: "The kernel usage",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -734,7 +734,7 @@ var memoryMetrics = []*metric{
 		help: "The kerneltcp failcnt",
 		unit: metrics.Total,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -750,7 +750,7 @@ var memoryMetrics = []*metric{
 		help: "The kerneltcp limit",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -766,7 +766,7 @@ var memoryMetrics = []*metric{
 		help: "The kerneltcp maximum usage",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}
@@ -782,7 +782,7 @@ var memoryMetrics = []*metric{
 		help: "The kerneltcp usage",
 		unit: metrics.Bytes,
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Memory == nil {
 				return nil
 			}

--- a/metrics/cgroups/metric.go
+++ b/metrics/cgroups/metric.go
@@ -19,7 +19,7 @@
 package cgroups
 
 import (
-	"github.com/containerd/cgroups"
+	v1 "github.com/containerd/containerd/metrics/types/v1"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -36,7 +36,7 @@ type metric struct {
 	vt     prometheus.ValueType
 	labels []string
 	// getValues returns the value and labels for the data
-	getValues func(stats *cgroups.Metrics) []value
+	getValues func(stats *v1.Metrics) []value
 }
 
 func (m *metric) desc(ns *metrics.Namespace) *prometheus.Desc {
@@ -44,7 +44,7 @@ func (m *metric) desc(ns *metrics.Namespace) *prometheus.Desc {
 	return ns.NewDesc(m.name, m.help, m.unit, append([]string{"container_id", "namespace"}, m.labels...)...)
 }
 
-func (m *metric) collect(id, namespace string, stats *cgroups.Metrics, ns *metrics.Namespace, ch chan<- prometheus.Metric, block bool) {
+func (m *metric) collect(id, namespace string, stats *v1.Metrics, ns *metrics.Namespace, ch chan<- prometheus.Metric, block bool) {
 	values := m.getValues(stats)
 	for _, v := range values {
 		// block signals to block on the sending the metrics so none are missed

--- a/metrics/cgroups/metrics.go
+++ b/metrics/cgroups/metrics.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/containerd/cgroups"
 	"github.com/containerd/containerd/log"
+	v1 "github.com/containerd/containerd/metrics/types/v1"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/runtime"
 	"github.com/containerd/typeurl"
@@ -114,7 +115,7 @@ func (c *collector) collect(t runtime.Task, ch chan<- prometheus.Metric, block b
 		log.L.WithError(err).Errorf("unmarshal stats for %s", t.ID())
 		return
 	}
-	s, ok := data.(*cgroups.Metrics)
+	s, ok := data.(*v1.Metrics)
 	if !ok {
 		log.L.WithError(err).Errorf("invalid metric type for %s", t.ID())
 		return

--- a/metrics/cgroups/pids.go
+++ b/metrics/cgroups/pids.go
@@ -19,7 +19,7 @@
 package cgroups
 
 import (
-	"github.com/containerd/cgroups"
+	v1 "github.com/containerd/containerd/metrics/types/v1"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -30,7 +30,7 @@ var pidMetrics = []*metric{
 		help: "The limit to the number of pids allowed",
 		unit: metrics.Unit("limit"),
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Pids == nil {
 				return nil
 			}
@@ -46,7 +46,7 @@ var pidMetrics = []*metric{
 		help: "The current number of pids",
 		unit: metrics.Unit("current"),
 		vt:   prometheus.GaugeValue,
-		getValues: func(stats *cgroups.Metrics) []value {
+		getValues: func(stats *v1.Metrics) []value {
 			if stats.Pids == nil {
 				return nil
 			}

--- a/metrics/types/v1/types.go
+++ b/metrics/types/v1/types.go
@@ -1,0 +1,44 @@
+// +build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package v1
+
+import "github.com/containerd/cgroups"
+
+type (
+	// Metrics alias
+	Metrics = cgroups.Metrics
+	// BlkIOEntry alias
+	BlkIOEntry = cgroups.BlkIOEntry
+	// MemoryStat alias
+	MemoryStat = cgroups.MemoryStat
+	// CPUStat alias
+	CPUStat = cgroups.CPUStat
+	// CPUUsage alias
+	CPUUsage = cgroups.CPUUsage
+	// BlkIOStat alias
+	BlkIOStat = cgroups.BlkIOStat
+	// PidsStat alias
+	PidsStat = cgroups.PidsStat
+	// RdmaStat alias
+	RdmaStat = cgroups.RdmaStat
+	// RdmaEntry alias
+	RdmaEntry = cgroups.RdmaEntry
+	// HugetlbStat alias
+	HugetlbStat = cgroups.HugetlbStat
+)


### PR DESCRIPTION
This will help to decouple the import in CRI from the cgroups package
directly by importing the type alias in containerd repo.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>