### PR TITLE
[port #5904 to sbserver] Setup pod network after creating the sandbox container

### DIFF
--- a/integration/sandbox_run_rollback_test.go
+++ b/integration/sandbox_run_rollback_test.go
@@ -20,6 +20,7 @@
 package integration
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -36,6 +37,7 @@ import (
 	"github.com/stretchr/testify/require"
 	criapiv1 "k8s.io/cri-api/pkg/apis/runtime/v1"
 
+	"github.com/containerd/containerd/pkg/cri/sbserver"
 	"github.com/containerd/containerd/pkg/cri/store/sandbox"
 	"github.com/containerd/containerd/pkg/failpoint"
 	"github.com/containerd/typeurl"
@@ -237,9 +239,6 @@ func TestRunPodSandboxAndTeardownCNISlow(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip()
 	}
-	if os.Getenv("ENABLE_CRI_SANDBOXES") != "" {
-		t.Skip()
-	}
 
 	t.Log("Init PodSandboxConfig with specific key")
 	sbName := t.Name()
@@ -295,31 +294,63 @@ func TestRunPodSandboxAndTeardownCNISlow(t *testing.T) {
 	assert.Equal(t, sb.Metadata.Uid, sbConfig.Metadata.Uid)
 	assert.Equal(t, sb.Metadata.Attempt, sbConfig.Metadata.Attempt)
 
-	t.Log("Get sandbox info")
-	_, info, err := SandboxInfo(sb.Id)
-	require.NoError(t, err)
-	require.False(t, info.NetNSClosed)
-
-	var netNS string
-	for _, n := range info.RuntimeSpec.Linux.Namespaces {
-		if n.Type == runtimespec.NetworkNamespace {
-			netNS = n.Path
+	switch os.Getenv("ENABLE_CRI_SANDBOXES") {
+	case "":
+		// non-sbserver
+		t.Log("Get sandbox info (non-sbserver)")
+		_, info, err := SandboxInfo(sb.Id)
+		require.NoError(t, err)
+		require.False(t, info.NetNSClosed)
+		var netNS string
+		for _, n := range info.RuntimeSpec.Linux.Namespaces {
+			if n.Type == runtimespec.NetworkNamespace {
+				netNS = n.Path
+			}
 		}
-	}
-	assert.NotEmpty(t, netNS, "network namespace should be set")
+		assert.NotEmpty(t, netNS, "network namespace should be set")
 
-	t.Log("Get sandbox container")
-	c, err := GetContainer(sb.Id)
-	require.NoError(t, err)
-	any, ok := c.Extensions["io.cri-containerd.sandbox.metadata"]
-	require.True(t, ok, "sandbox metadata should exist in extension")
-	i, err := typeurl.UnmarshalAny(any)
-	require.NoError(t, err)
-	require.IsType(t, &sandbox.Metadata{}, i)
-	metadata, ok := i.(*sandbox.Metadata)
-	require.True(t, ok)
-	assert.NotEmpty(t, metadata.NetNSPath)
-	assert.Equal(t, netNS, metadata.NetNSPath, "network namespace path should be the same in runtime spec and sandbox metadata")
+		t.Log("Get sandbox container")
+		c, err := GetContainer(sb.Id)
+		require.NoError(t, err)
+		any, ok := c.Extensions["io.cri-containerd.sandbox.metadata"]
+		require.True(t, ok, "sandbox metadata should exist in extension")
+		i, err := typeurl.UnmarshalAny(any)
+		require.NoError(t, err)
+		require.IsType(t, &sandbox.Metadata{}, i)
+		metadata, ok := i.(*sandbox.Metadata)
+		require.True(t, ok)
+		assert.Equal(t, netNS, metadata.NetNSPath, "network namespace path should be the same in runtime spec and sandbox metadata")
+	default:
+		// sbserver
+		t.Log("Get sandbox info (sbserver)")
+		_, info, err := sbserverSandboxInfo(sb.Id)
+		require.NoError(t, err)
+		require.False(t, info.NetNSClosed)
+
+		assert.NotEmpty(t, info.Metadata.NetNSPath, "network namespace should be set")
+	}
+
+}
+
+// sbserverSandboxInfo gets sandbox info.
+func sbserverSandboxInfo(id string) (*criapiv1.PodSandboxStatus, *sbserver.SandboxInfo, error) {
+	client, err := RawRuntimeClient()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get raw runtime client: %w", err)
+	}
+	resp, err := client.PodSandboxStatus(context.Background(), &criapiv1.PodSandboxStatusRequest{
+		PodSandboxId: id,
+		Verbose:      true,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get sandbox status: %w", err)
+	}
+	status := resp.GetStatus()
+	var info sbserver.SandboxInfo
+	if err := json.Unmarshal([]byte(resp.GetInfo()["info"]), &info); err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal sandbox info: %w", err)
+	}
+	return status, &info, nil
 }
 
 func ensureCNIAddRunning(t *testing.T, sbName string) error {

--- a/integration/sandbox_run_rollback_test.go
+++ b/integration/sandbox_run_rollback_test.go
@@ -103,9 +103,6 @@ func TestRunPodSandboxWithShimDeleteFailure(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip()
 	}
-	if os.Getenv("ENABLE_CRI_SANDBOXES") != "" {
-		t.Skip()
-	}
 
 	testCase := func(restart bool) func(*testing.T) {
 		return func(t *testing.T) {
@@ -175,9 +172,6 @@ func TestRunPodSandboxWithShimDeleteFailure(t *testing.T) {
 // record if failed to rollback CNI API.
 func TestRunPodSandboxWithShimStartAndTeardownCNIFailure(t *testing.T) {
 	if runtime.GOOS != "linux" {
-		t.Skip()
-	}
-	if os.Getenv("ENABLE_CRI_SANDBOXES") != "" {
 		t.Skip()
 	}
 

--- a/pkg/cri/sbserver/podsandbox/helpers.go
+++ b/pkg/cri/sbserver/podsandbox/helpers.go
@@ -63,6 +63,8 @@ const (
 	sandboxMetadataExtension = criContainerdPrefix + ".sandbox.metadata"
 	// runtimeRunhcsV1 is the runtime type for runhcs.
 	runtimeRunhcsV1 = "io.containerd.runhcs.v1"
+	// MetadataKey is the key used for storing metadata in the sandbox extensions
+	MetadataKey = "metadata"
 )
 
 const (

--- a/pkg/cri/sbserver/podsandbox/sandbox_delete.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_delete.go
@@ -49,11 +49,13 @@ func (c *Controller) Delete(ctx context.Context, sandboxID string) (*api.Control
 	}
 
 	// Delete sandbox container.
-	if err := sandbox.Container.Delete(ctx, containerd.WithSnapshotCleanup); err != nil {
-		if !errdefs.IsNotFound(err) {
-			return nil, fmt.Errorf("failed to delete sandbox container %q: %w", sandboxID, err)
+	if sandbox.Container != nil {
+		if err := sandbox.Container.Delete(ctx, containerd.WithSnapshotCleanup); err != nil {
+			if !errdefs.IsNotFound(err) {
+				return nil, fmt.Errorf("failed to delete sandbox container %q: %w", sandboxID, err)
+			}
+			log.G(ctx).Tracef("Sandbox controller Delete called for sandbox container %q that does not exist", sandboxID)
 		}
-		log.G(ctx).Tracef("Sandbox controller Delete called for sandbox container %q that does not exist", sandboxID)
 	}
 
 	return &api.ControllerDeleteResponse{}, nil

--- a/pkg/cri/sbserver/podsandbox/sandbox_stop.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_stop.go
@@ -21,13 +21,14 @@ import (
 	"fmt"
 	"syscall"
 
+	"github.com/sirupsen/logrus"
+
 	eventtypes "github.com/containerd/containerd/api/events"
 	api "github.com/containerd/containerd/api/services/sandbox/v1"
 	"github.com/containerd/containerd/errdefs"
 	sandboxstore "github.com/containerd/containerd/pkg/cri/store/sandbox"
 	ctrdutil "github.com/containerd/containerd/pkg/cri/util"
 	"github.com/containerd/containerd/protobuf"
-	"github.com/sirupsen/logrus"
 )
 
 func (c *Controller) Stop(ctx context.Context, sandboxID string) (*api.ControllerStopResponse, error) {
@@ -44,7 +45,7 @@ func (c *Controller) Stop(ctx context.Context, sandboxID string) (*api.Controlle
 	// TODO: The Controller maintains its own Status instead of CRI's sandboxStore.
 	// Only stop sandbox container when it's running or unknown.
 	state := sandbox.Status.Get().State
-	if state == sandboxstore.StateReady || state == sandboxstore.StateUnknown {
+	if (state == sandboxstore.StateReady || state == sandboxstore.StateUnknown) && sandbox.Container != nil {
 		if err := c.stopSandboxContainer(ctx, sandbox); err != nil {
 			return nil, fmt.Errorf("failed to stop sandbox container %q in %q state: %w", sandboxID, state, err)
 		}

--- a/pkg/cri/sbserver/sandbox_run.go
+++ b/pkg/cri/sbserver/sandbox_run.go
@@ -170,6 +170,14 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 			}
 		}()
 
+		if err := sandboxInfo.AddExtension(podsandbox.MetadataKey, &sandbox.Metadata); err != nil {
+			return nil, fmt.Errorf("unable to save sandbox %q to store: %w", id, err)
+		}
+		// Save sandbox metadata to store
+		if sandboxInfo, err = c.client.SandboxStore().Update(ctx, sandboxInfo, "extensions"); err != nil {
+			return nil, fmt.Errorf("unable to update extensions for sandbox %q: %w", id, err)
+		}
+
 		// Define this defer to teardownPodNetwork prior to the setupPodNetwork function call.
 		// This is because in setupPodNetwork the resource is allocated even if it returns error, unlike other resource
 		// creation functions.


### PR DESCRIPTION
This pull request ports #5904 and #7481 to the sbserver implementation in the CRI plugin.  Since sbserver is still incomplete, this PR is currently working around the incomplete parts.  However, it does pass all the integration tests and is working.

I'd like to get this merged as we continue to work on the Sandbox API since the integration tests enabled by this PR will help catch behavior regressions.

(cc @qiutongs)