### PR TITLE
[release/1.5 backport] native: fix deadlock from leaving transactions open

### DIFF
--- a/snapshots/native/native.go
+++ b/snapshots/native/native.go
@@ -151,11 +151,17 @@ func (o *snapshotter) Commit(ctx context.Context, name, key string, opts ...snap
 
 	id, _, _, err := storage.GetInfo(ctx, key)
 	if err != nil {
+		if rerr := t.Rollback(); rerr != nil {
+			log.G(ctx).WithError(rerr).Warn("failed to rollback transaction")
+		}
 		return err
 	}
 
 	usage, err := fs.DiskUsage(ctx, o.getSnapshotDir(id))
 	if err != nil {
+		if rerr := t.Rollback(); rerr != nil {
+			log.G(ctx).WithError(rerr).Warn("failed to rollback transaction")
+		}
 		return err
 	}
 
@@ -282,6 +288,9 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 				fs.WithXAttrErrorHandler(xattrErrorHandler),
 			}
 			if err := fs.CopyDir(td, parent, copyDirOpts...); err != nil {
+				if rerr := t.Rollback(); rerr != nil {
+					log.G(ctx).WithError(rerr).Warn("failed to rollback transaction")
+				}
 				return nil, errors.Wrap(err, "copying of parent failed")
 			}
 		}


### PR DESCRIPTION
cherry-pick of https://github.com/containerd/containerd/pull/6722

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
(cherry picked from commit fe426227d4ccb06fc5cbe7f11aa8eefc8d77768a)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>