### PR TITLE
cri: unpack images automatically on recovery

### DIFF
--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -218,12 +218,24 @@ version = 2
   enable_unprivileged_icmp = false
 
   # enable_cdi enables support of the Container Device Interface (CDI)
-	# For more details about CDI and the syntax of CDI Spec files please refer to
-	# https://github.com/container-orchestrated-devices/container-device-interface.
-	enable_cdi = false
+  # For more details about CDI and the syntax of CDI Spec files please refer to
+  # https://github.com/container-orchestrated-devices/container-device-interface.
+  enable_cdi = false
 
   # cdi_spec_dirs is the list of directories to scan for CDI spec files
-	cdi_spec_dirs = ["/etc/cdi", "/var/run/cdi"]
+  cdi_spec_dirs = ["/etc/cdi", "/var/run/cdi"]
+
+  # image_pull_progress_timeout is the maximum duration that there is no
+  # image data read from image registry in the open connection. It will
+  # be reset whatever a new byte has been read. If timeout, the image
+  # pulling will be cancelled. A zero value means there is no timeout.
+  # This config is a string value in the golang duration format,
+  # see: https://golang.org/pkg/time/#ParseDuration
+  image_pull_progress_timeout = "1m0s"
+
+  # auto_unpack_on_recovery indicates to automatically unpack images that are not already
+  # unpacked when images are reloaded during the recovery process. (default is `false`)
+  auto_unpack_on_recovery = false
 
   # 'plugins."io.containerd.grpc.v1.cri".containerd' contains config related to containerd
   [plugins."io.containerd.grpc.v1.cri".containerd]

--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -321,6 +321,9 @@ type PluginConfig struct {
 	// The string is in the golang duration format, see:
 	//   https://golang.org/pkg/time/#ParseDuration
 	ImagePullProgressTimeout string `toml:"image_pull_progress_timeout" json:"imagePullProgressTimeout"`
+	// AutoUnpackOnRecovery indicates to automatically unpack images that are not already
+	// unpacked when images are reloaded during the recovery process. (default is `false`)
+	AutoUnpackOnRecovery bool `toml:"auto_unpack_on_recovery" json:"auto_unpack_on_recovery"`
 }
 
 // X509KeyPairStreaming contains the x509 configuration for streaming

--- a/pkg/cri/config/config_unix.go
+++ b/pkg/cri/config/config_unix.go
@@ -109,5 +109,6 @@ func DefaultConfig() PluginConfig {
 		EnableCDI:                false,
 		CDISpecDirs:              []string{"/etc/cdi", "/var/run/cdi"},
 		ImagePullProgressTimeout: time.Minute.String(),
+		AutoUnpackOnRecovery:     false,
 	}
 }

--- a/pkg/cri/server/restart.go
+++ b/pkg/cri/server/restart.go
@@ -468,8 +468,14 @@ func (c *criService) loadImages(ctx context.Context, cImages []containerd.Image)
 				return
 			}
 			if !unpacked {
-				log.G(ctx).Warnf("The image %s is not unpacked.", i.Name())
-				// TODO(random-liu): Consider whether we should try unpack here.
+				if c.config.AutoUnpackOnRecovery {
+					log.G(ctx).Debugf("Image %q is not unpacked, unpacking it now", i.Name())
+					if err := i.Unpack(ctx, snapshotter); err != nil {
+						log.G(ctx).WithError(err).Errorf("Failed to unpack image %q", i.Name())
+					}
+				} else {
+					log.G(ctx).Warnf("The image %s is not unpacked.", i.Name())
+				}
 			}
 			if err := c.updateImage(ctx, i.Name()); err != nil {
 				log.G(ctx).WithError(err).Warnf("Failed to update reference for image %q", i.Name())


### PR DESCRIPTION
cri: unpack images automatically on recovery

Fixes: #6710

* Unpack images automatically on recovery
* Added `image_pull_progress_timeout` which is missing in CRI's sample config
* Minor indentation fixes in `config.md`

Signed-off-by: Henry Wang <henwang@amazon.com>