### PR TITLE
Add shared content label to namespaces

### DIFF
--- a/docs/ops.md
+++ b/docs/ops.md
@@ -232,3 +232,7 @@ The default is "shared". While this is largely the most desired policy, one can 
 [plugins.bolt]
 	content_sharing_policy = "isolated"
 ```
+
+In "isolated" mode, it is also possible to share only the contents of a specific namespace by adding the label `containerd.io/namespace.shareable=true` to that namespace.
+This will make its blobs available in all other namespaces even if the content sharing policy is set to "isolated".
+If the label value is set to anything other than `true`, the namespace content will not be shared.

--- a/integration/client/content_test.go
+++ b/integration/client/content_test.go
@@ -41,7 +41,7 @@ func newContentStore(ctx context.Context, root string) (context.Context, content
 		name  = testsuite.Name(ctx)
 	)
 
-	wrap := func(ctx context.Context) (context.Context, func(context.Context) error, error) {
+	wrap := func(ctx context.Context, sharedNS bool) (context.Context, func(context.Context) error, error) {
 		n := atomic.AddUint64(&count, 1)
 		ctx = namespaces.WithNamespace(ctx, fmt.Sprintf("%s-n%d", name, n))
 		return client.WithLease(ctx)

--- a/labels/labels.go
+++ b/labels/labels.go
@@ -19,3 +19,7 @@ package labels
 // LabelUncompressed is added to compressed layer contents.
 // The value is digest of the uncompressed content.
 const LabelUncompressed = "containerd.io/uncompressed"
+
+// LabelSharedNamespace is added to a namespace to allow that namespaces
+// contents to be shared.
+const LabelSharedNamespace = "containerd.io/namespace.shareable"


### PR DESCRIPTION
Re-introducing the shareable namespace feature

Related PR: #5043

This PR is a re-implementation on the shareable namespace feature that was originally introduced by #5043, which was reverted due to a bug identified during testing.

The new implementation follows and extends the semantic of the existing content sharing policy, by allowing the content of a namespace (if configured as "shareable") to be accessible from other namespaces even "content_sharing_policy" is set to "isolated".

For example:

```
$ cat config.toml
[plugins]
  [plugins.bolt]
    content_sharing_policy = "isolated"
    
// 0. label the shared namespace
$ ctr ns label shared containerd.io/namespace.shareable=true
    
// 1. pull image into shared namespace
$ ctr -n shared i pull docker.io/library/hello-world:latest

// 2. pull the same image into test namespace, this should be much quicker
//    due to content sharing
$ ctr -n test i pull docker.io/library/hello-world:latest

// 3. run container in test namespace
$ ctr -n test run --rm docker.io/library/hello-world:latest demo
```

Signed-off-by: Henry Wang <henwang@amazon.com>