### PR TITLE
cri: improve CRI log redirection efficiency

### DIFF
--- a/cio/io.go
+++ b/cio/io.go
@@ -357,3 +357,10 @@ func Load(set *FIFOSet) (IO, error) {
 func (p *pipes) closers() []io.Closer {
 	return []io.Closer{p.Stdin, p.Stdout, p.Stderr}
 }
+
+func Copy(to io.Writer, from io.Reader) (nw int64, err error) {
+	buffer := bufPool.Get().(*[]byte)
+	nw, err = io.CopyBuffer(to, from, *buffer)
+	bufPool.Put(buffer)
+	return
+}

--- a/pkg/cri/io/container_io.go
+++ b/pkg/cri/io/container_io.go
@@ -108,7 +108,7 @@ func (c *ContainerIO) Pipe() {
 	if c.stdout != nil {
 		wg.Add(1)
 		go func() {
-			if _, err := io.Copy(c.stdoutGroup, c.stdout); err != nil {
+			if _, err := cio.Copy(c.stdoutGroup, c.stdout); err != nil {
 				logrus.WithError(err).Errorf("Failed to pipe stdout of container %q", c.id)
 			}
 			c.stdout.Close()
@@ -121,7 +121,7 @@ func (c *ContainerIO) Pipe() {
 	if !c.fifos.Terminal && c.stderr != nil {
 		wg.Add(1)
 		go func() {
-			if _, err := io.Copy(c.stderrGroup, c.stderr); err != nil {
+			if _, err := cio.Copy(c.stderrGroup, c.stderr); err != nil {
 				logrus.WithError(err).Errorf("Failed to pipe stderr of container %q", c.id)
 			}
 			c.stderr.Close()
@@ -144,12 +144,12 @@ func (c *ContainerIO) Attach(opts AttachOptions) {
 	var stdinStreamRC io.ReadCloser
 	if c.stdin != nil && opts.Stdin != nil {
 		// Create a wrapper of stdin which could be closed. Note that the
-		// wrapper doesn't close the actual stdin, it only stops io.Copy.
+		// wrapper doesn't close the actual stdin, it only stops Copy.
 		// The actual stdin will be closed by stream server.
 		stdinStreamRC = cioutil.NewWrapReadCloser(opts.Stdin)
 		wg.Add(1)
 		go func() {
-			if _, err := io.Copy(c.stdin, stdinStreamRC); err != nil {
+			if _, err := cio.Copy(c.stdin, stdinStreamRC); err != nil {
 				logrus.WithError(err).Errorf("Failed to pipe stdin for container attach %q", c.id)
 			}
 			logrus.Infof("Attach stream %q closed", stdinKey)

--- a/pkg/cri/io/exec_io.go
+++ b/pkg/cri/io/exec_io.go
@@ -67,7 +67,7 @@ func (e *ExecIO) Attach(opts AttachOptions) <-chan struct{} {
 		stdinStreamRC = cioutil.NewWrapReadCloser(opts.Stdin)
 		wg.Add(1)
 		go func() {
-			if _, err := io.Copy(e.stdin, stdinStreamRC); err != nil {
+			if _, err := cio.Copy(e.stdin, stdinStreamRC); err != nil {
 				logrus.WithError(err).Errorf("Failed to redirect stdin for container exec %q", e.id)
 			}
 			logrus.Infof("Container exec %q stdin closed", e.id)
@@ -89,7 +89,7 @@ func (e *ExecIO) Attach(opts AttachOptions) <-chan struct{} {
 	}
 
 	attachOutput := func(t StreamType, stream io.WriteCloser, out io.ReadCloser) {
-		if _, err := io.Copy(stream, out); err != nil {
+		if _, err := cio.Copy(stream, out); err != nil {
 			logrus.WithError(err).Errorf("Failed to pipe %q for container exec %q", t, e.id)
 		}
 		out.Close()


### PR DESCRIPTION
currently, containerd CRI log framework work as following (take STDOUT as example)

{log file} <----- {redirect goroutine(decorate CRI log) } <-------{ stdoutGroup }<-------{goroutine (do io.Copy)} <------- { container }

we can replace io.Copy to Copy( sync.Pool based implementation) for improve effectiency :-)

Signed-off-by: zhang he zhanghe9702@163.com