### PR TITLE
Move test volume images from gcr to ghcr

### DIFF
--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -5,7 +5,7 @@ on:
       push_to_project:
         description: "Project to build images for"
         required: true
-        default: "gcr.io/k8s-cri-containerd"
+        default: "ghcr.io/containerd"
       azure_windows_image_id:
         description: Windows image URN to deploy
         required: true
@@ -139,13 +139,6 @@ jobs:
           scp -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.PUBLIC_IP }}:/Users/azureuser/.docker/cert.pem $HOME/.docker/cert.pem
           scp -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.PUBLIC_IP }}:/Users/azureuser/.docker/key.pem $HOME/.docker/key.pem
 
-      - name: Setup gcloud SDK
-        uses: google-github-actions/setup-gcloud@master
-        with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
@@ -157,7 +150,6 @@ jobs:
         shell: bash
         run: |
           make -C $GITHUB_WORKSPACE/src/github.com/containerd/containerd/integration/images/volume-copy-up setup-buildx
-          make -C $GITHUB_WORKSPACE/src/github.com/containerd/containerd/integration/images/volume-copy-up configure-docker PROJ=${{ github.event.inputs.push_to_project }}
 
           make -C $GITHUB_WORKSPACE/src/github.com/containerd/containerd/integration/images/volume-copy-up build-registry PROJ=${{ github.event.inputs.push_to_project }} REMOTE_DOCKER_URL=${{ env.PUBLIC_IP }}:2376
           make -C $GITHUB_WORKSPACE/src/github.com/containerd/containerd/integration/images/volume-copy-up push-manifest PROJ=${{ github.event.inputs.push_to_project }} REMOTE_DOCKER_URL=${{ env.PUBLIC_IP }}:2376

--- a/integration/client/client_unix_test.go
+++ b/integration/client/client_unix_test.go
@@ -34,7 +34,7 @@ const (
 
 var (
 	testImage             = "ghcr.io/containerd/busybox:1.32"
-	testMultiLayeredImage = "gcr.io/k8s-cri-containerd/volume-copy-up:2.1"
+	testMultiLayeredImage = "ghcr.io/containerd/volume-copy-up:2.1"
 	shortCommand          = withProcessArgs("true")
 	longCommand           = withProcessArgs("/bin/sh", "-c", "while true; do sleep 1; done")
 )

--- a/integration/client/client_windows_test.go
+++ b/integration/client/client_windows_test.go
@@ -33,7 +33,7 @@ var (
 	defaultRoot           = filepath.Join(os.Getenv("programfiles"), "containerd", "root-test")
 	defaultState          = filepath.Join(os.Getenv("programfiles"), "containerd", "state-test")
 	testImage             string
-	testMultiLayeredImage = "gcr.io/k8s-cri-containerd/volume-copy-up:2.1"
+	testMultiLayeredImage = "ghcr.io/containerd/volume-copy-up:2.1"
 	shortCommand          = withTrue()
 	longCommand           = withProcessArgs("ping", "-t", "localhost")
 )

--- a/integration/client/import_test.go
+++ b/integration/client/import_test.go
@@ -53,13 +53,6 @@ func TestExportAndImport(t *testing.T) {
 // images remain sane, and that the Garbage Collector won't delete part of its
 // content.
 func TestExportAndImportMultiLayer(t *testing.T) {
-	// Skip this test on Windows for now. The image being used for this test was updated recently and the manifest no longer has an entry for
-	// Windows so this will fail.
-	//
-	// TODO(dcantah): Look into what happened to the image and revert this.
-	if runtime.GOOS == "windows" {
-		t.Skip("Skipped on Windows")
-	}
 	testExportImport(t, testMultiLayeredImage)
 }
 

--- a/integration/images/volume-copy-up/Makefile
+++ b/integration/images/volume-copy-up/Makefile
@@ -14,7 +14,7 @@
 
 all: build
 
-PROJ=gcr.io/k8s-cri-containerd
+PROJ=ghcr.io/containerd
 VERSION=2.1
 IMAGE=$(PROJ)/volume-copy-up:$(VERSION)
 DOCKER_CERT_PATH ?= "$(HOME)/.docker"

--- a/integration/images/volume-ownership/Makefile
+++ b/integration/images/volume-ownership/Makefile
@@ -14,7 +14,7 @@
 
 all: build
 
-PROJ=gcr.io/k8s-cri-containerd
+PROJ=ghcr.io/containerd
 VERSION=2.1
 IMAGE=$(PROJ)/volume-ownership:$(VERSION)
 DOCKER_CERT_PATH ?= "$(HOME)/.docker"


### PR DESCRIPTION
With the ghcr images now built and working, switch over to use these new images and update the default name.

See packages at https://github.com/orgs/containerd/packages