### PR TITLE
remotes/docker/fetcher.go: Fix missing Close() on fetch from docker remote

### DIFF
--- a/remotes/docker/fetcher.go
+++ b/remotes/docker/fetcher.go
@@ -148,7 +148,7 @@ func (r dockerFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.R
 	})
 }
 
-func (r dockerFetcher) open(ctx context.Context, req *request, mediatype string, offset int64) (io.ReadCloser, error) {
+func (r dockerFetcher) open(ctx context.Context, req *request, mediatype string, offset int64) (_ io.ReadCloser, retErr error) {
 	req.header.Set("Accept", strings.Join([]string{mediatype, `*/*`}, ", "))
 
 	if offset > 0 {
@@ -162,13 +162,17 @@ func (r dockerFetcher) open(ctx context.Context, req *request, mediatype string,
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if retErr != nil {
+			resp.Body.Close()
+		}
+	}()
 
 	if resp.StatusCode > 299 {
 		// TODO(stevvooe): When doing a offset specific request, we should
 		// really distinguish between a 206 and a 200. In the case of 200, we
 		// can discard the bytes, hiding the seek behavior from the
 		// implementation.
-		defer resp.Body.Close()
 
 		if resp.StatusCode == http.StatusNotFound {
 			return nil, errors.Wrapf(errdefs.ErrNotFound, "content at %v not found", req.String())


### PR DESCRIPTION
missing Close() call on fetch from docker remote under certain failed condition

Signed-off-by: Shiming Zhang <wzshiming@foxmail.com>