### PR TITLE
Fix startup_delay within default configuration

### DIFF
--- a/docs/man/containerd-config.toml.5.md
+++ b/docs/man/containerd-config.toml.5.md
@@ -128,7 +128,7 @@ imports = ["/etc/containerd/runtime_*.toml", "./debug.toml"]
     deletion_threshold = 0
     mutation_threshold = 100
     schedule_delay = 0
-    startup_delay = 100000000
+    startup_delay = "100ms"
 ```
 
 ## BUGS


### PR DESCRIPTION
Without this patch, the containerd daemon fails to start using the
default configuration example:
containerd[37139]: containerd: time: missing unit in duration 100000000

Signed-off-by: Mihai Coman <mihai.cmn@gmail.com>