### PR TITLE
fix invalid validation error checking

### DIFF
--- a/metadata/containers.go
+++ b/metadata/containers.go
@@ -290,7 +290,7 @@ func validateContainer(container *containers.Container) error {
 
 	// image has no validation
 	for k, v := range container.Labels {
-		if err := labels.Validate(k, v); err == nil {
+		if err := labels.Validate(k, v); err != nil {
 			return errors.Wrapf(err, "containers.Labels")
 		}
 	}

--- a/metadata/content.go
+++ b/metadata/content.go
@@ -708,7 +708,7 @@ func (cs *contentStore) checkAccess(ctx context.Context, dgst digest.Digest) err
 
 func validateInfo(info *content.Info) error {
 	for k, v := range info.Labels {
-		if err := labels.Validate(k, v); err == nil {
+		if err := labels.Validate(k, v); err != nil {
 			return errors.Wrapf(err, "info.Labels")
 		}
 	}


### PR DESCRIPTION
validateContainer and validateInfo returning immediately if a label exists 

found these while reviewing if we had any issues regarding calling "github.com/pkg/errors"`.Wrapf(err,` where err is nil... turns out yes. Was looking thanks to learning from https://github.com/containerd/containerd/pull/5560 that if wrapping nil you get nil .. 

** side note `github.com/hashicorp/errorwrap.Wrapf` in our vendor tree (didn't check why) does in fact wrap nil with as `<nil>` and thus returns the nil wrapped vs returning nil) 

Signed-off-by: Mike Brown <brownwm@us.ibm.com>