### PR TITLE
[release/1.2 backport] Ensure close in content test

### DIFF
--- a/content/local/store.go
+++ b/content/local/store.go
@@ -34,7 +34,6 @@ import (
 	"github.com/containerd/containerd/filters"
 	"github.com/containerd/containerd/log"
 
-	"github.com/containerd/continuity"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -651,6 +650,19 @@ func writeTimestampFile(p string, t time.Time) error {
 	if err != nil {
 		return err
 	}
+	return atomicWrite(p, b, 0666)
+}
 
-	return continuity.AtomicWriteFile(p, b, 0666)
+func atomicWrite(path string, data []byte, mode os.FileMode) error {
+	tmp := fmt.Sprintf("%s.tmp", path)
+	f, err := os.OpenFile(tmp, os.O_RDWR|os.O_CREATE|os.O_TRUNC|os.O_SYNC, mode)
+	if err != nil {
+		return errors.Wrap(err, "create tmp file")
+	}
+	_, err = f.Write(data)
+	f.Close()
+	if err != nil {
+		return errors.Wrap(err, "write atomic data")
+	}
+	return os.Rename(tmp, path)
 }

--- a/content/testsuite/testsuite.go
+++ b/content/testsuite/testsuite.go
@@ -322,7 +322,7 @@ func checkRefNotAvailable(ctx context.Context, t *testing.T, cs content.Store, r
 
 	w, err := cs.Writer(ctx, content.WithRef(ref))
 	if err == nil {
-		w.Close()
+		defer w.Close()
 		t.Fatal("writer created with ref, expected to be in use")
 	}
 	if !errdefs.IsUnavailable(err) {
@@ -386,6 +386,7 @@ func checkCommitErrorState(ctx context.Context, t *testing.T, cs content.Store) 
 		}
 		t.Fatalf("Unexpected error: %+v", err)
 	}
+	w.Close()
 
 	w, err = cs.Writer(ctx, content.WithRef(ref))
 	if err != nil {
@@ -409,6 +410,7 @@ func checkCommitErrorState(ctx context.Context, t *testing.T, cs content.Store) 
 		t.Errorf("Unexpected error: %+v", err)
 	}
 
+	w.Close()
 	w, err = cs.Writer(ctx, content.WithRef(ref))
 	if err != nil {
 		t.Fatal(err)
@@ -424,6 +426,7 @@ func checkCommitErrorState(ctx context.Context, t *testing.T, cs content.Store) 
 		t.Errorf("Unexpected error: %+v", err)
 	}
 
+	w.Close()
 	w, err = cs.Writer(ctx, content.WithRef(ref))
 	if err != nil {
 		t.Fatal(err)
@@ -439,6 +442,7 @@ func checkCommitErrorState(ctx context.Context, t *testing.T, cs content.Store) 
 		t.Fatalf("Failed to commit: %+v", err)
 	}
 
+	w.Close()
 	// Create another writer with same reference
 	w, err = cs.Writer(ctx, content.WithRef(ref))
 	if err != nil {
@@ -465,6 +469,7 @@ func checkCommitErrorState(ctx context.Context, t *testing.T, cs content.Store) 
 		t.Fatalf("Unexpected error: %+v", err)
 	}
 
+	w.Close()
 	w, err = cs.Writer(ctx, content.WithRef(ref))
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
backport of https://github.com/containerd/containerd/pull/3324
hopefully addresses https://github.com/containerd/containerd/issues/3701 for the 1.2 branch