### PR TITLE
Revert "remove two very old no longer used runtime options"

### DIFF
--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -124,6 +124,16 @@ version = 2
     # default_runtime_name is the default runtime name to use.
     default_runtime_name = "runc"
 
+    # 'plugins."io.containerd.grpc.v1.cri".containerd.default_runtime' is the runtime to use in containerd.
+    # DEPRECATED: use `default_runtime_name` and `plugins."io.containerd.grpc.v1.cri".runtimes` instead.
+    # Remove in containerd 1.4.
+    [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
+
+    # 'plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime' is a runtime to run untrusted workloads on it.
+    # DEPRECATED: use `untrusted` runtime in `plugins."io.containerd.grpc.v1.cri".runtimes` instead.
+    # Remove in containerd 1.4.
+    [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
+
     # 'plugins."io.containerd.grpc.v1.cri".containerd.runtimes' is a map from CRI RuntimeHandler strings, which specify types
     # of runtime configurations, to the matching configurations.
     # In this example, 'runc' is the RuntimeHandler string to match.

--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -64,6 +64,13 @@ type ContainerdConfig struct {
 	Snapshotter string `toml:"snapshotter" json:"snapshotter"`
 	// DefaultRuntimeName is the default runtime name to use from the runtimes table.
 	DefaultRuntimeName string `toml:"default_runtime_name" json:"defaultRuntimeName"`
+	// DefaultRuntime is the default runtime to use in containerd.
+	// This runtime is used when no runtime handler (or the empty string) is provided.
+	// DEPRECATED: use DefaultRuntimeName instead. Remove in containerd 1.4.
+	DefaultRuntime Runtime `toml:"default_runtime" json:"defaultRuntime"`
+	// UntrustedWorkloadRuntime is a runtime to run untrusted workloads on it.
+	// DEPRECATED: use `untrusted` runtime in Runtimes instead. Remove in containerd 1.4.
+	UntrustedWorkloadRuntime Runtime `toml:"untrusted_workload_runtime" json:"untrustedWorkloadRuntime"`
 	// Runtimes is a map from CRI RuntimeHandler strings, which specify types of runtime
 	// configurations, to the matching configurations.
 	Runtimes map[string]Runtime `toml:"runtimes" json:"runtimes"`
@@ -298,6 +305,22 @@ const (
 func ValidatePluginConfig(ctx context.Context, c *PluginConfig) error {
 	if c.ContainerdConfig.Runtimes == nil {
 		c.ContainerdConfig.Runtimes = make(map[string]Runtime)
+	}
+
+	// Validation for deprecated untrusted_workload_runtime.
+	if c.ContainerdConfig.UntrustedWorkloadRuntime.Type != "" {
+		log.G(ctx).Warning("`untrusted_workload_runtime` is deprecated, please use `untrusted` runtime in `runtimes` instead")
+		if _, ok := c.ContainerdConfig.Runtimes[RuntimeUntrusted]; ok {
+			return errors.Errorf("conflicting definitions: configuration includes both `untrusted_workload_runtime` and `runtimes[%q]`", RuntimeUntrusted)
+		}
+		c.ContainerdConfig.Runtimes[RuntimeUntrusted] = c.ContainerdConfig.UntrustedWorkloadRuntime
+	}
+
+	// Validation for deprecated default_runtime field.
+	if c.ContainerdConfig.DefaultRuntime.Type != "" {
+		log.G(ctx).Warning("`default_runtime` is deprecated, please use `default_runtime_name` to reference the default configuration you have defined in `runtimes`")
+		c.ContainerdConfig.DefaultRuntimeName = RuntimeDefault
+		c.ContainerdConfig.Runtimes[RuntimeDefault] = c.ContainerdConfig.DefaultRuntime
 	}
 
 	// Validation for default_runtime_name

--- a/pkg/cri/config/config_test.go
+++ b/pkg/cri/config/config_test.go
@@ -31,6 +31,78 @@ func TestValidateConfig(t *testing.T) {
 		expectedErr string
 		expected    *PluginConfig
 	}{
+		"deprecated untrusted_workload_runtime": {
+			config: &PluginConfig{
+				ContainerdConfig: ContainerdConfig{
+					DefaultRuntimeName: RuntimeDefault,
+					UntrustedWorkloadRuntime: Runtime{
+						Type: "untrusted",
+					},
+					Runtimes: map[string]Runtime{
+						RuntimeDefault: {
+							Type: "default",
+						},
+					},
+				},
+			},
+			expected: &PluginConfig{
+				ContainerdConfig: ContainerdConfig{
+					DefaultRuntimeName: RuntimeDefault,
+					UntrustedWorkloadRuntime: Runtime{
+						Type: "untrusted",
+					},
+					Runtimes: map[string]Runtime{
+						RuntimeUntrusted: {
+							Type: "untrusted",
+						},
+						RuntimeDefault: {
+							Type: "default",
+						},
+					},
+				},
+			},
+		},
+		"both untrusted_workload_runtime and runtime[untrusted]": {
+			config: &PluginConfig{
+				ContainerdConfig: ContainerdConfig{
+					DefaultRuntimeName: RuntimeDefault,
+					UntrustedWorkloadRuntime: Runtime{
+						Type: "untrusted-1",
+					},
+					Runtimes: map[string]Runtime{
+						RuntimeUntrusted: {
+							Type: "untrusted-2",
+						},
+						RuntimeDefault: {
+							Type: "default",
+						},
+					},
+				},
+			},
+			expectedErr: fmt.Sprintf("conflicting definitions: configuration includes both `untrusted_workload_runtime` and `runtimes[%q]`", RuntimeUntrusted),
+		},
+		"deprecated default_runtime": {
+			config: &PluginConfig{
+				ContainerdConfig: ContainerdConfig{
+					DefaultRuntime: Runtime{
+						Type: "default",
+					},
+				},
+			},
+			expected: &PluginConfig{
+				ContainerdConfig: ContainerdConfig{
+					DefaultRuntime: Runtime{
+						Type: "default",
+					},
+					DefaultRuntimeName: RuntimeDefault,
+					Runtimes: map[string]Runtime{
+						RuntimeDefault: {
+							Type: "default",
+						},
+					},
+				},
+			},
+		},
 		"no default_runtime_name": {
 			config:      &PluginConfig{},
 			expectedErr: "`default_runtime_name` is empty",


### PR DESCRIPTION
Must be reverted due to discovery of v1 configs using v1 default runtimes
Reverts containerd/containerd#5303