### PR TITLE
archive: windows: chtimes(): remove redundant conversion

### DIFF
--- a/archive/time_windows.go
+++ b/archive/time_windows.go
@@ -25,18 +25,17 @@ import (
 // chtimes will set the create time on a file using the given modtime.
 // This requires calling SetFileTime and explicitly including the create time.
 func chtimes(path string, atime, mtime time.Time) error {
-	ctimespec := windows.NsecToTimespec(mtime.UnixNano())
-	pathp, e := windows.UTF16PtrFromString(path)
-	if e != nil {
-		return e
+	pathp, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return err
 	}
-	h, e := windows.CreateFile(pathp,
+	h, err := windows.CreateFile(pathp,
 		windows.FILE_WRITE_ATTRIBUTES, windows.FILE_SHARE_WRITE, nil,
 		windows.OPEN_EXISTING, windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
-	if e != nil {
-		return e
+	if err != nil {
+		return err
 	}
 	defer windows.Close(h)
-	c := windows.NsecToFiletime(windows.TimespecToNsec(ctimespec))
+	c := windows.NsecToFiletime(mtime.UnixNano())
 	return windows.SetFileTime(h, &c, nil, nil)
 }


### PR DESCRIPTION
It looks like this function was converting the time (`windows.NsecToTimespec()`), only to convert it back (`windows.TimespecToNsec()`). This became clear when moving the lines together:

```go
ctimespec := windows.NsecToTimespec(ctime.UnixNano())
c := windows.NsecToFiletime(windows.TimespecToNsec(ctimespec))
```

And looking at the Golang code, it looks like they're indeed the exact reverse:

```go
func TimespecToNsec(ts Timespec) int64 { return int64(ts.Sec)*1e9 + int64(ts.Nsec) }

func NsecToTimespec(nsec int64) (ts Timespec) {
    ts.Sec = nsec / 1e9
    ts.Nsec = nsec % 1e9
    return
}
```

While modifying this code, also renaming the `e` variable to a more common `err`.
