### PR TITLE
[release/1.6] runc.v1/v2: return init pid when clean dead shim

### DIFF
--- a/runtime/v2/runc/manager/manager_linux.go
+++ b/runtime/v2/runc/manager/manager_linux.go
@@ -270,8 +270,13 @@ func (manager) Stop(ctx context.Context, id string) (shim.StopStatus, error) {
 	if err := mount.UnmountAll(filepath.Join(path, "rootfs"), 0); err != nil {
 		log.G(ctx).WithError(err).Warn("failed to cleanup rootfs mount")
 	}
+	pid, err := runcC.ReadPidFile(filepath.Join(path, process.InitPidFile))
+	if err != nil {
+		log.G(ctx).WithError(err).Warn("failed to read init pid file")
+	}
 	return shim.StopStatus{
 		ExitedAt:   time.Now(),
 		ExitStatus: 128 + int(unix.SIGKILL),
+		Pid:        pid,
 	}, nil
 }

--- a/runtime/v2/runc/v1/service.go
+++ b/runtime/v2/runc/v1/service.go
@@ -259,9 +259,16 @@ func (s *service) Cleanup(ctx context.Context) (*taskAPI.DeleteResponse, error) 
 	if err := mount.UnmountAll(filepath.Join(path, "rootfs"), 0); err != nil {
 		logrus.WithError(err).Warn("failed to cleanup rootfs mount")
 	}
+
+	pid, err := runcC.ReadPidFile(filepath.Join(path, process.InitPidFile))
+	if err != nil {
+		logrus.WithError(err).Warn("failed to read init pid file")
+	}
+
 	return &taskAPI.DeleteResponse{
 		ExitedAt:   time.Now(),
 		ExitStatus: 128 + uint32(unix.SIGKILL),
+		Pid:        uint32(pid),
 	}, nil
 }
 


### PR DESCRIPTION
If containerd-shim-runc-v1/v2 process dead abnormally, such as received
kill 9 signal, panic or other unkown reasons, the containerd-shim-runc-v1/v2
server can not reap runc container and forward init process exit event.
This will lead the container leaked in dockerd. When shim dead, containerd
will clean dead shim, here read init process pid and forward exit event
with pid at the same time.

cherry-pick #6452 and #6571