### PR TITLE
cri: Devices ownership from SecurityContext

### DIFF
--- a/oci/spec_opts_unix.go
+++ b/oci/spec_opts_unix.go
@@ -37,7 +37,7 @@ func WithHostDevices(_ context.Context, _ Client, _ *containers.Container, s *Sp
 	return nil
 }
 
-// WithDevices recursively adds devices from the passed in path and associated cgroup rules for that device.
+// WithDevices recursively adds devices from the passed in path.
 // If devicePath is a dir it traverses the dir to add all devices in that dir.
 // If devicePath is not a dir, it attempts to add the single device.
 func WithDevices(devicePath, containerPath, permissions string) SpecOpts {

--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -258,6 +258,9 @@ type PluginConfig struct {
 	// present in /sys/fs/cgroup/cgroup.controllers.
 	// This helps with running rootless mode + cgroup v2 + systemd but without hugetlb delegation.
 	DisableHugetlbController bool `toml:"disable_hugetlb_controller" json:"disableHugetlbController"`
+	// DeviceOwnershipFromSecurityContext changes the default behavior of setting container devices uid/gid
+	// from CRI's SecurityContext (RunAsUser/RunAsGroup) instead of taking host's uid/gid. Defaults to false.
+	DeviceOwnershipFromSecurityContext bool `toml:"device_ownership_from_security_context" json:"device_ownership_from_security_context"`
 	// IgnoreImageDefinedVolumes ignores volumes defined by the image. Useful for better resource
 	// isolation, security and early detection of issues in the mount configuration when using
 	// ReadOnlyRootFilesystem since containers won't silently mount a temporary volume.

--- a/pkg/cri/server/container_create_linux.go
+++ b/pkg/cri/server/container_create_linux.go
@@ -222,11 +222,11 @@ func (c *criService) containerSpec(
 			specOpts = append(specOpts, oci.WithHostDevices, oci.WithAllDevicesAllowed)
 		} else {
 			// add requested devices by the config as host devices are not automatically added
-			specOpts = append(specOpts, customopts.WithDevices(c.os, config),
+			specOpts = append(specOpts, customopts.WithDevices(c.os, config, c.config.DeviceOwnershipFromSecurityContext),
 				customopts.WithCapabilities(securityContext, c.allCaps))
 		}
 	} else { // not privileged
-		specOpts = append(specOpts, customopts.WithDevices(c.os, config),
+		specOpts = append(specOpts, customopts.WithDevices(c.os, config, c.config.DeviceOwnershipFromSecurityContext),
 			customopts.WithCapabilities(securityContext, c.allCaps))
 	}
 


### PR DESCRIPTION
CRI container runtimes mount devices (set via kubernetes device plugins)
to containers by taking the host user/group IDs (uid/gid) to the
corresponding container device.

This triggers a problem when trying to run those containers with
non-zero (root uid/gid = 0) uid/gid set via runAsUser/runAsGroup:
the container process has no permission to use the device even when
its gid is permissive to non-root users because the container user
does not belong to that group.

It is possible to workaround the problem by manually adding the device
gid(s) to supplementalGroups. However, this is also problematic because
the device gid(s) may have different values depending on the workers'
distro/version in the cluster.

This patch suggests to take RunAsUser/RunAsGroup set via SecurityContext
as the device UID/GID, respectively. The feature must be enabled by
setting device_ownership_from_security_context runtime config value to
true (valid on Linux only).

## Which issue(s) this PR fixes:

Fixes: kubernetes/kubernetes#92211

## Special notes for your reviewer:

See the k/k issue for details. I have created a detailed Google doc about the
gap and proposed few alternatives how to address it. This PR implements our
"option A" which is what we prefer.

Our preference is that the gap is also addressed the same way in cri-p too.
I have opened a PR with the same implementation there too.

Need help in testing...