### PR TITLE
[release/1.3] Catch up vndr with state of vendor/ dir

### DIFF
--- a/vendor/github.com/opencontainers/runc/README.md
+++ b/vendor/github.com/opencontainers/runc/README.md
@@ -18,7 +18,7 @@ You can find official releases of `runc` on the [release](https://github.com/ope
 
 ## Security
 
-The reporting process and disclosure communications are outlined in [/org/security](https://github.com/opencontainers/org/blob/master/security/).
+Reporting process and disclosure communications are outlined in [/org/security](https://github.com/opencontainers/org/blob/master/security/)
 
 ## Building
 


### PR DESCRIPTION
Due to a temporarily broken containerd/project script the vendor dir
was slightly out of state with what it should have been after the
last runc vendor update.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>