### PR TITLE
test: e2e node COS cgroupv2 script

### DIFF
--- a/test/e2e_node/gci-init.sh
+++ b/test/e2e_node/gci-init.sh
@@ -30,7 +30,7 @@ if [ "${CONTAINERD_CGROUPV2:-"false"}"  == "true" ]; then
     OS_ID="$(. /etc/os-release && echo "$ID")"
   fi
   if [ "${OS_ID}" = "cos" ]; then
-    if ! grep -q 'systemd.unified_cgroup_hierarchy=true' /proc/cmdline; then
+    if ! grep -q 'systemd.unified_cgroup_hierarchy=true' /proc/cmdline && [ "$(stat -fc %T /sys/fs/cgroup/)" != "cgroup2fs" ]; then
       echo "Setting up cgroupv2"
 
       mount_path="/tmp/esp"


### PR DESCRIPTION
On newer COS M97 images, cgroupv2 is enabled out of the box. It is
enabled using default systemd configuration and does not have
`systemd.unified_cgroup_hierarchy` present `/proc/cmdline`. As a result, the
check for manual cgroupv2 enablement should be improved to not only check
`/proc/cmdline`, but also to see if it's enabled on the system using `stat
-fc %T /sys/fs/cgroup/`

Signed-off-by: David Porter <porterdavid@google.com>