### PR TITLE
Backport better support windows binaries to 1.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,10 +92,10 @@ GO_GCFLAGS=$(shell				\
 	echo "-gcflags=-trimpath=$${1}/src";	\
 	)
 
+BINARIES=$(addprefix bin/,$(COMMANDS))
+
 #include platform specific makefile
 -include Makefile.$(GOOS)
-
-BINARIES=$(addprefix bin/,$(COMMANDS))
 
 # Flags passed to `go test`
 TESTFLAGS ?= -v $(TESTFLAGS_RACE) $(EXTRA_TESTFLAGS)
@@ -164,10 +164,14 @@ benchmark: ## run benchmarks tests
 
 FORCE:
 
+define BUILD_BINARY =
+@echo "$(WHALE) $@"
+@go build ${GO_GCFLAGS} ${GO_BUILD_FLAGS} -o $@ ${GO_LDFLAGS} ${GO_TAGS}  ./$<
+endef
+
 # Build a binary from a cmd.
 bin/%: cmd/% FORCE
-	@echo "$(WHALE) $@${BINARY_SUFFIX}"
-	@go build ${GO_GCFLAGS} ${GO_BUILD_FLAGS} -o $@${BINARY_SUFFIX} ${GO_LDFLAGS} ${GO_TAGS}  ./$<
+	$(BUILD_BINARY)
 
 bin/containerd-shim: cmd/containerd-shim FORCE # set !cgo and omit pie for a static shim build: https://github.com/golang/go/issues/17789#issuecomment-258542220
 	@echo "$(WHALE) bin/containerd-shim"

--- a/Makefile.windows
+++ b/Makefile.windows
@@ -18,8 +18,6 @@ WHALE = "+"
 ONI = "-"
 COMMANDS += containerd-shim-runhcs-v1
 
-BINARY_SUFFIX=".exe"
-
 # amd64 supports go test -race
 ifeq ($(GOARCH),amd64)
 	TESTFLAGS_RACE= -race
@@ -31,3 +29,8 @@ endif
 ifeq (${BUILD_WINDOWS_V2},1)
 	BUILDTAGS += windows_v2
 endif
+
+BINARIES:=$(addsuffix .exe,$(BINARIES))
+
+bin/%.exe: cmd/% FORCE
+	$(BUILD_BINARY)


### PR DESCRIPTION
Backport of #3823 to 1.2 releases to make containerd-packaging work with both master and 1.2.x release branch.
