### PR TITLE
ci: remove GOPROXY environment variable due to https://github.com/go-yaml/yaml/issues/887

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,7 +439,6 @@ jobs:
       - run: script/setup/install-gotestsum
       - name: Tests
         env:
-          GOPROXY: direct
           GOTESTSUM_JUNITFILE: ${{github.workspace}}/test-unit-root-junit.xml
         run: |
           make test
@@ -447,7 +446,6 @@ jobs:
 
       - name: Integration 1
         env:
-          GOPROXY: direct
           TEST_RUNTIME: ${{ matrix.runtime }}
           RUNC_FLAVOR: ${{ matrix.runc }}
           ENABLE_CRI_SANDBOXES: ${{ matrix.enable_cri_sandboxes }}
@@ -462,7 +460,6 @@ jobs:
       # Run the integration suite a second time. See discussion in github.com/containerd/containerd/pull/1759
       - name: Integration 2
         env:
-          GOPROXY: direct
           TEST_RUNTIME: ${{ matrix.runtime }}
           RUNC_FLAVOR: ${{ matrix.runc }}
           ENABLE_CRI_SANDBOXES: ${{ matrix.enable_cri_sandboxes }}
@@ -539,7 +536,6 @@ jobs:
       - run: script/setup/install-gotestsum
       - name: Tests
         env:
-          GOPROXY: direct
           GOTESTSUM_JUNITFILE: "${{ github.workspace }}/macos-test-junit.xml"
         run: make test
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
`GOPROXY=direct` was introduced by @mxpv in https://github.com/containerd/containerd/commit/6d4429eddeaff0fa0640f4a51c66fb65702477df, but there does not seem to be any specific history for why it was set.  Our CI workflows are now failing due to https://github.com/go-yaml/yaml/issues/887, so at least for now it should help to remove this setting.