### PR TITLE
Remove Windows integration testing for 2004.

### DIFF
--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -28,12 +28,8 @@ jobs:
   winIntegration:
     strategy:
       matrix:
-        win_ver: [ltsc2019, sac2004, ltsc2022]
+        win_ver: [ltsc2019, ltsc2022]
         include:
-        - win_ver: sac2004
-          AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:datacenter-core-2004-with-containers-smalldisk:19041.928.2104150521"
-          AZURE_RESOURCE_GROUP: ctrd-integration-sac2004-${{ github.run_id }}
-          GOOGLE_BUCKET: "gs://containerd-integration/logs/windows-sac2004/"
         - win_ver: ltsc2019
           AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2019-Datacenter-with-Containers-smalldisk:17763.1935.2105080716"
           AZURE_RESOURCE_GROUP: ctrd-integration-ltsc2019-${{ github.run_id }}


### PR DESCRIPTION
Considering Windows 2004's EoL on the 14th of December, 2021,
this PR removes all periodic integration testing for 2004.

Signed-off-by: Nashwan Azhari <nazhari@cloudbasesolutions.com>