### PR TITLE
export oci.DeviceFromPath()

### DIFF
--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -1213,7 +1213,7 @@ func WithLinuxDevice(path, permissions string) SpecOpts {
 		setLinux(s)
 		setResources(s)
 
-		dev, err := deviceFromPath(path)
+		dev, err := DeviceFromPath(path)
 		if err != nil {
 			return err
 		}

--- a/oci/spec_opts_windows.go
+++ b/oci/spec_opts_windows.go
@@ -72,6 +72,6 @@ func WithHostDevices(_ context.Context, _ Client, _ *containers.Container, s *Sp
 	return nil
 }
 
-func deviceFromPath(path string) (*specs.LinuxDevice, error) {
+func DeviceFromPath(path string) (*specs.LinuxDevice, error) {
 	return nil, errors.New("device from path not supported on Windows")
 }


### PR DESCRIPTION
This will help to reduce the amount of runc/libcontainer code that's used in Moby / Docker Engine (in favor of using the containerd implementation).

