### PR TITLE
Consider StatusForbidden (403) for retries for manifest/blob HEAD query

### DIFF
--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -610,7 +610,7 @@ func (r *request) retryRequest(ctx context.Context, responses []*http.Response) 
 		}
 
 		return false, nil
-	case http.StatusMethodNotAllowed:
+	case http.StatusMethodNotAllowed, http.StatusForbidden:
 		// Support registries which have not properly implemented the HEAD method for
 		// manifests endpoint
 		if r.method == http.MethodHead && strings.Contains(r.path, "/manifests/") {


### PR DESCRIPTION
We're using `registry.centos.org` to work with `CentOS` images and the registry does not support HEAD queries for manifests. The problem though is that it returns `StatusForbidden` (403).

`docker` seems to cope with it just fine with [distribution](https://github.com/distribution/distribution), where the `tags` [implementation](https://github.com/distribution/distribution/blob/b5ca020cfbe998e5af3457fda087444cf5116496/registry/client/repository.go#L322-L337) will implicitly fallback to `GET` after attempting a `HEAD` on **any** error for a query like this:

```sh
$ docker pull registry.centos.org/centos/centos:7
```

Buildkit, though, relies on containerd's docker remote resolver which seems to handle each error response individually and it falls short here as it only supports `StatusMethodNotAllowed` as a response to retry.
