### PR TITLE
Fixed wording in docs, and broken link

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -21,7 +21,7 @@ External plugins allow extending containerd's functionality using an officially
 released version of containerd without needing to recompile the daemon to add a
 plugin.
 
-containerd allows extensions through two method:
+containerd allows extensions through two methods:
  - via a binary available in containerd's PATH
  - by configuring containerd to proxy to another gRPC service
 
@@ -32,7 +32,7 @@ These binaries are used to start the shim process for containerd and allows
 containerd to manage those containers using the runtime shim api returned by
 the binary.
 
-See [runtime v2 documentation](runtime/v2/README.md)
+See [runtime v2 documentation](../runtime/v2/README.md)
 
 ### Proxy Plugins
 

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -79,7 +79,7 @@ sudo systemd-run -p Delegate=yes -p KillMode=process /usr/local/bin/containerd
 In the containerd config file you will find settings for persistent and runtime storage locations as well as grpc, debug, and metrics addresses for the various APIs.
 
 There are a few settings that are important for ops.
-The first setting is the `oom_score`.  Because containerd will be managing multiple containers, we need to ensure that containers are killed before the containerd daemon in an out of memory condition.
+The first setting is the `oom_score`.  Because containerd will be managing multiple containers, we need to ensure that containers are killed before the containerd daemon gets into an out of memory condition.
 We also do not want to make containerd unkillable, but we want to lower its score to the level of other system daemons.
 
 containerd also exports its own metrics as well as container level metrics via the prometheus metrics format.
@@ -195,6 +195,8 @@ The only way we can do this is via the config file and not CLI flags.
 
 In the config file you can specify plugin level options for the set of plugins that you use via the `[plugins.<name>]` sections.
 You will have to read the plugin specific docs to find the options that your plugin accepts.
+
+See [containerd's Plugin documentation](./PLUGINS.md)
 
 ### Linux Runtime Plugin
 


### PR DESCRIPTION
Found a broken link replaced it with the relative path to it. 
Also, suggest some wording changes.