### PR TITLE
Fix auth token HTTP request not containing username in "account" GET parameter

### DIFF
--- a/remotes/docker/authorizer.go
+++ b/remotes/docker/authorizer.go
@@ -421,6 +421,7 @@ func (ah *authHandler) fetchToken(ctx context.Context, to tokenOptions) (string,
 
 	if to.secret != "" {
 		req.SetBasicAuth(to.username, to.secret)
+		reqParams.Add("account", to.username)
 	}
 
 	req.URL.RawQuery = reqParams.Encode()


### PR DESCRIPTION
When pushing a multi-arch image to a private registry that is attached to authentication frontends like [Portus](https://github.com/SUSE/Portus) or monitoring tools like [registry-web-ui](https://github.com/Quiq/docker-registry-ui), it is necessary to add the username to the URL parameters of the digest token request.

This is because if the `account` parameter is not present, the JWT access token issued will contain an empty `sub` field. When the registry then generates a notification for the frontend, the frontend cant correlate any user because the `actor` field is empty.

The regular `docker push` does this correctly, however (and thats how I found this bug) [Docker BuildX](https://github.com/docker/buildx) does not do this when pushing a multi-arch image. This is because buildx uses containerd via [buildkit](https://github.com/moby/buildkit).

This pull requests adds the required parameter to the token request URL. Also see the discovery of this bug: https://github.com/docker/buildx/issues/177

Signed-off-by: Christoph Honal <christoph.honal@web.de>