### PR TITLE
Fix error message in TestNewBinaryIO

### DIFF
--- a/pkg/process/io_test.go
+++ b/pkg/process/io_test.go
@@ -46,7 +46,7 @@ func TestNewBinaryIO(t *testing.T) {
 
 	after := descriptorCount(t)
 	if before != after-1 { // one descriptor must be closed from shim logger side
-		t.Fatalf("some descriptors weren't closed (%d != %d)", before, after)
+		t.Fatalf("some descriptors weren't closed (%d != %d -1)", before, after)
 	}
 }
 


### PR DESCRIPTION
I find the error message is misleading:

```
=== RUN   TestNewBinaryIO
    io_test.go:49: some descriptors weren't closed (11 != 11)
--- FAIL: TestNewBinaryIO (0.00s)
```

Full log: https://ci.debian.net/data/autopkgtest/testing/i386/c/containerd/20307755/log.gz

The test itself seems flaky, but this PR just fixes the error message.