### PR TITLE
script/setup: use git clone instead of go get -d

### DIFF
--- a/script/setup/install-cni
+++ b/script/setup/install-cni
@@ -25,8 +25,7 @@ CNI_COMMIT=$(grep containernetworking/plugins "$GOPATH"/src/github.com/container
 CNI_DIR=${DESTDIR:=''}/opt/cni
 CNI_CONFIG_DIR=${DESTDIR}/etc/cni/net.d
 
-cd "$GOPATH"
-go get -d github.com/containernetworking/plugins/...
+git clone https://github.com/containernetworking/plugins.git "$GOPATH"/src/github.com/containernetworking/plugins
 cd "$GOPATH"/src/github.com/containernetworking/plugins
 git checkout $CNI_COMMIT
 ./build_linux.sh

--- a/script/setup/install-cni-windows
+++ b/script/setup/install-cni-windows
@@ -21,8 +21,7 @@ WINCNI_BIN_DIR="${DESTDIR}/cni"
 WINCNI_PKG=github.com/Microsoft/windows-container-networking
 WINCNI_VERSION=aa10a0b31e9f72937063436454def1760b858ee2
 
-cd "$GOPATH"
-go get -d "${WINCNI_PKG}/..."
+git clone "https://${WINCNI_PKG}.git" "${GOPATH}/src/${WINCNI_PKG}"
 cd "${GOPATH}/src/${WINCNI_PKG}"
 git checkout "${WINCNI_VERSION}"
 make all

--- a/script/setup/install-critools
+++ b/script/setup/install-critools
@@ -23,9 +23,10 @@ set -eu -o pipefail
 cd "$GOPATH"
 go get -u github.com/onsi/ginkgo/ginkgo
 CRITEST_COMMIT=0f5f734a7e1da0979915c6e7d5b6641bd9dc2627
-go get -d github.com/kubernetes-sigs/cri-tools/...
+
+git clone https://github.com/kubernetes-sigs/cri-tools.git "$GOPATH"/src/github.com/kubernetes-sigs/cri-tools
 cd "$GOPATH"/src/github.com/kubernetes-sigs/cri-tools
-git checkout $CRITEST_COMMIT
+git checkout "$CRITEST_COMMIT"
 make
 make install -e BINDIR=${DESTDIR:=''}/usr/local/bin
 cat << EOF | tee ${DESTDIR}/etc/crictl.yaml

--- a/script/setup/install-runc
+++ b/script/setup/install-runc
@@ -23,21 +23,23 @@ set -eu -o pipefail
 function install_runc() {
 	RUNC_COMMIT=$(grep opencontainers/runc "$GOPATH"/src/github.com/containerd/containerd/go.mod | awk '{print $2}')
 
-	cd "$GOPATH"
-	go get -d github.com/opencontainers/runc
-	cd "$GOPATH"/src/github.com/opencontainers/runc
-	git checkout $RUNC_COMMIT
+	TMPROOT=$(mktemp -d)
+	git clone https://github.com/opencontainers/runc.git "${TMPROOT}"/runc
+	pushd "${TMPROOT}"/runc
+	git checkout "${RUNC_COMMIT}"
 	make BUILDTAGS='apparmor seccomp selinux' runc
 	make install
+	popd
+	rm -fR "${TMPROOT}"
 }
 
 function install_crun() {
 	CRUN_VERSION=0.17
-	curl -o /usr/local/sbin/runc -L https://github.com/containers/crun/releases/download/${CRUN_VERSION}/crun-${CRUN_VERSION}-linux-$(go env GOARCH)
+	curl -o /usr/local/sbin/runc -L https://github.com/containers/crun/releases/download/"${CRUN_VERSION}"/crun-"${CRUN_VERSION}"-linux-"$(go env GOARCH)"
 	chmod +x /usr/local/sbin/runc
 }
 
-: ${RUNC_FLAVOR:=runc}
+: "${RUNC_FLAVOR:=runc}"
 case ${RUNC_FLAVOR} in
 runc) install_runc ;;
 crun) install_crun ;;


### PR DESCRIPTION
relates to https://github.com/containerd/containerd/pull/5005

`go get -d` uses go modules by default in Go 1.16 and up, which results
in modules being fetched for the "latest" module version, after which we
tried to "git checkout" to `<VERSION>`.

For runc, this means that (possibly incorrectly), `go get` will download
runc `v0.1.1` (most recent non-"pre-release", which caused failures (e.g
the old `Sirupsen/logrus` being downloaded).

In addition, some of the dependencies we're installing use vendoring, and
thus would not require the modules to be downloaded (and vendored files
will be ignored when using `go get` with modules).

This patch switches several uses `go get -d` to use a regular
git clone, after which the desired version is checked out,
and the binaries are built.

