### PR TITLE
shows our runc.v2 default options

### DIFF
--- a/pkg/cri/config/config_unix.go
+++ b/pkg/cri/config/config_unix.go
@@ -21,10 +21,46 @@ package config
 import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/pkg/cri/streaming"
+	"github.com/pelletier/go-toml"
 )
 
 // DefaultConfig returns default configurations of cri plugin.
 func DefaultConfig() PluginConfig {
+	defaultRuncV2Opts := `
+	# NoPivotRoot disables pivot root when creating a container.
+	NoPivotRoot = false
+
+	# NoNewKeyring disables new keyring for the container.
+	NoNewKeyring = false
+
+	# ShimCgroup places the shim in a cgroup.
+	ShimCgroup = ""
+
+	# IoUid sets the I/O's pipes uid.
+	IoUid = 0
+
+	# IoGid sets the I/O's pipes gid.
+	IoGid = 0
+
+	# BinaryName is the binary name of the runc binary.
+	BinaryName = ""
+
+	# Root is the runc root directory.
+	Root = ""
+
+	# CriuPath is the criu binary path.
+	CriuPath = ""
+
+	# SystemdCgroup enables systemd cgroups.
+	SystemdCgroup = false
+
+	# CriuImagePath is the criu image path
+	CriuImagePath = ""
+
+	# CriuWorkPath is the criu work path.
+	CriuWorkPath = ""
+`
+	tree, _ := toml.Load(defaultRuncV2Opts)
 	return PluginConfig{
 		CniConfig: CniConfig{
 			NetworkPluginBinDir:       "/opt/cni/bin",
@@ -38,7 +74,8 @@ func DefaultConfig() PluginConfig {
 			NoPivot:            false,
 			Runtimes: map[string]Runtime{
 				"runc": {
-					Type: "io.containerd.runc.v2",
+					Type:    "io.containerd.runc.v2",
+					Options: tree,
 				},
 			},
 			DisableSnapshotAnnotations: true,

--- a/pkg/cri/config/config_unix.go
+++ b/pkg/cri/config/config_unix.go
@@ -75,7 +75,7 @@ func DefaultConfig() PluginConfig {
 			Runtimes: map[string]Runtime{
 				"runc": {
 					Type:    "io.containerd.runc.v2",
-					Options: tree,
+					Options: tree.ToMap(),
 				},
 			},
 			DisableSnapshotAnnotations: true,


### PR DESCRIPTION
When running the `containerd default config` command this pr adds output to show the available runc options:
```
      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]

        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
          base_runtime_spec = ""
          container_annotations = []
          pod_annotations = []
          privileged_without_host_devices = false
          runtime_engine = ""
          runtime_root = ""
          runtime_type = "io.containerd.runc.v2"

          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
            BinaryName = ""
            CriuImagePath = ""
            CriuPath = ""
            CriuWorkPath = ""
            IoGid = 0
            IoUid = 0
            NoNewKeyring = false
            NoPivotRoot = false
            Root = ""
            ShimCgroup = ""
            SystemdCgroup = false

```
and here's the `containerd default dump` output with just `SystemdCgroup = false` set
```
        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
          base_runtime_spec = ""
          container_annotations = []
          pod_annotations = []
          privileged_without_host_devices = false
          runtime_engine = ""
          runtime_root = ""
          runtime_type = "io.containerd.runc.v2"

          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
            SystemdCgroup = false
```


these map to the docs here:
- https://github.com/containerd/containerd/blob/master/docs/cri/config.md specifically 
- https://github.com/containerd/containerd/blame/master/docs/cri/config.md#L177-L209
and originate here:
https://github.com/containerd/containerd/blob/master/runtime/v2/runc/options/oci.proto#L9-L32

Signed-off-by: Mike Brown <brownwm@us.ibm.com>