### PR TITLE
[release/1.6 backport] Make the temp mount as ready only in container WithVolumes

### DIFF
--- a/pkg/cri/opts/container.go
+++ b/pkg/cri/opts/container.go
@@ -69,6 +69,12 @@ func WithVolumes(volumeMounts map[string]string) containerd.NewContainerOpts {
 		if err != nil {
 			return err
 		}
+		// Since only read is needed, append ReadOnly mount option to prevent linux kernel
+		// from syncing whole filesystem in umount syscall.
+		if len(mounts) == 1 && mounts[0].Type == "overlay" {
+			mounts[0].Options = append(mounts[0].Options, "ro")
+		}
+
 		root, err := os.MkdirTemp("", "ctd-volume")
 		if err != nil {
 			return err


### PR DESCRIPTION
backport of https://github.com/containerd/containerd/pull/6593
(cherry picked from commit ec90efbe99b97ad194fa1586cb0f1ff82bdd4915)
