### PR TITLE
Add option to disallow pulling the same image in parallel for cri

### DIFF
--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -87,6 +87,11 @@ type ContainerdConfig struct {
 	// remove layers from the content store after successfully unpacking these
 	// layers to the snapshotter.
 	DiscardUnpackedLayers bool `toml:"discard_unpacked_layers" json:"discardUnpackedLayers"`
+
+	// DisableSameImageParallelPull disables the ability to pull the exact same image in parallel which is a common
+	// operation on Kubernetes nodes. This saves some unnecessary fetch/unpack work as it's just duplicated effort
+	// for no gain.
+	DisableSameImageParallelPull bool `toml:"disable_same_image_parallel_pull" json:"disableSameImageParallelPull"`
 }
 
 // CniConfig contains toml config related to cni

--- a/pkg/cri/server/service.go
+++ b/pkg/cri/server/service.go
@@ -104,6 +104,9 @@ type criService struct {
 	// allCaps is the list of the capabilities.
 	// When nil, parsed from CapEff of /proc/self/status.
 	allCaps []string // nolint
+	// imagesInProgress represents any images currently being pulled. This can be used to deduplicate
+	// pulls of the same image to save work.
+	imagesInProgress *inProgress
 }
 
 // NewCRIService returns a new instance of CRIService
@@ -121,6 +124,7 @@ func NewCRIService(config criconfig.Config, client *containerd.Client) (CRIServi
 		sandboxNameIndex:   registrar.NewRegistrar(),
 		containerNameIndex: registrar.NewRegistrar(),
 		initialized:        atomic.NewBool(false),
+		imagesInProgress:   newInProgress(),
 	}
 
 	if client.SnapshotService(c.config.ContainerdConfig.Snapshotter) == nil {


### PR DESCRIPTION
Starting multiple pods on a single node, all using the same image and when the image isn't already present
on the node has pretty bad performance (especially on Windows, as unpack isn't cheap). This
change adds an option to skip this, by keeping an in memory cache of in progress pulls
at the cri layer.

Ideally this would be handled by disallowing an unpack of the same layer at the same time, but this seems like a nice middle ground.

Related to: https://github.com/containerd/containerd/issues/5675

Signed-off-by: Daniel Canter <dcanter@microsoft.com>