### PR TITLE
seccomp: add pidfd syscalls

### DIFF
--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -573,6 +573,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 			s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
 				Names: []string{
 					"kcmp",
+					"pidfd_getfd",
 					"process_vm_readv",
 					"process_vm_writev",
 					"ptrace",

--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -232,6 +232,8 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				"openat",
 				"openat2",
 				"pause",
+				"pidfd_open",
+				"pidfd_send_signal",
 				"pipe",
 				"pipe2",
 				"poll",


### PR DESCRIPTION
Similar to the changes merged in https://github.com/moby/moby/pull/41665 (thanks @mikroskeem)

- seccomp: add `pidfd_open` and `pidfd_send_signal`
- seccomp: add `pidfd_getfd` syscall (gated by `CAP_SYS_PTRACE`) 
