### PR TITLE
Add ppc64 support for test images

### DIFF
--- a/integration/images/volume-copy-up/Makefile
+++ b/integration/images/volume-copy-up/Makefile
@@ -41,7 +41,7 @@ OSVERSION ?= 1809
 OUTPUT_TYPE ?= docker
 
 ALL_OS = linux
-ALL_ARCH.linux = amd64 arm64
+ALL_ARCH.linux = amd64 arm64 ppc64le
 ALL_OS_ARCH.linux = $(foreach arch, ${ALL_ARCH.linux}, linux-$(arch))
 
 ifneq ($(REMOTE_DOCKER_URL),)
@@ -53,6 +53,7 @@ endif
 
 BASE.linux.amd64 := busybox
 BASE.linux.arm64 := arm64v8/busybox
+BASE.linux.ppc64le := busybox
 BASE.linux := ${BASE.linux.${ARCH}}
 BASE := ${BASE.${OS}}
 

--- a/integration/images/volume-ownership/Makefile
+++ b/integration/images/volume-ownership/Makefile
@@ -41,7 +41,7 @@ OSVERSION ?= 1809
 OUTPUT_TYPE ?= docker
 
 ALL_OS = linux
-ALL_ARCH.linux = amd64 arm64
+ALL_ARCH.linux = amd64 arm64 ppc64le
 ALL_OS_ARCH.linux = $(foreach arch, ${ALL_ARCH.linux}, linux-$(arch))
 
 ifneq ($(REMOTE_DOCKER_URL),)
@@ -53,6 +53,7 @@ endif
 
 BASE.linux.amd64 := busybox
 BASE.linux.arm64 := arm64v8/busybox
+BASE.linux.ppc64le := busybox
 BASE.linux := ${BASE.linux.${ARCH}}
 BASE := ${BASE.${OS}}
 


### PR DESCRIPTION
Add ppc64le support to the test images volume-copy-up and volume-ownership.

For the testing, I could only verify those changes for the non Windows images, that is (amd64, arm64 and ppc64le).
As I do not own any Azure VMs, I run a modified version of the  [build-test-images.yml](https://github.com/alunsin/containerd/compare/dev/build-image-for-ppc64le...test/build-image-for-ppc64le), that only relies on the Github's VM and does not build the Windows image.
You can take a look at the workflow execution from my personal repo https://github.com/alunsin/containerd/actions/runs/1684293097
