### PR TITLE
Enable client to control labels of schema1 manifests

### DIFF
--- a/pull.go
+++ b/pull.go
@@ -153,7 +153,7 @@ func (c *Client) fetch(ctx context.Context, rCtx *RemoteContext, ref string, lim
 		isConvertible = true
 
 		converterFunc = func(ctx context.Context, _ ocispec.Descriptor) (ocispec.Descriptor, error) {
-			return schema1Converter.Convert(ctx)
+			return schema1Converter.Convert(ctx, schema1.WithChildLabelMap(rCtx.ChildLabelMap))
 		}
 	} else {
 		// Get all the children for a descriptor


### PR DESCRIPTION
Following up: #4414

This commit gives control of the labelling of schema1 manifests to the client, which is already available for non-schema1 images.

cc: @dmcgowan
