### PR TITLE
Make losetup tests less flaky

### DIFF
--- a/snapshots/devmapper/losetup/losetup.go
+++ b/snapshots/devmapper/losetup/losetup.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
 )
 
 // FindAssociatedLoopDevices returns a list of loop devices attached to a given image
@@ -65,7 +66,7 @@ func RemoveLoopDevicesAssociatedWithImage(imagePath string) error {
 	}
 
 	for _, loopDevice := range loopDevices {
-		if err = DetachLoopDevice(loopDevice); err != nil {
+		if err = DetachLoopDevice(loopDevice); err != nil && err != unix.ENOENT {
 			return err
 		}
 	}
@@ -75,9 +76,15 @@ func RemoveLoopDevicesAssociatedWithImage(imagePath string) error {
 
 // losetup is a wrapper around losetup command line tool
 func losetup(args ...string) (string, error) {
-	data, err := exec.Command("losetup", args...).CombinedOutput()
+	cmd := exec.Command("losetup", args...)
+	cmd.Env = append(cmd.Env, "LANG=C")
+	data, err := cmd.CombinedOutput()
 	output := string(data)
 	if err != nil {
+		if strings.Contains(output, "No such file or directory") || strings.Contains(output, "No such device") {
+			return "", unix.ENOENT
+		}
+
 		return "", errors.Wrapf(err, "losetup %s\nerror: %s\n", strings.Join(args, " "), output)
 	}
 

--- a/snapshots/devmapper/losetup/losetup_test.go
+++ b/snapshots/devmapper/losetup/losetup_test.go
@@ -23,10 +23,12 @@ import (
 	"os"
 	"testing"
 
-	"github.com/containerd/containerd/pkg/testutil"
 	"github.com/docker/go-units"
+	"golang.org/x/sys/unix"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
+
+	"github.com/containerd/containerd/pkg/testutil"
 )
 
 func TestLosetup(t *testing.T) {
@@ -97,6 +99,11 @@ func TestLosetup(t *testing.T) {
 	t.Run("RemoveLoopDevicesAssociatedWithInvalidImage", func(t *testing.T) {
 		err := RemoveLoopDevicesAssociatedWithImage("")
 		assert.NilError(t, err)
+	})
+
+	t.Run("DetachInvalidDevice", func(t *testing.T) {
+		err := DetachLoopDevice("/dev/loop_invalid_idx")
+		assert.Equal(t, unix.ENOENT, err)
 	})
 }
 


### PR DESCRIPTION
This PR fixes
```
1538    --- FAIL: TestLosetup/RemoveLoopDevicesAssociatedWithImage (0.06s)
1539        losetup_test.go:90: assertion failed: error is not nil: losetup --detach /dev/loop5
1540            error: losetup: /dev/loop5: detach failed: No such device or address
1541            
1542            : exit status 1
1543FAIL
```
that I've seen in other PRs.

Signed-off-by: Maksym Pavlenko <makpav@amazon.com>