### PR TITLE
Add config for allowing GC to clean unpacked layers up

### DIFF
--- a/client.go
+++ b/client.go
@@ -312,6 +312,11 @@ type RemoteContext struct {
 	// afterwards. Unpacking is required to run an image.
 	Unpack bool
 
+	// DiscardContent is a boolean flag to specify whether to allow GC to clean
+	// layers up from the content store after successfully unpacking these
+	// contents to the snapshotter.
+	DiscardContent bool
+
 	// UnpackOpts handles options to the unpack call.
 	UnpackOpts []UnpackOpt
 

--- a/client_opts.go
+++ b/client_opts.go
@@ -132,6 +132,14 @@ func WithPullUnpack(_ *Client, c *RemoteContext) error {
 	return nil
 }
 
+// WithDiscardContent is used to allow GC to clean layers up from
+// the content store after successfully unpacking these contents to
+// the snapshotter.
+func WithDiscardContent(_ *Client, c *RemoteContext) error {
+	c.DiscardContent = true
+	return nil
+}
+
 // WithUnpackOpts is used to add unpack options to the unpacker.
 func WithUnpackOpts(opts []UnpackOpt) RemoteOpt {
 	return func(_ *Client, c *RemoteContext) error {

--- a/unpacker.go
+++ b/unpacker.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -77,6 +78,7 @@ func (u *unpacker) unpack(
 	rCtx *RemoteContext,
 	h images.Handler,
 	config ocispec.Descriptor,
+	parentDesc ocispec.Descriptor,
 	layers []ocispec.Descriptor,
 ) error {
 	p, err := content.ReadBlob(ctx, u.c.ContentStore(), config)
@@ -245,6 +247,31 @@ EachLayer:
 		"chainID": chainID,
 	}).Debug("image unpacked")
 
+	if rCtx.DiscardContent {
+		// delete references to successfully unpacked layers
+		layersMap := map[string]struct{}{}
+		for _, desc := range layers {
+			layersMap[desc.Digest.String()] = struct{}{}
+		}
+		pinfo, err := cs.Info(ctx, parentDesc.Digest)
+		if err != nil {
+			return err
+		}
+		fields := []string{}
+		for k, v := range pinfo.Labels {
+			if strings.HasPrefix(k, "containerd.io/gc.ref.content.") {
+				if _, ok := layersMap[v]; ok {
+					// We've already unpacked this layer content
+					pinfo.Labels[k] = ""
+					fields = append(fields, "labels."+k)
+				}
+			}
+		}
+		if _, err := cs.Update(ctx, pinfo, fields...); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -287,6 +314,7 @@ func (u *unpacker) handlerWrapper(
 		var (
 			lock   sync.Mutex
 			layers = map[digest.Digest][]ocispec.Descriptor{}
+			parent = map[digest.Digest]ocispec.Descriptor{}
 		)
 		return images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 			children, err := f.Handle(ctx, desc)
@@ -312,6 +340,7 @@ func (u *unpacker) handlerWrapper(
 				lock.Lock()
 				for _, nl := range nonLayers {
 					layers[nl.Digest] = manifestLayers
+					parent[nl.Digest] = desc
 				}
 				lock.Unlock()
 
@@ -319,11 +348,12 @@ func (u *unpacker) handlerWrapper(
 			case images.MediaTypeDockerSchema2Config, ocispec.MediaTypeImageConfig:
 				lock.Lock()
 				l := layers[desc.Digest]
+				p := parent[desc.Digest]
 				lock.Unlock()
 				if len(l) > 0 {
 					atomic.AddInt32(unpacks, 1)
 					eg.Go(func() error {
-						return u.unpack(uctx, rCtx, f, desc, l)
+						return u.unpack(uctx, rCtx, f, desc, p, l)
 					})
 				}
 			}


### PR DESCRIPTION
Fixes: #4304

This commit adds a flag through Pull API for allowing GC to clean layer contents up after unpacking these contents completed.

This patch takes an approach to directly delete GC labels pointing to layers from the manifest blob. This will result in other snapshotters cannot reuse these contents on the next pull. But this patch mainly focuses on CRI use-cases where single snapshotter is usually used throughout the node lifecycle so this shouldn't be a matter.

Could I get comments on this approach towards unpacked contents deduplication?
What I currently concern is whether is it OK to clean layers up immediately after the unpack because other services in containerd will also be inaccessible to that contents.

Related also to: #4249