### PR TITLE
import: Add option to prevent duplicated digest image

### DIFF
--- a/cmd/ctr/commands/images/import.go
+++ b/cmd/ctr/commands/images/import.go
@@ -60,6 +60,10 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 			Name:  "digests",
 			Usage: "whether to create digest images (default: false)",
 		},
+		cli.BoolFlag{
+			Name:  "skip-digest-for-named",
+			Usage: "skip applying --digests option to images named in the importing tar (use it in conjunction with --digests)",
+		},
 		cli.StringFlag{
 			Name:  "index-name",
 			Usage: "image name to keep index as, by default index is discarded",
@@ -95,6 +99,12 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 
 		if context.Bool("digests") {
 			opts = append(opts, containerd.WithDigestRef(archive.DigestTranslator(prefix)))
+		}
+		if context.Bool("skip-digest-for-named") {
+			if !context.Bool("digests") {
+				return fmt.Errorf("--skip-digest-for-named must be specified with --digests option")
+			}
+			opts = append(opts, containerd.WithSkipDigestRef(func(name string) bool { return name != "" }))
 		}
 
 		if idxName := context.String("index-name"); idxName != "" {

--- a/import.go
+++ b/import.go
@@ -34,6 +34,7 @@ type importOpts struct {
 	indexName    string
 	imageRefT    func(string) string
 	dgstRefT     func(digest.Digest) string
+	skipDgstRef  func(string) bool
 	allPlatforms bool
 	compress     bool
 }
@@ -55,6 +56,17 @@ func WithImageRefTranslator(f func(string) string) ImportOpt {
 func WithDigestRef(f func(digest.Digest) string) ImportOpt {
 	return func(c *importOpts) error {
 		c.dgstRefT = f
+		return nil
+	}
+}
+
+// WithSkipDigestRef is used to specify when to skip applying
+// WithDigestRef. The callback receives an image reference (or an empty
+// string if not specified in the image). When the callback returns true,
+// the skip occurs.
+func WithSkipDigestRef(f func(string) bool) ImportOpt {
+	return func(c *importOpts) error {
+		c.skipDgstRef = f
 		return nil
 	}
 }
@@ -151,6 +163,11 @@ func (c *Client) Import(ctx context.Context, reader io.Reader, opts ...ImportOpt
 					Name:   name,
 					Target: m,
 				})
+			}
+			if iopts.skipDgstRef != nil {
+				if iopts.skipDgstRef(name) {
+					continue
+				}
 			}
 			if iopts.dgstRefT != nil {
 				ref := iopts.dgstRefT(m.Digest)


### PR DESCRIPTION
Currently, import's `WithDigestRef` always creates digest image for all manifests
in an index even if some of them are named in the image tarball (by `RepoTag` of
manifest.json and annotations in index.json, etc).

However, there can be client tools that want to avoid duplicated digest images
for named images.
This commit addresses such requirements.

This should be needed to address the issue of duplicated images in nerdctl (https://github.com/containerd/nerdctl/issues/177, https://github.com/containerd/nerdctl/pull/357)

cc: @AkihiroSuda @fahedouch 