### PR TITLE
Fuzzing: Add experimental version of container fuzzer

### DIFF
--- a/contrib/fuzz/oss_fuzz_build.sh
+++ b/contrib/fuzz/oss_fuzz_build.sh
@@ -69,5 +69,7 @@ for i in $( ls *_test.go ); do mv $i ./${i%.*}_fuzz.go; done
 
 # Remove windows test to avoid double declarations:
 rm ./client_windows_test_fuzz.go
+rm ./helpers_windows_test_fuzz.go
 compile_go_fuzzer . FuzzCreateContainerNoTearDown fuzz_create_container_no_teardown
 compile_go_fuzzer . FuzzCreateContainerWithTearDown fuzz_create_container_with_teardown
+compile_go_fuzzer . FuzzNoTearDownWithDownload fuzz_no_teardown_with_download


### PR DESCRIPTION
1. Adds another version of the container_fuzzer that downloads the containerd binaries when starting a new fuzz run, instead of using the binaries that were built by `make`.
2. Moves the initialization out of `init()` since it now does not apply to all fuzzers.

The current approach to managing the containerd binaries works fine locally in the OSS-fuzz environment, but when running continuously by OSS-fuzz, then the performance is unsatisfactory. It would be great to get this version of the fuzzer up and running to observe it when running continuously.