### PR TITLE
platforms: add support for matching amd64 variants

### DIFF
--- a/platforms/compare.go
+++ b/platforms/compare.go
@@ -38,12 +38,22 @@ func platformVector(platform specs.Platform) []specs.Platform {
 
 	switch platform.Architecture {
 	case "amd64":
+		if amd64Version, err := strconv.Atoi(strings.TrimPrefix(platform.Variant, "v")); err == nil && amd64Version > 1 {
+			for amd64Version--; amd64Version >= 1; amd64Version-- {
+				vector = append(vector, specs.Platform{
+					Architecture: platform.Architecture,
+					OS:           platform.OS,
+					OSVersion:    platform.OSVersion,
+					OSFeatures:   platform.OSFeatures,
+					Variant:      "v" + strconv.Itoa(amd64Version),
+				})
+			}
+		}
 		vector = append(vector, specs.Platform{
 			Architecture: "386",
 			OS:           platform.OS,
 			OSVersion:    platform.OSVersion,
 			OSFeatures:   platform.OSFeatures,
-			Variant:      platform.Variant,
 		})
 	case "arm":
 		if armVersion, err := strconv.Atoi(strings.TrimPrefix(platform.Variant, "v")); err == nil && armVersion > 5 {

--- a/platforms/compare_test.go
+++ b/platforms/compare_test.go
@@ -33,6 +33,26 @@ func TestOnly(t *testing.T) {
 					"linux/386",
 				},
 				false: {
+					"linux/amd64/v2",
+					"linux/arm/v7",
+					"linux/arm64",
+					"windows/amd64",
+					"windows/arm",
+				},
+			},
+		},
+		{
+			platform: "linux/amd64/v2",
+			matches: map[bool][]string{
+				true: {
+					"linux/amd64",
+					"linux/amd64/v1",
+					"linux/amd64/v2",
+					"linux/386",
+				},
+				false: {
+					"linux/amd64/v3",
+					"linux/amd64/v4",
 					"linux/arm/v7",
 					"linux/arm64",
 					"windows/amd64",

--- a/platforms/database.go
+++ b/platforms/database.go
@@ -86,9 +86,11 @@ func normalizeArch(arch, variant string) (string, string) {
 	case "i386":
 		arch = "386"
 		variant = ""
-	case "x86_64", "x86-64":
+	case "x86_64", "x86-64", "amd64":
 		arch = "amd64"
-		variant = ""
+		if variant == "v1" {
+			variant = ""
+		}
 	case "aarch64", "arm64":
 		arch = "arm64"
 		switch variant {


### PR DESCRIPTION
AMD64 variants have been standardized in https://en.wikipedia.org/wiki/X86-64#Microarchitecture_levels and are available in modern compilers to optimize for modern machines when needed. For example, starting from 1.18 Go is adding `GOAMD64` to set the minimum compatibility version. If the host doesn't support the minimum version the binary will refuse to start.

This PR makes the `platformVector` matcher understand these values `v1-v4` as variants so they can be used in image indexes. `v1` will remain the default and is normalized out so the change is not visible unless when handling images that have variants with higher value. The behavior is the same as current ARM compatibility handling: `platformVector` will match the highest compatible version.

This is especially important for the cases when we are building multi-platform images on a single machine and some platforms build through emulation that has a lower compatibility version. We don't want these cases to break when choosing a higher compatibility version becomes more popular.

I pushed 2 example images if someone wants to test this: https://hub.docker.com/r/tonistiigi/test/tags?page=1&name=amd64

<details>

```
 # docker pull --platform=linux/amd64/v3 docker.io/tonistiigi/test:amd64all
amd64all: Pulling from tonistiigi/test
Digest: sha256:5786da7ced3792f614bdb51d55390b51cfce05f7030d300d791ec127be5982cc
Status: Image is up to date for tonistiigi/test:amd64all
docker.io/tonistiigi/test:amd64all
 # docker run -it --rm docker.io/tonistiigi/test:amd64all
WARNING: The requested image's platform (linux/amd64/v3) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
This program can only be run on AMD64 processors with v3 microarchitecture support.
 #
 #
 #
 # docker pull --platform=linux/amd64/v2 docker.io/tonistiigi/test:amd64all
amd64all: Pulling from tonistiigi/test
Digest: sha256:5786da7ced3792f614bdb51d55390b51cfce05f7030d300d791ec127be5982cc
Status: Downloaded newer image for tonistiigi/test:amd64all
docker.io/tonistiigi/test:amd64all
 # docker run -it --rm docker.io/tonistiigi/test:amd64all
WARNING: The requested image's platform (linux/amd64/v2) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
2022/01/19 04:27:04 This binary was built with v2 minimum compatibility
2022/01/19 04:27:04 Maximum host compatibility: linux/amd64/v2
 #
 #
 #
 # docker pull --platform=linux/amd64 docker.io/tonistiigi/test:amd64all
amd64all: Pulling from tonistiigi/test
59bf1c3509f3: Already exists
9e3aeff45a2a: Pull complete
Digest: sha256:5786da7ced3792f614bdb51d55390b51cfce05f7030d300d791ec127be5982cc
Status: Downloaded newer image for tonistiigi/test:amd64all
docker.io/tonistiigi/test:amd64all
 # docker run -it --rm docker.io/tonistiigi/test:amd64all
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
2022/01/19 04:27:38 This binary was built with v1 minimum compatibility
2022/01/19 04:27:38 Maximum host compatibility: linux/amd64/v2
```
</details>

@AkihiroSuda @dmcgowan 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>