### PR TITLE
Update cpuguy83/go-md2man binary to v2.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
         with:
           path: src/github.com/containerd/containerd
 
-      - run: GO111MODULE=on go get github.com/cpuguy83/go-md2man/v2@v2.0.0
+      - run: GO111MODULE=on go get github.com/cpuguy83/go-md2man/v2@v2.0.1
 
       - run: make man
         working-directory: src/github.com/containerd/containerd

--- a/script/setup/install-dev-tools
+++ b/script/setup/install-dev-tools
@@ -33,5 +33,5 @@ GO111MODULE=on go get github.com/stevvooe/protobuild
 GO111MODULE=off go get -d github.com/gogo/googleapis || true
 GO111MODULE=off go get -d github.com/gogo/protobuf || true
 
-GO111MODULE=on go get github.com/cpuguy83/go-md2man/v2@v2.0.0
+GO111MODULE=on go get github.com/cpuguy83/go-md2man/v2@v2.0.1
 GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.38.0


### PR DESCRIPTION
full diff: https://github.com/cpuguy83/go-md2man/compare/v2.0.0...v2.0.1

- Fix handling multiple definition descriptions
- Fix inline markup causing table cells to split
- Remove escaping tilde character (prevents tildes (`~`) from disappearing).
- Do not escape dash, underscore, and ampersand (prevents ampersands (`&`) from disappearing).
- Ignore unknown HTML tags to prevent noisy warnings

Note that this only updates the binaries we install. The vendor code also
includes go-md2man (as indirect dependency of urfave/cli). I don't think we use that
feature, so I did not add it to our go.mod
