### PR TITLE
seutil: Fix setting the "container_kvm_t" label

### DIFF
--- a/pkg/cri/server/helpers_linux.go
+++ b/pkg/cri/server/helpers_linux.go
@@ -269,17 +269,10 @@ func modifyProcessLabel(runtimeType string, spec *specs.Spec) error {
 	if !isVMBasedRuntime(runtimeType) {
 		return nil
 	}
-	l, err := getKVMLabel(spec.Process.SelinuxLabel)
+	l, err := seutil.ChangeToKVM(spec.Process.SelinuxLabel)
 	if err != nil {
 		return errors.Wrap(err, "failed to get selinux kvm label")
 	}
 	spec.Process.SelinuxLabel = l
 	return nil
-}
-
-func getKVMLabel(l string) (string, error) {
-	if !seutil.HasType("container_kvm_t") {
-		return "", nil
-	}
-	return seutil.ChangeToKVM(l)
 }

--- a/pkg/seutil/seutil.go
+++ b/pkg/seutil/seutil.go
@@ -17,38 +17,8 @@
 package seutil
 
 import (
-	"bufio"
-	"os"
-
 	"github.com/opencontainers/selinux/go-selinux"
 )
-
-var seTypes map[string]struct{}
-
-const typePath = "/etc/selinux/targeted/contexts/customizable_types"
-
-func init() {
-	seTypes = make(map[string]struct{})
-	if !selinux.GetEnabled() {
-		return
-	}
-	f, err := os.Open(typePath)
-	if err != nil {
-		return
-	}
-	defer f.Close()
-	s := bufio.NewScanner(f)
-	for s.Scan() {
-		seTypes[s.Text()] = struct{}{}
-	}
-}
-
-// HasType returns true if the underlying system has the
-// provided selinux type enabled.
-func HasType(name string) bool {
-	_, ok := seTypes[name]
-	return ok
-}
 
 // ChangeToKVM process label
 func ChangeToKVM(l string) (string, error) {


### PR DESCRIPTION
The ability to handle KVM based runtimes with SELinux has been added as
part of d715d00.

However, that commit introduced some logic to check whether the
"container_kvm_t" label would or not be present in the system, and while
the intentions were good, there's two major issues with the approach:
1. Inspecting "/etc/selinux/targeted/contexts/customizable_types" is not
   the way to go, as it doesn't list the "container_kvm_t" at all.
2. There's no need to check for the label, as if the label is invalid an
   "Invalid Label" error will be returned and that's it.

With those two in mind, let's simplify the logic behind setting the
"container_kvm_t" label, removing all the unnecessary code.

Here's an output of VMM process running, considering:
* The state before this patch:
  ```
  $ containerd --version
  containerd github.com/containerd/containerd v1.6.0-beta.3-88-g7fa44fc98 7fa44fc
  $ kubectl apply -f ~/simple-pod.yaml
  pod/nginx created
  $ ps -auxZ | grep cloud-hypervisor
  system_u:system_r:container_runtime_t:s0 root 609717 4.0  0.5 2987512 83588 ?    Sl   08:32   0:00 /usr/bin/cloud-hypervisor --api-socket /run/vc/vm/be9d5cbabf440510d58d89fc8a8e77c27e96ddc99709ecaf5ab94c6b6b0d4c89/clh-api.sock
  ```

* The state after this patch:
  ```
  $ containerd --version
  containerd github.com/containerd/containerd v1.6.0-beta.3-89-ga5f2113c9 a5f2113c9fc15b19b2c364caaedb99c22de4eb32
  $ kubectl apply -f ~/simple-pod.yaml
  pod/nginx created
  $ ps -auxZ | grep cloud-hypervisor
  system_u:system_r:container_kvm_t:s0:c638,c999 root 614842 14.0  0.5 2987512 83228 ? Sl 08:40   0:00 /usr/bin/cloud-hypervisor --api-socket /run/vc/vm/f8ff838afdbe0a546f6995fe9b08e0956d0d0cdfe749705d7ce4618695baa68c/clh-api.sock
  ```

Note, the tests were performed using the following configuration snippet:
```
[plugins]
  [plugins.cri]
    enable_selinux = true
    [plugins.cri.containerd]
      [plugins.cri.containerd.runtimes]
        [plugins.cri.containerd.runtimes.kata]
           runtime_type = "io.containerd.kata.v2"
           privileged_without_host_devices = true
```

And using the following pod yaml:
```
apiVersion: v1
kind: Pod
metadata:
  name: nginx
spec:
  runtimeClassName: kata
  containers:
  - name: nginx
    image: nginx:1.14.2
    ports:
    - containerPort: 80
```

Fixes: containerd#6371

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>