### PR TITLE
ctr flags of container rootfs propagation

### DIFF
--- a/cmd/ctr/commands/commands_unix.go
+++ b/cmd/ctr/commands/commands_unix.go
@@ -36,5 +36,8 @@ func init() {
 	}, cli.Uint64Flag{
 		Name:  "cpu-period",
 		Usage: "Limit CPU CFS period",
+	}, cli.StringFlag{
+		Name:  "rootfs-propagation",
+		Usage: "set the propagation of the container rootfs",
 	})
 }

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cmd/ctr/commands"
+	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/contrib/apparmor"
 	"github.com/containerd/containerd/contrib/nvidia"
 	"github.com/containerd/containerd/contrib/seccomp"
@@ -265,6 +266,21 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 		}
 		for _, dev := range context.StringSlice("device") {
 			opts = append(opts, oci.WithDevices(dev, "", "rwm"))
+		}
+
+		rootfsPropagation := context.String("rootfs-propagation")
+		if rootfsPropagation != "" {
+			opts = append(opts, func(_ gocontext.Context, _ oci.Client, _ *containers.Container, s *oci.Spec) error {
+				if s.Linux != nil {
+					s.Linux.RootfsPropagation = rootfsPropagation
+				} else {
+					s.Linux = &specs.Linux{
+						RootfsPropagation: rootfsPropagation,
+					}
+				}
+
+				return nil
+			})
 		}
 	}
 


### PR DESCRIPTION
Implement #5381.

A new flag `--rootfs-propagation` is added to `ctr run` and `ctr container create` to set propagation of the container rootfs.
Its value can be one of the propagation settings lists in [Configuare bind propagation](https://docs.docker.com/storage/bind-mounts/#configure-bind-propagation).

If the flag is set, say "rshared", users can check settings through `ctr c info CONTAINER`, and get the output below.
```json
{
    "Spec": {
        "linux": {
            "rootfsPropagation": "rshared"
        }
    }
}
```
