### PR TITLE
mount.isFUSE(): remove unused error return, and extract FUSE unmount to a function

### DIFF
--- a/mount/mount_linux.go
+++ b/mount/mount_linux.go
@@ -106,20 +106,20 @@ func Unmount(target string, flags int) error {
 	return nil
 }
 
-func isFUSE(dir string) (bool, error) {
+func isFUSE(dir string) bool {
 	// fuseSuperMagic is defined in statfs(2)
 	const fuseSuperMagic = 0x65735546
 	var st unix.Statfs_t
 	if err := unix.Statfs(dir, &st); err != nil {
-		return false, err
+		return false
 	}
-	return st.Type == fuseSuperMagic, nil
+	return st.Type == fuseSuperMagic
 }
 
 func unmount(target string, flags int) error {
 	// For FUSE mounts, attempting to execute fusermount helper binary is preferred
 	// https://github.com/containerd/containerd/pull/3765#discussion_r342083514
-	if ok, err := isFUSE(target); err == nil && ok {
+	if isFUSE(target) {
 		for _, helperBinary := range []string{"fusermount3", "fusermount"} {
 			cmd := exec.Command(helperBinary, "-u", target)
 			if err := cmd.Run(); err == nil {

--- a/mount/mount_linux.go
+++ b/mount/mount_linux.go
@@ -106,9 +106,10 @@ func Unmount(target string, flags int) error {
 	return nil
 }
 
+// fuseSuperMagic is defined in statfs(2)
+const fuseSuperMagic = 0x65735546
+
 func isFUSE(dir string) bool {
-	// fuseSuperMagic is defined in statfs(2)
-	const fuseSuperMagic = 0x65735546
 	var st unix.Statfs_t
 	if err := unix.Statfs(dir, &st); err != nil {
 		return false
@@ -116,16 +117,26 @@ func isFUSE(dir string) bool {
 	return st.Type == fuseSuperMagic
 }
 
+// unmountFUSE attempts to unmount using fusermount/fusermount3 helper binary.
+//
+// For FUSE mounts, using these helper binaries is preferred, see:
+// https://github.com/containerd/containerd/pull/3765#discussion_r342083514
+func unmountFUSE(target string) error {
+	var err error
+	for _, helperBinary := range []string{"fusermount3", "fusermount"} {
+		cmd := exec.Command(helperBinary, "-u", target)
+		err = cmd.Run()
+		if err == nil {
+			return nil
+		}
+	}
+	return err
+}
+
 func unmount(target string, flags int) error {
-	// For FUSE mounts, attempting to execute fusermount helper binary is preferred
-	// https://github.com/containerd/containerd/pull/3765#discussion_r342083514
 	if isFUSE(target) {
-		for _, helperBinary := range []string{"fusermount3", "fusermount"} {
-			cmd := exec.Command(helperBinary, "-u", target)
-			if err := cmd.Run(); err == nil {
-				return nil
-			}
-			// ignore error and try unix.Unmount
+		if err := unmountFUSE(target); err == nil {
+			return nil
 		}
 	}
 	for i := 0; i < 50; i++ {


### PR DESCRIPTION
This function was added in https://github.com/containerd/containerd/pull/3765; the error itself was unused, so may as well remove it.