### PR TITLE
pkg/cri/opts.WithoutRunMount -> oci.WithoutRunMount

### DIFF
--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -273,6 +273,28 @@ func WithMounts(mounts []specs.Mount) SpecOpts {
 	}
 }
 
+// WithoutMounts removes mounts
+func WithoutMounts(dests ...string) SpecOpts {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
+		var (
+			mounts  []specs.Mount
+			current = s.Mounts
+		)
+	mLoop:
+		for _, m := range current {
+			mDestination := filepath.Clean(m.Destination)
+			for _, dest := range dests {
+				if mDestination == dest {
+					continue mLoop
+				}
+			}
+			mounts = append(mounts, m)
+		}
+		s.Mounts = mounts
+		return nil
+	}
+}
+
 // WithHostNamespace allows a task to run inside the host's linux namespace
 func WithHostNamespace(ns specs.LinuxNamespaceType) SpecOpts {
 	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {

--- a/oci/spec_opts_linux.go
+++ b/oci/spec_opts_linux.go
@@ -247,3 +247,8 @@ var WithAllKnownCapabilities = func(ctx context.Context, client Client, c *conta
 	caps := cap.Known()
 	return WithCapabilities(caps)(ctx, client, c, s)
 }
+
+// WithoutRunMount removes the `/run` inside the spec
+func WithoutRunMount(ctx context.Context, client Client, c *containers.Container, s *Spec) error {
+	return WithoutMounts("/run")(ctx, client, c, s)
+}

--- a/pkg/cri/opts/spec_linux.go
+++ b/pkg/cri/opts/spec_linux.go
@@ -76,22 +76,6 @@ func mergeGids(gids1, gids2 []uint32) []uint32 {
 	return gids
 }
 
-// WithoutRunMount removes the `/run` inside the spec
-func WithoutRunMount(_ context.Context, _ oci.Client, c *containers.Container, s *runtimespec.Spec) error {
-	var (
-		mounts  []runtimespec.Mount
-		current = s.Mounts
-	)
-	for _, m := range current {
-		if filepath.Clean(m.Destination) == "/run" {
-			continue
-		}
-		mounts = append(mounts, m)
-	}
-	s.Mounts = mounts
-	return nil
-}
-
 // WithoutDefaultSecuritySettings removes the default security settings generated on a spec
 func WithoutDefaultSecuritySettings(_ context.Context, _ oci.Client, c *containers.Container, s *runtimespec.Spec) error {
 	if s.Process == nil {

--- a/pkg/cri/server/container_create_linux.go
+++ b/pkg/cri/server/container_create_linux.go
@@ -122,7 +122,7 @@ func (c *criService) containerSpec(
 	ociRuntime config.Runtime,
 ) (_ *runtimespec.Spec, retErr error) {
 	specOpts := []oci.SpecOpts{
-		customopts.WithoutRunMount,
+		oci.WithoutRunMount,
 	}
 	// only clear the default security settings if the runtime does not have a custom
 	// base runtime spec spec.  Admins can use this functionality to define

--- a/pkg/cri/server/sandbox_run_linux.go
+++ b/pkg/cri/server/sandbox_run_linux.go
@@ -41,7 +41,7 @@ func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 	// Creates a spec Generator with the default spec.
 	// TODO(random-liu): [P1] Compare the default settings with docker and containerd default.
 	specOpts := []oci.SpecOpts{
-		customopts.WithoutRunMount,
+		oci.WithoutRunMount,
 		customopts.WithoutDefaultSecuritySettings,
 		customopts.WithRelativeRoot(relativeRootfsPath),
 		oci.WithEnv(imageConfig.Env),


### PR DESCRIPTION
Move `pkg/cri/opts.WithoutRunMount` function to `oci.WithoutRunMount` so that it can be used without dependency on CRI.

Also add `oci.WithoutMounts(dests ...string)` for generality.

--- 

Will be used by nerdctl: https://github.com/containerd/nerdctl/pull/158