### PR TITLE
vendor: Updates go-cni

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/containerd/containerd/api v1.6.0-beta.1
 	github.com/containerd/continuity v0.2.0
 	github.com/containerd/fifo v1.0.0
-	github.com/containerd/go-cni v1.1.0
+	github.com/containerd/go-cni v1.1.1-0.20211026134925-aa8bf14323a5
 	github.com/containerd/go-runc v1.0.0
 	github.com/containerd/imgcrypt v1.1.1
 	github.com/containerd/nri v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/containerd/continuity v0.2.0 h1:j/9Wnn+hrEWjLvHuIxUU1YI5JjEjVlT2AA68c
 github.com/containerd/continuity v0.2.0/go.mod h1:wCYX+dRqZdImhGucXOqTQn05AhX6EUDaGEMUzTFFpLg=
 github.com/containerd/fifo v1.0.0 h1:6PirWBr9/L7GDamKr+XM0IeUFXu5mf3M/BPpH9gaLBU=
 github.com/containerd/fifo v1.0.0/go.mod h1:ocF/ME1SX5b1AOlWi9r677YJmCPSwwWnQ9O123vzpE4=
-github.com/containerd/go-cni v1.1.0 h1:kAe75MdTddsLCZDqP2BJn6e1ovD+il9oFkNlfGULEos=
-github.com/containerd/go-cni v1.1.0/go.mod h1:Rflh2EJ/++BA2/vY5ao3K6WJRR/bZKsX123aPk+kUtA=
+github.com/containerd/go-cni v1.1.1-0.20211026134925-aa8bf14323a5 h1:khacN1kfW+7jnuj5rWytfCORVL1RmeDpD7Y1fdM4G1c=
+github.com/containerd/go-cni v1.1.1-0.20211026134925-aa8bf14323a5/go.mod h1:Rflh2EJ/++BA2/vY5ao3K6WJRR/bZKsX123aPk+kUtA=
 github.com/containerd/go-runc v0.0.0-20201020171139-16b287bc67d0/go.mod h1:cNU0ZbCgCQVZK4lgG3P+9tn9/PaJNmoDXPpoJhDR+Ok=
 github.com/containerd/go-runc v1.0.0 h1:oU+lLv1ULm5taqgV/CJivypVODI4SUz1znWjv3nNYS0=
 github.com/containerd/go-runc v1.0.0/go.mod h1:cNU0ZbCgCQVZK4lgG3P+9tn9/PaJNmoDXPpoJhDR+Ok=

--- a/integration/client/go.sum
+++ b/integration/client/go.sum
@@ -121,7 +121,7 @@ github.com/containerd/continuity v0.2.0 h1:j/9Wnn+hrEWjLvHuIxUU1YI5JjEjVlT2AA68c
 github.com/containerd/continuity v0.2.0/go.mod h1:wCYX+dRqZdImhGucXOqTQn05AhX6EUDaGEMUzTFFpLg=
 github.com/containerd/fifo v1.0.0 h1:6PirWBr9/L7GDamKr+XM0IeUFXu5mf3M/BPpH9gaLBU=
 github.com/containerd/fifo v1.0.0/go.mod h1:ocF/ME1SX5b1AOlWi9r677YJmCPSwwWnQ9O123vzpE4=
-github.com/containerd/go-cni v1.1.0/go.mod h1:Rflh2EJ/++BA2/vY5ao3K6WJRR/bZKsX123aPk+kUtA=
+github.com/containerd/go-cni v1.1.1-0.20211026134925-aa8bf14323a5/go.mod h1:Rflh2EJ/++BA2/vY5ao3K6WJRR/bZKsX123aPk+kUtA=
 github.com/containerd/go-runc v0.0.0-20200220073739-7016d3ce2328/go.mod h1:PpyHrqVs8FTi9vpyHwPwiNEGaACDxT/N/pLcvMSRA9g=
 github.com/containerd/go-runc v0.0.0-20201020171139-16b287bc67d0/go.mod h1:cNU0ZbCgCQVZK4lgG3P+9tn9/PaJNmoDXPpoJhDR+Ok=
 github.com/containerd/go-runc v1.0.0 h1:oU+lLv1ULm5taqgV/CJivypVODI4SUz1znWjv3nNYS0=

--- a/vendor/github.com/containerd/go-cni/cni.go
+++ b/vendor/github.com/containerd/go-cni/cni.go
@@ -183,7 +183,9 @@ func (c *libcni) Remove(ctx context.Context, id string, path string, opts ...Nam
 			// https://github.com/containernetworking/plugins/issues/210
 			// TODO(random-liu): Remove the error handling when the issue is
 			// fixed and the CNI spec v0.6.0 support is deprecated.
-			if path == "" && strings.Contains(err.Error(), "no such file or directory") {
+			// NOTE(claudiub): Some CNIs could return a "not found" error, which could mean that
+			// it was already deleted.
+			if (path == "" && strings.Contains(err.Error(), "no such file or directory")) || strings.Contains(err.Error(), "not found") {
 				continue
 			}
 			return err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -110,7 +110,7 @@ github.com/containerd/continuity/testutil/loopback
 # github.com/containerd/fifo v1.0.0
 ## explicit
 github.com/containerd/fifo
-# github.com/containerd/go-cni v1.1.0
+# github.com/containerd/go-cni v1.1.1-0.20211026134925-aa8bf14323a5
 ## explicit
 github.com/containerd/go-cni
 # github.com/containerd/go-runc v1.0.0


### PR DESCRIPTION
This update will allow us to forcefully delete a Windows sandbox if its endpoint cannot be found anymore.

Fixes: #6135

Signed-off-by: Claudiu Belu <cbelu@cloudbasesolutions.com>