### PR TITLE
allow ptrace(2) by default for kernel >= 4.8

### DIFF
--- a/contrib/seccomp/kernelversion/kernel_linux.go
+++ b/contrib/seccomp/kernelversion/kernel_linux.go
@@ -1,0 +1,92 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+   File copied and customized based on
+   https://github.com/moby/moby/tree/v20.10.14/profiles/seccomp/kernel_linux.go
+*/
+
+package kernelversion
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+
+	"golang.org/x/sys/unix"
+)
+
+// KernelVersion holds information about the kernel.
+type KernelVersion struct {
+	Kernel uint64 // Version of the Kernel (i.e., the "4" in "4.1.2-generic")
+	Major  uint64 // Major revision of the Kernel (i.e., the "1" in "4.1.2-generic")
+}
+
+// String implements fmt.Stringer for KernelVersion
+func (k *KernelVersion) String() string {
+	if k.Kernel > 0 || k.Major > 0 {
+		return fmt.Sprintf("%d.%d", k.Kernel, k.Major)
+	}
+	return ""
+}
+
+var (
+	currentKernelVersion *KernelVersion
+	kernelVersionError   error
+	once                 sync.Once
+)
+
+// getKernelVersion gets the current kernel version.
+func getKernelVersion() (*KernelVersion, error) {
+	once.Do(func() {
+		var uts unix.Utsname
+		if err := unix.Uname(&uts); err != nil {
+			return
+		}
+		// Remove the \x00 from the release for Atoi to parse correctly
+		currentKernelVersion, kernelVersionError = parseRelease(string(uts.Release[:bytes.IndexByte(uts.Release[:], 0)]))
+	})
+	return currentKernelVersion, kernelVersionError
+}
+
+// parseRelease parses a string and creates a KernelVersion based on it.
+func parseRelease(release string) (*KernelVersion, error) {
+	var version = KernelVersion{}
+
+	// We're only make sure we get the "kernel" and "major revision". Sometimes we have
+	// 3.12.25-gentoo, but sometimes we just have 3.12-1-amd64.
+	_, err := fmt.Sscanf(release, "%d.%d", &version.Kernel, &version.Major)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse kernel version %q: %w", release, err)
+	}
+	return &version, nil
+}
+
+// GreaterEqualThan checks if the host's kernel version is greater than, or
+// equal to the given kernel version v. Only "kernel version" and "major revision"
+// can be specified (e.g., "3.12") and will be taken into account, which means
+// that 3.12.25-gentoo and 3.12-1-amd64 are considered equal (kernel: 3, major: 12).
+func GreaterEqualThan(minVersion KernelVersion) (bool, error) {
+	kv, err := getKernelVersion()
+	if err != nil {
+		return false, err
+	}
+	if kv.Kernel > minVersion.Kernel {
+		return true, nil
+	}
+	if kv.Kernel == minVersion.Kernel && kv.Major >= minVersion.Major {
+		return true, nil
+	}
+	return false, nil
+}

--- a/contrib/seccomp/kernelversion/kernel_linux_test.go
+++ b/contrib/seccomp/kernelversion/kernel_linux_test.go
@@ -1,0 +1,141 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+   File copied and customized based on
+   https://github.com/moby/moby/tree/v20.10.14/profiles/seccomp/kernel_linux_test.go
+*/
+
+package kernelversion
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestGetKernelVersion(t *testing.T) {
+	version, err := getKernelVersion()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version == nil {
+		t.Fatal("version is nil")
+	}
+	if version.Kernel == 0 {
+		t.Fatal("no kernel version")
+	}
+}
+
+// TestParseRelease tests the ParseRelease() function
+func TestParseRelease(t *testing.T) {
+	tests := []struct {
+		in          string
+		out         KernelVersion
+		expectedErr error
+	}{
+		{in: "3.8", out: KernelVersion{Kernel: 3, Major: 8}},
+		{in: "3.8.0", out: KernelVersion{Kernel: 3, Major: 8}},
+		{in: "3.8.0-19-generic", out: KernelVersion{Kernel: 3, Major: 8}},
+		{in: "3.4.54.longterm-1", out: KernelVersion{Kernel: 3, Major: 4}},
+		{in: "3.10.0-862.2.3.el7.x86_64", out: KernelVersion{Kernel: 3, Major: 10}},
+		{in: "3.12.8tag", out: KernelVersion{Kernel: 3, Major: 12}},
+		{in: "3.12-1-amd64", out: KernelVersion{Kernel: 3, Major: 12}},
+		{in: "3.12foobar", out: KernelVersion{Kernel: 3, Major: 12}},
+		{in: "99.999.999-19-generic", out: KernelVersion{Kernel: 99, Major: 999}},
+		{in: "", expectedErr: fmt.Errorf(`failed to parse kernel version "": EOF`)},
+		{in: "3", expectedErr: fmt.Errorf(`failed to parse kernel version "3": unexpected EOF`)},
+		{in: "3.", expectedErr: fmt.Errorf(`failed to parse kernel version "3.": EOF`)},
+		{in: "3a", expectedErr: fmt.Errorf(`failed to parse kernel version "3a": input does not match format`)},
+		{in: "3.a", expectedErr: fmt.Errorf(`failed to parse kernel version "3.a": expected integer`)},
+		{in: "a", expectedErr: fmt.Errorf(`failed to parse kernel version "a": expected integer`)},
+		{in: "a.a", expectedErr: fmt.Errorf(`failed to parse kernel version "a.a": expected integer`)},
+		{in: "a.a.a-a", expectedErr: fmt.Errorf(`failed to parse kernel version "a.a.a-a": expected integer`)},
+		{in: "-3", expectedErr: fmt.Errorf(`failed to parse kernel version "-3": expected integer`)},
+		{in: "-3.", expectedErr: fmt.Errorf(`failed to parse kernel version "-3.": expected integer`)},
+		{in: "-3.8", expectedErr: fmt.Errorf(`failed to parse kernel version "-3.8": expected integer`)},
+		{in: "-3.-8", expectedErr: fmt.Errorf(`failed to parse kernel version "-3.-8": expected integer`)},
+		{in: "3.-8", expectedErr: fmt.Errorf(`failed to parse kernel version "3.-8": expected integer`)},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.in, func(t *testing.T) {
+			version, err := parseRelease(tc.in)
+			if tc.expectedErr != nil {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				if err.Error() != tc.expectedErr.Error() {
+					t.Fatalf("expected: %s, got: %s", tc.expectedErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal("unexpected error:", err)
+			}
+			if version == nil {
+				t.Fatal("version is nil")
+			}
+			if version.Kernel != tc.out.Kernel || version.Major != tc.out.Major {
+				t.Fatalf("expected: %d.%d, got: %d.%d", tc.out.Kernel, tc.out.Major, version.Kernel, version.Major)
+			}
+		})
+	}
+}
+
+func TestGreaterEqualThan(t *testing.T) {
+	// Get the current kernel version, so that we can make test relative to that
+	v, err := getKernelVersion()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		doc      string
+		in       KernelVersion
+		expected bool
+	}{
+		{
+			doc:      "same version",
+			in:       KernelVersion{v.Kernel, v.Major},
+			expected: true,
+		},
+		{
+			doc:      "kernel minus one",
+			in:       KernelVersion{v.Kernel - 1, v.Major},
+			expected: true,
+		},
+		{
+			doc:      "kernel plus one",
+			in:       KernelVersion{v.Kernel + 1, v.Major},
+			expected: false,
+		},
+		{
+			doc:      "major plus one",
+			in:       KernelVersion{v.Kernel, v.Major + 1},
+			expected: false,
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.doc+": "+tc.in.String(), func(t *testing.T) {
+			ok, err := GreaterEqualThan(tc.in)
+			if err != nil {
+				t.Fatal("unexpected error:", err)
+			}
+			if ok != tc.expected {
+				t.Fatalf("expected: %v, got: %v", tc.expected, ok)
+			}
+		})
+	}
+}

--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -24,6 +24,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
+	"github.com/containerd/containerd/contrib/seccomp/kernelversion"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -465,6 +466,18 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 		DefaultAction: specs.ActErrno,
 		Architectures: arches(),
 		Syscalls:      syscalls,
+	}
+
+	// include by kernel version
+	if ok, err := kernelversion.GreaterEqualThan(
+		kernelversion.KernelVersion{Kernel: 4, Major: 8}); err == nil {
+		if ok {
+			s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
+				Names:  []string{"ptrace"},
+				Action: specs.ActAllow,
+				Args:   []specs.LinuxSeccompArg{},
+			})
+		}
 	}
 
 	// include by arch


### PR DESCRIPTION
Allow `ptrace(2)` by default for kernel >= 4.8

Fixes: #6802 

`kernel_linux.go` and `kernel_linux_test.go` are copied from moby project under:
https://github.com/moby/moby/tree/v20.10.14/profiles/seccomp

Testing was performed on 5.10 kernel with `strace` tool.

Signed-off-by: Henry Wang <henwang@amazon.com>