### PR TITLE
Temporarily disable cri-tools critest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,6 +423,8 @@ jobs:
       - name: cri-tools critest
         env:
           TEST_RUNTIME: ${{ matrix.runtime }}
+        # Temporarily disabled due to cri-tools hardcoded to use broken images
+        continue-on-error: true
         run: |
           BDIR="$(mktemp -d -p $PWD)"
           mkdir -p ${BDIR}/{root,state}
@@ -512,4 +514,6 @@ jobs:
         env:
           RUNC_FLAVOR: ${{ matrix.runc }}
           SELINUX: Enforcing
+        # Temporarily disabled due to cri-tools hardcoded to use broken images
+        continue-on-error: true
         run: vagrant up --provision-with=selinux,install-runc,test-cri


### PR DESCRIPTION
cri-tools is hardcoded to use images which are broken within their registry. Disable the tests to unblock CI until fixed.

See https://github.com/kubernetes-sigs/cri-tools/pull/733