### PR TITLE
apparmor: handle signal mediation

### DIFF
--- a/contrib/apparmor/template_test.go
+++ b/contrib/apparmor/template_test.go
@@ -1,0 +1,18 @@
+// +build linux
+
+package apparmor
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestCleanProfileName(t *testing.T) {
+	assert.Equal(t, cleanProfileName(""), "unconfined")
+	assert.Equal(t, cleanProfileName("unconfined"), "unconfined")
+	assert.Equal(t, cleanProfileName("unconfined (enforce)"), "unconfined")
+	assert.Equal(t, cleanProfileName("docker-default"), "docker-default")
+	assert.Equal(t, cleanProfileName("foo"), "foo")
+	assert.Equal(t, cleanProfileName("foo (enforce)"), "foo")
+}


### PR DESCRIPTION
On newer kernels and systems, AppArmor will block sending signals in
many scenarios by default resulting in strange behaviours (container
programs cannot signal each other, or host processes like containerd
cannot signal containers). [This issue was fixed in Docker in 2018][1] but
this code was copied before then and thus the patches weren't carried.
It also contains [a new fix for a more esoteric case][2].

Ideally this code should live in a project like "containerd/apparmor" so
that Docker, libpod, and containerd can share it, but that's probably
something to do separately.

In addition, the copyright header is updated to reference that the code
is copied from Docker (and thus was not written entirely by the
containerd authors).

[1]: https://github.com/docker/docker/pull/37831
[2]: https://github.com/docker/docker/pull/41337

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>