### PR TITLE
Add new ctr option for discarding unpacked layers

### DIFF
--- a/cmd/ctr/commands/images/import.go
+++ b/cmd/ctr/commands/images/import.go
@@ -136,10 +136,12 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 
 		opts = append(opts, containerd.WithAllPlatforms(context.Bool("all-platforms")))
 
-		if context.Bool("discard-unpacked-layers") && context.Bool("no-unpack") {
-			return fmt.Errorf("--discard-unpacked-layers and --no-unpack are incompatible options")
+		if context.Bool("discard-unpacked-layers") {
+			if context.Bool("no-unpack") {
+				return fmt.Errorf("--discard-unpacked-layers and --no-unpack are incompatible options")
+			}
+			opts = append(opts, containerd.WithDiscardUnpackedLayers())
 		}
-		opts = append(opts, containerd.WithDiscardUnpackedLayers(context.Bool("discard-unpacked-layers")))
 
 		client, ctx, cancel, err := commands.NewClient(context)
 		if err != nil {

--- a/import.go
+++ b/import.go
@@ -108,9 +108,9 @@ func WithImportCompression() ImportOpt {
 
 // WithDiscardUnpackedLayers allows the garbage collector to clean up
 // layers from content store after unpacking.
-func WithDiscardUnpackedLayers(discard bool) ImportOpt {
+func WithDiscardUnpackedLayers() ImportOpt {
 	return func(c *importOpts) error {
-		c.discardLayers = discard
+		c.discardLayers = true
 		return nil
 	}
 }

--- a/import.go
+++ b/import.go
@@ -38,6 +38,7 @@ type importOpts struct {
 	allPlatforms    bool
 	platformMatcher platforms.MatchComparer
 	compress        bool
+	discardLayers   bool
 }
 
 // ImportOpt allows the caller to specify import specific options
@@ -101,6 +102,15 @@ func WithImportPlatform(platformMacher platforms.MatchComparer) ImportOpt {
 func WithImportCompression() ImportOpt {
 	return func(c *importOpts) error {
 		c.compress = true
+		return nil
+	}
+}
+
+// WithDiscardUnpackedLayers allows the garbage collector to clean up
+// layers from content store after unpacking.
+func WithDiscardUnpackedLayers(discard bool) ImportOpt {
+	return func(c *importOpts) error {
+		c.discardLayers = discard
 		return nil
 	}
 }
@@ -195,7 +205,11 @@ func (c *Client) Import(ctx context.Context, reader io.Reader, opts ...ImportOpt
 	}
 
 	handler = images.FilterPlatforms(handler, platformMatcher)
-	handler = images.SetChildrenLabels(cs, handler)
+	if iopts.discardLayers {
+		handler = images.SetChildrenMappedLabels(cs, handler, images.ChildGCLabelsFilterLayers)
+	} else {
+		handler = images.SetChildrenLabels(cs, handler)
+	}
 	if err := images.WalkNotEmpty(ctx, handler, index); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add a new ctr cli option, allowing the garbage collector to discard any unpacked layers after importing an image. This new option is incompatible with the no-unpack ctr import option. This addresses issue #7125.