### PR TITLE
services/introspection: support to show introspection grpc service plugin

### DIFF
--- a/plugin/context.go
+++ b/plugin/context.go
@@ -130,9 +130,19 @@ func (ps *Set) Get(t Type) (interface{}, error) {
 	return nil, errors.Wrapf(errdefs.ErrNotFound, "no plugins registered for %s", t)
 }
 
+// GetAll returns all initialized plugins
+func (ps *Set) GetAll() []*Plugin {
+	return ps.ordered
+}
+
+// Plugins returns plugin set
+func (i *InitContext) Plugins() *Set {
+	return i.plugins
+}
+
 // GetAll plugins in the set
 func (i *InitContext) GetAll() []*Plugin {
-	return i.plugins.ordered
+	return i.plugins.GetAll()
 }
 
 // GetByType returns all plugins with the specific type.

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -193,6 +193,25 @@ func checkUnique(r *Registration) error {
 	return nil
 }
 
+// AreRegisteredPluginsInitialized returns all registered plugins are initialized
+func AreRegisteredPluginsInitialized(plugins *Set) bool {
+	if len(register.r) != len(plugins.ordered) {
+		return false
+	}
+	for _, reg := range register.r {
+		byID, typeok := plugins.byTypeAndID[reg.Type]
+		if !typeok {
+			return false
+		}
+
+		if _, ok := byID[reg.ID]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
 // DisableFilter filters out disabled plugins
 type DisableFilter func(r *Registration) bool
 

--- a/services/introspection/local.go
+++ b/services/introspection/local.go
@@ -42,12 +42,9 @@ func init() {
 		ID:       services.IntrospectionService,
 		Requires: []plugin.Type{},
 		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
-			// this service works by using the plugin context up till the point
-			// this service is initialized. Since we require this service last,
-			// it should provide the full set of plugins.
-			pluginsPB := pluginsToPB(ic.GetAll())
+			// this service fetches all plugins through the plugin set of the plugin context
 			return &Local{
-				plugins: pluginsPB,
+				plugins: ic.Plugins(),
 				root:    ic.Root,
 			}, nil
 		},
@@ -56,19 +53,19 @@ func init() {
 
 // Local is a local implementation of the introspection service
 type Local struct {
-	mu      sync.Mutex
-	plugins []api.Plugin
-	root    string
+	mu        sync.Mutex
+	root      string
+	plugins   *plugin.Set
+	pluginsPB []api.Plugin
 }
 
 var _ = (api.IntrospectionClient)(&Local{})
 
 // UpdateLocal updates the local introspection service
-func (l *Local) UpdateLocal(root string, plugins []api.Plugin) {
+func (l *Local) UpdateLocal(root string) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.root = root
-	l.plugins = plugins
 }
 
 // Plugins returns the locally defined plugins
@@ -94,9 +91,16 @@ func (l *Local) Plugins(ctx context.Context, req *api.PluginsRequest, _ ...grpc.
 }
 
 func (l *Local) getPlugins() []api.Plugin {
+	if !plugin.AreRegisteredPluginsInitialized(l.plugins) {
+		return pluginsToPB(l.plugins.GetAll())
+	}
+
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	return l.plugins
+	if l.pluginsPB == nil {
+		l.pluginsPB = pluginsToPB(l.plugins.GetAll())
+	}
+	return l.pluginsPB
 }
 
 // Server returns the local server information

--- a/services/introspection/service.go
+++ b/services/introspection/service.go
@@ -31,11 +31,8 @@ func init() {
 	plugin.Register(&plugin.Registration{
 		Type:     plugin.GRPCPlugin,
 		ID:       "introspection",
-		Requires: []plugin.Type{"*"},
+		Requires: []plugin.Type{plugin.ServicePlugin},
 		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
-			// this service works by using the plugin context up till the point
-			// this service is initialized. Since we require this service last,
-			// it should provide the full set of plugins.
 			plugins, err := ic.GetByType(plugin.ServicePlugin)
 			if err != nil {
 				return nil, err
@@ -50,13 +47,11 @@ func init() {
 				return nil, err
 			}
 
-			allPluginsPB := pluginsToPB(ic.GetAll())
-
 			localClient, ok := i.(*Local)
 			if !ok {
 				return nil, errors.Errorf("Could not create a local client for introspection service")
 			}
-			localClient.UpdateLocal(ic.Root, allPluginsPB)
+			localClient.UpdateLocal(ic.Root)
 
 			return &server{
 				local: localClient,


### PR DESCRIPTION
`ctr plugins ls` does not display the introspection grpc service plugin
```sh
# ctr plugins ls                                                                         
TYPE                            ID                       PLATFORMS      STATUS
io.containerd.content.v1        content                  -              ok
io.containerd.snapshotter.v1    aufs                     linux/amd64    error
io.containerd.snapshotter.v1    btrfs                    linux/amd64    error
io.containerd.snapshotter.v1    devmapper                linux/amd64    error
io.containerd.snapshotter.v1    native                   linux/amd64    ok
io.containerd.snapshotter.v1    overlayfs                linux/amd64    ok
io.containerd.snapshotter.v1    zfs                      linux/amd64    error
io.containerd.metadata.v1       bolt                     -              ok
io.containerd.differ.v1         walking                  linux/amd64    ok
io.containerd.gc.v1             scheduler                -              ok
io.containerd.service.v1        introspection-service    -              ok
io.containerd.service.v1        containers-service       -              ok
io.containerd.service.v1        content-service          -              ok
io.containerd.service.v1        diff-service             -              ok
io.containerd.service.v1        images-service           -              ok
io.containerd.service.v1        leases-service           -              ok
io.containerd.service.v1        namespaces-service       -              ok
io.containerd.service.v1        snapshots-service        -              ok
io.containerd.runtime.v1        linux                    linux/amd64    ok
io.containerd.runtime.v2        task                     linux/amd64    ok
io.containerd.monitor.v1        cgroups                  linux/amd64    ok
io.containerd.service.v1        tasks-service            -              ok
io.containerd.internal.v1       restart                  -              ok
io.containerd.grpc.v1           containers               -              ok
io.containerd.grpc.v1           content                  -              ok
io.containerd.grpc.v1           diff                     -              ok
io.containerd.grpc.v1           events                   -              ok
io.containerd.grpc.v1           healthcheck              -              ok
io.containerd.grpc.v1           images                   -              ok
io.containerd.grpc.v1           leases                   -              ok
io.containerd.grpc.v1           namespaces               -              ok
io.containerd.internal.v1       opt                      -              ok
io.containerd.grpc.v1           snapshots                -              ok
io.containerd.grpc.v1           tasks                    -              ok
io.containerd.grpc.v1           version                  -              ok
io.containerd.grpc.v1           cri                      linux/amd64    ok
```

## analysis
The `Plugins` method of the introspection grpc service does not show itself and the plugins initialised after it.

When the introspection grpc service is initialised, it will get the list of currently registered plugins from the plugin context, which will not contain itself and plugins that have not yet been initialised.

Add to initialization list when initialization is complete:
https://github.com/containerd/containerd/blob/14316794ad0a33b8688078f770655c9203e4d80d/services/server/server.go#L168-L173

When the introspection grpc service is initialised, it will get the list of currently registered plugins from the plugin context, which will not contain itself and plugins that have not yet been initialised.
https://github.com/containerd/containerd/blob/14316794ad0a33b8688078f770655c9203e4d80d/services/introspection/service.go#L53-L64

Although the introspection grpc service requires itself to be initialized last(`Requires: []plugin.Type{"*"}`), it still allows `Requests` from other plugins to also be `*`, and if these plugins are registered by calling `plugin.Register` before the introspection grpc service, they will be initialized after the introspection grpc service when using `plugin.Graph` sorting.

### output
```sh
# ctr plugin ls
TYPE                            ID                       PLATFORMS      STATUS
io.containerd.content.v1        content                  -              ok
io.containerd.snapshotter.v1    aufs                     linux/amd64    error
io.containerd.snapshotter.v1    btrfs                    linux/amd64    error
io.containerd.snapshotter.v1    devmapper                linux/amd64    error
io.containerd.snapshotter.v1    native                   linux/amd64    ok
io.containerd.snapshotter.v1    overlayfs                linux/amd64    ok
io.containerd.snapshotter.v1    zfs                      linux/amd64    error
io.containerd.metadata.v1       bolt                     -              ok
io.containerd.differ.v1         walking                  linux/amd64    ok
io.containerd.gc.v1             scheduler                -              ok
io.containerd.service.v1        introspection-service    -              ok
io.containerd.service.v1        containers-service       -              ok
io.containerd.service.v1        content-service          -              ok
io.containerd.service.v1        diff-service             -              ok
io.containerd.service.v1        images-service           -              ok
io.containerd.service.v1        leases-service           -              ok
io.containerd.service.v1        namespaces-service       -              ok
io.containerd.service.v1        snapshots-service        -              ok
io.containerd.runtime.v1        linux                    linux/amd64    ok
io.containerd.runtime.v2        task                     linux/amd64    ok
io.containerd.monitor.v1        cgroups                  linux/amd64    ok
io.containerd.service.v1        tasks-service            -              ok
io.containerd.grpc.v1           introspection            -              ok
io.containerd.internal.v1       restart                  -              ok
io.containerd.grpc.v1           containers               -              ok
io.containerd.grpc.v1           content                  -              ok
io.containerd.grpc.v1           diff                     -              ok
io.containerd.grpc.v1           events                   -              ok
io.containerd.grpc.v1           healthcheck              -              ok
io.containerd.grpc.v1           images                   -              ok
io.containerd.grpc.v1           leases                   -              ok
io.containerd.grpc.v1           namespaces               -              ok
io.containerd.internal.v1       opt                      -              ok
io.containerd.grpc.v1           snapshots                -              ok
io.containerd.grpc.v1           tasks                    -              ok
io.containerd.grpc.v1           version                  -              ok
io.containerd.grpc.v1           cri                      linux/amd64    ok
```
