### PR TITLE
[release/1.2] golangci-lint update and fix

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - errcheck
 
 run:
+  timeout: 3m
   skip-dirs:
     - api
     - design

--- a/remotes/docker/resolver_test.go
+++ b/remotes/docker/resolver_test.go
@@ -393,7 +393,7 @@ func (m testManifest) OCIManifest() []byte {
 		Config: m.config.Descriptor(),
 		Layers: make([]ocispec.Descriptor, len(m.references)),
 	}
-	for i, c := range append(m.references) {
+	for i, c := range m.references {
 		manifest.Layers[i] = c.Descriptor()
 	}
 	b, _ := json.Marshal(manifest)

--- a/script/setup/install-dev-tools
+++ b/script/setup/install-dev-tools
@@ -20,12 +20,14 @@
 #
 set -eu -o pipefail
 
-go get -u github.com/stevvooe/protobuild
-go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
-go get -u github.com/cpuguy83/go-md2man
+# to pin dependencies
+GO111MODULE=on go get github.com/stevvooe/protobuild
 
-(
-	cd $GOPATH/src/github.com/golangci/golangci-lint/cmd/golangci-lint
-	git checkout v1.18.0
-	go build -v && go install
-)
+# the following packages need to exist in $GOPATH so we can't use
+# go modules-aware mode of `go get` for these includes used during
+# proto building
+GO111MODULE=off go get -d github.com/gogo/googleapis || true
+GO111MODULE=off go get -d github.com/gogo/protobuf || true
+
+go get -u github.com/cpuguy83/go-md2man
+GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.23.8


### PR DESCRIPTION
Backported test code fix from master, checkout specific version of
golangci-lint, and set timeout to 3m like master

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>