### PR TITLE
Minor actions fixes/updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,7 @@ jobs:
       - name: Install Linux dependencies
         if: startsWith(matrix.os, 'ubuntu')
         run: |
+          sudo apt-get update
           sudo apt-get install -y btrfs-tools libseccomp-dev
 
       - name: Make

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,7 @@ jobs:
       - name: Install Linux dependencies
         if: startsWith(matrix.os, 'ubuntu')
         run: |
+          sudo apt-get update
           sudo apt-get install -y btrfs-tools libseccomp-dev
       - name: HCS Shim commit
         id: hcsshim_commit
@@ -146,13 +147,13 @@ jobs:
           done
       - name: Create Release
         id: create_release
-        uses: jbolda/create-release@v1.1.0
+        uses: actions/create-release@v1.1.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
           release_name: containerd ${{ needs.check.outputs.stringver }}
-          bodyFromFile: ./builds/containerd-release-notes/release-notes.md
+          body_path: ./builds/containerd-release-notes/release-notes.md
           draft: false
           prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
       - name: Upload Linux containerd tarball


### PR DESCRIPTION
- always apt-get update before installing packages
- move to tagged official `create_release` action

The official GH `create_release` action now has support for body text from
file.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>