### PR TITLE
Check error return from json.Unmarshal

### DIFF
--- a/runtime/v1/shim/service.go
+++ b/runtime/v1/shim/service.go
@@ -521,10 +521,7 @@ func (s *Service) checkProcesses(e runc.Exit) {
 		}
 
 		if ip, ok := p.(*process.Init); ok {
-			shouldKillAll, err := shouldKillAllOnExit(s.bundle)
-			if err != nil {
-				log.G(s.context).WithError(err).Error("failed to check shouldKillAll")
-			}
+			shouldKillAll := shouldKillAllOnExit(s.context, s.bundle)
 
 			// Ensure all children are killed
 			if shouldKillAll {
@@ -547,23 +544,27 @@ func (s *Service) checkProcesses(e runc.Exit) {
 	}
 }
 
-func shouldKillAllOnExit(bundlePath string) (bool, error) {
+func shouldKillAllOnExit(ctx context.Context, bundlePath string) bool {
 	var bundleSpec specs.Spec
 	bundleConfigContents, err := ioutil.ReadFile(filepath.Join(bundlePath, "config.json"))
 	if err != nil {
-		return false, err
+		log.G(ctx).WithError(err).Error("failed to check shouldKillAll")
+		return true
 	}
-	json.Unmarshal(bundleConfigContents, &bundleSpec)
+	if err := json.Unmarshal(bundleConfigContents, &bundleSpec); err != nil {
+		log.G(ctx).WithError(err).Error("failed to check shouldKillAll")
+		return true
+	}
 
 	if bundleSpec.Linux != nil {
 		for _, ns := range bundleSpec.Linux.Namespaces {
 			if ns.Type == specs.PIDNamespace && ns.Path == "" {
-				return false, nil
+				return false
 			}
 		}
 	}
 
-	return true, nil
+	return true
 }
 
 func (s *Service) getContainerPids(ctx context.Context, id string) ([]uint32, error) {

--- a/runtime/v2/runc/v2/service.go
+++ b/runtime/v2/runc/v2/service.go
@@ -701,7 +701,7 @@ func (s *service) checkProcesses(e runcC.Exit) {
 			}
 
 			if ip, ok := p.(*process.Init); ok {
-				shouldKillAll, err := shouldKillAllOnExit(container.Bundle)
+				shouldKillAll, err := shouldKillAllOnExit(s.context, container.Bundle)
 				if err != nil {
 					log.G(s.context).WithError(err).Error("failed to check shouldKillAll")
 				}
@@ -729,13 +729,17 @@ func (s *service) checkProcesses(e runcC.Exit) {
 	}
 }
 
-func shouldKillAllOnExit(bundlePath string) (bool, error) {
+func shouldKillAllOnExit(ctx context.Context, bundlePath string) (bool, error) {
 	var bundleSpec specs.Spec
 	bundleConfigContents, err := ioutil.ReadFile(filepath.Join(bundlePath, "config.json"))
 	if err != nil {
-		return false, err
+		log.G(ctx).WithError(err).Error("failed to check shouldKillAllOnExit")
+		return true, nil
 	}
-	json.Unmarshal(bundleConfigContents, &bundleSpec)
+	if err := json.Unmarshal(bundleConfigContents, &bundleSpec); err != nil {
+		log.G(ctx).WithError(err).Error("failed to check shouldKillAllOnExit")
+		return true, nil
+	}
 
 	if bundleSpec.Linux != nil {
 		for _, ns := range bundleSpec.Linux.Namespaces {


### PR DESCRIPTION
In shouldKillAllOnExit(), we should check the error return from json.Unmarshal before dereferencing bundleSpec.Linux