### PR TITLE
Update Go to 1.16.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.16.3]
+        go-version: [1.16.4]
         os: [ubuntu-18.04, macos-10.15, windows-2019]
 
     steps:
@@ -73,7 +73,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.3'
+          go-version: '1.16.4'
 
       - uses: actions/checkout@v2
         with:
@@ -106,7 +106,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.3'
+          go-version: '1.16.4'
 
       - name: Set env
         shell: bash
@@ -152,7 +152,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.3'
+          go-version: '1.16.4'
       - name: Set env
         shell: bash
         run: |
@@ -217,7 +217,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-10.15, windows-2019]
-        go-version: ['1.16.3']
+        go-version: ['1.16.4']
         include:
           # Go 1.13.x is still used by Docker/Moby
           - go-version: '1.13.x'
@@ -263,7 +263,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.3'
+          go-version: '1.16.4'
 
       - uses: actions/checkout@v2
         with:
@@ -344,7 +344,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.3'
+          go-version: '1.16.4'
 
       - uses: actions/checkout@v2
         with:
@@ -496,7 +496,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.3'
+          go-version: '1.16.4'
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.3'
+          go-version: '1.16.4'
 
       - uses: actions/checkout@v2
         with:
@@ -135,7 +135,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.3'
+          go-version: '1.16.4'
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16.3'
+          go-version: '1.16.4'
 
       - name: Set env
         shell: bash

--- a/.zuul/playbooks/containerd-build/run.yaml
+++ b/.zuul/playbooks/containerd-build/run.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.16.3'
+    go_version: '1.16.4'
     arch: arm64
   tasks:
   - name: Build containerd

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,7 +77,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.16.3",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.16.4",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -10,7 +10,7 @@
 #
 # docker build -t containerd-test --build-arg RUNC_VERSION=v1.0.0-rc93 -f Dockerfile.test ../
 
-ARG GOLANG_VERSION=1.16.3
+ARG GOLANG_VERSION=1.16.4
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd


### PR DESCRIPTION
fix [#45710](https://github.com/golang/go/issues/45710) and CVE-2021-31525.

full diff: https://github.com/golang/go/compare/go1.16.3...go1.16.4

Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>