### PR TITLE
Cleanup v2 shim

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -72,5 +72,5 @@ type PlatformRuntime interface {
 	// Add adds a task into runtime.
 	Add(ctx context.Context, task Task) error
 	// Delete remove a task.
-	Delete(ctx context.Context, taskID string)
+	Delete(ctx context.Context, taskID string) (*Exit, error)
 }

--- a/runtime/task.go
+++ b/runtime/task.go
@@ -47,6 +47,14 @@ type Process interface {
 	Start(ctx context.Context) error
 	// Wait for the process to exit
 	Wait(ctx context.Context) (*Exit, error)
+}
+
+// ExecProcess is a process spawned in container via Task.Exec call.
+// The only difference from a regular `Process` is that exec process can delete self,
+// while task process requires slightly more complex logic and needs to be deleted through the task manager.
+type ExecProcess interface {
+	Process
+
 	// Delete deletes the process
 	Delete(ctx context.Context) (*Exit, error)
 }
@@ -56,7 +64,7 @@ type Task interface {
 	Process
 
 	// PID of the process
-	PID() uint32
+	PID(ctx context.Context) (uint32, error)
 	// Namespace that the task exists in
 	Namespace() string
 	// Pause pauses the container process
@@ -64,7 +72,7 @@ type Task interface {
 	// Resume unpauses the container process
 	Resume(ctx context.Context) error
 	// Exec adds a process into the container
-	Exec(ctx context.Context, id string, opts ExecOpts) (Process, error)
+	Exec(ctx context.Context, id string, opts ExecOpts) (ExecProcess, error)
 	// Pids returns all pids
 	Pids(ctx context.Context) ([]ProcessInfo, error)
 	// Checkpoint checkpoints a container to an image with live system data
@@ -72,7 +80,7 @@ type Task interface {
 	// Update sets the provided resources to a running task
 	Update(ctx context.Context, resources *types.Any, annotations map[string]string) error
 	// Process returns a process within the task for the provided id
-	Process(ctx context.Context, id string) (Process, error)
+	Process(ctx context.Context, id string) (ExecProcess, error)
 	// Stats returns runtime specific metrics for a task
 	Stats(ctx context.Context) (*types.Any, error)
 }

--- a/runtime/v1/linux/runtime.go
+++ b/runtime/v1/linux/runtime.go
@@ -43,8 +43,8 @@ import (
 	"github.com/containerd/containerd/runtime"
 	"github.com/containerd/containerd/runtime/linux/runctypes"
 	v1 "github.com/containerd/containerd/runtime/v1"
-	shim "github.com/containerd/containerd/runtime/v1/shim/v1"
-	runc "github.com/containerd/go-runc"
+	"github.com/containerd/containerd/runtime/v1/shim/v1"
+	"github.com/containerd/go-runc"
 	"github.com/containerd/typeurl"
 	ptypes "github.com/gogo/protobuf/types"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -315,8 +315,20 @@ func (r *Runtime) Add(ctx context.Context, task runtime.Task) error {
 }
 
 // Delete a runtime task
-func (r *Runtime) Delete(ctx context.Context, id string) {
+func (r *Runtime) Delete(ctx context.Context, id string) (*runtime.Exit, error) {
+	task, err := r.tasks.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	s := task.(*Task)
+	exit, err := s.Delete(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	r.tasks.Delete(ctx, id)
+	return exit, nil
 }
 
 func (r *Runtime) loadTasks(ctx context.Context, ns string) ([]*Task, error) {

--- a/runtime/v1/linux/task.go
+++ b/runtime/v1/linux/task.go
@@ -85,8 +85,8 @@ func (t *Task) Namespace() string {
 }
 
 // PID of the task
-func (t *Task) PID() uint32 {
-	return uint32(t.pid)
+func (t *Task) PID(_ctx context.Context) (uint32, error) {
+	return uint32(t.pid), nil
 }
 
 // Delete the task and return the exit status
@@ -226,7 +226,7 @@ func (t *Task) Kill(ctx context.Context, signal uint32, all bool) error {
 }
 
 // Exec creates a new process inside the task
-func (t *Task) Exec(ctx context.Context, id string, opts runtime.ExecOpts) (runtime.Process, error) {
+func (t *Task) Exec(ctx context.Context, id string, opts runtime.ExecOpts) (runtime.ExecProcess, error) {
 	if err := identifiers.Validate(id); err != nil {
 		return nil, errors.Wrapf(err, "invalid exec id")
 	}
@@ -316,7 +316,7 @@ func (t *Task) Update(ctx context.Context, resources *types.Any, _ map[string]st
 }
 
 // Process returns a specific process inside the task by the process id
-func (t *Task) Process(ctx context.Context, id string) (runtime.Process, error) {
+func (t *Task) Process(ctx context.Context, id string) (runtime.ExecProcess, error) {
 	p := &Process{
 		id: id,
 		t:  t,

--- a/runtime/v2/binary.go
+++ b/runtime/v2/binary.go
@@ -24,7 +24,6 @@ import (
 	gruntime "runtime"
 	"strings"
 
-	"github.com/containerd/containerd/events/exchange"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/runtime"
@@ -36,14 +35,12 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func shimBinary(ctx context.Context, bundle *Bundle, runtime, containerdAddress string, containerdTTRPCAddress string, events *exchange.Exchange, rt *runtime.TaskList) *binary {
+func shimBinary(bundle *Bundle, runtime, containerdAddress string, containerdTTRPCAddress string) *binary {
 	return &binary{
 		bundle:                 bundle,
 		runtime:                runtime,
 		containerdAddress:      containerdAddress,
 		containerdTTRPCAddress: containerdTTRPCAddress,
-		events:                 events,
-		rtTasks:                rt,
 	}
 }
 
@@ -52,8 +49,6 @@ type binary struct {
 	containerdAddress      string
 	containerdTTRPCAddress string
 	bundle                 *Bundle
-	events                 *exchange.Exchange
-	rtTasks                *runtime.TaskList
 }
 
 func (b *binary) Start(ctx context.Context, opts *types.Any, onClose func()) (_ *shim, err error) {
@@ -123,11 +118,9 @@ func (b *binary) Start(ctx context.Context, opts *types.Any, onClose func()) (_ 
 	}
 	client := ttrpc.NewClient(conn, ttrpc.WithOnClose(onCloseWithShimLog))
 	return &shim{
-		bundle:  b.bundle,
-		client:  client,
-		task:    task.NewTaskClient(client),
-		events:  b.events,
-		rtTasks: b.rtTasks,
+		bundle: b.bundle,
+		client: client,
+		task:   task.NewTaskClient(client),
 	}, nil
 }
 

--- a/runtime/v2/manager.go
+++ b/runtime/v2/manager.go
@@ -162,7 +162,7 @@ func (m *TaskManager) startShim(ctx context.Context, bundle *Bundle, id string, 
 		topts = opts.RuntimeOptions
 	}
 
-	b := shimBinary(ctx, bundle, opts.Runtime, m.containerdAddress, m.containerdTTRPCAddress, m.events, m.tasks)
+	b := shimBinary(bundle, opts.Runtime, m.containerdAddress, m.containerdTTRPCAddress)
 	shim, err := b.Start(ctx, topts, func() {
 		log.G(ctx).WithField("id", id).Info("shim disconnected")
 
@@ -185,7 +185,7 @@ func (m *TaskManager) deleteShim(shim *shim) {
 	dctx, cancel := timeout.WithContext(context.Background(), cleanupTimeout)
 	defer cancel()
 
-	_, errShim := shim.Delete(dctx)
+	_, errShim := shim.delete(dctx, m.tasks.Delete)
 	if errShim != nil {
 		if errdefs.IsDeadlineExceeded(errShim) {
 			dctx, cancel = timeout.WithContext(context.Background(), cleanupTimeout)
@@ -207,8 +207,19 @@ func (m *TaskManager) Add(ctx context.Context, task runtime.Task) error {
 }
 
 // Delete a runtime task
-func (m *TaskManager) Delete(ctx context.Context, id string) {
-	m.tasks.Delete(ctx, id)
+func (m *TaskManager) Delete(ctx context.Context, id string) (*runtime.Exit, error) {
+	task, err := m.tasks.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	shim := task.(*shim)
+	exit, err := shim.delete(ctx, m.tasks.Delete)
+	if err != nil {
+		return nil, err
+	}
+
+	return exit, err
 }
 
 // Tasks lists all tasks
@@ -287,8 +298,8 @@ func (m *TaskManager) loadTasks(ctx context.Context) error {
 			bundle.Delete()
 			continue
 		}
-		binaryCall := shimBinary(ctx, bundle, container.Runtime.Name, m.containerdAddress, m.containerdTTRPCAddress, m.events, m.tasks)
-		shim, err := loadShim(ctx, bundle, m.events, m.tasks, func() {
+		binaryCall := shimBinary(bundle, container.Runtime.Name, m.containerdAddress, m.containerdTTRPCAddress)
+		shim, err := loadShim(ctx, bundle, func() {
 			log.G(ctx).WithField("id", id).Info("shim disconnected")
 
 			cleanupAfterDeadShim(context.Background(), id, ns, m.tasks, m.events, binaryCall)

--- a/services/tasks/local.go
+++ b/services/tasks/local.go
@@ -215,9 +215,13 @@ func (l *local) Create(ctx context.Context, r *api.CreateTaskRequest, _ ...grpc.
 	if err := l.monitor.Monitor(c, labels); err != nil {
 		return nil, errors.Wrap(err, "monitor task")
 	}
+	pid, err := c.PID(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get task pid")
+	}
 	return &api.CreateTaskResponse{
 		ContainerID: r.ContainerID,
-		Pid:         c.PID(),
+		Pid:         pid,
 	}, nil
 }
 
@@ -245,17 +249,32 @@ func (l *local) Start(ctx context.Context, r *api.StartRequest, _ ...grpc.CallOp
 }
 
 func (l *local) Delete(ctx context.Context, r *api.DeleteTaskRequest, _ ...grpc.CallOption) (*api.DeleteResponse, error) {
-	t, err := l.getTask(ctx, r.ContainerID)
+	container, err := l.getContainer(ctx, r.ContainerID)
 	if err != nil {
 		return nil, err
 	}
+
+	// Find runtime manager
+	rtime, err := l.getRuntime(container.Runtime.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get task object
+	t, err := rtime.Get(ctx, container.ID)
+	if err != nil {
+		return nil, status.Errorf(codes.NotFound, "task %v not found", container.ID)
+	}
+
 	if err := l.monitor.Stop(t); err != nil {
 		return nil, err
 	}
-	exit, err := t.Delete(ctx)
+
+	exit, err := rtime.Delete(ctx, r.ContainerID)
 	if err != nil {
 		return nil, errdefs.ToGRPC(err)
 	}
+
 	return &api.DeleteResponse{
 		ExitStatus: exit.Status,
 		ExitedAt:   exit.Timestamp,


### PR DESCRIPTION
In current shim v2 implementation there are 2 routines for shim deletion - `Task.Delete` and `TaskManager.Delete`.
Most of the cleanup logic is happening in `Task`, however there is also need to delete self from Manager’s task list and do proper cleanup after.
This requirements adds a lot of boilerplate logic and unnecessary relation between task, bundle, and manager.

This PR aims to simplify `shim` object and basically turns it into a stateless entity, that just translates API calls to the underlying shim. Instead of calling Task’s delete, we call TaskManager’s Delete (so it’s not useless anymore), which in turn calls Task’s delete. This makes cleanup logic more linear and with less dependencies between shim and the manager. All existing task cleanup logic preserved.

Shim before:
```golang
type shim struct {
	bundle  *Bundle
	client  *ttrpc.Client
	task    task.TaskService
	taskPid int
	events  *exchange.Exchange
	rtTasks *runtime.TaskList
}
```

After:
```golang
type shim struct {
	bundle  *Bundle
	client  *ttrpc.Client
	task    task.TaskService
}
```

Prerequisite for https://github.com/containerd/containerd/issues/5742
