### PR TITLE
Add a sharedNamespace label

### DIFF
--- a/docs/ops.md
+++ b/docs/ops.md
@@ -232,3 +232,7 @@ The default is "shared". While this is largely the most desired policy, one can 
 [plugins.bolt]
 	content_sharing_policy = "isolated"
 ```
+
+It is possible to share only the contents of a specific namespace by adding the label `containerd.io/namespace.shareable=true` to that namespace.
+This will share the contents of the namespace even if the content sharing policy is set to isolated and make its images usable by all other namespaces.
+If the label value is set to anything other than `true`, the namespace content will not be shared.

--- a/labels/labels.go
+++ b/labels/labels.go
@@ -19,3 +19,7 @@ package labels
 // LabelUncompressed is added to compressed layer contents.
 // The value is digest of the uncompressed content.
 const LabelUncompressed = "containerd.io/uncompressed"
+
+// LabelSharedNamespace is added to a namespace to allow that namespaces
+// contents to be shared.
+const LabelSharedNamespace = "containerd.io/namespace.shareable"

--- a/metadata/buckets_test.go
+++ b/metadata/buckets_test.go
@@ -1,0 +1,171 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package metadata
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/containerd/containerd/labels"
+	digest "github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
+	bolt "go.etcd.io/bbolt"
+)
+
+func TestHasSharedLabel(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "bucket-testing-")
+	if err != nil {
+		t.Error(err)
+	}
+
+	db, err := bolt.Open(filepath.Join(tmpdir, "metadata.db"), 0660, nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = createNamespaceLabelsBucket(db, "testing-with-shareable", true)
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = createNamespaceLabelsBucket(db, "testing-without-shareable", false)
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = db.View(func(tx *bolt.Tx) error {
+		if !hasSharedLabel(tx, "testing-with-shareable") {
+			return errors.New("hasSharedLabel should return true when label is set")
+		}
+		if hasSharedLabel(tx, "testing-without-shareable") {
+			return errors.New("hasSharedLabel should return false when label is not set")
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestGetShareableBucket(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "bucket-testing-")
+	if err != nil {
+		t.Error(err)
+	}
+
+	db, err := bolt.Open(filepath.Join(tmpdir, "metadata.db"), 0660, nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	goodDigest := digest.FromString("gooddigest")
+	imagePresentNS := "has-image-is-shareable"
+	imageAbsentNS := "image-absent"
+
+	// Create two namespaces, empty for now
+	err = db.Update(func(tx *bolt.Tx) error {
+		_, err := createImagesBucket(tx, imagePresentNS)
+		if err != nil {
+			return err
+		}
+
+		_, err = createImagesBucket(tx, imageAbsentNS)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Test that getShareableBucket is correctly returning nothing when a
+	// a bucket with that digest is not present in any namespace.
+	err = db.View(func(tx *bolt.Tx) error {
+		if bkt := getShareableBucket(tx, goodDigest); bkt != nil {
+			return errors.New("getShareableBucket should return nil if digest is not present")
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Create a blob bucket in one of the namespaces with a well-known digest
+	err = db.Update(func(tx *bolt.Tx) error {
+		_, err = createBlobBucket(tx, imagePresentNS, goodDigest)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Verify that it is still not retrievable if the shareable label is not present
+	err = db.View(func(tx *bolt.Tx) error {
+		if bkt := getShareableBucket(tx, goodDigest); bkt != nil {
+			return errors.New("getShareableBucket should return nil if digest is present but doesn't have shareable label")
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Create the namespace labels bucket and mark it as shareable
+	err = createNamespaceLabelsBucket(db, imagePresentNS, true)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Verify that this digest is retrievable from getShareableBucket
+	err = db.View(func(tx *bolt.Tx) error {
+		if bkt := getShareableBucket(tx, goodDigest); bkt == nil {
+			return errors.New("getShareableBucket should not return nil if digest is present")
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func createNamespaceLabelsBucket(db transactor, ns string, shareable bool) error {
+	err := db.Update(func(tx *bolt.Tx) error {
+		err := withNamespacesLabelsBucket(tx, ns, func(bkt *bolt.Bucket) error {
+			if shareable {
+				err := bkt.Put([]byte(labels.LabelSharedNamespace), []byte("true"))
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		return err
+	})
+	return err
+}


### PR DESCRIPTION
This changed based on feedback on the PR to use a different method. I kept the previous description for clarity below.

### What is this

This PR adds the ability to tag namespaces with a special label, `containerd.io/namespace/sharable` that indicates that images in this namespace are shareable with other namespaces. 

### Why is this

The goal is to be able to have namespace isolation while being able to share some common content across all namespaces.

---
### What is this

This PR adds a 'shared' namespace setting that enables content to be shared from a single, configured namespace when content_sharing_policy is set to isolated. It does this by looking for content first in the calling namespace and then, if configured, in the 'shared' namespace.

The config looks like:
```toml
[plugins.bolt]
content_sharing_policy = "isolated"
shared_content_namespace = "<shared_namespace>"
```

In other respects the 'shared' namespace is unmodified. Pulling content into a 'shared' namespace is no different from any other namespace for example.

This intentionally tries to not modify behavior in the default case. There should be no change except in the case that shared_content_namespace is set explicitly.

### Why is this

The goal is to be able to have namespace isolation while being able to share some common content across all namespaces.

### Example workflow

Add a config.toml snippet like:
```toml
...
[plugins.bolt]
content_sharing_policy = "isolated"
shared_content_namespace = "shared"
...
```

After starting containerd with this config, pull an image into the shared namespace:
```
ctr -n shared image pull docker.io/library/busybox:latest
```

Then check that there is nothing in the target namespace called empty:
```
ctr -n empty image ls
```

Now run it busybox in the empty namespace:
```
% ctr -n empty run docker.io/library/busybox:latest busybusy /bin/sh
```
Exit the busybox container and verify that the empty namespace does not have image present after running:
```
% sudo ctr -n empty image ls         
REF TYPE DIGEST SIZE PLATFORMS LABELS 
```

### Open questions

* Are changes needed to leases or gc? I'm less sure about this and will try to look into the code for a bit more to try to be sure I understand implications.




