### PR TITLE
Add snapshot-labels in snapshottOpts

### DIFF
--- a/pkg/cri/server/container_create_linux.go
+++ b/pkg/cri/server/container_create_linux.go
@@ -601,5 +601,5 @@ func generateUserString(username string, uid, gid *runtime.Int64Value) (string, 
 
 // snapshotterOpts returns any Linux specific snapshotter options for the rootfs snapshot
 func snapshotterOpts(snapshotterName string, config *runtime.ContainerConfig) []snapshots.Opt {
-	return []snapshots.Opt{}
+	return []snapshots.Opt{snapshots.WithLabels(snapshots.FilterInheritedLabels(config.Annotations))}
 }


### PR DESCRIPTION
OverlayBD support native writable layer by label
'containerd.io/snapshot/overlaybd.writable'. However, this annota-
tion can't pass to snapshotter when creating a container by CRI
because snapshotterOpts() returns empty.

This commit will return filtered snapshot labels in snapshotterOpts().

Signed-off-by: Yifan Yuan <tuji.yyf@alibaba-inc.com>