### PR TITLE
mips: -buildmode=pie is not supported for the mips arch

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -20,7 +20,7 @@ COMMANDS += containerd-shim containerd-shim-runc-v1 containerd-shim-runc-v2
 
 # check GOOS for cross compile builds
 ifeq ($(GOOS),linux)
-  ifneq ($(GOARCH),ppc64)
+  ifneq ($(GOARCH),$(filter $(GOARCH),mips mipsle mips64 mips64le ppc64))
 	GO_GCFLAGS += -buildmode=pie
   endif
 endif


### PR DESCRIPTION
Almost the same as https://github.com/containerd/containerd/pull/3784

Go doesn´t support pie for mips architectures.
So fix build for mips architectures and don´t use -buildmode=pie on mips, mipsle, mips64 and mips64le.

Signed-off-by: Johann Neuhauser <johann@it-neuhauser.de>