### PR TITLE
[release/1.3 backport] Bump Golang 1.13.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.14'
+          go-version: '1.13.15'
 
       - name: Set env
         shell: bash
@@ -66,7 +66,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.14'
+          go-version: '1.13.15'
 
       - name: Set env
         shell: bash
@@ -138,7 +138,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.14'
+          go-version: '1.13.15'
 
       - name: Set env
         shell: bash
@@ -185,7 +185,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.14'
+          go-version: '1.13.15'
 
       - name: Set env
         shell: bash
@@ -222,7 +222,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.14'
+          go-version: '1.13.15'
 
       - name: Set env
         shell: bash
@@ -264,7 +264,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.14'
+          go-version: '1.13.15'
 
       - name: Setup gosu
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.13'
+          go-version: '1.13.14'
 
       - name: Set env
         shell: bash
@@ -66,7 +66,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.13'
+          go-version: '1.13.14'
 
       - name: Set env
         shell: bash
@@ -138,7 +138,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.13'
+          go-version: '1.13.14'
 
       - name: Set env
         shell: bash
@@ -185,7 +185,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.13'
+          go-version: '1.13.14'
 
       - name: Set env
         shell: bash
@@ -222,7 +222,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.13'
+          go-version: '1.13.14'
 
       - name: Set env
         shell: bash
@@ -264,7 +264,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.13'
+          go-version: '1.13.14'
 
       - name: Setup gosu
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.12'
+          go-version: '1.13.13'
 
       - name: Set env
         shell: bash
@@ -66,7 +66,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.12'
+          go-version: '1.13.13'
 
       - name: Set env
         shell: bash
@@ -138,7 +138,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.12'
+          go-version: '1.13.13'
 
       - name: Set env
         shell: bash
@@ -185,7 +185,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.12'
+          go-version: '1.13.13'
 
       - name: Set env
         shell: bash
@@ -222,7 +222,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.12'
+          go-version: '1.13.13'
 
       - name: Set env
         shell: bash
@@ -264,7 +264,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.12'
+          go-version: '1.13.13'
 
       - name: Setup gosu
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.12'
+          go-version: '1.13.13'
 
       - name: Set env
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.14'
+          go-version: '1.13.15'
 
       - name: Set env
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.13'
+          go-version: '1.13.14'
 
       - name: Set env
         shell: bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ os:
 - linux
 
 go:
-  - "1.13.14"
+  - "1.13.15"
 
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ os:
 - linux
 
 go:
-  - "1.13.13"
+  - "1.13.14"
 
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ os:
 - linux
 
 go:
-  - "1.13.12"
+  - "1.13.13"
 
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct

--- a/.zuul/playbooks/containerd-build/run.yaml
+++ b/.zuul/playbooks/containerd-build/run.yaml
@@ -1,21 +1,23 @@
 - hosts: all
   become: yes
   roles:
-    - role: config-golang
-      arch: arm64
+  - role: config-golang
+    go_version: '1.13.10'
+    arch: arm64
   tasks:
-    - name: Build containerd
-      shell:
-        cmd: |
-          set -xe
-          set -o pipefail
-          apt-get update
-          apt-get install -y btrfs-tools libseccomp-dev git pkg-config
+  - name: Build containerd
+    shell:
+      cmd: |
+        set -xe
+        set -o pipefail
+        apt-get update
+        apt-get install -y btrfs-tools libseccomp-dev git pkg-config
 
-          make | tee $LOGS_PATH/make.txt
-          make test | tee $LOGS_PATH/make_test.txt
+        go version
+        make | tee $LOGS_PATH/make.txt
+        make test | tee $LOGS_PATH/make_test.txt
 
-          cp -r ./bin $RESULTS_PATH
-        chdir: '{{ zuul.project.src_dir }}'
-        executable: /bin/bash
-      environment: '{{ global_env }}'
+        cp -r ./bin $RESULTS_PATH
+      chdir: '{{ zuul.project.src_dir }}'
+      executable: /bin/bash
+    environment: '{{ global_env }}'

--- a/.zuul/playbooks/containerd-build/run.yaml
+++ b/.zuul/playbooks/containerd-build/run.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.13.13'
+    go_version: '1.13.14'
     arch: arm64
   tasks:
   - name: Build containerd

--- a/.zuul/playbooks/containerd-build/run.yaml
+++ b/.zuul/playbooks/containerd-build/run.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.13.10'
+    go_version: '1.13.13'
     arch: arm64
   tasks:
   - name: Build containerd

--- a/.zuul/playbooks/containerd-build/run.yaml
+++ b/.zuul/playbooks/containerd-build/run.yaml
@@ -8,6 +8,7 @@
       shell:
         cmd: |
           set -xe
+          set -o pipefail
           apt-get update
           apt-get install -y btrfs-tools libseccomp-dev git pkg-config
 

--- a/.zuul/playbooks/containerd-build/run.yaml
+++ b/.zuul/playbooks/containerd-build/run.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.13.14'
+    go_version: '1.13.15'
     arch: arm64
   tasks:
   - name: Build containerd

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.13.14
+ARG GOLANG_VERSION=1.13.15
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.13.13
+ARG GOLANG_VERSION=1.13.14
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.13.12
+ARG GOLANG_VERSION=1.13.13
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd


### PR DESCRIPTION
Backports of:

- https://github.com/containerd/containerd/pull/3944 ci: set pipefail in zuul script
    - fixes https://github.com/containerd/containerd/issues/3943 openlab ci is broken
- https://github.com/containerd/containerd/pull/4199 .zuul: update go version to 1.13.10
    - only the first commit; skipped the second commit
- https://github.com/containerd/containerd/pull/4375 Bump Go 1.13.13
- https://github.com/containerd/containerd/pull/4398 Bump Golang 1.13.14
- https://github.com/containerd/containerd/pull/4462 Bump Golang 1.13.15