### PR TITLE
[DNM] trigger CI with runc rc91-pre

### DIFF
--- a/script/setup/install-runc
+++ b/script/setup/install-runc
@@ -21,7 +21,7 @@
 set -eu -o pipefail
 
 function install_runc() {
-	RUNC_COMMIT=$(grep opencontainers/runc "$GOPATH"/src/github.com/containerd/containerd/vendor.conf | awk '{print $2}')
+	RUNC_COMMIT="9748b48742fad065666bcded00f2db5ded7e44c1" # June 19, 2020
 
 	go get -d github.com/opencontainers/runc
 	cd "$GOPATH"/src/github.com/opencontainers/runc


### PR DESCRIPTION
DNM until the actual release of rc91

NOTE: vendor is not updated due to Go API incompatibility: (https://github.com/containerd/cri/pull/1521)
    
    # github.com/containerd/containerd/vendor/github.com/containerd/cri/pkg/containerd/opts
    vendor/github.com/containerd/cri/pkg/containerd/opts/spec_unix.go:327:5: cannot use dev.DeviceRule.Permissions (type configs.DevicePermissions) as type string in field value
    make: *** [Makefile:193: bin/containerd] Error 2