### PR TITLE
[release/1.2 backport] Update to Golang 1.13.8

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.13.5
+    - GO_VERSION: 1.13.6
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.13.4
+    - GO_VERSION: 1.13.5
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.13.6
+    - GO_VERSION: 1.13.7
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.13.7
+    - GO_VERSION: 1.13.8
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.12.14
+    - GO_VERSION: 1.12.13
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.12.16
+    - GO_VERSION: 1.12.15
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.12.13
+    - GO_VERSION: 1.13.4
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.12.17
+    - GO_VERSION: 1.12.16
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.12.15
+    - GO_VERSION: 1.12.14
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 language: go
 
 go:
-  - "1.12.15"
+  - "1.12.14"
 os:
   - "linux"
   # TODO ppc64le is currently timing out on travis; see https://github.com/containerd/containerd/pull/2896

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 language: go
 
 go:
-  - "1.12.16"
+  - "1.12.15"
 os:
   - "linux"
   # TODO ppc64le is currently timing out on travis; see https://github.com/containerd/containerd/pull/2896

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 language: go
 
 go:
-  - "1.13.5"
+  - "1.13.6"
 os:
   - "linux"
   # TODO ppc64le is currently timing out on travis; see https://github.com/containerd/containerd/pull/2896

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 language: go
 
 go:
-  - "1.13.4"
+  - "1.13.5"
 os:
   - "linux"
   # TODO ppc64le is currently timing out on travis; see https://github.com/containerd/containerd/pull/2896

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 language: go
 
 go:
-  - "1.13.7"
+  - "1.13.8"
 os:
   - "linux"
   # TODO ppc64le is currently timing out on travis; see https://github.com/containerd/containerd/pull/2896

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 language: go
 
 go:
-  - "1.12.14"
+  - "1.12.13"
 os:
   - "linux"
   # TODO ppc64le is currently timing out on travis; see https://github.com/containerd/containerd/pull/2896

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 language: go
 
 go:
-  - "1.12.17"
+  - "1.12.16"
 os:
   - "linux"
   # TODO ppc64le is currently timing out on travis; see https://github.com/containerd/containerd/pull/2896

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 language: go
 
 go:
-  - "1.12.13"
+  - "1.13.4"
 os:
   - "linux"
   # TODO ppc64le is currently timing out on travis; see https://github.com/containerd/containerd/pull/2896
@@ -16,7 +16,7 @@ os:
 matrix:
   include:
     - os: "linux"
-      env: TRAVIS_GOOS=darwin TRAVIS_CGO_ENABLED=0
+      env: TRAVIS_GOOS=darwin TRAVIS_CGO_ENABLED=0 GOPROXY=direct
 
 go_import_path: github.com/containerd/containerd
 
@@ -36,8 +36,8 @@ addons:
       - socat
 
 env:
-  - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1
-  - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runtime.v1.linux TRAVIS_CGO_ENABLED=1
+  - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 GOPROXY=direct
+  - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runtime.v1.linux TRAVIS_CGO_ENABLED=1 GOPROXY=direct
 
 before_install:
   - uname -r
@@ -69,7 +69,7 @@ script:
   - DCO_VERBOSITY=-q ../project/script/validate/dco
   - ../project/script/validate/fileheader ../project/
   - travis_wait ../project/script/validate/vendor
-  - GOOS=linux script/setup/install-dev-tools
+  - GOOS=linux GO111MODULE=off script/setup/install-dev-tools
   - go build -i .
   - make check
   - if [ "$GOOS" = "linux" ]; then make check-protos check-api-descriptors; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 language: go
 
 go:
-  - "1.13.6"
+  - "1.13.7"
 os:
   - "linux"
   # TODO ppc64le is currently timing out on travis; see https://github.com/containerd/containerd/pull/2896

--- a/client_test.go
+++ b/client_test.go
@@ -52,7 +52,6 @@ func init() {
 	flag.StringVar(&address, "address", defaultAddress, "The address to the containerd socket for use in the tests")
 	flag.BoolVar(&noDaemon, "no-daemon", false, "Do not start a dedicated daemon for the tests")
 	flag.BoolVar(&noCriu, "no-criu", false, "Do not run the checkpoint tests")
-	flag.Parse()
 }
 
 func testContext() (context.Context, context.CancelFunc) {
@@ -62,6 +61,7 @@ func testContext() (context.Context, context.CancelFunc) {
 }
 
 func TestMain(m *testing.M) {
+	flag.Parse()
 	if testing.Short() {
 		os.Exit(m.Run())
 	}

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.13.6
+ARG GOLANG_VERSION=1.13.7
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.13.5
+ARG GOLANG_VERSION=1.13.6
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.13.7
+ARG GOLANG_VERSION=1.13.8
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.12.16
+ARG GOLANG_VERSION=1.12.15
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.12.15
+ARG GOLANG_VERSION=1.12.14
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.12.17
+ARG GOLANG_VERSION=1.12.16
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.12.14
+ARG GOLANG_VERSION=1.12.13
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.12.13
+ARG GOLANG_VERSION=1.13.4
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd
@@ -34,6 +34,8 @@ RUN apt-get update && apt-get install -y \
 
 COPY vendor.conf vendor.conf
 COPY script/setup/install-runc install-runc
+ARG GOPROXY=direct
+ARG GO111MODULE=off
 RUN ./install-runc
 
 FROM golang-base AS dev

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.13.4
+ARG GOLANG_VERSION=1.13.5
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd

--- a/platforms/database.go
+++ b/platforms/database.go
@@ -38,7 +38,7 @@ func isLinuxOS(os string) bool {
 // The OS value should be normalized before calling this function.
 func isKnownOS(os string) bool {
 	switch os {
-	case "android", "darwin", "dragonfly", "freebsd", "linux", "nacl", "netbsd", "openbsd", "plan9", "solaris", "windows", "zos":
+	case "aix", "android", "darwin", "dragonfly", "freebsd", "hurd", "illumos", "js", "linux", "nacl", "netbsd", "openbsd", "plan9", "solaris", "windows", "zos":
 		return true
 	}
 	return false
@@ -60,7 +60,7 @@ func isArmArch(arch string) bool {
 // The arch value should be normalized before being passed to this function.
 func isKnownArch(arch string) bool {
 	switch arch {
-	case "386", "amd64", "amd64p32", "arm", "armbe", "arm64", "arm64be", "ppc64", "ppc64le", "mips", "mipsle", "mips64", "mips64le", "mips64p32", "mips64p32le", "ppc", "s390", "s390x", "sparc", "sparc64":
+	case "386", "amd64", "amd64p32", "arm", "armbe", "arm64", "arm64be", "ppc64", "ppc64le", "mips", "mipsle", "mips64", "mips64le", "mips64p32", "mips64p32le", "ppc", "riscv", "riscv64", "s390", "s390x", "sparc", "sparc64", "wasm":
 		return true
 	}
 	return false


### PR DESCRIPTION
~based on top of https://github.com/containerd/containerd/pull/4061~ (merged)

Go 1.14 has been released, which means that Go 1.12 reached EOL, so updating supported branches to Go 1.13

This pull request backports updates to Golang 1.13 and related changes.

I first reverted the intermediate 1.12.x updates in the branch, then cherry-picked
each bump from master; doing so to preserve the commit message from those, and
to make sure we didn't miss changes associated with each Go update.

Updates to `travis.yml` in this branch don't apply cleanly due to travis.yml being
refactored on master; for those I applied the equivalent changes, but keeping the
original commit message.

backports of:

- https://github.com/containerd/containerd/pull/3744 Move flag.Parse in tests to TestMain
- https://github.com/containerd/containerd/pull/3624 platforms: update known OS and arch values
- revert https://github.com/containerd/containerd/pull/4031 [release/1.2 backport] Update Golang 1.12.17
- revert golang bump from https://github.com/containerd/containerd/pull/3988 [release/1.2] Update Golang 1.12.16, x/crypto (CVE-2020-0601, CVE-2020-7919)
- revert https://github.com/containerd/containerd/pull/3968 [release/1.2 backport] Update Golang 1.12.15
- revert https://github.com/containerd/containerd/pull/3918 [release/1.2 backport] Update Golang 1.12.14
- https://github.com/containerd/containerd/pull/3620 Update to Golang 1.13.4
- https://github.com/containerd/containerd/pull/3916 Bump golang 1.13.5
    - only first commit
- https://github.com/containerd/containerd/pull/3969 Update Golang 1.13.6
- https://github.com/containerd/containerd/pull/3987 Update Golang 1.13.7, x/crypto (CVE-2020-0601, CVE-2020-7919)
    - only first commit: second commit was already part of https://github.com/containerd/containerd/pull/3988
- https://github.com/containerd/containerd/pull/4032 Update Golang 1.13.8

Cherry-picks done;

<details>

```bash
# https://github.com/containerd/containerd/pull/3744 Move flag.Parse in tests to TestMain
git cherry-pick -s -S -x d5b7bf51aa7dc6217fea04e3e3b6e43289a25746

# https://github.com/containerd/containerd/pull/3624 platforms: update known OS and arch values
git cherry-pick -s -S -x c8cb864ce026316e68a149be9fbcdb0c68afab9d

# revert https://github.com/containerd/containerd/pull/4031 [release/1.2 backport] Update Golang 1.12.17
git revert -s -S 2a0ca2d077f2a792e5752c1513e706a7bb00ed0e

# revert golang bump from https://github.com/containerd/containerd/pull/3988 [release/1.2] Update Golang 1.12.16, x/crypto (CVE-2020-0601, CVE-2020-7919)
git revert -s -S 44b5bac0c08a0b296cd4e16f0055187b0dfb00d7

# revert https://github.com/containerd/containerd/pull/3968 [release/1.2 backport] Update Golang 1.12.15
git revert -s -S f106ae4ab5815564d8a0c8b7e738d5f44896caf8

# revert https://github.com/containerd/containerd/pull/3918 [release/1.2 backport] Update Golang 1.12.14
git revert -s -S e7b06baa68ff3554c4dc08e8d29b776698cce9ad

# https://github.com/containerd/containerd/pull/3620 Update to Golang 1.13.4
git cherry-pick -s -S -x 608791bfc34ead497cdae9851a572fc78552a864

# https://github.com/containerd/containerd/pull/3916 Bump golang 1.13.5
git cherry-pick -s -S -x c07e356d293895fa52f7dd215922861291d3d799

# https://github.com/containerd/containerd/pull/3969 Update Golang 1.13.6
git cherry-pick -s -S -x 94964b36d0248257743615a5e3bff0bea301d55c

# https://github.com/containerd/containerd/pull/3987 Update Golang 1.13.7, x/crypto (CVE-2020-0601, CVE-2020-7919)
git cherry-pick -s -S -x 32ba75f0fbfe47ad94e7c7daccc9f31efd0b2db2

# https://github.com/containerd/containerd/pull/4032 Update Golang 1.13.8
git cherry-pick -s -S -x 499ab8a99ad489fb911557f4ea7ffd33173ed65b
```

</details>
