### PR TITLE
windows: The DefaultSpec platform should match the Default matcher

### DIFF
--- a/platforms/defaults.go
+++ b/platforms/defaults.go
@@ -16,25 +16,9 @@
 
 package platforms
 
-import (
-	"runtime"
-
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
-)
-
 // DefaultString returns the default string specifier for the platform.
 func DefaultString() string {
 	return Format(DefaultSpec())
-}
-
-// DefaultSpec returns the current platform's default platform specification.
-func DefaultSpec() specs.Platform {
-	return specs.Platform{
-		OS:           runtime.GOOS,
-		Architecture: runtime.GOARCH,
-		// The Variant field will be empty if arch != ARM.
-		Variant: cpuVariant(),
-	}
 }
 
 // DefaultStrict returns strict form of Default.

--- a/platforms/defaults_unix.go
+++ b/platforms/defaults_unix.go
@@ -19,6 +19,22 @@
 
 package platforms
 
+import (
+	"runtime"
+
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// DefaultSpec returns the current platform's default platform specification.
+func DefaultSpec() specs.Platform {
+	return specs.Platform{
+		OS:           runtime.GOOS,
+		Architecture: runtime.GOARCH,
+		// The Variant field will be empty if arch != ARM.
+		Variant: cpuVariant(),
+	}
+}
+
 // Default returns the default matcher for the platform.
 func Default() MatchComparer {
 	return Only(DefaultSpec())

--- a/platforms/defaults_unix_test.go
+++ b/platforms/defaults_unix_test.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 /*
    Copyright The containerd Authors.
 

--- a/platforms/defaults_windows.go
+++ b/platforms/defaults_windows.go
@@ -27,6 +27,18 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// DefaultSpec returns the current platform's default platform specification.
+func DefaultSpec() specs.Platform {
+	major, minor, build := windows.RtlGetNtVersionNumbers()
+	return specs.Platform{
+		OS:           runtime.GOOS,
+		Architecture: runtime.GOARCH,
+		OSVersion:    fmt.Sprintf("%d.%d.%d", major, minor, build),
+		// The Variant field will be empty if arch != ARM.
+		Variant: cpuVariant(),
+	}
+}
+
 type matchComparer struct {
 	defaults        Matcher
 	osVersionPrefix string

--- a/platforms/defaults_windows_test.go
+++ b/platforms/defaults_windows_test.go
@@ -17,12 +17,35 @@
 package platforms
 
 import (
+	"fmt"
+	"reflect"
+	"runtime"
 	"sort"
 	"testing"
 
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/windows"
 )
+
+func TestDefault(t *testing.T) {
+	major, minor, build := windows.RtlGetNtVersionNumbers()
+	expected := imagespec.Platform{
+		OS:           runtime.GOOS,
+		Architecture: runtime.GOARCH,
+		OSVersion:    fmt.Sprintf("%d.%d.%d", major, minor, build),
+		Variant:      cpuVariant(),
+	}
+	p := DefaultSpec()
+	if !reflect.DeepEqual(p, expected) {
+		t.Fatalf("default platform not as expected: %#v != %#v", p, expected)
+	}
+
+	s := DefaultString()
+	if s != Format(p) {
+		t.Fatalf("default specifier should match formatted default spec: %v != %v", s, p)
+	}
+}
 
 func TestMatchComparerMatch(t *testing.T) {
 	m := matchComparer{
@@ -36,6 +59,10 @@ func TestMatchComparerMatch(t *testing.T) {
 		platform imagespec.Platform
 		match    bool
 	}{
+		{
+			platform: DefaultSpec(),
+			match:    true,
+		},
 		{
 			platform: imagespec.Platform{
 				Architecture: "amd64",


### PR DESCRIPTION
The Windows Default matcher also checks the the OS Version prefix, however, the platforms.DefaultSpec does not include it, which means that it won't match the matcher.

This solves the issue by adding the OS Version to the DefaultSpec.