### PR TITLE
move overlay-checks to an overlayutils package

### DIFF
--- a/archive/tar_linux_test.go
+++ b/archive/tar_linux_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/containerd/containerd/log/logtest"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/pkg/testutil"
-	"github.com/containerd/containerd/snapshots/overlay"
+	"github.com/containerd/containerd/snapshots/overlay/overlayutils"
 	"github.com/containerd/continuity/fs"
 	"github.com/containerd/continuity/fs/fstest"
 	"github.com/pkg/errors"
@@ -46,7 +46,7 @@ func TestOverlayApply(t *testing.T) {
 	}
 	defer os.RemoveAll(base)
 
-	if err := overlay.Supported(base); err != nil {
+	if err := overlayutils.Supported(base); err != nil {
 		t.Skipf("skipping because overlay is not supported %v", err)
 	}
 	fstest.FSSuite(t, overlayDiffApplier{
@@ -65,7 +65,7 @@ func TestOverlayApplyNoParents(t *testing.T) {
 	}
 	defer os.RemoveAll(base)
 
-	if err := overlay.Supported(base); err != nil {
+	if err := overlayutils.Supported(base); err != nil {
 		t.Skipf("skipping because overlay is not supported %v", err)
 	}
 	fstest.FSSuite(t, overlayDiffApplier{

--- a/snapshots/overlay/overlay.go
+++ b/snapshots/overlay/overlay.go
@@ -30,6 +30,7 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/snapshots"
+	"github.com/containerd/containerd/snapshots/overlay/overlayutils"
 	"github.com/containerd/containerd/snapshots/storage"
 	"github.com/containerd/continuity/fs"
 	"github.com/pkg/errors"
@@ -98,7 +99,7 @@ func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
 	}
 
 	// figure out whether "userxattr" option is recognized by the kernel && needed
-	userxattr, err := NeedsUserXAttr(root)
+	userxattr, err := overlayutils.NeedsUserXAttr(root)
 	if err != nil {
 		logrus.WithError(err).Warnf("cannot detect whether \"userxattr\" option needs to be used, assuming to be %v", userxattr)
 	}

--- a/snapshots/overlay/overlay_test.go
+++ b/snapshots/overlay/overlay_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/pkg/testutil"
 	"github.com/containerd/containerd/snapshots"
+	"github.com/containerd/containerd/snapshots/overlay/overlayutils"
 	"github.com/containerd/containerd/snapshots/storage"
 	"github.com/containerd/containerd/snapshots/testsuite"
 )
@@ -177,7 +178,7 @@ func testOverlayOverlayMount(t *testing.T, newSnapshotter testsuite.SnapshotterF
 	expected := []string{
 		"index=off",
 	}
-	if userxattr, err := NeedsUserXAttr(root); err != nil {
+	if userxattr, err := overlayutils.NeedsUserXAttr(root); err != nil {
 		t.Fatal(err)
 	} else if userxattr {
 		expected = append(expected, "userxattr")
@@ -346,7 +347,7 @@ func testOverlayView(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
 	}
 
 	expectedOptions := 2
-	userxattr, err := NeedsUserXAttr(root)
+	userxattr, err := overlayutils.NeedsUserXAttr(root)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/snapshots/overlay/overlayutils/check.go
+++ b/snapshots/overlay/overlayutils/check.go
@@ -16,7 +16,7 @@
    limitations under the License.
 */
 
-package overlay
+package overlayutils
 
 import (
 	"fmt"
@@ -31,14 +31,14 @@ import (
 	"github.com/pkg/errors"
 )
 
-// supportsMultipleLowerDir checks if the system supports multiple lowerdirs,
+// SupportsMultipleLowerDir checks if the system supports multiple lowerdirs,
 // which is required for the overlay snapshotter. On 4.x kernels, multiple lowerdirs
 // are always available (so this check isn't needed), and backported to RHEL and
 // CentOS 3.x kernels (3.10.0-693.el7.x86_64 and up). This function is to detect
 // support on those kernels, without doing a kernel version compare.
 //
 // Ported from moby overlay2.
-func supportsMultipleLowerDir(d string) error {
+func SupportsMultipleLowerDir(d string) error {
 	td, err := ioutil.TempDir(d, "multiple-lowerdir-check")
 	if err != nil {
 		return err
@@ -85,7 +85,7 @@ func Supported(root string) error {
 	if !supportsDType {
 		return fmt.Errorf("%s does not support d_type. If the backing filesystem is xfs, please reformat with ftype=1 to enable d_type support", root)
 	}
-	return supportsMultipleLowerDir(root)
+	return SupportsMultipleLowerDir(root)
 }
 
 // NeedsUserXAttr returns whether overlayfs should be mounted with the "userxattr" mount option.

--- a/snapshots/overlay/overlayutils/check_test.go
+++ b/snapshots/overlay/overlayutils/check_test.go
@@ -16,7 +16,7 @@
    limitations under the License.
 */
 
-package overlay
+package overlayutils
 
 import (
 	"io/ioutil"


### PR DESCRIPTION
This allows using the utilities without importing the whole snapshotter.

relates to the discussion on https://github.com/moby/moby/pull/42068#discussion_r591498492. This potentially allows moby to use this package, instead of maintaining the moby `overlayutils` package