### PR TITLE
Modify ctr run to search for read-only flag instead of readonly

### DIFF
--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -116,13 +116,13 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 			cOpts = append(cOpts,
 				containerd.WithImage(image),
 				containerd.WithSnapshotter(snapshotter),
-				// Even when "readonly" is set, we don't use KindView snapshot here. (#1495)
+				// Even when "read-only" is set, we don't use KindView snapshot here. (#1495)
 				// We pass writable snapshot to the OCI runtime, and the runtime remounts it as read-only,
 				// after creating some mount points on demand.
 				containerd.WithNewSnapshot(id, image),
 				containerd.WithImageStopSignal(image, "SIGTERM"))
 		}
-		if context.Bool("readonly") {
+		if context.Bool("read-only") {
 			opts = append(opts, oci.WithRootFSReadonly())
 		}
 		if len(args) > 0 {


### PR DESCRIPTION
We pass `--read-only` argument to `ctr` to be interpreted at
https://github.com/containerd/containerd/blob/master/cmd/ctr/commands/commands.go#L100-L103

`ctr run` looks for if `readonly` is defined instead of `read-only`, which is not defined. This allows for `ctr run` to set the container's filesystem as readonly.