### PR TITLE
[release/1.6] Update go 1.18.7, addresses CVE-2022-2879, CVE-2022-2880, CVE-2022-41715

### DIFF
--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.13'
+          go-version: '1.18.7'
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.17.13]
+        go-version: [1.18.7]
         os: [ubuntu-18.04, macos-12, windows-2019]
 
     steps:
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.13'
+          go-version: '1.18.7'
 
       - uses: actions/checkout@v2
         with:
@@ -78,7 +78,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.13'
+          go-version: '1.18.7'
 
       - uses: actions/checkout@v2
         with:
@@ -110,7 +110,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.13'
+          go-version: '1.18.7'
       - uses: actions/checkout@v2
       - run: go install github.com/cpuguy83/go-md2man/v2@v2.0.1
       - run: make man
@@ -148,7 +148,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.13'
+          go-version: '1.18.7'
       - uses: actions/checkout@v2
       - run: |
           set -e -x
@@ -215,7 +215,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-12, windows-2019, windows-2022]
-        go-version: ['1.16.15', '1.17.13']
+        go-version: ['1.17.13', '1.18.7']
 
     steps:
       - uses: actions/setup-go@v2
@@ -262,7 +262,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.13'
+          go-version: '1.18.7'
 
       - uses: actions/checkout@v2
         with:
@@ -352,7 +352,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.13'
+          go-version: '1.18.7'
 
       - uses: actions/checkout@v2
 
@@ -475,7 +475,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.13'
+          go-version: '1.18.7'
       - uses: actions/checkout@v2
       - run: sudo -E PATH=$PATH script/setup/install-gotestsum
       - name: Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.44.2
+          version: v1.49.0
           skip-cache: true
           args: --timeout=5m
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: 1.17.13
+        go-version: 1.18.7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.13'
+          go-version: '1.18.7'
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.13'
+          go-version: '1.18.7'
 
       - uses: actions/checkout@v2
         with:
@@ -155,7 +155,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.13'
+          go-version: '1.18.7'
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
           find ./releases/ -maxdepth 1 -type l | xargs rm
         working-directory: src/github.com/containerd/containerd
         env:
-          GO_VERSION: '1.17.13'
+          GO_VERSION: '1.18.7'
           PLATFORM: ${{ matrix.platform }}
       - name: Save Artifacts
         uses: actions/upload-artifact@v2

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -91,7 +91,7 @@ EOF
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.17.13",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.18.7",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/archive/tar_unix.go
+++ b/archive/tar_unix.go
@@ -63,7 +63,7 @@ func setHeaderForSpecialDevice(hdr *tar.Header, name string, fi os.FileInfo) err
 	}
 
 	// Rdev is int32 on darwin/bsd, int64 on linux/solaris
-	rdev := uint64(s.Rdev) // nolint: unconvert
+	rdev := uint64(s.Rdev) //nolint:unconvert
 
 	// Currently go does not fill in the major/minors
 	if s.Mode&syscall.S_IFBLK != 0 ||

--- a/cmd/containerd/command/service_windows.go
+++ b/cmd/containerd/command/service_windows.go
@@ -307,7 +307,7 @@ func launchService(s *server.Server, done chan struct{}) error {
 		done:    done,
 	}
 
-	interactive, err := svc.IsAnInteractiveSession() // nolint:staticcheck
+	interactive, err := svc.IsAnInteractiveSession() //nolint:staticcheck
 	if err != nil {
 		return err
 	}

--- a/content/local/store.go
+++ b/content/local/store.go
@@ -643,7 +643,6 @@ func (s *store) ingestRoot(ref string) string {
 // - root: entire ingest directory
 // - ref: name of the starting ref, must be unique
 // - data: file where data is written
-//
 func (s *store) ingestPaths(ref string) (string, string, string) {
 	var (
 		fp = s.ingestRoot(ref)

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -10,7 +10,7 @@
 #
 # docker build -t containerd-test --build-arg RUNC_VERSION=v1.0.0-rc94 -f Dockerfile.test ../
 
-ARG GOLANG_VERSION=1.17.13
+ARG GOLANG_VERSION=1.18.7
 ARG GOLANG_IMAGE=golang
 
 FROM ${GOLANG_IMAGE}:${GOLANG_VERSION} AS golang

--- a/contrib/fuzz/content_fuzzer.go
+++ b/contrib/fuzz/content_fuzzer.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-// nolint: golint
+//nolint:golint
 package fuzz
 
 import (

--- a/filters/filter.go
+++ b/filters/filter.go
@@ -65,7 +65,6 @@
 // ```
 // name==foo,labels.bar
 // ```
-//
 package filters
 
 import (

--- a/filters/parser.go
+++ b/filters/parser.go
@@ -45,7 +45,6 @@ field     := quoted | [A-Za-z] [A-Za-z0-9_]+
 operator  := "==" | "!=" | "~="
 value     := quoted | [^\s,]+
 quoted    := <go string syntax>
-
 */
 func Parse(s string) (Filter, error) {
 	// special case empty to match all

--- a/filters/quote.go
+++ b/filters/quote.go
@@ -31,10 +31,10 @@ var errQuoteSyntax = errors.New("quote syntax error")
 // or character literal represented by the string s.
 // It returns four values:
 //
-//	1) value, the decoded Unicode code point or byte value;
-//	2) multibyte, a boolean indicating whether the decoded character requires a multibyte UTF-8 representation;
-//	3) tail, the remainder of the string after the character; and
-//	4) an error that will be nil if the character is syntactically valid.
+//  1. value, the decoded Unicode code point or byte value;
+//  2. multibyte, a boolean indicating whether the decoded character requires a multibyte UTF-8 representation;
+//  3. tail, the remainder of the string after the character; and
+//  4. an error that will be nil if the character is syntactically valid.
 //
 // The second argument, quote, specifies the type of literal being parsed
 // and therefore which escaped quote character is permitted.

--- a/images/archive/importer.go
+++ b/images/archive/importer.go
@@ -55,12 +55,12 @@ func WithImportCompression() ImportOpt {
 }
 
 // ImportIndex imports an index from a tar archive image bundle
-// - implements Docker v1.1, v1.2 and OCI v1.
-// - prefers OCI v1 when provided
-// - creates OCI index for Docker formats
-// - normalizes Docker references and adds as OCI ref name
-//      e.g. alpine:latest -> docker.io/library/alpine:latest
-// - existing OCI reference names are untouched
+//   - implements Docker v1.1, v1.2 and OCI v1.
+//   - prefers OCI v1 when provided
+//   - creates OCI index for Docker formats
+//   - normalizes Docker references and adds as OCI ref name
+//     e.g. alpine:latest -> docker.io/library/alpine:latest
+//   - existing OCI reference names are untouched
 func ImportIndex(ctx context.Context, store content.Store, reader io.Reader, opts ...ImportOpt) (ocispec.Descriptor, error) {
 	var (
 		tr = tar.NewReader(reader)

--- a/integration/client/restart_monitor_test.go
+++ b/integration/client/restart_monitor_test.go
@@ -37,7 +37,8 @@ import (
 )
 
 // the following nolint is for shutting up gometalinter on non-linux.
-// nolint: unused
+//
+//nolint:unused
 func newDaemonWithConfig(t *testing.T, configTOML string) (*Client, *daemon, func()) {
 	if testing.Short() {
 		t.Skip()

--- a/integration/failpoint/cmd/cni-bridge-fp/main_linux.go
+++ b/integration/failpoint/cmd/cni-bridge-fp/main_linux.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -168,7 +168,7 @@ func (c *failpointControl) updateTx(updateFn func(conf *failpointConf) error) er
 	}
 	defer unflock(f.Fd())
 
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		return fmt.Errorf("failed to read failpoint setting %s: %w", c.confPath, err)
 	}

--- a/metadata/buckets.go
+++ b/metadata/buckets.go
@@ -26,7 +26,7 @@
 //
 // Generically, we try to do the following:
 //
-// 	<version>/<namespace>/<object>/<key> -> <field>
+//	<version>/<namespace>/<object>/<key> -> <field>
 //
 // version: Currently, this is "v1". Additions can be made to v1 in a backwards
 // compatible way. If the layout changes, a new version must be made, along
@@ -46,72 +46,73 @@
 // the structure is changed in addition to adding a migration and incrementing
 // the database version. Note that `╘══*...*` refers to maps with arbitrary
 // keys.
-//  ├──version : <varint>                        - Latest version, see migrations
-//  └──v1                                        - Schema version bucket
-//     ╘══*namespace*
-//        ├──labels
-//        │  ╘══*key* : <string>                 - Label value
-//        ├──image
-//        │  ╘══*image name*
-//        │     ├──createdat : <binary time>     - Created at
-//        │     ├──updatedat : <binary time>     - Updated at
-//        │     ├──target
-//        │     │  ├──digest : <digest>          - Descriptor digest
-//        │     │  ├──mediatype : <string>       - Descriptor media type
-//        │     │  └──size : <varint>            - Descriptor size
-//        │     └──labels
-//        │        ╘══*key* : <string>           - Label value
-//        ├──containers
-//        │  ╘══*container id*
-//        │     ├──createdat : <binary time>     - Created at
-//        │     ├──updatedat : <binary time>     - Updated at
-//        │     ├──spec : <binary>               - Proto marshaled spec
-//        │     ├──image : <string>              - Image name
-//        │     ├──snapshotter : <string>        - Snapshotter name
-//        │     ├──snapshotKey : <string>        - Snapshot key
-//        │     ├──runtime
-//        │     │  ├──name : <string>            - Runtime name
-//        │     │  ├──extensions
-//        │     │  │  ╘══*name* : <binary>       - Proto marshaled extension
-//        │     │  └──options : <binary>         - Proto marshaled options
-//        │     └──labels
-//        │        ╘══*key* : <string>           - Label value
-//        ├──snapshots
-//        │  ╘══*snapshotter*
-//        │     ╘══*snapshot key*
-//        │        ├──name : <string>            - Snapshot name in backend
-//        │        ├──createdat : <binary time>  - Created at
-//        │        ├──updatedat : <binary time>  - Updated at
-//        │        ├──parent : <string>          - Parent snapshot name
-//        │        ├──children
-//        │        │  ╘══*snapshot key* : <nil>  - Child snapshot reference
-//        │        └──labels
-//        │           ╘══*key* : <string>        - Label value
-//        ├──content
-//        │  ├──blob
-//        │  │  ╘══*blob digest*
-//        │  │     ├──createdat : <binary time>  - Created at
-//        │  │     ├──updatedat : <binary time>  - Updated at
-//        │  │     ├──size : <varint>            - Blob size
-//        │  │     └──labels
-//        │  │        ╘══*key* : <string>        - Label value
-//        │  └──ingests
-//        │     ╘══*ingest reference*
-//        │        ├──ref : <string>             - Ingest reference in backend
-//        │        ├──expireat : <binary time>   - Time to expire ingest
-//        │        └──expected : <digest>        - Expected commit digest
-//        └──leases
-//           ╘══*lease id*
-//              ├──createdat : <binary time>     - Created at
-//              ├──labels
-//              │  ╘══*key* : <string>           - Label value
-//              ├──snapshots
-//              │  ╘══*snapshotter*
-//              │     ╘══*snapshot key* : <nil>  - Snapshot reference
-//              ├──content
-//              │  ╘══*blob digest* : <nil>      - Content blob reference
-//              └──ingests
-//                 ╘══*ingest reference* : <nil> - Content ingest reference
+//
+//	├──version : <varint>                        - Latest version, see migrations
+//	└──v1                                        - Schema version bucket
+//	   ╘══*namespace*
+//	      ├──labels
+//	      │  ╘══*key* : <string>                 - Label value
+//	      ├──image
+//	      │  ╘══*image name*
+//	      │     ├──createdat : <binary time>     - Created at
+//	      │     ├──updatedat : <binary time>     - Updated at
+//	      │     ├──target
+//	      │     │  ├──digest : <digest>          - Descriptor digest
+//	      │     │  ├──mediatype : <string>       - Descriptor media type
+//	      │     │  └──size : <varint>            - Descriptor size
+//	      │     └──labels
+//	      │        ╘══*key* : <string>           - Label value
+//	      ├──containers
+//	      │  ╘══*container id*
+//	      │     ├──createdat : <binary time>     - Created at
+//	      │     ├──updatedat : <binary time>     - Updated at
+//	      │     ├──spec : <binary>               - Proto marshaled spec
+//	      │     ├──image : <string>              - Image name
+//	      │     ├──snapshotter : <string>        - Snapshotter name
+//	      │     ├──snapshotKey : <string>        - Snapshot key
+//	      │     ├──runtime
+//	      │     │  ├──name : <string>            - Runtime name
+//	      │     │  ├──extensions
+//	      │     │  │  ╘══*name* : <binary>       - Proto marshaled extension
+//	      │     │  └──options : <binary>         - Proto marshaled options
+//	      │     └──labels
+//	      │        ╘══*key* : <string>           - Label value
+//	      ├──snapshots
+//	      │  ╘══*snapshotter*
+//	      │     ╘══*snapshot key*
+//	      │        ├──name : <string>            - Snapshot name in backend
+//	      │        ├──createdat : <binary time>  - Created at
+//	      │        ├──updatedat : <binary time>  - Updated at
+//	      │        ├──parent : <string>          - Parent snapshot name
+//	      │        ├──children
+//	      │        │  ╘══*snapshot key* : <nil>  - Child snapshot reference
+//	      │        └──labels
+//	      │           ╘══*key* : <string>        - Label value
+//	      ├──content
+//	      │  ├──blob
+//	      │  │  ╘══*blob digest*
+//	      │  │     ├──createdat : <binary time>  - Created at
+//	      │  │     ├──updatedat : <binary time>  - Updated at
+//	      │  │     ├──size : <varint>            - Blob size
+//	      │  │     └──labels
+//	      │  │        ╘══*key* : <string>        - Label value
+//	      │  └──ingests
+//	      │     ╘══*ingest reference*
+//	      │        ├──ref : <string>             - Ingest reference in backend
+//	      │        ├──expireat : <binary time>   - Time to expire ingest
+//	      │        └──expected : <digest>        - Expected commit digest
+//	      └──leases
+//	         ╘══*lease id*
+//	            ├──createdat : <binary time>     - Created at
+//	            ├──labels
+//	            │  ╘══*key* : <string>           - Label value
+//	            ├──snapshots
+//	            │  ╘══*snapshotter*
+//	            │     ╘══*snapshot key* : <nil>  - Snapshot reference
+//	            ├──content
+//	            │  ╘══*blob digest* : <nil>      - Content blob reference
+//	            └──ingests
+//	               ╘══*ingest reference* : <nil> - Content ingest reference
 package metadata
 
 import (

--- a/namespaces/store.go
+++ b/namespaces/store.go
@@ -24,8 +24,6 @@ import "context"
 // oriented. A namespace is really just a name and a set of labels. Objects
 // that belong to a namespace are returned when the namespace is assigned to a
 // given context.
-//
-//
 type Store interface {
 	Create(ctx context.Context, namespace string, labels map[string]string) error
 	Labels(ctx context.Context, namespace string) (map[string]string, error)

--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -518,7 +518,8 @@ func WithNamespacedCgroup() SpecOpts {
 
 // WithUser sets the user to be used within the container.
 // It accepts a valid user string in OCI Image Spec v1.0.0:
-//   user, uid, user:group, uid:gid, uid:group, user:gid
+//
+//	user, uid, user:group, uid:gid, uid:group, user:gid
 func WithUser(userstr string) SpecOpts {
 	return func(ctx context.Context, client Client, c *containers.Container, s *Spec) error {
 		setProcess(s)

--- a/oci/spec_opts_nonlinux.go
+++ b/oci/spec_opts_nonlinux.go
@@ -28,19 +28,22 @@ import (
 
 // WithAllCurrentCapabilities propagates the effective capabilities of the caller process to the container process.
 // The capability set may differ from WithAllKnownCapabilities when running in a container.
-//nolint: deadcode, unused
+//
+//nolint:deadcode,unused
 var WithAllCurrentCapabilities = func(ctx context.Context, client Client, c *containers.Container, s *Spec) error {
 	return WithCapabilities(nil)(ctx, client, c, s)
 }
 
 // WithAllKnownCapabilities sets all the the known linux capabilities for the container process
-//nolint: deadcode, unused
+//
+//nolint:deadcode,unused
 var WithAllKnownCapabilities = func(ctx context.Context, client Client, c *containers.Container, s *Spec) error {
 	return WithCapabilities(nil)(ctx, client, c, s)
 }
 
 // WithCPUShares sets the container's cpu shares
-//nolint: deadcode, unused
+//
+//nolint:deadcode,unused
 func WithCPUShares(shares uint64) SpecOpts {
 	return func(ctx context.Context, _ Client, c *containers.Container, s *Spec) error {
 		return nil

--- a/pkg/apparmor/apparmor.go
+++ b/pkg/apparmor/apparmor.go
@@ -18,10 +18,11 @@ package apparmor
 
 // HostSupports returns true if apparmor is enabled for the host, // On non-Linux returns false
 // On Linux returns true if apparmor_parser is enabled, and if we
-//  are not running docker-in-docker.
 //
-//  It is a modified version of libcontainer/apparmor.IsEnabled(), which does not
-//  check for apparmor_parser to be present, or if we're running docker-in-docker.
+//	are not running docker-in-docker.
+//
+//	It is a modified version of libcontainer/apparmor.IsEnabled(), which does not
+//	check for apparmor_parser to be present, or if we're running docker-in-docker.
 func HostSupports() bool {
 	return hostSupports()
 }

--- a/pkg/cri/opts/container.go
+++ b/pkg/cri/opts/container.go
@@ -83,7 +83,7 @@ func WithVolumes(volumeMounts map[string]string) containerd.NewContainerOpts {
 		// if it fails but not RM snapshot data.
 		// refer to https://github.com/containerd/containerd/pull/1868
 		// https://github.com/containerd/containerd/pull/1785
-		defer os.Remove(root) // nolint: errcheck
+		defer os.Remove(root) //nolint:errcheck
 
 		unmounter := func(mountPath string) {
 			if uerr := mount.Unmount(mountPath, 0); uerr != nil {

--- a/pkg/cri/opts/spec.go
+++ b/pkg/cri/opts/spec.go
@@ -77,7 +77,8 @@ func WithProcessArgs(config *runtime.ContainerConfig, image *imagespec.ImageConf
 
 // mounts defines how to sort runtime.Mount.
 // This is the same with the Docker implementation:
-//   https://github.com/moby/moby/blob/17.05.x/daemon/volumes.go#L26
+//
+//	https://github.com/moby/moby/blob/17.05.x/daemon/volumes.go#L26
 type orderedMounts []*runtime.Mount
 
 // Len returns the number of mounts. Used in sorting.

--- a/pkg/cri/server/events.go
+++ b/pkg/cri/server/events.go
@@ -234,11 +234,11 @@ func convertEvent(e *gogotypes.Any) (string, interface{}, error) {
 // event monitor.
 //
 // NOTE:
-// 1. start must be called after subscribe.
-// 2. The task exit event has been handled in individual startSandboxExitMonitor
-//    or startContainerExitMonitor goroutine at the first. If the goroutine fails,
-//    it puts the event into backoff retry queue and event monitor will handle
-//    it later.
+//  1. start must be called after subscribe.
+//  2. The task exit event has been handled in individual startSandboxExitMonitor
+//     or startContainerExitMonitor goroutine at the first. If the goroutine fails,
+//     it puts the event into backoff retry queue and event monitor will handle
+//     it later.
 func (em *eventMonitor) start() <-chan error {
 	errCh := make(chan error)
 	if em.ch == nil || em.errCh == nil {

--- a/pkg/cri/server/image_pull.go
+++ b/pkg/cri/server/image_pull.go
@@ -295,7 +295,7 @@ func (c *criService) getTLSConfig(registryTLSConfig criconfig.TLSConfig) (*tls.C
 		if len(cert.Certificate) != 0 {
 			tlsConfig.Certificates = []tls.Certificate{cert}
 		}
-		tlsConfig.BuildNameToCertificate() // nolint:staticcheck
+		tlsConfig.BuildNameToCertificate() //nolint:staticcheck
 	}
 
 	if registryTLSConfig.CAFile != "" {

--- a/pkg/cri/store/container/container.go
+++ b/pkg/cri/store/container/container.go
@@ -205,6 +205,6 @@ func (s *Store) Delete(id string) {
 		c.IO.Close()
 	}
 	s.labels.Release(c.ProcessLabel)
-	s.idIndex.Delete(id) // nolint: errcheck
+	s.idIndex.Delete(id) //nolint:errcheck
 	delete(s.containers, id)
 }

--- a/pkg/cri/store/container/status_test.go
+++ b/pkg/cri/store/container/status_test.go
@@ -132,8 +132,7 @@ func TestStatus(t *testing.T) {
 
 	t.Logf("failed update should not take effect")
 	err = s.Update(func(o Status) (Status, error) {
-		o = updateStatus
-		return o, updateErr
+		return updateStatus, updateErr
 	})
 	assert.Equal(updateErr, err)
 	assert.Equal(testStatus, s.Get())
@@ -143,8 +142,7 @@ func TestStatus(t *testing.T) {
 
 	t.Logf("successful update should take effect but not checkpoint")
 	err = s.Update(func(o Status) (Status, error) {
-		o = updateStatus
-		return o, nil
+		return updateStatus, nil
 	})
 	assert.NoError(err)
 	assert.Equal(updateStatus, s.Get())
@@ -153,14 +151,12 @@ func TestStatus(t *testing.T) {
 	assert.Equal(testStatus, loaded)
 	// Recover status.
 	assert.NoError(s.Update(func(o Status) (Status, error) {
-		o = testStatus
-		return o, nil
+		return testStatus, nil
 	}))
 
 	t.Logf("failed update sync should not take effect")
 	err = s.UpdateSync(func(o Status) (Status, error) {
-		o = updateStatus
-		return o, updateErr
+		return updateStatus, updateErr
 	})
 	assert.Equal(updateErr, err)
 	assert.Equal(testStatus, s.Get())
@@ -170,8 +166,7 @@ func TestStatus(t *testing.T) {
 
 	t.Logf("successful update sync should take effect and checkpoint")
 	err = s.UpdateSync(func(o Status) (Status, error) {
-		o = updateStatus
-		return o, nil
+		return updateStatus, nil
 	})
 	assert.NoError(err)
 	assert.Equal(updateStatus, s.Get())

--- a/pkg/cri/store/image/image.go
+++ b/pkg/cri/store/image/image.go
@@ -250,6 +250,6 @@ func (s *store) delete(id, ref string) {
 		return
 	}
 	// Remove the image if it is not referenced any more.
-	s.digestSet.Remove(digest) // nolint: errcheck
+	s.digestSet.Remove(digest) //nolint:errcheck
 	delete(s.images, digest.String())
 }

--- a/pkg/cri/store/sandbox/sandbox.go
+++ b/pkg/cri/store/sandbox/sandbox.go
@@ -156,6 +156,6 @@ func (s *Store) Delete(id string) {
 		return
 	}
 	s.labels.Release(s.sandboxes[id].ProcessLabel)
-	s.idIndex.Delete(id) // nolint: errcheck
+	s.idIndex.Delete(id) //nolint:errcheck
 	delete(s.sandboxes, id)
 }

--- a/pkg/cri/store/sandbox/status_test.go
+++ b/pkg/cri/store/sandbox/status_test.go
@@ -45,16 +45,14 @@ func TestStatus(t *testing.T) {
 
 	t.Logf("failed update should not take effect")
 	err := s.Update(func(o Status) (Status, error) {
-		o = updateStatus
-		return o, updateErr
+		return updateStatus, updateErr
 	})
 	assert.Equal(updateErr, err)
 	assert.Equal(testStatus, s.Get())
 
 	t.Logf("successful update should take effect but not checkpoint")
 	err = s.Update(func(o Status) (Status, error) {
-		o = updateStatus
-		return o, nil
+		return updateStatus, nil
 	})
 	assert.NoError(err)
 	assert.Equal(updateStatus, s.Get())

--- a/pkg/failpoint/fail.go
+++ b/pkg/failpoint/fail.go
@@ -68,7 +68,7 @@ func (t Type) String() string {
 // user. The user controlled variable will be parsed for how the error injected
 // code should fire. There is the way to set the rule for failpoint.
 //
-// 	<count>*<type>[(arg)][-><more terms>]
+//	<count>*<type>[(arg)][-><more terms>]
 //
 // The <type> argument specifies which action to take; it can be one of:
 //

--- a/pkg/ioutil/write_closer.go
+++ b/pkg/ioutil/write_closer.go
@@ -73,10 +73,10 @@ func (n *nopWriteCloser) Close() error {
 // serialWriteCloser wraps a write closer and makes sure all writes
 // are done in serial.
 // Parallel write won't intersect with each other. Use case:
-// 1) Pipe: Write content longer than PIPE_BUF.
-//    See http://man7.org/linux/man-pages/man7/pipe.7.html
-// 2) <3.14 Linux Kernel: write is not atomic
-//    See http://man7.org/linux/man-pages/man2/write.2.html
+//  1. Pipe: Write content longer than PIPE_BUF.
+//     See http://man7.org/linux/man-pages/man7/pipe.7.html
+//  2. <3.14 Linux Kernel: write is not atomic
+//     See http://man7.org/linux/man-pages/man2/write.2.html
 type serialWriteCloser struct {
 	mu sync.Mutex
 	wc io.WriteCloser

--- a/pkg/netns/netns_linux.go
+++ b/pkg/netns/netns_linux.go
@@ -77,7 +77,7 @@ func newNS(baseDir string) (nsPath string, err error) {
 	defer func() {
 		// Ensure the mount point is cleaned up on errors
 		if err != nil {
-			os.RemoveAll(nsPath) // nolint: errcheck
+			os.RemoveAll(nsPath) //nolint:errcheck
 		}
 	}()
 
@@ -107,7 +107,7 @@ func newNS(baseDir string) (nsPath string, err error) {
 		}
 
 		// Put this thread back to the orig ns, since it might get reused (pre go1.10)
-		defer origNS.Set() // nolint: errcheck
+		defer origNS.Set() //nolint:errcheck
 
 		// bind mount the netns from the current thread (from /proc) onto the
 		// mount point. This causes the namespace to persist, even when there
@@ -214,6 +214,6 @@ func (n *NetNS) Do(f func(cnins.NetNS) error) error {
 	if err != nil {
 		return fmt.Errorf("get netns fd: %w", err)
 	}
-	defer ns.Close() // nolint: errcheck
+	defer ns.Close() //nolint:errcheck
 	return ns.Do(f)
 }

--- a/pkg/os/os_windows.go
+++ b/pkg/os/os_windows.go
@@ -29,9 +29,10 @@ import (
 // It works for both file and directory paths.
 //
 // We are not able to use builtin Go functionality for opening a directory path:
-// - os.Open on a directory returns a os.File where Fd() is a search handle from FindFirstFile.
-// - syscall.Open does not provide a way to specify FILE_FLAG_BACKUP_SEMANTICS, which is needed to
-//   open a directory.
+//   - os.Open on a directory returns a os.File where Fd() is a search handle from FindFirstFile.
+//   - syscall.Open does not provide a way to specify FILE_FLAG_BACKUP_SEMANTICS, which is needed to
+//     open a directory.
+//
 // We could use os.Open if the path is a file, but it's easier to just use the same code for both.
 // Therefore, we call windows.CreateFile directly.
 func openPath(path string) (windows.Handle, error) {
@@ -58,6 +59,7 @@ func openPath(path string) (windows.Handle, error) {
 }
 
 // GetFinalPathNameByHandle flags.
+//
 //nolint:revive // SNAKE_CASE is not idiomatic in Go, but aligned with Win32 API.
 const (
 	cFILE_NAME_OPENED = 0x8

--- a/pkg/progress/escape.go
+++ b/pkg/progress/escape.go
@@ -19,6 +19,6 @@ package progress
 const (
 	escape = "\x1b"
 	reset  = escape + "[0m"
-	red    = escape + "[31m" // nolint: deadcode, varcheck, unused
+	red    = escape + "[31m" //nolint:deadcode, varcheck, unused
 	green  = escape + "[32m"
 )

--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -27,40 +27,40 @@
 // The vast majority of use cases should simply use the match function with
 // user input. The first step is to parse a specifier into a matcher:
 //
-//   m, err := Parse("linux")
-//   if err != nil { ... }
+//	m, err := Parse("linux")
+//	if err != nil { ... }
 //
 // Once you have a matcher, use it to match against the platform declared by a
 // component, typically from an image or runtime. Since extracting an images
 // platform is a little more involved, we'll use an example against the
 // platform default:
 //
-//   if ok := m.Match(Default()); !ok { /* doesn't match */ }
+//	if ok := m.Match(Default()); !ok { /* doesn't match */ }
 //
 // This can be composed in loops for resolving runtimes or used as a filter for
 // fetch and select images.
 //
 // More details of the specifier syntax and platform spec follow.
 //
-// Declaring Platform Support
+// # Declaring Platform Support
 //
 // Components that have strict platform requirements should use the OCI
 // platform specification to declare their support. Typically, this will be
 // images and runtimes that should make these declaring which platform they
 // support specifically. This looks roughly as follows:
 //
-//   type Platform struct {
-//	   Architecture string
-//	   OS           string
-//	   Variant      string
-//   }
+//	  type Platform struct {
+//		   Architecture string
+//		   OS           string
+//		   Variant      string
+//	  }
 //
 // Most images and runtimes should at least set Architecture and OS, according
 // to their GOARCH and GOOS values, respectively (follow the OCI image
 // specification when in doubt). ARM should set variant under certain
 // discussions, which are outlined below.
 //
-// Platform Specifiers
+// # Platform Specifiers
 //
 // While the OCI platform specifications provide a tool for components to
 // specify structured information, user input typically doesn't need the full
@@ -77,7 +77,7 @@
 // where the architecture may be known but a runtime may support images from
 // different operating systems.
 //
-// Normalization
+// # Normalization
 //
 // Because not all users are familiar with the way the Go runtime represents
 // platforms, several normalizations have been provided to make this package
@@ -85,17 +85,17 @@
 //
 // The following are performed for architectures:
 //
-//   Value    Normalized
-//   aarch64  arm64
-//   armhf    arm
-//   armel    arm/v6
-//   i386     386
-//   x86_64   amd64
-//   x86-64   amd64
+//	Value    Normalized
+//	aarch64  arm64
+//	armhf    arm
+//	armel    arm/v6
+//	i386     386
+//	x86_64   amd64
+//	x86-64   amd64
 //
 // We also normalize the operating system `macos` to `darwin`.
 //
-// ARM Support
+// # ARM Support
 //
 // To qualify ARM architecture, the Variant field is used to qualify the arm
 // version. The most common arm version, v7, is represented without the variant

--- a/process.go
+++ b/process.go
@@ -71,8 +71,10 @@ type ExitStatus struct {
 
 // Result returns the exit code and time of the exit status.
 // An error may be returned here to which indicates there was an error
-//   at some point while waiting for the exit status. It does not signify
-//   an error with the process itself.
+//
+//	at some point while waiting for the exit status. It does not signify
+//	an error with the process itself.
+//
 // If an error is returned, the process may still be running.
 func (s ExitStatus) Result() (uint32, time.Time, error) {
 	return s.code, s.exitedAt, s.err

--- a/reference/docker/reference.go
+++ b/reference/docker/reference.go
@@ -19,13 +19,13 @@
 //
 // Grammar
 //
-// 	reference                       := name [ ":" tag ] [ "@" digest ]
+//	reference                       := name [ ":" tag ] [ "@" digest ]
 //	name                            := [domain '/'] path-component ['/' path-component]*
 //	domain                          := domain-component ['.' domain-component]* [':' port-number]
 //	domain-component                := /([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])/
 //	port-number                     := /[0-9]+/
 //	path-component                  := alpha-numeric [separator alpha-numeric]*
-// 	alpha-numeric                   := /[a-z0-9]+/
+//	alpha-numeric                   := /[a-z0-9]+/
 //	separator                       := /[_.]|__|[-]*/
 //
 //	tag                             := /[\w][\w.-]{0,127}/

--- a/remotes/docker/config/hosts.go
+++ b/remotes/docker/config/hosts.go
@@ -541,13 +541,13 @@ func makeAbsPath(p string, base string) string {
 
 // loadCertsDir loads certs from certsDir like "/etc/docker/certs.d" .
 // Compatible with Docker file layout
-// - files ending with ".crt" are treated as CA certificate files
-// - files ending with ".cert" are treated as client certificates, and
-//   files with the same name but ending with ".key" are treated as the
-//   corresponding private key.
-//   NOTE: If a ".key" file is missing, this function will just return
-//   the ".cert", which may contain the private key. If the ".cert" file
-//   does not contain the private key, the caller should detect and error.
+//   - files ending with ".crt" are treated as CA certificate files
+//   - files ending with ".cert" are treated as client certificates, and
+//     files with the same name but ending with ".key" are treated as the
+//     corresponding private key.
+//     NOTE: If a ".key" file is missing, this function will just return
+//     the ".cert", which may contain the private key. If the ".cert" file
+//     does not contain the private key, the caller should detect and error.
 func loadCertFiles(ctx context.Context, certsDir string) ([]hostConfig, error) {
 	fs, err := os.ReadDir(certsDir)
 	if err != nil && !os.IsNotExist(err) {

--- a/remotes/handlers.go
+++ b/remotes/handlers.go
@@ -257,8 +257,8 @@ func PushContent(ctx context.Context, pusher Pusher, desc ocispec.Descriptor, st
 // An example of this kind of content would be a Windows base layer, which is not supposed to be redistributed.
 //
 // This is based on the media type of the content:
-// 	- application/vnd.oci.image.layer.nondistributable
-// 	- application/vnd.docker.image.rootfs.foreign
+//   - application/vnd.oci.image.layer.nondistributable
+//   - application/vnd.docker.image.rootfs.foreign
 func SkipNonDistributableBlobs(f images.HandlerFunc) images.HandlerFunc {
 	return func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 		if images.IsNonDistributable(desc.MediaType) {

--- a/script/setup/install-dev-tools
+++ b/script/setup/install-dev-tools
@@ -23,7 +23,7 @@ set -eu -o pipefail
 # install `protobuild` and other commands
 go install github.com/stevvooe/protobuild@v0.1.0
 go install github.com/cpuguy83/go-md2man/v2@v2.0.1
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.0
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
 
 # the following packages need to exist in $GOPATH so we can't use
 # go modules-aware mode of `go get` for these includes used during

--- a/script/setup/prepare_env_windows.ps1
+++ b/script/setup/prepare_env_windows.ps1
@@ -1,6 +1,6 @@
 # Prepare windows environment for building and running containerd tests
 
-$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.17.13"; make = ""; nssm = "" }
+$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.18.7"; make = ""; nssm = "" }
 
 Write-Host "Downloading chocolatey package"
 curl.exe -L "https://packages.chocolatey.org/chocolatey.0.10.15.nupkg" -o 'c:\choco.zip'

--- a/snapshots/devmapper/dmsetup/dmsetup.go
+++ b/snapshots/devmapper/dmsetup/dmsetup.go
@@ -353,7 +353,8 @@ func BlockDeviceSize(path string) (int64, error) {
 }
 
 // DiscardBlocks discards all blocks for the given thin device
-//  ported from https://github.com/moby/moby/blob/7b9275c0da707b030e62c96b679a976f31f929d3/pkg/devicemapper/devmapper.go#L416
+//
+//	ported from https://github.com/moby/moby/blob/7b9275c0da707b030e62c96b679a976f31f929d3/pkg/devicemapper/devmapper.go#L416
 func DiscardBlocks(deviceName string) error {
 	inUse, err := isInUse(deviceName)
 	if err != nil {
@@ -402,8 +403,10 @@ func tryGetUnixError(output string) (unix.Errno, bool) {
 }
 
 // dmsetup returns error messages in format:
-// 	device-mapper: message ioctl on <name> failed: File exists\n
-// 	Command failed\n
+//
+//	device-mapper: message ioctl on <name> failed: File exists\n
+//	Command failed\n
+//
 // parseDmsetupError extracts text between "failed: " and "\n"
 func parseDmsetupError(output string) string {
 	lines := strings.SplitN(output, "\n", 2)

--- a/snapshots/devmapper/pool_device.go
+++ b/snapshots/devmapper/pool_device.go
@@ -484,7 +484,9 @@ func (p *PoolDevice) IsLoaded(deviceName string) bool {
 // GetUsage reports total size in bytes consumed by a thin-device.
 // It relies on the number of used blocks reported by 'dmsetup status'.
 // The output looks like:
-//  device2: 0 204800 thin 17280 204799
+//
+//	device2: 0 204800 thin 17280 204799
+//
 // Where 17280 is the number of used sectors
 func (p *PoolDevice) GetUsage(deviceName string) (int64, error) {
 	status, err := dmsetup.Status(deviceName)

--- a/snapshots/snapshotter.go
+++ b/snapshots/snapshotter.go
@@ -153,10 +153,10 @@ type WalkFunc func(context.Context, Info) error
 // For consistency, we define the following terms to be used throughout this
 // interface for snapshotter implementations:
 //
-// 	`ctx` - refers to a context.Context
-// 	`key` - refers to an active snapshot
-// 	`name` - refers to a committed snapshot
-// 	`parent` - refers to the parent in relation
+//	`ctx` - refers to a context.Context
+//	`key` - refers to an active snapshot
+//	`name` - refers to a committed snapshot
+//	`parent` - refers to the parent in relation
 //
 // Most methods take various combinations of these identifiers. Typically,
 // `name` and `parent` will be used in cases where a method *only* takes
@@ -168,7 +168,7 @@ type WalkFunc func(context.Context, Info) error
 // We cover several examples below to demonstrate the utility of a snapshot
 // snapshotter.
 //
-// Importing a Layer
+// # Importing a Layer
 //
 // To import a layer, we simply have the Snapshotter provide a list of
 // mounts to be applied such that our dst will capture a changeset. We start
@@ -185,7 +185,7 @@ type WalkFunc func(context.Context, Info) error
 //		"containerd.io/gc.root": time.Now().UTC().Format(time.RFC3339),
 //	})
 //	mounts, err := snapshotter.Prepare(ctx, key, "", noGcOpt)
-// 	if err != nil { ... }
+//	if err != nil { ... }
 //
 // We get back a list of mounts from Snapshotter.Prepare, with the key identifying
 // the active snapshot. Mount this to the temporary location with the
@@ -202,8 +202,8 @@ type WalkFunc func(context.Context, Info) error
 //
 //	layer, err := os.Open(layerPath)
 //	if err != nil { ... }
-// 	digest, err := unpackLayer(tmpLocation, layer) // unpack into layer location
-// 	if err != nil { ... }
+//	digest, err := unpackLayer(tmpLocation, layer) // unpack into layer location
+//	if err != nil { ... }
 //
 // When the above completes, we should have a filesystem the represents the
 // contents of the layer. Careful implementations should verify that digest
@@ -221,30 +221,30 @@ type WalkFunc func(context.Context, Info) error
 // Now, we have a layer in the Snapshotter that can be accessed with the digest
 // provided during commit.
 //
-// Importing the Next Layer
+// # Importing the Next Layer
 //
 // Making a layer depend on the above is identical to the process described
 // above except that the parent is provided as parent when calling
 // Manager.Prepare, assuming a clean, unique key identifier:
 //
-// 	mounts, err := snapshotter.Prepare(ctx, key, parentDigest, noGcOpt)
+//	mounts, err := snapshotter.Prepare(ctx, key, parentDigest, noGcOpt)
 //
 // We then mount, apply and commit, as we did above. The new snapshot will be
 // based on the content of the previous one.
 //
-// Running a Container
+// # Running a Container
 //
 // To run a container, we simply provide Snapshotter.Prepare the committed image
 // snapshot as the parent. After mounting, the prepared path can
 // be used directly as the container's filesystem:
 //
-// 	mounts, err := snapshotter.Prepare(ctx, containerKey, imageRootFSChainID)
+//	mounts, err := snapshotter.Prepare(ctx, containerKey, imageRootFSChainID)
 //
 // The returned mounts can then be passed directly to the container runtime. If
 // one would like to create a new image from the filesystem, Manager.Commit is
 // called:
 //
-// 	if err := snapshotter.Commit(ctx, newImageSnapshot, containerKey); err != nil { ... }
+//	if err := snapshotter.Commit(ctx, newImageSnapshot, containerKey); err != nil { ... }
 //
 // Alternatively, for most container runs, Snapshotter.Remove will be called to
 // signal the Snapshotter to abandon the changes.

--- a/snapshots/testsuite/testsuite.go
+++ b/snapshots/testsuite/testsuite.go
@@ -500,7 +500,7 @@ func checkDeletedFilesInChildSnapshot(ctx context.Context, t *testing.T, snapsho
 
 }
 
-//Create three layers. Deleting intermediate layer must fail.
+// Create three layers. Deleting intermediate layer must fail.
 func checkRemoveIntermediateSnapshot(ctx context.Context, t *testing.T, snapshotter snapshots.Snapshotter, work string) {
 
 	base, err := snapshotterPrepareMount(ctx, snapshotter, "base", "", work)
@@ -554,12 +554,13 @@ func checkRemoveIntermediateSnapshot(ctx context.Context, t *testing.T, snapshot
 
 // baseTestSnapshots creates a base set of snapshots for tests, each snapshot is empty
 // Tests snapshots:
-//  c1 - committed snapshot, no parent
-//  c2 - committed snapshot, c1 is parent
-//  a1 - active snapshot, c2 is parent
-//  a1 - active snapshot, no parent
-//  v1 - view snapshot, v1 is parent
-//  v2 - view snapshot, no parent
+//
+//	c1 - committed snapshot, no parent
+//	c2 - committed snapshot, c1 is parent
+//	a1 - active snapshot, c2 is parent
+//	a1 - active snapshot, no parent
+//	v1 - view snapshot, v1 is parent
+//	v2 - view snapshot, no parent
 func baseTestSnapshots(ctx context.Context, snapshotter snapshots.Snapshotter) error {
 	if _, err := snapshotter.Prepare(ctx, "c1-a", "", opt); err != nil {
 		return err


### PR DESCRIPTION
- relates to https://github.com/containerd/containerd/pull/7474

From the mailing list:

We have just released Go versions 1.19.2 and 1.18.7, minor point releases.

These minor releases include 3 security fixes following the security policy:

- archive/tar: unbounded memory consumption when reading headers

  Reader.Read did not set a limit on the maximum size of file headers. A maliciously crafted archive could cause Read to allocate unbounded amounts of memory, potentially causing resource exhaustion or panics. Reader.Read now limits the maximum size of header blocks to 1 MiB.

  Thanks to Adam Korczynski (ADA Logics) and OSS-Fuzz for reporting this issue.

  This is CVE-2022-2879 and Go issue https://go.dev/issue/54853.

- net/http/httputil: ReverseProxy should not forward unparseable query parameters

  Requests forwarded by ReverseProxy included the raw query parameters from the inbound request, including unparseable parameters rejected by net/http. This could permit query parameter smuggling when a Go proxy forwards a parameter with an unparseable value.

  ReverseProxy will now sanitize the query parameters in the forwarded query when the outbound request's Form field is set after the ReverseProxy.Director function returns, indicating that the proxy has parsed the query parameters. Proxies which do not parse query parameters continue to forward the original query parameters unchanged.

  Thanks to Gal Goldstein (Security Researcher, Oxeye) and Daniel Abeles (Head of Research, Oxeye) for reporting this issue.

  This is CVE-2022-2880 and Go issue https://go.dev/issue/54663.

- regexp/syntax: limit memory used by parsing regexps

  The parsed regexp representation is linear in the size of the input, but in some cases the constant factor can be as high as 40,000, making relatively small regexps consume much larger amounts of memory.

  Each regexp being parsed is now limited to a 256 MB memory footprint. Regular expressions whose representation would use more space than that are now rejected. Normal use of regular expressions is unaffected.

  Thanks to Adam Korczynski (ADA Logics) and OSS-Fuzz for reporting this issue.

  This is CVE-2022-41715 and Go issue https://go.dev/issue/55949.

View the release notes for more information: https://go.dev/doc/devel/release#go1.18.7
