### PR TITLE
Drop deprecated `ioutil`

### DIFF
--- a/archive/compression/benchmark_test.go
+++ b/archive/compression/benchmark_test.go
@@ -18,7 +18,7 @@ package compression
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -31,7 +31,7 @@ func BenchmarkDecompression(b *testing.B) {
 	resp, err := http.Get(benchmarkTestDataURL)
 	require.NoError(b, err)
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	require.NoError(b, err)
 	resp.Body.Close()
 

--- a/integration/client/export_test.go
+++ b/integration/client/export_test.go
@@ -19,7 +19,6 @@ package client
 import (
 	"archive/tar"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -46,7 +45,7 @@ func TestExport(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dstFile, err := ioutil.TempFile("", "export-import-test")
+	dstFile, err := os.CreateTemp("", "export-import-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/client/import_test.go
+++ b/integration/client/import_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"math/rand"
@@ -76,7 +75,7 @@ func testExportImport(t *testing.T, imageName string) {
 		t.Fatal(err)
 	}
 
-	dstFile, err := ioutil.TempFile("", "export-import-test")
+	dstFile, err := os.CreateTemp("", "export-import-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/sandbox_clean_remove_windows_test.go
+++ b/integration/sandbox_clean_remove_windows_test.go
@@ -22,7 +22,7 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -75,7 +75,7 @@ func TestSandboxRemoveWithoutIPLeakage(t *testing.T) {
 		require.NoError(t, err)
 		defer f.Close()
 
-		data, err := ioutil.ReadAll(f)
+		data, err := io.ReadAll(f)
 		require.NoError(t, err)
 
 		var jsonData map[string]interface{}

--- a/pkg/cri/sbserver/container_create_linux_test.go
+++ b/pkg/cri/sbserver/container_create_linux_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1524,14 +1523,14 @@ func writeFilesToTempDir(tmpDirPattern string, content []string) (string, error)
 		return "", nil
 	}
 
-	dir, err := ioutil.TempDir("", tmpDirPattern)
+	dir, err := os.MkdirTemp("", tmpDirPattern)
 	if err != nil {
 		return "", err
 	}
 
 	for idx, data := range content {
 		file := filepath.Join(dir, fmt.Sprintf("spec-%d.yaml", idx))
-		err := ioutil.WriteFile(file, []byte(data), 0644)
+		err := os.WriteFile(file, []byte(data), 0644)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/cri/server/container_create_linux_test.go
+++ b/pkg/cri/server/container_create_linux_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1524,14 +1523,14 @@ func writeFilesToTempDir(tmpDirPattern string, content []string) (string, error)
 		return "", nil
 	}
 
-	dir, err := ioutil.TempDir("", tmpDirPattern)
+	dir, err := os.MkdirTemp("", tmpDirPattern)
 	if err != nil {
 		return "", err
 	}
 
 	for idx, data := range content {
 		file := filepath.Join(dir, fmt.Sprintf("spec-%d.yaml", idx))
-		err := ioutil.WriteFile(file, []byte(data), 0644)
+		err := os.WriteFile(file, []byte(data), 0644)
 		if err != nil {
 			return "", err
 		}

--- a/remotes/docker/config/docker_fuzzer_internal.go
+++ b/remotes/docker/config/docker_fuzzer_internal.go
@@ -20,7 +20,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
@@ -28,7 +27,7 @@ import (
 
 func FuzzParseHostsFile(data []byte) int {
 	f := fuzz.NewConsumer(data)
-	dir, err := ioutil.TempDir("", "fuzz-")
+	dir, err := os.MkdirTemp("", "fuzz-")
 	if err != nil {
 		return 0
 	}

--- a/snapshots/lcow/lcow.go
+++ b/snapshots/lcow/lcow.go
@@ -456,7 +456,7 @@ func (s *snapshotter) openOrCreateScratch(ctx context.Context, sizeGB int, scrat
 
 		log.G(ctx).Debugf("vhdx %s not found, creating a new one", vhdFileName)
 
-		// Golang logic for ioutil.TempFile without the file creation
+		// Golang logic for os.CreateTemp without the file creation
 		r := uint32(time.Now().UnixNano() + int64(os.Getpid()))
 		r = r*1664525 + 1013904223 // constants from Numerical Recipes
 


### PR DESCRIPTION
`ioutil` has been deprecated by golang. All the code in `ioutil` just
forwards functionality to code in either the `io` or `os` packages.

See https://github.com/golang/go/pull/51961 for more info.

Signed-off-by: Jeff Widman <jeff@jeffwidman.com>