### PR TITLE
Prepare release notes for v1.6.0-beta.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fail_on_unmatched_files: true
+          name: containerd ${{ needs.check.outputs.stringver }}
           draft: false
           prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
           body_path: ./builds/containerd-release-notes/release-notes.md

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/containerd/btrfs v1.0.0
 	github.com/containerd/cgroups v1.0.2
 	github.com/containerd/console v1.0.3
-	github.com/containerd/containerd/api v1.6.0-beta.1
+	github.com/containerd/containerd/api v1.6.0-beta.3
 	github.com/containerd/continuity v0.2.0
 	github.com/containerd/fifo v1.0.0
 	github.com/containerd/go-cni v1.1.1-0.20211026134925-aa8bf14323a5

--- a/integration/client/go.mod
+++ b/integration/client/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/containerd/cgroups v1.0.2
 	// the actual version of containerd is replaced with the code at the root of this repository
 	github.com/containerd/containerd v1.5.7
-	github.com/containerd/containerd/api v1.6.0-beta.1
+	github.com/containerd/containerd/api v1.6.0-beta.3
 	github.com/containerd/go-runc v1.0.0
 	github.com/containerd/ttrpc v1.1.0
 	github.com/containerd/typeurl v1.0.2

--- a/releases/v1.6.0-beta.toml
+++ b/releases/v1.6.0-beta.toml
@@ -24,6 +24,7 @@ support to increase overall compatibility and stability.
 * **Split task manager into shim and task manager** ([#5918](https://github.com/containerd/containerd/pull/5918))
 * **Add runc shim support for core scheduling** ([#6011](https://github.com/containerd/containerd/pull/6011))
 * **Update shim client connect attempt to fail fast when shim errors** ([#6031](https://github.com/containerd/containerd/pull/6031))
+* **Add support for absolute path to shim binaries** ([#6206](https://github.com/containerd/containerd/pull/6206))
 
 #### Windows
 
@@ -37,7 +38,9 @@ support to increase overall compatibility and stability.
 * **Add support for unified resources field for cgroups v2** ([#5627](https://github.com/containerd/containerd/pull/5627))
 * **Add IP preference configuration for reporting pod IP** ([#5964](https://github.com/containerd/containerd/pull/5964))
 * **Implement new CRI pod sandbox stats API** ([#6113](https://github.com/containerd/containerd/pull/6113))
+* **Add sandbox and container latency metrics** ([#6111](https://github.com/containerd/containerd/pull/6111))
 * **Add namespace to ttrpc and grpc plugin connections** ([#6130](https://github.com/containerd/containerd/pull/6130))
+* **Add option to allow ping sockets and privileged ports with no capabilities** ([#6170](https://github.com/containerd/containerd/pull/6170))
 
 #### Other
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -78,7 +78,7 @@ github.com/containerd/cgroups/v2/stats
 # github.com/containerd/console v1.0.3
 ## explicit
 github.com/containerd/console
-# github.com/containerd/containerd/api v1.6.0-beta.1 => ./api
+# github.com/containerd/containerd/api v1.6.0-beta.3 => ./api
 ## explicit
 github.com/containerd/containerd/api/events
 github.com/containerd/containerd/api/services/containers/v1

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.0-beta.2+unknown"
+	Version = "1.6.0-beta.3+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
See sample generated notes at https://gist.github.com/dmcgowan/d9eba0f8f79c11c46734a109b6f7faef

Included API update this time, the `api/v1.6.0-beta.3` tag is created already