### PR TITLE
[release/1.6] Support RISC-V 64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
   crossbuild:
     name: Crossbuild Binaries
     needs: [project, linters, protos, man]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -135,6 +135,8 @@ jobs:
             goarm: "5"
           - goos: linux
             goarch: ppc64le
+          - goos: linux
+            goarch: riscv64
           - goos: freebsd
             goarch: amd64
           - goos: freebsd
@@ -151,7 +153,7 @@ jobs:
       - run: |
           set -e -x
 
-          packages=""
+          packages="libbtrfs-dev"
           platform="${{matrix.goos}}/${{matrix.goarch}}"
           if [ -n "${{matrix.goarm}}" ]; then
             platform+="/v${{matrix.goarm}}"
@@ -177,6 +179,11 @@ jobs:
             packages+=" crossbuild-essential-ppc64el"
             echo "CGO_ENABLED=1" >> $GITHUB_ENV
             echo "CC=powerpc64le-linux-gnu-gcc" >> $GITHUB_ENV
+            ;;
+          linux/riscv64)
+            packages+=" crossbuild-essential-riscv64"
+            echo "CGO_ENABLED=1" >> $GITHUB_ENV
+            echo "CC=riscv64-linux-gnu-gcc" >> $GITHUB_ENV
             ;;
           windows/arm/v7)
             echo "CGO_ENABLED=0" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,8 @@ jobs:
           - goos: linux
             goarch: arm
             goarm: "5"
+          - goos: linux
+            goarch: ppc64le
           - goos: freebsd
             goarch: amd64
           - goos: freebsd
@@ -170,6 +172,11 @@ jobs:
             packages+=" crossbuild-essential-arm64"
             echo "CGO_ENABLED=1" >> $GITHUB_ENV
             echo "CC=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+            ;;
+          linux/ppc64le)
+            packages+=" crossbuild-essential-ppc64el"
+            echo "CGO_ENABLED=1" >> $GITHUB_ENV
+            echo "CC=powerpc64le-linux-gnu-gcc" >> $GITHUB_ENV
             ;;
           windows/arm/v7)
             echo "CGO_ENABLED=0" >> $GITHUB_ENV

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,12 +36,13 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo add-apt-repository "deb [arch=arm64,s390x,ppc64el] http://ports.ubuntu.com/ubuntu-ports/ $(lsb_release -sc) main" || true
-          sudo add-apt-repository "deb [arch=arm64,s390x,ppc64el] http://ports.ubuntu.com/ubuntu-ports/ $(lsb_release -sc)-updates main" || true
+          sudo add-apt-repository "deb [arch=arm64,s390x,ppc64el,riscv64] http://ports.ubuntu.com/ubuntu-ports/ $(lsb_release -sc) main" || true
+          sudo add-apt-repository "deb [arch=arm64,s390x,ppc64el,riscv64] http://ports.ubuntu.com/ubuntu-ports/ $(lsb_release -sc)-updates main" || true
 
           sudo dpkg --add-architecture arm64
           sudo dpkg --add-architecture s390x
           sudo dpkg --add-architecture ppc64el
+          sudo dpkg --add-architecture riscv64
 
           sudo apt-get update || true
 
@@ -49,14 +50,17 @@ jobs:
             crossbuild-essential-arm64 \
             crossbuild-essential-s390x \
             crossbuild-essential-ppc64el \
+            crossbuild-essential-riscv64 \
             libseccomp-dev:amd64 \
             libseccomp-dev:arm64 \
             libseccomp-dev:s390x \
             libseccomp-dev:ppc64el \
+            libseccomp-dev:riscv64 \
             libbtrfs-dev:amd64 \
             libbtrfs-dev:arm64 \
             libbtrfs-dev:s390x \
-            libbtrfs-dev:ppc64el
+            libbtrfs-dev:ppc64el \
+            libbtrfs-dev:riscv64
 
       - name: Build amd64
         env:
@@ -96,6 +100,16 @@ jobs:
           make binaries
           mv bin bin_ppc64le
 
+      - name: Build riscv64
+        env:
+          GOOS: linux
+          GOARCH: riscv64
+          CGO_ENABLED: 1
+          CC: riscv64-linux-gnu-gcc
+        run: |
+          make binaries
+          mv bin bin_riscv64
+
       #
       # Upload
       #
@@ -123,6 +137,12 @@ jobs:
         with:
           name: linux_ppc64le
           path: src/github.com/containerd/containerd/bin_ppc64le
+
+      - name: Upload artifacts (linux_riscv64)
+        uses: actions/upload-artifact@v1
+        with:
+          name: linux_riscv64
+          path: src/github.com/containerd/containerd/bin_riscv64
 
   windows:
     name: Windows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,7 @@ jobs:
         platform:
           - linux/amd64
           - linux/arm64
+          - linux/ppc64le
           - windows/amd64
     steps:
       - name: Install Go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
           - linux/amd64
           - linux/arm64
           - linux/ppc64le
+          - linux/riscv64
           - windows/amd64
     steps:
       - name: Install Go

--- a/.github/workflows/release/Dockerfile
+++ b/.github/workflows/release/Dockerfile
@@ -12,20 +12,20 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-ARG UBUNTU_VERSION=18.04
+ARG UBUNTU_VERSION=22.04
 ARG BASE_IMAGE=ubuntu:${UBUNTU_VERSION}
 ARG GO_VERSION
 ARG GO_IMAGE=golang:${GO_VERSION}
 FROM --platform=$BUILDPLATFORM $GO_IMAGE AS go
-FROM --platform=$BUILDPLATFORM tonistiigi/xx@sha256:425941eb25cc113009b1c651bd275e04593cea12c48311fe8ace6ceeecdcc645 AS xx
+FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.1.0@sha256:76a8510b1798f66fcc87e7ec2f4684aa1b16756df2a397ec307b9efb6023f6c5 AS xx
 
 FROM --platform=$BUILDPLATFORM ${BASE_IMAGE} AS base
 COPY --from=xx / /
 SHELL ["/bin/bash", "-xec"]
 RUN	apt-get update && \
-	apt-get install -y git pkg-config
+	apt-get install -y dpkg-dev git make pkg-config
 ARG TARGETPLATFORM
-RUN xx-apt-get install -y libseccomp-dev btrfs-progs gcc
+RUN xx-apt-get install -y libseccomp-dev libbtrfs-dev gcc
 ENV PATH=/usr/local/go/bin:$PATH
 ENV GOPATH=/go
 ENV CGO_ENABLED=1

--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -44,6 +44,9 @@ func arches() []specs.Arch {
 		return []specs.Arch{specs.ArchMIPSEL, specs.ArchMIPSEL64, specs.ArchMIPSEL64N32}
 	case "s390x":
 		return []specs.Arch{specs.ArchS390, specs.ArchS390X}
+	case "riscv64":
+		// ArchRISCV32 (SCMP_ARCH_RISCV32) does not exist
+		return []specs.Arch{specs.ArchRISCV64}
 	default:
 		return []specs.Arch{}
 	}
@@ -527,6 +530,14 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				"s390_pci_mmio_read",
 				"s390_pci_mmio_write",
 				"s390_runtime_instr",
+			},
+			Action: specs.ActAllow,
+			Args:   []specs.LinuxSeccompArg{},
+		})
+	case "riscv64":
+		s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
+			Names: []string{
+				"riscv_flush_icache",
 			},
 			Action: specs.ActAllow,
 			Args:   []specs.LinuxSeccompArg{},


### PR DESCRIPTION
Cherry-pick (clean):
- https://github.com/containerd/containerd/pull/6858 (due to the commit dependency)
- https://github.com/containerd/containerd/pull/6882

runc needs https://github.com/opencontainers/runc/pull/3446 
(https://github.com/opencontainers/runc/pull/3446/commits/1d7b297128d0d8914290b458333984625c4d1180)
