### PR TITLE
ctr: implement CDI support

### DIFF
--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -83,6 +83,10 @@ var platformRunFlags = []cli.Flag{
 		Name:  "cni",
 		Usage: "enable cni networking for the container",
 	},
+	cli.StringSliceFlag{
+		Name:  "cdi",
+		Usage: "CDI device in the vendor.com/device=<device name> format to add to the container",
+	},
 }
 
 // NewContainer creates a new container
@@ -294,6 +298,10 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 		}
 		for _, dev := range context.StringSlice("device") {
 			opts = append(opts, oci.WithDevices(dev, "", "rwm"))
+		}
+		cdiDevices := context.StringSlice("cdi")
+		if len(cdiDevices) > 0 {
+			opts = append(opts, oci.WithCDIDevices(cdiDevices))
 		}
 
 		rootfsPropagation := context.String("rootfs-propagation")

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20210715213245-6c3934b029d8
 	github.com/Microsoft/go-winio v0.5.0
 	github.com/Microsoft/hcsshim v0.9.1
+	github.com/container-orchestrated-devices/container-device-interface v0.0.0-20211102125128-1eb67455b699
 	github.com/containerd/aufs v1.0.0
 	github.com/containerd/btrfs v1.0.0
 	github.com/containerd/cgroups v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
+github.com/container-orchestrated-devices/container-device-interface v0.0.0-20211102125128-1eb67455b699 h1:ad6H5aXKhrRr+V9ctI2sqIJw6QGG2aT9ewK7xQUxUXw=
+github.com/container-orchestrated-devices/container-device-interface v0.0.0-20211102125128-1eb67455b699/go.mod h1:eQt66kIaJpUhCrjCtBFQGQxGLbAUl0OuuwjTH16ON4s=
 github.com/containerd/aufs v1.0.0 h1:2oeJiwX5HstO7shSrPZjrohJZLzK36wvpdmzDRkL/LY=
 github.com/containerd/aufs v1.0.0/go.mod h1:kL5kd6KM5TzQjR79jljyi4olc1Vrx6XBlcyj3gNv2PU=
 github.com/containerd/btrfs v1.0.0 h1:osn1exbzdub9L5SouXO5swW4ea/xVdJZ3wokxN5GrnA=
@@ -598,6 +600,9 @@ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f h1:p4VB7kIXpOQvVn1ZaTIVp+3vuYAXFe3OJEvjbUYJLaA=
 github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/integration/client/go.sum
+++ b/integration/client/go.sum
@@ -104,6 +104,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
+github.com/container-orchestrated-devices/container-device-interface v0.0.0-20211102125128-1eb67455b699 h1:ad6H5aXKhrRr+V9ctI2sqIJw6QGG2aT9ewK7xQUxUXw=
+github.com/container-orchestrated-devices/container-device-interface v0.0.0-20211102125128-1eb67455b699/go.mod h1:eQt66kIaJpUhCrjCtBFQGQxGLbAUl0OuuwjTH16ON4s=
 github.com/containerd/aufs v1.0.0/go.mod h1:kL5kd6KM5TzQjR79jljyi4olc1Vrx6XBlcyj3gNv2PU=
 github.com/containerd/btrfs v1.0.0/go.mod h1:zMcX3qkXTAi9GI50+0HOeuV8LU2ryCE/V2vG/ZBiTss=
 github.com/containerd/cgroups v0.0.0-20200824123100-0b889c03f102/go.mod h1:s5q4SojHctfxANBDvMeIaIovkq29IP48TKAxnhYRxvo=
@@ -557,6 +559,9 @@ github.com/vishvananda/netlink v1.1.1-0.20210330154013-f5de75959ad5/go.mod h1:tw
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/oci/spec_opts_linux.go
+++ b/oci/spec_opts_linux.go
@@ -19,6 +19,7 @@ package oci
 import (
 	"context"
 
+	cdi "github.com/container-orchestrated-devices/container-device-interface/pkg"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/pkg/cap"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -140,4 +141,12 @@ var WithAllKnownCapabilities = func(ctx context.Context, client Client, c *conta
 // WithoutRunMount removes the `/run` inside the spec
 func WithoutRunMount(ctx context.Context, client Client, c *containers.Container, s *Spec) error {
 	return WithoutMounts("/run")(ctx, client, c, s)
+}
+
+// WithCDIDevices adds CDI devices to the spec
+func WithCDIDevices(cdiDevices []string) SpecOpts {
+	return func(ctx context.Context, _ Client, c *containers.Container, s *Spec) error {
+		err := cdi.UpdateOCISpecForDevices(s, cdiDevices)
+		return err
+	}
 }

--- a/oci/spec_opts_unix.go
+++ b/oci/spec_opts_unix.go
@@ -22,6 +22,7 @@ package oci
 import (
 	"context"
 
+	cdi "github.com/container-orchestrated-devices/container-device-interface/pkg"
 	"github.com/containerd/containerd/containers"
 )
 
@@ -55,5 +56,13 @@ func WithDevices(devicePath, containerPath, permissions string) SpecOpts {
 func WithCPUCFS(quota int64, period uint64) SpecOpts {
 	return func(ctx context.Context, _ Client, c *containers.Container, s *Spec) error {
 		return nil
+	}
+}
+
+// WithCDIDevices adds CDI devices to the spec
+func WithCDIDevices(cdiDevices []string) SpecOpts {
+	return func(ctx context.Context, _ Client, c *containers.Container, s *Spec) error {
+		err := cdi.UpdateOCISpecForDevices(s, cdiDevices)
+		return err
 	}
 }

--- a/vendor/github.com/container-orchestrated-devices/container-device-interface/LICENSE
+++ b/vendor/github.com/container-orchestrated-devices/container-device-interface/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/container-orchestrated-devices/container-device-interface/pkg/devices.go
+++ b/vendor/github.com/container-orchestrated-devices/container-device-interface/pkg/devices.go
@@ -1,0 +1,181 @@
+package pkg
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	cdispec "github.com/container-orchestrated-devices/container-device-interface/specs-go"
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+const (
+	root = "/etc/cdi"
+)
+
+func collectCDISpecs() (map[string]*cdispec.Spec, error) {
+	var files []string
+	vendor := make(map[string]*cdispec.Spec)
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if info == nil || info.IsDir() {
+			return nil
+		}
+
+		if filepath.Ext(path) != ".json" {
+			return nil
+		}
+
+		files = append(files, path)
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, path := range files {
+		spec, err := loadCDIFile(path)
+		if err != nil {
+			continue
+		}
+
+		if _, ok := vendor[spec.Kind]; ok {
+			continue
+		}
+
+		vendor[spec.Kind] = spec
+	}
+
+	return vendor, nil
+}
+
+// TODO: Validate (e.g: duplicate device names)
+func loadCDIFile(path string) (*cdispec.Spec, error) {
+	file, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var spec *cdispec.Spec
+	err = json.Unmarshal([]byte(file), &spec)
+	if err != nil {
+		return nil, err
+	}
+
+	return spec, nil
+}
+
+/*
+* Pattern "vendor.com/device=myDevice" with the vendor being optional
+ */
+func extractVendor(dev string) (string, string) {
+	if strings.IndexByte(dev, '=') == -1 {
+		return "", dev
+	}
+
+	split := strings.SplitN(dev, "=", 2)
+	return split[0], split[1]
+}
+
+// GetCDIForDevice returns the CDI specification that matches the device name the user provided.
+func GetCDIForDevice(dev string, specs map[string]*cdispec.Spec) (*cdispec.Spec, error) {
+	vendor, device := extractVendor(dev)
+
+	if vendor != "" {
+		s, ok := specs[vendor]
+		if !ok {
+			return nil, fmt.Errorf("Could not find vendor %q for device %q", vendor, device)
+		}
+
+		for _, d := range s.Devices {
+			if d.Name != device {
+				continue
+			}
+
+			return s, nil
+		}
+
+		return nil, fmt.Errorf("Could not find device %q for vendor %q", device, vendor)
+	}
+
+	var found []*cdispec.Spec
+	var vendors []string
+	for vendor, spec := range specs {
+
+		for _, d := range spec.Devices {
+			if d.Name != device {
+				continue
+			}
+
+			found = append(found, spec)
+			vendors = append(vendors, vendor)
+		}
+	}
+
+	if len(found) > 1 {
+		return nil, fmt.Errorf("%q is ambiguous and currently refers to multiple devices from different vendors: %q", dev, vendors)
+	}
+
+	if len(found) == 1 {
+		return found[0], nil
+	}
+
+	return nil, fmt.Errorf("Could not find device %q", dev)
+}
+
+// HasDevice returns true if a device is a CDI device
+// an error may be returned in cases where permissions may be required
+func HasDevice(dev string) (bool, error) {
+	specs, err := collectCDISpecs()
+	if err != nil {
+		return false, err
+	}
+
+	d, err := GetCDIForDevice(dev, specs)
+	if err != nil {
+		return false, err
+	}
+
+	return d != nil, nil
+}
+
+// UpdateOCISpecForDevices updates the given OCI spec based on the requested CDI devices
+func UpdateOCISpecForDevices(ociconfig *spec.Spec, devs []string) error {
+	specs, err := collectCDISpecs()
+	if err != nil {
+		return err
+	}
+
+	return UpdateOCISpecForDevicesWithSpec(ociconfig, devs, specs)
+}
+
+// UpdateOCISpecForDevicesWithSpec updates the given OCI spec based on the requested CDI devices using the given CDI specs.
+func UpdateOCISpecForDevicesWithSpec(ociconfig *spec.Spec, devs []string, specs map[string]*cdispec.Spec) error {
+	edits := make(map[string]*cdispec.Spec)
+
+	for _, d := range devs {
+		spec, err := GetCDIForDevice(d, specs)
+		if err != nil {
+			return err
+		}
+
+		edits[spec.Kind] = spec
+		_, device := extractVendor(d)
+		err = cdispec.ApplyOCIEditsForDevice(ociconfig, spec, device)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, spec := range edits {
+		if err := cdispec.ApplyOCIEdits(ociconfig, spec); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/container-orchestrated-devices/container-device-interface/specs-go/config.go
+++ b/vendor/github.com/container-orchestrated-devices/container-device-interface/specs-go/config.go
@@ -1,0 +1,57 @@
+package specs
+
+import "os"
+
+// Spec is the base configuration for CDI
+type Spec struct {
+	Version          string   `json:"cdiVersion"`
+	Kind             string   `json:"kind"`
+	KindShort        []string `json:"kindShort,omitempty"`
+	ContainerRuntime []string `json:"containerRuntime,omitempty"`
+
+	Devices        []Device       `json:"devices"`
+	ContainerEdits ContainerEdits `json:"containerEdits,omitempty"`
+}
+
+// Device is a "Device" a container runtime can add to a container
+type Device struct {
+	Name           string         `json:"name"`
+	NameShort      []string       `json:"nameShort"`
+	ContainerEdits ContainerEdits `json:"containerEdits"`
+}
+
+// ContainerEdits are edits a container runtime must make to the OCI spec to expose the device.
+type ContainerEdits struct {
+	Env         []string      `json:"env,omitempty"`
+	DeviceNodes []*DeviceNode `json:"deviceNodes,omitempty"`
+	Hooks       []*Hook       `json:"hooks,omitempty"`
+	Mounts      []*Mount      `json:"mounts,omitempty"`
+}
+
+// DeviceNode represents a device node that needs to be added to the OCI spec.
+type DeviceNode struct {
+	Path        string       `json:"path"`
+	Type        string       `json:"type,omitempty"`
+	Major       int64        `json:"major,omitempty"`
+	Minor       int64        `json:"minor,omitempty"`
+	FileMode    *os.FileMode `json:"fileMode,omitempty"`
+	Permissions string       `json:"permissions,omitempty"`
+	UID         *uint32      `json:"uid,omitempty"`
+	GID         *uint32      `json:"gid,omitempty"`
+}
+
+// Mount represents a mount that needs to be added to the OCI spec.
+type Mount struct {
+	HostPath      string   `json:"hostPath"`
+	ContainerPath string   `json:"containerPath"`
+	Options       []string `json:"options,omitempty"`
+}
+
+// Hook represents a hook that needs to be added to the OCI spec.
+type Hook struct {
+	HookName string   `json:"hookName"`
+	Path     string   `json:"path"`
+	Args     []string `json:"args,omitempty"`
+	Env      []string `json:"env,omitempty"`
+	Timeout  *int     `json:"timeout,omitempty"`
+}

--- a/vendor/github.com/container-orchestrated-devices/container-device-interface/specs-go/oci.go
+++ b/vendor/github.com/container-orchestrated-devices/container-device-interface/specs-go/oci.go
@@ -1,0 +1,109 @@
+package specs
+
+import (
+	"errors"
+	"fmt"
+
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// ApplyOCIEditsForDevice applies devices OCI edits, in other words
+// it finds the device in the CDI spec and applies the OCI patches that device
+// requires to the OCI specification.
+func ApplyOCIEditsForDevice(config *spec.Spec, cdi *Spec, dev string) error {
+	for _, d := range cdi.Devices {
+		if d.Name != dev {
+			continue
+		}
+
+		return ApplyEditsToOCISpec(config, &d.ContainerEdits)
+	}
+
+	return fmt.Errorf("CDI: device %q not found for spec %q", dev, cdi.Kind)
+}
+
+// ApplyOCIEdits applies the OCI edits the CDI spec declares globablly
+func ApplyOCIEdits(config *spec.Spec, cdi *Spec) error {
+	return ApplyEditsToOCISpec(config, &cdi.ContainerEdits)
+}
+
+// ApplyEditsToOCISpec applies the specified edits to the OCI spec.
+func ApplyEditsToOCISpec(config *spec.Spec, edits *ContainerEdits) error {
+	if config == nil {
+		return errors.New("spec is nil")
+	}
+	if edits == nil {
+		return nil
+	}
+
+	if len(edits.Env) > 0 {
+		if config.Process == nil {
+			config.Process = &spec.Process{}
+		}
+		config.Process.Env = append(config.Process.Env, edits.Env...)
+	}
+
+	for _, d := range edits.DeviceNodes {
+		if config.Linux == nil {
+			config.Linux = &spec.Linux{}
+		}
+		config.Linux.Devices = append(config.Linux.Devices, toOCILinuxDevice(d))
+	}
+
+	for _, m := range edits.Mounts {
+		config.Mounts = append(config.Mounts, toOCIMount(m))
+	}
+
+	for _, h := range edits.Hooks {
+		if config.Hooks == nil {
+			config.Hooks = &spec.Hooks{}
+		}
+		switch h.HookName {
+		case "prestart":
+			config.Hooks.Prestart = append(config.Hooks.Prestart, toOCIHook(h))
+		case "createRuntime":
+			config.Hooks.CreateRuntime = append(config.Hooks.CreateRuntime, toOCIHook(h))
+		case "createContainer":
+			config.Hooks.CreateContainer = append(config.Hooks.CreateContainer, toOCIHook(h))
+		case "startContainer":
+			config.Hooks.StartContainer = append(config.Hooks.StartContainer, toOCIHook(h))
+		case "poststart":
+			config.Hooks.Poststart = append(config.Hooks.Poststart, toOCIHook(h))
+		case "poststop":
+			config.Hooks.Poststop = append(config.Hooks.Poststop, toOCIHook(h))
+		default:
+			fmt.Printf("CDI: Unknown hook %q\n", h.HookName)
+		}
+	}
+
+	return nil
+}
+
+func toOCIHook(h *Hook) spec.Hook {
+	return spec.Hook{
+		Path:    h.Path,
+		Args:    h.Args,
+		Env:     h.Env,
+		Timeout: h.Timeout,
+	}
+}
+
+func toOCIMount(m *Mount) spec.Mount {
+	return spec.Mount{
+		Source:      m.HostPath,
+		Destination: m.ContainerPath,
+		Options:     m.Options,
+	}
+}
+
+func toOCILinuxDevice(d *DeviceNode) spec.LinuxDevice {
+	return spec.LinuxDevice{
+		Path:     d.Path,
+		Type:     d.Type,
+		Major:    d.Major,
+		Minor:    d.Minor,
+		FileMode: d.FileMode,
+		UID:      d.UID,
+		GID:      d.GID,
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -62,6 +62,10 @@ github.com/cilium/ebpf/internal
 github.com/cilium/ebpf/internal/btf
 github.com/cilium/ebpf/internal/unix
 github.com/cilium/ebpf/link
+# github.com/container-orchestrated-devices/container-device-interface v0.0.0-20211102125128-1eb67455b699
+## explicit
+github.com/container-orchestrated-devices/container-device-interface/pkg
+github.com/container-orchestrated-devices/container-device-interface/specs-go
 # github.com/containerd/aufs v1.0.0
 ## explicit
 github.com/containerd/aufs


### PR DESCRIPTION
Implement support of the [Container Device Interface (CDI)](https://github.com/container-orchestrated-devices/container-device-interface) in ctr.

CDI goal is to update device-related information (devices, mounts, hooks, environment variables etc) in the OCI spec from the JSON files provided by device vendors. That would allow workloads to access properly configured devices.

The plan is to have CDI support in at least containerd, cri-o and podman. It's already implemented in podman: https://github.com/containers/podman/pull/10081

Here is a typical usage scenario:
- vendor provides a spec update in the CDI JSON format, e.g: 
```
$ cat /etc/cdi/test.json 
{
  "cdiVersion": "0.2.0",
  "kind": "vendor.com/device",
  "devices": [
    {
      "name": "myDevice",
      "containerEdits": {
        "deviceNodes": [
          {"path": "/dev/device1", "type": "b", "major": 7, "minor": 0, "fileMode": 432, "permissions": "rw", "uid": 1000, "gid": 1000}
        ]
      }
    }
  ],
  "containerEdits": {
    "env": [
      "FOO=VALID_SPEC",
      "BAR=BARVALUE1"
    ],
    "deviceNodes": [
      {"path": "/dev/device1", "type": "b", "major": 7, "minor": 0, "fileMode": 432, "permissions": "rw", "uid": 1000, "gid": 1000}
    ],
    "mounts": [
       {"hostPath": "/bin/vendorBin", "containerPath": "/bin/vendorBin", "options": ["bind"]}
    ],
    "hooks": [
       {"hookName": "startContainer", "path": "/bin/vendorHook", "args": ["/bin/vendorHook", "param1", "param2"]}
    ]
  }
}
```

- OCI spec gets updated by the ctr/containerd/other runtime and passed to the OCI runtime
- workload can access the device inside a container