### PR TITLE
task service: return known error type

### DIFF
--- a/services/tasks/local.go
+++ b/services/tasks/local.go
@@ -210,7 +210,7 @@ func (l *local) Create(ctx context.Context, r *api.CreateTaskRequest, _ ...grpc.
 		return nil, errdefs.ToGRPC(err)
 	}
 	if err == nil {
-		return nil, errdefs.ToGRPC(fmt.Errorf("task %s already exists", r.ContainerID))
+		return nil, errdefs.ToGRPC(fmt.Errorf("task %s: %w", r.ContainerID, errdefs.ErrAlreadyExists))
 	}
 	c, err := rtime.Create(ctx, r.ContainerID, opts)
 	if err != nil {


### PR DESCRIPTION
Found this error in a docker daemon log classified as an "uknown" error.
Since we know what this is return the correct error type so it can be
handled.