### PR TITLE
ISSUE_TEMPLATE: remove redundant "report a security issue" button

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,9 +7,6 @@ contact_links:
       In most cases, GitHub Discussions is the best place to ask a question.
       If you are not sure whether you are going to report a bug or ask a question,
       please consider asking in GitHub Discussions first.
-  - name: Report a security issue
-    url: https://github.com/containerd/project/blob/master/SECURITY.md
-    about: A security issue should be reported privately by email.
   - name: Chat with containerd users and developers
     url: https://slack.cncf.io/
     about: CNCF slack has `#containerd` and `#containerd-dev` channels


### PR DESCRIPTION
"report a security issue" button was shown redundantly in https://github.com/containerd/containerd/issues/new/choose

![image](https://user-images.githubusercontent.com/9248427/103425154-e9686080-4bf3-11eb-8a19-1fc08d89b585.png)

