### PR TITLE
Fix rdt build tags for go 1.16

### DIFF
--- a/pkg/cri/server/rdt_linux.go
+++ b/pkg/cri/server/rdt_linux.go
@@ -1,4 +1,5 @@
 //go:build !no_rdt
+// +build !no_rdt
 
 /*
    Copyright The containerd Authors.

--- a/pkg/cri/server/rdt_stub_linux.go
+++ b/pkg/cri/server/rdt_stub_linux.go
@@ -1,4 +1,5 @@
 //go:build no_rdt
+// +build no_rdt
 
 /*
    Copyright The containerd Authors.


### PR DESCRIPTION
go 1.16 is still a stable and support Go release and requires the `+build` tag to be present.