### PR TITLE
Vagrantfile: dump containerd log after critest

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -259,6 +259,7 @@ EOF
         function cleanup()
         {
             journalctl -u containerd > /tmp/containerd.log
+            cat /tmp/containerd.log
             systemctl stop containerd
         }
         selinux=$(getenforce)


### PR DESCRIPTION
It is used to debug if there is any flaky test cases.

Signed-off-by: Wei Fu <fuweid89@gmail.com>

---- 

REF: #7264 

----

Example: https://api.cirrus-ci.com/v1/task/5387167588417536/logs/cri_test.log