### PR TITLE
import: Raise error if the imported image is filtered out

### DIFF
--- a/images/handlers.go
+++ b/images/handlers.go
@@ -40,6 +40,10 @@ var (
 	// This applies only to a single descriptor in a handler
 	// chain and does not apply to descendant descriptors.
 	ErrStopHandler = fmt.Errorf("stop handler")
+
+	// ErrEmptyWalk is used when the WalkNotEmpty handlers return no
+	// children (e.g.: they were filtered out).
+	ErrEmptyWalk = fmt.Errorf("image might be filtered out")
 )
 
 // Handler handles image manifests
@@ -98,6 +102,36 @@ func Walk(ctx context.Context, handler Handler, descs ...ocispec.Descriptor) err
 				return err
 			}
 		}
+	}
+	return nil
+}
+
+// WalkNotEmpty works the same way Walk does, with the exception that it ensures that
+// some children are still found by Walking the descriptors (for example, not all of
+// them have been filtered out by one of the handlers). If there are no children,
+// then an ErrEmptyWalk error is returned.
+func WalkNotEmpty(ctx context.Context, handler Handler, descs ...ocispec.Descriptor) error {
+	isEmpty := true
+	var notEmptyHandler HandlerFunc = func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		children, err := handler.Handle(ctx, desc)
+		if err != nil {
+			return children, err
+		}
+
+		if len(children) > 0 {
+			isEmpty = false
+		}
+
+		return children, nil
+	}
+
+	err := Walk(ctx, notEmptyHandler, descs...)
+	if err != nil {
+		return err
+	}
+
+	if isEmpty {
+		return ErrEmptyWalk
 	}
 
 	return nil

--- a/import.go
+++ b/import.go
@@ -185,7 +185,7 @@ func (c *Client) Import(ctx context.Context, reader io.Reader, opts ...ImportOpt
 
 	handler = images.FilterPlatforms(handler, platformMatcher)
 	handler = images.SetChildrenLabels(cs, handler)
-	if err := images.Walk(ctx, handler, index); err != nil {
+	if err := images.WalkNotEmpty(ctx, handler, index); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
During import, if an image does not match the host's platform, it won't have any children labels set, which will result in the
Garbage Collector deleting its content later, resulting in an unusable image. In this case, we should fail early.

This can still be bypassed by using ``ctr import --all-platforms``.

Depends On: https://github.com/containerd/containerd/pull/5916