### PR TITLE
Use DeactivateLayer to unlock layers that we cannot rename

### DIFF
--- a/snapshots/windows/windows.go
+++ b/snapshots/windows/windows.go
@@ -468,7 +468,7 @@ func (s *snapshotter) createScratchLayer(ctx context.Context, snDir string, pare
 	return nil
 }
 
-// convertScratchToReadOnlyLayer reimporst the layer over itself, to transfer the files from the sandbox.vhdx to the on-disk storage.
+// convertScratchToReadOnlyLayer reimports the layer over itself, to transfer the files from the sandbox.vhdx to the on-disk storage.
 func (s *snapshotter) convertScratchToReadOnlyLayer(ctx context.Context, snapshot storage.Snapshot, path string) (retErr error) {
 
 	// TODO darrenstahlmsft: When this is done isolated, we should disable these.


### PR DESCRIPTION
It seems that something has shifted in an API, and `vhd.DetachVhd` is returning "failed to open virtual disk: invalid argument" on Windows Server LTSC 2019.

Since the snapshotter test suite is not being run for Windows, nothing is likely to have been exercising this code on CI. #4419 is trying to get the snapshot suite working, and was seeing errors like the below a bit randomly on both CI, and an LTSC 2019 eval instance, but _not_ on my Windows 10 20H2 desktop:
```
    issues.go:89: Check snapshots failed: rename C:\Users\ADMINI~1\AppData\Local\Temp\2\snapshot-suite-Windows-014324559\root\snapshots\6 C:\Users\ADMINI~1\AppData\Local\Temp\2\snapshot-suite-Windows-014324559\root\snapshots\rm-6: Access is denied.
        failed to detach VHD: failed to open virtual disk: invalid argument
        github.com/containerd/containerd/snapshots/windows.(*snapshotter).Remove
        	C:/Users/Administrator/Documents/go/containerd/snapshots/windows/windows.go:266
...
```

Note that this is `failed to open virtual disk`, i.e. it hasn't even tried to detach the disk yet, so its current 'attached' state should not matter.

Based on https://github.com/microsoft/go-winio/pull/157#issuecomment-518790925, this should be a semantically-equivalent replacement, and lets HCS handle the best way to detach the VHD, since HCS and the VHD infrastructure will be from the same system version, avoiding risk of mismatch (as I think we're seeing here).

The code being changed was added in #2705 by @jterry75 (who may still recall any context for using `DetachVhd` instead of `DeactivateLayer`) based on https://github.com/moby/moby/pull/37712.

In this repro case, there is no server crash or similar, it's just under heavy load from the containerd snapshotter test suite. I haven't tried to recreate the failure from the original Docker ticket above.

---

As I mention elsewhere, there's no current CI that is likely to exercise this code path as until #4419, containerd does not support locally mounting a read-write container layer on Windows, let alone writing data to it. The text of the original issue in Docker suggests that a container that was running when the daemon crashed might be left in that state.

I've observed this issue on LTSC 2019 in https://github.com/containerd/containerd/pull/4419#issuecomment-810632253 (and confirmed it stayed stuck until I used `wclayer unmount`) and again in https://github.com/containerd/containerd/pull/4419#issuecomment-826072640, and with this fix applied, haven't seen the problem since with the same setup as the latter.

The `failed to open virtual disk: invalid argument` error hasn't ever appeared on my other test platform, Windows 10 20H2, but I can't prove (due to lack of logs in this code-path) whether the initial rename never failed, or if the existing `DetachVhd` call was successful in unlocking the layer when it did fail. Either is possible, since 20H2 isn't showing the same parallelisation issues I'm seeing on LTSC 2019 in the first place, which I suspect are part of the cause here.

I'm breaking it out of #4419 for separate review because:
* It's existing code, which has history and context, rather than being new code acting weirdly like the rest of #4419
* It should be mergeable separately from #4419.

I am however relying on #4419 for CI and manual testing of this change.

---

At the time of #2705, this code was written and tested against go-winio 0.4.11.

The [`OpenVirtualDisk` flags used in v0.4.11](https://github.com/microsoft/go-winio/blob/v0.4.11/vhd/vhd.go#L93-L101)
```
	if err := openVirtualDisk(
		&defaultType,
		path,
		virtualDiskAccessDETACH,
		0,
		nil,
		&handle); err != nil {
		return err
	}
```

are rather different to the [`OpenVirtualDisk` flags used in v0.4.17](https://github.com/microsoft/go-winio/blob/v0.4.17/vhd/vhd.go#L165-L169)
```
	handle, err := OpenVirtualDisk(
		path,
		VirtualDiskAccessNone,
		OpenVirtualDiskFlagCachedIO|OpenVirtualDiskFlagIgnoreRelativeParentLocator,
	)
```
```
	parameters := OpenVirtualDiskParameters{Version: 2}
	handle, err := OpenVirtualDiskWithParameters(
		vhdPath,
		virtualDiskAccessMask,
		openVirtualDiskFlags,
		&parameters,
	)
```
```
	if err := openVirtualDisk(
		&defaultType,
		vhdPath,
		uint32(virtualDiskAccessMask),
		uint32(openVirtualDiskFlags),
		parameters,
		&handle,
	); err != nil {
```

I suspect that https://github.com/microsoft/go-winio/pull/111 introduced a breakage in v0.4.13, and https://github.com/microsoft/go-winio/pull/157 fixed it for v0.4.14 but didn't notice that RS5 was broken. It's also possible the former worked on RS5, and the latter was a post-RS5 fix.

Unlike https://github.com/microsoft/go-winio/pull/189, as far as I can tell, `OpenVirtualDiskParameters{Version: 2}` _is_ [valid on RS5](https://docs.microsoft.com/en-us/windows/win32/api/virtdisk/ns-virtdisk-open_virtual_disk_parameters), so my best guess is that the disk access mask requirements have changed since RS5.

Either way, I think calling `DeactivateLayer` is the more semantically-clear action anyway. We're already using hcsshim here, and I think it's better to keep reasoning about layers rather than their details, excluding open-coded HCS workalikes like `createScratchLayer`.

----

TODO but not a blocker for merging this:
* Actually write a test for this in go-winio, and test it on an RS5 host, to identify/confirm the root issue, and propose a fix.
* Docker Engine [probably has the same problem](https://github.com/moby/moby/issues/36218#issuecomment-829786293), so try and extract a repro from https://github.com/moby/moby/issues/36218 and if so, propose the same fix there.
  * Since the 19.03 and 20.10 series have different go-winio versions, a repro in Docker mgiht tell us _which_ of the two possible go-winio releases introduced the issue.