### PR TITLE
[release/1.4] runtime: ignore ErrNotExist when remove rootfs

### DIFF
--- a/runtime/v2/bundle.go
+++ b/runtime/v2/bundle.go
@@ -121,7 +121,7 @@ func (b *Bundle) Delete() error {
 	if err := mount.UnmountAll(rootfs, 0); err != nil {
 		return errors.Wrapf(err, "unmount rootfs %s", rootfs)
 	}
-	if err := os.Remove(rootfs); err != nil && os.IsNotExist(err) {
+	if err := os.Remove(rootfs); err != nil && !os.IsNotExist(err) {
 		return errors.Wrap(err, "failed to remove bundle rootfs")
 	}
 	err := atomicDelete(b.Path)


### PR DESCRIPTION
Signed-off-by: Wei Fu <fuweid89@gmail.com>
(cherry picked from commit 73b14492782983b43444a2208d5e618f399052b0)
Signed-off-by: Wei Fu <fuweid89@gmail.com>

cherry-pick #4472 