### PR TITLE
Set a default OOM score for containerd

### DIFF
--- a/cmd/containerd/command/config_linux.go
+++ b/cmd/containerd/command/config_linux.go
@@ -23,9 +23,10 @@ import (
 
 func defaultConfig() *srvconfig.Config {
 	return &srvconfig.Config{
-		Version: 1,
-		Root:    defaults.DefaultRootDir,
-		State:   defaults.DefaultStateDir,
+		Version:  1,
+		Root:     defaults.DefaultRootDir,
+		State:    defaults.DefaultStateDir,
+		OOMScore: defaults.DefaultOOMScore,
 		GRPC: srvconfig.GRPCConfig{
 			Address:        defaults.DefaultAddress,
 			MaxRecvMsgSize: defaults.DefaultMaxRecvMsgSize,

--- a/defaults/defaults_unix.go
+++ b/defaults/defaults_unix.go
@@ -34,4 +34,6 @@ const (
 	DefaultFIFODir = "/run/containerd/fifo"
 	// DefaultRuntime is the default linux runtime
 	DefaultRuntime = "io.containerd.runc.v2"
+	// DefaultOOMScore is the default OOM score for the containerd daemon
+	DefaultOOMScore = -999
 )


### PR DESCRIPTION
Relates to https://github.com/docker/for-linux/issues/1062#issuecomment-660916887
Closes https://github.com/containerd/containerd/issues/3901

The current default doesn't adjust the OOM score, which makes it more likely for containerd to be killed by the OOM killer before other processes.

I picked `-999` for now, which is the same as containerd-cri uses (https://github.com/containerd/cri/pull/347) but happy to adjust.