### PR TITLE
Fix content copy to not ignore unexpected EOF

### DIFF
--- a/content/helpers.go
+++ b/content/helpers.go
@@ -144,8 +144,13 @@ func Copy(ctx context.Context, cw Writer, r io.Reader, size int64, expected dige
 		}
 	}
 
-	if _, err := copyWithBuffer(cw, r); err != nil {
+	copied, err := copyWithBuffer(cw, r)
+	if err != nil {
 		return errors.Wrap(err, "failed to copy")
+	}
+	if size != 0 && copied < size-ws.Offset {
+		// Short writes would return its own error, this indicates a read failure
+		return errors.Wrapf(io.ErrUnexpectedEOF, "failed to read expected number of bytes")
 	}
 
 	if err := cw.Commit(ctx, size, expected, opts...); err != nil {
@@ -165,8 +170,15 @@ func CopyReaderAt(cw Writer, ra ReaderAt, n int64) error {
 		return err
 	}
 
-	_, err = copyWithBuffer(cw, io.NewSectionReader(ra, ws.Offset, n))
-	return err
+	copied, err := copyWithBuffer(cw, io.NewSectionReader(ra, ws.Offset, n))
+	if err != nil {
+		return errors.Wrap(err, "failed to copy")
+	}
+	if copied < n {
+		// Short writes would return its own error, this indicates a read failure
+		return errors.Wrap(io.ErrUnexpectedEOF, "failed to read expected number of bytes")
+	}
+	return nil
 }
 
 // CopyReader copies to a writer from a given reader, returning

--- a/content/helpers_test.go
+++ b/content/helpers_test.go
@@ -65,10 +65,11 @@ func TestCopy(t *testing.T) {
 		},
 		{
 			name:   "commit already exists",
-			source: defaultSource,
+			source: newCopySource("this already exists"),
 			writer: fakeWriter{commitFunc: func() error {
 				return errdefs.ErrAlreadyExists
 			}},
+			expected: "this already exists",
 		},
 	}
 


### PR DESCRIPTION
Also fixes the incorrect unit test which was no actually copying anything because of its reuse of a fully read reader