### PR TITLE
Update golangci-lint timeout to match config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           version: v1.48.0
           skip-cache: true
-          args: --timeout=5m
+          args: --timeout=8m
 
   #
   # Project checks


### PR DESCRIPTION
Our GitHub Actions CI timeout setting was different than the config
file; we are now getting somewhat regular timeouts on the Windows
linting jobs so this should solve that and give us room in case runs
start taking longer

Signed-off-by: Phil Estes <estesp@amazon.com>