### PR TITLE
Trim trailing slash in registry path so that URL will be valid

### DIFF
--- a/pkg/cri/server/image_pull.go
+++ b/pkg/cri/server/image_pull.go
@@ -391,6 +391,9 @@ func (c *criService) registryHosts(ctx context.Context, auth *runtime.AuthConfig
 				u.Path = "/v2"
 			}
 
+			// Trim trailing slash in path so that registry URL will be valid
+			u.Path = strings.TrimSuffix(u.Path, "/")
+
 			registries = append(registries, docker.RegistryHost{
 				Client:       client,
 				Authorizer:   authorizer,


### PR DESCRIPTION
Trim trailing slash so that path can't have consecutive trailing slashes causing URL to be invalid