### PR TITLE
ParseSignal: drop add'l check for numeric signals

### DIFF
--- a/signals_test.go
+++ b/signals_test.go
@@ -31,7 +31,6 @@ func TestParseSignal(t *testing.T) {
 		{"1", syscall.Signal(1), false},
 		{"SIGKILL", syscall.SIGKILL, false},
 		{"NONEXIST", 0, true},
-		{"65536", 0, true},
 	}
 	for _, ts := range testSignals {
 		t.Run(fmt.Sprintf("%s/%d/%t", ts.raw, ts.want, ts.err), func(t *testing.T) {

--- a/signals_unix.go
+++ b/signals_unix.go
@@ -33,11 +33,7 @@ import (
 func ParseSignal(rawSignal string) (syscall.Signal, error) {
 	s, err := strconv.Atoi(rawSignal)
 	if err == nil {
-		signal := syscall.Signal(s)
-		if unix.SignalName(signal) != "" {
-			return signal, nil
-		}
-		return -1, fmt.Errorf("unknown signal %q", rawSignal)
+		return syscall.Signal(s), nil
 	}
 	signal := unix.SignalNum(strings.ToUpper(rawSignal))
 	if signal == 0 {


### PR DESCRIPTION
The kernel will return an error anyway.