### PR TITLE
Fix resolver request header

### DIFF
--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -148,11 +148,11 @@ func NewResolver(options ResolverOptions) remotes.Resolver {
 	resolveHeader := http.Header{}
 	if _, ok := options.Headers["Accept"]; !ok {
 		// set headers for all the types we support for resolution.
-		resolveHeader.Set("Accept", strings.Join([]string{
+		resolveHeader["Accept"] = []string{
 			images.MediaTypeDockerSchema2Manifest,
 			images.MediaTypeDockerSchema2ManifestList,
 			ocispec.MediaTypeImageManifest,
-			ocispec.MediaTypeImageIndex, "*/*"}, ", "))
+			ocispec.MediaTypeImageIndex, "*/*"}
 	} else {
 		resolveHeader["Accept"] = options.Headers["Accept"]
 		delete(options.Headers, "Accept")


### PR DESCRIPTION
Fix: https://github.com/containerd/containerd/issues/5632

Currently,  **ctr --debug images pull  \<Image\>** shows
```
request.header.accept="application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.oci.image.index.v1+json, */*"
```

After change resolveHeader["Accept"] to []string, **ctr --debug images pull  \<Image\>** shows
```
request.header.accept=application/vnd.docker.distribution.manifest.v2+json request.header.accept.1=application/vnd.docker.distribution.manifest.list.v2+json request.header.accept.2=application/vnd.oci.image.manifest.v1+json request.header.accept.3=application/vnd.oci.image.index.v1+json request.header.accept.4="*/*"
```