### PR TITLE
Cri integration cleanup

### DIFF
--- a/integration/addition_gids_test.go
+++ b/integration/addition_gids_test.go
@@ -36,14 +36,8 @@ func TestAdditionalGids(t *testing.T) {
 	defer os.RemoveAll(testPodLogDir)
 
 	t.Log("Create a sandbox with log directory")
-	sbConfig := PodSandboxConfig("sandbox", "additional-gids",
+	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "additional-gids",
 		WithPodLogDirectory(testPodLogDir))
-	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-	}()
 
 	var (
 		testImage     = GetImage(BusyBox)

--- a/integration/container_log_test.go
+++ b/integration/container_log_test.go
@@ -36,15 +36,9 @@ func TestContainerLogWithoutTailingNewLine(t *testing.T) {
 	defer os.RemoveAll(testPodLogDir)
 
 	t.Log("Create a sandbox with log directory")
-	sbConfig := PodSandboxConfig("sandbox", "container-log-without-tailing-newline",
+	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "container-log-without-tailing-newline",
 		WithPodLogDirectory(testPodLogDir),
 	)
-	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-	}()
 
 	var (
 		testImage     = GetImage(BusyBox)
@@ -92,15 +86,9 @@ func TestLongContainerLog(t *testing.T) {
 	defer os.RemoveAll(testPodLogDir)
 
 	t.Log("Create a sandbox with log directory")
-	sbConfig := PodSandboxConfig("sandbox", "long-container-log",
+	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "long-container-log",
 		WithPodLogDirectory(testPodLogDir),
 	)
-	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-	}()
 
 	var (
 		testImage     = GetImage(BusyBox)

--- a/integration/container_restart_test.go
+++ b/integration/container_restart_test.go
@@ -26,13 +26,7 @@ import (
 // Test to verify container can be restarted
 func TestContainerRestart(t *testing.T) {
 	t.Logf("Create a pod config and run sandbox container")
-	sbConfig := PodSandboxConfig("sandbox1", "restart")
-	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-	}()
+	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox1", "restart")
 
 	EnsureImageExists(t, pauseImage)
 

--- a/integration/container_stats_test.go
+++ b/integration/container_stats_test.go
@@ -31,13 +31,7 @@ import (
 // Test to verify for a container ID
 func TestContainerStats(t *testing.T) {
 	t.Logf("Create a pod config and run sandbox container")
-	sbConfig := PodSandboxConfig("sandbox1", "stats")
-	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-	}()
+	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox1", "stats")
 
 	EnsureImageExists(t, pauseImage)
 
@@ -78,13 +72,7 @@ func TestContainerStats(t *testing.T) {
 // Test to verify if the consumed stats are correct.
 func TestContainerConsumedStats(t *testing.T) {
 	t.Logf("Create a pod config and run sandbox container")
-	sbConfig := PodSandboxConfig("sandbox1", "stats")
-	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-	}()
+	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox1", "stats")
 
 	testImage := GetImage(ResourceConsumer)
 	img, err := imageService.PullImage(&runtime.ImageSpec{Image: testImage}, nil, sbConfig)
@@ -154,14 +142,12 @@ func TestContainerConsumedStats(t *testing.T) {
 
 // Test to verify filtering without any filter
 func TestContainerListStats(t *testing.T) {
+	var (
+		stats []*runtime.ContainerStats
+		err   error
+	)
 	t.Logf("Create a pod config and run sandbox container")
-	sbConfig := PodSandboxConfig("running-pod", "statsls")
-	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-	}()
+	sb, sbConfig := PodSandboxConfigWithCleanup(t, "running-pod", "statsls")
 
 	EnsureImageExists(t, pauseImage)
 
@@ -188,7 +174,6 @@ func TestContainerListStats(t *testing.T) {
 	}
 
 	t.Logf("Fetch all container stats")
-	var stats []*runtime.ContainerStats
 	require.NoError(t, Eventually(func() (bool, error) {
 		stats, err = runtimeService.ListContainerStats(&runtime.ContainerStatsFilter{})
 		if err != nil {
@@ -211,14 +196,12 @@ func TestContainerListStats(t *testing.T) {
 // Test to verify filtering given a specific container ID
 // TODO Convert the filter tests into table driven tests and unit tests
 func TestContainerListStatsWithIdFilter(t *testing.T) {
+	var (
+		stats []*runtime.ContainerStats
+		err   error
+	)
 	t.Logf("Create a pod config and run sandbox container")
-	sbConfig := PodSandboxConfig("running-pod", "statsls")
-	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-	}()
+	sb, sbConfig := PodSandboxConfigWithCleanup(t, "running-pod", "statsls")
 
 	EnsureImageExists(t, pauseImage)
 
@@ -245,7 +228,6 @@ func TestContainerListStatsWithIdFilter(t *testing.T) {
 	}
 
 	t.Logf("Fetch container stats for each container with Filter")
-	var stats []*runtime.ContainerStats
 	for id := range containerConfigMap {
 		require.NoError(t, Eventually(func() (bool, error) {
 			stats, err = runtimeService.ListContainerStats(
@@ -273,14 +255,12 @@ func TestContainerListStatsWithIdFilter(t *testing.T) {
 // Test to verify filtering given a specific Sandbox ID. Stats for
 // all the containers in a pod should be returned
 func TestContainerListStatsWithSandboxIdFilter(t *testing.T) {
+	var (
+		stats []*runtime.ContainerStats
+		err   error
+	)
 	t.Logf("Create a pod config and run sandbox container")
-	sbConfig := PodSandboxConfig("running-pod", "statsls")
-	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-	}()
+	sb, sbConfig := PodSandboxConfigWithCleanup(t, "running-pod", "statsls")
 
 	EnsureImageExists(t, pauseImage)
 
@@ -307,7 +287,6 @@ func TestContainerListStatsWithSandboxIdFilter(t *testing.T) {
 	}
 
 	t.Logf("Fetch container stats for each container with Filter")
-	var stats []*runtime.ContainerStats
 	require.NoError(t, Eventually(func() (bool, error) {
 		stats, err = runtimeService.ListContainerStats(
 			&runtime.ContainerStatsFilter{PodSandboxId: sb})
@@ -332,14 +311,12 @@ func TestContainerListStatsWithSandboxIdFilter(t *testing.T) {
 // Test to verify filtering given a specific container ID and
 // sandbox ID
 func TestContainerListStatsWithIdSandboxIdFilter(t *testing.T) {
+	var (
+		stats []*runtime.ContainerStats
+		err   error
+	)
 	t.Logf("Create a pod config and run sandbox container")
-	sbConfig := PodSandboxConfig("running-pod", "statsls")
-	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-	}()
+	sb, sbConfig := PodSandboxConfigWithCleanup(t, "running-pod", "statsls")
 
 	EnsureImageExists(t, pauseImage)
 
@@ -365,7 +342,6 @@ func TestContainerListStatsWithIdSandboxIdFilter(t *testing.T) {
 		}()
 	}
 	t.Logf("Fetch container stats for sandbox ID and container ID filter")
-	var stats []*runtime.ContainerStats
 	for id, config := range containerConfigMap {
 		require.NoError(t, Eventually(func() (bool, error) {
 			stats, err = runtimeService.ListContainerStats(

--- a/integration/container_stats_test.go
+++ b/integration/container_stats_test.go
@@ -75,11 +75,7 @@ func TestContainerConsumedStats(t *testing.T) {
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox1", "stats")
 
 	testImage := GetImage(ResourceConsumer)
-	img, err := imageService.PullImage(&runtime.ImageSpec{Image: testImage}, nil, sbConfig)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, imageService.RemoveImage(&runtime.ImageSpec{Image: img}))
-	}()
+	EnsureImageExists(t, testImage)
 
 	t.Logf("Create a container config and run container in a pod")
 	containerConfig := ContainerConfig(

--- a/integration/container_stop_test.go
+++ b/integration/container_stop_test.go
@@ -76,13 +76,7 @@ func TestContainerStopCancellation(t *testing.T) {
 		t.Skip("Skipped on Windows.")
 	}
 	t.Log("Create a pod sandbox")
-	sbConfig := PodSandboxConfig("sandbox", "cancel-container-stop")
-	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-	}()
+	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "cancel-container-stop")
 
 	var (
 		testImage     = GetImage(BusyBox)

--- a/integration/container_update_resources_test.go
+++ b/integration/container_update_resources_test.go
@@ -41,13 +41,7 @@ func checkMemoryLimit(t *testing.T, spec *runtimespec.Spec, memLimit int64) {
 func TestUpdateContainerResources(t *testing.T) {
 	// TODO(claudiub): Make this test work once https://github.com/microsoft/hcsshim/pull/931 merges.
 	t.Log("Create a sandbox")
-	sbConfig := PodSandboxConfig("sandbox", "update-container-resources")
-	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-	}()
+	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "update-container-resources")
 
 	EnsureImageExists(t, pauseImage)
 

--- a/integration/container_volume_test.go
+++ b/integration/container_volume_test.go
@@ -99,15 +99,9 @@ func TestContainerSymlinkVolumes(t *testing.T) {
 			require.NoError(t, err)
 
 			t.Log("Create test sandbox with log directory")
-			sbConfig := PodSandboxConfig("sandbox", "test-symlink",
+			sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "test-symlink",
 				WithPodLogDirectory(testPodLogDir),
 			)
-			sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
-			require.NoError(t, err)
-			defer func() {
-				assert.NoError(t, runtimeService.StopPodSandbox(sb))
-				assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-			}()
 
 			var (
 				testImage     = GetImage(BusyBox)

--- a/integration/container_without_image_ref_test.go
+++ b/integration/container_without_image_ref_test.go
@@ -27,13 +27,7 @@ import (
 // Test container lifecycle can work without image references.
 func TestContainerLifecycleWithoutImageRef(t *testing.T) {
 	t.Log("Create a sandbox")
-	sbConfig := PodSandboxConfig("sandbox", "container-lifecycle-without-image-ref")
-	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-	}()
+	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "container-lifecycle-without-image-ref")
 
 	var (
 		testImage     = GetImage(BusyBox)

--- a/integration/containerd_image_test.go
+++ b/integration/containerd_image_test.go
@@ -122,13 +122,7 @@ func TestContainerdImage(t *testing.T) {
 	assert.Equal(t, imgByID.Labels()["io.cri-containerd.image"], "managed")
 
 	t.Logf("should be able to start container with the image")
-	sbConfig := PodSandboxConfig("sandbox", "containerd-image")
-	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-	}()
+	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "containerd-image")
 
 	cnConfig := ContainerConfig(
 		"test-container",
@@ -183,7 +177,7 @@ func TestContainerdImageInOtherNamespaces(t *testing.T) {
 	}
 	require.NoError(t, Consistently(checkImage, 100*time.Millisecond, time.Second))
 
-	PodSandboxConfig("sandbox", "test")
+	PodSandboxConfigWithCleanup(t, "sandbox", "test")
 	EnsureImageExists(t, testImage)
 
 	t.Logf("cri plugin should see the image now")

--- a/integration/duplicate_name_test.go
+++ b/integration/duplicate_name_test.go
@@ -19,22 +19,15 @@ package integration
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDuplicateName(t *testing.T) {
 	t.Logf("Create a sandbox")
-	sbConfig := PodSandboxConfig("sandbox", "duplicate-name")
-	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-	}()
+	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "duplicate-name")
 
 	t.Logf("Create the sandbox again should fail")
-	_, err = runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
+	_, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
 	require.Error(t, err)
 
 	EnsureImageExists(t, pauseImage)

--- a/integration/image_load_test.go
+++ b/integration/image_load_test.go
@@ -77,13 +77,7 @@ func TestImageLoad(t *testing.T) {
 	require.Equal(t, []string{loadedImage}, img.RepoTags)
 
 	t.Logf("create a container with the loaded image")
-	sbConfig := PodSandboxConfig("sandbox", Randomize("image-load"))
-	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-	}()
+	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", Randomize("image-load"))
 	containerConfig := ContainerConfig(
 		"container",
 		testImage,

--- a/integration/imagefs_info_test.go
+++ b/integration/imagefs_info_test.go
@@ -28,18 +28,11 @@ import (
 )
 
 func TestImageFSInfo(t *testing.T) {
-	config := PodSandboxConfig("running-pod", "imagefs")
+	t.Logf("Create a sandbox to make sure there is an active snapshot")
+	PodSandboxConfigWithCleanup(t, "running-pod", "imagefs")
 
 	t.Logf("Pull an image to make sure image fs is not empty")
 	EnsureImageExists(t, GetImage(BusyBox))
-
-	t.Logf("Create a sandbox to make sure there is an active snapshot")
-	sb, err := runtimeService.RunPodSandbox(config, *runtimeHandler)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-	}()
 
 	// It takes time to populate imagefs stats. Use eventually
 	// to check for a period of time.
@@ -66,6 +59,6 @@ func TestImageFSInfo(t *testing.T) {
 	}, time.Second, 30*time.Second))
 
 	t.Logf("Image filesystem mountpath should exist")
-	_, err = os.Stat(info.GetFsId().GetMountpoint())
+	_, err := os.Stat(info.GetFsId().GetMountpoint())
 	assert.NoError(t, err)
 }

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -181,6 +181,18 @@ func PodSandboxConfig(name, ns string, opts ...PodSandboxOpts) *runtime.PodSandb
 	return config
 }
 
+func PodSandboxConfigWithCleanup(t *testing.T, name, ns string, opts ...PodSandboxOpts) (string, *runtime.PodSandboxConfig) {
+	sbConfig := PodSandboxConfig(name, ns, opts...)
+	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, runtimeService.StopPodSandbox(sb))
+		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
+	})
+
+	return sb, sbConfig
+}
+
 // ContainerOpts to set any specific attribute like labels,
 // annotations, metadata etc
 type ContainerOpts func(*runtime.ContainerConfig)

--- a/integration/no_metadata_test.go
+++ b/integration/no_metadata_test.go
@@ -32,16 +32,9 @@ func TestRunPodSandboxWithoutMetadata(t *testing.T) {
 }
 
 func TestCreateContainerWithoutMetadata(t *testing.T) {
-	sbConfig := PodSandboxConfig("sandbox", "container-create")
-	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
-	require.NoError(t, err)
-	defer func() {
-		// Make sure the sandbox is cleaned up in any case.
-		runtimeService.StopPodSandbox(sb)
-		runtimeService.RemovePodSandbox(sb)
-	}()
+	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "container-create")
 	config := &runtime.ContainerConfig{}
-	_, err = runtimeService.CreateContainer(sb, config, sbConfig)
+	_, err := runtimeService.CreateContainer(sb, config, sbConfig)
 	require.Error(t, err)
 	_, err = runtimeService.Status()
 	require.NoError(t, err)

--- a/integration/pod_dualstack_test.go
+++ b/integration/pod_dualstack_test.go
@@ -37,13 +37,7 @@ func TestPodDualStack(t *testing.T) {
 	defer os.RemoveAll(testPodLogDir)
 
 	t.Log("Create a sandbox")
-	sbConfig := PodSandboxConfig("sandbox", "dualstack", WithPodLogDirectory(testPodLogDir))
-	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-	}()
+	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "dualstack", WithPodLogDirectory(testPodLogDir))
 
 	var (
 		testImage     = GetImage(BusyBox)

--- a/integration/runtime_handler_test.go
+++ b/integration/runtime_handler_test.go
@@ -29,20 +29,12 @@ import (
 // TODO(chrisfegly): add/update test(s) to allow testing of multiple runtimes at the same time
 func TestRuntimeHandler(t *testing.T) {
 	t.Logf("Create a sandbox")
-	sbConfig := PodSandboxConfig("sandbox", "test-runtime-handler")
-
 	if *runtimeHandler == "" {
 		t.Logf("The --runtime-handler flag value is empty which results internally to setting the default runtime")
 	} else {
 		t.Logf("The --runtime-handler flag value is %s", *runtimeHandler)
 	}
-	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
-	require.NoError(t, err)
-	defer func() {
-		// Make sure the sandbox is cleaned up in any case.
-		runtimeService.StopPodSandbox(sb)
-		runtimeService.RemovePodSandbox(sb)
-	}()
+	sb, _ := PodSandboxConfigWithCleanup(t, "sandbox", "test-runtime-handler")
 
 	t.Logf("Verify runtimeService.PodSandboxStatus() returns previously set runtimeHandler")
 	sbStatus, err := runtimeService.PodSandboxStatus(sb)

--- a/integration/volume_copy_up_test.go
+++ b/integration/volume_copy_up_test.go
@@ -39,13 +39,7 @@ func TestVolumeCopyUp(t *testing.T) {
 	)
 
 	t.Logf("Create a sandbox")
-	sbConfig := PodSandboxConfig("sandbox", "volume-copy-up")
-	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-	}()
+	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "volume-copy-up")
 
 	EnsureImageExists(t, testImage)
 
@@ -102,13 +96,7 @@ func TestVolumeOwnership(t *testing.T) {
 	)
 
 	t.Logf("Create a sandbox")
-	sbConfig := PodSandboxConfig("sandbox", "volume-ownership")
-	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-	}()
+	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "volume-ownership")
 
 	EnsureImageExists(t, testImage)
 


### PR DESCRIPTION
Most of the tests creating and using Pod Sandboxes in the same way. We can create a common function that will do that for us, so we can have less duplicated code, and make it easier to add new tests in the future.

Most tests require pulling a test image, and most of them are doing it in the same way. A function ``PulImageWithCleanup`` was introduced in a previous commit. Using it will reduce the amount of duplicated code.