### PR TITLE
Deal with 403 for POST method in OAuth2 authentication for private im…

### DIFF
--- a/remotes/docker/authorizer.go
+++ b/remotes/docker/authorizer.go
@@ -366,7 +366,8 @@ func (ah *authHandler) fetchTokenWithOAuth(ctx context.Context, to tokenOptions)
 	// Registries without support for POST may return 404 for POST /v2/token.
 	// As of September 2017, GCR is known to return 404.
 	// As of February 2018, JFrog Artifactory is known to return 401.
-	if (resp.StatusCode == 405 && to.username != "") || resp.StatusCode == 404 || resp.StatusCode == 401 {
+	// As of December 2019, for private image pulls, Harbor is known to return 403.
+	if (resp.StatusCode == 405 && to.username != "") || resp.StatusCode == 404 || resp.StatusCode == 401 || resp.StatusCode == 403 {
 		return ah.fetchToken(ctx, to)
 	} else if resp.StatusCode < 200 || resp.StatusCode >= 400 {
 		b, _ := ioutil.ReadAll(io.LimitReader(resp.Body, 64000)) // 64KB


### PR DESCRIPTION
…age pulls using harbor

This fixes the bug for private image registries that need to get a token using OAuth2 within the authorization server, but the request returns 403 for POST method. E.g., v1.9.2 Harbor has been observed to respond with a 403 (Forbidden) in that case. Adding 403 handling enables private image pulls using Harbor.