### PR TITLE
RELEASES.md: 1.1 EOL

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -97,7 +97,7 @@ The current state is available in the following table:
 | [0.1](https://github.com/containerd/containerd/releases/tag/v0.1.0) | End of Life | Mar 21, 2016 | - |
 | [0.2](https://github.com/containerd/containerd/tree/v0.2.x)         | End of Life | Apr 21, 2016      | December 5, 2017 |
 | [1.0](https://github.com/containerd/containerd/releases/tag/v1.0.3) | End of Life | December 5, 2017  | December 5, 2018 |
-| [1.1](https://github.com/containerd/containerd/releases/tag/v1.1.8) | Extended   | April 23, 2018  | October 23, 2019 |
+| [1.1](https://github.com/containerd/containerd/releases/tag/v1.1.8) | End of Life | April 23, 2018  | October 23, 2019 |
 | [1.2](https://github.com/containerd/containerd/releases/tag/v1.2.10) | Active   | October 24, 2018 | March 26, 2020 |
 | [1.3](https://github.com/containerd/containerd/releases/tag/v1.3.0)  | Active   | September 26, 2019  | max(September 26, 2020, release of 1.4.0 + 6 months) |
 | [1.4](https://github.com/containerd/containerd/milestone/27)        | Next   | TBD  | max(TBD+1 year, release of 1.5.0 + 6 months) |


### PR DESCRIPTION
v1.1 reached EOL on October 23, 2019

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>