### PR TITLE
[release 1.3] Fix cleanup error on content client test

### DIFF
--- a/content_test.go
+++ b/content_test.go
@@ -57,7 +57,7 @@ func newContentStore(ctx context.Context, root string) (context.Context, content
 				return err
 			}
 			for _, st := range statuses {
-				if err := cs.Abort(ctx, st.Ref); err != nil {
+				if err := cs.Abort(ctx, st.Ref); err != nil && !errdefs.IsNotFound(err) {
 					return errors.Wrapf(err, "failed to abort %s", st.Ref)
 				}
 			}


### PR DESCRIPTION
A race occurs today where the cleanup runs after the lease
has been deleted, making all the content and statuses
eligible for collection during the cleanup. There is a case
where a status could be listed but removed before the
abort is called. In this case, abort will return a not found
and the test cleanup should ignore it.

Signed-off-by: Derek McGowan <derek@mcgstyle.net>
(cherry picked from commit 8da4346686f339241efed3e6bf752cc4f8670103)
Signed-off-by: Wei Fu <fuweid89@gmail.com>

cherry-pick #3853 