### PR TITLE
[release/1.2] Update cri to 40affe7c7402d41618b9791a8cf105ac74ce56d0.

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -43,7 +43,7 @@ github.com/google/go-cmp v0.1.0
 go.etcd.io/bbolt v1.3.1-etcd.8
 
 # cri dependencies
-github.com/containerd/cri ad5dcc6cba067488d017540d06ebc08b21bb82bc # release/1.2 branch
+github.com/containerd/cri 40affe7c7402d41618b9791a8cf105ac74ce56d0 # release/1.2 branch
 github.com/containerd/go-cni 40bcf8ec8acd7372be1d77031d585d5d8e561c90
 github.com/blang/semver v3.1.0
 github.com/containernetworking/cni v0.6.0

--- a/vendor/github.com/containerd/cri/pkg/server/container_create.go
+++ b/vendor/github.com/containerd/cri/pkg/server/container_create.go
@@ -264,6 +264,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get runtime options")
 	}
+
 	opts = append(opts,
 		containerd.WithSpec(spec, specOpts...),
 		containerd.WithRuntime(sandboxInfo.Runtime.Name, runtimeOptions),
@@ -904,6 +905,8 @@ func defaultRuntimeSpec(id string) (*runtimespec.Spec, error) {
 	}
 	if spec.Linux != nil {
 		spec.Linux.Seccomp = nil
+		// add default UNIX path; will be optionally overwritten by image config PATH env
+		spec.Process.Env = append(spec.Process.Env, "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
 	}
 
 	// Remove default rlimits (See issue #515)


### PR DESCRIPTION
* Fix a bug that the default `PATH` is not set in the container https://github.com/containerd/cri/issues/1279.

Signed-off-by: Lantao Liu <lantaol@google.com>