### PR TITLE
use write lock when updating container stats

### DIFF
--- a/pkg/cri/store/container/container.go
+++ b/pkg/cri/store/container/container.go
@@ -170,8 +170,8 @@ func (s *Store) List() []Container {
 }
 
 func (s *Store) UpdateContainerStats(id string, newContainerStats *stats.ContainerStats) error {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
+	s.lock.Lock()
+	defer s.lock.Unlock()
 	id, err := s.idIndex.Get(id)
 	if err != nil {
 		if err == truncindex.ErrNotExist {


### PR DESCRIPTION
I ran into this panic when testing out `main`. This should be part of 1.6

Signed-off-by: Michael Crosby <michael@thepasture.io>