### PR TITLE
Makefile: man page: rename containerd.1 to containerd.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ endif
 
 # Project binaries.
 COMMANDS=ctr containerd containerd-stress
-MANPAGES=ctr.1 containerd.1 containerd-config.1 containerd-config.toml.5
+MANPAGES=ctr.1 containerd.8 containerd-config.1 containerd-config.toml.5
 
 ifdef BUILDTAGS
     GO_BUILDTAGS = ${BUILDTAGS}
@@ -214,9 +214,9 @@ mandir:
 	@mkdir -p man
 
 # Kept for backwards compatability
-genman: man/containerd.1 man/ctr.1
+genman: man/containerd.8 man/ctr.1
 
-man/containerd.1: FORCE
+man/containerd.8: FORCE
 	@echo "$(WHALE) $@"
 	go run cmd/gen-manpages/main.go containerd man/
 

--- a/docs/man/containerd-config.1.md
+++ b/docs/man/containerd-config.1.md
@@ -38,4 +38,4 @@ Phil Estes <estesp@gmail.com>
 
 ## SEE ALSO
 
-ctr(1), containerd(1), containerd-config.toml(5)
+ctr(1), containerd(8), containerd-config.toml(5)

--- a/docs/man/containerd-config.toml.5.md
+++ b/docs/man/containerd-config.toml.5.md
@@ -142,4 +142,4 @@ Phil Estes <estesp@gmail.com>
 
 ## SEE ALSO
 
-ctr(1), containerd-config(1), containerd(1)
+ctr(1), containerd-config(1), containerd(8)


### PR DESCRIPTION
The generated file was incorrectly named containerd.1 and should
be in section 8 (see [MAN-PAGES(7)]: Sections of the manual pages)

This patch fixes the filename and updates references to containerd(1)
to refer to containerd(8).

The generated file itself already had the correct section set in its
header, so didn't need updating.

[MAN-PAGES(7)]: http://man7.org/linux/man-pages/man7/man-pages.7.html
