### PR TITLE
Integration: Remove explicit version passing to `azure/CLI`.

### DIFF
--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -66,28 +66,24 @@ jobs:
       - name: AZResourceGroupCreate
         uses: azure/CLI@v1
         with:
-          azcliversion: 2.29.2
           inlinescript: |
             az group create -n ${{ matrix.AZURE_RESOURCE_GROUP }} -l ${{ env.AZURE_DEFAULT_LOCATION }} --tags creationTimestamp=$(date +%Y-%m-%dT%T%z)
 
       - name: AZTestVMCreate
         uses: azure/CLI@v1
         with:
-          azcliversion: 2.29.2
           inlinescript: |
             az vm create -n winTestVM --admin-username ${{ env.DEFAULT_ADMIN_USERNAME }} --admin-password ${{ env.PASSWORD }} --image ${{ matrix.AZURE_IMG }} -g ${{ matrix.AZURE_RESOURCE_GROUP }} --nsg-rule SSH --size ${{ env.AZURE_DEFAULT_VM_SIZE }}
 
       - name: GetAZVMPublicIP
         uses: azure/CLI@v1
         with:
-          azcliversion: 2.29.2
           inlinescript: |
             echo "VM_PUB_IP=$(az network public-ip list -g ${{ matrix.AZURE_RESOURCE_GROUP }} | jq '.[0]["ipAddress"]' | tr -d '\"')" >> $GITHUB_ENV
 
       - name: EnableAZVMSSH
         uses: azure/CLI@v1
         with:
-          azcliversion: 2.29.2
           inlinescript: |
             az vm run-command invoke  --command-id RunPowerShellScript -n winTestVM -g ${{ matrix.AZURE_RESOURCE_GROUP }} --scripts @$GITHUB_WORKSPACE/script/setup/enable_ssh_windows.ps1 --parameters 'SSHPublicKey=${{ env.SSH_PUB_KEY }}'
 
@@ -205,6 +201,5 @@ jobs:
       - name: ResourceCleanup
         uses: azure/CLI@v1
         with:
-          azcliversion: 2.29.2
           inlinescript: |
             az group delete -g ${{ matrix.AZURE_RESOURCE_GROUP }} --yes


### PR DESCRIPTION
In the Windows CI's periodic runs the `azure/CLI` GitHub action library is leveraged to run various Azure-related commands.

To avoid possible desyncing between the auth libraries of `azure/Login` and `azure/CLI` as described [here](https://github.com/Azure/cli/issues/56#issuecomment-958705517), this patch neglects to pass an explicit `azcliversion` to `azure/CLI` in order to have it default to the Azure CLI version set up by `azure/Login`.
    
 Signed-off-by: Nashwan Azhari <nazhari@cloudbasesolutions.com>