### PR TITLE
docs: rename main to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you are interested in trying out containerd see our example at [Getting Start
 ## Nightly builds
 
 There are nightly builds available for download [here](https://github.com/containerd/containerd/actions?query=workflow%3ANightly).
-Binaries are generated from `master` branch every night for `Linux` and `Windows`.
+Binaries are generated from `main` branch every night for `Linux` and `Windows`.
 
 Please be aware: nightly builds might have critical bugs, it's not recommended for use in production and no support provided.
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -27,7 +27,7 @@ considered "pre-releases".
 
 ### Major and Minor Releases
 
-Major and minor releases of containerd will be made from master. Releases of
+Major and minor releases of containerd will be made from main. Releases of
 containerd will be marked with GPG signed tags and announced at
 https://github.com/containerd/containerd/releases. The tag will be of the
 format `v<major>.<minor>.<patch>` and should be made with the command `git tag
@@ -43,7 +43,7 @@ done against that branch.
 
 Pre-releases, such as alphas, betas and release candidates will be conducted
 from their source branch. For major and minor releases, these releases will be
-done from master. For patch releases, these pre-releases should be done within
+done from main. For patch releases, these pre-releases should be done within
 the corresponding release branch.
 
 While pre-releases are done to assist in the stabilization process, no
@@ -132,7 +132,7 @@ If there are important fixes that need to be backported, please let use know in
 one of three ways:
 
 1. Open an issue.
-2. Open a PR with cherry-picked change from master.
+2. Open a PR with cherry-picked change from main.
 3. Open a PR with a ported fix.
 
 __If you are reporting a security issue, please reach out discreetly at security@containerd.io__.
@@ -140,10 +140,10 @@ Remember that backported PRs must follow the versioning guidelines from this doc
 
 Any release that is "active" can accept backports. Opening a backport PR is
 fairly straightforward. The steps differ depending on whether you are pulling
-a fix from master or need to draft a new commit specific to a particular
+a fix from main or need to draft a new commit specific to a particular
 branch.
 
-To cherry pick a straightforward commit from master, simply use the cherry pick
+To cherry pick a straightforward commit from main, simply use the cherry pick
 process:
 
 1. Pick the branch to which you want backported, usually in the format
@@ -167,7 +167,7 @@ process:
 	```
 
    Make sure to replace `stevvooe` with whatever fork you are using to open
-   the PR. When you open the PR, make sure to switch `master` with whatever
+   the PR. When you open the PR, make sure to switch `main` with whatever
    release branch you are targeting with the fix. Make sure the PR title has
    `[<release branch>]` prefixed. e.g.:
 
@@ -175,11 +175,11 @@ process:
    [release/1.4] Fix foo in bar
    ```
 
-If there is no existing fix in master, you should first fix the bug in master,
+If there is no existing fix in main, you should first fix the bug in main,
 or ask us a maintainer or contributor to do it via an issue. Once that PR is
 completed, open a PR using the process above.
 
-Only when the bug is not seen in master and must be made for the specific
+Only when the bug is not seen in main and must be made for the specific
 release branch should you open a PR with new code.
 
 ## Public API Stability

--- a/archive/tar.go
+++ b/archive/tar.go
@@ -48,7 +48,7 @@ var errInvalidArchive = errors.New("invalid archive")
 // Produces a tar using OCI style file markers for deletions. Deleted
 // files will be prepended with the prefix ".wh.". This style is
 // based off AUFS whiteouts.
-// See https://github.com/opencontainers/image-spec/blob/master/layer.md
+// See https://github.com/opencontainers/image-spec/blob/main/layer.md
 func Diff(ctx context.Context, a, b string) io.ReadCloser {
 	r, w := io.Pipe()
 
@@ -68,7 +68,7 @@ func Diff(ctx context.Context, a, b string) io.ReadCloser {
 // Produces a tar using OCI style file markers for deletions. Deleted
 // files will be prepended with the prefix ".wh.". This style is
 // based off AUFS whiteouts.
-// See https://github.com/opencontainers/image-spec/blob/master/layer.md
+// See https://github.com/opencontainers/image-spec/blob/main/layer.md
 func WriteDiff(ctx context.Context, w io.Writer, a, b string, opts ...WriteDiffOpt) error {
 	var options WriteDiffOptions
 	for _, opt := range opts {
@@ -89,7 +89,7 @@ func WriteDiff(ctx context.Context, w io.Writer, a, b string, opts ...WriteDiffO
 // Produces a tar using OCI style file markers for deletions. Deleted
 // files will be prepended with the prefix ".wh.". This style is
 // based off AUFS whiteouts.
-// See https://github.com/opencontainers/image-spec/blob/master/layer.md
+// See https://github.com/opencontainers/image-spec/blob/main/layer.md
 func writeDiffNaive(ctx context.Context, w io.Writer, a, b string, _ WriteDiffOptions) error {
 	cw := NewChangeWriter(w, b)
 	err := fs.Changes(ctx, a, b, cw.HandleChange)
@@ -102,7 +102,7 @@ func writeDiffNaive(ctx context.Context, w io.Writer, a, b string, _ WriteDiffOp
 const (
 	// whiteoutPrefix prefix means file is a whiteout. If this is followed by a
 	// filename this means that file has been removed from the base layer.
-	// See https://github.com/opencontainers/image-spec/blob/master/layer.md#whiteouts
+	// See https://github.com/opencontainers/image-spec/blob/main/layer.md#whiteouts
 	whiteoutPrefix = ".wh."
 
 	// whiteoutMetaPrefix prefix means whiteout has a special meaning and is not
@@ -118,7 +118,7 @@ const (
 )
 
 // Apply applies a tar stream of an OCI style diff tar.
-// See https://github.com/opencontainers/image-spec/blob/master/layer.md#applying-changesets
+// See https://github.com/opencontainers/image-spec/blob/main/layer.md#applying-changesets
 func Apply(ctx context.Context, root string, r io.Reader, opts ...ApplyOpt) (int64, error) {
 	root = filepath.Clean(root)
 
@@ -140,7 +140,7 @@ func Apply(ctx context.Context, root string, r io.Reader, opts ...ApplyOpt) (int
 
 // applyNaive applies a tar stream of an OCI style diff tar to a directory
 // applying each file as either a whole file or whiteout.
-// See https://github.com/opencontainers/image-spec/blob/master/layer.md#applying-changesets
+// See https://github.com/opencontainers/image-spec/blob/main/layer.md#applying-changesets
 func applyNaive(ctx context.Context, root string, r io.Reader, options ApplyOptions) (size int64, err error) {
 	var (
 		dirs []*tar.Header
@@ -469,7 +469,7 @@ func mkparent(ctx context.Context, path, root string, parents []string) error {
 // This should be used combining with continuity's diff computing functionality
 // (e.g. `fs.Change` of github.com/containerd/continuity/fs).
 //
-// See also https://github.com/opencontainers/image-spec/blob/master/layer.md for details
+// See also https://github.com/opencontainers/image-spec/blob/main/layer.md for details
 // about OCI layers
 type ChangeWriter struct {
 	tw        *tar.Writer

--- a/archive/tar_opts_windows.go
+++ b/archive/tar_opts_windows.go
@@ -24,7 +24,7 @@ import (
 )
 
 // applyWindowsLayer applies a tar stream of an OCI style diff tar of a Windows layer
-// See https://github.com/opencontainers/image-spec/blob/master/layer.md#applying-changesets
+// See https://github.com/opencontainers/image-spec/blob/main/layer.md#applying-changesets
 func applyWindowsLayer(ctx context.Context, root string, r io.Reader, options ApplyOptions) (size int64, err error) {
 	return ociwclayer.ImportLayerFromTar(ctx, r, root, options.Parents)
 }
@@ -45,7 +45,7 @@ func AsWindowsContainerLayer() ApplyOpt {
 // Produces a tar using OCI style file markers for deletions. Deleted
 // files will be prepended with the prefix ".wh.". This style is
 // based off AUFS whiteouts.
-// See https://github.com/opencontainers/image-spec/blob/master/layer.md
+// See https://github.com/opencontainers/image-spec/blob/main/layer.md
 func writeDiffWindowsLayers(ctx context.Context, w io.Writer, _, layer string, options WriteDiffOptions) error {
 	return ociwclayer.ExportLayerToTar(ctx, w, layer, options.ParentLayers)
 }


### PR DESCRIPTION
containerd and opencontainers/image-spec have renamed its main branch
from "master" to "main"

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>