### PR TITLE
Support 32-bit userspace on 64-bit ARM cores

### DIFF
--- a/platforms/cpuinfo.go
+++ b/platforms/cpuinfo.go
@@ -98,7 +98,12 @@ func getCPUVariant() string {
 
 	switch strings.ToLower(variant) {
 	case "8", "aarch64":
-		variant = "v8"
+		// special case: if running a 32-bit userspace on aarch64, the variant should be "v7"
+		if runtime.GOARCH == "arm" {
+			variant = "v7"
+		} else {
+			variant = "v8"
+		}
 	case "7", "7m", "?(12)", "?(13)", "?(14)", "?(15)", "?(16)", "?(17)":
 		variant = "v7"
 	case "6", "6tej":


### PR DESCRIPTION
Fixes: #3990 

Don't rely on `/proc/cpuinfo` denoting a 64-bit ARMv8 processor if the
runtime detected `GOARCH` == `arm`. This allows aarch64 32-bit userspace
distros to run containers properly via a 32-bit runtime.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>