### PR TITLE
Disable TestContainerHook on Windows

### DIFF
--- a/integration/client/container_test.go
+++ b/integration/client/container_test.go
@@ -1569,6 +1569,12 @@ func TestContainerLabels(t *testing.T) {
 }
 
 func TestContainerHook(t *testing.T) {
+	// OCI hooks aren't implemented on Windows. This test will actually run fine on Windows if there's a 'ps' binary in the users PATH, but
+	// there's not any actual hook functionality being tested as any of the OCI fields are plain ignored for Windows containers.
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+
 	t.Parallel()
 
 	client, err := newClient(t, address)
@@ -2012,7 +2018,7 @@ func TestDaemonRestart(t *testing.T) {
 }
 
 type directIO struct {
-    cio.DirectIO
+	cio.DirectIO
 }
 
 // ioCreate returns IO available for use with task creation


### PR DESCRIPTION
OCI hooks aren't implemented on Windows. The test will, and has been, actually
running fine on Windows because the Github runners seem to have a 'ps' binary in
the users PATH, but there's not any actual hook functionality being tested as
any of the OCI fields are ignored for Windows containers.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>