### PR TITLE
[release/1.4] runtime/v2: should use defer ctx to cleanup

### DIFF
--- a/runtime/v2/manager.go
+++ b/runtime/v2/manager.go
@@ -159,7 +159,7 @@ func (m *TaskManager) Create(ctx context.Context, id string, opts runtime.Create
 			defer cancel()
 			_, errShim := shim.Delete(dctx)
 			if errShim != nil {
-				shim.Shutdown(ctx)
+				shim.Shutdown(dctx)
 				shim.Close()
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Wei Fu <fuweid89@gmail.com>
(cherry picked from commit 846cb963cc4fe20237092bdbe62828dfe2ff1541)
Signed-off-by: Wei Fu <fuweid89@gmail.com>

cherry-pick: https://github.com/containerd/containerd/pull/4923