### PR TITLE
Fail windows mounts with incompatible parameters

### DIFF
--- a/mount/mount_windows.go
+++ b/mount/mount_windows.go
@@ -36,6 +36,10 @@ func (m *Mount) Mount(target string) error {
 		return errors.Errorf("invalid windows mount type: '%s'", m.Type)
 	}
 
+	if m.Source != target {
+		return errors.Wrapf(ErrNotImplementOnWindows, "layer %s must mount in-place, not at %s", m.Source, target)
+	}
+
 	home, layerID := filepath.Split(m.Source)
 
 	parentLayerPaths, err := m.GetParentPaths()

--- a/mount/mount_windows.go
+++ b/mount/mount_windows.go
@@ -40,6 +40,12 @@ func (m *Mount) Mount(target string) error {
 		return errors.Wrapf(ErrNotImplementOnWindows, "layer %s must mount in-place, not at %s", m.Source, target)
 	}
 
+	for _, opt := range m.Options {
+		if opt == "ro" {
+			return errors.Wrapf(ErrNotImplementOnWindows, "layer %s cannot be mounted read-only", m.Source)
+		}
+	}
+
 	home, layerID := filepath.Split(m.Source)
 
 	parentLayerPaths, err := m.GetParentPaths()


### PR DESCRIPTION
Until #2366 or similar is implemented, passing a `target` to `Mount.Mount` that is different from the `Mount.Source` will successfully mount the requested layer, but not at `target`, which will cause calling code to almost certainly do the wrong thing.

This also rejects the `"ro"` flag in `Mount.Options`, as we do not honour that, and that seems like a significant risk to callers expecting to be able to expose such mounts in less-trusted environments.

See https://github.com/moby/buildkit/pull/1571 for the caller-side use-case which inspired these changes.