### PR TITLE
devmapper: isolate faulty devices in separate bucket

### DIFF
--- a/snapshots/devmapper/device_info.go
+++ b/snapshots/devmapper/device_info.go
@@ -58,6 +58,8 @@ const (
 	Removed
 	// Faulty means that the device is errored and the snapshotter failed to rollback it
 	Faulty
+	// AlreadyExists means that the device already exists in meta store and the key conflicts.
+	AlreadyExists
 )
 
 func (s DeviceState) String() string {
@@ -88,6 +90,8 @@ func (s DeviceState) String() string {
 		return "Removed"
 	case Faulty:
 		return "Faulty"
+	case AlreadyExists:
+		return "AlreadyExists"
 	default:
 		return fmt.Sprintf("unknown %d", s)
 	}

--- a/snapshots/devmapper/metadata_test.go
+++ b/snapshots/devmapper/metadata_test.go
@@ -165,7 +165,10 @@ func TestPoolMetadata_MarkFaulty(t *testing.T) {
 	err = store.MarkFaulty(testCtx, "test")
 	assert.NilError(t, err)
 
-	saved, err := store.GetDevice(testCtx, info.Name)
+	_, err = store.GetDevice(testCtx, info.Name)
+	// Faulty device has been moved into faulty devices bucket.
+	assert.Assert(t, err != nil)
+	saved, err := store.GetFaultyDevice(testCtx, info.Name)
 	assert.NilError(t, err)
 	assert.Equal(t, saved.State, Faulty)
 	assert.Assert(t, saved.DeviceID > 0)


### PR DESCRIPTION
- Problem

A critical issue can happen that devmapper snapshotter fails to
create new snapshot because the snapshot ID conflicts in scenario
that we will explain later. The error message is like:

"
"failed to create containerd container: failed to save metadata for device "vg0-mythinpool-snap-67451"
(parent: "vg0-mythinpool-snap-45443"): object already exists"
"

- An reproducer

Restarting containerd during processing an snapshot creating request may
lead to this issue, but the possibility is low. To fast reproduce, the
following fault injection is enough:

```go
func (s *Snapshotter) Prepare(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
...
	err = s.withTransaction(ctx, true, func(ctx context.Context) error {
		mounts, err = s.createSnapshot(ctx, snapshots.KindActive, key, parent, opts...)
		// crash injection
		panic("panic after creating snapshot, but before the upper database tx commits")

		return err
	})

	return mounts, err
}
```

- Why snapshot ID conflicts

The snapshot ID is the seqence ID of snapshotter metadata.db.
The snapshot name is in format of $thinpool-snap-$snapshot ID, which stores
in devmapper snapshotter $thinpool.db.

The 2-layer databases are separately wrapped by tranasations. The outer transation
is for metadata.db, and the inner transaction is for $thinpool.db.

As the reproducer, panic comes between inner tx commits and out tx not commits yet.
Then, the sequence ID of metadata.db is not committed, it will reuse the snapshot ID
before panics, but that snapshot ID has already been used by $thinpool.db.

- Idea

Because containerd can quit or crash at any time, it's possible that the snapshot ID can
conflict. Currently, I have no idea how to handle 2 nested transactions.

One possible fix is to isolate faulty devices to s separate buckets to avoid snapshot name
conflicts in such case.

Fixes #5646
Signed-off-by: Eric Ren <renzhen@linux.alibaba.com>