### PR TITLE
Use logrus trace support.

### DIFF
--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -284,7 +284,7 @@ func setLevel(context *cli.Context, config *srvconfig.Config) error {
 		l = config.Debug.Level
 	}
 	if l != "" {
-		lvl, err := log.ParseLevel(l)
+		lvl, err := logrus.ParseLevel(l)
 		if err != nil {
 			return err
 		}

--- a/log/context.go
+++ b/log/context.go
@@ -18,7 +18,6 @@ package log
 
 import (
 	"context"
-	"sync/atomic"
 
 	"github.com/sirupsen/logrus"
 )
@@ -38,22 +37,9 @@ type (
 	loggerKey struct{}
 )
 
-// TraceLevel is the log level for tracing. Trace level is lower than debug level,
-// and is usually used to trace detailed behavior of the program.
-const TraceLevel = logrus.Level(uint32(logrus.DebugLevel + 1))
-
 // RFC3339NanoFixed is time.RFC3339Nano with nanoseconds padded using zeros to
 // ensure the formatted time is always the same number of characters.
 const RFC3339NanoFixed = "2006-01-02T15:04:05.000000000Z07:00"
-
-// ParseLevel takes a string level and returns the Logrus log level constant.
-// It supports trace level.
-func ParseLevel(lvl string) (logrus.Level, error) {
-	if lvl == "trace" {
-		return TraceLevel, nil
-	}
-	return logrus.ParseLevel(lvl)
-}
 
 // WithLogger returns a new context with the provided logger. Use in
 // combination with logger.WithField(s) for great effect.
@@ -71,20 +57,4 @@ func GetLogger(ctx context.Context) *logrus.Entry {
 	}
 
 	return logger.(*logrus.Entry)
-}
-
-// Trace logs a message at level Trace with the log entry passed-in.
-func Trace(e *logrus.Entry, args ...interface{}) {
-	level := logrus.Level(atomic.LoadUint32((*uint32)(&e.Logger.Level)))
-	if level >= TraceLevel {
-		e.Debug(args...)
-	}
-}
-
-// Tracef logs a message at level Trace with the log entry passed-in.
-func Tracef(e *logrus.Entry, format string, args ...interface{}) {
-	level := logrus.Level(atomic.LoadUint32((*uint32)(&e.Logger.Level)))
-	if level >= TraceLevel {
-		e.Debugf(format, args...)
-	}
 }

--- a/vendor.conf
+++ b/vendor.conf
@@ -51,7 +51,7 @@ github.com/cpuguy83/go-md2man v1.0.10
 github.com/russross/blackfriday v1.5.2
 
 # cri dependencies
-github.com/containerd/cri 0ebf032aac5f6029f95a94e42161e9db7a7e84df # release/1.3+
+github.com/containerd/cri 8ce2ad6b7c9a83f830684d1025034fb3ad2ec375 # master
 github.com/containerd/go-cni 0d360c50b10b350b6bb23863fd4dfb1c232b01c9
 github.com/containernetworking/cni v0.7.1
 github.com/containernetworking/plugins v0.7.6

--- a/vendor/github.com/containerd/cri/cri.go
+++ b/vendor/github.com/containerd/cri/cri.go
@@ -172,7 +172,7 @@ func setGLogLevel() error {
 		return err
 	}
 	switch l {
-	case log.TraceLevel:
+	case logrus.TraceLevel:
 		return fs.Set("v", "5")
 	case logrus.DebugLevel:
 		return fs.Set("v", "4")

--- a/vendor/github.com/containerd/cri/vendor.conf
+++ b/vendor/github.com/containerd/cri/vendor.conf
@@ -22,7 +22,7 @@ github.com/prometheus/client_model 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
 github.com/prometheus/client_golang f4fb1b73fb099f396a7f0036bf86aa8def4ed823
 github.com/pkg/errors v0.8.1
 github.com/opencontainers/runtime-spec 29686dbc5559d93fb1ef402eeda3e35c38d75af4 # v1.0.1-59-g29686db
-github.com/opencontainers/runc f4982d86f7fde0b6f953cc62ccc4022c519a10a9 # v1.0.0-rc8-32-gf4982d86
+github.com/opencontainers/runc d736ef14f0288d6993a1845745d6756cfc9ddd5a # v1.0.0-rc9
 github.com/opencontainers/image-spec v1.0.1
 github.com/opencontainers/go-digest c9281466c8b2f606084ac71339773efd177436e7
 github.com/matttproud/golang_protobuf_extensions v1.0.1
@@ -44,9 +44,9 @@ github.com/containerd/ttrpc 92c8520ef9f86600c650dd540266a007bf03670f
 github.com/containerd/go-runc 9007c2405372fe28918845901a3276c0915689a1
 github.com/containerd/fifo bda0ff6ed73c67bfb5e62bc9c697f146b7fd7f13
 github.com/containerd/continuity f2a389ac0a02ce21c09edd7344677a601970f41c
-github.com/containerd/containerd ed16170c4c399c57f25d6aa1e97b345ed6ab96cb
+github.com/containerd/containerd a6a0c8b6e36415a151d93d096c1c0af9e0bd7977
 github.com/containerd/console 0650fd9eeb50bab4fc99dceb9f2e14cf58f36e7f
-github.com/containerd/cgroups c4b9ac5c7601384c965b9646fc515884e091ebb9
+github.com/containerd/cgroups abd0b19954a6b05e0963f48427062d1481b7faad
 github.com/beorn7/perks 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
 github.com/Microsoft/hcsshim c088f411aaf3585d8dffc9deb4289ffa32854497 # TODO(windows): update this in containerd/containerd
 github.com/Microsoft/go-winio v0.4.14


### PR DESCRIPTION
This PR depends on https://github.com/containerd/cri/pull/1323.

Logrus supports trace level natively now. See https://github.com/sirupsen/logrus/pull/844

Signed-off-by: Lantao Liu <lantaol@google.com>