### PR TITLE
containerd: promethus metrics could be partially supported

### DIFF
--- a/services/server/config/config.go
+++ b/services/server/config/config.go
@@ -153,8 +153,9 @@ type Debug struct {
 
 // MetricsConfig provides metrics configuration
 type MetricsConfig struct {
-	Address       string `toml:"address"`
-	GRPCHistogram bool   `toml:"grpc_histogram"`
+	Address              string `toml:"address"`
+	GRPCHistogram        bool   `toml:"grpc_histogram"`
+	ContainerMetricsOnly bool   `toml:"container_metrics_only"`
 }
 
 // CgroupConfig provides cgroup configuration

--- a/vendor/github.com/prometheus/client_golang/prometheus/collectors/collectors.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/collectors/collectors.go
@@ -1,0 +1,16 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package collectors provides implementations of prometheus.Collector to
+// conveniently collect process and Go-related metrics.
+package collectors

--- a/vendor/github.com/prometheus/client_golang/prometheus/collectors/dbstats_collector.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/collectors/dbstats_collector.go
@@ -1,0 +1,119 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collectors
+
+import (
+	"database/sql"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type dbStatsCollector struct {
+	db *sql.DB
+
+	maxOpenConnections *prometheus.Desc
+
+	openConnections  *prometheus.Desc
+	inUseConnections *prometheus.Desc
+	idleConnections  *prometheus.Desc
+
+	waitCount         *prometheus.Desc
+	waitDuration      *prometheus.Desc
+	maxIdleClosed     *prometheus.Desc
+	maxIdleTimeClosed *prometheus.Desc
+	maxLifetimeClosed *prometheus.Desc
+}
+
+// NewDBStatsCollector returns a collector that exports metrics about the given *sql.DB.
+// See https://golang.org/pkg/database/sql/#DBStats for more information on stats.
+func NewDBStatsCollector(db *sql.DB, dbName string) prometheus.Collector {
+	fqName := func(name string) string {
+		return "go_sql_" + name
+	}
+	return &dbStatsCollector{
+		db: db,
+		maxOpenConnections: prometheus.NewDesc(
+			fqName("max_open_connections"),
+			"Maximum number of open connections to the database.",
+			nil, prometheus.Labels{"db_name": dbName},
+		),
+		openConnections: prometheus.NewDesc(
+			fqName("open_connections"),
+			"The number of established connections both in use and idle.",
+			nil, prometheus.Labels{"db_name": dbName},
+		),
+		inUseConnections: prometheus.NewDesc(
+			fqName("in_use_connections"),
+			"The number of connections currently in use.",
+			nil, prometheus.Labels{"db_name": dbName},
+		),
+		idleConnections: prometheus.NewDesc(
+			fqName("idle_connections"),
+			"The number of idle connections.",
+			nil, prometheus.Labels{"db_name": dbName},
+		),
+		waitCount: prometheus.NewDesc(
+			fqName("wait_count_total"),
+			"The total number of connections waited for.",
+			nil, prometheus.Labels{"db_name": dbName},
+		),
+		waitDuration: prometheus.NewDesc(
+			fqName("wait_duration_seconds_total"),
+			"The total time blocked waiting for a new connection.",
+			nil, prometheus.Labels{"db_name": dbName},
+		),
+		maxIdleClosed: prometheus.NewDesc(
+			fqName("max_idle_closed_total"),
+			"The total number of connections closed due to SetMaxIdleConns.",
+			nil, prometheus.Labels{"db_name": dbName},
+		),
+		maxIdleTimeClosed: prometheus.NewDesc(
+			fqName("max_idle_time_closed_total"),
+			"The total number of connections closed due to SetConnMaxIdleTime.",
+			nil, prometheus.Labels{"db_name": dbName},
+		),
+		maxLifetimeClosed: prometheus.NewDesc(
+			fqName("max_lifetime_closed_total"),
+			"The total number of connections closed due to SetConnMaxLifetime.",
+			nil, prometheus.Labels{"db_name": dbName},
+		),
+	}
+}
+
+// Describe implements Collector.
+func (c *dbStatsCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.maxOpenConnections
+	ch <- c.openConnections
+	ch <- c.inUseConnections
+	ch <- c.idleConnections
+	ch <- c.waitCount
+	ch <- c.waitDuration
+	ch <- c.maxIdleClosed
+	ch <- c.maxLifetimeClosed
+	c.describeNewInGo115(ch)
+}
+
+// Collect implements Collector.
+func (c *dbStatsCollector) Collect(ch chan<- prometheus.Metric) {
+	stats := c.db.Stats()
+	ch <- prometheus.MustNewConstMetric(c.maxOpenConnections, prometheus.GaugeValue, float64(stats.MaxOpenConnections))
+	ch <- prometheus.MustNewConstMetric(c.openConnections, prometheus.GaugeValue, float64(stats.OpenConnections))
+	ch <- prometheus.MustNewConstMetric(c.inUseConnections, prometheus.GaugeValue, float64(stats.InUse))
+	ch <- prometheus.MustNewConstMetric(c.idleConnections, prometheus.GaugeValue, float64(stats.Idle))
+	ch <- prometheus.MustNewConstMetric(c.waitCount, prometheus.CounterValue, float64(stats.WaitCount))
+	ch <- prometheus.MustNewConstMetric(c.waitDuration, prometheus.CounterValue, stats.WaitDuration.Seconds())
+	ch <- prometheus.MustNewConstMetric(c.maxIdleClosed, prometheus.CounterValue, float64(stats.MaxIdleClosed))
+	ch <- prometheus.MustNewConstMetric(c.maxLifetimeClosed, prometheus.CounterValue, float64(stats.MaxLifetimeClosed))
+	c.collectNewInGo115(ch, stats)
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/collectors/dbstats_collector_go115.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/collectors/dbstats_collector_go115.go
@@ -1,0 +1,31 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build go1.15
+// +build go1.15
+
+package collectors
+
+import (
+	"database/sql"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func (c *dbStatsCollector) describeNewInGo115(ch chan<- *prometheus.Desc) {
+	ch <- c.maxIdleTimeClosed
+}
+
+func (c *dbStatsCollector) collectNewInGo115(ch chan<- prometheus.Metric, stats sql.DBStats) {
+	ch <- prometheus.MustNewConstMetric(c.maxIdleTimeClosed, prometheus.CounterValue, float64(stats.MaxIdleTimeClosed))
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/collectors/dbstats_collector_pre_go115.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/collectors/dbstats_collector_pre_go115.go
@@ -1,0 +1,27 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !go1.15
+// +build !go1.15
+
+package collectors
+
+import (
+	"database/sql"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func (c *dbStatsCollector) describeNewInGo115(ch chan<- *prometheus.Desc) {}
+
+func (c *dbStatsCollector) collectNewInGo115(ch chan<- prometheus.Metric, stats sql.DBStats) {}

--- a/vendor/github.com/prometheus/client_golang/prometheus/collectors/expvar_collector.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/collectors/expvar_collector.go
@@ -1,0 +1,57 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collectors
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// NewExpvarCollector returns a newly allocated expvar Collector.
+//
+// An expvar Collector collects metrics from the expvar interface. It provides a
+// quick way to expose numeric values that are already exported via expvar as
+// Prometheus metrics. Note that the data models of expvar and Prometheus are
+// fundamentally different, and that the expvar Collector is inherently slower
+// than native Prometheus metrics. Thus, the expvar Collector is probably great
+// for experiments and prototying, but you should seriously consider a more
+// direct implementation of Prometheus metrics for monitoring production
+// systems.
+//
+// The exports map has the following meaning:
+//
+// The keys in the map correspond to expvar keys, i.e. for every expvar key you
+// want to export as Prometheus metric, you need an entry in the exports
+// map. The descriptor mapped to each key describes how to export the expvar
+// value. It defines the name and the help string of the Prometheus metric
+// proxying the expvar value. The type will always be Untyped.
+//
+// For descriptors without variable labels, the expvar value must be a number or
+// a bool. The number is then directly exported as the Prometheus sample
+// value. (For a bool, 'false' translates to 0 and 'true' to 1). Expvar values
+// that are not numbers or bools are silently ignored.
+//
+// If the descriptor has one variable label, the expvar value must be an expvar
+// map. The keys in the expvar map become the various values of the one
+// Prometheus label. The values in the expvar map must be numbers or bools again
+// as above.
+//
+// For descriptors with more than one variable label, the expvar must be a
+// nested expvar map, i.e. where the values of the topmost map are maps again
+// etc. until a depth is reached that corresponds to the number of labels. The
+// leaves of that structure must be numbers or bools as above to serve as the
+// sample values.
+//
+// Anything that does not fit into the scheme above is silently ignored.
+func NewExpvarCollector(exports map[string]*prometheus.Desc) prometheus.Collector {
+	//nolint:staticcheck // Ignore SA1019 until v2.
+	return prometheus.NewExpvarCollector(exports)
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/collectors/go_collector.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/collectors/go_collector.go
@@ -1,0 +1,69 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collectors
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// NewGoCollector returns a collector that exports metrics about the current Go
+// process. This includes memory stats. To collect those, runtime.ReadMemStats
+// is called. This requires to “stop the world”, which usually only happens for
+// garbage collection (GC). Take the following implications into account when
+// deciding whether to use the Go collector:
+//
+// 1. The performance impact of stopping the world is the more relevant the more
+// frequently metrics are collected. However, with Go1.9 or later the
+// stop-the-world time per metrics collection is very short (~25µs) so that the
+// performance impact will only matter in rare cases. However, with older Go
+// versions, the stop-the-world duration depends on the heap size and can be
+// quite significant (~1.7 ms/GiB as per
+// https://go-review.googlesource.com/c/go/+/34937).
+//
+// 2. During an ongoing GC, nothing else can stop the world. Therefore, if the
+// metrics collection happens to coincide with GC, it will only complete after
+// GC has finished. Usually, GC is fast enough to not cause problems. However,
+// with a very large heap, GC might take multiple seconds, which is enough to
+// cause scrape timeouts in common setups. To avoid this problem, the Go
+// collector will use the memstats from a previous collection if
+// runtime.ReadMemStats takes more than 1s. However, if there are no previously
+// collected memstats, or their collection is more than 5m ago, the collection
+// will block until runtime.ReadMemStats succeeds.
+//
+// NOTE: The problem is solved in Go 1.15, see
+// https://github.com/golang/go/issues/19812 for the related Go issue.
+func NewGoCollector() prometheus.Collector {
+	//nolint:staticcheck // Ignore SA1019 until v2.
+	return prometheus.NewGoCollector()
+}
+
+// NewBuildInfoCollector returns a collector collecting a single metric
+// "go_build_info" with the constant value 1 and three labels "path", "version",
+// and "checksum". Their label values contain the main module path, version, and
+// checksum, respectively. The labels will only have meaningful values if the
+// binary is built with Go module support and from source code retrieved from
+// the source repository (rather than the local file system). This is usually
+// accomplished by building from outside of GOPATH, specifying the full address
+// of the main package, e.g. "GO111MODULE=on go run
+// github.com/prometheus/client_golang/examples/random". If built without Go
+// module support, all label values will be "unknown". If built with Go module
+// support but using the source code from the local file system, the "path" will
+// be set appropriately, but "checksum" will be empty and "version" will be
+// "(devel)".
+//
+// This collector uses only the build information for the main module. See
+// https://github.com/povilasv/prommod for an example of a collector for the
+// module dependencies.
+func NewBuildInfoCollector() prometheus.Collector {
+	//nolint:staticcheck // Ignore SA1019 until v2.
+	return prometheus.NewBuildInfoCollector()
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/collectors/process_collector.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/collectors/process_collector.go
@@ -1,0 +1,56 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collectors
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// ProcessCollectorOpts defines the behavior of a process metrics collector
+// created with NewProcessCollector.
+type ProcessCollectorOpts struct {
+	// PidFn returns the PID of the process the collector collects metrics
+	// for. It is called upon each collection. By default, the PID of the
+	// current process is used, as determined on construction time by
+	// calling os.Getpid().
+	PidFn func() (int, error)
+	// If non-empty, each of the collected metrics is prefixed by the
+	// provided string and an underscore ("_").
+	Namespace string
+	// If true, any error encountered during collection is reported as an
+	// invalid metric (see NewInvalidMetric). Otherwise, errors are ignored
+	// and the collected metrics will be incomplete. (Possibly, no metrics
+	// will be collected at all.) While that's usually not desired, it is
+	// appropriate for the common "mix-in" of process metrics, where process
+	// metrics are nice to have, but failing to collect them should not
+	// disrupt the collection of the remaining metrics.
+	ReportErrors bool
+}
+
+// NewProcessCollector returns a collector which exports the current state of
+// process metrics including CPU, memory and file descriptor usage as well as
+// the process start time. The detailed behavior is defined by the provided
+// ProcessCollectorOpts. The zero value of ProcessCollectorOpts creates a
+// collector for the current process with an empty namespace string and no error
+// reporting.
+//
+// The collector only works on operating systems with a Linux-style proc
+// filesystem and on Microsoft Windows. On other operating systems, it will not
+// collect any metrics.
+func NewProcessCollector(opts ProcessCollectorOpts) prometheus.Collector {
+	//nolint:staticcheck // Ignore SA1019 until v2.
+	return prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{
+		PidFn:        opts.PidFn,
+		Namespace:    opts.Namespace,
+		ReportErrors: opts.ReportErrors,
+	})
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -352,6 +352,7 @@ github.com/pmezard/go-difflib/difflib
 # github.com/prometheus/client_golang v1.12.1
 ## explicit; go 1.13
 github.com/prometheus/client_golang/prometheus
+github.com/prometheus/client_golang/prometheus/collectors
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp
 # github.com/prometheus/client_model v0.2.0


### PR DESCRIPTION
simplify the containerd metrics api, ignore some truffle messages to focus on containers' metric statics

Signed-off-by: Miao Xia <xia.miao1@zte.com.cn>