### PR TITLE
fix panic in shim is not logged

### DIFF
--- a/runtime/v2/shim/shim_unix.go
+++ b/runtime/v2/shim/shim_unix.go
@@ -90,5 +90,5 @@ func handleSignals(ctx context.Context, logger *logrus.Entry, signals chan os.Si
 }
 
 func openLog(ctx context.Context, _ string) (io.Writer, error) {
-	return fifo.OpenFifo(ctx, "log", unix.O_WRONLY, 0700)
+	return fifo.OpenFifoWithDup2(ctx, "log", unix.O_WRONLY, 0700, int(os.Stderr.Fd()))
 }


### PR DESCRIPTION
#4274 

The daemon log will be:
```
...
DEBU[2020-06-03T14:48:54.204864142+08:00] event forwarded                               ns=default topic=/tasks/create type=containerd.events.TaskCreate
DEBU[2020-06-03T14:48:54.225318724+08:00] event forwarded                               ns=default topic=/tasks/start type=containerd.events.TaskStart
panic: test20200520

goroutine 7 [running]:
github.com/containerd/containerd/runtime/v2/shim.Run.func1()
	/home/zsy/.asdf/installs/golang/1.13.5/packages/src/github.com/containerd/containerd/runtime/v2/shim/shim.go:151 +0x47
created by github.com/containerd/containerd/runtime/v2/shim.Run
	/home/zsy/.asdf/installs/golang/1.13.5/packages/src/github.com/containerd/containerd/runtime/v2/shim/shim.go:149 +0x47
INFO[2020-06-03T14:48:56.998794944+08:00] shim disconnected                             id=foo
WARN[2020-06-03T14:48:56.998935894+08:00] cleaning up after shim disconnected           id=foo namespace=default
INFO[2020-06-03T14:48:56.998989197+08:00] cleaning up dead shim                        
...
```
This pr has changed project  `containerd/fifo` in vendor directory, because `dup2` need to pass `fd` as param which hold by struct `fifo`.


