### PR TITLE
[cri] add pod annotations to CNI call

### DIFF
--- a/pkg/cri/annotations/annotations.go
+++ b/pkg/cri/annotations/annotations.go
@@ -53,6 +53,10 @@ const (
 
 	// ContainerName is the name of the container in the pod
 	ContainerName = "io.kubernetes.cri.container-name"
+
 	// ImageName is the name of the image used to create the container
 	ImageName = "io.kubernetes.cri.image-name"
+
+	// PodAnnotations are the annotations of the pod
+	PodAnnotations = "io.kubernetes.cri.pod-annotations"
 )

--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -370,6 +370,7 @@ func (c *criService) setupPodNetwork(ctx context.Context, sandbox *sandboxstore.
 func cniNamespaceOpts(id string, config *runtime.PodSandboxConfig) ([]cni.NamespaceOpts, error) {
 	opts := []cni.NamespaceOpts{
 		cni.WithLabels(toCNILabels(id, config)),
+		cni.WithCapability(annotations.PodAnnotations, config.Annotations),
 	}
 
 	portMappings := toCNIPortMappings(config.GetPortMappings())


### PR DESCRIPTION
This additional information is helpful for CNI plugins when creating the network stack for a container.  The plugin still has to have this capability added in its config to take advantage of this information.

ref: https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md#dynamic-plugin-specific-fields-capabilities--runtime-configuration

Signed-off-by: Michael Crosby <michael@thepasture.io>