### PR TITLE
seccomp: move the syslog syscall to be gated by CAP_SYS_ADMIN or CAP_SYSLOG

### DIFF
--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -346,7 +346,6 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				"sync_file_range",
 				"syncfs",
 				"sysinfo",
-				"syslog",
 				"tee",
 				"tgkill",
 				"time",
@@ -493,6 +492,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 					"setdomainname",
 					"sethostname",
 					"setns",
+					"syslog",
 					"umount",
 					"umount2",
 					"unshare",
@@ -561,6 +561,12 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 		case "CAP_SYS_TTY_CONFIG":
 			s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
 				Names:  []string{"vhangup"},
+				Action: specs.ActAllow,
+				Args:   []specs.LinuxSeccompArg{},
+			})
+		case "CAP_SYSLOG":
+			s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
+				Names:  []string{"syslog"},
 				Action: specs.ActAllow,
 				Args:   []specs.LinuxSeccompArg{},
 			})


### PR DESCRIPTION
equivalent of https://github.com/moby/moby/pull/37929

This call is what is used to implement `dmesg` to get kernel messages
about the host. This can leak substantial information about the host.
It is normally available to unprivileged users on the host, unless
the sysctl `kernel.dmesg_restrict = 1` is set, but this is not set
by standard on the majority of distributions. Blocking this to restrict
leaks about the configuration seems correct.

Relates to docker/docker#37897 "docker exposes dmesg to containers by default"

See also https://googleprojectzero.blogspot.com/2018/09/a-cache-invalidation-bug-in-linux.html
