### PR TITLE
Update btrfs vendor for chkptr fix for Go >= 1.14

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,7 +1,7 @@
 github.com/beorn7/perks                             v1.0.1
 github.com/BurntSushi/toml                          v0.3.1
 github.com/cespare/xxhash/v2                        v2.1.1
-github.com/containerd/btrfs                         153935315f4ab9be5bf03650a1341454b05efa5d
+github.com/containerd/btrfs                         404b9149801e455c8076f615b06dc0abee0a977a
 github.com/containerd/cgroups                       0b889c03f102012f1d93a97ddd3ef71cd6f4f510
 github.com/containerd/console                       v1.0.1
 github.com/containerd/continuity                    efbc4488d8fe1bdc16bde3b2d2990d9b3a899165

--- a/vendor/github.com/containerd/btrfs/btrfs.go
+++ b/vendor/github.com/containerd/btrfs/btrfs.go
@@ -275,7 +275,7 @@ func SubvolCreate(path string) error {
 	if len(name) > C.BTRFS_PATH_NAME_MAX {
 		return errors.Errorf("%q too long for subvolume", name)
 	}
-	nameptr := (*[maxByteSliceSize]byte)(unsafe.Pointer(&args.name[0]))
+	nameptr := (*[maxByteSliceSize]byte)(unsafe.Pointer(&args.name[0]))[:C.BTRFS_PATH_NAME_MAX:C.BTRFS_PATH_NAME_MAX]
 	copy(nameptr[:C.BTRFS_PATH_NAME_MAX], []byte(name))
 
 	if err := ioctl(fp.Fd(), C.BTRFS_IOC_SUBVOL_CREATE, uintptr(unsafe.Pointer(&args))); err != nil {
@@ -311,7 +311,7 @@ func SubvolSnapshot(dst, src string, readonly bool) error {
 		return errors.Errorf("%q too long for subvolume", dstname)
 	}
 
-	nameptr := (*[maxByteSliceSize]byte)(unsafe.Pointer(name))
+	nameptr := (*[maxByteSliceSize]byte)(unsafe.Pointer(name))[:C.BTRFS_SUBVOL_NAME_MAX:C.BTRFS_SUBVOL_NAME_MAX]
 	copy(nameptr[:C.BTRFS_SUBVOL_NAME_MAX], []byte(dstname))
 
 	if readonly {
@@ -370,7 +370,7 @@ func SubvolDelete(path string) error {
 		return errors.Errorf("%q too long for subvolume", name)
 	}
 
-	nameptr := (*[maxByteSliceSize]byte)(unsafe.Pointer(&args.name[0]))
+	nameptr := (*[maxByteSliceSize]byte)(unsafe.Pointer(&args.name[0]))[:C.BTRFS_SUBVOL_NAME_MAX:C.BTRFS_SUBVOL_NAME_MAX]
 	copy(nameptr[:C.BTRFS_SUBVOL_NAME_MAX], []byte(name))
 
 	if err := ioctl(fp.Fd(), C.BTRFS_IOC_SNAP_DESTROY, uintptr(unsafe.Pointer(&args))); err != nil {

--- a/vendor/github.com/containerd/btrfs/go.mod
+++ b/vendor/github.com/containerd/btrfs/go.mod
@@ -1,5 +1,5 @@
 module github.com/containerd/btrfs
 
-go 1.13
+go 1.15
 
 require github.com/pkg/errors v0.8.1


### PR DESCRIPTION
Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>