### PR TITLE
[release/1.3] Prepare v1.3.1 release

### DIFF
--- a/releases/v1.3.1.toml
+++ b/releases/v1.3.1.toml
@@ -1,0 +1,34 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release
+previous = "v1.3.0"
+
+pre_release = false
+
+preface = """\
+The first patch release for `containerd` 1.3  includes updated vendors/build runtimes that fix reported CVEs in runc and the Golang 1.12 runtime respectively.
+
+### Notable Updates
+
+* Update the runc vendor to v1.0.0-rc9 which includes an additional mitigation for [CVE-2019-16884](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16884).
+    - More details on the runc CVE in [opencontainers/runc#2128](https://github.com/opencontainers/runc/issues/2128), and the additional mitigations in [opencontainers/runc#2130](https://github.com/opencontainers/runc/pull/2130).
+* Add local-fs.target to service file to fix corrupt image after unexpected host reboot. Reported in [containerd/containerd#3671](https://github.com/containerd/containerd/issues/3671), and fixed by [containerd/containerd#3745](https://github.com/containerd/containerd/pull/3745).
+* Fix large output of processes with TTY getting occasionally truncated. Reported in [containerd/containerd#3738](https://github.com/containerd/containerd/issues/3738) and fixed by [containerd/containerd#3754](https://github.com/containerd/containerd/pull/3754).
+* Fix direct unpack when running in user namespace. Reported in [containerd/containerd#3762](https://github.com/containerd/containerd/issues/3762), and fixed by [containerd/containerd#3779](https://github.com/containerd/containerd/pull/3779).
+* Update Golang runtime to 1.12.13, which includes security fixes to the `crypto/dsa` package made in Go 1.12.11 ([CVE-2019-17596](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-17596)), and fixes to the go command, `runtime`, `syscall` and `net` packages (Go 1.12.12).
+* Add Windows process shim installer [containerd/containerd#3792](https://github.com/containerd/containerd/pull/3792)
+
+* CRI fixes:
+    - Fix shim delete error code to avoid unnecessary retries in the CRI plugin. Discovered in [containerd/cri#1309](https://github.com/containerd/cri/issues/1309), and fixed by [containerd/containerd#3733](https://github.com/containerd/containerd/pull/3733) and [containerd/containerd#3740](https://github.com/containerd/containerd/pull/3740).
+
+"""
+
+# notable prs to include in the release notes, 1234 is the pr number
+[notes]
+
+[breaking]

--- a/releases/v1.3.1.toml
+++ b/releases/v1.3.1.toml
@@ -11,10 +11,12 @@ previous = "v1.3.0"
 pre_release = false
 
 preface = """\
-The first patch release for `containerd` 1.3  includes updated vendors/build runtimes that fix reported CVEs in runc and the Golang 1.12 runtime respectively.
+The first patch release for `containerd` 1.3 includes a fix for a hang on pull
+when there is a registry error and important vendor updates.
 
 ### Notable Updates
 
+* Fix deadlock on image pull and unpack after a registry error [containerd/containerd#3816](https://github.com/containerd/containerd/issues/3816).
 * Update the runc vendor to v1.0.0-rc9 which includes an additional mitigation for [CVE-2019-16884](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16884).
     - More details on the runc CVE in [opencontainers/runc#2128](https://github.com/opencontainers/runc/issues/2128), and the additional mitigations in [opencontainers/runc#2130](https://github.com/opencontainers/runc/pull/2130).
 * Add local-fs.target to service file to fix corrupt image after unexpected host reboot. Reported in [containerd/containerd#3671](https://github.com/containerd/containerd/issues/3671), and fixed by [containerd/containerd#3745](https://github.com/containerd/containerd/pull/3745).

--- a/version/version.go
+++ b/version/version.go
@@ -21,7 +21,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.3.0+unknown"
+	Version = "1.3.1+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
* Update the runc vendor to v1.0.0-rc9 which includes an additional mitigation for [CVE-2019-16884](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16884).
    - More details on the runc CVE in [opencontainers/runc#2128](https://github.com/opencontainers/runc/issues/2128), and the additional mitigations in [opencontainers/runc#2130](https://github.com/opencontainers/runc/pull/2130).
* Add local-fs.target to service file to fix corrupt image after unexpected host reboot. Reported in [containerd/containerd#3671](https://github.com/containerd/containerd/issues/3671), and fixed by [containerd/containerd#3745](https://github.com/containerd/containerd/pull/3745).
* Fix large output of processes with TTY getting occasionally truncated. Reported in [containerd/containerd#3738](https://github.com/containerd/containerd/issues/3738) and fixed by [containerd/containerd#3754](https://github.com/containerd/containerd/pull/3754).
* Fix direct unpack when running in user namespace. Reported in [containerd/containerd#3762](https://github.com/containerd/containerd/issues/3762), and fixed by [containerd/containerd#3779](https://github.com/containerd/containerd/pull/3779).
* Update Golang runtime to 1.12.13, which includes security fixes to the `crypto/dsa` package made in Go 1.12.11 ([CVE-2019-17596](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-17596)), and fixes to the go command, `runtime`, `syscall` and `net` packages (Go 1.12.12).
* Add Windows process shim installer [containerd/containerd#3792](https://github.com/containerd/containerd/pull/3792)

* CRI fixes:
    - Fix shim delete error code to avoid unnecessary retries in the CRI plugin. Discovered in [containerd/cri#1309](https://github.com/containerd/cri/issues/1309), and fixed by [containerd/containerd#3733](https://github.com/containerd/containerd/pull/3733) and [containerd/containerd#3740](https://github.com/containerd/containerd/pull/3740).

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>