### PR TITLE
Remove libcontainer from containerd-shim

### DIFF
--- a/cmd/containerd-shim/shim_linux.go
+++ b/cmd/containerd-shim/shim_linux.go
@@ -20,10 +20,10 @@ import (
 	"os"
 	"os/signal"
 
+	"github.com/containerd/containerd/sys"
 	"github.com/containerd/containerd/sys/reaper"
 	runc "github.com/containerd/go-runc"
 	"github.com/containerd/ttrpc"
-	"github.com/opencontainers/runc/libcontainer/system"
 	"golang.org/x/sys/unix"
 )
 
@@ -36,7 +36,7 @@ func setupSignals() (chan os.Signal, error) {
 	// for waiting on processes
 	runc.Monitor = reaper.Default
 	// set the shim as the subreaper for all orphaned processes created by the container
-	if err := system.SetSubreaper(1); err != nil {
+	if err := sys.SetSubreaper(1); err != nil {
 		return nil, err
 	}
 	return signals, nil


### PR DESCRIPTION
Libcontainer was only used for a single function, which in itself was just a tiny wrapper around `golang.org/x/sys/unix`; https://github.com/opencontainers/runc/blob/dbe44cbb1099eabfaa753322be2055a0a6e8fe2d/libcontainer/system/linux.go#L127-L130

```go
// SetSubreaper sets the value i as the subreaper setting for the calling process
func SetSubreaper(i int) error {
	return unix.Prctl(unix.PR_SET_CHILD_SUBREAPER, uintptr(i), 0, 0, 0)
}
```

This patch replaces it with the implementation in our sys package
