### PR TITLE
[release/1.5] shimv2: handle sigint/sigterm

### DIFF
--- a/runtime/v2/shim/shim.go
+++ b/runtime/v2/shim/shim.go
@@ -214,7 +214,7 @@ func run(id string, initFunc Init, config Config) error {
 			"pid":       os.Getpid(),
 			"namespace": namespaceFlag,
 		})
-		go handleSignals(ctx, logger, signals)
+		go reap(ctx, logger, signals)
 		response, err := service.Cleanup(ctx)
 		if err != nil {
 			return err
@@ -310,7 +310,9 @@ func (s *Client) Serve() error {
 			dumpStacks(logger)
 		}
 	}()
-	return handleSignals(s.context, logger, s.signals)
+	ctx, cancel := context.WithCancel(s.context)
+	go handleExitSignals(ctx, logger, cancel)
+	return reap(ctx, logger, s.signals)
 }
 
 // serve serves the ttrpc API over a unix socket at the provided path

--- a/runtime/v2/shim/shim_windows.go
+++ b/runtime/v2/shim/shim_windows.go
@@ -48,8 +48,11 @@ func serveListener(path string) (net.Listener, error) {
 	return nil, errors.New("not supported")
 }
 
-func handleSignals(ctx context.Context, logger *logrus.Entry, signals chan os.Signal) error {
+func reap(ctx context.Context, logger *logrus.Entry, signals chan os.Signal) error {
 	return errors.New("not supported")
+}
+
+func handleExitSignals(ctx context.Context, logger *logrus.Entry, cancel context.CancelFunc) {
 }
 
 func openLog(ctx context.Context, _ string) (io.Writer, error) {


### PR DESCRIPTION

backport of https://github.com/containerd/containerd/pull/5828 (to fix https://github.com/containerd/containerd/issues/5502 for 1.5)

This causes sigint/sigterm to trigger a shutdown of the shim.
It is needed because otherwise the v2 shim hangs system shutdown.

Signed-off-by: Brian Goff <cpuguy83@gmail.com>
(cherry picked from commit 3ffb6a61130298cd27636df2b64a53e2161cdced)
Signed-off-by: Varsha Teratipally <teratipally@google.com>