### PR TITLE
oci: add func for map host device to different container path

### DIFF
--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -1324,13 +1324,12 @@ func WithLinuxDevices(devices []specs.LinuxDevice) SpecOpts {
 	}
 }
 
-// WithLinuxDevice adds the device specified by path to the spec
-func WithLinuxDevice(path, permissions string) SpecOpts {
+func WithLinuxDeviceNewContainerPath(path, containerPath, permissions string) SpecOpts {
 	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 		setLinux(s)
 		setResources(s)
 
-		dev, err := DeviceFromPath(path)
+		dev, err := DeviceFromPathNewContainerPath(path, containerPath)
 		if err != nil {
 			return err
 		}
@@ -1347,6 +1346,11 @@ func WithLinuxDevice(path, permissions string) SpecOpts {
 
 		return nil
 	}
+}
+
+// WithLinuxDevice adds the device specified by path to the spec
+func WithLinuxDevice(path, permissions string) SpecOpts {
+	return WithLinuxDeviceNewContainerPath(path, path, permissions)
 }
 
 // WithEnvFile adds environment variables from a file to the container's spec

--- a/oci/utils_unix.go
+++ b/oci/utils_unix.go
@@ -133,9 +133,7 @@ const (
 	fifoDevice     = "p"
 )
 
-// DeviceFromPath takes the path to a device to look up the information about a
-// linux device and returns that information as a LinuxDevice struct.
-func DeviceFromPath(path string) (*specs.LinuxDevice, error) {
+func DeviceFromPathNewContainerPath(path, containerPath string) (*specs.LinuxDevice, error) {
 	if overrideDeviceFromPath != nil {
 		if err := overrideDeviceFromPath(path); err != nil {
 			return nil, err
@@ -171,11 +169,17 @@ func DeviceFromPath(path string) (*specs.LinuxDevice, error) {
 	fm := os.FileMode(mode &^ unix.S_IFMT)
 	return &specs.LinuxDevice{
 		Type:     devType,
-		Path:     path,
+		Path:     containerPath,
 		Major:    int64(major),
 		Minor:    int64(minor),
 		FileMode: &fm,
 		UID:      &stat.Uid,
 		GID:      &stat.Gid,
 	}, nil
+}
+
+// DeviceFromPath takes the path to a device to look up the information about a
+// linux device and returns that information as a LinuxDevice struct.
+func DeviceFromPath(path string) (*specs.LinuxDevice, error) {
+	return DeviceFromPathNewContainerPath(path, path)
 }


### PR DESCRIPTION
…ontainer path

in some scenario, containerd need add device to container with different name in
/dev to container.

Signed-off-by: Tingting Yang <shidao@linux.alibaba.com>