### PR TITLE
modify the way for checking cos

### DIFF
--- a/test/e2e_node/gci-init.sh
+++ b/test/e2e_node/gci-init.sh
@@ -26,7 +26,10 @@ fi
 
 if [ "${CONTAINERD_CGROUPV2:-"false"}"  == "true" ]; then
   # check cos image
-  if uname -a | grep -q cos; then
+  if [ -r /etc/os-release ]; then
+    OS_ID="$(. /etc/os-release && echo "$ID")"
+  fi
+  if [ "${OS_ID}" = "cos" ]; then
     if ! grep -q 'systemd.unified_cgroup_hierarchy=true' /proc/cmdline; then
       echo "Setting up cgroupv2"
 


### PR DESCRIPTION
As discovered, `if uname -a | grep -q cos; then` only works for k8bs node e2e tests, not for cluster e2e tests. Change the way for verifying the cos by using `/etc/os-release` information