### PR TITLE
runtime/v2: clean up redundant path resolve for runtime

### DIFF
--- a/runtime/v2/manager.go
+++ b/runtime/v2/manager.go
@@ -326,7 +326,7 @@ func (m *ShimManager) resolveRuntimePath(runtime string) (string, error) {
 			// Match the calling binaries (containerd) path and see
 			// if they are side by side. If so, execute the shim
 			// found there.
-			cmdPath := filepath.Join(filepath.Dir(self), name)
+			cmdPath = filepath.Join(filepath.Dir(self), name)
 			if _, serr := os.Stat(cmdPath); serr != nil {
 				return "", fmt.Errorf("runtime %q binary not installed %q: %w", runtime, name, os.ErrNotExist)
 			}

--- a/runtime/v2/shim/util.go
+++ b/runtime/v2/shim/util.go
@@ -99,20 +99,6 @@ func BinaryName(runtime string) string {
 	return fmt.Sprintf(shimBinaryFormat, parts[len(parts)-2], parts[len(parts)-1])
 }
 
-// BinaryPath returns the full path for the shim binary from the runtime name,
-// empty string returns means runtime name is invalid
-func BinaryPath(runtime string) string {
-	dir := filepath.Dir(runtime)
-	binary := BinaryName(runtime)
-
-	path, err := filepath.Abs(filepath.Join(dir, binary))
-	if err != nil {
-		return ""
-	}
-
-	return path
-}
-
 // Connect to the provided address
 func Connect(address string, d func(string, time.Duration) (net.Conn, error)) (net.Conn, error) {
 	return d(address, 100*time.Second)


### PR DESCRIPTION
We have added support for runtime binary paths in https://github.com/containerd/containerd/pull/5007 and https://github.com/containerd/containerd/pull/6206 respectively.

However, their functions appear to be duplicated, and according to https://github.com/containerd/containerd/pull/6519 , the path must not be an absolute or relative path, so we can skip the `BinaryPath`