### PR TITLE
Do not use `go get` to install executables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,6 @@ jobs:
         shell: bash
         run: |
           echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
-          echo "GO111MODULE=off" >> $GITHUB_ENV
           echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
       - name: Install protobuf
@@ -113,7 +112,7 @@ jobs:
         with:
           go-version: '1.17.3'
       - uses: actions/checkout@v2
-      - run: go get github.com/cpuguy83/go-md2man/v2@v2.0.1
+      - run: go install github.com/cpuguy83/go-md2man/v2@v2.0.1
       - run: make man
 
   # Make sure binaries compile with other platforms

--- a/script/setup/install-critools
+++ b/script/setup/install-critools
@@ -23,7 +23,7 @@ set -eu -o pipefail
 script_dir="$(cd -- "$(dirname -- "$0")" > /dev/null 2>&1; pwd -P)"
 
 cd "$(go env GOPATH)"
-go get -u github.com/onsi/ginkgo/ginkgo
+go install github.com/onsi/ginkgo/ginkgo@v1.16.5
 
 : "${CRITEST_COMMIT:=$(cat "${script_dir}/critools-version")}"
 : "${DESTDIR:=""}"

--- a/script/setup/install-dev-tools
+++ b/script/setup/install-dev-tools
@@ -20,18 +20,14 @@
 #
 set -eu -o pipefail
 
-# change to tmp dir, otherwise `go get` will change go.mod
-cd "$GOPATH"
-
-# install the `protobuild` binary in $GOPATH/bin; requires module-aware install
-# to pin dependencies
-GO111MODULE=on go get github.com/stevvooe/protobuild@v0.1.0
+# install `protobuild` and other commands
+go install github.com/stevvooe/protobuild@v0.1.0
+go install github.com/cpuguy83/go-md2man/v2@v2.0.1
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.0
 
 # the following packages need to exist in $GOPATH so we can't use
 # go modules-aware mode of `go get` for these includes used during
 # proto building
+cd "$GOPATH"
 GO111MODULE=off go get -d github.com/gogo/googleapis || true
 GO111MODULE=off go get -d github.com/gogo/protobuf || true
-
-GO111MODULE=on go get github.com/cpuguy83/go-md2man/v2@v2.0.1
-GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.0

--- a/script/setup/prepare_env_windows.ps1
+++ b/script/setup/prepare_env_windows.ps1
@@ -37,7 +37,7 @@ Write-Host $env:PATH
 mkdir c:\Logs
 
 # Pull junit conversion tool
-go get -u github.com/jstemmer/go-junit-report
+go install github.com/jstemmer/go-junit-report@v0.9.1
 
 # Get critctl tool. Used for cri-integration tests
 $CRICTL_DOWNLOAD_URL="https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.21.0/crictl-v1.21.0-windows-amd64.tar.gz"


### PR DESCRIPTION
https://go.dev/doc/go-get-install-deprecation

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>