### PR TITLE
Prepare releases notes for 1.6.7

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -83,6 +83,7 @@ Mario Hros <spam@k3a.me>
 Mario Hros <spam@k3a.me> <root@k3a.me>
 Mario Macias <mariomac@gmail.com> <mmacias@newrelic.com>
 Mark Gordon <msg555@gmail.com>
+Marvin Giessing <marvin.giessing@gmail.com>
 Michael Crosby <crosbymichael@gmail.com> <michael@thepasture.io>
 Michael Katsoulis <michaelkatsoulis88@gmail.com>
 Mike Brown <brownwm@us.ibm.com> <mikebrow@users.noreply.github.com>

--- a/releases/v1.6.7.toml
+++ b/releases/v1.6.7.toml
@@ -1,0 +1,28 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release
+previous = "v1.6.6"
+
+pre_release = false
+
+preface = """\
+The seventh patch release for containerd 1.6 contains various fixes,
+includes a new version of runc and adds support for ppc64le and riscv64
+(requires unreleased runc 1.2) builds.
+
+### Notable Updates
+
+* **Update runc to v1.1.3** ([#7036](https://github.com/containerd/containerd/pull/7036))
+* **Seccomp: Allow clock_settime64 with CAP_SYS_TIME** ([#7172](https://github.com/containerd/containerd/pull/7172))
+* **Fix WWW-Authenticate parsing** ([#7131](https://github.com/containerd/containerd/pull/7131))
+* **Support RISC-V 64 and ppc64le builds** ([#7170](https://github.com/containerd/containerd/pull/7170))
+* **Windows: Update hcsshim to v0.9.4 to fix regression with HostProcess stats** ([#7200](https://github.com/containerd/containerd/pull/7200))
+* **Windows: Fix shim logs going to panic.log file** ([#7242](https://github.com/containerd/containerd/pull/7242))
+* **Allow ptrace(2) by default for kernels >= 4.8** ([#7171](https://github.com/containerd/containerd/pull/7171))
+
+See the changelog for complete list of changes"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.6+unknown"
+	Version = "1.6.7+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
See: https://gist.github.com/dcantah/7e1aef7bf809270960c2814d0d976a2b