### PR TITLE
Fix Windows service panic file to not be read-only

### DIFF
--- a/cmd/containerd/command/service_windows.go
+++ b/cmd/containerd/command/service_windows.go
@@ -323,7 +323,7 @@ Loop:
 
 func initPanicFile(path string) error {
 	var err error
-	panicFile, err = os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0)
+	panicFile, err = os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Go 1.14 introduced a change to os.OpenFile (and syscall.Open) on Windows
that uses the permissions passed to determine if the file should be
created read-only or not. If the user-write bit (0200) is not set, then
FILE_ATTRIBUTE_READONLY is set on the underlying CreateFile call.

This is a significant change for any Windows code which created new
files and set the permissions to 0 (previously the permissions had no
affect, so some code didn't set them at all).

This change fixes the issue for the Windows service panic file. It will
now properly be created as a non-read-only file on Go 1.14+.

I have looked over the rest of the containerd code and didn't see other
places where this seems like an issue.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>