### PR TITLE
Remove unnecessary go mod download from makefile integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ root-test: ## run tests, except integration tests
 
 integration: ## run integration tests
 	@echo "$(WHALE) $@"
-	@cd "${ROOTDIR}/integration/client" && $(GO) mod download && $(GOTEST) -v ${TESTFLAGS} -test.root -parallel ${TESTFLAGS_PARALLEL} .
+	@cd "${ROOTDIR}/integration/client" && $(GOTEST) -v ${TESTFLAGS} -test.root -parallel ${TESTFLAGS_PARALLEL} .
 
 # TODO integrate cri integration bucket with coverage
 bin/cri-integration.test:


### PR DESCRIPTION
go mod download helps warm the cache for subsequent builds, however, this is unnecessary in the makefile and for CI.
