### PR TITLE
Use RFC3339 format on Windows periodic resource group creation so cleanup works

### DIFF
--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -75,7 +75,7 @@ jobs:
         uses: azure/CLI@v1
         with:
           inlinescript: |
-            az group create -n ${{ matrix.AZURE_RESOURCE_GROUP }} -l ${{ env.AZURE_DEFAULT_LOCATION }} --tags creationTimestamp=$(date +%Y-%m-%dT%T%z)
+            az group create -n ${{ matrix.AZURE_RESOURCE_GROUP }} -l ${{ env.AZURE_DEFAULT_LOCATION }} --tags creationTimestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 
       - name: AZTestVMCreate
         uses: azure/CLI@v1


### PR DESCRIPTION
We found that some Azure resource groups are being leaked causing core quota pressure in the sub we are using.  This can happen if the final task that cleans up the rg isn't run.

We have a cleanup process that should catch these vms but the creation timestamp must be in RFC3339 format.