### PR TITLE
Fix missing closed HTTP Body

### DIFF
--- a/cmd/ctr/commands/pprof/pprof.go
+++ b/cmd/ctr/commands/pprof/pprof.go
@@ -182,6 +182,7 @@ func httpGetRequest(client *http.Client, request string) (io.ReadCloser, error) 
 		return nil, err
 	}
 	if resp.StatusCode != 200 {
+		resp.Body.Close()
 		return nil, fmt.Errorf("http get failed with status: %s", resp.Status)
 	}
 	return resp.Body, nil


### PR DESCRIPTION
Need to close the body when the status is not 200, 
otherwise, this resource will not be released.