### PR TITLE
Registry config header support and fixes

### DIFF
--- a/remotes/docker/config/hosts_test.go
+++ b/remotes/docker/config/hosts_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/http"
 	"path/filepath"
 	"testing"
 
@@ -76,11 +77,15 @@ func TestParseHostFile(t *testing.T) {
 	const testtoml = `
 server = "https://test-default.registry"
 ca = "/etc/path/default"
+[header]
+  x-custom-1 = "custom header"
 
 [host."https://mirror.registry"]
   capabilities = ["pull"]
   ca = "/etc/certs/mirror.pem"
   skip_verify = false
+  [host."https://mirror.registry".header]
+    x-custom-2 = ["value1", "value2"]
 
 [host."https://mirror-bak.registry/us"]
   capabilities = ["pull"]
@@ -109,6 +114,7 @@ ca = "/etc/path/default"
 			capabilities: docker.HostCapabilityPull,
 			caCerts:      []string{filepath.FromSlash("/etc/certs/mirror.pem")},
 			skipVerify:   &fb,
+			header:       http.Header{"x-custom-2": {"value1", "value2"}},
 		},
 		{
 			scheme:       "https",
@@ -159,6 +165,7 @@ ca = "/etc/path/default"
 			path:         "/v2",
 			capabilities: allCaps,
 			caCerts:      []string{filepath.FromSlash("/etc/path/default")},
+			header:       http.Header{"x-custom-1": {"custom header"}},
 		},
 	}
 	hosts, err := parseHostsFile(ctx, "", []byte(testtoml))
@@ -241,6 +248,20 @@ func compareHostConfig(j, k hostConfig) bool {
 		return false
 	}
 
+	if len(j.header) != len(k.header) {
+		return false
+	}
+	for key := range j.header {
+		if len(j.header[key]) != len(k.header[key]) {
+			return false
+		}
+		for i := range j.header[key] {
+			if j.header[key][i] != k.header[key][i] {
+				return false
+			}
+		}
+	}
+
 	return true
 }
 
@@ -258,6 +279,7 @@ func printHostConfig(hc []hostConfig) string {
 		} else {
 			fmt.Fprintf(b, "\t\tskip-verify: %t\n", *hc[i].skipVerify)
 		}
+		fmt.Fprintf(b, "\t\theader: %#v\n", hc[i].header)
 	}
 	return b.String()
 }

--- a/remotes/docker/config/hosts_test.go
+++ b/remotes/docker/config/hosts_test.go
@@ -80,6 +80,7 @@ ca = "/etc/path/default"
 [host."https://mirror.registry"]
   capabilities = ["pull"]
   ca = "/etc/certs/mirror.pem"
+  skip_verify = false
 
 [host."https://mirror-bak.registry/us"]
   capabilities = ["pull"]
@@ -132,7 +133,6 @@ ca = "/etc/path/default"
 				{filepath.FromSlash("/etc/certs/client.cert"), filepath.FromSlash("/etc/certs/client.key")},
 				{filepath.FromSlash("/etc/certs/client.pem"), ""},
 			},
-			skipVerify: &fb,
 		},
 		{
 			scheme:       "https",
@@ -142,7 +142,6 @@ ca = "/etc/path/default"
 			clientPairs: [][2]string{
 				{filepath.FromSlash("/etc/certs/client.pem")},
 			},
-			skipVerify: &fb,
 		},
 		{
 			scheme:       "https",
@@ -153,14 +152,13 @@ ca = "/etc/path/default"
 				{filepath.FromSlash("/etc/certs/client-1.pem")},
 				{filepath.FromSlash("/etc/certs/client-2.pem")},
 			},
-			skipVerify: &fb,
 		},
 		{
 			scheme:       "https",
 			host:         "test-default.registry",
 			path:         "/v2",
 			capabilities: allCaps,
-			skipVerify:   &fb,
+			caCerts:      []string{filepath.FromSlash("/etc/path/default")},
 		},
 	}
 	hosts, err := parseHostsFile(ctx, "", []byte(testtoml))

--- a/remotes/docker/registry.go
+++ b/remotes/docker/registry.go
@@ -70,6 +70,7 @@ type RegistryHost struct {
 	Scheme       string
 	Path         string
 	Capabilities HostCapabilities
+	Header       http.Header
 }
 
 // RegistryHosts fetches the registry hosts for a given namespace,

--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -450,6 +450,9 @@ func (r *dockerBase) request(host RegistryHost, method string, ps ...string) *re
 	for key, value := range r.header {
 		header[key] = append(header[key], value...)
 	}
+	for key, value := range host.Header {
+		header[key] = append(header[key], value...)
+	}
 	parts := append([]string{"/", host.Path, r.namespace}, ps...)
 	p := path.Join(parts...)
 	// Join strips trailing slash, re-add ending "/" if included


### PR DESCRIPTION
Fixes a few unresolved bugs in the host config code including a few uninitialized values.

Adds support for per registry host HTTP headers. (Related to https://github.com/containerd/cri/issues/1400)