### PR TITLE
add caller info to the testHook

### DIFF
--- a/log/logtest/context.go
+++ b/log/logtest/context.go
@@ -18,7 +18,10 @@ package logtest
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/containerd/containerd/log"
@@ -35,6 +38,7 @@ func WithT(ctx context.Context, t testing.TB) context.Context {
 	// Increase debug level for tests
 	l.SetLevel(logrus.DebugLevel)
 	l.SetOutput(ioutil.Discard)
+	l.SetReportCaller(true)
 
 	// Add testing hook
 	l.AddHook(&testHook{
@@ -42,6 +46,9 @@ func WithT(ctx context.Context, t testing.TB) context.Context {
 		fmt: &logrus.TextFormatter{
 			DisableColors:   true,
 			TimestampFormat: log.RFC3339NanoFixed,
+			CallerPrettyfier: func(frame *runtime.Frame) (string, string) {
+				return filepath.Base(frame.Function), fmt.Sprintf("%s:%d", frame.File, frame.Line)
+			},
 		},
 	})
 


### PR DESCRIPTION
issue: https://github.com/containerd/containerd/issues/5093

It may be inconvenient to have no caller information in the test log when a problem occurs.

output:
```
=== RUN   TestLogTest
    log_hook.go:40: time="2021-02-27T02:19:31.384471000+08:00" level=info msg="test message" func=logtest.TestLogTest file="/Users/icebergu/workspace/containerd/log/logtest/context_test.go:12"
--- PASS: TestLogTest (0.00s)
PASS
ok      github.com/containerd/containerd/log/logtest    0.008s
```