### PR TITLE
oci/deviceFromPath(): correctly check device types

### DIFF
--- a/oci/utils_unix_test.go
+++ b/oci/utils_unix_test.go
@@ -1,0 +1,44 @@
+//go:build !windows && !darwin
+// +build !windows,!darwin
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package oci
+
+import "testing"
+
+func TestHostDevicesAllValid(t *testing.T) {
+	devices, err := HostDevices()
+	if err != nil {
+		t.Fatalf("failed to get host devices: %v", err)
+	}
+
+	for _, device := range devices {
+		// Devices can't have major number 0.
+		if device.Major == 0 {
+			t.Errorf("device entry %+v has zero major number", device)
+		}
+		switch device.Type {
+		case blockDevice, charDevice:
+		case fifoDevice:
+			t.Logf("fifo devices shouldn't show up from HostDevices")
+			fallthrough
+		default:
+			t.Errorf("device entry %+v has unexpected type %v", device, device.Type)
+		}
+	}
+}


### PR DESCRIPTION
Relates to https://github.com/moby/moby/pull/42638 (https://github.com/moby/moby/pull/42638#discussion_r760048516)

This ports the changes of https://github.com/opencontainers/runc/commit/95a59bf206f86bc449c4ccc22e2c08e78c707eb6 (https://github.com/opencontainers/runc/pull/2529) to this repository.

From that PR:

    (mode&S_IFCHR == S_IFCHR) is the wrong way of checking the type of an
    inode because the S_IF* bits are actually not a bitmask and instead must
    be checked using S_IF*. This bug was neatly hidden behind a (major == 0)
    sanity-check but that was removed by [1].

    In addition, add a test that makes sure that HostDevices() doesn't give
    rubbish results -- because we broke this and fixed this before[2].

    [1]: https://github.com/opencontainers/runc/commit/24388be71e1aef7facd0d78dda22e696c1694272 ("configs: use different types for .Devices and .Resources.Devices")
    [2]: https://github.com/opencontainers/runc/commit/3ed492ad33f37bd3ee6c5de1ebf9a63b04389957 ("Handle non-devices correctly in DeviceFromPath")

