### PR TITLE
Fuzzing: Remove panics of container_fuzzer

### DIFF
--- a/contrib/fuzz/container_fuzzer.go
+++ b/contrib/fuzz/container_fuzzer.go
@@ -70,10 +70,7 @@ func tearDown() error {
 // working socket.
 func checkIfShouldRestart(err error) {
 	if strings.Contains(err.Error(), "daemon is not running") {
-		err2 := deleteSocket()
-		if err2 != nil {
-			panic(err2)
-		}
+		deleteSocket()
 	}
 }
 
@@ -104,7 +101,6 @@ func startDaemon(ctx context.Context, shouldTearDown bool) {
 		// so we panic
 		if !strings.Contains(err.Error(), "daemon is already running") {
 			fmt.Fprintf(os.Stderr, "%s: %s\n", err, buf.String())
-			panic(err)
 		}
 	}
 	if shouldTearDown {


### PR DESCRIPTION
The fuzzer runs fine, but OSS-fuzz's CI includes a test that uses a different `/out` which means that the binaries that are there will not be available and the panics will cause the CI to fail. This PR removes the panics so there will not be complications with the CI.

This PR will allow https://github.com/google/oss-fuzz/pull/6145 to become green.

Signed-off-by: AdamKorcz <adam@adalogics.com>