### PR TITLE
promote pause image to 3.7 (sync with kube v1.24)

### DIFF
--- a/contrib/ansible/cri-containerd.yaml
+++ b/contrib/ansible/cri-containerd.yaml
@@ -61,6 +61,6 @@
     # TODO This needs to be removed once we have consistent concurrent pull results
     - name: "Pre-pull pause container image"
       shell: |
-        /usr/local/bin/ctr pull k8s.gcr.io/pause:3.6
+        /usr/local/bin/ctr pull k8s.gcr.io/pause:3.7
         /usr/local/bin/crictl --runtime-endpoint unix:///run/containerd/containerd.sock \
-        pull k8s.gcr.io/pause:3.6
+        pull k8s.gcr.io/pause:3.7

--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -137,7 +137,7 @@ version = 2
   selinux_category_range = 1024
 
   # sandbox_image is the image used by sandbox container.
-  sandbox_image = "k8s.gcr.io/pause:3.6"
+  sandbox_image = "k8s.gcr.io/pause:3.7"
 
   # stats_collect_period is the period (in seconds) of snapshots stats collection.
   stats_collect_period = 10

--- a/docs/cri/crictl.md
+++ b/docs/cri/crictl.md
@@ -59,29 +59,29 @@ command. With the load command you inject a container image into the container
 runtime from a file. First you need to create a container image tarball. For
 example to create an image tarball for a pause container using Docker:
 ```console
-$ docker pull k8s.gcr.io/pause:3.6
-  3.6: Pulling from pause
-  fbe1a72f5dcd: Pull complete
-  Digest: sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db
-  Status: Downloaded newer image for k8s.gcr.io/pause:3.6
-  k8s.gcr.io/pause:3.6
-$ docker save k8s.gcr.io/pause:3.6 -o pause.tar
+$ docker pull k8s.gcr.io/pause:3.7
+  3.7: Pulling from pause
+  7582c2cc65ef: Pull complete
+  Digest: sha256:bb6ed397957e9ca7c65ada0db5c5d1c707c9c8afc80a94acbe69f3ae76988f0c
+  Status: Downloaded newer image for k8s.gcr.io/pause:3.7
+  k8s.gcr.io/pause:3.7
+$ docker save k8s.gcr.io/pause:3.7 -o pause.tar
 ```
 Then use `ctr` to load the container image into the container runtime:
 ```console
 # The cri plugin uses the "k8s.io" containerd namespace.
 $ sudo ctr -n=k8s.io images import pause.tar
-  Loaded image: k8s.gcr.io/pause:3.6
+  Loaded image: k8s.gcr.io/pause:3.7
 ```
 List images and inspect the pause image:
 ```console
 $ sudo crictl images
 IMAGE                       TAG                 IMAGE ID            SIZE
 docker.io/library/busybox   latest              f6e427c148a76       728kB
-k8s.gcr.io/pause            3.6                 ed210e3e4a5ba       683kB
-$ sudo crictl inspecti ed210e3e4a5ba
+k8s.gcr.io/pause            3.7                 221177c6082a8       311kB
+$ sudo crictl inspecti 221177c6082a8
   ... displays information about the pause image.
-$ sudo crictl inspecti k8s.gcr.io/pause:3.6
+$ sudo crictl inspecti k8s.gcr.io/pause:3.7
   ... displays information about the pause image.
 ```
 
@@ -201,7 +201,7 @@ $ crictl info
       }
     },
     "streamServerPort": "10010",
-    "sandboxImage": "k8s.gcr.io/pause:3.6",
+    "sandboxImage": "k8s.gcr.io/pause:3.7",
     "statsCollectPeriod": 10,
     "containerdRootDir": "/var/lib/containerd",
     "containerdEndpoint": "unix:///run/containerd/containerd.sock",

--- a/integration/client/client_test.go
+++ b/integration/client/client_test.go
@@ -333,7 +333,7 @@ func TestImagePullAllPlatforms(t *testing.T) {
 	defer cancel()
 
 	cs := client.ContentStore()
-	img, err := client.Fetch(ctx, "k8s.gcr.io/pause:3.6")
+	img, err := client.Fetch(ctx, "k8s.gcr.io/pause:3.7")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/client/image_test.go
+++ b/integration/client/image_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestImageIsUnpacked(t *testing.T) {
-	const imageName = "k8s.gcr.io/pause:3.6"
+	const imageName = "k8s.gcr.io/pause:3.7"
 	ctx, cancel := testContext(t)
 	defer cancel()
 
@@ -137,7 +137,7 @@ func TestImageUsage(t *testing.T) {
 		t.Skip()
 	}
 
-	imageName := "k8s.gcr.io/pause:3.6"
+	imageName := "k8s.gcr.io/pause:3.7"
 	ctx, cancel := testContext(t)
 	defer cancel()
 

--- a/integration/client/lease_test.go
+++ b/integration/client/lease_test.go
@@ -55,7 +55,7 @@ func TestLeaseResources(t *testing.T) {
 	defer ls.Delete(ctx, l, leases.SynchronousDelete)
 
 	// step 1: download image
-	imageName := "k8s.gcr.io/pause:3.6"
+	imageName := "k8s.gcr.io/pause:3.7"
 
 	image, err := client.Pull(ctx, imageName, WithPullUnpack, WithPullSnapshotter(snapshotterName))
 	if err != nil {

--- a/integration/common.go
+++ b/integration/common.go
@@ -49,7 +49,7 @@ func initImages(imageListFile string) {
 	imageList = ImageList{
 		Alpine:           "docker.io/library/alpine:latest",
 		BusyBox:          "docker.io/library/busybox:latest",
-		Pause:            "k8s.gcr.io/pause:3.6",
+		Pause:            "k8s.gcr.io/pause:3.7",
 		ResourceConsumer: "k8s.gcr.io/e2e-test-images/resource-consumer:1.10",
 		VolumeCopyUp:     "ghcr.io/containerd/volume-copy-up:2.1",
 		VolumeOwnership:  "ghcr.io/containerd/volume-ownership:2.1",

--- a/integration/image_list.sample.toml
+++ b/integration/image_list.sample.toml
@@ -1,5 +1,5 @@
 alpine = "docker.io/library/alpine:latest"
 busybox = "docker.io/library/busybox:latest"
-pause = "k8s.gcr.io/pause:3.6"
+pause = "k8s.gcr.io/pause:3.7"
 VolumeCopyUp = "ghcr.io/containerd/volume-copy-up:2.1"
 VolumeOwnership = "ghcr.io/containerd/volume-ownership:2.1"

--- a/pkg/cri/config/config_unix.go
+++ b/pkg/cri/config/config_unix.go
@@ -94,7 +94,7 @@ func DefaultConfig() PluginConfig {
 			TLSKeyFile:  "",
 			TLSCertFile: "",
 		},
-		SandboxImage:                     "k8s.gcr.io/pause:3.6",
+		SandboxImage:                     "k8s.gcr.io/pause:3.7",
 		StatsCollectPeriod:               10,
 		SystemdCgroup:                    false,
 		MaxContainerLogLineSize:          16 * 1024,

--- a/pkg/cri/config/config_windows.go
+++ b/pkg/cri/config/config_windows.go
@@ -53,7 +53,7 @@ func DefaultConfig() PluginConfig {
 			TLSKeyFile:  "",
 			TLSCertFile: "",
 		},
-		SandboxImage:              "k8s.gcr.io/pause:3.6",
+		SandboxImage:              "k8s.gcr.io/pause:3.7",
 		StatsCollectPeriod:        10,
 		MaxContainerLogLineSize:   16 * 1024,
 		MaxConcurrentDownloads:    3,


### PR DESCRIPTION
A friend try to load images of kube firstly by `kubeadm config image list` and run `kubeadm init`, but he failed to start the cluster as GFW.
```
[root@paco ~]# ./kubeadm config images list
k8s.gcr.io/kube-apiserver:v1.24.1
k8s.gcr.io/kube-controller-manager:v1.24.1
k8s.gcr.io/kube-scheduler:v1.24.1
k8s.gcr.io/kube-proxy:v1.24.1
k8s.gcr.io/pause:3.7
k8s.gcr.io/etcd:3.5.3-0
k8s.gcr.io/coredns/coredns:v1.8.6
```

> kuberuntime_sandbox.go:70] "Failed to create sandbox for pod" err="rpc error: code = Unknown desc = failed pulling image \"k8s.gcr.io/pause:3.6\": Error response from daemon: Get \"https://k8s.gcr.io/v2/\": read tcp 127.0.0.1:57370->127.0.0.1:9880: read: connection reset by peer" pod="kube-system/etcd-k1"

A simple workaround for him is 
```
docker tag k8s.gcr.io/pause:3.7 k8s.gcr.io/pause:3.6
```



