### PR TITLE
[events/exchange_test] Fix deadlock in TestExchangeFilters

### DIFF
--- a/events/exchange/exchange_test.go
+++ b/events/exchange/exchange_test.go
@@ -19,7 +19,6 @@ package exchange
 import (
 	"context"
 	"reflect"
-	"sync"
 	"testing"
 	"time"
 
@@ -221,11 +220,8 @@ func TestExchangeFilters(t *testing.T) {
 	}
 
 	t.Log("publish")
-	var wg sync.WaitGroup
-	wg.Add(1)
 	errChan := make(chan error)
 	go func() {
-		defer wg.Done()
 		defer close(errChan)
 		for _, es := range testEventSets {
 			for _, e := range es.events {
@@ -240,7 +236,6 @@ func TestExchangeFilters(t *testing.T) {
 	}()
 
 	t.Log("waiting")
-	wg.Wait()
 	if err := <-errChan; err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>

xref #4353 

The goroutine writing to errChan will block on the reader (main routine), however the main routine will block for the goroutine to finish with the wait() before it can read from errChan thus causing the deadlock.
An example here: https://play.golang.com/p/zwk-FHPKx-4