### PR TITLE
Remove seccomp/Linux deps steps in GH Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,12 +235,6 @@ jobs:
         with:
           path: src/github.com/containerd/containerd
 
-      - name: Install Linux dependencies
-        if: startsWith(matrix.os, 'ubuntu')
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y btrfs-tools libseccomp-dev
-
       - name: Make
         run: |
           make build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,11 +79,6 @@ jobs:
           repository: containerd/containerd
           ref: ${{ github.ref }}
           path: src/github.com/containerd/containerd
-      - name: Install Linux dependencies
-        if: startsWith(matrix.os, 'ubuntu')
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y btrfs-tools libseccomp-dev
       - name: HCS Shim commit
         id: hcsshim_commit
         if: startsWith(matrix.os, 'windows')


### PR DESCRIPTION
Recent changes removed the need for libseccomp-dev when building
containerd. The btrfs tools package is already installed on GH Actions
runners and was already a no-op so the whole step can be removed.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>