### PR TITLE
snapshots/devmapper: do not stop snapshot GC when one snapshot removing fails

### DIFF
--- a/snapshots/devmapper/README.md
+++ b/snapshots/devmapper/README.md
@@ -25,6 +25,7 @@ The following configuration flags are supported:
 * `pool_name` - a name to use for the devicemapper thin pool. Pool name
   should be the same as in `/dev/mapper/` directory
 * `base_image_size` - defines how much space to allocate when creating the base device
+* `async_remove` - flag to async remove device using snapshot GC's cleanup callback
 
 Pool name and base image size are required snapshotter parameters.
 

--- a/snapshots/devmapper/config.go
+++ b/snapshots/devmapper/config.go
@@ -40,6 +40,9 @@ type Config struct {
 	// Defines how much space to allocate when creating base image for container
 	BaseImageSize      string `toml:"base_image_size"`
 	BaseImageSizeBytes uint64 `toml:"-"`
+
+	// Flag to async remove device using Cleanup() callback in snapshots GC
+	AsyncRemove bool `toml:"async_remove"`
 }
 
 // LoadConfig reads devmapper configuration file from disk in TOML format

--- a/snapshots/devmapper/metadata.go
+++ b/snapshots/devmapper/metadata.go
@@ -122,6 +122,14 @@ func (m *PoolMetadata) AddDevice(ctx context.Context, info *DeviceInfo) error {
 	return nil
 }
 
+// ChangeDeviceState changes the device state given the device name in devices bucket.
+func (m *PoolMetadata) ChangeDeviceState(ctx context.Context, name string, state DeviceState) error {
+	return m.UpdateDevice(ctx, name, func(deviceInfo *DeviceInfo) error {
+		deviceInfo.State = state
+		return nil
+	})
+}
+
 // MarkFaulty marks the given device and corresponding devmapper device ID as faulty.
 // The snapshotter might attempt to recreate a device in 'Faulty' state with another devmapper ID in
 // subsequent calls, and in case of success it's status will be changed to 'Created' or 'Activated'.

--- a/snapshots/devmapper/pool_device.go
+++ b/snapshots/devmapper/pool_device.go
@@ -84,7 +84,7 @@ func (p *PoolDevice) ensureDeviceStates(ctx context.Context) error {
 	var faultyDevices []*DeviceInfo
 	var activatedDevices []*DeviceInfo
 
-	if err := p.metadata.WalkDevices(ctx, func(info *DeviceInfo) error {
+	if err := p.WalkDevices(ctx, func(info *DeviceInfo) error {
 		switch info.State {
 		case Suspended, Resumed, Deactivated, Removed, Faulty:
 		case Activated:
@@ -492,6 +492,18 @@ func (p *PoolDevice) RemovePool(ctx context.Context) error {
 	}
 
 	return result.ErrorOrNil()
+}
+
+// MarkDeviceState changes the device's state in metastore
+func (p *PoolDevice) MarkDeviceState(ctx context.Context, name string, state DeviceState) error {
+	return p.metadata.ChangeDeviceState(ctx, name, state)
+}
+
+// WalkDevices iterates all devices in pool metadata
+func (p *PoolDevice) WalkDevices(ctx context.Context, cb func(info *DeviceInfo) error) error {
+	return p.metadata.WalkDevices(ctx, func(info *DeviceInfo) error {
+		return cb(info)
+	})
 }
 
 // Close closes pool device (thin-pool will not be removed)

--- a/snapshots/devmapper/snapshotter.go
+++ b/snapshots/devmapper/snapshotter.go
@@ -303,9 +303,18 @@ func (s *Snapshotter) removeDevice(ctx context.Context, key string) error {
 	}
 
 	deviceName := s.getDeviceName(snapID)
-	if err := s.pool.RemoveDevice(ctx, deviceName); err != nil {
-		log.G(ctx).WithError(err).Errorf("failed to remove device")
-		return err
+	if !s.config.AsyncRemove {
+		if err := s.pool.RemoveDevice(ctx, deviceName); err != nil {
+			log.G(ctx).WithError(err).Errorf("failed to remove device")
+			return err
+		}
+	} else {
+		// The asynchronous cleanup will do the real device remove work.
+		log.G(ctx).WithField("device", deviceName).Debug("async remove")
+		if err := s.pool.MarkDeviceState(ctx, deviceName, Removed); err != nil {
+			log.G(ctx).WithError(err).Errorf("failed to mark device as removed")
+			return err
+		}
 	}
 
 	return nil
@@ -485,4 +494,35 @@ func (s *Snapshotter) withTransaction(ctx context.Context, writable bool, fn fun
 	}
 
 	return nil
+}
+
+func (s *Snapshotter) Cleanup(ctx context.Context) error {
+	var removedDevices []*DeviceInfo
+
+	if !s.config.AsyncRemove {
+		return nil
+	}
+
+	if err := s.pool.WalkDevices(ctx, func(info *DeviceInfo) error {
+		if info.State == Removed {
+			removedDevices = append(removedDevices, info)
+		}
+		return nil
+	}); err != nil {
+		log.G(ctx).WithError(err).Errorf("failed to query devices from metastore")
+		return err
+	}
+
+	var result *multierror.Error
+	for _, dev := range removedDevices {
+		log.G(ctx).WithField("device", dev.Name).Debug("cleanup device")
+		if err := s.pool.RemoveDevice(ctx, dev.Name); err != nil {
+			log.G(ctx).WithField("device", dev.Name).Error("failed to cleanup device")
+			result = multierror.Append(result, err)
+		} else {
+			log.G(ctx).WithField("device", dev.Name).Debug("cleanuped device")
+		}
+	}
+
+	return result.ErrorOrNil()
 }


### PR DESCRIPTION
Snapshots GC takes use of pruneBranch() function to remove snapshots,
but GC will stop if snapshotter.Remove() returns error and the error
number is not ErrFailedPrecondition. This results in thousands of
dm snapshots not deleted if one snapshot is not deleted, due to
errors like "contains a filesystem in use".

1. the first method:
So return ErrFailedPrecondition error number in Remove() function where
appropriate, and let GC process go on collecting other snapshots.

2. the second method:
Also, we add a "async_remove" for devmapper as overylay does, mark the snapshot as `removed` quickly,  and really delete it on the next cleanup() method.

I'd like to have both them merged, so that:
- the first way doesn't have overhead to iterate devices to find the `removed` device to cleanup, it should help when `async_remove` is off;
- when `async_remove` is on,  except deleting the `removed` device, we can consider to add another option to cleanup the *faulty* devices because *handy* handling is not acceptable in production env (one reason: it may needs to stop containerd fist), also manual handling with devmapper is not simple to most people.