### PR TITLE
cri: add rate limiter for container logs

### DIFF
--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -77,6 +77,16 @@ version = 2
   # limit.
   max_container_log_line_size = 16384
 
+  # container_log_limit is the maximum number of log lines allowed to write to disk per second.
+  # If more lines than specified in container_log_limit= are logged by a container in 1 second,
+  # all further log lines within this second are dropped until this second is over.
+  # Non-positive value means no limit.
+  container_log_limit = 0
+
+  # container_log_burst is the burst number of log lines allowed to write to disk per second.
+  # This works together with container_log_limit and is usually greater than or equal to it.
+  container_log_burst = 0
+
   # disable_cgroup indicates to disable the cgroup support.
   # This is useful when the daemon does not have permission to access cgroup.
   disable_cgroup = false

--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	golang.org/x/net v0.0.0-20201224014010-6772e930b67b
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
 	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c
+	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 	google.golang.org/grpc v1.33.2
 	gotest.tools/v3 v3.0.3
 	k8s.io/api v0.20.1

--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -231,6 +231,14 @@ type PluginConfig struct {
 	// Log line longer than the limit will be split into multiple lines. Non-positive
 	// value means no limit.
 	MaxContainerLogLineSize int `toml:"max_container_log_line_size" json:"maxContainerLogSize"`
+	// ContainerLogLimit is the maximum number of log lines allowed to write to disk per second.
+	// If more lines than specified in ContainerLogLimit= are logged by a container in 1 second,
+	// all further log lines within this second will be dropped until this second is over.
+	// Non-positive value means no limit.
+	ContainerLogLimit int `toml:"container_log_limit" json:"containerLogLimit"`
+	// ContainerLogBurst is the burst number of log lines allowed to write to disk per second.
+	// This works together with ContainerLogLimit and is usually greater than or equal to it.
+	ContainerLogBurst int `toml:"container_log_burst" json:"containerLogBurst"`
 	// DisableCgroup indicates to disable the cgroup support.
 	// This is useful when the containerd does not have permission to access cgroup.
 	DisableCgroup bool `toml:"disable_cgroup" json:"disableCgroup"`

--- a/pkg/cri/config/config_unix.go
+++ b/pkg/cri/config/config_unix.go
@@ -60,6 +60,8 @@ func DefaultConfig() PluginConfig {
 		StatsCollectPeriod:      10,
 		SystemdCgroup:           false,
 		MaxContainerLogLineSize: 16 * 1024,
+		ContainerLogLimit:       0,
+		ContainerLogBurst:       0,
 		Registry: Registry{
 			Mirrors: map[string]Mirror{
 				"docker.io": {

--- a/pkg/cri/server/container_start.go
+++ b/pkg/cri/server/container_start.go
@@ -198,10 +198,10 @@ func (c *criService) createContainerLoggers(logPath string, tty bool) (stdout io
 		}()
 		var stdoutCh, stderrCh <-chan struct{}
 		wc := cioutil.NewSerialWriteCloser(f)
-		stdout, stdoutCh = cio.NewCRILogger(logPath, wc, cio.Stdout, c.config.MaxContainerLogLineSize)
+		stdout, stdoutCh = cio.NewCRILogger(logPath, wc, cio.Stdout, c.config.MaxContainerLogLineSize, c.config.ContainerLogLimit, c.config.ContainerLogBurst)
 		// Only redirect stderr when there is no tty.
 		if !tty {
-			stderr, stderrCh = cio.NewCRILogger(logPath, wc, cio.Stderr, c.config.MaxContainerLogLineSize)
+			stderr, stderrCh = cio.NewCRILogger(logPath, wc, cio.Stderr, c.config.MaxContainerLogLineSize, c.config.ContainerLogLimit, c.config.ContainerLogBurst)
 		}
 		go func() {
 			if stdoutCh != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -375,6 +375,7 @@ golang.org/x/text/transform
 golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
 # golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
+## explicit
 golang.org/x/time/rate
 # golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 golang.org/x/xerrors


### PR DESCRIPTION
Provide an option to limit the speed of the container's stdout/stderr logs.
See [#4604](https://github.com/containerd/containerd/issues/4604)

When use containerd directly in Kubernetes, the container's stdout/stderr logs will be written to persistent disk through CRI plugin. If the application running in container output logs too fast, it may cause high disk IO and CreateContainerError when create a new pod. Hence, it may need to limit the speed of writing container logs to disk in some case. For example, when we deploy services in K8s cluster, if some containers output logs very fast because of bugs or other reasons, it would make some nodes unable to deploy new services.

**Steps to reproduce the problem**

1.  Create pods which running the following program to simulate the application that output logs fast.
`#include <stdio.h>
int main() {
    char data[512];
    for (int i=0; i<512; i++) {
	    data[i]=65+i%24;
    }
    while(1) {
	    printf("%s\n", data);
    }
    return 0;
}
`
![image](https://user-images.githubusercontent.com/24526539/108472554-dc98ec80-72c7-11eb-876f-055ca919d3c3.png)
![image](https://user-images.githubusercontent.com/24526539/108469942-21228900-72c4-11eb-85bd-edcbc8aa9f75.png)
2. Then create new nginx pod. It would be failed due to `failed to reserve container name` error if not limit the speed of writing container logs.
![image](https://user-images.githubusercontent.com/24526539/108472987-66e15080-72c8-11eb-9a8d-8b343135fc27.png)
![image](https://user-images.githubusercontent.com/24526539/108475027-220ae900-72cb-11eb-9fa0-3ef7705fdfde.png)

