### PR TITLE
cmd/containerd: replace deprecated windows.IsAnInteractiveSession()

### DIFF
--- a/cmd/containerd/command/service_windows.go
+++ b/cmd/containerd/command/service_windows.go
@@ -307,16 +307,17 @@ func launchService(s *server.Server, done chan struct{}) error {
 		done:    done,
 	}
 
-	interactive, err := svc.IsAnInteractiveSession() // nolint:staticcheck
+	// Check if we're running as a Windows service or interactively.
+	isService, err := svc.IsWindowsService()
 	if err != nil {
 		return err
 	}
 
 	go func() {
-		if interactive {
-			err = debug.Run(serviceNameFlag, h)
-		} else {
+		if isService {
 			err = svc.Run(serviceNameFlag, h)
+		} else {
+			err = debug.Run(serviceNameFlag, h)
 		}
 		h.fromsvc <- err
 	}()


### PR DESCRIPTION
- relates to https://github.com/containerd/containerd/pull/7349#discussion_r990638738
- relates to https://github.com/containerd/containerd/pull/4626

The `//nolint` comment was added in https://github.com/containerd/containerd/commit/edc671d6a0192111e20578fc19531cb74fd8ce96 (https://github.com/containerd/containerd/pull/4626) to suppress the deprecation warning.

The `IsAnInteractiveSession` was deprecated, and `IsWindowsService` is marked as the recommended replacement.

For details, see https://github.com/golang/sys/commit/280f808b4a5303f80a30dd9dc62f9a042d992ad0

> CL 244958 includes isWindowsService function that determines if a
> process is running as a service. The code of the function is based on
> public .Net implementation.
>
> IsAnInteractiveSession function implements similar functionality, but
> is based on an old Stackoverflow post., which is not as authoritative
> as code written by Microsoft for their official product.
>
> This change copies CL 244958 isWindowsService function into svc package
> and makes it public. The intention is that future users will prefer
> IsWindowsService to IsAnInteractiveSession.
