### PR TITLE
Fixes for Windows CI

### DIFF
--- a/script/setup/prepare_env_windows.ps1
+++ b/script/setup/prepare_env_windows.ps1
@@ -1,6 +1,6 @@
 # Prepare windows environment for building and running containerd tests
 
-$PACKAGES= @{ mingw = ""; git = ""; golang = "1.17.1"; make = ""; nssm = "" }
+$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.17.1"; make = ""; nssm = "" }
 
 write-host "Downloading chocolatey package"
 curl.exe -L "https://packages.chocolatey.org/chocolatey.0.10.15.nupkg" -o 'c:\choco.zip'

--- a/script/setup/prepare_env_windows.ps1
+++ b/script/setup/prepare_env_windows.ps1
@@ -1,6 +1,6 @@
 # Prepare windows environment for building and running containerd tests
 
-$PACKAGES= @{ mingw = ""; git = ""; golang = "1.16.7"; make = ""; nssm = "" }
+$PACKAGES= @{ mingw = ""; git = ""; golang = "1.17.1"; make = ""; nssm = "" }
 
 write-host "Downloading chocolatey package"
 curl.exe -L "https://packages.chocolatey.org/chocolatey.0.10.15.nupkg" -o 'c:\choco.zip'

--- a/script/setup/prepare_env_windows.ps1
+++ b/script/setup/prepare_env_windows.ps1
@@ -1,6 +1,6 @@
 # Prepare windows environment for building and running containerd tests
 
-$PACKAGES= @{ mingw = ""; git = ""; golang = "1.16.7"; make = "" }
+$PACKAGES= @{ mingw = ""; git = ""; golang = "1.16.7"; make = ""; nssm = "" }
 
 write-host "Downloading chocolatey package"
 curl.exe -L "https://packages.chocolatey.org/chocolatey.0.10.15.nupkg" -o 'c:\choco.zip'


### PR DESCRIPTION
Changes in this PR:
- Install nssm - needed for updates in the way cir-integration tests run on Windows
- Update Go to version 1.17.1 - to be in line with recent changes in containerD
- Pin Mingw to version 10.2.0 - newer versions consistently result in error "ThreadSanitizer failed to allocate 0x000002561000 (39194624) bytes at 0x200d952c5c000" 