### PR TITLE
[release/1.5] update golang to 1.17.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.17.11]
+        go-version: [1.17.12]
         os: [ubuntu-18.04, macos-10.15, windows-2019]
 
     steps:
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.11'
+          go-version: '1.17.12'
 
       - shell: bash
         run: |
@@ -86,7 +86,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.11'
+          go-version: '1.17.12'
 
       - uses: actions/checkout@v2
         with:
@@ -119,7 +119,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.11'
+          go-version: '1.17.12'
 
       - name: Set env
         shell: bash
@@ -165,7 +165,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.11'
+          go-version: '1.17.12'
       - name: Set env
         shell: bash
         run: |
@@ -230,7 +230,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-10.15, windows-2019]
-        go-version: ['1.17.11']
+        go-version: ['1.17.12']
         include:
           # Go 1.13.x is still used by Docker/Moby
           - go-version: '1.13.x'
@@ -276,7 +276,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.11'
+          go-version: '1.17.12'
 
       - uses: actions/checkout@v2
         with:
@@ -365,7 +365,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.11'
+          go-version: '1.17.12'
 
       - uses: actions/checkout@v2
         with:
@@ -517,7 +517,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.11'
+          go-version: '1.17.12'
       - uses: actions/checkout@v2
         with:
           path: src/github.com/containerd/containerd

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.11'
+          go-version: '1.17.12'
 
       - uses: actions/checkout@v2
         with:
@@ -135,7 +135,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.11'
+          go-version: '1.17.12'
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17.11'
+          go-version: '1.17.12'
 
       - name: Set env
         shell: bash

--- a/.zuul/playbooks/containerd-build/integration-test.yaml
+++ b/.zuul/playbooks/containerd-build/integration-test.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.17.11'
+    go_version: '1.17.12'
     arch: arm64
   tasks:
   - name: Install pre-requisites

--- a/.zuul/playbooks/containerd-build/run.yaml
+++ b/.zuul/playbooks/containerd-build/run.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.17.11'
+    go_version: '1.17.12'
     arch: arm64
   tasks:
   - name: Build containerd

--- a/.zuul/playbooks/containerd-build/unit-test.yaml
+++ b/.zuul/playbooks/containerd-build/unit-test.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.17.11'
+    go_version: '1.17.12'
     arch: arm64
   tasks:
   - name: Build and test containerd

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,7 +77,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.17.11",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.17.12",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -10,7 +10,7 @@
 #
 # docker build -t containerd-test --build-arg RUNC_VERSION=v1.0.0-rc93 -f Dockerfile.test ../
 
-ARG GOLANG_VERSION=1.17.11
+ARG GOLANG_VERSION=1.17.12
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd


### PR DESCRIPTION
```markdown
- Update Go runtime to 1.17.12 to address CVE-2022-1705, CVE-2022-1962, CVE-2022-28131,
  CVE-2022-30630, CVE-2022-30631, CVE-2022-30632, CVE-2022-30633, CVE-2022-30635,
  and CVE-2022-32148.
```

----


go1.17.12 (released 2022-07-12) includes security fixes to the compress/gzip,
encoding/gob, encoding/xml, go/parser, io/fs, net/http, and path/filepath
packages, as well as bug fixes to the compiler, the go command, the runtime,
and the runtime/metrics package. See the Go 1.17.12 milestone on the issue
tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.17.12+label%3ACherryPickApproved

This update addresses:

CVE-2022-1705, CVE-2022-1962, CVE-2022-28131, CVE-2022-30630, CVE-2022-30631,
CVE-2022-30632, CVE-2022-30633, CVE-2022-30635, and CVE-2022-32148.

Full diff: https://github.com/golang/go/compare/go1.17.11...go1.17.12

From the security announcement;
https://groups.google.com/g/golang-announce/c/nqrv9fbR0zE

We have just released Go versions 1.18.4 and 1.17.12, minor point releases. These
minor releases include 9 security fixes following the security policy:

- net/http: improper sanitization of Transfer-Encoding header

  The HTTP/1 client accepted some invalid Transfer-Encoding headers as indicating
  a "chunked" encoding. This could potentially allow for request smuggling, but
  only if combined with an intermediate server that also improperly failed to
  reject the header as invalid.

  This is CVE-2022-1705 and https://go.dev/issue/53188.

- When `httputil.ReverseProxy.ServeHTTP` was called with a `Request.Header` map
  containing a nil value for the X-Forwarded-For header, ReverseProxy would set
  the client IP as the value of the X-Forwarded-For header, contrary to its
  documentation. In the more usual case where a Director function set the
  X-Forwarded-For header value to nil, ReverseProxy would leave the header
  unmodified as expected.

  This is https://go.dev/issue/53423 and CVE-2022-32148.

  Thanks to Christian Mehlmauer for reporting this issue.

- compress/gzip: stack exhaustion in Reader.Read

  Calling Reader.Read on an archive containing a large number of concatenated
  0-length compressed files can cause a panic due to stack exhaustion.

  This is CVE-2022-30631 and Go issue https://go.dev/issue/53168.

- encoding/xml: stack exhaustion in Unmarshal

  Calling Unmarshal on a XML document into a Go struct which has a nested field
  that uses the any field tag can cause a panic due to stack exhaustion.

  This is CVE-2022-30633 and Go issue https://go.dev/issue/53611.

- encoding/xml: stack exhaustion in Decoder.Skip

  Calling Decoder.Skip when parsing a deeply nested XML document can cause a
  panic due to stack exhaustion. The Go Security team discovered this issue, and
  it was independently reported by Juho Nurminen of Mattermost.

  This is CVE-2022-28131 and Go issue https://go.dev/issue/53614.

- encoding/gob: stack exhaustion in Decoder.Decode

  Calling Decoder.Decode on a message which contains deeply nested structures
  can cause a panic due to stack exhaustion.

  This is CVE-2022-30635 and Go issue https://go.dev/issue/53615.

- path/filepath: stack exhaustion in Glob

  Calling Glob on a path which contains a large number of path separators can
  cause a panic due to stack exhaustion.

  Thanks to Juho Nurminen of Mattermost for reporting this issue.

  This is CVE-2022-30632 and Go issue https://go.dev/issue/53416.

- io/fs: stack exhaustion in Glob

  Calling Glob on a path which contains a large number of path separators can
  cause a panic due to stack exhaustion.

  This is CVE-2022-30630 and Go issue https://go.dev/issue/53415.

- go/parser: stack exhaustion in all Parse* functions

  Calling any of the Parse functions on Go source code which contains deeply
  nested types or declarations can cause a panic due to stack exhaustion.

  Thanks to Juho Nurminen of Mattermost for reporting this issue.

  This is CVE-2022-1962 and Go issue https://go.dev/issue/53616.

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>