### PR TITLE
update gotestsum to v1.7.0

### DIFF
--- a/script/setup/install-gotestsum
+++ b/script/setup/install-gotestsum
@@ -14,4 +14,4 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-GO111MODULE=on go install gotest.tools/gotestsum@1a9438079330f60c1301fdfacafbfac8763214a5
+GO111MODULE=on go install gotest.tools/gotestsum@v1.7.0


### PR DESCRIPTION
Same as previous commit, but a release was tagged (https://github.com/gotestyourself/gotestsum/issues/206);

https://github.com/gotestyourself/gotestsum/compare/1a9438079330f60c1301fdfacafbfac8763214a5...v1.7.0
