### PR TITLE
Add Windows Server 2022 CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-10.15, windows-2019]
+        os: [ubuntu-18.04, macos-10.15, windows-2019, windows-2022]
         go-version: ['1.17.3']
 
     steps:
@@ -230,11 +230,15 @@ jobs:
   #
   integration-windows:
     name: Windows Integration
-    runs-on: windows-2019
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 35
     needs: [project, linters, protos, man]
     env:
       GOTEST: gotestsum --
+
+    strategy:
+      matrix:
+        os: [windows-2019, windows-2022]
 
     defaults:
       run:

--- a/integration/client/client_windows_test.go
+++ b/integration/client/client_windows_test.go
@@ -57,7 +57,21 @@ func init() {
 		testImage = "mcr.microsoft.com/windows/nanoserver:2004"
 	case osversion.V20H2:
 		testImage = "mcr.microsoft.com/windows/nanoserver:20H2"
+	case 20348:
+		// 20348 is Windows server 2022's build number.
+		//
+		// TODO(dcantah): Use the hardcoded number until there's an hcsshim release with this build
+		// number included.
+		testImage = "mcr.microsoft.com/windows/nanoserver:ltsc2022"
 	default:
+		// Due to some efforts in improving down-level compatibility for Windows containers (see
+		// https://techcommunity.microsoft.com/t5/containers/windows-server-2022-and-beyond-for-containers/ba-p/2712487)
+		// the ltsc2022 image should continue to work on builds ws2022 and onwards (Winodws 11 for example). With this in mind,
+		// if there's no mapping for the host build just use the Windows Server 2022 image.
+		if b > 20348 {
+			testImage = "mcr.microsoft.com/windows/nanoserver:ltsc2022"
+			return
+		}
 		fmt.Println("No test image defined for Windows build version:", b)
 		panic("No windows test image found for this Windows build")
 	}

--- a/integration/client/image_test.go
+++ b/integration/client/image_test.go
@@ -81,7 +81,7 @@ func TestImagePullWithDistSourceLabel(t *testing.T) {
 	var (
 		source   = "k8s.gcr.io"
 		repoName = "pause"
-		tag      = "3.5"
+		tag      = "3.6"
 	)
 
 	ctx, cancel := testContext(t)

--- a/platforms/defaults_windows_test.go
+++ b/platforms/defaults_windows_test.go
@@ -48,12 +48,14 @@ func TestDefault(t *testing.T) {
 }
 
 func TestMatchComparerMatch(t *testing.T) {
+	major, minor, build := windows.RtlGetNtVersionNumbers()
+	buildStr := fmt.Sprintf("%d.%d.%d", major, minor, build)
 	m := matchComparer{
 		defaults: Only(imagespec.Platform{
 			Architecture: "amd64",
 			OS:           "windows",
 		}),
-		osVersionPrefix: "10.0.17763",
+		osVersionPrefix: buildStr,
 	}
 	for _, test := range []struct {
 		platform imagespec.Platform
@@ -67,7 +69,7 @@ func TestMatchComparerMatch(t *testing.T) {
 			platform: imagespec.Platform{
 				Architecture: "amd64",
 				OS:           "windows",
-				OSVersion:    "10.0.17763.1",
+				OSVersion:    buildStr + ".1",
 			},
 			match: true,
 		},
@@ -75,7 +77,7 @@ func TestMatchComparerMatch(t *testing.T) {
 			platform: imagespec.Platform{
 				Architecture: "amd64",
 				OS:           "windows",
-				OSVersion:    "10.0.17763.2",
+				OSVersion:    buildStr + ".2",
 			},
 			match: true,
 		},
@@ -83,7 +85,8 @@ func TestMatchComparerMatch(t *testing.T) {
 			platform: imagespec.Platform{
 				Architecture: "amd64",
 				OS:           "windows",
-				OSVersion:    "10.0.17762.1",
+				// Use an nonexistent Windows build so we don't get a match. Ws2019's build is 17763/
+				OSVersion: "10.0.17762.1",
 			},
 			match: false,
 		},
@@ -91,7 +94,8 @@ func TestMatchComparerMatch(t *testing.T) {
 			platform: imagespec.Platform{
 				Architecture: "amd64",
 				OS:           "windows",
-				OSVersion:    "10.0.17764.1",
+				// Use an nonexistent Windows build so we don't get a match. Ws2019's build is 17763/
+				OSVersion: "10.0.17764.1",
 			},
 			match: false,
 		},


### PR DESCRIPTION
GA for ws2022 github actions VMs launched a couple weeks ago so seems like
it's time to try out the CI on this new SKU.

This involved adding new ws2022 runs for the OS matrices in the CI, fixing up
a test in the platforms package and adding a mapping for the ws2022 container image in
integration/client.