### PR TITLE
Fix Documentation Issue

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -127,7 +127,10 @@ Now that we have an image to base our container off of, we need to generate an O
 containerd provides reasonable defaults for generating OCI runtime specs.
 There is also an `Opt` for modifying the default config based on the image that we pulled.
 
-The container will be based off of the image, use the runtime information in the spec that was just created, and we will allocate a new read-write snapshot so the container can store any persistent information.
+The container will be based off of the image, and we will:
+1. allocate a new read-write snapshot so the container can store any persistent information.
+2. create a new spec for the container.
+
 
 ```go
 	container, err := client.NewContainer(


### PR DESCRIPTION
Fix doc: since containerd doesn't have the `GenerateSpec` method any longer, spec has to be generated with `WithNewSpec`

Signed-off-by: Yakul Garg <2000yeshu@gmail.com>