### PR TITLE
cri: close fifos when container is deleted

### DIFF
--- a/pkg/cri/store/container/container.go
+++ b/pkg/cri/store/container/container.go
@@ -200,7 +200,11 @@ func (s *Store) Delete(id string) {
 		// So we need to return if there are error.
 		return
 	}
-	s.labels.Release(s.containers[id].ProcessLabel)
+	c := s.containers[id]
+	if c.IO != nil {
+		c.IO.Close()
+	}
+	s.labels.Release(c.ProcessLabel)
 	s.idIndex.Delete(id) // nolint: errcheck
 	delete(s.containers, id)
 }


### PR DESCRIPTION
cri: close fifos when container is deleted

Fixes: #6834

<details><summary>Testing</summary>
<p>

```
$ sudo critest -ginkgo.focus 'runtime should support removing created container'
critest version: 1.20.0-24-g53ad8bb7
Running Suite: CRI validation
=============================
Random Seed: 1650576768 - Will randomize all specs
Will run 1 of 97 specs

SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
[k8s.io] Container runtime should support basic operations on container
  runtime should support removing created container [Conformance]
  /tmp/tmp.KuBJ4DNF8R/cri-tools/pkg/validate/container.go:111
[BeforeEach] [k8s.io] Container
  /tmp/tmp.KuBJ4DNF8R/cri-tools/pkg/framework/framework.go:50
[BeforeEach] [k8s.io] Container
  /tmp/tmp.KuBJ4DNF8R/cri-tools/pkg/validate/container.go:63
[BeforeEach] runtime should support basic operations on container
  /tmp/tmp.KuBJ4DNF8R/cri-tools/pkg/validate/container.go:72
[It] runtime should support removing created container [Conformance]
  /tmp/tmp.KuBJ4DNF8R/cri-tools/pkg/validate/container.go:111
STEP: create container
STEP: Get image status for image: busybox:1.28
STEP: Create container.
Apr 21 21:32:50.839: INFO: Created container "40b4cb3869d7b83140ce357fb9a7abd9985c070ee90dc2f7797aaac380131264"

STEP: test remove container
STEP: Remove container for containerID: 40b4cb3869d7b83140ce357fb9a7abd9985c070ee90dc2f7797aaac380131264
Apr 21 21:32:50.842: INFO: Removed container "40b4cb3869d7b83140ce357fb9a7abd9985c070ee90dc2f7797aaac380131264"

STEP: List containers for containerID: 40b4cb3869d7b83140ce357fb9a7abd9985c070ee90dc2f7797aaac380131264
[AfterEach] runtime should support basic operations on container
  /tmp/tmp.KuBJ4DNF8R/cri-tools/pkg/validate/container.go:76
STEP: stop PodSandbox
STEP: delete PodSandbox
[AfterEach] [k8s.io] Container
  /tmp/tmp.KuBJ4DNF8R/cri-tools/pkg/framework/framework.go:51
•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
Ran 1 of 97 Specs in 2.075 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 96 Skipped
PASS

$ sudo lsof -p $(pidof containerd)
COMMAND     PID USER   FD      TYPE             DEVICE SIZE/OFF      NODE NAME
container 10814 root  cwd       DIR              259,1     4096 247464070 /home/ec2-user/go/src/github.com/henry118/containerd
container 10814 root  rtd       DIR              259,1      237        96 /
container 10814 root  txt       REG              259,1 59427040   8411081 /usr/bin/containerd
container 10814 root  mem-W     REG              259,1   262144 163620864 /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/metadata.db
container 10814 root  mem-W     REG              259,1   753664 172023349 /var/lib/containerd/io.containerd.metadata.v1.bolt/meta.db
container 10814 root  mem       REG              259,1  2021864  12584057 /usr/lib64/libc-2.26.so
container 10814 root  mem       REG              259,1   149416  12584075 /usr/lib64/libpthread-2.26.so
container 10814 root  mem       REG              259,1    19208  12584061 /usr/lib64/libdl-2.26.so
container 10814 root  mem       REG              259,1   174280  12584050 /usr/lib64/ld-2.26.so
container 10814 root    0u      CHR              136,2      0t0         5 /dev/pts/2
container 10814 root    1u      CHR              136,2      0t0         5 /dev/pts/2
container 10814 root    2u      CHR              136,2      0t0         5 /dev/pts/2
container 10814 root    3uW     REG              259,1   753664 172023349 /var/lib/containerd/io.containerd.metadata.v1.bolt/meta.db
container 10814 root    4u  a_inode               0,12        0     13869 [eventpoll]
container 10814 root    5r     FIFO               0,11      0t0    380290 pipe
container 10814 root    6w     FIFO               0,11      0t0    380290 pipe
container 10814 root    7u  a_inode               0,12        0     13869 [eventpoll]
container 10814 root    8r  a_inode               0,12        0     13869 inotify
container 10814 root    9u  a_inode               0,12        0     13869 [eventpoll]
container 10814 root   10r     FIFO               0,11      0t0    378687 pipe
container 10814 root   11w     FIFO               0,11      0t0    378687 pipe
container 10814 root   12u     unix 0xffff9fcc9c00dc00      0t0    378688 /run/containerd/containerd.sock.ttrpc
container 10814 root   13u     unix 0xffff9fcc9c00e400      0t0    378689 /run/containerd/containerd.sock
container 10814 root   14u     IPv4             378690      0t0       TCP localhost:41933 (LISTEN)
container 10814 root   22uW     REG              259,1   262144 163620864 /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/metadata.db
```
</p>
</details>

Signed-off-by: Henry Wang <henwang@amazon.com>