### PR TITLE
Replace ocispec.MediaTypeImageManifest with manifest.MediaType

### DIFF
--- a/images/archive/importer.go
+++ b/images/archive/importer.go
@@ -181,7 +181,7 @@ func ImportIndex(ctx context.Context, store content.Store, reader io.Reader, opt
 			Layers:        layers,
 		}
 
-		desc, err := writeManifest(ctx, store, manifest, ocispec.MediaTypeImageManifest)
+		desc, err := writeManifest(ctx, store, manifest, manifest.MediaType)
 		if err != nil {
 			return ocispec.Descriptor{}, errors.Wrap(err, "write docker manifest")
 		}


### PR DESCRIPTION
Import a tar with `manifest.json`, `ctr image ls` returns incorrect `TYPE`.

```
REF                              TYPE                                       DIGEST                                                                  SIZE      PLATFORMS   LABELS 
docker.io/library/myimage:latest application/vnd.oci.image.manifest.v1+json sha256:663a45ec27ca42bd4ad37eab55a7ad96db3ee5d7ad5c6dc5bbec958b9e63ad53 745.9 KiB linux/amd64 -   
```

Signed-off-by: Xiaodong Ye xiaodongy@vmware.com