### PR TITLE
Makefile: Drop vndr whitelist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,7 @@ root-coverage: ## generate coverage profiles for unit tests that require root
 
 vendor:
 	@echo "$(WHALE) $@"
-	@vndr -whitelist github.com/urfave/cli/autocomplete/
+	@vndr
 
 help: ## this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort


### PR DESCRIPTION
Since autocompletions moved to contrib/ in https://github.com/containerd/containerd/pull/3766 we can remove this from the Makefile as well.