### PR TITLE
Some small test improvements

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -169,8 +169,9 @@ func TestMain(m *testing.M) {
 			fmt.Fprintln(os.Stderr, "failed to remove test root dir", err)
 			os.Exit(1)
 		}
-		// only print containerd logs if the test failed
-		if status != 0 {
+
+		// only print containerd logs if the test failed or tests were run with -v
+		if status != 0 || testing.Verbose() {
 			fmt.Fprintln(os.Stderr, buf.String())
 		}
 	}

--- a/client_windows_test.go
+++ b/client_windows_test.go
@@ -51,6 +51,8 @@ func init() {
 		testImage = "mcr.microsoft.com/windows/nanoserver:1903"
 	case 18363: // this isn't in osversion yet, but the image should be available
 		testImage = "mcr.microsoft.com/windows/nanoserver:1909"
+	case 19041: // this isn't in osversion yet, but the image should be available
+		testImage = "mcr.microsoft.com/windows/nanoserver:2004"
 	case 9200: // Missing manifest, so it's running in compatibility mode
 		fmt.Println("You need to copy Microsoft/hcsshim/test/functional/manifest/rsrc_amd64.syso into the containerd checkout")
 		panic("Running in Windows 8/Windows Server 2012 compatibility mode, failed to detect Windows build version")

--- a/client_windows_test.go
+++ b/client_windows_test.go
@@ -51,6 +51,12 @@ func init() {
 		testImage = "mcr.microsoft.com/windows/nanoserver:1903"
 	case 18363: // this isn't in osversion yet, but the image should be available
 		testImage = "mcr.microsoft.com/windows/nanoserver:1909"
+	case 9200: // Missing manifest, so it's running in compatibility mode
+		fmt.Println("You need to copy Microsoft/hcsshim/test/functional/manifest/rsrc_amd64.syso into the containerd checkout")
+		panic("Running in Windows 8/Windows Server 2012 compatibility mode, failed to detect Windows build version")
+	default:
+		fmt.Println("No test image defined for Windows build version:", b)
+		panic("No windows test image found for this Windows build")
 	}
 
 	fmt.Println("Windows test image:", testImage, ", Windows build version:", b)


### PR DESCRIPTION
Some stuff I hit while trying to reproduce an integration test failure seen on CI:
* When running the integration tests with `-v`, output the server log even on success, to help diagnose whatever you're trying to diagnose by adding `-v`.
* Add test image repository for Windows 10 2004/Windows Server 2004
* Fail early and with a useful course of action, if a test image cannot be determined on Windows, since there is no reasonable fallback option.