### PR TITLE
Update install-protobuf script  to install protobuf on Darwin

### DIFF
--- a/script/setup/install-protobuf
+++ b/script/setup/install-protobuf
@@ -37,6 +37,8 @@ amd64|386)
 		wget -O "$PROTOBUF_DIR/protobuf" "https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VERSION/protoc-$PROTOBUF_VERSION-win32.zip"
 	elif [ "$GOOS" = linux ]; then
 		wget -O "$PROTOBUF_DIR/protobuf" "https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VERSION/protoc-$PROTOBUF_VERSION-linux-x86_64.zip"
+	elif [ "$GOOS" == darwin ]; then
+	  wget -O "$PROTOBUF_DIR/protobuf" "https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VERSION/protoc-$PROTOBUF_VERSION-osx-x86_64.zip"
 	fi
 	unzip "$PROTOBUF_DIR/protobuf" -d /usr/local
 	;;


### PR DESCRIPTION
This is for convenience, so `make protos` can be ran from Darwin envs too.

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>