### PR TITLE
[cri] remove image defined volumes from default

### DIFF
--- a/pkg/cri/config/config_unix.go
+++ b/pkg/cri/config/config_unix.go
@@ -71,6 +71,6 @@ func DefaultConfig() PluginConfig {
 		DisableProcMount:                 false,
 		TolerateMissingHugetlbController: true,
 		DisableHugetlbController:         true,
-		IgnoreImageDefinedVolumes:        false,
+		IgnoreImageDefinedVolumes:        true,
 	}
 }

--- a/pkg/cri/config/config_windows.go
+++ b/pkg/cri/config/config_windows.go
@@ -44,6 +44,7 @@ func DefaultConfig() PluginConfig {
 					Type: "io.containerd.runhcs.v1",
 				},
 			},
+			DisableSnapshotAnnotations: true,
 		},
 		DisableTCPService:   true,
 		StreamServerAddress: "127.0.0.1",
@@ -65,7 +66,7 @@ func DefaultConfig() PluginConfig {
 			},
 		},
 		MaxConcurrentDownloads:    3,
-		IgnoreImageDefinedVolumes: false,
+		IgnoreImageDefinedVolumes: true,
 		// TODO(windows): Add platform specific config, so that most common defaults can be shared.
 	}
 }


### PR DESCRIPTION
From the image defined volumes from the default config settings.

Signed-off-by: Michael Crosby <michael@thepasture.io>