### PR TITLE
New Openlab based job to run ARM64 tests

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -4,6 +4,7 @@
     check:
       jobs:
         - containerd-build-arm64
+        - containerd-test-arm64
 
 - job:
     name: containerd-build-arm64
@@ -11,5 +12,14 @@
     description: |
       Containerd build in openlab cluster.
     run: .zuul/playbooks/containerd-build/run.yaml
+    nodeset: ubuntu-xenial-arm64-openlab
+    voting: false
+
+- job:
+    name: containerd-test-arm64
+    parent: init-test
+    description: |
+      Containerd unit tests in openlab cluster.
+    run: .zuul/playbooks/containerd-build/unit-test.yaml
     nodeset: ubuntu-xenial-arm64-openlab
     voting: false

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -5,6 +5,7 @@
       jobs:
         - containerd-build-arm64
         - containerd-test-arm64
+        - containerd-integration-test-arm64
 
 - job:
     name: containerd-build-arm64
@@ -21,5 +22,14 @@
     description: |
       Containerd unit tests in openlab cluster.
     run: .zuul/playbooks/containerd-build/unit-test.yaml
+    nodeset: ubuntu-xenial-arm64-openlab
+    voting: false
+
+- job:
+    name: containerd-integration-test-arm64
+    parent: init-test
+    description: |
+      Containerd unit tests in openlab cluster.
+    run: .zuul/playbooks/containerd-build/integration-test.yaml
     nodeset: ubuntu-xenial-arm64-openlab
     voting: false

--- a/.zuul/playbooks/containerd-build/integration-test.yaml
+++ b/.zuul/playbooks/containerd-build/integration-test.yaml
@@ -1,0 +1,96 @@
+- hosts: all
+  become: yes
+  roles:
+  - role: config-golang
+    go_version: '1.16.3'
+    arch: arm64
+  tasks:
+  - name: Install pre-requisites
+    shell:
+      cmd: |
+        set -xe
+        set -o pipefail
+        apt-get update
+        apt-get install -y btrfs-tools libseccomp-dev git pkg-config
+
+        go version
+      chdir: '{{ zuul.project.src_dir }}'
+      executable: /bin/bash
+    environment: '{{ global_env }}'
+  - name: Install containerd and cri dependencies
+    shell:
+      cmd: |
+        set -xe
+        make install-deps
+      chdir: '{{ zuul.project.src_dir }}'
+      executable: /bin/bash
+    environment: '{{ global_env }}'
+  - name: Install criu
+    shell:
+      cmd: |
+        set -xe
+        apt-get install -y \
+          libprotobuf-dev \
+          libprotobuf-c-dev \
+          protobuf-c-compiler \
+          protobuf-compiler \
+          python-protobuf \
+          libnl-3-dev \
+          libnet-dev \
+          libcap-dev \
+          python-future
+        wget https://github.com/checkpoint-restore/criu/archive/v3.13.tar.gz -O criu.tar.gz
+        tar -zxf criu.tar.gz
+        cd criu-3.13
+        make install-criu
+      chdir: '{{ zuul.project.src_dir }}'
+      executable: /bin/bash
+    environment: '{{ global_env }}'
+  - name: Install containerd
+    shell:
+      cmd: |
+        set -xe
+        make binaries
+        make install | tee $LOGS_PATH/make_install.log
+      chdir: '{{ zuul.project.src_dir }}'
+      executable: /bin/bash
+    environment: '{{ global_env }}'
+  - name: Tests
+    shell:
+      cmd: |
+        make test | tee $LOGS_PATH/make_test.log
+        make root-test | tee $LOGS_PATH/make_root-test.log
+      chdir: '{{ zuul.project.src_dir }}'
+      executable: /bin/bash
+    environment: '{{ global_env }}'
+  - name: Integration 1
+    shell:
+      cmd: |
+        make integration EXTRA_TESTFLAGS=-no-criu TESTFLAGS_RACE=-race | tee $LOGS_PATH/make_integration-test.log
+      chdir: '{{ zuul.project.src_dir }}'
+      executable: /bin/bash
+    environment: '{{ global_env }}'
+  - name: Integration 2
+    shell:
+      cmd: |
+        TESTFLAGS_PARALLEL=1 make integration EXTRA_TESTFLAGS=-no-criu | tee $LOGS_PATH/make_integration-test.log
+      chdir: '{{ zuul.project.src_dir }}'
+      executable: /bin/bash
+    environment: '{{ global_env }}'
+  - name: CRI Integration Test
+    shell:
+      cmd: |
+        CONTAINERD_RUNTIME="io.containerd.runc.v2" make cri-integration | tee $LOGS_PATH/make_cri-integration-test.log
+      chdir: '{{ zuul.project.src_dir }}'
+      executable: /bin/bash
+    environment: '{{ global_env }}'
+  - name: CRI Integration Test
+    shell:
+      cmd: |
+        if grep -q "FAIL:" $LOGS_PATH/*.log; then
+          echo "FAILURE"
+          exit 1
+        fi
+      chdir: '{{ zuul.project.src_dir }}'
+      executable: /bin/bash
+    environment: '{{ global_env }}'

--- a/.zuul/playbooks/containerd-build/unit-test.yaml
+++ b/.zuul/playbooks/containerd-build/unit-test.yaml
@@ -5,7 +5,7 @@
     go_version: '1.16.3'
     arch: arm64
   tasks:
-  - name: Build containerd
+  - name: Build and test containerd
     shell:
       cmd: |
         set -xe
@@ -14,9 +14,7 @@
         apt-get install -y btrfs-tools libseccomp-dev git pkg-config
 
         go version
-        make | tee $LOGS_PATH/make.txt
-
-        cp -r ./bin $RESULTS_PATH
+        make build test | tee $LOGS_PATH/make_test.txt
       chdir: '{{ zuul.project.src_dir }}'
       executable: /bin/bash
     environment: '{{ global_env }}'


### PR DESCRIPTION
Running the following tests:
```
make test
make root-test
make integration EXTRA_TESTFLAGS=-no-criu TESTFLAGS_RACE=-race
TESTFLAGS_PARALLEL=1 make integration EXTRA_TESTFLAGS=-no-criu
CONTAINERD_RUNTIME="io.containerd.runc.v2" make cri-integration
```

Should be easy to add more as needed or break this into multiple jobs.

NOTE: some tests are failing.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>