### PR TITLE
Fix dir support for devices

### DIFF
--- a/oci/spec_opts_linux.go
+++ b/oci/spec_opts_linux.go
@@ -46,13 +46,13 @@ func WithDevices(devicePath, containerPath, permissions string) SpecOpts {
 		if err != nil {
 			return err
 		}
-		for _, dev := range devs {
-			s.Linux.Devices = append(s.Linux.Devices, dev)
+		for i := range devs {
+			s.Linux.Devices = append(s.Linux.Devices, devs[i])
 			s.Linux.Resources.Devices = append(s.Linux.Resources.Devices, specs.LinuxDeviceCgroup{
 				Allow:  true,
-				Type:   dev.Type,
-				Major:  &dev.Major,
-				Minor:  &dev.Minor,
+				Type:   devs[i].Type,
+				Major:  &devs[i].Major,
+				Minor:  &devs[i].Minor,
 				Access: permissions,
 			})
 		}


### PR DESCRIPTION
The bug prevents all major/minor combinations that exists on a directory to be enabled, only the last one on the list is enabled. This problem exists on main, 1.5 branches and the Issue #4847 is also bring backported to 1.4.
Another suggestion is including the line dev := dev that will create a new copy of the dev variable inside the loop as suggested by @cpuguy83.