### PR TITLE
cri: add support for configuring swap

### DIFF
--- a/pkg/cri/opts/spec_linux.go
+++ b/pkg/cri/opts/spec_linux.go
@@ -450,6 +450,7 @@ func WithResources(resources *runtime.LinuxContainerResources, tolerateMissingHu
 			q         = resources.GetCpuQuota()
 			shares    = uint64(resources.GetCpuShares())
 			limit     = resources.GetMemoryLimitInBytes()
+			swapLimit = resources.GetMemorySwapLimitInBytes()
 			hugepages = resources.GetHugepageLimits()
 		)
 
@@ -471,6 +472,10 @@ func WithResources(resources *runtime.LinuxContainerResources, tolerateMissingHu
 		if limit != 0 {
 			s.Linux.Resources.Memory.Limit = &limit
 		}
+		if swapLimit != 0 {
+			s.Linux.Resources.Memory.Swap = &swapLimit
+		}
+
 		if !disableHugetlbController {
 			if isHugetlbControllerPresent() {
 				for _, limit := range hugepages {


### PR DESCRIPTION
Initial attempt at #6302.

This is my first real containerd PR, and I'm new to the codebase, so sorry if I'm going the wrong way about implementing or testing this.

This PR attempts to add and test support for swap in the CRI server, the test is loosely based on the memory test that already existed, but with support for cgroupsv2 too. I've only been able to test this locally with cgroupsv2 so far though (I'll test with cgroupsv1 locally later, if CI can't validate there).