### PR TITLE
update gotestsum to current master

### DIFF
--- a/script/setup/install-gotestsum
+++ b/script/setup/install-gotestsum
@@ -14,4 +14,4 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-GO111MODULE=on go install gotest.tools/gotestsum@012a85e34a7ce5554057d512e55dcb54b6f2505e
+GO111MODULE=on go install gotest.tools/gotestsum@1a9438079330f60c1301fdfacafbfac8763214a5


### PR DESCRIPTION
removes golang.org/x/cryto dependency:
full diff: https://github.com/gotestyourself/gotestsum/compare/012a85e34a7ce5554057d512e55dcb54b6f2505e...1a9438079330f60c1301fdfacafbfac8763214a5
