### PR TITLE
Add RPi1/RPi0 workaround

### DIFF
--- a/platforms/cpuinfo.go
+++ b/platforms/cpuinfo.go
@@ -96,6 +96,15 @@ func getCPUVariant() string {
 		return ""
 	}
 
+	// handle edge case for Raspberry Pi ARMv6 devices (which due to a kernel quirk, report "CPU architecture: 7")
+	// https://www.raspberrypi.org/forums/viewtopic.php?t=12614
+	if runtime.GOARCH == "arm" && variant == "7" {
+		model, err := getCPUInfo("model name")
+		if err == nil && strings.HasPrefix(strings.ToLower(model), "armv6-compatible") {
+			variant = "6"
+		}
+	}
+
 	switch strings.ToLower(variant) {
 	case "8", "aarch64":
 		// special case: if running a 32-bit userspace on aarch64, the variant should be "v7"


### PR DESCRIPTION
On the very popular Raspberry Pi 1 and Zero devices, the CPU is actually ARMv6, but the chip happens to support the feature bit the kernel uses to differentiate v6/v7, so it gets reported as "CPU architecture: 7" and thus fails to run many of the images that get pulled.

To account for this very popular edge case, this also checks "model name" which on these chips will begin with "ARMv6-compatible" -- we could also check uname, but getCPUInfo is already handy, low overhead, and mirrors the code before this.

To give a small taste of how common this issue is and why (in my opinion) it warrants a special case:

- https://github.com/moby/moby/issues/41017
- https://github.com/moby/moby/issues/37647
- https://github.com/moby/moby/issues/34875
- https://github.com/biarms/mysql/issues/4

(I proposed this over in https://github.com/moby/moby/issues/41017#issuecomment-686788886, which prompted the following query:)

> @estesp: is there any variant of the ARMv7 CPU family that might be adversely affected by this; e.g. might get "downgraded" to a v6 variant inadvertently?

I'm not aware of any that report `model name` to be `ARMv6-compatible` like these RPi devices do (and my Google search for `"model name : armv6-compatible"` comes up with tons of hits for RPi-related discussion, usually around this very kernel quirk, but not much else I can see), so I think the regression potential here is really low.

I personally tested on a Raspberry Pi 1 (ARMv6) and a NanoPi NEO (ARMv7), and `ctr i pull docker.io/library/alpine:3.12` does the right thing in both instances (on the RPi1, I get `unpacking linux/arm/v6 sha256:...` and on the NanoPi, I get `unpacking linux/arm/v7 sha256:...`, whereas before this change the RPi1 would choose the `linux/arm/v7` image which then fails to run).