### PR TITLE
[release/1.4] backport: Remove setuid gosu in favor of "sudo -E PATH=$PATH ..."

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,16 +327,6 @@ jobs:
         with:
           go-version: '1.13.15'
 
-      - name: Setup gosu
-        shell: bash
-        run: |
-          GOSU=/usr/local/bin/gosu
-          arch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"
-          sudo wget -O ${GOSU} "https://github.com/tianon/gosu/releases/download/1.12/gosu-$arch"
-          sudo chmod +x ${GOSU}
-          sudo chown root ${GOSU}
-          sudo chmod +s ${GOSU}
-
       - name: Set env
         shell: bash
         run: |
@@ -352,10 +342,10 @@ jobs:
         env:
           RUNC_FLAVOR: ${{ matrix.runc }}
         run: |
-          sudo PATH=$PATH script/setup/install-seccomp
-          gosu root script/setup/install-runc
-          script/setup/install-cni
-          script/setup/install-critools
+          sudo -E PATH=$PATH script/setup/install-seccomp
+          sudo -E PATH=$PATH script/setup/install-runc
+          sudo -E PATH=$PATH script/setup/install-cni
+          sudo -E PATH=$PATH script/setup/install-critools
         working-directory: src/github.com/containerd/containerd
 
       - name: Install criu


### PR DESCRIPTION
Signed-off-by: Tianon Gravi <admwiggin@gmail.com>
(cherry picked from commit 17688a733ad0d472ffcf87dabf5d206626f0f338)

Backport of #4692 to `release/1.4`