### PR TITLE
Bump Golang 1.13.11

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 0
   matrix:
-    - GO_VERSION: 1.13.10
+    - GO_VERSION: 1.13.11
 
 before_build:
   - choco install --no-progress -y mingw --version 5.3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.10'
+          go-version: '1.13.11'
 
       - name: Set env
         shell: bash
@@ -66,7 +66,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.10'
+          go-version: '1.13.11'
 
       - name: Set env
         shell: bash
@@ -138,7 +138,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.10'
+          go-version: '1.13.11'
 
       - name: Set env
         shell: bash
@@ -185,7 +185,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.10'
+          go-version: '1.13.11'
 
       - name: Set env
         shell: bash
@@ -222,7 +222,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.10'
+          go-version: '1.13.11'
 
       - name: Set env
         shell: bash
@@ -267,7 +267,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.10'
+          go-version: '1.13.11'
 
       - name: Setup gosu
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.10'
+          go-version: '1.13.11'
 
       - name: Checkout
         uses: actions/checkout@v1
@@ -126,7 +126,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.10'
+          go-version: '1.13.11'
 
       - name: Checkout
         uses: actions/checkout@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ os:
 - linux
 
 go:
-  - "1.13.10"
+  - "1.13.11"
 
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct

--- a/.zuul/playbooks/containerd-build/run.yaml
+++ b/.zuul/playbooks/containerd-build/run.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.13.10'
+    go_version: '1.13.11'
     arch: arm64
   tasks:
   - name: Build containerd

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.13.10
+ARG GOLANG_VERSION=1.13.11
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd


### PR DESCRIPTION
full diff: https://github.com/golang/go/compare/go1.13.10...go1.13.11

go1.13.11 (released 2020/05/14) includes fixes to the compiler. See the Go 1.13.11
milestone on the issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.13.11+label%3ACherryPickApproved
