### PR TITLE
[release/1.4] Fix containerd fails to pull OCI image with non-`http(s)://` urls

### DIFF
--- a/remotes/docker/fetcher.go
+++ b/remotes/docker/fetcher.go
@@ -60,6 +60,10 @@ func (r dockerFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.R
 				log.G(ctx).WithError(err).Debug("failed to parse")
 				continue
 			}
+			if u.Scheme != "http" && u.Scheme != "https" {
+				log.G(ctx).Debug("non-http(s) alternative url is unsupported")
+				continue
+			}
 			log.G(ctx).Debug("trying alternative url")
 
 			// Try this first, parse it


### PR DESCRIPTION
Backporting #6221
Fixes #6220

Currently, containerd cannot pull OCI images that contain non-http(s):// urls.
This commit fixes this issue by allowing fallback when pull fails on a non-http(s):// url.
