### PR TITLE
[ci] install runc with gosu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,6 +269,16 @@ jobs:
         with:
           go-version: '1.13.10'
 
+      - name: Setup gosu
+        shell: bash
+        run: |
+          GOSU=/usr/local/bin/gosu
+          arch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"
+          sudo wget -O ${GOSU} "https://github.com/tianon/gosu/releases/download/1.12/gosu-$arch"
+          sudo chmod +x ${GOSU}
+          sudo chown root ${GOSU}
+          sudo chmod +s ${GOSU}
+
       - name: Set env
         shell: bash
         run: |
@@ -285,7 +295,7 @@ jobs:
           RUNC_FLAVOR: ${{ matrix.runc }}
         run: |
           sudo PATH=$PATH script/setup/install-seccomp
-          script/setup/install-runc
+          gosu root script/setup/install-runc
           script/setup/install-cni
           script/setup/install-critools
         working-directory: src/github.com/containerd/containerd

--- a/script/setup/install-runc
+++ b/script/setup/install-runc
@@ -27,13 +27,13 @@ function install_runc() {
 	cd "$GOPATH"/src/github.com/opencontainers/runc
 	git checkout $RUNC_COMMIT
 	make BUILDTAGS='apparmor seccomp selinux' runc
-	sudo make install
+	make install
 }
 
 function install_crun() {
 	CRUN_VERSION=0.11
-	sudo curl -o /usr/local/sbin/runc -L https://github.com/containers/crun/releases/download/${CRUN_VERSION}/crun-${CRUN_VERSION}-static-$(uname -m)
-	sudo chmod +x /usr/local/sbin/runc
+	curl -o /usr/local/sbin/runc -L https://github.com/containers/crun/releases/download/${CRUN_VERSION}/crun-${CRUN_VERSION}-static-$(uname -m)
+	chmod +x /usr/local/sbin/runc
 }
 
 : ${RUNC_FLAVOR=runc}


### PR DESCRIPTION
Signed-off-by: fahedouch fahed.dorgaa@gmail.com

removing `sudo` from the script  `install-runc` command lines and call  `install-runc` with sudo privileges using `gosu` in GH Actions ci.

PS : Sudo and Golang do not get along in GH Actions. ([source](https://github.com/containerd/containerd/pull/4224#issuecomment-622990022))