### PR TITLE
cri_stats: handle missing cpu stats

### DIFF
--- a/pkg/cri/server/container_stats_list.go
+++ b/pkg/cri/server/container_stats_list.go
@@ -65,12 +65,14 @@ func (c *criService) toCRIContainerStats(
 			return nil, fmt.Errorf("failed to decode container metrics for %q: %w", cntr.ID, err)
 		}
 
-		// this is a calculated value and should be computed for all OSes
-		nanoUsage, err := c.getUsageNanoCores(cntr.Metadata.ID, false, cs.Cpu.UsageCoreNanoSeconds.Value, time.Unix(0, cs.Cpu.Timestamp))
-		if err != nil {
-			return nil, fmt.Errorf("failed to get usage nano cores, containerID: %s: %w", cntr.Metadata.ID, err)
+		if cs.Cpu != nil && cs.Cpu.UsageCoreNanoSeconds != nil {
+			// this is a calculated value and should be computed for all OSes
+			nanoUsage, err := c.getUsageNanoCores(cntr.Metadata.ID, false, cs.Cpu.UsageCoreNanoSeconds.Value, time.Unix(0, cs.Cpu.Timestamp))
+			if err != nil {
+				return nil, fmt.Errorf("failed to get usage nano cores, containerID: %s: %w", cntr.Metadata.ID, err)
+			}
+			cs.Cpu.UsageNanoCores = &runtime.UInt64Value{Value: nanoUsage}
 		}
-		cs.Cpu.UsageNanoCores = &runtime.UInt64Value{Value: nanoUsage}
 
 		containerStats.Stats = append(containerStats.Stats, cs)
 	}


### PR DESCRIPTION
 #7186 changed how container cpu stats are populated. Previously, UsageNanoCores were computed at the same time as populating UsageCoreNanoSeconds, and only when UsageCoreNanoSeconds could be populated.

After the change however, we attempt to compute UsageNanoCore's regardless of the state of the provided metrics. This can panic in cases where we do not yet have CPU stats (e.g if the container did not start).

This change restores the previous behavior, by skipping the computation if cpu metrics are unavailable.