### PR TITLE
Re-enable criu in main integration runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,7 +420,11 @@ jobs:
           RUNC_FLAVOR: ${{ matrix.runc }}
           GOTESTSUM_JUNITFILE: ${{github.workspace}}/test-integration-serial-junit.xml
         run: |
-          sudo -E PATH=$PATH make integration EXTRA_TESTFLAGS=-no-criu TESTFLAGS_RACE=-race
+          extraflags=""
+          [ "${RUNC_FLAVOR}" == "crun" ] && {
+                  extraflags="EXTRA_TESTFLAGS=-no-criu";
+          }
+          sudo -E PATH=$PATH make integration ${extraflags} TESTFLAGS_RACE=-race
         working-directory: src/github.com/containerd/containerd
 
       # Run the integration suite a second time. See discussion in github.com/containerd/containerd/pull/1759
@@ -431,24 +435,11 @@ jobs:
           RUNC_FLAVOR: ${{ matrix.runc }}
           GOTESTSUM_JUNITFILE: ${{github.workspace}}/test-integration-parallel-junit.xml
         run: |
-          sudo -E PATH=$PATH TESTFLAGS_PARALLEL=1 make integration EXTRA_TESTFLAGS=-no-criu
-        working-directory: src/github.com/containerd/containerd
-
-      # CRIU wouldn't work with overlay snapshotter yet.
-      # See https://github.com/containerd/containerd/pull/4708#issuecomment-724322294.
-      - name: CRIU Integration
-        env:
-          GOPROXY: direct
-          TEST_RUNTIME: ${{ matrix.runtime }}
-          RUNC_FLAVOR: ${{ matrix.runc }}
-          GOTESTSUM_JUNITFILE: ${{github.workspace}}/test-integration-criu-junit.xml
-        # crun doesn't have "checkpoint" command.
-        if: ${{ matrix.runc == 'runc' }}
-        run: |
-          sudo -E PATH=$PATH \
-          TESTFLAGS_PARALLEL=1 \
-          TEST_SNAPSHOTTER=native \
-          make integration EXTRA_TESTFLAGS='-run TestCheckpoint'
+          extraflags=""
+          [ "${RUNC_FLAVOR}" == "crun" ] && {
+                  extraflags="EXTRA_TESTFLAGS=-no-criu";
+          }
+          sudo -E PATH=$PATH TESTFLAGS_PARALLEL=1 make integration ${extraflags}
         working-directory: src/github.com/containerd/containerd
 
       - name: CRI Integration Test


### PR DESCRIPTION
Ubuntu kernel updates claim that the criu+overlayfs bug is finally fixed
in released kernels.

Signed-off-by: Phil Estes <estesp@amazon.com>