### PR TITLE
CRI update for sandbox sizing

### DIFF
--- a/pkg/cri/annotations/annotations.go
+++ b/pkg/cri/annotations/annotations.go
@@ -32,6 +32,16 @@ const (
 	// SandboxID is the sandbox ID annotation
 	SandboxID = "io.kubernetes.cri.sandbox-id"
 
+	// SandboxCPU annotations are based on the initial CPU configuration for the sandbox. This is calculated as the
+	// sum of container CPU resources, optionally provided by Kubelet (introduced  in 1.23) as part of the PodSandboxConfig
+	SandboxCPUPeriod = "io.kubernetes.cri.sandbox-cpu-period"
+	SandboxCPUQuota  = "io.kubernetes.cri.sandbox-cpu-quota"
+	SandboxCPUShares = "io.kubernetes.cri.sandbox-cpu-shares"
+
+	// SandboxMemory is the initial amount of memory associated with this sandbox. This is calculated as the sum
+	// of container memory, optionally provided by Kubelet (introduced in 1.23) as part of the PodSandboxConfig.
+	SandboxMem = "io.kubernetes.cri.sandbox-memory"
+
 	// SandboxLogDir is the pod log directory annotation.
 	// If the sandbox needs to generate any log, it will put it into this directory.
 	// Kubelet will be responsible for:

--- a/pkg/cri/server/sandbox_run_linux.go
+++ b/pkg/cri/server/sandbox_run_linux.go
@@ -19,6 +19,7 @@ package server
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/containerd/containerd"
@@ -155,6 +156,15 @@ func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 	if !c.config.DisableCgroup {
 		specOpts = append(specOpts, customopts.WithDefaultSandboxShares)
 	}
+
+	if res := config.GetLinux().GetResources(); res != nil {
+		specOpts = append(specOpts,
+			customopts.WithAnnotation(annotations.SandboxCPUPeriod, strconv.FormatInt(res.CpuPeriod, 10)),
+			customopts.WithAnnotation(annotations.SandboxCPUQuota, strconv.FormatInt(res.CpuQuota, 10)),
+			customopts.WithAnnotation(annotations.SandboxCPUShares, strconv.FormatInt(res.CpuShares, 10)),
+			customopts.WithAnnotation(annotations.SandboxMem, strconv.FormatInt(res.MemoryLimitInBytes, 10)))
+	}
+
 	specOpts = append(specOpts, customopts.WithPodOOMScoreAdj(int(defaultSandboxOOMAdj), c.config.RestrictOOMScoreAdj))
 
 	for pKey, pValue := range getPassthroughAnnotations(config.Annotations,

--- a/pkg/cri/server/sandbox_run_linux_test.go
+++ b/pkg/cri/server/sandbox_run_linux_test.go
@@ -19,6 +19,7 @@ package server
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -27,6 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+	v1 "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/containerd/containerd/pkg/cri/annotations"
 	"github.com/containerd/containerd/pkg/cri/opts"
@@ -171,6 +173,65 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 				require.NotNil(t, spec.Process)
 				assert.Contains(t, spec.Linux.Sysctl["net.ipv4.ip_unprivileged_port_start"], "500")
 				assert.Contains(t, spec.Linux.Sysctl["net.ipv4.ping_group_range"], "1 1000")
+			},
+		},
+		"sandbox sizing annotations should be set if LinuxContainerResources were provided": {
+			configChange: func(c *runtime.PodSandboxConfig) {
+				c.Linux.Resources = &v1.LinuxContainerResources{
+					CpuPeriod:          100,
+					CpuQuota:           200,
+					CpuShares:          5000,
+					MemoryLimitInBytes: 1024,
+				}
+			},
+			specCheck: func(t *testing.T, spec *runtimespec.Spec) {
+				value, ok := spec.Annotations[annotations.SandboxCPUPeriod]
+				assert.True(t, ok)
+				assert.EqualValues(t, strconv.FormatInt(100, 10), value)
+				assert.EqualValues(t, "100", value)
+
+				value, ok = spec.Annotations[annotations.SandboxCPUQuota]
+				assert.True(t, ok)
+				assert.EqualValues(t, "200", value)
+
+				value, ok = spec.Annotations[annotations.SandboxCPUShares]
+				assert.True(t, ok)
+				assert.EqualValues(t, "5000", value)
+
+				value, ok = spec.Annotations[annotations.SandboxMem]
+				assert.True(t, ok)
+				assert.EqualValues(t, "1024", value)
+			},
+		},
+		"sandbox sizing annotations should not be set if LinuxContainerResources were not provided": {
+			specCheck: func(t *testing.T, spec *runtimespec.Spec) {
+				_, ok := spec.Annotations[annotations.SandboxCPUPeriod]
+				assert.False(t, ok)
+				_, ok = spec.Annotations[annotations.SandboxCPUQuota]
+				assert.False(t, ok)
+				_, ok = spec.Annotations[annotations.SandboxCPUShares]
+				assert.False(t, ok)
+				_, ok = spec.Annotations[annotations.SandboxMem]
+				assert.False(t, ok)
+			},
+		},
+		"sandbox sizing annotations are zero if the resources are set to 0": {
+			configChange: func(c *runtime.PodSandboxConfig) {
+				c.Linux.Resources = &v1.LinuxContainerResources{}
+			},
+			specCheck: func(t *testing.T, spec *runtimespec.Spec) {
+				value, ok := spec.Annotations[annotations.SandboxCPUPeriod]
+				assert.True(t, ok)
+				assert.EqualValues(t, "0", value)
+				value, ok = spec.Annotations[annotations.SandboxCPUQuota]
+				assert.True(t, ok)
+				assert.EqualValues(t, "0", value)
+				value, ok = spec.Annotations[annotations.SandboxCPUShares]
+				assert.True(t, ok)
+				assert.EqualValues(t, "0", value)
+				value, ok = spec.Annotations[annotations.SandboxMem]
+				assert.True(t, ok)
+				assert.EqualValues(t, "0", value)
 			},
 		},
 	} {


### PR DESCRIPTION
## Background

Today in Kubernetes, sandbox level sizing information is not available through CRI. With 1.23 (see https://github.com/kubernetes/kubernetes/pull/104886), the CRI API is updated to include an optional field in the LinuxPodSandboxConfig field which is part of the RunPodSandbox request. sandbox create request, as seen here: https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1alpha2/api.proto#L334-L335

Having sandbox level resource details at sandbox creation time will have large benefits for sandboxed runtimes. In the case of Kata Containers, for example, this'll allow us to better support SW/HW architectures which don't allow for resource hot plug (memory/CPU), and it'll allow for better queue sizing for virtio devices associated with the sandbox VM.

## RFC: 

Now that containerd will have access to this information, I am seeking to make this information available for the underlying "OCI runtime." In the case of shim-v2 task API, I'm looking to get this information passed when creating a sandbox, https://github.com/containerd/containerd/blob/45c5298700a81b4b50b73b2125d6f082998bfec7/pkg/cri/server/sandbox_run.go#L59

With sandbox API, this will be a natural fit. From looking at this for task API, we can include this information when making a CreateTaskRequest for a sandbox container. I see a couple of options:

### Option 1: include sizing information in the pause containers OCI spec:

Setting up creation of a container (task) using pause container, containerd leaves minimal constraints (just applies minimum CPU shares) in place for the OCI spec.  Since the runtime could *know* that it is a sandbox create request, if an enlightened runtime is in place, containerd could place the sandbox resources directly into the pause container's spec (for example, have a config option per-runtime on whether we expect to consume sandbox information from the pause container's spec).  The runtime would just use this information for sandbox sizing, and would be required to constrain the in-guest pause container appropriately. The benefit of this approach is that the small changes are contained within the CRI portion of containerd code base, not modifying task request behavior.

###  Option 2 Include this sizing information as part of  CreateTaskRqeuest `options` "blob": 

We could Marshall this information as part of the `options` field within CreateTaskRequest for sandbox create requests (ie: https://github.com/containerd/containerd/blob/0d0fb6858971e5dd92cb044a744979ccb1e9635a/api/services/tasks/v1/tasks.pb.go#L53). Task options is used minimally today to set a couple of flags. The existing handling would need refactoring to include details from the CRI request (the linux config resources) in order to properly create the resulting 'blob'. While this wouldn't require a config option, I wasn't confident how viable this refactoring would be, and if the Options field is intended for this kind of usage (as opposed to just runtime flags). 
