### PR TITLE
Update build doc with Go 1.13 requirement

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -14,7 +14,7 @@ This doc includes:
 
 To build the `containerd` daemon, and the `ctr` simple test client, the following build system dependencies are required:
 
-* Go 1.10.x or above
+* Go 1.13.x or above except 1.14.x
 * Protoc 3.x compiler and headers (download at the [Google protobuf releases page](https://github.com/google/protobuf/releases))
 * Btrfs headers and libraries for your distribution. Note that building the btrfs driver can be disabled via the build tag `no_btrfs`, removing this dependency.
 * `libseccomp` is required if you're building with seccomp support


### PR DESCRIPTION
Build doc specifies Go 1.10.x as min version. But it does not build at version below 1.13. Updating Go to 1.13 allows build to complete successfully. Updating build doc to reflect this. Closes #4363 