### PR TITLE
strip path-info from `-v` (version) output, and implement -v flag for containerd-shim 

### DIFF
--- a/integration/images/volume-ownership/tools/get_owner_windows.go
+++ b/integration/images/volume-ownership/tools/get_owner_windows.go
@@ -26,7 +26,7 @@ import (
 
 func main() {
 	if len(os.Args) != 2 {
-		fmt.Printf("Usage: %s file_or_directory\n", os.Args[0])
+		fmt.Println("Usage: get_owner_windows.exe file_or_directory")
 		os.Exit(1)
 	}
 

--- a/runtime/v2/shim/shim.go
+++ b/runtime/v2/shim/shim.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"runtime"
 	"runtime/debug"
 	"strings"
@@ -240,7 +241,7 @@ func RunManager(ctx context.Context, manager Manager, opts ...BinaryOpts) {
 func run(ctx context.Context, manager Manager, initFunc Init, name string, config Config) error {
 	parseFlags()
 	if versionFlag {
-		fmt.Printf("%s:\n", os.Args[0])
+		fmt.Printf("%s:\n", filepath.Base(os.Args[0]))
 		fmt.Println("  Version: ", version.Version)
 		fmt.Println("  Revision:", version.Revision)
 		fmt.Println("  Go version:", version.GoVersion)


### PR DESCRIPTION
### runtime/v2/shim: strip path information from version output

I noticed that path information showed up in the version output:

    ./bin/containerd-shim-runc-v1 -v
    ./bin/containerd-shim-runc-v1:
    Version:  v1.6.0-rc.1
    Revision: ad77111.m
    Go version: go1.17.2

POSIX guidelines describes; https://www.gnu.org/prep/standards/html_node/_002d_002dversion.html#g_t_002d_002dversion

> The program’s name should be a constant string; don’t compute it from argv[0].
> The idea is to state the standard or canonical name for the program, not its
> file name.

Unfortunately, this code is used by multiple binaries, so we can't fully remove the use of os.Args[0], but let's make a start and just remove the path info.

### integration/images/volume-ownership: strip path information from usage output

POSIX guidelines describes; https://www.gnu.org/prep/standards/html_node/_002d_002dversion.html#g_t_002d_002dversion

> The program’s name should be a constant string; don’t compute it from argv[0].
> The idea is to state the standard or canonical name for the program, not its
> file name.

We don't have a const for this, but let's make a start and just remove the path info.


### cmd/containerd-shim: add -v (version) flag
Unlike the other shims, containerd-shim did not have a -v (version) flag:

    ./bin/containerd-shim-runc-v1 -v
    ./bin/containerd-shim-runc-v1:
    Version: v1.6.0-rc.1
    Revision: ad77111.m
    Go version: go1.17.2

    ./bin/containerd-shim -v
    flag provided but not defined: -v
    Usage of ./bin/containerd-shim:

This patch adds a `-v` flag to be consistent with the other shims. The code was
slightly refactored to match the implementation in the other shims, taking the
same approach as https://github.com/containerd/containerd/blob/77d53d2d230c3bcd3f02e6f493019a72905c875b/runtime/v2/shim/shim.go#L240-L256