### PR TITLE
remove exec sync debug contents from logs

### DIFF
--- a/pkg/cri/server/instrumented_service.go
+++ b/pkg/cri/server/instrumented_service.go
@@ -253,8 +253,6 @@ func (in *instrumentedService) ExecSync(ctx context.Context, r *runtime.ExecSync
 			log.G(ctx).WithError(err).Errorf("ExecSync for %q failed", r.GetContainerId())
 		} else {
 			log.G(ctx).Debugf("ExecSync for %q returns with exit code %d", r.GetContainerId(), res.GetExitCode())
-			log.G(ctx).Debugf("ExecSync for %q outputs - stdout: %q, stderr: %q", r.GetContainerId(),
-				res.GetStdout(), res.GetStderr())
 		}
 	}()
 	res, err = in.c.ExecSync(ctrdutil.WithNamespace(ctx), r)


### PR DESCRIPTION
This was dumping untrusted output to the debug logs from user containers.
We should not dump this type of information to reduce log sizes and any
information leaks from user containers.

Signed-off-by: Michael Crosby <michael@thepasture.io>