### PR TITLE
Add MountProvider APIs to client 

### DIFF
--- a/client.go
+++ b/client.go
@@ -48,6 +48,7 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/leases"
 	leasesproxy "github.com/containerd/containerd/leases/proxy"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/pkg/dialer"
 	"github.com/containerd/containerd/platforms"
@@ -590,6 +591,10 @@ func (c *Client) SnapshotService(snapshotterName string) snapshots.Snapshotter {
 	return snproxy.NewSnapshotter(snapshotsapi.NewSnapshotsClient(c.conn), snapshotterName)
 }
 
+func (c *Client) MountProvider(name string) mount.MountProvider {
+	return c.SnapshotService(name)
+}
+
 // TaskService returns the underlying TasksClient
 func (c *Client) TaskService() tasks.TasksClient {
 	if c.taskService != nil {
@@ -744,6 +749,10 @@ func (c *Client) getSnapshotter(ctx context.Context, name string) (snapshots.Sna
 	}
 
 	return s, nil
+}
+
+func (c *Client) getMountProvider(ctx context.Context, name string) (mount.MountProvider, error) {
+	return c.getSnapshotter(ctx, name)
 }
 
 // CheckRuntime returns true if the current runtime matches the expected

--- a/client_opts.go
+++ b/client_opts.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/remotes"
 	"google.golang.org/grpc"
@@ -32,6 +33,7 @@ type clientOpts struct {
 	services        *services
 	dialOptions     []grpc.DialOption
 	timeout         time.Duration
+	mountProviders  map[string]mount.Provider
 }
 
 // ClientOpt allows callers to set options on the containerd client
@@ -87,6 +89,14 @@ func WithServices(opts ...ServicesOpt) ClientOpt {
 func WithTimeout(d time.Duration) ClientOpt {
 	return func(c *clientOpts) error {
 		c.timeout = d
+		return nil
+	}
+}
+
+// WithMountProvider sets the provider by name to the client
+func WithMountProvider(name string, p mount.Provider) ClientOpt {
+	return func(c *clientOpts) error {
+		c.mountProviders[name] = p
 		return nil
 	}
 }

--- a/container.go
+++ b/container.go
@@ -233,12 +233,12 @@ func (c *container) NewTask(ctx context.Context, ioCreate cio.Creator, opts ...N
 			return nil, errors.Wrapf(errdefs.ErrInvalidArgument, "unable to resolve rootfs mounts without snapshotter on container")
 		}
 
-		// get the rootfs from the snapshotter and add it to the request
-		s, err := c.client.getSnapshotter(ctx, r.Snapshotter)
+		// get the rootfs from the mount provider and add it to the request
+		p, err := c.client.getMountProvider(ctx, r.Snapshotter)
 		if err != nil {
 			return nil, err
 		}
-		mounts, err := s.Mounts(ctx, r.SnapshotKey)
+		mounts, err := p.Mounts(ctx, r.SnapshotKey)
 		if err != nil {
 			return nil, err
 		}

--- a/image.go
+++ b/image.go
@@ -327,10 +327,7 @@ func (i *image) UnpackTo(ctx context.Context, opts ...UnpackOpt) error {
 		chain   []digest.Digest
 		applyFn func(rootfs.Layer, []digest.Digest) (bool, error)
 	)
-	if config.SnapshotterName == "" && len(config.Mounts) == 0 {
-		return errors.New("snapshotter name and mounts are both empty for unpack")
-	}
-	if config.SnapshotterName != "" {
+	if len(config.Mounts) == 0 {
 		config.SnapshotterName, err = i.client.resolveSnapshotterName(ctx, config.SnapshotterName)
 		if err != nil {
 			return err

--- a/mount/provider.go
+++ b/mount/provider.go
@@ -1,0 +1,27 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package mount
+
+import (
+	"context"
+)
+
+// MountProvider for mounts via various sources.
+type MountProvider interface {
+	// Mounts returns the mounts for the provided key.
+	Mounts(ctx context.Context, key string) ([]Mount, error)
+}

--- a/mount/provider.go
+++ b/mount/provider.go
@@ -20,8 +20,8 @@ import (
 	"context"
 )
 
-// MountProvider for mounts via various sources.
-type MountProvider interface {
+// Provider for mounts via various sources.
+type Provider interface {
 	// Mounts returns the mounts for the provided key.
 	Mounts(ctx context.Context, key string) ([]Mount, error)
 }

--- a/oci/client.go
+++ b/oci/client.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/snapshots"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -27,6 +28,7 @@ import (
 // Client interface used by SpecOpt
 type Client interface {
 	SnapshotService(snapshotterName string) snapshots.Snapshotter
+	MountProvider(name string) mount.MountProvider
 }
 
 // Image interface used by some SpecOpt to query image configuration

--- a/oci/client.go
+++ b/oci/client.go
@@ -28,7 +28,7 @@ import (
 // Client interface used by SpecOpt
 type Client interface {
 	SnapshotService(snapshotterName string) snapshots.Snapshotter
-	MountProvider(name string) mount.MountProvider
+	MountProvider(name string) mount.Provider
 }
 
 // Image interface used by some SpecOpt to query image configuration

--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -557,8 +557,8 @@ func WithUser(userstr string) SpecOpts {
 			if c.SnapshotKey == "" {
 				return errors.New("rootfs snapshot not created for container")
 			}
-			snapshotter := client.SnapshotService(c.Snapshotter)
-			mounts, err := snapshotter.Mounts(ctx, c.SnapshotKey)
+			p := client.MountProvider(c.Snapshotter)
+			mounts, err := p.Mounts(ctx, c.SnapshotKey)
 			if err != nil {
 				return err
 			}
@@ -610,8 +610,8 @@ func WithUserID(uid uint32) SpecOpts {
 		if c.SnapshotKey == "" {
 			return errors.Errorf("rootfs snapshot not created for container")
 		}
-		snapshotter := client.SnapshotService(c.Snapshotter)
-		mounts, err := snapshotter.Mounts(ctx, c.SnapshotKey)
+		p := client.MountProvider(c.Snapshotter)
+		mounts, err := p.Mounts(ctx, c.SnapshotKey)
 		if err != nil {
 			return err
 		}
@@ -743,8 +743,8 @@ func WithAdditionalGIDs(userstr string) SpecOpts {
 		if c.SnapshotKey == "" {
 			return errors.Errorf("rootfs snapshot not created for container")
 		}
-		snapshotter := client.SnapshotService(c.Snapshotter)
-		mounts, err := snapshotter.Mounts(ctx, c.SnapshotKey)
+		p := client.MountProvider(c.Snapshotter)
+		mounts, err := p.Mounts(ctx, c.SnapshotKey)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
These APIs allow simple infrastructure to provide mounts for use with container root filesystems.  For remote filesystems that only provide runtime rootfs' to a container, the entire snapshotter API is not needed.  Snapshotters are still needed for local and build usecases but at runtime, only a pull and mount flow is required to run a container.

