### PR TITLE
[release/1.4] backport some github-action changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
           GO111MODULE: off
         working-directory: src/github.com/containerd/containerd
         run: |
-          sudo env PATH=$PATH GOPATH=$GOPATH script/setup/install-protobuf
+          sudo -E PATH=$PATH script/setup/install-protobuf
           sudo chmod +x /usr/local/bin/protoc
           sudo chmod og+rx /usr/local/include/google /usr/local/include/google/protobuf /usr/local/include/google/protobuf/compiler
           sudo chmod -R og+r /usr/local/include/google/protobuf/
@@ -317,7 +317,7 @@ jobs:
           CGO_ENABLED: 1
         run: |
           make binaries
-          sudo make install
+          sudo -E PATH=$PATH make install
         working-directory: src/github.com/containerd/containerd
 
       - name: Tests
@@ -326,7 +326,7 @@ jobs:
           SKIPTESTS: github.com/containerd/containerd/snapshots/devmapper
         run: |
           make test
-          sudo -E PATH=$PATH GOPATH=$GOPATH GOPROXY=$GOPROXY make root-test
+          sudo -E PATH=$PATH make root-test
         working-directory: src/github.com/containerd/containerd
 
       - name: Integration 1
@@ -335,7 +335,7 @@ jobs:
           TEST_RUNTIME: ${{ matrix.runtime }}
           RUNC_FLAVOR: ${{ matrix.runc }}
         run: |
-          sudo GOPATH=$GOPATH GOPROXY=$GOPROXY TEST_RUNTIME=$TEST_RUNTIME RUNC_FLAVOR=$RUNC_FLAVOR make integration EXTRA_TESTFLAGS=-no-criu TESTFLAGS_RACE=-race
+          sudo -E PATH=$PATH make integration EXTRA_TESTFLAGS=-no-criu TESTFLAGS_RACE=-race
         working-directory: src/github.com/containerd/containerd
 
       # Run the integration suite a second time. See discussion in github.com/containerd/containerd/pull/1759
@@ -345,7 +345,7 @@ jobs:
           TEST_RUNTIME: ${{ matrix.runtime }}
           RUNC_FLAVOR: ${{ matrix.runc }}
         run: |
-          sudo GOPATH=$GOPATH GOPROXY=$GOPROXY TEST_RUNTIME=$TEST_RUNTIME RUNC_FLAVOR=$RUNC_FLAVOR TESTFLAGS_PARALLEL=1 make integration EXTRA_TESTFLAGS=-no-criu
+          sudo -E PATH=$PATH TESTFLAGS_PARALLEL=1 make integration EXTRA_TESTFLAGS=-no-criu
         working-directory: src/github.com/containerd/containerd
 
       - name: CRI test
@@ -359,13 +359,13 @@ jobs:
               runtime_type = "${TEST_RUNTIME}"
           EOF
           sudo ls /etc/cni/net.d
-          sudo PATH=$PATH BDIR=$BDIR /usr/local/bin/containerd -a ${BDIR}/c.sock --config ${BDIR}/config.toml --root ${BDIR}/root --state ${BDIR}/state --log-level debug &> ${BDIR}/containerd-cri.log &
-          sudo PATH=$PATH BDIR=$BDIR /usr/local/bin/ctr -a ${BDIR}/c.sock version
-          sudo PATH=$PATH BDIR=$BDIR GOPATH=$GOPATH critest --runtime-endpoint=unix:///${BDIR}/c.sock --parallel=8
+          sudo -E PATH=$PATH /usr/local/bin/containerd -a ${BDIR}/c.sock --config ${BDIR}/config.toml --root ${BDIR}/root --state ${BDIR}/state --log-level debug &> ${BDIR}/containerd-cri.log &
+          sudo -E PATH=$PATH /usr/local/bin/ctr -a ${BDIR}/c.sock version
+          sudo -E PATH=$PATH critest --runtime-endpoint=unix:///${BDIR}/c.sock --parallel=8
           TEST_RC=$?
           test $TEST_RC -ne 0 && cat ${BDIR}/containerd-cri.log
           sudo pkill containerd
-          sudo BDIR=$BDIR rm -rf ${BDIR}
+          sudo -E rm -rf ${BDIR}
           test $TEST_RC -eq 0 || /bin/false
 
   cgroup2:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Install Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: '1.15.11'
 
@@ -78,8 +78,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v1
+      - uses: actions/setup-go@v2
         with:
           go-version: '1.15.11'
 
@@ -125,8 +124,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v1
+      - uses: actions/setup-go@v2
         with:
           go-version: '1.15.11'
 
@@ -162,8 +160,7 @@ jobs:
         os: [ubuntu-18.04, macos-10.15, windows-2019]
 
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v1
+      - uses: actions/setup-go@v2
         with:
           go-version: '1.15.11'
 
@@ -194,8 +191,7 @@ jobs:
     needs: [project, linters, protos, man]
 
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v1
+      - uses: actions/setup-go@v2
         with:
           go-version: '1.15.11'
 
@@ -274,8 +270,7 @@ jobs:
             runc: crun
 
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v1
+      - uses: actions/setup-go@v2
         with:
           go-version: '1.15.11'
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,8 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v1
+      - uses: actions/setup-go@v2
         with:
           go-version: '1.15.11'
 
@@ -133,8 +132,7 @@ jobs:
     name: Windows
     runs-on: windows-latest
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v1
+      - uses: actions/setup-go@v2
         with:
           go-version: '1.15.11'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Install Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: '1.15.11'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,7 @@ jobs:
             sudo install -m 644 containerd.service ${DESTDIR}/etc/systemd/system
             echo "CONTAINERD_VERSION: '${RELEASE_VER#v}'" | sudo tee ${DESTDIR}/opt/containerd/cluster/version
 
-            sudo PATH=$PATH script/setup/install-seccomp
+            sudo -E PATH=$PATH script/setup/install-seccomp
             USESUDO=true script/setup/install-runc
             script/setup/install-cni
             script/setup/install-critools


### PR DESCRIPTION
partial backports of:

- https://github.com/containerd/containerd/pull/5011 GHA: use setup-go@v2 
- https://github.com/containerd/containerd/pull/4741 gha: use sudo -E in some places to prevent dropping env-vars

### cherry-picks didn't apply clean (which was to be expected), so I made some modifications

To get a clean cherry-pick we'd have to backport a lot more changes, which I don't think is worth the effort, but we can update other changes manually if we think it's worth it