### PR TITLE
plugin: optimize the check for the last registration

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -171,14 +171,10 @@ func Register(r *Registration) {
 		panic(err)
 	}
 
-	var last bool
 	for _, requires := range r.Requires {
-		if requires == "*" {
-			last = true
+		if requires == "*" && len(r.Requires) != 1 {
+			panic(ErrInvalidRequires)
 		}
-	}
-	if last && len(r.Requires) != 1 {
-		panic(ErrInvalidRequires)
 	}
 
 	register.r = append(register.r, r)


### PR DESCRIPTION
 Optimize the check for the last registration

I originally wanted to change it to:
```go
        var last bool
        for _, requires := range r.Requires {
                if requires == "*" {
                        last = true
                        break
                }
        }
        if last && len(r.Requires) != 1 {
                panic(ErrInvalidRequires)
        }
```
But I found that the `last` would not be used elsewhere, so I changed it to:
```go
        for _, requires := range r.Requires {
                if requires == "*" && len(r.Requires) != 1 {
                        panic(ErrInvalidRequires)
                }
        }
```