### PR TITLE
converter: use OpenWriter helper function

### DIFF
--- a/images/converter/uncompress/uncompress.go
+++ b/images/converter/uncompress/uncompress.go
@@ -55,7 +55,7 @@ func LayerConvertFunc(ctx context.Context, cs content.Store, desc ocispec.Descri
 	}
 	defer newR.Close()
 	ref := fmt.Sprintf("convert-uncompress-from-%s", desc.Digest)
-	w, err := cs.Writer(ctx, content.WithRef(ref))
+	w, err := content.OpenWriter(ctx, cs, content.WithRef(ref))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When several goroutines call uncompress converter in parallel, the ref name conflicts with each other. This leads to Writer method failing with Unavaliable error  without retry.
For solving this issue, OpenWriter helper should be used. This allows them to retry in such situations.
