### PR TITLE
ctr: Enable shell autocompletion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,7 +294,7 @@ root-coverage: ## generate coverage profiles for unit tests that require root
 
 vendor:
 	@echo "$(WHALE) $@"
-	@vndr
+	@vndr -whitelist github.com/urfave/cli/autocomplete/
 
 help: ## this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort

--- a/cmd/ctr/app/main.go
+++ b/cmd/ctr/app/main.go
@@ -71,6 +71,7 @@ stable from release to release of the containerd project.`
 
 containerd CLI
 `
+	app.EnableBashCompletion = true
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{
 			Name:  "debug",

--- a/vendor/github.com/urfave/cli/autocomplete/bash_autocomplete
+++ b/vendor/github.com/urfave/cli/autocomplete/bash_autocomplete
@@ -1,0 +1,21 @@
+#! /bin/bash
+
+: ${PROG:=$(basename ${BASH_SOURCE})}
+
+_cli_bash_autocomplete() {
+  if [[ "${COMP_WORDS[0]}" != "source" ]]; then
+    local cur opts base
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    if [[ "$cur" == "-"* ]]; then
+      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} ${cur} --generate-bash-completion )
+    else
+      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+    fi
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+    return 0
+  fi
+}
+
+complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete $PROG
+unset PROG

--- a/vendor/github.com/urfave/cli/autocomplete/zsh_autocomplete
+++ b/vendor/github.com/urfave/cli/autocomplete/zsh_autocomplete
@@ -1,0 +1,11 @@
+_cli_zsh_autocomplete() {
+
+  local -a opts
+  opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} --generate-bash-completion)}")
+
+  _describe 'values' opts
+
+  return
+}
+
+compdef _cli_zsh_autocomplete $PROG


### PR DESCRIPTION
This enables shell autocompletion for ctr command. I whitelisted the autocompletes in urfave/cli so users can enable and distribute it. See also: https://github.com/urfave/cli#bash-completion