### PR TITLE
[WIP] Add s390x and ppc64le builds to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,6 @@ os:
 go:
   - "1.13.4"
 
-env:
-  - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct
-  - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v2 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic TRAVIS_RELEASE=yes GOPROXY=direct
-  - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runtime.v1.linux TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct
-  - TRAVIS_GOOS=darwin TRAVIS_CGO_ENABLED=0 GOPROXY=direct
-
 matrix:
   include:
     # Skip testing previous LTS (Xenial / Ubuntu 16.04 LTS) on pull requests
@@ -25,6 +19,28 @@ matrix:
       os: linux
       dist: xenial
       env: TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v2 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=xenial GOPROXY=direct
+    # CI on darwin (macos)
+    - os: linux
+      arch: x86_64
+      env: TRAVIS_GOOS=darwin TRAVIS_CGO_ENABLED=0
+    # CI on ppc64le
+    - os: linux
+      arch: ppc64le
+      env: TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v2 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct
+    # CI on s390x
+    - os: linux
+      arch: s390x
+      env: TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v2 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct
+    # CI on x86_64
+    - os: linux
+      arch: x86_64
+      env: TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runtime.v1.linux TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct
+    - os: linux
+      arch: x86_64
+      env: TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct
+    - os: linux
+      arch: x86_64
+      env: TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v2 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic TRAVIS_RELEASE=yes GOPROXY=direct
 
 go_import_path: github.com/containerd/containerd
 
@@ -42,6 +58,7 @@ addons:
       - libprotobuf-c-dev
       - libprotobuf-dev
       - socat
+      - unzip
 
 before_install:
   - uname -r


### PR DESCRIPTION
Test new LXD-based Travis support for ppc64le and s390x.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>