### PR TITLE
Set 1.2.x end of life date to October 15

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -98,7 +98,7 @@ The current state is available in the following table:
 | [0.2](https://github.com/containerd/containerd/tree/v0.2.x)          | End of Life | Apr 21, 2016      | December 5, 2017 |
 | [1.0](https://github.com/containerd/containerd/releases/tag/v1.0.3)  | End of Life | December 5, 2017  | December 5, 2018 |
 | [1.1](https://github.com/containerd/containerd/releases/tag/v1.1.8)  | End of Life | April 23, 2018  | October 23, 2019 |
-| [1.2](https://github.com/containerd/containerd/releases/tag/v1.2.13) | Extended   | October 24, 2018 | September 26, 2020 |
+| [1.2](https://github.com/containerd/containerd/releases/tag/v1.2.13) | Extended   | October 24, 2018 | October 15, 2020 |
 | [1.3](https://github.com/containerd/containerd/releases/tag/v1.3.7)  | Active   | September 26, 2019  | February 17, 2021 |
 | [1.4](https://github.com/containerd/containerd/releases/tag/v1.4.1)  | Active   | August 17, 2020 | max(August 17, 2021, release of 1.5.0 + 6 months) |
 | [1.5](https://github.com/containerd/containerd/milestone/30)         | Next   | TBD  | max(TBD+1 year, release of 1.6.0 + 6 months) |


### PR DESCRIPTION
The maintainers discussed extending the end of life date for 1.2 to allow time for EOL announcement and migration to 1.3.

