### PR TITLE
[fix bug] the first failed garbage collect  will cause a null pointer references on scheduler

### DIFF
--- a/gc/scheduler/scheduler.go
+++ b/gc/scheduler/scheduler.go
@@ -312,11 +312,11 @@ func (s *gcScheduler) run(ctx context.Context) {
 		if err != nil {
 			log.G(ctx).WithError(err).Error("garbage collection failed")
 
-			// Reschedule garbage collection for same duration + 1 second
-			schedC, nextCollection = schedule(nextCollection.Sub(*lastCollection) + time.Second)
-
 			// Update last collection time even though failure occurred
 			lastCollection = &last
+			
+			// Reschedule garbage collection for same duration + 1 second
+			schedC, nextCollection = schedule(nextCollection.Sub(*lastCollection) + time.Second)
 
 			for _, w := range s.waiters {
 				close(w)


### PR DESCRIPTION
When the GarbageCollect runs for the first time and returns an error, the lastCollection is not assigned  but referenced.It could cause panic. We should assign lastCollection first.

Signed-off-by: weichangkun <waykwin@gmail.com>