### PR TITLE
freebsd: runtime support

### DIFF
--- a/runtime/v2/binary.go
+++ b/runtime/v2/binary.go
@@ -133,11 +133,13 @@ func (b *binary) Start(ctx context.Context, opts *types.Any, onClose func()) (_ 
 func (b *binary) Delete(ctx context.Context) (*runtime.Exit, error) {
 	log.G(ctx).Info("cleaning up dead shim")
 
-	// Windows cannot delete the current working directory while an
-	// executable is in use with it. For the cleanup case we invoke with the
-	// default work dir and forward the bundle path on the cmdline.
+	// On Windows and FreeBSD, the current working directory of the shim should
+	// not be the bundle path during the delete operation.  Instead, we invoke
+	// with the default work dir and forward the bundle path on the cmdline.
+	// Windows cannot delete the current working directory while an executable
+	// is in use with it. On FreeBSD, fork/exec can fail.
 	var bundlePath string
-	if gruntime.GOOS != "windows" {
+	if gruntime.GOOS != "windows" && gruntime.GOOS != "freebsd" {
 		bundlePath = b.bundle.Path
 	}
 
@@ -160,6 +162,7 @@ func (b *binary) Delete(ctx context.Context) (*runtime.Exit, error) {
 	cmd.Stdout = out
 	cmd.Stderr = errb
 	if err := cmd.Run(); err != nil {
+		log.G(ctx).WithField("cmd", cmd).WithError(err).Error("failed to delete")
 		return nil, errors.Wrapf(err, "%s", errb.String())
 	}
 	s := errb.String()

--- a/services/tasks/local_freebsd.go
+++ b/services/tasks/local_freebsd.go
@@ -1,4 +1,4 @@
-// +build !windows,!freebsd
+// +build freebsd
 
 /*
    Copyright The containerd Authors.
@@ -19,38 +19,17 @@
 package tasks
 
 import (
-	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/runtime"
-	"github.com/pkg/errors"
 )
 
 var tasksServiceRequires = []plugin.Type{
-	plugin.RuntimePlugin,
 	plugin.RuntimePluginV2,
 	plugin.MetadataPlugin,
 	plugin.TaskMonitorPlugin,
 }
 
+// loadV1Runtimes on FreeBSD returns an empty map. There are no v1 runtimes
 func loadV1Runtimes(ic *plugin.InitContext) (map[string]runtime.PlatformRuntime, error) {
-	rt, err := ic.GetByType(plugin.RuntimePlugin)
-	if err != nil {
-		return nil, err
-	}
-
-	runtimes := make(map[string]runtime.PlatformRuntime)
-	for _, rr := range rt {
-		ri, err := rr.Instance()
-		if err != nil {
-			log.G(ic.Context).WithError(err).Warn("could not load runtime instance due to initialization error")
-			continue
-		}
-		r := ri.(runtime.PlatformRuntime)
-		runtimes[r.ID()] = r
-	}
-
-	if len(runtimes) == 0 {
-		return nil, errors.New("no runtimes available to create task service")
-	}
-	return runtimes, nil
+	return make(map[string]runtime.PlatformRuntime), nil
 }


### PR DESCRIPTION
This PR contains two commits adding runtime support for FreeBSD.  These commits are usable with [runj](https://github.com/samuelkarp/runj) and the `containerd-shim-runj-v1` shim.

