### PR TITLE
containerd fix type convert compile error on mips64el

### DIFF
--- a/vendor/github.com/docker/docker/pkg/system/stat_linux.go
+++ b/vendor/github.com/docker/docker/pkg/system/stat_linux.go
@@ -8,7 +8,7 @@ func fromStatT(s *syscall.Stat_t) (*StatT, error) {
 		mode: s.Mode,
 		uid:  s.Uid,
 		gid:  s.Gid,
-		rdev: s.Rdev,
+		rdev: uint64(s.Rdev),
 		mtim: s.Mtim}, nil
 }
 


### PR DESCRIPTION
containerd fix type convert compile error on mips64el;
the type of the "s.Rdev" is 32bit on mip64el, and it cannot convert 'uint32' to 'uint64' implicitly with programming in GO language;
convert the "s.Rdev" type to 'uint64' explicitly;