### PR TITLE
containerd to ignore stderr on "start"

### DIFF
--- a/runtime/v2/binary.go
+++ b/runtime/v2/binary.go
@@ -103,7 +103,7 @@ func (b *binary) Start(ctx context.Context, opts *types.Any, onClose func()) (_ 
 			log.G(ctx).WithError(err).Error("copy shim log")
 		}
 	}()
-	out, err := cmd.CombinedOutput()
+	out, err := cmd.Output()
 	if err != nil {
 		return nil, errors.Wrapf(err, "%s", out)
 	}


### PR DESCRIPTION
When starting a new shim, the address is written to stdout:
https://github.com/containerd/containerd/blob/master/runtime/v2/shim/shim.go#L226
```
	case "start":
		address, err := service.StartShim(....)
		if err != nil {
			return err
		}
		if _, err := os.Stdout.WriteString(address); err != nil {
			return err
		}
		return nil
```
However, containerd checks for combined stdout and stderr.

Signed-off-by: Dmitry Shmulevich <dmitry.shmulevich@gmail.com>