### PR TITLE
Bump Golang 1.13.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.13'
+          go-version: '1.13.14'
 
       - name: Set env
         shell: bash
@@ -66,7 +66,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.13'
+          go-version: '1.13.14'
 
       - name: Set env
         shell: bash
@@ -138,7 +138,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.13'
+          go-version: '1.13.14'
 
       - name: Set env
         shell: bash
@@ -185,7 +185,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.13'
+          go-version: '1.13.14'
 
       - name: Set env
         shell: bash
@@ -222,7 +222,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.13'
+          go-version: '1.13.14'
 
       - name: Set env
         shell: bash
@@ -260,7 +260,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.13'
+          go-version: '1.13.14'
 
       - name: Set env
         shell: bash
@@ -332,7 +332,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.13'
+          go-version: '1.13.14'
 
       - name: Setup gosu
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.13'
+          go-version: '1.13.14'
 
       - name: Checkout
         uses: actions/checkout@v1
@@ -126,7 +126,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.13'
+          go-version: '1.13.14'
 
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.13'
+          go-version: '1.13.14'
 
       - name: Set env
         shell: bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ os:
 - linux
 
 go:
-  - "1.13.13"
+  - "1.13.14"
 
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct

--- a/.zuul/playbooks/containerd-build/run.yaml
+++ b/.zuul/playbooks/containerd-build/run.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.13.13'
+    go_version: '1.13.14'
     arch: arm64
   tasks:
   - name: Build containerd

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,7 +29,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", inline: <<-SHELL
     set -eux -o pipefail
     # configuration
-    GO_VERSION="1.13.13"
+    GO_VERSION="1.13.14"
     RUNC_FLAVOR="crun"
 
     # install dnf deps

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.13.13
+ARG GOLANG_VERSION=1.13.14
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd


### PR DESCRIPTION
full diff: https://github.com/golang/go/compare/go1.13.13...go1.13.14

go1.13.14 (released 2020/07/16) includes fixes to the compiler, vet, and the
database/sql, net/http, and reflect packages. See the Go 1.13.14 milestone on
the issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.13.14+label%3ACherryPickApproved
