### PR TITLE
Start removal of Travis CI components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v2 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic TRAVIS_RELEASE=yes GOPROXY=direct
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v2 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct RUNC_FLAVOR=crun
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runtime.v1.linux TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct
-  - TRAVIS_GOOS=darwin TRAVIS_CGO_ENABLED=0 GOPROXY=direct
 
 matrix:
   include:
@@ -53,9 +52,6 @@ install:
   - sudo chmod og+rx /usr/local/include/google /usr/local/include/google/protobuf /usr/local/include/google/protobuf/compiler
   - sudo chmod -R og+r /usr/local/include/google/protobuf/
   - protoc --version
-  - go get -u github.com/vbatts/git-validation
-  - go get -u github.com/kunalkushwaha/ltag
-  - go get -u github.com/LK4D4/vndr
   - if [ "$TRAVIS_GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH script/setup/install-seccomp ; fi
   - if [ "$TRAVIS_GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH script/setup/install-runc ; fi
   - if [ "$TRAVIS_GOOS" = "linux" ]; then sudo PATH=$PATH GOPATH=$GOPATH script/setup/install-cni ; fi
@@ -65,20 +61,11 @@ install:
   - if [ "$TRAVIS_GOOS" = "linux" ]; then cd /tmp/criu-3.13 && sudo make install-criu ; fi
   - cd $TRAVIS_BUILD_DIR
 
-before_script:
-  - pushd ..; git clone https://github.com/containerd/project; popd
-
 script:
   - export GOOS=$TRAVIS_GOOS
   - export CGO_ENABLED=$TRAVIS_CGO_ENABLED
-  - DCO_VERBOSITY=-q ../project/script/validate/dco
-  - ../project/script/validate/fileheader ../project/
-  - travis_wait ../project/script/validate/vendor
   - GOOS=linux GO111MODULE=off script/setup/install-dev-tools
   - go build -i .
-  - make check
-  - if [ "$GOOS" = "linux" ]; then make check-protos check-api-descriptors; fi
-  - if [ "$TRAVIS_GOOS" = "linux" ]; then make man ; fi
   - make build
   - make binaries
   - if [ "$TRAVIS_GOOS" = "linux" ]; then sudo make install ; fi


### PR DESCRIPTION
Reduce duplication while we test GH actions.

For now:
 - no Darwin/macOS build: done in Actions and is a simple build with no testing
 - project "pre-checks" (DCO, whitespace, vendor, golangci-lint) all working well in actions
 - remove protobufs checks; working well in actions
 - remove manpage generation test (also working fine in actions)

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>