### PR TITLE
Move snapshot event publishing into metadata store

### DIFF
--- a/metadata/gc_test.go
+++ b/metadata/gc_test.go
@@ -237,7 +237,7 @@ func TestGCRemove(t *testing.T) {
 
 	if err := db.Update(func(tx *bolt.Tx) error {
 		for _, n := range deleted {
-			if err := c.remove(ctx, tx, n); err != nil {
+			if _, err := c.remove(ctx, tx, n); err != nil {
 				return err
 			}
 		}
@@ -482,7 +482,7 @@ func TestCollectibleResources(t *testing.T) {
 	})
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		if err := c.remove(ctx, tx, all[removeIndex]); err != nil {
+		if _, err := c.remove(ctx, tx, all[removeIndex]); err != nil {
 			return err
 		}
 		return nil

--- a/metadata/plugin/plugin.go
+++ b/metadata/plugin/plugin.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containerd/containerd/pkg/timeout"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/snapshots"
+
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -162,7 +163,7 @@ func init() {
 			}
 
 			dbopts := []metadata.DBOpt{
-				//	metadata.WithEventsPublisher(ic.Events),
+				metadata.WithEventsPublisher(ic.Events),
 			}
 
 			if !shared {


### PR DESCRIPTION
Removes the snapshot event publishing from the snapshot service.

Cleans up metadata plugin registration into separate packages.

Adds an option to metadata db to add a publisher. Adds event
publishing to prepare, commit, and remove snapshot operations.
Adds remove snapshot event to garbage collection.

Adds snapshotter field to snapshot events

----
This is useful for snapshot caches which attempt to track current snapshots based on creation and deletion events. Most snapshots are not removed through the API, but through garbage collection. The end goal being the removal of the inefficient snapshot syncer in the CRI plugin