### PR TITLE
[Windows CI] Address some timeout issues

### DIFF
--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -153,7 +153,11 @@ jobs:
 
       - name: RunIntegrationTests
         run: |
-          ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }} "sh.exe -c 'cd /c/containerd && (make integration | tee /c/Logs/integration.log)'"
+          ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }} "sh.exe -s" << EOF
+            cd /c/containerd
+            export EXTRA_TESTFLAGS="-timeout=20m"
+            make integration | tee /c/Logs/integration.log
+          EOF
           ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }} "sh.exe -c 'cat /c/Logs/integration.log | go-junit-report.exe > /c/Logs/junit_00.xml'"
 
       - name: PrepareRepoList

--- a/script/setup/prepare_env_windows.ps1
+++ b/script/setup/prepare_env_windows.ps1
@@ -1,5 +1,10 @@
 # Prepare windows environment for building and running containerd tests
 
+# Disable Windows Defender real time monitoring. Real time monitoring consumes a lot of
+# CPU and slows down tests as images are unarchived, and is not really needed in a short
+# lived test environment.
+Set-MpPreference -DisableRealtimeMonitoring:$true
+
 $PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.18"; make = ""; nssm = "" }
 
 Write-Host "Downloading chocolatey package"


### PR DESCRIPTION
This change disables Windows Defender real-time monitoring on the test
workers, and increases the test timeout to 20 minutes (default is 10).

The Windows Defender real time monitoring feature scans any newly
created files for malitious contents. This takes up a lot of CPU when
expanding image archives, which contain lots of files. The CI has been
timing out due to the fact that tests take longer than 10 minutes. This
change should address that issue.

Signed-off-by: Gabriel Adrian Samfira <gsamfira@cloudbasesolutions.com>