### PR TITLE
integration tests needs lsof

### DIFF
--- a/.zuul/playbooks/containerd-build/integration-test.yaml
+++ b/.zuul/playbooks/containerd-build/integration-test.yaml
@@ -11,7 +11,7 @@
         set -xe
         set -o pipefail
         apt-get update
-        apt-get install -y btrfs-tools libseccomp-dev git pkg-config
+        apt-get install -y btrfs-tools libseccomp-dev git pkg-config lsof
 
         go version
       chdir: '{{ zuul.project.src_dir }}'


### PR DESCRIPTION
We need/use `lsof` in integration tests:
https://github.com/containerd/containerd/blob/master/integration/client/container_linux_test.go#L493

`TestShimDoesNotLeakPipes` fails if `lsof` is not present

Signed-off-by: Davanum Srinivas <davanum@gmail.com>