### PR TITLE
[release/1.4] cherry-pick: Check if a process exists before returning it

### DIFF
--- a/runtime/v2/shim.go
+++ b/runtime/v2/shim.go
@@ -433,10 +433,14 @@ func (s *shim) Stats(ctx context.Context) (*ptypes.Any, error) {
 }
 
 func (s *shim) Process(ctx context.Context, id string) (runtime.Process, error) {
-	return &process{
+	p := &process{
 		id:   id,
 		shim: s,
-	}, nil
+	}
+	if _, err := p.State(ctx); err != nil {
+		return nil, err
+	}
+	return p, nil
 }
 
 func (s *shim) State(ctx context.Context) (runtime.State, error) {


### PR DESCRIPTION
Cherry-pick #4645 for `release/1.4`

Signed-off-by: Giuseppe Capizzi <gcapizzi@pivotal.io>
Co-authored-by: Danail Branekov <danailster@gmail.com>
(cherry picked from commit 8eda32e10780dc1adabc2c40f7295d4638d8915d)