### PR TITLE
go.mod: add warnings about overridden versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,8 +27,10 @@ require (
 	github.com/docker/go-units v0.4.0
 	github.com/emicklei/go-restful v2.9.5+incompatible
 	github.com/fsnotify/fsnotify v1.4.9
+	// googleapis: the actual version is replaced in replace()
 	github.com/gogo/googleapis v1.4.0
 	github.com/gogo/protobuf v1.3.2
+	// protobuf: the actual version is replaced in replace()
 	github.com/golang/protobuf v1.4.3
 	github.com/google/go-cmp v0.5.4
 	github.com/google/uuid v1.1.2
@@ -48,11 +50,13 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.6.1
 	github.com/tchap/go-patricia v2.2.6+incompatible
+	// urfave/cli: the actual version is replaced in replace()
 	github.com/urfave/cli v1.22.2
 	go.etcd.io/bbolt v1.3.5
 	golang.org/x/net v0.0.0-20201224014010-6772e930b67b
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
 	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c
+	// grpc: the actual version is replaced in replace()
 	google.golang.org/grpc v1.33.2
 	gotest.tools/v3 v3.0.3
 	k8s.io/api v0.20.1
@@ -66,10 +70,14 @@ require (
 )
 
 replace (
+	// FIXME gogo/googleapis must be v1.3.2 <BECAUSE>
 	github.com/gogo/googleapis => github.com/gogo/googleapis v1.3.2
+	// FIXME golang/protobuf must be v1.3.5 <BECAUSE>
 	github.com/golang/protobuf => github.com/golang/protobuf v1.3.5
 	// urfave/cli must be <= v1.22.1 due to a regression: https://github.com/urfave/cli/issues/1092
 	github.com/urfave/cli => github.com/urfave/cli v1.22.1
+	// FIXME genproto must be v0.0.0-20200224152610-e50cd9704f63 <BECAUSE>
 	google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200224152610-e50cd9704f63
+	// FIXME olang.org/grpc be v1.27.1 <BECAUSE>
 	google.golang.org/grpc => google.golang.org/grpc v1.27.1
 )


### PR DESCRIPTION
Adding warning comments to go.mod to guide users to the actual version that is used (and tested against).

In the "replace" section, adding comments that explain the reason for pinning some of the dependencies to specific versions.
