### PR TITLE
metrics: rename pids_v2 to pids

### DIFF
--- a/metrics/cgroups/cgroups.go
+++ b/metrics/cgroups/cgroups.go
@@ -19,20 +19,13 @@
 package cgroups
 
 import (
-	"context"
-
 	"github.com/containerd/cgroups"
-	eventstypes "github.com/containerd/containerd/api/events"
-	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/events"
-	"github.com/containerd/containerd/log"
-	"github.com/containerd/containerd/namespaces"
+	v1 "github.com/containerd/containerd/metrics/cgroups/v1"
+	v2 "github.com/containerd/containerd/metrics/cgroups/v2"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/runtime"
-	"github.com/containerd/containerd/runtime/v1/linux"
 	metrics "github.com/docker/go-metrics"
-	"github.com/sirupsen/logrus"
 )
 
 // Config for the cgroups monitor
@@ -56,8 +49,15 @@ func New(ic *plugin.InitContext) (interface{}, error) {
 	if !config.NoPrometheus {
 		ns = metrics.NewNamespace("container", "", nil)
 	}
-	collector := newCollector(ns)
-	oom, err := newOOMCollector(ns)
+	var (
+		tm  runtime.TaskMonitor
+		err error
+	)
+	if cgroups.Mode() == cgroups.Unified {
+		tm, err = v2.NewTaskMonitor(ic.Context, ic.Events, ns)
+	} else {
+		tm, err = v1.NewTaskMonitor(ic.Context, ic.Events, ns)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -65,54 +65,5 @@ func New(ic *plugin.InitContext) (interface{}, error) {
 		metrics.Register(ns)
 	}
 	ic.Meta.Platforms = append(ic.Meta.Platforms, platforms.DefaultSpec())
-	return &cgroupsMonitor{
-		collector: collector,
-		oom:       oom,
-		context:   ic.Context,
-		publisher: ic.Events,
-	}, nil
-}
-
-type cgroupsMonitor struct {
-	collector *collector
-	oom       *oomCollector
-	context   context.Context
-	publisher events.Publisher
-}
-
-func (m *cgroupsMonitor) Monitor(c runtime.Task) error {
-	if err := m.collector.Add(c); err != nil {
-		return err
-	}
-	t, ok := c.(*linux.Task)
-	if !ok {
-		return nil
-	}
-	cg, err := t.Cgroup()
-	if err != nil {
-		if errdefs.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-	err = m.oom.Add(c.ID(), c.Namespace(), cg, m.trigger)
-	if err == cgroups.ErrMemoryNotSupported {
-		logrus.WithError(err).Warn("OOM monitoring failed")
-		return nil
-	}
-	return err
-}
-
-func (m *cgroupsMonitor) Stop(c runtime.Task) error {
-	m.collector.Remove(c)
-	return nil
-}
-
-func (m *cgroupsMonitor) trigger(id, namespace string, cg cgroups.Cgroup) {
-	ctx := namespaces.WithNamespace(m.context, namespace)
-	if err := m.publisher.Publish(ctx, runtime.TaskOOMEventTopic, &eventstypes.TaskOOM{
-		ContainerID: id,
-	}); err != nil {
-		log.G(m.context).WithError(err).Error("post OOM event")
-	}
+	return tm, nil
 }

--- a/metrics/cgroups/v1/blkio.go
+++ b/metrics/cgroups/v1/blkio.go
@@ -16,7 +16,7 @@
    limitations under the License.
 */
 
-package cgroups
+package v1
 
 import (
 	"strconv"

--- a/metrics/cgroups/v1/cpu.go
+++ b/metrics/cgroups/v1/cpu.go
@@ -16,7 +16,7 @@
    limitations under the License.
 */
 
-package cgroups
+package v1
 
 import (
 	"strconv"

--- a/metrics/cgroups/v1/hugetlb.go
+++ b/metrics/cgroups/v1/hugetlb.go
@@ -16,7 +16,7 @@
    limitations under the License.
 */
 
-package cgroups
+package v1
 
 import (
 	v1 "github.com/containerd/containerd/metrics/types/v1"

--- a/metrics/cgroups/v1/memory.go
+++ b/metrics/cgroups/v1/memory.go
@@ -16,7 +16,7 @@
    limitations under the License.
 */
 
-package cgroups
+package v1
 
 import (
 	v1 "github.com/containerd/containerd/metrics/types/v1"

--- a/metrics/cgroups/v1/metric.go
+++ b/metrics/cgroups/v1/metric.go
@@ -16,7 +16,7 @@
    limitations under the License.
 */
 
-package cgroups
+package v1
 
 import (
 	v1 "github.com/containerd/containerd/metrics/types/v1"

--- a/metrics/cgroups/v1/metrics.go
+++ b/metrics/cgroups/v1/metrics.go
@@ -16,7 +16,7 @@
    limitations under the License.
 */
 
-package cgroups
+package v1
 
 import (
 	"context"

--- a/metrics/cgroups/v1/oom.go
+++ b/metrics/cgroups/v1/oom.go
@@ -16,7 +16,7 @@
    limitations under the License.
 */
 
-package cgroups
+package v1
 
 import (
 	"sync"

--- a/metrics/cgroups/v1/pids.go
+++ b/metrics/cgroups/v1/pids.go
@@ -16,7 +16,7 @@
    limitations under the License.
 */
 
-package cgroups
+package v1
 
 import (
 	v1 "github.com/containerd/containerd/metrics/types/v1"

--- a/metrics/cgroups/v2/pids.go
+++ b/metrics/cgroups/v2/pids.go
@@ -26,8 +26,8 @@ import (
 
 var pidMetrics = []*metric{
 	{
-		name: "pids_v2",
-		help: "The limit to the number of pids allowed",
+		name: "pids",
+		help: "The limit to the number of pids allowed (cgroup v2)",
 		unit: metrics.Unit("limit"),
 		vt:   prometheus.GaugeValue,
 		getValues: func(stats *v2.Metrics) []value {
@@ -42,8 +42,8 @@ var pidMetrics = []*metric{
 		},
 	},
 	{
-		name: "pids_v2",
-		help: "The current number of pids",
+		name: "pids",
+		help: "The current number of pids (cgroup v2)",
 		unit: metrics.Unit("current"),
 		vt:   prometheus.GaugeValue,
 		getValues: func(stats *v2.Metrics) []value {


### PR DESCRIPTION
dicussed in #3726

Also unifies the task monitor instances to avoid the name collision issue across multiple instances: https://github.com/containerd/containerd/issues/3726#issuecomment-565316687

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>