### PR TITLE
content/helper: use semaphore for OpenWriter

### DIFF
--- a/content/kmutex.go
+++ b/content/kmutex.go
@@ -1,0 +1,92 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package content
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"golang.org/x/sync/semaphore"
+)
+
+func newKmutex() *kmutex {
+	return &kmutex{
+		locks: make(map[string]*klock),
+	}
+}
+
+type kmutex struct {
+	mu sync.Mutex
+
+	locks map[string]*klock
+}
+
+type klock struct {
+	*semaphore.Weighted
+	ref int
+}
+
+func (km *kmutex) lock(ctx context.Context, key string) error {
+	km.mu.Lock()
+
+	l, ok := km.locks[key]
+	if !ok {
+		km.locks[key] = &klock{
+			Weighted: semaphore.NewWeighted(1),
+		}
+		l = km.locks[key]
+	}
+	l.ref++
+
+	km.mu.Unlock()
+
+	if err := l.Acquire(ctx, 1); err != nil {
+		km.mu.Lock()
+		defer km.mu.Unlock()
+
+		l.ref--
+		if l.ref <= 0 {
+			if l.ref < 0 {
+				panic(fmt.Errorf("kmutex: release of unlocked key %v", key))
+			}
+			delete(km.locks, key)
+		}
+		return err
+	}
+	return nil
+}
+
+func (km *kmutex) unlock(key string) {
+	km.mu.Lock()
+	defer km.mu.Unlock()
+
+	l, ok := km.locks[key]
+	if !ok {
+		panic(fmt.Errorf("kmutex: unlock of unlocked key %v", key))
+	}
+
+	l.Release(1)
+
+	l.ref--
+	if l.ref <= 0 {
+		if l.ref < 0 {
+			panic(fmt.Errorf("kmutex: released of unlocked key %v", key))
+		}
+		delete(km.locks, key)
+	}
+}

--- a/content/kmutex_test.go
+++ b/content/kmutex_test.go
@@ -1,0 +1,167 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package content
+
+import (
+	"context"
+	"math/rand"
+	"runtime"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestKmutex(t *testing.T) {
+	t.Parallel()
+
+	km := newKmutex()
+	ctx := context.Background()
+
+	km.lock(ctx, "c1")
+	km.lock(ctx, "c2")
+
+	assert.Check(t, is.Equal(len(km.locks), 2))
+	assert.Check(t, is.Equal(km.locks["c1"].ref, 1))
+	assert.Check(t, is.Equal(km.locks["c2"].ref, 1))
+
+	waitCh := make(chan struct{})
+	go func() {
+		defer close(waitCh)
+
+		km.lock(ctx, "c1")
+	}()
+
+	retries := 100
+	waitLock := false
+	for i := 0; i < retries; i++ {
+		// prevent from data-race
+		km.mu.Lock()
+		c1Ref := km.locks["c1"].ref
+		km.mu.Unlock()
+
+		if c1Ref == 2 {
+			waitLock = true
+			break
+		}
+		time.Sleep(time.Duration(rand.Int63n(100)) * time.Millisecond)
+	}
+
+	assert.Check(t, is.Equal(waitLock, true))
+	km.unlock("c1")
+
+	<-waitCh
+	assert.Check(t, is.Equal(km.locks["c1"].ref, 1))
+}
+
+func TestKmutexUnlockPanic(t *testing.T) {
+	t.Parallel()
+
+	km := newKmutex()
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("unlock of unlocked key did not panic")
+		}
+	}()
+
+	km.unlock(t.Name())
+}
+
+func TestKmutexMultiLockOnKeys(t *testing.T) {
+	t.Parallel()
+
+	km := newKmutex()
+	nproc := runtime.GOMAXPROCS(0)
+	nloops := 10000
+
+	var wg sync.WaitGroup
+	for i := 0; i < nproc; i++ {
+		wg.Add(1)
+
+		go func(key string) {
+			defer wg.Done()
+
+			ctx := context.Background()
+			for i := 0; i < nloops; i++ {
+				km.lock(ctx, key)
+
+				time.Sleep(time.Duration(rand.Int63n(100)) * time.Nanosecond)
+
+				km.unlock(key)
+			}
+		}(strconv.Itoa(i))
+	}
+	wg.Wait()
+}
+
+func TestKmutexMultiLockOnSameKey(t *testing.T) {
+	t.Parallel()
+
+	km := newKmutex()
+	key := "c1"
+
+	assert.NilError(t, km.lock(context.Background(), key))
+
+	// cancel should cancel waiting lock
+	func() {
+		var (
+			ackCh = make(chan struct{}, 1)
+			errCh = make(chan error, 1)
+		)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			ackCh <- struct{}{}
+			errCh <- km.lock(ctx, key)
+		}()
+
+		<-ackCh
+		time.Sleep(time.Duration(rand.Int63n(100)) * time.Millisecond)
+		cancel()
+		assert.Check(t, is.Equal(<-errCh, context.Canceled))
+	}()
+
+	nproc := runtime.GOMAXPROCS(0)
+	nloops := 10000
+
+	var wg sync.WaitGroup
+	for i := 0; i < nproc; i++ {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			ctx := context.Background()
+			for i := 0; i < nloops; i++ {
+				km.lock(ctx, key)
+
+				time.Sleep(time.Duration(rand.Int63n(100)) * time.Nanosecond)
+
+				km.unlock(key)
+			}
+		}()
+	}
+	km.unlock(key)
+	wg.Wait()
+
+	// c1 key has been released so the km should not have any klock.
+	assert.Check(t, is.Equal(len(km.locks), 0))
+}


### PR DESCRIPTION
The content backend uses key lock for long-lived write transaction. When
the content reference has been marked for write transaction, the other
request on the same reference will fail fast with unavailable error.
Since the metadata plugin is based on boltbd which only supports single
writer, the backend can't block or handle the request too long. It requires
the client to handle retry by itself.

And OpenWriter is one retry helper to handle unavailable error for
content write transaction. The OpenWriter's maximum retry interval can
be up to 2 seconds. If there are several concurrent requires for the
same image, it will take long time to finish all the pulling jobs. And
it will be worse if the image has many more layers.

In order to improve the performance, use a weighted semaphore before
backoff and retry in OpenWriter. When the reference write transaction
has been hold, we should park the fetching-the-same-blob goroutines into
waiting state. When the transaction has been committed or aborted, the
one of waiting goroutines will be notified. It also saves CPU resources.

Since the OpenWriter is used in client side, we still need retry to
handle unavailable error.

---------

Test script:

localhost:5000/redis:latest is equal to docker.io/library/redis:latest.
The image is hold in local registry service by

```bash
docker run -d -p 5000:5000 --name registry registry:2
docker tag redis:latest localhost:5000/redis:latest
docker push localhost:5000/redis:latest
```

```bash

image_name="localhost:5000/redis:latest"
pull_times=10

cleanup() {
  ctr image rmi "${image_name}"
  ctr -n k8s.io image rmi "${image_name}"
  crictl rmi "${image_name}"
  docker rmi "${image_name}"
  sleep 2
}

crictl_testing() {
  for idx in $(seq 1 ${pull_times}); do
    crictl pull "${image_name}" > /dev/null 2>&1 &
  done
  wait
}

docker_testing() {
  for idx in $(seq 1 ${pull_times}); do
    docker pull "${image_name}" > /dev/null 2>&1 &
  done
  wait
}

cleanup > /dev/null 2>&1

echo 3 > /proc/sys/vm/drop_caches
sleep 3
echo "crictl pull $image_name (x${pull_times}) takes ..."
time crictl_testing
echo

echo 3 > /proc/sys/vm/drop_caches
sleep 3
echo "docker pull $image_name (x${pull_times}) takes ..."
time docker_testing
```

Test result(local):

```plain
from main commit https://github.com/fuweid/containerd/commit/3122239ee50624a0159d0107e53f3a9fd612570f

crictl pull localhost:5000/redis:latest (x10) takes ...

real	0m29.780s
user	0m0.124s
sys	0m0.169s

docker pull localhost:5000/redis:latest (x10) takes ...

real	0m1.233s
user	0m0.204s
sys	0m0.224s

from this patch

crictl pull localhost:5000/redis:latest (x10) takes ...

real	0m2.655s
user	0m0.091s
sys	0m0.141s

docker pull localhost:5000/redis:latest (x10) takes ...

real	0m1.188s
user	0m0.198s
sys	0m0.200s
```

Fixes: #4937

Signed-off-by: Wei Fu <fuweid89@gmail.com>