### PR TITLE
Integration: Add image build workflow

### DIFF
--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -1,0 +1,163 @@
+name: "Build volume test images"
+on:
+  workflow_dispatch:
+    inputs:
+      push_to_project:
+        description: "Project to build images for"
+        required: true
+        default: "gcr.io/k8s-cri-containerd"
+      azure_windows_image_id:
+        description: Windows image URN to deploy
+        required: true
+        default: MicrosoftWindowsServer:WindowsServer:2022-datacenter:20348.350.2111030009
+      azure_vm_size:
+        description: Windows image builder VM size
+        required: true
+        default: Standard_D2s_v3
+      azure_location:
+        description: The Azure region to deploy to
+        required: true
+        default: westeurope
+
+env:
+  AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUB_ID }}
+  DEFAULT_ADMIN_USERNAME: azureuser
+  SSH_OPTS: "-o ServerAliveInterval=20 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+  AZURE_RESOURCE_GROUP: ctrd-test-image-build-${{ github.run_id }}
+
+jobs:
+  images:
+    name: "Build volume test images"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/github.com/containerd/containerd
+
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17.3'
+
+      - uses: actions/checkout@v2
+        with:
+          path: src/github.com/containerd/containerd
+
+      - name: Set env
+        shell: bash
+        run: |
+          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+
+      - name: Install docker
+        shell: bash
+        run: |
+          sudo apt update
+          sudo apt install -y ca-certificates curl gnupg lsb-release
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg > /tmp/docker.gpg
+          sudo gpg --yes --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg /tmp/docker.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt update
+          sudo apt install -y docker-ce docker-ce-cli containerd.io jq
+          sudo adduser $USER docker
+
+      - name: Generate ssh key pair
+        run: |
+          mkdir -p $HOME/.ssh/
+          ssh-keygen -t rsa -b 4096 -C "ci@containerd.com" -f $HOME/.ssh/id_rsa -q -N ""
+          echo "SSH_PUB_KEY=$(cat ~/.ssh/id_rsa.pub)" >> $GITHUB_ENV
+
+      - name: Azure Login
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDS }}
+
+      - name: Create Azure Resource Group
+        uses: azure/CLI@v1
+        with:
+          inlinescript: |
+            az group create -n ${{ env.AZURE_RESOURCE_GROUP }} -l ${{ github.event.inputs.azure_location }} --tags creationTimestamp=$(date +%Y-%m-%dT%T%z)
+
+      - name: Create Windows Helper VM
+        uses: azure/CLI@v1
+        with:
+          inlinescript: |
+            PASSWORD="$(/usr/bin/tr -dc "a-zA-Z0-9@#$%^&*()_+?><~\`;" < /dev/urandom | /usr/bin/head -c 24; echo '')"
+            az vm create -n WinDockerHelper \
+              --admin-username ${{ env.DEFAULT_ADMIN_USERNAME }} \
+              --public-ip-sku Basic \
+              --admin-password "::add-mask::$PASSWORD" \
+              --image ${{ github.event.inputs.azure_windows_image_id }} \
+              -g ${{ env.AZURE_RESOURCE_GROUP }} \
+              --size ${{ github.event.inputs.azure_vm_size }}
+            az vm open-port --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name WinDockerHelper --port 22 --priority 101
+            az vm open-port --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name WinDockerHelper --port 2376 --priority 102
+
+      - name: Prepare Windows image helper
+        uses: azure/CLI@v1
+        with:
+          inlinescript: |
+            # Installs Windows features, opens SSH and Docker port
+            az vm run-command invoke \
+              --command-id RunPowerShellScript \
+              -n WinDockerHelper \
+              -g ${{ env.AZURE_RESOURCE_GROUP }} \
+              --scripts @$GITHUB_WORKSPACE/src/github.com/containerd/containerd/script/setup/prepare_windows_docker_helper.ps1
+            # The prepare_windows_docker_helper.ps1 script reboots the server after enabling the Windows features
+            # Give it a chance to reboot. Running another run-command via azure CLI should work even without this
+            # sleep, but we want to avoid the possibility that it may run before the server reboots.
+            sleep 30
+            # Enable SSH and import public key
+            az vm run-command invoke  \
+              --command-id RunPowerShellScript \
+              -n WinDockerHelper \
+              -g ${{ env.AZURE_RESOURCE_GROUP }} \
+              --scripts @$GITHUB_WORKSPACE/src/github.com/containerd/containerd/script/setup/enable_ssh_windows.ps1 \
+              --parameters 'SSHPublicKey=${{ env.SSH_PUB_KEY }}'
+
+      - name: Get Windows Helper IPs
+        uses: azure/CLI@v1
+        with:
+          inlinescript: |
+            VM_DETAILS=$(az vm show -d -g ${{ env.AZURE_RESOURCE_GROUP }} -n WinDockerHelper -o json)
+            echo "PUBLIC_IP=$(echo $VM_DETAILS | jq -r .publicIps)" >> $GITHUB_ENV
+            echo "PRIVATE_IP=$(echo $VM_DETAILS | jq -r .privateIps)" >> $GITHUB_ENV
+
+      - name: Enable Docker TLS
+        shell: bash
+        run: |
+          scp -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} $GITHUB_WORKSPACE/src/github.com/containerd/containerd/script/setup/enable_docker_tls_on_windows.ps1  azureuser@${{ env.PUBLIC_IP }}:/enable_docker_tls_on_windows.ps1
+          ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.PUBLIC_IP }} "powershell.exe -command { C:/enable_docker_tls_on_windows.ps1 -IPAddresses ${{ env.PUBLIC_IP }},${{ env.PRIVATE_IP }} }"
+
+      - name: Fetch client certificate and key
+        shell: bash
+        run: |
+          mkdir -p $HOME/.docker
+          scp -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.PUBLIC_IP }}:/Users/azureuser/.docker/ca.pem $HOME/.docker/ca.pem
+          scp -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.PUBLIC_IP }}:/Users/azureuser/.docker/cert.pem $HOME/.docker/cert.pem
+          scp -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.PUBLIC_IP }}:/Users/azureuser/.docker/key.pem $HOME/.docker/key.pem
+
+      - name: Setup gcloud SDK
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+
+      - name: Build and push images
+        shell: bash
+        run: |
+          make -C $GITHUB_WORKSPACE/src/github.com/containerd/containerd/integration/images/volume-copy-up setup-buildx
+          make -C $GITHUB_WORKSPACE/src/github.com/containerd/containerd/integration/images/volume-copy-up configure-docker PROJ=${{ github.event.inputs.push_to_project }}
+
+          make -C $GITHUB_WORKSPACE/src/github.com/containerd/containerd/integration/images/volume-copy-up build-registry PROJ=${{ github.event.inputs.push_to_project }} REMOTE_DOCKER_URL=${{ env.PUBLIC_IP }}:2376
+          make -C $GITHUB_WORKSPACE/src/github.com/containerd/containerd/integration/images/volume-copy-up push-manifest PROJ=${{ github.event.inputs.push_to_project }} REMOTE_DOCKER_URL=${{ env.PUBLIC_IP }}:2376
+
+          make -C $GITHUB_WORKSPACE/src/github.com/containerd/containerd/integration/images/volume-ownership build-registry PROJ=${{ github.event.inputs.push_to_project }} REMOTE_DOCKER_URL=${{ env.PUBLIC_IP }}:2376
+          make -C $GITHUB_WORKSPACE/src/github.com/containerd/containerd/integration/images/volume-ownership push-manifest PROJ=${{ github.event.inputs.push_to_project }} REMOTE_DOCKER_URL=${{ env.PUBLIC_IP }}:2376
+
+      - name: Cleanup resources
+        if: always()
+        uses: azure/CLI@v1
+        with:
+          inlinescript: |
+            az group delete -g ${{ env.AZURE_RESOURCE_GROUP }} --yes

--- a/script/setup/enable_docker_tls_on_windows.ps1
+++ b/script/setup/enable_docker_tls_on_windows.ps1
@@ -1,0 +1,22 @@
+Param(
+    [parameter(Mandatory=$true)]
+    [string[]]$IPAddresses
+)
+
+$ErrorActionPreference = "Stop"
+$IPAddresses += "127.0.0.1"
+$IPParams = $IPAddresses -join ","
+mkdir $env:USERPROFILE\.docker
+
+docker run --isolation=hyperv --user=ContainerAdministrator --rm `
+   -e SERVER_NAME=$(hostname) `
+   -e IP_ADDRESSES=$IPParams `
+   -v "c:\programdata\docker:c:\programdata\docker" `
+   -v "$env:USERPROFILE\.docker:c:\users\containeradministrator\.docker" stefanscherer/dockertls-windows:2.5.5
+
+if ($LASTEXITCODE) {
+    Throw "Failed to setup Docker TLS: $LASTEXITCODE"
+}
+
+Stop-Service docker
+Start-Service docker

--- a/script/setup/prepare_windows_docker_helper.ps1
+++ b/script/setup/prepare_windows_docker_helper.ps1
@@ -1,0 +1,21 @@
+$ErrorActionPreference = "Stop"
+
+# Enable Hyper-V and management tools
+Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V,Microsoft-Hyper-V-Management-Clients,Microsoft-Hyper-V-Management-PowerShell -All -NoRestart
+
+# Enable SSH (this can be skipped if you don't need it)
+Add-WindowsCapability -Online -Name OpenSSH*
+
+# Install Docker
+Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force -Confirm:$false
+Install-Module -Name DockerMsftProvider -Repository PSGallery -Force -Confirm:$false
+Install-Package -Name docker -ProviderName DockerMsftProvider -Force -Confirm:$false
+
+# Open SSH port
+New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
+
+# Open Docker port
+New-NetFirewallRule -Name 'Docker-TLS-In-TCP' -DisplayName 'Docker (TLS)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 2376
+
+# Restart
+Restart-Computer -Force


### PR DESCRIPTION
This change adds a new workflow that builds the volume test images and pushes them to a remote registry. This action needs to be manually triggered and can be configured to push to any remote repository to which the google cloud credentials configured as secrets have access to push.

For Windows images, a single image builder helper is used. Hyper-V isolation is leveraged to build images for all supported targets.

The easiest way to use this workflow is to fork the repo then configure your own secrets, run a build, test the images, then mirror the images to gcr.io.

Depends-on: https://github.com/containerd/containerd/pull/6274

Signed-off-by: Gabriel Adrian Samfira <gsamfira@cloudbasesolutions.com>