### PR TITLE
fix: `ctr run --cni` get failed

### DIFF
--- a/cmd/ctr/commands/cni.go
+++ b/cmd/ctr/commands/cni.go
@@ -1,0 +1,45 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package commands
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/namespaces"
+)
+
+const (
+
+	// CtrCniMetadataExtension is an extension name that identify metadata of container in CreateContainerRequest
+	CtrCniMetadataExtension = "ctr.cni-containerd.metadata"
+)
+
+//ctr pass metadata to containerd if ctr run use option of --cni
+type NetworkMetaData struct {
+	EnableCni bool
+}
+
+func FullID(ctx context.Context, c containerd.Container) string {
+	id := c.ID()
+	ns, ok := namespaces.Namespace(ctx)
+	if !ok {
+		return id
+	}
+	return fmt.Sprintf("%s-%s", ns, id)
+}

--- a/cmd/ctr/commands/run/run.go
+++ b/cmd/ctr/commands/run/run.go
@@ -17,7 +17,6 @@
 package run
 
 import (
-	"context"
 	gocontext "context"
 	"encoding/csv"
 	"errors"
@@ -31,7 +30,6 @@ import (
 	"github.com/containerd/containerd/cmd/ctr/commands/tasks"
 	"github.com/containerd/containerd/containers"
 	clabels "github.com/containerd/containerd/labels"
-	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
 	gocni "github.com/containerd/go-cni"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -196,7 +194,7 @@ var Command = cli.Command{
 		if !detach {
 			defer func() {
 				if enableCNI {
-					if err := network.Remove(ctx, fullID(ctx, container), ""); err != nil {
+					if err := network.Remove(ctx, commands.FullID(ctx, container), ""); err != nil {
 						logrus.WithError(err).Error("network review")
 					}
 				}
@@ -218,7 +216,7 @@ var Command = cli.Command{
 				return err
 			}
 
-			if _, err := network.Setup(ctx, fullID(ctx, container), netNsPath); err != nil {
+			if _, err := network.Setup(ctx, commands.FullID(ctx, container), netNsPath); err != nil {
 				return err
 			}
 		}
@@ -249,15 +247,6 @@ var Command = cli.Command{
 		}
 		return nil
 	},
-}
-
-func fullID(ctx context.Context, c containerd.Container) string {
-	id := c.ID()
-	ns, ok := namespaces.Namespace(ctx)
-	if !ok {
-		return id
-	}
-	return fmt.Sprintf("%s-%s", ns, id)
 }
 
 // buildLabel builds the labels from command line labels and the image labels

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -39,10 +39,16 @@ import (
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/containerd/containerd/snapshots"
+	"github.com/containerd/typeurl"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
+
+func init() {
+	typeurl.Register(&commands.NetworkMetaData{},
+		"github.com/containerd/containerd/cmd/ctr/commands", "NetworkMetaData")
+}
 
 var platformRunFlags = []cli.Flag{
 	cli.StringFlag{
@@ -214,6 +220,10 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 			)
 		}
 
+		if context.Bool("cni") {
+			cniMeta := &commands.NetworkMetaData{EnableCni: true}
+			cOpts = append(cOpts, containerd.WithContainerExtension(commands.CtrCniMetadataExtension, cniMeta))
+		}
 		if caps := context.StringSlice("cap-add"); len(caps) > 0 {
 			for _, cap := range caps {
 				if !strings.HasPrefix(cap, "CAP_") {

--- a/cmd/ctr/commands/tasks/kill.go
+++ b/cmd/ctr/commands/tasks/kill.go
@@ -17,15 +17,54 @@
 package tasks
 
 import (
+	"context"
 	"errors"
+	"fmt"
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cmd/ctr/commands"
+	gocni "github.com/containerd/go-cni"
+	"github.com/containerd/typeurl"
 	"github.com/moby/sys/signal"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
 const defaultSignal = "SIGTERM"
+
+func init() {
+	typeurl.Register(&commands.NetworkMetaData{},
+		"github.com/containerd/containerd/cmd/ctr/commands", "NetworkMetaData")
+}
+
+func RemoveCniNetworkIfExist(ctx context.Context, container containerd.Container) error {
+	exts, err := container.Extensions(ctx)
+	if err != nil {
+		return err
+	}
+	networkMeta, ok := exts[commands.CtrCniMetadataExtension]
+	if !ok {
+		return nil
+	}
+
+	data, err := typeurl.UnmarshalAny(&networkMeta)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal cni metadata extension  %s", commands.CtrCniMetadataExtension)
+	}
+	networkMetaData := data.(*commands.NetworkMetaData)
+
+	var network gocni.CNI
+	if networkMetaData.EnableCni {
+		if network, err = gocni.New(gocni.WithDefaultConf); err != nil {
+			return err
+		}
+		if err := network.Remove(ctx, commands.FullID(ctx, container), ""); err != nil {
+			logrus.WithError(err).Error("network remove error")
+			return err
+		}
+	}
+	return nil
+}
 
 var killCommand = cli.Command{
 	Name:      "kill",
@@ -90,6 +129,10 @@ var killCommand = cli.Command{
 			}
 		}
 		task, err := container.Task(ctx, nil)
+		if err != nil {
+			return err
+		}
+		err = RemoveCniNetworkIfExist(ctx, container)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
   when user executes `ctr run --cni`  to start a container,it will call cni plugin to create network .But when user kills it,the network won’t be removed. if we run a container with same namespace and name again will trigger a bug. we should remove the network when user kills task if it enables cni plugin.

Fix:#6604

Signed-off-by: SongJiang Han <songjiang.dark@gmail.com>