### PR TITLE
[release/1.3] runtime: fix shutdown runc v2 service

### DIFF
--- a/runtime/v2/runc/v2/service.go
+++ b/runtime/v2/runc/v2/service.go
@@ -620,9 +620,10 @@ func (s *service) Connect(ctx context.Context, r *taskAPI.ConnectRequest) (*task
 
 func (s *service) Shutdown(ctx context.Context, r *taskAPI.ShutdownRequest) (*ptypes.Empty, error) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	// return out if the shim is still servicing containers
 	if len(s.containers) > 0 {
-		s.mu.Unlock()
 		return empty, nil
 	}
 	s.cancel()


### PR DESCRIPTION
Signed-off-by: IceberGu <wei.cai-nat@daocloud.io>
(cherry picked from commit b458583b76e84204dca17587625757247bb4053e)
Signed-off-by: Iceber Gu <wei.cai-nat@daocloud.io>

Cherry-pick: https://github.com/containerd/containerd/pull/4988