### PR TITLE
remove mirrors from default; document the deprecation of registry.configs and registry.mirrors

### DIFF
--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -225,23 +225,6 @@ version = 2
     # See the "CNI Config Template" section for more details.
     conf_template = ""
 
-  # 'plugins."io.containerd.grpc.v1.cri".registry' contains config related to the registry
-  [plugins."io.containerd.grpc.v1.cri".registry]
-    # Specifies a directory to look for registry configs in.
-    # Dir can be used just like /etc/docker/certs.d OR can contain a hosts.toml with more specific configurations.
-    #
-    # NOTE: Specifying this will cause the cri plugin to ignore any other registry configs specified in this configuration file.
-    config_path = "/etc/containerd/certs.d"
-
-    # 'plugins."io.containerd.grpc.v1.cri.registry.headers sets the http request headers to send for all registry requests
-    [plugins."io.containerd.grpc.v1.cri".registry.headers]
-        Foo = ["bar"]
-
-    # 'plugins."io.containerd.grpc.v1.cri".registry.mirrors' are namespace to mirror mapping for all namespaces.
-    [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-      [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-        endpoint = ["https://registry-1.docker.io", ]
-
   # 'plugins."io.containerd.grpc.v1.cri".image_decryption' contains config related
   # to handling decryption of encrypted container images.
   [plugins."io.containerd.grpc.v1.cri".image_decryption]
@@ -263,6 +246,34 @@ version = 2
     # * Stream processors: https://github.com/containerd/containerd/blob/master/docs/stream_processors.md
     # * Containerd imgcrypt: https://github.com/containerd/imgcrypt
     key_model = "node"
+
+  # 'plugins."io.containerd.grpc.v1.cri".registry' contains config related to
+  # the registry
+  [plugins."io.containerd.grpc.v1.cri".registry]
+    # config_path specifies a directory to look for the registry hosts configuration.
+    #
+    # The cri plugin will look for and use config_path/host-namespace/hosts.toml
+    #   configs if present OR load certificate files as laid out in the Docker/Moby
+    #   specific layout https://docs.docker.com/engine/security/certificates/
+    #
+    # If config_path is not provided defaults are used.
+    #
+    # *** registry.configs and registry.mirrors that were a part of containerd 1.4
+    # are now DEPRECATED and will only be used if the config_path is not specified.
+    config_path = "/etc/containerd/certs.d"
+```
+Here is a simple example for a default registry hosts configuration when specifying config_path:
+```
+$ tree /etc/containerd/certs.d
+/etc/containerd/certs.d
+└── docker.io
+    └── hosts.toml
+
+$ cat /etc/containerd/certs.d/docker.io/hosts.toml
+server = "https://docker.io"
+
+[host."https://registry-1.docker.io"]
+  capabilities = ["pull", "resolve"]
 ```
 
 ## Untrusted Workload

--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -260,9 +260,16 @@ version = 2
     #
     # *** registry.configs and registry.mirrors that were a part of containerd 1.4
     # are now DEPRECATED and will only be used if the config_path is not specified.
-    config_path = "/etc/containerd/certs.d"
+    config_path = ""
 ```
-Here is a simple example for a default registry hosts configuration when specifying config_path:
+
+## Registry Configuration
+
+Here is a simple example for a default registry hosts configuration. Set
+`config_path = "/etc/containerd/certs.d"` in your config.toml for containerd.
+Make a directory tree at the config path that includes `docker.io` as a directory
+representing the host namespace to be configured. Then add a `hosts.toml` file
+in the `docker.io` to configure the host namespace. It should look like this:
 ```
 $ tree /etc/containerd/certs.d
 /etc/containerd/certs.d

--- a/docs/cri/registry.md
+++ b/docs/cri/registry.md
@@ -2,6 +2,14 @@
 
 This document describes the method to configure the image registry for `containerd` for use with the `cri` plugin.
 
+*** registry.mirrors and registry.configs as described in this document
+have been DEPRECATED. As described in [the cri config](./config.md) you
+should now use the form
+```toml
+[plugins."io.containerd.grpc.v1.cri".registry]
+   config_path = "/etc/containerd/certs.d"
+```
+
 ## Configure Registry Endpoint
 
 With containerd, `docker.io` is the default image registry. You can also set up other image registries similar to docker.

--- a/docs/cri/registry.md
+++ b/docs/cri/registry.md
@@ -3,7 +3,7 @@
 This document describes the method to configure the image registry for `containerd` for use with the `cri` plugin.
 
 *** registry.mirrors and registry.configs as described in this document
-have been DEPRECATED. As described in [the cri config](./config.md) you
+have been DEPRECATED. As described in [the cri config](./config.md#registry-configuration) you
 should now use the form
 ```toml
 [plugins."io.containerd.grpc.v1.cri".registry]

--- a/pkg/cri/config/config_unix.go
+++ b/pkg/cri/config/config_unix.go
@@ -54,17 +54,10 @@ func DefaultConfig() PluginConfig {
 			TLSKeyFile:  "",
 			TLSCertFile: "",
 		},
-		SandboxImage:            "k8s.gcr.io/pause:3.5",
-		StatsCollectPeriod:      10,
-		SystemdCgroup:           false,
-		MaxContainerLogLineSize: 16 * 1024,
-		Registry: Registry{
-			Mirrors: map[string]Mirror{
-				"docker.io": {
-					Endpoints: []string{"https://registry-1.docker.io"},
-				},
-			},
-		},
+		SandboxImage:                     "k8s.gcr.io/pause:3.5",
+		StatsCollectPeriod:               10,
+		SystemdCgroup:                    false,
+		MaxContainerLogLineSize:          16 * 1024,
 		MaxConcurrentDownloads:           3,
 		DisableProcMount:                 false,
 		TolerateMissingHugetlbController: true,

--- a/pkg/cri/config/config_windows.go
+++ b/pkg/cri/config/config_windows.go
@@ -54,16 +54,9 @@ func DefaultConfig() PluginConfig {
 			TLSKeyFile:  "",
 			TLSCertFile: "",
 		},
-		SandboxImage:            "k8s.gcr.io/pause:3.5",
-		StatsCollectPeriod:      10,
-		MaxContainerLogLineSize: 16 * 1024,
-		Registry: Registry{
-			Mirrors: map[string]Mirror{
-				"docker.io": {
-					Endpoints: []string{"https://registry-1.docker.io"},
-				},
-			},
-		},
+		SandboxImage:              "k8s.gcr.io/pause:3.5",
+		StatsCollectPeriod:        10,
+		MaxContainerLogLineSize:   16 * 1024,
 		MaxConcurrentDownloads:    3,
 		IgnoreImageDefinedVolumes: false,
 		// TODO(windows): Add platform specific config, so that most common defaults can be shared.


### PR DESCRIPTION
Some clean up of the docs around registry config.

A fix to remove old style mirrors config from the default config. Without the fix init will report 
`WARN[2021-04-07T09:21:29.773381274-05:00] failed to load plugin io.containerd.grpc.v1.cri  error="invalid plugin config: `mirrors` cannot be set when `config_path` is provided"`

Signed-off-by: Mike Brown <brownwm@us.ibm.com>