### PR TITLE
bump microsoft/hcsshim to 0.8.7

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -27,7 +27,7 @@ github.com/imdario/mergo                            7c29201646fa3de8506f70121347
 github.com/konsorten/go-windows-terminal-sequences  5c8c8bd35d3832f5d134ae1e1e375b69a4d25242 # v1.0.1
 github.com/matttproud/golang_protobuf_extensions    c12348ce28de40eed0136aa2b644d0ee0650e56c # v1.0.1
 github.com/Microsoft/go-winio                       6c72808b55902eae4c5943626030429ff20f3b63 # v0.4.14
-github.com/Microsoft/hcsshim                        d2849cbdb9dfe5f513292a9610ca2eb734cdd1e7
+github.com/Microsoft/hcsshim                        b3f49c06ffaeef24d09c6c08ec8ec8425a0303e2 # v0.8.7
 github.com/opencontainers/go-digest                 c9281466c8b2f606084ac71339773efd177436e7
 github.com/opencontainers/image-spec                d60099175f88c47cd379c4738d158884749ed235 # v1.0.1
 github.com/opencontainers/runc                      d736ef14f0288d6993a1845745d6756cfc9ddd5a # v1.0.0-rc9

--- a/vendor/github.com/Microsoft/hcsshim/container.go
+++ b/vendor/github.com/Microsoft/hcsshim/container.go
@@ -196,7 +196,7 @@ func (container *container) MappedVirtualDisks() (map[int]MappedVirtualDiskContr
 
 // CreateProcess launches a new process within the container.
 func (container *container) CreateProcess(c *ProcessConfig) (Process, error) {
-	p, err := container.system.CreateProcessNoStdio(c)
+	p, err := container.system.CreateProcess(context.Background(), c)
 	if err != nil {
 		return nil, convertSystemError(err, container)
 	}

--- a/vendor/github.com/Microsoft/hcsshim/go.mod
+++ b/vendor/github.com/Microsoft/hcsshim/go.mod
@@ -1,6 +1,6 @@
 module github.com/Microsoft/hcsshim
 
-go 1.12
+go 1.13
 
 require (
 	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5

--- a/vendor/github.com/Microsoft/hcsshim/hcn/hcn.go
+++ b/vendor/github.com/Microsoft/hcsshim/hcn/hcn.go
@@ -161,6 +161,33 @@ func DSRSupported() error {
 	return platformDoesNotSupportError("Direct Server Return (DSR)")
 }
 
+// Slash32EndpointPrefixesSupported returns an error if the HCN version does not support configuring endpoints with /32 prefixes.
+func Slash32EndpointPrefixesSupported() error {
+	supported := GetSupportedFeatures()
+	if supported.Slash32EndpointPrefixes {
+		return nil
+	}
+	return platformDoesNotSupportError("Slash 32 Endpoint prefixes")
+}
+
+// AclSupportForProtocol252Supported returns an error if the HCN version does not support HNS ACL Policies to support protocol 252 for VXLAN.
+func AclSupportForProtocol252Supported() error {
+	supported := GetSupportedFeatures()
+	if supported.AclSupportForProtocol252 {
+		return nil
+	}
+	return platformDoesNotSupportError("HNS ACL Policies to support protocol 252 for VXLAN")
+}
+
+// SessionAffinitySupported returns an error if the HCN version does not support Session Affinity.
+func SessionAffinitySupported() error {
+	supported := GetSupportedFeatures()
+	if supported.SessionAffinity {
+		return nil
+	}
+	return platformDoesNotSupportError("Session Affinity")
+}
+
 // RequestType are the different operations performed to settings.
 // Used to update the settings of Endpoint/Namespace objects.
 type RequestType string

--- a/vendor/github.com/Microsoft/hcsshim/hcn/hcnglobals.go
+++ b/vendor/github.com/Microsoft/hcsshim/hcn/hcnglobals.go
@@ -3,6 +3,7 @@ package hcn
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 
 	"github.com/Microsoft/hcsshim/internal/hcserror"
 	"github.com/Microsoft/hcsshim/internal/interop"
@@ -20,17 +21,36 @@ type Version struct {
 	Minor int `json:"Minor"`
 }
 
+type VersionRange struct {
+	MinVersion Version
+	MaxVersion Version
+}
+
+type VersionRanges []VersionRange
+
 var (
 	// HNSVersion1803 added ACL functionality.
-	HNSVersion1803 = Version{Major: 7, Minor: 2}
+	HNSVersion1803 = VersionRanges{VersionRange{MinVersion: Version{Major: 7, Minor: 2}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
 	// V2ApiSupport allows the use of V2 Api calls and V2 Schema.
-	V2ApiSupport = Version{Major: 9, Minor: 2}
+	V2ApiSupport = VersionRanges{VersionRange{MinVersion: Version{Major: 9, Minor: 2}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
 	// Remote Subnet allows for Remote Subnet policies on Overlay networks
-	RemoteSubnetVersion = Version{Major: 9, Minor: 2}
+	RemoteSubnetVersion = VersionRanges{VersionRange{MinVersion: Version{Major: 9, Minor: 2}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
 	// A Host Route policy allows for local container to local host communication Overlay networks
-	HostRouteVersion = Version{Major: 9, Minor: 2}
+	HostRouteVersion = VersionRanges{VersionRange{MinVersion: Version{Major: 9, Minor: 2}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
 	// HNS 10.2 allows for Direct Server Return for loadbalancing
-	DSRVersion = Version{Major: 10, Minor: 2}
+	DSRVersion = VersionRanges{VersionRange{MinVersion: Version{Major: 10, Minor: 2}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
+	// HNS 9.3 through 10.0 (not included) and, 10.4+ provide support for configuring endpoints with /32 prefixes
+	Slash32EndpointPrefixesVersion = VersionRanges{
+		VersionRange{MinVersion: Version{Major: 9, Minor: 3}, MaxVersion: Version{Major: 9, Minor: math.MaxInt32}},
+		VersionRange{MinVersion: Version{Major: 10, Minor: 4}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}},
+	}
+	// HNS 9.3 through 10.0 (not included) and, 10.4+ allow for HNS ACL Policies to support protocol 252 for VXLAN
+	AclSupportForProtocol252Version = VersionRanges{
+		VersionRange{MinVersion: Version{Major: 9, Minor: 3}, MaxVersion: Version{Major: 9, Minor: math.MaxInt32}},
+		VersionRange{MinVersion: Version{Major: 10, Minor: 4}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}},
+	}
+	// HNS 11.10 allows for session affinity for loadbalancing
+	SessionAffinityVersion = VersionRanges{VersionRange{MinVersion: Version{Major: 11, Minor: 10}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
 )
 
 // GetGlobals returns the global properties of the HCN Service.

--- a/vendor/github.com/Microsoft/hcsshim/hcn/hcnloadbalancer.go
+++ b/vendor/github.com/Microsoft/hcsshim/hcn/hcnloadbalancer.go
@@ -10,10 +10,11 @@ import (
 
 // LoadBalancerPortMapping is associated with HostComputeLoadBalancer
 type LoadBalancerPortMapping struct {
-	Protocol     uint32                       `json:",omitempty"` // EX: TCP = 6, UDP = 17
-	InternalPort uint16                       `json:",omitempty"`
-	ExternalPort uint16                       `json:",omitempty"`
-	Flags        LoadBalancerPortMappingFlags `json:",omitempty"`
+	Protocol         uint32                       `json:",omitempty"` // EX: TCP = 6, UDP = 17
+	InternalPort     uint16                       `json:",omitempty"`
+	ExternalPort     uint16                       `json:",omitempty"`
+	DistributionType LoadBalancerDistribution     `json:",omitempty"` // EX: Distribute per connection = 0, distribute traffic of the same protocol per client IP = 1, distribute per client IP = 2
+	Flags            LoadBalancerPortMappingFlags `json:",omitempty"`
 }
 
 // HostComputeLoadBalancer represents software load balancer.
@@ -51,6 +52,18 @@ var (
 	LoadBalancerPortMappingFlagsUseMux LoadBalancerPortMappingFlags = 4
 	// LoadBalancerPortMappingFlagsPreserveDIP delivers packets with destination IP as the VIP.
 	LoadBalancerPortMappingFlagsPreserveDIP LoadBalancerPortMappingFlags = 8
+)
+
+// LoadBalancerDistribution specifies how the loadbalancer distributes traffic.
+type LoadBalancerDistribution uint32
+
+var (
+	// LoadBalancerDistributionNone is the default and loadbalances each connection to the same pod.
+	LoadBalancerDistributionNone LoadBalancerDistribution
+	// LoadBalancerDistributionSourceIPProtocol loadbalances all traffic of the same protocol from a client IP to the same pod.
+	LoadBalancerDistributionSourceIPProtocol LoadBalancerDistribution = 1
+	// LoadBalancerDistributionSourceIP loadbalances all traffic from a client IP to the same pod.
+	LoadBalancerDistributionSourceIP LoadBalancerDistribution = 2
 )
 
 func getLoadBalancer(loadBalancerGuid guid.GUID, query string) (*HostComputeLoadBalancer, error) {

--- a/vendor/github.com/Microsoft/hcsshim/hcn/hcnsupport.go
+++ b/vendor/github.com/Microsoft/hcsshim/hcn/hcnsupport.go
@@ -6,11 +6,14 @@ import (
 
 // SupportedFeatures are the features provided by the Service.
 type SupportedFeatures struct {
-	Acl          AclFeatures `json:"ACL"`
-	Api          ApiSupport  `json:"API"`
-	RemoteSubnet bool        `json:"RemoteSubnet"`
-	HostRoute    bool        `json:"HostRoute"`
-	DSR          bool        `json:"DSR"`
+	Acl                      AclFeatures `json:"ACL"`
+	Api                      ApiSupport  `json:"API"`
+	RemoteSubnet             bool        `json:"RemoteSubnet"`
+	HostRoute                bool        `json:"HostRoute"`
+	DSR                      bool        `json:"DSR"`
+	Slash32EndpointPrefixes  bool        `json:"Slash32EndpointPrefixes"`
+	AclSupportForProtocol252 bool        `json:"AclSupportForProtocol252"`
+	SessionAffinity          bool        `json:"SessionAffinity"`
 }
 
 // AclFeatures are the supported ACL possibilities.
@@ -53,18 +56,38 @@ func GetSupportedFeatures() SupportedFeatures {
 	features.RemoteSubnet = isFeatureSupported(globals.Version, RemoteSubnetVersion)
 	features.HostRoute = isFeatureSupported(globals.Version, HostRouteVersion)
 	features.DSR = isFeatureSupported(globals.Version, DSRVersion)
+	features.Slash32EndpointPrefixes = isFeatureSupported(globals.Version, Slash32EndpointPrefixesVersion)
+	features.AclSupportForProtocol252 = isFeatureSupported(globals.Version, AclSupportForProtocol252Version)
+	features.SessionAffinity = isFeatureSupported(globals.Version, SessionAffinityVersion)
 
 	return features
 }
 
-func isFeatureSupported(currentVersion Version, minVersionSupported Version) bool {
-	if currentVersion.Major < minVersionSupported.Major {
+func isFeatureSupported(currentVersion Version, versionsSupported VersionRanges) bool {
+	isFeatureSupported := false
+
+	for _, versionRange := range versionsSupported {
+		isFeatureSupported = isFeatureSupported || isFeatureInRange(currentVersion, versionRange)
+	}
+
+	return isFeatureSupported
+}
+
+func isFeatureInRange(currentVersion Version, versionRange VersionRange) bool {
+	if currentVersion.Major < versionRange.MinVersion.Major {
+		logrus.Infof("currentVersion.Major < versionRange.MinVersion.Major: %v, %v", currentVersion.Major, versionRange.MinVersion.Major)
 		return false
 	}
-	if currentVersion.Major > minVersionSupported.Major {
-		return true
+	if currentVersion.Major > versionRange.MaxVersion.Major {
+		logrus.Infof("currentVersion.Major > versionRange.MaxVersion.Major: %v, %v", currentVersion.Major, versionRange.MaxVersion.Major)
+		return false
 	}
-	if currentVersion.Minor < minVersionSupported.Minor {
+	if currentVersion.Major == versionRange.MinVersion.Major && currentVersion.Minor < versionRange.MinVersion.Minor {
+		logrus.Infof("currentVersion.Minor < versionRange.MinVersion.Major: %v, %v", currentVersion.Minor, versionRange.MinVersion.Minor)
+		return false
+	}
+	if currentVersion.Major == versionRange.MaxVersion.Major && currentVersion.Minor > versionRange.MaxVersion.Minor {
+		logrus.Infof("currentVersion.Minor > versionRange.MaxVersion.Major: %v, %v", currentVersion.Minor, versionRange.MaxVersion.Minor)
 		return false
 	}
 	return true

--- a/vendor/github.com/Microsoft/hcsshim/internal/vmcompute/vmcompute.go
+++ b/vendor/github.com/Microsoft/hcsshim/internal/vmcompute/vmcompute.go
@@ -204,7 +204,9 @@ func HcsShutdownComputeSystem(ctx gcontext.Context, computeSystem HcsSystem, opt
 		if result != "" {
 			span.AddAttributes(trace.StringAttribute("result", result))
 		}
-		oc.SetSpanStatus(span, hr)
+		if hr != errVmcomputeOperationPending {
+			oc.SetSpanStatus(span, hr)
+		}
 	}()
 	span.AddAttributes(trace.StringAttribute("options", options))
 

--- a/vendor/github.com/Microsoft/hcsshim/osversion/windowsbuilds.go
+++ b/vendor/github.com/Microsoft/hcsshim/osversion/windowsbuilds.go
@@ -21,7 +21,7 @@ const (
 	// 2019 (ltsc2019), and Windows 10 (October 2018 Update).
 	RS5 = 17763
 
-	// V19H1 (version 1903) corresponds to Windows Sever 1903 (semi-annual
+	// V19H1 (version 1903) corresponds to Windows Server 1903 (semi-annual
 	// channel).
 	V19H1 = 18362
 )


### PR DESCRIPTION
Update vendored dependency hcsshim to v0.8.7

It has been a long time since the last version update, some bugs were fixed in the middle, and a new version was finally released recently
https://github.com/microsoft/hcsshim/releases/tag/v0.8.7
