### PR TITLE
Update cri to 5d49e7e51b43e36a6b9c4386257c7d08c602237f.

### DIFF
--- a/script/setup/install-critools
+++ b/script/setup/install-critools
@@ -21,7 +21,7 @@
 set -eu -o pipefail
 
 go get -u github.com/onsi/ginkgo/ginkgo
-CRITEST_COMMIT=427262054f59f3b849391310856a19474acb7e83
+CRITEST_COMMIT=v1.16.1
 go get -d github.com/kubernetes-incubator/cri-tools/...
 cd $GOPATH/src/github.com/kubernetes-incubator/cri-tools
 git checkout $CRITEST_COMMIT

--- a/vendor.conf
+++ b/vendor.conf
@@ -51,7 +51,7 @@ github.com/cpuguy83/go-md2man v1.0.10
 github.com/russross/blackfriday v1.5.2
 
 # cri dependencies
-github.com/containerd/cri 4ea022f82a55c449bf15bfc62ac8b0de968d81be # release/1.3
+github.com/containerd/cri 5d49e7e51b43e36a6b9c4386257c7d08c602237f # release/1.3
 github.com/containerd/go-cni 49fbd9b210f3c8ee3b7fd3cd797aabaf364627c1
 github.com/containernetworking/cni v0.7.1
 github.com/containernetworking/plugins v0.7.6


### PR DESCRIPTION
Update cri to 5d49e7e51b43e36a6b9c4386257c7d08c602237f, and critest to v1.16.1.

All CRI changes are done for 1.3.0 after this I believe.

Signed-off-by: Lantao Liu <lantaol@google.com>