### PR TITLE
Add support for overlay volatile option

### DIFF
--- a/mount/temp.go
+++ b/mount/temp.go
@@ -59,6 +59,24 @@ func WithTempMount(ctx context.Context, mounts []Mount, f func(root string) erro
 			}
 		}
 	}()
+
+	// The volatile option of overlayfs doesn't allow to mount again using the
+	// same upper / work dirs. Since it's a temp mount, avoid using that
+	// option here.
+	// TODO: Make this logic conditional once the kernel supports reusing
+	// overlayfs volatile mounts.
+	for _, m := range mounts {
+		if m.Type != "overlay" {
+			continue
+		}
+		for i, opt := range m.Options {
+			if opt == "volatile" {
+				m.Options[i] = ""
+				break
+			}
+		}
+	}
+
 	if uerr = All(mounts, root); uerr != nil {
 		return errors.Wrapf(uerr, "failed to mount %s", root)
 	}

--- a/snapshots/overlay/plugin/plugin.go
+++ b/snapshots/overlay/plugin/plugin.go
@@ -30,6 +30,7 @@ import (
 type Config struct {
 	// Root directory for the plugin
 	RootPath string `toml:"root_path"`
+	Volatile bool   `toml:"volatile"`
 }
 
 func init() {
@@ -51,7 +52,11 @@ func init() {
 			}
 
 			ic.Meta.Exports["root"] = root
-			return overlay.NewSnapshotter(root, overlay.AsynchronousRemove)
+			opts := []overlay.Opt{overlay.AsynchronousRemove}
+			if config.Volatile {
+				opts = append(opts, overlay.Volatile)
+			}
+			return overlay.NewSnapshotter(root, opts...)
 		},
 	})
 }


### PR DESCRIPTION
Linux 5.10 [adds support](https://github.com/torvalds/linux/commit/c86243b090bc25f81abe33ddfa9fe833e02c4d64) for a new [volatile](https://github.com/torvalds/linux/blob/c86243b090bc25f81abe33ddfa9fe833e02c4d64/Documentation/filesystems/overlayfs.rst#volatile-mount) option for overlay mounts that increases performance by avoiding sync calls to the filesystem where the upper directory resides. The goal of this PR is to discuss possible implementations to support this in containerd and also present some challenges regarding the remount when that option is used. 

I did some experiments using this PR and Kubernetes and the time required to install emacs on an image with the cached packages drop from ~55s to ~30s on my machine. 

<details><summary>Test details</summary>
<p>

The image I used was created with the following Docker file
```
FROM ubuntu
RUN apt-get update && apt-get -y install -d emacs
ENTRYPOINT bash -c "time DEBIAN_FRONTEND=noninteractive apt-get -y install emacs
```
A run with `kubectl run --restart=Never --image=mauriciovasquezbernal/testimage:latest m$RANDOM` in Kubernetes. 

</p>
</details>

The volatile option has the particularity that it's not possible to perform a mount reusing the upper/work directories as they could be out of sync. Sargun Dhillon has sent some [patches](https://www.spinics.net/lists/linux-unionfs/msg08641.html) to relax this requirement in some cases where it's safe to perform such mount, however they probably won't be part of 5.10.

Containerd performs some mounts of the overlayfs with `WithTempMount` before starting the container to inspect the image, then a mount for the rootfs of the container is done. This makes the support for the volatile option a bit difficult to implement as this option can only be used in the last mount (the root fs of the container).  

This PR proposes a way to implement it. The volatile option is not set by the snapshotter but it's set in `NewTask`, in this way mounts performed with `WithTempMount` don't have this option and only the final mount has it. This solution is far from ideal because it breaks the modularity polluting other components with overlay specific options, but it's the less invasive option we've found so far. 

We've considered the following options to far:
- Making the overlayfs snapshotter return this option and introducing a check in `WithTempMount` to remove it. 
  - Pros
    - Easy to implement, few lines of code in `WithTempMount`
  - Cons
    - Pollutes `WithTempMount` with overlayfs specific logic 
    - Any other place doing an overlay remount should implement a similar logic to avoid the remounting problem
- Extend the snapshotter interface with a `TempMounts` method that return the mounts to be used in the temp mounts case. It's be the same as `Mount` in all implementations but in overlayfs it'll return the mounts without the volatile option
  - Pros
    - Clean solution as the volatile logic keeps contained in the snapshotter
  - Cons
    - Changes in too many places
    - Could be an overkill if Sargun's patches land in the kernel

I'd like to get more opinions and ideas on this.

cc @rata @alban 
