### PR TITLE
Makefile: fix DESTDIR and PREFIX concatenation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,8 +255,8 @@ man/%: docs/man/%.md FORCE
 	go-md2man -in "$<" -out "$@"
 
 define installmanpage
-$(INSTALL) -d $(DESTDIR)/$(MANDIR)/man$(2);
-gzip -c $(1) >$(DESTDIR)/$(MANDIR)/man$(2)/$(3).gz;
+$(INSTALL) -d $(DESTDIR)$(MANDIR)/man$(2);
+gzip -c $(1) >$(DESTDIR)$(MANDIR)/man$(2)/$(3).gz;
 endef
 
 install-man: man
@@ -351,12 +351,12 @@ clean-test: ## clean up debris from previously failed tests
 
 install: ## install binaries
 	@echo "$(WHALE) $@ $(BINARIES)"
-	@$(INSTALL) -d $(DESTDIR)/$(PREFIX)/bin
-	@$(INSTALL) $(BINARIES) $(DESTDIR)/$(PREFIX)/bin
+	@$(INSTALL) -d $(DESTDIR)$(PREFIX)/bin
+	@$(INSTALL) $(BINARIES) $(DESTDIR)$(PREFIX)/bin
 
 uninstall:
 	@echo "$(WHALE) $@"
-	@rm -f $(addprefix $(DESTDIR)/$(PREFIX)/bin/,$(notdir $(BINARIES)))
+	@rm -f $(addprefix $(DESTDIR)$(PREFIX)/bin/,$(notdir $(BINARIES)))
 
 ifeq ($(GOOS),windows)
 install-deps:


### PR DESCRIPTION
Commits 77374e8 (https://github.com/containerd/containerd/pull/5577) and b5f530a  https://github.com/containerd/containerd/pull/5535) changed handling of the `DESTDIR` and `PREFIX` variables, and introduced a `MANDIR` variable.

However, in those commits, the variables are concatenated with a directory separator (`/`); `$DESTDIR/$PREFIX`. The `$PREFIX` variable (and consequently, the `MANDIR` variable) already should have a leading `/` (absolute path), so there should be no need to add it. In addition, adding the `/`, would not allow either an empty path to be passed (well, it would result in `//` in the path), or for `$PREFIX` to be used with a relative path (with an empty `$PREFIX`).

This patch removes the directory separator.
