### PR TITLE
[release/1.5] update golang to 1.17.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.17.10]
+        go-version: [1.17.11]
         os: [ubuntu-18.04, macos-10.15, windows-2019]
 
     steps:
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.10'
+          go-version: '1.17.11'
 
       - shell: bash
         run: |
@@ -86,7 +86,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.10'
+          go-version: '1.17.11'
 
       - uses: actions/checkout@v2
         with:
@@ -119,7 +119,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.10'
+          go-version: '1.17.11'
 
       - name: Set env
         shell: bash
@@ -165,7 +165,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.10'
+          go-version: '1.17.11'
       - name: Set env
         shell: bash
         run: |
@@ -230,7 +230,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-10.15, windows-2019]
-        go-version: ['1.17.10']
+        go-version: ['1.17.11']
         include:
           # Go 1.13.x is still used by Docker/Moby
           - go-version: '1.13.x'
@@ -276,7 +276,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.10'
+          go-version: '1.17.11'
 
       - uses: actions/checkout@v2
         with:
@@ -357,7 +357,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.10'
+          go-version: '1.17.11'
 
       - uses: actions/checkout@v2
         with:
@@ -509,7 +509,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.10'
+          go-version: '1.17.11'
       - uses: actions/checkout@v2
         with:
           path: src/github.com/containerd/containerd

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.10'
+          go-version: '1.17.11'
 
       - uses: actions/checkout@v2
         with:
@@ -135,7 +135,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.10'
+          go-version: '1.17.11'
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17.10'
+          go-version: '1.17.11'
 
       - name: Set env
         shell: bash

--- a/.zuul/playbooks/containerd-build/integration-test.yaml
+++ b/.zuul/playbooks/containerd-build/integration-test.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.17.10'
+    go_version: '1.17.11'
     arch: arm64
   tasks:
   - name: Install pre-requisites

--- a/.zuul/playbooks/containerd-build/run.yaml
+++ b/.zuul/playbooks/containerd-build/run.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.17.10'
+    go_version: '1.17.11'
     arch: arm64
   tasks:
   - name: Build containerd

--- a/.zuul/playbooks/containerd-build/unit-test.yaml
+++ b/.zuul/playbooks/containerd-build/unit-test.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.17.10'
+    go_version: '1.17.11'
     arch: arm64
   tasks:
   - name: Build and test containerd

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,7 +77,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.17.10",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.17.11",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -10,7 +10,7 @@
 #
 # docker build -t containerd-test --build-arg RUNC_VERSION=v1.0.0-rc93 -f Dockerfile.test ../
 
-ARG GOLANG_VERSION=1.17.10
+ARG GOLANG_VERSION=1.17.11
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd


### PR DESCRIPTION
go1.17.11 (released 2022-06-01) includes security fixes to the crypto/rand,
crypto/tls, os/exec, and path/filepath packages, as well as bug fixes to the
crypto/tls package. See the Go 1.17.11 milestone on our issue tracker for details.

https://github.com/golang/go/issues?q=milestone%3AGo1.17.11+label%3ACherryPickApproved

Hello gophers,

We have just released Go versions 1.18.3 and 1.17.11, minor point releases.

These minor releases include 4 security fixes following the security policy:

- crypto/rand: rand.Read hangs with extremely large buffers
  On Windows, rand.Read will hang indefinitely if passed a buffer larger than
  1 << 32 - 1 bytes.

  Thanks to Davis Goodin and Quim Muntal, working at Microsoft on the Go toolset,
  for reporting this issue.

  This is [CVE-2022-30634][CVE-2022-30634] and Go issue https://go.dev/issue/52561.
- crypto/tls: session tickets lack random ticket_age_add
  Session tickets generated by crypto/tls did not contain a randomly generated
  ticket_age_add. This allows an attacker that can observe TLS handshakes to
  correlate successive connections by comparing ticket ages during session
  resumption.

  Thanks to GitHub user nervuri for reporting this.

  This is [CVE-2022-30629][CVE-2022-30629] and Go issue https://go.dev/issue/52814.
- `os/exec`: empty `Cmd.Path` can result in running unintended binary on Windows

  If, on Windows, `Cmd.Run`, `cmd.Start`, `cmd.Output`, or `cmd.CombinedOutput`
  are executed when Cmd.Path is unset and, in the working directory, there are
  binaries named either "..com" or "..exe", they will be executed.

  Thanks to Chris Darroch, brian m. carlson, and Mikhail Shcherbakov for reporting
  this.

  This is [CVE-2022-30580][CVE-2022-30580] and Go issue https://go.dev/issue/52574.
- `path/filepath`: Clean(`.\c:`) returns `c:` on Windows

  On Windows, the `filepath.Clean` function could convert an invalid path to a
  valid, absolute path. For example, Clean(`.\c:`) returned `c:`.

  Thanks to Unrud for reporting this issue.

  This is [CVE-2022-29804][CVE-2022-29804] and Go issue https://go.dev/issue/52476.

[CVE-2022-30634]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-30634
[CVE-2022-30629]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-30629
[CVE-2022-30580]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-30580
[CVE-2022-29804]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-29804

