### PR TITLE
update doc url about k8s

### DIFF
--- a/contrib/ansible/README.md
+++ b/contrib/ansible/README.md
@@ -83,7 +83,7 @@ To start using your cluster, you need to run (as a regular user):
 
 You should now deploy a pod network to the cluster.
 Run "kubectl apply -f [podnetwork].yaml" with one of the options listed at:
-  http://kubernetes.io/docs/admin/addons/
+  https://kubernetes.io/docs/concepts/cluster-administration/addons/
 
 You can now join any number of machines by running the following on each node
 as root:


### PR DESCRIPTION
Update k8s doc url 
The 'http://kubernetes.io/docs/admin/addons/' seems moved to 'https://kubernetes.io/docs/concepts/cluster-administration/addons/'