### PR TITLE
 FreeBSD: fix tar headers & the nil check on getxattr 

### DIFF
--- a/archive/tar.go
+++ b/archive/tar.go
@@ -598,7 +598,7 @@ func (cw *ChangeWriter) HandleChange(k fs.ChangeKind, p string, f os.FileInfo, e
 
 		if capability, err := getxattr(source, "security.capability"); err != nil {
 			return errors.Wrap(err, "failed to get capabilities xattr")
-		} else if capability != nil {
+		} else if len(capability) > 0 {
 			if hdr.PAXRecords == nil {
 				hdr.PAXRecords = map[string]string{}
 			}

--- a/archive/tar_unix.go
+++ b/archive/tar_unix.go
@@ -22,6 +22,7 @@ package archive
 import (
 	"archive/tar"
 	"os"
+	"runtime"
 	"strings"
 	"syscall"
 
@@ -41,6 +42,20 @@ func chmodTarEntry(perm os.FileMode) os.FileMode {
 }
 
 func setHeaderForSpecialDevice(hdr *tar.Header, name string, fi os.FileInfo) error {
+	// Devmajor and Devminor are only needed for special devices.
+
+	// In FreeBSD, RDev for regular files is -1 (unless overridden by FS):
+	// https://cgit.freebsd.org/src/tree/sys/kern/vfs_default.c?h=stable/13#n1531
+	// (NODEV is -1: https://cgit.freebsd.org/src/tree/sys/sys/param.h?h=stable/13#n241).
+
+	// ZFS in particular does not override the default:
+	// https://cgit.freebsd.org/src/tree/sys/contrib/openzfs/module/os/freebsd/zfs/zfs_vnops_os.c?h=stable/13#n2027
+
+	// Since `Stat_t.Rdev` is uint64, the cast turns -1 into (2^64 - 1).
+	// Such large values cannot be encoded in a tar header.
+	if runtime.GOOS == "freebsd" && hdr.Typeflag != tar.TypeBlock && hdr.Typeflag != tar.TypeChar {
+		return nil
+	}
 	s, ok := fi.Sys().(*syscall.Stat_t)
 	if !ok {
 		return errors.New("unsupported stat type")


### PR DESCRIPTION
On FreeBSD + zfs, stat call seem to return garbage in RDev for regular
files & folders. The value returned is large enough not to fit into
`Devmajor` & `Devminor` fields of the tar header. Fortunately, these
fields are required just for special devices.

This change

* adds a check into `setHeaderForSpecialDevice` that the
  input header represents a special device. If it's not the case, we
  don't set the Devmajor & Devminor fields.

* fixes the nil check on `getxattr`: it never returns nils, but rather
  an empty slice instead