### PR TITLE
release workflow: increase timeout to 30 minutes & remove Go setup action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
     name: Build Release Binaries
     runs-on: ${{ matrix.os }}
     needs: [check]
-    timeout-minutes: 10
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [ubuntu-18.04]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,10 +66,6 @@ jobs:
           - linux/riscv64
           - windows/amd64
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GO_VERSION }}
       - name: Set env
         shell: bash
         env:


### PR DESCRIPTION
In the 1.6.7 release, we saw significantly longer execution time for producing builds that exceeded the previous timeout of 10 minutes, causing the workflow to fail.  After increasing to 20 minutes in the release/1.6 branch, we continued to see one failure (which succeeded on retry).

Increase to 30 minutes to provide additional buffer for the build to complete.

--------

Release builds are performed from within a Dockerfile-defined environment and do not require Go to be installed in the GitHub Actions runner environment.

-------

See https://github.com/samuelkarp/containerd/actions/runs/2805142467 for a successful run.

