### PR TITLE
Move autocomplete files to contrib/

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,23 +220,23 @@ architectures, such as [Canonical's Ubuntu packaging](https://launchpad.net/ubun
 
 #### Enabling command auto-completion
 
-Starting with containerd 1.4, the urfave client feature for auto-creation of bash
-autocompletion data is enabled. To use the autocomplete feature in your shell, source
-the autocomplete/bash_autocomplete file in your .bashrc file while setting the `PROG`
-variable to `ctr`:
+Starting with containerd 1.4, the urfave client feature for auto-creation of bash and zsh
+autocompletion data is enabled. To use the autocomplete feature in a bash shell for example, source
+the autocomplete/ctr file in your `.bashrc`, or manually like:
 
 ```
-$ PROG=ctr source vendor/github.com/urfave/cli/autocomplete/bash_autocomplete
+$ source ./contrib/autocomplete/ctr
 ```
 
-#### Distribution of `ctr` autocomplete for bash
+#### Distribution of `ctr` autocomplete for bash and zsh
 
-Copy `vendor/github.com/urfave/cli/autocomplete/bash_autocomplete` into
-`/etc/bash_completion.d/` and rename it to `ctr`.
+For bash, copy the `contrib/autocomplete/ctr` script into
+`/etc/bash_completion.d/` and rename it to `ctr`. The `zsh_autocomplete`
+file is also available and can be used similarly for zsh users.
 
 Provide documentation to users to `source` this file into their shell if
 you don't place the autocomplete file in a location where it is automatically
-loaded for user's bash shell environment.
+loaded for the user's shell environment.
 
 ### Communication
 

--- a/contrib/autocomplete/ctr
+++ b/contrib/autocomplete/ctr
@@ -1,0 +1,22 @@
+#! /bin/bash
+## This file is a direct copy of https://github.com/urfave/cli/blob/a221e662f14fd7404302444a5c4293409a401210/autocomplete/bash_autocomplete
+
+: ${PROG:=$(basename ${BASH_SOURCE})}
+
+_cli_bash_autocomplete() {
+  if [[ "${COMP_WORDS[0]}" != "source" ]]; then
+    local cur opts base
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    if [[ "$cur" == "-"* ]]; then
+      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} ${cur} --generate-bash-completion )
+    else
+      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+    fi
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+    return 0
+  fi
+}
+
+complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete $PROG
+unset PROG

--- a/contrib/autocomplete/zsh_autocomplete
+++ b/contrib/autocomplete/zsh_autocomplete
@@ -1,0 +1,15 @@
+#compdef ctr
+# This file is a direct copy of https://github.com/urfave/cli/blob/a221e662f14fd7404302444a5c4293409a401210/autocomplete/zsh_autocomplete
+# With $PROG changed to ctr
+
+_cli_zsh_autocomplete() {
+
+  local -a opts
+  opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} --generate-bash-completion)}")
+
+  _describe 'values' opts
+
+  return
+}
+
+compdef _cli_zsh_autocomplete ctr


### PR DESCRIPTION
Since recent versions of `vndr` are going to remove the autocomplete
scripts from the urfave vendored content, we will just move them into
`contrib/` and reference them in the documentation from that location.

See #3759 for background

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>