### PR TITLE
Fix Linux CI Linter using Go 1.15.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
         os: [ubuntu-18.04, macos-10.15, windows-2019]
 
     steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+
       - uses: actions/checkout@v2
         with:
           path: src/github.com/containerd/containerd
@@ -41,6 +45,7 @@ jobs:
           version: v1.36.0
           working-directory: src/github.com/containerd/containerd
           args: --timeout=5m
+          skip-go-installation: true
 
   #
   # Project checks


### PR DESCRIPTION
For some reason the Linux CI runs end up using go 1.15.14 instead of 1.16.6 like the Windows runs, or any of the other CI steps. Not sure if this is due to the linter installing it's own version of go or something else.

Remedy this by running the `actions/setup-go@v2` action for the Linters and setting `skip-go-installation` to true for golangci-lint

Signed-off-by: Daniel Canter <dcanter@microsoft.com>