### PR TITLE
Deny deprecated packages on CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ linters:
     - gosec
     - exportloopref # Checks for pointers to enclosing loop variables
     - tenv # Detects using os.Setenv instead of t.Setenv since Go 1.17
+    - depguard # Checks if package imports are in a list of acceptable packages
   disable:
     - errcheck
 
@@ -42,6 +43,11 @@ linters-settings:
       - G306
       - G402
       - G404
+  depguard:
+    list-type: denylist
+    include-go-root: true
+    packages-with-error-message:
+      - io/ioutil: "deprecated in 1.16 (see https://go.dev/doc/go1.16#ioutil)"
 
 run:
   timeout: 8m


### PR DESCRIPTION
Follow up https://github.com/containerd/containerd/pull/7203
Make sure on CI that we don't import deprecated packages accidentally.

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>