### PR TITLE
Include runtime v2 in default builtins

### DIFF
--- a/cmd/containerd/builtins.go
+++ b/cmd/containerd/builtins.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/containerd/containerd/events/plugin"
 	_ "github.com/containerd/containerd/gc/scheduler"
 	_ "github.com/containerd/containerd/runtime/restart/monitor"
+	_ "github.com/containerd/containerd/runtime/v2"
 	_ "github.com/containerd/containerd/services/containers"
 	_ "github.com/containerd/containerd/services/content"
 	_ "github.com/containerd/containerd/services/diff"

--- a/cmd/containerd/builtins_linux.go
+++ b/cmd/containerd/builtins_linux.go
@@ -20,7 +20,6 @@ import (
 	_ "github.com/containerd/containerd/metrics/cgroups"
 	_ "github.com/containerd/containerd/metrics/cgroups/v2"
 	_ "github.com/containerd/containerd/runtime/v1/linux"
-	_ "github.com/containerd/containerd/runtime/v2"
 	_ "github.com/containerd/containerd/runtime/v2/runc/options"
 	_ "github.com/containerd/containerd/snapshots/native/plugin"
 	_ "github.com/containerd/containerd/snapshots/overlay/plugin"

--- a/cmd/containerd/builtins_windows.go
+++ b/cmd/containerd/builtins_windows.go
@@ -19,7 +19,6 @@ package main
 import (
 	_ "github.com/containerd/containerd/diff/lcow"
 	_ "github.com/containerd/containerd/diff/windows"
-	_ "github.com/containerd/containerd/runtime/v2"
 	_ "github.com/containerd/containerd/snapshots/lcow"
 	_ "github.com/containerd/containerd/snapshots/windows"
 )


### PR DESCRIPTION
This PR adds `github.com/containerd/containerd/runtime/v2` package to default builtins.

It has no platform specific dependencies, so it's safe to include this package on all supported platforms (specifically in current implementation runtime v2 is not registered on darwin).

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>