### PR TITLE
Authenticate against ghcr.io

### DIFF
--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -143,6 +143,13 @@ jobs:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push images
         shell: bash
         run: |

--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -19,6 +19,9 @@ on:
         required: true
         default: westeurope
 
+permissions:
+  packages: write
+
 env:
   AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUB_ID }}
   DEFAULT_ADMIN_USERNAME: azureuser


### PR DESCRIPTION
This change adds a login step that authenticates the runner to ghcr.io. This allows whomever triggers the action to use github packages as a destination for the container images.

An example run can be seen here:

https://github.com/gabriel-samfira/containerd/runs/4395940700?check_suite_focus=true

The resulting images can be viewed here:

https://github.com/gabriel-samfira?repo_name=containerd&tab=packages

Signed-off-by: Gabriel Adrian Samfira <gsamfira@cloudbasesolutions.com>