### PR TITLE
[release/1.6] retry request on writer reset

### DIFF
--- a/content/helpers.go
+++ b/content/helpers.go
@@ -26,9 +26,15 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/log"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
+
+// maxResets is the no.of times the Copy() method can tolerate a reset of the body
+const maxResets = 5
+
+var ErrReset = errors.New("writer has been reset")
 
 var bufPool = sync.Pool{
 	New: func() interface{} {
@@ -80,7 +86,7 @@ func WriteBlob(ctx context.Context, cs Ingester, ref string, r io.Reader, desc o
 			return fmt.Errorf("failed to open writer: %w", err)
 		}
 
-		return nil // all ready present
+		return nil // already present
 	}
 	defer cw.Close()
 
@@ -131,35 +137,63 @@ func OpenWriter(ctx context.Context, cs Ingester, opts ...WriterOpt) (Writer, er
 // the size or digest is unknown, these values may be empty.
 //
 // Copy is buffered, so no need to wrap reader in buffered io.
-func Copy(ctx context.Context, cw Writer, r io.Reader, size int64, expected digest.Digest, opts ...Opt) error {
+func Copy(ctx context.Context, cw Writer, or io.Reader, size int64, expected digest.Digest, opts ...Opt) error {
 	ws, err := cw.Status()
 	if err != nil {
 		return fmt.Errorf("failed to get status: %w", err)
 	}
-
+	r := or
 	if ws.Offset > 0 {
-		r, err = seekReader(r, ws.Offset, size)
+		r, err = seekReader(or, ws.Offset, size)
 		if err != nil {
 			return fmt.Errorf("unable to resume write to %v: %w", ws.Ref, err)
 		}
 	}
 
-	copied, err := copyWithBuffer(cw, r)
-	if err != nil {
-		return fmt.Errorf("failed to copy: %w", err)
-	}
-	if size != 0 && copied < size-ws.Offset {
-		// Short writes would return its own error, this indicates a read failure
-		return fmt.Errorf("failed to read expected number of bytes: %w", io.ErrUnexpectedEOF)
-	}
-
-	if err := cw.Commit(ctx, size, expected, opts...); err != nil {
-		if !errdefs.IsAlreadyExists(err) {
-			return fmt.Errorf("failed commit on ref %q: %w", ws.Ref, err)
+	for i := 0; i < maxResets; i++ {
+		if i >= 1 {
+			log.G(ctx).WithField("digest", expected).Debugf("retrying copy due to reset")
 		}
+		copied, err := copyWithBuffer(cw, r)
+		if errors.Is(err, ErrReset) {
+			ws, err := cw.Status()
+			if err != nil {
+				return fmt.Errorf("failed to get status: %w", err)
+			}
+			r, err = seekReader(or, ws.Offset, size)
+			if err != nil {
+				return fmt.Errorf("unable to resume write to %v: %w", ws.Ref, err)
+			}
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("failed to copy: %w", err)
+		}
+		if size != 0 && copied < size-ws.Offset {
+			// Short writes would return its own error, this indicates a read failure
+			return fmt.Errorf("failed to read expected number of bytes: %w", io.ErrUnexpectedEOF)
+		}
+		if err := cw.Commit(ctx, size, expected, opts...); err != nil {
+			if errors.Is(err, ErrReset) {
+				ws, err := cw.Status()
+				if err != nil {
+					return fmt.Errorf("failed to get status: %w", err)
+				}
+				r, err = seekReader(or, ws.Offset, size)
+				if err != nil {
+					return fmt.Errorf("unable to resume write to %v: %w", ws.Ref, err)
+				}
+				continue
+			}
+			if !errdefs.IsAlreadyExists(err) {
+				return fmt.Errorf("failed commit on ref %q: %w", ws.Ref, err)
+			}
+		}
+		return nil
 	}
 
-	return nil
+	log.G(ctx).WithField("digest", expected).Errorf("failed to copy after %d retries", maxResets)
+	return fmt.Errorf("failed to copy after %d retries", maxResets)
 }
 
 // CopyReaderAt copies to a writer from a given reader at for the given

--- a/content/helpers_test.go
+++ b/content/helpers_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	_ "crypto/sha256" // required by go-digest
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -39,37 +40,106 @@ type copySource struct {
 func TestCopy(t *testing.T) {
 	defaultSource := newCopySource("this is the source to copy")
 
+	cf1 := func(buf *bytes.Buffer, st Status) commitFunction {
+		i := 0
+		return func() error {
+			// function resets the first time
+			if i == 0 {
+				// this is the case where, the pipewriter to which the data was being written has
+				// changed. which means we need to clear the buffer
+				i++
+				buf.Reset()
+				st.Offset = 0
+				return ErrReset
+			}
+			return nil
+		}
+	}
+
+	cf2 := func(buf *bytes.Buffer, st Status) commitFunction {
+		i := 0
+		return func() error {
+			// function resets for more than the maxReset value
+			if i < maxResets+1 {
+				// this is the case where, the pipewriter to which the data was being written has
+				// changed. which means we need to clear the buffer
+				i++
+				buf.Reset()
+				st.Offset = 0
+				return ErrReset
+			}
+			return nil
+		}
+	}
+
+	s1 := Status{}
+	s2 := Status{}
+	b1 := bytes.Buffer{}
+	b2 := bytes.Buffer{}
+
 	var testcases = []struct {
-		name     string
-		source   copySource
-		writer   fakeWriter
-		expected string
+		name        string
+		source      copySource
+		writer      fakeWriter
+		expected    string
+		expectedErr error
 	}{
 		{
-			name:     "copy no offset",
-			source:   defaultSource,
-			writer:   fakeWriter{},
+			name:   "copy no offset",
+			source: defaultSource,
+			writer: fakeWriter{
+				Buffer: &bytes.Buffer{},
+			},
 			expected: "this is the source to copy",
 		},
 		{
-			name:     "copy with offset from seeker",
-			source:   defaultSource,
-			writer:   fakeWriter{status: Status{Offset: 8}},
+			name:   "copy with offset from seeker",
+			source: defaultSource,
+			writer: fakeWriter{
+				Buffer: &bytes.Buffer{},
+				status: Status{Offset: 8},
+			},
 			expected: "the source to copy",
 		},
 		{
-			name:     "copy with offset from unseekable source",
-			source:   copySource{reader: bytes.NewBufferString("foobar"), size: 6},
-			writer:   fakeWriter{status: Status{Offset: 3}},
+			name:   "copy with offset from unseekable source",
+			source: copySource{reader: bytes.NewBufferString("foobar"), size: 6},
+			writer: fakeWriter{
+				Buffer: &bytes.Buffer{},
+				status: Status{Offset: 3},
+			},
 			expected: "bar",
 		},
 		{
 			name:   "commit already exists",
 			source: newCopySource("this already exists"),
-			writer: fakeWriter{commitFunc: func() error {
-				return errdefs.ErrAlreadyExists
-			}},
+			writer: fakeWriter{
+				Buffer: &bytes.Buffer{},
+				commitFunc: func() error {
+					return errdefs.ErrAlreadyExists
+				}},
 			expected: "this already exists",
+		},
+		{
+			name:   "commit fails first time with ErrReset",
+			source: newCopySource("content to copy"),
+			writer: fakeWriter{
+				Buffer:     &b1,
+				status:     s1,
+				commitFunc: cf1(&b1, s1),
+			},
+			expected: "content to copy",
+		},
+		{
+			name:   "write fails more than maxReset times due to reset",
+			source: newCopySource("content to copy"),
+			writer: fakeWriter{
+				Buffer:     &b2,
+				status:     s2,
+				commitFunc: cf2(&b2, s2),
+			},
+			expected:    "",
+			expectedErr: fmt.Errorf("failed to copy after %d retries", maxResets),
 		},
 	}
 
@@ -80,6 +150,12 @@ func TestCopy(t *testing.T) {
 				testcase.source.reader,
 				testcase.source.size,
 				testcase.source.digest)
+
+			// if an error is expected then further comparisons are not required
+			if testcase.expectedErr != nil {
+				assert.Check(t, is.Equal(testcase.expectedErr.Error(), err.Error()))
+				return
+			}
 
 			assert.NilError(t, err)
 			assert.Check(t, is.Equal(testcase.source.digest, testcase.writer.committedDigest))
@@ -96,11 +172,13 @@ func newCopySource(raw string) copySource {
 	}
 }
 
+type commitFunction func() error
+
 type fakeWriter struct {
-	bytes.Buffer
+	*bytes.Buffer
 	committedDigest digest.Digest
 	status          Status
-	commitFunc      func() error
+	commitFunc      commitFunction
 }
 
 func (f *fakeWriter) Close() error {

--- a/remotes/docker/pusher.go
+++ b/remotes/docker/pusher.go
@@ -261,27 +261,20 @@ func (p dockerPusher) push(ctx context.Context, desc ocispec.Descriptor, ref str
 
 	// TODO: Support chunked upload
 
-	pr, pw := io.Pipe()
-	respC := make(chan response, 1)
-	body := io.NopCloser(pr)
+	pushw := newPushWriter(p.dockerBase, ref, desc.Digest, p.tracker, isManifest)
 
 	req.body = func() (io.ReadCloser, error) {
-		if body == nil {
-			return nil, errors.New("cannot reuse body, request must be retried")
-		}
-		// Only use the body once since pipe cannot be seeked
-		ob := body
-		body = nil
-		return ob, nil
+		pr, pw := io.Pipe()
+		pushw.setPipe(pw)
+		return io.NopCloser(pr), nil
 	}
 	req.size = desc.Size
 
 	go func() {
-		defer close(respC)
 		resp, err := req.doWithRetries(ctx, nil)
 		if err != nil {
-			respC <- response{err: err}
-			pr.CloseWithError(err)
+			pushw.setError(err)
+			pushw.Close()
 			return
 		}
 
@@ -290,20 +283,13 @@ func (p dockerPusher) push(ctx context.Context, desc ocispec.Descriptor, ref str
 		default:
 			err := remoteserrors.NewUnexpectedStatusErr(resp)
 			log.G(ctx).WithField("resp", resp).WithField("body", string(err.(remoteserrors.ErrUnexpectedStatus).Body)).Debug("unexpected response")
-			pr.CloseWithError(err)
+			pushw.setError(err)
+			pushw.Close()
 		}
-		respC <- response{Response: resp}
+		pushw.setResponse(resp)
 	}()
 
-	return &pushWriter{
-		base:       p.dockerBase,
-		ref:        ref,
-		pipe:       pw,
-		responseC:  respC,
-		isManifest: isManifest,
-		expected:   desc.Digest,
-		tracker:    p.tracker,
-	}, nil
+	return pushw, nil
 }
 
 func getManifestPath(object string, dgst digest.Digest) []string {
@@ -325,21 +311,45 @@ func getManifestPath(object string, dgst digest.Digest) []string {
 	return []string{"manifests", object}
 }
 
-type response struct {
-	*http.Response
-	err error
-}
-
 type pushWriter struct {
 	base *dockerBase
 	ref  string
 
-	pipe       *io.PipeWriter
-	responseC  <-chan response
+	pipe *io.PipeWriter
+
+	pipeC chan *io.PipeWriter
+	respC chan *http.Response
+	errC  chan error
+
 	isManifest bool
 
 	expected digest.Digest
 	tracker  StatusTracker
+}
+
+func newPushWriter(db *dockerBase, ref string, expected digest.Digest, tracker StatusTracker, isManifest bool) *pushWriter {
+	// Initialize and create response
+	return &pushWriter{
+		base:       db,
+		ref:        ref,
+		expected:   expected,
+		tracker:    tracker,
+		pipeC:      make(chan *io.PipeWriter, 1),
+		respC:      make(chan *http.Response, 1),
+		errC:       make(chan error, 1),
+		isManifest: isManifest,
+	}
+}
+
+func (pw *pushWriter) setPipe(p *io.PipeWriter) {
+	pw.pipeC <- p
+}
+
+func (pw *pushWriter) setError(err error) {
+	pw.errC <- err
+}
+func (pw *pushWriter) setResponse(resp *http.Response) {
+	pw.respC <- resp
 }
 
 func (pw *pushWriter) Write(p []byte) (n int, err error) {
@@ -347,6 +357,34 @@ func (pw *pushWriter) Write(p []byte) (n int, err error) {
 	if err != nil {
 		return n, err
 	}
+
+	if pw.pipe == nil {
+		p, ok := <-pw.pipeC
+		if !ok {
+			return 0, io.ErrClosedPipe
+		}
+		pw.pipe = p
+	} else {
+		select {
+		case p, ok := <-pw.pipeC:
+			if !ok {
+				return 0, io.ErrClosedPipe
+			}
+			pw.pipe.CloseWithError(content.ErrReset)
+			pw.pipe = p
+
+			// If content has already been written, the bytes
+			// cannot be written and the caller must reset
+			if status.Offset > 0 {
+				status.Offset = 0
+				status.UpdatedAt = time.Now()
+				pw.tracker.SetStatus(pw.ref, status)
+				return 0, content.ErrReset
+			}
+		default:
+		}
+	}
+
 	n, err = pw.pipe.Write(p)
 	status.Offset += int64(n)
 	status.UpdatedAt = time.Now()
@@ -355,13 +393,26 @@ func (pw *pushWriter) Write(p []byte) (n int, err error) {
 }
 
 func (pw *pushWriter) Close() error {
-	status, err := pw.tracker.GetStatus(pw.ref)
-	if err == nil && !status.Committed {
-		// Closing an incomplete writer. Record this as an error so that following write can retry it.
-		status.ErrClosed = errors.New("closed incomplete writer")
-		pw.tracker.SetStatus(pw.ref, status)
+	// Ensure pipeC is closed but handle `Close()` being
+	// called multiple times without panicking
+	select {
+	case _, ok := <-pw.pipeC:
+		if ok {
+			close(pw.pipeC)
+		}
+	default:
+		close(pw.pipeC)
 	}
-	return pw.pipe.Close()
+	if pw.pipe != nil {
+		status, err := pw.tracker.GetStatus(pw.ref)
+		if err == nil && !status.Committed {
+			// Closing an incomplete writer. Record this as an error so that following write can retry it.
+			status.ErrClosed = errors.New("closed incomplete writer")
+			pw.tracker.SetStatus(pw.ref, status)
+		}
+		return pw.pipe.Close()
+	}
+	return nil
 }
 
 func (pw *pushWriter) Status() (content.Status, error) {
@@ -388,18 +439,43 @@ func (pw *pushWriter) Commit(ctx context.Context, size int64, expected digest.Di
 		return err
 	}
 	// TODO: timeout waiting for response
-	resp := <-pw.responseC
-	if resp.err != nil {
-		return resp.err
+	var resp *http.Response
+	select {
+	case err := <-pw.errC:
+		if err != nil {
+			return err
+		}
+	case resp = <-pw.respC:
+		defer resp.Body.Close()
+	case p, ok := <-pw.pipeC:
+		// check whether the pipe has changed in the commit, because sometimes Write
+		// can complete successfully, but the pipe may have changed. In that case, the
+		// content needs to be reset.
+		if !ok {
+			return io.ErrClosedPipe
+		}
+		pw.pipe.CloseWithError(content.ErrReset)
+		pw.pipe = p
+		status, err := pw.tracker.GetStatus(pw.ref)
+		if err != nil {
+			return err
+		}
+		// If content has already been written, the bytes
+		// cannot be written again and the caller must reset
+		if status.Offset > 0 {
+			status.Offset = 0
+			status.UpdatedAt = time.Now()
+			pw.tracker.SetStatus(pw.ref, status)
+			return content.ErrReset
+		}
 	}
-	defer resp.Response.Body.Close()
 
 	// 201 is specified return status, some registries return
 	// 200, 202 or 204.
 	switch resp.StatusCode {
 	case http.StatusOK, http.StatusCreated, http.StatusNoContent, http.StatusAccepted:
 	default:
-		return remoteserrors.NewUnexpectedStatusErr(resp.Response)
+		return remoteserrors.NewUnexpectedStatusErr(resp)
 	}
 
 	status, err := pw.tracker.GetStatus(pw.ref)


### PR DESCRIPTION
Cherry-pick (clean) #6995

when a put request is retried due to the response from registry, the body of the request should be seekable. A dynamic pipe is added to the body so that the content of the body can be read again. Currently a maximum of 5 resets are allowed, above which will fail the request. A new error ErrReset is introduced which informs that a reset has occured and request needs to be retried.

also added tests for Copy() and push() to test the new functionality

Signed-off-by: Akhil Mohan <makhil@vmware.com>
(cherry picked from commit 8f4c23b69f4f21c964cc097a5156e6eb22f1ed67)
Signed-off-by: Akhil Mohan <makhil@vmware.com>