### PR TITLE
Integration: Enable CRITest on Windows 2022.

### DIFF
--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -170,17 +170,14 @@ jobs:
            ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }} "sh.exe -c 'cat /c/Logs/cri-integration.log | go-junit-report.exe > c:/Logs/junit_01.xml' "
 
       - name: GetCritestRepo
-        if: ${{ matrix.win_ver != 'ltsc2022' }}
         run: |
           ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }} "git clone https://github.com/kubernetes-sigs/cri-tools c:/cri-tools"
 
       - name: BuildCritest
-        if: ${{ matrix.win_ver != 'ltsc2022' }}
         run: |
           ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }} "sh.exe -c 'cd /c/cri-tools && make critest'"
 
       - name: RunCritest
-        if: ${{ matrix.win_ver != 'ltsc2022' }}
         run: |
           ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }} "powershell.exe -command { Start-Process -FilePath C:\containerd\bin\containerd.exe -NoNewWindow -RedirectStandardError true -PassThru ; get-process | sls containerd ; start-sleep 5 ; c:\cri-tools\build\bin\critest.exe --runtime-endpoint=\"npipe:\\\\.\\pipe\\containerd-containerd\" --test-images-file='c:\cri-test-images.yaml' --report-dir='c:\Logs' }"
 


### PR DESCRIPTION
Depends-On: https://github.com/kubernetes-sigs/cri-tools/pull/855

This patch enables the running of `critest` on Windows 2022 as part of the Windows periodic integration tests by removing the checks in the workflow file which skipped the tasks on 2022, as well as parametrizing the test images used by `critest` to newer versions of the images which are supported on 2022.

NOTE: This PR depends on the afferent [cri-tools PR](https://github.com/kubernetes-sigs/cri-tools/pull/855) which adds support for configuring the test images used by `critest` through an external YAML file.
The use of updated test image tags is required on 2022, as the previously-hardcoded images were not built for 2022. (please see [this cri-tools PR](https://github.com/kubernetes-sigs/cri-tools/pull/853) for full details on that)

A successful run can be inspected [here](https://github.com/aznashwan/containerd/runs/4521236203?check_suite_focus=true). (note that this run included the changes from #6292 to skip the Google cloud test results upload, but this PR does not)

