### PR TITLE
Bump Golang 1.13.9

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 0
   matrix:
-    - GO_VERSION: 1.13.8
+    - GO_VERSION: 1.13.9
 
 before_build:
   - choco install --no-progress -y mingw --version 5.3.0

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.8'
+          go-version: '1.13.9'
 
       - name: Set env
         shell: bash
@@ -60,7 +60,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.8'
+          go-version: '1.13.9'
 
       - name: Set env
         shell: bash
@@ -131,7 +131,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.8'
+          go-version: '1.13.9'
 
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.8'
+          go-version: '1.13.9'
 
       - name: Checkout
         uses: actions/checkout@v1
@@ -123,7 +123,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.8'
+          go-version: '1.13.9'
 
       - name: Checkout
         uses: actions/checkout@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
 - linux
 
 go:
-  - "1.13.8"
+  - "1.13.9"
 
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.13.8
+ARG GOLANG_VERSION=1.13.9
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd


### PR DESCRIPTION
go1.13.9 (released 2020/03/19) includes fixes to the go command, tools, the
runtime, the toolchain, and the crypto/cypher package. See the Go 1.13.9
milestone on the issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.13.9+label%3ACherryPickApproved

full diff: https://github.com/golang/go/compare/go1.13.8...go1.13.9