### PR TITLE
Make mkfs.xfs available on OpenLab's CI environment

### DIFF
--- a/.zuul/playbooks/containerd-build/integration-test.yaml
+++ b/.zuul/playbooks/containerd-build/integration-test.yaml
@@ -11,7 +11,7 @@
         set -xe
         set -o pipefail
         apt-get update
-        apt-get install -y btrfs-tools libseccomp-dev git pkg-config lsof gperf apparmor
+        apt-get install -y btrfs-tools libseccomp-dev git pkg-config lsof gperf apparmor xfsprogs
 
         go version
       chdir: '{{ zuul.project.src_dir }}'


### PR DESCRIPTION
Since 0d0b2bd4f, our tests need mkfs.xfs.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>