### PR TITLE
CI: Some Go 1.13.10 updates that were missed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.8'
+          go-version: '1.13.10'
 
       - name: Set env
         shell: bash
@@ -228,7 +228,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.8'
+          go-version: '1.13.10'
 
       - name: Set env
         shell: bash


### PR DESCRIPTION
This file was still on Go 1.13.8, which caused it to be missed when updating Go 1.13.9 to 1.13.10
