### PR TITLE
seccomp: add `openat2` syscall.

### DIFF
--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -224,6 +224,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				"_newselect",
 				"open",
 				"openat",
+				"openat2",
 				"pause",
 				"pipe",
 				"pipe2",


### PR DESCRIPTION
related to https://patchwork.kernel.org/patch/11167585/

Note: `openat2()` first appeared in Linux 5.6. And Glibc does not provide a wrapper for this system call; call it using
`syscall(2)`.

ref: https://man7.org/linux/man-pages/man2/openat2.2.html