### PR TITLE
Change nodeset to `ubuntu-xenial-arm64-openlab`

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -10,5 +10,5 @@
     description: |
       Containerd build in openlab cluster.
     run: .zuul/playbooks/containerd-build/run.yaml
-    nodeset: ubuntu-xenial-arm64
+    nodeset: ubuntu-xenial-arm64-openlab
     voting: false


### PR DESCRIPTION
The old nodeset is unstable and apt source is unavailable, we change the nodeset from `ubuntu-xenial-arm64` to `ubuntu-xenial-arm64-openlab` to enable stable new nodeset.