### PR TITLE
[release/1.2] Prepare v1.2.12 release

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -30,3 +30,4 @@ Ace-Tang <aceapril@126.com>
 Wei Fu <fuweid89@gmail.com>
 Andrey Kolomentsev <andrey.kolomentsev@gmail.com> akolomentsev <andrey.kolomentsev@gmail.com>
 Mark Gordon <msg555@gmail.com>
+Reid Li <reid.li@utexas.edu>

--- a/releases/v1.2.12.toml
+++ b/releases/v1.2.12.toml
@@ -1,0 +1,43 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release
+previous = "v1.2.11"
+
+pre_release = false
+
+preface = """\
+The twelfth patch release for `containerd` 1.2 includes an updated runc with
+a fix for CVE-2019-19921, an updated version of the opencontainers/selinux
+dependency, which includes a fix for CVE-2019-16884, an updated version of the
+`gopkg.in/yaml.v2` dependency to address CVE-2019-11253, and a Golang update.
+
+### Notable Updates
+
+* Update the runc vendor to v1.0.0-rc10 which includes a mitigation for [CVE-2019-19921](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19921).
+* Update the opencontainers/selinux which includes a mitigation for [CVE-2019-16884](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16884).
+* Update Golang runtime to 1.12.16, mitigating the [CVE-2020-0601](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-0601) certificate verification bypass on Windows, and [CVE-2020-7919](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-7919), which only affects 32-bit architectures.
+* Update Golang runtime to 1.12.15, which includes a fix to the runtime (Go 1.12.14, Go 1.12.15) and and the `net/http` package (Go 1.12.15)
+* A fix to prevent `SIGSEGV` when starting containerd-shim [containerd/containerd#3960](https://github.com/containerd/containerd/pull/3960)
+* Fixes to `exec` [containerd/containerd#3755](https://github.com/containerd/containerd/pull/3755)
+    - Prevent `docker exec` hanging if an earlier `docker exec` left a zombie process
+    - Prevent High system load/CPU utilization with liveness and readiness probes
+    - Prevent Docker healthcheck causing high CPU utilization
+
+* CRI fixes:
+    - Update the `gopkg.in/yaml.v2` vendor to v2.2.8 with a mitigation for [CVE-2019-11253](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11253)
+
+### API
+
+* Fix API filters to properly handle and return parse errors [containerd/containerd#3950](https://github.com/containerd/containerd/pull/3950)
+
+"""
+
+# notable prs to include in the release notes, 1234 is the pr number
+[notes]
+
+[breaking]

--- a/version/version.go
+++ b/version/version.go
@@ -21,7 +21,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.2.11+unknown"
+	Version = "1.2.12+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
* Update the runc vendor to v1.0.0-rc10 which includes a mitigation for [CVE-2019-19921](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19921).
* Update the opencontainers/selinux which includes a mitigation for [CVE-2019-16884](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16884).
* Update Golang runtime to 1.12.15, which includes a fix to the runtime (Go 1.12.14, Go 1.12.15) and and the `net/http` package (Go 1.12.15)
* A fix to prevent `SIGSEGV` when starting containerd-shim [containerd/containerd#3960](https://github.com/containerd/containerd/pull/3960)
* Fixes to `exec` [containerd/containerd#3755](https://github.com/containerd/containerd/pull/3755)
    - Prevent `docker exec` hanging if an earlier `docker exec` left a zombie process
    - Prevent High system load/CPU utilization with liveness and readiness probes
    - Prevent Docker healthcheck causing high CPU utilization

* CRI fixes:
    - Update the `gopkg.in/yaml.v2` vendor to v2.2.8 with a mitigation for [CVE-2019-11253](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11253)
