### PR TITLE
[release/1.4] Re-vendor CRI to get disabled annotation config default

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -57,7 +57,7 @@ gotest.tools/v3                                     v3.0.2
 github.com/cilium/ebpf                              1c8d4c9ef7759622653a1d319284a44652333b28
 
 # cri dependencies
-github.com/containerd/cri                           4e6644c8cf7fb825f62e0007421b7d83dfeab5a1 # master
+github.com/containerd/cri                           61363b3e2c97ba2d389dc774d977fc906591a6fd # release/1.4
 github.com/davecgh/go-spew                          v1.1.1
 github.com/docker/docker                            4634ce647cf2ce2c6031129ccd109e557244986f
 github.com/docker/spdystream                        449fdfce4d962303d702fec724ef0ad181c92528

--- a/vendor/github.com/containerd/cri/README.md
+++ b/vendor/github.com/containerd/cri/README.md
@@ -1,16 +1,24 @@
+# Moved to [`github.com/containerd/containerd/pkg/cri`](https://github.com/containerd/containerd/tree/master/pkg/cri)
+
+On October 7, 2020, the contents of this repo were merged into [the `containerd/containerd` repo](https://github.com/containerd/cri).
+For example, the source code previously stored under [`containerd/cri/pkg`](https://github.com/containerd/cri/tree/release/1.4/pkg)
+was moved to [`containerd/containerd/pkg/cri` package](https://github.com/containerd/containerd/tree/master/pkg/cri).
+
+**Pull requests are no longer accepted in the master branch of this repo.**
+
+Bug-fix PRs for `release/1.3` and `release/1.4` branches are still accepted in this repo.
+However, the master branch for `containerd/cri` integration work is now located in the `containerd/containerd` repository,
+and as such new commits should be merged there.
+
+This repo will be archived after the EOL of containerd 1.4.
+
+- - -
+
 # cri
 <p align="center">
 <img src="https://kubernetes.io/images/favicon.png" width="50" height="50">
 <img src="https://containerd.io/img/logos/icon/black/containerd-icon-black.png" width="50" >
 </p>
-
-*Note: The standalone `cri-containerd` binary is end-of-life. `cri-containerd` is
-transitioning from a standalone binary that talks to containerd to a plugin within
-containerd. This github branch is for the `cri` plugin. See
-[standalone-cri-containerd branch](https://github.com/containerd/cri/tree/standalone-cri-containerd)
-for information about the standalone version of `cri-containerd`.*
-
-*Note: You need to [drain your node](https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/) before upgrading from standalone `cri-containerd` to containerd with `cri` plugin.*
 
 [![Build Status](https://api.travis-ci.org/containerd/cri.svg?style=flat-square)](https://travis-ci.org/containerd/cri)
 [![Go Report Card](https://goreportcard.com/badge/github.com/containerd/cri)](https://goreportcard.com/report/github.com/containerd/cri)
@@ -36,8 +44,9 @@ See [test dashboard](https://k8s-testgrid.appspot.com/sig-node-containerd)
 |     v1.0.0-alpha.x     |                    |      1.7, 1.8      |   v1alpha1  |
 |      v1.0.0-beta.x     |                    |        1.9         |   v1alpha1  |
 |       End-Of-Life      | v1.1 (End-Of-Life) |        1.10+       |   v1alpha2  |
-|                        |        v1.2        |        1.10+       |   v1alpha2  |
+|                        |  v1.2 (Extended)   |        1.10+       |   v1alpha2  |
 |                        |        v1.3        |        1.12+       |   v1alpha2  |
+|                        |        v1.4        |      1.19+ (rc)    |   v1alpha2  |
 
 **Note:** The support table above specifies the Kubernetes Version that was supported at time of release of the containerd - cri integration.
 
@@ -45,8 +54,9 @@ The following is the current support table for containerd CRI integration taking
 
 | Containerd Version | Kubernetes Version | CRI Version |
 |:------------------:|:------------------:|:-----------:|
-|        v1.2        |        1.14+       |   v1alpha2  |
-|        v1.3        |        1.14+       |   v1alpha2  |
+|        v1.2        |        1.15+       |   v1alpha2  |
+|        v1.3        |        1.15+       |   v1alpha2  |
+|        v1.4        |      1.19+ (rc)    |   v1alpha2  |
 
 ## Production Quality Cluster on GCE
 For a production quality cluster on GCE brought up with `kube-up.sh` refer [here](docs/kube-up.md).

--- a/vendor/github.com/containerd/cri/pkg/config/config_unix.go
+++ b/vendor/github.com/containerd/cri/pkg/config/config_unix.go
@@ -43,6 +43,7 @@ func DefaultConfig() PluginConfig {
 					Options: new(toml.Primitive),
 				},
 			},
+			DisableSnapshotAnnotations: true,
 		},
 		DisableTCPService:    true,
 		StreamServerAddress:  "127.0.0.1",

--- a/vendor/github.com/containerd/cri/pkg/server/container_create_unix.go
+++ b/vendor/github.com/containerd/cri/pkg/server/container_create_unix.go
@@ -182,11 +182,15 @@ func (c *criService) containerSpec(id string, sandboxID string, sandboxPid uint3
 	if !c.config.DisableProcMount {
 		// Apply masked paths if specified.
 		// If the container is privileged, this will be cleared later on.
-		specOpts = append(specOpts, oci.WithMaskedPaths(securityContext.GetMaskedPaths()))
+		if maskedPaths := securityContext.GetMaskedPaths(); maskedPaths != nil {
+			specOpts = append(specOpts, oci.WithMaskedPaths(maskedPaths))
+		}
 
 		// Apply readonly paths if specified.
 		// If the container is privileged, this will be cleared later on.
-		specOpts = append(specOpts, oci.WithReadonlyPaths(securityContext.GetReadonlyPaths()))
+		if readonlyPaths := securityContext.GetReadonlyPaths(); readonlyPaths != nil {
+			specOpts = append(specOpts, oci.WithReadonlyPaths(readonlyPaths))
+		}
 	}
 
 	if securityContext.GetPrivileged() {

--- a/vendor/github.com/containerd/cri/vendor.conf
+++ b/vendor/github.com/containerd/cri/vendor.conf
@@ -2,7 +2,7 @@
 github.com/docker/docker                            4634ce647cf2ce2c6031129ccd109e557244986f
 github.com/opencontainers/selinux                   v1.6.0
 github.com/tchap/go-patricia                        v2.2.6
-github.com/willf/bitset                             d5bec3311243426a3c6d1b7a795f24b17c686dbb # 1.1.10+ used by selinux pkg
+github.com/willf/bitset                             v1.1.11
 
 # containerd dependencies
 github.com/beorn7/perks                             v1.0.1
@@ -10,7 +10,7 @@ github.com/BurntSushi/toml                          v0.3.1
 github.com/cespare/xxhash/v2                        v2.1.1
 github.com/containerd/cgroups                       318312a373405e5e91134d8063d04d59768a1bff
 github.com/containerd/console                       v1.0.0
-github.com/containerd/containerd                    v1.4.0-rc.0
+github.com/containerd/containerd                    v1.4.1
 github.com/containerd/continuity                    efbc4488d8fe1bdc16bde3b2d2990d9b3a899165
 github.com/containerd/fifo                          f15a3290365b9d2627d189e619ab4008e0069caf
 github.com/containerd/go-runc                       7016d3ce2328dd2cb1192b2076ebd565c4e8df0c
@@ -37,8 +37,8 @@ github.com/Microsoft/go-winio                       v0.4.14
 github.com/Microsoft/hcsshim                        v0.8.9
 github.com/opencontainers/go-digest                 v1.0.0
 github.com/opencontainers/image-spec                v1.0.1
-github.com/opencontainers/runc                      67169a9d43456ff0d5ae12b967acb8e366e2f181 # v1.0.0-rc91-48-g67169a9d
-github.com/opencontainers/runtime-spec              237cc4f519e2e8f9b235bacccfa8ef5a84df2875 # v1.0.2-14-g8e2f17c
+github.com/opencontainers/runc                      v1.0.0-rc92
+github.com/opencontainers/runtime-spec              4d89ac9fbff6c455f46a5bb59c6b1bb7184a5e43 # v1.0.3-0.20200728170252-4d89ac9fbff6
 github.com/pkg/errors                               v0.9.1
 github.com/prometheus/client_golang                 v1.6.0
 github.com/prometheus/client_model                  v0.2.0
@@ -77,21 +77,21 @@ golang.org/x/oauth2                                 858c2ad4c8b6c5d10852cb89079f
 golang.org/x/time                                   555d28b269f0569763d25dbe1a237ae74c6bcc82
 gopkg.in/inf.v0                                     v0.9.1
 gopkg.in/yaml.v2                                    v2.2.8
-k8s.io/api                                          v0.19.0-rc.4
-k8s.io/apiserver                                    v0.19.0-rc.4
-k8s.io/apimachinery                                 v0.19.0-rc.4
-k8s.io/client-go                                    v0.19.0-rc.4
-k8s.io/component-base                               v0.19.0-rc.4
-k8s.io/cri-api                                      v0.19.0-rc.4
+k8s.io/api                                          v0.19.2
+k8s.io/apiserver                                    v0.19.2
+k8s.io/apimachinery                                 v0.19.2
+k8s.io/client-go                                    v0.19.2
+k8s.io/component-base                               v0.19.2
+k8s.io/cri-api                                      v0.19.2
 k8s.io/klog/v2                                      v2.2.0
-k8s.io/utils                                        2df71ebbae66f39338aed4cd0bb82d2212ee33cc
-sigs.k8s.io/structured-merge-diff/v3                v3.0.0
+k8s.io/utils                                        d5654de09c73da55eb19ae4ab4f734f7a61747a6
+sigs.k8s.io/structured-merge-diff/v4                v4.0.1
 sigs.k8s.io/yaml                                    v1.2.0
 
 # cni dependencies
-github.com/containerd/go-cni                        v1.0.0
-github.com/containernetworking/cni                  v0.7.1
-github.com/containernetworking/plugins              v0.7.6
+github.com/containerd/go-cni                        v1.0.1
+github.com/containernetworking/cni                  v0.8.0
+github.com/containernetworking/plugins              v0.8.6
 github.com/fsnotify/fsnotify                        v1.4.9
 
 # image decrypt depedencies


### PR DESCRIPTION
This is the "cherry pick" of the CRI config change in #4665, but via a PR against the 1.4 branch in the now-merged CRI sub-project and now a re-vendor.

This includes a few other minor changes in the CRI branch.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>