### PR TITLE
[release/1.6] Downgrade MinGW to version 10.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,14 @@ jobs:
 
       - run: script/setup/install-dev-tools
 
+      # There is currently an issue in the race detector in Go on Windows when
+      # used with a newer version of GCC. The issue was first reported here:
+      # https://github.com/golang/go/issues/46099
+      - name: Downgrade MinGW
+        shell: bash
+        run: |
+          choco install mingw --version 10.2.0 --allow-downgrade
+
       - name: Binaries
         env:
           CGO_ENABLED: 1


### PR DESCRIPTION
There is currently an issue in the race detector in Go on Windows when
used with a newer version of GCC. The issue was first reported here:

https://github.com/golang/go/issues/46099

Fixes #7104

Signed-off-by: Gabriel Adrian Samfira <gsamfira@cloudbasesolutions.com>
(cherry picked from commit 1ef4bda43301ef1de059346a9c37a0876eb635f3)

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>