### PR TITLE
[release/1.2 backport] Fix btrfs packages in contrib Dockerfile

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -135,7 +135,7 @@ You can build an image from this `Dockerfile`:
 FROM golang
 
 RUN apt-get update && \
-    apt-get install -y btrfs-tools libseccomp-dev
+    apt-get install -y libbtrfs-dev libseccomp-dev
 ```
 
 Let's suppose that you built an image called `containerd/build`. From the

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -38,7 +38,8 @@ RUN ./install-runc
 
 FROM golang-base AS dev
 RUN apt-get update && apt-get install -y \
-    btrfs-tools \
+    libbtrfs-dev \
+    btrfs-progs \
     gcc \
     git \
     libseccomp-dev \


### PR DESCRIPTION
Building containerd inside a container showed that the Dockerfile was broken (due to the `golang:1.12.x` image now using Debian Buster as base image)

Nothing critical, but let's make the Dockerfile work again. Backports of:

- https://github.com/containerd/containerd/pull/3814 Fix dependency in BUILDING.md
    - fixes https://github.com/containerd/containerd/issues/3813 Dependency missing after following Docker build instructions
- https://github.com/containerd/containerd/pull/3815 Update name for btrfs headers package
