### PR TITLE
CRI plugin needs selinux tag as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,8 +93,8 @@ MANPAGES=ctr.8 containerd.8 containerd-config.8 containerd-config.toml.5
 ifdef BUILDTAGS
     GO_BUILDTAGS = ${BUILDTAGS}
 endif
-# Build tags seccomp and apparmor are needed by CRI plugin.
-GO_BUILDTAGS ?= seccomp apparmor
+# Build tags seccomp, apparmor and selinux are needed by CRI plugin.
+GO_BUILDTAGS ?= seccomp apparmor selinux
 GO_BUILDTAGS += ${DEBUG_TAGS}
 GO_TAGS=$(if $(GO_BUILDTAGS),-tags "$(GO_BUILDTAGS)",)
 GO_LDFLAGS=-ldflags '-X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PACKAGE) $(EXTRA_LDFLAGS)'


### PR DESCRIPTION
A simple `grep selinux_stub bin/containerd` shows that we are not using
selinux tag when building containerd. The CRI plugin pulls in a bunch of
selinux related code, so we need to enable this tag as well.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>