### PR TITLE
docs: Fix sample config.toml syntax

### DIFF
--- a/docs/man/containerd-config.toml.5.md
+++ b/docs/man/containerd-config.toml.5.md
@@ -155,7 +155,7 @@ the main config.
 
 The following is a complete **config.toml** default configuration example:
 
-```
+```toml
 version = 2
 
 root = "/var/lib/containerd"
@@ -182,7 +182,7 @@ imports = ["/etc/containerd/runtime_*.toml", "./debug.toml"]
   path = ""
 
 [plugins]
-  [[plugins."io.containerd.monitor.v1.cgroups"]
+  [plugins."io.containerd.monitor.v1.cgroups"]
     no_prometheus = false
   [plugins."io.containerd.service.v1.diff-service"]
     default = ["walking"]


### PR DESCRIPTION
Sample `config.toml` has a syntax error. Gives the following error when used:
```
containerd: failed to load TOML: /etc/containerd/config.toml: (27, 47):
was expecting token [[, but got table array key cannot contain ']' instead
```

Also changed to have syntax highlighting. Syntax highlighting would have marked the error in red