### PR TITLE
Fix TestRuntimeHandler logging

### DIFF
--- a/integration/runtime_handler_test.go
+++ b/integration/runtime_handler_test.go
@@ -26,10 +26,16 @@ import (
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
+// TODO(chrisfegly): add/update test(s) to allow testing of multiple runtimes at the same time
 func TestRuntimeHandler(t *testing.T) {
 	t.Logf("Create a sandbox")
 	sbConfig := PodSandboxConfig("sandbox", "test-runtime-handler")
-	t.Logf("the --runtime-handler flag value is: %s", *runtimeHandler)
+
+	if *runtimeHandler == "" {
+		t.Logf("The --runtime-handler flag value is empty which results internally to setting the default runtime")
+	} else {
+		t.Logf("The --runtime-handler flag value is %s", *runtimeHandler)
+	}
 	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
 	require.NoError(t, err)
 	defer func() {
@@ -38,15 +44,13 @@ func TestRuntimeHandler(t *testing.T) {
 		runtimeService.RemovePodSandbox(sb)
 	}()
 
-	t.Logf("Verify runtimeService.PodSandboxStatus sets RuntimeHandler")
+	t.Logf("Verify runtimeService.PodSandboxStatus() returns previously set runtimeHandler")
 	sbStatus, err := runtimeService.PodSandboxStatus(sb)
 	require.NoError(t, err)
-	t.Logf("runtimeService.PodSandboxStatus sets RuntimeHandler to %s", sbStatus.RuntimeHandler)
 	assert.Equal(t, *runtimeHandler, sbStatus.RuntimeHandler)
 
-	t.Logf("Verify runtimeService.ListPodSandbox sets RuntimeHandler")
+	t.Logf("Verify runtimeService.ListPodSandbox() returns previously set runtimeHandler")
 	sandboxes, err := runtimeService.ListPodSandbox(&runtime.PodSandboxFilter{})
 	require.NoError(t, err)
-	t.Logf("runtimeService.ListPodSandbox sets RuntimeHandler to %s", sbStatus.RuntimeHandler)
 	assert.Equal(t, *runtimeHandler, sandboxes[0].RuntimeHandler)
 }


### PR DESCRIPTION
Resolving issue #5032:
- An empty `--runtime-handler` flag results in testing against the default runtime so modified and removed logging to clarify.
- Added a TODO for future work on potentially adding test(s) for multiple runtimes at the same time. 