### PR TITLE
docs: fix deprecation config for default runtime

### DIFF
--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -125,13 +125,11 @@ version = 2
     default_runtime_name = "runc"
 
     # 'plugins."io.containerd.grpc.v1.cri".containerd.default_runtime' is the runtime to use in containerd.
-    # DEPRECATED: use `default_runtime_name` and `plugins."io.containerd.grpc.v1.cri".runtimes` instead.
-    # Remove in containerd 1.4.
+    # DEPRECATED: use `default_runtime_name` and `plugins."io.containerd.grpc.v1.cri".containerd.runtimes` instead.
     [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
 
     # 'plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime' is a runtime to run untrusted workloads on it.
-    # DEPRECATED: use `untrusted` runtime in `plugins."io.containerd.grpc.v1.cri".runtimes` instead.
-    # Remove in containerd 1.4.
+    # DEPRECATED: use `untrusted` runtime in `plugins."io.containerd.grpc.v1.cri".containerd.runtimes` instead.
     [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
 
     # 'plugins."io.containerd.grpc.v1.cri".containerd.runtimes' is a map from CRI RuntimeHandler strings, which specify types


### PR DESCRIPTION
based on https://github.com/containerd/containerd/blob/master/pkg/cri/config/config.go#L305, we still can use
- [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
- [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]

Alo fix typo `plugins."io.containerd.grpc.v1.cri".runtimes` to `plugins."io.containerd.grpc.v1.cri".containerd.runtimes`. 