### PR TITLE
Do not append []string{""} to command to preserve Docker compatibility

### DIFF
--- a/pkg/cri/opts/spec.go
+++ b/pkg/cri/opts/spec.go
@@ -63,7 +63,9 @@ func WithProcessArgs(config *runtime.ContainerConfig, image *imagespec.ImageConf
 				args = append([]string{}, image.Cmd...)
 			}
 			if command == nil {
-				command = append([]string{}, image.Entrypoint...)
+				if !(len(image.Entrypoint) == 1 && image.Entrypoint[0] == "") {
+					command = append([]string{}, image.Entrypoint...)
+				}
 			}
 		}
 		if len(command) == 0 && len(args) == 0 {


### PR DESCRIPTION
Preserve compatibility with `docker run`: https://github.com/moby/moby/blob/99b2894e17528d0f8640d91bc3c0001e5a99cb3b/daemon/create.go#L279-L282

Some build tools (notably `docker run` and `docker commit`) creates a string slice with an empty string as the first member. This gets stripped in `docker run` and works transparently if you use docker/moby as container runtime. Does not work so well in the containerd, unfortunately.