### PR TITLE
ListContainerStats to return stats response if ContainerStatsFilter is nil

### DIFF
--- a/pkg/cri/server/container_stats_list.go
+++ b/pkg/cri/server/container_stats_list.go
@@ -81,7 +81,7 @@ func (c *criService) buildTaskMetricsRequest(
 ) (tasks.MetricsRequest, []containerstore.Container, error) {
 	var req tasks.MetricsRequest
 	if r.GetFilter() == nil {
-		return req, nil, nil
+		return req, c.containerStore.List(), nil
 	}
 	c.normalizeContainerStatsFilter(r.GetFilter())
 	var containers []containerstore.Container


### PR DESCRIPTION
Addresses this issue https://github.com/containerd/containerd/issues/6198

 Currently for the `ListContainerStats` RPC in CRI, if a supplied `ContainerStatsFilter` is nil , the response is empty.
With the change  -  the list of stats for all containers is returned

Change also makes the `ListContainerStats` implementation consistent with CRI-O implementation
https://github.com/cri-o/cri-o/blob/main/server/container_stats_list.go