### PR TITLE
Add ext2 fs support to devmapper snapshotter

### DIFF
--- a/snapshots/devmapper/config.go
+++ b/snapshots/devmapper/config.go
@@ -117,7 +117,7 @@ func (c *Config) Validate() error {
 
 	if c.FileSystemType != "" {
 		switch c.FileSystemType {
-		case fsTypeExt4, fsTypeXFS:
+		case fsTypeExt4, fsTypeXFS, fsTypeExt2:
 		default:
 			result = multierror.Append(result, fmt.Errorf("unsupported Filesystem Type: %q", c.FileSystemType))
 		}

--- a/snapshots/devmapper/snapshotter.go
+++ b/snapshots/devmapper/snapshotter.go
@@ -44,6 +44,7 @@ type fsType string
 const (
 	metadataFileName               = "metadata.db"
 	fsTypeExt4              fsType = "ext4"
+	fsTypeExt2              fsType = "ext2"
 	fsTypeXFS               fsType = "xfs"
 	devmapperSnapshotFsType        = "containerd.io/snapshot/devmapper/fstype"
 )
@@ -463,6 +464,13 @@ func mkfs(ctx context.Context, fs fsType, fsOptions string, path string) error {
 	switch fs {
 	case fsTypeExt4:
 		mkfsCommand = "mkfs.ext4"
+		args = []string{
+			"-E",
+			fsOptions,
+			path,
+		}
+	case fsTypeExt2:
+		mkfsCommand = "mkfs.ext2"
 		args = []string{
 			"-E",
 			fsOptions,


### PR DESCRIPTION
This PR adds support for ext2fs for devmapper snapshotter.

We have a use-case (NetBSD) where ext4 or xfs is not an option and since adding ext2 support could be a configurable parameter (`fs_type = "ext2"` in `config.toml`), and not that intrusive, it didn't seem like such a bad idea.

FYI, we are building a custom handler to boot unikernels -- we are trying to minimize the steps to prepare the storage part, and if we could give the snapshot directly to the unikernel, that would save us the time from generating an image file or doing some other kind of hack.
