### PR TITLE
Remove redundant build tags

### DIFF
--- a/archive/tar_freebsd.go
+++ b/archive/tar_freebsd.go
@@ -1,5 +1,3 @@
-// +build freebsd
-
 /*
    Copyright The containerd Authors.
 

--- a/archive/tar_linux_test.go
+++ b/archive/tar_linux_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
    Copyright The containerd Authors.
 

--- a/archive/tar_opts_linux.go
+++ b/archive/tar_opts_linux.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
    Copyright The containerd Authors.
 

--- a/archive/tar_opts_windows.go
+++ b/archive/tar_opts_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/archive/tar_windows.go
+++ b/archive/tar_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/cio/io_windows_test.go
+++ b/cio/io_windows_test.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/cmd/containerd-shim/shim_darwin.go
+++ b/cmd/containerd-shim/shim_darwin.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 /*
    Copyright The containerd Authors.
 

--- a/cmd/containerd-shim/shim_freebsd.go
+++ b/cmd/containerd-shim/shim_freebsd.go
@@ -1,5 +1,3 @@
-// +build freebsd
-
 /*
    Copyright The containerd Authors.
 

--- a/cmd/containerd-stress/rlimit_freebsd.go
+++ b/cmd/containerd-stress/rlimit_freebsd.go
@@ -1,5 +1,3 @@
-// +build freebsd
-
 /*
    Copyright The containerd Authors.
 

--- a/cmd/containerd-stress/rlimit_windows.go
+++ b/cmd/containerd-stress/rlimit_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/cmd/containerd/builtins_windows.go
+++ b/cmd/containerd/builtins_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/cmd/containerd/command/notify_linux.go
+++ b/cmd/containerd/command/notify_linux.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
    Copyright The containerd Authors.
 

--- a/cmd/ctr/commands/commands_windows.go
+++ b/cmd/ctr/commands/commands_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/defaults/defaults_darwin.go
+++ b/defaults/defaults_darwin.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 /*
    Copyright The containerd Authors.
 

--- a/defaults/defaults_windows.go
+++ b/defaults/defaults_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/diff/apply/apply_linux.go
+++ b/diff/apply/apply_linux.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
    Copyright The containerd Authors.
 

--- a/diff/apply/apply_linux_test.go
+++ b/diff/apply/apply_linux_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
    Copyright The containerd Authors.
 

--- a/diff/stream_windows.go
+++ b/diff/stream_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
    Copyright The containerd Authors.
 

--- a/integration/client/helpers_windows_test.go
+++ b/integration/client/helpers_windows_test.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/integration/remote/util/util_windows.go
+++ b/integration/remote/util/util_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/integration/util/boottime_util_darwin.go
+++ b/integration/util/boottime_util_darwin.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 /*
    Copyright The containerd Authors.
 

--- a/integration/util/util_windows.go
+++ b/integration/util/util_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/mount/lookup_linux_test.go
+++ b/mount/lookup_linux_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
    Copyright The containerd Authors.
 

--- a/mount/losetup_linux_test.go
+++ b/mount/losetup_linux_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
    Copyright The containerd Authors.
 

--- a/mount/mount_freebsd.go
+++ b/mount/mount_freebsd.go
@@ -1,5 +1,3 @@
-// +build freebsd
-
 /*
    Copyright The containerd Authors.
 

--- a/mount/mount_linux_test.go
+++ b/mount/mount_linux_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
    Copyright The containerd Authors.
 

--- a/oci/spec_opts_linux.go
+++ b/oci/spec_opts_linux.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
    Copyright The containerd Authors.
 

--- a/oci/spec_opts_windows.go
+++ b/oci/spec_opts_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/oci/spec_opts_windows_test.go
+++ b/oci/spec_opts_windows_test.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/pkg/apparmor/apparmor_linux.go
+++ b/pkg/apparmor/apparmor_linux.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
    Copyright The containerd Authors.
 

--- a/pkg/cri/config/config_windows.go
+++ b/pkg/cri/config/config_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/pkg/cri/io/helpers_windows.go
+++ b/pkg/cri/io/helpers_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/pkg/cri/opts/spec_windows.go
+++ b/pkg/cri/opts/spec_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/pkg/cri/server/container_create_windows.go
+++ b/pkg/cri/server/container_create_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/pkg/cri/server/container_create_windows_test.go
+++ b/pkg/cri/server/container_create_windows_test.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/pkg/cri/server/container_stats_list_windows.go
+++ b/pkg/cri/server/container_stats_list_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/pkg/cri/server/container_update_resources_windows.go
+++ b/pkg/cri/server/container_update_resources_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/pkg/cri/server/helpers_windows.go
+++ b/pkg/cri/server/helpers_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/pkg/cri/server/sandbox_portforward_windows.go
+++ b/pkg/cri/server/sandbox_portforward_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/pkg/cri/server/sandbox_run_windows.go
+++ b/pkg/cri/server/sandbox_run_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/pkg/cri/server/sandbox_run_windows_test.go
+++ b/pkg/cri/server/sandbox_run_windows_test.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/pkg/cri/server/service_windows.go
+++ b/pkg/cri/server/service_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/pkg/netns/netns_windows.go
+++ b/pkg/netns/netns_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/platforms/defaults_windows.go
+++ b/platforms/defaults_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/platforms/defaults_windows_test.go
+++ b/platforms/defaults_windows_test.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/remotes/docker/config/config_windows.go
+++ b/remotes/docker/config/config_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/runtime/v1/shim/client/client_linux.go
+++ b/runtime/v1/shim/client/client_linux.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
    Copyright The containerd Authors.
 

--- a/runtime/v2/logging/logging_windows.go
+++ b/runtime/v2/logging/logging_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/runtime/v2/manager_windows.go
+++ b/runtime/v2/manager_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/runtime/v2/shim/shim_darwin.go
+++ b/runtime/v2/shim/shim_darwin.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 /*
    Copyright The containerd Authors.
 

--- a/runtime/v2/shim/shim_freebsd.go
+++ b/runtime/v2/shim/shim_freebsd.go
@@ -1,5 +1,3 @@
-// +build freebsd
-
 /*
    Copyright The containerd Authors.
 

--- a/runtime/v2/shim/shim_windows.go
+++ b/runtime/v2/shim/shim_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/services/diff/service_windows.go
+++ b/services/diff/service_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/services/server/server_windows.go
+++ b/services/server/server_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/services/tasks/local_freebsd.go
+++ b/services/tasks/local_freebsd.go
@@ -1,5 +1,3 @@
-// +build freebsd
-
 /*
    Copyright The containerd Authors.
 

--- a/services/tasks/local_windows.go
+++ b/services/tasks/local_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/snapshots/native/native_freebsd.go
+++ b/snapshots/native/native_freebsd.go
@@ -1,5 +1,3 @@
-// +build freebsd
-
 /*
    Copyright The containerd Authors.
 

--- a/sys/filesys_windows.go
+++ b/sys/filesys_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 

--- a/sys/socket_windows.go
+++ b/sys/socket_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 /*
    Copyright The containerd Authors.
 


### PR DESCRIPTION
Remove build tags which are already implied by the name of the file.
Ensures build tags are used consistently

We could automate this in CI in the future if we want to ensure the usage remains consistent.