### PR TITLE
Rename atomicWrite to writeToCompletion

### DIFF
--- a/content/local/store.go
+++ b/content/local/store.go
@@ -683,10 +683,10 @@ func writeTimestampFile(p string, t time.Time) error {
 	if err != nil {
 		return err
 	}
-	return atomicWrite(p, b, 0666)
+	return writeToCompletion(p, b, 0666)
 }
 
-func atomicWrite(path string, data []byte, mode os.FileMode) error {
+func writeToCompletion(path string, data []byte, mode os.FileMode) error {
 	tmp := fmt.Sprintf("%s.tmp", path)
 	f, err := os.OpenFile(tmp, os.O_RDWR|os.O_CREATE|os.O_TRUNC|os.O_SYNC, mode)
 	if err != nil {
@@ -695,7 +695,11 @@ func atomicWrite(path string, data []byte, mode os.FileMode) error {
 	_, err = f.Write(data)
 	f.Close()
 	if err != nil {
-		return errors.Wrap(err, "write atomic data")
+		return errors.Wrap(err, "write tmp file")
 	}
-	return os.Rename(tmp, path)
+	err = os.Rename(tmp, path)
+	if err != nil {
+		return errors.Wrap(err, "rename tmp file")
+	}
+	return nil
 }


### PR DESCRIPTION
The function does not guarantee atomicity, because the same temporary file will be opened multiple times.

https://github.com/containerd/containerd/blob/75a0c2b7d35cb91714bbfdf0fcadfe25f777ee8d/content/local/store.go#L689-L701

Should be changed to write a random temporary file Instead of writing a fixed temporary file.
Like this https://github.com/containerd/continuity/blob/93e15499afd51cdc830773dc804c89c11673fc63/ioutils.go#L34-L63
Signed-off-by: Shiming Zhang <wzshiming@foxmail.com>