### PR TITLE
Add cgo tag to btrfs plugin

### DIFF
--- a/cmd/containerd/builtins_btrfs_linux.go
+++ b/cmd/containerd/builtins_btrfs_linux.go
@@ -1,4 +1,4 @@
-// +build !no_btrfs
+// +build !no_btrfs,cgo
 
 /*
    Copyright The containerd Authors.

--- a/snapshots/btrfs/btrfs.go
+++ b/snapshots/btrfs/btrfs.go
@@ -1,4 +1,4 @@
-// +build linux,!no_btrfs
+// +build linux,!no_btrfs,cgo
 
 /*
    Copyright The containerd Authors.

--- a/snapshots/btrfs/btrfs_test.go
+++ b/snapshots/btrfs/btrfs_test.go
@@ -1,4 +1,4 @@
-// +build linux,!no_btrfs
+// +build linux,!no_btrfs,cgo
 
 /*
    Copyright The containerd Authors.

--- a/snapshots/btrfs/plugin/plugin.go
+++ b/snapshots/btrfs/plugin/plugin.go
@@ -1,4 +1,4 @@
-// +build linux,!no_btrfs
+// +build linux,!no_btrfs,cgo
 
 /*
    Copyright The containerd Authors.


### PR DESCRIPTION
btrfs plugin needs CGO support. However on riscv64, cgo
is only support on go1.16 (not released yet).
Instead of setting no_btrfs manually, adding a cgo tag tells
the compiler to skip it automatically.