### PR TITLE
[release/1.3] cherry-pick: Add bounds on max oom_score_adj value for AdjustOOMScore

### DIFF
--- a/container_linux_test.go
+++ b/container_linux_test.go
@@ -1845,10 +1845,6 @@ func TestShimOOMScore(t *testing.T) {
 		t.Fatal(err)
 	}
 	expectedScore := containerdScore + 1
-	if expectedScore > sys.OOMScoreAdjMax {
-		expectedScore = sys.OOMScoreAdjMax
-	}
-
 	// find the shim's pid
 	for _, p := range processes {
 		score, err := sys.GetOOMScoreAdj(p.Pid)

--- a/container_linux_test.go
+++ b/container_linux_test.go
@@ -1845,6 +1845,10 @@ func TestShimOOMScore(t *testing.T) {
 		t.Fatal(err)
 	}
 	expectedScore := containerdScore + 1
+	if expectedScore > sys.OOMScoreAdjMax {
+		expectedScore = sys.OOMScoreAdjMax
+	}
+
 	// find the shim's pid
 	for _, p := range processes {
 		score, err := sys.GetOOMScoreAdj(p.Pid)

--- a/runtime/v1/shim/client/client.go
+++ b/runtime/v1/shim/client/client.go
@@ -170,7 +170,6 @@ func eaddrinuse(err error) bool {
 
 // setupOOMScore gets containerd's oom score and adds +1 to it
 // to ensure a shim has a lower* score than the daemons
-// if not already at the maximum OOM Score
 func setupOOMScore(shimPid int) error {
 	pid := os.Getpid()
 	score, err := sys.GetOOMScoreAdj(pid)
@@ -178,9 +177,6 @@ func setupOOMScore(shimPid int) error {
 		return errors.Wrap(err, "get daemon OOM score")
 	}
 	shimScore := score + 1
-	if shimScore > sys.OOMScoreAdjMax {
-		shimScore = sys.OOMScoreAdjMax
-	}
 	if err := sys.SetOOMScore(shimPid, shimScore); err != nil {
 		return errors.Wrap(err, "set shim OOM score")
 	}

--- a/runtime/v1/shim/client/client.go
+++ b/runtime/v1/shim/client/client.go
@@ -170,6 +170,7 @@ func eaddrinuse(err error) bool {
 
 // setupOOMScore gets containerd's oom score and adds +1 to it
 // to ensure a shim has a lower* score than the daemons
+// if not already at the maximum OOM Score
 func setupOOMScore(shimPid int) error {
 	pid := os.Getpid()
 	score, err := sys.GetOOMScoreAdj(pid)
@@ -177,6 +178,9 @@ func setupOOMScore(shimPid int) error {
 		return errors.Wrap(err, "get daemon OOM score")
 	}
 	shimScore := score + 1
+	if shimScore > sys.OOMScoreAdjMax {
+		shimScore = sys.OOMScoreAdjMax
+	}
 	if err := sys.SetOOMScore(shimPid, shimScore); err != nil {
 		return errors.Wrap(err, "set shim OOM score")
 	}

--- a/runtime/v2/shim/util_unix.go
+++ b/runtime/v2/shim/util_unix.go
@@ -52,6 +52,7 @@ func SetScore(pid int) error {
 
 // AdjustOOMScore sets the OOM score for the process to the parents OOM score +1
 // to ensure that they parent has a lower* score than the shim
+// if not already at the maximum OOM Score
 func AdjustOOMScore(pid int) error {
 	parent := os.Getppid()
 	score, err := sys.GetOOMScoreAdj(parent)
@@ -59,6 +60,9 @@ func AdjustOOMScore(pid int) error {
 		return errors.Wrap(err, "get parent OOM score")
 	}
 	shimScore := score + 1
+	if shimScore > sys.OOMScoreAdjMax {
+		shimScore = sys.OOMScoreAdjMax
+	}
 	if err := sys.SetOOMScore(pid, shimScore); err != nil {
 		return errors.Wrap(err, "set shim OOM score")
 	}

--- a/runtime/v2/shim/util_unix.go
+++ b/runtime/v2/shim/util_unix.go
@@ -52,7 +52,6 @@ func SetScore(pid int) error {
 
 // AdjustOOMScore sets the OOM score for the process to the parents OOM score +1
 // to ensure that they parent has a lower* score than the shim
-// if not already at the maximum OOM Score
 func AdjustOOMScore(pid int) error {
 	parent := os.Getppid()
 	score, err := sys.GetOOMScoreAdj(parent)
@@ -60,9 +59,6 @@ func AdjustOOMScore(pid int) error {
 		return errors.Wrap(err, "get parent OOM score")
 	}
 	shimScore := score + 1
-	if shimScore > sys.OOMScoreAdjMax {
-		shimScore = sys.OOMScoreAdjMax
-	}
 	if err := sys.SetOOMScore(pid, shimScore); err != nil {
 		return errors.Wrap(err, "set shim OOM score")
 	}

--- a/sys/oom_unix.go
+++ b/sys/oom_unix.go
@@ -28,12 +28,8 @@ import (
 	"github.com/opencontainers/runc/libcontainer/system"
 )
 
-const (
-	// OOMScoreMaxKillable is the maximum score keeping the process killable by the oom killer
-	OOMScoreMaxKillable = -999
-	// OOMScoreAdjMax is from OOM_SCORE_ADJ_MAX https://github.com/torvalds/linux/blob/master/include/uapi/linux/oom.h
-	OOMScoreAdjMax = 1000
-)
+// OOMScoreMaxKillable is the maximum score keeping the process killable by the oom killer
+const OOMScoreMaxKillable = -999
 
 // SetOOMScore sets the oom score for the provided pid
 func SetOOMScore(pid, score int) error {

--- a/sys/oom_unix.go
+++ b/sys/oom_unix.go
@@ -28,8 +28,12 @@ import (
 	"github.com/opencontainers/runc/libcontainer/system"
 )
 
-// OOMScoreMaxKillable is the maximum score keeping the process killable by the oom killer
-const OOMScoreMaxKillable = -999
+const (
+	// OOMScoreMaxKillable is the maximum score keeping the process killable by the oom killer
+	OOMScoreMaxKillable = -999
+	// OOMScoreAdjMax is from OOM_SCORE_ADJ_MAX https://github.com/torvalds/linux/blob/master/include/uapi/linux/oom.h
+	OOMScoreAdjMax = 1000
+)
 
 // SetOOMScore sets the oom score for the provided pid
 func SetOOMScore(pid, score int) error {

--- a/sys/oom_windows.go
+++ b/sys/oom_windows.go
@@ -16,6 +16,11 @@
 
 package sys
 
+const (
+	// OOMScoreAdjMax is not implemented on Windows
+	OOMScoreAdjMax = 0
+)
+
 // SetOOMScore sets the oom score for the process
 //
 // Not implemented on Windows

--- a/sys/oom_windows.go
+++ b/sys/oom_windows.go
@@ -16,11 +16,6 @@
 
 package sys
 
-const (
-	// OOMScoreAdjMax is not implemented on Windows
-	OOMScoreAdjMax = 0
-)
-
 // SetOOMScore sets the oom score for the process
 //
 // Not implemented on Windows


### PR DESCRIPTION
oom_score_adj must be in the range -1000 to 1000. In AdjustOOMScore if containerd's score is already at the maximum value we should set that value for the shim instead of trying to set 1001 which is invalid.

Signed-off-by: Simon Kaegi <simon_kaegi@ca.ibm.com>