### PR TITLE
Build on FreeBSD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,13 @@ jobs:
           make binaries
         working-directory: src/github.com/containerd/containerd
 
+      - name: Cross-compile
+        if: startsWith(matrix.os, 'ubuntu')
+        run : |
+          GOOS=freebsd make build
+          GOOS=freebsd make binaries
+        working-directory: src/github.com/containerd/containerd
+
   #
   # Integration and CRI tests
   #

--- a/archive/tar_freebsd.go
+++ b/archive/tar_freebsd.go
@@ -1,0 +1,36 @@
+// +build freebsd
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package archive
+
+import "golang.org/x/sys/unix"
+
+// mknod wraps unix.Mknod.  FreeBSD's unix.Mknod signature is different from
+// other Unix and Unix-like operating systems.
+func mknod(path string, mode uint32, dev uint64) error {
+	return unix.Mknod(path, mode, dev)
+}
+
+// lsetxattrCreate wraps unix.Lsetxattr with FreeBSD-specific flags and errors
+func lsetxattrCreate(link string, attr string, data []byte) error {
+	err := unix.Lsetxattr(link, attr, data, 0)
+	if err == unix.ENOTSUP|| err == unix.EEXIST {
+		return nil
+	}
+	return err
+}

--- a/archive/tar_mostunix.go
+++ b/archive/tar_mostunix.go
@@ -1,0 +1,36 @@
+// +build !windows,!freebsd
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package archive
+
+import "golang.org/x/sys/unix"
+
+// mknod wraps Unix.Mknod and casts dev to int
+func mknod(path string, mode uint32, dev uint64) error {
+	return unix.Mknod(path, mode, int(dev))
+}
+
+// lsetxattrCreate wraps unix.Lsetxattr, passes the unix.XATTR_CREATE flag on
+// supported operating systems,and ignores appropriate errors
+func lsetxattrCreate(link string, attr string, data []byte) error {
+	err := unix.Lsetxattr(link, attr, data, unix.XATTR_CREATE)
+	if err == unix.ENOTSUP || err == unix.ENODATA || err == unix.EEXIST {
+		return nil
+	}
+	return err
+}

--- a/archive/tar_unix.go
+++ b/archive/tar_unix.go
@@ -108,7 +108,7 @@ func handleTarTypeBlockCharFifo(hdr *tar.Header, path string) error {
 		mode |= unix.S_IFIFO
 	}
 
-	return unix.Mknod(path, mode, int(unix.Mkdev(uint32(hdr.Devmajor), uint32(hdr.Devminor))))
+	return mknod(path, mode, unix.Mkdev(uint32(hdr.Devmajor), uint32(hdr.Devminor)))
 }
 
 func handleLChmod(hdr *tar.Header, path string, hdrInfo os.FileInfo) error {
@@ -196,10 +196,7 @@ func copyUpXAttrs(dst, src string) error {
 			}
 			return errors.Wrapf(err, "failed to get xattr %q on %s", xattr, src)
 		}
-		if err := unix.Lsetxattr(dst, xattr, data, unix.XATTR_CREATE); err != nil {
-			if err == unix.ENOTSUP || err == unix.ENODATA || err == unix.EEXIST {
-				continue
-			}
+		if err := lsetxattrCreate(dst, xattr, data); err != nil {
 			return errors.Wrapf(err, "failed to set xattr %q on %s", xattr, dst)
 		}
 	}

--- a/cmd/containerd-shim/shim_freebsd.go
+++ b/cmd/containerd-shim/shim_freebsd.go
@@ -22,7 +22,8 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/containerd/containerd/runtime/v1/shim"
+	"github.com/containerd/containerd/sys/reaper"
+
 	runc "github.com/containerd/go-runc"
 	"github.com/containerd/ttrpc"
 )
@@ -34,7 +35,7 @@ func setupSignals() (chan os.Signal, error) {
 	signal.Notify(signals)
 	// make sure runc is setup to use the monitor
 	// for waiting on processes
-	runc.Monitor = shim.Default
+	runc.Monitor = reaper.Default
 	return signals, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/containerd/btrfs v0.0.0-20201111183144-404b9149801e
 	github.com/containerd/cgroups v0.0.0-20200824123100-0b889c03f102
 	github.com/containerd/console v1.0.1
-	github.com/containerd/continuity v0.0.0-20201204184040-1d9893e5674b
+	github.com/containerd/continuity v0.0.0-20201208142359-180525291bb7
 	github.com/containerd/fifo v0.0.0-20201026212402-0724c46b320c
 	github.com/containerd/go-cni v1.0.1
 	github.com/containerd/go-runc v0.0.0-20200220073739-7016d3ce2328

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/containerd/continuity v0.0.0-20190815185530-f2a389ac0a02/go.mod h1:GL
 github.com/containerd/continuity v0.0.0-20191127005431-f65d91d395eb/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20200710164510-efbc4488d8fe h1:PEmIrUvwG9Yyv+0WKZqjXfSFDeZjs/q15g0m08BYS9k=
 github.com/containerd/continuity v0.0.0-20200710164510-efbc4488d8fe/go.mod h1:cECdGN1O8G9bgKTlLhuPJimka6Xb/Gg7vYzCTNVxhvo=
-github.com/containerd/continuity v0.0.0-20201204184040-1d9893e5674b h1:CUx5QuAGQukRZT3ewWwEQK8RPPX043TJkeTuOd1vINw=
-github.com/containerd/continuity v0.0.0-20201204184040-1d9893e5674b/go.mod h1:kR3BEg7bDFaEddKm54WSmrol1fKWDU1nKYkgrcgZT7Y=
+github.com/containerd/continuity v0.0.0-20201208142359-180525291bb7 h1:6ejg6Lkk8dskcM7wQ28gONkukbQkM4qpj4RnYbpFzrI=
+github.com/containerd/continuity v0.0.0-20201208142359-180525291bb7/go.mod h1:kR3BEg7bDFaEddKm54WSmrol1fKWDU1nKYkgrcgZT7Y=
 github.com/containerd/fifo v0.0.0-20180307165137-3d5202aec260/go.mod h1:ODA38xgv3Kuk8dQz2ZQXpnv/UZZUHUCL7pnLehbXgQI=
 github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448/go.mod h1:ODA38xgv3Kuk8dQz2ZQXpnv/UZZUHUCL7pnLehbXgQI=
 github.com/containerd/fifo v0.0.0-20200410184934-f15a3290365b/go.mod h1:jPQ2IAeZRCYxpS/Cm1495vGFww6ecHmMk1YJH2Q5ln0=

--- a/vendor/github.com/containerd/continuity/AUTHORS
+++ b/vendor/github.com/containerd/continuity/AUTHORS
@@ -19,11 +19,15 @@ Justin Cummins <sul3n3t@gmail.com>
 Kasper Fabæch Brandt <poizan@poizan.dk>
 Kir Kolyshkin <kolyshkin@gmail.com>
 Michael Crosby <crosbymichael@gmail.com>
+Michael Crosby <michael@thepasture.io>
 Michael Wan <zirenwan@gmail.com>
+Mike Brown <brownwm@us.ibm.com>
 Niels de Vos <ndevos@redhat.com>
 Phil Estes <estesp@gmail.com>
 Phil Estes <estesp@linux.vnet.ibm.com>
+Samuel Karp <me@samuelkarp.com>
 Sam Whited <sam@samwhited.com>
+Sebastiaan van Stijn <github@gone.nl>
 Shengjing Zhu <zhsj@debian.org>
 Stephen J Day <stephen.day@docker.com>
 Tibor Vass <tibor@docker.com>

--- a/vendor/github.com/containerd/continuity/README.md
+++ b/vendor/github.com/containerd/continuity/README.md
@@ -63,6 +63,10 @@ $ stat -c %a Makefile
 $ ./bin/continuity verify . /tmp/a.pb
 ```
 
+## Platforms
+
+continuity primarily targets Linux.  continuity may compile for and work on
+other operating systems, but those platforms are not tested.
 
 ## Contribution Guide
 ### Building Proto Package

--- a/vendor/github.com/containerd/continuity/devices/devices_unix.go
+++ b/vendor/github.com/containerd/continuity/devices/devices_unix.go
@@ -56,7 +56,7 @@ func Mknod(p string, mode os.FileMode, maj, min int) error {
 		m |= unix.S_IFIFO
 	}
 
-	return unix.Mknod(p, m, int(dev))
+	return mknod(p, m, dev)
 }
 
 // syscallMode returns the syscall-specific mode bits from Go's portable mode bits.

--- a/vendor/github.com/containerd/continuity/devices/mknod_freebsd.go
+++ b/vendor/github.com/containerd/continuity/devices/mknod_freebsd.go
@@ -1,0 +1,25 @@
+// +build freebsd
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package devices
+
+import "golang.org/x/sys/unix"
+
+func mknod(path string, mode uint32, dev uint64) (err error) {
+	return unix.Mknod(path, mode, dev)
+}

--- a/vendor/github.com/containerd/continuity/devices/mknod_unix.go
+++ b/vendor/github.com/containerd/continuity/devices/mknod_unix.go
@@ -1,0 +1,25 @@
+// +build linux darwin solaris
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package devices
+
+import "golang.org/x/sys/unix"
+
+func mknod(path string, mode uint32, dev uint64) (err error) {
+	return unix.Mknod(path, mode, int(dev))
+}

--- a/vendor/github.com/containerd/continuity/fs/copy_darwinopenbsdsolaris.go
+++ b/vendor/github.com/containerd/continuity/fs/copy_darwinopenbsdsolaris.go
@@ -1,0 +1,40 @@
+// +build darwin openbsd solaris
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fs
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+func copyDevice(dst string, fi os.FileInfo) error {
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return errors.New("unsupported stat type")
+	}
+	return unix.Mknod(dst, uint32(fi.Mode()), int(st.Rdev))
+}
+
+func utimesNano(name string, atime, mtime syscall.Timespec) error {
+	timespec := []syscall.Timespec{atime, mtime}
+	return syscall.UtimesNano(name, timespec)
+}

--- a/vendor/github.com/containerd/continuity/fs/copy_freebsd.go
+++ b/vendor/github.com/containerd/continuity/fs/copy_freebsd.go
@@ -1,0 +1,42 @@
+// +build freebsd
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fs
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+func copyDevice(dst string, fi os.FileInfo) error {
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return errors.New("unsupported stat type")
+	}
+	return unix.Mknod(dst, uint32(fi.Mode()), st.Rdev)
+}
+
+func utimesNano(name string, atime, mtime syscall.Timespec) error {
+	at := unix.NsecToTimespec(atime.Nano())
+	mt := unix.NsecToTimespec(mtime.Nano())
+	utimes := [2]unix.Timespec{at, mt}
+	return unix.UtimesNanoAt(unix.AT_FDCWD, name, utimes[0:], unix.AT_SYMLINK_NOFOLLOW)
+}

--- a/vendor/github.com/containerd/continuity/fs/copy_unix.go
+++ b/vendor/github.com/containerd/continuity/fs/copy_unix.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/containerd/continuity/sysx"
 	"github.com/pkg/errors"
-	"golang.org/x/sys/unix"
 )
 
 func copyFileInfo(fi os.FileInfo, name string) error {
@@ -53,8 +52,7 @@ func copyFileInfo(fi os.FileInfo, name string) error {
 		}
 	}
 
-	timespec := []syscall.Timespec{StatAtime(st), StatMtime(st)}
-	if err := syscall.UtimesNano(name, timespec); err != nil {
+	if err := utimesNano(name, StatAtime(st), StatMtime(st)); err != nil {
 		return errors.Wrapf(err, "failed to utime %s", name)
 	}
 
@@ -101,12 +99,4 @@ func copyXAttrs(dst, src string, xeh XAttrErrorHandler) error {
 	}
 
 	return nil
-}
-
-func copyDevice(dst string, fi os.FileInfo) error {
-	st, ok := fi.Sys().(*syscall.Stat_t)
-	if !ok {
-		return errors.New("unsupported stat type")
-	}
-	return unix.Mknod(dst, uint32(fi.Mode()), int(st.Rdev))
 }

--- a/vendor/github.com/containerd/continuity/fs/du_unix.go
+++ b/vendor/github.com/containerd/continuity/fs/du_unix.go
@@ -41,9 +41,9 @@ type inode struct {
 
 func newInode(stat *syscall.Stat_t) inode {
 	return inode{
-		// Dev is uint32 on darwin/bsd, uint64 on linux/solaris
+		// Dev is uint32 on darwin/bsd, uint64 on linux/solaris/freebsd
 		dev: uint64(stat.Dev), // nolint: unconvert
-		// Ino is uint32 on bsd, uint64 on darwin/linux/solaris
+		// Ino is uint32 on bsd, uint64 on darwin/linux/solaris/freebsd
 		ino: uint64(stat.Ino), // nolint: unconvert
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -71,7 +71,7 @@ github.com/containerd/cgroups/v2/stats
 # github.com/containerd/console v1.0.1
 ## explicit
 github.com/containerd/console
-# github.com/containerd/continuity v0.0.0-20201204184040-1d9893e5674b
+# github.com/containerd/continuity v0.0.0-20201208142359-180525291bb7
 ## explicit
 github.com/containerd/continuity
 github.com/containerd/continuity/devices


### PR DESCRIPTION
This PR updates continuity to include https://github.com/containerd/continuity/pull/173 and updates containerd to compile for FreeBSD.  The built containerd and ctr binaries run, with some plugins not yet loading.

```
% sudo ctr plugin ls
TYPE                            ID                       PLATFORMS        STATUS    
io.containerd.content.v1        content                  -                ok        
io.containerd.snapshotter.v1    native                   freebsd/amd64    ok        
io.containerd.metadata.v1       bolt                     -                ok        
io.containerd.differ.v1         walking                  freebsd/amd64    ok        
io.containerd.gc.v1             scheduler                -                ok        
io.containerd.service.v1        introspection-service    -                ok        
io.containerd.service.v1        containers-service       -                ok        
io.containerd.service.v1        content-service          -                ok        
io.containerd.service.v1        diff-service             -                ok        
io.containerd.service.v1        images-service           -                ok        
io.containerd.service.v1        leases-service           -                ok        
io.containerd.service.v1        namespaces-service       -                ok        
io.containerd.service.v1        snapshots-service        -                ok        
io.containerd.runtime.v2        task                     freebsd/amd64    ok        
io.containerd.service.v1        tasks-service            -                error     
io.containerd.internal.v1       restart                  -                error     
io.containerd.grpc.v1           containers               -                ok        
io.containerd.grpc.v1           content                  -                ok        
io.containerd.grpc.v1           diff                     -                ok        
io.containerd.grpc.v1           events                   -                ok        
io.containerd.grpc.v1           healthcheck              -                ok        
io.containerd.grpc.v1           images                   -                ok        
io.containerd.grpc.v1           leases                   -                ok        
io.containerd.grpc.v1           namespaces               -                ok        
io.containerd.internal.v1       opt                      -                ok        
io.containerd.grpc.v1           snapshots                -                ok        
io.containerd.grpc.v1           tasks                    -                error     
io.containerd.grpc.v1           version                  -                ok 
```