### PR TITLE
[release/1.3 backport] cgroups: throttle.* metrics must be kept for non-CFQ schedulers

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,7 +1,7 @@
 github.com/beorn7/perks                             4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
 github.com/BurntSushi/toml                          v0.3.1
 github.com/containerd/btrfs                         af5082808c833de0e79c1e72eea9fea239364877
-github.com/containerd/cgroups                       c4b9ac5c7601384c965b9646fc515884e091ebb9
+github.com/containerd/cgroups                       9f1c62dddf4bc7cc72822ebe353bae7006141b1b
 github.com/containerd/console                       v1.0.0
 github.com/containerd/continuity                    f2a389ac0a02ce21c09edd7344677a601970f41c
 github.com/containerd/fifo                          bda0ff6ed73c67bfb5e62bc9c697f146b7fd7f13


### PR DESCRIPTION
Backport cgroups bug fix https://github.com/containerd/cgroups/pull/147

master: https://github.com/containerd/containerd/pull/4146

Signed-off-by: Maksym Pavlenko <makpav@amazon.com>