### PR TITLE
Skip TestExportAndImportMultiLayer on Windows

### DIFF
--- a/integration/client/import_test.go
+++ b/integration/client/import_test.go
@@ -53,6 +53,13 @@ func TestExportAndImport(t *testing.T) {
 // images remain sane, and that the Garbage Collector won't delete part of its
 // content.
 func TestExportAndImportMultiLayer(t *testing.T) {
+	// Skip this test on Windows for now. The image being used for this test was updated recently and the manifest no longer has an entry for
+	// Windows so this will fail.
+	//
+	// TODO(dcantah): Look into what happened to the image and revert this.
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipped on Windows")
+	}
 	testExportImport(t, testMultiLayeredImage)
 }
 


### PR DESCRIPTION
This change skips the TestExportAndImportMultiLayer test in integration/client
for the time being. It seems the image was updated recently and no longer
has a Windows entry in the manifest so the test will always fail. This should
be reverted when we figure out what happened to the image, but this is to
unblock PRs for the time being.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>