### PR TITLE
run `gofmt` with GO 1.17

### DIFF
--- a/contrib/fuzz/archive_fuzzer.go
+++ b/contrib/fuzz/archive_fuzzer.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 /*

--- a/contrib/fuzz/cap_fuzzer.go
+++ b/contrib/fuzz/cap_fuzzer.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 /*

--- a/contrib/fuzz/container_fuzzer.go
+++ b/contrib/fuzz/container_fuzzer.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 /*

--- a/contrib/fuzz/containerd_import_fuzzer.go
+++ b/contrib/fuzz/containerd_import_fuzzer.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 /*

--- a/contrib/fuzz/content_fuzzer.go
+++ b/contrib/fuzz/content_fuzzer.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 /*

--- a/contrib/fuzz/cri_fuzzer.go
+++ b/contrib/fuzz/cri_fuzzer.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 /*

--- a/contrib/fuzz/docker_fuzzer.go
+++ b/contrib/fuzz/docker_fuzzer.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 /*

--- a/contrib/fuzz/filters_fuzzers.go
+++ b/contrib/fuzz/filters_fuzzers.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 /*

--- a/contrib/fuzz/metadata_fuzzer.go
+++ b/contrib/fuzz/metadata_fuzzer.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 /*
@@ -12,7 +13,6 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-
 
 package fuzz
 

--- a/contrib/fuzz/platforms_fuzzers.go
+++ b/contrib/fuzz/platforms_fuzzers.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 /*

--- a/diff/lcow/lcow.go
+++ b/diff/lcow/lcow.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*

--- a/diff/windows/windows.go
+++ b/diff/windows/windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*

--- a/integration/client/client_unix_test.go
+++ b/integration/client/client_unix_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/integration/client/container_checkpoint_test.go
+++ b/integration/client/container_checkpoint_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/integration/client/helpers_unix_test.go
+++ b/integration/client/helpers_unix_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/integration/client/task_opts_unix_test.go
+++ b/integration/client/task_opts_unix_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/platforms/defaults_darwin.go
+++ b/platforms/defaults_darwin.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 /*

--- a/services/tasks/local_darwin.go
+++ b/services/tasks/local_darwin.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 /*

--- a/snapshots/lcow/lcow.go
+++ b/snapshots/lcow/lcow.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*

--- a/snapshots/windows/windows.go
+++ b/snapshots/windows/windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*


### PR DESCRIPTION
new `gofmt` adds //go:build lines (https://golang.org/doc/go1.17#tools).

Signed-off-by: Zou Nengren <zouyee1989@gmail.com>