### PR TITLE
cri: fix container status

### DIFF
--- a/pkg/cri/server/container_status.go
+++ b/pkg/cri/server/container_status.go
@@ -93,13 +93,23 @@ func toCRIContainerStatus(container containerstore.Container, spec *runtime.Imag
 		}
 	}
 
+	// If container is in the created state, not set started and finished unix timestamps
+	var st, ft int64
+	switch status.State() {
+	case runtime.ContainerState_CONTAINER_RUNNING:
+		// If container is in the running state, set started unix timestamps
+		st = status.StartedAt
+	case runtime.ContainerState_CONTAINER_EXITED, runtime.ContainerState_CONTAINER_UNKNOWN:
+		st, ft = status.StartedAt, status.FinishedAt
+	}
+
 	return &runtime.ContainerStatus{
 		Id:          meta.ID,
 		Metadata:    meta.Config.GetMetadata(),
 		State:       status.State(),
 		CreatedAt:   status.CreatedAt,
-		StartedAt:   status.StartedAt,
-		FinishedAt:  status.FinishedAt,
+		StartedAt:   st,
+		FinishedAt:  ft,
 		ExitCode:    status.ExitCode,
 		Image:       spec,
 		ImageRef:    imageRef,


### PR DESCRIPTION
fix crictl: https://github.com/kubernetes-sigs/cri-tools/pull/724
fix dockershim: https://github.com/kubernetes/kubernetes/pull/99585

In some container states, the startedAt and finishedAt should not be specified
https://github.com/containerd/containerd/blob/134f7a737074727a6e87214323629b87ba658658/vendor/k8s.io/cri-api/pkg/apis/runtime/v1alpha2/api.pb.go#L4211-L4223