### PR TITLE
Extend mount package on macOS to use external snapshotters

### DIFF
--- a/mount/mount_darwin.go
+++ b/mount/mount_darwin.go
@@ -1,0 +1,138 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package mount
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/log"
+)
+
+var (
+	// ErrNotImplementOnUnix is returned for methods that are not implemented
+	ErrNotImplementOnUnix = errors.New("not implemented under darwin")
+	// allowedHelperBinaries is a list of third-party executable, which can
+	// be extended in future uses, e.g., mount_nfs, mount_9p.  `mount_darwin`
+	// is a special case where we will use the internal darwin snapshotter.
+	allowedHelperBinaries = []string{"mount_containerd_darwin"}
+)
+
+// Mount to the provided target path.
+//
+func (m *Mount) Mount(target string) error {
+	log.L.Debugf("mount: %s, src %s, type %s", target, m.Source, m.Type)
+
+	binary := fmt.Sprintf("mount_containerd_%s", m.Type)
+	if _, err := exec.LookPath(binary); err != nil {
+		return fmt.Errorf("mount binary not found: '%s(%s)': %w", m.Type, binary, errdefs.ErrNotFound)
+	}
+
+	for _, helperBinary := range allowedHelperBinaries {
+		if binary == helperBinary {
+			return mountWithHelper(binary, target, m.Source, m.Options)
+		}
+	}
+
+	return fmt.Errorf("mount binary isn't allowed to use: '%s(%s)': %w", m.Type, binary, ErrNotImplementOnUnix)
+}
+
+// Unmount the provided mount path with the flags
+func Unmount(target string, flags int) error {
+	return unmount(target, flags)
+}
+
+// UnmountAll the provided mount path with the flags
+func UnmountAll(target string, flags int) error {
+	return unmount(target, flags)
+}
+
+func unmount(target string, flags int) error {
+	log.L.Debugf("unmount: %s", target)
+
+	if !isMounted(target) {
+		log.L.Debugf("%s is already unmounted. skipped.", target)
+		return nil
+	}
+
+	return unmountWithHelper("mount_containerd_darwin", target, flags)
+}
+
+func isMounted(target string) bool {
+	// if target is no longer resolvable, treat it as unmounted
+	_, err := os.Stat(target)
+	if os.IsNotExist(err) {
+		log.L.Debugf("%s no longer exists", target)
+		return false
+	}
+
+	// resolve realpath(3?) for mountinfo
+	targetP, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		log.L.Debugf("failed to resolve target: %s", target)
+		return false
+	}
+
+	mInfo, err := Lookup(targetP)
+	if err != nil {
+		log.L.Debugf("failed to lookup mount information: %s", targetP)
+		return false
+	}
+
+	if mInfo.Mountpoint == "/" {
+		log.L.Debugf("mount point is root '/'. skipped: %s", targetP)
+		return false
+	}
+
+	log.L.Debugf("Mountinfo: %+v\n", mInfo)
+	return true
+}
+
+func mountWithHelper(helperBinary, target, source string, options []string) error {
+	var err error
+
+	args := []string{
+		"mount",
+		target,
+		source,
+	}
+	args = append(args, options...)
+	cmd := exec.Command(helperBinary, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%v: %s", err, out)
+	}
+
+	return nil
+}
+
+func unmountWithHelper(helperBinary, target string, flags int) error {
+	var err error
+
+	cmd := exec.Command(helperBinary, "unmount", target, strconv.Itoa(flags))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%v: %s", err, out)
+	}
+
+	return nil
+}

--- a/mount/mount_darwin_test.go
+++ b/mount/mount_darwin_test.go
@@ -1,0 +1,77 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package mount
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/containerd/containerd/errdefs"
+)
+
+func TestMountDarwin(t *testing.T) {
+	testcases := []struct {
+		mounts Mount
+		err    error
+		msg    string
+	}{
+		{
+			mounts: Mount{
+				Type:   "nfs",
+				Source: "source",
+			},
+			err: errdefs.ErrNotFound,
+			msg: "should fail with non-allowed type",
+		},
+		{
+			mounts: Mount{
+				Type:   "blah",
+				Source: "source",
+			},
+			err: errdefs.ErrNotFound,
+			msg: "should fail with non-existent binary",
+		},
+		{
+			mounts: Mount{
+				Type:   "darwin",
+				Source: "source",
+			},
+			err: nil,
+			msg: "should fail with non-existent target",
+		},
+		{
+			mounts: Mount{
+				Type:   "9p",
+				Source: "source",
+			},
+			err: errdefs.ErrNotFound,
+			msg: "should fail with non-allowed type",
+		},
+	}
+
+	for _, tc := range testcases {
+		err := tc.mounts.Mount("target")
+		t.Log(err)
+		if tc.mounts.Type == "darwin" {
+			if err == nil {
+				t.Fatalf("%s: %s", tc.msg, tc.mounts.Type)
+			}
+		} else if !errors.Is(err, tc.err) {
+			t.Fatalf("%s: %s", tc.msg, tc.mounts.Type)
+		}
+	}
+}

--- a/mount/mount_unix.go
+++ b/mount/mount_unix.go
@@ -1,5 +1,5 @@
-//go:build darwin || openbsd
-// +build darwin openbsd
+//go:build openbsd
+// +build openbsd
 
 /*
    Copyright The containerd Authors.


### PR DESCRIPTION
(splitting from the original patchset: https://github.com/containerd/containerd/pull/4526)

This PR tries to support the native snapshotter on macOS.  As macOS doesn't have union-fs like feature (nullfs nor aufs), the mount operation is simulated by using symlinks.

The snapshotter passes the test on `darwin/amd64` platform.

```
% uname -a
Darwin sun.local 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5/RELEASE_X86_64 x86_64
% pwd
~/.go/src/github.com/containerd/containerd/snapshots/native
% sudo go test -test.root -v .
(snip)
--- PASS: TestNaive (0.00s)
    --- SKIP: TestNaive/Rename (0.08s)
    --- SKIP: TestNaive/ViewReadonly (0.10s)
    --- PASS: TestNaive/RootPermission (0.76s)
    --- PASS: TestNaive/CloseTwice (0.82s)
    --- PASS: TestNaive/StatInWalk (1.44s)
    --- PASS: TestNaive/Remove (2.09s)
    --- PASS: TestNaive/PreareViewFailingtest (2.05s)
    --- PASS: TestNaive/StatActive (1.33s)
    --- PASS: TestNaive/StatComitted (1.40s)
    --- PASS: TestNaive/TransitivityTest (2.25s)
    --- PASS: TestNaive/Walk (2.89s)
    --- PASS: TestNaive/Update (4.28s)
    --- PASS: TestNaive/RemoveDirectoryInLowerLayer (4.28s)
    --- PASS: TestNaive/Basic (4.32s)
    --- PASS: TestNaive/RemoveIntermediateSnapshot (2.27s)
    --- PASS: TestNaive/DeletedFilesInChildSnapshot (4.42s)
    --- PASS: TestNaive/MoveFileFromLowerLayer (3.47s)
    --- PASS: TestNaive/Chown (2.86s)
    --- PASS: TestNaive/DirectoryPermissionOnCommit (3.29s)
    --- PASS: TestNaive/LayerFileupdate (7.12s)
    --- PASS: TestNaive/128LayersMount (22.64s)
PASS
ok      github.com/containerd/containerd/snapshots/native       22.775s

% ./bin/ctr -a /tmp/ctrd/run/containerd/containerd.sock i ls
REF                                        TYPE                                                 DIGEST                                                                  SIZE     PLATFORMS    LABELS
ghcr.io/ukontainer/runu-base:0.3-osx-extra application/vnd.docker.distribution.manifest.v2+json sha256:0a6e9d725a7a50a34dd7cf87991f7fc597b85f4b0ea591bdc5d2762776c33bf7 65.9 MiB darwin/amd64 -

```