### PR TITLE
Add error message to in TestContainerdRestart integration test

### DIFF
--- a/integration/restart_test.go
+++ b/integration/restart_test.go
@@ -136,7 +136,7 @@ func TestContainerdRestart(t *testing.T) {
 			require.NoError(t, err)
 			_, err = task.Delete(ctx, containerd.WithProcessKill)
 			if err != nil {
-				require.True(t, errdefs.IsNotFound(err))
+				require.True(t, errdefs.IsNotFound(err), "delete should return not found error but returned %v", err)
 			}
 		}
 	}


### PR DESCRIPTION
Currently a failure looks like...
```
=== RUN   TestContainerdRestart
    restart_test.go:89: Make sure no sandbox is running before test
    restart_test.go:94: Start test sandboxes and containers
    common.go:115: Image "k8s.gcr.io/pause:3.6" already exists, not pulling.
    common.go:115: Image "k8s.gcr.io/pause:3.6" already exists, not pulling.
    restart_test.go:136: 
        	Error Trace:	restart_test.go:136
        	Error:      	Should be true
        	Test:       	TestContainerdRestart
--- FAIL: TestContainerdRestart (4.85s)
```
...which is not helpful since it does not show the underlying error condition