### PR TITLE
[release/1.5] Output a warning for label image labels instead of erroring

### DIFF
--- a/pkg/cri/server/helpers_test.go
+++ b/pkg/cri/server/helpers_test.go
@@ -19,6 +19,7 @@ package server
 import (
 	"context"
 	"io/ioutil"
+	"strings"
 	"testing"
 	"time"
 
@@ -119,8 +120,9 @@ func TestGetRepoDigestAndTag(t *testing.T) {
 
 func TestBuildLabels(t *testing.T) {
 	imageConfigLabels := map[string]string{
-		"a": "z",
-		"d": "y",
+		"a":          "z",
+		"d":          "y",
+		"long-label": strings.Repeat("example", 10000),
 	}
 	configLabels := map[string]string{
 		"a": "b",
@@ -132,6 +134,7 @@ func TestBuildLabels(t *testing.T) {
 	assert.Equal(t, "d", newLabels["c"])
 	assert.Equal(t, "y", newLabels["d"])
 	assert.Equal(t, containerKindSandbox, newLabels[containerKindLabel])
+	assert.NotContains(t, newLabels, "long-label")
 
 	newLabels["a"] = "e"
 	assert.Empty(t, configLabels[containerKindLabel], "should not add new labels into original label")


### PR DESCRIPTION
This patch seems to needed to fix https://github.com/kubernetes-sigs/kind/issues/2518.
Backporting from https://github.com/containerd/containerd/pull/6124 (fixes https://github.com/containerd/containerd/issues/6123).

This change ignore errors during container runtime due to large
image labels and instead outputs warning. This is necessary as certain
image building tools like buildpacks may have large labels in the images
which need not be passed to the container.

Signed-off-by: Sambhav Kothari <sambhavs.email@gmail.com>
(cherry picked from commit 2a8dac12a7629c1c9f1be66c40e6cd5d25d9c70b)
Signed-off-by: Kohei Tokunaga <ktokunaga.mail@gmail.com>