### PR TITLE
[release/1.5] add-list-stat: return container list if filter is nil

### DIFF
--- a/pkg/cri/server/container_stats_list.go
+++ b/pkg/cri/server/container_stats_list.go
@@ -81,7 +81,7 @@ func (c *criService) buildTaskMetricsRequest(
 ) (tasks.MetricsRequest, []containerstore.Container, error) {
 	var req tasks.MetricsRequest
 	if r.GetFilter() == nil {
-		return req, nil, nil
+		return req, c.containerStore.List(), nil
 	}
 	c.normalizeContainerStatsFilter(r.GetFilter())
 	var containers []containerstore.Container


### PR DESCRIPTION
this cherry-pick is needed to fix 
https://github.com/kubernetes-sigs/cri-tools/pull/857
(cherry picked from commit c8a009d18cd667c0a8b13e454a110b4fa5baba03)
