### PR TITLE
go.mod: Update hcsshim to v0.8.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20210715213245-6c3934b029d8
 	github.com/Microsoft/go-winio v0.5.0
-	github.com/Microsoft/hcsshim v0.8.18
+	github.com/Microsoft/hcsshim v0.8.21
 	github.com/containerd/aufs v1.0.0
 	github.com/containerd/btrfs v1.0.0
 	github.com/containerd/cgroups v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/Microsoft/go-winio v0.5.0 h1:Elr9Wn+sGKPlkaBvwu4mTrxtmOp3F3yV9qhaHbXG
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/Microsoft/hcsshim v0.8.16/go.mod h1:o5/SZqmR7x9JNKsW3pu+nqHm0MF8vbA+VxGOoXdC600=
-github.com/Microsoft/hcsshim v0.8.18 h1:cYnKADiM1869gvBpos3YCteeT6sZLB48lB5dmMMs8Tg=
-github.com/Microsoft/hcsshim v0.8.18/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwTOcER2fw4I4=
+github.com/Microsoft/hcsshim v0.8.21 h1:btRfUDThBE5IKcvI8O8jOiIkujUsAMBSRsYDYmEi6oM=
+github.com/Microsoft/hcsshim v0.8.21/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwTOcER2fw4I4=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/integration/client/go.mod
+++ b/integration/client/go.mod
@@ -3,7 +3,7 @@ module github.com/containerd/containerd/integration/client
 go 1.15
 
 require (
-	github.com/Microsoft/hcsshim v0.8.18
+	github.com/Microsoft/hcsshim v0.8.21
 	github.com/Microsoft/hcsshim/test v0.0.0-20210408205431-da33ecd607e1
 	github.com/containerd/cgroups v1.0.1
 	// the actual version of containerd is replaced with the code at the root of this repository

--- a/integration/client/go.sum
+++ b/integration/client/go.sum
@@ -44,8 +44,8 @@ github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpz
 github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/Microsoft/hcsshim v0.8.15/go.mod h1:x38A4YbHbdxJtc0sF6oIz+RG0npwSCAvn69iY6URG00=
 github.com/Microsoft/hcsshim v0.8.16/go.mod h1:o5/SZqmR7x9JNKsW3pu+nqHm0MF8vbA+VxGOoXdC600=
-github.com/Microsoft/hcsshim v0.8.18 h1:cYnKADiM1869gvBpos3YCteeT6sZLB48lB5dmMMs8Tg=
-github.com/Microsoft/hcsshim v0.8.18/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwTOcER2fw4I4=
+github.com/Microsoft/hcsshim v0.8.21 h1:btRfUDThBE5IKcvI8O8jOiIkujUsAMBSRsYDYmEi6oM=
+github.com/Microsoft/hcsshim v0.8.21/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwTOcER2fw4I4=
 github.com/Microsoft/hcsshim/test v0.0.0-20210408205431-da33ecd607e1 h1:pVKfKyPkXna29XlGjxSr9J0A7vNucOUHZ/2ClcTWalw=
 github.com/Microsoft/hcsshim/test v0.0.0-20210408205431-da33ecd607e1/go.mod h1:Cmvnhlie15Ha2UYrJs9EhgSx76Bq9RV2FgfEiT78GhI=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=

--- a/vendor/github.com/Microsoft/hcsshim/errors.go
+++ b/vendor/github.com/Microsoft/hcsshim/errors.go
@@ -59,7 +59,7 @@ var (
 	// ErrVmcomputeOperationInvalidState is an error encountered when the compute system is not in a valid state for the requested operation
 	ErrVmcomputeOperationInvalidState = hcs.ErrVmcomputeOperationInvalidState
 
-	// ErrProcNotFound is an error encountered when the the process cannot be found
+	// ErrProcNotFound is an error encountered when a procedure look up fails.
 	ErrProcNotFound = hcs.ErrProcNotFound
 
 	// ErrVmcomputeOperationAccessIsDenied is an error which can be encountered when enumerating compute systems in RS1/RS2
@@ -159,7 +159,7 @@ func (e *ProcessError) Error() string {
 // IsNotExist checks if an error is caused by the Container or Process not existing.
 // Note: Currently, ErrElementNotFound can mean that a Process has either
 // already exited, or does not exist. Both IsAlreadyStopped and IsNotExist
-// will currently return true when the error is ErrElementNotFound or ErrProcNotFound.
+// will currently return true when the error is ErrElementNotFound.
 func IsNotExist(err error) bool {
 	if _, ok := err.(EndpointNotFoundError); ok {
 		return true
@@ -192,7 +192,7 @@ func IsTimeout(err error) bool {
 // a Container or Process being already stopped.
 // Note: Currently, ErrElementNotFound can mean that a Process has either
 // already exited, or does not exist. Both IsAlreadyStopped and IsNotExist
-// will currently return true when the error is ErrElementNotFound or ErrProcNotFound.
+// will currently return true when the error is ErrElementNotFound.
 func IsAlreadyStopped(err error) bool {
 	return hcs.IsAlreadyStopped(getInnerError(err))
 }

--- a/vendor/github.com/Microsoft/hcsshim/hcn/hcn.go
+++ b/vendor/github.com/Microsoft/hcsshim/hcn/hcn.go
@@ -127,7 +127,10 @@ func platformDoesNotSupportError(featureName string) error {
 
 // V2ApiSupported returns an error if the HCN version does not support the V2 Apis.
 func V2ApiSupported() error {
-	supported := GetSupportedFeatures()
+	supported, err := GetCachedSupportedFeatures()
+	if err != nil {
+		return err
+	}
 	if supported.Api.V2 {
 		return nil
 	}
@@ -143,7 +146,10 @@ func V2SchemaVersion() SchemaVersion {
 
 // RemoteSubnetSupported returns an error if the HCN version does not support Remote Subnet policies.
 func RemoteSubnetSupported() error {
-	supported := GetSupportedFeatures()
+	supported, err := GetCachedSupportedFeatures()
+	if err != nil {
+		return err
+	}
 	if supported.RemoteSubnet {
 		return nil
 	}
@@ -152,7 +158,10 @@ func RemoteSubnetSupported() error {
 
 // HostRouteSupported returns an error if the HCN version does not support Host Route policies.
 func HostRouteSupported() error {
-	supported := GetSupportedFeatures()
+	supported, err := GetCachedSupportedFeatures()
+	if err != nil {
+		return err
+	}
 	if supported.HostRoute {
 		return nil
 	}
@@ -161,7 +170,10 @@ func HostRouteSupported() error {
 
 // DSRSupported returns an error if the HCN version does not support Direct Server Return.
 func DSRSupported() error {
-	supported := GetSupportedFeatures()
+	supported, err := GetCachedSupportedFeatures()
+	if err != nil {
+		return err
+	}
 	if supported.DSR {
 		return nil
 	}
@@ -170,7 +182,10 @@ func DSRSupported() error {
 
 // Slash32EndpointPrefixesSupported returns an error if the HCN version does not support configuring endpoints with /32 prefixes.
 func Slash32EndpointPrefixesSupported() error {
-	supported := GetSupportedFeatures()
+	supported, err := GetCachedSupportedFeatures()
+	if err != nil {
+		return err
+	}
 	if supported.Slash32EndpointPrefixes {
 		return nil
 	}
@@ -179,7 +194,10 @@ func Slash32EndpointPrefixesSupported() error {
 
 // AclSupportForProtocol252Supported returns an error if the HCN version does not support HNS ACL Policies to support protocol 252 for VXLAN.
 func AclSupportForProtocol252Supported() error {
-	supported := GetSupportedFeatures()
+	supported, err := GetCachedSupportedFeatures()
+	if err != nil {
+		return err
+	}
 	if supported.AclSupportForProtocol252 {
 		return nil
 	}
@@ -188,7 +206,10 @@ func AclSupportForProtocol252Supported() error {
 
 // SessionAffinitySupported returns an error if the HCN version does not support Session Affinity.
 func SessionAffinitySupported() error {
-	supported := GetSupportedFeatures()
+	supported, err := GetCachedSupportedFeatures()
+	if err != nil {
+		return err
+	}
 	if supported.SessionAffinity {
 		return nil
 	}
@@ -197,7 +218,10 @@ func SessionAffinitySupported() error {
 
 // IPv6DualStackSupported returns an error if the HCN version does not support IPv6DualStack.
 func IPv6DualStackSupported() error {
-	supported := GetSupportedFeatures()
+	supported, err := GetCachedSupportedFeatures()
+	if err != nil {
+		return err
+	}
 	if supported.IPv6DualStack {
 		return nil
 	}
@@ -206,7 +230,10 @@ func IPv6DualStackSupported() error {
 
 //L4proxySupported returns an error if the HCN verison does not support L4Proxy
 func L4proxyPolicySupported() error {
-	supported := GetSupportedFeatures()
+	supported, err := GetCachedSupportedFeatures()
+	if err != nil {
+		return err
+	}
 	if supported.L4Proxy {
 		return nil
 	}
@@ -215,7 +242,10 @@ func L4proxyPolicySupported() error {
 
 // L4WfpProxySupported returns an error if the HCN verison does not support L4WfpProxy
 func L4WfpProxyPolicySupported() error {
-	supported := GetSupportedFeatures()
+	supported, err := GetCachedSupportedFeatures()
+	if err != nil {
+		return err
+	}
 	if supported.L4WfpProxy {
 		return nil
 	}
@@ -224,7 +254,10 @@ func L4WfpProxyPolicySupported() error {
 
 // SetPolicySupported returns an error if the HCN version does not support SetPolicy.
 func SetPolicySupported() error {
-	supported := GetSupportedFeatures()
+	supported, err := GetCachedSupportedFeatures()
+	if err != nil {
+		return err
+	}
 	if supported.SetPolicy {
 		return nil
 	}
@@ -233,7 +266,10 @@ func SetPolicySupported() error {
 
 // VxlanPortSupported returns an error if the HCN version does not support configuring the VXLAN TCP port.
 func VxlanPortSupported() error {
-	supported := GetSupportedFeatures()
+	supported, err := GetCachedSupportedFeatures()
+	if err != nil {
+		return err
+	}
 	if supported.VxlanPort {
 		return nil
 	}
@@ -242,7 +278,10 @@ func VxlanPortSupported() error {
 
 // TierAclPolicySupported returns an error if the HCN version does not support configuring the TierAcl.
 func TierAclPolicySupported() error {
-	supported := GetSupportedFeatures()
+	supported, err := GetCachedSupportedFeatures()
+	if err != nil {
+		return err
+	}
 	if supported.TierAcl {
 		return nil
 	}

--- a/vendor/github.com/Microsoft/hcsshim/hcn/hcnsupport.go
+++ b/vendor/github.com/Microsoft/hcsshim/hcn/hcnsupport.go
@@ -1,7 +1,19 @@
 package hcn
 
 import (
+	"fmt"
+	"sync"
+
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+)
+
+var (
+	// featuresOnce handles assigning the supported features and printing the supported info to stdout only once to avoid unnecessary work
+	// multiple times.
+	featuresOnce      sync.Once
+	featuresErr       error
+	supportedFeatures SupportedFeatures
 )
 
 // SupportedFeatures are the features provided by the Service.
@@ -36,17 +48,41 @@ type ApiSupport struct {
 	V2 bool `json:"V2"`
 }
 
-// GetSupportedFeatures returns the features supported by the Service.
-func GetSupportedFeatures() SupportedFeatures {
-	var features SupportedFeatures
+// GetCachedSupportedFeatures returns the features supported by the Service and an error if the query failed. If this has been called
+// before it will return the supported features and error received from the first call. This can be used to optimize if many calls to the
+// various hcn.IsXSupported methods need to be made.
+func GetCachedSupportedFeatures() (SupportedFeatures, error) {
+	// Only query the HCN version and features supported once, instead of everytime this is invoked. The logs are useful to
+	// debug incidents where there's confusion on if a feature is supported on the host machine. The sync.Once helps to avoid redundant
+	// spam of these anytime a check needs to be made for if an HCN feature is supported. This is a common occurrence in kube-proxy
+	// for example.
+	featuresOnce.Do(func() {
+		supportedFeatures, featuresErr = getSupportedFeatures()
+	})
 
-	globals, err := GetGlobals()
+	return supportedFeatures, featuresErr
+}
+
+// GetSupportedFeatures returns the features supported by the Service.
+//
+// Deprecated: Use GetCachedSupportedFeatures instead.
+func GetSupportedFeatures() SupportedFeatures {
+	features, err := GetCachedSupportedFeatures()
 	if err != nil {
 		// Expected on pre-1803 builds, all features will be false/unsupported
-		logrus.Debugf("Unable to obtain globals: %s", err)
+		logrus.WithError(err).Errorf("unable to obtain supported features")
 		return features
 	}
+	return features
+}
 
+func getSupportedFeatures() (SupportedFeatures, error) {
+	var features SupportedFeatures
+	globals, err := GetGlobals()
+	if err != nil {
+		// It's expected if this fails once, it should always fail. It should fail on pre 1803 builds for example.
+		return SupportedFeatures{}, errors.Wrap(err, "failed to query HCN version number: this is expected on pre 1803 builds.")
+	}
 	features.Acl = AclFeatures{
 		AclAddressLists:       isFeatureSupported(globals.Version, HNSVersion1803),
 		AclNoHostRulePriority: isFeatureSupported(globals.Version, HNSVersion1803),
@@ -72,7 +108,12 @@ func GetSupportedFeatures() SupportedFeatures {
 	features.L4WfpProxy = isFeatureSupported(globals.Version, L4WfpProxyPolicyVersion)
 	features.TierAcl = isFeatureSupported(globals.Version, TierAclPolicyVersion)
 
-	return features
+	logrus.WithFields(logrus.Fields{
+		"version":           fmt.Sprintf("%+v", globals.Version),
+		"supportedFeatures": fmt.Sprintf("%+v", features),
+	}).Info("HCN feature check")
+
+	return features, nil
 }
 
 func isFeatureSupported(currentVersion Version, versionsSupported VersionRanges) bool {
@@ -87,19 +128,15 @@ func isFeatureSupported(currentVersion Version, versionsSupported VersionRanges)
 
 func isFeatureInRange(currentVersion Version, versionRange VersionRange) bool {
 	if currentVersion.Major < versionRange.MinVersion.Major {
-		logrus.Infof("currentVersion.Major < versionRange.MinVersion.Major: %v, %v", currentVersion.Major, versionRange.MinVersion.Major)
 		return false
 	}
 	if currentVersion.Major > versionRange.MaxVersion.Major {
-		logrus.Infof("currentVersion.Major > versionRange.MaxVersion.Major: %v, %v", currentVersion.Major, versionRange.MaxVersion.Major)
 		return false
 	}
 	if currentVersion.Major == versionRange.MinVersion.Major && currentVersion.Minor < versionRange.MinVersion.Minor {
-		logrus.Infof("currentVersion.Minor < versionRange.MinVersion.Major: %v, %v", currentVersion.Minor, versionRange.MinVersion.Minor)
 		return false
 	}
 	if currentVersion.Major == versionRange.MaxVersion.Major && currentVersion.Minor > versionRange.MaxVersion.Minor {
-		logrus.Infof("currentVersion.Minor > versionRange.MaxVersion.Major: %v, %v", currentVersion.Minor, versionRange.MaxVersion.Minor)
 		return false
 	}
 	return true

--- a/vendor/github.com/Microsoft/hcsshim/hnsendpoint.go
+++ b/vendor/github.com/Microsoft/hcsshim/hnsendpoint.go
@@ -7,6 +7,9 @@ import (
 // HNSEndpoint represents a network endpoint in HNS
 type HNSEndpoint = hns.HNSEndpoint
 
+// HNSEndpointStats represent the stats for an networkendpoint in HNS
+type HNSEndpointStats = hns.EndpointStats
+
 // Namespace represents a Compartment.
 type Namespace = hns.Namespace
 
@@ -107,4 +110,9 @@ func GetHNSEndpointByID(endpointID string) (*HNSEndpoint, error) {
 // GetHNSEndpointByName gets the endpoint filtered by Name
 func GetHNSEndpointByName(endpointName string) (*HNSEndpoint, error) {
 	return hns.GetHNSEndpointByName(endpointName)
+}
+
+// GetHNSEndpointStats gets the endpoint stats by ID
+func GetHNSEndpointStats(endpointName string) (*HNSEndpointStats, error) {
+	return hns.GetHNSEndpointStats(endpointName)
 }

--- a/vendor/github.com/Microsoft/hcsshim/internal/hcs/errors.go
+++ b/vendor/github.com/Microsoft/hcsshim/internal/hcs/errors.go
@@ -60,7 +60,7 @@ var (
 	// ErrVmcomputeOperationInvalidState is an error encountered when the compute system is not in a valid state for the requested operation
 	ErrVmcomputeOperationInvalidState = syscall.Errno(0xc0370105)
 
-	// ErrProcNotFound is an error encountered when the the process cannot be found
+	// ErrProcNotFound is an error encountered when a procedure look up fails.
 	ErrProcNotFound = syscall.Errno(0x7f)
 
 	// ErrVmcomputeOperationAccessIsDenied is an error which can be encountered when enumerating compute systems in RS1/RS2
@@ -242,12 +242,11 @@ func makeProcessError(process *Process, op string, err error, events []ErrorEven
 // IsNotExist checks if an error is caused by the Container or Process not existing.
 // Note: Currently, ErrElementNotFound can mean that a Process has either
 // already exited, or does not exist. Both IsAlreadyStopped and IsNotExist
-// will currently return true when the error is ErrElementNotFound or ErrProcNotFound.
+// will currently return true when the error is ErrElementNotFound.
 func IsNotExist(err error) bool {
 	err = getInnerError(err)
 	return err == ErrComputeSystemDoesNotExist ||
-		err == ErrElementNotFound ||
-		err == ErrProcNotFound
+		err == ErrElementNotFound
 }
 
 // IsAlreadyClosed checks if an error is caused by the Container or Process having been
@@ -278,12 +277,11 @@ func IsTimeout(err error) bool {
 // a Container or Process being already stopped.
 // Note: Currently, ErrElementNotFound can mean that a Process has either
 // already exited, or does not exist. Both IsAlreadyStopped and IsNotExist
-// will currently return true when the error is ErrElementNotFound or ErrProcNotFound.
+// will currently return true when the error is ErrElementNotFound.
 func IsAlreadyStopped(err error) bool {
 	err = getInnerError(err)
 	return err == ErrVmcomputeAlreadyStopped ||
-		err == ErrElementNotFound ||
-		err == ErrProcNotFound
+		err == ErrElementNotFound
 }
 
 // IsNotSupported returns a boolean indicating whether the error is caused by

--- a/vendor/github.com/Microsoft/hcsshim/internal/hns/hnsendpoint.go
+++ b/vendor/github.com/Microsoft/hcsshim/internal/hns/hnsendpoint.go
@@ -30,6 +30,7 @@ type HNSEndpoint struct {
 	EnableLowMetric    bool              `json:",omitempty"`
 	Namespace          *Namespace        `json:",omitempty"`
 	EncapOverhead      uint16            `json:",omitempty"`
+	SharedContainers   []string          `json:",omitempty"`
 }
 
 //SystemType represents the type of the system on which actions are done
@@ -57,6 +58,18 @@ type EndpointResquestResponse struct {
 	Error   string
 }
 
+// EndpointStats is the object that has stats for a given endpoint
+type EndpointStats struct {
+	BytesReceived          uint64 `json:"BytesReceived"`
+	BytesSent              uint64 `json:"BytesSent"`
+	DroppedPacketsIncoming uint64 `json:"DroppedPacketsIncoming"`
+	DroppedPacketsOutgoing uint64 `json:"DroppedPacketsOutgoing"`
+	EndpointID             string `json:"EndpointId"`
+	InstanceID             string `json:"InstanceId"`
+	PacketsReceived        uint64 `json:"PacketsReceived"`
+	PacketsSent            uint64 `json:"PacketsSent"`
+}
+
 // HNSEndpointRequest makes a HNS call to modify/query a network endpoint
 func HNSEndpointRequest(method, path, request string) (*HNSEndpoint, error) {
 	endpoint := &HNSEndpoint{}
@@ -79,9 +92,25 @@ func HNSListEndpointRequest() ([]HNSEndpoint, error) {
 	return endpoint, nil
 }
 
+// hnsEndpointStatsRequest makes a HNS call to query the stats for a given endpoint ID
+func hnsEndpointStatsRequest(id string) (*EndpointStats, error) {
+	var stats EndpointStats
+	err := hnsCall("GET", "/endpointstats/"+id, "", &stats)
+	if err != nil {
+		return nil, err
+	}
+
+	return &stats, nil
+}
+
 // GetHNSEndpointByID get the Endpoint by ID
 func GetHNSEndpointByID(endpointID string) (*HNSEndpoint, error) {
 	return HNSEndpointRequest("GET", endpointID, "")
+}
+
+// GetHNSEndpointStats get the stats for a n Endpoint by ID
+func GetHNSEndpointStats(endpointID string) (*EndpointStats, error) {
+	return hnsEndpointStatsRequest(endpointID)
 }
 
 // GetHNSEndpointByName gets the endpoint filtered by Name

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -11,7 +11,7 @@ github.com/Microsoft/go-winio/pkg/fs
 github.com/Microsoft/go-winio/pkg/guid
 github.com/Microsoft/go-winio/pkg/security
 github.com/Microsoft/go-winio/vhd
-# github.com/Microsoft/hcsshim v0.8.18
+# github.com/Microsoft/hcsshim v0.8.21
 ## explicit
 github.com/Microsoft/hcsshim
 github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options


### PR DESCRIPTION
This version brings in some bug fixes to layer handling. The actual fix isn't
present in the diff as it's not used here, but the Windows shim is built from
the tag present in go.mod, so the fix will be in the Windows shim on a new release
of Containerd if this tag is in.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>