### PR TITLE
This config no longer exists, so remove from docs.

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,7 +19,6 @@ The daemon also uses a configuration file located in `/etc/containerd/config.tom
 A sample configuration file looks like this:
 
 ```toml
-subreaper = true
 oom_score = -999
 
 [debug]

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -82,9 +82,6 @@ There are a few settings that are important for ops.
 The first setting is the `oom_score`.  Because containerd will be managing multiple containers, we need to ensure that containers are killed before the containerd daemon in an out of memory condition.
 We also do not want to make containerd unkillable, but we want to lower its score to the level of other system daemons.
 
-The `subreaper` setting is also important on linux systems.
-This allows containerd to reap any re-parented processes from the shims or containers.
-
 containerd also exports its own metrics as well as container level metrics via the prometheus metrics format.
 Currently, prometheus only supports TCP endpoints, therefore, the metrics address should be a TCP address that your prometheus infrastructure can scrape metrics from.
 
@@ -161,8 +158,6 @@ External apps reading or watching changes in these directories have been known t
 root = "/var/lib/containerd"
 # runtime state information
 state = "/run/containerd"
-# set containerd as a subreaper on linux when it is not running as PID 1
-subreaper = true
 # set containerd's OOM score
 oom_score = -999
 


### PR DESCRIPTION
This was changed to `no_subreaper` in
6e9f24b71129ea9457ad707b0880a8277232ab3b and, as far as I can tell,
`no_subreaper` doesn't exist as a config anymore.