### PR TITLE
Integration: Generalize Windows CI setup scripts for any username.

### DIFF
--- a/script/setup/prepare_env_windows.ps1
+++ b/script/setup/prepare_env_windows.ps1
@@ -2,17 +2,17 @@
 
 $PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.17.3"; make = ""; nssm = "" }
 
-write-host "Downloading chocolatey package"
+Write-Host "Downloading chocolatey package"
 curl.exe -L "https://packages.chocolatey.org/chocolatey.0.10.15.nupkg" -o 'c:\choco.zip'
 Expand-Archive "c:\choco.zip" -DestinationPath "c:\choco"
 
-write-host "Installing choco"
+Write-Host "Installing choco"
 & "c:\choco\tools\chocolateyInstall.ps1"
 
-write-host "Set choco.exe path."
+Write-Host "Set choco.exe path."
 $env:PATH+=";C:\ProgramData\chocolatey\bin"
 
-write-host "Install necessary packages"
+Write-Host "Install necessary packages"
 
 foreach ($package in $PACKAGES.Keys) {
     $command = "choco.exe install $package --yes"
@@ -23,12 +23,12 @@ foreach ($package in $PACKAGES.Keys) {
     Invoke-Expression $command
 }
 
-write-host "Set up environment."
+Write-Host "Set up environment."
 
 $path = ";c:\Program Files\Git\bin;c:\Program Files\Go\bin;c:\Users\azureuser\go\bin;c:\containerd\bin"
 $env:PATH+=$path
 
-write-host $env:PATH
+Write-Host $env:PATH
 
 [Environment]::SetEnvironmentVariable("PATH", $env:PATH, 'User')
 

--- a/script/setup/prepare_env_windows.ps1
+++ b/script/setup/prepare_env_windows.ps1
@@ -25,7 +25,8 @@ foreach ($package in $PACKAGES.Keys) {
 
 Write-Host "Set up environment."
 
-$path = ";c:\Program Files\Git\bin;c:\Program Files\Go\bin;c:\Users\azureuser\go\bin;c:\containerd\bin"
+$userGoBin = "${env:HOME}\go\bin"
+$path = ";c:\Program Files\Git\bin;c:\Program Files\Go\bin;${userGoBin};c:\containerd\bin"
 $env:PATH+=$path
 
 Write-Host $env:PATH
@@ -42,4 +43,4 @@ go get -u github.com/jstemmer/go-junit-report
 $CRICTL_DOWNLOAD_URL="https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.21.0/crictl-v1.21.0-windows-amd64.tar.gz"
 curl.exe -L $CRICTL_DOWNLOAD_URL -o c:\crictl.tar.gz
 tar -xvf c:\crictl.tar.gz
-mv crictl.exe c:\Users\azureuser\go\bin\crictl.exe # Move crictl somewhere in path
+mv crictl.exe "${userGoBin}\crictl.exe" # Move crictl somewhere in path


### PR DESCRIPTION
The current Windows CI setup script assumes it will always be run under the `azureuser` username.

While this username is defined in the Windows CI GitHub action, the current version of the script both exposes us to a future risk of breaking should the CI action be changed, and is also unfriendly to`curl | sh`-ing it for quick test environment setups.

This patch makes the Windows CI setup script work with any username provided they have administrative privileges.

Signed-off-by: Nashwan Azhari <nazhari@cloudbasesolutions.com>