### PR TITLE
Makefile: fix FHS install location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -342,8 +342,8 @@ clean-test: ## clean up debris from previously failed tests
 
 install: ## install binaries
 	@echo "$(WHALE) $@ $(BINARIES)"
-	@mkdir -p $(DESTDIR)/bin
-	@install $(BINARIES) $(DESTDIR)/bin
+	@mkdir -p $(DESTDIR)/usr/bin
+	@install $(BINARIES) $(DESTDIR)/usr/bin
 
 uninstall:
 	@echo "$(WHALE) $@"


### PR DESCRIPTION
FHS mandates that /bin is only for binaries that are essential to boot
up into single user mode and system repair. Anything else belongs into
/usr/bin instead.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>