### PR TITLE
Allow to use repository scope helper function from other packages

### DIFF
--- a/remotes/docker/fetcher.go
+++ b/remotes/docker/fetcher.go
@@ -45,7 +45,7 @@ func (r dockerFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.R
 		return nil, errors.Wrap(errdefs.ErrNotFound, "no pull hosts")
 	}
 
-	ctx, err := contextWithRepositoryScope(ctx, r.refspec, false)
+	ctx, err := ContextWithRepositoryScope(ctx, r.refspec, false)
 	if err != nil {
 		return nil, err
 	}

--- a/remotes/docker/pusher.go
+++ b/remotes/docker/pusher.go
@@ -45,7 +45,7 @@ type dockerPusher struct {
 }
 
 func (p dockerPusher) Push(ctx context.Context, desc ocispec.Descriptor) (content.Writer, error) {
-	ctx, err := contextWithRepositoryScope(ctx, p.refspec, true)
+	ctx, err := ContextWithRepositoryScope(ctx, p.refspec, true)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func (p dockerPusher) Push(ctx context.Context, desc ocispec.Descriptor) (conten
 		var resp *http.Response
 		if fromRepo := selectRepositoryMountCandidate(p.refspec, desc.Annotations); fromRepo != "" {
 			preq := requestWithMountFrom(req, desc.Digest.String(), fromRepo)
-			pctx := contextWithAppendPullRepositoryScope(ctx, fromRepo)
+			pctx := ContextWithAppendPullRepositoryScope(ctx, fromRepo)
 
 			// NOTE: the fromRepo might be private repo and
 			// auth service still can grant token without error.

--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -263,7 +263,7 @@ func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocisp
 		return "", ocispec.Descriptor{}, errors.Wrap(errdefs.ErrNotFound, "no resolve hosts")
 	}
 
-	ctx, err = contextWithRepositoryScope(ctx, refspec, false)
+	ctx, err = ContextWithRepositoryScope(ctx, refspec, false)
 	if err != nil {
 		return "", ocispec.Descriptor{}, err
 	}

--- a/remotes/docker/scope.go
+++ b/remotes/docker/scope.go
@@ -26,10 +26,10 @@ import (
 	"github.com/containerd/containerd/reference"
 )
 
-// repositoryScope returns a repository scope string such as "repository:foo/bar:pull"
+// RepositoryScope returns a repository scope string such as "repository:foo/bar:pull"
 // for "host/foo/bar:baz".
 // When push is true, both pull and push are added to the scope.
-func repositoryScope(refspec reference.Spec, push bool) (string, error) {
+func RepositoryScope(refspec reference.Spec, push bool) (string, error) {
 	u, err := url.Parse("dummy://" + refspec.Locator)
 	if err != nil {
 		return "", err
@@ -45,9 +45,9 @@ func repositoryScope(refspec reference.Spec, push bool) (string, error) {
 // value: []string (e.g. {"registry:foo/bar:pull"})
 type tokenScopesKey struct{}
 
-// contextWithRepositoryScope returns a context with tokenScopesKey{} and the repository scope value.
-func contextWithRepositoryScope(ctx context.Context, refspec reference.Spec, push bool) (context.Context, error) {
-	s, err := repositoryScope(refspec, push)
+// ContextWithRepositoryScope returns a context with tokenScopesKey{} and the repository scope value.
+func ContextWithRepositoryScope(ctx context.Context, refspec reference.Spec, push bool) (context.Context, error) {
+	s, err := RepositoryScope(refspec, push)
 	if err != nil {
 		return nil, err
 	}
@@ -66,9 +66,9 @@ func WithScope(ctx context.Context, scope string) context.Context {
 	return context.WithValue(ctx, tokenScopesKey{}, scopes)
 }
 
-// contextWithAppendPullRepositoryScope is used to append repository pull
+// ContextWithAppendPullRepositoryScope is used to append repository pull
 // scope into existing scopes indexed by the tokenScopesKey{}.
-func contextWithAppendPullRepositoryScope(ctx context.Context, repo string) context.Context {
+func ContextWithAppendPullRepositoryScope(ctx context.Context, repo string) context.Context {
 	return WithScope(ctx, fmt.Sprintf("repository:%s:pull", repo))
 }
 

--- a/remotes/docker/scope_test.go
+++ b/remotes/docker/scope_test.go
@@ -50,7 +50,7 @@ func TestRepositoryScope(t *testing.T) {
 	}
 	for _, x := range testCases {
 		t.Run(x.refspec.String(), func(t *testing.T) {
-			actual, err := repositoryScope(x.refspec, x.push)
+			actual, err := RepositoryScope(x.refspec, x.push)
 			assert.NilError(t, err)
 			assert.Equal(t, x.expected, actual)
 		})
@@ -99,7 +99,7 @@ func TestGetTokenScopes(t *testing.T) {
 func TestCustomScope(t *testing.T) {
 	scope := "whatever:foo/bar:pull"
 	ctx := WithScope(context.Background(), scope)
-	ctx = contextWithAppendPullRepositoryScope(ctx, "foo/bar")
+	ctx = ContextWithAppendPullRepositoryScope(ctx, "foo/bar")
 
 	scopes := GetTokenScopes(ctx, []string{})
 	assert.Assert(t, cmp.Len(scopes, 2))


### PR DESCRIPTION
`docker.Authorizer` requires library clients to configure scope via context.
It is helpful for the clients to use the helper (currently private) function for
generating scope string and to use that function with the combination of other
scope-related ones (e.g. `docker.WithScope`).
