### PR TITLE
Add reader option to local content reader at

### DIFF
--- a/content/helpers.go
+++ b/content/helpers.go
@@ -37,10 +37,16 @@ var bufPool = sync.Pool{
 	},
 }
 
+type reader interface {
+	Reader() io.Reader
+}
+
 // NewReader returns a io.Reader from a ReaderAt
 func NewReader(ra ReaderAt) io.Reader {
-	rd := io.NewSectionReader(ra, 0, ra.Size())
-	return rd
+	if rd, ok := ra.(reader); ok {
+		return rd.Reader()
+	}
+	return io.NewSectionReader(ra, 0, ra.Size())
 }
 
 // ReadBlob retrieves the entire contents of the blob from the provider.

--- a/content/local/readerat.go
+++ b/content/local/readerat.go
@@ -18,6 +18,7 @@ package local
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/containerd/containerd/content"
@@ -64,4 +65,8 @@ func (ra sizeReaderAt) Size() int64 {
 
 func (ra sizeReaderAt) Close() error {
 	return ra.fp.Close()
+}
+
+func (ra sizeReaderAt) Reader() io.Reader {
+	return io.LimitReader(ra.fp, ra.size)
 }


### PR DESCRIPTION
Allows optimized copying from a local content file into another file.

Using a `*LimitedReader` allows for an optimized copy file range to be performed when copying into a `*os.File` on Linux. Currently our custom type or use of section reader hide the source `*os.File`. 
See https://cs.opensource.google/go/go/+/refs/tags/go1.19.1:src/os/readfrom_linux.go;drc=f1b7b2fc52947711b8e78f7078c9e0bda35320d3;l=14