### PR TITLE
Port (some) unit tests to FreeBSD

### DIFF
--- a/archive/link_default.go
+++ b/archive/link_default.go
@@ -1,0 +1,25 @@
+//go:build !freebsd
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package archive
+
+import "os"
+
+func link(oldname, newname string) error {
+	return os.Link(oldname, newname)
+}

--- a/archive/link_freebsd.go
+++ b/archive/link_freebsd.go
@@ -1,0 +1,82 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package archive
+
+import (
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func link(oldname, newname string) error {
+	e := ignoringEINTR(func() error {
+		return unix.Linkat(unix.AT_FDCWD, oldname, unix.AT_FDCWD, newname, 0)
+	})
+	if e != nil {
+		return &os.LinkError{Op: "link", Old: oldname, New: newname, Err: e}
+	}
+	return nil
+}
+
+// The following contents were copied from Go 1.18.2.
+// Use of this source code is governed by the following
+// BSD-style license:
+//
+// Copyright (c) 2009 The Go Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//   * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//   * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// ignoringEINTR makes a function call and repeats it if it returns an
+// EINTR error. This appears to be required even though we install all
+// signal handlers with SA_RESTART: see #22838, #38033, #38836, #40846.
+// Also #20400 and #36644 are issues in which a signal handler is
+// installed without setting SA_RESTART. None of these are the common case,
+// but there are enough of them that it seems that we can't avoid
+// an EINTR loop.
+func ignoringEINTR(fn func() error) error {
+	for {
+		err := fn()
+		if err != syscall.EINTR {
+			return err
+		}
+	}
+}

--- a/archive/tar.go
+++ b/archive/tar.go
@@ -361,7 +361,7 @@ func createTarFile(ctx context.Context, path, extractDir string, hdr *tar.Header
 			return err
 		}
 
-		if err := os.Link(targetPath, path); err != nil {
+		if err := link(targetPath, path); err != nil {
 			return err
 		}
 

--- a/archive/tar_test.go
+++ b/archive/tar_test.go
@@ -844,7 +844,7 @@ func testApply(t *testing.T, a fstest.Applier) error {
 		return fmt.Errorf("failed to apply filesystem changes: %w", err)
 	}
 
-	tarArgs := []string{"c", "-C", td}
+	tarArgs := []string{"cf", "-", "-C", td}
 	names, err := readDirNames(td)
 	if err != nil {
 		return fmt.Errorf("failed to read directory names: %w", err)
@@ -879,9 +879,12 @@ func testBaseDiff(t *testing.T, a fstest.Applier) error {
 
 	arch := Diff(context.Background(), "", td)
 
-	cmd := exec.Command(tarCmd, "x", "-C", dest)
+	cmd := exec.Command(tarCmd, "xf", "-", "-C", dest)
 	cmd.Stdin = arch
+	stderr := &bytes.Buffer{}
+	cmd.Stderr = stderr
 	if err := cmd.Run(); err != nil {
+		fmt.Println(stderr.String())
 		return fmt.Errorf("tar command failed: %w", err)
 	}
 

--- a/oci/mounts_freebsd.go
+++ b/oci/mounts_freebsd.go
@@ -32,7 +32,6 @@ func defaultMounts() []specs.Mount {
 			Destination: "/dev/fd",
 			Type:        "fdescfs",
 			Source:      "fdescfs",
-			Options:     []string{},
 		},
 	}
 }

--- a/oci/utils_unix_test.go
+++ b/oci/utils_unix_test.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -149,9 +150,11 @@ func TestHostDevicesAllValid(t *testing.T) {
 	}
 
 	for _, device := range devices {
-		// Devices can't have major number 0.
-		if device.Major == 0 {
-			t.Errorf("device entry %+v has zero major number", device)
+		if runtime.GOOS != "freebsd" {
+			// On Linux, devices can't have major number 0.
+			if device.Major == 0 {
+				t.Errorf("device entry %+v has zero major number", device)
+			}
 		}
 		switch device.Type {
 		case blockDevice, charDevice:

--- a/pkg/cri/server/container_create_test.go
+++ b/pkg/cri/server/container_create_test.go
@@ -69,8 +69,11 @@ func TestGeneralContainerSpec(t *testing.T) {
 }
 
 func TestPodAnnotationPassthroughContainerSpec(t *testing.T) {
-	if goruntime.GOOS == "darwin" {
+	switch goruntime.GOOS {
+	case "darwin":
 		t.Skip("not implemented on Darwin")
+	case "freebsd":
+		t.Skip("not implemented on FreeBSD")
 	}
 
 	testID := "test-id"
@@ -279,8 +282,11 @@ func TestVolumeMounts(t *testing.T) {
 }
 
 func TestContainerAnnotationPassthroughContainerSpec(t *testing.T) {
-	if goruntime.GOOS == "darwin" {
+	switch goruntime.GOOS {
+	case "darwin":
 		t.Skip("not implemented on Darwin")
+	case "freebsd":
+		t.Skip("not implemented on FreeBSD")
 	}
 
 	testID := "test-id"

--- a/pkg/cri/server/sandbox_run_test.go
+++ b/pkg/cri/server/sandbox_run_test.go
@@ -35,10 +35,12 @@ import (
 )
 
 func TestSandboxContainerSpec(t *testing.T) {
-	if goruntime.GOOS == "darwin" {
+	switch goruntime.GOOS {
+	case "darwin":
 		t.Skip("not implemented on Darwin")
+	case "freebsd":
+		t.Skip("not implemented on FreeBSD")
 	}
-
 	testID := "test-id"
 	nsPath := "test-cni"
 	for desc, test := range map[string]struct {

--- a/platforms/defaults_freebsd.go
+++ b/platforms/defaults_freebsd.go
@@ -17,8 +17,9 @@
 package platforms
 
 import (
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"runtime"
+
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // DefaultSpec returns the current platform's default platform specification.


### PR DESCRIPTION
This patch series ports a number of unit tests to FreeBSD and removes a few that test features that haven't been ported to FreeBSD yet (CRI-related).

I have not yet added a new Cirrus-CI task for these unit tests as not all tests yet pass in that environment.  Notably there are differences in behavior between ZFS and UFS which have not yet been accounted for in the tests (I haven't dug into them yet), but may require changes in [continuity](https://github.com/containerd/continuity) to be resolved.  When run in ZFS, all tests currently pass; when run in UFS (which is the default filesystem in use in Cirrus) there are a few failures.  (You can see a sample of failures [here](https://cirrus-ci.com/task/4837901690208256) if you're interested.)