### PR TITLE
Avoid deadlock in unpacker.

### DIFF
--- a/pull.go
+++ b/pull.go
@@ -70,6 +70,11 @@ func (c *Client) Pull(ctx context.Context, ref string, opts ...RemoteOpt) (_ Ima
 		}
 		unpackWrapper, eg := u.handlerWrapper(ctx, &unpacks)
 		defer func() {
+			if retErr != nil {
+				// Forcibly stop the unpacker if there is
+				// an error.
+				eg.Cancel()
+			}
 			if err := eg.Wait(); err != nil {
 				if retErr == nil {
 					retErr = errors.Wrap(err, "unpack")


### PR DESCRIPTION
Fixes https://github.com/containerd/containerd/issues/3816.

It turns out that some layers are downloaded with error `response.status="206 Partial Content"`. However, we don't stop unpacker when there are layer download errors, thus it will wait for those layers forever.

This PR:
1) Stoped the unpacker if any error happens during fetch;
2) Avoided sending update when unpacker is stopped, this can prevent another potential deadlock when `updateCh` is full.

/cc @dmcgowan @ungureanuvladvictor  

Signed-off-by: Lantao Liu <lantaol@google.com>