### PR TITLE
Makefile: make sure manpages are built before install-man

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,7 @@ mkdir -p $(DESTDIR)/man/man$(2);
 gzip -c $(1) >$(DESTDIR)/man/man$(2)/$(3).gz;
 endef
 
-install-man:
+install-man: man
 	@echo "$(WHALE) $@"
 	$(foreach manpage,$(addprefix man/,$(MANPAGES)), $(call installmanpage,$(manpage),$(subst .,,$(suffix $(manpage))),$(notdir $(manpage))))
 


### PR DESCRIPTION
Let install-man depend on man, so manpages are really built before
trying to install them.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>