### PR TITLE
fix the restart desired to running when task not found

### DIFF
--- a/runtime/restart/monitor/monitor.go
+++ b/runtime/restart/monitor/monitor.go
@@ -232,14 +232,17 @@ func (m *monitor) monitor(ctx context.Context) ([]change, error) {
 			}
 		}
 
-		// Task or Status return error, only desired to stop
+		// Task or Status return error, only desired to running
 		if err != nil {
 			logrus.WithError(err).Error("monitor")
-			if desiredStatus != containerd.Stopped {
+			if desiredStatus == containerd.Stopped {
 				continue
 			}
 		}
 
+		// Known issue:
+		// The status may be empty when task failed but was deleted,
+		// which will result in an `on-failure` restart policy reconcile error.
 		switch desiredStatus {
 		case containerd.Running:
 			if !restart.Reconcile(status, labels) {


### PR DESCRIPTION
Signed-off-by: Ye Sijun <junnplus@gmail.com>

Report of @AkihiroSuda https://github.com/containerd/containerd/pull/6830#issuecomment-1103705037

I'm sorry for misunderstanding https://github.com/containerd/containerd/commit/9503d7219e2adb5906f4c396f3f47e5eb45272c5#diff-a9d90e82d0fee932f0437ab217a8ef14e4a56b4be02321de5193de0ad98e20f9L239-L249

For the case when `Task` returns not found and the restart desired to running, we need to continue to restart the container.
