### PR TITLE
bump continuity and console version  that remove pkg/errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,9 @@ require (
 	github.com/containerd/aufs v1.0.0
 	github.com/containerd/btrfs v1.0.0
 	github.com/containerd/cgroups v1.0.1
-	github.com/containerd/console v1.0.2
+	github.com/containerd/console v1.0.3
 	github.com/containerd/containerd/api v0.0.0
-	github.com/containerd/continuity v0.1.1-0.20210910181051-2e0898a8e801
+	github.com/containerd/continuity v0.2.0
 	github.com/containerd/fifo v1.0.0
 	github.com/containerd/go-cni v1.0.2
 	github.com/containerd/go-runc v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -108,11 +108,12 @@ github.com/containerd/cgroups v0.0.0-20210114181951-8a68de567b68/go.mod h1:ZJeTF
 github.com/containerd/cgroups v1.0.1 h1:iJnMvco9XGvKUvNQkv88bE4uJXxRQH18efbKo9w5vHQ=
 github.com/containerd/cgroups v1.0.1/go.mod h1:0SJrPIenamHDcZhEcJMNBB85rHcUsw4f25ZfBiPYRkU=
 github.com/containerd/console v1.0.1/go.mod h1:XUsP6YE/mKtz6bxc+I8UiKKTP04qjQL4qcS3XoQ5xkw=
-github.com/containerd/console v1.0.2 h1:Pi6D+aZXM+oUw1czuKgH5IJ+y0jhYcwBJfx5/Ghn9dE=
 github.com/containerd/console v1.0.2/go.mod h1:ytZPjGgY2oeTkAONYafi2kSj0aYggsf8acV1PGKCbzQ=
+github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=
+github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=
 github.com/containerd/continuity v0.0.0-20210208174643-50096c924a4e/go.mod h1:EXlVlkqNba9rJe3j7w3Xa924itAMLgZH4UD/Q4PExuQ=
-github.com/containerd/continuity v0.1.1-0.20210910181051-2e0898a8e801 h1:JKh6jHPjtcqEVLsZ2vSC34Er40Bj/Fdq9ROGPuiQPLg=
-github.com/containerd/continuity v0.1.1-0.20210910181051-2e0898a8e801/go.mod h1:51Oa4sEFsAGujlzNbDPNB0hC1utY7N91xOzW161q5nE=
+github.com/containerd/continuity v0.2.0 h1:j/9Wnn+hrEWjLvHuIxUU1YI5JjEjVlT2AA68cse9rwY=
+github.com/containerd/continuity v0.2.0/go.mod h1:wCYX+dRqZdImhGucXOqTQn05AhX6EUDaGEMUzTFFpLg=
 github.com/containerd/fifo v1.0.0 h1:6PirWBr9/L7GDamKr+XM0IeUFXu5mf3M/BPpH9gaLBU=
 github.com/containerd/fifo v1.0.0/go.mod h1:ocF/ME1SX5b1AOlWi9r677YJmCPSwwWnQ9O123vzpE4=
 github.com/containerd/go-cni v1.0.2 h1:YbJAhpTevL2v6u8JC1NhCYRwf+3Vzxcc5vGnYoJ7VeE=

--- a/integration/client/go.sum
+++ b/integration/client/go.sum
@@ -105,11 +105,12 @@ github.com/containerd/cgroups v1.0.1 h1:iJnMvco9XGvKUvNQkv88bE4uJXxRQH18efbKo9w5
 github.com/containerd/cgroups v1.0.1/go.mod h1:0SJrPIenamHDcZhEcJMNBB85rHcUsw4f25ZfBiPYRkU=
 github.com/containerd/console v0.0.0-20191206165004-02ecf6a7291e/go.mod h1:8Pf4gM6VEbTNRIT26AyyU7hxdQU3MvAvxVI0sc00XBE=
 github.com/containerd/console v1.0.1/go.mod h1:XUsP6YE/mKtz6bxc+I8UiKKTP04qjQL4qcS3XoQ5xkw=
-github.com/containerd/console v1.0.2 h1:Pi6D+aZXM+oUw1czuKgH5IJ+y0jhYcwBJfx5/Ghn9dE=
 github.com/containerd/console v1.0.2/go.mod h1:ytZPjGgY2oeTkAONYafi2kSj0aYggsf8acV1PGKCbzQ=
+github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=
+github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=
 github.com/containerd/continuity v0.0.0-20210208174643-50096c924a4e/go.mod h1:EXlVlkqNba9rJe3j7w3Xa924itAMLgZH4UD/Q4PExuQ=
-github.com/containerd/continuity v0.1.1-0.20210910181051-2e0898a8e801 h1:JKh6jHPjtcqEVLsZ2vSC34Er40Bj/Fdq9ROGPuiQPLg=
-github.com/containerd/continuity v0.1.1-0.20210910181051-2e0898a8e801/go.mod h1:51Oa4sEFsAGujlzNbDPNB0hC1utY7N91xOzW161q5nE=
+github.com/containerd/continuity v0.2.0 h1:j/9Wnn+hrEWjLvHuIxUU1YI5JjEjVlT2AA68cse9rwY=
+github.com/containerd/continuity v0.2.0/go.mod h1:wCYX+dRqZdImhGucXOqTQn05AhX6EUDaGEMUzTFFpLg=
 github.com/containerd/fifo v1.0.0 h1:6PirWBr9/L7GDamKr+XM0IeUFXu5mf3M/BPpH9gaLBU=
 github.com/containerd/fifo v1.0.0/go.mod h1:ocF/ME1SX5b1AOlWi9r677YJmCPSwwWnQ9O123vzpE4=
 github.com/containerd/go-cni v1.0.2/go.mod h1:nrNABBHzu0ZwCug9Ije8hL2xBCYh/pjfMb1aZGrrohk=

--- a/vendor/github.com/containerd/console/console_windows.go
+++ b/vendor/github.com/containerd/console/console_windows.go
@@ -17,10 +17,10 @@
 package console
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/windows"
 )
 
@@ -103,7 +103,7 @@ func (m *master) Reset() error {
 		{m.err, m.errMode},
 	} {
 		if err := windows.SetConsoleMode(s.fd, s.mode); err != nil {
-			return errors.Wrap(err, "unable to restore console mode")
+			return fmt.Errorf("unable to restore console mode: %w", err)
 		}
 	}
 
@@ -114,7 +114,7 @@ func (m *master) Size() (WinSize, error) {
 	var info windows.ConsoleScreenBufferInfo
 	err := windows.GetConsoleScreenBufferInfo(m.out, &info)
 	if err != nil {
-		return WinSize{}, errors.Wrap(err, "unable to get console info")
+		return WinSize{}, fmt.Errorf("unable to get console info: %w", err)
 	}
 
 	winsize := WinSize{
@@ -139,7 +139,7 @@ func (m *master) DisableEcho() error {
 	mode |= windows.ENABLE_LINE_INPUT
 
 	if err := windows.SetConsoleMode(m.in, mode); err != nil {
-		return errors.Wrap(err, "unable to set console to disable echo")
+		return fmt.Errorf("unable to set console to disable echo: %w", err)
 	}
 
 	return nil
@@ -192,7 +192,7 @@ func makeInputRaw(fd windows.Handle, mode uint32) error {
 	}
 
 	if err := windows.SetConsoleMode(fd, mode); err != nil {
-		return errors.Wrap(err, "unable to set console to raw mode")
+		return fmt.Errorf("unable to set console to raw mode: %w", err)
 	}
 
 	return nil

--- a/vendor/github.com/containerd/console/console_zos.go
+++ b/vendor/github.com/containerd/console/console_zos.go
@@ -1,0 +1,163 @@
+// +build zos
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package console
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// NewPty creates a new pty pair
+// The master is returned as the first console and a string
+// with the path to the pty slave is returned as the second
+func NewPty() (Console, string, error) {
+	var f File
+	var err error
+	var slave string
+	for i := 0;; i++ {
+		ptyp := fmt.Sprintf("/dev/ptyp%04d", i)
+		f, err = os.OpenFile(ptyp, os.O_RDWR, 0600)
+		if err == nil {
+			slave = fmt.Sprintf("/dev/ttyp%04d", i)
+			break
+		}
+		if os.IsNotExist(err) {
+			return nil, "", err
+		}
+		// else probably Resource Busy
+	}
+	m, err := newMaster(f)
+	if err != nil {
+		return nil, "", err
+	}
+	return m, slave, nil
+}
+
+type master struct {
+	f        File
+	original *unix.Termios
+}
+
+func (m *master) Read(b []byte) (int, error) {
+	return m.f.Read(b)
+}
+
+func (m *master) Write(b []byte) (int, error) {
+	return m.f.Write(b)
+}
+
+func (m *master) Close() error {
+	return m.f.Close()
+}
+
+func (m *master) Resize(ws WinSize) error {
+	return tcswinsz(m.f.Fd(), ws)
+}
+
+func (m *master) ResizeFrom(c Console) error {
+	ws, err := c.Size()
+	if err != nil {
+		return err
+	}
+	return m.Resize(ws)
+}
+
+func (m *master) Reset() error {
+	if m.original == nil {
+		return nil
+	}
+	return tcset(m.f.Fd(), m.original)
+}
+
+func (m *master) getCurrent() (unix.Termios, error) {
+	var termios unix.Termios
+	if err := tcget(m.f.Fd(), &termios); err != nil {
+		return unix.Termios{}, err
+	}
+	return termios, nil
+}
+
+func (m *master) SetRaw() error {
+	rawState, err := m.getCurrent()
+	if err != nil {
+		return err
+	}
+	rawState = cfmakeraw(rawState)
+	rawState.Oflag = rawState.Oflag | unix.OPOST
+	return tcset(m.f.Fd(), &rawState)
+}
+
+func (m *master) DisableEcho() error {
+	rawState, err := m.getCurrent()
+	if err != nil {
+		return err
+	}
+	rawState.Lflag = rawState.Lflag &^ unix.ECHO
+	return tcset(m.f.Fd(), &rawState)
+}
+
+func (m *master) Size() (WinSize, error) {
+	return tcgwinsz(m.f.Fd())
+}
+
+func (m *master) Fd() uintptr {
+	return m.f.Fd()
+}
+
+func (m *master) Name() string {
+	return m.f.Name()
+}
+
+// checkConsole checks if the provided file is a console
+func checkConsole(f File) error {
+	var termios unix.Termios
+	if tcget(f.Fd(), &termios) != nil {
+		return ErrNotAConsole
+	}
+	return nil
+}
+
+func newMaster(f File) (Console, error) {
+	m := &master{
+		f: f,
+	}
+	t, err := m.getCurrent()
+	if err != nil {
+		return nil, err
+	}
+	m.original = &t
+	return m, nil
+}
+
+// ClearONLCR sets the necessary tty_ioctl(4)s to ensure that a pty pair
+// created by us acts normally. In particular, a not-very-well-known default of
+// Linux unix98 ptys is that they have +onlcr by default. While this isn't a
+// problem for terminal emulators, because we relay data from the terminal we
+// also relay that funky line discipline.
+func ClearONLCR(fd uintptr) error {
+	return setONLCR(fd, false)
+}
+
+// SetONLCR sets the necessary tty_ioctl(4)s to ensure that a pty pair
+// created by us acts as intended for a terminal emulator.
+func SetONLCR(fd uintptr) error {
+	return setONLCR(fd, true)
+}

--- a/vendor/github.com/containerd/console/go.mod
+++ b/vendor/github.com/containerd/console/go.mod
@@ -2,7 +2,4 @@ module github.com/containerd/console
 
 go 1.13
 
-require (
-	github.com/pkg/errors v0.9.1
-	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c
-)
+require golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c

--- a/vendor/github.com/containerd/console/go.sum
+++ b/vendor/github.com/containerd/console/go.sum
@@ -1,4 +1,2 @@
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/vendor/github.com/containerd/console/tc_unix.go
+++ b/vendor/github.com/containerd/console/tc_unix.go
@@ -1,4 +1,4 @@
-// +build darwin freebsd linux netbsd openbsd solaris
+// +build darwin freebsd linux netbsd openbsd solaris zos
 
 /*
    Copyright The containerd Authors.

--- a/vendor/github.com/containerd/console/tc_zos.go
+++ b/vendor/github.com/containerd/console/tc_zos.go
@@ -1,6 +1,3 @@
-//go:build freebsd
-// +build freebsd
-
 /*
    Copyright The containerd Authors.
 
@@ -17,10 +14,13 @@
    limitations under the License.
 */
 
-package devices
+package console
 
-import "golang.org/x/sys/unix"
+import (
+	"golang.org/x/sys/unix"
+)
 
-func mknod(path string, mode uint32, dev uint64) (err error) {
-	return unix.Mknod(path, mode, dev)
-}
+const (
+	cmdTcGet = unix.TCGETS
+	cmdTcSet = unix.TCSETS
+)

--- a/vendor/github.com/containerd/continuity/devices/devices_unix.go
+++ b/vendor/github.com/containerd/continuity/devices/devices_unix.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin || freebsd || solaris
 // +build linux darwin freebsd solaris
 
 /*

--- a/vendor/github.com/containerd/continuity/devices/devices_windows.go
+++ b/vendor/github.com/containerd/continuity/devices/devices_windows.go
@@ -17,11 +17,10 @@
 package devices
 
 import (
+	"fmt"
 	"os"
-
-	"github.com/pkg/errors"
 )
 
 func DeviceInfo(fi os.FileInfo) (uint64, uint64, error) {
-	return 0, 0, errors.Wrap(ErrNotSupported, "cannot get device info on windows")
+	return 0, 0, fmt.Errorf("cannot get device info on windows: %w", ErrNotSupported)
 }

--- a/vendor/github.com/containerd/continuity/devices/mknod_unix.go
+++ b/vendor/github.com/containerd/continuity/devices/mknod_unix.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin || solaris
 // +build linux darwin solaris
 
 /*

--- a/vendor/github.com/containerd/continuity/driver/driver_unix.go
+++ b/vendor/github.com/containerd/continuity/driver/driver_unix.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin || freebsd || solaris
 // +build linux darwin freebsd solaris
 
 /*

--- a/vendor/github.com/containerd/continuity/driver/driver_windows.go
+++ b/vendor/github.com/containerd/continuity/driver/driver_windows.go
@@ -1,3 +1,4 @@
+//go:build go1.13
 // +build go1.13
 
 /*

--- a/vendor/github.com/containerd/continuity/driver/lchmod_unix.go
+++ b/vendor/github.com/containerd/continuity/driver/lchmod_unix.go
@@ -1,3 +1,4 @@
+//go:build darwin || freebsd || solaris
 // +build darwin freebsd solaris
 
 /*

--- a/vendor/github.com/containerd/continuity/fs/copy.go
+++ b/vendor/github.com/containerd/continuity/fs/copy.go
@@ -17,12 +17,11 @@
 package fs
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
-
-	"github.com/pkg/errors"
 )
 
 var bufferPool = &sync.Pool{
@@ -92,35 +91,35 @@ func CopyDir(dst, src string, opts ...CopyDirOpt) error {
 func copyDirectory(dst, src string, inodes map[uint64]string, o *copyDirOpts) error {
 	stat, err := os.Stat(src)
 	if err != nil {
-		return errors.Wrapf(err, "failed to stat %s", src)
+		return fmt.Errorf("failed to stat %s: %w", src, err)
 	}
 	if !stat.IsDir() {
-		return errors.Errorf("source %s is not directory", src)
+		return fmt.Errorf("source %s is not directory", src)
 	}
 
 	if st, err := os.Stat(dst); err != nil {
 		if err := os.Mkdir(dst, stat.Mode()); err != nil {
-			return errors.Wrapf(err, "failed to mkdir %s", dst)
+			return fmt.Errorf("failed to mkdir %s: %w", dst, err)
 		}
 	} else if !st.IsDir() {
-		return errors.Errorf("cannot copy to non-directory: %s", dst)
+		return fmt.Errorf("cannot copy to non-directory: %s", dst)
 	} else {
 		if err := os.Chmod(dst, stat.Mode()); err != nil {
-			return errors.Wrapf(err, "failed to chmod on %s", dst)
+			return fmt.Errorf("failed to chmod on %s: %w", dst, err)
 		}
 	}
 
 	fis, err := ioutil.ReadDir(src)
 	if err != nil {
-		return errors.Wrapf(err, "failed to read %s", src)
+		return fmt.Errorf("failed to read %s: %w", src, err)
 	}
 
 	if err := copyFileInfo(stat, dst); err != nil {
-		return errors.Wrapf(err, "failed to copy file info for %s", dst)
+		return fmt.Errorf("failed to copy file info for %s: %w", dst, err)
 	}
 
 	if err := copyXAttrs(dst, src, o.xex, o.xeh); err != nil {
-		return errors.Wrap(err, "failed to copy xattrs")
+		return fmt.Errorf("failed to copy xattrs: %w", err)
 	}
 
 	for _, fi := range fis {
@@ -136,37 +135,37 @@ func copyDirectory(dst, src string, inodes map[uint64]string, o *copyDirOpts) er
 		case (fi.Mode() & os.ModeType) == 0:
 			link, err := getLinkSource(target, fi, inodes)
 			if err != nil {
-				return errors.Wrap(err, "failed to get hardlink")
+				return fmt.Errorf("failed to get hardlink: %w", err)
 			}
 			if link != "" {
 				if err := os.Link(link, target); err != nil {
-					return errors.Wrap(err, "failed to create hard link")
+					return fmt.Errorf("failed to create hard link: %w", err)
 				}
 			} else if err := CopyFile(target, source); err != nil {
-				return errors.Wrap(err, "failed to copy files")
+				return fmt.Errorf("failed to copy files: %w", err)
 			}
 		case (fi.Mode() & os.ModeSymlink) == os.ModeSymlink:
 			link, err := os.Readlink(source)
 			if err != nil {
-				return errors.Wrapf(err, "failed to read link: %s", source)
+				return fmt.Errorf("failed to read link: %s: %w", source, err)
 			}
 			if err := os.Symlink(link, target); err != nil {
-				return errors.Wrapf(err, "failed to create symlink: %s", target)
+				return fmt.Errorf("failed to create symlink: %s: %w", target, err)
 			}
 		case (fi.Mode() & os.ModeDevice) == os.ModeDevice:
 			if err := copyDevice(target, fi); err != nil {
-				return errors.Wrapf(err, "failed to create device")
+				return fmt.Errorf("failed to create device: %w", err)
 			}
 		default:
 			// TODO: Support pipes and sockets
-			return errors.Wrapf(err, "unsupported mode %s", fi.Mode())
+			return fmt.Errorf("unsupported mode %s: %w", fi.Mode(), err)
 		}
 		if err := copyFileInfo(fi, target); err != nil {
-			return errors.Wrap(err, "failed to copy file info")
+			return fmt.Errorf("failed to copy file info: %w", err)
 		}
 
 		if err := copyXAttrs(target, source, o.xex, o.xeh); err != nil {
-			return errors.Wrap(err, "failed to copy xattrs")
+			return fmt.Errorf("failed to copy xattrs: %w", err)
 		}
 	}
 
@@ -178,12 +177,12 @@ func copyDirectory(dst, src string, inodes map[uint64]string, o *copyDirOpts) er
 func CopyFile(target, source string) error {
 	src, err := os.Open(source)
 	if err != nil {
-		return errors.Wrapf(err, "failed to open source %s", source)
+		return fmt.Errorf("failed to open source %s: %w", source, err)
 	}
 	defer src.Close()
 	tgt, err := os.Create(target)
 	if err != nil {
-		return errors.Wrapf(err, "failed to open target %s", target)
+		return fmt.Errorf("failed to open target %s: %w", target, err)
 	}
 	defer tgt.Close()
 

--- a/vendor/github.com/containerd/continuity/fs/copy_darwin.go
+++ b/vendor/github.com/containerd/continuity/fs/copy_darwin.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 /*
@@ -19,10 +20,10 @@
 package fs
 
 import (
+	"errors"
 	"os"
 	"syscall"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 

--- a/vendor/github.com/containerd/continuity/fs/copy_freebsd.go
+++ b/vendor/github.com/containerd/continuity/fs/copy_freebsd.go
@@ -1,3 +1,4 @@
+//go:build freebsd
 // +build freebsd
 
 /*
@@ -19,10 +20,10 @@
 package fs
 
 import (
+	"errors"
 	"os"
 	"syscall"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 

--- a/vendor/github.com/containerd/continuity/fs/copy_openbsdsolaris.go
+++ b/vendor/github.com/containerd/continuity/fs/copy_openbsdsolaris.go
@@ -1,3 +1,4 @@
+//go:build openbsd || solaris
 // +build openbsd solaris
 
 /*
@@ -19,10 +20,10 @@
 package fs
 
 import (
+	"errors"
 	"os"
 	"syscall"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 

--- a/vendor/github.com/containerd/continuity/fs/copy_unix.go
+++ b/vendor/github.com/containerd/continuity/fs/copy_unix.go
@@ -1,3 +1,4 @@
+//go:build darwin || freebsd || openbsd || solaris
 // +build darwin freebsd openbsd solaris
 
 /*
@@ -19,12 +20,12 @@
 package fs
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"syscall"
 
 	"github.com/containerd/continuity/sysx"
-	"github.com/pkg/errors"
 )
 
 func copyFileInfo(fi os.FileInfo, name string) error {
@@ -42,18 +43,18 @@ func copyFileInfo(fi os.FileInfo, name string) error {
 			}
 		}
 		if err != nil {
-			return errors.Wrapf(err, "failed to chown %s", name)
+			return fmt.Errorf("failed to chown %s: %w", name, err)
 		}
 	}
 
 	if (fi.Mode() & os.ModeSymlink) != os.ModeSymlink {
 		if err := os.Chmod(name, fi.Mode()); err != nil {
-			return errors.Wrapf(err, "failed to chmod %s", name)
+			return fmt.Errorf("failed to chmod %s: %w", name, err)
 		}
 	}
 
 	if err := utimesNano(name, StatAtime(st), StatMtime(st)); err != nil {
-		return errors.Wrapf(err, "failed to utime %s", name)
+		return fmt.Errorf("failed to utime %s: %w", name, err)
 	}
 
 	return nil
@@ -70,7 +71,7 @@ func copyFileContent(dst, src *os.File) error {
 func copyXAttrs(dst, src string, excludes map[string]struct{}, errorHandler XAttrErrorHandler) error {
 	xattrKeys, err := sysx.LListxattr(src)
 	if err != nil {
-		e := errors.Wrapf(err, "failed to list xattrs on %s", src)
+		e := fmt.Errorf("failed to list xattrs on %s: %w", src, err)
 		if errorHandler != nil {
 			e = errorHandler(dst, src, "", e)
 		}
@@ -82,7 +83,7 @@ func copyXAttrs(dst, src string, excludes map[string]struct{}, errorHandler XAtt
 		}
 		data, err := sysx.LGetxattr(src, xattr)
 		if err != nil {
-			e := errors.Wrapf(err, "failed to get xattr %q on %s", xattr, src)
+			e := fmt.Errorf("failed to get xattr %q on %s: %w", xattr, src, err)
 			if errorHandler != nil {
 				if e = errorHandler(dst, src, xattr, e); e == nil {
 					continue
@@ -91,7 +92,7 @@ func copyXAttrs(dst, src string, excludes map[string]struct{}, errorHandler XAtt
 			return e
 		}
 		if err := sysx.LSetxattr(dst, xattr, data, 0); err != nil {
-			e := errors.Wrapf(err, "failed to set xattr %q on %s", xattr, dst)
+			e := fmt.Errorf("failed to set xattr %q on %s: %w", xattr, dst, err)
 			if errorHandler != nil {
 				if e = errorHandler(dst, src, xattr, e); e == nil {
 					continue

--- a/vendor/github.com/containerd/continuity/fs/copy_windows.go
+++ b/vendor/github.com/containerd/continuity/fs/copy_windows.go
@@ -17,15 +17,15 @@
 package fs
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"os"
-
-	"github.com/pkg/errors"
 )
 
 func copyFileInfo(fi os.FileInfo, name string) error {
 	if err := os.Chmod(name, fi.Mode()); err != nil {
-		return errors.Wrapf(err, "failed to chmod %s", name)
+		return fmt.Errorf("failed to chmod %s: %w", name, err)
 	}
 
 	// TODO: copy windows specific metadata

--- a/vendor/github.com/containerd/continuity/fs/diff_unix.go
+++ b/vendor/github.com/containerd/continuity/fs/diff_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*
@@ -20,11 +21,11 @@ package fs
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"syscall"
 
 	"github.com/containerd/continuity/sysx"
-	"github.com/pkg/errors"
 )
 
 // detectDirDiff returns diff dir options if a directory could
@@ -56,11 +57,11 @@ func compareSysStat(s1, s2 interface{}) (bool, error) {
 func compareCapabilities(p1, p2 string) (bool, error) {
 	c1, err := sysx.LGetxattr(p1, "security.capability")
 	if err != nil && err != sysx.ENODATA {
-		return false, errors.Wrapf(err, "failed to get xattr for %s", p1)
+		return false, fmt.Errorf("failed to get xattr for %s: %w", p1, err)
 	}
 	c2, err := sysx.LGetxattr(p2, "security.capability")
 	if err != nil && err != sysx.ENODATA {
-		return false, errors.Wrapf(err, "failed to get xattr for %s", p2)
+		return false, fmt.Errorf("failed to get xattr for %s: %w", p2, err)
 	}
 	return bytes.Equal(c1, c2), nil
 }

--- a/vendor/github.com/containerd/continuity/fs/dtype_linux.go
+++ b/vendor/github.com/containerd/continuity/fs/dtype_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/vendor/github.com/containerd/continuity/fs/du_unix.go
+++ b/vendor/github.com/containerd/continuity/fs/du_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/vendor/github.com/containerd/continuity/fs/du_windows.go
+++ b/vendor/github.com/containerd/continuity/fs/du_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*

--- a/vendor/github.com/containerd/continuity/fs/fstest/compare.go
+++ b/vendor/github.com/containerd/continuity/fs/fstest/compare.go
@@ -17,11 +17,11 @@
 package fstest
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 
 	"github.com/containerd/continuity"
-	"github.com/pkg/errors"
 )
 
 // CheckDirectoryEqual compares two directory paths to make sure that
@@ -29,27 +29,27 @@ import (
 func CheckDirectoryEqual(d1, d2 string) error {
 	c1, err := continuity.NewContext(d1)
 	if err != nil {
-		return errors.Wrap(err, "failed to build context")
+		return fmt.Errorf("failed to build context: %w", err)
 	}
 
 	c2, err := continuity.NewContext(d2)
 	if err != nil {
-		return errors.Wrap(err, "failed to build context")
+		return fmt.Errorf("failed to build context: %w", err)
 	}
 
 	m1, err := continuity.BuildManifest(c1)
 	if err != nil {
-		return errors.Wrap(err, "failed to build manifest")
+		return fmt.Errorf("failed to build manifest: %w", err)
 	}
 
 	m2, err := continuity.BuildManifest(c2)
 	if err != nil {
-		return errors.Wrap(err, "failed to build manifest")
+		return fmt.Errorf("failed to build manifest: %w", err)
 	}
 
 	diff := diffResourceList(m1.Resources, m2.Resources)
 	if diff.HasDiff() {
-		return errors.Errorf("directory diff between %s and %s\n%s", d1, d2, diff.String())
+		return fmt.Errorf("directory diff between %s and %s\n%s", d1, d2, diff.String())
 	}
 
 	return nil

--- a/vendor/github.com/containerd/continuity/fs/fstest/compare_unix.go
+++ b/vendor/github.com/containerd/continuity/fs/fstest/compare_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/vendor/github.com/containerd/continuity/fs/fstest/file_unix.go
+++ b/vendor/github.com/containerd/continuity/fs/fstest/file_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/vendor/github.com/containerd/continuity/fs/fstest/file_windows.go
+++ b/vendor/github.com/containerd/continuity/fs/fstest/file_windows.go
@@ -17,9 +17,8 @@
 package fstest
 
 import (
+	"errors"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // Lchtimes changes access and mod time of file without following symlink

--- a/vendor/github.com/containerd/continuity/fs/hardlink_unix.go
+++ b/vendor/github.com/containerd/continuity/fs/hardlink_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/vendor/github.com/containerd/continuity/fs/path.go
+++ b/vendor/github.com/containerd/continuity/fs/path.go
@@ -19,11 +19,10 @@ package fs
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 )
 
 var (

--- a/vendor/github.com/containerd/continuity/fs/stat_darwinbsd.go
+++ b/vendor/github.com/containerd/continuity/fs/stat_darwinbsd.go
@@ -1,3 +1,4 @@
+//go:build darwin || freebsd || netbsd
 // +build darwin freebsd netbsd
 
 /*

--- a/vendor/github.com/containerd/continuity/fs/stat_linuxopenbsd.go
+++ b/vendor/github.com/containerd/continuity/fs/stat_linuxopenbsd.go
@@ -1,3 +1,4 @@
+//go:build linux || openbsd
 // +build linux openbsd
 
 /*

--- a/vendor/github.com/containerd/continuity/go.mod
+++ b/vendor/github.com/containerd/continuity/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/golang/protobuf v1.3.5
 	github.com/opencontainers/go-digest v1.0.0
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.0.0
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a

--- a/vendor/github.com/containerd/continuity/go.sum
+++ b/vendor/github.com/containerd/continuity/go.sum
@@ -65,8 +65,6 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -115,7 +113,6 @@ golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20190522155817-f3200d17e092 h1:4QSRKanuywn15aTZvI/mIDEgPQpswuFndXpOj3rKEco=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/vendor/github.com/containerd/continuity/hardlinks_unix.go
+++ b/vendor/github.com/containerd/continuity/hardlinks_unix.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin || freebsd || solaris
 // +build linux darwin freebsd solaris
 
 /*

--- a/vendor/github.com/containerd/continuity/resource_unix.go
+++ b/vendor/github.com/containerd/continuity/resource_unix.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin || freebsd || solaris
 // +build linux darwin freebsd solaris
 
 /*

--- a/vendor/github.com/containerd/continuity/sysx/nodata_unix.go
+++ b/vendor/github.com/containerd/continuity/sysx/nodata_unix.go
@@ -1,3 +1,4 @@
+//go:build darwin || freebsd || openbsd
 // +build darwin freebsd openbsd
 
 /*

--- a/vendor/github.com/containerd/continuity/sysx/xattr.go
+++ b/vendor/github.com/containerd/continuity/sysx/xattr.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 // +build linux darwin
 
 /*

--- a/vendor/github.com/containerd/continuity/sysx/xattr_unsupported.go
+++ b/vendor/github.com/containerd/continuity/sysx/xattr_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux && !darwin
 // +build !linux,!darwin
 
 /*

--- a/vendor/github.com/containerd/continuity/testutil/helpers_unix.go
+++ b/vendor/github.com/containerd/continuity/testutil/helpers_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/vendor/github.com/containerd/continuity/testutil/mount_other.go
+++ b/vendor/github.com/containerd/continuity/testutil/mount_other.go
@@ -1,3 +1,4 @@
+//go:build !linux && !windows
 // +build !linux,!windows
 
 /*

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -74,7 +74,7 @@ github.com/containerd/cgroups
 github.com/containerd/cgroups/stats/v1
 github.com/containerd/cgroups/v2
 github.com/containerd/cgroups/v2/stats
-# github.com/containerd/console v1.0.2
+# github.com/containerd/console v1.0.3
 ## explicit
 github.com/containerd/console
 # github.com/containerd/containerd/api v0.0.0 => ./api
@@ -94,7 +94,7 @@ github.com/containerd/containerd/api/services/ttrpc/events/v1
 github.com/containerd/containerd/api/services/version/v1
 github.com/containerd/containerd/api/types
 github.com/containerd/containerd/api/types/task
-# github.com/containerd/continuity v0.1.1-0.20210910181051-2e0898a8e801
+# github.com/containerd/continuity v0.2.0
 ## explicit
 github.com/containerd/continuity
 github.com/containerd/continuity/devices


### PR DESCRIPTION
bump continuity version to v0.2.0 that remove pkg/errors

xref: 
   - https://github.com/containerd/continuity/pull/185
   - https://github.com/containerd/console/pull/54

Signed-off-by: Zou Nengren <zouyee1989@gmail.com>