### PR TITLE
[release/1.6] Do not append []string{""} to command to preserve Docker compatibility

### DIFF
--- a/pkg/cri/opts/spec.go
+++ b/pkg/cri/opts/spec.go
@@ -63,7 +63,9 @@ func WithProcessArgs(config *runtime.ContainerConfig, image *imagespec.ImageConf
 				args = append([]string{}, image.Cmd...)
 			}
 			if command == nil {
-				command = append([]string{}, image.Entrypoint...)
+				if !(len(image.Entrypoint) == 1 && image.Entrypoint[0] == "") {
+					command = append([]string{}, image.Entrypoint...)
+				}
 			}
 		}
 		if len(command) == 0 && len(args) == 0 {


### PR DESCRIPTION
Cherry-pick https://github.com/containerd/containerd/pull/6805