### PR TITLE
Pin az CLI version to 2.33.1

### DIFF
--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -78,12 +78,14 @@ jobs:
       - name: AZResourceGroupCreate
         uses: azure/CLI@v1
         with:
+          azcliversion: 2.33.1
           inlinescript: |
             az group create -n ${{ matrix.AZURE_RESOURCE_GROUP }} -l ${{ env.AZURE_DEFAULT_LOCATION }} --tags creationTimestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 
       - name: AZTestVMCreate
         uses: azure/CLI@v1
         with:
+          azcliversion: 2.33.1
           inlinescript: |
             DETAILS=$(az vm create -n winTestVM --admin-username ${{ env.DEFAULT_ADMIN_USERNAME }} --admin-password ${{ env.PASSWORD }} --image ${{ matrix.AZURE_IMG }} -g ${{ matrix.AZURE_RESOURCE_GROUP }} --nsg-rule SSH --size ${{ env.AZURE_DEFAULT_VM_SIZE }} --public-ip-sku Standard -o json)
             PUB_IP=$(echo $DETAILS | jq -r .publicIpAddress)
@@ -108,6 +110,7 @@ jobs:
       - name: EnableAZVMSSH
         uses: azure/CLI@v1
         with:
+          azcliversion: 2.33.1
           inlinescript: |
             az vm run-command invoke  --command-id RunPowerShellScript -n winTestVM -g ${{ matrix.AZURE_RESOURCE_GROUP }} --scripts @$GITHUB_WORKSPACE/script/setup/enable_ssh_windows.ps1 --parameters 'SSHPublicKey=${{ env.SSH_PUB_KEY }}'
 
@@ -247,5 +250,6 @@ jobs:
         if: always()
         uses: azure/CLI@v1
         with:
+          azcliversion: 2.33.1
           inlinescript: |
             az group delete -g ${{ matrix.AZURE_RESOURCE_GROUP }} --yes


### PR DESCRIPTION
Due to this bug:

https://docs.microsoft.com/en-us/answers/questions/727655/39vmcustomization39-is-not-enabled-for-the-subscri.html

We must pin the az CLI version to 2.33.1 until the default version is bumped. The current default version is 2.33.0.

Signed-off-by: Gabriel Adrian Samfira <gsamfira@cloudbasesolutions.com>