### PR TITLE
Add REGISTRY_USER variable option to user flag on pull command

### DIFF
--- a/cmd/ctr/commands/commands.go
+++ b/cmd/ctr/commands/commands.go
@@ -60,8 +60,9 @@ var (
 			Usage: "allow connections using plain HTTP",
 		},
 		cli.StringFlag{
-			Name:  "user,u",
-			Usage: "user[:password] Registry user and password",
+			Name:   "user,u",
+			Usage:  "user[:password] Registry user and password",
+			EnvVar: "REGISTRY_USER",
 		},
 		cli.StringFlag{
 			Name:  "refresh",


### PR DESCRIPTION
Signed-off-by: Josh Ferrell <jkferr@amazon.com>

For #7444 to allow the registry user and password to be set using the REGISTRY_USER environment variable.