### PR TITLE
Fix cwd flag for `ctr tasks exec`

### DIFF
--- a/cmd/ctr/commands/tasks/exec.go
+++ b/cmd/ctr/commands/tasks/exec.go
@@ -104,6 +104,10 @@ var execCommand = cli.Command{
 		pspec.Terminal = tty
 		pspec.Args = args
 
+		if cwd := context.String("cwd"); cwd != "" {
+			pspec.Cwd = cwd
+		}
+
 		task, err := container.Task(ctx, nil)
 		if err != nil {
 			return err


### PR DESCRIPTION
It seems like the cwd flag isn't used anywhere for `ctr tasks exec`. This change
just sets the cwd field on the spec for the execed process if a new one was
asked for, otherwise it will continue using whatever was on the containers spec.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>