### PR TITLE
plugin: remove go < 1.8 stub, enable on windows and arm64

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -138,7 +138,11 @@ var register = struct {
 	r []*Registration
 }{}
 
-// Load loads all plugins at the provided path into containerd
+// Load loads all plugins at the provided path into containerd.
+//
+// Load is currently only implemented on non-static, non-gccgo builds for amd64
+// and arm64, and plugins must be built with the exact same version of Go as
+// containerd itself.
 func Load(path string) (err error) {
 	defer func() {
 		if v := recover(); v != nil {

--- a/plugin/plugin_supported.go
+++ b/plugin/plugin_supported.go
@@ -1,4 +1,4 @@
-//go:build go1.8 && !windows && amd64 && !static_build && !gccgo
+//go:build (amd64 || arm64) && !static_build && !gccgo
 
 /*
    Copyright The containerd Authors.

--- a/plugin/plugin_unsupported.go
+++ b/plugin/plugin_unsupported.go
@@ -1,4 +1,4 @@
-//go:build !go1.8 || windows || !amd64 || static_build || gccgo
+//go:build (!amd64 && !arm64) || static_build || gccgo
 
 /*
    Copyright The containerd Authors.
@@ -18,7 +18,11 @@
 
 package plugin
 
+// loadPlugins is not supported;
+//
+// - with gccgo: gccgo has no plugin support golang/go#36403
+// - on static builds; https://github.com/containerd/containerd/commit/0d682e24a1ba8e93e5e54a73d64f7d256f87492f
+// - on architectures other than amd64 and arm64 (other architectures need to be tested)
 func loadPlugins(path string) error {
-	// plugins not supported until 1.8
 	return nil
 }


### PR DESCRIPTION
- updates https://github.com/containerd/containerd/issues/563

**Disclaimer: not 100% if we want all of these changes; I started this branch because I wanted to remove the Go 1.8 stub, but it turned out to be more complicated than that (see below)**; decided to push it as a branch either way for consideration.

- we don't support go < 1.8. this restriction as added because plugin support  requires go 1.8 or up, but with such old versions being EOL, this check was   rather redundant
- add back arm64 support; in 6bd0710831cb0796e903b7e9e41ca33214913620 (https://github.com/containerd/containerd/pull/645), non-amd64 was disabled, pending golang/go#17138, which was tracking arm64 support, and  is now resolved. It's unclear if architectures other than amd64 and arm64 are  supported, so keeping it restricted to amd64 and arm64.
- enable plugin support on Windows; it was disabled in 0b44e24c073a3abb8953cd9e3fafcaa045d7e2f1 (https://github.com/containerd/containerd/pull/608) but the code looks to take windows into account.
