### PR TITLE
shimv2: handle sigint/sigterm

### DIFF
--- a/runtime/v2/shim/shim_unix.go
+++ b/runtime/v2/shim/shim_unix.go
@@ -71,7 +71,7 @@ func serveListener(path string) (net.Listener, error) {
 	return l, nil
 }
 
-func handleSignals(ctx context.Context, logger *logrus.Entry, signals chan os.Signal) error {
+func reap(ctx context.Context, logger *logrus.Entry, signals chan os.Signal) error {
 	logger.Info("starting signal loop")
 
 	for {
@@ -79,6 +79,8 @@ func handleSignals(ctx context.Context, logger *logrus.Entry, signals chan os.Si
 		case <-ctx.Done():
 			return ctx.Err()
 		case s := <-signals:
+			// Exit signals are handled separately from this loop
+			// They get registered with this channel so that we can ignore such signals for short-running actions (e.g. `delete`)
 			switch s {
 			case unix.SIGCHLD:
 				if err := reaper.Reap(); err != nil {
@@ -86,6 +88,22 @@ func handleSignals(ctx context.Context, logger *logrus.Entry, signals chan os.Si
 				}
 			case unix.SIGPIPE:
 			}
+		}
+	}
+}
+
+func handleExitSignals(ctx context.Context, logger *logrus.Entry, cancel context.CancelFunc) {
+	ch := make(chan os.Signal, 32)
+	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
+
+	for {
+		select {
+		case s := <-ch:
+			logger.WithField("signal", s).Debugf("Caught exit signal")
+			cancel()
+			return
+		case <-ctx.Done():
+			return
 		}
 	}
 }

--- a/runtime/v2/shim/shim_windows.go
+++ b/runtime/v2/shim/shim_windows.go
@@ -46,8 +46,11 @@ func serveListener(path string) (net.Listener, error) {
 	return nil, errors.New("not supported")
 }
 
-func handleSignals(ctx context.Context, logger *logrus.Entry, signals chan os.Signal) error {
+func reap(ctx context.Context, logger *logrus.Entry, signals chan os.Signal) error {
 	return errors.New("not supported")
+}
+
+func handleExitSignals(ctx context.Context, logger *logrus.Entry, cancel context.CancelFunc) {
 }
 
 func openLog(ctx context.Context, _ string) (io.Writer, error) {


### PR DESCRIPTION
This causes sigint/sigterm to trigger a shutdown of the shim.
It is needed because otherwise the v2 shim hangs system shutdown.

Fixes #5502