### PR TITLE
shim: fix debug flag not working

### DIFF
--- a/runtime/v2/runc/manager/manager_linux.go
+++ b/runtime/v2/runc/manager/manager_linux.go
@@ -69,7 +69,7 @@ type manager struct {
 	name string
 }
 
-func newCommand(ctx context.Context, id, containerdBinary, containerdAddress, containerdTTRPCAddress string) (*exec.Cmd, error) {
+func newCommand(ctx context.Context, id, containerdBinary, containerdAddress, containerdTTRPCAddress string, debug bool) (*exec.Cmd, error) {
 	ns, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {
 		return nil, err
@@ -86,6 +86,9 @@ func newCommand(ctx context.Context, id, containerdBinary, containerdAddress, co
 		"-namespace", ns,
 		"-id", id,
 		"-address", containerdAddress,
+	}
+	if debug {
+		args = append(args, "-debug")
 	}
 	cmd := exec.Command(self, args...)
 	cmd.Dir = cwd
@@ -114,7 +117,7 @@ func (m manager) Name() string {
 }
 
 func (manager) Start(ctx context.Context, id string, opts shim.StartOpts) (_ string, retErr error) {
-	cmd, err := newCommand(ctx, id, opts.ContainerdBinary, opts.Address, opts.TTRPCAddress)
+	cmd, err := newCommand(ctx, id, opts.ContainerdBinary, opts.Address, opts.TTRPCAddress, opts.Debug)
 	if err != nil {
 		return "", err
 	}

--- a/runtime/v2/shim/shim.go
+++ b/runtime/v2/shim/shim.go
@@ -54,6 +54,7 @@ type StartOpts struct {
 	ContainerdBinary string
 	Address          string
 	TTRPCAddress     string
+	Debug            bool
 }
 
 type StopStatus struct {
@@ -329,6 +330,7 @@ func run(ctx context.Context, manager Manager, initFunc Init, name string, confi
 			ContainerdBinary: containerdBinaryFlag,
 			Address:          addressFlag,
 			TTRPCAddress:     ttrpcAddress,
+			Debug:            debugFlag,
 		}
 
 		address, err := manager.Start(ctx, id, opts)


### PR DESCRIPTION
As we know, shim starts twice. The first time we execute the shim with the
`start` arguments, the `-debug` argument is passed to the shim
process correctly. But the second time we execute shim, the debug flag
is ignored.

Signed-off-by: wllenyj <wllenyj@linux.alibaba.com>