### PR TITLE
Don't check for apparmor_parser to be present

### DIFF
--- a/pkg/apparmor/apparmor_linux.go
+++ b/pkg/apparmor/apparmor_linux.go
@@ -36,7 +36,7 @@ var (
 // check for apparmor_parser to be present, or if we're running docker-in-docker.
 func hostSupports() bool {
 	checkAppArmor.Do(func() {
-		// see https://github.com/docker/docker/commit/de191e86321f7d3136ff42ff75826b8107399497
+		// see https://github.com/opencontainers/runc/blob/0d49470392206f40eaab3b2190a57fe7bb3df458/libcontainer/apparmor/apparmor_linux.go
 		if _, err := os.Stat("/sys/kernel/security/apparmor"); err == nil && os.Getenv("container") == "" {
 			buf, err := ioutil.ReadFile("/sys/module/apparmor/parameters/enabled")
 			appArmorSupported = err == nil && len(buf) > 1 && buf[0] == 'Y'

--- a/pkg/apparmor/apparmor_linux.go
+++ b/pkg/apparmor/apparmor_linux.go
@@ -38,10 +38,8 @@ func hostSupports() bool {
 	checkAppArmor.Do(func() {
 		// see https://github.com/docker/docker/commit/de191e86321f7d3136ff42ff75826b8107399497
 		if _, err := os.Stat("/sys/kernel/security/apparmor"); err == nil && os.Getenv("container") == "" {
-			if _, err = os.Stat("/sbin/apparmor_parser"); err == nil {
-				buf, err := ioutil.ReadFile("/sys/module/apparmor/parameters/enabled")
-				appArmorSupported = err == nil && len(buf) > 1 && buf[0] == 'Y'
-			}
+			buf, err := ioutil.ReadFile("/sys/module/apparmor/parameters/enabled")
+			appArmorSupported = err == nil && len(buf) > 1 && buf[0] == 'Y'
 		}
 	})
 	return appArmorSupported


### PR DESCRIPTION
https://github.com/containerd/containerd/blob/055c801ededcb7a5e82f47bdeed555cdf6c64bd8/pkg/apparmor/apparmor_linux.go#L32-L48

> which does not check for apparmor_parser to be present

This comment does not match the behavior


https://github.com/opencontainers/runc/blob/0d49470392206f40eaab3b2190a57fe7bb3df458/libcontainer/apparmor/apparmor_linux.go#L13-L27