### PR TITLE
Cleanup code

### DIFF
--- a/pkg/process/io.go
+++ b/pkg/process/io.go
@@ -252,14 +252,6 @@ func NewBinaryIO(ctx context.Context, id string, uri *url.URL) (_ runc.IO, err e
 		return nil, err
 	}
 
-	var args []string
-	for k, vs := range uri.Query() {
-		args = append(args, k)
-		if len(vs) > 0 {
-			args = append(args, vs[0])
-		}
-	}
-
 	var closers []func() error
 	defer func() {
 		if err == nil {
@@ -290,12 +282,7 @@ func NewBinaryIO(ctx context.Context, id string, uri *url.URL) (_ runc.IO, err e
 	}
 	closers = append(closers, r.Close, w.Close)
 
-	cmd := exec.Command(uri.Path, args...)
-	cmd.Env = append(cmd.Env,
-		"CONTAINER_ID="+id,
-		"CONTAINER_NAMESPACE="+ns,
-	)
-
+	cmd := NewBinaryCmd(uri, id, ns)
 	cmd.ExtraFiles = append(cmd.ExtraFiles, out.r, serr.r, w)
 	// don't need to register this with the reaper or wait when
 	// running inside a shim

--- a/pkg/process/io_util.go
+++ b/pkg/process/io_util.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package runtime
+package process
 
 import (
 	"net/url"

--- a/runtime/v1/shim/service_linux.go
+++ b/runtime/v1/shim/service_linux.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/containerd/console"
 	"github.com/containerd/containerd/namespaces"
-	"github.com/containerd/containerd/runtime"
+	"github.com/containerd/containerd/pkg/process"
 	"github.com/containerd/fifo"
 	"github.com/pkg/errors"
 )
@@ -75,14 +75,14 @@ func (p *linuxPlatform) CopyConsole(ctx context.Context, console console.Console
 			return nil, err
 		}
 
-		cmd := runtime.NewBinaryCmd(uri, id, ns)
+		cmd := process.NewBinaryCmd(uri, id, ns)
 
 		// In case of unexpected errors during logging binary start, close open pipes
 		var filesToClose []*os.File
 
 		defer func() {
 			if retErr != nil {
-				runtime.CloseFiles(filesToClose...)
+				process.CloseFiles(filesToClose...)
 			}
 		}()
 

--- a/runtime/v1/shim/service_unix.go
+++ b/runtime/v1/shim/service_unix.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/containerd/console"
 	"github.com/containerd/containerd/namespaces"
-	"github.com/containerd/containerd/runtime"
+	"github.com/containerd/containerd/pkg/process"
 	"github.com/containerd/fifo"
 	"github.com/pkg/errors"
 )
@@ -63,15 +63,14 @@ func (p *unixPlatform) CopyConsole(ctx context.Context, console console.Console,
 		if err != nil {
 			return nil, err
 		}
-
-		cmd := runtime.NewBinaryCmd(uri, id, ns)
+		cmd := process.NewBinaryCmd(uri, id, ns)
 
 		// In case of unexpected errors during logging binary start, close open pipes
 		var filesToClose []*os.File
 
 		defer func() {
 			if retErr != nil {
-				runtime.CloseFiles(filesToClose...)
+				process.CloseFiles(filesToClose...)
 			}
 		}()
 

--- a/runtime/v2/runc/platform.go
+++ b/runtime/v2/runc/platform.go
@@ -28,8 +28,8 @@ import (
 
 	"github.com/containerd/console"
 	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/pkg/process"
 	"github.com/containerd/containerd/pkg/stdio"
-	"github.com/containerd/containerd/runtime"
 	"github.com/containerd/fifo"
 	"github.com/pkg/errors"
 )
@@ -99,14 +99,14 @@ func (p *linuxPlatform) CopyConsole(ctx context.Context, console console.Console
 			return nil, err
 		}
 
-		cmd := runtime.NewBinaryCmd(uri, id, ns)
+		cmd := process.NewBinaryCmd(uri, id, ns)
 
 		// In case of unexpected errors during logging binary start, close open pipes
 		var filesToClose []*os.File
 
 		defer func() {
 			if retErr != nil {
-				runtime.CloseFiles(filesToClose...)
+				process.CloseFiles(filesToClose...)
 			}
 		}()
 


### PR DESCRIPTION
Clean up the code, move `runtime.NewBinaryCmd` to `process.NewBinaryCmd` and use `process.NewBinaryCmd` directly 

https://github.com/containerd/containerd/blob/bbbd851381338e96eea77abb3dd14a3d2f18b9f3/runtime/io.go#L25-L45
