### PR TITLE
CI: Add a name for the vagrant up step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,7 +369,8 @@ jobs:
           path: ~/.vagrant.d/boxes
           key: vagrant-${{ hashFiles('Vagrantfile*') }}
 
-      - run: |
+      - name: Vagrant start
+        run: |
           # Retry if it fails (download.fedoraproject.org returns 404 sometimes)
           vagrant up || vagrant up
 


### PR DESCRIPTION
Without a name the logs use a carriage return followed by the long
comment ("# Retry if it fails"...) as the name of the job step which is messy when working with the
actions API/logs.

Signed-off-by: Phil Estes <estesp@amazon.com>