### PR TITLE
runtime: fix the issue of always call cleanup

### DIFF
--- a/runtime/v2/shim.go
+++ b/runtime/v2/shim.go
@@ -138,12 +138,6 @@ func cleanupAfterDeadShim(ctx context.Context, id, ns string, rt *runtime.TaskLi
 		}).Warn("failed to clean up after shim disconnected")
 	}
 
-	if _, err := rt.Get(ctx, id); err != nil {
-		// Task was never started or was already successfully deleted
-		// No need to publish events
-		return
-	}
-
 	var (
 		pid        uint32
 		exitStatus uint32


### PR DESCRIPTION
Once the task has been stopped and deleted successfully,
there's no need to call the shim's cleanup any more.

Signed-off-by: fupan.lfp <fupan.lfp@antfin.com>