### PR TITLE
cleanup deprecated package  `io/ioutil `

### DIFF
--- a/contrib/fuzz/metadata_fuzzer.go
+++ b/contrib/fuzz/metadata_fuzzer.go
@@ -19,7 +19,6 @@ package fuzz
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -43,7 +42,7 @@ func testEnv() (context.Context, *bolt.DB, func(), error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	ctx = namespaces.WithNamespace(ctx, "testing")
 
-	dirname, err := ioutil.TempDir("", "fuzz-")
+	dirname, err := os.MkdirTemp("", "fuzz-")
 	if err != nil {
 		return ctx, nil, nil, err
 	}
@@ -263,7 +262,7 @@ func testDB(opt ...testOpt) (context.Context, *metadata.DB, func(), error) {
 		o(&topts)
 	}
 
-	dirname, err := ioutil.TempDir("", "fuzzing-")
+	dirname, err := os.MkdirTemp("", "fuzzing-")
 	if err != nil {
 		return ctx, nil, func() { cancel() }, err
 	}

--- a/integration/shim_dial_unix_test.go
+++ b/integration/shim_dial_unix_test.go
@@ -21,7 +21,6 @@ package integration
 
 import (
 	"context"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -147,7 +146,7 @@ func testFailFastWhenConnectShim(abstract bool, dialFn dialFunc) func(*testing.T
 }
 
 func newTestListener(t testing.TB, abstract bool) (string, net.Listener, func()) {
-	tmpDir, err := ioutil.TempDir("", "shim-ut-XX")
+	tmpDir, err := os.MkdirTemp("", "shim-ut-XX")
 	if err != nil {
 		t.Fatalf("failed to create tmp directory: %v", err)
 	}

--- a/runtime/v1/linux/bundle_test.go
+++ b/runtime/v1/linux/bundle_test.go
@@ -22,7 +22,6 @@ package linux
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -49,7 +48,7 @@ func TestNewBundle(t *testing.T) {
 
 	for i, tc := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "test-new-bundle")
+			dir, err := os.MkdirTemp("", "test-new-bundle")
 			require.NoError(t, err, "failed to create test directory")
 			defer os.RemoveAll(dir)
 			work := filepath.Join(dir, "work")

--- a/runtime/v2/bundle_linux_test.go
+++ b/runtime/v2/bundle_linux_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -48,7 +47,7 @@ func TestNewBundle(t *testing.T) {
 
 	for i, tc := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "test-new-bundle")
+			dir, err := os.MkdirTemp("", "test-new-bundle")
 			require.NoError(t, err, "failed to create test directory")
 			defer os.RemoveAll(dir)
 			work := filepath.Join(dir, "work")


### PR DESCRIPTION
`io/ioutil` package has been deprecated in Go 1.16 (xref https://golang.org/doc/go1.16#ioutil), replaces the existing `io/ioutil` functions with os packages.

Signed-off-by: Zou Nengren <zouyee1989@gmail.com>