### PR TITLE
Makefile.linux: build on RISC-V with PIE

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -20,7 +20,7 @@ COMMANDS += containerd-shim containerd-shim-runc-v1 containerd-shim-runc-v2
 
 # check GOOS for cross compile builds
 ifeq ($(GOOS),linux)
-  ifneq ($(GOARCH),$(filter $(GOARCH),mips mipsle mips64 mips64le ppc64 riscv64))
+  ifneq ($(GOARCH),$(filter $(GOARCH),mips mipsle mips64 mips64le ppc64))
 	GO_GCFLAGS += -buildmode=pie
   endif
 endif


### PR DESCRIPTION
Since go 1.16, -buildmode=pie is supported on riscv [1],
so let's remove the platform from the exclusion list.

This reverts commit e34bf08e5891bb805aba7b80a35d4267721eaa0e.

[1] https://golang.org/doc/go1.16#riscv