### PR TITLE
check for duplicate nspath possibilities

### DIFF
--- a/pkg/netns/netns_linux.go
+++ b/pkg/netns/netns_linux.go
@@ -52,7 +52,9 @@ import (
 // path to the network namespace.
 func newNS(baseDir string) (nsPath string, err error) {
 	b := make([]byte, 16)
-	if _, err := rand.Reader.Read(b); err != nil {
+
+	_, err = rand.Read(b)
+	if err != nil {
 		return "", fmt.Errorf("failed to generate random netns name: %w", err)
 	}
 
@@ -63,10 +65,10 @@ func newNS(baseDir string) (nsPath string, err error) {
 		return "", err
 	}
 
-	// create an empty file at the mount point
+	// create an empty file at the mount point and fail if it already exists
 	nsName := fmt.Sprintf("cni-%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
 	nsPath = path.Join(baseDir, nsName)
-	mountPointFd, err := os.Create(nsPath)
+	mountPointFd, err := os.OpenFile(nsPath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Seeing a flake in k8s e2e summary test that should not happen where network stats do not exist as reported by cadvisor. While debugging ran into docs indicating rand.Reader.Read may return < n bytes, may return 0 with no err. .. Per suggestion from @fuweid moved to rand.Read()...  While in here should not hurt to check if the "random" generated namespace already exists, because in use or because did not get torn down. If the later and still exists should do further investigation for tearing it down. 

`https://github.com/kubernetes/kubernetes/issues/109082`

Signed-off-by: Mike Brown <brownwm@us.ibm.com>