### PR TITLE
[release/1.2] fix regression caused by pushing manifests as octet stream

### DIFF
--- a/remotes/docker/pusher.go
+++ b/remotes/docker/pusher.go
@@ -176,7 +176,7 @@ func (p dockerPusher) Push(ctx context.Context, desc ocispec.Descriptor) (conten
 		q := req.URL.Query()
 		q.Add("digest", desc.Digest.String())
 		req.URL.RawQuery = q.Encode()
-
+		req.Header.Set("Content-Type", "application/octet-stream")
 	}
 	p.tracker.SetStatus(ref, Status{
 		Status: content.Status{
@@ -193,7 +193,6 @@ func (p dockerPusher) Push(ctx context.Context, desc ocispec.Descriptor) (conten
 	respC := make(chan *http.Response, 1)
 
 	req.Body = ioutil.NopCloser(pr)
-	req.Header.Set("Content-Type", "application/octet-stream")
 	req.ContentLength = desc.Size
 
 	go func() {


### PR DESCRIPTION
In master the change added the header set inside the block which created the blob request. This got incorrectly backported outside of the block, overriding the correctly set manifest header with the incorrect octet-stream header on manifest push.

This fix only applies to the 1.2 branch, and other branches were correctly backported and this bug does not happen in master.

Fixes #4252