### PR TITLE
Fallback to request scope if missing from auth challange

### DIFF
--- a/remotes/docker/authorizer.go
+++ b/remotes/docker/authorizer.go
@@ -198,6 +198,11 @@ func (a *dockerAuthorizer) generateTokenOptions(ctx context.Context, host string
 	scope, ok := c.parameters["scope"]
 	if ok {
 		to.scopes = append(to.scopes, scope)
+	}
+	// fallback to request scope if there's no scope in the challenge
+	if v := ctx.Value(tokenScopesKey{}); !ok && v != nil {
+		scopes := v.([]string)
+		to.scopes = append(to.scopes, scopes...)
 	} else {
 		log.G(ctx).WithField("host", host).Debug("no scope specified for token auth challenge")
 	}


### PR DESCRIPTION
I've run across an issue similar to these: https://github.com/containerd/containerd/issues/3761 https://github.com/containerd/containerd/issues/3556

The general consensus is that this is an issue with the registry - which does seem to be the case for me as well (a badly behaving proxy is likely the culprit).

This change adds a fallback to fill in the scope (if missing from the auth challenge) by using the scope of the original request. In my case (and I suspect the linked cases as well), this fixes the issue. 

This fallback behavior seems like a reasonable change to make the resolver more robust, even if there are good arguments to be made that the registry is not to spec. I'm interested in any feedback on this approach, and would love to merge it if there's some consensus.