### PR TITLE
shim v2 runc: propagate options.Root to Cleanup

### DIFF
--- a/runtime/v2/runc/container.go
+++ b/runtime/v2/runc/container.go
@@ -20,6 +20,7 @@ package runc
 
 import (
 	"context"
+	"encoding/json"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -88,6 +89,10 @@ func NewContainer(ctx context.Context, platform stdio.Platform, r *task.CreateTa
 		Options:          r.Options,
 	}
 
+	if err := WriteOptions(r.Bundle, opts); err != nil {
+		return nil, err
+	}
+	// For historical reason, we write opts.BinaryName as well as the entire opts
 	if err := WriteRuntime(r.Bundle, opts.BinaryName); err != nil {
 		return nil, err
 	}
@@ -154,6 +159,39 @@ func NewContainer(ctx context.Context, platform stdio.Platform, r *task.CreateTa
 		container.cgroup = cg
 	}
 	return container, nil
+}
+
+const optionsFilename = "options.json"
+
+// ReadOptions reads the option information from the path.
+// When the file does not exist, ReadOptions returns nil without an error.
+func ReadOptions(path string) (*options.Options, error) {
+	filePath := filepath.Join(path, optionsFilename)
+	if _, err := os.Stat(filePath); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+	var opts options.Options
+	if err := json.Unmarshal(data, &opts); err != nil {
+		return nil, err
+	}
+	return &opts, nil
+}
+
+// WriteOptions writes the options information into the path
+func WriteOptions(path string, opts options.Options) error {
+	data, err := json.Marshal(opts)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(filepath.Join(path, optionsFilename), data, 0600)
 }
 
 // ReadRuntime reads the runtime information from the path

--- a/runtime/v2/runc/v1/service.go
+++ b/runtime/v2/runc/v1/service.go
@@ -208,7 +208,16 @@ func (s *service) Cleanup(ctx context.Context) (*taskAPI.DeleteResponse, error) 
 	if err != nil {
 		return nil, err
 	}
-	r := process.NewRunc(process.RuncRoot, path, ns, runtime, "", false)
+	opts, err := runc.ReadOptions(path)
+	if err != nil {
+		return nil, err
+	}
+	root := process.RuncRoot
+	if opts != nil && opts.Root != "" {
+		root = opts.Root
+	}
+
+	r := process.NewRunc(root, path, ns, runtime, "", false)
 	if err := r.Delete(ctx, s.id, &runcC.DeleteOpts{
 		Force: true,
 	}); err != nil {

--- a/runtime/v2/runc/v2/service.go
+++ b/runtime/v2/runc/v2/service.go
@@ -277,7 +277,16 @@ func (s *service) Cleanup(ctx context.Context) (*taskAPI.DeleteResponse, error) 
 	if err != nil {
 		return nil, err
 	}
-	r := process.NewRunc(process.RuncRoot, path, ns, runtime, "", false)
+	opts, err := runc.ReadOptions(path)
+	if err != nil {
+		return nil, err
+	}
+	root := process.RuncRoot
+	if opts != nil && opts.Root != "" {
+		root = opts.Root
+	}
+
+	r := process.NewRunc(root, path, ns, runtime, "", false)
 	if err := r.Delete(ctx, s.id, &runcC.DeleteOpts{
 		Force: true,
 	}); err != nil {


### PR DESCRIPTION
Previously shim v2 (`io.containerd.runc.{v1,v2}`) always used `/run/containerd/runc` as the runc root.

Fix #4326
Fix https://github.com/containerd/containerd/issues/2767
