### PR TITLE
Decouple task manager

### DIFF
--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -41,7 +41,10 @@ import (
 	"github.com/containerd/containerd/runtime/linux/runctypes"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/containerd/containerd/sys"
+	"github.com/containerd/typeurl"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
 	exec "golang.org/x/sys/execabs"
 	"golang.org/x/sys/unix"
 )
@@ -430,7 +433,7 @@ func getLogDirPath(runtimeVersion, id string) string {
 	case "v1":
 		return filepath.Join(defaultRoot, plugin.RuntimeLinuxV1, testNamespace, id)
 	case "v2":
-		return filepath.Join(defaultState, "io.containerd.runtime.v2.task", testNamespace, id)
+		return filepath.Join(defaultState, "io.containerd.runtime.v2.shim", testNamespace, id)
 	default:
 		panic(fmt.Errorf("Unsupported runtime version %s", runtimeVersion))
 	}

--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -433,7 +433,7 @@ func getLogDirPath(runtimeVersion, id string) string {
 	case "v1":
 		return filepath.Join(defaultRoot, plugin.RuntimeLinuxV1, testNamespace, id)
 	case "v2":
-		return filepath.Join(defaultState, "io.containerd.runtime.v2.shim", testNamespace, id)
+		return filepath.Join(defaultState, "io.containerd.runtime.v2.task", testNamespace, id)
 	default:
 		panic(fmt.Errorf("Unsupported runtime version %s", runtimeVersion))
 	}

--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -433,7 +433,7 @@ func getLogDirPath(runtimeVersion, id string) string {
 	case "v1":
 		return filepath.Join(defaultRoot, plugin.RuntimeLinuxV1, testNamespace, id)
 	case "v2":
-		return filepath.Join(defaultState, "io.containerd.runtime.v2.task", testNamespace, id)
+		return filepath.Join(defaultState, "io.containerd.runtime-shim.v2.shim", testNamespace, id)
 	default:
 		panic(fmt.Errorf("Unsupported runtime version %s", runtimeVersion))
 	}

--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -41,10 +41,7 @@ import (
 	"github.com/containerd/containerd/runtime/linux/runctypes"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/containerd/containerd/sys"
-	"github.com/containerd/typeurl"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 	exec "golang.org/x/sys/execabs"
 	"golang.org/x/sys/unix"
 )

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -57,6 +57,8 @@ const (
 	RuntimePlugin Type = "io.containerd.runtime.v1"
 	// RuntimePluginV2 implements a runtime v2
 	RuntimePluginV2 Type = "io.containerd.runtime.v2"
+	// RuntimePluginV2Service is a shim provided service implemented on top of runtime v2 plugins.
+	RuntimePluginV2Service Type = "io.containerd.runtime.v2.service"
 	// ServicePlugin implements a internal service
 	ServicePlugin Type = "io.containerd.service.v1"
 	// GRPCPlugin implements a grpc service

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -57,8 +57,8 @@ const (
 	RuntimePlugin Type = "io.containerd.runtime.v1"
 	// RuntimePluginV2 implements a runtime v2
 	RuntimePluginV2 Type = "io.containerd.runtime.v2"
-	// RuntimePluginV2Service is a shim provided service implemented on top of runtime v2 plugins.
-	RuntimePluginV2Service Type = "io.containerd.runtime.v2.service"
+	// RuntimeShimPlugin implements the shim manager for runtime v2.
+	RuntimeShimPlugin Type = "io.containerd.runtime-shim.v2"
 	// ServicePlugin implements a internal service
 	ServicePlugin Type = "io.containerd.service.v1"
 	// GRPCPlugin implements a grpc service

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -69,8 +69,6 @@ type PlatformRuntime interface {
 	// Tasks returns all the current tasks for the runtime.
 	// Any container runs at most one task at a time.
 	Tasks(ctx context.Context, all bool) ([]Task, error)
-	// Add adds a task into runtime.
-	Add(ctx context.Context, task Task) error
 	// Delete remove a task.
 	Delete(ctx context.Context, taskID string) (*Exit, error)
 }

--- a/runtime/task_list.go
+++ b/runtime/task_list.go
@@ -128,3 +128,16 @@ func (l *TaskList) Delete(ctx context.Context, id string) {
 		delete(tasks, id)
 	}
 }
+
+func (l *TaskList) IsEmpty() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	for ns := range l.tasks {
+		if len(l.tasks[ns]) > 0 {
+			return false
+		}
+	}
+
+	return true
+}

--- a/runtime/v2/binary.go
+++ b/runtime/v2/binary.go
@@ -60,7 +60,7 @@ type binary struct {
 	bundle                 *Bundle
 }
 
-func (b *binary) Start(ctx context.Context, opts *types.Any, onClose func()) (_ *shimTask, err error) {
+func (b *binary) Start(ctx context.Context, opts *types.Any, onClose func()) (_ *shim, err error) {
 	args := []string{"-id", b.bundle.ID}
 	switch logrus.GetLevel() {
 	case logrus.DebugLevel, logrus.TraceLevel:
@@ -128,12 +128,9 @@ func (b *binary) Start(ctx context.Context, opts *types.Any, onClose func()) (_ 
 		f.Close()
 	}
 	client := ttrpc.NewClient(conn, ttrpc.WithOnClose(onCloseWithShimLog))
-	return &shimTask{
-		shim: &shim{
-			bundle: b.bundle,
-			client: client,
-		},
-		task: task.NewTaskClient(client),
+	return &shim{
+		bundle: b.bundle,
+		client: client,
 	}, nil
 }
 

--- a/runtime/v2/binary.go
+++ b/runtime/v2/binary.go
@@ -60,7 +60,7 @@ type binary struct {
 	bundle                 *Bundle
 }
 
-func (b *binary) Start(ctx context.Context, opts *types.Any, onClose func()) (_ *shim, err error) {
+func (b *binary) Start(ctx context.Context, opts *types.Any, onClose func()) (_ *shimTask, err error) {
 	args := []string{"-id", b.bundle.ID}
 	switch logrus.GetLevel() {
 	case logrus.DebugLevel, logrus.TraceLevel:
@@ -128,10 +128,12 @@ func (b *binary) Start(ctx context.Context, opts *types.Any, onClose func()) (_ 
 		f.Close()
 	}
 	client := ttrpc.NewClient(conn, ttrpc.WithOnClose(onCloseWithShimLog))
-	return &shim{
-		bundle: b.bundle,
-		client: client,
-		task:   task.NewTaskClient(client),
+	return &shimTask{
+		shim: &shim{
+			bundle: b.bundle,
+			client: client,
+		},
+		task: task.NewTaskClient(client),
 	}, nil
 }
 

--- a/runtime/v2/manager.go
+++ b/runtime/v2/manager.go
@@ -166,6 +166,7 @@ func NewShimManager(ctx context.Context, config *ManagerConfig) (*ShimManager, e
 		list:                   runtime.NewTaskList(),
 		events:                 config.Events,
 		containers:             config.Store,
+		schedCore:              config.SchedCore,
 	}
 
 	if err := m.loadExistingTasks(ctx); err != nil {

--- a/runtime/v2/manager.go
+++ b/runtime/v2/manager.go
@@ -95,8 +95,11 @@ func init() {
 	})
 
 	plugin.Register(&plugin.Registration{
-		Type: plugin.RuntimePluginV2,
+		Type: plugin.RuntimePluginV2Service,
 		ID:   "task",
+		Requires: []plugin.Type{
+			plugin.RuntimePluginV2,
+		},
 		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
 			shimInstance, err := ic.GetByID(plugin.RuntimePluginV2, "shim")
 			if err != nil {
@@ -417,7 +420,7 @@ func NewTaskManager(shims *ShimManager) *TaskManager {
 
 // ID of the task manager
 func (m *TaskManager) ID() string {
-	return fmt.Sprintf("%s.%s", plugin.RuntimePluginV2, "task")
+	return fmt.Sprintf("%s.%s", plugin.RuntimePluginV2Service, "task")
 }
 
 // Create launches new shim instance and creates new task

--- a/runtime/v2/process.go
+++ b/runtime/v2/process.go
@@ -29,7 +29,7 @@ import (
 
 type process struct {
 	id   string
-	shim *shim
+	shim *shimTask
 }
 
 func (p *process) ID() string {

--- a/runtime/v2/shim.go
+++ b/runtime/v2/shim.go
@@ -186,6 +186,16 @@ func cleanupAfterDeadShim(ctx context.Context, id, ns string, rt *runtime.TaskLi
 	})
 }
 
+// ShimProcess represents a shim instance managed by the shim service.
+type ShimProcess interface {
+	runtime.Process
+
+	// ID of the shim.
+	ID() string
+	// Namespace of this shim.
+	Namespace() string
+}
+
 type shim struct {
 	bundle *Bundle
 	client *ttrpc.Client

--- a/runtime/v2/shim.go
+++ b/runtime/v2/shim.go
@@ -61,7 +61,7 @@ func loadAddress(path string) (string, error) {
 	return string(data), nil
 }
 
-func loadShim(ctx context.Context, bundle *Bundle, onClose func()) (_ *shim, err error) {
+func loadShim(ctx context.Context, bundle *Bundle, onClose func()) (_ *shimTask, err error) {
 	address, err := loadAddress(filepath.Join(bundle.Path, "address"))
 	if err != nil {
 		return nil, err
@@ -115,10 +115,12 @@ func loadShim(ctx context.Context, bundle *Bundle, onClose func()) (_ *shim, err
 			client.Close()
 		}
 	}()
-	s := &shim{
-		client: client,
-		task:   task.NewTaskClient(client),
-		bundle: bundle,
+	s := &shimTask{
+		shim: &shim{
+			bundle: bundle,
+			client: client,
+		},
+		task: task.NewTaskClient(client),
 	}
 	ctx, cancel := timeout.WithContext(ctx, loadTimeout)
 	defer cancel()
@@ -182,45 +184,14 @@ func cleanupAfterDeadShim(ctx context.Context, id, ns string, rt *runtime.TaskLi
 	})
 }
 
-var _ runtime.Task = &shim{}
-
 type shim struct {
 	bundle *Bundle
 	client *ttrpc.Client
-	task   task.TaskService
-}
-
-func (s *shim) Shutdown(ctx context.Context) error {
-	_, err := s.task.Shutdown(ctx, &task.ShutdownRequest{
-		ID: s.ID(),
-	})
-	if err != nil && !errors.Is(err, ttrpc.ErrClosed) {
-		return errdefs.FromGRPC(err)
-	}
-	return nil
-}
-
-func (s *shim) waitShutdown(ctx context.Context) error {
-	ctx, cancel := timeout.WithContext(ctx, shutdownTimeout)
-	defer cancel()
-	return s.Shutdown(ctx)
 }
 
 // ID of the shim/task
 func (s *shim) ID() string {
 	return s.bundle.ID
-}
-
-// PID of the task
-func (s *shim) PID(ctx context.Context) (uint32, error) {
-	response, err := s.task.Connect(ctx, &task.ConnectRequest{
-		ID: s.ID(),
-	})
-	if err != nil {
-		return 0, errdefs.FromGRPC(err)
-	}
-
-	return response.TaskPid, nil
 }
 
 func (s *shim) Namespace() string {
@@ -231,7 +202,43 @@ func (s *shim) Close() error {
 	return s.client.Close()
 }
 
-func (s *shim) delete(ctx context.Context, removeTask func(ctx context.Context, id string)) (*runtime.Exit, error) {
+var _ runtime.Task = &shimTask{}
+
+// shimTask wraps shim process and adds task service client for compatibility with existing shim manager.
+type shimTask struct {
+	*shim
+	task task.TaskService
+}
+
+func (s *shimTask) Shutdown(ctx context.Context) error {
+	_, err := s.task.Shutdown(ctx, &task.ShutdownRequest{
+		ID: s.ID(),
+	})
+	if err != nil && !errors.Is(err, ttrpc.ErrClosed) {
+		return errdefs.FromGRPC(err)
+	}
+	return nil
+}
+
+func (s *shimTask) waitShutdown(ctx context.Context) error {
+	ctx, cancel := timeout.WithContext(ctx, shutdownTimeout)
+	defer cancel()
+	return s.Shutdown(ctx)
+}
+
+// PID of the task
+func (s *shimTask) PID(ctx context.Context) (uint32, error) {
+	response, err := s.task.Connect(ctx, &task.ConnectRequest{
+		ID: s.ID(),
+	})
+	if err != nil {
+		return 0, errdefs.FromGRPC(err)
+	}
+
+	return response.TaskPid, nil
+}
+
+func (s *shimTask) delete(ctx context.Context, removeTask func(ctx context.Context, id string)) (*runtime.Exit, error) {
 	response, shimErr := s.task.Delete(ctx, &task.DeleteRequest{
 		ID: s.ID(),
 	})
@@ -281,7 +288,7 @@ func (s *shim) delete(ctx context.Context, removeTask func(ctx context.Context, 
 	}, nil
 }
 
-func (s *shim) Create(ctx context.Context, opts runtime.CreateOpts) (runtime.Task, error) {
+func (s *shimTask) Create(ctx context.Context, opts runtime.CreateOpts) (runtime.Task, error) {
 	topts := opts.TaskOptions
 	if topts == nil {
 		topts = opts.RuntimeOptions
@@ -312,7 +319,7 @@ func (s *shim) Create(ctx context.Context, opts runtime.CreateOpts) (runtime.Tas
 	return s, nil
 }
 
-func (s *shim) Pause(ctx context.Context) error {
+func (s *shimTask) Pause(ctx context.Context) error {
 	if _, err := s.task.Pause(ctx, &task.PauseRequest{
 		ID: s.ID(),
 	}); err != nil {
@@ -321,7 +328,7 @@ func (s *shim) Pause(ctx context.Context) error {
 	return nil
 }
 
-func (s *shim) Resume(ctx context.Context) error {
+func (s *shimTask) Resume(ctx context.Context) error {
 	if _, err := s.task.Resume(ctx, &task.ResumeRequest{
 		ID: s.ID(),
 	}); err != nil {
@@ -330,7 +337,7 @@ func (s *shim) Resume(ctx context.Context) error {
 	return nil
 }
 
-func (s *shim) Start(ctx context.Context) error {
+func (s *shimTask) Start(ctx context.Context) error {
 	_, err := s.task.Start(ctx, &task.StartRequest{
 		ID: s.ID(),
 	})
@@ -340,7 +347,7 @@ func (s *shim) Start(ctx context.Context) error {
 	return nil
 }
 
-func (s *shim) Kill(ctx context.Context, signal uint32, all bool) error {
+func (s *shimTask) Kill(ctx context.Context, signal uint32, all bool) error {
 	if _, err := s.task.Kill(ctx, &task.KillRequest{
 		ID:     s.ID(),
 		Signal: signal,
@@ -351,7 +358,7 @@ func (s *shim) Kill(ctx context.Context, signal uint32, all bool) error {
 	return nil
 }
 
-func (s *shim) Exec(ctx context.Context, id string, opts runtime.ExecOpts) (runtime.ExecProcess, error) {
+func (s *shimTask) Exec(ctx context.Context, id string, opts runtime.ExecOpts) (runtime.ExecProcess, error) {
 	if err := identifiers.Validate(id); err != nil {
 		return nil, errors.Wrapf(err, "invalid exec id %s", id)
 	}
@@ -373,7 +380,7 @@ func (s *shim) Exec(ctx context.Context, id string, opts runtime.ExecOpts) (runt
 	}, nil
 }
 
-func (s *shim) Pids(ctx context.Context) ([]runtime.ProcessInfo, error) {
+func (s *shimTask) Pids(ctx context.Context) ([]runtime.ProcessInfo, error) {
 	resp, err := s.task.Pids(ctx, &task.PidsRequest{
 		ID: s.ID(),
 	})
@@ -390,7 +397,7 @@ func (s *shim) Pids(ctx context.Context) ([]runtime.ProcessInfo, error) {
 	return processList, nil
 }
 
-func (s *shim) ResizePty(ctx context.Context, size runtime.ConsoleSize) error {
+func (s *shimTask) ResizePty(ctx context.Context, size runtime.ConsoleSize) error {
 	_, err := s.task.ResizePty(ctx, &task.ResizePtyRequest{
 		ID:     s.ID(),
 		Width:  size.Width,
@@ -402,7 +409,7 @@ func (s *shim) ResizePty(ctx context.Context, size runtime.ConsoleSize) error {
 	return nil
 }
 
-func (s *shim) CloseIO(ctx context.Context) error {
+func (s *shimTask) CloseIO(ctx context.Context) error {
 	_, err := s.task.CloseIO(ctx, &task.CloseIORequest{
 		ID:    s.ID(),
 		Stdin: true,
@@ -413,7 +420,7 @@ func (s *shim) CloseIO(ctx context.Context) error {
 	return nil
 }
 
-func (s *shim) Wait(ctx context.Context) (*runtime.Exit, error) {
+func (s *shimTask) Wait(ctx context.Context) (*runtime.Exit, error) {
 	taskPid, err := s.PID(ctx)
 	if err != nil {
 		return nil, err
@@ -431,7 +438,7 @@ func (s *shim) Wait(ctx context.Context) (*runtime.Exit, error) {
 	}, nil
 }
 
-func (s *shim) Checkpoint(ctx context.Context, path string, options *ptypes.Any) error {
+func (s *shimTask) Checkpoint(ctx context.Context, path string, options *ptypes.Any) error {
 	request := &task.CheckpointTaskRequest{
 		ID:      s.ID(),
 		Path:    path,
@@ -443,7 +450,7 @@ func (s *shim) Checkpoint(ctx context.Context, path string, options *ptypes.Any)
 	return nil
 }
 
-func (s *shim) Update(ctx context.Context, resources *ptypes.Any, annotations map[string]string) error {
+func (s *shimTask) Update(ctx context.Context, resources *ptypes.Any, annotations map[string]string) error {
 	if _, err := s.task.Update(ctx, &task.UpdateTaskRequest{
 		ID:          s.ID(),
 		Resources:   resources,
@@ -454,7 +461,7 @@ func (s *shim) Update(ctx context.Context, resources *ptypes.Any, annotations ma
 	return nil
 }
 
-func (s *shim) Stats(ctx context.Context) (*ptypes.Any, error) {
+func (s *shimTask) Stats(ctx context.Context) (*ptypes.Any, error) {
 	response, err := s.task.Stats(ctx, &task.StatsRequest{
 		ID: s.ID(),
 	})
@@ -464,7 +471,7 @@ func (s *shim) Stats(ctx context.Context) (*ptypes.Any, error) {
 	return response.Stats, nil
 }
 
-func (s *shim) Process(ctx context.Context, id string) (runtime.ExecProcess, error) {
+func (s *shimTask) Process(ctx context.Context, id string) (runtime.ExecProcess, error) {
 	p := &process{
 		id:   id,
 		shim: s,
@@ -475,7 +482,7 @@ func (s *shim) Process(ctx context.Context, id string) (runtime.ExecProcess, err
 	return p, nil
 }
 
-func (s *shim) State(ctx context.Context) (runtime.State, error) {
+func (s *shimTask) State(ctx context.Context) (runtime.State, error) {
 	response, err := s.task.State(ctx, &task.StateRequest{
 		ID: s.ID(),
 	})

--- a/runtime/v2/shim_load.go
+++ b/runtime/v2/shim_load.go
@@ -1,0 +1,151 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package v2
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/events/exchange"
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/plugin"
+	"github.com/containerd/containerd/runtime"
+)
+
+func loadExistingTasks(ic *plugin.InitContext, list *runtime.TaskList, events *exchange.Exchange, containers containers.Store) error {
+	var (
+		ctx                    = ic.Context
+		state                  = ic.State
+		root                   = ic.Root
+		containerdAddress      = ic.Address
+		containerdTTRPCAddress = ic.TTRPCAddress
+	)
+
+	nsDirs, err := os.ReadDir(state)
+	if err != nil {
+		return err
+	}
+	for _, nsd := range nsDirs {
+		if !nsd.IsDir() {
+			continue
+		}
+		ns := nsd.Name()
+		// skip hidden directories
+		if len(ns) > 0 && ns[0] == '.' {
+			continue
+		}
+		log.G(ctx).WithField("namespace", ns).Debug("loading tasks in namespace")
+		if err := loadShims(namespaces.WithNamespace(ctx, ns), state, list, events, containers, containerdAddress, containerdTTRPCAddress); err != nil {
+			log.G(ctx).WithField("namespace", ns).WithError(err).Error("loading tasks in namespace")
+			continue
+		}
+		if err := cleanupWorkDirs(namespaces.WithNamespace(ctx, ns), root, list); err != nil {
+			log.G(ctx).WithField("namespace", ns).WithError(err).Error("cleanup working directory in namespace")
+			continue
+		}
+	}
+
+	return nil
+}
+
+func loadShims(ctx context.Context, state string, list *runtime.TaskList, events *exchange.Exchange, containers containers.Store, containerdAddress string, containerdTTRPCAddress string) error {
+	ns, err := namespaces.NamespaceRequired(ctx)
+	if err != nil {
+		return err
+	}
+	shimDirs, err := os.ReadDir(filepath.Join(state, ns))
+	if err != nil {
+		return err
+	}
+	for _, sd := range shimDirs {
+		if !sd.IsDir() {
+			continue
+		}
+		id := sd.Name()
+		// skip hidden directories
+		if len(id) > 0 && id[0] == '.' {
+			continue
+		}
+		bundle, err := LoadBundle(ctx, state, id)
+		if err != nil {
+			// fine to return error here, it is a programmer error if the context
+			// does not have a namespace
+			return err
+		}
+		// fast path
+		bf, err := os.ReadDir(bundle.Path)
+		if err != nil {
+			bundle.Delete()
+			log.G(ctx).WithError(err).Errorf("fast path read bundle path for %s", bundle.Path)
+			continue
+		}
+		if len(bf) == 0 {
+			bundle.Delete()
+			continue
+		}
+		container, err := containers.Get(ctx, id)
+		if err != nil {
+			log.G(ctx).WithError(err).Errorf("loading container %s", id)
+			if err := mount.UnmountAll(filepath.Join(bundle.Path, "rootfs"), 0); err != nil {
+				log.G(ctx).WithError(err).Errorf("forceful unmount of rootfs %s", id)
+			}
+			bundle.Delete()
+			continue
+		}
+		binaryCall := shimBinary(bundle, container.Runtime.Name, containerdAddress, containerdTTRPCAddress)
+		shim, err := loadShim(ctx, bundle, func() {
+			log.G(ctx).WithField("id", id).Info("shim disconnected")
+
+			cleanupAfterDeadShim(context.Background(), id, ns, list, events, binaryCall)
+			// Remove self from the runtime task list.
+			list.Delete(ctx, id)
+		})
+		if err != nil {
+			cleanupAfterDeadShim(ctx, id, ns, list, events, binaryCall)
+			continue
+		}
+		list.Add(ctx, shim)
+	}
+	return nil
+}
+
+func cleanupWorkDirs(ctx context.Context, root string, list *runtime.TaskList) error {
+	ns, err := namespaces.NamespaceRequired(ctx)
+	if err != nil {
+		return err
+	}
+	dirs, err := os.ReadDir(filepath.Join(root, ns))
+	if err != nil {
+		return err
+	}
+	for _, d := range dirs {
+		// if the task was not loaded, cleanup and empty working directory
+		// this can happen on a reboot where /run for the bundle state is cleaned up
+		// but that persistent working dir is left
+		if _, err := list.Get(ctx, d.Name()); err != nil {
+			path := filepath.Join(root, ns, d.Name())
+			if err := os.RemoveAll(path); err != nil {
+				log.G(ctx).WithError(err).Errorf("cleanup working dir %s", path)
+			}
+		}
+	}
+	return nil
+}

--- a/runtime/v2/shim_load.go
+++ b/runtime/v2/shim_load.go
@@ -107,15 +107,15 @@ func (m *ShimManager) loadShims(ctx context.Context) error {
 		shim, err := loadShim(ctx, bundle, func() {
 			log.G(ctx).WithField("id", id).Info("shim disconnected")
 
-			cleanupAfterDeadShim(context.Background(), id, ns, m.list, m.events, binaryCall)
+			cleanupAfterDeadShim(context.Background(), id, ns, m.shims, m.events, binaryCall)
 			// Remove self from the runtime task list.
-			m.list.Delete(ctx, id)
+			m.shims.Delete(ctx, id)
 		})
 		if err != nil {
-			cleanupAfterDeadShim(ctx, id, ns, m.list, m.events, binaryCall)
+			cleanupAfterDeadShim(ctx, id, ns, m.shims, m.events, binaryCall)
 			continue
 		}
-		m.list.Add(ctx, shim)
+		m.shims.Add(ctx, shim)
 	}
 	return nil
 }
@@ -133,7 +133,7 @@ func (m *ShimManager) cleanupWorkDirs(ctx context.Context) error {
 		// if the task was not loaded, cleanup and empty working directory
 		// this can happen on a reboot where /run for the bundle state is cleaned up
 		// but that persistent working dir is left
-		if _, err := m.list.Get(ctx, d.Name()); err != nil {
+		if _, err := m.shims.Get(ctx, d.Name()); err != nil {
 			path := filepath.Join(m.root, ns, d.Name())
 			if err := os.RemoveAll(path); err != nil {
 				log.G(ctx).WithError(err).Errorf("cleanup working dir %s", path)

--- a/services/tasks/local.go
+++ b/services/tasks/local.go
@@ -81,7 +81,7 @@ func initFunc(ic *plugin.InitContext) (interface{}, error) {
 		return nil, err
 	}
 
-	v2r, err := ic.GetByID(plugin.RuntimePluginV2Service, "task")
+	v2r, err := ic.GetByID(plugin.RuntimePluginV2, "task")
 	if err != nil {
 		return nil, err
 	}

--- a/services/tasks/local.go
+++ b/services/tasks/local.go
@@ -81,7 +81,7 @@ func initFunc(ic *plugin.InitContext) (interface{}, error) {
 		return nil, err
 	}
 
-	v2r, err := ic.GetByID(plugin.RuntimePluginV2, "task")
+	v2r, err := ic.GetByID(plugin.RuntimePluginV2Service, "task")
 	if err != nil {
 		return nil, err
 	}

--- a/services/tasks/local.go
+++ b/services/tasks/local.go
@@ -111,7 +111,7 @@ func initFunc(ic *plugin.InitContext) (interface{}, error) {
 		store:      db.ContentStore(),
 		publisher:  ep.(events.Publisher),
 		monitor:    monitor.(runtime.TaskMonitor),
-		v2Runtime:  v2r.(*v2.TaskManager),
+		v2Runtime:  v2r.(*v2.ShimManager),
 	}
 	for _, r := range runtimes {
 		tasks, err := r.Tasks(ic.Context, true)
@@ -139,7 +139,7 @@ type local struct {
 	publisher  events.Publisher
 
 	monitor   runtime.TaskMonitor
-	v2Runtime *v2.TaskManager
+	v2Runtime *v2.ShimManager
 }
 
 func (l *local) Create(ctx context.Context, r *api.CreateTaskRequest, _ ...grpc.CallOption) (*api.CreateTaskResponse, error) {

--- a/services/tasks/local.go
+++ b/services/tasks/local.go
@@ -81,7 +81,7 @@ func initFunc(ic *plugin.InitContext) (interface{}, error) {
 		return nil, err
 	}
 
-	v2r, err := ic.Get(plugin.RuntimePluginV2)
+	v2r, err := ic.GetByID(plugin.RuntimePluginV2, "task")
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func initFunc(ic *plugin.InitContext) (interface{}, error) {
 		store:      db.ContentStore(),
 		publisher:  ep.(events.Publisher),
 		monitor:    monitor.(runtime.TaskMonitor),
-		v2Runtime:  v2r.(*v2.ShimManager),
+		v2Runtime:  v2r.(*v2.TaskManager),
 	}
 	for _, r := range runtimes {
 		tasks, err := r.Tasks(ic.Context, true)
@@ -139,7 +139,7 @@ type local struct {
 	publisher  events.Publisher
 
 	monitor   runtime.TaskMonitor
-	v2Runtime *v2.ShimManager
+	v2Runtime *v2.TaskManager
 }
 
 func (l *local) Create(ctx context.Context, r *api.CreateTaskRequest, _ ...grpc.CallOption) (*api.CreateTaskResponse, error) {

--- a/services/tasks/local_freebsd.go
+++ b/services/tasks/local_freebsd.go
@@ -24,6 +24,7 @@ import (
 var tasksServiceRequires = []plugin.Type{
 	plugin.EventPlugin,
 	plugin.RuntimePluginV2,
+	plugin.RuntimePluginV2Service,
 	plugin.MetadataPlugin,
 	plugin.TaskMonitorPlugin,
 }

--- a/services/tasks/local_freebsd.go
+++ b/services/tasks/local_freebsd.go
@@ -24,7 +24,7 @@ import (
 var tasksServiceRequires = []plugin.Type{
 	plugin.EventPlugin,
 	plugin.RuntimePluginV2,
-	plugin.RuntimePluginV2Service,
+	plugin.RuntimeShimPlugin,
 	plugin.MetadataPlugin,
 	plugin.TaskMonitorPlugin,
 }

--- a/services/tasks/local_unix.go
+++ b/services/tasks/local_unix.go
@@ -30,7 +30,7 @@ var tasksServiceRequires = []plugin.Type{
 	plugin.EventPlugin,
 	plugin.RuntimePlugin,
 	plugin.RuntimePluginV2,
-	plugin.RuntimePluginV2Service,
+	plugin.RuntimeShimPlugin,
 	plugin.MetadataPlugin,
 	plugin.TaskMonitorPlugin,
 }

--- a/services/tasks/local_unix.go
+++ b/services/tasks/local_unix.go
@@ -30,6 +30,7 @@ var tasksServiceRequires = []plugin.Type{
 	plugin.EventPlugin,
 	plugin.RuntimePlugin,
 	plugin.RuntimePluginV2,
+	plugin.RuntimePluginV2Service,
 	plugin.MetadataPlugin,
 	plugin.TaskMonitorPlugin,
 }

--- a/services/tasks/local_windows.go
+++ b/services/tasks/local_windows.go
@@ -24,6 +24,7 @@ import (
 var tasksServiceRequires = []plugin.Type{
 	plugin.EventPlugin,
 	plugin.RuntimePluginV2,
+	plugin.RuntimePluginV2Service,
 	plugin.MetadataPlugin,
 	plugin.TaskMonitorPlugin,
 }

--- a/services/tasks/local_windows.go
+++ b/services/tasks/local_windows.go
@@ -24,7 +24,7 @@ import (
 var tasksServiceRequires = []plugin.Type{
 	plugin.EventPlugin,
 	plugin.RuntimePluginV2,
-	plugin.RuntimePluginV2Service,
+	plugin.RuntimeShimPlugin,
 	plugin.MetadataPlugin,
 	plugin.TaskMonitorPlugin,
 }


### PR DESCRIPTION
This PR decouples shim v2 TaskManger into ShimManager + TaskManager.
ShimManager manages shim instances and implements Start/Delete with cleanup/Get funcs.
This can be exposed as separate containerd service to deal with shims from client (will follow up).
TaskManager works on top of shim manager and manages tasks to keep things compatible. 

ref: https://github.com/containerd/containerd/issues/5742
