### PR TITLE
mark device faulty after parent fails to suspend

### DIFF
--- a/snapshots/devmapper/pool_device.go
+++ b/snapshots/devmapper/pool_device.go
@@ -331,12 +331,6 @@ func (p *PoolDevice) CreateSnapshotDevice(ctx context.Context, deviceName string
 		}
 	}()
 
-	// Save snapshot metadata and allocate new device ID
-	metaErr = p.metadata.AddDevice(ctx, snapInfo)
-	if metaErr != nil {
-		return metaErr
-	}
-
 	// The base device must be suspend before taking a snapshot to
 	// avoid corruption.
 	// https://github.com/torvalds/linux/blob/v5.7/Documentation/admin-guide/device-mapper/thin-provisioning.rst#internal-snapshots
@@ -352,6 +346,12 @@ func (p *PoolDevice) CreateSnapshotDevice(ctx context.Context, deviceName string
 				log.G(ctx).WithError(err).Errorf("failed to resume base device %q after taking its snapshot", baseInfo.Name)
 			}
 		}()
+	}
+
+	// Save snapshot metadata and allocate new device ID
+	metaErr = p.metadata.AddDevice(ctx, snapInfo)
+	if metaErr != nil {
+		return metaErr
 	}
 
 	// Create thin device snapshot


### PR DESCRIPTION
When an error is returned here, unlike the other error returns in the function, nothing is done to mark the added device as faulty or remove it.

I have observed this causing future snapshot creations to continue to attempt to use the same ID (from the sequence) to create new devices and get blocked because the device already exists because it was not rolled back here.

Hopefully fixes #5110