### PR TITLE
runtime: revert part of #6206

### DIFF
--- a/runtime/v2/binary.go
+++ b/runtime/v2/binary.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	gruntime "runtime"
 	"strings"
 
@@ -127,10 +126,6 @@ func (b *binary) Start(ctx context.Context, opts *types.Any, onClose func()) (_ 
 		onClose()
 		cancelShimLog()
 		f.Close()
-	}
-	// Save runtime binary path for restore.
-	if err := os.WriteFile(filepath.Join(b.bundle.Path, "runtime"), []byte(b.runtime), 0600); err != nil {
-		return nil, err
 	}
 	client := ttrpc.NewClient(conn, ttrpc.WithOnClose(onCloseWithShimLog))
 	return &shim{

--- a/runtime/v2/shim_load.go
+++ b/runtime/v2/shim_load.go
@@ -89,32 +89,17 @@ func (m *ShimManager) loadShims(ctx context.Context) error {
 			continue
 		}
 
-		var (
-			runtime string
-		)
-
-		// If we're on 1.6+ and specified custom path to the runtime binary, path will be saved in 'runtime' file.
-		if data, err := os.ReadFile(filepath.Join(bundle.Path, "runtime")); err == nil {
-			runtime = string(data)
-		} else if err != nil && !os.IsNotExist(err) {
-			log.G(ctx).WithError(err).Error("failed to read `runtime` path from bundle")
-		}
-
-		// Query runtime name from metadata store
-		if runtime == "" {
-			container, err := m.containers.Get(ctx, id)
-			if err != nil {
-				log.G(ctx).WithError(err).Errorf("loading container %s", id)
-				if err := mount.UnmountAll(filepath.Join(bundle.Path, "rootfs"), 0); err != nil {
-					log.G(ctx).WithError(err).Errorf("failed to unmount of rootfs %s", id)
-				}
-				bundle.Delete()
-				continue
+		container, err := m.containers.Get(ctx, id)
+		if err != nil {
+			log.G(ctx).WithError(err).Errorf("loading container %s", id)
+			if err := mount.UnmountAll(filepath.Join(bundle.Path, "rootfs"), 0); err != nil {
+				log.G(ctx).WithError(err).Errorf("failed to unmount of rootfs %s", id)
 			}
-			runtime = container.Runtime.Name
+			bundle.Delete()
+			continue
 		}
 
-		runtime, err = m.resolveRuntimePath(runtime)
+		runtime, err := m.resolveRuntimePath(container.Runtime.Name)
 		if err != nil {
 			bundle.Delete()
 			log.G(ctx).WithError(err).Error("failed to resolve runtime path")


### PR DESCRIPTION
 runtime: revert part of #6206
    
 In container bundle, the `runtime` file has been reserved for runtime's
`BinaryName` like runc or crun [1]. In #6206, we supported to use
 absolute path as shim runtime name and also stored it in `runtime`
 file[2]. It will be conflict if user wants to use BinaryName instead of
 empty default value.
    
 Before we figure out new filename for shim binary path, I would like to
 revert the code from #6206 because the information has been stored in
 container store service. If the shim runtime is absolute binary path,
 we can just read it from container store service. If it is normal shim name
 like `io.containerd.runc.v2`, we need to resolve it into binary path again,
 which is the same to before pr #6206.
    
    
 [1]: https://github.com/containerd/containerd/commit/6bcbf88f82e814f76ede351f48b57613540af425
 [2]: https://github.com/containerd/containerd/pull/6206
    
 Fixes: #6534

Signed-off-by: Wei Fu <fuweid89@gmail.com>