### PR TITLE
[release/1.5] cherry pick #5565 to release 1.5 - fix invalid validation error checking

### DIFF
--- a/metadata/containers.go
+++ b/metadata/containers.go
@@ -290,7 +290,7 @@ func validateContainer(container *containers.Container) error {
 
 	// image has no validation
 	for k, v := range container.Labels {
-		if err := labels.Validate(k, v); err == nil {
+		if err := labels.Validate(k, v); err != nil {
 			return errors.Wrapf(err, "containers.Labels")
 		}
 	}

--- a/metadata/content.go
+++ b/metadata/content.go
@@ -708,7 +708,7 @@ func (cs *contentStore) checkAccess(ctx context.Context, dgst digest.Digest) err
 
 func validateInfo(info *content.Info) error {
 	for k, v := range info.Labels {
-		if err := labels.Validate(k, v); err == nil {
+		if err := labels.Validate(k, v); err != nil {
 			return errors.Wrapf(err, "info.Labels")
 		}
 	}


### PR DESCRIPTION
fix invalid validation error checking - validateContainer and validateInfo were returning immediately if a label exists
Signed-off-by: Mike Brown <brownwm@us.ibm.com>
(cherry picked from commit 014748bc04623346725d2a1330d7a2292563a4df)

#5565