### PR TITLE
task: allow checkpoint on pause state

### DIFF
--- a/task.go
+++ b/task.go
@@ -451,11 +451,20 @@ func (t *task) Checkpoint(ctx context.Context, opts ...CheckpointTaskOpts) (Imag
 		}
 		request.Options = any
 	}
-	// make sure we pause it and resume after all other filesystem operations are completed
-	if err := t.Pause(ctx); err != nil {
+
+	status, err := t.Status(ctx)
+	if err != nil {
 		return nil, err
 	}
-	defer t.Resume(ctx)
+
+	if status.Status != Paused {
+		// make sure we pause it and resume after all other filesystem operations are completed
+		if err := t.Pause(ctx); err != nil {
+			return nil, err
+		}
+		defer t.Resume(ctx)
+	}
+
 	index := v1.Index{
 		Versioned: is.Versioned{
 			SchemaVersion: 2,


### PR DESCRIPTION
task.Checkpoint should check status of container before handle
checkpoint. If the container has been paused, task.Checkpoint should
handle checkpoint and leave it paused.

Signed-off-by: Wei Fu <fuweid89@gmail.com>
Signed-off-by: Baijia <baijia.wr@antfin.com>