### PR TITLE
Add amd64->386 fallback

### DIFF
--- a/platforms/compare.go
+++ b/platforms/compare.go
@@ -37,6 +37,14 @@ func platformVector(platform specs.Platform) []specs.Platform {
 	vector := []specs.Platform{platform}
 
 	switch platform.Architecture {
+	case "amd64":
+		vector = append(vector, specs.Platform{
+			Architecture: "386",
+			OS:           platform.OS,
+			OSVersion:    platform.OSVersion,
+			OSFeatures:   platform.OSFeatures,
+			Variant:      platform.Variant,
+		})
 	case "arm":
 		if armVersion, err := strconv.Atoi(strings.TrimPrefix(platform.Variant, "v")); err == nil && armVersion > 5 {
 			for armVersion--; armVersion >= 5; armVersion-- {
@@ -60,6 +68,7 @@ func platformVector(platform specs.Platform) []specs.Platform {
 // For arm/v8, will also match arm/v7, arm/v6 and arm/v5
 // For arm/v7, will also match arm/v6 and arm/v5
 // For arm/v6, will also match arm/v5
+// For amd64, will also match 386
 func Only(platform specs.Platform) MatchComparer {
 	return Ordered(platformVector(Normalize(platform))...)
 }

--- a/platforms/compare_test.go
+++ b/platforms/compare_test.go
@@ -30,9 +30,9 @@ func TestOnly(t *testing.T) {
 			matches: map[bool][]string{
 				true: {
 					"linux/amd64",
+					"linux/386",
 				},
 				false: {
-					"linux/386",
 					"linux/arm/v7",
 					"linux/arm64",
 					"windows/amd64",


### PR DESCRIPTION
This ~~adds a test for `platforms.Only` (previously untested, as far as I can tell), improves the hard-coded list of ARM fallbacks in the `platform.Only` implementation (by doing a descending loop over variant numbers instead, which is all the hard-coded list was doing), and~~ adds `386` as a fallback architecture for `amd64`.

I'd like to do something similar for `arm64` (falling back to `linux/arm/v8`, `linux/arm/v7`, etc, which I think would more accurately fix what was reported in https://github.com/containerd/containerd/issues/3990 and allow us to revert https://github.com/containerd/containerd/pull/4013), but figured I'd start with this and see what the interest in the approach is. :heart: