### PR TITLE
Change Wrapf of non-error to an actual error

### DIFF
--- a/content/local/store.go
+++ b/content/local/store.go
@@ -500,7 +500,7 @@ func (s *store) resumeStatus(ref string, total int64, digester digest.Digester) 
 	if ref != status.Ref {
 		// NOTE(stevvooe): This is fairly catastrophic. Either we have some
 		// layout corruption or a hash collision for the ref key.
-		return status, errors.Wrapf(err, "ref key does not match: %v != %v", ref, status.Ref)
+		return status, errors.Errorf("ref key does not match: %v != %v", ref, status.Ref)
 	}
 
 	if total > 0 && status.Total > 0 && total != status.Total {


### PR DESCRIPTION
Fixes: #3974 

Per this [comment](https://github.com/containerd/containerd/issues/3974#issuecomment-851400334) in #3974 there is definitely a problem in that the `Wrapf` is wrapping a non-error and therefore the return has no error.

Signed-off-by: Phil Estes <estesp@amazon.com>