### PR TITLE
Tolerate 403 response for registry OAuth fallback

### DIFF
--- a/remotes/docker/authorizer.go
+++ b/remotes/docker/authorizer.go
@@ -284,7 +284,14 @@ func (ah *authHandler) doBearerAuth(ctx context.Context) (token string, err erro
 				// Registries without support for POST may return 404 for POST /v2/token.
 				// As of September 2017, GCR is known to return 404.
 				// As of February 2018, JFrog Artifactory is known to return 401.
-				if (errStatus.StatusCode == 405 && to.Username != "") || errStatus.StatusCode == 404 || errStatus.StatusCode == 401 {
+				// As of December 2019, Harbor is known to return 403, and it's fixed soon
+				// in https://github.com/goharbor/harbor/pull/10362
+				// As of January 2021, Docker community's registry implementation (https://github.com/distribution/distribution)
+				// is known to return 403, too.
+				// See https://github.com/containerd/containerd/issues/4982 for details.
+				if (errStatus.StatusCode == http.StatusMethodNotAllowed && to.Username != "") ||
+					errStatus.StatusCode == http.StatusNotFound || errStatus.StatusCode == http.StatusUnauthorized ||
+					errStatus.StatusCode == http.StatusForbidden {
 					resp, err := auth.FetchToken(ctx, ah.client, ah.header, to)
 					if err != nil {
 						return "", err


### PR DESCRIPTION
Fix #4982 

<details>
  <summary>registry logs prove that it works as expected after patch</summary>
<pre>
time="2021-02-01T03:32:36.39742404Z" level=debug msg="authorizing request" go.version=go1.12.14 http.request.host="localhost:5000" http.request.id=9bd25d6d-1c61-4306-bb07-151c53053ff4 http.request.method=HEAD http.request.remoteaddr="172.16.0.1:38105" http.request.uri="/v2/test-img/manifests/test" http.request.useragent="containerd/v1.5.0-beta.0-37-ge83ac5f" vars.name=test-img vars.reference=test

time="2021-02-01T03:32:36.397812657Z" level=warning msg="error authorizing context: authorization token required" go.version=go1.12.14 http.request.host="localhost:5000" http.request.id=9bd25d6d-1c61-4306-bb07-151c53053ff4 http.request.method=HEAD http.request.remoteaddr="172.16.0.1:38105" http.request.uri="/v2/test-img/manifests/test" http.request.useragent="containerd/v1.5.0-beta.0-37-ge83ac5f" vars.name=test-img vars.reference=test

172.16.0.1 - - [01/Feb/2021:03:32:36 +0000] "HEAD /v2/test-img/manifests/test HTTP/1.1" 401 155 "" "containerd/v1.5.0-beta.0-37-ge83ac5f"

2021/02/01 03:32:36.428 [E]  Authorization not exist

172.16.0.1 - - [30/Jan/2021:03:43:20 +0000] "POST /auth/token HTTP/1.1" 403 0 "" "Go-http-client/1.1"

172.16.0.1 - - [01/Feb/2021:03:32:38 +0000] "GET /auth/token?scope=repository%3Atest-img%3Apull&service=test-token-service HTTP/1.1" 200 301 "" "Go-http-client/1.1"

time="2021-02-01T03:32:38.698417376Z" level=info msg="response completed" go.version=go1.12.14 http.request.host="localhost:5000" http.request.id=714b2231-652c-42f3-8778-430904e5b010 http.request.method=GET http.request.remoteaddr="172.16.0.1:12359" http.request.uri="/auth/token?scope=repository%3Atest-img%3Apull&service=test-token-service" http.request.useragent="Go-http-client/1.1" http.response.contenttype="application/json" http.response.duration=246.510005ms http.response.status=200 http.response.written=301

time="2021-02-01T03:32:38.703916953Z" level=debug msg="authorizing request" go.version=go1.12.14 http.request.host="localhost:5000" http.request.id=87695298-04a2-4283-badd-e49de4fa0772 http.request.method=GET http.request.remoteaddr="172.16.0.1:12359" http.request.uri="/v2/test-img/manifests/sha256:6544bf9c79d15fe1004c504c61d0776d151f6a9d90c3246119dbff5001220d17" http.request.useragent="containerd/v1.5.0-beta.0-37-ge83ac5f" vars.name=test-img vars.reference="sha256:6544bf9c79d15fe1004c504c61d0776d151f6a9d90c3246119dbff5001220d17"

time="2021-02-01T03:32:38.704193517Z" level=info msg="authorized request" go.version=go1.12.14 http.request.host="localhost:5000" http.request.id=87695298-04a2-4283-badd-e49de4fa0772 http.request.method=GET http.request.remoteaddr="172.16.0.1:12359" http.request.uri="/v2/test-img/manifests/sha256:6544bf9c79d15fe1004c504c61d0776d151f6a9d90c3246119dbff5001220d17" http.request.useragent="containerd/v1.5.0-beta.0-37-ge83ac5f" vars.name=test-img vars.reference="sha256:6544bf9c79d15fe1004c504c61d0776d151f6a9d90c3246119dbff5001220d17"

time="2021-02-01T03:32:38.704371619Z" level=debug msg=GetImageManifest auth.user.name=registry-admin go.version=go1.12.14 http.request.host="localhost:5000" http.request.id=87695298-04a2-4283-badd-e49de4fa0772 http.request.method=GET http.request.remoteaddr="172.16.0.1:12359" http.request.uri="/v2/test-img/manifests/sha256:6544bf9c79d15fe1004c504c61d0776d151f6a9d90c3246119dbff5001220d17" http.request.useragent="containerd/v1.5.0-beta.0-37-ge83ac5f" vars.name=test-img vars.reference="sha256:6544bf9c79d15fe1004c504c61d0776d151f6a9d90c3246119dbff5001220d17"

time="2021-02-01T03:32:38.70464124Z" level=debug msg="(*manifestStore).Get" auth.user.name=registry-admin go.version=go1.12.14 http.request.host="localhost:5000" http.request.id=87695298-04a2-4283-badd-e49de4fa0772 http.request.method=GET http.request.remoteaddr="172.16.0.1:12359" http.request.uri="/v2/test-img/manifests/sha256:6544bf9c79d15fe1004c504c61d0776d151f6a9d90c3246119dbff5001220d17" http.request.useragent="containerd/v1.5.0-beta.0-37-ge83ac5f" vars.name=test-img vars.reference="sha256:6544bf9c79d15fe1004c504c61d0776d151f6a9d90c3246119dbff5001220d17"

time="2021-02-01T03:32:38.705237965Z" level=debug msg="filesystem.GetContent("/docker/registry/v2/repositories/test-img/_manifests/revisions/sha256/6544bf9c79d15fe1004c504c61d0776d151f6a9d90c3246119dbff5001220d17/link")" auth.user.name=registry-admin go.version=go1.12.14 http.request.host="localhost:5000" http.request.id=87695298-04a2-4283-badd-e49de4fa0772 http.request.method=GET http.request.remoteaddr="172.16.0.1:12359" http.request.uri="/v2/test-img/manifests/sha256:6544bf9c79d15fe1004c504c61d0776d151f6a9d90c3246119dbff5001220d17" http.request.useragent="containerd/v1.5.0-beta.0-37-ge83ac5f" trace.duration=450.576µs trace.file="/root/golang/go_path/src/github.com/docker/distribution/registry/storage/driver/base/base.go" trace.func="github.com/docker/distribution/registry/storage/driver/base.(*Base).GetContent" trace.id=7abcad5e-b50c-4adb-889d-042b3ee3cf7f trace.line=95 vars.name=test-img vars.reference="sha256:6544bf9c79d15fe1004c504c61d0776d151f6a9d90c3246119dbff5001220d17"
</pre>
</details>


Signed-off-by: povsister <pov@mahou-shoujo.moe>