### PR TITLE
[release/1.5] cherry-pick: CI: Switch to available latest images

### DIFF
--- a/integration/client/client_unix_test.go
+++ b/integration/client/client_unix_test.go
@@ -32,7 +32,7 @@ const (
 )
 
 var (
-	testImage    = "mirror.gcr.io/library/busybox:1.32.0"
+	testImage    = "mirror.gcr.io/library/busybox:1.32"
 	shortCommand = withProcessArgs("true")
 	longCommand  = withProcessArgs("/bin/sh", "-c", "while true; do sleep 1; done")
 )

--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -55,7 +55,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const testUserNSImage = "mirror.gcr.io/library/alpine:3.13"
+const testUserNSImage = "mirror.gcr.io/library/alpine:3.13.5"
 
 // TestRegressionIssue4769 verifies the number of task exit events.
 //


### PR DESCRIPTION
Cherry-pick PR #5625 from main to `release/1.5` to fix CI

--------

`mirror.gcr.io/library/busybox:1.32.0` is unavailable.

```console
$ curl -s https://mirror.gcr.io//v2/library/busybox/tags/list | jq '.tags'
[
  "1.26.2",
  "1.27.2",
  "1.28",
  "1.29",
  "1.29.2",
  "1.29.3",
  "1.30",
  "1.30.1",
  "1.31",
  "1.31.0",
  "1.31.1",
  "1.32",
  "latest"
]
```

`mirror.gcr.io/library/alpine:3.13` is unavailable.

```console
$ curl -s https://mirror.gcr.io//v2/library/alpine/tags/list | jq '.tags'
[
  "20200428",
  "3",
  "3.10",
  "3.11",
  "3.12",
  "3.12.0",
  "3.12.1",
  "3.13.5",
  "3.3",
  "3.4",
  "3.6",
  "3.7",
  "3.8",
  "3.9",
  "latest"
]
```

Signed-off-by: Kohei Tokunaga <ktokunaga.mail@gmail.com>
(cherry picked from commit cd33c007cecdee2c8e5333190cad1bbce4ade13d)