### PR TITLE
Change log for unknown mt to debug

### DIFF
--- a/images/image.go
+++ b/images/image.go
@@ -362,7 +362,7 @@ func Children(ctx context.Context, provider content.Provider, desc ocispec.Descr
 			// childless data types.
 			return nil, nil
 		}
-		log.G(ctx).Warnf("encountered unknown type %v; children may not be fetched", desc.MediaType)
+		log.G(ctx).Debugf("encountered unknown type %v; children may not be fetched", desc.MediaType)
 	}
 
 	return descs, nil


### PR DESCRIPTION
This log message shows up in the client's logs. For any media type that
the client doesn't know about it will wind up with a warning log.
Downgrade this to debug since it is more of a development concern.

We encountered this trying to fetch Docker plugins which has a media
type for plugin configs.

Replacement for #4345 