### PR TITLE
[release/1.3 backport] v2: Cancel shim log ctx when ttrpc is closed

### DIFF
--- a/runtime/v2/binary.go
+++ b/runtime/v2/binary.go
@@ -74,7 +74,7 @@ func (b *binary) Start(ctx context.Context, opts *types.Any, onClose func()) (_ 
 	if err != nil {
 		return nil, err
 	}
-	f, err := openShimLog(ctx, b.bundle, client.AnonDialer)
+	f, err := openShimLog(context.Background(), b.bundle, client.AnonDialer)
 	if err != nil {
 		return nil, errors.Wrap(err, "open shim log pipe")
 	}

--- a/runtime/v2/binary.go
+++ b/runtime/v2/binary.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/containerd/containerd/events/exchange"
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/runtime"
 	client "github.com/containerd/containerd/runtime/v2/shim"
 	"github.com/containerd/containerd/runtime/v2/task"
@@ -74,7 +75,9 @@ func (b *binary) Start(ctx context.Context, opts *types.Any, onClose func()) (_ 
 	if err != nil {
 		return nil, err
 	}
-	f, err := openShimLog(context.Background(), b.bundle, client.AnonDialer)
+	// Windows needs a namespace when openShimLog
+	ns, _ := namespaces.Namespace(ctx)
+	f, err := openShimLog(namespaces.WithNamespace(context.Background(), ns), b.bundle, client.AnonDialer)
 	if err != nil {
 		return nil, errors.Wrap(err, "open shim log pipe")
 	}

--- a/runtime/v2/manager.go
+++ b/runtime/v2/manager.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containerd/containerd/metadata"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/pkg/timeout"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/runtime"
@@ -154,8 +155,13 @@ func (m *TaskManager) Create(ctx context.Context, id string, opts runtime.Create
 	}
 	defer func() {
 		if err != nil {
-			shim.Shutdown(ctx)
-			shim.Close()
+			dctx, cancel := timeout.WithContext(context.Background(), cleanupTimeout)
+			defer cancel()
+			_, errShim := shim.Delete(dctx)
+			if errShim != nil {
+				shim.Shutdown(ctx)
+				shim.Close()
+			}
 		}
 	}()
 	t, err := shim.Create(ctx, opts)

--- a/runtime/v2/shim.go
+++ b/runtime/v2/shim.go
@@ -235,11 +235,11 @@ func (s *shim) Delete(ctx context.Context) (*runtime.Exit, error) {
 	// this seems dirty but it cleans up the API across runtimes, tasks, and the service
 	s.rtTasks.Delete(ctx, s.ID())
 	if err := s.waitShutdown(ctx); err != nil {
-		log.G(ctx).WithError(err).Error("failed to shutdown shim")
+		log.G(ctx).WithField("id", s.ID()).WithError(err).Error("failed to shutdown shim")
 	}
 	s.Close()
 	if err := s.bundle.Delete(); err != nil {
-		log.G(ctx).WithError(err).Error("failed to delete bundle")
+		log.G(ctx).WithField("id", s.ID()).WithError(err).Error("failed to delete bundle")
 	}
 	if shimErr != nil {
 		return nil, shimErr


### PR DESCRIPTION
This back ports;

- https://github.com/containerd/containerd/pull/3921 v2: Call shim.Delete at first when create is failed
- https://github.com/containerd/containerd/pull/3929 v2: Fix missing ns when openShimLog on windows
    - follow up to https://github.com/containerd/containerd/pull/3921#discussion_r363046745
- https://github.com/containerd/containerd/pull/4046: v2: Cancel shim log ctx when ttrpc is closed
    - was marked for cherry-picking; https://github.com/containerd/containerd/pull/4046#issuecomment-589662202


The first two cherry-picks were to get a clean backport, but (from the description) seem good to have