### PR TITLE
add check that snapshotter supports the image platform when unpacking

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -137,7 +137,7 @@ func TestMain(m *testing.M) {
 	}).Info("running tests against containerd")
 
 	// pull a seed image
-	log.G(ctx).Info("start to pull seed image")
+	log.G(ctx).WithField("image", testImage).Info("start to pull seed image")
 	if _, err = client.Pull(ctx, testImage, WithPullUnpack); err != nil {
 		fmt.Fprintf(os.Stderr, "%s: %s\n", err, buf.String())
 		ctrd.Kill()

--- a/image.go
+++ b/image.go
@@ -18,6 +18,7 @@ package containerd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync/atomic"
@@ -281,10 +282,21 @@ type UnpackConfig struct {
 	ApplyOpts []diff.ApplyOpt
 	// SnapshotOpts for configuring a snapshotter
 	SnapshotOpts []snapshots.Opt
+	// CheckPlatformSupported is whether to validate that a snapshotter
+	// supports an image's platform before unpacking
+	CheckPlatformSupported bool
 }
 
 // UnpackOpt provides configuration for unpack
 type UnpackOpt func(context.Context, *UnpackConfig) error
+
+// WithSnapshotterPlatformCheck sets `CheckPlatformSupported` on the UnpackConfig
+func WithSnapshotterPlatformCheck() UnpackOpt {
+	return func(ctx context.Context, uc *UnpackConfig) error {
+		uc.CheckPlatformSupported = true
+		return nil
+	}
+}
 
 func (i *image) Unpack(ctx context.Context, snapshotterName string, opts ...UnpackOpt) error {
 	ctx, done, err := i.client.WithLease(ctx)
@@ -300,7 +312,12 @@ func (i *image) Unpack(ctx context.Context, snapshotterName string, opts ...Unpa
 		}
 	}
 
-	layers, err := i.getLayers(ctx, i.platform)
+	manifest, err := i.getManifest(ctx, i.platform)
+	if err != nil {
+		return err
+	}
+
+	layers, err := i.getLayers(ctx, i.platform, manifest)
 	if err != nil {
 		return err
 	}
@@ -320,6 +337,12 @@ func (i *image) Unpack(ctx context.Context, snapshotterName string, opts ...Unpa
 	if err != nil {
 		return err
 	}
+	if config.CheckPlatformSupported {
+		if err := i.checkSnapshotterSupport(ctx, snapshotterName, manifest); err != nil {
+			return err
+		}
+	}
+
 	for _, layer := range layers {
 		unpacked, err = rootfs.ApplyLayerWithOpts(ctx, layer, chain, sn, a, config.SnapshotOpts, config.ApplyOpts)
 		if err != nil {
@@ -361,14 +384,17 @@ func (i *image) Unpack(ctx context.Context, snapshotterName string, opts ...Unpa
 	return err
 }
 
-func (i *image) getLayers(ctx context.Context, platform platforms.MatchComparer) ([]rootfs.Layer, error) {
-	cs := i.client.ContentStore()
-
+func (i *image) getManifest(ctx context.Context, platform platforms.MatchComparer) (ocispec.Manifest, error) {
+	cs := i.ContentStore()
 	manifest, err := images.Manifest(ctx, cs, i.i.Target, platform)
 	if err != nil {
-		return nil, err
+		return ocispec.Manifest{}, err
 	}
+	return manifest, nil
+}
 
+func (i *image) getLayers(ctx context.Context, platform platforms.MatchComparer, manifest ocispec.Manifest) ([]rootfs.Layer, error) {
+	cs := i.ContentStore()
 	diffIDs, err := i.i.RootFS(ctx, cs, platform)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to resolve rootfs")
@@ -386,6 +412,37 @@ func (i *image) getLayers(ctx context.Context, platform platforms.MatchComparer)
 		layers[i].Blob = manifest.Layers[i]
 	}
 	return layers, nil
+}
+
+func (i *image) getManifestPlatform(ctx context.Context, manifest ocispec.Manifest) (ocispec.Platform, error) {
+	cs := i.ContentStore()
+	p, err := content.ReadBlob(ctx, cs, manifest.Config)
+	if err != nil {
+		return ocispec.Platform{}, err
+	}
+
+	var image ocispec.Image
+	if err := json.Unmarshal(p, &image); err != nil {
+		return ocispec.Platform{}, err
+	}
+	return platforms.Normalize(ocispec.Platform{OS: image.OS, Architecture: image.Architecture}), nil
+}
+
+func (i *image) checkSnapshotterSupport(ctx context.Context, snapshotterName string, manifest ocispec.Manifest) error {
+	snapshotterPlatformMatcher, err := i.client.GetSnapshotterSupportedPlatforms(ctx, snapshotterName)
+	if err != nil {
+		return err
+	}
+
+	manifestPlatform, err := i.getManifestPlatform(ctx, manifest)
+	if err != nil {
+		return err
+	}
+
+	if snapshotterPlatformMatcher.Match(manifestPlatform) {
+		return nil
+	}
+	return fmt.Errorf("snapshotter %s does not support platform %s for image %s", snapshotterName, manifestPlatform, manifest.Config.Digest)
 }
 
 func (i *image) ContentStore() content.Store {

--- a/image_test.go
+++ b/image_test.go
@@ -81,6 +81,9 @@ func TestImageIsUnpacked(t *testing.T) {
 }
 
 func TestImagePullWithDistSourceLabel(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
 	var (
 		source   = "docker.io"
 		repoName = "library/busybox"
@@ -231,5 +234,41 @@ func TestImageUsage(t *testing.T) {
 		t.Fatal(err)
 	} else if s <= s3 {
 		t.Fatalf("Expected actual usage with snapshots to be greater: %d <= %d", s, s3)
+	}
+}
+
+func TestImageSupportedBySnapshotter_Error(t *testing.T) {
+	var unsupportedImage string
+	if runtime.GOOS == "windows" {
+		unsupportedImage = "docker.io/library/busybox:latest"
+	} else {
+		unsupportedImage = "mcr.microsoft.com/windows/nanoserver:1809"
+	}
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	client, err := newClient(t, address)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	// Cleanup
+	err = client.ImageService().Delete(ctx, unsupportedImage)
+	if err != nil && !errdefs.IsNotFound(err) {
+		t.Fatal(err)
+	}
+
+	_, err = client.Pull(ctx, unsupportedImage,
+		WithSchema1Conversion,
+		WithPlatform(platforms.DefaultString()),
+		WithPullSnapshotter(DefaultSnapshotter),
+		WithPullUnpack,
+		WithUnpackOpts([]UnpackOpt{WithSnapshotterPlatformCheck()}),
+	)
+
+	if err == nil {
+		t.Fatalf("expected unpacking %s for snapshotter %s to fail", unsupportedImage, DefaultSnapshotter)
 	}
 }

--- a/services/introspection/introspection.go
+++ b/services/introspection/introspection.go
@@ -21,6 +21,7 @@ import (
 
 	api "github.com/containerd/containerd/api/services/introspection/v1"
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/log"
 	ptypes "github.com/gogo/protobuf/types"
 )
 
@@ -40,6 +41,7 @@ func NewIntrospectionServiceFromClient(c api.IntrospectionClient) Service {
 }
 
 func (i *introspectionRemote) Plugins(ctx context.Context, filters []string) (*api.PluginsResponse, error) {
+	log.G(ctx).WithField("filters", filters).Info("remote introspection plugin filters")
 	resp, err := i.client.Plugins(ctx, &api.PluginsRequest{
 		Filters: filters,
 	})

--- a/snapshots/windows/windows.go
+++ b/snapshots/windows/windows.go
@@ -32,10 +32,12 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/containerd/snapshots/storage"
 	"github.com/containerd/continuity/fs"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -44,6 +46,7 @@ func init() {
 		Type: plugin.SnapshotPlugin,
 		ID:   "windows",
 		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
+			ic.Meta.Platforms = []ocispec.Platform{platforms.DefaultSpec()}
 			return NewSnapshotter(ic.Root)
 		},
 	})


### PR DESCRIPTION
This work is to prevent a snapshotter from attempting to unpack an image with a platform the snapshotter doesn't support. 

For example, a windows snapshotter attempting to unpack an image with a target linux/amd64 platform. Previously, the snapshotter would attempt to unpack this image and fail with an obscure message. This work instead returns an error earlier on indicating the underlying issue that the snapshotter doesn't support the target image platform. 

Additionally updated the target windows image used for testing. 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>