### PR TITLE
fix `make test` failure of missing sha256 package

### DIFF
--- a/metadata/leases_test.go
+++ b/metadata/leases_test.go
@@ -17,6 +17,7 @@
 package metadata
 
 import (
+	_ "crypto/sha256"
 	"testing"
 
 	"github.com/containerd/containerd/errdefs"


### PR DESCRIPTION
Looks like since PR #4517 was merged, make test fails, at least on darwin/x86-64, and linux/arm64 (https://logs.openlabtesting.org/logs/26/4526/6bc6efaefef4864a2347f38c642cc24343cfe6d3/check/containerd-build-arm64/85fa8cc/).

error messages is

```
2020-09-04 01:03:59.591076 | ubuntu-xenial-arm64-openlab | panic: sha256 not available (make sure it is imported) [recovered]
2020-09-04 01:03:59.591113 | ubuntu-xenial-arm64-openlab | 	panic: sha256 not available (make sure it is imported)
2020-09-04 01:03:59.591127 | ubuntu-xenial-arm64-openlab |
2020-09-04 01:03:59.591149 | ubuntu-xenial-arm64-openlab | goroutine 33 [running]:
2020-09-04 01:03:59.591175 | ubuntu-xenial-arm64-openlab | testing.tRunner.func1(0x4000195800)
2020-09-04 01:03:59.591207 | ubuntu-xenial-arm64-openlab | 	/usr/local/go/src/testing/testing.go:874 +0x348
2020-09-04 01:03:59.591231 | ubuntu-xenial-arm64-openlab | panic(0x3c1460, 0x40001c69d0)
2020-09-04 01:03:59.591262 | ubuntu-xenial-arm64-openlab | 	/usr/local/go/src/runtime/panic.go:679 +0x194
2020-09-04 01:03:59.591331 | ubuntu-xenial-arm64-openlab | github.com/containerd/containerd/vendor/github.com/opencontainers/go-digest.Algorithm.Hash(0x4647e2, 0x6, 0x0, 0x40000cde18)
(snip)
```

Reverting c50ff694f013cac12651b813a285d2f32ce9f4cd makes this fixed, but this commit contains another workaround.

Fixes: c50ff694 ("refactor(native): separate init from implementation")

Signed-off-by: Hajime Tazaki <thehajime@gmail.com>