### PR TITLE
Generate token options with each scope as a separate string.

### DIFF
--- a/remotes/docker/auth/fetch.go
+++ b/remotes/docker/auth/fetch.go
@@ -58,7 +58,7 @@ func GenerateTokenOptions(ctx context.Context, host, username, secret string, c 
 
 	scope, ok := c.Parameters["scope"]
 	if ok {
-		to.Scopes = append(to.Scopes, scope)
+		to.Scopes = append(to.Scopes, strings.Split(scope, " ")...)
 	} else {
 		log.G(ctx).WithField("host", host).Debug("no scope specified for token auth challenge")
 	}


### PR DESCRIPTION
Currently scopes added to token options are added with all scopes included in space delimited string. This changes it so that each scope is added to the string slice as a separate string. This seems to be the desire behavior based on the fact that a string slice is used and the usage of this function in github.com/moby/buildkit.

Signed-off-by: Jacob MacElroy <jacob@okteto.com>