### PR TITLE
Set grpc code for unimplemented cri-api methods

### DIFF
--- a/pkg/cri/sbserver/container_checkpoint.go
+++ b/pkg/cri/sbserver/container_checkpoint.go
@@ -18,11 +18,12 @@ package sbserver
 
 import (
 	"context"
-	"errors"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func (c *criService) CheckpointContainer(ctx context.Context, r *runtime.CheckpointContainerRequest) (res *runtime.CheckpointContainerResponse, err error) {
-	return nil, errors.New("not implemented")
+	return nil, status.Errorf(codes.Unimplemented, "method CheckpointContainer not implemented")
 }

--- a/pkg/cri/sbserver/container_events.go
+++ b/pkg/cri/sbserver/container_events.go
@@ -17,11 +17,11 @@
 package sbserver
 
 import (
-	"errors"
-
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func (c *criService) GetContainerEvents(r *runtime.GetEventsRequest, s runtime.RuntimeService_GetContainerEventsServer) error {
-	return errors.New("not implemented")
+	return status.Errorf(codes.Unimplemented, "method GetContainerEvents not implemented")
 }

--- a/pkg/cri/server/container_checkpoint.go
+++ b/pkg/cri/server/container_checkpoint.go
@@ -18,11 +18,12 @@ package server
 
 import (
 	"context"
-	"errors"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func (c *criService) CheckpointContainer(ctx context.Context, r *runtime.CheckpointContainerRequest) (res *runtime.CheckpointContainerResponse, err error) {
-	return nil, errors.New("not implemented")
+	return nil, status.Errorf(codes.Unimplemented, "method CheckpointContainer not implemented")
 }

--- a/pkg/cri/server/container_events.go
+++ b/pkg/cri/server/container_events.go
@@ -17,11 +17,11 @@
 package server
 
 import (
-	"errors"
-
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func (c *criService) GetContainerEvents(r *runtime.GetEventsRequest, s runtime.RuntimeService_GetContainerEventsServer) error {
-	return errors.New("not implemented")
+	return status.Errorf(codes.Unimplemented, "method GetContainerEvents not implemented")
 }


### PR DESCRIPTION
Replaces unimplemented errors with `status.Errorf` and grpc code `Unimplemented` set.

xref: https://github.com/containerd/containerd/pull/7410#issuecomment-1254535922

cc @dmcgowan 