### PR TITLE
Add configurable overlayfs path

### DIFF
--- a/snapshots/overlay/config.go
+++ b/snapshots/overlay/config.go
@@ -1,0 +1,25 @@
+// +build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package overlay
+
+// Config represents configuration for the overlay plugin.
+type Config struct {
+	// Root directory for the plugin
+	RootPath string `toml:"root_path"`
+}

--- a/snapshots/overlay/overlay.go
+++ b/snapshots/overlay/overlay.go
@@ -39,12 +39,24 @@ import (
 
 func init() {
 	plugin.Register(&plugin.Registration{
-		Type: plugin.SnapshotPlugin,
-		ID:   "overlayfs",
+		Type:   plugin.SnapshotPlugin,
+		ID:     "overlayfs",
+		Config: &Config{},
 		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
 			ic.Meta.Platforms = append(ic.Meta.Platforms, platforms.DefaultSpec())
-			ic.Meta.Exports["root"] = ic.Root
-			return NewSnapshotter(ic.Root, AsynchronousRemove)
+
+			config, ok := ic.Config.(*Config)
+			if !ok {
+				return nil, errors.New("invalid overlay configuration")
+			}
+
+			root := ic.Root
+			if config.RootPath != "" {
+				root = config.RootPath
+			}
+
+			ic.Meta.Exports["root"] = root
+			return NewSnapshotter(root, AsynchronousRemove)
 		},
 	})
 }


### PR DESCRIPTION
Fixes https://github.com/containerd/containerd/issues/4500

This allows configuring the location of the overlayfs snapshotter by
adding the following in config.toml
```
[plugins]
  [plugins.overlayfs]
    root_path = "/custom_location"
```

This is useful to isolate disk i/o for overlayfs from the rest of
containerd and prevent containers saturating disk i/o from negatively
affecting containerd operations and cause timeouts.