### PR TITLE
CRI: Drop effective and permitted cap for non-root user.

### DIFF
--- a/integration/images/private-workdir/Dockerfile
+++ b/integration/images/private-workdir/Dockerfile
@@ -1,0 +1,20 @@
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+FROM busybox
+
+RUN mkdir /workdir
+RUN chmod 700 /workdir
+RUN chown nobody /workdir
+WORKDIR /workdir

--- a/integration/images/private-workdir/Makefile
+++ b/integration/images/private-workdir/Makefile
@@ -1,0 +1,27 @@
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+all: build
+
+PROJ=gcr.io/k8s-cri-containerd
+VERSION=1.0
+IMAGE=$(PROJ)/private-workdir:$(VERSION)
+
+build:
+	docker build -t $(IMAGE) .
+
+push:
+	gcloud docker -- push $(IMAGE)
+
+.PHONY: build push

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -252,6 +252,19 @@ func WithSupplementalGroups(gids []int64) ContainerOpts {
 	}
 }
 
+// WithRunAsUser adds RunAsUser uid.
+func WithRunAsUser(uid int64) ContainerOpts {
+	return func(c *runtime.ContainerConfig) {
+		if c.Linux == nil {
+			c.Linux = &runtime.LinuxContainerConfig{}
+		}
+		if c.Linux.SecurityContext == nil {
+			c.Linux.SecurityContext = &runtime.LinuxContainerSecurityContext{}
+		}
+		c.Linux.SecurityContext.RunAsUser = &runtime.Int64Value{Value: uid}
+	}
+}
+
 // ContainerConfig creates a container config given a name and image name
 // and additional container config options
 func ContainerConfig(name, image string, opts ...ContainerOpts) *runtime.ContainerConfig {

--- a/integration/non_root_user_cap_test.go
+++ b/integration/non_root_user_cap_test.go
@@ -67,7 +67,7 @@ func TestNonRootUserCap(t *testing.T) {
 			cnConfig := ContainerConfig(
 				containerName,
 				testImage,
-				WithCommand("ls", "."),
+				WithCommand("touch", "./foo"),
 				WithLogPath(containerName),
 				WithRunAsUser(test.uid),
 			)

--- a/integration/non_root_user_cap_test.go
+++ b/integration/non_root_user_cap_test.go
@@ -66,7 +66,7 @@ func TestNonRootUserCap(t *testing.T) {
 			cnConfig := ContainerConfig(
 				containerName,
 				testImage,
-				WithCommand("ls", "/"),
+				WithCommand("ls", "."),
 				WithLogPath(containerName),
 				WithRunAsUser(test.uid),
 			)

--- a/integration/non_root_user_cap_test.go
+++ b/integration/non_root_user_cap_test.go
@@ -1,0 +1,84 @@
+// +build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func TestNonRootUserCap(t *testing.T) {
+	for name, test := range map[string]struct {
+		uid     int64
+		startOK bool
+	}{
+		"shouldn't be able to run test container, with a private workdir that is accessible to nobody, as non-root user": {
+			uid:     1234,
+			startOK: false,
+		},
+		"should be able to run test container, with a private workdir that is accessible to nobody, as root user": {
+			uid:     0,
+			startOK: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Log("Create a sandbox")
+			sbConfig := PodSandboxConfig("sandbox", "non-root-user-cap")
+			sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
+			require.NoError(t, err)
+			// Make sure the sandbox is cleaned up.
+			defer func() {
+				assert.NoError(t, runtimeService.StopPodSandbox(sb))
+				assert.NoError(t, runtimeService.RemovePodSandbox(sb))
+			}()
+
+			const (
+				testImage     = "gcr.io/k8s-cri-containerd/private-workdir:1.0"
+				containerName = "test-container"
+			)
+			t.Logf("Pull test image %q", testImage)
+			img, err := imageService.PullImage(&runtime.ImageSpec{Image: testImage}, nil, sbConfig)
+			require.NoError(t, err)
+			defer func() {
+				assert.NoError(t, imageService.RemoveImage(&runtime.ImageSpec{Image: img}))
+			}()
+
+			t.Log("Create a container to test capabilities")
+			cnConfig := ContainerConfig(
+				containerName,
+				testImage,
+				WithCommand("ls", "/"),
+				WithLogPath(containerName),
+				WithRunAsUser(test.uid),
+			)
+			cn, err := runtimeService.CreateContainer(sb, cnConfig, sbConfig)
+			require.NoError(t, err)
+
+			t.Log("Start the container")
+			if test.startOK {
+				require.NoError(t, runtimeService.StartContainer(cn))
+			} else {
+				require.Error(t, runtimeService.StartContainer(cn))
+			}
+		})
+	}
+}

--- a/pkg/cri/opts/spec_linux.go
+++ b/pkg/cri/opts/spec_linux.go
@@ -375,10 +375,11 @@ func WithCapabilities(sc *runtime.LinuxContainerSecurityContext) oci.SpecOpts {
 //
 // This option should be after options for setting users and capabilities.
 func WithCapDropForNonRootUser(_ context.Context, _ oci.Client, _ *containers.Container, s *runtimespec.Spec) error {
-	if s.Process != nil && s.Process.User.UID != 0 && s.Process.Capabilities != nil {
+	// TODO: TEMP FOR TESTING: don't actually do this, so we can verify that integration tests fail in CI environments
+	/*if s.Process != nil && s.Process.User.UID != 0 && s.Process.Capabilities != nil {
 		s.Process.Capabilities.Effective = []string{}
 		s.Process.Capabilities.Permitted = []string{}
-	}
+	}*/
 	return nil
 }
 

--- a/pkg/cri/server/container_create_linux.go
+++ b/pkg/cri/server/container_create_linux.go
@@ -319,6 +319,9 @@ func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageCon
 	if seccompSpecOpts != nil {
 		specOpts = append(specOpts, seccompSpecOpts)
 	}
+
+	// Add this at the end to make sure that capabilities and users have both been set.
+	specOpts = append(specOpts, customopts.WithCapDropForNonRootUser)
 	return specOpts, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Benjamin Elder <bentheelder@google.com>

NOTE: this is a carry of https://github.com/containerd/cri/pull/1397
- I have reworked the headers / paths etc. to match the current state of merging in cri-containerd.
- I have also addressed the outstanding review comments.

We still see users bitten by testing with KIND where the lack of capability drop causes an image / pod to work that will not work on dockerd, e.g. https://github.com/tektoncd/pipeline/issues/3273

This could cause breakage for users unaware of this, but AIUI they should not have been relying on ambient caps.
It's particularly easy to do with filesystem permissions in the image though (as in the integration test here).

xref: https://github.com/kubernetes-sigs/kind/issues/1331 