### PR TITLE
Integration: Separate Windows Periodic Tests workflow trigger.

### DIFF
--- a/.github/workflows/windows-periodic-trigger.yml
+++ b/.github/workflows/windows-periodic-trigger.yml
@@ -1,0 +1,25 @@
+# Workflow intended to periodically run the Windows Integration test workflow.
+
+name: Windows Periodic Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 1 * * *"
+
+jobs:
+
+  triggerWinIntegration:
+    if: github.repository == 'containerd/containerd'
+    # NOTE(aznashwan, 11/24/21): GitHub actions do not currently support referencing
+    # or evaluating any kind of variables in the `uses` clause, but this will
+    # ideally be added in the future in which case the hardcoded reference to the
+    # upstream containerd repository should be replaced with the following to
+    # potentially allow contributors to enable periodic Windows tests on forks as well:
+    # uses: "${{ github.repository }}/.github/workflows/windows-periodic.yml@${{ github.ref_name }}"
+    uses: containerd/containerd/.github/workflows/windows-periodic.yml@main
+    secrets:
+      AZURE_SUB_ID: "${{ secrets.AZURE_SUB_ID }}"
+      AZURE_CREDS: "${{ secrets.AZURE_CREDS }}"
+      GCP_PROJECT_ID: "${{ secrets.GCP_PROJECT_ID }}"
+      GCP_SA_KEY: "${{ secrets.GCP_SA_KEY }}"

--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -1,11 +1,19 @@
-# Workflow intended to periodically test containerd integration tests
+# Workflow intended to run containerd integration tests on Windows.
 
-name: Windows Periodic Tests
+name: Windows Integration Tests
 
 on:
-  schedule:
-  - cron: "0 1 * * *"
   workflow_dispatch:
+  workflow_call:
+    secrets:
+      AZURE_SUB_ID:
+        required: true
+      AZURE_CREDS:
+        required: true
+      GCP_PROJECT_ID:
+        required: true
+      GCP_SA_KEY:
+        required: true
 
 env:
   AZURE_DEFAULT_LOCATION: westeurope
@@ -18,7 +26,6 @@ env:
 
 jobs:
   winIntegration:
-    if: github.repository == 'containerd/containerd'
     strategy:
       matrix:
         win_ver: [ltsc2019, sac2004, ltsc2022]


### PR DESCRIPTION
Following PR #6284, the Windows Periodic Workflow is prevented from
running on any repository outside of the original.

While this achieves the goal of preventing senseless Windows workflow
failures in contributors' forks, it makes running the workflow for
contributors (even manually) impossible.

This PR adds a separate workflow file which triggers the Windows
Integration workflow iff it is being run off of the original repository,
thus maintaining the upstream scheduling, while allowing contributors to
manually trigger the workflow on their forks if they so desire.

Signed-off-by: Nashwan Azhari <nazhari@cloudbasesolutions.com>