### PR TITLE
build: Fix manpage generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,7 @@ script:
   - go build -i .
   - make check
   - if [ "$GOOS" = "linux" ]; then make check-protos check-api-descriptors; fi
+  - if [ "$TRAVIS_GOOS" = "linux" ]; then make man ; fi
   - make build
   - make binaries
   - if [ "$TRAVIS_GOOS" = "linux" ]; then sudo make install ; fi

--- a/Makefile
+++ b/Makefile
@@ -203,11 +203,19 @@ man: mandir $(addprefix man/,$(MANPAGES))
 mandir:
 	@mkdir -p man
 
-genman: FORCE
-	go run cmd/gen-manpages/main.go man/
+# Kept for backwards compatability
+genman: man/containerd.1 man/ctr.1
+
+man/containerd.1: FORCE
+	@echo "$(WHALE) $@"
+	go run cmd/gen-manpages/main.go containerd man/
+
+man/ctr.1: FORCE
+	@echo "$(WHALE) $@"
+	go run cmd/gen-manpages/main.go ctr man/
 
 man/%: docs/man/%.md FORCE
-	@echo "$(WHALE) $<"
+	@echo "$(WHALE) $@"
 	go-md2man -in "$<" -out "$@"
 
 define installmanpage

--- a/cmd/gen-manpages/main.go
+++ b/cmd/gen-manpages/main.go
@@ -41,20 +41,23 @@ func run() error {
 		"containerd": command.App(),
 		"ctr":        app.New(),
 	}
-	dir := flag.Arg(0)
-	for name, app := range apps {
-		// clear out the usage as we use banners that do not display in man pages
-		app.Usage = ""
-		data, err := app.ToMan()
-		if err != nil {
-			return err
-		}
-		if _, err := os.Stat(dir); os.IsNotExist(err) {
-			os.Mkdir(dir, os.ModePerm)
-		}
-		if err := ioutil.WriteFile(filepath.Join(dir, fmt.Sprintf("%s.1", name)), []byte(data), 0644); err != nil {
-			return err
-		}
+	name := flag.Arg(0)
+	dir := flag.Arg(1)
+	app, ok := apps[name]
+	if !ok {
+		return fmt.Errorf("Invalid application '%s'", name)
+	}
+	// clear out the usage as we use banners that do not display in man pages
+	app.Usage = ""
+	data, err := app.ToMan()
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		os.Mkdir(dir, os.ModePerm)
+	}
+	if err := ioutil.WriteFile(filepath.Join(dir, fmt.Sprintf("%s.1", name)), []byte(data), 0644); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
Seems to be that docs/man/ctr.1.md and docs/man/containerd.1.md were
removed in #3637 and were not updated correctly in the Makefile, leading
to build failures like:

    + make man

    make: *** No rule to make target `man/ctr.1', needed by `man'.  Stop.

Changes the gen-manpages command to be specific on which manpages are to
be generated.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>

Also added a check in the travis yml so that this gets checked on PRs

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>