### PR TITLE
[release/1.3 backport] Bump to opencontainers/runc new version - v1.0.0-rc10

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -20,7 +20,7 @@ github.com/gogo/protobuf v1.2.1
 github.com/gogo/googleapis v1.2.0
 github.com/golang/protobuf v1.2.0
 github.com/opencontainers/runtime-spec 29686dbc5559d93fb1ef402eeda3e35c38d75af4 # v1.0.1-59-g29686db
-github.com/opencontainers/runc d736ef14f0288d6993a1845745d6756cfc9ddd5a # v1.0.0-rc9
+github.com/opencontainers/runc dc9208a3303feef5b3839f4323d9beb36df0a9dd # v1.0.0-rc10
 github.com/konsorten/go-windows-terminal-sequences v1.0.1
 github.com/sirupsen/logrus v1.4.1
 github.com/urfave/cli v1.22.0

--- a/vendor/github.com/opencontainers/runc/README.md
+++ b/vendor/github.com/opencontainers/runc/README.md
@@ -16,9 +16,13 @@ This means that `runc` 1.0.0 should implement the 1.0 version of the specificati
 
 You can find official releases of `runc` on the [release](https://github.com/opencontainers/runc/releases) page.
 
+Currently, the following features are not considered to be production-ready:
+
+* Support for cgroup v2
+
 ## Security
 
-Reporting process and disclosure communications are outlined in [/org/security](https://github.com/opencontainers/org/blob/master/security/)
+The reporting process and disclosure communications are outlined in [/org/security](https://github.com/opencontainers/org/blob/master/security/).
 
 ## Building
 
@@ -229,7 +233,14 @@ runc delete mycontainerid
 This allows higher level systems to augment the containers creation logic with setup of various settings after the container is created and/or before it is deleted. For example, the container's network stack is commonly set up after `create` but before `start`.
 
 #### Rootless containers
-`runc` has the ability to run containers without root privileges. This is called `rootless`. You need to pass some parameters to `runc` in order to run rootless containers. See below and compare with the previous version. Run the following commands as an ordinary user:
+`runc` has the ability to run containers without root privileges. This is called `rootless`. You need to pass some parameters to `runc` in order to run rootless containers. See below and compare with the previous version.
+
+**Note:** In order to use this feature, "User Namespaces" must be compiled and enabled in your kernel. There are various ways to do this depending on your distribution:
+- Confirm `CONFIG_USER_NS=y` is set in your kernel configuration (normally found in `/proc/config.gz`)
+- Arch/Debian: `echo 1 > /proc/sys/kernel/unprivileged_userns_clone`
+- RHEL/CentOS 7: `echo 28633 > /proc/sys/user/max_user_namespaces`
+
+Run the following commands as an ordinary user:
 ```bash
 # Same as the first example
 mkdir ~/mycontainer

--- a/vendor/github.com/opencontainers/runc/vendor.conf
+++ b/vendor/github.com/opencontainers/runc/vendor.conf
@@ -26,3 +26,6 @@ golang.org/x/sys                        9eafafc0a87e0fd0aeeba439a4573537970c44c7
 # console dependencies
 github.com/containerd/console           0650fd9eeb50bab4fc99dceb9f2e14cf58f36e7f
 github.com/pkg/errors                   ba968bfe8b2f7e042a574c888954fccecfa385b4 # v0.8.1
+
+# ebpf dependencies
+github.com/cilium/ebpf                  95b36a581eed7b0f127306ed1d16cc0ddc06cf67


### PR DESCRIPTION
We have a new release of runc ( opencontainers/runc#2217 ). This release
has a fix for a race condition we are struggling with in kubernetes
(especially CI jobs) which was fixed in opencontainers/runc#2185

The v1.0.0-rc10 includes the fix for CVE-2019-19921 as well. The full
diff upstream is here:
https://github.com/opencontainers/runc/compare/v1.0.0-rc9...v1.0.0-rc10

`Signed-off-by: Davanum Srinivas <davanum@gmail.com>`