### PR TITLE
Allow 202 response code for commit

### DIFF
--- a/remotes/docker/pusher.go
+++ b/remotes/docker/pusher.go
@@ -339,9 +339,9 @@ func (pw *pushWriter) Commit(ctx context.Context, size int64, expected digest.Di
 	}
 
 	// 201 is specified return status, some registries return
-	// 200 or 204.
+	// 200, 202 or 204.
 	switch resp.StatusCode {
-	case http.StatusOK, http.StatusCreated, http.StatusNoContent:
+	case http.StatusOK, http.StatusCreated, http.StatusNoContent, http.StatusAccepted:
 	default:
 		return errors.Errorf("unexpected status: %s", resp.Status)
 	}


### PR DESCRIPTION
When using containerd, I noticed that I would get an `unexpected status: 202 Accepted` when pushing manifests to Quay.

