### PR TITLE
script/setup: handle cnidir with SUDO

### DIFF
--- a/script/setup/install-cni
+++ b/script/setup/install-cni
@@ -36,8 +36,8 @@ git clone https://github.com/containernetworking/plugins.git "${TMPROOT}"/plugin
 pushd "${TMPROOT}"/plugins
 git checkout "$CNI_COMMIT"
 ./build_linux.sh
-mkdir -p $CNI_DIR
-cp -r ./bin $CNI_DIR
+$SUDO mkdir -p $CNI_DIR
+$SUDO cp -r ./bin $CNI_DIR
 $SUDO mkdir -p $CNI_CONFIG_DIR
 $SUDO cat << EOF | $SUDO tee $CNI_CONFIG_DIR/10-containerd-net.conflist
 {


### PR DESCRIPTION
The dir related to CNI should be handled with sudo if EUID != 0.

Follow-up: 8add7e5d39

Signed-off-by: Wei Fu <fuweid89@gmail.com>