### PR TITLE
test: run tests with selinux enforcing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,15 +347,11 @@ jobs:
       - name: Integration
         env:
           RUNC_FLAVOR: ${{ matrix.runc }}
-          # SELinux: replace Permissive with Enforcing after https://github.com/containers/container-selinux/pull/98
-          # is merged and the package becomes generally available.
-          SELINUX: Permissive
+          SELINUX: Enforcing
         run: vagrant up --provision-with=selinux,install-runc,test-integration
 
       - name: CRI test
         env:
           RUNC_FLAVOR: ${{ matrix.runc }}
-          # SELinux: replace Permissive with Enforcing after https://github.com/containers/container-selinux/pull/98
-          # is merged and the package becomes generally available.
-          SELINUX: Permissive
+          SELINUX: Enforcing
         run: vagrant up --provision-with=selinux,install-runc,test-cri

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -214,9 +214,6 @@ EOF
   #
   config.vm.provision "test-cri", type: "shell", run: "never" do |sh|
     sh.upload_path = "/tmp/test-cri"
-    sh.env = {
-        'CRITEST_ARGS': ENV['CRITEST_ARGS'],
-    }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash
         source /etc/environment
@@ -239,7 +236,7 @@ EOF
         fi
         trap cleanup EXIT
         ctr version
-        critest --parallel=$(nproc) ${CRITEST_ARGS}
+        critest --parallel=$(nproc) --ginkgo.skip='HostIpc is true'
     SHELL
   end
 


### PR DESCRIPTION
With container-selinux policy updated to 2.145+ (the default for Fedora 32+) we
can enable SELinux=Enforcing mode in the CI workflow and pass all integration
and CRI tests except one, see https://github.com/containerd/containerd/issues/4460,
which has been marked as skipped.

Tested locally with:
- SELINUX=Enforcing vagrant up --provision-with=shell,selinux,test-integration
- SELINUX=Enforcing vagrant up --provision-with=shell,selinux,test-cri

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>
