### PR TITLE
Prepare 1.5.0-rc.2 release notes

### DIFF
--- a/releases/v1.5.0-rc.toml
+++ b/releases/v1.5.0-rc.toml
@@ -48,6 +48,7 @@ brings support for the Node Resource Interface (NRI).
 #### Runtime
 * **Add annotations to containerd task update API** [#4647](https://github.com/containerd/containerd/pull/4647)
 * **Add logging binary support when terminal is true** [#4502](https://github.com/containerd/containerd/pull/4502)
+* **Runtime support on FreeBSD** [#5375](https://github.com/containerd/containerd/pull/5375)
 
 #### Windows
 * **Optimize LCOW snapshotter use of scratch layers** [#4643](https://github.com/containerd/containerd/pull/4643)

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.5.0-rc.1+unknown"
+	Version = "1.5.0-rc.2+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Last rc, after https://github.com/containerd/containerd/pull/5393