### PR TITLE
Added cri to github release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,8 @@ deploy:
     file:
       - releases/*.tar.gz
       - releases/*.tar.gz.sha256sum
+      - releases/cri/*.tar.gz
+      - releases/cri/*.tar.gz.sha256sum
     skip_cleanup: true
     on:
       repo: containerd/containerd


### PR DESCRIPTION
It seems like travis builds the cri components, it's just not put in the release files.