### PR TITLE
apparmor: add DumpDefaultProfile

### DIFF
--- a/contrib/apparmor/apparmor.go
+++ b/contrib/apparmor/apparmor.go
@@ -19,6 +19,7 @@
 package apparmor
 
 import (
+	"bytes"
 	"context"
 	"io/ioutil"
 	"os"
@@ -78,4 +79,18 @@ func LoadDefaultProfile(name string) error {
 		return errors.Wrapf(err, "load apparmor profile %s", path)
 	}
 	return nil
+}
+
+// DumpDefaultProfiles dumps the default profile with the given name.
+func DumpDefaultProfile(name string) (string, error) {
+	p, err := loadData(name)
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	if err := generate(p, &buf); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
 }

--- a/contrib/apparmor/apparmor_test.go
+++ b/contrib/apparmor/apparmor_test.go
@@ -104,3 +104,16 @@ Copyright 2009-2018 Canonical Ltd.
 		}
 	}
 }
+
+func TestDumpDefaultProfile(t *testing.T) {
+	if _, err := getVersion(); err != nil {
+		t.Skipf("AppArmor not available: %+v", err)
+	}
+	name := "test-dump-default-profile"
+	prof, err := DumpDefaultProfile(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Generated profile %q", name)
+	t.Log(prof)
+}


### PR DESCRIPTION
This function will be used by [nerdctl](https://github.com/AkihiroSuda/nerdctl) for printing the default AppArmor profile: `nerdctl system inspect apparmor-profile`

```console
$ go test -v -run TestDumpDefaultProfile
=== RUN   TestDumpDefaultProfile
    apparmor_test.go:117: Generated profile "test-dump-default-profile"
    apparmor_test.go:118: 
        
        #include <tunables/global>
        
        
        profile test-dump-default-profile flags=(attach_disconnected,mediate_deleted) {
        
          #include <abstractions/base>
        
        
          network,
          capability,
          file,
          umount,
        
          deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
          # deny write to files not in /proc/<number>/** or /proc/sys/**
          deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,
          deny @{PROC}/sys/[^k]** w,  # deny /proc/sys except /proc/sys/k* (effectively /proc/sys/kernel)
          deny @{PROC}/sys/kernel/{?,??,[^s][^h][^m]**} w,  # deny everything except shm* in /proc/sys/kernel/
          deny @{PROC}/sysrq-trigger rwklx,
          deny @{PROC}/mem rwklx,
          deny @{PROC}/kmem rwklx,
          deny @{PROC}/kcore rwklx,
        
          deny mount,
        
          deny /sys/[^f]*/** wklx,
          deny /sys/f[^s]*/** wklx,
          deny /sys/fs/[^c]*/** wklx,
          deny /sys/fs/c[^g]*/** wklx,
          deny /sys/fs/cg[^r]*/** wklx,
          deny /sys/firmware/** rwklx,
          deny /sys/kernel/security/** rwklx,
        
        
          ptrace (trace,read) peer=test-dump-default-profile,
        
        }
        
--- PASS: TestDumpDefaultProfile (0.00s)
PASS
ok      github.com/containerd/containerd/contrib/apparmor       0.007s
```