### PR TITLE
sandbox: send pod UID to CNI plugins as K8S_POD_UID

### DIFF
--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -409,6 +409,7 @@ func toCNILabels(id string, config *runtime.PodSandboxConfig) map[string]string 
 		"K8S_POD_NAMESPACE":          config.GetMetadata().GetNamespace(),
 		"K8S_POD_NAME":               config.GetMetadata().GetName(),
 		"K8S_POD_INFRA_CONTAINER_ID": id,
+		"K8S_POD_UID":                config.GetMetadata().GetUid(),
 		"IgnoreUnknown":              "1",
 	}
 }


### PR DESCRIPTION
CNI plugins that need to wait for network state to converge
may want to cancel waiting when a short lived pod is deleted.
However, there is a race between when kubelet asks the runtime
to create the sandbox for the pod, and when the plugin is able
request the pod object from the apiserver. It may be the case
that the plugin receives the new pod, rather than the pod
the sandbox request was initiated for.

Passing the pod UID to the plugin allows the plugin to check
whether the pod it gets from the apiserver is actually the
pod its sandbox request was started for.

(corresponding crio PR is https://github.com/cri-o/cri-o/pull/5026, FWIW)

@estesp @fuweid 