### PR TITLE
Fix restart container test

### DIFF
--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -364,7 +364,7 @@ func Randomize(str string) string {
 func KillProcess(name string) error {
 	var command []string
 	if goruntime.GOOS == "windows" {
-		command = []string{"tskill", strings.TrimSuffix(name, ".exe")}
+		command = []string{"taskkill", "/IM", name, "/F"}
 	} else {
 		command = []string{"pkill", "-x", fmt.Sprintf("^%s$", name)}
 	}


### PR DESCRIPTION
This change fixes some issues in ```TestContainerdRestart``` on Windows.

Note, this will not fix current flakiness in the CI. That is most likely caused by a bug in ```hcsshim```, described here: https://github.com/microsoft/hcsshim/pull/1249