### PR TITLE
upgrade pause image to 3.5 for non-root

### DIFF
--- a/contrib/ansible/cri-containerd.yaml
+++ b/contrib/ansible/cri-containerd.yaml
@@ -61,6 +61,6 @@
     # TODO This needs to be removed once we have consistent concurrent pull results
     - name: "Pre-pull pause container image"
       shell: |
-        /usr/local/bin/ctr pull k8s.gcr.io/pause:3.4.1
+        /usr/local/bin/ctr pull k8s.gcr.io/pause:3.5
         /usr/local/bin/crictl --runtime-endpoint unix:///run/containerd/containerd.sock \
-        pull k8s.gcr.io/pause:3.4.1
+        pull k8s.gcr.io/pause:3.5

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -244,7 +244,7 @@ example configuration
     stream_server_address = ""
     stream_server_port = "10010"
     enable_selinux = false
-    sandbox_image = "k8s.gcr.io/pause:3.4.1"
+    sandbox_image = "k8s.gcr.io/pause:3.5"
     stats_collect_period = 10
     systemd_cgroup = false
     [plugins.cri.containerd]

--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -40,7 +40,7 @@ version = 2
   selinux_category_range = 1024
 
   # sandbox_image is the image used by sandbox container.
-  sandbox_image = "k8s.gcr.io/pause:3.4.1"
+  sandbox_image = "k8s.gcr.io/pause:3.5"
 
   # stats_collect_period is the period (in seconds) of snapshots stats collection.
   stats_collect_period = 10

--- a/docs/cri/crictl.md
+++ b/docs/cri/crictl.md
@@ -59,28 +59,29 @@ command. With the load command you inject a container image into the container
 runtime from a file. First you need to create a container image tarball. For
 example to create an image tarball for a pause container using Docker:
 ```console
-$ docker pull k8s.gcr.io/pause:3.4.1
-  3.4.1: Pulling from pause
-  67ddbfb20a22: Pull complete
-  Digest: sha256:6c3835cab3980f11b83277305d0d736051c32b17606f5ec59f1dda67c9ba3810
-  Status: Downloaded newer image for k8s.gcr.io/pause:3.4.1
-$ docker save k8s.gcr.io/pause:3.4.1 -o pause.tar
+$ docker pull k8s.gcr.io/pause:3.5
+  3.5: Pulling from pause
+  019d8da33d91: Pull complete
+  Digest: sha256:1ff6c18fbef2045af6b9c16bf034cc421a29027b800e4f9b68ae9b1cb3e9ae07
+  Status: Downloaded newer image for k8s.gcr.io/pause:3.5
+  k8s.gcr.io/pause:3.5
+$ docker save k8s.gcr.io/pause:3.5 -o pause.tar
 ```
 Then use `ctr` to load the container image into the container runtime:
 ```console
 # The cri plugin uses the "k8s.io" containerd namespace.
 $ sudo ctr -n=k8s.io images import pause.tar
-  Loaded image: k8s.gcr.io/pause:3.4.1
+  Loaded image: k8s.gcr.io/pause:3.5
 ```
 List images and inspect the pause image:
 ```console
 $ sudo crictl images
 IMAGE                       TAG                 IMAGE ID            SIZE
 docker.io/library/busybox   latest              f6e427c148a76       728kB
-k8s.gcr.io/pause            3.4.1               0f8457a4c2eca       686kB
-$ sudo crictl inspecti 0f8457a4c2eca
+k8s.gcr.io/pause            3.5                 ed210e3e4a5ba       683kB
+$ sudo crictl inspecti ed210e3e4a5ba
   ... displays information about the pause image.
-$ sudo crictl inspecti k8s.gcr.io/pause:3.4.1
+$ sudo crictl inspecti k8s.gcr.io/pause:3.5
   ... displays information about the pause image.
 ```
 
@@ -200,7 +201,7 @@ $ crictl info
       }
     },
     "streamServerPort": "10010",
-    "sandboxImage": "k8s.gcr.io/pause:3.4.1",
+    "sandboxImage": "k8s.gcr.io/pause:3.5",
     "statsCollectPeriod": 10,
     "containerdRootDir": "/var/lib/containerd",
     "containerdEndpoint": "unix:///run/containerd/containerd.sock",

--- a/integration/client/client_test.go
+++ b/integration/client/client_test.go
@@ -310,7 +310,7 @@ func TestImagePullAllPlatforms(t *testing.T) {
 	defer cancel()
 
 	cs := client.ContentStore()
-	img, err := client.Fetch(ctx, "k8s.gcr.io/pause:3.4.1")
+	img, err := client.Fetch(ctx, "k8s.gcr.io/pause:3.5")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/client/image_test.go
+++ b/integration/client/image_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestImageIsUnpacked(t *testing.T) {
-	const imageName = "k8s.gcr.io/pause:3.4.1"
+	const imageName = "k8s.gcr.io/pause:3.5"
 	ctx, cancel := testContext(t)
 	defer cancel()
 
@@ -81,7 +81,7 @@ func TestImagePullWithDistSourceLabel(t *testing.T) {
 	var (
 		source   = "k8s.gcr.io"
 		repoName = "pause"
-		tag      = "3.4.1"
+		tag      = "3.5"
 	)
 
 	ctx, cancel := testContext(t)
@@ -137,7 +137,7 @@ func TestImageUsage(t *testing.T) {
 		t.Skip()
 	}
 
-	imageName := "k8s.gcr.io/pause:3.4.1"
+	imageName := "k8s.gcr.io/pause:3.5"
 	ctx, cancel := testContext(t)
 	defer cancel()
 

--- a/integration/client/lease_test.go
+++ b/integration/client/lease_test.go
@@ -55,7 +55,7 @@ func TestLeaseResources(t *testing.T) {
 	defer ls.Delete(ctx, l, leases.SynchronousDelete)
 
 	// step 1: download image
-	imageName := "k8s.gcr.io/pause:3.4.1"
+	imageName := "k8s.gcr.io/pause:3.5"
 
 	image, err := client.Pull(ctx, imageName, WithPullUnpack, WithPullSnapshotter("native"))
 	if err != nil {

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -49,7 +49,7 @@ import (
 
 const (
 	timeout      = 1 * time.Minute
-	pauseImage   = "k8s.gcr.io/pause:3.4.1" // This is the same with default sandbox image.
+	pauseImage   = "k8s.gcr.io/pause:3.5" // This is the same with default sandbox image.
 	k8sNamespace = constants.K8sContainerdNamespace
 )
 

--- a/pkg/cri/config/config_unix.go
+++ b/pkg/cri/config/config_unix.go
@@ -56,7 +56,7 @@ func DefaultConfig() PluginConfig {
 			TLSKeyFile:  "",
 			TLSCertFile: "",
 		},
-		SandboxImage:            "k8s.gcr.io/pause:3.4.1",
+		SandboxImage:            "k8s.gcr.io/pause:3.5",
 		StatsCollectPeriod:      10,
 		SystemdCgroup:           false,
 		MaxContainerLogLineSize: 16 * 1024,

--- a/pkg/cri/config/config_windows.go
+++ b/pkg/cri/config/config_windows.go
@@ -54,7 +54,7 @@ func DefaultConfig() PluginConfig {
 			TLSKeyFile:  "",
 			TLSCertFile: "",
 		},
-		SandboxImage:            "k8s.gcr.io/pause:3.4.1",
+		SandboxImage:            "k8s.gcr.io/pause:3.5",
 		StatsCollectPeriod:      10,
 		MaxContainerLogLineSize: 16 * 1024,
 		Registry: Registry{


### PR DESCRIPTION
After https://github.com/kubernetes/k8s.io/pull/1793 is promoted, update pause image in containerd