### PR TITLE
Remove unmaintained contrib/linuxkit

### DIFF
--- a/contrib/linuxkit/README.md
+++ b/contrib/linuxkit/README.md
@@ -1,8 +1,0 @@
-# LinuxKit Kubernetes project
-
-The [LinuxKit](https://github.com/linuxkit/kubernetes) is a project for building os images for kubernetes master and worker node virtual machines.
-
-When the images are built with cri-containerd as the `KUBE_RUNTIME` option they will use `cri-containerd` as their execution backend.
-```
-make all KUBE_RUNTIME=cri-containerd
-```


### PR DESCRIPTION
The last commit on https://github.com/linuxkit/kubernetes was on Nov 2018.