### PR TITLE
Follow up #7254 (Switch to Go 1.19)

### DIFF
--- a/contrib/fuzz/daemon.go
+++ b/contrib/fuzz/daemon.go
@@ -3,10 +3,13 @@
 
 /*
    Copyright The containerd Authors.
+
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
+
        http://www.apache.org/licenses/LICENSE-2.0
+
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/cri/streaming/server.go
+++ b/pkg/cri/streaming/server.go
@@ -162,10 +162,11 @@ func NewServer(config Config, runtime Runtime) (Server, error) {
 	handler.Add(ws)
 	s.handler = handler
 	s.server = &http.Server{
-		Addr:              s.config.Addr,
-		Handler:           s.handler,
-		TLSConfig:         s.config.TLSConfig,
-		ReadHeaderTimeout: 3 * time.Second, // Fix linter G112: Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server
+		Addr:      s.config.Addr,
+		Handler:   s.handler,
+		TLSConfig: s.config.TLSConfig,
+		// TODO(fuweid): allow user to configure streaming server
+		ReadHeaderTimeout: 30 * time.Minute, // Fix linter G112: Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server
 	}
 
 	return s, nil


### PR DESCRIPTION
* [pkg/cri/streaming: increase ReadHeaderTimeout](https://github.com/containerd/containerd/commit/71a9fa8d212606b916fc4aa555acdb1d09010b39) 

It is follow-up of https://github.com/containerd/containerd/pull/7254. This commit will increase ReadHeaderTimeout
from 3s to 30m, which prevent from unexpected timeout when the node is
running with high-load. 30 Minutes is longer enough to get close to
before what https://github.com/containerd/containerd/pull/7254 changes.

And ideally, we should allow user to configure the streaming server if
the users want this feature.

* [contrib/fuzz/daemon.go: reformat the fileheader](https://github.com/containerd/containerd/commit/38c98bc94173b59938a7b148b45fd9360f849037) 

Align with https://github.com/containerd/project/blob/main/script/validate/template/go.txt.

cc @mxpv and @mikebrow 