### PR TITLE
Check if response has unformatted error details

### DIFF
--- a/remotes/docker/errcode.go
+++ b/remotes/docker/errcode.go
@@ -254,7 +254,7 @@ func (errs Errors) MarshalJSON() ([]byte, error) {
 // Error or ErrorCode
 func (errs *Errors) UnmarshalJSON(data []byte) error {
 	var tmpErrs struct {
-		Errors []Error
+		Errors []Error `json:"errors"`
 	}
 
 	if err := json.Unmarshal(data, &tmpErrs); err != nil {

--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -299,7 +299,7 @@ func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocisp
 				if resp.StatusCode == http.StatusNotFound {
 					continue
 				}
-				return "", ocispec.Descriptor{}, errors.Errorf("unexpected status code %v: %v", u, resp.Status)
+				return "", ocispec.Descriptor{}, getResponseErr(ctx, req, resp)
 			}
 			size := resp.ContentLength
 			contentType := getManifestMediaType(resp)


### PR DESCRIPTION
In some cases a registry may not return a formaatted message, in this
case try to get error details from the response body as a simple string.

Closes #4672