### PR TITLE
cr: fix checkpoint from image getting skipped

### DIFF
--- a/services/tasks/local.go
+++ b/services/tasks/local.go
@@ -148,7 +148,7 @@ func (l *local) Create(ctx context.Context, r *api.CreateTaskRequest, _ ...grpc.
 		return nil, err
 	}
 	// jump get checkpointPath from checkpoint image
-	if checkpointPath != "" && r.Checkpoint != nil {
+	if checkpointPath == "" && r.Checkpoint != nil {
 		checkpointPath, err = ioutil.TempDir(os.Getenv("XDG_RUNTIME_DIR"), "ctrd-checkpoint")
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This fixes an issue with restoring from a checkpoint image. One either restores from an image *or* a path, but currently restoring from an image only works if a path is set as well.

It looks like a simple logical error: The path apparently is supposed to take precedence over the image, so restoring form an image should only be done when *no* checkpoint path is set. Therefore a `checkpointPath == ""` makes more sense than `checkpointPath != ""`.

I haven't tested this (yet), but I'll do so when I have the time.