### PR TITLE
content/local: use syscall.Timespec.Unix

### DIFF
--- a/content/local/store_bsd.go
+++ b/content/local/store_bsd.go
@@ -27,7 +27,7 @@ import (
 
 func getATime(fi os.FileInfo) time.Time {
 	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
-		return time.Unix(int64(st.Atimespec.Sec), int64(st.Atimespec.Nsec)) //nolint: unconvert // int64 conversions ensure the line compiles for 32-bit systems as well.
+		return time.Unix(st.Atimespec.Unix())
 	}
 
 	return fi.ModTime()

--- a/content/local/store_openbsd.go
+++ b/content/local/store_openbsd.go
@@ -27,7 +27,7 @@ import (
 
 func getATime(fi os.FileInfo) time.Time {
 	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
-		return time.Unix(int64(st.Atim.Sec), int64(st.Atim.Nsec)) //nolint: unconvert // int64 conversions ensure the line compiles for 32-bit systems as well.
+		return time.Unix(st.Atim.Unix())
 	}
 
 	return fi.ModTime()

--- a/content/local/store_unix.go
+++ b/content/local/store_unix.go
@@ -27,7 +27,7 @@ import (
 
 func getATime(fi os.FileInfo) time.Time {
 	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
-		return time.Unix(int64(st.Atim.Sec), int64(st.Atim.Nsec)) //nolint: unconvert // int64 conversions ensure the line compiles for 32-bit systems as well.
+		return time.Unix(st.Atim.Unix())
 	}
 
 	return fi.ModTime()


### PR DESCRIPTION
Use the syscall method instead of repeating the type conversions for
the syscall.Stat_t Atim/Atimespec members. This also allows to drop the
//nolint: unconvert comments.