### PR TITLE
[Carry] containerd: allow building w/o systemd notify

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -101,6 +101,7 @@ make generate
 > *Note*: Several build tags are currently available:
 > * `no_cri`: A build tag disables building Kubernetes [CRI](http://blog.kubernetes.io/2016/12/container-runtime-interface-cri-in-kubernetes.html) support into containerd.
 > See [here](https://github.com/containerd/cri-containerd#build-tags) for build tags of CRI plugin.
+> * `no_systemd`: Disable systemd notifications via [sd_notify](https://www.freedesktop.org/software/systemd/man/sd_notify.html) on Linux.
 > * snapshotters (alphabetical order)
 >   * `no_aufs`: A build tag disables building the aufs snapshot driver.
 >   * `no_btrfs`: A build tag disables building the Btrfs snapshot driver.

--- a/cmd/containerd/command/notify_linux.go
+++ b/cmd/containerd/command/notify_linux.go
@@ -1,3 +1,6 @@
+//go:build !no_systemd
+// +build !no_systemd
+
 /*
    Copyright The containerd Authors.
 

--- a/cmd/containerd/command/notify_unsupported.go
+++ b/cmd/containerd/command/notify_unsupported.go
@@ -1,5 +1,5 @@
-//go:build !linux
-// +build !linux
+//go:build !linux || no_systemd
+// +build !linux no_systemd
 
 /*
    Copyright The containerd Authors.


### PR DESCRIPTION
Carry: https://github.com/containerd/containerd/pull/5591

This PR adds `no_systemd` build tag to exclude systemd dependency.
This changes no files, when `no_systemd` specified, it'll fallback to `notify_unsupported.go`

cc: @metux @wzshiming

<details>

```bash
# Linux

$ make bin/containerd
+ bin/containerd
$ sudo bin/containerd
SYSTEMD: ON
INFO[2022-04-20T10:24:59.280590003-07:00] starting containerd revision=cf6f19cea0030dbf21716602a612168db7cad551.m version=v1.6.0-beta.3-8-gcf6f19cea.m

$ make BUILDTAGS="no_systemd" bin/containerd
+ bin/containerd
$ sudo bin/containerd
SYSTEMD: OFF
INFO[2022-04-20T10:25:14.034784026-07:00] starting containerd revision=cf6f19cea0030dbf21716602a612168db7cad551.m version=v1.6.0-beta.3-8-gcf6f19cea.m

# MacOS
❯ make bin/containerd
🇩 bin/containerd
❯ sudo bin/containerd
SYSTEMD: OFF
INFO[2022-04-20T10:24:34.033767000-07:00] starting containerd revision=eb662621218ee2e8a14ef56a85b85698e544bcbe.m version=v1.6.0-282-geb6626212.m

```

</details>