### PR TITLE
Support adding devices by dir

### DIFF
--- a/cmd/ctr/commands/commands.go
+++ b/cmd/ctr/commands/commands.go
@@ -153,7 +153,7 @@ var (
 		},
 		cli.StringSliceFlag{
 			Name:  "device",
-			Usage: "add a device to a container",
+			Usage: "file path to a device to add to the container; or a path to a directory tree of devices to add to the container",
 		},
 		cli.BoolFlag{
 			Name:  "seccomp",

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -264,7 +264,7 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 			opts = append(opts, oci.WithMemoryLimit(limit))
 		}
 		for _, dev := range context.StringSlice("device") {
-			opts = append(opts, oci.WithLinuxDevice(dev, "rwm"))
+			opts = append(opts, oci.WithDevices(dev, "", "rwm"))
 		}
 	}
 

--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -1178,7 +1178,7 @@ func WithLinuxDevice(path, permissions string) SpecOpts {
 		setLinux(s)
 		setResources(s)
 
-		dev, err := deviceFromPath(path, permissions)
+		dev, err := deviceFromPath(path)
 		if err != nil {
 			return err
 		}

--- a/oci/spec_opts_linux.go
+++ b/oci/spec_opts_linux.go
@@ -35,7 +35,7 @@ import (
 func WithHostDevices(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 	setLinux(s)
 
-	devs, err := getDevices("/dev")
+	devs, err := getDevices("/dev", "")
 	if err != nil {
 		return err
 	}
@@ -45,7 +45,47 @@ func WithHostDevices(_ context.Context, _ Client, _ *containers.Container, s *Sp
 
 var errNotADevice = errors.New("not a device node")
 
-func getDevices(path string) ([]specs.LinuxDevice, error) {
+// WithDevices recursively adds devices from the passed in path and associated cgroup rules for that device.
+// If devicePath is a dir it traverses the dir to add all devices in that dir.
+// If devicePath is not a dir, it attempts to add the single device.
+// If containerPath is not set then the device path is used for the container path.
+func WithDevices(devicePath, containerPath, permissions string) SpecOpts {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
+		devs, err := getDevices(devicePath, containerPath)
+		if err != nil {
+			return err
+		}
+		for _, dev := range devs {
+			s.Linux.Devices = append(s.Linux.Devices, dev)
+			s.Linux.Resources.Devices = append(s.Linux.Resources.Devices, specs.LinuxDeviceCgroup{
+				Allow:  true,
+				Type:   dev.Type,
+				Major:  &dev.Major,
+				Minor:  &dev.Minor,
+				Access: permissions,
+			})
+		}
+		return nil
+	}
+}
+
+func getDevices(path, containerPath string) ([]specs.LinuxDevice, error) {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return nil, errors.Wrap(err, "error stating device path")
+	}
+
+	if !stat.IsDir() {
+		dev, err := deviceFromPath(path)
+		if err != nil {
+			return nil, err
+		}
+		if containerPath != "" {
+			dev.Path = containerPath
+		}
+		return []specs.LinuxDevice{*dev}, nil
+	}
+
 	files, err := ioutil.ReadDir(path)
 	if err != nil {
 		return nil, err
@@ -60,7 +100,11 @@ func getDevices(path string) ([]specs.LinuxDevice, error) {
 			case "pts", "shm", "fd", "mqueue", ".lxc", ".lxd-mounts", ".udev":
 				continue
 			default:
-				sub, err := getDevices(filepath.Join(path, f.Name()))
+				var cp string
+				if containerPath != "" {
+					cp = filepath.Join(containerPath, filepath.Base(f.Name()))
+				}
+				sub, err := getDevices(filepath.Join(path, f.Name()), cp)
 				if err != nil {
 					return nil, err
 				}
@@ -71,7 +115,7 @@ func getDevices(path string) ([]specs.LinuxDevice, error) {
 		case f.Name() == "console":
 			continue
 		}
-		device, err := deviceFromPath(filepath.Join(path, f.Name()), "rwm")
+		device, err := deviceFromPath(filepath.Join(path, f.Name()))
 		if err != nil {
 			if err == errNotADevice {
 				continue
@@ -81,12 +125,15 @@ func getDevices(path string) ([]specs.LinuxDevice, error) {
 			}
 			return nil, err
 		}
+		if containerPath != "" {
+			device.Path = filepath.Join(containerPath, filepath.Base(f.Name()))
+		}
 		out = append(out, *device)
 	}
 	return out, nil
 }
 
-func deviceFromPath(path, permissions string) (*specs.LinuxDevice, error) {
+func deviceFromPath(path string) (*specs.LinuxDevice, error) {
 	var stat unix.Stat_t
 	if err := unix.Lstat(path, &stat); err != nil {
 		return nil, err

--- a/oci/spec_opts_linux_test.go
+++ b/oci/spec_opts_linux_test.go
@@ -18,9 +18,14 @@ package oci
 
 import (
 	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/containerd/containerd/pkg/testutil"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"golang.org/x/sys/unix"
 )
 
 func TestAddCaps(t *testing.T) {
@@ -105,4 +110,114 @@ func TestDropCaps(t *testing.T) {
 			t.Errorf("cap list %d is not empty", i)
 		}
 	}
+}
+
+func TestGetDevices(t *testing.T) {
+	testutil.RequiresRoot(t)
+
+	dir, err := ioutil.TempDir("/dev", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	zero := filepath.Join(dir, "zero")
+	if err := ioutil.WriteFile(zero, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := unix.Mount("/dev/zero", zero, "", unix.MS_BIND, ""); err != nil {
+		t.Fatal(err)
+	}
+	defer unix.Unmount(filepath.Join(dir, "zero"), unix.MNT_DETACH)
+
+	t.Run("single device", func(t *testing.T) {
+		t.Run("no container path", func(t *testing.T) {
+			devices, err := getDevices(dir, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if len(devices) != 1 {
+				t.Fatalf("expected one device %v", devices)
+			}
+			if devices[0].Path != zero {
+				t.Fatalf("got unexpected device path %s", devices[0].Path)
+			}
+		})
+		t.Run("with container path", func(t *testing.T) {
+			newPath := "/dev/testNew"
+			devices, err := getDevices(dir, newPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if len(devices) != 1 {
+				t.Fatalf("expected one device %v", devices)
+			}
+			if devices[0].Path != filepath.Join(newPath, "zero") {
+				t.Fatalf("got unexpected device path %s", devices[0].Path)
+			}
+		})
+	})
+	t.Run("With symlink in dir", func(t *testing.T) {
+		if err := os.Symlink("/dev/zero", filepath.Join(dir, "zerosym")); err != nil {
+			t.Fatal(err)
+		}
+		devices, err := getDevices(dir, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(devices) != 1 {
+			t.Fatalf("expected one device %v", devices)
+		}
+		if devices[0].Path != filepath.Join(dir, "zero") {
+			t.Fatalf("got unexpected device path, expected %q, got %q", filepath.Join(dir, "zero"), devices[0].Path)
+		}
+	})
+	t.Run("No devices", func(t *testing.T) {
+		dir := dir + "2"
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(dir)
+
+		t.Run("empty dir", func(T *testing.T) {
+			devices, err := getDevices(dir, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(devices) != 0 {
+				t.Fatalf("expected no devices, got %+v", devices)
+			}
+		})
+		t.Run("symlink to device in dir", func(t *testing.T) {
+			if err := os.Symlink("/dev/zero", filepath.Join(dir, "zerosym")); err != nil {
+				t.Fatal(err)
+			}
+			defer os.Remove(filepath.Join(dir, "zerosym"))
+
+			devices, err := getDevices(dir, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(devices) != 0 {
+				t.Fatalf("expected no devices, got %+v", devices)
+			}
+		})
+		t.Run("regular file in dir", func(t *testing.T) {
+			if err := ioutil.WriteFile(filepath.Join(dir, "somefile"), []byte("hello"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			defer os.Remove(filepath.Join(dir, "somefile"))
+
+			devices, err := getDevices(dir, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(devices) != 0 {
+				t.Fatalf("expected no devices, got %+v", devices)
+			}
+		})
+	})
 }

--- a/oci/spec_opts_unix.go
+++ b/oci/spec_opts_unix.go
@@ -34,7 +34,7 @@ import (
 func WithHostDevices(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 	setLinux(s)
 
-	devs, err := getDevices("/dev")
+	devs, err := getDevices("/dev", "")
 	if err != nil {
 		return err
 	}
@@ -44,7 +44,37 @@ func WithHostDevices(_ context.Context, _ Client, _ *containers.Container, s *Sp
 
 var errNotADevice = errors.New("not a device node")
 
-func getDevices(path string) ([]specs.LinuxDevice, error) {
+// WithDevices recursively adds devices from the passed in path and associated cgroup rules for that device.
+// If devicePath is a dir it traverses the dir to add all devices in that dir.
+// If devicePath is not a dir, it attempts to add the signle device.
+func WithDevices(devicePath, containerPath, permissions string) SpecOpts {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
+		devs, err := getDevices(devicePath, containerPath)
+		if err != nil {
+			return err
+		}
+		s.Linux.Devices = append(s.Linux.Devices, devs...)
+		return nil
+	}
+}
+
+func getDevices(path, containerPath string) ([]specs.LinuxDevice, error) {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return nil, errors.Wrap(err, "error stating device path")
+	}
+
+	if !stat.IsDir() {
+		dev, err := deviceFromPath(path)
+		if err != nil {
+			return nil, err
+		}
+		if containerPath != "" {
+			dev.Path = containerPath
+		}
+		return []specs.LinuxDevice{*dev}, nil
+	}
+
 	files, err := ioutil.ReadDir(path)
 	if err != nil {
 		return nil, err
@@ -59,7 +89,11 @@ func getDevices(path string) ([]specs.LinuxDevice, error) {
 			case "pts", "shm", "fd", "mqueue", ".lxc", ".lxd-mounts", ".udev":
 				continue
 			default:
-				sub, err := getDevices(filepath.Join(path, f.Name()))
+				var cp string
+				if containerPath != "" {
+					cp = filepath.Join(containerPath, filepath.Base(f.Name()))
+				}
+				sub, err := getDevices(filepath.Join(path, f.Name()), cp)
 				if err != nil {
 					return nil, err
 				}
@@ -70,7 +104,7 @@ func getDevices(path string) ([]specs.LinuxDevice, error) {
 		case f.Name() == "console":
 			continue
 		}
-		device, err := deviceFromPath(filepath.Join(path, f.Name()), "rwm")
+		device, err := deviceFromPath(filepath.Join(path, f.Name()))
 		if err != nil {
 			if err == errNotADevice {
 				continue
@@ -80,12 +114,15 @@ func getDevices(path string) ([]specs.LinuxDevice, error) {
 			}
 			return nil, err
 		}
+		if containerPath != "" {
+			device.Path = filepath.Join(containerPath, filepath.Base(f.Name()))
+		}
 		out = append(out, *device)
 	}
 	return out, nil
 }
 
-func deviceFromPath(path, permissions string) (*specs.LinuxDevice, error) {
+func deviceFromPath(path string) (*specs.LinuxDevice, error) {
 	var stat unix.Stat_t
 	if err := unix.Lstat(path, &stat); err != nil {
 		return nil, err

--- a/oci/spec_opts_windows.go
+++ b/oci/spec_opts_windows.go
@@ -74,6 +74,6 @@ func WithHostDevices(_ context.Context, _ Client, _ *containers.Container, s *Sp
 	return nil
 }
 
-func deviceFromPath(path, permissions string) (*specs.LinuxDevice, error) {
+func deviceFromPath(path string) (*specs.LinuxDevice, error) {
 	return nil, errors.New("device from path not supported on Windows")
 }


### PR DESCRIPTION
This enables cases where devices exist in a subdirectory of /dev,
particularly where those device names are not portable across machines,
which makes it problematic to specify from a runtime such as cri.

Added this to `ctr` as well so I could test that the code at least
works.

Closes #4846