### PR TITLE
remotes/docker: Only return "already exists" on push when the upload was sucessful

### DIFF
--- a/remotes/docker/pusher.go
+++ b/remotes/docker/pusher.go
@@ -52,7 +52,7 @@ func (p dockerPusher) Push(ctx context.Context, desc ocispec.Descriptor) (conten
 	ref := remotes.MakeRefKey(ctx, desc)
 	status, err := p.tracker.GetStatus(ref)
 	if err == nil {
-		if status.Offset == status.Total {
+		if status.Committed && status.Offset == status.Total {
 			return nil, errors.Wrapf(errdefs.ErrAlreadyExists, "ref %v", ref)
 		}
 		// TODO: Handle incomplete status
@@ -341,8 +341,6 @@ func (pw *pushWriter) Commit(ctx context.Context, size int64, expected digest.Di
 	if err := pw.pipe.Close(); err != nil {
 		return err
 	}
-	// TODO: Update status to determine committing
-
 	// TODO: timeout waiting for response
 	resp := <-pw.responseC
 	if resp.err != nil {
@@ -378,6 +376,10 @@ func (pw *pushWriter) Commit(ctx context.Context, size int64, expected digest.Di
 	if actual != expected {
 		return errors.Errorf("got digest %s, expected %s", actual, expected)
 	}
+
+	status.Committed = true
+	status.UpdatedAt = time.Now()
+	pw.tracker.SetStatus(pw.ref, status)
 
 	return nil
 }

--- a/remotes/docker/status.go
+++ b/remotes/docker/status.go
@@ -28,6 +28,8 @@ import (
 type Status struct {
 	content.Status
 
+	Committed bool
+
 	// UploadUUID is used by the Docker registry to reference blob uploads
 	UploadUUID string
 }


### PR DESCRIPTION
The `(dockerPusher).Push` method uses a `StatusTracker` to check if an
upload already happened, before repeating the upload. However, there is
no provision for failure handling. If a PUT request returns an error,
the `StatusTracker` will still see the upload as if it happened
successfully. Add a status boolean so that only successful uploads
short-circuit `Push`.

Signed-off-by: Aaron Lehmann <alehmann@netflix.com>