### PR TITLE
not use * as the config would be not readable

### DIFF
--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -168,12 +168,12 @@ type Registry struct {
 // RegistryConfig contains configuration used to communicate with the registry.
 type RegistryConfig struct {
 	// Auth contains information to authenticate to the registry.
-	Auth *AuthConfig `toml:"auth" json:"auth"`
+	Auth AuthConfig `toml:"auth" json:"auth"`
 	// TLS is a pair of CA/Cert/Key which then are used when creating the transport
 	// that communicates with the registry.
 	// This field will not be used when ConfigPath is provided.
 	// DEPRECATED: Use ConfigPath instead. Remove in containerd 1.7.
-	TLS *TLSConfig `toml:"tls" json:"tls"`
+	TLS TLSConfig `toml:"tls" json:"tls"`
 }
 
 // ImageDecryption contains configuration to handling decryption of encrypted container images.
@@ -396,7 +396,7 @@ func ValidatePluginConfig(ctx context.Context, c *PluginConfig) error {
 				endpoint = u.Host
 			}
 			config := c.Registry.Configs[endpoint]
-			config.Auth = &auth
+			config.Auth = auth
 			c.Registry.Configs[endpoint] = config
 		}
 		log.G(ctx).Warning("`auths` is deprecated, please use `configs` instead")

--- a/pkg/cri/config/config_test.go
+++ b/pkg/cri/config/config_test.go
@@ -295,7 +295,7 @@ func TestValidateConfig(t *testing.T) {
 				Registry: Registry{
 					Configs: map[string]RegistryConfig{
 						"gcr.io": {
-							Auth: &AuthConfig{
+							Auth: AuthConfig{
 								Username: "test",
 							},
 						},
@@ -353,7 +353,7 @@ func TestValidateConfig(t *testing.T) {
 					ConfigPath: "/etc/containerd/conf.d",
 					Configs: map[string]RegistryConfig{
 						"something.io": {
-							TLS: &TLSConfig{},
+							TLS: TLSConfig{},
 						},
 					},
 				},

--- a/pkg/cri/server/image_pull.go
+++ b/pkg/cri/server/image_pull.go
@@ -339,7 +339,7 @@ func (c *criService) registryHosts(ctx context.Context, auth *runtime.AuthConfig
 			if hostauth == nil {
 				config := c.config.Registry.Configs[host]
 				if config.Auth != nil {
-					hostauth = toRuntimeAuthConfig(*config.Auth)
+					hostauth = toRuntimeAuthConfig(config.Auth)
 				}
 			}
 			return ParseAuth(hostauth, host)
@@ -376,7 +376,7 @@ func (c *criService) registryHosts(ctx context.Context, auth *runtime.AuthConfig
 			}
 
 			if auth == nil && config.Auth != nil {
-				auth = toRuntimeAuthConfig(*config.Auth)
+				auth = toRuntimeAuthConfig(config.Auth)
 			}
 
 			if u.Path == "" {


### PR DESCRIPTION

> Configs:map[dce:{Auth:0xc000045b40 TLS:0xc000045a40}]

It seems to be intended 😓