### PR TITLE
oci: Enable cgroup namespace by default when use cgroup v2

### DIFF
--- a/oci/spec.go
+++ b/oci/spec.go
@@ -21,6 +21,8 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/containerd/cgroups"
+
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/platforms"
 
@@ -110,7 +112,7 @@ func defaultUnixCaps() []string {
 }
 
 func defaultUnixNamespaces() []specs.LinuxNamespace {
-	return []specs.LinuxNamespace{
+	specNs := []specs.LinuxNamespace{
 		{
 			Type: specs.PIDNamespace,
 		},
@@ -127,6 +129,12 @@ func defaultUnixNamespaces() []specs.LinuxNamespace {
 			Type: specs.NetworkNamespace,
 		},
 	}
+	if cgroups.Mode() == cgroups.Unified {
+		specNs = append(specNs, specs.LinuxNamespace{
+			Type: specs.CgroupNamespace,
+		})
+	}
+	return specNs
 }
 
 func populateDefaultUnixSpec(ctx context.Context, s *Spec, id string) error {


### PR DESCRIPTION
As of now, the default setting of moby and runc and so on was changed to use cgroup namespace when use cgorup v2.

- https://github.com/moby/moby/commit/19baeaca267d5710907ac1
- https://github.com/opencontainers/runc/pull/2322

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>