### PR TITLE
[release/1.3 backport] fix killall when use pidnamespace

### DIFF
--- a/runtime/v2/runc/v1/service.go
+++ b/runtime/v2/runc/v1/service.go
@@ -623,7 +623,7 @@ func shouldKillAllOnExit(bundlePath string) (bool, error) {
 
 	if bundleSpec.Linux != nil {
 		for _, ns := range bundleSpec.Linux.Namespaces {
-			if ns.Type == specs.PIDNamespace {
+			if ns.Type == specs.PIDNamespace && ns.Path == "" {
 				return false, nil
 			}
 		}


### PR DESCRIPTION
backport of https://github.com/containerd/containerd/pull/4063, which was a follow-up to https://github.com/containerd/containerd/pull/3149. (relates to https://github.com/moby/moby/issues/38978) 