### PR TITLE
Fix shim delete error code.

### DIFF
--- a/runtime/v1/shim/service.go
+++ b/runtime/v1/shim/service.go
@@ -217,7 +217,7 @@ func (s *Service) Delete(ctx context.Context, r *ptypes.Empty) (*shimapi.DeleteR
 		return nil, err
 	}
 	if err := p.Delete(ctx); err != nil {
-		return nil, err
+		return nil, errdefs.ToGRPC(err)
 	}
 	s.mu.Lock()
 	delete(s.processes, s.id)
@@ -240,7 +240,7 @@ func (s *Service) DeleteProcess(ctx context.Context, r *shimapi.DeleteProcessReq
 		return nil, err
 	}
 	if err := p.Delete(ctx); err != nil {
-		return nil, err
+		return nil, errdefs.ToGRPC(err)
 	}
 	s.mu.Lock()
 	delete(s.processes, r.ID)


### PR DESCRIPTION
The delete error code is not properly propagated.

Found this when working on https://github.com/containerd/cri/pull/1309.

Let's cherrypick the fix, because the correct error code can avoid unnecessary retries in the CRI plugin.

Signed-off-by: Lantao Liu <lantaol@google.com>