### PR TITLE
[release/1.2] Bump Golang 1.13.12

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.13.10
+    - GO_VERSION: 1.13.12
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 language: go
 
 go:
-  - "1.13.10"
+  - "1.13.12"
 os:
   - "linux"
   # TODO ppc64le is currently timing out on travis; see https://github.com/containerd/containerd/pull/2896

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.13.10
+ARG GOLANG_VERSION=1.13.12
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd


### PR DESCRIPTION
Essentially cherry-picking #4260 #4333
(but without `git-cherry-pick(1)` due to the code divergence between v1.2 and master caused by CI changes)
