### PR TITLE
[release/1.5 backport] Allow expanded DNS configuration

### DIFF
--- a/pkg/cri/server/helpers_linux.go
+++ b/pkg/cri/server/helpers_linux.go
@@ -48,9 +48,6 @@ const (
 	defaultShmSize = int64(1024 * 1024 * 64)
 	// relativeRootfsPath is the rootfs path relative to bundle path.
 	relativeRootfsPath = "rootfs"
-	// According to http://man7.org/linux/man-pages/man5/resolv.conf.5.html:
-	// "The search list is currently limited to six domains with a total of 256 characters."
-	maxDNSSearches = 6
 	// devShm is the default path of /dev/shm.
 	devShm = "/dev/shm"
 	// etcHosts is the default path of /etc/hosts file.

--- a/pkg/cri/server/sandbox_run_linux.go
+++ b/pkg/cri/server/sandbox_run_linux.go
@@ -275,10 +275,6 @@ func (c *criService) setupSandboxFiles(id string, config *runtime.PodSandboxConf
 func parseDNSOptions(servers, searches, options []string) (string, error) {
 	resolvContent := ""
 
-	if len(searches) > maxDNSSearches {
-		return "", errors.Errorf("DNSOption.Searches has more than %d domains", maxDNSSearches)
-	}
-
 	if len(searches) > 0 {
 		resolvContent += fmt.Sprintf("search %s\n", strings.Join(searches, " "))
 	}

--- a/pkg/cri/server/sandbox_run_linux_test.go
+++ b/pkg/cri/server/sandbox_run_linux_test.go
@@ -394,7 +394,8 @@ nameserver server.google.com
 options timeout:1
 `,
 		},
-		"should return error if dns search exceeds limit(6)": {
+		"expanded dns config should return correct content on modern libc (e.g. glibc 2.26 and above)": {
+			servers: []string{"8.8.8.8", "server.google.com"},
 			searches: []string{
 				"server0.google.com",
 				"server1.google.com",
@@ -404,7 +405,12 @@ options timeout:1
 				"server5.google.com",
 				"server6.google.com",
 			},
-			expectErr: true,
+			options: []string{"timeout:1"},
+			expectedContent: `search server0.google.com server1.google.com server2.google.com server3.google.com server4.google.com server5.google.com server6.google.com
+nameserver 8.8.8.8
+nameserver server.google.com
+options timeout:1
+`,
 		},
 	} {
 		t.Logf("TestCase %q", desc)


### PR DESCRIPTION
Cherry pick of #5878 on release/1.5.

#5878: Allow expanded DNS configuration