### PR TITLE
Revert "Downgrade MinGW to version 10.2.0"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,14 +286,6 @@ jobs:
 
       - run: script/setup/install-dev-tools
 
-      # There is currently an issue in the race detector in Go on Windows when
-      # used with a newer version of GCC. The issue was first reported here:
-      # https://github.com/golang/go/issues/46099
-      - name: Downgrade MinGW
-        shell: bash
-        run: |
-          choco install mingw --version 10.2.0 --allow-downgrade
-
       - name: Binaries
         env:
           CGO_ENABLED: 1


### PR DESCRIPTION
This reverts commit https://github.com/containerd/containerd/commit/1ef4bda43301ef1de059346a9c37a0876eb635f3.

Previously we were downgrading mingw to work around an issue in the race
detector in Go on Windows when used with a newer version of GCC. The
issue was first reported here:

https://github.com/golang/go/issues/46099

Shortly after the release of 1.19 someone had commented this issue was
solved for them, and after trying it out in some test runs on actions
machines, it seems to be the case. Disabling ASLR got things in order, and
PIE was disabled for -race builds in 1.19, so this is likely the reason
things work now:
https://github.com/golang/go/commit/0c7fcf6bd1fd8df2bfae3a482f1261886f6313c1.

The downgrade was mostly harmless except for two shortcomings:

1. It took quite a while for the package to get downloaded+installed.

2. Chocolatey would frequently fail to download with `The remote file
either doesn't exist, is unauthorized, or is forbidden for url ...
Exception calling "GetResponse" with "0" argument(s): "The request
was aborted: Could not create SSL/TLS secure channel."` Restarting the
failed run would often resolve this, but a 50-50 shot of things working
is not a great situation.