### PR TITLE
Ignore file/directory does not exist with os.Remove

### DIFF
--- a/container.go
+++ b/container.go
@@ -435,7 +435,7 @@ func loadFifos(response *tasks.GetResponse) *cio.FIFOSet {
 		)
 		for _, fifo := range fifos {
 			if isFifo, _ := sys.IsFifo(fifo); isFifo {
-				if rerr := os.Remove(fifo); err == nil {
+				if rerr := os.Remove(fifo); err == nil && !os.IsNotExist(rerr) {
 					err = rerr
 				}
 				dirs[filepath.Dir(fifo)] = struct{}{}


### PR DESCRIPTION
we call `os.Remove` to delete a file, if we get told that the file does
not exist .... it's mission accomplished. right?

Context: we are seeing a bunch of these in k8s CI: https://github.com/kubernetes/kubernetes/issues/91579#issuecomment-637255827

Signed-off-by: Davanum Srinivas <davanum@gmail.com>