### PR TITLE
remotes: mark GetTokenScopes public

### DIFF
--- a/remotes/docker/authorizer.go
+++ b/remotes/docker/authorizer.go
@@ -273,7 +273,7 @@ func (ah *authHandler) doBearerAuth(ctx context.Context) (string, error) {
 	// copy common tokenOptions
 	to := ah.common
 
-	to.scopes = getTokenScopes(ctx, to.scopes)
+	to.scopes = GetTokenScopes(ctx, to.scopes)
 
 	// Docs: https://docs.docker.com/registry/spec/auth/scope
 	scoped := strings.Join(to.scopes, " ")

--- a/remotes/docker/scope.go
+++ b/remotes/docker/scope.go
@@ -72,8 +72,8 @@ func contextWithAppendPullRepositoryScope(ctx context.Context, repo string) cont
 	return WithScope(ctx, fmt.Sprintf("repository:%s:pull", repo))
 }
 
-// getTokenScopes returns deduplicated and sorted scopes from ctx.Value(tokenScopesKey{}) and common scopes.
-func getTokenScopes(ctx context.Context, common []string) []string {
+// GetTokenScopes returns deduplicated and sorted scopes from ctx.Value(tokenScopesKey{}) and common scopes.
+func GetTokenScopes(ctx context.Context, common []string) []string {
 	var scopes []string
 	if x := ctx.Value(tokenScopesKey{}); x != nil {
 		scopes = append(scopes, x.([]string)...)

--- a/remotes/docker/scope_test.go
+++ b/remotes/docker/scope_test.go
@@ -91,7 +91,7 @@ func TestGetTokenScopes(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		ctx := context.WithValue(context.TODO(), tokenScopesKey{}, tc.scopesInCtx)
-		actual := getTokenScopes(ctx, tc.commonScopes)
+		actual := GetTokenScopes(ctx, tc.commonScopes)
 		assert.DeepEqual(t, tc.expected, actual)
 	}
 }
@@ -101,7 +101,7 @@ func TestCustomScope(t *testing.T) {
 	ctx := WithScope(context.Background(), scope)
 	ctx = contextWithAppendPullRepositoryScope(ctx, "foo/bar")
 
-	scopes := getTokenScopes(ctx, []string{})
+	scopes := GetTokenScopes(ctx, []string{})
 	assert.Assert(t, cmp.Len(scopes, 2))
 	assert.Check(t, cmp.Equal(scopes[0], "repository:foo/bar:pull"))
 	assert.Check(t, cmp.Equal(scopes[1], scope))


### PR DESCRIPTION
Authorizer interface can’t be really implemented because scopes are passed in on a side channel via private value in context.

The current structure of the resolver/fetcher/pusher where hardcoded auth scopes are passed in with a context that bypasses the Authorizer interface is quite awful. I'm willing to do a refactor as a follow-up if we can agree on the updated interface.

@AkihiroSuda 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>