### PR TITLE
[release/1.4] Update to go 1.15.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
 
       - name: Set env
         shell: bash
@@ -81,7 +81,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
 
       - name: Set env
         shell: bash
@@ -128,7 +128,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
 
       - name: Set env
         shell: bash
@@ -165,7 +165,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
 
       - name: Set env
         shell: bash
@@ -197,7 +197,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
 
       - name: Set env
         shell: bash
@@ -277,7 +277,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
 
       - name: Set env
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
 
       - name: Checkout
         uses: actions/checkout@v1
@@ -132,7 +132,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
 
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.15.5'
+          go-version: '1.15.8'
 
       - name: Set env
         shell: bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ os:
 - linux
 
 go:
-  - "1.15.5"
+  - "1.15.8"
 
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct

--- a/.zuul/playbooks/containerd-build/run.yaml
+++ b/.zuul/playbooks/containerd-build/run.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.15.5'
+    go_version: '1.15.8'
     arch: arm64
   tasks:
   - name: Build containerd

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,7 +77,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.15.5",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.15.8",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -6,7 +6,7 @@
 # 3.) $ make binaries install test
 #
 
-ARG GOLANG_VERSION=1.15.5
+ARG GOLANG_VERSION=1.15.8
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd


### PR DESCRIPTION
go1.15.8 (released 2021/02/04) includes fixes to the compiler, linker, runtime,
the go command, and the net/http package. See the Go 1.15.8 milestone on the
issue tracker for details.

https://github.com/golang/go/issues?q=milestone%3AGo1.15.8+label%3ACherryPickApproved

The 1.4 branch was still on Go 1.15.5, so this patch also includes previous
patch updates;

full diff: https://github.com/golang/go/compare/go1.15.5...go1.15.8

back ports the equivalent of;

- https://github.com/containerd/containerd/pull/4934
- https://github.com/containerd/containerd/pull/4959
- https://github.com/containerd/containerd/pull/5004
