### PR TITLE
[release/1.1] Add timeout for I/O waitgroups

### DIFF
--- a/linux/proc/exec.go
+++ b/linux/proc/exec.go
@@ -94,7 +94,7 @@ func (e *execProcess) setExited(status int) {
 }
 
 func (e *execProcess) delete(ctx context.Context) error {
-	e.wg.Wait()
+	waitTimeout(ctx, &e.wg, 2*time.Second)
 	if e.io != nil {
 		for _, c := range e.closers {
 			c.Close()


### PR DESCRIPTION
Backport for #3361

This and a combination of a couple Docker changes are needed to fully
resolve the issue on the Docker side.  However, this ensures that after
processes exit, we still leave some time for the I/O to fully flush
before closing.  Without this timeout, the delete methods would block
forever.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>