### PR TITLE
Bump golang 1.13.5

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.13.4
+    - GO_VERSION: 1.13.5
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.12
+          go-version: '1.13.5'
 
       - name: Checkout
         uses: actions/checkout@v1
@@ -123,7 +123,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.12
+          go-version: '1.13.5'
 
       - name: Checkout
         uses: actions/checkout@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
 - linux
 
 go:
-  - "1.13.4"
+  - "1.13.5"
 
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.13.4
+ARG GOLANG_VERSION=1.13.5
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd


### PR DESCRIPTION
#### Update Golang 1.13.5

go1.13.5 (released 2019/12/04) includes fixes to the go command, the runtime, the
linker, and the net/http package. See the Go 1.13.5 milestone on our issue tracker
for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.13.5+label%3ACherryPickApproved

#### switch nightly builds to Go 1.13.5