### PR TITLE
Install specific golang version in Windows CI.

### DIFF
--- a/script/setup/prepare_env_windows.ps1
+++ b/script/setup/prepare_env_windows.ps1
@@ -1,6 +1,6 @@
 # Prepare windows environment for building and running containerd tests
 
-$PACKAGES= "mingw", "git", "golang", "make"
+$PACKAGES= @{ mingw = ""; git = ""; golang = "1.16.4"; make = "" }
 
 write-host "Downloading chocolatey package"
 curl.exe -L "https://packages.chocolatey.org/chocolatey.0.10.15.nupkg" -o 'c:\choco.zip'
@@ -14,8 +14,13 @@ $env:PATH+=";C:\ProgramData\chocolatey\bin"
 
 write-host "Install necessary packages"
 
-foreach ($package in $PACKAGES) {
-    choco.exe install $package --yes
+foreach ($package in $PACKAGES.Keys) {
+    $command = "choco.exe install $package --yes"
+    $version = $PACKAGES[$package]
+    if (-Not [string]::IsNullOrEmpty($version)) {
+        $command += " --version $version"
+    }
+    Invoke-Expression $command
 }
 
 write-host "Set up environment."


### PR DESCRIPTION
For Periodic Windows runs we installed the latest available golang version.
It seems 1.16.5 is creating problems with go.sum. We now introduce the
ability to install specific versions for required packages when preparing
the testing env.

This was noticed after the merge of PR: #5562

Trying to run integration tests with golang v1.16.5 results in:

```
$ make integration
+ integration
# github.com/containerd/containerd/integration/client
..\..\container.go:40:2: missing go.sum entry for module providing package github.com/opencontainers/selinux/go-selinux/label (imported by github.com/containerd/containerd); to add:
        go get github.com/containerd/containerd@v1.5.1
FAIL    github.com/containerd/containerd/integration/client [setup failed]
make: *** [Makefile:192: integration] Error 1
```
The usual suspects like `go mod tidy` do not work.

Every other version up until and including v1.16.4 works.
 

Signed-off-by: Adelina Tuvenie <atuvenie@cloudbasesolutions.com>