### PR TITLE
ConfigureHosts: remove deprecated DualStack option

### DIFF
--- a/remotes/docker/config/hosts.go
+++ b/remotes/docker/config/hosts.go
@@ -108,9 +108,9 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
 		defaultTransport := &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
 			DialContext: (&net.Dialer{
-				Timeout:   30 * time.Second,
-				KeepAlive: 30 * time.Second,
-				DualStack: true,
+				Timeout:       30 * time.Second,
+				KeepAlive:     30 * time.Second,
+				FallbackDelay: 300 * time.Millisecond,
 			}).DialContext,
 			MaxIdleConns:          10,
 			IdleConnTimeout:       30 * time.Second,


### PR DESCRIPTION
The `DualStack` option was deprecated in Go 1.12, and is now enabled by default (through commit https://github.com/golang/go/commit/efc185029bf770894defe63cec2c72a4c84b2ee9).

> The Dialer.DualStack field is now meaningless and documented as deprecated.
>
> To disable fallback, set FallbackDelay to a negative value.

The default `FallbackDelay` is 300ms; to make this more explicit, this patch sets `FallbackDelay` to the default value.

Note that Docker Hub currently does not support IPv6 (https://github.com/docker/hub-feedback/issues/1945) (DNS for registry-1.docker.io has no AAAA records, so we should not hit the 300ms delay).
