### PR TITLE
[WIP] adds option for setting default oci hooks

### DIFF
--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -97,6 +97,12 @@ version = 2
   # when using containerd with Kubernetes <=1.11.
   disable_proc_mount = false
 
+  # default_oci_hooks is the filepath to an OCI runtime spec Hooks struct in json.
+  # see details and example:
+  #    https://github.com/opencontainers/runtime-spec/blob/master/config.md#posix-platform-hooks
+  # ** Note: Overridden if set by CRI
+  default_oci_hooks = ""
+
   # unset_seccomp_profile is the seccomp profile containerd/cri will use if the seccomp
   # profile requested over CRI is unset (or nil) for a pod/container (otherwise if this field is not set the
   # default unset profile will map to `unconfined`)

--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -247,6 +247,10 @@ type PluginConfig struct {
 	// DisableProcMount disables Kubernetes ProcMount support. This MUST be set to `true`
 	// when using containerd with Kubernetes <=1.11.
 	DisableProcMount bool `toml:"disable_proc_mount" json:"disableProcMount"`
+	// DefaultOCIHooks (optional) is a path to a json file that specifies a
+	// default OCI spec Hooks struct. ** Note: The any hooks set by default can be
+	// overridden if/when the hooks are set via the CRI.
+	DefaultOCIHooks string `toml:"default_oci_hooks" json:"defaultOCIHooks,omitempty"`
 	// UnsetSeccompProfile is the profile containerd/cri will use If the provided seccomp profile is
 	// unset (`""`) for a container (default is `unconfined`)
 	UnsetSeccompProfile string `toml:"unset_seccomp_profile" json:"unsetSeccompProfile"`

--- a/pkg/cri/opts/spec.go
+++ b/pkg/cri/opts/spec.go
@@ -111,3 +111,11 @@ func WithAnnotation(k, v string) oci.SpecOpts {
 		return nil
 	}
 }
+
+// WithHooks sets or replaces the runtimespec.Hooks with the provided hooks
+func WithHooks(hooks *runtimespec.Hooks) oci.SpecOpts {
+	return func(ctx context.Context, client oci.Client, c *containers.Container, s *runtimespec.Spec) error {
+		s.Hooks = hooks
+		return nil
+	}
+}

--- a/pkg/cri/server/container_create.go
+++ b/pkg/cri/server/container_create.go
@@ -17,6 +17,8 @@
 package server
 
 import (
+	"encoding/json"
+	"io/ioutil"
 	"path/filepath"
 	"time"
 
@@ -342,4 +344,20 @@ func (c *criService) runtimeSpec(id string, baseSpecFile string, opts ...oci.Spe
 	}
 
 	return spec, nil
+}
+
+// generateOCIHooks generates a runtimespec.Hooks struct from json in the passed in filepath.
+func (c *criService) generateOCIHooks(profile string) (*runtimespec.Hooks, error) {
+	if profile == "" {
+		return nil, nil
+	}
+	hooks := &runtimespec.Hooks{}
+	f, err := ioutil.ReadFile(profile)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(f, hooks); err != nil {
+		return nil, err
+	}
+	return hooks, nil
 }

--- a/pkg/cri/server/container_create_linux.go
+++ b/pkg/cri/server/container_create_linux.go
@@ -260,6 +260,15 @@ func (c *criService) containerSpec(
 
 	supplementalGroups := securityContext.GetSupplementalGroups()
 
+	ociHooksProfile := c.config.DefaultOCIHooks
+	hooks, err := c.generateOCIHooks(ociHooksProfile)
+	if err != nil { // TODO (mikebrow): clean up prototype
+		return nil, errors.Wrapf(err, "failed to generate OCI hooks %+v", ociHooksProfile)
+	}
+	if hooks != nil {
+		specOpts = append(specOpts, customopts.WithHooks(hooks))
+	}
+
 	for pKey, pValue := range getPassthroughAnnotations(sandboxConfig.Annotations,
 		ociRuntime.PodAnnotations) {
 		specOpts = append(specOpts, customopts.WithAnnotation(pKey, pValue))


### PR DESCRIPTION
carry wip for experimentation ... hook injector from https://github.com/containerd/cri/pull/1248

since that ^ commit we've added base_runtime_spec to each runtime (custom json specifying the runtime's base spec instead of using the core runc spec) and we've added NRI.

We currently can use NRI to handle the hooks or do a custom base runtime spec with hooks for each runtime where hooks are needed.. 

Other options for injecting hooks/runtime may include using something like this PR or we could so some injection pattern/schema based on how it's done in crio..
 
Signed-off-by: Mike Brown <brownwm@us.ibm.com>