### PR TITLE
Windows: Cleanup rm- prefixed layers

### DIFF
--- a/sys/filesys_windows.go
+++ b/sys/filesys_windows.go
@@ -278,12 +278,22 @@ func ForceRemoveAll(path string) error {
 func cleanupWCOWLayers(root string) error {
 	// See snapshots/windows/windows.go getSnapshotDir()
 	var layerNums []int
+	var rmLayerNums []int
 	if err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if path != root && info.IsDir() {
-			if layerNum, err := strconv.Atoi(filepath.Base(path)); err == nil {
-				layerNums = append(layerNums, layerNum)
+			name := filepath.Base(path)
+			if strings.HasPrefix(name, "rm-") {
+				layerNum, err := strconv.Atoi(strings.TrimPrefix(name, "rm-"))
+				if err != nil {
+					return err
+				}
+				rmLayerNums = append(rmLayerNums, layerNum)
 			} else {
-				return err
+				layerNum, err := strconv.Atoi(name)
+				if err != nil {
+					return err
+				}
+				layerNums = append(layerNums, layerNum)
 			}
 			return filepath.SkipDir
 		}
@@ -293,8 +303,14 @@ func cleanupWCOWLayers(root string) error {
 		return err
 	}
 
-	sort.Sort(sort.Reverse(sort.IntSlice(layerNums)))
+	sort.Sort(sort.Reverse(sort.IntSlice(rmLayerNums)))
+	for _, rmLayerNum := range rmLayerNums {
+		if err := cleanupWCOWLayer(filepath.Join(root, "rm-"+strconv.Itoa(rmLayerNum))); err != nil {
+			return err
+		}
+	}
 
+	sort.Sort(sort.Reverse(sort.IntSlice(layerNums)))
 	for _, layerNum := range layerNums {
 		if err := cleanupWCOWLayer(filepath.Join(root, strconv.Itoa(layerNum))); err != nil {
 			return err


### PR DESCRIPTION
Some layers might be prefixed with rm-, which will result in an error when converting that string into an integer.

Sample error observed in the Windows Integration test run: https://github.com/containerd/containerd/pull/6121/checks?check_run_id=3887281043

```
2021-10-13T20:28:10.6946300Z === FAIL: .  (0.00s)
2021-10-13T20:28:10.6946895Z Windows test image: mcr.microsoft.com/windows/nanoserver:1809 , Windows build version: 17763
2021-10-13T20:28:10.6948053Z time="2021-10-13T20:22:10Z" level=info msg="running tests against containerd" revision=5e95ad080248a51b3c7583e7c6a8fb2a7aa6ad7e runtime= snapshotter= version=5e95ad0
2021-10-13T20:28:10.6953651Z time="2021-10-13T20:22:10Z" level=info msg="start to pull seed image" image="mcr.microsoft.com/windows/nanoserver:1809"
2021-10-13T20:28:10.6954373Z PASS
2021-10-13T20:28:10.6955606Z failed to remove test root dir failed to cleanup WCOW layers in C:\Program Files\containerd\root-test\io.containerd.snapshotter.v1.windows\snapshots: strconv.Atoi: parsing "rm-44": invalid syntax
2021-10-13T20:28:10.6956819Z exit status 1
2021-10-13T20:28:10.6957348Z FAIL	github.com/containerd/containerd/integration/client	360.735s
2021-10-13T20:28:10.6957951Z 
2021-10-13T20:28:10.6961846Z DONE 86 tests, 3 skipped, 1 failure in 366.536s
2021-10-13T20:28:10.8462145Z mingw32-make: *** [Makefile:202: integration] Error 1
```

Signed-off-by: Claudiu Belu <cbelu@cloudbasesolutions.com>