### PR TITLE
[release/1.2] backport: Fix delete error code on the containerd daemon side.

### DIFF
--- a/services/tasks/local.go
+++ b/services/tasks/local.go
@@ -229,7 +229,7 @@ func (l *local) Delete(ctx context.Context, r *api.DeleteTaskRequest, _ ...grpc.
 	}
 	exit, err := t.Delete(ctx)
 	if err != nil {
-		return nil, err
+		return nil, errdefs.ToGRPC(err)
 	}
 	return &api.DeleteResponse{
 		ExitStatus: exit.Status,
@@ -245,7 +245,7 @@ func (l *local) DeleteProcess(ctx context.Context, r *api.DeleteProcessRequest, 
 	}
 	process, err := t.Process(ctx, r.ExecID)
 	if err != nil {
-		return nil, err
+		return nil, errdefs.ToGRPC(err)
 	}
 	exit, err := process.Delete(ctx)
 	if err != nil {


### PR DESCRIPTION
Slight backport of the cherry-pick due to small code differences in `runtime/v2/shim.go`

Signed-off-by: Lantao Liu <lantaol@google.com>
Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>