### PR TITLE
[release/1.3] Enable GH Actions for release/1.3 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,355 @@
+name: CI
+on:
+  push:
+    branches:
+      - master
+      - 'release/**'
+  pull_request:
+    branches:
+      - master
+      - 'release/**'
+
+jobs:
+  #
+  # golangci-lint
+  #
+  linters:
+    name: Linters
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, macos-10.15] # TODO: pass linters on 'windows-2019'
+
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.13.10'
+
+      - name: Set env
+        shell: bash
+        run: |
+          echo "::set-env name=GOPATH::${{ github.workspace }}"
+          echo "::add-path::${{ github.workspace }}/bin"
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: src/github.com/containerd/containerd
+
+      - name: Install dev tools
+        env:
+          GO111MODULE: off
+        shell: bash
+        run: script/setup/install-dev-tools
+        working-directory: src/github.com/containerd/containerd
+
+      - name: Make check
+        shell: bash
+        run: make check
+        working-directory: src/github.com/containerd/containerd
+
+  #
+  # Project checks
+  #
+  project:
+    name: Project Checks
+    runs-on: ubuntu-18.04
+    timeout-minutes: 5
+
+    steps:
+      #
+      # Install Go
+      #
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.13.10'
+
+      - name: Set env
+        shell: bash
+        run: |
+          echo "::set-env name=GOPATH::${{ github.workspace }}"
+          echo "::add-path::${{ github.workspace }}/bin"
+
+      #
+      # Checkout repos
+      #
+      - name: Checkout this repo
+        uses: actions/checkout@v2
+        with:
+          path: src/github.com/containerd/containerd
+          fetch-depth: 25
+
+      - name: Checkout project repo
+        uses: actions/checkout@v2
+        with:
+          repository: containerd/project
+          path: src/github.com/containerd/project
+
+      #
+      # Go get dependencies
+      #
+      - name: Install dependencies
+        env:
+          GO111MODULE: off
+        run: |
+          go get -u github.com/vbatts/git-validation
+          go get -u github.com/kunalkushwaha/ltag
+          go get -u github.com/LK4D4/vndr
+
+      #
+      # DCO / File headers / Vendor directory validation
+      #
+      - name: DCO
+        env:
+          GITHUB_COMMIT_URL: ${{ github.event.pull_request.commits_url }}
+          DCO_VERBOSITY: "-q"
+          DCO_RANGE: ""
+        working-directory: src/github.com/containerd/containerd
+        run: |
+          set -x
+          if [ -z "${GITHUB_COMMIT_URL}" ]; then
+          DCO_RANGE=$(jq -r '.after + "..HEAD"' ${GITHUB_EVENT_PATH})
+          else
+          DCO_RANGE=$(curl ${GITHUB_COMMIT_URL} | jq -r '.[0].parents[0].sha +".."+ .[-1].sha')
+          fi
+          ../project/script/validate/dco
+
+      - name: Headers
+        run: ../project/script/validate/fileheader ../project/
+        working-directory: src/github.com/containerd/containerd
+
+      - name: Vendor
+        run: ../project/script/validate/vendor
+        working-directory: src/github.com/containerd/containerd
+
+  #
+  # Protobuf checks
+  #
+  protos:
+    name: Protobuf
+    runs-on: ubuntu-18.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.13.10'
+
+      - name: Set env
+        shell: bash
+        run: |
+          echo "::set-env name=GOPATH::${{ github.workspace }}"
+          echo "::add-path::${{ github.workspace }}/bin"
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: src/github.com/containerd/containerd
+
+      - name: Install protobuf
+        env:
+          GO111MODULE: off
+        working-directory: src/github.com/containerd/containerd
+        run: |
+          sudo env PATH=$PATH GOPATH=$GOPATH script/setup/install-protobuf
+          sudo chmod +x /usr/local/bin/protoc
+          sudo chmod og+rx /usr/local/include/google /usr/local/include/google/protobuf /usr/local/include/google/protobuf/compiler
+          sudo chmod -R og+r /usr/local/include/google/protobuf/
+          protoc --version
+
+      - name: Install dev tools
+        env:
+          GO111MODULE: off
+        run: script/setup/install-dev-tools
+        working-directory: src/github.com/containerd/containerd
+
+      - name: Make
+        env:
+          GO111MODULE: off
+        working-directory: src/github.com/containerd/containerd
+        run: |
+          export PATH=$PATH:$(go env GOPATH)/bin
+          make check-protos check-api-descriptors
+
+  man:
+    name: Manpages
+    runs-on: ubuntu-18.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.13.10'
+
+      - name: Set env
+        shell: bash
+        run: |
+          echo "::set-env name=GOPATH::${{ github.workspace }}"
+          echo "::add-path::${{ github.workspace }}/bin"
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: src/github.com/containerd/containerd
+
+      - name: Install dependencies
+        run: go get -u github.com/cpuguy83/go-md2man
+
+      - name: Make
+        run: make man
+        working-directory: src/github.com/containerd/containerd
+
+  #
+  # Build containerd binaries
+  #
+  binaries:
+    name: Binaries
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    needs: [project, linters, protos, man]
+
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, macos-10.15, windows-2019]
+
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.13.10'
+
+      - name: Set env
+        shell: bash
+        run: |
+          echo "::set-env name=GOPATH::${{ github.workspace }}"
+          echo "::add-path::${{ github.workspace }}/bin"
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: src/github.com/containerd/containerd
+
+      - name: Install Linux dependencies
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get install -y btrfs-tools libseccomp-dev
+
+      - name: Make
+        run: |
+          make build
+          make binaries
+        working-directory: src/github.com/containerd/containerd
+
+  #
+  # Integration and CRI tests
+  #
+  integration:
+    name: Integration
+    runs-on: ubuntu-18.04
+    timeout-minutes: 15
+    needs: [project, linters, protos, man]
+
+    strategy:
+      matrix:
+        runtime: [runc.v1, runc.v2, runtime.v1.linux]
+
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.13.10'
+
+      - name: Setup gosu
+        shell: bash
+        run: |
+          GOSU=/usr/local/bin/gosu
+          arch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"
+          sudo wget -O ${GOSU} "https://github.com/tianon/gosu/releases/download/1.12/gosu-$arch"
+          sudo chmod +x ${GOSU}
+          sudo chown root ${GOSU}
+          sudo chmod +s ${GOSU}
+
+      - name: Set env
+        shell: bash
+        run: |
+          echo "::set-env name=GOPATH::${{ github.workspace }}"
+          echo "::add-path::${{ github.workspace }}/bin"
+
+      - name: Checkout containerd
+        uses: actions/checkout@v2
+        with:
+          path: src/github.com/containerd/containerd
+
+      - name: Install containerd dependencies
+        run: |
+          sudo PATH=$PATH script/setup/install-seccomp
+          gosu root script/setup/install-runc
+          script/setup/install-cni
+          script/setup/install-critools
+        working-directory: src/github.com/containerd/containerd
+
+      - name: Install criu
+        run: |
+          sudo apt-get install -y \
+            libprotobuf-dev \
+            libprotobuf-c-dev \
+            protobuf-c-compiler \
+            protobuf-compiler \
+            python-protobuf \
+            libnl-3-dev \
+            libnet-dev \
+            libcap-dev \
+            python-future
+          wget https://github.com/checkpoint-restore/criu/archive/v3.13.tar.gz -O criu.tar.gz
+          tar -zxf criu.tar.gz
+          cd criu-3.13
+          sudo make install-criu
+
+      - name: Install containerd
+        env:
+          CGO_ENABLED: 1
+        run: |
+          make binaries
+          sudo make install
+        working-directory: src/github.com/containerd/containerd
+
+      - name: Integration 1
+        env:
+          GOPROXY: direct
+          TEST_RUNTIME: io.containerd.${{ matrix.runtime }}
+        run: |
+          sudo GOPATH=$GOPATH GOPROXY=$GOPROXY TEST_RUNTIME=$TEST_RUNTIME make integration EXTRA_TESTFLAGS=-no-criu TESTFLAGS_RACE=-race
+        working-directory: src/github.com/containerd/containerd
+
+      # Run the integration suite a second time. See discussion in github.com/containerd/containerd/pull/1759
+      - name: Integration 2
+        env:
+          GOPROXY: direct
+          TEST_RUNTIME: io.containerd.${{ matrix.runtime }}
+        run: |
+          sudo GOPATH=$GOPATH GOPROXY=$GOPROXY TEST_RUNTIME=$TEST_RUNTIME TESTFLAGS_PARALLEL=1 make integration EXTRA_TESTFLAGS=-no-criu
+        working-directory: src/github.com/containerd/containerd
+
+      - name: CRI test
+        env:
+          TEST_RUNTIME: io.containerd.${{ matrix.runtime }}
+        run: |
+          sudo mkdir -p /etc/containerd
+          sudo bash -c "cat > /etc/containerd/config.toml <<EOF
+            [plugins.cri.containerd.default_runtime]
+              runtime_type = \"${TEST_RUNTIME}\"
+          EOF"
+          sudo PATH=$PATH containerd -log-level debug &> /tmp/containerd-cri.log &
+          sudo ctr version
+          sudo PATH=$PATH GOPATH=$GOPATH critest --runtime-endpoint=/var/run/containerd/containerd.sock --parallel=8
+          TEST_RC=$?
+          test $TEST_RC -ne 0 && cat /tmp/containerd-cri.log
+          sudo pkill containerd
+          sudo rm -rf /etc/containerd
+          test $TEST_RC -eq 0 || /bin/false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,7 +305,8 @@ jobs:
             libnl-3-dev \
             libnet-dev \
             libcap-dev \
-            python-future
+            python-future \
+            socat
           wget https://github.com/checkpoint-restore/criu/archive/v3.13.tar.gz -O criu.tar.gz
           tar -zxf criu.tar.gz
           cd criu-3.13

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,7 @@ linters:
     - errcheck
 
 run:
-  deadline: 2m
+  deadline: 3m
   skip-dirs:
     - api
     - design

--- a/cmd/containerd/command/service_windows.go
+++ b/cmd/containerd/command/service_windows.go
@@ -49,8 +49,6 @@ var (
 	allocConsole = kernel32.NewProc("AllocConsole")
 	oldStderr    windows.Handle
 	panicFile    *os.File
-
-	service *handler
 )
 
 const defaultServiceName = "containerd"
@@ -282,7 +280,6 @@ func launchService(s *server.Server, done chan struct{}) error {
 		return err
 	}
 
-	service = h
 	go func() {
 		if interactive {
 			err = debug.Run(serviceNameFlag, h)

--- a/remotes/docker/resolver_test.go
+++ b/remotes/docker/resolver_test.go
@@ -491,7 +491,7 @@ func (m testManifest) OCIManifest() []byte {
 		Config: m.config.Descriptor(),
 		Layers: make([]ocispec.Descriptor, len(m.references)),
 	}
-	for i, c := range append(m.references) {
+	for i, c := range m.references {
 		manifest.Layers[i] = c.Descriptor()
 	}
 	b, _ := json.Marshal(manifest)

--- a/script/setup/install-cni
+++ b/script/setup/install-cni
@@ -29,10 +29,10 @@ go get -d github.com/containernetworking/plugins/...
 cd $GOPATH/src/github.com/containernetworking/plugins
 git checkout $CNI_COMMIT
 FASTBUILD=true ./build.sh
-mkdir -p $CNI_DIR
-cp -r ./bin $CNI_DIR
-mkdir -p $CNI_CONFIG_DIR
-bash -c 'cat >'$CNI_CONFIG_DIR'/10-containerd-net.conflist <<EOF
+sudo mkdir -p $CNI_DIR
+sudo cp -r ./bin $CNI_DIR
+sudo mkdir -p $CNI_CONFIG_DIR
+cat <<EOF | sudo tee $CNI_CONFIG_DIR/10-containerd-net.conflist
 {
   "cniVersion": "0.3.1",
   "name": "containerd-net",
@@ -57,4 +57,4 @@ bash -c 'cat >'$CNI_CONFIG_DIR'/10-containerd-net.conflist <<EOF
     }
   ]
 }
-EOF'
+EOF

--- a/script/setup/install-critools
+++ b/script/setup/install-critools
@@ -26,4 +26,4 @@ go get -d github.com/kubernetes-sigs/cri-tools/...
 cd "$GOPATH"/src/github.com/kubernetes-sigs/cri-tools
 git checkout $CRITEST_COMMIT
 make
-make install
+sudo make install

--- a/script/setup/install-dev-tools
+++ b/script/setup/install-dev-tools
@@ -30,11 +30,5 @@ GO111MODULE=on go get github.com/stevvooe/protobuild
 GO111MODULE=off go get -d github.com/gogo/googleapis || true
 GO111MODULE=off go get -d github.com/gogo/protobuf || true
 
-go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 go get -u github.com/cpuguy83/go-md2man
-
-(
-	cd $GOPATH/src/github.com/golangci/golangci-lint/cmd/golangci-lint
-	git checkout v1.18.0
-	go build -v && go install
-)
+GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.23.8

--- a/script/setup/install-runc
+++ b/script/setup/install-runc
@@ -26,4 +26,5 @@ RUNC_COMMIT=$(grep opencontainers/runc ${GOPATH}/src/github.com/containerd/conta
 go get -d github.com/opencontainers/runc
 cd $GOPATH/src/github.com/opencontainers/runc
 git checkout $RUNC_COMMIT
-make BUILDTAGS="apparmor seccomp" runc install
+make BUILDTAGS="apparmor seccomp" runc
+sudo make install


### PR DESCRIPTION
Configuration that matches the Travis setup for release/1.3.

Copied script changes from master for actions; lint fix in resolver test and updated to golangci-lint version from master, as well as matched 3m timeout for linting from master.

Cherry picked 4756258faf55c1e2b4eb601c9fb669ecb3b43e8b from master to fix lint issue on Windows (unused var).

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>