### PR TITLE
cri: Add configuration support for process RLIMIT_NOFILE limits

### DIFF
--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -64,6 +64,17 @@ version = 2
   # requires that all containers are deleted.
   netns_mounts_under_state_dir = false
 
+  # process_rlimit_no_file_soft sets the soft limit of maximum file descriptors each container process can use.
+  # process_rlimit_no_file_soft and process_rlimit_no_file_hard must be set together.
+  # Also note the soft limit must not be larger than the hard limit.
+  # If not specified containers inherit the limits, if any, from the containerd process.
+  process_rlimit_no_file_soft = 65536
+
+  # process_rlimit_no_file_hard sets the hard limit of maximum file descriptors each container process can use.
+  # process_rlimit_no_file_soft and process_rlimit_no_file_hard must be set together.
+  # If not specified containers inherit the limits, if any, from the containerd process.
+  process_rlimit_no_file_hard = 1048576
+
   # 'plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming' contains a x509 valid key pair to stream with tls.
   [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
     # tls_cert_file is the filepath to the certificate paired with the "tls_key_file"

--- a/pkg/cri/config/config_test.go
+++ b/pkg/cri/config/config_test.go
@@ -26,6 +26,10 @@ import (
 )
 
 func TestValidateConfig(t *testing.T) {
+	// Values to be used in tests that require *int
+	hardLimit := 512
+	softLimit := 1024
+
 	for desc, test := range map[string]struct {
 		config      *PluginConfig
 		expectedErr string
@@ -359,6 +363,49 @@ func TestValidateConfig(t *testing.T) {
 				},
 			},
 			expectedErr: "`configs.tls` cannot be set when `config_path` is provided",
+		},
+		"invalid rlimit_nofile config": {
+			config: &PluginConfig{
+				ContainerdConfig: ContainerdConfig{
+					DefaultRuntimeName: RuntimeDefault,
+					Runtimes: map[string]Runtime{
+						RuntimeDefault: {
+							Type: plugin.RuntimeLinuxV1,
+						},
+					},
+				},
+				ProcessRLimitNoFileSoft: &softLimit,
+				ProcessRLimitNoFileHard: &hardLimit,
+			},
+			expectedErr: "`process_rlimit_no_file_soft` must not be greater than `process_rlimit_no_file_hard`",
+		},
+		"missing process_rlimit_no_file_soft": {
+			config: &PluginConfig{
+				ContainerdConfig: ContainerdConfig{
+					DefaultRuntimeName: RuntimeDefault,
+					Runtimes: map[string]Runtime{
+						RuntimeDefault: {
+							Type: plugin.RuntimeLinuxV1,
+						},
+					},
+				},
+				ProcessRLimitNoFileSoft: &softLimit,
+			},
+			expectedErr: "`process_rlimit_no_file_soft` and `process_rlimit_no_file_hard` must both be configured",
+		},
+		"missing process_rlimit_no_file_hard": {
+			config: &PluginConfig{
+				ContainerdConfig: ContainerdConfig{
+					DefaultRuntimeName: RuntimeDefault,
+					Runtimes: map[string]Runtime{
+						RuntimeDefault: {
+							Type: plugin.RuntimeLinuxV1,
+						},
+					},
+				},
+				ProcessRLimitNoFileHard: &hardLimit,
+			},
+			expectedErr: "`process_rlimit_no_file_soft` and `process_rlimit_no_file_hard` must both be configured",
 		},
 	} {
 		t.Run(desc, func(t *testing.T) {

--- a/pkg/cri/opts/spec_linux.go
+++ b/pkg/cri/opts/spec_linux.go
@@ -43,6 +43,17 @@ import (
 	osinterface "github.com/containerd/containerd/pkg/os"
 )
 
+// WithProcessRLimits sets the RLimits for this container process
+func WithProcessRLimits(rlimits []runtimespec.POSIXRlimit) oci.SpecOpts {
+	return func(ctx context.Context, client oci.Client, c *containers.Container, s *runtimespec.Spec) (err error) {
+		if s.Process == nil {
+			s.Process = &runtimespec.Process{}
+		}
+		s.Process.Rlimits = rlimits
+		return nil
+	}
+}
+
 // WithAdditionalGIDs adds any additional groups listed for a particular user in the
 // /etc/groups file of the image's root filesystem to the OCI spec's additionalGids array.
 func WithAdditionalGIDs(userstr string) oci.SpecOpts {

--- a/pkg/cri/server/container_create_linux.go
+++ b/pkg/cri/server/container_create_linux.go
@@ -302,6 +302,19 @@ func (c *criService) containerSpec(
 				Type: runtimespec.CgroupNamespace,
 			}))
 	}
+
+	// Override the default oci.Spec RLIMIT_NOFILE if these values are set in config
+	if c.config.PluginConfig.ProcessRLimitNoFileHard != nil && c.config.PluginConfig.ProcessRLimitNoFileSoft != nil {
+		var rlimits = []runtimespec.POSIXRlimit{
+			{
+				Type: "RLIMIT_NOFILE",
+				Hard: uint64(*c.config.PluginConfig.ProcessRLimitNoFileHard),
+				Soft: uint64(*c.config.PluginConfig.ProcessRLimitNoFileSoft),
+			},
+		}
+		specOpts = append(specOpts, customopts.WithProcessRLimits(rlimits))
+	}
+
 	return c.runtimeSpec(id, ociRuntime.BaseRuntimeSpec, specOpts...)
 }
 


### PR DESCRIPTION
Fixes #6063 

This set of commits adds the initial support for the configuration of process RLIMIT_NOFILE limits for the `cri` plugin.  The end result is that an administrator can configure the limits for all containers launched via `cri-containerd`:
```
[plugins."io.containerd.grpc.v1.cri"]
process_rlimit_no_file_soft = 512
process_rlimit_no_file_hard = 1024
```

As mentioned in the commits, the change adds two additional struct members (`ProcessRLimitNoFileSoft` and `ProcessRLimitNoFileHard`) to`PluginConfig`.    The change also includes validation for the configuration, ensuring that both values are set and that soft limits aren't set greater than hard limits.  Unit test also included.

A custom OCI spec option is used to add the limits to the OCI spec at container creation time, provided both soft/hard limits are both set.

All unit tests pass, and I'm working on figuring out why I can't get all the CRI integration tests to run/pass.  (I'm pretty sure it's something in my environment and not a result of this change)