### PR TITLE
[release/1.3] shim: move event context timeout to publisher

### DIFF
--- a/runtime/v2/runc/v2/service.go
+++ b/runtime/v2/runc/v2/service.go
@@ -738,9 +738,7 @@ func (s *service) forward(ctx context.Context, publisher shim.Publisher) {
 	ns, _ := namespaces.Namespace(ctx)
 	ctx = namespaces.WithNamespace(context.Background(), ns)
 	for e := range s.events {
-		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		err := publisher.Publish(ctx, runc.GetTopic(e), e)
-		cancel()
 		if err != nil {
 			logrus.WithError(err).Error("post event")
 		}

--- a/runtime/v2/shim/publisher.go
+++ b/runtime/v2/shim/publisher.go
@@ -128,7 +128,9 @@ func (l *RemoteEventsPublisher) Publish(ctx context.Context, topic string, event
 }
 
 func (l *RemoteEventsPublisher) forwardRequest(ctx context.Context, req *v1.ForwardRequest) error {
-	_, err := l.client.EventsService().Forward(ctx, req)
+	fCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	_, err := l.client.EventsService().Forward(fCtx, req)
+	cancel()
 	if err == nil {
 		return nil
 	}
@@ -142,9 +144,9 @@ func (l *RemoteEventsPublisher) forwardRequest(ctx context.Context, req *v1.Forw
 		return err
 	}
 
-	if _, err := l.client.EventsService().Forward(ctx, req); err != nil {
-		return err
-	}
+	fCtx, cancel = context.WithTimeout(ctx, 5*time.Second)
+	_, err = l.client.EventsService().Forward(fCtx, req)
+	cancel()
 
-	return nil
+	return err
 }


### PR DESCRIPTION
Backports #4412 to the 1.3 branch

---

Before this change, if an event fails to send on the first attempt,
subsequent attempts will fail with context.Cancelled because the the
caller of publish passes a cancellable timeout, which the publisher uses
to send the event.

The publisher returns immediately if the send fails, but adds the event
to an async queue to try again.
Meanwhile the caller will return cancelling the context.

Additionally, subsequent attempts may fail to send because the timeout
was expected to be for a single request but the queue sleeps for
`attempt*time.Second`.

In the shim service, the timeout was set to 5s, which means the send
will fail with context.DeadlineExceeded before it reaches `maxRequeue`
(which is currently 5).

This change moves the timeout to the publisher so each send attempt gets
its own timeout.

Signed-off-by: Brian Goff <cpuguy83@gmail.com>
(cherry picked from commit d7b9cb00198600574ea8ac6db62ea8bdd076e466)
Signed-off-by: Brian Goff <cpuguy83@gmail.com>