### PR TITLE
restart: allow passing existing log URI object

### DIFF
--- a/runtime/restart/restart.go
+++ b/runtime/restart/restart.go
@@ -31,6 +31,7 @@ package restart
 
 import (
 	"context"
+	"net/url"
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
@@ -49,37 +50,49 @@ const (
 	LogPathLabel = "containerd.io/restart.logpath"
 )
 
-// WithBinaryLogURI sets the binary-type log uri for a container.
-func WithBinaryLogURI(binary string, args map[string]string) func(context.Context, *containerd.Client, *containers.Container) error {
-	return func(_ context.Context, _ *containerd.Client, c *containers.Container) error {
-		uri, err := cio.LogURIGenerator("binary", binary, args)
-		if err != nil {
-			return err
-		}
+// WithLogURI sets the specified log uri for a container.
+func WithLogURI(uri *url.URL) func(context.Context, *containerd.Client, *containers.Container) error {
+	return WithLogURIString(uri.String())
+}
 
+// WithLogURIString sets the specified log uri string for a container.
+func WithLogURIString(uriString string) func(context.Context, *containerd.Client, *containers.Container) error {
+	return func(_ context.Context, _ *containerd.Client, c *containers.Container) error {
 		ensureLabels(c)
-		c.Labels[LogURILabel] = uri.String()
+		c.Labels[LogURILabel] = uriString
 		return nil
 	}
 }
 
-// WithFileLogURI sets the file-type log uri for a container.
-func WithFileLogURI(path string) func(context.Context, *containerd.Client, *containers.Container) error {
-	return func(_ context.Context, _ *containerd.Client, c *containers.Container) error {
-		uri, err := cio.LogURIGenerator("file", path, nil)
-		if err != nil {
+// WithBinaryLogURI sets the binary-type log uri for a container.
+//
+// Deprecated(in release 1.5): use WithLogURI
+func WithBinaryLogURI(binary string, args map[string]string) func(context.Context, *containerd.Client, *containers.Container) error {
+	uri, err := cio.LogURIGenerator("binary", binary, args)
+	if err != nil {
+		return func(context.Context, *containerd.Client, *containers.Container) error {
 			return err
 		}
-
-		ensureLabels(c)
-		c.Labels[LogURILabel] = uri.String()
-		return nil
 	}
+	return WithLogURI(uri)
+}
+
+// WithFileLogURI sets the file-type log uri for a container.
+//
+// Deprecated(in release 1.5): use WithLogURI
+func WithFileLogURI(path string) func(context.Context, *containerd.Client, *containers.Container) error {
+	uri, err := cio.LogURIGenerator("file", path, nil)
+	if err != nil {
+		return func(context.Context, *containerd.Client, *containers.Container) error {
+			return err
+		}
+	}
+	return WithLogURI(uri)
 }
 
 // WithLogPath sets the log path for a container
 //
-// Deprecated(in release 1.5): use WithFileLogURI.
+// Deprecated(in release 1.5): use WithLogURI with "file://<path>" URI.
 func WithLogPath(path string) func(context.Context, *containerd.Client, *containers.Container) error {
 	return func(_ context.Context, _ *containerd.Client, c *containers.Container) error {
 		ensureLabels(c)


### PR DESCRIPTION
The new function `WithLogURI(uri *url.URL)` replaces `WithBinaryLogURI(binary string, args map[string]string)` so as to allow passing an existring URI object.
