### PR TITLE
Update release docs for 1.3.0

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -97,9 +97,10 @@ The current state is available in the following table:
 | [0.1](https://github.com/containerd/containerd/releases/tag/v0.1.0) | End of Life | Mar 21, 2016 | - |
 | [0.2](https://github.com/containerd/containerd/tree/v0.2.x)         | End of Life | Apr 21, 2016      | December 5, 2017 |
 | [1.0](https://github.com/containerd/containerd/releases/tag/v1.0.3) | End of Life | December 5, 2017  | December 5, 2018 |
-| [1.1](https://github.com/containerd/containerd/releases/tag/v1.1.7) | Extended   | April 23, 2018  | October 23, 2019 |
-| [1.2](https://github.com/containerd/containerd/releases/tag/v1.2.6) | Active   | October 24, 2018 | max(October 24, 2019, release of 1.3.0 + 6 months) |
-| [1.3](https://github.com/containerd/containerd/milestone/20)        | Next   | TBD  | max(TBD+1 year, release of 1.4.0 + 6 months) |
+| [1.1](https://github.com/containerd/containerd/releases/tag/v1.1.8) | Extended   | April 23, 2018  | October 23, 2019 |
+| [1.2](https://github.com/containerd/containerd/releases/tag/v1.2.10) | Active   | October 24, 2018 | March 26, 2020 |
+| [1.3](https://github.com/containerd/containerd/releases/tag/v1.3.0)  | Active   | September 26, 2019  | max(September 26, 2020, release of 1.4.0 + 6 months) |
+| [1.4](https://github.com/containerd/containerd/milestone/27)        | Next   | TBD  | max(TBD+1 year, release of 1.5.0 + 6 months) |
 
 Note that branches and release from before 1.0 may not follow these rules.
 

--- a/releases/v1.3.0.toml
+++ b/releases/v1.3.0.toml
@@ -8,10 +8,10 @@ match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
 # previous release
 previous = "v1.2.0"
 
-pre_release = true
+pre_release = false
 
 preface = """\
-The fourth major release of containerd comes over 9 months after the previous
+The fourth major release of containerd comes 11 months after the previous
 major release and covers a period of both significant project growth and
 further stabilization. Similar to previous releases, the number of API changes
 are small and, as always, backwards compatible. The growing ecosystem of plugins
@@ -24,6 +24,7 @@ implemented in the client libraries without requiring daemon upgrade.
 * **New Windows V2 runtime using shim API.** Adds support for the Windows runtime shims in containerd. *NOTE: while containerd's runtime is stable in this release, running Windows containers are not yet fully supported until the [runhcs shim](https://github.com/microsoft/hcsshim/tree/master/cmd/containerd-shim-runhcs-v1) is fully supported.*
 * **Improvements to ttrpc.** For better daemon to shim communication (https://github.com/containerd/containerd/pull/3341)
 * **Removed experimental Windows V1 runtime**
+* **Update runc dependency** Updated runc for CVE-2019-16884
 
 ### Snapshots
 * **New Devmapper snapshotter** (https://github.com/containerd/containerd/pull/3022)
@@ -47,7 +48,7 @@ implemented in the client libraries without requiring daemon upgrade.
 * **Add payload parameter to apply in diff service API**
 
 ### CRI
-This version of containerd is validated against v1.15, but it is also compatible with Kubernetes v1.12+. (See [more details](https://github.com/containerd/cri#support-metrics) about support metrics)
+This version of containerd is validated against v1.16, but it is also compatible with Kubernetes v1.12+. (See [more details](https://github.com/containerd/cri#support-metrics) about support metrics)
 
 #### Features
 * **Supported per-pod containerd shim.** The `io.containerd.runc.v2` runtime is fully validated and ready to be used in production. This helps minimizing per-pod resource overhead. Note that `io.containerd.runtime.v1.linux` is still the default runtime. (https://github.com/containerd/cri/issues/1075)

--- a/version/version.go
+++ b/version/version.go
@@ -21,7 +21,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.2.0+unknown"
+	Version = "1.3.0+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Updated release docs and notes for 1.3.0 final

Hold on this until after 1.1.8 and 1.2.10

Example of generated notes https://gist.github.com/dmcgowan/faa870c4a0890e739fd1aaf0cfd76eff