### PR TITLE
Re-enable CRIU tests by not using overlayfs snapshotter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,6 +322,22 @@ jobs:
           sudo GOPATH=$GOPATH GOPROXY=$GOPROXY TEST_RUNTIME=$TEST_RUNTIME RUNC_FLAVOR=$RUNC_FLAVOR TESTFLAGS_PARALLEL=1 make integration EXTRA_TESTFLAGS=-no-criu
         working-directory: src/github.com/containerd/containerd
 
+      # CRIU wouldn't work with overlay snapshotter yet.
+      # See https://github.com/containerd/containerd/pull/4708#issuecomment-724322294.
+      - name: CRIU Integration
+        env:
+          GOPROXY: direct
+          TEST_RUNTIME: ${{ matrix.runtime }}
+          RUNC_FLAVOR: ${{ matrix.runc }}
+        # crun doesn't have "checkpoint" command.
+        if: ${{ matrix.runc == 'runc' }}
+        run: |
+          sudo GOPATH=$GOPATH GOPROXY=$GOPROXY \
+          TEST_RUNTIME=$TEST_RUNTIME RUNC_FLAVOR=$RUNC_FLAVOR TESTFLAGS_PARALLEL=1 \
+          TEST_SNAPSHOTTER=native \
+          make integration EXTRA_TESTFLAGS='-run TestCheckpoint'
+        working-directory: src/github.com/containerd/containerd
+
       - name: CRI Integration Test
         env:
           TEST_RUNTIME: ${{ matrix.runtime }}

--- a/integration/client/container_checkpoint_test.go
+++ b/integration/client/container_checkpoint_test.go
@@ -414,7 +414,7 @@ func TestCheckpointLeaveRunning(t *testing.T) {
 	<-statusC
 }
 
-func TestCRWithImagePath(t *testing.T) {
+func TestCheckpointRestoreWithImagePath(t *testing.T) {
 	if !supportsCriu {
 		t.Skip("system does not have criu installed")
 	}

--- a/pkg/process/init.go
+++ b/pkg/process/init.go
@@ -193,11 +193,15 @@ func (p *Init) createCheckpointedState(r *CreateConfig, pidFile *pidFile) error 
 			ParentPath: r.ParentCheckpoint,
 		},
 		PidFile:     pidFile.Path(),
-		IO:          p.io.IO(),
 		NoPivot:     p.NoPivotRoot,
 		Detach:      true,
 		NoSubreaper: true,
 	}
+
+	if p.io != nil {
+		opts.IO = p.io.IO()
+	}
+
 	p.initState = &createdCheckpointState{
 		p:    p,
 		opts: opts,

--- a/runtime/v2/runc/container.go
+++ b/runtime/v2/runc/container.go
@@ -49,7 +49,7 @@ func NewContainer(ctx context.Context, platform stdio.Platform, r *task.CreateTa
 	}
 
 	var opts options.Options
-	if r.Options != nil {
+	if r.Options != nil && r.Options.GetTypeUrl() != "" {
 		v, err := typeurl.UnmarshalAny(r.Options)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
While the issue hasn't been fixed in the kernel yet, we can workaround
the issue by not using overlayfs snapshotter.

Fixes #3930.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>