### PR TITLE
Set resolver to pull the image from next registry

### DIFF
--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -296,7 +296,8 @@ func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocisp
 			resp.Body.Close() // don't care about body contents.
 
 			if resp.StatusCode > 299 {
-				if resp.StatusCode == http.StatusNotFound {
+				// in case of error try next host
+				if resp.StatusCode > 399 {
 					continue
 				}
 				return "", ocispec.Descriptor{}, errors.Errorf("unexpected status code %v: %v", u, resp.Status)


### PR DESCRIPTION
Fixes #4531, and likely https://github.com/containerd/cri/issues/1419#issuecomment-616995422 is related as well.

Seems like retry currently works only for 404. Not sure if this is the best way to fix it but I tried to follow previous discussions (#3850 & #3868) and understood that retry always on error would be the way to go.

Let me know what you think.