### PR TITLE
Fix unpacker to pass apply options

### DIFF
--- a/unpacker.go
+++ b/unpacker.go
@@ -191,7 +191,7 @@ EachLayer:
 		case <-fetchC[i-fetchOffset]:
 		}
 
-		diff, err := a.Apply(ctx, desc, mounts)
+		diff, err := a.Apply(ctx, desc, mounts, u.config.ApplyOpts...)
 		if err != nil {
 			abort()
 			return errors.Wrapf(err, "failed to extract layer %s", diffIDs[i])


### PR DESCRIPTION
Ran into this issue when using encrypted images via CRI where the payloads were not registering for the stream processor. This fixed it.

Signed-off-by: Brandon Lum <lumjjb@gmail.com>