### PR TITLE
specifying overlay upperdir path with label

### DIFF
--- a/snapshots/overlay/overlay.go
+++ b/snapshots/overlay/overlay.go
@@ -27,19 +27,26 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/containerd/continuity/fs"
+	"github.com/sirupsen/logrus"
+
+	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/containerd/snapshots/overlay/overlayutils"
 	"github.com/containerd/containerd/snapshots/storage"
-	"github.com/containerd/continuity/fs"
-	"github.com/sirupsen/logrus"
 )
 
 // upperdirKey is a key of an optional lablel to each snapshot.
 // This optional label of a snapshot contains the location of "upperdir" where
 // the change set between this snapshot and its parent is stored.
 const upperdirKey = "containerd.io/snapshot/overlay.upperdir"
+
+// activePath is a key of an optional label to active snapshot.
+// If this label is specified, content of this active snapshot(and subsequent rootfs write)
+// will be stored in the specified path.
+const activePath = "containerd.io/snapshot/overlay.active.path"
 
 // SnapshotterConfig is used to configure the overlay snapshotter instance
 type SnapshotterConfig struct {
@@ -142,7 +149,7 @@ func (o *snapshotter) Stat(ctx context.Context, key string) (snapshots.Info, err
 		if info.Labels == nil {
 			info.Labels = make(map[string]string)
 		}
-		info.Labels[upperdirKey] = o.upperPath(id)
+		info.Labels[upperdirKey] = o.upperPath(&info, id, key)
 	}
 
 	return info, nil
@@ -172,7 +179,7 @@ func (o *snapshotter) Update(ctx context.Context, info snapshots.Info, fieldpath
 		if info.Labels == nil {
 			info.Labels = make(map[string]string)
 		}
-		info.Labels[upperdirKey] = o.upperPath(id)
+		info.Labels[upperdirKey] = o.upperPath(&info, id, info.Name)
 	}
 
 	return info, nil
@@ -197,7 +204,7 @@ func (o *snapshotter) Usage(ctx context.Context, key string) (snapshots.Usage, e
 	}
 
 	if info.Kind == snapshots.KindActive {
-		upperPath := o.upperPath(id)
+		upperPath := o.upperPath(&info, id, key)
 		du, err := fs.DiskUsage(ctx, upperPath)
 		if err != nil {
 			// TODO(stevvooe): Consider not reporting an error in this case.
@@ -227,12 +234,16 @@ func (o *snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, er
 	if err != nil {
 		return nil, err
 	}
+	_, info, _, err := storage.GetInfo(ctx, key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get info for snapshot %s: %w", key, err)
+	}
 	s, err := storage.GetSnapshot(ctx, key)
 	t.Rollback()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get active mount: %w", err)
 	}
-	return o.mounts(s), nil
+	return o.mounts(&info, s, key), nil
 }
 
 func (o *snapshotter) Commit(ctx context.Context, name, key string, opts ...snapshots.Opt) error {
@@ -250,12 +261,12 @@ func (o *snapshotter) Commit(ctx context.Context, name, key string, opts ...snap
 	}()
 
 	// grab the existing id
-	id, _, _, err := storage.GetInfo(ctx, key)
+	id, info, _, err := storage.GetInfo(ctx, key)
 	if err != nil {
 		return err
 	}
 
-	usage, err := fs.DiskUsage(ctx, o.upperPath(id))
+	usage, err := fs.DiskUsage(ctx, o.upperPath(&info, id, key))
 	if err != nil {
 		return err
 	}
@@ -281,6 +292,21 @@ func (o *snapshotter) Remove(ctx context.Context, key string) (err error) {
 			}
 		}
 	}()
+
+	_, info, _, err := storage.GetInfo(ctx, key)
+	if err != nil {
+		if strings.Contains(err.Error(), "snapshot does not exist") {
+			return nil
+		}
+		return fmt.Errorf("failed to get snapshot info: %w", err)
+	}
+
+	var home string
+	if home, err = getActivePath(&info, key); err == nil {
+		if err = removeActivePath(&info, key); err != nil {
+			return fmt.Errorf("failed to remove directory %v: %w", home, err)
+		}
+	}
 
 	_, _, err = storage.Remove(ctx, key)
 	if err != nil {
@@ -328,7 +354,7 @@ func (o *snapshotter) Walk(ctx context.Context, fn snapshots.WalkFunc, fs ...str
 			if info.Labels == nil {
 				info.Labels = make(map[string]string)
 			}
-			info.Labels[upperdirKey] = o.upperPath(id)
+			info.Labels[upperdirKey] = o.upperPath(&info, id, info.Name)
 			return fn(ctx, info)
 		}, fs...)
 	}
@@ -393,13 +419,65 @@ func (o *snapshotter) getCleanupDirectories(ctx context.Context, t storage.Trans
 	return cleanup, nil
 }
 
+// getActivePath tries to obtain specified path for Active layer in annotation
+func getActivePath(info *snapshots.Info, key string) (string, error) {
+	if info.Labels != nil {
+		if home, ok := info.Labels[activePath]; ok {
+			if !filepath.IsAbs(home) {
+				return "", fmt.Errorf("path for active layer must be an absolute path: %w", errdefs.ErrInvalidArgument)
+			}
+			if key == "" {
+				return filepath.Join(home, ".rwlayer", info.Created.String()), nil
+			}
+			return filepath.Join(home, ".rwlayer", key), nil
+		}
+	}
+	return "", fmt.Errorf("active snapshot path is not specified")
+}
+
+// removeActivePath removes the path created as rwlayer in specified path
+func removeActivePath(info *snapshots.Info, key string) error {
+	var removePath string
+
+	if info.Labels == nil {
+		return nil
+	}
+
+	if home, ok := info.Labels[activePath]; ok {
+		if key == "" {
+			removePath = filepath.Join(home, ".rwlayer", info.Created.String())
+			return os.RemoveAll(removePath)
+		}
+		keyList := append([]string{".rwlayer"}, strings.Split(key, "/")...)
+		if err := os.RemoveAll(filepath.Join(home, ".rwlayer", key)); err != nil {
+			return err
+		}
+		for i := len(keyList) - 1; i > 0; i-- {
+			dirPath := strings.Join(keyList[0:i], "/")
+			dir, _ := os.ReadDir(filepath.Join(home, dirPath))
+			if len(dir) == 0 {
+				os.RemoveAll(filepath.Join(home, dirPath))
+			}
+		}
+
+	}
+	return nil
+}
+
 func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, key, parent string, opts []snapshots.Opt) (_ []mount.Mount, err error) {
 	ctx, t, err := o.ms.TransactionContext(ctx, true)
 	if err != nil {
 		return nil, err
 	}
 
-	var td, path string
+	var base snapshots.Info
+	for _, opt := range opts {
+		if err := opt(&base); err != nil {
+			return nil, err
+		}
+	}
+
+	var td, path, snapshotDir string
 	defer func() {
 		if err != nil {
 			if td != "" {
@@ -416,7 +494,26 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 		}
 	}()
 
-	snapshotDir := filepath.Join(o.root, "snapshots")
+	if homePath, err := getActivePath(&base, key); err == nil {
+		//TODO Chaofeng: This section will clear the rwlayer data on specified path to handle malfunctioning machine data leak.
+		//               Need a more elegant way to handle this
+		if _, err := os.Stat(homePath); err == nil {
+			if err = os.RemoveAll(homePath); err != nil {
+				logrus.WithError(err).Errorf("failed to cleanup %s created by last time", homePath)
+			}
+		}
+
+		if err = os.MkdirAll(homePath, 0711); err != nil {
+			return nil, err
+		}
+		snapshotDir = homePath
+	} else {
+		if !errdefs.IsNotFound(err) {
+			log.G(ctx).WithError(err).Warn("activePath specified invalid")
+		}
+		snapshotDir = filepath.Join(o.root, "snapshots")
+	}
+
 	td, err = o.prepareDirectory(ctx, snapshotDir, kind)
 	if err != nil {
 		if rerr := t.Rollback(); rerr != nil {
@@ -439,7 +536,7 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 	}
 
 	if len(s.ParentIDs) > 0 {
-		st, err := os.Stat(o.upperPath(s.ParentIDs[0]))
+		st, err := os.Stat(o.upperPath(nil, s.ParentIDs[0], key))
 		if err != nil {
 			return nil, fmt.Errorf("failed to stat parent: %w", err)
 		}
@@ -465,7 +562,7 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 		return nil, fmt.Errorf("commit failed: %w", err)
 	}
 
-	return o.mounts(s), nil
+	return o.mounts(&base, s, key), nil
 }
 
 func (o *snapshotter) prepareDirectory(ctx context.Context, snapshotDir string, kind snapshots.Kind) (string, error) {
@@ -487,7 +584,7 @@ func (o *snapshotter) prepareDirectory(ctx context.Context, snapshotDir string, 
 	return td, nil
 }
 
-func (o *snapshotter) mounts(s storage.Snapshot) []mount.Mount {
+func (o *snapshotter) mounts(info *snapshots.Info, s storage.Snapshot, key string) []mount.Mount {
 	if len(s.ParentIDs) == 0 {
 		// if we only have one layer/no parents then just return a bind mount as overlay
 		// will not work
@@ -498,7 +595,7 @@ func (o *snapshotter) mounts(s storage.Snapshot) []mount.Mount {
 
 		return []mount.Mount{
 			{
-				Source: o.upperPath(s.ID),
+				Source: o.upperPath(info, s.ID, ""),
 				Type:   "bind",
 				Options: []string{
 					roFlag,
@@ -520,13 +617,13 @@ func (o *snapshotter) mounts(s storage.Snapshot) []mount.Mount {
 
 	if s.Kind == snapshots.KindActive {
 		options = append(options,
-			fmt.Sprintf("workdir=%s", o.workPath(s.ID)),
-			fmt.Sprintf("upperdir=%s", o.upperPath(s.ID)),
+			fmt.Sprintf("workdir=%s", o.workPath(info, s.ID, key)),
+			fmt.Sprintf("upperdir=%s", o.upperPath(info, s.ID, key)),
 		)
 	} else if len(s.ParentIDs) == 1 {
 		return []mount.Mount{
 			{
-				Source: o.upperPath(s.ParentIDs[0]),
+				Source: o.upperPath(info, s.ParentIDs[0], ""),
 				Type:   "bind",
 				Options: []string{
 					"ro",
@@ -538,7 +635,7 @@ func (o *snapshotter) mounts(s storage.Snapshot) []mount.Mount {
 
 	parentPaths := make([]string, len(s.ParentIDs))
 	for i := range s.ParentIDs {
-		parentPaths[i] = o.upperPath(s.ParentIDs[i])
+		parentPaths[i] = o.upperPath(nil, s.ParentIDs[i], "")
 	}
 
 	options = append(options, fmt.Sprintf("lowerdir=%s", strings.Join(parentPaths, ":")))
@@ -552,11 +649,21 @@ func (o *snapshotter) mounts(s storage.Snapshot) []mount.Mount {
 
 }
 
-func (o *snapshotter) upperPath(id string) string {
+func (o *snapshotter) upperPath(info *snapshots.Info, id string, key string) string {
+	if info != nil {
+		if home, err := getActivePath(info, key); err == nil {
+			return filepath.Join(home, id, "fs")
+		}
+	}
 	return filepath.Join(o.root, "snapshots", id, "fs")
 }
 
-func (o *snapshotter) workPath(id string) string {
+func (o *snapshotter) workPath(info *snapshots.Info, id string, key string) string {
+	if info != nil {
+		if home, err := getActivePath(info, key); err == nil {
+			return filepath.Join(home, id, "work")
+		}
+	}
 	return filepath.Join(o.root, "snapshots", id, "work")
 }
 


### PR DESCRIPTION
support specifying where to store rwlayer of containers with annotations (containerd.io/snapshot/overlay.active.path) when creating containers.

Implements: #6522 