### PR TITLE
[release/1.4] runtime/v2/runc: fix the defer cleanup of the NewContainer

### DIFF
--- a/runtime/v2/runc/container.go
+++ b/runtime/v2/runc/container.go
@@ -42,7 +42,7 @@ import (
 )
 
 // NewContainer returns a new runc container
-func NewContainer(ctx context.Context, platform stdio.Platform, r *task.CreateTaskRequest) (*Container, error) {
+func NewContainer(ctx context.Context, platform stdio.Platform, r *task.CreateTaskRequest) (_ *Container, retErr error) {
 	ns, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "create namespace")
@@ -97,9 +97,9 @@ func NewContainer(ctx context.Context, platform stdio.Platform, r *task.CreateTa
 		return nil, err
 	}
 	defer func() {
-		if err != nil {
-			if err2 := mount.UnmountAll(rootfs, 0); err2 != nil {
-				logrus.WithError(err2).Warn("failed to cleanup rootfs mount")
+		if retErr != nil {
+			if err := mount.UnmountAll(rootfs, 0); err != nil {
+				logrus.WithError(err).Warn("failed to cleanup rootfs mount")
 			}
 		}
 	}()


### PR DESCRIPTION
Signed-off-by: Iceber Gu <wei.cai-nat@daocloud.io>
(cherry picked from commit 5e484c96139d2e4c93a277ff0c0caf815acb466f)
Signed-off-by: Iceber Gu <wei.cai-nat@daocloud.io>

cherry-pick: https://github.com/containerd/containerd/pull/5206