### PR TITLE
Fix for image push to use chunked encoding

### DIFF
--- a/remotes/docker/pusher.go
+++ b/remotes/docker/pusher.go
@@ -263,8 +263,6 @@ func (p dockerPusher) push(ctx context.Context, desc ocispec.Descriptor, ref str
 		},
 	})
 
-	// TODO: Support chunked upload
-
 	pushw := newPushWriter(p.dockerBase, ref, desc.Digest, p.tracker, isManifest)
 
 	req.body = func() (io.ReadCloser, error) {
@@ -272,7 +270,6 @@ func (p dockerPusher) push(ctx context.Context, desc ocispec.Descriptor, ref str
 		pushw.setPipe(pw)
 		return io.NopCloser(pr), nil
 	}
-	req.size = desc.Size
 
 	go func() {
 		resp, err := req.doWithRetries(ctx, nil)

--- a/remotes/docker/pusher_test.go
+++ b/remotes/docker/pusher_test.go
@@ -300,6 +300,7 @@ func Test_dockerPusher_push(t *testing.T) {
 				unavailableOnFail: false,
 			},
 			checkerFunc: func(writer *pushWriter) bool {
+				writer.Close()
 				select {
 				case resp := <-writer.respC:
 					// 201 should be the response code when uploading a new manifest
@@ -334,6 +335,7 @@ func Test_dockerPusher_push(t *testing.T) {
 				unavailableOnFail: false,
 			},
 			checkerFunc: func(writer *pushWriter) bool {
+				writer.Close()
 				select {
 				case resp := <-writer.respC:
 					// 201 should be the response code when uploading a new blob


### PR DESCRIPTION
By not setting the request size, we can let net/http handle chunking the request. This is important for any registry that is behind Cloudflare or another CDN that limits HTTP POST chunk size.