### PR TITLE
Use cached state instead of `runc state`.

### DIFF
--- a/pkg/process/deleted_state.go
+++ b/pkg/process/deleted_state.go
@@ -69,3 +69,7 @@ func (s *deletedState) SetExited(status int) {
 func (s *deletedState) Exec(ctx context.Context, path string, r *ExecConfig) (Process, error) {
 	return nil, errors.Errorf("cannot exec in a deleted state")
 }
+
+func (s *deletedState) Status(ctx context.Context) (string, error) {
+	return "stopped", nil
+}

--- a/pkg/process/exec.go
+++ b/pkg/process/exec.go
@@ -261,17 +261,5 @@ func (e *execProcess) Status(ctx context.Context) (string, error) {
 	}
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	// if we don't have a pid(pid=0) then the exec process has just been created
-	if e.pid.get() == 0 {
-		return "created", nil
-	}
-	if e.pid.get() == StoppedPID {
-		return "stopped", nil
-	}
-	// if we have a pid and it can be signaled, the process is running
-	if err := unix.Kill(e.pid.get(), 0); err == nil {
-		return "running", nil
-	}
-	// else if we have a pid but it can nolonger be signaled, it has stopped
-	return "stopped", nil
+	return e.execState.Status(ctx)
 }

--- a/pkg/process/exec_state.go
+++ b/pkg/process/exec_state.go
@@ -31,6 +31,7 @@ type execState interface {
 	Delete(context.Context) error
 	Kill(context.Context, uint32, bool) error
 	SetExited(int)
+	Status(context.Context) (string, error)
 }
 
 type execCreatedState struct {
@@ -82,6 +83,10 @@ func (s *execCreatedState) SetExited(status int) {
 	}
 }
 
+func (s *execCreatedState) Status(ctx context.Context) (string, error) {
+	return "created", nil
+}
+
 type execRunningState struct {
 	p *execProcess
 }
@@ -120,6 +125,10 @@ func (s *execRunningState) SetExited(status int) {
 	}
 }
 
+func (s *execRunningState) Status(ctx context.Context) (string, error) {
+	return "running", nil
+}
+
 type execStoppedState struct {
 	p *execProcess
 }
@@ -156,4 +165,8 @@ func (s *execStoppedState) Kill(ctx context.Context, sig uint32, all bool) error
 
 func (s *execStoppedState) SetExited(status int) {
 	// no op
+}
+
+func (s *execStoppedState) Status(ctx context.Context) (string, error) {
+	return "stopped", nil
 }

--- a/pkg/process/init.go
+++ b/pkg/process/init.go
@@ -56,12 +56,14 @@ type Init struct {
 
 	WorkDir string
 
-	id           string
-	Bundle       string
-	console      console.Console
-	Platform     stdio.Platform
-	io           *processIO
-	runtime      *runc.Runc
+	id       string
+	Bundle   string
+	console  console.Console
+	Platform stdio.Platform
+	io       *processIO
+	runtime  *runc.Runc
+	// pausing preserves the pausing state.
+	pausing      *atomicBool
 	status       int
 	exited       time.Time
 	pid          safePid
@@ -97,6 +99,7 @@ func New(id string, runtime *runc.Runc, stdio stdio.Stdio) *Init {
 	p := &Init{
 		id:        id,
 		runtime:   runtime,
+		pausing:   new(atomicBool),
 		stdio:     stdio,
 		status:    0,
 		waitBlock: make(chan struct{}),
@@ -237,17 +240,14 @@ func (p *Init) ExitedAt() time.Time {
 
 // Status of the process
 func (p *Init) Status(ctx context.Context) (string, error) {
+	if p.pausing.get() {
+		return "pausing", nil
+	}
+
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	c, err := p.runtime.State(ctx, p.id)
-	if err != nil {
-		if strings.Contains(err.Error(), "does not exist") {
-			return "stopped", nil
-		}
-		return "", p.runtimeError(err, "OCI runtime state failed")
-	}
-	return c.Status, nil
+	return p.initState.Status(ctx)
 }
 
 // Start the init process

--- a/pkg/process/utils.go
+++ b/pkg/process/utils.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/containerd/containerd/errdefs"
@@ -60,6 +61,20 @@ func (s *safePid) set(pid int) {
 	s.Lock()
 	s.pid = pid
 	s.Unlock()
+}
+
+type atomicBool int32
+
+func (ab *atomicBool) set(b bool) {
+	if b {
+		atomic.StoreInt32((*int32)(ab), 1)
+	} else {
+		atomic.StoreInt32((*int32)(ab), 0)
+	}
+}
+
+func (ab *atomicBool) get() bool {
+	return atomic.LoadInt32((*int32)(ab)) == 1
 }
 
 // TODO(mlaventure): move to runc package?


### PR DESCRIPTION
See https://github.com/kubernetes/kubernetes/issues/82440 and https://github.com/moby/moby/issues/39102

I think we should cherry-pick this into 1.2 and 1.3.

In Kubernetes, we observed that exec in containerd is fair expensive. With Docker 18.09, for each exec process, 8 `runc state` processes will be spawned.

The followings are results of `sudo strace -f -p SHIM_PID -e execve` when we simply run a `crictl exec CONTAINER_ID echo hello`.

* Containerd with `containerd-shim` (I believe most people are still using this):
```console
$ cat result | grep execve
[pid 229037] execve("/usr/local/sbin/runc", ["runc", "--root", "/run/containerd/runc/k8s.io", "--log", "/run/containerd/io.containerd.ru"..., "--log-format", "json", "state", "174c9870fbd569c79d7e8d706323134a"...], 0xc000059000 /* 6 vars */) = 0
[pid 229043] execve("/usr/local/sbin/runc", ["runc", "--root", "/run/containerd/runc/k8s.io", "--log", "/run/containerd/io.containerd.ru"..., "--log-format", "json", "state", "174c9870fbd569c79d7e8d706323134a"...], 0xc0001393c0 /* 6 vars */) = 0
[pid 229049] execve("/usr/local/sbin/runc", ["runc", "--root", "/run/containerd/runc/k8s.io", "--log", "/run/containerd/io.containerd.ru"..., "--log-format", "json", "state", "174c9870fbd569c79d7e8d706323134a"...], 0xc000059080 /* 6 vars */) = 0
[pid 229055] execve("/usr/local/sbin/runc", ["runc", "--root", "/run/containerd/runc/k8s.io", "--log", "/run/containerd/io.containerd.ru"..., "--log-format", "json", "exec", "--process", "/tmp/runc-process270233118", "--detach", "--pid-file", "/run/containerd/io.containerd.ru"..., "174c9870fbd569c79d7e8d706323134a"...], 0xc000059140 /* 6 vars */) = 0
[pid 229062] execve("/proc/self/exe", ["runc", "init"], 0xc000058500 /* 6 vars */) = 0
[pid 229066] execve("/bin/echo", ["echo", "hello"], 0xc00007d0c0 /* 3 vars */ <unfinished ...>
[pid 229066] <... execve resumed> )     = 0
[pid 229073] execve("/usr/local/sbin/runc", ["runc", "--root", "/run/containerd/runc/k8s.io", "--log", "/run/containerd/io.containerd.ru"..., "--log-format", "json", "state", "174c9870fbd569c79d7e8d706323134a"...], 0xc000059340 /* 6 vars */) = 0
[pid 229074] execve("/usr/local/bin/containerd", ["/usr/local/bin/containerd", "--address", "/run/containerd/containerd.sock", "publish", "--topic", "/tasks/exit", "--namespace", "k8s.io"], 0xc0002d0540 /* 6 vars */) = 0
[pid 229080] execve("/usr/local/sbin/runc", ["runc", "--root", "/run/containerd/runc/k8s.io", "--log", "/run/containerd/io.containerd.ru"..., "--log-format", "json", "state", "174c9870fbd569c79d7e8d706323134a"...], 0xc0002d0a40 /* 6 vars */) = 0
[pid 229091] execve("/usr/local/sbin/runc", ["runc", "--root", "/run/containerd/runc/k8s.io", "--log", "/run/containerd/io.containerd.ru"..., "--log-format", "json", "state", "174c9870fbd569c79d7e8d706323134a"...], 0xc0000593c0 /* 6 vars */) = 0
[pid 229099] execve("/usr/local/sbin/runc", ["runc", "--root", "/run/containerd/runc/k8s.io", "--log", "/run/containerd/io.containerd.ru"..., "--log-format", "json", "state", "174c9870fbd569c79d7e8d706323134a"...], 0xc000059480 /* 6 vars */) = 0
[pid 229105] execve("/usr/local/sbin/runc", ["runc", "--root", "/run/containerd/runc/k8s.io", "--log", "/run/containerd/io.containerd.ru"..., "--log-format", "json", "state", "174c9870fbd569c79d7e8d706323134a"...], 0xc0002d17c0 /* 6 vars */) = 0
[pid 229111] execve("/usr/local/sbin/runc", ["runc", "--root", "/run/containerd/runc/k8s.io", "--log", "/run/containerd/io.containerd.ru"..., "--log-format", "json", "state", "174c9870fbd569c79d7e8d706323134a"...], 0xc000059940 /* 6 vars */) = 0

```

* Containerd with `containerd-shim-runc-v1` (shim v2 implementation has less unnecessary `runc state`, because those unnecessary `runc state` are introduced by `containerd-shim` specific code https://github.com/containerd/containerd/blob/v1.3.0/runtime/v1/linux/task.go#L318):
```console
$ cat result | grep execve
[pid 225273] execve("/usr/local/sbin/runc", ["runc", "--root", "/run/containerd/runc.v1/k8s.io", "--log", "/run/containerd/io.containerd.ru"..., "--log-format", "json", "state", "9d7dfbb4ce08f1ed732ad9683d6ab09b"...], 0xc000290040 /* 7 vars */) = 0
[pid 225280] execve("/usr/local/sbin/runc", ["runc", "--root", "/run/containerd/runc.v1/k8s.io", "--log", "/run/containerd/io.containerd.ru"..., "--log-format", "json", "exec", "--process", "/tmp/runc-process475686972", "--detach", "--pid-file", "/run/containerd/io.containerd.ru"..., "9d7dfbb4ce08f1ed732ad9683d6ab09b"...], 0xc000290380 /* 7 vars */) = 0
[pid 225286] execve("/proc/self/exe", ["runc", "init"], 0xc00005a200 /* 6 vars */) = 0
[pid 225290] execve("/bin/echo", ["echo", "hello"], 0xc00007d0c0 /* 3 vars */ <unfinished ...>
[pid 225290] <... execve resumed> )     = 0
[pid 225297] execve("/usr/local/sbin/runc", ["runc", "--root", "/run/containerd/runc.v1/k8s.io", "--log", "/run/containerd/io.containerd.ru"..., "--log-format", "json", "state", "9d7dfbb4ce08f1ed732ad9683d6ab09b"...], 0xc000290880 /* 7 vars */) = 0
[pid 225303] execve("/usr/local/sbin/runc", ["runc", "--root", "/run/containerd/runc.v1/k8s.io", "--log", "/run/containerd/io.containerd.ru"..., "--log-format", "json", "state", "9d7dfbb4ce08f1ed732ad9683d6ab09b"...], 0xc000290980 /* 7 vars */) = 0
```

* Containerd with `containerd-shim` with this change (no `runc state` anymore):
```console
$ cat result | grep execve
[pid 220550] execve("/usr/local/sbin/runc", ["runc", "--root", "/run/containerd/runc/k8s.io", "--log", "/run/containerd/io.containerd.ru"..., "--log-format", "json", "exec", "--process", "/tmp/runc-process002244826", "--detach", "--pid-file", "/run/containerd/io.containerd.ru"..., "1821a71464ad289dc60f6fd6a2d1a2cd"...], 0xc00007e200 /* 6 vars */) = 0
[pid 220556] execve("/proc/self/exe", ["runc", "init"], 0xc000058300 /* 6 vars */) = 0
[pid 220560] execve("/bin/echo", ["echo", "hello"], 0xc00007d0c0 /* 3 vars */ <unfinished ...>
[pid 220560] <... execve resumed> )     = 0
[pid 220568] execve("/usr/local/bin/containerd", ["/usr/local/bin/containerd", "--address", "/run/containerd/containerd.sock", "publish", "--topic", "/tasks/exit", "--namespace", "k8s.io"], 0xc00007f000 /* 6 vars */) = 0
```
Signed-off-by: Lantao Liu <lantaol@google.com>