### PR TITLE
container_opts.go: add WithAdditionalContainerLabels

### DIFF
--- a/container_opts.go
+++ b/container_opts.go
@@ -85,10 +85,27 @@ func WithImageName(n string) NewContainerOpts {
 	}
 }
 
-// WithContainerLabels adds the provided labels to the container
+// WithContainerLabels sets the provided labels to the container.
+// The existing labels are cleared.
+// Use WithAdditionalContainerLabels to preserve the existing labels.
 func WithContainerLabels(labels map[string]string) NewContainerOpts {
 	return func(_ context.Context, _ *Client, c *containers.Container) error {
 		c.Labels = labels
+		return nil
+	}
+}
+
+// WithAdditionalContainerLabels adds the provided labels to the container
+// The existing labels are preserved as long as they do not conflict with the added labels.
+func WithAdditionalContainerLabels(labels map[string]string) NewContainerOpts {
+	return func(_ context.Context, _ *Client, c *containers.Container) error {
+		if c.Labels == nil {
+			c.Labels = labels
+			return nil
+		}
+		for k, v := range labels {
+			c.Labels[k] = v
+		}
 		return nil
 	}
 }


### PR DESCRIPTION
`WithAdditionalContainerLabels()` preserves the existing entries in c.Labels.

OTOH, `WithContainerLabels()` clears them.
