### PR TITLE
runtime: ignore ttrpc closed error

### DIFF
--- a/runtime/v2/shim.go
+++ b/runtime/v2/shim.go
@@ -226,9 +226,12 @@ func (s *shim) Delete(ctx context.Context) (*runtime.Exit, error) {
 		ID: s.ID(),
 	})
 	if shimErr != nil {
-		shimErr = errdefs.FromGRPC(shimErr)
-		if !errdefs.IsNotFound(shimErr) {
-			return nil, shimErr
+		log.G(ctx).WithField("id", s.ID()).WithError(shimErr).Debug("failed to delete task")
+		if errors.Cause(shimErr) != ttrpc.ErrClosed {
+			shimErr = errdefs.FromGRPC(shimErr)
+			if !errdefs.IsNotFound(shimErr) {
+				return nil, shimErr
+			}
 		}
 	}
 	// remove self from the runtime task list

--- a/vendor.conf
+++ b/vendor.conf
@@ -7,7 +7,7 @@ github.com/containerd/console                       8375c3424e4d7b114e8a90a4a40c
 github.com/containerd/continuity                    0ec596719c75bfd42908850990acea594b7593ac
 github.com/containerd/fifo                          bda0ff6ed73c67bfb5e62bc9c697f146b7fd7f13
 github.com/containerd/go-runc                       a5c2862aed5e6358b305b0e16bfce58e0549b1cd
-github.com/containerd/ttrpc                         92c8520ef9f86600c650dd540266a007bf03670f # v1.0.0
+github.com/containerd/ttrpc                         6e416eafd26e6e738df716b21d421d5b59702bb4
 github.com/containerd/typeurl                       a93fcdb778cd272c6e9b3028b2f42d813e785d40 # v1.0.0
 github.com/coreos/go-systemd/v22                    2d78030078ef61b3cae27f42ad6d0e46db51b339 # v22.0.0
 github.com/cpuguy83/go-md2man                       7762f7e404f8416dfa1d9bb6a8c192aa9acb4d19 # v1.0.10

--- a/vendor/github.com/containerd/ttrpc/client.go
+++ b/vendor/github.com/containerd/ttrpc/client.go
@@ -338,9 +338,12 @@ func filterCloseErr(err error) error {
 	case strings.Contains(err.Error(), "use of closed network connection"):
 		return ErrClosed
 	default:
-		// if we have an epipe on a write, we cast to errclosed
-		if oerr, ok := err.(*net.OpError); ok && oerr.Op == "write" {
-			if serr, ok := oerr.Err.(*os.SyscallError); ok && serr.Err == syscall.EPIPE {
+		// if we have an epipe on a write or econnreset on a read , we cast to errclosed
+		if oerr, ok := err.(*net.OpError); ok && (oerr.Op == "write" || oerr.Op == "read") {
+			serr, sok := oerr.Err.(*os.SyscallError)
+			if sok && ((serr.Err == syscall.EPIPE && oerr.Op == "write") ||
+				(serr.Err == syscall.ECONNRESET && oerr.Op == "read")) {
+
 				return ErrClosed
 			}
 		}

--- a/vendor/github.com/containerd/ttrpc/go.mod
+++ b/vendor/github.com/containerd/ttrpc/go.mod
@@ -1,0 +1,13 @@
+module github.com/containerd/ttrpc
+
+go 1.12
+
+require (
+	github.com/gogo/protobuf v1.2.1
+	github.com/pkg/errors v0.8.1
+	github.com/prometheus/procfs v0.0.0-20190522114515-bc1a522cf7b1
+	github.com/sirupsen/logrus v1.4.2
+	golang.org/x/sys v0.0.0-20190522044717-8097e1b27ff5
+	google.golang.org/genproto v0.0.0-20190522204451-c2c4e71fbf69
+	google.golang.org/grpc v1.21.0
+)


### PR DESCRIPTION
For some reason, shimv2 process doesn't exist. The ttrpc doesn't detect
the connection closed by server until delete task. For this case, we
should ignore the ttrpc.ErrClosed and let task manager handle the
cleanup.

And update ttrpc vendor with 6e416eafd26e6e738df716b21d421d5b59702bb4 to have better ErrClosed filter.

Signed-off-by: Wei Fu <fuweid89@gmail.com>