### PR TITLE
Tune test timeouts for GH Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
   integration-linux:
     name: Linux Integration
     runs-on: ubuntu-18.04
-    timeout-minutes: 20
+    timeout-minutes: 25
     needs: [project, linters, protos, man]
 
     strategy:
@@ -353,7 +353,7 @@ jobs:
     name: CGroupsV2 and SELinux Integration
     # nested virtualization is only available on macOS hosts
     runs-on: macos-10.15
-    timeout-minutes: 40
+    timeout-minutes: 45
     needs: [project, linters, protos, man]
     strategy:
       matrix:


### PR DESCRIPTION
We have enough failures these days; getting timed out when tests are
almost done is the last thing we need :)

On avg. the Linux integration tests are taking 15-17 min, but sometimes
they end up at 20 or a bit over and get canceled. I've seen rare cases
where the Vagrant setup+build+test runs gets very close to 40 min as
well.

Signed-off-by: Phil Estes <estesp@amazon.com>