### PR TITLE
Separate spec for checkpoint

### DIFF
--- a/cmd/ctr/commands/containers/checkpoint.go
+++ b/cmd/ctr/commands/containers/checkpoint.go
@@ -60,6 +60,7 @@ var checkpointCommand = cli.Command{
 		defer cancel()
 		opts := []containerd.CheckpointOpts{
 			containerd.WithCheckpointRuntime,
+			containerd.WithCheckpointSpec,
 		}
 
 		if context.Bool("image") {

--- a/cmd/ctr/commands/containers/restore.go
+++ b/cmd/ctr/commands/containers/restore.go
@@ -18,7 +18,6 @@ package containers
 
 import (
 	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/pkg/errors"
@@ -33,10 +32,6 @@ var restoreCommand = cli.Command{
 		cli.BoolFlag{
 			Name:  "rw",
 			Usage: "restore the rw layer from the checkpoint",
-		},
-		cli.BoolFlag{
-			Name:  "live",
-			Usage: "restore the runtime and memory data from the checkpoint",
 		},
 	},
 	Action: func(context *cli.Context) error {
@@ -76,21 +71,10 @@ var restoreCommand = cli.Command{
 			opts = append(opts, containerd.WithRestoreRW)
 		}
 
-		ctr, err := client.Restore(ctx, id, checkpoint, opts...)
-		if err != nil {
+		if _, err := client.Restore(ctx, id, checkpoint, opts...); err != nil {
 			return err
 		}
 
-		topts := []containerd.NewTaskOpts{}
-		if context.Bool("live") {
-			topts = append(topts, containerd.WithTaskCheckpoint(checkpoint))
-		}
-
-		task, err := ctr.NewTask(ctx, cio.NewCreator(cio.WithStdio), topts...)
-		if err != nil {
-			return err
-		}
-
-		return task.Start(ctx)
+		return nil
 	},
 }

--- a/cmd/ctr/commands/tasks/start.go
+++ b/cmd/ctr/commands/tasks/start.go
@@ -51,6 +51,10 @@ var startCommand = cli.Command{
 			Name:  "detach,d",
 			Usage: "detach from the task after it has started execution",
 		},
+		cli.BoolFlag{
+			Name:  "live",
+			Usage: "restore runtime and memory data from a checkpoint in the image",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		var (
@@ -80,6 +84,13 @@ var startCommand = cli.Command{
 			opts   = getNewTaskOpts(context)
 			ioOpts = []cio.Opt{cio.WithFIFODir(context.String("fifo-dir"))}
 		)
+		if context.Bool("live") {
+			img, err := container.Image(ctx)
+			if err != nil {
+				return err
+			}
+			opts = append(opts, containerd.WithTaskCheckpoint(img))
+		}
 		var con console.Console
 		if tty {
 			con = console.Current()

--- a/container_restore_opts.go
+++ b/container_restore_opts.go
@@ -87,7 +87,7 @@ func WithRestoreRuntime(ctx context.Context, id string, client *Client, checkpoi
 				return err
 			}
 		}
-		var options *ptypes.Any
+		options := &ptypes.Any{}
 		if m != nil {
 			store := client.ContentStore()
 			data, err := content.ReadBlob(ctx, store, *m)
@@ -110,7 +110,7 @@ func WithRestoreRuntime(ctx context.Context, id string, client *Client, checkpoi
 // WithRestoreSpec restores the spec from the checkpoint for the container
 func WithRestoreSpec(ctx context.Context, id string, client *Client, checkpoint Image, index *imagespec.Index) NewContainerOpts {
 	return func(ctx context.Context, client *Client, c *containers.Container) error {
-		m, err := GetIndexByMediaType(index, images.MediaTypeContainerd1CheckpointConfig)
+		m, err := GetIndexByMediaType(index, images.MediaTypeContainerd1CheckpointSpec)
 		if err != nil {
 			return err
 		}

--- a/images/mediatypes.go
+++ b/images/mediatypes.go
@@ -44,6 +44,7 @@ const (
 	MediaTypeContainerd1RW                       = "application/vnd.containerd.container.rw.tar"
 	MediaTypeContainerd1CheckpointConfig         = "application/vnd.containerd.container.checkpoint.config.v1+proto"
 	MediaTypeContainerd1CheckpointOptions        = "application/vnd.containerd.container.checkpoint.options.v1+proto"
+	MediaTypeContainerd1CheckpointSpec           = "application/vnd.containerd.container.checkpoint.spec.v1+proto"
 	MediaTypeContainerd1CheckpointRuntimeName    = "application/vnd.containerd.container.checkpoint.runtime.name"
 	MediaTypeContainerd1CheckpointRuntimeOptions = "application/vnd.containerd.container.checkpoint.runtime.options+proto"
 	// Legacy Docker schema1 manifest


### PR DESCRIPTION
This splits out the container spec from the task operation when performing a checkpoint.  Previously this was part of the task checkpoint but meant that a live restore was needed to restore the spec unless otherwise created.

This also changes the behavior in `ctr` when restoring to not attempt to start the task.  Instead this is left to the operator to decide how to start the task.