### PR TITLE
Make building static binaries simpler

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -122,14 +122,13 @@ Please refer to [RUNC.md](/docs/RUNC.md) for the currently supported version of 
 You can build static binaries by providing a few variables to `make`:
 
 ```sh
-make EXTRA_FLAGS="-buildmode pie" \
-	EXTRA_LDFLAGS='-linkmode external -extldflags "-fno-PIC -static"' \
-	BUILDTAGS="netgo osusergo static_build"
+make STATIC=1
 ```
 
 > *Note*:
 > - static build is discouraged
 > - static containerd binary does not support loading shared object plugins (`*.so`)
+> - static build binaries are not position-independent
 
 # Via Docker container
 

--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,17 @@ endif
 GO_BUILDTAGS ?=
 GO_BUILDTAGS += urfave_cli_no_docs
 GO_BUILDTAGS += ${DEBUG_TAGS}
+ifneq ($(STATIC),)
+	GO_BUILDTAGS += osusergo netgo static_build
+endif
 GO_TAGS=$(if $(GO_BUILDTAGS),-tags "$(strip $(GO_BUILDTAGS))",)
-GO_LDFLAGS=-ldflags '-X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PACKAGE) $(EXTRA_LDFLAGS)'
+
+GO_LDFLAGS=-ldflags '-X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PACKAGE) $(EXTRA_LDFLAGS)
+ifneq ($(STATIC),)
+	GO_LDFLAGS += -extldflags "-static"
+endif
+GO_LDFLAGS+='
+
 SHIM_GO_LDFLAGS=-ldflags '-X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PACKAGE) -extldflags "-static" $(EXTRA_LDFLAGS)'
 
 # Project packages.

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -21,7 +21,9 @@ COMMANDS += containerd-shim containerd-shim-runc-v1 containerd-shim-runc-v2
 # check GOOS for cross compile builds
 ifeq ($(GOOS),linux)
   ifneq ($(GOARCH),$(filter $(GOARCH),mips mipsle mips64 mips64le ppc64))
-	GO_GCFLAGS += -buildmode=pie
+    ifeq ($(STATIC),)
+	    GO_GCFLAGS += -buildmode=pie
+    endif
   endif
 endif
 


### PR DESCRIPTION
This commit adds STATIC makefile variable to adjust LDFLAGS and build
tags accordingly.

Fixes #5824.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>