### PR TITLE
Set timeout when collecting metrics from shim's Stat

### DIFF
--- a/metrics/cgroups/v1/metrics.go
+++ b/metrics/cgroups/v1/metrics.go
@@ -26,9 +26,11 @@ import (
 
 	"github.com/containerd/cgroups"
 	"github.com/containerd/containerd/log"
+	cmetrics "github.com/containerd/containerd/metrics"
 	"github.com/containerd/containerd/metrics/cgroups/common"
 	v1 "github.com/containerd/containerd/metrics/types/v1"
 	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/pkg/timeout"
 	"github.com/containerd/typeurl"
 	"github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
@@ -136,13 +138,17 @@ func (c *Collector) collect(entry entry, ch chan<- prometheus.Metric, block bool
 	if wg != nil {
 		defer wg.Done()
 	}
+
 	t := entry.task
-	ctx := namespaces.WithNamespace(context.Background(), t.Namespace())
-	stats, err := t.Stats(ctx)
+	ctx, cancel := timeout.WithContext(context.Background(), cmetrics.ShimStatsRequestTimeout)
+	stats, err := t.Stats(namespaces.WithNamespace(ctx, t.Namespace()))
+	cancel()
+
 	if err != nil {
 		log.L.WithError(err).Errorf("stat task %s", t.ID())
 		return
 	}
+
 	data, err := typeurl.UnmarshalAny(stats)
 	if err != nil {
 		log.L.WithError(err).Errorf("unmarshal stats for %s", t.ID())

--- a/metrics/cgroups/v2/metrics.go
+++ b/metrics/cgroups/v2/metrics.go
@@ -25,9 +25,11 @@ import (
 	"sync"
 
 	"github.com/containerd/containerd/log"
+	cmetrics "github.com/containerd/containerd/metrics"
 	"github.com/containerd/containerd/metrics/cgroups/common"
 	v2 "github.com/containerd/containerd/metrics/types/v2"
 	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/pkg/timeout"
 	"github.com/containerd/typeurl"
 	"github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
@@ -129,13 +131,17 @@ func (c *Collector) collect(entry entry, ch chan<- prometheus.Metric, block bool
 	if wg != nil {
 		defer wg.Done()
 	}
+
 	t := entry.task
-	ctx := namespaces.WithNamespace(context.Background(), t.Namespace())
-	stats, err := t.Stats(ctx)
+	ctx, cancel := timeout.WithContext(context.Background(), cmetrics.ShimStatsRequestTimeout)
+	stats, err := t.Stats(namespaces.WithNamespace(ctx, t.Namespace()))
+	cancel()
+
 	if err != nil {
 		log.L.WithError(err).Errorf("stat task %s", t.ID())
 		return
 	}
+
 	data, err := typeurl.UnmarshalAny(stats)
 	if err != nil {
 		log.L.WithError(err).Errorf("unmarshal stats for %s", t.ID())

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -17,8 +17,15 @@
 package metrics
 
 import (
+	"time"
+
+	"github.com/containerd/containerd/pkg/timeout"
 	"github.com/containerd/containerd/version"
 	goMetrics "github.com/docker/go-metrics"
+)
+
+const (
+	ShimStatsRequestTimeout = "io.containerd.timeout.metrics.shimstats"
 )
 
 func init() {
@@ -26,4 +33,5 @@ func init() {
 	c := ns.NewLabeledCounter("build_info", "containerd build information", "version", "revision")
 	c.WithValues(version.Version, version.Revision).Inc()
 	goMetrics.Register(ns)
+	timeout.Set(ShimStatsRequestTimeout, 2*time.Second)
 }


### PR DESCRIPTION
### Issue

- When containerd collects metrics from shim's [Stat API](https://github.com/containerd/containerd/blob/d3aa7ee9f065d5d8773b4b38124ad6e3d6634dc2/runtime/v2/task/shim.proto#L49), there is no timeout set:

https://github.com/containerd/containerd/blob/d3aa7ee9f065d5d8773b4b38124ad6e3d6634dc2/metrics/cgroups/v2/metrics.go#L118
https://github.com/containerd/containerd/blob/d3aa7ee9f065d5d8773b4b38124ad6e3d6634dc2/metrics/cgroups/v1/metrics.go#L125

-  If the shim process is not responsive, the request blocks there, `Collect.Collect()` blocks. https://github.com/containerd/containerd/blob/d3aa7ee9f065d5d8773b4b38124ad6e3d6634dc2/metrics/cgroups/v2/metrics.go#L92

- This causes leaked goroutines and memory. Requests to prometheus metrics /v1/metrics to hangs when there is a "bad shim"

### Reproducing

- Launch containerd with "metrics" and "debug" enable

```sh
cat /etc/containerd/config.toml
[metrics]
    address = ":8080"
[debug]
    address = "/run/containerd/debug.sock"
```

- I launched a container with a mock shim implementation that hangs on Stats: https://github.com/phanhuy1502/containerd/commit/a6add780c2b58b32751bd9549aae1ae33f9d2e6b

- Observe request to prometheus endpoint hangs

```sh
curl localhost:8080/v1/metrics
# hangs
```

- Goroutines dump of containerd daemon shows hangs in the `Stats` call to the shim process

```bash
ctr pprof goroutines > /tmp/containerd_goroutines

grep "/metrics.go" /tmp/containerd_goroutines
        /go/src/github.com/containerd/containerd/metrics/cgroups/v1/metrics.go:117 +0x233
        /go/src/github.com/containerd/containerd/metrics/cgroups/v1/metrics.go:126 +0x118
        /go/src/github.com/containerd/containerd/metrics/cgroups/v1/metrics.go:104 +0xb1
```

### Fix

- Send a request to shim with timeout. Default to 2 seconds.
- I repeat the same steps to verify. After the fix, containerd daemon returns Prometheus metrics even when one of the shim hangs, containerd logs show a request timeout to stat:

```
Apr 06 09:00:04 ubuntu-xenial containerd[25364]: time="2022-04-06T09:00:04.189993886Z" level=error msg="stat task test1" error="context deadline exceeded: unknown"
```

### Timeout setting

The default timeout is set to 2 seconds. Can be configured by:

```
[timeouts]
    "io.containerd.timeout.metrics.shimstats" = "10s"
```

Signed-off-by: Nguyen Phan Huy <phanhuy1502@gmail.com>