### PR TITLE
Small fixes to our Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,11 @@ jobs:
             runc: crun
 
     steps:
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.13.10'
+
       - name: Set env
         shell: bash
         run: |
@@ -279,19 +284,10 @@ jobs:
         env:
           RUNC_FLAVOR: ${{ matrix.runc }}
         run: |
-          sudo PATH=$PATH GOPATH=$GOPATH script/setup/install-seccomp
-          sudo PATH=$PATH GOPATH=$GOPATH RUNC_FLAVOR=$RUNC_FLAVOR script/setup/install-runc
-          sudo PATH=$PATH GOPATH=$GOPATH script/setup/install-cni
-          sudo PATH=$PATH GOPATH=$GOPATH script/setup/install-critools
-        working-directory: src/github.com/containerd/containerd
-
-      - name: Install protobuf
-        run: |
-          sudo env PATH=$PATH GOPATH=$GOPATH script/setup/install-protobuf
-          sudo chmod +x /usr/local/bin/protoc
-          sudo chmod og+rx /usr/local/include/google /usr/local/include/google/protobuf /usr/local/include/google/protobuf/compiler
-          sudo chmod -R og+r /usr/local/include/google/protobuf/
-          protoc --version
+          sudo PATH=$PATH script/setup/install-seccomp
+          script/setup/install-runc
+          script/setup/install-cni
+          script/setup/install-critools
         working-directory: src/github.com/containerd/containerd
 
       - name: Install criu

--- a/script/setup/install-cni
+++ b/script/setup/install-cni
@@ -29,10 +29,10 @@ go get -d github.com/containernetworking/plugins/...
 cd "$GOPATH"/src/github.com/containernetworking/plugins
 git checkout $CNI_COMMIT
 FASTBUILD=true ./build.sh
-mkdir -p $CNI_DIR
-cp -r ./bin $CNI_DIR
-mkdir -p $CNI_CONFIG_DIR
-cat > $CNI_CONFIG_DIR/10-containerd-net.conflist <<EOF
+sudo mkdir -p $CNI_DIR
+sudo cp -r ./bin $CNI_DIR
+sudo mkdir -p $CNI_CONFIG_DIR
+cat <<EOF | sudo tee $CNI_CONFIG_DIR/10-containerd-net.conflist
 {
   "cniVersion": "0.3.1",
   "name": "containerd-net",

--- a/script/setup/install-critools
+++ b/script/setup/install-critools
@@ -26,4 +26,4 @@ go get -d github.com/kubernetes-sigs/cri-tools/...
 cd "$GOPATH"/src/github.com/kubernetes-sigs/cri-tools
 git checkout $CRITEST_COMMIT
 make
-make install
+sudo make install

--- a/script/setup/install-runc
+++ b/script/setup/install-runc
@@ -26,13 +26,14 @@ function install_runc() {
 	go get -d github.com/opencontainers/runc
 	cd "$GOPATH"/src/github.com/opencontainers/runc
 	git checkout $RUNC_COMMIT
-	make BUILDTAGS='seccomp apparmor selinux' runc install
+	make BUILDTAGS='apparmor seccomp selinux' runc
+	sudo make install
 }
 
 function install_crun() {
 	CRUN_VERSION=0.11
-	curl -o /usr/local/sbin/runc -L https://github.com/containers/crun/releases/download/${CRUN_VERSION}/crun-${CRUN_VERSION}-static-$(uname -m)
-	chmod +x /usr/local/sbin/runc
+	sudo curl -o /usr/local/sbin/runc -L https://github.com/containers/crun/releases/download/${CRUN_VERSION}/crun-${CRUN_VERSION}-static-$(uname -m)
+	sudo chmod +x /usr/local/sbin/runc
 }
 
 : ${RUNC_FLAVOR=runc}


### PR DESCRIPTION
Integration tests were running with latest Go release rather than the
version used everywhere else. Also, we don't need to install protoc from
tarball and also apt-get the package for Ubuntu when used as a
dependency for criu build.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>