### PR TITLE
Enable CRI plugin for Windows builds as well

### DIFF
--- a/cmd/containerd/builtins_cri.go
+++ b/cmd/containerd/builtins_cri.go
@@ -1,3 +1,4 @@
+// +build linux windows
 // +build !no_cri
 
 /*


### PR DESCRIPTION
The builtins_cri_linux.go file only being included for _linux builds which
means that the builds for Windows do not contain the CRI plugin. This can
be disabled for either platform with the no_cri tag.

Signed-off-by: Justin Terry (SF) <juterry@microsoft.com>