### PR TITLE
Change default directories on Darwin

### DIFF
--- a/defaults/defaults_darwin.go
+++ b/defaults/defaults_darwin.go
@@ -1,4 +1,4 @@
-// +build !windows,!darwin
+// +build darwin
 
 /*
    Copyright The containerd Authors.
@@ -24,16 +24,17 @@ const (
 	DefaultRootDir = "/var/lib/containerd"
 	// DefaultStateDir is the default location used by containerd to store
 	// transient data
-	DefaultStateDir = "/run/containerd"
+	DefaultStateDir = "/var/run/containerd"
 	// DefaultAddress is the default unix socket address
-	DefaultAddress = "/run/containerd/containerd.sock"
+	DefaultAddress = "/var/run/containerd/containerd.sock"
 	// DefaultDebugAddress is the default unix socket address for pprof data
-	DefaultDebugAddress = "/run/containerd/debug.sock"
+	DefaultDebugAddress = "/var/run/containerd/debug.sock"
 	// DefaultFIFODir is the default location used by client-side cio library
 	// to store FIFOs.
-	DefaultFIFODir = "/run/containerd/fifo"
-	// DefaultRuntime is the default linux runtime
-	DefaultRuntime = "io.containerd.runc.v2"
+	DefaultFIFODir = "/var/run/containerd/fifo"
+	// DefaultRuntime is the default Darwin runtime.
+	// NOTE: there is no runtime on Darwin as of now.
+	DefaultRuntime = ""
 	// DefaultConfigDir is the default location for config files.
 	DefaultConfigDir = "/etc/containerd"
 )

--- a/mount/temp_unix.go
+++ b/mount/temp_unix.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows,!darwin
 
 /*
    Copyright The containerd Authors.

--- a/mount/temp_unsupported.go
+++ b/mount/temp_unsupported.go
@@ -1,4 +1,4 @@
-// +build windows
+// +build windows darwin
 
 /*
    Copyright The containerd Authors.


### PR DESCRIPTION
A couple of minor fixes that prevent containerd from launching on darwin:

```
containerd: mkdir /run: read-only file system
```

```
unmounting temp mounts  error="not implemented on darwin/amd64"
```

```
containerd: failed to get listener for debug endpoint: mkdir /run: read-only file system
```

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>