### PR TITLE
Cleanup CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Set env
         shell: bash
         run: |
-          echo "::set-env name=GOPATH::${{ github.workspace }}"
-          echo "::add-path::${{ github.workspace }}/bin"
+          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
       - uses: golangci/golangci-lint-action@v2
         with:
@@ -48,6 +48,10 @@ jobs:
     runs-on: ubuntu-18.04
     timeout-minutes: 5
 
+    defaults:
+      run:
+        working-directory: src/github.com/containerd/containerd
+
     steps:
       #
       # Install Go
@@ -56,12 +60,6 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: '1.15.2'
-
-      - name: Set env
-        shell: bash
-        run: |
-          echo "::set-env name=GOPATH::${{ github.workspace }}"
-          echo "::add-path::${{ github.workspace }}/bin"
 
       #
       # Checkout repos
@@ -77,6 +75,12 @@ jobs:
         with:
           repository: containerd/project
           path: src/github.com/containerd/project
+
+      - name: Set env
+        shell: bash
+        run: |
+          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
       #
       # Go get dependencies
@@ -97,7 +101,6 @@ jobs:
           GITHUB_COMMIT_URL: ${{ github.event.pull_request.commits_url }}
           DCO_VERBOSITY: "-q"
           DCO_RANGE: ""
-        working-directory: src/github.com/containerd/containerd
         run: |
           set -x
           if [ -z "${GITHUB_COMMIT_URL}" ]; then
@@ -109,11 +112,9 @@ jobs:
 
       - name: Headers
         run: ../project/script/validate/fileheader ../project/
-        working-directory: src/github.com/containerd/containerd
 
       - name: Vendor
         run: ../project/script/validate/vendor
-        working-directory: src/github.com/containerd/containerd
 
   #
   # Protobuf checks
@@ -123,27 +124,27 @@ jobs:
     runs-on: ubuntu-18.04
     timeout-minutes: 5
 
+    defaults:
+      run:
+        working-directory: src/github.com/containerd/containerd
+
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v1
+      - uses: actions/setup-go@v1
         with:
           go-version: '1.15.2'
+
+      - uses: actions/checkout@v2
+        with:
+          path: src/github.com/containerd/containerd
 
       - name: Set env
         shell: bash
         run: |
-          echo "::set-env name=GOPATH::${{ github.workspace }}"
-          echo "::add-path::${{ github.workspace }}/bin"
-
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          path: src/github.com/containerd/containerd
+          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "GO111MODULE=off" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
       - name: Install protobuf
-        env:
-          GO111MODULE: off
-        working-directory: src/github.com/containerd/containerd
         run: |
           sudo env PATH=$PATH GOPATH=$GOPATH script/setup/install-protobuf
           sudo chmod +x /usr/local/bin/protoc
@@ -151,23 +152,9 @@ jobs:
           sudo chmod -R og+r /usr/local/include/google/protobuf/
           protoc --version
 
-      - name: Install dev tools
-        env:
-          GO111MODULE: off
-        run: script/setup/install-dev-tools
-        working-directory: src/github.com/containerd/containerd
-
-      - name: Check fmt
-        working-directory: src/github.com/containerd/containerd
-        run: |
-          make proto-fmt
-
-      - name: Check protos
-        env:
-          GO111MODULE: off
-        working-directory: src/github.com/containerd/containerd
-        run: |
-          make check-protos check-api-descriptors
+      - run: script/setup/install-dev-tools
+      - run: make proto-fmt
+      - run: make check-protos check-api-descriptors
 
   man:
     name: Manpages
@@ -175,27 +162,23 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v1
+      - uses: actions/setup-go@v1
         with:
           go-version: '1.15.2'
 
       - name: Set env
         shell: bash
         run: |
-          echo "::set-env name=GOPATH::${{ github.workspace }}"
-          echo "::add-path::${{ github.workspace }}/bin"
+          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
           path: src/github.com/containerd/containerd
 
-      - name: Install dependencies
-        run: GO111MODULE=on go get github.com/cpuguy83/go-md2man/v2@v2.0.0
+      - run: GO111MODULE=on go get github.com/cpuguy83/go-md2man/v2@v2.0.0
 
-      - name: Make
-        run: make man
+      - run: make man
         working-directory: src/github.com/containerd/containerd
 
   #
@@ -212,19 +195,17 @@ jobs:
         os: [ubuntu-18.04, macos-10.15, windows-2019]
 
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v1
+      - uses: actions/setup-go@v1
         with:
           go-version: '1.15.2'
 
       - name: Set env
         shell: bash
         run: |
-          echo "::set-env name=GOPATH::${{ github.workspace }}"
-          echo "::add-path::${{ github.workspace }}/bin"
+          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
           path: src/github.com/containerd/containerd
 
@@ -243,39 +224,37 @@ jobs:
     timeout-minutes: 30
     needs: [project, linters, protos, man]
 
+    defaults:
+      run:
+        shell: bash
+        working-directory: src/github.com/containerd/containerd
+
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v1
+      - uses: actions/setup-go@v1
         with:
           go-version: '1.15.2'
 
-      - name: Set env
-        shell: bash
-        run: |
-          echo "::set-env name=GOPATH::${{ github.workspace }}"
-          echo "::add-path::${{ github.workspace }}/src/github.com/containerd/containerd/bin"
-
-      - name: Checkout containerd
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
           path: src/github.com/containerd/containerd
-      - name: Checkout Microsoft/hcsshim
-        uses: actions/checkout@v2
+
+      - uses: actions/checkout@v2
         with:
           repository: Microsoft/hcsshim
           path: src/github.com/Microsoft/hcsshim
 
-      - name: Install Build Deps
-        shell: bash
+      - name: Set env
         run: |
-          cd src/github.com/containerd/containerd
-          script/setup/install-dev-tools
+          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/src/github.com/containerd/containerd/bin" >> $GITHUB_PATH
+
+      - run: script/setup/install-dev-tools
+
       - name: Binaries
-        shell: bash
+        env:
+          CGO_ENABLED: 1
         run: |
           set -o xtrace
-          export CGO_ENABLED=1
-          cd src/github.com/containerd/containerd
           mingw32-make.exe binaries
           bindir="$(pwd)"
           SHIM_COMMIT=$(grep Microsoft/hcsshim vendor.conf | awk '{print $2}')
@@ -283,20 +262,18 @@ jobs:
           git fetch --tags origin "${SHIM_COMMIT}"
           git checkout "${SHIM_COMMIT}"
           GO111MODULE=on go build -mod=vendor -o "${bindir}/containerd-shim-runhcs-v1.exe" ./cmd/containerd-shim-runhcs-v1
+
       - name: Integration 1
-        shell: bash
-        run: |
-          cd src/github.com/containerd/containerd
-          export CGO_ENABLED=1
-          mingw32-make.exe integration
+        env:
+          CGO_ENABLED: 1
+        run: mingw32-make.exe integration
+
       # Run the integration suite a second time. See discussion in github.com/containerd/containerd/pull/175
       - name: Integration 2
-        shell: bash
-        run: |
-          cd src/github.com/containerd/containerd
-          export TESTFLAGS_PARALLEL=1
-          export CGO_ENABLED=1
-          mingw32-make.exe integration
+        env:
+          TESTFLAGS_PARALLEL: 1
+          CGO_ENABLED: 1
+        run: mingw32-make.exe integration
 
   integration-linux:
     name: Linux Integration
@@ -315,13 +292,11 @@ jobs:
             runc: crun
 
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v1
+      - uses: actions/setup-go@v1
         with:
           go-version: '1.15.2'
 
       - name: Setup gosu
-        shell: bash
         run: |
           GOSU=/usr/local/bin/gosu
           arch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"
@@ -330,16 +305,14 @@ jobs:
           sudo chown root ${GOSU}
           sudo chmod +s ${GOSU}
 
-      - name: Set env
-        shell: bash
-        run: |
-          echo "::set-env name=GOPATH::${{ github.workspace }}"
-          echo "::add-path::${{ github.workspace }}/bin"
-
-      - name: Checkout containerd
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
           path: src/github.com/containerd/containerd
+
+      - name: Set env
+        run: |
+          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
       - name: Install containerd dependencies
         env:
@@ -427,11 +400,9 @@ jobs:
         # We can enable crun again when we get a better CI infra.
         runc: [runc]
     steps:
-      - name: Checkout containerd
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-      - name: Start vagrant
-        run: vagrant up
+      - run: vagrant up
 
       - name: Integration
         env:


### PR DESCRIPTION
`echo "::set-env name=GOPATH::${{ github.workspace }}"` is now [deprecated](https://github.com/containerd/containerd/runs/1260889026?check_suite_focus=true#step:3:5) on Github, so this updates script to use the suggested one `echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV`

Also this PR does some cleanup to avoid code repetition.

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>