### PR TITLE
[release/1.4] cherry-pick: Update make snapshot annotations disabled by default

### DIFF
--- a/vendor/github.com/containerd/cri/pkg/config/config_unix.go
+++ b/vendor/github.com/containerd/cri/pkg/config/config_unix.go
@@ -43,6 +43,7 @@ func DefaultConfig() PluginConfig {
 					Options: new(toml.Primitive),
 				},
 			},
+			DisableSnapshotAnnotations: true,
 		},
 		DisableTCPService:    true,
 		StreamServerAddress:  "127.0.0.1",


### PR DESCRIPTION
This experimental feature should not be enabled by default as
it is not used by any default snapshotters.

Signed-off-by: Derek McGowan <derek@mcg.dev>
(cherry picked from commit b2642458f984183cc5310d0b1f47a030d4371c6e)

Cherry pick #4665 