### PR TITLE
Split uid and gid user ns remapping in oci

### DIFF
--- a/container_linux_test.go
+++ b/container_linux_test.go
@@ -1362,12 +1362,24 @@ func testUserNamespaces(t *testing.T, readonlyRootFS bool) {
 
 	opts := []NewContainerOpts{WithNewSpec(oci.WithImageConfig(image),
 		withExitStatus(7),
-		oci.WithUserNamespace(0, 1000, 10000),
+		oci.WithUserNamespace([]specs.LinuxIDMapping{
+			{
+				ContainerID: 0,
+				HostID:      1000,
+				Size:        10000,
+			},
+		}, []specs.LinuxIDMapping{
+			{
+				ContainerID: 0,
+				HostID:      2000,
+				Size:        10000,
+			},
+		}),
 	)}
 	if readonlyRootFS {
-		opts = append([]NewContainerOpts{WithRemappedSnapshotView(id, image, 1000, 1000)}, opts...)
+		opts = append([]NewContainerOpts{WithRemappedSnapshotView(id, image, 1000, 2000)}, opts...)
 	} else {
-		opts = append([]NewContainerOpts{WithRemappedSnapshot(id, image, 1000, 1000)}, opts...)
+		opts = append([]NewContainerOpts{WithRemappedSnapshot(id, image, 1000, 2000)}, opts...)
 	}
 
 	container, err := client.NewContainer(ctx, id, opts...)
@@ -1380,12 +1392,12 @@ func testUserNamespaces(t *testing.T, readonlyRootFS bool) {
 	if CheckRuntime(client.runtime, "io.containerd.runc") {
 		copts = &options.Options{
 			IoUid: 1000,
-			IoGid: 1000,
+			IoGid: 2000,
 		}
 	} else {
 		copts = &runctypes.CreateOptions{
 			IoUid: 1000,
-			IoGid: 1000,
+			IoGid: 2000,
 		}
 	}
 

--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -439,7 +439,7 @@ func WithHostLocaltime(_ context.Context, _ Client, _ *containers.Container, s *
 
 // WithUserNamespace sets the uid and gid mappings for the task
 // this can be called multiple times to add more mappings to the generated spec
-func WithUserNamespace(container, host, size uint32) SpecOpts {
+func WithUserNamespace(uidMap, gidMap []specs.LinuxIDMapping) SpecOpts {
 	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 		var hasUserns bool
 		setLinux(s)
@@ -454,13 +454,8 @@ func WithUserNamespace(container, host, size uint32) SpecOpts {
 				Type: specs.UserNamespace,
 			})
 		}
-		mapping := specs.LinuxIDMapping{
-			ContainerID: container,
-			HostID:      host,
-			Size:        size,
-		}
-		s.Linux.UIDMappings = append(s.Linux.UIDMappings, mapping)
-		s.Linux.GIDMappings = append(s.Linux.GIDMappings, mapping)
+		s.Linux.UIDMappings = append(s.Linux.UIDMappings, uidMap...)
+		s.Linux.GIDMappings = append(s.Linux.GIDMappings, gidMap...)
 		return nil
 	}
 }

--- a/oci/spec_opts_test.go
+++ b/oci/spec_opts_test.go
@@ -467,21 +467,42 @@ func TestWithTTYSize(t *testing.T) {
 func TestWithUserNamespace(t *testing.T) {
 	t.Parallel()
 	s := Spec{}
+
 	opts := []SpecOpts{
-		WithUserNamespace(1, 2, 20000),
+		WithUserNamespace([]specs.LinuxIDMapping{
+			{
+				ContainerID: 1,
+				HostID:      2,
+				Size:        10000,
+			},
+		}, []specs.LinuxIDMapping{
+			{
+				ContainerID: 2,
+				HostID:      3,
+				Size:        20000,
+			},
+		}),
 	}
+
 	for _, opt := range opts {
 		if err := opt(nil, nil, nil, &s); err != nil {
 			t.Fatal(err)
 		}
 	}
-	testMapping := specs.LinuxIDMapping{
+
+	expectedUIDMapping := specs.LinuxIDMapping{
 		ContainerID: 1,
 		HostID:      2,
+		Size:        10000,
+	}
+	expectedGIDMapping := specs.LinuxIDMapping{
+		ContainerID: 2,
+		HostID:      3,
 		Size:        20000,
 	}
-	if !(len(s.Linux.UIDMappings) == 1 && s.Linux.UIDMappings[0] == testMapping) || !(len(s.Linux.GIDMappings) == 1 && s.Linux.GIDMappings[0] == testMapping) {
-		t.Fatal("WithUserNamespace Cannot set the uid/gid  mappings for the task")
+
+	if !(len(s.Linux.UIDMappings) == 1 && s.Linux.UIDMappings[0] == expectedUIDMapping) || !(len(s.Linux.GIDMappings) == 1 && s.Linux.GIDMappings[0] == expectedGIDMapping) {
+		t.Fatal("WithUserNamespace Cannot set the uid/gid mappings for the task")
 	}
 
 }


### PR DESCRIPTION
User namespaces used to remap both UID and GID to the same mapping given. This commit will split the UID and GID remapping.

Signed-off-by: Jie Hao Liao <liaojh1998@gmail.com>

Refer to #3876 
cc @AkihiroSuda, @estesp 