### PR TITLE
Fix missing Body.Close() calls on push to docker remote

### DIFF
--- a/remotes/docker/pusher.go
+++ b/remotes/docker/pusher.go
@@ -190,6 +190,7 @@ func (p dockerPusher) push(ctx context.Context, desc ocispec.Descriptor, ref str
 				return nil, err
 			}
 		}
+		defer resp.Body.Close()
 
 		switch resp.StatusCode {
 		case http.StatusOK, http.StatusAccepted, http.StatusNoContent:
@@ -382,6 +383,7 @@ func (pw *pushWriter) Commit(ctx context.Context, size int64, expected digest.Di
 	if resp.err != nil {
 		return resp.err
 	}
+	defer resp.Response.Body.Close()
 
 	// 201 is specified return status, some registries return
 	// 200, 202 or 204.


### PR DESCRIPTION
Discovered this while using HTTP tracing via OpenTelemetry inside of
buildkitd, where the trace spans were not being reported for the
registry PUT http requests.  The spans are only reported on the Close
for the Body, after adding these Close calls, the spans are reported as
expected.

[related buildkit code](https://github.com/moby/buildkit/blob/1d0597e85a1ee56c24b11c800a185eec31758332/util/tracing/tracing.go#L130-L133)

cc @tonistiigi 