### PR TITLE
[release/1.3 backport] Update to Golang 1.13.8

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.13.5
+    - GO_VERSION: 1.13.6
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.13.4
+    - GO_VERSION: 1.13.5
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.13.6
+    - GO_VERSION: 1.13.7
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.13.7
+    - GO_VERSION: 1.13.8
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.12.14
+    - GO_VERSION: 1.12.13
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.12.16
+    - GO_VERSION: 1.12.15
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.12.13
+    - GO_VERSION: 1.13.4
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.12.17
+    - GO_VERSION: 1.12.16
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.12.15
+    - GO_VERSION: 1.12.14
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
 - linux
 
 go:
-  - "1.13.6"
+  - "1.13.7"
 
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
 - linux
 
 go:
-  - "1.13.5"
+  - "1.13.6"
 
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
 - linux
 
 go:
-  - "1.13.7"
+  - "1.13.8"
 
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
 - linux
 
 go:
-  - "1.12.17"
+  - "1.12.16"
 
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
 - linux
 
 go:
-  - "1.12.16"
+  - "1.12.15"
 
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
 - linux
 
 go:
-  - "1.12.15"
+  - "1.12.14"
 
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
 - linux
 
 go:
-  - "1.13.4"
+  - "1.13.5"
 
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
 - linux
 
 go:
-  - "1.12.14"
+  - "1.12.13"
 
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,13 @@ os:
 - linux
 
 go:
-  - "1.12.13"
+  - "1.13.4"
 
 env:
-  - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic
-  - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v2 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic TRAVIS_RELEASE=yes
-  - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runtime.v1.linux TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic
-  - TRAVIS_GOOS=darwin TRAVIS_CGO_ENABLED=0
+  - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct
+  - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v2 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic TRAVIS_RELEASE=yes GOPROXY=direct
+  - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runtime.v1.linux TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct
+  - TRAVIS_GOOS=darwin TRAVIS_CGO_ENABLED=0 GOPROXY=direct
 
 matrix:
   include:
@@ -24,7 +24,7 @@ matrix:
     - if: type != pull_request
       os: linux
       dist: xenial
-      env: TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v2 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=xenial
+      env: TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v2 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=xenial GOPROXY=direct
 
 go_import_path: github.com/containerd/containerd
 
@@ -73,7 +73,7 @@ script:
   - DCO_VERBOSITY=-q ../project/script/validate/dco
   - ../project/script/validate/fileheader ../project/
   - travis_wait ../project/script/validate/vendor
-  - GOOS=linux script/setup/install-dev-tools
+  - GOOS=linux GO111MODULE=off script/setup/install-dev-tools
   - go build -i .
   - make check
   - if [ "$GOOS" = "linux" ]; then make check-protos check-api-descriptors; fi

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.13.6
+ARG GOLANG_VERSION=1.13.7
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.13.5
+ARG GOLANG_VERSION=1.13.6
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.13.7
+ARG GOLANG_VERSION=1.13.8
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.12.16
+ARG GOLANG_VERSION=1.12.15
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.12.15
+ARG GOLANG_VERSION=1.12.14
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.12.17
+ARG GOLANG_VERSION=1.12.16
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.12.14
+ARG GOLANG_VERSION=1.12.13
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.12.13
+ARG GOLANG_VERSION=1.13.4
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd
@@ -34,6 +34,8 @@ RUN apt-get update && apt-get install -y \
 
 COPY vendor.conf vendor.conf
 COPY script/setup/install-runc install-runc
+ARG GOPROXY=direct
+ARG GO111MODULE=off
 RUN ./install-runc
 
 FROM golang-base AS dev

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.13.4
+ARG GOLANG_VERSION=1.13.5
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd


### PR DESCRIPTION
Go 1.14 has been released, which means that Go 1.12 reached EOL, so updating supported branches to Go 1.13

This pull request backports updates to Golang 1.13 and related changes.

I first reverted the intermediate 1.12.x updates in the branch, then cherry-picked
each bump from master; doing so to preserve the commit message from those, and
to make sure we didn't miss changes associated with each Go update.

Updates to `.github/workflows/nightly.yml`, were ignored, because that file is not
not in the 1.3 branch.

backports of:

- revert https://github.com/containerd/containerd/pull/4030 [release/1.3] Update Golang 1.12.17
- revert golang bump from https://github.com/containerd/containerd/pull/3989 [release/1.3] Update Golang 1.12.16, x/crypto (CVE-2020-0601, CVE-2020-7919)
- revert https://github.com/containerd/containerd/pull/3967 [release/1.3] Update Golang 1.12.15
- revert https://github.com/containerd/containerd/pull/3917 [release/1.3] Update Golang 1.12.14
- https://github.com/containerd/containerd/pull/3620 Update to Golang 1.13.4
- https://github.com/containerd/containerd/pull/3916 Bump golang 1.13.5
    - only first commit
- https://github.com/containerd/containerd/pull/3969 Update Golang 1.13.6
- https://github.com/containerd/containerd/pull/3987 Update Golang 1.13.7, x/crypto (CVE-2020-0601, CVE-2020-7919)
    - only first commit: second commit was already part of https://github.com/containerd/containerd/pull/3989
- https://github.com/containerd/containerd/pull/4032 Update Golang 1.13.8

No conflicts, other than the missing `.github/workflows/nightly.yml` mentioned above.

Cherry-picks done;

<details>

```bash
# revert https://github.com/containerd/containerd/pull/4030 [release/1.3] Update Golang 1.12.17
git revert -s -S 6a3416449ee8dbc1ccc01887108465435c38b6bb

# revert golang bump from https://github.com/containerd/containerd/pull/3989 [release/1.3] Update Golang 1.12.16, x/crypto (CVE-2020-0601, CVE-2020-7919)
git revert -s -S d1e31f9f2deadc1816da1bfcdf0dbff85818a28d

# revert https://github.com/containerd/containerd/pull/3967 [release/1.3] Update Golang 1.12.15
git revert -s -S 72d9dd9bb42d2fbe7d49197a9ef4737ddd47d223

# revert https://github.com/containerd/containerd/pull/3917 [release/1.3] Update Golang 1.12.14
git revert -s -S f4824d5a6109362dad8abff552193f7ff08d9e2e

# https://github.com/containerd/containerd/pull/3620 Update to Golang 1.13.4
git cherry-pick -s -S -x 608791bfc34ead497cdae9851a572fc78552a864

# https://github.com/containerd/containerd/pull/3916 Bump golang 1.13.5
git cherry-pick -s -S -x c07e356d293895fa52f7dd215922861291d3d799

# https://github.com/containerd/containerd/pull/3969 Update Golang 1.13.6
git cherry-pick -s -S -x 94964b36d0248257743615a5e3bff0bea301d55c

# https://github.com/containerd/containerd/pull/3987 Update Golang 1.13.7, x/crypto (CVE-2020-0601, CVE-2020-7919)
git cherry-pick -s -S -x 32ba75f0fbfe47ad94e7c7daccc9f31efd0b2db2

# https://github.com/containerd/containerd/pull/4032 Update Golang 1.13.8
git cherry-pick -s -S -x 499ab8a99ad489fb911557f4ea7ffd33173ed65b
```

</details>
