### PR TITLE
Update protobuf install to use correct repository

### DIFF
--- a/script/setup/install-protobuf
+++ b/script/setup/install-protobuf
@@ -28,25 +28,25 @@ PROTOBUF_DIR=$(mktemp -d)
 case $GOARCH in
 
 arm64)
-	wget -O $PROTOBUF_DIR/protobuf "https://github.com/google/protobuf/releases/download/v$PROTOBUF_VERSION/protoc-$PROTOBUF_VERSION-linux-aarch64.zip"
+	wget -O $PROTOBUF_DIR/protobuf "https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VERSION/protoc-$PROTOBUF_VERSION-linux-aarch64.zip"
 	unzip $PROTOBUF_DIR/protobuf -d /usr/local
 	;;
 
 amd64|386)
 	if [ "$GOOS" = windows ]; then
-		wget -O $PROTOBUF_DIR/protobuf "https://github.com/google/protobuf/releases/download/v$PROTOBUF_VERSION/protoc-$PROTOBUF_VERSION-win32.zip"
+		wget -O $PROTOBUF_DIR/protobuf "https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VERSION/protoc-$PROTOBUF_VERSION-win32.zip"
 	elif [ "$GOOS" = linux ]; then
-		wget -O $PROTOBUF_DIR/protobuf "https://github.com/google/protobuf/releases/download/v$PROTOBUF_VERSION/protoc-$PROTOBUF_VERSION-linux-x86_64.zip"
+		wget -O $PROTOBUF_DIR/protobuf "https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VERSION/protoc-$PROTOBUF_VERSION-linux-x86_64.zip"
 	fi
 	unzip $PROTOBUF_DIR/protobuf -d /usr/local
 	;;
 
 ppc64le)
-	wget -O $PROTOBUF_DIR/protobuf "https://github.com/google/protobuf/releases/download/v$PROTOBUF_VERSION/protoc-$PROTOBUF_VERSION-linux-ppcle_64.zip"
+	wget -O $PROTOBUF_DIR/protobuf "https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VERSION/protoc-$PROTOBUF_VERSION-linux-ppcle_64.zip"
 	unzip $PROTOBUF_DIR/protobuf -d /usr/local
 	;;
 *)
-	wget -O $PROTOBUF_DIR/protobuf "https://github.com/google/protobuf/releases/download/v$PROTOBUF_VERSION/protobuf-cpp-$PROTOBUF_VERSION.zip"
+	wget -O $PROTOBUF_DIR/protobuf "https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VERSION/protobuf-cpp-$PROTOBUF_VERSION.zip"
 	unzip $PROTOBUF_DIR/protobuf -d /usr/src/protobuf
 	cd /usr/src/protobuf/protobuf-$PROTOBUF_VERSION
 	./autogen.sh


### PR DESCRIPTION
The protobuf repository is under the protocolbuffers org

NOTE: The Github redirect which was being used before seems to have broke