### PR TITLE
Add ctr command label in NewContainerOpts

### DIFF
--- a/cmd/ctr/commands/commands.go
+++ b/cmd/ctr/commands/commands.go
@@ -37,6 +37,12 @@ var (
 		},
 	}
 
+	// SnapshotterLabels are cli flags specifying labels which will be add to the new snapshot for container.
+	SnapshotterLabels = cli.StringSliceFlag{
+		Name:  "snapshotter-label",
+		Usage: "labels added to the new snapshot for this container.",
+	}
+
 	// LabelFlag is a cli flag specifying labels
 	LabelFlag = cli.StringSliceFlag{
 		Name:  "label",

--- a/cmd/ctr/commands/containers/containers.go
+++ b/cmd/ctr/commands/containers/containers.go
@@ -55,7 +55,7 @@ var createCommand = cli.Command{
 	Name:      "create",
 	Usage:     "create container",
 	ArgsUsage: "[flags] Image|RootFS CONTAINER [COMMAND] [ARG...]",
-	Flags:     append(commands.SnapshotterFlags, commands.ContainerFlags...),
+	Flags:     append(append(commands.SnapshotterFlags, []cli.Flag{commands.SnapshotterLabels}...), commands.ContainerFlags...),
 	Action: func(context *cli.Context) error {
 		var (
 			id     string

--- a/cmd/ctr/commands/run/run.go
+++ b/cmd/ctr/commands/run/run.go
@@ -122,7 +122,9 @@ var Command = cli.Command{
 			Name:  "platform",
 			Usage: "run image for specific platform",
 		},
-	}, append(platformRunFlags, append(commands.SnapshotterFlags, commands.ContainerFlags...)...)...),
+	}, append(platformRunFlags,
+		append(append(commands.SnapshotterFlags, []cli.Flag{commands.SnapshotterLabels}...),
+			commands.ContainerFlags...)...)...),
 	Action: func(context *cli.Context) error {
 		var (
 			err error


### PR DESCRIPTION
Pass command label to snapshotter can help it determine which kind of writable snapshots should be provide.
    
For some snapshotter, such as overlaybd ( https://github.com/alibaba/accelerated-container-image ), it can provide 2 kind of writable snapshot(overlayfs dir or blockdevice) by command label values.
