### PR TITLE
Don't clash with GH Actions runner's containerd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,18 +415,19 @@ jobs:
         env:
           TEST_RUNTIME: ${{ matrix.runtime }}
         run: |
-          sudo mkdir -p /etc/containerd
-          sudo bash -c "cat > /etc/containerd/config.toml <<EOF
+          BDIR="$(mktemp -d -p $PWD)"
+          mkdir -p ${BDIR}/{root,state}
+          cat > ${BDIR}/config.toml <<EOF
             [plugins.cri.containerd.default_runtime]
               runtime_type = \"${TEST_RUNTIME}\"
-          EOF"
-          sudo PATH=$PATH containerd -log-level debug &> /tmp/containerd-cri.log &
-          sudo ctr version
-          sudo PATH=$PATH GOPATH=$GOPATH critest --runtime-endpoint=unix:///var/run/containerd/containerd.sock --parallel=8
+          EOF
+          sudo PATH=$PATH BDIR=$BDIR /usr/local/bin/containerd -a ${BDIR}/c.sock -root ${BDIR}/root -state ${BDIR}/state -log-level debug &> ${BDIR}/containerd-cri.log &
+          sudo BDIR=$BDIR /usr/local/bin/ctr -a ${BDIR}/c.sock version
+          sudo PATH=$PATH BDIR=$BDIR GOPATH=$GOPATH critest --runtime-endpoint=unix:///${BDIR}/c.sock --parallel=8
           TEST_RC=$?
-          test $TEST_RC -ne 0 && cat /tmp/containerd-cri.log
+          test $TEST_RC -ne 0 && cat ${BDIR}/containerd-cri.log
           sudo pkill containerd
-          sudo rm -rf /etc/containerd
+          sudo BDIR=$BDIR rm -rf ${BDIR}
           test $TEST_RC -eq 0 || /bin/false
 
   cgroup2:

--- a/script/setup/install-critools
+++ b/script/setup/install-critools
@@ -21,7 +21,7 @@
 set -eu -o pipefail
 
 go get -u github.com/onsi/ginkgo/ginkgo
-CRITEST_COMMIT=75ef33dc2b4ecb08e0237d91de1b664909d262de
+CRITEST_COMMIT=16911795a3c33833fa0ec83dac1ade3172f6989e
 go get -d github.com/kubernetes-sigs/cri-tools/...
 cd "$GOPATH"/src/github.com/kubernetes-sigs/cri-tools
 git checkout $CRITEST_COMMIT


### PR DESCRIPTION
GH runners now have a systemd-run containerd running on the standard
socket, impacting the CRI test's expectation of our CI-built containerd
running there.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>