### PR TITLE
Extend default timeout for nested VM integration run

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -204,7 +204,7 @@ EOF
         set -eux -o pipefail
         rm -rf /var/lib/containerd-test /run/containerd-test
         cd ${GOPATH}/src/github.com/containerd/containerd
-        make integration EXTRA_TESTFLAGS="-no-criu -test.v" TEST_RUNTIME=io.containerd.runc.v2 RUNC_FLAVOR=$RUNC_FLAVOR
+        make integration EXTRA_TESTFLAGS="-timeout 15m -no-criu -test.v" TEST_RUNTIME=io.containerd.runc.v2 RUNC_FLAVOR=$RUNC_FLAVOR
     SHELL
   end
 


### PR DESCRIPTION
When integration tests are run under nested VM (for SELinux, Cgroupsv2
testing) they are regularly starting to push past 10 minutes, causing
`go test` to fatally kill the test run (default timeout is 10m).

Signed-off-by: Phil Estes <estesp@amazon.com>

(Recent example in #5266)