### PR TITLE
Change the context to avoid misunderstandings in architecture.md.

### DIFF
--- a/docs/cri/architecture.md
+++ b/docs/cri/architecture.md
@@ -9,7 +9,7 @@ The `cri` plugin uses containerd to manage the full container lifecycle and all 
 
 Let's use an example to demonstrate how the `cri` plugin works for the case when Kubelet creates a single-container pod:
 * Kubelet calls the `cri` plugin, via the CRI runtime service API, to create a pod;
-* `cri` creates and configures the pod’s network namespace using CNI;
+* `cri` creates the pod’s network namespace, and then configures it using CNI;
 * `cri` uses containerd internal to create and start a special [pause container](https://www.ianlewis.org/en/almighty-pause-container) (the sandbox container) and put that container inside the pod’s cgroups and namespace (steps omitted for brevity);
 * Kubelet subsequently calls the `cri` plugin, via the CRI image service API, to pull the application container image;
 * `cri` further uses containerd to pull the image if the image is not present on the node;


### PR DESCRIPTION

I think the following context is misleading in architecture.md.
 > `cri` creates and configures the pod’s network namespace using CNI;

cri creates the network namespace by itself, and then configures it using CNI; cri does not create the netns "with CNI".
So it should be better to change the wording for reducing misunderstarndings.

### Note
I've confirmed the current implement shows "cri creates the pod’s network namespace, and then configures it using CNI".
https://github.com/containerd/containerd/blob/77d53d2d230c3bcd3f02e6f493019a72905c875b/pkg/cri/server/sandbox_run.go#L127-L170

Previous commit to  architecture.md : https://github.com/containerd/cri/commit/c88e18b907f10ce10aa395631d80fd7ec41d36f3
```diff
+ * `cri` creates and configures the pod’s network namespace using CNI;
- * `cri` configures the pod’s network namespace using CNI;
```