### PR TITLE
[release/1.5] cherry-pick #5533: Fix incorrect UA used for registry authentication

### DIFF
--- a/remotes/docker/auth/fetch.go
+++ b/remotes/docker/auth/fetch.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/containerd/containerd/log"
 	remoteserrors "github.com/containerd/containerd/remotes/errors"
+	"github.com/containerd/containerd/version"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context/ctxhttp"
 )
@@ -109,6 +110,9 @@ func FetchTokenWithOAuth(ctx context.Context, client *http.Client, headers http.
 	for k, v := range headers {
 		req.Header[k] = append(req.Header[k], v...)
 	}
+	if len(req.Header.Get("User-Agent")) == 0 {
+		req.Header.Set("User-Agent", "containerd/"+version.Version)
+	}
 
 	resp, err := ctxhttp.Do(ctx, client, req)
 	if err != nil {
@@ -152,6 +156,9 @@ func FetchToken(ctx context.Context, client *http.Client, headers http.Header, t
 
 	for k, v := range headers {
 		req.Header[k] = append(req.Header[k], v...)
+	}
+	if len(req.Header.Get("User-Agent")) == 0 {
+		req.Header.Set("User-Agent", "containerd/"+version.Version)
 	}
 
 	reqParams := req.URL.Query()


### PR DESCRIPTION
Previously, containerd uses Go's default UA "Go-http-client/1.1" while authenticating with registry.
This commit changes it to the pattern like "containerd/v1.5.2" which is used for all other requests.

Signed-off-by: Ethan Chen <pov@mahou-shoujo.moe>
(cherry picked from commit 50ad4b96c4acfde425e1fc6e7411b52658d7af92)

Cherry-pick of https://github.com/containerd/containerd/pull/5533

I saw there is a cherry-pick label but no PR is created, so I help create this for cherry-picking.