### PR TITLE
fix: ctr images mount with snapshotter option can't get snapshotter

### DIFF
--- a/cmd/ctr/commands/images/mount.go
+++ b/cmd/ctr/commands/images/mount.go
@@ -67,7 +67,7 @@ When you are done, use the unmount command.
 		}
 		defer cancel()
 
-		snapshotter := context.GlobalString("snapshotter")
+		snapshotter := context.String("snapshotter")
 		if snapshotter == "" {
 			snapshotter = containerd.DefaultSnapshotter
 		}


### PR DESCRIPTION
`ctr images mount` with snapshotter option can't get the specified parameter value.

example:
`ctr images mount --snapshotter "aufs" docker.io/library/busybox:latest /mnt`
The actual snapshotter used by the above command is the default snapshotter--"overlayfs".


Signed-off-by: Qian Zhang <cosmoer@qq.com>