### PR TITLE
Fix some signal forwarder issues

### DIFF
--- a/cmd/ctr/commands/signals.go
+++ b/cmd/ctr/commands/signals.go
@@ -23,6 +23,7 @@ import (
 	"syscall"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/errdefs"
 	"github.com/sirupsen/logrus"
 )
 
@@ -38,6 +39,10 @@ func ForwardAllSignals(ctx gocontext.Context, task killer) chan os.Signal {
 		for s := range sigc {
 			logrus.Debug("forwarding signal ", s)
 			if err := task.Kill(ctx, s.(syscall.Signal)); err != nil {
+				if errdefs.IsNotFound(err) {
+					logrus.WithError(err).Debugf("Not forwarding signal %s", s)
+					return
+				}
 				logrus.WithError(err).Errorf("forward signal %s", s)
 			}
 		}

--- a/cmd/ctr/commands/signals.go
+++ b/cmd/ctr/commands/signals.go
@@ -37,6 +37,10 @@ func ForwardAllSignals(ctx gocontext.Context, task killer) chan os.Signal {
 	signal.Notify(sigc)
 	go func() {
 		for s := range sigc {
+			if canIgnoreSignal(s) {
+				logrus.Debugf("Ignoring signal %s", s)
+				continue
+			}
 			logrus.Debug("forwarding signal ", s)
 			if err := task.Kill(ctx, s.(syscall.Signal)); err != nil {
 				if errdefs.IsNotFound(err) {

--- a/cmd/ctr/commands/signals_linux.go
+++ b/cmd/ctr/commands/signals_linux.go
@@ -1,0 +1,27 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package commands
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func canIgnoreSignal(s os.Signal) bool {
+	return s == unix.SIGURG
+}

--- a/cmd/ctr/commands/signals_notlinux.go
+++ b/cmd/ctr/commands/signals_notlinux.go
@@ -1,0 +1,25 @@
+//+build !linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package commands
+
+import "os"
+
+func canIgnoreSignal(_ os.Signal) bool {
+	return false
+}


### PR DESCRIPTION
### Exit signal forward if process not found
Previously the signal loop can end up racing with the process exiting.
Intead of logging and continuing the loop, exit early.

### Ignore SIGURG signals in signal forwarder
Starting with go1.14, the go runtime hijacks SIGURG but with no way to
not send to other signal handlers.

In practice, we get this signal frequently.
I found this while testing out go1.15 with ctr and multiple execs with
only `echo hello`. When the process exits quickly, if the previous
commit is not applied, you end up with an error message that it couldn't
forward SIGURG to the container (due to the process being gone).