### PR TITLE
Fix eight typos "the the" -> "the"

### DIFF
--- a/vendor/github.com/Microsoft/hcsshim/errors.go
+++ b/vendor/github.com/Microsoft/hcsshim/errors.go
@@ -59,7 +59,7 @@ var (
 	// ErrVmcomputeOperationInvalidState is an error encountered when the compute system is not in a valid state for the requested operation
 	ErrVmcomputeOperationInvalidState = hcs.ErrVmcomputeOperationInvalidState
 
-	// ErrProcNotFound is an error encountered when the the process cannot be found
+	// ErrProcNotFound is an error encountered when the process cannot be found
 	ErrProcNotFound = hcs.ErrProcNotFound
 
 	// ErrVmcomputeOperationAccessIsDenied is an error which can be encountered when enumerating compute systems in RS1/RS2

--- a/vendor/github.com/Microsoft/hcsshim/hcn/hcnnamespace.go
+++ b/vendor/github.com/Microsoft/hcsshim/hcn/hcnnamespace.go
@@ -337,7 +337,7 @@ func (namespace *HostComputeNamespace) Delete() error {
 // hosting those endpoints. It is safe to call for any `NamespaceType` but
 // `NamespaceTypeGuest` is the only case when a sync will actually occur. For
 // `NamespaceTypeHost` the process container will be automatically synchronized
-// when the the endpoint is added via `AddNamespaceEndpoint`.
+// when the endpoint is added via `AddNamespaceEndpoint`.
 //
 // Note: This method sync's both additions and removals of endpoints from a
 // `NamespaceTypeGuest` namespace.

--- a/vendor/github.com/Microsoft/hcsshim/internal/hcs/errors.go
+++ b/vendor/github.com/Microsoft/hcsshim/internal/hcs/errors.go
@@ -60,7 +60,7 @@ var (
 	// ErrVmcomputeOperationInvalidState is an error encountered when the compute system is not in a valid state for the requested operation
 	ErrVmcomputeOperationInvalidState = syscall.Errno(0xc0370105)
 
-	// ErrProcNotFound is an error encountered when the the process cannot be found
+	// ErrProcNotFound is an error encountered when the process cannot be found
 	ErrProcNotFound = syscall.Errno(0x7f)
 
 	// ErrVmcomputeOperationAccessIsDenied is an error which can be encountered when enumerating compute systems in RS1/RS2

--- a/vendor/github.com/Microsoft/hcsshim/internal/oc/exporter.go
+++ b/vendor/github.com/Microsoft/hcsshim/internal/oc/exporter.go
@@ -12,7 +12,7 @@ var _ = (trace.Exporter)(&LogrusExporter{})
 type LogrusExporter struct {
 }
 
-// ExportSpan exports `s` based on the the following rules:
+// ExportSpan exports `s` based on the following rules:
 //
 // 1. All output will contain `s.Attributes`, `s.TraceID`, `s.SpanID`,
 // `s.ParentSpanID` for correlation

--- a/vendor/github.com/davecgh/go-spew/spew/config.go
+++ b/vendor/github.com/davecgh/go-spew/spew/config.go
@@ -228,7 +228,7 @@ types similar to the standard %v format specifier.
 
 The custom formatter only responds to the %v (most compact), %+v (adds pointer
 addresses), %#v (adds types), and %#+v (adds types and pointer addresses) verb
-combinations.  Any other verbs such as %x and %q will be sent to the the
+combinations.  Any other verbs such as %x and %q will be sent to the
 standard fmt package for formatting.  In addition, the custom formatter ignores
 the width and precision arguments (however they will still work on the format
 specifiers not handled by the custom formatter).

--- a/vendor/github.com/davecgh/go-spew/spew/doc.go
+++ b/vendor/github.com/davecgh/go-spew/spew/doc.go
@@ -165,7 +165,7 @@ standard %v format specifier.
 
 The custom formatter only responds to the %v (most compact), %+v (adds pointer
 addresses), %#v (adds types), or %#+v (adds types and pointer addresses) verb
-combinations.  Any other verbs such as %x and %q will be sent to the the
+combinations.  Any other verbs such as %x and %q will be sent to the
 standard fmt package for formatting.  In addition, the custom formatter ignores
 the width and precision arguments (however they will still work on the format
 specifiers not handled by the custom formatter).

--- a/vendor/github.com/davecgh/go-spew/spew/format.go
+++ b/vendor/github.com/davecgh/go-spew/spew/format.go
@@ -405,7 +405,7 @@ types similar to the standard %v format specifier.
 
 The custom formatter only responds to the %v (most compact), %+v (adds pointer
 addresses), %#v (adds types), or %#+v (adds types and pointer addresses) verb
-combinations.  Any other verbs such as %x and %q will be sent to the the
+combinations.  Any other verbs such as %x and %q will be sent to the
 standard fmt package for formatting.  In addition, the custom formatter ignores
 the width and precision arguments (however they will still work on the format
 specifiers not handled by the custom formatter).

--- a/vendor/golang.org/x/oauth2/internal/oauth2.go
+++ b/vendor/golang.org/x/oauth2/internal/oauth2.go
@@ -14,7 +14,7 @@ import (
 
 // ParseKey converts the binary contents of a private key file
 // to an *rsa.PrivateKey. It detects whether the private key is in a
-// PEM container or not. If so, it extracts the the private key
+// PEM container or not. If so, it extracts the private key
 // from PEM container before conversion. It only supports PEM
 // containers with no passphrase.
 func ParseKey(key []byte) (*rsa.PrivateKey, error) {


### PR DESCRIPTION
Signed-off-by: Hu Shuai <hus.fnst@cn.fujitsu.com>