### PR TITLE
Linux kernel module `overlay` should be loaded via config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,6 +351,8 @@ install-cri-deps: $(BINARIES)
 	@$(INSTALL) -D -m 755 bin/* ${CRIDIR}/usr/local/bin
 	@$(INSTALL) -d ${CRIDIR}/opt/containerd/cluster
 	@cp -r contrib/gce ${CRIDIR}/opt/containerd/cluster/
+	@$(INSTALL) -d ${CRIDIR}/etc/modules-load.d
+	@$(INSTALL) -m 644 containerd-modules-load.conf ${CRIDIR}/etc/modules-load.d/containerd.conf
 	@$(INSTALL) -d ${CRIDIR}/etc/systemd/system
 	@$(INSTALL) -m 644 containerd.service ${CRIDIR}/etc/systemd/system
 	echo "CONTAINERD_VERSION: '$(VERSION:v%=%)'" | tee ${CRIDIR}/opt/containerd/cluster/version

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -317,6 +317,7 @@ EOF
         if [[ $selinux == Enforcing ]]; then
             setenforce 0
         fi
+        modprobe overlay
         systemctl enable --now ${GOPATH}/src/github.com/containerd/containerd/containerd.service
         if [[ $selinux == Enforcing ]]; then
             setenforce 1

--- a/containerd-modules-load.conf
+++ b/containerd-modules-load.conf
@@ -1,0 +1,1 @@
+overlay

--- a/containerd.service
+++ b/containerd.service
@@ -18,7 +18,6 @@ Documentation=https://containerd.io
 After=network.target local-fs.target
 
 [Service]
-ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/local/bin/containerd
 
 Type=notify

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,11 +41,18 @@ Users of such distributions may have to install containerd from the source or a 
 
 
 ##### systemd
+
 If you intend to start containerd via systemd, you should also download the `containerd.service` unit file from
-https://raw.githubusercontent.com/containerd/containerd/main/containerd.service into `/usr/local/lib/systemd/system/containerd.service`,
+https://raw.githubusercontent.com/containerd/containerd/main/containerd.service into `/etc/systemd/system/containerd.service`,
+(for package managers into `/usr/lib/systemd/system/containerd.service`)
+In most cases the containerd service needs the loaded `overlay` kernel module.
+For make the loading persistent (after system restart) you should also download the modprobe conf file
+https://raw.githubusercontent.com/containerd/containerd/main/containerd-modules-load.conf into `/etc/modules-load.d/containerd`,
+(for package managers into `/usr/lib/modules-load.d/containerd.conf`)
 and run the following commands:
 
 ```bash
+modprobe overlay
 systemctl daemon-reload
 systemctl enable --now containerd
 ```


### PR DESCRIPTION
Currently containerd loads the needed Linux kernel module "overlay" via the `ExecStartPre=-/sbin/modprobe overlay`.

The Linux way to load a kernel module, to the best of my knowledge, is to use the location  `/etc/modules-load.d/` resp. `/usr/lib/modules-load.d/`.

Background to the effort: 
In my use case, I'm using a Kubernetes Cluster within Lxd containers for learning purposes,  the module cannot be used and it is easier to avoid the deployment of the module file than to modified the service file.
