### PR TITLE
ctr: add --cni for container create command

### DIFF
--- a/cmd/ctr/commands/commands.go
+++ b/cmd/ctr/commands/commands.go
@@ -193,6 +193,10 @@ var (
 			Name:  "apparmor-profile",
 			Usage: "enable AppArmor with an existing custom profile",
 		},
+		cli.BoolFlag{
+			Name:  "cni",
+			Usage: "enable cni networking for the container",
+		},
 	}
 )
 

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -79,10 +79,6 @@ var platformRunFlags = []cli.Flag{
 		Usage: "set the cpu shares",
 		Value: 1024,
 	},
-	cli.BoolFlag{
-		Name:  "cni",
-		Usage: "enable cni networking for the container",
-	},
 }
 
 // NewContainer creates a new container

--- a/cmd/ctr/commands/tasks/network.go
+++ b/cmd/ctr/commands/tasks/network.go
@@ -1,0 +1,125 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package tasks
+
+import (
+	"context"
+	gocontext "context"
+	"fmt"
+
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/pkg/netns"
+	gocni "github.com/containerd/go-cni"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/urfave/cli"
+)
+
+type Network struct {
+	id    string
+	netNS *netns.NetNS
+	cni   gocni.CNI
+}
+
+func LoadNetworkFromContainer(ctx gocontext.Context, id string, spec *specs.Spec) (*Network, error) {
+
+	if spec.Linux == nil {
+		return nil, nil
+	}
+
+	var nsPath string
+	for _, ns := range spec.Linux.Namespaces {
+		if ns.Type == specs.NetworkNamespace {
+			nsPath = ns.Path
+			break
+		}
+	}
+
+	if nsPath == "" {
+		return nil, nil
+	}
+	log.G(ctx).Debugf("Get container network namespace %s", nsPath)
+
+	cni, err := gocni.New(gocni.WithDefaultConf, gocni.WithLoNetwork, gocni.WithMinNetworkCount(2))
+	if err != nil {
+		return nil, err
+	}
+
+	return &Network{
+		id:    id,
+		netNS: netns.LoadNetNS(nsPath),
+		cni:   cni,
+	}, nil
+}
+
+func SetupNetwork(ctx context.Context, id string, context *cli.Context) (*Network, error) {
+	var err error
+
+	var netnsMountDir = "/var/run/netns"
+	netNS, err := netns.NewNetNS(netnsMountDir)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		if err != nil && netNS != nil {
+			if err := netNS.Remove(); err != nil {
+				log.G(ctx).WithError(err).Error("failed to remove netNS in rollback")
+			}
+		}
+	}()
+
+	// CNI needs to attach to at least loopback network and a non host network,
+	// hence networkAttachCount is 2.
+	cni, err := gocni.New(gocni.WithDefaultConf, gocni.WithLoNetwork, gocni.WithMinNetworkCount(2))
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err = cni.Setup(ctx, namespacedID(ctx, id), netNS.GetPath()); err != nil {
+		return nil, err
+	}
+
+	// FIXME should check `--with-ns network:/run/xxx` before creating new NS?
+	context.Set("with-ns", fmt.Sprintf("%s:%s", specs.NetworkNamespace, netNS.GetPath()))
+
+	return &Network{
+		id:    id,
+		netNS: netNS,
+		cni:   cni,
+	}, nil
+}
+
+func (n *Network) Teardown(ctx context.Context) error {
+	if err := n.cni.Remove(ctx, namespacedID(ctx, n.id), ""); err != nil {
+		return err
+	}
+	if closed, err := n.netNS.Closed(); err != nil {
+		return err
+	} else if closed {
+		return nil
+	}
+	return n.netNS.Remove()
+}
+
+func namespacedID(ctx context.Context, id string) string {
+	ns, ok := namespaces.Namespace(ctx)
+	if !ok {
+		return id
+	}
+	return fmt.Sprintf("%s-%s", ns, id)
+}


### PR DESCRIPTION
In CRI/CNI, the upper runtimes will handle CNI plugin and pass
network namespace path to lower runtimes.

`ctr run` supports `--cni` option and can use a CNI plugin, but
it does not work with vm-based runtime like Kata Containers.

Kata Containers depends on the network namespace passed through
OCI spec:

```
"namespaces": [
    {
        "type": "network",
        "path": "/var/run/netns/cni-a98499f5-5161-62c8-16ca-0a39ebd17607"
    }
]
```

This commit will add `--cni` to `ctr container create` command, and create
the network namespaces before containers start. The namespace will be deleted
only when container to be deleted, that means network namespace created by
CNI plugin will have the same life-cycle with containers it belongs to.

Signed-off-by: bin liu <liubin0329@gmail.com>


Below are some test cases:

### Case 1: ctr container create/runc

```bash
# 
# rt=io.containerd.runc.v2
# ip netns ls
cni-af95bfed-4020-6f15-e59f-a5277cfe2ba3 (id: 4)
cni-077e20b7-e175-a3e4-484c-bd3d779d4b0e (id: 1)
cni-a98499f5-5161-62c8-16ca-0a39ebd17607 (id: 0)
# ctr c create --cni --runtime $rt docker.io/containerstack/alpine-stress:latest test top
# ip netns ls
cni-b35af723-6d4a-3d66-6475-8a6cf2f8d634 (id: 3)
cni-af95bfed-4020-6f15-e59f-a5277cfe2ba3 (id: 4)
cni-077e20b7-e175-a3e4-484c-bd3d779d4b0e (id: 1)
cni-a98499f5-5161-62c8-16ca-0a39ebd17607 (id: 0)
# ctr t start -d test
# ctr t exec --exec-id abc test ifconfig
eth0      Link encap:Ethernet  HWaddr B2:99:96:04:D4:51  
          inet addr:172.19.0.46  Bcast:172.19.0.255  Mask:255.255.255.0
          inet6 addr: fe80::b099:96ff:fe04:d451/64 Scope:Link
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:18 errors:0 dropped:0 overruns:0 frame:0
          TX packets:9 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:0 
          RX bytes:2447 (2.3 KiB)  TX bytes:698 (698.0 B)

lo        Link encap:Local Loopback  
          inet addr:127.0.0.1  Mask:255.0.0.0
          inet6 addr: ::1/128 Scope:Host
          UP LOOPBACK RUNNING  MTU:65536  Metric:1
          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
          TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:0 (0.0 B)  TX bytes:0 (0.0 B)

# ctr t kill -s 9 test
# ctr t delete test
WARN[0000] task test exit with non-zero exit code 137   
# ctr c delete test
# ip netns ls
cni-af95bfed-4020-6f15-e59f-a5277cfe2ba3 (id: 4)
cni-077e20b7-e175-a3e4-484c-bd3d779d4b0e (id: 1)
cni-a98499f5-5161-62c8-16ca-0a39ebd17607 (id: 0)
```

### Case 2: ctr container create/kata

```bash
# rt=io.containerd.kata.v2
# ip netns ls
cni-af95bfed-4020-6f15-e59f-a5277cfe2ba3 (id: 4)
cni-077e20b7-e175-a3e4-484c-bd3d779d4b0e (id: 1)
cni-a98499f5-5161-62c8-16ca-0a39ebd17607 (id: 0)
# ctr c create --cni --runtime $rt docker.io/containerstack/alpine-stress:latest test top
# ip netns ls
cni-e108192a-3b19-8744-dfa0-996aa6f00b99 (id: 3)
cni-af95bfed-4020-6f15-e59f-a5277cfe2ba3 (id: 4)
cni-077e20b7-e175-a3e4-484c-bd3d779d4b0e (id: 1)
cni-a98499f5-5161-62c8-16ca-0a39ebd17607 (id: 0)
# ctr t start -d test
# ctr t exec --exec-id abc test ifconfig
eth0      Link encap:Ethernet  HWaddr 6A:D5:A0:0B:15:12  
          inet addr:172.19.0.47  Bcast:172.19.0.255  Mask:255.255.255.0
          inet6 addr: fe80::68d5:a0ff:fe0b:1512/64 Scope:Link
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:6 errors:0 dropped:0 overruns:0 frame:0
          TX packets:7 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:537 (537.0 B)  TX bytes:606 (606.0 B)

lo        Link encap:Local Loopback  
          inet addr:127.0.0.1  Mask:255.0.0.0
          inet6 addr: ::1/128 Scope:Host
          UP LOOPBACK RUNNING  MTU:65536  Metric:1
          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
          TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:0 (0.0 B)  TX bytes:0 (0.0 B)

# ctr t kill -s 9 test
# ctr t delete test
WARN[0000] task test exit with non-zero exit code 9     
# ctr c delete test
# ip netns ls
cni-af95bfed-4020-6f15-e59f-a5277cfe2ba3 (id: 4)
cni-077e20b7-e175-a3e4-484c-bd3d779d4b0e (id: 1)
cni-a98499f5-5161-62c8-16ca-0a39ebd17607 (id: 0)
```

### Case 3: ctr run

```bash
# ip netns ls
cni-af95bfed-4020-6f15-e59f-a5277cfe2ba3 (id: 4)
cni-077e20b7-e175-a3e4-484c-bd3d779d4b0e (id: 1)
cni-a98499f5-5161-62c8-16ca-0a39ebd17607 (id: 0)
# rt=io.containerd.kata.v2
# ctr run --cni --runtime $rt -t --rm docker.io/containerstack/alpine-stress:latest test ifconfig
eth0      Link encap:Ethernet  HWaddr 3E:92:3C:44:4E:B6  
          inet addr:172.19.0.48  Bcast:172.19.0.255  Mask:255.255.255.0
          inet6 addr: fe80::3c92:3cff:fe44:4eb6/64 Scope:Link
          UP BROADCAST MULTICAST  MTU:1500  Metric:1
          RX packets:3 errors:0 dropped:0 overruns:0 frame:0
          TX packets:1 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:270 (270.0 B)  TX bytes:90 (90.0 B)

lo        Link encap:Local Loopback  
          inet addr:127.0.0.1  Mask:255.0.0.0
          inet6 addr: ::1/128 Scope:Host
          UP LOOPBACK RUNNING  MTU:65536  Metric:1
          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
          TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:0 (0.0 B)  TX bytes:0 (0.0 B)

# ip netns ls
cni-af95bfed-4020-6f15-e59f-a5277cfe2ba3 (id: 4)
cni-077e20b7-e175-a3e4-484c-bd3d779d4b0e (id: 1)
cni-a98499f5-5161-62c8-16ca-0a39ebd17607 (id: 0)
# rt=io.containerd.runc.v2
# ctr run --cni --runtime $rt -t --rm docker.io/containerstack/alpine-stress:latest test ifconfig
eth0      Link encap:Ethernet  HWaddr 2E:63:55:57:16:A0  
          inet addr:172.19.0.49  Bcast:172.19.0.255  Mask:255.255.255.0
          inet6 addr: fe80::2c63:55ff:fe57:16a0/64 Scope:Link
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:3 errors:0 dropped:0 overruns:0 frame:0
          TX packets:2 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:0 
          RX bytes:266 (266.0 B)  TX bytes:132 (132.0 B)

lo        Link encap:Local Loopback  
          inet addr:127.0.0.1  Mask:255.0.0.0
          inet6 addr: ::1/128 Scope:Host
          UP LOOPBACK RUNNING  MTU:65536  Metric:1
          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
          TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:0 (0.0 B)  TX bytes:0 (0.0 B)

# ip netns ls
cni-af95bfed-4020-6f15-e59f-a5277cfe2ba3 (id: 4)
cni-077e20b7-e175-a3e4-484c-bd3d779d4b0e (id: 1)
cni-a98499f5-5161-62c8-16ca-0a39ebd17607 (id: 0)
# 

```


