### PR TITLE
[release/1.3] vendor containerd/cri f864905c93b97db15503c217dc9a43eb65670b53

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -51,7 +51,7 @@ github.com/cpuguy83/go-md2man v1.0.10
 github.com/russross/blackfriday v1.5.2
 
 # cri dependencies
-github.com/containerd/cri 50b9e10ea54a9b57049fe311e4fe0a96277ef1c2 # release/1.3
+github.com/containerd/cri f864905c93b97db15503c217dc9a43eb65670b53
 github.com/containerd/go-cni 49fbd9b210f3c8ee3b7fd3cd797aabaf364627c1
 github.com/containernetworking/cni v0.7.1
 github.com/containernetworking/plugins v0.7.6


### PR DESCRIPTION
Update `containerd/cri` in release/1.3 branch.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>

Hi, 
Want to update the `containerd/cri` commit in the `vendor.conf` as we use this entry to checkout and run cri tests using kata-containers and current commit is broken when running the tests with go1.13. The new `cri` commit fixes that issue. 
There are no changes in the `vendor` directory as the fix only touches tests files. 