### PR TITLE
Pin upload-cloud-storage action to 0.8.0 in Windows workflow.

### DIFF
--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -235,7 +235,7 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
 
       - name: UploadJobReport
-        uses: google-github-actions/upload-cloud-storage@v0
+        uses: google-github-actions/upload-cloud-storage@v0.8.0
         if: steps.AssignGcpCreds.outputs.GCP_SERVICE_ACCOUNT && steps.AssignGcpCreds.outputs.GCP_WORKLOAD_IDENTITY_PROVIDER
         with:
           path: ${{ github.workspace }}/latest-build.txt
@@ -243,7 +243,7 @@ jobs:
           parent: false
 
       - name: UploadLogsDir
-        uses: google-github-actions/upload-cloud-storage@v0
+        uses: google-github-actions/upload-cloud-storage@v0.8.0
         if: steps.AssignGcpCreds.outputs.GCP_SERVICE_ACCOUNT && steps.AssignGcpCreds.outputs.GCP_WORKLOAD_IDENTITY_PROVIDER
         with:
           path: ${{ env.LOGS_DIR }}


### PR DESCRIPTION
Pin the version of the `google-github-actions/upload-cloud-storage`
action library to `0.8.0` to avoid a regression which prevents
test results being uploaded in the Windows periodic workflow.

Signed-off-by: Nashwan Azhari <nazhari@cloudbasesolutions.com>