### PR TITLE
Add restart policy for enhanced restart manager

### DIFF
--- a/runtime/restart/monitor/monitor.go
+++ b/runtime/restart/monitor/monitor.go
@@ -19,6 +19,7 @@ package monitor
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
@@ -72,6 +73,7 @@ func init() {
 			},
 		},
 		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
+			ic.Meta.Capabilities = []string{"no", "always", "on-failure", "unless-stopped"}
 			opts, err := getServicesOpts(ic)
 			if err != nil {
 				return nil, err
@@ -213,15 +215,29 @@ func (m *monitor) monitor(ctx context.Context) ([]change, error) {
 			return nil, err
 		}
 		desiredStatus := containerd.ProcessStatus(labels[restart.StatusLabel])
-		if m.isSameStatus(ctx, desiredStatus, c) {
+		task, err := c.Task(ctx, nil)
+		if err != nil && desiredStatus == containerd.Stopped {
 			continue
 		}
+		status, err := task.Status(ctx)
+		if err != nil && desiredStatus == containerd.Stopped {
+			continue
+		}
+		if desiredStatus == status.Status {
+			continue
+		}
+
 		switch desiredStatus {
 		case containerd.Running:
+			if !restart.Reconcile(status, labels) {
+				continue
+			}
+			restartCount, _ := strconv.Atoi(labels[restart.CountLabel])
 			changes = append(changes, &startChange{
 				container: c,
 				logPath:   labels[restart.LogPathLabel],
 				logURI:    labels[restart.LogURILabel],
+				count:     restartCount + 1,
 			})
 		case containerd.Stopped:
 			changes = append(changes, &stopChange{
@@ -230,16 +246,4 @@ func (m *monitor) monitor(ctx context.Context) ([]change, error) {
 		}
 	}
 	return changes, nil
-}
-
-func (m *monitor) isSameStatus(ctx context.Context, desired containerd.ProcessStatus, container containerd.Container) bool {
-	task, err := container.Task(ctx, nil)
-	if err != nil {
-		return desired == containerd.Stopped
-	}
-	state, err := task.Status(ctx)
-	if err != nil {
-		return desired == containerd.Stopped
-	}
-	return desired == state.Status
 }

--- a/runtime/restart/restart_test.go
+++ b/runtime/restart/restart_test.go
@@ -1,0 +1,221 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package restart
+
+import (
+	"testing"
+
+	"github.com/containerd/containerd"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRestartPolicy(t *testing.T) {
+	tests := []struct {
+		policy string
+		want   *Policy
+	}{
+		{
+			policy: "unknow",
+			want:   nil,
+		},
+		{
+			policy: "",
+			want:   &Policy{name: "always"},
+		},
+		{
+			policy: "always",
+			want:   &Policy{name: "always"},
+		},
+		{
+			policy: "always:3",
+			want:   nil,
+		},
+		{
+			policy: "on-failure",
+			want:   &Policy{name: "on-failure"},
+		},
+		{
+			policy: "on-failure:10",
+			want: &Policy{
+				name:              "on-failure",
+				maximumRetryCount: 10,
+			},
+		},
+		{
+			policy: "unless-stopped",
+			want: &Policy{
+				name: "unless-stopped",
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		result, _ := NewPolicy(testCase.policy)
+		assert.Equal(t, testCase.want, result)
+	}
+}
+
+func TestRestartPolicyToString(t *testing.T) {
+	tests := []struct {
+		policy string
+		want   string
+	}{
+		{
+			policy: "",
+			want:   "always",
+		},
+		{
+			policy: "always",
+			want:   "always",
+		},
+		{
+			policy: "on-failure",
+			want:   "on-failure",
+		},
+		{
+			policy: "on-failure:10",
+			want:   "on-failure:10",
+		},
+		{
+			policy: "unless-stopped",
+			want:   "unless-stopped",
+		},
+	}
+
+	for _, testCase := range tests {
+		policy, err := NewPolicy(testCase.policy)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result := policy.String()
+		assert.Equal(t, testCase.want, result)
+	}
+}
+
+func TestRestartPolicyReconcile(t *testing.T) {
+	tests := []struct {
+		status containerd.Status
+		labels map[string]string
+		want   bool
+	}{
+		{
+			status: containerd.Status{
+				Status: containerd.Stopped,
+			},
+			labels: map[string]string{
+				PolicyLabel: "always",
+			},
+			want: true,
+		},
+		{
+			status: containerd.Status{
+				Status: containerd.Unknown,
+			},
+			labels: map[string]string{
+				PolicyLabel: "always",
+			},
+			want: true,
+		},
+		{
+			status: containerd.Status{
+				Status: containerd.Stopped,
+			},
+			labels: map[string]string{
+				PolicyLabel: "on-failure:10",
+				CountLabel:  "1",
+			},
+			want: false,
+		},
+		{
+			status: containerd.Status{
+				Status:     containerd.Unknown,
+				ExitStatus: 1,
+			},
+			// test without count label
+			labels: map[string]string{
+				PolicyLabel: "on-failure:10",
+			},
+			want: true,
+		},
+		{
+			status: containerd.Status{
+				Status:     containerd.Unknown,
+				ExitStatus: 1,
+			},
+			// test without valid count label
+			labels: map[string]string{
+				PolicyLabel: "on-failure:10",
+				CountLabel:  "invalid",
+			},
+			want: false,
+		},
+		{
+			status: containerd.Status{
+				Status:     containerd.Unknown,
+				ExitStatus: 1,
+			},
+			labels: map[string]string{
+				PolicyLabel: "on-failure:10",
+				CountLabel:  "1",
+			},
+			want: true,
+		},
+		{
+			status: containerd.Status{
+				Status:     containerd.Unknown,
+				ExitStatus: 1,
+			},
+			labels: map[string]string{
+				PolicyLabel: "on-failure:3",
+				CountLabel:  "3",
+			},
+			want: false,
+		},
+		{
+			status: containerd.Status{
+				Status: containerd.Unknown,
+			},
+			labels: map[string]string{
+				PolicyLabel: "unless-stopped",
+			},
+			want: true,
+		},
+		{
+			status: containerd.Status{
+				Status: containerd.Stopped,
+			},
+			labels: map[string]string{
+				PolicyLabel: "unless-stopped",
+			},
+			want: true,
+		},
+		{
+			status: containerd.Status{
+				Status: containerd.Stopped,
+			},
+			labels: map[string]string{
+				PolicyLabel:            "unless-stopped",
+				ExplicitlyStoppedLabel: "true",
+			},
+			want: false,
+		},
+	}
+	for _, testCase := range tests {
+		result := Reconcile(testCase.status, testCase.labels)
+		assert.Equal(t, testCase.want, result, testCase)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Ye Sijun <junnplus@gmail.com>

TL;DR: In order to be compatible with the restart policies of docker in nerdctl, we need enhance containerd's restart manager by adding a label:
`containerd.io/restart.policy`, `containerd.io/restart.count`.

Discussed in https://github.com/containerd/nerdctl/issues/945

```
policy, _ := restart.NewPolicy("on-failure")
container, err := client.NewContainer(ctx, id,
    restart.WithStatus(containerd.Running),
    restart.WithPolicy(policy))
```