### PR TITLE
Mount snapshots on Windows (Isolated PR)

### DIFF
--- a/mount/mount_windows.go
+++ b/mount/mount_windows.go
@@ -18,6 +18,8 @@ package mount
 
 import (
 	"encoding/json"
+	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -25,13 +27,19 @@ import (
 	"github.com/pkg/errors"
 )
 
+const sourceStreamName = "containerd.io-source"
+
 var (
 	// ErrNotImplementOnWindows is returned when an action is not implemented for windows
 	ErrNotImplementOnWindows = errors.New("not implemented under windows")
 )
 
 // Mount to the provided target
-func (m *Mount) Mount(target string) error {
+func (m *Mount) Mount(target string) (err error) {
+	if m.Type == "bind" {
+		return errors.Wrapf(m.bindMount(target), "failed to bind-mount to %s", target)
+	}
+
 	if m.Type != "windows-layer" {
 		return errors.Errorf("invalid windows mount type: '%s'", m.Type)
 	}
@@ -59,6 +67,33 @@ func (m *Mount) Mount(target string) error {
 	if err = hcsshim.PrepareLayer(di, layerID, parentLayerPaths); err != nil {
 		return errors.Wrapf(err, "failed to prepare layer %s", m.Source)
 	}
+	defer func() {
+		if err != nil {
+			hcsshim.UnprepareLayer(di, layerID)
+		}
+	}()
+
+	volume, err := hcsshim.GetLayerMountPath(di, layerID)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get volume path for layer %s", m.Source)
+	}
+
+	if err = setVolumeMountPoint(target, volume); err != nil {
+		return errors.Wrapf(err, "failed to set volume mount path for layer %s", m.Source)
+	}
+	defer func() {
+		if err != nil {
+			deleteVolumeMountPoint(target)
+		}
+	}()
+
+	// Add an Alternate Data Stream to record the layer source.
+	// See https://docs.microsoft.com/en-au/archive/blogs/askcore/alternate-data-streams-in-ntfs
+	// for details on Alternate Data Streams.
+	if err = ioutil.WriteFile(filepath.Clean(target)+":"+sourceStreamName, []byte(m.Source), 0666); err != nil {
+		return errors.Wrapf(err, "failed to record source for layer %s", m.Source)
+	}
+
 	return nil
 }
 
@@ -82,8 +117,34 @@ func (m *Mount) GetParentPaths() ([]string, error) {
 
 // Unmount the mount at the provided path
 func Unmount(mount string, flags int) error {
+	mount = filepath.Clean(mount)
+
+	// Helpfully, both reparse points and symlinks look like links to Go
+	// Less-helpfully, ReadLink cannot return \\?\Volume{GUID} for a volume mount,
+	// and ends up returning the directory we gave it for some reason.
+	if mountTarget, err := os.Readlink(mount); err != nil {
+		// Not a mount point.
+		// This isn't an error, per the EINVAL handling in the Linux version
+		return nil
+	} else if mount != filepath.Clean(mountTarget) {
+		// Directory symlink
+		return errors.Wrapf(bindUnmount(mount), "failed to bind-unmount from %s", mount)
+	}
+
+	layerPathb, err := ioutil.ReadFile(mount + ":" + sourceStreamName)
+
+	if err != nil {
+		return errors.Wrapf(err, "failed to retrieve source for layer %s", mount)
+	}
+
+	layerPath := string(layerPathb)
+
+	if err := deleteVolumeMountPoint(mount); err != nil {
+		return errors.Wrapf(err, "failed failed to release volume mount path for layer %s", mount)
+	}
+
 	var (
-		home, layerID = filepath.Split(mount)
+		home, layerID = filepath.Split(layerPath)
 		di            = hcsshim.DriverInfo{
 			HomeDir: home,
 		}
@@ -92,6 +153,7 @@ func Unmount(mount string, flags int) error {
 	if err := hcsshim.UnprepareLayer(di, layerID); err != nil {
 		return errors.Wrapf(err, "failed to unprepare layer %s", mount)
 	}
+
 	if err := hcsshim.DeactivateLayer(di, layerID); err != nil {
 		return errors.Wrapf(err, "failed to deactivate layer %s", mount)
 	}
@@ -101,5 +163,24 @@ func Unmount(mount string, flags int) error {
 
 // UnmountAll unmounts from the provided path
 func UnmountAll(mount string, flags int) error {
+	if mount == "" {
+		// This isn't an error, per the EINVAL handling in the Linux version
+		return nil
+	}
+
 	return Unmount(mount, flags)
+}
+
+func (m *Mount) bindMount(target string) error {
+	if err := os.Remove(target); err != nil {
+		return err
+	}
+
+	// TODO: We don't honour the Read-Only flag.
+	// It's possible that Windows simply lacks this.
+	return os.Symlink(m.Source, target)
+}
+
+func bindUnmount(target string) error {
+	return os.Remove(target)
 }

--- a/mount/volumemountutils_windows.go
+++ b/mount/volumemountutils_windows.go
@@ -1,0 +1,76 @@
+// +build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package mount
+
+// Simple wrappers around SetVolumeMountPoint and DeleteVolumeMountPoint
+
+import (
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/windows"
+)
+
+// Mount volumePath (in format '\\?\Volume{GUID}' at targetPath.
+// https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setvolumemountpointw
+func setVolumeMountPoint(targetPath string, volumePath string) error {
+	if !strings.HasPrefix(volumePath, "\\\\?\\Volume{") {
+		return errors.Errorf("unable to mount non-volume path %s", volumePath)
+	}
+
+	// Both must end in a backslash
+	slashedTarget := filepath.Clean(targetPath) + string(filepath.Separator)
+	slashedVolume := volumePath + string(filepath.Separator)
+
+	targetP, err := syscall.UTF16PtrFromString(slashedTarget)
+	if err != nil {
+		return errors.Wrapf(err, "unable to utf16-ise %s", slashedTarget)
+	}
+
+	volumeP, err := syscall.UTF16PtrFromString(slashedVolume)
+	if err != nil {
+		return errors.Wrapf(err, "unable to utf16-ise %s", slashedVolume)
+	}
+
+	if err := windows.SetVolumeMountPoint(targetP, volumeP); err != nil {
+		return errors.Wrapf(err, "failed calling SetVolumeMount('%s', '%s')", slashedTarget, slashedVolume)
+	}
+
+	return nil
+}
+
+// Remove the volume mount at targetPath
+// https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-deletevolumemountpointa
+func deleteVolumeMountPoint(targetPath string) error {
+	// Must end in a backslash
+	slashedTarget := filepath.Clean(targetPath) + string(filepath.Separator)
+
+	targetP, err := syscall.UTF16PtrFromString(slashedTarget)
+	if err != nil {
+		return errors.Wrapf(err, "unable to utf16-ise %s", slashedTarget)
+	}
+
+	if err := windows.DeleteVolumeMountPoint(targetP); err != nil {
+		return errors.Wrapf(err, "failed calling DeleteVolumeMountPoint('%s')", slashedTarget)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This is a rebase of #4419 to master, isolating it from #4415 and antecedants (#4399 and #4395). Original description follows:

Full credit to @darstahl and @crosbymichael, on whose shoulders I stood to implement this, as well as any other contributors to #2366 and #2287. 

This reimplements the bare-minimum of #2366 to support Mount and Unmount under Windows, with the following approach:
* A snapshot without a parent is a `bind` mount, exposed via symlink. We can't make these read-only usefully, AFAIK.
* A snapshot with a parent is a `windows-layer` mount, exposed by HCS as a volume and mounted from there. We support read-only mounts by creating a temporary scratch layer on top of the desired read-only layer. So you can write to the mount, but it won't affect the underlying data.

In order to unmount a windows-layer without access to the original `[]mount.Mount`, we store the original layer path in an Alternative Data Stream on the mount-point. Happily, we do not require the parents list to tear down the stack.

It's a shame, really. If HCS exposed an inverse for `hcsshim.GetLayerMountPath`, then we wouldn't need the ADS storage, as Windows exposes an API to get the Volume back from a Volume mount, and that would let me find the Layer in-question.

I haven't brought in the tests from #2366 yet, or really tested this beyond `ctr image mount` and hammering on it with BuildKit to make progress towards https://github.com/moby/buildkit/issues/616. I'm looking for directional feedback on this (and the whole stack, really) before I start trying to wrangle the tests into place.

----

Note that I have not tested this rebase in isolation, it's a fallback measure in case issues are found with the other PRs, and so I can get a CI run to triage https://github.com/containerd/containerd/pull/4419#issuecomment-663163435 (Edit: Now resolved)

See also https://github.com/containerd/containerd/pull/4419#issuecomment-663825861 and https://github.com/containerd/containerd/pull/4419#discussion_r460777271 which are applicable here.