### PR TITLE
feat: skip ci for fork

### DIFF
--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -18,6 +18,7 @@ env:
 
 jobs:
   winIntegration:
+    if: github.repository == 'containerd/containerd'
     strategy:
       matrix:
         win_ver: [ltsc2019, sac2004, ltsc2022]


### PR DESCRIPTION
winIntegration ci job will failed for fork repository because of less of azure credentials.
 
https://github.com/jonyhy96/containerd/runs/4306903963?check_suite_focus=true