### PR TITLE
ci: workaround Cirrus CI's INVALID_ARGUMENT

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,5 @@
-# While Cirrus CI gives open-source projects free 16.0 CPUs,
-# we use only 2 CPUs x 3 tasks = 6 CPUs since the tests here aren't fully
-# utilizing multiple CPUs.
+# Cirrus CI gives open-source projects free 16.0 CPUs,
+# we use 4 CPUs x 3 tasks = 12 CPUs.
 # https://cirrus-ci.org/faq/#are-there-any-limits
 #
 # Undocumented constraints;
@@ -15,8 +14,8 @@ task:
     image: family/docker-kvm
     platform: linux
     nested_virtualization: true
-    cpu: 2
-    memory: 8G
+    cpu: 4
+    memory: 16G
 
   env:
     GOTEST: gotestsum --
@@ -54,8 +53,8 @@ task:
     image: family/docker-kvm
     platform: linux
     nested_virtualization: true
-    cpu: 2
-    memory: 8G
+    cpu: 4
+    memory: 16G
 
   install_libvirt_vagrant_script: |
     apt-get update


### PR DESCRIPTION
We are constantly getting the message below from Cirrus CI;
    
> Machine type with name 'c2-standard-2' does not exist in zone 'us-central1-c'."
    
Seems Cirrus CI is constructing the machine type based on
the "cpu" field from the YAML file. However c2-standard's minimal vCPU
count is 4 based on the official document below.
    
https://cloud.google.com/compute/docs/compute-optimized-machines

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>