### PR TITLE
Binary IO fixes and tests

### DIFF
--- a/pkg/process/io.go
+++ b/pkg/process/io.go
@@ -383,11 +383,7 @@ func (b *binaryIO) cancel() error {
 
 	done := make(chan error)
 	go func() {
-		err := b.cmd.Wait()
-		if err != nil {
-			err = errors.Wrap(err, "failed to wait for shim logger process after SIGTERM")
-		}
-		done <- err
+		done <- b.cmd.Wait()
 	}()
 
 	select {

--- a/pkg/process/io_test.go
+++ b/pkg/process/io_test.go
@@ -1,0 +1,72 @@
+// +build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package process
+
+import (
+	"context"
+	"io/ioutil"
+	"net/url"
+	"testing"
+
+	"github.com/containerd/containerd/namespaces"
+)
+
+func TestNewBinaryIO(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	uri, _ := url.Parse("binary:///bin/echo?test")
+
+	before := descriptorCount(t)
+
+	io, err := NewBinaryIO(ctx, "1", uri)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = io.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	after := descriptorCount(t)
+	if before != after-1 { // one descriptor must be closed from shim logger side
+		t.Fatalf("some descriptors weren't closed (%d != %d)", before, after)
+	}
+}
+
+func TestNewBinaryIOCleanup(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "test")
+	uri, _ := url.Parse("binary:///not/existing")
+
+	before := descriptorCount(t)
+	_, err := NewBinaryIO(ctx, "2", uri)
+	if err == nil {
+		t.Fatal("error expected for invalid binary")
+	}
+
+	after := descriptorCount(t)
+	if before != after {
+		t.Fatalf("some descriptors weren't closed (%d != %d)", before, after)
+	}
+}
+
+func descriptorCount(t *testing.T) int {
+	t.Helper()
+	files, _ := ioutil.ReadDir("/proc/self/fd")
+	return len(files)
+}


### PR DESCRIPTION
This PR:
- Addresses @fuweid's [comment](https://github.com/containerd/containerd/pull/4162/files#r405644727) to cleanup allocated resources in case of error in `NewBinaryIO`.
- Hardcodes SIGTERM timeout to 10 seconds. No longer rely on `timeout` package, since shim binary doesn't load `config.toml` file and hence doesn't contain configured timeouts.
- Adds tests to make sure proper resource cleanup (by counting open descriptors).
