### PR TITLE
[release/1.6] Fix WWW-Authenticate parsing

### DIFF
--- a/remotes/docker/auth/parse.go
+++ b/remotes/docker/auth/parse.go
@@ -134,9 +134,6 @@ func parseValueAndParams(header string) (value string, params map[string]string)
 		}
 		var pvalue string
 		pvalue, s = expectTokenOrQuoted(s[1:])
-		if pvalue == "" {
-			return
-		}
 		pkey = strings.ToLower(pkey)
 		params[pkey] = pvalue
 		s = skipSpace(s)

--- a/remotes/docker/auth/parse_test.go
+++ b/remotes/docker/auth/parse_test.go
@@ -21,9 +21,11 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestParseAuthHeader(t *testing.T) {
+func TestParseAuthHeaderBearer(t *testing.T) {
 	headerTemplate := `Bearer realm="%s",service="%s",scope="%s"`
 
 	for _, tc := range []struct {
@@ -68,4 +70,18 @@ func TestParseAuthHeader(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParseAuthHeader(t *testing.T) {
+	v := `Bearer realm="https://auth.example.io/token",empty="",service="registry.example.io",scope="repository:library/hello-world:pull,push"`
+	h := http.Header{http.CanonicalHeaderKey("WWW-Authenticate"): []string{v}}
+	challenge := ParseAuthHeader(h)
+
+	actual, ok := challenge[0].Parameters["empty"]
+	assert.True(t, ok)
+	assert.Equal(t, "", actual)
+
+	actual, ok = challenge[0].Parameters["service"]
+	assert.True(t, ok)
+	assert.Equal(t, "registry.example.io", actual)
 }


### PR DESCRIPTION
According to RFC 9110, quoted-string could be "".

https://datatracker.ietf.org/doc/html/rfc9110#section-11.6.1
https://datatracker.ietf.org/doc/html/rfc9110#appendix-A

Fixes #6376.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

(cherry picked from commit 548c9c317ba47b7df54b96c833c9ac881c47bd90)