### PR TITLE
[release/1.4] Update Go to 1.16.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16.13'
+          go-version: '1.16.14'
 
       - name: Set env
         shell: bash
@@ -82,7 +82,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.13'
+          go-version: '1.16.14'
 
       - name: Set env
         shell: bash
@@ -128,7 +128,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.13'
+          go-version: '1.16.14'
 
       - name: Set env
         shell: bash
@@ -166,7 +166,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.13'
+          go-version: '1.16.14'
 
       - name: Set env
         shell: bash
@@ -199,7 +199,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.13'
+          go-version: '1.16.14'
 
       - name: Set env
         shell: bash
@@ -285,7 +285,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.13'
+          go-version: '1.16.14'
 
       - name: Set env
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16.12'
+          go-version: '1.16.13'
 
       - name: Set env
         shell: bash
@@ -82,7 +82,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.12'
+          go-version: '1.16.13'
 
       - name: Set env
         shell: bash
@@ -128,7 +128,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.12'
+          go-version: '1.16.13'
 
       - name: Set env
         shell: bash
@@ -166,7 +166,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.12'
+          go-version: '1.16.13'
 
       - name: Set env
         shell: bash
@@ -199,7 +199,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.12'
+          go-version: '1.16.13'
 
       - name: Set env
         shell: bash
@@ -285,7 +285,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.12'
+          go-version: '1.16.13'
 
       - name: Set env
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.12'
+          go-version: '1.16.13'
 
       - name: Checkout
         uses: actions/checkout@v1
@@ -138,7 +138,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.12'
+          go-version: '1.16.13'
 
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.13'
+          go-version: '1.16.14'
 
       - name: Checkout
         uses: actions/checkout@v1
@@ -138,7 +138,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.13'
+          go-version: '1.16.14'
 
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16.12'
+          go-version: '1.16.13'
 
       - name: Set env
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16.13'
+          go-version: '1.16.14'
 
       - name: Set env
         shell: bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ os:
 - linux
 
 go:
-  - "1.16.13"
+  - "1.16.14"
 
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ os:
 - linux
 
 go:
-  - "1.16.12"
+  - "1.16.13"
 
 env:
   - TRAVIS_GOOS=linux TEST_RUNTIME=io.containerd.runc.v1 TRAVIS_CGO_ENABLED=1 TRAVIS_DISTRO=bionic GOPROXY=direct

--- a/.zuul/playbooks/containerd-build/run.yaml
+++ b/.zuul/playbooks/containerd-build/run.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.16.13'
+    go_version: '1.16.14'
     arch: arm64
   tasks:
   - name: Build containerd

--- a/.zuul/playbooks/containerd-build/run.yaml
+++ b/.zuul/playbooks/containerd-build/run.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.16.12'
+    go_version: '1.16.13'
     arch: arm64
   tasks:
   - name: Build containerd

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,7 +77,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.16.13",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.16.14",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,7 +77,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.16.12",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.16.13",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -10,7 +10,7 @@
 #
 # docker build -t containerd-test --build-arg RUNC_VERSION=v1.0.0-rc93 -f Dockerfile.test ../
 
-ARG GOLANG_VERSION=1.16.12
+ARG GOLANG_VERSION=1.16.13
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -10,7 +10,7 @@
 #
 # docker build -t containerd-test --build-arg RUNC_VERSION=v1.0.0-rc93 -f Dockerfile.test ../
 
-ARG GOLANG_VERSION=1.16.13
+ARG GOLANG_VERSION=1.16.14
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd

--- a/script/setup/install-critools
+++ b/script/setup/install-critools
@@ -20,7 +20,8 @@
 #
 set -eu -o pipefail
 
-go get -u github.com/onsi/ginkgo/ginkgo
+GO111MODULE=on go install github.com/onsi/ginkgo/ginkgo@v1.16.5
+
 CRITEST_COMMIT=53ad8bb7f97e1b1d1c0c0634e43a3c2b8b07b718
 git clone https://github.com/kubernetes-sigs/cri-tools.git "$GOPATH"/src/github.com/kubernetes-sigs/cri-tools
 cd "$GOPATH"/src/github.com/kubernetes-sigs/cri-tools

--- a/script/setup/install-dev-tools
+++ b/script/setup/install-dev-tools
@@ -20,15 +20,13 @@
 #
 set -eu -o pipefail
 
-# install the `protobuild` binary in $GOPATH/bin; requires module-aware install
-# to pin dependencies
-GO111MODULE=on go get github.com/stevvooe/protobuild
+# install `protobuild` and other commands
+GO111MODULE=on go install github.com/stevvooe/protobuild@v0.1.0
+GO111MODULE=on go install github.com/cpuguy83/go-md2man/v2@v2.0.0
+GO111MODULE=on go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.23.8
 
 # the following packages need to exist in $GOPATH so we can't use
 # go modules-aware mode of `go get` for these includes used during
 # proto building
 GO111MODULE=off go get -d github.com/gogo/googleapis || true
 GO111MODULE=off go get -d github.com/gogo/protobuf || true
-
-GO111MODULE=on go get github.com/cpuguy83/go-md2man/v2@v2.0.0
-GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.23.8


### PR DESCRIPTION
### Update Go to 1.16.14

Includes security fixes for crypto/elliptic (CVE-2022-23806), math/big (CVE-2022-23772),
and cmd/go (CVE-2022-23773).

go1.16.14 (released 2022-02-10) includes security fixes to the crypto/elliptic,
math/big packages and to the go command, as well as bug fixes to the compiler,
linker, runtime, the go command, and the debug/macho, debug/pe, net/http/httptest,
and testing packages. See the Go 1.16.14 milestone on our issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.16.14+label%3ACherryPickApproved

full diff: https://github.com/golang/go/compare/go1.16.13...go1.16.14

### Update Go to 1.16.13

go1.16.13 (released 2022-01-06) includes fixes to the compiler, linker, runtime,
and the net/http package. See the Go 1.16.13 milestone on our issue tracker for
details:

https://github.com/golang/go/issues?q=milestone%3AGo1.16.13+label%3ACherryPickApproved
