### PR TITLE
update cri to 35e623e6bf7512e8c82b8ac6052cb1d7201

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -58,7 +58,7 @@ gotest.tools/v3                                     v3.0.2
 github.com/cilium/ebpf                              1c8d4c9ef7759622653a1d319284a44652333b28
 
 # cri dependencies
-github.com/containerd/cri                           56a89cda34644fedf0c99f96c888de5851e0e406 # master
+github.com/containerd/cri                           35e623e6bf7512e8c82b8ac6052cb1d720189f28 # master
 github.com/davecgh/go-spew                          v1.1.1
 github.com/docker/docker                            4634ce647cf2ce2c6031129ccd109e557244986f
 github.com/docker/spdystream                        449fdfce4d962303d702fec724ef0ad181c92528

--- a/vendor/github.com/containerd/cri/pkg/server/container_create.go
+++ b/vendor/github.com/containerd/cri/pkg/server/container_create.go
@@ -161,6 +161,12 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	}
 
 	meta.ProcessLabel = spec.Process.SelinuxLabel
+
+	// handle any KVM based runtime
+	if err := modifyProcessLabel(ociRuntime.Type, spec); err != nil {
+		return nil, err
+	}
+
 	if config.GetLinux().GetSecurityContext().GetPrivileged() {
 		// If privileged don't set the SELinux label but still record it on the container so
 		// the unused MCS label can be release later

--- a/vendor/github.com/containerd/cri/pkg/server/helpers_windows.go
+++ b/vendor/github.com/containerd/cri/pkg/server/helpers_windows.go
@@ -24,6 +24,8 @@ import (
 	"path/filepath"
 	"syscall"
 	"time"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // openLogFile opens/creates a container log file.
@@ -216,4 +218,8 @@ func ensureRemoveAll(_ context.Context, dir string) error {
 		exitOnErr[pe.Path]++
 		time.Sleep(100 * time.Millisecond)
 	}
+}
+
+func modifyProcessLabel(runtimeType string, spec *specs.Spec) error {
+	return nil
 }

--- a/vendor/github.com/containerd/cri/pkg/server/sandbox_run.go
+++ b/vendor/github.com/containerd/cri/pkg/server/sandbox_run.go
@@ -167,6 +167,11 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		}
 	}()
 
+	// handle any KVM based runtime
+	if err := modifyProcessLabel(ociRuntime.Type, spec); err != nil {
+		return nil, err
+	}
+
 	if config.GetLinux().GetSecurityContext().GetPrivileged() {
 		// If privileged don't set selinux label, but we still record the MCS label so that
 		// the unused label can be freed later.

--- a/vendor/github.com/containerd/cri/pkg/seutil/seutil.go
+++ b/vendor/github.com/containerd/cri/pkg/seutil/seutil.go
@@ -1,0 +1,71 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package seutil
+
+import (
+	"bufio"
+	"os"
+
+	"github.com/opencontainers/selinux/go-selinux"
+)
+
+var seTypes map[string]struct{}
+
+const typePath = "/etc/selinux/targeted/contexts/customizable_types"
+
+func init() {
+	seTypes = make(map[string]struct{})
+	if !selinux.GetEnabled() {
+		return
+	}
+	f, err := os.Open(typePath)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		seTypes[s.Text()] = struct{}{}
+	}
+}
+
+// HasType returns true if the underlying system has the
+// provided selinux type enabled.
+func HasType(name string) bool {
+	_, ok := seTypes[name]
+	return ok
+}
+
+// ChangeToKVM process label
+func ChangeToKVM(l string) (string, error) {
+	if l == "" || !selinux.GetEnabled() {
+		return "", nil
+	}
+	proc, _ := selinux.KVMContainerLabels()
+	selinux.ReleaseLabel(proc)
+
+	current, err := selinux.NewContext(l)
+	if err != nil {
+		return "", err
+	}
+	next, err := selinux.NewContext(proc)
+	if err != nil {
+		return "", err
+	}
+	current["type"] = next["type"]
+	return current.Get(), nil
+}


### PR DESCRIPTION
This includes changes for kata or other kvm based runtimes with selinux support.

Signed-off-by: Michael Crosby <michael@thepasture.io>