### PR TITLE
Add namespace query parameter for registry proxying

### DIFF
--- a/remotes/docker/fetcher.go
+++ b/remotes/docker/fetcher.go
@@ -98,6 +98,9 @@ func (r dockerFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.R
 			var firstErr error
 			for _, host := range r.hosts {
 				req := r.request(host, http.MethodGet, "manifests", desc.Digest.String())
+				if err := req.addNamespace(r.refspec.Hostname()); err != nil {
+					return nil, err
+				}
 
 				rc, err := r.open(ctx, req, desc.MediaType, offset)
 				if err != nil {
@@ -118,6 +121,9 @@ func (r dockerFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.R
 		var firstErr error
 		for _, host := range r.hosts {
 			req := r.request(host, http.MethodGet, "blobs", desc.Digest.String())
+			if err := req.addNamespace(r.refspec.Hostname()); err != nil {
+				return nil, err
+			}
 
 			rc, err := r.open(ctx, req, desc.MediaType, offset)
 			if err != nil {

--- a/remotes/docker/fetcher_test.go
+++ b/remotes/docker/fetcher_test.go
@@ -52,7 +52,7 @@ func TestFetcherOpen(t *testing.T) {
 	}
 
 	f := dockerFetcher{&dockerBase{
-		namespace: "nonempty",
+		repository: "nonempty",
 	}}
 
 	host := RegistryHost{
@@ -182,7 +182,7 @@ func TestDockerFetcherOpen(t *testing.T) {
 			}
 
 			f := dockerFetcher{&dockerBase{
-				namespace: "ns",
+				repository: "ns",
 			}}
 
 			host := RegistryHost{

--- a/remotes/docker/registry.go
+++ b/remotes/docker/registry.go
@@ -73,6 +73,15 @@ type RegistryHost struct {
 	Header       http.Header
 }
 
+func (h RegistryHost) isProxy(refhost string) bool {
+	if refhost != h.Host {
+		if refhost != "docker.io" || h.Host != "registry-1.docker.io" {
+			return true
+		}
+	}
+	return false
+}
+
 // RegistryHosts fetches the registry hosts for a given namespace,
 // provided by the host component of an distribution image reference.
 type RegistryHosts func(string) ([]RegistryHost, error)

--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"path"
 	"strings"
 
@@ -276,6 +277,10 @@ func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocisp
 			ctx := log.WithLogger(ctx, log.G(ctx).WithField("host", host.Host))
 
 			req := base.request(host, http.MethodHead, u...)
+			if err := req.addNamespace(base.refspec.Hostname()); err != nil {
+				return "", ocispec.Descriptor{}, err
+			}
+
 			for key, value := range r.resolveHeader {
 				req.header[key] = append(req.header[key], value...)
 			}
@@ -323,6 +328,10 @@ func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocisp
 				log.G(ctx).Debug("no Docker-Content-Digest header, fetching manifest instead")
 
 				req = base.request(host, http.MethodGet, u...)
+				if err := req.addNamespace(base.refspec.Hostname()); err != nil {
+					return "", ocispec.Descriptor{}, err
+				}
+
 				for key, value := range r.resolveHeader {
 					req.header[key] = append(req.header[key], value...)
 				}
@@ -416,10 +425,10 @@ func (r *dockerResolver) Pusher(ctx context.Context, ref string) (remotes.Pusher
 }
 
 type dockerBase struct {
-	refspec   reference.Spec
-	namespace string
-	hosts     []RegistryHost
-	header    http.Header
+	refspec    reference.Spec
+	repository string
+	hosts      []RegistryHost
+	header     http.Header
 }
 
 func (r *dockerResolver) base(refspec reference.Spec) (*dockerBase, error) {
@@ -429,10 +438,10 @@ func (r *dockerResolver) base(refspec reference.Spec) (*dockerBase, error) {
 		return nil, err
 	}
 	return &dockerBase{
-		refspec:   refspec,
-		namespace: strings.TrimPrefix(refspec.Locator, host+"/"),
-		hosts:     hosts,
-		header:    r.header,
+		refspec:    refspec,
+		repository: strings.TrimPrefix(refspec.Locator, host+"/"),
+		hosts:      hosts,
+		header:     r.header,
 	}, nil
 }
 
@@ -453,7 +462,7 @@ func (r *dockerBase) request(host RegistryHost, method string, ps ...string) *re
 	for key, value := range host.Header {
 		header[key] = append(header[key], value...)
 	}
-	parts := append([]string{"/", host.Path, r.namespace}, ps...)
+	parts := append([]string{"/", host.Path, r.repository}, ps...)
 	p := path.Join(parts...)
 	// Join strips trailing slash, re-add ending "/" if included
 	if len(parts) > 0 && strings.HasSuffix(parts[len(parts)-1], "/") {
@@ -476,6 +485,29 @@ func (r *request) authorize(ctx context.Context, req *http.Request) error {
 	}
 
 	return nil
+}
+
+func (r *request) addNamespace(ns string) (err error) {
+	if !r.host.isProxy(ns) {
+		return nil
+	}
+	var q url.Values
+	// Parse query
+	if i := strings.IndexByte(r.path, '?'); i > 0 {
+		r.path = r.path[:i+1]
+		q, err = url.ParseQuery(r.path[i+1:])
+		if err != nil {
+			return
+		}
+	} else {
+		r.path = r.path + "?"
+		q = url.Values{}
+	}
+	q.Add("ns", ns)
+
+	r.path = r.path + q.Encode()
+
+	return
 }
 
 type request struct {


### PR DESCRIPTION
Proxy registries are designed to serve content from upstreams. However, the proxy hostname will usually not match the hostname of the upstream, requiring the proxy to only use a single upstream or use its own pattern matching to determine the upstream. To solve this issue, the client will pass along the namespace which is being used for the request, allowing mirrors to easily map to multiple upstreams. This query parameter can safely be ignored if multiple upstreams are not supported.

This is has been approved in the OCI spec to be merged after 1.0
See https://github.com/opencontainers/distribution-spec/pull/66