### PR TITLE
fix: use _ for consistency

### DIFF
--- a/runtime/v1/linux/task.go
+++ b/runtime/v1/linux/task.go
@@ -86,7 +86,7 @@ func (t *Task) Namespace() string {
 }
 
 // PID of the task
-func (t *Task) PID(_ctx context.Context) (uint32, error) {
+func (t *Task) PID(_ context.Context) (uint32, error) {
 	return uint32(t.pid), nil
 }
 


### PR DESCRIPTION
Signed-off-by: haoyun <yun.hao@daocloud.io>

use _ for code consistency https://github.com/containerd/containerd/pull/5813/files#r686973662