### PR TITLE
Run CRI integration tests in GitHub Actions (Windows)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
   integration-windows:
     name: Windows Integration
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 35
+    timeout-minutes: 50
     needs: [project, linters, protos, man]
     env:
       GOTEST: gotestsum --
@@ -280,6 +280,25 @@ jobs:
           git checkout "${SHIM_COMMIT}"
           GO111MODULE=on go build -mod=vendor -o "${bindir}/integration/client/containerd-shim-runhcs-v1.exe" ./cmd/containerd-shim-runhcs-v1
 
+      - run: script/setup/install-cni-windows
+
+      - env:
+          TEST_IMAGE_LIST: ${{github.workspace}}/repolist.toml
+          BUSYBOX_TESTING_IMAGE_REF: "k8s.gcr.io/e2e-test-images/busybox:1.29-2"
+          RESOURCE_CONSUMER_TESTING_IMAGE_REF: "k8s.gcr.io/e2e-test-images/resource-consumer:1.10"
+        run: |
+            cat > "${{ env.TEST_IMAGE_LIST }}" << EOF
+            busybox = "${{ env.BUSYBOX_TESTING_IMAGE_REF }}"
+            ResourceConsumer = "${{ env.RESOURCE_CONSUMER_TESTING_IMAGE_REF }}"
+            EOF
+
+      - name: Set env for prepare_env_windows.ps1
+        shell: bash
+        run: echo "HOME=${USERPROFILE}" >> $GITHUB_ENV
+
+      - shell: powershell
+        run: script/setup/prepare_env_windows.ps1
+
       - run: script/setup/install-gotestsum
       - name: Tests
         env:
@@ -301,6 +320,12 @@ jobs:
           CGO_ENABLED: 1
           GOTESTSUM_JUNITFILE: ${{github.workspace}}/test-integration-parallel-junit.xml
         run: mingw32-make.exe integration
+
+      - name: CRI Integration Test
+        env:
+          TEST_IMAGE_LIST: ${{github.workspace}}/repolist.toml
+        run: |
+          make cri-integration
       - uses: actions/upload-artifact@v2
         if: always()
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
   integration-windows:
     name: Windows Integration
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 55
+    timeout-minutes: 50
     needs: [project, linters, protos, man]
     env:
       GOTEST: gotestsum --
@@ -306,12 +306,14 @@ jobs:
             webServerTestImage: ${{ env.WEBSERVER_TESTING_IMAGE_REF }}
             EOF
 
-      - name: Set env for prepare_env_windows.ps1
-        shell: bash
-        run: echo "HOME=${USERPROFILE}" >> $GITHUB_ENV
-
-      - shell: powershell
-        run: script/setup/prepare_env_windows.ps1
+      - name: Get crictl tool
+        shell: powershell
+        run: |
+          # Get critctl tool. Used for cri-integration tests
+          $CRICTL_DOWNLOAD_URL="https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.21.0/crictl-v1.21.0-windows-amd64.tar.gz"
+          curl.exe -L $CRICTL_DOWNLOAD_URL -o c:\crictl.tar.gz
+          tar -xvf c:\crictl.tar.gz
+          mv crictl.exe "${{ github.workspace }}/bin/crictl.exe" # Move crictl somewhere in path
 
       - run: script/setup/install-gotestsum
       - name: Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
   integration-windows:
     name: Windows Integration
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 50
+    timeout-minutes: 55
     needs: [project, linters, protos, man]
     env:
       GOTEST: gotestsum --
@@ -259,11 +259,17 @@ jobs:
           repository: Microsoft/hcsshim
           path: src/github.com/Microsoft/hcsshim
 
+      - uses: actions/checkout@v2
+        with:
+          repository: kubernetes-sigs/cri-tools
+          path: src/github.com/kubernetes-sigs/cri-tools
+
       - name: Set env
         run: |
           echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
           echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
           echo "${{ github.workspace }}/src/github.com/containerd/containerd/bin" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/src/github.com/kubernetes-sigs/cri-tools/build/bin" >> $GITHUB_PATH
 
       - run: script/setup/install-dev-tools
 
@@ -279,17 +285,25 @@ jobs:
           git fetch --tags origin "${SHIM_COMMIT}"
           git checkout "${SHIM_COMMIT}"
           GO111MODULE=on go build -mod=vendor -o "${bindir}/integration/client/containerd-shim-runhcs-v1.exe" ./cmd/containerd-shim-runhcs-v1
+          cd ../../kubernetes-sigs/cri-tools
+          make critest
 
       - run: script/setup/install-cni-windows
 
       - env:
           TEST_IMAGE_LIST: ${{github.workspace}}/repolist.toml
+          CRI_TEST_IMAGES: ${{github.workspace}}/cri-test-images.yaml
           BUSYBOX_TESTING_IMAGE_REF: "k8s.gcr.io/e2e-test-images/busybox:1.29-2"
           RESOURCE_CONSUMER_TESTING_IMAGE_REF: "k8s.gcr.io/e2e-test-images/resource-consumer:1.10"
+          WEBSERVER_TESTING_IMAGE_REF: "k8s.gcr.io/e2e-test-images/nginx:1.14-2"
         run: |
             cat > "${{ env.TEST_IMAGE_LIST }}" << EOF
             busybox = "${{ env.BUSYBOX_TESTING_IMAGE_REF }}"
             ResourceConsumer = "${{ env.RESOURCE_CONSUMER_TESTING_IMAGE_REF }}"
+            EOF
+            cat > "${{ env.CRI_TEST_IMAGES }}" << EOF
+            defaultTestContainerImage: ${{ env.BUSYBOX_TESTING_IMAGE_REF }}
+            webServerTestImage: ${{ env.WEBSERVER_TESTING_IMAGE_REF }}
             EOF
 
       - name: Set env for prepare_env_windows.ps1
@@ -326,6 +340,16 @@ jobs:
           TEST_IMAGE_LIST: ${{github.workspace}}/repolist.toml
         run: |
           make cri-integration
+
+      - name: cri-tools critest
+        env:
+          CRI_TEST_IMAGES: ${{github.workspace}}/cri-test-images.yaml
+        shell: powershell
+        run: |
+          Start-Process -FilePath containerd.exe -NoNewWindow -RedirectStandardError true -PassThru
+          get-process | sls containerd
+          start-sleep 5
+          critest.exe --runtime-endpoint=npipe://.//pipe//containerd-containerd --test-images-file='${{env.CRI_TEST_IMAGES}}' --report-dir='${{github.workspace}}/critestreport'
       - uses: actions/upload-artifact@v2
         if: always()
         with:

--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -183,7 +183,6 @@ jobs:
            ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }} "sh.exe -s" <<EOF
              cd c:/containerd
              ./script/setup/install-cni-windows
-             mkdir /c/tmp
              export TEST_IMAGE_LIST=c:/repolist.toml
              make cri-integration | tee c:/Logs/cri-integration.log
            EOF

--- a/integration/addition_gids_test.go
+++ b/integration/addition_gids_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestAdditionalGids(t *testing.T) {
-	testPodLogDir, err := os.MkdirTemp("/tmp", "additional-gids")
+	testPodLogDir, err := os.MkdirTemp("", "additional-gids")
 	require.NoError(t, err)
 	defer os.RemoveAll(testPodLogDir)
 

--- a/integration/container_log_test.go
+++ b/integration/container_log_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestContainerLogWithoutTailingNewLine(t *testing.T) {
-	testPodLogDir, err := os.MkdirTemp("/tmp", "container-log-without-tailing-newline")
+	testPodLogDir, err := os.MkdirTemp("", "container-log-without-tailing-newline")
 	require.NoError(t, err)
 	defer os.RemoveAll(testPodLogDir)
 
@@ -80,7 +80,7 @@ func TestContainerLogWithoutTailingNewLine(t *testing.T) {
 }
 
 func TestLongContainerLog(t *testing.T) {
-	testPodLogDir, err := os.MkdirTemp("/tmp", "long-container-log")
+	testPodLogDir, err := os.MkdirTemp("", "long-container-log")
 	require.NoError(t, err)
 	defer os.RemoveAll(testPodLogDir)
 

--- a/integration/pod_dualstack_test.go
+++ b/integration/pod_dualstack_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestPodDualStack(t *testing.T) {
-	testPodLogDir, err := os.MkdirTemp("/tmp", "dualstack")
+	testPodLogDir, err := os.MkdirTemp("", "dualstack")
 	require.NoError(t, err)
 	defer os.RemoveAll(testPodLogDir)
 

--- a/integration/pod_hostname_test.go
+++ b/integration/pod_hostname_test.go
@@ -64,7 +64,7 @@ func TestPodHostname(t *testing.T) {
 			if test.needsHostNetwork && goruntime.GOOS == "windows" {
 				t.Skip("Skipped on Windows.")
 			}
-			testPodLogDir, err := os.MkdirTemp("/tmp", "hostname")
+			testPodLogDir, err := os.MkdirTemp("", "hostname")
 			require.NoError(t, err)
 			defer os.RemoveAll(testPodLogDir)
 


### PR DESCRIPTION
As suggested at https://github.com/containerd/containerd/issues/4878#issuecomment-814132549, and enhancing #5039.

I figured this was less work and less-costly than actually getting AKS and GCP accounts set up to let me run the CRI tests via the periodic job, and I don't have a regular Windows Server machine at-hand to run the tests locally.