### PR TITLE
Integration: Enable TestVolumeOwnership on Windows

### DIFF
--- a/integration/volume_copy_up_unix_test.go
+++ b/integration/volume_copy_up_unix_test.go
@@ -1,0 +1,35 @@
+//go:build !windows
+// +build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"fmt"
+
+	exec "golang.org/x/sys/execabs"
+)
+
+func getVolumeHostPathOwnership(criRoot, containerID string) (string, error) {
+	hostCmd := fmt.Sprintf("find %s/containers/%s/volumes/* | xargs stat -c %%U:%%G", criRoot, containerID)
+	output, err := exec.Command("sh", "-c", hostCmd).CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	return string(output), nil
+}

--- a/integration/volume_copy_up_unix_test.go
+++ b/integration/volume_copy_up_unix_test.go
@@ -25,8 +25,8 @@ import (
 	exec "golang.org/x/sys/execabs"
 )
 
-func getVolumeHostPathOwnership(criRoot, containerID string) (string, error) {
-	hostCmd := fmt.Sprintf("find %s/containers/%s/volumes/* | xargs stat -c %%U:%%G", criRoot, containerID)
+func getOwnership(path string) (string, error) {
+	hostCmd := fmt.Sprintf("stat -c %%U:%%G '%s'", path)
 	output, err := exec.Command("sh", "-c", hostCmd).CombinedOutput()
 	if err != nil {
 		return "", err

--- a/integration/volume_copy_up_windows_test.go
+++ b/integration/volume_copy_up_windows_test.go
@@ -20,31 +20,12 @@
 package integration
 
 import (
-	"fmt"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-
 	"golang.org/x/sys/windows"
 )
 
-func getVolumeHostPathOwnership(criRoot, containerID string) (string, error) {
-	hostPath := fmt.Sprintf("%s/containers/%s/volumes/", criRoot, containerID)
-	if _, err := os.Stat(hostPath); err != nil {
-		return "", err
-	}
-
-	volumes, err := ioutil.ReadDir(hostPath)
-	if err != nil {
-		return "", err
-	}
-
-	if len(volumes) != 1 {
-		return "", fmt.Errorf("expected to find exactly 1 volume (got %d)", len(volumes))
-	}
-
+func getOwnership(path string) (string, error) {
 	secInfo, err := windows.GetNamedSecurityInfo(
-		filepath.Join(hostPath, volumes[0].Name()), windows.SE_FILE_OBJECT,
+		path, windows.SE_FILE_OBJECT,
 		windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
 
 	if err != nil {

--- a/integration/volume_copy_up_windows_test.go
+++ b/integration/volume_copy_up_windows_test.go
@@ -1,0 +1,59 @@
+//go:build windows
+// +build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+func getVolumeHostPathOwnership(criRoot, containerID string) (string, error) {
+	hostPath := fmt.Sprintf("%s/containers/%s/volumes/", criRoot, containerID)
+	if _, err := os.Stat(hostPath); err != nil {
+		return "", err
+	}
+
+	volumes, err := ioutil.ReadDir(hostPath)
+	if err != nil {
+		return "", err
+	}
+
+	if len(volumes) != 1 {
+		return "", fmt.Errorf("expected to find exactly 1 volume (got %d)", len(volumes))
+	}
+
+	secInfo, err := windows.GetNamedSecurityInfo(
+		filepath.Join(hostPath, volumes[0].Name()), windows.SE_FILE_OBJECT,
+		windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
+
+	if err != nil {
+		return "", err
+	}
+
+	sid, _, err := secInfo.Owner()
+	if err != nil {
+		return "", err
+	}
+	return sid.String(), nil
+}


### PR DESCRIPTION
This change enables the TestVolumeOwnership on Windows. The test assumes that the volume-ownership image is built on Windows, thus ensuring that Windows file security info (ACLs and ownership info) are attached to the C:\volumes\test_dir path.

This change also removes the need for executing ```find``` in order to get the full path to the files or folders we wish to test against on the host.

Depends-on: https://github.com/containerd/containerd/pull/6321

Signed-off-by: Gabriel Adrian Samfira <gsamfira@cloudbasesolutions.com>