### PR TITLE
Order containerd.service before kubelet.service

### DIFF
--- a/containerd.service
+++ b/containerd.service
@@ -16,6 +16,7 @@
 Description=containerd container runtime
 Documentation=https://containerd.io
 After=network.target local-fs.target
+Before=kubelet.service
 
 [Service]
 ExecStartPre=-/sbin/modprobe overlay


### PR DESCRIPTION
containerd.service:
Order containerd.service before kubelet.service, as this way it is
started before a kubelet (if that unit is enabled) and allows for
garbage collection to work (see
https://github.com/cri-o/cri-o/issues/4437 for comparison).
As docker.service in
https://github.com/moby/moby/blob/1f8d44babf18811ff9020de667bf6fda8d3c4401/contrib/init/systemd/docker.service#L4
is ordered after containerd.service this should suffice to ensure
garbage collection to work with docker as kubernetes container runtime.

Signed-off-by: David Runge <dave@sleepmap.de>