### PR TITLE
Support runtime level snapshotter for issue 6657

### DIFF
--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -228,7 +228,8 @@ version = 2
   # 'plugins."io.containerd.grpc.v1.cri".containerd' contains config related to containerd
   [plugins."io.containerd.grpc.v1.cri".containerd]
 
-    # snapshotter is the snapshotter used by containerd.
+    # snapshotter is the default snapshotter used by containerd
+    # for all runtimes, if not overridden by an experimental runtime's snapshotter config.
     snapshotter = "overlayfs"
 
     # no_pivot disables pivot-root (linux only), required when running a container in a RamDisk with runc.
@@ -328,6 +329,11 @@ version = 2
       # interpreted as no limit is desired and will result in all CNI plugin
       # config files being loaded from the CNI config directory.
       cni_max_conf_num = 1
+
+      # snapshotter overrides the global default snapshotter to a runtime specific value.
+      # Please be aware that overriding the default snapshotter on a runtime basis is currently an experimental feature.
+      # See https://github.com/containerd/containerd/issues/6657 for context.
+      snapshotter = ""
 
       # 'plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options' is options specific to
       # "io.containerd.runc.v1" and "io.containerd.runc.v2". Its corresponding options type is:

--- a/pkg/cri/annotations/annotations.go
+++ b/pkg/cri/annotations/annotations.go
@@ -70,6 +70,13 @@ const (
 	// PodAnnotations are the annotations of the pod
 	PodAnnotations = "io.kubernetes.cri.pod-annotations"
 
+	// RuntimeHandler an experimental annotation key for getting runtime handler from pod annotations.
+	// See https://github.com/containerd/containerd/issues/6657 and https://github.com/containerd/containerd/pull/6899 for details.
+	// The value of this annotation should be the runtime for sandboxes.
+	// e.g. for [plugins.cri.containerd.runtimes.runc] runtime config, this value should be runc
+	// TODO: we should deprecate this annotation as soon as kubelet supports passing RuntimeHandler from PullImageRequest
+	RuntimeHandler = "io.containerd.cri.runtime-handler"
+
 	// WindowsHostProcess is used by hcsshim to identify windows pods that are running HostProcesses
 	WindowsHostProcess = "microsoft.com/hostprocess-container"
 )

--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -71,6 +71,11 @@ type Runtime struct {
 	// be loaded from the cni config directory by go-cni. Set the value to 0 to
 	// load all config files (no arbitrary limit). The legacy default value is 1.
 	NetworkPluginMaxConfNum int `toml:"cni_max_conf_num" json:"cniMaxConfNum"`
+	// Snapshotter setting snapshotter at runtime level instead of making it as a global configuration.
+	// An example use case is to use devmapper or other snapshotters in Kata containers for performance and security
+	// while using default snapshotters for operational simplicity.
+	// See https://github.com/containerd/containerd/issues/6657 for details.
+	Snapshotter string `toml:"snapshotter" json:"snapshotter"`
 }
 
 // ContainerdConfig contains toml config related to containerd

--- a/pkg/cri/server/container_create.go
+++ b/pkg/cri/server/container_create.go
@@ -23,11 +23,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/containers"
-	"github.com/containerd/containerd/log"
-	"github.com/containerd/containerd/oci"
-	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/typeurl"
 	"github.com/davecgh/go-spew/spew"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -35,11 +30,17 @@ import (
 	selinux "github.com/opencontainers/selinux/go-selinux"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/oci"
+	criconfig "github.com/containerd/containerd/pkg/cri/config"
 	cio "github.com/containerd/containerd/pkg/cri/io"
 	customopts "github.com/containerd/containerd/pkg/cri/opts"
 	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
 	"github.com/containerd/containerd/pkg/cri/util"
 	ctrdutil "github.com/containerd/containerd/pkg/cri/util"
+	"github.com/containerd/containerd/snapshots"
 )
 
 func init() {
@@ -186,7 +187,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	snapshotterOpt := snapshots.WithLabels(snapshots.FilterInheritedLabels(config.Annotations))
 	// Set snapshotter before any other options.
 	opts := []containerd.NewContainerOpts{
-		containerd.WithSnapshotter(c.config.ContainerdConfig.Snapshotter),
+		containerd.WithSnapshotter(c.runtimeSnapshotter(ctx, ociRuntime)),
 		// Prepare container rootfs. This is always writeable even if
 		// the container wants a readonly rootfs since we want to give
 		// the runtime (runc) a chance to modify (e.g. to create mount
@@ -347,4 +348,15 @@ func (c *criService) runtimeSpec(id string, baseSpecFile string, opts ...oci.Spe
 	}
 
 	return spec, nil
+}
+
+// Overrides the default snapshotter if Snapshotter is set for this runtime.
+// See See https://github.com/containerd/containerd/issues/6657
+func (c *criService) runtimeSnapshotter(ctx context.Context, ociRuntime criconfig.Runtime) string {
+	if ociRuntime.Snapshotter == "" {
+		return c.config.ContainerdConfig.Snapshotter
+	}
+
+	log.G(ctx).Debugf("Set snapshotter for runtime %s to %s", ociRuntime.Type, ociRuntime.Snapshotter)
+	return ociRuntime.Snapshotter
 }

--- a/pkg/cri/server/container_create_test.go
+++ b/pkg/cri/server/container_create_test.go
@@ -22,13 +22,13 @@ import (
 	goruntime "runtime"
 	"testing"
 
-	"github.com/containerd/containerd/oci"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
+	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/pkg/cri/config"
 	"github.com/containerd/containerd/pkg/cri/constants"
 	"github.com/containerd/containerd/pkg/cri/opts"
@@ -415,4 +415,36 @@ func TestBaseRuntimeSpec(t *testing.T) {
 	assert.Equal(t, c.baseOCISpecs["/etc/containerd/cri-base.json"].Hostname, "old")
 
 	assert.Equal(t, filepath.Join("/", constants.K8sContainerdNamespace, "id1"), out.Linux.CgroupsPath)
+}
+
+func TestRuntimeSnapshotter(t *testing.T) {
+	defaultRuntime := config.Runtime{
+		Snapshotter: "",
+	}
+
+	fooRuntime := config.Runtime{
+		Snapshotter: "devmapper",
+	}
+
+	for desc, test := range map[string]struct {
+		runtime           config.Runtime
+		expectSnapshotter string
+	}{
+		"should return default snapshotter when runtime.Snapshotter is not set": {
+			runtime:           defaultRuntime,
+			expectSnapshotter: config.DefaultConfig().Snapshotter,
+		},
+		"should return overridden snapshotter when runtime.Snapshotter is set": {
+			runtime:           fooRuntime,
+			expectSnapshotter: "devmapper",
+		},
+	} {
+		t.Run(desc, func(t *testing.T) {
+			cri := newTestCRIService()
+			cri.config = config.Config{
+				PluginConfig: config.DefaultConfig(),
+			}
+			assert.Equal(t, test.expectSnapshotter, cri.runtimeSnapshotter(context.Background(), test.runtime))
+		})
+	}
 }

--- a/pkg/cri/server/image_pull.go
+++ b/pkg/cri/server/image_pull.go
@@ -33,20 +33,21 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/errdefs"
-	containerdimages "github.com/containerd/containerd/images"
-	"github.com/containerd/containerd/labels"
-	"github.com/containerd/containerd/log"
-	distribution "github.com/containerd/containerd/reference/docker"
-	"github.com/containerd/containerd/remotes/docker"
-	"github.com/containerd/containerd/remotes/docker/config"
 	"github.com/containerd/imgcrypt"
 	"github.com/containerd/imgcrypt/images/encryption"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/errdefs"
+	containerdimages "github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/labels"
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/pkg/cri/annotations"
 	criconfig "github.com/containerd/containerd/pkg/cri/config"
+	distribution "github.com/containerd/containerd/reference/docker"
+	"github.com/containerd/containerd/remotes/docker"
+	"github.com/containerd/containerd/remotes/docker/config"
 )
 
 // For image management:
@@ -126,10 +127,17 @@ func (c *criService) PullImage(ctx context.Context, r *runtime.PullImageRequest)
 		}
 	)
 
+	defer pcancel()
+	snapshotter, err := c.snapshotterFromPodSandboxConfig(ctx, ref, r.SandboxConfig)
+	if err != nil {
+		return nil, err
+	}
+	log.G(ctx).Debugf("PullImage %q with snapshotter %s", ref, snapshotter)
+
 	pullOpts := []containerd.RemoteOpt{
 		containerd.WithSchema1Conversion, //nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
 		containerd.WithResolver(resolver),
-		containerd.WithPullSnapshotter(c.config.ContainerdConfig.Snapshotter),
+		containerd.WithPullSnapshotter(snapshotter),
 		containerd.WithPullUnpack,
 		containerd.WithPullLabel(imageLabelKey, imageLabelValue),
 		containerd.WithMaxConcurrentDownloads(c.config.MaxConcurrentDownloads),
@@ -785,4 +793,30 @@ func (rt *pullRequestReporterRoundTripper) RoundTrip(req *http.Request) (*http.R
 		reqReporter: rt.reqReporter,
 	}
 	return resp, err
+}
+
+// Given that runtime information is not passed from PullImageRequest, we depend on an experimental annotation
+// passed from pod sandbox config to get the runtimeHandler. The annotation key is specified in configuration.
+// Once we know the runtime, try to override default snapshotter if it is set for this runtime.
+// See https://github.com/containerd/containerd/issues/6657
+func (c *criService) snapshotterFromPodSandboxConfig(ctx context.Context, imageRef string,
+	s *runtime.PodSandboxConfig) (string, error) {
+	snapshotter := c.config.ContainerdConfig.Snapshotter
+	if s == nil || s.Annotations == nil {
+		return snapshotter, nil
+	}
+
+	runtimeHandler, ok := s.Annotations[annotations.RuntimeHandler]
+	if !ok {
+		return snapshotter, nil
+	}
+
+	ociRuntime, err := c.getSandboxRuntime(s, runtimeHandler)
+	if err != nil {
+		return "", fmt.Errorf("experimental: failed to get sandbox runtime for %s, err: %+v", runtimeHandler, err)
+	}
+
+	snapshotter = c.runtimeSnapshotter(context.Background(), ociRuntime)
+	log.G(ctx).Infof("experimental: PullImage %q for runtime %s, using snapshotter %s", imageRef, runtimeHandler, snapshotter)
+	return snapshotter, nil
 }

--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -27,19 +27,19 @@ import (
 	"strings"
 	"time"
 
-	"github.com/containerd/containerd"
-	containerdio "github.com/containerd/containerd/cio"
-	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/log"
-	"github.com/containerd/containerd/snapshots"
 	cni "github.com/containerd/go-cni"
 	"github.com/containerd/nri"
 	v1 "github.com/containerd/nri/types/v1"
 	"github.com/containerd/typeurl"
 	"github.com/davecgh/go-spew/spew"
+	selinux "github.com/opencontainers/selinux/go-selinux"
 	"github.com/sirupsen/logrus"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
+	"github.com/containerd/containerd"
+	containerdio "github.com/containerd/containerd/cio"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/pkg/cri/annotations"
 	criconfig "github.com/containerd/containerd/pkg/cri/config"
 	customopts "github.com/containerd/containerd/pkg/cri/opts"
@@ -48,7 +48,7 @@ import (
 	"github.com/containerd/containerd/pkg/cri/util"
 	ctrdutil "github.com/containerd/containerd/pkg/cri/util"
 	"github.com/containerd/containerd/pkg/netns"
-	selinux "github.com/opencontainers/selinux/go-selinux"
+	"github.com/containerd/containerd/snapshots"
 )
 
 func init() {
@@ -211,7 +211,7 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	}
 	snapshotterOpt := snapshots.WithLabels(snapshots.FilterInheritedLabels(config.Annotations))
 	opts := []containerd.NewContainerOpts{
-		containerd.WithSnapshotter(c.config.ContainerdConfig.Snapshotter),
+		containerd.WithSnapshotter(c.runtimeSnapshotter(ctx, ociRuntime)),
 		customopts.WithNewSnapshot(id, containerdImage, snapshotterOpt),
 		containerd.WithSpec(spec, specOpts...),
 		containerd.WithContainerLabels(sandboxLabels),


### PR DESCRIPTION
## What is this change
This is the implementation for https://github.com/containerd/containerd/issues/6657, the following lists core ideas:

1. Added `snapshotter` option in CRI per-runtime config
2. For containers related operations e.g. create containers, respect the runtime.snapshotter if set, otherwise using the global  snapshotter.

```
[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.my-runtime]
  snapshotter = "devmapper"
```

3. For pull images, given the runtime info is not passed along in the PullImageRequest, we used a configurable annotation key `io.kubernetes.cri/runtimehandler` to specify runtime during pull time such that the appropriate snapshotter can be used.

Pod sandbox config with annotations specifying the runtime, and image_pull will get the correct snapshotter for unpacking
```
{
  "metadata": {
    "name": "busybox-sandbox-devmapper",
    "namespace": "default",
    "attempt": 1,
    "uid": "hdishd83djaidwnduwk28bcsb"
  },
  "log_directory": "/tmp",
  "linux": {
  },
  "annotations": {
    "io.kubernetes.cri/runtimehandler": "my-runtime"
  }
}
```

## Testings done

- [x] Pull an image with annotation `"io.kubernetes.cri/runtimehandler": "my-runtime"`, image is unpacked with `devmapper`
- [x] Pull the same image without annotation, image is unpacked with `overlayfs`
- [x] Create a pod with runtime `my-runtime`, sandbox is created with `devmapper` snapshotter
- [x] Create a pod without runtime, sandbox is created with `overlayfs` snapshotter
- [x] Create a container within the `my-runtime` pod, container uses `devmapper` snapshotter
- [x] Create a container within the default pod, container uses `overlayfs` snapshotter
- [x]  Snapshots were removed cleanly after containers/pods are deleted
- [x] No snapshotter override for runtime, used the default snapshoter
- [x] No snapshotter override for runtime, with `"io.kubernetes.cri/runtimehandler": "my-runtime"` still used default snapshotter
- [x] No snapshotter override for runtime, pull with  `"io.kubernetes.cri/runtimehandler": "my-runtime"`, using default snapshotter
- [x] No snapshotter override for runtime, pull without `"io.kubernetes.cri/runtimehandler": "my-runtime"`, using default snapshotter
- [x] List images
- [x] Remove an image with both overlayfs and devmapper snapshotters, both snapshotter are cleaned up
- [x] imagefsinfo, expecting only the default snapshotter fs info, the full support is in the TODO list
- [x] Inspect images
- [x] crictl info, all runtimes and their snapshotters are of the expected values
- [x] stats expect behavior unchanged

### Test logs
1. Pull images with annotations `"io.kubernetes.cri/runtimehandler": "my-runtime"`
```
crictl pull --pod-config ./podsandbox-config-devmapper.json docker.io/library/busybox:latest

cat ./podsandbox-config-devmapper.json 
{
  "metadata": {
    "name": "busybox-sandbox-devmapper",
    "namespace": "default",
    "attempt": 1,
    "uid": "hdishd83djaidwnduwk28bcsb"
  },
  "log_directory": "/tmp",
  "linux": {
  },
  "annotations": {
    "io.kubernetes.cri/runtimehandler": "my-runtime"
  }
}

May 17 22:07:45 shuaichang-containerd-patch containerd[27091]: time="2022-05-17T22:07:45.693190447Z" level=debug msg="Set snapshotter for runtime io.containerd.my-runtimev2 to devmapper"
May 17 22:07:45 shuaichang-containerd-patch containerd[27091]: time="2022-05-17T22:07:45.693230747Z" level=info msg="experimental: PullImage \"docker.io/library/busybox:latest\" for runtime my-runtime, using snapshotter devmapper"
```

2. Pull the same image without annotation, image is unpacked with `overlayfs`

```
crictl pull --pod-config ./podsandbox-config-default.json docker.io/library/busybox:latest

{
  "metadata": {
    "name": "busybox-sandbox-default",
    "namespace": "default",
    "attempt": 1,
    "uid": "hdishd83djaidwnduwk28bcsb"
  },
  "log_directory": "/tmp",
  "linux": {
  }
}

May 17 22:08:30 shuaichang-containerd-patch containerd[27091]: time="2022-05-17T22:08:30.888721442Z" level=info msg="PullImage \"docker.io/library/busybox:latest\""
May 17 22:08:30 shuaichang-containerd-patch containerd[27091]: time="2022-05-17T22:08:30.888831043Z" level=debug msg="PullImage \"docker.io/library/busybox:latest\" with snapshotter overlayfs"
```

3. Create a pod with runtime `my-runtime`, sandbox is created with `devmapper` snapshotter

```
crictl runp --runtime my-runtime ./podsandbox-config-devmapper.json

# Inspect pod
  "info": {
    "pid": 12251,
    "processStatus": "running",
    "netNamespaceClosed": false,
    "image": "mcr.microsoft.com/oss/kubernetes/pause:3.6",
    "snapshotKey": "ad0458f9cb8f9584c59c14320d7c3fa898d19ae5f6c2a42abd6de2eda6f69b73",
    "snapshotter": "devmapper",
    "runtimeHandler": "my-runtime",
```

4. Create a pod without runtime, sandbox is created with `overlayfs` snapshotter

```
crictl runp ./podsandbox-config-default.json

# Inspect pod
  "info": {
    "pid": 13512,
    "processStatus": "running",
    "netNamespaceClosed": false,
    "image": "mcr.microsoft.com/oss/kubernetes/pause:3.6",
    "snapshotKey": "06cf19be56bab58536f1a44ab67af96da8d6a3867624b307b66c3ef70d00362d",
    "snapshotter": "overlayfs",
    "runtimeHandler": "",
```

5. Create a container within the default pod, container uses `overlayfs` snapshotter

```
root@shuaichang-containerd-patch:~/crictl-exp# crictl create ad0458f9cb8f9 container-config.json podsandbox-config-default.json 

# Inspect container
  "info": {
    "sandboxID": "ad0458f9cb8f9584c59c14320d7c3fa898d19ae5f6c2a42abd6de2eda6f69b73",
    "pid": 0,
    "removing": false,
    "snapshotKey": "0b6abe6d4582e959ea38665b25e5a2d6fb5d5cd0e22cea1ea918487069a93d9d",
    "snapshotter": "devmapper",
    "runtimeType": "io.containerd.my-runtime.v2",
```

6. Create a container within the default pod, container uses `overlayfs` snapshotter

```
crictl create 06cf19be56bab container-config.json podsandbox-config-devmapper.json 

# Inspect container

  "info": {
    "sandboxID": "06cf19be56bab58536f1a44ab67af96da8d6a3867624b307b66c3ef70d00362d",
    "pid": 0,
    "removing": false,
    "snapshotKey": "4259cabaeaa9dbda6d25252ceba6161983c307b960fcc206c9bce9c8de42a060",
    "snapshotter": "overlayfs",
    "runtimeType": "io.containerd.runc.v2",
    "runtimeOptions": {
      "binary_name": "/usr/bin/runc"
    },
```

7. Snapshots were removed cleanly after containers/pods are deleted

```
# Note all the mounts are gone both device mapper and overlayfs
crictl stopp 06cf19be56bab
crictl stopp ad0458f9cb8f9
crictl rmp ad0458f9cb8f9
crictl rmp 06cf19be56bab
mount|grep runc
```

8. No snapshotter override for runtime, used the default snapshoter

```
  "info": {
    "pid": 9818,
    "processStatus": "running",
    "netNamespaceClosed": false,
    "image": "mcr.microsoft.com/oss/kubernetes/pause:3.6",
    "snapshotKey": "1f7561825971d3b02e7280ae80fdabba3646c158bf1e2c83dc2d2afdb2681d7b",
    "snapshotter": "overlayfs",
    "runtimeHandler": "my-runtime",
```

9. No snapshotter override for runtime, with `"io.kubernetes.cri/runtimehandler": "my-runtime"` still used default 

```
crictl runp --runtime my-runtime ./podsandbox-config-default.json

  "info": {
    "pid": 10946,
    "processStatus": "running",
    "netNamespaceClosed": false,
    "image": "mcr.microsoft.com/oss/kubernetes/pause:3.6",
    "snapshotKey": "898a1775c10bda85ac107759d6611d19a561028452cd5a104fe120c1ed016e28",
    "snapshotter": "overlayfs",
    "runtimeHandler": "my-runtime",
```

10. No snapshotter override for runtime, pull with  `"io.kubernetes.cri/runtimehandler": "my-runtime"`, using default snapshotter

```
crictl pull --pod-config ./podsandbox-config-devmapper.json docker.io/library/busybox:latest

May 18 05:09:27 shuaichang-containerd-patch containerd[4422]: time="2022-05-18T05:09:27.311754823Z" level=debug msg="PullImage \"docker.io/library/busybox:latest\" with snapshotter overlayfs"
```

11. No snapshotter override for runtime, pull without `"io.kubernetes.cri/runtimehandler": "my-runtime"`, using default snapshotter

```
crictl pull --pod-config ./podsandbox-config-default.json docker.io/library/busybox:latest
May 18 05:10:30 shuaichang-containerd-patch containerd[4422]: time="2022-05-18T05:10:30.361737931Z" level=debug msg="PullImage \"docker.io/busybox:latest/busybox:latest\" with snapshotter overlayfs"
```

12. List images

```
crictl images
IMAGE                                                                                                     TAG                                                                                                                  IMAGE ID            SIZE
docker.io/library/busybox                                                                                 latest                                                                                                               1a80408de790c       777kB
docker.io/library/ubuntu                                                                                  latest                                                                                                               825d55fb63400       28.6MB
```

13. Remove an image with both overlayfs and devmapper snapshotters, both snapshotter are cleaned up

```
crictl rmi docker.io/library/busybox:latest

sha256:eb6b01329ebe73e209e44a616a0e16c2b8e91de6f719df9c35e6cdadadbe5965" snapshotter=overlayfs
May 19 06:30:50 shuaichang-containerd-patch containerd[4001]: time="2022-05-19T06:30:50.037608744Z" level=debug msg="snapshot garbage collected" d=10.517849ms snapshotter=overlayfs

sha256:eb6b01329ebe73e209e44a616a0e16c2b8e91de6f719df9c35e6cdadadbe5965" snapshotter=devmapper
May 19 06:30:50 shuaichang-containerd-patch containerd[4001]: time="2022-05-19T06:30:50.055348796Z" level=debug msg="snapshot garbage collected" d=28.284601ms snapshotter=devmapper
```

14. imagefsinfo, expecting only the default snapshotter fs info, the full support is in the TODO list

```
{
  "status": {
    "timestamp": "1652944758835233108",
    "fsId": {
      "mountpoint": "/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs"
    },
    "usedBytes": {
      "value": "28228698112"
    },
    "inodesUsed": {
      "value": "731121"
    }
  }
}
```

15. Inspect images

```
crictl inspecti docker.io/library/busybox:latest
{
  "status": {
    "id": "sha256:1a80408de790c0b1075d0a7e23ff7da78b311f85f36ea10098e4a6184c200964",
    "repoTags": [
      "docker.io/library/busybox:latest"
    ],
    "repoDigests": [
      "docker.io/library/busybox@sha256:d2b53584f580310186df7a2055ce3ff83cc0df6caacf1e3489bff8cf5d0af5d8"
    ],
    "size": "777091",
    "uid": null,
    "username": "",
    "spec": null
  },
  "info": {
    "chainID": "sha256:eb6b01329ebe73e209e44a616a0e16c2b8e91de6f719df9c35e6cdadadbe5965",
    "imageSpec": {
      "created": "2022-04-14T02:29:36.517566461Z",
      "architecture": "amd64",
      "os": "linux",
      "config": {
        "Env": [
          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
        ],
        "Cmd": [
          "sh"
        ]
      },
      "rootfs": {
        "type": "layers",
        "diff_ids": [
          "sha256:eb6b01329ebe73e209e44a616a0e16c2b8e91de6f719df9c35e6cdadadbe5965"
        ]
      },
      "history": [
        {
          "created": "2022-04-14T02:29:36.368193089Z",
          "created_by": "/bin/sh -c #(nop) ADD file:1c8dd4a97e690506e2c94f7dee8e24c0612c0f227736d6259e5045f9d1efce02 in / "
        },
        {
          "created": "2022-04-14T02:29:36.517566461Z",
          "created_by": "/bin/sh -c #(nop)  CMD [\"sh\"]",
          "empty_layer": true
        }
      ]
    }
  }
}
```

16. crictl info, all runtimes and their snapshotters are of the expected values

```
crictl info

  "config": {
    "containerd": {
      "snapshotter": "overlayfs",

        "my-runtime": {
          "runtimeType": "io.containerd.my-runtime.v2",
         .......
          "snapshotter": "devmapper"
        },
```

17. stats expect behavior unchanged

```
crictl stats
CONTAINER           CPU %               MEM                 DISK                INODES
1826178f1d02f       0.00                798.7kB             16.38kB             7
```