### PR TITLE
Return GRPC not found error instead of plain one

### DIFF
--- a/container_linux_test.go
+++ b/container_linux_test.go
@@ -1178,6 +1178,10 @@ func TestContainerLoadUnexistingProcess(t *testing.T) {
 		t.Fatal("an error should have occurred when loading a process that does not exist")
 	}
 
+	if !errdefs.IsNotFound(err) {
+		t.Fatalf("an error of type NotFound should have been returned when loading a process that does not exist, got %#v instead ", err)
+	}
+
 	if err := task.Kill(ctx, syscall.SIGKILL); err != nil {
 		t.Error(err)
 	}

--- a/runtime/v2/runc/v2/service.go
+++ b/runtime/v2/runc/v2/service.go
@@ -483,7 +483,7 @@ func (s *service) State(ctx context.Context, r *taskAPI.StateRequest) (*taskAPI.
 	}
 	p, err := container.Process(r.ExecID)
 	if err != nil {
-		return nil, err
+		return nil, errdefs.ToGRPC(err)
 	}
 	st, err := p.Status(ctx)
 	if err != nil {


### PR DESCRIPTION
When the shim returns a plain error when a process does not exist,
the server is unable to recognise its GRPC status code and assumes
UnknownError. This is awkward for containerd client users as they are
unable to recognise the actual reason for the error.

When the shim returns a NotFound GRPC error, it is properly translated
by the server and clients receive a proper NotFound error instead of
Unknown

Please note that we (CF Garden) would like to have the eventual fix backported to 1.4 as well.

Co-authored-by: Georgi Sabev <georgethebeatle@gmail.com>

