### PR TITLE
[release/1.3 backport] Use cached state instead of `runc state`.

### DIFF
--- a/pkg/process/deleted_state.go
+++ b/pkg/process/deleted_state.go
@@ -69,3 +69,7 @@ func (s *deletedState) SetExited(status int) {
 func (s *deletedState) Exec(ctx context.Context, path string, r *ExecConfig) (Process, error) {
 	return nil, errors.Errorf("cannot exec in a deleted state")
 }
+
+func (s *deletedState) Status(ctx context.Context) (string, error) {
+	return "stopped", nil
+}

--- a/pkg/process/exec.go
+++ b/pkg/process/exec.go
@@ -261,17 +261,5 @@ func (e *execProcess) Status(ctx context.Context) (string, error) {
 	}
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	// if we don't have a pid(pid=0) then the exec process has just been created
-	if e.pid.get() == 0 {
-		return "created", nil
-	}
-	if e.pid.get() == StoppedPID {
-		return "stopped", nil
-	}
-	// if we have a pid and it can be signaled, the process is running
-	if err := unix.Kill(e.pid.get(), 0); err == nil {
-		return "running", nil
-	}
-	// else if we have a pid but it can nolonger be signaled, it has stopped
-	return "stopped", nil
+	return e.execState.Status(ctx)
 }

--- a/pkg/process/exec_state.go
+++ b/pkg/process/exec_state.go
@@ -31,6 +31,7 @@ type execState interface {
 	Delete(context.Context) error
 	Kill(context.Context, uint32, bool) error
 	SetExited(int)
+	Status(context.Context) (string, error)
 }
 
 type execCreatedState struct {
@@ -82,6 +83,10 @@ func (s *execCreatedState) SetExited(status int) {
 	}
 }
 
+func (s *execCreatedState) Status(ctx context.Context) (string, error) {
+	return "created", nil
+}
+
 type execRunningState struct {
 	p *execProcess
 }
@@ -120,6 +125,10 @@ func (s *execRunningState) SetExited(status int) {
 	}
 }
 
+func (s *execRunningState) Status(ctx context.Context) (string, error) {
+	return "running", nil
+}
+
 type execStoppedState struct {
 	p *execProcess
 }
@@ -156,4 +165,8 @@ func (s *execStoppedState) Kill(ctx context.Context, sig uint32, all bool) error
 
 func (s *execStoppedState) SetExited(status int) {
 	// no op
+}
+
+func (s *execStoppedState) Status(ctx context.Context) (string, error) {
+	return "stopped", nil
 }

--- a/pkg/process/init.go
+++ b/pkg/process/init.go
@@ -56,12 +56,14 @@ type Init struct {
 
 	WorkDir string
 
-	id           string
-	Bundle       string
-	console      console.Console
-	Platform     stdio.Platform
-	io           *processIO
-	runtime      *runc.Runc
+	id       string
+	Bundle   string
+	console  console.Console
+	Platform stdio.Platform
+	io       *processIO
+	runtime  *runc.Runc
+	// pausing preserves the pausing state.
+	pausing      *atomicBool
 	status       int
 	exited       time.Time
 	pid          safePid
@@ -97,6 +99,7 @@ func New(id string, runtime *runc.Runc, stdio stdio.Stdio) *Init {
 	p := &Init{
 		id:        id,
 		runtime:   runtime,
+		pausing:   new(atomicBool),
 		stdio:     stdio,
 		status:    0,
 		waitBlock: make(chan struct{}),
@@ -237,17 +240,14 @@ func (p *Init) ExitedAt() time.Time {
 
 // Status of the process
 func (p *Init) Status(ctx context.Context) (string, error) {
+	if p.pausing.get() {
+		return "pausing", nil
+	}
+
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	c, err := p.runtime.State(ctx, p.id)
-	if err != nil {
-		if strings.Contains(err.Error(), "does not exist") {
-			return "stopped", nil
-		}
-		return "", p.runtimeError(err, "OCI runtime state failed")
-	}
-	return c.Status, nil
+	return p.initState.Status(ctx)
 }
 
 // Start the init process

--- a/pkg/process/utils.go
+++ b/pkg/process/utils.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/containerd/containerd/errdefs"
@@ -60,6 +61,20 @@ func (s *safePid) set(pid int) {
 	s.Lock()
 	s.pid = pid
 	s.Unlock()
+}
+
+type atomicBool int32
+
+func (ab *atomicBool) set(b bool) {
+	if b {
+		atomic.StoreInt32((*int32)(ab), 1)
+	} else {
+		atomic.StoreInt32((*int32)(ab), 0)
+	}
+}
+
+func (ab *atomicBool) get() bool {
+	return atomic.LoadInt32((*int32)(ab)) == 1
 }
 
 // TODO(mlaventure): move to runc package?


### PR DESCRIPTION
backport of https://github.com/containerd/containerd/pull/3711

- relates to https://github.com/kubernetes/kubernetes/issues/82440 High system load/CPU utilization with trivial liveness and readiness probes
- relates to https://github.com/moby/moby/issues/39102 Docker healthcheck causes high CPU utilization
- relates to https://github.com/google/gvisor-containerd-shim/issues/39 Reduce `runsc state` call

cherry-pick was clean

