### PR TITLE
[release/1.5] cherry-pick: Add proper Go version before project checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,15 @@ jobs:
     timeout-minutes: 5
 
     steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16.4'
+
+      - shell: bash
+        run: |
+          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+
       - uses: actions/checkout@v2
         with:
           path: src/github.com/containerd/containerd


### PR DESCRIPTION
Due to a change in Go, the go.mod file cannot declare a version of Go
above the installed `go version`; until the default Go version in GitHub
actions virt environments is 1.16, we have to install 1.16 before
running the project checks now.

Signed-off-by: Phil Estes <estesp@amazon.com>
(cherry picked from commit 3ab97443360775ff3fb13a7be2efedb875805824)

Cherry pick of #5594 