### PR TITLE
devmapper: update example base image size in README

### DIFF
--- a/snapshots/devmapper/README.md
+++ b/snapshots/devmapper/README.md
@@ -15,7 +15,7 @@ Here's minimal sample entry that can be made in the configuration file:
   ...
   [plugins.devmapper]
     pool_name = "containerd-pool"
-    base_image_size = "128MB"
+    base_image_size = "8192MB"
   ...
 ```
 


### PR DESCRIPTION
base_image_size effectively is the limit of a layer size that can be
created using the devmapper snapshotter. While this will also depend on
the thinpool size itself, something closer to the total image size
(80%?) is more appropriate.

As is, if you try to run an image like elastic, you'll need a much
larger base_image_size than 128MB.

As a reference point, this is my reference thinpool setup for devmapper, [1]. It may be useful to maintain a reference script in the docs with a big "YMMV" warning, for setting this up.  

Happy to add this if there's interest.

[1] - https://github.com/egernst/k8s-pod-overhead/blob/master/node-setup/containerd_devmapper_setup.sh 

Signed-off-by: Eric Ernst <eric.ernst@intel.com>