### PR TITLE
Make sure exit signals trigger an exit during init

### DIFF
--- a/cmd/containerd/command/main_unix.go
+++ b/cmd/containerd/command/main_unix.go
@@ -36,7 +36,7 @@ var handledSignals = []os.Signal{
 	unix.SIGPIPE,
 }
 
-func handleSignals(ctx context.Context, signals chan os.Signal, serverC chan *server.Server) chan struct{} {
+func handleSignals(ctx context.Context, signals chan os.Signal, serverC chan *server.Server, cancel func()) chan struct{} {
 	done := make(chan struct{}, 1)
 	go func() {
 		var server *server.Server
@@ -61,11 +61,10 @@ func handleSignals(ctx context.Context, signals chan os.Signal, serverC chan *se
 						log.G(ctx).WithError(err).Error("notify stopping failed")
 					}
 
-					if server == nil {
-						close(done)
-						return
+					cancel()
+					if server != nil {
+						server.Stop()
 					}
-					server.Stop()
 					close(done)
 					return
 				}

--- a/cmd/containerd/command/main_windows.go
+++ b/cmd/containerd/command/main_windows.go
@@ -39,7 +39,7 @@ var (
 	}
 )
 
-func handleSignals(ctx context.Context, signals chan os.Signal, serverC chan *server.Server) chan struct{} {
+func handleSignals(ctx context.Context, signals chan os.Signal, serverC chan *server.Server, cancel func()) chan struct{} {
 	done := make(chan struct{})
 	go func() {
 		var server *server.Server
@@ -54,12 +54,12 @@ func handleSignals(ctx context.Context, signals chan os.Signal, serverC chan *se
 					log.G(ctx).WithError(err).Error("notify stopping failed")
 				}
 
-				if server == nil {
-					close(done)
-					return
+				cancel()
+				if server != nil {
+					server.Stop()
 				}
-				server.Stop()
 				close(done)
+				return
 			}
 		}
 	}()


### PR DESCRIPTION
Some cases can cause the server initialization to block (namely running
a 2nd containerd instance by accident against the same root dir). In
this case there is no way to quit the daemon except with `kill -9`.

This changes context things so that server init is done in a goroutine
and we wait on a channel for it to be ready while we also wait for a
ctx.Done(), which will be cancelled if there is a termination signal.

Closes #5963