### PR TITLE
cgroup2: monitor OOMKill instead of OOM to prevent missing container events

### DIFF
--- a/pkg/oom/v2/v2.go
+++ b/pkg/oom/v2/v2.go
@@ -71,15 +71,15 @@ func (w *watcher) Run(ctx context.Context) {
 				continue
 			}
 			lastOOM := lastOOMMap[i.id]
-			if i.ev.OOM > lastOOM {
+			if i.ev.OOMKill > lastOOM {
 				if err := w.publisher.Publish(ctx, runtime.TaskOOMEventTopic, &eventstypes.TaskOOM{
 					ContainerID: i.id,
 				}); err != nil {
 					logrus.WithError(err).Error("publish OOM event")
 				}
 			}
-			if i.ev.OOM > 0 {
-				lastOOMMap[i.id] = i.ev.OOM
+			if i.ev.OOMKill > 0 {
+				lastOOMMap[i.id] = i.ev.OOMKill
 			}
 		}
 	}


### PR DESCRIPTION
When running on cgroup2, currently in a 1-container-pod-with-memory-limit configuration, no `/tasks/oom` events are generated. This is because the pod cgroup and container cgroups both get the same `memory.max` setting, and the `oom` events gets counted to the pod cgroup, while containerd monitors container cgroups for oom events. Fix that by monitoring `oom_kill` instead and reporting that.
`oom_kill` events are counted both to the pod and container cgroups.

My test case was the following kubernetes manifest:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  creationTimestamp: null
  labels:
    app: stress
  name: stress
spec:
  replicas: 1
  selector:
    matchLabels:
      app: stress
  strategy: {}
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: stress
    spec:
      containers:
      - image: progrium/stress
        resources:
          limits:
            memory: "256Mi"
        name: stress
        args:
        - "--vm-bytes"
        - "128m"
        - "--vm"
        - "10"
status: {}
```
Related issue: https://github.com/k3s-io/k3s/issues/4572