### PR TITLE
Return err from DeviceInfoCallback in PoolDevice#transition

### DIFF
--- a/snapshots/devmapper/pool_device.go
+++ b/snapshots/devmapper/pool_device.go
@@ -24,7 +24,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 
@@ -155,7 +154,7 @@ func (p *PoolDevice) transition(ctx context.Context, deviceName string, tryingSt
 		} else {
 			deviceInfo.Error = err.Error()
 		}
-		return nil
+		return err
 	})
 
 	if uerr != nil {


### PR DESCRIPTION
In PoolDevice#transition, the DeviceInfoCallback is defined such that nil is always returned.

This would result in the following error check being ineffective in PoolMetadata#UpdateDevice
```
		if err := fn(device); err != nil {
			return err
```
We should return error from the DeviceInfoCallback