### PR TITLE
Support disk usage in windows snapshot.

### DIFF
--- a/snapshots/overlay/overlay.go
+++ b/snapshots/overlay/overlay.go
@@ -165,9 +165,8 @@ func (o *snapshotter) Usage(ctx context.Context, key string) (snapshots.Usage, e
 		return snapshots.Usage{}, err
 	}
 
-	upperPath := o.upperPath(id)
-
 	if info.Kind == snapshots.KindActive {
+		upperPath := o.upperPath(id)
 		du, err := fs.DiskUsage(ctx, upperPath)
 		if err != nil {
 			// TODO(stevvooe): Consider not reporting an error in this case.


### PR DESCRIPTION
Add `Usage` support in windows snapshotter.

For https://github.com/containerd/cri/issues/1299.

/cc @jterry75 
Signed-off-by: Lantao Liu <lantaol@google.com>