### PR TITLE
Add kubernetes v1.25 supported version as v1.24

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -124,6 +124,7 @@ of containerd for every supported version of Kubernetes.
 | 1.22               | 1.5.5+             | v1alpha2     |
 | 1.23               | 1.6.0+, 1,5.8+     | v1, v1alpha2 |
 | 1.24               | 1.6.4+, 1.5.11+    | v1, v1alpha2 |
+| 1.25               | 1.6.4+, 1.5.11+    | v1, v1alpha2 |
 
 Deprecated containerd and kubernetes versions
 


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/releases/v1.25.0

There seems to be no containerd related change

CRI changes are like below(v1.25 with v1.24):
- in-place resource update https://github.com/kubernetes/kubernetes/pull/111645 
- evented PLEG https://github.com/kubernetes/kubernetes/pull/111642
- user namespace https://github.com/kubernetes/kubernetes/pull/110535
- checkpoint support https://github.com/kubernetes/kubernetes/pull/104907

**containerd v1.6.8** is using **cri-api v0.23.1** that is same as **containerd v1.6.4**