### PR TITLE
Use cgroups.AddProc() for cgroups v1

### DIFF
--- a/runtime/v1/shim/client/client_linux.go
+++ b/runtime/v1/shim/client/client_linux.go
@@ -35,9 +35,7 @@ func setCgroup(cgroupPath string, cmd *exec.Cmd) error {
 	if err != nil {
 		return fmt.Errorf("failed to load cgroup %s: %w", cgroupPath, err)
 	}
-	if err := cg.Add(cgroups.Process{
-		Pid: cmd.Process.Pid,
-	}); err != nil {
+	if err := cg.AddProc(uint64(cmd.Process.Pid)); err != nil {
 		return fmt.Errorf("failed to join cgroup %s: %w", cgroupPath, err)
 	}
 	return nil

--- a/runtime/v2/runc/manager/manager_linux.go
+++ b/runtime/v2/runc/manager/manager_linux.go
@@ -221,9 +221,7 @@ func (manager) Start(ctx context.Context, id string, opts shim.StartOpts) (_ str
 						if err != nil {
 							return "", fmt.Errorf("failed to load cgroup %s: %w", opts.ShimCgroup, err)
 						}
-						if err := cg.Add(cgroups.Process{
-							Pid: cmd.Process.Pid,
-						}); err != nil {
+						if err := cg.AddProc(uint64(cmd.Process.Pid)); err != nil {
 							return "", fmt.Errorf("failed to join cgroup %s: %w", opts.ShimCgroup, err)
 						}
 					}

--- a/runtime/v2/runc/v1/service.go
+++ b/runtime/v2/runc/v1/service.go
@@ -207,9 +207,7 @@ func (s *service) StartShim(ctx context.Context, opts shim.StartOpts) (_ string,
 					if err != nil {
 						return "", fmt.Errorf("failed to load cgroup %s: %w", opts.ShimCgroup, err)
 					}
-					if err := cg.Add(cgroups.Process{
-						Pid: cmd.Process.Pid,
-					}); err != nil {
+					if err := cg.AddProc(uint64(cmd.Process.Pid)); err != nil {
 						return "", fmt.Errorf("failed to join cgroup %s: %w", opts.ShimCgroup, err)
 					}
 				}

--- a/services/server/server_linux.go
+++ b/services/server/server_linux.go
@@ -56,9 +56,7 @@ func apply(ctx context.Context, config *srvconfig.Config) error {
 					return err
 				}
 			}
-			if err := cg.Add(cgroups.Process{
-				Pid: os.Getpid(),
-			}); err != nil {
+			if err := cg.AddProc(uint64(os.Getpid())); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
depends on ~https://github.com/containerd/cgroups/pull/200~ https://github.com/containerd/cgroups/pull/202

All occurrences only passed a PID, so we can use this utility to make the code more symmetrical with their cgroups v2 counterparts.