### PR TITLE
Swap to net.ErrClosed checks for services

### DIFF
--- a/cmd/containerd-shim/main_unix.go
+++ b/cmd/containerd-shim/main_unix.go
@@ -22,6 +22,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -237,8 +238,7 @@ func serve(ctx context.Context, server *ttrpc.Server, path string) error {
 	logrus.WithField("socket", path).Debug("serving api on unix socket")
 	go func() {
 		defer l.Close()
-		if err := server.Serve(ctx, l); err != nil &&
-			!strings.Contains(err.Error(), "use of closed network connection") {
+		if err := server.Serve(ctx, l); err != nil && !errors.Is(err, net.ErrClosed) {
 			logrus.WithError(err).Fatal("containerd-shim: ttrpc server failure")
 		}
 	}()

--- a/runtime/v2/shim/shim.go
+++ b/runtime/v2/shim/shim.go
@@ -22,11 +22,11 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
-	"strings"
 	"time"
 
 	shimapi "github.com/containerd/containerd/api/runtime/task/v2"
@@ -486,8 +486,7 @@ func serve(ctx context.Context, server *ttrpc.Server, signals chan os.Signal, sh
 	}
 	go func() {
 		defer l.Close()
-		if err := server.Serve(ctx, l); err != nil &&
-			!strings.Contains(err.Error(), "use of closed network connection") {
+		if err := server.Serve(ctx, l); err != nil && !errors.Is(err, net.ErrClosed) {
 			log.G(ctx).WithError(err).Fatal("containerd-shim: ttrpc server failure")
 		}
 	}()

--- a/services/server/server.go
+++ b/services/server/server.go
@@ -30,7 +30,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"sync"
 	"time"
 
@@ -473,10 +472,7 @@ func (pc *proxyClients) getClient(address string) (*grpc.ClientConn, error) {
 }
 
 func trapClosedConnErr(err error) error {
-	if err == nil {
-		return nil
-	}
-	if strings.Contains(err.Error(), "use of closed network connection") {
+	if err == nil || errors.Is(err, net.ErrClosed) {
 		return nil
 	}
 	return err


### PR DESCRIPTION
In Go 1.16 `net.ErrClosed` was exported, removing the need to check the exact text of "use of closed network connection". The stdlib's net listeners are all setup for this to be a reality, but on Windows containerd uses the the go-winio projects named pipe implementation as the listener for services. Before version 0.6.0 this project returned a different error named `ErrPipeListenerClosed` for using a closed pipe, where this error was just an `errors.New` with the same text as `net.ErrClosed`, so checking against `net.ErrClosed` wasn't possible.

Starting in 0.6.0 go-winio has that error assigned to `net.ErrClosed` directly so this *should* be alright to finally change.