### PR TITLE
[release/1.6] Update Fedora version to 36

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,7 +499,7 @@ jobs:
         # We can enable crun again when we get a better CI infra.
         runc: [runc]
         # Fedora is for testing cgroup v2 functionality, Rocky Linux is for testing on an enterprise-grade environment
-        box: ["fedora/35-cloud-base", "rockylinux/8"]
+        box: ["fedora/36-cloud-base", "rockylinux/8"]
     env:
       GOTEST: gotestsum --
     steps:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,7 @@
 
 # Vagrantfile for Fedora and EL
 Vagrant.configure("2") do |config|
-  config.vm.box = ENV["BOX"] || "fedora/35-cloud-base"
+  config.vm.box = ENV["BOX"] || "fedora/36-cloud-base"
   config.vm.box_version = ENV["BOX_VERSION"]
   memory = 4096
   cpus = 2


### PR DESCRIPTION
Effectively a backport of #6925 from `main` but we have no Cirrus CI in `release/1.6`

Signed-off-by: Phil Estes <estesp@amazon.com>