### PR TITLE
fix: Remove duplicate resolveSnapshotterName

### DIFF
--- a/container_opts.go
+++ b/container_opts.go
@@ -142,10 +142,7 @@ func WithSnapshot(id string) NewContainerOpts {
 	return func(ctx context.Context, client *Client, c *containers.Container) error {
 		// check that the snapshot exists, if not, fail on creation
 		var err error
-		c.Snapshotter, err = client.resolveSnapshotterName(ctx, c.Snapshotter)
-		if err != nil {
-			return err
-		}
+
 		s, err := client.getSnapshotter(ctx, c.Snapshotter)
 		if err != nil {
 			return err
@@ -168,10 +165,7 @@ func WithNewSnapshot(id string, i Image, opts ...snapshots.Opt) NewContainerOpts
 		}
 
 		parent := identity.ChainID(diffIDs).String()
-		c.Snapshotter, err = client.resolveSnapshotterName(ctx, c.Snapshotter)
-		if err != nil {
-			return err
-		}
+
 		s, err := client.getSnapshotter(ctx, c.Snapshotter)
 		if err != nil {
 			return err
@@ -212,10 +206,7 @@ func WithNewSnapshotView(id string, i Image, opts ...snapshots.Opt) NewContainer
 		}
 
 		parent := identity.ChainID(diffIDs).String()
-		c.Snapshotter, err = client.resolveSnapshotterName(ctx, c.Snapshotter)
-		if err != nil {
-			return err
-		}
+
 		s, err := client.getSnapshotter(ctx, c.Snapshotter)
 		if err != nil {
 			return err

--- a/container_opts_unix.go
+++ b/container_opts_unix.go
@@ -53,10 +53,7 @@ func withRemappedSnapshotBase(id string, i Image, uid, gid uint32, readonly bool
 			parent   = identity.ChainID(diffIDs).String()
 			usernsID = fmt.Sprintf("%s-%d-%d", parent, uid, gid)
 		)
-		c.Snapshotter, err = client.resolveSnapshotterName(ctx, c.Snapshotter)
-		if err != nil {
-			return err
-		}
+
 		snapshotter, err := client.getSnapshotter(ctx, c.Snapshotter)
 		if err != nil {
 			return err

--- a/image.go
+++ b/image.go
@@ -329,10 +329,7 @@ func (i *image) Unpack(ctx context.Context, snapshotterName string, opts ...Unpa
 		chain    []digest.Digest
 		unpacked bool
 	)
-	snapshotterName, err = i.client.resolveSnapshotterName(ctx, snapshotterName)
-	if err != nil {
-		return err
-	}
+
 	sn, err := i.client.getSnapshotter(ctx, snapshotterName)
 	if err != nil {
 		return err


### PR DESCRIPTION
resolveSnapshotterName will be called in getSnapshotter, we repeat it twice here.