### PR TITLE
fix multi-arch Windows image preference

### DIFF
--- a/platforms/defaults_windows_test.go
+++ b/platforms/defaults_windows_test.go
@@ -204,6 +204,7 @@ func TestMatchComparerMatch_LCOW(t *testing.T) {
 }
 
 func TestMatchComparerLess(t *testing.T) {
+	ubr := GetCurrentWindowsUpdateBuildRevision()
 	m := windowsmatcher{
 		Platform:        DefaultSpec(),
 		osVersionPrefix: "10.0.17763",
@@ -224,12 +225,17 @@ func TestMatchComparerLess(t *testing.T) {
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    "10.0.17763.1",
+			OSVersion:    fmt.Sprintf("10.0.17763.%d", ubr-1),
 		},
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    "10.0.17763.2",
+			OSVersion:    fmt.Sprintf("10.0.17763.%d", ubr+1),
+		},
+		{
+			Architecture: "amd64",
+			OS:           "windows",
+			OSVersion:    fmt.Sprintf("10.0.17763.%d", ubr),
 		},
 		{
 			Architecture: "amd64",
@@ -241,12 +247,17 @@ func TestMatchComparerLess(t *testing.T) {
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    "10.0.17763.2",
+			OSVersion:    fmt.Sprintf("10.0.17763.%d", ubr), // version with same UBR as host is best match
 		},
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    "10.0.17763.1",
+			OSVersion:    fmt.Sprintf("10.0.17763.%d", ubr+1),
+		},
+		{
+			Architecture: "amd64",
+			OS:           "windows",
+			OSVersion:    fmt.Sprintf("10.0.17763.%d", ubr-1),
 		},
 		{
 			Architecture: "amd64",


### PR DESCRIPTION
Signed-off-by: Frederik Siegmund <siegmund@slb.com>

- What I did

Changes in platforms/defaults_windows.go:

Multi-arch windows with UBR matching host UBR will be preferred

Change sorting logic of multi-arch image. Images that exactly match host OS version will be moved to the top, followed by versions that match host build, in descending order.

- How to verify it

See https://github.com/containerd/containerd/issues/6693

The image with exact host version will be preferred. Otherwise as logic above.

Description for the changelog
fix multi-arch Windows image preference

Note: This fix was first submitted to Moby. On recommendation from [thaJeztah](https://github.com/thaJeztah) I implemented the same fix for containerd.






