### PR TITLE
Added command line options for 'ctr container info' and 'containerd c…

### DIFF
--- a/cmd/ctr/commands/utils.go
+++ b/cmd/ctr/commands/utils.go
@@ -16,6 +16,12 @@
 
 package commands
 
+import (
+   "fmt"
+   "strings"
+   "strconv"
+)
+
 // IntToInt32Array converts an array of int's to int32's
 func IntToInt32Array(in []int) []int32 {
 	var ret []int32
@@ -24,4 +30,60 @@ func IntToInt32Array(in []int) []int32 {
 		ret = append(ret, int32(v))
 	}
 	return ret
+}
+
+// TraverseMap walks the depth of a map and returns the value of the nested keys provided.
+func TraverseMap(m map[string]interface{}, keys ...string) (value interface{}, err error) {
+
+   var (
+      ok bool
+      k []interface{}
+   )
+
+   if len(keys) == 0 {
+      return nil, fmt.Errorf("TraverseMap needs at least one key")
+   }
+   if strings.Contains(keys[0], "[") && strings.Contains(keys[0], "]") { // handling arrays
+      s1 := strings.Split(keys[0], "[")
+      if len(s1) != 2 {
+         return nil, fmt.Errorf("invalid key %v", keys[0])
+      }
+      if value, ok = m[s1[0]]; !ok {
+         return nil, fmt.Errorf("key not found; remaining keys: %v", keys)
+      } else if k, ok = value.([]interface{}); !ok {
+         return nil, fmt.Errorf("malformed structure at %#v", value)
+      } else {
+         s2 := strings.Split(s1[1], "]")
+         if s2[0] == "%" {
+            var arr []interface{}
+            for i, _ := range k {
+               a, err := TraverseMap(m, append([]string{s1[0] + "["+strconv.Itoa(i)+"]"}, keys[1:]...)...)
+               if err != nil {
+                  return nil, err
+               }
+
+               arr = append(arr, a)
+            }
+
+            return arr, nil
+         }
+         index, err := strconv.Atoi(s2[0])
+         if err != nil {
+            return nil, fmt.Errorf("invalid key %v", keys[0])
+         }
+         value = k[index]
+      }
+   } else {
+      if value, ok = m[keys[0]]; !ok {
+         return nil, fmt.Errorf("key not found; remaining keys: %v", keys)
+      }
+   }
+
+   if len(keys) == 1 { // Final key
+      return value, nil
+   } else if m, ok = value.(map[string]interface{}); !ok {
+      return nil, fmt.Errorf("malformed structure at %#v", value)
+   } else {
+      return TraverseMap(m, keys[1:]...)
+   }
 }

--- a/services/server/config/config.go
+++ b/services/server/config/config.go
@@ -17,7 +17,9 @@
 package config
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -201,6 +203,11 @@ func LoadConfig(path string, out *Config) error {
 		// Check if a file at the given path already loaded to prevent circular imports
 		if _, ok := loaded[path]; ok {
 			continue
+		}
+
+		if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+			// use default config
+			return nil
 		}
 
 		config, err := loadConfigFile(path)


### PR DESCRIPTION
…onfig dump' commands

Command line options can be much more powerful with the introduction of 'value' flag for both 'containerd config dump' and 'ctr container info' commands.

Eg: 
ctr container info <container_id> --value Spec.linux.resources.devices[1].allow
**true**

containerd config dump --value plugins:io.containerd.grpc.v1.cri:cni:conf_dir
**/etc/cni/net.d**