### PR TITLE
runtime/v2/shim: clean up the use of containerdBinary

### DIFF
--- a/runtime/v2/runc/manager/manager_linux.go
+++ b/runtime/v2/runc/manager/manager_linux.go
@@ -69,7 +69,7 @@ type manager struct {
 	name string
 }
 
-func newCommand(ctx context.Context, id, containerdBinary, containerdAddress, containerdTTRPCAddress string, debug bool) (*exec.Cmd, error) {
+func newCommand(ctx context.Context, id, containerdAddress, containerdTTRPCAddress string, debug bool) (*exec.Cmd, error) {
 	ns, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {
 		return nil, err
@@ -117,7 +117,7 @@ func (m manager) Name() string {
 }
 
 func (manager) Start(ctx context.Context, id string, opts shim.StartOpts) (_ string, retErr error) {
-	cmd, err := newCommand(ctx, id, opts.ContainerdBinary, opts.Address, opts.TTRPCAddress, opts.Debug)
+	cmd, err := newCommand(ctx, id, opts.Address, opts.TTRPCAddress, opts.Debug)
 	if err != nil {
 		return "", err
 	}

--- a/runtime/v2/runc/v1/service.go
+++ b/runtime/v2/runc/v1/service.go
@@ -103,7 +103,7 @@ type service struct {
 	cancel func()
 }
 
-func newCommand(ctx context.Context, id, containerdBinary, containerdAddress, containerdTTRPCAddress string) (*exec.Cmd, error) {
+func newCommand(ctx context.Context, id, containerdAddress, containerdTTRPCAddress string) (*exec.Cmd, error) {
 	ns, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {
 		return nil, err
@@ -131,7 +131,7 @@ func newCommand(ctx context.Context, id, containerdBinary, containerdAddress, co
 }
 
 func (s *service) StartShim(ctx context.Context, opts shim.StartOpts) (_ string, retErr error) {
-	cmd, err := newCommand(ctx, opts.ID, opts.ContainerdBinary, opts.Address, opts.TTRPCAddress)
+	cmd, err := newCommand(ctx, opts.ID, opts.Address, opts.TTRPCAddress)
 	if err != nil {
 		return "", err
 	}

--- a/runtime/v2/shim/shim.go
+++ b/runtime/v2/shim/shim.go
@@ -51,7 +51,7 @@ type Publisher interface {
 // StartOpts describes shim start configuration received from containerd
 type StartOpts struct {
 	ID               string // TODO(2.0): Remove ID, passed directly to start for call symmetry
-	ContainerdBinary string
+	ContainerdBinary string // TODO(2.0): Remove ContainerdBinary, use the TTRPC_ADDRESS env to forward events
 	Address          string
 	TTRPCAddress     string
 	Debug            bool
@@ -148,7 +148,9 @@ func parseFlags() {
 	flag.StringVar(&bundlePath, "bundle", "", "path to the bundle if not workdir")
 
 	flag.StringVar(&addressFlag, "address", "", "grpc address back to main containerd")
-	flag.StringVar(&containerdBinaryFlag, "publish-binary", "containerd", "path to publish binary (used for publishing events)")
+	flag.StringVar(&containerdBinaryFlag, "publish-binary", "",
+		fmt.Sprintf("path to publish binary (used for publishing events), but %s will ignore this flag, please use the %s env", os.Args[0], ttrpcAddressEnv),
+	)
 
 	flag.Parse()
 	action = flag.Arg(0)
@@ -333,10 +335,9 @@ func run(ctx context.Context, manager Manager, initFunc Init, name string, confi
 		return nil
 	case "start":
 		opts := StartOpts{
-			ContainerdBinary: containerdBinaryFlag,
-			Address:          addressFlag,
-			TTRPCAddress:     ttrpcAddress,
-			Debug:            debugFlag,
+			Address:      addressFlag,
+			TTRPCAddress: ttrpcAddress,
+			Debug:        debugFlag,
 		}
 
 		address, err := manager.Start(ctx, id, opts)


### PR DESCRIPTION
The shim based on the file *shim/shim.go* no longer needs to use public flag to publish events, instead using the `TTRPC_ADDRESS` environment variable, we can remove the meaningless use of containerdBinary

Of course, for compatibility we still need to support `--publish-binary` flag.