### PR TITLE
[release/v1.4] [cri] ensure log dir is created

### DIFF
--- a/vendor/github.com/containerd/cri/pkg/server/helpers_unix.go
+++ b/vendor/github.com/containerd/cri/pkg/server/helpers_unix.go
@@ -151,6 +151,9 @@ func (c *criService) seccompEnabled() bool {
 
 // openLogFile opens/creates a container log file.
 func openLogFile(path string) (*os.File, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return nil, err
+	}
 	return os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0640)
 }
 


### PR DESCRIPTION
containerd is responsible for creating the log but there is no code to ensure
that the log dir exists.  While kubelet should have created this there can be
times where this is not the case and this can cause stuck tasks.

Signed-off-by: Michael Crosby <michael@thepasture.io>
(cherry picked from commit 2e442ea4852d3a4a4bb01438032da3e1896fe3f0)
Signed-off-by: Shengjing Zhu <zhsj@debian.org>

cherry-pick #4863