### PR TITLE
log containerd's panic.log if one is present during startup

### DIFF
--- a/cmd/containerd/command/service_windows.go
+++ b/cmd/containerd/command/service_windows.go
@@ -337,6 +337,13 @@ func initPanicFile(path string) error {
 	// and replace it.
 	if st.Size() > 0 {
 		panicFile.Close()
+
+		if content, err := ioutil.ReadFile(path); err != nil {
+			logrus.WithError(err).Debug("failed to read containerd panic.log")
+		} else {
+			logrus.WithField("panic.log", string(content)).Debug("containerd panic.log content")
+		}
+
 		os.Rename(path, path+".old")
 		panicFile, err = os.Create(path)
 		if err != nil {


### PR DESCRIPTION
Currenetly (on windows) when there's an existing panic.log file
during containerd startup, it is renamed to panic.log.old and a
new panic.log file is created instead. This means, that in the
rare case of multiple containerd restarts, we can lose old panic
logs. To remedy that, log the contents of panic.log file before
renaming it.

Signed-off-by: Maksim An <maksiman@microsoft.com>