### PR TITLE
Cleanup metadata tests

### DIFF
--- a/metadata/content_test.go
+++ b/metadata/content_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/containerd/containerd/labels"
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/namespaces"
-	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	bolt "go.etcd.io/bbolt"
 )
@@ -95,8 +95,7 @@ func TestContent(t *testing.T) {
 }
 
 func TestContentLeased(t *testing.T) {
-	ctx, db, cancel := testDB(t)
-	defer cancel()
+	ctx, db := testDB(t)
 
 	cs := db.ContentStore()
 
@@ -143,11 +142,8 @@ func TestContentLeased(t *testing.T) {
 }
 
 func TestIngestLeased(t *testing.T) {
-	ctx, db, cancel := testDB(t)
-	defer cancel()
-
+	ctx, db := testDB(t)
 	cs := db.ContentStore()
-
 	blob := []byte("any content")
 	expected := digest.FromBytes(blob)
 

--- a/metadata/images_test.go
+++ b/metadata/images_test.go
@@ -26,13 +26,12 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/filters"
 	"github.com/containerd/containerd/images"
-	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func TestImagesList(t *testing.T) {
-	ctx, db, cancel := testEnv(t)
-	defer cancel()
+	ctx, db := testEnv(t)
 	store := NewImageStore(NewDB(db, nil, nil))
 
 	testset := map[string]*images.Image{}
@@ -148,8 +147,7 @@ func TestImagesList(t *testing.T) {
 	}
 }
 func TestImagesCreateUpdateDelete(t *testing.T) {
-	ctx, db, cancel := testEnv(t)
-	defer cancel()
+	ctx, db := testEnv(t)
 	store := NewImageStore(NewDB(db, nil, nil))
 
 	for _, testcase := range []struct {

--- a/metadata/leases_test.go
+++ b/metadata/leases_test.go
@@ -28,8 +28,7 @@ import (
 )
 
 func TestLeases(t *testing.T) {
-	ctx, db, cancel := testEnv(t)
-	defer cancel()
+	ctx, db := testEnv(t)
 
 	lm := NewLeaseManager(NewDB(db, nil, nil))
 
@@ -108,8 +107,7 @@ func TestLeases(t *testing.T) {
 }
 
 func TestLeasesList(t *testing.T) {
-	ctx, db, cancel := testEnv(t)
-	defer cancel()
+	ctx, db := testEnv(t)
 
 	lm := NewLeaseManager(NewDB(db, nil, nil))
 
@@ -252,8 +250,7 @@ func TestLeasesList(t *testing.T) {
 }
 
 func TestLeaseResource(t *testing.T) {
-	ctx, db, cancel := testEnv(t)
-	defer cancel()
+	ctx, db := testEnv(t)
 
 	lm := NewLeaseManager(NewDB(db, nil, nil))
 

--- a/metadata/namespaces_test.go
+++ b/metadata/namespaces_test.go
@@ -29,8 +29,7 @@ import (
 )
 
 func TestCreateDelete(t *testing.T) {
-	ctx, db, cleanup := testDB(t)
-	defer cleanup()
+	ctx, db := testDB(t)
 
 	subtests := []struct {
 		name     string

--- a/metadata/sandbox_test.go
+++ b/metadata/sandbox_test.go
@@ -27,8 +27,7 @@ import (
 )
 
 func TestSandboxCreate(t *testing.T) {
-	ctx, db, done := testDB(t)
-	defer done()
+	ctx, db := testDB(t)
 
 	store := NewSandboxStore(db)
 
@@ -60,8 +59,7 @@ func TestSandboxCreate(t *testing.T) {
 }
 
 func TestSandboxCreateDup(t *testing.T) {
-	ctx, db, done := testDB(t)
-	defer done()
+	ctx, db := testDB(t)
 
 	store := NewSandboxStore(db)
 
@@ -83,9 +81,7 @@ func TestSandboxCreateDup(t *testing.T) {
 }
 
 func TestSandboxUpdate(t *testing.T) {
-	ctx, db, done := testDB(t)
-	defer done()
-
+	ctx, db := testDB(t)
 	store := NewSandboxStore(db)
 
 	if _, err := store.Create(ctx, api.Sandbox{
@@ -131,9 +127,7 @@ func TestSandboxUpdate(t *testing.T) {
 }
 
 func TestSandboxGetInvalid(t *testing.T) {
-	ctx, db, done := testDB(t)
-	defer done()
-
+	ctx, db := testDB(t)
 	store := NewSandboxStore(db)
 
 	_, err := store.Get(ctx, "invalid_id")
@@ -145,9 +139,7 @@ func TestSandboxGetInvalid(t *testing.T) {
 }
 
 func TestSandboxList(t *testing.T) {
-	ctx, db, done := testDB(t)
-	defer done()
-
+	ctx, db := testDB(t)
 	store := NewSandboxStore(db)
 
 	in := []api.Sandbox{
@@ -192,9 +184,7 @@ func TestSandboxList(t *testing.T) {
 }
 
 func TestSandboxListWithFilter(t *testing.T) {
-	ctx, db, done := testDB(t)
-	defer done()
-
+	ctx, db := testDB(t)
 	store := NewSandboxStore(db)
 
 	in := []api.Sandbox{
@@ -237,8 +227,7 @@ func TestSandboxListWithFilter(t *testing.T) {
 }
 
 func TestSandboxDelete(t *testing.T) {
-	ctx, db, done := testDB(t)
-	defer done()
+	ctx, db := testDB(t)
 
 	store := NewSandboxStore(db)
 

--- a/metadata/snapshot_test.go
+++ b/metadata/snapshot_test.go
@@ -73,11 +73,9 @@ func TestMetadata(t *testing.T) {
 }
 
 func TestSnapshotterWithRef(t *testing.T) {
-	ctx, db, done := testDB(t, withSnapshotter("tmp", func(string) (snapshots.Snapshotter, error) {
+	ctx, db := testDB(t, withSnapshotter("tmp", func(string) (snapshots.Snapshotter, error) {
 		return NewTmpSnapshotter(), nil
 	}))
-	defer done()
-
 	sn := db.Snapshotter("tmp")
 
 	test1opt := snapshots.WithLabels(


### PR DESCRIPTION
This PR replaces func returns with `t.Cleanup`,
which makes tests slightly easier to maintain as
there is no need to call `defer cancel()` everywhere.

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>