### PR TITLE
Use t.Setenv instead of os.Setenv

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,8 @@ linters:
     - unused
     - misspell
     - gosec
+    - exportloopref # Checks for pointers to enclosing loop variables
+    - tenv # Detects using os.Setenv instead of t.Setenv since Go 1.17
   disable:
     - errcheck
 
@@ -38,6 +40,10 @@ run:
   timeout: 8m
   skip-dirs:
     - api
+    - cluster
     - design
     - docs
     - docs/man
+    - releases
+    - reports
+    - test # e2e scripts

--- a/archive/compression/compression_test.go
+++ b/archive/compression/compression_test.go
@@ -135,9 +135,7 @@ func TestDetectPigz(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	oldPath := os.Getenv("PATH")
-	os.Setenv("PATH", tempPath)
-	defer os.Setenv("PATH", oldPath)
+	t.Setenv("PATH", tempPath)
 
 	if pigzPath := detectPigz(); pigzPath == "" {
 		t.Fatal("failed to detect pigz path")
@@ -145,8 +143,7 @@ func TestDetectPigz(t *testing.T) {
 		t.Fatalf("wrong pigz found: %s != %s", pigzPath, fullPath)
 	}
 
-	os.Setenv(disablePigzEnv, "1")
-	defer os.Unsetenv(disablePigzEnv)
+	t.Setenv(disablePigzEnv, "1")
 
 	if pigzPath := detectPigz(); pigzPath != "" {
 		t.Fatalf("disable via %s doesn't work", disablePigzEnv)

--- a/namespaces/context_test.go
+++ b/namespaces/context_test.go
@@ -18,7 +18,6 @@ package namespaces
 
 import (
 	"context"
-	"os"
 	"testing"
 )
 
@@ -47,9 +46,6 @@ func TestContext(t *testing.T) {
 }
 
 func TestNamespaceFromEnv(t *testing.T) {
-	oldenv := os.Getenv(NamespaceEnvVar)
-	defer os.Setenv(NamespaceEnvVar, oldenv) // restore old env var
-
 	ctx := context.Background()
 	namespace, ok := Namespace(ctx)
 	if ok {
@@ -61,7 +57,7 @@ func TestNamespaceFromEnv(t *testing.T) {
 	}
 
 	expected := "test-namespace"
-	os.Setenv(NamespaceEnvVar, expected)
+	t.Setenv(NamespaceEnvVar, expected)
 	nctx := NamespaceFromEnv(ctx)
 
 	namespace, ok = Namespace(nctx)

--- a/runtime/v2/shim/shim_test.go
+++ b/runtime/v2/shim/shim_test.go
@@ -18,7 +18,6 @@ package shim
 
 import (
 	"context"
-	"os"
 	"runtime"
 	"testing"
 )
@@ -27,7 +26,7 @@ func TestRuntimeWithEmptyMaxEnvProcs(t *testing.T) {
 	var oldGoMaxProcs = runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(oldGoMaxProcs)
 
-	os.Setenv("GOMAXPROCS", "")
+	t.Setenv("GOMAXPROCS", "")
 	setRuntime()
 
 	var currentGoMaxProcs = runtime.GOMAXPROCS(0)
@@ -37,7 +36,7 @@ func TestRuntimeWithEmptyMaxEnvProcs(t *testing.T) {
 }
 
 func TestRuntimeWithNonEmptyMaxEnvProcs(t *testing.T) {
-	os.Setenv("GOMAXPROCS", "not_empty")
+	t.Setenv("GOMAXPROCS", "not_empty")
 	setRuntime()
 	var oldGoMaxProcs2 = runtime.GOMAXPROCS(0)
 	if oldGoMaxProcs2 != runtime.NumCPU() {


### PR DESCRIPTION
Go 1.17 introduced `t.Setenv`, which automatically restores env changes on test cleanup.
It's quite handy to use instead of `os.Setenv` which requires to restore env manually. Also this PR adds a few changes to linter's config.