### PR TITLE
Fix out of date comments for CRI store packages

### DIFF
--- a/pkg/cri/server/helpers.go
+++ b/pkg/cri/server/helpers.go
@@ -162,7 +162,7 @@ func getRepoDigestAndTag(namedRef docker.Named, digest imagedigest.Digest, schem
 }
 
 // localResolve resolves image reference locally and returns corresponding image metadata. It
-// returns store.ErrNotExist if the reference doesn't exist.
+// returns errdefs.ErrNotFound if the reference doesn't exist.
 func (c *criService) localResolve(refOrID string) (imagestore.Image, error) {
 	getImageID := func(refOrId string) string {
 		if _, err := imagedigest.Parse(refOrID); err == nil {

--- a/pkg/cri/store/container/container.go
+++ b/pkg/cri/store/container/container.go
@@ -122,7 +122,7 @@ func NewStore(labels *label.Store) *Store {
 	}
 }
 
-// Add a container into the store. Returns store.ErrAlreadyExist if the
+// Add a container into the store. Returns errdefs.ErrAlreadyExists if the
 // container already exists.
 func (s *Store) Add(c Container) error {
 	s.lock.Lock()
@@ -140,7 +140,7 @@ func (s *Store) Add(c Container) error {
 	return nil
 }
 
-// Get returns the container with specified id. Returns store.ErrNotExist
+// Get returns the container with specified id. Returns errdefs.ErrNotFound
 // if the container doesn't exist.
 func (s *Store) Get(id string) (Container, error) {
 	s.lock.RLock()
@@ -169,6 +169,9 @@ func (s *Store) List() []Container {
 	return containers
 }
 
+// UpdateContainerStats updates the container specified by ID with the
+// stats present in 'newContainerStats'. Returns errdefs.ErrNotFound
+// if the container does not exist in the store.
 func (s *Store) UpdateContainerStats(id string, newContainerStats *stats.ContainerStats) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()

--- a/pkg/cri/store/image/image.go
+++ b/pkg/cri/store/image/image.go
@@ -161,7 +161,7 @@ func (s *Store) Resolve(ref string) (string, error) {
 
 // Get gets image metadata by image id. The id can be truncated.
 // Returns various validation errors if the image id is invalid.
-// Returns storeutil.ErrNotExist if the image doesn't exist.
+// Returns errdefs.ErrNotFound if the image doesn't exist.
 func (s *Store) Get(id string) (Image, error) {
 	return s.store.get(id)
 }

--- a/pkg/cri/store/sandbox/sandbox.go
+++ b/pkg/cri/store/sandbox/sandbox.go
@@ -78,7 +78,8 @@ func NewStore(labels *label.Store) *Store {
 	}
 }
 
-// Add a sandbox into the store.
+// Add a sandbox into the store. Returns errdefs.ErrAlreadyExists if the sandbox is
+// already stored.
 func (s *Store) Add(sb Sandbox) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
@@ -96,7 +97,7 @@ func (s *Store) Add(sb Sandbox) error {
 }
 
 // Get returns the sandbox with specified id.
-// Returns store.ErrNotExist if the sandbox doesn't exist.
+// Returns errdefs.ErrNotFound if the sandbox doesn't exist.
 func (s *Store) Get(id string) (Sandbox, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
@@ -124,6 +125,9 @@ func (s *Store) List() []Sandbox {
 	return sandboxes
 }
 
+// UpdateContainerStats updates the sandbox specified by ID with the
+// stats present in 'newContainerStats'. Returns errdefs.ErrNotFound
+// if the sandbox does not exist in the store.
 func (s *Store) UpdateContainerStats(id string, newContainerStats *stats.ContainerStats) error {
 	s.lock.RLock()
 	defer s.lock.RUnlock()

--- a/pkg/cri/store/snapshot/snapshot.go
+++ b/pkg/cri/store/snapshot/snapshot.go
@@ -56,7 +56,7 @@ func (s *Store) Add(snapshot Snapshot) {
 	s.snapshots[snapshot.Key] = snapshot
 }
 
-// Get returns the snapshot with specified key. Returns store.ErrNotExist if the
+// Get returns the snapshot with specified key. Returns errdefs.ErrNotFound if the
 // snapshot doesn't exist.
 func (s *Store) Get(key string) (Snapshot, error) {
 	s.lock.RLock()


### PR DESCRIPTION
All of the CRI store related packages all use the standard errdefs
errors now for if a key doesn't or already exists (ErrAlreadyExists,
ErrNotFound), but the comments for the methods still referenced
some unused package specific error definitions. This change just
updates the comments to reflect what errors are actually returned
and adds comments for some previously undocumented exported 
functions.