### PR TITLE
Revert arm64 release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,13 +56,7 @@ jobs:
 
     strategy:
       matrix:
-        include:
-        - os: ubuntu-18.04
-          arch: amd64
-        - os: ubuntu-18.04
-          arch: arm64
-        - os: windows-2019
-          arch: amd64
+        os: [ubuntu-18.04, windows-2019]
 
     steps:
       - name: Install Go
@@ -74,7 +68,6 @@ jobs:
         shell: bash
         env:
           MOS: ${{ matrix.os }}
-          MARCH: ${{ matrix.arch }}
         run: |
           releasever=${{ github.ref }}
           releasever="${releasever#refs/tags/}"
@@ -84,42 +77,8 @@ jobs:
           }
           echo "RELEASE_VER=${releasever}" >> $GITHUB_ENV
           echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
-          echo "GOOS=${os}" >> $GITHUB_ENV
-          echo "GOARCH=${{ matrix.arch }}" >> $GITHUB_ENV
-          [[ "${MARCH}" == "arm64" ]] && {
-            echo "CGO_ENABLED=1" >> $GITHUB_ENV
-            echo "CC=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
-          }
+          echo "OS=${os}" >> $GITHUB_ENV
           echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
-
-      - name: Install dependencies
-        if: ${{ runner.os == 'Linux' }}
-        shell: bash
-        run: |
-          if [[ "${GOARCH}" != "amd64" ]]; then
-            sudo add-apt-repository "deb [arch=arm64,s390x,ppc64el] http://ports.ubuntu.com/ubuntu-ports/ $(lsb_release -sc) main" || true
-            sudo add-apt-repository "deb [arch=arm64,s390x,ppc64el] http://ports.ubuntu.com/ubuntu-ports/ $(lsb_release -sc)-updates main" || true
-
-            sudo dpkg --add-architecture arm64
-            sudo dpkg --add-architecture s390x
-            sudo dpkg --add-architecture ppc64el
-
-            sudo apt-get update || true
-
-            sudo apt-get install -y \
-              crossbuild-essential-arm64 \
-              crossbuild-essential-s390x \
-              crossbuild-essential-ppc64el \
-              libseccomp-dev:amd64 \
-              libseccomp-dev:arm64 \
-              libseccomp-dev:s390x \
-              libseccomp-dev:ppc64el
-              # libbtrfs-dev is not available for Ubuntu 18.04
-              # libbtrfs-dev:amd64 \
-              # libbtrfs-dev:arm64 \
-              # libbtrfs-dev:s390x \
-              # libbtrfs-dev:ppc64el
-          fi
 
       - name: Checkout containerd
         uses: actions/checkout@v2
@@ -149,14 +108,14 @@ jobs:
           make build
           make binaries
           rm bin/containerd-stress*
-          [[ "${GOOS}" == "windows" ]] && {
+          [[ "${OS}" == "windows" ]] && {
               (
                 bindir="$(pwd)/bin"
                 cd ../../Microsoft/hcsshim
                 GO111MODULE=on go build -mod=vendor -o "${bindir}/containerd-shim-runhcs-v1.exe" ./cmd/containerd-shim-runhcs-v1
               )
           }
-          TARFILE="containerd-${RELEASE_VER#v}-${GOOS}-${GOARCH}.tar.gz"
+          TARFILE="containerd-${RELEASE_VER#v}-${OS}-amd64.tar.gz"
           tar czf ${TARFILE} bin/
           sha256sum ${TARFILE} >${TARFILE}.sha256sum
         working-directory: src/github.com/containerd/containerd
@@ -164,7 +123,7 @@ jobs:
       - name: Save build binaries
         uses: actions/upload-artifact@v2
         with:
-          name: containerd-binaries-${{ matrix.os }}-${{ matrix.arch }}
+          name: containerd-binaries-${{ matrix.os }}
           path: src/github.com/containerd/containerd/*.tar.gz*
 
       - name: Make cri-containerd tar
@@ -172,7 +131,7 @@ jobs:
         env:
           RUNC_FLAVOR: runc
         run: |
-          if [[ "${GOOS}" == "linux" ]]; then
+          if [[ "${OS}" == "linux" ]]; then
             sudo -E PATH=$PATH script/setup/install-seccomp
           fi
           make cri-cni-release
@@ -181,7 +140,7 @@ jobs:
       - name: Save cri-containerd binaries
         uses: actions/upload-artifact@v2
         with:
-          name: cri-containerd-binaries-${{ matrix.os }}-${{ matrix.arch }}
+          name: cri-containerd-binaries-${{ matrix.os }}
           path: src/github.com/containerd/containerd/releases/cri-containerd-cni-*.tar.gz*
 
   release:
@@ -199,7 +158,7 @@ jobs:
         id: catalog
         run: |
           _filenum=1
-          for i in "ubuntu-18.04-amd64" "ubuntu-18.04-arm64" "windows-2019-amd64"; do
+          for i in "ubuntu-18.04" "windows-2019"; do
             for f in `ls builds/containerd-binaries-${i}`; do
               echo "::set-output name=file${_filenum}::${f}"
               let "_filenum+=1"
@@ -220,111 +179,75 @@ jobs:
           body_path: ./builds/containerd-release-notes/release-notes.md
           draft: false
           prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
-      - name: Upload Linux AMD64 containerd tarball
+      - name: Upload Linux containerd tarball
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./builds/containerd-binaries-ubuntu-18.04-amd64/${{ steps.catalog.outputs.file1 }}
+          asset_path: ./builds/containerd-binaries-ubuntu-18.04/${{ steps.catalog.outputs.file1 }}
           asset_name: ${{ steps.catalog.outputs.file1 }}
           asset_content_type: application/gzip
-      - name: Upload Linux AMD64 sha256 sum
+      - name: Upload Linux sha256 sum
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./builds/containerd-binaries-ubuntu-18.04-amd64/${{ steps.catalog.outputs.file2 }}
+          asset_path: ./builds/containerd-binaries-ubuntu-18.04/${{ steps.catalog.outputs.file2 }}
           asset_name: ${{ steps.catalog.outputs.file2 }}
           asset_content_type: text/plain
-      - name: Upload Linux AMD64 cri containerd tarball
+      - name: Upload Linux cri containerd tarball
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./builds/cri-containerd-binaries-ubuntu-18.04-amd64/${{ steps.catalog.outputs.file3 }}
+          asset_path: ./builds/cri-containerd-binaries-ubuntu-18.04/${{ steps.catalog.outputs.file3 }}
           asset_name: ${{ steps.catalog.outputs.file3 }}
           asset_content_type: application/gzip
-      - name: Upload Linux AMD64 cri sha256 sum
+      - name: Upload Linux cri sha256 sum
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./builds/cri-containerd-binaries-ubuntu-18.04-amd64/${{ steps.catalog.outputs.file4 }}
+          asset_path: ./builds/cri-containerd-binaries-ubuntu-18.04/${{ steps.catalog.outputs.file4 }}
           asset_name: ${{ steps.catalog.outputs.file4 }}
           asset_content_type: text/plain
-      - name: Upload Linux ARM64 containerd tarball
+      - name: Upload Windows containerd tarball
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./builds/containerd-binaries-ubuntu-18.04-arm64/${{ steps.catalog.outputs.file5 }}
+          asset_path: ./builds/containerd-binaries-windows-2019/${{ steps.catalog.outputs.file5 }}
           asset_name: ${{ steps.catalog.outputs.file5 }}
           asset_content_type: application/gzip
-      - name: Upload Linux ARM64 sha256 sum
+      - name: Upload Windows sha256 sum
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./builds/containerd-binaries-ubuntu-18.04-arm64/${{ steps.catalog.outputs.file6 }}
+          asset_path: ./builds/containerd-binaries-windows-2019/${{ steps.catalog.outputs.file6 }}
           asset_name: ${{ steps.catalog.outputs.file6 }}
           asset_content_type: text/plain
-      - name: Upload Linux ARM64 cri containerd tarball
+      - name: Upload Windows cri containerd tarball
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./builds/cri-containerd-binaries-ubuntu-18.04-arm64/${{ steps.catalog.outputs.file7 }}
+          asset_path: ./builds/cri-containerd-binaries-windows-2019/${{ steps.catalog.outputs.file7 }}
           asset_name: ${{ steps.catalog.outputs.file7 }}
           asset_content_type: application/gzip
-      - name: Upload Linux ARM64 cri sha256 sum
+      - name: Upload Windows cri sha256 sum
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./builds/cri-containerd-binaries-ubuntu-18.04-arm64/${{ steps.catalog.outputs.file8 }}
+          asset_path: ./builds/cri-containerd-binaries-windows-2019/${{ steps.catalog.outputs.file8 }}
           asset_name: ${{ steps.catalog.outputs.file8 }}
-          asset_content_type: text/plain
-      - name: Upload Windows AMD64 containerd tarball
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./builds/containerd-binaries-windows-2019-amd64/${{ steps.catalog.outputs.file9 }}
-          asset_name: ${{ steps.catalog.outputs.file9 }}
-          asset_content_type: application/gzip
-      - name: Upload Windows AMD64 sha256 sum
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./builds/containerd-binaries-windows-2019-amd64/${{ steps.catalog.outputs.file10 }}
-          asset_name: ${{ steps.catalog.outputs.file10 }}
-          asset_content_type: text/plain
-      - name: Upload Windows AMD64 cri containerd tarball
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./builds/cri-containerd-binaries-windows-2019-amd64/${{ steps.catalog.outputs.file11 }}
-          asset_name: ${{ steps.catalog.outputs.file11 }}
-          asset_content_type: application/gzip
-      - name: Upload Windows AMD64 cri sha256 sum
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./builds/cri-containerd-binaries-windows-2019-amd64/${{ steps.catalog.outputs.file12 }}
-          asset_name: ${{ steps.catalog.outputs.file12 }}
           asset_content_type: text/plain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,6 @@ jobs:
           [[ "${MARCH}" == "arm64" ]] && {
             echo "CGO_ENABLED=1" >> $GITHUB_ENV
             echo "CC=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
-            echo "SECCOMP_ARCH=aarch64" >> $GITHUB_ENV
           }
           echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
@@ -174,7 +173,7 @@ jobs:
           RUNC_FLAVOR: runc
         run: |
           if [[ "${GOOS}" == "linux" ]]; then
-            sudo -E PATH=$PATH -E SECCOMP_ARCH="${SECCOMP_ARCH}" script/setup/install-seccomp
+            sudo -E PATH=$PATH script/setup/install-seccomp
           fi
           make cri-cni-release
         working-directory: src/github.com/containerd/containerd

--- a/releases/v1.5.0-rc.toml
+++ b/releases/v1.5.0-rc.toml
@@ -15,7 +15,7 @@ The sixth major release of containerd includes many stability improvements
 and code organization changes to make contribution easier and make future
 features cleaner to develop. This includes bringing CRI development into the
 main containerd repository and switching to Go modules. This release also
-brings support for the Node Resource Interface (NRI) and ARM64 builds.
+brings support for the Node Resource Interface (NRI).
 
 ### Highlights
 
@@ -24,7 +24,6 @@ brings support for the Node Resource Interface (NRI) and ARM64 builds.
 * **Move to Go modules** [#4760](https://github.com/containerd/containerd/pull/4760)
 * **Remove `selinux` build tag** [#4849](https://github.com/containerd/containerd/pull/4849)
 * **Add json log format output option for daemon log** [#4803](https://github.com/containerd/containerd/pull/4803)
-* **Add release builds for ARM64** [#5329](https://github.com/containerd/containerd/pull/5329)
 
 #### Snapshots
 * **Add configurable overlayfs path** [#4505](https://github.com/containerd/containerd/pull/4505)

--- a/script/setup/install-seccomp
+++ b/script/setup/install-seccomp
@@ -27,11 +27,7 @@ export SECCOMP_PATH=$(mktemp -d)
 curl -fsSL "https://github.com/seccomp/libseccomp/releases/download/v${SECCOMP_VERSION}/libseccomp-${SECCOMP_VERSION}.tar.gz" | tar -xzC "$SECCOMP_PATH" --strip-components=1
 (
 	cd "$SECCOMP_PATH"
-	host=""
-	if [ -v SECCOMP_ARCH ]; then
-		host="--host=${SECCOMP_ARCH}"
-	fi
-	./configure --prefix=/usr/local ${host}
+	./configure --prefix=/usr/local
 	make
 	make install
 	ldconfig


### PR DESCRIPTION
The ARM builds are failing during the release process. These need a bit more work to cross compile all the binaries and be tested before going into a release.