### PR TITLE
prevent visit for path with /${hdr.Linkname} in host during image pull

### DIFF
--- a/archive/tar.go
+++ b/archive/tar.go
@@ -395,7 +395,7 @@ func createTarFile(ctx context.Context, path, extractDir string, hdr *tar.Header
 
 	// There is no LChmod, so ignore mode for symlink. Also, this
 	// must happen after chown, as that can modify the file mode
-	if err := handleLChmod(hdr, path, hdrInfo); err != nil {
+	if err := handleLChmod(hdr, extractDir, path, hdrInfo); err != nil {
 		return err
 	}
 

--- a/archive/tar_unix.go
+++ b/archive/tar_unix.go
@@ -111,9 +111,13 @@ func handleTarTypeBlockCharFifo(hdr *tar.Header, path string) error {
 	return mknod(path, mode, unix.Mkdev(uint32(hdr.Devmajor), uint32(hdr.Devminor)))
 }
 
-func handleLChmod(hdr *tar.Header, path string, hdrInfo os.FileInfo) error {
+func handleLChmod(hdr *tar.Header, extractDir string, path string, hdrInfo os.FileInfo) error {
 	if hdr.Typeflag == tar.TypeLink {
-		if fi, err := os.Lstat(hdr.Linkname); err == nil && (fi.Mode()&os.ModeSymlink == 0) {
+		hdrLinkname, err := hardlinkRootPath(extractDir, hdr.Linkname)
+		if err != nil {
+			return err
+		}
+		if fi, err := os.Lstat(hdrLinkname); err == nil && (fi.Mode()&os.ModeSymlink == 0) {
 			if err := os.Chmod(path, hdrInfo.Mode()); err != nil && !os.IsNotExist(err) {
 				return err
 			}

--- a/archive/tar_windows.go
+++ b/archive/tar_windows.go
@@ -98,7 +98,7 @@ func handleTarTypeBlockCharFifo(hdr *tar.Header, path string) error {
 	return nil
 }
 
-func handleLChmod(hdr *tar.Header, path string, hdrInfo os.FileInfo) error {
+func handleLChmod(hdr *tar.Header, extractDir string, path string, hdrInfo os.FileInfo) error {
 	return nil
 }
 


### PR DESCRIPTION
hdr.Linkname is always a relative path, and func `handleLChmod` works in '/',
it is ok for os.Symlink, but for Lstat it behaves wrong, the func will
vist files/dirs in host filesystem's root path.

Signed-off-by: Rancho Chen <ranchochen@tencent.com>