### PR TITLE
containerd-stress: start task ctr before starting execs

### DIFF
--- a/cmd/containerd-stress/exec_worker.go
+++ b/cmd/containerd-stress/exec_worker.go
@@ -63,6 +63,12 @@ func (w *execWorker) exec(ctx, tctx context.Context) {
 		logrus.WithError(err).Error("wait exec container's task")
 		return
 	}
+
+	if err := task.Start(ctx); err != nil {
+		logrus.WithError(err).Error("exec container start failure")
+		return
+	}
+
 	spec, err := c.Spec(ctx)
 	if err != nil {
 		logrus.WithError(err).Error("failed to get spec")


### PR DESCRIPTION
For some runtimes, the container is not ready for exec until the
container's task has been started (as opposed to just having the task created).

More specifically, running containerd-stress with --exec would break
with Kata Container shim, since the sandbox is not created until a
start is issued. By starting the container's primary task before adding
exec's, we can avoid:
```
error="cannot enter container exec-container-1, with err Sandbox not running, impossible to enter the container: unknown"
```

Signed-off-by: Eric Ernst <eric_ernst@apple.com>