### PR TITLE
snapshots: fix flaky TestMetastore

### DIFF
--- a/snapshots/storage/metastore_test.go
+++ b/snapshots/storage/metastore_test.go
@@ -261,7 +261,7 @@ var cmpSnapshotInfo = cmp.FilterPath(
 		// actual value should be within a few seconds of now
 		now := time.Now()
 		delta := now.Sub(actual)
-		threshold := 10 * time.Second
+		threshold := 30 * time.Second
 		return delta > -threshold && delta < threshold
 	}))
 


### PR DESCRIPTION
Today in my two PR(#3962, #3963), the openlab-ci bot sometimes reports failure...

For example,

https://logs.openlabtesting.org/logs/62/3962/35a8e6e589eb37a73f94cdbd5c8d7938b2b04140/check/containerd-build-arm64/de237af/logs/make_test.txt

```
--- FAIL: TestMetastore (18.27s)
    --- FAIL: TestMetastore/GetInfo (13.91s)
        metastore_test.go:242: assertion failed:
            --- expected
            +++ info
            {snapshots.Info}.Created:
            	-: s"0001-01-01 00:00:00 +0000 UTC"
            	+: s"2020-01-15 14:15:38.71882571 +0000 UTC"
            {snapshots.Info}.Updated:
            	-: s"0001-01-01 00:00:00 +0000 UTC"
            	+: s"2020-01-15 14:15:38.71882571 +0000 UTC"
            : on key committed-1
```

It seems the test runs 13.91s...