### PR TITLE
[release/1.6 backport] Mount devmapper xfs file system with "nouuid" option.

### DIFF
--- a/snapshots/devmapper/snapshotter.go
+++ b/snapshots/devmapper/snapshotter.go
@@ -504,6 +504,8 @@ func (s *Snapshotter) buildMounts(ctx context.Context, snap storage.Snapshot, fi
 	if fileSystemType == "" {
 		log.G(ctx).Error("File system type cannot be empty")
 		return nil
+	} else if fileSystemType == fsTypeXFS {
+		options = append(options, "nouuid")
 	}
 	if snap.Kind != snapshots.KindActive {
 		options = append(options, "ro")


### PR DESCRIPTION
backport of https://github.com/containerd/containerd/pull/6650
fixes https://github.com/containerd/containerd/issues/6587

Two xfs file systems with same UUID can not be mounted on the same system.
However devmapper snapshots will have same UUID as original filesystem.

This patch fixes the bug by mounting a xfs file system with "nouuid" option.

(cherry picked from commit 0d0b2bd4fe0551464e1ab6adc39077e833be8746)
