### PR TITLE
pkg/oom/v2: handle EventChan routine shutdown quietly

### DIFF
--- a/pkg/oom/v2/v2.go
+++ b/pkg/oom/v2/v2.go
@@ -102,10 +102,13 @@ func (w *watcher) Add(id string, cgx interface{}) error {
 				i.ev = ev
 				w.itemCh <- i
 			case err := <-errCh:
-				i.err = err
-				w.itemCh <- i
-				// we no longer get any event/err when we got an err
-				logrus.WithError(err).Warn("error from *cgroupsv2.Manager.EventChan")
+				// channel is closed when cgroup gets deleted
+				if err != nil {
+					i.err = err
+					w.itemCh <- i
+					// we no longer get any event/err when we got an err
+					logrus.WithError(err).Warn("error from *cgroupsv2.Manager.EventChan")
+				}
 				return
 			}
 		}


### PR DESCRIPTION
When the cgroup is removed, EventChan is closed (this was pulled in by
8d69c041c52ac688430df7fd540018bf74f341c2). This results in a nil error
being received. Don't log an error in that case but instead return.

See also: https://github.com/containerd/containerd/issues/5670