### PR TITLE
Makefile: run "go mod tidy" when vendoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -376,6 +376,7 @@ root-coverage: ## generate coverage profiles for unit tests that require root
 
 vendor:
 	@echo "$(WHALE) $@"
+	@go mod tidy
 	@go mod vendor
 
 help: ## this help


### PR DESCRIPTION
relates to https://github.com/containerd/containerd/pull/4717#issuecomment-768295224

`make vendor` did not do a `go mod tidy` after vendoring, whereas CI does this as part of the vendor validation, causing CI to fail if `make vendor` was used to update vendoring, without doing a `go mod tidy` afterwards.
