### PR TITLE
shim: Export the TaskService struct.

### DIFF
--- a/runtime/v2/shim/shim.go
+++ b/runtime/v2/shim/shim.go
@@ -88,12 +88,13 @@ type ttrpcService interface {
 	RegisterTTRPC(*ttrpc.Server) error
 }
 
-type taskService struct {
-	local shimapi.TaskService
+// Implement TaskService
+type TaskService struct {
+	Local shimapi.TaskService
 }
 
-func (t *taskService) RegisterTTRPC(server *ttrpc.Server) error {
-	shimapi.RegisterTaskService(server, t.local)
+func (t *TaskService) RegisterTTRPC(server *ttrpc.Server) error {
+	shimapi.RegisterTaskService(server, t.Local)
 	return nil
 }
 
@@ -274,7 +275,7 @@ func run(id string, initFunc Init, config Config) error {
 			Type: plugin.TTRPCPlugin,
 			ID:   "task",
 			InitFn: func(ic *plugin.InitContext) (interface{}, error) {
-				return &taskService{ts}, nil
+				return &TaskService{ts}, nil
 			},
 		})
 	}


### PR DESCRIPTION
Making `taskService` public  makes it easy to do type conversions and
share objects between shim plugins.

Signed-off-by: wanglei01 <wllenyj@linux.alibaba.com>

When I supported containerd 1.6.0 in kata-runtime, I encountered several problems about shim plugins.
1. I implemented ImageService using shim-plugin in kata-runtime. But it was found that ImageService could not communicate with TaskService. So with this patch. Then you can use type conversion to get the TaskService in the ImageService. eg. https://github.com/kata-containers/kata-containers/pull/2733/commits/f9ae9250c7a8c44b9f7d219b8c344f6cf47edfd1#diff-746ec2eee773da5e91770c3c8963e656eb0901e4e10076bdeb35e2d9a82cec10

``` go
func init() {
	plugin.Register(&plugin.Registration{
		Type:     plugin.TTRPCPlugin,
		ID:       "image",
		Requires: []plugin.Type{"*"},
		InitFn:   initImageService,
	})
}
func initImageService(ic *plugin.InitContext) (interface{}, error) {
	i, err := ic.GetByID(plugin.TTRPCPlugin, "task")
	if err != nil {
		return nil, errors.Errorf("get task plugin error. %v", err)
	}
	task := i.(*shim.TaskService)
	s := task.Local.(*service)
	is := &ImageService{s: s}
	return is, nil
}
```
