### PR TITLE
[release/1.3] cherry-pick: Fix image usage calculation error

### DIFF
--- a/image.go
+++ b/image.go
@@ -197,24 +197,26 @@ func (i *image) Usage(ctx context.Context, opts ...UsageOpt) (int64, error) {
 				desc.Size = info.Size
 			}
 
-			for k, v := range info.Labels {
-				const prefix = "containerd.io/gc.ref.snapshot."
-				if !strings.HasPrefix(k, prefix) {
-					continue
-				}
-
-				sn := i.client.SnapshotService(k[len(prefix):])
-				if sn == nil {
-					continue
-				}
-
-				u, err := sn.Usage(ctx, v)
-				if err != nil {
-					if !errdefs.IsNotFound(err) && !errdefs.IsInvalidArgument(err) {
-						return nil, err
+			if config.snapshots {
+				for k, v := range info.Labels {
+					const prefix = "containerd.io/gc.ref.snapshot."
+					if !strings.HasPrefix(k, prefix) {
+						continue
 					}
-				} else {
-					usage += u.Size
+
+					sn := i.client.SnapshotService(k[len(prefix):])
+					if sn == nil {
+						continue
+					}
+
+					u, err := sn.Usage(ctx, v)
+					if err != nil {
+						if !errdefs.IsNotFound(err) && !errdefs.IsInvalidArgument(err) {
+							return nil, err
+						}
+					} else {
+						usage += u.Size
+					}
 				}
 			}
 		}

--- a/image_test.go
+++ b/image_test.go
@@ -179,6 +179,7 @@ func TestImageUsage(t *testing.T) {
 
 	// Pin image name to specific version for future fetches
 	imageName = imageName + "@" + image.Target().Digest.String()
+	defer client.ImageService().Delete(ctx, imageName, images.SynchronousDelete())
 
 	// Fetch single platforms, but all manifests pulled
 	if _, err := client.Fetch(ctx, imageName, WithPlatformMatcher(testPlatform), WithAllMetadata()); err != nil {


### PR DESCRIPTION
Cherry-picked 0c9b05fa60e9b3a8ab2b0eb0254833741a73db74 from #4275 for `release/1.3`

Including snapshotter usage in total calculation should be gated by the
option `snapshotter` boolean.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>