### PR TITLE
OCI: Mount (accessible) host devices in privileged rootless containers

### DIFF
--- a/oci/utils_unix.go
+++ b/oci/utils_unix.go
@@ -81,24 +81,25 @@ func getDevices(path, containerPath string) ([]specs.LinuxDevice, error) {
 			}
 		case f.Name() == "console":
 			continue
-		}
-		device, err := DeviceFromPath(filepath.Join(path, f.Name()))
-		if err != nil {
-			if err == ErrNotADevice {
+		default:
+			device, err := DeviceFromPath(filepath.Join(path, f.Name()))
+			if err != nil {
+				if err == ErrNotADevice {
+					continue
+				}
+				if os.IsNotExist(err) {
+					continue
+				}
+				return nil, err
+			}
+			if device.Type == fifoDevice {
 				continue
 			}
-			if os.IsNotExist(err) {
-				continue
+			if containerPath != "" {
+				device.Path = filepath.Join(containerPath, filepath.Base(f.Name()))
 			}
-			return nil, err
+			out = append(out, *device)
 		}
-		if device.Type == fifoDevice {
-			continue
-		}
-		if containerPath != "" {
-			device.Path = filepath.Join(containerPath, filepath.Base(f.Name()))
-		}
-		out = append(out, *device)
 	}
 	return out, nil
 }

--- a/oci/utils_unix_go116_test.go
+++ b/oci/utils_unix_go116_test.go
@@ -1,0 +1,55 @@
+//go:build !go1.17 && !windows && !darwin
+// +build !go1.17,!windows,!darwin
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package oci
+
+import "io/fs"
+
+// The following code is adapted from go1.17.1/src/io/fs/readdir.go
+// to compensate for the lack of fs.FileInfoToDirEntry in Go 1.16.
+
+// dirInfo is a DirEntry based on a FileInfo.
+type dirInfo struct {
+	fileInfo fs.FileInfo
+}
+
+func (di dirInfo) IsDir() bool {
+	return di.fileInfo.IsDir()
+}
+
+func (di dirInfo) Type() fs.FileMode {
+	return di.fileInfo.Mode().Type()
+}
+
+func (di dirInfo) Info() (fs.FileInfo, error) {
+	return di.fileInfo, nil
+}
+
+func (di dirInfo) Name() string {
+	return di.fileInfo.Name()
+}
+
+// fileInfoToDirEntry returns a DirEntry that returns information from info.
+// If info is nil, FileInfoToDirEntry returns nil.
+func fileInfoToDirEntry(info fs.FileInfo) fs.DirEntry {
+	if info == nil {
+		return nil
+	}
+	return dirInfo{fileInfo: info}
+}

--- a/oci/utils_unix_go117_test.go
+++ b/oci/utils_unix_go117_test.go
@@ -1,0 +1,24 @@
+//go:build go1.17 && !windows && !darwin
+// +build go1.17,!windows,!darwin
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package oci
+
+import "io/fs"
+
+var fileInfoToDirEntry = fs.FileInfoToDirEntry


### PR DESCRIPTION
follow-up to https://github.com/containerd/containerd/pull/6306 (first commit is from that PR)
this is a quick attempt to port https://github.com/moby/moby/pull/42638 to containerd, so that we're not creating yet-another copy of libcontainer/devices/GetDevices

Allow rootless containers with privileged to mount devices that are accessible (ignore permission errors in rootless mode).


Allow rootless containers with privileged to mount devices that are accessible
(ignore permission errors in rootless mode).

This patch updates oci.getDevices() to ignore access denied errors on sub-
directories and files within the given path if the container is running with
userns enabled.

Note that these errors are _only_ ignored on paths _under_ the specified path,
and not the path itself, so if `HostDevices()` is used, and `/dev` itself is
not accessible, or `WithDevices()` is used to specify a device that is not
accessible, an error is still produced.

Tests were added, which includes a temporary workaround for compatibility
with Go 1.16 (we could decide to skip these tests on Go 1.16 instead).

To verify the patch in a container:

    docker run --rm -v $(pwd):/go/src/github.com/containerd/containerd -w /go/src/github.com/containerd/containerd golang:1.17 sh -c 'go test -v -run TestHostDevices ./oci'
    === RUN   TestHostDevicesOSReadDirFailure
    --- PASS: TestHostDevicesOSReadDirFailure (0.00s)
    === RUN   TestHostDevicesOSReadDirFailureInUserNS
    --- PASS: TestHostDevicesOSReadDirFailureInUserNS (0.00s)
    === RUN   TestHostDevicesDeviceFromPathFailure
    --- PASS: TestHostDevicesDeviceFromPathFailure (0.00s)
    === RUN   TestHostDevicesDeviceFromPathFailureInUserNS
    --- PASS: TestHostDevicesDeviceFromPathFailureInUserNS (0.00s)
    === RUN   TestHostDevicesAllValid
    --- PASS: TestHostDevicesAllValid (0.00s)
    PASS