### PR TITLE
Runtime cleanup

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -63,14 +63,14 @@ type PlatformRuntime interface {
 	// ID of the runtime
 	ID() string
 	// Create creates a task with the provided id and options.
-	Create(ctx context.Context, id string, opts CreateOpts) (Task, error)
+	Create(ctx context.Context, taskID string, opts CreateOpts) (Task, error)
 	// Get returns a task.
-	Get(context.Context, string) (Task, error)
+	Get(ctx context.Context, taskID string) (Task, error)
 	// Tasks returns all the current tasks for the runtime.
 	// Any container runs at most one task at a time.
-	Tasks(context.Context, bool) ([]Task, error)
+	Tasks(ctx context.Context, all bool) ([]Task, error)
 	// Add adds a task into runtime.
-	Add(context.Context, Task) error
+	Add(ctx context.Context, task Task) error
 	// Delete remove a task.
-	Delete(context.Context, string)
+	Delete(ctx context.Context, taskID string)
 }

--- a/runtime/task.go
+++ b/runtime/task.go
@@ -36,19 +36,19 @@ type Process interface {
 	// ID of the process
 	ID() string
 	// State returns the process state
-	State(context.Context) (State, error)
+	State(ctx context.Context) (State, error)
 	// Kill signals a container
-	Kill(context.Context, uint32, bool) error
-	// Pty resizes the processes pty/console
-	ResizePty(context.Context, ConsoleSize) error
-	// CloseStdin closes the processes stdin
-	CloseIO(context.Context) error
+	Kill(ctx context.Context, signal uint32, all bool) error
+	// ResizePty resizes the processes pty/console
+	ResizePty(ctx context.Context, size ConsoleSize) error
+	// CloseIO closes the processes IO
+	CloseIO(ctx context.Context) error
 	// Start the container's user defined process
-	Start(context.Context) error
+	Start(ctx context.Context) error
 	// Wait for the process to exit
-	Wait(context.Context) (*Exit, error)
+	Wait(ctx context.Context) (*Exit, error)
 	// Delete deletes the process
-	Delete(context.Context) (*Exit, error)
+	Delete(ctx context.Context) (*Exit, error)
 }
 
 // Task is the runtime object for an executing container
@@ -60,21 +60,21 @@ type Task interface {
 	// Namespace that the task exists in
 	Namespace() string
 	// Pause pauses the container process
-	Pause(context.Context) error
+	Pause(ctx context.Context) error
 	// Resume unpauses the container process
-	Resume(context.Context) error
+	Resume(ctx context.Context) error
 	// Exec adds a process into the container
-	Exec(context.Context, string, ExecOpts) (Process, error)
+	Exec(ctx context.Context, id string, opts ExecOpts) (Process, error)
 	// Pids returns all pids
-	Pids(context.Context) ([]ProcessInfo, error)
+	Pids(ctx context.Context) ([]ProcessInfo, error)
 	// Checkpoint checkpoints a container to an image with live system data
-	Checkpoint(context.Context, string, *types.Any) error
+	Checkpoint(ctx context.Context, path string, opts *types.Any) error
 	// Update sets the provided resources to a running task
-	Update(context.Context, *types.Any, map[string]string) error
+	Update(ctx context.Context, resources *types.Any, annotations map[string]string) error
 	// Process returns a process within the task for the provided id
-	Process(context.Context, string) (Process, error)
+	Process(ctx context.Context, id string) (Process, error)
 	// Stats returns runtime specific metrics for a task
-	Stats(context.Context) (*types.Any, error)
+	Stats(ctx context.Context) (*types.Any, error)
 }
 
 // ExecOpts provides additional options for additional processes running in a task

--- a/runtime/v2/example/example.go
+++ b/runtime/v2/example/example.go
@@ -42,7 +42,7 @@ type service struct {
 }
 
 // StartShim is a binary call that executes a new shim returning the address
-func (s *service) StartShim(ctx context.Context, id, containerdBinary, containerdAddress, containerdTTRPCAddress string) (string, error) {
+func (s *service) StartShim(ctx context.Context, opts shim.StartOpts) (string, error) {
 	return "", nil
 }
 

--- a/runtime/v2/runc/v1/service.go
+++ b/runtime/v2/runc/v1/service.go
@@ -126,12 +126,12 @@ func newCommand(ctx context.Context, id, containerdBinary, containerdAddress, co
 	return cmd, nil
 }
 
-func (s *service) StartShim(ctx context.Context, id, containerdBinary, containerdAddress, containerdTTRPCAddress string) (_ string, retErr error) {
-	cmd, err := newCommand(ctx, id, containerdBinary, containerdAddress, containerdTTRPCAddress)
+func (s *service) StartShim(ctx context.Context, opts shim.StartOpts) (_ string, retErr error) {
+	cmd, err := newCommand(ctx, opts.ID, opts.ContainerdBinary, opts.Address, opts.TTRPCAddress)
 	if err != nil {
 		return "", err
 	}
-	address, err := shim.SocketAddress(ctx, containerdAddress, id)
+	address, err := shim.SocketAddress(ctx, opts.Address, opts.ID)
 	if err != nil {
 		return "", err
 	}

--- a/runtime/v2/runc/v2/service.go
+++ b/runtime/v2/runc/v2/service.go
@@ -171,12 +171,12 @@ func readSpec() (*spec, error) {
 	return &s, nil
 }
 
-func (s *service) StartShim(ctx context.Context, id, containerdBinary, containerdAddress, containerdTTRPCAddress string) (_ string, retErr error) {
-	cmd, err := newCommand(ctx, id, containerdBinary, containerdAddress, containerdTTRPCAddress)
+func (s *service) StartShim(ctx context.Context, opts shim.StartOpts) (_ string, retErr error) {
+	cmd, err := newCommand(ctx, opts.ID, opts.ContainerdBinary, opts.Address, opts.TTRPCAddress)
 	if err != nil {
 		return "", err
 	}
-	grouping := id
+	grouping := opts.ID
 	spec, err := readSpec()
 	if err != nil {
 		return "", err
@@ -187,7 +187,7 @@ func (s *service) StartShim(ctx context.Context, id, containerdBinary, container
 			break
 		}
 	}
-	address, err := shim.SocketAddress(ctx, containerdAddress, grouping)
+	address, err := shim.SocketAddress(ctx, opts.Address, grouping)
 	if err != nil {
 		return "", err
 	}

--- a/runtime/v2/shim/shim.go
+++ b/runtime/v2/shim/shim.go
@@ -51,6 +51,14 @@ type Publisher interface {
 	io.Closer
 }
 
+// StartOpts describes shim start configuration received from containerd
+type StartOpts struct {
+	ID               string
+	ContainerdBinary string
+	Address          string
+	TTRPCAddress     string
+}
+
 // Init func for the creation of a shim server
 type Init func(context.Context, string, Publisher, func()) (Shim, error)
 
@@ -58,7 +66,7 @@ type Init func(context.Context, string, Publisher, func()) (Shim, error)
 type Shim interface {
 	shimapi.TaskService
 	Cleanup(ctx context.Context) (*shimapi.DeleteResponse, error)
-	StartShim(ctx context.Context, id, containerdBinary, containerdAddress, containerdTTRPCAddress string) (string, error)
+	StartShim(ctx context.Context, opts StartOpts) (string, error)
 }
 
 // OptsKey is the context key for the Opts value.
@@ -219,7 +227,13 @@ func run(id string, initFunc Init, config Config) error {
 		}
 		return nil
 	case "start":
-		address, err := service.StartShim(ctx, idFlag, containerdBinaryFlag, addressFlag, ttrpcAddress)
+		opts := StartOpts{
+			ID:               idFlag,
+			ContainerdBinary: containerdBinaryFlag,
+			Address:          addressFlag,
+			TTRPCAddress:     ttrpcAddress,
+		}
+		address, err := service.StartShim(ctx, opts)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
A few minor runtime changes:
- b83d04f adds variable names to runtime's interface definitions to ease readability.
- 993b863 extracts out `ShimStart` params into a separate structure `shim.StartOpts`. This will make easier adding new options and keep backward compatibility. For instance, turns out we [pass shim runtime options via Stdin](https://github.com/containerd/containerd/blob/master/runtime/v2/shim/util.go#L116), but don't really use those in the shim itself. I think we should expose this option in 1.6.