### PR TITLE
Handle an image ref with scheme

### DIFF
--- a/reference/reference.go
+++ b/reference/reference.go
@@ -85,6 +85,10 @@ var splitRe = regexp.MustCompile(`[:@]`)
 
 // Parse parses the string into a structured ref.
 func Parse(s string) (Spec, error) {
+	if strings.Contains(s, "://") {
+		return Spec{}, ErrInvalid
+	}
+
 	u, err := url.Parse("dummy://" + s)
 	if err != nil {
 		return Spec{}, err

--- a/reference/reference_test.go
+++ b/reference/reference_test.go
@@ -151,7 +151,6 @@ func TestReferenceParser(t *testing.T) {
 			},
 		},
 		{
-			Skip:     true, // TODO(stevvooe): Implement this case.
 			Name:     "SchemeDefined",
 			Input:    "http://xn--7o8h.com/myimage:xn--7o8h.com@sha512:fffffff",
 			Hostname: "xn--7o8h.com",
@@ -160,11 +159,6 @@ func TestReferenceParser(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.Name, func(t *testing.T) {
-			if testcase.Skip {
-				t.Skip("testcase disabled")
-				return
-			}
-
 			ref, err := Parse(testcase.Input)
 			if err != testcase.Err {
 				if testcase.Err != nil {


### PR DESCRIPTION
An image ref must be a scheme-less URI. A reference with scheme (such
as `http://`) must return ErrInvalid.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>