### PR TITLE
bump containerd/go-runc a2952bc25f5116103a8b78f3817f6df759aa7def

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,4 +1,4 @@
-github.com/containerd/go-runc e029b79d8cda8374981c64eba71f28ec38e5526f
+github.com/containerd/go-runc a2952bc25f5116103a8b78f3817f6df759aa7def
 github.com/containerd/console 0650fd9eeb50bab4fc99dceb9f2e14cf58f36e7f
 github.com/containerd/cgroups abd0b19954a6b05e0963f48427062d1481b7faad
 github.com/containerd/typeurl a93fcdb778cd272c6e9b3028b2f42d813e785d40

--- a/vendor/github.com/containerd/go-runc/runc.go
+++ b/vendor/github.com/containerd/go-runc/runc.go
@@ -172,7 +172,7 @@ func (r *Runc) Create(context context.Context, id, bundle string, opts *CreateOp
 	}
 	status, err := Monitor.Wait(cmd, ec)
 	if err == nil && status != 0 {
-		err = fmt.Errorf("%s did not terminate sucessfully", cmd.Args[0])
+		err = fmt.Errorf("%s did not terminate successfully", cmd.Args[0])
 	}
 	return err
 }
@@ -251,7 +251,7 @@ func (r *Runc) Exec(context context.Context, id string, spec specs.Process, opts
 	}
 	status, err := Monitor.Wait(cmd, ec)
 	if err == nil && status != 0 {
-		err = fmt.Errorf("%s did not terminate sucessfully", cmd.Args[0])
+		err = fmt.Errorf("%s did not terminate successfully", cmd.Args[0])
 	}
 	return err
 }
@@ -277,7 +277,7 @@ func (r *Runc) Run(context context.Context, id, bundle string, opts *CreateOpts)
 	}
 	status, err := Monitor.Wait(cmd, ec)
 	if err == nil && status != 0 {
-		err = fmt.Errorf("%s did not terminate sucessfully", cmd.Args[0])
+		err = fmt.Errorf("%s did not terminate successfully", cmd.Args[0])
 	}
 	return status, err
 }
@@ -576,7 +576,7 @@ func (r *Runc) Restore(context context.Context, id, bundle string, opts *Restore
 	}
 	status, err := Monitor.Wait(cmd, ec)
 	if err == nil && status != 0 {
-		err = fmt.Errorf("%s did not terminate sucessfully", cmd.Args[0])
+		err = fmt.Errorf("%s did not terminate successfully", cmd.Args[0])
 	}
 	return status, err
 }
@@ -682,7 +682,7 @@ func (r *Runc) runOrError(cmd *exec.Cmd) error {
 		}
 		status, err := Monitor.Wait(cmd, ec)
 		if err == nil && status != 0 {
-			err = fmt.Errorf("%s did not terminate sucessfully", cmd.Args[0])
+			err = fmt.Errorf("%s did not terminate successfully", cmd.Args[0])
 		}
 		return err
 	}
@@ -708,7 +708,7 @@ func cmdOutput(cmd *exec.Cmd, combined bool) ([]byte, error) {
 
 	status, err := Monitor.Wait(cmd, ec)
 	if err == nil && status != 0 {
-		err = fmt.Errorf("%s did not terminate sucessfully", cmd.Args[0])
+		err = fmt.Errorf("%s did not terminate successfully", cmd.Args[0])
 	}
 
 	return b.Bytes(), err


### PR DESCRIPTION
full diff: https://github.com/containerd/go-runc/compare/e029b79d8cda8374981c64eba71f28ec38e5526f...a2952bc25f5116103a8b78f3817f6df759aa7def

- containerd/go-runc#56 fix typo in successfully
