### PR TITLE
Replace errors.Cause() with errors.Is()

### DIFF
--- a/archive/tar.go
+++ b/archive/tar.go
@@ -361,7 +361,7 @@ func createTarFile(ctx context.Context, path, extractDir string, hdr *tar.Header
 		if strings.HasPrefix(key, paxSchilyXattr) {
 			key = key[len(paxSchilyXattr):]
 			if err := setxattr(path, key, value); err != nil {
-				if errors.Cause(err) == syscall.ENOTSUP {
+				if errors.Is(err, syscall.ENOTSUP) {
 					log.G(ctx).WithError(err).Warnf("ignored xattr %s in archive", key)
 					continue
 				}

--- a/archive/tar_test.go
+++ b/archive/tar_test.go
@@ -317,7 +317,7 @@ func TestBreakouts(t *testing.T) {
 			if err == nil {
 				return errors.New("files are the same, expected diff")
 			}
-			if errors.Cause(err) != errFileDiff {
+			if !errors.Is(err, errFileDiff) {
 				return err
 			}
 			return nil
@@ -932,7 +932,7 @@ func makeWriterToTarTest(wt tartest.WriterToTar, a fstest.Applier, validate func
 		if _, err := Apply(context.Background(), td, tr); err != nil {
 			if applyErr == nil {
 				t.Fatalf("Failed to apply tar: %v", err)
-			} else if errors.Cause(err) != applyErr {
+			} else if !errors.Is(err, applyErr) {
 				t.Fatalf("Unexpected apply error: %v, expected %v", err, applyErr)
 			}
 			return

--- a/container_linux_test.go
+++ b/container_linux_test.go
@@ -44,7 +44,6 @@ import (
 	"github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/containerd/containerd/sys"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 
@@ -1539,7 +1538,7 @@ func TestContainerNoImage(t *testing.T) {
 	if err == nil {
 		t.Fatal("error should not be nil when container is created without an image")
 	}
-	if errors.Cause(err) != errdefs.ErrNotFound {
+	if !errdefs.IsNotFound(err) {
 		t.Fatalf("expected error to be %s but received %s", errdefs.ErrNotFound, err)
 	}
 }

--- a/container_opts.go
+++ b/container_opts.go
@@ -226,7 +226,7 @@ func WithContainerExtension(name string, extension interface{}) NewContainerOpts
 
 		any, err := typeurl.MarshalAny(extension)
 		if err != nil {
-			if errors.Cause(err) == typeurl.ErrNotFound {
+			if errors.Is(err, typeurl.ErrNotFound) {
 				return errors.Wrapf(err, "extension %q is not registered with the typeurl package, see `typeurl.Register`", name)
 			}
 			return errors.Wrap(err, "error marshalling extension")

--- a/errdefs/errors.go
+++ b/errdefs/errors.go
@@ -51,43 +51,43 @@ var (
 
 // IsInvalidArgument returns true if the error is due to an invalid argument
 func IsInvalidArgument(err error) bool {
-	return errors.Cause(err) == ErrInvalidArgument
+	return errors.Is(err, ErrInvalidArgument)
 }
 
 // IsNotFound returns true if the error is due to a missing object
 func IsNotFound(err error) bool {
-	return errors.Cause(err) == ErrNotFound
+	return errors.Is(err, ErrNotFound)
 }
 
 // IsAlreadyExists returns true if the error is due to an already existing
 // metadata item
 func IsAlreadyExists(err error) bool {
-	return errors.Cause(err) == ErrAlreadyExists
+	return errors.Is(err, ErrAlreadyExists)
 }
 
 // IsFailedPrecondition returns true if an operation could not proceed to the
 // lack of a particular condition
 func IsFailedPrecondition(err error) bool {
-	return errors.Cause(err) == ErrFailedPrecondition
+	return errors.Is(err, ErrFailedPrecondition)
 }
 
 // IsUnavailable returns true if the error is due to a resource being unavailable
 func IsUnavailable(err error) bool {
-	return errors.Cause(err) == ErrUnavailable
+	return errors.Is(err, ErrUnavailable)
 }
 
 // IsNotImplemented returns true if the error is due to not being implemented
 func IsNotImplemented(err error) bool {
-	return errors.Cause(err) == ErrNotImplemented
+	return errors.Is(err, ErrNotImplemented)
 }
 
 // IsCanceled returns true if the error is due to `context.Canceled`.
 func IsCanceled(err error) bool {
-	return errors.Cause(err) == context.Canceled
+	return errors.Is(err, context.Canceled)
 }
 
 // IsDeadlineExceeded returns true if the error is due to
 // `context.DeadlineExceeded`.
 func IsDeadlineExceeded(err error) bool {
-	return errors.Cause(err) == context.DeadlineExceeded
+	return errors.Is(err, context.DeadlineExceeded)
 }

--- a/errdefs/grpc_test.go
+++ b/errdefs/grpc_test.go
@@ -88,6 +88,9 @@ func TestGRPCRoundTrip(t *testing.T) {
 			if errors.Cause(ferr) != testcase.cause {
 				t.Fatalf("unexpected cause: %v != %v", errors.Cause(ferr), testcase.cause)
 			}
+			if !errors.Is(ferr, testcase.cause) {
+				t.Fatalf("unexpected cause: !errors.Is(%v, %v)", ferr, testcase.cause)
+			}
 
 			expected := testcase.str
 			if expected == "" {

--- a/events/exchange/exchange_test.go
+++ b/events/exchange/exchange_test.go
@@ -300,7 +300,7 @@ func TestExchangeValidateTopic(t *testing.T) {
 	} {
 		t.Run(testcase.input, func(t *testing.T) {
 			event := &eventstypes.ContainerCreate{ID: t.Name()}
-			if err := exchange.Publish(ctx, testcase.input, event); errors.Cause(err) != testcase.err {
+			if err := exchange.Publish(ctx, testcase.input, event); !errors.Is(err, testcase.err) {
 				if err == nil {
 					t.Fatalf("expected error %v, received nil", testcase.err)
 				} else {
@@ -321,7 +321,7 @@ func TestExchangeValidateTopic(t *testing.T) {
 			}
 
 			// make sure we get same errors with forward.
-			if err := exchange.Forward(ctx, &envelope); errors.Cause(err) != testcase.err {
+			if err := exchange.Forward(ctx, &envelope); !errors.Is(err, testcase.err) {
 				if err == nil {
 					t.Fatalf("expected error %v, received nil", testcase.err)
 				} else {

--- a/images/handlers.go
+++ b/images/handlers.go
@@ -64,7 +64,7 @@ func Handlers(handlers ...Handler) HandlerFunc {
 		for _, handler := range handlers {
 			ch, err := handler.Handle(ctx, desc)
 			if err != nil {
-				if errors.Cause(err) == ErrStopHandler {
+				if errors.Is(err, ErrStopHandler) {
 					break
 				}
 				return nil, err
@@ -87,7 +87,7 @@ func Walk(ctx context.Context, handler Handler, descs ...ocispec.Descriptor) err
 
 		children, err := handler.Handle(ctx, desc)
 		if err != nil {
-			if errors.Cause(err) == ErrSkipDesc {
+			if errors.Is(err, ErrSkipDesc) {
 				continue // don't traverse the children.
 			}
 			return err
@@ -136,7 +136,7 @@ func Dispatch(ctx context.Context, handler Handler, limiter *semaphore.Weighted,
 				limiter.Release(1)
 			}
 			if err != nil {
-				if errors.Cause(err) == ErrSkipDesc {
+				if errors.Is(err, ErrSkipDesc) {
 					return nil // don't traverse the children.
 				}
 				return err

--- a/lease_test.go
+++ b/lease_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/leases"
 	"github.com/opencontainers/image-spec/identity"
-	"github.com/pkg/errors"
 )
 
 func TestLeaseResources(t *testing.T) {
@@ -108,7 +107,7 @@ func TestLeaseResources(t *testing.T) {
 	}
 
 	// config should be removed but the snapshotter should exist
-	if _, err := cs.Info(ctx, cfgDesc.Digest); errors.Cause(err) != errdefs.ErrNotFound {
+	if _, err := cs.Info(ctx, cfgDesc.Digest); !errdefs.IsNotFound(err) {
 		t.Fatalf("expected error(%v), but got(%v)", errdefs.ErrNotFound, err)
 	}
 
@@ -135,7 +134,7 @@ func TestLeaseResources(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := sn.Stat(ctx, chainID.String()); errors.Cause(err) != errdefs.ErrNotFound {
+	if _, err := sn.Stat(ctx, chainID.String()); !errdefs.IsNotFound(err) {
 		t.Fatalf("expected error(%v), but got(%v)", errdefs.ErrNotFound, err)
 	}
 }

--- a/metadata/containers_test.go
+++ b/metadata/containers_test.go
@@ -167,7 +167,7 @@ func TestContainersList(t *testing.T) {
 		// try it again, get NotFound
 		if err := store.Delete(ctx, id); err == nil {
 			t.Fatalf("expected error deleting non-existent container")
-		} else if errors.Cause(err) != errdefs.ErrNotFound {
+		} else if !errdefs.IsNotFound(err) {
 			t.Fatalf("unexpected error %v", err)
 		}
 	}
@@ -636,7 +636,7 @@ func TestContainersCreateUpdateDelete(t *testing.T) {
 			now := time.Now().UTC()
 
 			result, err := store.Create(ctx, testcase.original)
-			if errors.Cause(err) != testcase.createerr {
+			if !errors.Is(err, testcase.createerr) {
 				if testcase.createerr == nil {
 					t.Fatalf("unexpected error: %v", err)
 				} else {
@@ -658,7 +658,7 @@ func TestContainersCreateUpdateDelete(t *testing.T) {
 
 			now = time.Now()
 			result, err = store.Update(ctx, testcase.input, testcase.fieldpaths...)
-			if errors.Cause(err) != testcase.cause {
+			if !errors.Is(err, testcase.cause) {
 				if testcase.cause == nil {
 					t.Fatalf("unexpected error: %v", err)
 				} else {

--- a/metadata/images_test.go
+++ b/metadata/images_test.go
@@ -141,7 +141,7 @@ func TestImagesList(t *testing.T) {
 		}
 
 		// try it again, get NotFound
-		if err := store.Delete(ctx, id); errors.Cause(err) != errdefs.ErrNotFound {
+		if err := store.Delete(ctx, id); !errdefs.IsNotFound(err) {
 			t.Fatalf("unexpected error %v", err)
 		}
 	}
@@ -496,7 +496,7 @@ func TestImagesCreateUpdateDelete(t *testing.T) {
 			// Create
 			now := time.Now()
 			created, err := store.Create(ctx, testcase.original)
-			if errors.Cause(err) != testcase.createerr {
+			if !errors.Is(err, testcase.createerr) {
 				if testcase.createerr == nil {
 					t.Fatalf("unexpected error: %v", err)
 				} else {
@@ -518,7 +518,7 @@ func TestImagesCreateUpdateDelete(t *testing.T) {
 			// Update
 			now = time.Now()
 			updated, err := store.Update(ctx, testcase.input, testcase.fieldpaths...)
-			if errors.Cause(err) != testcase.cause {
+			if !errors.Is(err, testcase.cause) {
 				if testcase.cause == nil {
 					t.Fatalf("unexpected error: %v", err)
 				} else {

--- a/metadata/leases_test.go
+++ b/metadata/leases_test.go
@@ -55,7 +55,7 @@ func TestLeases(t *testing.T) {
 		if err := db.Update(func(tx *bolt.Tx) error {
 			lease, err := lm.Create(WithTransactionContext(ctx, tx), leases.WithID(tc.ID))
 			if err != nil {
-				if tc.CreateErr != nil && errors.Cause(err) == tc.CreateErr {
+				if tc.CreateErr != nil && errors.Is(err, tc.CreateErr) {
 					return nil
 				}
 				return err
@@ -88,7 +88,7 @@ func TestLeases(t *testing.T) {
 		if err := lm.Delete(ctx, leases.Lease{
 			ID: tc.ID,
 		}); err != nil {
-			if tc.DeleteErr == nil && errors.Cause(err) != tc.DeleteErr {
+			if tc.DeleteErr == nil && !errors.Is(err, tc.DeleteErr) {
 				t.Fatal(err)
 			}
 
@@ -363,7 +363,7 @@ func TestLeaseResource(t *testing.T) {
 	for i, tc := range testCases {
 		if err := db.Update(func(tx *bolt.Tx) error {
 			err0 := lm.AddResource(WithTransactionContext(ctx, tx), tc.lease, tc.resource)
-			if got := errors.Cause(err0); got != tc.err {
+			if !errors.Is(err0, tc.err) {
 				return errors.Errorf("expect error (%v), but got (%v)", tc.err, err0)
 			}
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -44,7 +44,7 @@ var (
 
 // IsSkipPlugin returns true if the error is skipping the plugin
 func IsSkipPlugin(err error) bool {
-	return errors.Cause(err) == ErrSkipPlugin
+	return errors.Is(err, ErrSkipPlugin)
 }
 
 // Type is the type of the plugin

--- a/remotes/docker/pusher.go
+++ b/remotes/docker/pusher.go
@@ -86,7 +86,7 @@ func (p dockerPusher) Push(ctx context.Context, desc ocispec.Descriptor) (conten
 
 	resp, err := req.doWithRetries(ctx, nil)
 	if err != nil {
-		if errors.Cause(err) != ErrInvalidAuthorization {
+		if !errors.Is(err, ErrInvalidAuthorization) {
 			return nil, err
 		}
 		log.G(ctx).WithError(err).Debugf("Unable to check existence, continuing with push")

--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -283,7 +283,7 @@ func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocisp
 			log.G(ctx).Debug("resolving")
 			resp, err := req.doWithRetries(ctx, nil)
 			if err != nil {
-				if errors.Cause(err) == ErrInvalidAuthorization {
+				if errors.Is(err, ErrInvalidAuthorization) {
 					err = errors.Wrapf(err, "pull access denied, repository does not exist or may require authorization")
 				}
 				// Store the error for referencing later

--- a/remotes/docker/resolver_test.go
+++ b/remotes/docker/resolver_test.go
@@ -188,7 +188,7 @@ func TestBadTokenResolver(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected error getting token with inssufficient scope")
 	}
-	if errors.Cause(err) != ErrInvalidAuthorization {
+	if !errors.Is(err, ErrInvalidAuthorization) {
 		t.Fatal(err)
 	}
 }

--- a/runtime/v1/linux/process.go
+++ b/runtime/v1/linux/process.go
@@ -62,7 +62,7 @@ func (p *Process) State(ctx context.Context) (runtime.State, error) {
 		ID: p.id,
 	})
 	if err != nil {
-		if errors.Cause(err) != ttrpc.ErrClosed {
+		if !errors.Is(err, ttrpc.ErrClosed) {
 			return runtime.State{}, errdefs.FromGRPC(err)
 		}
 

--- a/runtime/v1/linux/task.go
+++ b/runtime/v1/linux/task.go
@@ -159,7 +159,7 @@ func (t *Task) State(ctx context.Context) (runtime.State, error) {
 		ID: t.id,
 	})
 	if err != nil {
-		if errors.Cause(err) != ttrpc.ErrClosed {
+		if !errors.Is(err, ttrpc.ErrClosed) {
 			return runtime.State{}, errdefs.FromGRPC(err)
 		}
 		return runtime.State{}, errdefs.ErrNotFound

--- a/runtime/v2/process.go
+++ b/runtime/v2/process.go
@@ -54,7 +54,7 @@ func (p *process) State(ctx context.Context) (runtime.State, error) {
 		ExecID: p.id,
 	})
 	if err != nil {
-		if errors.Cause(err) != ttrpc.ErrClosed {
+		if !errors.Is(err, ttrpc.ErrClosed) {
 			return runtime.State{}, errdefs.FromGRPC(err)
 		}
 		return runtime.State{}, errdefs.ErrNotFound

--- a/runtime/v2/shim.go
+++ b/runtime/v2/shim.go
@@ -94,7 +94,7 @@ func loadShim(ctx context.Context, bundle *Bundle, events *exchange.Exchange, rt
 			// When using a multi-container shim the 2nd to Nth container in the
 			// shim will not have a separate log pipe. Ignore the failure log
 			// message here when the shim connect times out.
-			if !os.IsNotExist(errors.Cause(err)) {
+			if !errors.Is(err, os.ErrNotExist) {
 				log.G(ctx).WithError(err).Error("copy shim log")
 			}
 		}
@@ -191,7 +191,7 @@ func (s *shim) Shutdown(ctx context.Context) error {
 	_, err := s.task.Shutdown(ctx, &task.ShutdownRequest{
 		ID: s.ID(),
 	})
-	if err != nil && errors.Cause(err) != ttrpc.ErrClosed {
+	if err != nil && !errors.Is(err, ttrpc.ErrClosed) {
 		return errdefs.FromGRPC(err)
 	}
 	return nil
@@ -227,7 +227,7 @@ func (s *shim) Delete(ctx context.Context) (*runtime.Exit, error) {
 	})
 	if shimErr != nil {
 		log.G(ctx).WithField("id", s.ID()).WithError(shimErr).Debug("failed to delete task")
-		if errors.Cause(shimErr) != ttrpc.ErrClosed {
+		if !errors.Is(shimErr, ttrpc.ErrClosed) {
 			shimErr = errdefs.FromGRPC(shimErr)
 			if !errdefs.IsNotFound(shimErr) {
 				return nil, shimErr
@@ -444,7 +444,7 @@ func (s *shim) State(ctx context.Context) (runtime.State, error) {
 		ID: s.ID(),
 	})
 	if err != nil {
-		if errors.Cause(err) != ttrpc.ErrClosed {
+		if !errors.Is(err, ttrpc.ErrClosed) {
 			return runtime.State{}, errdefs.FromGRPC(err)
 		}
 		return runtime.State{}, errdefs.ErrNotFound

--- a/runtime/v2/shim_windows.go
+++ b/runtime/v2/shim_windows.go
@@ -90,7 +90,7 @@ func checkCopyShimLogError(ctx context.Context, err error) error {
 	// When using a multi-container shim the 2nd to Nth container in the
 	// shim will not have a separate log pipe. Ignore the failure log
 	// message here when the shim connect times out.
-	if os.IsNotExist(errors.Cause(err)) {
+	if errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
 	return err

--- a/snapshots/btrfs/btrfs_test.go
+++ b/snapshots/btrfs/btrfs_test.go
@@ -81,7 +81,7 @@ func boltSnapshotter(t *testing.T) func(context.Context, string) (snapshots.Snap
 			snapshotter, err = NewSnapshotter(root)
 			if err == nil {
 				break
-			} else if errors.Cause(err) != plugin.ErrSkipPlugin {
+			} else if !errors.Is(err, plugin.ErrSkipPlugin) {
 				return nil, nil, err
 			}
 

--- a/snapshots/devmapper/metadata_test.go
+++ b/snapshots/devmapper/metadata_test.go
@@ -80,7 +80,7 @@ func TestPoolMetadata_AddDeviceDuplicate(t *testing.T) {
 	assert.NilError(t, err)
 
 	err = store.AddDevice(testCtx, &DeviceInfo{Name: "test"})
-	assert.Equal(t, ErrAlreadyExists, errors.Cause(err))
+	assert.Assert(t, errors.Is(err, ErrAlreadyExists))
 }
 
 func TestPoolMetadata_ReuseDeviceID(t *testing.T) {

--- a/sys/mount_linux_test.go
+++ b/sys/mount_linux_test.go
@@ -125,8 +125,8 @@ func testFMountatWithFileFd(t *testing.T, root string) {
 	defer f.Close()
 
 	err = FMountat(f.Fd(), filepath.Join(root, "empty"), filepath.Join(root, "work"), "", 0, "")
-	if got := errors.Cause(err); got != expectedErr {
-		t.Fatalf("expected error %v, but got %v", expectedErr, got)
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected error %v, but got %v", expectedErr, errors.Cause(err))
 	}
 }
 
@@ -146,8 +146,8 @@ func testFMountatWithInvalidSource(t *testing.T, root string) {
 	defer f.Close()
 
 	err = FMountat(f.Fd(), filepath.Join(root, "oops"), "at", "bind", unix.MS_BIND, "")
-	if got := errors.Cause(err); got != expectedErr {
-		t.Fatalf("expected error %v, but got %v", expectedErr, got)
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected error %v, but got %v", expectedErr, err)
 	}
 }
 

--- a/unpacker.go
+++ b/unpacker.go
@@ -265,7 +265,7 @@ func (u *unpacker) fetch(ctx context.Context, h images.Handler, layers []ocispec
 			if u.limiter != nil {
 				u.limiter.Release(1)
 			}
-			if err != nil && errors.Cause(err) != images.ErrSkipDesc {
+			if err != nil && !errors.Is(err, images.ErrSkipDesc) {
 				return err
 			}
 			close(done[i])


### PR DESCRIPTION
follow-up to https://github.com/containerd/containerd/pull/4237

Dependencies may be switching to use the new `%w` formatting option to wrap errors; switching to use `errors.Is()` makes sure that we are still able to unwrap the error and detect the underlying cause.
