### PR TITLE
fix: crictl can't list images while use external snapshotter plugins

### DIFF
--- a/pkg/cri/server/restart.go
+++ b/pkg/cri/server/restart.go
@@ -441,9 +441,8 @@ func (c *criService) loadImages(ctx context.Context, cImages []containerd.Image)
 		unpacked, err := i.IsUnpacked(ctx, snapshotter)
 		if err != nil {
 			log.G(ctx).WithError(err).Warnf("Failed to check whether image is unpacked for image %s", i.Name())
-			continue
 		}
-		if !unpacked {
+		if err == nil && !unpacked {
 			log.G(ctx).Warnf("The image %s is not unpacked.", i.Name())
 			// TODO(random-liu): Consider whether we should try unpack here.
 		}


### PR DESCRIPTION
we use external snapshotter plugins,  while snapshotter plugins service is not ready, 
`IsUnpacked` func will return error.
at the moment,  `updateImage` func will not be called, CRI service will not to load the images.
So,  `crictl images`  will print null images list. 

@fuweid 