### PR TITLE
diff/walking: fix defer cleanup

### DIFF
--- a/diff/walking/differ.go
+++ b/diff/walking/differ.go
@@ -80,7 +80,7 @@ func (s *walkingDiff) Compare(ctx context.Context, lower, upper []mount.Mount, o
 
 	var ocidesc ocispec.Descriptor
 	if err := mount.WithTempMount(ctx, lower, func(lowerRoot string) error {
-		return mount.WithTempMount(ctx, upper, func(upperRoot string) error {
+		return mount.WithTempMount(ctx, upper, func(upperRoot string) (retErr error) {
 			var newReference bool
 			if config.Reference == "" {
 				newReference = true
@@ -96,7 +96,7 @@ func (s *walkingDiff) Compare(ctx context.Context, lower, upper []mount.Mount, o
 				return errors.Wrap(err, "failed to open writer")
 			}
 			defer func() {
-				if err != nil {
+				if retErr != nil {
 					cw.Close()
 					if newReference {
 						if abortErr := s.store.Abort(ctx, config.Reference); abortErr != nil {


### PR DESCRIPTION
`err` may be overwritten
https://github.com/containerd/containerd/blob/c8b33ba297d86550dd5e530527cf5d92246d292f/diff/walking/differ.go#L143-L147
https://github.com/containerd/containerd/blob/c8b33ba297d86550dd5e530527cf5d92246d292f/diff/walking/differ.go#L156-L162