### PR TITLE
add option to resolve symlinks in WithLinuxDevice

### DIFF
--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -1307,11 +1307,27 @@ func WithLinuxDevices(devices []specs.LinuxDevice) SpecOpts {
 	}
 }
 
+func WithLinuxDeviceFollowSymlinks(path, permissions string) SpecOpts {
+	return withLinuxDevice(path, permissions, true)
+}
+
 // WithLinuxDevice adds the device specified by path to the spec
 func WithLinuxDevice(path, permissions string) SpecOpts {
+	return withLinuxDevice(path, permissions, false)
+}
+
+func withLinuxDevice(path, permissions string, followSymlinks bool) SpecOpts {
 	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
 		setLinux(s)
 		setResources(s)
+
+		if followSymlinks {
+			resolvedPath, err := filepath.EvalSymlinks(path)
+			if err != nil {
+				return err
+			}
+			path = resolvedPath
+		}
 
 		dev, err := DeviceFromPath(path)
 		if err != nil {


### PR DESCRIPTION
This change adds `withLinuxDevice` to take an option `followSymlinks`. An option
`WithLinuxDeviceFollowSymlinks` will call this unexported option to
follow a symlink, which will resolve a symlink before calling
`DeviceFromPath`. `WithLinuxDevice` has been changed to call
`withLinuxDevice` without following symlinks.


~~Previously DeviceFromPath used Lstat to get information about a device file, but Lstat will not follow symlinks; stat will. The use case could be using a tool like [`udev`](https://wiki.archlinux.org/title/udev) which will create symlinks to devices and wishing to attach one of these devices to a container.~~

~~It looks like `DeviceFromPath` is coming from runc, which does use Lstat instead of Stat but I didn't find any discussions as to why not resolve symlinks: [opencontainers/runc/libcontainer/devices/device_unix.go](https://github.com/opencontainers/runc/blob/70e3b757c0eb39221aa5a4dbeb723c88f348f5cd/libcontainer/devices/device_unix.go#L33)~~

Docker is resolving symlinks themselves before calling this function: 
[moby/moby/oci/devices_linux.go](https://github.com/moby/moby/blob/968a0bcd636b3720d2178d5dfed691c00c68e4a1/oci/devices_linux.go#L24-L34)

which they did after some previous discussions in these issues/PRs:

* https://github.com/moby/moby/issues/13840
* https://github.com/moby/moby/pull/20684
* https://github.com/moby/moby/issues/13706
* https://github.com/moby/moby/pull/22272


Fixes #7006

Signed-off-by: Gavin Inglis <giinglis@amazon.com>