### PR TITLE
[Scripts] Add trap to cri-integration test script

### DIFF
--- a/script/test/cri-integration.sh
+++ b/script/test/cri-integration.sh
@@ -21,6 +21,8 @@ set -o pipefail
 basedir="$(dirname "${BASH_SOURCE[0]}")"
 source "${basedir}/utils.sh"
 
+trap test_teardown EXIT
+
 ROOT="$( cd "${basedir}" && pwd )"/../..
 cd "${ROOT}"
 
@@ -45,7 +47,5 @@ ${sudo} bin/cri-integration.test --test.run="${FOCUS}" --test.v \
   --image-list="${TEST_IMAGE_LIST:-}"
 
 test_exit_code=$?
-
-test_teardown
 
 exit ${test_exit_code}


### PR DESCRIPTION
The cri-integration.sh script sets errexit option. This does not
work properly on Bash in Windows, espectially when the script is
piped to something else ( tee in this case ). In this particular
case, the problem arises from the fact that if the script exits
prematurely, it will not get a chance to call test_teardown and
thus clean the remaining containerd process, thus the whole
command will hang indefinetly.

Adding a simple trap on EXIT to call test_teardown will easily
fix this.

Signed-off-by: Adelina Tuvenie <atuvenie@cloudbasesolutions.com>