### PR TITLE
ppc64: -buildmode=pie is not supported

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -20,7 +20,9 @@ COMMANDS += containerd-shim containerd-shim-runc-v1 containerd-shim-runc-v2
 
 # check GOOS for cross compile builds
 ifeq ($(GOOS),linux)
+  ifneq ($(GOARCH),ppc64)
 	GO_GCFLAGS += -buildmode=pie
+  endif
 endif
 
 # amd64 supports go test -race


### PR DESCRIPTION
I needed this patch to compile containerd for ppc64.

Signed-off-by: Tibor Vass <tibor@docker.com>