### PR TITLE
Nit: fix use of bufio.Scanner.Err

### DIFF
--- a/mount/mountinfo_linux.go
+++ b/mount/mountinfo_linux.go
@@ -45,10 +45,6 @@ func parseInfoFile(r io.Reader) ([]Info, error) {
 	out := []Info{}
 	var err error
 	for s.Scan() {
-		if err = s.Err(); err != nil {
-			return nil, err
-		}
-
 		/*
 		   See http://man7.org/linux/man-pages/man5/proc.5.html
 
@@ -128,6 +124,10 @@ func parseInfoFile(r io.Reader) ([]Info, error) {
 
 		out = append(out, p)
 	}
+	if err = s.Err(); err != nil {
+		return nil, err
+	}
+
 	return out, nil
 }
 

--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -1238,10 +1238,10 @@ func WithEnvFile(path string) SpecOpts {
 
 		sc := bufio.NewScanner(f)
 		for sc.Scan() {
-			if sc.Err() != nil {
-				return sc.Err()
-			}
 			vars = append(vars, sc.Text())
+		}
+		if err = sc.Err(); err != nil {
+			return err
 		}
 		return WithEnv(vars)(nil, nil, nil, s)
 	}

--- a/runtime/v2/README.md
+++ b/runtime/v2/README.md
@@ -227,9 +227,6 @@ func copy(wg *sync.WaitGroup, r io.Reader, pri journal.Priority, vars map[string
 	defer wg.Done()
 	s := bufio.NewScanner(r)
 	for s.Scan() {
-		if s.Err() != nil {
-			return
-		}
 		journal.Send(s.Text(), pri, vars)
 	}
 }


### PR DESCRIPTION
The `Err()` method should be called after the `Scan()` loop, not inside it.

Found by: `git grep -A3 -F '.Scan()'`