### PR TITLE
Fix container pid race condition.

### DIFF
--- a/container_test.go
+++ b/container_test.go
@@ -1675,6 +1675,55 @@ func TestContainerExecLargeOutputWithTTY(t *testing.T) {
 	<-finishedC
 }
 
+func TestShortRunningTaskPid(t *testing.T) {
+	t.Parallel()
+
+	client, err := newClient(t, address)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	var (
+		image       Image
+		ctx, cancel = testContext(t)
+		id          = t.Name()
+	)
+	defer cancel()
+
+	image, err = client.GetImage(ctx, testImage)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	container, err := client.NewContainer(ctx, id, WithNewSnapshot(id, image), WithNewSpec(oci.WithImageConfig(image), withProcessArgs("true")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer container.Delete(ctx, WithSnapshotCleanup)
+
+	task, err := container.NewTask(ctx, empty())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer task.Delete(ctx)
+
+	finishedC, err := task.Wait(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := task.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	int32PID := int32(task.Pid())
+	if int32PID <= 0 {
+		t.Errorf("Unexpected task pid %d", int32PID)
+	}
+	<-finishedC
+}
+
 func withProcessTTY() cio.Opt {
 	return func(opt *cio.Streams) {
 		cio.WithTerminal(opt)

--- a/pkg/process/exec.go
+++ b/pkg/process/exec.go
@@ -96,7 +96,6 @@ func (e *execProcess) setExited(status int) {
 	e.status = status
 	e.exited = time.Now()
 	e.parent.Platform.ShutdownConsole(context.Background(), e.console)
-	e.pid.set(StoppedPID)
 	close(e.waitBlock)
 }
 
@@ -147,7 +146,7 @@ func (e *execProcess) kill(ctx context.Context, sig uint32, _ bool) error {
 	switch {
 	case pid == 0:
 		return errors.Wrap(errdefs.ErrFailedPrecondition, "process not created")
-	case pid < 0:
+	case !e.exited.IsZero():
 		return errors.Wrapf(errdefs.ErrNotFound, "process already finished")
 	default:
 		if err := unix.Kill(pid, syscall.Signal(sig)); err != nil {

--- a/pkg/process/init_state.go
+++ b/pkg/process/init_state.go
@@ -147,9 +147,6 @@ func (s *createdCheckpointState) Start(ctx context.Context) error {
 	p := s.p
 	sio := p.stdio
 
-	p.pid.Lock()
-	defer p.pid.Unlock()
-
 	var (
 		err    error
 		socket *runc.Socket
@@ -189,7 +186,7 @@ func (s *createdCheckpointState) Start(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to retrieve OCI runtime container pid")
 	}
-	p.pid.pid = pid
+	p.pid = pid
 	return s.transition("running")
 }
 

--- a/pkg/process/utils.go
+++ b/pkg/process/utils.go
@@ -39,8 +39,6 @@ import (
 const (
 	// RuncRoot is the path to the root runc state directory
 	RuncRoot = "/run/containerd/runc"
-	// StoppedPID is the pid assigned after a container has run and stopped
-	StoppedPID = -1
 	// InitPidFile name of the file that contains the init pid
 	InitPidFile = "init.pid"
 )
@@ -55,12 +53,6 @@ func (s *safePid) get() int {
 	s.Lock()
 	defer s.Unlock()
 	return s.pid
-}
-
-func (s *safePid) set(pid int) {
-	s.Lock()
-	s.pid = pid
-	s.Unlock()
 }
 
 type atomicBool int32


### PR DESCRIPTION
If you try docker with containerd 1.3, and run `docker run hello-world`, it will stuck.

After https://github.com/containerd/containerd/pull/3366, we change pid after container/exec process created, this causes various issues:
1) The pid we get from `task.Start` might be `-1` if the container is a short running container, because `Start` and `State` are not called in a transaction: https://github.com/containerd/containerd/blob/master/services/tasks/local.go#L230.
2) This is fine for Kubernetes integration, because we stopped relying on containerd event and pid matching. However, this will break Docker: https://github.com/moby/moby/blob/05469b5fa2b48cf20cd0137ca8c45645b63049ff/daemon/monitor.go#L50
3) In all higher level apis, pid is an `uint`, returning `-1` will eventually make it `4294967295`, which is not very user friendly:
```
        "State": {
            "Status": "running",
            "Running": true,
            "Paused": false,
            "Restarting": false,
            "OOMKilled": false,
            "Dead": false,
            "Pid": 4294967295,
            "ExitCode": 0,
            "Error": "",
            "StartedAt": "2019-11-27T22:21:24.999965567Z",
            "FinishedAt": "0001-01-01T00:00:00Z"
        },
```

This PR partially reverts https://github.com/containerd/containerd/pull/3366, and use `exited` to figure out whether the process has already exited. I tested the change with Docker, and `docker run hello-world` works now.


Signed-off-by: Lantao Liu <lantaol@google.com>