### PR TITLE
build: Fix references to check-protos target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ GOTEST ?= $(GO) test
 OUTPUTDIR = $(join $(ROOTDIR), _output)
 CRIDIR=$(OUTPUTDIR)/cri
 
-.PHONY: clean all AUTHORS build binaries test integration generate protos checkprotos coverage ci check help install uninstall vendor release mandir install-man genman install-cri-deps cri-release cri-cni-release cri-integration install-deps bin/cri-integration.test
+.PHONY: clean all AUTHORS build binaries test integration generate protos check-protos coverage ci check help install uninstall vendor release mandir install-man genman install-cri-deps cri-release cri-cni-release cri-integration install-deps bin/cri-integration.test
 .DEFAULT: default
 
 # Forcibly set the default goal to all, in case an include above brought in a rule definition.
@@ -150,7 +150,7 @@ check: proto-fmt ## run all linters
 	@echo "$(WHALE) $@"
 	GOGC=75 golangci-lint run
 
-ci: check binaries checkprotos coverage coverage-integration ## to be used by the CI
+ci: check binaries check-protos coverage coverage-integration ## to be used by the CI
 
 AUTHORS: .mailmap .git/HEAD
 	git log --format='%aN <%aE>' | sort -fu > $@


### PR DESCRIPTION
There is no Makefile target for `checkprotos` -- this is a typo of the `check-protos` target. This PR fixes those references.

Signed-off-by: Ethan Lowman <ethan.lowman@datadoghq.com>