### PR TITLE
Cri - Pass snapshotter labels into customopts.WithNewSnapshot

### DIFF
--- a/pkg/cri/opts/container.go
+++ b/pkg/cri/opts/container.go
@@ -27,14 +27,15 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/continuity/fs"
 	"github.com/pkg/errors"
 )
 
 // WithNewSnapshot wraps `containerd.WithNewSnapshot` so that if creating the
 // snapshot fails we make sure the image is actually unpacked and and retry.
-func WithNewSnapshot(id string, i containerd.Image) containerd.NewContainerOpts {
-	f := containerd.WithNewSnapshot(id, i)
+func WithNewSnapshot(id string, i containerd.Image, opts ...snapshots.Opt) containerd.NewContainerOpts {
+	f := containerd.WithNewSnapshot(id, i, opts...)
 	return func(ctx context.Context, client *containerd.Client, c *containers.Container) error {
 		if err := f(ctx, client, c); err != nil {
 			if !errdefs.IsNotFound(err) {

--- a/pkg/cri/server/container_create.go
+++ b/pkg/cri/server/container_create.go
@@ -24,6 +24,7 @@ import (
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/oci"
+	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/typeurl"
 	"github.com/davecgh/go-spew/spew"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -180,6 +181,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 
 	log.G(ctx).Debugf("Container %q spec: %#+v", id, spew.NewFormatter(spec))
 
+	snapshotterOpt := snapshots.WithLabels(config.Annotations)
 	// Set snapshotter before any other options.
 	opts := []containerd.NewContainerOpts{
 		containerd.WithSnapshotter(c.config.ContainerdConfig.Snapshotter),
@@ -188,7 +190,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 		// the runtime (runc) a chance to modify (e.g. to create mount
 		// points corresponding to spec.Mounts) before making the
 		// rootfs readonly (requested by spec.Root.Readonly).
-		customopts.WithNewSnapshot(id, containerdImage),
+		customopts.WithNewSnapshot(id, containerdImage, snapshotterOpt),
 	}
 	if len(volumeMounts) > 0 {
 		mountMap := make(map[string]string)

--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -44,6 +44,7 @@ import (
 	"github.com/containerd/containerd/pkg/cri/util"
 	ctrdutil "github.com/containerd/containerd/pkg/cri/util"
 	"github.com/containerd/containerd/pkg/netns"
+	"github.com/containerd/containerd/snapshots"
 	selinux "github.com/opencontainers/selinux/go-selinux"
 )
 
@@ -190,9 +191,11 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to generate runtime options")
 	}
+
+	snapshotterOpt := snapshots.WithLabels(config.Annotations)
 	opts := []containerd.NewContainerOpts{
 		containerd.WithSnapshotter(c.config.ContainerdConfig.Snapshotter),
-		customopts.WithNewSnapshot(id, containerdImage),
+		customopts.WithNewSnapshot(id, containerdImage, snapshotterOpt),
 		containerd.WithSpec(spec, specOpts...),
 		containerd.WithContainerLabels(sandboxLabels),
 		containerd.WithContainerExtension(sandboxMetadataExtension, &sandbox.Metadata),

--- a/snapshots/lcow/lcow.go
+++ b/snapshots/lcow/lcow.go
@@ -346,7 +346,7 @@ func (s *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 		defer scratchSource.Close()
 
 		// TODO: JTERRY75 - This has to be called sandbox.vhdx for the time
-		// being but it really is the scratch.vhdx Using this naming convention
+		// being but it really is the scratch.vhdx. Using this naming convention
 		// for now but this is not the kubernetes sandbox.
 		//
 		// Create the sandbox.vhdx for this snapshot from the cache.
@@ -371,7 +371,7 @@ func (s *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 }
 
 func (s *snapshotter) openOrCreateScratch(ctx context.Context, sizeGB int) (_ *os.File, err error) {
-	// Create the scratch.vhdx cache file if it doesn't already exit.
+	// Create the scratch.vhdx cache file if it doesn't already exist.
 	s.scratchLock.Lock()
 	defer s.scratchLock.Unlock()
 


### PR DESCRIPTION
Previously there wwasn't a way to pass any labels to snapshotters as the wrapper
around WithNewSnapshot didn't have a param to pass them in.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>