### PR TITLE
Add two fuzzers to integrate containerd into OSS-fuzz

### DIFF
--- a/fuzz/filters_fuzzers.go
+++ b/fuzz/filters_fuzzers.go
@@ -1,0 +1,31 @@
+// +build gofuzz
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fuzz
+
+import (
+	"github.com/containerd/containerd/filters"
+)
+
+func FuzzFiltersParse(data []byte) int {
+	_, err := filters.Parse(string(data))
+	if err != nil {
+		return 0
+	}
+	return 1
+}

--- a/fuzz/platforms_fuzzers.go
+++ b/fuzz/platforms_fuzzers.go
@@ -1,0 +1,31 @@
+// +build gofuzz
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fuzz
+
+import (
+	"github.com/containerd/containerd/platforms"
+)
+
+func FuzzPlatformsParse(data []byte) int {
+	_, err := platforms.Parse(string(data))
+	if err != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
This PR adds two fuzzers to set up continuous fuzzing for containerd on the OSS-fuzz platform.

Fuzzing is a method for testing whereby pseudo-random data is passed to a target entry point in an application - which in these two fuzzers are filters.Parse and platforms.Parse respectively. The application is then observed in the hope of finding bugs and vulnerabilities.
Integrating containerd into OSS-fuzz will allow these two fuzzers to run continuously and look for harder-to-find bugs. If bugs are found maintainers get notified with emails containing a link to a detailed bug report that includes stacktrace and reproducible test case.
I have set up a draft integration PR on the OSS-fuzz side that will be updated according to the progression of this PR: https://github.com/google/oss-fuzz/pull/4839. The build currently fails but I will get it up and running once the fuzzers here are integrated. In the PR on OSS-fuzz there is a `project.yaml` file which requires at least one maintainers email address.

Signed-off-by: AdamKorcz <adam@adalogics.com>