### PR TITLE
Stats() shouldn't assume s.container is non-nil

### DIFF
--- a/runtime/v2/runc/v1/service.go
+++ b/runtime/v2/runc/v1/service.go
@@ -596,7 +596,11 @@ func (s *service) Shutdown(ctx context.Context, r *taskAPI.ShutdownRequest) (*pt
 }
 
 func (s *service) Stats(ctx context.Context, r *taskAPI.StatsRequest) (*taskAPI.StatsResponse, error) {
-	cgx := s.container.Cgroup()
+	container, err := s.getContainer()
+	if err != nil {
+		return nil, err
+	}
+	cgx := container.Cgroup()
 	if cgx == nil {
 		return nil, errdefs.ToGRPCf(errdefs.ErrNotFound, "cgroup does not exist")
 	}


### PR DESCRIPTION
Like other exported methods, Stats() shouldn't assume s.container is non-nil.

Fixes #7468.