### PR TITLE
blockio: add blockio_reconfigure option

### DIFF
--- a/docs/man/containerd-config.toml.5.md
+++ b/docs/man/containerd-config.toml.5.md
@@ -105,6 +105,8 @@ documentation.
     (Default: **""**). Controls I/O scheduler priority and bandwidth throttling.
     See [blockio configuration](https://github.com/intel/goresctrl/blob/main/doc/blockio.md#configuration)
     for details of the file format.
+  - **blockio_reconfigure** (Linux only) specifies if the configuration file must be re-read
+    and block devices rescanned in the system when it can make a difference. (Default: **false**)
   - **rdt_config_file** (Linux only) specifies path to a configuration used for configuring
     RDT (Default: **""**). Enables support for Intel RDT, a technology
     for cache and memory bandwidth management.
@@ -197,6 +199,7 @@ imports = ["/etc/containerd/runtime_*.toml", "./debug.toml"]
     sched_core = true
   [plugins."io.containerd.service.v1.tasks-service"]
     blockio_config_file = ""
+    blockio_reconfigure = false
     rdt_config_file = ""
 ```
 

--- a/pkg/blockio/blockio_nonlinux.go
+++ b/pkg/blockio/blockio_nonlinux.go
@@ -24,7 +24,7 @@ import runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 func IsEnabled() bool { return false }
 
 // SetConfig always is no-op in non-linux platforms.
-func SetConfig(configFilePath string) error {
+func SetConfig(configFilePath string, alwaysReconfigure bool) error {
 	return nil
 }
 

--- a/services/tasks/local.go
+++ b/services/tasks/local.go
@@ -69,6 +69,10 @@ const (
 type Config struct {
 	// BlockIOConfigFile specifies the path to blockio configuration file
 	BlockIOConfigFile string `toml:"blockio_config_file" json:"blockioConfigFile"`
+	// BlockIOReconfigure specifies if the configuration file and
+	// system's block devices must be re-read for changes before
+	// applying blockio parameters
+	BlockIOReconfigure bool `toml:"blockio_reconfigure" json:"blockioReconfigure"`
 	// RdtConfigFile specifies the path to RDT configuration file
 	RdtConfigFile string `toml:"rdt_config_file" json:"rdtConfigFile"`
 }
@@ -128,7 +132,7 @@ func initFunc(ic *plugin.InitContext) (interface{}, error) {
 		l.monitor.Monitor(t, nil)
 	}
 
-	if err := blockio.SetConfig(config.BlockIOConfigFile); err != nil {
+	if err := blockio.SetConfig(config.BlockIOConfigFile, config.BlockIOReconfigure); err != nil {
 		log.G(ic.Context).WithError(err).Errorf("blockio initialization failed")
 	}
 	if err := rdt.SetConfig(config.RdtConfigFile); err != nil {


### PR DESCRIPTION
Reconfiguring blockio is needed in the following scenarios.
- Block devices (/dev/*) change, for example when a CSI driver adds a new block device for a pod. Reconfiguration finds current devices and enables applying appropriate blockio parameters for them.
- Blockio class configuration file has been updated in the system. Reconfiguration applies changes without restarting containerd.

Signed-off-by: Antti Kervinen <antti.kervinen@intel.com>