### PR TITLE
Fixed authorization against Cesenta Docker registry authentication

### DIFF
--- a/remotes/docker/authorizer.go
+++ b/remotes/docker/authorizer.go
@@ -324,6 +324,7 @@ type tokenOptions struct {
 
 type postTokenResponse struct {
 	AccessToken  string    `json:"access_token"`
+	LegacyToken  string    `json:"token"`
 	RefreshToken string    `json:"refresh_token"`
 	ExpiresIn    int       `json:"expires_in"`
 	IssuedAt     time.Time `json:"issued_at"`
@@ -383,6 +384,10 @@ func (ah *authHandler) fetchTokenWithOAuth(ctx context.Context, to tokenOptions)
 	var tr postTokenResponse
 	if err = decoder.Decode(&tr); err != nil {
 		return "", fmt.Errorf("unable to decode token response: %s", err)
+	}
+
+	if tr.AccessToken == "" && tr.LegacyToken != "" {
+		tr.AccessToken = tr.LegacyToken
 	}
 
 	return tr.AccessToken, nil

--- a/remotes/docker/authorizer.go
+++ b/remotes/docker/authorizer.go
@@ -348,6 +348,9 @@ func (ah *authHandler) fetchTokenWithOAuth(ctx context.Context, to tokenOptions)
 	}
 
 	req, err := http.NewRequest("POST", to.realm, strings.NewReader(form.Encode()))
+	if to.username != "" {
+		req.SetBasicAuth(to.username, to.secret)
+	}
 	if err != nil {
 		return "", err
 	}

--- a/remotes/docker/authorizer.go
+++ b/remotes/docker/authorizer.go
@@ -348,11 +348,11 @@ func (ah *authHandler) fetchTokenWithOAuth(ctx context.Context, to tokenOptions)
 	}
 
 	req, err := http.NewRequest("POST", to.realm, strings.NewReader(form.Encode()))
-	if to.username != "" {
-		req.SetBasicAuth(to.username, to.secret)
-	}
 	if err != nil {
 		return "", err
+	}
+	if to.username != "" {
+		req.SetBasicAuth(to.username, to.secret)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
 	if ah.header != nil {


### PR DESCRIPTION
I'm using Cesenta authentication for my private docker registry and could not make authorisation work from containerd. After digging through both the code of containerd and cesenta I fixed authorisation by adjusting two things:

- during parsing of the OAuth token, containerd expects `{"access_token": "..."}` while cesenta is sending `{"token": "..."}` (https://github.com/cesanta/docker_auth/blob/master/auth_server/server/server.go#L425). I added a field to `postTokenResponse` called `LegacyToken` (didn't really know what else to call it) and when that is set but `AccessToken` isn't, `LegacyToken` is used instead.
- Cesenta only uses username/password when Basic Authentication header is set (https://github.com/cesanta/docker_auth/blob/master/auth_server/server/server.go#L188), so I'm setting that as well.

With those 2 small fixes I could pull images from my registry. 