### PR TITLE
fix incomplete host device for PrivilegedWithoutHostDevices

### DIFF
--- a/vendor/github.com/containerd/cri/pkg/server/container_create_unix.go
+++ b/vendor/github.com/containerd/cri/pkg/server/container_create_unix.go
@@ -172,6 +172,9 @@ func (c *criService) containerSpec(id string, sandboxID string, sandboxPid uint3
 		specOpts = append(specOpts, oci.WithPrivileged)
 		if !ociRuntime.PrivilegedWithoutHostDevices {
 			specOpts = append(specOpts, oci.WithHostDevices, oci.WithAllDevicesAllowed)
+		} else {
+			// add requested devices by the config as host devices are not automatically added
+			specOpts = append(specOpts, customopts.WithDevices(c.os, config), customopts.WithCapabilities(securityContext))
 		}
 	} else { // not privileged
 		specOpts = append(specOpts, customopts.WithDevices(c.os, config), customopts.WithCapabilities(securityContext))


### PR DESCRIPTION
For a privilege pods with PrivilegedWithoutHostDevices set to true
host device specified in the config are not provided (whereas it is done for
non privilege pods or privilege pods with PrivilegedWithoutHostDevices set
to false as all devices are included).

Add them in this case.

Fixes: 9cbd18ac76ac ("Update cri to f1d492b0cdd14e76476ee4dd024696ce3634e501.")
Signed-off-by: Thibaut Collet <thibaut.collet@6wind.com>