### PR TITLE
runtime: fix shutdown runc v2 service

### DIFF
--- a/runtime/v2/runc/v2/service.go
+++ b/runtime/v2/runc/v2/service.go
@@ -662,9 +662,10 @@ func (s *service) Connect(ctx context.Context, r *taskAPI.ConnectRequest) (*task
 
 func (s *service) Shutdown(ctx context.Context, r *taskAPI.ShutdownRequest) (*ptypes.Empty, error) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	// return out if the shim is still servicing containers
 	if len(s.containers) > 0 {
-		s.mu.Unlock()
 		return empty, nil
 	}
 	s.cancel()


### PR DESCRIPTION
@crosbymichael 
Even if the service is no longer in use after `Shutdown`, I think it is important to unlock `service.mu`

If `os.Exit` is called, it may be possible not to unlock `service.mu`
https://github.com/containerd/containerd/pull/3204/files#diff-784b061d666f1368d1c3be590b14a7bdc559e199b0855349b993a395bbd2cdb5L573