### PR TITLE
seccomp: add get_mempolicy, mbind, set_mempolicy, with CAP_SYS_NICE

### DIFF
--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -652,6 +652,16 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				Action: specs.ActAllow,
 				Args:   []specs.LinuxSeccompArg{},
 			})
+		case "CAP_SYS_NICE":
+			s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
+				Names: []string{
+					"get_mempolicy",
+					"mbind",
+					"set_mempolicy",
+				},
+				Action: specs.ActAllow,
+				Args:   []specs.LinuxSeccompArg{},
+			})
 		case "CAP_SYSLOG":
 			s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
 				Names:  []string{"syslog"},


### PR DESCRIPTION
- same as https://github.com/moby/moby/pull/37242
- relates to https://github.com/moby/moby/issues/37241
- fixes https://github.com/containerd/containerd/issues/7150

This aligns the profile with docker's profile, which added this in
https://github.com/moby/moby/commit/47dfff68e4365668279e235bf8c7778b637f2517
