### PR TITLE
CRI: Support enable_unprivileged_icmp and enable_unprivileged_ports options

### DIFF
--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -107,6 +107,19 @@ version = 2
     # set to nil or `unconfined`, and the default used when the runtime default seccomp profile is requested.
   unset_seccomp_profile = ""
 
+  # enable_unprivileged_ports configures net.ipv4.ip_unprivileged_port_start=0
+  # for all containers which are not using host network
+  # and if it is not overwritten by PodSandboxConfig
+  # Note that currently default is set to disabled but target change it in future, see:
+  #   [k8s discussion](https://github.com/kubernetes/kubernetes/issues/102612)
+  enable_unprivileged_ports = false
+
+  # enable_unprivileged_icmp configures net.ipv4.ping_group_range="0 2147483647"
+  # for all containers which are not using host network, are not running in user namespace
+  # and if it is not overwritten by PodSandboxConfig
+  # Note that currently default is set to disabled but target change it in future together with enable_unprivileged_ports
+  enable_unprivileged_icmp = false
+
   # 'plugins."io.containerd.grpc.v1.cri".containerd' contains config related to containerd
   [plugins."io.containerd.grpc.v1.cri".containerd]
 

--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -282,6 +282,17 @@ type PluginConfig struct {
 	// of being placed under the hardcoded directory /var/run/netns. Changing this setting requires
 	// that all containers are deleted.
 	NetNSMountsUnderStateDir bool `toml:"netns_mounts_under_state_dir" json:"netnsMountsUnderStateDir"`
+	// EnableUnprivilegedPorts configures net.ipv4.ip_unprivileged_port_start=0
+	// for all containers which are not using host network
+	// and if it is not overwritten by PodSandboxConfig
+	// Note that currently default is set to disabled but target change it in future, see:
+	//   https://github.com/kubernetes/kubernetes/issues/102612
+	EnableUnprivilegedPorts bool `toml:"enable_unprivileged_ports" json:"enableUnprivilegedPorts"`
+	// EnableUnprivilegedICMP configures net.ipv4.ping_group_range="0 2147483647"
+	// for all containers which are not using host network, are not running in user namespace
+	// and if it is not overwritten by PodSandboxConfig
+	// Note that currently default is set to disabled but target change it in future together with EnableUnprivilegedPorts
+	EnableUnprivilegedICMP bool `toml:"enable_unprivileged_icmp" json:"enableUnprivilegedICMP"`
 }
 
 // X509KeyPairStreaming contains the x509 configuration for streaming


### PR DESCRIPTION
Borrowing logic from https://github.com/moby/moby/pull/41030 to solve #4936 (and https://github.com/kubernetes/kubernetes/issues/102612 ) by adding options `enable_unprivileged_icmp` and `enable_unprivileged_ports`. However in-this point those are disabled by default.

~Only open question is do we need similar logic like was added by https://github.com/moby/moby/pull/42736 here too? (I'm not familiar enough to be able answer that question).~