### PR TITLE
[release/1.5] Update test timeout based on recent cancellations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,7 +334,7 @@ jobs:
   integration-linux:
     name: Linux Integration
     runs-on: ubuntu-18.04
-    timeout-minutes: 30
+    timeout-minutes: 40
     needs: [project, linters, protos, man]
 
     strategy:


### PR DESCRIPTION
This change bumps the Linux integration tests timeouts in the CI for release/1.5 to 40 minutes to handle some recent cancellations. 

@estesp I'd seen you'd increased the Windows and Linux runs to 35 first because of some regressions that seem to be related to go 1.17 (we're still on 1.16.8 on release/1.5) and then separately changed Linux to 40 afterwards. Let me know if just jumping to the 40 change makes sense here or we should just bring in the 35 change for both the Windows and Linux runs instead (or both if we think we're going to bump to 1.17 in the near term on release/1.5 as the Windows tests could use the change to 35 then). 

------

Edited by @fuweid 

cherry-pick from #6107