### PR TITLE
Use t.Run for /pkg/cri tests

### DIFF
--- a/pkg/cri/io/logger_test.go
+++ b/pkg/cri/io/logger_test.go
@@ -236,23 +236,24 @@ func TestRedirectLogs(t *testing.T) {
 			},
 		},
 	} {
-		t.Logf("TestCase %q", desc)
-		rc := io.NopCloser(strings.NewReader(test.input))
-		buf := bytes.NewBuffer(nil)
-		wc := cioutil.NewNopWriteCloser(buf)
-		redirectLogs("test-path", rc, wc, test.stream, test.maxLen)
-		output := buf.String()
-		lines := strings.Split(output, "\n")
-		lines = lines[:len(lines)-1] // Discard empty string after last \n
-		assert.Len(t, lines, len(test.content))
-		for i := range lines {
-			fields := strings.SplitN(lines[i], string([]byte{delimiter}), 4)
-			require.Len(t, fields, 4)
-			_, err := time.Parse(timestampFormat, fields[0])
-			assert.NoError(t, err)
-			assert.EqualValues(t, test.stream, fields[1])
-			assert.Equal(t, string(test.tag[i]), fields[2])
-			assert.Equal(t, test.content[i], fields[3])
-		}
+		t.Run(desc, func(t *testing.T) {
+			rc := io.NopCloser(strings.NewReader(test.input))
+			buf := bytes.NewBuffer(nil)
+			wc := cioutil.NewNopWriteCloser(buf)
+			redirectLogs("test-path", rc, wc, test.stream, test.maxLen)
+			output := buf.String()
+			lines := strings.Split(output, "\n")
+			lines = lines[:len(lines)-1] // Discard empty string after last \n
+			assert.Len(t, lines, len(test.content))
+			for i := range lines {
+				fields := strings.SplitN(lines[i], string([]byte{delimiter}), 4)
+				require.Len(t, fields, 4)
+				_, err := time.Parse(timestampFormat, fields[0])
+				assert.NoError(t, err)
+				assert.EqualValues(t, test.stream, fields[1])
+				assert.Equal(t, string(test.tag[i]), fields[2])
+				assert.Equal(t, test.content[i], fields[3])
+			}
+		})
 	}
 }

--- a/pkg/cri/server/container_list_test.go
+++ b/pkg/cri/server/container_list_test.go
@@ -149,8 +149,10 @@ func TestFilterContainers(t *testing.T) {
 			expect: []*runtime.Container{testContainers[2]},
 		},
 	} {
-		filtered := c.filterCRIContainers(testContainers, test.filter)
-		assert.Equal(t, test.expect, filtered, desc)
+		t.Run(desc, func(t *testing.T) {
+			filtered := c.filterCRIContainers(testContainers, test.filter)
+			assert.Equal(t, test.expect, filtered, desc)
+		})
 	}
 }
 
@@ -332,14 +334,15 @@ func TestListContainers(t *testing.T) {
 			expect: expectedContainers[:1],
 		},
 	} {
-		t.Logf("TestCase: %s", testdesc)
-		resp, err := c.ListContainers(context.Background(), &runtime.ListContainersRequest{Filter: testdata.filter})
-		assert.NoError(t, err)
-		require.NotNil(t, resp)
-		containers := resp.GetContainers()
-		assert.Len(t, containers, len(testdata.expect))
-		for _, cntr := range testdata.expect {
-			assert.Contains(t, containers, cntr)
-		}
+		t.Run(testdesc, func(t *testing.T) {
+			resp, err := c.ListContainers(context.Background(), &runtime.ListContainersRequest{Filter: testdata.filter})
+			assert.NoError(t, err)
+			require.NotNil(t, resp)
+			containers := resp.GetContainers()
+			assert.Len(t, containers, len(testdata.expect))
+			for _, cntr := range testdata.expect {
+				assert.Contains(t, containers, cntr)
+			}
+		})
 	}
 }

--- a/pkg/cri/server/container_remove_test.go
+++ b/pkg/cri/server/container_remove_test.go
@@ -65,21 +65,22 @@ func TestSetContainerRemoving(t *testing.T) {
 			expectErr: false,
 		},
 	} {
-		t.Logf("TestCase %q", desc)
-		container, err := containerstore.NewContainer(
-			containerstore.Metadata{ID: testID},
-			containerstore.WithFakeStatus(test.status),
-		)
-		assert.NoError(t, err)
-		err = setContainerRemoving(container)
-		if test.expectErr {
-			assert.Error(t, err)
-			assert.Equal(t, test.status, container.Status.Get(), "metadata should not be updated")
-		} else {
+		t.Run(desc, func(t *testing.T) {
+			container, err := containerstore.NewContainer(
+				containerstore.Metadata{ID: testID},
+				containerstore.WithFakeStatus(test.status),
+			)
 			assert.NoError(t, err)
-			assert.True(t, container.Status.Get().Removing, "removing should be set")
-			assert.NoError(t, resetContainerRemoving(container))
-			assert.False(t, container.Status.Get().Removing, "removing should be reset")
-		}
+			err = setContainerRemoving(container)
+			if test.expectErr {
+				assert.Error(t, err)
+				assert.Equal(t, test.status, container.Status.Get(), "metadata should not be updated")
+			} else {
+				assert.NoError(t, err)
+				assert.True(t, container.Status.Get().Removing, "removing should be set")
+				assert.NoError(t, resetContainerRemoving(container))
+				assert.False(t, container.Status.Get().Removing, "removing should be reset")
+			}
+		})
 	}
 }

--- a/pkg/cri/server/container_start_test.go
+++ b/pkg/cri/server/container_start_test.go
@@ -78,21 +78,22 @@ func TestSetContainerStarting(t *testing.T) {
 			expectErr: true,
 		},
 	} {
-		t.Logf("TestCase %q", desc)
-		container, err := containerstore.NewContainer(
-			containerstore.Metadata{ID: testID},
-			containerstore.WithFakeStatus(test.status),
-		)
-		assert.NoError(t, err)
-		err = setContainerStarting(container)
-		if test.expectErr {
-			assert.Error(t, err)
-			assert.Equal(t, test.status, container.Status.Get(), "metadata should not be updated")
-		} else {
+		t.Run(desc, func(t *testing.T) {
+			container, err := containerstore.NewContainer(
+				containerstore.Metadata{ID: testID},
+				containerstore.WithFakeStatus(test.status),
+			)
 			assert.NoError(t, err)
-			assert.True(t, container.Status.Get().Starting, "starting should be set")
-			assert.NoError(t, resetContainerStarting(container))
-			assert.False(t, container.Status.Get().Starting, "starting should be reset")
-		}
+			err = setContainerStarting(container)
+			if test.expectErr {
+				assert.Error(t, err)
+				assert.Equal(t, test.status, container.Status.Get(), "metadata should not be updated")
+			} else {
+				assert.NoError(t, err)
+				assert.True(t, container.Status.Get().Starting, "starting should be set")
+				assert.NoError(t, resetContainerStarting(container))
+				assert.False(t, container.Status.Get().Starting, "starting should be reset")
+			}
+		})
 	}
 }

--- a/pkg/cri/server/container_stats_list_linux_test.go
+++ b/pkg/cri/server/container_stats_list_linux_test.go
@@ -168,7 +168,6 @@ func TestContainerMetricsCPU(t *testing.T) {
 		expectedFirst  *runtime.CpuUsage
 		expectedSecond *runtime.CpuUsage
 	}{
-
 		"v1 metrics": {
 			firstMetrics: &v1.Metrics{
 				CPU: &v1.CPUStat{

--- a/pkg/cri/server/container_stop_test.go
+++ b/pkg/cri/server/container_stop_test.go
@@ -61,25 +61,27 @@ func TestWaitContainerStop(t *testing.T) {
 			expectErr: false,
 		},
 	} {
-		c := newTestCRIService()
-		container, err := containerstore.NewContainer(
-			containerstore.Metadata{ID: id},
-			containerstore.WithFakeStatus(*test.status),
-		)
-		assert.NoError(t, err)
-		assert.NoError(t, c.containerStore.Add(container))
-		ctx := context.Background()
-		if test.cancel {
-			cancelledCtx, cancel := context.WithCancel(ctx)
-			cancel()
-			ctx = cancelledCtx
-		}
-		if test.timeout > 0 {
-			timeoutCtx, cancel := context.WithTimeout(ctx, test.timeout)
-			defer cancel()
-			ctx = timeoutCtx
-		}
-		err = c.waitContainerStop(ctx, container)
-		assert.Equal(t, test.expectErr, err != nil, desc)
+		t.Run(desc, func(t *testing.T) {
+			c := newTestCRIService()
+			container, err := containerstore.NewContainer(
+				containerstore.Metadata{ID: id},
+				containerstore.WithFakeStatus(*test.status),
+			)
+			assert.NoError(t, err)
+			assert.NoError(t, c.containerStore.Add(container))
+			ctx := context.Background()
+			if test.cancel {
+				cancelledCtx, cancel := context.WithCancel(ctx)
+				cancel()
+				ctx = cancelledCtx
+			}
+			if test.timeout > 0 {
+				timeoutCtx, cancel := context.WithTimeout(ctx, test.timeout)
+				defer cancel()
+				ctx = timeoutCtx
+			}
+			err = c.waitContainerStop(ctx, container)
+			assert.Equal(t, test.expectErr, err != nil, desc)
+		})
 	}
 }

--- a/pkg/cri/server/container_update_resources_linux_test.go
+++ b/pkg/cri/server/container_update_resources_linux_test.go
@@ -211,19 +211,20 @@ func TestUpdateOCILinuxResource(t *testing.T) {
 			},
 		},
 	} {
-		t.Logf("TestCase %q", desc)
-		config := criconfig.Config{
-			PluginConfig: criconfig.PluginConfig{
-				TolerateMissingHugetlbController: true,
-				DisableHugetlbController:         false,
-			},
-		}
-		got, err := updateOCIResource(context.Background(), test.spec, test.request, config)
-		if test.expectErr {
-			assert.Error(t, err)
-		} else {
-			assert.NoError(t, err)
-		}
-		assert.Equal(t, test.expected, got)
+		t.Run(desc, func(t *testing.T) {
+			config := criconfig.Config{
+				PluginConfig: criconfig.PluginConfig{
+					TolerateMissingHugetlbController: true,
+					DisableHugetlbController:         false,
+				},
+			}
+			got, err := updateOCIResource(context.Background(), test.spec, test.request, config)
+			if test.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, test.expected, got)
+		})
 	}
 }

--- a/pkg/cri/server/helpers_linux_test.go
+++ b/pkg/cri/server/helpers_linux_test.go
@@ -54,9 +54,10 @@ func TestGetCgroupsPath(t *testing.T) {
 			expected:      "/test-id",
 		},
 	} {
-		t.Logf("TestCase %q", desc)
-		got := getCgroupsPath(test.cgroupsParent, testID)
-		assert.Equal(t, test.expected, got)
+		t.Run(desc, func(t *testing.T) {
+			got := getCgroupsPath(test.cgroupsParent, testID)
+			assert.Equal(t, test.expected, got)
+		})
 	}
 }
 

--- a/pkg/cri/server/helpers_test.go
+++ b/pkg/cri/server/helpers_test.go
@@ -75,10 +75,11 @@ func TestGetUserFromImage(t *testing.T) {
 			name: "test",
 		},
 	} {
-		t.Logf("TestCase - %q", c)
-		actualUID, actualName := getUserFromImage(test.user)
-		assert.Equal(t, test.uid, actualUID)
-		assert.Equal(t, test.name, actualName)
+		t.Run(c, func(t *testing.T) {
+			actualUID, actualName := getUserFromImage(test.user)
+			assert.Equal(t, test.uid, actualUID)
+			assert.Equal(t, test.name, actualName)
+		})
 	}
 }
 
@@ -112,12 +113,13 @@ func TestGetRepoDigestAndTag(t *testing.T) {
 			expectedRepoTag:    "",
 		},
 	} {
-		t.Logf("TestCase %q", desc)
-		named, err := docker.ParseDockerRef(test.ref)
-		assert.NoError(t, err)
-		repoDigest, repoTag := getRepoDigestAndTag(named, digest, test.schema1)
-		assert.Equal(t, test.expectedRepoDigest, repoDigest)
-		assert.Equal(t, test.expectedRepoTag, repoTag)
+		t.Run(desc, func(t *testing.T) {
+			named, err := docker.ParseDockerRef(test.ref)
+			assert.NoError(t, err)
+			repoDigest, repoTag := getRepoDigestAndTag(named, digest, test.schema1)
+			assert.Equal(t, test.expectedRepoDigest, repoDigest)
+			assert.Equal(t, test.expectedRepoTag, repoTag)
+		})
 	}
 }
 
@@ -364,17 +366,18 @@ func TestEnvDeduplication(t *testing.T) {
 			},
 		},
 	} {
-		t.Logf("TestCase %q", desc)
-		var spec runtimespec.Spec
-		if len(test.existing) > 0 {
-			spec.Process = &runtimespec.Process{
-				Env: test.existing,
+		t.Run(desc, func(t *testing.T) {
+			var spec runtimespec.Spec
+			if len(test.existing) > 0 {
+				spec.Process = &runtimespec.Process{
+					Env: test.existing,
+				}
 			}
-		}
-		for _, kv := range test.kv {
-			oci.WithEnv([]string{kv[0] + "=" + kv[1]})(context.Background(), nil, nil, &spec)
-		}
-		assert.Equal(t, test.expected, spec.Process.Env)
+			for _, kv := range test.kv {
+				oci.WithEnv([]string{kv[0] + "=" + kv[1]})(context.Background(), nil, nil, &spec)
+			}
+			assert.Equal(t, test.expected, spec.Process.Env)
+		})
 	}
 }
 

--- a/pkg/cri/server/image_pull_test.go
+++ b/pkg/cri/server/image_pull_test.go
@@ -102,11 +102,12 @@ func TestParseAuth(t *testing.T) {
 			expectedSecret: testPasswd,
 		},
 	} {
-		t.Logf("TestCase %q", desc)
-		u, s, err := ParseAuth(test.auth, test.host)
-		assert.Equal(t, test.expectErr, err != nil)
-		assert.Equal(t, test.expectedUser, u)
-		assert.Equal(t, test.expectedSecret, s)
+		t.Run(desc, func(t *testing.T) {
+			u, s, err := ParseAuth(test.auth, test.host)
+			assert.Equal(t, test.expectErr, err != nil)
+			assert.Equal(t, test.expectedUser, u)
+			assert.Equal(t, test.expectedSecret, s)
+		})
 	}
 }
 
@@ -250,12 +251,13 @@ func TestRegistryEndpoints(t *testing.T) {
 			},
 		},
 	} {
-		t.Logf("TestCase %q", desc)
-		c := newTestCRIService()
-		c.config.Registry.Mirrors = test.mirrors
-		got, err := c.registryEndpoints(test.host)
-		assert.NoError(t, err)
-		assert.Equal(t, test.expected, got)
+		t.Run(desc, func(t *testing.T) {
+			c := newTestCRIService()
+			c.config.Registry.Mirrors = test.mirrors
+			got, err := c.registryEndpoints(test.host)
+			assert.NoError(t, err)
+			assert.Equal(t, test.expected, got)
+		})
 	}
 }
 
@@ -305,9 +307,10 @@ func TestDefaultScheme(t *testing.T) {
 			expected: "https",
 		},
 	} {
-		t.Logf("TestCase %q", desc)
-		got := defaultScheme(test.host)
-		assert.Equal(t, test.expected, got)
+		t.Run(desc, func(t *testing.T) {
+			got := defaultScheme(test.host)
+			assert.Equal(t, test.expected, got)
+		})
 	}
 }
 
@@ -325,11 +328,12 @@ func TestEncryptedImagePullOpts(t *testing.T) {
 			expectedOpts: 0,
 		},
 	} {
-		t.Logf("TestCase %q", desc)
-		c := newTestCRIService()
-		c.config.ImageDecryption.KeyModel = test.keyModel
-		got := len(c.encryptedImagesPullOpts())
-		assert.Equal(t, test.expectedOpts, got)
+		t.Run(desc, func(t *testing.T) {
+			c := newTestCRIService()
+			c.config.ImageDecryption.KeyModel = test.keyModel
+			got := len(c.encryptedImagesPullOpts())
+			assert.Equal(t, test.expectedOpts, got)
+		})
 	}
 }
 

--- a/pkg/cri/server/sandbox_list_test.go
+++ b/pkg/cri/server/sandbox_list_test.go
@@ -70,13 +70,15 @@ func TestToCRISandbox(t *testing.T) {
 			expectedState: runtime.PodSandboxState_SANDBOX_NOTREADY,
 		},
 	} {
-		status := sandboxstore.Status{
-			CreatedAt: createdAt,
-			State:     test.state,
-		}
-		expect.State = test.expectedState
-		s := toCRISandbox(meta, status)
-		assert.Equal(t, expect, s, desc)
+		t.Run(desc, func(t *testing.T) {
+			status := sandboxstore.Status{
+				CreatedAt: createdAt,
+				State:     test.state,
+			}
+			expect.State = test.expectedState
+			s := toCRISandbox(meta, status)
+			assert.Equal(t, expect, s, desc)
+		})
 	}
 }
 
@@ -201,8 +203,9 @@ func TestFilterSandboxes(t *testing.T) {
 			expect: []*runtime.PodSandbox{testSandboxes[2]},
 		},
 	} {
-		t.Logf("TestCase: %s", desc)
-		filtered := c.filterCRISandboxes(testSandboxes, test.filter)
-		assert.Equal(t, test.expect, filtered, desc)
+		t.Run(desc, func(t *testing.T) {
+			filtered := c.filterCRISandboxes(testSandboxes, test.filter)
+			assert.Equal(t, test.expect, filtered, desc)
+		})
 	}
 }

--- a/pkg/cri/server/sandbox_run_test.go
+++ b/pkg/cri/server/sandbox_run_test.go
@@ -92,29 +92,30 @@ func TestSandboxContainerSpec(t *testing.T) {
 			},
 		},
 	} {
-		t.Logf("TestCase %q", desc)
-		c := newTestCRIService()
-		config, imageConfig, specCheck := getRunPodSandboxTestData()
-		if test.configChange != nil {
-			test.configChange(config)
-		}
+		t.Run(desc, func(t *testing.T) {
+			c := newTestCRIService()
+			config, imageConfig, specCheck := getRunPodSandboxTestData()
+			if test.configChange != nil {
+				test.configChange(config)
+			}
 
-		if test.imageConfigChange != nil {
-			test.imageConfigChange(imageConfig)
-		}
-		spec, err := c.sandboxContainerSpec(testID, config, imageConfig, nsPath,
-			test.podAnnotations)
-		if test.expectErr {
-			assert.Error(t, err)
-			assert.Nil(t, spec)
-			continue
-		}
-		assert.NoError(t, err)
-		assert.NotNil(t, spec)
-		specCheck(t, testID, spec)
-		if test.specCheck != nil {
-			test.specCheck(t, spec)
-		}
+			if test.imageConfigChange != nil {
+				test.imageConfigChange(imageConfig)
+			}
+			spec, err := c.sandboxContainerSpec(testID, config, imageConfig, nsPath,
+				test.podAnnotations)
+			if test.expectErr {
+				assert.Error(t, err)
+				assert.Nil(t, spec)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, spec)
+			specCheck(t, testID, spec)
+			if test.specCheck != nil {
+				test.specCheck(t, spec)
+			}
+		})
 	}
 }
 
@@ -139,25 +140,26 @@ func TestTypeurlMarshalUnmarshalSandboxMeta(t *testing.T) {
 			},
 		},
 	} {
-		t.Logf("TestCase %q", desc)
-		meta := &sandboxstore.Metadata{
-			ID:        "1",
-			Name:      "sandbox_1",
-			NetNSPath: "/home/cloud",
-		}
-		meta.Config, _, _ = getRunPodSandboxTestData()
-		if test.configChange != nil {
-			test.configChange(meta.Config)
-		}
+		t.Run(desc, func(t *testing.T) {
+			meta := &sandboxstore.Metadata{
+				ID:        "1",
+				Name:      "sandbox_1",
+				NetNSPath: "/home/cloud",
+			}
+			meta.Config, _, _ = getRunPodSandboxTestData()
+			if test.configChange != nil {
+				test.configChange(meta.Config)
+			}
 
-		any, err := typeurl.MarshalAny(meta)
-		assert.NoError(t, err)
-		data, err := typeurl.UnmarshalAny(any)
-		assert.NoError(t, err)
-		assert.IsType(t, &sandboxstore.Metadata{}, data)
-		curMeta, ok := data.(*sandboxstore.Metadata)
-		assert.True(t, ok)
-		assert.Equal(t, meta, curMeta)
+			any, err := typeurl.MarshalAny(meta)
+			assert.NoError(t, err)
+			data, err := typeurl.UnmarshalAny(any)
+			assert.NoError(t, err)
+			assert.IsType(t, &sandboxstore.Metadata{}, data)
+			curMeta, ok := data.(*sandboxstore.Metadata)
+			assert.True(t, ok)
+			assert.Equal(t, meta, curMeta)
+		})
 	}
 }
 
@@ -251,8 +253,9 @@ func TestToCNIPortMappings(t *testing.T) {
 			},
 		},
 	} {
-		t.Logf("TestCase %q", desc)
-		assert.Equal(t, test.cniPortMappings, toCNIPortMappings(test.criPortMappings))
+		t.Run(desc, func(t *testing.T) {
+			assert.Equal(t, test.cniPortMappings, toCNIPortMappings(test.criPortMappings))
+		})
 	}
 }
 
@@ -297,16 +300,17 @@ func TestSelectPodIP(t *testing.T) {
 			expectedAdditionalIPs: []string{"2001:db8:85a3::8a2e:370:7334", "2001:db8:85a3::8a2e:370:7335", "192.168.17.45"},
 		},
 	} {
-		t.Logf("TestCase %q", desc)
-		var ipConfigs []*cni.IPConfig
-		for _, ip := range test.ips {
-			ipConfigs = append(ipConfigs, &cni.IPConfig{
-				IP: net.ParseIP(ip),
-			})
-		}
-		ip, additionalIPs := selectPodIPs(context.Background(), ipConfigs, test.pref)
-		assert.Equal(t, test.expectedIP, ip)
-		assert.Equal(t, test.expectedAdditionalIPs, additionalIPs)
+		t.Run(desc, func(t *testing.T) {
+			var ipConfigs []*cni.IPConfig
+			for _, ip := range test.ips {
+				ipConfigs = append(ipConfigs, &cni.IPConfig{
+					IP: net.ParseIP(ip),
+				})
+			}
+			ip, additionalIPs := selectPodIPs(context.Background(), ipConfigs, test.pref)
+			assert.Equal(t, test.expectedIP, ip)
+			assert.Equal(t, test.expectedAdditionalIPs, additionalIPs)
+		})
 	}
 }
 

--- a/pkg/cri/server/sandbox_status_test.go
+++ b/pkg/cri/server/sandbox_status_test.go
@@ -104,13 +104,14 @@ func TestPodSandboxStatus(t *testing.T) {
 			expectedState: runtime.PodSandboxState_SANDBOX_NOTREADY,
 		},
 	} {
-		t.Logf("TestCase: %s", desc)
-		status := sandboxstore.Status{
-			CreatedAt: createdAt,
-			State:     test.state,
-		}
-		expected.State = test.expectedState
-		got := toCRISandboxStatus(metadata, status, ip, additionalIPs)
-		assert.Equal(t, expected, got)
+		t.Run(desc, func(t *testing.T) {
+			status := sandboxstore.Status{
+				CreatedAt: createdAt,
+				State:     test.state,
+			}
+			expected.State = test.expectedState
+			got := toCRISandboxStatus(metadata, status, ip, additionalIPs)
+			assert.Equal(t, expected, got)
+		})
 	}
 }

--- a/pkg/cri/server/sandbox_stop_test.go
+++ b/pkg/cri/server/sandbox_stop_test.go
@@ -51,23 +51,25 @@ func TestWaitSandboxStop(t *testing.T) {
 			expectErr: false,
 		},
 	} {
-		c := newTestCRIService()
-		sandbox := sandboxstore.NewSandbox(
-			sandboxstore.Metadata{ID: id},
-			sandboxstore.Status{State: test.state},
-		)
-		ctx := context.Background()
-		if test.cancel {
-			cancelledCtx, cancel := context.WithCancel(ctx)
-			cancel()
-			ctx = cancelledCtx
-		}
-		if test.timeout > 0 {
-			timeoutCtx, cancel := context.WithTimeout(ctx, test.timeout)
-			defer cancel()
-			ctx = timeoutCtx
-		}
-		err := c.waitSandboxStop(ctx, sandbox)
-		assert.Equal(t, test.expectErr, err != nil, desc)
+		t.Run(desc, func(t *testing.T) {
+			c := newTestCRIService()
+			sandbox := sandboxstore.NewSandbox(
+				sandboxstore.Metadata{ID: id},
+				sandboxstore.Status{State: test.state},
+			)
+			ctx := context.Background()
+			if test.cancel {
+				cancelledCtx, cancel := context.WithCancel(ctx)
+				cancel()
+				ctx = cancelledCtx
+			}
+			if test.timeout > 0 {
+				timeoutCtx, cancel := context.WithTimeout(ctx, test.timeout)
+				defer cancel()
+				ctx = timeoutCtx
+			}
+			err := c.waitSandboxStop(ctx, sandbox)
+			assert.Equal(t, test.expectErr, err != nil, desc)
+		})
 	}
 }

--- a/pkg/cri/store/container/status_test.go
+++ b/pkg/cri/store/container/status_test.go
@@ -65,8 +65,9 @@ func TestContainerState(t *testing.T) {
 			state: runtime.ContainerState_CONTAINER_EXITED,
 		},
 	} {
-		t.Logf("TestCase %q", c)
-		assertlib.Equal(t, test.state, test.status.State())
+		t.Run(c, func(t *testing.T) {
+			assertlib.Equal(t, test.state, test.status.State())
+		})
 	}
 }
 

--- a/pkg/cri/store/image/image_test.go
+++ b/pkg/cri/store/image/image_test.go
@@ -221,28 +221,29 @@ func TestImageStore(t *testing.T) {
 			expected: []Image{},
 		},
 	} {
-		t.Logf("TestCase %q", desc)
-		s, err := NewFakeStore([]Image{image})
-		assert.NoError(err)
-		assert.NoError(s.update(test.ref, test.image))
-
-		assert.Len(s.List(), len(test.expected))
-		for _, expect := range test.expected {
-			got, err := s.Get(expect.ID)
+		t.Run(desc, func(t *testing.T) {
+			s, err := NewFakeStore([]Image{image})
 			assert.NoError(err)
-			equal(got, expect)
-			for _, ref := range expect.References {
-				id, err := s.Resolve(ref)
-				assert.NoError(err)
-				assert.Equal(expect.ID, id)
-			}
-		}
+			assert.NoError(s.update(test.ref, test.image))
 
-		if test.image == nil {
-			// Shouldn't be able to index by removed ref.
-			id, err := s.Resolve(test.ref)
-			assert.Equal(errdefs.ErrNotFound, err)
-			assert.Empty(id)
-		}
+			assert.Len(s.List(), len(test.expected))
+			for _, expect := range test.expected {
+				got, err := s.Get(expect.ID)
+				assert.NoError(err)
+				equal(got, expect)
+				for _, ref := range expect.References {
+					id, err := s.Resolve(ref)
+					assert.NoError(err)
+					assert.Equal(expect.ID, id)
+				}
+			}
+
+			if test.image == nil {
+				// Shouldn't be able to index by removed ref.
+				id, err := s.Resolve(test.ref)
+				assert.Equal(errdefs.ErrNotFound, err)
+				assert.Empty(id)
+			}
+		})
 	}
 }

--- a/pkg/cri/util/image_test.go
+++ b/pkg/cri/util/image_test.go
@@ -73,12 +73,13 @@ func TestNormalizeImageRef(t *testing.T) {
 			expect: "gcr.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
 		},
 	} {
-		t.Logf("TestCase %q", test.input)
-		normalized, err := NormalizeImageRef(test.input)
-		assert.NoError(t, err)
-		output := normalized.String()
-		assert.Equal(t, test.expect, output)
-		_, err = reference.Parse(output)
-		assert.NoError(t, err, "%q should be containerd supported reference", output)
+		t.Run(test.input, func(t *testing.T) {
+			normalized, err := NormalizeImageRef(test.input)
+			assert.NoError(t, err)
+			output := normalized.String()
+			assert.Equal(t, test.expect, output)
+			_, err = reference.Parse(output)
+			assert.NoError(t, err, "%q should be containerd supported reference", output)
+		})
 	}
 }


### PR DESCRIPTION
A majority of the tests in /pkg/cri are testing/validating multiple things per test (generally spec or options validations). This flow lends itself well to using *testing.T's Run method to run each thing as a subtest so `go test` output can actually display which subtest failed/passed.

Some of the tests in the packages in pkg/cri already did this, but a bunch simply logged what testcase was currently running without invoking `t.Run()`.

Thanks to @samuelkarp for suggesting this on another PR https://github.com/containerd/containerd/pull/6996#discussion_r884055199. I'm not married to the "TestCase" prefix for the subtest names, but it was already used for the log and a couple other `t.Run()` uses so mostly following how things already were. 