### PR TITLE
runtime,v2: Enable debug when containerd is on debug+ log level

### DIFF
--- a/runtime/v2/binary.go
+++ b/runtime/v2/binary.go
@@ -58,7 +58,8 @@ type binary struct {
 
 func (b *binary) Start(ctx context.Context, opts *types.Any, onClose func()) (_ *shim, err error) {
 	args := []string{"-id", b.bundle.ID}
-	if logrus.GetLevel() == logrus.DebugLevel {
+	switch logrus.GetLevel() {
+	case logrus.DebugLevel, logrus.TraceLevel:
 		args = append(args, "-debug")
 	}
 	args = append(args, "start")


### PR DESCRIPTION
Currently the shimv2 debug is only enabled when containerd is,
specifically, on debug mode.  However, it should be enabled whenever the
CRI runtime is on debug *or any other lower* mode, as in trace mode.
