### PR TITLE
CI: allow Go 1.13 for Docker/Moby compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,11 +217,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-10.15, windows-2019]
+        go-version: ['1.16.3']
+        include:
+          # Go 1.13.x is still used by Docker/Moby
+          - go-version: '1.13.x'
+            os: ubuntu-18.04
 
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.3'
+          go-version: ${{ matrix.go-version }}
 
       - name: Set env
         shell: bash


### PR DESCRIPTION
Docker/Moby still uses Go 1.13 for building containerd binaries.
