### PR TITLE
[release/1.3] backport: Transfer error to ErrNotFound when kill a not exist container, also add test case.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,16 +342,17 @@ jobs:
         env:
           TEST_RUNTIME: io.containerd.${{ matrix.runtime }}
         run: |
-          sudo mkdir -p /etc/containerd
-          sudo bash -c "cat > /etc/containerd/config.toml <<EOF
+          BDIR="$(mktemp -d -p $PWD)"
+          mkdir -p ${BDIR}/{root,state}
+          cat > ${BDIR}/config.toml <<EOF
             [plugins.cri.containerd.default_runtime]
               runtime_type = \"${TEST_RUNTIME}\"
           EOF"
-          sudo PATH=$PATH containerd -log-level debug &> /tmp/containerd-cri.log &
-          sudo ctr version
-          sudo PATH=$PATH GOPATH=$GOPATH critest --runtime-endpoint=/var/run/containerd/containerd.sock --parallel=8
+          sudo PATH=$PATH BDIR=$BDIR /usr/local/bin/containerd -a ${BDIR}/c.sock -root ${BDIR}/root -state ${BDIR}/state -log-level debug &> ${BDIR}/containerd-cri.log &
+          sudo BDIR=$BDIR /usr/local/bin/ctr -a ${BDIR}/c.sock version
+          sudo PATH=$PATH BDIR=$BDIR GOPATH=$GOPATH critest --runtime-endpoint=unix:///${BDIR}/c.sock --parallel=8
           TEST_RC=$?
-          test $TEST_RC -ne 0 && cat /tmp/containerd-cri.log
+          test $TEST_RC -ne 0 && cat ${BDIR}/containerd-cri.log
           sudo pkill containerd
-          sudo rm -rf /etc/containerd
+          sudo BDIR=$BDIR rm -rf ${BDIR}
           test $TEST_RC -eq 0 || /bin/false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,8 +324,9 @@ jobs:
         env:
           GOPROXY: direct
           TEST_RUNTIME: io.containerd.${{ matrix.runtime }}
+          RUNC_FLAVOR: ${{ matrix.runc }}
         run: |
-          sudo GOPATH=$GOPATH GOPROXY=$GOPROXY TEST_RUNTIME=$TEST_RUNTIME make integration EXTRA_TESTFLAGS=-no-criu TESTFLAGS_RACE=-race
+          sudo GOPATH=$GOPATH GOPROXY=$GOPROXY TEST_RUNTIME=$TEST_RUNTIME RUNC_FLAVOR=$RUNC_FLAVOR make integration EXTRA_TESTFLAGS=-no-criu TESTFLAGS_RACE=-race
         working-directory: src/github.com/containerd/containerd
 
       # Run the integration suite a second time. See discussion in github.com/containerd/containerd/pull/1759
@@ -333,8 +334,9 @@ jobs:
         env:
           GOPROXY: direct
           TEST_RUNTIME: io.containerd.${{ matrix.runtime }}
+          RUNC_FLAVOR: ${{ matrix.runc }}
         run: |
-          sudo GOPATH=$GOPATH GOPROXY=$GOPROXY TEST_RUNTIME=$TEST_RUNTIME TESTFLAGS_PARALLEL=1 make integration EXTRA_TESTFLAGS=-no-criu
+          sudo GOPATH=$GOPATH GOPROXY=$GOPROXY TEST_RUNTIME=$TEST_RUNTIME RUNC_FLAVOR=$RUNC_FLAVOR TESTFLAGS_PARALLEL=1 make integration EXTRA_TESTFLAGS=-no-criu
         working-directory: src/github.com/containerd/containerd
 
       - name: CRI test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,7 @@ jobs:
       - name: Install Linux dependencies
         if: startsWith(matrix.os, 'ubuntu')
         run: |
+          sudo apt-get update
           sudo apt-get install -y btrfs-tools libseccomp-dev
 
       - name: Make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,9 +325,8 @@ jobs:
         env:
           GOPROXY: direct
           TEST_RUNTIME: io.containerd.${{ matrix.runtime }}
-          RUNC_FLAVOR: ${{ matrix.runc }}
         run: |
-          sudo GOPATH=$GOPATH GOPROXY=$GOPROXY TEST_RUNTIME=$TEST_RUNTIME RUNC_FLAVOR=$RUNC_FLAVOR make integration EXTRA_TESTFLAGS=-no-criu TESTFLAGS_RACE=-race
+          sudo GOPATH=$GOPATH GOPROXY=$GOPROXY TEST_RUNTIME=$TEST_RUNTIME make integration EXTRA_TESTFLAGS=-no-criu TESTFLAGS_RACE=-race
         working-directory: src/github.com/containerd/containerd
 
       # Run the integration suite a second time. See discussion in github.com/containerd/containerd/pull/1759
@@ -335,9 +334,8 @@ jobs:
         env:
           GOPROXY: direct
           TEST_RUNTIME: io.containerd.${{ matrix.runtime }}
-          RUNC_FLAVOR: ${{ matrix.runc }}
         run: |
-          sudo GOPATH=$GOPATH GOPROXY=$GOPROXY TEST_RUNTIME=$TEST_RUNTIME RUNC_FLAVOR=$RUNC_FLAVOR TESTFLAGS_PARALLEL=1 make integration EXTRA_TESTFLAGS=-no-criu
+          sudo GOPATH=$GOPATH GOPROXY=$GOPROXY TEST_RUNTIME=$TEST_RUNTIME TESTFLAGS_PARALLEL=1 make integration EXTRA_TESTFLAGS=-no-criu
         working-directory: src/github.com/containerd/containerd
 
       - name: CRI test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,7 @@ jobs:
       - name: Install Linux dependencies
         if: startsWith(matrix.os, 'ubuntu')
         run: |
+          sudo apt-get update
           sudo apt-get install -y btrfs-tools
           sudo script/setup/install-seccomp
         working-directory: src/github.com/containerd/containerd
@@ -148,13 +149,13 @@ jobs:
           done
       - name: Create Release
         id: create_release
-        uses: jbolda/create-release@v1.1.0
+        uses: actions/create-release@v1.1.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
           release_name: containerd ${{ needs.check.outputs.stringver }}
-          bodyFromFile: ./builds/containerd-release-notes/release-notes.md
+          body_path: ./builds/containerd-release-notes/release-notes.md
           draft: false
           prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
       - name: Upload Linux containerd tarball

--- a/container_linux_test.go
+++ b/container_linux_test.go
@@ -451,15 +451,6 @@ func getLogDirPath(runtimeVersion, id string) string {
 	}
 }
 
-func getRuntimeVersion() string {
-	switch rt := os.Getenv("TEST_RUNTIME"); rt {
-	case plugin.RuntimeRuncV1, plugin.RuntimeRuncV2:
-		return "v2"
-	default:
-		return "v1"
-	}
-}
-
 func TestContainerPTY(t *testing.T) {
 	t.Parallel()
 

--- a/container_test.go
+++ b/container_test.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
 	"runtime"
 	"strings"
 	"syscall"
@@ -36,10 +37,12 @@ import (
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/platforms"
 	_ "github.com/containerd/containerd/runtime"
+	"github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/containerd/typeurl"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/go-runc"
 	gogotypes "github.com/gogo/protobuf/types"
 )
 
@@ -626,6 +629,78 @@ func TestContainerKill(t *testing.T) {
 	}
 	if !errdefs.IsNotFound(err) {
 		t.Errorf("expected error %q but received %q", errdefs.ErrNotFound, err)
+	}
+}
+
+func TestKillContainerDeletedByRunc(t *testing.T) {
+	t.Parallel()
+
+	// We skip this case when runtime is crun.
+	// More information in https://github.com/containerd/containerd/pull/4214#discussion_r422769497
+	if os.Getenv("RUNC_FLAVOR") == "crun" {
+		t.Skip("skip it when using crun")
+	}
+
+	client, err := newClient(t, address)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	var (
+		image       Image
+		ctx, cancel = testContext(t)
+		id          = t.Name()
+		runcRoot    = "/tmp/runc-test"
+	)
+	defer cancel()
+
+	image, err = client.GetImage(ctx, testImage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	container, err := client.NewContainer(ctx, id,
+		WithNewSnapshot(id, image),
+		WithNewSpec(oci.WithImageConfig(image), withProcessArgs("sleep", "10")),
+		WithRuntime(client.runtime, &options.Options{Root: runcRoot}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer container.Delete(ctx)
+
+	task, err := container.NewTask(ctx, empty())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer task.Delete(ctx)
+
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := task.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	rcmd := &runc.Runc{
+		Root: path.Join(runcRoot, testNamespace),
+	}
+
+	if err := rcmd.Delete(ctx, id, &runc.DeleteOpts{Force: true}); err != nil {
+		t.Fatal(err)
+	}
+	err = task.Kill(ctx, syscall.SIGKILL)
+	if err == nil {
+		t.Fatal("kill should return NotFound error")
+	} else if !errdefs.IsNotFound(err) {
+		t.Errorf("expected error %q but received %q", errdefs.ErrNotFound, err)
+	}
+
+	select {
+	case <-statusC:
+	case <-time.After(2 * time.Second):
+		t.Errorf("unexpected timeout when try to get exited container's status")
 	}
 }
 

--- a/image_test.go
+++ b/image_test.go
@@ -45,7 +45,8 @@ func TestImageIsUnpacked(t *testing.T) {
 	defer client.Close()
 
 	// Cleanup
-	err = client.ImageService().Delete(ctx, imageName)
+	opts := []images.DeleteOpt{images.SynchronousDelete()}
+	err = client.ImageService().Delete(ctx, imageName, opts...)
 	if err != nil && !errdefs.IsNotFound(err) {
 		t.Fatal(err)
 	}

--- a/image_test.go
+++ b/image_test.go
@@ -151,7 +151,7 @@ func TestImageUsage(t *testing.T) {
 	defer client.Close()
 
 	// Cleanup
-	err = client.ImageService().Delete(ctx, imageName)
+	err = client.ImageService().Delete(ctx, imageName, images.SynchronousDelete())
 	if err != nil && !errdefs.IsNotFound(err) {
 		t.Fatal(err)
 	}

--- a/pkg/process/utils.go
+++ b/pkg/process/utils.go
@@ -137,6 +137,8 @@ func checkKillError(err error) error {
 		strings.Contains(strings.ToLower(err.Error()), "no such process") ||
 		err == unix.ESRCH {
 		return errors.Wrapf(errdefs.ErrNotFound, "process already finished")
+	} else if strings.Contains(err.Error(), "does not exist") {
+		return errors.Wrapf(errdefs.ErrNotFound, "no such container")
 	}
 	return errors.Wrapf(err, "unknown error after kill")
 }

--- a/script/setup/install-critools
+++ b/script/setup/install-critools
@@ -21,7 +21,7 @@
 set -eu -o pipefail
 
 go get -u github.com/onsi/ginkgo/ginkgo
-CRITEST_COMMIT=v1.16.1
+CRITEST_COMMIT=16911795a3c33833fa0ec83dac1ade3172f6989e
 go get -d github.com/kubernetes-sigs/cri-tools/...
 cd "$GOPATH"/src/github.com/kubernetes-sigs/cri-tools
 git checkout $CRITEST_COMMIT


### PR DESCRIPTION
Backports:
-   Transfer error to ErrNotFound when kill a not exist container #4214
    Fixes #4359
-   Minor actions fixes/updates #4356
    Fixes build issues
-   test: Do SynchronousDelete cleanup before testing ImageIsUnpacked #3832
    cleanup the image synchronously for Usage case #4049
    Fixes race that causes `TestImageUsage` to fail
-   Don't clash with GH Actions runner's containerd #4380
    Fixes Github Actions
    
Not-backport:
-   fixes for backports to 1.3 from 1.4
    Fixes up backport changes that didn't fit 1.3        

Signed-off-by: Joe Julian <me@joejulian.name>