### PR TITLE
refactor: functions for error log and error return

### DIFF
--- a/archive/tar_test.go
+++ b/archive/tar_test.go
@@ -425,7 +425,7 @@ func TestBreakouts(t *testing.T) {
 					return errors.Wrap(err, "failed to read unbroken")
 				}
 				if len(b) > 0 {
-					return errors.Errorf("/etc/emptied: non-empty")
+					return errors.New("/etc/emptied: non-empty")
 				}
 				return nil
 			},
@@ -1215,7 +1215,7 @@ func fileEntry(name string, expected []byte, mode int) tarEntryValidator {
 			return errors.Errorf("wrong mode %o, expected %o", hdr.Mode, mode)
 		}
 		if !bytes.Equal(b, expected) {
-			return errors.Errorf("different file content")
+			return errors.New("different file content")
 		}
 		return nil
 	}

--- a/cmd/ctr/commands/content/fetch.go
+++ b/cmd/ctr/commands/content/fetch.go
@@ -280,7 +280,7 @@ outer:
 					info, err := cs.Info(ctx, j.Digest)
 					if err != nil {
 						if !errdefs.IsNotFound(err) {
-							log.G(ctx).WithError(err).Errorf("failed to get content info")
+							log.G(ctx).WithError(err).Error("failed to get content info")
 							continue outer
 						} else {
 							statuses[key] = StatusInfo{

--- a/content/helpers.go
+++ b/content/helpers.go
@@ -234,7 +234,7 @@ func seekReader(r io.Reader, offset, size int64) (io.Reader, error) {
 		return nil, errors.Wrap(err, "failed to discard to offset")
 	}
 	if n != offset {
-		return nil, errors.Errorf("unable to discard to offset")
+		return nil, errors.New("unable to discard to offset")
 	}
 
 	return r, nil

--- a/content/local/writer.go
+++ b/content/local/writer.go
@@ -127,7 +127,7 @@ func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest,
 	if _, err := os.Stat(target); err == nil {
 		// collision with the target file!
 		if err := os.RemoveAll(w.path); err != nil {
-			log.G(ctx).WithField("ref", w.ref).WithField("path", w.path).Errorf("failed to remove ingest directory")
+			log.G(ctx).WithField("ref", w.ref).WithField("path", w.path).Error("failed to remove ingest directory")
 		}
 		return errors.Wrapf(errdefs.ErrAlreadyExists, "content %v", dgst)
 	}
@@ -142,17 +142,17 @@ func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest,
 
 	commitTime := time.Now()
 	if err := os.Chtimes(target, commitTime, commitTime); err != nil {
-		log.G(ctx).WithField("digest", dgst).Errorf("failed to change file time to commit time")
+		log.G(ctx).WithField("digest", dgst).Error("failed to change file time to commit time")
 	}
 
 	// clean up!!
 	if err := os.RemoveAll(w.path); err != nil {
-		log.G(ctx).WithField("ref", w.ref).WithField("path", w.path).Errorf("failed to remove ingest directory")
+		log.G(ctx).WithField("ref", w.ref).WithField("path", w.path).Error("failed to remove ingest directory")
 	}
 
 	if w.s.ls != nil && base.Labels != nil {
 		if err := w.s.ls.Set(dgst, base.Labels); err != nil {
-			log.G(ctx).WithField("digest", dgst).Errorf("failed to set labels")
+			log.G(ctx).WithField("digest", dgst).Error("failed to set labels")
 		}
 	}
 
@@ -165,7 +165,7 @@ func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest,
 	// NOTE: Windows does not support this operation
 	if runtime.GOOS != "windows" {
 		if err := os.Chmod(target, (fi.Mode()&os.ModePerm)&^0333); err != nil {
-			log.G(ctx).WithField("ref", w.ref).Errorf("failed to make readonly")
+			log.G(ctx).WithField("ref", w.ref).Error("failed to make readonly")
 		}
 	}
 

--- a/image.go
+++ b/image.go
@@ -402,7 +402,7 @@ func (i *image) getLayers(ctx context.Context, platform platforms.MatchComparer,
 		return nil, errors.Wrap(err, "failed to resolve rootfs")
 	}
 	if len(diffIDs) != len(manifest.Layers) {
-		return nil, errors.Errorf("mismatched image rootfs and manifest layers")
+		return nil, errors.New("mismatched image rootfs and manifest layers")
 	}
 	layers := make([]rootfs.Layer, len(diffIDs))
 	for i := range diffIDs {

--- a/images/archive/importer.go
+++ b/images/archive/importer.go
@@ -141,7 +141,7 @@ func ImportIndex(ctx context.Context, store content.Store, reader io.Reader, opt
 	}
 
 	if mfsts == nil {
-		return ocispec.Descriptor{}, errors.Errorf("unrecognized image format")
+		return ocispec.Descriptor{}, errors.New("unrecognized image format")
 	}
 
 	for name, linkname := range symlinks {

--- a/images/handlers.go
+++ b/images/handlers.go
@@ -33,17 +33,17 @@ import (
 var (
 	// ErrSkipDesc is used to skip processing of a descriptor and
 	// its descendants.
-	ErrSkipDesc = fmt.Errorf("skip descriptor")
+	ErrSkipDesc = errors.New("skip descriptor")
 
 	// ErrStopHandler is used to signify that the descriptor
 	// has been handled and should not be handled further.
 	// This applies only to a single descriptor in a handler
 	// chain and does not apply to descendant descriptors.
-	ErrStopHandler = fmt.Errorf("stop handler")
+	ErrStopHandler = errors.New("stop handler")
 
 	// ErrEmptyWalk is used when the WalkNotEmpty handlers return no
 	// children (e.g.: they were filtered out).
-	ErrEmptyWalk = fmt.Errorf("image might be filtered out")
+	ErrEmptyWalk = errors.New("image might be filtered out")
 )
 
 // Handler handles image manifests

--- a/mount/mount_linux.go
+++ b/mount/mount_linux.go
@@ -63,7 +63,7 @@ func (m *Mount) Mount(target string) (err error) {
 
 	flags, data, losetup := parseMountOptions(options)
 	if len(data) > pagesize {
-		return errors.Errorf("mount options is too long")
+		return errors.New("mount options is too long")
 	}
 
 	// propagation types.

--- a/mount/temp.go
+++ b/mount/temp.go
@@ -43,7 +43,7 @@ func WithTempMount(ctx context.Context, mounts []Mount, f func(root string) erro
 	// For details, please refer to #1868 #1785.
 	defer func() {
 		if uerr = os.Remove(root); uerr != nil {
-			log.G(ctx).WithError(uerr).WithField("dir", root).Errorf("failed to remove mount temp dir")
+			log.G(ctx).WithError(uerr).WithField("dir", root).Error("failed to remove mount temp dir")
 		}
 	}()
 

--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -628,7 +628,7 @@ func WithUserID(uid uint32) SpecOpts {
 		setProcess(s)
 		if c.Snapshotter == "" && c.SnapshotKey == "" {
 			if !isRootfsAbs(s.Root.Path) {
-				return errors.Errorf("rootfs absolute path is required")
+				return errors.New("rootfs absolute path is required")
 			}
 			user, err := UserFromPath(s.Root.Path, func(u user.User) bool {
 				return u.Uid == int(uid)
@@ -645,10 +645,10 @@ func WithUserID(uid uint32) SpecOpts {
 
 		}
 		if c.Snapshotter == "" {
-			return errors.Errorf("no snapshotter set for container")
+			return errors.New("no snapshotter set for container")
 		}
 		if c.SnapshotKey == "" {
-			return errors.Errorf("rootfs snapshot not created for container")
+			return errors.New("rootfs snapshot not created for container")
 		}
 		snapshotter := client.SnapshotService(c.Snapshotter)
 		mounts, err := snapshotter.Mounts(ctx, c.SnapshotKey)
@@ -684,7 +684,7 @@ func WithUsername(username string) SpecOpts {
 		if s.Linux != nil {
 			if c.Snapshotter == "" && c.SnapshotKey == "" {
 				if !isRootfsAbs(s.Root.Path) {
-					return errors.Errorf("rootfs absolute path is required")
+					return errors.New("rootfs absolute path is required")
 				}
 				user, err := UserFromPath(s.Root.Path, func(u user.User) bool {
 					return u.Name == username
@@ -696,10 +696,10 @@ func WithUsername(username string) SpecOpts {
 				return nil
 			}
 			if c.Snapshotter == "" {
-				return errors.Errorf("no snapshotter set for container")
+				return errors.New("no snapshotter set for container")
 			}
 			if c.SnapshotKey == "" {
-				return errors.Errorf("rootfs snapshot not created for container")
+				return errors.New("rootfs snapshot not created for container")
 			}
 			snapshotter := client.SnapshotService(c.Snapshotter)
 			mounts, err := snapshotter.Mounts(ctx, c.SnapshotKey)
@@ -775,15 +775,15 @@ func WithAdditionalGIDs(userstr string) SpecOpts {
 		}
 		if c.Snapshotter == "" && c.SnapshotKey == "" {
 			if !isRootfsAbs(s.Root.Path) {
-				return errors.Errorf("rootfs absolute path is required")
+				return errors.New("rootfs absolute path is required")
 			}
 			return setAdditionalGids(s.Root.Path)
 		}
 		if c.Snapshotter == "" {
-			return errors.Errorf("no snapshotter set for container")
+			return errors.New("no snapshotter set for container")
 		}
 		if c.SnapshotKey == "" {
-			return errors.Errorf("rootfs snapshot not created for container")
+			return errors.New("rootfs snapshot not created for container")
 		}
 		snapshotter := client.SnapshotService(c.Snapshotter)
 		mounts, err := snapshotter.Mounts(ctx, c.SnapshotKey)

--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -394,7 +394,7 @@ func ValidatePluginConfig(ctx context.Context, c *PluginConfig) error {
 	useConfigPath := c.Registry.ConfigPath != ""
 	if len(c.Registry.Mirrors) > 0 {
 		if useConfigPath {
-			return errors.Errorf("`mirrors` cannot be set when `config_path` is provided")
+			return errors.New("`mirrors` cannot be set when `config_path` is provided")
 		}
 		log.G(ctx).Warning("`mirrors` is deprecated, please use `config_path` instead")
 	}
@@ -407,7 +407,7 @@ func ValidatePluginConfig(ctx context.Context, c *PluginConfig) error {
 	}
 	if hasDeprecatedTLS {
 		if useConfigPath {
-			return errors.Errorf("`configs.tls` cannot be set when `config_path` is provided")
+			return errors.New("`configs.tls` cannot be set when `config_path` is provided")
 		}
 		log.G(ctx).Warning("`configs.tls` is deprecated, please use `config_path` instead")
 	}

--- a/pkg/cri/opts/spec_linux.go
+++ b/pkg/cri/opts/spec_linux.go
@@ -481,7 +481,7 @@ func WithResources(resources *runtime.LinuxContainerResources, tolerateMissingHu
 				}
 			} else {
 				if !tolerateMissingHugetlbController {
-					return errors.Errorf("huge pages limits are specified but hugetlb cgroup controller is missing. " +
+					return errors.New("huge pages limits are specified but hugetlb cgroup controller is missing. " +
 						"Please set tolerate_missing_hugetlb_controller to `true` to ignore this error")
 				}
 				logrus.Warn("hugetlb cgroup controller is absent. skipping huge pages limits")

--- a/pkg/cri/server/events.go
+++ b/pkg/cri/server/events.go
@@ -272,7 +272,7 @@ func (em *eventMonitor) start() <-chan error {
 			case err := <-em.errCh:
 				// Close errCh in defer directly if there is no error.
 				if err != nil {
-					logrus.WithError(err).Errorf("Failed to handle event stream")
+					logrus.WithError(err).Error("Failed to handle event stream")
 					errCh <- err
 				}
 				return

--- a/pkg/process/deleted_state.go
+++ b/pkg/process/deleted_state.go
@@ -32,27 +32,27 @@ type deletedState struct {
 }
 
 func (s *deletedState) Pause(ctx context.Context) error {
-	return errors.Errorf("cannot pause a deleted process")
+	return errors.New("cannot pause a deleted process")
 }
 
 func (s *deletedState) Resume(ctx context.Context) error {
-	return errors.Errorf("cannot resume a deleted process")
+	return errors.New("cannot resume a deleted process")
 }
 
 func (s *deletedState) Update(context context.Context, r *google_protobuf.Any) error {
-	return errors.Errorf("cannot update a deleted process")
+	return errors.New("cannot update a deleted process")
 }
 
 func (s *deletedState) Checkpoint(ctx context.Context, r *CheckpointConfig) error {
-	return errors.Errorf("cannot checkpoint a deleted process")
+	return errors.New("cannot checkpoint a deleted process")
 }
 
 func (s *deletedState) Resize(ws console.WinSize) error {
-	return errors.Errorf("cannot resize a deleted process")
+	return errors.New("cannot resize a deleted process")
 }
 
 func (s *deletedState) Start(ctx context.Context) error {
-	return errors.Errorf("cannot start a deleted process")
+	return errors.New("cannot start a deleted process")
 }
 
 func (s *deletedState) Delete(ctx context.Context) error {
@@ -68,7 +68,7 @@ func (s *deletedState) SetExited(status int) {
 }
 
 func (s *deletedState) Exec(ctx context.Context, path string, r *ExecConfig) (Process, error) {
-	return nil, errors.Errorf("cannot exec in a deleted state")
+	return nil, errors.New("cannot exec in a deleted state")
 }
 
 func (s *deletedState) Status(ctx context.Context) (string, error) {

--- a/pkg/process/exec_state.go
+++ b/pkg/process/exec_state.go
@@ -107,11 +107,11 @@ func (s *execRunningState) Resize(ws console.WinSize) error {
 }
 
 func (s *execRunningState) Start(ctx context.Context) error {
-	return errors.Errorf("cannot start a running process")
+	return errors.New("cannot start a running process")
 }
 
 func (s *execRunningState) Delete(ctx context.Context) error {
-	return errors.Errorf("cannot delete a running process")
+	return errors.New("cannot delete a running process")
 }
 
 func (s *execRunningState) Kill(ctx context.Context, sig uint32, all bool) error {
@@ -145,11 +145,11 @@ func (s *execStoppedState) transition(name string) error {
 }
 
 func (s *execStoppedState) Resize(ws console.WinSize) error {
-	return errors.Errorf("cannot resize a stopped container")
+	return errors.New("cannot resize a stopped container")
 }
 
 func (s *execStoppedState) Start(ctx context.Context) error {
-	return errors.Errorf("cannot start a stopped process")
+	return errors.New("cannot start a stopped process")
 }
 
 func (s *execStoppedState) Delete(ctx context.Context) error {

--- a/pkg/process/init_state.go
+++ b/pkg/process/init_state.go
@@ -60,11 +60,11 @@ func (s *createdState) transition(name string) error {
 }
 
 func (s *createdState) Pause(ctx context.Context) error {
-	return errors.Errorf("cannot pause task in created state")
+	return errors.New("cannot pause task in created state")
 }
 
 func (s *createdState) Resume(ctx context.Context) error {
-	return errors.Errorf("cannot resume task in created state")
+	return errors.New("cannot resume task in created state")
 }
 
 func (s *createdState) Update(ctx context.Context, r *google_protobuf.Any) error {
@@ -72,7 +72,7 @@ func (s *createdState) Update(ctx context.Context, r *google_protobuf.Any) error
 }
 
 func (s *createdState) Checkpoint(ctx context.Context, r *CheckpointConfig) error {
-	return errors.Errorf("cannot checkpoint a task in created state")
+	return errors.New("cannot checkpoint a task in created state")
 }
 
 func (s *createdState) Start(ctx context.Context) error {
@@ -129,11 +129,11 @@ func (s *createdCheckpointState) transition(name string) error {
 }
 
 func (s *createdCheckpointState) Pause(ctx context.Context) error {
-	return errors.Errorf("cannot pause task in created state")
+	return errors.New("cannot pause task in created state")
 }
 
 func (s *createdCheckpointState) Resume(ctx context.Context) error {
-	return errors.Errorf("cannot resume task in created state")
+	return errors.New("cannot resume task in created state")
 }
 
 func (s *createdCheckpointState) Update(ctx context.Context, r *google_protobuf.Any) error {
@@ -141,7 +141,7 @@ func (s *createdCheckpointState) Update(ctx context.Context, r *google_protobuf.
 }
 
 func (s *createdCheckpointState) Checkpoint(ctx context.Context, r *CheckpointConfig) error {
-	return errors.Errorf("cannot checkpoint a task in created state")
+	return errors.New("cannot checkpoint a task in created state")
 }
 
 func (s *createdCheckpointState) Start(ctx context.Context) error {
@@ -211,7 +211,7 @@ func (s *createdCheckpointState) SetExited(status int) {
 }
 
 func (s *createdCheckpointState) Exec(ctx context.Context, path string, r *ExecConfig) (Process, error) {
-	return nil, errors.Errorf("cannot exec in a created state")
+	return nil, errors.New("cannot exec in a created state")
 }
 
 func (s *createdCheckpointState) Status(ctx context.Context) (string, error) {
@@ -250,7 +250,7 @@ func (s *runningState) Pause(ctx context.Context) error {
 }
 
 func (s *runningState) Resume(ctx context.Context) error {
-	return errors.Errorf("cannot resume a running process")
+	return errors.New("cannot resume a running process")
 }
 
 func (s *runningState) Update(ctx context.Context, r *google_protobuf.Any) error {
@@ -262,11 +262,11 @@ func (s *runningState) Checkpoint(ctx context.Context, r *CheckpointConfig) erro
 }
 
 func (s *runningState) Start(ctx context.Context) error {
-	return errors.Errorf("cannot start a running process")
+	return errors.New("cannot start a running process")
 }
 
 func (s *runningState) Delete(ctx context.Context) error {
-	return errors.Errorf("cannot delete a running process")
+	return errors.New("cannot delete a running process")
 }
 
 func (s *runningState) Kill(ctx context.Context, sig uint32, all bool) error {
@@ -306,7 +306,7 @@ func (s *pausedState) transition(name string) error {
 }
 
 func (s *pausedState) Pause(ctx context.Context) error {
-	return errors.Errorf("cannot pause a paused container")
+	return errors.New("cannot pause a paused container")
 }
 
 func (s *pausedState) Resume(ctx context.Context) error {
@@ -326,11 +326,11 @@ func (s *pausedState) Checkpoint(ctx context.Context, r *CheckpointConfig) error
 }
 
 func (s *pausedState) Start(ctx context.Context) error {
-	return errors.Errorf("cannot start a paused process")
+	return errors.New("cannot start a paused process")
 }
 
 func (s *pausedState) Delete(ctx context.Context) error {
-	return errors.Errorf("cannot delete a paused process")
+	return errors.New("cannot delete a paused process")
 }
 
 func (s *pausedState) Kill(ctx context.Context, sig uint32, all bool) error {
@@ -350,7 +350,7 @@ func (s *pausedState) SetExited(status int) {
 }
 
 func (s *pausedState) Exec(ctx context.Context, path string, r *ExecConfig) (Process, error) {
-	return nil, errors.Errorf("cannot exec in a paused state")
+	return nil, errors.New("cannot exec in a paused state")
 }
 
 func (s *pausedState) Status(ctx context.Context) (string, error) {
@@ -372,23 +372,23 @@ func (s *stoppedState) transition(name string) error {
 }
 
 func (s *stoppedState) Pause(ctx context.Context) error {
-	return errors.Errorf("cannot pause a stopped container")
+	return errors.New("cannot pause a stopped container")
 }
 
 func (s *stoppedState) Resume(ctx context.Context) error {
-	return errors.Errorf("cannot resume a stopped container")
+	return errors.New("cannot resume a stopped container")
 }
 
 func (s *stoppedState) Update(ctx context.Context, r *google_protobuf.Any) error {
-	return errors.Errorf("cannot update a stopped container")
+	return errors.New("cannot update a stopped container")
 }
 
 func (s *stoppedState) Checkpoint(ctx context.Context, r *CheckpointConfig) error {
-	return errors.Errorf("cannot checkpoint a stopped container")
+	return errors.New("cannot checkpoint a stopped container")
 }
 
 func (s *stoppedState) Start(ctx context.Context) error {
-	return errors.Errorf("cannot start a stopped process")
+	return errors.New("cannot start a stopped process")
 }
 
 func (s *stoppedState) Delete(ctx context.Context) error {
@@ -407,7 +407,7 @@ func (s *stoppedState) SetExited(status int) {
 }
 
 func (s *stoppedState) Exec(ctx context.Context, path string, r *ExecConfig) (Process, error) {
-	return nil, errors.Errorf("cannot exec in a stopped state")
+	return nil, errors.New("cannot exec in a stopped state")
 }
 
 func (s *stoppedState) Status(ctx context.Context) (string, error) {

--- a/remotes/docker/config/hosts.go
+++ b/remotes/docker/config/hosts.go
@@ -483,7 +483,7 @@ func parseHostConfig(server string, baseDir string, config hostFileConfig) (host
 func getSortedHosts(root *toml.Tree) ([]string, error) {
 	iter, ok := root.Get("host").(*toml.Tree)
 	if !ok {
-		return nil, errors.Errorf("invalid `host` tree")
+		return nil, errors.New("invalid `host` tree")
 	}
 
 	list := append([]string{}, iter.Keys()...)

--- a/remotes/docker/fetcher.go
+++ b/remotes/docker/fetcher.go
@@ -205,7 +205,7 @@ func (r dockerFetcher) open(ctx context.Context, req *request, mediatype string,
 				return nil, errors.Wrap(err, "failed to discard to offset")
 			}
 			if n != offset {
-				return nil, errors.Errorf("unable to discard to offset")
+				return nil, errors.New("unable to discard to offset")
 			}
 
 		}

--- a/remotes/docker/httpreadseeker.go
+++ b/remotes/docker/httpreadseeker.go
@@ -69,7 +69,7 @@ func (hrs *httpReadSeeker) Read(p []byte) (n int, err error) {
 		}
 		if hrs.rc != nil {
 			if clsErr := hrs.rc.Close(); clsErr != nil {
-				log.L.WithError(clsErr).Errorf("httpReadSeeker: failed to close ReadCloser")
+				log.L.WithError(clsErr).Error("httpReadSeeker: failed to close ReadCloser")
 			}
 			hrs.rc = nil
 		}
@@ -119,7 +119,7 @@ func (hrs *httpReadSeeker) Seek(offset int64, whence int) (int64, error) {
 	if abs != hrs.offset {
 		if hrs.rc != nil {
 			if err := hrs.rc.Close(); err != nil {
-				log.L.WithError(err).Errorf("Fetcher.Seek: failed to close ReadCloser")
+				log.L.WithError(err).Error("Fetcher.Seek: failed to close ReadCloser")
 			}
 
 			hrs.rc = nil
@@ -150,7 +150,7 @@ func (hrs *httpReadSeeker) reader() (io.Reader, error) {
 
 		if hrs.rc != nil {
 			if err := hrs.rc.Close(); err != nil {
-				log.L.WithError(err).Errorf("httpReadSeeker: failed to close ReadCloser")
+				log.L.WithError(err).Error("httpReadSeeker: failed to close ReadCloser")
 			}
 		}
 		hrs.rc = rc

--- a/rootfs/init.go
+++ b/rootfs/init.go
@@ -44,7 +44,7 @@ type Mounter interface {
 func InitRootFS(ctx context.Context, name string, parent digest.Digest, readonly bool, snapshotter snapshots.Snapshotter, mounter Mounter) ([]mount.Mount, error) {
 	_, err := snapshotter.Stat(ctx, name)
 	if err == nil {
-		return nil, errors.Errorf("rootfs already exists")
+		return nil, errors.New("rootfs already exists")
 	}
 	// TODO: ensure not exist error once added to snapshot package
 

--- a/runtime/v2/shim.go
+++ b/runtime/v2/shim.go
@@ -304,7 +304,7 @@ func (s *shimTask) delete(ctx context.Context, removeTask func(ctx context.Conte
 	}
 
 	if err := s.shim.delete(ctx); err != nil {
-		log.G(ctx).WithField("id", s.ID()).WithError(err).Errorf("failed to delete shim")
+		log.G(ctx).WithField("id", s.ID()).WithError(err).Error("failed to delete shim")
 	}
 
 	// remove self from the runtime task list

--- a/services/introspection/service.go
+++ b/services/introspection/service.go
@@ -54,7 +54,7 @@ func init() {
 
 			localClient, ok := i.(*Local)
 			if !ok {
-				return nil, errors.Errorf("Could not create a local client for introspection service")
+				return nil, errors.New("Could not create a local client for introspection service")
 			}
 			localClient.UpdateLocal(ic.Root, allPluginsPB)
 

--- a/services/server/server.go
+++ b/services/server/server.go
@@ -351,7 +351,7 @@ func (s *Server) Stop() {
 		instance, err := p.Instance()
 		if err != nil {
 			log.L.WithError(err).WithField("id", p.Registration.URI()).
-				Errorf("could not get plugin instance")
+				Error("could not get plugin instance")
 			continue
 		}
 		closer, ok := instance.(io.Closer)
@@ -360,7 +360,7 @@ func (s *Server) Stop() {
 		}
 		if err := closer.Close(); err != nil {
 			log.L.WithError(err).WithField("id", p.Registration.URI()).
-				Errorf("failed to close plugin")
+				Error("failed to close plugin")
 		}
 	}
 }

--- a/snapshots/devmapper/metadata.go
+++ b/snapshots/devmapper/metadata.go
@@ -193,7 +193,7 @@ func getNextDeviceID(tx *bolt.Tx) (uint32, error) {
 	}
 
 	if seq >= maxDeviceID {
-		return 0, errors.Errorf("dm-meta: couldn't find free device key")
+		return 0, errors.New("dm-meta: couldn't find free device key")
 	}
 
 	id := uint32(seq)

--- a/snapshots/devmapper/pool_device.go
+++ b/snapshots/devmapper/pool_device.go
@@ -48,7 +48,7 @@ func NewPoolDevice(ctx context.Context, config *Config) (*PoolDevice, error) {
 
 	version, err := dmsetup.Version()
 	if err != nil {
-		log.G(ctx).Errorf("dmsetup not available")
+		log.G(ctx).Error("dmsetup not available")
 		return nil, err
 	}
 
@@ -491,7 +491,7 @@ func (p *PoolDevice) GetUsage(deviceName string) (int64, error) {
 	}
 
 	if len(status.Params) == 0 {
-		return 0, errors.Errorf("failed to get the number of used blocks, unexpected output from dmsetup status")
+		return 0, errors.New("failed to get the number of used blocks, unexpected output from dmsetup status")
 	}
 
 	count, err := strconv.ParseInt(status.Params[0], 10, 64)

--- a/snapshots/devmapper/snapshotter.go
+++ b/snapshots/devmapper/snapshotter.go
@@ -307,7 +307,7 @@ func (s *Snapshotter) removeDevice(ctx context.Context, key string) error {
 	deviceName := s.getDeviceName(snapID)
 	if !s.config.AsyncRemove {
 		if err := s.pool.RemoveDevice(ctx, deviceName); err != nil {
-			log.G(ctx).WithError(err).Errorf("failed to remove device")
+			log.G(ctx).WithError(err).Error("failed to remove device")
 			// Tell snapshot GC continue to collect other snapshots.
 			// Otherwise, one snapshot collection failure will stop
 			// the GC, and all snapshots won't be collected even though
@@ -318,7 +318,7 @@ func (s *Snapshotter) removeDevice(ctx context.Context, key string) error {
 		// The asynchronous cleanup will do the real device remove work.
 		log.G(ctx).WithField("device", deviceName).Debug("async remove")
 		if err := s.pool.MarkDeviceState(ctx, deviceName, Removed); err != nil {
-			log.G(ctx).WithError(err).Errorf("failed to mark device as removed")
+			log.G(ctx).WithError(err).Error("failed to mark device as removed")
 			return err
 		}
 	}
@@ -571,7 +571,7 @@ func (s *Snapshotter) Cleanup(ctx context.Context) error {
 		}
 		return nil
 	}); err != nil {
-		log.G(ctx).WithError(err).Errorf("failed to query devices from metastore")
+		log.G(ctx).WithError(err).Error("failed to query devices from metastore")
 		return err
 	}
 

--- a/snapshots/lcow/lcow.go
+++ b/snapshots/lcow/lcow.go
@@ -239,7 +239,7 @@ func (s *snapshotter) Remove(ctx context.Context, key string) error {
 	if err := t.Commit(); err != nil {
 		if err1 := os.Rename(renamed, path); err1 != nil {
 			// May cause inconsistent data on disk
-			log.G(ctx).WithError(err1).WithField("path", renamed).Errorf("Failed to rename after failed commit")
+			log.G(ctx).WithError(err1).WithField("path", renamed).Error("Failed to rename after failed commit")
 		}
 		return errors.Wrap(err, "failed to commit")
 	}

--- a/snapshots/native/native.go
+++ b/snapshots/native/native.go
@@ -202,7 +202,7 @@ func (o *snapshotter) Remove(ctx context.Context, key string) (err error) {
 		if renamed != "" {
 			if err1 := os.Rename(renamed, path); err1 != nil {
 				// May cause inconsistent data on disk
-				log.G(ctx).WithError(err1).WithField("path", renamed).Errorf("failed to rename after failed commit")
+				log.G(ctx).WithError(err1).WithField("path", renamed).Error("failed to rename after failed commit")
 			}
 		}
 		return errors.Wrap(err, "failed to commit")

--- a/snapshots/storage/metastore_test.go
+++ b/snapshots/storage/metastore_test.go
@@ -273,7 +273,7 @@ func testWalk(ctx context.Context, t *testing.T, _ *MetaStore) {
 	found := map[string]snapshots.Info{}
 	err := WalkInfo(ctx, func(ctx context.Context, info snapshots.Info) error {
 		if _, ok := found[info.Name]; ok {
-			return errors.Errorf("entry already encountered")
+			return errors.New("entry already encountered")
 		}
 		found[info.Name] = info
 		return nil

--- a/snapshots/windows/windows.go
+++ b/snapshots/windows/windows.go
@@ -276,7 +276,7 @@ func (s *snapshotter) Remove(ctx context.Context, key string) error {
 	if err := t.Commit(); err != nil {
 		if err1 := os.Rename(renamed, path); err1 != nil {
 			// May cause inconsistent data on disk
-			log.G(ctx).WithError(err1).WithField("path", renamed).Errorf("Failed to rename after failed commit")
+			log.G(ctx).WithError(err1).WithField("path", renamed).Error("Failed to rename after failed commit")
 		}
 		return errors.Wrap(err, "failed to commit")
 	}


### PR DESCRIPTION
There is a lot wrong usage of Errorf in codebase, both when doing log and return.

If error info not contains any arguments, use `errors.New` or `logrus.Error` instead.

