### PR TITLE
archive: replace tarName() with filepath.ToSlash()

### DIFF
--- a/archive/tar.go
+++ b/archive/tar.go
@@ -574,11 +574,9 @@ func (cw *ChangeWriter) HandleChange(k fs.ChangeKind, p string, f os.FileInfo, e
 				return fmt.Errorf("failed to make path relative: %w", err)
 			}
 		}
-		name, err = tarName(name)
-		if err != nil {
-			return fmt.Errorf("cannot canonicalize path: %w", err)
-		}
-		// suffix with '/' for directories
+		// Canonicalize to POSIX-style paths using forward slashes. Directory
+		// entries must end with a slash.
+		name = filepath.ToSlash(name)
 		if f.IsDir() && !strings.HasSuffix(name, "/") {
 			name += "/"
 		}

--- a/archive/tar_unix.go
+++ b/archive/tar_unix.go
@@ -34,10 +34,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func tarName(p string) (string, error) {
-	return p, nil
-}
-
 func chmodTarEntry(perm os.FileMode) os.FileMode {
 	return perm
 }

--- a/archive/tar_windows.go
+++ b/archive/tar_windows.go
@@ -26,21 +26,6 @@ import (
 	"github.com/containerd/containerd/sys"
 )
 
-// tarName returns platform-specific filepath
-// to canonical posix-style path for tar archival. p is relative
-// path.
-func tarName(p string) (string, error) {
-	// windows: convert windows style relative path with backslashes
-	// into forward slashes. Since windows does not allow '/' or '\'
-	// in file names, it is mostly safe to replace however we must
-	// check just in case
-	if strings.Contains(p, "/") {
-		return "", fmt.Errorf("windows path contains forward slash: %s", p)
-	}
-
-	return strings.Replace(p, string(os.PathSeparator), "/", -1), nil
-}
-
 // chmodTarEntry is used to adjust the file permissions used in tar header based
 // on the platform the archival is done.
 func chmodTarEntry(perm os.FileMode) os.FileMode {


### PR DESCRIPTION
This code was copied from github.com/moby/moby/pkg/archive; https://github.com/moby/moby/commit/28842d3f093e69cf62a090a532aacba1e6ff6d1c, which got later simplified in
https://github.com/moby/moby/commit/a5aed699cfaa4d84b1b134033fb468b3a7a874f0

This patch aligns the containerd implementation with those changes, and uses `filepath.ToSlash()` unconditionally on all platforms, as it's a no-op on platforms that use a forward-slash; https://github.com/golang/go/blob/go1.19/src/path/filepath/path.go#L175-L183
