### PR TITLE
Fix all media types in Accept header to match RFC

### DIFF
--- a/remotes/docker/fetcher.go
+++ b/remotes/docker/fetcher.go
@@ -136,7 +136,7 @@ func (r dockerFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.R
 }
 
 func (r dockerFetcher) open(ctx context.Context, req *request, mediatype string, offset int64) (io.ReadCloser, error) {
-	req.header.Set("Accept", strings.Join([]string{mediatype, `*`}, ", "))
+	req.header.Set("Accept", strings.Join([]string{mediatype, `*/*`}, ", "))
 
 	if offset > 0 {
 		// Note: "Accept-Ranges: bytes" cannot be trusted as some endpoints

--- a/remotes/docker/pusher.go
+++ b/remotes/docker/pusher.go
@@ -80,7 +80,7 @@ func (p dockerPusher) Push(ctx context.Context, desc ocispec.Descriptor) (conten
 	}
 
 	req := p.request(host, http.MethodHead, existCheck...)
-	req.header.Set("Accept", strings.Join([]string{desc.MediaType, `*`}, ", "))
+	req.header.Set("Accept", strings.Join([]string{desc.MediaType, `*/*`}, ", "))
 
 	log.G(ctx).WithField("url", req.String()).Debugf("checking and pushing to")
 

--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -155,7 +155,7 @@ func NewResolver(options ResolverOptions) remotes.Resolver {
 			images.MediaTypeDockerSchema2Manifest,
 			images.MediaTypeDockerSchema2ManifestList,
 			ocispec.MediaTypeImageManifest,
-			ocispec.MediaTypeImageIndex, "*"}, ", "))
+			ocispec.MediaTypeImageIndex, "*/*"}, ", "))
 	} else {
 		resolveHeader["Accept"] = options.Headers["Accept"]
 		delete(options.Headers, "Accept")


### PR DESCRIPTION
Fixes the media type to align with Accept HTTP header RFC which specifies glob syntax */*

See https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html

Related to #3291 