### PR TITLE
containerd-stress: introduce option for specifying image

### DIFF
--- a/cmd/containerd-stress/density.go
+++ b/cmd/containerd-stress/density.go
@@ -52,6 +52,7 @@ var densityCommand = cli.Command{
 			Duration:    cliContext.GlobalDuration("duration"),
 			Concurrency: cliContext.GlobalInt("concurrent"),
 			Exec:        cliContext.GlobalBool("exec"),
+			Image:       cliContext.GlobalString("image"),
 			JSON:        cliContext.GlobalBool("json"),
 			Metrics:     cliContext.GlobalString("metrics"),
 			Snapshotter: cliContext.GlobalString("snapshotter"),
@@ -65,8 +66,8 @@ var densityCommand = cli.Command{
 		if err := cleanup(ctx, client); err != nil {
 			return err
 		}
-		logrus.Infof("pulling %s", imageName)
-		image, err := client.Pull(ctx, imageName, containerd.WithPullUnpack, containerd.WithPullSnapshotter(config.Snapshotter))
+		logrus.Infof("pulling %s", config.Image)
+		image, err := client.Pull(ctx, config.Image, containerd.WithPullUnpack, containerd.WithPullSnapshotter(config.Snapshotter))
 		if err != nil {
 			return err
 		}

--- a/cmd/containerd-stress/main.go
+++ b/cmd/containerd-stress/main.go
@@ -36,8 +36,6 @@ import (
 	"github.com/urfave/cli"
 )
 
-const imageName = "docker.io/library/alpine:latest"
-
 var (
 	ct              metrics.LabeledTimer
 	execTimer       metrics.LabeledTimer
@@ -136,6 +134,11 @@ func main() {
 			Name:  "exec",
 			Usage: "add execs to the stress tests",
 		},
+		cli.StringFlag{
+			Name:  "image,i",
+			Value: "docker.io/library/alpine:latest",
+			Usage: "image to be utilized for testing",
+		},
 		cli.BoolFlag{
 			Name:  "json,j",
 			Usage: "output results in json format",
@@ -173,6 +176,7 @@ func main() {
 			Duration:    context.GlobalDuration("duration"),
 			Concurrency: context.GlobalInt("concurrent"),
 			Exec:        context.GlobalBool("exec"),
+			Image:       context.GlobalString("image"),
 			JSON:        context.GlobalBool("json"),
 			Metrics:     context.GlobalString("metrics"),
 			Runtime:     context.GlobalString("runtime"),
@@ -194,6 +198,7 @@ type config struct {
 	Duration    time.Duration
 	Address     string
 	Exec        bool
+	Image       string
 	JSON        bool
 	Metrics     string
 	Runtime     string
@@ -228,8 +233,8 @@ func test(c config) error {
 	if err := cleanup(ctx, client); err != nil {
 		return err
 	}
-	logrus.Infof("pulling %s", imageName)
-	image, err := client.Pull(ctx, imageName, containerd.WithPullUnpack, containerd.WithPullSnapshotter(c.Snapshotter))
+	logrus.Infof("pulling %s", c.Image)
+	image, err := client.Pull(ctx, c.Image, containerd.WithPullUnpack, containerd.WithPullSnapshotter(c.Snapshotter))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
allow user to specify what image should be used for containerd-stress.

Signed-off-by: Eric Ernst <eric_ernst@apple.com>