### PR TITLE
Update RELEASES.md to reflect latest releases

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -99,8 +99,8 @@ The current state is available in the following table:
 | [1.0](https://github.com/containerd/containerd/releases/tag/v1.0.3)  | End of Life | December 5, 2017  | December 5, 2018 |
 | [1.1](https://github.com/containerd/containerd/releases/tag/v1.1.8)  | End of Life | April 23, 2018  | October 23, 2019 |
 | [1.2](https://github.com/containerd/containerd/releases/tag/v1.2.13) | End of Life | October 24, 2018 | October 15, 2020 |
-| [1.3](https://github.com/containerd/containerd/releases/tag/v1.3.7)  | Active   | September 26, 2019  | February 17, 2021 |
-| [1.4](https://github.com/containerd/containerd/releases/tag/v1.4.1)  | Active   | August 17, 2020 | max(August 17, 2021, release of 1.5.0 + 6 months) |
+| [1.3](https://github.com/containerd/containerd/releases/tag/v1.3.10) | End of Life | September 26, 2019  | March 4, 2021 |
+| [1.4](https://github.com/containerd/containerd/releases/tag/v1.4.4)  | Active   | August 17, 2020 | max(August 17, 2021, release of 1.5.0 + 6 months) |
 | [1.5](https://github.com/containerd/containerd/milestone/30)         | Next   | TBD  | max(TBD+1 year, release of 1.6.0 + 6 months) |
 
 Note that branches and release from before 1.0 may not follow these rules.


### PR DESCRIPTION
Mark 1.3 as end of life as of the 1.3.10 release on March 4th.
Update 1.4 to latest release.