### PR TITLE
Process I/O: Fix goroutine leak

### DIFF
--- a/pkg/process/io.go
+++ b/pkg/process/io.go
@@ -381,7 +381,7 @@ func (b *binaryIO) cancel() error {
 		return result.ErrorOrNil()
 	}
 
-	done := make(chan error)
+	done := make(chan error, 1)
 	go func() {
 		done <- b.cmd.Wait()
 	}()


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>

The goroutine executing `b.cmd.Wait()` can leak if it time outs and there is no corresponding reader for the `done` channel. To fix this, make `error` an asynchronous buffered channel.