### PR TITLE
Fix error checking when resolving shim binary path

### DIFF
--- a/runtime/v2/shim/util.go
+++ b/runtime/v2/shim/util.go
@@ -70,7 +70,7 @@ func Command(ctx context.Context, runtime, containerdAddress, containerdTTRPCAdd
 		}
 
 		if cmdPath == "" {
-			if cmdPath, lerr = exec.LookPath(name); err != nil {
+			if cmdPath, lerr = exec.LookPath(name); lerr != nil {
 				if eerr, ok := lerr.(*exec.Error); ok {
 					if eerr.Err == exec.ErrNotFound {
 						// LookPath only finds current directory matches based on


### PR DESCRIPTION
Previously a typo was introduced that caused the wrong error to be
checked against when calling exec.LookPath. This had the effect that
containerd would never locate the shim binary if it was in the same
directory as containerd's binary, but not in PATH.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>