### PR TITLE
.zuul: update go version to 1.13.10

### DIFF
--- a/.zuul/playbooks/containerd-build/run.yaml
+++ b/.zuul/playbooks/containerd-build/run.yaml
@@ -1,21 +1,23 @@
 - hosts: all
   become: yes
   roles:
-    - role: config-golang
-      arch: arm64
+  - role: config-golang
+    go_version: '1.13.10'
+    arch: arm64
   tasks:
-    - name: Build containerd
-      shell:
-        cmd: |
-          set -xe
-          set -o pipefail
-          apt-get update
-          apt-get install -y btrfs-tools libseccomp-dev git pkg-config
+  - name: Build containerd
+    shell:
+      cmd: |
+        set -xe
+        set -o pipefail
+        apt-get update
+        apt-get install -y btrfs-tools libseccomp-dev git pkg-config
 
-          make | tee $LOGS_PATH/make.txt
-          make test | tee $LOGS_PATH/make_test.txt
+        go version
+        make | tee $LOGS_PATH/make.txt
+        make test | tee $LOGS_PATH/make_test.txt
 
-          cp -r ./bin $RESULTS_PATH
-        chdir: '{{ zuul.project.src_dir }}'
-        executable: /bin/bash
-      environment: '{{ global_env }}'
+        cp -r ./bin $RESULTS_PATH
+      chdir: '{{ zuul.project.src_dir }}'
+      executable: /bin/bash
+    environment: '{{ global_env }}'

--- a/runtime/v2/shim/shim_test.go
+++ b/runtime/v2/shim/shim_test.go
@@ -24,11 +24,14 @@ import (
 )
 
 func TestRuntimeWithEmptyMaxEnvProcs(t *testing.T) {
+	var oldGoMaxProcs = runtime.GOMAXPROCS(0)
+	defer runtime.GOMAXPROCS(oldGoMaxProcs)
 
 	os.Setenv("GOMAXPROCS", "")
 	setRuntime()
-	var oldGoMaxProcs = runtime.GOMAXPROCS(0)
-	if oldGoMaxProcs != 2 {
+
+	var currentGoMaxProcs = runtime.GOMAXPROCS(0)
+	if currentGoMaxProcs != 2 {
 		t.Fatal("the max number of procs should be 2")
 	}
 }


### PR DESCRIPTION
* update go version for aarch64 testing
* fix flaky test case
   * TestRuntimeWithEmptyMaxEnvProcs should restore the GoMaxProcs after
    test so that the temporary change of GoMaxProcs will not impact other
    case, like TestRuntimeWithNonEmptyMaxEnvProcs.

Signed-off-by: Wei Fu <fuweid89@gmail.com>