### PR TITLE
doc: add missing namespaces package

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,11 @@ containerd offers a full client package to help you integrate containerd into yo
 ```go
 
 import (
+  "context"
+
   "github.com/containerd/containerd"
   "github.com/containerd/containerd/cio"
+  "github.com/containerd/containerd/namespaces"
 )
 
 


### PR DESCRIPTION
Currently, we can not reproduce the given Namespaces section examples written in the README, since it's not clear to which package should we import to.

Signed-off-by: Furkan Turkal <furkan.turkal@trendyol.com>