### PR TITLE
 Fix return event publishing error 

### DIFF
--- a/cmd/containerd-shim/main_unix.go
+++ b/cmd/containerd-shim/main_unix.go
@@ -297,7 +297,10 @@ func (l *remoteEventsPublisher) Publish(ctx context.Context, topic string, event
 	cmd := exec.CommandContext(ctx, containerdBinaryFlag, "--address", l.address, "publish", "--topic", topic, "--namespace", ns)
 	cmd.Stdin = bytes.NewReader(data)
 	b := bufPool.Get().(*bytes.Buffer)
-	defer bufPool.Put(b)
+	defer func() {
+		b.Reset()
+		bufPool.Put(b)
+	}()
 	cmd.Stdout = b
 	cmd.Stderr = b
 	c, err := reaper.Default.Start(cmd)


### PR DESCRIPTION
 Fix that the returned event publishing error may contain historical error messages and memory leaks

Signed-off-by: Shiming Zhang <wzshiming@foxmail.com>