### PR TITLE
Allow arm64 to fallback to arm (v8, v7, v6, v5)

### DIFF
--- a/platforms/compare.go
+++ b/platforms/compare.go
@@ -57,6 +57,18 @@ func platformVector(platform specs.Platform) []specs.Platform {
 				})
 			}
 		}
+	case "arm64":
+		variant := platform.Variant
+		if variant == "" {
+			variant = "v8"
+		}
+		vector = append(vector, platformVector(specs.Platform{
+			Architecture: "arm",
+			OS:           platform.OS,
+			OSVersion:    platform.OSVersion,
+			OSFeatures:   platform.OSFeatures,
+			Variant:      variant,
+		})...)
 	}
 
 	return vector

--- a/platforms/compare_test.go
+++ b/platforms/compare_test.go
@@ -166,17 +166,17 @@ func TestOnly(t *testing.T) {
 			platform: "linux/arm64",
 			matches: map[bool][]string{
 				true: {
+					"linux/arm",
+					"linux/arm/v5",
+					"linux/arm/v6",
+					"linux/arm/v7",
+					"linux/arm/v8",
 					"linux/arm64",
 					"linux/arm64/v8",
 				},
 				false: {
 					"linux/amd64",
-					"linux/arm",
 					"linux/arm/v4",
-					"linux/arm/v5",
-					"linux/arm/v6",
-					"linux/arm/v7",
-					"linux/arm/v8",
 					"linux/arm/v9",
 					"linux/arm64/v9",
 					"windows/amd64",

--- a/platforms/cpuinfo.go
+++ b/platforms/cpuinfo.go
@@ -107,12 +107,7 @@ func getCPUVariant() string {
 
 	switch strings.ToLower(variant) {
 	case "8", "aarch64":
-		// special case: if running a 32-bit userspace on aarch64, the variant should be "v7"
-		if runtime.GOARCH == "arm" {
-			variant = "v7"
-		} else {
-			variant = "v8"
-		}
+		variant = "v8"
 	case "7", "7m", "?(12)", "?(13)", "?(14)", "?(15)", "?(16)", "?(17)":
 		variant = "v7"
 	case "6", "6tej":


### PR DESCRIPTION
This isn't supported by *all* arm64 chips, but it is common enough that I think it's worth an explicit fallback.  I think it will be more common for images to have arm64 support without arm support, but even if a user has an arm64 chip that does not support arm32, having it fail to run the arm32 image is an acceptable compromise (because it's non-trivial to detect arm32 support without running a binary, AFAIK).

Also, before this change the failure would've simply been "no such image" instead of "failed to run" so I think it's pretty reasonable to allow it to try the additional 32bit set of images just in case one of them actually does work (like it will on many popular chips like 64bit Raspberry Pis and AWS Graviton).

This also reverts https://github.com/containerd/containerd/pull/4013 (https://github.com/containerd/containerd/issues/3990) because it should no longer be necessary with this follow-up to #4891 - if `GOARCH` is `arm` but the CPU reports variant 8, it will try 8, then 7, 6, and finally 5, and `arm64` will fall back to that same vector.

The exact set of "acceptable" platforms is more clearly seen in the test changes. :smile: :smirk: