### PR TITLE
cri: fix possible nil-pointer

### DIFF
--- a/pkg/cri/server/container_stats_list.go
+++ b/pkg/cri/server/container_stats_list.go
@@ -36,6 +36,9 @@ func (c *criService) ListContainerStats(
 	if err != nil {
 		return nil, fmt.Errorf("failed to build metrics request: %w", err)
 	}
+	if c.client == nil {
+		return nil, fmt.Errorf("failed to fetch metrics for tasks: no client found")
+	}
 	resp, err := c.client.TaskService().Metrics(ctx, &request)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch metrics for tasks: %w", err)


### PR DESCRIPTION
`(*criService).ListContainerStats()` assumes a client is available, and as a result a possible nil pointer dereference exists.

This PR checks if a client is available, and throws an error if it is not.

This was reported by OSS-fuzz: https://oss-fuzz.com/testcase-detail/5162129408262144