### PR TITLE
Make Cirrus CI tests more stable

### DIFF
--- a/integration/client/client_test.go
+++ b/integration/client/client_test.go
@@ -449,6 +449,13 @@ func TestImagePullSchema1(t *testing.T) {
 }
 
 func TestImagePullWithConcurrencyLimit(t *testing.T) {
+	if os.Getenv("CIRRUS_CI") != "" {
+		// This test tends to fail under Cirrus CI + Vagrant due to "connection reset by peer" from
+		// pkg-containers.githubusercontent.com.
+		// Does GitHub throttle requests from Cirrus CI more compared to GitHub Actions?
+		t.Skip("unstable under Cirrus CI")
+	}
+
 	client, err := newClient(t, address)
 	if err != nil {
 		t.Fatal(err)

--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -1117,7 +1117,6 @@ func TestContainerKillInitPidHost(t *testing.T) {
 }
 
 func TestUserNamespaces(t *testing.T) {
-	t.Parallel()
 	t.Run("WritableRootFS", func(t *testing.T) { testUserNamespaces(t, false) })
 	// see #1373 and runc#1572
 	t.Run("ReadonlyRootFS", func(t *testing.T) { testUserNamespaces(t, true) })


### PR DESCRIPTION
This test tends to fail under Cirrus CI + Vagrant. Skipping for now
since running the test on GitHub Actions would be suffice.