### PR TITLE
Install apparmor parser for arm64 environment

### DIFF
--- a/.zuul/playbooks/containerd-build/integration-test.yaml
+++ b/.zuul/playbooks/containerd-build/integration-test.yaml
@@ -11,7 +11,7 @@
         set -xe
         set -o pipefail
         apt-get update
-        apt-get install -y btrfs-tools libseccomp-dev git pkg-config lsof gperf
+        apt-get install -y btrfs-tools libseccomp-dev git pkg-config lsof gperf apparmor
 
         go version
       chdir: '{{ zuul.project.src_dir }}'


### PR DESCRIPTION
fix for `containerd-integration-test-arm64` CI job failing with missing apparmor.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>