### PR TITLE
[release/1.4] tasks: Monitor v2 tasks in initFunc as well

### DIFF
--- a/services/tasks/local.go
+++ b/services/tasks/local.go
@@ -118,6 +118,13 @@ func initFunc(ic *plugin.InitContext) (interface{}, error) {
 			l.monitor.Monitor(t)
 		}
 	}
+	v2Tasks, err := l.v2Runtime.Tasks(ic.Context, true)
+	if err != nil {
+		return nil, err
+	}
+	for _, t := range v2Tasks {
+		l.monitor.Monitor(t)
+	}
 	return l, nil
 }
 


### PR DESCRIPTION
When containerd is restarted, only v1 tasks are monitored again. This
leads to the lack of existing v2 task metrics.

Signed-off-by: Li Yuxuan <liyuxuan04@baidu.com>
(cherry picked from commit 4422ae363828c035f76a7b2c45e3419f77d164f9)
Signed-off-by: Wei Fu <fuweid89@gmail.com>

cherry-pick: #4486 