### PR TITLE
[events] Fix deadlock in TestExchangeBasic

### DIFF
--- a/events/exchange/exchange_test.go
+++ b/events/exchange/exchange_test.go
@@ -52,11 +52,8 @@ func TestExchangeBasic(t *testing.T) {
 	eventq2, errq2 := exchange.Subscribe(ctx2)
 
 	t.Log("publish")
-	var wg sync.WaitGroup
-	wg.Add(1)
 	errChan := make(chan error)
 	go func() {
-		defer wg.Done()
 		defer close(errChan)
 		for _, event := range testevents {
 			if err := exchange.Publish(ctx, "/test", event); err != nil {
@@ -69,7 +66,6 @@ func TestExchangeBasic(t *testing.T) {
 	}()
 
 	t.Log("waiting")
-	wg.Wait()
 	if err := <-errChan; err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>

The goroutine writing to errChan will block on the reader (main routine), however the main routine will block for the goroutine to finish with the wait() before it can read from errChan thus causing the deadlock. 
An example here: https://play.golang.com/p/zwk-FHPKx-4

For this case, we don't really need the sync.WaitGroup at all since the main routine's execution is already blocked on the errChan (read or close). Fix this by removing the wait logic.