### PR TITLE
Enable lazy init for ext4 with devicemapper

### DIFF
--- a/snapshots/devmapper/config.go
+++ b/snapshots/devmapper/config.go
@@ -50,6 +50,9 @@ type Config struct {
 
 	// Defines file system to use for snapshout device mount. Defaults to "ext4"
 	FileSystemType fsType `toml:"fs_type"`
+
+	// Defines optional file system options passed through config file
+	FsOptions string `toml:"fs_options"`
 }
 
 // LoadConfig reads devmapper configuration file from disk in TOML format

--- a/snapshots/devmapper/snapshotter_test.go
+++ b/snapshots/devmapper/snapshotter_test.go
@@ -142,12 +142,26 @@ func testUsage(t *testing.T, snapshotter snapshots.Snapshotter) {
 
 func TestMkfsExt4(t *testing.T) {
 	ctx := context.Background()
-	err := mkfs(ctx, "ext4", "")
+	// We test the default setting which is lazy init is disabled
+	err := mkfs(ctx, "ext4", "nodiscard,lazy_itable_init=0,lazy_journal_init=0", "")
+	assert.ErrorContains(t, err, `mkfs.ext4 couldn't initialize ""`)
+}
+
+func TestMkfsExt4NonDefault(t *testing.T) {
+	ctx := context.Background()
+	// We test a non default setting where we enable lazy init for ext4
+	err := mkfs(ctx, "ext4", "nodiscard", "")
 	assert.ErrorContains(t, err, `mkfs.ext4 couldn't initialize ""`)
 }
 
 func TestMkfsXfs(t *testing.T) {
 	ctx := context.Background()
-	err := mkfs(ctx, "xfs", "")
+	err := mkfs(ctx, "xfs", "", "")
+	assert.ErrorContains(t, err, `mkfs.xfs couldn't initialize ""`)
+}
+
+func TestMkfsXfsNonDefault(t *testing.T) {
+	ctx := context.Background()
+	err := mkfs(ctx, "xfs", "noquota", "")
 	assert.ErrorContains(t, err, `mkfs.xfs couldn't initialize ""`)
 }


### PR DESCRIPTION
Lazy initialization reduces file system initialization time drastically.
This removes explicit disabling of lazy init options.

#6119 https://github.com/containerd/containerd/issues/6119

Signed-off-by: Alakesh Haloi <alakeshh@amazon.com>
