### PR TITLE
[release/1.2 backport] bugfix: cleanup dangling shim by brand new context

### DIFF
--- a/runtime/v1/linux/runtime.go
+++ b/runtime/v1/linux/runtime.go
@@ -63,6 +63,9 @@ const (
 	configFilename = "config.json"
 	defaultRuntime = "runc"
 	defaultShim    = "containerd-shim"
+
+	// cleanupTimeout is default timeout for cleanup operations
+	cleanupTimeout = 1 * time.Minute
 )
 
 func init() {
@@ -218,7 +221,10 @@ func (r *Runtime) Create(ctx context.Context, id string, opts runtime.CreateOpts
 	}
 	defer func() {
 		if err != nil {
-			if kerr := s.KillShim(ctx); kerr != nil {
+			deferCtx, deferCancel := context.WithTimeout(
+				namespaces.WithNamespace(context.TODO(), namespace), cleanupTimeout)
+			defer deferCancel()
+			if kerr := s.KillShim(deferCtx); kerr != nil {
 				log.G(ctx).WithError(err).Error("failed to kill shim")
 			}
 		}


### PR DESCRIPTION
When there is timeout or cancel for create container, killShim will fail
because of canceled context. The shim will be dangling and unmanageable.

Need to use new context to do cleanup.

Signed-off-by: Wei Fu <fuweid89@gmail.com>
(cherry picked from commit 18e581dd91fd671aaeba86dcae2b6c97142a1cb0)
Signed-off-by: Wei Fu <fuweid89@gmail.com>

from #4052 