### PR TITLE
[release/1.6] Backport: bump macos runner version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.17.12]
-        os: [ubuntu-18.04, macos-10.15, windows-2019]
+        os: [ubuntu-18.04, macos-12, windows-2019]
 
     steps:
       - uses: actions/setup-go@v2
@@ -214,7 +214,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-10.15, windows-2019, windows-2022]
+        os: [ubuntu-18.04, macos-12, windows-2019, windows-2022]
         go-version: ['1.16.15', '1.17.12']
 
     steps:
@@ -462,7 +462,7 @@ jobs:
 
   tests-mac-os:
     name: MacOS unit tests
-    runs-on: macos-10.15
+    runs-on: macos-12
     timeout-minutes: 10
     needs: [project, linters, protos, man]
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -489,7 +489,7 @@ jobs:
   vagrant:
     name: Vagrant
     # nested virtualization is only available on macOS hosts
-    runs-on: macos-10.15
+    runs-on: macos-12
     timeout-minutes: 45
     needs: [project, linters, protos, man]
     strategy:
@@ -560,7 +560,7 @@ jobs:
   cgroup2-misc:
     name: CGroupsV2 - rootless CRI test
     # nested virtualization is only available on macOS hosts
-    runs-on: macos-10.15
+    runs-on: macos-12
     timeout-minutes: 45
     needs: [project, linters, protos, man]
     steps:


### PR DESCRIPTION
 - Cherry-pick (required fixup for mismatch on go-version) commit from #7206 
 - Update Vagrant instances to macos-12 image (not used in `main` anymore)