### PR TITLE
integration: mirror.gcr.io/* -> ghcr.io/stargz-containers/*-org

### DIFF
--- a/integration/client/client_unix_test.go
+++ b/integration/client/client_unix_test.go
@@ -32,7 +32,8 @@ const (
 )
 
 var (
-	testImage    = "mirror.gcr.io/library/busybox:1.32.0"
+	// plain mirror, NOT stargz-converted image
+	testImage    = "ghcr.io/stargz-containers/busybox:1.32.0-org"
 	shortCommand = withProcessArgs("true")
 	longCommand  = withProcessArgs("/bin/sh", "-c", "while true; do sleep 1; done")
 )

--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -53,7 +53,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const testUserNSImage = "mirror.gcr.io/library/alpine:3.13.5"
+// plain mirror, NOT stargz-converted image
+const testUserNSImage = "ghcr.io/stargz-containers/alpine:3.13-org"
 
 // TestRegressionIssue4769 verifies the number of task exit events.
 //


### PR DESCRIPTION
We have been seeing 404 errors randomly because mirror.gcr.io actually works
as a cache, not a mirror.

So switch away from mirror.gcr.io/* to ghcr.io/stargz-containers/*-org .
The *-org images are plain mirror images, NOT stargz-converted images.

Thanks to @ktock for creating mirrors