### PR TITLE
[release/1.2 backport] Pin to libseccomp 2.3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ addons:
       - libprotobuf-c0-dev
       - libprotobuf-dev
       - socat
-      - libseccomp-dev
 
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1
@@ -52,6 +51,7 @@ install:
   - go get -u github.com/vbatts/git-validation
   - go get -u github.com/kunalkushwaha/ltag
   - go get -u github.com/LK4D4/vndr
+  - if [ "$TRAVIS_GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH script/setup/install-seccomp ; fi
   - if [ "$TRAVIS_GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH script/setup/install-runc ; fi
   - if [ "$TRAVIS_GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH script/setup/install-cni ; fi
   - if [ "$TRAVIS_GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH script/setup/install-critools ; fi

--- a/script/setup/install-seccomp
+++ b/script/setup/install-seccomp
@@ -16,8 +16,7 @@
 
 
 #
-# Builds and installs runc to /usr/local/go/bin based off
-# the commit defined in vendor.conf
+# Builds a specific version of libseccomp and installs in /usr/local
 #
 set -eu -o pipefail
 

--- a/script/setup/install-seccomp
+++ b/script/setup/install-seccomp
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+
+#
+# Builds and installs runc to /usr/local/go/bin based off
+# the commit defined in vendor.conf
+#
+set -eu -o pipefail
+
+set -x
+
+export SECCOMP_VERSION="2.3.3"
+export SECCOMP_PATH="$(mktemp -d)"
+curl -fsSL "https://github.com/seccomp/libseccomp/releases/download/v${SECCOMP_VERSION}/libseccomp-${SECCOMP_VERSION}.tar.gz" | tar -xzC "$SECCOMP_PATH" --strip-components=1
+(
+	cd "$SECCOMP_PATH"
+	./configure --prefix=/usr/local
+	make
+	make install
+	ldconfig
+)
+
+rm -rf "$SECCOMP_PATH"


### PR DESCRIPTION
Besides the fact that lib seccomp 2.4 has huge performance regressions, it also breaks support for older distros like Debian 9 and RHEL/CentOS 7, as discussed in https://github.com/containerd/containerd/issues/4008.
This change pins to 2.3.3 where that is not an issue.

Fixes #4008.

(cherry picked from commits b5f03eacd34c7beffe5c8cc2a5cfee852335f681 and 75d0c5f2e74b44353da357c5603a52871bea3940)
Signed-off-by: Ciprian Hacman <ciprian.hacman@sematext.com>