### PR TITLE
add current process state to the error message

### DIFF
--- a/process.go
+++ b/process.go
@@ -210,7 +210,7 @@ func (p *process) Delete(ctx context.Context, opts ...ProcessDeleteOpts) (*ExitS
 	}
 	switch status.Status {
 	case Running, Paused, Pausing:
-		return nil, errors.Wrapf(errdefs.ErrFailedPrecondition, "process must be stopped before deletion")
+		return nil, errors.Wrapf(errdefs.ErrFailedPrecondition, "current process state: %s, process must be stopped before deletion", status.Status)
 	}
 	r, err := p.task.client.TaskService().DeleteProcess(ctx, &tasks.DeleteProcessRequest{
 		ContainerID: p.task.id,


### PR DESCRIPTION
It will aid debugging if a procees delete fails, to figure out whether
it is paused or running.

Signed-off-by: Alakesh Haloi <alakeshh@amazon.com>