### PR TITLE
Ambient capability

### DIFF
--- a/oci/spec_opts_linux_test.go
+++ b/oci/spec_opts_linux_test.go
@@ -107,6 +107,23 @@ func TestDropCaps(t *testing.T) {
 	}
 }
 
+func TestAmbientCaps(t *testing.T) {
+	t.Parallel()
+
+	var s specs.Spec
+
+	if err := WithAmbientCapabilities([]string{"CAP_NET_ADMIN"})(context.Background(), nil, nil, &s); err != nil {
+		t.Fatal(err)
+	}
+	for i, cl := range [][]string{
+		s.Process.Capabilities.Ambient,
+	} {
+		if !capsContain(cl, "CAP_NET_ADMIN") {
+			t.Errorf("cap list %d does not contain added ambient cap", i)
+		}
+	}
+}
+
 func TestGetDevices(t *testing.T) {
 	testutil.RequiresRoot(t)
 

--- a/pkg/cri/opts/spec_linux.go
+++ b/pkg/cri/opts/spec_linux.go
@@ -364,19 +364,14 @@ func WithCapabilities(sc *runtime.LinuxContainerSecurityContext, allCaps []strin
 		caps = append(caps, "CAP_"+strings.ToUpper(c))
 	}
 	opts = append(opts, oci.WithDroppedCapabilities(caps))
-	return oci.Compose(opts...)
-}
 
-// WithoutAmbientCaps removes the ambient caps from the spec
-func WithoutAmbientCaps(_ context.Context, _ oci.Client, c *containers.Container, s *runtimespec.Spec) error {
-	if s.Process == nil {
-		s.Process = &runtimespec.Process{}
+	caps = []string{}
+	for _, c := range capabilities.GetAddAmbientCapabilities() {
+		caps = append(caps, "CAP_"+strings.ToUpper(c))
 	}
-	if s.Process.Capabilities == nil {
-		s.Process.Capabilities = &runtimespec.LinuxCapabilities{}
-	}
-	s.Process.Capabilities.Ambient = nil
-	return nil
+	opts = append(opts, oci.WithAmbientCapabilities(caps))
+
+	return oci.Compose(opts...)
 }
 
 // WithDisabledCgroups clears the Cgroups Path from the spec

--- a/pkg/cri/server/container_create_linux.go
+++ b/pkg/cri/server/container_create_linux.go
@@ -233,12 +233,7 @@ func (c *criService) containerSpec(
 		}
 	}
 
-	// Clear all ambient capabilities. The implication of non-root + caps
-	// is not clearly defined in Kubernetes.
-	// See https://github.com/kubernetes/kubernetes/issues/56374
-	// Keep docker's behavior for now.
 	specOpts = append(specOpts,
-		customopts.WithoutAmbientCaps,
 		customopts.WithSelinuxLabels(processLabel, mountLabel),
 	)
 


### PR DESCRIPTION
This PR adds support for ambient capability. The ambient set is provided by newly introduced field `add_ambient_capabilities`  of CRI in [PR](https://github.com/kubernetes/kubernetes/pull/104620)

The whole idea was discussed in [KEP](https://github.com/kubernetes/enhancements/pull/2757)

Fixes: https://github.com/containerd/containerd/issues/5644