### PR TITLE
bugfix: add default host config if not set

### DIFF
--- a/remotes/docker/config/hosts.go
+++ b/remotes/docker/config/hosts.go
@@ -88,21 +88,20 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
 		if hosts == nil {
 			hosts = make([]hostConfig, 1)
 		}
-		if len(hosts) > 1 {
-			if hosts[len(hosts)-1].host == "" {
-				if host == "docker.io" {
-					hosts[len(hosts)-1].scheme = "https"
-					hosts[len(hosts)-1].host = "https://registry-1.docker.io"
+		if len(hosts) >= 1 && hosts[len(hosts)-1].host == "" {
+			if host == "docker.io" {
+				hosts[len(hosts)-1].scheme = "https"
+				hosts[len(hosts)-1].host = "registry-1.docker.io"
+			} else {
+				hosts[len(hosts)-1].host = host
+				if options.DefaultScheme != "" {
+					hosts[len(hosts)-1].scheme = options.DefaultScheme
 				} else {
-					hosts[len(hosts)-1].host = host
-					if options.DefaultScheme != "" {
-						hosts[len(hosts)-1].scheme = options.DefaultScheme
-					} else {
-						hosts[len(hosts)-1].scheme = "https"
-					}
+					hosts[len(hosts)-1].scheme = "https"
 				}
-				hosts[len(hosts)-1].path = "/v2"
 			}
+			hosts[len(hosts)-1].path = "/v2"
+			hosts[len(hosts)-1].capabilities = docker.HostCapabilityPull | docker.HostCapabilityResolve | docker.HostCapabilityPush
 		}
 
 		defaultTransport := &http.Transport{

--- a/remotes/docker/config/hosts.go
+++ b/remotes/docker/config/hosts.go
@@ -74,6 +74,7 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
 				return nil, err
 			}
 			if dir != "" {
+				log.G(ctx).WithField("dir", dir).Debug("loading host directory")
 				hosts, err = loadHostDir(ctx, dir)
 				if err != nil {
 					return nil, err
@@ -88,7 +89,7 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
 		if hosts == nil {
 			hosts = make([]hostConfig, 1)
 		}
-		if len(hosts) >= 1 && hosts[len(hosts)-1].host == "" {
+		if len(hosts) > 0 && hosts[len(hosts)-1].host == "" {
 			if host == "docker.io" {
 				hosts[len(hosts)-1].scheme = "https"
 				hosts[len(hosts)-1].host = "registry-1.docker.io"


### PR DESCRIPTION
If there is not specific host config, like ctr does, the resolver will
fail to get host path. And this patch is to add default host config if
needs.

And default config host config should have all caps for pull and push.

Signed-off-by: Wei Fu <fuweid89@gmail.com>