### PR TITLE
[release/1.4] Prepare v1.4.5 release notes

### DIFF
--- a/releases/v1.4.5.toml
+++ b/releases/v1.4.5.toml
@@ -1,0 +1,28 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release
+previous = "v1.4.4"
+
+pre_release = false
+
+preface = """\
+The fifth patch release for `containerd` 1.4 has fixes in the runc shim and
+CRI plugin as well as an updated runc version to fix some runc regressions.
+
+### Notable Updates
+* **Update runc to rc94** [#5473](https://github.com/containerd/containerd/pull/5473)
+* **Fix leaking socket path in runc shim v2** [#5195](https://github.com/containerd/containerd/pull/5195)
+* **Fix cleanup logic in new container in runc shim v2** [#5206](https://github.com/containerd/containerd/pull/5206)
+* **Fix registry mirror authorization logic in CRI plugin** [#5446](https://github.com/containerd/containerd/pull/5446)
+* **Add support for `userxattr` in overlay snapshotter for kernel 5.11+** [#5076](https://github.com/containerd/containerd/pull/5076)
+"""
+
+# notable prs to include in the release notes, 1234 is the pr number
+[notes]
+
+[breaking]

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.4.4+unknown"
+	Version = "1.4.5+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
See generate notes at https://gist.github.com/dmcgowan/b6e2032d5ad03f6c9fb7b6565fb87bf7