### PR TITLE
Derive cpuinfo as needed, instead of at init-time

### DIFF
--- a/platforms/cpuinfo.go
+++ b/platforms/cpuinfo.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync"
 
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
@@ -28,14 +29,18 @@ import (
 )
 
 // Present the ARM instruction set architecture, eg: v7, v8
-var cpuVariant string
+// Don't use this value directly; call cpuVariant() instead.
+var cpuVariantValue string
 
-func init() {
-	if isArmArch(runtime.GOARCH) {
-		cpuVariant = getCPUVariant()
-	} else {
-		cpuVariant = ""
-	}
+var cpuVariantOnce sync.Once
+
+func cpuVariant() string {
+	cpuVariantOnce.Do(func() {
+		if isArmArch(runtime.GOARCH) {
+			cpuVariantValue = getCPUVariant()
+		}
+	})
+	return cpuVariantValue
 }
 
 // For Linux, the kernel has already detected the ABI, ISA and Features.

--- a/platforms/defaults.go
+++ b/platforms/defaults.go
@@ -33,6 +33,6 @@ func DefaultSpec() specs.Platform {
 		OS:           runtime.GOOS,
 		Architecture: runtime.GOARCH,
 		// The Variant field will be empty if arch != ARM.
-		Variant: cpuVariant,
+		Variant: cpuVariant(),
 	}
 }

--- a/platforms/defaults_test.go
+++ b/platforms/defaults_test.go
@@ -28,7 +28,7 @@ func TestDefault(t *testing.T) {
 	expected := specs.Platform{
 		OS:           runtime.GOOS,
 		Architecture: runtime.GOARCH,
-		Variant:      cpuVariant,
+		Variant:      cpuVariant(),
 	}
 	p := DefaultSpec()
 	if !reflect.DeepEqual(p, expected) {

--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -189,8 +189,8 @@ func Parse(specifier string) (specs.Platform, error) {
 		if isKnownOS(p.OS) {
 			// picks a default architecture
 			p.Architecture = runtime.GOARCH
-			if p.Architecture == "arm" && cpuVariant != "v7" {
-				p.Variant = cpuVariant
+			if p.Architecture == "arm" && cpuVariant() != "v7" {
+				p.Variant = cpuVariant()
 			}
 
 			return p, nil

--- a/platforms/platforms_test.go
+++ b/platforms/platforms_test.go
@@ -31,8 +31,8 @@ func TestParseSelector(t *testing.T) {
 		defaultVariant = ""
 	)
 
-	if defaultArch == "arm" && cpuVariant != "v7" {
-		defaultVariant = cpuVariant
+	if defaultArch == "arm" && cpuVariant() != "v7" {
+		defaultVariant = cpuVariant()
 	}
 
 	for _, testcase := range []struct {


### PR DESCRIPTION
This changes `platforms.Parse` to hit `/proc` to look up CPU info only when it's needed, instead of in `init()`. This makes the package a bit easier for other packages to consume, especially clients that don't call `platforms.Parse` or need to lookup CPU info.

This recently came up in https://github.com/google/go-containerregistry/issues/916 since go-containerregistry imports moby/moby, which imports containerd/containerd/platforms to call `platforms.Parse` when starting a container -- go-containerregistry never starts containers and doesn't care about the value of `platforms.Parse` or `cpuInfo`.

cc @jonjohnsonjr 