### PR TITLE
Run unit tests on CI for MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,6 +375,33 @@ jobs:
           df
           losetup -l
 
+  tests-mac-os:
+    name: MacOS unit tests
+    runs-on: macos-10.15
+    timeout-minutes: 10
+    needs: [project, linters, protos, man]
+
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16.2'
+
+      - uses: actions/checkout@v2
+        with:
+          path: src/github.com/containerd/containerd
+
+      - name: Set env
+        run: |
+          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+
+      - name: Tests
+        env:
+          GOPROXY: direct
+        run: |
+          make test
+        working-directory: src/github.com/containerd/containerd
+
   cgroup2:
     name: CGroupsV2 and SELinux Integration
     # nested virtualization is only available on macOS hosts

--- a/archive/tar_test.go
+++ b/archive/tar_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows,!darwin
 
 /*
    Copyright The containerd Authors.

--- a/pkg/cri/server/container_create_test.go
+++ b/pkg/cri/server/container_create_test.go
@@ -19,6 +19,7 @@ package server
 import (
 	"context"
 	"path/filepath"
+	goruntime "runtime"
 	"testing"
 
 	"github.com/containerd/containerd/oci"
@@ -68,6 +69,10 @@ func TestGeneralContainerSpec(t *testing.T) {
 }
 
 func TestPodAnnotationPassthroughContainerSpec(t *testing.T) {
+	if goruntime.GOOS == "darwin" {
+		t.Skip("not implemented on Darwin")
+	}
+
 	testID := "test-id"
 	testSandboxID := "sandbox-id"
 	testContainerName := "container-name"
@@ -272,6 +277,10 @@ func TestVolumeMounts(t *testing.T) {
 }
 
 func TestContainerAnnotationPassthroughContainerSpec(t *testing.T) {
+	if goruntime.GOOS == "darwin" {
+		t.Skip("not implemented on Darwin")
+	}
+
 	testID := "test-id"
 	testSandboxID := "sandbox-id"
 	testContainerName := "container-name"

--- a/pkg/cri/server/sandbox_run_test.go
+++ b/pkg/cri/server/sandbox_run_test.go
@@ -18,6 +18,7 @@ package server
 
 import (
 	"net"
+	goruntime "runtime"
 	"testing"
 
 	cni "github.com/containerd/go-cni"
@@ -33,6 +34,10 @@ import (
 )
 
 func TestSandboxContainerSpec(t *testing.T) {
+	if goruntime.GOOS == "darwin" {
+		t.Skip("not implemented on Darwin")
+	}
+
 	testID := "test-id"
 	nsPath := "test-cni"
 	for desc, test := range map[string]struct {


### PR DESCRIPTION
Though we don't officially support Macs, we should at least run unit tests
to make sure things are not broken on this platform.

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>