### PR TITLE
Fix empty scopes return

### DIFF
--- a/remotes/docker/scope.go
+++ b/remotes/docker/scope.go
@@ -74,13 +74,17 @@ func ContextWithAppendPullRepositoryScope(ctx context.Context, repo string) cont
 
 // GetTokenScopes returns deduplicated and sorted scopes from ctx.Value(tokenScopesKey{}) and common scopes.
 func GetTokenScopes(ctx context.Context, common []string) []string {
-	var scopes []string
+	scopes := []string{}
 	if x := ctx.Value(tokenScopesKey{}); x != nil {
 		scopes = append(scopes, x.([]string)...)
 	}
 
 	scopes = append(scopes, common...)
 	sort.Strings(scopes)
+
+	if len(scopes) == 0 {
+		return scopes
+	}
 
 	l := 0
 	for idx := 1; idx < len(scopes); idx++ {

--- a/remotes/docker/scope_test.go
+++ b/remotes/docker/scope_test.go
@@ -65,6 +65,11 @@ func TestGetTokenScopes(t *testing.T) {
 	}{
 		{
 			scopesInCtx:  []string{},
+			commonScopes: []string{},
+			expected:     []string{},
+		},
+		{
+			scopesInCtx:  []string{},
 			commonScopes: []string{"repository:foo/bar:pull"},
 			expected:     []string{"repository:foo/bar:pull"},
 		},


### PR DESCRIPTION
Signed-off-by: ye.sijun <junnplus@gmail.com>

Ref: https://github.com/containerd/nerdctl/pull/718

Empty scopes will cause `GetTokenScopes` to panic.