### PR TITLE
test: Add grace period for restart monitor test

### DIFF
--- a/integration/client/restart_monitor_test.go
+++ b/integration/client/restart_monitor_test.go
@@ -174,7 +174,11 @@ version = 2
 
 	begin := time.Now()
 
-	expected := begin.Add(interval).Add(epsilon)
+	// The restart is "truly" expected after (interval + epsilon), but due to some flakiness in CI, we give it a bit extra time.
+	// Specifically, we give an extra "grace period" of (count / 2) seconds.
+	expected := begin.Add(interval).Add(epsilon * (count / 2))
+
+	// Deadline determines when check for restart should be aborted.
 	deadline := begin.Add(interval).Add(epsilon * count)
 	for {
 		status, err := task.Status(ctx)


### PR DESCRIPTION
restart monitor test was failing due to occasionally taking past the
deadline on windows tests. Add a small additional grace period to
deflake the test.

Signed-off-by: David Porter <porterdavid@google.com>