### PR TITLE
ctr: add AppArmor flags

### DIFF
--- a/cmd/ctr/commands/commands.go
+++ b/cmd/ctr/commands/commands.go
@@ -159,6 +159,14 @@ var (
 			Name:  "seccomp-profile",
 			Usage: "file path to custom seccomp profile. seccomp must be set to true, before using seccomp-profile",
 		},
+		cli.StringFlag{
+			Name:  "apparmor-default-profile",
+			Usage: "enable AppArmor with the default profile with the specified name, e.g. \"cri-containerd.apparmor.d\"",
+		},
+		cli.StringFlag{
+			Name:  "apparmor-profile",
+			Usage: "enable AppArmor with an existing custom profile",
+		},
 	}
 )
 

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cmd/ctr/commands"
+	"github.com/containerd/containerd/contrib/apparmor"
 	"github.com/containerd/containerd/contrib/nvidia"
 	"github.com/containerd/containerd/contrib/seccomp"
 	"github.com/containerd/containerd/oci"
@@ -203,6 +204,17 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 			} else {
 				opts = append(opts, seccomp.WithDefaultProfile())
 			}
+		}
+
+		if s := context.String("apparmor-default-profile"); len(s) > 0 {
+			opts = append(opts, apparmor.WithDefaultProfile(s))
+		}
+
+		if s := context.String("apparmor-profile"); len(s) > 0 {
+			if len(context.String("apparmor-default-profile")) > 0 {
+				return nil, fmt.Errorf("apparmor-profile conflicts with apparmor-default-profile")
+			}
+			opts = append(opts, apparmor.WithProfile(s))
 		}
 
 		if cpus := context.Float64("cpus"); cpus > 0.0 {


### PR DESCRIPTION
e.g.
```
$ sudo ./bin/ctr run --apparmor-default-profile "cri-containerd.apparmor.d" docker.io/library/alpine:latest foo cat /proc/self/attr/current
cri-containerd.apparmor.d (enforce)
```
