### PR TITLE
[release/1.3] Fix filter errors

### DIFF
--- a/filters/filter_test.go
+++ b/filters/filter_test.go
@@ -272,6 +272,16 @@ func TestFilters(t *testing.T) {
 			input:     "image~=,id?=?fbaq",
 			errString: `filters: parse error: [image~= >|,|< id?=?fbaq]: expected value or quoted`,
 		},
+		{
+			name:      "FieldQuotedLiteralNotTerminated",
+			input:     "labels.ns/key==value",
+			errString: `filters: parse error: [labels.ns >|/|< key==value]: quoted literal not terminated`,
+		},
+		{
+			name:      "ValueQuotedLiteralNotTerminated",
+			input:     "labels.key==/value",
+			errString: `filters: parse error: [labels.key== >|/|< value]: quoted literal not terminated`,
+		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
 			filter, err := Parse(testcase.input)

--- a/filters/parser.go
+++ b/filters/parser.go
@@ -209,6 +209,8 @@ func (p *parser) field() (string, error) {
 		return s, nil
 	case tokenQuoted:
 		return p.unquote(pos, s, false)
+	case tokenIllegal:
+		return "", p.mkerr(pos, p.scanner.err)
 	}
 
 	return "", p.mkerr(pos, "expected field or quoted")
@@ -228,6 +230,8 @@ func (p *parser) operator() (operator, error) {
 		default:
 			return 0, p.mkerr(pos, "unsupported operator %q", s)
 		}
+	case tokenIllegal:
+		return 0, p.mkerr(pos, p.scanner.err)
 	}
 
 	return 0, p.mkerr(pos, `expected an operator ("=="|"!="|"~=")`)
@@ -241,6 +245,8 @@ func (p *parser) value(allowAltQuotes bool) (string, error) {
 		return s, nil
 	case tokenQuoted:
 		return p.unquote(pos, s, allowAltQuotes)
+	case tokenIllegal:
+		return "", p.mkerr(pos, p.scanner.err)
 	}
 
 	return "", p.mkerr(pos, "expected value or quoted")

--- a/services/content/contentserver/contentserver.go
+++ b/services/content/contentserver/contentserver.go
@@ -115,7 +115,7 @@ func (s *service) List(req *api.ListContentRequest, session api.Content_ListServ
 
 		return nil
 	}, req.Filters...); err != nil {
-		return err
+		return errdefs.ToGRPC(err)
 	}
 
 	if len(buffer) > 0 {


### PR DESCRIPTION
Prevent error messages from being output to stderr.
Return illegal token when a quoted string is invalid and capture the error.

This issue occurs on the daemon and a good candidate to backport.