### PR TITLE
Freebsd linux containers

### DIFF
--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -1293,6 +1293,5 @@ func freebsdLinuxEmulationMounts(s *Spec) error {
 		Source:      "linsysfs",
 		Options:     []string{}})
 	s.Mounts = mounts
-	//fmt.Printf("Mounts %+v\n\n\n", mounts)
 	return nil
 }

--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -24,9 +24,9 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
-	"runtime"
 
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/content"
@@ -1275,23 +1275,23 @@ func freebsdLinuxEmulationMounts(s *Spec) error {
 		path := filepath.Clean(m.Destination)
 		if path == "/proc" {
 			mounts = append(mounts, specs.Mount{
-				Destination:	"/proc",
-				Type:		"linprocfs",
-				Source:		"linprocfs",
-				Options:	[]string{},
+				Destination: "/proc",
+				Type:        "linprocfs",
+				Source:      "linprocfs",
+				Options:     []string{},
 			})
 			continue
 		}
-		if path ==  "/dev/fd" {
+		if path == "/dev/fd" {
 			m.Options = append(m.Options, "linrdlink")
 		}
 		mounts = append(mounts, m)
 	}
 	mounts = append(mounts, specs.Mount{
-		Destination:	"/sys",
-		Type:		"linsysfs",
-		Source:		"linsysfs",
-		Options:	[]string{},})
+		Destination: "/sys",
+		Type:        "linsysfs",
+		Source:      "linsysfs",
+		Options:     []string{}})
 	s.Mounts = mounts
 	//fmt.Printf("Mounts %+v\n\n\n", mounts)
 	return nil

--- a/platforms/defaults_freebsd.go
+++ b/platforms/defaults_freebsd.go
@@ -1,5 +1,3 @@
-// +build !windows,!freebsd
-
 /*
    Copyright The containerd Authors.
 
@@ -18,7 +16,16 @@
 
 package platforms
 
+
+import (
+        "runtime"
+        specs "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
 // Default returns the default matcher for the platform.
 func Default() MatchComparer {
-	return Only(DefaultSpec())
+	return Ordered(DefaultSpec(), specs.Platform{
+		OS:		"linux",
+		Architecture:	runtime.GOARCH,
+	})
 }

--- a/platforms/defaults_freebsd.go
+++ b/platforms/defaults_freebsd.go
@@ -16,16 +16,15 @@
 
 package platforms
 
-
 import (
-        "runtime"
-        specs "github.com/opencontainers/image-spec/specs-go/v1"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"runtime"
 )
 
 // Default returns the default matcher for the platform.
 func Default() MatchComparer {
 	return Ordered(DefaultSpec(), specs.Platform{
-		OS:		"linux",
-		Architecture:	runtime.GOARCH,
+		OS:           "linux",
+		Architecture: runtime.GOARCH,
 	})
 }

--- a/platforms/defaults_freebsd.go
+++ b/platforms/defaults_freebsd.go
@@ -26,5 +26,7 @@ func Default() MatchComparer {
 	return Ordered(DefaultSpec(), specs.Platform{
 		OS:           "linux",
 		Architecture: runtime.GOARCH,
+		// The Variant field will be empty if arch != ARM.
+		Variant: cpuVariant(),
 	})
 }


### PR DESCRIPTION
This allows running Linux containers on FreeBSD and modifies the mounts so that they represent the linux emulated filesystems, as per: https://wiki.freebsd.org/LinuxJails
Depends on PR: #5472