### PR TITLE
test: stop containerd before accessing the stdout

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -139,9 +139,9 @@ func TestMain(m *testing.M) {
 	// pull a seed image
 	log.G(ctx).WithField("image", testImage).Info("start to pull seed image")
 	if _, err = client.Pull(ctx, testImage, WithPullUnpack); err != nil {
-		fmt.Fprintf(os.Stderr, "%s: %s\n", err, buf.String())
 		ctrd.Kill()
 		ctrd.Wait()
+		fmt.Fprintf(os.Stderr, "%s: %s\n", err, buf.String())
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
The variable `buf` is connected to containerd's stdout. So, accessing
the variable before killing containerd can cause a race condition.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>