### PR TITLE
Fix no-daemon flag for integration/client tests

### DIFF
--- a/integration/client/client_test.go
+++ b/integration/client/client_test.go
@@ -111,6 +111,10 @@ func TestMain(m *testing.M) {
 			fmt.Fprintf(os.Stderr, "%s: %s\n", err, buf.String())
 			os.Exit(1)
 		}
+	} else {
+		// Otherwise if no-daemon was specified we need to connect to an already running ctrd instance.
+		// Set the addr field on the daemon object so it knows what to try connecting to.
+		ctrd.addr = address
 	}
 
 	waitCtx, waitCancel := context.WithTimeout(ctx, 4*time.Second)


### PR DESCRIPTION
The global &daemon{} object only gets an address assigned if you call start() on it, which only gets called if you don't pass no-daemon. The aftermath of this is that running the integration tests with no-daemon just has them fail trying to create a client for containerd. This change just assigns whatever address is passed to the binary even in the no-daemon case so you can run the integration tests against an already running containerd instance.