### PR TITLE
vendor: containerd/cgroups 318312a373405e5e91134d8063d04d59768a1bff

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -2,7 +2,7 @@ github.com/beorn7/perks                             v1.0.1
 github.com/BurntSushi/toml                          v0.3.1
 github.com/cespare/xxhash/v2                        v2.1.1
 github.com/containerd/btrfs                         153935315f4ab9be5bf03650a1341454b05efa5d
-github.com/containerd/cgroups                       0dbf7f05ba59274095946e2c0c89540726e8a8aa
+github.com/containerd/cgroups                       318312a373405e5e91134d8063d04d59768a1bff
 github.com/containerd/console                       v1.0.0
 github.com/containerd/continuity                    d3ef23f19fbb106bb73ffde425d07a9187e30745
 github.com/containerd/fifo                          f15a3290365b9d2627d189e619ab4008e0069caf

--- a/vendor/github.com/containerd/cgroups/README.md
+++ b/vendor/github.com/containerd/cgroups/README.md
@@ -1,6 +1,6 @@
 # cgroups
 
-[![Build Status](https://travis-ci.org/containerd/cgroups.svg?branch=master)](https://travis-ci.org/containerd/cgroups)
+[![Build Status](https://github.com/containerd/cgroups/workflows/CI/badge.svg)](https://github.com/containerd/cgroups/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/containerd/cgroups/branch/master/graph/badge.svg)](https://codecov.io/gh/containerd/cgroups)
 [![GoDoc](https://godoc.org/github.com/containerd/cgroups?status.svg)](https://godoc.org/github.com/containerd/cgroups)
 [![Go Report Card](https://goreportcard.com/badge/github.com/containerd/cgroups)](https://goreportcard.com/report/github.com/containerd/cgroups)
@@ -65,7 +65,7 @@ To update the resources applied in the cgroup
 ```go
 shares = uint64(200)
 if err := control.Update(&specs.LinuxResources{
-    CPU: &specs.CPU{
+    CPU: &specs.LinuxCPU{
         Shares: &shares,
     },
 }); err != nil {

--- a/vendor/github.com/containerd/cgroups/blkio.go
+++ b/vendor/github.com/containerd/cgroups/blkio.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -72,8 +71,8 @@ func (b *blkioController) Create(path string, resources *specs.LinuxResources) e
 	}
 	for _, t := range createBlkioSettings(resources.BlockIO) {
 		if t.value != nil {
-			if err := ioutil.WriteFile(
-				filepath.Join(b.Path(path), fmt.Sprintf("blkio.%s", t.name)),
+			if err := retryingWriteFile(
+				filepath.Join(b.Path(path), "blkio."+t.name),
 				t.format(t.value),
 				defaultFilePerm,
 			); err != nil {
@@ -94,7 +93,7 @@ func (b *blkioController) Stat(path string, stats *v1.Metrics) error {
 	var settings []blkioStatSettings
 
 	// Try to read CFQ stats available on all CFQ enabled kernels first
-	if _, err := os.Lstat(filepath.Join(b.Path(path), fmt.Sprintf("blkio.io_serviced_recursive"))); err == nil {
+	if _, err := os.Lstat(filepath.Join(b.Path(path), "blkio.io_serviced_recursive")); err == nil {
 		settings = []blkioStatSettings{
 			{
 				name:  "sectors_recursive",
@@ -174,7 +173,7 @@ func (b *blkioController) Stat(path string, stats *v1.Metrics) error {
 }
 
 func (b *blkioController) readEntry(devices map[deviceKey]string, path, name string, entry *[]*v1.BlkIOEntry) error {
-	f, err := os.Open(filepath.Join(b.Path(path), fmt.Sprintf("blkio.%s", name)))
+	f, err := os.Open(filepath.Join(b.Path(path), "blkio."+name))
 	if err != nil {
 		return err
 	}
@@ -188,7 +187,7 @@ func (b *blkioController) readEntry(devices map[deviceKey]string, path, name str
 				// skip total line
 				continue
 			} else {
-				return fmt.Errorf("Invalid line found while parsing %s: %s", path, sc.Text())
+				return fmt.Errorf("invalid line found while parsing %s: %s", path, sc.Text())
 			}
 		}
 		major, err := strconv.ParseUint(fields[0], 10, 64)
@@ -356,12 +355,4 @@ func getDevices(r io.Reader) (map[deviceKey]string, error) {
 		devices[key] = filepath.Join("/dev", fields[2])
 	}
 	return devices, s.Err()
-}
-
-func major(devNumber uint64) uint64 {
-	return (devNumber >> 8) & 0xfff
-}
-
-func minor(devNumber uint64) uint64 {
-	return (devNumber & 0xff) | ((devNumber >> 12) & 0xfff00)
 }

--- a/vendor/github.com/containerd/cgroups/cgroup.go
+++ b/vendor/github.com/containerd/cgroups/cgroup.go
@@ -18,7 +18,6 @@ package cgroups
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -169,7 +168,7 @@ func (c *cgroup) add(process Process) error {
 		if err != nil {
 			return err
 		}
-		if err := ioutil.WriteFile(
+		if err := retryingWriteFile(
 			filepath.Join(s.Path(p), cgroupProcs),
 			[]byte(strconv.Itoa(process.Pid)),
 			defaultFilePerm,
@@ -199,7 +198,7 @@ func (c *cgroup) addTask(process Process) error {
 		if err != nil {
 			return err
 		}
-		if err := ioutil.WriteFile(
+		if err := retryingWriteFile(
 			filepath.Join(s.Path(p), cgroupTasks),
 			[]byte(strconv.Itoa(process.Pid)),
 			defaultFilePerm,
@@ -217,7 +216,7 @@ func (c *cgroup) Delete() error {
 	if c.err != nil {
 		return c.err
 	}
-	var errors []string
+	var errs []string
 	for _, s := range c.subsystems {
 		if d, ok := s.(deleter); ok {
 			sp, err := c.path(s.Name())
@@ -225,7 +224,7 @@ func (c *cgroup) Delete() error {
 				return err
 			}
 			if err := d.Delete(sp); err != nil {
-				errors = append(errors, string(s.Name()))
+				errs = append(errs, string(s.Name()))
 			}
 			continue
 		}
@@ -236,12 +235,12 @@ func (c *cgroup) Delete() error {
 			}
 			path := p.Path(sp)
 			if err := remove(path); err != nil {
-				errors = append(errors, path)
+				errs = append(errs, path)
 			}
 		}
 	}
-	if len(errors) > 0 {
-		return fmt.Errorf("cgroups: unable to remove paths %s", strings.Join(errors, ", "))
+	if len(errs) > 0 {
+		return fmt.Errorf("cgroups: unable to remove paths %s", strings.Join(errs, ", "))
 	}
 	c.err = ErrCgroupDeleted
 	return nil

--- a/vendor/github.com/containerd/cgroups/cpu.go
+++ b/vendor/github.com/containerd/cgroups/cpu.go
@@ -18,8 +18,6 @@ package cgroups
 
 import (
 	"bufio"
-	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -84,8 +82,8 @@ func (c *cpuController) Create(path string, resources *specs.LinuxResources) err
 				value = []byte(strconv.FormatInt(*t.ivalue, 10))
 			}
 			if value != nil {
-				if err := ioutil.WriteFile(
-					filepath.Join(c.Path(path), fmt.Sprintf("cpu.%s", t.name)),
+				if err := retryingWriteFile(
+					filepath.Join(c.Path(path), "cpu."+t.name),
 					value,
 					defaultFilePerm,
 				); err != nil {

--- a/vendor/github.com/containerd/cgroups/cpuset.go
+++ b/vendor/github.com/containerd/cgroups/cpuset.go
@@ -26,7 +26,7 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-func NewCputset(root string) *cpusetController {
+func NewCpuset(root string) *cpusetController {
 	return &cpusetController{
 		root: filepath.Join(root, string(Cpuset)),
 	}
@@ -69,8 +69,8 @@ func (c *cpusetController) Create(path string, resources *specs.LinuxResources) 
 			},
 		} {
 			if t.value != "" {
-				if err := ioutil.WriteFile(
-					filepath.Join(c.Path(path), fmt.Sprintf("cpuset.%s", t.name)),
+				if err := retryingWriteFile(
+					filepath.Join(c.Path(path), "cpuset."+t.name),
 					[]byte(t.value),
 					defaultFilePerm,
 				); err != nil {
@@ -134,7 +134,7 @@ func (c *cpusetController) copyIfNeeded(current, parent string) error {
 		return err
 	}
 	if isEmpty(currentCpus) {
-		if err := ioutil.WriteFile(
+		if err := retryingWriteFile(
 			filepath.Join(current, "cpuset.cpus"),
 			parentCpus,
 			defaultFilePerm,
@@ -143,7 +143,7 @@ func (c *cpusetController) copyIfNeeded(current, parent string) error {
 		}
 	}
 	if isEmpty(currentMems) {
-		if err := ioutil.WriteFile(
+		if err := retryingWriteFile(
 			filepath.Join(current, "cpuset.mems"),
 			parentMems,
 			defaultFilePerm,

--- a/vendor/github.com/containerd/cgroups/devices.go
+++ b/vendor/github.com/containerd/cgroups/devices.go
@@ -18,7 +18,6 @@ package cgroups
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -61,7 +60,7 @@ func (d *devicesController) Create(path string, resources *specs.LinuxResources)
 		if device.Type == "" {
 			device.Type = "a"
 		}
-		if err := ioutil.WriteFile(
+		if err := retryingWriteFile(
 			filepath.Join(d.Path(path), file),
 			[]byte(deviceString(device)),
 			defaultFilePerm,

--- a/vendor/github.com/containerd/cgroups/freezer.go
+++ b/vendor/github.com/containerd/cgroups/freezer.go
@@ -50,7 +50,7 @@ func (f *freezerController) Thaw(path string) error {
 }
 
 func (f *freezerController) changeState(path string, state State) error {
-	return ioutil.WriteFile(
+	return retryingWriteFile(
 		filepath.Join(f.root, path, "freezer.state"),
 		[]byte(strings.ToUpper(string(state))),
 		defaultFilePerm,

--- a/vendor/github.com/containerd/cgroups/go.mod
+++ b/vendor/github.com/containerd/cgroups/go.mod
@@ -3,17 +3,16 @@ module github.com/containerd/cgroups
 go 1.13
 
 require (
-	github.com/cilium/ebpf v0.0.0-20200110133405-4032b1d8aae3
+	github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
 	github.com/coreos/go-systemd/v22 v22.0.0
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/docker/go-units v0.4.0
 	github.com/godbus/dbus/v5 v5.0.3
 	github.com/gogo/protobuf v1.3.1
-	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/opencontainers/runtime-spec v1.0.2
 	github.com/pkg/errors v0.9.1
-	github.com/sirupsen/logrus v1.4.2
+	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.2.2
 	github.com/urfave/cli v1.22.2
-	golang.org/x/sys v0.0.0-20200120151820-655fe14d7479
+	golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9
 )

--- a/vendor/github.com/containerd/cgroups/hugetlb.go
+++ b/vendor/github.com/containerd/cgroups/hugetlb.go
@@ -17,7 +17,6 @@
 package cgroups
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -57,7 +56,7 @@ func (h *hugetlbController) Create(path string, resources *specs.LinuxResources)
 		return err
 	}
 	for _, limit := range resources.HugepageLimits {
-		if err := ioutil.WriteFile(
+		if err := retryingWriteFile(
 			filepath.Join(h.Path(path), strings.Join([]string{"hugetlb", limit.Pagesize, "limit_in_bytes"}, ".")),
 			[]byte(strconv.FormatUint(limit.Limit, 10)),
 			defaultFilePerm,

--- a/vendor/github.com/containerd/cgroups/net_cls.go
+++ b/vendor/github.com/containerd/cgroups/net_cls.go
@@ -17,7 +17,6 @@
 package cgroups
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -48,7 +47,7 @@ func (n *netclsController) Create(path string, resources *specs.LinuxResources) 
 		return err
 	}
 	if resources.Network != nil && resources.Network.ClassID != nil && *resources.Network.ClassID > 0 {
-		return ioutil.WriteFile(
+		return retryingWriteFile(
 			filepath.Join(n.Path(path), "net_cls.classid"),
 			[]byte(strconv.FormatUint(uint64(*resources.Network.ClassID), 10)),
 			defaultFilePerm,

--- a/vendor/github.com/containerd/cgroups/net_prio.go
+++ b/vendor/github.com/containerd/cgroups/net_prio.go
@@ -18,7 +18,6 @@ package cgroups
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -49,7 +48,7 @@ func (n *netprioController) Create(path string, resources *specs.LinuxResources)
 	}
 	if resources.Network != nil {
 		for _, prio := range resources.Network.Priorities {
-			if err := ioutil.WriteFile(
+			if err := retryingWriteFile(
 				filepath.Join(n.Path(path), "net_prio.ifpriomap"),
 				formatPrio(prio.Name, prio.Priority),
 				defaultFilePerm,

--- a/vendor/github.com/containerd/cgroups/opts.go
+++ b/vendor/github.com/containerd/cgroups/opts.go
@@ -48,12 +48,12 @@ func newInitConfig() *InitConfig {
 type InitCheck func(Subsystem, Path, error) error
 
 // AllowAny allows any subsystem errors to be skipped
-func AllowAny(s Subsystem, p Path, err error) error {
+func AllowAny(_ Subsystem, _ Path, _ error) error {
 	return ErrIgnoreSubsystem
 }
 
 // RequireDevices requires the device subsystem but no others
-func RequireDevices(s Subsystem, p Path, err error) error {
+func RequireDevices(s Subsystem, _ Path, _ error) error {
 	if s.Name() == Devices {
 		return ErrDevicesRequired
 	}

--- a/vendor/github.com/containerd/cgroups/paths.go
+++ b/vendor/github.com/containerd/cgroups/paths.go
@@ -25,7 +25,7 @@ import (
 
 type Path func(subsystem Name) (string, error)
 
-func RootPath(subsysem Name) (string, error) {
+func RootPath(subsystem Name) (string, error) {
 	return "/", nil
 }
 
@@ -63,7 +63,7 @@ var ErrControllerNotActive = errors.New("controller is not supported")
 func existingPath(paths map[string]string, suffix string) Path {
 	// localize the paths based on the root mount dest for nested cgroups
 	for n, p := range paths {
-		dest, err := getCgroupDestination(string(n))
+		dest, err := getCgroupDestination(n)
 		if err != nil {
 			return errorPath(err)
 		}
@@ -79,7 +79,7 @@ func existingPath(paths map[string]string, suffix string) Path {
 	return func(name Name) (string, error) {
 		root, ok := paths[string(name)]
 		if !ok {
-			if root, ok = paths[fmt.Sprintf("name=%s", name)]; !ok {
+			if root, ok = paths["name="+string(name)]; !ok {
 				return "", ErrControllerNotActive
 			}
 		}

--- a/vendor/github.com/containerd/cgroups/pids.go
+++ b/vendor/github.com/containerd/cgroups/pids.go
@@ -50,7 +50,7 @@ func (p *pidsController) Create(path string, resources *specs.LinuxResources) er
 		return err
 	}
 	if resources.Pids != nil && resources.Pids.Limit > 0 {
-		return ioutil.WriteFile(
+		return retryingWriteFile(
 			filepath.Join(p.Path(path), "pids.max"),
 			[]byte(strconv.FormatInt(resources.Pids.Limit, 10)),
 			defaultFilePerm,

--- a/vendor/github.com/containerd/cgroups/rdma.go
+++ b/vendor/github.com/containerd/cgroups/rdma.go
@@ -67,7 +67,7 @@ func (p *rdmaController) Create(path string, resources *specs.LinuxResources) er
 
 	for device, limit := range resources.Rdma {
 		if device != "" && (limit.HcaHandles != nil || limit.HcaObjects != nil) {
-			return ioutil.WriteFile(
+			return retryingWriteFile(
 				filepath.Join(p.Path(path), "rdma.max"),
 				[]byte(createCmdString(device, &limit)),
 				defaultFilePerm,

--- a/vendor/github.com/containerd/cgroups/systemd.go
+++ b/vendor/github.com/containerd/cgroups/systemd.go
@@ -17,7 +17,6 @@
 package cgroups
 
 import (
-	"fmt"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -78,7 +77,7 @@ func (s *SystemdController) Name() Name {
 	return SystemdDbus
 }
 
-func (s *SystemdController) Create(path string, resources *specs.LinuxResources) error {
+func (s *SystemdController) Create(path string, _ *specs.LinuxResources) error {
 	conn, err := systemdDbus.New()
 	if err != nil {
 		return err
@@ -105,7 +104,7 @@ func (s *SystemdController) Create(path string, resources *specs.LinuxResources)
 	}
 	once.Do(checkDelegate)
 	properties := []systemdDbus.Property{
-		systemdDbus.PropDescription(fmt.Sprintf("cgroup %s", name)),
+		systemdDbus.PropDescription("cgroup " + name),
 		systemdDbus.PropWants(slice),
 		newProperty("DefaultDependencies", false),
 		newProperty("MemoryAccounting", true),
@@ -148,10 +147,6 @@ func newProperty(name string, units interface{}) systemdDbus.Property {
 		Name:  name,
 		Value: dbus.MakeVariant(units),
 	}
-}
-
-func unitName(name string) string {
-	return fmt.Sprintf("%s.slice", name)
 }
 
 func splitName(path string) (slice string, unit string) {

--- a/vendor/github.com/containerd/cgroups/utils.go
+++ b/vendor/github.com/containerd/cgroups/utils.go
@@ -18,6 +18,7 @@ package cgroups
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -26,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	units "github.com/docker/go-units"
@@ -121,7 +123,7 @@ func defaults(root string) ([]Subsystem, error) {
 		NewNetCls(root),
 		NewNetPrio(root),
 		NewPerfEvent(root),
-		NewCputset(root),
+		NewCpuset(root),
 		NewCpu(root),
 		NewCpuacct(root),
 		NewMemory(root),
@@ -380,5 +382,18 @@ func cleanPath(path string) string {
 	if !filepath.IsAbs(path) {
 		path, _ = filepath.Rel(string(os.PathSeparator), filepath.Clean(string(os.PathSeparator)+path))
 	}
-	return filepath.Clean(path)
+	return path
+}
+
+func retryingWriteFile(path string, data []byte, mode os.FileMode) error {
+	// Retry writes on EINTR; see:
+	//    https://github.com/golang/go/issues/38033
+	for {
+		err := ioutil.WriteFile(path, data, mode)
+		if err == nil {
+			return nil
+		} else if !errors.Is(err, syscall.EINTR) {
+			return err
+		}
+	}
 }

--- a/vendor/github.com/containerd/cgroups/v2/errors.go
+++ b/vendor/github.com/containerd/cgroups/v2/errors.go
@@ -44,7 +44,3 @@ func IgnoreNotExist(err error) error {
 	}
 	return err
 }
-
-func errPassthrough(err error) error {
-	return err
-}

--- a/vendor/github.com/containerd/cgroups/v2/paths.go
+++ b/vendor/github.com/containerd/cgroups/v2/paths.go
@@ -29,7 +29,7 @@ func NestedGroupPath(suffix string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(string(path), suffix), nil
+	return filepath.Join(path, suffix), nil
 }
 
 // PidGroupPath will return the correct cgroup paths for an existing process running inside a cgroup

--- a/vendor/github.com/containerd/cgroups/v2/utils.go
+++ b/vendor/github.com/containerd/cgroups/v2/utils.go
@@ -28,9 +28,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/godbus/dbus/v5"
-
 	"github.com/containerd/cgroups/v2/stats"
+	"github.com/godbus/dbus/v5"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -106,14 +105,6 @@ func parseKV(raw string) (string, interface{}, error) {
 	}
 }
 
-func readUint(path string) (uint64, error) {
-	v, err := ioutil.ReadFile(path)
-	if err != nil {
-		return 0, err
-	}
-	return parseUint(strings.TrimSpace(string(v)), 10, 64)
-}
-
 func parseUint(s string, base, bitSize int) (uint64, error) {
 	v, err := strconv.ParseUint(s, base, bitSize)
 	if err != nil {
@@ -178,7 +169,7 @@ func ToResources(spec *specs.LinuxResources) *Resources {
 			Mems: cpu.Mems,
 		}
 		if shares := cpu.Shares; shares != nil {
-			convertedWeight := (1 + ((*shares-2)*9999)/262142)
+			convertedWeight := 1 + ((*shares-2)*9999)/262142
 			resources.CPU.Weight = &convertedWeight
 		}
 		if period := cpu.Period; period != nil {
@@ -301,8 +292,8 @@ func readIoStats(path string) []*stats.IOEntry {
 			Major: major,
 			Minor: minor,
 		}
-		for _, stats := range parts {
-			keyPairValue := strings.Split(stats, "=")
+		for _, s := range parts {
+			keyPairValue := strings.Split(s, "=")
 			if len(keyPairValue) != 2 {
 				continue
 			}


### PR DESCRIPTION
full diff: https://github.com/containerd/cgroups/compare/0dbf7f05ba59274095946e2c0c89540726e8a8aa...318312a373405e5e91134d8063d04d59768a1bff

relevant changes:

- cpuset: typo fix for function name
- Retry file writes on EINTR errors to work with Go 1.14 asynchronous preemption
- Various linting issues and cleanup
