### PR TITLE
runtime: runc v2: remove redundant validation

### DIFF
--- a/runtime/v2/runc/v2/service.go
+++ b/runtime/v2/runc/v2/service.go
@@ -257,9 +257,6 @@ func (s *service) StartShim(ctx context.Context, opts shim.StartOpts) (_ string,
 			if opts, ok := v.(*options.Options); ok {
 				if opts.ShimCgroup != "" {
 					if cgroups.Mode() == cgroups.Unified {
-						if err := cgroupsv2.VerifyGroupPath(opts.ShimCgroup); err != nil {
-							return "", errors.Wrapf(err, "failed to verify cgroup path %q", opts.ShimCgroup)
-						}
 						cg, err := cgroupsv2.LoadManager("/sys/fs/cgroup", opts.ShimCgroup)
 						if err != nil {
 							return "", errors.Wrapf(err, "failed to load cgroup %s", opts.ShimCgroup)


### PR DESCRIPTION
cgroupsv2.LoadManager() already performs VerifyGroupPath(), and returns an error if the path is invalid, so this check is redundant.

see https://github.com/containerd/containerd/blob/34fb8d8967595292adce04b53b12ee33499cd6b8/vendor/github.com/containerd/cgroups/v2/manager.go#L196-L200
