### PR TITLE
[release/1.6] cherry-pick: Set grpc code for unimplemented cri-api methods

### DIFF
--- a/pkg/cri/server/container_checkpoint.go
+++ b/pkg/cri/server/container_checkpoint.go
@@ -18,11 +18,12 @@ package server
 
 import (
 	"context"
-	"errors"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func (c *criService) CheckpointContainer(ctx context.Context, r *runtime.CheckpointContainerRequest) (res *runtime.CheckpointContainerResponse, err error) {
-	return nil, errors.New("not implemented")
+	return nil, status.Errorf(codes.Unimplemented, "method CheckpointContainer not implemented")
 }

--- a/pkg/cri/server/container_events.go
+++ b/pkg/cri/server/container_events.go
@@ -17,11 +17,11 @@
 package server
 
 import (
-	"errors"
-
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func (c *criService) GetContainerEvents(r *runtime.GetEventsRequest, s runtime.RuntimeService_GetContainerEventsServer) error {
-	return errors.New("not implemented")
+	return status.Errorf(codes.Unimplemented, "method GetContainerEvents not implemented")
 }


### PR DESCRIPTION
Signed-off-by: ruiwen-zhao <ruiwen@google.com>

This is a cherry-pick of https://github.com/containerd/containerd/pull/7417