### PR TITLE
migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,9 +300,9 @@ jobs:
       - env:
           TEST_IMAGE_LIST: ${{github.workspace}}/repolist.toml
           CRI_TEST_IMAGES: ${{github.workspace}}/cri-test-images.yaml
-          BUSYBOX_TESTING_IMAGE_REF: "k8s.gcr.io/e2e-test-images/busybox:1.29-2"
-          RESOURCE_CONSUMER_TESTING_IMAGE_REF: "k8s.gcr.io/e2e-test-images/resource-consumer:1.10"
-          WEBSERVER_TESTING_IMAGE_REF: "k8s.gcr.io/e2e-test-images/nginx:1.14-2"
+          BUSYBOX_TESTING_IMAGE_REF: "registry.k8s.io/e2e-test-images/busybox:1.29-2"
+          RESOURCE_CONSUMER_TESTING_IMAGE_REF: "registry.k8s.io/e2e-test-images/resource-consumer:1.10"
+          WEBSERVER_TESTING_IMAGE_REF: "registry.k8s.io/e2e-test-images/nginx:1.14-2"
         run: |
             cat > "${{ env.TEST_IMAGE_LIST }}" << EOF
             busybox = "${{ env.BUSYBOX_TESTING_IMAGE_REF }}"

--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -23,9 +23,9 @@ env:
   DEFAULT_ADMIN_USERNAME: azureuser
   SSH_OPTS: "-o ServerAliveInterval=20 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
   REMOTE_VM_BIN_PATH: "c:\\containerd\\bin"
-  BUSYBOX_TESTING_IMAGE_REF: "k8s.gcr.io/e2e-test-images/busybox:1.29-2"
-  RESOURCE_CONSUMER_TESTING_IMAGE_REF: "k8s.gcr.io/e2e-test-images/resource-consumer:1.10"
-  WEBSERVER_TESTING_IMAGE_REF: "k8s.gcr.io/e2e-test-images/nginx:1.14-2"
+  BUSYBOX_TESTING_IMAGE_REF: "registry.k8s.io/e2e-test-images/busybox:1.29-2"
+  RESOURCE_CONSUMER_TESTING_IMAGE_REF: "registry.k8s.io/e2e-test-images/resource-consumer:1.10"
+  WEBSERVER_TESTING_IMAGE_REF: "registry.k8s.io/e2e-test-images/nginx:1.14-2"
 
 
 jobs:

--- a/contrib/ansible/cri-containerd.yaml
+++ b/contrib/ansible/cri-containerd.yaml
@@ -61,6 +61,6 @@
     # TODO This needs to be removed once we have consistent concurrent pull results
     - name: "Pre-pull pause container image"
       shell: |
-        /usr/local/bin/ctr pull k8s.gcr.io/pause:3.7
+        /usr/local/bin/ctr pull registry.k8s.io/pause:3.7
         /usr/local/bin/crictl --runtime-endpoint unix:///run/containerd/containerd.sock \
-        pull k8s.gcr.io/pause:3.7
+        pull registry.k8s.io/pause:3.7

--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -137,7 +137,7 @@ version = 2
   selinux_category_range = 1024
 
   # sandbox_image is the image used by sandbox container.
-  sandbox_image = "k8s.gcr.io/pause:3.7"
+  sandbox_image = "registry.k8s.io/pause:3.7"
 
   # stats_collect_period is the period (in seconds) of snapshots stats collection.
   stats_collect_period = 10

--- a/docs/cri/crictl.md
+++ b/docs/cri/crictl.md
@@ -59,29 +59,29 @@ command. With the load command you inject a container image into the container
 runtime from a file. First you need to create a container image tarball. For
 example to create an image tarball for a pause container using Docker:
 ```console
-$ docker pull k8s.gcr.io/pause:3.7
+$ docker pull registry.k8s.io/pause:3.7
   3.7: Pulling from pause
   7582c2cc65ef: Pull complete
   Digest: sha256:bb6ed397957e9ca7c65ada0db5c5d1c707c9c8afc80a94acbe69f3ae76988f0c
-  Status: Downloaded newer image for k8s.gcr.io/pause:3.7
-  k8s.gcr.io/pause:3.7
-$ docker save k8s.gcr.io/pause:3.7 -o pause.tar
+  Status: Downloaded newer image for registry.k8s.io/pause:3.7
+  registry.k8s.io/pause:3.7
+$ docker save registry.k8s.io/pause:3.7 -o pause.tar
 ```
 Then use `ctr` to load the container image into the container runtime:
 ```console
 # The cri plugin uses the "k8s.io" containerd namespace.
 $ sudo ctr -n=k8s.io images import pause.tar
-  Loaded image: k8s.gcr.io/pause:3.7
+  Loaded image: registry.k8s.io/pause:3.7
 ```
 List images and inspect the pause image:
 ```console
 $ sudo crictl images
 IMAGE                       TAG                 IMAGE ID            SIZE
 docker.io/library/busybox   latest              f6e427c148a76       728kB
-k8s.gcr.io/pause            3.7                 221177c6082a8       311kB
+registry.k8s.io/pause            3.7                 221177c6082a8       311kB
 $ sudo crictl inspecti 221177c6082a8
   ... displays information about the pause image.
-$ sudo crictl inspecti k8s.gcr.io/pause:3.7
+$ sudo crictl inspecti registry.k8s.io/pause:3.7
   ... displays information about the pause image.
 ```
 
@@ -201,7 +201,7 @@ $ crictl info
       }
     },
     "streamServerPort": "10010",
-    "sandboxImage": "k8s.gcr.io/pause:3.7",
+    "sandboxImage": "registry.k8s.io/pause:3.7",
     "statsCollectPeriod": 10,
     "containerdRootDir": "/var/lib/containerd",
     "containerdEndpoint": "unix:///run/containerd/containerd.sock",

--- a/integration/client/client_test.go
+++ b/integration/client/client_test.go
@@ -384,7 +384,7 @@ func TestImagePullSomePlatforms(t *testing.T) {
 
 	// Note: Must be different to the image used in TestImagePullAllPlatforms
 	// or it will see the content pulled by that, and fail.
-	img, err := client.Fetch(ctx, "k8s.gcr.io/e2e-test-images/busybox:1.29-2", opts...)
+	img, err := client.Fetch(ctx, "registry.k8s.io/e2e-test-images/busybox:1.29-2", opts...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/client/image_test.go
+++ b/integration/client/image_test.go
@@ -80,7 +80,7 @@ func TestImageIsUnpacked(t *testing.T) {
 
 func TestImagePullWithDistSourceLabel(t *testing.T) {
 	var (
-		source   = "k8s.gcr.io"
+		source   = "registry.k8s.io"
 		repoName = "pause"
 		tag      = "3.6"
 	)
@@ -232,7 +232,7 @@ func TestImageUsage(t *testing.T) {
 func TestImageSupportedBySnapshotter_Error(t *testing.T) {
 	var unsupportedImage string
 	if runtime.GOOS == "windows" {
-		unsupportedImage = "k8s.gcr.io/pause-amd64:3.2"
+		unsupportedImage = "registry.k8s.io/pause-amd64:3.2"
 	} else {
 		unsupportedImage = "mcr.microsoft.com/windows/nanoserver:1809"
 	}

--- a/integration/images/image_list.go
+++ b/integration/images/image_list.go
@@ -49,8 +49,8 @@ func initImages(imageListFile string) {
 	imageList = ImageList{
 		Alpine:           "docker.io/library/alpine:latest",
 		BusyBox:          "docker.io/library/busybox:latest",
-		Pause:            "k8s.gcr.io/pause:3.7",
-		ResourceConsumer: "k8s.gcr.io/e2e-test-images/resource-consumer:1.10",
+		Pause:            "registry.k8s.io/pause:3.7",
+		ResourceConsumer: "registry.k8s.io/e2e-test-images/resource-consumer:1.10",
 		VolumeCopyUp:     "ghcr.io/containerd/volume-copy-up:2.1",
 		VolumeOwnership:  "ghcr.io/containerd/volume-ownership:2.1",
 	}

--- a/integration/images/image_list.sample.toml
+++ b/integration/images/image_list.sample.toml
@@ -1,5 +1,5 @@
 alpine = "docker.io/library/alpine:latest"
 busybox = "docker.io/library/busybox:latest"
-pause = "k8s.gcr.io/pause:3.7"
+pause = "registry.k8s.io/pause:3.7"
 VolumeCopyUp = "ghcr.io/containerd/volume-copy-up:2.1"
 VolumeOwnership = "ghcr.io/containerd/volume-ownership:2.1"

--- a/pkg/cri/config/config_unix.go
+++ b/pkg/cri/config/config_unix.go
@@ -94,7 +94,7 @@ func DefaultConfig() PluginConfig {
 			TLSKeyFile:  "",
 			TLSCertFile: "",
 		},
-		SandboxImage:                     "k8s.gcr.io/pause:3.7",
+		SandboxImage:                     "registry.k8s.io/pause:3.7",
 		StatsCollectPeriod:               10,
 		SystemdCgroup:                    false,
 		MaxContainerLogLineSize:          16 * 1024,

--- a/pkg/cri/config/config_windows.go
+++ b/pkg/cri/config/config_windows.go
@@ -53,7 +53,7 @@ func DefaultConfig() PluginConfig {
 			TLSKeyFile:  "",
 			TLSCertFile: "",
 		},
-		SandboxImage:              "k8s.gcr.io/pause:3.7",
+		SandboxImage:              "registry.k8s.io/pause:3.7",
 		StatsCollectPeriod:        10,
 		MaxContainerLogLineSize:   16 * 1024,
 		MaxConcurrentDownloads:    3,


### PR DESCRIPTION
Signed-off-by: Paco Xu <paco.xu@daocloud.io>

Kubernetes migrated to `registry.k8s.io` since https://github.com/kubernetes/kubernetes/pull/109938.

I'm not sure if contained should migrate to it in this release cycle 1.7. Or at least, pause image should migrate to `registry.k8s.io` .

Some context can be found in 
- https://github.com/kubernetes/k8s.io/wiki/New-Registry-url-for-Kubernetes-(registry.k8s.io)
- https://github.com/kubernetes/enhancements/blob/master/keps/sig-release/3000-artifact-distribution/README.md
- https://github.com/kubernetes/kubernetes/pull/110350
- https://github.com/kubernetes/kubernetes/issues/110471

[the k8s project is moving away from k8s.gcr.io to registry.k8s.io.](https://github.com/kubernetes/kubeadm/issues/2671) 
- registry.k8s.io is currently redirecting to k8s.gcr.io
- in 1.25 we should switch kubeadm's code to use registry.k8s.io by default.
- k8s.gcr.io will continue working (for some time) by redirecting to registry.k8s.io