### PR TITLE
metadata: make sure snapshots' children are removable

### DIFF
--- a/metadata/snapshot.go
+++ b/metadata/snapshot.go
@@ -645,7 +645,11 @@ func (s *snapshotter) Remove(ctx context.Context, key string) error {
 		cbkt := sbkt.Bucket(bucketKeyChildren)
 		if cbkt != nil {
 			if child, _ := cbkt.Cursor().First(); child != nil {
-				return errors.Wrap(errdefs.ErrFailedPrecondition, "cannot remove snapshot with child")
+				b := bkt.Bucket(child)
+				if b != nil {
+					return errors.Wrapf(errdefs.ErrFailedPrecondition, "cannot remove snapshot with child %q", child)
+				}
+				// If the child doesn't have the corresponding bucket, ignore it.
 			}
 		}
 


### PR DESCRIPTION
Sometimes I see snapshots that have children in "children" bucket,
but not in "snapshots" bucket. In this case, there is no way to remove
the snapshots.

This change adds an extra check to make sure that snapshots' children
are actually removable. If the child is deleted even partially,
it should not cause ErrFailedPrecondition.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>