### PR TITLE
[WIP] Prepare release notes for v1.5.6

### DIFF
--- a/releases/v1.5.6.toml
+++ b/releases/v1.5.6.toml
@@ -1,0 +1,23 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release
+previous = "v1.5.5"
+
+pre_release = false
+
+preface = """\
+The sixth patch release for containerd 1.5 updates runc to 1.0.2, seccomp to 2.5.1, and contains various other fixes.
+
+### Notable Updates
+
+* **Update runc binary to 1.0.2** [#5983](https://github.com/containerd/containerd/pull/5983)
+* **Update hcsshim to v0.8.21 which contains a fix in the Windows shim for layer issues on Windows Server 2019** [#5942](https://github.com/containerd/containerd/pull/5942)
+* **Install apparmor parser for arm64 and update seccomp to 2.5.1** [#5763](https://github.com/containerd/containerd/pull/5763)
+* **Add support for 'clone3' syscall to fix issues with certain images when seccomp is enabled** [#6013](https://github.com/containerd/containerd/pull/6013)
+
+See the changelog for complete list of changes"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.5.5+unknown"
+	Version = "1.5.6+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Wanted to open this to get the convo started on a new 1.5.x release as seems like there's enough to justify a new patch. Noticed @dmcgowan has opened all of the previous patch bump PRs so feel free to steal my branch and re-open 😋

There's a couple outstanding PRs that might be nice to wait for. 

1. https://github.com/containerd/containerd/pull/6024
2. https://github.com/containerd/containerd/pull/5981
3. https://github.com/containerd/containerd/pull/5104

cc @kevpar