### PR TITLE
unpacker: don't log when context is canceled

### DIFF
--- a/unpacker.go
+++ b/unpacker.go
@@ -178,7 +178,9 @@ EachLayer:
 		// Abort the snapshot if commit does not happen
 		abort := func() {
 			if err := sn.Remove(ctx, key); err != nil {
-				log.G(ctx).WithError(err).Errorf("failed to cleanup %q", key)
+				if !errdefs.IsCanceled(err) && !errdefs.IsDeadlineExceeded(err) {
+					log.G(ctx).WithError(err).Errorf("failed to cleanup %q", key)
+				}
 			}
 		}
 


### PR DESCRIPTION
When using the client pull API, `Client.Pull`, I'm noticing that if the context is canceled, for instance, due to a SIGINT, there is a spurious log message "failed to cleanup" with the error "context canceled". This is coming from the unpacker.

I'd like to silence this log message if the cleanup fails because of a context canceled or timeout. The three places where this happens will already return a `context.Canceled` error, which bubbles up to the API caller. 