### PR TITLE
Makefile: make hardcoded config defaults build-time-customizable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ releases/*.tar.gz
 releases/*.tar.gz.sha256sum
 _output/
 .vagrant/
+/defaults/defaults_unix.go

--- a/defaults/defaults_unix.go.in
+++ b/defaults/defaults_unix.go.in
@@ -21,19 +21,19 @@ package defaults
 const (
 	// DefaultRootDir is the default location used by containerd to store
 	// persistent data
-	DefaultRootDir = "/var/lib/containerd"
+	DefaultRootDir = "@CONFIG_DEFAULT_ROOT_DIR@"
 	// DefaultStateDir is the default location used by containerd to store
 	// transient data
-	DefaultStateDir = "/run/containerd"
+	DefaultStateDir = "@CONFIG_DEFAULT_STATE_DIR@"
 	// DefaultAddress is the default unix socket address
-	DefaultAddress = "/run/containerd/containerd.sock"
+	DefaultAddress = "@CONFIG_DEFAULT_ADDRESS@"
 	// DefaultDebugAddress is the default unix socket address for pprof data
-	DefaultDebugAddress = "/run/containerd/debug.sock"
+	DefaultDebugAddress = "@CONFIG_DEFAULT_DEBUG_ADDRESS@"
 	// DefaultFIFODir is the default location used by client-side cio library
 	// to store FIFOs.
-	DefaultFIFODir = "/run/containerd/fifo"
+	DefaultFIFODir = "@CONFIG_DEFAULT_FIFO_DIR@"
 	// DefaultRuntime is the default linux runtime
-	DefaultRuntime = "io.containerd.runc.v2"
+	DefaultRuntime = "@CONFIG_DEFAULT_RUNTIME@"
 	// DefaultConfigDir is the default location for config files.
-	DefaultConfigDir = "/etc/containerd"
+	DefaultConfigDir = "@CONFIG_DEFAULT_CONFIG_DIR@"
 )


### PR DESCRIPTION
The defaults/defaults_unix.go file contains a bunch of defaults which
distros or site local installs might wanna customize. In order to allow
that w/o individual patching, instead by just passing via environment,
this file needs to be auto-generated.

Introducing a bunch of new environment variables (named CONFIG_*),
which default to the previously hardcoded values. Also deriving the
path names from GNU style standard variables, but defaulting them to
the previously hardcoded values.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>