### PR TITLE
Update BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -260,6 +260,10 @@ PASS
 ok  	github.com/containerd/containerd	4.778s
 ```
 
+> *Note*: in order to run `sudo go` you need to
+> - either keep user PATH environment variable. ex: `sudo "PATH=$PATH" env go test <args>`
+> - or use `go test -exec` ex: `go test -exec sudo -v -run "TestTarWithXattr" ./archive/ -test.root`
+
 ## Additional tools
 
 ### containerd-stress


### PR DESCRIPTION
This commit inserts instructions for adding go path to secure_path variable of /etc/sudoers. Since some go tests require elevated permissions to run, `sudo go` command might be needed. I noticed this after building from the source and trying to run `make root-test` and `make integration`. Even though this is not needed for building, it might still be needed for some functions.