### PR TITLE
Add Makefile variable to skip test packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,11 @@ TEST_REQUIRES_ROOT_PACKAGES=$(filter \
 	done | sort -u) \
     )
 
+ifdef SKIPTESTS
+    PACKAGES:=$(filter-out ${SKIPTESTS},${PACKAGES})
+    TEST_REQUIRES_ROOT_PACKAGES:=$(filter-out ${SKIPTESTS},${TEST_REQUIRES_ROOT_PACKAGES})
+endif
+
 # Project binaries.
 COMMANDS=ctr containerd containerd-stress
 MANPAGES=ctr.1 containerd.1 containerd-config.1 containerd-config.toml.5


### PR DESCRIPTION
The package lists for testing/build are currently auto generated with no way to explicitly skip packages for test. This adds a variable which can be set to filter out packages.

Fixes #3940 