### PR TITLE
ctr: Support auth from docker config

### DIFF
--- a/cmd/ctr/commands/resolver.go
+++ b/cmd/ctr/commands/resolver.go
@@ -34,6 +34,7 @@ import (
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/containerd/containerd/remotes/docker/config"
+	"github.com/cpuguy83/dockercfg"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
@@ -87,7 +88,10 @@ func GetResolver(ctx gocontext.Context, clicontext *cli.Context) (remotes.Resolv
 	hostOptions.Credentials = func(host string) (string, string, error) {
 		// If host doesn't match...
 		// Only one host
-		return username, secret, nil
+		if username != "" && secret != "" {
+			return username, secret, nil
+		}
+		return dockercfg.GetRegistryCredentials(dockercfg.ResolveRegistryHost(host))
 	}
 	if clicontext.Bool("plain-http") {
 		hostOptions.DefaultScheme = "http"

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/containerd/zfs v1.0.0
 	github.com/containernetworking/plugins v0.9.1
 	github.com/coreos/go-systemd/v22 v22.3.2
+	github.com/cpuguy83/dockercfg v0.3.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c
 	github.com/docker/go-metrics v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,8 @@ github.com/coreos/go-systemd/v22 v22.3.2 h1:D9/bQk5vlXQFZ6Kwuu6zaiXJ9oTPe68++AzA
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cpuguy83/dockercfg v0.3.0 h1:rsyeW1hvsI0JMAZpQGB3lzb47MSq32Gz/pfBoV5TBxM=
+github.com/cpuguy83/dockercfg v0.3.0/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=

--- a/vendor/github.com/cpuguy83/dockercfg/LICENSE
+++ b/vendor/github.com/cpuguy83/dockercfg/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Brian Goff
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/cpuguy83/dockercfg/README.md
+++ b/vendor/github.com/cpuguy83/dockercfg/README.md
@@ -1,0 +1,8 @@
+### github.com/cpuguy83/dockercfg
+Go library to load docker CLI configs, auths, etc. with minimal deps.
+So far the only deps are on the stdlib.
+
+### Usage
+See the [godoc](https://godoc.org/github.com/cpuguy83/dockercfg) for API details.
+
+I'm currently using this in [zapp](https://github.com/cpuguy83/zapp/blob/d25c43d4cd7ccf29fba184aafbc720a753e1a15d/main.go#L58-L83) to handle registry auth instead of always asking the user to enter it.

--- a/vendor/github.com/cpuguy83/dockercfg/auth.go
+++ b/vendor/github.com/cpuguy83/dockercfg/auth.go
@@ -1,0 +1,184 @@
+package dockercfg
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// This is used by the docker CLI in casses where an oauth identity token is used.
+// In that case the username is stored litterally as `<token>`
+// When fetching the credentials we check for this value to determine if
+const tokenUsername = "<token>"
+
+// GetRegistryCredentials gets registry credentials for the passed in registry host.
+//
+// This will use `LoadDefaultConfig` to read registry auth details from the config.
+// If the config doesn't exist, it will attempt to load registry credentials using the default credential helper for the platform.
+func GetRegistryCredentials(hostname string) (string, string, error) {
+	cfg, err := LoadDefaultConfig()
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return "", "", err
+		}
+		return GetCredentialsFromHelper("", hostname)
+	}
+	return cfg.GetRegistryCredentials(hostname)
+}
+
+// ResolveRegistryHost can be used to transform a docker registry host name into what is used for the docker config/cred helpers
+//
+// This is useful for using with containerd authorizers.
+// Natrually this only transforms docker hub URLs.
+func ResolveRegistryHost(host string) string {
+	switch host {
+	case "index.docker.io", "docker.io", "https://index.docker.io/v1/", "registry-1.docker.io":
+		return "https://index.docker.io/v1/"
+	}
+	return host
+}
+
+// GetRegistryCredentials gets credentials, if any, for the provided hostname
+//
+// Hostnames should already be resolved using `ResolveRegistryAuth`
+//
+// If the returned username string is empty, the password is an identity token.
+func (c *Config) GetRegistryCredentials(hostname string) (string, string, error) {
+	h, ok := c.CredentialHelpers[hostname]
+	if ok {
+		return GetCredentialsFromHelper(h, hostname)
+	}
+
+	if c.CredentialsStore != "" {
+		return GetCredentialsFromHelper(c.CredentialsStore, hostname)
+	}
+
+	auth, ok := c.AuthConfigs[hostname]
+	if !ok {
+		return GetCredentialsFromHelper("", hostname)
+	}
+
+	if auth.IdentityToken != "" {
+		return "", auth.IdentityToken, nil
+	}
+
+	if auth.Username != "" && auth.Password != "" {
+		return auth.Username, auth.Password, nil
+	}
+
+	return DecodeBase64Auth(auth)
+}
+
+// DecodeBase64Auth decodes the legacy file-based auth storage from the docker CLI.
+// It takes the "Auth" filed from AuthConfig and decodes that into a username and password.
+//
+// If "Auth" is empty, an empty user/pass will be returned, but not an error.
+func DecodeBase64Auth(auth AuthConfig) (string, string, error) {
+	if auth.Auth == "" {
+		return "", "", nil
+	}
+
+	decLen := base64.StdEncoding.DecodedLen(len(auth.Auth))
+	decoded := make([]byte, decLen)
+	n, err := base64.StdEncoding.Decode(decoded, []byte(auth.Auth))
+	if err != nil {
+		return "", "", fmt.Errorf("error decoding auth from file: %w", err)
+	}
+
+	if n != decLen {
+		return "", "", fmt.Errorf("decoded value does not match expected length, expected: %d, actual: %d", decLen, n)
+	}
+
+	split := strings.SplitN(string(decoded), ":", 2)
+	if len(split) != 2 {
+		return "", "", errors.New("invalid auth string")
+	}
+
+	return split[0], strings.Trim(split[1], "\x00"), nil
+}
+
+// Errors from credential helpers
+var (
+	ErrCredentialsNotFound         = errors.New("credentials not found in native keychain")
+	ErrCredentialsMissingServerURL = errors.New("no credentials server URL")
+)
+
+// GetCredentialsFromHelper attempts to lookup credentials from the passed in docker credential helper.
+//
+// The credential helpoer should just be the suffix name (no "docker-credential-").
+// If the passed in helper program is empty this will look up the default helper for the platform.
+//
+// If the credentials are not found, no error is returned, only empty credentials.
+//
+// Hostnames should already be resolved using `ResolveRegistryAuth`
+//
+// If the username string is empty, the password string is an identity token.
+func GetCredentialsFromHelper(helper, hostname string) (string, string, error) {
+	if helper == "" {
+		helper = getCredentialHelper()
+	}
+	if helper == "" {
+		return "", "", nil
+	}
+
+	p, err := exec.LookPath("docker-credential-" + helper)
+	if err != nil {
+		return "", "", nil
+	}
+
+	cmd := exec.Command(p, "get")
+	cmd.Stdin = strings.NewReader(hostname)
+
+	b, err := cmd.Output()
+	if err != nil {
+		s := strings.TrimSpace(string(b))
+
+		switch s {
+		case ErrCredentialsNotFound.Error():
+			return "", "", nil
+		case ErrCredentialsMissingServerURL.Error():
+			return "", "", errors.New(s)
+		default:
+		}
+
+		return "", "", err
+	}
+
+	var creds struct {
+		Username string
+		Secret   string
+	}
+
+	if err := json.Unmarshal(b, &creds); err != nil {
+		return "", "", err
+	}
+
+	// When tokenUsername is used, the output is an identity token and the username is garbage
+	if creds.Username == tokenUsername {
+		creds.Username = ""
+	}
+
+	return creds.Username, creds.Secret, nil
+}
+
+// getCredentialHelper gets the default credential helper name for the current platform.
+func getCredentialHelper() string {
+	switch runtime.GOOS {
+	case "linux":
+		if _, err := exec.LookPath("pass"); err == nil {
+			return "pass"
+		}
+		return "secretservice"
+	case "darwin":
+		return "osxkeychain"
+	case "windows":
+		return "wincred"
+	default:
+		return ""
+	}
+}

--- a/vendor/github.com/cpuguy83/dockercfg/config.go
+++ b/vendor/github.com/cpuguy83/dockercfg/config.go
@@ -1,0 +1,65 @@
+package dockercfg
+
+// Config represents the on disk format of the docker CLI's config file.
+type Config struct {
+	AuthConfigs          map[string]AuthConfig  `json:"auths"`
+	HTTPHeaders          map[string]string      `json:"HttpHeaders,omitempty"`
+	PsFormat             string                 `json:"psFormat,omitempty"`
+	ImagesFormat         string                 `json:"imagesFormat,omitempty"`
+	NetworksFormat       string                 `json:"networksFormat,omitempty"`
+	PluginsFormat        string                 `json:"pluginsFormat,omitempty"`
+	VolumesFormat        string                 `json:"volumesFormat,omitempty"`
+	StatsFormat          string                 `json:"statsFormat,omitempty"`
+	DetachKeys           string                 `json:"detachKeys,omitempty"`
+	CredentialsStore     string                 `json:"credsStore,omitempty"`
+	CredentialHelpers    map[string]string      `json:"credHelpers,omitempty"`
+	Filename             string                 `json:"-"` // Note: for internal use only
+	ServiceInspectFormat string                 `json:"serviceInspectFormat,omitempty"`
+	ServicesFormat       string                 `json:"servicesFormat,omitempty"`
+	TasksFormat          string                 `json:"tasksFormat,omitempty"`
+	SecretFormat         string                 `json:"secretFormat,omitempty"`
+	ConfigFormat         string                 `json:"configFormat,omitempty"`
+	NodesFormat          string                 `json:"nodesFormat,omitempty"`
+	PruneFilters         []string               `json:"pruneFilters,omitempty"`
+	Proxies              map[string]ProxyConfig `json:"proxies,omitempty"`
+	Experimental         string                 `json:"experimental,omitempty"`
+	StackOrchestrator    string                 `json:"stackOrchestrator,omitempty"`
+	Kubernetes           *KubernetesConfig      `json:"kubernetes,omitempty"`
+	CurrentContext       string                 `json:"currentContext,omitempty"`
+	CLIPluginsExtraDirs  []string               `json:"cliPluginsExtraDirs,omitempty"`
+	Aliases              map[string]string      `json:"aliases,omitempty"`
+}
+
+// ProxyConfig contains proxy configuration settings
+type ProxyConfig struct {
+	HTTPProxy  string `json:"httpProxy,omitempty"`
+	HTTPSProxy string `json:"httpsProxy,omitempty"`
+	NoProxy    string `json:"noProxy,omitempty"`
+	FTPProxy   string `json:"ftpProxy,omitempty"`
+}
+
+// AuthConfig contains authorization information for connecting to a Registry
+type AuthConfig struct {
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+	Auth     string `json:"auth,omitempty"`
+
+	// Email is an optional value associated with the username.
+	// This field is deprecated and will be removed in a later
+	// version of docker.
+	Email string `json:"email,omitempty"`
+
+	ServerAddress string `json:"serveraddress,omitempty"`
+
+	// IdentityToken is used to authenticate the user and get
+	// an access token for the registry.
+	IdentityToken string `json:"identitytoken,omitempty"`
+
+	// RegistryToken is a bearer token to be sent to a registry
+	RegistryToken string `json:"registrytoken,omitempty"`
+}
+
+// KubernetesConfig contains Kubernetes orchestrator settings
+type KubernetesConfig struct {
+	AllNamespaces string `json:"allNamespaces,omitempty"`
+}

--- a/vendor/github.com/cpuguy83/dockercfg/go.mod
+++ b/vendor/github.com/cpuguy83/dockercfg/go.mod
@@ -1,0 +1,3 @@
+module github.com/cpuguy83/dockercfg
+
+go 1.13

--- a/vendor/github.com/cpuguy83/dockercfg/load.go
+++ b/vendor/github.com/cpuguy83/dockercfg/load.go
@@ -1,0 +1,51 @@
+package dockercfg
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// UserHomeConfigPath returns the path to the docker config in the current user's home dir.
+func UserHomeConfigPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("error looking up user home dir: %w", err)
+	}
+
+	return filepath.Join(home, ".docker", "config.json"), nil
+}
+
+// ConfigPath returns the path to the docker cli config.
+//
+// It will either use the DOCKER_CONFIG env var if set, or the value from `UserHomeConfigPath`
+// DOCKER_CONFIG would be the dir path where `config.json` is stored, this returns the path to config.json.
+func ConfigPath() (string, error) {
+	if p := os.Getenv("DOCKER_CONFIG"); p != "" {
+		return filepath.Join(p, "config.json"), nil
+	}
+	return UserHomeConfigPath()
+}
+
+// LoadDefaultConfig loads the docker cli config from the path returned from `ConfigPath`
+func LoadDefaultConfig() (Config, error) {
+	var cfg Config
+	p, err := ConfigPath()
+	if err != nil {
+		return cfg, err
+	}
+	return cfg, FromFile(p, &cfg)
+}
+
+// FromFile loads config from the specified path into cfg
+func FromFile(configPath string, cfg *Config) error {
+	f, err := os.Open(configPath)
+	if err != nil {
+		return err
+	}
+
+	err = json.NewDecoder(f).Decode(&cfg)
+	f.Close()
+	return err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -140,6 +140,9 @@ github.com/containers/ocicrypt/utils/keyprovider
 ## explicit
 github.com/coreos/go-systemd/v22/daemon
 github.com/coreos/go-systemd/v22/dbus
+# github.com/cpuguy83/dockercfg v0.3.0
+## explicit
+github.com/cpuguy83/dockercfg
 # github.com/cpuguy83/go-md2man/v2 v2.0.0
 github.com/cpuguy83/go-md2man/v2/md2man
 # github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
This should auth pretty much just like the docker CLI does using either
the legacy base64 encoding in ~/.docker/config.json or using docker
credential helpers.

Pulls in a lib, github.com/cpuguy83/dockercfg which is a minimal package
with no external deps.
I've been using this for some custom tooling and it has been working
well.

Downside is this is pretty much useless when using `ctr` with `sudo`.
On my local dev machine I give my user access to the containerd socket and it works well.