### PR TITLE
[WIP] implement UnmountRecursive, EnsureRemoveAll

### DIFF
--- a/mount/mount_unix.go
+++ b/mount/mount_unix.go
@@ -39,3 +39,8 @@ func Unmount(mount string, flags int) error {
 func UnmountAll(mount string, flags int) error {
 	return ErrNotImplementOnUnix
 }
+
+// UnmountRecursive is not implemented on this platform
+func UnmountRecursive(mount string, flags int) (warnings []error, err error) {
+	return nil, ErrNotImplementOnUnix
+}

--- a/mount/mount_windows.go
+++ b/mount/mount_windows.go
@@ -103,3 +103,9 @@ func Unmount(mount string, flags int) error {
 func UnmountAll(mount string, flags int) error {
 	return Unmount(mount, flags)
 }
+
+// UnmountRecursive unmounts the target and all mounts underneath, starting with
+// the deepest mount first.
+func UnmountRecursive(target string) (warnings []error, err error) {
+	return nil, Unmount(mount, 0)
+}

--- a/sys/rm.go
+++ b/sys/rm.go
@@ -1,0 +1,92 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package sys
+
+import (
+	"os"
+	"syscall"
+	"time"
+
+	"github.com/containerd/containerd/mount"
+	"github.com/pkg/errors"
+)
+
+// EnsureRemoveAll wraps `os.RemoveAll` to check for specific errors that can
+// often be remedied.
+// Only use `EnsureRemoveAll` if you really want to make every effort to remove
+// a directory.
+//
+// Because of the way `os.Remove` (and by extension `os.RemoveAll`) works, there
+// can be a race between reading directory entries and then actually attempting
+// to remove everything in the directory.
+// These types of errors do not need to be returned since it's ok for the dir to
+// be gone we can just retry the remove operation.
+//
+// This should not return a `os.ErrNotExist` kind of error under any circumstances
+func EnsureRemoveAll(dir string) error {
+	notExistErr := make(map[string]bool)
+
+	// track retries
+	exitOnErr := make(map[string]int)
+	maxRetry := 50
+
+	// Attempt to unmount anything beneath this dir first. Ignore errors,
+	// as they will show up below
+	_, _ = mount.UnmountRecursive(dir, mntDetach)
+
+	for {
+		err := os.RemoveAll(dir)
+		if err == nil {
+			return nil
+		}
+
+		pe, ok := err.(*os.PathError)
+		if !ok {
+			return err
+		}
+
+		if os.IsNotExist(err) {
+			if notExistErr[pe.Path] {
+				return err
+			}
+			notExistErr[pe.Path] = true
+
+			// There is a race where some subdir can be removed but after the
+			// parent dir entries have been read.
+			// So the path could be from `os.Remove(subdir)`
+			// If the reported non-existent path is not the passed in `dir` we
+			// should just retry, but otherwise return with no error.
+			if pe.Path == dir {
+				return nil
+			}
+			continue
+		}
+
+		if pe.Err != syscall.EBUSY {
+			return err
+		}
+		if e := mount.Unmount(pe.Path, mntDetach); e != nil {
+			return errors.Wrapf(e, "error while removing %s", dir)
+		}
+
+		if exitOnErr[pe.Path] == maxRetry {
+			return err
+		}
+		exitOnErr[pe.Path]++
+		time.Sleep(100 * time.Millisecond)
+	}
+}

--- a/sys/rm_linux.go
+++ b/sys/rm_linux.go
@@ -1,0 +1,22 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package sys
+
+import "golang.org/x/sys/unix"
+
+const mntDetach = unix.MNT_DETACH
+

--- a/sys/rm_other.go
+++ b/sys/rm_other.go
@@ -1,0 +1,21 @@
+// +build !linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package sys
+
+const mntDetach = 0

--- a/sys/rm_test.go
+++ b/sys/rm_test.go
@@ -1,0 +1,105 @@
+// +build !linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package sys
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/pkg/mount"
+)
+
+func TestEnsureRemoveAllNotExist(t *testing.T) {
+	// should never return an error for a non-existent path
+	if err := EnsureRemoveAll("/non/existent/path"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnsureRemoveAllWithDir(t *testing.T) {
+	dir, err := ioutil.TempDir("", "test-ensure-removeall-with-dir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureRemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnsureRemoveAllWithFile(t *testing.T) {
+	tmp, err := ioutil.TempFile("", "test-ensure-removeall-with-dir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+	if err := EnsureRemoveAll(tmp.Name()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnsureRemoveAllWithMount(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mount not supported on Windows")
+	}
+	if os.Getuid() != 0 {
+		t.Skip("skipping test that requires root")
+	}
+
+	dir1, err := ioutil.TempDir("", "test-ensure-removeall-with-dir1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir2, err := ioutil.TempDir("", "test-ensure-removeall-with-dir2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir2)
+
+	bindDir := filepath.Join(dir1, "bind")
+	if err := os.MkdirAll(bindDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mount.Mount(dir2, bindDir, "none", "bind"); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		err = EnsureRemoveAll(dir1)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for EnsureRemoveAll to finish")
+	}
+
+	if _, err := os.Stat(dir1); !os.IsNotExist(err) {
+		t.Fatalf("expected %q to not exist", dir1)
+	}
+}


### PR DESCRIPTION
Trying to reduce (or remove) the dependency on github.com/docker/docker, this implements UnmountRecursive and EnsureRemoveAll, which should provide the same functionality as [`github.com/docker/docker. RecursiveUnmount()`](https://github.com/moby/moby/blob/19008faf03fbf36d9e3e4b7c5769201d3516f613/pkg/mount/mount.go#L131)
and [`github.com/docker/docker/pkg/system.EnsureRemoveAll()`](https://github.com/moby/moby/blob/0211de67ab92cd62ab4484bac28c33f9cbd92b7f/pkg/system/rm.go#L24).

With this, containerd/cri no longer has to import those packages.


Relates to https://github.com/containerd/cri/pull/1416