### PR TITLE
gha: specify full version for golang-ci-lint to speedup selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.29
+          version: v1.29.0
           working-directory: src/github.com/containerd/containerd
           args: --timeout=5m
 


### PR DESCRIPTION
Noticed this in the CI output:

    Requested golangci-lint 'v1.29', using 'v1.29.0', calculation took 7969ms
    Installing golangci-lint v1.29.0...
    Downloading https://github.com/golangci/golangci-lint/releases/download/v1.29.0/golangci-lint-1.29.0-darwin-amd64.tar.gz ...

Using nearly 8 seconds to convert v1.29 to v1.29.0 seems a bit long,
so hard-coding to the full version to speedup CI somewhat.
