### PR TITLE
darwin: runtime support

### DIFF
--- a/defaults/defaults_darwin.go
+++ b/defaults/defaults_darwin.go
@@ -30,8 +30,7 @@ const (
 	// DefaultFIFODir is the default location used by client-side cio library
 	// to store FIFOs.
 	DefaultFIFODir = "/var/run/containerd/fifo"
-	// DefaultRuntime is the default Darwin runtime.
-	// NOTE: there is no runtime on Darwin as of now.
+	// DefaultRuntime would be a multiple of choices, thus empty
 	DefaultRuntime = ""
 	// DefaultConfigDir is the default location for config files.
 	DefaultConfigDir = "/etc/containerd"

--- a/platforms/defaults_darwin.go
+++ b/platforms/defaults_darwin.go
@@ -1,5 +1,4 @@
-//go:build !windows && !darwin
-// +build !windows,!darwin
+// +build darwin
 
 /*
    Copyright The containerd Authors.
@@ -37,5 +36,9 @@ func DefaultSpec() specs.Platform {
 
 // Default returns the default matcher for the platform.
 func Default() MatchComparer {
-	return Only(DefaultSpec())
+	return Ordered(DefaultSpec(), specs.Platform{
+		// darwin runtime also supports Linux binary via runu/LKL
+		OS:           "linux",
+		Architecture: runtime.GOARCH,
+	})
 }

--- a/runtime/v2/shim/util_unix.go
+++ b/runtime/v2/shim/util_unix.go
@@ -30,6 +30,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/pkg/dialer"
 	"github.com/containerd/containerd/sys"
@@ -63,7 +64,7 @@ func AdjustOOMScore(pid int) error {
 	return nil
 }
 
-const socketRoot = "/run/containerd"
+const socketRoot = defaults.DefaultStateDir
 
 // SocketAddress returns a socket address
 func SocketAddress(ctx context.Context, socketPath, id string) (string, error) {

--- a/services/tasks/local_darwin.go
+++ b/services/tasks/local_darwin.go
@@ -1,5 +1,4 @@
-//go:build !windows && !darwin
-// +build !windows,!darwin
+// +build darwin
 
 /*
    Copyright The containerd Authors.
@@ -17,25 +16,20 @@
    limitations under the License.
 */
 
-package platforms
+package tasks
 
 import (
-	"runtime"
-
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/containerd/containerd/plugin"
+	"github.com/containerd/containerd/runtime"
 )
 
-// DefaultSpec returns the current platform's default platform specification.
-func DefaultSpec() specs.Platform {
-	return specs.Platform{
-		OS:           runtime.GOOS,
-		Architecture: runtime.GOARCH,
-		// The Variant field will be empty if arch != ARM.
-		Variant: cpuVariant(),
-	}
+var tasksServiceRequires = []plugin.Type{
+	plugin.RuntimePluginV2,
+	plugin.MetadataPlugin,
+	plugin.TaskMonitorPlugin,
 }
 
-// Default returns the default matcher for the platform.
-func Default() MatchComparer {
-	return Only(DefaultSpec())
+// loadV1Runtimes on darwin returns an empty map. There are no v1 runtimes
+func loadV1Runtimes(ic *plugin.InitContext) (map[string]runtime.PlatformRuntime, error) {
+	return make(map[string]runtime.PlatformRuntime), nil
 }

--- a/services/tasks/local_unix.go
+++ b/services/tasks/local_unix.go
@@ -1,5 +1,5 @@
-//go:build !windows && !freebsd
-// +build !windows,!freebsd
+//go:build !windows && !freebsd && !darwin
+// +build !windows,!freebsd,!darwin
 
 /*
    Copyright The containerd Authors.


### PR DESCRIPTION
(splitting from the original patchset: https://github.com/containerd/containerd/pull/4526)

This PR proposes the runtime support on darwin platform.  containerd can run directly on darwin (i.e., without a Linux VM) using [runu](https://github.com/ukontainer/runu) runtime with the external shim (`containerd-shim-runu-v1`), though it's not limited to.

There are no integration tests in this PR: this can be followed up by subsequent PRs.