### PR TITLE
Change merge strategy to preserve Plugins when importing Configs

### DIFF
--- a/cmd/containerd/command/config.go
+++ b/cmd/containerd/command/config.go
@@ -18,6 +18,7 @@ package command
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -34,6 +35,10 @@ import (
 )
 
 func outputConfig(ctx context.Context, config *srvconfig.Config) error {
+	return generateConfig(ctx, config, os.Stdout)
+}
+
+func generateConfig(ctx context.Context, config *srvconfig.Config, output io.Writer) error {
 	plugins, err := server.LoadPlugins(ctx, config)
 	if err != nil {
 		return err
@@ -66,13 +71,13 @@ func outputConfig(ctx context.Context, config *srvconfig.Config) error {
 		}
 	}
 
-	// for the time being, keep the defaultConfig's version set at 1 so that
+	// for the time being, keep the defaultConfig's version set at 3 so that
 	// when a config without a version is loaded from disk and has no version
-	// set, we assume it's a v1 config.  But when generating new configs via
+	// set, we assume it's a v3 config.  But when generating new configs via
 	// this command, generate the max configuration version
 	config.Version = version.ConfigVersion
 
-	return toml.NewEncoder(os.Stdout).SetIndentTables(true).Encode(config)
+	return toml.NewEncoder(output).SetIndentTables(true).Encode(config)
 }
 
 func defaultConfig() *srvconfig.Config {

--- a/cmd/containerd/command/config_test.go
+++ b/cmd/containerd/command/config_test.go
@@ -1,0 +1,167 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package command
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pelletier/go-toml/v2"
+
+	srvconfig "github.com/containerd/containerd/v2/cmd/containerd/server/config"
+	// without the following two includes the behavior of this unit test would be different
+	_ "github.com/containerd/containerd/v2/plugins/cri"
+	_ "github.com/containerd/containerd/v2/plugins/cri/runtime"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommandConfig(t *testing.T) {
+	// deprecated but still accepted at the time of writing
+	data1 := ` version = 2
+	[plugins."io.containerd.grpc.v1.runtime".registry.configs."registry-1.docker.io".auth]
+	 username = "my-username"
+	 password = "my-password"
+	`
+	// the old location, should not be accepted at all
+	data2 := ` version = 2
+	[plugins."io.containerd.grpc.v1.cri".registry.configs."registry-1.docker.io".auth]
+	 username = "should-not-be-present"
+	 password = "should-not-be-present"
+	`
+	data3 := `
+	[plugins."io.containerd.grpc.v1.runtime"]
+	 sandbox_image = "my-sandbox-image:1.0"
+	`
+	data4 := `
+	[plugins."io.containerd.grpc.v1.runtime".registry]
+	 config_path = "/my-custom-certs.d-config-path"
+	`
+	data5 := `
+	[plugins."io.containerd.grpc.v1.runtime".containerd.runtimes.runc]
+	 runtime_type = "io.containerd.runc.v2"
+	 [plugins."io.containerd.grpc.v1.runtime".containerd.runtimes.runc.options]
+	  SystemdCgroup = true
+	`
+	data6 := `
+	[plugins.'io.containerd.grpc.v1.cri'.cni]
+	 bin_dir = '/should-not-be-present'
+	 conf_dir = '/should-not-be-present'
+`
+	data7 := `
+	[plugins.'io.containerd.grpc.v1.runtime'.cni]
+	 bin_dir = '/custom-bin-dir'
+`
+	data8 := `
+	[plugins.'io.containerd.grpc.v1.runtime'.cni]
+	 conf_dir = '/custom-conf-dir'
+`
+	data9 := `
+	[plugins]
+	 [plugins."io.containerd.grpc.v1.runtime"]
+	   [plugins."io.containerd.grpc.v1.runtime".containerd]
+	     default_runtime_name = "nvidia"
+	     [plugins."io.containerd.grpc.v1.runtime".containerd.runtimes]
+	       [plugins."io.containerd.grpc.v1.runtime".containerd.runtimes.nvidia]
+	         privileged_without_host_devices = false
+	         runtime_type = "io.containerd.runc.v2"
+	         [plugins."io.containerd.grpc.v1.runtime".containerd.runtimes.nvidia.options]
+	           BinaryName = "/usr/bin/nvidia-container-runtime"
+	           SystemdCgroup = true
+	`
+	expectedRuntimes := `
+    [plugins.'io.containerd.grpc.v1.runtime'.containerd]
+      default_runtime_name = 'nvidia'
+
+      [plugins.'io.containerd.grpc.v1.runtime'.containerd.runtimes]
+        [plugins.'io.containerd.grpc.v1.runtime'.containerd.runtimes.nvidia]
+          privileged_without_host_devices = false
+          runtime_type = 'io.containerd.runc.v2'
+
+          [plugins.'io.containerd.grpc.v1.runtime'.containerd.runtimes.nvidia.options]
+            BinaryName = '/usr/bin/nvidia-container-runtime'
+            SystemdCgroup = true
+
+        [plugins.'io.containerd.grpc.v1.runtime'.containerd.runtimes.runc]
+          runtime_type = 'io.containerd.runc.v2'
+
+          [plugins.'io.containerd.grpc.v1.runtime'.containerd.runtimes.runc.options]
+            SystemdCgroup = true
+`
+	// currently we cannot invoke testMergeConfig() more than once, due to:
+	//  panic: io.containerd.content.v1.content: plugin: id already registered
+	asserts := []CheckAsserts{
+		{Expected: false, Value: "should-not-be-present"},
+		{Expected: true, Value: "/custom-bin-dir"},
+		{Expected: true, Value: "/custom-conf-dir"},
+		{Expected: true, Value: "my-username"},
+		{Expected: true, Value: "my-password"},
+		{Expected: true, Value: "my-sandbox-image:1.0"},
+		{Expected: true, Value: "my-sandbox-image:1.0"},
+		{Expected: true, Value: "/my-custom-certs.d-config-path"},
+		{Expected: true, Value: expectedRuntimes},
+	}
+	testMergeConfig(t, []string{data1, data2, data3, data4, data5, data6, data7, data8, data9}, asserts)
+}
+
+type CheckAsserts struct {
+	Expected bool
+	Value    string
+}
+
+func testMergeConfig(t *testing.T, inputs []string, asserts []CheckAsserts) {
+	tempDir := t.TempDir()
+	var result srvconfig.Config
+
+	for i, data := range inputs {
+		// write input to a file on disk
+		inputFilePath := filepath.Join(tempDir, fmt.Sprintf("data%d.toml", i+1))
+		err := os.WriteFile(inputFilePath, []byte(data), 0600)
+		assert.NoError(t, err)
+
+		// append it to the main config as an import statement
+		result.Imports = append(result.Imports, inputFilePath)
+	}
+
+	// now write the main config file that imports all written files so far
+	mainFilepath := filepath.Join(tempDir, "containerd.toml")
+	resultString, err := toml.Marshal(result)
+	assert.NoError(t, err)
+	err = os.WriteFile(mainFilepath, resultString, 0600)
+	assert.NoError(t, err)
+
+	// now load this config, and see if all the imports results in what we expect
+	config := defaultConfig()
+	ctx := context.Background()
+	err = srvconfig.LoadConfig(ctx, mainFilepath, config)
+	assert.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = generateConfig(ctx, config, &buf)
+	assert.NoError(t, err)
+
+	for _, item := range asserts {
+		if item.Expected {
+			assert.Contains(t, buf.String(), item.Value)
+		} else {
+			assert.NotContains(t, buf.String(), item.Value)
+		}
+	}
+}

--- a/cmd/containerd/server/config/config.go
+++ b/cmd/containerd/server/config/config.go
@@ -412,10 +412,6 @@ func mergeConfig(to, from *Config) error {
 	}
 
 	// Replace entire sections instead of merging map's values.
-	for k, v := range from.Plugins {
-		to.Plugins[k] = v
-	}
-
 	for k, v := range from.StreamProcessors {
 		to.StreamProcessors[k] = v
 	}


### PR DESCRIPTION
Hi guys,

Hope you are all doing well. At work we ran into the following issue. Which is also being discussed here: https://github.com/containerd/containerd/issues/5837. This PR tries to propose a solution. 

**Example**

Given the following `config.toml` for containerd:

```
# cat /cm/local/apps/containerd/var/etc/config.toml 
version = 2
imports = ["/cm/local/apps/containerd/var/etc/conf.d/*.toml"]
```

With multiple files that match this import:

```
# cat /cm/local/apps/containerd/var/etc/conf.d/cri.toml
[plugins."io.containerd.grpc.v1.cri".cni]
    bin_dir = "/cm/local/apps/kubernetes/current/bin/cni"
    
# cat /cm/local/apps/containerd/var/etc/conf.d/registry.toml 
[plugins."io.containerd.grpc.v1.cri".registry]
    config_path = "/cm/local/apps/containerd/var/etc/certs.d"
```

The current merge strategy for imports will overwrite the entire plugin `io.containerd.grpc.v1.cri`.

This means that depending on the filenames, containerd ends up with either just the `cni` config, or just the `registry` config. This was a conscious decision in the past. I _hope_ however we can slightly modify this behavior in containerd, to _merge_ the Plugin configuration instead? :innocent:

### Current behavior

The two imports from the example effectively result in containerd having this configuration for the plugin:

```
[plugins."io.containerd.grpc.v1.cri".registry]
    config_path = "/cm/local/apps/containerd/var/etc/certs.d"
```

Note the absence of the cni bin_dir configuration, that was overwritten.

### New proposed behavior

The change in this PR will have the merge result in the following configuration instead:

```
[plugins."io.containerd.grpc.v1.cri".cni]
    bin_dir = "/cm/local/apps/kubernetes/current/bin/cni"
    
[plugins."io.containerd.grpc.v1.cri".registry]
    config_path = "/cm/local/apps/containerd/var/etc/certs.d"
```

There are also two extra unit tests that attempt to demonstrate the change.

### Why this change?

Whether the proposed behavior is better is probably subjective, but reasons why I am in favor of it ...

Let's say we have three configurations, `cni.toml` (for cni bin), `registry.toml` (for cert config path) and `nvidia.toml` (for changing the default runtime to `nvidia`).

Then it's nice to have separate smaller files, also arguably easier to get rid of certain configuration (get rid of nvidia being default runtime, rm -rf nvidia.toml). The problem now is that they all add something to the `io.containerd.grpc.v1.cri` plugin, and the last one wins.

If you have existing configuration files, it's in my opinion extra burden for the user to have the user first figure out which of the files already configures something for the same plugin before they can add their configuration without removing existing config.

In our case we try to automate this, so our code becomes more complex because of this as well :stuck_out_tongue: 

### How the old merge works

The following function seems to take care of the merging:

https://github.com/containerd/containerd/blob/455127859b70eb0e06d426be9ebb42ebd8c8674a/services/server/config/config.go#L291

The `config.Config` being merged, has `Plugins map[string]toml.Tree` and is the only field in the struct that includes the `toml.Tree` struct. The above mentioned merge function will handle the actual merging of this struct here:

https://github.com/containerd/containerd/blob/455127859b70eb0e06d426be9ebb42ebd8c8674a/vendor/github.com/imdario/mergo/merge.go#L90-L96

This will already have the effect of overwriting the whole `io.containerd.grpc.v1.cri` plugin, which surprised me! Because that means that the following for loop is unnecessary (which is why I removed it in this PR):

https://github.com/containerd/containerd/blob/455127859b70eb0e06d426be9ebb42ebd8c8674a/services/server/config/config.go#L296-L299

### How the new merge works

In my PR I used the Transformer feature from mergo (see https://github.com/imdario/mergo#transformers)

With that feature we can hook into `toml.Tree`'s merge from `src` to `dst` with a callback function. Since it will overwrite the struct completely, the best idea I could come up with is to preserve the values that would have been discarded by copying them from _destination_ to _source_. This is slightly confusing, but knowing that `mergo.merge` will overwrite _destination_ with _source_ later, the values need to be present in _source_ :smiley: 

### How I tested this code change

In order to avoid cluttering this already long PR description, I will add a text document as an attachment that shows a "real" example, how I tested if this code is also working on a real machine, and not just in unit tests.


Please let me know if this approach makes sense, and if not, how to do it differently.
It would make my life quite a bit easier if this would be the merge behavior for importing configs, but would be even better if others agree and see it as an improvement as well.

Thanks,
Ray

[manual_testing.txt](https://github.com/containerd/containerd/files/9455737/manual_testing.txt)