### PR TITLE
snapshot/devmapper: log exported methods correctly

### DIFF
--- a/snapshots/devmapper/snapshotter.go
+++ b/snapshots/devmapper/snapshotter.go
@@ -204,7 +204,7 @@ func (s *Snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 
 // View creates readonly thin device for the given snapshot key
 func (s *Snapshotter) View(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
-	log.G(ctx).WithFields(logrus.Fields{"key": key, "parent": parent}).Debug("prepare")
+	log.G(ctx).WithFields(logrus.Fields{"key": key, "parent": parent}).Debug("view")
 
 	var (
 		mounts []mount.Mount
@@ -490,6 +490,8 @@ func (s *Snapshotter) withTransaction(ctx context.Context, writable bool, fn fun
 
 // Cleanup cleans up all removed and unused resources
 func (s *Snapshotter) Cleanup(ctx context.Context) error {
+	log.G(ctx).Debug("cleanup")
+
 	var removedDevices []*DeviceInfo
 
 	if !s.config.AsyncRemove {


### PR DESCRIPTION
- View was somehow logging itself as "prepare"
- Cleanup should have its debug log as like other exported methods

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>