### PR TITLE
Fix deprecated registry auth conversion.

### DIFF
--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"context"
+	"net/url"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -353,6 +354,14 @@ func ValidatePluginConfig(ctx context.Context, c *PluginConfig) error {
 		}
 		for endpoint, auth := range c.Registry.Auths {
 			auth := auth
+			u, err := url.Parse(endpoint)
+			if err != nil {
+				return errors.Wrapf(err, "failed to parse registry url %q from `registry.auths`", endpoint)
+			}
+			if u.Scheme != "" {
+				// Do not include the scheme in the new registry config.
+				endpoint = u.Host
+			}
 			config := c.Registry.Configs[endpoint]
 			config.Auth = &auth
 			c.Registry.Configs[endpoint] = config

--- a/pkg/cri/config/config_test.go
+++ b/pkg/cri/config/config_test.go
@@ -294,7 +294,7 @@ func TestValidateConfig(t *testing.T) {
 				},
 				Registry: Registry{
 					Configs: map[string]RegistryConfig{
-						"https://gcr.io": {
+						"gcr.io": {
 							Auth: &AuthConfig{
 								Username: "test",
 							},


### PR DESCRIPTION
In the old field `registry.auths` in containerd 1.2, the field has the scheme. https://github.com/containerd/cri/blob/release/1.4/docs/registry.md#configure-registry-credentials

However, in the new field `registry.configs` introduced in containerd 1.3 and above, the field doesn't need the scheme any more. https://github.com/containerd/cri/blob/master/docs/registry.md#configure-registry-credentials

Although containerd 1.2 is End-Of-Life, the config option field is not removed yet, so we should do the conversion correctly.

This should probably be cherrypicked into 1.3 and 1.4.