### PR TITLE
add ip_pref CNI options for primary pod ip

### DIFF
--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -238,6 +238,12 @@ version = 2
     # This will be deprecated when kubenet is deprecated.
     # See the "CNI Config Template" section for more details.
     conf_template = ""
+    # ip_pref specifies the strategy to use when selecting the main IP address for a pod.
+    # options include:
+    # * ipv4, "" - (default) select the first ipv4 address
+    # * ipv6 - select the first ipv6 address
+    # * cni - use the order returned by the CNI plugins, returning the first IP address from the results
+    ip_pref = "ipv4"
 
   # 'plugins."io.containerd.grpc.v1.cri".image_decryption' contains config related
   # to handling decryption of encrypted container images.

--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -111,6 +111,13 @@ type CniConfig struct {
 	// a temporary backward-compatible solution for them.
 	// TODO(random-liu): Deprecate this option when kubenet is deprecated.
 	NetworkPluginConfTemplate string `toml:"conf_template" json:"confTemplate"`
+	// IPPreference specifies the strategy to use when selecting the main IP address for a pod.
+	//
+	// Options include:
+	// * ipv4, "" - (default) select the first ipv4 address
+	// * ipv6 - select the first ipv6 address
+	// * cni - use the order returned by the CNI plugins, returning the first IP address from the results
+	IPPreference string `toml:"ip_pref" json:"ipPref"`
 }
 
 // Mirror contains the config related to the registry mirror


### PR DESCRIPTION
This fixes the TODO of this function and also expands on how the primary pod ip
is selected. This change allows the operator to prefer ipv4, ipv6, or retain the
ordering provided by the return results of the CNI plugins.

This makes it much more flexible for ops to configure containerd and how IPs are
set on the pod.

Signed-off-by: Michael Crosby <michael@thepasture.io>