### PR TITLE
archive: Add WriteDiff error logs

### DIFF
--- a/archive/tar.go
+++ b/archive/tar.go
@@ -54,6 +54,9 @@ func Diff(ctx context.Context, a, b string) io.ReadCloser {
 
 	go func() {
 		err := WriteDiff(ctx, w, a, b)
+		if err != nil {
+			log.G(ctx).WithError(err).Debugf("write diff failed")
+		}
 		if err = w.CloseWithError(err); err != nil {
 			log.G(ctx).WithError(err).Debugf("closing tar pipe failed")
 		}


### PR DESCRIPTION
Signed-off-by: Shiming Zhang <wzshiming@foxmail.com>


This seems to ignore the error message log of `WriteDiff`