### PR TITLE
[release/1.2] Add local-fs.target to service file

### DIFF
--- a/containerd.service
+++ b/containerd.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=containerd container runtime
 Documentation=https://containerd.io
-After=network.target
+After=network.target local-fs.target
 
 [Service]
 ExecStartPre=-/sbin/modprobe overlay


### PR DESCRIPTION
This will ensure that containerd is started after the /etc/fstab entries

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>