### PR TITLE
Run `go fmt` with Go 1.17

### DIFF
--- a/archive/tar_mostunix.go
+++ b/archive/tar_mostunix.go
@@ -1,3 +1,4 @@
+//go:build !windows && !freebsd
 // +build !windows,!freebsd
 
 /*

--- a/archive/tar_test.go
+++ b/archive/tar_test.go
@@ -1,3 +1,4 @@
+//go:build !windows && !darwin
 // +build !windows,!darwin
 
 /*

--- a/archive/tar_unix.go
+++ b/archive/tar_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/archive/time_unix.go
+++ b/archive/time_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/cio/io_test.go
+++ b/cio/io_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/cio/io_unix.go
+++ b/cio/io_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/cio/io_unix_test.go
+++ b/cio/io_unix_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/cmd/containerd-shim-runc-v1/main.go
+++ b/cmd/containerd-shim-runc-v1/main.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/cmd/containerd-shim-runc-v2/main.go
+++ b/cmd/containerd-shim-runc-v2/main.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/cmd/containerd-shim/main_unix.go
+++ b/cmd/containerd-shim/main_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/cmd/containerd-stress/rlimit_unix.go
+++ b/cmd/containerd-stress/rlimit_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows && !freebsd
 // +build !windows,!freebsd
 
 /*

--- a/cmd/containerd/builtins_aufs_linux.go
+++ b/cmd/containerd/builtins_aufs_linux.go
@@ -1,3 +1,4 @@
+//go:build !no_aufs
 // +build !no_aufs
 
 /*

--- a/cmd/containerd/builtins_btrfs_linux.go
+++ b/cmd/containerd/builtins_btrfs_linux.go
@@ -1,3 +1,4 @@
+//go:build !no_btrfs && cgo
 // +build !no_btrfs,cgo
 
 /*

--- a/cmd/containerd/builtins_cri.go
+++ b/cmd/containerd/builtins_cri.go
@@ -1,3 +1,4 @@
+//go:build (linux && !no_cri) || (windows && !no_cri)
 // +build linux,!no_cri windows,!no_cri
 
 /*

--- a/cmd/containerd/builtins_devmapper_linux.go
+++ b/cmd/containerd/builtins_devmapper_linux.go
@@ -1,3 +1,4 @@
+//go:build !no_devmapper
 // +build !no_devmapper
 
 /*

--- a/cmd/containerd/builtins_unix.go
+++ b/cmd/containerd/builtins_unix.go
@@ -1,3 +1,4 @@
+//go:build darwin || freebsd || solaris
 // +build darwin freebsd solaris
 
 /*

--- a/cmd/containerd/builtins_zfs_linux.go
+++ b/cmd/containerd/builtins_zfs_linux.go
@@ -1,3 +1,4 @@
+//go:build !no_zfs
 // +build !no_zfs
 
 /*

--- a/cmd/containerd/command/config_unsupported.go
+++ b/cmd/containerd/command/config_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux && !windows && !solaris
 // +build !linux,!windows,!solaris
 
 /*

--- a/cmd/containerd/command/main_unix.go
+++ b/cmd/containerd/command/main_unix.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin || freebsd || solaris
 // +build linux darwin freebsd solaris
 
 /*

--- a/cmd/containerd/command/notify_unsupported.go
+++ b/cmd/containerd/command/notify_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 /*

--- a/cmd/containerd/command/service_unsupported.go
+++ b/cmd/containerd/command/service_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/cmd/ctr/app/main_unix.go
+++ b/cmd/ctr/app/main_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/cmd/ctr/commands/commands_unix.go
+++ b/cmd/ctr/commands/commands_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/cmd/ctr/commands/namespaces/namespaces_other.go
+++ b/cmd/ctr/commands/namespaces/namespaces_other.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 /*

--- a/cmd/ctr/commands/pprof/pprof_unix.go
+++ b/cmd/ctr/commands/pprof/pprof_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/cmd/ctr/commands/shim/io_unix.go
+++ b/cmd/ctr/commands/shim/io_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/cmd/ctr/commands/shim/shim.go
+++ b/cmd/ctr/commands/shim/shim.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/cmd/ctr/commands/signals_notlinux.go
+++ b/cmd/ctr/commands/signals_notlinux.go
@@ -1,4 +1,5 @@
-//+build !linux
+//go:build !linux
+// +build !linux
 
 /*
    Copyright The containerd Authors.

--- a/cmd/ctr/commands/tasks/metrics.go
+++ b/cmd/ctr/commands/tasks/metrics.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/cmd/ctr/commands/tasks/tasks_unix.go
+++ b/cmd/ctr/commands/tasks/tasks_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/container_opts_unix.go
+++ b/container_opts_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/content/local/store_bsd.go
+++ b/content/local/store_bsd.go
@@ -1,3 +1,4 @@
+//go:build darwin || freebsd || netbsd
 // +build darwin freebsd netbsd
 
 /*

--- a/content/local/store_openbsd.go
+++ b/content/local/store_openbsd.go
@@ -1,3 +1,4 @@
+//go:build openbsd
 // +build openbsd
 
 /*

--- a/content/local/store_unix.go
+++ b/content/local/store_unix.go
@@ -1,3 +1,4 @@
+//go:build linux || solaris
 // +build linux solaris
 
 /*

--- a/contrib/apparmor/apparmor.go
+++ b/contrib/apparmor/apparmor.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/contrib/apparmor/apparmor_test.go
+++ b/contrib/apparmor/apparmor_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/contrib/apparmor/apparmor_unsupported.go
+++ b/contrib/apparmor/apparmor_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 /*

--- a/contrib/apparmor/template.go
+++ b/contrib/apparmor/template.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/contrib/apparmor/template_test.go
+++ b/contrib/apparmor/template_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package apparmor

--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/contrib/seccomp/seccomp_default_unsupported.go
+++ b/contrib/seccomp/seccomp_default_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 /*

--- a/defaults/defaults_unix.go
+++ b/defaults/defaults_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows && !darwin
 // +build !windows,!darwin
 
 /*

--- a/diff/apply/apply_other.go
+++ b/diff/apply/apply_other.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 /*

--- a/diff/stream_unix.go
+++ b/diff/stream_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/integration/addition_gids_test.go
+++ b/integration/addition_gids_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/integration/container_update_resources_test.go
+++ b/integration/container_update_resources_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/integration/remote/util/util_unix.go
+++ b/integration/remote/util/util_unix.go
@@ -1,3 +1,4 @@
+//go:build freebsd || linux || darwin
 // +build freebsd linux darwin
 
 /*

--- a/integration/remote/util/util_unsupported.go
+++ b/integration/remote/util/util_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !freebsd && !linux && !windows && !darwin
 // +build !freebsd,!linux,!windows,!darwin
 
 /*

--- a/integration/runtime_handler_test.go
+++ b/integration/runtime_handler_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/integration/sandbox_clean_remove_test.go
+++ b/integration/sandbox_clean_remove_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/integration/util/boottime_util_linux.go
+++ b/integration/util/boottime_util_linux.go
@@ -1,3 +1,4 @@
+//go:build freebsd || linux
 // +build freebsd linux
 
 /*

--- a/integration/util/util_unix.go
+++ b/integration/util/util_unix.go
@@ -1,3 +1,4 @@
+//go:build freebsd || linux || darwin
 // +build freebsd linux darwin
 
 /*

--- a/integration/util/util_unsupported.go
+++ b/integration/util/util_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !freebsd && !linux && !windows && !darwin
 // +build !freebsd,!linux,!windows,!darwin
 
 /*

--- a/metrics/cgroups/cgroups.go
+++ b/metrics/cgroups/cgroups.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/metrics/cgroups/v1/blkio.go
+++ b/metrics/cgroups/v1/blkio.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/metrics/cgroups/v1/cgroups.go
+++ b/metrics/cgroups/v1/cgroups.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/metrics/cgroups/v1/cpu.go
+++ b/metrics/cgroups/v1/cpu.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/metrics/cgroups/v1/hugetlb.go
+++ b/metrics/cgroups/v1/hugetlb.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/metrics/cgroups/v1/memory.go
+++ b/metrics/cgroups/v1/memory.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/metrics/cgroups/v1/metric.go
+++ b/metrics/cgroups/v1/metric.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/metrics/cgroups/v1/metrics.go
+++ b/metrics/cgroups/v1/metrics.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/metrics/cgroups/v1/oom.go
+++ b/metrics/cgroups/v1/oom.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/metrics/cgroups/v1/pids.go
+++ b/metrics/cgroups/v1/pids.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/metrics/cgroups/v2/cgroups.go
+++ b/metrics/cgroups/v2/cgroups.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/metrics/cgroups/v2/cpu.go
+++ b/metrics/cgroups/v2/cpu.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/metrics/cgroups/v2/io.go
+++ b/metrics/cgroups/v2/io.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/metrics/cgroups/v2/memory.go
+++ b/metrics/cgroups/v2/memory.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/metrics/cgroups/v2/metric.go
+++ b/metrics/cgroups/v2/metric.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/metrics/cgroups/v2/metrics.go
+++ b/metrics/cgroups/v2/metrics.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/metrics/cgroups/v2/pids.go
+++ b/metrics/cgroups/v2/pids.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/metrics/types/v1/types.go
+++ b/metrics/types/v1/types.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/metrics/types/v2/types.go
+++ b/metrics/types/v2/types.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/mount/lookup_unix.go
+++ b/mount/lookup_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/mount/lookup_unsupported.go
+++ b/mount/lookup_unsupported.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*

--- a/mount/mount_unix.go
+++ b/mount/mount_unix.go
@@ -1,3 +1,4 @@
+//go:build darwin || openbsd
 // +build darwin openbsd
 
 /*

--- a/mount/temp_unix.go
+++ b/mount/temp_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows && !darwin
 // +build !windows,!darwin
 
 /*

--- a/mount/temp_unsupported.go
+++ b/mount/temp_unsupported.go
@@ -1,3 +1,4 @@
+//go:build windows || darwin
 // +build windows darwin
 
 /*

--- a/oci/mounts.go
+++ b/oci/mounts.go
@@ -1,3 +1,4 @@
+//go:build !freebsd
 // +build !freebsd
 
 /*

--- a/oci/spec_opts_nonlinux.go
+++ b/oci/spec_opts_nonlinux.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 /*

--- a/oci/spec_opts_unix.go
+++ b/oci/spec_opts_unix.go
@@ -1,3 +1,4 @@
+//go:build !linux && !windows
 // +build !linux,!windows
 
 /*

--- a/oci/spec_opts_unix_test.go
+++ b/oci/spec_opts_unix_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/oci/utils_unix.go
+++ b/oci/utils_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/apparmor/apparmor_unsupported.go
+++ b/pkg/apparmor/apparmor_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 /*

--- a/pkg/cri/config/config_unix.go
+++ b/pkg/cri/config/config_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/cri/io/helpers_unix.go
+++ b/pkg/cri/io/helpers_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/cri/server/bandwidth/linux.go
+++ b/pkg/cri/server/bandwidth/linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/pkg/cri/server/bandwidth/unsupported.go
+++ b/pkg/cri/server/bandwidth/unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 /*

--- a/pkg/cri/server/container_create_other.go
+++ b/pkg/cri/server/container_create_other.go
@@ -1,3 +1,4 @@
+//go:build !windows && !linux
 // +build !windows,!linux
 
 /*

--- a/pkg/cri/server/container_create_other_test.go
+++ b/pkg/cri/server/container_create_other_test.go
@@ -1,3 +1,4 @@
+//go:build !windows && !linux
 // +build !windows,!linux
 
 /*

--- a/pkg/cri/server/container_stats_list_other.go
+++ b/pkg/cri/server/container_stats_list_other.go
@@ -1,3 +1,4 @@
+//go:build !windows && !linux
 // +build !windows,!linux
 
 /*

--- a/pkg/cri/server/container_update_resources_other.go
+++ b/pkg/cri/server/container_update_resources_other.go
@@ -1,3 +1,4 @@
+//go:build !windows && !linux
 // +build !windows,!linux
 
 /*

--- a/pkg/cri/server/helpers_other.go
+++ b/pkg/cri/server/helpers_other.go
@@ -1,3 +1,4 @@
+//go:build !windows && !linux
 // +build !windows,!linux
 
 /*

--- a/pkg/cri/server/sandbox_portforward_other.go
+++ b/pkg/cri/server/sandbox_portforward_other.go
@@ -1,3 +1,4 @@
+//go:build !windows && !linux
 // +build !windows,!linux
 
 /*

--- a/pkg/cri/server/sandbox_run_other.go
+++ b/pkg/cri/server/sandbox_run_other.go
@@ -1,3 +1,4 @@
+//go:build !windows && !linux
 // +build !windows,!linux
 
 /*

--- a/pkg/cri/server/sandbox_run_other_test.go
+++ b/pkg/cri/server/sandbox_run_other_test.go
@@ -1,3 +1,4 @@
+//go:build !windows && !linux
 // +build !windows,!linux
 
 /*

--- a/pkg/cri/server/service_other.go
+++ b/pkg/cri/server/service_other.go
@@ -1,3 +1,4 @@
+//go:build !windows && !linux
 // +build !windows,!linux
 
 /*

--- a/pkg/dialer/dialer_unix.go
+++ b/pkg/dialer/dialer_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/netns/netns_other.go
+++ b/pkg/netns/netns_other.go
@@ -1,3 +1,4 @@
+//go:build !windows && !linux
 // +build !windows,!linux
 
 /*

--- a/pkg/oom/oom.go
+++ b/pkg/oom/oom.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/pkg/oom/v1/v1.go
+++ b/pkg/oom/v1/v1.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/pkg/oom/v2/v2.go
+++ b/pkg/oom/v2/v2.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/pkg/os/mount_other.go
+++ b/pkg/os/mount_other.go
@@ -1,3 +1,4 @@
+//go:build !windows && !linux
 // +build !windows,!linux
 
 /*

--- a/pkg/os/mount_unix.go
+++ b/pkg/os/mount_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows && !linux
 // +build !windows,!linux
 
 /*

--- a/pkg/os/os_unix.go
+++ b/pkg/os/os_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/os/testing/fake_os_unix.go
+++ b/pkg/os/testing/fake_os_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/process/deleted_state.go
+++ b/pkg/process/deleted_state.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/process/exec.go
+++ b/pkg/process/exec.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/process/exec_state.go
+++ b/pkg/process/exec_state.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/process/init.go
+++ b/pkg/process/init.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/process/init_state.go
+++ b/pkg/process/init_state.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/process/io.go
+++ b/pkg/process/io.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/process/io_test.go
+++ b/pkg/process/io_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/pkg/process/utils.go
+++ b/pkg/process/utils.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/seccomp/seccomp_unsupported.go
+++ b/pkg/seccomp/seccomp_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 /*

--- a/pkg/seed/seed_other.go
+++ b/pkg/seed/seed_other.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 /*

--- a/pkg/testutil/helpers_unix.go
+++ b/pkg/testutil/helpers_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/testutil/mount_other.go
+++ b/pkg/testutil/mount_other.go
@@ -1,3 +1,4 @@
+//go:build !linux && !windows
 // +build !linux,!windows
 
 /*

--- a/pkg/userns/userns_unsupported.go
+++ b/pkg/userns/userns_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 /*

--- a/platforms/defaults_unix.go
+++ b/platforms/defaults_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/plugin/plugin_go18.go
+++ b/plugin/plugin_go18.go
@@ -1,3 +1,4 @@
+//go:build go1.8 && !windows && amd64 && !static_build && !gccgo
 // +build go1.8,!windows,amd64,!static_build,!gccgo
 
 /*

--- a/plugin/plugin_other.go
+++ b/plugin/plugin_other.go
@@ -1,3 +1,4 @@
+//go:build !go1.8 || windows || !amd64 || static_build || gccgo
 // +build !go1.8 windows !amd64 static_build gccgo
 
 /*

--- a/remotes/docker/config/config_unix.go
+++ b/remotes/docker/config/config_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/rootfs/init_other.go
+++ b/rootfs/init_other.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 /*

--- a/runtime/v1/linux/bundle.go
+++ b/runtime/v1/linux/bundle.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/runtime/v1/linux/process.go
+++ b/runtime/v1/linux/process.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/runtime/v1/linux/runtime.go
+++ b/runtime/v1/linux/runtime.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/runtime/v1/linux/task.go
+++ b/runtime/v1/linux/task.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/runtime/v1/shim.go
+++ b/runtime/v1/shim.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/runtime/v1/shim/client/client.go
+++ b/runtime/v1/shim/client/client.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/runtime/v1/shim/client/client_unix.go
+++ b/runtime/v1/shim/client/client_unix.go
@@ -1,3 +1,4 @@
+//go:build !linux && !windows
 // +build !linux,!windows
 
 /*

--- a/runtime/v1/shim/local.go
+++ b/runtime/v1/shim/local.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/runtime/v1/shim/service.go
+++ b/runtime/v1/shim/service.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/runtime/v1/shim/service_unix.go
+++ b/runtime/v1/shim/service_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows && !linux
 // +build !windows,!linux
 
 /*

--- a/runtime/v2/example/cmd/main.go
+++ b/runtime/v2/example/cmd/main.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/runtime/v2/example/example.go
+++ b/runtime/v2/example/example.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/runtime/v2/logging/logging_unix.go
+++ b/runtime/v2/logging/logging_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/runtime/v2/manager_unix.go
+++ b/runtime/v2/manager_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/runtime/v2/runc/container.go
+++ b/runtime/v2/runc/container.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/runtime/v2/runc/platform.go
+++ b/runtime/v2/runc/platform.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/runtime/v2/runc/util.go
+++ b/runtime/v2/runc/util.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/runtime/v2/runc/v1/service.go
+++ b/runtime/v2/runc/v1/service.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/runtime/v2/runc/v2/service.go
+++ b/runtime/v2/runc/v2/service.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/runtime/v2/shim/shim_unix.go
+++ b/runtime/v2/shim/shim_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/runtime/v2/shim/util_unix.go
+++ b/runtime/v2/shim/util_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/runtime/v2/shim_unix.go
+++ b/runtime/v2/shim_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/runtime/v2/shim_unix_test.go
+++ b/runtime/v2/shim_unix_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/services/diff/service_unix.go
+++ b/services/diff/service_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/services/opt/path_unix.go
+++ b/services/opt/path_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/services/server/server_unsupported.go
+++ b/services/server/server_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux && !windows && !solaris
 // +build !linux,!windows,!solaris
 
 /*

--- a/services/tasks/local_unix.go
+++ b/services/tasks/local_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows && !freebsd
 // +build !windows,!freebsd
 
 /*

--- a/snapshots/benchsuite/benchmark.go
+++ b/snapshots/benchsuite/benchmark.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/snapshots/benchsuite/benchmark_test.go
+++ b/snapshots/benchsuite/benchmark_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/snapshots/btrfs/btrfs.go
+++ b/snapshots/btrfs/btrfs.go
@@ -1,3 +1,4 @@
+//go:build linux && !no_btrfs && cgo
 // +build linux,!no_btrfs,cgo
 
 /*

--- a/snapshots/btrfs/btrfs_test.go
+++ b/snapshots/btrfs/btrfs_test.go
@@ -1,3 +1,4 @@
+//go:build linux && !no_btrfs && cgo
 // +build linux,!no_btrfs,cgo
 
 /*

--- a/snapshots/btrfs/plugin/plugin.go
+++ b/snapshots/btrfs/plugin/plugin.go
@@ -1,3 +1,4 @@
+//go:build linux && !no_btrfs && cgo
 // +build linux,!no_btrfs,cgo
 
 /*

--- a/snapshots/devmapper/blkdiscard/blkdiscard.go
+++ b/snapshots/devmapper/blkdiscard/blkdiscard.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/snapshots/devmapper/config.go
+++ b/snapshots/devmapper/config.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/snapshots/devmapper/config_test.go
+++ b/snapshots/devmapper/config_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/snapshots/devmapper/device_info.go
+++ b/snapshots/devmapper/device_info.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/snapshots/devmapper/dmsetup/dmsetup.go
+++ b/snapshots/devmapper/dmsetup/dmsetup.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/snapshots/devmapper/dmsetup/dmsetup_test.go
+++ b/snapshots/devmapper/dmsetup/dmsetup_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/snapshots/devmapper/metadata.go
+++ b/snapshots/devmapper/metadata.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/snapshots/devmapper/metadata_test.go
+++ b/snapshots/devmapper/metadata_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/snapshots/devmapper/plugin/plugin.go
+++ b/snapshots/devmapper/plugin/plugin.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/snapshots/devmapper/pool_device.go
+++ b/snapshots/devmapper/pool_device.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/snapshots/devmapper/pool_device_test.go
+++ b/snapshots/devmapper/pool_device_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/snapshots/devmapper/snapshotter.go
+++ b/snapshots/devmapper/snapshotter.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/snapshots/devmapper/snapshotter_test.go
+++ b/snapshots/devmapper/snapshotter_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/snapshots/native/native_default.go
+++ b/snapshots/native/native_default.go
@@ -1,3 +1,4 @@
+//go:build !freebsd
 // +build !freebsd
 
 /*

--- a/snapshots/overlay/overlay.go
+++ b/snapshots/overlay/overlay.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/snapshots/overlay/overlay_test.go
+++ b/snapshots/overlay/overlay_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/snapshots/overlay/overlayutils/check.go
+++ b/snapshots/overlay/overlayutils/check.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/snapshots/overlay/overlayutils/check_test.go
+++ b/snapshots/overlay/overlayutils/check_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/snapshots/overlay/plugin/plugin.go
+++ b/snapshots/overlay/plugin/plugin.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/snapshots/testsuite/helpers_other.go
+++ b/snapshots/testsuite/helpers_other.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 /*

--- a/snapshots/testsuite/testsuite_unix.go
+++ b/snapshots/testsuite/testsuite_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/snapshotter_default_unix.go
+++ b/snapshotter_default_unix.go
@@ -1,3 +1,4 @@
+//go:build darwin || freebsd || solaris
 // +build darwin freebsd solaris
 
 /*

--- a/snapshotter_opts_unix.go
+++ b/snapshotter_opts_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/sys/epoll.go
+++ b/sys/epoll.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/sys/fds.go
+++ b/sys/fds.go
@@ -1,3 +1,4 @@
+//go:build !windows && !darwin
 // +build !windows,!darwin
 
 /*

--- a/sys/filesys_unix.go
+++ b/sys/filesys_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/sys/oom_unsupported.go
+++ b/sys/oom_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 /*

--- a/sys/reaper/reaper_unix.go
+++ b/sys/reaper/reaper_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/sys/socket_unix.go
+++ b/sys/socket_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/task_opts_unix.go
+++ b/task_opts_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*


### PR DESCRIPTION
The new `go fmt` adds `//go:build` lines (https://golang.org/doc/go1.17#tools).
