### PR TITLE
Fix containerd-stress duration flag

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -273,7 +273,7 @@ In addition to `go test`-based testing executed via the `Makefile` targets, the 
 With this tool you can stress a running containerd daemon for a specified period of time, selecting a concurrency level to generate stress against the daemon. The following command is an example of having five workers running for two hours against a default containerd gRPC socket address:
 
 ```sh
-containerd-stress -c 5 -t 120
+containerd-stress -c 5 -d 120m
 ```
 
 For more information on this tool's options please run `containerd-stress --help`.


### PR DESCRIPTION
The command for stressing containerd using `containerd-stress`, as specified in `BUILDING.md`, currently has `-t 120` to run stress test for 2 hours. However, the actual command seems to require the duration to be specified using the `-d` flag.

Signed-off-by: SilverSoldier <soldatargent@gmail.com>