### PR TITLE
vendor: bump golang.org/x/crypto bac4c82f6975

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -70,7 +70,7 @@ github.com/opencontainers/selinux                   31f70552238c5e017d78c3f1ba65
 github.com/seccomp/libseccomp-golang                689e3c1541a84461afc49c1c87352a6cedf72e9c # v0.9.1
 github.com/stretchr/testify                         221dbe5ed46703ee255b1da0dec05086f5035f62 # v1.4.0
 github.com/tchap/go-patricia                        666120de432aea38ab06bd5c818f04f4129882c9 # v2.2.6
-golang.org/x/crypto                                 1d94cc7ab1c630336ab82ccb9c9cda72a875c382
+golang.org/x/crypto                                 bac4c82f69751a6dd76e702d54b3ceb88adab236
 golang.org/x/oauth2                                 0f29369cfe4552d0e4bcddc57cc75f4d7e672a33
 golang.org/x/time                                   9d24e82272b4f38b78bc8cff74fa936d31ccd8ef
 gopkg.in/inf.v0                                     d2d2541c53f18d2a059457998ce2876cc8e67cbf # v0.9.1


### PR DESCRIPTION
follow-up to https://github.com/containerd/containerd/pull/4042
closes https://github.com/containerd/containerd/issues/4082

This version contains a fix for CVE-2020-9283, but the code-path is not in use in this repository.

Updating the dependency in case people are concerned that we use a version of the dependency that doesn't have the fix.
