### PR TITLE
[release/1.3] Disable TravisCI and Codecov comments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ sudo: required
 services:
   - docker
 
+branches:
+  except:
+    - master
+    - release/1.3
+
 language: go
 
 os:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
Now that release/1.3 has working GH Actions for CI we can disable Travis
on PRs for this branch. Also copied the codecov comment disable setting
from master.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>