### PR TITLE
Make CI Fuzz less noisy

### DIFF
--- a/contrib/fuzz/archive_fuzzer.go
+++ b/contrib/fuzz/archive_fuzzer.go
@@ -22,15 +22,25 @@ import (
 	"os"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	"github.com/sirupsen/logrus"
 
 	"github.com/containerd/containerd/archive"
 	"github.com/containerd/containerd/content/local"
 	imageArchive "github.com/containerd/containerd/images/archive"
+	"github.com/containerd/containerd/log"
 )
 
 // FuzzApply implements a fuzzer that applies
 // a fuzzed tar archive on a directory
 func FuzzApply(data []byte) int {
+	ctx := context.Background()
+
+	// Apply() is logging the below message, which is too noisy and not really useful
+	// if the input is random.
+	//
+	// level=warning msg="ignored xattr ... in archive" error="operation not supported"
+	log.G(ctx).Logger.SetLevel(logrus.PanicLevel)
+
 	f := fuzz.NewConsumer(data)
 	iters, err := f.GetInt()
 	if err != nil {
@@ -48,7 +58,7 @@ func FuzzApply(data []byte) int {
 			return 0
 		}
 		r := bytes.NewReader(rBytes)
-		_, _ = archive.Apply(context.Background(), tmpDir, r)
+		_, _ = archive.Apply(ctx, tmpDir, r)
 	}
 	return 1
 }

--- a/contrib/fuzz/oss_fuzz_build.sh
+++ b/contrib/fuzz/oss_fuzz_build.sh
@@ -54,7 +54,6 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 cd ../../
 
 # Move all fuzzers that don't have the "fuzz" package out of this dir
-mv contrib/fuzz/docker_fuzzer.go remotes/docker/
 mv contrib/fuzz/container_fuzzer.go integration/client/
 
 rm -r vendor

--- a/contrib/fuzz/oss_fuzz_build.sh
+++ b/contrib/fuzz/oss_fuzz_build.sh
@@ -16,11 +16,10 @@
 set -o nounset
 set -o pipefail
 set -o errexit
-set -x
 
 apt-get update && apt-get install -y wget
 cd $SRC
-wget https://go.dev/dl/go1.18.3.linux-amd64.tar.gz
+wget --quiet https://go.dev/dl/go1.18.3.linux-amd64.tar.gz
 
 mkdir temp-go
 rm -rf /root/.go/*
@@ -87,7 +86,7 @@ compile_go_fuzzer github.com/containerd/containerd/contrib/fuzz FuzzContentStore
 
 # The below fuzzers require more setup than the fuzzers above.
 # We need the binaries from "make".
-wget -c https://github.com/protocolbuffers/protobuf/releases/download/v3.11.4/protoc-3.11.4-linux-x86_64.zip
+wget --quiet https://github.com/protocolbuffers/protobuf/releases/download/v3.11.4/protoc-3.11.4-linux-x86_64.zip
 unzip protoc-3.11.4-linux-x86_64.zip -d /usr/local
 
 export CGO_ENABLED=1
@@ -102,10 +101,7 @@ make install
 
 # Build static containerd
 cd $SRC/containerd
-make EXTRA_FLAGS="-buildmode pie" \
-	EXTRA_LDFLAGS='-linkmode external -extldflags "-fno-PIC -static"' \
-	BUILDTAGS="netgo osusergo static_build"
-
+make STATIC=1
 
 mkdir $OUT/containerd-binaries || true
 cd $SRC/containerd/bin && cp * $OUT/containerd-binaries/ && cd -

--- a/integration/client/go.mod
+++ b/integration/client/go.mod
@@ -20,6 +20,7 @@ require (
 )
 
 require (
+	github.com/AdaLogics/go-fuzz-headers v0.0.0-20210715213245-6c3934b029d8 // indirect
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cilium/ebpf v0.7.0 // indirect

--- a/integration/client/go.sum
+++ b/integration/client/go.sum
@@ -38,6 +38,7 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+github.com/AdaLogics/go-fuzz-headers v0.0.0-20210715213245-6c3934b029d8 h1:V8krnnfGj4pV65YLUm3C0/8bl7V5Nry2Pwvy3ru/wLc=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20210715213245-6c3934b029d8/go.mod h1:CzsSbkDixRphAF5hS6wbMKq0eI6ccJRb7/A0M6JBnwg=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=

--- a/remotes/docker/converter_fuzz.go
+++ b/remotes/docker/converter_fuzz.go
@@ -1,0 +1,56 @@
+//go:build gofuzz
+// +build gofuzz
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package docker
+
+import (
+	"context"
+	"os"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	"github.com/containerd/containerd/content/local"
+	"github.com/containerd/containerd/log"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
+)
+
+func FuzzConvertManifest(data []byte) int {
+	ctx := context.Background()
+
+	// Do not log the message below
+	// level=warning msg="do nothing for media type: ..."
+	log.G(ctx).Logger.SetLevel(logrus.PanicLevel)
+
+	f := fuzz.NewConsumer(data)
+	desc := ocispec.Descriptor{}
+	err := f.GenerateStruct(&desc)
+	if err != nil {
+		return 0
+	}
+	tmpdir, err := os.MkdirTemp("", "fuzzing-")
+	if err != nil {
+		return 0
+	}
+	cs, err := local.NewStore(tmpdir)
+	if err != nil {
+		return 0
+	}
+	_, _ = ConvertManifest(ctx, cs, desc)
+	return 1
+}

--- a/remotes/docker/fetcher_fuzz.go
+++ b/remotes/docker/fetcher_fuzz.go
@@ -3,22 +3,18 @@
 
 /*
    Copyright The containerd Authors.
+
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
+
        http://www.apache.org/licenses/LICENSE-2.0
+
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-*/
-
-/*
-   This fuzzer is run continuously by OSS-fuzz.
-   It is stored in contrib/fuzz for organization,
-   but in order to execute it, it must be moved to
-   remotes/docker first.
 */
 
 package docker


### PR DESCRIPTION
This PR makes CR Fuzz less noisy. The fuzzers in cncf-fuzzing are untouched yet. They will be merged later (see #7066).