### PR TITLE
Enable gosec linter for golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,12 +11,28 @@ linters:
     - vet
     - unused
     - misspell
+    - gosec
   disable:
     - errcheck
 
 issues:
   include:
     - EXC0002
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+linters-settings:
+  gosec:
+    # The following issues surfaced when `gosec` linter
+    # was enabled. They are temporarily excluded to unblock
+    # the existing workflow, but still to be addressed by
+    # by future works.
+    excludes:
+      - G204
+      - G305
+      - G306
+      - G402
+      - G404
 
 run:
   timeout: 8m

--- a/metadata/boltutil/helpers.go
+++ b/metadata/boltutil/helpers.go
@@ -162,6 +162,7 @@ func WriteExtensions(bkt *bolt.Bucket, extensions map[string]types.Any) error {
 	}
 
 	for name, ext := range extensions {
+		ext := ext
 		p, err := proto.Marshal(&ext)
 		if err != nil {
 			return err

--- a/metadata/containers_test.go
+++ b/metadata/containers_test.go
@@ -152,6 +152,7 @@ func TestContainersList(t *testing.T) {
 			}
 
 			for _, result := range results {
+				result := result
 				checkContainersEqual(t, &result, testset[result.ID], "list results did not match")
 			}
 		})

--- a/metadata/images_test.go
+++ b/metadata/images_test.go
@@ -129,6 +129,7 @@ func TestImagesList(t *testing.T) {
 			}
 
 			for _, result := range results {
+				result := result
 				checkImagesEqual(t, &result, testset[result.Name], "list results did not match")
 			}
 		})

--- a/oci/spec_opts_test.go
+++ b/oci/spec_opts_test.go
@@ -596,6 +596,7 @@ func TestDevShmSize(t *testing.T) {
 
 	expected := "1024k"
 	for _, s := range ss {
+		s := s
 		if err := WithDevShmSize(1024)(nil, nil, nil, &s); err != nil {
 			if err != ErrNoShmMount {
 				t.Fatal(err)

--- a/services/containers/helpers.go
+++ b/services/containers/helpers.go
@@ -25,6 +25,7 @@ func containersToProto(containers []containers.Container) []api.Container {
 	var containerspb []api.Container
 
 	for _, image := range containers {
+		image := image
 		containerspb = append(containerspb, containerToProto(&image))
 	}
 

--- a/services/images/helpers.go
+++ b/services/images/helpers.go
@@ -27,6 +27,7 @@ func imagesToProto(images []images.Image) []imagesapi.Image {
 	var imagespb []imagesapi.Image
 
 	for _, image := range images {
+		image := image
 		imagespb = append(imagespb, imageToProto(&image))
 	}
 


### PR DESCRIPTION
Fixes: #6584

`gosec` linter is able to identify issues described in #6584

e.g.

```
$ git revert 54e95e6b880912e489529be120d4ecead80dbd90
[gosec dfc8ca1ec] Revert "fix Implicit memory aliasing in for loop"
 2 files changed, 2 deletions(-)

$ make check
+ proto-fmt
+ check
GOGC=75 golangci-lint run
containerstore.go:192:54: G601: Implicit memory aliasing in for loop. (gosec)
		containers = append(containers, containerFromProto(&container))
		                                                   ^
image_store.go:132:42: G601: Implicit memory aliasing in for loop. (gosec)
		images = append(images, imageFromProto(&image))
		                                       ^
make: *** [check] Error 1
```

I also disabled following two settings which prevents the linter to show a complete list of issues.
* `max-issues-per-linter (default 50)`
* `max-same-issues (default 3)`

Furthermore enabling `gosec` reveals many other issues. For now I blacklisted the ones except `G601`. Maybe we can create tasks to address them one by one moving forward?


Signed-off-by: Henry Wang <henwang@amazon.com>