### PR TITLE
Fix delete error code on the containerd daemon side.

### DIFF
--- a/runtime/v1/linux/task.go
+++ b/runtime/v1/linux/task.go
@@ -91,9 +91,12 @@ func (t *Task) PID() uint32 {
 
 // Delete the task and return the exit status
 func (t *Task) Delete(ctx context.Context) (*runtime.Exit, error) {
-	rsp, err := t.shim.Delete(ctx, empty)
-	if err != nil && !errdefs.IsNotFound(err) {
-		return nil, errdefs.FromGRPC(err)
+	rsp, shimErr := t.shim.Delete(ctx, empty)
+	if shimErr != nil {
+		shimErr = errdefs.FromGRPC(shimErr)
+		if !errdefs.IsNotFound(shimErr) {
+			return nil, shimErr
+		}
 	}
 	t.tasks.Delete(ctx, t.id)
 	if err := t.shim.KillShim(ctx); err != nil {
@@ -101,6 +104,9 @@ func (t *Task) Delete(ctx context.Context) (*runtime.Exit, error) {
 	}
 	if err := t.bundle.Delete(); err != nil {
 		log.G(ctx).WithError(err).Error("failed to delete bundle")
+	}
+	if shimErr != nil {
+		return nil, shimErr
 	}
 	t.events.Publish(ctx, runtime.TaskDeleteEventTopic, &eventstypes.TaskDelete{
 		ContainerID: t.id,

--- a/runtime/v2/shim.go
+++ b/runtime/v2/shim.go
@@ -222,11 +222,14 @@ func (s *shim) Close() error {
 }
 
 func (s *shim) Delete(ctx context.Context) (*runtime.Exit, error) {
-	response, err := s.task.Delete(ctx, &task.DeleteRequest{
+	response, shimErr := s.task.Delete(ctx, &task.DeleteRequest{
 		ID: s.ID(),
 	})
-	if err != nil && !errdefs.IsNotFound(err) {
-		return nil, errdefs.FromGRPC(err)
+	if shimErr != nil {
+		shimErr = errdefs.FromGRPC(shimErr)
+		if !errdefs.IsNotFound(shimErr) {
+			return nil, shimErr
+		}
 	}
 	// remove self from the runtime task list
 	// this seems dirty but it cleans up the API across runtimes, tasks, and the service
@@ -237,6 +240,9 @@ func (s *shim) Delete(ctx context.Context) (*runtime.Exit, error) {
 	s.Close()
 	if err := s.bundle.Delete(); err != nil {
 		log.G(ctx).WithError(err).Error("failed to delete bundle")
+	}
+	if shimErr != nil {
+		return nil, shimErr
 	}
 	return &runtime.Exit{
 		Status:    response.ExitStatus,

--- a/services/tasks/local.go
+++ b/services/tasks/local.go
@@ -241,7 +241,7 @@ func (l *local) Delete(ctx context.Context, r *api.DeleteTaskRequest, _ ...grpc.
 	}
 	exit, err := t.Delete(ctx)
 	if err != nil {
-		return nil, err
+		return nil, errdefs.ToGRPC(err)
 	}
 	return &api.DeleteResponse{
 		ExitStatus: exit.Status,
@@ -257,7 +257,7 @@ func (l *local) DeleteProcess(ctx context.Context, r *api.DeleteProcessRequest, 
 	}
 	process, err := t.Process(ctx, r.ExecID)
 	if err != nil {
-		return nil, err
+		return nil, errdefs.ToGRPC(err)
 	}
 	exit, err := process.Delete(ctx)
 	if err != nil {


### PR DESCRIPTION
With more test, I found that https://github.com/containerd/containerd/pull/3730 is not enough:
1) The containerd daemon doesn't return grpc error properly;
2) The fix https://github.com/containerd/containerd/pull/3244 never worked, because the returned error is not converted to internal errors. And after converting to internal error, we didn't handle the `nil` response properly.

Signed-off-by: Lantao Liu <lantaol@google.com>