### PR TITLE
remotes/docker: Don't reject blobs due to size

### DIFF
--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -367,7 +367,8 @@ func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocisp
 				size = bodyReader.bytesRead
 			}
 			// Prevent resolving to excessively large manifests
-			if size > MaxManifestSize {
+			isManifest := u[0] == "manifests"
+			if isManifest && size > MaxManifestSize {
 				if firstErr == nil {
 					firstErr = fmt.Errorf("rejecting %d byte manifest for %s: %w", size, ref, errdefs.ErrNotFound)
 				}


### PR DESCRIPTION
Resolve checks if the manifest size is below a reasonable maximum size.
This fixes a bug which makes the Resolve fail for blobs over 4MiB due to the check being performed even if the content is not a manifest.

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>