### PR TITLE
ci/gha/fedora: retry vagrant up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,7 +363,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - run: vagrant up
+      - run: |
+          # Retry if it fails (download.fedoraproject.org returns 404 sometimes)
+          vagrant up || vagrant up
 
       - name: Integration
         env:


### PR DESCRIPTION
relates to https://github.com/containerd/containerd/pull/4717#issuecomment-773465081
using the same hack as https://github.com/opencontainers/runc/pull/2787 to reduce flakiness

> download.fedoraproject.org gives HTTP 404 at times, breaking the CI. Let's give it another chance.
