### PR TITLE
[backport release/1.2] runtime: only check killall for init process

### DIFF
--- a/runtime/v2/runc/service.go
+++ b/runtime/v2/runc/service.go
@@ -642,32 +642,35 @@ func (s *service) processExits() {
 }
 
 func (s *service) checkProcesses(e runcC.Exit) {
-	shouldKillAll, err := shouldKillAllOnExit(s.bundle)
-	if err != nil {
-		log.G(s.context).WithError(err).Error("failed to check shouldKillAll")
-	}
-
 	for _, p := range s.allProcesses() {
-		if p.Pid() == e.Pid {
+		if p.Pid() != e.Pid {
+			continue
+
+		}
+
+		if ip, ok := p.(*proc.Init); ok {
+			shouldKillAll, err := shouldKillAllOnExit(s.bundle)
+			if err != nil {
+				log.G(s.context).WithError(err).Error("failed to check shouldKillAll")
+			}
+
 			if shouldKillAll {
-				if ip, ok := p.(*proc.Init); ok {
-					// Ensure all children are killed
-					if err := ip.KillAll(s.context); err != nil {
-						logrus.WithError(err).WithField("id", ip.ID()).
-							Error("failed to kill init's children")
-					}
+				// Ensure all children are killed
+				if err := ip.KillAll(s.context); err != nil {
+					logrus.WithError(err).WithField("id", ip.ID()).
+						Error("failed to kill init's children")
 				}
 			}
-			p.SetExited(e.Status)
-			s.events <- &eventstypes.TaskExit{
-				ContainerID: s.id,
-				ID:          p.ID(),
-				Pid:         uint32(e.Pid),
-				ExitStatus:  uint32(e.Status),
-				ExitedAt:    p.ExitedAt(),
-			}
-			return
 		}
+		p.SetExited(e.Status)
+		s.events <- &eventstypes.TaskExit{
+			ContainerID: s.id,
+			ID:          p.ID(),
+			Pid:         uint32(e.Pid),
+			ExitStatus:  uint32(e.Status),
+			ExitedAt:    p.ExitedAt(),
+		}
+		return
 	}
 }
 


### PR DESCRIPTION
When containerd-shim does reaper, the most processes are not init
process. Since json.Decode consumes more CPU resource, we should check
killall option for init process only.

Signed-off-by: Wei Fu <fuweid89@gmail.com>

backport https://github.com/containerd/containerd/pull/3559
and fixes #3958. 