### PR TITLE
[release/1.6] cherry-pick: binaryProcessor `Wait`

### DIFF
--- a/diff/stream_unix.go
+++ b/diff/stream_unix.go
@@ -87,6 +87,7 @@ func NewBinaryProcessor(ctx context.Context, imt, rmt string, stream StreamProce
 		r:      r,
 		mt:     rmt,
 		stderr: stderr,
+		done:   make(chan struct{}),
 	}
 	go p.wait()
 
@@ -109,6 +110,11 @@ type binaryProcessor struct {
 
 	mu  sync.Mutex
 	err error
+
+	// There is a race condition between waiting on c.cmd.Wait() and setting c.err within
+	// c.wait(), and reading that value from c.Err().
+	// Use done to wait for the returned error to be captured and set.
+	done chan struct{}
 }
 
 func (c *binaryProcessor) Err() error {
@@ -124,6 +130,16 @@ func (c *binaryProcessor) wait() {
 			c.err = errors.New(c.stderr.String())
 			c.mu.Unlock()
 		}
+	}
+	close(c.done)
+}
+
+func (c *binaryProcessor) Wait(ctx context.Context) error {
+	select {
+	case <-c.done:
+		return c.Err()
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 

--- a/diff/stream_windows.go
+++ b/diff/stream_windows.go
@@ -96,6 +96,7 @@ func NewBinaryProcessor(ctx context.Context, imt, rmt string, stream StreamProce
 		r:      r,
 		mt:     rmt,
 		stderr: stderr,
+		done:   make(chan struct{}),
 	}
 	go p.wait()
 
@@ -115,6 +116,11 @@ type binaryProcessor struct {
 
 	mu  sync.Mutex
 	err error
+
+	// There is a race condition between waiting on c.cmd.Wait() and setting c.err within
+	// c.wait(), and reading that value from c.Err().
+	// Use done to wait for the returned error to be captured and set.
+	done chan struct{}
 }
 
 func (c *binaryProcessor) Err() error {
@@ -130,6 +136,16 @@ func (c *binaryProcessor) wait() {
 			c.err = errors.New(c.stderr.String())
 			c.mu.Unlock()
 		}
+	}
+	close(c.done)
+}
+
+func (c *binaryProcessor) Wait(ctx context.Context) error {
+	select {
+	case <-c.done:
+		return c.Err()
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 


### PR DESCRIPTION
Backporting PR #6916 to release 1.6

Add exported `Wait(ctx context.Context) error` interface that waits on
the underlying command (or context cancellation) and returns the error.

This fixes a race condition between .wait() and .Err error: https://github.com/containerd/containerd/issues/6914

(cherry picked from commit ad8b87ba234e0a4993fe84983ff4e45a3e47a58f)
Signed-off-by: Hamza El-Saawy <hamzaelsaawy@microsoft.com>