### PR TITLE
[release/1.6] cri: relax test for system without hugetlb

### DIFF
--- a/pkg/cri/server/container_update_resources_linux_test.go
+++ b/pkg/cri/server/container_update_resources_linux_test.go
@@ -214,7 +214,7 @@ func TestUpdateOCILinuxResource(t *testing.T) {
 		t.Logf("TestCase %q", desc)
 		config := criconfig.Config{
 			PluginConfig: criconfig.PluginConfig{
-				TolerateMissingHugetlbController: false,
+				TolerateMissingHugetlbController: true,
 				DisableHugetlbController:         false,
 			},
 		}

--- a/pkg/cri/server/service_test.go
+++ b/pkg/cri/server/service_test.go
@@ -55,7 +55,8 @@ func newTestCRIService() *criService {
 			RootDir:  testRootDir,
 			StateDir: testStateDir,
 			PluginConfig: criconfig.PluginConfig{
-				SandboxImage: testSandboxImage,
+				SandboxImage:                     testSandboxImage,
+				TolerateMissingHugetlbController: true,
 			},
 		},
 		imageFSPath:        testImageFSPath,


### PR DESCRIPTION
These unit tests don't check hugetlb. However by setting
TolerateMissingHugetlbController to false, these tests can't
be run on system without hugetlb (e.g. Debian buildd).

Signed-off-by: Shengjing Zhu <zhsj@debian.org>
(cherry picked from commit 352a8f49f7942f588a091ef5c3c49c0c0bb120e8)