### PR TITLE
converter: improve concurrency performance

### DIFF
--- a/cmd/ctr/commands/images/convert.go
+++ b/cmd/ctr/commands/images/convert.go
@@ -98,7 +98,11 @@ When '--all-platforms' is given all images in a manifest list must be available.
 		}
 		defer cancel()
 
-		newImg, err := converter.Convert(ctx, client, targetRef, srcRef, convertOpts...)
+		cvt, err := converter.New(client, convertOpts...)
+		if err != nil {
+			return err
+		}
+		newImg, err := cvt.Convert(ctx, targetRef, srcRef)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.7.0
 	go.opentelemetry.io/otel/sdk v1.7.0
 	go.opentelemetry.io/otel/trace v1.7.0
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a
 	google.golang.org/genproto v0.0.0-20220426171045-31bebdecfb46
 	google.golang.org/grpc v1.47.0

--- a/go.sum
+++ b/go.sum
@@ -1171,8 +1171,9 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f h1:Ax0t5p6N38Ga0dThY21weqDEyz2oklo4IvDkpigvkD8=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/images/converter/converter.go
+++ b/images/converter/converter.go
@@ -24,6 +24,7 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/platforms"
+	"golang.org/x/sync/singleflight"
 )
 
 type convertOpts struct {
@@ -32,6 +33,7 @@ type convertOpts struct {
 	indexConvertFunc ConvertFunc
 	platformMC       platforms.MatchComparer
 	hooks            ConvertHooks
+	sg               *singleflight.Group
 }
 
 // Opt is an option for Convert()
@@ -75,6 +77,15 @@ func WithIndexConvertFunc(fn ConvertFunc) Opt {
 func WithConvertHooks(hooks ConvertHooks) Opt {
 	return func(copts *convertOpts) error {
 		copts.hooks = hooks
+		return nil
+	}
+}
+
+// WithSingleflight makes sure that only one conversion execution is
+// in-flight for a given child descriptor at a time.
+func WithSingleflight() Opt {
+	return func(copts *convertOpts) error {
+		copts.sg = &singleflight.Group{}
 		return nil
 	}
 }

--- a/integration/client/convert_test.go
+++ b/integration/client/convert_test.go
@@ -17,24 +17,82 @@
 package client
 
 import (
+	"archive/tar"
+	"bytes"
+	"context"
 	"fmt"
+	"io"
 	"testing"
 
 	. "github.com/containerd/containerd"
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/images/converter"
 	"github.com/containerd/containerd/images/converter/uncompress"
 	"github.com/containerd/containerd/platforms"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sync/errgroup"
 )
 
-// TestConvert creates multiple images from testImage, with the following conversion:
-// - Media type: Docker -> OCI
-// - Layer type: tar.gz -> tar
-// - Arch:       Multi  -> Single
-func TestConvert(t *testing.T) {
+// convertToUncompressedWithAppendedFooter converts a given layer to uncompressed tar
+// format and appending a footer file, which changes the diff id of the original layer,
+// simulates a conversion similar to the estargz format.
+func convertUncompressWithAppendedFooter(ctx context.Context, cs content.Store, desc ocispec.Descriptor) (*ocispec.Descriptor, error) {
+	tarDesc, err := uncompress.LayerConvertFunc(ctx, cs, desc)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := cs.Info(ctx, tarDesc.Digest)
+	if err != nil {
+		return nil, err
+	}
+	readerAt, err := cs.ReaderAt(ctx, *tarDesc)
+	if err != nil {
+		return nil, err
+	}
+	defer readerAt.Close()
+	sr := io.NewSectionReader(readerAt, 0, tarDesc.Size)
+	ref := fmt.Sprintf("convert-uncompress-from-%s", tarDesc.Digest)
+	w, err := content.OpenWriter(ctx, cs, content.WithRef(ref))
+	if err != nil {
+		return nil, err
+	}
+	defer w.Close()
+
+	var footer bytes.Buffer
+	tw := tar.NewWriter(&footer)
+	if err := tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     "appended_footer",
+		Size:     0,
+	}); err != nil {
+		return nil, err
+	}
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+
+	n, err := io.Copy(w, io.MultiReader(sr, &footer))
+	if err != nil {
+		return nil, err
+	}
+	if err = w.Commit(ctx, 0, "", content.WithLabels(info.Labels)); err != nil && !errdefs.IsAlreadyExists(err) {
+		return nil, err
+	}
+	if err := w.Close(); err != nil {
+		return nil, err
+	}
+	newDesc := *tarDesc
+	newDesc.Digest = w.Digest()
+	newDesc.Size = n
+	return &newDesc, nil
+}
+
+func testConvert(t *testing.T, layerConvertFunc converter.ConvertFunc) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -55,7 +113,7 @@ func TestConvert(t *testing.T) {
 	defPlat := platforms.DefaultStrict()
 	opts := []converter.Opt{
 		converter.WithDockerToOCI(true),
-		converter.WithLayerConvertFunc(uncompress.LayerConvertFunc),
+		converter.WithLayerConvertFunc(layerConvertFunc),
 		converter.WithPlatform(defPlat),
 		converter.WithSingleflight(),
 	}
@@ -95,13 +153,31 @@ func TestConvert(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+				actualDiffIDs := []digest.Digest{}
 				for _, l := range mani.Layers {
 					if plats[0].OS == "windows" {
 						assert.Equal(t, ocispec.MediaTypeImageLayerNonDistributable, l.MediaType)
 					} else {
 						assert.Equal(t, ocispec.MediaTypeImageLayer, l.MediaType)
 					}
+					actualDiffID, err := images.GetDiffID(ctx, cs, l)
+					if err != nil {
+						t.Fatal(err)
+					}
+					actualDiffIDs = append(actualDiffIDs, actualDiffID)
 				}
+
+				// Assert that the diff ids in the config are equal to actual.
+				configDesc, err := images.Config(ctx, cs, dstImg.Target, defPlat)
+				if err != nil {
+					t.Fatal(err)
+				}
+				expectedDiffIDs, err := images.RootFS(ctx, cs, configDesc)
+				if err != nil {
+					t.Fatal(err)
+				}
+				assert.Equal(t, expectedDiffIDs, actualDiffIDs)
+
 				return nil
 			})
 		}(i)
@@ -110,4 +186,13 @@ func TestConvert(t *testing.T) {
 	if err := eg.Wait(); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// TestConvert creates multiple images from testImage, with the following conversion:
+// - Media type: Docker -> OCI
+// - Layer type: tar.gz -> tar / tar with footer
+// - Arch:       Multi  -> Single
+func TestConvert(t *testing.T) {
+	testConvert(t, uncompress.LayerConvertFunc)
+	testConvert(t, convertUncompressWithAppendedFooter)
 }

--- a/integration/client/convert_test.go
+++ b/integration/client/convert_test.go
@@ -1,12 +1,9 @@
 /*
    Copyright The containerd Authors.
-
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
-
        http://www.apache.org/licenses/LICENSE-2.0
-
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -51,12 +48,12 @@ func TestConvert(t *testing.T) {
 	}
 	dstRef := testImage + "-testconvert"
 	defPlat := platforms.DefaultStrict()
-	opts := []converter.Opt{
+	dstImg, err := converter.New(
+		client,
 		converter.WithDockerToOCI(true),
 		converter.WithLayerConvertFunc(uncompress.LayerConvertFunc),
 		converter.WithPlatform(defPlat),
-	}
-	dstImg, err := converter.Convert(ctx, client, dstRef, testImage, opts...)
+	).Convert(ctx, dstRef, testImage)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/client/convert_test.go
+++ b/integration/client/convert_test.go
@@ -115,7 +115,7 @@ func testConvert(t *testing.T, layerConvertFunc converter.ConvertFunc) {
 		converter.WithDockerToOCI(true),
 		converter.WithLayerConvertFunc(layerConvertFunc),
 		converter.WithPlatform(defPlat),
-		converter.WithSingleflight(),
+		converter.WithSingleflight(client.LeasesService()),
 	}
 
 	c, err := converter.New(client, opts...)

--- a/integration/client/go.mod
+++ b/integration/client/go.mod
@@ -3,6 +3,7 @@ module github.com/containerd/containerd/integration/client
 go 1.18
 
 require (
+	github.com/AdaLogics/go-fuzz-headers v0.0.0-20220706123152-fef3fe1bab07
 	github.com/Microsoft/hcsshim v0.9.4
 	github.com/Microsoft/hcsshim/test v0.0.0-20210408205431-da33ecd607e1
 	github.com/containerd/cgroups v1.0.4
@@ -16,10 +17,9 @@ require (
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.8.0
+	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a
 )
-
-require github.com/AdaLogics/go-fuzz-headers v0.0.0-20220706123152-fef3fe1bab07
 
 require (
 	github.com/Microsoft/go-winio v0.5.2 // indirect
@@ -58,7 +58,6 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 // indirect
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20220426171045-31bebdecfb46 // indirect
 	google.golang.org/grpc v1.47.0 // indirect

--- a/integration/client/go.sum
+++ b/integration/client/go.sum
@@ -851,8 +851,9 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f h1:Ax0t5p6N38Ga0dThY21weqDEyz2oklo4IvDkpigvkD8=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/vendor/golang.org/x/sync/errgroup/errgroup.go
+++ b/vendor/golang.org/x/sync/errgroup/errgroup.go
@@ -8,20 +8,33 @@ package errgroup
 
 import (
 	"context"
+	"fmt"
 	"sync"
 )
+
+type token struct{}
 
 // A Group is a collection of goroutines working on subtasks that are part of
 // the same overall task.
 //
-// A zero Group is valid and does not cancel on error.
+// A zero Group is valid, has no limit on the number of active goroutines,
+// and does not cancel on error.
 type Group struct {
 	cancel func()
 
 	wg sync.WaitGroup
 
+	sem chan token
+
 	errOnce sync.Once
 	err     error
+}
+
+func (g *Group) done() {
+	if g.sem != nil {
+		<-g.sem
+	}
+	g.wg.Done()
 }
 
 // WithContext returns a new Group and an associated Context derived from ctx.
@@ -45,14 +58,19 @@ func (g *Group) Wait() error {
 }
 
 // Go calls the given function in a new goroutine.
+// It blocks until the new goroutine can be added without the number of
+// active goroutines in the group exceeding the configured limit.
 //
 // The first call to return a non-nil error cancels the group; its error will be
 // returned by Wait.
 func (g *Group) Go(f func() error) {
-	g.wg.Add(1)
+	if g.sem != nil {
+		g.sem <- token{}
+	}
 
+	g.wg.Add(1)
 	go func() {
-		defer g.wg.Done()
+		defer g.done()
 
 		if err := f(); err != nil {
 			g.errOnce.Do(func() {
@@ -63,4 +81,52 @@ func (g *Group) Go(f func() error) {
 			})
 		}
 	}()
+}
+
+// TryGo calls the given function in a new goroutine only if the number of
+// active goroutines in the group is currently below the configured limit.
+//
+// The return value reports whether the goroutine was started.
+func (g *Group) TryGo(f func() error) bool {
+	if g.sem != nil {
+		select {
+		case g.sem <- token{}:
+			// Note: this allows barging iff channels in general allow barging.
+		default:
+			return false
+		}
+	}
+
+	g.wg.Add(1)
+	go func() {
+		defer g.done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel()
+				}
+			})
+		}
+	}()
+	return true
+}
+
+// SetLimit limits the number of active goroutines in this group to at most n.
+// A negative value indicates no limit.
+//
+// Any subsequent call to the Go method will block until it can add an active
+// goroutine without exceeding the configured limit.
+//
+// The limit must not be modified while any goroutines in the group are active.
+func (g *Group) SetLimit(n int) {
+	if n < 0 {
+		g.sem = nil
+		return
+	}
+	if len(g.sem) != 0 {
+		panic(fmt.Errorf("errgroup: modify limit while %v goroutines in the group are still active", len(g.sem)))
+	}
+	g.sem = make(chan token, n)
 }

--- a/vendor/golang.org/x/sync/singleflight/singleflight.go
+++ b/vendor/golang.org/x/sync/singleflight/singleflight.go
@@ -1,0 +1,212 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package singleflight provides a duplicate function call suppression
+// mechanism.
+package singleflight // import "golang.org/x/sync/singleflight"
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"sync"
+)
+
+// errGoexit indicates the runtime.Goexit was called in
+// the user given function.
+var errGoexit = errors.New("runtime.Goexit was called")
+
+// A panicError is an arbitrary value recovered from a panic
+// with the stack trace during the execution of given function.
+type panicError struct {
+	value interface{}
+	stack []byte
+}
+
+// Error implements error interface.
+func (p *panicError) Error() string {
+	return fmt.Sprintf("%v\n\n%s", p.value, p.stack)
+}
+
+func newPanicError(v interface{}) error {
+	stack := debug.Stack()
+
+	// The first line of the stack trace is of the form "goroutine N [status]:"
+	// but by the time the panic reaches Do the goroutine may no longer exist
+	// and its status will have changed. Trim out the misleading line.
+	if line := bytes.IndexByte(stack[:], '\n'); line >= 0 {
+		stack = stack[line+1:]
+	}
+	return &panicError{value: v, stack: stack}
+}
+
+// call is an in-flight or completed singleflight.Do call
+type call struct {
+	wg sync.WaitGroup
+
+	// These fields are written once before the WaitGroup is done
+	// and are only read after the WaitGroup is done.
+	val interface{}
+	err error
+
+	// forgotten indicates whether Forget was called with this call's key
+	// while the call was still in flight.
+	forgotten bool
+
+	// These fields are read and written with the singleflight
+	// mutex held before the WaitGroup is done, and are read but
+	// not written after the WaitGroup is done.
+	dups  int
+	chans []chan<- Result
+}
+
+// Group represents a class of work and forms a namespace in
+// which units of work can be executed with duplicate suppression.
+type Group struct {
+	mu sync.Mutex       // protects m
+	m  map[string]*call // lazily initialized
+}
+
+// Result holds the results of Do, so they can be passed
+// on a channel.
+type Result struct {
+	Val    interface{}
+	Err    error
+	Shared bool
+}
+
+// Do executes and returns the results of the given function, making
+// sure that only one execution is in-flight for a given key at a
+// time. If a duplicate comes in, the duplicate caller waits for the
+// original to complete and receives the same results.
+// The return value shared indicates whether v was given to multiple callers.
+func (g *Group) Do(key string, fn func() (interface{}, error)) (v interface{}, err error, shared bool) {
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[string]*call)
+	}
+	if c, ok := g.m[key]; ok {
+		c.dups++
+		g.mu.Unlock()
+		c.wg.Wait()
+
+		if e, ok := c.err.(*panicError); ok {
+			panic(e)
+		} else if c.err == errGoexit {
+			runtime.Goexit()
+		}
+		return c.val, c.err, true
+	}
+	c := new(call)
+	c.wg.Add(1)
+	g.m[key] = c
+	g.mu.Unlock()
+
+	g.doCall(c, key, fn)
+	return c.val, c.err, c.dups > 0
+}
+
+// DoChan is like Do but returns a channel that will receive the
+// results when they are ready.
+//
+// The returned channel will not be closed.
+func (g *Group) DoChan(key string, fn func() (interface{}, error)) <-chan Result {
+	ch := make(chan Result, 1)
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[string]*call)
+	}
+	if c, ok := g.m[key]; ok {
+		c.dups++
+		c.chans = append(c.chans, ch)
+		g.mu.Unlock()
+		return ch
+	}
+	c := &call{chans: []chan<- Result{ch}}
+	c.wg.Add(1)
+	g.m[key] = c
+	g.mu.Unlock()
+
+	go g.doCall(c, key, fn)
+
+	return ch
+}
+
+// doCall handles the single call for a key.
+func (g *Group) doCall(c *call, key string, fn func() (interface{}, error)) {
+	normalReturn := false
+	recovered := false
+
+	// use double-defer to distinguish panic from runtime.Goexit,
+	// more details see https://golang.org/cl/134395
+	defer func() {
+		// the given function invoked runtime.Goexit
+		if !normalReturn && !recovered {
+			c.err = errGoexit
+		}
+
+		c.wg.Done()
+		g.mu.Lock()
+		defer g.mu.Unlock()
+		if !c.forgotten {
+			delete(g.m, key)
+		}
+
+		if e, ok := c.err.(*panicError); ok {
+			// In order to prevent the waiting channels from being blocked forever,
+			// needs to ensure that this panic cannot be recovered.
+			if len(c.chans) > 0 {
+				go panic(e)
+				select {} // Keep this goroutine around so that it will appear in the crash dump.
+			} else {
+				panic(e)
+			}
+		} else if c.err == errGoexit {
+			// Already in the process of goexit, no need to call again
+		} else {
+			// Normal return
+			for _, ch := range c.chans {
+				ch <- Result{c.val, c.err, c.dups > 0}
+			}
+		}
+	}()
+
+	func() {
+		defer func() {
+			if !normalReturn {
+				// Ideally, we would wait to take a stack trace until we've determined
+				// whether this is a panic or a runtime.Goexit.
+				//
+				// Unfortunately, the only way we can distinguish the two is to see
+				// whether the recover stopped the goroutine from terminating, and by
+				// the time we know that, the part of the stack trace relevant to the
+				// panic has been discarded.
+				if r := recover(); r != nil {
+					c.err = newPanicError(r)
+				}
+			}
+		}()
+
+		c.val, c.err = fn()
+		normalReturn = true
+	}()
+
+	if !normalReturn {
+		recovered = true
+	}
+}
+
+// Forget tells the singleflight to forget about a key.  Future calls
+// to Do for this key will call the function rather than waiting for
+// an earlier call to complete.
+func (g *Group) Forget(key string) {
+	g.mu.Lock()
+	if c, ok := g.m[key]; ok {
+		c.forgotten = true
+	}
+	delete(g.m, key)
+	g.mu.Unlock()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -493,10 +493,11 @@ golang.org/x/net/websocket
 ## explicit; go 1.11
 golang.org/x/oauth2
 golang.org/x/oauth2/internal
-# golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+# golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 ## explicit
 golang.org/x/sync/errgroup
 golang.org/x/sync/semaphore
+golang.org/x/sync/singleflight
 # golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a
 ## explicit; go 1.17
 golang.org/x/sys/execabs


### PR DESCRIPTION
converter: introduce converter.New method

With `converter.New` and `converter.NewDefault`, users can specify
`WithConvertHooks` or other any option func wrappers, it's provides
better extensibility.

converter: improve concurrency performance

Introduce `converter.WithSingleflight` for `converter.New` and
`converter.NewDefault`, it uses singleflight to make sure that
only one conversion execution is in-flight for a given child
descriptor at a time.

This change can improve converter performance to avoid getting lock
on writing to the content store, in particular, in the use case of implementing
an image conversion service based on the converter (e.g. [accled](https://github.com/goharbor/acceleration-service)).

The performance of this change in the image conversion test case for a
concurrent number of 20 is compared as follows:

Tested with local registry (`localhost:5000/busybox:latest`):

**Before**: 20s+ with part errors.
**After**: 0.283s

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>