### PR TITLE
integration: add stats result in error message

### DIFF
--- a/integration/container_stats_test.go
+++ b/integration/container_stats_test.go
@@ -368,7 +368,7 @@ func TestContainerListStatsWithIdSandboxIdFilter(t *testing.T) {
 				return false, err
 			}
 			if len(stats) != 1 {
-				return false, errors.New("unexpected stats length")
+				return false, errors.Errorf("expected only one stat, but got %v", stats)
 			}
 			if stats[0].GetWritableLayer().GetUsedBytes().GetValue() != 0 {
 				return true, nil


### PR DESCRIPTION
```
// from  https://github.com/containerd/containerd/pull/6150#issuecomment-974747473

container_stats_test.go:364:
        	Error Trace:	container_stats_test.go:364
        	Error:      	Received unexpected error:
        	            	unexpected stats length
        	            	github.com/containerd/containerd/integration.TestContainerListStatsWithIdSandboxIdFilter.func4
        	            		/home/runner/work/containerd/containerd/integration/container_stats_test.go:371
        	            	github.com/containerd/containerd/integration.Eventually
        	            		/home/runner/work/containerd/containerd/integration/main_test.go:324
        	            	github.com/containerd/containerd/integration.TestContainerListStatsWithIdSandboxIdFilter
        	            		/home/runner/work/containerd/containerd/integration/container_stats_test.go:364
        	            	testing.tRunner
        	            		/opt/hostedtoolcache/go/1.17.3/x64/src/testing/testing.go:1259
        	            	runtime.goexit
        	            		/opt/hostedtoolcache/go/1.17.3/x64/src/runtime/asm_amd64.s:1581
        	Test:       	TestContainerListStatsWithIdSandboxIdFilter
```

Add stats result for the purpose of debug.

Signed-off-by: Wei Fu <fuweid89@gmail.com>