### PR TITLE
ctr plugin ls: plugin status should be skip, not error

### DIFF
--- a/cmd/ctr/commands/plugins/plugins.go
+++ b/cmd/ctr/commands/plugins/plugins.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/platforms"
+	pluginutils "github.com/containerd/containerd/plugin"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/urfave/cli"
 	"google.golang.org/grpc/codes"
@@ -121,7 +122,11 @@ var listCommand = cli.Command{
 			status := "ok"
 
 			if plugin.InitErr != nil {
-				status = "error"
+				if strings.Contains(plugin.InitErr.Message, pluginutils.ErrSkipPlugin.Error()) {
+					status = "skip"
+				} else {
+					status = "error"
+				}
 			}
 
 			var platformColumn = "-"


### PR DESCRIPTION
```
[root@daocloud ~]# ctr plugin ls
TYPE                            ID                       PLATFORMS      STATUS
io.containerd.content.v1        content                  -              ok
io.containerd.snapshotter.v1    aufs                     linux/amd64    error
io.containerd.snapshotter.v1    devmapper                linux/amd64    error
io.containerd.snapshotter.v1    native                   linux/amd64    ok
io.containerd.snapshotter.v1    overlayfs                linux/amd64    ok
io.containerd.snapshotter.v1    zfs                      linux/amd64    error
```

```
Type:          io.containerd.snapshotter.v1
ID:            zfs
Platforms:     linux/amd64
Exports:
               root      /var/lib/containerd/io.containerd.snapshotter.v1.zfs
Error:
               Code:        Unknown
               Message:     path /var/lib/containerd/io.containerd.snapshotter.v1.zfs must be a zfs filesystem to be used with the zfs snapshotter: skip plugin
```

Skip error can be identified as `skip`
/kind bug
