### PR TITLE
Adding support of CAP_BPF and CAP_PERFMON

### DIFF
--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -671,6 +671,18 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				Action: specs.ActAllow,
 				Args:   []specs.LinuxSeccompArg{},
 			})
+		case "CAP_BPF":
+			s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
+				Names:  []string{"bpf"},
+				Action: specs.ActAllow,
+				Args:   []specs.LinuxSeccompArg{},
+			})
+		case "CAP_PERFMON":
+			s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
+				Names:  []string{"perf_event_open"},
+				Action: specs.ActAllow,
+				Args:   []specs.LinuxSeccompArg{},
+			})
 		}
 	}
 


### PR DESCRIPTION
Adding CAP_BPF and CAP_PERFMON

The PR adds support of `CAP_BPF` and `CAP_PERFMON` capabilities. Prior to kernel 5.8 `bpf` and `perf_event_open` requires `CAP_SYS_ADMIN`. This change enables finer control of the privilege setting, thus allowing us to run certain system tracing tools with minimal privileges.

Signed-off-by: Henry Wang <henwang@amazon.com>