### PR TITLE
Update to Go 1.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
   integration-windows:
     name: Windows Integration
     runs-on: windows-2019
-    timeout-minutes: 30
+    timeout-minutes: 35
     needs: [project, linters, protos, man]
     env:
       GOTEST: gotestsum --
@@ -306,7 +306,7 @@ jobs:
   integration-linux:
     name: Linux Integration
     runs-on: ubuntu-18.04
-    timeout-minutes: 30
+    timeout-minutes: 35
     needs: [project, linters, protos, man]
 
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.16.7]
+        go-version: [1.17]
         os: [ubuntu-18.04, macos-10.15, windows-2019]
 
     steps:
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.7'
+          go-version: '1.17'
 
       - uses: actions/checkout@v2
         with:
@@ -78,7 +78,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.7'
+          go-version: '1.17'
 
       - uses: actions/checkout@v2
         with:
@@ -111,7 +111,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.7'
+          go-version: '1.17'
       - uses: actions/checkout@v2
       - run: go get github.com/cpuguy83/go-md2man/v2@v2.0.1
       - run: make man
@@ -145,7 +145,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.7'
+          go-version: '1.17'
       - uses: actions/checkout@v2
       - run: |
           set -e -x
@@ -202,7 +202,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-10.15, windows-2019]
-        go-version: ['1.16.7']
+        go-version: ['1.17']
 
     steps:
       - uses: actions/setup-go@v2
@@ -244,7 +244,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.7'
+          go-version: '1.17'
 
       - uses: actions/checkout@v2
         with:
@@ -325,7 +325,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.7'
+          go-version: '1.17'
 
       - uses: actions/checkout@v2
 
@@ -444,7 +444,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.7'
+          go-version: '1.17'
       - uses: actions/checkout@v2
       - run: sudo -E PATH=$PATH script/setup/install-gotestsum
       - name: Tests

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.7'
+          go-version: '1.17'
 
       - uses: actions/checkout@v2
         with:
@@ -135,7 +135,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.7'
+          go-version: '1.17'
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16.7'
+          go-version: '1.17'
 
       - name: Set env
         shell: bash

--- a/.zuul/playbooks/containerd-build/integration-test.yaml
+++ b/.zuul/playbooks/containerd-build/integration-test.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.16.7'
+    go_version: '1.17'
     arch: arm64
   tasks:
   - name: Install pre-requisites

--- a/.zuul/playbooks/containerd-build/run.yaml
+++ b/.zuul/playbooks/containerd-build/run.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.16.7'
+    go_version: '1.17'
     arch: arm64
   tasks:
   - name: Build containerd

--- a/.zuul/playbooks/containerd-build/unit-test.yaml
+++ b/.zuul/playbooks/containerd-build/unit-test.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.16.7'
+    go_version: '1.17'
     arch: arm64
   tasks:
   - name: Build and test containerd

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,7 +77,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.16.7",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.17",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -10,7 +10,7 @@
 #
 # docker build -t containerd-test --build-arg RUNC_VERSION=v1.0.0-rc94 -f Dockerfile.test ../
 
-ARG GOLANG_VERSION=1.16.7
+ARG GOLANG_VERSION=1.17
 ARG GOLANG_IMAGE=golang
 
 FROM ${GOLANG_IMAGE}:${GOLANG_VERSION} AS golang


### PR DESCRIPTION
Go 1.17 has been released.

Release Notes: https://golang.org/doc/go1.17

Has small performance gains and binary size improvements; new architecture support for arm64 on Windows (https://twitter.com/kelseyhightower/status/1427400588900241410)

Signed-off-by: Phil Estes <estesp@amazon.com>