### PR TITLE
Refactor platforms.Only with a "platformVector" helper

### DIFF
--- a/image_test.go
+++ b/image_test.go
@@ -113,7 +113,7 @@ func TestImagePullWithDistSourceLabel(t *testing.T) {
 	key := fmt.Sprintf("containerd.io/distribution.source.%s", source)
 
 	// only check the target platform
-	childrenHandler := images.FilterPlatforms(images.ChildrenHandler(cs), pMatcher)
+	childrenHandler := images.LimitManifests(images.ChildrenHandler(cs), pMatcher, 1)
 
 	checkLabelHandler := func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 		children, err := childrenHandler(ctx, desc)


### PR DESCRIPTION
This improves the hard-coded list of ARM fallbacks in the `platform.Only` implementation (by doing a descending loop over variant numbers instead, which is all the hard-coded list was doing).

Making this a separate function can then more easily be recursive later for handling an `arm64`->`arm` fallback (or similar), but I think it makes the code a lot more clear too (so we're calculating a vector of platforms separately from building a matcher object).

This also makes a minor adjustment in `TestImagePullWithDistSourceLabel` which had an implicit assumption that `platforms.Only` would only ever result in a single suitable manifest, which isn't strictly true (and is likely failing as-is when run on any 32bit `arm` system that's `v6` or higher, which this fixes 😅).

Additionally, this makes `singlePlatformComparer` unused, so rather than switch implementations when `len(vector) == 1`, I opted to remove it because there really shouldn't be much overhead in looping over a single vector list item vs just using/comparing it directly (but I'm happy to revert/adjust if that's preferred).

This splits off another bit from #4528 which should be (hopefully?) less controversial as well. :smile: :heart: