### PR TITLE
CI: Increase golangci-lint timeout

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,7 @@ issues:
     - EXC0002
 
 run:
-  timeout: 3m
+  timeout: 8m
   skip-dirs:
     - api
     - design


### PR DESCRIPTION
https://github.com/containerd/containerd/pull/5615#issuecomment-863057676

> Linter timeouts ( level=error msg="Timeout exceeded: try increasing it by passing --timeout option").
> Could we rerun tests?

Recently I experienced the timeout of linter. This PR increases the timeout limit +5m for avoiding the same CI failure.