### PR TITLE
Remove setuid gosu in favor of "sudo -E PATH=$PATH ..."

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,15 +238,6 @@ jobs:
         with:
           go-version: '1.15.2'
 
-      - name: Setup gosu
-        run: |
-          GOSU=/usr/local/bin/gosu
-          arch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"
-          sudo wget -O ${GOSU} "https://github.com/tianon/gosu/releases/download/1.12/gosu-$arch"
-          sudo chmod +x ${GOSU}
-          sudo chown root ${GOSU}
-          sudo chmod +s ${GOSU}
-
       - uses: actions/checkout@v2
         with:
           path: src/github.com/containerd/containerd
@@ -260,10 +251,10 @@ jobs:
         env:
           RUNC_FLAVOR: ${{ matrix.runc }}
         run: |
-          sudo PATH=$PATH script/setup/install-seccomp
-          gosu root script/setup/install-runc
-          gosu root script/setup/install-cni
-          gosu root script/setup/install-critools
+          sudo -E PATH=$PATH script/setup/install-seccomp
+          sudo -E PATH=$PATH script/setup/install-runc
+          sudo -E PATH=$PATH script/setup/install-cni
+          sudo -E PATH=$PATH script/setup/install-critools
         working-directory: src/github.com/containerd/containerd
 
       - name: Install criu


### PR DESCRIPTION
This is a follow-up to #4232, #4224

See also https://github.com/actions/virtual-environments/issues/731
(`sudo -E` wasn't considered sufficient previously thanks to `secure_path` in `/etc/sudoers` but that's trivially overcome via `PATH=$PATH`)

As the author of `gosu`, I can say without reservation that running it with setuid bits is definitely not recommended (even in a temporary/ephemeral environment with passwordless `sudo`).