### PR TITLE
Linux containers on FreeBSD

### DIFF
--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -377,6 +377,7 @@ func WithImageConfigArgs(image Image, args []string) SpecOpts {
 			return fmt.Errorf("unknown image config media type %s", ic.MediaType)
 		}
 
+		appendOSMounts(s, ociimage.OS)
 		setProcess(s)
 		if s.Linux != nil {
 			defaults := config.Env

--- a/oci/spec_opts_darwin.go
+++ b/oci/spec_opts_darwin.go
@@ -1,6 +1,3 @@
-//go:build !windows && !darwin && !freebsd
-// +build !windows,!darwin,!freebsd
-
 /*
    Copyright The containerd Authors.
 
@@ -17,25 +14,8 @@
    limitations under the License.
 */
 
-package platforms
+package oci
 
-import (
-	"runtime"
-
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
-)
-
-// DefaultSpec returns the current platform's default platform specification.
-func DefaultSpec() specs.Platform {
-	return specs.Platform{
-		OS:           runtime.GOOS,
-		Architecture: runtime.GOARCH,
-		// The Variant field will be empty if arch != ARM.
-		Variant: cpuVariant(),
-	}
-}
-
-// Default returns the default matcher for the platform.
-func Default() MatchComparer {
-	return Only(DefaultSpec())
+func appendOSMounts(s *Spec, os string) error {
+	return nil
 }

--- a/oci/spec_opts_freebsd.go
+++ b/oci/spec_opts_freebsd.go
@@ -1,0 +1,50 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package oci
+
+import (
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// appendOSMounts modifies the mount spec to mount emulated Linux filesystems on FreeBSD,
+// as per: https://wiki.freebsd.org/LinuxJails
+func appendOSMounts(s *Spec, os string) error {
+	// No-op for FreeBSD containers
+	if os != "linux" {
+		return nil
+	}
+	/* The nosuid noexec options are for consistency with Linux mounts: on FreeBSD it is
+	   by default impossible to execute anything from these filesystems.
+	*/
+	var mounts = []specs.Mount{
+		{
+			Destination: "/proc",
+			Type:        "linprocfs",
+			Source:      "linprocfs",
+			Options:     []string{"nosuid", "noexec"},
+		},
+		{
+			Destination: "/sys",
+			Type:        "linsysfs",
+			Source:      "linsysfs",
+			Options:     []string{"nosuid", "noexec", "nodev"},
+		},
+	}
+
+	s.Mounts = append(mounts, s.Mounts...)
+	return nil
+}

--- a/oci/spec_opts_linux.go
+++ b/oci/spec_opts_linux.go
@@ -203,3 +203,7 @@ func WithCDI(annotations map[string]string, cdiSpecDirs []string) SpecOpts {
 		return nil
 	}
 }
+
+func appendOSMounts(s *Spec, os string) error {
+	return nil
+}

--- a/oci/spec_opts_windows.go
+++ b/oci/spec_opts_windows.go
@@ -115,3 +115,7 @@ func escapeAndCombineArgs(args []string) string {
 	}
 	return strings.Join(escaped, " ")
 }
+
+func appendOSMounts(s *Spec, os string) error {
+	return nil
+}

--- a/platforms/defaults_freebsd.go
+++ b/platforms/defaults_freebsd.go
@@ -1,6 +1,3 @@
-//go:build !windows && !darwin && !freebsd
-// +build !windows,!darwin,!freebsd
-
 /*
    Copyright The containerd Authors.
 
@@ -20,9 +17,8 @@
 package platforms
 
 import (
-	"runtime"
-
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"runtime"
 )
 
 // DefaultSpec returns the current platform's default platform specification.
@@ -37,5 +33,10 @@ func DefaultSpec() specs.Platform {
 
 // Default returns the default matcher for the platform.
 func Default() MatchComparer {
-	return Only(DefaultSpec())
+	return Ordered(DefaultSpec(), specs.Platform{
+		OS:           "linux",
+		Architecture: runtime.GOARCH,
+		// The Variant field will be empty if arch != ARM.
+		Variant: cpuVariant(),
+	})
 }


### PR DESCRIPTION
This allows running Linux containers on FreeBSD and modifies the
mounts so that they represent the linux emulated filesystems, as per:
https://wiki.freebsd.org/LinuxJails

Supersedes #5480 per convo with @gizahNL in OCI Slack chat 