### PR TITLE
sys: optimize and refactor MkdirAllWithACL()

### DIFF
--- a/sys/filesys_windows.go
+++ b/sys/filesys_windows.go
@@ -67,11 +67,7 @@ func mkdirall(path string, perm *windows.SecurityAttributes) error {
 		if dir.IsDir() {
 			return nil
 		}
-		return &os.PathError{
-			Op:   "mkdir",
-			Path: path,
-			Err:  syscall.ENOTDIR,
-		}
+		return &os.PathError{Op: "mkdir", Path: path, Err: syscall.ENOTDIR}
 	}
 
 	// Slow path: make sure parent exists and then call Mkdir for path.
@@ -86,14 +82,14 @@ func mkdirall(path string, perm *windows.SecurityAttributes) error {
 	}
 
 	if j > 1 {
-		// Create parent
-		err = mkdirall(path[0:j-1], perm)
+		// Create parent.
+		err = mkdirall(fixRootDirectory(path[:j-1]), perm)
 		if err != nil {
 			return err
 		}
 	}
 
-	// Parent now exists; invoke os.Mkdir or mkdirWithACL and use its result.
+	// Parent now exists; invoke Mkdir and use its result.
 	err = mkdirWithACL(path, perm)
 	if err != nil {
 		// Handle arguments like "foo/." by
@@ -129,6 +125,17 @@ func mkdirWithACL(name string, sa *windows.SecurityAttributes) error {
 		return &os.PathError{Op: "mkdir", Path: name, Err: err}
 	}
 	return nil
+}
+
+// fixRootDirectory fixes a reference to a drive's root directory to
+// have the required trailing slash.
+func fixRootDirectory(p string) string {
+	if len(p) == len(`\\?\c:`) {
+		if os.IsPathSeparator(p[0]) && os.IsPathSeparator(p[1]) && p[2] == '?' && os.IsPathSeparator(p[3]) && p[5] == ':' {
+			return p + `\`
+		}
+	}
+	return p
 }
 
 func makeSecurityAttributes(sddl string) (*windows.SecurityAttributes, error) {

--- a/sys/filesys_windows.go
+++ b/sys/filesys_windows.go
@@ -29,8 +29,9 @@ import (
 const SddlAdministratorsLocalSystem = "D:P(A;OICI;GA;;;BA)(A;OICI;GA;;;SY)"
 
 // volumePath is a regular expression to check if a path is a Windows
-// volume path (e.g., "\\?\Volume{4c1b02c1-d990-11dc-99ae-806e6f6e6963}".
-var volumePath = regexp.MustCompile(`^\\\\\?\\Volume{[a-z0-9-]+}$`)
+// volume path (e.g., "\\?\Volume{4c1b02c1-d990-11dc-99ae-806e6f6e6963}"
+// or "\\?\Volume{4c1b02c1-d990-11dc-99ae-806e6f6e6963}\").
+var volumePath = regexp.MustCompile(`^\\\\\?\\Volume{[a-z0-9-]+}\\?$`)
 
 // MkdirAllWithACL is a custom version of os.MkdirAll modified for use on Windows
 // so that it is both volume path aware, and to create a directory

--- a/sys/filesys_windows.go
+++ b/sys/filesys_windows.go
@@ -25,19 +25,22 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-const (
-	// SddlAdministratorsLocalSystem is local administrators plus NT AUTHORITY\System
-	SddlAdministratorsLocalSystem = "D:P(A;OICI;GA;;;BA)(A;OICI;GA;;;SY)"
-)
+// SddlAdministratorsLocalSystem is local administrators plus NT AUTHORITY\System.
+const SddlAdministratorsLocalSystem = "D:P(A;OICI;GA;;;BA)(A;OICI;GA;;;SY)"
 
-// MkdirAllWithACL is a wrapper for MkdirAll that creates a directory
-// ACL'd for Builtin Administrators and Local System.
-func MkdirAllWithACL(path string, perm os.FileMode) error {
+// volumePath is a regular expression to check if a path is a Windows
+// volume path (e.g., "\\?\Volume{4c1b02c1-d990-11dc-99ae-806e6f6e6963}".
+var volumePath = regexp.MustCompile(`^\\\\\?\\Volume{[a-z0-9-]+}$`)
+
+// MkdirAllWithACL is a custom version of os.MkdirAll modified for use on Windows
+// so that it is both volume path aware, and to create a directory
+// an appropriate SDDL defined ACL for Builtin Administrators and Local System.
+func MkdirAllWithACL(path string, _ os.FileMode) error {
 	return mkdirall(path, true)
 }
 
-// MkdirAll implementation that is volume path aware for Windows. It can be used
-// as a drop-in replacement for os.MkdirAll()
+// MkdirAll is a custom version of os.MkdirAll that is volume path aware for
+// Windows. It can be used as a drop-in replacement for os.MkdirAll.
 func MkdirAll(path string, _ os.FileMode) error {
 	return mkdirall(path, false)
 }
@@ -46,7 +49,7 @@ func MkdirAll(path string, _ os.FileMode) error {
 // so that it is both volume path aware, and can create a directory with
 // a DACL.
 func mkdirall(path string, adminAndLocalSystem bool) error {
-	if re := regexp.MustCompile(`^\\\\\?\\Volume{[a-z0-9-]+}$`); re.MatchString(path) {
+	if volumePath.MatchString(path) {
 		return nil
 	}
 


### PR DESCRIPTION
See individual commits for details 😄 

### sys: compile volume-path regex once, and update GoDoc

Ideally, we would construct this lazily, but adding a function and a
sync.Once felt like a bit "too much".

Also updated the GoDoc for some functions to better describe what they do.

### sys: update volumePath regex to allow returning earlier

The regex only matched volume paths without a trailing path-separator. In cases
where a path would be passed with a trailing path-separator, it would depend on
further code in mkdirall to strip the trailing slash, then to perform the regex
again in the next iteration.

While regexes aren't ideal, we're already executing this one, so we may as well
use it to match those situations as well (instead of executing it twice), to
allow us to return early.

### sys: create SecurityAttribute only once (Windows)

The same attribute was generated for each path that was created, but always
the same, so instead of generating it in each iteration, generate it once,
and pass it to our mkdirall() implementation.

### sys: synchronize mkdirall() with latest os.MkDirAll()

