### PR TITLE
[release/1.3] seccomp: add `openat2` and `faccessat2` syscall

### DIFF
--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -216,6 +216,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				"_newselect",
 				"open",
 				"openat",
+				"openat2",
 				"pause",
 				"pipe",
 				"pipe2",

--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -89,6 +89,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				"exit",
 				"exit_group",
 				"faccessat",
+				"faccessat2",
 				"fadvise64",
 				"fadvise64_64",
 				"fallocate",


### PR DESCRIPTION
backport of https://github.com/containerd/containerd/pull/4481

> related to https://patchwork.kernel.org/patch/11167585/
> 
> Note: `openat2()` first appeared in Linux 5.6. And Glibc does not provide a wrapper for this system call; call it using
> `syscall(2)`.
> 
> ref: https://man7.org/linux/man-pages/man2/openat2.2.html
