### PR TITLE
Fix the env cannot be overridden in `config.json`

### DIFF
--- a/internal/cri/server/helpers_test.go
+++ b/internal/cri/server/helpers_test.go
@@ -220,9 +220,9 @@ func TestEnvDeduplication(t *testing.T) {
 				{"k4", "v6"},
 			},
 			expected: []string{
-				"k1=v5",
 				"k2=v2",
 				"k3=v4",
+				"k1=v5",
 				"k4=v6",
 			},
 		},
@@ -240,8 +240,8 @@ func TestEnvDeduplication(t *testing.T) {
 			},
 			expected: []string{
 				"k1=v1",
-				"k2=v5",
 				"k3=v4",
+				"k2=v5",
 				"k4=v6",
 			},
 		},

--- a/internal/cri/server/podsandbox/helpers_test.go
+++ b/internal/cri/server/podsandbox/helpers_test.go
@@ -153,9 +153,9 @@ func TestEnvDeduplication(t *testing.T) {
 				{"k4", "v6"},
 			},
 			expected: []string{
-				"k1=v5",
 				"k2=v2",
 				"k3=v4",
+				"k1=v5",
 				"k4=v6",
 			},
 		},
@@ -173,8 +173,8 @@ func TestEnvDeduplication(t *testing.T) {
 			},
 			expected: []string{
 				"k1=v1",
-				"k2=v5",
 				"k3=v4",
+				"k2=v5",
 				"k4=v6",
 			},
 		},

--- a/pkg/oci/spec_opts.go
+++ b/pkg/oci/spec_opts.go
@@ -190,40 +190,32 @@ func WithEnv(environmentVariables []string) SpecOpts {
 // replaceOrAppendEnvValues returns the defaults with the overrides either
 // replaced by env key or appended to the list
 func replaceOrAppendEnvValues(defaults, overrides []string) []string {
-	cache := make(map[string]int, len(defaults))
-	results := make([]string, 0, len(defaults))
-	for i, e := range defaults {
-		k, _, _ := strings.Cut(e, "=")
-		results = append(results, e)
-		cache[k] = i
-	}
+	cache := make(map[string]int, len(defaults)+len(overrides))
+	results := make([]string, 0, len(defaults)+len(overrides))
+	envs := append(defaults, overrides...)
 
-	for _, value := range overrides {
-		// Values w/o = means they want this env to be removed/unset.
-		k, _, ok := strings.Cut(value, "=")
+	for n, e := range envs {
+		k, _, ok := strings.Cut(e, "=")
 		if !ok {
-			if i, exists := cache[k]; exists {
-				results[i] = "" // Used to indicate it should be removed
-			}
+			// Values w/o = means they want this env to be removed/unset.
+			delete(cache, e)
 			continue
 		}
-
-		// Just do a normal set/update
-		if i, exists := cache[k]; exists {
-			results[i] = value
-		} else {
-			results = append(results, value)
-		}
+		// Keep track of the position of the last instance of an env-var.
+		cache[k] = n
 	}
 
-	// Now remove all entries that we want to "unset"
-	for i := 0; i < len(results); i++ {
-		if results[i] == "" {
-			results = append(results[:i], results[i+1:]...)
-			i--
+	for n, e := range envs {
+		k, _, ok := strings.Cut(e, "=")
+		if ok {
+			if i, ok := cache[k]; !ok || n != i {
+				// This is not the last instance, or var has been removed and
+				// should not be added.
+				continue
+			}
+			results = append(results, e)
 		}
 	}
-
 	return results
 }
 

--- a/pkg/oci/spec_opts_test.go
+++ b/pkg/oci/spec_opts_test.go
@@ -140,7 +140,7 @@ func TestReplaceOrAppendEnvValues(t *testing.T) {
 		"x=bar", "y", "a=42", "o=", "e", "s=",
 	}
 	expected := []string{
-		"o=", "p=$e", "x=bar", "z", "t=", "a=42", "s=",
+		"p=$e", "t=", "x=bar", "a=42", "o=", "s=",
 	}
 
 	defaultsOrig := make([]string, len(defaults))
@@ -237,6 +237,31 @@ func TestWithEnv(t *testing.T) {
 
 	if len(s.Process.Env) != 2 {
 		t.Fatal("couldn't unset")
+	}
+}
+
+func TestWithEnv2(t *testing.T) {
+	t.Parallel()
+
+	var (
+		imageConfigEnv = []string{"MYENV=void", "IMAGE_ENV2=image_val2", "IMAGE_ENV1=image_val1", "IMAGE_ENV2=image_val_duplicate"}
+		configEnv      = []string{"MYENV=override", "IMAGE_ENV1", "CONFIG_ENV=config_val", "CONFIG_ENV=config_val_duplicate"}
+		expected       = []string{"IMAGE_ENV2=image_val_duplicate", "MYENV=override", "CONFIG_ENV=config_val_duplicate"}
+	)
+
+	env := append([]string{}, imageConfigEnv...)
+	env = append(env, configEnv...)
+
+	s := Spec{Process: &specs.Process{}}
+	_ = WithEnv(env)(context.Background(), nil, nil, &s)
+
+	if len(s.Process.Env) != len(expected) {
+		t.Fatal("didn't append")
+	}
+	for i, v := range s.Process.Env {
+		if v != expected[i] {
+			t.Fatalf("expected %s, got %s on position %d", expected[i], v, i)
+		}
 	}
 }
 
@@ -526,7 +551,7 @@ func TestWithImageConfigArgs(t *testing.T) {
 		WithImageConfigArgs(img, []string{"--boo", "bar"}),
 	}
 
-	expectedEnv := []string{"z=bar", "y=boo", "x=foo"}
+	expectedEnv := []string{"z=bar", "x=foo", "y=boo"}
 	expectedArgs := []string{"create", "--namespace=test", "--boo", "bar"}
 
 	for _, opt := range opts {


### PR DESCRIPTION
This PR fixes the issue that `Envs` in runtime.ContainerConfig cannot override the env in the container image.

My user scenario:
1. Build a container image `myimage:latest` with the following `Dockerfile`:
   ```Dockerfile
   FROM ubuntu:20.04
   ENV MYENV void
   ```
2. Run a pod with the above image in a Kubernetes cluster with a resource limit
3. A custom Kubernetes device plugin applies extra env to the container, say `MYENV all`
4. Check the `config.json` of the container
5. Both `MYENV=void` and `MYENV=all` exist in the config file
6. Shell into the container, `printenv` shows only `MYENV=all`

Since I'm also using a custom runtime, when lookup env of `MYENV`, I get `MYENV=void`.

`Docker` doesn't have this issue, the envs are correctly merged in `config.json`.

```bash
docker run -it --env MYENV=all myimage:latest bash
```

Signed-off-by: Xiaodong Ye <yeahdongcn@gmail.com>