### PR TITLE
Add multi-arch support for test images

### DIFF
--- a/integration/images/volume-copy-up/Makefile
+++ b/integration/images/volume-copy-up/Makefile
@@ -15,13 +15,20 @@
 all: build
 
 PROJ=gcr.io/k8s-cri-containerd
-VERSION=1.0
+VERSION=2.0
 IMAGE=$(PROJ)/volume-copy-up:$(VERSION)
+PLATFORMS?=linux/amd64,linux/arm64
+
+configure-docker:
+	gcloud auth configure-docker
 
 build:
-	docker build -t $(IMAGE) .
+	docker buildx build \
+	$(OUTPUT) \
+	--platform=${PLATFORMS} \
+	--tag $(IMAGE) .
 
-push:
-	gcloud docker -- push $(IMAGE)
+push: OUTPUT=--push
+push: configure-docker build
 
-.PHONY: build push
+.PHONY: configure-docker build push

--- a/integration/images/volume-ownership/Dockerfile
+++ b/integration/images/volume-ownership/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM busybox
+FROM ubuntu
 RUN mkdir -p /test_dir && \
     chown -R nobody:nogroup /test_dir
 VOLUME /test_dir

--- a/integration/images/volume-ownership/Makefile
+++ b/integration/images/volume-ownership/Makefile
@@ -15,13 +15,20 @@
 all: build
 
 PROJ=gcr.io/k8s-cri-containerd
-VERSION=1.0
+VERSION=2.0
 IMAGE=$(PROJ)/volume-ownership:$(VERSION)
+PLATFORMS?=linux/amd64,linux/arm64
+
+configure-docker:
+	gcloud auth configure-docker
 
 build:
-	docker build -t $(IMAGE) .
+	docker buildx build \
+	$(OUTPUT) \
+	--platform=${PLATFORMS} \
+	--tag $(IMAGE) .
 
-push:
-	gcloud docker -- push $(IMAGE)
+push: OUTPUT=--push
+push: configure-docker build
 
-.PHONY: build push
+.PHONY: configure-docker build push


### PR DESCRIPTION
- Add a multi-arch image with linux/amd64 and linux/arm64 (limit to just
  what we are running in CI)
- Bump versions to 2.0 as 1.0 is the single-arch image
- Use `docker buildx` instead of just docker, so we don't need to build
  manifests by hand
- busybox now does not have `nogroup`, since the test needs it, switch
  over from busybox to ubuntu for just the volume-ownership image

NOTE: not switching over integration/volume_copy_up_test.go to this newer image yet as it has not yet been pushed to the gcr repo.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>