### PR TITLE
[release/1.5] Update Go to 1.16.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.16.12]
+        go-version: [1.16.13]
         os: [ubuntu-18.04, macos-10.15, windows-2019]
 
     steps:
@@ -56,7 +56,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.12'
+          go-version: '1.16.13'
 
       - shell: bash
         run: |
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.12'
+          go-version: '1.16.13'
 
       - uses: actions/checkout@v2
         with:
@@ -120,7 +120,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.12'
+          go-version: '1.16.13'
 
       - name: Set env
         shell: bash
@@ -166,7 +166,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.12'
+          go-version: '1.16.13'
       - name: Set env
         shell: bash
         run: |
@@ -231,7 +231,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-10.15, windows-2019]
-        go-version: ['1.16.12']
+        go-version: ['1.16.13']
         include:
           # Go 1.13.x is still used by Docker/Moby
           - go-version: '1.13.x'
@@ -277,7 +277,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.12'
+          go-version: '1.16.13'
 
       - uses: actions/checkout@v2
         with:
@@ -358,7 +358,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.12'
+          go-version: '1.16.13'
 
       - uses: actions/checkout@v2
         with:
@@ -510,7 +510,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.12'
+          go-version: '1.16.13'
       - uses: actions/checkout@v2
         with:
           path: src/github.com/containerd/containerd

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.12'
+          go-version: '1.16.13'
 
       - uses: actions/checkout@v2
         with:
@@ -135,7 +135,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.12'
+          go-version: '1.16.13'
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16.12'
+          go-version: '1.16.13'
 
       - name: Set env
         shell: bash

--- a/.zuul/playbooks/containerd-build/integration-test.yaml
+++ b/.zuul/playbooks/containerd-build/integration-test.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.16.12'
+    go_version: '1.16.13'
     arch: arm64
   tasks:
   - name: Install pre-requisites

--- a/.zuul/playbooks/containerd-build/run.yaml
+++ b/.zuul/playbooks/containerd-build/run.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.16.12'
+    go_version: '1.16.13'
     arch: arm64
   tasks:
   - name: Build containerd

--- a/.zuul/playbooks/containerd-build/unit-test.yaml
+++ b/.zuul/playbooks/containerd-build/unit-test.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.16.12'
+    go_version: '1.16.13'
     arch: arm64
   tasks:
   - name: Build and test containerd

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,7 +77,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.16.12",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.16.13",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -10,7 +10,7 @@
 #
 # docker build -t containerd-test --build-arg RUNC_VERSION=v1.0.0-rc93 -f Dockerfile.test ../
 
-ARG GOLANG_VERSION=1.16.12
+ARG GOLANG_VERSION=1.16.13
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd


### PR DESCRIPTION
go1.16.13 (released 2022-01-06) includes fixes to the compiler, linker, runtime,
and the net/http package. See the Go 1.16.13 milestone on our issue tracker for
details:

https://github.com/golang/go/issues?q=milestone%3AGo1.16.13+label%3ACherryPickApproved
