### PR TITLE
Fix `content.ReaderAt` close

### DIFF
--- a/cmd/ctr/commands/snapshots/snapshots.go
+++ b/cmd/ctr/commands/snapshots/snapshots.go
@@ -164,6 +164,7 @@ var diffCommand = cli.Command{
 		if err != nil {
 			return err
 		}
+		defer ra.Close()
 		_, err = io.Copy(os.Stdout, content.NewReader(ra))
 
 		return err

--- a/content/testsuite/testsuite.go
+++ b/content/testsuite/testsuite.go
@@ -780,6 +780,7 @@ func checkSmallBlob(ctx context.Context, t *testing.T, store content.Store) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ra.Close()
 	r := io.NewSectionReader(ra, 0, readSize)
 	b, err := ioutil.ReadAll(r)
 	if err != nil {

--- a/images/archive/importer.go
+++ b/images/archive/importer.go
@@ -281,6 +281,7 @@ func resolveLayers(ctx context.Context, store content.Store, layerFiles []string
 		}
 		s, err := compression.DecompressStream(content.NewReader(ra))
 		if err != nil {
+			ra.Close()
 			return nil, errors.Wrapf(err, "failed to detect compression for %q", layerFiles[i])
 		}
 		if s.GetCompression() == compression.Uncompressed {
@@ -292,6 +293,7 @@ func resolveLayers(ctx context.Context, store content.Store, layerFiles []string
 				layers[i], err = compressBlob(ctx, store, s, ref, content.WithLabels(labels))
 				if err != nil {
 					s.Close()
+					ra.Close()
 					return nil, err
 				}
 				layers[i].MediaType = images.MediaTypeDockerSchema2LayerGzip
@@ -302,7 +304,7 @@ func resolveLayers(ctx context.Context, store content.Store, layerFiles []string
 			layers[i].MediaType = images.MediaTypeDockerSchema2LayerGzip
 		}
 		s.Close()
-
+		ra.Close()
 	}
 	return layers, nil
 }

--- a/install.go
+++ b/install.go
@@ -66,6 +66,7 @@ func (c *Client) Install(ctx context.Context, image Image, opts ...InstallOpts) 
 		cr := content.NewReader(ra)
 		r, err := compression.DecompressStream(cr)
 		if err != nil {
+			ra.Close()
 			return err
 		}
 		if _, err := archive.Apply(ctx, path, r, archive.WithFilter(func(hdr *tar.Header) (bool, error) {
@@ -87,9 +88,11 @@ func (c *Client) Install(ctx context.Context, image Image, opts ...InstallOpts) 
 			return result, nil
 		})); err != nil {
 			r.Close()
+			ra.Close()
 			return err
 		}
 		r.Close()
+		ra.Close()
 	}
 	return nil
 }


### PR DESCRIPTION
`content.ReaderAt` is used in many places but not closed, It will actually call `os.Open`, this PR complements this close.

https://github.com/containerd/containerd/blob/01ca105b6a7c3d4307fe3d9cd847c7d48519a7bd/content/local/store.go#L128-L141

https://github.com/containerd/containerd/blob/01ca105b6a7c3d4307fe3d9cd847c7d48519a7bd/content/local/readerat.go#L35-L56