### PR TITLE
Windows periodic job: Add creation timestamp to RG

### DIFF
--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           azcliversion: latest
           inlinescript: |
-            az group create -n ${{ matrix.AZURE_RESOURCE_GROUP }} -l ${{ env.AZURE_DEFAULT_LOCATION }}
+            az group create -n ${{ matrix.AZURE_RESOURCE_GROUP }} -l ${{ env.AZURE_DEFAULT_LOCATION }} --tags creationTimestamp=$(date +%Y-%m-%dT%T%z)
 
       - name: AZTestVMCreate
         uses: azure/CLI@v1


### PR DESCRIPTION
When creating a resource group in Azure for the Windows Periodic Job, we need to tag it with a timestamp so that the automatic cleanup tool will not delete the RG mid run.

Signed-off-by: Adelina Tuvenie <atuvenie@cloudbasesolutions.com>