### PR TITLE
docs: Fix incorrect camel-case runc options

### DIFF
--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -168,40 +168,40 @@ version = 2
 
       # 'plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options' is options specific to
       # "io.containerd.runc.v1" and "io.containerd.runc.v2". Its corresponding options type is:
-      #   https://github.com/containerd/containerd/blob/v1.3.2/runtime/v2/runc/options/oci.pb.go#L26 .
+      #   https://github.com/containerd/containerd/blob/v1.4.3/runtime/v2/runc/options/oci.pb.go#L27 .
       [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
-        # NoPivotRoot disables pivot root when creating a container.
-        NoPivotRoot = false
+        # no_pivot_root disables pivot root when creating a container.
+        no_pivot_root = false
 
-        # NoNewKeyring disables new keyring for the container.
-        NoNewKeyring = false
+        # no_new_keyring disables new keyring for the container.
+        no_new_keyring = false
 
-        # ShimCgroup places the shim in a cgroup.
-        ShimCgroup = ""
+        # shim_cgroup places the shim in a cgroup.
+        shim_cgroup = ""
 
-        # IoUid sets the I/O's pipes uid.
-        IoUid = 0
+        # io_uid sets the I/O's pipes uid.
+        io_uid = 0
 
-        # IoGid sets the I/O's pipes gid.
-        IoGid = 0
+        # io_gid sets the I/O's pipes gid.
+        io_gid = 0
 
-        # BinaryName is the binary name of the runc binary.
-        BinaryName = ""
+        # binary_name is the binary name of the runc binary.
+        binary_name = ""
 
-        # Root is the runc root directory.
-        Root = ""
+        # root is the runc root directory.
+        root = ""
 
-        # CriuPath is the criu binary path.
-        CriuPath = ""
+        # criu_path is the criu binary path.
+        criu_path = ""
 
-        # SystemdCgroup enables systemd cgroups.
-        SystemdCgroup = false
+        # systemd_cgroup enables systemd cgroups.
+        systemd_cgroup = false
 
-        # CriuImagePath is the criu image path
-        CriuImagePath = ""
+        # criu_image_path is the criu image path
+        criu_image_path = ""
 
-        # CriuWorkPath is the criu work path.
-        CriuWorkPath = ""
+        # criu_work_path is the criu work path.
+        criu_work_path = ""
 
   # 'plugins."io.containerd.grpc.v1.cri".cni' contains config related to cni
   [plugins."io.containerd.grpc.v1.cri".cni]


### PR DESCRIPTION
According to [protobuf definition here](https://github.com/containerd/containerd/blob/master/runtime/v2/runc/options/oci.proto)
All options should be snake-case.


Also, using camel-case in configuration proved to be not working.