### PR TITLE
Reenable make test targets in GH Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,11 @@ jobs:
           git checkout "${SHIM_COMMIT}"
           GO111MODULE=on go build -mod=vendor -o "${bindir}/containerd-shim-runhcs-v1.exe" ./cmd/containerd-shim-runhcs-v1
 
+      - name: Tests
+        env:
+          CGO_ENABLED: 1
+        run: mingw32-make.exe test root-test
+
       - name: Integration 1
         env:
           CGO_ENABLED: 1
@@ -280,6 +285,15 @@ jobs:
         run: |
           make binaries
           sudo make install
+        working-directory: src/github.com/containerd/containerd
+
+      - name: Tests
+        env:
+          GOPROXY: direct
+          SKIPTESTS: github.com/containerd/containerd/snapshots/devmapper
+        run: |
+          make test
+          sudo -E PATH=$PATH GOPATH=$GOPATH GOPROXY=$GOPROXY make root-test
         working-directory: src/github.com/containerd/containerd
 
       - name: Integration 1

--- a/snapshots/overlay/overlay_test.go
+++ b/snapshots/overlay/overlay_test.go
@@ -174,6 +174,7 @@ func testOverlayOverlayMount(t *testing.T, newSnapshotter testsuite.SnapshotterF
 		lower = "lowerdir=" + getParents(ctx, o, root, "/tmp/layer2")[0]
 	)
 	for i, v := range []string{
+		"index=off",
 		work,
 		upper,
 		lower,
@@ -334,12 +335,12 @@ func testOverlayView(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
 	if m.Source != "overlay" {
 		t.Errorf("mount source should be overlay but received %q", m.Source)
 	}
-	if len(m.Options) != 1 {
-		t.Errorf("expected 1 mount option but got %d", len(m.Options))
+	if len(m.Options) != 2 {
+		t.Errorf("expected 1 additional mount option but got %d", len(m.Options))
 	}
 	lowers := getParents(ctx, o, root, "/tmp/view2")
 	expected = fmt.Sprintf("lowerdir=%s:%s", lowers[0], lowers[1])
-	if m.Options[0] != expected {
+	if m.Options[1] != expected {
 		t.Errorf("expected option %q but received %q", expected, m.Options[0])
 	}
 }

--- a/snapshots/testsuite/testsuite.go
+++ b/snapshots/testsuite/testsuite.go
@@ -18,6 +18,8 @@ package testsuite
 
 import (
 	"context"
+	//nolint:golint
+	_ "crypto/sha256"
 	"fmt"
 	"io/ioutil"
 	"math/rand"


### PR DESCRIPTION
Related to #4705:  re-enable tests hidden by removal of "coverage" targets

I will drop the first commit and rebase when #4705 is merged but want to verify we can get passing tests

