### PR TITLE
vendor: opencontainers/go-digest v1.0.0

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -29,7 +29,7 @@ github.com/konsorten/go-windows-terminal-sequences  v1.0.3
 github.com/matttproud/golang_protobuf_extensions    v1.0.1
 github.com/Microsoft/go-winio                       v0.4.14
 github.com/Microsoft/hcsshim                        v0.8.9
-github.com/opencontainers/go-digest                 28d3ccc31a47933556673856d9807b4ca436108e # v1.0.0-rc1-37-g28d3ccc
+github.com/opencontainers/go-digest                 v1.0.0
 github.com/opencontainers/image-spec                v1.0.1
 github.com/opencontainers/runc                      v1.0.0-rc10
 github.com/opencontainers/runtime-spec              v1.0.2


### PR DESCRIPTION
full diff: https://github.com/opencontainers/go-digest/compare/28d3ccc31a47933556673856d9807b4ca436108e...v1.0.0
