### PR TITLE
Disable Travis CI on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 dist: bionic
 sudo: required
+
+branches:
+  except:
+    - master
+
 # setup travis so that we can run containers for integration tests
 services:
   - docker


### PR DESCRIPTION
This allows Travis to continue running on PRs for release/1.x branches
where we have not enabled GH Actions.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>