### PR TITLE
change default runtime for containerd-stress app

### DIFF
--- a/cmd/containerd-stress/main.go
+++ b/cmd/containerd-stress/main.go
@@ -147,7 +147,7 @@ func main() {
 		cli.StringFlag{
 			Name:  "runtime",
 			Usage: "set the runtime to stress test",
-			Value: plugin.RuntimeLinuxV1,
+			Value: plugin.RuntimeRuncV2,
 		},
 	}
 	app.Before = func(context *cli.Context) error {


### PR DESCRIPTION
This fixes following warning message by changing the default runtime
to io.containerd.runc.v2 and does not require user to set the runtime
from command line anymore.

"WARN[2021-03-17T21:11:01.441207858Z] runtime v1 is deprecated since
containerd v1.4, consider using runtime v2"

Signed-off-by: Alakesh Haloi <alakeshh@amazon.com>