### PR TITLE
[release/1.3] Pin libseccomp to 2.3.3 for GH Actions release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,9 @@ jobs:
       - name: Install Linux dependencies
         if: startsWith(matrix.os, 'ubuntu')
         run: |
-          sudo apt-get install -y btrfs-tools libseccomp-dev
+          sudo apt-get install -y btrfs-tools
+          sudo script/setup/install-seccomp
+        working-directory: src/github.com/containerd/containerd
       - name: HCS Shim commit
         id: hcsshim_commit
         if: startsWith(matrix.os, 'windows')


### PR DESCRIPTION
Use the same pinning we were using in Travis CI to not force
dependencies on the newer libseccomp 2.4.x in our binaries.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>

Fixes: #4349