### PR TITLE
Adding ability to set priority class for containerd and child process on Windows

### DIFF
--- a/services/server/config/config.go
+++ b/services/server/config/config.go
@@ -41,6 +41,8 @@ type Config struct {
 	State string `toml:"state"`
 	// PluginDir is the directory for dynamic plugins to be stored
 	PluginDir string `toml:"plugin_dir"`
+	// WindowsPriorityClass is the priority class used to run containerd and child processes at on Windows machines
+	WindowsPriorityClass string `toml:"windows_priority_class"`
 	// GRPC configuration settings
 	GRPC GRPCConfig `toml:"grpc"`
 	// TTRPC configuration settings

--- a/services/server/config/config.go
+++ b/services/server/config/config.go
@@ -41,8 +41,6 @@ type Config struct {
 	State string `toml:"state"`
 	// PluginDir is the directory for dynamic plugins to be stored
 	PluginDir string `toml:"plugin_dir"`
-	// WindowsPriorityClass is the priority class used to run containerd and child processes at on Windows machines
-	WindowsPriorityClass string `toml:"windows_priority_class"`
 	// GRPC configuration settings
 	GRPC GRPCConfig `toml:"grpc"`
 	// TTRPC configuration settings
@@ -71,6 +69,8 @@ type Config struct {
 	Imports []string `toml:"imports"`
 	// StreamProcessors configuration
 	StreamProcessors map[string]StreamProcessor `toml:"stream_processors"`
+
+	OS OSConfig `toml:"os"`
 }
 
 // StreamProcessor provides configuration for diff content processors
@@ -85,6 +85,18 @@ type StreamProcessor struct {
 	Args []string `toml:"args"`
 	// Environment variables for the binary
 	Env []string `toml:"env"`
+}
+
+// OSConfig provides OS specific configuration options
+type OSConfig struct {
+	Windows WindowsConfig `toml:"windows"`
+}
+
+// WindowsConfig provides Windows specific OS configuration options
+type WindowsConfig struct {
+	// PriorityClass is the priority class used to run containerd and child processes at on Windows machines
+	// Valid values and more information can be found at https://docs.microsoft.com/en-us/windows/win32/procthread/scheduling-priorities
+	PriorityClass string `toml:"priority_class"`
 }
 
 // GetVersion returns the config file's version

--- a/services/server/server_windows.go
+++ b/services/server/server_windows.go
@@ -18,12 +18,71 @@ package server
 
 import (
 	"context"
+	"unsafe"
 
+	"github.com/containerd/containerd/log"
 	srvconfig "github.com/containerd/containerd/services/server/config"
 	"github.com/containerd/ttrpc"
+	"github.com/pkg/errors"
+	"golang.org/x/sys/windows"
 )
 
-func apply(_ context.Context, _ *srvconfig.Config) error {
+func getPriorityClass(priorityClassName string) uint32 {
+	var priorityClassMap = map[string]uint32{
+		"IDLE_PRIORITY_CLASS":         uint32(windows.IDLE_PRIORITY_CLASS),
+		"BELOW_NORMAL_PRIORITY_CLASS": uint32(windows.BELOW_NORMAL_PRIORITY_CLASS),
+		"NORMAL_PRIORITY_CLASS":       uint32(windows.NORMAL_PRIORITY_CLASS),
+		"ABOVE_NORMAL_PRIORITY_CLASS": uint32(windows.ABOVE_NORMAL_PRIORITY_CLASS),
+		"HIGH_PRIORITY_CLASS":         uint32(windows.HIGH_PRIORITY_CLASS),
+		"REALTIME_PRIORITY_CLASS":     uint32(windows.REALTIME_PRIORITY_CLASS),
+	}
+	return priorityClassMap[priorityClassName]
+}
+
+// addCurrentProcessToJobObjectAndSetPriorityClass creates a new Job Object
+// (https://docs.microsoft.com/en-us/windows/win32/procthread/job-objects),
+// adds the current process to the job object, and specifies the priority
+// class for the job object to the specified value.
+// A job object is used here so that any spawned processes such as CNI or
+// shim binaries are created at the specified thread priority class.
+// Running containerd and shim binaries with above normal / high priority
+// can help improve responsiveness on machines with high CPU utilization.
+func addCurrentProcessToJobObjectAndSetPriorityClass(pc uint32) error {
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return err
+	}
+	limitInfo := windows.JOBOBJECT_BASIC_LIMIT_INFORMATION{
+		LimitFlags:    windows.JOB_OBJECT_LIMIT_PRIORITY_CLASS,
+		PriorityClass: pc}
+	if _, err := windows.SetInformationJobObject(
+		job,
+		windows.JobObjectBasicLimitInformation,
+		uintptr(unsafe.Pointer(&limitInfo)),
+		uint32(unsafe.Sizeof(limitInfo))); err != nil {
+		return err
+	}
+	if err := windows.AssignProcessToJobObject(job, windows.CurrentProcess()); err != nil {
+		return err
+	}
+	return nil
+}
+
+func apply(ctx context.Context, config *srvconfig.Config) error {
+	if config.WindowsPriorityClass != "" {
+		log.G(ctx).Infof("Setting process priority class to %s", config.WindowsPriorityClass)
+
+		pc := getPriorityClass(config.WindowsPriorityClass)
+		if pc == 0 {
+			return errors.Errorf("Invalid priority class %s, valid priority classes are defined at "+
+				"https://docs.microsoft.com/en-us/windows/win32/procthread/scheduling-priorities", config.WindowsPriorityClass)
+		}
+		if err := addCurrentProcessToJobObjectAndSetPriorityClass(pc); err != nil {
+			log.G(ctx).Error(err)
+			return err
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Alternative approach to https://github.com/containerd/containerd/pull/4789 and related to https://github.com/containerd/containerd/issues/4773

This PR uses a job object and sets the priority class on the job object so that spawned processes like the shim/cni binaries will also run with the specified process priority based on feedback from @kevpar 

cc @ravisantoshgudimetla  @jsturtevant @dcantah

Signed-off-by: Mark Rossetti <marosset@microsoft.com>