### PR TITLE
fix:userattr-unmount unexpected timeout

### DIFF
--- a/snapshots/overlay/overlayutils/check.go
+++ b/snapshots/overlay/overlayutils/check.go
@@ -145,7 +145,7 @@ func NeedsUserXAttr(d string) (bool, error) {
 	}
 
 	opts := []string{
-		fmt.Sprintf("lowerdir=%s:%s,upperdir=%s,workdir=%s", filepath.Join(td, "lower2"), filepath.Join(td, "lower1"), filepath.Join(td, "upper"), filepath.Join(td, "work")),
+		fmt.Sprintf("ro,lowerdir=%s:%s,upperdir=%s,workdir=%s", filepath.Join(td, "lower2"), filepath.Join(td, "lower1"), filepath.Join(td, "upper"), filepath.Join(td, "work")),
 		"userxattr",
 	}
 


### PR DESCRIPTION
I am trying to run containerd in docker container environment with user-namespace.

I found that the Unmount logic of this code usually takes tens of seconds when the machine is under high disk load and running multiple containers.And this will cause the startup of docker to fail

I'm not particularly sure what's causing this, but the unmount error just outputs the log and doesn't affect the execution logic of the function. So I think it would be better to change this to asynchronous execution.

This is the log of docker

time="2022-05-31T18:13:34.490264526+08:00" level=info msg="Starting up"
time="2022-05-31T18:13:34.491918527+08:00" level=debug msg="Listener created for HTTP on unix (/var/run/docker.sock)"
time="2022-05-31T18:13:34.491948011+08:00" level=debug msg="Containerd not running, starting daemon managed containerd"
time="2022-05-31T18:13:34.492139165+08:00" level=info msg="libcontainerd: containerd is still running" pid=144
time="2022-05-31T18:13:34.492210488+08:00" level=info msg="parsed scheme: \"unix\"" module=grpc
time="2022-05-31T18:13:34.492302486+08:00" level=info msg="scheme \"unix\" not registered, fallback to default scheme" module=grpc
time="2022-05-31T18:13:34.492376002+08:00" level=info msg="ccResolverWrapper: sending update to cc: {[{unix:///var/run/docker/containerd/containerd.sock 0  <nil>}] <nil>}" module=grpc
time="2022-05-31T18:13:34.492407392+08:00" level=info msg="ClientConn switching balancer to \"pick_first\"" module=grpc
failed to start containerd: timeout waiting for containerd to start


This is the log of containerd

time="2022-05-31T18:13:18+08:00" level=warning msg="deprecated version : `1`, please switch to version `2`"
time="2022-05-31T18:13:18.171464520+08:00" level=info msg="starting containerd" revision=3df54a852345ae127d1fa3092b95168e4a88e2f8 version=1.5.11
time="2022-05-31T18:13:18.203640835+08:00" level=info msg="loading plugin \"io.containerd.content.v1.content\"..." type=io.containerd.content.v1
time="2022-05-31T18:13:18.203784689+08:00" level=info msg="loading plugin \"io.containerd.snapshotter.v1.aufs\"..." type=io.containerd.snapshotter.v1
time="2022-05-31T18:13:18.203972923+08:00" level=info msg="skip loading plugin \"io.containerd.snapshotter.v1.aufs\"..." error="aufs is not supported (modprobe aufs failed: exec: \"modprobe\": executable file not found in $PATH \"\"): skip plugin" type=io.containerd.snapshotter.v1
time="2022-05-31T18:13:18.204007046+08:00" level=info msg="loading plugin \"io.containerd.snapshotter.v1.btrfs\"..." type=io.containerd.snapshotter.v1
time="2022-05-31T18:13:18.204351797+08:00" level=info msg="skip loading plugin \"io.containerd.snapshotter.v1.btrfs\"..." error="path /var/lib/containerd/io.containerd.snapshotter.v1.btrfs (overlay) must be a btrfs filesystem to be used with the btrfs snapshotter: skip plugin" type=io.containerd.snapshotter.v1
time="2022-05-31T18:13:18.204377535+08:00" level=info msg="loading plugin \"io.containerd.snapshotter.v1.devmapper\"..." type=io.containerd.snapshotter.v1
time="2022-05-31T18:13:18.204407926+08:00" level=warning msg="failed to load plugin io.containerd.snapshotter.v1.devmapper" error="devmapper not configured"
time="2022-05-31T18:13:18.204420177+08:00" level=info msg="loading plugin \"io.containerd.snapshotter.v1.native\"..." type=io.containerd.snapshotter.v1
time="2022-05-31T18:13:18.204516354+08:00" level=info msg="loading plugin \"io.containerd.snapshotter.v1.overlayfs\"..." type=io.containerd.snapshotter.v1
time="2022-05-31T18:13:41.004910809+08:00" level=info msg="loading plugin \"io.containerd.snapshotter.v1.zfs\"..." type=io.containerd.snapshotter.v1
time="2022-05-31T18:13:41.005450480+08:00" level=info msg="skip loading plugin \"io.containerd.snapshotter.v1.zfs\"..." error="path /var/lib/containerd/io.containerd.snapshotter.v1.zfs must be a zfs filesystem to be used with the zfs snapshotter: skip plugin" type=io.containerd.snapshotter.v1
time="2022-05-31T18:13:41.005487845+08:00" level=info msg="loading plugin \"io.containerd.metadata.v1.bolt\"..." type=io.containerd.metadata.v1
time="2022-05-31T18:13:41.005592205+08:00" level=warning msg="could not use snapshotter devmapper in metadata plugin" error="devmapper not configured"
time="2022-05-31T18:13:41.005614328+08:00" level=info msg="metadata content store policy set" policy=shared
time="2022-05-31T18:13:41.025727901+08:00" level=info msg="loading plugin \"io.containerd.differ.v1.walking\"..." type=io.containerd.differ.v1
time="2022-05-31T18:13:41.025789547+08:00" level=info msg="loading plugin \"io.containerd.gc.v1.scheduler\"..." type=io.containerd.gc.v1
time="2022-05-31T18:13:41.025861278+08:00" level=info msg="loading plugin \"io.containerd.service.v1.introspection-service\"..." type=io.containerd.service.v1
time="2022-05-31T18:13:41.025936748+08:00" level=info msg="loading plugin \"io.containerd.service.v1.containers-service\"..." type=io.containerd.service.v1
time="2022-05-31T18:13:41.025965102+08:00" level=info msg="loading plugin \"io.containerd.service.v1.content-service\"..." type=io.containerd.service.v1
time="2022-05-31T18:13:41.025990351+08:00" level=info msg="loading plugin \"io.containerd.service.v1.diff-service\"..." type=io.containerd.service.v1
time="2022-05-31T18:13:41.026016690+08:00" level=info msg="loading plugin \"io.containerd.service.v1.images-service\"..." type=io.containerd.service.v1
time="2022-05-31T18:13:41.026041617+08:00" level=info msg="loading plugin \"io.containerd.service.v1.leases-service\"..." type=io.containerd.service.v1
time="2022-05-31T18:13:41.026068688+08:00" level=info msg="loading plugin \"io.containerd.service.v1.namespaces-service\"..." type=io.containerd.service.v1
time="2022-05-31T18:13:41.026107338+08:00" level=info msg="loading plugin \"io.containerd.service.v1.snapshots-service\"..." type=io.containerd.service.v1
time="2022-05-31T18:13:41.026133823+08:00" level=info msg="loading plugin \"io.containerd.runtime.v1.linux\"..." type=io.containerd.runtime.v1
time="2022-05-31T18:13:41.026410620+08:00" level=info msg="loading plugin \"io.containerd.runtime.v2.task\"..." type=io.containerd.runtime.v2
time="2022-05-31T18:13:41.026647883+08:00" level=info msg="loading plugin \"io.containerd.monitor.v1.cgroups\"..." type=io.containerd.monitor.v1
time="2022-05-31T18:13:41.027386842+08:00" level=info msg="loading plugin \"io.containerd.service.v1.tasks-service\"..." type=io.containerd.service.v1
time="2022-05-31T18:13:41.027435146+08:00" level=info msg="loading plugin \"io.containerd.internal.v1.restart\"..." type=io.containerd.internal.v1
time="2022-05-31T18:13:41.027523152+08:00" level=info msg="loading plugin \"io.containerd.grpc.v1.containers\"..." type=io.containerd.grpc.v1
time="2022-05-31T18:13:41.027551955+08:00" level=info msg="loading plugin \"io.containerd.grpc.v1.content\"..." type=io.containerd.grpc.v1
time="2022-05-31T18:13:41.027583857+08:00" level=info msg="loading plugin \"io.containerd.grpc.v1.diff\"..." type=io.containerd.grpc.v1
time="2022-05-31T18:13:41.027608009+08:00" level=info msg="loading plugin \"io.containerd.grpc.v1.events\"..." type=io.containerd.grpc.v1
time="2022-05-31T18:13:41.027631601+08:00" level=info msg="loading plugin \"io.containerd.grpc.v1.healthcheck\"..." type=io.containerd.grpc.v1
time="2022-05-31T18:13:41.027656475+08:00" level=info msg="loading plugin \"io.containerd.grpc.v1.images\"..." type=io.containerd.grpc.v1
time="2022-05-31T18:13:41.027690787+08:00" level=info msg="loading plugin \"io.containerd.grpc.v1.leases\"..." type=io.containerd.grpc.v1
time="2022-05-31T18:13:41.027715415+08:00" level=info msg="loading plugin \"io.containerd.grpc.v1.namespaces\"..." type=io.containerd.grpc.v1
time="2022-05-31T18:13:41.027738980+08:00" level=info msg="loading plugin \"io.containerd.internal.v1.opt\"..." type=io.containerd.internal.v1
time="2022-05-31T18:13:41.028128713+08:00" level=info msg="loading plugin \"io.containerd.grpc.v1.snapshots\"..." type=io.containerd.grpc.v1
time="2022-05-31T18:13:41.028186241+08:00" level=info msg="loading plugin \"io.containerd.grpc.v1.tasks\"..." type=io.containerd.grpc.v1
time="2022-05-31T18:13:41.028227378+08:00" level=info msg="loading plugin \"io.containerd.grpc.v1.version\"..." type=io.containerd.grpc.v1
time="2022-05-31T18:13:41.028251473+08:00" level=info msg="loading plugin \"io.containerd.grpc.v1.introspection\"..." type=io.containerd.grpc.v1
time="2022-05-31T18:13:41.029709381+08:00" level=info msg=serving... address=/run/containerd/containerd.sock.ttrpc
time="2022-05-31T18:13:41.029854566+08:00" level=info msg=serving... address=/run/containerd/containerd.sock
time="2022-05-31T18:13:41.029899526+08:00" level=debug msg="sd notification" error="<nil>" notified=false state="READY=1"
time="2022-05-31T18:13:41.029925993+08:00" level=info msg="containerd successfully booted in 22.860007s"
time="2022-05-31T18:13:41.127070200+08:00" level=debug msg="garbage collected" d="892.627<C2><B5>s"
