### PR TITLE
Move lease manager plugin to separate package

### DIFF
--- a/cmd/containerd/builtins.go
+++ b/cmd/containerd/builtins.go
@@ -21,6 +21,7 @@ import (
 	_ "github.com/containerd/containerd/diff/walking/plugin"
 	_ "github.com/containerd/containerd/events/plugin"
 	_ "github.com/containerd/containerd/gc/scheduler"
+	_ "github.com/containerd/containerd/leases/plugin"
 	_ "github.com/containerd/containerd/runtime/restart/monitor"
 	_ "github.com/containerd/containerd/runtime/v2"
 	_ "github.com/containerd/containerd/services/containers"

--- a/leases/plugin/local.go
+++ b/leases/plugin/local.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package leases
+package plugin
 
 import (
 	"context"
@@ -23,15 +23,15 @@ import (
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/metadata"
 	"github.com/containerd/containerd/plugin"
-	"github.com/containerd/containerd/services"
 )
 
 func init() {
 	plugin.Register(&plugin.Registration{
-		Type: plugin.ServicePlugin,
-		ID:   services.LeasesService,
+		Type: plugin.LeasePlugin,
+		ID:   "manager",
 		Requires: []plugin.Type{
 			plugin.MetadataPlugin,
+			plugin.GCPlugin,
 		},
 		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
 			m, err := ic.Get(plugin.MetadataPlugin)

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -76,6 +76,8 @@ const (
 	GCPlugin Type = "io.containerd.gc.v1"
 	// EventPlugin implements event handling
 	EventPlugin Type = "io.containerd.event.v1"
+	// LeasePlugin implements lease manager
+	LeasePlugin Type = "io.containerd.lease.v1"
 	// TracingProcessorPlugin implements a open telemetry span processor
 	TracingProcessorPlugin Type = "io.containerd.tracing.processor.v1"
 )

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -98,12 +98,12 @@ func TestContainerdPlugin(t *testing.T) {
 		Type: GRPCPlugin,
 		ID:   "leases",
 		Requires: []Type{
-			ServicePlugin,
+			LeasePlugin,
 		},
 	})
 	Register(&Registration{
-		Type: ServicePlugin,
-		ID:   services.LeasesService,
+		Type: LeasePlugin,
+		ID:   "manager",
 		Requires: []Type{
 			MetadataPlugin,
 		},
@@ -250,7 +250,6 @@ func TestContainerdPlugin(t *testing.T) {
 		"io.containerd.service.v1.introspection-service",
 		"io.containerd.service.v1.namespaces-service",
 		"io.containerd.service.v1.containers-service",
-		"io.containerd.service.v1.leases-service",
 		"io.containerd.differ.v1.walking",
 		"io.containerd.service.v1.diff-service",
 		"io.containerd.service.v1.snapshots-service",
@@ -259,6 +258,7 @@ func TestContainerdPlugin(t *testing.T) {
 		"io.containerd.grpc.v1.content",
 		"io.containerd.grpc.v1.containers",
 		"io.containerd.grpc.v1.events",
+		"io.containerd.lease.v1.manager",
 		"io.containerd.grpc.v1.leases",
 		"io.containerd.grpc.v1.diff",
 		"io.containerd.grpc.v1.snapshots",

--- a/runtime/restart/monitor/monitor.go
+++ b/runtime/restart/monitor/monitor.go
@@ -91,18 +91,25 @@ func init() {
 
 // getServicesOpts get service options from plugin context.
 func getServicesOpts(ic *plugin.InitContext) ([]containerd.ServicesOpt, error) {
+	var opts []containerd.ServicesOpt
+	for t, fn := range map[plugin.Type]func(interface{}) containerd.ServicesOpt{
+		plugin.EventPlugin: func(i interface{}) containerd.ServicesOpt {
+			return containerd.WithEventService(i.(containerd.EventService))
+		},
+		plugin.LeasePlugin: func(i interface{}) containerd.ServicesOpt {
+			return containerd.WithLeasesService(i.(leases.Manager))
+		},
+	} {
+		i, err := ic.Get(t)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get %q plugin: %w", t, err)
+		}
+		opts = append(opts, fn(i))
+	}
+
 	plugins, err := ic.GetByType(plugin.ServicePlugin)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get service plugin: %w", err)
-	}
-
-	ep, err := ic.Get(plugin.EventPlugin)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get event plugin: %w", err)
-	}
-
-	opts := []containerd.ServicesOpt{
-		containerd.WithEventService(ep.(containerd.EventService)),
 	}
 	for s, fn := range map[string]func(interface{}) containerd.ServicesOpt{
 		services.ContentService: func(s interface{}) containerd.ServicesOpt {
@@ -125,9 +132,6 @@ func getServicesOpts(ic *plugin.InitContext) ([]containerd.ServicesOpt, error) {
 		},
 		services.NamespacesService: func(s interface{}) containerd.ServicesOpt {
 			return containerd.WithNamespaceClient(s.(namespacesapi.NamespacesClient))
-		},
-		services.LeasesService: func(s interface{}) containerd.ServicesOpt {
-			return containerd.WithLeasesService(s.(leases.Manager))
 		},
 	} {
 		p := plugins[s]

--- a/services/leases/service.go
+++ b/services/leases/service.go
@@ -18,13 +18,11 @@ package leases
 
 import (
 	"context"
-	"errors"
 
 	api "github.com/containerd/containerd/api/services/leases/v1"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/plugin"
-	"github.com/containerd/containerd/services"
 	ptypes "github.com/gogo/protobuf/types"
 	"google.golang.org/grpc"
 )
@@ -34,18 +32,10 @@ func init() {
 		Type: plugin.GRPCPlugin,
 		ID:   "leases",
 		Requires: []plugin.Type{
-			plugin.ServicePlugin,
+			plugin.LeasePlugin,
 		},
 		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
-			plugins, err := ic.GetByType(plugin.ServicePlugin)
-			if err != nil {
-				return nil, err
-			}
-			p, ok := plugins[services.LeasesService]
-			if !ok {
-				return nil, errors.New("leases service not found")
-			}
-			i, err := p.Instance()
+			i, err := ic.GetByID(plugin.LeasePlugin, "manager")
 			if err != nil {
 				return nil, err
 			}

--- a/services/services.go
+++ b/services/services.go
@@ -29,8 +29,6 @@ const (
 	TasksService = "tasks-service"
 	// NamespacesService is id of namespaces service.
 	NamespacesService = "namespaces-service"
-	// LeasesService is id of leases service.
-	LeasesService = "leases-service"
 	// DiffService is id of diff service.
 	DiffService = "diff-service"
 	// IntrospectionService is the id of introspection service


### PR DESCRIPTION
Create lease plugin type to separate lease manager from services plugin. This allows other service plugins to depend on the lease manager.
