### PR TITLE
Specifically mention "mkfs.ext4" on the error from the command

### DIFF
--- a/snapshots/devmapper/snapshotter_test.go
+++ b/snapshots/devmapper/snapshotter_test.go
@@ -139,3 +139,9 @@ func testUsage(t *testing.T, snapshotter snapshots.Snapshotter) {
 	assert.Check(t, layer2Usage.Size >= sizeBytes,
 		"%d > %d", layer2Usage.Size, sizeBytes)
 }
+
+func TestMkfs(t *testing.T) {
+	ctx := context.Background()
+	err := mkfs(ctx, "")
+	assert.ErrorContains(t, err, `mkfs.ext4 couldn't initialize ""`)
+}


### PR DESCRIPTION
Before the change, the error on the caller-side (e.g. ctr) was
something like

> unpack: failed to prepare extraction snapshot "...": exit status 5:
> unknown

which was too cryptic.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>