### PR TITLE
[release/1.2 backport] backport exec fixes

### DIFF
--- a/runtime/v1/linux/proc/deleted_state.go
+++ b/runtime/v1/linux/proc/deleted_state.go
@@ -70,3 +70,7 @@ func (s *deletedState) SetExited(status int) {
 func (s *deletedState) Exec(ctx context.Context, path string, r *ExecConfig) (proc.Process, error) {
 	return nil, errors.Errorf("cannot exec in a deleted state")
 }
+
+func (s *deletedState) Status(ctx context.Context) (string, error) {
+	return "stopped", nil
+}

--- a/runtime/v1/linux/proc/exec.go
+++ b/runtime/v1/linux/proc/exec.go
@@ -106,7 +106,7 @@ func (e *execProcess) Delete(ctx context.Context) error {
 }
 
 func (e *execProcess) delete(ctx context.Context) error {
-	e.wg.Wait()
+	waitTimeout(ctx, &e.wg, 2*time.Second)
 	if e.io != nil {
 		for _, c := range e.closers {
 			c.Close()

--- a/runtime/v1/linux/proc/exec.go
+++ b/runtime/v1/linux/proc/exec.go
@@ -255,17 +255,5 @@ func (e *execProcess) Status(ctx context.Context) (string, error) {
 	}
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	// if we don't have a pid(pid=0) then the exec process has just been created
-	if e.pid.get() == 0 {
-		return "created", nil
-	}
-	if e.pid.get() == StoppedPID {
-		return "stopped", nil
-	}
-	// if we have a pid and it can be signaled, the process is running
-	if err := unix.Kill(e.pid.get(), 0); err == nil {
-		return "running", nil
-	}
-	// else if we have a pid but it can nolonger be signaled, it has stopped
-	return "stopped", nil
+	return e.execState.Status(ctx)
 }

--- a/runtime/v1/linux/proc/exec.go
+++ b/runtime/v1/linux/proc/exec.go
@@ -31,6 +31,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/containerd/console"
+	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/runtime/proc"
 	"github.com/containerd/fifo"
 	runc "github.com/containerd/go-runc"
@@ -49,7 +50,7 @@ type execProcess struct {
 	io      runc.IO
 	status  int
 	exited  time.Time
-	pid     *safePid
+	pid     safePid
 	closers []io.Closer
 	stdin   io.Closer
 	stdio   proc.Stdio
@@ -95,6 +96,7 @@ func (e *execProcess) setExited(status int) {
 	e.status = status
 	e.exited = time.Now()
 	e.parent.Platform.ShutdownConsole(context.Background(), e.console)
+	e.pid.set(StoppedPID)
 	close(e.waitBlock)
 }
 
@@ -142,7 +144,12 @@ func (e *execProcess) Kill(ctx context.Context, sig uint32, _ bool) error {
 
 func (e *execProcess) kill(ctx context.Context, sig uint32, _ bool) error {
 	pid := e.pid.get()
-	if pid != 0 {
+	switch {
+	case pid == 0:
+		return errors.Wrap(errdefs.ErrFailedPrecondition, "process not created")
+	case pid < 0:
+		return errors.Wrapf(errdefs.ErrNotFound, "process already finished")
+	default:
 		if err := unix.Kill(pid, syscall.Signal(sig)); err != nil {
 			return errors.Wrapf(checkKillError(err), "exec kill error")
 		}
@@ -248,9 +255,12 @@ func (e *execProcess) Status(ctx context.Context) (string, error) {
 	}
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	// if we don't have a pid then the exec process has just been created
+	// if we don't have a pid(pid=0) then the exec process has just been created
 	if e.pid.get() == 0 {
 		return "created", nil
+	}
+	if e.pid.get() == StoppedPID {
+		return "stopped", nil
 	}
 	// if we have a pid and it can be signaled, the process is running
 	if err := unix.Kill(e.pid.get(), 0); err == nil {

--- a/runtime/v1/linux/proc/exec_state.go
+++ b/runtime/v1/linux/proc/exec_state.go
@@ -31,6 +31,7 @@ type execState interface {
 	Delete(context.Context) error
 	Kill(context.Context, uint32, bool) error
 	SetExited(int)
+	Status(context.Context) (string, error)
 }
 
 type execCreatedState struct {
@@ -82,6 +83,10 @@ func (s *execCreatedState) SetExited(status int) {
 	}
 }
 
+func (s *execCreatedState) Status(ctx context.Context) (string, error) {
+	return "created", nil
+}
+
 type execRunningState struct {
 	p *execProcess
 }
@@ -120,6 +125,10 @@ func (s *execRunningState) SetExited(status int) {
 	}
 }
 
+func (s *execRunningState) Status(ctx context.Context) (string, error) {
+	return "running", nil
+}
+
 type execStoppedState struct {
 	p *execProcess
 }
@@ -156,4 +165,8 @@ func (s *execStoppedState) Kill(ctx context.Context, sig uint32, all bool) error
 
 func (s *execStoppedState) SetExited(status int) {
 	// no op
+}
+
+func (s *execStoppedState) Status(ctx context.Context) (string, error) {
+	return "stopped", nil
 }

--- a/runtime/v1/linux/proc/init.go
+++ b/runtime/v1/linux/proc/init.go
@@ -278,7 +278,7 @@ func (p *Init) Delete(ctx context.Context) error {
 }
 
 func (p *Init) delete(ctx context.Context) error {
-	p.wg.Wait()
+	waitTimeout(ctx, &p.wg, 2*time.Second)
 	err := p.runtime.Delete(ctx, p.id, nil)
 	// ignore errors if a runtime has already deleted the process
 	// but we still hold metadata and pipes

--- a/runtime/v1/linux/proc/init_state.go
+++ b/runtime/v1/linux/proc/init_state.go
@@ -156,6 +156,9 @@ func (s *createdCheckpointState) Start(ctx context.Context) error {
 	p := s.p
 	sio := p.stdio
 
+	p.pid.Lock()
+	defer p.pid.Unlock()
+
 	var (
 		err    error
 		socket *runc.Socket
@@ -201,7 +204,7 @@ func (s *createdCheckpointState) Start(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to retrieve OCI runtime container pid")
 	}
-	p.pid = pid
+	p.pid.pid = pid
 	return s.transition("running")
 }
 

--- a/runtime/v1/linux/proc/process.go
+++ b/runtime/v1/linux/proc/process.go
@@ -23,7 +23,11 @@ import (
 )
 
 // RuncRoot is the path to the root runc state directory
-const RuncRoot = "/run/containerd/runc"
+const (
+	RuncRoot = "/run/containerd/runc"
+	// StoppedPID is the pid assigned after a container has run and stopped
+	StoppedPID = -1
+)
 
 func stateName(v interface{}) string {
 	switch v.(type) {

--- a/runtime/v1/linux/proc/utils.go
+++ b/runtime/v1/linux/proc/utils.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/containerd/containerd/errdefs"
@@ -49,6 +50,20 @@ func (s *safePid) set(pid int) {
 	s.Lock()
 	s.pid = pid
 	s.Unlock()
+}
+
+type atomicBool int32
+
+func (ab *atomicBool) set(b bool) {
+	if b {
+		atomic.StoreInt32((*int32)(ab), 1)
+	} else {
+		atomic.StoreInt32((*int32)(ab), 0)
+	}
+}
+
+func (ab *atomicBool) get() bool {
+	return atomic.LoadInt32((*int32)(ab)) == 1
 }
 
 // TODO(mlaventure): move to runc package?

--- a/runtime/v1/linux/proc/utils.go
+++ b/runtime/v1/linux/proc/utils.go
@@ -45,6 +45,12 @@ func (s *safePid) get() int {
 	return s.pid
 }
 
+func (s *safePid) set(pid int) {
+	s.Lock()
+	s.pid = pid
+	s.Unlock()
+}
+
 // TODO(mlaventure): move to runc package?
 func getLastRuntimeError(r *runc.Runc) (string, error) {
 	if r.Log == "" {


### PR DESCRIPTION
Backports of:

- https://github.com/containerd/containerd/pull/3361 Add timeout for I/O waitgroups
    - fixes https://github.com/containerd/containerd/issues/3286 docker exec hang if earlier docker exec left a zombie process
- https://github.com/containerd/containerd/pull/3366 Robust pid locking for shim processes
    - closes https://github.com/containerd/containerd/pull/2832 fixes: pid reuse attack when kill a exec process
- https://github.com/containerd/containerd/pull/3711 Use cached state instead of `runc state`
    - relates to https://github.com/kubernetes/kubernetes/issues/82440 High system load/CPU utilization with trivial liveness and readiness probes
    - relates to https://github.com/moby/moby/issues/39102 Docker healthcheck causes high CPU utilization

First two cherry-picks were clean:

```
# https://github.com/containerd/containerd/pull/3361 Add timeout for I/O waitgroups
git cherry-pick -s -S -x 245052243d23c8de21fcc95bbf47fb1dbc731ab4

# https://github.com/containerd/containerd/pull/3366 Robust pid locking for shim processes
git cherry-pick -s -S -x 719a2c594e4aad6a2de5cd9c298ab95309c2135c

# https://github.com/containerd/containerd/pull/3711 Use cached state instead of `runc state`
git cherry-pick -s -S -x 18be6e37140e778dffd91804dab2bc66ba54493f
```

Last cherry-pick didn't apply clean:

```
both modified:   runtime/v1/linux/proc/init.go
```

This was because https://github.com/containerd/containerd/pull/3085 (Shim pluggable logging) and https://github.com/containerd/containerd/pull/3374 (Refactor runtime package for code usage) are not in the 1.2 branch,
and respectively changed `runc.IO -> `*processIO`, and `proc.Platform` -> `stdio.Platform`:

```patch
diff --cc runtime/v1/linux/proc/init.go
index 4a87b2455,539f9c24a..000000000
--- a/runtime/v1/linux/proc/init.go
+++ b/runtime/v1/linux/proc/init.go
@@@ -59,12 -56,14 +59,23 @@@ type Init struct 
  
        WorkDir string
  
++<<<<<<< HEAD:runtime/v1/linux/proc/init.go
 +      id           string
 +      Bundle       string
 +      console      console.Console
 +      Platform     proc.Platform
 +      io           runc.IO
 +      runtime      *runc.Runc
++=======
+       id       string
+       Bundle   string
+       console  console.Console
+       Platform stdio.Platform
+       io       *processIO
+       runtime  *runc.Runc
+       // pausing preserves the pausing state.
+       pausing      *atomicBool
++>>>>>>> 18be6e371... Use cached state instead of `runc state`.:pkg/process/init.go
        status       int
        exited       time.Time
        pid          safePid
```

