### PR TITLE
allow specifiying extra RemoteOpt in FetchConfig

### DIFF
--- a/cmd/ctr/commands/content/fetch.go
+++ b/cmd/ctr/commands/content/fetch.go
@@ -108,6 +108,8 @@ type FetchConfig struct {
 	Platforms []string
 	// Whether or not download all metadata
 	AllMetadata bool
+	// RemoteOpts to be appended
+	RemoteOpts []containerd.RemoteOpt
 }
 
 // NewFetchConfig returns the default FetchConfig from cli flags
@@ -172,6 +174,7 @@ func Fetch(ctx context.Context, client *containerd.Client, ref string, config *F
 		containerd.WithImageHandler(h),
 		containerd.WithSchema1Conversion,
 	}
+	opts = append(opts, config.RemoteOpts...)
 
 	if config.AllMetadata {
 		opts = append(opts, containerd.WithAllMetadata())


### PR DESCRIPTION
expected to be used in custom ctr-like apps

e.g. https://github.com/ktock/stargz-snapshotter/blob/45e21f444d17da2c2a84139b5a5482586e73a08d/cmd/ctr-remote/commands/rpull.go
