### PR TITLE
Update test timeout based on recent cancellations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,7 +306,7 @@ jobs:
   integration-linux:
     name: Linux Integration
     runs-on: ubuntu-18.04
-    timeout-minutes: 35
+    timeout-minutes: 40
     needs: [project, linters, protos, man]
 
     strategy:


### PR DESCRIPTION
Running some scripts against the last few months of test run data to see if we can pinpoint why this is slowly increasing, but for now, too many PRs are getting canceled for hitting the 35 min limit on the Linux integration runs.

Signed-off-by: Phil Estes <estesp@amazon.com>