### PR TITLE
Enable snapshotter to make snapshots without pulling the contents

### DIFF
--- a/client.go
+++ b/client.go
@@ -342,6 +342,10 @@ type RemoteContext struct {
 
 	// AllMetadata downloads all manifests and known-configuration files
 	AllMetadata bool
+
+	// SkipPullingBySnapshotter skips pulling layers which can be provided by
+	// snapshotter without pulling the actual contnets.
+	SkipPullingBySnapshotter bool
 }
 
 func defaultRemoteContext() *RemoteContext {

--- a/client_opts.go
+++ b/client_opts.go
@@ -219,3 +219,12 @@ func WithAllMetadata() RemoteOpt {
 		return nil
 	}
 }
+
+// WithSkipPullingBySnapshotter skips pulling layers which can be provided by
+// snapshotter without pulling the actual contents.
+func WithSkipPullingBySnapshotter() RemoteOpt {
+	return func(_ *Client, c *RemoteContext) error {
+		c.SkipPullingBySnapshotter = true
+		return nil
+	}
+}

--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -57,6 +57,10 @@ command. As part of this process, we do the following:
 			Name:  "all-metadata",
 			Usage: "Pull metadata for all platforms",
 		},
+		cli.BoolFlag{
+			Name:  "skip-download",
+			Usage: "Skip downloading layers which can be provided by snapshotter without pulling it",
+		},
 	),
 	Action: func(context *cli.Context) error {
 		var (

--- a/snapshots/handler/handler.go
+++ b/snapshots/handler/handler.go
@@ -1,0 +1,156 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package handler
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/remotes"
+	"github.com/containerd/containerd/snapshots"
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/identity"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+const (
+	TargetSnapshotLabel = "containerd.io/snapshot.ref"
+	TargetRefLabel      = "containerd.io/snapshot/target.reference"
+	TargetDigestLabel   = "containerd.io/snapshot/target.digest"
+)
+
+// FilterLayerBySnapshotter filters out layers from download candidates if the
+// snapshotter can prepare the layer snapshot without pulling it.
+func FilterLayerBySnapshotter(f images.HandlerFunc, sn snapshots.Snapshotter, store content.Store, fetcher remotes.Fetcher, ref string) images.HandlerFunc {
+	return func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		children, err := f(ctx, desc)
+		if err != nil {
+			return nil, err
+		}
+
+		if desc.MediaType == ocispec.MediaTypeImageManifest ||
+			desc.MediaType == images.MediaTypeDockerSchema2Manifest {
+			p, err := content.ReadBlob(ctx, store, desc)
+			if err != nil {
+				return nil, err
+			}
+			var manifest ocispec.Manifest
+			if err := json.Unmarshal(p, &manifest); err != nil {
+				return nil, err
+			}
+
+			if _, err := remotes.FetchHandler(store, fetcher)(ctx, manifest.Config); err != nil {
+				return nil, err
+			}
+			chain, err := images.RootFS(ctx, store, manifest.Config)
+			if err != nil {
+				return nil, err
+			}
+
+			// Get the index of a layer which is the lowest non-skippable layer. We avoid
+			// downloading skippable layers which are lower than it by filtering out them.
+			i := firstFalseIdx(manifest.Layers, chain, isPullSkippable(ctx, sn, ref))
+			children = exclude(children, manifest.Layers[:i])
+		}
+
+		return children, nil
+	}
+}
+
+func isPullSkippable(ctx context.Context, sn snapshots.Snapshotter, ref string) func(ocispec.Descriptor, []digest.Digest) bool {
+
+	// Check if the given layer is a pull-skippable snapshot. Using chain, this
+	// function generates chainID to prepare/commit the snapshot so that the
+	// snapshot can be Prepare()ed later using the chainID as a normal way.
+	return func(layer ocispec.Descriptor, chain []digest.Digest) bool {
+		var (
+			parent      = identity.ChainID(chain[:len(chain)-1]).String()
+			chainID     = identity.ChainID(chain).String()
+			layerDigest = layer.Digest.String()
+		)
+
+		// If this layer can be provided without pulling the actual contents, the
+		// snapshotter gives us ErrAlreadyExists.
+		for {
+			pKey := getUniqueKey(ctx, sn, chainID)
+			if _, err := sn.Prepare(ctx, pKey, parent, snapshots.WithLabels(map[string]string{
+				TargetSnapshotLabel: chainID,
+				TargetRefLabel:      ref,
+				TargetDigestLabel:   layerDigest,
+			})); !errdefs.IsAlreadyExists(err) {
+				sn.Remove(ctx, pKey)
+				return false
+			}
+			if _, err := sn.Stat(ctx, pKey); err == nil {
+
+				// We got ErrAlreadyExist and the ActiveSnapshot already exists. This
+				// doesn't indicade pull-skippable snapshot existence but key confliction.
+				// Try again with another key.
+				continue
+			}
+
+			break
+		}
+
+		return true
+	}
+}
+
+func getUniqueKey(ctx context.Context, sn snapshots.Snapshotter, chainID string) (key string) {
+	for {
+		t := time.Now()
+		var b [3]byte
+		// Ignore read failures, just decreases uniqueness
+		rand.Read(b[:])
+		uniquePart := fmt.Sprintf("%d-%s", t.Nanosecond(), base64.URLEncoding.EncodeToString(b[:]))
+		key = fmt.Sprintf("target-%s %s", uniquePart, chainID)
+		if _, err := sn.Stat(ctx, key); err == nil {
+			continue
+		}
+		break
+	}
+	return
+}
+
+func firstFalseIdx(layers []ocispec.Descriptor, chain []digest.Digest, f func(ocispec.Descriptor, []digest.Digest) bool) int {
+	for i, l := range layers {
+		if !f(l, chain[:i+1]) {
+			return i
+		}
+	}
+	return len(layers)
+}
+
+func exclude(a []ocispec.Descriptor, b []ocispec.Descriptor) (res []ocispec.Descriptor) {
+	bmap := make(map[string]ocispec.Descriptor)
+	for _, vb := range b {
+		bmap[vb.Digest.String()] = vb
+	}
+	for _, va := range a {
+		if _, ok := bmap[va.Digest.String()]; !ok {
+			res = append(res, va)
+		}
+	}
+	return
+}

--- a/snapshots/handler/handler.go
+++ b/snapshots/handler/handler.go
@@ -35,9 +35,23 @@ import (
 )
 
 const (
+	// TargetSnapshotLabel is a label to tell the backend snapshotter the
+	// chainID of this snapshot. The backend snapshotter can use this
+	// information to search for the contents of the snapshot and to commit
+	// it. The client can use the committed snapshot with the chainID later.
 	TargetSnapshotLabel = "containerd.io/snapshot.ref"
-	TargetRefLabel      = "containerd.io/snapshot/target.reference"
-	TargetDigestLabel   = "containerd.io/snapshot/target.digest"
+
+	// TargetRefLabel is a label to tell the backend snapshotter the basic
+	// information(image reference) of the image layer. The backend
+	// snapshotter can use this information to search for the contents of
+	// the snapshot.
+	TargetRefLabel = "containerd.io/snapshot/target.reference"
+
+	// TargetDigestLabel is a label to tell the backend snapshotter the
+	// basic information(layer digest) of the image layer. The backend
+	// snapshotter can use this information to search for the contents of
+	// the snapshot.
+	TargetDigestLabel = "containerd.io/snapshot/target.digest"
 )
 
 // FilterLayerBySnapshotter filters out layers from download candidates if the

--- a/snapshots/handler/handler.go
+++ b/snapshots/handler/handler.go
@@ -143,12 +143,12 @@ func firstFalseIdx(layers []ocispec.Descriptor, chain []digest.Digest, f func(oc
 }
 
 func exclude(a []ocispec.Descriptor, b []ocispec.Descriptor) (res []ocispec.Descriptor) {
-	bmap := make(map[string]ocispec.Descriptor)
+	bmap := make(map[string]bool)
 	for _, vb := range b {
-		bmap[vb.Digest.String()] = vb
+		bmap[vb.Digest.String()] = true
 	}
 	for _, va := range a {
-		if _, ok := bmap[va.Digest.String()]; !ok {
+		if ok := bmap[va.Digest.String()]; !ok {
 			res = append(res, va)
 		}
 	}

--- a/snapshots/handler/handler.go
+++ b/snapshots/handler/handler.go
@@ -105,7 +105,7 @@ func isPullSkippable(ctx context.Context, sn snapshots.Snapshotter, ref string) 
 			if _, err := sn.Stat(ctx, pKey); err == nil {
 
 				// We got ErrAlreadyExist and the ActiveSnapshot already exists. This
-				// doesn't indicade pull-skippable snapshot existence but key confliction.
+				// doesn't indicate pull-skippable snapshot existence but key confliction.
 				// Try again with another key.
 				continue
 			}

--- a/snapshots/handler/handler_test.go
+++ b/snapshots/handler/handler_test.go
@@ -96,7 +96,7 @@ func TestSkippableCheck(t *testing.T) {
 				return
 			}
 			if len(sn.active) != 0 {
-				t.Errorf("remaining garbedge active snapshot. must bo clean")
+				t.Errorf("remaining garbage active snapshot. must be clean")
 				return
 			}
 			if len(sn.committed) != wantI {

--- a/snapshots/handler/handler_test.go
+++ b/snapshots/handler/handler_test.go
@@ -1,0 +1,298 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package handler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/snapshots"
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/identity"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+const testRef = "testRef"
+
+// TestSkippableCheck tests functionality to check if a snapshot is
+// pull-skippable and to filter out the layer from download candidates.
+func TestSkippableCheck(t *testing.T) {
+	tests := []struct {
+		name      string
+		skippable []bool
+	}{
+		{
+			name:      "download_all",
+			skippable: []bool{false, false, false},
+		},
+		{
+			name:      "all_skippable",
+			skippable: []bool{true, true, true},
+		},
+		{
+			name:      "lower_layer_skippable",
+			skippable: []bool{true, true, false},
+		},
+		{
+			name:      "upper_layer_skippable",
+			skippable: []bool{false, true, false},
+		},
+		{
+			name:      "partially_skippable_1",
+			skippable: []bool{true, false, true, false},
+		},
+		{
+			name:      "partially_skippable_2",
+			skippable: []bool{false, true, false, true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				skippable = make(map[string]bool)
+				inDesc    []ocispec.Descriptor
+				inChain   []digest.Digest
+			)
+			for i, e := range tt.skippable {
+				desc := descriptor(i)
+				inDesc = append(inDesc, desc)
+				inChain = append(inChain, digest.Digest(fmt.Sprintf("%d-chain", i)))
+				if e {
+					skippable[desc.Digest.String()] = true
+					t.Logf("  skippable: %v", desc.Digest.String())
+				}
+			}
+			sn := &testSnapshotter{
+				t:         t,
+				skippable: skippable,
+				active:    make(map[string]bool),
+				committed: make(map[string]bool),
+			}
+			gotI := firstFalseIdx(inDesc, inChain, isPullSkippable(context.TODO(), sn, testRef))
+			wantI := firstFalseIdx(inDesc, inChain, func(l ocispec.Descriptor, chain []digest.Digest) bool {
+				return tt.skippable[len(chain)-1]
+			})
+			if gotI != wantI {
+				t.Errorf("upper-most skippable = %d; want %d", gotI, wantI)
+				return
+			}
+			if len(sn.active) != 0 {
+				t.Errorf("remaining garbedge active snapshot. must bo clean")
+				return
+			}
+			if len(sn.committed) != wantI {
+				t.Errorf("num of the committed snapshot: %d; want: %d", len(sn.committed), wantI)
+				return
+			}
+			for i := 0; i < wantI; i++ {
+				chainID := identity.ChainID(inChain[:i+1]).String()
+				if ok := sn.committed[chainID]; !ok {
+					t.Errorf("chainID %q must be committed", chainID)
+					return
+				}
+			}
+		})
+	}
+}
+
+// TestExeclude tests function to get a slice which has been excluded by another
+// slice from original one.
+func TestExclude(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []int
+		b    []int
+		want []int
+	}{
+		{
+			name: "nothing",
+			a:    nil,
+			b:    []int{1, 2, 3},
+			want: nil,
+		},
+		{
+			name: "all_remain",
+			a:    []int{1, 2, 3},
+			b:    nil,
+			want: []int{1, 2, 3},
+		},
+		{
+			name: "all_remove",
+			a:    []int{1, 2, 3},
+			b:    []int{1, 2, 3},
+			want: nil,
+		},
+		{
+			name: "ordered",
+			a:    []int{1, 2, 3, 4, 5},
+			b:    []int{2, 4},
+			want: []int{1, 3, 5},
+		},
+		{
+			name: "random",
+			a:    []int{5, 1, 3, 2, 4},
+			b:    []int{4, 2},
+			want: []int{5, 1, 3},
+		},
+		{
+			name: "duplicated",
+			a:    []int{5, 4, 5, 1, 2, 3, 1, 5},
+			b:    []int{4, 1, 3},
+			want: []int{5, 5, 2, 5},
+		},
+		{
+			name: "unnecessary",
+			a:    []int{1, 2, 3, 4},
+			b:    []int{1, 7, 8, 2, 9},
+			want: []int{3, 4},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := exclude(descSlice(tt.a), descSlice(tt.b))
+			want := descSlice(tt.want)
+			t.Logf("  result: %v", res)
+			t.Logf("  wanted: %v", want)
+			if len(res) != len(want) {
+				t.Errorf("result slice size is %d; want %d", len(res), len(want))
+			}
+			for i := 0; i < len(res); i++ {
+				if res[i].Digest.String() != want[i].Digest.String() {
+					t.Errorf("result value is %q; want %q",
+						res[i].Digest.String(), want[i].Digest.String())
+				}
+			}
+		})
+	}
+}
+
+func descSlice(ids []int) (desc []ocispec.Descriptor) {
+	for _, id := range ids {
+		desc = append(desc, descriptor(id))
+	}
+	return
+}
+
+func descriptor(id int) ocispec.Descriptor {
+	return ocispec.Descriptor{
+		Digest: digest.Digest(fmt.Sprintf("%d-desc", id)),
+	}
+}
+
+type testSnapshotter struct {
+	t         *testing.T
+	skippable map[string]bool
+	active    map[string]bool
+	committed map[string]bool
+}
+
+func (ts *testSnapshotter) Stat(ctx context.Context, key string) (snapshots.Info, error) {
+	if ok := ts.active[key]; ok {
+		return snapshots.Info{}, nil
+	}
+	if ok := ts.committed[key]; ok {
+		return snapshots.Info{}, nil
+	}
+	return snapshots.Info{}, errors.Wrapf(errdefs.ErrNotFound, "resource %q does not exist", key)
+}
+
+func (ts *testSnapshotter) Prepare(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
+	if parent != "" {
+		if ok := ts.committed[parent]; !ok {
+			return nil, errors.Wrapf(errdefs.ErrNotFound, "parent snapshot %q does not exist", parent)
+		}
+	}
+
+	if err := ts.createSnapshot(opts...); err != nil {
+		ts.t.Logf("failed to create snapshot: %q", err)
+		ts.active[key] = true
+		return nil, nil
+	}
+
+	return nil, errors.Wrapf(errdefs.ErrAlreadyExists, "created snapshot")
+}
+
+func (ts *testSnapshotter) createSnapshot(opts ...snapshots.Opt) error {
+	var base snapshots.Info
+	for _, opt := range opts {
+		if err := opt(&base); err != nil {
+			return err
+		}
+	}
+
+	chainID, ok := base.Labels[TargetSnapshotLabel]
+	if !ok {
+		return fmt.Errorf("chainID is not passed")
+	}
+	ref, ok := base.Labels[TargetRefLabel]
+	if !ok {
+		return fmt.Errorf("image reference is not passed")
+	}
+	digest, ok := base.Labels[TargetDigestLabel]
+	if !ok {
+		return fmt.Errorf("image digest are not passed")
+	}
+	if ref != testRef {
+		return fmt.Errorf("unknown ref")
+	}
+	if ok := ts.skippable[digest]; !ok {
+		return fmt.Errorf("unknown digest")
+	}
+	ts.committed[chainID] = true
+
+	return nil
+}
+
+func (ts *testSnapshotter) Remove(ctx context.Context, key string) error {
+	delete(ts.active, key)
+	delete(ts.committed, key)
+	return nil
+}
+
+func (ts *testSnapshotter) Update(ctx context.Context, info snapshots.Info, fieldpaths ...string) (snapshots.Info, error) {
+	return snapshots.Info{}, nil
+}
+
+func (ts *testSnapshotter) Usage(ctx context.Context, key string) (snapshots.Usage, error) {
+	return snapshots.Usage{}, nil
+}
+
+func (ts *testSnapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, error) {
+	return nil, nil
+}
+
+func (ts *testSnapshotter) View(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
+	return nil, nil
+}
+
+func (ts *testSnapshotter) Commit(ctx context.Context, name, key string, opts ...snapshots.Opt) error {
+	return nil
+}
+
+func (ts *testSnapshotter) Walk(ctx context.Context, fn snapshots.WalkFunc, filters ...string) error {
+	return nil
+}
+
+func (ts *testSnapshotter) Close() error {
+	return nil
+}


### PR DESCRIPTION
This commit allows snapshotter to prepare snapshots as well as to prevent the
client from downloading the layer's contents. This hopefully enables to reduce
time for pulling the image. The client passes basic information of the image
layer(ref, digest) to the snapshotter as labels and the snapsohtter can use or
simply ignore it.

This commit also includes changes on ctr command to make using this
functionality easier.

This commit depends on PR #3793 because the implementation uses the target snapshot reference functionality. So this is a little bit early, but I raised this PR also for discussion based on the concrete implementation.

This functionality enables remote snapshots(discussed on the issue #3731) and you can test it with current remote snapshotter implementation on:

- https://github.com/ktock/remote-snapshotter/tree/filter-by-snapshotter-test

The step of the demo:

- https://github.com/ktock/remote-snapshotter/tree/filter-by-snapshotter-test#demo

