### PR TITLE
[release/1.4 backport] BUILDING.md: fix description about static builds

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -117,13 +117,13 @@ You can build static binaries by providing a few variables to `make`:
 
 ```sudo
 make EXTRA_FLAGS="-buildmode pie" \
-	EXTRA_LDFLAGS='-extldflags "-fno-PIC -static"' \
+	EXTRA_LDFLAGS='-linkmode external -extldflags "-fno-PIC -static"' \
 	BUILDTAGS="netgo osusergo static_build"
 ```
 
 > *Note*:
 > - static build is discouraged
-> - static containerd binary does not support loading plugins
+> - static containerd binary does not support loading shared object plugins (`*.so`)
 
 # Via Docker container
 


### PR DESCRIPTION
backport of https://github.com/containerd/containerd/pull/4470

* `-linkmode external` is required since Go 1.15 for static builds: https://github.com/golang/go/issues/40711
* Clarify the meaning of "loading plugins"

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
(cherry picked from commit 43cbdf89e9142b9b8cb54fb0932e4c7a45f1daeb)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>