### PR TITLE
Landlock support for containerd

### DIFF
--- a/cmd/ctr/commands/commands.go
+++ b/cmd/ctr/commands/commands.go
@@ -185,6 +185,10 @@ var (
 			Name:  "apparmor-profile",
 			Usage: "enable AppArmor with an existing custom profile",
 		},
+		cli.StringFlag{
+			Name:  "landlock-profile",
+			Usage: "enable Landlock with an existing profile",
+		},
 	}
 )
 

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -31,6 +31,7 @@ import (
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/contrib/apparmor"
+	"github.com/containerd/containerd/contrib/landlock"
 	"github.com/containerd/containerd/contrib/nvidia"
 	"github.com/containerd/containerd/contrib/seccomp"
 	"github.com/containerd/containerd/oci"
@@ -241,6 +242,10 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 				return nil, fmt.Errorf("apparmor-profile conflicts with apparmor-default-profile")
 			}
 			opts = append(opts, apparmor.WithProfile(s))
+		}
+
+		if s := context.String("landlock-profile"); len(s) > 0 {
+			opts = append(opts, landlock.WithProfile(s))
 		}
 
 		if cpus := context.Float64("cpus"); cpus > 0.0 {

--- a/contrib/landlock/landlock.go
+++ b/contrib/landlock/landlock.go
@@ -57,3 +57,10 @@ func WithProfile(profile string) oci.SpecOpts {
 		return nil
 	}
 }
+
+// Supporting a default landlock profile is under discussion with community: https://github.com/containerd/containerd/issues/6056
+func WithDefaultProfile() oci.SpecOpts {
+	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {		
+		return nil
+	}
+}

--- a/contrib/landlock/landlock.go
+++ b/contrib/landlock/landlock.go
@@ -1,0 +1,59 @@
+// +build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package landlock
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/oci"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// loadSpec loads the specification from the provided path.
+func loadLandlock(cPath string) (landlockSpec *specs.Landlock, err error) {
+	cf, err := os.Open(cPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("landlock JSON specification file %s not found", cPath)
+		}
+		return nil, err
+	}
+	defer cf.Close()
+
+	if err = json.NewDecoder(cf).Decode(&landlockSpec); err != nil {
+		return nil, err
+	}
+	return landlockSpec, err
+}
+
+// WithProfile sets the provided landlock profile to the spec
+func WithProfile(profile string) oci.SpecOpts {
+	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {		
+		landlock, err := loadLandlock(profile)
+		if err != nil {
+			return err
+		}
+		s.Process.Landlock = landlock
+		return nil
+	}
+}

--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -282,6 +282,9 @@ type PluginConfig struct {
 	// of being placed under the hardcoded directory /var/run/netns. Changing this setting requires
 	// that all containers are deleted.
 	NetNSMountsUnderStateDir bool `toml:"netns_mounts_under_state_dir" json:"netnsMountsUnderStateDir"`
+	// DisableLandlock indicates to disable the landlock support.
+	// This is useful when the containerd does not have permission to access Landlock.
+	DisableLandlock bool `toml:"disable_landlock" json:"disableLandlock"`
 }
 
 // X509KeyPairStreaming contains the x509 configuration for streaming

--- a/pkg/cri/server/helpers_linux.go
+++ b/pkg/cri/server/helpers_linux.go
@@ -32,6 +32,7 @@ import (
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/pkg/apparmor"
 	"github.com/containerd/containerd/pkg/seccomp"
+	"github.com/containerd/containerd/pkg/landlock"
 	"github.com/containerd/containerd/pkg/seutil"
 	"github.com/moby/sys/mountinfo"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -146,6 +147,15 @@ func (c *criService) apparmorEnabled() bool {
 		return false
 	}
 	return apparmor.HostSupports()
+}
+
+// landlockEnabled returns true if landlock is enabled, supported by the host,
+// and not disabled manually
+func (c *criService) landlockEnabled() bool {
+	if c.config.DisableLandlock {
+		return false
+	}
+	return landlock.HostSupports()
 }
 
 func (c *criService) seccompEnabled() bool {

--- a/pkg/landlock/landlock.go
+++ b/pkg/landlock/landlock.go
@@ -1,0 +1,22 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package landlock
+
+// HostSupports returns true if landlock is enabled on the host
+func HostSupports() bool {
+	return hostSupports()
+}

--- a/pkg/landlock/landlock_linux.go
+++ b/pkg/landlock/landlock_linux.go
@@ -1,0 +1,51 @@
+// +build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package landlock
+
+import (
+	"io/ioutil"
+	"os"
+	"sync"
+	"strings"
+)
+
+var (
+	landlockSupported bool
+	checkLandlock     sync.Once
+)
+
+// hostSupports returns true if a is enabled for on the host
+func hostSupports() bool {
+	checkLandlock.Do(func() {
+		landlockSupported = false
+		if _, err := os.Stat("/sys/kernel/security/lsm"); err == nil {
+			buf, err := ioutil.ReadFile("/sys/kernel/security/lsm");
+			if err == nil {
+				lsm_str := string(buf)
+				lsm_slice := strings.Split(lsm_str, ",")
+				for _ , lsm := range lsm_slice {
+					if lsm == "landlock" {
+						landlockSupported = true
+					}  
+				}
+			}
+		}	
+	})
+	return landlockSupported
+}

--- a/pkg/landlock/landlock_unsupported.go
+++ b/pkg/landlock/landlock_unsupported.go
@@ -1,0 +1,23 @@
+// +build !linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package landlock
+
+func hostSupports() bool {
+	return false
+}


### PR DESCRIPTION
This patch introduces Landlock Linux Security Module (LSM) support in
containerd. This is a base version for community discussion.

This allows unprivileged processes to create safe security sandboxes
that can securely restrict the ambient rights (e.g. global filesystem
access) for themselves.

Fixes #6056 

Signed-off-by: Konstantin Meskhidze konstantin.meskhidze@huawei.com