### PR TITLE
ctr events: do not exit on an error

### DIFF
--- a/cmd/ctr/commands/events/events.go
+++ b/cmd/ctr/commands/events/events.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/events"
+	"github.com/containerd/containerd/log"
 	"github.com/containerd/typeurl"
 	"github.com/urfave/cli"
 
@@ -54,11 +55,13 @@ var Command = cli.Command{
 				if e.Event != nil {
 					v, err := typeurl.UnmarshalAny(e.Event)
 					if err != nil {
-						return err
+						log.G(ctx).WithError(err).Warn("cannot unmarshal an event from Any")
+						continue
 					}
 					out, err = json.Marshal(v)
 					if err != nil {
-						return err
+						log.G(ctx).WithError(err).Warn("cannot marshal Any into JSON")
+						continue
 					}
 				}
 				if _, err := fmt.Println(


### PR DESCRIPTION
Errors like "type with url %s: not found" are typical for non-builtin event types, and should not resultin exiting `ctr`.
