### PR TITLE
Allow configuration of different log formats: text, json

### DIFF
--- a/log/context.go
+++ b/log/context.go
@@ -37,9 +37,17 @@ type (
 	loggerKey struct{}
 )
 
-// RFC3339NanoFixed is time.RFC3339Nano with nanoseconds padded using zeros to
-// ensure the formatted time is always the same number of characters.
-const RFC3339NanoFixed = "2006-01-02T15:04:05.000000000Z07:00"
+const (
+	// RFC3339NanoFixed is time.RFC3339Nano with nanoseconds padded using zeros to
+	// ensure the formatted time is always the same number of characters.
+	RFC3339NanoFixed = "2006-01-02T15:04:05.000000000Z07:00"
+
+	// TextFormat represents the text logging format
+	TextFormat = "text"
+
+	// JSONFormat represents the JSON logging format
+	JSONFormat = "json"
+)
 
 // WithLogger returns a new context with the provided logger. Use in
 // combination with logger.WithField(s) for great effect.

--- a/services/server/config/config.go
+++ b/services/server/config/config.go
@@ -138,6 +138,8 @@ type Debug struct {
 	UID     int    `toml:"uid"`
 	GID     int    `toml:"gid"`
 	Level   string `toml:"level"`
+	// Format represents the logging format
+	Format string `toml:"format"`
 }
 
 // MetricsConfig provides metrics configuration


### PR DESCRIPTION
This PR allows configuring logrus to output in 2 different formats:
- text (default which is today)
- json (new addition)

The way I've configured this is to be via the `debug` section in the toml config. I did not add a CLI flag for this, curious if you folks think this would be useful here. In my experience I've found all my interactions with containerd via the toml config.