### PR TITLE
Use actions v2 on nightly ci

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Build amd64
         env:
-          GOPATH: ${{ runner.workspace }}
+          GOPATH: ${{ runner.workspace }}/containerd
           GOOS: linux
           GOARCH: amd64
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,12 +18,12 @@ jobs:
           go-version: '1.13.10'
 
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         env:
           GOPATH: ${{ runner.workspace }}
           GO111MODULE: off
         with:
-          path: ./src/github.com/containerd/containerd
+          path: src/github.com/containerd/containerd
 
       #
       # Build
@@ -129,12 +129,12 @@ jobs:
           go-version: '1.13.10'
 
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         env:
           GOPATH: ${{ runner.workspace }}
           GO111MODULE: off
         with:
-          path: ./src/github.com/containerd/containerd
+          path: src/github.com/containerd/containerd
 
       - name: Build amd64
         env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,6 +57,7 @@ jobs:
         run: |
           make binaries
           mv bin bin_amd64
+        working-directory: src/github.com/containerd/containerd
 
       - name: Build arm64
         env:
@@ -68,6 +69,7 @@ jobs:
         run: |
           make binaries
           mv bin bin_arm64
+        working-directory: src/github.com/containerd/containerd
 
       - name: Build s390x
         env:
@@ -79,6 +81,7 @@ jobs:
         run: |
           make binaries
           mv bin bin_s390x
+        working-directory: src/github.com/containerd/containerd
 
       - name: Build ppc64le
         env:
@@ -90,6 +93,7 @@ jobs:
         run: |
           make binaries
           mv bin bin_ppc64le
+        working-directory: src/github.com/containerd/containerd
 
       #
       # Upload
@@ -143,6 +147,7 @@ jobs:
           GOARCH: amd64
         run: |
           make binaries
+        working-directory: src/github.com/containerd/containerd
 
       - name: Upload artifacts (windows_amd64)
         uses: actions/upload-artifact@v1


### PR DESCRIPTION
The main CI uses checkout@v2 so I made nightly follows it!