### PR TITLE
Add article to pull access denied error message

### DIFF
--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -284,7 +284,7 @@ func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocisp
 			resp, err := req.doWithRetries(ctx, nil)
 			if err != nil {
 				if errors.Is(err, ErrInvalidAuthorization) {
-					err = errors.Wrapf(err, "pull access denied, repository does not exist or may require authorization")
+					err = errors.Wrapf(err, "pull access denied, the repository does not exist or may require authorization")
 				}
 				// Store the error for referencing later
 				if lastErr == nil {


### PR DESCRIPTION
The spelling fix was suggested to me by Grammarly when I pasted such error in our internal issue tracker.