### PR TITLE
Makefile: FHS conformant manpage installation pathes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ ROOTDIR=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 # The files will be installed under `$(DESTDIR)/$(PREFIX)`.
 # The convention of `DESTDIR` was changed in containerd v1.6.
 PREFIX        ?= /usr/local
+DATADIR       ?= $(PREFIX)/share
+MANDIR        ?= $(DATADIR)/man
 
 TEST_IMAGE_LIST ?=
 
@@ -253,8 +255,8 @@ man/%: docs/man/%.md FORCE
 	go-md2man -in "$<" -out "$@"
 
 define installmanpage
-$(INSTALL) -d $(DESTDIR)/$(PREFIX)/man/man$(2);
-gzip -c $(1) >$(DESTDIR)/$(PREFIX)/man/man$(2)/$(3).gz;
+$(INSTALL) -d $(DESTDIR)/$(MANDIR)/man$(2);
+gzip -c $(1) >$(DESTDIR)/$(MANDIR)/man$(2)/$(3).gz;
 endef
 
 install-man: man


### PR DESCRIPTION
FHS mandates manpages should go to /usr/share/man (or /usr/local/share/man,
for site local installations) -- /usr/man was an fallout of some ancient
Unices that haven't been fully FHS conformant and usually just a symlink to
/usr/share/man, if existing at all.

Distros sometimes need to override this (eg. MVCC installs), therefore go
the 30+ years common practise way and introduce MANDIR environment variable.
Since it's a subdir under the prefix for general constant and machine
architecture independ data -- which in turn also sometimes wants to be
overridden by distros, it shall be derived from DATADIR variable.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>