### PR TITLE
Add release GH Action triggered by signed tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,177 @@
+on:
+  push:
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: Containerd Release
+
+jobs:
+  check:
+    name: Check Signed Tag
+    runs-on: ubuntu-18.04
+    timeout-minutes: 5
+    outputs:
+      stringver: ${{ steps.contentrel.outputs.stringver }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+          path: src/github.com/containerd/containerd
+
+      - name: Check signature
+        run: |
+          releasever=${{ github.ref }}
+          releasever="${releasever#refs/tags/}"
+          TAGCHECK=$(git tag -v ${releasever} 2>&1 >/dev/null) ||
+          echo "${TAGCHECK}" | grep -q "error" && {
+              echo "::error::tag ${releasever} is not a signed tag. Failing release process."
+              exit 1
+          } || {
+              echo "Tag ${releasever} is signed."
+              exit 0
+          }
+        working-directory: src/github.com/containerd/containerd
+
+      - name: Release content
+        id: contentrel
+        run: |
+          RELEASEVER=${{ github.ref }}
+          echo "::set-output name=stringver::${RELEASEVER#refs/tags/v}"
+          git tag -l ${RELEASEVER#refs/tags/} -n1000 | tail -n +3 | cut -c 5- >release-notes.md
+        working-directory: src/github.com/containerd/containerd
+
+      - name: Save release notes
+        uses: actions/upload-artifact@v2
+        with:
+          name: containerd-release-notes
+          path: src/github.com/containerd/containerd/release-notes.md
+
+  build:
+    name: Build Release Binaries
+    runs-on: ${{ matrix.os }}
+    needs: [check]
+    timeout-minutes: 10
+
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, windows-2019]
+
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.13.11'
+
+      - name: Set env
+        shell: bash
+        run: |
+          releasever=${{ github.ref }}
+          releasever="${releasever#refs/tags/}"
+          echo "::set-env name=RELEASE_VER::${releasever}"
+          echo "::set-env name=GOPATH::${{ github.workspace }}"
+          echo "::add-path::${{ github.workspace }}/bin"
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          repository: containerd/containerd
+          ref: ${{ github.ref }}
+          path: src/github.com/containerd/containerd
+
+      - name: Install Linux dependencies
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get install -y btrfs-tools libseccomp-dev
+
+      - name: Make
+        shell: bash
+        env:
+          MOS: ${{ matrix.os }}
+          OS: linux
+        run: |
+          make build
+          make binaries
+          [[ "${MOS}" =~ "windows" ]] && {
+              OS=windows
+          }
+          TARFILE="containerd-${RELEASE_VER#v}-${OS}-amd64.tar.gz"
+          tar czf ${TARFILE} bin/
+          sha256sum ${TARFILE} >${TARFILE}.sha256sum
+        working-directory: src/github.com/containerd/containerd
+
+      - name: Save build binaries
+        uses: actions/upload-artifact@v2
+        with:
+          name: containerd-binaries-${{ matrix.os }}
+          path: src/github.com/containerd/containerd/*.tar.gz*
+
+  release:
+    name: Create containerd Release
+    runs-on: ubuntu-18.04
+    timeout-minutes: 10
+    needs: [build, check]
+
+    steps:
+      - name: Download builds and release notes
+        uses: actions/download-artifact@v2
+        with:
+          path: builds
+      - name: Catalog build assets for upload
+        id: catalog
+        run: |
+          _filenum=1
+          for i in "ubuntu-18.04" "windows-2019"; do
+            for i in `ls builds/containerd-binaries-${i}`; do
+              echo "::set-output name=file${_filenum}::${i}"
+              let "_filenum+=1"
+            done
+          done
+      - name: Create Release
+        id: create_release
+        uses: jbolda/create-release@v1.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: containerd ${{ needs.check.outputs.stringver }}
+          bodyFromFile: ./builds/containerd-release-notes/release-notes.md
+          draft: false
+          prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
+      - name: Upload Linux containerd tarball
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./builds/containerd-binaries-ubuntu-18.04/${{ steps.catalog.outputs.file1 }}
+          asset_name: ${{ steps.catalog.outputs.file1 }}
+          asset_content_type: application/gzip
+      - name: Upload Linux sha256 sum
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./builds/containerd-binaries-ubuntu-18.04/${{ steps.catalog.outputs.file2 }}
+          asset_name: ${{ steps.catalog.outputs.file2 }}
+          asset_content_type: text/plain
+      - name: Upload Windows containerd tarball
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./builds/containerd-binaries-windows-2019/${{ steps.catalog.outputs.file3 }}
+          asset_name: ${{ steps.catalog.outputs.file3 }}
+          asset_content_type: application/gzip
+      - name: Upload Windows sha256 sum
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./builds/containerd-binaries-windows-2019/${{ steps.catalog.outputs.file4 }}
+          asset_name: ${{ steps.catalog.outputs.file4 }}
+          asset_content_type: text/plain


### PR DESCRIPTION
This will check that the tag is signed and then checkout the tag, build
official binaries, sha256sum the tarball, and upload those assets to the
release, officially generating a release in GitHub from the signed tag.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>