### PR TITLE
AppVeyor: disable download progress on choco installs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,13 +16,13 @@ environment:
     - GO_VERSION: 1.13.8
 
 before_build:
-  - choco install -y mingw --version 5.3.0
+  - choco install --no-progress -y mingw --version 5.3.0
   # Install Go
   - rd C:\Go /s /q
   - appveyor DownloadFile https://storage.googleapis.com/golang/go%GO_VERSION%.windows-amd64.zip
   - 7z x go%GO_VERSION%.windows-amd64.zip -oC:\ >nul
   - go version
-  - choco install codecov
+  - choco install --no-progress codecov
   # Clone hcsshim at the vendored version
   - bash.exe -elc "export PATH=/c/tools/mingw64/bin:$PATH;
        rm -rf /c/gopath/src/github.com/Microsoft/hcsshim;


### PR DESCRIPTION
Downloading packages is quite noisy in the logs. This patch disables
the download progress output, which should save +/- 4000 lines of
output;

```
[00:00:15] Progress: Downloading mingw 5.3.0... 12%
[00:00:15] Progress: Downloading mingw 5.3.0... 35%
[00:00:15] Progress: Downloading mingw 5.3.0... 58%
[00:00:15] Progress: Downloading mingw 5.3.0... 82%
[00:00:15] Progress: Downloading mingw 5.3.0... 100%
[00:00:15] 
[00:00:15] mingw v5.3.0 [Approved]
[00:00:15] mingw package files install completed. Performing other installation steps.
[00:00:17] Get-BinRoot is going to be deprecated in v1 and removed in v2. It has been replaced with Get-ToolsLocation (starting with v0.9.10), however many packages no longer require a special separate directory since package folders no longer have versions on them. Some do though and should continue to use Get-ToolsLocation.
[00:00:18] WARNING: Url has SSL/TLS available, switching to HTTPS for download
[00:00:19] Downloading mingw 
[00:00:19]   from 'https://downloads.sourceforge.net/mingw-w64/x86_64-5.3.0-release-posix-seh-rt_v4-rev0.7z'
[00:00:20] 
[00:00:20] Progress: 0% - Saving 160 KB of 43.95 MB
[00:00:20] Progress: 0% - Saving 320 KB of 43.95 MB
[00:00:20] Progress: 1% - Saving 480 KB of 43.95 MB
[00:00:20] Progress: 1% - Saving 640 KB of 43.95 MB
[00:00:20] Progress: 1% - Saving 800 KB of 43.95 MB
[00:00:20] Progress: 2% - Saving 960 KB of 43.95 MB
```