### PR TITLE
limiting encrypted image pull to linux for now

### DIFF
--- a/pkg/cri/server/image_pull.go
+++ b/pkg/cri/server/image_pull.go
@@ -35,8 +35,6 @@ import (
 	"github.com/containerd/containerd/log"
 	distribution "github.com/containerd/containerd/reference/docker"
 	"github.com/containerd/containerd/remotes/docker"
-	"github.com/containerd/imgcrypt"
-	"github.com/containerd/imgcrypt/images/encryption"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -438,18 +436,6 @@ func newTransport() *http.Transport {
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 5 * time.Second,
 	}
-}
-
-// encryptedImagesPullOpts returns the necessary list of pull options required
-// for decryption of encrypted images based on the cri decryption configuration.
-func (c *criService) encryptedImagesPullOpts() []containerd.RemoteOpt {
-	if c.config.ImageDecryption.KeyModel == criconfig.KeyModelNode {
-		ltdd := imgcrypt.Payload{}
-		decUnpackOpt := encryption.WithUnpackConfigApplyOpts(encryption.WithDecryptedUnpack(&ltdd))
-		opt := containerd.WithUnpackOpts([]containerd.UnpackOpt{decUnpackOpt})
-		return []containerd.RemoteOpt{opt}
-	}
-	return nil
 }
 
 const (

--- a/pkg/cri/server/image_pull_linux.go
+++ b/pkg/cri/server/image_pull_linux.go
@@ -1,0 +1,37 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"github.com/containerd/containerd"
+	"github.com/containerd/imgcrypt"
+	"github.com/containerd/imgcrypt/images/encryption"
+
+	criconfig "github.com/containerd/containerd/pkg/cri/config"
+)
+
+// encryptedImagesPullOpts returns the necessary list of pull options required
+// for decryption of encrypted images based on the cri decryption configuration.
+func (c *criService) encryptedImagesPullOpts() []containerd.RemoteOpt {
+	if c.config.ImageDecryption.KeyModel == criconfig.KeyModelNode {
+		ltdd := imgcrypt.Payload{}
+		decUnpackOpt := encryption.WithUnpackConfigApplyOpts(encryption.WithDecryptedUnpack(&ltdd))
+		opt := containerd.WithUnpackOpts([]containerd.UnpackOpt{decUnpackOpt})
+		return []containerd.RemoteOpt{opt}
+	}
+	return nil
+}

--- a/pkg/cri/server/image_pull_linux_test.go
+++ b/pkg/cri/server/image_pull_linux_test.go
@@ -1,0 +1,47 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	criconfig "github.com/containerd/containerd/pkg/cri/config"
+)
+
+func TestEncryptedImagePullOpts(t *testing.T) {
+	for desc, test := range map[string]struct {
+		keyModel     string
+		expectedOpts int
+	}{
+		"node key model should return one unpack opt": {
+			keyModel:     criconfig.KeyModelNode,
+			expectedOpts: 1,
+		},
+		"no key model selected should default to node key model": {
+			keyModel:     "",
+			expectedOpts: 0,
+		},
+	} {
+		t.Logf("TestCase %q", desc)
+		c := newTestCRIService()
+		c.config.ImageDecryption.KeyModel = test.keyModel
+		got := len(c.encryptedImagesPullOpts())
+		assert.Equal(t, test.expectedOpts, got)
+	}
+}

--- a/pkg/cri/server/image_pull_other.go
+++ b/pkg/cri/server/image_pull_other.go
@@ -1,0 +1,29 @@
+// +build !windows,!linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"github.com/containerd/containerd"
+)
+
+// encryptedImagesPullOpts returns the necessary list of pull options required
+// for decryption of encrypted images based on the cri decryption configuration.
+func (c *criService) encryptedImagesPullOpts() []containerd.RemoteOpt {
+	return nil
+}

--- a/pkg/cri/server/image_pull_test.go
+++ b/pkg/cri/server/image_pull_test.go
@@ -311,28 +311,6 @@ func TestDefaultScheme(t *testing.T) {
 	}
 }
 
-func TestEncryptedImagePullOpts(t *testing.T) {
-	for desc, test := range map[string]struct {
-		keyModel     string
-		expectedOpts int
-	}{
-		"node key model should return one unpack opt": {
-			keyModel:     criconfig.KeyModelNode,
-			expectedOpts: 1,
-		},
-		"no key model selected should default to node key model": {
-			keyModel:     "",
-			expectedOpts: 0,
-		},
-	} {
-		t.Logf("TestCase %q", desc)
-		c := newTestCRIService()
-		c.config.ImageDecryption.KeyModel = test.keyModel
-		got := len(c.encryptedImagesPullOpts())
-		assert.Equal(t, test.expectedOpts, got)
-	}
-}
-
 func TestImageLayersLabel(t *testing.T) {
 	sampleKey := "sampleKey"
 	sampleDigest, err := digest.Parse("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")

--- a/pkg/cri/server/image_pull_windows.go
+++ b/pkg/cri/server/image_pull_windows.go
@@ -1,0 +1,27 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"github.com/containerd/containerd"
+)
+
+// encryptedImagesPullOpts returns the necessary list of pull options required
+// for decryption of encrypted images based on the cri decryption configuration.
+func (c *criService) encryptedImagesPullOpts() []containerd.RemoteOpt {
+	return nil
+}

--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -121,7 +121,7 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		// handle. NetNSPath in sandbox metadata and NetNS is non empty only for non host network
 		// namespaces. If the pod is in host network namespace then both are empty and should not
 		// be used.
-		var netnsMountDir string = "/var/run/netns"
+		var netnsMountDir = "/var/run/netns"
 		if c.config.NetNSMountsUnderStateDir {
 			netnsMountDir = filepath.Join(c.config.StateDir, "netns")
 		}


### PR DESCRIPTION
Attempt to address https://github.com/containerd/containerd/pull/5101#issuecomment-789229330

per maintainer chat it looks like github.com/containers/ocicrypt@v1.1.0 brought a version of github.com/miekg/pkcs11@v1.0.3 that needs cgo.. and that might not be available to MinGW..

We can/should revert this commit, which disables image pull with encryption on windows, after we iron out the dependencies.

Signed-off-by: Mike Brown <brownwm@us.ibm.com>