### PR TITLE
[release/1.3] cherry-pick: runtime v2: Close platform in runc shim's Shutdown method.

### DIFF
--- a/runtime/v2/runc/v2/service.go
+++ b/runtime/v2/runc/v2/service.go
@@ -348,15 +348,11 @@ func (s *service) Delete(ctx context.Context, r *taskAPI.DeleteRequest) (*taskAP
 	if err != nil {
 		return nil, errdefs.ToGRPC(err)
 	}
-	// if we deleted our init task, close the platform and send the task delete event
+	// if we deleted an init task, send the task delete event
 	if r.ExecID == "" {
 		s.mu.Lock()
 		delete(s.containers, r.ID)
-		hasContainers := len(s.containers) > 0
 		s.mu.Unlock()
-		if s.platform != nil && !hasContainers {
-			s.platform.Close()
-		}
 		s.send(&eventstypes.TaskDelete{
 			ContainerID: container.ID,
 			Pid:         uint32(p.Pid()),
@@ -600,6 +596,11 @@ func (s *service) Shutdown(ctx context.Context, r *taskAPI.ShutdownRequest) (*pt
 	}
 	s.cancel()
 	close(s.events)
+
+	if s.platform != nil {
+		s.platform.Close()
+	}
+
 	return empty, nil
 }
 


### PR DESCRIPTION
Previously, the platform was closed as part of the Delete method when the
process was an init for a task and there were no more tasks after its deletion.
This can create problems if another task is created within the shim right after
the delete runs, which results in the platform being closed but the shim
continuing to run.

This change moves closing the platform to the Shutdown method after the shim's
context is canceled, which ensures the platform is only closed once the shim
is sure its done servicing containers.

Signed-off-by: Erik Sipsma <sipsma@amazon.com>
Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>