### PR TITLE
[GHA] Add containerd log output when cri-integration tests fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,7 +320,11 @@ jobs:
         env:
           TEST_RUNTIME: ${{ matrix.runtime }}
         run: |
+          set +e
           CONTAINERD_RUNTIME=$TEST_RUNTIME make cri-integration
+          TEST_RC=$?
+          test $TEST_RC -ne 0 && cat /tmp/test-integration/containerd.log
+          test $TEST_RC -eq 0 || /bin/false
         working-directory: src/github.com/containerd/containerd
 
       - name: cri-tools critest


### PR DESCRIPTION
By default cri-integration tests will put the containerd output in a `containerd.log` file under tmp. In Github actions this file is not accessible after the test fails. This file may give important output to debug tests or containerd startup failure.