### PR TITLE
integration: TestUpdateContainerResources_MemoryLimit: remove TODO comment

### DIFF
--- a/integration/container_update_resources_test.go
+++ b/integration/container_update_resources_test.go
@@ -230,7 +230,6 @@ func TestUpdateContainerResources_MemorySwap(t *testing.T) {
 }
 
 func TestUpdateContainerResources_MemoryLimit(t *testing.T) {
-	// TODO(claudiub): Make this test work once https://github.com/microsoft/hcsshim/pull/931 merges.
 	t.Log("Create a sandbox")
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "update-container-resources")
 


### PR DESCRIPTION
This comment was added in 09a0c9471bf687ebcc7d8f8594606d127b3a803e (https://github.com/containerd/containerd/pull/5163) when the Windows integration tests were enabled. The PR (microsoft/hcsshim#931) was merged, and part of hcsshim v0.9.0, and support for resource limits on Windows was added in 2bc77b8a2865efe83bc50225223555a919191f54 (https://github.com/containerd/containerd/pull/5778), so it looks like this comment is no longer current.
