### PR TITLE
LCOW differ return ErrNotImplemented for wrong mount type

### DIFF
--- a/diff/lcow/lcow.go
+++ b/diff/lcow/lcow.go
@@ -205,7 +205,7 @@ func mountsToLayerAndParents(mounts []mount.Mount) (string, []string, error) {
 	}
 	mnt := mounts[0]
 	if mnt.Type != "lcow-layer" {
-		return "", nil, fmt.Errorf("mount layer type must be lcow-layer: %w", errdefs.ErrInvalidArgument)
+		return "", nil, fmt.Errorf("mount layer type must be lcow-layer: %w", errdefs.ErrNotImplemented)
 	}
 
 	parentLayerPaths, err := mnt.GetParentPaths()


### PR DESCRIPTION
On Windows the two differs we register by default are the "windows" and "windows-lcow" differs. The diff service checks if Apply returns `ErrNotImplemented` and will move on to the next differ in the line if so. The Windows differ makes use of this to fallback to LCOW if it's determined the mount type passed is incorrect, but the LCOW differ does not return `ErrNotImplemented` for the same scenario. This puts a strict ordering requirement on the default differ entries in the config, namely that ["windows", "windows-lcow"] will work, as windows will correctly fall back to the lcow differ, but ["windows-lcow", "windows"] won't as the diff services `Apply` will just return the error directly. Not too much of an issue, but if you're hand editing a config and place lcow first it can be ran into.