### PR TITLE
switch usage directly to errdefs.(ErrAlreadyExists and ErrNotFound)

### DIFF
--- a/.empty-mod/go.mod
+++ b/.empty-mod/go.mod
@@ -9,3 +9,5 @@
 // containerd to be the source of truth, helping us catch missing go.mod rules,
 // or version changes early.
 module empty-mod
+
+go 1.13

--- a/pkg/cri/server/container_remove.go
+++ b/pkg/cri/server/container_remove.go
@@ -20,20 +20,19 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
+	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
-
-	"github.com/containerd/containerd/pkg/cri/store"
-	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
 )
 
 // RemoveContainer removes the container.
 func (c *criService) RemoveContainer(ctx context.Context, r *runtime.RemoveContainerRequest) (_ *runtime.RemoveContainerResponse, retErr error) {
 	container, err := c.containerStore.Get(r.GetContainerId())
 	if err != nil {
-		if err != store.ErrNotExist {
+		if !errdefs.IsNotFound(err) {
 			return nil, errors.Wrapf(err, "an error occurred when try to find container %q", r.GetContainerId())
 		}
 		// Do not return error if container metadata doesn't exist.

--- a/pkg/cri/server/container_status.go
+++ b/pkg/cri/server/container_status.go
@@ -19,13 +19,13 @@ package server
 import (
 	"encoding/json"
 
+	"github.com/containerd/containerd/errdefs"
+	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
+
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
-
-	"github.com/containerd/containerd/pkg/cri/store"
-	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
 )
 
 // ContainerStatus inspects the container and returns the status.
@@ -44,7 +44,7 @@ func (c *criService) ContainerStatus(ctx context.Context, r *runtime.ContainerSt
 	imageRef := container.ImageRef
 	image, err := c.imageStore.Get(imageRef)
 	if err != nil {
-		if err != store.ErrNotExist {
+		if !errdefs.IsNotFound(err) {
 			return nil, errors.Wrapf(err, "failed to get image %q", imageRef)
 		}
 	} else {

--- a/pkg/cri/server/container_stop.go
+++ b/pkg/cri/server/container_stop.go
@@ -24,14 +24,13 @@ import (
 	eventtypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
+	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
+	ctrdutil "github.com/containerd/containerd/pkg/cri/util"
+
+	"github.com/moby/sys/signal"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
-
-	"github.com/containerd/containerd/pkg/cri/store"
-	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
-	ctrdutil "github.com/containerd/containerd/pkg/cri/util"
-	"github.com/moby/sys/signal"
 )
 
 // StopContainer stops a running container with a grace period (i.e., timeout).
@@ -116,7 +115,7 @@ func (c *criService) stopContainer(ctx context.Context, container containerstore
 			// TODO(random-liu): Remove this logic when containerd 1.2 is deprecated.
 			image, err := c.imageStore.Get(container.ImageRef)
 			if err != nil {
-				if err != store.ErrNotExist {
+				if !errdefs.IsNotFound(err) {
 					return errors.Wrapf(err, "failed to get image %q", container.ImageRef)
 				}
 				log.G(ctx).Warningf("Image %q not found, stop container with signal %q", container.ImageRef, stopSignal)

--- a/pkg/cri/server/helpers.go
+++ b/pkg/cri/server/helpers.go
@@ -23,26 +23,26 @@ import (
 	"strconv"
 	"strings"
 
-	runhcsoptions "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/errdefs"
+	criconfig "github.com/containerd/containerd/pkg/cri/config"
+	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
+	imagestore "github.com/containerd/containerd/pkg/cri/store/image"
+	sandboxstore "github.com/containerd/containerd/pkg/cri/store/sandbox"
+	runtimeoptions "github.com/containerd/containerd/pkg/runtimeoptions/v1"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/reference/docker"
 	"github.com/containerd/containerd/runtime/linux/runctypes"
 	runcoptions "github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/containerd/typeurl"
+
+	runhcsoptions "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
 	imagedigest "github.com/opencontainers/go-digest"
 	"github.com/pelletier/go-toml"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
-
-	criconfig "github.com/containerd/containerd/pkg/cri/config"
-	"github.com/containerd/containerd/pkg/cri/store"
-	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
-	imagestore "github.com/containerd/containerd/pkg/cri/store/image"
-	sandboxstore "github.com/containerd/containerd/pkg/cri/store/sandbox"
-	runtimeoptions "github.com/containerd/containerd/pkg/runtimeoptions/v1"
 )
 
 const (
@@ -222,7 +222,7 @@ func getUserFromImage(user string) (*int64, string) {
 // pulled yet, the function will pull the image.
 func (c *criService) ensureImageExists(ctx context.Context, ref string, config *runtime.PodSandboxConfig) (*imagestore.Image, error) {
 	image, err := c.localResolve(ref)
-	if err != nil && err != store.ErrNotExist {
+	if err != nil && !errdefs.IsNotFound(err) {
 		return nil, errors.Wrapf(err, "failed to get image %q", ref)
 	}
 	if err == nil {

--- a/pkg/cri/server/helpers_test.go
+++ b/pkg/cri/server/helpers_test.go
@@ -22,21 +22,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/oci"
+	criconfig "github.com/containerd/containerd/pkg/cri/config"
+	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
+	imagestore "github.com/containerd/containerd/pkg/cri/store/image"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/reference/docker"
 	"github.com/containerd/containerd/runtime/linux/runctypes"
 	runcoptions "github.com/containerd/containerd/runtime/v2/runc/options"
+
 	imagedigest "github.com/opencontainers/go-digest"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pelletier/go-toml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	criconfig "github.com/containerd/containerd/pkg/cri/config"
-	"github.com/containerd/containerd/pkg/cri/store"
-	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
-	imagestore "github.com/containerd/containerd/pkg/cri/store/image"
 )
 
 // TestGetUserFromImage tests the logic of getting image uid or user name of image user.
@@ -189,7 +189,7 @@ func TestLocalResolve(t *testing.T) {
 		assert.Equal(t, image, img)
 	}
 	img, err := c.localResolve("randomid")
-	assert.Equal(t, store.ErrNotExist, err)
+	assert.Equal(t, errdefs.IsNotFound(err), true)
 	assert.Equal(t, imagestore.Image{}, img)
 }
 

--- a/pkg/cri/server/image_remove.go
+++ b/pkg/cri/server/image_remove.go
@@ -19,11 +19,10 @@ package server
 import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
+
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
-
-	"github.com/containerd/containerd/pkg/cri/store"
 )
 
 // RemoveImage removes the image.
@@ -35,7 +34,7 @@ import (
 func (c *criService) RemoveImage(ctx context.Context, r *runtime.RemoveImageRequest) (*runtime.RemoveImageResponse, error) {
 	image, err := c.localResolve(r.GetImage().GetImage())
 	if err != nil {
-		if err == store.ErrNotExist {
+		if errdefs.IsNotFound(err) {
 			// return empty without error when image not found.
 			return &runtime.RemoveImageResponse{}, nil
 		}

--- a/pkg/cri/server/image_status.go
+++ b/pkg/cri/server/image_status.go
@@ -19,14 +19,14 @@ package server
 import (
 	"encoding/json"
 
+	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
+	imagestore "github.com/containerd/containerd/pkg/cri/store/image"
+
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
-
-	"github.com/containerd/containerd/pkg/cri/store"
-	imagestore "github.com/containerd/containerd/pkg/cri/store/image"
 )
 
 // ImageStatus returns the status of the image, returns nil if the image isn't present.
@@ -35,7 +35,7 @@ import (
 func (c *criService) ImageStatus(ctx context.Context, r *runtime.ImageStatusRequest) (*runtime.ImageStatusResponse, error) {
 	image, err := c.localResolve(r.GetImage().GetImage())
 	if err != nil {
-		if err == store.ErrNotExist {
+		if errdefs.IsNotFound(err) {
 			// return empty without error when image not found.
 			return &runtime.ImageStatusResponse{}, nil
 		}

--- a/pkg/cri/server/sandbox_remove.go
+++ b/pkg/cri/server/sandbox_remove.go
@@ -20,12 +20,11 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
-
-	"github.com/containerd/containerd/pkg/cri/store"
 )
 
 // RemovePodSandbox removes the sandbox. If there are running containers in the
@@ -33,7 +32,7 @@ import (
 func (c *criService) RemovePodSandbox(ctx context.Context, r *runtime.RemovePodSandboxRequest) (*runtime.RemovePodSandboxResponse, error) {
 	sandbox, err := c.sandboxStore.Get(r.GetPodSandboxId())
 	if err != nil {
-		if err != store.ErrNotExist {
+		if !errdefs.IsNotFound(err) {
 			return nil, errors.Wrapf(err, "an error occurred when try to find sandbox %q",
 				r.GetPodSandboxId())
 		}

--- a/pkg/cri/store/container/container.go
+++ b/pkg/cri/store/container/container.go
@@ -20,12 +20,13 @@ import (
 	"sync"
 
 	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/pkg/cri/store/label"
-	"github.com/containerd/containerd/pkg/cri/store/truncindex"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
-
+	"github.com/containerd/containerd/errdefs"
 	cio "github.com/containerd/containerd/pkg/cri/io"
 	"github.com/containerd/containerd/pkg/cri/store"
+	"github.com/containerd/containerd/pkg/cri/store/label"
+	"github.com/containerd/containerd/pkg/cri/store/truncindex"
+
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // Container contains all resources associated with the container. All methods to
@@ -124,7 +125,7 @@ func (s *Store) Add(c Container) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	if _, ok := s.containers[c.ID]; ok {
-		return store.ErrAlreadyExist
+		return errdefs.ErrAlreadyExists
 	}
 	if err := s.labels.Reserve(c.ProcessLabel); err != nil {
 		return err
@@ -144,14 +145,14 @@ func (s *Store) Get(id string) (Container, error) {
 	id, err := s.idIndex.Get(id)
 	if err != nil {
 		if err == truncindex.ErrNotExist {
-			err = store.ErrNotExist
+			err = errdefs.ErrNotFound
 		}
 		return Container{}, err
 	}
 	if c, ok := s.containers[id]; ok {
 		return c, nil
 	}
-	return Container{}, store.ErrNotExist
+	return Container{}, errdefs.ErrNotFound
 }
 
 // List lists all containers.

--- a/pkg/cri/store/container/container_test.go
+++ b/pkg/cri/store/container/container_test.go
@@ -21,13 +21,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/containerd/errdefs"
+	cio "github.com/containerd/containerd/pkg/cri/io"
 	"github.com/containerd/containerd/pkg/cri/store/label"
+
 	"github.com/opencontainers/selinux/go-selinux"
 	assertlib "github.com/stretchr/testify/assert"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
-
-	cio "github.com/containerd/containerd/pkg/cri/io"
-	"github.com/containerd/containerd/pkg/cri/store"
 )
 
 func TestContainerStore(t *testing.T) {
@@ -183,7 +183,7 @@ func TestContainerStore(t *testing.T) {
 		truncID := genTruncIndex(testID)
 
 		t.Logf("add should return already exists error for duplicated container")
-		assert.Equal(store.ErrAlreadyExist, s.Add(v))
+		assert.Equal(errdefs.ErrAlreadyExists, s.Add(v))
 
 		t.Logf("should be able to delete container")
 		s.Delete(truncID)
@@ -194,7 +194,7 @@ func TestContainerStore(t *testing.T) {
 		t.Logf("get should return not exist error after deletion")
 		c, err := s.Get(truncID)
 		assert.Equal(Container{}, c)
-		assert.Equal(store.ErrNotExist, err)
+		assert.Equal(errdefs.ErrNotFound, err)
 	}
 
 	if selinux.GetEnabled() {

--- a/pkg/cri/store/errors_test.go
+++ b/pkg/cri/store/errors_test.go
@@ -19,14 +19,14 @@ package store
 import (
 	"testing"
 
+	"github.com/containerd/containerd/errdefs"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	"github.com/containerd/containerd/errdefs"
 )
 
 func TestStoreErrAlreadyExistGRPCStatus(t *testing.T) {
-	err := errdefs.ToGRPC(ErrAlreadyExist)
+	err := errdefs.ToGRPC(errdefs.ErrAlreadyExists)
 	s, ok := status.FromError(err)
 	if !ok {
 		t.Fatalf("failed to convert err: %v to status: %d", err, codes.AlreadyExists)
@@ -37,7 +37,7 @@ func TestStoreErrAlreadyExistGRPCStatus(t *testing.T) {
 }
 
 func TestStoreErrNotExistGRPCStatus(t *testing.T) {
-	err := errdefs.ToGRPC(ErrNotExist)
+	err := errdefs.ToGRPC(errdefs.ErrNotFound)
 	s, ok := status.FromError(err)
 	if !ok {
 		t.Fatalf("failed to convert err: %v to status: %d", err, codes.NotFound)

--- a/pkg/cri/store/image/image.go
+++ b/pkg/cri/store/image/image.go
@@ -24,14 +24,13 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/pkg/cri/util"
+
 	imagedigest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/go-digest/digestset"
 	imageidentity "github.com/opencontainers/image-spec/identity"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
-
-	storeutil "github.com/containerd/containerd/pkg/cri/store"
-	"github.com/containerd/containerd/pkg/cri/util"
 )
 
 // Image contains all resources associated with the image. All fields
@@ -159,7 +158,7 @@ func (s *Store) Resolve(ref string) (string, error) {
 	defer s.lock.RUnlock()
 	id, ok := s.refCache[ref]
 	if !ok {
-		return "", storeutil.ErrNotExist
+		return "", errdefs.ErrNotFound
 	}
 	return id, nil
 }
@@ -222,14 +221,14 @@ func (s *store) get(id string) (Image, error) {
 	digest, err := s.digestSet.Lookup(id)
 	if err != nil {
 		if err == digestset.ErrDigestNotFound {
-			err = storeutil.ErrNotExist
+			err = errdefs.ErrNotFound
 		}
 		return Image{}, err
 	}
 	if i, ok := s.images[digest.String()]; ok {
 		return i, nil
 	}
-	return Image{}, storeutil.ErrNotExist
+	return Image{}, errdefs.ErrNotFound
 }
 
 func (s *store) delete(id, ref string) {

--- a/pkg/cri/store/image/image_test.go
+++ b/pkg/cri/store/image/image_test.go
@@ -21,10 +21,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/containerd/containerd/errdefs"
+
 	"github.com/opencontainers/go-digest/digestset"
 	assertlib "github.com/stretchr/testify/assert"
-
-	storeutil "github.com/containerd/containerd/pkg/cri/store"
 )
 
 func TestInternalStore(t *testing.T) {
@@ -128,7 +128,7 @@ func TestInternalStore(t *testing.T) {
 		t.Logf("should be able to delete image")
 		s.delete(truncID, newRef)
 		got, err = s.get(truncID)
-		assert.Equal(storeutil.ErrNotExist, err)
+		assert.Equal(errdefs.ErrNotFound, err)
 		assert.Equal(Image{}, got)
 
 		imageNum--
@@ -241,7 +241,7 @@ func TestImageStore(t *testing.T) {
 		if test.image == nil {
 			// Shouldn't be able to index by removed ref.
 			id, err := s.Resolve(test.ref)
-			assert.Equal(storeutil.ErrNotExist, err)
+			assert.Equal(errdefs.ErrNotFound, err)
 			assert.Empty(id)
 		}
 	}

--- a/pkg/cri/store/sandbox/sandbox.go
+++ b/pkg/cri/store/sandbox/sandbox.go
@@ -20,10 +20,10 @@ import (
 	"sync"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/pkg/cri/store"
 	"github.com/containerd/containerd/pkg/cri/store/label"
 	"github.com/containerd/containerd/pkg/cri/store/truncindex"
-
-	"github.com/containerd/containerd/pkg/cri/store"
 	"github.com/containerd/containerd/pkg/netns"
 )
 
@@ -80,7 +80,7 @@ func (s *Store) Add(sb Sandbox) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	if _, ok := s.sandboxes[sb.ID]; ok {
-		return store.ErrAlreadyExist
+		return errdefs.ErrAlreadyExists
 	}
 	if err := s.labels.Reserve(sb.ProcessLabel); err != nil {
 		return err
@@ -100,14 +100,14 @@ func (s *Store) Get(id string) (Sandbox, error) {
 	id, err := s.idIndex.Get(id)
 	if err != nil {
 		if err == truncindex.ErrNotExist {
-			err = store.ErrNotExist
+			err = errdefs.ErrNotFound
 		}
 		return Sandbox{}, err
 	}
 	if sb, ok := s.sandboxes[id]; ok {
 		return sb, nil
 	}
-	return Sandbox{}, store.ErrNotExist
+	return Sandbox{}, errdefs.ErrNotFound
 }
 
 // List lists all sandboxes.

--- a/pkg/cri/store/sandbox/sandbox_test.go
+++ b/pkg/cri/store/sandbox/sandbox_test.go
@@ -19,11 +19,11 @@ package sandbox
 import (
 	"testing"
 
+	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/pkg/cri/store/label"
+
 	assertlib "github.com/stretchr/testify/assert"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
-
-	"github.com/containerd/containerd/pkg/cri/store"
 )
 
 func TestSandboxStore(t *testing.T) {
@@ -140,7 +140,7 @@ func TestSandboxStore(t *testing.T) {
 		truncID := genTruncIndex(testID)
 
 		t.Logf("add should return already exists error for duplicated sandbox")
-		assert.Equal(store.ErrAlreadyExist, s.Add(v))
+		assert.Equal(errdefs.ErrAlreadyExists, s.Add(v))
 
 		t.Logf("should be able to delete sandbox")
 		s.Delete(truncID)
@@ -151,6 +151,6 @@ func TestSandboxStore(t *testing.T) {
 		t.Logf("get should return not exist error after deletion")
 		sb, err := s.Get(truncID)
 		assert.Equal(Sandbox{}, sb)
-		assert.Equal(store.ErrNotExist, err)
+		assert.Equal(errdefs.ErrNotFound, err)
 	}
 }

--- a/pkg/cri/store/snapshot/snapshot.go
+++ b/pkg/cri/store/snapshot/snapshot.go
@@ -19,9 +19,8 @@ package snapshot
 import (
 	"sync"
 
+	"github.com/containerd/containerd/errdefs"
 	snapshot "github.com/containerd/containerd/snapshots"
-
-	"github.com/containerd/containerd/pkg/cri/store"
 )
 
 // Snapshot contains the information about the snapshot.
@@ -65,7 +64,7 @@ func (s *Store) Get(key string) (Snapshot, error) {
 	if sn, ok := s.snapshots[key]; ok {
 		return sn, nil
 	}
-	return Snapshot{}, store.ErrNotExist
+	return Snapshot{}, errdefs.ErrNotFound
 }
 
 // List lists all snapshots.

--- a/pkg/cri/store/snapshot/snapshot_test.go
+++ b/pkg/cri/store/snapshot/snapshot_test.go
@@ -20,10 +20,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/containerd/errdefs"
 	snapshot "github.com/containerd/containerd/snapshots"
-	assertlib "github.com/stretchr/testify/assert"
 
-	"github.com/containerd/containerd/pkg/cri/store"
+	assertlib "github.com/stretchr/testify/assert"
 )
 
 func TestSnapshotStore(t *testing.T) {
@@ -80,5 +80,5 @@ func TestSnapshotStore(t *testing.T) {
 	t.Logf("get should return empty struct and ErrNotExist after deletion")
 	sn, err := s.Get(testKey)
 	assert.Equal(Snapshot{}, sn)
-	assert.Equal(store.ErrNotExist, err)
+	assert.Equal(errdefs.ErrNotFound, err)
 }


### PR DESCRIPTION
These errors have been DEPRECATED and will be removed in 1.5, switch usage directly to `errdefs.ErrAlreadyExists`.

Signed-off-by: Zou Nengren <zouyee1989@gmail.com>