### PR TITLE
[release/1.3 backport] Build runc with selinux support

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -207,7 +207,7 @@ Next, let's build `runc`:
 
 ```sh
 cd /go/src/github.com/opencontainers/runc
-make BUILDTAGS='seccomp apparmor' && make install
+make BUILDTAGS='seccomp apparmor selinux' && make install
 ```
 
 When working with `ctr`, the simple test client we just built, don't forget to start the daemon!

--- a/script/setup/install-runc
+++ b/script/setup/install-runc
@@ -26,5 +26,5 @@ RUNC_COMMIT=$(grep opencontainers/runc ${GOPATH}/src/github.com/containerd/conta
 go get -d github.com/opencontainers/runc
 cd $GOPATH/src/github.com/opencontainers/runc
 git checkout $RUNC_COMMIT
-make BUILDTAGS="apparmor seccomp" runc
+make BUILDTAGS="seccomp apparmor selinux" runc
 sudo make install


### PR DESCRIPTION
docker-ce seems to be building runc with selinux support, let us follow
the same pattern here please:
https://github.com/docker/docker-ce/search?p=1&q=RUNC_BUILDTAGS&unscoped_q=RUNC_BUILDTAGS

Signed-off-by: Davanum Srinivas <davanum@gmail.com>

(cherry picked from commit 7a252f3ca1f158203574f2c7786a28e6c0368f5e)