### PR TITLE
If capabilities are explicitly added then also add them to the ambient set.

### DIFF
--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -824,6 +824,7 @@ func WithAddedCapabilities(caps []string) SpecOpts {
 				&s.Process.Capabilities.Effective,
 				&s.Process.Capabilities.Permitted,
 				&s.Process.Capabilities.Inheritable,
+				&s.Process.Capabilities.Ambient,
 			} {
 				if !capsContain(*cl, c) {
 					*cl = append(*cl, c)
@@ -844,6 +845,7 @@ func WithDroppedCapabilities(caps []string) SpecOpts {
 				&s.Process.Capabilities.Effective,
 				&s.Process.Capabilities.Permitted,
 				&s.Process.Capabilities.Inheritable,
+				&s.Process.Capabilities.Ambient,
 			} {
 				removeCap(cl, c)
 			}


### PR DESCRIPTION
This change makes it so that we add capabilities to the ambient set if they are explicitly added. So in kubernetes if we add a capability to the container securityContext then that capability will be added to the ambient set in addition to the inheritable, effective, permitted and bounding sets. This will allow users to run a container as non-root while giving it just the capabilities it needs, without having to apply file capabilities and allowing privilege escalation.

If ALL capabilities are added then we don't add ALL capabilities to the ambient set because that would make a non-root user essentially root. We also don't add the defaultUnixCaps i.e. the default capabilities that are always added to inheritable, effective, permitted and bounded sets to the ambient capability set as that will also make non-root user as power full as root.