### PR TITLE
Support for sharing snapshots

### DIFF
--- a/image.go
+++ b/image.go
@@ -382,7 +382,7 @@ func (i *image) Unpack(ctx context.Context, snapshotterName string, opts ...Unpa
 
 	for _, layer := range layers {
 		unpacked, err = rootfs.ApplyLayerWithOpts(ctx, layer, chain, sn, a, config.SnapshotOpts, config.ApplyOpts)
-		if err != nil {
+		if err != nil && !errdefs.IsAlreadyExists(err) {
 			return err
 		}
 

--- a/metadata/content_test.go
+++ b/metadata/content_test.go
@@ -86,11 +86,11 @@ func TestContent(t *testing.T) {
 	testsuite.ContentCrossNSSharedSuite(t, "metadata", createContentStoreWithPolicy())
 	testsuite.ContentCrossNSIsolatedSuite(
 		t, "metadata", createContentStoreWithPolicy([]DBOpt{
-			WithPolicyIsolated,
+			WithContentPolicyIsolated,
 		}...))
 	testsuite.ContentSharedNSIsolatedSuite(
 		t, "metadata", createContentStoreWithPolicy([]DBOpt{
-			WithPolicyIsolated,
+			WithContentPolicyIsolated,
 		}...))
 }
 

--- a/metadata/snapshot_windows_test.go
+++ b/metadata/snapshot_windows_test.go
@@ -1,0 +1,145 @@
+//go:build windows
+// +build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package metadata
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/containerd/containerd/content/local"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/snapshots"
+	"github.com/containerd/containerd/snapshots/windows"
+	bolt "go.etcd.io/bbolt"
+)
+
+func initTestDB(t *testing.T, root string, sns map[string]snapshots.Snapshotter) (*DB, func()) {
+	cs, err := local.NewStore(filepath.Join(root, "content"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bdb, err := bolt.Open(filepath.Join(root, "metadata.db"), 0644, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	db := NewDB(bdb, cs, sns, WithSnapshotPolicyShared)
+	if err := db.Init(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	return db, func() { db.db.Close() }
+}
+
+func TestSnapshotSharingSimple(t *testing.T) {
+	root, err := ioutil.TempDir("", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(root)
+
+	windowsSn, err := windows.NewSnapshotter(filepath.Join(root, "snapshotter"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sns := map[string]snapshots.Snapshotter{"windows": windowsSn}
+
+	db, closer := initTestDB(t, root, sns)
+	defer closer()
+	defer windowsSn.Close()
+
+	testsn := db.Snapshotter("windows")
+
+	ctxns1 := namespaces.WithNamespace(context.Background(), "testns1")
+	ctxns2 := namespaces.WithNamespace(context.Background(), "testns2")
+
+	labelOpt := snapshots.WithLabels(map[string]string{labelSnapshotRef: "ref1"})
+
+	if _, err = testsn.Prepare(ctxns1, "extract sn1", "", labelOpt); err != nil {
+		t.Fatal(err)
+	}
+
+	if err = testsn.Commit(ctxns1, "ref1", "extract sn1", labelOpt); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = testsn.Prepare(ctxns2, "extract sn2", "", labelOpt)
+	if err == nil || !snapshots.IsTargetSnapshotExists(err) {
+		t.Fatalf("expected already exists error, got: %s", err)
+	}
+}
+
+func TestSnapshotSharingAfterRemove(t *testing.T) {
+	root, err := ioutil.TempDir("", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(root)
+
+	windowsSn, err := windows.NewSnapshotter(filepath.Join(root, "snapshotter"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sns := map[string]snapshots.Snapshotter{"windows": windowsSn}
+
+	db, closer := initTestDB(t, root, sns)
+	defer closer()
+	defer windowsSn.Close()
+
+	testsn := db.Snapshotter("windows")
+
+	ctxns1 := namespaces.WithNamespace(context.Background(), "testns1")
+	ctxns2 := namespaces.WithNamespace(context.Background(), "testns2")
+
+	labelOpt := snapshots.WithLabels(map[string]string{labelSnapshotRef: "ref1"})
+
+	if _, err = testsn.Prepare(ctxns1, "extract sn1", "", labelOpt); err != nil {
+		t.Fatal(err)
+	}
+
+	if err = testsn.Commit(ctxns1, "ref1", "extract sn1", labelOpt); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = testsn.Prepare(ctxns2, "extract sn2", "", labelOpt)
+	if err == nil || !snapshots.IsTargetSnapshotExists(err) {
+		t.Fatalf("expected already exists error, got: %s", err)
+	}
+
+	if err = testsn.Remove(ctxns1, "ref1"); err != nil {
+		t.Fatal(err)
+	}
+
+	// check if we can still access from other namespace
+	if si, err := testsn.Stat(ctxns2, "ref1"); err != nil {
+		t.Fatal(err)
+	} else if si.Kind != snapshots.KindCommitted || si.Labels[labelSnapshotRef] != "ref1" {
+		t.Fatalf("expected snapshot Info doesn't match: %+v\n", si)
+	}
+
+	if err = testsn.Remove(ctxns2, "ref1"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/services/server/config/config.go
+++ b/services/server/config/config.go
@@ -187,6 +187,9 @@ type BoltConfig struct {
 	// bandwidth across namespaces, at the cost of allowing access to any blob
 	// just by knowing its digest.
 	ContentSharingPolicy string `toml:"content_sharing_policy"`
+
+	// SnapshotSharingPolicy is same as ContentSharingPolicy but for snapshots.
+	SnapshotSharingPolicy string `toml:"snapshot_sharing_policy"`
 }
 
 const (
@@ -200,10 +203,17 @@ const (
 func (bc *BoltConfig) Validate() error {
 	switch bc.ContentSharingPolicy {
 	case SharingPolicyShared, SharingPolicyIsolated:
-		return nil
 	default:
 		return fmt.Errorf("unknown policy: %s: %w", bc.ContentSharingPolicy, errdefs.ErrInvalidArgument)
 	}
+
+	switch bc.SnapshotSharingPolicy {
+	case SharingPolicyShared, SharingPolicyIsolated:
+	default:
+		return fmt.Errorf("unknown policy: %s: %w", bc.SnapshotSharingPolicy, errdefs.ErrInvalidArgument)
+	}
+
+	return nil
 }
 
 // Decode unmarshals a plugin specific configuration by plugin id


### PR DESCRIPTION
Contents in different namespaces can be shared by setting the content sharing policy. This
change adds the support for doing the same for snapshots. If same image is pulled and
extracted in different namespaces the same image layers will be extracted in multiple
namespaces. The snapshots created for these extracted layers contain the exact same
content. To avoid this duplication of work & improve the performance of image pull (if
the same image is already pulled in another namespace) snapshots of existing layers can be
shared across namespaces. Setting the newly added snapshot sharing policy will enable this.

Signed-off-by: Amit Barve <ambarve@microsoft.com>