### PR TITLE
`isLinuxOS`: Treat `android` as `linux`

### DIFF
--- a/platforms/database.go
+++ b/platforms/database.go
@@ -25,7 +25,11 @@ import (
 //
 // The OS value should be normalized before calling this function.
 func isLinuxOS(os string) bool {
-	return os == "linux"
+	switch os {
+	case "linux", "android":
+		return true
+	}
+	return false
 }
 
 // These function are generated from https://golang.org/src/go/build/syslist.go.


### PR DESCRIPTION
Closes #5592
