### PR TITLE
CI: Switch to available latest images

### DIFF
--- a/integration/client/client_unix_test.go
+++ b/integration/client/client_unix_test.go
@@ -32,7 +32,7 @@ const (
 )
 
 var (
-	testImage    = "mirror.gcr.io/library/busybox:1.32"
+	testImage    = "mirror.gcr.io/library/busybox:1.32.0"
 	shortCommand = withProcessArgs("true")
 	longCommand  = withProcessArgs("/bin/sh", "-c", "while true; do sleep 1; done")
 )


### PR DESCRIPTION
`mirror.gcr.io/library/busybox:1.32` is unavailable.

```console
$ curl -s https://mirror.gcr.io//v2/library/busybox/tags/list | jq '.tags'
[
    "1-musl",
    "1.26.2",
    "1.27.2",
    "1.28",
    "1.29",
    "1.29.2",
    "1.29.3",
    "1.30",
    "1.30.1",
    "1.31",
    "1.31.0",
    "1.31.1",
    "1.32.0",
    "1.33",
    "latest",
    "stable"
]
```
and latest is the same as 1.33
```
tag: [
    "1.33",
    "latest",
    "stable"
],
```

Signed-off-by: wllenyj <wllenyj@linux.alibaba.com>