### PR TITLE
docs: fix broken links

### DIFF
--- a/docs/content-flow.md
+++ b/docs/content-flow.md
@@ -408,7 +408,7 @@ in turn, depends on the next layer down, so it is protected from collection, and
 ### Container
 
 With the above in place, we know how to create an active snapshot that is useful for the container. We simply
-need to [https://godoc.org/github.com/containerd/containerd/snapshots#Snapshotter](Prepare()) the active snapshot,
+need to [Prepare()](https://godoc.org/github.com/containerd/containerd/snapshots#Snapshotter) the active snapshot,
 passing it an ID and the parent, in this case the top layer of committed snapshots.
 
 Thus, the steps are:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -428,4 +428,4 @@ redis-server exited with status: 0
 In the end, we really did not write that much code when you use the client package.
 
 I hope this guide helped to get you up and running with containerd.
-Feel free to join the [slack channel](https://dockr.ly/community) if you have any questions and like all things, if you want to help contribute to containerd or this guide, submit a pull request.
+Feel free to join the `#containerd` and `#containerd-dev` slack channels on Cloud Native Computing Foundation's (CNCF) slack - `cloud-native.slack.com` if you have any questions and like all things, if you want to help contribute to containerd or this guide, submit a pull request. [Get Invite to CNCF slack.](https://slack.cncf.io)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -58,7 +58,7 @@ Information about the binaries in the release tarball:
 |               runc             | seccomp, apparmor  | linux |     amd64    |
 
 
-If you have other requirements for the binaries, e.g. selinux support, another architecture support etc., you need to build the binaries yourself following [the instructions](../README.md#getting-started-for-developers).
+If you have other requirements for the binaries, e.g. selinux support, another architecture support etc., you need to build the binaries yourself following [the instructions](../BUILDING.md).
 
 ### Download
 


### PR DESCRIPTION
This change fixes broken links in docs/.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>