### PR TITLE
Remove Windows container stats from a linux-only ctr command

### DIFF
--- a/cmd/ctr/commands/tasks/metrics.go
+++ b/cmd/ctr/commands/tasks/metrics.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"text/tabwriter"
 
-	wstats "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats"
 	v1 "github.com/containerd/cgroups/stats/v1"
 	v2 "github.com/containerd/cgroups/v2/stats"
 	"github.com/containerd/containerd/cmd/ctr/commands"
@@ -80,19 +79,16 @@ var metricsCommand = cli.Command{
 			return err
 		}
 		var (
-			data         *v1.Metrics
-			data2        *v2.Metrics
-			windowsStats *wstats.Statistics
+			data  *v1.Metrics
+			data2 *v2.Metrics
 		)
 		switch v := anydata.(type) {
 		case *v1.Metrics:
 			data = v
 		case *v2.Metrics:
 			data2 = v
-		case *wstats.Statistics:
-			windowsStats = v
 		default:
-			return errors.New("cannot convert metric data to cgroups.Metrics or windows.Statistics")
+			return errors.New("cannot convert metric data to cgroups.Metrics")
 		}
 
 		switch context.String(formatFlag) {
@@ -104,16 +100,6 @@ var metricsCommand = cli.Command{
 				printCgroupMetricsTable(w, data)
 			} else if data2 != nil {
 				printCgroup2MetricsTable(w, data2)
-			} else {
-				if windowsStats.GetLinux() != nil {
-					printCgroupMetricsTable(w, windowsStats.GetLinux())
-				} else if windowsStats.GetWindows() != nil {
-					printWindowsContainerStatistics(w, windowsStats.GetWindows())
-				}
-				// Print VM stats if its isolated
-				if windowsStats.VM != nil {
-					printWindowsVMStatistics(w, windowsStats.VM)
-				}
 			}
 			return w.Flush()
 		case formatJSON:
@@ -165,46 +151,5 @@ func printCgroup2MetricsTable(w *tabwriter.Writer, data *v2.Metrics) {
 		fmt.Fprintf(w, "memory.usage_limit\t%v\t\n", data.Memory.UsageLimit)
 		fmt.Fprintf(w, "memory.swap_usage\t%v\t\n", data.Memory.SwapUsage)
 		fmt.Fprintf(w, "memory.swap_limit\t%v\t\n", data.Memory.SwapLimit)
-	}
-}
-
-func printWindowsContainerStatistics(w *tabwriter.Writer, stats *wstats.WindowsContainerStatistics) {
-	fmt.Fprintf(w, "METRIC\tVALUE\t\n")
-	fmt.Fprintf(w, "timestamp\t%s\t\n", stats.Timestamp)
-	fmt.Fprintf(w, "start_time\t%s\t\n", stats.ContainerStartTime)
-	fmt.Fprintf(w, "uptime_ns\t%d\t\n", stats.UptimeNS)
-	if stats.Processor != nil {
-		fmt.Fprintf(w, "cpu.total_runtime_ns\t%d\t\n", stats.Processor.TotalRuntimeNS)
-		fmt.Fprintf(w, "cpu.runtime_user_ns\t%d\t\n", stats.Processor.RuntimeUserNS)
-		fmt.Fprintf(w, "cpu.runtime_kernel_ns\t%d\t\n", stats.Processor.RuntimeKernelNS)
-	}
-	if stats.Memory != nil {
-		fmt.Fprintf(w, "memory.commit_bytes\t%d\t\n", stats.Memory.MemoryUsageCommitBytes)
-		fmt.Fprintf(w, "memory.commit_peak_bytes\t%d\t\n", stats.Memory.MemoryUsageCommitPeakBytes)
-		fmt.Fprintf(w, "memory.private_working_set_bytes\t%d\t\n", stats.Memory.MemoryUsagePrivateWorkingSetBytes)
-	}
-	if stats.Storage != nil {
-		fmt.Fprintf(w, "storage.read_count_normalized\t%d\t\n", stats.Storage.ReadCountNormalized)
-		fmt.Fprintf(w, "storage.read_size_bytes\t%d\t\n", stats.Storage.ReadSizeBytes)
-		fmt.Fprintf(w, "storage.write_count_normalized\t%d\t\n", stats.Storage.WriteCountNormalized)
-		fmt.Fprintf(w, "storage.write_size_bytes\t%d\t\n", stats.Storage.WriteSizeBytes)
-	}
-}
-
-func printWindowsVMStatistics(w *tabwriter.Writer, stats *wstats.VirtualMachineStatistics) {
-	fmt.Fprintf(w, "METRIC\tVALUE\t\n")
-	if stats.Processor != nil {
-		fmt.Fprintf(w, "vm.cpu.total_runtime_ns\t%d\t\n", stats.Processor.TotalRuntimeNS)
-	}
-	if stats.Memory != nil {
-		fmt.Fprintf(w, "vm.memory.working_set_bytes\t%d\t\n", stats.Memory.WorkingSetBytes)
-		fmt.Fprintf(w, "vm.memory.virtual_node_count\t%d\t\n", stats.Memory.VirtualNodeCount)
-		fmt.Fprintf(w, "vm.memory.available\t%d\t\n", stats.Memory.VmMemory.AvailableMemory)
-		fmt.Fprintf(w, "vm.memory.available_buffer\t%d\t\n", stats.Memory.VmMemory.AvailableMemoryBuffer)
-		fmt.Fprintf(w, "vm.memory.reserved\t%d\t\n", stats.Memory.VmMemory.ReservedMemory)
-		fmt.Fprintf(w, "vm.memory.assigned\t%d\t\n", stats.Memory.VmMemory.AssignedMemory)
-		fmt.Fprintf(w, "vm.memory.slp_active\t%t\t\n", stats.Memory.VmMemory.SlpActive)
-		fmt.Fprintf(w, "vm.memory.balancing_enabled\t%t\t\n", stats.Memory.VmMemory.BalancingEnabled)
-		fmt.Fprintf(w, "vm.memory.dm_operation_in_progress\t%t\t\n", stats.Memory.VmMemory.DmOperationInProgress)
 	}
 }


### PR DESCRIPTION
Reverts 37b56cafc (#3775)

File `cmd/ctr/commands/tasks/metrics.go` is used only on Linux (it has `// +build linux`) but support for Windows container stats was added.