### PR TITLE
Bump Golang 1.13.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.14'
+          go-version: '1.13.15'
 
       - name: Set env
         shell: bash
@@ -66,7 +66,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.14'
+          go-version: '1.13.15'
 
       - name: Set env
         shell: bash
@@ -138,7 +138,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.14'
+          go-version: '1.13.15'
 
       - name: Set env
         shell: bash
@@ -185,7 +185,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.14'
+          go-version: '1.13.15'
 
       - name: Set env
         shell: bash
@@ -222,7 +222,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.14'
+          go-version: '1.13.15'
 
       - name: Set env
         shell: bash
@@ -254,7 +254,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.14'
+          go-version: '1.13.15'
 
       - name: Set env
         shell: bash
@@ -325,7 +325,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.14'
+          go-version: '1.13.15'
 
       - name: Setup gosu
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.14'
+          go-version: '1.13.15'
 
       - name: Checkout
         uses: actions/checkout@v1
@@ -126,7 +126,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.14'
+          go-version: '1.13.15'
 
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.14'
+          go-version: '1.13.15'
 
       - name: Set env
         shell: bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ os:
 - linux
 
 go:
-  - "1.13.14"
+  - "1.13.15"
 
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct

--- a/.zuul/playbooks/containerd-build/run.yaml
+++ b/.zuul/playbooks/containerd-build/run.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.13.14'
+    go_version: '1.13.15'
     arch: arm64
   tasks:
   - name: Build containerd

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,7 +29,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", env: {"RUNC_FLAVOR"=>ENV["RUNC_FLAVOR"]}, inline: <<-SHELL
     set -eux -o pipefail
     # configuration
-    GO_VERSION="1.13.14"
+    GO_VERSION="1.13.15"
 
     # install dnf deps
     dnf install -y container-selinux gcc git iptables libseccomp-devel lsof make

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.13.14
+ARG GOLANG_VERSION=1.13.15
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd


### PR DESCRIPTION
full diff: https://github.com/golang/go/compare/go1.13.14...go1.13.15

go1.13.15 (released 2020/08/06) includes security fixes to the encoding/binary
package. See the Go 1.13.15 milestone on the issue tracker for details.

https://github.com/golang/go/issues?q=milestone%3AGo1.13.15+label%3ACherryPickApproved
