### PR TITLE
Add test flag for skipping shim cgroup test

### DIFF
--- a/integration/client/client_test.go
+++ b/integration/client/client_test.go
@@ -46,11 +46,13 @@ var (
 	noDaemon     bool
 	noCriu       bool
 	supportsCriu bool
+	noShimCgroup bool
 )
 
 func init() {
 	flag.BoolVar(&noDaemon, "no-daemon", false, "Do not start a dedicated daemon for the tests")
 	flag.BoolVar(&noCriu, "no-criu", false, "Do not run the checkpoint tests")
+	flag.BoolVar(&noShimCgroup, "no-shim-cgroup", false, "Do not run the shim cgroup tests")
 }
 
 func TestMain(m *testing.M) {

--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -160,6 +160,10 @@ func TestTaskUpdate(t *testing.T) {
 }
 
 func TestShimInCgroup(t *testing.T) {
+	if noShimCgroup {
+		t.Skip("shim cgroup is not enabled")
+	}
+
 	t.Parallel()
 
 	client, err := newClient(t, address)


### PR DESCRIPTION
For some shims (namely github.com/cpuguy83/containerd-shim-systemd-v1), the shim cgroup test doesn't make sense since there is only a single shim process for the entire node.

I use these integration tests to make sure the shim is compatible with the runc shims and generally works as expected. This will let me skip the shim cgroup test as there is no process for the shim to stick into the cgroup... mostly.
There is a bootstrap process as well as a PTY copier proces which do use the shim cgroup if provided, but the test is not able to check for those (unless we enable tty on the test, which is a bit arbitrary and not useful).

Signed-off-by: Brian Goff <cpuguy83@gmail.com>