### PR TITLE
go.mod: github.com/containerd/zfs v0.0.0-20210322090317-0e92c2247fb7 (for snapshot usage)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/containerd/nri v0.0.0-20210316161719-dbaa18c31c14
 	github.com/containerd/ttrpc v1.0.2
 	github.com/containerd/typeurl v1.0.1
-	github.com/containerd/zfs v0.0.0-20210315114300-dde8f0fda960
+	github.com/containerd/zfs v0.0.0-20210322090317-0e92c2247fb7
 	github.com/containernetworking/plugins v0.8.6
 	github.com/coreos/go-systemd/v22 v22.1.0
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/containerd/typeurl v1.0.1 h1:PvuK4E3D5S5q6IqsPDCy928FhP0LUIGcmZ/Yhgp5
 github.com/containerd/typeurl v1.0.1/go.mod h1:TB1hUtrpaiO88KEK56ijojHS1+NeF0izUACaJW2mdXg=
 github.com/containerd/zfs v0.0.0-20200918131355-0a33824f23a2/go.mod h1:8IgZOBdv8fAgXddBT4dBXJPtxyRsejFIpXoklgxgEjw=
 github.com/containerd/zfs v0.0.0-20210301145711-11e8f1707f62/go.mod h1:A9zfAbMlQwE+/is6hi0Xw8ktpL+6glmqZYtevJgaB8Y=
-github.com/containerd/zfs v0.0.0-20210315114300-dde8f0fda960 h1:HXgv62Qod4KvnxeNWszVQ4ZR+NrVY9ODFxlaqKzDQMs=
-github.com/containerd/zfs v0.0.0-20210315114300-dde8f0fda960/go.mod h1:m+m51S1DvAP6r3FcmYCp54bQ34pyOwTieQDNRIRHsFY=
+github.com/containerd/zfs v0.0.0-20210322090317-0e92c2247fb7 h1:8vskJ2uVsiu9pjODDUnyj6gKZ6mNPMlqPgfqV6gnuRc=
+github.com/containerd/zfs v0.0.0-20210322090317-0e92c2247fb7/go.mod h1:m+m51S1DvAP6r3FcmYCp54bQ34pyOwTieQDNRIRHsFY=
 github.com/containernetworking/cni v0.7.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/cni v0.8.0 h1:BT9lpgGoH4jw3lFC7Odz2prU5ruiYKcgAjMCbgybcKI=
 github.com/containernetworking/cni v0.8.0/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=

--- a/vendor/github.com/containerd/zfs/plugin/plugin.go
+++ b/vendor/github.com/containerd/zfs/plugin/plugin.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-
 // Config represents configuration for the zfs plugin
 type Config struct {
 	// Root directory for the plugin

--- a/vendor/github.com/containerd/zfs/zfs.go
+++ b/vendor/github.com/containerd/zfs/zfs.go
@@ -20,6 +20,7 @@ package zfs
 
 import (
 	"context"
+	"math"
 	"path/filepath"
 
 	"github.com/containerd/containerd/log"
@@ -116,7 +117,40 @@ func (z *snapshotter) Stat(ctx context.Context, key string) (snapshots.Info, err
 
 // Usage retrieves the disk usage of the top-level snapshot.
 func (z *snapshotter) Usage(ctx context.Context, key string) (snapshots.Usage, error) {
-	return snapshots.Usage{}, errors.New("zfs does not implement Usage() yet")
+	return z.usage(ctx, key)
+}
+
+func (z *snapshotter) usage(ctx context.Context, key string) (snapshots.Usage, error) {
+	ctx, t, err := z.ms.TransactionContext(ctx, false)
+	if err != nil {
+		return snapshots.Usage{}, err
+	}
+	id, info, usage, err := storage.GetInfo(ctx, key)
+	t.Rollback() //nolint:errcheck
+
+	if err != nil {
+		return snapshots.Usage{}, err
+	}
+
+	if info.Kind == snapshots.KindActive {
+		activeName := filepath.Join(z.dataset.Name, id)
+		sDataset, err := zfs.GetDataset(activeName)
+
+		if err != nil {
+			return snapshots.Usage{}, err
+		}
+
+		if sDataset.Used > math.MaxInt64 {
+			return snapshots.Usage{}, errors.Errorf("Dataset size exceeds maximum snapshot size of %v bytes", math.MaxInt64)
+		}
+
+		usage = snapshots.Usage{
+			Size:   int64(sDataset.Used),
+			Inodes: -1,
+		}
+	}
+
+	return usage, nil
 }
 
 // Walk the committed snapshots.
@@ -201,6 +235,11 @@ func (z *snapshotter) mounts(dataset *zfs.Dataset, readonly bool) ([]mount.Mount
 }
 
 func (z *snapshotter) Commit(ctx context.Context, name, key string, opts ...snapshots.Opt) (err error) {
+	usage, err := z.usage(ctx, key)
+	if err != nil {
+		return errors.Wrap(err, "failed to compute usage")
+	}
+
 	ctx, t, err := z.ms.TransactionContext(ctx, true)
 	if err != nil {
 		return err
@@ -213,7 +252,7 @@ func (z *snapshotter) Commit(ctx context.Context, name, key string, opts ...snap
 		}
 	}()
 
-	id, err := storage.CommitActive(ctx, key, name, snapshots.Usage{}, opts...)
+	id, err := storage.CommitActive(ctx, key, name, usage, opts...)
 	if err != nil {
 		return errors.Wrap(err, "failed to commit")
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -105,7 +105,7 @@ github.com/containerd/ttrpc/plugin
 # github.com/containerd/typeurl v1.0.1
 ## explicit
 github.com/containerd/typeurl
-# github.com/containerd/zfs v0.0.0-20210315114300-dde8f0fda960
+# github.com/containerd/zfs v0.0.0-20210322090317-0e92c2247fb7
 ## explicit
 github.com/containerd/zfs
 github.com/containerd/zfs/plugin


### PR DESCRIPTION
Contains "Implements zfs usage by returning the USED field from the zfs snapshot"
(https://github.com/containerd/zfs/pull/38)
