### PR TITLE
seccomp: add support for "swapcontext" syscall in default policy

### DIFF
--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -467,6 +467,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 		s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
 			Names: []string{
 				"sync_file_range2",
+				"swapcontext",
 			},
 			Action: specs.ActAllow,
 			Args:   []specs.LinuxSeccompArg{},


### PR DESCRIPTION
This system call is only available on 32- and 64-bit PowerPC, it is used
by modern programming language implementations to implement coroutine
features through userspace context switches.

moby [\[1\]][1] and systemd nspawn [\[2\]][2] already whitelist this system call so it
makes sense to whitelist it in containerd as well.

[1]: https://github.com/moby/moby/pull/43092
[2]: https://github.com/systemd/systemd/pull/9487