### PR TITLE
export: add --skip-non-distributable

### DIFF
--- a/cmd/ctr/commands/images/export.go
+++ b/cmd/ctr/commands/images/export.go
@@ -44,6 +44,10 @@ When '--all-platforms' is given all images in a manifest list must be available.
 			Name:  "skip-manifest-json",
 			Usage: "do not add Docker compatible manifest.json to archive",
 		},
+		cli.BoolFlag{
+			Name:  "skip-non-distributable",
+			Usage: "do not add non-distributable blobs such as Windows layers to archive",
+		},
 		cli.StringSliceFlag{
 			Name:  "platform",
 			Usage: "Pull content from a specific platform",
@@ -84,6 +88,10 @@ When '--all-platforms' is given all images in a manifest list must be available.
 
 		if context.Bool("skip-manifest-json") {
 			exportOpts = append(exportOpts, archive.WithSkipDockerManifest())
+		}
+
+		if context.Bool("skip-non-distributable") {
+			exportOpts = append(exportOpts, archive.WithSkipNonDistributableBlobs())
 		}
 
 		client, ctx, cancel, err := commands.NewClient(context)

--- a/images/mediatypes.go
+++ b/images/mediatypes.go
@@ -102,6 +102,12 @@ func parseMediaTypes(mt string) (string, []string) {
 	return s[0], ext
 }
 
+// IsNonDistributable returns true if the media type is non-distributable.
+func IsNonDistributable(mt string) bool {
+	return strings.HasPrefix(mt, "application/vnd.oci.image.layer.nondistributable.") ||
+		strings.HasPrefix(mt, "application/vnd.docker.image.rootfs.foreign.")
+}
+
 // IsLayerTypes returns true if the media type is a layer
 func IsLayerType(mt string) bool {
 	if strings.HasPrefix(mt, "application/vnd.oci.image.layer.") {


### PR DESCRIPTION
The flag skips adding non-distributable blobs such as Windows layers to archive.
