### PR TITLE
runtime/v2: add configuration of default runc root

### DIFF
--- a/pkg/process/utils.go
+++ b/pkg/process/utils.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	// RuncRoot is the path to the root runc state directory
+	// RuncRoot is the default path to the root runc state directory
 	RuncRoot = "/run/containerd/runc"
 	// InitPidFile name of the file that contains the init pid
 	InitPidFile = "init.pid"


### PR DESCRIPTION
This change enables an administrator to configure a default runc root directory for the `io.containerd.runc.v2` runtime. Prior to this change, all containers would default to `/run/containerd/runc` even if the administrator had intended to change containerd's state directory to something different from `/run/containerd`.

Fixes https://github.com/containerd/containerd/issues/5096

---

I don't know if this is the right place to inject the default, nor do I know if checking specifically for `io.containerd.runc.v2` is the right approach.  I had initially tried to use the single `state` config value in the file , but was unable to easily get access to that value from within the plugin init; instead, this is a separate configurable.  I'd appreciate any and all feedback about better ways to accomplish this same goal.

---

I've tested this locally with a config file that looks like this:

```
version = 2
root = "/var/lib/dev-containerd"
state = "/run/dev-containerd"
disabled_plugins = [
    "io.containerd.internal.v1.opt",
    "io.containerd.snapshotter.v1.aufs",
    "io.containerd.snapshotter.v1.devmapper",
    "io.containerd.snapshotter.v1.native",
    "io.containerd.snapshotter.v1.zfs",
    "io.containerd.grpc.v1.cri",
]

[grpc]
address = "/run/dev-containerd/containerd.sock"

[plugins."io.containerd.runtime.v2.task"]
runc_root = "/run/dev-containerd/runc"
```

For a containerd running with this config file, default for containers run through `ctr` now puts the runc state files under `/run/dev-containerd/runc` instead of `/run/containerd/runc`.  Specifying `--runc-root` on `ctr run` still allows this value to be overridden, so clients that are already specifying an alternate root are not affected.

As far as I can tell, the runc root option is only passed to the shim during the "Create" operation so this is the only adjustment that needs to be made.  After the shim is created, it controls this directory directly and is responsible for managing it.  This should mean that shims started prior to the value being reconfigured (an administrator changes the value and restarts containerd) should not be affected.  (And this seems to work in my local testing.)

