### PR TITLE
Move docker reference logic to reference/docker package

### DIFF
--- a/pkg/cri/store/image/image.go
+++ b/pkg/cri/store/image/image.go
@@ -24,7 +24,7 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/pkg/cri/util"
-	"github.com/containerd/containerd/reference"
+	"github.com/containerd/containerd/reference/docker"
 
 	imagedigest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/go-digest/digestset"
@@ -206,7 +206,7 @@ func (s *store) add(img Image) error {
 		return nil
 	}
 	// Or else, merge and sort the references.
-	i.References = reference.Sort(util.MergeStringSlices(i.References, img.References))
+	i.References = docker.Sort(util.MergeStringSlices(i.References, img.References))
 	s.images[img.ID] = i
 	return nil
 }

--- a/reference/docker/sort_test.go
+++ b/reference/docker/sort_test.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package reference
+package docker
 
 import (
 	"io"


### PR DESCRIPTION
`reference` package should not export Docker-inherited reference logic, the `reference/docker` package is for that. The `reference` package has a smaller and less opinionated scope.