### PR TITLE
fix: make exec-id flag required in exec command

### DIFF
--- a/cmd/ctr/commands/tasks/exec.go
+++ b/cmd/ctr/commands/tasks/exec.go
@@ -31,7 +31,6 @@ import (
 	"github.com/urfave/cli"
 )
 
-//TODO:(jessvalarezo) exec-id is optional here, update to required arg
 var execCommand = cli.Command{
 	Name:           "exec",
 	Usage:          "execute additional processes in an existing container",
@@ -51,8 +50,9 @@ var execCommand = cli.Command{
 			Usage: "detach from the task after it has started execution",
 		},
 		cli.StringFlag{
-			Name:  "exec-id",
-			Usage: "exec specific id for the process",
+			Name:     "exec-id",
+			Required: true,
+			Usage:    "exec specific id for the process",
 		},
 		cli.StringFlag{
 			Name:  "fifo-dir",


### PR DESCRIPTION
make exec-id flag required in exec command

```bash
$ ./ctr t exec
NAME:
   ctr tasks exec - execute additional processes in an existing container

USAGE:
   ctr tasks exec [command options] [flags] CONTAINER CMD [ARG...]

OPTIONS:
   --cwd value       working directory of the new process
   --tty, -t         allocate a TTY for the container
   --detach, -d      detach from the task after it has started execution
   --exec-id value   exec specific id for the process
   --fifo-dir value  directory used for storing IO FIFOs
   --log-uri value   log uri for custom shim logging
   --user value      user id or name
   
ctr: Required flag "exec-id" not set
```