### PR TITLE
cri doc: fix formatting for CDI options

### DIFF
--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -218,12 +218,12 @@ version = 2
   enable_unprivileged_icmp = false
 
   # enable_cdi enables support of the Container Device Interface (CDI)
-	# For more details about CDI and the syntax of CDI Spec files please refer to
-	# https://github.com/container-orchestrated-devices/container-device-interface.
-	enable_cdi = false
+  # For more details about CDI and the syntax of CDI Spec files please refer to
+  # https://github.com/container-orchestrated-devices/container-device-interface.
+  enable_cdi = false
 
   # cdi_spec_dirs is the list of directories to scan for CDI spec files
-	cdi_spec_dirs = ["/etc/cdi", "/var/run/cdi"]
+  cdi_spec_dirs = ["/etc/cdi", "/var/run/cdi"]
 
   # 'plugins."io.containerd.grpc.v1.cri".containerd' contains config related to containerd
   [plugins."io.containerd.grpc.v1.cri".containerd]


### PR DESCRIPTION
Replaced tabs with spaces to follow document formatting style.