### PR TITLE
remotes: fix dockerPusher to handle abort correctly

### DIFF
--- a/remotes/docker/pusher_test.go
+++ b/remotes/docker/pusher_test.go
@@ -17,10 +17,20 @@
 package docker
 
 import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"reflect"
+	"regexp"
+	"strings"
 	"testing"
 
+	"github.com/containerd/containerd/content"
 	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func TestGetManifestPath(t *testing.T) {
@@ -49,4 +59,105 @@ func TestGetManifestPath(t *testing.T) {
 			t.Fatalf("expected %v, but got %v", tc.expected, got)
 		}
 	}
+}
+
+// TestPusherErrClosedRetry tests if retrying work when error occurred on close.
+func TestPusherErrClosedRetry(t *testing.T) {
+	ctx := context.Background()
+
+	p, reg, done := samplePusher(t)
+	defer done()
+
+	layerContent := []byte("test")
+	reg.uploadable = false
+	if err := tryUpload(ctx, t, p, layerContent); err == nil {
+		t.Errorf("upload should fail but succeeded")
+	}
+
+	// retry
+	reg.uploadable = true
+	if err := tryUpload(ctx, t, p, layerContent); err != nil {
+		t.Errorf("upload should succeed but got %v", err)
+	}
+}
+
+func tryUpload(ctx context.Context, t *testing.T, p dockerPusher, layerContent []byte) error {
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageLayerGzip,
+		Digest:    digest.FromBytes(layerContent),
+		Size:      int64(len(layerContent)),
+	}
+	cw, err := p.Writer(ctx, content.WithRef("test-1"), content.WithDescriptor(desc))
+	if err != nil {
+		return err
+	}
+	defer cw.Close()
+	if _, err := cw.Write(layerContent); err != nil {
+		return err
+	}
+	return cw.Commit(ctx, 0, "")
+}
+
+func samplePusher(t *testing.T) (dockerPusher, *uploadableMockRegistry, func()) {
+	reg := &uploadableMockRegistry{}
+	s := httptest.NewServer(reg)
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dockerPusher{
+		dockerBase: &dockerBase{
+			repository: "sample",
+			hosts: []RegistryHost{
+				{
+					Client:       s.Client(),
+					Host:         u.Host,
+					Scheme:       u.Scheme,
+					Path:         u.Path,
+					Capabilities: HostCapabilityPush | HostCapabilityResolve,
+				},
+			},
+		},
+		object:  "sample",
+		tracker: NewInMemoryTracker(),
+	}, reg, s.Close
+}
+
+var manifestRegexp = regexp.MustCompile(`/([a-z0-9]+)/manifests/(.*)`)
+var blobUploadRegexp = regexp.MustCompile(`/([a-z0-9]+)/blobs/uploads/`)
+
+// uploadableMockRegistry provides minimal registry APIs which are enough to serve requests from dockerPusher.
+type uploadableMockRegistry struct {
+	uploadable bool
+}
+
+func (u *uploadableMockRegistry) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method == "POST" {
+		if matches := blobUploadRegexp.FindStringSubmatch(r.URL.Path); len(matches) != 0 {
+			if u.uploadable {
+				w.Header().Set("Location", "/upload")
+			} else {
+				w.Header().Set("Location", "/cannotupload")
+			}
+			w.WriteHeader(202)
+			return
+		}
+	} else if r.Method == "PUT" {
+		mfstMatches := manifestRegexp.FindStringSubmatch(r.URL.Path)
+		if len(mfstMatches) != 0 || strings.HasPrefix(r.URL.Path, "/upload") {
+			dgstr := digest.Canonical.Digester()
+			if _, err := io.Copy(dgstr.Hash(), r.Body); err != nil {
+				w.WriteHeader(500)
+				return
+			}
+			w.Header().Set("Docker-Content-Digest", dgstr.Digest().String())
+			w.WriteHeader(201)
+			return
+		} else if r.URL.Path == "/cannotupload" {
+			w.WriteHeader(500)
+			return
+		}
+	}
+	fmt.Println(r)
+	w.WriteHeader(404)
 }

--- a/remotes/docker/status.go
+++ b/remotes/docker/status.go
@@ -31,6 +31,9 @@ type Status struct {
 
 	Committed bool
 
+	// ErrClosed contains error encountered on close.
+	ErrClosed error
+
 	// UploadUUID is used by the Docker registry to reference blob uploads
 	UploadUUID string
 }


### PR DESCRIPTION
Fixes #6242

`dockerPusher` provides `pushWriter` which implements `content.Writer`.
However, even if `pushWriter` become abort status (i.e. `Close()` is called
before `Commit()`), `dockerPusher` doesn't recognise that status and treats that
writer as on-going.
This behaviour doesn't allow the client to retry an aborted push.

This commit fixes this issue.
This commit also adds a test to ensure that the issue is fixed.

## Repro

We can repro this issue by applying the following patch to enable `PushHandler` retrying.

```diff
--- a/remotes/handlers.go
+++ b/remotes/handlers.go
@@ -22,6 +22,7 @@ import (
        "io"
        "strings"
        "sync"
+       "time"
 
        "github.com/containerd/containerd/content"
        "github.com/containerd/containerd/errdefs"
@@ -162,6 +163,20 @@ func PushHandler(pusher Pusher, provider content.Provider) images.HandlerFunc {
        }
 }
 
+func withRetry(h images.HandlerFunc) images.HandlerFunc {
+       return func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+               for {
+                       descs, err := h(ctx, desc)
+                       if err == nil {
+                               return descs, nil
+                       }
+                       time.Sleep(time.Second)
+                       fmt.Println("retrying", err)
+               }
+               return nil, nil
+       }
+}
+
 func push(ctx context.Context, provider content.Provider, pusher Pusher, desc ocispec.Descriptor) error {
        log.G(ctx).Debug("push")
 
@@ -215,7 +230,7 @@ func PushContent(ctx context.Context, pusher Pusher, desc ocispec.Descriptor, st
                }
        })
 
-       pushHandler := PushHandler(pusher, store)
+       pushHandler := withRetry(PushHandler(pusher, store))
 
        platformFilterhandler := images.FilterPlatforms(images.ChildrenHandler(store), platform)
```

I believe this is similar as done in BuildKit.

https://github.com/moby/buildkit/blob/f421e242918320dbeeac982752de67e79fda9a49/util/push/push.go#L90

Here, we use the following mock registry. The first argument represents whether the registry accepts blob uploads.

- `true` : registry accepts blob uploads (called "allow" mode)
- `false` : blob uploads fails always (called "deny" mode)

```golang
package main

import (
	"flag"
	"fmt"
	"io"
	"log"
	"net/http"
	"os"
	"regexp"
	"strconv"
	"strings"

	digest "github.com/opencontainers/go-digest"
)

func main() {
	flag.Parse()
	args := flag.Args()
	uploadable := true
	if len(args) > 0 {
		var err error
		uploadable, err = strconv.ParseBool(args[0])
		if err != nil {
			fmt.Println(err)
			os.Exit(1)
		}
	}
	fmt.Printf("serving (uploadable=%v)...\n", uploadable)
	s := &uploadableMockRegistry{uploadable}
	http.HandleFunc("/", s.ServeHTTP)
	log.Fatal(http.ListenAndServe("localhost:5001", nil))
}

var manifestRegexp = regexp.MustCompile(`/v2/([a-z0-9]+)/manifests/(.*)`)
var blobUploadRegexp = regexp.MustCompile(`/v2/([a-z0-9]+)/blobs/uploads/`)

// uploadableMockRegistry provides minimal registry APIs which are enough to serve requests from dockerPusher.
type uploadableMockRegistry struct {
	uploadable bool
}

func (u *uploadableMockRegistry) ServeHTTP(w http.ResponseWriter, r *http.Request) {
	fmt.Println(r)
	if r.Method == "GET" || r.Method == "HEAD" {
		if r.URL.Path == "/v2/" {
			w.WriteHeader(200)
			return
		}
	} else if r.Method == "POST" {
		if matches := blobUploadRegexp.FindStringSubmatch(r.URL.Path); len(matches) != 0 {
			if u.uploadable {
				w.Header().Set("Location", "/upload")
			} else {
				w.Header().Set("Location", "/cannotupload")
			}
			w.WriteHeader(202)
			return
		}
	} else if r.Method == "PUT" {
		mfstMatches := manifestRegexp.FindStringSubmatch(r.URL.Path)
		if len(mfstMatches) != 0 || strings.HasPrefix(r.URL.Path, "/upload") {
			dgstr := digest.Canonical.Digester()
			if _, err := io.Copy(dgstr.Hash(), r.Body); err != nil {
				w.WriteHeader(500)
				return
			}
			w.Header().Set("Docker-Content-Digest", dgstr.Digest().String())
			w.WriteHeader(201)
			return
		} else if r.URL.Path == "/cannotupload" {
			w.WriteHeader(500)
			return
		}
	}
	w.WriteHeader(404)
}
```


When we push an image to the deny-mode of the registry using main-branch version of ctr with the above patch, it hangs after it encounters an error.

```console
# go run reg.go false
# ctr i push --plain-http localhost:5001/alpine:3
retrying failed commit on ref "config-sha256:0a97eee8041e2b6c0e65abb2700b0705d0da5525ca69060b9e0bde8a3d17afdb": unexpected status: 500 Internal Server Error
retrying failed to copy: unexpected status: 500 Internal Server Error
...(hang)...
```

Even if we restart the registry with the allow mode, ctr hangs forever without retrying.

```console
# go run reg.go true
```

But if we apply this PR, ctr can perform retry without hanging and succeeds to upload the image when the registry restarted with the allow mode.

```console
# ctr i push --plain-http localhost:5001/alpine:3
retrying failed to do request: Head "http://localhost:5001/v2/alpine/blobs/sha256:0a97eee8041e2b6c0e65abb2700b0705d0da5525ca69060b9e0bde8a3d17afdb": dial tcp 127.0.0.1:5001: connect: connection refused
retrying failed to do request: Head "http://localhost:5001/v2/alpine/blobs/sha256:97518928ae5f3d52d4164b314a7e73654eb686ecd8aafa0b79acd980773a740d": dial tcp 127.0.0.1:5001: connect: connection refused
...
index-sha256:40796e972a77e7a3e41850a581e7a79368970de2f6bddb3e56d400404677ba68:    done           |++++++++++++++++++++++++++++++++++++++| 
manifest-sha256:5e604d3358ab7b6b734402ce2e19ddd822a354dc14843f34d36c603521dbb4f9: done           |++++++++++++++++++++++++++++++++++++++| 
layer-sha256:97518928ae5f3d52d4164b314a7e73654eb686ecd8aafa0b79acd980773a740d:    done           |++++++++++++++++++++++++++++++++++++++| 
config-sha256:0a97eee8041e2b6c0e65abb2700b0705d0da5525ca69060b9e0bde8a3d17afdb:   done           |++++++++++++++++++++++++++++++++++++++| 
elapsed: 5.1 s                                                                    total:  2.7 Mi (541.0 KiB/s)                                     
```

