### PR TITLE
Support device path mapping and permission in ctr

### DIFF
--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -264,7 +264,19 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 			opts = append(opts, oci.WithMemoryLimit(limit))
 		}
 		for _, dev := range context.StringSlice("device") {
-			opts = append(opts, oci.WithDevices(dev, "", "rwm"))
+			parts := strings.Split(dev, ":")
+			if len(parts) > 3 {
+				return nil, errors.New("--device requires the format 'hostpath:containerpath:permission', while containerpath and permission are optional")
+			}
+			var partsArr [3]string
+			copy(partsArr[:], parts)
+			if partsArr[1] == "" {
+				partsArr[1] = partsArr[0]
+			}
+			if partsArr[2] == "" {
+				partsArr[2] = "rwm"
+			}
+			opts = append(opts, oci.WithDevices(partsArr[0], partsArr[1], partsArr[2]))
 		}
 	}
 

--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -1163,40 +1163,6 @@ func WithAnnotations(annotations map[string]string) SpecOpts {
 	}
 }
 
-// WithLinuxDevices adds the provided linux devices to the spec
-func WithLinuxDevices(devices []specs.LinuxDevice) SpecOpts {
-	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
-		setLinux(s)
-		s.Linux.Devices = append(s.Linux.Devices, devices...)
-		return nil
-	}
-}
-
-// WithLinuxDevice adds the device specified by path to the spec
-func WithLinuxDevice(path, permissions string) SpecOpts {
-	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
-		setLinux(s)
-		setResources(s)
-
-		dev, err := deviceFromPath(path)
-		if err != nil {
-			return err
-		}
-
-		s.Linux.Devices = append(s.Linux.Devices, *dev)
-
-		s.Linux.Resources.Devices = append(s.Linux.Resources.Devices, specs.LinuxDeviceCgroup{
-			Type:   dev.Type,
-			Allow:  true,
-			Major:  &dev.Major,
-			Minor:  &dev.Minor,
-			Access: permissions,
-		})
-
-		return nil
-	}
-}
-
 // WithEnvFile adds environment variables from a file to the container's spec
 func WithEnvFile(path string) SpecOpts {
 	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {

--- a/oci/spec_opts_windows.go
+++ b/oci/spec_opts_windows.go
@@ -73,7 +73,3 @@ func WithWindowNetworksAllowUnqualifiedDNSQuery() SpecOpts {
 func WithHostDevices(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 	return nil
 }
-
-func deviceFromPath(path string) (*specs.LinuxDevice, error) {
-	return nil, errors.New("device from path not supported on Windows")
-}


### PR DESCRIPTION
Signed-off-by: Qiutong Song <songqt01@gmail.com>

- Solved issue https://github.com/containerd/containerd/issues/5046
- `WithLinuxDevices` is not needed after https://github.com/containerd/containerd/pull/4847

Usage:
```
ctr run --device=<PATH>
ctr run --device=<HOST PATH>:<CONTAINER PATH>
ctr run --device=<HOST PATH>:<CONTAINER PATH>:<PERMISSION>
```

Test 1: More than three parameters returns error
```
$ sudo /usr/local/bin/ctr run --device=/dev/sda2:/dev/xyz:rwm:dummy --rm -t docker.io/library/ubuntu:latest c1 fdisk -l /dev/xyz
ctr: --device requires the format 'hostpath:containerpath:permission', while containerpath and permission are optional
```

Test 2: Given only device path
```
$ sudo /usr/local/bin/ctr run --device=/dev/sda2 --rm -t docker.io/library/ubuntu:latest c1 fdisk -l /dev/sda2
Disk /dev/sda2: 1.88 GiB, 2000000000 bytes, 3906250 sectors
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 4096 bytes
I/O size (minimum/optimal): 4096 bytes / 4096 bytes
Alignment offset: 3072 bytes
```

Test 3: Given host path and container path
```
$ sudo /usr/local/bin/ctr run --device=/dev/sda2:/dev/xyz --rm -t docker.io/library/ubuntu:latest c1 fdisk -l /dev/sda2
fdisk: cannot open /dev/sda2: No such file or directory
$ sudo /usr/local/bin/ctr run --device=/dev/sda2:/dev/xyz --rm -t docker.io/library/ubuntu:latest c1 fdisk -l /dev/xyz
Disk /dev/xyz: 1.88 GiB, 2000000000 bytes, 3906250 sectors
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 4096 bytes
I/O size (minimum/optimal): 4096 bytes / 4096 bytes
Alignment offset: 3072 bytes
```

Test 4: Given permission
```
$ sudo /usr/local/bin/ctr run --device=/dev/sda2:/dev/xyz:r --rm -t docker.io/library/ubuntu:latest c1 fdisk -l /dev/xyz
Disk /dev/xyz: 1.88 GiB, 2000000000 bytes, 3906250 sectors
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 4096 bytes
I/O size (minimum/optimal): 4096 bytes / 4096 bytes
Alignment offset: 3072 bytes
$ sudo /usr/local/bin/ctr run --device=/dev/sda2:/dev/xyz:w --rm -t docker.io/library/ubuntu:latest c1 fdisk -l /dev/xyz
fdisk: cannot open /dev/xyz: Operation not permitted
$ sudo /usr/local/bin/ctr run --device=/dev/sda2:/dev/xyz:m --rm -t docker.io/library/ubuntu:latest c1 fdisk -l /dev/xyz
fdisk: cannot open /dev/xyz: Operation not permitted
```

## Others

- Original issue supporting "--device" https://github.com/containerd/containerd/issues/3066
- Original PR: https://github.com/containerd/containerd/pull/3424