### PR TITLE
cmd: ctr: pprof: build windows code only on windows

### DIFF
--- a/cmd/ctr/commands/pprof/pprof_windows.go
+++ b/cmd/ctr/commands/pprof/pprof_windows.go
@@ -1,3 +1,5 @@
+// +build windows
+
 /*
    Copyright The containerd Authors.
 


### PR DESCRIPTION
pprof_windows.go (and its dependencies) is only needed on windows,
so add build tag so it's skipped on non-windows builds.

This removes dependency on and thus unnecessary code on non-windows
builds.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>