### PR TITLE
Fix reference to LICENSE in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ __If you are reporting a security issue, please reach out discreetly at security
 
 ## Licenses
 
-The containerd codebase is released under the [Apache 2.0 license](LICENSE.code).
+The containerd codebase is released under the [Apache 2.0 license](LICENSE).
 The README.md file, and files in the "docs" folder are licensed under the
 Creative Commons Attribution 4.0 International License. You may obtain a
 copy of the license, titled CC-BY-4.0, at http://creativecommons.org/licenses/by/4.0/.


### PR DESCRIPTION
Dedicated to our anonymous contributor @x448. Thanks for alerting us to this broken link!

Ref: #4014 

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>