### PR TITLE
Fix: cgroupsv2 never returns ErrCgroupDeleted

### DIFF
--- a/runtime/opts/opts_linux.go
+++ b/runtime/opts/opts_linux.go
@@ -29,9 +29,6 @@ func WithNamespaceCgroupDeletion(ctx context.Context, i *namespaces.DeleteInfo) 
 	if cgroups.Mode() == cgroups.Unified {
 		cg, err := cgroupsv2.LoadManager("/sys/fs/cgroup", i.Name)
 		if err != nil {
-			if err == cgroupsv2.ErrCgroupDeleted {
-				return nil
-			}
 			return err
 		}
 		return cg.Delete()

--- a/services/server/server_linux.go
+++ b/services/server/server_linux.go
@@ -41,12 +41,7 @@ func apply(ctx context.Context, config *srvconfig.Config) error {
 		if cgroups.Mode() == cgroups.Unified {
 			cg, err := cgroupsv2.LoadManager("/sys/fs/cgroup", config.Cgroup.Path)
 			if err != nil {
-				if err != cgroupsv2.ErrCgroupDeleted {
-					return err
-				}
-				if cg, err = cgroupsv2.NewManager("/sys/fs/cgroup", config.Cgroup.Path, nil); err != nil {
-					return err
-				}
+				return err
 			}
 			if err := cg.AddProc(uint64(os.Getpid())); err != nil {
 				return err


### PR DESCRIPTION
I noticed that this code is checking for `cgroupsv2.ErrCgroupDeleted`

However, `cgroupsv2.LoadManager()` will never return this error type, rendering
the `cgroupsv2.NewManager()` code to be unused.

Even _if_ `cgroupsv2.` would be used, calling `NewManager()` with a `nil` resources
would produce an error ("resources reference is nil");
https://github.com/containerd/cgroups/blob/v1.0.1/v2/manager.go#L169-L172

    func NewManager(mountpoint string, group string, resources *Resources) (*Manager, error) {
        if resources == nil {
            return nil, errors.New("resources reference is nil")
        }

This patch removes checks for `cgroupsv2.ErrCgroupDeleted`, as it is not used
in cgroups v2. As outlined above, this change should not affect the current
behavior.

Question remains: *should* containerd create a new manager? In the current
codebase, `cgroupsv2.NewManager()` is not used, which means that the cgroup
path is never (explicitly) created, and controllers are never enabled (by
containerd); https://github.com/containerd/cgroups/blob/v1.0.1/v2/manager.go#L176-L192

Cgroup paths *will* be created implicitly, as the code continues with `cg.AddProc()`,
which:

- calls `writeValues()` https://github.com/containerd/cgroups/blob/v1.0.1/v2/manager.go#L319
- calls `Value.write()` https://github.com/containerd/cgroups/blob/v1.0.1/v2/manager.go#L162
- calls `ioutil.Writefile()` https://github.com/containerd/cgroups/blob/v1.0.1/v2/manager.go#L147.
    which creates files when missing: https://pkg.go.dev/io/ioutil#WriteFile

    > WriteFile writes data to a file named by filename. If the file does not exist,
    > WriteFile creates it with permissions perm (before umask) (...)
