### PR TITLE
Fix dependency in BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -174,7 +174,7 @@ We can build an image from this `Dockerfile`:
 FROM golang
 
 RUN apt-get update && \
-    apt-get install -y btrfs-tools libseccomp-dev
+    apt-get install -y libbtrfs-dev libseccomp-dev
 
 ```
 


### PR DESCRIPTION
This commit fixes the btrfs dependency in the
"Build containerd and runc" section of BUILDING.md needed
for building containerd. btrfs/ioctl.h is now contained in
libbtrfs-dev.

Fixes #3865

Signed-off-by: Alex Price <aprice@atlassian.com>