### PR TITLE
[release/1.2 backport] Update Golang 1.12.15

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.12.14
+    - GO_VERSION: 1.12.15
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 language: go
 
 go:
-  - "1.12.14"
+  - "1.12.15"
 os:
   - "linux"
   # TODO ppc64le is currently timing out on travis; see https://github.com/containerd/containerd/pull/2896

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.12.14
+ARG GOLANG_VERSION=1.12.15
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd


### PR DESCRIPTION
backport of https://github.com/containerd/containerd/pull/3967

full diff: https://github.com/golang/go/compare/go1.12.14...go1.12.15

go1.12.15 (released 2020/01/09) includes fixes to the runtime and the net/http
package. See the Go 1.12.15 milestone on the issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.12.15+label%3ACherryPickApproved
