### PR TITLE
Set content labels based on content type

### DIFF
--- a/client.go
+++ b/client.go
@@ -312,11 +312,6 @@ type RemoteContext struct {
 	// afterwards. Unpacking is required to run an image.
 	Unpack bool
 
-	// DiscardContent is a boolean flag to specify whether to allow GC to clean
-	// layers up from the content store after successfully unpacking these
-	// contents to the snapshotter.
-	DiscardContent bool
-
 	// UnpackOpts handles options to the unpack call.
 	UnpackOpts []UnpackOpt
 
@@ -356,6 +351,10 @@ type RemoteContext struct {
 
 	// AllMetadata downloads all manifests and known-configuration files
 	AllMetadata bool
+
+	// ChildLabelMap sets the labels used to reference child objects in the content
+	// store. By default, all GC reference labels will be set for all fetched content.
+	ChildLabelMap func(ocispec.Descriptor) []string
 }
 
 func defaultRemoteContext() *RemoteContext {

--- a/client.go
+++ b/client.go
@@ -312,6 +312,11 @@ type RemoteContext struct {
 	// afterwards. Unpacking is required to run an image.
 	Unpack bool
 
+	// DiscardContent is a boolean flag to specify whether to allow GC to clean
+	// layers up from the content store after successfully unpacking these
+	// contents to the snapshotter.
+	DiscardContent bool
+
 	// UnpackOpts handles options to the unpack call.
 	UnpackOpts []UnpackOpt
 

--- a/client_opts.go
+++ b/client_opts.go
@@ -132,6 +132,14 @@ func WithPullUnpack(_ *Client, c *RemoteContext) error {
 	return nil
 }
 
+// WithDiscardContent is used to allow GC to clean layers up from
+// the content store after successfully unpacking these contents to
+// the snapshotter.
+func WithDiscardContent(_ *Client, c *RemoteContext) error {
+	c.DiscardContent = true
+	return nil
+}
+
 // WithUnpackOpts is used to add unpack options to the unpacker.
 func WithUnpackOpts(opts []UnpackOpt) RemoteOpt {
 	return func(_ *Client, c *RemoteContext) error {

--- a/client_test.go
+++ b/client_test.go
@@ -229,6 +229,11 @@ func TestImagePullWithDiscardContent(t *testing.T) {
 	ctx, cancel := testContext(t)
 	defer cancel()
 
+	err = client.ImageService().Delete(ctx, testImage, images.SynchronousDelete())
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ls := client.LeasesService()
 	l, err := ls.Create(ctx, leases.WithRandomID(), leases.WithExpiration(24*time.Hour))
 	if err != nil {
@@ -238,7 +243,7 @@ func TestImagePullWithDiscardContent(t *testing.T) {
 	img, err := client.Pull(ctx, testImage,
 		WithPlatformMatcher(platforms.Default()),
 		WithPullUnpack,
-		WithDiscardContent,
+		WithChildLabelMap(images.ChildGCLabelsFilterLayers),
 	)
 	// Synchronously garbage collect contents
 	if errL := ls.Delete(ctx, l, leases.SynchronousDelete); errL != nil {

--- a/images/mediatypes.go
+++ b/images/mediatypes.go
@@ -124,3 +124,31 @@ func IsKnownConfig(mt string) bool {
 	}
 	return false
 }
+
+// ChildGCLabels returns the label for a given descriptor to reference it
+func ChildGCLabels(desc ocispec.Descriptor) []string {
+	mt := desc.MediaType
+	if IsKnownConfig(mt) {
+		return []string{"containerd.io/gc.ref.content.config"}
+	}
+
+	switch mt {
+	case MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest:
+		return []string{"containerd.io/gc.ref.content.m."}
+	}
+
+	if IsLayerType(mt) {
+		return []string{"containerd.io/gc.ref.content.l."}
+	}
+
+	return []string{"containerd.io/gc.ref.content."}
+}
+
+// ChildGCLabelsFilterLayers returns the labels for a given descriptor to
+// reference it, skipping layer media types
+func ChildGCLabelsFilterLayers(desc ocispec.Descriptor) []string {
+	if IsLayerType(desc.MediaType) {
+		return nil
+	}
+	return ChildGCLabels(desc)
+}

--- a/pull.go
+++ b/pull.go
@@ -159,7 +159,7 @@ func (c *Client) fetch(ctx context.Context, rCtx *RemoteContext, ref string, lim
 		// Get all the children for a descriptor
 		childrenHandler := images.ChildrenHandler(store)
 		// Set any children labels for that content
-		childrenHandler = images.SetChildrenLabels(store, childrenHandler)
+		childrenHandler = images.SetChildrenMappedLabels(store, childrenHandler, rCtx.ChildLabelMap)
 		if rCtx.AllMetadata {
 			// Filter manifests by platforms but allow to handle manifest
 			// and configuration for not-target platforms

--- a/unpacker.go
+++ b/unpacker.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -77,6 +78,7 @@ func (u *unpacker) unpack(
 	rCtx *RemoteContext,
 	h images.Handler,
 	config ocispec.Descriptor,
+	parentDesc ocispec.Descriptor,
 	layers []ocispec.Descriptor,
 ) error {
 	p, err := content.ReadBlob(ctx, u.c.ContentStore(), config)
@@ -245,6 +247,31 @@ EachLayer:
 		"chainID": chainID,
 	}).Debug("image unpacked")
 
+	if rCtx.DiscardContent {
+		// delete references to successfully unpacked layers
+		layersMap := map[string]struct{}{}
+		for _, desc := range layers {
+			layersMap[desc.Digest.String()] = struct{}{}
+		}
+		pinfo, err := cs.Info(ctx, parentDesc.Digest)
+		if err != nil {
+			return err
+		}
+		fields := []string{}
+		for k, v := range pinfo.Labels {
+			if strings.HasPrefix(k, "containerd.io/gc.ref.content.") {
+				if _, ok := layersMap[v]; ok {
+					// We've already unpacked this layer content
+					pinfo.Labels[k] = ""
+					fields = append(fields, "labels."+k)
+				}
+			}
+		}
+		if _, err := cs.Update(ctx, pinfo, fields...); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -287,6 +314,7 @@ func (u *unpacker) handlerWrapper(
 		var (
 			lock   sync.Mutex
 			layers = map[digest.Digest][]ocispec.Descriptor{}
+			parent = map[digest.Digest]ocispec.Descriptor{}
 		)
 		return images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 			children, err := f.Handle(ctx, desc)
@@ -312,6 +340,7 @@ func (u *unpacker) handlerWrapper(
 				lock.Lock()
 				for _, nl := range nonLayers {
 					layers[nl.Digest] = manifestLayers
+					parent[nl.Digest] = desc
 				}
 				lock.Unlock()
 
@@ -319,11 +348,12 @@ func (u *unpacker) handlerWrapper(
 			case images.MediaTypeDockerSchema2Config, ocispec.MediaTypeImageConfig:
 				lock.Lock()
 				l := layers[desc.Digest]
+				p := parent[desc.Digest]
 				lock.Unlock()
 				if len(l) > 0 {
 					atomic.AddInt32(unpacks, 1)
 					eg.Go(func() error {
-						return u.unpack(uctx, rCtx, f, desc, l)
+						return u.unpack(uctx, rCtx, f, desc, p, l)
 					})
 				}
 			}


### PR DESCRIPTION
This change gives control of the content labeling process for children to the client. This allows the client to control the names associated with the labels and filter out labels.

Includes and replaces changes from #4332 

This newer approach avoids the additional label mutation pass after unpack. This prevents the process for removing previously set labels and better ensures the content gets garbage collected if the client ends the operation before the removal.

Comment from #4332 
----
Fixes: #4304

This commit adds a flag through Pull API for allowing GC to clean layer contents up after unpacking these contents completed.

This patch takes an approach to directly delete GC labels pointing to layers from the manifest blob. This will result in other snapshotters cannot reuse these contents on the next pull. But this patch mainly focuses on CRI use-cases where single snapshotter is usually used throughout the node lifecycle so this shouldn't be a matter.

Could I get comments on this approach towards unpacked contents deduplication?
What I currently concern is whether is it OK to clean layers up immediately after the unpack because other services in containerd will also be inaccessible to that contents.

Related also to: #4249