### PR TITLE
Allow more time for containerd to start for integration

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -108,7 +108,7 @@ func TestMain(m *testing.M) {
 		}
 	}
 
-	waitCtx, waitCancel := context.WithTimeout(ctx, 2*time.Second)
+	waitCtx, waitCancel := context.WithTimeout(ctx, 4*time.Second)
 	client, err := ctrd.waitForStart(waitCtx)
 	waitCancel()
 	if err != nil {


### PR DESCRIPTION
Test hardcoded 2 seconds and in GitHub actions we see a cancel randomly
right at 2 seconds even though containerd is within milliseconds of
being ready.

Example:
```
FAIL	github.com/containerd/containerd	2.043s
```

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>