### PR TITLE
fix pool_device_test

### DIFF
--- a/snapshots/devmapper/pool_device_test.go
+++ b/snapshots/devmapper/pool_device_test.go
@@ -40,8 +40,8 @@ const (
 	thinDevice1 = "thin-1"
 	thinDevice2 = "thin-2"
 	snapDevice1 = "snap-1"
-	device1Size = 100000
-	device2Size = 200000
+	device1Size = 1000000
+	device2Size = 2000000
 	testsPrefix = "devmapper-snapshotter-tests-"
 )
 


### PR DESCRIPTION
fixed #6627 

## Issue

While executing mke2fs, 'Not enough space to build proposed filesystem while setting up superblock' is happend.

## Fix
extend the disk size.

On the original issue #6627 , the architecture (ppc64le) is the cause, but it is reproduced on Ubuntu 20.04 on x86-64 and not reproduced on Ubuntu18.04 on ppc64le.
So, I think it is caused by the change in Ubuntu version.

`make root-test` result is below.

### before change

ubuntu20.04 on x86-64 (EC2)
```
+ root-test
...
--- FAIL: TestPoolDevice (1.65s)
    --- FAIL: TestPoolDevice/MakeFileSystem (0.01s)
        pool_device_test.go:245:
                Error Trace:    pool_device_test.go:245
                                                        pool_device_test.go:103
                Error:          Expected nil, but got: &exec.ExitError{ProcessState:(*os.ProcessState)(0xc0002677d0), Stderr:[]uint8(nil)}
                Test:           TestPoolDevice/MakeFileSystem
                Messages:       failed to make filesystem on 'thin-1': mke2fs 1.45.5 (07-Jan-2020)
                                /dev/mapper/thin-1: Not enough space to build proposed filesystem while setting up superblock
        pool_device_test.go:249:
                Error Trace:    pool_device_test.go:249
                                                        pool_device_test.go:103
                Error:          Should be true
                Test:           TestPoolDevice/MakeFileSystem
    pool_device_test.go:130:
                Error Trace:    pool_device_test.go:130
                Error:          Received unexpected error:
                                failed to mount /run/user/0/containerd-mount2737791447: invalid argument
                Test:           TestPoolDevice
    pool_device_test.go:142:
                Error Trace:    pool_device_test.go:142
                Error:          Received unexpected error:
                                failed to mount /run/user/0/containerd-mount1848998475: invalid argument
                Test:           TestPoolDevice
...
```

ubuntu20.04 on ppc64el (QEMU)

```
+ root-test
....

--- FAIL: TestPoolDevice (42.77s)
    --- FAIL: TestPoolDevice/MakeFileSystem (1.15s)
        pool_device_test.go:245:
            	Error Trace:	pool_device_test.go:245
            	            				pool_device_test.go:103
            	Error:      	Expected nil, but got: &exec.ExitError{ProcessState:(*os.ProcessState)(0xc000214060), Stderr:[]uint8(nil)}
            	Test:       	TestPoolDevice/MakeFileSystem
            	Messages:   	failed to make filesystem on 'thin-1': mke2fs 1.45.5 (07-Jan-2020)
            	            	/dev/mapper/thin-1: Not enough space to build proposed filesystem while setting up superblock
        pool_device_test.go:249:
            	Error Trace:	pool_device_test.go:249
            	            				pool_device_test.go:103
            	Error:      	Should be true
            	Test:       	TestPoolDevice/MakeFileSystem
    pool_device_test.go:130:
        	Error Trace:	pool_device_test.go:130
        	Error:      	Received unexpected error:
        	            	failed to mount /run/user/1000/containerd-mount3435104661: invalid argument
        	Test:       	TestPoolDevice
    pool_device_test.go:142:
        	Error Trace:	pool_device_test.go:142
        	Error:      	Received unexpected error:
        	            	failed to mount /run/user/1000/containerd-mount3924761438: invalid argument
        	Test:       	TestPoolDevice

...
```

### after change

ubuntu20.04 on x86-64 (EC2)
```
+ root-test
ok      github.com/containerd/containerd/archive        1.353s
ok      github.com/containerd/containerd/metadata       25.322s
ok      github.com/containerd/containerd/mount  0.633s
ok      github.com/containerd/containerd/oci    0.074s
ok      github.com/containerd/containerd/runtime/v1/linux       0.042s
ok      github.com/containerd/containerd/runtime/v2     0.042s
ok      github.com/containerd/containerd/snapshots/btrfs        0.029s
ok      github.com/containerd/containerd/snapshots/devmapper    67.495s
ok      github.com/containerd/containerd/snapshots/devmapper/dmsetup    0.606s
ok      github.com/containerd/containerd/snapshots/native       14.947s
ok      github.com/containerd/containerd/snapshots/overlay      29.535s
ok      github.com/containerd/containerd/snapshots/overlay/overlayutils 0.024s [no tests to run]
```

ubuntu20.04 on ppc64el (QEMU)

```
+ root-test
ok  	github.com/containerd/containerd/archive	89.362s
ok  	github.com/containerd/containerd/metadata	450.899s
ok  	github.com/containerd/containerd/mount	18.712s
ok  	github.com/containerd/containerd/oci	4.244s
ok  	github.com/containerd/containerd/runtime/v1/linux	3.634s
ok  	github.com/containerd/containerd/runtime/v2	4.581s
ok  	github.com/containerd/containerd/snapshots/btrfs	408.540s
ok  	github.com/containerd/containerd/snapshots/devmapper	890.803s
ok  	github.com/containerd/containerd/snapshots/devmapper/dmsetup	33.302s
ok  	github.com/containerd/containerd/snapshots/native	385.485s
ok  	github.com/containerd/containerd/snapshots/overlay	448.571s
ok  	github.com/containerd/containerd/snapshots/overlay/overlayutils	1.914s [no tests to run]
```

Signed-off-by: Shinichi Morimoto <shnmorimoto@gmail.com>