### PR TITLE
script: update golangci-lint from v1.38.0 and v1.36.0 to v1.42.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.36.0
+          version: v1.42.0
           args: --timeout=5m
           skip-go-installation: true
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,7 @@ linters:
     - unconvert
     - gofmt
     - goimports
-    - golint
+    - revive
     - ineffassign
     - vet
     - unused

--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -121,7 +121,7 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		// handle. NetNSPath in sandbox metadata and NetNS is non empty only for non host network
 		// namespaces. If the pod is in host network namespace then both are empty and should not
 		// be used.
-		var netnsMountDir string = "/var/run/netns"
+		var netnsMountDir = "/var/run/netns"
 		if c.config.NetNSMountsUnderStateDir {
 			netnsMountDir = filepath.Join(c.config.StateDir, "netns")
 		}

--- a/pkg/os/os_windows.go
+++ b/pkg/os/os_windows.go
@@ -58,7 +58,7 @@ func openPath(path string) (windows.Handle, error) {
 }
 
 // GetFinalPathNameByHandle flags.
-//nolint:golint
+//nolint:revive // SNAKE_CASE is not idiomatic in Go, but aligned with Win32 API.
 const (
 	cFILE_NAME_OPENED = 0x8
 

--- a/script/setup/install-dev-tools
+++ b/script/setup/install-dev-tools
@@ -34,4 +34,4 @@ GO111MODULE=off go get -d github.com/gogo/googleapis || true
 GO111MODULE=off go get -d github.com/gogo/protobuf || true
 
 GO111MODULE=on go get github.com/cpuguy83/go-md2man/v2@v2.0.1
-GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.38.0
+GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.0

--- a/snapshots/testsuite/testsuite.go
+++ b/snapshots/testsuite/testsuite.go
@@ -18,7 +18,7 @@ package testsuite
 
 import (
 	"context"
-	//nolint:golint
+	//nolint:revive // go-digest needs the blank import. See https://github.com/opencontainers/go-digest#usage.
 	_ "crypto/sha256"
 	"fmt"
 	"io/ioutil"


### PR DESCRIPTION
golint has been deprecated and replaced by revive since v1.41.0.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>