### PR TITLE
RFC: Initial support of idmapped mount points

### DIFF
--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -165,8 +165,9 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 				opts = append(opts,
 					oci.WithUserNamespace([]specs.LinuxIDMapping{uidMap}, []specs.LinuxIDMapping{gidMap}))
 				// use snapshotter opts or the remapped snapshot support to shift the filesystem
-				// currently the only snapshotter known to support the labels is fuse-overlayfs:
-				// https://github.com/AkihiroSuda/containerd-fuse-overlayfs
+				// currently the snapshotters known to support the labels are:
+				// fuse-overlayfs - https://github.com/AkihiroSuda/containerd-fuse-overlayfs
+				// overlay - in case of idmapped mount points are supported by host kernel (Linux kernel 5.12)
 				if context.Bool("remap-labels") {
 					cOpts = append(cOpts, containerd.WithNewSnapshot(id, image,
 						containerd.WithRemapperLabels(0, uidMap.HostID, 0, gidMap.HostID, uidMap.Size)))

--- a/mount/mount_id_mapped.go
+++ b/mount/mount_id_mapped.go
@@ -1,0 +1,125 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package mount
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"unsafe"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+// TODO: Support multiple mappings in future
+func parseIdMapping(mapping string) ([]syscall.SysProcIDMap, error) {
+	parts := strings.Split(mapping, ":")
+	if len(parts) != 3 {
+		return []syscall.SysProcIDMap{}, errors.New("user namespace mappings require the format `container-id:host-id:size`")
+	}
+	cID, err := strconv.ParseUint(parts[0], 0, 32)
+	if err != nil {
+		return []syscall.SysProcIDMap{}, errors.Wrapf(err, "invalid container id for user namespace remapping")
+	}
+	hID, err := strconv.ParseUint(parts[1], 0, 32)
+	if err != nil {
+		return []syscall.SysProcIDMap{}, errors.Wrapf(err, "invalid host id for user namespace remapping")
+	}
+	size, err := strconv.ParseUint(parts[2], 0, 32)
+	if err != nil {
+		return []syscall.SysProcIDMap{}, errors.Wrapf(err, "invalid size for user namespace remapping")
+	}
+
+	return []syscall.SysProcIDMap{
+		{
+			ContainerID: int(cID),
+			HostID:      int(hID),
+			Size:        int(size),
+		},
+	}, nil
+}
+
+func mountIdMapped(target string, pid int) (err error) {
+	var (
+		path       string
+		attr       MountAttr
+		userNsFile *os.File
+		targetDir  *os.File
+	)
+
+	path = fmt.Sprintf("/proc/%d/ns/user", pid)
+	if userNsFile, err = os.OpenFile(path, os.O_RDONLY, 0); err != nil {
+		return errors.Wrapf(err, "Unable to get user ns file descriptor for - %s\n", path)
+	}
+
+	attr.attr_set = MOUNT_ATTR_IDMAP
+	attr.userns = uint64(userNsFile.Fd())
+
+	defer userNsFile.Close()
+	if targetDir, err = os.OpenFile(target, os.O_RDONLY, 0); err != nil {
+		return errors.Wrapf(err, "Unable to get mount point target file descriptor - %s\n", target)
+	}
+
+	defer targetDir.Close()
+	return MountSetAttr(int(targetDir.Fd()), "", unix.AT_EMPTY_PATH|AT_RECURSIVE,
+		&attr, uint(unsafe.Sizeof(attr)))
+}
+
+func MapMount(uidmap string, gidmap string, target string) (err error) {
+	const (
+		userNsHelperBinary = "/bin/sh"
+	)
+	// TODO: Avoid dependency on /bin/sh or do in a complete different way
+	// Currently there is no way to pass idmapping directly to mount_setattr,
+	// this is not very convinient from the container runtime point of view.
+	// The id remapping procedure should be done in containerd, due to we have
+	// old approach the use recurcive chown.
+	// Maybe it is necessary to think about moving of container rootfs ownership
+	// adjustment to runc due to runc have a knowledge about container user namespace.
+	// But personally I think that it would be better to add possibility to call
+	// mount_setattr with explicit id mappings and leave container runtime components
+	// responcibilities unchanged.
+	cmd := exec.Command(userNsHelperBinary)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Cloneflags: syscall.CLONE_NEWUSER,
+	}
+
+	if cmd.SysProcAttr.UidMappings, err = parseIdMapping(uidmap); err != nil {
+		return err
+	}
+	if cmd.SysProcAttr.GidMappings, err = parseIdMapping(gidmap); err != nil {
+		return err
+	}
+
+	if err = cmd.Start(); err != nil {
+		return errors.Wrapf(err, "Failed to run the %s helper binary\n", userNsHelperBinary)
+	}
+
+	if err = mountIdMapped(target, cmd.Process.Pid); err != nil {
+		return errors.Wrapf(err, "Failed to create idmapped mount for target - %s\n", target)
+	}
+
+	if err = cmd.Wait(); err != nil {
+		return errors.Wrapf(err, "Failed to run the %s helper binary\n", userNsHelperBinary)
+	}
+
+	return nil
+}

--- a/mount/mount_setattr.go
+++ b/mount/mount_setattr.go
@@ -1,0 +1,78 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package mount
+
+import (
+	"runtime"
+	"syscall"
+	"unsafe"
+)
+
+// There is no support of mount_setattr in golang
+// "golang.org/x/sys/unix" package and even in glibc
+
+type MountAttr struct {
+	attr_set    uint64
+	attr_clr    uint64
+	propagation uint64
+	userns      uint64
+}
+
+// AT_RECURSIVE is supported by glibc
+// but doesn't supported by "golang.org/x/sys/unix"
+const (
+	AT_RECURSIVE = 0x8000
+)
+
+const (
+	MOUNT_ATTR_RDONLY      = 0x00000001
+	MOUNT_ATTR_NOSUID      = 0x00000002
+	MOUNT_ATTR_NODEV       = 0x00000004
+	MOUNT_ATTR_NOEXEC      = 0x00000008
+	MOUNT_ATTR__ATIME      = 0x00000070
+	MOUNT_ATTR_RELATIME    = 0x00000000
+	MOUNT_ATTR_NOATIME     = 0x00000010
+	MOUNT_ATTR_STRICTATIME = 0x00000020
+	MOUNT_ATTR_NODIRATIME  = 0x00000080
+	MOUNT_ATTR_IDMAP       = 0x00100000
+)
+
+func mountSetAttrSyscallNr() int {
+	switch runtime.GOARCH {
+	case "mips", "mipsle":
+		return 4441
+	case "mips64", "mips64le":
+		return 5441
+	default:
+		return 441
+	}
+}
+
+func MountSetAttr(dfd int, path string, flags uint, attr *MountAttr, size uint) (err error) {
+	var _p0 *byte
+
+	if _p0, err = syscall.BytePtrFromString(path); err != nil {
+		return err
+	}
+
+	_, _, e1 := syscall.Syscall6(uintptr(mountSetAttrSyscallNr()), uintptr(dfd), uintptr(unsafe.Pointer(_p0)),
+		uintptr(flags), uintptr(unsafe.Pointer(attr)), uintptr(size), 0)
+	if e1 != 0 {
+		err = e1
+	}
+	return
+}

--- a/snapshots/overlay/overlay.go
+++ b/snapshots/overlay/overlay.go
@@ -236,11 +236,15 @@ func (o *snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, er
 		return nil, err
 	}
 	s, err := storage.GetSnapshot(ctx, key)
+	_, info, _, err_info := storage.GetInfo(ctx, key)
 	t.Rollback()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get active mount")
 	}
-	return o.mounts(s), nil
+	if err_info != nil {
+		return nil, errors.Wrap(err_info, "failed to get snapshot info")
+	}
+	return o.mounts(s, info), nil
 }
 
 func (o *snapshotter) Commit(ctx context.Context, name, key string, opts ...snapshots.Opt) error {
@@ -468,12 +472,17 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 	}
 	td = ""
 
+	_, info, _, err := storage.GetInfo(ctx, key)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get snapshot info")
+	}
+
 	rollback = false
 	if err = t.Commit(); err != nil {
 		return nil, errors.Wrap(err, "commit failed")
 	}
 
-	return o.mounts(s), nil
+	return o.mounts(s, info), nil
 }
 
 func (o *snapshotter) prepareDirectory(ctx context.Context, snapshotDir string, kind snapshots.Kind) (string, error) {
@@ -495,7 +504,7 @@ func (o *snapshotter) prepareDirectory(ctx context.Context, snapshotDir string, 
 	return td, nil
 }
 
-func (o *snapshotter) mounts(s storage.Snapshot) []mount.Mount {
+func (o *snapshotter) mounts(s storage.Snapshot, info snapshots.Info) []mount.Mount {
 	if len(s.ParentIDs) == 0 {
 		// if we only have one layer/no parents then just return a bind mount as overlay
 		// will not work
@@ -550,6 +559,12 @@ func (o *snapshotter) mounts(s storage.Snapshot) []mount.Mount {
 	}
 
 	options = append(options, fmt.Sprintf("lowerdir=%s", strings.Join(parentPaths, ":")))
+	if mapping, ok := info.Labels["containerd.io/snapshot/uidmapping"]; ok {
+		options = append(options, fmt.Sprintf("mapuid=%s", mapping))
+	}
+	if mapping, ok := info.Labels["containerd.io/snapshot/gidmapping"]; ok {
+		options = append(options, fmt.Sprintf("mapgid=%s", mapping))
+	}
 	return []mount.Mount{
 		{
 			Type:    "overlay",


### PR DESCRIPTION
Hi,
this is this is initial support of idmapped mount points in containerd. The original PR was published by **@mauriciovasquezbernal** here https://github.com/containerd/containerd/pull/4734.

Updates:

- Original PR was rebased on top of latest containerd.
- Idmapped mount support was reimplemented using in Go.
- Small changes in error handling.
- Added some comments.
- Updated container start time performance measurement results (numbers are in seconds).

<html>
<body>
<!--StartFragment-->

Image | ID mapped mount | WithRemappedSnapshot
-- | -- | --
BusyBox | 00.135 | 04.964
Ubuntu | 00.171 | 15.713
Fedora | 00.143 | 38.799

<!--EndFragment-->
</body>
</html>

In current patch set the only idmapped mount points functionality is implemented. I think that user namespace support for containerd should be integrated separately, please share your opinion, maybe I am wrong here. I don't know if anybody is working on it, if no I would like to work on user namespaces support also.

Dear reviewers, could you please check this PR.
Thank you in advance!

cc @alban @rata @mauriciovasquezbernal @AkihiroSuda