### PR TITLE
CRI: set container to unknown if fail to start

### DIFF
--- a/pkg/cri/server/container_start.go
+++ b/pkg/cri/server/container_start.go
@@ -64,8 +64,12 @@ func (c *criService) StartContainer(ctx context.Context, r *runtime.StartContain
 	}
 	defer func() {
 		if retErr != nil {
-			// Set container to exited if fail to start.
+			// Set container state depended on whether task is alive
 			if err := cntr.Status.UpdateSync(func(status containerstore.Status) (containerstore.Status, error) {
+				if _, err := container.Task(ctx, nil); err == nil {
+					// task still alive
+					return unknownContainerStatus(), nil
+				}
 				status.Pid = 0
 				status.FinishedAt = time.Now().UnixNano()
 				status.ExitCode = errorStartExitCode


### PR DESCRIPTION
CRI: Contianer state should be **unknown** if fail to start, not exited. 

I believe the exited state indicates that the process has started successfully and exited either by killed or with a completed execution. While the unknown state can be interpreted as this task has returned an error somehow and the reason is unknown.

In addition, if `task.Start()` failed and defered `task.Delete()` failed too, the follow-up `RemoveContainer()` will failed with `ErrFailedPrecondition` forever because task still can be loaded.

Signed-off-by: Zhang Tianyang <burning9699@gmail.com>