### PR TITLE
Prepare release notes for v1.6.0-beta.4

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.0-beta.3+unknown"
+	Version = "1.6.0-beta.4+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
No changelog updates this time, fixes a regression from beta.3 https://github.com/containerd/nerdctl/pull/551