### PR TITLE
Fix dependency in BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -138,7 +138,7 @@ You can build an image from this `Dockerfile`:
 FROM golang
 
 RUN apt-get update && \
-    apt-get install -y btrfs-tools libseccomp-dev
+    apt-get install -y libbtrfs-dev libseccomp-dev
 ```
 
 Let's suppose that you built an image called `containerd/build`. From the


### PR DESCRIPTION
btrfs/ioctl.h is now included in libbtrfs-dev instead of btrfs-tools.
Update BUILDING.md Dockerfile to install the correct dependency.

Resolves: #3813

Signed-off-by: Reid Li <reid.li@utexas.edu>