### PR TITLE
update cpuinfo to match kunpeng920 Architecture:aarch64

### DIFF
--- a/platforms/cpuinfo.go
+++ b/platforms/cpuinfo.go
@@ -96,16 +96,16 @@ func getCPUVariant() string {
 		return ""
 	}
 
-	switch variant {
-	case "8", "AArch64":
+	switch strings.ToLower(variant) {
+	case "8", "aarch64":
 		variant = "v8"
-	case "7", "7M", "?(12)", "?(13)", "?(14)", "?(15)", "?(16)", "?(17)":
+	case "7", "7m", "?(12)", "?(13)", "?(14)", "?(15)", "?(16)", "?(17)":
 		variant = "v7"
-	case "6", "6TEJ":
+	case "6", "6tej":
 		variant = "v6"
-	case "5", "5T", "5TE", "5TEJ":
+	case "5", "5t", "5te", "5tej":
 		variant = "v5"
-	case "4", "4T":
+	case "4", "4t":
 		variant = "v4"
 	case "3":
 		variant = "v3"


### PR DESCRIPTION
The cpuinfo of kunpeng920 is like this:
```
model name	: Kunpeng 920-4826 
BogoMIPS	: 200.00
Features	: half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt lpae evtstrm
CPU implementer	: 0x48
CPU architecture: aarch64
CPU variant	: 0x1
CPU part	: 0xd01
CPU revision	: 0
```
The variant will be unknown, because `aarch64` doesn't match `AArch64`.
So I update the cpuinfo logic to deal with `aarch64`, `AArch64`