### PR TITLE
Use path based unix socket for shims

### DIFF
--- a/cmd/ctr/commands/shim/shim.go
+++ b/cmd/ctr/commands/shim/shim.go
@@ -242,8 +242,8 @@ func getTaskService(context *cli.Context) (task.TaskService, error) {
 	ctx := namespaces.WithNamespace(gocontext.Background(), ns)
 	s2, _ := shim.SocketAddress(ctx, id)
 
-	for _, socket := range []string{s1, s2} {
-		conn, err := net.Dial("unix", "\x00"+socket)
+	for _, socket := range []string{"\x00" + s1, s2} {
+		conn, err := net.Dial("unix", socket)
 		if err == nil {
 			client := ttrpc.NewClient(conn)
 

--- a/runtime/v2/shim/shim.go
+++ b/runtime/v2/shim/shim.go
@@ -300,11 +300,15 @@ func serve(ctx context.Context, server *ttrpc.Server, path string) error {
 		return err
 	}
 	go func() {
-		defer l.Close()
 		if err := server.Serve(ctx, l); err != nil &&
 			!strings.Contains(err.Error(), "use of closed network connection") {
 			logrus.WithError(err).Fatal("containerd-shim: ttrpc server failure")
 		}
+		l.Close()
+		if address, err := ReadAddress("address"); err == nil {
+			RemoveSocket(address)
+		}
+
 	}()
 	return nil
 }

--- a/runtime/v2/shim/shim_unix.go
+++ b/runtime/v2/shim/shim_unix.go
@@ -58,10 +58,10 @@ func serveListener(path string) (net.Listener, error) {
 		l, err = net.FileListener(os.NewFile(3, "socket"))
 		path = "[inherited from parent]"
 	} else {
-		if len(path) > 106 {
-			return nil, errors.Errorf("%q: unix socket path too long (> 106)", path)
+		if len(path) > socketPathLimit {
+			return nil, errors.Errorf("%q: unix socket path too long (> %d)", path, socketPathLimit)
 		}
-		l, err = net.Listen("unix", "\x00"+path)
+		l, err = net.Listen("unix", path)
 	}
 	if err != nil {
 		return nil, err

--- a/runtime/v2/shim/util_windows.go
+++ b/runtime/v2/shim/util_windows.go
@@ -79,3 +79,9 @@ func AnonDialer(address string, timeout time.Duration) (net.Conn, error) {
 		return c, nil
 	}
 }
+
+// RemoveSocket removes the socket at the sepcified address if
+// it exists on the filesystem
+func RemoveSocket(address string) error {
+	return nil
+}


### PR DESCRIPTION
This allows filesystem based ACLs for configuring access to the socket of a
shim.

Signed-off-by: Michael Crosby <michael@thepasture.io>