### PR TITLE
config path option to ctr for runtime

### DIFF
--- a/cmd/ctr/commands/commands.go
+++ b/cmd/ctr/commands/commands.go
@@ -123,6 +123,10 @@ var (
 			Usage: "runtime name",
 			Value: defaults.DefaultRuntime,
 		},
+		cli.StringFlag{
+			Name:  "runtime-config-path",
+			Usage: "optional runtime config path",
+		},
 		cli.BoolFlag{
 			Name:  "tty,t",
 			Usage: "allocate a TTY for the container",

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -30,6 +30,7 @@ import (
 	"github.com/containerd/containerd/contrib/nvidia"
 	"github.com/containerd/containerd/contrib/seccomp"
 	"github.com/containerd/containerd/oci"
+	crioptions "github.com/containerd/containerd/pkg/cri/runtimeoptions/v1"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -300,6 +301,12 @@ func getRuntimeOptions(context *cli.Context) (interface{}, error) {
 
 	if context.String("runtime") == "io.containerd.runc.v2" {
 		return getRuncOptions(context)
+	}
+
+	if configPath := context.String("runtime-config-path"); configPath != "" {
+		return &crioptions.Options{
+			ConfigPath: configPath,
+		}, nil
 	}
 
 	return nil, nil


### PR DESCRIPTION
This adds an option to pass the config path for an external runtime via `runtime-config-path`.

Signed-off-by: Evan Hazlett <ejhazlett@gmail.com>