### PR TITLE
Set CONTAINERD_ROOT in Windows cri-integration

### DIFF
--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -162,6 +162,7 @@ jobs:
              ./script/setup/install-cni-windows
              mkdir /c/tmp
              export TEST_IMAGE_LIST=c:/repolist.toml
+             export CONTAINERD_ROOT=/c/ProgramData/containerd/root
              make cri-integration | tee c:/Logs/cri-integration.log
            EOF
            ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }} "sh.exe -c 'cat /c/Logs/cri-integration.log | go-junit-report.exe > c:/Logs/junit_01.xml' "


### PR DESCRIPTION
This change sets the ```CONTAINERD_ROOT``` environment variable for cri-integration tests. This is needed in order for the tests to use the same containerd root as ```containerd.exe``` itself. The path should have been already set by the test suite. This issue will be properly resolved once I find the root cause of this mismatch. 

Signed-off-by: Gabriel Adrian Samfira <gsamfira@cloudbasesolutions.com>