### PR TITLE
Enable CDI injection from the command-line.

### DIFF
--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -238,6 +238,7 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 				return nil, err
 			}
 			opts = append(opts, oci.WithAnnotations(annos))
+			opts = append(opts, oci.WithCDI(annos, []string{"/etc/cdi"}))
 		}
 
 		if context.Bool("cni") {

--- a/oci/spec_opts_nonlinux.go
+++ b/oci/spec_opts_nonlinux.go
@@ -22,7 +22,9 @@ package oci
 import (
 	"context"
 	"errors"
+	"fmt"
 
+	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
 	"github.com/containerd/containerd/containers"
 )
 
@@ -59,5 +61,18 @@ func WithCPUShares(shares uint64) SpecOpts {
 func WithRdt(closID, l3CacheSchema, memBwSchema string) SpecOpts {
 	return func(_ context.Context, _ Client, _ *containers.Container, _ *Spec) error {
 		return errors.New("RDT not supported")
+	}
+}
+
+func WithCDI(annotations map[string]string, cdiSpecDirs []string) SpecOpts {
+	return func(ctx context.Context, _ Client, c *containers.Container, s *Spec) error {
+		_, cdiDevices, err := cdi.ParseAnnotations(annotations)
+		if err != nil {
+			return fmt.Errorf("failed to parse CDI device annotations: %w", err)
+		}
+		if cdiDevices == nil {
+			return nil
+		}
+		return errors.New("CDI not supported")
 	}
 }


### PR DESCRIPTION
Allows for CDI devices to be injected into containers from the ctr command-line tool using cdi.k8s.io/ prefixed annotations.

CDI annotations are of the form:

cdi.k8s.io/vendor.com.class_device='vendor.com/class=device'