### PR TITLE
Fix multi-arch Windows image preference

### DIFF
--- a/platforms/defaults_windows_test.go
+++ b/platforms/defaults_windows_test.go
@@ -30,10 +30,11 @@ import (
 
 func TestDefault(t *testing.T) {
 	major, minor, build := windows.RtlGetNtVersionNumbers()
+	ubr := getHostWindowsUpdateBuildRevision()
 	expected := imagespec.Platform{
 		OS:           runtime.GOOS,
 		Architecture: runtime.GOARCH,
-		OSVersion:    fmt.Sprintf("%d.%d.%d", major, minor, build),
+		OSVersion:    fmt.Sprintf("%d.%d.%d.%d", major, minor, build, ubr),
 		Variant:      cpuVariant(),
 	}
 	p := DefaultSpec()
@@ -77,6 +78,7 @@ func TestMatchComparerMatch_WCOW(t *testing.T) {
 	m := windowsmatcher{
 		Platform:        DefaultSpec(),
 		osVersionPrefix: buildStr,
+		osUBR:           getHostWindowsUpdateBuildRevision(),
 		defaultMatcher: &matcher{
 			Platform: Normalize(DefaultSpec()),
 		},
@@ -204,7 +206,7 @@ func TestMatchComparerMatch_LCOW(t *testing.T) {
 }
 
 func TestMatchComparerLess(t *testing.T) {
-	ubr := GetHostWindowsUpdateBuildRevision()
+	ubr := getHostWindowsUpdateBuildRevision()
 	m := windowsmatcher{
 		Platform:        DefaultSpec(),
 		osVersionPrefix: "10.0.17763",

--- a/platforms/defaults_windows_test.go
+++ b/platforms/defaults_windows_test.go
@@ -204,10 +204,11 @@ func TestMatchComparerMatch_LCOW(t *testing.T) {
 }
 
 func TestMatchComparerLess(t *testing.T) {
-	ubr := GetCurrentWindowsUpdateBuildRevision()
+	ubr := GetHostWindowsUpdateBuildRevision()
 	m := windowsmatcher{
 		Platform:        DefaultSpec(),
 		osVersionPrefix: "10.0.17763",
+		osUBR:           ubr,
 		defaultMatcher: &matcher{
 			Platform: Normalize(DefaultSpec()),
 		},

--- a/platforms/defaults_windows_test.go
+++ b/platforms/defaults_windows_test.go
@@ -204,6 +204,7 @@ func TestMatchComparerMatch_LCOW(t *testing.T) {
 }
 
 func TestMatchComparerLess(t *testing.T) {
+	ubr := GetCurrentWindowsUpdateBuildRevision()
 	m := windowsmatcher{
 		Platform:        DefaultSpec(),
 		osVersionPrefix: "10.0.17763",
@@ -224,12 +225,17 @@ func TestMatchComparerLess(t *testing.T) {
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    "10.0.17763.1",
+			OSVersion:    fmt.Sprintf("10.0.17763.%d", ubr-1),
 		},
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    "10.0.17763.2",
+			OSVersion:    fmt.Sprintf("10.0.17763.%d", ubr+1),
+		},
+		{
+			Architecture: "amd64",
+			OS:           "windows",
+			OSVersion:    fmt.Sprintf("10.0.17763.%d", ubr),
 		},
 		{
 			Architecture: "amd64",
@@ -241,12 +247,17 @@ func TestMatchComparerLess(t *testing.T) {
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    "10.0.17763.2",
+			OSVersion:    fmt.Sprintf("10.0.17763.%d", ubr), // version with same UBR as host is best match
 		},
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    "10.0.17763.1",
+			OSVersion:    fmt.Sprintf("10.0.17763.%d", ubr+1),
+		},
+		{
+			Architecture: "amd64",
+			OS:           "windows",
+			OSVersion:    fmt.Sprintf("10.0.17763.%d", ubr-1),
 		},
 		{
 			Architecture: "amd64",

--- a/platforms/defaults_windows_test.go
+++ b/platforms/defaults_windows_test.go
@@ -206,11 +206,10 @@ func TestMatchComparerMatch_LCOW(t *testing.T) {
 }
 
 func TestMatchComparerLess(t *testing.T) {
-	ubr := getHostWindowsUpdateBuildRevision()
 	m := windowsmatcher{
 		Platform:        DefaultSpec(),
 		osVersionPrefix: "10.0.17763",
-		osUBR:           ubr,
+		osUBR:           1000,
 		defaultMatcher: &matcher{
 			Platform: Normalize(DefaultSpec()),
 		},
@@ -228,17 +227,17 @@ func TestMatchComparerLess(t *testing.T) {
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    fmt.Sprintf("10.0.17763.%d", ubr-1),
+			OSVersion:    "10.0.17763.999",
 		},
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    fmt.Sprintf("10.0.17763.%d", ubr+1),
+			OSVersion:    "10.0.17763.1001",
 		},
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    fmt.Sprintf("10.0.17763.%d", ubr),
+			OSVersion:    "10.0.17763.1000",
 		},
 		{
 			Architecture: "amd64",
@@ -250,17 +249,17 @@ func TestMatchComparerLess(t *testing.T) {
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    fmt.Sprintf("10.0.17763.%d", ubr), // version with same UBR as host is best match
+			OSVersion:    "10.0.17763.1000", // version with same UBR as host is best match
 		},
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    fmt.Sprintf("10.0.17763.%d", ubr+1),
+			OSVersion:    "10.0.17763.1001",
 		},
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    fmt.Sprintf("10.0.17763.%d", ubr-1),
+			OSVersion:    "10.0.17763.999",
 		},
 		{
 			Architecture: "amd64",

--- a/platforms/platforms_windows.go
+++ b/platforms/platforms_windows.go
@@ -20,7 +20,7 @@ import (
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// NewMatcher returns a Windows matcher that will match on osVersionPrefix and oxUBR if
+// NewMatcher returns a Windows matcher that will match on osVersionPrefix and osUBR if
 // the platform is Windows otherwise use the default matcher
 func newDefaultMatcher(platform specs.Platform) Matcher {
 	prefix := prefix(platform.OSVersion)

--- a/platforms/platforms_windows.go
+++ b/platforms/platforms_windows.go
@@ -17,18 +17,47 @@
 package platforms
 
 import (
+	"log"
+	"sync"
+
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/sys/windows/registry"
 )
 
-// NewMatcher returns a Windows matcher that will match on osVersionPrefix if
+// NewMatcher returns a Windows matcher that will match on osVersionPrefix and osUBR if
 // the platform is Windows otherwise use the default matcher
 func newDefaultMatcher(platform specs.Platform) Matcher {
-	prefix := prefix(platform.OSVersion)
+	prefix := prefix(platform.OSVersion) // note: the UBR in OSVersion is
 	return windowsmatcher{
 		Platform:        platform,
 		osVersionPrefix: prefix,
+		osUBR:           GetHostWindowsUpdateBuildRevision(),
 		defaultMatcher: &matcher{
 			Platform: Normalize(platform),
 		},
 	}
+}
+
+var (
+	ubr  int
+	once sync.Once
+)
+
+func GetHostWindowsUpdateBuildRevision() int {
+	once.Do(func() {
+		ubr = 0
+		k, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows NT\CurrentVersion`, registry.QUERY_VALUE)
+		if err != nil {
+			log.Printf("can't open windows host UBR registry path: %v", err)
+			return
+		}
+		defer k.Close()
+		d, _, err := k.GetIntegerValue("UBR")
+		if err != nil {
+			log.Printf("can't read windows host UBR: %v", err)
+			return
+		}
+		ubr = int(d)
+	})
+	return ubr
 }

--- a/platforms/platforms_windows.go
+++ b/platforms/platforms_windows.go
@@ -20,13 +20,15 @@ import (
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// NewMatcher returns a Windows matcher that will match on osVersionPrefix if
+// NewMatcher returns a Windows matcher that will match on osVersionPrefix and oxUBR if
 // the platform is Windows otherwise use the default matcher
 func newDefaultMatcher(platform specs.Platform) Matcher {
 	prefix := prefix(platform.OSVersion)
+	ubr := revision(platform.OSVersion)
 	return windowsmatcher{
 		Platform:        platform,
 		osVersionPrefix: prefix,
+		osUBR:           ubr,
 		defaultMatcher: &matcher{
 			Platform: Normalize(platform),
 		},

--- a/platforms/platforms_windows.go
+++ b/platforms/platforms_windows.go
@@ -17,47 +17,18 @@
 package platforms
 
 import (
-	"log"
-	"sync"
-
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
-	"golang.org/x/sys/windows/registry"
 )
 
-// NewMatcher returns a Windows matcher that will match on osVersionPrefix and osUBR if
+// NewMatcher returns a Windows matcher that will match on osVersionPrefix if
 // the platform is Windows otherwise use the default matcher
 func newDefaultMatcher(platform specs.Platform) Matcher {
-	prefix := prefix(platform.OSVersion) // note: the UBR in OSVersion is
+	prefix := prefix(platform.OSVersion)
 	return windowsmatcher{
 		Platform:        platform,
 		osVersionPrefix: prefix,
-		osUBR:           GetHostWindowsUpdateBuildRevision(),
 		defaultMatcher: &matcher{
 			Platform: Normalize(platform),
 		},
 	}
-}
-
-var (
-	ubr  int
-	once sync.Once
-)
-
-func GetHostWindowsUpdateBuildRevision() int {
-	once.Do(func() {
-		ubr = 0
-		k, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows NT\CurrentVersion`, registry.QUERY_VALUE)
-		if err != nil {
-			log.Printf("can't open windows host UBR registry path: %v", err)
-			return
-		}
-		defer k.Close()
-		d, _, err := k.GetIntegerValue("UBR")
-		if err != nil {
-			log.Printf("can't read windows host UBR: %v", err)
-			return
-		}
-		ubr = int(d)
-	})
-	return ubr
 }


### PR DESCRIPTION
- What I did

Changes in platforms/defaults_windows.go:

Multi-arch windows with UBR matching host UBR will be preferred

Changed sorting logic of multi-arch image. Images that exactly match host OS version will be moved to the top, followed by versions that match host build, in descending order.

- How to verify it

See #6693

The image with exact host version will be preferred. Otherwise as logic above.

- Description for the changelog

fix multi-arch Windows image preference

Note: This fix was first submitted to Moby. On recommendation from thaJeztah I implemented the same fix for containerd.

Signed-off-by: Frederik Siegmund <siegmund@slb.com>