### PR TITLE
shimv2: Open log fifo with `RDWR` instead of `WRONLY`

### DIFF
--- a/runtime/v2/shim/shim_unix.go
+++ b/runtime/v2/shim/shim_unix.go
@@ -90,5 +90,5 @@ func handleSignals(ctx context.Context, logger *logrus.Entry, signals chan os.Si
 }
 
 func openLog(ctx context.Context, _ string) (io.Writer, error) {
-	return fifo.OpenFifo(ctx, "log", unix.O_WRONLY, 0700)
+	return fifo.OpenFifo(ctx, "log", unix.O_RDWR, 0700)
 }


### PR DESCRIPTION
The shim's log fifo is opened as O_WRONLY, when the read side of
fifo is closed temporarily such as restarting contaienrd, log to
the pipe will get an EPIPE error and thus after containerd
restarted, the shim's log wouldn't reconnected to the pipe.

Opening the log fifo with RDWR instead of WRONLY avoids the fifo
returning EPIPE when the read side is closed, and keeps the fifo open
until the reader reopening it.

Signed-off-by: fupan.lfp <fupan.lfp@antfin.com>