### PR TITLE
Add support for skipping non-dist blob push

### DIFF
--- a/cmd/ctr/commands/images/push.go
+++ b/cmd/ctr/commands/images/push.go
@@ -68,6 +68,9 @@ var pushCommand = cli.Command{
 	}, cli.IntFlag{
 		Name:  "max-concurrent-uploaded-layers",
 		Usage: "Set the max concurrent uploaded layers for each push",
+	}, cli.BoolFlag{
+		Name:  "allow-non-distributable-blobs",
+		Usage: "Allow pushing blobs that are marked as non-distributable",
 	}),
 	Action: func(context *cli.Context) error {
 		var (
@@ -144,13 +147,21 @@ var pushCommand = cli.Command{
 			log.G(ctx).WithField("image", ref).WithField("digest", desc.Digest).Debug("pushing")
 
 			jobHandler := images.HandlerFunc(func(ctx gocontext.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+				if !context.Bool("allow-non-distributable-blobs") && images.IsNonDistributable(desc.MediaType) {
+					return nil, nil
+				}
 				ongoing.add(remotes.MakeRefKey(ctx, desc))
 				return nil, nil
 			})
 
+			handler := jobHandler
+			if !context.Bool("allow-non-distributable-blobs") {
+				handler = remotes.SkipNonDistributableBlobs(handler)
+			}
+
 			ropts := []containerd.RemoteOpt{
 				containerd.WithResolver(resolver),
-				containerd.WithImageHandler(jobHandler),
+				containerd.WithImageHandler(handler),
 			}
 
 			if context.IsSet("max-concurrent-uploaded-layers") {

--- a/remotes/handlers_test.go
+++ b/remotes/handlers_test.go
@@ -18,9 +18,15 @@ package remotes
 
 import (
 	"context"
+	_ "crypto/sha256"
+	"encoding/json"
+	"sync"
 	"testing"
 
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/content/local"
 	"github.com/containerd/containerd/images"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -70,4 +76,142 @@ func TestContextCustomKeyPrefix(t *testing.T) {
 			t.Fatalf("unexpected ref key, expected %s, got: %s", expected, actual)
 		}
 	})
+}
+
+func TestSkipNonDistributableBlobs(t *testing.T) {
+	ctx := context.Background()
+
+	out, err := SkipNonDistributableBlobs(images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		return []ocispec.Descriptor{
+			{MediaType: images.MediaTypeDockerSchema2Layer, Digest: "test:1"},
+			{MediaType: images.MediaTypeDockerSchema2LayerForeign, Digest: "test:2"},
+			{MediaType: images.MediaTypeDockerSchema2LayerForeignGzip, Digest: "test:3"},
+			{MediaType: ocispec.MediaTypeImageLayerNonDistributable, Digest: "test:4"},
+			{MediaType: ocispec.MediaTypeImageLayerNonDistributableGzip, Digest: "test:5"},
+			{MediaType: ocispec.MediaTypeImageLayerNonDistributableZstd, Digest: "test:6"},
+		}, nil
+	}))(ctx, ocispec.Descriptor{MediaType: images.MediaTypeDockerSchema2Manifest})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(out) != 1 {
+		t.Fatalf("unexpected number of descriptors returned: %d", len(out))
+	}
+	if out[0].Digest != "test:1" {
+		t.Fatalf("unexpected digest returned: %s", out[0].Digest)
+	}
+
+	dir := t.TempDir()
+	cs, err := local.NewLabeledStore(dir, newMemoryLabelStore())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	write := func(i interface{}, ref string) digest.Digest {
+		t.Helper()
+
+		data, err := json.Marshal(i)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		w, err := cs.Writer(ctx, content.WithRef(ref))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer w.Close()
+
+		dgst := digest.SHA256.FromBytes(data)
+
+		n, err := w.Write(data)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := w.Commit(ctx, int64(n), dgst); err != nil {
+			t.Fatal(err)
+		}
+
+		return dgst
+	}
+
+	configDigest := write(ocispec.ImageConfig{}, "config")
+
+	manifest := ocispec.Manifest{
+		Config:    ocispec.Descriptor{Digest: configDigest, MediaType: ocispec.MediaTypeImageConfig},
+		MediaType: ocispec.MediaTypeImageManifest,
+		Layers: []ocispec.Descriptor{
+			{MediaType: images.MediaTypeDockerSchema2Layer, Digest: "test:1"},
+			{MediaType: images.MediaTypeDockerSchema2LayerForeign, Digest: "test:2"},
+			{MediaType: images.MediaTypeDockerSchema2LayerForeignGzip, Digest: "test:3"},
+			{MediaType: ocispec.MediaTypeImageLayerNonDistributable, Digest: "test:4"},
+			{MediaType: ocispec.MediaTypeImageLayerNonDistributableGzip, Digest: "test:5"},
+			{MediaType: ocispec.MediaTypeImageLayerNonDistributableZstd, Digest: "test:6"},
+		},
+	}
+
+	manifestDigest := write(manifest, "manifest")
+
+	out, err = SkipNonDistributableBlobs(images.ChildrenHandler(cs))(ctx, ocispec.Descriptor{MediaType: manifest.MediaType, Digest: manifestDigest})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(out) != 2 {
+		t.Fatalf("unexpected number of descriptors returned: %v", out)
+	}
+
+	if out[0].Digest != configDigest {
+		t.Fatalf("unexpected digest returned: %v", out[0])
+	}
+	if out[1].Digest != manifest.Layers[0].Digest {
+		t.Fatalf("unexpected digest returned: %v", out[1])
+	}
+}
+
+type memoryLabelStore struct {
+	l      sync.Mutex
+	labels map[digest.Digest]map[string]string
+}
+
+func newMemoryLabelStore() local.LabelStore {
+	return &memoryLabelStore{
+		labels: map[digest.Digest]map[string]string{},
+	}
+}
+
+func (mls *memoryLabelStore) Get(d digest.Digest) (map[string]string, error) {
+	mls.l.Lock()
+	labels := mls.labels[d]
+	mls.l.Unlock()
+
+	return labels, nil
+}
+
+func (mls *memoryLabelStore) Set(d digest.Digest, labels map[string]string) error {
+	mls.l.Lock()
+	mls.labels[d] = labels
+	mls.l.Unlock()
+
+	return nil
+}
+
+func (mls *memoryLabelStore) Update(d digest.Digest, update map[string]string) (map[string]string, error) {
+	mls.l.Lock()
+	labels, ok := mls.labels[d]
+	if !ok {
+		labels = map[string]string{}
+	}
+	for k, v := range update {
+		if v == "" {
+			delete(labels, k)
+		} else {
+			labels[k] = v
+		}
+	}
+	mls.labels[d] = labels
+	mls.l.Unlock()
+
+	return labels, nil
 }


### PR DESCRIPTION
Add image handler to skip non-distributable blobs.
Add flag to ctr explicitly enable non-dist blob push -- breaking change, can flip this flag if needed, just figured it's best to have the expected handling of this blobs as a default.