### PR TITLE
add cpu-shares to ctr

### DIFF
--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -70,6 +70,11 @@ var platformRunFlags = []cli.Flag{
 		Usage: "set the CFS cpu quota",
 		Value: 0.0,
 	},
+	cli.IntFlag{
+		Name:  "cpu-shares",
+		Usage: "set the cpu shares",
+		Value: 1024,
+	},
 	cli.BoolFlag{
 		Name:  "cni",
 		Usage: "enable cni networking for the container",
@@ -224,6 +229,10 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 				quota  = int64(cpus * 100000.0)
 			)
 			opts = append(opts, oci.WithCPUCFS(quota, period))
+		}
+
+		if shares := context.Int("cpu-shares"); shares > 0 {
+			opts = append(opts, oci.WithCPUShares(uint64(shares)))
 		}
 
 		quota := context.Int64("cpu-quota")

--- a/oci/spec_opts_nonlinux.go
+++ b/oci/spec_opts_nonlinux.go
@@ -36,3 +36,11 @@ var WithAllCurrentCapabilities = func(ctx context.Context, client Client, c *con
 var WithAllKnownCapabilities = func(ctx context.Context, client Client, c *containers.Container, s *Spec) error {
 	return WithCapabilities(nil)(ctx, client, c, s)
 }
+
+// WithCPUShares sets the container's cpu shares
+//nolint: deadcode, unused
+func WithCPUShares(shares uint64) SpecOpts {
+	return func(ctx context.Context, _ Client, c *containers.Container, s *Spec) error {
+		return nil
+	}
+}


### PR DESCRIPTION
This allows the cpu shares to be modified via ctr.

Signed-off-by: Michael Crosby <michael@thepasture.io>