### PR TITLE
tasks: Monitor v2 tasks in initFunc as well

### DIFF
--- a/services/tasks/local.go
+++ b/services/tasks/local.go
@@ -118,6 +118,13 @@ func initFunc(ic *plugin.InitContext) (interface{}, error) {
 			l.monitor.Monitor(t)
 		}
 	}
+	v2Tasks, err := l.v2Runtime.Tasks(ic.Context, true)
+	if err != nil {
+		return nil, err
+	}
+	for _, t := range v2Tasks {
+		l.monitor.Monitor(t)
+	}
 	return l, nil
 }
 


### PR DESCRIPTION
When containerd is restarted, only v1 tasks are monitored again. 
This leads to the lack of existing v2 task metrics.

Signed-off-by: Li Yuxuan <liyuxuan04@baidu.com>