### PR TITLE
Fix seccomp build in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,7 @@ jobs:
             sudo install -m 644 containerd.service ${DESTDIR}/etc/systemd/system
             echo "CONTAINERD_VERSION: '${RELEASE_VER#v}'" | sudo tee ${DESTDIR}/opt/containerd/cluster/version
 
-            sudo -E PATH=$PATH script/setup/install-seccomp
+            sudo PATH=$PATH script/setup/install-seccomp
             USESUDO=true script/setup/install-runc
             script/setup/install-cni
             script/setup/install-critools


### PR DESCRIPTION
The `-E` is incorrect for the seccomp build. This causes environment set through `DESTDIR: ${{ github.workspace }}/cri-release` to get passed to seccomp, which installs the seccomp in the release directory, rather than the system directory needed for runc build.