### PR TITLE
ga: Linux Integration: extend timeout to 20 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
   integration-linux:
     name: Linux Integration
     runs-on: ubuntu-18.04
-    timeout-minutes: 15
+    timeout-minutes: 20
     needs: [project, linters, protos, man]
 
     strategy:


### PR DESCRIPTION
CI was timing out after 15 minutes on the crun tests; extending the timeout to 20 minutes (we can make it shorter again if we know the exact time it takes to run)


e.g. https://github.com/containerd/containerd/pull/4578/checks?check_run_id=1380571893