### PR TITLE
add overlay to default containerd config

### DIFF
--- a/cmd/containerd/builtins_overlay_linux.go
+++ b/cmd/containerd/builtins_overlay_linux.go
@@ -1,0 +1,19 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import _ "github.com/containerd/containerd/snapshots/overlay/plugin"


### PR DESCRIPTION

Similar with docker https://docs.docker.com/storage/storagedriver/select-storage-driver/

We are moving from devicemapper to overlayfs2.

Current `containerd config default` will return "io.containerd.snapshotter.v1.devmapper", but no "io.containerd.snapshotter.v1.overlay2" as an example.
```
  [plugins."io.containerd.snapshotter.v1.devmapper"]
    root_path = ""
    pool_name = ""
    base_image_size = ""
    async_remove = false
```

Hence, add overlay as default.