### PR TITLE
archive: cleanup lchmod logic

### DIFF
--- a/archive/tar.go
+++ b/archive/tar.go
@@ -393,9 +393,8 @@ func createTarFile(ctx context.Context, path, extractDir string, hdr *tar.Header
 		}
 	}
 
-	// There is no LChmod, so ignore mode for symlink. Also, this
-	// must happen after chown, as that can modify the file mode
-	if err := handleLChmod(hdr, path, hdrInfo); err != nil {
+	// call lchmod after lchown since lchown can modify the file mode
+	if err := lchmod(path, hdrInfo.Mode()); err != nil {
 		return err
 	}
 

--- a/archive/tar_freebsd.go
+++ b/archive/tar_freebsd.go
@@ -18,7 +18,11 @@
 
 package archive
 
-import "golang.org/x/sys/unix"
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
 
 // mknod wraps unix.Mknod.  FreeBSD's unix.Mknod signature is different from
 // other Unix and Unix-like operating systems.
@@ -31,6 +35,14 @@ func lsetxattrCreate(link string, attr string, data []byte) error {
 	err := unix.Lsetxattr(link, attr, data, 0)
 	if err == unix.ENOTSUP || err == unix.EEXIST {
 		return nil
+	}
+	return err
+}
+
+func lchmod(path string, mode os.FileMode) error {
+	err := unix.Fchmodat(unix.AT_FDCWD, path, uint32(mode), unix.AT_SYMLINK_NOFOLLOW)
+	if err != nil {
+		err = &os.PathError{Op: "lchmod", Path: path, Err: err}
 	}
 	return err
 }

--- a/archive/tar_mostunix.go
+++ b/archive/tar_mostunix.go
@@ -18,7 +18,11 @@
 
 package archive
 
-import "golang.org/x/sys/unix"
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
 
 // mknod wraps Unix.Mknod and casts dev to int
 func mknod(path string, mode uint32, dev uint64) error {
@@ -33,4 +37,19 @@ func lsetxattrCreate(link string, attr string, data []byte) error {
 		return nil
 	}
 	return err
+}
+
+// lchmod checks for symlink and changes the mode if not a symlink
+func lchmod(path string, mode os.FileMode) error {
+	fi, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+
+	if fi.Mode()&os.ModeSymlink == 0 {
+		if err := os.Chmod(path, mode); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/archive/tar_unix.go
+++ b/archive/tar_unix.go
@@ -111,21 +111,6 @@ func handleTarTypeBlockCharFifo(hdr *tar.Header, path string) error {
 	return mknod(path, mode, unix.Mkdev(uint32(hdr.Devmajor), uint32(hdr.Devminor)))
 }
 
-func handleLChmod(hdr *tar.Header, path string, hdrInfo os.FileInfo) error {
-	if hdr.Typeflag == tar.TypeLink {
-		if fi, err := os.Lstat(hdr.Linkname); err == nil && (fi.Mode()&os.ModeSymlink == 0) {
-			if err := os.Chmod(path, hdrInfo.Mode()); err != nil && !os.IsNotExist(err) {
-				return err
-			}
-		}
-	} else if hdr.Typeflag != tar.TypeSymlink {
-		if err := os.Chmod(path, hdrInfo.Mode()); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func getxattr(path, attr string) ([]byte, error) {
 	b, err := sysx.LGetxattr(path, attr)
 	if err == unix.ENOTSUP || err == sysx.ENODATA {

--- a/archive/tar_windows.go
+++ b/archive/tar_windows.go
@@ -98,7 +98,7 @@ func handleTarTypeBlockCharFifo(hdr *tar.Header, path string) error {
 	return nil
 }
 
-func handleLChmod(hdr *tar.Header, path string, hdrInfo os.FileInfo) error {
+func lchmod(path string, mode os.FileMode) error {
 	return nil
 }
 


### PR DESCRIPTION
Move to single lchmod interface mirroring other implementations.
Separate logic for freebsd which supports symlink no follow flag.

Also see https://github.com/containerd/continuity/tree/main/driver