### PR TITLE
add Vscode dir to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ releases/*.tar.gz
 releases/*.tar.gz.sha256sum
 _output/
 .vagrant/
+.vscode/


### PR DESCRIPTION
Signed-off-by: Paco Xu <paco.xu@daocloud.io>

```
containerd git:(add-metrics-scheduler) ✗ git status
位于分支 add-metrics-scheduler
您的分支与上游分支 'origin/add-metrics-scheduler' 一致。

未跟踪的文件:
  （使用 "git add <文件>..." 以包含要提交的内容）
        .vscode/

提交为空，但是存在尚未跟踪的文件（使用 "git add" 建立跟踪）
➜  containerd git:(add-metrics-scheduler) ✗ ls .vscode 
configurationCache.log dryrun.log             settings.json          targets.log
```

