### PR TITLE
Allow moving netns directory into StateDir 

### DIFF
--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -59,6 +59,11 @@ version = 2
 	# ReadOnlyRootFilesystem since containers won't silently mount a temporary volume.
   ignore_image_defined_volumes = false
 
+  # netns_mounts_under_state_dir places all mounts for network namespaces under StateDir/netns
+  # instead of being placed under the hardcoded directory /var/run/netns. Changing this setting
+  # requires that all containers are deleted.
+  netns_mounts_under_state_dir = false
+
   # 'plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming' contains a x509 valid key pair to stream with tls.
   [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
     # tls_cert_file is the filepath to the certificate paired with the "tls_key_file"

--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -253,6 +253,10 @@ type PluginConfig struct {
 	// isolation, security and early detection of issues in the mount configuration when using
 	// ReadOnlyRootFilesystem since containers won't silently mount a temporary volume.
 	IgnoreImageDefinedVolumes bool `toml:"ignore_image_defined_volumes" json:"ignoreImageDefinedVolumes"`
+	// NetNSMountsUnderStateDir places all mounts for network namespaces under StateDir/netns instead
+	// of being placed under the hardcoded directory /var/run/netns. Changing this setting requires
+	// that all containers are deleted.
+	NetNSMountsUnderStateDir bool `toml:"netns_mounts_under_state_dir" json:"netnsMountsUnderStateDir"`
 }
 
 // X509KeyPairStreaming contains the x509 configuration for streaming

--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -19,6 +19,7 @@ package server
 import (
 	"encoding/json"
 	"math"
+	"path/filepath"
 	goruntime "runtime"
 	"strings"
 
@@ -120,7 +121,11 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		// handle. NetNSPath in sandbox metadata and NetNS is non empty only for non host network
 		// namespaces. If the pod is in host network namespace then both are empty and should not
 		// be used.
-		sandbox.NetNS, err = netns.NewNetNS()
+		var netnsMountDir string = "/var/run/netns"
+		if c.config.NetNSMountsUnderStateDir {
+			netnsMountDir = filepath.Join(c.config.StateDir, "netns")
+		}
+		sandbox.NetNS, err = netns.NewNetNS(netnsMountDir)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to create network namespace for sandbox %q", id)
 		}

--- a/pkg/netns/netns_other.go
+++ b/pkg/netns/netns_other.go
@@ -30,7 +30,7 @@ type NetNS struct {
 }
 
 // NewNetNS creates a network namespace.
-func NewNetNS() (*NetNS, error) {
+func NewNetNS(baseDir string) (*NetNS, error) {
 	return nil, errNotImplementedOnUnix
 }
 

--- a/pkg/netns/netns_windows.go
+++ b/pkg/netns/netns_windows.go
@@ -26,7 +26,7 @@ type NetNS struct {
 }
 
 // NewNetNS creates a network namespace for the sandbox
-func NewNetNS() (*NetNS, error) {
+func NewNetNS(baseDir string) (*NetNS, error) {
 	temp := hcn.HostComputeNamespace{}
 	hcnNamespace, err := temp.Create()
 	if err != nil {


### PR DESCRIPTION
The directory where cri puts the netns references is currently hardcoded. This moves it into StateDir which can be configured.

Having this configurable is useful for systems with read-only root filesystems where one needs tight controls over where software
is able to write to.