### PR TITLE
release: change tar name to match prior releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ endif
 WHALE = "🇩"
 ONI = "👹"
 
-RELEASE=containerd-$(VERSION:v%=%).${GOOS}-${GOARCH}
+RELEASE=containerd-$(VERSION:v%=%)-${GOOS}-${GOARCH}
 CRIRELEASE=cri-containerd-$(VERSION:v%=%)-${GOOS}-${GOARCH}
 CRICNIRELEASE=cri-containerd-cni-$(VERSION:v%=%)-${GOOS}-${GOARCH}
 


### PR DESCRIPTION
In prior releases we were not using this variable and instead were
self-constructing a release tar file.
This was changed in 27d7c50384b11d6a3c5982c7e20e89ec360d542a
The change means the variable is being used now and is causing the
artifacts to be produced to have a different name which may break
download scripts.