### PR TITLE
commands: Enables task metrics for Windows

### DIFF
--- a/cmd/ctr/commands/tasks/metrics.go
+++ b/cmd/ctr/commands/tasks/metrics.go
@@ -1,6 +1,3 @@
-//go:build linux
-// +build linux
-
 /*
    Copyright The containerd Authors.
 


### PR DESCRIPTION
The command already contains logic for Windows container metrics, we just need to enable the command.

Signed-off-by: Claudiu Belu <cbelu@cloudbasesolutions.com>

Sample:

```
PS C:\tmp> $POD_ID=(crictl --runtime-endpoint=npipe://./pipe/run/containerd-test/containerd runp .\pod.json)
PS C:\tmp> $CONTAINER_ID=(crictl --runtime-endpoint=npipe://./pipe/run/containerd-test/containerd create $POD_ID .\container-normal.json .\pod.json)
PS C:\tmp> crictl --runtime-endpoint=npipe://./pipe/run/containerd-test/containerd start $CONTAINER_ID
fd0db6cef164e2102ae02889e7d53d5aba673be7d080f1cea0bb1a41deb7265f
PS C:\tmp> cd C:\Users\azureuser\containerd\
PS C:\Users\azureuser\containerd> bin/ctr.exe --address //./pipe//run/containerd-test/containerd --namespace k8s.io task metrics $CONTAINER_ID
ID                                                                  TIMESTAMP
fd0db6cef164e2102ae02889e7d53d5aba673be7d080f1cea0bb1a41deb7265f    2021-10-26 08:25:42.8711436 +0000 UTC

METRIC                              VALUE
timestamp                           2021-10-26 08:25:42.8728789 +0000 UTC
start_time                          2021-10-26 08:24:23.8881435 +0000 UTC
uptime_ns                           78984735400
cpu.total_runtime_ns                1265625000
cpu.runtime_user_ns                 312500000
memory.commit_bytes                 25169920
memory.commit_peak_bytes            27045888
memory.private_working_set_bytes    13623296
storage.read_count_normalized       241
storage.read_size_bytes             1842688
storage.write_count_normalized      635
storage.write_size_bytes            4444160
```