### PR TITLE
seccomp: remove the unused query_module(2)

### DIFF
--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -515,7 +515,6 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 					"delete_module",
 					"init_module",
 					"finit_module",
-					"query_module",
 				},
 				Action: specs.ActAllow,
 				Args:   []specs.LinuxSeccompArg{},


### PR DESCRIPTION
query_module(2) is only in kernels before Linux 2.6.
This issue is as same as https://github.com/moby/moby/pull/40995

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>