### PR TITLE
[WIP] Add path prefix to support transparent mirrors

### DIFF
--- a/remotes/docker/config/hosts.go
+++ b/remotes/docker/config/hosts.go
@@ -373,7 +373,7 @@ func parseHostConfig(server string, baseDir string, config hostFileConfig) (host
 		//   OCI v1    - Always use given path as is
 		//   Docker v2 - Always ensure ends with /v2/
 		if len(config.Path) > 0 {
-			if !strings.HasSuffix(config.Path, "/") {
+			if !strings.HasPrefix(config.Path, "/") {
 				config.Path = "/" + config.Path
 			}
 		}

--- a/remotes/docker/config/hosts.go
+++ b/remotes/docker/config/hosts.go
@@ -293,6 +293,7 @@ type hostFileConfig struct {
 
 	Header map[string]interface{} `toml:"header"`
 
+	Path string `toml:"path"`
 	// API (default: "docker")
 	// API Version (default: "v2")
 	// Credentials: helper? name? username? alternate domain? token?
@@ -371,13 +372,18 @@ func parseHostConfig(server string, baseDir string, config hostFileConfig) (host
 		// Define a registry protocol type
 		//   OCI v1    - Always use given path as is
 		//   Docker v2 - Always ensure ends with /v2/
+		if len(config.Path) > 0 {
+			if !strings.HasSuffix(config.Path, "/") {
+				config.Path = "/" + config.Path
+			}
+		}
 		if len(u.Path) > 0 {
 			u.Path = path.Clean(u.Path)
 			if !strings.HasSuffix(u.Path, "/v2") {
-				u.Path = u.Path + "/v2"
+				u.Path = u.Path + "/v2" + config.Path
 			}
 		} else {
-			u.Path = "/v2"
+			u.Path = "/v2" + config.Path
 		}
 		result.path = u.Path
 	}


### PR DESCRIPTION
When using following host configuration,  the request from `critctl pull hello-world` is not the right one on Harbor.

```
server = "https://docker.io"
[host."https://registry.example.com/dockerhub-proxy"]
  capabilities = ["pull", "resolve"]
  skip_verify = true
```

``` 
GET /dockerhub-proxy/v2/library/hello-world/manifests/latest?ns=docker.io HTTP/1.1
```

To get the right one below
```
GET /v2/dockerhub-proxy/library/hello-world/manifests/latest HTTP/1.1
```

I suggest this PR to add `path` parameter in `hostFileConfig`.

As a result, the configuration would be
```
server = "https://docker.io"
[host."https://registry.example.com"]
  capabilities = ["pull", "resolve"]
  path = "/dockerhub-proxy"
  skip_verify = true
```
