### PR TITLE
gen-manpages: Create man directory if it does not exist

### DIFF
--- a/cmd/gen-manpages/main.go
+++ b/cmd/gen-manpages/main.go
@@ -49,6 +49,9 @@ func run() error {
 		if err != nil {
 			return err
 		}
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			os.Mkdir(dir, os.ModePerm)
+		}
 		if err := ioutil.WriteFile(filepath.Join(dir, fmt.Sprintf("%s.1", name)), []byte(data), 0644); err != nil {
 			return err
 		}


### PR DESCRIPTION
`make genman` does not work if the `man` directory does not exist first