### PR TITLE
Enable linter checks on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.go text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,13 @@ jobs:
 
     strategy:
       matrix:
+        go-version: [1.15.2]
         os: [ubuntu-18.04, macos-10.15, windows-2019]
 
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v1
+      - uses: actions/checkout@v2
         with:
-          go-version: '1.15.2'
+          path: src/github.com/containerd/containerd
 
       - name: Set env
         shell: bash
@@ -34,22 +34,10 @@ jobs:
           echo "::set-env name=GOPATH::${{ github.workspace }}"
           echo "::add-path::${{ github.workspace }}/bin"
 
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: golangci/golangci-lint-action@v2
         with:
-          path: src/github.com/containerd/containerd
-
-      - name: Install dev tools
-        env:
-          GO111MODULE: off
-        shell: bash
-        run: script/setup/install-dev-tools
-        working-directory: src/github.com/containerd/containerd
-
-      - name: Make check
-        shell: bash
-        run: make check
-        working-directory: src/github.com/containerd/containerd
+          version: v1.29
+          working-directory: src/github.com/containerd/containerd
 
   #
   # Project checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-10.15] # TODO: pass linters on 'windows-2019'
+        os: [ubuntu-18.04, macos-10.15, windows-2019]
 
     steps:
       - name: Install Go

--- a/remotes/docker/auth/fetch.go
+++ b/remotes/docker/auth/fetch.go
@@ -106,10 +106,8 @@ func FetchTokenWithOAuth(ctx context.Context, client *http.Client, headers http.
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
-	if headers != nil {
-		for k, v := range headers {
-			req.Header[k] = append(req.Header[k], v...)
-		}
+	for k, v := range headers {
+		req.Header[k] = append(req.Header[k], v...)
 	}
 
 	resp, err := ctxhttp.Do(ctx, client, req)
@@ -152,10 +150,8 @@ func FetchToken(ctx context.Context, client *http.Client, headers http.Header, t
 		return nil, err
 	}
 
-	if headers != nil {
-		for k, v := range headers {
-			req.Header[k] = append(req.Header[k], v...)
-		}
+	for k, v := range headers {
+		req.Header[k] = append(req.Header[k], v...)
 	}
 
 	reqParams := req.URL.Query()

--- a/runtime/v2/example/example.go
+++ b/runtime/v2/example/example.go
@@ -31,8 +31,6 @@ import (
 var (
 	// check to make sure the *service implements the GRPC API
 	_ = (taskAPI.TaskService)(&service{})
-	// common response type
-	empty = &ptypes.Empty{}
 )
 
 // New returns a new shim service
@@ -121,7 +119,7 @@ func (s *service) Connect(ctx context.Context, r *taskAPI.ConnectRequest) (*task
 // Shutdown is called after the underlying resources of the shim are cleaned up and the service can be stopped
 func (s *service) Shutdown(ctx context.Context, r *taskAPI.ShutdownRequest) (*ptypes.Empty, error) {
 	os.Exit(0)
-	return empty, nil
+	return &ptypes.Empty{}, nil
 }
 
 // Stats returns container level system stats for a container and its processes


### PR DESCRIPTION
This PR:
- Enables linter checks on Windows
- Uses the Github Action for golangci-lint, so setup is a bit simpler and we have less things to manage (they also [promise](https://github.com/golangci/golangci-lint-action#performance) better performance due to caching).

This will also make linter errors more expressive:
![](https://golangci-lint.run/static/5428acac260f021b95d9edddaadca460/29114/annotations.png)
