### PR TITLE
integration: assume TEST_RUNTIME to be io.containerd.runc.v2 by default

### DIFF
--- a/container_linux_test.go
+++ b/container_linux_test.go
@@ -508,10 +508,10 @@ func getLogDirPath(runtimeVersion, id string) string {
 
 func getRuntimeVersion() string {
 	switch rt := os.Getenv("TEST_RUNTIME"); rt {
-	case plugin.RuntimeRuncV1, plugin.RuntimeRuncV2:
-		return "v2"
-	default:
+	case plugin.RuntimeLinuxV1:
 		return "v1"
+	default:
+		return "v2"
 	}
 }
 


### PR DESCRIPTION
containerd 1.4 uses io.containerd.runc.v2 as the default runtime for both CRI and non-CRI.
The test is updated to assume v2 shim by default.
