### PR TITLE
fuzzing: create structured tar bytes in archive fuzzer

### DIFF
--- a/contrib/fuzz/archive_fuzzer.go
+++ b/contrib/fuzz/archive_fuzzer.go
@@ -67,7 +67,7 @@ func FuzzApply(data []byte) int {
 // that targets archive.ImportIndex()
 func FuzzImportIndex(data []byte) int {
 	f := fuzz.NewConsumer(data)
-	tarBytes, err := f.GetBytes()
+	tarBytes, err := f.TarBytes()
 	if err != nil {
 		return 0
 	}


### PR DESCRIPTION
`TarBytes` has undergone some work with a few more improvements which makes it more suitable for the archive fuzzer.

@kzys 

Signed-off-by: AdamKorcz <adam@adalogics.com>