### PR TITLE
[release/1.4 backport] Fix missing Body.Close() calls on push to docker remote

### DIFF
--- a/remotes/docker/pusher.go
+++ b/remotes/docker/pusher.go
@@ -155,6 +155,7 @@ func (p dockerPusher) Push(ctx context.Context, desc ocispec.Descriptor) (conten
 				return nil, err
 			}
 		}
+		defer resp.Body.Close()
 
 		switch resp.StatusCode {
 		case http.StatusOK, http.StatusAccepted, http.StatusNoContent:
@@ -338,6 +339,7 @@ func (pw *pushWriter) Commit(ctx context.Context, size int64, expected digest.Di
 	if resp == nil {
 		return errors.New("no response")
 	}
+	defer resp.Body.Close()
 
 	// 201 is specified return status, some registries return
 	// 200, 202 or 204.


### PR DESCRIPTION

> note: This is a slightly modified version of the commit in main, because
> pusher.Commit() uses a regular http.Response, not a wrapped one.


backport of https://github.com/containerd/containerd/pull/5712

Discovered this while using HTTP tracing via OpenTelemetry inside of
buildkitd, where the trace spans were not being reported for the
registry PUT http requests.  The spans are only reported on the Close
for the Body, after adding these Close calls, the spans are reported as
expected.

Signed-off-by: coryb <cbennett@netflix.com>
(cherry picked from commit 894b6ae39b9266411d0d4e6325235390c06fc0ab)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>