### PR TITLE
[release/1.6] cherry-pick: Upgrade golangci-lint and its GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,10 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - uses: actions/checkout@v2
-      - uses: golangci/golangci-lint-action@v2
+      - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.42.0
+          version: v1.44.2
           args: --timeout=5m
-          skip-go-installation: true
 
   #
   # Project checks


### PR DESCRIPTION
The GitHub Action is unstable especially on Windows (see #6618).
This change may not address the issue itself, but using the latest
version makes reporting the upstream the issue easier.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>
(cherry picked from commit 622a35a4fa7c275ad45618c672d4e7d94ae87102)