### PR TITLE
systemd: add license header to systemd unit

### DIFF
--- a/containerd.service
+++ b/containerd.service
@@ -1,3 +1,17 @@
+# Copyright The containerd Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 [Unit]
 Description=containerd container runtime
 Documentation=https://containerd.io


### PR DESCRIPTION
I thought this would make sense, as this is a file that would likely be shipped in packages, but wasn't sure if this was desired or not, and if https://github.com/kunalkushwaha/ltag should be updated to allow verifying `.service` files