### PR TITLE
remotes/docker/config: Skipping TLS verification for localhost

### DIFF
--- a/pkg/cri/server/image_pull.go
+++ b/pkg/cri/server/image_pull.go
@@ -400,7 +400,7 @@ func (c *criService) registryHosts(ctx context.Context, auth *runtime.AuthConfig
 				if err != nil {
 					return nil, fmt.Errorf("get TLSConfig for registry %q: %w", e, err)
 				}
-			} else if isLocalHost(host) && u.Scheme == "http" {
+			} else if docker.IsLocalhost(host) && u.Scheme == "http" {
 				// Skipping TLS verification for localhost
 				transport.TLSClientConfig = &tls.Config{
 					InsecureSkipVerify: true,
@@ -445,24 +445,10 @@ func (c *criService) registryHosts(ctx context.Context, auth *runtime.AuthConfig
 
 // defaultScheme returns the default scheme for a registry host.
 func defaultScheme(host string) string {
-	if isLocalHost(host) {
+	if docker.IsLocalhost(host) {
 		return "http"
 	}
 	return "https"
-}
-
-// isLocalHost checks if the registry host is local.
-func isLocalHost(host string) bool {
-	if h, _, err := net.SplitHostPort(host); err == nil {
-		host = h
-	}
-
-	if host == "localhost" {
-		return true
-	}
-
-	ip := net.ParseIP(host)
-	return ip.IsLoopback()
 }
 
 // addDefaultScheme returns the endpoint with default scheme

--- a/remotes/docker/config/hosts.go
+++ b/remotes/docker/config/hosts.go
@@ -99,6 +99,17 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
 			if host == "docker.io" {
 				hosts[len(hosts)-1].scheme = "https"
 				hosts[len(hosts)-1].host = "registry-1.docker.io"
+			} else if docker.IsLocalhost(host) {
+				hosts[len(hosts)-1].host = host
+				if options.DefaultScheme == "" || options.DefaultScheme == "http" {
+					hosts[len(hosts)-1].scheme = "http"
+
+					// Skipping TLS verification for localhost
+					var skipVerify = true
+					hosts[len(hosts)-1].skipVerify = &skipVerify
+				} else {
+					hosts[len(hosts)-1].scheme = options.DefaultScheme
+				}
 			} else {
 				hosts[len(hosts)-1].host = host
 				if options.DefaultScheme != "" {

--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"path"
@@ -666,4 +667,18 @@ func responseFields(resp *http.Response) logrus.Fields {
 	}
 
 	return logrus.Fields(fields)
+}
+
+// IsLocalhost checks if the registry host is local.
+func IsLocalhost(host string) bool {
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+
+	if host == "localhost" {
+		return true
+	}
+
+	ip := net.ParseIP(host)
+	return ip.IsLoopback()
 }


### PR DESCRIPTION
issue: https://github.com/containerd/containerd/issues/7392

After configuring config_path for the cri plugin, it doesn't handle the case where the host is local. 
We also need to skipping TLS verification for localhost.
