### PR TITLE
diff/apply.readCounter: check negative size

### DIFF
--- a/diff/apply/apply.go
+++ b/diff/apply/apply.go
@@ -125,6 +125,8 @@ type readCounter struct {
 
 func (rc *readCounter) Read(p []byte) (n int, err error) {
 	n, err = rc.r.Read(p)
-	rc.c += int64(n)
+	if n > 0 {
+		rc.c += int64(n)
+	}
 	return
 }


### PR DESCRIPTION
`rc.r.Read()` may return a negative `int` on an error when the reader is set to a custom content store implementation
