### PR TITLE
use endpoint's config instead of host config

### DIFF
--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -398,6 +398,13 @@ func ValidatePluginConfig(ctx context.Context, c *PluginConfig) error {
 			config := c.Registry.Configs[endpoint]
 			config.Auth = &auth
 			c.Registry.Configs[endpoint] = config
+			// set both endpoint and host for tls/auth configs
+			if endpoint != u.Host {
+				// avoid overwriting
+				if _, found := c.Registry.Configs[u.Host]; !found {
+					c.Registry.Configs[u.Host] = config
+				}
+			}
 		}
 		log.G(ctx).Warning("`auths` is deprecated, please use `configs` instead")
 	}

--- a/pkg/cri/server/image_pull.go
+++ b/pkg/cri/server/image_pull.go
@@ -365,7 +365,7 @@ func (c *criService) registryHosts(ctx context.Context, auth *runtime.AuthConfig
 			var (
 				transport = newTransport()
 				client    = &http.Client{Transport: transport}
-				config    = c.config.Registry.Configs[e]
+				config    = c.config.Registry.Configs[u.Host]
 			)
 
 			if config.TLS != nil {

--- a/pkg/cri/server/image_pull.go
+++ b/pkg/cri/server/image_pull.go
@@ -365,7 +365,7 @@ func (c *criService) registryHosts(ctx context.Context, auth *runtime.AuthConfig
 			var (
 				transport = newTransport()
 				client    = &http.Client{Transport: transport}
-				config    = c.config.Registry.Configs[u.Host]
+				config    = c.config.Registry.Configs[e]
 			)
 
 			if config.TLS != nil {


### PR DESCRIPTION
Fixes #5248

```
version = 2
...
   [plugins."io.containerd.grpc.v1.cri".registry]
      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
          endpoint = ["https://registry-1.docker.io"]
      [plugins."io.containerd.grpc.v1.cri".registry.configs]
        [plugins."io.containerd.grpc.v1.cri".registry.configs."10.6.150.60:30004"]
          [plugins."io.containerd.grpc.v1.cri".registry.configs."10.6.150.60:30004".tls]
            insecure_skip_verify = true
            ca_file = ""
            cert_file = ""
            key_file = ""
```
This config would work with this fix.


Another fix way is like https://github.com/containerd/containerd/compare/master...pacoxu:fix/config?expand=1 (It may be not correct in my opinion.)
