### PR TITLE
sys: mkdirAs: do chown if dir already exists

### DIFF
--- a/sys/socket_unix.go
+++ b/sys/socket_unix.go
@@ -68,11 +68,11 @@ func GetLocalListener(path string, uid, gid int) (net.Listener, error) {
 }
 
 func mkdirAs(path string, uid, gid int) error {
-	if _, err := os.Stat(path); err == nil || !os.IsNotExist(err) {
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		return err
 	}
 
-	if err := os.Mkdir(path, 0770); err != nil {
+	if err := os.MkdirAll(path, 0770); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Fix `buildkitd --group GROUP` issue when `/run/buildkit` already exists
and is owned by the root.

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>