### PR TITLE
Allow empty scope authorization

### DIFF
--- a/remotes/docker/authorizer.go
+++ b/remotes/docker/authorizer.go
@@ -196,10 +196,11 @@ func (a *dockerAuthorizer) generateTokenOptions(ctx context.Context, host string
 	}
 
 	scope, ok := c.parameters["scope"]
-	if !ok {
-		return tokenOptions{}, errors.Errorf("no scope specified for token auth challenge")
+	if ok {
+		to.scopes = append(to.scopes, scope)
+	} else {
+		log.G(ctx).WithField("host", host).Debug("no scope specified for token auth challenge")
 	}
-	to.scopes = append(to.scopes, scope)
 
 	if a.credentials != nil {
 		to.username, to.secret, err = a.credentials(host)
@@ -273,9 +274,6 @@ func (ah *authHandler) doBearerAuth(ctx context.Context) (string, error) {
 	to := ah.common
 
 	to.scopes = getTokenScopes(ctx, to.scopes)
-	if len(to.scopes) == 0 {
-		return "", errors.Errorf("no scope specified for token auth challenge")
-	}
 
 	// Docs: https://docs.docker.com/registry/spec/auth/scope
 	scoped := strings.Join(to.scopes, " ")
@@ -332,7 +330,9 @@ type postTokenResponse struct {
 
 func (ah *authHandler) fetchTokenWithOAuth(ctx context.Context, to tokenOptions) (string, error) {
 	form := url.Values{}
-	form.Set("scope", strings.Join(to.scopes, " "))
+	if len(to.scopes) > 0 {
+		form.Set("scope", strings.Join(to.scopes, " "))
+	}
 	form.Set("service", to.service)
 	// TODO: Allow setting client_id
 	form.Set("client_id", "containerd-client")


### PR DESCRIPTION
Registries may allow using token authorization without explicitly setting the scope. This may cover use cases where no scope is required for an endpoint or the registry is only covering authentication using the token. This aligns with the oauth2 spec which specifies the scope as optional.