### PR TITLE
add check quiet option and update usage 

### DIFF
--- a/cmd/ctr/commands/images/images.go
+++ b/cmd/ctr/commands/images/images.go
@@ -199,9 +199,9 @@ var setLabelsCommand = cli.Command{
 
 var checkCommand = cli.Command{
 	Name:        "check",
-	Usage:       "check that an image has all content available locally",
+	Usage:       "check existing images to ensure all content is available locally",
 	ArgsUsage:   "[flags] [<filter>, ...]",
-	Description: "check that an image has all content available locally",
+	Description: "check existing images to ensure all content is available locally",
 	Flags:       commands.SnapshotterFlags,
 	Action: func(context *cli.Context) error {
 		var (
@@ -212,17 +212,21 @@ var checkCommand = cli.Command{
 			return err
 		}
 		defer cancel()
-		var (
-			contentStore = client.ContentStore()
-			tw           = tabwriter.NewWriter(os.Stdout, 1, 8, 1, ' ', 0)
-		)
-		fmt.Fprintln(tw, "REF\tTYPE\tDIGEST\tSTATUS\tSIZE\tUNPACKED\t")
+
+		var contentStore = client.ContentStore()
 
 		args := []string(context.Args())
 		imageList, err := client.ListImages(ctx, args...)
 		if err != nil {
 			return errors.Wrap(err, "failed listing images")
 		}
+		if len(imageList) == 0 {
+			log.G(ctx).Debugf("no images found")
+			return exitErr
+		}
+
+		var tw = tabwriter.NewWriter(os.Stdout, 1, 8, 1, ' ', 0)
+		fmt.Fprintln(tw, "REF\tTYPE\tDIGEST\tSTATUS\tSIZE\tUNPACKED\t")
 
 		for _, image := range imageList {
 			var (


### PR DESCRIPTION
resolving issue: https://github.com/containerd/containerd/issues/5352

check command returns errors for some cases when check fails, but not for the case when the image being checked via filter does not exist.. 

```
   check       check that an image has all content available locally
```

we should fix or.. document and maybe add another sub command for the desired check  

...

After discussion with Derek decision is to document existing usage a little better, and add a -q quiet option to output only the images that are ready.  Idea being that script writers can then use `wc -l` and check for non-zero ... etc.

example outputs after changes:
```
mike@mike-VirtualBox:~/go/src/github.com/containerd/containerd$ sudo bin/ctr i check --help
NAME:
   ctr images check - check existing images to ensure all content is available locally

USAGE:
   ctr images check [command options] [flags] [<filter>, ...]

DESCRIPTION:
   check existing images to ensure all content is available locally

OPTIONS:
   --quiet, -q          print only the ready image refs (fully downloaded and unpacked)
   --snapshotter value  snapshotter name. Empty value stands for the default value. [$CONTAINERD_SNAPSHOTTER]

```

```
mike@mike-VirtualBox:~/go/src/github.com/containerd/containerd$ sudo bin/ctr i check -q 
docker.io/library/busybox:latest
docker.io/library/nats-streaming:0.11.2
docker.io/library/redis:alpine
```

```
mike@mike-VirtualBox:~/go/src/github.com/containerd/containerd$ sudo bin/ctr i check name==docker.io/library/busybox:latest -q | wc -l
1
mike@mike-VirtualBox:~/go/src/github.com/containerd/containerd$ sudo bin/ctr i check name==docker.io/library/busybox:ss -q | wc -l
0
```

Signed-off-by: Mike Brown <brownwm@us.ibm.com>