### PR TITLE
Make Cgroup driver configurable in gce configure script

### DIFF
--- a/contrib/gce/configure.sh
+++ b/contrib/gce/configure.sh
@@ -176,8 +176,8 @@ if [ "${KUBERNETES_MASTER:-}" != "true" ]; then
     cni_template_path=""
   fi
 fi
-# Use systemd cgroup if cgroupv2 is enabled
-systemdCgroup="${CONTAINERD_CGROUPV2:-"false"}"
+# Use systemd cgroup if specified in env
+systemdCgroup="${CONTAINERD_SYSTEMD_CGROUP:-"false"}"
 log_level="${CONTAINERD_LOG_LEVEL:-"info"}"
 max_container_log_line="${CONTAINERD_MAX_CONTAINER_LOG_LINE:-16384}"
 cat > ${config_path} <<EOF


### PR DESCRIPTION
Adding a Kubernetes node e2e job with systemd cgroup driver,  Need to enable systemd cgroup driver via env variable
https://github.com/kubernetes/test-infra/pull/23253


Signed-off-by: Aditi Sharma <adi.sky17@gmail.com>