### PR TITLE
riscv64 arch does not support -buildmode=pie

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -20,7 +20,7 @@ COMMANDS += containerd-shim containerd-shim-runc-v1 containerd-shim-runc-v2
 
 # check GOOS for cross compile builds
 ifeq ($(GOOS),linux)
-  ifneq ($(GOARCH),$(filter $(GOARCH),mips mipsle mips64 mips64le ppc64))
+  ifneq ($(GOARCH),$(filter $(GOARCH),mips mipsle mips64 mips64le ppc64 riscv64))
 	GO_GCFLAGS += -buildmode=pie
   endif
 endif


### PR DESCRIPTION
While trying to update the containerd package in Ubuntu to version 1.3.4 I faced a build failure on riscv64 (full build log [here](https://launchpadlibrarian.net/480602209/buildlog_ubuntu-groovy-riscv64.containerd_1.3.4-0ubuntu1_BUILDING.txt.gz)):

```
make[2]: Entering directory '/<<PKGBUILDDIR>>'
+ bin/ctr
-buildmode=pie not supported on linux/riscv64
```
This PR simply filters out riscv64 arch when adding the `-buildmode=pie` option, as it is already done for other architectures.
