### PR TITLE
Add mkdir on Dockerfile

### DIFF
--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -90,6 +90,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY script/setup/install-protobuf install-protobuf
 RUN ./install-protobuf \
+ && mkdir -p $DESTDIR/usr/local/bin $DESTDIR/usr/local/include \
  && mv /usr/local/bin/protoc $DESTDIR/usr/local/bin/protoc \
  && mv /usr/local/include/google $DESTDIR/usr/local/include/google
 


### PR DESCRIPTION
The Dockerfile.test used to test containerd in a container does not work. It fails with error 

```
mv: cannot move '/usr/local/bin/protoc' to '/build/usr/local/bin/protoc': No such file or directory
```

This PR adds `mkdir -p` to ensure required folders exist.

Tested on Linux Ubuntu 18.04 LTS with Docker 20.10.7.