### PR TITLE
adding go version to client description

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ DESTDIR ?= /usr/local
 VERSION=$(shell git describe --match 'v[0-9]*' --dirty='.m' --always)
 REVISION=$(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi)
 PACKAGE=github.com/containerd/containerd
+GOVERSION=$(shell go version | awk '{print $$3}')
 
 ifneq "$(strip $(shell command -v go 2>/dev/null))" ""
 	GOOS ?= $(shell go env GOOS)
@@ -91,7 +92,7 @@ endif
 GO_BUILDTAGS ?= seccomp apparmor
 GO_BUILDTAGS += ${DEBUG_TAGS}
 GO_TAGS=$(if $(GO_BUILDTAGS),-tags "$(GO_BUILDTAGS)",)
-GO_LDFLAGS=-ldflags '-X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PACKAGE) $(EXTRA_LDFLAGS)'
+GO_LDFLAGS=-ldflags '-X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PACKAGE) -X $(PKG)/version.GoVersion=$(GOVERSION)  $(EXTRA_LDFLAGS)'
 SHIM_GO_LDFLAGS=-ldflags '-X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PACKAGE) -extldflags "-static" $(EXTRA_LDFLAGS)'
 
 #Replaces ":" (*nix), ";" (windows) with newline for easy parsing

--- a/cmd/ctr/commands/version/version.go
+++ b/cmd/ctr/commands/version/version.go
@@ -33,6 +33,7 @@ var Command = cli.Command{
 		fmt.Println("Client:")
 		fmt.Println("  Version: ", version.Version)
 		fmt.Println("  Revision:", version.Revision)
+		fmt.Println("  Go version:", version.GoVersion)
 		fmt.Println("")
 		client, ctx, cancel, err := commands.NewClient(context)
 		if err != nil {

--- a/version/version.go
+++ b/version/version.go
@@ -26,4 +26,7 @@ var (
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.
 	Revision = ""
+
+	// GoVersion is filled at linking time
+	GoVersion = ""
 )


### PR DESCRIPTION
Signed-off-by: fahed dorgaa <fahed.dorgaa@gmail.com>

It is important to have the go version in the client and server description. This PR handle only the go version in the client. We should do the same think for server.