### PR TITLE
medatada: make namespaces' deletion error less cryptic

### DIFF
--- a/metadata/namespaces.go
+++ b/metadata/namespaces.go
@@ -18,6 +18,7 @@ package metadata
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/containerd/containerd/errdefs"
@@ -184,7 +185,7 @@ func (s *namespaceStore) listNs(namespace string) ([]string, error) {
 		if err := snbkt.ForEach(func(k, v []byte) error {
 			if v == nil {
 				if !isBucketEmpty(snbkt.Bucket(k)) {
-					out = append(out, "snapshot-"+string(k))
+					out = append(out, fmt.Sprintf("snapshots on %q snapshotter", k))
 				}
 			}
 			return nil

--- a/metadata/namespaces_test.go
+++ b/metadata/namespaces_test.go
@@ -54,10 +54,22 @@ func TestCreateDelete(t *testing.T) {
 					Spec:    &types.Any{},
 				})
 				require.NoError(t, err)
+
+				db.Update(func(tx *bbolt.Tx) error {
+					ns, err := namespaces.NamespaceRequired(ctx)
+					if err != nil {
+						return err
+					}
+					bucket, err := createSnapshotterBucket(tx, ns, "testss")
+					if err != nil {
+						return err
+					}
+					return bucket.Put([]byte("key"), []byte("value"))
+				})
 			},
 			validate: func(t *testing.T, err error) {
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), "still has containers")
+				assert.Contains(t, err.Error(), `still has containers, snapshots on "testss" snapshotter`)
 			},
 		},
 	}


### PR DESCRIPTION
The error message was unnecessary cryptic. `snapshot-[name]` notation
was only used here and hard to understand.

Instead it should say `snapshots on "..." snapshotter`.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>