### PR TITLE
vendor: golang.org/x/crypto 1d94cc7ab1c630336ab82ccb9c9cda72a875c382

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -70,7 +70,7 @@ github.com/opencontainers/selinux                   5215b1806f52b1fcc2070a8826c5
 github.com/seccomp/libseccomp-golang                689e3c1541a84461afc49c1c87352a6cedf72e9c # v0.9.1
 github.com/stretchr/testify                         221dbe5ed46703ee255b1da0dec05086f5035f62 # v1.4.0
 github.com/tchap/go-patricia                        666120de432aea38ab06bd5c818f04f4129882c9 # v2.2.6
-golang.org/x/crypto                                 69ecbb4d6d5dab05e49161c6e77ea40a030884e1
+golang.org/x/crypto                                 1d94cc7ab1c630336ab82ccb9c9cda72a875c382
 golang.org/x/oauth2                                 0f29369cfe4552d0e4bcddc57cc75f4d7e672a33
 golang.org/x/time                                   9d24e82272b4f38b78bc8cff74fa936d31ccd8ef
 gopkg.in/inf.v0                                     d2d2541c53f18d2a059457998ce2876cc8e67cbf # v0.9.1


### PR DESCRIPTION
related PR in containerd/cri: https://github.com/containerd/cri/pull/1402

full diff: https://github.com/golang/crypto/compare/69ecbb4d6d5dab05e49161c6e77ea40a030884e1...1d94cc7ab1c630336ab82ccb9c9cda72a875c382

I'm doing a around across repositories to update in preparation of a security release that was announced for tomorrow (so that we can update again with just the changes related to that fix);

https://groups.google.com/d/msgid/golang-announce/CA%2B2K_Kox3xkjj6gWkp%3DY6fmp7sO4T%2BbgudjjZZ%3Duwgp476pmEw%40mail.gmail.com
