### PR TITLE
ctr: Unify the delete subcommand alias

### DIFF
--- a/cmd/ctr/commands/containers/containers.go
+++ b/cmd/ctr/commands/containers/containers.go
@@ -148,7 +148,7 @@ var deleteCommand = cli.Command{
 	Name:      "delete",
 	Usage:     "delete one or more existing containers",
 	ArgsUsage: "[flags] CONTAINER [CONTAINER, ...]",
-	Aliases:   []string{"del", "rm"},
+	Aliases:   []string{"del", "remove", "rm"},
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "keep-snapshot",

--- a/cmd/ctr/commands/images/images.go
+++ b/cmd/ctr/commands/images/images.go
@@ -311,8 +311,8 @@ var checkCommand = cli.Command{
 }
 
 var removeCommand = cli.Command{
-	Name:        "remove",
-	Aliases:     []string{"rm"},
+	Name:        "delete",
+	Aliases:     []string{"del", "remove", "rm"},
 	Usage:       "remove one or more images by reference",
 	ArgsUsage:   "[flags] <ref> [<ref>, ...]",
 	Description: "remove one or more images by reference",

--- a/cmd/ctr/commands/leases/leases.go
+++ b/cmd/ctr/commands/leases/leases.go
@@ -158,7 +158,7 @@ var createCommand = cli.Command{
 
 var deleteCommand = cli.Command{
 	Name:        "delete",
-	Aliases:     []string{"rm"},
+	Aliases:     []string{"del", "remove", "rm"},
 	Usage:       "delete a lease",
 	ArgsUsage:   "[flags] <lease id> ...",
 	Description: "delete a lease",

--- a/cmd/ctr/commands/snapshots/snapshots.go
+++ b/cmd/ctr/commands/snapshots/snapshots.go
@@ -248,8 +248,8 @@ var usageCommand = cli.Command{
 }
 
 var removeCommand = cli.Command{
-	Name:      "remove",
-	Aliases:   []string{"rm"},
+	Name:      "delete",
+	Aliases:   []string{"del", "remove", "rm"},
 	ArgsUsage: "<key> [<key>, ...]",
 	Usage:     "remove snapshots",
 	Action: func(context *cli.Context) error {

--- a/cmd/ctr/commands/tasks/delete.go
+++ b/cmd/ctr/commands/tasks/delete.go
@@ -30,7 +30,7 @@ var deleteCommand = cli.Command{
 	Name:      "delete",
 	Usage:     "delete one or more tasks",
 	ArgsUsage: "CONTAINER [CONTAINER, ...]",
-	Aliases:   []string{"rm"},
+	Aliases:   []string{"del", "remove", "rm"},
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "force, f",


### PR DESCRIPTION
This commit unifies the following sub commands alias for
deleting/removing.
- containers
- tasks
- contents
- leases
- images
- snapshots

Signed-off-by: Ning Li <lining2020x@163.com>