### PR TITLE
Fuzzing: Instrument with new sanitizers

### DIFF
--- a/contrib/fuzz/archive_fuzzer.go
+++ b/contrib/fuzz/archive_fuzzer.go
@@ -67,7 +67,7 @@ func FuzzApply(data []byte) int {
 // that targets archive.ImportIndex()
 func FuzzImportIndex(data []byte) int {
 	f := fuzz.NewConsumer(data)
-	tarBytes, err := f.TarBytes()
+	tarBytes, err := f.GetBytes()
 	if err != nil {
 		return 0
 	}

--- a/contrib/fuzz/fuzz_FuzzImportIndex.dict
+++ b/contrib/fuzz/fuzz_FuzzImportIndex.dict
@@ -1,0 +1,2 @@
+"oci-layout"
+"manifest.json"

--- a/contrib/fuzz/fuzz_FuzzImportIndex.options
+++ b/contrib/fuzz/fuzz_FuzzImportIndex.options
@@ -1,0 +1,3 @@
+[libfuzzer]
+max_len = 1500000
+len_control = 0

--- a/contrib/fuzz/oss_fuzz_build.sh
+++ b/contrib/fuzz/oss_fuzz_build.sh
@@ -38,6 +38,10 @@ compile_fuzzers() {
     done
 }
 
+# This is from https://github.com/AdamKorcz/instrumentation
+cd $SRC/instrumentation
+go run main.go $SRC/containerd/images
+
 apt-get update && apt-get install -y wget
 cd $SRC
 wget --quiet https://go.dev/dl/go1.19.1.linux-amd64.tar.gz
@@ -89,3 +93,6 @@ sed -i 's/\/run\/containerd-test/\/tmp\/containerd-test/g' $SRC/containerd/integ
 cd integration/client
 
 compile_fuzzers '^func FuzzInteg.*data' compile_go_fuzzer vendor
+
+cp $SRC/containerd/contrib/fuzz/*.options $OUT/
+cp $SRC/containerd/contrib/fuzz/*.dict $OUT/


### PR DESCRIPTION
This instruments `images/` with new sanitizers/bug detectors that AdaLogics are developing to work with fuzzing. 

The plan is to start with a small part of Containerd and if everything runs well move on to the entire project. I will observe the OSS-Fuzz dashboard closely for any breakages.

No extra work is required from the Containerd side. Everything should work as usual.

@kzys 

Needs https://github.com/google/oss-fuzz/pull/8504 to be merged first - this is why CIFuzz is failing.

Signed-off-by: AdamKorcz <adam@adalogics.com>