### PR TITLE
Add capability for snapshotters to declare support for UID remapping

### DIFF
--- a/client.go
+++ b/client.go
@@ -854,3 +854,21 @@ func toPlatforms(pt []*apitypes.Platform) []ocispec.Platform {
 	}
 	return platforms
 }
+
+// GetSnapshotterCapabilities returns the capabilities of a snapshotter.
+func (c *Client) GetSnapshotterCapabilities(ctx context.Context, snapshotterName string) ([]string, error) {
+	filters := []string{fmt.Sprintf("type==%s, id==%s", plugin.SnapshotPlugin, snapshotterName)}
+	in := c.IntrospectionService()
+
+	resp, err := in.Plugins(ctx, filters)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(resp.Plugins) <= 0 {
+		return nil, fmt.Errorf("inspection service could not find snapshotter %s plugin", snapshotterName)
+	}
+
+	sn := resp.Plugins[0]
+	return sn.Capabilities, nil
+}

--- a/container_opts.go
+++ b/container_opts.go
@@ -223,6 +223,11 @@ func WithNewSnapshot(id string, i Image, opts ...snapshots.Opt) NewContainerOpts
 		if err != nil {
 			return err
 		}
+
+		parent, err = resolveSnapshotOptions(ctx, client, c.Snapshotter, s, parent, opts...)
+		if err != nil {
+			return err
+		}
 		if _, err := s.Prepare(ctx, id, parent, opts...); err != nil {
 			return err
 		}
@@ -264,6 +269,11 @@ func WithNewSnapshotView(id string, i Image, opts ...snapshots.Opt) NewContainer
 			return err
 		}
 		s, err := client.getSnapshotter(ctx, c.Snapshotter)
+		if err != nil {
+			return err
+		}
+
+		parent, err = resolveSnapshotOptions(ctx, client, c.Snapshotter, s, parent, opts...)
 		if err != nil {
 			return err
 		}

--- a/pkg/cri/server/container_create.go
+++ b/pkg/cri/server/container_create.go
@@ -184,7 +184,10 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	log.G(ctx).Debugf("Container %q spec: %#+v", id, spew.NewFormatter(spec))
 
 	// Grab any platform specific snapshotter opts.
-	sOpts := snapshotterOpts(c.config.ContainerdConfig.Snapshotter, config)
+	sOpts, err := snapshotterOpts(c.config.ContainerdConfig.Snapshotter, config)
+	if err != nil {
+		return nil, err
+	}
 
 	// Set snapshotter before any other options.
 	opts := []containerd.NewContainerOpts{

--- a/pkg/cri/server/container_create_linux.go
+++ b/pkg/cri/server/container_create_linux.go
@@ -602,15 +602,15 @@ func generateUserString(username string, uid, gid *runtime.Int64Value) (string, 
 
 // snapshotterOpts returns any Linux specific snapshotter options for the rootfs snapshot
 func snapshotterOpts(snapshotterName string, config *runtime.ContainerConfig) ([]snapshots.Opt, error) {
-			 nsOpts := config.GetLinux().GetSecurityContext().GetNamespaceOptions()
-       uids, gids, err := validateUserns(nsOpts.GetUsernsOptions())
-       if err != nil {
-               return nil, err
-       }
+	nsOpts := config.GetLinux().GetSecurityContext().GetNamespaceOptions()
+	uids, gids, err := validateUserns(nsOpts.GetUsernsOptions())
+	if err != nil {
+		return nil, err
+	}
 
-       snapshotOpt := []snapshots.Opt{}
-       if nsOpts.GetUsernsOptions() != nil && nsOpts.GetUsernsOptions().GetMode() == runtime.NamespaceMode_POD {
-               snapshotOpt = append(snapshotOpt, containerd.WithRemapperLabels(0, uids[0].HostID, 0, gids[0].HostID, uids[0].Size))
-       }
-       return snapshotOpt, nil
+	snapshotOpt := []snapshots.Opt{}
+	if nsOpts.GetUsernsOptions() != nil && nsOpts.GetUsernsOptions().GetMode() == runtime.NamespaceMode_POD {
+		snapshotOpt = append(snapshotOpt, containerd.WithRemapperLabels(0, uids[0].HostID, 0, gids[0].HostID, uids[0].Size))
+	}
+	return snapshotOpt, nil
 }

--- a/pkg/cri/server/container_create_linux.go
+++ b/pkg/cri/server/container_create_linux.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/containerd/cgroups"
+	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/contrib/apparmor"
 	"github.com/containerd/containerd/contrib/seccomp"
 	"github.com/containerd/containerd/oci"
@@ -600,6 +601,16 @@ func generateUserString(username string, uid, gid *runtime.Int64Value) (string, 
 }
 
 // snapshotterOpts returns any Linux specific snapshotter options for the rootfs snapshot
-func snapshotterOpts(snapshotterName string, config *runtime.ContainerConfig) []snapshots.Opt {
-	return []snapshots.Opt{}
+func snapshotterOpts(snapshotterName string, config *runtime.ContainerConfig) ([]snapshots.Opt, error) {
+			 nsOpts := config.GetLinux().GetSecurityContext().GetNamespaceOptions()
+       uids, gids, err := validateUserns(nsOpts.GetUsernsOptions())
+       if err != nil {
+               return nil, err
+       }
+
+       snapshotOpt := []snapshots.Opt{}
+       if nsOpts.GetUsernsOptions() != nil && nsOpts.GetUsernsOptions().GetMode() == runtime.NamespaceMode_POD {
+               snapshotOpt = append(snapshotOpt, containerd.WithRemapperLabels(0, uids[0].HostID, 0, gids[0].HostID, uids[0].Size))
+       }
+       return snapshotOpt, nil
 }

--- a/pkg/cri/server/container_create_other.go
+++ b/pkg/cri/server/container_create_other.go
@@ -56,6 +56,6 @@ func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageCon
 }
 
 // snapshotterOpts returns snapshotter options for the rootfs snapshot
-func snapshotterOpts(snapshotterName string, config *runtime.ContainerConfig) []snapshots.Opt {
-	return []snapshots.Opt{}
+func snapshotterOpts(snapshotterName string, config *runtime.ContainerConfig) ([]snapshots.Opt, error) {
+	return []snapshots.Opt{}, nil
 }

--- a/pkg/cri/server/container_create_windows.go
+++ b/pkg/cri/server/container_create_windows.go
@@ -144,7 +144,7 @@ func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageCon
 }
 
 // snapshotterOpts returns any Windows specific snapshotter options for the r/w layer
-func snapshotterOpts(snapshotterName string, config *runtime.ContainerConfig) []snapshots.Opt {
+func snapshotterOpts(snapshotterName string, config *runtime.ContainerConfig) ([]snapshots.Opt, error) {
 	var opts []snapshots.Opt
 
 	switch snapshotterName {
@@ -159,5 +159,5 @@ func snapshotterOpts(snapshotterName string, config *runtime.ContainerConfig) []
 		}
 	}
 
-	return opts
+	return opts, nil
 }

--- a/pkg/cri/server/helpers_linux.go
+++ b/pkg/cri/server/helpers_linux.go
@@ -277,85 +277,85 @@ func modifyProcessLabel(runtimeType string, spec *specs.Spec) error {
 }
 
 func parseUsernsIDs(runtimeIDMap []*runtime.IDMapping) ([]specs.LinuxIDMapping, error) {
-       var m []specs.LinuxIDMapping
+	var m []specs.LinuxIDMapping
 
-       if len(runtimeIDMap) == 0 {
-               return m, nil
-       }
+	if len(runtimeIDMap) == 0 {
+		return m, nil
+	}
 
-       if len(runtimeIDMap) > 1 {
-               // We only accept 1 line, because containerd.WithRemappedSnapshot() only supports that.
-               return m, fmt.Errorf("only one mapping line supported, got %v mapping lines", len(runtimeIDMap))
-       }
+	if len(runtimeIDMap) > 1 {
+		// We only accept 1 line, because containerd.WithRemappedSnapshot() only supports that.
+		return m, fmt.Errorf("only one mapping line supported, got %v mapping lines", len(runtimeIDMap))
+	}
 
-       // We know len is 1 now.
-       if runtimeIDMap[0] == nil {
-               return m, nil
-       }
-       uidMap := *runtimeIDMap[0]
+	// We know len is 1 now.
+	if runtimeIDMap[0] == nil {
+		return m, nil
+	}
+	uidMap := *runtimeIDMap[0]
 
-       if uidMap.Length < 1 {
-               return m, fmt.Errorf("invalid mapping length: %v", uidMap.Length)
-       }
+	if uidMap.Length < 1 {
+		return m, fmt.Errorf("invalid mapping length: %v", uidMap.Length)
+	}
 
-       m = []specs.LinuxIDMapping{
-               specs.LinuxIDMapping{
-                       ContainerID: uidMap.ContainerId,
-                       HostID:      uidMap.HostId,
-                       Size:        uidMap.Length,
-               },
-       }
+	m = []specs.LinuxIDMapping{
+		{
+			ContainerID: uidMap.ContainerId,
+			HostID:      uidMap.HostId,
+			Size:        uidMap.Length,
+		},
+	}
 
-       return m, nil
+	return m, nil
 }
 
 func parseUsernsAllIDs(UIDMap, GIDMap []*runtime.IDMapping) (uids, gids []specs.LinuxIDMapping, err error) {
-       if uids, err = parseUsernsIDs(UIDMap); err != nil {
-               err = fmt.Errorf("UID mapping: %w", err)
-               return
-       }
+	if uids, err = parseUsernsIDs(UIDMap); err != nil {
+		err = fmt.Errorf("UID mapping: %w", err)
+		return
+	}
 
-       if gids, err = parseUsernsIDs(GIDMap); err != nil {
-               err = fmt.Errorf("GID mapping: %w", err)
-               return
-       }
+	if gids, err = parseUsernsIDs(GIDMap); err != nil {
+		err = fmt.Errorf("GID mapping: %w", err)
+		return
+	}
 
-       return
+	return
 }
 
 func validateUserns(userns *runtime.UserNamespace) (retUids, retGids []specs.LinuxIDMapping, retErr error) {
-       if userns == nil {
-               // If userns is not set, the kubelet doesn't support this option
-               // and we should just fallback to no userns. This is completely
-               // valid.
-               return
-       }
+	if userns == nil {
+		// If userns is not set, the kubelet doesn't support this option
+		// and we should just fallback to no userns. This is completely
+		// valid.
+		return
+	}
 
-       uidRuntimeMap := userns.GetUids()
-       gidRuntimeMap := userns.GetGids()
+	uidRuntimeMap := userns.GetUids()
+	gidRuntimeMap := userns.GetGids()
 
-       uids, gids, err := parseUsernsAllIDs(uidRuntimeMap, gidRuntimeMap)
-       if err != nil {
-               retErr = fmt.Errorf("failed to parse user namespace mappings: %w", err)
-               return
-       }
+	uids, gids, err := parseUsernsAllIDs(uidRuntimeMap, gidRuntimeMap)
+	if err != nil {
+		retErr = fmt.Errorf("failed to parse user namespace mappings: %w", err)
+		return
+	}
 
-       switch mode := userns.GetMode(); mode {
-       case runtime.NamespaceMode_NODE:
-               if len(uids) != 0 || len(gids) != 0 {
-                       retErr = fmt.Errorf("can't use user namespace mode %q with mappings. Got %v UID mappings and %v GID mappings", mode, len(uids), len(gids))
-                       return
-               }
-       case runtime.NamespaceMode_POD:
-               // This is valid, we will handle it in WithPodNamespaces().
-               if len(uids) == 0 || len(gids) == 0 {
-                       retErr = fmt.Errorf("can't use user namespace mode %q without mappings", mode)
-                       return
-               }
-       default:
-               retErr = fmt.Errorf("unsupported user namespace mode: %q", mode)
-               return
-       }
+	switch mode := userns.GetMode(); mode {
+	case runtime.NamespaceMode_NODE:
+		if len(uids) != 0 || len(gids) != 0 {
+			retErr = fmt.Errorf("can't use user namespace mode %q with mappings. Got %v UID mappings and %v GID mappings", mode, len(uids), len(gids))
+			return
+		}
+	case runtime.NamespaceMode_POD:
+		// This is valid, we will handle it in WithPodNamespaces().
+		if len(uids) == 0 || len(gids) == 0 {
+			retErr = fmt.Errorf("can't use user namespace mode %q without mappings", mode)
+			return
+		}
+	default:
+		retErr = fmt.Errorf("unsupported user namespace mode: %q", mode)
+		return
+	}
 
-       return uids, gids, nil
+	return uids, gids, nil
 }

--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -209,10 +209,17 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate runtime options: %w", err)
 	}
-	snapshotterOpt := snapshots.WithLabels(snapshots.FilterInheritedLabels(config.Annotations))
+
+	sOpts := []snapshots.Opt{snapshots.WithLabels(snapshots.FilterInheritedLabels(config.Annotations))}
+	extraSOpts, err := sandboxSnapshotterOpts(config)
+	if err != nil {
+		return nil, err
+	}
+	sOpts = append(sOpts, extraSOpts...)
+
 	opts := []containerd.NewContainerOpts{
 		containerd.WithSnapshotter(c.runtimeSnapshotter(ctx, ociRuntime)),
-		customopts.WithNewSnapshot(id, containerdImage, snapshotterOpt),
+		customopts.WithNewSnapshot(id, containerdImage, sOpts...),
 		containerd.WithSpec(spec, specOpts...),
 		containerd.WithContainerLabels(sandboxLabels),
 		containerd.WithContainerExtension(sandboxMetadataExtension, &sandbox.Metadata),

--- a/pkg/cri/server/sandbox_run_other.go
+++ b/pkg/cri/server/sandbox_run_other.go
@@ -22,6 +22,7 @@ package server
 import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
+	"github.com/containerd/containerd/snapshots"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -53,4 +54,10 @@ func (c *criService) cleanupSandboxFiles(id string, config *runtime.PodSandboxCo
 // taskOpts generates task options for a (sandbox) container.
 func (c *criService) taskOpts(runtimeType string) []containerd.NewTaskOpts {
 	return []containerd.NewTaskOpts{}
+}
+
+// sandboxSnapshotterOpts generates any platform specific snapshotter options
+// for a sandbox container.
+func sandboxSnapshotterOpts(config *runtime.PodSandboxConfig) ([]snapshots.Opt, error) {
+	return []snapshots.Opt{}, nil
 }

--- a/pkg/cri/server/sandbox_run_windows.go
+++ b/pkg/cri/server/sandbox_run_windows.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
+	"github.com/containerd/containerd/snapshots"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -110,4 +111,9 @@ func (c *criService) cleanupSandboxFiles(id string, config *runtime.PodSandboxCo
 // No task options needed for windows.
 func (c *criService) taskOpts(runtimeType string) []containerd.NewTaskOpts {
 	return nil
+}
+
+// No sandbox snapshotter options needed for windows.
+func sandboxSnapshotterOpts(config *runtime.PodSandboxConfig) ([]snapshots.Opt, error) {
+	return []snapshots.Opt{}, nil
 }

--- a/snapshotter_opts_unix.go
+++ b/snapshotter_opts_unix.go
@@ -20,9 +20,15 @@
 package containerd
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/containerd/containerd/snapshots"
+)
+
+const (
+	labelSnapshotUidMapping = "containerd.io/snapshot/uidmapping"
+	labelSnapshotGidMapping = "containerd.io/snapshot/gidmapping"
 )
 
 // WithRemapperLabels creates the labels used by any supporting snapshotter
@@ -30,7 +36,77 @@ import (
 // supported by the fuse-overlayfs snapshotter
 func WithRemapperLabels(ctrUID, hostUID, ctrGID, hostGID, length uint32) snapshots.Opt {
 	return snapshots.WithLabels(map[string]string{
-		"containerd.io/snapshot/uidmapping": fmt.Sprintf("%d:%d:%d", ctrUID, hostUID, length),
-		"containerd.io/snapshot/gidmapping": fmt.Sprintf("%d:%d:%d", ctrGID, hostGID, length),
-	})
+		labelSnapshotUidMapping: fmt.Sprintf("%d:%d:%d", ctrUID, hostUID, length),
+		labelSnapshotGidMapping: fmt.Sprintf("%d:%d:%d", ctrGID, hostGID, length)})
+}
+
+func resolveSnapshotOptions(ctx context.Context, client *Client, snapshotterName string, snapshotter snapshots.Snapshotter, parent string, opts ...snapshots.Opt) (string, error) {
+	capabs, err := client.GetSnapshotterCapabilities(ctx, snapshotterName)
+	if err != nil {
+		return "", err
+	}
+
+	for _, capab := range capabs {
+		if capab == "remap-ids" {
+			// Snapshotter supports ID remapping, we don't need to do anything.
+			return parent, nil
+		}
+	}
+
+	var local snapshots.Info
+	for _, opt := range opts {
+		opt(&local)
+	}
+
+	needsRemap := false
+	var uidMap, gidMap string
+
+	if value, ok := local.Labels[labelSnapshotUidMapping]; ok {
+		needsRemap = true
+		uidMap = value
+	}
+	if value, ok := local.Labels[labelSnapshotGidMapping]; ok {
+		needsRemap = true
+		gidMap = value
+	}
+
+	if !needsRemap {
+		return parent, nil
+	}
+
+	var ctrUID, hostUID, length uint32
+	_, err = fmt.Sscanf(uidMap, "%d:%d:%d", &ctrUID, &hostUID, &length)
+	if err != nil {
+		return "", fmt.Errorf("uidMap unparsable: %w")
+	}
+
+	var ctrGID, hostGID, lengthGID uint32
+	_, err = fmt.Sscanf(gidMap, "%d:%d:%d", &ctrGID, &hostGID, &lengthGID)
+	if err != nil {
+		return "", fmt.Errorf("gidMap unparsable: %w")
+	}
+
+	if ctrUID != 0 || ctrGID != 0 {
+		return "", fmt.Errorf("Container UID/GID of 0 only supported currently (%d/%d)", ctrUID, ctrGID)
+	}
+
+	// TODO(dgl): length isn't taken into account for the intermediate snapshot id.
+	usernsID := fmt.Sprintf("%s-%d-%d", parent, hostUID, hostGID)
+	if _, err := snapshotter.Stat(ctx, usernsID); err == nil {
+		return usernsID, nil
+	}
+	mounts, err := snapshotter.Prepare(ctx, usernsID+"-remap", parent)
+	if err != nil {
+		return "", err
+	}
+	// TODO(dgl): length isn't taken into account here yet either.
+	if err := remapRootFS(ctx, mounts, hostUID, hostGID); err != nil {
+		snapshotter.Remove(ctx, usernsID+"-remap")
+		return "", err
+	}
+	if err := snapshotter.Commit(ctx, usernsID, usernsID+"-remap"); err != nil {
+		return "", err
+	}
+
+	return usernsID, nil
 }

--- a/snapshotter_opts_unix.go
+++ b/snapshotter_opts_unix.go
@@ -27,8 +27,8 @@ import (
 )
 
 const (
-	labelSnapshotUidMapping = "containerd.io/snapshot/uidmapping"
-	labelSnapshotGidMapping = "containerd.io/snapshot/gidmapping"
+	labelSnapshotUIDMapping = "containerd.io/snapshot/uidmapping"
+	labelSnapshotGIDMapping = "containerd.io/snapshot/gidmapping"
 )
 
 // WithRemapperLabels creates the labels used by any supporting snapshotter
@@ -36,8 +36,8 @@ const (
 // supported by the fuse-overlayfs snapshotter
 func WithRemapperLabels(ctrUID, hostUID, ctrGID, hostGID, length uint32) snapshots.Opt {
 	return snapshots.WithLabels(map[string]string{
-		labelSnapshotUidMapping: fmt.Sprintf("%d:%d:%d", ctrUID, hostUID, length),
-		labelSnapshotGidMapping: fmt.Sprintf("%d:%d:%d", ctrGID, hostGID, length)})
+		labelSnapshotUIDMapping: fmt.Sprintf("%d:%d:%d", ctrUID, hostUID, length),
+		labelSnapshotGIDMapping: fmt.Sprintf("%d:%d:%d", ctrGID, hostGID, length)})
 }
 
 func resolveSnapshotOptions(ctx context.Context, client *Client, snapshotterName string, snapshotter snapshots.Snapshotter, parent string, opts ...snapshots.Opt) (string, error) {
@@ -61,11 +61,11 @@ func resolveSnapshotOptions(ctx context.Context, client *Client, snapshotterName
 	needsRemap := false
 	var uidMap, gidMap string
 
-	if value, ok := local.Labels[labelSnapshotUidMapping]; ok {
+	if value, ok := local.Labels[labelSnapshotUIDMapping]; ok {
 		needsRemap = true
 		uidMap = value
 	}
-	if value, ok := local.Labels[labelSnapshotGidMapping]; ok {
+	if value, ok := local.Labels[labelSnapshotGIDMapping]; ok {
 		needsRemap = true
 		gidMap = value
 	}
@@ -77,13 +77,13 @@ func resolveSnapshotOptions(ctx context.Context, client *Client, snapshotterName
 	var ctrUID, hostUID, length uint32
 	_, err = fmt.Sscanf(uidMap, "%d:%d:%d", &ctrUID, &hostUID, &length)
 	if err != nil {
-		return "", fmt.Errorf("uidMap unparsable: %w")
+		return "", fmt.Errorf("uidMap unparsable: %w", err)
 	}
 
 	var ctrGID, hostGID, lengthGID uint32
 	_, err = fmt.Sscanf(gidMap, "%d:%d:%d", &ctrGID, &hostGID, &lengthGID)
 	if err != nil {
-		return "", fmt.Errorf("gidMap unparsable: %w")
+		return "", fmt.Errorf("gidMap unparsable: %w", err)
 	}
 
 	if ctrUID != 0 || ctrGID != 0 {

--- a/snapshotter_opts_windows.go
+++ b/snapshotter_opts_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+// +build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package containerd
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/snapshots"
+)
+
+func resolveSnapshotOptions(ctx context.Context, client *Client, snapshotterName string, snapshotter snapshots.Snapshotter, parent string, opts ...snapshots.Opt) (string, error) {
+	return parent, nil
+}


### PR DESCRIPTION
I'm opening this as a draft, this is part of the needed support for user namespaces with Kubernetes. It lacks tests and general polish.

I've discussed this approach with @rata, it uses the existing labels used by fuse-overlayfs and makes them more general by adding a capability "remap-ids", I would like some initial thoughts on the idea.

Snapshotters would implement the capability, potentially conditionally (e.g. overlayfs would only return it if running on Linux >= 5.19).

cc @AkihiroSuda for fuse-overlayfs and @artqzn for pending PRs on related overlayfs parts.