### PR TITLE
fix TestSetOOMScoreBoundaries and replace missing busybox image in CI

### DIFF
--- a/integration/client/client_unix_test.go
+++ b/integration/client/client_unix_test.go
@@ -32,7 +32,7 @@ const (
 )
 
 var (
-	testImage    = "mirror.gcr.io/library/busybox:latest"
+	testImage    = "mirror.gcr.io/library/busybox:1.32.0"
 	shortCommand = withProcessArgs("true")
 	longCommand  = withProcessArgs("/bin/sh", "-c", "while true; do sleep 1; done")
 )

--- a/sys/oom_linux.go
+++ b/sys/oom_linux.go
@@ -65,7 +65,8 @@ func SetOOMScore(pid, score int) error {
 	return nil
 }
 
-// GetOOMScoreAdj gets the oom score for a process
+// GetOOMScoreAdj gets the oom score for a process. It returns 0 (zero) if either
+// no oom score is set, or a sore is set to 0.
 func GetOOMScoreAdj(pid int) (int, error) {
 	path := fmt.Sprintf("/proc/%d/oom_score_adj", pid)
 	data, err := ioutil.ReadFile(path)

--- a/sys/oom_linux_test.go
+++ b/sys/oom_linux_test.go
@@ -71,9 +71,11 @@ func TestSetOOMScoreBoundaries(t *testing.T) {
 
 	score, err := GetOOMScoreAdj(os.Getpid())
 	assert.NilError(t, err)
-	if score == 0 || score == OOMScoreAdjMin {
-		// we won't be able to set the score lower than the parent process,
-		// so only test if parent process does not have a oom-score-adj
+	if score == OOMScoreAdjMin {
+		// We won't be able to set the score lower than the parent process. This
+		// could also be tested if the parent process does not have a oom-score-adj
+		// set, but GetOOMScoreAdj does not distinguish between "not set" and
+		// "score is set, but zero".
 		_, adjustment, err = adjustOom(OOMScoreAdjMin)
 		assert.NilError(t, err)
 		assert.Check(t, is.Equal(adjustment, OOMScoreAdjMin))


### PR DESCRIPTION
updates / closes  https://github.com/containerd/containerd/pull/5320

Introduced in 44240116aa8b4d9e9846a916e94476aef37d60ae / https://github.com/containerd/containerd/pull/5253
To address the failure described in https://github.com/containerd/containerd/pull/5320#issuecomment-815624208


Setting the oom-score-adj to -1000 is only possible if the parent process
either has no score set, or if the score is set to -1000.

However, the current implementation of GetOOMScoreAdj conflates situations
where either _no_ oom-score is set, _or_ oom-score is set, but set to 0.

In the latter case, the test would fail:

    --- FAIL: TestSetOOMScoreBoundaries (0.01s)
        oom_linux_test.go:79: assertion failed: 0 (adjustment int) != -1000 (OOMScoreAdjMin int)
    FAIL

To prevent failures in this situation, skip that part of the test in the
above situation.

Also update the description of GetOOMScoreAdj to clarify its behavior.

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>