### PR TITLE
Update TestNormalize to only test Windows platform

### DIFF
--- a/platforms/platforms_test.go
+++ b/platforms/platforms_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/stretchr/testify/require"
 )
 
 func TestParseSelector(t *testing.T) {
@@ -364,8 +363,4 @@ func TestParseSelectorInvalid(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestNormalize(t *testing.T) {
-	require.Equal(t, DefaultSpec(), Normalize(DefaultSpec()))
 }

--- a/platforms/platforms_windows_test.go
+++ b/platforms/platforms_windows_test.go
@@ -1,0 +1,27 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package platforms
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalize(t *testing.T) {
+	require.Equal(t, DefaultSpec(), Normalize(DefaultSpec()))
+}


### PR DESCRIPTION
The output of `platforms.DefaultSpec()` and the normalized version of the
default platform on 32- and 64-bit ARM are not comparable. This test
was added to validate not losing Windows-specific information during
normalize of the platform object, so for now we are moving this to be a
Windows-only test until we resolve the right behavior on ARM.

I noticed that tests on ARM64 were failing and found that #6497 added this
test; I also verified in the openlab test logs this is the new failure.

// cc: @thaJeztah 

Signed-off-by: Phil Estes <estesp@amazon.com>