### PR TITLE
add help wanted, update slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,23 @@
 
 containerd is an industry-standard container runtime with an emphasis on simplicity, robustness and portability. It is available as a daemon for Linux and Windows, which can manage the complete container lifecycle of its host system: image transfer and storage, container execution and supervision, low-level storage and network attachments, etc.
 
+containerd is a member of CNCF with ['graduated'](https://landscape.cncf.io/selected=containerd) status.
+
 containerd is designed to be embedded into a larger system, rather than being used directly by developers or end-users.
 
 ![architecture](design/architecture.png)
+
+## Now Recruiting
+
+We are a large inclusive OSS project that is welcoming help of any kind shape or form:
+* Documentation help is needed to make the product easier to consume and extend.
+* We need OSS community outreach / organizing help to get the word out; manage
+and create messaging and educational content; and to help with social media, community forums/groups, and google groups.
+* We are actively inviting new [security advisors](https://github.com/containerd/project/blob/master/GOVERNANCE.md#security-advisors) to join the team.
+* New sub-projects are being created, core and non-core that could use additional development help.
+* Each of the [containerd projects](https://github.com/containerd) has a list of issues currently being worked on or that need help resolving.
+  - If the issue has not already been assigned to someone, or has not made recent progress and you are interested, please inquire.
+  - If you are interested in starting with a smaller / beginner level issue, look for issues with an `exp/beginner` tag, for example [containerd/containerd beginner issues.](https://github.com/containerd/containerd/issues?q=is%3Aissue+is%3Aopen+label%3Aexp%2Fbeginner)
 
 ## Getting Started
 
@@ -250,10 +264,7 @@ loaded for the user's shell environment.
 For async communication and long running discussions please use issues and pull requests on the github repo.
 This will be the best place to discuss design and implementation.
 
-For sync communication we have a community slack with a #containerd channel that everyone is welcome to join and chat about development.
-
-**Slack:** Catch us in the #containerd and #containerd-dev channels on dockercommunity.slack.com.
-[Click here for an invite to docker community slack.](https://dockr.ly/slack)
+For sync communication catch us in the `#containerd` and `#containerd-dev` slack channels on Cloud Native Computing Foundation's (CNCF) slack - `cloud-native.slack.com`. Everyone is welcome to join and chat. [Get Invite to CNCF slack.](https://slack.cncf.io)
 
 ### Security audit
 


### PR DESCRIPTION
Updates slack link to point to CNCF slack.

Adds a help wanted section to let people know help is needed, wanted, and welcome.  

Need more documentation / material outlining how said helpers can contribute. But wanted to at least make it known/visible on the repo.

Signed-off-by: Mike Brown <brownwm@us.ibm.com>