### PR TITLE
freebsd: add zfs to the default plugins

### DIFF
--- a/cmd/containerd/builtins_freebsd.go
+++ b/cmd/containerd/builtins_freebsd.go
@@ -1,0 +1,19 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import _ "github.com/containerd/zfs/plugin"


### PR DESCRIPTION
~Note: this PR will remain in draft until https://github.com/containerd/zfs/pull/43 https://github.com/containerd/containerd/pull/5380 is merged.~

```
$ sudo ctr run \
    --snapshotter=native \
    --runtime wtf.sbk.runj.v1 \
    --rm \
    public.ecr.aws/samuelkarp/freebsd:12.1-RELEASE test-native mount
/var/lib/containerd/io.containerd.snapshotter.v1.native/snapshots/153 on / (nullfs, local)
$ sudo ctr run \
    --snapshotter=zfs \
    --runtime wtf.sbk.runj.v1 \
    --rm \
    public.ecr.aws/samuelkarp/freebsd:12.1-RELEASE test-zfs mount   
zroot/containerd/4 on / (zfs, local, noatime, nfsv4acls)
```