### PR TITLE
Use specific image for user namespaces tests

### DIFF
--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -55,6 +55,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const testUserNSImage = "mirror.gcr.io/library/alpine:latest"
+
 // TestRegressionIssue4769 verifies the number of task exit events.
 //
 // Issue: https://github.com/containerd/containerd/issues/4769.
@@ -1596,7 +1598,7 @@ func testUserNamespaces(t *testing.T, readonlyRootFS bool) {
 	)
 	defer cancel()
 
-	image, err = client.GetImage(ctx, testImage)
+	image, err = client.Pull(ctx, testUserNSImage, WithPullUnpack)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Due to the lack of an existing /proc dir in the rootfs of the busybox image, there
seems to be a race between the `mkdir` prior to the mount of /proc and whether
the root dir is already readonly? May need investigation, but for now use an image
that has a /proc dir existing.

Follow-on to comments in #5216 // cc @crosbymichael 

Signed-off-by: Phil Estes <estesp@amazon.com>