### PR TITLE
Fix `containerd config dump`.

### DIFF
--- a/cmd/containerd/command/config.go
+++ b/cmd/containerd/command/config.go
@@ -65,10 +65,14 @@ func outputConfig(cfg *srvconfig.Config) error {
 		}
 	}
 
+	if config.Timeouts == nil {
+		config.Timeouts = make(map[string]string)
+	}
 	timeouts := timeout.All()
-	config.Timeouts = make(map[string]string)
 	for k, v := range timeouts {
-		config.Timeouts[k] = v.String()
+		if config.Timeouts[k] == "" {
+			config.Timeouts[k] = v.String()
+		}
 	}
 
 	// for the time being, keep the defaultConfig's version set at 1 so that

--- a/docs/man/containerd-config.toml.5.md
+++ b/docs/man/containerd-config.toml.5.md
@@ -39,6 +39,8 @@ separately (for example vendors may keep a custom runtime configuration in a
 separate file without modifying the main `config.toml`).
 Imported files will overwrite simple fields like `int` or
 `string` (if not empty) and will append `array` and `map` fields.
+Imported files are also versioned, and the version can't be higher than
+the main config.
 
 **[grpc]**
 : Section for gRPC socket listener settings. Contains three properties:

--- a/services/server/config/config.go
+++ b/services/server/config/config.go
@@ -28,6 +28,8 @@ import (
 	"github.com/containerd/containerd/plugin"
 )
 
+// NOTE: Any new map fields added also need to be handled in mergeConfig.
+
 // Config provides containerd configuration data for the server
 type Config struct {
 	// Version of the config file
@@ -319,6 +321,10 @@ func mergeConfig(to, from *Config) error {
 
 	for k, v := range from.ProxyPlugins {
 		to.ProxyPlugins[k] = v
+	}
+
+	for k, v := range from.Timeouts {
+		to.Timeouts[k] = v
 	}
 
 	return nil


### PR DESCRIPTION
This PR:
1) Updated man file for https://github.com/containerd/containerd/issues/3776;
2) Add missing `Timeouts` support in `containerd config dump` output;

There are still 2 problems:
1) The import behavior is very confusing. For example, as a user using `config.toml`, you don't know whether a section is a map or struct underlying. It's impossible for them to tell whether the subsequent config will be merged or overwritten... I understand that we do this because of the limitation of `mergo`, but we should at least make the behavior consistent, for example all 1st level section will be overwritten directly.
2) It is hard to maintain future map fields. IIUC, any new map fields added in the config (maybe in a child struct), needs to be taken care in `mergeConfig`. It seems a bit hard to maintain.

Signed-off-by: Lantao Liu <lantaol@google.com>