### PR TITLE
Deprecate built-in aufs snapshotter

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -321,9 +321,9 @@ against total impact.
 
 The deprecated features are shown in the following table:
 
-| Component                                                            | Deprecation release | Target release for removal |
-|----------------------------------------------------------------------|---------------------|----------------------------|
-| Runtime V1 API and implementation (`io.containerd.runtime.v1.linux`) | containerd v1.4     | containerd v2.0            |
-| Runc V1 implementation of Runtime V2 (`io.containerd.runc.v1`)       | containerd v1.4     | containerd v2.0            |
-| config.toml `version = 1`                                            | containerd v1.5     | containerd v2.0            |
-| Built-in `aufs` snapshotter                                          | containerd v1.5     | containerd v2.0            |
+| Component                                                            | Deprecation release | Target release for removal | Recommendation                |
+|----------------------------------------------------------------------|---------------------|----------------------------|-------------------------------|
+| Runtime V1 API and implementation (`io.containerd.runtime.v1.linux`) | containerd v1.4     | containerd v2.0            | Use `io.containerd.runc.v2`   |
+| Runc V1 implementation of Runtime V2 (`io.containerd.runc.v1`)       | containerd v1.4     | containerd v2.0            | Use `io.containerd.runc.v2`   |
+| config.toml `version = 1`                                            | containerd v1.5     | containerd v2.0            | Use config.toml `version = 2` |
+| Built-in `aufs` snapshotter                                          | containerd v1.5     | containerd v2.0            | Use `overlayfs` snapshotter   |

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -326,3 +326,4 @@ The deprecated features are shown in the following table:
 | Runtime V1 API and implementation (`io.containerd.runtime.v1.linux`) | containerd v1.4     | containerd v2.0            |
 | Runc V1 implementation of Runtime V2 (`io.containerd.runc.v1`)       | containerd v1.4     | containerd v2.0            |
 | config.toml `version = 1`                                            | containerd v1.5     | containerd v2.0            |
+| Built-in `aufs` snapshotter                                          | containerd v1.5     | containerd v2.0            |


### PR DESCRIPTION
aufs was removed from Ubuntu kernel in Ubuntu 21.04, and Ubuntu 16.04 is going to reach EOL on Apr 30,  so deprecate the built-in aufs snapshotter.

The aufs snapshotter can be still maintained as a non-builtin snapshotter.

