### PR TITLE
[release/1.5 backport] install apparmor parser for arm64, and update seccomp to 2.5.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,6 +368,7 @@ jobs:
         env:
           RUNC_FLAVOR: ${{ matrix.runc }}
         run: |
+          sudo apt-get install -y gperf
           sudo -E PATH=$PATH script/setup/install-seccomp
           sudo -E PATH=$PATH script/setup/install-runc
           sudo -E PATH=$PATH script/setup/install-cni

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,8 @@ jobs:
           RUNC_FLAVOR: runc
         run: |
           if [[ "${OS}" == "linux" ]]; then
+            sudo apt-get update
+            sudo apt-get install -y gperf
             sudo -E PATH=$PATH script/setup/install-seccomp
           fi
           make cri-cni-release

--- a/.zuul/playbooks/containerd-build/integration-test.yaml
+++ b/.zuul/playbooks/containerd-build/integration-test.yaml
@@ -11,7 +11,7 @@
         set -xe
         set -o pipefail
         apt-get update
-        apt-get install -y btrfs-tools libseccomp-dev git pkg-config lsof
+        apt-get install -y btrfs-tools libseccomp-dev git pkg-config lsof gperf
 
         go version
       chdir: '{{ zuul.project.src_dir }}'

--- a/.zuul/playbooks/containerd-build/integration-test.yaml
+++ b/.zuul/playbooks/containerd-build/integration-test.yaml
@@ -11,7 +11,7 @@
         set -xe
         set -o pipefail
         apt-get update
-        apt-get install -y btrfs-tools libseccomp-dev git pkg-config lsof gperf
+        apt-get install -y btrfs-tools libseccomp-dev git pkg-config lsof gperf apparmor
 
         go version
       chdir: '{{ zuul.project.src_dir }}'

--- a/script/setup/install-seccomp
+++ b/script/setup/install-seccomp
@@ -22,7 +22,7 @@ set -eu -o pipefail
 
 set -x
 
-export SECCOMP_VERSION=2.3.3
+export SECCOMP_VERSION=2.5.1
 export SECCOMP_PATH=$(mktemp -d)
 curl -fsSL "https://github.com/seccomp/libseccomp/releases/download/v${SECCOMP_VERSION}/libseccomp-${SECCOMP_VERSION}.tar.gz" | tar -xzC "$SECCOMP_PATH" --strip-components=1
 (


### PR DESCRIPTION
backport of:

- https://github.com/containerd/containerd/pull/5445 (to get a conflict-free cherry-pick) update seccomp version
- https://github.com/containerd/containerd/pull/5558 Install apparmor parser for arm64 environment

resolves https://github.com/containerd/containerd/issues/5444 for the 1.5 branch
