### PR TITLE
Remove linux specific paths in cri integration tests

### DIFF
--- a/integration/addition_gids_test.go
+++ b/integration/addition_gids_test.go
@@ -31,9 +31,7 @@ import (
 )
 
 func TestAdditionalGids(t *testing.T) {
-	testPodLogDir, err := os.MkdirTemp("/tmp", "additional-gids")
-	require.NoError(t, err)
-	defer os.RemoveAll(testPodLogDir)
+	testPodLogDir := t.TempDir()
 
 	t.Log("Create a sandbox with log directory")
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "additional-gids",

--- a/integration/container_log_test.go
+++ b/integration/container_log_test.go
@@ -30,9 +30,7 @@ import (
 )
 
 func TestContainerLogWithoutTailingNewLine(t *testing.T) {
-	testPodLogDir, err := os.MkdirTemp("/tmp", "container-log-without-tailing-newline")
-	require.NoError(t, err)
-	defer os.RemoveAll(testPodLogDir)
+	testPodLogDir := t.TempDir()
 
 	t.Log("Create a sandbox with log directory")
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "container-log-without-tailing-newline",
@@ -80,9 +78,7 @@ func TestContainerLogWithoutTailingNewLine(t *testing.T) {
 }
 
 func TestLongContainerLog(t *testing.T) {
-	testPodLogDir, err := os.MkdirTemp("/tmp", "long-container-log")
-	require.NoError(t, err)
-	defer os.RemoveAll(testPodLogDir)
+	testPodLogDir := t.TempDir()
 
 	t.Log("Create a sandbox with log directory")
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "long-container-log",

--- a/integration/container_volume_test.go
+++ b/integration/container_volume_test.go
@@ -82,13 +82,8 @@ func TestContainerSymlinkVolumes(t *testing.T) {
 	} {
 		testCase := testCase // capture range variable
 		t.Run(name, func(t *testing.T) {
-			testPodLogDir, err := os.MkdirTemp("", "symlink-test")
-			require.NoError(t, err)
-			defer os.RemoveAll(testPodLogDir)
-
-			testVolDir, err := os.MkdirTemp("", "symlink-test-vol")
-			require.NoError(t, err)
-			defer os.RemoveAll(testVolDir)
+			testPodLogDir := t.TempDir()
+			testVolDir := t.TempDir()
 
 			content := "hello there\n"
 			regularFile, err := createRegularFile(testVolDir, content)

--- a/integration/image_load_test.go
+++ b/integration/image_load_test.go
@@ -17,12 +17,10 @@
 package integration
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	exec "golang.org/x/sys/execabs"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -40,12 +38,8 @@ func TestImageLoad(t *testing.T) {
 	output, err := exec.Command("docker", "pull", testImage).CombinedOutput()
 	require.NoError(t, err, "output: %q", output)
 	// os.CreateTemp also opens a file, which might prevent us from overwriting that file with docker save.
-	tarDir, err := os.MkdirTemp("", "image-load")
+	tarDir := t.TempDir()
 	tar := filepath.Join(tarDir, "image.tar")
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, os.RemoveAll(tarDir))
-	}()
 	output, err = exec.Command("docker", "save", testImage, "-o", tar).CombinedOutput()
 	require.NoError(t, err, "output: %q", output)
 

--- a/integration/pod_dualstack_test.go
+++ b/integration/pod_dualstack_test.go
@@ -31,9 +31,7 @@ import (
 )
 
 func TestPodDualStack(t *testing.T) {
-	testPodLogDir, err := os.MkdirTemp("/tmp", "dualstack")
-	require.NoError(t, err)
-	defer os.RemoveAll(testPodLogDir)
+	testPodLogDir := t.TempDir()
 
 	t.Log("Create a sandbox")
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "dualstack", WithPodLogDirectory(testPodLogDir))

--- a/integration/pod_hostname_test.go
+++ b/integration/pod_hostname_test.go
@@ -64,9 +64,7 @@ func TestPodHostname(t *testing.T) {
 			if test.needsHostNetwork && goruntime.GOOS == "windows" {
 				t.Skip("Skipped on Windows.")
 			}
-			testPodLogDir, err := os.MkdirTemp("/tmp", "hostname")
-			require.NoError(t, err)
-			defer os.RemoveAll(testPodLogDir)
+			testPodLogDir := t.TempDir()
 
 			opts := append(test.opts, WithPodLogDirectory(testPodLogDir))
 			t.Log("Create a sandbox with hostname")


### PR DESCRIPTION
This PR removes the "/tmp" hardcoded path in the cri integration tests to prevent test failures when running the tests directly on windows. 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>