### PR TITLE
add RegisterTCP method for services

### DIFF
--- a/pkg/dialer/dialer_unix.go
+++ b/pkg/dialer/dialer_unix.go
@@ -30,6 +30,12 @@ import (
 // DialAddress returns the address with unix:// prepended to the
 // provided address
 func DialAddress(address string) string {
+	m := strings.Index(address, ":")
+	// tcp address:port
+	if m > 0 {
+		return fmt.Sprintf("tcp://%s", address)
+	}
+	// unix socket path
 	return fmt.Sprintf("unix://%s", address)
 }
 
@@ -47,6 +53,9 @@ func isNoent(err error) bool {
 }
 
 func dialer(address string, timeout time.Duration) (net.Conn, error) {
-	address = strings.TrimPrefix(address, "unix://")
-	return net.DialTimeout("unix", address, timeout)
+	data := strings.Split(address, "://")
+	if len(data) != 2 {
+		return nil, fmt.Errorf("invalid address: %s", address)
+	}
+	return net.DialTimeout(data[0], data[1], timeout)
 }

--- a/pkg/dialer/dialer_unix.go
+++ b/pkg/dialer/dialer_unix.go
@@ -30,12 +30,6 @@ import (
 // DialAddress returns the address with unix:// prepended to the
 // provided address
 func DialAddress(address string) string {
-	m := strings.Index(address, ":")
-	// tcp address:port
-	if m > 0 {
-		return fmt.Sprintf("tcp://%s", address)
-	}
-	// unix socket path
 	return fmt.Sprintf("unix://%s", address)
 }
 
@@ -53,9 +47,6 @@ func isNoent(err error) bool {
 }
 
 func dialer(address string, timeout time.Duration) (net.Conn, error) {
-	data := strings.Split(address, "://")
-	if len(data) != 2 {
-		return nil, fmt.Errorf("invalid address: %s", address)
-	}
-	return net.DialTimeout(data[0], data[1], timeout)
+	address = strings.TrimPrefix(address, "unix://")
+	return net.DialTimeout("unix", address, timeout)
 }

--- a/services/containers/service.go
+++ b/services/containers/service.go
@@ -64,6 +64,11 @@ func (s *service) Register(server *grpc.Server) error {
 	return nil
 }
 
+func (s *service) RegisterTCP(server *grpc.Server) error {
+	api.RegisterContainersServer(server, s)
+	return nil
+}
+
 func (s *service) Get(ctx context.Context, req *api.GetContainerRequest) (*api.GetContainerResponse, error) {
 	return s.local.Get(ctx, req)
 }

--- a/services/content/contentserver/contentserver.go
+++ b/services/content/contentserver/contentserver.go
@@ -56,6 +56,11 @@ func (s *service) Register(server *grpc.Server) error {
 	return nil
 }
 
+func (s *service) RegisterTCP(server *grpc.Server) error {
+	api.RegisterContentServer(server, s)
+	return nil
+}
+
 func (s *service) Info(ctx context.Context, req *api.InfoRequest) (*api.InfoResponse, error) {
 	if err := req.Digest.Validate(); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "%q failed validation", req.Digest)

--- a/services/diff/service.go
+++ b/services/diff/service.go
@@ -62,6 +62,11 @@ func (s *service) Register(gs *grpc.Server) error {
 	return nil
 }
 
+func (s *service) RegisterTCP(gs *grpc.Server) error {
+	diffapi.RegisterDiffServer(gs, s)
+	return nil
+}
+
 func (s *service) Apply(ctx context.Context, er *diffapi.ApplyRequest) (*diffapi.ApplyResponse, error) {
 	return s.local.Apply(ctx, er)
 }

--- a/services/events/service.go
+++ b/services/events/service.go
@@ -61,6 +61,11 @@ func (s *service) Register(server *grpc.Server) error {
 	return nil
 }
 
+func (s *service) RegisterTCP(server *grpc.Server) error {
+	api.RegisterEventsServer(server, s)
+	return nil
+}
+
 func (s *service) RegisterTTRPC(server *ttrpc.Server) error {
 	apittrpc.RegisterEventsService(server, s.ttService)
 	return nil

--- a/services/images/service.go
+++ b/services/images/service.go
@@ -63,6 +63,11 @@ func (s *service) Register(server *grpc.Server) error {
 	return nil
 }
 
+func (s *service) RegisterTCP(server *grpc.Server) error {
+	imagesapi.RegisterImagesServer(server, s)
+	return nil
+}
+
 func (s *service) Get(ctx context.Context, req *imagesapi.GetImageRequest) (*imagesapi.GetImageResponse, error) {
 	return s.local.Get(ctx, req)
 }

--- a/services/introspection/service.go
+++ b/services/introspection/service.go
@@ -76,6 +76,11 @@ func (s *server) Register(server *grpc.Server) error {
 	return nil
 }
 
+func (s *server) RegisterTCP(server *grpc.Server) error {
+	api.RegisterIntrospectionServer(server, s)
+	return nil
+}
+
 func (s *server) Plugins(ctx context.Context, req *api.PluginsRequest) (*api.PluginsResponse, error) {
 	return s.local.Plugins(ctx, req)
 }

--- a/services/leases/service.go
+++ b/services/leases/service.go
@@ -64,6 +64,11 @@ func (s *service) Register(server *grpc.Server) error {
 	return nil
 }
 
+func (s *service) RegisterTCP(server *grpc.Server) error {
+	api.RegisterLeasesServer(server, s)
+	return nil
+}
+
 func (s *service) Create(ctx context.Context, r *api.CreateRequest) (*api.CreateResponse, error) {
 	opts := []leases.Opt{
 		leases.WithLabels(r.Labels),

--- a/services/namespaces/service.go
+++ b/services/namespaces/service.go
@@ -63,6 +63,11 @@ func (s *service) Register(server *grpc.Server) error {
 	return nil
 }
 
+func (s *service) RegisterTCP(server *grpc.Server) error {
+	api.RegisterNamespacesServer(server, s)
+	return nil
+}
+
 func (s *service) Get(ctx context.Context, req *api.GetNamespaceRequest) (*api.GetNamespaceResponse, error) {
 	return s.local.Get(ctx, req)
 }

--- a/services/snapshots/service.go
+++ b/services/snapshots/service.go
@@ -83,6 +83,11 @@ func (s *service) Register(gs *grpc.Server) error {
 	return nil
 }
 
+func (s *service) RegisterTCP(gs *grpc.Server) error {
+	snapshotsapi.RegisterSnapshotsServer(gs, s)
+	return nil
+}
+
 func (s *service) Prepare(ctx context.Context, pr *snapshotsapi.PrepareSnapshotRequest) (*snapshotsapi.PrepareSnapshotResponse, error) {
 	log.G(ctx).WithField("parent", pr.Parent).WithField("key", pr.Key).Debugf("prepare snapshot")
 	sn, err := s.getSnapshotter(pr.Snapshotter)

--- a/services/tasks/service.go
+++ b/services/tasks/service.go
@@ -65,6 +65,11 @@ func (s *service) Register(server *grpc.Server) error {
 	return nil
 }
 
+func (s *service) RegisterTCP(server *grpc.Server) error {
+	api.RegisterTasksServer(server, s)
+	return nil
+}
+
 func (s *service) Create(ctx context.Context, r *api.CreateTaskRequest) (*api.CreateTaskResponse, error) {
 	return s.local.Create(ctx, r)
 }

--- a/services/version/service.go
+++ b/services/version/service.go
@@ -48,6 +48,11 @@ func (s *service) Register(server *grpc.Server) error {
 	return nil
 }
 
+func (s *service) RegisterTCP(server *grpc.Server) error {
+	api.RegisterVersionServer(server, s)
+	return nil
+}
+
 func (s *service) Version(ctx context.Context, _ *ptypes.Empty) (*api.VersionResponse, error) {
 	return &api.VersionResponse{
 		Version:  ctrdversion.Version,


### PR DESCRIPTION
This PR add RegisterTCP method for existing services to support gRPC over TCP.