### PR TITLE
Add timestamp to flaky restart monitor test

### DIFF
--- a/integration/client/restart_monitor_linux_test.go
+++ b/integration/client/restart_monitor_linux_test.go
@@ -99,8 +99,8 @@ version = 2
 		}
 		time.Sleep(epsilon)
 	}
-	t.Fatalf("the task was not restarted in %s + %s",
-		interval.String(), epsilon.String())
+	t.Fatalf("%v: the task was not restarted in %s + %s",
+		time.Now(), interval.String(), epsilon.String())
 }
 
 // withRestartStatus is a copy of "github.com/containerd/containerd/runtime/restart".WithStatus.

--- a/integration/client/restart_monitor_linux_test.go
+++ b/integration/client/restart_monitor_linux_test.go
@@ -81,7 +81,7 @@ version = 2
 	task.Kill(ctx, syscall.SIGKILL)
 	begin := time.Now()
 	deadline := begin.Add(interval).Add(epsilon)
-	for time.Now().Before(deadline) {
+	for {
 		status, err := task.Status(ctx)
 		now := time.Now()
 		if err != nil {
@@ -96,6 +96,9 @@ version = 2
 				t.Logf("the task was restarted within %s", elapsed.String())
 				return
 			}
+		}
+		if time.Now().After(deadline) {
+			break
 		}
 		time.Sleep(epsilon)
 	}


### PR DESCRIPTION
This adds the timestamp to the final log to help debug this flaky test. See logs below
```
    default:     restart_monitor_linux_test.go:92: 2021-07-13 16:21:49.450742838 +0000 UTC m=+145.976532745: status={"stopped" '\u0089' "2021-07-13 16:21:49.446496309 +0000 UTC"}
    default:     restart_monitor_linux_test.go:92: 2021-07-13 16:21:50.459980678 +0000 UTC m=+146.985770567: status={"stopped" '\u0089' "2021-07-13 16:21:49.446496309 +0000 UTC"}
    default:     restart_monitor_linux_test.go:92: 2021-07-13 16:21:51.467907321 +0000 UTC m=+147.993697215: status={"stopped" '\u0089' "2021-07-13 16:21:49.446496309 +0000 UTC"}
    default:     restart_monitor_linux_test.go:92: 2021-07-13 16:21:52.47103632 +0000 UTC m=+148.996826201: status={"stopped" '\u0089' "2021-07-13 16:21:49.446496309 +0000 UTC"}
    default:     restart_monitor_linux_test.go:92: 2021-07-13 16:21:53.478105735 +0000 UTC m=+150.003895616: status={"stopped" '\u0089' "2021-07-13 16:21:49.446496309 +0000 UTC"}
    default:     restart_monitor_linux_test.go:92: 2021-07-13 16:21:54.507516616 +0000 UTC m=+151.033306499: status={"stopped" '\u0089' "2021-07-13 16:21:49.446496309 +0000 UTC"}
    default:     restart_monitor_linux_test.go:92: 2021-07-13 16:21:55.511818588 +0000 UTC m=+152.037608464: status={"stopped" '\u0089' "2021-07-13 16:21:49.446496309 +0000 UTC"}
    default:     restart_monitor_linux_test.go:92: 2021-07-13 16:21:56.520061366 +0000 UTC m=+153.045851249: status={"stopped" '\u0089' "2021-07-13 16:21:49.446496309 +0000 UTC"}
    default:     restart_monitor_linux_test.go:102: the task was not restarted in 10s + 1s
```
The last log should not have run until after 16:22:0 and additional checks at 1 second intervals in between. This was seen on the VM test which sometimes has had pauses, but this will help diagnose how long the delay is. 