### PR TITLE
Prepare release notes for 1.5.0-beta.1

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -12,6 +12,7 @@ Arnaud Porterie <icecrime@gmail.com>
 Arnaud Porterie <icecrime@gmail.com> <arnaud.porterie@docker.com>
 Bob Mader <swapdisk@users.noreply.github.com>
 Boris Popovschi <zyqsempai@mail.ru>
+Bowen Yan <loneybw@gmail.com>
 Brent Baude <bbaude@redhat.com>
 Cao Zhihao <caozhihao@163.com>
 Cao Zhihao <caozhihao@163.com> <caozhihao.xd@bytedance.com>
@@ -48,6 +49,7 @@ John Howard <github@lowenna.com> <jhoward@microsoft.com>
 John Howard <github@lowenna.com> <jhowardmsft@users.noreply.github.com>
 Luc Perkins <lucperkins@gmail.com>
 Julien Balestra <julien.balestra@datadoghq.com>
+Jun Lin Chen <webmaster@mc256.com> <1913688+mc256@users.noreply.github.com>
 Justin Cormack <justin.cormack@docker.com> <justin@specialbusservice.com>
 Justin Terry <juterry@microsoft.com>
 Justin Terry <juterry@microsoft.com> <jterry75@users.noreply.github.com>
@@ -69,10 +71,12 @@ Mark Gordon <msg555@gmail.com>
 Michael Crosby <crosbymichael@gmail.com> <michael@thepasture.io>
 Michael Katsoulis <michaelkatsoulis88@gmail.com>
 Mike Brown <brownwm@us.ibm.com> <mikebrow@users.noreply.github.com>
+Mohammad Asif Siddiqui <mohammad.asif.siddiqui1@huawei.com>
 Nishchay Kumar <mrawesomenix@gmail.com>
 Oliver Stenbom <oliver@stenbom.eu> <ostenbom@pivotal.io>
 Phil Estes <estesp@gmail.com> <estesp@linux.vnet.ibm.com>
 Reid Li <reid.li@utexas.edu>
+Robin Winkelewski <w9ncontact@gmail.com>
 Ross Boucher <rboucher@gmail.com>
 Ruediger Maass <ruediger.maass@de.ibm.com>
 Rui Cao <ruicao@alauda.io> <ruicao@alauda.io>
@@ -87,8 +91,11 @@ Stephen J Day <stevvooe@gmail.com> <stevvooe@users.noreply.github.com>
 Stephen J Day <stevvooe@gmail.com> <stephen.day@docker.com>
 Sudeesh John <sudeesh@linux.vnet.ibm.com>
 Su Fei  <fesu@ebay.com> <fesu@ebay.com>
+Su Xiaolin <linxxnil@126.com>
 Ted Yu <yuzhihong@gmail.com>
 Tõnis Tiigi <tonistiigi@gmail.com>
+Wade Lee <weidonglee27@gmail.com>
+Wade Lee <weidonglee27@gmail.com> <21621232@zju.edu.cn>
 Wei Fu <fuweid89@gmail.com> <fhfuwei@163.com>
 Xiaodong Zhang <a4012017@sina.com>
 Xuean Yan <yan.xuean@zte.com.cn>
@@ -96,6 +103,7 @@ Yue Zhang <zy675793960@yeah.net>
 Yuxing Liu <starnop@163.com>
 Zhang Wei <zhangwei555@huawei.com>
 Zhenguang Zhu <zhengguang.zhu@daocloud.io>
+Zhiyu Li <payall4u@qq.com>
 Zhiyu Li <payall4u@qq.com> <404977848@qq.com>
 Zhongming Chang<zhongming.chang@daocloud.io>
 Zhoulin Xie <zhoulin.xie@daocloud.io>

--- a/releases/v1.5.0-beta.toml
+++ b/releases/v1.5.0-beta.toml
@@ -39,6 +39,7 @@ brings support for the Node Resource Interface (NRI).
 * **Improve image pull performance over HTTP 1.1** [#4653](https://github.com/containerd/containerd/pull/4653)
 * **Registry configuration package** [#4138](https://github.com/containerd/containerd/pull/4138)
 * **Add support for layers compressed with zstd** [#4809](https://github.com/containerd/containerd/pull/4809)
+* **Allow arm64 to fallback to arm (v8, v7, v6, v5)** [4932](https://github.com/containerd/containerd/pull/4932)
 
 ## Runtime
 * **Add annotations to containerd task update API** [#4647](https://github.com/containerd/containerd/pull/4647)

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.5.0-beta.0+unknown"
+	Version = "1.5.0-beta.1+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
See https://gist.github.com/dmcgowan/dc3cacd6f1c6fbb5ae69d7d0e392cc35

A couple more dependency issues we may need to solve in the release tool

`github.com/Microsoft/hcsshim/test d3e5debf77da new`

and

```
DEBU[0019] git ls-remote git://github.com/kubernetes/klog/v2 v2.2.0 v2.2.0^{}  cache=miss
DEBU[0019] not using sha                                 error="exit status 128: fatal: remote error: \n  kubernetes/klog/v2 is not a valid repository name\n  Visit https://support.github.com/ for help\n" key="git ls-remote git://github.com/kubernetes/klog/v2 v2.2.0 v2.2.0^{}"
```