### PR TITLE
Fix reference for unknown type: application/octet-stream

### DIFF
--- a/unpacker.go
+++ b/unpacker.go
@@ -35,6 +35,7 @@ import (
 	"github.com/containerd/containerd/snapshots"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
+	"github.com/containerd/containerd/remotes/docker"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -328,7 +329,7 @@ func (u *unpacker) handlerWrapper(
 				lock.Unlock()
 
 				children = nonLayers
-			case images.MediaTypeDockerSchema2Config, ocispec.MediaTypeImageConfig:
+			case images.MediaTypeDockerSchema2Config, ocispec.MediaTypeImageConfig, docker.LegacyConfigMediaType:
 				lock.Lock()
 				l := layers[desc.Digest]
 				lock.Unlock()


### PR DESCRIPTION
Pr(#2814) haved supported application/octet-stream MediaType, And pr(#3870) haved missed this. we should add application/octet-stream MediaType back.
Fix: #4756 

Additionally,
in containerd v1.3.4, crictl pull redis:2 is ok.
but in containerd v1.4.3, crictl pull redis:2 is error.