### PR TITLE
cri: set default masked/readonly paths to empty paths

### DIFF
--- a/pkg/cri/server/container_create_linux.go
+++ b/pkg/cri/server/container_create_linux.go
@@ -195,6 +195,11 @@ func (c *criService) containerSpec(
 	specOpts = append(specOpts, customopts.WithMounts(c.os, config, extraMounts, mountLabel), customopts.WithRelabeledContainerMounts(mountLabel))
 
 	if !c.config.DisableProcMount {
+		// Change the default masked/readonly paths to empty slices
+		// See https://github.com/containerd/containerd/issues/5029
+		// TODO: Provide an option to set default paths to the ones in oci.populateDefaultUnixSpec()
+		specOpts = append(specOpts, oci.WithMaskedPaths([]string{}), oci.WithReadonlyPaths([]string{}))
+
 		// Apply masked paths if specified.
 		// If the container is privileged, this will be cleared later on.
 		if maskedPaths := securityContext.GetMaskedPaths(); maskedPaths != nil {

--- a/pkg/cri/server/container_create_linux_test.go
+++ b/pkg/cri/server/container_create_linux_test.go
@@ -1118,8 +1118,8 @@ func TestMaskedAndReadonlyPaths(t *testing.T) {
 			disableProcMount: false,
 			masked:           nil,
 			readonly:         nil,
-			expectedMasked:   defaultSpec.Linux.MaskedPaths,
-			expectedReadonly: defaultSpec.Linux.ReadonlyPaths,
+			expectedMasked:   []string{},
+			expectedReadonly: []string{},
 			privileged:       false,
 		},
 		"should be able to specify empty paths": {


### PR DESCRIPTION
Fixes #5029.

Signed-off-by: Yohei Ueda <yohei@jp.ibm.com>