### PR TITLE
vendor: bump cri, gopkg.in/yaml.v2 v2.2.8

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -53,7 +53,7 @@ google.golang.org/grpc                              39e8a7b072a67ca2a75f57fa2e0d
 gotest.tools                                        1083505acf35a0bd8a696b26837e1fb3187a7a83 # v2.3.0
 
 # cri dependencies
-github.com/containerd/cri                           19589b4bf9663815649f1125fb45a1674d52a702 # master
+github.com/containerd/cri                           c0294ebfe0b4342db85c0faf7727ceb8d8c3afce # master
 github.com/containerd/go-cni                        0d360c50b10b350b6bb23863fd4dfb1c232b01c9
 github.com/containernetworking/cni                  4cfb7b568922a3c79a23e438dc52fe537fc9687e # v0.7.1
 github.com/containernetworking/plugins              9f96827c7cabb03f21d86326000c00f61e181f6a # v0.7.6

--- a/vendor.conf
+++ b/vendor.conf
@@ -74,7 +74,7 @@ golang.org/x/crypto                                 69ecbb4d6d5dab05e49161c6e77e
 golang.org/x/oauth2                                 0f29369cfe4552d0e4bcddc57cc75f4d7e672a33
 golang.org/x/time                                   9d24e82272b4f38b78bc8cff74fa936d31ccd8ef
 gopkg.in/inf.v0                                     d2d2541c53f18d2a059457998ce2876cc8e67cbf # v0.9.1
-gopkg.in/yaml.v2                                    f221b8435cfb71e54062f6c6e99e9ade30b124d5 # v2.2.4
+gopkg.in/yaml.v2                                    53403b58ad1b561927d19068c655246f2db79d48 # v2.2.8
 k8s.io/api                                          7643814f1c97f24ccfb38c2b85a7bb3c7f494346 # kubernetes-1.17.1
 k8s.io/apimachinery                                 79c2a76c473a20cdc4ce59cae4b72529b5d9d16b # kubernetes-1.17.1
 k8s.io/apiserver                                    5381f05fcb881d39af12eeecab5645364229300c # kubernetes-1.17.1

--- a/vendor/github.com/containerd/cri/vendor.conf
+++ b/vendor/github.com/containerd/cri/vendor.conf
@@ -67,7 +67,7 @@ k8s.io/client-go kubernetes-1.17.1
 k8s.io/api kubernetes-1.17.1
 k8s.io/apiserver kubernetes-1.17.1
 k8s.io/apimachinery kubernetes-1.17.1
-gopkg.in/yaml.v2 v2.2.4
+gopkg.in/yaml.v2 53403b58ad1b561927d19068c655246f2db79d48 # v2.2.8
 gopkg.in/inf.v0 v0.9.1
 golang.org/x/time 9d24e82272b4f38b78bc8cff74fa936d31ccd8ef
 golang.org/x/oauth2 0f29369cfe4552d0e4bcddc57cc75f4d7e672a33

--- a/vendor/gopkg.in/yaml.v2/decode.go
+++ b/vendor/gopkg.in/yaml.v2/decode.go
@@ -319,10 +319,14 @@ func (d *decoder) prepare(n *node, out reflect.Value) (newout reflect.Value, unm
 }
 
 const (
-	// 400,000 decode operations is ~500kb of dense object declarations, or ~5kb of dense object declarations with 10000% alias expansion
+	// 400,000 decode operations is ~500kb of dense object declarations, or
+	// ~5kb of dense object declarations with 10000% alias expansion
 	alias_ratio_range_low = 400000
-	// 4,000,000 decode operations is ~5MB of dense object declarations, or ~4.5MB of dense object declarations with 10% alias expansion
+
+	// 4,000,000 decode operations is ~5MB of dense object declarations, or
+	// ~4.5MB of dense object declarations with 10% alias expansion
 	alias_ratio_range_high = 4000000
+
 	// alias_ratio_range is the range over which we scale allowed alias ratios
 	alias_ratio_range = float64(alias_ratio_range_high - alias_ratio_range_low)
 )
@@ -784,8 +788,7 @@ func (d *decoder) merge(n *node, out reflect.Value) {
 	case mappingNode:
 		d.unmarshal(n, out)
 	case aliasNode:
-		an, ok := d.doc.anchors[n.value]
-		if ok && an.kind != mappingNode {
+		if n.alias != nil && n.alias.kind != mappingNode {
 			failWantMap()
 		}
 		d.unmarshal(n, out)
@@ -794,8 +797,7 @@ func (d *decoder) merge(n *node, out reflect.Value) {
 		for i := len(n.children) - 1; i >= 0; i-- {
 			ni := n.children[i]
 			if ni.kind == aliasNode {
-				an, ok := d.doc.anchors[ni.value]
-				if ok && an.kind != mappingNode {
+				if ni.alias != nil && ni.alias.kind != mappingNode {
 					failWantMap()
 				}
 			} else if ni.kind != mappingNode {

--- a/vendor/gopkg.in/yaml.v2/yaml.go
+++ b/vendor/gopkg.in/yaml.v2/yaml.go
@@ -89,7 +89,7 @@ func UnmarshalStrict(in []byte, out interface{}) (err error) {
 	return unmarshal(in, out, true)
 }
 
-// A Decorder reads and decodes YAML values from an input stream.
+// A Decoder reads and decodes YAML values from an input stream.
 type Decoder struct {
 	strict bool
 	parser *parser

--- a/vendor/gopkg.in/yaml.v2/yamlh.go
+++ b/vendor/gopkg.in/yaml.v2/yamlh.go
@@ -579,6 +579,7 @@ type yaml_parser_t struct {
 
 	simple_key_allowed bool                // May a simple key occur at the current position?
 	simple_keys        []yaml_simple_key_t // The stack of simple keys.
+	simple_keys_by_tok map[int]int         // possible simple_key indexes indexed by token_number
 
 	// Parser stuff
 


### PR DESCRIPTION
### vendor: update containerd/cri c0294ebfe0b4342db85c0faf7727ceb8d8c3afce

full diff: https://github.com/containerd/cri/compare/19589b4bf9663815649f1125fb45a1674d52a702...c0294ebfe0b4342db85c0faf7727ceb8d8c3afce

- containerd/cri#1387 vendor: bump gopkg.in/yaml.v2 v2.2.8


### vendor: bump gopkg.in/yaml.v2 v2.2.8

full diff: https://github.com/go-yaml/yaml/compare/v2.2.4...v2.2.8

includes:

- go-yaml/yaml@f90ceb4 Fix check for non-map alias merging in v2
    - fix for "yaml.Unmarshal crashes on "assignment to entry in nil map""
- go-yaml/yaml 543 Port stale simple_keys fix to v2
- go-yaml/yaml@1f64d61 Fix issue in simple_keys improvements
    - fixes "Invalid simple_keys now cause panics later in decode"
- go-yaml/yaml 555 Optimize cases with long potential simple_keys