### PR TITLE
fix: .dockerignore make git working tree dirty

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,0 @@
-.github/
-.dockerignore
-releases/
-bin/

--- a/.github/workflows/release/Dockerfile
+++ b/.github/workflows/release/Dockerfile
@@ -50,5 +50,10 @@ RUN \
 	make release cri-release cri-cni-release && \
 	for f in $(find bin -executable -type f); do xx-verify $f; done
 
+# check git working tree after build
+RUN \
+	export GIT_STATUS_OUTPUT=$(git status --porcelain) && \
+	test -z $GIT_STATUS_OUTPUT || (echo $GIT_STATUS_OUTPUT && exit 1)
+
 FROM scratch AS release
 COPY --from=target /go/src/github.com/containerd/containerd/releases/ /


### PR DESCRIPTION
The .github/workflows/release/Dockerfile will use working dir as docker
build context. But the .dockerignore will ignore the .github/release/...
and cause dirty. We should remove it and verify git working tree after
build.

Fix: #6484

Signed-off-by: Wei Fu <fuweid89@gmail.com>