### PR TITLE
restart plugin: support binary log uri

### DIFF
--- a/cio/io.go
+++ b/cio/io.go
@@ -245,19 +245,11 @@ func LogURI(uri *url.URL) Creator {
 // BinaryIO forwards container STDOUT|STDERR directly to a logging binary
 func BinaryIO(binary string, args map[string]string) Creator {
 	return func(_ string) (IO, error) {
-		binary = filepath.Clean(binary)
-		if !strings.HasPrefix(binary, "/") {
-			return nil, errors.New("absolute path needed")
+		uri, err := LogURIGenerator("binary", binary, args)
+		if err != nil {
+			return nil, err
 		}
-		uri := &url.URL{
-			Scheme: "binary",
-			Path:   binary,
-		}
-		q := uri.Query()
-		for k, v := range args {
-			q.Set(k, v)
-		}
-		uri.RawQuery = q.Encode()
+
 		res := uri.String()
 		return &logURI{
 			config: Config{
@@ -272,14 +264,11 @@ func BinaryIO(binary string, args map[string]string) Creator {
 // If the log file already exists, the logs will be appended to the file.
 func LogFile(path string) Creator {
 	return func(_ string) (IO, error) {
-		path = filepath.Clean(path)
-		if !strings.HasPrefix(path, "/") {
-			return nil, errors.New("absolute path needed")
+		uri, err := LogURIGenerator("file", path, nil)
+		if err != nil {
+			return nil, err
 		}
-		uri := &url.URL{
-			Scheme: "file",
-			Path:   path,
-		}
+
 		res := uri.String()
 		return &logURI{
 			config: Config{
@@ -288,6 +277,30 @@ func LogFile(path string) Creator {
 			},
 		}, nil
 	}
+}
+
+// LogURIGenerator is the helper to generate log uri with specific scheme.
+func LogURIGenerator(scheme string, path string, args map[string]string) (*url.URL, error) {
+	path = filepath.Clean(path)
+	if !strings.HasPrefix(path, "/") {
+		return nil, errors.New("absolute path needed")
+	}
+
+	uri := &url.URL{
+		Scheme: scheme,
+		Path:   path,
+	}
+
+	if len(args) == 0 {
+		return uri, nil
+	}
+
+	q := uri.Query()
+	for k, v := range args {
+		q.Set(k, v)
+	}
+	uri.RawQuery = q.Encode()
+	return uri, nil
 }
 
 type logURI struct {

--- a/cio/io_test.go
+++ b/cio/io_test.go
@@ -195,3 +195,47 @@ func TestLogFileFailOnRelativePath(t *testing.T) {
 	_, err := LogFile("./file.txt")("!")
 	assert.Error(t, err, "absolute path needed")
 }
+
+func TestLogURIGenerator(t *testing.T) {
+	for _, tc := range []struct {
+		scheme   string
+		path     string
+		args     map[string]string
+		expected string
+		err      string
+	}{
+		{
+			scheme:   "fifo",
+			path:     "/full/path/pipe.fifo",
+			expected: "fifo:///full/path/pipe.fifo",
+		},
+		{
+			scheme: "file",
+			path:   "/full/path/file.txt",
+			args: map[string]string{
+				"maxSize": "100MB",
+			},
+			expected: "file:///full/path/file.txt?maxSize=100MB",
+		},
+		{
+			scheme: "binary",
+			path:   "/full/path/bin",
+			args: map[string]string{
+				"id": "testing",
+			},
+			expected: "binary:///full/path/bin?id=testing",
+		},
+		{
+			scheme: "unknown",
+			path:   "nowhere",
+			err:    "absolute path needed",
+		},
+	} {
+		uri, err := LogURIGenerator(tc.scheme, tc.path, tc.args)
+		if err != nil {
+			assert.Error(t, err, tc.err)
+			continue
+		}
+		assert.Equal(t, tc.expected, uri.String())
+	}
+}

--- a/runtime/restart/monitor/monitor.go
+++ b/runtime/restart/monitor/monitor.go
@@ -200,6 +200,7 @@ func (m *monitor) monitor(ctx context.Context) ([]change, error) {
 			changes = append(changes, &startChange{
 				container: c,
 				logPath:   labels[restart.LogPathLabel],
+				logURI:    labels[restart.LogURILabel],
 			})
 		case containerd.Stopped:
 			changes = append(changes, &stopChange{


### PR DESCRIPTION
Introduce LogURIGenerator helper function in cio package. It is used in
the restart options, like WithBinaryLogURI and WithFileLogURI.

And restart.LogPathLabel might be used in production and work well. In
order to reduce breaking change, the LogPathLabel is still recognized if
new LogURILabel is not set. In next release 1.5, the LogPathLabel will
be removed.

Signed-off-by: Wei Fu <fuweid89@gmail.com>

---------

fix: #4294