### PR TITLE
Add initial window size for grpc communication

### DIFF
--- a/client.go
+++ b/client.go
@@ -126,6 +126,8 @@ func New(address string, opts ...ClientOpt) (*Client, error) {
 			grpc.WithConnectParams(connParams),
 			grpc.WithContextDialer(dialer.ContextDialer),
 			grpc.WithReturnConnectionError(),
+			grpc.WithInitialWindowSize(defaults.DefaultWindowSize),
+			grpc.WithInitialConnWindowSize(defaults.DefaultConnWindowSize),
 		}
 		if len(copts.dialOptions) > 0 {
 			gopts = copts.dialOptions

--- a/cmd/containerd/command/publish.go
+++ b/cmd/containerd/command/publish.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	eventsapi "github.com/containerd/containerd/api/services/events/v1"
+	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/pkg/dialer"
@@ -105,6 +106,8 @@ func connect(address string, d func(gocontext.Context, string) (net.Conn, error)
 		grpc.WithContextDialer(d),
 		grpc.FailOnNonTempDialError(true),
 		grpc.WithConnectParams(connParams),
+		grpc.WithInitialWindowSize(defaults.DefaultWindowSize),
+		grpc.WithInitialConnWindowSize(defaults.DefaultConnWindowSize),
 	}
 	ctx, cancel := gocontext.WithTimeout(gocontext.Background(), 2*time.Second)
 	defer cancel()

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -29,4 +29,12 @@ const (
 	// DefaultSnapshotterNSLabel defines the namespace label to check for the
 	// default snapshotter
 	DefaultSnapshotterNSLabel = "containerd.io/defaults/snapshotter"
+	// DefaultWindowSize defines the default window size for stream
+	// issue: https://github.com/containerd/containerd/issues/6190
+	// reference： https://github.com/earthly/buildkit/pull/42/files
+	DefaultWindowSize = 2 << 20
+	// DefaultConnWindowSize defines the default window size for a connection
+	// issue: https://github.com/containerd/containerd/issues/6190
+	// reference： https://github.com/earthly/buildkit/pull/42/files
+	DefaultConnWindowSize = 2 << 19
 )

--- a/integration/remote/remote_image.go
+++ b/integration/remote/remote_image.go
@@ -38,13 +38,15 @@ import (
 	"fmt"
 	"time"
 
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+
+	"google.golang.org/grpc"
 	"k8s.io/klog/v2"
 
 	internalapi "github.com/containerd/containerd/integration/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 
+	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/integration/remote/util"
 )
 
@@ -69,7 +71,8 @@ func NewImageService(endpoint string, connectionTimeout time.Duration) (internal
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithContextDialer(dialer),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)),
-	)
+		grpc.WithInitialWindowSize(defaults.DefaultWindowSize),
+		grpc.WithInitialConnWindowSize(defaults.DefaultConnWindowSize))
 	if err != nil {
 		klog.Errorf("Connect remote image service %s failed: %v", addr, err)
 		return nil, err

--- a/integration/remote/remote_runtime.go
+++ b/integration/remote/remote_runtime.go
@@ -39,8 +39,9 @@ import (
 	"strings"
 	"time"
 
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+
+	"google.golang.org/grpc"
 	"k8s.io/klog/v2"
 
 	internalapi "github.com/containerd/containerd/integration/cri-api/pkg/apis"
@@ -48,6 +49,7 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	utilexec "k8s.io/utils/exec"
 
+	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/integration/remote/util"
 )
 
@@ -78,7 +80,8 @@ func NewRuntimeService(endpoint string, connectionTimeout time.Duration) (intern
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithContextDialer(dialer),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)),
-	)
+		grpc.WithInitialWindowSize(defaults.DefaultWindowSize),
+		grpc.WithInitialConnWindowSize(defaults.DefaultConnWindowSize))
 	if err != nil {
 		klog.Errorf("Connect remote runtime %s failed: %v", addr, err)
 		return nil, err

--- a/services/server/server.go
+++ b/services/server/server.go
@@ -128,6 +128,8 @@ func New(ctx context.Context, config *srvconfig.Config) (*Server, error) {
 			grpc_prometheus.UnaryServerInterceptor,
 			unaryNamespaceInterceptor,
 		)),
+		grpc.InitialWindowSize(defaults.DefaultWindowSize),
+		grpc.InitialConnWindowSize(defaults.DefaultConnWindowSize),
 	}
 	if config.GRPC.MaxRecvMsgSize > 0 {
 		serverOpts = append(serverOpts, grpc.MaxRecvMsgSize(config.GRPC.MaxRecvMsgSize))
@@ -463,6 +465,8 @@ func (pc *proxyClients) getClient(address string) (*grpc.ClientConn, error) {
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithConnectParams(connParams),
 		grpc.WithContextDialer(dialer.ContextDialer),
+		grpc.WithInitialWindowSize(defaults.DefaultWindowSize),
+		grpc.WithInitialConnWindowSize(defaults.DefaultConnWindowSize),
 
 		// TODO(stevvooe): We may need to allow configuration of this on the client.
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(defaults.DefaultMaxRecvMsgSize)),


### PR DESCRIPTION
Add initial window size for grpc communication

For: [issues6190](https://github.com/containerd/containerd/issues/6190)

Signed-off-by: qifeng.guo <qifeng.guo@daocloud.io>