### PR TITLE
Add support for shim plugins

### DIFF
--- a/pkg/cri/server/service.go
+++ b/pkg/cri/server/service.go
@@ -65,7 +65,7 @@ type CRIService interface {
 	Run() error
 	// io.Closer is used by containerd to gracefully stop cri service.
 	io.Closer
-	plugin.Service
+	Register(*grpc.Server) error
 	grpcServices
 }
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -20,9 +20,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/containerd/ttrpc"
 	"github.com/pkg/errors"
-	"google.golang.org/grpc"
 )
 
 var (
@@ -63,6 +61,8 @@ const (
 	ServicePlugin Type = "io.containerd.service.v1"
 	// GRPCPlugin implements a grpc service
 	GRPCPlugin Type = "io.containerd.grpc.v1"
+	// TTRPCPlugin implements a ttrpc shim service
+	TTRPCPlugin Type = "io.containerd.ttrpc.v1"
 	// SnapshotPlugin implements a snapshotter
 	SnapshotPlugin Type = "io.containerd.snapshotter.v1"
 	// TaskMonitorPlugin implements a task monitor
@@ -122,21 +122,6 @@ func (r *Registration) Init(ic *InitContext) *Plugin {
 // URI returns the full plugin URI
 func (r *Registration) URI() string {
 	return fmt.Sprintf("%s.%s", r.Type, r.ID)
-}
-
-// Service allows GRPC services to be registered with the underlying server
-type Service interface {
-	Register(*grpc.Server) error
-}
-
-// TTRPCService allows TTRPC services to be registered with the underlying server
-type TTRPCService interface {
-	RegisterTTRPC(*ttrpc.Server) error
-}
-
-// TCPService allows GRPC services to be registered with the underlying tcp server
-type TCPService interface {
-	RegisterTCP(*grpc.Server) error
 }
 
 var register = struct {


### PR DESCRIPTION
Refactor shim v2 to load and register plugins. Update init shim interface to not require task service implementation on returned service, but register as plugin if it is.