### PR TITLE
[release/1.2] backport: Set octet-stream content-type on put request

### DIFF
--- a/remotes/docker/pusher.go
+++ b/remotes/docker/pusher.go
@@ -193,6 +193,7 @@ func (p dockerPusher) Push(ctx context.Context, desc ocispec.Descriptor) (conten
 	respC := make(chan *http.Response, 1)
 
 	req.Body = ioutil.NopCloser(pr)
+	req.Header.Set("Content-Type", "application/octet-stream")
 	req.ContentLength = desc.Size
 
 	go func() {


### PR DESCRIPTION
Backport #4017 to release/1.2.

Signed-off-by: Josh Dolitsky <393494+jdolitsky@users.noreply.github.com>