### PR TITLE
[release/1.5] Use deactivatelayer to recover layers that we cannot rename 

### DIFF
--- a/snapshots/windows/windows.go
+++ b/snapshots/windows/windows.go
@@ -264,8 +264,8 @@ func (s *snapshotter) Remove(ctx context.Context, key string) error {
 			}
 		)
 
-		if deactvateErr := hcsshim.DeactivateLayer(di, layerID); deactvateErr != nil {
-			return errors.Wrapf(err, "failed to deactivate layer following failed rename: %s", deactvateErr)
+		if deactivateErr := hcsshim.DeactivateLayer(di, layerID); deactivateErr != nil {
+			return errors.Wrapf(err, "failed to deactivate layer following failed rename: %s", deactivateErr)
 		}
 
 		if renameErr := os.Rename(path, renamed); renameErr != nil && !os.IsNotExist(renameErr) {


### PR DESCRIPTION
It seems that something has shifted in an API, and vhd.DetachVhd is
returning "failed to open virtual disk: invalid argument" on Windows
Server LTSC 2019.

Signed-off-by: Paul "TBBle" Hampson <Paul.Hampson@Pobox.com>
(cherry picked from commit f216270)
Signed-off-by: Daniel Canter <dcanter@microsoft.com>