### PR TITLE
Bump Golang 1.13.10

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 0
   matrix:
-    - GO_VERSION: 1.13.9
+    - GO_VERSION: 1.13.10
 
 before_build:
   - choco install --no-progress -y mingw --version 5.3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.9'
+          go-version: '1.13.10'
 
       - name: Set env
         shell: bash
@@ -66,7 +66,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.9'
+          go-version: '1.13.10'
 
       - name: Set env
         shell: bash
@@ -138,7 +138,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.9'
+          go-version: '1.13.10'
 
       - name: Set env
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.9'
+          go-version: '1.13.10'
 
       - name: Checkout
         uses: actions/checkout@v1
@@ -123,7 +123,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.9'
+          go-version: '1.13.10'
 
       - name: Checkout
         uses: actions/checkout@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
 - linux
 
 go:
-  - "1.13.9"
+  - "1.13.10"
 
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.13.9
+ARG GOLANG_VERSION=1.13.10
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd


### PR DESCRIPTION
go1.13.10 (released 2020/04/08) includes fixes to the go command, the runtime,
os/exec, and time packages. See the Go 1.13.10 milestone on the issue tracker
for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.13.10+label%3ACherryPickApproved

full diff: https://github.com/golang/go/compare/go1.13.9...go1.13.10
