### PR TITLE
Fix deprecation warnings in CRI tests due to missing unix:// scheme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,7 +421,7 @@ jobs:
           EOF"
           sudo PATH=$PATH containerd -log-level debug &> /tmp/containerd-cri.log &
           sudo ctr version
-          sudo PATH=$PATH GOPATH=$GOPATH critest --runtime-endpoint=/var/run/containerd/containerd.sock --parallel=8
+          sudo PATH=$PATH GOPATH=$GOPATH critest --runtime-endpoint=unix:///var/run/containerd/containerd.sock --parallel=8
           TEST_RC=$?
           test $TEST_RC -ne 0 && cat /tmp/containerd-cri.log
           sudo pkill containerd


### PR DESCRIPTION
    [BeforeEach] [k8s.io] Security Context
      /home/runner/work/containerd/containerd/src/github.com/kubernetes-sigs/cri-tools/pkg/framework/framework.go:50
     W0624 12:26:28.532644   30569 util_unix.go:103] Using "/var/run/containerd/containerd.sock" as endpoint is deprecated, please consider using full url format "unix:///var/run/containerd/containerd.sock".
     W0624 12:26:28.532700   30569 util_unix.go:103] Using "/var/run/containerd/containerd.sock" as endpoint is deprecated, please consider using full url format "unix:///var/run/containerd/containerd.sock".

