### PR TITLE
Adds support for enabling integrity protection for LCOW layers

### DIFF
--- a/image.go
+++ b/image.go
@@ -300,6 +300,14 @@ func WithSnapshotterPlatformCheck() UnpackOpt {
 	}
 }
 
+// WithUnpackConfigApplyOpts sets ApplyOpts for UnpackConfig
+func WithUnpackConfigApplyOpts(opts ...diff.ApplyOpt) UnpackOpt {
+	return func(_ context.Context, uc *UnpackConfig) error {
+		uc.ApplyOpts = append(uc.ApplyOpts, opts...)
+		return nil
+	}
+}
+
 func (i *image) Unpack(ctx context.Context, snapshotterName string, opts ...UnpackOpt) error {
 	ctx, done, err := i.client.WithLease(ctx)
 	if err != nil {

--- a/pkg/cri/server/image_pull.go
+++ b/pkg/cri/server/image_pull.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/diff"
 	"github.com/containerd/containerd/errdefs"
 	containerdimages "github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/labels"
@@ -121,6 +122,7 @@ func (c *criService) PullImage(ctx context.Context, r *runtime.PullImageRequest)
 		containerd.WithPullLabel(imageLabelKey, imageLabelValue),
 		containerd.WithMaxConcurrentDownloads(c.config.MaxConcurrentDownloads),
 		containerd.WithImageHandler(imageHandler),
+		containerd.WithPullLabels(diff.FilterDiffLabels(r.GetSandboxConfig().GetLabels())),
 	}
 
 	pullOpts = append(pullOpts, c.encryptedImagesPullOpts()...)


### PR DESCRIPTION
A new feature has been added to hcsshim where read-only LCOW layers
can be mounted with integrity protection. This is done by reading
the hash device information from layer VHD and passing it to the
LCOW UVM, where device mapper checks the integrity via dm-verity
Linux kernel feature. Layout on disk is expected to be:

```
|Byte 0   |Byte size(ext4)      |Byte size(ext4)+size(hash device)|
|ext4 data|dm-verity hash device|VHD footer                       |
```

This PR adds ability to append hash device data during LCOW image
extraction. The additional metadata to tar2ext4 converter is passed
via diff.ApplyConfig.ProcessorPayloads.

Signed-off-by: Maksim An <maksiman@microsoft.com>