### PR TITLE
Update TestContainerSymlinkVolumes to use windows path

### DIFF
--- a/integration/container_volume_test.go
+++ b/integration/container_volume_test.go
@@ -19,6 +19,7 @@ package integration
 import (
 	"os"
 	"path/filepath"
+	goruntime "runtime"
 	"testing"
 	"time"
 
@@ -103,9 +104,14 @@ func TestContainerSymlinkVolumes(t *testing.T) {
 			)
 
 			var (
-				testImage     = GetImage(BusyBox)
-				containerName = "test-container"
+				testImage          = GetImage(BusyBox)
+				containerName      = "test-container"
+				containerMountPath = "/mounted_file"
 			)
+
+			if goruntime.GOOS == "windows" {
+				containerMountPath = filepath.Clean("C:" + containerMountPath)
+			}
 
 			EnsureImageExists(t, testImage)
 
@@ -113,9 +119,9 @@ func TestContainerSymlinkVolumes(t *testing.T) {
 			cnConfig := ContainerConfig(
 				containerName,
 				testImage,
-				WithCommand("cat", "/mounted_file"),
+				WithCommand("cat", containerMountPath),
 				WithLogPath(containerName),
-				WithVolumeMount(file, "/mounted_file"),
+				WithVolumeMount(file, containerMountPath),
 			)
 
 			cn, err := runtimeService.CreateContainer(sb, cnConfig, sbConfig)


### PR DESCRIPTION
When mounting a file from the host into a container on windows, the container mount path must resolve to the form "C:/path" or starting the container will fail. If these tests are run from a drive other than the C:/ drive on the host, the path will not be resolved in the expected form, causing failures. This PR updates TestContainerSymlinkVolumes to explicitly mount the expected file on the C drive of the container when running on windows. 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>