### PR TITLE
Update gotestsum to add timestamps to junit output

### DIFF
--- a/script/setup/install-gotestsum
+++ b/script/setup/install-gotestsum
@@ -14,4 +14,4 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-GO111MODULE=on go install gotest.tools/gotestsum@v1.6.2
+GO111MODULE=on go install gotest.tools/gotestsum@012a85e34a7ce5554057d512e55dcb54b6f2505e


### PR DESCRIPTION
The current release of gotestsum is missing timestamps in the junit
data, which makes it difficult to import in an external system later.

https://github.com/gotestyourself/gotestsum/commit/012a85e34a7ce5554057d512e55dcb
includes the necessary changes to add the timestamp for the test run to
the junit output.