### PR TITLE
platforms: fill default arm variant when parse platform specifier

### DIFF
--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -189,9 +189,8 @@ func Parse(specifier string) (specs.Platform, error) {
 		if isKnownOS(p.OS) {
 			// picks a default architecture
 			p.Architecture = runtime.GOARCH
-			if p.Architecture == "arm" {
-				// TODO(stevvooe): Resolve arm variant, if not v6 (default)
-				return specs.Platform{}, errors.Wrapf(errdefs.ErrNotImplemented, "arm support not fully implemented")
+			if p.Architecture == "arm" && cpuVariant != "v7" {
+				p.Variant = cpuVariant
 			}
 
 			return p, nil

--- a/platforms/platforms_test.go
+++ b/platforms/platforms_test.go
@@ -26,9 +26,14 @@ import (
 
 func TestParseSelector(t *testing.T) {
 	var (
-		defaultOS   = runtime.GOOS
-		defaultArch = runtime.GOARCH
+		defaultOS      = runtime.GOOS
+		defaultArch    = runtime.GOARCH
+		defaultVariant = ""
 	)
+
+	if defaultArch == "arm" && cpuVariant != "v7" {
+		defaultVariant = cpuVariant
+	}
 
 	for _, testcase := range []struct {
 		skip      bool
@@ -255,8 +260,9 @@ func TestParseSelector(t *testing.T) {
 			expected: specs.Platform{
 				OS:           "linux",
 				Architecture: defaultArch,
+				Variant:      defaultVariant,
 			},
-			formatted: joinNotEmpty("linux", defaultArch),
+			formatted: joinNotEmpty("linux", defaultArch, defaultVariant),
 		},
 		{
 			input: "s390x",
@@ -279,8 +285,9 @@ func TestParseSelector(t *testing.T) {
 			expected: specs.Platform{
 				OS:           "darwin",
 				Architecture: defaultArch,
+				Variant:      defaultVariant,
 			},
-			formatted: joinNotEmpty("darwin", defaultArch),
+			formatted: joinNotEmpty("darwin", defaultArch, defaultVariant),
 		},
 	} {
 		t.Run(testcase.input, func(t *testing.T) {


### PR DESCRIPTION
arm has been supported, but something is missing, causes test failure

```
--- FAIL: TestParseSelector (0.00s)
    --- SKIP: TestParseSelector/* (0.00s)
        platforms_test.go:288: this case is not yet supported
    --- SKIP: TestParseSelector/linux/* (0.00s)
        platforms_test.go:288: this case is not yet supported
    --- SKIP: TestParseSelector/*/arm64 (0.00s)
        platforms_test.go:288: this case is not yet supported
    --- PASS: TestParseSelector/linux/arm64 (0.00s)
    --- PASS: TestParseSelector/linux/arm64/v8 (0.00s)
    --- PASS: TestParseSelector/linux/arm (0.00s)
    --- PASS: TestParseSelector/linux/arm/v6 (0.00s)
    --- PASS: TestParseSelector/linux/arm/v7 (0.00s)
    --- PASS: TestParseSelector/arm (0.00s)
    --- PASS: TestParseSelector/armel (0.00s)
    --- PASS: TestParseSelector/armhf (0.00s)
    --- PASS: TestParseSelector/Aarch64 (0.00s)
    --- PASS: TestParseSelector/x86_64 (0.00s)
    --- PASS: TestParseSelector/Linux/x86_64 (0.00s)
    --- PASS: TestParseSelector/i386 (0.00s)
    --- FAIL: TestParseSelector/linux (0.00s)
        platforms_test.go:292: arm support not fully implemented: not implemented
    --- PASS: TestParseSelector/s390x (0.00s)
    --- PASS: TestParseSelector/linux/s390x (0.00s)
    --- FAIL: TestParseSelector/macOS (0.00s)
        platforms_test.go:292: arm support not fully implemented: not implemented
```
The test like `linux/arm/v6` and `linux/arm/v7` have passed, so I don't think there's issue for arm actually.