### PR TITLE
Pass snapshotter opts from client Pull

### DIFF
--- a/client.go
+++ b/client.go
@@ -319,6 +319,9 @@ type RemoteContext struct {
 	// Snapshotter used for unpacking
 	Snapshotter string
 
+	// SnapshotterOpts are additional options to be passed to a snapshotter during pull
+	SnapshotterOpts []snapshots.Opt
+
 	// Labels to be applied to the created image
 	Labels map[string]string
 

--- a/client_opts.go
+++ b/client_opts.go
@@ -22,6 +22,8 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/remotes"
+	"github.com/containerd/containerd/snapshots"
+
 	"google.golang.org/grpc"
 )
 
@@ -138,10 +140,11 @@ func WithUnpackOpts(opts []UnpackOpt) RemoteOpt {
 	}
 }
 
-// WithPullSnapshotter specifies snapshotter name used for unpacking
-func WithPullSnapshotter(snapshotterName string) RemoteOpt {
+// WithPullSnapshotter specifies snapshotter name used for unpacking.
+func WithPullSnapshotter(snapshotterName string, opts ...snapshots.Opt) RemoteOpt {
 	return func(_ *Client, c *RemoteContext) error {
 		c.Snapshotter = snapshotterName
+		c.SnapshotterOpts = opts
 		return nil
 	}
 }

--- a/pull.go
+++ b/pull.go
@@ -72,7 +72,7 @@ func (c *Client) Pull(ctx context.Context, ref string, opts ...RemoteOpt) (_ Ima
 		if err != nil {
 			return nil, errors.Wrap(err, "create unpacker")
 		}
-		unpackWrapper, unpackEg = u.handlerWrapper(ctx, &unpacks)
+		unpackWrapper, unpackEg = u.handlerWrapper(ctx, pullCtx, &unpacks)
 		defer func() {
 			if err := unpackEg.Wait(); err != nil {
 				if retErr == nil {

--- a/rootfs/apply.go
+++ b/rootfs/apply.go
@@ -129,7 +129,7 @@ func applyLayers(ctx context.Context, layers []Layer, chain []digest.Digest, sn 
 		mounts, err = sn.Prepare(ctx, key, parent.String(), opts...)
 		if err != nil {
 			if errdefs.IsNotFound(err) && len(layers) > 1 {
-				if err := applyLayers(ctx, layers[:len(layers)-1], chain[:len(chain)-1], sn, a, nil, applyOpts); err != nil {
+				if err := applyLayers(ctx, layers[:len(layers)-1], chain[:len(chain)-1], sn, a, opts, applyOpts); err != nil {
 					if !errdefs.IsAlreadyExists(err) {
 						return err
 					}

--- a/snapshots/snapshotter.go
+++ b/snapshots/snapshotter.go
@@ -355,10 +355,17 @@ type Cleaner interface {
 // Opt allows setting mutable snapshot properties on creation
 type Opt func(info *Info) error
 
-// WithLabels adds labels to a created snapshot
+// WithLabels appends labels to a created snapshot
 func WithLabels(labels map[string]string) Opt {
 	return func(info *Info) error {
-		info.Labels = labels
+		if info.Labels == nil {
+			info.Labels = make(map[string]string)
+		}
+
+		for k, v := range labels {
+			info.Labels[k] = v
+		}
+
 		return nil
 	}
 }

--- a/unpacker.go
+++ b/unpacker.go
@@ -72,7 +72,13 @@ func (c *Client) newUnpacker(ctx context.Context, rCtx *RemoteContext) (*unpacke
 	}, nil
 }
 
-func (u *unpacker) unpack(ctx context.Context, h images.Handler, config ocispec.Descriptor, layers []ocispec.Descriptor) error {
+func (u *unpacker) unpack(
+	ctx context.Context,
+	rCtx *RemoteContext,
+	h images.Handler,
+	config ocispec.Descriptor,
+	layers []ocispec.Descriptor,
+) error {
 	p, err := content.ReadBlob(ctx, u.c.ContentStore(), config)
 	if err != nil {
 		return err
@@ -123,17 +129,17 @@ EachLayer:
 			labels = make(map[string]string)
 		}
 		labels[labelSnapshotRef] = chainID
-		labelOpt := snapshots.WithLabels(labels)
 
 		var (
 			key    string
 			mounts []mount.Mount
+			opts   = append(rCtx.SnapshotterOpts, snapshots.WithLabels(labels))
 		)
 
 		for try := 1; try <= 3; try++ {
 			// Prepare snapshot with from parent, label as root
 			key = fmt.Sprintf("extract-%s %s", uniquePart(), chainID)
-			mounts, err = sn.Prepare(ctx, key, parent.String(), labelOpt)
+			mounts, err = sn.Prepare(ctx, key, parent.String(), opts...)
 			if err != nil {
 				if errdefs.IsAlreadyExists(err) {
 					if _, err := sn.Stat(ctx, chainID); err != nil {
@@ -201,7 +207,7 @@ EachLayer:
 			return errors.Errorf("wrong diff id calculated on extraction %q", diffIDs[i])
 		}
 
-		if err = sn.Commit(ctx, chainID, key, labelOpt); err != nil {
+		if err = sn.Commit(ctx, chainID, key, opts...); err != nil {
 			abort()
 			if errdefs.IsAlreadyExists(err) {
 				continue
@@ -271,7 +277,11 @@ func (u *unpacker) fetch(ctx context.Context, h images.Handler, layers []ocispec
 	return eg.Wait()
 }
 
-func (u *unpacker) handlerWrapper(uctx context.Context, unpacks *int32) (func(images.Handler) images.Handler, *errgroup.Group) {
+func (u *unpacker) handlerWrapper(
+	uctx context.Context,
+	rCtx *RemoteContext,
+	unpacks *int32,
+) (func(images.Handler) images.Handler, *errgroup.Group) {
 	eg, uctx := errgroup.WithContext(uctx)
 	return func(f images.Handler) images.Handler {
 		var (
@@ -313,7 +323,7 @@ func (u *unpacker) handlerWrapper(uctx context.Context, unpacks *int32) (func(im
 				if len(l) > 0 {
 					atomic.AddInt32(unpacks, 1)
 					eg.Go(func() error {
-						return u.unpack(uctx, f, desc, l)
+						return u.unpack(uctx, rCtx, f, desc, l)
 					})
 				}
 			}


### PR DESCRIPTION
This PR is a variation of https://github.com/containerd/containerd/pull/4044.
There are cases when, in addition to `ChainID`, a remote snapshotter needs to know more context about an image - API URL to query remote layer from, credentials to use, etc.
It would be useful to have this info passed from the client.

This PR slighly extends `WithPullSnapshotter` to pass extra labels to a snapshotter.

@ktock @dmcgowan would be interested in your opinion on this. 