### PR TITLE
Fix default makefile target for windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,9 @@ CRIDIR=$(OUTPUTDIR)/cri
 .PHONY: clean all AUTHORS build binaries test integration generate protos checkprotos coverage ci check help install uninstall vendor release mandir install-man genman install-cri-deps cri-release cri-cni-release cri-integration install-deps bin/cri-integration.test
 .DEFAULT: default
 
+# Forcibly set the default goal to all, in case an include above brought in a rule definition.
+.DEFAULT_GOAL := all
+
 all: binaries
 
 check: proto-fmt ## run all linters


### PR DESCRIPTION
[A recent change](https://github.com/containerd/containerd/commit/27d7c50384b11d6a3c5982c7e20e89ec360d542a#diff-0aecf097aa5ef1fae976210b147ff1f50248c18d32aab75a40b9c73420b69ceaR28) altered the default target that would get run for the makefile which ended up making a standalone 'make' invocation only build the Windows shim and nothing else. This was [affecting the CI](https://github.com/kubernetes-sigs/cri-tools/runs/4403863280?check_suite_focus=true) of some other projects that relied on 'make' building containerd, ctr, and friends.