### PR TITLE
[release/1.5] backport: update GitHub Actions runners to macos-12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -546,7 +546,7 @@ jobs:
   cgroup2:
     name: CGroupsV2 and SELinux Integration
     # nested virtualization is only available on macOS hosts
-    runs-on: macos-10.15
+    runs-on: macos-12
     timeout-minutes: 45
     needs: [project, linters, protos, man]
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.17.13]
-        os: [ubuntu-18.04, macos-10.15, windows-2019]
+        os: [ubuntu-18.04, macos-12, windows-2019]
 
     steps:
       - uses: actions/setup-go@v2
@@ -229,7 +229,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-10.15, windows-2019]
+        os: [ubuntu-18.04, macos-12, windows-2019]
         go-version: ['1.17.13']
         include:
           # Go 1.13.x is still used by Docker/Moby
@@ -508,7 +508,7 @@ jobs:
 
   tests-mac-os:
     name: MacOS unit tests
-    runs-on: macos-10.15
+    runs-on: macos-12
     timeout-minutes: 10
     needs: [project, linters, protos, man]
     env:


### PR DESCRIPTION
Needs to be on macos-12 for CI runners to work properly after deprecation