### PR TITLE
docs: Adding windows installation steps to getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -105,6 +105,31 @@ The `containerd.io` package contains runc too, but does not contain CNI plugins.
 
 To install containerd and its dependencies from the source, see [`BUILDING.md`](/BUILDING.md).
 
+## Installing containerd on Windows
+
+From a PowerShell session run the following commands:
+
+```PowerShell
+# Download and extract desired containerd Windows binaries
+$Version=1.6.2
+curl.exe -L https://github.com/containerd/containerd/releases/download/v$Version/containerd-$Version-windows-amd64.tar.gz -o containerd-windows-amd64.tar.gz
+tar.exe xvf .\containerd-windows-amd64.tar.gz
+
+# Copy and configure
+Copy-Item -Path ".\bin\" -Destination "$Env:ProgramFiles\containerd" -Recurse -Force
+cd $Env:ProgramFiles\containerd\
+.\containerd.exe config default | Out-File config.toml -Encoding ascii
+
+# Review the configuration. Depending on setup you may want to adjust:
+# - the sandbox_image (Kubernetes pause image)
+# - cni bin_dir and conf_dir locations
+Get-Content config.toml
+
+# Register and start service
+.\containerd.exe --register-service
+Start-Service containerd
+```
+
 ## Interacting with containerd via CLI
 
 There are several command line interface (CLI) projects for interacting with containerd:


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

These instructions used to be hosted at https://v1-22.docs.kubernetes.io/docs/setup/production-environment/container-runtimes/#containerd but have been removed. 

It makes more sense to host them here.