### PR TITLE
oci: skip checking group id for WithAppendAdditionalGroups

### DIFF
--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -879,15 +879,19 @@ func WithAppendAdditionalGroups(groups ...string) SpecOpts {
 			groupMap := make(map[string]user.Group)
 			for _, group := range ugroups {
 				groupMap[group.Name] = group
-				groupMap[strconv.Itoa(group.Gid)] = group
 			}
 			var gids []uint32
 			for _, group := range groups {
-				g, ok := groupMap[group]
-				if !ok {
-					return fmt.Errorf("unable to find group %s", group)
+				gid, err := strconv.ParseUint(group, 10, 32)
+				if err == nil {
+					gids = append(gids, uint32(gid))
+				} else {
+					g, ok := groupMap[group]
+					if !ok {
+						return fmt.Errorf("unable to find group %s", group)
+					}
+					gids = append(gids, uint32(g.Gid))
 				}
-				gids = append(gids, uint32(g.Gid))
 			}
 			s.Process.User.AdditionalGids = append(s.Process.User.AdditionalGids, gids...)
 			return nil

--- a/oci/spec_opts_linux_test.go
+++ b/oci/spec_opts_linux_test.go
@@ -477,6 +477,11 @@ daemon:x:2:root,bin,daemon
 			expected:       []uint32{0, 1, 2},
 		},
 		{
+			name:     "append group id",
+			groups:   []string{"999"},
+			expected: []uint32{999},
+		},
+		{
 			name:   "unknown group",
 			groups: []string{"unknown"},
 			err:    "unable to find group unknown",


### PR DESCRIPTION
Signed-off-by: Ye Sijun <junnplus@gmail.com>

`WithAppendAdditionalGroups` should allow appending the group id directly instead of checking it.