### PR TITLE
ctr: Add Linux Capabilities control flags

### DIFF
--- a/cmd/ctr/commands/commands.go
+++ b/cmd/ctr/commands/commands.go
@@ -169,6 +169,14 @@ var (
 			Name:  "device",
 			Usage: "file path to a device to add to the container; or a path to a directory tree of devices to add to the container",
 		},
+		cli.StringSliceFlag{
+			Name:  "cap-add",
+			Usage: "add Linux capabilities (Set capabilities with 'CAP_' prefix)",
+		},
+		cli.StringSliceFlag{
+			Name:  "cap-drop",
+			Usage: "drop Linux capabilities (Set capabilities with 'CAP_' prefix)",
+		},
 		cli.BoolFlag{
 			Name:  "seccomp",
 			Usage: "enable the default seccomp profile",

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -218,6 +218,24 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 			)
 		}
 
+		if caps := context.StringSlice("cap-add"); len(caps) > 0 {
+			for _, cap := range caps {
+				if !strings.HasPrefix(cap, "CAP_") {
+					return nil, fmt.Errorf("capabilities must be specified with 'CAP_' prefix")
+				}
+			}
+			opts = append(opts, oci.WithAddedCapabilities(caps))
+		}
+
+		if caps := context.StringSlice("cap-drop"); len(caps) > 0 {
+			for _, cap := range caps {
+				if !strings.HasPrefix(cap, "CAP_") {
+					return nil, fmt.Errorf("capabilities must be specified with 'CAP_' prefix")
+				}
+			}
+			opts = append(opts, oci.WithDroppedCapabilities(caps))
+		}
+
 		seccompProfile := context.String("seccomp-profile")
 
 		if !context.Bool("seccomp") && seccompProfile != "" {


### PR DESCRIPTION
This allows Linux Capabilities to be modified via `ctr`.

e.g.
```
$ sudo ./bin/ctr run --cap-add "CAP_SYS_ADMIN" --cap-drop "CAP_NET_RAW" \
--rm docker.io/library/busybox:latest foo cat /proc/self/status | grep Cap
CapInh: 00000000a82405fb
CapPrm: 00000000a82405fb
CapEff: 00000000a82405fb
CapBnd: 00000000a82405fb
CapAmb: 0000000000000000
```

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>