### PR TITLE
Support pushing a specific platform of a multi-architecture docker image to a registry

### DIFF
--- a/cmd/ctr/commands/images/push.go
+++ b/cmd/ctr/commands/images/push.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/pkg/progress"
+	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	digest "github.com/opencontainers/go-digest"
@@ -58,6 +59,10 @@ var pushCommand = cli.Command{
 		Name:  "manifest-type",
 		Usage: "media type of manifest digest",
 		Value: ocispec.MediaTypeImageManifest,
+	}, cli.StringSliceFlag{
+		Name:  "platform",
+		Usage: "push content from a specific platform",
+		Value: &cli.StringSlice{},
 	}),
 	Action: func(context *cli.Context) error {
 		var (
@@ -91,6 +96,27 @@ var pushCommand = cli.Command{
 				return errors.Wrap(err, "unable to resolve image to manifest")
 			}
 			desc = img.Target
+
+			if pss := context.StringSlice("platform"); len(pss) == 1 {
+				p, err := platforms.Parse(pss[0])
+				if err != nil {
+					return errors.Wrapf(err, "invalid platform %q", pss[0])
+				}
+
+				cs := client.ContentStore()
+				if manifests, err := images.Children(ctx, cs, desc); err == nil && len(manifests) > 0 {
+					matcher := platforms.NewMatcher(p)
+					for _, manifest := range manifests {
+						if manifest.Platform != nil && matcher.Match(*manifest.Platform) {
+							if _, err := images.Children(ctx, cs, manifest); err != nil {
+								return errors.Wrap(err, "no matching manifest")
+							}
+							desc = manifest
+							break
+						}
+					}
+				}
+			}
 		}
 
 		resolver, err := commands.GetResolver(ctx, context)


### PR DESCRIPTION
Signed-off-by: Xiaodong Ye <xiaodongy@vmware.com>

Pull a fat image like docker.io/library/hello-world:latest with `--platform linux/amd64` then push the image to a local registry using `ctr`, `ctr: content digest sha256:1e44d8bca6fb0464794555e5ccd3a32e2a4f6e44a20605e4e82605189904f44d: not found` shows.

This PR adds `--platform` to the `push` command, so `ctr` can only push a specific platform to the registry without the manifest list.

