### PR TITLE
CI: add back shim v1 test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,10 +324,12 @@ jobs:
 
     strategy:
       matrix:
-        runtime: [io.containerd.runc.v1, io.containerd.runc.v2]
+        runtime: [io.containerd.runtime.v1.linux, io.containerd.runc.v1, io.containerd.runc.v2]
         runc: [runc, crun]
         exclude:
           - runtime: io.containerd.runc.v1
+            runc: crun
+          - runtime: io.containerd.runtime.v1.linux
             runc: crun
 
     steps:

--- a/container_test.go
+++ b/container_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/platforms"
+	"github.com/containerd/containerd/plugin"
 	_ "github.com/containerd/containerd/runtime"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/containerd/typeurl"
@@ -660,6 +661,10 @@ func TestKillContainerDeletedByRunc(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer client.Close()
+
+	if client.runtime == plugin.RuntimeLinuxV1 {
+		t.Skip("test relies on runtime v2")
+	}
 
 	var (
 		image       Image


### PR DESCRIPTION
We are going to deprecate shim v1 (#4365), but it is still early to disable the tests for them
