### PR TITLE
remove "apparmor" build tag

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -107,7 +107,6 @@ make generate
 > * `no_cri`: A build tag disables building Kubernetes [CRI](http://blog.kubernetes.io/2016/12/container-runtime-interface-cri-in-kubernetes.html) support into containerd.
 > See [here](https://github.com/containerd/cri-containerd#build-tags) for build tags of CRI plugin.
 > * `no_devmapper`: A build tag disables building the device mapper snapshot driver.
-> * `apparmor`: Enables apparmor support in the cri plugin
 > * `selinux`: Enables selinux support in the cri plugin
 >
 > For example, adding `BUILDTAGS=no_btrfs` to your environment before calling the **binaries**

--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,8 @@ MANPAGES=ctr.8 containerd.8 containerd-config.8 containerd-config.toml.5
 ifdef BUILDTAGS
     GO_BUILDTAGS = ${BUILDTAGS}
 endif
-# Build tags apparmor and selinux are needed by CRI plugin.
-GO_BUILDTAGS ?= apparmor selinux
+# Build tag "selinux" is needed by CRI plugin.
+GO_BUILDTAGS ?= selinux
 GO_BUILDTAGS += ${DEBUG_TAGS}
 GO_TAGS=$(if $(GO_BUILDTAGS),-tags "$(GO_BUILDTAGS)",)
 GO_LDFLAGS=-ldflags '-X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PACKAGE) $(EXTRA_LDFLAGS)'

--- a/pkg/apparmor/apparmor.go
+++ b/pkg/apparmor/apparmor.go
@@ -1,4 +1,4 @@
-// +build apparmor,linux
+// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/pkg/apparmor/apparmor_unsupported.go
+++ b/pkg/apparmor/apparmor_unsupported.go
@@ -1,4 +1,4 @@
-// +build !apparmor !linux
+// +build !linux
 
 /*
    Copyright The containerd Authors.


### PR DESCRIPTION
The "apparmor" build tag does not have any cgo dependency and can be removed safely.

Related: https://github.com/opencontainers/runc/issues/2704
