### PR TITLE
[release/1.5] Update golang to 1.17.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.17.12]
+        go-version: [1.17.13]
         os: [ubuntu-18.04, macos-10.15, windows-2019]
 
     steps:
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.12'
+          go-version: '1.17.13'
 
       - shell: bash
         run: |
@@ -86,7 +86,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.12'
+          go-version: '1.17.13'
 
       - uses: actions/checkout@v2
         with:
@@ -119,7 +119,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.12'
+          go-version: '1.17.13'
 
       - name: Set env
         shell: bash
@@ -165,7 +165,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.12'
+          go-version: '1.17.13'
       - name: Set env
         shell: bash
         run: |
@@ -230,7 +230,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-10.15, windows-2019]
-        go-version: ['1.17.12']
+        go-version: ['1.17.13']
         include:
           # Go 1.13.x is still used by Docker/Moby
           - go-version: '1.13.x'
@@ -276,7 +276,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.12'
+          go-version: '1.17.13'
 
       - uses: actions/checkout@v2
         with:
@@ -365,7 +365,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.12'
+          go-version: '1.17.13'
 
       - uses: actions/checkout@v2
         with:
@@ -517,7 +517,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.12'
+          go-version: '1.17.13'
       - uses: actions/checkout@v2
         with:
           path: src/github.com/containerd/containerd

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.12'
+          go-version: '1.17.13'
 
       - uses: actions/checkout@v2
         with:
@@ -135,7 +135,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.12'
+          go-version: '1.17.13'
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17.12'
+          go-version: '1.17.13'
 
       - name: Set env
         shell: bash

--- a/.zuul/playbooks/containerd-build/integration-test.yaml
+++ b/.zuul/playbooks/containerd-build/integration-test.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.17.12'
+    go_version: '1.17.13'
     arch: arm64
   tasks:
   - name: Install pre-requisites

--- a/.zuul/playbooks/containerd-build/run.yaml
+++ b/.zuul/playbooks/containerd-build/run.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.17.12'
+    go_version: '1.17.13'
     arch: arm64
   tasks:
   - name: Build containerd

--- a/.zuul/playbooks/containerd-build/unit-test.yaml
+++ b/.zuul/playbooks/containerd-build/unit-test.yaml
@@ -2,7 +2,7 @@
   become: yes
   roles:
   - role: config-golang
-    go_version: '1.17.12'
+    go_version: '1.17.13'
     arch: arm64
   tasks:
   - name: Build and test containerd

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,7 +77,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.17.12",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.17.13",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -10,7 +10,7 @@
 #
 # docker build -t containerd-test --build-arg RUNC_VERSION=v1.0.0-rc93 -f Dockerfile.test ../
 
-ARG GOLANG_VERSION=1.17.12
+ARG GOLANG_VERSION=1.17.13
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd


### PR DESCRIPTION
Update Go runtime to 1.17.13 to address CVE-2022-32189.

Full diff:
https://github.com/golang/go/compare/go1.17.12...go1.17.13

------------------------------------------

From the security announcement:
https://groups.google.com/g/golang-announce/c/YqYYG87xB10

We have just released Go versions 1.18.5 and 1.17.13, minor point
releases.

These minor releases include 1 security fixes following the security
policy:

encoding/gob & math/big: decoding big.Float and big.Rat can panic

Decoding big.Float and big.Rat types can panic if the encoded message is
too short.

This is CVE-2022-32189 and Go issue https://go.dev/issue/53871.

View the release notes for more information:
https://go.dev/doc/devel/release#go1.17.13