### PR TITLE
content: close stream after commit request

### DIFF
--- a/services/content/contentserver/contentserver.go
+++ b/services/content/contentserver/contentserver.go
@@ -423,6 +423,10 @@ func (s *service) Write(session api.Content_WriteServer) (err error) {
 			return err
 		}
 
+		if req.Action == api.WriteActionCommit {
+			return nil
+		}
+
 		req, err = session.Recv()
 		if err != nil {
 			if err == io.EOF {


### PR DESCRIPTION
This allows both client and server to determine when
stream is completed. Previously this was done by
closesend call(after https://github.com/containerd/containerd/pull/5227) from the client side but that is async
so the client can not assume that the server side also
already thinks that stream is complete.

fixes docker/buildx#713

@AkihiroSuda 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>