### PR TITLE
bugfix: change the flag of open log fifo to avoid containerd hang on syscall open

### DIFF
--- a/runtime/v2/binary.go
+++ b/runtime/v2/binary.go
@@ -115,6 +115,7 @@ func (b *binary) Start(ctx context.Context, opts *types.Any, onClose func()) (_ 
 	onCloseWithShimLog := func() {
 		onClose()
 		cancelShimLog()
+		f.Close()
 	}
 	client := ttrpc.NewClient(conn, ttrpc.WithOnClose(onCloseWithShimLog))
 	return &shim{

--- a/runtime/v2/shim_unix.go
+++ b/runtime/v2/shim_unix.go
@@ -30,7 +30,7 @@ import (
 )
 
 func openShimLog(ctx context.Context, bundle *Bundle, _ func(string, time.Duration) (net.Conn, error)) (io.ReadCloser, error) {
-	return fifo.OpenFifo(ctx, filepath.Join(bundle.Path, "log"), unix.O_RDONLY|unix.O_CREAT|unix.O_NONBLOCK, 0700)
+	return fifo.OpenFifo(ctx, filepath.Join(bundle.Path, "log"), unix.O_RDWR|unix.O_CREAT|unix.O_NONBLOCK, 0700)
 }
 
 func checkCopyShimLogError(ctx context.Context, err error) error {


### PR DESCRIPTION
From #4905 
If shim never call openLog or died, some thread of containerd will hang on openat.
Considering #3266 and #4046, open the fifo with RDWR and close the fifo-wrapper when shim closed.

Signed-off-by: payall4u <payall4u@qq.com>