### PR TITLE
Allow to pass --no-cgroups option to nvidia-container-cli

### DIFF
--- a/contrib/nvidia/nvidia.go
+++ b/contrib/nvidia/nvidia.go
@@ -111,6 +111,7 @@ type config struct {
 	LDConfig     string
 	Requirements []string
 	OCIHookPath  string
+	NoCgroups    bool
 }
 
 func (c *config) args() []string {
@@ -136,6 +137,9 @@ func (c *config) args() []string {
 	}
 	for _, r := range c.Requirements {
 		args = append(args, fmt.Sprintf("--require=%s", r))
+	}
+	if c.NoCgroups {
+		args = append(args, "--no-cgroups")
 	}
 	args = append(args, "--pid={{pid}}", "{{rootfs}}")
 	return args
@@ -208,4 +212,10 @@ func WithLookupOCIHookPath(name string) Opts {
 		c.OCIHookPath = path
 		return nil
 	}
+}
+
+// WithNoCgroups passes --no-cgroups option to nvidia-container-cli.
+func WithNoCgroups(c *config) error {
+	c.NoCgroups = true
+	return nil
 }


### PR DESCRIPTION
Fixes https://github.com/containerd/containerd/issues/5603

Through discussion in https://github.com/moby/moby/issues/38729#issuecomment-463493866 and https://github.com/containerd/nerdctl/pull/251#pullrequestreview-682850894, it turns out we need to pass `--no-cgroups` option to `nvidia-container-cli` for using it in rootless environmetns.

This commit allows `nvidia` pkg to do this.
