### PR TITLE
release: Update azure repo list to be amd64 only

### DIFF
--- a/.github/workflows/release/Dockerfile.ubuntu-18.04
+++ b/.github/workflows/release/Dockerfile.ubuntu-18.04
@@ -1,0 +1,70 @@
+ARG GO_VERSION=1.16.4
+ARG GO_IMAGE=golang:${GO_VERSION}
+FROM --platform=$BUILDPLATFORM $GO_IMAGE AS go
+
+FROM --platform=$BUILDPLATFORM ubuntu:18.04 AS base
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
+SHELL ["/bin/bash", "-xec"]
+RUN if [ ! "$TARGETARCH" = "amd64" ] && [ ! "$TARGETPLATFORM" = "$BUILDPLATFORM" ]; then \
+		echo deb [arch=$(dpkg --print-architecture)] http://archive.ubuntu.com/ubuntu/ bionic main multiverse restricted universe > /etc/apt/sources.list; \
+		echo deb [arch=$(dpkg --print-architecture)] http://archive.ubuntu.com/ubuntu/ bionic-updates main multiverse restricted universe >> /etc/apt/sources.list; \
+		echo deb [arch=$(dpkg --print-architecture)] http://security.ubuntu.com/ubuntu/ bionic-security main multiverse restricted universe >> /etc/apt/sources.lis; \
+		echo deb [arch=arm64,armhf] http://ports.ubuntu.com/ubuntu-ports/ bionic main multiverse restricted universe >> /etc/apt/sources.list; \
+		echo deb [arch=arm64,armhf] http://ports.ubuntu.com/ubuntu-ports/ bionic-updates main multiverse restricted universe >> /etc/apt/sources.list; \
+		dpkg --add-architecture "$TARGETARCH"; \
+	fi
+RUN	apt-get update && apt-get install -y \
+	crossbuild-essential-arm64 \
+	git \
+	pkg-config \
+	btrfs-progs:${TARGETARCH} \
+	libseccomp-dev:${TARGETARCH}
+ENV PATH=/usr/local/go/bin:$PATH
+ENV CGO_ENABLED=1
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
+
+FROM base AS base-arm64
+ENV CC=aarch64-linux-gnu-gcc
+
+FROM base AS base-amd64
+
+FROM base-${TARGETARCH}${TARGETVARIANT} AS base-target
+RUN \
+    PKG_CONFIG_PATH="$(pkg-config --variable pc_path pkg-config)"; \
+    for i in $(find /usr/lib -name 'pkgconfig'); do \
+      PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:$i"; \
+    done; \
+    echo export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}" > /tmp/pkgconfig
+
+FROM base-target AS containerd
+COPY . /go/src/github.com/containerd/containerd
+WORKDIR /go/src/github.com/containerd/containerd
+ENV GOCACHE=/tmp/gocache
+RUN \
+	--mount=from=go,source=/usr/local/go,target=/usr/local/go \
+	--mount=type=cache,target=/tmp/gocache \
+	. /tmp/pkgconfig; \
+	make binaries; \
+	rm bin/containerd-stress
+
+FROM base-target AS runc
+ARG RUNC_COMMIT=master
+ARG RUNC_REPO=https://github.com/opencontainers/runc.git
+WORKDIR /go/src/github.com/opencontainers/runc
+RUN git clone --depth=1 $RUNC_REPO . && git fetch origin $RUNC_COMMIT && git checkout $RUNC_COMMIT
+ENV BUILDTAGS=seccomp
+RUN \
+	--mount=from=go,source=/usr/local/go,target=/usr/local/go \
+	. /tmp/pkgconfig; \
+	make runc
+
+FROM scratch
+ARG TARGETARCH
+ARG TARGETVARIANT
+COPY --from=containerd /go/src/github.com/containerd/containerd/bin/* /ubuntu-18.04-${TARGETARCH}${TARGETVARIANT}/
+COPY --from=runc /go/src/github.com/opencontainers/runc/runc /ubuntu-18.04-${TARGETARCH}${TARGETVARIANT}/

--- a/.github/workflows/release/Dockerfile.windows
+++ b/.github/workflows/release/Dockerfile.windows
@@ -1,0 +1,37 @@
+ARG GO_VERSION=1.16.4
+
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION} AS base
+RUN apt-get update && apt-get install -y \
+	binutils-mingw-w64 \
+	g++-mingw-w64-x86-64
+ARG TARGETARCH
+ENV CGO_ENABLED=1
+ENV GOOS=windows
+ENV GOARCH=$TARGETARCH
+SHELL ["/bin/bash", "-xec"]
+
+FROM base as base-amd64
+ENV CC=x86_64-w64-mingw32-gcc
+
+FROM base-${TARGETARCH}${TARGETVARIANT} AS base-target
+
+FROM base-target AS containerd
+COPY . /go/src/github.com/containerd/containerd
+WORKDIR /go/src/github.com/containerd/containerd
+RUN make binaries; rm bin/containerd-stress.exe
+
+FROM base-target AS runhcs
+WORKDIR /go/src/github.com/microsoft/hcsshim
+ARG HCS_REPO=https://github.com/Microsoft/hcsshim.git
+RUN \
+	--mount=source=go.mod,target=/tmp/go.mod \
+	HCS_COMMIT="$(grep 'Microsoft/hcsshim ' /tmp/go.mod | awk '{print $2}')"; \
+	git clone --depth=1 "${HCS_REPO}" .; \
+	git fetch --tags origin "${HCS_COMMIT}";
+RUN GO111MODULE=on go build -mod=vendor -o containerd-shim-runhcs-v1.exe ./cmd/containerd-shim-runhcs-v1
+
+FROM scratch
+ARG TARGETARCH
+ARG TARGETVARIANT
+COPY --from=containerd /go/src/github.com/containerd/containerd/bin/* /windows-${TARGETARCH}${TARGETVARIANT}/
+COPY --from=runhcs /go/src/github.com/microsoft/hcsshim/containerd-shim-runhcs-v1.exe /windows-${TARGETARCH}${TARGETVARIANT}/


### PR DESCRIPTION
Azure archive only has amd64 in it.
When new architectures are added in the workflow, since the repo list
does not specify a particular arch it assumes all arches. We need to
scope this down to amd64 only to avoid 404's.

Also fixes btrfs packages for reloads workflow.
