### PR TITLE
[release/1.4] Update Go to 1.16.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16.10'
+          go-version: '1.16.11'
 
       - name: Set env
         shell: bash
@@ -82,7 +82,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.10'
+          go-version: '1.16.11'
 
       - name: Set env
         shell: bash
@@ -128,7 +128,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.10'
+          go-version: '1.16.11'
 
       - name: Set env
         shell: bash
@@ -166,7 +166,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.10'
+          go-version: '1.16.11'
 
       - name: Set env
         shell: bash
@@ -199,7 +199,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.10'
+          go-version: '1.16.11'
 
       - name: Set env
         shell: bash
@@ -285,7 +285,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.10'
+          go-version: '1.16.11'
 
       - name: Set env
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.10'
+          go-version: '1.16.11'
 
       - name: Checkout
         uses: actions/checkout@v1
@@ -138,7 +138,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.10'
+          go-version: '1.16.11'
 
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16.10'
+          go-version: '1.16.11'
 
       - name: Set env
         shell: bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ os:
 - linux
 
 go:
-  - "1.16.10"
+  - "1.16.11"
 
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct

--- a/.zuul/playbooks/containerd-build/run.yaml
+++ b/.zuul/playbooks/containerd-build/run.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.16.10'
+    go_version: '1.16.11'
     arch: arm64
   tasks:
   - name: Build containerd

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,7 +77,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.16.10",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.16.11",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -10,7 +10,7 @@
 #
 # docker build -t containerd-test --build-arg RUNC_VERSION=v1.0.0-rc93 -f Dockerfile.test ../
 
-ARG GOLANG_VERSION=1.16.10
+ARG GOLANG_VERSION=1.16.11
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd


### PR DESCRIPTION
go1.16.11 (released 2021-12-02) includes fixes to the compiler, runtime, and the
net/http, net/http/httptest, and time packages. See the Go 1.16.11 milestone on
the issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.16.11+label%3ACherryPickApproved
