### PR TITLE
Update to go 1.15.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.15.7]
+        go-version: [1.15.8]
         os: [ubuntu-18.04, macos-10.15, windows-2019]
 
     steps:
@@ -73,7 +73,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: '1.15.7'
+          go-version: '1.15.8'
 
       - uses: actions/checkout@v2
         with:
@@ -106,7 +106,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: '1.15.7'
+          go-version: '1.15.8'
 
       - name: Set env
         shell: bash
@@ -139,7 +139,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: '1.15.7'
+          go-version: '1.15.8'
 
       - name: Set env
         shell: bash
@@ -181,7 +181,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: '1.15.7'
+          go-version: '1.15.8'
 
       - uses: actions/checkout@v2
         with:
@@ -249,7 +249,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: '1.15.7'
+          go-version: '1.15.8'
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: '1.15.7'
+          go-version: '1.15.8'
 
       - uses: actions/checkout@v2
         with:
@@ -131,7 +131,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: '1.15.7'
+          go-version: '1.15.8'
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.15.7'
+          go-version: '1.15.8'
 
       - name: Set env
         shell: bash

--- a/.zuul/playbooks/containerd-build/run.yaml
+++ b/.zuul/playbooks/containerd-build/run.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.15.7'
+    go_version: '1.15.8'
     arch: arm64
   tasks:
   - name: Build containerd

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,7 +77,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.15.7",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.15.8",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.15.7
+ARG GOLANG_VERSION=1.15.8
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd


### PR DESCRIPTION
go1.15.8 (released 2021/02/04) includes fixes to the compiler, linker, runtime,
the go command, and the net/http package. See the Go 1.15.8 milestone on the
issue tracker for details.

https://github.com/golang/go/issues?q=milestone%3AGo1.15.8+label%3ACherryPickApproved

full diff: https://github.com/golang/go/compare/go1.15.7...go1.15.8
