### PR TITLE
tests: Adds support for Windows cri-integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ bin/cri-integration.test:
 
 cri-integration: binaries bin/cri-integration.test ## run cri integration tests
 	@echo "$(WHALE) $@"
-	@./script/test/cri-integration.sh
+	@bash -x ./script/test/cri-integration.sh
 	@rm -rf bin/cri-integration.test
 
 benchmark: ## run benchmarks tests

--- a/integration/common.go
+++ b/integration/common.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
    Copyright The containerd Authors.
 

--- a/integration/container_log_test.go
+++ b/integration/container_log_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
    Copyright The containerd Authors.
 

--- a/integration/container_restart_test.go
+++ b/integration/container_restart_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
    Copyright The containerd Authors.
 
@@ -35,6 +33,9 @@ func TestContainerRestart(t *testing.T) {
 		assert.NoError(t, runtimeService.StopPodSandbox(sb))
 		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
 	}()
+
+	EnsureImageExists(t, pauseImage)
+
 	t.Logf("Create a container config and run container in a pod")
 	containerConfig := ContainerConfig(
 		"container1",

--- a/integration/container_stop_test.go
+++ b/integration/container_stop_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
    Copyright The containerd Authors.
 
@@ -20,6 +18,7 @@ package integration
 
 import (
 	"context"
+	goruntime "runtime"
 	"testing"
 	"time"
 
@@ -73,6 +72,9 @@ func TestSharedPidMultiProcessContainerStop(t *testing.T) {
 }
 
 func TestContainerStopCancellation(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("Skipped on Windows.")
+	}
 	t.Log("Create a pod sandbox")
 	sbConfig := PodSandboxConfig("sandbox", "cancel-container-stop")
 	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)

--- a/integration/container_update_resources_test.go
+++ b/integration/container_update_resources_test.go
@@ -39,6 +39,7 @@ func checkMemoryLimit(t *testing.T, spec *runtimespec.Spec, memLimit int64) {
 }
 
 func TestUpdateContainerResources(t *testing.T) {
+	// TODO(claudiub): Make this test work once https://github.com/microsoft/hcsshim/pull/931 merges.
 	t.Log("Create a sandbox")
 	sbConfig := PodSandboxConfig("sandbox", "update-container-resources")
 	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
@@ -47,6 +48,8 @@ func TestUpdateContainerResources(t *testing.T) {
 		assert.NoError(t, runtimeService.StopPodSandbox(sb))
 		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
 	}()
+
+	EnsureImageExists(t, pauseImage)
 
 	t.Log("Create a container with memory limit")
 	cnConfig := ContainerConfig(

--- a/integration/container_without_image_ref_test.go
+++ b/integration/container_without_image_ref_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
    Copyright The containerd Authors.
 

--- a/integration/containerd_image_test.go
+++ b/integration/containerd_image_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
    Copyright The containerd Authors.
 
@@ -135,7 +133,7 @@ func TestContainerdImage(t *testing.T) {
 	cnConfig := ContainerConfig(
 		"test-container",
 		id,
-		WithCommand("top"),
+		WithCommand("sleep", "300"),
 	)
 	cn, err := runtimeService.CreateContainer(sb, cnConfig, sbConfig)
 	require.NoError(t, err)

--- a/integration/duplicate_name_test.go
+++ b/integration/duplicate_name_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
    Copyright The containerd Authors.
 
@@ -38,6 +36,8 @@ func TestDuplicateName(t *testing.T) {
 	t.Logf("Create the sandbox again should fail")
 	_, err = runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
 	require.Error(t, err)
+
+	EnsureImageExists(t, pauseImage)
 
 	t.Logf("Create a container")
 	cnConfig := ContainerConfig(

--- a/integration/image_load_test.go
+++ b/integration/image_load_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
    Copyright The containerd Authors.
 
@@ -22,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -41,11 +40,12 @@ func TestImageLoad(t *testing.T) {
 	t.Logf("docker save image into tarball")
 	output, err := exec.Command("docker", "pull", testImage).CombinedOutput()
 	require.NoError(t, err, "output: %q", output)
-	tarF, err := ioutil.TempFile("", "image-load")
-	tar := tarF.Name()
+	// ioutil.TempFile also opens a file, which might prevent us from overwriting that file with docker save.
+	tarDir, err := ioutil.TempDir("", "image-load")
+	tar := filepath.Join(tarDir, "image.tar")
 	require.NoError(t, err)
 	defer func() {
-		assert.NoError(t, os.RemoveAll(tar))
+		assert.NoError(t, os.RemoveAll(tarDir))
 	}()
 	output, err = exec.Command("docker", "save", testImage, "-o", tar).CombinedOutput()
 	require.NoError(t, err, "output: %q", output)

--- a/integration/imagefs_info_test.go
+++ b/integration/imagefs_info_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
    Copyright The containerd Authors.
 
@@ -61,7 +59,6 @@ func TestImageFSInfo(t *testing.T) {
 		info = stats[0]
 		if info.GetTimestamp() != 0 &&
 			info.GetUsedBytes().GetValue() != 0 &&
-			info.GetInodesUsed().GetValue() != 0 &&
 			info.GetFsId().GetMountpoint() != "" {
 			return true, nil
 		}

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
    Copyright The containerd Authors.
 
@@ -97,6 +95,7 @@ func ConnectDaemons() error {
 	}
 	// containerdEndpoint is the same with criEndpoint now
 	containerdEndpoint = strings.TrimPrefix(*criEndpoint, "unix://")
+	containerdEndpoint = strings.TrimPrefix(containerdEndpoint, "npipe:")
 	containerdClient, err = containerd.New(containerdEndpoint, containerd.WithDefaultNamespace(k8sNamespace))
 	if err != nil {
 		return errors.Wrap(err, "failed to connect containerd")
@@ -198,7 +197,7 @@ func WithTestAnnotations() ContainerOpts {
 }
 
 // Add container resource limits.
-func WithResources(r *runtime.LinuxContainerResources) ContainerOpts {
+func WithResources(r *runtime.LinuxContainerResources) ContainerOpts { //nolint:unused
 	return func(c *runtime.ContainerConfig) {
 		if c.Linux == nil {
 			c.Linux = &runtime.LinuxContainerConfig{}
@@ -240,7 +239,7 @@ func WithLogPath(path string) ContainerOpts {
 }
 
 // WithSupplementalGroups adds supplemental groups.
-func WithSupplementalGroups(gids []int64) ContainerOpts {
+func WithSupplementalGroups(gids []int64) ContainerOpts { //nolint:unused
 	return func(c *runtime.ContainerConfig) {
 		if c.Linux == nil {
 			c.Linux = &runtime.LinuxContainerConfig{}
@@ -325,7 +324,7 @@ func KillProcess(name string) error {
 }
 
 // KillPid kills the process by pid. kill is used.
-func KillPid(pid int) error {
+func KillPid(pid int) error { //nolint:unused
 	output, err := exec.Command("kill", strconv.Itoa(pid)).CombinedOutput()
 	if err != nil {
 		return errors.Errorf("failed to kill %d - error: %v, output: %q", pid, err, output)
@@ -379,7 +378,7 @@ func CRIConfig() (*criconfig.Config, error) {
 }
 
 // SandboxInfo gets sandbox info.
-func SandboxInfo(id string) (*runtime.PodSandboxStatus, *server.SandboxInfo, error) {
+func SandboxInfo(id string) (*runtime.PodSandboxStatus, *server.SandboxInfo, error) { //nolint:unused
 	client, err := RawRuntimeClient()
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to get raw runtime client")

--- a/integration/no_metadata_test.go
+++ b/integration/no_metadata_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
    Copyright The containerd Authors.
 

--- a/integration/pod_hostname_test.go
+++ b/integration/pod_hostname_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
    Copyright The containerd Authors.
 
@@ -22,6 +20,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	goruntime "runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -37,6 +37,7 @@ func TestPodHostname(t *testing.T) {
 		opts             []PodSandboxOpts
 		expectedHostname string
 		expectErr        bool
+		needsHostNetwork bool
 	}{
 		"regular pod with custom hostname": {
 			opts: []PodSandboxOpts{
@@ -49,16 +50,21 @@ func TestPodHostname(t *testing.T) {
 				WithHostNetwork,
 			},
 			expectedHostname: hostname,
+			needsHostNetwork: true,
 		},
 		"host network pod with custom hostname should fail": {
 			opts: []PodSandboxOpts{
 				WithHostNetwork,
 				WithPodHostname("test-hostname"),
 			},
-			expectErr: true,
+			expectErr:        true,
+			needsHostNetwork: true,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
+			if test.needsHostNetwork && goruntime.GOOS == "windows" {
+				t.Skip("Skipped on Windows.")
+			}
 			testPodLogDir, err := ioutil.TempDir("/tmp", "hostname")
 			require.NoError(t, err)
 			defer os.RemoveAll(testPodLogDir)
@@ -94,7 +100,7 @@ func TestPodHostname(t *testing.T) {
 				containerName,
 				testImage,
 				WithCommand("sh", "-c",
-					"echo -n /etc/hostname= && cat /etc/hostname && env"),
+					"echo -n /etc/hostname= && hostname && env"),
 				WithLogPath(containerName),
 			)
 			cn, err := runtimeService.CreateContainer(sb, cnConfig, sbConfig)
@@ -119,7 +125,11 @@ func TestPodHostname(t *testing.T) {
 			assert.NoError(t, err)
 
 			t.Log("Search hostname env in container log")
-			assert.Contains(t, string(content), "HOSTNAME="+test.expectedHostname)
+			if goruntime.GOOS == "windows" {
+				assert.Contains(t, string(content), "COMPUTERNAME="+strings.ToUpper(test.expectedHostname))
+			} else {
+				assert.Contains(t, string(content), "HOSTNAME="+test.expectedHostname)
+			}
 
 			t.Log("Search /etc/hostname content in container log")
 			assert.Contains(t, string(content), "/etc/hostname="+test.expectedHostname)

--- a/integration/restart_test.go
+++ b/integration/restart_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
    Copyright The containerd Authors.
 
@@ -19,6 +17,7 @@
 package integration
 
 import (
+	goruntime "runtime"
 	"sort"
 	"testing"
 
@@ -33,6 +32,9 @@ import (
 // Restart test must run sequentially.
 
 func TestContainerdRestart(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("Skipped on Windows.")
+	}
 	type container struct {
 		name  string
 		id    string
@@ -100,6 +102,9 @@ func TestContainerdRestart(t *testing.T) {
 			runtimeService.StopPodSandbox(sid)
 			runtimeService.RemovePodSandbox(sid)
 		}()
+
+		EnsureImageExists(t, pauseImage)
+
 		s.id = sid
 		for j := range s.containers {
 			c := &s.containers[j]

--- a/integration/truncindex_test.go
+++ b/integration/truncindex_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
    Copyright The containerd Authors.
 
@@ -19,6 +17,7 @@
 package integration
 
 import (
+	goruntime "runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -82,7 +81,7 @@ func TestTruncIndex(t *testing.T) {
 	cnConfig := ContainerConfig(
 		"containerTruncIndex",
 		appImage,
-		WithCommand("top"),
+		WithCommand("sleep", "300"),
 	)
 	cn, err := runtimeService.CreateContainer(sbTruncIndex, cnConfig, sbConfig)
 	require.NoError(t, err)
@@ -112,11 +111,15 @@ func TestTruncIndex(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, cn, cStats.Attributes.Id)
 
-	t.Logf("Update container memory limit after started")
-	err = runtimeService.UpdateContainerResources(cnTruncIndex, &runtimeapi.LinuxContainerResources{
-		MemoryLimitInBytes: 50 * 1024 * 1024,
-	})
-	assert.NoError(t, err)
+	if goruntime.GOOS != "windows" {
+		// TODO(claudiub): remove this when UpdateContainerResources works on running Windows Containers.
+		// https://github.com/containerd/containerd/issues/5187
+		t.Logf("Update container memory limit after started")
+		err = runtimeService.UpdateContainerResources(cnTruncIndex, &runtimeapi.LinuxContainerResources{
+			MemoryLimitInBytes: 50 * 1024 * 1024,
+		})
+		assert.NoError(t, err)
+	}
 
 	t.Logf("Execute cmd in container")
 	execReq := &runtimeapi.ExecRequest{

--- a/integration/volume_copy_up_test.go
+++ b/integration/volume_copy_up_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
    Copyright The containerd Authors.
 
@@ -21,6 +19,7 @@ package integration
 import (
 	"fmt"
 	"os/exec"
+	goruntime "runtime"
 	"testing"
 	"time"
 
@@ -29,6 +28,11 @@ import (
 )
 
 func TestVolumeCopyUp(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		// TODO(claudiub): Remove this when the volume-copy-up image has Windows support.
+		// https://github.com/containerd/containerd/pull/5162
+		t.Skip("Skipped on Windows.")
+	}
 	var (
 		testImage   = GetImage(VolumeCopyUp)
 		execTimeout = time.Minute
@@ -89,6 +93,9 @@ func TestVolumeCopyUp(t *testing.T) {
 }
 
 func TestVolumeOwnership(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("Skipped on Windows.")
+	}
 	var (
 		testImage   = GetImage(VolumeOwnership)
 		execTimeout = time.Minute

--- a/script/test/cri-integration.sh
+++ b/script/test/cri-integration.sh
@@ -33,7 +33,7 @@ mkdir -p ${REPORT_DIR}
 test_setup ${REPORT_DIR}
 
 # Run integration test.
-sudo PATH=${PATH} bin/cri-integration.test --test.run="${FOCUS}" --test.v \
+${sudo} bin/cri-integration.test --test.run="${FOCUS}" --test.v \
   --cri-endpoint=${CONTAINERD_SOCK} \
   --cri-root=${CRI_ROOT} \
   --runtime-handler=${RUNTIME} \

--- a/script/test/utils.sh
+++ b/script/test/utils.sh
@@ -16,6 +16,11 @@
 
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/../..
 
+IS_WINDOWS=0
+if [ -v "OS" ] && [ "${OS}" == "Windows_NT" ]; then
+  IS_WINDOWS=1
+fi
+
 # RESTART_WAIT_PERIOD is the period to wait before restarting containerd.
 RESTART_WAIT_PERIOD=${RESTART_WAIT_PERIOD:-10}
 # CONTAINERD_FLAGS contains all containerd flags.
@@ -52,17 +57,35 @@ CONTAINERD_ROOT=${CONTAINERD_ROOT:-"/var/lib/containerd${CONTAINERD_TEST_SUFFIX}
 # The containerd state directory.
 CONTAINERD_STATE=${CONTAINERD_STATE:-"/run/containerd${CONTAINERD_TEST_SUFFIX}"}
 # The containerd socket address.
-CONTAINERD_SOCK=${CONTAINERD_SOCK:-unix://${CONTAINERD_STATE}/containerd.sock}
+if [ $IS_WINDOWS -eq 0 ]; then
+  CONTAINERD_SOCK=${CONTAINERD_SOCK:-unix://${CONTAINERD_STATE}/containerd.sock}
+  TRIMMED_CONTAINERD_SOCK="${CONTAINERD_SOCK#unix://}"
+else
+  CONTAINERD_SOCK=${CONTAINERD_SOCK:-npipe://./pipe/${CONTAINERD_STATE}/containerd}
+  TRIMMED_CONTAINERD_SOCK="${CONTAINERD_SOCK#npipe:}"
+fi
+
 # The containerd binary name.
-CONTAINERD_BIN=${CONTAINERD_BIN:-"containerd"} # don't need a suffix now
+EXE_SUFFIX=""
+if [ $IS_WINDOWS -eq 1 ]; then
+  EXE_SUFFIX=".exe"
+fi
+CONTAINERD_BIN=${CONTAINERD_BIN:-"containerd"}${EXE_SUFFIX}
 if [ -f "${CONTAINERD_CONFIG_FILE}" ]; then
   CONTAINERD_FLAGS+="--config ${CONTAINERD_CONFIG_FILE} "
 fi
-CONTAINERD_FLAGS+="--address ${CONTAINERD_SOCK#"unix://"} \
+
+CONTAINERD_FLAGS+="--address ${TRIMMED_CONTAINERD_SOCK} \
   --state ${CONTAINERD_STATE} \
   --root ${CONTAINERD_ROOT}"
 
-containerd_groupid=
+kill_containerd_cmd=
+
+# NOTE: We don't have the sudo command on Windows.
+sudo=""
+if [ $(id -u) -ne 0 ] && command -v sudo &> /dev/null; then
+  sudo="sudo PATH=${PATH}"
+fi
 
 # test_setup starts containerd.
 test_setup() {
@@ -75,11 +98,17 @@ test_setup() {
   set -m
   # Create containerd in a different process group
   # so that we can easily clean them up.
-  keepalive "sudo PATH=${PATH} bin/containerd ${CONTAINERD_FLAGS}" \
+  keepalive "${sudo} bin/containerd ${CONTAINERD_FLAGS}" \
     ${RESTART_WAIT_PERIOD} &> ${report_dir}/containerd.log &
   pid=$!
   set +m
-  containerd_groupid=$(ps -o pgid= -p ${pid})
+
+  if [ $IS_WINDOWS -eq 1 ]; then
+    kill_containerd_cmd="${sudo} kill ${pid}"
+  else
+    kill_containerd_cmd="${sudo} pkill -g $(ps -o pgid= -p ${pid})"
+  fi
+
   # Wait for containerd to be running by using the containerd client ctr to check the version
   # of the containerd server. Wait an increasing amount of time after each of five attempts
   local -r crictl_path=$(which crictl)
@@ -87,14 +116,14 @@ test_setup() {
     echo "crictl is not in PATH"
     exit 1
   fi
-  readiness_check "sudo bin/ctr --address ${CONTAINERD_SOCK#"unix://"} version"
-  readiness_check "sudo ${crictl_path} --runtime-endpoint=${CONTAINERD_SOCK} info"
+  readiness_check "${sudo} bin/ctr --address ${TRIMMED_CONTAINERD_SOCK} version"
+  readiness_check "${sudo} ${crictl_path} --runtime-endpoint=${CONTAINERD_SOCK} info"
 }
 
 # test_teardown kills containerd.
 test_teardown() {
-  if [ -n "${containerd_groupid}" ]; then
-    sudo pkill -g ${containerd_groupid}
+  if [ -n "${kill_containerd_cmd}" ]; then
+    ${kill_containerd_cmd}
   fi
 }
 


### PR DESCRIPTION
Currently, the cri-integration tests do not work on Windows due to various reasons. One of the reasons is because all the tests are using Linux-specific images. This commit refactors the image pulling / usage in the cri-integration tests, making it
easier to update, and easier to configure the a custom registry to pull those images from.

For Windows runs, custom registries can be created, which will also contain Windows images, and the cri-integration tests can be configured to use those registries by specifying the ``--repo-list`` argument, a YAML file which will contain an alternative
mapping of the default registries. This is similar to how E2E tests are handled for Windows runs in Kubernetes.

Some of the tests are Skipped, as they do not pass yet on Windows.

Windows does not collect inodes used stats, thus, the tests that were expecting non-zero inodes stats were failing.