### PR TITLE
Centralize tls.Config creation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,7 +33,6 @@ linters-settings:
       - G204
       - G305
       - G306
-      - G402
       - G404
 
 run:

--- a/cmd/ctr/commands/resolver.go
+++ b/cmd/ctr/commands/resolver.go
@@ -31,6 +31,7 @@ import (
 	"strings"
 
 	"github.com/containerd/console"
+	"github.com/containerd/containerd/internal"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
@@ -117,8 +118,7 @@ func GetResolver(ctx gocontext.Context, clicontext *cli.Context) (remotes.Resolv
 }
 
 func resolverDefaultTLS(clicontext *cli.Context) (*tls.Config, error) {
-	config := &tls.Config{}
-
+	config := internal.TLSConfig()
 	if clicontext.Bool("skip-verify") {
 		config.InsecureSkipVerify = true
 	}

--- a/internal/tls.go
+++ b/internal/tls.go
@@ -1,0 +1,31 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package internal
+
+import "crypto/tls"
+
+// TLSConfig returns a new tls.Config.
+func TLSConfig() *tls.Config {
+	// TLS 1.0 and 1.1 are no longer supported by Firefox, Chrome and Edge.
+	// We could upgrade our minimum version as well.
+	// - https://hacks.mozilla.org/2020/02/its-the-boot-for-tls-1-0-and-tls-1-1/
+	// - https://chromestatus.com/feature/5759116003770368
+	// - https://docs.microsoft.com/en-us/lifecycle/announcements/transport-layer-security-1x-disablement
+	//
+	//nolint:gosec
+	return &tls.Config{MinVersion: tls.VersionTLS10}
+}

--- a/pkg/cri/server/image_pull.go
+++ b/pkg/cri/server/image_pull.go
@@ -36,6 +36,7 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
 	containerdimages "github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/internal"
 	"github.com/containerd/containerd/labels"
 	"github.com/containerd/containerd/log"
 	distribution "github.com/containerd/containerd/reference/docker"
@@ -292,7 +293,7 @@ func (c *criService) updateImage(ctx context.Context, r string) error {
 // getTLSConfig returns a TLSConfig configured with a CA/Cert/Key specified by registryTLSConfig
 func (c *criService) getTLSConfig(registryTLSConfig criconfig.TLSConfig) (*tls.Config, error) {
 	var (
-		tlsConfig = &tls.Config{}
+		tlsConfig = internal.TLSConfig()
 		cert      tls.Certificate
 		err       error
 	)
@@ -395,7 +396,7 @@ func (c *criService) registryHosts(ctx context.Context, auth *runtime.AuthConfig
 			} else if isLocalHost(host) && u.Scheme == "http" {
 				// Skipping TLS verification for localhost
 				transport.TLSClientConfig = &tls.Config{
-					InsecureSkipVerify: true,
+					InsecureSkipVerify: true, // nolint:gosec
 				}
 			}
 

--- a/remotes/docker/config/hosts.go
+++ b/remotes/docker/config/hosts.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/internal"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/pelletier/go-toml"
@@ -115,7 +116,7 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
 		if options.DefaultTLS != nil {
 			defaultTLSConfig = options.DefaultTLS
 		} else {
-			defaultTLSConfig = &tls.Config{}
+			defaultTLSConfig = internal.TLSConfig()
 		}
 
 		defaultTransport := &http.Transport{

--- a/services/server/server.go
+++ b/services/server/server.go
@@ -42,6 +42,7 @@ import (
 	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/diff"
 	"github.com/containerd/containerd/events/exchange"
+	"github.com/containerd/containerd/internal"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/metadata"
 	"github.com/containerd/containerd/pkg/dialer"
@@ -160,7 +161,8 @@ func New(ctx context.Context, config *srvconfig.Config) (*Server, error) {
 		if err != nil {
 			return nil, err
 		}
-		tlsConfig := &tls.Config{Certificates: []tls.Certificate{tlsCert}}
+		tlsConfig := internal.TLSConfig()
+		tlsConfig.Certificates = []tls.Certificate{tlsCert}
 
 		if config.GRPC.TCPTLSCA != "" {
 			caCertPool := x509.NewCertPool()


### PR DESCRIPTION
tls.Config is used to set TLS's minimum supported version.

While this commit itself doesn't upgrade the version, this would make
such a upgrade easier in future.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>