### PR TITLE
[release/1.5 backport] Update docker resolver to authorize redirects

### DIFF
--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -539,7 +539,21 @@ func (r *request) do(ctx context.Context) (*http.Response, error) {
 	if err := r.authorize(ctx, req); err != nil {
 		return nil, errors.Wrap(err, "failed to authorize")
 	}
-	resp, err := ctxhttp.Do(ctx, r.host.Client, req)
+
+	var client = &http.Client{}
+	if r.host.Client != nil {
+		*client = *r.host.Client
+	}
+	if client.CheckRedirect == nil {
+		client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return errors.New("stopped after 10 redirects")
+			}
+			return errors.Wrap(r.authorize(ctx, req), "failed to authorize redirect")
+		}
+	}
+
+	resp, err := ctxhttp.Do(ctx, client, req)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to do request")
 	}


### PR DESCRIPTION
backport of https://github.com/containerd/containerd/pull/5504
fixes https://github.com/containerd/containerd/issues/5503

Allows redirects to be authorized if authorization is provided
for the redirected to host. The authorization will always go
to the redirect and never to the referrer.
