### PR TITLE
[release/1.4] update Go to 1.15.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.15.8'
+          go-version: '1.15.11'
 
       - name: Set env
         shell: bash
@@ -81,7 +81,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.15.8'
+          go-version: '1.15.11'
 
       - name: Set env
         shell: bash
@@ -128,7 +128,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.15.8'
+          go-version: '1.15.11'
 
       - name: Set env
         shell: bash
@@ -165,7 +165,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.15.8'
+          go-version: '1.15.11'
 
       - name: Set env
         shell: bash
@@ -197,7 +197,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.15.8'
+          go-version: '1.15.11'
 
       - name: Set env
         shell: bash
@@ -277,7 +277,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.15.8'
+          go-version: '1.15.11'
 
       - name: Set env
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.15.8'
+          go-version: '1.15.11'
 
       - name: Checkout
         uses: actions/checkout@v1
@@ -136,7 +136,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.15.8'
+          go-version: '1.15.11'
 
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,7 +53,11 @@ jobs:
             libseccomp-dev:amd64 \
             libseccomp-dev:arm64 \
             libseccomp-dev:s390x \
-            libseccomp-dev:ppc64el
+            libseccomp-dev:ppc64el \
+            libbtrfs-dev:amd64 \
+            libbtrfs-dev:arm64 \
+            libbtrfs-dev:s390x \
+            libbtrfs-dev:ppc64el
 
       - name: Build amd64
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.15.8'
+          go-version: '1.15.11'
 
       - name: Set env
         shell: bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ os:
 - linux
 
 go:
-  - "1.15.8"
+  - "1.15.11"
 
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct

--- a/.zuul/playbooks/containerd-build/run.yaml
+++ b/.zuul/playbooks/containerd-build/run.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.15.8'
+    go_version: '1.15.11'
     arch: arm64
   tasks:
   - name: Build containerd

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,7 +77,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.15.8",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.15.11",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -10,7 +10,7 @@
 #
 # docker build -t containerd-test --build-arg RUNC_VERSION=v1.0.0-rc93 -f Dockerfile.test ../
 
-ARG GOLANG_VERSION=1.15.8
+ARG GOLANG_VERSION=1.15.11
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd


### PR DESCRIPTION
This patch is specific for the 1.4 release-branch, which is not on Go1.16, and
brings the branch to the latest patch release of Go 1.15

full diff: https://github.com/golang/go/compare/go1.15.8...go1.15.11

go1.15.9 (released 2021/03/10) includes security fixes to the encoding/xml
package. See the Go 1.15.9 milestone on our issue tracker for details.
https://github.com/golang/go/issues?q=milestone%3AGo1.15.9+label%3ACherryPickApproved

go1.15.10 (released 2021/03/11) includes fixes to the compiler, the go command,
and the net/http, os, syscall, and time packages. See the Go 1.15.10 milestone
on our issue tracker for details.
https://github.com/golang/go/issues?q=milestone%3AGo1.15.10+label%3ACherryPickApproved

go1.15.11 (released 2021/04/01) includes fixes to cgo, the compiler, linker,
runtime, the go command, and the database/sql and net/http packages. See the Go
1.15.11 milestone on our issue tracker for details.
https://github.com/golang/go/issues?q=milestone%3AGo1.15.11+label%3ACherryPickApproved
