### PR TITLE
[release/1.3 backport] platforms: fill default arm variant when parse platform specifier

### DIFF
--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -189,9 +189,8 @@ func Parse(specifier string) (specs.Platform, error) {
 		if isKnownOS(p.OS) {
 			// picks a default architecture
 			p.Architecture = runtime.GOARCH
-			if p.Architecture == "arm" {
-				// TODO(stevvooe): Resolve arm variant, if not v6 (default)
-				return specs.Platform{}, errors.Wrapf(errdefs.ErrNotImplemented, "arm support not fully implemented")
+			if p.Architecture == "arm" && cpuVariant != "v7" {
+				p.Variant = cpuVariant
 			}
 
 			return p, nil

--- a/platforms/platforms_test.go
+++ b/platforms/platforms_test.go
@@ -26,9 +26,14 @@ import (
 
 func TestParseSelector(t *testing.T) {
 	var (
-		defaultOS   = runtime.GOOS
-		defaultArch = runtime.GOARCH
+		defaultOS      = runtime.GOOS
+		defaultArch    = runtime.GOARCH
+		defaultVariant = ""
 	)
+
+	if defaultArch == "arm" && cpuVariant != "v7" {
+		defaultVariant = cpuVariant
+	}
 
 	for _, testcase := range []struct {
 		skip      bool
@@ -255,8 +260,9 @@ func TestParseSelector(t *testing.T) {
 			expected: specs.Platform{
 				OS:           "linux",
 				Architecture: defaultArch,
+				Variant:      defaultVariant,
 			},
-			formatted: joinNotEmpty("linux", defaultArch),
+			formatted: joinNotEmpty("linux", defaultArch, defaultVariant),
 		},
 		{
 			input: "s390x",
@@ -279,8 +285,9 @@ func TestParseSelector(t *testing.T) {
 			expected: specs.Platform{
 				OS:           "darwin",
 				Architecture: defaultArch,
+				Variant:      defaultVariant,
 			},
-			formatted: joinNotEmpty("darwin", defaultArch),
+			formatted: joinNotEmpty("darwin", defaultArch, defaultVariant),
 		},
 	} {
 		t.Run(testcase.input, func(t *testing.T) {


### PR DESCRIPTION
Backport #3939