### PR TITLE
vendor: update go-events to fix alignment for 32bit systems

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -11,7 +11,7 @@ github.com/containerd/ttrpc                         92c8520ef9f86600c650dd540266
 github.com/containerd/typeurl                       a93fcdb778cd272c6e9b3028b2f42d813e785d40 # v1.0.0
 github.com/coreos/go-systemd/v22                    2d78030078ef61b3cae27f42ad6d0e46db51b339 # v22.0.0
 github.com/cpuguy83/go-md2man                       7762f7e404f8416dfa1d9bb6a8c192aa9acb4d19 # v1.0.10
-github.com/docker/go-events                         9461782956ad83b30282bf90e31fa6a70c255ba9
+github.com/docker/go-events                         e31b211e4f1cd09aa76fe4ac244571fab96ae47f
 github.com/docker/go-metrics                        b619b3592b65de4f087d9f16863a7e6ff905973c # v0.0.1
 github.com/docker/go-units                          519db1ee28dcc9fd2474ae59fca29a810482bfb1 # v0.4.0
 github.com/godbus/dbus/v5                           37bf87eef99d69c4f1d3528bd66e3a87dc201472 # v5.0.3

--- a/vendor/github.com/docker/go-events/retry.go
+++ b/vendor/github.com/docker/go-events/retry.go
@@ -203,8 +203,8 @@ type ExponentialBackoffConfig struct {
 // ExponentialBackoff implements random backoff with exponentially increasing
 // bounds as the number consecutive failures increase.
 type ExponentialBackoff struct {
+	failures uint64 // consecutive failure counter (needs to be 64-bit aligned)
 	config   ExponentialBackoffConfig
-	failures uint64 // consecutive failure counter.
 }
 
 // NewExponentialBackoff returns an exponential backoff strategy with the


### PR DESCRIPTION
- relates to moby/buildkit 1111
- relates to moby/buildkit 1079
- relates to docker/buildx 129

full diff: https://github.com/docker/go-events/compare/9461782956ad83b30282bf90e31fa6a70c255ba9...e31b211e4f1cd09aa76fe4ac244571fab96ae47f
