### PR TITLE
[CRI] Support CRI plugins

### DIFF
--- a/cmd/containerd/builtins_cri.go
+++ b/cmd/containerd/builtins_cri.go
@@ -19,4 +19,7 @@
 
 package main
 
-import _ "github.com/containerd/containerd/pkg/cri"
+import (
+	_ "github.com/containerd/containerd/pkg/cri"
+	_ "github.com/containerd/containerd/pkg/cri/services/cc"
+)

--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -67,6 +67,10 @@ type Runtime struct {
 	// be loaded from the cni config directory by go-cni. Set the value to 0 to
 	// load all config files (no arbitrary limit). The legacy default value is 1.
 	NetworkPluginMaxConfNum int `toml:"cni_max_conf_num" json:"cniMaxConfNum"`
+	// CRIHandler control cri specific implementations.
+	// e.g. The "vm" is the mode used by the vm based runtime,
+	// the "cc" is the mode used by the confidential computing.
+	CRIHandler string `toml:"cri_handler" json:"cri_handler"`
 }
 
 // ContainerdConfig contains toml config related to containerd
@@ -335,6 +339,8 @@ const (
 	// KeyModelNode is the key model where key for encrypted images reside
 	// on the worker nodes
 	KeyModelNode = "node"
+	// CriDefaultHandler is the default runtime mode
+	DefaultCRIHandler = "default"
 )
 
 // ValidatePluginConfig validates the given plugin configuration.

--- a/pkg/cri/cri.go
+++ b/pkg/cri/cri.go
@@ -97,7 +97,7 @@ func initCRIService(ic *plugin.InitContext) (interface{}, error) {
 		return nil, fmt.Errorf("failed to create containerd client: %w", err)
 	}
 
-	s, err := server.NewCRIService(c, client)
+	s, err := server.NewCRIService(&c, client)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create CRI service: %w", err)
 	}

--- a/pkg/cri/cri.go
+++ b/pkg/cri/cri.go
@@ -97,18 +97,18 @@ func initCRIService(ic *plugin.InitContext) (interface{}, error) {
 		return nil, fmt.Errorf("failed to create containerd client: %w", err)
 	}
 
-	s, err := server.NewCRIService(&c, client)
+	manager, err := server.NewCRIManager(c, client)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create CRI service: %w", err)
 	}
 
 	go func() {
-		if err := s.Run(); err != nil {
-			log.G(ctx).WithError(err).Fatal("Failed to run CRI service")
+		if err := manager.Run(); err != nil {
+			log.G(ctx).WithError(err).Fatal("Failed to run CRI manager")
 		}
 		// TODO(random-liu): Whether and how we can stop containerd.
 	}()
-	return s, nil
+	return manager, nil
 }
 
 // getServicesOpts get service options from plugin context.

--- a/pkg/cri/server/container_attach.go
+++ b/pkg/cri/server/container_attach.go
@@ -31,7 +31,7 @@ import (
 
 // Attach prepares a streaming endpoint to attach to a running container, and returns the address.
 func (c *criService) Attach(ctx context.Context, r *runtime.AttachRequest) (*runtime.AttachResponse, error) {
-	cntr, err := c.containerStore.Get(r.GetContainerId())
+	cntr, err := c.ContainerStore.Get(r.GetContainerId())
 	if err != nil {
 		return nil, fmt.Errorf("failed to find container in store: %w", err)
 	}
@@ -47,7 +47,7 @@ func (c *criService) attachContainer(ctx context.Context, id string, stdin io.Re
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	// Get container from our container store.
-	cntr, err := c.containerStore.Get(id)
+	cntr, err := c.ContainerStore.Get(id)
 	if err != nil {
 		return fmt.Errorf("failed to find container %q in store: %w", id, err)
 	}

--- a/pkg/cri/server/container_create.go
+++ b/pkg/cri/server/container_create.go
@@ -52,7 +52,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	config := r.GetConfig()
 	log.G(ctx).Debugf("Container config %+v", config)
 	sandboxConfig := r.GetSandboxConfig()
-	sandbox, err := c.sandboxStore.Get(r.GetPodSandboxId())
+	sandbox, err := c.SandboxStore.Get(r.GetPodSandboxId())
 	if err != nil {
 		return nil, fmt.Errorf("failed to find sandbox id %q: %w", r.GetPodSandboxId(), err)
 	}
@@ -74,13 +74,13 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	containerName := metadata.Name
 	name := makeContainerName(metadata, sandboxConfig.GetMetadata())
 	log.G(ctx).Debugf("Generated id %q for container %q", id, name)
-	if err = c.containerNameIndex.Reserve(name, id); err != nil {
+	if err = c.ContainerNameIndex.Reserve(name, id); err != nil {
 		return nil, fmt.Errorf("failed to reserve container name %q: %w", name, err)
 	}
 	defer func() {
 		// Release the name if the function returns with an error.
 		if retErr != nil {
-			c.containerNameIndex.ReleaseByName(name)
+			c.ContainerNameIndex.ReleaseByName(name)
 		}
 	}()
 
@@ -276,7 +276,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	}()
 
 	// Add container into container store.
-	if err := c.containerStore.Add(container); err != nil {
+	if err := c.ContainerStore.Add(container); err != nil {
 		return nil, fmt.Errorf("failed to add container %q into store: %w", id, err)
 	}
 

--- a/pkg/cri/server/container_create_linux.go
+++ b/pkg/cri/server/container_create_linux.go
@@ -178,7 +178,7 @@ func (c *criService) containerSpec(
 	}
 	if len(labelOptions) == 0 {
 		// Use pod level SELinux config
-		if sandbox, err := c.sandboxStore.Get(sandboxID); err == nil {
+		if sandbox, err := c.SandboxStore.Get(sandboxID); err == nil {
 			labelOptions, err = selinux.DupSecOpt(sandbox.ProcessLabel)
 			if err != nil {
 				return nil, err

--- a/pkg/cri/server/container_create_linux_test.go
+++ b/pkg/cri/server/container_create_linux_test.go
@@ -920,7 +920,9 @@ func TestGenerateSeccompSecurityProfileSpecOpts(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("TestCase %q", desc), func(t *testing.T) {
-			cri := &criService{}
+			cri := &criService{
+				config: &config.Config{},
+			}
 			cri.config.UnsetSeccompProfile = test.defaultProfile
 			ssp := test.sp
 			csp, err := generateSeccompSecurityProfile(

--- a/pkg/cri/server/container_exec.go
+++ b/pkg/cri/server/container_exec.go
@@ -25,7 +25,7 @@ import (
 
 // Exec prepares a streaming endpoint to execute a command in the container, and returns the address.
 func (c *criService) Exec(ctx context.Context, r *runtime.ExecRequest) (*runtime.ExecResponse, error) {
-	cntr, err := c.containerStore.Get(r.GetContainerId())
+	cntr, err := c.ContainerStore.Get(r.GetContainerId())
 	if err != nil {
 		return nil, fmt.Errorf("failed to find container %q in store: %w", r.GetContainerId(), err)
 	}

--- a/pkg/cri/server/container_execsync.go
+++ b/pkg/cri/server/container_execsync.go
@@ -195,7 +195,7 @@ func (c *criService) execInternal(ctx context.Context, container containerd.Cont
 // to exit and log the exit code, but dockershim won't.
 func (c *criService) execInContainer(ctx context.Context, id string, opts execOptions) (*uint32, error) {
 	// Get container from our container store.
-	cntr, err := c.containerStore.Get(id)
+	cntr, err := c.ContainerStore.Get(id)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to find container %q in store: %w", id, err)

--- a/pkg/cri/server/container_list.go
+++ b/pkg/cri/server/container_list.go
@@ -30,7 +30,7 @@ import (
 func (c *criService) ListContainers(ctx context.Context, r *runtime.ListContainersRequest) (*runtime.ListContainersResponse, error) {
 	start := time.Now()
 	// List all containers from store.
-	containersInStore := c.containerStore.List()
+	containersInStore := c.ContainerStore.List()
 
 	var containers []*runtime.Container
 	for _, container := range containersInStore {
@@ -60,10 +60,10 @@ func toCRIContainer(container containerstore.Container) *runtime.Container {
 }
 
 func (c *criService) normalizeContainerFilter(filter *runtime.ContainerFilter) {
-	if cntr, err := c.containerStore.Get(filter.GetId()); err == nil {
+	if cntr, err := c.ContainerStore.Get(filter.GetId()); err == nil {
 		filter.Id = cntr.ID
 	}
-	if sb, err := c.sandboxStore.Get(filter.GetPodSandboxId()); err == nil {
+	if sb, err := c.SandboxStore.Get(filter.GetPodSandboxId()); err == nil {
 		filter.PodSandboxId = sb.ID
 	}
 }
@@ -79,7 +79,7 @@ func (c *criService) filterCRIContainers(containers []*runtime.Container, filter
 	// included in the filter.
 	sb := filter.GetPodSandboxId()
 	if sb != "" {
-		sandbox, err := c.sandboxStore.Get(sb)
+		sandbox, err := c.SandboxStore.Get(sb)
 		if err == nil {
 			sb = sandbox.ID
 		}

--- a/pkg/cri/server/container_list_test.go
+++ b/pkg/cri/server/container_list_test.go
@@ -275,14 +275,14 @@ func TestListContainers(t *testing.T) {
 
 	// Inject test sandbox metadata
 	for _, sb := range sandboxesInStore {
-		assert.NoError(t, c.sandboxStore.Add(sb))
+		assert.NoError(t, c.SandboxStore.Add(sb))
 	}
 
 	// Inject test container metadata
 	for _, cntr := range containersInStore {
 		container, err := cntr.toContainer()
 		assert.NoError(t, err)
-		assert.NoError(t, c.containerStore.Add(container))
+		assert.NoError(t, c.ContainerStore.Add(container))
 	}
 
 	for testdesc, testdata := range map[string]struct {

--- a/pkg/cri/server/container_log_reopen.go
+++ b/pkg/cri/server/container_log_reopen.go
@@ -28,7 +28,7 @@ import (
 // ReopenContainerLog asks the cri plugin to reopen the stdout/stderr log file for the container.
 // This is often called after the log file has been rotated.
 func (c *criService) ReopenContainerLog(ctx context.Context, r *runtime.ReopenContainerLogRequest) (*runtime.ReopenContainerLogResponse, error) {
-	container, err := c.containerStore.Get(r.GetContainerId())
+	container, err := c.ContainerStore.Get(r.GetContainerId())
 	if err != nil {
 		return nil, fmt.Errorf("an error occurred when try to find container %q: %w", r.GetContainerId(), err)
 	}

--- a/pkg/cri/server/container_remove.go
+++ b/pkg/cri/server/container_remove.go
@@ -33,7 +33,7 @@ import (
 // RemoveContainer removes the container.
 func (c *criService) RemoveContainer(ctx context.Context, r *runtime.RemoveContainerRequest) (_ *runtime.RemoveContainerResponse, retErr error) {
 	start := time.Now()
-	container, err := c.containerStore.Get(r.GetContainerId())
+	container, err := c.ContainerStore.Get(r.GetContainerId())
 	if err != nil {
 		if !errdefs.IsNotFound(err) {
 			return nil, fmt.Errorf("an error occurred when try to find container %q: %w", r.GetContainerId(), err)
@@ -102,9 +102,9 @@ func (c *criService) RemoveContainer(ctx context.Context, r *runtime.RemoveConta
 			volatileContainerRootDir, err)
 	}
 
-	c.containerStore.Delete(id)
+	c.ContainerStore.Delete(id)
 
-	c.containerNameIndex.ReleaseByKey(id)
+	c.ContainerNameIndex.ReleaseByKey(id)
 
 	containerRemoveTimer.WithValues(i.Runtime.Name).UpdateSince(start)
 

--- a/pkg/cri/server/container_start.go
+++ b/pkg/cri/server/container_start.go
@@ -42,7 +42,7 @@ import (
 // StartContainer starts the container.
 func (c *criService) StartContainer(ctx context.Context, r *runtime.StartContainerRequest) (retRes *runtime.StartContainerResponse, retErr error) {
 	start := time.Now()
-	cntr, err := c.containerStore.Get(r.GetContainerId())
+	cntr, err := c.ContainerStore.Get(r.GetContainerId())
 	if err != nil {
 		return nil, fmt.Errorf("an error occurred when try to find container %q: %w", r.GetContainerId(), err)
 	}
@@ -82,7 +82,7 @@ func (c *criService) StartContainer(ctx context.Context, r *runtime.StartContain
 	}()
 
 	// Get sandbox config from sandbox store.
-	sandbox, err := c.sandboxStore.Get(meta.SandboxID)
+	sandbox, err := c.SandboxStore.Get(meta.SandboxID)
 	if err != nil {
 		return nil, fmt.Errorf("sandbox %q not found: %w", meta.SandboxID, err)
 	}

--- a/pkg/cri/server/container_stats.go
+++ b/pkg/cri/server/container_stats.go
@@ -27,7 +27,7 @@ import (
 // ContainerStats returns stats of the container. If the container does not
 // exist, the call returns an error.
 func (c *criService) ContainerStats(ctx context.Context, in *runtime.ContainerStatsRequest) (*runtime.ContainerStatsResponse, error) {
-	cntr, err := c.containerStore.Get(in.GetContainerId())
+	cntr, err := c.ContainerStore.Get(in.GetContainerId())
 	if err != nil {
 		return nil, fmt.Errorf("failed to find container: %w", err)
 	}

--- a/pkg/cri/server/container_stats_list.go
+++ b/pkg/cri/server/container_stats_list.go
@@ -67,26 +67,26 @@ func (c *criService) toCRIContainerStats(
 }
 
 func (c *criService) normalizeContainerStatsFilter(filter *runtime.ContainerStatsFilter) {
-	if cntr, err := c.containerStore.Get(filter.GetId()); err == nil {
+	if cntr, err := c.ContainerStore.Get(filter.GetId()); err == nil {
 		filter.Id = cntr.ID
 	}
-	if sb, err := c.sandboxStore.Get(filter.GetPodSandboxId()); err == nil {
+	if sb, err := c.SandboxStore.Get(filter.GetPodSandboxId()); err == nil {
 		filter.PodSandboxId = sb.ID
 	}
 }
 
 // buildTaskMetricsRequest constructs a tasks.MetricsRequest based on
-// the information in the stats request and the containerStore
+// the information in the stats request and the ContainerStore
 func (c *criService) buildTaskMetricsRequest(
 	r *runtime.ListContainerStatsRequest,
 ) (tasks.MetricsRequest, []containerstore.Container, error) {
 	var req tasks.MetricsRequest
 	if r.GetFilter() == nil {
-		return req, c.containerStore.List(), nil
+		return req, c.ContainerStore.List(), nil
 	}
 	c.normalizeContainerStatsFilter(r.GetFilter())
 	var containers []containerstore.Container
-	for _, cntr := range c.containerStore.List() {
+	for _, cntr := range c.ContainerStore.List() {
 		if r.GetFilter().GetId() != "" && cntr.ID != r.GetFilter().GetId() {
 			continue
 		}

--- a/pkg/cri/server/container_stats_list_linux.go
+++ b/pkg/cri/server/container_stats_list_linux.go
@@ -84,13 +84,13 @@ func (c *criService) getUsageNanoCores(containerID string, isSandbox bool, curre
 	var oldStats *stats.ContainerStats
 
 	if isSandbox {
-		sandbox, err := c.sandboxStore.Get(containerID)
+		sandbox, err := c.SandboxStore.Get(containerID)
 		if err != nil {
 			return 0, fmt.Errorf("failed to get sandbox container: %s: %w", containerID, err)
 		}
 		oldStats = sandbox.Stats
 	} else {
-		container, err := c.containerStore.Get(containerID)
+		container, err := c.ContainerStore.Get(containerID)
 		if err != nil {
 			return 0, fmt.Errorf("failed to get container ID: %s: %w", containerID, err)
 		}
@@ -103,12 +103,12 @@ func (c *criService) getUsageNanoCores(containerID string, isSandbox bool, curre
 			Timestamp:            currentTimestamp,
 		}
 		if isSandbox {
-			err := c.sandboxStore.UpdateContainerStats(containerID, newStats)
+			err := c.SandboxStore.UpdateContainerStats(containerID, newStats)
 			if err != nil {
 				return 0, fmt.Errorf("failed to update sandbox stats container ID: %s: %w", containerID, err)
 			}
 		} else {
-			err := c.containerStore.UpdateContainerStats(containerID, newStats)
+			err := c.ContainerStore.UpdateContainerStats(containerID, newStats)
 			if err != nil {
 				return 0, fmt.Errorf("failed to update container stats ID: %s: %w", containerID, err)
 			}
@@ -131,13 +131,13 @@ func (c *criService) getUsageNanoCores(containerID string, isSandbox bool, curre
 		Timestamp:            currentTimestamp,
 	}
 	if isSandbox {
-		err := c.sandboxStore.UpdateContainerStats(containerID, newStats)
+		err := c.SandboxStore.UpdateContainerStats(containerID, newStats)
 		if err != nil {
 			return 0, fmt.Errorf("failed to update sandbox container stats: %s: %w", containerID, err)
 		}
 
 	} else {
-		err := c.containerStore.UpdateContainerStats(containerID, newStats)
+		err := c.ContainerStore.UpdateContainerStats(containerID, newStats)
 		if err != nil {
 			return 0, fmt.Errorf("failed to update container stats ID: %s: %w", containerID, err)
 		}

--- a/pkg/cri/server/container_stats_list_linux_test.go
+++ b/pkg/cri/server/container_stats_list_linux_test.go
@@ -202,13 +202,13 @@ func TestContainerMetricsCPU(t *testing.T) {
 			)
 			assert.NoError(t, err)
 			assert.Nil(t, container.Stats)
-			err = c.containerStore.Add(container)
+			err = c.ContainerStore.Add(container)
 			assert.NoError(t, err)
 
 			cpuUsage, err := c.cpuContainerStats(ID, false, test.firstMetrics, timestamp)
 			assert.NoError(t, err)
 
-			container, err = c.containerStore.Get(ID)
+			container, err = c.ContainerStore.Get(ID)
 			assert.NoError(t, err)
 			assert.NotNil(t, container.Stats)
 
@@ -218,7 +218,7 @@ func TestContainerMetricsCPU(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, test.expectedSecond, cpuUsage)
 
-			container, err = c.containerStore.Get(ID)
+			container, err = c.ContainerStore.Get(ID)
 			assert.NoError(t, err)
 			assert.NotNil(t, container.Stats)
 		})

--- a/pkg/cri/server/container_status.go
+++ b/pkg/cri/server/container_status.go
@@ -30,7 +30,7 @@ import (
 
 // ContainerStatus inspects the container and returns the status.
 func (c *criService) ContainerStatus(ctx context.Context, r *runtime.ContainerStatusRequest) (*runtime.ContainerStatusResponse, error) {
-	container, err := c.containerStore.Get(r.GetContainerId())
+	container, err := c.ContainerStore.Get(r.GetContainerId())
 	if err != nil {
 		return nil, fmt.Errorf("an error occurred when try to find container %q: %w", r.GetContainerId(), err)
 	}
@@ -42,7 +42,7 @@ func (c *criService) ContainerStatus(ctx context.Context, r *runtime.ContainerSt
 	// * ImageRef in container status is repo digest.
 	spec := container.Config.GetImage()
 	imageRef := container.ImageRef
-	image, err := c.imageStore.Get(imageRef)
+	image, err := c.ImageStore.Get(imageRef)
 	if err != nil {
 		if !errdefs.IsNotFound(err) {
 			return nil, fmt.Errorf("failed to get image %q: %w", imageRef, err)

--- a/pkg/cri/server/container_status_test.go
+++ b/pkg/cri/server/container_status_test.go
@@ -222,10 +222,10 @@ func TestContainerStatus(t *testing.T) {
 		)
 		assert.NoError(t, err)
 		if test.exist {
-			assert.NoError(t, c.containerStore.Add(container))
+			assert.NoError(t, c.ContainerStore.Add(container))
 		}
 		if test.imageExist {
-			c.imageStore, err = imagestore.NewFakeStore([]imagestore.Image{*image})
+			c.ImageStore, err = imagestore.NewFakeStore([]imagestore.Image{*image})
 			assert.NoError(t, err)
 		}
 		resp, err := c.ContainerStatus(context.Background(), &runtime.ContainerStatusRequest{ContainerId: container.ID})

--- a/pkg/cri/server/container_stop.go
+++ b/pkg/cri/server/container_stop.go
@@ -37,7 +37,7 @@ import (
 func (c *criService) StopContainer(ctx context.Context, r *runtime.StopContainerRequest) (*runtime.StopContainerResponse, error) {
 	start := time.Now()
 	// Get container config from container store.
-	container, err := c.containerStore.Get(r.GetContainerId())
+	container, err := c.ContainerStore.Get(r.GetContainerId())
 	if err != nil {
 		return nil, fmt.Errorf("an error occurred when try to find container %q: %w", r.GetContainerId(), err)
 	}
@@ -121,7 +121,7 @@ func (c *criService) stopContainer(ctx context.Context, container containerstore
 			// default SIGTERM is still better than returning error and leaving
 			// the container unstoppable. (See issue #990)
 			// TODO(random-liu): Remove this logic when containerd 1.2 is deprecated.
-			image, err := c.imageStore.Get(container.ImageRef)
+			image, err := c.ImageStore.Get(container.ImageRef)
 			if err != nil {
 				if !errdefs.IsNotFound(err) {
 					return fmt.Errorf("failed to get image %q: %w", container.ImageRef, err)

--- a/pkg/cri/server/container_stop_test.go
+++ b/pkg/cri/server/container_stop_test.go
@@ -67,7 +67,7 @@ func TestWaitContainerStop(t *testing.T) {
 			containerstore.WithFakeStatus(*test.status),
 		)
 		assert.NoError(t, err)
-		assert.NoError(t, c.containerStore.Add(container))
+		assert.NoError(t, c.ContainerStore.Add(container))
 		ctx := context.Background()
 		if test.cancel {
 			cancelledCtx, cancel := context.WithCancel(ctx)

--- a/pkg/cri/server/container_update_resources.go
+++ b/pkg/cri/server/container_update_resources.go
@@ -38,7 +38,7 @@ import (
 
 // UpdateContainerResources updates ContainerConfig of the container.
 func (c *criService) UpdateContainerResources(ctx context.Context, r *runtime.UpdateContainerResourcesRequest) (retRes *runtime.UpdateContainerResourcesResponse, retErr error) {
-	container, err := c.containerStore.Get(r.GetContainerId())
+	container, err := c.ContainerStore.Get(r.GetContainerId())
 	if err != nil {
 		return nil, fmt.Errorf("failed to find container: %w", err)
 	}

--- a/pkg/cri/server/container_update_resources_linux.go
+++ b/pkg/cri/server/container_update_resources_linux.go
@@ -30,7 +30,7 @@ import (
 
 // updateOCIResource updates container resource limit.
 func updateOCIResource(ctx context.Context, spec *runtimespec.Spec, r *runtime.UpdateContainerResourcesRequest,
-	config criconfig.Config) (*runtimespec.Spec, error) {
+	config *criconfig.Config) (*runtimespec.Spec, error) {
 
 	// Copy to make sure old spec is not changed.
 	var cloned runtimespec.Spec

--- a/pkg/cri/server/container_update_resources_linux_test.go
+++ b/pkg/cri/server/container_update_resources_linux_test.go
@@ -218,7 +218,7 @@ func TestUpdateOCILinuxResource(t *testing.T) {
 				DisableHugetlbController:         false,
 			},
 		}
-		got, err := updateOCIResource(context.Background(), test.spec, test.request, config)
+		got, err := updateOCIResource(context.Background(), test.spec, test.request, &config)
 		if test.expectErr {
 			assert.Error(t, err)
 		} else {

--- a/pkg/cri/server/container_update_resources_other.go
+++ b/pkg/cri/server/container_update_resources_other.go
@@ -30,7 +30,7 @@ import (
 
 // UpdateContainerResources updates ContainerConfig of the container.
 func (c *criService) UpdateContainerResources(ctx context.Context, r *runtime.UpdateContainerResourcesRequest) (retRes *runtime.UpdateContainerResourcesResponse, retErr error) {
-	container, err := c.containerStore.Get(r.GetContainerId())
+	container, err := c.ContainerStore.Get(r.GetContainerId())
 	if err != nil {
 		return nil, fmt.Errorf("failed to find container: %w", err)
 	}

--- a/pkg/cri/server/container_update_resources_windows.go
+++ b/pkg/cri/server/container_update_resources_windows.go
@@ -30,7 +30,7 @@ import (
 
 // updateOCIResource updates container resource limit.
 func updateOCIResource(ctx context.Context, spec *runtimespec.Spec, r *runtime.UpdateContainerResourcesRequest,
-	config criconfig.Config) (*runtimespec.Spec, error) {
+	config *criconfig.Config) (*runtimespec.Spec, error) {
 
 	// Copy to make sure old spec is not changed.
 	var cloned runtimespec.Spec

--- a/pkg/cri/server/events.go
+++ b/pkg/cri/server/events.go
@@ -134,7 +134,7 @@ func (em *eventMonitor) startSandboxExitMonitor(ctx context.Context, id string, 
 				dctx, dcancel := context.WithTimeout(dctx, handleEventTimeout)
 				defer dcancel()
 
-				sb, err := em.c.sandboxStore.Get(e.ID)
+				sb, err := em.c.SandboxStore.Get(e.ID)
 				if err == nil {
 					if err := handleSandboxExit(dctx, e, sb); err != nil {
 						return err
@@ -185,7 +185,7 @@ func (em *eventMonitor) startContainerExitMonitor(ctx context.Context, id string
 				dctx, dcancel := context.WithTimeout(dctx, handleEventTimeout)
 				defer dcancel()
 
-				cntr, err := em.c.containerStore.Get(e.ID)
+				cntr, err := em.c.ContainerStore.Get(e.ID)
 				if err == nil {
 					if err := handleContainerExit(dctx, e, cntr); err != nil {
 						return err
@@ -311,7 +311,7 @@ func (em *eventMonitor) handleEvent(any interface{}) error {
 	case *eventtypes.TaskExit:
 		logrus.Infof("TaskExit event %+v", e)
 		// Use ID instead of ContainerID to rule out TaskExit event for exec.
-		cntr, err := em.c.containerStore.Get(e.ID)
+		cntr, err := em.c.ContainerStore.Get(e.ID)
 		if err == nil {
 			if err := handleContainerExit(ctx, e, cntr); err != nil {
 				return fmt.Errorf("failed to handle container TaskExit event: %w", err)
@@ -320,7 +320,7 @@ func (em *eventMonitor) handleEvent(any interface{}) error {
 		} else if !errdefs.IsNotFound(err) {
 			return fmt.Errorf("can't find container for TaskExit event: %w", err)
 		}
-		sb, err := em.c.sandboxStore.Get(e.ID)
+		sb, err := em.c.SandboxStore.Get(e.ID)
 		if err == nil {
 			if err := handleSandboxExit(ctx, e, sb); err != nil {
 				return fmt.Errorf("failed to handle sandbox TaskExit event: %w", err)
@@ -333,7 +333,7 @@ func (em *eventMonitor) handleEvent(any interface{}) error {
 	case *eventtypes.TaskOOM:
 		logrus.Infof("TaskOOM event %+v", e)
 		// For TaskOOM, we only care which container it belongs to.
-		cntr, err := em.c.containerStore.Get(e.ContainerID)
+		cntr, err := em.c.ContainerStore.Get(e.ContainerID)
 		if err != nil {
 			if !errdefs.IsNotFound(err) {
 				return fmt.Errorf("can't find container for TaskOOM event: %w", err)

--- a/pkg/cri/server/helpers.go
+++ b/pkg/cri/server/helpers.go
@@ -333,7 +333,7 @@ func parseImageReferences(refs []string) ([]string, []string) {
 }
 
 // generateRuntimeOptions generates runtime options from cri plugin config.
-func generateRuntimeOptions(r criconfig.Runtime, c criconfig.Config) (interface{}, error) {
+func generateRuntimeOptions(r criconfig.Runtime, c *criconfig.Config) (interface{}, error) {
 	if r.Options == nil {
 		if r.Type != plugin.RuntimeLinuxV1 {
 			return nil, nil

--- a/pkg/cri/server/helpers.go
+++ b/pkg/cri/server/helpers.go
@@ -175,7 +175,7 @@ func (c *criService) localResolve(refOrID string) (imagestore.Image, error) {
 			if err != nil {
 				return ""
 			}
-			id, err := c.imageStore.Resolve(normalized.String())
+			id, err := c.ImageStore.Resolve(normalized.String())
 			if err != nil {
 				return ""
 			}
@@ -188,7 +188,7 @@ func (c *criService) localResolve(refOrID string) (imagestore.Image, error) {
 		// Try to treat ref as imageID
 		imageID = refOrID
 	}
-	return c.imageStore.Get(imageID)
+	return c.ImageStore.Get(imageID)
 }
 
 // toContainerdImage converts an image object in image store to containerd image handler.
@@ -235,7 +235,7 @@ func (c *criService) ensureImageExists(ctx context.Context, ref string, config *
 		return nil, fmt.Errorf("failed to pull image %q: %w", ref, err)
 	}
 	imageID := resp.GetImageRef()
-	newImage, err := c.imageStore.Get(imageID)
+	newImage, err := c.ImageStore.Get(imageID)
 	if err != nil {
 		// It's still possible that someone removed the image right after it is pulled.
 		return nil, fmt.Errorf("failed to get image %q after pulling: %w", imageID, err)
@@ -248,7 +248,7 @@ func (c *criService) ensureImageExists(ctx context.Context, ref string, config *
 // The target container must be in the same sandbox and must be running.
 // Returns the target container for convenience.
 func (c *criService) validateTargetContainer(sandboxID, targetContainerID string) (containerstore.Container, error) {
-	targetContainer, err := c.containerStore.Get(targetContainerID)
+	targetContainer, err := c.ContainerStore.Get(targetContainerID)
 	if err != nil {
 		return containerstore.Container{}, fmt.Errorf("container %q does not exist: %w", targetContainerID, err)
 	}

--- a/pkg/cri/server/helpers_test.go
+++ b/pkg/cri/server/helpers_test.go
@@ -169,7 +169,7 @@ func TestLocalResolve(t *testing.T) {
 	}
 	c := newTestCRIService()
 	var err error
-	c.imageStore, err = imagestore.NewFakeStore([]imagestore.Image{image})
+	c.ImageStore, err = imagestore.NewFakeStore([]imagestore.Image{image})
 	assert.NoError(t, err)
 
 	for _, ref := range []string{
@@ -530,7 +530,7 @@ func addContainer(c *criService, containerID, sandboxID string, PID uint32, crea
 	if err != nil {
 		return err
 	}
-	return c.containerStore.Add(container)
+	return c.ContainerStore.Add(container)
 }
 
 func TestValidateTargetContainer(t *testing.T) {

--- a/pkg/cri/server/helpers_test.go
+++ b/pkg/cri/server/helpers_test.go
@@ -295,7 +295,7 @@ systemd_cgroup = true
 		},
 	} {
 		t.Run(desc, func(t *testing.T) {
-			opts, err := generateRuntimeOptions(test.r, test.c)
+			opts, err := generateRuntimeOptions(test.r, &test.c)
 			assert.NoError(t, err)
 			assert.Equal(t, test.expectedOptions, opts)
 		})

--- a/pkg/cri/server/image_list.go
+++ b/pkg/cri/server/image_list.go
@@ -25,7 +25,7 @@ import (
 // TODO(random-liu): Add image list filters after CRI defines this more clear, and kubelet
 // actually needs it.
 func (c *criService) ListImages(ctx context.Context, r *runtime.ListImagesRequest) (*runtime.ListImagesResponse, error) {
-	imagesInStore := c.imageStore.List()
+	imagesInStore := c.ImageStore.List()
 
 	var images []*runtime.Image
 	for _, image := range imagesInStore {

--- a/pkg/cri/server/image_list_test.go
+++ b/pkg/cri/server/image_list_test.go
@@ -99,7 +99,7 @@ func TestListImages(t *testing.T) {
 	}
 
 	var err error
-	c.imageStore, err = imagestore.NewFakeStore(imagesInStore)
+	c.ImageStore, err = imagestore.NewFakeStore(imagesInStore)
 	assert.NoError(t, err)
 
 	resp, err := c.ListImages(context.Background(), &runtime.ListImagesRequest{})

--- a/pkg/cri/server/image_pull.go
+++ b/pkg/cri/server/image_pull.go
@@ -157,7 +157,7 @@ func (c *criService) PullImage(ctx context.Context, r *runtime.PullImageRequest)
 		// Update image store to reflect the newest state in containerd.
 		// No need to use `updateImage`, because the image reference must
 		// have been managed by the cri plugin.
-		if err := c.imageStore.Update(ctx, r); err != nil {
+		if err := c.ImageStore.Update(ctx, r); err != nil {
 			return nil, fmt.Errorf("failed to update image store %q: %w", r, err)
 		}
 	}
@@ -255,7 +255,7 @@ func (c *criService) updateImage(ctx context.Context, r string) error {
 		if err := c.createImageReference(ctx, id, img.Target()); err != nil {
 			return fmt.Errorf("create image id reference %q: %w", id, err)
 		}
-		if err := c.imageStore.Update(ctx, id); err != nil {
+		if err := c.ImageStore.Update(ctx, id); err != nil {
 			return fmt.Errorf("update image store for %q: %w", id, err)
 		}
 		// The image id is ready, add the label to mark the image as managed.
@@ -265,7 +265,7 @@ func (c *criService) updateImage(ctx context.Context, r string) error {
 	}
 	// If the image is not found, we should continue updating the cache,
 	// so that the image can be removed from the cache.
-	if err := c.imageStore.Update(ctx, r); err != nil {
+	if err := c.ImageStore.Update(ctx, r); err != nil {
 		return fmt.Errorf("update image store for %q: %w", r, err)
 	}
 	return nil

--- a/pkg/cri/server/image_remove.go
+++ b/pkg/cri/server/image_remove.go
@@ -54,7 +54,7 @@ func (c *criService) RemoveImage(ctx context.Context, r *runtime.RemoveImageRequ
 		err = c.client.ImageService().Delete(ctx, ref, opts...)
 		if err == nil || errdefs.IsNotFound(err) {
 			// Update image store to reflect the newest state in containerd.
-			if err := c.imageStore.Update(ctx, ref); err != nil {
+			if err := c.ImageStore.Update(ctx, ref); err != nil {
 				return nil, fmt.Errorf("failed to update image reference %q for %q: %w", ref, image.ID, err)
 			}
 			continue

--- a/pkg/cri/server/image_status_test.go
+++ b/pkg/cri/server/image_status_test.go
@@ -61,7 +61,7 @@ func TestImageStatus(t *testing.T) {
 	require.NotNil(t, resp)
 	assert.Nil(t, resp.GetImage())
 
-	c.imageStore, err = imagestore.NewFakeStore([]imagestore.Image{image})
+	c.ImageStore, err = imagestore.NewFakeStore([]imagestore.Image{image})
 	assert.NoError(t, err)
 
 	t.Logf("should return correct image status for exist image")

--- a/pkg/cri/server/instrumented_service.go
+++ b/pkg/cri/server/instrumented_service.go
@@ -30,19 +30,19 @@ import (
 
 // instrumentedService wraps service with containerd namespace and logs.
 type instrumentedService struct {
-	c *criService
+	c *criManager
 }
 
-func newInstrumentedService(c *criService) grpcServices {
+func newInstrumentedService(c *criManager) grpcServices {
 	return &instrumentedService{c: c}
 }
 
 // instrumentedAlphaService wraps service with containerd namespace and logs.
 type instrumentedAlphaService struct {
-	c *criService
+	c *criManager
 }
 
-func newInstrumentedAlphaService(c *criService) grpcAlphaServices {
+func newInstrumentedAlphaService(c *criManager) grpcAlphaServices {
 	return &instrumentedAlphaService{c: c}
 }
 
@@ -51,7 +51,7 @@ func newInstrumentedAlphaService(c *criService) grpcAlphaServices {
 // initialized.
 // NOTE(random-liu): All following functions MUST check initialized at the beginning.
 func (in *instrumentedService) checkInitialized() error {
-	if in.c.initialized.IsSet() {
+	if in.c.c.initialized.IsSet() {
 		return nil
 	}
 	return errors.New("server is not initialized yet")
@@ -62,7 +62,7 @@ func (in *instrumentedService) checkInitialized() error {
 // initialized.
 // NOTE(random-liu): All following functions MUST check initialized at the beginning.
 func (in *instrumentedAlphaService) checkInitialized() error {
-	if in.c.initialized.IsSet() {
+	if in.c.c.initialized.IsSet() {
 		return nil
 	}
 	return errors.New("server is not initialized yet")
@@ -1491,7 +1491,7 @@ func (in *instrumentedAlphaService) Version(ctx context.Context, r *runtime_alph
 			log.G(ctx).Tracef("Version returns %+v", res)
 		}
 	}()
-	res, err = in.c.AlphaVersion(ctrdutil.WithNamespace(ctx), r)
+	res, err = in.c.c.AlphaVersion(ctrdutil.WithNamespace(ctx), r)
 	return res, errdefs.ToGRPC(err)
 }
 

--- a/pkg/cri/server/instrumented_service.go
+++ b/pkg/cri/server/instrumented_service.go
@@ -33,7 +33,7 @@ type instrumentedService struct {
 	c *criManager
 }
 
-func newInstrumentedService(c *criManager) grpcServices {
+func newInstrumentedService(c *criManager) GrpcServices {
 	return &instrumentedService{c: c}
 }
 
@@ -51,7 +51,7 @@ func newInstrumentedAlphaService(c *criManager) grpcAlphaServices {
 // initialized.
 // NOTE(random-liu): All following functions MUST check initialized at the beginning.
 func (in *instrumentedService) checkInitialized() error {
-	if in.c.c.initialized.IsSet() {
+	if in.c.Initialized() {
 		return nil
 	}
 	return errors.New("server is not initialized yet")
@@ -62,7 +62,7 @@ func (in *instrumentedService) checkInitialized() error {
 // initialized.
 // NOTE(random-liu): All following functions MUST check initialized at the beginning.
 func (in *instrumentedAlphaService) checkInitialized() error {
-	if in.c.c.initialized.IsSet() {
+	if in.c.Initialized() {
 		return nil
 	}
 	return errors.New("server is not initialized yet")

--- a/pkg/cri/server/manager.go
+++ b/pkg/cri/server/manager.go
@@ -72,6 +72,11 @@ func (cm *criManager) Run() error {
 	return cm.c.Run()
 }
 
+// implement CRIPlugin Initialized interface
+func (cm *criManager) Initialized() bool {
+	return cm.c.Initialized()
+}
+
 // Close stops the CRI service.
 func (cm *criManager) Close() error {
 	return cm.c.Close()

--- a/pkg/cri/server/manager.go
+++ b/pkg/cri/server/manager.go
@@ -26,9 +26,12 @@ import (
 	runtime_alpha "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 
 	criconfig "github.com/containerd/containerd/pkg/cri/config"
+	cristore "github.com/containerd/containerd/pkg/cri/store/service"
 )
 
 type criManager struct {
+	// stores all resources associated with cri
+	*cristore.Store
 	// config contains all configurations.
 	config *criconfig.Config
 	// default service
@@ -36,12 +39,13 @@ type criManager struct {
 }
 
 // NewCRIManager returns a new instance of CRIService
-func NewCRIManager(config criconfig.Config, client *containerd.Client) (CRIService, error) {
-	c, err := newCRIService(&config, client)
+func NewCRIManager(config criconfig.Config, client *containerd.Client, store *cristore.Store) (CRIService, error) {
+	c, err := newCRIService(&config, client, store)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create CRI service")
 	}
 	cm := &criManager{
+		Store:  store,
 		config: &config,
 		c:      c,
 	}

--- a/pkg/cri/server/manager.go
+++ b/pkg/cri/server/manager.go
@@ -18,14 +18,17 @@ package server
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/containerd/containerd"
-	"github.com/pkg/errors"
+	"github.com/containerd/containerd/log"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 	runtime_alpha "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 
 	criconfig "github.com/containerd/containerd/pkg/cri/config"
+	"github.com/containerd/containerd/pkg/cri/store"
 	cristore "github.com/containerd/containerd/pkg/cri/store/service"
 )
 
@@ -44,7 +47,7 @@ type criManager struct {
 func NewCRIManager(config criconfig.Config, client *containerd.Client, store *cristore.Store, services map[string]CRIPlugin) (CRIService, error) {
 	c, err := newCRIService(&config, client, store)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create CRI service")
+		return nil, fmt.Errorf("failed to create CRI service: %w", err)
 	}
 	for _, cri := range services {
 		cri.SetDelegate(c)
@@ -76,16 +79,33 @@ func (cm *criManager) RegisterTCP(s *grpc.Server) error {
 
 // Run starts the CRI service.
 func (cm *criManager) Run() error {
+	// run services
+	for handler, s := range cm.services {
+		go func(handler string, service CRIPlugin) {
+			if err := service.Run(); err != nil {
+				logrus.Fatalf("Failed to run CRI %s service", handler)
+			}
+		}(handler, s)
+	}
 	return cm.c.Run()
 }
 
 // implement CRIPlugin Initialized interface
 func (cm *criManager) Initialized() bool {
-	return cm.c.Initialized()
+	initialized := true
+	for _, s := range cm.services {
+		initialized = initialized && s.Initialized()
+	}
+	return initialized && cm.c.Initialized()
 }
 
 // Close stops the CRI service.
 func (cm *criManager) Close() error {
+	for handler, s := range cm.services {
+		if err := s.Close(); err != nil {
+			logrus.Errorf("Failed to Close CRI %s service", handler)
+		}
+	}
 	return cm.c.Close()
 }
 
@@ -99,8 +119,52 @@ func (cm *criManager) register(s *grpc.Server) error {
 	return nil
 }
 
+// getServiceByRuntime get runtime specific implementations
+func (cm *criManager) getServiceByRuntime(runtime string) (GrpcServices, error) {
+	r, ok := cm.config.ContainerdConfig.Runtimes[runtime]
+	if !ok {
+		return cm.c, nil
+	}
+	if len(r.CRIHandler) == 0 || r.CRIHandler == criconfig.DefaultCRIHandler {
+		return cm.c, nil
+	}
+	return cm.getServiceByCRIHandler(r.CRIHandler)
+}
+
+func (cm *criManager) getServiceByCRIHandler(criHandler string) (GrpcServices, error) {
+	i, ok := cm.services[criHandler]
+	if !ok {
+		// there is not plugin
+		return nil, fmt.Errorf("the handler %q not implement plugin", criHandler)
+	}
+	return i, nil
+}
+
+func (cm *criManager) getServiceBySandboxID(id string) (GrpcServices, error) {
+	sandbox, err := cm.SandboxStore.Get(id)
+	if err != nil {
+		return nil, err
+	}
+	if len(sandbox.CRIHandler) == 0 || sandbox.CRIHandler == criconfig.DefaultCRIHandler {
+		return cm.c, nil
+	}
+	return cm.getServiceByCRIHandler(sandbox.CRIHandler)
+}
+
+func (cm *criManager) getServiceByContainerID(id string) (GrpcServices, error) {
+	container, err := cm.ContainerStore.Get(id)
+	if err != nil {
+		return nil, err
+	}
+	return cm.getServiceBySandboxID(container.SandboxID)
+}
+
 func (cm *criManager) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandboxRequest) (*runtime.RunPodSandboxResponse, error) {
-	return cm.c.RunPodSandbox(ctx, r)
+	i, err := cm.getServiceByRuntime(r.GetRuntimeHandler())
+	if err != nil {
+		return nil, fmt.Errorf("no cir handler for %q is configured: %w", r.GetRuntimeHandler(), err)
+	}
+	return i.RunPodSandbox(ctx, r)
 }
 
 func (cm *criManager) ListPodSandbox(ctx context.Context, r *runtime.ListPodSandboxRequest) (*runtime.ListPodSandboxResponse, error) {
@@ -108,27 +172,57 @@ func (cm *criManager) ListPodSandbox(ctx context.Context, r *runtime.ListPodSand
 }
 
 func (cm *criManager) PodSandboxStatus(ctx context.Context, r *runtime.PodSandboxStatusRequest) (*runtime.PodSandboxStatusResponse, error) {
-	return cm.c.PodSandboxStatus(ctx, r)
+	i, err := cm.getServiceBySandboxID(r.GetPodSandboxId())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service for sandbox %q: %w", r.GetPodSandboxId(), err)
+	}
+	return i.PodSandboxStatus(ctx, r)
 }
 
 func (cm *criManager) StopPodSandbox(ctx context.Context, r *runtime.StopPodSandboxRequest) (*runtime.StopPodSandboxResponse, error) {
-	return cm.c.StopPodSandbox(ctx, r)
+	i, err := cm.getServiceBySandboxID(r.GetPodSandboxId())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service for sandbox %q: %w", r.GetPodSandboxId(), err)
+	}
+	return i.StopPodSandbox(ctx, r)
 }
 
 func (cm *criManager) RemovePodSandbox(ctx context.Context, r *runtime.RemovePodSandboxRequest) (*runtime.RemovePodSandboxResponse, error) {
-	return cm.c.RemovePodSandbox(ctx, r)
+	i, err := cm.getServiceBySandboxID(r.GetPodSandboxId())
+	if err != nil {
+		if err != store.ErrNotExist {
+			return nil, fmt.Errorf("failed to get service for sandbox %q: %w", r.GetPodSandboxId(), err)
+		}
+		// Do not return error if the service doesn't exist.
+		log.G(ctx).Tracef("RemovePodSandbox called for sandbox %q that does not exist",
+			r.GetPodSandboxId())
+		return &runtime.RemovePodSandboxResponse{}, nil
+	}
+	return i.RemovePodSandbox(ctx, r)
 }
 
 func (cm *criManager) PortForward(ctx context.Context, r *runtime.PortForwardRequest) (*runtime.PortForwardResponse, error) {
-	return cm.c.PortForward(ctx, r)
+	i, err := cm.getServiceBySandboxID(r.GetPodSandboxId())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service for sandbox %q: %w", r.GetPodSandboxId(), err)
+	}
+	return i.PortForward(ctx, r)
 }
 
 func (cm *criManager) CreateContainer(ctx context.Context, r *runtime.CreateContainerRequest) (*runtime.CreateContainerResponse, error) {
-	return cm.c.CreateContainer(ctx, r)
+	i, err := cm.getServiceBySandboxID(r.GetPodSandboxId())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service for sandbox %q: %w", r.GetPodSandboxId(), err)
+	}
+	return i.CreateContainer(ctx, r)
 }
 
 func (cm *criManager) StartContainer(ctx context.Context, r *runtime.StartContainerRequest) (*runtime.StartContainerResponse, error) {
-	return cm.c.StartContainer(ctx, r)
+	i, err := cm.getServiceByContainerID(r.GetContainerId())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service for container %q: %w", r.GetContainerId(), err)
+	}
+	return i.StartContainer(ctx, r)
 }
 
 func (cm *criManager) ListContainers(ctx context.Context, r *runtime.ListContainersRequest) (*runtime.ListContainersResponse, error) {
@@ -136,35 +230,78 @@ func (cm *criManager) ListContainers(ctx context.Context, r *runtime.ListContain
 }
 
 func (cm *criManager) ContainerStatus(ctx context.Context, r *runtime.ContainerStatusRequest) (*runtime.ContainerStatusResponse, error) {
-	return cm.c.ContainerStatus(ctx, r)
+	i, err := cm.getServiceByContainerID(r.GetContainerId())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service for container %q: %w", r.GetContainerId(), err)
+	}
+	return i.ContainerStatus(ctx, r)
 }
 
 func (cm *criManager) StopContainer(ctx context.Context, r *runtime.StopContainerRequest) (*runtime.StopContainerResponse, error) {
-	return cm.c.StopContainer(ctx, r)
+	i, err := cm.getServiceByContainerID(r.GetContainerId())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service for container %q: %w", r.GetContainerId(), err)
+	}
+	return i.StopContainer(ctx, r)
 }
 
 func (cm *criManager) RemoveContainer(ctx context.Context, r *runtime.RemoveContainerRequest) (*runtime.RemoveContainerResponse, error) {
-	return cm.c.RemoveContainer(ctx, r)
+	i, err := cm.getServiceByContainerID(r.GetContainerId())
+	if err != nil {
+		if err != store.ErrNotExist {
+			return nil, fmt.Errorf("failed to get service for container %q: %w", r.GetContainerId(), err)
+		}
+		log.G(ctx).Tracef("RemoveContainer called for container %q that does not exist", r.GetContainerId())
+		return &runtime.RemoveContainerResponse{}, nil
+	}
+	return i.RemoveContainer(ctx, r)
 }
 
 func (cm *criManager) ExecSync(ctx context.Context, r *runtime.ExecSyncRequest) (*runtime.ExecSyncResponse, error) {
-	return cm.c.ExecSync(ctx, r)
+	i, err := cm.getServiceByContainerID(r.GetContainerId())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service for container %q: %w", r.GetContainerId(), err)
+	}
+	return i.ExecSync(ctx, r)
 }
 
 func (cm *criManager) Exec(ctx context.Context, r *runtime.ExecRequest) (*runtime.ExecResponse, error) {
-	return cm.c.Exec(ctx, r)
+	i, err := cm.getServiceByContainerID(r.GetContainerId())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service for container %q: %w", r.GetContainerId(), err)
+	}
+	return i.Exec(ctx, r)
 }
 
 func (cm *criManager) Attach(ctx context.Context, r *runtime.AttachRequest) (*runtime.AttachResponse, error) {
-	return cm.c.Attach(ctx, r)
+	i, err := cm.getServiceByContainerID(r.GetContainerId())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service for container %q: %w", r.GetContainerId(), err)
+	}
+	return i.Attach(ctx, r)
 }
 
 func (cm *criManager) UpdateContainerResources(ctx context.Context, r *runtime.UpdateContainerResourcesRequest) (*runtime.UpdateContainerResourcesResponse, error) {
-	return cm.c.UpdateContainerResources(ctx, r)
+	i, err := cm.getServiceByContainerID(r.GetContainerId())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service for container %q: %w", r.GetContainerId(), err)
+	}
+	return i.UpdateContainerResources(ctx, r)
 }
 
 func (cm *criManager) PullImage(ctx context.Context, r *runtime.PullImageRequest) (*runtime.PullImageResponse, error) {
-	return cm.c.PullImage(ctx, r)
+	if r.GetSandboxConfig() == nil || r.GetSandboxConfig().GetMetadata() == nil {
+		return cm.c.PullImage(ctx, r)
+	}
+	key := cm.SandboxNameIndex.GetKeyByName(makeSandboxName(r.GetSandboxConfig().GetMetadata()))
+	if len(key) == 0 {
+		return cm.c.PullImage(ctx, r)
+	}
+	i, err := cm.getServiceBySandboxID(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service for sandbox %q: %w", key, err)
+	}
+	return i.PullImage(ctx, r)
 }
 
 func (cm *criManager) ListImages(ctx context.Context, r *runtime.ListImagesRequest) (*runtime.ListImagesResponse, error) {
@@ -184,11 +321,19 @@ func (cm *criManager) ImageFsInfo(ctx context.Context, r *runtime.ImageFsInfoReq
 }
 
 func (cm *criManager) PodSandboxStats(ctx context.Context, r *runtime.PodSandboxStatsRequest) (*runtime.PodSandboxStatsResponse, error) {
-	return cm.c.PodSandboxStats(ctx, r)
+	i, err := cm.getServiceBySandboxID(r.GetPodSandboxId())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service for sandbox %q: %w", r.GetPodSandboxId(), err)
+	}
+	return i.PodSandboxStats(ctx, r)
 }
 
 func (cm *criManager) ContainerStats(ctx context.Context, r *runtime.ContainerStatsRequest) (*runtime.ContainerStatsResponse, error) {
-	return cm.c.ContainerStats(ctx, r)
+	i, err := cm.getServiceByContainerID(r.GetContainerId())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service for container %q: %w", r.GetContainerId(), err)
+	}
+	return i.ContainerStats(ctx, r)
 }
 
 func (cm *criManager) ListPodSandboxStats(ctx context.Context, r *runtime.ListPodSandboxStatsRequest) (res *runtime.ListPodSandboxStatsResponse, err error) {
@@ -212,5 +357,9 @@ func (cm *criManager) UpdateRuntimeConfig(ctx context.Context, r *runtime.Update
 }
 
 func (cm *criManager) ReopenContainerLog(ctx context.Context, r *runtime.ReopenContainerLogRequest) (*runtime.ReopenContainerLogResponse, error) {
-	return cm.c.ReopenContainerLog(ctx, r)
+	i, err := cm.getServiceByContainerID(r.GetContainerId())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service for container %q: %w", r.GetContainerId(), err)
+	}
+	return i.ReopenContainerLog(ctx, r)
 }

--- a/pkg/cri/server/manager.go
+++ b/pkg/cri/server/manager.go
@@ -1,0 +1,200 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+
+	"github.com/containerd/containerd"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtime_alpha "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+
+	criconfig "github.com/containerd/containerd/pkg/cri/config"
+)
+
+type criManager struct {
+	// config contains all configurations.
+	config *criconfig.Config
+	// default service
+	c *criService
+}
+
+// NewCRIManager returns a new instance of CRIService
+func NewCRIManager(config criconfig.Config, client *containerd.Client) (CRIService, error) {
+	c, err := newCRIService(&config, client)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create CRI service")
+	}
+	cm := &criManager{
+		config: &config,
+		c:      c,
+	}
+	return cm, nil
+}
+
+// Register registers all required services onto a specific grpc server.
+// This is used by containerd cri plugin.
+func (cm *criManager) Register(s *grpc.Server) error {
+	return cm.register(s)
+}
+
+// RegisterTCP register all required services onto a GRPC server on TCP.
+// This is used by containerd CRI plugin.
+func (cm *criManager) RegisterTCP(s *grpc.Server) error {
+	if !cm.config.DisableTCPService {
+		return cm.register(s)
+	}
+	return nil
+}
+
+// Run starts the CRI service.
+func (cm *criManager) Run() error {
+	return cm.c.Run()
+}
+
+// Close stops the CRI service.
+func (cm *criManager) Close() error {
+	return cm.c.Close()
+}
+
+func (cm *criManager) register(s *grpc.Server) error {
+	instrumented := newInstrumentedService(cm)
+	runtime.RegisterRuntimeServiceServer(s, instrumented)
+	runtime.RegisterImageServiceServer(s, instrumented)
+	instrumentedAlpha := newInstrumentedAlphaService(cm)
+	runtime_alpha.RegisterRuntimeServiceServer(s, instrumentedAlpha)
+	runtime_alpha.RegisterImageServiceServer(s, instrumentedAlpha)
+	return nil
+}
+
+func (cm *criManager) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandboxRequest) (*runtime.RunPodSandboxResponse, error) {
+	return cm.c.RunPodSandbox(ctx, r)
+}
+
+func (cm *criManager) ListPodSandbox(ctx context.Context, r *runtime.ListPodSandboxRequest) (*runtime.ListPodSandboxResponse, error) {
+	return cm.c.ListPodSandbox(ctx, r)
+}
+
+func (cm *criManager) PodSandboxStatus(ctx context.Context, r *runtime.PodSandboxStatusRequest) (*runtime.PodSandboxStatusResponse, error) {
+	return cm.c.PodSandboxStatus(ctx, r)
+}
+
+func (cm *criManager) StopPodSandbox(ctx context.Context, r *runtime.StopPodSandboxRequest) (*runtime.StopPodSandboxResponse, error) {
+	return cm.c.StopPodSandbox(ctx, r)
+}
+
+func (cm *criManager) RemovePodSandbox(ctx context.Context, r *runtime.RemovePodSandboxRequest) (*runtime.RemovePodSandboxResponse, error) {
+	return cm.c.RemovePodSandbox(ctx, r)
+}
+
+func (cm *criManager) PortForward(ctx context.Context, r *runtime.PortForwardRequest) (*runtime.PortForwardResponse, error) {
+	return cm.c.PortForward(ctx, r)
+}
+
+func (cm *criManager) CreateContainer(ctx context.Context, r *runtime.CreateContainerRequest) (*runtime.CreateContainerResponse, error) {
+	return cm.c.CreateContainer(ctx, r)
+}
+
+func (cm *criManager) StartContainer(ctx context.Context, r *runtime.StartContainerRequest) (*runtime.StartContainerResponse, error) {
+	return cm.c.StartContainer(ctx, r)
+}
+
+func (cm *criManager) ListContainers(ctx context.Context, r *runtime.ListContainersRequest) (*runtime.ListContainersResponse, error) {
+	return cm.c.ListContainers(ctx, r)
+}
+
+func (cm *criManager) ContainerStatus(ctx context.Context, r *runtime.ContainerStatusRequest) (*runtime.ContainerStatusResponse, error) {
+	return cm.c.ContainerStatus(ctx, r)
+}
+
+func (cm *criManager) StopContainer(ctx context.Context, r *runtime.StopContainerRequest) (*runtime.StopContainerResponse, error) {
+	return cm.c.StopContainer(ctx, r)
+}
+
+func (cm *criManager) RemoveContainer(ctx context.Context, r *runtime.RemoveContainerRequest) (*runtime.RemoveContainerResponse, error) {
+	return cm.c.RemoveContainer(ctx, r)
+}
+
+func (cm *criManager) ExecSync(ctx context.Context, r *runtime.ExecSyncRequest) (*runtime.ExecSyncResponse, error) {
+	return cm.c.ExecSync(ctx, r)
+}
+
+func (cm *criManager) Exec(ctx context.Context, r *runtime.ExecRequest) (*runtime.ExecResponse, error) {
+	return cm.c.Exec(ctx, r)
+}
+
+func (cm *criManager) Attach(ctx context.Context, r *runtime.AttachRequest) (*runtime.AttachResponse, error) {
+	return cm.c.Attach(ctx, r)
+}
+
+func (cm *criManager) UpdateContainerResources(ctx context.Context, r *runtime.UpdateContainerResourcesRequest) (*runtime.UpdateContainerResourcesResponse, error) {
+	return cm.c.UpdateContainerResources(ctx, r)
+}
+
+func (cm *criManager) PullImage(ctx context.Context, r *runtime.PullImageRequest) (*runtime.PullImageResponse, error) {
+	return cm.c.PullImage(ctx, r)
+}
+
+func (cm *criManager) ListImages(ctx context.Context, r *runtime.ListImagesRequest) (*runtime.ListImagesResponse, error) {
+	return cm.c.ListImages(ctx, r)
+}
+
+func (cm *criManager) ImageStatus(ctx context.Context, r *runtime.ImageStatusRequest) (*runtime.ImageStatusResponse, error) {
+	return cm.c.ImageStatus(ctx, r)
+}
+
+func (cm *criManager) RemoveImage(ctx context.Context, r *runtime.RemoveImageRequest) (*runtime.RemoveImageResponse, error) {
+	return cm.c.RemoveImage(ctx, r)
+}
+
+func (cm *criManager) ImageFsInfo(ctx context.Context, r *runtime.ImageFsInfoRequest) (*runtime.ImageFsInfoResponse, error) {
+	return cm.c.ImageFsInfo(ctx, r)
+}
+
+func (cm *criManager) PodSandboxStats(ctx context.Context, r *runtime.PodSandboxStatsRequest) (*runtime.PodSandboxStatsResponse, error) {
+	return cm.c.PodSandboxStats(ctx, r)
+}
+
+func (cm *criManager) ContainerStats(ctx context.Context, r *runtime.ContainerStatsRequest) (*runtime.ContainerStatsResponse, error) {
+	return cm.c.ContainerStats(ctx, r)
+}
+
+func (cm *criManager) ListPodSandboxStats(ctx context.Context, r *runtime.ListPodSandboxStatsRequest) (res *runtime.ListPodSandboxStatsResponse, err error) {
+	return cm.c.ListPodSandboxStats(ctx, r)
+}
+
+func (cm *criManager) ListContainerStats(ctx context.Context, r *runtime.ListContainerStatsRequest) (*runtime.ListContainerStatsResponse, error) {
+	return cm.c.ListContainerStats(ctx, r)
+}
+
+func (cm *criManager) Status(ctx context.Context, r *runtime.StatusRequest) (*runtime.StatusResponse, error) {
+	return cm.c.Status(ctx, r)
+}
+
+func (cm *criManager) Version(ctx context.Context, r *runtime.VersionRequest) (*runtime.VersionResponse, error) {
+	return cm.c.Version(ctx, r)
+}
+
+func (cm *criManager) UpdateRuntimeConfig(ctx context.Context, r *runtime.UpdateRuntimeConfigRequest) (*runtime.UpdateRuntimeConfigResponse, error) {
+	return cm.c.UpdateRuntimeConfig(ctx, r)
+}
+
+func (cm *criManager) ReopenContainerLog(ctx context.Context, r *runtime.ReopenContainerLogRequest) (*runtime.ReopenContainerLogResponse, error) {
+	return cm.c.ReopenContainerLog(ctx, r)
+}

--- a/pkg/cri/server/restart.go
+++ b/pkg/cri/server/restart.go
@@ -63,10 +63,10 @@ func (c *criService) recover(ctx context.Context) error {
 			continue
 		}
 		log.G(ctx).Debugf("Loaded sandbox %+v", sb)
-		if err := c.sandboxStore.Add(sb); err != nil {
+		if err := c.SandboxStore.Add(sb); err != nil {
 			return fmt.Errorf("failed to add sandbox %q to store: %w", sandbox.ID(), err)
 		}
-		if err := c.sandboxNameIndex.Reserve(sb.Name, sb.ID); err != nil {
+		if err := c.SandboxNameIndex.Reserve(sb.Name, sb.ID); err != nil {
 			return fmt.Errorf("failed to reserve sandbox name %q: %w", sb.Name, err)
 		}
 	}
@@ -83,10 +83,10 @@ func (c *criService) recover(ctx context.Context) error {
 			continue
 		}
 		log.G(ctx).Debugf("Loaded container %+v", cntr)
-		if err := c.containerStore.Add(cntr); err != nil {
+		if err := c.ContainerStore.Add(cntr); err != nil {
 			return fmt.Errorf("failed to add container %q to store: %w", container.ID(), err)
 		}
-		if err := c.containerNameIndex.Reserve(cntr.Name, cntr.ID); err != nil {
+		if err := c.ContainerNameIndex.Reserve(cntr.Name, cntr.ID); err != nil {
 			return fmt.Errorf("failed to reserve container name %q: %w", cntr.Name, err)
 		}
 	}

--- a/pkg/cri/server/sandbox_list.go
+++ b/pkg/cri/server/sandbox_list.go
@@ -29,7 +29,7 @@ import (
 func (c *criService) ListPodSandbox(ctx context.Context, r *runtime.ListPodSandboxRequest) (*runtime.ListPodSandboxResponse, error) {
 	start := time.Now()
 	// List all sandboxes from store.
-	sandboxesInStore := c.sandboxStore.List()
+	sandboxesInStore := c.SandboxStore.List()
 	var sandboxes []*runtime.PodSandbox
 	for _, sandboxInStore := range sandboxesInStore {
 		sandboxes = append(sandboxes, toCRISandbox(
@@ -63,13 +63,13 @@ func toCRISandbox(meta sandboxstore.Metadata, status sandboxstore.Status) *runti
 }
 
 func (c *criService) normalizePodSandboxFilter(filter *runtime.PodSandboxFilter) {
-	if sb, err := c.sandboxStore.Get(filter.GetId()); err == nil {
+	if sb, err := c.SandboxStore.Get(filter.GetId()); err == nil {
 		filter.Id = sb.ID
 	}
 }
 
 func (c *criService) normalizePodSandboxStatsFilter(filter *runtime.PodSandboxStatsFilter) {
-	if sb, err := c.sandboxStore.Get(filter.GetId()); err == nil {
+	if sb, err := c.SandboxStore.Get(filter.GetId()); err == nil {
 		filter.Id = sb.ID
 	}
 }

--- a/pkg/cri/server/sandbox_list_test.go
+++ b/pkg/cri/server/sandbox_list_test.go
@@ -152,7 +152,7 @@ func TestFilterSandboxes(t *testing.T) {
 
 	// Inject test sandbox metadata
 	for _, sb := range sandboxes {
-		assert.NoError(t, c.sandboxStore.Add(sb))
+		assert.NoError(t, c.SandboxStore.Add(sb))
 	}
 
 	for desc, test := range map[string]struct {

--- a/pkg/cri/server/sandbox_portforward.go
+++ b/pkg/cri/server/sandbox_portforward.go
@@ -28,7 +28,7 @@ import (
 
 // PortForward prepares a streaming endpoint to forward ports from a PodSandbox, and returns the address.
 func (c *criService) PortForward(ctx context.Context, r *runtime.PortForwardRequest) (retRes *runtime.PortForwardResponse, retErr error) {
-	sandbox, err := c.sandboxStore.Get(r.GetPodSandboxId())
+	sandbox, err := c.SandboxStore.Get(r.GetPodSandboxId())
 	if err != nil {
 		return nil, fmt.Errorf("failed to find sandbox %q: %w", r.GetPodSandboxId(), err)
 	}

--- a/pkg/cri/server/sandbox_portforward_linux.go
+++ b/pkg/cri/server/sandbox_portforward_linux.go
@@ -32,7 +32,7 @@ import (
 // portForward uses netns to enter the sandbox namespace, and forwards a stream inside the
 // the namespace to a specific port. It keeps forwarding until it exits or client disconnect.
 func (c *criService) portForward(ctx context.Context, id string, port int32, stream io.ReadWriteCloser) error {
-	s, err := c.sandboxStore.Get(id)
+	s, err := c.SandboxStore.Get(id)
 	if err != nil {
 		return fmt.Errorf("failed to find sandbox %q in store: %w", id, err)
 	}

--- a/pkg/cri/server/sandbox_portforward_windows.go
+++ b/pkg/cri/server/sandbox_portforward_windows.go
@@ -44,7 +44,7 @@ func (c *criService) portForward(ctx context.Context, id string, port int32, str
 
 func (c *criService) execInSandbox(ctx context.Context, sandboxID string, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser) error {
 	// Get sandbox from our sandbox store.
-	sb, err := c.sandboxStore.Get(sandboxID)
+	sb, err := c.SandboxStore.Get(sandboxID)
 	if err != nil {
 		return fmt.Errorf("failed to find sandbox %q in store: %w", sandboxID, err)
 	}

--- a/pkg/cri/server/sandbox_remove.go
+++ b/pkg/cri/server/sandbox_remove.go
@@ -33,7 +33,7 @@ import (
 // sandbox, they should be forcibly removed.
 func (c *criService) RemovePodSandbox(ctx context.Context, r *runtime.RemovePodSandboxRequest) (*runtime.RemovePodSandboxResponse, error) {
 	start := time.Now()
-	sandbox, err := c.sandboxStore.Get(r.GetPodSandboxId())
+	sandbox, err := c.SandboxStore.Get(r.GetPodSandboxId())
 	if err != nil {
 		if !errdefs.IsNotFound(err) {
 			return nil, fmt.Errorf("an error occurred when try to find sandbox %q: %w",
@@ -70,7 +70,7 @@ func (c *criService) RemovePodSandbox(ctx context.Context, r *runtime.RemovePodS
 	// not rely on this behavior.
 	// TODO(random-liu): Introduce an intermediate state to avoid container creation after
 	// this point.
-	cntrs := c.containerStore.List()
+	cntrs := c.ContainerStore.List()
 	for _, cntr := range cntrs {
 		if cntr.SandboxID != id {
 			continue
@@ -106,10 +106,10 @@ func (c *criService) RemovePodSandbox(ctx context.Context, r *runtime.RemovePodS
 	// 1) ListPodSandbox will not include this sandbox.
 	// 2) PodSandboxStatus and StopPodSandbox will return error.
 	// 3) On-going operations which have held the reference will not be affected.
-	c.sandboxStore.Delete(id)
+	c.SandboxStore.Delete(id)
 
 	// Release the sandbox name reserved for the sandbox.
-	c.sandboxNameIndex.ReleaseByKey(id)
+	c.SandboxNameIndex.ReleaseByKey(id)
 
 	sandboxRemoveTimer.WithValues(sandbox.RuntimeHandler).UpdateSince(start)
 

--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -56,6 +56,15 @@ func init() {
 		"github.com/containerd/cri/pkg/store/sandbox", "Metadata")
 }
 
+func (c *criService) getCRIHandlerByRuntime(runtime string) string {
+	if r, ok := c.config.ContainerdConfig.Runtimes[runtime]; ok {
+		if len(r.CRIHandler) != 0 {
+			return r.CRIHandler
+		}
+	}
+	return criconfig.DefaultCRIHandler
+}
+
 // RunPodSandbox creates and starts a pod-level sandbox. Runtimes should ensure
 // the sandbox is in ready state.
 func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandboxRequest) (_ *runtime.RunPodSandboxResponse, retErr error) {
@@ -109,6 +118,8 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	if err != nil {
 		return nil, fmt.Errorf("failed to get sandbox runtime: %w", err)
 	}
+	sandbox.Metadata.CRIHandler = c.getCRIHandlerByRuntime(r.GetRuntimeHandler())
+
 	log.G(ctx).WithField("podsandboxid", id).Debugf("use OCI runtime %+v", ociRuntime)
 
 	podNetwork := true

--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -72,13 +72,13 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	log.G(ctx).WithField("podsandboxid", id).Debugf("generated id for sandbox name %q", name)
 	// Reserve the sandbox name to avoid concurrent `RunPodSandbox` request starting the
 	// same sandbox.
-	if err := c.sandboxNameIndex.Reserve(name, id); err != nil {
+	if err := c.SandboxNameIndex.Reserve(name, id); err != nil {
 		return nil, fmt.Errorf("failed to reserve sandbox name %q: %w", name, err)
 	}
 	defer func() {
 		// Release the name if the function returns with an error.
 		if retErr != nil {
-			c.sandboxNameIndex.ReleaseByName(name)
+			c.SandboxNameIndex.ReleaseByName(name)
 		}
 	}()
 
@@ -342,7 +342,7 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	// Add sandbox into sandbox store in INIT state.
 	sandbox.Container = container
 
-	if err := c.sandboxStore.Add(sandbox); err != nil {
+	if err := c.SandboxStore.Add(sandbox); err != nil {
 		return nil, fmt.Errorf("failed to add sandbox %+v into store: %w", sandbox, err)
 	}
 

--- a/pkg/cri/server/sandbox_run_test.go
+++ b/pkg/cri/server/sandbox_run_test.go
@@ -507,7 +507,7 @@ func TestGetSandboxRuntime(t *testing.T) {
 	} {
 		t.Run(desc, func(t *testing.T) {
 			cri := newTestCRIService()
-			cri.config = criconfig.Config{
+			cri.config = &criconfig.Config{
 				PluginConfig: criconfig.DefaultConfig(),
 			}
 			cri.config.ContainerdConfig.DefaultRuntimeName = criconfig.RuntimeDefault

--- a/pkg/cri/server/sandbox_stats.go
+++ b/pkg/cri/server/sandbox_stats.go
@@ -28,7 +28,7 @@ func (c *criService) PodSandboxStats(
 	r *runtime.PodSandboxStatsRequest,
 ) (*runtime.PodSandboxStatsResponse, error) {
 
-	sandbox, err := c.sandboxStore.Get(r.GetPodSandboxId())
+	sandbox, err := c.SandboxStore.Get(r.GetPodSandboxId())
 	if err != nil {
 		return nil, fmt.Errorf("an error occurred when trying to find sandbox %s: %w", r.GetPodSandboxId(), err)
 	}

--- a/pkg/cri/server/sandbox_stats_linux.go
+++ b/pkg/cri/server/sandbox_stats_linux.go
@@ -83,7 +83,7 @@ func (c *criService) podSandboxStats(
 		}
 
 		var pidCount uint64
-		for _, cntr := range c.containerStore.List() {
+		for _, cntr := range c.ContainerStore.List() {
 			if cntr.SandboxID != sandbox.ID {
 				continue
 			}

--- a/pkg/cri/server/sandbox_stats_list.go
+++ b/pkg/cri/server/sandbox_stats_list.go
@@ -50,7 +50,7 @@ func (c *criService) ListPodSandboxStats(
 }
 
 func (c *criService) sandboxesForListPodSandboxStatsRequest(r *runtime.ListPodSandboxStatsRequest) []sandboxstore.Sandbox {
-	sandboxesInStore := c.sandboxStore.List()
+	sandboxesInStore := c.SandboxStore.List()
 
 	if r.GetFilter() == nil {
 		return sandboxesInStore

--- a/pkg/cri/server/sandbox_status.go
+++ b/pkg/cri/server/sandbox_status.go
@@ -33,7 +33,7 @@ import (
 
 // PodSandboxStatus returns the status of the PodSandbox.
 func (c *criService) PodSandboxStatus(ctx context.Context, r *runtime.PodSandboxStatusRequest) (*runtime.PodSandboxStatusResponse, error) {
-	sandbox, err := c.sandboxStore.Get(r.GetPodSandboxId())
+	sandbox, err := c.SandboxStore.Get(r.GetPodSandboxId())
 	if err != nil {
 		return nil, fmt.Errorf("an error occurred when try to find sandbox: %w", err)
 	}

--- a/pkg/cri/server/sandbox_stop.go
+++ b/pkg/cri/server/sandbox_stop.go
@@ -35,7 +35,7 @@ import (
 // StopPodSandbox stops the sandbox. If there are any running containers in the
 // sandbox, they should be forcibly terminated.
 func (c *criService) StopPodSandbox(ctx context.Context, r *runtime.StopPodSandboxRequest) (*runtime.StopPodSandboxResponse, error) {
-	sandbox, err := c.sandboxStore.Get(r.GetPodSandboxId())
+	sandbox, err := c.SandboxStore.Get(r.GetPodSandboxId())
 	if err != nil {
 		return nil, fmt.Errorf("an error occurred when try to find sandbox %q: %w",
 			r.GetPodSandboxId(), err)
@@ -56,7 +56,7 @@ func (c *criService) stopPodSandbox(ctx context.Context, sandbox sandboxstore.Sa
 	// and container may still be created, so production should not rely on this behavior.
 	// TODO(random-liu): Introduce a state in sandbox to avoid future container creation.
 	stop := time.Now()
-	containers := c.containerStore.List()
+	containers := c.ContainerStore.List()
 	for _, container := range containers {
 		if container.SandboxID != id {
 			continue

--- a/pkg/cri/server/service.go
+++ b/pkg/cri/server/service.go
@@ -43,6 +43,7 @@ import (
 	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
 	imagestore "github.com/containerd/containerd/pkg/cri/store/image"
 	sandboxstore "github.com/containerd/containerd/pkg/cri/store/sandbox"
+	cristore "github.com/containerd/containerd/pkg/cri/store/service"
 	snapshotstore "github.com/containerd/containerd/pkg/cri/store/snapshot"
 	ctrdutil "github.com/containerd/containerd/pkg/cri/util"
 	osinterface "github.com/containerd/containerd/pkg/os"
@@ -74,24 +75,14 @@ type CRIService interface {
 
 // criService implements CRIService.
 type criService struct {
+	// stores all resources associated with cri
+	*cristore.Store
 	// config contains all configurations.
 	config *criconfig.Config
 	// imageFSPath is the path to image filesystem.
 	imageFSPath string
 	// os is an interface for all required os operations.
 	os osinterface.OS
-	// sandboxStore stores all resources associated with sandboxes.
-	sandboxStore *sandboxstore.Store
-	// sandboxNameIndex stores all sandbox names and make sure each name
-	// is unique.
-	sandboxNameIndex *registrar.Registrar
-	// containerStore stores all resources associated with containers.
-	containerStore *containerstore.Store
-	// containerNameIndex stores all container names and make sure each
-	// name is unique.
-	containerNameIndex *registrar.Registrar
-	// imageStore stores all resources associated with images.
-	imageStore *imagestore.Store
 	// snapshotStore stores information of all snapshots.
 	snapshotStore *snapshotstore.Store
 	// netPlugin is used to setup and teardown network when run/stop pod sandbox.
@@ -120,17 +111,19 @@ func newCRIService(config *criconfig.Config, client *containerd.Client) (*criSer
 	var err error
 	labels := label.NewStore()
 	c := &criService{
-		config:             config,
-		client:             client,
-		os:                 osinterface.RealOS{},
-		sandboxStore:       sandboxstore.NewStore(labels),
-		containerStore:     containerstore.NewStore(labels),
-		imageStore:         imagestore.NewStore(client),
-		snapshotStore:      snapshotstore.NewStore(),
-		sandboxNameIndex:   registrar.NewRegistrar(),
-		containerNameIndex: registrar.NewRegistrar(),
-		initialized:        atomic.NewBool(false),
-		netPlugin:          make(map[string]cni.CNI),
+		config:        config,
+		client:        client,
+		os:            osinterface.RealOS{},
+		snapshotStore: snapshotstore.NewStore(),
+		Store: &cristore.Store{
+			SandboxStore:       sandboxstore.NewStore(labels),
+			ContainerStore:     containerstore.NewStore(labels),
+			ImageStore:         imagestore.NewStore(client),
+			SandboxNameIndex:   registrar.NewRegistrar(),
+			ContainerNameIndex: registrar.NewRegistrar(),
+		},
+		initialized: atomic.NewBool(false),
+		netPlugin:   make(map[string]cni.CNI),
 	}
 
 	if client.SnapshotService(c.config.ContainerdConfig.Snapshotter) == nil {

--- a/pkg/cri/server/service.go
+++ b/pkg/cri/server/service.go
@@ -115,8 +115,8 @@ type criService struct {
 	allCaps []string // nolint
 }
 
-// NewCRIService returns a new instance of CRIService
-func NewCRIService(config *criconfig.Config, client *containerd.Client) (CRIService, error) {
+// newCRIService returns a new instance of criService
+func newCRIService(config *criconfig.Config, client *containerd.Client) (*criService, error) {
 	var err error
 	labels := label.NewStore()
 	c := &criService{
@@ -176,21 +176,6 @@ func NewCRIService(config *criconfig.Config, client *containerd.Client) (CRIServ
 	}
 
 	return c, nil
-}
-
-// Register registers all required services onto a specific grpc server.
-// This is used by containerd cri plugin.
-func (c *criService) Register(s *grpc.Server) error {
-	return c.register(s)
-}
-
-// RegisterTCP register all required services onto a GRPC server on TCP.
-// This is used by containerd CRI plugin.
-func (c *criService) RegisterTCP(s *grpc.Server) error {
-	if !c.config.DisableTCPService {
-		return c.register(s)
-	}
-	return nil
 }
 
 // Run starts the CRI service.
@@ -305,16 +290,6 @@ func (c *criService) Close() error {
 	if err := c.streamServer.Stop(); err != nil {
 		return fmt.Errorf("failed to stop stream server: %w", err)
 	}
-	return nil
-}
-
-func (c *criService) register(s *grpc.Server) error {
-	instrumented := newInstrumentedService(c)
-	runtime.RegisterRuntimeServiceServer(s, instrumented)
-	runtime.RegisterImageServiceServer(s, instrumented)
-	instrumentedAlpha := newInstrumentedAlphaService(c)
-	runtime_alpha.RegisterRuntimeServiceServer(s, instrumentedAlpha)
-	runtime_alpha.RegisterImageServiceServer(s, instrumentedAlpha)
 	return nil
 }
 

--- a/pkg/cri/server/service.go
+++ b/pkg/cri/server/service.go
@@ -36,18 +36,12 @@ import (
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 	runtime_alpha "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 
-	"github.com/containerd/containerd/pkg/cri/store/label"
-
 	"github.com/containerd/containerd/pkg/atomic"
 	criconfig "github.com/containerd/containerd/pkg/cri/config"
-	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
-	imagestore "github.com/containerd/containerd/pkg/cri/store/image"
-	sandboxstore "github.com/containerd/containerd/pkg/cri/store/sandbox"
 	cristore "github.com/containerd/containerd/pkg/cri/store/service"
 	snapshotstore "github.com/containerd/containerd/pkg/cri/store/snapshot"
 	ctrdutil "github.com/containerd/containerd/pkg/cri/util"
 	osinterface "github.com/containerd/containerd/pkg/os"
-	"github.com/containerd/containerd/pkg/registrar"
 )
 
 // defaultNetworkPlugin is used for the default CNI configuration
@@ -107,23 +101,16 @@ type criService struct {
 }
 
 // newCRIService returns a new instance of criService
-func newCRIService(config *criconfig.Config, client *containerd.Client) (*criService, error) {
+func newCRIService(config *criconfig.Config, client *containerd.Client, store *cristore.Store) (*criService, error) {
 	var err error
-	labels := label.NewStore()
 	c := &criService{
+		Store:         store,
 		config:        config,
 		client:        client,
 		os:            osinterface.RealOS{},
 		snapshotStore: snapshotstore.NewStore(),
-		Store: &cristore.Store{
-			SandboxStore:       sandboxstore.NewStore(labels),
-			ContainerStore:     containerstore.NewStore(labels),
-			ImageStore:         imagestore.NewStore(client),
-			SandboxNameIndex:   registrar.NewRegistrar(),
-			ContainerNameIndex: registrar.NewRegistrar(),
-		},
-		initialized: atomic.NewBool(false),
-		netPlugin:   make(map[string]cni.CNI),
+		netPlugin:     make(map[string]cni.CNI),
+		initialized:   atomic.NewBool(false),
 	}
 
 	if client.SnapshotService(c.config.ContainerdConfig.Snapshotter) == nil {

--- a/pkg/cri/server/service.go
+++ b/pkg/cri/server/service.go
@@ -75,7 +75,7 @@ type CRIService interface {
 // criService implements CRIService.
 type criService struct {
 	// config contains all configurations.
-	config criconfig.Config
+	config *criconfig.Config
 	// imageFSPath is the path to image filesystem.
 	imageFSPath string
 	// os is an interface for all required os operations.
@@ -116,7 +116,7 @@ type criService struct {
 }
 
 // NewCRIService returns a new instance of CRIService
-func NewCRIService(config criconfig.Config, client *containerd.Client) (CRIService, error) {
+func NewCRIService(config *criconfig.Config, client *containerd.Client) (CRIService, error) {
 	var err error
 	labels := label.NewStore()
 	c := &criService{
@@ -170,7 +170,7 @@ func NewCRIService(config criconfig.Config, client *containerd.Client) (CRIServi
 	}
 
 	// Preload base OCI specs
-	c.baseOCISpecs, err = loadBaseOCISpecs(&config)
+	c.baseOCISpecs, err = loadBaseOCISpecs(config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cri/server/service_test.go
+++ b/pkg/cri/server/service_test.go
@@ -51,7 +51,7 @@ const (
 func newTestCRIService() *criService {
 	labels := label.NewStore()
 	return &criService{
-		config: criconfig.Config{
+		config: &criconfig.Config{
 			RootDir:  testRootDir,
 			StateDir: testStateDir,
 			PluginConfig: criconfig.PluginConfig{

--- a/pkg/cri/server/service_test.go
+++ b/pkg/cri/server/service_test.go
@@ -32,6 +32,7 @@ import (
 	imagestore "github.com/containerd/containerd/pkg/cri/store/image"
 	"github.com/containerd/containerd/pkg/cri/store/label"
 	sandboxstore "github.com/containerd/containerd/pkg/cri/store/sandbox"
+	cristore "github.com/containerd/containerd/pkg/cri/store/service"
 	snapshotstore "github.com/containerd/containerd/pkg/cri/store/snapshot"
 	ostesting "github.com/containerd/containerd/pkg/os/testing"
 	"github.com/containerd/containerd/pkg/registrar"
@@ -58,14 +59,16 @@ func newTestCRIService() *criService {
 				SandboxImage: testSandboxImage,
 			},
 		},
-		imageFSPath:        testImageFSPath,
-		os:                 ostesting.NewFakeOS(),
-		sandboxStore:       sandboxstore.NewStore(labels),
-		imageStore:         imagestore.NewStore(nil),
-		snapshotStore:      snapshotstore.NewStore(),
-		sandboxNameIndex:   registrar.NewRegistrar(),
-		containerStore:     containerstore.NewStore(labels),
-		containerNameIndex: registrar.NewRegistrar(),
+		imageFSPath:   testImageFSPath,
+		os:            ostesting.NewFakeOS(),
+		snapshotStore: snapshotstore.NewStore(),
+		Store: &cristore.Store{
+			SandboxStore:       sandboxstore.NewStore(labels),
+			ImageStore:         imagestore.NewStore(nil),
+			ContainerStore:     containerstore.NewStore(labels),
+			SandboxNameIndex:   registrar.NewRegistrar(),
+			ContainerNameIndex: registrar.NewRegistrar(),
+		},
 		netPlugin: map[string]cni.CNI{
 			defaultNetworkPlugin: servertesting.NewFakeCNIPlugin(),
 		},

--- a/pkg/cri/server/streaming_test.go
+++ b/pkg/cri/server/streaming_test.go
@@ -31,7 +31,7 @@ func TestValidateStreamServer(t *testing.T) {
 	}{
 		"should pass with default withoutTLS": {
 			criService: &criService{
-				config: config.Config{
+				config: &config.Config{
 					PluginConfig: config.DefaultConfig(),
 				},
 			},
@@ -40,7 +40,7 @@ func TestValidateStreamServer(t *testing.T) {
 		},
 		"should pass with x509KeyPairTLS": {
 			criService: &criService{
-				config: config.Config{
+				config: &config.Config{
 					PluginConfig: config.PluginConfig{
 						EnableTLSStreaming: true,
 						X509KeyPairStreaming: config.X509KeyPairStreaming{
@@ -55,7 +55,7 @@ func TestValidateStreamServer(t *testing.T) {
 		},
 		"should pass with selfSign": {
 			criService: &criService{
-				config: config.Config{
+				config: &config.Config{
 					PluginConfig: config.PluginConfig{
 						EnableTLSStreaming: true,
 					},
@@ -66,7 +66,7 @@ func TestValidateStreamServer(t *testing.T) {
 		},
 		"should return error with X509 keypair but not EnableTLSStreaming": {
 			criService: &criService{
-				config: config.Config{
+				config: &config.Config{
 					PluginConfig: config.PluginConfig{
 						EnableTLSStreaming: false,
 						X509KeyPairStreaming: config.X509KeyPairStreaming{
@@ -81,7 +81,7 @@ func TestValidateStreamServer(t *testing.T) {
 		},
 		"should return error with X509 TLSCertFile empty": {
 			criService: &criService{
-				config: config.Config{
+				config: &config.Config{
 					PluginConfig: config.PluginConfig{
 						EnableTLSStreaming: true,
 						X509KeyPairStreaming: config.X509KeyPairStreaming{
@@ -96,7 +96,7 @@ func TestValidateStreamServer(t *testing.T) {
 		},
 		"should return error with X509 TLSKeyFile empty": {
 			criService: &criService{
-				config: config.Config{
+				config: &config.Config{
 					PluginConfig: config.PluginConfig{
 						EnableTLSStreaming: true,
 						X509KeyPairStreaming: config.X509KeyPairStreaming{
@@ -111,7 +111,7 @@ func TestValidateStreamServer(t *testing.T) {
 		},
 		"should return error without EnableTLSStreaming and only TLSCertFile set": {
 			criService: &criService{
-				config: config.Config{
+				config: &config.Config{
 					PluginConfig: config.PluginConfig{
 						EnableTLSStreaming: false,
 						X509KeyPairStreaming: config.X509KeyPairStreaming{
@@ -126,7 +126,7 @@ func TestValidateStreamServer(t *testing.T) {
 		},
 		"should return error without EnableTLSStreaming and only TLSKeyFile set": {
 			criService: &criService{
-				config: config.Config{
+				config: &config.Config{
 					PluginConfig: config.PluginConfig{
 						EnableTLSStreaming: false,
 						X509KeyPairStreaming: config.X509KeyPairStreaming{

--- a/pkg/cri/services/cc/service.go
+++ b/pkg/cri/services/cc/service.go
@@ -1,0 +1,215 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containerd/containerd/plugin"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	criconfig "github.com/containerd/containerd/pkg/cri/config"
+	"github.com/containerd/containerd/pkg/cri/server"
+	cristore "github.com/containerd/containerd/pkg/cri/store/service"
+)
+
+func init() {
+	plugin.Register(&plugin.Registration{
+		Type: plugin.CRIPlugin,
+		ID:   "cc",
+		Requires: []plugin.Type{
+			plugin.CRIServicePlugin,
+		},
+		InitFn: initCRICCService,
+	})
+}
+
+func initCRICCService(ic *plugin.InitContext) (interface{}, error) {
+	criStore, err := getCRIStore(ic)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get CRI store services: %w", err)
+	}
+	cc := &ccService{
+		Store: criStore,
+	}
+	return cc, nil
+}
+
+func getCRIStore(ic *plugin.InitContext) (*cristore.Store, error) {
+	plugins, err := ic.GetByType(plugin.CRIServicePlugin)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cri store: %w", err)
+	}
+	p := plugins[cristore.CRIStoreService]
+	if p == nil {
+		return nil, fmt.Errorf("cri service store not found")
+	}
+	i, err := p.Instance()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get instance of cri service store: %w", err)
+	}
+	return i.(*cristore.Store), nil
+}
+
+type ccService struct {
+	// stores all resources associated with cri
+	*cristore.Store
+	// config contains all configurations.
+	config *criconfig.Config
+	// default cir implemention
+	delegate server.GrpcServices
+}
+
+func (cc *ccService) SetDelegate(delegate server.GrpcServices) {
+	cc.delegate = delegate
+}
+
+func (cc *ccService) SetConfig(config *criconfig.Config) {
+	cc.config = config
+}
+
+// implement CRIPlugin Initialized interface
+func (cc *ccService) Initialized() bool {
+	return true
+}
+
+// Run starts the CRI service.
+func (cc *ccService) Run() error {
+	return nil
+}
+
+// Close stops the CRI service.
+func (cc *ccService) Close() error {
+	return nil
+}
+
+func (cc *ccService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandboxRequest) (*runtime.RunPodSandboxResponse, error) {
+	return cc.delegate.RunPodSandbox(ctx, r)
+}
+
+func (cc *ccService) ListPodSandbox(ctx context.Context, r *runtime.ListPodSandboxRequest) (*runtime.ListPodSandboxResponse, error) {
+	return cc.delegate.ListPodSandbox(ctx, r)
+}
+
+func (cc *ccService) PodSandboxStatus(ctx context.Context, r *runtime.PodSandboxStatusRequest) (*runtime.PodSandboxStatusResponse, error) {
+	return cc.delegate.PodSandboxStatus(ctx, r)
+}
+
+func (cc *ccService) StopPodSandbox(ctx context.Context, r *runtime.StopPodSandboxRequest) (*runtime.StopPodSandboxResponse, error) {
+	return cc.delegate.StopPodSandbox(ctx, r)
+}
+
+func (cc *ccService) RemovePodSandbox(ctx context.Context, r *runtime.RemovePodSandboxRequest) (*runtime.RemovePodSandboxResponse, error) {
+	return cc.delegate.RemovePodSandbox(ctx, r)
+}
+
+func (cc *ccService) PortForward(ctx context.Context, r *runtime.PortForwardRequest) (*runtime.PortForwardResponse, error) {
+	return cc.delegate.PortForward(ctx, r)
+}
+
+func (cc *ccService) CreateContainer(ctx context.Context, r *runtime.CreateContainerRequest) (*runtime.CreateContainerResponse, error) {
+	return cc.delegate.CreateContainer(ctx, r)
+}
+
+func (cc *ccService) StartContainer(ctx context.Context, r *runtime.StartContainerRequest) (*runtime.StartContainerResponse, error) {
+	return cc.delegate.StartContainer(ctx, r)
+}
+
+func (cc *ccService) ListContainers(ctx context.Context, r *runtime.ListContainersRequest) (*runtime.ListContainersResponse, error) {
+	return cc.delegate.ListContainers(ctx, r)
+}
+
+func (cc *ccService) ContainerStatus(ctx context.Context, r *runtime.ContainerStatusRequest) (*runtime.ContainerStatusResponse, error) {
+	return cc.delegate.ContainerStatus(ctx, r)
+}
+
+func (cc *ccService) StopContainer(ctx context.Context, r *runtime.StopContainerRequest) (*runtime.StopContainerResponse, error) {
+	return cc.delegate.StopContainer(ctx, r)
+}
+
+func (cc *ccService) RemoveContainer(ctx context.Context, r *runtime.RemoveContainerRequest) (*runtime.RemoveContainerResponse, error) {
+	return cc.delegate.RemoveContainer(ctx, r)
+}
+
+func (cc *ccService) ExecSync(ctx context.Context, r *runtime.ExecSyncRequest) (*runtime.ExecSyncResponse, error) {
+	return cc.delegate.ExecSync(ctx, r)
+}
+
+func (cc *ccService) Exec(ctx context.Context, r *runtime.ExecRequest) (*runtime.ExecResponse, error) {
+	return cc.delegate.Exec(ctx, r)
+}
+
+func (cc *ccService) Attach(ctx context.Context, r *runtime.AttachRequest) (*runtime.AttachResponse, error) {
+	return cc.delegate.Attach(ctx, r)
+}
+
+func (cc *ccService) UpdateContainerResources(ctx context.Context, r *runtime.UpdateContainerResourcesRequest) (*runtime.UpdateContainerResourcesResponse, error) {
+	return cc.delegate.UpdateContainerResources(ctx, r)
+}
+
+func (cc *ccService) PullImage(ctx context.Context, r *runtime.PullImageRequest) (*runtime.PullImageResponse, error) {
+	return cc.delegate.PullImage(ctx, r)
+}
+
+func (cc *ccService) ListImages(ctx context.Context, r *runtime.ListImagesRequest) (*runtime.ListImagesResponse, error) {
+	return cc.delegate.ListImages(ctx, r)
+}
+
+func (cc *ccService) ImageStatus(ctx context.Context, r *runtime.ImageStatusRequest) (*runtime.ImageStatusResponse, error) {
+	return cc.delegate.ImageStatus(ctx, r)
+}
+
+func (cc *ccService) RemoveImage(ctx context.Context, r *runtime.RemoveImageRequest) (*runtime.RemoveImageResponse, error) {
+	return cc.delegate.RemoveImage(ctx, r)
+}
+
+func (cc *ccService) ImageFsInfo(ctx context.Context, r *runtime.ImageFsInfoRequest) (*runtime.ImageFsInfoResponse, error) {
+	return cc.delegate.ImageFsInfo(ctx, r)
+}
+
+func (cc *ccService) PodSandboxStats(ctx context.Context, r *runtime.PodSandboxStatsRequest) (*runtime.PodSandboxStatsResponse, error) {
+	return cc.delegate.PodSandboxStats(ctx, r)
+}
+
+func (cc *ccService) ContainerStats(ctx context.Context, r *runtime.ContainerStatsRequest) (*runtime.ContainerStatsResponse, error) {
+	return cc.delegate.ContainerStats(ctx, r)
+}
+
+func (cc *ccService) ListPodSandboxStats(ctx context.Context, r *runtime.ListPodSandboxStatsRequest) (*runtime.ListPodSandboxStatsResponse, error) {
+	return cc.delegate.ListPodSandboxStats(ctx, r)
+}
+
+func (cc *ccService) ListContainerStats(ctx context.Context, r *runtime.ListContainerStatsRequest) (*runtime.ListContainerStatsResponse, error) {
+	return cc.delegate.ListContainerStats(ctx, r)
+}
+
+func (cc *ccService) Status(ctx context.Context, r *runtime.StatusRequest) (*runtime.StatusResponse, error) {
+	return cc.delegate.Status(ctx, r)
+}
+
+func (cc *ccService) Version(ctx context.Context, r *runtime.VersionRequest) (*runtime.VersionResponse, error) {
+	return cc.delegate.Version(ctx, r)
+}
+
+func (cc *ccService) UpdateRuntimeConfig(ctx context.Context, r *runtime.UpdateRuntimeConfigRequest) (*runtime.UpdateRuntimeConfigResponse, error) {
+	return cc.delegate.UpdateRuntimeConfig(ctx, r)
+}
+
+func (cc *ccService) ReopenContainerLog(ctx context.Context, r *runtime.ReopenContainerLogRequest) (*runtime.ReopenContainerLogResponse, error) {
+	return cc.delegate.ReopenContainerLog(ctx, r)
+}

--- a/pkg/cri/store/sandbox/metadata.go
+++ b/pkg/cri/store/sandbox/metadata.go
@@ -63,6 +63,8 @@ type Metadata struct {
 	CNIResult *cni.Result
 	// ProcessLabel is the SELinux process label for the container
 	ProcessLabel string
+	// CRIHandler control cri specific implementations.
+	CRIHandler string
 }
 
 // MarshalJSON encodes Metadata into bytes in json format.

--- a/pkg/cri/store/service/service.go
+++ b/pkg/cri/store/service/service.go
@@ -17,12 +17,61 @@
 package service
 
 import (
-	"github.com/containerd/containerd/pkg/registrar"
+	"fmt"
 
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/api/services/images/v1"
+	"github.com/containerd/containerd/api/services/namespaces/v1"
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/platforms"
+	"github.com/containerd/containerd/plugin"
+	"github.com/containerd/containerd/services"
+
+	"github.com/containerd/containerd/pkg/cri/constants"
 	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
 	imagestore "github.com/containerd/containerd/pkg/cri/store/image"
+	"github.com/containerd/containerd/pkg/cri/store/label"
 	sandboxstore "github.com/containerd/containerd/pkg/cri/store/sandbox"
+	"github.com/containerd/containerd/pkg/registrar"
 )
+
+// CRIStoreService is the Plugin ID
+const CRIStoreService = "cri-store"
+
+func init() {
+	plugin.Register(&plugin.Registration{
+		Type: plugin.CRIServicePlugin,
+		ID:   CRIStoreService,
+		Requires: []plugin.Type{
+			plugin.ServicePlugin,
+		},
+		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
+			servicesOpts, err := getServicesOpts(ic)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get services: %w", err)
+			}
+
+			client, err := containerd.New(
+				"",
+				containerd.WithDefaultNamespace(constants.K8sContainerdNamespace),
+				containerd.WithDefaultPlatform(platforms.Default()),
+				containerd.WithServices(servicesOpts...),
+			)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create containerd client: %w", err)
+			}
+			labels := label.NewStore()
+			store := &Store{
+				SandboxStore:       sandboxstore.NewStore(labels),
+				ContainerStore:     containerstore.NewStore(labels),
+				ImageStore:         imagestore.NewStore(client),
+				SandboxNameIndex:   registrar.NewRegistrar(),
+				ContainerNameIndex: registrar.NewRegistrar(),
+			}
+			return store, nil
+		},
+	})
+}
 
 // Store stores all resources associated with cri
 type Store struct {
@@ -38,4 +87,41 @@ type Store struct {
 	ContainerNameIndex *registrar.Registrar
 	// imageStore stores all resources associated with images.
 	ImageStore *imagestore.Store
+}
+
+// getServicesOpts get service options from plugin context.
+func getServicesOpts(ic *plugin.InitContext) ([]containerd.ServicesOpt, error) {
+	plugins, err := ic.GetByType(plugin.ServicePlugin)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service plugin: %w", err)
+	}
+
+	opts := []containerd.ServicesOpt{
+		containerd.WithEventService(ic.Events),
+	}
+	for s, fn := range map[string]func(interface{}) containerd.ServicesOpt{
+		services.ContentService: func(s interface{}) containerd.ServicesOpt {
+			return containerd.WithContentStore(s.(content.Store))
+		},
+		services.ImagesService: func(s interface{}) containerd.ServicesOpt {
+			return containerd.WithImageClient(s.(images.ImagesClient))
+		},
+		services.NamespacesService: func(s interface{}) containerd.ServicesOpt {
+			return containerd.WithNamespaceClient(s.(namespaces.NamespacesClient))
+		},
+	} {
+		p := plugins[s]
+		if p == nil {
+			return nil, fmt.Errorf("service %q not found", s)
+		}
+		i, err := p.Instance()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get instance of service %q: %w", s, err)
+		}
+		if i == nil {
+			return nil, fmt.Errorf("instance of service %q not found", s)
+		}
+		opts = append(opts, fn(i))
+	}
+	return opts, nil
 }

--- a/pkg/cri/store/service/service.go
+++ b/pkg/cri/store/service/service.go
@@ -1,0 +1,41 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package service
+
+import (
+	"github.com/containerd/containerd/pkg/registrar"
+
+	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
+	imagestore "github.com/containerd/containerd/pkg/cri/store/image"
+	sandboxstore "github.com/containerd/containerd/pkg/cri/store/sandbox"
+)
+
+// Store stores all resources associated with cri
+type Store struct {
+	// sandboxStore stores all resources associated with sandboxes.
+	SandboxStore *sandboxstore.Store
+	// SandboxNameIndex stores all sandbox names and make sure each name
+	// is unique.
+	SandboxNameIndex *registrar.Registrar
+	// containerStore stores all resources associated with containers.
+	ContainerStore *containerstore.Store
+	// ContainerNameIndex stores all container names and make sure each
+	// name is unique.
+	ContainerNameIndex *registrar.Registrar
+	// imageStore stores all resources associated with images.
+	ImageStore *imagestore.Store
+}

--- a/pkg/registrar/registrar.go
+++ b/pkg/registrar/registrar.go
@@ -99,3 +99,15 @@ func (r *Registrar) ReleaseByKey(key string) {
 	delete(r.nameToKey, name)
 	delete(r.keyToName, key)
 }
+
+// GetKeyByName get the key by name.
+func (r *Registrar) GetKeyByName(name string) string {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	key, exists := r.nameToKey[name]
+	if !exists {
+		return ""
+	}
+	return key
+}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -78,6 +78,8 @@ const (
 	EventPlugin Type = "io.containerd.event.v1"
 	// TracingProcessorPlugin implements a open telemetry span processor
 	TracingProcessorPlugin Type = "io.containerd.tracing.processor.v1"
+	// CRIServicePlugin implements cri needed service
+	CRIServicePlugin Type = "io.containerd.cri.service.v1"
 )
 
 const (

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -80,6 +80,8 @@ const (
 	TracingProcessorPlugin Type = "io.containerd.tracing.processor.v1"
 	// CRIServicePlugin implements cri needed service
 	CRIServicePlugin Type = "io.containerd.cri.service.v1"
+	// CRIPlugin implements different cri implementations
+	CRIPlugin Type = "io.containerd.cri.v1"
 )
 
 const (


### PR DESCRIPTION
This PR is to improve the implementation of #5742

In the #5742, implements Sandbox API in containerd. However, Sandbox API has not been used in CRI. This PR provides a plugin mechanism in CRI, which can use the Sandbox API to implement specific CRI implementations.

### Goals
* With the popularity of different runtimes, such as vm-based kata, confidential computing. Different strategies need to be used to implement the CRI interface. But it needs to remain compatible with the original runc implementation. So this PR adds a CRI plugin mechanism that allows the type of runtime to have its own specific CRI implementation.

### Changes
1. Added two new Plugin types to be used in cri only.
   * **CRIServicePlugin**, which provides basic services in cri.
   * **CRIPlugin**, specific CRI implementation.
2. In the cri Runtime Config, a **CRIHandler** field is added to indicate which cri implementation is used by the runtime.
3. Add an intermediate layer **criManager**  between `instrumentedService` and `criService`. 
    In order to distribute different CRI implementations.
4. Implement cri **Store** as CRIServicePlugin.
    It requires ServicePlugin. As an infrastructure, it can be used for other CRI Plugins and `criService`. which contains `sandboxStore`/`containerStore`/`imageStore`.

![image](https://user-images.githubusercontent.com/8768126/132795378-93f44b46-e8f3-40f3-bea3-880d97f87502.png)

### Future
1. Change SandboxStore to save interface instead of Sandbox struct. 
    SandboxStore may store different types, such as vm-based kata may need store Sandbox client instead of Container client. 


### Problems
1.  In **criManager**,  some implementations call `criService` directly as the default implementation. For example: `Version` interface, `ListPodSandbox` interface. There are many similar global interface that can be implemented inside criServices.
2. Some basic functions, which can be used as a basic service, are shared by all CRIPlugin. such as `recover` logic.
4. and so on...
