### PR TITLE
Don't fail test when GOOGLE_APPLICATION_CREDENTIALS is unset

### DIFF
--- a/test/build-utils.sh
+++ b/test/build-utils.sh
@@ -18,13 +18,9 @@
 : "${PROJECT:=k8s-cri-containerd}"
 
 # GOOGLE_APPLICATION_CREDENTIALS is the path of service account file.
-if [ -z "${GOOGLE_APPLICATION_CREDENTIALS:-""}" ]; then
-  echo "GOOGLE_APPLICATION_CREDENTIALS is not set"
-  exit 1
+if [ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]; then
+  gcloud auth activate-service-account --key-file "${GOOGLE_APPLICATION_CREDENTIALS}" --project="${PROJECT}"
 fi
-
-# Activate gcloud service account.
-gcloud auth activate-service-account --key-file "${GOOGLE_APPLICATION_CREDENTIALS}" --project="${PROJECT}"
 
 cat /etc/os-release
 apt-get update


### PR DESCRIPTION
Workload identity is preferred in CI instead of GOOGLE_APPLICATION_CREDENTIALS

related: https://github.com/kubernetes/test-infra/issues/27157

/cc @dims 