### PR TITLE
contrib/fuzz: fix broken OSS-Fuzz build

### DIFF
--- a/contrib/fuzz/oss_fuzz_build.sh
+++ b/contrib/fuzz/oss_fuzz_build.sh
@@ -49,8 +49,7 @@ mv temp-go/go/* /root/.go/
 cd $SRC/containerd
 
 go mod tidy
-rm vendor/github.com/cilium/ebpf/internal/btf/fuzz.go
-rm /root/go/pkg/mod/github.com/cilium/ebpf@v0.7.0/internal/btf/fuzz.go
+go get github.com/cilium/ebpf@latest
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 cd ../../


### PR DESCRIPTION
A broken fuzzer in an old version of github.com/cilium/ebpf breaks the OSS-Fuzz build. This PR fixes that by using the latest version of the dependency which does not have the broken fuzzer.

Signed-off-by: AdamKorcz <Adam@adalogics.com>