### PR TITLE
Fix image usage calculation error

### DIFF
--- a/image.go
+++ b/image.go
@@ -203,24 +203,26 @@ func (i *image) Usage(ctx context.Context, opts ...UsageOpt) (int64, error) {
 				desc.Size = info.Size
 			}
 
-			for k, v := range info.Labels {
-				const prefix = "containerd.io/gc.ref.snapshot."
-				if !strings.HasPrefix(k, prefix) {
-					continue
-				}
-
-				sn := i.client.SnapshotService(k[len(prefix):])
-				if sn == nil {
-					continue
-				}
-
-				u, err := sn.Usage(ctx, v)
-				if err != nil {
-					if !errdefs.IsNotFound(err) && !errdefs.IsInvalidArgument(err) {
-						return nil, err
+			if config.snapshots {
+				for k, v := range info.Labels {
+					const prefix = "containerd.io/gc.ref.snapshot."
+					if !strings.HasPrefix(k, prefix) {
+						continue
 					}
-				} else {
-					usage += u.Size
+
+					sn := i.client.SnapshotService(k[len(prefix):])
+					if sn == nil {
+						continue
+					}
+
+					u, err := sn.Usage(ctx, v)
+					if err != nil {
+						if !errdefs.IsNotFound(err) && !errdefs.IsInvalidArgument(err) {
+							return nil, err
+						}
+					} else {
+						usage += u.Size
+					}
 				}
 			}
 		}

--- a/image_test.go
+++ b/image_test.go
@@ -180,6 +180,7 @@ func TestImageUsage(t *testing.T) {
 
 	// Pin image name to specific version for future fetches
 	imageName = imageName + "@" + image.Target().Digest.String()
+	defer client.ImageService().Delete(ctx, imageName, images.SynchronousDelete())
 
 	// Fetch single platforms, but all manifests pulled
 	if _, err := client.Fetch(ctx, imageName, WithPlatformMatcher(testPlatform), WithAllMetadata()); err != nil {


### PR DESCRIPTION
Including snapshotter usage in total calculation should be gated by the
option `snapshotter` boolean.

Sometimes a flaky test is trying to tell you something 😄 The intermittent failures of `TestImageUsage` were actually always reporting the same "offset"; turns out that offset was the exact size of the unpacked root fs of the busybox amd64 build. What was happening is since busybox is used throughout other tests, a snapshot was created that was sometimes not garbage collected by the time `TestImageUsage` ran, and therefore since the label was associated with the amd64 manifest, it would be added to the size calculation and cause this test to fail.

// cc: @fuweid since I know you had tried to fix this at one point; I also added a deferred deletion of the image reference pinned to the sha256 in the test as when you run it locally multiple times you still get wrong results unless both images are removed. A possibly more "stable" result would be to use a totally different image name that isn't used by any other tests.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>