### PR TITLE
[CRI] Use the pointer of Config in the criService

### DIFF
--- a/pkg/cri/cri.go
+++ b/pkg/cri/cri.go
@@ -98,7 +98,7 @@ func initCRIService(ic *plugin.InitContext) (interface{}, error) {
 		return nil, errors.Wrap(err, "failed to create containerd client")
 	}
 
-	s, err := server.NewCRIService(c, client)
+	s, err := server.NewCRIService(&c, client)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create CRI service")
 	}

--- a/pkg/cri/server/container_create_linux_test.go
+++ b/pkg/cri/server/container_create_linux_test.go
@@ -907,7 +907,9 @@ func TestGenerateSeccompSecurityProfileSpecOpts(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("TestCase %q", desc), func(t *testing.T) {
-			cri := &criService{}
+			cri := &criService{
+				config: &config.Config{},
+			}
 			cri.config.UnsetSeccompProfile = test.defaultProfile
 			ssp := test.sp
 			csp, err := generateSeccompSecurityProfile(

--- a/pkg/cri/server/helpers.go
+++ b/pkg/cri/server/helpers.go
@@ -321,7 +321,7 @@ func parseImageReferences(refs []string) ([]string, []string) {
 }
 
 // generateRuntimeOptions generates runtime options from cri plugin config.
-func generateRuntimeOptions(r criconfig.Runtime, c criconfig.Config) (interface{}, error) {
+func generateRuntimeOptions(r criconfig.Runtime, c *criconfig.Config) (interface{}, error) {
 	if r.Options == nil {
 		if r.Type != plugin.RuntimeLinuxV1 {
 			return nil, nil

--- a/pkg/cri/server/helpers_test.go
+++ b/pkg/cri/server/helpers_test.go
@@ -287,7 +287,7 @@ systemd_cgroup = true
 		},
 	} {
 		t.Run(desc, func(t *testing.T) {
-			opts, err := generateRuntimeOptions(test.r, test.c)
+			opts, err := generateRuntimeOptions(test.r, &test.c)
 			assert.NoError(t, err)
 			assert.Equal(t, test.expectedOptions, opts)
 		})

--- a/pkg/cri/server/sandbox_run_test.go
+++ b/pkg/cri/server/sandbox_run_test.go
@@ -492,7 +492,7 @@ func TestGetSandboxRuntime(t *testing.T) {
 	} {
 		t.Run(desc, func(t *testing.T) {
 			cri := newTestCRIService()
-			cri.config = criconfig.Config{
+			cri.config = &criconfig.Config{
 				PluginConfig: criconfig.DefaultConfig(),
 			}
 			cri.config.ContainerdConfig.DefaultRuntimeName = criconfig.RuntimeDefault

--- a/pkg/cri/server/service.go
+++ b/pkg/cri/server/service.go
@@ -72,7 +72,7 @@ type CRIService interface {
 // criService implements CRIService.
 type criService struct {
 	// config contains all configurations.
-	config criconfig.Config
+	config *criconfig.Config
 	// imageFSPath is the path to image filesystem.
 	imageFSPath string
 	// os is an interface for all required os operations.
@@ -113,7 +113,7 @@ type criService struct {
 }
 
 // NewCRIService returns a new instance of CRIService
-func NewCRIService(config criconfig.Config, client *containerd.Client) (CRIService, error) {
+func NewCRIService(config *criconfig.Config, client *containerd.Client) (CRIService, error) {
 	var err error
 	labels := label.NewStore()
 	c := &criService{
@@ -154,7 +154,7 @@ func NewCRIService(config criconfig.Config, client *containerd.Client) (CRIServi
 	}
 
 	// Preload base OCI specs
-	c.baseOCISpecs, err = loadBaseOCISpecs(&config)
+	c.baseOCISpecs, err = loadBaseOCISpecs(config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cri/server/service_test.go
+++ b/pkg/cri/server/service_test.go
@@ -51,7 +51,7 @@ const (
 func newTestCRIService() *criService {
 	labels := label.NewStore()
 	return &criService{
-		config: criconfig.Config{
+		config: &criconfig.Config{
 			RootDir:  testRootDir,
 			StateDir: testStateDir,
 			PluginConfig: criconfig.PluginConfig{

--- a/pkg/cri/server/streaming_test.go
+++ b/pkg/cri/server/streaming_test.go
@@ -31,7 +31,7 @@ func TestValidateStreamServer(t *testing.T) {
 	}{
 		"should pass with default withoutTLS": {
 			criService: &criService{
-				config: config.Config{
+				config: &config.Config{
 					PluginConfig: config.DefaultConfig(),
 				},
 			},
@@ -40,7 +40,7 @@ func TestValidateStreamServer(t *testing.T) {
 		},
 		"should pass with x509KeyPairTLS": {
 			criService: &criService{
-				config: config.Config{
+				config: &config.Config{
 					PluginConfig: config.PluginConfig{
 						EnableTLSStreaming: true,
 						X509KeyPairStreaming: config.X509KeyPairStreaming{
@@ -55,7 +55,7 @@ func TestValidateStreamServer(t *testing.T) {
 		},
 		"should pass with selfSign": {
 			criService: &criService{
-				config: config.Config{
+				config: &config.Config{
 					PluginConfig: config.PluginConfig{
 						EnableTLSStreaming: true,
 					},
@@ -66,7 +66,7 @@ func TestValidateStreamServer(t *testing.T) {
 		},
 		"should return error with X509 keypair but not EnableTLSStreaming": {
 			criService: &criService{
-				config: config.Config{
+				config: &config.Config{
 					PluginConfig: config.PluginConfig{
 						EnableTLSStreaming: false,
 						X509KeyPairStreaming: config.X509KeyPairStreaming{
@@ -81,7 +81,7 @@ func TestValidateStreamServer(t *testing.T) {
 		},
 		"should return error with X509 TLSCertFile empty": {
 			criService: &criService{
-				config: config.Config{
+				config: &config.Config{
 					PluginConfig: config.PluginConfig{
 						EnableTLSStreaming: true,
 						X509KeyPairStreaming: config.X509KeyPairStreaming{
@@ -96,7 +96,7 @@ func TestValidateStreamServer(t *testing.T) {
 		},
 		"should return error with X509 TLSKeyFile empty": {
 			criService: &criService{
-				config: config.Config{
+				config: &config.Config{
 					PluginConfig: config.PluginConfig{
 						EnableTLSStreaming: true,
 						X509KeyPairStreaming: config.X509KeyPairStreaming{
@@ -111,7 +111,7 @@ func TestValidateStreamServer(t *testing.T) {
 		},
 		"should return error without EnableTLSStreaming and only TLSCertFile set": {
 			criService: &criService{
-				config: config.Config{
+				config: &config.Config{
 					PluginConfig: config.PluginConfig{
 						EnableTLSStreaming: false,
 						X509KeyPairStreaming: config.X509KeyPairStreaming{
@@ -126,7 +126,7 @@ func TestValidateStreamServer(t *testing.T) {
 		},
 		"should return error without EnableTLSStreaming and only TLSKeyFile set": {
 			criService: &criService{
-				config: config.Config{
+				config: &config.Config{
 					PluginConfig: config.PluginConfig{
 						EnableTLSStreaming: false,
 						X509KeyPairStreaming: config.X509KeyPairStreaming{


### PR DESCRIPTION
Using pointers makes it easy to share Config between different types.
And reduce the copying of entire types.

Signed-off-by: wanglei <wllenyj@linux.alibaba.com>