### PR TITLE
contentproxy: ensure grpc stream is closed on commit

### DIFF
--- a/content/proxy/content_writer.go
+++ b/content/proxy/content_writer.go
@@ -97,7 +97,14 @@ func (rw *remoteWriter) Write(p []byte) (n int, err error) {
 	return
 }
 
-func (rw *remoteWriter) Commit(ctx context.Context, size int64, expected digest.Digest, opts ...content.Opt) error {
+func (rw *remoteWriter) Commit(ctx context.Context, size int64, expected digest.Digest, opts ...content.Opt) (err error) {
+	defer func() {
+		err1 := rw.Close()
+		if err == nil {
+			err = err1
+		}
+	}()
+
 	var base content.Info
 	for _, opt := range opts {
 		if err := opt(&base); err != nil {


### PR DESCRIPTION
Committing writer does not close the grpc stream, causing resource leak and making it not possible to close the client side cleanly.

@AkihiroSuda 

buildkit issue moby/buildkit#2025

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>