### PR TITLE
Add docs for build tags used by cri.

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -107,6 +107,9 @@ make generate
 > * `no_cri`: A build tag disables building Kubernetes [CRI](http://blog.kubernetes.io/2016/12/container-runtime-interface-cri-in-kubernetes.html) support into containerd.
 > See [here](https://github.com/containerd/cri-containerd#build-tags) for build tags of CRI plugin.
 > * `no_devmapper`: A build tag disables building the device mapper snapshot driver.
+> * `seccomp`: Enables seccomp support in the cri plugin
+> * `apparmor`: Enables apparmor support in the cri plugin
+> * `selinux`: Enables selinux support in the cri plugin
 >
 > For example, adding `BUILDTAGS=no_btrfs` to your environment before calling the **binaries**
 > Makefile target will disable the btrfs driver within the containerd Go build.


### PR DESCRIPTION
Since CRI is compiled in with containerd, builders should be aware that
these buildtags are available.