### PR TITLE
Trigger nightly builds on pull reuqest events

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,6 +2,9 @@ name: Nightly
 on:
   schedule:
     - cron: '0 0 * * *' # Every day at midnight
+  pull_request:
+    paths:
+      - '.github/workflows/nightly.yml'
 
 jobs:
   linux:


### PR DESCRIPTION
Run nightly build job in PRs that modify `nightly.yml`. This will help to test changes within PR itself (for instance https://github.com/containerd/containerd/pull/4191)

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>