### PR TITLE
Fix bad `make protos` failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,11 +160,11 @@ protos: bin/protoc-gen-gogoctrd ## generate protobuf
 	@echo "$(WHALE) $@"
 	@find . -path ./vendor -prune -false -o -name '*.pb.go' | xargs rm
 	$(eval TMPDIR := $(shell mktemp -d))
-	@mv ${ROOTDIR}/vendor $TMPDIR
+	@mv ${ROOTDIR}/vendor ${TMPDIR}
 	@(cd ${ROOTDIR}/api && PATH="${ROOTDIR}/bin:${PATH}" protobuild --quiet ${API_PACKAGES})
 	@(PATH="${ROOTDIR}/bin:${PATH}" protobuild --quiet ${NON_API_PACKAGES})
-	@mv $TMPDIR ${ROOTDIR}/vendor
-	@rm -rf $TMPDIR
+	@mv ${TMPDIR}/vendor ${ROOTDIR}
+	@rm -rf ${TMPDIR}
 
 check-protos: protos ## check if protobufs needs to be generated again
 	@echo "$(WHALE) $@"


### PR DESCRIPTION
Somehow messed up the TMPDIR expansion

Signed-off-by: Davanum Srinivas <davanum@gmail.com>