### PR TITLE
Fix "getCPUInfo for OS freebsd: not implemented" on FreeBSD/arm64

### DIFF
--- a/platforms/cpuinfo.go
+++ b/platforms/cpuinfo.go
@@ -94,6 +94,19 @@ func getCPUVariant() string {
 
 		return variant
 	}
+	if runtime.GOOS == "freebsd" {
+		// FreeBSD supports ARMv6 and ARMv7 as well as ARMv4 and ARMv5 (though deprecated)
+		// detecting those variants is currently unimplemented
+		var variant string
+		switch runtime.GOARCH {
+		case "arm64":
+			variant = "v8"
+		default:
+			variant = "unknown"
+		}
+
+		return variant
+	}
 
 	variant, err := getCPUInfo("Cpu architecture")
 	if err != nil {


### PR DESCRIPTION
cc @dfr

I'm not sure how to do better for arm32 but at least it's a step.

See https://github.com/samuelkarp/runj/issues/33#issuecomment-1244525428 for an example of the failure.