### PR TITLE
content: return the error with its timestamp

### DIFF
--- a/content/local/locks.go
+++ b/content/local/locks.go
@@ -41,7 +41,13 @@ func tryLock(ref string) error {
 	defer locksMu.Unlock()
 
 	if v, ok := locks[ref]; ok {
-		return errors.Wrapf(errdefs.ErrUnavailable, "ref %s locked since %s", ref, v.since)
+		// Returning the duration may help developers distinguish dead locks (long duration) from
+		// lock contentions (short duration).
+		now := time.Now()
+		return errors.Wrapf(
+			errdefs.ErrUnavailable,
+			"ref %s locked for %s (since %s)", ref, now.Sub(v.since), v.since,
+		)
 	}
 
 	locks[ref] = &lock{time.Now()}

--- a/content/local/locks_test.go
+++ b/content/local/locks_test.go
@@ -28,5 +28,5 @@ func TestTryLock(t *testing.T) {
 	defer unlock("testref")
 
 	err = tryLock("testref")
-	assert.ErrorContains(t, err, "ref testref locked since ")
+	assert.ErrorContains(t, err, "ref testref locked for ")
 }


### PR DESCRIPTION
The current timestamp is probably included in production logs, but
won't be in testing environments such as GitHub Actions.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>