### PR TITLE
integration: use busybox:1.32.0 since latest is unavailable

### DIFF
--- a/integration/client/client_unix_test.go
+++ b/integration/client/client_unix_test.go
@@ -32,7 +32,7 @@ const (
 )
 
 var (
-	testImage    = "mirror.gcr.io/library/busybox:latest"
+	testImage    = "mirror.gcr.io/library/busybox:1.32.0"
 	shortCommand = withProcessArgs("true")
 	longCommand  = withProcessArgs("/bin/sh", "-c", "while true; do sleep 1; done")
 )


### PR DESCRIPTION
```bash
curl -s https://mirror.gcr.io//v2/library/busybox/tags/list | jq '[.tags ]'
[
  [
    "1.26.2",
    "1.27.2",
    "1.28",
    "1.29",
    "1.29.2",
    "1.30",
    "1.30.1",
    "1.31",
    "1.31.0",
    "1.31.1",
    "1.32.0"
  ]
]
```

The latest is gone. I think we should setup image in github container
registry for CI if possible.

Signed-off-by: Wei Fu <fuweid89@gmail.com>