### PR TITLE
[release/1.6] release workflow: increase timeout to 30 minutes & remove Go setup action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
     name: Build Release Binaries
     runs-on: ubuntu-${{ matrix.ubuntu }}
     needs: [check]
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       matrix:
         include:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,10 +69,6 @@ jobs:
           - ubuntu: 18.04
             platform: windows/amd64
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: '1.17.13'
       - name: Set env
         shell: bash
         env:


### PR DESCRIPTION
Backport of https://github.com/containerd/containerd/pull/7259

See run at https://github.com/samuelkarp/containerd/actions/runs/2807107122

----

In the 1.6.7 release, we saw significantly longer execution time for
producing builds that exceeded the previous timeout of 10 minutes,
causing the workflow to fail.  After increasing to 20 minutes in the
release/1.6 branch, we continued to see one failure (which succeeded on
retry).

Increase to 30 minutes to provide additional buffer for the build to
complete.

Signed-off-by: Samuel Karp <samuelkarp@google.com>
(cherry picked from commit f8add92)
Signed-off-by: Samuel Karp <samuelkarp@google.com>