### PR TITLE
mount: remove unused ErrNotImplementOnWindows

### DIFF
--- a/mount/mount_windows.go
+++ b/mount/mount_windows.go
@@ -18,18 +18,12 @@ package mount
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/Microsoft/hcsshim"
-)
-
-var (
-	// ErrNotImplementOnWindows is returned when an action is not implemented for windows
-	ErrNotImplementOnWindows = errors.New("not implemented under windows")
 )
 
 // Mount to the provided target


### PR DESCRIPTION
This error was added in c5843b761596564ba05f1a7f7b70c2368baf93ab (https://github.com/containerd/containerd/pull/700), but no longer used since a5a9f91832f9f414a24626173ad5471df3abdb27 (https://github.com/containerd/containerd/pull/1969), which implemented Windows support.
