### PR TITLE
Support AppArmor beta version format for Ubuntu 20.10

### DIFF
--- a/contrib/apparmor/apparmor_test.go
+++ b/contrib/apparmor/apparmor_test.go
@@ -1,0 +1,106 @@
+// +build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package apparmor
+
+import (
+	"testing"
+)
+
+type versionExpected struct {
+	output  string
+	version int
+}
+
+func TestParseVersion(t *testing.T) {
+	versions := []versionExpected{
+		{
+			output: `AppArmor parser version 2.10
+Copyright (C) 1999-2008 Novell Inc.
+Copyright 2009-2012 Canonical Ltd.
+`,
+			version: 210000,
+		},
+		{
+			output: `AppArmor parser version 2.8
+Copyright (C) 1999-2008 Novell Inc.
+Copyright 2009-2012 Canonical Ltd.
+`,
+			version: 208000,
+		},
+		{
+			output: `AppArmor parser version 2.20
+Copyright (C) 1999-2008 Novell Inc.
+Copyright 2009-2012 Canonical Ltd.
+`,
+			version: 220000,
+		},
+		{
+			output: `AppArmor parser version 2.05
+Copyright (C) 1999-2008 Novell Inc.
+Copyright 2009-2012 Canonical Ltd.
+`,
+			version: 205000,
+		},
+		{
+			output: `AppArmor parser version 2.9.95
+Copyright (C) 1999-2008 Novell Inc.
+Copyright 2009-2012 Canonical Ltd.
+`,
+			version: 209095,
+		},
+		{
+			output: `AppArmor parser version 3.14.159
+Copyright (C) 1999-2008 Novell Inc.
+Copyright 2009-2012 Canonical Ltd.
+`,
+			version: 314159,
+		},
+		{
+			output: `AppArmor parser version 3.0.0-beta1
+Copyright (C) 1999-2008 Novell Inc.
+Copyright 2009-2018 Canonical Ltd.
+`,
+			version: 300000,
+		},
+		{
+			output: `AppArmor parser version 3.0.0-beta1-foo-bar
+Copyright (C) 1999-2008 Novell Inc.
+Copyright 2009-2018 Canonical Ltd.
+`,
+			version: 300000,
+		},
+		{
+			output: `AppArmor parser version 2.7.0~rc2
+Copyright (C) 1999-2008 Novell Inc.
+Copyright 2009-2018 Canonical Ltd.
+`,
+			version: 207000,
+		},
+	}
+
+	for _, v := range versions {
+		version, err := parseVersion(v.output)
+		if err != nil {
+			t.Fatalf("expected error to be nil for %#v, got: %v", v, err)
+		}
+		if version != v.version {
+			t.Fatalf("expected version to be %d, was %d, for: %#v\n", v.version, version, v)
+		}
+	}
+}

--- a/contrib/apparmor/template.go
+++ b/contrib/apparmor/template.go
@@ -154,6 +154,11 @@ func parseVersion(output string) (int, error) {
 	words := strings.Split(lines[0], " ")
 	version := words[len(words)-1]
 
+	// trim "-beta1" suffix from version="3.0.0-beta1" if exists
+	version = strings.SplitN(version, "-", 2)[0]
+	// also trim tilde
+	version = strings.SplitN(version, "~", 2)[0]
+
 	// split by major minor version
 	v := strings.Split(version, ".")
 	if len(v) == 0 || len(v) > 3 {


### PR DESCRIPTION
The fix is ported from https://github.com/moby/moby/pull/41518#issue-496766512

Ubuntu 20.10 uses AppArmor 3.0.0-beta1 version.
This causes container not able to start due to invalid syntax in parsing AppArmor version.

Signed-off-by: Evan Tsai <devillordking@gmail.com>

