### PR TITLE
[cri/config] : fix range iterator issue in ValidatePluginConfig

### DIFF
--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -352,6 +352,7 @@ func ValidatePluginConfig(ctx context.Context, c *PluginConfig) error {
 			c.Registry.Configs = make(map[string]RegistryConfig)
 		}
 		for endpoint, auth := range c.Registry.Auths {
+			auth := auth
 			config := c.Registry.Configs[endpoint]
 			config.Auth = &auth
 			c.Registry.Configs[endpoint] = config


### PR DESCRIPTION
Go uses the same address variable while iterating in a range, so use a copy when using its address.

Sample code to highlight the issue: https://play.golang.org/p/YSqm1Gu3O0i