### PR TITLE
release: Compile runc w/ older libseccomp

### DIFF
--- a/.github/workflows/release/Dockerfile
+++ b/.github/workflows/release/Dockerfile
@@ -25,7 +25,7 @@ SHELL ["/bin/bash", "-xec"]
 RUN	apt-get update && \
 	apt-get install -y git pkg-config
 ARG TARGETPLATFORM
-RUN xx-apt-get install -y libseccomp-dev btrfs-progs gcc
+RUN xx-apt-get install -y --allow-downgrades libseccomp-dev=2.3.* libseccomp2=2.3.* btrfs-progs gcc
 ENV PATH=/usr/local/go/bin:$PATH
 ENV GOPATH=/go
 ENV CGO_ENABLED=1


### PR DESCRIPTION
This makes our compiled version of runc work on rhel7 and other releases
with older versions of libseccomp.

Fixes #6209 #6091