### PR TITLE
Move flag.Parse in tests to TestMain

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -54,7 +54,6 @@ func init() {
 	flag.StringVar(&address, "address", defaultAddress, "The address to the containerd socket for use in the tests")
 	flag.BoolVar(&noDaemon, "no-daemon", false, "Do not start a dedicated daemon for the tests")
 	flag.BoolVar(&noCriu, "no-criu", false, "Do not run the checkpoint tests")
-	flag.Parse()
 }
 
 func testContext(t testing.TB) (context.Context, context.CancelFunc) {
@@ -67,6 +66,7 @@ func testContext(t testing.TB) (context.Context, context.CancelFunc) {
 }
 
 func TestMain(m *testing.M) {
+	flag.Parse()
 	if testing.Short() {
 		os.Exit(m.Run())
 	}


### PR DESCRIPTION
This this fixes issues with custom and testing flags in Go 1.3 and should work
in previous go versions.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>