### PR TITLE
WithLease: shorten the expire time of lease

### DIFF
--- a/lease.go
+++ b/lease.go
@@ -38,7 +38,7 @@ func (c *Client) WithLease(ctx context.Context, opts ...leases.Opt) (context.Con
 		// Use default lease configuration if no options provided
 		opts = []leases.Opt{
 			leases.WithRandomID(),
-			leases.WithExpiration(24 * time.Hour),
+			leases.WithExpiration(2 * time.Hour),
 		}
 	}
 


### PR DESCRIPTION
Some pods use huge images and kubelet always canceled the ImagePull requests.
Even if the kubelet uses backoff to handle retry, the expired time of lease
is 24 hours. With multiple times of retry, the downloaded blob data has been
hold by many more leases. If the host has disk pressure, the kubelet can't
remove image actually because the blob is still hold by lease. Just in case,
shorten the expire time of lease to 2 hours.

Signed-off-by: Wei Fu <fuweid89@gmail.com>