### PR TITLE
[release/1.5] cherry-pick: Allow git commands in Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -91,6 +91,7 @@ EOF
 GOPATH=\\$HOME/go
 PATH=\\$GOPATH/bin:\\$PATH
 export GOPATH PATH
+git config --global --add safe.directory /vagrant
 EOF
     source /etc/profile.d/sh.local
     SHELL


### PR DESCRIPTION
Due to a git CVE, we need to mark /vagrant as a "safe" directory
otherwise building containerd inside Vagrant fails with git command
failures.

Cherry-pick of #6941

Signed-off-by: Phil Estes <estesp@amazon.com>