### PR TITLE
Turn paths from cmdline into absolute paths

### DIFF
--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -323,6 +323,13 @@ func applyFlags(context *cli.Context, config *srvconfig.Config) error {
 	} {
 		if s := context.GlobalString(v.name); s != "" {
 			*v.d = s
+			if v.name == "root" || v.name == "state" {
+				absPath, err := filepath.Abs(s)
+				if err != nil {
+					return err
+				}
+				*v.d = absPath
+			}
 		}
 	}
 


### PR DESCRIPTION
Snapshotter service returning relative paths confuses the client (i.e.
ctr).

Closes: #6671

Signed-off-by: Eric Lin <linxiulei@gmail.com>