### PR TITLE
cri: patch update image labels

### DIFF
--- a/pkg/cri/server/image_pull.go
+++ b/pkg/cri/server/image_pull.go
@@ -233,7 +233,7 @@ func (c *criService) createImageReference(ctx context.Context, name string, desc
 	if oldImg.Target.Digest == img.Target.Digest && oldImg.Labels[imageLabelKey] == imageLabelValue {
 		return nil
 	}
-	_, err = c.client.ImageService().Update(ctx, img, "target", "labels")
+	_, err = c.client.ImageService().Update(ctx, img, "target", "labels."+imageLabelKey)
 	return err
 }
 


### PR DESCRIPTION
The CRI-plugin subscribes the image event on k8s.io namespace. By
default, the image event is created by CRI-API. However, the image can
be downloaded by containerd API on k8s.io with the customized labels.
The CRI-plugin should use patch update for `io.cri-containerd.image`
label in this case.

Fixes: #5900

Signed-off-by: Wei Fu <fuweid89@gmail.com>