### PR TITLE
docs/cri: update links

### DIFF
--- a/docs/cri/crictl.md
+++ b/docs/cri/crictl.md
@@ -12,7 +12,7 @@ or `crictl` please make sure the issue has not already been submitted.
 If you have not already installed crictl please install the version compatible
 with the `cri` plugin you are using. If you are a user, your deployment
 should have installed crictl for you. If not, get it from your release tarball.
-If you are a developer the current version of crictl is specified [here](../hack/utils.sh).
+If you are a developer the current version of crictl is specified [here](/script/setup/critools-version).
 A helper command has been included to install the dependencies at the right version:
 ```console
 $ make install.deps

--- a/docs/cri/decryption.md
+++ b/docs/cri/decryption.md
@@ -42,4 +42,4 @@ version = 2
 In this example, container image decryption is set to use the "node" key model.
 In addition, the decryption [`stream_processors`](https://github.com/containerd/containerd/blob/master/docs/stream_processors.md) are configured as specified in [containerd/imgcrypt project](https://github.com/containerd/imgcrypt), with the additional field `--decryption-keys-path` configured to specify where decryption keys are located locally in the node.
 
-The `$OCICRYPT_KEYPROVIDER_CONFIG` environment variable is used for [ocicrypt keyprovider protocol](https://github.com/containers/ocicrypt/blob/master/docs/keyprovider.md).
+The `$OCICRYPT_KEYPROVIDER_CONFIG` environment variable is used for [ocicrypt keyprovider protocol](https://github.com/containers/ocicrypt/blob/main/docs/keyprovider.md).


### PR DESCRIPTION
1. fix crictl version link
2. [containers/ocicrypt](https://github.com/containers/ocicrypt): branch master was renamed to main.