### PR TITLE
oci: fix the file mode of the device

### DIFF
--- a/oci/spec_opts_linux.go
+++ b/oci/spec_opts_linux.go
@@ -108,7 +108,7 @@ func deviceFromPath(path, permissions string) (*specs.LinuxDevice, error) {
 	case mode&unix.S_IFCHR == unix.S_IFCHR:
 		devType = "c"
 	}
-	fm := os.FileMode(mode)
+	fm := os.FileMode(mode &^ unix.S_IFMT)
 	return &specs.LinuxDevice{
 		Type:     devType,
 		Path:     path,

--- a/oci/spec_opts_unix.go
+++ b/oci/spec_opts_unix.go
@@ -107,7 +107,7 @@ func deviceFromPath(path, permissions string) (*specs.LinuxDevice, error) {
 	case mode&unix.S_IFCHR == unix.S_IFCHR:
 		devType = "c"
 	}
-	fm := os.FileMode(mode)
+	fm := os.FileMode(mode &^ unix.S_IFMT)
 	return &specs.LinuxDevice{
 		Type:     devType,
 		Path:     path,


### PR DESCRIPTION
The file mode of the device in the OCI runtime specification does not contain file type bits

`unix.Stat_t.Mode` contains the file type and mode，details are in "The file type and mode" section of [inode](https://man7.org/linux/man-pages/man7/inode.7.html)

This issue causes some `config.json` to fail [the runtime spec schema validation](https://github.com/opencontainers/runtime-spec/tree/master/schema#utility)

For example, the `config.json` for the kube-proxy container
```json
devices:
    [
            {
                "path":"/dev/sda",
                "type":"b",
                "major":8,
                "minor":0,
                "fileMode":25008,
                "uid":0,
                "gid":6
            },
           {
                "path":"/dev/null",
                "type":"c",
                "major":1,
                "minor":3,
                "fileMode":8630,
                "uid":0,
                "gid":0
            },
            {
                "path":"/dev/tty0",
                "type":"c",
                "major":4,
                "minor":0,
                "fileMode":8592,
                "uid":0,
                "gid":5
            },
            ...
    ]
```

Discussions about `FileMode`: https://github.com/opencontainers/runtime-spec/pull/1082
