### PR TITLE
platforms.Normalize(): do not reset OSVersion and OSFeatures

### DIFF
--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -257,10 +257,5 @@ func Format(platform specs.Platform) string {
 func Normalize(platform specs.Platform) specs.Platform {
 	platform.OS = normalizeOS(platform.OS)
 	platform.Architecture, platform.Variant = normalizeArch(platform.Architecture, platform.Variant)
-
-	// these fields are deprecated, remove them
-	platform.OSFeatures = nil
-	platform.OSVersion = ""
-
 	return platform
 }

--- a/platforms/platforms_test.go
+++ b/platforms/platforms_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseSelector(t *testing.T) {
@@ -363,4 +364,8 @@ func TestParseSelectorInvalid(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNormalize(t *testing.T) {
+	require.Equal(t, DefaultSpec(), Normalize(DefaultSpec()))
 }


### PR DESCRIPTION
fixes https://github.com/containerd/containerd/issues/6168

Commit fb0688362cafb5c24cfe6bd4f83765a0515af374 (https://github.com/containerd/containerd/pull/1403) implemented the `Normalize()` function, but marked these fields as deprecated.

It's unclear what the motivation was for this (https://github.com/containerd/containerd/pull/1403#discussion_r199289449), as the fields are part of the OCI Image spec. On Windows, the OSVersion field specifically is important when matching images (as kernel versions may not be compatible).

This patch updates platforms.Normalize() to preserve the OSVersion and OSFeatures fields.

As a follow-up, we should look at defining an appropriate string-representation for these fields (possibly as part of the OCI Spec), and update platforms.Parse() accordingly.
