### PR TITLE
Fix backword-compatibility issue of non-versioned config file

### DIFF
--- a/cmd/containerd/command/config.go
+++ b/cmd/containerd/command/config.go
@@ -120,7 +120,11 @@ var configCommand = cli.Command{
 
 func platformAgnosticDefaultConfig() *srvconfig.Config {
 	return &srvconfig.Config{
-		Version: 2,
+		// see: https://github.com/containerd/containerd/blob/5c6ea7fdc1247939edaddb1eba62a94527418687/RELEASES.md#daemon-configuration
+		// this version MUST remain set to 1 until either there exists a means to
+		// override / configure the default at the containerd cli .. or when
+		// version 1 is no longer supported
+		Version: 1,
 		Root:    defaults.DefaultRootDir,
 		State:   defaults.DefaultStateDir,
 		GRPC: srvconfig.GRPCConfig{

--- a/services/server/config/config.go
+++ b/services/server/config/config.go
@@ -98,6 +98,7 @@ func (c *Config) ValidateV2() error {
 	version := c.GetVersion()
 	if version < 2 {
 		logrus.Warnf("deprecated version : `%d`, please switch to version `2`", version)
+		return nil
 	}
 	for _, p := range c.DisabledPlugins {
 		if len(strings.Split(p, ".")) < 4 {

--- a/services/server/config/config_test.go
+++ b/services/server/config/config_test.go
@@ -207,3 +207,29 @@ version = 2
 	assert.NilError(t, err)
 	assert.Equal(t, true, pluginConfig["shim_debug"])
 }
+
+// TestDecodePluginInV1Config tests decoding non-versioned
+// config (should be parsed as V1 config).
+func TestDecodePluginInV1Config(t *testing.T) {
+	data := `
+[plugins.linux]
+  shim_debug = true
+`
+
+	tempDir, err := ioutil.TempDir("", "containerd_")
+	assert.NilError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	path := filepath.Join(tempDir, "config.toml")
+	err = ioutil.WriteFile(path, []byte(data), 0600)
+	assert.NilError(t, err)
+
+	var out Config
+	err = LoadConfig(path, &out)
+	assert.NilError(t, err)
+
+	pluginConfig := map[string]interface{}{}
+	_, err = out.Decode(&plugin.Registration{ID: "linux", Config: &pluginConfig})
+	assert.NilError(t, err)
+	assert.Equal(t, true, pluginConfig["shim_debug"])
+}


### PR DESCRIPTION
Related: https://github.com/containerd/containerd/pull/5335

According to [the doc about `config.toml`](https://github.com/containerd/containerd/blob/5c6ea7fdc1247939edaddb1eba62a94527418687/RELEASES.md#daemon-configuration) of containerd:

```
If no version number is specified inside the config file then it is assumed to be a version 1 config and parsed as such.
```

However, it's not true recently.

```console
# cat <<EOF > /tmp/config.toml
[plugins]
  [plugins.overlayfs]
    root_path = "/dummy"
EOF
# containerd --config=/tmp/config.toml
containerd: failed to load TOML from /tmp/config.toml: invalid plugin key URI "overlayfs" expect io.containerd.x.vx
```

This will break the backward-compatibility in some environment (e.g. [stargz-snapshotter project CI](https://github.com/containerd/stargz-snapshotter/runs/2329093209?check_suite_focus=true#step:4:1358)).
This commit fixes this issue.

cc @dims @AkihiroSuda @mikebrow @kzys 
