### PR TITLE
[release/1.3 backport] ci: run critest target for all runtimes + use compatible critest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,9 +346,9 @@ jobs:
           mkdir -p ${BDIR}/{root,state}
           cat > ${BDIR}/config.toml <<EOF
             [plugins.cri.containerd.default_runtime]
-              runtime_type = \"${TEST_RUNTIME}\"
-          EOF"
-          sudo PATH=$PATH BDIR=$BDIR /usr/local/bin/containerd -a ${BDIR}/c.sock -root ${BDIR}/root -state ${BDIR}/state -log-level debug &> ${BDIR}/containerd-cri.log &
+              runtime_type = "${TEST_RUNTIME}"
+          EOF
+          sudo PATH=$PATH BDIR=$BDIR /usr/local/bin/containerd -a ${BDIR}/c.sock --config ${BDIR}/config.toml --root ${BDIR}/root --state ${BDIR}/state --log-level debug &> ${BDIR}/containerd-cri.log &
           sudo BDIR=$BDIR /usr/local/bin/ctr -a ${BDIR}/c.sock version
           sudo PATH=$PATH BDIR=$BDIR GOPATH=$GOPATH critest --runtime-endpoint=unix:///${BDIR}/c.sock --parallel=8
           TEST_RC=$?

--- a/script/setup/install-critools
+++ b/script/setup/install-critools
@@ -21,7 +21,7 @@
 set -eu -o pipefail
 
 go get -u github.com/onsi/ginkgo/ginkgo
-CRITEST_COMMIT=16911795a3c33833fa0ec83dac1ade3172f6989e
+CRITEST_COMMIT=v1.16.1
 go get -d github.com/kubernetes-sigs/cri-tools/...
 cd "$GOPATH"/src/github.com/kubernetes-sigs/cri-tools
 git checkout $CRITEST_COMMIT


### PR DESCRIPTION
Backport of https://github.com/containerd/containerd/pull/4687 (including a bugfix where `EOF"` was not seen as a valid heredoc end marker by bash, preventing the tests from running) and use a version of critest compatible with the vendored containerd/cri.

cc @mikebrow @tianon 