### PR TITLE
adds explanation for seccomp unset/unconfined default vs runtime default

### DIFF
--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -97,8 +97,14 @@ version = 2
   # when using containerd with Kubernetes <=1.11.
   disable_proc_mount = false
 
-  # unsetSeccompProfile is the profile containerd/cri will use if the provided seccomp profile is
-  # unset (`""`) for a container (default is `unconfined`)
+  # unset_seccomp_profile is the seccomp profile containerd/cri will use if the seccomp
+  # profile requested over CRI is unset (or nil) for a pod/container (otherwise if this field is not set the
+  # default unset profile will map to `unconfined`)
+    # Note: The default unset seccomp profile should not be confused with the seccomp profile
+    # used in CRI when the runtime default seccomp profile is requested. In the later case, the
+    # default is set by the following code (https://github.com/containerd/containerd/blob/master/contrib/seccomp/seccomp_default.go).
+    # To summarize, there are two different seccomp defaults, the unset default used when the CRI request is
+    # set to nil or `unconfined`, and the default used when the runtime default seccomp profile is requested.
   unset_seccomp_profile = ""
 
   # 'plugins."io.containerd.grpc.v1.cri".containerd' contains config related to containerd


### PR DESCRIPTION
Had a question in slack from a user:
```
Hi，what’s the default seccomp profile for containerd? Is it undefined?  I mean if k8s provided the runtime/default , what seccomp profile would containerd use?
From this parameter settings I think it’s undefined , but I am not sure:

# unsetSeccompProfile is the profile containerd/cri will use if the provided seccomp profile is
# unset (`""`) for a container (default is `unconfined`)
unset_seccomp_profile = ""

```

This doc update should resolve further questions in this regard..

Signed-off-by: Mike Brown <brownwm@us.ibm.com>