### PR TITLE
ctr: make exec pty behavior consistent with run

### DIFF
--- a/cmd/ctr/commands/tasks/exec.go
+++ b/cmd/ctr/commands/tasks/exec.go
@@ -117,30 +117,31 @@ var execCommand = cli.Command{
 			con console.Console
 		)
 
-		ioOpts := []cio.Opt{cio.WithFIFODir(context.String("fifo-dir"))}
-		if tty {
+		fifoDir := context.String("fifo-dir")
+		logURI := context.String("log-uri")
+		ioOpts := []cio.Opt{cio.WithFIFODir(fifoDir)}
+		switch {
+		case tty && logURI != "":
+			return errors.New("can't use log-uri with tty")
+		case logURI != "" && fifoDir != "":
+			return errors.New("can't use log-uri with fifo-dir")
+
+		case tty:
 			con = console.Current()
 			defer con.Reset()
 			if err := con.SetRaw(); err != nil {
 				return err
 			}
 			ioCreator = cio.NewCreator(append([]cio.Opt{cio.WithStreams(con, con, nil), cio.WithTerminal}, ioOpts...)...)
-		} else if logURI := context.String("log-uri"); logURI != "" {
+
+		case logURI != "":
 			uri, err := url.Parse(logURI)
 			if err != nil {
 				return err
 			}
-
-			if dir := context.String("fifo-dir"); dir != "" {
-				return errors.New("can't use log-uri with fifo-dir")
-			}
-
-			if tty {
-				return errors.New("can't use log-uri with tty")
-			}
-
 			ioCreator = cio.LogURI(uri)
-		} else {
+
+		default:
 			ioCreator = cio.NewCreator(append([]cio.Opt{cio.WithStreams(stdinC, os.Stdout, os.Stderr)}, ioOpts...)...)
 		}
 
@@ -161,22 +162,19 @@ var execCommand = cli.Command{
 			return err
 		}
 
-		if !detach {
-			if tty {
-				if err := HandleConsoleResize(ctx, process, con); err != nil {
-					logrus.WithError(err).Error("console resize")
-				}
-			} else {
-				sigc := commands.ForwardAllSignals(ctx, process)
-				defer commands.StopCatch(sigc)
-			}
-		}
-
 		if err := process.Start(ctx); err != nil {
 			return err
 		}
 		if detach {
 			return nil
+		}
+		if tty {
+			if err := HandleConsoleResize(ctx, process, con); err != nil {
+				logrus.WithError(err).Error("console resize")
+			}
+		} else {
+			sigc := commands.ForwardAllSignals(ctx, process)
+			defer commands.StopCatch(sigc)
 		}
 		status := <-statusC
 		code, _, err := status.Result()


### PR DESCRIPTION
This series adjusts the pty behavior in `ctr task exec` to be consistent with `ctr run`.  Two changes are made:

1. The `console.Console` is found prior to `task.Exec` and used as with `cio.WithStreams`
2. Initial pty resize and signal handling is moved after `task.Start`

Both of these changes seem necessary on FreeBSD with [runj](https://github.com/samuelkarp/runj); without change 1 keyboard input did not seem to be correctly sent to the shim and without change 2 the initial resize was lost.

I also tested these changes on Linux and `ctr task exec` seemed to continue to work fine both before and after these commits.  I do not currently have access to a Windows machine to test any behavioral differences there.