### PR TITLE
[release/1.5] task delete: Closes task IO before waiting

### DIFF
--- a/pkg/cri/io/helpers_windows.go
+++ b/pkg/cri/io/helpers_windows.go
@@ -52,6 +52,10 @@ func openPipe(ctx context.Context, fn string, flag int, perm os.FileMode) (io.Re
 		}
 		p.con = c
 	}()
+	go func() {
+		<-ctx.Done()
+		p.Close()
+	}()
 	return p, nil
 }
 

--- a/task.go
+++ b/task.go
@@ -315,6 +315,7 @@ func (t *task) Delete(ctx context.Context, opts ...ProcessDeleteOpts) (*ExitStat
 		return nil, errors.Wrapf(errdefs.ErrFailedPrecondition, "task must be stopped before deletion: %s", status.Status)
 	}
 	if t.io != nil {
+		t.io.Close()
 		t.io.Cancel()
 		t.io.Wait()
 	}


### PR DESCRIPTION
After containerd restarts, it will try to recover its sandboxes,
containers, and images. If it detects a task in the Created or
Stopped state, it will be removed. This will cause the containerd
process it hang on Windows on the t.io.Wait() call.

Calling t.io.Close() beforehand will solve this issue.

Additionally, the same issue occurs when trying to stopp a sandbox
after containerd restarts. This will solve that case as well.

Signed-off-by: Claudiu Belu <cbelu@cloudbasesolutions.com>
(cherry picked from commit 55faa5e93d7fdacc7d9b28ee79a0972ec18e3471)

Signed-off-by: Daniel Canter <dcanter@microsoft.com>