### PR TITLE
Refactor dockerResolver with resolveDockerBase helper

### DIFF
--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -219,18 +219,13 @@ func (r *countingReader) Read(p []byte) (int, error) {
 var _ remotes.Resolver = &dockerResolver{}
 
 func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocispec.Descriptor, error) {
-	refspec, err := reference.Parse(ref)
+	base, err := r.resolveDockerBase(ref)
 	if err != nil {
 		return "", ocispec.Descriptor{}, err
 	}
-
+	refspec := base.refspec
 	if refspec.Object == "" {
 		return "", ocispec.Descriptor{}, reference.ErrObjectRequired
-	}
-
-	base, err := r.base(refspec)
-	if err != nil {
-		return "", ocispec.Descriptor{}, err
 	}
 
 	var (
@@ -387,12 +382,7 @@ func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocisp
 }
 
 func (r *dockerResolver) Fetcher(ctx context.Context, ref string) (remotes.Fetcher, error) {
-	refspec, err := reference.Parse(ref)
-	if err != nil {
-		return nil, err
-	}
-
-	base, err := r.base(refspec)
+	base, err := r.resolveDockerBase(ref)
 	if err != nil {
 		return nil, err
 	}
@@ -403,21 +393,25 @@ func (r *dockerResolver) Fetcher(ctx context.Context, ref string) (remotes.Fetch
 }
 
 func (r *dockerResolver) Pusher(ctx context.Context, ref string) (remotes.Pusher, error) {
-	refspec, err := reference.Parse(ref)
-	if err != nil {
-		return nil, err
-	}
-
-	base, err := r.base(refspec)
+	base, err := r.resolveDockerBase(ref)
 	if err != nil {
 		return nil, err
 	}
 
 	return dockerPusher{
 		dockerBase: base,
-		object:     refspec.Object,
+		object:     base.refspec.Object,
 		tracker:    r.tracker,
 	}, nil
+}
+
+func (r *dockerResolver) resolveDockerBase(ref string) (*dockerBase, error) {
+	refspec, err := reference.Parse(ref)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.base(refspec)
 }
 
 type dockerBase struct {
@@ -451,10 +445,8 @@ func (r *dockerBase) filterHosts(caps HostCapabilities) (hosts []RegistryHost) {
 }
 
 func (r *dockerBase) request(host RegistryHost, method string, ps ...string) *request {
-	header := http.Header{}
-	for key, value := range r.header {
-		header[key] = append(header[key], value...)
-	}
+	header := r.header.Clone()
+
 	for key, value := range host.Header {
 		header[key] = append(header[key], value...)
 	}


### PR DESCRIPTION
Recently I started reading the containerd 's source code, when I read at `remotes/docker/resolver.go`,  find there are some codes are too similar and repetitive.

 So I just add a `resolveDockerBase` helper for it , the changed code looks more  simple.