### PR TITLE
Update Go to 1.16.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.16.4]
+        go-version: [1.16.5]
         os: [ubuntu-18.04, macos-10.15, windows-2019]
 
     steps:
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.4'
+          go-version: '1.16.5'
 
       - shell: bash
         run: |
@@ -84,7 +84,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.4'
+          go-version: '1.16.5'
 
       - uses: actions/checkout@v2
         with:
@@ -117,7 +117,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.4'
+          go-version: '1.16.5'
 
       - name: Set env
         shell: bash
@@ -163,7 +163,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.4'
+          go-version: '1.16.5'
       - name: Set env
         shell: bash
         run: |
@@ -228,7 +228,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-10.15, windows-2019]
-        go-version: ['1.16.4']
+        go-version: ['1.16.5']
         include:
           # Go 1.13.x is still used by Docker/Moby
           - go-version: '1.13.x'
@@ -274,7 +274,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.4'
+          go-version: '1.16.5'
 
       - uses: actions/checkout@v2
         with:
@@ -355,7 +355,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.4'
+          go-version: '1.16.5'
 
       - uses: actions/checkout@v2
         with:
@@ -498,7 +498,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.4'
+          go-version: '1.16.5'
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.4'
+          go-version: '1.16.5'
 
       - uses: actions/checkout@v2
         with:
@@ -135,7 +135,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.4'
+          go-version: '1.16.5'
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16.4'
+          go-version: '1.16.5'
 
       - name: Set env
         shell: bash

--- a/.zuul/playbooks/containerd-build/run.yaml
+++ b/.zuul/playbooks/containerd-build/run.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.16.4'
+    go_version: '1.16.5'
     arch: arm64
   tasks:
   - name: Build containerd

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,7 +77,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.16.4",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.16.5",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -10,7 +10,7 @@
 #
 # docker build -t containerd-test --build-arg RUNC_VERSION=v1.0.0-rc94 -f Dockerfile.test ../
 
-ARG GOLANG_VERSION=1.16.4
+ARG GOLANG_VERSION=1.16.5
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd


### PR DESCRIPTION
go1.16.5 (released 2021-06-03) includes security fixes to the archive/zip, math/big,
net, and net/http/httputil packages, as well as bug fixes to the linker, the go
command, and the net/http package. See the Go 1.16.5 milestone on the issue
tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.16.5+label%3ACherryPickApproved

full diff: https://github.com/golang/go/compare/go1.16.4...go1.16.5
