### PR TITLE
rootfs: fix the error handling of the snapshotter.Commit

### DIFF
--- a/rootfs/init.go
+++ b/rootfs/init.go
@@ -67,7 +67,7 @@ func InitRootFS(ctx context.Context, name string, parent digest.Digest, readonly
 	return snapshotter.Prepare(ctx, name, parentS)
 }
 
-func createInitLayer(ctx context.Context, parent, initName string, initFn func(string) error, snapshotter snapshots.Snapshotter, mounter Mounter) (string, error) {
+func createInitLayer(ctx context.Context, parent, initName string, initFn func(string) error, snapshotter snapshots.Snapshotter, mounter Mounter) (_ string, retErr error) {
 	initS := fmt.Sprintf("%s %s", parent, initName)
 	if _, err := snapshotter.Stat(ctx, initS); err == nil {
 		return initS, nil
@@ -87,7 +87,7 @@ func createInitLayer(ctx context.Context, parent, initName string, initFn func(s
 	}
 
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			if rerr := snapshotter.Remove(ctx, td); rerr != nil {
 				log.G(ctx).Errorf("Failed to remove snapshot %s: %v", td, rerr)
 			}


### PR DESCRIPTION
If the `snapshotter.Commit` return an error, then the `snapshotter.Remove` should also be called.
https://github.com/containerd/containerd/blob/6b410ba41ff28471134ca508665f89a10610eb7f/rootfs/init.go#L112-L117
https://github.com/containerd/containerd/blob/e231b955dd9a0fa88f7928f5c69b09e8ed95e4dd/rootfs/init.go#L88-L96

@dmcgowan @dnephin PTAL. Thanks
