### PR TITLE
Match version used in CRI project

### DIFF
--- a/script/setup/install-critools
+++ b/script/setup/install-critools
@@ -21,7 +21,7 @@
 set -eu -o pipefail
 
 go get -u github.com/onsi/ginkgo/ginkgo
-CRITEST_COMMIT=v1.18.0
+CRITEST_COMMIT=75ef33dc2b4ecb08e0237d91de1b664909d262de
 go get -d github.com/kubernetes-sigs/cri-tools/...
 cd "$GOPATH"/src/github.com/kubernetes-sigs/cri-tools
 git checkout $CRITEST_COMMIT


### PR DESCRIPTION
Use the critools version currently being used in the CRI project CI.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>

*Based on the comment from @mikebrow [here](https://github.com/containerd/containerd/pull/4296#pullrequestreview-423024118)*