### PR TITLE
man: move ctr.1 and containerd-config to section 8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ endif
 
 # Project binaries.
 COMMANDS=ctr containerd containerd-stress
-MANPAGES=ctr.1 containerd.8 containerd-config.1 containerd-config.toml.5
+MANPAGES=ctr.8 containerd.8 containerd-config.8 containerd-config.toml.5
 
 ifdef BUILDTAGS
     GO_BUILDTAGS = ${BUILDTAGS}
@@ -214,15 +214,15 @@ mandir:
 	@mkdir -p man
 
 # Kept for backwards compatability
-genman: man/containerd.8 man/ctr.1
+genman: man/containerd.8 man/ctr.8
 
 man/containerd.8: FORCE
 	@echo "$(WHALE) $@"
-	go run cmd/gen-manpages/main.go containerd man/
+	go run cmd/gen-manpages/main.go $(@F) $(@D)
 
-man/ctr.1: FORCE
+man/ctr.8: FORCE
 	@echo "$(WHALE) $@"
-	go run cmd/gen-manpages/main.go ctr man/
+	go run cmd/gen-manpages/main.go $(@F) $(@D)
 
 man/%: docs/man/%.md FORCE
 	@echo "$(WHALE) $@"

--- a/docs/man/containerd-config.8.md
+++ b/docs/man/containerd-config.8.md
@@ -1,4 +1,4 @@
-# containerd-config 1 01/30/2018
+# containerd-config 8 01/30/2018
 
 ## NAME
 
@@ -38,4 +38,4 @@ Phil Estes <estesp@gmail.com>
 
 ## SEE ALSO
 
-ctr(1), containerd(8), containerd-config.toml(5)
+ctr(8), containerd(8), containerd-config.toml(5)

--- a/docs/man/containerd-config.toml.5.md
+++ b/docs/man/containerd-config.toml.5.md
@@ -142,4 +142,4 @@ Phil Estes <estesp@gmail.com>
 
 ## SEE ALSO
 
-ctr(1), containerd-config(1), containerd(8)
+ctr(8), containerd-config(8), containerd(8)


### PR DESCRIPTION
I missed this in my previous change: the ctr man page is also in Section 8, because it's considered an administrative tool, and containerd-config is related to containerd so updating these as well.