### PR TITLE
CI: Switch to the available latest images

### DIFF
--- a/integration/client/client_unix_test.go
+++ b/integration/client/client_unix_test.go
@@ -32,7 +32,7 @@ const (
 )
 
 var (
-	testImage    = "mirror.gcr.io/library/busybox:1.32.0"
+	testImage    = "mirror.gcr.io/library/busybox:1.32"
 	shortCommand = withProcessArgs("true")
 	longCommand  = withProcessArgs("/bin/sh", "-c", "while true; do sleep 1; done")
 )

--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -55,7 +55,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const testUserNSImage = "mirror.gcr.io/library/alpine:3.13"
+const testUserNSImage = "mirror.gcr.io/library/alpine:3.13.5"
 
 // TestRegressionIssue4769 verifies the number of task exit events.
 //


### PR DESCRIPTION
This PR will fix recent CI flakiness.

e.g. https://github.com/containerd/containerd/pull/5624/checks?check_run_id=2872129388#step:10:24
```
failed to resolve reference "mirror.gcr.io/library/busybox:1.32.0": mirror.gcr.io/library/busybox:1.32.0: not found: time="2021-06-21T05:13:34.429018623Z" level=info msg="starting containerd" revision=7a05fcc46b77bd0f0250a3f4d6d74c08c803d794 version=7a05fcc
```

`mirror.gcr.io/library/busybox:1.32.0` is unavailable.

```console
$ curl -s https://mirror.gcr.io//v2/library/busybox/tags/list | jq '.tags'
[
  "1.26.2",
  "1.27.2",
  "1.28",
  "1.29",
  "1.29.2",
  "1.29.3",
  "1.30",
  "1.30.1",
  "1.31",
  "1.31.0",
  "1.31.1",
  "1.32",
  "latest"
]
```

`mirror.gcr.io/library/alpine:3.13` is unavailable.

```console
$ curl -s https://mirror.gcr.io//v2/library/alpine/tags/list | jq '.tags'
[
  "20200428",
  "3",
  "3.10",
  "3.11",
  "3.12",
  "3.12.0",
  "3.12.1",
  "3.13.5",
  "3.3",
  "3.4",
  "3.6",
  "3.7",
  "3.8",
  "3.9",
  "latest"
]
```
