### PR TITLE
cri: append envs from image config to empty slice to avoid env lost

### DIFF
--- a/pkg/cri/server/container_create_windows.go
+++ b/pkg/cri/server/container_create_windows.go
@@ -62,7 +62,7 @@ func (c *criService) containerSpec(
 
 	// Apply envs from image config first, so that envs from container config
 	// can override them.
-	env := imageConfig.Env
+	env := append([]string{}, imageConfig.Env...)
 	for _, e := range config.GetEnvs() {
 		env = append(env, e.GetKey()+"="+e.GetValue())
 	}


### PR DESCRIPTION
Signed-off-by: Justin Terry (SF) <juterry@microsoft.com>