### PR TITLE
Make sure for next release branch appveyor runs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,6 +7,7 @@ clone_folder: c:\gopath\src\github.com\containerd\containerd
 branches:
   only:
     - master
+    - /release\/.*/
 
 environment:
   GOPATH: C:\gopath


### PR DESCRIPTION
This is already added in release/1.3 and release/1.2 was fixed with a
specific branch name at some point.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>