### PR TITLE
Switch test image to a non rate-limited manifest list

### DIFF
--- a/integration/client/client_unix_test.go
+++ b/integration/client/client_unix_test.go
@@ -19,7 +19,6 @@
 package containerd
 
 import (
-	"runtime"
 	"testing"
 
 	. "github.com/containerd/containerd"
@@ -33,27 +32,10 @@ const (
 )
 
 var (
-	testImage    string
+	testImage    = "mirror.gcr.io/library/busybox:latest"
 	shortCommand = withProcessArgs("true")
 	longCommand  = withProcessArgs("/bin/sh", "-c", "while true; do sleep 1; done")
 )
-
-func init() {
-	switch runtime.GOARCH {
-	case "386":
-		testImage = "docker.io/i386/alpine:latest"
-	case "arm":
-		testImage = "docker.io/arm32v6/alpine:latest"
-	case "arm64":
-		testImage = "docker.io/arm64v8/alpine:latest"
-	case "ppc64le":
-		testImage = "docker.io/ppc64le/alpine:latest"
-	case "s390x":
-		testImage = "docker.io/s390x/alpine:latest"
-	default:
-		testImage = "docker.io/library/alpine:latest"
-	}
-}
 
 func TestImagePullSchema1WithEmptyLayers(t *testing.T) {
 	client, err := newClient(t, address)

--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -887,10 +887,10 @@ func TestContainerUsername(t *testing.T) {
 		io.Copy(buf, direct.Stdout)
 	}()
 
-	// squid user in the alpine image has a uid of 31
+	// the www-data user in the busybox image has a uid of 33
 	container, err := client.NewContainer(ctx, id,
 		WithNewSnapshot(id, image),
-		WithNewSpec(oci.WithImageConfig(image), oci.WithUsername("squid"), oci.WithProcessArgs("id", "-u")),
+		WithNewSpec(oci.WithImageConfig(image), oci.WithUsername("www-data"), oci.WithProcessArgs("id", "-u")),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -916,16 +916,16 @@ func TestContainerUsername(t *testing.T) {
 	wg.Wait()
 
 	output := strings.TrimSuffix(buf.String(), "\n")
-	if output != "31" {
-		t.Errorf("expected squid uid to be 31 but received %q", output)
+	if output != "33" {
+		t.Errorf("expected www-data uid to be 33 but received %q", output)
 	}
 }
 
 func TestContainerUser(t *testing.T) {
 	t.Parallel()
-	t.Run("UserNameAndGroupName", func(t *testing.T) { testContainerUser(t, "squid:squid", "31:31") })
-	t.Run("UserIDAndGroupName", func(t *testing.T) { testContainerUser(t, "1001:squid", "1001:31") })
-	t.Run("UserNameAndGroupID", func(t *testing.T) { testContainerUser(t, "squid:1002", "31:1002") })
+	t.Run("UserNameAndGroupName", func(t *testing.T) { testContainerUser(t, "www-data:www-data", "33:33") })
+	t.Run("UserIDAndGroupName", func(t *testing.T) { testContainerUser(t, "1001:www-data", "1001:33") })
+	t.Run("UserNameAndGroupID", func(t *testing.T) { testContainerUser(t, "www-data:1002", "33:1002") })
 	t.Run("UserIDAndGroupID", func(t *testing.T) { testContainerUser(t, "1001:1002", "1001:1002") })
 }
 
@@ -1225,7 +1225,7 @@ func TestContainerUserID(t *testing.T) {
 		io.Copy(buf, direct.Stdout)
 	}()
 
-	// adm user in the alpine image has a uid of 3 and gid of 4.
+	// sys user in the busybox image has a uid and gid of 3.
 	container, err := client.NewContainer(ctx, id,
 		WithNewSnapshot(id, image),
 		WithNewSpec(oci.WithImageConfig(image), oci.WithUserID(3), oci.WithProcessArgs("sh", "-c", "echo $(id -u):$(id -g)")),
@@ -1254,8 +1254,8 @@ func TestContainerUserID(t *testing.T) {
 	wg.Wait()
 
 	output := strings.TrimSuffix(buf.String(), "\n")
-	if output != "3:4" {
-		t.Errorf("expected uid:gid to be 3:4, but received %q", output)
+	if output != "3:3" {
+		t.Errorf("expected uid:gid to be 3:3, but received %q", output)
 	}
 }
 


### PR DESCRIPTION
Builds on changes from #5189 to default to a non rate-limited `testImage` used across many of the client tests since we are still having a lot of rate-limiting on the macos nodes running the SELinux/Cgroupsv2 tests.

Signed-off-by: Phil Estes <estesp@amazon.com>