### PR TITLE
[cri] add sandbox and container latency metrics

### DIFF
--- a/pkg/cri/server/container_create.go
+++ b/pkg/cri/server/container_create.go
@@ -102,6 +102,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 		return nil, errors.Wrapf(err, "failed to get image from containerd %q", image.ID)
 	}
 
+	start := time.Now()
 	// Run container using the same runtime with sandbox.
 	sandboxInfo, err := sandbox.Container.Info(ctx)
 	if err != nil {
@@ -277,6 +278,8 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	if err := c.containerStore.Add(container); err != nil {
 		return nil, errors.Wrapf(err, "failed to add container %q into store", id)
 	}
+
+	containerCreateTimer.WithValues(ociRuntime.Type).UpdateSince(start)
 
 	return &runtime.CreateContainerResponse{ContainerId: id}, nil
 }

--- a/pkg/cri/server/container_list.go
+++ b/pkg/cri/server/container_list.go
@@ -17,6 +17,8 @@
 package server
 
 import (
+	"time"
+
 	"golang.org/x/net/context"
 
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -26,6 +28,7 @@ import (
 
 // ListContainers lists all containers matching the filter.
 func (c *criService) ListContainers(ctx context.Context, r *runtime.ListContainersRequest) (*runtime.ListContainersResponse, error) {
+	start := time.Now()
 	// List all containers from store.
 	containersInStore := c.containerStore.List()
 
@@ -35,6 +38,8 @@ func (c *criService) ListContainers(ctx context.Context, r *runtime.ListContaine
 	}
 
 	containers = c.filterCRIContainers(containers, r.GetFilter())
+
+	containerListTimer.UpdateSince(start)
 	return &runtime.ListContainersResponse{Containers: containers}, nil
 }
 

--- a/pkg/cri/server/metrics.go
+++ b/pkg/cri/server/metrics.go
@@ -1,0 +1,58 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	metrics "github.com/docker/go-metrics"
+)
+
+var (
+	sandboxListTimer          metrics.Timer
+	sandboxCreateNetworkTimer metrics.Timer
+	sandboxDeleteNetwork      metrics.Timer
+
+	sandboxRuntimeCreateTimer metrics.LabeledTimer
+	sandboxRuntimeStopTimer   metrics.LabeledTimer
+	sandboxRemoveTimer        metrics.LabeledTimer
+
+	containerListTimer   metrics.Timer
+	containerRemoveTimer metrics.LabeledTimer
+	containerCreateTimer metrics.LabeledTimer
+	containerStopTimer   metrics.LabeledTimer
+	containerStartTimer  metrics.LabeledTimer
+)
+
+func init() {
+	// these CRI metrics record latencies for successful operations around a sandbox and container's lifecycle.
+	ns := metrics.NewNamespace("containerd", "cri", nil)
+
+	sandboxListTimer = ns.NewTimer("sandbox_list", "time to list sandboxes")
+	sandboxCreateNetworkTimer = ns.NewTimer("sandbox_create_network", "time to create the network for a sandbox")
+	sandboxDeleteNetwork = ns.NewTimer("sandbox_delete_network", "time to delete a sandbox's network")
+
+	sandboxRuntimeCreateTimer = ns.NewLabeledTimer("sandbox_runtime_create", "time to create a sandbox in the runtime", "runtime")
+	sandboxRuntimeStopTimer = ns.NewLabeledTimer("sandbox_runtime_stop", "time to stop a sandbox", "runtime")
+	sandboxRemoveTimer = ns.NewLabeledTimer("sandbox_remove", "time to remove a sandbox", "runtime")
+
+	containerListTimer = ns.NewTimer("container_list", "time to list containers")
+	containerRemoveTimer = ns.NewLabeledTimer("container_remove", "time to remove a container", "runtime")
+	containerCreateTimer = ns.NewLabeledTimer("container_create", "time to create a container", "runtime")
+	containerStopTimer = ns.NewLabeledTimer("container_stop", "time to stop a container", "runtime")
+	containerStartTimer = ns.NewLabeledTimer("container_start", "time to start a container", "runtime")
+
+	metrics.Register(ns)
+}

--- a/pkg/cri/server/sandbox_list.go
+++ b/pkg/cri/server/sandbox_list.go
@@ -17,6 +17,8 @@
 package server
 
 import (
+	"time"
+
 	"golang.org/x/net/context"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
@@ -25,6 +27,7 @@ import (
 
 // ListPodSandbox returns a list of Sandbox.
 func (c *criService) ListPodSandbox(ctx context.Context, r *runtime.ListPodSandboxRequest) (*runtime.ListPodSandboxResponse, error) {
+	start := time.Now()
 	// List all sandboxes from store.
 	sandboxesInStore := c.sandboxStore.List()
 	var sandboxes []*runtime.PodSandbox
@@ -36,6 +39,8 @@ func (c *criService) ListPodSandbox(ctx context.Context, r *runtime.ListPodSandb
 	}
 
 	sandboxes = c.filterCRISandboxes(sandboxes, r.GetFilter())
+
+	sandboxListTimer.UpdateSince(start)
 	return &runtime.ListPodSandboxResponse{Items: sandboxes}, nil
 }
 

--- a/pkg/cri/server/sandbox_remove.go
+++ b/pkg/cri/server/sandbox_remove.go
@@ -17,6 +17,8 @@
 package server
 
 import (
+	"time"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
@@ -30,6 +32,7 @@ import (
 // RemovePodSandbox removes the sandbox. If there are running containers in the
 // sandbox, they should be forcibly removed.
 func (c *criService) RemovePodSandbox(ctx context.Context, r *runtime.RemovePodSandboxRequest) (*runtime.RemovePodSandboxResponse, error) {
+	start := time.Now()
 	sandbox, err := c.sandboxStore.Get(r.GetPodSandboxId())
 	if err != nil {
 		if !errdefs.IsNotFound(err) {
@@ -107,6 +110,8 @@ func (c *criService) RemovePodSandbox(ctx context.Context, r *runtime.RemovePodS
 
 	// Release the sandbox name reserved for the sandbox.
 	c.sandboxNameIndex.ReleaseByKey(id)
+
+	sandboxRemoveTimer.WithValues(sandbox.RuntimeHandler).UpdateSince(start)
 
 	return &runtime.RemovePodSandboxResponse{}, nil
 }

--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	goruntime "runtime"
 	"strings"
+	"time"
 
 	"github.com/containerd/containerd"
 	containerdio "github.com/containerd/containerd/cio"
@@ -123,6 +124,7 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	}
 
 	if podNetwork {
+		netStart := time.Now()
 		// If it is not in host network namespace then create a namespace and set the sandbox
 		// handle. NetNSPath in sandbox metadata and NetNS is non empty only for non host network
 		// namespaces. If the pod is in host network namespace then both are empty and should not
@@ -163,8 +165,10 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		if err := c.setupPodNetwork(ctx, &sandbox); err != nil {
 			return nil, errors.Wrapf(err, "failed to setup network for sandbox %q", id)
 		}
+		sandboxCreateNetworkTimer.UpdateSince(netStart)
 	}
 
+	runtimeStart := time.Now()
 	// Create sandbox container.
 	// NOTE: sandboxContainerSpec SHOULD NOT have side
 	// effect, e.g. accessing/creating files, so that we can test
@@ -344,6 +348,8 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	// TaskOOM from containerd may come before sandbox is added to store,
 	// but we don't care about sandbox TaskOOM right now, so it is fine.
 	c.eventMonitor.startSandboxExitMonitor(context.Background(), id, task.Pid(), exitCh)
+
+	sandboxRuntimeCreateTimer.WithValues(ociRuntime.Type).UpdateSince(runtimeStart)
 
 	return &runtime.RunPodSandboxResponse{PodSandboxId: id}, nil
 }


### PR DESCRIPTION
These are simple metrics that allow users to view more fine grained metrics on
internal operations.

Signed-off-by: Michael Crosby <michael@thepasture.io>