### PR TITLE
Windows snapshotter touch ups and new functionality

### DIFF
--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -231,6 +231,16 @@ func WithResources(r *runtime.LinuxContainerResources) ContainerOpts { //nolint:
 	}
 }
 
+// Adds Windows container resource limits.
+func WithWindowsResources(r *runtime.WindowsContainerResources) ContainerOpts { //nolint:unused
+	return func(c *runtime.ContainerConfig) {
+		if c.Windows == nil {
+			c.Windows = &runtime.WindowsContainerConfig{}
+		}
+		c.Windows.Resources = r
+	}
+}
+
 func WithVolumeMount(hostPath, containerPath string) ContainerOpts {
 	return func(c *runtime.ContainerConfig) {
 		hostPath, _ = filepath.Abs(hostPath)

--- a/integration/windows_rootfs_size_test.go
+++ b/integration/windows_rootfs_size_test.go
@@ -1,0 +1,134 @@
+//go:build windows
+// +build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+func TestWindowsRootfsSize(t *testing.T) {
+	testPodLogDir := t.TempDir()
+
+	t.Log("Create a sandbox with log directory")
+	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "windows-rootfs-size",
+		WithPodLogDirectory(testPodLogDir),
+	)
+
+	var (
+		testImage     = GetImage(Pause)
+		containerName = "test-container"
+	)
+
+	EnsureImageExists(t, testImage)
+
+	t.Log("Create a container to run the rootfs size test")
+
+	// Ask for 200GiB disk size
+	rootfsSize := int64(200 * 1024 * 1024 * 1024)
+	cnConfig := ContainerConfig(
+		containerName,
+		testImage,
+		// Execute dir on the root of the image as it'll show the size available.
+		// We're asking for ten times the default volume size so this should be
+		// easy to verify.
+		WithCommand("cmd", "/c", "dir", "/-C", "C:\\"),
+		WithLogPath(containerName),
+		WithWindowsResources(&runtime.WindowsContainerResources{RootfsSizeInBytes: rootfsSize}),
+	)
+	cn, err := runtimeService.CreateContainer(sb, cnConfig, sbConfig)
+	require.NoError(t, err)
+
+	t.Log("Start the container")
+	require.NoError(t, runtimeService.StartContainer(cn))
+
+	t.Log("Wait for container to finish running")
+	require.NoError(t, Eventually(func() (bool, error) {
+		s, err := runtimeService.ContainerStatus(cn)
+		if err != nil {
+			return false, err
+		}
+		if s.GetState() == runtime.ContainerState_CONTAINER_EXITED {
+			return true, nil
+		}
+		return false, nil
+	}, time.Second, 30*time.Second))
+
+	t.Log("Check container log")
+	content, err := os.ReadFile(filepath.Join(testPodLogDir, containerName))
+	assert.NoError(t, err)
+
+	// Format of output for dir /-C:
+	//
+	// Volume in drive C has no label.
+	// Volume Serial Number is 5CA1-BDE0
+
+	// Directory of C:\
+	//
+	// 05/05/2022  09:36 AM              5510 License.txt
+	// 05/12/2022  08:34 PM    <DIR>          Users
+	// 05/12/2022  08:34 PM    <DIR>          Windows
+	// 			1 File(s)           5510 bytes
+	// 			2 Dir(s)    214545743872 bytes free
+	scanner := bufio.NewScanner(strings.NewReader(string(content)))
+	found := false
+	var (
+		cols      []string
+		driveSize int64
+	)
+	for scanner.Scan() {
+		outputLine := scanner.Text()
+		cols = strings.Fields(outputLine)
+		n := len(cols)
+		if n >= 3 {
+			if cols[n-2] == "bytes" && cols[n-1] == "free" {
+				driveSize, err = strconv.ParseInt(cols[n-3], 10, 64)
+				if err != nil {
+					t.Fatal(err)
+				}
+				found = true
+				break
+			}
+		}
+	}
+
+	if !found {
+		t.Log(string(content))
+		t.Fatalf("could not find the size available on the drive")
+	}
+
+	// Compare the bytes available at the root of the drive with the 200GiB we asked for. They won't
+	// match up exactly as space is always occupied but we're giving 300MiB of leeway for content on
+	// the virtual drive.
+	toleranceInMB := int64(300 * 1024 * 1024)
+	if driveSize < (rootfsSize - toleranceInMB) {
+		t.Log(string(content))
+		t.Fatalf("Size of the C:\\ volume is not within 300MiB of 200GiB. It is %d bytes", driveSize)
+	}
+}

--- a/pkg/cri/server/container_create_linux.go
+++ b/pkg/cri/server/container_create_linux.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containerd/containerd/contrib/apparmor"
 	"github.com/containerd/containerd/contrib/seccomp"
 	"github.com/containerd/containerd/oci"
+	"github.com/containerd/containerd/snapshots"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	selinux "github.com/opencontainers/selinux/go-selinux"
@@ -596,4 +597,9 @@ func generateUserString(username string, uid, gid *runtime.Int64Value) (string, 
 		userstr = userstr + ":" + groupstr
 	}
 	return userstr, nil
+}
+
+// snapshotterOpts returns any Linux specific snapshotter options for the rootfs snapshot
+func snapshotterOpts(snapshotterName string, config *runtime.ContainerConfig) []snapshots.Opt {
+	return []snapshots.Opt{}
 }

--- a/pkg/cri/server/container_create_other.go
+++ b/pkg/cri/server/container_create_other.go
@@ -21,6 +21,7 @@ package server
 
 import (
 	"github.com/containerd/containerd/oci"
+	"github.com/containerd/containerd/snapshots"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -52,4 +53,9 @@ func (c *criService) containerSpec(
 
 func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageConfig *imagespec.ImageConfig) ([]oci.SpecOpts, error) {
 	return []oci.SpecOpts{}, nil
+}
+
+// snapshotterOpts returns snapshotter options for the rootfs snapshot
+func snapshotterOpts(snapshotterName string, config *runtime.ContainerConfig) []snapshots.Opt {
+	return []snapshots.Opt{}
 }


### PR DESCRIPTION
This change does a couple things to remove some cruft/unused functionality
in the Windows snapshotter, as well as add a way to specify the rootfs
size in bytes for a Windows container via a new field added in the CRI api in
k8s 1.24. Setting the rootfs/scratch volume size was assumed to be working
prior to this but turns out not to be the case.

Previously I'd added a change to pass any annotations in the containerd
snapshot form (containerd.io/snapshot/*) as labels for the containers
rootfs snapshot. This was added as a means for a client to be able to provide
containerd.io/snapshot/io.microsoft.container.storage.rootfs.size-gb as an
annotation and have that be translated to a label and ultimately set the
size for the scratch volume in Windows. However, this actually only worked if
interfacing with the CRI api directly (crictl) as Kubernetes itself will
fail to validate annotations that if split by "/" end up with > 2 parts,
which the snapshot labels will (containerd.io / snapshot / foobarbaz).

With this in mind, passing the annotations and filtering to
containerd.io/snapshot/* is moot, so I've removed this code in favor of
a new `snapshotterOpts()` function that will return platform specific
snapshotter options if ones exist. Now on Windows we can just check if
RootfsSizeInBytes is set on the WindowsContainerResources struct and
then return a snapshotter option that sets the right label.

So all in all this change:
- Gets rid of code to pass CRI annotations as labels down to snapshotters.

- Gets rid of the functionality to create a 1GB sized scratch disk if
the client provided a size < 20GB. This code is not used currently and
has a few logical shortcomings as it won't be able to create the disk
if a container is already running and using the same base layer. WCIFS
(driver that handles the unioning of windows container layers together)
holds open handles to some files that we need to delete to create the
1GB scratch disk is the underlying problem.

- Deprecates the containerd.io/snapshot/io.microsoft.container.storage.rootfs.size-gb
label in favor of a new containerd.io/snapshot.rootfs.size-bytes label.
The previous label/annotation wasn't being used by us, and from a cursory
github search wasn't being used by anyone else either. Now that there is a CRI
field to specify the size, this should just be a field that users can set
on their pod specs and don't need to concern themselves with what it eventually
gets translated to, but I've added a more generic label for non-CRI clients.

Verified rootfs size work via:
```json
{
	"metadata": {
		"name": "rootfs-size-test"
	},
	"image": {
		"image": "mcr.microsoft.com/windows/nanoserver:1809"
	},
	"command": [
		"ping",
		"-t",
		"127.0.0.1"
	],
        "windows": {
                "resources": {
                        "rootfs_size_in_bytes": 26843545600 
                }
        }
}
```

```powershell 
PS C:\Users\Administrator\Desktop> $pod = .\crictl.exe -t 20s --config .\crictl.yaml runp .\configs\pod.json ; $c = .\crictl.e
xe -t 20s create $pod .\configs\ctr.json .\configs\pod.json ; .\crictl.exe -t 20s start $c
e8fce4f3b03d225a8a82a318876abb7534b893d21491d14804d5938ccf45fe50

PS C:\Users\Administrator\Desktop> .\crictl.exe exec -it $c cmd
Microsoft Windows [Version 10.0.17763.2928]
(c) 2018 Microsoft Corporation. All rights reserved.

C:\>dir
 Volume in drive C has no label.
 Volume Serial Number is 5CA1-BDE0

 Directory of C:\

05/05/2022  09:36 AM             5,510 License.txt
05/05/2022  09:42 AM    <DIR>          Users
05/12/2022  07:14 PM    <DIR>          Windows
               1 File(s)          5,510 bytes
               2 Dir(s)  26,647,625,728 bytes free
```