### PR TITLE
Separate overlay implementation from plugin

### DIFF
--- a/cmd/containerd/builtins_linux.go
+++ b/cmd/containerd/builtins_linux.go
@@ -23,5 +23,5 @@ import (
 	_ "github.com/containerd/containerd/runtime/v2"
 	_ "github.com/containerd/containerd/runtime/v2/runc/options"
 	_ "github.com/containerd/containerd/snapshots/native"
-	_ "github.com/containerd/containerd/snapshots/overlay"
+	_ "github.com/containerd/containerd/snapshots/overlay/plugin"
 )

--- a/snapshots/overlay/overlay.go
+++ b/snapshots/overlay/overlay.go
@@ -29,37 +29,11 @@ import (
 
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
-	"github.com/containerd/containerd/platforms"
-	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/containerd/snapshots/storage"
 	"github.com/containerd/continuity/fs"
 	"github.com/pkg/errors"
 )
-
-func init() {
-	plugin.Register(&plugin.Registration{
-		Type:   plugin.SnapshotPlugin,
-		ID:     "overlayfs",
-		Config: &Config{},
-		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
-			ic.Meta.Platforms = append(ic.Meta.Platforms, platforms.DefaultSpec())
-
-			config, ok := ic.Config.(*Config)
-			if !ok {
-				return nil, errors.New("invalid overlay configuration")
-			}
-
-			root := ic.Root
-			if config.RootPath != "" {
-				root = config.RootPath
-			}
-
-			ic.Meta.Exports["root"] = root
-			return NewSnapshotter(root, AsynchronousRemove)
-		},
-	})
-}
 
 // SnapshotterConfig is used to configure the overlay snapshotter instance
 type SnapshotterConfig struct {

--- a/snapshots/overlay/plugin/plugin.go
+++ b/snapshots/overlay/plugin/plugin.go
@@ -18,8 +18,40 @@
 
 package overlay
 
+import (
+	"errors"
+
+	"github.com/containerd/containerd/platforms"
+	"github.com/containerd/containerd/plugin"
+	"github.com/containerd/containerd/snapshots/overlay"
+)
+
 // Config represents configuration for the overlay plugin.
 type Config struct {
 	// Root directory for the plugin
 	RootPath string `toml:"root_path"`
+}
+
+func init() {
+	plugin.Register(&plugin.Registration{
+		Type:   plugin.SnapshotPlugin,
+		ID:     "overlayfs",
+		Config: &Config{},
+		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
+			ic.Meta.Platforms = append(ic.Meta.Platforms, platforms.DefaultSpec())
+
+			config, ok := ic.Config.(*Config)
+			if !ok {
+				return nil, errors.New("invalid overlay configuration")
+			}
+
+			root := ic.Root
+			if config.RootPath != "" {
+				root = config.RootPath
+			}
+
+			ic.Meta.Exports["root"] = root
+			return overlay.NewSnapshotter(root, overlay.AsynchronousRemove)
+		},
+	})
 }


### PR DESCRIPTION
Put the overlay plugin in a separate package to allow the overlay package to be used without needing to import and initialize the plugin.

Downstream implementations will need to account for this one, but considering the other plugin refactoring being targeted for 1.5, it makes sense to do it now.