### PR TITLE
Use tagged versions in vendor file

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,102 +1,102 @@
-github.com/beorn7/perks                             37c8de3658fcb183f997c4e13e8337516ab753e6 # v1.0.1
-github.com/BurntSushi/toml                          3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005 # v0.3.1
-github.com/cespare/xxhash/v2                        d7df74196a9e781ede915320c11c378c1b2f3a1f # v2.1.1
+github.com/beorn7/perks                             v1.0.1
+github.com/BurntSushi/toml                          v0.3.1
+github.com/cespare/xxhash/v2                        v2.1.1
 github.com/containerd/btrfs                         153935315f4ab9be5bf03650a1341454b05efa5d
 github.com/containerd/cgroups                       b4448137398923af7f4918b8b2ad8249172ca7a6
-github.com/containerd/console                       8375c3424e4d7b114e8a90a4a40c8e1b40d1d4e6 # v1.0.0
+github.com/containerd/console                       v1.0.0
 github.com/containerd/continuity                    0ec596719c75bfd42908850990acea594b7593ac
 github.com/containerd/fifo                          bda0ff6ed73c67bfb5e62bc9c697f146b7fd7f13
 github.com/containerd/go-runc                       a5c2862aed5e6358b305b0e16bfce58e0549b1cd
-github.com/containerd/ttrpc                         72bb1b21c5b0a4a107f59dd85f6ab58e564b68d6 # v1.0.1
-github.com/containerd/typeurl                       cd3ce7159eae562a4f60ceff37dada11a939d247 # v1.0.1
-github.com/coreos/go-systemd/v22                    2d78030078ef61b3cae27f42ad6d0e46db51b339 # v22.0.0
-github.com/cpuguy83/go-md2man                       7762f7e404f8416dfa1d9bb6a8c192aa9acb4d19 # v1.0.10
+github.com/containerd/ttrpc                         v1.0.1
+github.com/containerd/typeurl                       v1.0.1
+github.com/coreos/go-systemd/v22                    v22.0.0
+github.com/cpuguy83/go-md2man                       v1.0.10
 github.com/docker/go-events                         e31b211e4f1cd09aa76fe4ac244571fab96ae47f
-github.com/docker/go-metrics                        b619b3592b65de4f087d9f16863a7e6ff905973c # v0.0.1
-github.com/docker/go-units                          519db1ee28dcc9fd2474ae59fca29a810482bfb1 # v0.4.0
-github.com/godbus/dbus/v5                           37bf87eef99d69c4f1d3528bd66e3a87dc201472 # v5.0.3
-github.com/gogo/googleapis                          01e0f9cca9b92166042241267ee2a5cdf5cff46c # v1.3.2
-github.com/gogo/protobuf                            5628607bb4c51c3157aacc3a50f0ab707582b805 # v1.3.1
-github.com/golang/protobuf                          d23c5127dc24889085f8ccea5c9d560a57a879d8 # v1.3.3
-github.com/google/go-cmp                            3af367b6b30c263d47e8895973edcca9a49cf029 # v0.2.0
-github.com/google/uuid                              0cd6bf5da1e1c83f8b45653022c74f71af0538a4 # v1.1.1
-github.com/grpc-ecosystem/go-grpc-prometheus        c225b8c3b01faf2899099b768856a9e916e5087b # v1.2.0
-github.com/hashicorp/errwrap                        8a6fb523712970c966eefc6b39ed2c5e74880354 # v1.0.0
-github.com/hashicorp/go-multierror                  886a7fbe3eb1c874d46f623bfa70af45f425b3d1 # v1.0.0
-github.com/hashicorp/golang-lru                     7f827b33c0f158ec5dfbba01bb0b14a4541fd81d # v0.5.3
-github.com/imdario/mergo                            7c29201646fa3de8506f701213473dd407f19646 # v0.3.7
-github.com/konsorten/go-windows-terminal-sequences  edb144dfd453055e1e49a3d8b410a660b5a87613 # v1.0.3
-github.com/matttproud/golang_protobuf_extensions    c12348ce28de40eed0136aa2b644d0ee0650e56c # v1.0.1
-github.com/Microsoft/go-winio                       6c72808b55902eae4c5943626030429ff20f3b63 # v0.4.14
-github.com/Microsoft/hcsshim                        5bc557dd210ff2caf615e6e22d398123de77fc11 # v0.8.9
+github.com/docker/go-metrics                        v0.0.1
+github.com/docker/go-units                          v0.4.0
+github.com/godbus/dbus/v5                           v5.0.3
+github.com/gogo/googleapis                          v1.3.2
+github.com/gogo/protobuf                            v1.3.1
+github.com/golang/protobuf                          v1.3.3
+github.com/google/go-cmp                            v0.2.0
+github.com/google/uuid                              v1.1.1
+github.com/grpc-ecosystem/go-grpc-prometheus        v1.2.0
+github.com/hashicorp/errwrap                        v1.0.0
+github.com/hashicorp/go-multierror                  v1.0.0
+github.com/hashicorp/golang-lru                     v0.5.3
+github.com/imdario/mergo                            v0.3.7
+github.com/konsorten/go-windows-terminal-sequences  v1.0.3
+github.com/matttproud/golang_protobuf_extensions    v1.0.1
+github.com/Microsoft/go-winio                       v0.4.14
+github.com/Microsoft/hcsshim                        v0.8.9
 github.com/opencontainers/go-digest                 c9281466c8b2f606084ac71339773efd177436e7
-github.com/opencontainers/image-spec                d60099175f88c47cd379c4738d158884749ed235 # v1.0.1
-github.com/opencontainers/runc                      dc9208a3303feef5b3839f4323d9beb36df0a9dd # v1.0.0-rc10
-github.com/opencontainers/runtime-spec              c4ee7d12c742ffe806cd9350b6af3b4b19faed6f # v1.0.2
-github.com/pkg/errors                               614d223910a179a466c1767a985424175c39b465 # v0.9.1
-github.com/prometheus/client_golang                 c42bebe5a5cddfc6b28cd639103369d8a75dfa89 # v1.3.0
-github.com/prometheus/client_model                  d1d2010b5beead3fa1c5f271a5cf626e40b3ad6e # v0.1.0
-github.com/prometheus/common                        287d3e634a1e550c9e463dd7e5a75a422c614505 # v0.7.0
-github.com/prometheus/procfs                        6d489fc7f1d9cd890a250f3ea3431b1744b9623f # v0.0.8
-github.com/russross/blackfriday                     05f3235734ad95d0016f6a23902f06461fcf567a # v1.5.2
-github.com/sirupsen/logrus                          60c74ad9be0d874af0ab0daef6ab07c5c5911f0d # v1.6.0
+github.com/opencontainers/image-spec                v1.0.1
+github.com/opencontainers/runc                      v1.0.0-rc10
+github.com/opencontainers/runtime-spec              v1.0.2
+github.com/pkg/errors                               v0.9.1
+github.com/prometheus/client_golang                 v1.3.0
+github.com/prometheus/client_model                  v0.1.0
+github.com/prometheus/common                        v0.7.0
+github.com/prometheus/procfs                        v0.0.8
+github.com/russross/blackfriday                     v1.5.2
+github.com/sirupsen/logrus                          v1.6.0
 github.com/syndtr/gocapability                      d98352740cb2c55f81556b63d4a1ec64c5a319c2
-github.com/urfave/cli                               bfe2e925cfb6d44b40ad3a779165ea7e8aff9212 # v1.22.0
-go.etcd.io/bbolt                                    a0458a2b35708eef59eb5f620ceb3cd1c01a824d # v1.3.3
-go.opencensus.io                                    9c377598961b706d1542bd2d84d538b5094d596e # v0.22.0
+github.com/urfave/cli                               v1.22.0
+go.etcd.io/bbolt                                    v1.3.3
+go.opencensus.io                                    v0.22.0
 golang.org/x/net                                    f3200d17e092c607f615320ecaad13d87ad9a2b3
 golang.org/x/sync                                   42b317875d0fa942474b76e1b46a6060d720ae6e
 golang.org/x/sys                                    5c8b2ff67527cb88b770f693cebf3799036d8bc0
 golang.org/x/text                                   19e51611da83d6be54ddafce4a4af510cb3e9ea4
 google.golang.org/genproto                          e50cd9704f63023d62cd06a1994b98227fc4d21a
-google.golang.org/grpc                              f495f5b15ae7ccda3b38c53a1bfcde4c1a58a2bc # v1.27.1
-gotest.tools/v3                                     bb0d8a963040ea5048dcef1a14d8f8b58a33d4b3 # v3.0.2
+google.golang.org/grpc                              v1.27.1
+gotest.tools/v3                                     v3.0.2
 
 # cgroups dependencies
 github.com/cilium/ebpf                              4032b1d8aae306b7bb94a2a11002932caf88c644
 
 # cri dependencies
 github.com/containerd/cri                           65830369b6b2b4edc454bf5cebbd9b76c1c1ac66 # master
-github.com/davecgh/go-spew                          8991bc29aa16c548c550c7ff78260e27b9ab7c73 # v1.1.1
+github.com/davecgh/go-spew                          v1.1.1
 github.com/docker/distribution                      0d3efadf0154c2b8a4e7b6621fff9809655cc580
 github.com/docker/docker                            4634ce647cf2ce2c6031129ccd109e557244986f
 github.com/docker/spdystream                        449fdfce4d962303d702fec724ef0ad181c92528
-github.com/emicklei/go-restful                      b993709ae1a4f6dd19cfa475232614441b11c9d5 # v2.9.5
-github.com/google/gofuzz                            db92cf7ae75e4a7a28abc005addab2b394362888 # v1.1.0
-github.com/json-iterator/go                         03217c3e97663914aec3faafde50d081f197a0a2 # v1.1.8
-github.com/modern-go/concurrent                     bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94 # 1.0.3
-github.com/modern-go/reflect2                       4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd # 1.0.1
-github.com/opencontainers/selinux                   0d49ba2a6aae052c614dfe5de62a158711a6c461 # 1.5.1
-github.com/seccomp/libseccomp-golang                689e3c1541a84461afc49c1c87352a6cedf72e9c # v0.9.1
-github.com/stretchr/testify                         221dbe5ed46703ee255b1da0dec05086f5035f62 # v1.4.0
-github.com/tchap/go-patricia                        666120de432aea38ab06bd5c818f04f4129882c9 # v2.2.6
+github.com/emicklei/go-restful                      v2.9.5
+github.com/google/gofuzz                            v1.1.0
+github.com/json-iterator/go                         v1.1.8
+github.com/modern-go/concurrent                     1.0.3
+github.com/modern-go/reflect2                       v1.0.1
+github.com/opencontainers/selinux                   v1.5.1
+github.com/seccomp/libseccomp-golang                v0.9.1
+github.com/stretchr/testify                         v1.4.0
+github.com/tchap/go-patricia                        v2.2.6
 golang.org/x/crypto                                 bac4c82f69751a6dd76e702d54b3ceb88adab236
 golang.org/x/oauth2                                 0f29369cfe4552d0e4bcddc57cc75f4d7e672a33
 golang.org/x/time                                   9d24e82272b4f38b78bc8cff74fa936d31ccd8ef
-gopkg.in/inf.v0                                     d2d2541c53f18d2a059457998ce2876cc8e67cbf # v0.9.1
-gopkg.in/yaml.v2                                    53403b58ad1b561927d19068c655246f2db79d48 # v2.2.8
-k8s.io/api                                          d2dce8e1788e4be2be3a62b6439b3eaa087df0df # v0.18.0
-k8s.io/apimachinery                                 105e0c6d63f10531ed07f3b5a2195771a0fa444b # v0.18.0
-k8s.io/apiserver                                    5c8e895629a454efd75a453d1dea5b8142db0013 # v0.18.0
-k8s.io/client-go                                    0b19784585bd0a0ee5509855829ead81feaa2bdc # v0.18.0
-k8s.io/cri-api                                      3d1680d8d202aa12c5dc5689170c3c03a488d35b # v0.18.0
-k8s.io/klog                                         2ca9ad30301bf30a8a6e0fa2110db6b8df699a91 # v1.0.0
-k8s.io/kubernetes                                   9e991415386e4cf155a24b1da15becaa390438d8 # v1.18.0
+gopkg.in/inf.v0                                     v0.9.1
+gopkg.in/yaml.v2                                    v2.2.8
+k8s.io/api                                          v0.18.0
+k8s.io/apimachinery                                 v0.18.0
+k8s.io/apiserver                                    v0.18.0
+k8s.io/client-go                                    v0.18.0
+k8s.io/cri-api                                      v0.18.0
+k8s.io/klog                                         v1.0.0
+k8s.io/kubernetes                                   v1.18.0
 k8s.io/utils                                        a9aa75ae1b89e1b992c33383f48e942d97e52dae
-sigs.k8s.io/structured-merge-diff/v3                877aee05330847a873a1a8998b40e12a1e0fde25 # v3.0.0
-sigs.k8s.io/yaml                                    9fc95527decd95bb9d28cc2eab08179b2d0f6971 # v1.2.0
+sigs.k8s.io/structured-merge-diff/v3                v3.0.0
+sigs.k8s.io/yaml                                    v1.2.0
 
 # cni dependencies
 github.com/containerd/go-cni                        0d360c50b10b350b6bb23863fd4dfb1c232b01c9
-github.com/containernetworking/cni                  4cfb7b568922a3c79a23e438dc52fe537fc9687e # v0.7.1
-github.com/containernetworking/plugins              9f96827c7cabb03f21d86326000c00f61e181f6a # v0.7.6
-github.com/fsnotify/fsnotify                        4bf2d1fec78374803a39307bfb8d340688f4f28e # v1.4.8
+github.com/containernetworking/cni                  v0.7.1
+github.com/containernetworking/plugins              v0.7.6
+github.com/fsnotify/fsnotify                        v1.4.8
 
 # image decrypt depedencies
-github.com/containerd/imgcrypt                      9e761ccd6069fb707ec9493435f31475b5524b38 # v1.0.1
-github.com/containers/ocicrypt                      0343cc6053fd65069df55bce6838096e09b4033a # v1.0.1 from containerd/imgcrypt
-github.com/fullsailor/pkcs7                         8306686428a5fe132eac8cb7c4848af725098bd4 #        from containers/ocicrypt
-gopkg.in/square/go-jose.v2                          730df5f748271903322feb182be83b43ebbbe27d # v2.3.1 from containers/ocicrypt
+github.com/containerd/imgcrypt                      v1.0.1
+github.com/containers/ocicrypt                      v1.0.1
+github.com/fullsailor/pkcs7                         8306686428a5fe132eac8cb7c4848af725098bd4
+gopkg.in/square/go-jose.v2                          v2.3.1
 
 # zfs dependencies
 github.com/containerd/zfs                           9abf673ca6ff9ab8d9bd776a4ceff8f6dc699c3d


### PR DESCRIPTION
- Reverts change from tagged versions to sha. Maintainers agreed to use tagged versions before 1.3 release, this fixes the issue before 1.4.
- Removes tag ambiguity on what version a sha points to when multiple tags available. The sha may end up representing the release commit or the sha of the tag object, when it points to a release commit, multiple tags are possible adding ambiguity to automated tag dereferencing. Parsing the comment to reduce the ambiguity is not a great solution for the release tooling.
- Fixes sync issue between tag in comment and sha, the selinux comment was incorrect here.
- Updates reflect2 library to correctly tagged version, includes global variable fix.