### PR TITLE
update golang to 1.18.1, 1.17.9

### DIFF
--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.0'
+          go-version: '1.18.1'
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.18.0]
+        go-version: [1.18.1]
         os: [ubuntu-18.04, macos-10.15, windows-2019]
 
     steps:
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.0'
+          go-version: '1.18.1'
 
       - uses: actions/checkout@v2
         with:
@@ -78,7 +78,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.0'
+          go-version: '1.18.1'
 
       - uses: actions/checkout@v2
         with:
@@ -110,7 +110,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.0'
+          go-version: '1.18.1'
       - uses: actions/checkout@v2
       - run: go install github.com/cpuguy83/go-md2man/v2@v2.0.1
       - run: make man
@@ -144,7 +144,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.0'
+          go-version: '1.18.1'
       - uses: actions/checkout@v2
       - run: |
           set -e -x
@@ -201,7 +201,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-10.15, windows-2019, windows-2022]
-        go-version: ['1.17.8', '1.18.0']
+        go-version: ['1.17.9', '1.18.1']
     steps:
       - uses: actions/setup-go@v2
         with:
@@ -247,7 +247,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.0'
+          go-version: '1.18.1'
 
       - uses: actions/checkout@v2
         with:
@@ -375,7 +375,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.0'
+          go-version: '1.18.1'
 
       - uses: actions/checkout@v2
 
@@ -494,7 +494,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.0'
+          go-version: '1.18.1'
       - uses: actions/checkout@v2
       - run: sudo -E PATH=$PATH script/setup/install-gotestsum
       - name: Tests

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: 1.18.0
+        go-version: 1.18.1
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.0'
+          go-version: '1.18.1'
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.0'
+          go-version: '1.18.1'
 
       - uses: actions/checkout@v2
         with:
@@ -135,7 +135,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.0'
+          go-version: '1.18.1'
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.18.0'
+          go-version: '1.18.1'
       - name: Set env
         shell: bash
         env:
@@ -107,7 +107,7 @@ jobs:
           find ./releases/ -maxdepth 1 -type l | xargs rm
         working-directory: src/github.com/containerd/containerd
         env:
-          GO_VERSION: '1.17.2'
+          GO_VERSION: '1.18.1'
           PLATFORM: ${{ matrix.platform }}
       - name: Save Artifacts
         uses: actions/upload-artifact@v2

--- a/.zuul/playbooks/containerd-build/integration-test.yaml
+++ b/.zuul/playbooks/containerd-build/integration-test.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.17.4'
+    go_version: '1.18.1'
     arch: arm64
   tasks:
   - name: Install pre-requisites

--- a/.zuul/playbooks/containerd-build/run.yaml
+++ b/.zuul/playbooks/containerd-build/run.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.18'
+    go_version: '1.18.1'
     arch: arm64
   tasks:
   - name: Build containerd

--- a/.zuul/playbooks/containerd-build/unit-test.yaml
+++ b/.zuul/playbooks/containerd-build/unit-test.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.17.4'
+    go_version: '1.18.1'
     arch: arm64
   tasks:
   - name: Build and test containerd

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -91,7 +91,7 @@ EOF
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.18",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.18.1",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -10,7 +10,7 @@
 #
 # docker build -t containerd-test --build-arg RUNC_VERSION=v1.0.0-rc94 -f Dockerfile.test ../
 
-ARG GOLANG_VERSION=1.18
+ARG GOLANG_VERSION=1.18.1
 ARG GOLANG_IMAGE=golang
 
 FROM ${GOLANG_IMAGE}:${GOLANG_VERSION} AS golang


### PR DESCRIPTION
go1.18.1 (released 2022-04-12) includes security fixes to the crypto/elliptic,
crypto/x509, and encoding/pem packages, as well as bug fixes to the compiler,
linker, runtime, the go command, vet, and the bytes, crypto/x509, and go/types
packages. See the Go 1.18.1 milestone on the issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.18.1+label%3ACherryPickApproved

Includes fixes for:

- CVE-2022-24675 (https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24675)
- CVE-2022-27536 (https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-27536)
- CVE-2022-28327 (https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-28327)

go1.17.9 (released 2022-04-12) includes security fixes to the crypto/elliptic
and encoding/pem packages, as well as bug fixes to the linker and runtime. See
the Go 1.17.9 milestone on the issue tracker for details:

Includes fixes for:

- CVE-2022-24675 (https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24675)
- CVE-2022-28327 (https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-28327)
