### PR TITLE
fix: confirm content exist when load image

### DIFF
--- a/images/image.go
+++ b/images/image.go
@@ -332,7 +332,7 @@ func Check(ctx context.Context, provider content.Provider, image ocispec.Descrip
 
 	}
 
-	return true, required, present, missing, nil
+	return len(missing) == 0, required, present, missing, nil
 }
 
 // Children returns the immediate children of content described by the descriptor.


### PR DESCRIPTION
https://github.com/containerd/containerd/blob/51e60404aec6f6646d65e8ba0e821e2aed7ca3ef/pkg/cri/server/restart.go#L431-L439

If content and snapshot missing when load image, cri would not retry and block on `failed to create containerd container: error unpacking image: failed to extract layer xxx: failed to get reader from content store: content digest xxx: not found"`