### PR TITLE
[cri] ensure log dir is created

### DIFF
--- a/pkg/cri/server/helpers_linux.go
+++ b/pkg/cri/server/helpers_linux.go
@@ -156,6 +156,9 @@ func (c *criService) seccompEnabled() bool {
 
 // openLogFile opens/creates a container log file.
 func openLogFile(path string) (*os.File, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return nil, err
+	}
 	return os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0640)
 }
 


### PR DESCRIPTION
containerd is responsible for creating the log but there is no code to ensure
that the log dir exists.  While kubelet should have created this there can be
times where this is not the case and this can cause stuck tasks.

Signed-off-by: Michael Crosby <michael@thepasture.io>