### PR TITLE
Increase timeout for linux integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
   integration-linux:
     name: Linux Integration
     runs-on: ubuntu-18.04
-    timeout-minutes: 25
+    timeout-minutes: 30
     needs: [project, linters, protos, man]
 
     strategy:


### PR DESCRIPTION
The integration test times have slightly increased and are often
hitting the 25 minutes timeout. This increases to give more room
but still keeps it low enough to catch regressions in tests
causing longer than expected execution.