### PR TITLE
Update name for btrfs headers package

### DIFF
--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -38,7 +38,8 @@ RUN ./install-runc
 
 FROM golang-base AS dev
 RUN apt-get update && apt-get install -y \
-    btrfs-tools \
+    libbtrfs-dev \
+    btrfs-progs \
     gcc \
     git \
     libseccomp-dev \


### PR DESCRIPTION
Change noted in #3814 is also needed in our contributed `Dockerfile.test`. Left the `btrfs-progs` as an install candidate for potential use for debugging even though not required to compile the daemon.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>