### PR TITLE
Fuzzing: Fix for OSS-fuzz issue 36825

### DIFF
--- a/contrib/fuzz/container_fuzzer.go
+++ b/contrib/fuzz/container_fuzzer.go
@@ -41,9 +41,8 @@ import (
 func init() {
 	err := updatePathEnv()
 	if err != nil {
-		panic(err)
+		fmt.Println(err)
 	}
-
 }
 
 func tearDown() error {
@@ -130,7 +129,7 @@ func startDaemon(ctx context.Context, shouldTearDown bool) {
 // refuse a connection to it, and deleting it allows us
 // to create a new socket when invoking containerd.New()
 func deleteSocket() error {
-	err := os.Remove("/run/containerd-test/containerd.sock")
+	err := os.Remove(defaultAddress)
 	if err != nil {
 		return err
 	}
@@ -143,7 +142,7 @@ func deleteSocket() error {
 // to $PATH, since the binaries are available there.
 func updatePathEnv() error {
 	// Create test dir for socket
-	err := os.MkdirAll("/run/containerd-test", 0777)
+	err := os.MkdirAll(defaultState, 0777)
 	if err != nil {
 		return err
 	}
@@ -273,7 +272,7 @@ func doFuzz(data []byte, shouldTearDown bool) int {
 	if ctrd.cmd == nil {
 		startDaemon(ctx, shouldTearDown)
 	}
-	client, err := containerd.New(address)
+	client, err := containerd.New(defaultAddress)
 	if err != nil {
 		// The error here is most likely with the socket.
 		// Deleting it will allow the creation of a new
@@ -282,6 +281,7 @@ func doFuzz(data []byte, shouldTearDown bool) int {
 		return -1
 	}
 	defer client.Close()
+
 	f := fuzz.NewConsumer(data)
 
 	// Begin import tars:

--- a/contrib/fuzz/oss_fuzz_build.sh
+++ b/contrib/fuzz/oss_fuzz_build.sh
@@ -59,10 +59,15 @@ make EXTRA_FLAGS="-buildmode pie" \
 mkdir $OUT/containerd-binaries || true
 cd $SRC/containerd/bin && cp * $OUT/containerd-binaries/ && cd -
 
+# Change defaultState and defaultAddress fron /run/containerd-test to /tmp/containerd-test:
+sed -i 's/\/run\/containerd-test/\/tmp\/containerd-test/g' $SRC/containerd/integration/client/client_unix_test.go
+
 cd integration/client
+
 # Rename all *_test.go to *_test_fuzz.go to use their declarations:
 for i in $( ls *_test.go ); do mv $i ./${i%.*}_fuzz.go; done
-# Remove windows test to avoid double declarations
+
+# Remove windows test to avoid double declarations:
 rm ./client_windows_test_fuzz.go
 compile_go_fuzzer . FuzzCreateContainerNoTearDown fuzz_create_container_no_teardown
 compile_go_fuzzer . FuzzCreateContainerWithTearDown fuzz_create_container_with_teardown


### PR DESCRIPTION
Currently the `container_fuzzer.go` breaks when creating `/run/containerd-test` in `init()`.
The error does not reproduce locally.

This PR adds two fixes for this:

1. Remove the `panic` to disable notifications about this breakage.
2. Use `/tmp/containerd-test` instead of `/run/containerd-test`. 


Signed-off-by: AdamKorcz <adam@adalogics.com>