### PR TITLE
Bump github.com/Microsoft/go-winio from 0.4.15 to 0.5.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/containerd/containerd
 go 1.16
 
 require (
-	github.com/Microsoft/go-winio v0.4.17
+	github.com/Microsoft/go-winio v0.5.0
 	github.com/Microsoft/hcsshim v0.8.17
 	github.com/containerd/aufs v1.0.0
 	github.com/containerd/btrfs v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/Microsoft/go-winio v0.4.17-0.20210211115548-6eac466e5fa3/go.mod h1:JP
 github.com/Microsoft/go-winio v0.4.17-0.20210324224401-5516f17a5958/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.4.17 h1:iT12IBVClFevaf8PuVyi3UmZOVh4OqnaLxDTW2O6j3w=
 github.com/Microsoft/go-winio v0.4.17/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
+github.com/Microsoft/go-winio v0.5.0 h1:Elr9Wn+sGKPlkaBvwu4mTrxtmOp3F3yV9qhaHbXGjwU=
+github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/Microsoft/hcsshim v0.8.16/go.mod h1:o5/SZqmR7x9JNKsW3pu+nqHm0MF8vbA+VxGOoXdC600=
 github.com/Microsoft/hcsshim v0.8.17 h1:yFHH5bghP9ij5Y34PPaMOE8g//oXZ0uJQeMENVo2zcI=

--- a/vendor/github.com/Microsoft/go-winio/README.md
+++ b/vendor/github.com/Microsoft/go-winio/README.md
@@ -1,4 +1,4 @@
-# go-winio
+# go-winio [![Build Status](https://github.com/microsoft/go-winio/actions/workflows/ci.yml/badge.svg)](https://github.com/microsoft/go-winio/actions/workflows/ci.yml)
 
 This repository contains utilities for efficiently performing Win32 IO operations in
 Go. Currently, this is focused on accessing named pipes and other file handles, and

--- a/vendor/github.com/Microsoft/go-winio/privilege.go
+++ b/vendor/github.com/Microsoft/go-winio/privilege.go
@@ -28,8 +28,9 @@ const (
 
 	ERROR_NOT_ALL_ASSIGNED syscall.Errno = 1300
 
-	SeBackupPrivilege  = "SeBackupPrivilege"
-	SeRestorePrivilege = "SeRestorePrivilege"
+	SeBackupPrivilege   = "SeBackupPrivilege"
+	SeRestorePrivilege  = "SeRestorePrivilege"
+	SeSecurityPrivilege = "SeSecurityPrivilege"
 )
 
 const (

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/Microsoft/go-winio v0.4.17
+# github.com/Microsoft/go-winio v0.5.0
 ## explicit
 github.com/Microsoft/go-winio
 github.com/Microsoft/go-winio/backuptar


### PR DESCRIPTION
Just hygiene! not much changes are picked up. Though here's the history.

Bumps [github.com/Microsoft/go-winio](https://github.com/Microsoft/go-winio) from 0.4.15 to 0.5.0.
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/Microsoft/go-winio/releases">github.com/Microsoft/go-winio's releases</a>.</em></p>
<blockquote>
<h2>v0.5.0</h2>
<ul>
<li>Added GetFileStandardInfo which returns information from the GetFileInformationByHandleEx syscall with FileStandardInfo specified.
<ul>
<li>This is a potentially breaking change, see <a href="https://github-redirect.dependabot.com/moby/moby/pull/42307">moby/moby#42307</a></li>
</ul>
</li>
</ul>
<h2>v0.4.19</h2>
<ul>
<li>Temporarily reverted implementation of GetFileStandardInfo which returns information from the GetFileInformationByHandleEx syscall with FileStandardInfo specified to address <a href="https://github-redirect.dependabot.com/moby/moby/pull/42307">moby/moby#42307</a></li>
</ul>
<h2>v0.4.18</h2>
<ul>
<li>Added <code>SeSecurityPrivilege</code> constant.</li>
</ul>
<h2>v0.4.17</h2>
<ul>
<li>Added build constraints to Windows specific files.</li>
<li>Fixed error handling for <code>GetFileSystemType</code>.</li>
<li><code>pkg/etw</code> now supports setting a provider group ID.</li>
<li>Switched from <code>os/exec</code> to <code>golang.org/x/sys/execabs</code> for launching processes. This removes a generally unintended affect where the current directory would be searched for the binary to be launched.</li>
<li>Added <code>GetFileStandardInfo</code> which returns information from the <code>GetFileInformationByHandleEx</code> syscall with <code>FileStandardInfo</code> specified.</li>
</ul>
<h2>v0.4.16</h2>
<ul>
<li>Added new bindings, functions, and exported all of the flags in the vhd package. This is to facilitate finer grained control in managing vhds.</li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/microsoft/go-winio/commit/58dba89befbca5b5a2c944f84642f5b0540bcfd5"><code>58dba89</code></a> Merge pull request <a href="https://github-redirect.dependabot.com/Microsoft/go-winio/issues/209">#209</a> from microsoft/revert-204-revert_fileinfo_break</li>
<li><a href="https://github.com/microsoft/go-winio/commit/8f0d50b3b381b741820d6737cfbda5b9284be616"><code>8f0d50b</code></a> Revert &quot;[Temporary] Revert Implement winio.GetFileStandardInfo FileInfo commi...</li>
<li><a href="https://github.com/microsoft/go-winio/commit/5c2e05d71961716a6c392a06ada435aaf5d5302c"><code>5c2e05d</code></a> Merge pull request <a href="https://github-redirect.dependabot.com/Microsoft/go-winio/issues/204">#204</a> from katiewasnothere/revert_fileinfo_break</li>
<li><a href="https://github.com/microsoft/go-winio/commit/a6ee88c751fbd15c93ab446af03b3b135421f30f"><code>a6ee88c</code></a> Merge pull request <a href="https://github-redirect.dependabot.com/Microsoft/go-winio/issues/208">#208</a> from dcantah/build-bins-ci</li>
<li><a href="https://github.com/microsoft/go-winio/commit/1358edb60703d9dd7f44b287e8c8c8aa708fecdc"><code>1358edb</code></a> Build the three binaries in this repo from the ci</li>
<li><a href="https://github.com/microsoft/go-winio/commit/4ee6e51bfdbd8d4b3a499f4503509f5443464731"><code>4ee6e51</code></a> Merge pull request <a href="https://github-redirect.dependabot.com/Microsoft/go-winio/issues/206">#206</a> from katiewasnothere/build_badge</li>
<li><a href="https://github.com/microsoft/go-winio/commit/090e4c6b27d46dd427cc00f12659fa329979599c"><code>090e4c6</code></a> Add build status badge to readme</li>
<li><a href="https://github.com/microsoft/go-winio/commit/3e47278dcaca4afde12ae81d0a968112b2ba47ea"><code>3e47278</code></a> Merge pull request <a href="https://github-redirect.dependabot.com/Microsoft/go-winio/issues/205">#205</a> from katiewasnothere/gh_actions</li>
<li><a href="https://github.com/microsoft/go-winio/commit/085c1a94ab02c4635b3819f237d0e0a6eb459c87"><code>085c1a9</code></a> Add CI github action for testing on push and PR</li>
<li><a href="https://github.com/microsoft/go-winio/commit/e5bd3f6e2840343c8c692408e3efc746e5923249"><code>e5bd3f6</code></a> Revert &quot;Implement winio.GetFileStandardInfo&quot;</li>
<li>Additional commits viewable in <a href="https://github.com/Microsoft/go-winio/compare/v0.4.15...v0.5.0">compare view</a></li>
</ul>
</details>
<br />

Signed-off-by: Davanum Srinivas <davanum@gmail.com>