### PR TITLE
process: use the unbuffered channel as the done signal

### DIFF
--- a/pkg/process/utils.go
+++ b/pkg/process/utils.go
@@ -172,7 +172,7 @@ func (p *pidFile) Read() (int, error) {
 func waitTimeout(ctx context.Context, wg *sync.WaitGroup, timeout time.Duration) error {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	done := make(chan struct{}, 1)
+	done := make(chan struct{})
 	go func() {
 		wg.Wait()
 		close(done)


### PR DESCRIPTION
The `done` is used as a signal channel to do notifications by closing, no data will be written, so `done`  does not need to be a buffer channel.