### PR TITLE
Output a warning for label image labels instead of erroring

### DIFF
--- a/cmd/ctr/commands/run/run.go
+++ b/cmd/ctr/commands/run/run.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/cmd/ctr/commands/tasks"
 	"github.com/containerd/containerd/containers"
+	clabels "github.com/containerd/containerd/labels"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
 	gocni "github.com/containerd/go-cni"
@@ -254,7 +255,13 @@ func fullID(ctx context.Context, c containerd.Container) string {
 func buildLabels(cmdLabels, imageLabels map[string]string) map[string]string {
 	labels := make(map[string]string)
 	for k, v := range imageLabels {
-		labels[k] = v
+		if err := clabels.Validate(k, v); err == nil {
+			labels[k] = v
+		} else {
+			// In case the image label is invalid, we output a warning and skip adding it to the
+			// container.
+			logrus.WithError(err).Warnf("unable to add image label with key %s to the container", k)
+		}
 	}
 	// labels from the command line will override image and the initial image config labels
 	for k, v := range cmdLabels {

--- a/pkg/cri/server/helpers_test.go
+++ b/pkg/cri/server/helpers_test.go
@@ -19,6 +19,7 @@ package server
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -119,8 +120,9 @@ func TestGetRepoDigestAndTag(t *testing.T) {
 
 func TestBuildLabels(t *testing.T) {
 	imageConfigLabels := map[string]string{
-		"a": "z",
-		"d": "y",
+		"a":          "z",
+		"d":          "y",
+		"long-label": strings.Repeat("example", 10000),
 	}
 	configLabels := map[string]string{
 		"a": "b",
@@ -132,6 +134,7 @@ func TestBuildLabels(t *testing.T) {
 	assert.Equal(t, "d", newLabels["c"])
 	assert.Equal(t, "y", newLabels["d"])
 	assert.Equal(t, containerKindSandbox, newLabels[containerKindLabel])
+	assert.NotContains(t, newLabels, "long-label")
 
 	newLabels["a"] = "e"
 	assert.Empty(t, configLabels[containerKindLabel], "should not add new labels into original label")


### PR DESCRIPTION
This change ignore errors during container runtime due to large
image labels and instead outputs warning. This is necessary as certain
image building tools like buildpacks may have large labels in the images
which need not be passed to the container.

Signed-off-by: Sambhav Kothari <sambhavs.email@gmail.com>

Fixes #6123 


Note: This is one possible fix for the related issue, but not sure if it is the best way to fix this. Happy to change this if there are other possible options.