### PR TITLE
Zero out buildid to make builds reproducible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ else
 endif
 
 ifndef GODEBUG
-	EXTRA_LDFLAGS += -s -w
+	EXTRA_LDFLAGS += -s -w -buildid=
 	DEBUG_GO_GCFLAGS :=
 	DEBUG_TAGS :=
 else


### PR DESCRIPTION
Whilst working on the [reproducible-builds](https://reproducible-builds.org) effort, I saw that `containerd` couldn't be built reproducibly. On further investigation and hints from https://github.com/golang/go/issues/34186#issuecomment-529390306, it appears that zeroing out `buildid` by setting `-buildid=` does help here.

I hope this does make sense (or we can work out something) so that I can upload the same patch to Debian to make the builds reproducible there as well.

Let me know what you think?

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>