### PR TITLE
Temporarily disable criu tests in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,9 +59,9 @@ install:
   - if [ "$TRAVIS_GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH script/setup/install-runc ; fi
   - if [ "$TRAVIS_GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH script/setup/install-cni ; fi
   - if [ "$TRAVIS_GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH script/setup/install-critools ; fi
-  - if [ "$TRAVIS_GOOS" = "linux" ]; then wget https://github.com/checkpoint-restore/criu/archive/v3.12.tar.gz -O /tmp/criu.tar.gz ; fi
+  - if [ "$TRAVIS_GOOS" = "linux" ]; then wget https://github.com/checkpoint-restore/criu/archive/v3.13.tar.gz -O /tmp/criu.tar.gz ; fi
   - if [ "$TRAVIS_GOOS" = "linux" ]; then tar -C /tmp/ -zxf /tmp/criu.tar.gz ; fi
-  - if [ "$TRAVIS_GOOS" = "linux" ]; then cd /tmp/criu-3.12 && sudo make install-criu ; fi
+  - if [ "$TRAVIS_GOOS" = "linux" ]; then cd /tmp/criu-3.13 && sudo make install-criu ; fi
   - cd $TRAVIS_BUILD_DIR
 
 before_script:
@@ -83,9 +83,9 @@ script:
   - if [ "$TRAVIS_GOOS" = "linux" ]; then sudo make install ; fi
   - if [ "$TRAVIS_GOOS" = "linux" ]; then make coverage ; fi
   - if [ "$TRAVIS_GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH make root-coverage ; fi
-  - if [ "$TRAVIS_GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH make integration ; fi
+  - if [ "$TRAVIS_GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH make integration EXTRA_TESTFLAGS=-no-criu ; fi
   # Run the integration suite a second time. See discussion in github.com/containerd/containerd/pull/1759
-  - if [ "$TRAVIS_GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH TESTFLAGS_PARALLEL=1 make integration ; fi
+  - if [ "$TRAVIS_GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH TESTFLAGS_PARALLEL=1 make integration EXTRA_TESTFLAGS=-no-criu ; fi
   - |
     if [ "$TRAVIS_GOOS" = "linux" ]; then
       sudo mkdir -p /etc/containerd

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ BINARIES=$(addprefix bin/,$(COMMANDS))
 -include Makefile.$(GOOS)
 
 # Flags passed to `go test`
-TESTFLAGS ?= $(TESTFLAGS_RACE)
+TESTFLAGS ?= $(TESTFLAGS_RACE) $(EXTRA_TESTFLAGS)
 TESTFLAGS_PARALLEL ?= 8
 
 .PHONY: clean all AUTHORS build binaries test integration generate protos checkprotos coverage ci check help install uninstall vendor release mandir install-man genman


### PR DESCRIPTION
Until we resolve what's wrong with the criu tests with the update to the 5.0.0 kernel in Travis. Also updates installed criu to latest version so any bug reports will be against latest release.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>