### PR TITLE
Prepare 1.6.0-rc.2

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -100,8 +100,8 @@ The current state is available in the following tables:
 | [1.1](https://github.com/containerd/containerd/releases/tag/v1.1.8)  | End of Life | April 23, 2018  | October 23, 2019 |
 | [1.2](https://github.com/containerd/containerd/releases/tag/v1.2.13) | End of Life | October 24, 2018 | October 15, 2020 |
 | [1.3](https://github.com/containerd/containerd/releases/tag/v1.3.10) | End of Life | September 26, 2019  | March 4, 2021 |
-| [1.4](https://github.com/containerd/containerd/releases/tag/v1.4.4)  | Extended   | August 17, 2020 | November 3, 2021 (Active), February 3, 2022 (Extended) |
-| [1.5](https://github.com/containerd/containerd/releases/tag/v1.5.0)  | Active   | May 3, 2021  | max(May 3, 2022, release of 1.6.0 + 6 months) |
+| [1.4](https://github.com/containerd/containerd/releases/tag/v1.4.12) | Extended   | August 17, 2020 | November 3, 2021 (Active), March 3, 2022 (Extended) |
+| [1.5](https://github.com/containerd/containerd/releases/tag/v1.5.9)  | Active   | May 3, 2021  | max(May 3, 2022, release of 1.6.0 + 6 months) |
 | [1.6](https://github.com/containerd/containerd/milestone/34)         | Next   | TBD  | max(TBD+1 year, release of 1.7.0 or 2.0.0 + 6 months) |
 
 Note that branches and release from before 1.0 may not follow these rules.

--- a/releases/v1.6.0-rc.toml
+++ b/releases/v1.6.0-rc.toml
@@ -21,6 +21,7 @@ support to increase overall compatibility and stability.
 * **Add runtime label to metrics** ([#5744](https://github.com/containerd/containerd/pull/5744))
 * **Cleanup task delete logic in v2 shim** ([#5813](https://github.com/containerd/containerd/pull/5813))
 * **Add support for shim plugins** ([#5817](https://github.com/containerd/containerd/pull/5817))
+* **Handle sigint and sigterm in shimv2** ([#5828](https://github.com/containerd/containerd/pull/5828))
 * **Decouple shim and task manager** ([#5918](https://github.com/containerd/containerd/pull/5918))
 * **Add runc shim support for core scheduling** ([#6011](https://github.com/containerd/containerd/pull/6011))
 * **Update shim client connect attempt to fail fast when shim errors** ([#6031](https://github.com/containerd/containerd/pull/6031))

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.0-rc.1+unknown"
+	Version = "1.6.0-rc.2+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
See generated release notes https://gist.github.com/dmcgowan/fb2b125fd74d6c268fcabd7c89bb831a

Due to timing of 1.6, this also bumps support date for 1.4