### PR TITLE
Set explicit ACL on test files

### DIFF
--- a/integration/images/volume-copy-up/Dockerfile_windows
+++ b/integration/images/volume-copy-up/Dockerfile_windows
@@ -26,8 +26,11 @@ RUN cmd.exe /c "@echo off && FOR %i in (%BUSYBOX_EXES%) do (mklink %i.exe busybo
 
 USER ContainerUser
 
-RUN cmd.exe /c mkdir C:\test_dir
-
+RUN mkdir C:\test_dir
+# Explicitly set full access rights for "CREATOR OWNER". While
+# this is set by default for Windows Server 2019, it seems that
+# on Windows Server 2022 it is not.
+RUN icacls C:\test_dir /grant "CREATOR OWNER":(OI)(CI)(IO)F /T
 RUN /bin/sh.exe -c "echo test_content > /test_dir/test_file"
 
 ENV PATH="C:\bin;C:\Windows\System32;C:\Windows;"

--- a/integration/images/volume-copy-up/Dockerfile_windows
+++ b/integration/images/volume-copy-up/Dockerfile_windows
@@ -26,12 +26,12 @@ RUN cmd.exe /c "@echo off && FOR %i in (%BUSYBOX_EXES%) do (mklink %i.exe busybo
 
 USER ContainerUser
 
-RUN mkdir C:\test_dir
 # Explicitly set full access rights for "CREATOR OWNER". While
 # this is set by default for Windows Server 2019, it seems that
 # on Windows Server 2022 it is not.
-RUN icacls C:\test_dir /grant "CREATOR OWNER":(OI)(CI)(IO)F /T
-RUN /bin/sh.exe -c "echo test_content > /test_dir/test_file"
+RUN mkdir C:\test_dir && \
+    icacls C:\test_dir /grant "CREATOR OWNER":(OI)(CI)(IO)F /T && \
+    /bin/sh.exe -c "echo test_content > /test_dir/test_file"
 
 ENV PATH="C:\bin;C:\Windows\System32;C:\Windows;"
 VOLUME "C:/test_dir"

--- a/integration/images/volume-ownership/Dockerfile_windows
+++ b/integration/images/volume-ownership/Dockerfile_windows
@@ -27,14 +27,13 @@ RUN cmd.exe /c "@echo off && FOR %i in (%BUSYBOX_EXES%) do (mklink %i.exe busybo
 
 USER ContainerUser
 
-RUN mkdir C:\volumes
 # Explicitly set full access rights for "CREATOR OWNER". While
 # this is set by default for Windows Server 2019, it seems that
 # on Windows Server 2022 it is not.
-RUN icacls C:\volumes /grant "CREATOR OWNER":(OI)(CI)(IO)F /T
-
-RUN mkdir C:\volumes\test_dir
-RUN /bin/sh.exe -c "echo test_content > /volumes/test_dir/test_file"
+RUN mkdir C:\volumes && \
+    icacls C:\volumes /grant "CREATOR OWNER":(OI)(CI)(IO)F /T && \
+    mkdir C:\volumes\test_dir && \
+    /bin/sh.exe -c "echo test_content > /volumes/test_dir/test_file"
 
 ENV PATH="C:\bin;C:\Windows\System32;C:\Windows;"
 VOLUME "C:/volumes/test_dir"

--- a/integration/images/volume-ownership/Dockerfile_windows
+++ b/integration/images/volume-ownership/Dockerfile_windows
@@ -25,9 +25,13 @@ WORKDIR C:/bin
 ADD tools/get_owner_windows.exe C:/bin/get_owner.exe
 RUN cmd.exe /c "@echo off && FOR %i in (%BUSYBOX_EXES%) do (mklink %i.exe busybox.exe)"
 
-RUN cmd.exe /c mkdir C:\volumes
-
 USER ContainerUser
+
+RUN mkdir C:\volumes
+# Explicitly set full access rights for "CREATOR OWNER". While
+# this is set by default for Windows Server 2019, it seems that
+# on Windows Server 2022 it is not.
+RUN icacls C:\volumes /grant "CREATOR OWNER":(OI)(CI)(IO)F /T
 
 RUN mkdir C:\volumes\test_dir
 RUN /bin/sh.exe -c "echo test_content > /volumes/test_dir/test_file"


### PR DESCRIPTION
It seems that the default ACLs inherited from the parent folder on Windows Server 2022, does not include "CREATOR OWNER" as it does on Windows Server 2019. This sets explicit ACLs on test files inside volume test images.

The image build workflow will need to be manually triggered after this merges.

Signed-off-by: Gabriel Adrian Samfira <gsamfira@cloudbasesolutions.com>