### PR TITLE
Fix panic on reference.Spec.Hostname()

### DIFF
--- a/reference/reference.go
+++ b/reference/reference.go
@@ -124,7 +124,7 @@ func (r Spec) Hostname() string {
 	i := strings.Index(r.Locator, "/")
 
 	if i < 0 {
-		i = len(r.Locator) + 1
+		return r.Locator
 	}
 	return r.Locator[:i]
 }


### PR DESCRIPTION
Fix #3817 

Signed-off-by: Shiwei Zhang <shizh@microsoft.com>