### PR TITLE
[release/1.5] cherry-pick: make xattr EPERM non-fatal in createTarFile

### DIFF
--- a/archive/tar.go
+++ b/archive/tar.go
@@ -117,6 +117,8 @@ const (
 	whiteoutOpaqueDir = whiteoutMetaPrefix + ".opq"
 
 	paxSchilyXattr = "SCHILY.xattr."
+
+	userXattrPrefix = "user."
 )
 
 // Apply applies a tar stream of an OCI style diff tar.
@@ -390,11 +392,19 @@ func createTarFile(ctx context.Context, path, extractDir string, hdr *tar.Header
 		if strings.HasPrefix(key, paxSchilyXattr) {
 			key = key[len(paxSchilyXattr):]
 			if err := setxattr(path, key, value); err != nil {
+				if errors.Is(err, syscall.EPERM) && strings.HasPrefix(key, userXattrPrefix) {
+					// In the user.* namespace, only regular files and directories can have extended attributes.
+					// See https://man7.org/linux/man-pages/man7/xattr.7.html for details.
+					if fi, err := os.Lstat(path); err == nil && (!fi.Mode().IsRegular() && !fi.Mode().IsDir()) {
+						log.G(ctx).WithError(err).Warnf("ignored xattr %s in archive", key)
+						continue
+					}
+				}
 				if errors.Is(err, syscall.ENOTSUP) {
 					log.G(ctx).WithError(err).Warnf("ignored xattr %s in archive", key)
 					continue
 				}
-				return err
+				return fmt.Errorf("failed to setxattr %q for key %q: %w", path, key, err)
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Ye Sijun <junnplus@gmail.com>
(cherry picked from commit 68a55fe8bdba268d0ccb301cee8a085958bf9275)
Signed-off-by: Phil Estes <estesp@amazon.com>

Cherry-pick of #7094 for `release/1.5`