### PR TITLE
[release/1.6] Update golang to 1.17.13

### DIFF
--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.12'
+          go-version: '1.17.13'
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.17.12]
+        go-version: [1.17.13]
         os: [ubuntu-18.04, macos-12, windows-2019]
 
     steps:
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.12'
+          go-version: '1.17.13'
 
       - uses: actions/checkout@v2
         with:
@@ -78,7 +78,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.12'
+          go-version: '1.17.13'
 
       - uses: actions/checkout@v2
         with:
@@ -110,7 +110,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.12'
+          go-version: '1.17.13'
       - uses: actions/checkout@v2
       - run: go install github.com/cpuguy83/go-md2man/v2@v2.0.1
       - run: make man
@@ -148,7 +148,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.12'
+          go-version: '1.17.13'
       - uses: actions/checkout@v2
       - run: |
           set -e -x
@@ -215,7 +215,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-12, windows-2019, windows-2022]
-        go-version: ['1.16.15', '1.17.12']
+        go-version: ['1.16.15', '1.17.13']
 
     steps:
       - uses: actions/setup-go@v2
@@ -262,7 +262,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.12'
+          go-version: '1.17.13'
 
       - uses: actions/checkout@v2
         with:
@@ -352,7 +352,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.12'
+          go-version: '1.17.13'
 
       - uses: actions/checkout@v2
 
@@ -471,7 +471,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.12'
+          go-version: '1.17.13'
       - uses: actions/checkout@v2
       - run: sudo -E PATH=$PATH script/setup/install-gotestsum
       - name: Tests

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: 1.17.12
+        go-version: 1.17.13
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.12'
+          go-version: '1.17.13'
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.12'
+          go-version: '1.17.13'
 
       - uses: actions/checkout@v2
         with:
@@ -155,7 +155,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.12'
+          go-version: '1.17.13'
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17.12'
+          go-version: '1.17.13'
       - name: Set env
         shell: bash
         env:
@@ -109,7 +109,7 @@ jobs:
           find ./releases/ -maxdepth 1 -type l | xargs rm
         working-directory: src/github.com/containerd/containerd
         env:
-          GO_VERSION: '1.17.12'
+          GO_VERSION: '1.17.13'
           PLATFORM: ${{ matrix.platform }}
       - name: Save Artifacts
         uses: actions/upload-artifact@v2

--- a/.zuul/playbooks/containerd-build/integration-test.yaml
+++ b/.zuul/playbooks/containerd-build/integration-test.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.17.12'
+    go_version: '1.17.13'
     arch: arm64
   tasks:
   - name: Install pre-requisites

--- a/.zuul/playbooks/containerd-build/run.yaml
+++ b/.zuul/playbooks/containerd-build/run.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.17.12'
+    go_version: '1.17.13'
     arch: arm64
   tasks:
   - name: Build containerd

--- a/.zuul/playbooks/containerd-build/unit-test.yaml
+++ b/.zuul/playbooks/containerd-build/unit-test.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.17.12'
+    go_version: '1.17.13'
     arch: arm64
   tasks:
   - name: Build and test containerd

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -91,7 +91,7 @@ EOF
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.17.12",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.17.13",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -10,7 +10,7 @@
 #
 # docker build -t containerd-test --build-arg RUNC_VERSION=v1.0.0-rc94 -f Dockerfile.test ../
 
-ARG GOLANG_VERSION=1.17.12
+ARG GOLANG_VERSION=1.17.13
 ARG GOLANG_IMAGE=golang
 
 FROM ${GOLANG_IMAGE}:${GOLANG_VERSION} AS golang

--- a/script/setup/prepare_env_windows.ps1
+++ b/script/setup/prepare_env_windows.ps1
@@ -1,6 +1,6 @@
 # Prepare windows environment for building and running containerd tests
 
-$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.17.12"; make = ""; nssm = "" }
+$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.17.13"; make = ""; nssm = "" }
 
 Write-Host "Downloading chocolatey package"
 curl.exe -L "https://packages.chocolatey.org/chocolatey.0.10.15.nupkg" -o 'c:\choco.zip'


### PR DESCRIPTION
Update Go runtime to 1.17.13 to address CVE-2022-32189.

Full diff:
https://github.com/golang/go/compare/go1.17.12...go1.17.13

--------------------------------------------

From the security announcement:
https://groups.google.com/g/golang-announce/c/YqYYG87xB10

We have just released Go versions 1.18.5 and 1.17.13, minor point
releases.

These minor releases include 1 security fixes following the security
policy:

encoding/gob & math/big: decoding big.Float and big.Rat can panic

Decoding big.Float and big.Rat types can panic if the encoded message is
too short.

This is CVE-2022-32189 and Go issue https://go.dev/issue/53871.

View the release notes for more information:
https://go.dev/doc/devel/release#go1.17.13