### PR TITLE
Run fuzzers in CI

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,26 @@
+name: CI Fuzz
+on: [pull_request]
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'containerd'
+        dry-run: false
+        language: go
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'containerd'
+        fuzz-seconds: 300
+        dry-run: false
+        language: go
+    - name: Upload Crash
+      uses: actions/upload-artifact@v1
+      if: failure() && steps.build.outcome == 'success'
+      with:
+        name: artifacts
+        path: ./out/artifacts


### PR DESCRIPTION
This PR adds CIFuzz to Containerds CI. CIFuzz is a service offered by OSS-Fuzz and is recommended for all OSS-Fuzz projects. It will run all fuzzers for 10 minutes in the CI to catch low-hanging bugs and verify that no breaking changes to the fuzzing suite are introduced.

The time each fuzzer should run can be adjusted.
Only fuzzers that cover code that is affected by changes in PRs will run.

The CIFuzz documentation can be found here: https://google.github.io/oss-fuzz/getting-started/continuous-integration/