### PR TITLE
cio: prevent NPE when closing, and fix pipes potentially not being closed on Windows 

### DIFF
--- a/cio/io.go
+++ b/cio/io.go
@@ -80,7 +80,7 @@ type FIFOSet struct {
 
 // Close the FIFOSet
 func (f *FIFOSet) Close() error {
-	if f.close != nil {
+	if f != nil && f.close != nil {
 		return f.close()
 	}
 	return nil

--- a/cio/io_unix.go
+++ b/cio/io_unix.go
@@ -103,38 +103,36 @@ func copyIO(fifos *FIFOSet, ioset *Streams) (*cio, error) {
 	}, nil
 }
 
-func openFifos(ctx context.Context, fifos *FIFOSet) (pipes, error) {
-	var err error
+func openFifos(ctx context.Context, fifos *FIFOSet) (f pipes, retErr error) {
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			fifos.Close()
 		}
 	}()
 
-	var f pipes
 	if fifos.Stdin != "" {
-		if f.Stdin, err = fifo.OpenFifo(ctx, fifos.Stdin, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
-			return f, errors.Wrapf(err, "failed to open stdin fifo")
+		if f.Stdin, retErr = fifo.OpenFifo(ctx, fifos.Stdin, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); retErr != nil {
+			return f, errors.Wrapf(retErr, "failed to open stdin fifo")
 		}
 		defer func() {
-			if err != nil && f.Stdin != nil {
+			if retErr != nil && f.Stdin != nil {
 				f.Stdin.Close()
 			}
 		}()
 	}
 	if fifos.Stdout != "" {
-		if f.Stdout, err = fifo.OpenFifo(ctx, fifos.Stdout, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
-			return f, errors.Wrapf(err, "failed to open stdout fifo")
+		if f.Stdout, retErr = fifo.OpenFifo(ctx, fifos.Stdout, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); retErr != nil {
+			return f, errors.Wrapf(retErr, "failed to open stdout fifo")
 		}
 		defer func() {
-			if err != nil && f.Stdout != nil {
+			if retErr != nil && f.Stdout != nil {
 				f.Stdout.Close()
 			}
 		}()
 	}
 	if !fifos.Terminal && fifos.Stderr != "" {
-		if f.Stderr, err = fifo.OpenFifo(ctx, fifos.Stderr, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
-			return f, errors.Wrapf(err, "failed to open stderr fifo")
+		if f.Stderr, retErr = fifo.OpenFifo(ctx, fifos.Stderr, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); retErr != nil {
+			return f, errors.Wrapf(retErr, "failed to open stderr fifo")
 		}
 	}
 	return f, nil


### PR DESCRIPTION


### 1. cio: FIFOSet.Close() check if FIFOSet is nill to prevent NPE

This relates to https://github.com/docker/for-linux/issues/1186. Perhaps this needs synchronisation elsewhere, but looks like this could potentially panic here as well. Seems not harmful to check for `nil`.

### 2. cio: openFifos() use named return variables to use in defer()

This change is mostly defensive; when checking for the returned error, it's easy to make a mistake, and check for a "local" error, not the actual returned error.

This patch changes the function to use a named return variable, which is checked in the defer.

### 3. cio.copyIO: fix pipes potentially not being closed (Windows)

The defer functions were checking the local variable, and would therefore not be executed, as the function returned if an error occurred.

Perhaps best illustrated when renaming the local variables;

```go
if fifos.Stdin != "" {
    l, err1 := winio.ListenPipe(fifos.Stdin, nil)
    if err1 != nil {
        return nil, errors.Wrapf(err1, "failed to create stdin pipe %s", fifos.Stdin)
    }
    defer func(l net.Listener) {
        if err1 != nil {
            l.Close()
        }
    }(l)
    // ...
}

if fifos.Stdout != "" {
    l, err2 := winio.ListenPipe(fifos.Stdout, nil)
    if err2 != nil {
        return nil, errors.Wrapf(err2, "failed to create stdout pipe %s", fifos.Stdout)
    }
    defer func(l net.Listener) {
        if err2 != nil {
            l.Close()
        }
    }(l)
    // ....
}
```

This patch changes the function to use a named return variable, and to use a single `defer()` that closes all pipes.

### 4. cio.copyIO: refactor to use cio.Close() (windows)

A follow-up to the patch above; Use the existing `.Close()` method instead of implementing the same
logic in this function.

The defer sets `cios` to `nil` if an error occurred to preserve the existing behavior.
