### PR TITLE
[release/1.6 backport] oci: WithDefaultUnixDevices(): remove tun/tap from the default devices

### DIFF
--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -1120,17 +1120,10 @@ func WithDefaultUnixDevices(_ context.Context, _ Client, _ *containers.Container
 			Allow:  true,
 		},
 		{
+			// "dev/ptmx"
 			Type:   "c",
 			Major:  intptr(5),
 			Minor:  intptr(2),
-			Access: rwm,
-			Allow:  true,
-		},
-		{
-			// tuntap
-			Type:   "c",
-			Major:  intptr(10),
-			Minor:  intptr(200),
 			Access: rwm,
 			Allow:  true,
 		},


### PR DESCRIPTION
- backport ofhttps://github.com/containerd/containerd/pull/6923

A container should not have access to tun/tap device, unless it is explicitly
specified in configuration.

This device was already removed from docker's default, and runc's default;

- https://github.com/opencontainers/runc/pull/3468/commits/2ce40b6ad72b4bd4391380cafc5ef1bad1fa0b31
- https://github.com/moby/moby//commit/9c4570a958df42d1ad19364b1a8da55b891d850a

Per the commit message in runc, this should also fix these messages;

> Apr 26 03:46:56 foo.bar systemd[1]: Couldn't stat device /dev/char/10:200: No such file or directory

coming from systemd on every container start, when the systemd cgroup driver
is used, and the system runs an old (< v240) version of systemd
(the message was presumably eliminated by [1]).

[1]: https://github.com/systemd/systemd/commit/d5aecba6e0b7c73657c4cf544ce57289115098e7

(cherry picked from commit a3ac1560076f5e3eca43b5027cca4f23dfdd639f)
