### PR TITLE
Add no_tracing tag

### DIFF
--- a/cmd/containerd/builtins.go
+++ b/cmd/containerd/builtins.go
@@ -36,5 +36,4 @@ import (
 	_ "github.com/containerd/containerd/services/snapshots"
 	_ "github.com/containerd/containerd/services/tasks"
 	_ "github.com/containerd/containerd/services/version"
-	_ "github.com/containerd/containerd/tracing/plugin"
 )

--- a/cmd/containerd/builtins_tracing.go
+++ b/cmd/containerd/builtins_tracing.go
@@ -1,0 +1,24 @@
+//go:build !no_tracing
+// +build !no_tracing
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	_ "github.com/containerd/containerd/tracing/plugin"
+)

--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -35,7 +35,6 @@ import (
 	"github.com/containerd/containerd/services/server"
 	srvconfig "github.com/containerd/containerd/services/server/config"
 	"github.com/containerd/containerd/sys"
-	"github.com/containerd/containerd/tracing"
 	"github.com/containerd/containerd/version"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -302,7 +301,6 @@ func applyFlags(context *cli.Context, config *srvconfig.Config) error {
 	if err := setLogFormat(config); err != nil {
 		return err
 	}
-	setLogHooks()
 
 	for _, v := range []struct {
 		name string
@@ -367,10 +365,6 @@ func setLogFormat(config *srvconfig.Config) error {
 	}
 
 	return nil
-}
-
-func setLogHooks() {
-	logrus.StandardLogger().AddHook(tracing.NewLogrusHook())
 }
 
 func dumpStacks(writeToFile bool) {

--- a/tracing/plugin/otlp.go
+++ b/tracing/plugin/otlp.go
@@ -25,6 +25,8 @@ import (
 
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/plugin"
+	"github.com/containerd/containerd/tracing"
+	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
@@ -59,6 +61,9 @@ func init() {
 			return newTracer(ic)
 		},
 	})
+
+	// Register logging hook for tracing
+	logrus.StandardLogger().AddHook(tracing.NewLogrusHook())
 }
 
 // OTLPConfig holds the configurations for the built-in otlp span processor


### PR DESCRIPTION
Tracing plugin pulls in a few heavy vendor dependencies, which is not always a requirement.
For cases, when tracing is not needed, this PR adds `no_tracing` build tag to exclude it at build time.

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>