### PR TITLE
Pin integration test image for alpine

### DIFF
--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -55,7 +55,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const testUserNSImage = "mirror.gcr.io/library/alpine:latest"
+const testUserNSImage = "mirror.gcr.io/library/alpine:3.13"
 
 // TestRegressionIssue4769 verifies the number of task exit events.
 //


### PR DESCRIPTION
The latest tag is no longer available for alpine, pin to the latest version rather than using latest.