### PR TITLE
Check if a process exists before returning it

### DIFF
--- a/runtime/v2/shim.go
+++ b/runtime/v2/shim.go
@@ -441,10 +441,14 @@ func (s *shim) Stats(ctx context.Context) (*ptypes.Any, error) {
 }
 
 func (s *shim) Process(ctx context.Context, id string) (runtime.Process, error) {
-	return &process{
+	p := &process{
 		id:   id,
 		shim: s,
-	}, nil
+	}
+	if _, err := p.State(ctx); err != nil {
+		return nil, err
+	}
+	return p, nil
 }
 
 func (s *shim) State(ctx context.Context) (runtime.State, error) {


### PR DESCRIPTION
Fixes #4632. See also https://github.com/containerd/containerd/commit/8e598fcb21a41dcdb28046981d69ef1fda171112 for an identical fix made on runc runtime v1.

This does not come with a test, as I don't have enough context to write one, but I'd be happy to add one with some help from the team. FWIW this makes [this test](https://github.com/cloudfoundry/guardian/blob/master/rundmc/runcontainerd/nerd/nerd_linux_test.go#L391-L396) on Garden pass, even after removing [the workaround](https://github.com/cloudfoundry/guardian/blob/3da697a62154c6d1f797aede3a0fb23f2297e6cd/rundmc/runcontainerd/nerd/nerd.go#L222-L234) we have in place at the moment.