### PR TITLE
[release/1.3 backport] script: use github.com/kubernetes-sigs/cri-tools directly

### DIFF
--- a/script/setup/install-critools
+++ b/script/setup/install-critools
@@ -22,8 +22,8 @@ set -eu -o pipefail
 
 go get -u github.com/onsi/ginkgo/ginkgo
 CRITEST_COMMIT=v1.16.1
-go get -d github.com/kubernetes-incubator/cri-tools/...
-cd $GOPATH/src/github.com/kubernetes-incubator/cri-tools
+go get -d github.com/kubernetes-sigs/cri-tools/...
+cd "$GOPATH"/src/github.com/kubernetes-sigs/cri-tools
 git checkout $CRITEST_COMMIT
 make
 make install


### PR DESCRIPTION
When we call `go get -d -v
github.com/kubernetes-incubator/cri-tools/...` which repos has been
moved to `github.com/kubernetes-sigs/cri-tools`, `go get` will create
package `github.com/kubernetes-sigs/cri-tools`.

```
go get -d -v github.com/kubernetes-incubator/cri-tools/...
github.com/kubernetes-incubator/cri-tools (download)
github.com/kubernetes-sigs/cri-tools (download)
```

According to old version of `github.com/kubernetes-incubator/cri-tools`
Makefile, if there is no `github.com/kubernetes-sigs/cri-tools` package,
it will create softlink self to `github.com/kubernetes-sigs/cri-tools`.
But `go get` will create `github.com/kubernetes-sigs/cri-tools` and
there is no softlink. Therefore, the critools are always latest one, not
specific version.

So, use `github.com/kubernetes-sigs/cri-tools` will be better and save
traffic from `go get`.

Signed-off-by: Wei Fu <fuweid89@gmail.com>
(cherry picked from commit 246a560edb19ef9220bb452d0a3c82c7770213fb)
Signed-off-by: Wei Fu <fuweid89@gmail.com>

from #4034