### PR TITLE
[release/1.5] Fix panic in metadata content writer on copy error

### DIFF
--- a/metadata/content.go
+++ b/metadata/content.go
@@ -551,13 +551,13 @@ func (nw *namespacedWriter) createAndCopy(ctx context.Context, desc ocispec.Desc
 	if desc.Size > 0 {
 		ra, err := nw.provider.ReaderAt(ctx, nw.desc)
 		if err != nil {
+			w.Close()
 			return err
 		}
 		defer ra.Close()
 
 		if err := content.CopyReaderAt(w, ra, desc.Size); err != nil {
-			nw.w.Close()
-			nw.w = nil
+			w.Close()
 			return err
 		}
 	}


### PR DESCRIPTION
The `createAndCopy` function is only called when `nw.w` is nil
in order to create a new writer and prepare it. The current code
is attempting to close `nw.w` when there is a copy error. The
correct behavior would be to close the new writer and not touch `nw.w`.

Signed-off-by: Derek McGowan <derek@mcg.dev>
(cherry picked from commit b9cf0d75a9f4a8a09ab55caa1983a8988ba4834d)
Signed-off-by: Derek McGowan <derek@mcg.dev>