### PR TITLE
Add NoSameOwner option when unpacking tars

### DIFF
--- a/archive/issues_test.go
+++ b/archive/issues_test.go
@@ -43,7 +43,7 @@ func TestPrefixHeaderReadable(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer r.Close()
-	_, err = Apply(context.Background(), tmpDir, r)
+	_, err = Apply(context.Background(), tmpDir, r, WithNoSameOwner())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/archive/tar.go
+++ b/archive/tar.go
@@ -24,7 +24,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -290,7 +289,7 @@ func applyNaive(ctx context.Context, root string, r io.Reader, options ApplyOpti
 		srcData := io.Reader(tr)
 		srcHdr := hdr
 
-		if err := createTarFile(ctx, path, root, srcHdr, srcData); err != nil {
+		if err := createTarFile(ctx, path, root, srcHdr, srcData, options.NoSameOwner); err != nil {
 			return 0, err
 		}
 
@@ -315,7 +314,7 @@ func applyNaive(ctx context.Context, root string, r io.Reader, options ApplyOpti
 	return size, nil
 }
 
-func createTarFile(ctx context.Context, path, extractDir string, hdr *tar.Header, reader io.Reader) error {
+func createTarFile(ctx context.Context, path, extractDir string, hdr *tar.Header, reader io.Reader, noSameOwner bool) error {
 	// hdr.Mode is in linux format, which we can use for syscalls,
 	// but for os.Foo() calls we need the mode converted to os.FileMode,
 	// so use hdrInfo.Mode() (they differ for e.g. setuid bits)
@@ -380,8 +379,7 @@ func createTarFile(ctx context.Context, path, extractDir string, hdr *tar.Header
 		return fmt.Errorf("unhandled tar header type %d", hdr.Typeflag)
 	}
 
-	// Lchown is not supported on Windows.
-	if runtime.GOOS != "windows" {
+	if !noSameOwner {
 		if err := os.Lchown(path, hdr.Uid, hdr.Gid); err != nil {
 			err = fmt.Errorf("failed to Lchown %q for UID %d, GID %d: %w", path, hdr.Uid, hdr.Gid, err)
 			if errors.Is(err, syscall.EINVAL) && userns.RunningInUserNS() {

--- a/archive/tar_opts.go
+++ b/archive/tar_opts.go
@@ -27,6 +27,7 @@ type ApplyOptions struct {
 	Filter          Filter          // Filter tar headers
 	ConvertWhiteout ConvertWhiteout // Convert whiteout files
 	Parents         []string        // Parent directories to handle inherited attributes without CoW
+	NoSameOwner     bool            // NoSameOwner will not attempt to preserve the owner specified in the tar archive.
 
 	applyFunc func(context.Context, string, io.Reader, ApplyOptions) (int64, error)
 }
@@ -57,6 +58,15 @@ func WithFilter(f Filter) ApplyOpt {
 func WithConvertWhiteout(c ConvertWhiteout) ApplyOpt {
 	return func(options *ApplyOptions) error {
 		options.ConvertWhiteout = c
+		return nil
+	}
+}
+
+// WithNoSameOwner is same as '--no-same-owner` in 'tar' command.
+// It'll skip attempt to preserve the owner specified in the tar archive.
+func WithNoSameOwner() ApplyOpt {
+	return func(options *ApplyOptions) error {
+		options.NoSameOwner = true
 		return nil
 	}
 }

--- a/diff/apply/apply_darwin.go
+++ b/diff/apply/apply_darwin.go
@@ -19,6 +19,7 @@ package apply
 import (
 	"context"
 	"io"
+	"os"
 
 	"github.com/containerd/containerd/archive"
 	"github.com/containerd/containerd/mount"
@@ -28,8 +29,14 @@ func apply(ctx context.Context, mounts []mount.Mount, r io.Reader) error {
 	// We currently do not support mounts nor bind mounts on MacOS in the containerd daemon.
 	// Using this as an exception to enable native snapshotter and allow further research.
 	if len(mounts) == 1 && mounts[0].Type == "bind" {
+		opts := []archive.ApplyOpt{}
+
+		if os.Getuid() != 0 {
+			opts = append(opts, archive.WithNoSameOwner())
+		}
+
 		path := mounts[0].Source
-		_, err := archive.Apply(ctx, path, r)
+		_, err := archive.Apply(ctx, path, r, opts...)
 		return err
 	}
 

--- a/diff/windows/windows.go
+++ b/diff/windows/windows.go
@@ -27,7 +27,7 @@ import (
 	"io"
 	"time"
 
-	winio "github.com/Microsoft/go-winio"
+	"github.com/Microsoft/go-winio"
 	"github.com/containerd/containerd/archive"
 	"github.com/containerd/containerd/archive/compression"
 	"github.com/containerd/containerd/content"
@@ -38,7 +38,7 @@ import (
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/plugin"
-	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
 )
@@ -144,7 +144,13 @@ func (s windowsDiff) Apply(ctx context.Context, desc ocispec.Descriptor, mounts 
 		return emptyDesc, err
 	}
 
-	if _, err := archive.Apply(ctx, layer, rc, archive.WithParents(parentLayerPaths), archive.AsWindowsContainerLayer()); err != nil {
+	archiveOpts := []archive.ApplyOpt{
+		archive.WithParents(parentLayerPaths),
+		archive.AsWindowsContainerLayer(),
+		archive.WithNoSameOwner(), // Lchown is not supported on Windows
+	}
+
+	if _, err := archive.Apply(ctx, layer, rc, archiveOpts...); err != nil {
 		return emptyDesc, err
 	}
 


### PR DESCRIPTION
When unpacking a TAR archive, containerd preserves file's owner: https://github.com/containerd/containerd/blob/main/archive/tar.go#L384

In some cases this behavior is not desired. In current implementation we avoid `Lchown` on Windows. Another case when this should be skipped is when using native snapshotter on darwin and running as non-root user.

This PR extracts a generic option - `WithNoSameOwner` (same as `tar --no-same-owner`) to skip `Lchown` when its not required.

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>