### PR TITLE
overlay: expose upperdir location of each snapshot via an optional label

### DIFF
--- a/snapshots/overlay/plugin/plugin.go
+++ b/snapshots/overlay/plugin/plugin.go
@@ -29,7 +29,8 @@ import (
 // Config represents configuration for the overlay plugin.
 type Config struct {
 	// Root directory for the plugin
-	RootPath string `toml:"root_path"`
+	RootPath      string `toml:"root_path"`
+	UpperdirLabel bool   `toml:"upperdir_label"`
 }
 
 func init() {
@@ -50,8 +51,13 @@ func init() {
 				root = config.RootPath
 			}
 
+			var oOpts []overlay.Opt
+			if config.UpperdirLabel {
+				oOpts = append(oOpts, overlay.WithUpperdirLabel)
+			}
+
 			ic.Meta.Exports["root"] = root
-			return overlay.NewSnapshotter(root, overlay.AsynchronousRemove)
+			return overlay.NewSnapshotter(root, append(oOpts, overlay.AsynchronousRemove)...)
 		},
 	})
 }


### PR DESCRIPTION
Overlayfs snapshotter provides a generic snapshotting functionality based on overlayfs but it doesn't expose the location of each snapshot's `upperdir` where the changeset between that snapshot and its parent is stored.

From the snapshotter users perspective, `upperdir` can be used for performing overlayfs-specific optimization. For example, this enables to compute diff between a snapshot and its parent faster than comparing the entire filesystem objects between them like done by `walking` differ.

This PR adds as an optional label `containerd.io/snapshot/overlay.upperdir` and this stores the location of `upperdir` that contains the changeset between the labelled snapshot and its parent. This is defined as an **optional** label because this is an implementation detail of overlayfs snapshotter and the futural version of the snapshotter can change the way to treat `upperdir` and stop exposing that label if needed.

An example use case of this is for the overlayfs-oriented diff logic discussed in BuildKit (moby/buildkit#2181 and containerd/continuity#145).

### Configuration to enable this label (disabled by default)

```toml
version = 2

[plugins."io.containerd.snapshotter.v1.overlayfs"]
  upperdir_label = true
```

### Snapshots info

```console
# nerdctl run -d ubuntu:20.04 sleep infinity
# ctr snapshot info sha256:3dd8c8d4fd5b59d543c8f75a67cdfaab30aef5a6d99aea3fe74d8cc69d4e7bf2
{
    "Kind": "Committed",
    "Name": "sha256:3dd8c8d4fd5b59d543c8f75a67cdfaab30aef5a6d99aea3fe74d8cc69d4e7bf2",
    "Parent": "sha256:8d8dceacec7085abcab1f93ac1128765bc6cf0caac334c821e01546bd96eb741",
    "Labels": {
        "containerd.io/snapshot.ref": "sha256:3dd8c8d4fd5b59d543c8f75a67cdfaab30aef5a6d99aea3fe74d8cc69d4e7bf2",
        "containerd.io/snapshot/overlay.upperdir": "/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/3/fs"
    },
    "Created": "2021-06-17T08:36:23.732084958Z",
    "Updated": "2021-06-17T08:36:23.732084958Z"
}
# ctr snapshot info e17fa09a92b84b1983fe5375d1da785d84f85f1fc22bd1581fbc2c5847bc0d5d
{
    "Kind": "Active",
    "Name": "18ec329621bffd30c789915fe21cacc69f508164eb501267edbcb33394f7ac4f",
    "Parent": "sha256:3dd8c8d4fd5b59d543c8f75a67cdfaab30aef5a6d99aea3fe74d8cc69d4e7bf2",
    "Labels": {
        "containerd.io/snapshot/overlay.upperdir": "/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/7/fs"
    },
    "Created": "2021-06-17T08:41:45.468302628Z",
    "Updated": "2021-06-17T08:41:45.468302628Z"
}
```
