### PR TITLE
add xfs support to devicemapper snapshotter

### DIFF
--- a/snapshots/devmapper/config_test.go
+++ b/snapshots/devmapper/config_test.go
@@ -85,18 +85,20 @@ func TestFieldValidation(t *testing.T) {
 	assert.Assert(t, err != nil)
 
 	multErr := (err).(*multierror.Error)
-	assert.Assert(t, is.Len(multErr.Errors, 3))
+	assert.Assert(t, is.Len(multErr.Errors, 4))
 
 	assert.Assert(t, multErr.Errors[0] != nil, "pool_name is empty")
 	assert.Assert(t, multErr.Errors[1] != nil, "root_path is empty")
 	assert.Assert(t, multErr.Errors[2] != nil, "base_image_size is empty")
+	assert.Assert(t, multErr.Errors[3] != nil, "filesystem type cannot be empty")
 }
 
 func TestExistingPoolFieldValidation(t *testing.T) {
 	config := &Config{
-		PoolName:      "test",
-		RootPath:      "test",
-		BaseImageSize: "10mb",
+		PoolName:       "test",
+		RootPath:       "test",
+		BaseImageSize:  "10mb",
+		FileSystemType: "ext4",
 	}
 
 	err := config.Validate()

--- a/snapshots/devmapper/snapshotter_test.go
+++ b/snapshots/devmapper/snapshotter_test.go
@@ -141,8 +141,14 @@ func testUsage(t *testing.T, snapshotter snapshots.Snapshotter) {
 		"%d > %d", layer2Usage.Size, sizeBytes)
 }
 
-func TestMkfs(t *testing.T) {
+func TestMkfsExt4(t *testing.T) {
 	ctx := context.Background()
-	err := mkfs(ctx, "")
+	err := mkfs(ctx, "ext4", "")
 	assert.ErrorContains(t, err, `mkfs.ext4 couldn't initialize ""`)
+}
+
+func TestMkfsXfs(t *testing.T) {
+	ctx := context.Background()
+	err := mkfs(ctx, "xfs", "")
+	assert.ErrorContains(t, err, `mkfs.xfs couldn't initialize ""`)
 }


### PR DESCRIPTION
ext4 file system was supported before. This adds support for xfs as
well. containerd config file can have fs_type as an additional option
with possible values as "xfs" and "ext4" for now. In future other
fstype support can be added.

Signed-off-by: Alakesh Haloi <alakeshh@amazon.com>

Issue: https://github.com/containerd/containerd/issues/5665

Notes: Initial draft of this PR was based on reading file system type from device and using that for mkfs and other related code. Due to concerns of overhead and inconsistency, switched the design to use labels instead. A new file system type label is introduced that is passed along. If a snapshot has no parents, then file system type passed in config or default in case no type is found. For child snapshots, file system type is inherited from parents. This ensures consistency of file system type for all snapshots.  Snapshots that have already been created with prior default i.e. ext4, will continue to be mounted as ext4. If user moves to xfs type, old snapshots should continue to work. New snapshots created from existing ext4 will still be created and mounted with ext4 in that case.