### PR TITLE
add .gitconfig to handle case-only renames

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,2 @@
+[core]
+	ignorecase = false


### PR DESCRIPTION
In preparation for an upcoming update of the ebpf dependency, which contains
a rename of `readme.md` to `README.md`, which may cause git or vendor validation
to fail.

If you're on a case-insensitive (but case-preserving) filesystem, such as on
macOS or Windows, this is the equivalent of;

    git config core.ignorecase false

Or to configure it globally:

    git config --global core.ignorecase false

