### PR TITLE
vendor runc library to v1.0.0-rc91-48-g67169a9d

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -31,7 +31,7 @@ github.com/Microsoft/go-winio                       v0.4.14
 github.com/Microsoft/hcsshim                        v0.8.9
 github.com/opencontainers/go-digest                 v1.0.0
 github.com/opencontainers/image-spec                v1.0.1
-github.com/opencontainers/runc                      v1.0.0-rc91
+github.com/opencontainers/runc                      67169a9d43456ff0d5ae12b967acb8e366e2f181 # v1.0.0-rc91-48-g67169a9d
 github.com/opencontainers/runtime-spec              237cc4f519e2e8f9b235bacccfa8ef5a84df2875 # v1.0.3-0.20200520003142-237cc4f519e2
 github.com/pkg/errors                               v0.9.1
 github.com/prometheus/client_golang                 v1.6.0

--- a/vendor/github.com/opencontainers/runc/go.mod
+++ b/vendor/github.com/opencontainers/runc/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/checkpoint-restore/go-criu/v4 v4.0.2
-	github.com/cilium/ebpf v0.0.0-20200507155900-a9f01edf17e3
+	github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775
 	github.com/containerd/console v1.0.0
 	github.com/coreos/go-systemd/v22 v22.0.0
 	github.com/cyphar/filepath-securejoin v0.2.2

--- a/vendor/github.com/opencontainers/runc/libcontainer/configs/cgroup_linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/configs/cgroup_linux.go
@@ -126,4 +126,11 @@ type Resources struct {
 
 	// CpuWeight sets a proportional bandwidth limit.
 	CpuWeight uint64 `json:"cpu_weight"`
+
+	// SkipDevices allows to skip configuring device permissions.
+	// Used by e.g. kubelet while creating a parent cgroup (kubepods)
+	// common for many containers.
+	//
+	// NOTE it is impossible to start a container which has this flag set.
+	SkipDevices bool `json:"skip_devices"`
 }

--- a/vendor/github.com/opencontainers/runc/libcontainer/configs/device.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/configs/device.go
@@ -1,19 +1,14 @@
 package configs
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"strconv"
-
-	"golang.org/x/sys/unix"
 )
 
 const (
 	Wildcard = -1
 )
-
-// TODO Windows: This can be factored out in the future
 
 type Device struct {
 	DeviceRule
@@ -172,11 +167,4 @@ func (d *DeviceRule) CgroupString() string {
 		minor = "*"
 	}
 	return fmt.Sprintf("%c %s:%s %s", d.Type, major, minor, d.Permissions)
-}
-
-func (d *DeviceRule) Mkdev() (uint64, error) {
-	if d.Major == Wildcard || d.Minor == Wildcard {
-		return 0, errors.New("cannot mkdev() device with wildcards")
-	}
-	return unix.Mkdev(uint32(d.Major), uint32(d.Minor)), nil
 }

--- a/vendor/github.com/opencontainers/runc/libcontainer/configs/device_unix.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/configs/device_unix.go
@@ -1,0 +1,16 @@
+// +build !windows
+
+package configs
+
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+)
+
+func (d *DeviceRule) Mkdev() (uint64, error) {
+	if d.Major == Wildcard || d.Minor == Wildcard {
+		return 0, errors.New("cannot mkdev() device with wildcards")
+	}
+	return unix.Mkdev(uint32(d.Major), uint32(d.Minor)), nil
+}

--- a/vendor/github.com/opencontainers/runc/libcontainer/configs/device_windows.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/configs/device_windows.go
@@ -1,0 +1,5 @@
+package configs
+
+func (d *DeviceRule) Mkdev() (uint64, error) {
+	return 0, nil
+}

--- a/vendor/github.com/opencontainers/runc/libcontainer/devices/devices.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/devices/devices.go
@@ -37,12 +37,12 @@ func DeviceFromPath(path, permissions string) (*configs.Device, error) {
 		major     = unix.Major(devNumber)
 		minor     = unix.Minor(devNumber)
 	)
-	switch {
-	case mode&unix.S_IFBLK == unix.S_IFBLK:
+	switch mode & unix.S_IFMT {
+	case unix.S_IFBLK:
 		devType = configs.BlockDevice
-	case mode&unix.S_IFCHR == unix.S_IFCHR:
+	case unix.S_IFCHR:
 		devType = configs.CharDevice
-	case mode&unix.S_IFIFO == unix.S_IFIFO:
+	case unix.S_IFIFO:
 		devType = configs.FifoDevice
 	default:
 		return nil, ErrNotADevice
@@ -103,6 +103,9 @@ func GetDevices(path string) ([]*configs.Device, error) {
 				continue
 			}
 			return nil, err
+		}
+		if device.Type == configs.FifoDevice {
+			continue
 		}
 		out = append(out, device)
 	}

--- a/vendor/github.com/opencontainers/runc/libcontainer/user/user.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/user/user.go
@@ -60,7 +60,7 @@ type Group struct {
 
 // groupFromOS converts an os/user.(*Group) to local Group
 //
-// (This does not include Pass, Shell or Gecos)
+// (This does not include Pass or List)
 func groupFromOS(g *user.Group) (Group, error) {
 	newGroup := Group{
 		Name: g.Name,


### PR DESCRIPTION
runc v1.0.0-rc91 has some modifications, it will break docker. https://github.com/opencontainers/runc/pull/2529



More detail https://github.com/moby/moby/pull/41178

--- 
Or we can wait until runc rc92 is released and then merge.