### PR TITLE
Filter snapshotter labels passed to wrapper of WithNewSnapshot

### DIFF
--- a/pkg/cri/server/container_create.go
+++ b/pkg/cri/server/container_create.go
@@ -181,7 +181,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 
 	log.G(ctx).Debugf("Container %q spec: %#+v", id, spew.NewFormatter(spec))
 
-	snapshotterOpt := snapshots.WithLabels(config.Annotations)
+	snapshotterOpt := snapshots.WithLabels(snapshots.FilterInheritedLabels(config.Annotations))
 	// Set snapshotter before any other options.
 	opts := []containerd.NewContainerOpts{
 		containerd.WithSnapshotter(c.config.ContainerdConfig.Snapshotter),

--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -192,7 +192,7 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		return nil, errors.Wrap(err, "failed to generate runtime options")
 	}
 
-	snapshotterOpt := snapshots.WithLabels(config.Annotations)
+	snapshotterOpt := snapshots.WithLabels(snapshots.FilterInheritedLabels(config.Annotations))
 	opts := []containerd.NewContainerOpts{
 		containerd.WithSnapshotter(c.config.ContainerdConfig.Snapshotter),
 		customopts.WithNewSnapshot(id, containerdImage, snapshotterOpt),


### PR DESCRIPTION
Made a change yesterday (https://github.com/containerd/containerd/pull/4630) that passed through snapshotter labels into the wrapper of WithNewSnapshot, but it passed the entirety of the annotations into the snapshotter. This change just filters the set that we care about down to snapshotter specific labels.

Will probably be future changes to add some more labels for LCOW/WCOW and the corresponding
behavior for these new labels.