### PR TITLE
fix install cni script

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -152,7 +152,8 @@ EOF
         source /etc/environment
         source /etc/profile.d/sh.local
         set -eux -o pipefail
-        ${GOPATH}/src/github.com/containerd/containerd/script/setup/install-cni
+        cd ${GOPATH}/src/github.com/containerd/containerd
+        script/setup/install-cni
         PATH=/opt/cni/bin:$PATH type ${CNI_BINARIES} || true
     SHELL
   end

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -40,9 +40,8 @@ WORKDIR /go/src/github.com/containerd/containerd
 
 FROM golang AS cni
 ENV DESTDIR=/build
-COPY script/setup/install-cni ./
-COPY go.mod /go/src/github.com/containerd/containerd/go.mod
-RUN ./install-cni
+COPY script/setup/install-cni go.mod /
+RUN DESTDIR=/build /install-cni
 
 FROM golang AS critools
 ARG DESTDIR=/build

--- a/script/setup/install-cni
+++ b/script/setup/install-cni
@@ -21,7 +21,7 @@
 #
 set -eu -o pipefail
 
-CNI_COMMIT=${1:-$(grep containernetworking/plugins "$GOPATH"/src/github.com/containerd/containerd/go.mod | awk '{print $2}')}
+CNI_COMMIT=${1:-$(go list -f "{{.Version}}" -m github.com/containernetworking/plugins)}
 CNI_DIR=${DESTDIR:=''}/opt/cni
 CNI_CONFIG_DIR=${DESTDIR}/etc/cni/net.d
 


### PR DESCRIPTION
Replace the source of the read value, from `"$GOPATH"/src/github.com/containerd/containerd/go.mod` changing to `go.mod` or `../../go.mod`.

issue: https://github.com/containerd/containerd/issues/7472