### PR TITLE
Don't use "uname -a" as Cirrus CI's cache key

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -32,7 +32,7 @@ task:
 
   vagrant_cache:
     folder: /root/.vagrant.d
-    fingerprint_script: uname -a; cat Vagrantfile
+    fingerprint_script: uname --kernel-release --kernel-version && cat Vagrantfile
 
   vagrant_up_script: |
     vagrant up --no-tty


### PR DESCRIPTION
"uname -a" includes its hostname, which could be
cirrus-task-6102504847966208, cirrus-task-6665454801387520, ...
This is unnecessary invalidating the cache.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>