### PR TITLE
Upgrade containerd/cgroups

### DIFF
--- a/cmd/ctr/commands/tasks/metrics.go
+++ b/cmd/ctr/commands/tasks/metrics.go
@@ -24,8 +24,8 @@ import (
 	"text/tabwriter"
 
 	wstats "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats"
-	v1 "github.com/containerd/cgroups/stats/v1"
-	v2 "github.com/containerd/cgroups/v2/stats"
+	v2 "github.com/containerd/cgroups/v2/cgroup2/stats"
+	v1 "github.com/containerd/cgroups/v2/stats/v1"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/typeurl"
 	"github.com/urfave/cli"

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/container-orchestrated-devices/container-device-interface v0.5.1
 	github.com/containerd/aufs v1.0.0
 	github.com/containerd/btrfs v1.0.0
-	github.com/containerd/cgroups v1.0.5-0.20220816231112-7083cd60b721
+	github.com/containerd/cgroups/v2 v2.0.0-20221108021732-3e546aa1dbb0
 	github.com/containerd/console v1.0.3
 	github.com/containerd/continuity v0.3.0
 	github.com/containerd/fifo v1.0.0
@@ -85,6 +85,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/cilium/ebpf v0.9.1 // indirect
+	github.com/containerd/cgroups v1.0.3 // indirect
 	github.com/containers/ocicrypt v1.1.3 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -196,9 +196,10 @@ github.com/containerd/cgroups v0.0.0-20200710171044-318312a37340/go.mod h1:s5q4S
 github.com/containerd/cgroups v0.0.0-20200824123100-0b889c03f102/go.mod h1:s5q4SojHctfxANBDvMeIaIovkq29IP48TKAxnhYRxvo=
 github.com/containerd/cgroups v0.0.0-20210114181951-8a68de567b68/go.mod h1:ZJeTFisyysqgcCdecO57Dj79RfL0LNeGiFUqLYQRYLE=
 github.com/containerd/cgroups v1.0.1/go.mod h1:0SJrPIenamHDcZhEcJMNBB85rHcUsw4f25ZfBiPYRkU=
+github.com/containerd/cgroups v1.0.3 h1:ADZftAkglvCiD44c77s5YmMqaP2pzVCFZvBmAlBdAP4=
 github.com/containerd/cgroups v1.0.3/go.mod h1:/ofk34relqNjSGyqPrmEULrO4Sc8LJhvJmWbUCUKqj8=
-github.com/containerd/cgroups v1.0.5-0.20220816231112-7083cd60b721 h1:qWq0iv560E8jXZKwWipx3Xot0dYPyfKBeDNfRwYth/U=
-github.com/containerd/cgroups v1.0.5-0.20220816231112-7083cd60b721/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
+github.com/containerd/cgroups/v2 v2.0.0-20221108021732-3e546aa1dbb0 h1:mVq/CHJ5Nz6VbWW+dJ1wI/p0T3FZBrP+uJzQtAFwHFQ=
+github.com/containerd/cgroups/v2 v2.0.0-20221108021732-3e546aa1dbb0/go.mod h1:nno7catpBPPU5fP1B4f1c1B5B5v8VTs+U2z62ZsTzSE=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/console v0.0.0-20181022165439-0650fd9eeb50/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/console v0.0.0-20191206165004-02ecf6a7291e/go.mod h1:8Pf4gM6VEbTNRIT26AyyU7hxdQU3MvAvxVI0sc00XBE=

--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -30,8 +30,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/cgroups"
-	cgroupsv2 "github.com/containerd/cgroups/v2"
+	"github.com/containerd/cgroups/v2"
+	cgroupsv2 "github.com/containerd/cgroups/v2/cgroup2"
 	. "github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/containers"

--- a/integration/client/daemon_config_linux_test.go
+++ b/integration/client/daemon_config_linux_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/cgroups"
+	"github.com/containerd/cgroups/v2"
 	. "github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/plugin"

--- a/integration/container_update_resources_test.go
+++ b/integration/container_update_resources_test.go
@@ -26,8 +26,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/containerd/cgroups"
-	cgroupsv2 "github.com/containerd/cgroups/v2"
+	"github.com/containerd/cgroups/v2"
+	cgroupsv2 "github.com/containerd/cgroups/v2/cgroup2"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/integration/images"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"

--- a/metrics/cgroups/cgroups.go
+++ b/metrics/cgroups/cgroups.go
@@ -20,7 +20,7 @@
 package cgroups
 
 import (
-	"github.com/containerd/cgroups"
+	"github.com/containerd/cgroups/v2"
 	"github.com/containerd/containerd/events"
 	v1 "github.com/containerd/containerd/metrics/cgroups/v1"
 	v2 "github.com/containerd/containerd/metrics/cgroups/v2"

--- a/metrics/cgroups/metrics_test.go
+++ b/metrics/cgroups/metrics_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/cgroups"
+	"github.com/containerd/cgroups/v2"
 	"github.com/containerd/containerd/metrics/cgroups/common"
 	v1 "github.com/containerd/containerd/metrics/cgroups/v1"
 	v2 "github.com/containerd/containerd/metrics/cgroups/v2"

--- a/metrics/cgroups/v1/cgroups.go
+++ b/metrics/cgroups/v1/cgroups.go
@@ -22,7 +22,7 @@ package v1
 import (
 	"context"
 
-	"github.com/containerd/cgroups"
+	"github.com/containerd/cgroups/v2"
 	eventstypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/events"

--- a/metrics/cgroups/v1/metrics.go
+++ b/metrics/cgroups/v1/metrics.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/containerd/cgroups"
+	"github.com/containerd/cgroups/v2"
 	"github.com/containerd/containerd/log"
 	cmetrics "github.com/containerd/containerd/metrics"
 	"github.com/containerd/containerd/metrics/cgroups/common"

--- a/metrics/cgroups/v1/oom.go
+++ b/metrics/cgroups/v1/oom.go
@@ -25,7 +25,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	"github.com/containerd/cgroups"
+	"github.com/containerd/cgroups/v2"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"

--- a/metrics/types/v1/types.go
+++ b/metrics/types/v1/types.go
@@ -20,7 +20,7 @@
 package v1
 
 import (
-	v1 "github.com/containerd/cgroups/stats/v1"
+	v1 "github.com/containerd/cgroups/v2/stats/v1"
 )
 
 type (

--- a/metrics/types/v2/types.go
+++ b/metrics/types/v2/types.go
@@ -20,7 +20,7 @@
 package v2
 
 import (
-	v2 "github.com/containerd/cgroups/v2/stats"
+	v2 "github.com/containerd/cgroups/v2/cgroup2/stats"
 )
 
 type (

--- a/pkg/cri/sbserver/container_create_linux.go
+++ b/pkg/cri/sbserver/container_create_linux.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/containerd/cgroups"
+	"github.com/containerd/cgroups/v2"
 	"github.com/containerd/containerd/contrib/apparmor"
 	"github.com/containerd/containerd/contrib/seccomp"
 	"github.com/containerd/containerd/oci"

--- a/pkg/cri/sbserver/container_stats_list_linux_test.go
+++ b/pkg/cri/sbserver/container_stats_list_linux_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 	"time"
 
-	v1 "github.com/containerd/cgroups/stats/v1"
-	v2 "github.com/containerd/cgroups/v2/stats"
+	v2 "github.com/containerd/cgroups/v2/cgroup2/stats"
+	v1 "github.com/containerd/cgroups/v2/stats/v1"
 	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
 	"github.com/stretchr/testify/assert"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"

--- a/pkg/cri/sbserver/sandbox_stats_linux.go
+++ b/pkg/cri/sbserver/sandbox_stats_linux.go
@@ -24,8 +24,8 @@ import (
 	"github.com/containernetworking/plugins/pkg/ns"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
-	"github.com/containerd/cgroups"
-	cgroupsv2 "github.com/containerd/cgroups/v2"
+	"github.com/containerd/cgroups/v2"
+	cgroupsv2 "github.com/containerd/cgroups/v2/cgroup2"
 
 	"github.com/vishvananda/netlink"
 

--- a/pkg/cri/server/container_create_linux.go
+++ b/pkg/cri/server/container_create_linux.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/containerd/cgroups"
+	"github.com/containerd/cgroups/v2"
 	"github.com/containerd/containerd/contrib/apparmor"
 	"github.com/containerd/containerd/contrib/seccomp"
 	"github.com/containerd/containerd/oci"

--- a/pkg/cri/server/container_stats_list_linux_test.go
+++ b/pkg/cri/server/container_stats_list_linux_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 	"time"
 
-	v1 "github.com/containerd/cgroups/stats/v1"
-	v2 "github.com/containerd/cgroups/v2/stats"
+	v2 "github.com/containerd/cgroups/v2/cgroup2/stats"
+	v1 "github.com/containerd/cgroups/v2/stats/v1"
 	"github.com/stretchr/testify/assert"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )

--- a/pkg/cri/server/sandbox_stats_linux.go
+++ b/pkg/cri/server/sandbox_stats_linux.go
@@ -24,8 +24,8 @@ import (
 	"github.com/containernetworking/plugins/pkg/ns"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
-	"github.com/containerd/cgroups"
-	cgroupsv2 "github.com/containerd/cgroups/v2"
+	"github.com/containerd/cgroups/v2"
+	cgroupsv2 "github.com/containerd/cgroups/v2/cgroup2"
 
 	"github.com/vishvananda/netlink"
 

--- a/runtime/opts/opts_linux.go
+++ b/runtime/opts/opts_linux.go
@@ -19,8 +19,8 @@ package opts
 import (
 	"context"
 
-	"github.com/containerd/cgroups"
-	cgroupsv2 "github.com/containerd/cgroups/v2"
+	"github.com/containerd/cgroups/v2"
+	cgroupsv2 "github.com/containerd/cgroups/v2/cgroup2"
 	"github.com/containerd/containerd/namespaces"
 )
 

--- a/runtime/v1/linux/task.go
+++ b/runtime/v1/linux/task.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/containerd/cgroups"
+	"github.com/containerd/cgroups/v2"
 	eventstypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/events/exchange"

--- a/runtime/v2/runc/container.go
+++ b/runtime/v2/runc/container.go
@@ -27,8 +27,8 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/containerd/cgroups"
-	cgroupsv2 "github.com/containerd/cgroups/v2"
+	"github.com/containerd/cgroups/v2"
+	cgroupsv2 "github.com/containerd/cgroups/v2/cgroup2"
 	"github.com/containerd/console"
 	"github.com/containerd/containerd/api/runtime/task/v2"
 	"github.com/containerd/containerd/errdefs"

--- a/runtime/v2/runc/manager/manager_linux.go
+++ b/runtime/v2/runc/manager/manager_linux.go
@@ -27,8 +27,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/containerd/cgroups"
-	cgroupsv2 "github.com/containerd/cgroups/v2"
+	"github.com/containerd/cgroups/v2"
+	cgroupsv2 "github.com/containerd/cgroups/v2/cgroup2"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/namespaces"

--- a/runtime/v2/runc/task/service.go
+++ b/runtime/v2/runc/task/service.go
@@ -25,8 +25,8 @@ import (
 	"os"
 	"sync"
 
-	"github.com/containerd/cgroups"
-	cgroupsv2 "github.com/containerd/cgroups/v2"
+	"github.com/containerd/cgroups/v2"
+	cgroupsv2 "github.com/containerd/cgroups/v2/cgroup2"
 	eventstypes "github.com/containerd/containerd/api/events"
 	taskAPI "github.com/containerd/containerd/api/runtime/task/v2"
 	"github.com/containerd/containerd/api/types/task"

--- a/runtime/v2/runc/v1/service.go
+++ b/runtime/v2/runc/v1/service.go
@@ -30,7 +30,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/containerd/cgroups"
+	"github.com/containerd/cgroups/v2"
 	eventstypes "github.com/containerd/containerd/api/events"
 	taskAPI "github.com/containerd/containerd/api/runtime/task/v2"
 	"github.com/containerd/containerd/api/types/task"

--- a/services/server/server_linux.go
+++ b/services/server/server_linux.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"os"
 
-	"github.com/containerd/cgroups"
-	cgroupsv2 "github.com/containerd/cgroups/v2"
+	"github.com/containerd/cgroups/v2"
+	cgroupsv2 "github.com/containerd/cgroups/v2/cgroup2"
 	"github.com/containerd/containerd/log"
 	srvconfig "github.com/containerd/containerd/services/server/config"
 	"github.com/containerd/containerd/sys"


### PR DESCRIPTION
I wonder we can consume gogo-less containerd/cgroups without upgrading the rest.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>