### PR TITLE
integration/util: remove dependency on k8s.io/klog/v2

### DIFF
--- a/integration/remote/util/util_unix.go
+++ b/integration/remote/util/util_unix.go
@@ -44,7 +44,6 @@ import (
 	"path/filepath"
 
 	"golang.org/x/sys/unix"
-	"k8s.io/klog/v2"
 )
 
 const (
@@ -115,9 +114,6 @@ func parseEndpointWithFallbackProtocol(endpoint string, fallbackProtocol string)
 	if protocol, addr, err = parseEndpoint(endpoint); err != nil && protocol == "" {
 		fallbackEndpoint := fallbackProtocol + "://" + endpoint
 		protocol, addr, err = parseEndpoint(fallbackEndpoint)
-		if err == nil {
-			klog.Warningf("Using %q as endpoint is deprecated, please consider using full url format %q.", endpoint, fallbackEndpoint)
-		}
 	}
 	return
 }

--- a/integration/util/util_unix.go
+++ b/integration/util/util_unix.go
@@ -44,7 +44,6 @@ import (
 	"path/filepath"
 
 	"golang.org/x/sys/unix"
-	"k8s.io/klog/v2"
 )
 
 const (
@@ -115,9 +114,6 @@ func parseEndpointWithFallbackProtocol(endpoint string, fallbackProtocol string)
 	if protocol, addr, err = parseEndpoint(endpoint); err != nil && protocol == "" {
 		fallbackEndpoint := fallbackProtocol + "://" + endpoint
 		protocol, addr, err = parseEndpoint(fallbackEndpoint)
-		if err == nil {
-			klog.Warningf("Using %q as endpoint is deprecated, please consider using full url format %q.", endpoint, fallbackEndpoint)
-		}
 	}
 	return
 }


### PR DESCRIPTION
relates to https://github.com/microsoft/hcsshim/pull/984

Having this log should not be critical, and removing it allows
using this package without pulling in the explicit dependency
on k8s.io/klog.
