### PR TITLE
Implement CRI pause image support

### DIFF
--- a/integration/containerd_image_test.go
+++ b/integration/containerd_image_test.go
@@ -203,3 +203,20 @@ func TestContainerdImageInOtherNamespaces(t *testing.T) {
 	}
 	assert.NoError(t, Consistently(checkImage, 100*time.Millisecond, time.Second))
 }
+
+func TestContainerdSandboxImage(t *testing.T) {
+	ctx := context.Background()
+
+	t.Log("make sure the pause image exist")
+	pauseImg, err := containerdClient.GetImage(ctx, pauseImage)
+	require.NoError(t, err)
+	t.Log("ensure correct labels are set on pause image")
+	assert.Equal(t, pauseImg.Labels()["io.cri-containerd.image.kind"], "sandbox")
+
+	t.Log("pause image should be seen by cri plugin")
+	pimg, err := imageService.ImageStatus(&runtime.ImageSpec{Image: pauseImage})
+	require.NoError(t, err)
+	require.NotNil(t, pimg)
+	t.Log("verify pinned field is set for pause image")
+	assert.True(t, pimg.Pinned)
+}

--- a/pkg/cri/server/image_status.go
+++ b/pkg/cri/server/image_status.go
@@ -64,6 +64,7 @@ func toCRIImage(image imagestore.Image) *runtime.Image {
 		RepoTags:    repoTags,
 		RepoDigests: repoDigests,
 		Size_:       uint64(image.Size),
+		Pinned:      image.Pinned,
 	}
 	uid, username := getUserFromImage(image.ImageSpec.Config.User)
 	if uid != nil {

--- a/pkg/cri/util/image.go
+++ b/pkg/cri/util/image.go
@@ -20,6 +20,14 @@ import (
 	"github.com/containerd/containerd/reference/docker"
 )
 
+// sandboxImage label defined here to avoid cyclic imports as they are used in both image store and cri server.
+const (
+	// sandboxImageLabelKey is the label value indicating the image is sandbox image
+	sandboxImageLabelKey = "io.cri-containerd" + ".image.kind"
+	// sandboxImageLabelValue is the label value indicating the image is sandbox image
+	sandboxImageLabelValue = "sandbox"
+)
+
 // NormalizeImageRef normalizes the image reference following the docker convention. This is added
 // mainly for backward compatibility.
 // The reference returned can only be either tagged or digested. For reference contains both tag
@@ -30,4 +38,9 @@ import (
 // Deprecated: use github.com/containerd/containerd/reference/docker.ParseDockerRef() instead
 func NormalizeImageRef(ref string) (docker.Named, error) {
 	return docker.ParseDockerRef(ref)
+}
+
+// GetSandboxImageLabels returns label applied on sandbox image
+func GetSandboxImageLabels() (string, string) {
+	return sandboxImageLabelKey, sandboxImageLabelValue
 }


### PR DESCRIPTION
This commit adds "Pinned" as "true" in CRI image struct if the image has been configured as sandbox_image in containerd config, also labels the sandbox image in containerd store to avoid additional field in container image store

fixes: https://github.com/containerd/containerd/issues/6352

Signed-off-by: Aditi Sharma <adi.sky17@gmail.com>