### PR TITLE
[release/1.2 backport] Pick up fix for CVE-2019-16884 in opencontainers/selinux

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -62,7 +62,7 @@ github.com/json-iterator/go 1.1.5
 github.com/modern-go/reflect2 1.0.1
 github.com/modern-go/concurrent 1.0.3
 github.com/opencontainers/runtime-tools v0.6.0
-github.com/opencontainers/selinux v1.2.2
+github.com/opencontainers/selinux 5215b1806f52b1fcc2070a8826c542c9d33cd3cf
 github.com/seccomp/libseccomp-golang v0.9.1
 github.com/tchap/go-patricia v2.2.6
 github.com/xeipuuv/gojsonpointer 4e3ac2762d5f479393488629ee9370b50873b3a6

--- a/vendor/github.com/opencontainers/selinux/go-selinux/label/label_selinux.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/label/label_selinux.go
@@ -13,11 +13,12 @@ import (
 
 // Valid Label Options
 var validOptions = map[string]bool{
-	"disable": true,
-	"type":    true,
-	"user":    true,
-	"role":    true,
-	"level":   true,
+	"disable":  true,
+	"type":     true,
+	"filetype": true,
+	"user":     true,
+	"role":     true,
+	"level":    true,
 }
 
 var ErrIncompatibleLabel = fmt.Errorf("Bad SELinux option z and Z can not be used together")
@@ -51,12 +52,15 @@ func InitLabels(options []string) (plabel string, mlabel string, Err error) {
 				return "", mountLabel, nil
 			}
 			if i := strings.Index(opt, ":"); i == -1 {
-				return "", "", fmt.Errorf("Bad label option %q, valid options 'disable' or \n'user, role, level, type' followed by ':' and a value", opt)
+				return "", "", fmt.Errorf("Bad label option %q, valid options 'disable' or \n'user, role, level, type, filetype' followed by ':' and a value", opt)
 			}
 			con := strings.SplitN(opt, ":", 2)
 			if !validOptions[con[0]] {
-				return "", "", fmt.Errorf("Bad label option %q, valid options 'disable, user, role, level, type'", con[0])
+				return "", "", fmt.Errorf("Bad label option %q, valid options 'disable, user, role, level, type, filetype'", con[0])
 
+			}
+			if con[0] == "filetype" {
+				mcon["type"] = con[1]
 			}
 			pcon[con[0]] = con[1]
 			if con[0] == "level" || con[0] == "user" {

--- a/vendor/github.com/opencontainers/selinux/go-selinux/selinux_stub.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/selinux_stub.go
@@ -97,6 +97,14 @@ func SetExecLabel(label string) error {
 }
 
 /*
+SetTaskLabel sets the SELinux label for the current thread, or an error.
+This requires the dyntransition permission.
+*/
+func SetTaskLabel(label string) error {
+        return nil
+}
+
+/*
 SetSocketLabel sets the SELinux label that the kernel will use for any programs
 that are executed by the current process thread, or an error.
 */
@@ -106,6 +114,11 @@ func SetSocketLabel(label string) error {
 
 // SocketLabel retrieves the current socket label setting
 func SocketLabel() (string, error) {
+	return "", nil
+}
+
+// PeerLabel retrieves the label of the client on the other side of a socket
+func PeerLabel(fd uintptr) (string, error) {
 	return "", nil
 }
 


### PR DESCRIPTION
Picking up the changes in the following diff:
https://github.com/containerd/containerd/compare/master...dims:bump-opencontainers/selinux-for-CVE-2019-16884-release-1.3?expand=1

specifically so we can include:
https://github.com/opencontainers/selinux/commit/03b517dc4fd57245b1cf506e8ba7b817b6d309da