### PR TITLE
fix the --no-pivot flag being ignored by `ctr tasks start`

### DIFF
--- a/cmd/ctr/commands/tasks/start.go
+++ b/cmd/ctr/commands/tasks/start.go
@@ -31,7 +31,7 @@ var startCommand = cli.Command{
 	Name:      "start",
 	Usage:     "start a container that has been created",
 	ArgsUsage: "CONTAINER",
-	Flags: []cli.Flag{
+	Flags: append(platformStartFlags, []cli.Flag{
 		cli.BoolFlag{
 			Name:  "null-io",
 			Usage: "send all IO to /dev/null",
@@ -52,7 +52,7 @@ var startCommand = cli.Command{
 			Name:  "detach,d",
 			Usage: "detach from the task after it has started execution",
 		},
-	},
+	}...),
 	Action: func(context *cli.Context) error {
 		var (
 			err    error

--- a/cmd/ctr/commands/tasks/tasks_unix.go
+++ b/cmd/ctr/commands/tasks/tasks_unix.go
@@ -34,11 +34,11 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func init() {
-	startCommand.Flags = append(startCommand.Flags, cli.BoolFlag{
+var platformStartFlags = []cli.Flag{
+	cli.BoolFlag{
 		Name:  "no-pivot",
 		Usage: "disable use of pivot-root (linux only)",
-	})
+	},
 }
 
 // HandleConsoleResize resizes the console

--- a/cmd/ctr/commands/tasks/tasks_windows.go
+++ b/cmd/ctr/commands/tasks/tasks_windows.go
@@ -29,6 +29,8 @@ import (
 	"github.com/urfave/cli"
 )
 
+var platformStartFlags = []cli.Flag{}
+
 // HandleConsoleResize resizes the console
 func HandleConsoleResize(ctx gocontext.Context, task resizer, con console.Console) error {
 	// do an initial resize of the console


### PR DESCRIPTION
```bash
$ ctr tasks start -h
NAME:
   ctr tasks start - start a container that has been created

USAGE:
   ctr tasks start [command options] CONTAINER

OPTIONS:
   --null-io         send all IO to /dev/null
   --log-uri value   log uri
   --fifo-dir value  directory used for storing IO FIFOs
   --pid-file value  file path to write the task's pid
   --detach, -d      detach from the task after it has started execution
```
->
```bash
$ ctr tasks start -h
NAME:
   ctr tasks start - start a container that has been created

USAGE:
   ctr tasks start [command options] CONTAINER

OPTIONS:
   --no-pivot        disable use of pivot-root (linux only)
   --null-io         send all IO to /dev/null
   --log-uri value   log uri
   --fifo-dir value  directory used for storing IO FIFOs
   --pid-file value  file path to write the task's pid
   --detach, -d      detach from the task after it has started execution
```