### PR TITLE
unpacker: Fix data race and possible data corruption

### DIFF
--- a/unpacker.go
+++ b/unpacker.go
@@ -178,13 +178,13 @@ EachLayer:
 				fetchC[i] = make(chan struct{})
 			}
 
-			go func() {
+			go func(i int) {
 				err := u.fetch(ctx, h, layers[i:], fetchC)
 				if err != nil {
 					fetchErr <- err
 				}
 				close(fetchErr)
-			}()
+			}(i)
 		}
 
 		select {


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>

The iterator variable i should be captured in the go func() through an argument to avoid possible data race and data corruption.