### PR TITLE
sandboxContainer: Do not add pass through annotations to `pause` container.

### DIFF
--- a/pkg/cri/server/sandbox_run_linux.go
+++ b/pkg/cri/server/sandbox_run_linux.go
@@ -167,11 +167,6 @@ func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 
 	specOpts = append(specOpts, customopts.WithPodOOMScoreAdj(int(defaultSandboxOOMAdj), c.config.RestrictOOMScoreAdj))
 
-	for pKey, pValue := range getPassthroughAnnotations(config.Annotations,
-		runtimePodAnnotations) {
-		specOpts = append(specOpts, customopts.WithAnnotation(pKey, pValue))
-	}
-
 	specOpts = append(specOpts,
 		customopts.WithAnnotation(annotations.ContainerType, annotations.ContainerTypeSandbox),
 		customopts.WithAnnotation(annotations.SandboxID, id),


### PR DESCRIPTION
SandboxContainers carry regular process such as `pause` containers
runtimes expect custom annotations for regular containers not for
pause containers.

Following commit prevents adding custom pod annotations to internal
`Sandbox` containers.