### PR TITLE
cmd/ctr: protect contents from GC

### DIFF
--- a/cmd/ctr/commands/images/import.go
+++ b/cmd/ctr/commands/images/import.go
@@ -122,6 +122,13 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 				return err
 			}
 		}
+
+		ctx, done, err := client.WithLease(ctx)
+		if err != nil {
+			return err
+		}
+		defer done(ctx)
+
 		imgs, err := client.Import(ctx, r, opts...)
 		closeErr := r.Close()
 		if err != nil {


### PR DESCRIPTION
"ctr image import" didn't have a lease. Due to that, GC would remove
contents during the import process.

Fixes #5690.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>