### PR TITLE
[release/1.2] Prepare v1.2.13 release

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,33 +1,90 @@
-Abhinandan Prativadi <abhi@docker.com> Abhinandan Prativadi <aprativadi@gmail.com>
-Abhinandan Prativadi <abhi@docker.com> abhi <abhi@docker.com>
-Akihiro Suda <suda.akihiro@lab.ntt.co.jp> Akihiro Suda <suda.kyoto@gmail.com>
-Andrei Vagin <avagin@virtuozzo.com> Andrei Vagin <avagin@openvz.org>
-Brent Baude <bbaude@redhat.com> baude <bbaude@redhat.com>
-Frank Yang <yyb196@gmail.com> frank yang <yyb196@gmail.com>
-Georgia Panoutsakopoulou <gpanoutsak@gmail.com> gpanouts <gpanoutsak@gmail.com>
-Jie Zhang <iamkadisi@163.com> kadisi <iamkadisi@163.com>
-John Howard <john.howard@microsoft.com> John Howard <jhoward@microsoft.com>
-Justin Terry <juterry@microsoft.com> Justin Terry (VM) <juterry@microsoft.com>
-Justin Terry <juterry@microsoft.com> Justin <jterry75@users.noreply.github.com>
-Kenfe-Mickaël Laventure <mickael.laventure@gmail.com> Kenfe-Mickael Laventure <mickael.laventure@gmail.com>
-Kevin Xu <cming.xu@gmail.com> kevin.xu <cming.xu@gmail.com>
-Lu Jingxiao <lujingxiao@huawei.com> l00397676 <lujingxiao@huawei.com>
-Lantao Liu <lantaol@google.com> Lantao Liu <taotaotheripper@gmail.com>
-Phil Estes <estesp@gmail.com> Phil Estes <estesp@linux.vnet.ibm.com>
-Stephen J Day <stevvooe@gmail.com> Stephen J Day <stephen.day@docker.com>
-Stephen J Day <stevvooe@gmail.com> Stephen Day <stevvooe@users.noreply.github.com>
-Stephen J Day <stevvooe@gmail.com> Stephen Day <stephen.day@getcruise.com>
-Sudeesh John <sudeesh@linux.vnet.ibm.com> sudeesh john <sudeesh@linux.vnet.ibm.com>
-Tõnis Tiigi <tonistiigi@gmail.com> Tonis Tiigi <tonistiigi@gmail.com>
-Lifubang <lifubang@aliyun.com> Lifubang <lifubang@acmcoder.com>
-Xiaodong Zhang <a4012017@sina.com> nashasha1 <a4012017@sina.com>
-Jian Liao <jliao@alauda.io> liaoj <jliao@alauda.io>
-Jian Liao <jliao@alauda.io> liaojian <liaojian@Dabllo.local>
-Rui Cao <ruicao@alauda.io> ruicao <ruicao@alauda.io>
-Xuean Yan <yan.xuean@zte.com.cn> yanxuean <yan.xuean@zte.com.cn>
-Mike Brown <brownwm@us.ibm.com> Mike Brown <mikebrow@users.noreply.github.com>
+Abhinandan Prativadi <abhi@docker.com>
+Abhinandan Prativadi <abhi@docker.com> <aprativadi@gmail.com>
 Ace-Tang <aceapril@126.com>
-Wei Fu <fuweid89@gmail.com>
-Andrey Kolomentsev <andrey.kolomentsev@gmail.com> akolomentsev <andrey.kolomentsev@gmail.com>
+Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp> <suda.akihiro@lab.ntt.co.jp>
+Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp> <suda.kyoto@gmail.com>
+Allen Sun <shlallen1990@gmail.com> <allensun@AllenSundeMacBook-Pro.local>
+Alexander Morozov <lk4d4math@gmail.com> <lk4d4@docker.com>
+Amit Krishnan <krish.amit@gmail.com> <amit.krishnan@oracle.com>
+Andrei Vagin <avagin@virtuozzo.com> <avagin@openvz.org>
+Andrey Kolomentsev <andrey.kolomentsev@gmail.com>
+Arnaud Porterie <icecrime@gmail.com>
+Arnaud Porterie <icecrime@gmail.com> <arnaud.porterie@docker.com>
+Bob Mader <swapdisk@users.noreply.github.com>
+Boris Popovschi <zyqsempai@mail.ru>
+Brent Baude <bbaude@redhat.com>
+Cao Zhihao <caozhihao@163.com>
+Cao Zhihao <caozhihao@163.com> <caozhihao.xd@bytedance.com>
+Carlos Eduardo <me@carlosedp.com> <me@carlosedp.com>
+Cristian Staretu <cristian.staretu@gmail.com>
+Cristian Staretu <cristian.staretu@gmail.com> <unclejack@users.noreply.github.com>
+Daniel Dao <dqminh89@gmail.com>
+Edgar Lee <edgarl@netflix.com> <edgar.lee@docker.com>
+Eric Ren <renzhen.rz@alibaba-linux.com> <renzhen.rz@alibaba-inc.com>
+Fahed Dorgaa <fahed.dorgaa@gmail.com>
+Frank Yang <yyb196@gmail.com>
+Fupan Li <lifupan@gmail.com>
+Georgia Panoutsakopoulou <gpanoutsak@gmail.com>
+Guangming Wang <guangming.wang@daocloud.io>
+Haiyan Meng <haiyanmeng@google.com>
+Harry Zhang <harryz@hyper.sh> <harryzhang@zju.edu.cn>
+Hu Shuai <hus.fnst@cn.fujitsu.com>
+Hu Shuai <hus.fnst@cn.fujitsu.com> <hushuaiia@qq.com>
+Jaana Burcu Dogan <burcujdogan@gmail.com> <jbd@golang.org>
+Jess Valarezo <valarezo.jessica@gmail.com>
+Jess Valarezo <valarezo.jessica@gmail.com> <jessica.valarezo@docker.com>
+Jian Liao <jliao@alauda.io>
+Jian Liao <jliao@alauda.io> <liaojian@Dabllo.local>
+Ji'an Liu <anthonyliu@zju.edu.cn>
+Jie Zhang <iamkadisi@163.com>
+John Howard <github@lowenna.com>
+John Howard <github@lowenna.com> <john.howard@microsoft.com>
+John Howard <github@lowenna.com> <jhoward@microsoft.com>
+John Howard <github@lowenna.com> <jhowardmsft@users.noreply.github.com>
+Luc Perkins <lucperkins@gmail.com>
+Julien Balestra <julien.balestra@datadoghq.com>
+Justin Cormack <justin.cormack@docker.com> <justin@specialbusservice.com>
+Justin Terry <juterry@microsoft.com>
+Justin Terry <juterry@microsoft.com> <jterry75@users.noreply.github.com>
+Kenfe-Mickaël Laventure <mickael.laventure@gmail.com>
+Kevin Kern <kaiwentan@harmonycloud.cn>
+Kevin Xu <cming.xu@gmail.com>
+Kohei Tokunaga <ktokunaga.mail@gmail.com>
+Krasi Georgiev <krasi.root@gmail.com> <krasi@vip-consult.solutions>
+Lantao Liu <lantaol@google.com>
+Lantao Liu <lantaol@google.com> <taotaotheripper@gmail.com>
+Lifubang <lifubang@aliyun.com> <lifubang@acmcoder.com>
+Lu Jingxiao <lujingxiao@huawei.com>
+Maksym Pavlenko <makpav@amazon.com> <pavlenko.maksym@gmail.com>
+Mario Hros <spam@k3a.me>
+Mario Hros <spam@k3a.me> <root@k3a.me>
 Mark Gordon <msg555@gmail.com>
+Michael Katsoulis <michaelkatsoulis88@gmail.com>
+Mike Brown <brownwm@us.ibm.com> <mikebrow@users.noreply.github.com>
+Nishchay Kumar <mrawesomenix@gmail.com>
+Oliver Stenbom <oliver@stenbom.eu> <ostenbom@pivotal.io>
+Phil Estes <estesp@gmail.com> <estesp@linux.vnet.ibm.com>
 Reid Li <reid.li@utexas.edu>
+Ross Boucher <rboucher@gmail.com>
+Ruediger Maass <ruediger.maass@de.ibm.com>
+Rui Cao <ruicao@alauda.io> <ruicao@alauda.io>
+Sakeven Jiang <jc5930@sina.cn>
+Seth Pellegrino <spellegrino@newrelic.com> <30441101+sethp-nr@users.noreply.github.com>
+Shengbo Song <thomassong@tencent.com>
+Stephen J Day <stevvooe@gmail.com> <stephen.day@getcruise.com>
+Stephen J Day <stevvooe@gmail.com> <stevvooe@users.noreply.github.com>
+Stephen J Day <stevvooe@gmail.com> <stephen.day@docker.com>
+Sudeesh John <sudeesh@linux.vnet.ibm.com>
+Su Fei  <fesu@ebay.com> <fesu@ebay.com>
+Tõnis Tiigi <tonistiigi@gmail.com>
+Wei Fu <fuweid89@gmail.com> <fhfuwei@163.com>
+Xiaodong Zhang <a4012017@sina.com>
+Xuean Yan <yan.xuean@zte.com.cn>
+Yue Zhang <zy675793960@yeah.net>
+Yuxing Liu <starnop@163.com>
+Zhang Wei <zhangwei555@huawei.com>
+Zhenguang Zhu <zhengguang.zhu@daocloud.io>
+Zhongming Chang<zhongming.chang@daocloud.io>
+Zhoulin Xie <zhoulin.xie@daocloud.io>
+Zhoulin Xie <zhoulin.xie@daocloud.io> <42261994+JoeWrightss@users.noreply.github.com>
+张潇 <xiaozhang0210@hotmail.com>

--- a/releases/v1.2.13.toml
+++ b/releases/v1.2.13.toml
@@ -1,0 +1,31 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release
+previous = "v1.2.12"
+
+pre_release = false
+
+preface = """\
+The thirteenth patch release for `containerd` 1.2 fixes a regression introduced
+in v1.2.12 that caused container/shim to hang on single core machines, fixes an
+issue with blkio, and updates the Golang runtime to 1.12.17.
+
+### Notable Updates
+
+* Fix container pid race condition [containerd#4025](https://github.com/containerd/containerd/pull/4025)
+* Update containerd/cgroups dependency to address blkio issue [containerd#4001](https://github.com/containerd/containerd/pull/4001)
+* Set octet-stream content-type on PUT request [containerd#4028](https://github.com/containerd/containerd/pull/4028)
+* Pin to libseccomp 2.3.3 to preserve compatibility with hosts that do not have libseccomp 2.4 or higher installed [containerd#4015](https://github.com/containerd/containerd/pull/4015)
+* Update Golang runtime to 1.12.17, which includes a fix to the runtime [containerd#4031](https://github.com/containerd/containerd/pull/4031)
+
+"""
+
+# notable prs to include in the release notes, 1234 is the pr number
+[notes]
+
+[breaking]

--- a/version/version.go
+++ b/version/version.go
@@ -21,7 +21,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.2.12+unknown"
+	Version = "1.2.13+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
depends on:

- [x] https://github.com/containerd/containerd/pull/4025 [release/1.2 backport] Fix container pid race condition
- [x] https://github.com/containerd/containerd/pull/4001 [release/1.2] bump cgroups dependency to address blkio issue
- [x] https://github.com/containerd/containerd/pull/4028 [release/1.2] backport: Set octet-stream content-type on put request
- [x] https://github.com/containerd/containerd/pull/4015 [release/1.2 backport] Pin to libseccomp 2.3.3
- [x] https://github.com/containerd/containerd/pull/4031 [release/1.2 backport] Update Golang 1.12.17


The thirteenth patch release for `containerd` 1.2 fixes a regression introduced
in v1.2.12 that caused container/shim to hang on single core machines, fixes an
issue with blkio, and updates the Golang runtime to 1.12.17.

Notable Updates
----------------------------------

* Fix container pid race condition [containerd#4025](https://github.com/containerd/containerd/pull/4025)
* Update containerd/cgroups dependency to address blkio issue [containerd#4001](https://github.com/containerd/containerd/pull/4001)
* Set octet-stream content-type on PUT request [containerd#4028](https://github.com/containerd/containerd/pull/4028)
* Pin to libseccomp 2.3.3 to preserve compatibility with hosts that do not have libseccomp 2.4 or up installed [containerd#4015](https://github.com/containerd/containerd/pull/4015)
* Update Golang runtime to 1.12.17, which includes a fix to the runtime [contrainerd#4031](https://github.com/containerd/containerd/pull/4031)
