### PR TITLE
Fix wrong make target on documentation

### DIFF
--- a/docs/cri/crictl.md
+++ b/docs/cri/crictl.md
@@ -15,7 +15,7 @@ should have installed crictl for you. If not, get it from your release tarball.
 If you are a developer the current version of crictl is specified [here](/script/setup/critools-version).
 A helper command has been included to install the dependencies at the right version:
 ```console
-$ make install.deps
+$ make install-deps
 ```
 * Note: The file named `/etc/crictl.yaml` is used to configure crictl
 so you don't have to repeatedly specify the runtime sock used to connect crictl

--- a/integration/image_load_test.go
+++ b/integration/image_load_test.go
@@ -58,7 +58,7 @@ func TestImageLoad(t *testing.T) {
 
 	t.Logf("load image in cri")
 	ctr, err := exec.LookPath("ctr")
-	require.NoError(t, err, "ctr should be installed, make sure you've run `make install.deps`")
+	require.NoError(t, err, "ctr should be installed, make sure you've run `make install-deps`")
 	output, err = exec.Command(ctr, "-address="+containerdEndpoint,
 		"-n=k8s.io", "images", "import", tar).CombinedOutput()
 	require.NoError(t, err, "output: %q", output)


### PR DESCRIPTION
I think the correct target is `install-deps`. [1]

[1]: https://github.com/containerd/containerd/blob/main/Makefile#L376

Signed-off-by: Takumasa Sakao <sakataku7@gmail.com>