### PR TITLE
Fix documentation on [plugins."io.containerd.runtime.v1.linux"]

### DIFF
--- a/docs/ops.md
+++ b/docs/ops.md
@@ -203,7 +203,8 @@ See [containerd's Plugin documentation](./PLUGINS.md)
 The linux runtime allows a few options to be set to configure the shim and the runtime that you are using.
 
 ```toml
-[plugins.linux]
+[plugins]
+[plugins."io.containerd.runtime.v1.linux"]
 	# shim binary name/path
 	shim = ""
 	# runtime binary name/path


### PR DESCRIPTION
The docs seem to be out of date, updated using a sample config working on 1.5.8