### PR TITLE
Specify seccomp target arch for CC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,7 @@ jobs:
           [[ "${MARCH}" == "arm64" ]] && {
             echo "CGO_ENABLED=1" >> $GITHUB_ENV
             echo "CC=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+            echo "SECCOMP_ARCH=aarch64" >> $GITHUB_ENV
           }
           echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
@@ -173,7 +174,7 @@ jobs:
           RUNC_FLAVOR: runc
         run: |
           if [[ "${GOOS}" == "linux" ]]; then
-            sudo -E PATH=$PATH script/setup/install-seccomp
+            sudo -E PATH=$PATH -E SECCOMP_ARCH="${SECCOMP_ARCH}" script/setup/install-seccomp
           fi
           make cri-cni-release
         working-directory: src/github.com/containerd/containerd

--- a/script/setup/install-seccomp
+++ b/script/setup/install-seccomp
@@ -27,7 +27,11 @@ export SECCOMP_PATH=$(mktemp -d)
 curl -fsSL "https://github.com/seccomp/libseccomp/releases/download/v${SECCOMP_VERSION}/libseccomp-${SECCOMP_VERSION}.tar.gz" | tar -xzC "$SECCOMP_PATH" --strip-components=1
 (
 	cd "$SECCOMP_PATH"
-	./configure --prefix=/usr/local
+	host=""
+	if [ -v SECCOMP_ARCH ]; then
+		host="--host=${SECCOMP_ARCH}"
+	fi
+	./configure --prefix=/usr/local ${host}
 	make
 	make install
 	ldconfig


### PR DESCRIPTION
seccomp's build scripts require setting the target arch that will be
built when cross compiling.