### PR TITLE
[release/1.4] vendor: github.com/opencontainers/image-spec v1.0.2

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -30,7 +30,7 @@ github.com/matttproud/golang_protobuf_extensions    v1.0.1
 github.com/Microsoft/go-winio                       v0.4.19
 github.com/Microsoft/hcsshim                        v0.8.21
 github.com/opencontainers/go-digest                 v1.0.0
-github.com/opencontainers/image-spec                v1.0.1
+github.com/opencontainers/image-spec                v1.0.2
 github.com/opencontainers/runc                      v1.0.0-rc94
 github.com/opencontainers/runtime-spec              4d89ac9fbff6c455f46a5bb59c6b1bb7184a5e43 # v1.0.3-0.20200728170252-4d89ac9fbff6
 github.com/pkg/errors                               v0.9.1

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/index.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/index.go
@@ -21,6 +21,9 @@ import "github.com/opencontainers/image-spec/specs-go"
 type Index struct {
 	specs.Versioned
 
+	// MediaType specificies the type of this document data structure e.g. `application/vnd.oci.image.index.v1+json`
+	MediaType string `json:"mediaType,omitempty"`
+
 	// Manifests references platform specific manifests.
 	Manifests []Descriptor `json:"manifests"`
 

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/manifest.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/manifest.go
@@ -20,6 +20,9 @@ import "github.com/opencontainers/image-spec/specs-go"
 type Manifest struct {
 	specs.Versioned
 
+	// MediaType specificies the type of this document data structure e.g. `application/vnd.oci.image.manifest.v1+json`
+	MediaType string `json:"mediaType,omitempty"`
+
 	// Config references a configuration object for a container, by digest.
 	// The referenced configuration object is a JSON blob that the runtime uses to set up the container.
 	Config Descriptor `json:"config"`

--- a/vendor/github.com/opencontainers/image-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/version.go
@@ -22,7 +22,7 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 0
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 1
+	VersionPatch = 2
 
 	// VersionDev indicates development branch. Releases will be empty string.
 	VersionDev = ""


### PR DESCRIPTION
- Bring mediaType out of reserved status
- specs-go: adding mediaType to the index and manifest structures

full diff: https://github.com/opencontainers/image-spec/compare/v1.0.1...v1.0.2
