### PR TITLE
Change the type of CRI runtime option 

### DIFF
--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/plugin"
-	"github.com/pelletier/go-toml"
 	"github.com/pkg/errors"
 )
 
@@ -47,9 +46,11 @@ type Runtime struct {
 	// DEPRECATED: use Options instead. Remove when shim v1 is deprecated.
 	// This only works for runtime type "io.containerd.runtime.v1.linux".
 	Root string `toml:"runtime_root" json:"runtimeRoot"`
-	// Options are config options for the runtime. If options is loaded
-	// from toml config, it will be toml.Tree.
-	Options *toml.Tree `toml:"options" json:"options"`
+	// Options are config options for the runtime.
+	// If options is loaded from toml config, it will be map[string]interface{}.
+	// Options can be converted into toml.Tree using toml.TreeFromMap().
+	// Using options type as map[string]interface{} helps in correctly marshaling options from Go to JSON.
+	Options map[string]interface{} `toml:"options" json:"options"`
 	// PrivilegedWithoutHostDevices overloads the default behaviour for adding host devices to the
 	// runtime spec when the container is privileged. Defaults to false.
 	PrivilegedWithoutHostDevices bool `toml:"privileged_without_host_devices" json:"privileged_without_host_devices"`

--- a/pkg/cri/server/helpers.go
+++ b/pkg/cri/server/helpers.go
@@ -32,6 +32,7 @@ import (
 	runcoptions "github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/containerd/typeurl"
 	imagedigest "github.com/opencontainers/go-digest"
+	"github.com/pelletier/go-toml"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
@@ -308,8 +309,12 @@ func generateRuntimeOptions(r criconfig.Runtime, c criconfig.Config) (interface{
 			SystemdCgroup: c.SystemdCgroup,
 		}, nil
 	}
+	optionsTree, err := toml.TreeFromMap(r.Options)
+	if err != nil {
+		return nil, err
+	}
 	options := getRuntimeOptionsType(r.Type)
-	if err := r.Options.Unmarshal(options); err != nil {
+	if err := optionsTree.Unmarshal(options); err != nil {
 		return nil, err
 	}
 	return options, nil


### PR DESCRIPTION
 Trying to fix the issue in which runtime options does not get printed in `crictl info`.  
<strike>Added separate field for runtime options in status response. </strike>

Update the type of `Options *toml.Tree` to `Options *toml.Tree map[string]interface{}`. This is correctly marshalling the options in CRI status response. 


Ref Issue: https://github.com/kubernetes-sigs/cri-tools/issues/728