### PR TITLE
Add proper Go version before project checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,15 @@ jobs:
     timeout-minutes: 5
 
     steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16.4'
+
+      - shell: bash
+        run: |
+          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+
       - uses: actions/checkout@v2
         with:
           path: src/github.com/containerd/containerd


### PR DESCRIPTION
Due to a change in Go, the go.mod file cannot declare a version of Go
above the installed `go version`; until the default Go version in GitHub
Actions virtual environments is 1.16 or above, we have to install 1.16 before
running the project checks now.

More details: https://github.com/golang/go/issues/46143

The *20210606 version* of virtenv **ubuntu-18.04** is still rolling out so I have only seen this fail one PR build in the last 24 hours, but we should get this change in before it starts breaking all PR runs once rollout of the new virt. env. image is complete.

Signed-off-by: Phil Estes <estesp@amazon.com>