### PR TITLE
Discard blocks when removing a thin device

### DIFF
--- a/snapshots/devmapper/README.md
+++ b/snapshots/devmapper/README.md
@@ -26,6 +26,7 @@ The following configuration flags are supported:
   should be the same as in `/dev/mapper/` directory
 * `base_image_size` - defines how much space to allocate when creating the base device
 * `async_remove` - flag to async remove device using snapshot GC's cleanup callback
+* `discard_blocks` - whether to discard blocks when removing a device. This is especially useful for returning disk space to the filesystem when using loopback devices.
 
 Pool name and base image size are required snapshotter parameters.
 
@@ -93,6 +94,7 @@ cat << EOF
     pool_name = "${POOL_NAME}"
     root_path = "${DATA_DIR}"
     base_image_size = "10GB"
+    discard_blocks = true
 EOF
 ```
 

--- a/snapshots/devmapper/blkdiscard/blkdiscard.go
+++ b/snapshots/devmapper/blkdiscard/blkdiscard.go
@@ -1,0 +1,41 @@
+// +build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package blkdiscard
+
+import "os/exec"
+
+// Version returns the output of "blkdiscard --version"
+func Version() (string, error) {
+	return blkdiscard("--version")
+}
+
+// BlkDiscard discards all blocks of a device.
+// devicePath is expected to be a fully qualified path.
+// BlkDiscard expects the caller to verify that the device is not in use.
+func BlkDiscard(devicePath string) (string, error) {
+	return blkdiscard(devicePath)
+}
+
+func blkdiscard(args ...string) (string, error) {
+	output, err := exec.Command("blkdiscard", args...).CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	return string(output), nil
+}

--- a/snapshots/devmapper/config.go
+++ b/snapshots/devmapper/config.go
@@ -43,6 +43,9 @@ type Config struct {
 
 	// Flag to async remove device using Cleanup() callback in snapshots GC
 	AsyncRemove bool `toml:"async_remove"`
+
+	// Whether to discard blocks when removing a thin device.
+	DiscardBlocks bool `toml:"discard_blocks"`
 }
 
 // LoadConfig reads devmapper configuration file from disk in TOML format

--- a/snapshots/devmapper/dmsetup/dmsetup_test.go
+++ b/snapshots/devmapper/dmsetup/dmsetup_test.go
@@ -83,6 +83,7 @@ func TestDMSetup(t *testing.T) {
 	t.Run("ActivateDevice", testActivateDevice)
 	t.Run("DeviceStatus", testDeviceStatus)
 	t.Run("SuspendResumeDevice", testSuspendResumeDevice)
+	t.Run("DiscardBlocks", testDiscardBlocks)
 	t.Run("RemoveDevice", testRemoveDevice)
 
 	t.Run("RemovePool", func(t *testing.T) {
@@ -167,6 +168,11 @@ func testSuspendResumeDevice(t *testing.T) {
 
 	err = ResumeDevice(testDeviceName)
 	assert.NilError(t, err)
+}
+
+func testDiscardBlocks(t *testing.T) {
+	err := DiscardBlocks(testDeviceName)
+	assert.NilError(t, err, "failed to discard blocks")
 }
 
 func testRemoveDevice(t *testing.T) {

--- a/snapshots/devmapper/pool_device_test.go
+++ b/snapshots/devmapper/pool_device_test.go
@@ -85,6 +85,7 @@ func TestPoolDevice(t *testing.T) {
 		RootPath:           tempDir,
 		BaseImageSize:      "16mb",
 		BaseImageSizeBytes: 16 * 1024 * 1024,
+		DiscardBlocks:      true,
 	}
 
 	pool, err := NewPoolDevice(ctx, config)


### PR DESCRIPTION
dmsetup does not discard blocks when removing a thin device. The unused blocks
are reused by the thin-pool, but will remain allocated in the underlying
device indefinitely. For loop device backed thin-pools, this results in
"lost" disk space in the underlying file system as the blocks remain allocated
in the loop device's backing file.

This change adds an option, discard_blocks, to the devmapper snapshotter which
causes the snapshotter to issue blkdiscard ioctls on the thin device before
removal. With this option enabled, loop device setups will see disk space
return to the underlying filesystem immediately on exiting a container.

Fixes #5691

Signed-off-by: Kern Walster <walster@amazon.com>