### PR TITLE
Reformat vendor.conf: use columns, pin by git-sha, and sort alphabetically

### DIFF
--- a/script/release/release-cri
+++ b/script/release/release-cri
@@ -25,7 +25,7 @@ if [[ -z "${VERSION:-}" ]]; then
 fi
 
 ROOT=${GOPATH}/src/github.com/containerd/containerd
-CRI_COMMIT=$(grep github.com/containerd/cri ${ROOT}/vendor.conf | cut -d " " -f 2)
+CRI_COMMIT=$(grep github.com/containerd/cri ${ROOT}/vendor.conf | awk '{print $2}')
 
 go get -d github.com/containerd/cri/...
 cd $GOPATH/src/github.com/containerd/cri

--- a/script/setup/install-cni
+++ b/script/setup/install-cni
@@ -21,7 +21,7 @@
 #
 set -eu -o pipefail
 
-CNI_COMMIT=$(grep containernetworking/plugins ${GOPATH}/src/github.com/containerd/containerd/vendor.conf | cut -d " " -f 2)
+CNI_COMMIT=$(grep containernetworking/plugins ${GOPATH}/src/github.com/containerd/containerd/vendor.conf | awk '{print $2}')
 CNI_DIR=/opt/cni
 CNI_CONFIG_DIR=/etc/cni/net.d
 

--- a/script/setup/install-runc
+++ b/script/setup/install-runc
@@ -21,7 +21,7 @@
 #
 set -eu -o pipefail
 
-RUNC_COMMIT=$(grep opencontainers/runc ${GOPATH}/src/github.com/containerd/containerd/vendor.conf | cut -d " " -f 2)
+RUNC_COMMIT=$(grep opencontainers/runc ${GOPATH}/src/github.com/containerd/containerd/vendor.conf | awk '{print $2}')
 
 go get -d github.com/opencontainers/runc
 cd $GOPATH/src/github.com/opencontainers/runc

--- a/vendor.conf
+++ b/vendor.conf
@@ -8,80 +8,80 @@ github.com/containerd/continuity                    f2a389ac0a02ce21c09edd734467
 github.com/coreos/go-systemd                        48702e0da86bd25e76cfef347e2adeb434a0d0a6
 github.com/docker/go-metrics                        4ea375f7759c82740c893fc030bc37088d2ec098
 github.com/docker/go-events                         9461782956ad83b30282bf90e31fa6a70c255ba9
-github.com/docker/go-units                          v0.4.0
+github.com/docker/go-units                          519db1ee28dcc9fd2474ae59fca29a810482bfb1 # v0.4.0
 github.com/godbus/dbus                              c7fdd8b5cd55e87b4e1f4e372cdb1db61dd6c66f
 github.com/prometheus/client_golang                 f4fb1b73fb099f396a7f0036bf86aa8def4ed823
 github.com/prometheus/client_model                  99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
 github.com/prometheus/common                        89604d197083d4781071d3c65855d24ecfb0a563
 github.com/prometheus/procfs                        cb4147076ac75738c9a7d279075a253c0cc5acbd
 github.com/beorn7/perks                             4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
-github.com/matttproud/golang_protobuf_extensions    v1.0.1
-github.com/gogo/protobuf                            v1.2.1
-github.com/gogo/googleapis                          v1.2.0
-github.com/golang/protobuf                          v1.2.0
+github.com/matttproud/golang_protobuf_extensions    c12348ce28de40eed0136aa2b644d0ee0650e56c # v1.0.1
+github.com/gogo/protobuf                            ba06b47c162d49f2af050fb4c75bcbc86a159d5c # v1.2.1
+github.com/gogo/googleapis                          d31c731455cb061f42baff3bda55bad0118b126b # v1.2.0
+github.com/golang/protobuf                          aa810b61a9c79d51363740d207bb46cf8e620ed5 # v1.2.0
 github.com/opencontainers/runtime-spec              29686dbc5559d93fb1ef402eeda3e35c38d75af4 # v1.0.1-59-g29686db
 github.com/opencontainers/runc                      d736ef14f0288d6993a1845745d6756cfc9ddd5a # v1.0.0-rc9
-github.com/konsorten/go-windows-terminal-sequences  v1.0.1
-github.com/sirupsen/logrus                          v1.4.1
-github.com/urfave/cli                               v1.22.0
+github.com/konsorten/go-windows-terminal-sequences  5c8c8bd35d3832f5d134ae1e1e375b69a4d25242 # v1.0.1
+github.com/sirupsen/logrus                          8bdbc7bcc01dcbb8ec23dc8a28e332258d25251f # v1.4.1
+github.com/urfave/cli                               bfe2e925cfb6d44b40ad3a779165ea7e8aff9212 # v1.22.0
 golang.org/x/net                                    f3200d17e092c607f615320ecaad13d87ad9a2b3
 google.golang.org/grpc                              39e8a7b072a67ca2a75f57fa2e0d50995f5b22f6 # v1.23.1
-github.com/pkg/errors                               v0.8.1
+github.com/pkg/errors                               ba968bfe8b2f7e042a574c888954fccecfa385b4 # v0.8.1
 github.com/opencontainers/go-digest                 c9281466c8b2f606084ac71339773efd177436e7
 golang.org/x/sys                                    c990c680b611ac1aeb7d8f2af94a825f98d69720 https://github.com/golang/sys
-github.com/opencontainers/image-spec                v1.0.1
+github.com/opencontainers/image-spec                d60099175f88c47cd379c4738d158884749ed235 # v1.0.1
 golang.org/x/sync                                   42b317875d0fa942474b76e1b46a6060d720ae6e
-github.com/BurntSushi/toml                          v0.3.1
+github.com/BurntSushi/toml                          3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005 # v0.3.1
 github.com/grpc-ecosystem/go-grpc-prometheus        6b7015e65d366bf3f19b2b2a000a831940f0f7e0
-github.com/Microsoft/go-winio                       v0.4.14
+github.com/Microsoft/go-winio                       6c72808b55902eae4c5943626030429ff20f3b63 # v0.4.14
 github.com/Microsoft/hcsshim                        d2849cbdb9dfe5f513292a9610ca2eb734cdd1e7
 google.golang.org/genproto                          d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
 golang.org/x/text                                   19e51611da83d6be54ddafce4a4af510cb3e9ea4
 github.com/containerd/ttrpc                         92c8520ef9f86600c650dd540266a007bf03670f
 github.com/syndtr/gocapability                      d98352740cb2c55f81556b63d4a1ec64c5a319c2
-gotest.tools                                        v2.3.0
-github.com/google/go-cmp                            v0.2.0
-go.etcd.io/bbolt                                    v1.3.3
-github.com/hashicorp/errwrap                        v1.0.0
-github.com/hashicorp/go-multierror                  v1.0.0
-github.com/hashicorp/golang-lru                     v0.5.3
-go.opencensus.io                                    v0.22.0
-github.com/imdario/mergo                            v0.3.7
-github.com/cpuguy83/go-md2man                       v1.0.10
-github.com/russross/blackfriday                     v1.5.2
-github.com/google/uuid                              v1.1.1
+gotest.tools                                        1083505acf35a0bd8a696b26837e1fb3187a7a83 # v2.3.0
+github.com/google/go-cmp                            3af367b6b30c263d47e8895973edcca9a49cf029 # v0.2.0
+go.etcd.io/bbolt                                    a0458a2b35708eef59eb5f620ceb3cd1c01a824d # v1.3.3
+github.com/hashicorp/errwrap                        8a6fb523712970c966eefc6b39ed2c5e74880354 # v1.0.0
+github.com/hashicorp/go-multierror                  886a7fbe3eb1c874d46f623bfa70af45f425b3d1 # v1.0.0
+github.com/hashicorp/golang-lru                     7f827b33c0f158ec5dfbba01bb0b14a4541fd81d # v0.5.3
+go.opencensus.io                                    9c377598961b706d1542bd2d84d538b5094d596e # v0.22.0
+github.com/imdario/mergo                            7c29201646fa3de8506f701213473dd407f19646 # v0.3.7
+github.com/cpuguy83/go-md2man                       7762f7e404f8416dfa1d9bb6a8c192aa9acb4d19 # v1.0.10
+github.com/russross/blackfriday                     05f3235734ad95d0016f6a23902f06461fcf567a # v1.5.2
+github.com/google/uuid                              0cd6bf5da1e1c83f8b45653022c74f71af0538a4 # v1.1.1
 
 # cri dependencies
 github.com/containerd/cri                           c9d45e65263e26f7e7f0ac8fdca0d510622f12cb # master
 github.com/containerd/go-cni                        0d360c50b10b350b6bb23863fd4dfb1c232b01c9
-github.com/containernetworking/cni                  v0.7.1
-github.com/containernetworking/plugins              v0.7.6
-github.com/davecgh/go-spew                          v1.1.1
+github.com/containernetworking/cni                  4cfb7b568922a3c79a23e438dc52fe537fc9687e # v0.7.1
+github.com/containernetworking/plugins              9f96827c7cabb03f21d86326000c00f61e181f6a # v0.7.6
+github.com/davecgh/go-spew                          8991bc29aa16c548c550c7ff78260e27b9ab7c73 # v1.1.1
 github.com/docker/distribution                      0d3efadf0154c2b8a4e7b6621fff9809655cc580
 github.com/docker/docker                            d1d5f6476656c6aad457e2a91d3436e66b6f2251
 github.com/docker/spdystream                        449fdfce4d962303d702fec724ef0ad181c92528
-github.com/emicklei/go-restful                      v2.9.5
-github.com/google/gofuzz                            v1.0.0
-github.com/json-iterator/go                         v1.1.7
-github.com/modern-go/reflect2                       1.0.1
-github.com/modern-go/concurrent                     1.0.3
-github.com/opencontainers/selinux                   v1.2.2
-github.com/seccomp/libseccomp-golang                v0.9.1
-github.com/tchap/go-patricia                        v2.2.6
+github.com/emicklei/go-restful                      b993709ae1a4f6dd19cfa475232614441b11c9d5 # v2.9.5
+github.com/google/gofuzz                            f140a6486e521aad38f5917de355cbf147cc0496 # v1.0.0
+github.com/json-iterator/go                         27518f6661eba504be5a7a9a9f6d9460d892ade3 # v1.1.7
+github.com/modern-go/reflect2                       4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd # 1.0.1
+github.com/modern-go/concurrent                     bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94 # 1.0.3
+github.com/opencontainers/selinux                   3a1f366feb7aecbf7a0e71ac4cea88b31597de9e # v1.2.2
+github.com/seccomp/libseccomp-golang                689e3c1541a84461afc49c1c87352a6cedf72e9c # v0.9.1
+github.com/tchap/go-patricia                        666120de432aea38ab06bd5c818f04f4129882c9 # v2.2.6
 golang.org/x/crypto                                 5c40567a22f818bd14a1ea7245dad9f8ef0691aa
 golang.org/x/oauth2                                 0f29369cfe4552d0e4bcddc57cc75f4d7e672a33
 golang.org/x/time                                   85acf8d2951cb2a3bde7632f9ff273ef0379bcbd
-gopkg.in/inf.v0                                     v0.9.0
-gopkg.in/yaml.v2                                    v2.2.2
-k8s.io/api                                          kubernetes-1.16.0-rc.2
-k8s.io/apimachinery                                 kubernetes-1.16.0-rc.2
-k8s.io/apiserver                                    kubernetes-1.16.0-rc.2
-k8s.io/cri-api                                      kubernetes-1.16.0-rc.2
-k8s.io/client-go                                    kubernetes-1.16.0-rc.2
-k8s.io/klog                                         v0.4.0
-k8s.io/kubernetes                                   v1.16.0-rc.2
+gopkg.in/inf.v0                                     3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4 # v0.9.0
+gopkg.in/yaml.v2                                    51d6538a90f86fe93ac480b35f37b2be17fef232 # v2.2.2
+k8s.io/api                                          d2ab659560cb09bd6c9a3011b6468f0025c65e63 # kubernetes-1.16.0-rc.2
+k8s.io/apimachinery                                 27d36303b6556f377b4f34e64705fa9024a12b0c # kubernetes-1.16.0-rc.2
+k8s.io/apiserver                                    5669a5603d961de1ecb7a73b85199e4799081334 # kubernetes-1.16.0-rc.2
+k8s.io/cri-api                                      608eb1dad4ac015f9d4f36a3fc70ad3e579af892 # kubernetes-1.16.0-rc.2
+k8s.io/client-go                                    5ff489491ea74e098486c3530bbfa0171dc7bf95 # kubernetes-1.16.0-rc.2
+k8s.io/klog                                         3ca30a56d8a775276f9cdae009ba326fdc05af7f # v0.4.0
+k8s.io/kubernetes                                   4cb51f0d2d8392ea12aeae13182b41008b3a268e # v1.16.0-rc.2
 k8s.io/utils                                        c2654d5206da6b7b6ace12841e8f359bb89b443c
-sigs.k8s.io/yaml                                    v1.1.0
+sigs.k8s.io/yaml                                    fd68e9863619f6ec2fdd8625fe1f02e7c877e480 # v1.1.0
 
 # zfs dependencies
 github.com/containerd/zfs                           9abf673ca6ff9ab8d9bd776a4ceff8f6dc699c3d

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,55 +1,55 @@
-github.com/containerd/go-runc                       a2952bc25f5116103a8b78f3817f6df759aa7def
-github.com/containerd/console                       0650fd9eeb50bab4fc99dceb9f2e14cf58f36e7f
-github.com/containerd/cgroups                       abd0b19954a6b05e0963f48427062d1481b7faad
-github.com/containerd/typeurl                       a93fcdb778cd272c6e9b3028b2f42d813e785d40
-github.com/containerd/fifo                          bda0ff6ed73c67bfb5e62bc9c697f146b7fd7f13
+github.com/beorn7/perks                             4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+github.com/BurntSushi/toml                          3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005 # v0.3.1
 github.com/containerd/btrfs                         af5082808c833de0e79c1e72eea9fea239364877
+github.com/containerd/cgroups                       abd0b19954a6b05e0963f48427062d1481b7faad
+github.com/containerd/console                       0650fd9eeb50bab4fc99dceb9f2e14cf58f36e7f
 github.com/containerd/continuity                    f2a389ac0a02ce21c09edd7344677a601970f41c
+github.com/containerd/fifo                          bda0ff6ed73c67bfb5e62bc9c697f146b7fd7f13
+github.com/containerd/go-runc                       a2952bc25f5116103a8b78f3817f6df759aa7def
+github.com/containerd/ttrpc                         92c8520ef9f86600c650dd540266a007bf03670f
+github.com/containerd/typeurl                       a93fcdb778cd272c6e9b3028b2f42d813e785d40
 github.com/coreos/go-systemd                        48702e0da86bd25e76cfef347e2adeb434a0d0a6
-github.com/docker/go-metrics                        4ea375f7759c82740c893fc030bc37088d2ec098
+github.com/cpuguy83/go-md2man                       7762f7e404f8416dfa1d9bb6a8c192aa9acb4d19 # v1.0.10
 github.com/docker/go-events                         9461782956ad83b30282bf90e31fa6a70c255ba9
+github.com/docker/go-metrics                        4ea375f7759c82740c893fc030bc37088d2ec098
 github.com/docker/go-units                          519db1ee28dcc9fd2474ae59fca29a810482bfb1 # v0.4.0
 github.com/godbus/dbus                              c7fdd8b5cd55e87b4e1f4e372cdb1db61dd6c66f
+github.com/gogo/googleapis                          d31c731455cb061f42baff3bda55bad0118b126b # v1.2.0
+github.com/gogo/protobuf                            ba06b47c162d49f2af050fb4c75bcbc86a159d5c # v1.2.1
+github.com/golang/protobuf                          aa810b61a9c79d51363740d207bb46cf8e620ed5 # v1.2.0
+github.com/google/go-cmp                            3af367b6b30c263d47e8895973edcca9a49cf029 # v0.2.0
+github.com/google/uuid                              0cd6bf5da1e1c83f8b45653022c74f71af0538a4 # v1.1.1
+github.com/grpc-ecosystem/go-grpc-prometheus        6b7015e65d366bf3f19b2b2a000a831940f0f7e0
+github.com/hashicorp/errwrap                        8a6fb523712970c966eefc6b39ed2c5e74880354 # v1.0.0
+github.com/hashicorp/go-multierror                  886a7fbe3eb1c874d46f623bfa70af45f425b3d1 # v1.0.0
+github.com/hashicorp/golang-lru                     7f827b33c0f158ec5dfbba01bb0b14a4541fd81d # v0.5.3
+github.com/imdario/mergo                            7c29201646fa3de8506f701213473dd407f19646 # v0.3.7
+github.com/konsorten/go-windows-terminal-sequences  5c8c8bd35d3832f5d134ae1e1e375b69a4d25242 # v1.0.1
+github.com/matttproud/golang_protobuf_extensions    c12348ce28de40eed0136aa2b644d0ee0650e56c # v1.0.1
+github.com/Microsoft/go-winio                       6c72808b55902eae4c5943626030429ff20f3b63 # v0.4.14
+github.com/Microsoft/hcsshim                        d2849cbdb9dfe5f513292a9610ca2eb734cdd1e7
+github.com/opencontainers/go-digest                 c9281466c8b2f606084ac71339773efd177436e7
+github.com/opencontainers/image-spec                d60099175f88c47cd379c4738d158884749ed235 # v1.0.1
+github.com/opencontainers/runc                      d736ef14f0288d6993a1845745d6756cfc9ddd5a # v1.0.0-rc9
+github.com/opencontainers/runtime-spec              29686dbc5559d93fb1ef402eeda3e35c38d75af4 # v1.0.1-59-g29686db
+github.com/pkg/errors                               ba968bfe8b2f7e042a574c888954fccecfa385b4 # v0.8.1
 github.com/prometheus/client_golang                 f4fb1b73fb099f396a7f0036bf86aa8def4ed823
 github.com/prometheus/client_model                  99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
 github.com/prometheus/common                        89604d197083d4781071d3c65855d24ecfb0a563
 github.com/prometheus/procfs                        cb4147076ac75738c9a7d279075a253c0cc5acbd
-github.com/beorn7/perks                             4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
-github.com/matttproud/golang_protobuf_extensions    c12348ce28de40eed0136aa2b644d0ee0650e56c # v1.0.1
-github.com/gogo/protobuf                            ba06b47c162d49f2af050fb4c75bcbc86a159d5c # v1.2.1
-github.com/gogo/googleapis                          d31c731455cb061f42baff3bda55bad0118b126b # v1.2.0
-github.com/golang/protobuf                          aa810b61a9c79d51363740d207bb46cf8e620ed5 # v1.2.0
-github.com/opencontainers/runtime-spec              29686dbc5559d93fb1ef402eeda3e35c38d75af4 # v1.0.1-59-g29686db
-github.com/opencontainers/runc                      d736ef14f0288d6993a1845745d6756cfc9ddd5a # v1.0.0-rc9
-github.com/konsorten/go-windows-terminal-sequences  5c8c8bd35d3832f5d134ae1e1e375b69a4d25242 # v1.0.1
-github.com/sirupsen/logrus                          8bdbc7bcc01dcbb8ec23dc8a28e332258d25251f # v1.4.1
-github.com/urfave/cli                               bfe2e925cfb6d44b40ad3a779165ea7e8aff9212 # v1.22.0
-golang.org/x/net                                    f3200d17e092c607f615320ecaad13d87ad9a2b3
-google.golang.org/grpc                              39e8a7b072a67ca2a75f57fa2e0d50995f5b22f6 # v1.23.1
-github.com/pkg/errors                               ba968bfe8b2f7e042a574c888954fccecfa385b4 # v0.8.1
-github.com/opencontainers/go-digest                 c9281466c8b2f606084ac71339773efd177436e7
-golang.org/x/sys                                    c990c680b611ac1aeb7d8f2af94a825f98d69720 https://github.com/golang/sys
-github.com/opencontainers/image-spec                d60099175f88c47cd379c4738d158884749ed235 # v1.0.1
-golang.org/x/sync                                   42b317875d0fa942474b76e1b46a6060d720ae6e
-github.com/BurntSushi/toml                          3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005 # v0.3.1
-github.com/grpc-ecosystem/go-grpc-prometheus        6b7015e65d366bf3f19b2b2a000a831940f0f7e0
-github.com/Microsoft/go-winio                       6c72808b55902eae4c5943626030429ff20f3b63 # v0.4.14
-github.com/Microsoft/hcsshim                        d2849cbdb9dfe5f513292a9610ca2eb734cdd1e7
-google.golang.org/genproto                          d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
-golang.org/x/text                                   19e51611da83d6be54ddafce4a4af510cb3e9ea4
-github.com/containerd/ttrpc                         92c8520ef9f86600c650dd540266a007bf03670f
-github.com/syndtr/gocapability                      d98352740cb2c55f81556b63d4a1ec64c5a319c2
-gotest.tools                                        1083505acf35a0bd8a696b26837e1fb3187a7a83 # v2.3.0
-github.com/google/go-cmp                            3af367b6b30c263d47e8895973edcca9a49cf029 # v0.2.0
-go.etcd.io/bbolt                                    a0458a2b35708eef59eb5f620ceb3cd1c01a824d # v1.3.3
-github.com/hashicorp/errwrap                        8a6fb523712970c966eefc6b39ed2c5e74880354 # v1.0.0
-github.com/hashicorp/go-multierror                  886a7fbe3eb1c874d46f623bfa70af45f425b3d1 # v1.0.0
-github.com/hashicorp/golang-lru                     7f827b33c0f158ec5dfbba01bb0b14a4541fd81d # v0.5.3
-go.opencensus.io                                    9c377598961b706d1542bd2d84d538b5094d596e # v0.22.0
-github.com/imdario/mergo                            7c29201646fa3de8506f701213473dd407f19646 # v0.3.7
-github.com/cpuguy83/go-md2man                       7762f7e404f8416dfa1d9bb6a8c192aa9acb4d19 # v1.0.10
 github.com/russross/blackfriday                     05f3235734ad95d0016f6a23902f06461fcf567a # v1.5.2
-github.com/google/uuid                              0cd6bf5da1e1c83f8b45653022c74f71af0538a4 # v1.1.1
+github.com/sirupsen/logrus                          8bdbc7bcc01dcbb8ec23dc8a28e332258d25251f # v1.4.1
+github.com/syndtr/gocapability                      d98352740cb2c55f81556b63d4a1ec64c5a319c2
+github.com/urfave/cli                               bfe2e925cfb6d44b40ad3a779165ea7e8aff9212 # v1.22.0
+go.etcd.io/bbolt                                    a0458a2b35708eef59eb5f620ceb3cd1c01a824d # v1.3.3
+go.opencensus.io                                    9c377598961b706d1542bd2d84d538b5094d596e # v0.22.0
+golang.org/x/net                                    f3200d17e092c607f615320ecaad13d87ad9a2b3
+golang.org/x/sync                                   42b317875d0fa942474b76e1b46a6060d720ae6e
+golang.org/x/sys                                    c990c680b611ac1aeb7d8f2af94a825f98d69720 https://github.com/golang/sys
+golang.org/x/text                                   19e51611da83d6be54ddafce4a4af510cb3e9ea4
+google.golang.org/genproto                          d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
+google.golang.org/grpc                              39e8a7b072a67ca2a75f57fa2e0d50995f5b22f6 # v1.23.1
+gotest.tools                                        1083505acf35a0bd8a696b26837e1fb3187a7a83 # v2.3.0
 
 # cri dependencies
 github.com/containerd/cri                           c9d45e65263e26f7e7f0ac8fdca0d510622f12cb # master
@@ -63,8 +63,8 @@ github.com/docker/spdystream                        449fdfce4d962303d702fec724ef
 github.com/emicklei/go-restful                      b993709ae1a4f6dd19cfa475232614441b11c9d5 # v2.9.5
 github.com/google/gofuzz                            f140a6486e521aad38f5917de355cbf147cc0496 # v1.0.0
 github.com/json-iterator/go                         27518f6661eba504be5a7a9a9f6d9460d892ade3 # v1.1.7
-github.com/modern-go/reflect2                       4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd # 1.0.1
 github.com/modern-go/concurrent                     bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94 # 1.0.3
+github.com/modern-go/reflect2                       4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd # 1.0.1
 github.com/opencontainers/selinux                   3a1f366feb7aecbf7a0e71ac4cea88b31597de9e # v1.2.2
 github.com/seccomp/libseccomp-golang                689e3c1541a84461afc49c1c87352a6cedf72e9c # v0.9.1
 github.com/tchap/go-patricia                        666120de432aea38ab06bd5c818f04f4129882c9 # v2.2.6
@@ -76,8 +76,8 @@ gopkg.in/yaml.v2                                    51d6538a90f86fe93ac480b35f37
 k8s.io/api                                          d2ab659560cb09bd6c9a3011b6468f0025c65e63 # kubernetes-1.16.0-rc.2
 k8s.io/apimachinery                                 27d36303b6556f377b4f34e64705fa9024a12b0c # kubernetes-1.16.0-rc.2
 k8s.io/apiserver                                    5669a5603d961de1ecb7a73b85199e4799081334 # kubernetes-1.16.0-rc.2
-k8s.io/cri-api                                      608eb1dad4ac015f9d4f36a3fc70ad3e579af892 # kubernetes-1.16.0-rc.2
 k8s.io/client-go                                    5ff489491ea74e098486c3530bbfa0171dc7bf95 # kubernetes-1.16.0-rc.2
+k8s.io/cri-api                                      608eb1dad4ac015f9d4f36a3fc70ad3e579af892 # kubernetes-1.16.0-rc.2
 k8s.io/klog                                         3ca30a56d8a775276f9cdae009ba326fdc05af7f # v0.4.0
 k8s.io/kubernetes                                   4cb51f0d2d8392ea12aeae13182b41008b3a268e # v1.16.0-rc.2
 k8s.io/utils                                        c2654d5206da6b7b6ace12841e8f359bb89b443c

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,91 +1,91 @@
-github.com/containerd/go-runc a2952bc25f5116103a8b78f3817f6df759aa7def
-github.com/containerd/console 0650fd9eeb50bab4fc99dceb9f2e14cf58f36e7f
-github.com/containerd/cgroups abd0b19954a6b05e0963f48427062d1481b7faad
-github.com/containerd/typeurl a93fcdb778cd272c6e9b3028b2f42d813e785d40
-github.com/containerd/fifo bda0ff6ed73c67bfb5e62bc9c697f146b7fd7f13
-github.com/containerd/btrfs af5082808c833de0e79c1e72eea9fea239364877
-github.com/containerd/continuity f2a389ac0a02ce21c09edd7344677a601970f41c
-github.com/coreos/go-systemd 48702e0da86bd25e76cfef347e2adeb434a0d0a6
-github.com/docker/go-metrics 4ea375f7759c82740c893fc030bc37088d2ec098
-github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
-github.com/docker/go-units v0.4.0
-github.com/godbus/dbus c7fdd8b5cd55e87b4e1f4e372cdb1db61dd6c66f
-github.com/prometheus/client_golang f4fb1b73fb099f396a7f0036bf86aa8def4ed823
-github.com/prometheus/client_model 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
-github.com/prometheus/common 89604d197083d4781071d3c65855d24ecfb0a563
-github.com/prometheus/procfs cb4147076ac75738c9a7d279075a253c0cc5acbd
-github.com/beorn7/perks 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
-github.com/matttproud/golang_protobuf_extensions v1.0.1
-github.com/gogo/protobuf v1.2.1
-github.com/gogo/googleapis v1.2.0
-github.com/golang/protobuf v1.2.0
-github.com/opencontainers/runtime-spec 29686dbc5559d93fb1ef402eeda3e35c38d75af4 # v1.0.1-59-g29686db
-github.com/opencontainers/runc d736ef14f0288d6993a1845745d6756cfc9ddd5a # v1.0.0-rc9
-github.com/konsorten/go-windows-terminal-sequences v1.0.1
-github.com/sirupsen/logrus v1.4.1
-github.com/urfave/cli v1.22.0
-golang.org/x/net f3200d17e092c607f615320ecaad13d87ad9a2b3
-google.golang.org/grpc 39e8a7b072a67ca2a75f57fa2e0d50995f5b22f6 # v1.23.1
-github.com/pkg/errors v0.8.1
-github.com/opencontainers/go-digest c9281466c8b2f606084ac71339773efd177436e7
-golang.org/x/sys c990c680b611ac1aeb7d8f2af94a825f98d69720 https://github.com/golang/sys
-github.com/opencontainers/image-spec v1.0.1
-golang.org/x/sync 42b317875d0fa942474b76e1b46a6060d720ae6e
-github.com/BurntSushi/toml v0.3.1
-github.com/grpc-ecosystem/go-grpc-prometheus 6b7015e65d366bf3f19b2b2a000a831940f0f7e0
-github.com/Microsoft/go-winio v0.4.14
-github.com/Microsoft/hcsshim d2849cbdb9dfe5f513292a9610ca2eb734cdd1e7
-google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
-golang.org/x/text 19e51611da83d6be54ddafce4a4af510cb3e9ea4
-github.com/containerd/ttrpc 92c8520ef9f86600c650dd540266a007bf03670f
-github.com/syndtr/gocapability d98352740cb2c55f81556b63d4a1ec64c5a319c2
-gotest.tools v2.3.0
-github.com/google/go-cmp v0.2.0
-go.etcd.io/bbolt v1.3.3
-github.com/hashicorp/errwrap v1.0.0
-github.com/hashicorp/go-multierror v1.0.0
-github.com/hashicorp/golang-lru v0.5.3
-go.opencensus.io v0.22.0
-github.com/imdario/mergo v0.3.7
-github.com/cpuguy83/go-md2man v1.0.10
-github.com/russross/blackfriday v1.5.2
-github.com/google/uuid v1.1.1
+github.com/containerd/go-runc                       a2952bc25f5116103a8b78f3817f6df759aa7def
+github.com/containerd/console                       0650fd9eeb50bab4fc99dceb9f2e14cf58f36e7f
+github.com/containerd/cgroups                       abd0b19954a6b05e0963f48427062d1481b7faad
+github.com/containerd/typeurl                       a93fcdb778cd272c6e9b3028b2f42d813e785d40
+github.com/containerd/fifo                          bda0ff6ed73c67bfb5e62bc9c697f146b7fd7f13
+github.com/containerd/btrfs                         af5082808c833de0e79c1e72eea9fea239364877
+github.com/containerd/continuity                    f2a389ac0a02ce21c09edd7344677a601970f41c
+github.com/coreos/go-systemd                        48702e0da86bd25e76cfef347e2adeb434a0d0a6
+github.com/docker/go-metrics                        4ea375f7759c82740c893fc030bc37088d2ec098
+github.com/docker/go-events                         9461782956ad83b30282bf90e31fa6a70c255ba9
+github.com/docker/go-units                          v0.4.0
+github.com/godbus/dbus                              c7fdd8b5cd55e87b4e1f4e372cdb1db61dd6c66f
+github.com/prometheus/client_golang                 f4fb1b73fb099f396a7f0036bf86aa8def4ed823
+github.com/prometheus/client_model                  99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
+github.com/prometheus/common                        89604d197083d4781071d3c65855d24ecfb0a563
+github.com/prometheus/procfs                        cb4147076ac75738c9a7d279075a253c0cc5acbd
+github.com/beorn7/perks                             4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+github.com/matttproud/golang_protobuf_extensions    v1.0.1
+github.com/gogo/protobuf                            v1.2.1
+github.com/gogo/googleapis                          v1.2.0
+github.com/golang/protobuf                          v1.2.0
+github.com/opencontainers/runtime-spec              29686dbc5559d93fb1ef402eeda3e35c38d75af4 # v1.0.1-59-g29686db
+github.com/opencontainers/runc                      d736ef14f0288d6993a1845745d6756cfc9ddd5a # v1.0.0-rc9
+github.com/konsorten/go-windows-terminal-sequences  v1.0.1
+github.com/sirupsen/logrus                          v1.4.1
+github.com/urfave/cli                               v1.22.0
+golang.org/x/net                                    f3200d17e092c607f615320ecaad13d87ad9a2b3
+google.golang.org/grpc                              39e8a7b072a67ca2a75f57fa2e0d50995f5b22f6 # v1.23.1
+github.com/pkg/errors                               v0.8.1
+github.com/opencontainers/go-digest                 c9281466c8b2f606084ac71339773efd177436e7
+golang.org/x/sys                                    c990c680b611ac1aeb7d8f2af94a825f98d69720 https://github.com/golang/sys
+github.com/opencontainers/image-spec                v1.0.1
+golang.org/x/sync                                   42b317875d0fa942474b76e1b46a6060d720ae6e
+github.com/BurntSushi/toml                          v0.3.1
+github.com/grpc-ecosystem/go-grpc-prometheus        6b7015e65d366bf3f19b2b2a000a831940f0f7e0
+github.com/Microsoft/go-winio                       v0.4.14
+github.com/Microsoft/hcsshim                        d2849cbdb9dfe5f513292a9610ca2eb734cdd1e7
+google.golang.org/genproto                          d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
+golang.org/x/text                                   19e51611da83d6be54ddafce4a4af510cb3e9ea4
+github.com/containerd/ttrpc                         92c8520ef9f86600c650dd540266a007bf03670f
+github.com/syndtr/gocapability                      d98352740cb2c55f81556b63d4a1ec64c5a319c2
+gotest.tools                                        v2.3.0
+github.com/google/go-cmp                            v0.2.0
+go.etcd.io/bbolt                                    v1.3.3
+github.com/hashicorp/errwrap                        v1.0.0
+github.com/hashicorp/go-multierror                  v1.0.0
+github.com/hashicorp/golang-lru                     v0.5.3
+go.opencensus.io                                    v0.22.0
+github.com/imdario/mergo                            v0.3.7
+github.com/cpuguy83/go-md2man                       v1.0.10
+github.com/russross/blackfriday                     v1.5.2
+github.com/google/uuid                              v1.1.1
 
 # cri dependencies
-github.com/containerd/cri c9d45e65263e26f7e7f0ac8fdca0d510622f12cb # master
-github.com/containerd/go-cni 0d360c50b10b350b6bb23863fd4dfb1c232b01c9
-github.com/containernetworking/cni v0.7.1
-github.com/containernetworking/plugins v0.7.6
-github.com/davecgh/go-spew v1.1.1
-github.com/docker/distribution 0d3efadf0154c2b8a4e7b6621fff9809655cc580
-github.com/docker/docker d1d5f6476656c6aad457e2a91d3436e66b6f2251
-github.com/docker/spdystream 449fdfce4d962303d702fec724ef0ad181c92528
-github.com/emicklei/go-restful v2.9.5
-github.com/google/gofuzz v1.0.0
-github.com/json-iterator/go v1.1.7
-github.com/modern-go/reflect2 1.0.1
-github.com/modern-go/concurrent 1.0.3
-github.com/opencontainers/selinux v1.2.2
-github.com/seccomp/libseccomp-golang v0.9.1
-github.com/tchap/go-patricia v2.2.6
-golang.org/x/crypto 5c40567a22f818bd14a1ea7245dad9f8ef0691aa
-golang.org/x/oauth2 0f29369cfe4552d0e4bcddc57cc75f4d7e672a33
-golang.org/x/time 85acf8d2951cb2a3bde7632f9ff273ef0379bcbd
-gopkg.in/inf.v0 v0.9.0
-gopkg.in/yaml.v2 v2.2.2
-k8s.io/api kubernetes-1.16.0-rc.2
-k8s.io/apimachinery kubernetes-1.16.0-rc.2
-k8s.io/apiserver kubernetes-1.16.0-rc.2
-k8s.io/cri-api kubernetes-1.16.0-rc.2
-k8s.io/client-go kubernetes-1.16.0-rc.2
-k8s.io/klog v0.4.0
-k8s.io/kubernetes v1.16.0-rc.2
-k8s.io/utils c2654d5206da6b7b6ace12841e8f359bb89b443c
-sigs.k8s.io/yaml v1.1.0
+github.com/containerd/cri                           c9d45e65263e26f7e7f0ac8fdca0d510622f12cb # master
+github.com/containerd/go-cni                        0d360c50b10b350b6bb23863fd4dfb1c232b01c9
+github.com/containernetworking/cni                  v0.7.1
+github.com/containernetworking/plugins              v0.7.6
+github.com/davecgh/go-spew                          v1.1.1
+github.com/docker/distribution                      0d3efadf0154c2b8a4e7b6621fff9809655cc580
+github.com/docker/docker                            d1d5f6476656c6aad457e2a91d3436e66b6f2251
+github.com/docker/spdystream                        449fdfce4d962303d702fec724ef0ad181c92528
+github.com/emicklei/go-restful                      v2.9.5
+github.com/google/gofuzz                            v1.0.0
+github.com/json-iterator/go                         v1.1.7
+github.com/modern-go/reflect2                       1.0.1
+github.com/modern-go/concurrent                     1.0.3
+github.com/opencontainers/selinux                   v1.2.2
+github.com/seccomp/libseccomp-golang                v0.9.1
+github.com/tchap/go-patricia                        v2.2.6
+golang.org/x/crypto                                 5c40567a22f818bd14a1ea7245dad9f8ef0691aa
+golang.org/x/oauth2                                 0f29369cfe4552d0e4bcddc57cc75f4d7e672a33
+golang.org/x/time                                   85acf8d2951cb2a3bde7632f9ff273ef0379bcbd
+gopkg.in/inf.v0                                     v0.9.0
+gopkg.in/yaml.v2                                    v2.2.2
+k8s.io/api                                          kubernetes-1.16.0-rc.2
+k8s.io/apimachinery                                 kubernetes-1.16.0-rc.2
+k8s.io/apiserver                                    kubernetes-1.16.0-rc.2
+k8s.io/cri-api                                      kubernetes-1.16.0-rc.2
+k8s.io/client-go                                    kubernetes-1.16.0-rc.2
+k8s.io/klog                                         v0.4.0
+k8s.io/kubernetes                                   v1.16.0-rc.2
+k8s.io/utils                                        c2654d5206da6b7b6ace12841e8f359bb89b443c
+sigs.k8s.io/yaml                                    v1.1.0
 
 # zfs dependencies
-github.com/containerd/zfs 9abf673ca6ff9ab8d9bd776a4ceff8f6dc699c3d
-github.com/mistifyio/go-zfs f784269be439d704d3dfa1906f45dd848fed2beb
+github.com/containerd/zfs                           9abf673ca6ff9ab8d9bd776a4ceff8f6dc699c3d
+github.com/mistifyio/go-zfs                         f784269be439d704d3dfa1906f45dd848fed2beb
 
 # aufs dependencies
-github.com/containerd/aufs 371312c1e31c210a21e49bf3dfd3f31729ed9f2f
+github.com/containerd/aufs                          371312c1e31c210a21e49bf3dfd3f31729ed9f2f


### PR DESCRIPTION
Since it doesn't look like this repo will switch to using go mod soon, let's reformat this file to make comparing with other repositories slightly easier and to encourage pinning 

Best to review individual commits (no dependencies were updated, so vendored files should stay unmodified)