### PR TITLE
Integration: Check GCP secrets on Windows CI artifact upload.

### DIFF
--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -187,7 +187,14 @@ jobs:
           jq -n --arg result SUCCESS --arg timestamp $(date +%s) '$timestamp|tonumber|{timestamp:.,$result}' > ${{ env.LOGS_DIR }}/finished.json
           echo "${{ env.STARTED_TIME }}" > $HOME/latest-build.txt
 
+      - name: AssignGcpCreds
+        id: AssignGcpCreds
+        run: |
+          echo '::set-output name=GCP_PROJECT_ID::${{ secrets.GCP_PROJECT_ID }}'
+          echo '::set-output name=GCP_SA_KEY::${{ secrets.GCP_SA_KEY }}'
+
       - name: SetUpCloudSDK
+        if: steps.AssignGcpCreds.outputs.GCP_PROJECT_ID && steps.AssignGcpCreds.outputs.GCP_SA_KEY
         uses: google-github-actions/setup-gcloud@master
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
@@ -195,6 +202,7 @@ jobs:
           export_default_credentials: true
 
       - name: UploadArtifacts
+        if: steps.AssignGcpCreds.outputs.GCP_PROJECT_ID && steps.AssignGcpCreds.outputs.GCP_SA_KEY
         run: |
           gsutil cp -r ${{ env.LOGS_DIR }} ${{ matrix.GOOGLE_BUCKET }}
           gsutil cp $HOME/latest-build.txt ${{ matrix.GOOGLE_BUCKET }}


### PR DESCRIPTION
This patch makes the Windows Integration GitHub workflow conditionally
execute the CI artifact upload to GCP on successful runs iff the GitHub
secrets containing the GCP access info are defined.

Signed-off-by: Nashwan Azhari <nazhari@cloudbasesolutions.com>