### PR TITLE
[release/1.3] revert pin vendors by git sha

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,89 +1,89 @@
 github.com/beorn7/perks                             4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
-github.com/BurntSushi/toml                          3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005 # v0.3.1
+github.com/BurntSushi/toml                          v0.3.1
 github.com/containerd/btrfs                         af5082808c833de0e79c1e72eea9fea239364877
 github.com/containerd/cgroups                       c4b9ac5c7601384c965b9646fc515884e091ebb9
-github.com/containerd/console                       8375c3424e4d7b114e8a90a4a40c8e1b40d1d4e6 # v1.0.0
+github.com/containerd/console                       v1.0.0
 github.com/containerd/continuity                    f2a389ac0a02ce21c09edd7344677a601970f41c
 github.com/containerd/fifo                          bda0ff6ed73c67bfb5e62bc9c697f146b7fd7f13
 github.com/containerd/go-runc                       e029b79d8cda8374981c64eba71f28ec38e5526f
-github.com/containerd/ttrpc                         92c8520ef9f86600c650dd540266a007bf03670f # v1.0.0
-github.com/containerd/typeurl                       a93fcdb778cd272c6e9b3028b2f42d813e785d40 # v1.0.0
+github.com/containerd/ttrpc                         v1.0.0
+github.com/containerd/typeurl                       v1.0.0
 github.com/coreos/go-systemd                        48702e0da86bd25e76cfef347e2adeb434a0d0a6
-github.com/cpuguy83/go-md2man                       7762f7e404f8416dfa1d9bb6a8c192aa9acb4d19 # v1.0.10
+github.com/cpuguy83/go-md2man                       v1.0.10
 github.com/docker/go-events                         e31b211e4f1cd09aa76fe4ac244571fab96ae47f
 github.com/docker/go-metrics                        4ea375f7759c82740c893fc030bc37088d2ec098
-github.com/docker/go-units                          519db1ee28dcc9fd2474ae59fca29a810482bfb1 # v0.4.0
-github.com/godbus/dbus                              c7fdd8b5cd55e87b4e1f4e372cdb1db61dd6c66f # v3
-github.com/gogo/googleapis                          d31c731455cb061f42baff3bda55bad0118b126b # v1.2.0
-github.com/gogo/protobuf                            ba06b47c162d49f2af050fb4c75bcbc86a159d5c # v1.2.1
-github.com/golang/protobuf                          aa810b61a9c79d51363740d207bb46cf8e620ed5 # v1.2.0
-github.com/google/go-cmp                            3af367b6b30c263d47e8895973edcca9a49cf029 # v0.2.0
-github.com/google/uuid                              0cd6bf5da1e1c83f8b45653022c74f71af0538a4 # v1.1.1
+github.com/docker/go-units                          v0.4.0
+github.com/godbus/dbus                              v3
+github.com/gogo/googleapis                          v1.2.0
+github.com/gogo/protobuf                            v1.2.1
+github.com/golang/protobuf                          v1.2.0
+github.com/google/go-cmp                            v0.2.0
+github.com/google/uuid                              v1.1.1
 github.com/grpc-ecosystem/go-grpc-prometheus        6b7015e65d366bf3f19b2b2a000a831940f0f7e0
-github.com/hashicorp/errwrap                        8a6fb523712970c966eefc6b39ed2c5e74880354 # v1.0.0
-github.com/hashicorp/go-multierror                  886a7fbe3eb1c874d46f623bfa70af45f425b3d1 # v1.0.0
-github.com/hashicorp/golang-lru                     7f827b33c0f158ec5dfbba01bb0b14a4541fd81d # v0.5.3
-github.com/imdario/mergo                            7c29201646fa3de8506f701213473dd407f19646 # v0.3.7
-github.com/konsorten/go-windows-terminal-sequences  5c8c8bd35d3832f5d134ae1e1e375b69a4d25242 # v1.0.1
-github.com/matttproud/golang_protobuf_extensions    c12348ce28de40eed0136aa2b644d0ee0650e56c # v1.0.1
-github.com/Microsoft/go-winio                       6c72808b55902eae4c5943626030429ff20f3b63 # v0.4.14
+github.com/hashicorp/errwrap                        v1.0.0
+github.com/hashicorp/go-multierror                  v1.0.0
+github.com/hashicorp/golang-lru                     v0.5.3
+github.com/imdario/mergo                            v0.3.7
+github.com/konsorten/go-windows-terminal-sequences  v1.0.1
+github.com/matttproud/golang_protobuf_extensions    v1.0.1
+github.com/Microsoft/go-winio                       v0.4.14
 github.com/Microsoft/hcsshim                        9e921883ac929bbe515b39793ece99ce3a9d7706
 github.com/opencontainers/go-digest                 c9281466c8b2f606084ac71339773efd177436e7
-github.com/opencontainers/image-spec                d60099175f88c47cd379c4738d158884749ed235 # v1.0.1
-github.com/opencontainers/runc                      dc9208a3303feef5b3839f4323d9beb36df0a9dd # v1.0.0-rc10
+github.com/opencontainers/image-spec                v1.0.1
+github.com/opencontainers/runc                      v1.0.0-rc10
 github.com/opencontainers/runtime-spec              29686dbc5559d93fb1ef402eeda3e35c38d75af4 # v1.0.1-59-g29686db
-github.com/pkg/errors                               ba968bfe8b2f7e042a574c888954fccecfa385b4 # v0.8.1
+github.com/pkg/errors                               v0.8.1
 github.com/prometheus/client_golang                 f4fb1b73fb099f396a7f0036bf86aa8def4ed823
 github.com/prometheus/client_model                  99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
 github.com/prometheus/common                        89604d197083d4781071d3c65855d24ecfb0a563
 github.com/prometheus/procfs                        cb4147076ac75738c9a7d279075a253c0cc5acbd
-github.com/russross/blackfriday                     05f3235734ad95d0016f6a23902f06461fcf567a # v1.5.2
-github.com/sirupsen/logrus                          8bdbc7bcc01dcbb8ec23dc8a28e332258d25251f # v1.4.1
+github.com/russross/blackfriday                     v1.5.2
+github.com/sirupsen/logrus                          v1.4.1
 github.com/syndtr/gocapability                      d98352740cb2c55f81556b63d4a1ec64c5a319c2
-github.com/urfave/cli                               bfe2e925cfb6d44b40ad3a779165ea7e8aff9212 # v1.22.0
-go.etcd.io/bbolt                                    a0458a2b35708eef59eb5f620ceb3cd1c01a824d # v1.3.3
-go.opencensus.io                                    9c377598961b706d1542bd2d84d538b5094d596e # v0.22.0
+github.com/urfave/cli                               v1.22.0
+go.etcd.io/bbolt                                    v1.3.3
+go.opencensus.io                                    v0.22.0
 golang.org/x/net                                    f3200d17e092c607f615320ecaad13d87ad9a2b3
 golang.org/x/sync                                   42b317875d0fa942474b76e1b46a6060d720ae6e
 golang.org/x/sys                                    9eafafc0a87e0fd0aeeba439a4573537970c44c7
 golang.org/x/text                                   19e51611da83d6be54ddafce4a4af510cb3e9ea4
 google.golang.org/genproto                          d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
-google.golang.org/grpc                              6eaf6f47437a6b4e2153a190160ef39a92c7eceb # v1.23.0
-gotest.tools                                        1083505acf35a0bd8a696b26837e1fb3187a7a83 # v2.3.0
+google.golang.org/grpc                              v1.23.0
+gotest.tools                                        v2.3.0
 
 # cri dependencies
 github.com/containerd/cri                           f864905c93b97db15503c217dc9a43eb65670b53 # release/1.3 branch
-github.com/davecgh/go-spew                          8991bc29aa16c548c550c7ff78260e27b9ab7c73 # v1.1.1
+github.com/davecgh/go-spew                          v1.1.1
 github.com/docker/distribution                      0d3efadf0154c2b8a4e7b6621fff9809655cc580
 github.com/docker/docker                            86f080cff0914e9694068ed78d503701667c4c00
 github.com/docker/spdystream                        449fdfce4d962303d702fec724ef0ad181c92528
-github.com/emicklei/go-restful                      b993709ae1a4f6dd19cfa475232614441b11c9d5 # v2.9.5
-github.com/google/gofuzz                            f140a6486e521aad38f5917de355cbf147cc0496 # v1.0.0
-github.com/json-iterator/go                         03217c3e97663914aec3faafde50d081f197a0a2 # v1.1.8
-github.com/modern-go/concurrent                     bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94 # 1.0.3
-github.com/modern-go/reflect2                       4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd # 1.0.1
+github.com/emicklei/go-restful                      v2.9.5
+github.com/google/gofuzz                            v1.0.0
+github.com/json-iterator/go                         v1.1.8
+github.com/modern-go/concurrent                     1.0.3
+github.com/modern-go/reflect2                       1.0.1
 github.com/opencontainers/selinux                   5215b1806f52b1fcc2070a8826c542c9d33cd3cf
-github.com/seccomp/libseccomp-golang                689e3c1541a84461afc49c1c87352a6cedf72e9c # v0.9.1
-github.com/tchap/go-patricia                        666120de432aea38ab06bd5c818f04f4129882c9 # v2.2.6
+github.com/seccomp/libseccomp-golang                v0.9.1
+github.com/tchap/go-patricia                        v2.2.6
 golang.org/x/crypto                                 69ecbb4d6d5dab05e49161c6e77ea40a030884e1
 golang.org/x/oauth2                                 0f29369cfe4552d0e4bcddc57cc75f4d7e672a33
 golang.org/x/time                                   9d24e82272b4f38b78bc8cff74fa936d31ccd8ef
-gopkg.in/inf.v0                                     d2d2541c53f18d2a059457998ce2876cc8e67cbf # v0.9.1
-gopkg.in/yaml.v2                                    53403b58ad1b561927d19068c655246f2db79d48 # v2.2.8
-k8s.io/api                                          955e84e216900b30afa183d8b097bd5bab3c8498 # v0.16.6
-k8s.io/apimachinery                                 f69eda767ee8601f65e8966e702f25a344dd2698 # v0.16.6
-k8s.io/apiserver                                    939931fab8e2b74de1bc7625002878d4818fef85 # v0.16.6
-k8s.io/client-go                                    e77b6202900a02e7f2b60dc323e53198bb631581 # v0.16.6
-k8s.io/cri-api                                      955518131889479dd539b11f39a033c865902a60 # v0.16.6
-k8s.io/klog                                         2ca9ad30301bf30a8a6e0fa2110db6b8df699a91 # v1.0.0
-k8s.io/kubernetes                                   72c30166b2105cd7d3350f2c28a219e6abcd79eb # v1.16.6
+gopkg.in/inf.v0                                     v0.9.1
+gopkg.in/yaml.v2                                    v2.2.8
+k8s.io/api                                          v0.16.6
+k8s.io/apimachinery                                 v0.16.6
+k8s.io/apiserver                                    v0.16.6
+k8s.io/client-go                                    v0.16.6
+k8s.io/cri-api                                      v0.16.6
+k8s.io/klog                                         v1.0.0
+k8s.io/kubernetes                                   v1.16.6
 k8s.io/utils                                        e782cd3c129fc98ee807f3c889c0f26eb7c9daf5
-sigs.k8s.io/yaml                                    fd68e9863619f6ec2fdd8625fe1f02e7c877e480 # v1.1.0
+sigs.k8s.io/yaml                                    v1.1.0
 
 # cni dependencies
 github.com/containerd/go-cni                        49fbd9b210f3c8ee3b7fd3cd797aabaf364627c1
-github.com/containernetworking/cni                  4cfb7b568922a3c79a23e438dc52fe537fc9687e # v0.7.1
-github.com/containernetworking/plugins              9f96827c7cabb03f21d86326000c00f61e181f6a # v0.7.6
+github.com/containernetworking/cni                  v0.7.1
+github.com/containernetworking/plugins              v0.7.6
 
 # zfs dependencies
 github.com/containerd/zfs                           2ceb2dbb8154202ed1b8fd32e4ea25b491d7b251


### PR DESCRIPTION
Continue using git tags to pin vendors when available. This needs needs more discussion on master and was not agreed on to backport. This currently breaks the release tool version comparison logic. Going forward, either the release tool needs to be updated to resolve sha to tag (and vendor checking validating tag comments), or we continue to use git tags to pin vendors.