### PR TITLE
integration: log all processes to investigate the test failure

### DIFF
--- a/integration/client/container_test.go
+++ b/integration/client/container_test.go
@@ -462,7 +462,7 @@ func TestContainerPids(t *testing.T) {
 		if len(processes) > 0 {
 			actual := processes[0].Pid
 			if pid != actual {
-				t.Errorf("expected pid %d but received %d", pid, actual)
+				t.Errorf("expected pid %d but received %d. processes = %+v", pid, actual, processes)
 			}
 		}
 	}


### PR DESCRIPTION
The test is failing on
https://github.com/containerd/containerd/runs/3129202049#step:10:43.

I'd like to know whether the order of the array is the cause, or
the result is completely off.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>