### PR TITLE
update the docs 

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,21 +16,7 @@ You can download one of the latest builds for containerd on the [github releases
 If you are using systemd, we have a `containerd.service` file at the root of the repository that you can use.
 
 The daemon also uses a configuration file located in `/etc/containerd/config.toml` for specifying daemon level options.
-A sample configuration file looks like this:
-
-```toml
-oom_score = -999
-
-[debug]
-        level = "debug"
-
-[metrics]
-        address = "127.0.0.1:1338"
-
-[plugins.linux]
-        runtime = "runc"
-        shim_debug = true
-```
+A sample configuration file can be found [here](containerd/docs/man/containerd-config.toml.5.md)
 
 The default configuration can be generated via `containerd config default > /etc/containerd/config.toml`.
 

--- a/docs/man/containerd-config.toml.5.md
+++ b/docs/man/containerd-config.toml.5.md
@@ -107,8 +107,6 @@ documentation.
 **timeouts**
 : Timeouts specified as a duration
 
- - **[plugins.cgroup]** has one option __no_prometheus__ (Default: **false**)
-
 <!-- [timeouts]
   "io.containerd.timeout.shim.cleanup" = "5s"
   "io.containerd.timeout.shim.load" = "5s"

--- a/docs/man/containerd-config.toml.5.md
+++ b/docs/man/containerd-config.toml.5.md
@@ -23,28 +23,32 @@ settings.
 
 ## FORMAT
 
+**version**
+: The version of the config file
+
 **root**
 : The root directory for containerd metadata. (Default: "/var/lib/containerd")
 
 **state**
 : The state directory for containerd (Default: "/run/containerd")
 
-**oom_score**
-: The out of memory (OOM) score applied to the containerd daemon process (Default: 0)
-
-**imports**
-: Imports is a list of additional configuration files to include.
-This allows to split the main configuration file and keep some sections
-separately (for example vendors may keep a custom runtime configuration in a
-separate file without modifying the main `config.toml`).
-Imported files will overwrite simple fields like `int` or
-`string` (if not empty) and will append `array` and `map` fields.
-Imported files are also versioned, and the version can't be higher than
-the main config.
+**plugin_dir**
+: The directory for dynamic plugins to be stored
 
 **[grpc]**
-: Section for gRPC socket listener settings. Contains three properties:
+: Section for gRPC socket listener settings. Contains properties:
  - **address** (Default: "/run/containerd/containerd.sock")
+ - **tcp_address**
+ - **tcp_tls_cert**
+ - **tcp_tls_key**
+ - **uid** (Default: 0)
+ - **gid** (Default: 0)
+ - **max_recv_message_size**
+ - **max_send_message_size**
+
+**[ttrpc]**
+: Section for TTRPC settings. Contains properties:
+ - **address** (Default: "")
  - **uid** (Default: 0)
  - **gid** (Default: 0)
 
@@ -59,10 +63,14 @@ the main config.
 : Section to enable and configure a metrics listener. Contains two properties:
  - **address** (Default: "") Metrics endpoint does not listen by default
  - **grpc_histogram** (Default: false) Turn on or off gRPC histogram metrics
+  
+**disabled_plugins**
+: DisabledPlugins are IDs of plugins to disable. Disabled plugins won't be
+initialized and started.
 
-**[cgroup]**
-: Section for Linux cgroup specific settings
- - **path** (Default: "") Specify a custom cgroup path for created containers
+**required_plugins**
+: RequiredPlugins are IDs of required plugins. Containerd exits if any
+required plugin doesn't exist or fails to be initialized or started.
 
 **[plugins]**
 : The plugins section contains configuration options exposed from installed plugins.
@@ -77,12 +85,51 @@ documentation.
    **runtime_root** is the root directory used by the runtime (Default: **""**),
    **no_shim** specifies whether to use a shim or not (Default: **false**),
    **shim_debug** turns on debugging for the shim (Default: **false**)
- - **[plugins.scheduler]** has several options that perform advanced tuning for the scheduler:
+ - **[plugins.io.containerd.gc.v1.scheduler]** has several options that perform advanced tuning for the scheduler:
    **pause_threshold** is the maximum amount of time GC should be scheduled (Default: **0.02**),
    **deletion_threshold** guarantees GC is scheduled after n number of deletions (Default: **0** [not triggered]),
    **mutation_threshold** guarantees GC is scheduled after n number of database mutations (Default: **100**),
    **schedule_delay** defines the delay after trigger event before scheduling a GC (Default **"0ms"** [immediate]),
    **startup_delay** defines the delay after startup before scheduling a GC (Default **"100ms"**)
+   
+**oom_score**
+: The out of memory (OOM) score applied to the containerd daemon process (Default: 0)
+
+**[cgroup]**
+: Section for Linux cgroup specific settings
+ - **path** (Default: "") Specify a custom cgroup path for created containers
+
+**[proxy_plugins]**
+: ProxyPlugins configures plugins which are communicated to over GRPC
+ - **type** (Default: "")
+ - **address** (Default: "")
+
+**timeouts**
+: Timeouts specified as a duration
+
+ - **[plugins.cgroup]** has one option __no_prometheus__ (Default: **false**)
+
+<!-- [timeouts]
+  "io.containerd.timeout.shim.cleanup" = "5s"
+  "io.containerd.timeout.shim.load" = "5s"
+  "io.containerd.timeout.shim.shutdown" = "3s"
+  "io.containerd.timeout.task.state" = "2s" -->
+
+**imports**
+: Imports is a list of additional configuration files to include.
+This allows to split the main configuration file and keep some sections
+separately (for example vendors may keep a custom runtime configuration in a
+separate file without modifying the main `config.toml`).
+Imported files will overwrite simple fields like `int` or
+`string` (if not empty) and will append `array` and `map` fields.
+Imported files are also versioned, and the version can't be higher than
+the main config.
+
+**stream_processors**
+ - **accepts** (Default: "[]") Accepts specific media-types
+ - **returns** (Default: "") Returns the media-type
+ - **path** (Default: "") Path or name of the binary
+ - **args** (Default: "[]") Args to the binary
 
 ## EXAMPLE
 


### PR DESCRIPTION
updated the docs to config version=2. https://github.com/containerd/containerd/issues/4426

However, We are not sure where to find the exact config struct and descriptions for plugins and timeouts. Can you guide me on where to find descriptions apart from https://github.com/QFREEE/containerd/blob/master/services/server/config/config.go ?

We also found these timeout properties from other configs, however we are not sure where exactly they are coming from.[timeouts] "io.containerd.timeout.shim.cleanup" = "5s" "io.containerd.timeout.shim.load" = "5s" "io.containerd.timeout.shim.shutdown" = "3s" "io.containerd.timeout.task.state" = "2s"