### PR TITLE
Switch from merge-resolve(default) to merge mode for containerd-build-arm64

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,5 +1,6 @@
 - project:
     name: containerd/containerd
+    merge-mode: merge
     check:
       jobs:
         - containerd-build-arm64


### PR DESCRIPTION
Just use the same default merge mode as github, don't use the conservative thing zuul defaults to. More info at:
https://zuul-ci.org/docs/zuul/reference/project_def.html

```
project.merge-mode
Default: merge-resolve

merge
Uses the default git merge strategy (recursive). This maps to the merge mode merge in Github.

merge-resolve
Uses the resolve git merge strategy. This is a very conservative merge strategy which most closely matches the behavior of Gerrit. This maps to the merge mode merge in Github.
```


Signed-off-by: Davanum Srinivas <davanum@gmail.com>