### PR TITLE
[release/1.5 backport] content/local: inline sys.StatATimeAsTime()

### DIFF
--- a/content/local/store_bsd.go
+++ b/content/local/store_bsd.go
@@ -1,4 +1,4 @@
-// +build linux solaris
+// +build darwin freebsd netbsd
 
 /*
    Copyright The containerd Authors.
@@ -26,7 +26,7 @@ import (
 
 func getATime(fi os.FileInfo) time.Time {
 	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
-		return time.Unix(int64(st.Atim.Sec), int64(st.Atim.Nsec)) //nolint: unconvert // int64 conversions ensure the line compiles for 32-bit systems as well.
+		return time.Unix(int64(st.Atimespec.Sec), int64(st.Atimespec.Nsec)) //nolint: unconvert // int64 conversions ensure the line compiles for 32-bit systems as well.
 	}
 
 	return fi.ModTime()

--- a/content/local/store_openbsd.go
+++ b/content/local/store_openbsd.go
@@ -1,4 +1,4 @@
-// +build linux solaris
+// +build openbsd
 
 /*
    Copyright The containerd Authors.


### PR DESCRIPTION
cherry-pick of https://github.com/containerd/containerd/pull/5633
relates to https://github.com/docker/cli/pull/3154

The sys.StatATimeAsTime() utility is currently only used in a single place,
but because it's living in the "sys" package, also brings in other dependencies,
such as Microsoft/hcsshim.

This patch inlines the code from sys.StatATimeAsTime(), to remove that dependency.
