### PR TITLE
platforms: add "ios" as known OS, "loong64" as known ARCH

### DIFF
--- a/platforms/database.go
+++ b/platforms/database.go
@@ -38,7 +38,7 @@ func isLinuxOS(os string) bool {
 // The OS value should be normalized before calling this function.
 func isKnownOS(os string) bool {
 	switch os {
-	case "aix", "android", "darwin", "dragonfly", "freebsd", "hurd", "illumos", "js", "linux", "nacl", "netbsd", "openbsd", "plan9", "solaris", "windows", "zos":
+	case "aix", "android", "darwin", "dragonfly", "freebsd", "hurd", "illumos", "ios", "js", "linux", "nacl", "netbsd", "openbsd", "plan9", "solaris", "windows", "zos":
 		return true
 	}
 	return false
@@ -60,7 +60,7 @@ func isArmArch(arch string) bool {
 // The arch value should be normalized before being passed to this function.
 func isKnownArch(arch string) bool {
 	switch arch {
-	case "386", "amd64", "amd64p32", "arm", "armbe", "arm64", "arm64be", "ppc64", "ppc64le", "mips", "mipsle", "mips64", "mips64le", "mips64p32", "mips64p32le", "ppc", "riscv", "riscv64", "s390", "s390x", "sparc", "sparc64", "wasm":
+	case "386", "amd64", "amd64p32", "arm", "armbe", "arm64", "arm64be", "ppc64", "ppc64le", "loong64", "mips", "mipsle", "mips64", "mips64le", "mips64p32", "mips64p32le", "ppc", "riscv", "riscv64", "s390", "s390x", "sparc", "sparc64", "wasm":
 		return true
 	}
 	return false


### PR DESCRIPTION
I noticed these were added in golang;

- GOOS iOS was added in https://go-review.googlesource.com/c/go/+/254740, and part of go1.16beta1
- GOARCH loong64 was added in https://go-review.googlesource.com/c/go/+/333909, and currently only in master
