### PR TITLE
Enable to propagate necessary information to snapshotter during unpack

### DIFF
--- a/metadata/snapshot.go
+++ b/metadata/snapshot.go
@@ -219,7 +219,7 @@ func (s *snapshotter) Update(ctx context.Context, info snapshots.Info, fieldpath
 
 		inner := snapshots.Info{
 			Name:   bkey,
-			Labels: filterInheritedLabels(local.Labels),
+			Labels: snapshots.FilterInheritedLabels(local.Labels),
 		}
 
 		// NOTE: Perform this inside the transaction to reduce the
@@ -306,7 +306,7 @@ func (s *snapshotter) createSnapshot(ctx context.Context, key, parent string, re
 		bparent string
 		bkey    string
 		bopts   = []snapshots.Opt{
-			snapshots.WithLabels(filterInheritedLabels(base.Labels)),
+			snapshots.WithLabels(snapshots.FilterInheritedLabels(base.Labels)),
 		}
 	)
 
@@ -586,7 +586,7 @@ func (s *snapshotter) Commit(ctx context.Context, name, key string, opts ...snap
 			return err
 		}
 
-		inheritedOpt := snapshots.WithLabels(filterInheritedLabels(base.Labels))
+		inheritedOpt := snapshots.WithLabels(snapshots.FilterInheritedLabels(base.Labels))
 
 		// NOTE: Backend snapshotters should commit fast and reliably to
 		// prevent metadata store locking and minimizing rollbacks.
@@ -938,21 +938,4 @@ func (s *snapshotter) pruneBranch(ctx context.Context, node *treeNode) error {
 // Close closes s.Snapshotter but not db
 func (s *snapshotter) Close() error {
 	return s.Snapshotter.Close()
-}
-
-// filterInheritedLabels filters the provided labels by removing any key which
-// isn't a snapshot label. Snapshot labels have a prefix of "containerd.io/snapshot/"
-// or are the "containerd.io/snapshot.ref" label.
-func filterInheritedLabels(labels map[string]string) map[string]string {
-	if labels == nil {
-		return nil
-	}
-
-	filtered := make(map[string]string)
-	for k, v := range labels {
-		if k == labelSnapshotRef || strings.HasPrefix(k, inheritedLabelsPrefix) {
-			filtered[k] = v
-		}
-	}
-	return filtered
 }

--- a/metadata/snapshot_test.go
+++ b/metadata/snapshot_test.go
@@ -227,7 +227,7 @@ func TestFilterInheritedLabels(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if actual := filterInheritedLabels(test.labels); !reflect.DeepEqual(actual, test.expected) {
+		if actual := snapshots.FilterInheritedLabels(test.labels); !reflect.DeepEqual(actual, test.expected) {
 			t.Fatalf("expected %v but got %v", test.expected, actual)
 		}
 	}

--- a/pull.go
+++ b/pull.go
@@ -81,7 +81,7 @@ func (c *Client) Pull(ctx context.Context, ref string, opts ...RemoteOpt) (_ Ima
 			if wrapper == nil {
 				return unpackWrapper(h)
 			}
-			return wrapper(unpackWrapper(h))
+			return unpackWrapper(wrapper(h))
 		}
 	}
 

--- a/snapshots/snapshotter.go
+++ b/snapshots/snapshotter.go
@@ -25,6 +25,11 @@ import (
 	"github.com/containerd/containerd/mount"
 )
 
+const (
+	inheritedLabelsPrefix = "containerd.io/snapshot/"
+	labelSnapshotRef      = "containerd.io/snapshot.ref"
+)
+
 // Kind identifies the kind of snapshot.
 type Kind uint8
 
@@ -345,4 +350,21 @@ func WithLabels(labels map[string]string) Opt {
 		info.Labels = labels
 		return nil
 	}
+}
+
+// FilterInheritedLabels filters the provided labels by removing any key which
+// isn't a snapshot label. Snapshot labels have a prefix of "containerd.io/snapshot/"
+// or are the "containerd.io/snapshot.ref" label.
+func FilterInheritedLabels(labels map[string]string) map[string]string {
+	if labels == nil {
+		return nil
+	}
+
+	filtered := make(map[string]string)
+	for k, v := range labels {
+		if k == labelSnapshotRef || strings.HasPrefix(k, inheritedLabelsPrefix) {
+			filtered[k] = v
+		}
+	}
+	return filtered
 }


### PR DESCRIPTION
Though containerd gives ChainID to backend snapshotters during unpack for
searching snapshots to be skipped downloading the contents, ChainID isn't enough
for some snapshotters which require additional information of layers.
Some examples are remote snapshotters which is based on stargz filesystem
(requires image-related information to query the contents to docker registry)
and those which is based on CernVM-FS (requires manifest digest, etc. for
providing squashed rootfs).

This commit solves this issue by enabling a handler to inject additional
information of layers to snapshotters during unpack.

Related discussion
- Issue: https://github.com/containerd/containerd/issues/3731
- Initial version of patch: https://github.com/containerd/containerd/pull/3846
- Related patch: https://github.com/containerd/containerd/pull/3870

You can test it on [this remote snapshotter branch](https://github.com/ktock/remote-snapshotter/tree/custom-ctr) and the reproduction steps are [here](https://github.com/ktock/remote-snapshotter/blob/custom-ctr/README.md#demo).

We need to discuss reasonable way to integrate handlers to containerd but I'm keeping it separated PR/issue.