### PR TITLE
modify the error url of cri

### DIFF
--- a/docs/cri/architecture.md
+++ b/docs/cri/architecture.md
@@ -1,7 +1,7 @@
 # Architecture of The CRI Plugin
 This document describes the architecture of the `cri` plugin for `containerd`.
 
-This plugin is an implementation of Kubernetes [container runtime interface (CRI)](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/apis/cri/runtime/v1alpha2/api.proto). Containerd operates on the same node as the [Kubelet](https://kubernetes.io/docs/reference/generated/kubelet/). The `cri` plugin inside containerd handles all CRI service requests from the Kubelet and uses containerd internals to manage containers and container images.
+This plugin is an implementation of Kubernetes [container runtime interface (CRI)](https://github.com/kubernetes/cri-api/blob/master/pkg/apis/runtime/v1alpha2/api.proto). Containerd operates on the same node as the [Kubelet](https://kubernetes.io/docs/reference/generated/kubelet/). The `cri` plugin inside containerd handles all CRI service requests from the Kubelet and uses containerd internals to manage containers and container images.
 
 The `cri` plugin uses containerd to manage the full container lifecycle and all container images. As also shown below, `cri` manages pod networking via [CNI](https://github.com/containernetworking/cni) (another CNCF project).
 


### PR DESCRIPTION
Signed-off-by: timyinshi <shiguangyin@inspur.com>
the error url is :https://github.com/kubernetes/kubernetes/blob/mast                                                                                                                                                    er/pkg/kubelet/apis/cri/runtime/v1alpha2/api.proto
the right url is: https://github.com/kubernetes/cri-api/blob/master/pkg/apis/runtime/v1alpha2/api.proto