### PR TITLE
waitForPid: fix goroutine leak

### DIFF
--- a/sys/oom_unix_test.go
+++ b/sys/oom_unix_test.go
@@ -87,7 +87,7 @@ func adjustOom(adjustment int) (int, error) {
 }
 
 func waitForPid(process *os.Process) (int, error) {
-	c := make(chan int)
+	c := make(chan int, 1)
 	go func() {
 		for {
 			pid := process.Pid


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>

The goroutine fetching the Process pid may timeout and cause a leak if there is no reader for the channel. To fix this, make it a buffered channel.