### PR TITLE
images/image.go: typo

### DIFF
--- a/images/image.go
+++ b/images/image.go
@@ -311,7 +311,7 @@ func Check(ctx context.Context, provider content.Provider, image ocispec.Descrip
 		return false, nil, nil, nil, fmt.Errorf("failed to check image %v: %w", image.Digest, err)
 	}
 
-	// TODO(stevvooe): It is possible that referenced conponents could have
+	// TODO(stevvooe): It is possible that referenced components could have
 	// children, but this is rare. For now, we ignore this and only verify
 	// that manifest components are present.
 	required = append([]ocispec.Descriptor{mfst.Config}, mfst.Layers...)


### PR DESCRIPTION
Signed-off-by: Zhang Kang [Kang.Zhang@intel.com](mailto:Kang.Zhang@intel.com)