### PR TITLE
Fix panic in metadata content writer on copy error

### DIFF
--- a/metadata/content.go
+++ b/metadata/content.go
@@ -558,13 +558,13 @@ func (nw *namespacedWriter) createAndCopy(ctx context.Context, desc ocispec.Desc
 	if desc.Size > 0 {
 		ra, err := nw.provider.ReaderAt(ctx, nw.desc)
 		if err != nil {
+			w.Close()
 			return err
 		}
 		defer ra.Close()
 
 		if err := content.CopyReaderAt(w, ra, desc.Size); err != nil {
-			nw.w.Close()
-			nw.w = nil
+			w.Close()
 			return err
 		}
 	}


### PR DESCRIPTION
The `createAndCopy` function is only called when `nw.w` is nil in order to create a new writer and prepare it. The current code is attempting to close `nw.w` when there is a copy error. The correct behavior would be to close the new writer and not touch `nw.w`.

This issue has existed for awhile, but was recently seen when `content.CopyReaderAt(w, ra, desc.Size)` returned an error during testing another change.