### PR TITLE
Fix several conversions of "ocispec.Image" to "ocispec.Platform"

### DIFF
--- a/image.go
+++ b/image.go
@@ -472,11 +472,13 @@ func (i *image) getManifestPlatform(ctx context.Context, manifest ocispec.Manife
 		return ocispec.Platform{}, err
 	}
 
-	var image ocispec.Image
-	if err := json.Unmarshal(p, &image); err != nil {
+	// Technically, this should be ocispec.Image, but we only need the
+	// ocispec.Platform that is embedded in the image struct.
+	var imagePlatform ocispec.Platform
+	if err := json.Unmarshal(p, &imagePlatform); err != nil {
 		return ocispec.Platform{}, err
 	}
-	return platforms.Normalize(ocispec.Platform{OS: image.OS, Architecture: image.Architecture}), nil
+	return platforms.Normalize(imagePlatform), nil
 }
 
 func (i *image) checkSnapshotterSupport(ctx context.Context, snapshotterName string, manifest ocispec.Manifest) error {

--- a/images/image.go
+++ b/images/image.go
@@ -174,12 +174,14 @@ func Manifest(ctx context.Context, provider content.Provider, image ocispec.Desc
 						return nil, err
 					}
 
-					var image ocispec.Image
-					if err := json.Unmarshal(p, &image); err != nil {
+					// Technically, this should be ocispec.Image, but we only need the
+					// ocispec.Platform that is embedded in the image struct.
+					var imagePlatform ocispec.Platform
+					if err := json.Unmarshal(p, &imagePlatform); err != nil {
 						return nil, err
 					}
 
-					if !platform.Match(platforms.Normalize(ocispec.Platform{OS: image.OS, Architecture: image.Architecture})) {
+					if !platform.Match(platforms.Normalize(imagePlatform)) {
 						return nil, nil
 					}
 
@@ -279,13 +281,14 @@ func Platforms(ctx context.Context, provider content.Provider, image ocispec.Des
 				return nil, err
 			}
 
-			var image ocispec.Image
-			if err := json.Unmarshal(p, &image); err != nil {
+			// Technically, this should be ocispec.Image, but we only need the
+			// ocispec.Platform that is embedded in the image struct.
+			var imagePlatform ocispec.Platform
+			if err := json.Unmarshal(p, &imagePlatform); err != nil {
 				return nil, err
 			}
 
-			platformSpecs = append(platformSpecs,
-				platforms.Normalize(ocispec.Platform{OS: image.OS, Architecture: image.Architecture}))
+			platformSpecs = append(platformSpecs, platforms.Normalize(imagePlatform))
 		}
 		return nil, nil
 	}), ChildrenHandler(provider)), image)

--- a/pkg/unpack/unpacker.go
+++ b/pkg/unpack/unpacker.go
@@ -253,7 +253,7 @@ func (u *Unpacker) unpack(
 	// TODO: Support multiple unpacks rather than just first match
 	var unpack *Platform
 
-	imgPlatform := platforms.Normalize(ocispec.Platform{OS: i.OS, Architecture: i.Architecture})
+	imgPlatform := platforms.Normalize(i.Platform)
 	for _, up := range u.platforms {
 		if up.Platform.Match(imgPlatform) {
 			unpack = up


### PR DESCRIPTION
Several bits of code unmarshal image config JSON into an `ocispec.Image`, and then immediately create an `ocispec.Platform` out of it, but then discard the original image *and* miss several potential platform fields (most notably, `variant`).

Because [`ocispec.Platform`](https://github.com/opencontainers/image-spec/blob/50b6194995ebfd16d933ce16064898d6b7f60249/specs-go/v1/descriptor.go#L52-L72) is a strict subset of [`ocispec.Image`](https://github.com/opencontainers/image-spec/blob/50b6194995ebfd16d933ce16064898d6b7f60249/specs-go/v1/config.go#L80-L114), most of these can be updated to simply unmarshal the image config directly to `ocispec.Platform` instead, which allows these additional fields to be picked up appropriately.

We can use `tianon/raspbian` as a concrete reproducer to demonstrate.

Before:

```console
$ ctr content fetch docker.io/tianon/raspbian:bullseye-slim
...

$ ctr image ls
REF                                     TYPE                                                 DIGEST                                                                  SIZE     PLATFORMS    LABELS
docker.io/tianon/raspbian:bullseye-slim application/vnd.docker.distribution.manifest.v2+json sha256:66e96f8af40691b335acc54e5f69711584ef7f926597b339e7d12ab90cc394ce 28.6 MiB linux/arm/v7 -
```

(Note that the `PLATFORMS` column lists `linux/arm/v7` -- the image itself is actually `linux/arm/v6`, but one of these bits of code leads to only `linux/arm` being extracted from the image config, which `platforms.Normalize` then updates to an explicit `v7`.)

After:

```console
$ ctr image ls
REF                                     TYPE                                                 DIGEST                                                                  SIZE     PLATFORMS    LABELS
docker.io/tianon/raspbian:bullseye-slim application/vnd.docker.distribution.manifest.v2+json sha256:66e96f8af40691b335acc54e5f69711584ef7f926597b339e7d12ab90cc394ce 28.6 MiB linux/arm/v6 -
```

(Tianon's back on his BS :innocent: :heart:)

There's probably a pretty decent argument to be made for the OCI's `Image` type to embed `Platform` directly (which would make this more straightforward) and/or to offer a helper function that appropriately extracts a `Platform` object _from_ an `Image` object, but I didn't want the perfect to be the enemy of the good, and this seemed like a good place to start.