### PR TITLE
Allow CRI on Darwin

### DIFF
--- a/cmd/containerd/builtins_cri.go
+++ b/cmd/containerd/builtins_cri.go
@@ -1,5 +1,5 @@
-//go:build (linux && !no_cri) || (windows && !no_cri)
-// +build linux,!no_cri windows,!no_cri
+//go:build (linux && !no_cri) || (windows && !no_cri) || (darwin && !no_cri)
+// +build linux,!no_cri windows,!no_cri darwin,!no_cri
 
 /*
    Copyright The containerd Authors.


### PR DESCRIPTION
microVM/VM based containers are possible on Apple platforms, so no reason to not allow CRI there (though this is experimental and not something we officially support).

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>