### PR TITLE
Add Windows HostProcess Support

### DIFF
--- a/pkg/cri/annotations/annotations.go
+++ b/pkg/cri/annotations/annotations.go
@@ -59,4 +59,7 @@ const (
 
 	// PodAnnotations are the annotations of the pod
 	PodAnnotations = "io.kubernetes.cri.pod-annotations"
+
+	// WindowsHostProcess is used by hcsshim to identify windows pods that are running HostProcesses
+	WindowsHostProcess = "microsoft.com/hostprocess-container"
 )

--- a/pkg/cri/server/container_create_windows.go
+++ b/pkg/cri/server/container_create_windows.go
@@ -17,6 +17,8 @@
 package server
 
 import (
+	"strconv"
+
 	"github.com/containerd/containerd/oci"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
@@ -118,6 +120,7 @@ func (c *criService) containerSpec(
 		customopts.WithAnnotation(annotations.SandboxName, sandboxConfig.GetMetadata().GetName()),
 		customopts.WithAnnotation(annotations.ContainerName, containerName),
 		customopts.WithAnnotation(annotations.ImageName, imageName),
+		customopts.WithAnnotation(annotations.WindowsHostProcess, strconv.FormatBool(sandboxConfig.GetWindows().GetSecurityContext().GetHostProcess())),
 	)
 	return c.runtimeSpec(id, ociRuntime.BaseRuntimeSpec, specOpts...)
 }

--- a/pkg/cri/server/container_create_windows_test.go
+++ b/pkg/cri/server/container_create_windows_test.go
@@ -72,6 +72,7 @@ func getCreateContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandbox
 			SecurityContext: &runtime.WindowsContainerSecurityContext{
 				RunAsUsername:  "test-user",
 				CredentialSpec: "{\"test\": \"spec\"}",
+				HostProcess:    false,
 			},
 		},
 	}
@@ -130,6 +131,9 @@ func getCreateContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandbox
 
 		assert.Contains(t, spec.Annotations, annotations.SandboxName)
 		assert.EqualValues(t, spec.Annotations[annotations.SandboxName], "test-sandbox-name")
+
+		assert.Contains(t, spec.Annotations, annotations.WindowsHostProcess)
+		assert.EqualValues(t, spec.Annotations[annotations.WindowsHostProcess], "false")
 	}
 	return config, sandboxConfig, imageConfig, specCheck
 }

--- a/pkg/cri/server/restart.go
+++ b/pkg/cri/server/restart.go
@@ -414,6 +414,9 @@ func (c *criService) loadSandbox(ctx context.Context, cntr containerd.Container)
 		// Don't need to load netns for host network sandbox.
 		return sandbox, nil
 	}
+	if goruntime.GOOS == "windows" && meta.Config.GetWindows().GetSecurityContext().GetHostProcess() {
+		return sandbox, nil
+	}
 	sandbox.NetNS = netns.LoadNetNS(meta.NetNSPath)
 
 	// It doesn't matter whether task is running or not. If it is running, sandbox

--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -110,12 +110,18 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	log.G(ctx).Debugf("Use OCI %+v for sandbox %q", ociRuntime, id)
 
 	podNetwork := true
-	// Pod network is always needed on windows.
+
 	if goruntime.GOOS != "windows" &&
 		config.GetLinux().GetSecurityContext().GetNamespaceOptions().GetNetwork() == runtime.NamespaceMode_NODE {
 		// Pod network is not needed on linux with host network.
 		podNetwork = false
 	}
+	if goruntime.GOOS == "windows" &&
+		config.GetWindows().GetSecurityContext().GetHostProcess() {
+		//Windows HostProcess pods can only run on the host network
+		podNetwork = false
+	}
+
 	if podNetwork {
 		// If it is not in host network namespace then create a namespace and set the sandbox
 		// handle. NetNSPath in sandbox metadata and NetNS is non empty only for non host network

--- a/pkg/cri/server/sandbox_run_windows.go
+++ b/pkg/cri/server/sandbox_run_windows.go
@@ -17,6 +17,8 @@
 package server
 
 import (
+	"strconv"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -65,6 +67,7 @@ func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 		customopts.WithAnnotation(annotations.SandboxNamespace, config.GetMetadata().GetNamespace()),
 		customopts.WithAnnotation(annotations.SandboxName, config.GetMetadata().GetName()),
 		customopts.WithAnnotation(annotations.SandboxLogDir, config.GetLogDirectory()),
+		customopts.WithAnnotation(annotations.WindowsHostProcess, strconv.FormatBool(config.GetWindows().GetSecurityContext().GetHostProcess())),
 	)
 
 	return c.runtimeSpec(id, "", specOpts...)

--- a/pkg/cri/server/sandbox_run_windows_test.go
+++ b/pkg/cri/server/sandbox_run_windows_test.go
@@ -40,6 +40,13 @@ func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConf
 		LogDirectory: "test-log-directory",
 		Labels:       map[string]string{"a": "b"},
 		Annotations:  map[string]string{"c": "d"},
+		Windows: &runtime.WindowsPodSandboxConfig{
+			SecurityContext: &runtime.WindowsSandboxSecurityContext{
+				RunAsUsername:  "test-user",
+				CredentialSpec: "{\"test\": \"spec\"}",
+				HostProcess:    false,
+			},
+		},
 	}
 	imageConfig := &imagespec.ImageConfig{
 		Env:        []string{"a=b", "c=d"},
@@ -70,6 +77,9 @@ func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConf
 
 		assert.Contains(t, spec.Annotations, annotations.SandboxLogDir)
 		assert.EqualValues(t, spec.Annotations[annotations.SandboxLogDir], "test-log-directory")
+
+		assert.Contains(t, spec.Annotations, annotations.WindowsHostProcess)
+		assert.EqualValues(t, spec.Annotations[annotations.WindowsHostProcess], "false")
 	}
 	return config, imageConfig, specCheck
 }

--- a/pkg/cri/server/sandbox_status.go
+++ b/pkg/cri/server/sandbox_status.go
@@ -76,6 +76,9 @@ func (c *criService) getIPs(sandbox sandboxstore.Sandbox) (string, []string, err
 		// responsible for reporting the IP.
 		return "", nil, nil
 	}
+	if goruntime.GOOS == "windows" && config.GetWindows().GetSecurityContext().GetHostProcess() {
+		return "", nil, nil
+	}
 
 	if closed, err := sandbox.NetNS.Closed(); err != nil {
 		return "", nil, errors.Wrap(err, "check network namespace closed")


### PR DESCRIPTION
This PR adds support for Windows HostProcess containers introduced in HCSShim https://github.com/microsoft/hcsshim/pull/903 by @dcantah and skips CNI calls for HostProcess Containers as they are not used, allowing pods to schedule before CNI is Ready and therefore allowing CNI agents to be scheduled in HostProcess Pods