### PR TITLE
contrib/apparmor: expose LoadDefaultProfile

### DIFF
--- a/contrib/apparmor/apparmor.go
+++ b/contrib/apparmor/apparmor.go
@@ -41,33 +41,41 @@ func WithProfile(profile string) oci.SpecOpts {
 // for the container.  It is only generated if a profile under that name does not exist.
 func WithDefaultProfile(name string) oci.SpecOpts {
 	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {
-		yes, err := isLoaded(name)
-		if err != nil {
+		if err := LoadDefaultProfile(name); err != nil {
 			return err
-		}
-		if yes {
-			s.Process.ApparmorProfile = name
-			return nil
-		}
-		p, err := loadData(name)
-		if err != nil {
-			return err
-		}
-		f, err := ioutil.TempFile(os.Getenv("XDG_RUNTIME_DIR"), p.Name)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-		path := f.Name()
-		defer os.Remove(path)
-
-		if err := generate(p, f); err != nil {
-			return err
-		}
-		if err := load(path); err != nil {
-			return errors.Wrapf(err, "load apparmor profile %s", path)
 		}
 		s.Process.ApparmorProfile = name
 		return nil
 	}
+}
+
+// LoadDefaultProfile ensures the default profile to be loaded with the given name.
+// Returns nil error if the profile is already loaded.
+func LoadDefaultProfile(name string) error {
+	yes, err := isLoaded(name)
+	if err != nil {
+		return err
+	}
+	if yes {
+		return nil
+	}
+	p, err := loadData(name)
+	if err != nil {
+		return err
+	}
+	f, err := ioutil.TempFile(os.Getenv("XDG_RUNTIME_DIR"), p.Name)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	path := f.Name()
+	defer os.Remove(path)
+
+	if err := generate(p, f); err != nil {
+		return err
+	}
+	if err := load(path); err != nil {
+		return errors.Wrapf(err, "load apparmor profile %s", path)
+	}
+	return nil
 }


### PR DESCRIPTION
Expected to be used by nerdctl: https://github.com/AkihiroSuda/nerdctl/blob/6026ae740a52136a5674f322f133f9e3998dc0dc/internal_oci_hook.go#L170-L180
