### PR TITLE
Compile binaries for go1.16 and go1.17 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-10.15, windows-2019, windows-2022]
-        go-version: ['1.17.5']
+        go-version: ['1.16.13', '1.17.5']
 
     steps:
       - uses: actions/setup-go@v2


### PR DESCRIPTION
Ensure containerd compiles for all stable versions of Go