### PR TITLE
Improve image pull performance from http 1.1 container registries

### DIFF
--- a/content/helpers.go
+++ b/content/helpers.go
@@ -230,6 +230,15 @@ func seekReader(r io.Reader, offset, size int64) (io.Reader, error) {
 }
 
 func copyWithBuffer(dst io.Writer, src io.Reader) (written int64, err error) {
+	// If the reader has a WriteTo method, use it to do the copy.
+	// Avoids an allocation and a copy.
+	if wt, ok := src.(io.WriterTo); ok {
+		return wt.WriteTo(dst)
+	}
+	// Similarly, if the writer has a ReadFrom method, use it to do the copy.
+	if rt, ok := dst.(io.ReaderFrom); ok {
+		return rt.ReadFrom(src)
+	}
 	bufRef := bufPool.Get().(*[]byte)
 	defer bufPool.Put(bufRef)
 	buf := *bufRef

--- a/content/helpers.go
+++ b/content/helpers.go
@@ -229,6 +229,10 @@ func seekReader(r io.Reader, offset, size int64) (io.Reader, error) {
 	return r, nil
 }
 
+// copyWithBuffer is very similar to  io.CopyBuffer https://golang.org/pkg/io/#CopyBuffer
+// but instead of using Read to read from the src, we use ReadAtLeast to make sure we have
+// a full buffer before we do a write operation to dst to reduce overheads associated
+// with the write operations of small buffers.
 func copyWithBuffer(dst io.Writer, src io.Reader) (written int64, err error) {
 	// If the reader has a WriteTo method, use it to do the copy.
 	// Avoids an allocation and a copy.
@@ -259,6 +263,8 @@ func copyWithBuffer(dst io.Writer, src io.Reader) (written int64, err error) {
 			}
 		}
 		if er != nil {
+			// If an EOF happens after reading fewer than the requested bytes,
+			// ReadAtLeast returns ErrUnexpectedEOF.
 			if er != io.EOF && er != io.ErrUnexpectedEOF {
 				err = er
 			}


### PR DESCRIPTION
Private registries that does not support http 2.0 such as Azure Container Registry streams back content in a max of 16KB chunks (max TLS record size). The small chunks introduce an overhead when copying the layers to the content store sine each chunk incurs the overhead of  grpc message that has to be sent to the content store.

This change reduces this overhead by buffering the chunks into 1MB chunks and only then writes a message to the content store.

Below is a per comparsion between the 2 approaches using a couple of large images that are being pulled from the docker hub (http 2.0) and a private Azure CR (http 1.1) in seconds.

image                                                   | Buffered copy | master
-------                                                 |---------------|----------
docker.io/pytorch/pytorch:latest                        |  55.63        | 58.33
docker.io/nvidia/cuda:latest                            |  72.05        | 75.98
containerdpulltest.azurecr.io/pytorch/pytorch:latest    | 61.45         | 77.1
containerdpulltest.azurecr.io/nvidia/cuda:latest        | 77.13         | 85.47

![image](https://user-images.githubusercontent.com/1451116/97135697-46d0c480-170e-11eb-9224-e05220f100b5.png)


## Test setup:
* Cloud: Azure
* OS: Linux
* VM Size: Standard_DS13_v2 
* Disk Size: 128GB
* VM location: West US
* Private ACR Location: West US

Signed-off-by: Amr Mahdi <amramahdi@gmail.com>