### PR TITLE
Ensure request.header is never nil

### DIFF
--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -446,6 +446,9 @@ func (r *dockerBase) filterHosts(caps HostCapabilities) (hosts []RegistryHost) {
 
 func (r *dockerBase) request(host RegistryHost, method string, ps ...string) *request {
 	header := r.header.Clone()
+	if header == nil {
+		header = http.Header{}
+	}
 
 	for key, value := range host.Header {
 		header[key] = append(header[key], value...)


### PR DESCRIPTION
Header.Clone() will return `nil` if called on a nil object.

Fixes a panic seen in the unit tests after #4302 was merged.