### PR TITLE
[release/1.4] Fix incorrect UA used for registry authentication

### DIFF
--- a/remotes/docker/authorizer.go
+++ b/remotes/docker/authorizer.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/version"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context/ctxhttp"
@@ -356,6 +357,9 @@ func (ah *authHandler) fetchTokenWithOAuth(ctx context.Context, to tokenOptions)
 			req.Header[k] = append(req.Header[k], v...)
 		}
 	}
+	if len(req.Header.Get("User-Agent")) == 0 {
+		req.Header.Set("User-Agent", "containerd/"+version.Version)
+	}
 
 	resp, err := ctxhttp.Do(ctx, ah.client, req)
 	if err != nil {
@@ -407,6 +411,9 @@ func (ah *authHandler) fetchToken(ctx context.Context, to tokenOptions) (string,
 		for k, v := range ah.header {
 			req.Header[k] = append(req.Header[k], v...)
 		}
+	}
+	if len(req.Header.Get("User-Agent")) == 0 {
+		req.Header.Set("User-Agent", "containerd/"+version.Version)
 	}
 
 	reqParams := req.URL.Query()


### PR DESCRIPTION
This is the equivalent of 50ad4b96c4acfde425e1fc6e7411b52658d7af92 (https://github.com/containerd/containerd/pull/5533), but modified for the release/1.4 branch. From the original commit:

> Previously, containerd uses Go's default UA "Go-http-client/1.1" while authenticating with registry.
> This commit changes it to the pattern like "containerd/v1.5.2" which is used for all other requests.

Fixes https://github.com/containerd/containerd/issues/5532 for 1.4.x