### PR TITLE
Support HTTP debug in ctr

### DIFF
--- a/cmd/ctr/commands/commands.go
+++ b/cmd/ctr/commands/commands.go
@@ -78,6 +78,14 @@ var (
 			Name:  "tlskey",
 			Usage: "path to TLS client key",
 		},
+		cli.BoolFlag{
+			Name:  "http-dump",
+			Usage: "dump all HTTP request/responses when interacting with container registry",
+		},
+		cli.BoolFlag{
+			Name:  "http-trace",
+			Usage: "enable HTTP tracing for registry interactions",
+		},
 	}
 
 	// ContainerFlags are cli flags specifying container options

--- a/cmd/ctr/commands/images/images.go
+++ b/cmd/ctr/commands/images/images.go
@@ -17,9 +17,7 @@
 package images
 
 import (
-	"context"
 	"fmt"
-	"net/http/httptrace"
 	"os"
 	"sort"
 	"strings"
@@ -333,24 +331,4 @@ var removeCommand = cli.Command{
 
 		return exitErr
 	},
-}
-
-// NewDebugClientTrace returns a Go http trace client predefined to write DNS and connection
-// information to the log. This is used via the --trace flag on push and pull operations in ctr.
-func NewDebugClientTrace(ctx context.Context) *httptrace.ClientTrace {
-	return &httptrace.ClientTrace{
-		DNSStart: func(dnsInfo httptrace.DNSStartInfo) {
-			log.G(ctx).WithField("host", dnsInfo.Host).Debugf("DNS lookup")
-		},
-		DNSDone: func(dnsInfo httptrace.DNSDoneInfo) {
-			if dnsInfo.Err != nil {
-				log.G(ctx).WithField("lookup_err", dnsInfo.Err).Debugf("DNS lookup error")
-			} else {
-				log.G(ctx).WithField("result", dnsInfo.Addrs[0].String()).WithField("coalesced", dnsInfo.Coalesced).Debugf("DNS lookup complete")
-			}
-		},
-		GotConn: func(connInfo httptrace.GotConnInfo) {
-			log.G(ctx).WithField("reused", connInfo.Reused).WithField("remote_addr", connInfo.Conn.RemoteAddr().String()).Debugf("Connection successful")
-		},
-	}
 }

--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -18,7 +18,6 @@ package images
 
 import (
 	"fmt"
-	"net/http/httptrace"
 	"time"
 
 	"github.com/containerd/containerd"
@@ -57,10 +56,6 @@ command. As part of this process, we do the following:
 			Usage: "pull content and metadata from all platforms",
 		},
 		cli.BoolFlag{
-			Name:  "trace",
-			Usage: "enable HTTP tracing for registry interactions",
-		},
-		cli.BoolFlag{
 			Name:  "all-metadata",
 			Usage: "Pull metadata for all platforms",
 		},
@@ -94,9 +89,6 @@ command. As part of this process, we do the following:
 			return err
 		}
 
-		if context.Bool("trace") {
-			ctx = httptrace.WithClientTrace(ctx, NewDebugClientTrace(ctx))
-		}
 		img, err := content.Fetch(ctx, client, ref, config)
 		if err != nil {
 			return err

--- a/cmd/ctr/commands/images/push.go
+++ b/cmd/ctr/commands/images/push.go
@@ -60,9 +60,6 @@ var pushCommand = cli.Command{
 		Name:  "manifest-type",
 		Usage: "media type of manifest digest",
 		Value: ocispec.MediaTypeImageManifest,
-	}, cli.BoolFlag{
-		Name:  "trace",
-		Usage: "enable HTTP tracing for registry interactions",
 	}, cli.StringSliceFlag{
 		Name:  "platform",
 		Usage: "push content from a specific platform",
@@ -123,8 +120,8 @@ var pushCommand = cli.Command{
 			}
 		}
 
-		if context.Bool("trace") {
-			ctx = httptrace.WithClientTrace(ctx, NewDebugClientTrace(ctx))
+		if context.Bool("http-trace") {
+			ctx = httptrace.WithClientTrace(ctx, commands.NewDebugClientTrace(ctx))
 		}
 		resolver, err := commands.GetResolver(ctx, context)
 		if err != nil {


### PR DESCRIPTION
This PR adds:
- `http-dump` flag can dump HTTP request/responses when interacting with container registry.
- `http-trace` is https://github.com/containerd/containerd/pull/5040 follow up

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>