### PR TITLE
Implement CDI support

### DIFF
--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -83,6 +83,10 @@ var platformRunFlags = []cli.Flag{
 		Name:  "cni",
 		Usage: "enable cni networking for the container",
 	},
+	cli.StringSliceFlag{
+		Name:  "cdi",
+		Usage: "CDI device in the vendor.com/device=<device name> format to add to the container",
+	},
 }
 
 // NewContainer creates a new container
@@ -294,6 +298,10 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 		}
 		for _, dev := range context.StringSlice("device") {
 			opts = append(opts, oci.WithDevices(dev, "", "rwm"))
+		}
+		cdiDevices := context.StringSlice("cdi")
+		if len(cdiDevices) > 0 {
+			opts = append(opts, oci.WithCDIdevices(cdiDevices))
 		}
 
 		rootfsPropagation := context.String("rootfs-propagation")

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20210715213245-6c3934b029d8
 	github.com/Microsoft/go-winio v0.5.0
 	github.com/Microsoft/hcsshim v0.9.0
+	github.com/container-orchestrated-devices/container-device-interface v0.0.0-20211102125128-1eb67455b699
 	github.com/containerd/aufs v1.0.0
 	github.com/containerd/btrfs v1.0.0
 	github.com/containerd/cgroups v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
+github.com/container-orchestrated-devices/container-device-interface v0.0.0-20211102125128-1eb67455b699 h1:ad6H5aXKhrRr+V9ctI2sqIJw6QGG2aT9ewK7xQUxUXw=
+github.com/container-orchestrated-devices/container-device-interface v0.0.0-20211102125128-1eb67455b699/go.mod h1:eQt66kIaJpUhCrjCtBFQGQxGLbAUl0OuuwjTH16ON4s=
 github.com/containerd/aufs v1.0.0 h1:2oeJiwX5HstO7shSrPZjrohJZLzK36wvpdmzDRkL/LY=
 github.com/containerd/aufs v1.0.0/go.mod h1:kL5kd6KM5TzQjR79jljyi4olc1Vrx6XBlcyj3gNv2PU=
 github.com/containerd/btrfs v1.0.0 h1:osn1exbzdub9L5SouXO5swW4ea/xVdJZ3wokxN5GrnA=
@@ -595,6 +597,9 @@ github.com/vishvananda/netlink v1.1.1-0.20210330154013-f5de75959ad5/go.mod h1:tw
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/oci/spec_opts_linux.go
+++ b/oci/spec_opts_linux.go
@@ -19,6 +19,7 @@ package oci
 import (
 	"context"
 
+	cdi "github.com/container-orchestrated-devices/container-device-interface/pkg"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/pkg/cap"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -140,4 +141,12 @@ var WithAllKnownCapabilities = func(ctx context.Context, client Client, c *conta
 // WithoutRunMount removes the `/run` inside the spec
 func WithoutRunMount(ctx context.Context, client Client, c *containers.Container, s *Spec) error {
 	return WithoutMounts("/run")(ctx, client, c, s)
+}
+
+// WithCDIdevices adds CDI devices to the spec
+func WithCDIdevices(cdiDevices []string) SpecOpts {
+	return func(ctx context.Context, _ Client, c *containers.Container, s *Spec) error {
+		err := cdi.UpdateOCISpecForDevices(s, cdiDevices)
+		return err
+	}
 }

--- a/pkg/cri/server/container_create.go
+++ b/pkg/cri/server/container_create.go
@@ -237,6 +237,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 		return nil, errors.Wrap(err, "failed to get runtime options")
 	}
 	opts = append(opts,
+		containerd.WithCDIdevices(spec),
 		containerd.WithSpec(spec, specOpts...),
 		containerd.WithRuntime(sandboxInfo.Runtime.Name, runtimeOptions),
 		containerd.WithContainerLabels(containerLabels),

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -62,6 +62,10 @@ github.com/cilium/ebpf/internal
 github.com/cilium/ebpf/internal/btf
 github.com/cilium/ebpf/internal/unix
 github.com/cilium/ebpf/link
+# github.com/container-orchestrated-devices/container-device-interface v0.0.0-20211102125128-1eb67455b699
+## explicit
+github.com/container-orchestrated-devices/container-device-interface/pkg
+github.com/container-orchestrated-devices/container-device-interface/specs-go
 # github.com/containerd/aufs v1.0.0
 ## explicit
 github.com/containerd/aufs


### PR DESCRIPTION
This is an initial implementation of the CDI support made on two levels:
- client side (ctr)
- server side (CRI)

**NOTE**: this is an alternative approach to NRI: https://github.com/klihub/nri/blob/5f41c0fbfab8c026f94db5e3f3dc91ce9ff509bf/v2alpha1/plugins/cdi-resolver/cdi-resolver.go#L48-L60
CRI implementation used this code