### PR TITLE
Move RunningInUserNS() to its own package

### DIFF
--- a/archive/tar_unix.go
+++ b/archive/tar_unix.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/containerd/containerd/sys"
+	"github.com/containerd/containerd/pkg/userns"
 	"github.com/containerd/continuity/fs"
 	"github.com/containerd/continuity/sysx"
 	"github.com/pkg/errors"
@@ -87,7 +87,7 @@ func skipFile(hdr *tar.Header) bool {
 	switch hdr.Typeflag {
 	case tar.TypeBlock, tar.TypeChar:
 		// cannot create a device if running in user namespace
-		return sys.RunningInUserNS()
+		return userns.RunningInUserNS()
 	default:
 		return false
 	}

--- a/diff/apply/apply_linux.go
+++ b/diff/apply/apply_linux.go
@@ -26,7 +26,7 @@ import (
 	"github.com/containerd/containerd/archive"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/mount"
-	"github.com/containerd/containerd/sys"
+	"github.com/containerd/containerd/pkg/userns"
 	"github.com/pkg/errors"
 )
 
@@ -35,7 +35,7 @@ func apply(ctx context.Context, mounts []mount.Mount, r io.Reader) error {
 	case len(mounts) == 1 && mounts[0].Type == "overlay":
 		// OverlayConvertWhiteout (mknod c 0 0) doesn't work in userns.
 		// https://github.com/containerd/containerd/issues/3762
-		if sys.RunningInUserNS() {
+		if userns.RunningInUserNS() {
 			break
 		}
 		path, parents, err := getOverlayPath(mounts[0].Options)

--- a/pkg/cri/server/service_linux.go
+++ b/pkg/cri/server/service_linux.go
@@ -18,7 +18,7 @@ package server
 
 import (
 	"github.com/containerd/containerd/pkg/cap"
-	"github.com/containerd/containerd/sys"
+	"github.com/containerd/containerd/pkg/userns"
 	cni "github.com/containerd/go-cni"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/pkg/errors"
@@ -33,7 +33,7 @@ const networkAttachCount = 2
 func (c *criService) initPlatform() error {
 	var err error
 
-	if sys.RunningInUserNS() {
+	if userns.RunningInUserNS() {
 		if !(c.config.DisableCgroup && !c.apparmorEnabled() && c.config.RestrictOOMScoreAdj) {
 			logrus.Warn("Running containerd in a user namespace typically requires disable_cgroup, disable_apparmor, restrict_oom_score_adj set to be true")
 		}

--- a/pkg/userns/userns_linux.go
+++ b/pkg/userns/userns_linux.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package sys
+package userns
 
 import (
 	"bufio"

--- a/pkg/userns/userns_unsupported.go
+++ b/pkg/userns/userns_unsupported.go
@@ -1,0 +1,25 @@
+// +build !linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package userns
+
+// RunningInUserNS is a stub for non-Linux systems
+// Always returns false
+func RunningInUserNS() bool {
+	return false
+}

--- a/runtime/v2/runc/v2/service.go
+++ b/runtime/v2/runc/v2/service.go
@@ -41,11 +41,11 @@ import (
 	oomv2 "github.com/containerd/containerd/pkg/oom/v2"
 	"github.com/containerd/containerd/pkg/process"
 	"github.com/containerd/containerd/pkg/stdio"
+	"github.com/containerd/containerd/pkg/userns"
 	"github.com/containerd/containerd/runtime/v2/runc"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/containerd/containerd/runtime/v2/shim"
 	taskAPI "github.com/containerd/containerd/runtime/v2/task"
-	"github.com/containerd/containerd/sys"
 	"github.com/containerd/containerd/sys/reaper"
 	runcC "github.com/containerd/go-runc"
 	"github.com/containerd/typeurl"
@@ -386,7 +386,7 @@ func (s *service) Start(ctx context.Context, r *taskAPI.StartRequest) (*taskAPI.
 				logrus.WithError(err).Error("failed to get root controllers")
 			} else {
 				if err := cg.ToggleControllers(allControllers, cgroupsv2.Enable); err != nil {
-					if sys.RunningInUserNS() {
+					if userns.RunningInUserNS() {
 						logrus.WithError(err).Debugf("failed to enable controllers (%v)", allControllers)
 					} else {
 						logrus.WithError(err).Errorf("failed to enable controllers (%v)", allControllers)

--- a/snapshots/overlay/overlayutils/check.go
+++ b/snapshots/overlay/overlayutils/check.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
-	"github.com/containerd/containerd/sys"
+	"github.com/containerd/containerd/pkg/userns"
 	"github.com/containerd/continuity/fs"
 	"github.com/pkg/errors"
 )
@@ -108,7 +108,7 @@ func Supported(root string) error {
 //
 // The "userxattr" support is not exposed in "/sys/module/overlay/parameters".
 func NeedsUserXAttr(d string) (bool, error) {
-	if !sys.RunningInUserNS() {
+	if !userns.RunningInUserNS() {
 		// we are the real root (i.e., the root in the initial user NS),
 		// so we do never need "userxattr" opt.
 		return false, nil

--- a/sys/oom_unix.go
+++ b/sys/oom_unix.go
@@ -24,6 +24,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/containerd/containerd/pkg/userns"
 )
 
 const (
@@ -42,7 +44,7 @@ func SetOOMScore(pid, score int) error {
 	}
 	defer f.Close()
 	if _, err = f.WriteString(strconv.Itoa(score)); err != nil {
-		if os.IsPermission(err) && (RunningInUserNS() || RunningUnprivileged()) {
+		if os.IsPermission(err) && (userns.RunningInUserNS() || RunningUnprivileged()) {
 			return nil
 		}
 		return err

--- a/sys/userns_deprecated.go
+++ b/sys/userns_deprecated.go
@@ -1,5 +1,3 @@
-// +build !linux
-
 /*
    Copyright The containerd Authors.
 
@@ -18,8 +16,8 @@
 
 package sys
 
-// RunningInUserNS is a stub for non-Linux systems
-// Always returns false
-func RunningInUserNS() bool {
-	return false
-}
+import "github.com/containerd/containerd/pkg/userns"
+
+// RunningInUserNS detects whether we are currently running in a user namespace.
+// Deprecated: use github.com/containerd/containerd/pkg/userns.RunningInUserNS instead.
+var RunningInUserNS = userns.RunningInUserNS


### PR DESCRIPTION
Trying to prevent the `sys` package to become too much of a kitchen-sink 😅 

This allows using the utility without bringing whole of "sys" with it.
