### PR TITLE
Don't fail-fast on Windows integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,7 @@ jobs:
       GOTEST: gotestsum --
 
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-2019, windows-2022]
 


### PR DESCRIPTION
As like other integration tests, Windows integration tests should not
fail-fast. So developers can see whether an issue is platform-specific
or not.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>