### PR TITLE
expose hostSupportsAppArmor()

### DIFF
--- a/pkg/apparmor/apparmor.go
+++ b/pkg/apparmor/apparmor.go
@@ -16,7 +16,7 @@
    limitations under the License.
 */
 
-package server
+package apparmor
 
 import (
 	"io/ioutil"
@@ -29,12 +29,12 @@ var (
 	checkAppArmor     sync.Once
 )
 
-// hostSupportsAppArmor returns true if apparmor is enabled for the host, if
+// HostSupports returns true if apparmor is enabled for the host, if
 // apparmor_parser is enabled, and if we are not running docker-in-docker.
 //
 // It is a modified version of libcontainer/apparmor.IsEnabled(), which does not
 // check for apparmor_parser to be present, or if we're running docker-in-docker.
-func hostSupportsAppArmor() bool {
+func HostSupports() bool {
 	checkAppArmor.Do(func() {
 		// see https://github.com/docker/docker/commit/de191e86321f7d3136ff42ff75826b8107399497
 		if _, err := os.Stat("/sys/kernel/security/apparmor"); err == nil && os.Getenv("container") == "" {

--- a/pkg/apparmor/apparmor_unsupported.go
+++ b/pkg/apparmor/apparmor_unsupported.go
@@ -16,9 +16,9 @@
    limitations under the License.
 */
 
-package server
+package apparmor
 
 //nolint: deadcode, unused
-func hostSupportsAppArmor() bool {
+func HostSupports() bool {
 	return false
 }

--- a/pkg/cri/server/helpers_linux.go
+++ b/pkg/cri/server/helpers_linux.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/pkg/apparmor"
 	"github.com/containerd/containerd/pkg/seccomp"
 	"github.com/containerd/containerd/pkg/seutil"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -146,7 +147,7 @@ func (c *criService) apparmorEnabled() bool {
 	if c.config.DisableApparmor {
 		return false
 	}
-	return hostSupportsAppArmor()
+	return apparmor.HostSupports()
 }
 
 func (c *criService) seccompEnabled() bool {


### PR DESCRIPTION
Expose `hostSupportsAppArmor()` as `pkg/apparmor.HostSupports`.

This function is expected to be used by https://github.com/AkihiroSuda/nerdctl