### PR TITLE
ctr: support $CONTAINERD_ADDRESS env var

### DIFF
--- a/cmd/ctr/app/main.go
+++ b/cmd/ctr/app/main.go
@@ -78,9 +78,10 @@ containerd CLI
 			Usage: "enable debug output in logs",
 		},
 		cli.StringFlag{
-			Name:  "address, a",
-			Usage: "address for containerd's GRPC server",
-			Value: defaults.DefaultAddress,
+			Name:   "address, a",
+			Usage:  "address for containerd's GRPC server",
+			Value:  defaults.DefaultAddress,
+			EnvVar: "CONTAINERD_ADDRESS",
 		},
 		cli.DurationFlag{
 			Name:  "timeout",

--- a/docs/rootless.md
+++ b/docs/rootless.md
@@ -33,9 +33,10 @@ state = "/run/user/1001/containerd"
 A client program such as `ctr` also needs to be executed inside the daemon namespaces.
 ```console
 $ nsenter -U --preserve-credentials -m -n -t $(cat /run/user/1001/rootlesskit-containerd/child_pid)
+$ export CONTAINERD_ADDRESS=/run/user/1001/containerd/containerd.sock
 $ export CONTAINERD_SNAPSHOTTER=native
-$ ctr -a /run/user/1001/containerd/containerd.sock pull docker.io/library/ubuntu:latest
-$ ctr -a /run/user/1001/containerd/containerd.sock run -t --rm --fifo-dir /tmp/foo-fifo --cgroup "" docker.io/library/ubuntu:latest foo
+$ ctr images pull docker.io/library/ubuntu:latest
+$ ctr run -t --rm --fifo-dir /tmp/foo-fifo --cgroup "" docker.io/library/ubuntu:latest foo
 ```
 
 * `overlayfs` snapshotter does not work inside user namespaces, except on Ubuntu kernel


### PR DESCRIPTION
`$CONTAINERD_ADDRESS` can be specified instead of the `ctr --address` flag.

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>