### PR TITLE
Update test build script to push containerd variant

### DIFF
--- a/test/build.sh
+++ b/test/build.sh
@@ -42,9 +42,10 @@ trap cleanup EXIT
 
 set -x
 latest=$(readlink ./releases/cri-cni-containerd.tar.gz)
-cp releases/${latest} ${BUILDDIR}/cri-containerd.tar.gz
-cp releases/${latest}.sha256sum ${BUILDDIR}/cri-containerd.tar.gz.sha256
+tarball=$(echo ${latest} | sed -e 's/cri-containerd-cni/containerd-cni/g' | sed -e 's/-linux-amd64/.linux-amd64/g')
+cp releases/${latest} ${BUILDDIR}/${tarball}
+cp releases/${latest}.sha256sum ${BUILDDIR}/${tarball}.sha256
 
 # Push test tarball to Google cloud storage.
 VERSION=$(git describe --match 'v[0-9]*' --dirty='.m' --always)
-PUSH_VERSION=true VERSION=${VERSION} BUILD_DIR=${BUILDDIR} ${ROOT}/test/push.sh
+PUSH_VERSION=true DEPLOY_DIR='containerd' TARBALL=${tarball} VERSION=${VERSION} BUILD_DIR=${BUILDDIR} ${ROOT}/test/push.sh

--- a/test/e2e_node/gci-init.sh
+++ b/test/e2e_node/gci-init.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# This script is used to do extra initialization on GCI.
+
+mount /tmp /tmp -o remount,exec,suid
+#TODO(random-liu): Stop docker and remove this docker thing.
+usermod -a -G docker jenkins
+#TODO(random-liu): Change current node e2e to use init script,
+# so that we don't need to copy this code everywhere.
+mkdir -p /var/lib/kubelet
+mkdir -p /home/kubernetes/containerized_mounter/rootfs
+mount --bind /home/kubernetes/containerized_mounter/ /home/kubernetes/containerized_mounter/
+mount -o remount, exec /home/kubernetes/containerized_mounter/
+wget https://storage.googleapis.com/kubernetes-release/gci-mounter/mounter.tar -O /tmp/mounter.tar
+tar xvf /tmp/mounter.tar -C /home/kubernetes/containerized_mounter/rootfs
+mkdir -p /home/kubernetes/containerized_mounter/rootfs/var/lib/kubelet
+mount --rbind /var/lib/kubelet /home/kubernetes/containerized_mounter/rootfs/var/lib/kubelet
+mount --make-rshared /home/kubernetes/containerized_mounter/rootfs/var/lib/kubelet
+mount --bind /proc /home/kubernetes/containerized_mounter/rootfs/proc
+mount --bind /dev /home/kubernetes/containerized_mounter/rootfs/dev
+rm /tmp/mounter.tar

--- a/test/e2e_node/init.yaml
+++ b/test/e2e_node/init.yaml
@@ -1,0 +1,73 @@
+#cloud-config
+
+write_files:
+  - path: /etc/systemd/system/containerd-installation.service
+    permissions: 0644
+    owner: root
+    content: |
+      # installed by cloud-init
+      [Unit]
+      Description=Download and install containerd binaries and configurations.
+      After=network-online.target
+
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      ExecStartPre=/bin/mkdir -p /home/containerd
+      ExecStartPre=/bin/mount --bind /home/containerd /home/containerd
+      ExecStartPre=/bin/mount -o remount,exec /home/containerd
+      ExecStartPre=/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /home/containerd/configure.sh http://metadata.google.internal/computeMetadata/v1/instance/attributes/containerd-configure-sh
+      ExecStartPre=/bin/chmod 544 /home/containerd/configure.sh
+      ExecStart=/home/containerd/configure.sh
+
+      [Install]
+      WantedBy=containerd.target
+
+  - path: /etc/systemd/system/containerd.service
+    permissions: 0644
+    owner: root
+    content: |
+      # installed by cloud-init
+      [Unit]
+      Description=containerd container runtime
+      Documentation=https://containerd.io
+      After=containerd-installation.service
+
+      [Service]
+      Restart=always
+      RestartSec=5
+      Delegate=yes
+      KillMode=process
+      OOMScoreAdjust=-999
+      LimitNOFILE=1048576
+      # Having non-zero Limit*s causes performance problems due to accounting overhead
+      # in the kernel. We recommend using cgroups to do container-local accounting.
+      LimitNPROC=infinity
+      LimitCORE=infinity
+      TasksMax=infinity
+      ExecStartPre=/sbin/modprobe overlay
+      ExecStart=/home/containerd/usr/local/bin/containerd
+
+      [Install]
+      WantedBy=containerd.target
+
+  - path: /etc/systemd/system/containerd.target
+    permissions: 0644
+    owner: root
+    content: |
+      [Unit]
+      Description=Containerd
+
+      [Install]
+      WantedBy=multi-user.target
+
+runcmd:
+  # Stop the existing containerd service if there is one. (for Docker 18.09+)
+  - systemctl is-active containerd && systemctl stop containerd
+  - systemctl daemon-reload
+  - systemctl enable containerd-installation.service
+  - systemctl enable containerd.service
+  - systemctl enable containerd.target
+  - systemctl start containerd.target
+  # Start docker after containerd is running. (for Docker 18.09+)
+  - systemctl is-active docker || systemctl start docker


### PR DESCRIPTION
Updates the build to support the configuration used for `containerd-master` in the prow k8s tests. After this is in, `containerd-master` will be updated to use the added `e2e_node` configuration here, unblocking the failing e2e tests today which fail since cri is no longer checked out.