### PR TITLE
fix(ctr): enable networking for Windows containers

### DIFF
--- a/cmd/ctr/commands/run/run.go
+++ b/cmd/ctr/commands/run/run.go
@@ -123,6 +123,10 @@ var Command = cli.Command{
 			Name:  "platform",
 			Usage: "run image for specific platform",
 		},
+		cli.BoolFlag{
+			Name:  "cni",
+			Usage: "enable cni networking for the container",
+		},
 	}, append(platformRunFlags,
 		append(append(commands.SnapshotterFlags, []cli.Flag{commands.SnapshotterLabels}...),
 			commands.ContainerFlags...)...)...),
@@ -209,7 +213,12 @@ var Command = cli.Command{
 			}
 		}
 		if enableCNI {
-			if _, err := network.Setup(ctx, fullID(ctx, container), fmt.Sprintf("/proc/%d/ns/net", task.Pid())); err != nil {
+			netNsPath, err := getNetNSPath(ctx, task)
+			if err != nil {
+				return err
+			}
+
+			if _, err := network.Setup(ctx, fullID(ctx, container), netNsPath); err != nil {
 				return err
 			}
 		}

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -79,10 +79,6 @@ var platformRunFlags = []cli.Flag{
 		Usage: "set the cpu shares",
 		Value: 1024,
 	},
-	cli.BoolFlag{
-		Name:  "cni",
-		Usage: "enable cni networking for the container",
-	},
 }
 
 // NewContainer creates a new container
@@ -448,4 +444,8 @@ func validNamespace(ns string) bool {
 	default:
 		return false
 	}
+}
+
+func getNetNSPath(_ gocontext.Context, task containerd.Task) (string, error) {
+	return fmt.Sprintf("/proc/%d/ns/net", task.Pid()), nil
 }

--- a/oci/spec_opts_windows.go
+++ b/oci/spec_opts_windows.go
@@ -75,3 +75,17 @@ func WithHostDevices(_ context.Context, _ Client, _ *containers.Container, s *Sp
 func deviceFromPath(path string) (*specs.LinuxDevice, error) {
 	return nil, errors.New("device from path not supported on Windows")
 }
+
+// WithWindowsNetworkNamespace sets the network namespace for a Windows container.
+func WithWindowsNetworkNamespace(ns string) SpecOpts {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
+		if s.Windows == nil {
+			s.Windows = &specs.Windows{}
+		}
+		if s.Windows.Network == nil {
+			s.Windows.Network = &specs.WindowsNetwork{}
+		}
+		s.Windows.Network.NetworkNamespace = ns
+		return nil
+	}
+}


### PR DESCRIPTION
`--cni` flag for run command is only available for Linux:
https://github.com/containerd/containerd/blob/af1a0908d06b4f7db4a11bfc67ecc2f34baeb04b/cmd/ctr/commands/run/run_unix.go#L82-L85

But not for Windows yet. I added the flag and also the necessary set up to make networking work in Windows containers.

fixes #6305