### PR TITLE
Use environment variable to specify Go version on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ on:
       - main
       - 'release/**'
 
+env:
+  # Go version we currently use to build containerd across all CI.
+  # Note: don't forget to update `Binaries` step, as it contains the matrix of all supported Go versions.
+  GO_VERSION: '1.18.5'
+
 jobs:
   #
   # golangci-lint
@@ -20,13 +25,12 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.18.5]
         os: [ubuntu-18.04, macos-12, windows-2019]
 
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: ${{ env.GO_VERSION }}
 
       - uses: actions/checkout@v2
       - uses: golangci/golangci-lint-action@v3
@@ -46,7 +50,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.5'
+          go-version: ${{ env.GO_VERSION }}
 
       - uses: actions/checkout@v2
         with:
@@ -78,7 +82,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.5'
+          go-version: ${{ env.GO_VERSION }}
 
       - uses: actions/checkout@v2
         with:
@@ -110,7 +114,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.5'
+          go-version: ${{ env.GO_VERSION }}
       - uses: actions/checkout@v2
       - run: go install github.com/cpuguy83/go-md2man/v2@v2.0.1
       - run: make man
@@ -148,7 +152,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.5'
+          go-version: ${{ env.GO_VERSION }}
       - uses: actions/checkout@v2
       - run: |
           set -e -x
@@ -262,7 +266,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.5'
+          go-version: ${{ env.GO_VERSION }}
 
       - uses: actions/checkout@v2
         with:
@@ -404,7 +408,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.5'
+          go-version: ${{ env.GO_VERSION }}
 
       - uses: actions/checkout@v2
 
@@ -534,7 +538,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.5'
+          go-version: ${{ env.GO_VERSION }}
       - uses: actions/checkout@v2
       - run: sudo -E PATH=$PATH script/setup/install-gotestsum
       - name: Tests

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - '.github/workflows/nightly.yml'
 
+env:
+  GO_VERSION: '1.18.5'
+
 jobs:
   linux:
     name: Linux
@@ -18,7 +21,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.5'
+          go-version: ${{ env.GO_VERSION }}
 
       - uses: actions/checkout@v2
         with:
@@ -155,7 +158,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.5'
+          go-version: ${{ env.GO_VERSION }}
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
 
 name: Containerd Release
 
+env:
+  GO_VERSION: '1.18.5'
+
 jobs:
   check:
     name: Check Signed Tag
@@ -66,7 +69,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.18.5'
+          go-version: ${{ env.GO_VERSION }}
       - name: Set env
         shell: bash
         env:
@@ -109,7 +112,6 @@ jobs:
           find ./releases/ -maxdepth 1 -type l | xargs rm
         working-directory: src/github.com/containerd/containerd
         env:
-          GO_VERSION: '1.18.5'
           PLATFORM: ${{ matrix.platform }}
       - name: Save Artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
This will significantly reduce the number of places where we have to bump Go version on our CI.

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>