### PR TITLE
use proper buffer size for content get

### DIFF
--- a/cmd/ctr/commands/content/content.go
+++ b/cmd/ctr/commands/content/content.go
@@ -78,7 +78,9 @@ var (
 			}
 			defer ra.Close()
 
-			_, err = io.Copy(os.Stdout, content.NewReader(ra))
+			// use 1MB buffer like we do for ingesting
+			buf := make([]byte, 1<<20)
+			_, err = io.CopyBuffer(os.Stdout, content.NewReader(ra), buf)
 			return err
 		},
 	}


### PR DESCRIPTION
The command-line `ctr content get` uses `io.Copy()`, with the default buffer size of 32KB. This creates significant slow-downs on large files, as the grpc overhead must be incurred with each 32KB chunk. 

This PR changes it to 1MB (1<<20), which is what we use for ingesting content, using `io.CopyBuffer()` instead.

I ran 10 tests on a 1.0GB file, `ctr content get` each with and without the change (yeah, I probably should do a proper go benchmark with hundreds of iterations; if people insist, I can, but it seems unnecessary for such a small change). In all cases I sent the results to `/dev/null`, to avoid any potential issues with disk writes.

* Average before: 13.752s
* Average after: 2.678s

I was rather blown away by the results.
Obviously, little difference on blobs not much bigger than 32KB, no difference at all on blobs 32KB or smaller.

Discussed with @dmcgowan and @estesp on Slack.