### PR TITLE
Makefile: fix DESTDIR environment variable behaviour

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -90,6 +90,25 @@ You can move them in your global path, `/usr/local/bin` with:
 sudo make install
 ```
 
+The install prefix can be changed by passing the `PREFIX` variable (defaults
+to `/usr/local`).
+
+Note: if you set one of these vars, set them to the same values on all make stages
+(build as well as install).
+
+If you want to prepend an additional prefix on actual installation (eg. packaging or chroot install),
+you can pass it via `DESTDIR` variable:
+
+```sudo
+sudo make install DESTDIR=/tmp/install-x973234/
+```
+
+The above command installs the `containerd` binary to `/tmp/install-x973234/usr/local/bin/containerd`
+
+The current `DESTDIR` convention is supported since containerd v1.6.
+Older releases was using `DESTDIR` for a different purpose that is similar to `PREFIX`.
+
+
 When making any changes to the gRPC API, you can use the installed `protoc`
 compiler to regenerate the API generated code packages with:
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,10 @@ INSTALL ?= install
 ROOTDIR=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 # Base path used to install.
-DESTDIR ?= /usr/local
+# The files will be installed under `$(DESTDIR)/$(PREFIX)`.
+# The convention of `DESTDIR` was changed in containerd v1.6.
+PREFIX        ?= /usr/local
+
 TEST_IMAGE_LIST ?=
 
 # Used to populate variables in version package.
@@ -250,8 +253,8 @@ man/%: docs/man/%.md FORCE
 	go-md2man -in "$<" -out "$@"
 
 define installmanpage
-$(INSTALL) -d $(DESTDIR)/man/man$(2);
-gzip -c $(1) >$(DESTDIR)/man/man$(2)/$(3).gz;
+$(INSTALL) -d $(DESTDIR)/$(PREFIX)/man/man$(2);
+gzip -c $(1) >$(DESTDIR)/$(PREFIX)/man/man$(2)/$(3).gz;
 endef
 
 install-man: man
@@ -346,12 +349,12 @@ clean-test: ## clean up debris from previously failed tests
 
 install: ## install binaries
 	@echo "$(WHALE) $@ $(BINARIES)"
-	@$(INSTALL) -d $(DESTDIR)/bin
-	@$(INSTALL) $(BINARIES) $(DESTDIR)/bin
+	@$(INSTALL) -d $(DESTDIR)/$(PREFIX)/bin
+	@$(INSTALL) $(BINARIES) $(DESTDIR)/$(PREFIX)/bin
 
 uninstall:
 	@echo "$(WHALE) $@"
-	@rm -f $(addprefix $(DESTDIR)/bin/,$(notdir $(BINARIES)))
+	@rm -f $(addprefix $(DESTDIR)/$(PREFIX)/bin/,$(notdir $(BINARIES)))
 
 ifeq ($(GOOS),windows)
 install-deps:


### PR DESCRIPTION
The DESTDIR environment variable is used in the wrong way: since 30+ years
it's common practise using it for specifying *temporary* target *root*
(where eg. packaging infrastructure picks up the install image), instead
of the installation *prefix* on the final target.

Fixing this by introducing PREFIX variable (with default /usr/local) and
using both variables according to the 30 years matured common practise.
That way, distro packagers and other standardized build/installation
systems can easily do correct deployments w/o individual hacks.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>