### PR TITLE
when kill a container check if it has been deleted

### DIFF
--- a/runtime/v1/linux/proc/utils.go
+++ b/runtime/v1/linux/proc/utils.go
@@ -126,6 +126,8 @@ func checkKillError(err error) error {
 		strings.Contains(err.Error(), "container not running") ||
 		err == unix.ESRCH {
 		return errors.Wrapf(errdefs.ErrNotFound, "process already finished")
+	} else if strings.Contains(err.Error(), "does not exist") {
+		return errors.Wrapf(errdefs.ErrNotFound, "no such container")
 	}
 	return errors.Wrapf(err, "unknown error after kill")
 }


### PR DESCRIPTION
From #4020 . When use cri-containerd and k8s, pod may be  stuck in terminating. It happens when container is delete by runc, however containerd unawares of this or deletes container failed.  When cri retry to delete container it will got a runc error `container <cid> does not exist`. This is because cri ignore IsNotFound error, but shim is not converting the runc error to a containerd NotFound error.