### PR TITLE
[release/1.3 backport] Update to Golang 1.12.13

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.12.12
+    - GO_VERSION: 1.12.13
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
 - linux
 
 go:
-  - "1.12.x"
+  - "1.12.13"
 
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
 - linux
 
 go:
-  - "1.12.12"
+  - "1.12.x"
 
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.12.12
+ARG GOLANG_VERSION=1.12.13
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd


### PR DESCRIPTION
backport of https://github.com/containerd/containerd/pull/3806 for the 1.3 release branch

go1.12.13 (released 2019/10/31) fixes an issue on macOS 10.15 Catalina
where the non-notarized installer and binaries were being rejected by
Gatekeeper. Only macOS users who hit this issue need to update.
