### PR TITLE
(Vagrant CI) Enable git commands due to git CVE fix

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -107,6 +107,7 @@ EOF
 GOPATH=\\$HOME/go
 PATH=\\$GOPATH/bin:\\$PATH
 export GOPATH PATH
+git config --global --add safe.directory /vagrant
 EOF
     source /etc/profile.d/sh.local
     SHELL


### PR DESCRIPTION
Add /vagrant to "safe directory" global git config so Vagrant runs work
properly again.

Example failure: https://cirrus-ci.com/task/6459485030973440?logs=vagrant_up#L1092
(Building containerd via the Makefile runs git commands that get a `fatal: unsafe repository` error due to a CVE fix in recent versions of git)

Signed-off-by: Phil Estes <estesp@amazon.com>