### PR TITLE
Dash is considered as a field instead as separator 

### DIFF
--- a/filters/scanner.go
+++ b/filters/scanner.go
@@ -138,6 +138,10 @@ chomp:
 		return pos, tokenValue, s.input[pos:s.ppos]
 	case isFieldRune(ch):
 		s.scanField()
+		if ch == '-' || isDigitRune(ch) { // illegal token if it starts with '-' or any digit
+			s.error("illegal token field")
+			return pos, tokenIllegal, s.input[pos:s.ppos]
+		}
 		return pos, tokenField, s.input[pos:s.ppos]
 	}
 
@@ -249,7 +253,7 @@ func digitVal(ch rune) int {
 }
 
 func isFieldRune(r rune) bool {
-	return (r == '_' || isAlphaRune(r) || isDigitRune(r))
+	return (r == '-' || r == '_' || isAlphaRune(r) || isDigitRune(r))
 }
 
 func isAlphaRune(r rune) bool {

--- a/filters/scanner_test.go
+++ b/filters/scanner_test.go
@@ -66,7 +66,7 @@ func TestScanner(t *testing.T) {
 		},
 		{
 			name:  "SelectorsWithFieldPaths",
-			input: "name==value,labels.foo=value,other.bar~=match",
+			input: "name==value,labels.foo=value,other.bar~=match,labels.io-foo==value",
 			expected: []tokenResult{
 				{pos: 0, token: tokenField, text: "name"},
 				{pos: 4, token: tokenOperator, text: "=="},
@@ -83,7 +83,13 @@ func TestScanner(t *testing.T) {
 				{pos: 35, token: tokenField, text: "bar"},
 				{pos: 38, token: tokenOperator, text: "~="},
 				{pos: 40, token: tokenValue, text: "match"},
-				{pos: 45, token: tokenEOF},
+				{pos: 45, token: tokenSeparator, text: ","},
+				{pos: 46, token: tokenField, text: "labels"},
+				{pos: 52, token: tokenSeparator, text: "."},
+				{pos: 53, token: tokenField, text: "io-foo"},
+				{pos: 59, token: tokenOperator, text: "=="},
+				{pos: 61, token: tokenValue, text: "value"},
+				{pos: 66, token: tokenEOF},
 			},
 		},
 		{
@@ -308,6 +314,30 @@ func TestScanner(t *testing.T) {
 				{pos: 6, token: tokenSeparator, text: "."},
 				{pos: 7, token: tokenIllegal, text: `"\g"`, err: "illegal escape sequence"},
 				{pos: 11, token: tokenEOF},
+			},
+		},
+		{
+			name:  "IllegalTokenFiledWithNumber",
+			input: `labels.1io-foo==value`,
+			expected: []tokenResult{
+				{pos: 0, token: tokenField, text: "labels"},
+				{pos: 6, token: tokenSeparator, text: "."},
+				{pos: 7, token: tokenIllegal, text: `1io-foo`, err: "illegal token field"},
+				{pos: 14, token: tokenOperator, text: "=="},
+				{pos: 16, token: tokenValue, text: "value"},
+				{pos: 21, token: tokenEOF},
+			},
+		},
+		{
+			name:  "IllegalTokenField",
+			input: `labels.-io-foo==value`,
+			expected: []tokenResult{
+				{pos: 0, token: tokenField, text: "labels"},
+				{pos: 6, token: tokenSeparator, text: "."},
+				{pos: 7, token: tokenIllegal, text: `-io-foo`, err: "illegal token field"},
+				{pos: 14, token: tokenOperator, text: "=="},
+				{pos: 16, token: tokenValue, text: "value"},
+				{pos: 21, token: tokenEOF},
 			},
 		},
 		{


### PR DESCRIPTION
Signed-off-by: Vaishnavi Vejella <vvejella@amazon.com>

**Description #5642:**
Containers have labels and they act as filters when querying the containers. So, while checking a label with the 'dash' which is failing because '-'  is interpreting here as an operator and it is not considering as a part of token field.
**Solution:**
This problem can be solved by treating `-` as a component of the field rather than a separator.
Also, it appears that there are some places where it is assumed that `.` is the only separator in a fieldpath.
[e.g]https://github.com/containerd/containerd/blob/902212651b12e4d81b7bc779632b2e4da0a8e673/metadata/adaptors.go#L175