### PR TITLE
[CRI] Fix panic when registry.mirrors use localhost

### DIFF
--- a/pkg/cri/server/image_pull.go
+++ b/pkg/cri/server/image_pull.go
@@ -375,7 +375,9 @@ func (c *criService) registryHosts(ctx context.Context, auth *runtime.AuthConfig
 				}
 			} else if isLocalHost(host) && u.Scheme == "http" {
 				// Skipping TLS verification for localhost
-				transport.TLSClientConfig.InsecureSkipVerify = true
+				transport.TLSClientConfig = &tls.Config{
+					InsecureSkipVerify: true,
+				}
 			}
 
 			// Make a copy of `auth`, so that different authorizers would not reference


### PR DESCRIPTION
When containerd use this config:

```
[plugins."io.containerd.grpc.v1.cri".registry.mirrors]
  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
      endpoint = ["http://localhost:5000"]
```

Due to the `newTransport` function does not initialize the `TLSClientConfig` field.
Then use `TLSClientConfig` to cause nil pointer dereference

Signed-off-by: wanglei01 <wllenyj@linux.alibaba.com>