### PR TITLE
add guidance about GitHub Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,15 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Ask a question (GitHub Discussions)
+    url: https://github.com/containerd/containerd/discussions
+    about: |
+      Please do not submit "a bug report" for asking a question.
+      In most cases, GitHub Discussions is the best place to ask a question.
+      If you are not sure whether you are going to report a bug or ask a question,
+      please consider asking in GitHub Discussions first.
+  - name: Report a security issue
+    url: https://github.com/containerd/project/blob/master/SECURITY.md
+    about: A security issue should be reported privately by email.
+  - name: Chat with containerd users and developers
+    url: https://slack.cncf.io/
+    about: CNCF slack has `#containerd` and `#containerd-dev` channels


### PR DESCRIPTION
Add `.github/ISSUE_TEMPLATE/config.yml` to clarify where is the right place (in the most cases) to ask questions.

ref: https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser