### PR TITLE
CI: run CRI tests on Fedora 32

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,3 +442,6 @@ jobs:
 
       - name: Integration
         run: vagrant ssh default -- sudo -i /integration.sh
+
+      - name: CRI test
+        run: vagrant ssh default -- sudo -i /critest.sh


### PR DESCRIPTION
SELinux is currently disabled.  (It doesn't expect the binaries to be under `/usr/local/bin`: https://github.com/containers/container-selinux/blob/988431700370bf7f554ab6507c836a9aa19e47ff/container.fc#L6)

SELinux will be enabled in a follow-up PR.
