### PR TITLE
gc: increase sleep time in test

### DIFF
--- a/gc/scheduler/scheduler_test.go
+++ b/gc/scheduler/scheduler_test.go
@@ -98,7 +98,7 @@ func TestDeletionThreshold(t *testing.T) {
 
 	select {
 	case <-gcWait:
-	case <-time.After(time.Millisecond * 10):
+	case <-time.After(time.Millisecond * 30):
 		t.Fatal("GC wait timed out")
 	}
 
@@ -162,7 +162,7 @@ func TestStartupDelay(t *testing.T) {
 	defer cancel()
 	go scheduler.run(ctx)
 
-	time.Sleep(time.Millisecond * 5)
+	time.Sleep(time.Millisecond * 30)
 
 	if c := tc.runCount(); c != 1 {
 		t.Fatalf("unexpected gc run count %d, expected 1", c)


### PR DESCRIPTION
Fix some flaky tests.

(I think time sensitive test is not good...)

Some failure test examples:

https://buildd.debian.org/status/fetch.php?pkg=containerd&arch=armhf&ver=1.3.2%7Eds1-3&stamp=1578476094&raw=0
```
--- FAIL: TestDeletionThreshold (0.02s)
    scheduler_test.go:102: GC wait timed out
```

https://tests.reproducible-builds.org/debian/logs/bullseye/amd64/containerd_1.3.2~ds1-3.build2.log.gz
```
--- FAIL: TestStartupDelay (0.01s)
    scheduler_test.go:168: unexpected gc run count 0, expected 1
```

https://tests.reproducible-builds.org/debian/logs/unstable/armhf/containerd_1.3.2~ds1-3.build2.log.gz
```
--- FAIL: TestStartupDelay (0.01s)
    scheduler_test.go:168: unexpected gc run count 0, expected 1
```