### PR TITLE
[release/1.2 backport] Update containerd/console vendor for fix

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,5 +1,5 @@
 github.com/containerd/go-runc e029b79d8cda8374981c64eba71f28ec38e5526f
-github.com/containerd/console c12b1e7919c14469339a5d38f2f8ed9b64a9de23
+github.com/containerd/console 0650fd9eeb50bab4fc99dceb9f2e14cf58f36e7f
 github.com/containerd/cgroups c4b9ac5c7601384c965b9646fc515884e091ebb9
 github.com/containerd/typeurl a93fcdb778cd272c6e9b3028b2f42d813e785d40
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,5 +1,5 @@
 github.com/containerd/go-runc e029b79d8cda8374981c64eba71f28ec38e5526f
-github.com/containerd/console 0650fd9eeb50bab4fc99dceb9f2e14cf58f36e7f
+github.com/containerd/console 02ecf6a7291e65f4a361525245c2bea023dc2e0b
 github.com/containerd/cgroups c4b9ac5c7601384c965b9646fc515884e091ebb9
 github.com/containerd/typeurl a93fcdb778cd272c6e9b3028b2f42d813e785d40
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,5 +1,5 @@
 github.com/containerd/go-runc e029b79d8cda8374981c64eba71f28ec38e5526f
-github.com/containerd/console 02ecf6a7291e65f4a361525245c2bea023dc2e0b
+github.com/containerd/console 8375c3424e4d7b114e8a90a4a40c8e1b40d1d4e6
 github.com/containerd/cgroups c4b9ac5c7601384c965b9646fc515884e091ebb9
 github.com/containerd/typeurl a93fcdb778cd272c6e9b3028b2f42d813e785d40
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c

--- a/vendor/github.com/containerd/console/LICENSE
+++ b/vendor/github.com/containerd/console/LICENSE
@@ -1,6 +1,7 @@
+
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -175,24 +176,13 @@
 
    END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
+   Copyright The containerd Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/vendor/github.com/containerd/console/README.md
+++ b/vendor/github.com/containerd/console/README.md
@@ -15,3 +15,13 @@ if err := current.SetRaw(); err != nil {
 ws, err := current.Size()
 current.Resize(ws)
 ```
+
+## Project details
+
+console is a containerd sub-project, licensed under the [Apache 2.0 license](./LICENSE).
+As a containerd sub-project, you will find the:
+ * [Project governance](https://github.com/containerd/project/blob/master/GOVERNANCE.md),
+ * [Maintainers](https://github.com/containerd/project/blob/master/MAINTAINERS),
+ * and [Contributing guidelines](https://github.com/containerd/project/blob/master/CONTRIBUTING.md)
+
+information in our [`containerd/project`](https://github.com/containerd/project) repository.

--- a/vendor/github.com/containerd/console/console.go
+++ b/vendor/github.com/containerd/console/console.go
@@ -24,10 +24,17 @@ import (
 
 var ErrNotAConsole = errors.New("provided file is not a console")
 
+type File interface {
+	io.ReadWriteCloser
+
+	// Fd returns its file descriptor
+	Fd() uintptr
+	// Name returns its file name
+	Name() string
+}
+
 type Console interface {
-	io.Reader
-	io.Writer
-	io.Closer
+	File
 
 	// Resize resizes the console to the provided window size
 	Resize(WinSize) error
@@ -42,10 +49,6 @@ type Console interface {
 	Reset() error
 	// Size returns the window size of the console
 	Size() (WinSize, error)
-	// Fd returns the console's file descriptor
-	Fd() uintptr
-	// Name returns the console's file name
-	Name() string
 }
 
 // WinSize specifies the window size of the console
@@ -70,7 +73,7 @@ func Current() Console {
 }
 
 // ConsoleFromFile returns a console using the provided file
-func ConsoleFromFile(f *os.File) (Console, error) {
+func ConsoleFromFile(f File) (Console, error) {
 	if err := checkConsole(f); err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/containerd/console/console_linux.go
+++ b/vendor/github.com/containerd/console/console_linux.go
@@ -58,6 +58,7 @@ type Epoller struct {
 	efd       int
 	mu        sync.Mutex
 	fdMapping map[int]*EpollConsole
+	closeOnce sync.Once
 }
 
 // NewEpoller returns an instance of epoller with a valid epoll fd.
@@ -151,7 +152,11 @@ func (e *Epoller) getConsole(sysfd int) *EpollConsole {
 
 // Close closes the epoll fd
 func (e *Epoller) Close() error {
-	return unix.Close(e.efd)
+	closeErr := os.ErrClosed // default to "file already closed"
+	e.closeOnce.Do(func() {
+		closeErr = unix.Close(e.efd)
+	})
+	return closeErr
 }
 
 // EpollConsole acts like a console but registers its file descriptor with an

--- a/vendor/github.com/containerd/console/console_unix.go
+++ b/vendor/github.com/containerd/console/console_unix.go
@@ -47,7 +47,7 @@ func NewPty() (Console, string, error) {
 }
 
 type master struct {
-	f        *os.File
+	f        File
 	original *unix.Termios
 }
 
@@ -122,7 +122,7 @@ func (m *master) Name() string {
 }
 
 // checkConsole checks if the provided file is a console
-func checkConsole(f *os.File) error {
+func checkConsole(f File) error {
 	var termios unix.Termios
 	if tcget(f.Fd(), &termios) != nil {
 		return ErrNotAConsole
@@ -130,7 +130,7 @@ func checkConsole(f *os.File) error {
 	return nil
 }
 
-func newMaster(f *os.File) (Console, error) {
+func newMaster(f File) (Console, error) {
 	m := &master{
 		f: f,
 	}

--- a/vendor/github.com/containerd/console/console_windows.go
+++ b/vendor/github.com/containerd/console/console_windows.go
@@ -198,7 +198,7 @@ func makeInputRaw(fd windows.Handle, mode uint32) error {
 	return nil
 }
 
-func checkConsole(f *os.File) error {
+func checkConsole(f File) error {
 	var mode uint32
 	if err := windows.GetConsoleMode(windows.Handle(f.Fd()), &mode); err != nil {
 		return err
@@ -206,7 +206,7 @@ func checkConsole(f *os.File) error {
 	return nil
 }
 
-func newMaster(f *os.File) (Console, error) {
+func newMaster(f File) (Console, error) {
 	if f != os.Stdin && f != os.Stdout && f != os.Stderr {
 		return nil, errors.New("creating a console from a file is not supported on windows")
 	}

--- a/vendor/github.com/containerd/console/go.mod
+++ b/vendor/github.com/containerd/console/go.mod
@@ -1,0 +1,8 @@
+module github.com/containerd/console
+
+go 1.13
+
+require (
+	github.com/pkg/errors v0.8.1
+	golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e
+)


### PR DESCRIPTION
backports of:
- https://github.com/containerd/containerd/pull/3906 Update containerd/console vendor for fix
    - brings in https://github.com/containerd/console/pull/34 Only close epoller FD at most once
    - relates to https://github.com/containerd/containerd/issues/3895 runtime: runc v2 shim closes platform prematurely and multiple times
    - relates to https://github.com/firecracker-microvm/firecracker-containerd/issues/363 TestMultipleVMs: "bad file descriptor" cleaning up task bundle in agent 
- https://github.com/containerd/containerd/pull/3878 Bump containerd console for os.File changes
- https://github.com/containerd/containerd/pull/3223 Bump syndtr/gocapability d983527, containerd/console