### PR TITLE
fix test error

### DIFF
--- a/integration/client/client_test.go
+++ b/integration/client/client_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"syscall"
 	"testing"
 	"time"
 
@@ -188,7 +189,9 @@ func TestMain(m *testing.M) {
 				fmt.Fprintln(os.Stderr, "failed to wait for containerd", err)
 			}
 		}
-
+		if err := syscall.Unmount(defaultRoot, syscall.MNT_FORCE); err != nil {
+			fmt.Fprintln(os.Stdout, "failed to  unmount test root dir", err)
+		}
 		if err := sys.ForceRemoveAll(defaultRoot); err != nil {
 			fmt.Fprintln(os.Stderr, "failed to remove test root dir", err)
 			os.Exit(1)

--- a/integration/client/client_test.go
+++ b/integration/client/client_test.go
@@ -190,7 +190,7 @@ func TestMain(m *testing.M) {
 			}
 		}
 		if err := syscall.Unmount(defaultRoot, syscall.MNT_FORCE); err != nil {
-			fmt.Fprintln(os.Stdout, "failed to  unmount test root dir", err)
+			fmt.Fprintln(os.Stderr, "failed to  unmount test root dir", err)
 		}
 		if err := sys.ForceRemoveAll(defaultRoot); err != nil {
 			fmt.Fprintln(os.Stderr, "failed to remove test root dir", err)


### PR DESCRIPTION
when run test at container
docker run --rm --net host --privileged -v /it_test:/tmp -e GOPATH=/go --tmpfs /var/lib/containerd-test \
-v `pwd`/containerd:/go/src/github.com/containerd/containerd \
-v  `pwd`:/go/src/github.com/opencontainers \
 -w /go/src/github.com/containerd/containerd 
containerd-dev-go1.16.12:1.5.9  make  && make install&&make integration
will show 
FAIL
failed to remove test root dir unlinkat /var/lib/containerd-test: device or resource busy