### PR TITLE
Unblock native snapshotter on Darwin

### DIFF
--- a/diff/apply/apply_darwin.go
+++ b/diff/apply/apply_darwin.go
@@ -1,6 +1,3 @@
-//go:build !linux && !darwin
-// +build !linux,!darwin
-
 /*
    Copyright The containerd Authors.
 
@@ -28,6 +25,14 @@ import (
 )
 
 func apply(ctx context.Context, mounts []mount.Mount, r io.Reader) error {
+	// We currently do not support mounts nor bind mounts on MacOS in the containerd daemon.
+	// Using this as an exception to enable native snapshotter and allow further research.
+	if len(mounts) == 1 && mounts[0].Type == "bind" {
+		path := mounts[0].Source
+		_, err := archive.Apply(ctx, path, r)
+		return err
+	}
+
 	return mount.WithTempMount(ctx, mounts, func(root string) error {
 		_, err := archive.Apply(ctx, root, r)
 		return err


### PR DESCRIPTION
There was a discussion in PR https://github.com/containerd/containerd/pull/5935 on how to enable native snapshotter on Mac and how to handle bind mounts with symlinks. While it's still unclear what the final approach should be, I'd like to enable native snapshotter to be at least able to unpack things and unblock further research/experiments.

This PR takes same approach as we do for overlay to skip temp mount in the Applier: https://github.com/containerd/containerd/blob/292b0c1561cf503123ad76e6bb7e26d7fa766a0a/diff/apply/apply_linux.go#L33

cc @thehajime 

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>