### PR TITLE
Makefile: use urfave_cli_no_docs for binaries that don't need it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ ifdef BUILDTAGS
     GO_BUILDTAGS = ${BUILDTAGS}
 endif
 GO_BUILDTAGS ?=
+GO_BUILDTAGS += urfave_cli_no_docs
 GO_BUILDTAGS += ${DEBUG_TAGS}
 GO_TAGS=$(if $(GO_BUILDTAGS),-tags "$(strip $(GO_BUILDTAGS))",)
 GO_LDFLAGS=-ldflags '-X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PACKAGE) $(EXTRA_LDFLAGS)'
@@ -221,12 +222,17 @@ FORCE:
 
 define BUILD_BINARY
 @echo "$(WHALE) $@"
-@$(GO) build ${DEBUG_GO_GCFLAGS} ${GO_GCFLAGS} ${GO_BUILD_FLAGS} -o $@ ${GO_LDFLAGS} ${GO_TAGS}  ./$<
+$(GO) build ${DEBUG_GO_GCFLAGS} ${GO_GCFLAGS} ${GO_BUILD_FLAGS} -o $@ ${GO_LDFLAGS} ${GO_TAGS}  ./$<
 endef
 
 # Build a binary from a cmd.
 bin/%: cmd/% FORCE
 	$(call BUILD_BINARY)
+
+# gen-manpages must not have the urfave_cli_no_docs build-tag set
+bin/gen-manpages: cmd/gen-manpages FORCE
+	@echo "$(WHALE) $@"
+	$(GO) build ${DEBUG_GO_GCFLAGS} ${GO_GCFLAGS} ${GO_BUILD_FLAGS} -o $@ ${GO_LDFLAGS} $(subst urfave_cli_no_docs,,${GO_TAGS})  ./cmd/gen-manpages
 
 bin/containerd-shim: cmd/containerd-shim FORCE # set !cgo and omit pie for a static shim build: https://github.com/golang/go/issues/17789#issuecomment-258542220
 	@echo "$(WHALE) $@"


### PR DESCRIPTION
- relates to https://github.com/urfave/cli/pull/1383
- follow-up to https://github.com/containerd/containerd/pull/6997

(first commit is from https://github.com/containerd/containerd/pull/6997 - I'll rebase once that's merged)


We only need the `ToMan()` as part of the `bin/gen-manpages` binary, which
generates the man-pages; other binaries don't use this code, so we can
set the `urfave_cli_no_docs` build-tag to exclude `cpuguy83/md2man` and
`russross/blackfriday` (and other dependencies) from the binaries:

Before:

    ls -lh bin
    total 149M
    -rwxr-xr-x 1 root root  49M May 27 10:12 containerd
    -rwxr-xr-x 1 root root 6.1M May 27 10:13 containerd-shim
    -rwxr-xr-x 1 root root 8.1M May 27 10:13 containerd-shim-runc-v1
    -rwxr-xr-x 1 root root 8.2M May 27 10:13 containerd-shim-runc-v2
    -rwxr-xr-x 1 root root  22M May 27 10:12 containerd-stress
    -rwxr-xr-x 1 root root  26M May 27 10:11 ctr
    -rwxr-xr-x 1 root root  30M May 27 10:14 gen-manpages

    ls -l bin
    total 151676
    -rwxr-xr-x 1 root root 51280184 May 27 10:12 containerd
    -rwxr-xr-x 1 root root  6332416 May 27 10:13 containerd-shim
    -rwxr-xr-x 1 root root  8458240 May 27 10:13 containerd-shim-runc-v1
    -rwxr-xr-x 1 root root  8536064 May 27 10:13 containerd-shim-runc-v2
    -rwxr-xr-x 1 root root 22567160 May 27 10:12 containerd-stress
    -rwxr-xr-x 1 root root 26873752 May 27 10:11 ctr
    -rwxr-xr-x 1 root root 30508888 May 27 10:14 gen-manpages

After:

    ls -lh bin
    total 147M
    -rwxr-xr-x 1 root root  49M May 27 10:26 containerd
    -rwxr-xr-x 1 root root 6.1M May 27 10:26 containerd-shim
    -rwxr-xr-x 1 root root 8.1M May 27 10:26 containerd-shim-runc-v1
    -rwxr-xr-x 1 root root 8.2M May 27 10:26 containerd-shim-runc-v2
    -rwxr-xr-x 1 root root  22M May 27 10:26 containerd-stress
    -rwxr-xr-x 1 root root  26M May 27 10:26 ctr
    -rwxr-xr-x 1 root root  30M May 27 10:27 gen-manpages

    ls -l bin
    total 149912
    -rwxr-xr-x 1 root root 50930360 May 27 10:26 containerd
    -rwxr-xr-x 1 root root  6332416 May 27 10:26 containerd-shim
    -rwxr-xr-x 1 root root  8458240 May 27 10:26 containerd-shim-runc-v1
    -rwxr-xr-x 1 root root  8536064 May 27 10:26 containerd-shim-runc-v2
    -rwxr-xr-x 1 root root 22209144 May 27 10:26 containerd-stress
    -rwxr-xr-x 1 root root 26523896 May 27 10:26 ctr
    -rwxr-xr-x 1 root root 30508888 May 27 10:27 gen-manpages
