### PR TITLE
containerd binaries nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,45 @@
+name: Nightly
+on:
+  schedule:
+    - cron: '0 0 * * *' # Every day at midnight
+
+jobs:
+  binaries:
+    name: Binaries
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.12
+
+      - name: Checkout
+        uses: actions/checkout@v1
+        env:
+          GOPATH: ${{ runner.workspace }}
+          GO111MODULE: off
+        with:
+          path: ./src/github.com/containerd/containerd
+
+      - name: Ubuntu dependencies
+        if: contains(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get install -y \
+            btrfs-tools \
+            libseccomp-dev
+
+      - name: Make
+        run: |
+          make binaries
+        env:
+          GOPATH: ${{ runner.workspace }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ matrix.os }}
+          path: bin


### PR DESCRIPTION
Let's give a try to Github Actions.
This PR adds a workflow that will trigger nightly jobs to build containerd binaries (both linux and windows).
Job artifacts will be uploaded to [Github Storage](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/persisting-workflow-data-using-artifacts#about-workflow-artifacts)  and available for 90 days.

Here is an example how job execution looks like: https://github.com/mxpv/containerd/commit/23f980b71cf63e99a07446bc35c1e932530c30ee/checks?check_suite_id=307992957

Binaries can be downloaded from the menu at top right corner:

<img width="987" alt="Screen Shot 2019-11-13 at 5 56 42 PM" src="https://user-images.githubusercontent.com/865334/68820070-008a6e80-063f-11ea-9ebc-1f2ac658ca3f.png">


Signed-off-by: Maksym Pavlenko <makpav@amazon.com>