### PR TITLE
test: fix assert.Check's argumets to show its parameters correctly

### DIFF
--- a/snapshots/devmapper/snapshotter_test.go
+++ b/snapshots/devmapper/snapshotter_test.go
@@ -137,7 +137,7 @@ func testUsage(t *testing.T, snapshotter snapshots.Snapshotter) {
 
 	// Should be at least 1 MB + fs metadata
 	assert.Check(t, layer2Usage.Size > sizeBytes,
-		"%d > %d", layer2Usage.Size > sizeBytes)
+		"%d > %d", layer2Usage.Size, sizeBytes)
 	assert.Check(t, layer2Usage.Size < sizeBytes+256*dmsetup.SectorSize,
-		"%d < %d", layer2Usage.Size < sizeBytes+256*dmsetup.SectorSize)
+		"%d < %d", layer2Usage.Size, sizeBytes+256*dmsetup.SectorSize)
 }


### PR DESCRIPTION
The change I made at db6075fc2 didn't show its parameters correctly.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>