### PR TITLE
CRI: Improve the /dev/shm mount options in Sandbox.

### DIFF
--- a/pkg/cri/server/sandbox_run_linux.go
+++ b/pkg/cri/server/sandbox_run_linux.go
@@ -103,12 +103,15 @@ func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 	}
 	// Remove the default /dev/shm mount from defaultMounts, it is added in oci/mounts.go.
 	specOpts = append(specOpts, oci.WithoutMounts(devShm))
+	// In future the when user-namespace is enabled, the `nosuid, nodev, noexec` flags are
+	// required, otherwise the remount will fail with EPERM. Just use them unconditionally,
+	// they are nice to have anyways.
 	specOpts = append(specOpts, oci.WithMounts([]runtimespec.Mount{
 		{
 			Source:      sandboxDevShm,
 			Destination: devShm,
 			Type:        "bind",
-			Options:     []string{"rbind", "ro"},
+			Options:     []string{"rbind", "ro", "nosuid", "nodev", "noexec"},
 		},
 		// Add resolv.conf for katacontainers to setup the DNS of pod VM properly.
 		{

--- a/pkg/cri/server/sandbox_run_linux.go
+++ b/pkg/cri/server/sandbox_run_linux.go
@@ -101,6 +101,8 @@ func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 	if nsOptions.GetIpc() == runtime.NamespaceMode_NODE {
 		sandboxDevShm = devShm
 	}
+	// Remove the default /dev/shm mount from defaultMounts, it is added in oci/mounts.go.
+	specOpts = append(specOpts, oci.WithoutMounts(devShm))
 	specOpts = append(specOpts, oci.WithMounts([]runtimespec.Mount{
 		{
 			Source:      sandboxDevShm,


### PR DESCRIPTION
This pr is a part of #6911, changes include:

* Optimized redundant /dev/shm mounts.
* Added `nosuid,nodev,noexec` flags to the /dev/shm mount options.

Fixes: #6911