### PR TITLE
Client can connect via tcp

### DIFF
--- a/client.go
+++ b/client.go
@@ -150,7 +150,10 @@ func New(address string, opts ...ClientOpt) (*Client, error) {
 		connector := func() (*grpc.ClientConn, error) {
 			ctx, cancel := context.WithTimeout(context.Background(), copts.timeout)
 			defer cancel()
-			conn, err := grpc.DialContext(ctx, dialer.DialAddress(address), gopts...)
+			if !strings.HasPrefix(address, "tcp://") {
+				address = dialer.DialAddress(address)
+			}
+			conn, err := grpc.DialContext(ctx, address, gopts...)
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to dial %q", address)
 			}

--- a/pkg/dialer/dialer_unix.go
+++ b/pkg/dialer/dialer_unix.go
@@ -48,6 +48,10 @@ func isNoent(err error) bool {
 }
 
 func dialer(address string, timeout time.Duration) (net.Conn, error) {
-	address = strings.TrimPrefix(address, "unix://")
-	return net.DialTimeout("unix", address, timeout)
+	parts := strings.SplitN(address, "://", 2)
+	if len(parts) == 2 {
+		return net.DialTimeout(parts[0], parts[1], timeout)
+	} else {
+		return net.DialTimeout("unix", address, timeout)
+	}
 }


### PR DESCRIPTION
In main branch, if caller pass address `tcp://1.1.1.1:8090` to `client.New`, will get err.

In this PR, if caller pass `tcp://1.1.1.1:8090`, the client will try to connect via tcp.