### PR TITLE
use raw link to containerd.service config

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,7 +42,7 @@ Users of such distributions may have to install containerd from the source or a 
 
 ##### systemd
 If you intend to start containerd via systemd, you should also download the `containerd.service` unit file from
-https://github.com/containerd/containerd/blob/main/containerd.service into `/usr/local/lib/systemd/system/containerd.service`,
+https://raw.githubusercontent.com/containerd/containerd/main/containerd.service into `/usr/local/lib/systemd/system/containerd.service`,
 and run the following commands:
 
 ```bash


### PR DESCRIPTION
Referencing the raw link to the containerd.service may enhance the developer experience by enabling those following the docs to use the raw link directly to `wget` or `curl` the file without additional navigation.

Signed-off-by: Kyle L Frisbie <KyleFrisbie@users.noreply.github.com>