### PR TITLE
CI: fix "ls: cannot access '/etc/cni/net.d': Permission denied"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,7 +339,7 @@ jobs:
             [plugins.cri.containerd.default_runtime]
               runtime_type = "${TEST_RUNTIME}"
           EOF
-          ls /etc/cni/net.d
+          sudo ls /etc/cni/net.d
           sudo PATH=$PATH BDIR=$BDIR /usr/local/bin/containerd -a ${BDIR}/c.sock --config ${BDIR}/config.toml --root ${BDIR}/root --state ${BDIR}/state --log-level debug &> ${BDIR}/containerd-cri.log &
           sudo PATH=$PATH BDIR=$BDIR /usr/local/bin/ctr -a ${BDIR}/c.sock version
           sudo PATH=$PATH BDIR=$BDIR GOPATH=$GOPATH critest --runtime-endpoint=unix:///${BDIR}/c.sock --parallel=8


### PR DESCRIPTION
The CI host was probably updated recently and the permission bits of the directory was changed.

Fix #5077
