### PR TITLE
[release/1.3 backport] Update containerd/console vendor for fix

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -2,7 +2,7 @@ github.com/beorn7/perks                             4c0e84591b9aa9e6dcfdf3e02011
 github.com/BurntSushi/toml                          3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005 # v0.3.1
 github.com/containerd/btrfs                         af5082808c833de0e79c1e72eea9fea239364877
 github.com/containerd/cgroups                       c4b9ac5c7601384c965b9646fc515884e091ebb9
-github.com/containerd/console                       0650fd9eeb50bab4fc99dceb9f2e14cf58f36e7f
+github.com/containerd/console                       02ecf6a7291e65f4a361525245c2bea023dc2e0b
 github.com/containerd/continuity                    f2a389ac0a02ce21c09edd7344677a601970f41c
 github.com/containerd/fifo                          bda0ff6ed73c67bfb5e62bc9c697f146b7fd7f13
 github.com/containerd/go-runc                       e029b79d8cda8374981c64eba71f28ec38e5526f

--- a/vendor.conf
+++ b/vendor.conf
@@ -2,11 +2,11 @@ github.com/beorn7/perks                             4c0e84591b9aa9e6dcfdf3e02011
 github.com/BurntSushi/toml                          3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005 # v0.3.1
 github.com/containerd/btrfs                         af5082808c833de0e79c1e72eea9fea239364877
 github.com/containerd/cgroups                       c4b9ac5c7601384c965b9646fc515884e091ebb9
-github.com/containerd/console                       8375c3424e4d7b114e8a90a4a40c8e1b40d1d4e6
+github.com/containerd/console                       8375c3424e4d7b114e8a90a4a40c8e1b40d1d4e6 # v1.0.0
 github.com/containerd/continuity                    f2a389ac0a02ce21c09edd7344677a601970f41c
 github.com/containerd/fifo                          bda0ff6ed73c67bfb5e62bc9c697f146b7fd7f13
 github.com/containerd/go-runc                       e029b79d8cda8374981c64eba71f28ec38e5526f
-github.com/containerd/ttrpc                         92c8520ef9f86600c650dd540266a007bf03670f
+github.com/containerd/ttrpc                         92c8520ef9f86600c650dd540266a007bf03670f # v1.0.0
 github.com/containerd/typeurl                       a93fcdb778cd272c6e9b3028b2f42d813e785d40 # v1.0.0
 github.com/coreos/go-systemd                        48702e0da86bd25e76cfef347e2adeb434a0d0a6
 github.com/cpuguy83/go-md2man                       7762f7e404f8416dfa1d9bb6a8c192aa9acb4d19 # v1.0.10

--- a/vendor.conf
+++ b/vendor.conf
@@ -2,7 +2,7 @@ github.com/beorn7/perks                             4c0e84591b9aa9e6dcfdf3e02011
 github.com/BurntSushi/toml                          3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005 # v0.3.1
 github.com/containerd/btrfs                         af5082808c833de0e79c1e72eea9fea239364877
 github.com/containerd/cgroups                       c4b9ac5c7601384c965b9646fc515884e091ebb9
-github.com/containerd/console                       02ecf6a7291e65f4a361525245c2bea023dc2e0b
+github.com/containerd/console                       8375c3424e4d7b114e8a90a4a40c8e1b40d1d4e6
 github.com/containerd/continuity                    f2a389ac0a02ce21c09edd7344677a601970f41c
 github.com/containerd/fifo                          bda0ff6ed73c67bfb5e62bc9c697f146b7fd7f13
 github.com/containerd/go-runc                       e029b79d8cda8374981c64eba71f28ec38e5526f

--- a/vendor/github.com/containerd/console/console.go
+++ b/vendor/github.com/containerd/console/console.go
@@ -24,10 +24,17 @@ import (
 
 var ErrNotAConsole = errors.New("provided file is not a console")
 
+type File interface {
+	io.ReadWriteCloser
+
+	// Fd returns its file descriptor
+	Fd() uintptr
+	// Name returns its file name
+	Name() string
+}
+
 type Console interface {
-	io.Reader
-	io.Writer
-	io.Closer
+	File
 
 	// Resize resizes the console to the provided window size
 	Resize(WinSize) error
@@ -42,10 +49,6 @@ type Console interface {
 	Reset() error
 	// Size returns the window size of the console
 	Size() (WinSize, error)
-	// Fd returns the console's file descriptor
-	Fd() uintptr
-	// Name returns the console's file name
-	Name() string
 }
 
 // WinSize specifies the window size of the console
@@ -70,7 +73,7 @@ func Current() Console {
 }
 
 // ConsoleFromFile returns a console using the provided file
-func ConsoleFromFile(f *os.File) (Console, error) {
+func ConsoleFromFile(f File) (Console, error) {
 	if err := checkConsole(f); err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/containerd/console/console_linux.go
+++ b/vendor/github.com/containerd/console/console_linux.go
@@ -58,6 +58,7 @@ type Epoller struct {
 	efd       int
 	mu        sync.Mutex
 	fdMapping map[int]*EpollConsole
+	closeOnce sync.Once
 }
 
 // NewEpoller returns an instance of epoller with a valid epoll fd.
@@ -151,7 +152,11 @@ func (e *Epoller) getConsole(sysfd int) *EpollConsole {
 
 // Close closes the epoll fd
 func (e *Epoller) Close() error {
-	return unix.Close(e.efd)
+	closeErr := os.ErrClosed // default to "file already closed"
+	e.closeOnce.Do(func() {
+		closeErr = unix.Close(e.efd)
+	})
+	return closeErr
 }
 
 // EpollConsole acts like a console but registers its file descriptor with an

--- a/vendor/github.com/containerd/console/console_unix.go
+++ b/vendor/github.com/containerd/console/console_unix.go
@@ -47,7 +47,7 @@ func NewPty() (Console, string, error) {
 }
 
 type master struct {
-	f        *os.File
+	f        File
 	original *unix.Termios
 }
 
@@ -122,7 +122,7 @@ func (m *master) Name() string {
 }
 
 // checkConsole checks if the provided file is a console
-func checkConsole(f *os.File) error {
+func checkConsole(f File) error {
 	var termios unix.Termios
 	if tcget(f.Fd(), &termios) != nil {
 		return ErrNotAConsole
@@ -130,7 +130,7 @@ func checkConsole(f *os.File) error {
 	return nil
 }
 
-func newMaster(f *os.File) (Console, error) {
+func newMaster(f File) (Console, error) {
 	m := &master{
 		f: f,
 	}

--- a/vendor/github.com/containerd/console/console_windows.go
+++ b/vendor/github.com/containerd/console/console_windows.go
@@ -198,7 +198,7 @@ func makeInputRaw(fd windows.Handle, mode uint32) error {
 	return nil
 }
 
-func checkConsole(f *os.File) error {
+func checkConsole(f File) error {
 	var mode uint32
 	if err := windows.GetConsoleMode(windows.Handle(f.Fd()), &mode); err != nil {
 		return err
@@ -206,7 +206,7 @@ func checkConsole(f *os.File) error {
 	return nil
 }
 
-func newMaster(f *os.File) (Console, error) {
+func newMaster(f File) (Console, error) {
 	if f != os.Stdin && f != os.Stdout && f != os.Stderr {
 		return nil, errors.New("creating a console from a file is not supported on windows")
 	}

--- a/vendor/github.com/containerd/console/go.mod
+++ b/vendor/github.com/containerd/console/go.mod
@@ -1,0 +1,8 @@
+module github.com/containerd/console
+
+go 1.13
+
+require (
+	github.com/pkg/errors v0.8.1
+	golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e
+)


### PR DESCRIPTION
backports of:

- https://github.com/containerd/containerd/pull/4125 Add version numbers for newly tagged repos
- https://github.com/containerd/containerd/pull/3906 Update containerd/console vendor for fix
    - brings in https://github.com/containerd/console/pull/34 Only close epoller FD at most once
    - relates to https://github.com/containerd/containerd/issues/3895 runtime: runc v2 shim closes platform prematurely and multiple times
    - relates to https://github.com/firecracker-microvm/firecracker-containerd/issues/363 TestMultipleVMs: "bad file descriptor" cleaning up task bundle in agent 
- https://github.com/containerd/containerd/pull/3878 Bump containerd console for os.File changes
