### PR TITLE
Add CI periodic Windows Jobs.

### DIFF
--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -4,7 +4,7 @@ name: win-periodic-integration
 
 on:
   schedule:
-  - cron: "0 */12 * * *"
+  - cron: "0 1 * * *"
 
 env:
   AZURE_DEFAULT_LOCATION: westeurope

--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -19,13 +19,16 @@ jobs:
   winIntegration:
     strategy:
       matrix:
-        win_ver: [sac1909]
+        win_ver: [ltsc2019, sac2004]
         include:
-        - win_ver: sac1909
-          AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:Datacenter-Core-1909-with-Containers-smalldisk:18363.900.2006061800"
-          AZURE_RESOURCE_GROUP: ctrd-integration-sac1909-${{ github.run_id }}
-          GOOGLE_BUCKET: "gs://containerd-integration/logs/windows-sac1909/"
-
+        - win_ver: sac2004
+          AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:datacenter-core-2004-with-containers-smalldisk:19041.928.2104150521"
+          AZURE_RESOURCE_GROUP: ctrd-integration-sac2004-${{ github.run_id }}
+          GOOGLE_BUCKET: "gs://containerd-integration/logs/windows-sac2004/"
+        - win_ver: ltsc2019
+          AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2019-Datacenter-with-Containers-smalldisk:17763.1935.2105080716"
+          AZURE_RESOURCE_GROUP: ctrd-integration-ltsc2019-${{ github.run_id }}
+          GOOGLE_BUCKET: "gs://containerd-integration/logs/windows-ltsc2019/"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -1,0 +1,165 @@
+# Workflow intended to periodically test containerd integration tests
+
+name: win-periodic-integration
+
+on:
+  schedule:
+  - cron: "0 */12 * * *"
+
+env:
+  AZURE_DEFAULT_LOCATION: westeurope
+  AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUB_ID }}
+  AZURE_DEFAULT_VM_SIZE: Standard_D2s_v3
+  PASSWORD: Passw0rdAdmin # temp for testing, will be generated
+  DEFAULT_ADMIN_USERNAME: azureuser
+  SSH_OPTS: "-o ServerAliveInterval=20 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+  REMOTE_VM_BIN_PATH: "c:\\containerd\\bin"
+
+jobs:
+  winIntegration:
+    strategy:
+      matrix:
+        win_ver: [sac1909]
+        include:
+        - win_ver: sac1909
+          AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:Datacenter-Core-1909-with-Containers-smalldisk:18363.900.2006061800"
+          AZURE_RESOURCE_GROUP: ctrd-integration-sac1909-${{ github.run_id }}
+          GOOGLE_BUCKET: "gs://containerd-integration/logs/windows-sac1909/"
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install required packages
+        run: |
+          sudo apt-get install xmlstarlet -y
+
+      - name: PrepareArtifacts
+        run: |
+          STARTED_TIME=$(date +%s)
+          LOGS_DIR=$HOME/$STARTED_TIME
+          echo "STARTED_TIME=$STARTED_TIME" >> $GITHUB_ENV
+          echo "LOGS_DIR=$LOGS_DIR" >> $GITHUB_ENV
+          mkdir -p $LOGS_DIR/artifacts
+
+          jq -n --arg node temp --arg timestamp $STARTED_TIME '$timestamp|tonumber|{timestamp:.,$node}' > $LOGS_DIR/started.json
+
+      - name: Generate ssh key pair
+        run: |
+          mkdir -p $HOME/.ssh/
+          ssh-keygen -t rsa -b 4096 -C "ci@containerd.com" -f $HOME/.ssh/id_rsa -q -N ""
+          echo "SSH_PUB_KEY=$(cat ~/.ssh/id_rsa.pub)" >> $GITHUB_ENV
+
+      - name: AZLogin
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDS }}
+
+      - name: AZResourceGroupCreate
+        uses: azure/CLI@v1
+        with:
+          azcliversion: latest
+          inlinescript: |
+            az group create -n ${{ matrix.AZURE_RESOURCE_GROUP }} -l ${{ env.AZURE_DEFAULT_LOCATION }}
+
+      - name: AZTestVMCreate
+        uses: azure/CLI@v1
+        with:
+          azcliversion: latest
+          inlinescript: |
+            az vm create -n winTestVM --admin-username ${{ env.DEFAULT_ADMIN_USERNAME }} --admin-password ${{ env.PASSWORD }} --image ${{ matrix.AZURE_IMG }} -g ${{ matrix.AZURE_RESOURCE_GROUP }} --nsg-rule SSH --size ${{ env.AZURE_DEFAULT_VM_SIZE }}
+
+      - name: GetAZVMPublicIP
+        uses: azure/CLI@v1
+        with:
+          azcliversion: latest
+          inlinescript: |
+            echo "VM_PUB_IP=$(az network public-ip list -g ${{ matrix.AZURE_RESOURCE_GROUP }} | jq '.[0]["ipAddress"]' | tr -d '\"')" >> $GITHUB_ENV
+
+      - name: EnableAZVMSSH
+        uses: azure/CLI@v1
+        with:
+          azcliversion: latest
+          inlinescript: |
+            az vm run-command invoke  --command-id RunPowerShellScript -n winTestVM -g ${{ matrix.AZURE_RESOURCE_GROUP }} --scripts @$GITHUB_WORKSPACE/script/setup/enable_ssh_windows.ps1 --parameters 'SSHPublicKey=${{ env.SSH_PUB_KEY }}'
+
+      - name: TestSSHConnection
+        run: |
+          if ! ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }}  "hostname";
+          then
+            exit 1
+          fi
+
+      - name: PrepareTestingEnv
+        run: |
+          scp -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }}  $GITHUB_WORKSPACE/script/setup/prepare_env_windows.ps1  azureuser@${{ env.VM_PUB_IP }}:/prepare_env_windows.ps1
+          ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }}  azureuser@${{ env.VM_PUB_IP }} "c:\\prepare_env_windows.ps1"
+
+      - name: MakeContainerDBins
+        run: |
+          ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }} "git clone http://github.com/containerd/containerd c:\\containerd "
+          ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }} "cd c:\containerd ; make binaries"
+          ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }} "git clone http://github.com/Microsoft/hcsshim c:\containerd\hcsshim "
+
+          # Get shim commit from containerd local repo
+          SHIM_COMMIT=$(grep 'Microsoft/hcsshim' go.mod | awk '{ print $2 }');
+
+          ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }} "cd c:\containerd\hcsshim; git fetch --tags origin $SHIM_COMMIT ; \
+                            git checkout $SHIM_COMMIT ; go build -mod=vendor -o ${{ env.REMOTE_VM_BIN_PATH }}\containerd-shim-runhcs-v1.exe .\cmd\containerd-shim-runhcs-v1"
+
+      - name: RunIntegrationTests
+        run: |
+          ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }} "sh.exe -c 'cd /c/containerd && (make integration | tee /c/Logs/integration.log)'"
+          ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }} "sh.exe -c 'cat /c/Logs/integration.log | go-junit-report.exe > /c/Logs/junit_00.xml'"
+
+      # CRI-integration tests for Windows PR is not merged. TO DO (adelina-t): enable these when PR #5163 merges.
+      #
+      # - name: PrepareRepoList
+      #   run: |
+      #     ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }} "sh -c 'cat > c:/repolist.yaml'" <<'EOF'
+      #       dockerLibraryRegistry: docker.io/claudiubelu
+      #       k8sCriContainerdRegistry: docker.io/claudiubelu
+      #       k8sGcrRegistry: docker.io/claudiubelu
+      #     EOF
+
+      # - name: RunCRIIntegrationTests
+      #   run: |
+      #     ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }} "sh.exe -s" <<EOF
+      #       cd c:/containerd
+      #       ./script/setup/install-cni-windows
+      #       export KUBE_TEST_REPO_LIST=c:/repolist.yaml
+      #       make cri-integration | tee c:/Logs/cri-integration.log
+      #     EOF
+      #     ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }} "sh.exe -c 'cat c:\Logs\cri-integration.log | go-junit-report.exe > c:/Logs/junit_01.xml' "
+
+      - name: PullLogsFromWinNode
+        run: |
+          scp -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }}:c:/Logs/*.xml ${{ env.LOGS_DIR }}/artifacts/
+          for f in $(ls ${{ env.LOGS_DIR }}/artifacts/*.xml); do
+              xmlstarlet ed -d "/testsuites/testsuite/properties" $f > ${{ env.LOGS_DIR }}/$(basename $f)
+              mv ${{ env.LOGS_DIR }}/$(basename $f) $f
+          done
+
+      - name: FinishJob
+        run: |
+          jq -n --arg result SUCCESS --arg timestamp $(date +%s) '$timestamp|tonumber|{timestamp:.,$result}' > ${{ env.LOGS_DIR }}/finished.json
+          echo "${{ env.STARTED_TIME }}" > $HOME/latest-build.txt
+
+      - name: SetUpCloudSDK
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+
+      - name: UploadArtifacts
+        run: |
+          gsutil cp -r ${{ env.LOGS_DIR }} ${{ matrix.GOOGLE_BUCKET }}
+          gsutil cp $HOME/latest-build.txt ${{ matrix.GOOGLE_BUCKET }}
+
+      - name: ResourceCleanup
+        uses: azure/CLI@v1
+        with:
+          azcliversion: latest
+          inlinescript: |
+            az group delete -g ${{ matrix.AZURE_RESOURCE_GROUP }} --yes

--- a/script/setup/enable_ssh_windows.ps1
+++ b/script/setup/enable_ssh_windows.ps1
@@ -1,0 +1,37 @@
+Param(
+    [parameter(Mandatory=$true)]
+    [string]$SSHPublicKey
+)
+
+$ErrorActionPreference = "Stop"
+
+
+function Set-SSHPublicKey {
+    if(!$SSHPublicKey) {
+        return
+    }
+    $authorizedKeysFile = Join-Path $env:ProgramData "ssh\administrators_authorized_keys"
+    Set-Content -Path $authorizedKeysFile -Value $SSHPublicKey -Encoding ascii
+    $acl = Get-Acl $authorizedKeysFile
+    $acl.SetAccessRuleProtection($true, $false)
+    $administratorsRule = New-Object system.security.accesscontrol.filesystemaccessrule("Administrators", "FullControl", "Allow")
+    $systemRule = New-Object system.security.accesscontrol.filesystemaccessrule("SYSTEM", "FullControl", "Allow")
+    $acl.SetAccessRule($administratorsRule)
+    $acl.SetAccessRule($systemRule)
+    $acl | Set-Acl
+}
+
+# Install OpenSSH
+$(
+
+Get-WindowsCapability -Online -Name OpenSSH* | Add-WindowsCapability -Online
+Set-Service -Name sshd -StartupType Automatic
+Start-Service sshd
+
+# Authorize SSH key
+Set-SSHPublicKey
+
+# Set PowerShell as default shell
+New-ItemProperty -Force -Path "HKLM:\SOFTWARE\OpenSSH" -PropertyType String `
+                 -Name DefaultShell -Value "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
+) *>$1 >> c:\output.txt

--- a/script/setup/install-cni-windows
+++ b/script/setup/install-cni-windows
@@ -17,7 +17,7 @@
 set -eu -o pipefail
 
 DESTDIR="${DESTDIR:-"C:\\Program Files\\containerd"}"
-WINCNI_BIN_DIR="${DESTDIR}/cni"
+WINCNI_BIN_DIR="${DESTDIR}/cni/bin"
 WINCNI_PKG=github.com/Microsoft/windows-container-networking
 WINCNI_VERSION=aa10a0b31e9f72937063436454def1760b858ee2
 

--- a/script/setup/prepare_env_windows.ps1
+++ b/script/setup/prepare_env_windows.ps1
@@ -1,0 +1,40 @@
+# Prepare windows environment for building and running containerd tests
+
+$PACKAGES= "mingw", "git", "golang", "make"
+
+write-host "Downloading chocolatey package"
+curl.exe -L "https://packages.chocolatey.org/chocolatey.0.10.15.nupkg" -o 'c:\choco.zip'
+Expand-Archive "c:\choco.zip" -DestinationPath "c:\choco"
+
+write-host "Installing choco"
+& "c:\choco\tools\chocolateyInstall.ps1"
+
+write-host "Set choco.exe path."
+$env:PATH+=";C:\ProgramData\chocolatey\bin"
+
+write-host "Install necessary packages"
+
+foreach ($package in $PACKAGES) {
+    choco.exe install $package --yes
+}
+
+write-host "Set up environment."
+
+$path = ";c:\Program Files\Git\bin;c:\Program Files\Go\bin;c:\Users\azureuser\go\bin;c:\containerd\bin"
+$env:PATH+=$path
+
+write-host $env:PATH
+
+[Environment]::SetEnvironmentVariable("PATH", $env:PATH, 'User')
+
+# Prepare Log dir
+mkdir c:\Logs
+
+# Pull junit conversion tool
+go get -u github.com/jstemmer/go-junit-report
+
+# Get critctl tool. Used for cri-integration tests
+$CRICTL_DOWNLOAD_URL="https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.21.0/crictl-v1.21.0-windows-amd64.tar.gz"
+curl.exe -L $CRICTL_DOWNLOAD_URL -o c:\crictl.tar.gz
+tar -xvf c:\crictl.tar.gz
+mv crictl.exe c:\Users\azureuser\go\bin\crictl.exe # Move crictl somewhere in path


### PR DESCRIPTION
Part of the ongoing work described here: https://github.com/containerd/containerd/issues/5039

This introduces a periodic Windows 1909 testing job. This will be expanded to multiple Windows Versions. The goal is to improve testing volume & coverage on multiple Windows versions in order to pick up any regression or intermittent issue with containerD for Windows. 

TO-DOs:

- [x]  Manage test VM lifecycle
- [ ]  Run cri-integration tests ( once these PRs get going: https://github.com/containerd/containerd/pull/5163 and https://github.com/containerd/containerd/pull/5162 )
    - This step has been commented out , pending reenabling when #5163 merges. It seems appropriate to not wait for that PR to merge as to not slow the process for this one unnecessarily
- [x]  Collect artifacts / logs 
- [x]  Publish artifacts to testgrid or similar ( ? )