### PR TITLE
Support size-based filtering

### DIFF
--- a/content/adaptor.go
+++ b/content/adaptor.go
@@ -17,6 +17,7 @@
 package content
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/containerd/containerd/filters"
@@ -33,7 +34,7 @@ func AdaptInfo(info Info) filters.Adaptor {
 		case "digest":
 			return info.Digest.String(), true
 		case "size":
-			// TODO: support size based filtering
+			return strconv.FormatInt(info.Size, 10), true
 		case "labels":
 			return checkMap(fieldpath[1:], info.Labels)
 		}

--- a/filters/filter_test.go
+++ b/filters/filter_test.go
@@ -78,6 +78,12 @@ func TestFilters(t *testing.T) {
 				"foo": "omg_asdf.asdf-qwer",
 			},
 		},
+		{
+			Name: "number",
+			Labels: map[string]string{
+				"size": "100",
+			},
+		},
 	}
 
 	var corpus []interface{}
@@ -175,6 +181,7 @@ func TestFilters(t *testing.T) {
 				corpus[6],
 				corpus[7],
 				corpus[8],
+				corpus[9],
 			},
 		},
 		{
@@ -250,6 +257,13 @@ func TestFilters(t *testing.T) {
 			input: `labels."more complex label with \\ and \"".post==present`,
 			expected: []interface{}{
 				corpus[5],
+			},
+		},
+		{
+			name:  "Number",
+			input: `labels.size > 10`,
+			expected: []interface{}{
+				corpus[9],
 			},
 		},
 		{

--- a/filters/parser.go
+++ b/filters/parser.go
@@ -43,7 +43,7 @@ selectors := selector ("," selector)*
 selector  := fieldpath (operator value)
 fieldpath := field ('.' field)*
 field     := quoted | [A-Za-z] [A-Za-z0-9_]+
-operator  := "==" | "!=" | "~="
+operator  := "==" | "!=" | "~=" | "<" | ">"
 value     := quoted | [^\s,]+
 quoted    := <go string syntax>
 
@@ -227,6 +227,10 @@ func (p *parser) operator() (operator, error) {
 			return operatorNotEqual, nil
 		case "~=":
 			return operatorMatches, nil
+		case "<":
+			return operatorLessThan, nil
+		case ">":
+			return operatorGreaterThan, nil
 		default:
 			return 0, p.mkerr(pos, "unsupported operator %q", s)
 		}

--- a/filters/scanner.go
+++ b/filters/scanner.go
@@ -160,6 +160,8 @@ func (s *scanner) scanOperator() {
 		switch ch {
 		case '=', '!', '~':
 			s.next()
+		case '<', '>':
+			return
 		default:
 			return
 		}
@@ -262,7 +264,7 @@ func isDigitRune(r rune) bool {
 
 func isOperatorRune(r rune) bool {
 	switch r {
-	case '=', '!', '~':
+	case '=', '!', '~', '<', '>':
 		return true
 	}
 

--- a/filters/scanner_test.go
+++ b/filters/scanner_test.go
@@ -320,6 +320,16 @@ func TestScanner(t *testing.T) {
 				{pos: 13, token: tokenEOF},
 			},
 		},
+		{
+			name:  "NumberComparisonOperator",
+			input: `size < 10`,
+			expected: []tokenResult{
+				{pos: 0, token: tokenField, text: "size"},
+				{pos: 5, token: tokenOperator, text: "<"},
+				{pos: 7, token: tokenValue, text: "10"},
+				{pos: 9, token: tokenEOF},
+			},
+		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
 			var sc scanner

--- a/metadata/adaptors.go
+++ b/metadata/adaptors.go
@@ -17,6 +17,7 @@
 package metadata
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/containerd/containerd/containers"
@@ -47,11 +48,11 @@ func adaptImage(o interface{}) filters.Adaptor {
 				return obj.Target.Digest.String(), len(obj.Target.Digest) > 0
 			case "mediatype":
 				return obj.Target.MediaType, len(obj.Target.MediaType) > 0
+			case "size":
+				return strconv.FormatInt(obj.Target.Size, 10), true
 			}
 		case "labels":
 			return checkMap(fieldpath[1:], obj.Labels)
-			// TODO(stevvooe): Greater/Less than filters would be awesome for
-			// size. Let's do it!
 		case "annotations":
 			return checkMap(fieldpath[1:], obj.Target.Annotations)
 		}


### PR DESCRIPTION
This change adds size-based filtering by exposing "size" attribute and
adding number comparison operators (< and >).

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>