### PR TITLE
[release/1.2 backport] Bump Golang 1.13.15

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.13.14
+    - GO_VERSION: 1.13.15
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.13.12
+    - GO_VERSION: 1.13.13
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
   GOPATH: C:\gopath
   CGO_ENABLED: 1
   matrix:
-    - GO_VERSION: 1.13.13
+    - GO_VERSION: 1.13.14
 
 before_build:
   - choco install -y mingw --version 5.3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 language: go
 
 go:
-  - "1.13.13"
+  - "1.13.14"
 os:
   - "linux"
   # TODO ppc64le is currently timing out on travis; see https://github.com/containerd/containerd/pull/2896

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 language: go
 
 go:
-  - "1.13.12"
+  - "1.13.13"
 os:
   - "linux"
   # TODO ppc64le is currently timing out on travis; see https://github.com/containerd/containerd/pull/2896

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 language: go
 
 go:
-  - "1.13.14"
+  - "1.13.15"
 os:
   - "linux"
   # TODO ppc64le is currently timing out on travis; see https://github.com/containerd/containerd/pull/2896

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.13.14
+ARG GOLANG_VERSION=1.13.15
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.13.13
+ARG GOLANG_VERSION=1.13.14
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.13.12
+ARG GOLANG_VERSION=1.13.13
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd


### PR DESCRIPTION
Backports of:

- https://github.com/containerd/containerd/pull/4375 Bump Go 1.13.13
- https://github.com/containerd/containerd/pull/4398 Bump Golang 1.13.14
- https://github.com/containerd/containerd/pull/4462 Bump Golang 1.13.15

Cherry-picks weren't clean, but trivial to fix