### PR TITLE
[release/1.6] archive: validate digests before use

### DIFF
--- a/images/archive/importer.go
+++ b/images/archive/importer.go
@@ -300,6 +300,9 @@ func resolveLayers(ctx context.Context, store content.Store, layerFiles []string
 		}
 		if s.GetCompression() == compression.Uncompressed {
 			if compress {
+				if err := desc.Digest.Validate(); err != nil {
+					return nil, err
+				}
 				ref := fmt.Sprintf("compress-blob-%s-%s", desc.Digest.Algorithm().String(), desc.Digest.Encoded())
 				labels := map[string]string{
 					"containerd.io/uncompressed": desc.Digest.String(),


### PR DESCRIPTION
digest.Algorithm() and digest.Encoded() may panic for invalid digests. Validate prior to calling those methods.

Signed-off-by: Samuel Karp <samuelkarp@google.com>
(cherry picked from commit f9c9121e5340acfedc29140a86c5fdc479a678fb)
Signed-off-by: Samuel Karp <samuelkarp@google.com>