### PR TITLE
sandbox: replace github.com/pkg/errors with native errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,6 @@ require (
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 	github.com/opencontainers/selinux v1.10.1
 	github.com/pelletier/go-toml v1.9.3
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
@@ -104,6 +103,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/opencontainers/runtime-tools v0.0.0-20190417131837-cd1349b7c47e // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect

--- a/sandbox.go
+++ b/sandbox.go
@@ -18,6 +18,7 @@ package containerd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -27,7 +28,6 @@ import (
 	"github.com/containerd/containerd/protobuf/types"
 	api "github.com/containerd/containerd/sandbox"
 	"github.com/containerd/typeurl"
-	"github.com/pkg/errors"
 )
 
 // Sandbox is a high level client to containerd's sandboxes.
@@ -183,7 +183,7 @@ func WithSandboxRuntime(name string, options interface{}) NewSandboxOpts {
 
 		opts, err := typeurl.MarshalAny(options)
 		if err != nil {
-			return errors.Wrap(err, "failed to marshal sandbox runtime options")
+			return fmt.Errorf("failed to marshal sandbox runtime options: %w", err)
 		}
 
 		s.Runtime = api.RuntimeOpts{
@@ -206,7 +206,7 @@ func WithSandboxSpec(s *oci.Spec, opts ...oci.SpecOpts) NewSandboxOpts {
 
 		spec, err := typeurl.MarshalAny(s)
 		if err != nil {
-			return errors.Wrap(err, "failed to marshal spec")
+			return fmt.Errorf("failed to marshal spec: %w", err)
 		}
 
 		sandbox.Spec = spec
@@ -223,7 +223,7 @@ func WithSandboxExtension(name string, ext interface{}) NewSandboxOpts {
 
 		any, err := typeurl.MarshalAny(ext)
 		if err != nil {
-			return errors.Wrap(err, "failed to marshal sandbox extension")
+			return fmt.Errorf("failed to marshal sandbox extension: %w", err)
 		}
 
 		s.Extensions[name] = any


### PR DESCRIPTION
PR #6366 implemented a tree-wide change to replace github.com/pkg/errors
to errors. The new sandbox API PR #6703 had few errors.Wrap*() leftovers
and pulled github.com/pkg/errors back. This commit replaces those
leftovers by following the pattern in #6366.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>