### PR TITLE
devmapper docs: small fixes

### DIFF
--- a/docs/snapshotters/devmapper.md
+++ b/docs/snapshotters/devmapper.md
@@ -8,7 +8,7 @@ in a devicemapper thin pool.
 To make it work you need to prepare `thin-pool` in advance and update containerd's configuration file.
 This file is typically located at `/etc/containerd/config.toml`.
 
-Here's minimal sample entry that can be made in the configuration file:
+Here's a minimal sample entry that can be made in the configuration file:
 
 ```toml
 version = 2
@@ -91,10 +91,10 @@ sudo dmsetup create "${POOL_NAME}" \
 
 cat << EOF
 #
-# Add this to your config.toml configuration file and restart containerd daemon
+# Add this to your config.toml configuration file and restart the containerd daemon
 #
 [plugins]
-  [plugins.devmapper]
+  [plugins."io.containerd.snapshotter.v1.devmapper"]
     pool_name = "${POOL_NAME}"
     root_path = "${DATA_DIR}"
     base_image_size = "10GB"
@@ -102,19 +102,19 @@ cat << EOF
 EOF
 ```
 
-Use `dmsetup` to verify that the thin-pool created successfully:
+Use `dmsetup` to verify that the thin-pool was created successfully:
 ```bash
 sudo dmsetup ls
 devpool	(253:0)
 ```
 
-Once configured and restarted `containerd`, you'll see the following output:
+Once `containerd` is configured and restarted, you'll see the following output:
 ```
 INFO[2020-03-17T20:24:45.532604888Z] loading plugin "io.containerd.snapshotter.v1.devmapper"...  type=io.containerd.snapshotter.v1
 INFO[2020-03-17T20:24:45.532672738Z] initializing pool device "dev-pool"
 ```
 
-Another way to setup a thin-pool is via [container-storage-setup](https://github.com/projectatomic/container-storage-setup)
+Another way to setup a thin-pool is via the [container-storage-setup](https://github.com/projectatomic/container-storage-setup)
 tool (formerly known as `docker-storage-setup`). It is a script to configure CoW file systems like devicemapper:
 
 ```bash

--- a/snapshots/devmapper/metadata.go
+++ b/snapshots/devmapper/metadata.go
@@ -55,13 +55,13 @@ var (
 	ErrAlreadyExists = errors.New("object already exists")
 )
 
-// PoolMetadata keeps device info for the given thin-pool device, it also responsible for
-// generating next available device ids and tracking devmapper transaction numbers
+// PoolMetadata keeps device info for the given thin-pool device, generates next available device ids,
+// and tracks devmapper transaction numbers
 type PoolMetadata struct {
 	db *bolt.DB
 }
 
-// NewPoolMetadata creates new or open existing pool metadata database
+// NewPoolMetadata creates new or opens existing pool metadata database
 func NewPoolMetadata(dbfile string) (*PoolMetadata, error) {
 	db, err := bolt.Open(dbfile, 0600, nil)
 	if err != nil {
@@ -133,7 +133,7 @@ func (m *PoolMetadata) ChangeDeviceState(ctx context.Context, name string, state
 
 // MarkFaulty marks the given device and corresponding devmapper device ID as faulty.
 // The snapshotter might attempt to recreate a device in 'Faulty' state with another devmapper ID in
-// subsequent calls, and in case of success it's status will be changed to 'Created' or 'Activated'.
+// subsequent calls, and in case of success its status will be changed to 'Created' or 'Activated'.
 // The devmapper dev ID will remain in 'deviceFaulty' state until manually handled by a user.
 func (m *PoolMetadata) MarkFaulty(ctx context.Context, name string) error {
 	return m.db.Update(func(tx *bolt.Tx) error {


### PR DESCRIPTION
some small nits/fixes on devmapper snapshotter documentation.

Also, curious if there is any interest in expanding these docs to include something like https://docs.docker.com/storage/storagedriver/device-mapper-driver/#how-the-devicemapper-storage-driver-works , or perhaps just including a reference to docker's devmapper documentation (can do that in this or subsequent PR).

Signed-off-by: Gavin Inglis <giinglis@amazon.com>