### PR TITLE
Add snapshotter cli option to containerd-stress utility

### DIFF
--- a/cmd/containerd-stress/density.go
+++ b/cmd/containerd-stress/density.go
@@ -55,6 +55,7 @@ var densityCommand = cli.Command{
 			Exec:        cliContext.GlobalBool("exec"),
 			JSON:        cliContext.GlobalBool("json"),
 			Metrics:     cliContext.GlobalString("metrics"),
+			Snapshotter: cliContext.GlobalString("snapshotter"),
 		}
 		client, err := config.newClient()
 		if err != nil {
@@ -66,7 +67,7 @@ var densityCommand = cli.Command{
 			return err
 		}
 		logrus.Infof("pulling %s", imageName)
-		image, err := client.Pull(ctx, imageName, containerd.WithPullUnpack)
+		image, err := client.Pull(ctx, imageName, containerd.WithPullUnpack, containerd.WithPullSnapshotter(config.Snapshotter))
 		if err != nil {
 			return err
 		}
@@ -91,6 +92,7 @@ var densityCommand = cli.Command{
 				id := fmt.Sprintf("density-%d", i)
 
 				c, err := client.NewContainer(ctx, id,
+					containerd.WithSnapshotter(config.Snapshotter),
 					containerd.WithNewSnapshot(id, image),
 					containerd.WithNewSpec(
 						oci.WithImageConfig(image),

--- a/cmd/containerd-stress/exec_worker.go
+++ b/cmd/containerd-stress/exec_worker.go
@@ -42,6 +42,7 @@ func (w *execWorker) exec(ctx, tctx context.Context) {
 	id := fmt.Sprintf("exec-container-%d", w.id)
 	c, err := w.client.NewContainer(ctx, id,
 		containerd.WithNewSnapshot(id, w.image),
+		containerd.WithSnapshotter(w.snapshotter),
 		containerd.WithNewSpec(oci.WithImageConfig(w.image), oci.WithUsername("games"), oci.WithProcessArgs("sleep", "30d")),
 	)
 	if err != nil {

--- a/cmd/containerd-stress/worker.go
+++ b/cmd/containerd-stress/worker.go
@@ -35,9 +35,10 @@ type worker struct {
 	count    int
 	failures int
 
-	client *containerd.Client
-	image  containerd.Image
-	commit string
+	client      *containerd.Client
+	image       containerd.Image
+	commit      string
+	snapshotter string
 }
 
 func (w *worker) run(ctx, tctx context.Context) {
@@ -74,6 +75,7 @@ func (w *worker) run(ctx, tctx context.Context) {
 func (w *worker) runContainer(ctx context.Context, id string) (err error) {
 	// fix up cgroups path for a default config
 	c, err := w.client.NewContainer(ctx, id,
+		containerd.WithSnapshotter(w.snapshotter),
 		containerd.WithNewSnapshot(id, w.image),
 		containerd.WithNewSpec(oci.WithImageConfig(w.image), oci.WithUsername("games"), oci.WithProcessArgs("true")),
 	)


### PR DESCRIPTION
containerd-stress utility does not have an option to pass snapshotter. This adds a cli option to pass other snapshotter e.g. devmapper. This is useful for comparing two different snapshotters.


