### PR TITLE
Enable devmapper tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,6 @@ jobs:
       - name: Tests
         env:
           GOPROXY: direct
-          SKIPTESTS: github.com/containerd/containerd/snapshots/devmapper
         run: |
           make test
           sudo -E PATH=$PATH GOPATH=$GOPATH GOPROXY=$GOPROXY make root-test

--- a/snapshots/devmapper/snapshotter.go
+++ b/snapshots/devmapper/snapshotter.go
@@ -265,7 +265,7 @@ func (s *Snapshotter) Commit(ctx context.Context, name, key string, opts ...snap
 			return err
 		}
 
-		return s.pool.DeactivateDevice(ctx, deviceName, false, false)
+		return s.pool.DeactivateDevice(ctx, deviceName, true, false)
 	})
 }
 


### PR DESCRIPTION
Enables the devmapper tests back (after disabling them in https://github.com/containerd/containerd/pull/4719#issuecomment-730002886)

We have included a few patches recently that affected unit tests:
- 2b87d4554f08456b7b4476bf2d15a3dbd9083c26 adds a fix to pass tests after https://github.com/containerd/containerd/pull/4374
- da686098668ec60eaca77dd82076044b5aad6698 partially reverts changes from https://github.com/containerd/containerd/pull/4235 (makes device removal deferred). @renzhengeek PTAL whether this still works for your case.

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>