### PR TITLE
ctr: parse mount options with embedded = character

### DIFF
--- a/cmd/ctr/commands/run/run.go
+++ b/cmd/ctr/commands/run/run.go
@@ -63,8 +63,8 @@ func parseMountFlag(m string) (specs.Mount, error) {
 	}
 
 	for _, field := range fields {
-		v := strings.Split(field, "=")
-		if len(v) != 2 {
+		v := strings.SplitN(field, "=", 2)
+		if len(v) < 2 {
 			return mount, fmt.Errorf("invalid mount specification: expected key=val")
 		}
 


### PR DESCRIPTION
FreeBSD mount options may have embedded = characters.  For example, devfs(5) supports the `ruleset` option which can be passed as `ruleset=4` to indicate that ruleset 4 should be used.