### PR TITLE
Better support windows binaries.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,10 +106,10 @@ GO_GCFLAGS=$(shell				\
 	echo "-gcflags=-trimpath=$${1}/src";	\
 	)
 
+BINARIES=$(addprefix bin/,$(COMMANDS))
+
 #include platform specific makefile
 -include Makefile.$(GOOS)
-
-BINARIES=$(addprefix bin/,$(COMMANDS))
 
 # Flags passed to `go test`
 TESTFLAGS ?= $(TESTFLAGS_RACE)
@@ -178,10 +178,14 @@ benchmark: ## run benchmarks tests
 
 FORCE:
 
+define BUILD_BINARY =
+@echo "$(WHALE) $@"
+@go build ${DEBUG_GO_GCFLAGS} ${GO_GCFLAGS} ${GO_BUILD_FLAGS} -o $@ ${GO_LDFLAGS} ${GO_TAGS}  ./$<
+endef
+
 # Build a binary from a cmd.
 bin/%: cmd/% FORCE
-	@echo "$(WHALE) $@${BINARY_SUFFIX}"
-	@go build ${DEBUG_GO_GCFLAGS} ${GO_GCFLAGS} ${GO_BUILD_FLAGS} -o $@${BINARY_SUFFIX} ${GO_LDFLAGS} ${GO_TAGS}  ./$<
+	$(BUILD_BINARY)
 
 bin/containerd-shim: cmd/containerd-shim FORCE # set !cgo and omit pie for a static shim build: https://github.com/golang/go/issues/17789#issuecomment-258542220
 	@echo "$(WHALE) bin/containerd-shim"

--- a/Makefile.windows
+++ b/Makefile.windows
@@ -17,9 +17,12 @@
 WHALE = "+"
 ONI = "-"
 
-BINARY_SUFFIX=".exe"
-
 # amd64 supports go test -race
 ifeq ($(GOARCH),amd64)
 	TESTFLAGS_RACE= -race
 endif
+
+BINARIES:=$(addsuffix .exe,$(BINARIES))
+
+bin/%.exe: cmd/% FORCE
+	$(BUILD_BINARY)


### PR DESCRIPTION
`make clean` and `make install` doesn't work for `.exe` binaries with linux shell today.

This fixed it. Please note that I'm not a Makefile expert, feel free to propose a better solution. :)

Signed-off-by: Lantao Liu <lantaol@google.com>