### PR TITLE
Add OpenReader to local store

### DIFF
--- a/content/content.go
+++ b/content/content.go
@@ -37,7 +37,7 @@ type Provider interface {
 	// ReaderAt only requires desc.Digest to be set.
 	// Other fields in the descriptor may be used internally for resolving
 	// the location of the actual data.
-	ReaderAt(ctx context.Context, dec ocispec.Descriptor) (ReaderAt, error)
+	ReaderAt(ctx context.Context, desc ocispec.Descriptor) (ReaderAt, error)
 }
 
 // Ingester writes content

--- a/content/local/readerat.go
+++ b/content/local/readerat.go
@@ -18,6 +18,11 @@ package local
 
 import (
 	"os"
+
+	"github.com/pkg/errors"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/errdefs"
 )
 
 // readerat implements io.ReaderAt in a completely stateless manner by opening
@@ -25,6 +30,29 @@ import (
 type sizeReaderAt struct {
 	size int64
 	fp   *os.File
+}
+
+// OpenReader creates ReaderAt from a file
+func OpenReader(p string) (content.ReaderAt, error) {
+	fi, err := os.Stat(p)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+
+		return nil, errors.Wrap(errdefs.ErrNotFound, "blob not found")
+	}
+
+	fp, err := os.Open(p)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+
+		return nil, errors.Wrap(errdefs.ErrNotFound, "blob not found")
+	}
+
+	return sizeReaderAt{size: fi.Size(), fp: fp}, nil
 }
 
 func (ra sizeReaderAt) ReadAt(p []byte, offset int64) (int, error) {

--- a/content/local/store.go
+++ b/content/local/store.go
@@ -131,25 +131,13 @@ func (s *store) ReaderAt(ctx context.Context, desc ocispec.Descriptor) (content.
 	if err != nil {
 		return nil, errors.Wrapf(err, "calculating blob path for ReaderAt")
 	}
-	fi, err := os.Stat(p)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			return nil, err
-		}
 
-		return nil, errors.Wrapf(errdefs.ErrNotFound, "blob %s expected at %s", desc.Digest, p)
+	reader, err := OpenReader(p)
+	if err != nil {
+		return nil, errors.Wrapf(err, "blob %s expected at %s", desc.Digest, p)
 	}
 
-	fp, err := os.Open(p)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			return nil, err
-		}
-
-		return nil, errors.Wrapf(errdefs.ErrNotFound, "blob %s expected at %s", desc.Digest, p)
-	}
-
-	return sizeReaderAt{size: fi.Size(), fp: fp}, nil
+	return reader, nil
 }
 
 // Delete removes a blob by its digest.


### PR DESCRIPTION
Add `OpenReader`func  to create `ReaderAt` interface from a file system path to simplify local store hacking.
This doesn't change any logic, just makes existing code more reusable.

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>