### PR TITLE
Make CI Fuzz optional

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -12,15 +12,17 @@ jobs:
       uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
       with:
         oss-fuzz-project-name: 'containerd'
-        dry-run: false
+        dry-run: true
         language: go
+      continue-on-error: true
     - name: Run Fuzzers
       uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
       with:
         oss-fuzz-project-name: 'containerd'
         fuzz-seconds: 300
-        dry-run: false
+        dry-run: true
         language: go
+      continue-on-error: true
     - name: Upload Crash
       uses: actions/upload-artifact@v1
       if: failure() && steps.build.outcome == 'success'


### PR DESCRIPTION
Until we merge cncf/cncf-fuzzing into this repository (see #7066),
we should keep this step optional.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>