### PR TITLE
runtime/v2: add comment for checkCopyShimLogError

### DIFF
--- a/runtime/v2/binary.go
+++ b/runtime/v2/binary.go
@@ -98,6 +98,9 @@ func (b *binary) Start(ctx context.Context, opts *types.Any, onClose func()) (_ 
 	go func() {
 		defer f.Close()
 		_, err := io.Copy(os.Stderr, f)
+		// To prevent flood of error messages, the expected error
+		// should be reset, like os.ErrClosed or os.ErrNotExist, which
+		// depends on platform.
 		err = checkCopyShimLogError(ctx, err)
 		if err != nil {
 			log.G(ctx).WithError(err).Error("copy shim log")

--- a/runtime/v2/shim.go
+++ b/runtime/v2/shim.go
@@ -97,6 +97,9 @@ func loadShim(ctx context.Context, bundle *Bundle, events *exchange.Exchange, rt
 	go func() {
 		defer f.Close()
 		_, err := io.Copy(os.Stderr, f)
+		// To prevent flood of error messages, the expected error
+		// should be reset, like os.ErrClosed or os.ErrNotExist, which
+		// depends on platform.
 		err = checkCopyShimLogError(ctx, err)
 		if err != nil {
 			log.G(ctx).WithError(err).Error("copy shim log after reload")


### PR DESCRIPTION
After #4906, containerd opens fifo in read/write mode in linux platform
The original comment doesn't correct and is removed by #5174.

```
// original comment

// When using a multi-container shim, the fifo of the 2nd to Nth
// container will not be opened when the ctx is done. This will
// cause an ErrReadClosed that can be ignored.
```

However, we should add comment for checkCopyShimLogError to mention why
we call checkCopyShimLogError. The checkCopyShimLogError, it is to prevent
the flood of expected error messages after task die and the expected
errors depend on platform.

Signed-off-by: Wei Fu <fuweid89@gmail.com>