### PR TITLE
test: Do SynchronousDelete cleanup before testing ImageIsUnpacked

### DIFF
--- a/image_test.go
+++ b/image_test.go
@@ -45,7 +45,8 @@ func TestImageIsUnpacked(t *testing.T) {
 	defer client.Close()
 
 	// Cleanup
-	err = client.ImageService().Delete(ctx, imageName)
+	opts := []images.DeleteOpt{images.SynchronousDelete()}
+	err = client.ImageService().Delete(ctx, imageName, opts...)
 	if err != nil && !errdefs.IsNotFound(err) {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Simply delete the image will not clean up the snapshots.

Signed-off-by: Li Yuxuan <liyuxuan04@baidu.com>