### PR TITLE
Fix calling Close twice when stopping CRI service

### DIFF
--- a/pkg/cri/server/cni_conf_syncer.go
+++ b/pkg/cri/server/cni_conf_syncer.go
@@ -121,5 +121,9 @@ func (syncer *cniNetConfSyncer) updateLastStatus(err error) {
 
 // stop stops watcher in the syncLoop.
 func (syncer *cniNetConfSyncer) stop() error {
-	return syncer.watcher.Close()
+	err := syncer.watcher.Close()
+	if err == nil {
+		logrus.Info("CNI network conf syncer stopped")
+	}
+	return err
 }

--- a/pkg/cri/server/events.go
+++ b/pkg/cri/server/events.go
@@ -300,6 +300,7 @@ func (em *eventMonitor) start() <-chan error {
 func (em *eventMonitor) stop() {
 	em.backOff.stop()
 	em.cancel()
+	logrus.Info("Event monitor stopped")
 }
 
 // handleEvent handles a containerd event.


### PR DESCRIPTION
Fix #5584 

It's mainly about cleanup. 

* Stop snapshots syncer on CRI service closing 
  Fix goroutine leak without waiting for the whole process to exit.
  Make it possible to completely shutdown CRI service at runtime.

* Fix duplicate logs when stopping CRI service
  Avoid calling Close() twice when containerd intends to close CRI service.
  This also removes the timeout mechanism for stopping stream server because golang/go#20239 has been fixed.

Test result
```
INFO[2021-06-09T17:37:24.459043312+08:00] containerd successfully booted in 0.154191s
INFO[2021-06-09T17:37:24.880085206+08:00] Start event monitor
INFO[2021-06-09T17:37:24.880242548+08:00] Start snapshots syncer
INFO[2021-06-09T17:37:24.880301803+08:00] Start cni network conf syncer
INFO[2021-06-09T17:37:24.880341629+08:00] Start streaming server
^CINFO[2021-06-09T17:37:31.276850497+08:00] Stop CRI service
INFO[2021-06-09T17:37:31.277399869+08:00] CNI network conf syncer stopped
INFO[2021-06-09T17:37:31.277577896+08:00] Event monitor stopped
INFO[2021-06-09T17:37:31.277765806+08:00] Snapshots syncer stopped
INFO[2021-06-09T17:37:31.277898004+08:00] Stream server stopped
```