### PR TITLE
Don't search for state.json path in tests

### DIFF
--- a/daemon_config_linux_test.go
+++ b/daemon_config_linux_test.go
@@ -164,9 +164,9 @@ version = 1
 		t.Fatal(err)
 	}
 
-	stateJSONPath := filepath.Join(runtimeRoot, testNamespace, id, "state.json")
-	if _, err = os.Stat(stateJSONPath); err != nil {
-		t.Errorf("error while getting stat for %s: %v", stateJSONPath, err)
+	containerPath := filepath.Join(runtimeRoot, testNamespace, id)
+	if _, err = os.Stat(containerPath); err != nil {
+		t.Errorf("error while getting stat for %s: %v", containerPath, err)
 	}
 
 	if err = task.Kill(ctx, syscall.SIGKILL); err != nil {


### PR DESCRIPTION
This is for supporting `crun`

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>