### PR TITLE
UpperdirLabel bugfix and implement specify rootfs with label 

### DIFF
--- a/snapshots/overlay/overlay.go
+++ b/snapshots/overlay/overlay.go
@@ -160,9 +160,6 @@ func (o *snapshotter) Update(ctx context.Context, info snapshots.Info, fieldpath
 		return snapshots.Info{}, err
 	}
 
-	if err := t.Commit(); err != nil {
-		return snapshots.Info{}, err
-	}
 
 	if o.upperdirLabel {
 		id, _, _, err := storage.GetInfo(ctx, info.Name)
@@ -173,6 +170,10 @@ func (o *snapshotter) Update(ctx context.Context, info snapshots.Info, fieldpath
 			info.Labels = make(map[string]string)
 		}
 		info.Labels[upperdirKey] = o.upperPath(id)
+	}
+
+	if err := t.Commit(); err != nil {
+		return snapshots.Info{}, err
 	}
 
 	return info, nil


### PR DESCRIPTION
Bugfix: When upperdirLabel specified, overlay Update will throw tx closed error since Commit is invoked before GetInfo

Feature: support specifying where to store rwlayer of containers with annotations (containerd.io/snapshot/overlay.active.path) when creating container

Implements: #6522 

Fixes: #5624 