### PR TITLE
build containerd with at least go 1.16

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -14,7 +14,7 @@ This doc includes:
 
 To build the `containerd` daemon, and the `ctr` simple test client, the following build system dependencies are required:
 
-* Go 1.13.x or above except 1.14.x
+* Go 1.16.x
 * Protoc 3.x compiler and headers (download at the [Google protobuf releases page](https://github.com/google/protobuf/releases))
 * Btrfs headers and libraries for your distribution. Note that building the btrfs driver can be disabled via the build tag `no_btrfs`, removing this dependency.
 


### PR DESCRIPTION
When I try to build `containerd` with go 1.15, I meet errors below. 
After upgrade go to 1.16.2, the error is gone.

> [root@13 containerd]# make
> `+ bin/ctr`
> `# runtime/internal/atomic
> /root/go/src/runtime/internal/atomic/atomic_amd64x.go:18:6: Load redeclared in this block
> 	previous declaration at /root/go/src/runtime/internal/atomic/atomic_amd64.go:16:24
> /root/go/src/runtime/internal/atomic/atomic_amd64x.go:24:6: Loadp redeclared in this block
> 	previous declaration at /root/go/src/runtime/internal/atomic/atomic_amd64.go:22:32
> /root/go/src/runtime/internal/atomic/atomic_amd64x.go:30:6: Load64 redeclared in this block
> 	previous declaration at /root/go/src/runtime/internal/atomic/atomic_amd64.go:28:26
> /root/go/src/runtime/internal/atomic/atomic_amd64x.go:36:6: LoadAcq redeclared in this block
> 	previous declaration at /root/go/src/runtime/internal/atomic/atomic_amd64.go:34:27
> /root/go/src/runtime/internal/atomic/atomic_amd64x.go:41:6: Xadd redeclared in this block
> 	previous declaration at /root/go/src/runtime/internal/atomic/atomic_amd64.go:39:37
> /root/go/src/runtime/internal/atomic/atomic_amd64x.go:44:6: Xadd64 redeclared in this block
> 	previous declaration at /root/go/src/runtime/internal/atomic/atomic_amd64.go:42:39
> /root/go/src/runtime/internal/atomic/atomic_amd64x.go:47:6: Xadduintptr redeclared in this block
> 	previous declaration at /root/go/src/runtime/internal/atomic/atomic_amd64.go:45:47
> /root/go/src/runtime/internal/atomic/atomic_amd64x.go:50:6: Xchg redeclared in this block
> 	previous declaration at /root/go/src/runtime/internal/atomic/atomic_amd64.go:48:36
> /root/go/src/runtime/internal/atomic/atomic_amd64x.go:53:6: Xchg64 redeclared in this block
> 	previous declaration at /root/go/src/runtime/internal/atomic/atomic_amd64.go:51:38
> /root/go/src/runtime/internal/atomic/atomic_amd64x.go:56:6: Xchguintptr redeclared in this block
> 	previous declaration at /root/go/src/runtime/internal/atomic/atomic_amd64.go:54:45
> /root/go/src/runtime/internal/atomic/atomic_amd64x.go:56:6: too many errors
> make: *** [bin/ctr] 错误 2