### PR TITLE
Remove unused variable from images action

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -38,7 +38,6 @@ jobs:
 
       - name: Install containerd dependencies
         env:
-          RUNC_FLAVOR: ${{ matrix.runc }}
           GOFLAGS: -modcacherw
         run: |
           sudo apt-get install -y gperf


### PR DESCRIPTION
Ran `actionlint` against all our actions and it found this variable that
is based on a non-existent property (there is no matrix definition in
this action yaml). The variable is also unused so simply removing it.

Signed-off-by: Phil Estes <estesp@amazon.com>