### PR TITLE
add imgcrypt stream processors to the default config

### DIFF
--- a/cmd/containerd/command/config.go
+++ b/cmd/containerd/command/config.go
@@ -22,6 +22,7 @@ import (
 	"os"
 
 	"github.com/BurntSushi/toml"
+	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/pkg/timeout"
 	"github.com/containerd/containerd/services/server"
 	srvconfig "github.com/containerd/containerd/services/server/config"
@@ -112,4 +113,19 @@ var configCommand = cli.Command{
 			},
 		},
 	},
+}
+
+func platformAgnosticDefaultConfig() *srvconfig.Config {
+	return &srvconfig.Config{
+		Version: 1,
+		Root:    defaults.DefaultRootDir,
+		State:   defaults.DefaultStateDir,
+		GRPC: srvconfig.GRPCConfig{
+			Address:        defaults.DefaultAddress,
+			MaxRecvMsgSize: defaults.DefaultMaxRecvMsgSize,
+			MaxSendMsgSize: defaults.DefaultMaxSendMsgSize,
+		},
+		DisabledPlugins: []string{},
+		RequiredPlugins: []string{},
+	}
 }

--- a/cmd/containerd/command/config.go
+++ b/cmd/containerd/command/config.go
@@ -20,12 +20,15 @@ import (
 	gocontext "context"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/BurntSushi/toml"
 	"github.com/containerd/containerd/defaults"
+	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/pkg/timeout"
 	"github.com/containerd/containerd/services/server"
 	srvconfig "github.com/containerd/containerd/services/server/config"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/urfave/cli"
 )
 
@@ -125,7 +128,38 @@ func platformAgnosticDefaultConfig() *srvconfig.Config {
 			MaxRecvMsgSize: defaults.DefaultMaxRecvMsgSize,
 			MaxSendMsgSize: defaults.DefaultMaxSendMsgSize,
 		},
-		DisabledPlugins: []string{},
-		RequiredPlugins: []string{},
+		DisabledPlugins:  []string{},
+		RequiredPlugins:  []string{},
+		StreamProcessors: streamProcessors(),
+	}
+}
+
+func streamProcessors() map[string]srvconfig.StreamProcessor {
+	const (
+		ctdDecoder = "ctd-decoder"
+		basename   = "io.containerd.ocicrypt.decoder.v1"
+	)
+	decryptionKeysPath := filepath.Join(defaults.DefaultConfigDir, "ocicrypt", "keys")
+	ctdDecoderArgs := []string{
+		"--decryption-keys-path", decryptionKeysPath,
+	}
+	ctdDecoderEnv := []string{
+		"OCICRYPT_KEYPROVIDER_CONFIG=" + filepath.Join(defaults.DefaultConfigDir, "ocicrypt", "ocicrypt_keyprovider.conf"),
+	}
+	return map[string]srvconfig.StreamProcessor{
+		basename + ".tar.gzip": {
+			Accepts: []string{images.MediaTypeImageLayerGzipEncrypted},
+			Returns: ocispec.MediaTypeImageLayerGzip,
+			Path:    ctdDecoder,
+			Args:    ctdDecoderArgs,
+			Env:     ctdDecoderEnv,
+		},
+		basename + ".tar": {
+			Accepts: []string{images.MediaTypeImageLayerEncrypted},
+			Returns: ocispec.MediaTypeImageLayer,
+			Path:    ctdDecoder,
+			Args:    ctdDecoderArgs,
+			Env:     ctdDecoderEnv,
+		},
 	}
 }

--- a/cmd/containerd/command/config_linux.go
+++ b/cmd/containerd/command/config_linux.go
@@ -17,21 +17,9 @@
 package command
 
 import (
-	"github.com/containerd/containerd/defaults"
 	srvconfig "github.com/containerd/containerd/services/server/config"
 )
 
 func defaultConfig() *srvconfig.Config {
-	return &srvconfig.Config{
-		Version: 1,
-		Root:    defaults.DefaultRootDir,
-		State:   defaults.DefaultStateDir,
-		GRPC: srvconfig.GRPCConfig{
-			Address:        defaults.DefaultAddress,
-			MaxRecvMsgSize: defaults.DefaultMaxRecvMsgSize,
-			MaxSendMsgSize: defaults.DefaultMaxSendMsgSize,
-		},
-		DisabledPlugins: []string{},
-		RequiredPlugins: []string{},
-	}
+	return platformAgnosticDefaultConfig()
 }

--- a/cmd/containerd/command/config_unsupported.go
+++ b/cmd/containerd/command/config_unsupported.go
@@ -24,18 +24,10 @@ import (
 )
 
 func defaultConfig() *srvconfig.Config {
-	return &srvconfig.Config{
-		Version: 1,
-		Root:    defaults.DefaultRootDir,
-		State:   defaults.DefaultStateDir,
-		GRPC: srvconfig.GRPCConfig{
-			Address: defaults.DefaultAddress,
-		},
-		Debug: srvconfig.Debug{
-			Level:   "info",
-			Address: defaults.DefaultDebugAddress,
-		},
-		DisabledPlugins: []string{},
-		RequiredPlugins: []string{},
+	cfg := platformAgnosticDefaultConfig()
+	cfg.Debug = srvconfig.Debug{
+		Level:   "info",
+		Address: defaults.DefaultDebugAddress,
 	}
+	return cfg
 }

--- a/cmd/containerd/command/config_windows.go
+++ b/cmd/containerd/command/config_windows.go
@@ -17,21 +17,9 @@
 package command
 
 import (
-	"github.com/containerd/containerd/defaults"
 	srvconfig "github.com/containerd/containerd/services/server/config"
 )
 
 func defaultConfig() *srvconfig.Config {
-	return &srvconfig.Config{
-		Version: 1,
-		Root:    defaults.DefaultRootDir,
-		State:   defaults.DefaultStateDir,
-		GRPC: srvconfig.GRPCConfig{
-			Address:        defaults.DefaultAddress,
-			MaxRecvMsgSize: defaults.DefaultMaxRecvMsgSize,
-			MaxSendMsgSize: defaults.DefaultMaxSendMsgSize,
-		},
-		DisabledPlugins: []string{},
-		RequiredPlugins: []string{},
-	}
+	return platformAgnosticDefaultConfig()
 }

--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -27,6 +27,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
@@ -80,7 +81,7 @@ can be used and modified as necessary as a custom configuration.`
 		cli.StringFlag{
 			Name:  "config,c",
 			Usage: "path to the configuration file",
-			Value: defaultConfigPath,
+			Value: filepath.Join(defaults.DefaultConfigDir, "config.toml"),
 		},
 		cli.StringFlag{
 			Name:  "log-level,l",

--- a/cmd/containerd/command/main_unix.go
+++ b/cmd/containerd/command/main_unix.go
@@ -27,8 +27,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const defaultConfigPath = "/etc/containerd/config.toml"
-
 var handledSignals = []os.Signal{
 	unix.SIGTERM,
 	unix.SIGINT,

--- a/cmd/containerd/command/main_windows.go
+++ b/cmd/containerd/command/main_windows.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"unsafe"
 
 	"github.com/Microsoft/go-winio/pkg/etw"
@@ -33,8 +32,7 @@ import (
 )
 
 var (
-	defaultConfigPath = filepath.Join(os.Getenv("programfiles"), "containerd", "config.toml")
-	handledSignals    = []os.Signal{
+	handledSignals = []os.Signal{
 		windows.SIGTERM,
 		windows.SIGINT,
 	}

--- a/defaults/defaults_unix.go
+++ b/defaults/defaults_unix.go
@@ -34,4 +34,6 @@ const (
 	DefaultFIFODir = "/run/containerd/fifo"
 	// DefaultRuntime is the default linux runtime
 	DefaultRuntime = "io.containerd.runc.v2"
+	// DefaultConfigDir is the default location for config files.
+	DefaultConfigDir = "/etc/containerd"
 )

--- a/defaults/defaults_windows.go
+++ b/defaults/defaults_windows.go
@@ -30,6 +30,9 @@ var (
 	// DefaultStateDir is the default location used by containerd to store
 	// transient data
 	DefaultStateDir = filepath.Join(os.Getenv("ProgramData"), "containerd", "state")
+
+	// DefaultConfigDir is the default location for config files.
+	DefaultConfigDir = filepath.Join(os.Getenv("programfiles"), "containerd")
 )
 
 const (

--- a/images/mediatypes.go
+++ b/images/mediatypes.go
@@ -49,6 +49,9 @@ const (
 	MediaTypeContainerd1CheckpointRuntimeOptions = "application/vnd.containerd.container.checkpoint.runtime.options+proto"
 	// Legacy Docker schema1 manifest
 	MediaTypeDockerSchema1Manifest = "application/vnd.docker.distribution.manifest.v1+prettyjws"
+	// Encypted media types
+	MediaTypeImageLayerEncrypted     = ocispec.MediaTypeImageLayer + "+encrypted"
+	MediaTypeImageLayerGzipEncrypted = ocispec.MediaTypeImageLayerGzip + "+encrypted"
 )
 
 // DiffCompression returns the compression as defined by the layer diff media

--- a/pkg/cri/config/config_unix.go
+++ b/pkg/cri/config/config_unix.go
@@ -72,5 +72,8 @@ func DefaultConfig() PluginConfig {
 		TolerateMissingHugetlbController: true,
 		DisableHugetlbController:         true,
 		IgnoreImageDefinedVolumes:        false,
+		ImageDecryption: ImageDecryption{
+			KeyModel: KeyModelNode,
+		},
 	}
 }

--- a/pkg/cri/config/config_windows.go
+++ b/pkg/cri/config/config_windows.go
@@ -67,5 +67,9 @@ func DefaultConfig() PluginConfig {
 		MaxConcurrentDownloads:    3,
 		IgnoreImageDefinedVolumes: false,
 		// TODO(windows): Add platform specific config, so that most common defaults can be shared.
+
+		ImageDecryption: ImageDecryption{
+			KeyModel: KeyModelNode,
+		},
 	}
 }


### PR DESCRIPTION
Enable the following config by default:

```toml
version = 2

[plugins."io.containerd.grpc.v1.cri".image_decryption]
  key_model = "node"

[stream_processors]
  [stream_processors."io.containerd.ocicrypt.decoder.v1.tar.gzip"]
    accepts = ["application/vnd.oci.image.layer.v1.tar+gzip+encrypted"]
    returns = "application/vnd.oci.image.layer.v1.tar+gzip"
    path = "ctd-decoder"
    args = ["--decryption-keys-path", "/etc/containerd/ocicrypt/keys"]
    env = ["OCICRYPT_KEYPROVIDER_CONFIG=/etc/containerd/ocicrypt/ocicrypt_keyprovider.conf"]

  [stream_processors."io.containerd.ocicrypt.decoder.v1.tar"]
    accepts = ["application/vnd.oci.image.layer.v1.tar+encrypted"]
    returns = "application/vnd.oci.image.layer.v1.tar"
    path = "ctd-decoder"
    args = ["--decryption-keys-path", "/etc/containerd/ocicrypt/keys"]
    env = ["OCICRYPT_KEYPROVIDER_CONFIG=/etc/containerd/ocicrypt/ocicrypt_keyprovider.conf"]
```

Fix #5128