### PR TITLE
[release/1.6] tracing: fix panic on startup when configured

### DIFF
--- a/tracing/plugin/otlp.go
+++ b/tracing/plugin/otlp.go
@@ -31,6 +31,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
+	"go.opentelemetry.io/otel/sdk/trace"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 )
@@ -47,7 +48,11 @@ func init() {
 			if cfg.Endpoint == "" {
 				return nil, fmt.Errorf("no OpenTelemetry endpoint: %w", plugin.ErrSkipPlugin)
 			}
-			return newExporter(ic.Context, cfg)
+			exp, err := newExporter(ic.Context, cfg)
+			if err != nil {
+				return nil, err
+			}
+			return trace.NewBatchSpanProcessor(exp), nil
 		},
 	})
 	plugin.Register(&plugin.Registration{


### PR DESCRIPTION
Backport of #6789

---

When support for http/protobuf was added, the OTLP tracing processor
plugin was mistakenly changed to return a raw OTLP exporter instance.
Consequently, the type-assertion to a trace.SpanProcessor inside the
tracing pluigin would panic if the processor plugin was configured.
Modify the OTLP plugin to return a BatchSpanProcessor derived from the
exporter once more.

Signed-off-by: Cory Snider <csnider@mirantis.com>
(cherry picked from commit 927b34e41e2ed0050dbeccbc7c3dffaeb2969949)
Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>