### PR TITLE
[release/1.5] release workflow: increase timeout to 30 minutes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
     name: Build Release Binaries
     runs-on: ${{ matrix.os }}
     needs: [check]
-    timeout-minutes: 10
+    timeout-minutes: 30
 
     strategy:
       matrix:


### PR DESCRIPTION
Backport of https://github.com/containerd/containerd/pull/7259

See run at https://github.com/samuelkarp/containerd/actions/runs/2807105354

----

In the 1.6.7 release, we saw significantly longer execution time for
producing builds that exceeded the previous timeout of 10 minutes,
causing the workflow to fail.  After increasing to 20 minutes in the
release/1.6 branch, we continued to see one failure (which succeeded on
retry).

Increase to 30 minutes to provide additional buffer for the build to
complete.

Signed-off-by: Samuel Karp <samuelkarp@google.com>
(cherry picked from commit f8add9263a9ba64ad4400b7c1877dbd527963fbb)
Signed-off-by: Samuel Karp <samuelkarp@google.com>