### PR TITLE
Fix oom tests on non Linux

### DIFF
--- a/sys/oom_linux.go
+++ b/sys/oom_linux.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 /*
    Copyright The containerd Authors.
 

--- a/sys/oom_linux_test.go
+++ b/sys/oom_linux_test.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 /*
    Copyright The containerd Authors.
 

--- a/sys/oom_unsupported.go
+++ b/sys/oom_unsupported.go
@@ -1,3 +1,5 @@
+// +build !linux
+
 /*
    Copyright The containerd Authors.
 
@@ -17,7 +19,9 @@
 package sys
 
 const (
-	// OOMScoreAdjMax is not implemented on Windows
+	// OOMScoreMaxKillable is not implemented on non Linux
+	OOMScoreMaxKillable = 0
+	// OOMScoreAdjMax is not implemented on non Linux
 	OOMScoreAdjMax = 0
 )
 


### PR DESCRIPTION
OOM procfs is linux specific, so should not be running on mac os, freebsd, etc.

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>