### PR TITLE
Set codecov to not comment on PRs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
Until we totally remove codecov, this will keep it from commenting on
PRs but reports will still be available on codecov.io

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>