### PR TITLE
Prepare 1.5.0-beta.2 release

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -75,12 +75,14 @@ Mohammad Asif Siddiqui <mohammad.asif.siddiqui1@huawei.com>
 Nishchay Kumar <mrawesomenix@gmail.com>
 Oliver Stenbom <oliver@stenbom.eu> <ostenbom@pivotal.io>
 Phil Estes <estesp@gmail.com> <estesp@linux.vnet.ibm.com>
+Phil Estes <estesp@gmail.com> <estesp@amazon.com>
 Reid Li <reid.li@utexas.edu>
 Robin Winkelewski <w9ncontact@gmail.com>
 Ross Boucher <rboucher@gmail.com>
 Ruediger Maass <ruediger.maass@de.ibm.com>
 Rui Cao <ruicao@alauda.io> <ruicao@alauda.io>
 Sakeven Jiang <jc5930@sina.cn>
+Samuel Karp <me@samuelkarp.com> <skarp@amazon.com>
 Seth Pellegrino <spellegrino@newrelic.com> <30441101+sethp-nr@users.noreply.github.com>
 Shengbo Song <thomassong@tencent.com>
 Shengjing Zhu <i@zhsj.me> <zhsj@debian.org>

--- a/releases/v1.5.0-beta.toml
+++ b/releases/v1.5.0-beta.toml
@@ -48,6 +48,10 @@ brings support for the Node Resource Interface (NRI).
 ## Windows
 * **Optimize LCOW snapshotter use of scratch layers** [#4643](https://github.com/containerd/containerd/pull/4643)
 
+## CRI
+* **Update privileged containers to use current capabilities instead of known capabilities** [#5017](https://github.com/containerd/containerd/pull/5017)
+* **Add pod annotations to CNI call** [#5026](https://github.com/containerd/containerd/pull/5026)
+
 And many more improvements and bug fixes in the complete changelog"""
 
 # notable prs to include in the release notes, 1234 is the pr number

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.5.0-beta.1+unknown"
+	Version = "1.5.0-beta.2+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Updates release notes, version, and mailmap for 1.5.0-beta.2