### PR TITLE
[release/1.4] cherry-pick: Read trailing data from tar reader

### DIFF
--- a/diff/lcow/lcow.go
+++ b/diff/lcow/lcow.go
@@ -21,6 +21,7 @@ package lcow
 import (
 	"context"
 	"io"
+	"io/ioutil"
 	"os"
 	"path"
 	"time"
@@ -162,6 +163,11 @@ func (s windowsLcowDiff) Apply(ctx context.Context, desc ocispec.Descriptor, mou
 		return emptyDesc, errors.Wrapf(err, "failed to sync tar2ext4 vhd to disk")
 	}
 	outFile.Close()
+
+	// Read any trailing data
+	if _, err := io.Copy(ioutil.Discard, rc); err != nil {
+		return emptyDesc, err
+	}
 
 	err = security.GrantVmGroupAccess(layerPath)
 	if err != nil {


### PR DESCRIPTION
Cherry-pick #4628 for `release/1.4`.

Not reading all the data from the tar reader causes the
layer digest mismatch which causes failures during unpack
of certain images for lcow. This changes fixes that.

Signed-off-by: Amit Barve <ambarve@microsoft.com>
(cherry picked from commit d3b817b95c39d44b94346fa4da3476157f255b91)
Signed-off-by: Kevin Parsons <kevpar@microsoft.com>