### PR TITLE
Wait for containerd installation in GCE scripts [1.5 backport]

### DIFF
--- a/contrib/gce/cloud-init/master.yaml
+++ b/contrib/gce/cloud-init/master.yaml
@@ -75,7 +75,8 @@ write_files:
     content: |
       [Unit]
       Description=Download and install k8s binaries and configurations
-      After=network-online.target
+      After=network-online.target containerd.target
+      Wants=network-online.target containerd.target
 
       [Service]
       Type=oneshot

--- a/contrib/gce/cloud-init/node.yaml
+++ b/contrib/gce/cloud-init/node.yaml
@@ -69,7 +69,8 @@ write_files:
     content: |
       [Unit]
       Description=Download and install k8s binaries and configurations
-      After=network-online.target
+      After=network-online.target containerd.target
+      Wants=network-online.target containerd.target
 
       [Service]
       Type=oneshot


### PR DESCRIPTION
This cherrypicks https://github.com/containerd/containerd/pull/6544 to `release-1.5` branch. This will only affect k/k CI and e2e tests. 

Prior to running the `kube-node-installation.service`, the containerd
installation should be complete as the k8s installation may have
dependencies on containerd and related binaries (e.g ctr). Add
wants/after systemd directives to ensure
`kube-node-installation.service` will only start after containerd
installation completes.

Signed-off-by: David Porter <porterdavid@google.com>