### PR TITLE
[release/1.5 backport] cri: filter selinux xattr for image volumes

### DIFF
--- a/pkg/cri/opts/container.go
+++ b/pkg/cri/opts/container.go
@@ -115,5 +115,5 @@ func copyExistingContents(source, destination string) error {
 	if len(dstList) != 0 {
 		return errors.Errorf("volume at %q is not initially empty", destination)
 	}
-	return fs.CopyDir(destination, source)
+	return fs.CopyDir(destination, source, fs.WithXAttrExclude("security.selinux"))
 }


### PR DESCRIPTION
Exclude the `security.selinux` xattr when copying content from layer
storage for image volumes. This allows for the already correct label at
the target location to be applied to the copied content, thus enabling
containers to write to volumes that they implicitly expect to be able to
write to.

- Backport of #5902
- Fixes containerd/containerd#5090 (for 1.5.x)
- See rancher/rke2#690
