### PR TITLE
Separate windows-2019 and windows-2022 test results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,7 +363,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: TestResults Windows
+          name: TestResults ${{ matrix.os }}
           path: |
             ${{github.workspace}}/*-junit.xml
 


### PR DESCRIPTION
This fixes the problem that only one upload is kept per artifact name.