### PR TITLE
Use GitHub Packages to workaround the throttling issue.

### DIFF
--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -12,7 +12,7 @@
 
 ARG GOLANG_VERSION=1.16.6
 
-FROM golang:${GOLANG_VERSION} AS golang-base
+FROM ghcr.io/containerd/golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd
 WORKDIR /go/src/github.com/containerd/containerd
 

--- a/integration/common.go
+++ b/integration/common.go
@@ -47,8 +47,8 @@ var (
 
 func initImages(imageListFile string) {
 	imageList = ImageList{
-		Alpine:           "docker.io/library/alpine:latest",
-		BusyBox:          "docker.io/library/busybox:latest",
+		Alpine:           "ghcr.io/containerd/alpine:3.14.0",
+		BusyBox:          "ghcr.io/containerd/busybox:1.32",
 		Pause:            "k8s.gcr.io/pause:3.5",
 		ResourceConsumer: "k8s.gcr.io/e2e-test-images/resource-consumer:1.9",
 		VolumeCopyUp:     "gcr.io/k8s-cri-containerd/volume-copy-up:2.0",

--- a/integration/images/volume-copy-up/Dockerfile
+++ b/integration/images/volume-copy-up/Dockerfile
@@ -12,6 +12,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM busybox
+FROM ghcr.io/containerd/busybox:1.32
 RUN sh -c "mkdir /test_dir; echo test_content > /test_dir/test_file"
 VOLUME "/test_dir"

--- a/integration/images/volume-ownership/Dockerfile
+++ b/integration/images/volume-ownership/Dockerfile
@@ -12,7 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM ubuntu
+# Use alpine since busybox doesn't have "nogroup" group.
+FROM ghcr.io/containerd/alpine:3.14.0
 RUN mkdir -p /test_dir && \
     chown -R nobody:nogroup /test_dir
 VOLUME /test_dir


### PR DESCRIPTION
Docker Hub is intermittently throttling image pull requests from
GitHub Actions. See #5748 for the detail.