### PR TITLE
Update CRI tests to build and push to gcs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,8 +354,8 @@ jobs:
         run: |
           sudo PATH=$PATH script/setup/install-seccomp
           gosu root script/setup/install-runc
-          script/setup/install-cni
-          script/setup/install-critools
+          gosu root script/setup/install-cni
+          gosu root script/setup/install-critools
         working-directory: src/github.com/containerd/containerd
 
       - name: Install criu

--- a/Makefile
+++ b/Makefile
@@ -298,15 +298,16 @@ endif
 
 cri-release: releases/$(CRIRELEASE).tar.gz
 	@echo "$(WHALE) $@"
-	@cd releases && sha256sum $(CRIRELEASE).tar.gz >$(CRIRELEASE).tar.gz.sha256sum
+	@cd releases && sha256sum $(CRIRELEASE).tar.gz >$(CRIRELEASE).tar.gz.sha256sum && ln -sf $(CRIRELEASE).tar.gz cri-containerd.tar.gz
 
 cri-cni-release: releases/$(CRICNIRELEASE).tar.gz
 	@echo "$(WHALE) $@"
-	@cd releases && sha256sum $(CRICNIRELEASE).tar.gz >$(CRICNIRELEASE).tar.gz.sha256sum
+	@cd releases && sha256sum $(CRICNIRELEASE).tar.gz >$(CRICNIRELEASE).tar.gz.sha256sum && ln -sf $(CRICNIRELEASE).tar.gz cri-cni-containerd.tar.gz
 
 clean: ## clean up binaries
 	@echo "$(WHALE) $@"
 	@rm -f $(BINARIES)
+	@rm -f releases/*.tar.gz*
 	@if [[ -d $(OUTPUTDIR) ]]; then sudo rm -rf $(OUTPUTDIR); fi
 
 clean-test: ## clean up debris from previously failed tests

--- a/Makefile
+++ b/Makefile
@@ -261,21 +261,21 @@ install-cri-deps: $(BINARIES)
 	cp bin/* $(CRIDIR)
 else
 install-cri-deps: $(BINARIES)
-	@sudo rm -rf ${CRIDIR}
-	@sudo install -d ${CRIDIR}/usr/local/bin
-	@sudo install -D -m 755 bin/* ${CRIDIR}/usr/local/bin
-	@sudo install -d ${CRIDIR}/opt/containerd/cluster
-	@sudo cp -r contrib/gce ${CRIDIR}/opt/containerd/cluster/
-	@sudo install -d ${CRIDIR}/etc/systemd/system
-	@sudo install -m 644 containerd.service ${CRIDIR}/etc/systemd/system
-	echo "CONTAINERD_VERSION: '$(VERSION:v%=%)'" | sudo tee ${CRIDIR}/opt/containerd/cluster/version
+	@rm -rf ${CRIDIR}
+	@install -d ${CRIDIR}/usr/local/bin
+	@install -D -m 755 bin/* ${CRIDIR}/usr/local/bin
+	@install -d ${CRIDIR}/opt/containerd/cluster
+	@cp -r contrib/gce ${CRIDIR}/opt/containerd/cluster/
+	@install -d ${CRIDIR}/etc/systemd/system
+	@install -m 644 containerd.service ${CRIDIR}/etc/systemd/system
+	echo "CONTAINERD_VERSION: '$(VERSION:v%=%)'" | tee ${CRIDIR}/opt/containerd/cluster/version
 
-	DESTDIR=$(CRIDIR) USESUDO=true script/setup/install-runc
+	DESTDIR=$(CRIDIR) USESUDO=false script/setup/install-runc
 	DESTDIR=$(CRIDIR) script/setup/install-cni
 	DESTDIR=$(CRIDIR) script/setup/install-critools
 
-	@sudo install -d $(CRIDIR)/bin
-	@sudo install $(BINARIES) $(CRIDIR)/bin
+	@install -d $(CRIDIR)/bin
+	@install $(BINARIES) $(CRIDIR)/bin
 endif
 
 ifeq ($(GOOS),windows)
@@ -308,7 +308,7 @@ clean: ## clean up binaries
 	@echo "$(WHALE) $@"
 	@rm -f $(BINARIES)
 	@rm -f releases/*.tar.gz*
-	@if [[ -d $(OUTPUTDIR) ]]; then sudo rm -rf $(OUTPUTDIR); fi
+	@rm -rf $(OUTPUTDIR)
 
 clean-test: ## clean up debris from previously failed tests
 	@echo "$(WHALE) $@"

--- a/script/setup/install-cni
+++ b/script/setup/install-cni
@@ -29,10 +29,10 @@ go get -d github.com/containernetworking/plugins/...
 cd "$GOPATH"/src/github.com/containernetworking/plugins
 git checkout $CNI_COMMIT
 ./build_linux.sh
-sudo mkdir -p $CNI_DIR
-sudo cp -r ./bin $CNI_DIR
-sudo mkdir -p $CNI_CONFIG_DIR
-cat << EOF | sudo tee $CNI_CONFIG_DIR/10-containerd-net.conflist
+mkdir -p $CNI_DIR
+cp -r ./bin $CNI_DIR
+mkdir -p $CNI_CONFIG_DIR
+cat << EOF | tee $CNI_CONFIG_DIR/10-containerd-net.conflist
 {
   "cniVersion": "0.4.0",
   "name": "containerd-net",

--- a/script/setup/install-critools
+++ b/script/setup/install-critools
@@ -26,7 +26,7 @@ go get -d github.com/kubernetes-sigs/cri-tools/...
 cd "$GOPATH"/src/github.com/kubernetes-sigs/cri-tools
 git checkout $CRITEST_COMMIT
 make
-sudo make install -e BINDIR=${DESTDIR:=''}/usr/local/bin
-cat << EOF | sudo tee ${DESTDIR}/etc/crictl.yaml
+make install -e BINDIR=${DESTDIR:=''}/usr/local/bin
+cat << EOF | tee ${DESTDIR}/etc/crictl.yaml
 runtime-endpoint: unix:///run/containerd/containerd.sock
 EOF

--- a/test/build-utils.sh
+++ b/test/build-utils.sh
@@ -20,21 +20,13 @@ ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
 PROJECT=${PROJECT:-"k8s-cri-containerd"}
 
 # GOOGLE_APPLICATION_CREDENTIALS is the path of service account file.
-if [ -z ${GOOGLE_APPLICATION_CREDENTIALS} ]; then
+if [ -z ${GOOGLE_APPLICATION_CREDENTIALS:-""} ]; then
   echo "GOOGLE_APPLICATION_CREDENTIALS is not set"
   exit 1
 fi
 
 # Activate gcloud service account.
 gcloud auth activate-service-account --key-file "${GOOGLE_APPLICATION_CREDENTIALS}" --project="${PROJECT}"
-
-# Install dependent libraries.
-apt-get update
-if apt-cache show libbtrfs-dev > /dev/null; then
-  apt-get install -y libbtrfs-dev
-else
-  apt-get install -y btrfs-tools
-fi
 
 # Kubernetes test infra uses jessie and stretch.
 if cat /etc/os-release | grep jessie; then
@@ -43,6 +35,8 @@ if cat /etc/os-release | grep jessie; then
   apt-get install -y libseccomp2/jessie-backports
   apt-get install -y libseccomp-dev/jessie-backports
 else
+  cat /etc/os-release
+  apt-get update
   apt-get install -y libseccomp2
   apt-get install -y libseccomp-dev
 fi

--- a/test/push.sh
+++ b/test/push.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source $(dirname "${BASH_SOURCE[0]}")/utils.sh
+
+# DEPLOY_BUCKET is the gcs bucket where the tarball should be stored in.
+DEPLOY_BUCKET=${DEPLOY_BUCKET:-"cri-containerd-staging"}
+# DEPLOY_DIR is the directory in the gcs bucket to store the tarball.
+DEPLOY_DIR=${DEPLOY_DIR:-""}
+# BUILD_DIR is the directory of the bulid out.
+BUILD_DIR=${BUILD_DIR:-"_output"}
+# TARBALL is the tarball name.
+TARBALL=${TARBALL:-"cri-containerd.tar.gz"}
+# LATEST is the name of the latest version file.
+LATEST=${LATEST:-"latest"}
+# PUSH_VERSION indicates whether to push version.
+PUSH_VERSION=${PUSH_VERSION:-false}
+
+release_tar=${BUILD_DIR}/${TARBALL}
+release_tar_checksum=${release_tar}.sha256
+if [[ ! -e ${release_tar} || ! -e ${release_tar_checksum} ]]; then
+  echo "Release tarball is not built"
+  exit 1
+fi
+
+if ! gsutil ls "gs://${DEPLOY_BUCKET}" > /dev/null; then
+  create_ttl_bucket ${DEPLOY_BUCKET}
+fi
+
+if [ -z "${DEPLOY_DIR}" ]; then
+  DEPLOY_PATH="${DEPLOY_BUCKET}"
+else
+  DEPLOY_PATH="${DEPLOY_BUCKET}/${DEPLOY_DIR}"
+fi
+
+gsutil cp ${release_tar} "gs://${DEPLOY_PATH}/"
+gsutil cp ${release_tar_checksum} "gs://${DEPLOY_PATH}/"
+echo "Release tarball is uploaded to:
+  https://storage.googleapis.com/${DEPLOY_PATH}/${TARBALL}"
+
+if ${PUSH_VERSION}; then
+  if [[ -z "${VERSION}" ]]; then
+    echo "VERSION is not set"
+    exit 1
+  fi
+  echo ${VERSION} | gsutil cp - "gs://${DEPLOY_PATH}/${LATEST}"
+  echo "Latest version is uploaded to:
+  https://storage.googleapis.com/${DEPLOY_PATH}/${LATEST}"
+fi

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
+
+# upload_logs_to_gcs uploads test logs to gcs.
+# Var set:
+# 1. Bucket: gcs bucket to upload logs.
+# 2. Dir: directory name to upload logs.
+# 3. Test Result: directory of the test result.
+upload_logs_to_gcs() {
+  local -r bucket=$1
+  local -r dir=$2
+  local -r result=$3
+  if ! gsutil ls "gs://${bucket}" > /dev/null; then
+    create_ttl_bucket ${bucket}
+  fi
+  local -r upload_log_path=${bucket}/${dir}
+  gsutil cp -r "${result}" "gs://${upload_log_path}"
+  echo "Test logs are uploaed to:
+    http://gcsweb.k8s.io/gcs/${upload_log_path}/"
+}
+
+# create_ttl_bucket create a public bucket in which all objects
+# have a default TTL (30 days).
+# Var set:
+# 1. Bucket: gcs bucket name.
+create_ttl_bucket() {
+  local -r bucket=$1
+  gsutil mb "gs://${bucket}"
+  local -r bucket_rule=$(mktemp)
+  # Set 30 day TTL for logs inside the bucket.
+  echo '{"rule": [{"action": {"type": "Delete"},"condition": {"age": 30}}]}' > ${bucket_rule}
+  gsutil lifecycle set "${bucket_rule}" "gs://${bucket}"
+  rm "${bucket_rule}"
+
+  gsutil -m acl ch -g all:R "gs://${bucket}"
+  gsutil defacl set public-read "gs://${bucket}"
+}
+
+# sha256 generates a sha256 checksum for a file.
+# Var set:
+# 1. Filename.
+sha256() {
+  if which sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{ print $1 }'
+  else
+    shasum -a256 "$1" | awk '{ print $1 }'
+  fi
+}


### PR DESCRIPTION
This enables to the CRI e2e tests to use the build from a PR

WIP: for testing