### PR TITLE
Improve error detection when loading config

### DIFF
--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -114,8 +114,14 @@ can be used and modified as necessary as a custom configuration.`
 			config  = defaultConfig()
 		)
 
-		if err := srvconfig.LoadConfig(context.GlobalString("config"), config); err != nil && !os.IsNotExist(err) {
-			return err
+		// Only try to load the config if it either exists, or the user explicitly
+		// told us to load this path.
+		configPath := context.GlobalString("config")
+		_, err := os.Stat(configPath)
+		if !os.IsNotExist(err) || context.GlobalIsSet("config") {
+			if err := srvconfig.LoadConfig(configPath, config); err != nil {
+				return err
+			}
 		}
 
 		// Apply flags to the config


### PR DESCRIPTION
Previously we simply ignored any not found error when loading the
containerd config. This created unintuitive behavior:

- If the user specified a path that didn't exist via --config, we would
  silently ignore the error.
- If a config specified an import that didn't exist, we would silently
  ignore the error.

In either of these cases, it appears we would end up using a potentially
corrupted config, as it would contain any files that were merged into it
before the not found error was hit.

However, we can't just remove the check for !os.IsNotExist(err),
as we shouldn't throw an error when --config is not passed, but the
default config doesn't exist.

This change updates the logic to only attempt to load the config if
we know it exists, or the user passed --config.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>

Note: This is a change in behavior for config loading, but as far as I can tell the previous behavior could be dangerous and end up with an incomplete config. So I think it's worth fixing this, but looking for feedback. :)