### PR TITLE
Enable Go HTTP tracing of registry interactions

### DIFF
--- a/cmd/ctr/commands/images/images.go
+++ b/cmd/ctr/commands/images/images.go
@@ -17,7 +17,9 @@
 package images
 
 import (
+	"context"
 	"fmt"
+	"net/http/httptrace"
 	"os"
 	"sort"
 	"strings"
@@ -331,4 +333,24 @@ var removeCommand = cli.Command{
 
 		return exitErr
 	},
+}
+
+// NewDebugClientTrace returns a Go http trace client predefined to write DNS and connection
+// information to the log. This is used via the --trace flag on push and pull operations in ctr.
+func NewDebugClientTrace(ctx context.Context) *httptrace.ClientTrace {
+	return &httptrace.ClientTrace{
+		DNSStart: func(dnsInfo httptrace.DNSStartInfo) {
+			log.G(ctx).WithField("host", dnsInfo.Host).Debugf("DNS lookup")
+		},
+		DNSDone: func(dnsInfo httptrace.DNSDoneInfo) {
+			if dnsInfo.Err != nil {
+				log.G(ctx).WithField("lookup_err", dnsInfo.Err).Debugf("DNS lookup error")
+			} else {
+				log.G(ctx).WithField("result", dnsInfo.Addrs[0].String()).WithField("coalesced", dnsInfo.Coalesced).Debugf("DNS lookup complete")
+			}
+		},
+		GotConn: func(connInfo httptrace.GotConnInfo) {
+			log.G(ctx).WithField("reused", connInfo.Reused).WithField("remote_addr", connInfo.Conn.RemoteAddr().String()).Debugf("Connection successful")
+		},
+	}
 }

--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -18,6 +18,7 @@ package images
 
 import (
 	"fmt"
+	"net/http/httptrace"
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cmd/ctr/commands"
@@ -55,6 +56,10 @@ command. As part of this process, we do the following:
 			Usage: "pull content and metadata from all platforms",
 		},
 		cli.BoolFlag{
+			Name:  "trace",
+			Usage: "enable HTTP tracing for registry interactions",
+		},
+		cli.BoolFlag{
 			Name:  "all-metadata",
 			Usage: "Pull metadata for all platforms",
 		},
@@ -88,6 +93,9 @@ command. As part of this process, we do the following:
 			return err
 		}
 
+		if context.Bool("trace") {
+			ctx = httptrace.WithClientTrace(ctx, NewDebugClientTrace(ctx))
+		}
 		img, err := content.Fetch(ctx, client, ref, config)
 		if err != nil {
 			return err

--- a/cmd/ctr/commands/images/push.go
+++ b/cmd/ctr/commands/images/push.go
@@ -18,6 +18,7 @@ package images
 
 import (
 	gocontext "context"
+	"net/http/httptrace"
 	"os"
 	"sync"
 	"text/tabwriter"
@@ -59,6 +60,9 @@ var pushCommand = cli.Command{
 		Name:  "manifest-type",
 		Usage: "media type of manifest digest",
 		Value: ocispec.MediaTypeImageManifest,
+	}, cli.BoolFlag{
+		Name:  "trace",
+		Usage: "enable HTTP tracing for registry interactions",
 	}, cli.StringSliceFlag{
 		Name:  "platform",
 		Usage: "push content from a specific platform",
@@ -119,6 +123,9 @@ var pushCommand = cli.Command{
 			}
 		}
 
+		if context.Bool("trace") {
+			ctx = httptrace.WithClientTrace(ctx, NewDebugClientTrace(ctx))
+		}
 		resolver, err := commands.GetResolver(ctx, context)
 		if err != nil {
 			return err


### PR DESCRIPTION
Enables a Go embedded feature for tracing certain aspects of HTTP connections; useful for debug of connectivity, DNS, etc. issues with registry interactions.

Example output:
```
DEBU[0000] fetching                                      image="docker.io/library/alpine:latest"
DEBU[0000] resolving                                     host=registry-1.docker.io
DEBU[0000] do request                                    host=registry-1.docker.io request.header.accept="application/vnd.docker.distribution.manifest.v2+json, ap
plication/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.oci.image.index.v1+json, */*" request.header.
user-agent=containerd/v1.5.0-beta.1-9-g87c9aeb6c.m request.method=HEAD url="https://registry-1.docker.io/v2/library/alpine/manifests/latest"
DEBU[0000] DNS lookup                                    host=registry-1.docker.io
DEBU[0000] DNS lookup complete                           coalesced=false result=34.238.187.50
DEBU[0000] Connection successful                         remote_addr="34.238.187.50:443" reused=false
```