### PR TITLE
ctr image mount handle mismatched snapshot type

### DIFF
--- a/cmd/ctr/commands/images/remount_linux.go
+++ b/cmd/ctr/commands/images/remount_linux.go
@@ -1,0 +1,27 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package images
+
+import "github.com/containerd/containerd/mount"
+
+func remountRO(m []mount.Mount) ([]mount.Mount, error) {
+	return append(m, mount.Mount{
+		Type:    "bind",
+		Source:  m[len(m)-1].Source,
+		Options: []string{"remount", "ro", "bind"},
+	}), nil
+}

--- a/cmd/ctr/commands/images/remount_unsupported.go
+++ b/cmd/ctr/commands/images/remount_unsupported.go
@@ -1,0 +1,30 @@
+//go:build !linux
+// +build !linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package images
+
+import (
+	"fmt"
+
+	"github.com/containerd/containerd/mount"
+)
+
+func remountRO(mounts []mount.Mount) ([]mount.Mount, error) {
+	return nil, fmt.Errorf("remounting to read-only is not supported on this platform")
+}


### PR DESCRIPTION
Marks mount as read-only even for active snapshots unless `--rw` was
specified.

It also errors if the snapshot type is a view but a read-write mount was
requested.