### PR TITLE
windows: Add runhcs-wcow-hypervisor runtimeclass to the default config

### DIFF
--- a/pkg/cri/config/config_windows.go
+++ b/pkg/cri/config/config_windows.go
@@ -40,7 +40,28 @@ func DefaultConfig() PluginConfig {
 			NoPivot:            false,
 			Runtimes: map[string]Runtime{
 				"runhcs-wcow-process": {
-					Type: "io.containerd.runhcs.v1",
+					Type:                 "io.containerd.runhcs.v1",
+					ContainerAnnotations: []string{"io.microsoft.container.*"},
+				},
+				"runhcs-wcow-hypervisor": {
+					Type:                 "io.containerd.runhcs.v1",
+					PodAnnotations:       []string{"io.microsoft.virtualmachine.*"},
+					ContainerAnnotations: []string{"io.microsoft.container.*"},
+					// Full set of Windows shim options:
+					// https://pkg.go.dev/github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options#Options
+					Options: map[string]interface{}{
+						// SandboxIsolation specifies the isolation level of the sandbox.
+						// PROCESS (0) and HYPERVISOR (1) are the valid options.
+						"SandboxIsolation": 1,
+						// ScaleCpuLimitsToSandbox indicates that the containers CPU
+						// maximum value (specifies the portion of processor cycles that
+						// a container can use as a percentage times 100) should be adjusted
+						// to account for the difference in the number of cores between the
+						// host and UVM.
+						//
+						// This should only be turned on if SandboxIsolation is 1.
+						"ScaleCpuLimitsToSandbox": true,
+					},
 				},
 			},
 		},


### PR DESCRIPTION
As part of the effort of getting Windows hypervisor isolated container support working for the CRI entrypoint here, add the runhcs-wcow-hypervisor handler to the default config. This sets the correct SandboxIsolation value that the Windows shim uses to differentiate process vs. hypervisor isolation. This additionally allows io.microsoft.container* annotations for the wcow-process runtime and io.microsoft.virtualmachine* annotations for the vm based runtime.

Note that for K8s users this runtime handler will need to be configured by creating the corresponding RuntimeClass resources on the cluster as it's not the default runtime. 

~~This needs a change in the shim that actually sets the HyperV field on the runtime spec to work properly, see here: https://github.com/microsoft/hcsshim/pull/1388~~ Done

```powershell
PS C:\Users\TestVMAdmin\Desktop> .\crictl.exe pods
POD ID              CREATED             STATE             NAME       NAMESPACE      ATTEMPT      RUNTIME
363319e093c7a       11 minutes ago      Ready             pod        default        1            runhcs-wcow-hypervisor

PS C:\Users\TestVMAdmin\Desktop> hcsdiag list
363319e093c7a688d8d18ad17f5d384e60cb805ba7bf128ea93f0613af5483e9@vm
    VM,                         Running, C2C42EC1-5040-5D0A-AC86-F4BACF6B75CB, containerd-shim-runhcs-v1.exe
```

