### PR TITLE
archive: skip chmod IsNotExist error

### DIFF
--- a/archive/tar_unix.go
+++ b/archive/tar_unix.go
@@ -125,7 +125,7 @@ func handleTarTypeBlockCharFifo(hdr *tar.Header, path string) error {
 func handleLChmod(hdr *tar.Header, path string, hdrInfo os.FileInfo) error {
 	if hdr.Typeflag == tar.TypeLink {
 		if fi, err := os.Lstat(hdr.Linkname); err == nil && (fi.Mode()&os.ModeSymlink == 0) {
-			if err := os.Chmod(path, hdrInfo.Mode()); err != nil {
+			if err := os.Chmod(path, hdrInfo.Mode()); err != nil && !os.IsNotExist(err) {
 				return err
 			}
 		}


### PR DESCRIPTION
handleLChmod() does not properly check that files behind the handlinks exist
before calling os.Chmod(). We've seen base images where this results in
"no such file or directory" error from os.Chmod() when unpacking the image.

os.Stat() follows symlinks and tells us if the destination file exists.
Use that as the pre-check before os.Chmod() to avoid errors.

The failing case for me was:
`sudo ctr i pull docker.io/library/clearlinux:base`