### PR TITLE
Fix Windows install powershell script

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -111,7 +111,7 @@ From a PowerShell session run the following commands:
 
 ```PowerShell
 # Download and extract desired containerd Windows binaries
-$Version=1.6.2
+$Version="1.6.4"
 curl.exe -L https://github.com/containerd/containerd/releases/download/v$Version/containerd-$Version-windows-amd64.tar.gz -o containerd-windows-amd64.tar.gz
 tar.exe xvf .\containerd-windows-amd64.tar.gz
 


### PR DESCRIPTION
PowerShell doesn't treat the variable implicitly as a string and it causes the install to fail if you're copy pasting from the docs:

![image](https://user-images.githubusercontent.com/13159458/169641481-38904da2-5e4d-4c41-ae8f-d7c4f078966c.png)

I just wrapped the version string in quotes and bumped it to the latest release.

Signed-off-by: Shaun Lawrie <beatbophiphop@gmail.com>