### PR TITLE
systemd: use LimitNOFILE=infinity instead of hard-coded max value

### DIFF
--- a/containerd.service
+++ b/containerd.service
@@ -16,7 +16,7 @@ RestartSec=5
 # in the kernel. We recommend using cgroups to do container-local accounting.
 LimitNPROC=infinity
 LimitCORE=infinity
-LimitNOFILE=1048576
+LimitNOFILE=infinity
 # Comment TasksMax if your systemd version does not supports it.
 # Only systemd 226 and above support this version.
 TasksMax=infinity


### PR DESCRIPTION
According to the systemd documentation, `infinity` can be used for all limits;
https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Process%20Properties

> Resource limits may be specified in two formats: either as single value to set a
> specific soft and hard limit to the same value, or as colon-separated pair soft:hard
> (...) Use the string infinity to configure no limit on a specific resource.
