### PR TITLE
Update make snapshot annotations disabled by default

### DIFF
--- a/pkg/cri/config/config_unix.go
+++ b/pkg/cri/config/config_unix.go
@@ -43,6 +43,7 @@ func DefaultConfig() PluginConfig {
 					Options: new(toml.Primitive),
 				},
 			},
+			DisableSnapshotAnnotations: true,
 		},
 		DisableTCPService:    true,
 		StreamServerAddress:  "127.0.0.1",


### PR DESCRIPTION
This experimental feature should not be enabled by default as it is not used by any default snapshotters.

For 1.5 we have discussed other ways to handle storing this information rather than continuing to grow the number of labels.

This should also be backported to 1.4 along with the regression fix for labels over the size limit (https://github.com/containerd/cri/pull/1572)