### PR TITLE
bump google.golang.org/grpc v1.23.1

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -25,7 +25,7 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1
 github.com/sirupsen/logrus v1.4.1
 github.com/urfave/cli v1.22.0
 golang.org/x/net f3200d17e092c607f615320ecaad13d87ad9a2b3
-google.golang.org/grpc 6eaf6f47437a6b4e2153a190160ef39a92c7eceb # v1.23.0
+google.golang.org/grpc 39e8a7b072a67ca2a75f57fa2e0d50995f5b22f6 # v1.23.1
 github.com/pkg/errors v0.8.1
 github.com/opencontainers/go-digest c9281466c8b2f606084ac71339773efd177436e7
 golang.org/x/sys 9eafafc0a87e0fd0aeeba439a4573537970c44c7 https://github.com/golang/sys

--- a/vendor/google.golang.org/grpc/internal/transport/http2_server.go
+++ b/vendor/google.golang.org/grpc/internal/transport/http2_server.go
@@ -138,7 +138,10 @@ func newHTTP2Server(conn net.Conn, config *ServerConfig) (_ ServerTransport, err
 	}
 	framer := newFramer(conn, writeBufSize, readBufSize, maxHeaderListSize)
 	// Send initial settings as connection preface to client.
-	var isettings []http2.Setting
+	isettings := []http2.Setting{{
+		ID:  http2.SettingMaxFrameSize,
+		Val: http2MaxFrameLen,
+	}}
 	// TODO(zhaoq): Have a better way to signal "no limit" because 0 is
 	// permitted in the HTTP2 spec.
 	maxStreams := config.MaxStreams

--- a/vendor/google.golang.org/grpc/internal/transport/http_util.go
+++ b/vendor/google.golang.org/grpc/internal/transport/http_util.go
@@ -667,6 +667,7 @@ func newFramer(conn net.Conn, writeBufferSize, readBufferSize int, maxHeaderList
 		writer: w,
 		fr:     http2.NewFramer(w, r),
 	}
+	f.fr.SetMaxReadFrameSize(http2MaxFrameLen)
 	// Opt-in to Frame reuse API on framer to reduce garbage.
 	// Frames aren't safe to read from after a subsequent call to ReadFrame.
 	f.fr.SetReuseFrames()

--- a/vendor/google.golang.org/grpc/version.go
+++ b/vendor/google.golang.org/grpc/version.go
@@ -19,4 +19,4 @@
 package grpc
 
 // Version is the current grpc version.
-const Version = "1.23.0"
+const Version = "1.23.1"


### PR DESCRIPTION
### note: this will probably fail CI until https://github.com/containerd/containerd/pull/3759 is merged

full diff: https://github.com/grpc/grpc-go/compare/v1.23.0...v1.23.1

- grpc/grpc-go#3018 server: set and advertise max frame size of 16KB
- grpc/grpc-go#3017 grpclb: fix deadlock in grpclb connection cache
    - Before the fix, if the timer to remove a SubConn fires at the
      same time NewSubConn cancels the timer, it caused a mutex leak
      and deadlock.
