### PR TITLE
Add flag on umount

### DIFF
--- a/runtime/v1/linux/proc/init.go
+++ b/runtime/v1/linux/proc/init.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"golang.org/x/sys/unix"
 	"io"
 	"os"
 	"path/filepath"
@@ -303,7 +304,7 @@ func (p *Init) delete(ctx context.Context) error {
 		p.io.Close()
 	}
 	if p.Rootfs != "" {
-		if err2 := mount.UnmountAll(p.Rootfs, 0); err2 != nil {
+		if err2 := mount.UnmountAll(p.Rootfs, unix.MNT_DETACH); err2 != nil {
 			log.G(ctx).WithError(err2).Warn("failed to cleanup rootfs mount")
 			if err == nil {
 				err = errors.Wrap(err2, "failed rootfs umount")


### PR DESCRIPTION
When containerd-shim umount the rootfs of container, the occupying of rootfs will cause the pod is stuck in terminating forever. Detail https://github.com/containerd/containerd/issues/4020. We can call umount with `unix.MNT_DETACH` like docker.