### PR TITLE
Do not hardcode "amd64" on LCOW and Windows-related files

### DIFF
--- a/diff/lcow/lcow.go
+++ b/diff/lcow/lcow.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"runtime"
 	"time"
 
 	"github.com/Microsoft/go-winio/pkg/security"
@@ -61,7 +62,7 @@ func init() {
 
 			ic.Meta.Platforms = append(ic.Meta.Platforms, ocispec.Platform{
 				OS:           "linux",
-				Architecture: "amd64",
+				Architecture: runtime.GOARCH,
 			})
 			return NewWindowsLcowDiff(md.(*metadata.DB).ContentStore())
 		},

--- a/platforms/defaults_windows.go
+++ b/platforms/defaults_windows.go
@@ -19,6 +19,8 @@
 package platforms
 
 import (
+	"runtime"
+
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -26,6 +28,6 @@ import (
 func Default() MatchComparer {
 	return Ordered(DefaultSpec(), specs.Platform{
 		OS:           "linux",
-		Architecture: "amd64",
+		Architecture: runtime.GOARCH,
 	})
 }

--- a/snapshots/lcow/lcow.go
+++ b/snapshots/lcow/lcow.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -50,7 +51,7 @@ func init() {
 		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
 			ic.Meta.Platforms = append(ic.Meta.Platforms, ocispec.Platform{
 				OS:           "linux",
-				Architecture: "amd64",
+				Architecture: runtime.GOARCH,
 			})
 			return NewSnapshotter(ic.Root)
 		},


### PR DESCRIPTION
Fixes #3281.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>