### PR TITLE
Fix executable file not found when restoring shims

### DIFF
--- a/runtime/v2/shim_load.go
+++ b/runtime/v2/shim_load.go
@@ -114,6 +114,13 @@ func (m *ShimManager) loadShims(ctx context.Context) error {
 			runtime = container.Runtime.Name
 		}
 
+		runtime, err = m.resolveRuntimePath(runtime)
+		if err != nil {
+			bundle.Delete()
+			log.G(ctx).WithError(err).Error("failed to resolve runtime path")
+			continue
+		}
+
 		binaryCall := shimBinary(bundle,
 			shimBinaryConfig{
 				runtime:      runtime,


### PR DESCRIPTION
Fixes `exec: \"io.containerd.runc.v2\": executable file not found in $PATH"` caught in [nerdctl CI](https://github.com/containerd/nerdctl/runs/4286643328?check_suite_focus=true).

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>