### PR TITLE
remotes/docker: add ErrNoToken alias for backward-compatibility

### DIFF
--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -31,6 +31,7 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/reference"
 	"github.com/containerd/containerd/remotes"
+	"github.com/containerd/containerd/remotes/docker/auth"
 	"github.com/containerd/containerd/remotes/docker/schema1"
 	"github.com/containerd/containerd/version"
 	digest "github.com/opencontainers/go-digest"
@@ -41,6 +42,11 @@ import (
 )
 
 var (
+	// ErrNoToken is returned if a request is successful but the body does not
+	// contain an authorization token.
+	// Deprecated: use github.com/containerd/containerd/remotes/docker/auth.ErrNoToken
+	ErrNoToken = auth.ErrNoToken
+
 	// ErrInvalidAuthorization is used when credentials are passed to a server but
 	// those credentials are rejected.
 	ErrInvalidAuthorization = errors.New("authorization failed")


### PR DESCRIPTION
This error was moved as part of the refactoring in commit 957bcb3dff38c57116ff79b0aeaf347cd47cee48 (https://github.com/containerd/containerd/pull/4445). However, this error was exported, so adding an alias to prevent breaking projects that used this.

To encourage people to use updatge their code, the alias is marked as deprecated, pointing to the new location.
