### PR TITLE
Move checks to Github actions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,174 @@
+name: Checks
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  #
+  # golangci-lint
+  #
+  linters:
+    name: Linters
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, macos-10.15] # TODO: pass linters on 'windows-2019'
+
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.13.8'
+
+      - name: Set env
+        shell: bash
+        run: |
+          echo "::set-env name=GOPATH::${{ github.workspace }}"
+          echo "::add-path::${{ github.workspace }}/bin"
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: src/github.com/containerd/containerd
+
+      - name: Install dev tools
+        env:
+          GO111MODULE: off
+        shell: bash
+        run: script/setup/install-dev-tools
+        working-directory: src/github.com/containerd/containerd
+
+      - name: Make check
+        shell: bash
+        run: make check
+        working-directory: src/github.com/containerd/containerd
+
+  #
+  # Project checks
+  #
+  project:
+    name: Project
+    runs-on: ubuntu-18.04
+
+    steps:
+      #
+      # Install Go
+      #
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.13.8'
+
+      - name: Set env
+        shell: bash
+        run: |
+          echo "::set-env name=GOPATH::${{ github.workspace }}"
+          echo "::add-path::${{ github.workspace }}/bin"
+
+      #
+      # Checkout repos
+      #
+      - name: Checkout this repo
+        uses: actions/checkout@v2
+        with:
+          path: src/github.com/containerd/containerd
+          fetch-depth: 25
+
+      - name: Checkout project repo
+        uses: actions/checkout@v2
+        with:
+          repository: containerd/project
+          path: src/github.com/containerd/project
+
+      #
+      # Go get dependencies
+      #
+      - name: Install dependencies
+        env:
+          GO111MODULE: off
+        run: |
+          go get -u github.com/vbatts/git-validation
+          go get -u github.com/kunalkushwaha/ltag
+          go get -u github.com/LK4D4/vndr
+
+      #
+      # DCO / File headers / Vendor directory validation
+      #
+      - name: DCO
+        env:
+          GITHUB_COMMIT_URL: ${{ github.event.pull_request.commits_url }}
+          DCO_VERBOSITY: "-q"
+          DCO_RANGE: ""
+        working-directory: src/github.com/containerd/containerd
+        run: |
+          set -x
+          if [ -z "${GITHUB_COMMIT_URL}" ]; then
+          DCO_RANGE=$(jq -r '.after + "..HEAD"' ${GITHUB_EVENT_PATH})
+          else
+          DCO_RANGE=$(curl ${GITHUB_COMMIT_URL} | jq -r '.[0].parents[0].sha +".."+ .[-1].sha')
+          fi
+          ../project/script/validate/dco
+
+      - name: Headers
+        run: ../project/script/validate/fileheader ../project/
+        working-directory: src/github.com/containerd/containerd
+
+      - name: Vendor
+        run: ../project/script/validate/vendor
+        working-directory: src/github.com/containerd/containerd
+
+  #
+  # Protobuf checks
+  #
+  protos:
+    name: Protobuf
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.13.8'
+
+      - name: Checkout
+        uses: actions/checkout@v1
+        env:
+          GOPATH: ${{ runner.workspace }}
+          GO111MODULE: off
+        with:
+          path: ./src/github.com/containerd/containerd
+
+      - name: Install protobuf
+        env:
+          GOPATH: ${{ runner.workspace }}
+          GO111MODULE: off
+        run: |
+          sudo env PATH=$PATH GOPATH=$GOPATH script/setup/install-protobuf
+          sudo chmod +x /usr/local/bin/protoc
+          sudo chmod og+rx /usr/local/include/google /usr/local/include/google/protobuf /usr/local/include/google/protobuf/compiler
+          sudo chmod -R og+r /usr/local/include/google/protobuf/
+          protoc --version
+
+      - name: Go get gogo
+        env:
+          GOPATH: ${{ runner.workspace }}
+          GO111MODULE: off
+        # Get proto files, ignore "package github.com/gogo/googleapis: no Go files in ~/go/src/github.com/gogo/googleapis"
+        run: go get -u github.com/gogo/googleapis || true
+
+      - name: Install dev tools
+        env:
+          GOPATH: ${{ runner.workspace }}
+          GO111MODULE: off
+        run: script/setup/install-dev-tools
+
+      - name: Make
+        env:
+          GOPATH: ${{ runner.workspace }}
+          GO111MODULE: off
+        run: |
+          export PATH=$PATH:$(go env GOPATH)/bin
+          make check-protos check-api-descriptors


### PR DESCRIPTION
This PR ports the majority of our checks that we currently do on Travis (golangci-lint, dco, headers, vendor, protobuf).
Currently `golangci-lint` doesn't pass on windows platform, so I disabled them. Will follow up once I get proper env. 

@estesp I took your DCO checks, hope you don't mind :) 

Signed-off-by: Maksym Pavlenko <makpav@amazon.com>