### PR TITLE
[release/1.6] release: rollback Ubuntu to 18.04 (except for riscv64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,18 +50,24 @@ jobs:
 
   build:
     name: Build Release Binaries
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-${{ matrix.ubuntu }}
     needs: [check]
     timeout-minutes: 20
     strategy:
       matrix:
-        os: [ubuntu-18.04]
-        platform:
-          - linux/amd64
-          - linux/arm64
-          - linux/ppc64le
-          - linux/riscv64
-          - windows/amd64
+        include:
+          # Choose an old release of Ubuntu to avoid glibc issue https://github.com/containerd/containerd/issues/7255
+          - ubuntu: 18.04
+            platform: linux/amd64
+          - ubuntu: 18.04
+            platform: linux/arm64
+          - ubuntu: 18.04
+            platform: linux/ppc64le
+          # riscv64 isn't supported by Ubuntu 18.04
+          - ubuntu: 22.04
+            platform: linux/riscv64
+          - ubuntu: 18.04
+            platform: windows/amd64
     steps:
       - name: Install Go
         uses: actions/setup-go@v2
@@ -70,7 +76,7 @@ jobs:
       - name: Set env
         shell: bash
         env:
-          MOS: ${{ matrix.os }}
+          MOS: ubuntu-${{ matrix.ubuntu }}
         run: |
           releasever=${{ github.ref }}
           releasever="${releasever#refs/tags/}"
@@ -102,7 +108,7 @@ jobs:
             export PREFIX_LEN=12
             BUILD_ARGS="--build-arg GATEWAY --build-arg PREFIX_LEN"
           fi
-          docker buildx build ${cache} --build-arg RELEASE_VER --build-arg GO_VERSION ${BUILD_ARGS} -f .github/workflows/release/Dockerfile --platform=${PLATFORM} -o releases/ .
+          docker buildx build ${cache} --build-arg RELEASE_VER --build-arg UBUNTU_VERSION=${{ matrix.ubuntu }} --build-arg GO_VERSION ${BUILD_ARGS} -f .github/workflows/release/Dockerfile --platform=${PLATFORM} -o releases/ .
           echo PLATFORM_CLEAN=${PLATFORM/\//-} >> $GITHUB_ENV
 
           # Remove symlinks since we don't want these in the release Artifacts

--- a/.github/workflows/release/Dockerfile
+++ b/.github/workflows/release/Dockerfile
@@ -12,7 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-ARG UBUNTU_VERSION=22.04
+# UBUNTU_VERSION can be set to 18.04 (bionic), 20.04 (focal), or 22.04 (jammy)
+ARG UBUNTU_VERSION=18.04
 ARG BASE_IMAGE=ubuntu:${UBUNTU_VERSION}
 ARG GO_VERSION
 ARG GO_IMAGE=golang:${GO_VERSION}
@@ -25,7 +26,8 @@ SHELL ["/bin/bash", "-xec"]
 RUN	apt-get update && \
 	apt-get install -y dpkg-dev git make pkg-config
 ARG TARGETPLATFORM
-RUN xx-apt-get install -y libseccomp-dev libbtrfs-dev gcc
+RUN xx-apt-get install -y libseccomp-dev btrfs-progs gcc
+RUN if grep -qE 'UBUNTU_CODENAME=(focal|jammy)' /etc/os-release; then xx-apt-get install -y libbtrfs-dev; fi
 ENV PATH=/usr/local/go/bin:$PATH
 ENV GOPATH=/go
 ENV CGO_ENABLED=1


### PR DESCRIPTION
Backport of https://github.com/containerd/containerd/pull/7258

See https://github.com/samuelkarp/containerd/actions/runs/2806523405 for a successful run

-------------

Partially revert 0e56e4f9ff2925d0755908f227f2b5fc9a1c4c78

Rollback the build environment from Ubuntu 22.04 to 18.04, except for riscv64 that isn't supported by Ubuntu 18.04.

Fix issue 7255 (`1.6.7 can't be run on Ubuntu LTS 20.04 (GLIBC_2.34 not found)`)

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
(cherry picked from commit 481861020742c194f25f2694cd09be8d37d45fba)
Signed-off-by: Samuel Karp <samuelkarp@google.com>