### PR TITLE
[release/1.6] seccomp: allow clock_settime64 when CAP_SYS_TIME is added

### DIFF
--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -617,6 +617,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 					"settimeofday",
 					"stime",
 					"clock_settime",
+					"clock_settime64",
 				},
 				Action: specs.ActAllow,
 				Args:   []specs.LinuxSeccompArg{},


### PR DESCRIPTION
Cherry-pick (clean) https://github.com/containerd/containerd/pull/7149