### PR TITLE
Check for more kill error types

### DIFF
--- a/pkg/process/utils.go
+++ b/pkg/process/utils.go
@@ -127,6 +127,7 @@ func checkKillError(err error) error {
 	}
 	if strings.Contains(err.Error(), "os: process already finished") ||
 		strings.Contains(err.Error(), "container not running") ||
+		strings.Contains(strings.ToLower(err.Error()), "no such process") ||
 		err == unix.ESRCH {
 		return errors.Wrapf(errdefs.ErrNotFound, "process already finished")
 	}


### PR DESCRIPTION
For `crun` support.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>