### PR TITLE
Dev main

### DIFF
--- a/cmd/ctr/app/main.go
+++ b/cmd/ctr/app/main.go
@@ -95,7 +95,7 @@ containerd CLI
 		cli.StringFlag{
 			Name:   "namespace, n",
 			Usage:  "namespace to use with commands",
-			Value:  "k8s.io",
+			Value:  "namespaces.Default",
 			EnvVar: namespaces.NamespaceEnvVar,
 		},
 	}

--- a/cmd/ctr/app/main.go
+++ b/cmd/ctr/app/main.go
@@ -95,7 +95,7 @@ containerd CLI
 		cli.StringFlag{
 			Name:   "namespace, n",
 			Usage:  "namespace to use with commands",
-			Value:  "namespaces.Default",
+			Value:  namespaces.Default,
 			EnvVar: namespaces.NamespaceEnvVar,
 		},
 	}

--- a/cmd/ctr/app/main.go
+++ b/cmd/ctr/app/main.go
@@ -95,7 +95,7 @@ containerd CLI
 		cli.StringFlag{
 			Name:   "namespace, n",
 			Usage:  "namespace to use with commands",
-			Value:  namespaces.Default,
+			Value:  "k8s.io",
 			EnvVar: namespaces.NamespaceEnvVar,
 		},
 	}

--- a/cmd/ctr/commands/containers/containers.go
+++ b/cmd/ctr/commands/containers/containers.go
@@ -137,7 +137,7 @@ var listCommand = cli.Command{
 			if err != nil {
 				return err
 			}
-			spec, err :=  c.Spec(ctx)
+			spec, err := c.Spec(ctx)
 			if err != nil {
 				return err
 			}
@@ -168,16 +168,15 @@ var listCommand = cli.Command{
 				imageName = "-"
 			}
 
-
 			cPrintInfo := &cInfoPrint{
-				id: c.ID(),
-				imageName: imageName,
-				kind: kind,
-				cmds: cmds,
+				id:         c.ID(),
+				imageName:  imageName,
+				kind:       kind,
+				cmds:       cmds,
 				podInfoStr: podInfoStr,
 				createTime: info.CreatedAt.In(local).Format("2006-01-02 15:04:05"),
-				createdAt: info.CreatedAt.UnixNano(),
-				runtime: info.Runtime.Name,
+				createdAt:  info.CreatedAt.UnixNano(),
+				runtime:    info.Runtime.Name,
 			}
 			cPrintArray = append(cPrintArray, cPrintInfo)
 		}
@@ -212,8 +211,8 @@ type cInfoPrint struct {
 
 type cInfoPrintSlice []*cInfoPrint
 
-func (s cInfoPrintSlice) Len() int { return len(s) }
-func (s cInfoPrintSlice) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s cInfoPrintSlice) Len() int           { return len(s) }
+func (s cInfoPrintSlice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func (s cInfoPrintSlice) Less(i, j int) bool { return s[i].createdAt > s[j].createdAt }
 
 var deleteCommand = cli.Command{

--- a/cmd/ctr/commands/containers/containers.go
+++ b/cmd/ctr/commands/containers/containers.go
@@ -157,11 +157,12 @@ var listCommand = cli.Command{
 			if v, OK := info.Labels["io.kubernetes.pod.namespace"]; OK {
 				podNS = v
 			}
-			podUid := "-"
+
+			podUID := "-"
 			if v, OK := info.Labels["io.kubernetes.pod.uid"]; OK {
-				podUid = v
+				podUID = v
 			}
-			podInfoStr := podName + "|" + podNS + "|" + podUid
+			podInfoStr := podName + "|" + podNS + "|" + podUID
 
 			imageName := info.Image
 			if imageName == "" {

--- a/cmd/ctr/commands/containers/containers.go
+++ b/cmd/ctr/commands/containers/containers.go
@@ -149,20 +149,6 @@ var listCommand = cli.Command{
 			if v, OK := info.Labels["io.cri-containerd.kind"]; OK {
 				kind = v
 			}
-			podName := "-"
-			if v, OK := info.Labels["io.kubernetes.pod.name"]; OK {
-				podName = v
-			}
-			podNS := "-"
-			if v, OK := info.Labels["io.kubernetes.pod.namespace"]; OK {
-				podNS = v
-			}
-
-			podUID := "-"
-			if v, OK := info.Labels["io.kubernetes.pod.uid"]; OK {
-				podUID = v
-			}
-			podInfoStr := podName + "|" + podNS + "|" + podUID
 
 			imageName := info.Image
 			if imageName == "" {
@@ -174,7 +160,6 @@ var listCommand = cli.Command{
 				imageName:  imageName,
 				kind:       kind,
 				cmds:       cmds,
-				podInfoStr: podInfoStr,
 				createTime: info.CreatedAt.In(local).Format("2006-01-02 15:04:05"),
 				createdAt:  info.CreatedAt.UnixNano(),
 				runtime:    info.Runtime.Name,

--- a/cmd/ctr/commands/images/images.go
+++ b/cmd/ctr/commands/images/images.go
@@ -125,12 +125,12 @@ var listCommand = cli.Command{
 			}
 
 			iPrint := &imagePrint{
-				imageName: image.Name,
-				digest: image.Target.Digest,
-				size: progress.Bytes(size),
-				platform: platformColumn,
+				imageName:  image.Name,
+				digest:     image.Target.Digest,
+				size:       progress.Bytes(size),
+				platform:   platformColumn,
 				createTime: image.CreatedAt.In(local).Format("2006-01-02 15:04:05"),
-				createdAt: image.CreatedAt.UnixNano(),
+				createdAt:  image.CreatedAt.UnixNano(),
 			}
 			imagePrintArray = append(imagePrintArray, iPrint)
 		}
@@ -150,7 +150,6 @@ var listCommand = cli.Command{
 	},
 }
 
-
 type imagePrint struct {
 	imageName  string
 	digest     digest.Digest
@@ -162,8 +161,8 @@ type imagePrint struct {
 
 type imagePrintSlice []*imagePrint
 
-func (s imagePrintSlice) Len() int { return len(s) }
-func (s imagePrintSlice) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s imagePrintSlice) Len() int           { return len(s) }
+func (s imagePrintSlice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func (s imagePrintSlice) Less(i, j int) bool { return s[i].createdAt > s[j].createdAt }
 
 var setLabelsCommand = cli.Command{

--- a/cmd/ctr/commands/images/images.go
+++ b/cmd/ctr/commands/images/images.go
@@ -124,24 +124,6 @@ var listCommand = cli.Command{
 				platformColumn = strings.Join(ps, ",")
 			}
 
-			//labels := "-"
-			//if len(image.Labels) > 0 {
-			//	var pairs []string
-			//	for k, v := range image.Labels {
-			//		pairs = append(pairs, fmt.Sprintf("%v=%v", k, v))
-			//	}
-			//	sort.Strings(pairs)
-			//	labels = strings.Join(pairs, ",")
-			//}
-			//
-			//urls := "-"
-			//if len(image.Target.URLs) >0 {
-			//	urls = "|"
-			//	for _, u := range image.Target.URLs {
-			//		urls += u + "|"
-			//	}
-			//}
-
 			iPrint := &imagePrint{
 				imageName: image.Name,
 				digest: image.Target.Digest,

--- a/cmd/ctr/commands/images/images.go
+++ b/cmd/ctr/commands/images/images.go
@@ -18,7 +18,6 @@ package images
 
 import (
 	"fmt"
-	"github.com/opencontainers/go-digest"
 	"os"
 	"sort"
 	"strings"
@@ -31,6 +30,7 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/pkg/progress"
 	"github.com/containerd/containerd/platforms"
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )


### PR DESCRIPTION
1. We modify the information about images and containers in the command ,because the information is not enough and the layout of the display contents is not reasonable.
 （1） Container content diff:
 old:  CONTAINER IMAGE RUNTIME
 new: CONTAINER IMAGE KIND CREATED PODINFO CMD
 （2）Image content diff:
 old:  REF TYPE DIGEST SIZE  PLATFORMS LABELS
 new: REF SIZE  DIGEST PLATFORMS CREATED

2. When we use the ctr ,we must view the specified content through the specified namespace, and in industrial production, containerd mostly in cooperation with Kubernetes. Thus, we modify the default namespace of ctr from "default" to "k8s.io" to improve work efficiency