### PR TITLE
[release/1.3 backport] snapshots/devmapper: fix rollback

### DIFF
--- a/snapshots/devmapper/metadata.go
+++ b/snapshots/devmapper/metadata.go
@@ -101,7 +101,7 @@ func (m *PoolMetadata) AddDevice(ctx context.Context, info *DeviceInfo) error {
 		// See https://github.com/containerd/containerd/pull/3436 for more context.
 		var existing DeviceInfo
 		if err := getObject(devicesBucket, info.Name, &existing); err == nil && existing.State != Faulty {
-			return ErrAlreadyExists
+			return errors.Wrapf(ErrAlreadyExists, "device %q is already there %+v", info.Name, existing)
 		}
 
 		// Find next available device ID

--- a/snapshots/devmapper/pool_device.go
+++ b/snapshots/devmapper/pool_device.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
 
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/snapshots/devmapper/dmsetup"
@@ -160,7 +161,22 @@ func (p *PoolDevice) transition(ctx context.Context, deviceName string, tryingSt
 		result = multierror.Append(result, uerr)
 	}
 
-	return result.ErrorOrNil()
+	return unwrapError(result)
+}
+
+// unwrapError converts multierror.Error to the original error when it is possible.
+// multierror 1.1.0 has the similar function named Unwrap, but it requires Go 1.14.
+func unwrapError(e *multierror.Error) error {
+	if e == nil {
+		return nil
+	}
+
+	// If the error can be expressed without multierror, return the original error.
+	if len(e.Errors) == 1 {
+		return e.Errors[0]
+	}
+
+	return e.ErrorOrNil()
 }
 
 // CreateThinDevice creates new devmapper thin-device with given name and size.
@@ -182,21 +198,7 @@ func (p *PoolDevice) CreateThinDevice(ctx context.Context, deviceName string, vi
 	defer func() {
 		// We've created a devmapper device, but failed to activate it, try rollback everything
 		if activeErr != nil {
-			// Delete the device first.
-			delErr := p.deleteDevice(ctx, info)
-			if delErr != nil {
-				// Failed to rollback, mark the device as faulty and keep metadata in order to
-				// preserve the faulty device ID
-				retErr = multierror.Append(retErr, delErr, p.metadata.MarkFaulty(ctx, info.Name))
-				return
-			}
-
-			// The devmapper device has been successfully deleted, deallocate device ID
-			if err := p.RemoveDevice(ctx, info.Name); err != nil {
-				retErr = multierror.Append(retErr, err)
-				return
-			}
-
+			retErr = p.rollbackActivate(ctx, info, activeErr)
 			return
 		}
 
@@ -226,6 +228,23 @@ func (p *PoolDevice) CreateThinDevice(ctx context.Context, deviceName string, vi
 	}
 
 	return nil
+}
+
+func (p *PoolDevice) rollbackActivate(ctx context.Context, info *DeviceInfo, activateErr error) error {
+	// Delete the device first.
+	delErr := p.deleteDevice(ctx, info)
+	if delErr != nil {
+		// Failed to rollback, mark the device as faulty and keep metadata in order to
+		// preserve the faulty device ID
+		return multierror.Append(activateErr, delErr, p.metadata.MarkFaulty(ctx, info.Name))
+	}
+
+	// The devmapper device has been successfully deleted, deallocate device ID
+	if err := p.RemoveDevice(ctx, info.Name); err != nil {
+		return multierror.Append(activateErr, err)
+	}
+
+	return activateErr
 }
 
 // createDevice creates thin device
@@ -273,21 +292,7 @@ func (p *PoolDevice) CreateSnapshotDevice(ctx context.Context, deviceName string
 	defer func() {
 		// We've created a devmapper device, but failed to activate it, try rollback everything
 		if activeErr != nil {
-			// Delete the device first.
-			delErr := p.deleteDevice(ctx, snapInfo)
-			if delErr != nil {
-				// Failed to rollback, mark the device as faulty and keep metadata in order to
-				// preserve the faulty device ID
-				retErr = multierror.Append(retErr, delErr, p.metadata.MarkFaulty(ctx, snapInfo.Name))
-				return
-			}
-
-			// The devmapper device has been successfully deleted, deallocate device ID
-			if err := p.RemoveDevice(ctx, snapInfo.Name); err != nil {
-				retErr = multierror.Append(retErr, err)
-				return
-			}
-
+			retErr = p.rollbackActivate(ctx, snapInfo, activeErr)
 			return
 		}
 
@@ -465,7 +470,13 @@ func (p *PoolDevice) RemoveDevice(ctx context.Context, deviceName string) error 
 func (p *PoolDevice) deleteDevice(ctx context.Context, info *DeviceInfo) error {
 	if err := p.transition(ctx, info.Name, Removing, Removed, func() error {
 		// Send 'delete' message to thin-pool
-		return dmsetup.DeleteDevice(p.poolName, info.DeviceID)
+		e := dmsetup.DeleteDevice(p.poolName, info.DeviceID)
+
+		// Ignores the error if the device has been deleted already.
+		if e != nil && errors.Cause(e) != unix.ENODATA {
+			return e
+		}
+		return nil
 	}); err != nil {
 		return errors.Wrapf(err, "failed to delete device %q (dev id: %d)", info.Name, info.DeviceID)
 	}


### PR DESCRIPTION
Backport of #4437. I will create another backport PR for 1.4 later.

---

The rollback mechanism is implemented by calling deleteDevice() and
RemoveDevice(). But RemoveDevice() is internally calling
deleteDevice() as well.

Since a device will be deleted by first deleteDevice(),
RemoveDevice() always will see ENODATA. The specific error must be
ignored to remove the device's metadata correctly.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>