### PR TITLE
Build runc with selinux support

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -212,7 +212,7 @@ Next, let's build `runc`:
 
 ```sh
 cd /go/src/github.com/opencontainers/runc
-make BUILDTAGS='seccomp apparmor' && make install
+make BUILDTAGS='seccomp apparmor selinux' && make install
 ```
 
 When working with `ctr`, the simple test client we just built, don't forget to start the daemon!

--- a/script/setup/install-runc
+++ b/script/setup/install-runc
@@ -26,7 +26,7 @@ function install_runc() {
 	go get -d github.com/opencontainers/runc
 	cd "$GOPATH"/src/github.com/opencontainers/runc
 	git checkout $RUNC_COMMIT
-	make BUILDTAGS='apparmor seccomp' runc install
+	make BUILDTAGS='seccomp apparmor selinux' runc install
 }
 
 function install_crun() {


### PR DESCRIPTION
docker-ce seems to be building runc with selinux support, let us follow
the same pattern here please:
https://github.com/docker/docker-ce/search?p=1&q=RUNC_BUILDTAGS&unscoped_q=RUNC_BUILDTAGS

Signed-off-by: Davanum Srinivas <davanum@gmail.com>