### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -117,7 +117,7 @@ tar.exe xvf .\containerd-windows-amd64.tar.gz
 
 # Copy and configure
 Copy-Item -Path ".\bin\" -Destination "$Env:ProgramFiles\containerd" -Recurse -Force
-cd $Env:ProgramFiles\containerd\
+cd $Env:ProgramFiles\containerd\bin
 .\containerd.exe config default | Out-File config.toml -Encoding ascii
 
 # Review the configuration. Depending on setup you may want to adjust:


### PR DESCRIPTION
Updated windows bin path to run directly containerd.exe . Changed from cd $Env:ProgramFiles\containerd to cd $Env:ProgramFiles\containerd\bin

Signed-off-by: Gokalp Kuscu <gokalpkuscu@gmail.com>