### PR TITLE
cleanup the image synchronously for Usage case

### DIFF
--- a/image_test.go
+++ b/image_test.go
@@ -151,7 +151,7 @@ func TestImageUsage(t *testing.T) {
 	defer client.Close()
 
 	// Cleanup
-	err = client.ImageService().Delete(ctx, imageName)
+	err = client.ImageService().Delete(ctx, imageName, images.SynchronousDelete())
 	if err != nil && !errdefs.IsNotFound(err) {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
TestImageIsUnpacked will unpacked docker.io/library/busybox:latest with
linux/amd64 platform. If the TestImageUsage doesn't wait for cleanup
finish (snapshotter is cleanup by gc asynchronously) and fetch image,
the Usage(ctx) will get 10767844 bytes(manifestUsage + snapshotUsage).

However, the manifestUsage is 9466142 bytes. That is why we got the
error:

```
Expected actual usage to equal manifest reported usage of 9466142:
got 10767844
```

This commit is to make sure that the image has been cleanup fully.

Signed-off-by: Wei Fu <fuweid89@gmail.com>