### PR TITLE
Bump Go 1.13.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.12'
+          go-version: '1.13.13'
 
       - name: Set env
         shell: bash
@@ -66,7 +66,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.12'
+          go-version: '1.13.13'
 
       - name: Set env
         shell: bash
@@ -138,7 +138,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.12'
+          go-version: '1.13.13'
 
       - name: Set env
         shell: bash
@@ -185,7 +185,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.12'
+          go-version: '1.13.13'
 
       - name: Set env
         shell: bash
@@ -222,7 +222,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.12'
+          go-version: '1.13.13'
 
       - name: Set env
         shell: bash
@@ -264,7 +264,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.12'
+          go-version: '1.13.13'
 
       - name: Set env
         shell: bash
@@ -334,7 +334,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.12'
+          go-version: '1.13.13'
 
       - name: Setup gosu
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.12'
+          go-version: '1.13.13'
 
       - name: Checkout
         uses: actions/checkout@v1
@@ -126,7 +126,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.12'
+          go-version: '1.13.13'
 
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.12'
+          go-version: '1.13.13'
 
       - name: Set env
         shell: bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ os:
 - linux
 
 go:
-  - "1.13.12"
+  - "1.13.13"
 
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct

--- a/.zuul/playbooks/containerd-build/run.yaml
+++ b/.zuul/playbooks/containerd-build/run.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.13.12'
+    go_version: '1.13.13'
     arch: arm64
   tasks:
   - name: Build containerd

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,7 +29,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", inline: <<-SHELL
     set -eux -o pipefail
     # configuration
-    GO_VERSION="1.13.12"
+    GO_VERSION="1.13.13"
     RUNC_FLAVOR="crun"
 
     # install dnf deps

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.13.12
+ARG GOLANG_VERSION=1.13.13
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd


### PR DESCRIPTION
Includes security fixes to the `crypto/x509` and `net/http` packages.

https://github.com/golang/go/issues?q=milestone%3AGo1.13.13+label%3ACherryPickApproved
