### PR TITLE
Update mirror images to take target image name

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -6,6 +6,9 @@ on:
         description: "Upstream image to mirror"
         required: true
         default: "docker.io/library/busybox:1.32"
+      image:
+        description: "Target image name (override)"
+
 
 jobs:
   mirror:
@@ -56,7 +59,12 @@ jobs:
           sleep 5
 
           upstream=${{ github.event.inputs.upstream }}
-          mirror="ghcr.io/containerd/${upstream##*/}"
+          target=${{ github.event.inputs.image }}
+          if [[ "$target" == "" ]]; then
+            mirror="ghcr.io/containerd/${upstream##*/}"
+          else
+            mirror="ghcr.io/containerd/${target}"
+          fi
 
           echo "Mirroring $upstream to $mirror"
 


### PR DESCRIPTION
Allow overwriting the target tag to support mirror images from multiple sources under our single namespace.

To handle this case in old branches, which currently would just all attempt to overwrite to the same tag
```
 41         switch runtime.GOARCH {
 42         case "386":
 43                 testImage = "docker.io/i386/alpine:latest"
 44         case "arm":
 45                 testImage = "docker.io/arm32v6/alpine:latest"
 46         case "arm64":
 47                 testImage = "docker.io/arm64v8/alpine:latest"
 48         case "ppc64le":
 49                 testImage = "docker.io/ppc64le/alpine:latest" 
 50         case "s390x": 
 51                 testImage = "docker.io/s390x/alpine:latest"
 52         default:
 53                 testImage = "docker.io/library/alpine:latest" 
 54         }
```

Tested at https://github.com/dmcgowan/containerd/actions/workflows/images.yml