### PR TITLE
[release/1.6] Update release build timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
     name: Build Release Binaries
     runs-on: ${{ matrix.os }}
     needs: [check]
-    timeout-minutes: 10
+    timeout-minutes: 20
     strategy:
       matrix:
         os: [ubuntu-18.04]


### PR DESCRIPTION
1.6 releases are timing out when building the release