### PR TITLE
Fix $(PWD) issue for Windows makefile

### DIFF
--- a/Makefile.windows
+++ b/Makefile.windows
@@ -26,7 +26,7 @@ WINDOWS_SHIM=bin/containerd-shim-runhcs-v1.exe
 BINARIES := $(addsuffix .exe,$(BINARIES)) $(WINDOWS_SHIM)
 
 $(WINDOWS_SHIM): script/setup/install-runhcs-shim go.mod
-	DESTDIR=$(PWD)/bin $<
+	DESTDIR=$(CURDIR)/bin $<
 
 bin/%.exe: cmd/% FORCE
 	$(BUILD_BINARY)


### PR DESCRIPTION
Seems $(PWD) if the shell is powershell may not be inherited properly as it ends up being an empty string. The result of this is that using mingw's make with powershell is $(PWD)/bin ends up being /bin and the windows shim will get placed there. `make install` afterwards will try to find the shim at $pwd/bin and fail.

Changing to CURDIR https://www.gnu.org/software/make/manual/make.html#index-CURDIR seems to be a solution here as it's not inherited by the environment and is set by make itself so should work across any type of shell.