### PR TITLE
Use utf8.RuneCountInString instead of len to handle certain characters like "─"

### DIFF
--- a/pkg/progress/writer.go
+++ b/pkg/progress/writer.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/containerd/console"
 )
@@ -105,7 +106,7 @@ func countLines(output string) int {
 	strlines := strings.Split(output, "\n")
 	lines := -1
 	for _, line := range strlines {
-		lines += (len(stripLine(line))-1)/width + 1
+		lines += (utf8.RuneCountInString(stripLine(line))-1)/width + 1
 	}
 	return lines
 }


### PR DESCRIPTION
Signed-off-by: Xiaodong Ye <xiaodongy@vmware.com>

```
length := len(stripLine("─"))
count := utf8.RuneCountInString(stripLine("─"))
fmt.Println(length, count)
```

The output is `3 1`