### PR TITLE
install-runc: remove unused USESUDO variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,7 +280,7 @@ install-cri-deps: $(BINARIES)
 	@install -m 644 containerd.service ${CRIDIR}/etc/systemd/system
 	echo "CONTAINERD_VERSION: '$(VERSION:v%=%)'" | tee ${CRIDIR}/opt/containerd/cluster/version
 
-	DESTDIR=$(CRIDIR) USESUDO=false script/setup/install-runc
+	DESTDIR=$(CRIDIR) script/setup/install-runc
 	DESTDIR=$(CRIDIR) script/setup/install-cni
 	DESTDIR=$(CRIDIR) script/setup/install-critools
 

--- a/script/setup/install-runc
+++ b/script/setup/install-runc
@@ -27,14 +27,7 @@ function install_runc() {
 	cd "$GOPATH"/src/github.com/opencontainers/runc
 	git checkout $RUNC_COMMIT
 	make BUILDTAGS='apparmor seccomp selinux' runc
-
-	USESUDO=${USESUDO:-false}
-	if ${USESUDO}; then
-	  SUDO='sudo -E'
-	else
-	  SUDO=''
-	fi
-	${SUDO} make install
+	make install
 }
 
 function install_crun() {


### PR DESCRIPTION
This is no longer needed, as the script is already run with sudo (see https://github.com/containerd/containerd/commit/65df8db2896e6a9f4352bc65bedb4a580b057a66).
