### PR TITLE
Fixes 404 error when authenticating with v2 reg

### DIFF
--- a/remotes/docker/config/hosts.go
+++ b/remotes/docker/config/hosts.go
@@ -107,7 +107,7 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
 					hosts[len(hosts)-1].scheme = "https"
 				}
 			}
-			hosts[len(hosts)-1].path = "/v2"
+			hosts[len(hosts)-1].path = "/v2/"
 			hosts[len(hosts)-1].capabilities = docker.HostCapabilityPull | docker.HostCapabilityResolve | docker.HostCapabilityPush
 		}
 

--- a/remotes/docker/config/hosts_test.go
+++ b/remotes/docker/config/hosts_test.go
@@ -45,7 +45,7 @@ func TestDefaultHosts(t *testing.T) {
 				{
 					Scheme:       "https",
 					Host:         "registry-1.docker.io",
-					Path:         "/v2",
+					Path:         "/v2/",
 					Capabilities: allCaps,
 				},
 			},


### PR DESCRIPTION
As discussed here https://github.com/containerd/nerdctl/issues/715 nerdctl login was failing due to the missing trailing `/` - https://github.com/containerd/nerdctl/pull/724 is the original PR and as requested by @AkihiroSuda I have raised the same PR here instead