### PR TITLE
Use busybox from GHCR

### DIFF
--- a/integration/addition_gids_test.go
+++ b/integration/addition_gids_test.go
@@ -46,7 +46,7 @@ func TestAdditionalGids(t *testing.T) {
 	}()
 
 	const (
-		testImage     = "busybox"
+		testImage     = BusyBox132Image
 		containerName = "test-container"
 	)
 	t.Logf("Pull test image %q", testImage)
@@ -59,7 +59,7 @@ func TestAdditionalGids(t *testing.T) {
 	t.Log("Create a container to print id")
 	cnConfig := ContainerConfig(
 		containerName,
-		"busybox",
+		testImage,
 		WithCommand("id"),
 		WithLogPath(containerName),
 		WithSupplementalGroups([]int64{1 /*daemon*/, 1234 /*new group*/}),

--- a/integration/client/client_unix_test.go
+++ b/integration/client/client_unix_test.go
@@ -32,7 +32,7 @@ const (
 )
 
 var (
-	testImage    = "mirror.gcr.io/library/busybox:1.32.0"
+	testImage    = "ghcr.io/containerd/busybox:1.32"
 	shortCommand = withProcessArgs("true")
 	longCommand  = withProcessArgs("/bin/sh", "-c", "while true; do sleep 1; done")
 )

--- a/integration/container_log_test.go
+++ b/integration/container_log_test.go
@@ -49,7 +49,7 @@ func TestContainerLogWithoutTailingNewLine(t *testing.T) {
 	}()
 
 	const (
-		testImage     = "busybox"
+		testImage     = BusyBox132Image
 		containerName = "test-container"
 	)
 	t.Logf("Pull test image %q", testImage)
@@ -109,7 +109,7 @@ func TestLongContainerLog(t *testing.T) {
 	}()
 
 	const (
-		testImage     = "busybox"
+		testImage     = BusyBox132Image
 		containerName = "test-container"
 	)
 	t.Logf("Pull test image %q", testImage)

--- a/integration/container_stop_test.go
+++ b/integration/container_stop_test.go
@@ -43,7 +43,7 @@ func TestSharedPidMultiProcessContainerStop(t *testing.T) {
 			}()
 
 			const (
-				testImage     = "busybox"
+				testImage     = BusyBox132Image
 				containerName = "test-container"
 			)
 			t.Logf("Pull test image %q", testImage)
@@ -87,7 +87,7 @@ func TestContainerStopCancellation(t *testing.T) {
 	}()
 
 	const (
-		testImage     = "busybox"
+		testImage     = BusyBox132Image
 		containerName = "test-container"
 	)
 	t.Logf("Pull test image %q", testImage)

--- a/integration/container_without_image_ref_test.go
+++ b/integration/container_without_image_ref_test.go
@@ -38,7 +38,7 @@ func TestContainerLifecycleWithoutImageRef(t *testing.T) {
 	}()
 
 	const (
-		testImage     = "busybox"
+		testImage     = BusyBox132Image
 		containerName = "test-container"
 	)
 	t.Log("Pull test image")

--- a/integration/containerd_image_test.go
+++ b/integration/containerd_image_test.go
@@ -35,7 +35,7 @@ import (
 
 // Test to test the CRI plugin should see image pulled into containerd directly.
 func TestContainerdImage(t *testing.T) {
-	const testImage = "docker.io/library/busybox:latest"
+	const testImage = BusyBox132Image
 	ctx := context.Background()
 
 	t.Logf("make sure the test image doesn't exist in the cri plugin")
@@ -153,7 +153,7 @@ func TestContainerdImage(t *testing.T) {
 
 // Test image managed by CRI plugin shouldn't be affected by images in other namespaces.
 func TestContainerdImageInOtherNamespaces(t *testing.T) {
-	const testImage = "docker.io/library/busybox:latest"
+	const testImage = BusyBox132Image
 	ctx := context.Background()
 
 	t.Logf("make sure the test image doesn't exist in the cri plugin")

--- a/integration/image_load_test.go
+++ b/integration/image_load_test.go
@@ -32,8 +32,7 @@ import (
 
 // Test to load an image from tarball.
 func TestImageLoad(t *testing.T) {
-	testImage := "busybox:latest"
-	loadedImage := "docker.io/library/" + testImage
+	testImage := BusyBox132Image
 	_, err := exec.LookPath("docker")
 	if err != nil {
 		t.Skipf("Docker is not available: %v", err)
@@ -74,7 +73,7 @@ func TestImageLoad(t *testing.T) {
 		}
 		return img != nil, nil
 	}, 100*time.Millisecond, 10*time.Second))
-	require.Equal(t, []string{loadedImage}, img.RepoTags)
+	require.Equal(t, []string{testImage}, img.RepoTags)
 
 	t.Logf("create a container with the loaded image")
 	sbConfig := PodSandboxConfig("sandbox", Randomize("image-load"))

--- a/integration/imagefs_info_test.go
+++ b/integration/imagefs_info_test.go
@@ -33,7 +33,7 @@ func TestImageFSInfo(t *testing.T) {
 	config := PodSandboxConfig("running-pod", "imagefs")
 
 	t.Logf("Pull an image to make sure image fs is not empty")
-	img, err := imageService.PullImage(&runtime.ImageSpec{Image: "busybox"}, nil, config)
+	img, err := imageService.PullImage(&runtime.ImageSpec{Image: BusyBox132Image}, nil, config)
 	require.NoError(t, err)
 	defer func() {
 		err := imageService.RemoveImage(&runtime.ImageSpec{Image: img})

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -48,9 +48,10 @@ import (
 )
 
 const (
-	timeout      = 1 * time.Minute
-	pauseImage   = "k8s.gcr.io/pause:3.5" // This is the same with default sandbox image.
-	k8sNamespace = constants.K8sContainerdNamespace
+	timeout         = 1 * time.Minute
+	pauseImage      = "k8s.gcr.io/pause:3.5" // This is the same with default sandbox image.
+	k8sNamespace    = constants.K8sContainerdNamespace
+	BusyBox132Image = "ghcr.io/containerd/busybox:1.32"
 )
 
 var (

--- a/integration/pod_dualstack_test.go
+++ b/integration/pod_dualstack_test.go
@@ -47,7 +47,7 @@ func TestPodDualStack(t *testing.T) {
 	}()
 
 	const (
-		testImage     = "busybox"
+		testImage     = BusyBox132Image
 		containerName = "test-container"
 	)
 	t.Logf("Pull test image %q", testImage)

--- a/integration/pod_hostname_test.go
+++ b/integration/pod_hostname_test.go
@@ -83,7 +83,7 @@ func TestPodHostname(t *testing.T) {
 			}
 
 			const (
-				testImage     = "busybox"
+				testImage     = BusyBox132Image
 				containerName = "test-container"
 			)
 			t.Logf("Pull test image %q", testImage)

--- a/integration/restart_test.go
+++ b/integration/restart_test.go
@@ -134,7 +134,7 @@ func TestContainerdRestart(t *testing.T) {
 	}
 
 	t.Logf("Pull test images")
-	for _, image := range []string{"busybox", "alpine"} {
+	for _, image := range []string{BusyBox132Image, "alpine"} {
 		img, err := imageService.PullImage(&runtime.ImageSpec{Image: image}, nil, nil)
 		require.NoError(t, err)
 		defer func() {

--- a/integration/truncindex_test.go
+++ b/integration/truncindex_test.go
@@ -34,7 +34,7 @@ func TestTruncIndex(t *testing.T) {
 	sbConfig := PodSandboxConfig("sandbox", "truncindex")
 
 	t.Logf("Pull an image")
-	const appImage = "busybox"
+	const appImage = BusyBox132Image
 	imgID, err := imageService.PullImage(&runtimeapi.ImageSpec{Image: appImage}, nil, sbConfig)
 	require.NoError(t, err)
 	imgTruncID := genTruncIndex(imgID)


### PR DESCRIPTION
I've [uploaded](https://github.com/orgs/containerd/packages/container/package/busybox) `busybox:1.32` to containerd's org container registry.
Let's give it a try in our integration tests.
This will help to offload Docker's registry.

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>