### PR TITLE
gha: use sudo -E in some places to prevent dropping env-vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Install protobuf
         run: |
-          sudo env PATH=$PATH GOPATH=$GOPATH script/setup/install-protobuf
+          sudo -E PATH=$PATH script/setup/install-protobuf
           sudo chmod +x /usr/local/bin/protoc
           sudo chmod og+rx /usr/local/include/google /usr/local/include/google/protobuf /usr/local/include/google/protobuf/compiler
           sudo chmod -R og+r /usr/local/include/google/protobuf/
@@ -382,7 +382,7 @@ jobs:
           CGO_ENABLED: 1
         run: |
           make binaries
-          sudo make install
+          sudo -E PATH=$PATH make install
         working-directory: src/github.com/containerd/containerd
 
       - run: sudo -E PATH=$PATH script/setup/install-gotestsum
@@ -393,7 +393,7 @@ jobs:
           GOTESTSUM_JUNITFILE: ${{github.workspace}}/test-unit-root-junit.xml
         run: |
           make test
-          sudo -E PATH=$PATH GOPATH=$GOPATH GOPROXY=$GOPROXY make root-test
+          sudo -E PATH=$PATH make root-test
         working-directory: src/github.com/containerd/containerd
 
       - name: Integration 1
@@ -403,7 +403,7 @@ jobs:
           RUNC_FLAVOR: ${{ matrix.runc }}
           GOTESTSUM_JUNITFILE: ${{github.workspace}}/test-integration-serial-junit.xml
         run: |
-          sudo GOPATH=$GOPATH GOPROXY=$GOPROXY TEST_RUNTIME=$TEST_RUNTIME RUNC_FLAVOR=$RUNC_FLAVOR make integration EXTRA_TESTFLAGS=-no-criu TESTFLAGS_RACE=-race
+          sudo -E PATH=$PATH make integration EXTRA_TESTFLAGS=-no-criu TESTFLAGS_RACE=-race
         working-directory: src/github.com/containerd/containerd
 
       # Run the integration suite a second time. See discussion in github.com/containerd/containerd/pull/1759
@@ -414,7 +414,7 @@ jobs:
           RUNC_FLAVOR: ${{ matrix.runc }}
           GOTESTSUM_JUNITFILE: ${{github.workspace}}/test-integration-parallel-junit.xml
         run: |
-          sudo GOPATH=$GOPATH GOPROXY=$GOPROXY TEST_RUNTIME=$TEST_RUNTIME RUNC_FLAVOR=$RUNC_FLAVOR TESTFLAGS_PARALLEL=1 make integration EXTRA_TESTFLAGS=-no-criu
+          sudo -E PATH=$PATH TESTFLAGS_PARALLEL=1 make integration EXTRA_TESTFLAGS=-no-criu
         working-directory: src/github.com/containerd/containerd
 
       # CRIU wouldn't work with overlay snapshotter yet.
@@ -428,8 +428,8 @@ jobs:
         # crun doesn't have "checkpoint" command.
         if: ${{ matrix.runc == 'runc' }}
         run: |
-          sudo GOPATH=$GOPATH GOPROXY=$GOPROXY \
-          TEST_RUNTIME=$TEST_RUNTIME RUNC_FLAVOR=$RUNC_FLAVOR TESTFLAGS_PARALLEL=1 \
+          sudo -E PATH=$PATH \
+          TESTFLAGS_PARALLEL=1 \
           TEST_SNAPSHOTTER=native \
           make integration EXTRA_TESTFLAGS='-run TestCheckpoint'
         working-directory: src/github.com/containerd/containerd
@@ -453,13 +453,13 @@ jobs:
             runtime_type = "${TEST_RUNTIME}"
           EOF
           sudo ls /etc/cni/net.d
-          sudo PATH=$PATH BDIR=$BDIR /usr/local/bin/containerd -a ${BDIR}/c.sock --config ${BDIR}/config.toml --root ${BDIR}/root --state ${BDIR}/state --log-level debug &> ${BDIR}/containerd-cri.log &
-          sudo PATH=$PATH BDIR=$BDIR /usr/local/bin/ctr -a ${BDIR}/c.sock version
-          sudo PATH=$PATH BDIR=$BDIR GOPATH=$GOPATH critest --report-dir "${{github.workspace}}/critestreport" --runtime-endpoint=unix:///${BDIR}/c.sock --parallel=8
+          sudo -E PATH=$PATH /usr/local/bin/containerd -a ${BDIR}/c.sock --config ${BDIR}/config.toml --root ${BDIR}/root --state ${BDIR}/state --log-level debug &> ${BDIR}/containerd-cri.log &
+          sudo -E PATH=$PATH /usr/local/bin/ctr -a ${BDIR}/c.sock version
+          sudo -E PATH=$PATH critest --report-dir "${{github.workspace}}/critestreport" --runtime-endpoint=unix:///${BDIR}/c.sock --parallel=8
           TEST_RC=$?
           test $TEST_RC -ne 0 && cat ${BDIR}/containerd-cri.log
           sudo pkill containerd
-          sudo BDIR=$BDIR rm -rf ${BDIR}
+          sudo -E rm -rf ${BDIR}
           test $TEST_RC -eq 0 || /bin/false
 
       # Log the status of this VM to investigate issues like

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,7 @@ jobs:
           RUNC_FLAVOR: runc
         run: |
           if [[ "${OS}" == "linux" ]]; then
-            sudo PATH=$PATH script/setup/install-seccomp
+            sudo -E PATH=$PATH script/setup/install-seccomp
           fi
           make cri-cni-release
         working-directory: src/github.com/containerd/containerd


### PR DESCRIPTION
Using `-E` preserves environment variables, except for PATH, so PATH has to be manually set to match the current environment.

I removed env-vars that were redundant (such as `GOPATH=$GOPATH`), which should be handled by `-E`.