### PR TITLE
ctr/snapshots/diff: show media-type in stderr

### DIFF
--- a/cmd/ctr/commands/snapshots/snapshots.go
+++ b/cmd/ctr/commands/snapshots/snapshots.go
@@ -133,8 +133,6 @@ var diffCommand = cli.Command{
 		labels := commands.LabelArgs(context.StringSlice("label"))
 		snapshotter := client.SnapshotService(context.GlobalString("snapshotter"))
 
-		fmt.Println(context.String("media-type"))
-
 		if context.Bool("keep") {
 			labels["containerd.io/gc.root"] = time.Now().UTC().Format(time.RFC3339)
 		}


### PR DESCRIPTION
By default, diff subcommand will print tar(.gz) on stdout. If we print
the media-type in stdout, the output will create invalid tar(.gz) data.

```
// before
➜  containerd git:(move_stdout_to_stderr) sudo ctr snapshot diff sha256:9f54eef412758095c8079ac465d494a2872e02e90bf1fb5f12a1641c0d1bb78b > /tmp/1.tar
➜  containerd git:(move_stdout_to_stderr) file /tmp/1.tar
/tmp/1.tar: data

// after change
➜  containerd git:(move_stdout_to_stderr) make bin/ctr
+ bin/ctr
➜  containerd git:(move_stdout_to_stderr) sudo bin/ctr snapshot diff sha256:9f54eef412758095c8079ac465d494a2872e02e90bf1fb5f12a1641c0d1bb78b > /tmp/2.tar
media-type: application/vnd.oci.image.layer.v1.tar+gzip

➜  containerd git:(move_stdout_to_stderr) file /tmp/2.tar
/tmp/2.tar: gzip compressed data, original size modulo 2^32 75155456
```

Signed-off-by: Wei Fu <fuweid89@gmail.com>