### PR TITLE
Add CNI support to ctr run

### DIFF
--- a/cmd/ctr/commands/run/run.go
+++ b/cmd/ctr/commands/run/run.go
@@ -17,6 +17,7 @@
 package run
 
 import (
+	"context"
 	gocontext "context"
 	"encoding/csv"
 	"fmt"
@@ -28,7 +29,9 @@ import (
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/cmd/ctr/commands/tasks"
 	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
+	gocni "github.com/containerd/go-cni"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -126,9 +129,10 @@ var Command = cli.Command{
 			id  string
 			ref string
 
-			tty    = context.Bool("tty")
-			detach = context.Bool("detach")
-			config = context.IsSet("config")
+			tty       = context.Bool("tty")
+			detach    = context.Bool("detach")
+			config    = context.IsSet("config")
+			enableCNI = context.Bool("cni")
 		)
 
 		if config {
@@ -167,21 +171,42 @@ var Command = cli.Command{
 				return err
 			}
 		}
+		var network gocni.CNI
+		if enableCNI {
+			if network, err = gocni.New(gocni.WithDefaultConf); err != nil {
+				return err
+			}
+		}
+
 		opts := getNewTaskOpts(context)
 		ioOpts := []cio.Opt{cio.WithFIFODir(context.String("fifo-dir"))}
 		task, err := tasks.NewTask(ctx, client, container, context.String("checkpoint"), con, context.Bool("null-io"), context.String("log-uri"), ioOpts, opts...)
 		if err != nil {
 			return err
 		}
+
 		var statusC <-chan containerd.ExitStatus
 		if !detach {
-			defer task.Delete(ctx)
+			defer func() {
+				if enableCNI {
+					if err := network.Remove(ctx, fullID(ctx, container), ""); err != nil {
+						logrus.WithError(err).Error("network review")
+					}
+				}
+				task.Delete(ctx)
+			}()
+
 			if statusC, err = task.Wait(ctx); err != nil {
 				return err
 			}
 		}
 		if context.IsSet("pid-file") {
 			if err := commands.WritePidFile(context.String("pid-file"), int(task.Pid())); err != nil {
+				return err
+			}
+		}
+		if enableCNI {
+			if _, err := network.Setup(ctx, fullID(ctx, container), fmt.Sprintf("/proc/%d/ns/net", task.Pid())); err != nil {
 				return err
 			}
 		}
@@ -212,4 +237,13 @@ var Command = cli.Command{
 		}
 		return nil
 	},
+}
+
+func fullID(ctx context.Context, c containerd.Container) string {
+	id := c.ID()
+	ns, ok := namespaces.Namespace(ctx)
+	if !ok {
+		return id
+	}
+	return fmt.Sprintf("%s-%s", ns, id)
 }

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -68,6 +68,10 @@ var platformRunFlags = []cli.Flag{
 		Usage: "set the CFS cpu quota",
 		Value: 0.0,
 	},
+	cli.BoolFlag{
+		Name:  "cni",
+		Usage: "enable cni networking for the container",
+	},
 }
 
 // NewContainer creates a new container


### PR DESCRIPTION
This adds linux cni support to `ctr run` via a `--cni` flag.  This uses the
default configuration for CNI on `ctr` to configure the network namespace for a
container.

Signed-off-by: Michael Crosby <michael@thepasture.io>