### PR TITLE
trim trailing slash of endpoint of registry

### DIFF
--- a/pkg/cri/server/image_pull.go
+++ b/pkg/cri/server/image_pull.go
@@ -498,6 +498,7 @@ func (c *criService) registryEndpoints(host string) ([]string, error) {
 		if err != nil {
 			return nil, fmt.Errorf("parse endpoint url: %w", err)
 		}
+		en = strings.TrimRight(en, "/")
 		endpoints[i] = en
 	}
 	for _, e := range endpoints {


### PR DESCRIPTION
Signed-off-by: wangyysde <net_use@bzhy.com>

Fix: #7068 

Kubernetes pods will get stuck in a image pull back off state and the crictl command will also fail when  the registry url for a custom registry is mistakenly configured with a trailing slash. And containerd never tell users what is wrong.

This PR trims the trainling slashes of endpoints of registry if the host of an image matched by a registry mirror.