### PR TITLE
[release/1.2 backport] Fix container pid race condition

### DIFF
--- a/container_test.go
+++ b/container_test.go
@@ -1528,3 +1528,52 @@ func TestContainerHook(t *testing.T) {
 	}
 	defer task.Delete(ctx, WithProcessKill)
 }
+
+func TestShortRunningTaskPid(t *testing.T) {
+	t.Parallel()
+
+	client, err := newClient(t, address)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	var (
+		image       Image
+		ctx, cancel = testContext()
+		id          = t.Name()
+	)
+	defer cancel()
+
+	image, err = client.GetImage(ctx, testImage)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	container, err := client.NewContainer(ctx, id, WithNewSnapshot(id, image), WithNewSpec(oci.WithImageConfig(image), withProcessArgs("true")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer container.Delete(ctx, WithSnapshotCleanup)
+
+	task, err := container.NewTask(ctx, empty())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer task.Delete(ctx)
+
+	finishedC, err := task.Wait(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := task.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	int32PID := int32(task.Pid())
+	if int32PID <= 0 {
+		t.Errorf("Unexpected task pid %d", int32PID)
+	}
+	<-finishedC
+}

--- a/runtime/v1/linux/proc/exec.go
+++ b/runtime/v1/linux/proc/exec.go
@@ -96,7 +96,6 @@ func (e *execProcess) setExited(status int) {
 	e.status = status
 	e.exited = time.Now()
 	e.parent.Platform.ShutdownConsole(context.Background(), e.console)
-	e.pid.set(StoppedPID)
 	close(e.waitBlock)
 }
 
@@ -147,7 +146,7 @@ func (e *execProcess) kill(ctx context.Context, sig uint32, _ bool) error {
 	switch {
 	case pid == 0:
 		return errors.Wrap(errdefs.ErrFailedPrecondition, "process not created")
-	case pid < 0:
+	case !e.exited.IsZero():
 		return errors.Wrapf(errdefs.ErrNotFound, "process already finished")
 	default:
 		if err := unix.Kill(pid, syscall.Signal(sig)); err != nil {

--- a/runtime/v1/linux/proc/init_state.go
+++ b/runtime/v1/linux/proc/init_state.go
@@ -161,9 +161,6 @@ func (s *createdCheckpointState) Start(ctx context.Context) error {
 	p := s.p
 	sio := p.stdio
 
-	p.pid.Lock()
-	defer p.pid.Unlock()
-
 	var (
 		err    error
 		socket *runc.Socket
@@ -209,7 +206,7 @@ func (s *createdCheckpointState) Start(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to retrieve OCI runtime container pid")
 	}
-	p.pid.pid = pid
+	p.pid = pid
 	return s.transition("running")
 }
 

--- a/runtime/v1/linux/proc/process.go
+++ b/runtime/v1/linux/proc/process.go
@@ -25,8 +25,6 @@ import (
 // RuncRoot is the path to the root runc state directory
 const (
 	RuncRoot = "/run/containerd/runc"
-	// StoppedPID is the pid assigned after a container has run and stopped
-	StoppedPID = -1
 )
 
 func stateName(v interface{}) string {

--- a/runtime/v1/linux/proc/utils.go
+++ b/runtime/v1/linux/proc/utils.go
@@ -46,12 +46,6 @@ func (s *safePid) get() int {
 	return s.pid
 }
 
-func (s *safePid) set(pid int) {
-	s.Lock()
-	s.pid = pid
-	s.Unlock()
-}
-
 type atomicBool int32
 
 func (ab *atomicBool) set(b bool) {


### PR DESCRIPTION
alternative for https://github.com/containerd/containerd/pull/4024 ([1.2] Revert #3366)
closes https://github.com/containerd/containerd/pull/4024 ([1.2] Revert #3366)

backport of:

- a6b6097c90c02ad2c8aac45e4f0332dc1a00a60c  https://github.com/containerd/containerd/pull/3857 Fix container pid race condition
    - relates to https://github.com/containerd/containerd/pull/3366 / https://github.com/containerd/containerd/pull/3755 Robust pid locking for shim processes
    - fixes https://github.com/containerd/containerd/issues/4023 [v1.2] regression in v1.2.12 leaves container/shim hanging


- Minor conflict in `container_test.go`, because https://github.com/containerd/containerd/pull/3743 and https://github.com/containerd/containerd/pull/3046 are not yet backported to the 1.2 branch
   - no real "conflict", but git having trouble finding a marker due to test of the above not being present
- Conflict in `runtime/v1/linux/proc/utils.go``, because files were renamed, and the `StoppedPID` const is in a different location;

```patch
++>>>>>>> a6b6097c9... Fix container pid.
diff --cc runtime/v1/linux/proc/utils.go
index 08fefdb3e,3c4661770..000000000
--- a/runtime/v1/linux/proc/utils.go
+++ b/runtime/v1/linux/proc/utils.go
@@@ -34,6 -36,13 +34,16 @@@ import
        "golang.org/x/sys/unix"
  )

++<<<<<<< HEAD:runtime/v1/linux/proc/utils.go
++=======
+ const (
+       // RuncRoot is the path to the root runc state directory
+       RuncRoot = "/run/containerd/runc"
+       // InitPidFile name of the file that contains the init pid
+       InitPidFile = "init.pid"
+ )
+
++>>>>>>> a6b6097c9... Fix container pid.:pkg/process/utils.go
  // safePid is a thread safe wrapper for pid.
  type safePid struct {
        sync.Mutex
```

Resolved by removing the `StoppedPID` const from `runtime/v1/linux/proc/process.go` instead of `pkg/process/utils.go`


Also had to make a small modification to the test, because https://github.com/containerd/containerd/pull/3417  is not in the 1.2 branch;

```patch
diff --git a/container_test.go b/container_test.go
index 2a0828f4c..aa04a31ad 100644
--- a/container_test.go
+++ b/container_test.go
@@ -1540,7 +1540,7 @@ func TestShortRunningTaskPid(t *testing.T) {

        var (
                image       Image
-               ctx, cancel = testContext(t)
+               ctx, cancel = testContext()
                id          = t.Name()
        )
        defer cancel()
```