### PR TITLE
update to go 1.16.15, 1.17.8 to address CVE-2022-24921

### DIFF
--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.7'
+          go-version: '1.17.8'
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.17.7]
+        go-version: [1.17.8]
         os: [ubuntu-18.04, macos-10.15, windows-2019]
 
     steps:
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.7'
+          go-version: '1.17.8'
 
       - uses: actions/checkout@v2
         with:
@@ -78,7 +78,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.7'
+          go-version: '1.17.8'
 
       - uses: actions/checkout@v2
         with:
@@ -110,7 +110,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.7'
+          go-version: '1.17.8'
       - uses: actions/checkout@v2
       - run: go install github.com/cpuguy83/go-md2man/v2@v2.0.1
       - run: make man
@@ -144,7 +144,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.7'
+          go-version: '1.17.8'
       - uses: actions/checkout@v2
       - run: |
           set -e -x
@@ -201,7 +201,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-10.15, windows-2019, windows-2022]
-        go-version: ['1.16.14', '1.17.7']
+        go-version: ['1.16.15', '1.17.8']
 
     steps:
       - uses: actions/setup-go@v2
@@ -248,7 +248,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.7'
+          go-version: '1.17.8'
 
       - uses: actions/checkout@v2
         with:
@@ -330,7 +330,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.7'
+          go-version: '1.17.8'
 
       - uses: actions/checkout@v2
 
@@ -449,7 +449,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.7'
+          go-version: '1.17.8'
       - uses: actions/checkout@v2
       - run: sudo -E PATH=$PATH script/setup/install-gotestsum
       - name: Tests

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: 1.17.7
+        go-version: 1.17.8
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.7'
+          go-version: '1.17.8'
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.7'
+          go-version: '1.17.8'
 
       - uses: actions/checkout@v2
         with:
@@ -135,7 +135,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.7'
+          go-version: '1.17.8'
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17.7'
+          go-version: '1.17.8'
       - name: Set env
         shell: bash
         env:

--- a/.zuul/playbooks/containerd-build/run.yaml
+++ b/.zuul/playbooks/containerd-build/run.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.17.7'
+    go_version: '1.17.8'
     arch: arm64
   tasks:
   - name: Build containerd

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,7 +77,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.17.7",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.17.8",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -10,7 +10,7 @@
 #
 # docker build -t containerd-test --build-arg RUNC_VERSION=v1.0.0-rc94 -f Dockerfile.test ../
 
-ARG GOLANG_VERSION=1.17.7
+ARG GOLANG_VERSION=1.17.8
 ARG GOLANG_IMAGE=golang
 
 FROM ${GOLANG_IMAGE}:${GOLANG_VERSION} AS golang

--- a/script/setup/prepare_env_windows.ps1
+++ b/script/setup/prepare_env_windows.ps1
@@ -1,6 +1,6 @@
 # Prepare windows environment for building and running containerd tests
 
-$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.17.7"; make = ""; nssm = "" }
+$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.17.8"; make = ""; nssm = "" }
 
 Write-Host "Downloading chocolatey package"
 curl.exe -L "https://packages.chocolatey.org/chocolatey.0.10.15.nupkg" -o 'c:\choco.zip'


### PR DESCRIPTION
Addresses [CVE-2022-24921](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24921)

go 1.16.15
--------------------

go1.16.15 (released 2022-03-03) includes a security fix to the regexp/syntax package,
as well as bug fixes to the compiler, runtime, the go command, and to the net package.
See the Go 1.16.15 milestone on the issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.16.15+label%3ACherryPickApproved

full diff: https://github.com/golang/go/compare/go1.16.14...go1.16.15

go 1.17.8
--------------------

go1.17.8 (released 2022-03-03) includes a security fix to the regexp/syntax package,
as well as bug fixes to the compiler, runtime, the go command, and the crypto/x509,
and net packages. See the Go 1.17.8 milestone on the issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.17.8+label%3ACherryPickApproved

full diff: https://github.com/golang/go/compare/go1.17.7...go1.17.8
