### PR TITLE
Add `ctr` flags for configuring default TLS credentials for registry

### DIFF
--- a/cmd/ctr/commands/commands.go
+++ b/cmd/ctr/commands/commands.go
@@ -66,6 +66,18 @@ var (
 			// compatible with "/etc/docker/certs.d"
 			Usage: "Custom hosts configuration directory",
 		},
+		cli.StringFlag{
+			Name:  "tlscacert",
+			Usage: "path to TLS root CA",
+		},
+		cli.StringFlag{
+			Name:  "tlscert",
+			Usage: "path to TLS client certificate",
+		},
+		cli.StringFlag{
+			Name:  "tlskey",
+			Usage: "path to TLS client key",
+		},
 	}
 
 	// ContainerFlags are cli flags specifying container options


### PR DESCRIPTION
This adds new flags to the `ctr` tool for configuring TLS credentials:
* `--tlscacert` is the path to a root CA certificate, to be used when verifying the server's identity.
* `--tlscert` and `--tlskey` are paths to the components of a TLS client keypair, used to authenticate with a server that requires mTLS authn.

See https://github.com/containerd/containerd/issues/3071 for context. This approach is more flexible than the `hosts.toml` solution (at the cost of higher per-call config verbosity), and can be used for cases such as integration tests and ad-hoc administrative scripts where maintaining a separate directory structure of per-registry certs is impractical.

R: @crosbymichael,@estesp
CC: @mmoriarity-stripe