### PR TITLE
client: surface a connection error more clearly

### DIFF
--- a/client.go
+++ b/client.go
@@ -123,6 +123,7 @@ func New(address string, opts ...ClientOpt) (*Client, error) {
 			grpc.FailOnNonTempDialError(true),
 			grpc.WithConnectParams(connParams),
 			grpc.WithContextDialer(dialer.ContextDialer),
+			grpc.WithReturnConnectionError(),
 
 			// TODO(stevvooe): We may need to allow configuration of this on the client.
 			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(defaults.DefaultMaxRecvMsgSize)),


### PR DESCRIPTION
gRPC-Go recently added grpc.WithReturnConnectionError() which improves
the situation of #2576.

Permission errors:

```
% ./bin/ctr t ls
ctr: failed to dial "/run/containerd/containerd.sock": connection error: desc = "transport: error while dialing: dial unix /run/containerd/containerd.sock: connect: permission denied"
%
```

Non-existent sockets:

```
% ./bin/ctr -a notfound t ls
ctr: failed to dial "notfound": context deadline exceeded: connection error: desc = "transport: error while dialing: dial unix://notfound: timeout"
%
```