### PR TITLE
Increase golangci-lint timeout

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,7 @@ linters:
     - errcheck
 
 run:
-  timeout: 2m
+  timeout: 3m
   skip-dirs:
     - api
     - design


### PR DESCRIPTION
AppVeyor is running over the current 2m timeout regularly these days
during PR CI runs.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>