### PR TITLE
Update cri-tools to v1.18.0-100-g2bf7674 for Go 1.15 compatibility

### DIFF
--- a/script/setup/install-critools
+++ b/script/setup/install-critools
@@ -21,7 +21,7 @@
 set -eu -o pipefail
 
 go get -u github.com/onsi/ginkgo/ginkgo
-CRITEST_COMMIT=16911795a3c33833fa0ec83dac1ade3172f6989e
+CRITEST_COMMIT=2bf7674922a424337d7580a08166d666c6802818 # v1.18.0-100-g2bf7674
 go get -d github.com/kubernetes-sigs/cri-tools/...
 cd "$GOPATH"/src/github.com/kubernetes-sigs/cri-tools
 git checkout $CRITEST_COMMIT


### PR DESCRIPTION
taken from https://github.com/containerd/containerd/pull/4050

full diff: https://github.com/kubernetes-sigs/cri-tools/compare/16911795a3c33833fa0ec83dac1ade3172f6989e...2bf7674922a424337d7580a08166d666c6802818
