### PR TITLE
Allow passing environent variables to StreamProcessors

### DIFF
--- a/diff/stream.go
+++ b/diff/stream.go
@@ -168,7 +168,7 @@ func (c *compressedProcessor) Close() error {
 	return c.rc.Close()
 }
 
-func BinaryHandler(id, returnsMediaType string, mediaTypes []string, path string, args []string) Handler {
+func BinaryHandler(id, returnsMediaType string, mediaTypes []string, path string, args, env []string) Handler {
 	set := make(map[string]struct{}, len(mediaTypes))
 	for _, m := range mediaTypes {
 		set[m] = struct{}{}
@@ -177,7 +177,7 @@ func BinaryHandler(id, returnsMediaType string, mediaTypes []string, path string
 		if _, ok := set[mediaType]; ok {
 			return func(ctx context.Context, stream StreamProcessor, payloads map[string]*types.Any) (StreamProcessor, error) {
 				payload := payloads[id]
-				return NewBinaryProcessor(ctx, mediaType, returnsMediaType, stream, path, args, payload)
+				return NewBinaryProcessor(ctx, mediaType, returnsMediaType, stream, path, args, env, payload)
 			}, true
 		}
 		return nil, false

--- a/diff/stream_unix.go
+++ b/diff/stream_unix.go
@@ -33,9 +33,10 @@ import (
 )
 
 // NewBinaryProcessor returns a binary processor for use with processing content streams
-func NewBinaryProcessor(ctx context.Context, imt, rmt string, stream StreamProcessor, name string, args []string, payload *types.Any) (StreamProcessor, error) {
+func NewBinaryProcessor(ctx context.Context, imt, rmt string, stream StreamProcessor, name string, args, env []string, payload *types.Any) (StreamProcessor, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, env...)
 
 	var payloadC io.Closer
 	if payload != nil {

--- a/diff/stream_windows.go
+++ b/diff/stream_windows.go
@@ -39,9 +39,10 @@ import (
 const processorPipe = "STREAM_PROCESSOR_PIPE"
 
 // NewBinaryProcessor returns a binary processor for use with processing content streams
-func NewBinaryProcessor(ctx context.Context, imt, rmt string, stream StreamProcessor, name string, args []string, payload *types.Any) (StreamProcessor, error) {
+func NewBinaryProcessor(ctx context.Context, imt, rmt string, stream StreamProcessor, name string, args, env []string, payload *types.Any) (StreamProcessor, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, env...)
 
 	if payload != nil {
 		data, err := proto.Marshal(payload)

--- a/services/server/config/config.go
+++ b/services/server/config/config.go
@@ -80,6 +80,8 @@ type StreamProcessor struct {
 	Path string `toml:"path"`
 	// Args to the binary
 	Args []string `toml:"args"`
+	// Environment variables for the binary
+	Env []string `toml:"env"`
 }
 
 // GetVersion returns the config file's version

--- a/services/server/server.go
+++ b/services/server/server.go
@@ -91,7 +91,7 @@ func New(ctx context.Context, config *srvconfig.Config) (*Server, error) {
 		return nil, err
 	}
 	for id, p := range config.StreamProcessors {
-		diff.RegisterProcessor(diff.BinaryHandler(id, p.Returns, p.Accepts, p.Path, p.Args))
+		diff.RegisterProcessor(diff.BinaryHandler(id, p.Returns, p.Accepts, p.Path, p.Args, p.Env))
 	}
 
 	serverOpts := []grpc.ServerOption{


### PR DESCRIPTION
Add support for an 'envs' field to the StreamProcessor configuration
and append it to the os.Environ() array.
The envs field takes environment variables in the form of key=value.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>