### PR TITLE
[WIP] Prepare release notes for v1.4.10

### DIFF
--- a/releases/v1.4.10.toml
+++ b/releases/v1.4.10.toml
@@ -1,0 +1,23 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release
+previous = "v1.4.9"
+
+pre_release = false
+
+preface = """\
+The tenth patch release for containerd 1.4 updates runc to 1.0.2, hcsshim to 0.8.21, Go
+to 1.15.15 and other minor updates.
+
+### Notable Updates
+
+* **Update Go to 1.15.15** [#5841](https://github.com/containerd/containerd/pull/5841)
+* **Update hcsshim to v0.8.21** [#5957](https://github.com/containerd/containerd/pull/5957)
+* **Update runc to v1.0.2** [#5984](https://github.com/containerd/containerd/pull/5984)
+
+See the changelog for complete list of changes"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.4.9+unknown"
+	Version = "1.4.10+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Wanted to open this to get the convo started on a new 1.4.x release as seems like there's enough to justify a new patch. Noticed @dmcgowan has opened all of the previous patch bump PRs so feel free to steal my branch and re-open 😋

As far as I can see, there's currently ~two~ one outstanding PR towards 1.4 that we might want to wait for. 

~https://github.com/containerd/containerd/pull/6014~ [Merged]
1. https://github.com/containerd/containerd/pull/6010

cc @kevpar 