### PR TITLE
reformat with goimports -local

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,6 +42,8 @@ linters-settings:
       - G306
       - G402
       - G404
+  goimports:
+    local-prefixes: github.com/containerd/containerd
 
 run:
   timeout: 8m

--- a/archive/compression/compression.go
+++ b/archive/compression/compression.go
@@ -28,9 +28,10 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/containerd/containerd/log"
 	"github.com/klauspost/compress/zstd"
 	exec "golang.org/x/sys/execabs"
+
+	"github.com/containerd/containerd/log"
 )
 
 type (

--- a/archive/tar.go
+++ b/archive/tar.go
@@ -29,9 +29,10 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/containerd/continuity/fs"
+
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/pkg/userns"
-	"github.com/containerd/continuity/fs"
 )
 
 var bufPool = &sync.Pool{

--- a/archive/tar_linux_test.go
+++ b/archive/tar_linux_test.go
@@ -25,12 +25,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/containerd/continuity/fs"
+	"github.com/containerd/continuity/fs/fstest"
+
 	"github.com/containerd/containerd/log/logtest"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/pkg/testutil"
 	"github.com/containerd/containerd/snapshots/overlay/overlayutils"
-	"github.com/containerd/continuity/fs"
-	"github.com/containerd/continuity/fs/fstest"
 )
 
 func TestOverlayApply(t *testing.T) {

--- a/archive/tar_test.go
+++ b/archive/tar_test.go
@@ -32,12 +32,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/containerd/archive/tartest"
-	"github.com/containerd/containerd/pkg/testutil"
 	"github.com/containerd/continuity/fs"
 	"github.com/containerd/continuity/fs/fstest"
 	"github.com/stretchr/testify/require"
 	exec "golang.org/x/sys/execabs"
+
+	"github.com/containerd/containerd/archive/tartest"
+	"github.com/containerd/containerd/pkg/testutil"
 )
 
 const tarCmd = "tar"

--- a/archive/tar_unix.go
+++ b/archive/tar_unix.go
@@ -28,10 +28,11 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/containerd/containerd/pkg/userns"
 	"github.com/containerd/continuity/fs"
 	"github.com/containerd/continuity/sysx"
 	"golang.org/x/sys/unix"
+
+	"github.com/containerd/containerd/pkg/userns"
 )
 
 func chmodTarEntry(perm os.FileMode) os.FileMode {

--- a/cio/io_windows.go
+++ b/cio/io_windows.go
@@ -22,6 +22,7 @@ import (
 	"io"
 
 	winio "github.com/Microsoft/go-winio"
+
 	"github.com/containerd/containerd/log"
 )
 

--- a/client.go
+++ b/client.go
@@ -27,6 +27,15 @@ import (
 	"sync"
 	"time"
 
+	"github.com/containerd/typeurl"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"golang.org/x/sync/semaphore"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
+
 	containersapi "github.com/containerd/containerd/api/services/containers/v1"
 	contentapi "github.com/containerd/containerd/api/services/content/v1"
 	diffapi "github.com/containerd/containerd/api/services/diff/v1"
@@ -60,14 +69,6 @@ import (
 	"github.com/containerd/containerd/services/introspection"
 	"github.com/containerd/containerd/snapshots"
 	snproxy "github.com/containerd/containerd/snapshots/proxy"
-	"github.com/containerd/typeurl"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/opencontainers/runtime-spec/specs-go"
-	"golang.org/x/sync/semaphore"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/backoff"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
 func init() {

--- a/client_opts.go
+++ b/client_opts.go
@@ -19,11 +19,12 @@ package containerd
 import (
 	"time"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/snapshots"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"google.golang.org/grpc"
 )

--- a/cmd/containerd-shim/main_unix.go
+++ b/cmd/containerd-shim/main_unix.go
@@ -36,6 +36,11 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/containerd/ttrpc"
+	"github.com/sirupsen/logrus"
+	exec "golang.org/x/sys/execabs"
+	"golang.org/x/sys/unix"
+
 	"github.com/containerd/containerd/events"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/pkg/process"
@@ -47,10 +52,6 @@ import (
 	shimapi "github.com/containerd/containerd/runtime/v1/shim/v1"
 	"github.com/containerd/containerd/sys/reaper"
 	"github.com/containerd/containerd/version"
-	"github.com/containerd/ttrpc"
-	"github.com/sirupsen/logrus"
-	exec "golang.org/x/sys/execabs"
-	"golang.org/x/sys/unix"
 )
 
 var (

--- a/cmd/containerd-shim/shim_darwin.go
+++ b/cmd/containerd-shim/shim_darwin.go
@@ -20,9 +20,10 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/containerd/containerd/sys/reaper"
 	runc "github.com/containerd/go-runc"
 	"github.com/containerd/ttrpc"
+
+	"github.com/containerd/containerd/sys/reaper"
 )
 
 // setupSignals creates a new signal handler for all signals and sets the shim as a

--- a/cmd/containerd-shim/shim_linux.go
+++ b/cmd/containerd-shim/shim_linux.go
@@ -20,10 +20,11 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/containerd/containerd/sys/reaper"
 	runc "github.com/containerd/go-runc"
 	"github.com/containerd/ttrpc"
 	"golang.org/x/sys/unix"
+
+	"github.com/containerd/containerd/sys/reaper"
 )
 
 // setupSignals creates a new signal handler for all signals and sets the shim as a

--- a/cmd/containerd-stress/cri_worker.go
+++ b/cmd/containerd-stress/cri_worker.go
@@ -25,9 +25,10 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	internalapi "github.com/containerd/containerd/integration/cri-api/pkg/apis"
 	"github.com/containerd/containerd/pkg/cri/util"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 type criWorker struct {

--- a/cmd/containerd-stress/density.go
+++ b/cmd/containerd-stress/density.go
@@ -28,12 +28,13 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
-	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
 )
 
 var densityCommand = cli.Command{

--- a/cmd/containerd-stress/exec_worker.go
+++ b/cmd/containerd-stress/exec_worker.go
@@ -23,11 +23,12 @@ import (
 	"syscall"
 	"time"
 
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/oci"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 )
 
 type execWorker struct {

--- a/cmd/containerd-stress/main.go
+++ b/cmd/containerd-stress/main.go
@@ -28,13 +28,14 @@ import (
 	"syscall"
 	"time"
 
+	metrics "github.com/docker/go-metrics"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/integration/remote"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/plugin"
-	metrics "github.com/docker/go-metrics"
-	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
 )
 
 var (

--- a/cmd/containerd-stress/worker.go
+++ b/cmd/containerd-stress/worker.go
@@ -23,10 +23,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/oci"
-	"github.com/sirupsen/logrus"
 )
 
 type ctrWorker struct {

--- a/cmd/containerd/command/config.go
+++ b/cmd/containerd/command/config.go
@@ -22,14 +22,15 @@ import (
 	"os"
 	"path/filepath"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pelletier/go-toml"
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/pkg/timeout"
 	"github.com/containerd/containerd/services/server"
 	srvconfig "github.com/containerd/containerd/services/server/config"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pelletier/go-toml"
-	"github.com/urfave/cli"
 )
 
 // Config is a wrapper of server config for printing out.

--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -27,6 +27,10 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+	"google.golang.org/grpc/grpclog"
+
 	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
@@ -36,9 +40,6 @@ import (
 	srvconfig "github.com/containerd/containerd/services/server/config"
 	"github.com/containerd/containerd/sys"
 	"github.com/containerd/containerd/version"
-	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
-	"google.golang.org/grpc/grpclog"
 )
 
 const usage = `

--- a/cmd/containerd/command/main_unix.go
+++ b/cmd/containerd/command/main_unix.go
@@ -24,9 +24,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/services/server"
-	"golang.org/x/sys/unix"
 )
 
 var handledSignals = []os.Signal{

--- a/cmd/containerd/command/main_windows.go
+++ b/cmd/containerd/command/main_windows.go
@@ -26,10 +26,11 @@ import (
 	"github.com/Microsoft/go-winio/pkg/etw"
 	"github.com/Microsoft/go-winio/pkg/etwlogrus"
 	"github.com/Microsoft/go-winio/pkg/guid"
-	"github.com/containerd/containerd/log"
-	"github.com/containerd/containerd/services/server"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows"
+
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/services/server"
 )
 
 var (

--- a/cmd/containerd/command/publish.go
+++ b/cmd/containerd/command/publish.go
@@ -24,16 +24,17 @@ import (
 	"os"
 	"time"
 
+	"github.com/urfave/cli"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/credentials/insecure"
+
 	eventsapi "github.com/containerd/containerd/api/services/events/v1"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/pkg/dialer"
 	"github.com/containerd/containerd/protobuf/proto"
 	"github.com/containerd/containerd/protobuf/types"
-	"github.com/urfave/cli"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/backoff"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 var publishCommand = cli.Command{

--- a/cmd/containerd/command/service_unsupported.go
+++ b/cmd/containerd/command/service_unsupported.go
@@ -20,8 +20,9 @@
 package command
 
 import (
-	"github.com/containerd/containerd/services/server"
 	"github.com/urfave/cli"
+
+	"github.com/containerd/containerd/services/server"
 )
 
 // serviceFlags returns an array of flags for configuring containerd to run

--- a/cmd/containerd/command/service_windows.go
+++ b/cmd/containerd/command/service_windows.go
@@ -23,8 +23,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/services/server"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	exec "golang.org/x/sys/execabs"
@@ -32,6 +30,9 @@ import (
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/debug"
 	"golang.org/x/sys/windows/svc/mgr"
+
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/services/server"
 )
 
 var (

--- a/cmd/ctr/app/main.go
+++ b/cmd/ctr/app/main.go
@@ -20,6 +20,10 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+	"google.golang.org/grpc/grpclog"
+
 	"github.com/containerd/containerd/cmd/ctr/commands/containers"
 	"github.com/containerd/containerd/cmd/ctr/commands/content"
 	"github.com/containerd/containerd/cmd/ctr/commands/events"
@@ -38,9 +42,6 @@ import (
 	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/version"
-	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
-	"google.golang.org/grpc/grpclog"
 )
 
 var extraCmds = []cli.Command{}

--- a/cmd/ctr/commands/client.go
+++ b/cmd/ctr/commands/client.go
@@ -19,9 +19,10 @@ package commands
 import (
 	gocontext "context"
 
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/namespaces"
-	"github.com/urfave/cli"
 )
 
 // AppContext returns the context for a command. Should only be called once per

--- a/cmd/ctr/commands/cni.go
+++ b/cmd/ctr/commands/cni.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/containerd/typeurl"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/namespaces"
-	"github.com/containerd/typeurl"
 )
 
 func init() {

--- a/cmd/ctr/commands/commands.go
+++ b/cmd/ctr/commands/commands.go
@@ -23,8 +23,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/containerd/containerd/defaults"
 	"github.com/urfave/cli"
+
+	"github.com/containerd/containerd/defaults"
 )
 
 var (

--- a/cmd/ctr/commands/containers/checkpoint.go
+++ b/cmd/ctr/commands/containers/checkpoint.go
@@ -20,10 +20,11 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/errdefs"
-	"github.com/urfave/cli"
 )
 
 var checkpointCommand = cli.Command{

--- a/cmd/ctr/commands/containers/containers.go
+++ b/cmd/ctr/commands/containers/containers.go
@@ -23,6 +23,9 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/containerd/typeurl"
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/cmd/ctr/commands"
@@ -30,8 +33,6 @@ import (
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
-	"github.com/containerd/typeurl"
-	"github.com/urfave/cli"
 )
 
 // Command is the cli command for managing containers

--- a/cmd/ctr/commands/containers/restore.go
+++ b/cmd/ctr/commands/containers/restore.go
@@ -19,11 +19,12 @@ package containers
 import (
 	"errors"
 
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/errdefs"
-	"github.com/urfave/cli"
 )
 
 var restoreCommand = cli.Command{

--- a/cmd/ctr/commands/content/content.go
+++ b/cmd/ctr/commands/content/content.go
@@ -25,15 +25,16 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/containerd/containerd/cmd/ctr/commands"
-	"github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/log"
 	units "github.com/docker/go-units"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/urfave/cli"
 	exec "golang.org/x/sys/execabs"
+
+	"github.com/containerd/containerd/cmd/ctr/commands"
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/log"
 )
 
 var (

--- a/cmd/ctr/commands/content/fetch.go
+++ b/cmd/ctr/commands/content/fetch.go
@@ -26,6 +26,10 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/content"
@@ -35,9 +39,6 @@ import (
 	"github.com/containerd/containerd/pkg/progress"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/remotes"
-	"github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/urfave/cli"
 )
 
 var fetchCommand = cli.Command{

--- a/cmd/ctr/commands/content/prune.go
+++ b/cmd/ctr/commands/content/prune.go
@@ -21,12 +21,13 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/log"
-	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
 )
 
 const (

--- a/cmd/ctr/commands/events/events.go
+++ b/cmd/ctr/commands/events/events.go
@@ -20,11 +20,12 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/containerd/typeurl"
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/events"
 	"github.com/containerd/containerd/log"
-	"github.com/containerd/typeurl"
-	"github.com/urfave/cli"
 
 	// Register grpc event types
 	_ "github.com/containerd/containerd/api/events"

--- a/cmd/ctr/commands/images/convert.go
+++ b/cmd/ctr/commands/images/convert.go
@@ -20,12 +20,13 @@ import (
 	"errors"
 	"fmt"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/images/converter"
 	"github.com/containerd/containerd/images/converter/uncompress"
 	"github.com/containerd/containerd/platforms"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/urfave/cli"
 )
 
 var convertCommand = cli.Command{

--- a/cmd/ctr/commands/images/export.go
+++ b/cmd/ctr/commands/images/export.go
@@ -22,11 +22,12 @@ import (
 	"io"
 	"os"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/images/archive"
 	"github.com/containerd/containerd/platforms"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/urfave/cli"
 )
 
 var exportCommand = cli.Command{

--- a/cmd/ctr/commands/images/images.go
+++ b/cmd/ctr/commands/images/images.go
@@ -24,13 +24,14 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/pkg/progress"
 	"github.com/containerd/containerd/platforms"
-	"github.com/urfave/cli"
 )
 
 // Command is the cli command for managing images

--- a/cmd/ctr/commands/images/import.go
+++ b/cmd/ctr/commands/images/import.go
@@ -22,12 +22,13 @@ import (
 	"os"
 	"time"
 
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/images/archive"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/platforms"
-	"github.com/urfave/cli"
 )
 
 var importCommand = cli.Command{

--- a/cmd/ctr/commands/images/mount.go
+++ b/cmd/ctr/commands/images/mount.go
@@ -20,14 +20,15 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/opencontainers/image-spec/identity"
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/platforms"
-	"github.com/opencontainers/image-spec/identity"
-	"github.com/urfave/cli"
 )
 
 var mountCommand = cli.Command{

--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -20,15 +20,16 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/opencontainers/image-spec/identity"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/cmd/ctr/commands/content"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/platforms"
-	"github.com/opencontainers/image-spec/identity"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/urfave/cli"
 )
 
 var pullCommand = cli.Command{

--- a/cmd/ctr/commands/images/push.go
+++ b/cmd/ctr/commands/images/push.go
@@ -26,6 +26,11 @@ import (
 	"text/tabwriter"
 	"time"
 
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/urfave/cli"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/cmd/ctr/commands/content"
@@ -35,10 +40,6 @@ import (
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
-	digest "github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/urfave/cli"
-	"golang.org/x/sync/errgroup"
 )
 
 var pushCommand = cli.Command{

--- a/cmd/ctr/commands/images/tag.go
+++ b/cmd/ctr/commands/images/tag.go
@@ -19,9 +19,10 @@ package images
 import (
 	"fmt"
 
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/errdefs"
-	"github.com/urfave/cli"
 )
 
 var tagCommand = cli.Command{

--- a/cmd/ctr/commands/images/unmount.go
+++ b/cmd/ctr/commands/images/unmount.go
@@ -19,11 +19,12 @@ package images
 import (
 	"fmt"
 
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/mount"
-	"github.com/urfave/cli"
 )
 
 var unmountCommand = cli.Command{

--- a/cmd/ctr/commands/install/install.go
+++ b/cmd/ctr/commands/install/install.go
@@ -17,9 +17,10 @@
 package install
 
 import (
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cmd/ctr/commands"
-	"github.com/urfave/cli"
 )
 
 // Command to install binary packages

--- a/cmd/ctr/commands/leases/leases.go
+++ b/cmd/ctr/commands/leases/leases.go
@@ -24,9 +24,10 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/leases"
-	"github.com/urfave/cli"
 )
 
 // Command is the cli command for managing content

--- a/cmd/ctr/commands/namespaces/namespaces.go
+++ b/cmd/ctr/commands/namespaces/namespaces.go
@@ -24,10 +24,11 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
-	"github.com/urfave/cli"
 )
 
 // Command is the cli command for managing namespaces

--- a/cmd/ctr/commands/namespaces/namespaces_linux.go
+++ b/cmd/ctr/commands/namespaces/namespaces_linux.go
@@ -17,9 +17,10 @@
 package namespaces
 
 import (
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/runtime/opts"
-	"github.com/urfave/cli"
 )
 
 func deleteOpts(context *cli.Context) []namespaces.DeleteOpts {

--- a/cmd/ctr/commands/namespaces/namespaces_other.go
+++ b/cmd/ctr/commands/namespaces/namespaces_other.go
@@ -20,8 +20,9 @@
 package namespaces
 
 import (
-	"github.com/containerd/containerd/namespaces"
 	"github.com/urfave/cli"
+
+	"github.com/containerd/containerd/namespaces"
 )
 
 func deleteOpts(context *cli.Context) []namespaces.DeleteOpts {

--- a/cmd/ctr/commands/plugins/plugins.go
+++ b/cmd/ctr/commands/plugins/plugins.go
@@ -23,13 +23,14 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/urfave/cli"
+	"google.golang.org/grpc/codes"
+
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/platforms"
 	pluginutils "github.com/containerd/containerd/plugin"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/urfave/cli"
-	"google.golang.org/grpc/codes"
 )
 
 // Command is a cli command that outputs plugin information

--- a/cmd/ctr/commands/pprof/pprof.go
+++ b/cmd/ctr/commands/pprof/pprof.go
@@ -23,8 +23,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/containerd/containerd/defaults"
 	"github.com/urfave/cli"
+
+	"github.com/containerd/containerd/defaults"
 )
 
 type pprofDialer struct {

--- a/cmd/ctr/commands/resolver.go
+++ b/cmd/ctr/commands/resolver.go
@@ -31,11 +31,12 @@ import (
 	"strings"
 
 	"github.com/containerd/console"
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/containerd/containerd/remotes/docker/config"
-	"github.com/urfave/cli"
 )
 
 // PushTracker returns a new InMemoryTracker which tracks the ref status

--- a/cmd/ctr/commands/run/run.go
+++ b/cmd/ctr/commands/run/run.go
@@ -24,6 +24,11 @@ import (
 	"strings"
 
 	"github.com/containerd/console"
+	gocni "github.com/containerd/go-cni"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/cmd/ctr/commands"
@@ -31,10 +36,6 @@ import (
 	"github.com/containerd/containerd/containers"
 	clabels "github.com/containerd/containerd/labels"
 	"github.com/containerd/containerd/oci"
-	gocni "github.com/containerd/go-cni"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
 )
 
 func withMounts(context *cli.Context) oci.SpecOpts {

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -28,6 +28,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/intel/goresctrl/pkg/blockio"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/containers"
@@ -39,10 +44,6 @@ import (
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/containerd/containerd/snapshots"
-	"github.com/intel/goresctrl/pkg/blockio"
-	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
 )
 
 var platformRunFlags = []cli.Flag{

--- a/cmd/ctr/commands/run/run_windows.go
+++ b/cmd/ctr/commands/run/run_windows.go
@@ -23,14 +23,15 @@ import (
 
 	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
 	"github.com/containerd/console"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/pkg/netns"
 	"github.com/containerd/containerd/snapshots"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
 )
 
 var platformRunFlags = []cli.Flag{

--- a/cmd/ctr/commands/sandboxes/sandboxes.go
+++ b/cmd/ctr/commands/sandboxes/sandboxes.go
@@ -22,12 +22,13 @@ import (
 	"os"
 	"text/tabwriter"
 
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/oci"
-	"github.com/urfave/cli"
 )
 
 // Command is a set of subcommands to manage runtimes with sandbox support

--- a/cmd/ctr/commands/shim/shim.go
+++ b/cmd/ctr/commands/shim/shim.go
@@ -29,16 +29,17 @@ import (
 	"strings"
 
 	"github.com/containerd/console"
-	"github.com/containerd/containerd/api/runtime/task/v2"
-	"github.com/containerd/containerd/cmd/ctr/commands"
-	"github.com/containerd/containerd/namespaces"
-	ptypes "github.com/containerd/containerd/protobuf/types"
-	"github.com/containerd/containerd/runtime/v2/shim"
 	"github.com/containerd/ttrpc"
 	"github.com/containerd/typeurl"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
+
+	"github.com/containerd/containerd/api/runtime/task/v2"
+	"github.com/containerd/containerd/cmd/ctr/commands"
+	"github.com/containerd/containerd/namespaces"
+	ptypes "github.com/containerd/containerd/protobuf/types"
+	"github.com/containerd/containerd/runtime/v2/shim"
 )
 
 var fifoFlags = []cli.Flag{

--- a/cmd/ctr/commands/signals.go
+++ b/cmd/ctr/commands/signals.go
@@ -22,9 +22,10 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
-	"github.com/sirupsen/logrus"
 )
 
 type killer interface {

--- a/cmd/ctr/commands/snapshots/snapshots.go
+++ b/cmd/ctr/commands/snapshots/snapshots.go
@@ -26,6 +26,10 @@ import (
 	"text/tabwriter"
 	"time"
 
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/diff"
@@ -35,9 +39,6 @@ import (
 	"github.com/containerd/containerd/pkg/progress"
 	"github.com/containerd/containerd/rootfs"
 	"github.com/containerd/containerd/snapshots"
-	digest "github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/urfave/cli"
 )
 
 // Command is the cli command for managing snapshots

--- a/cmd/ctr/commands/tasks/attach.go
+++ b/cmd/ctr/commands/tasks/attach.go
@@ -18,10 +18,11 @@ package tasks
 
 import (
 	"github.com/containerd/console"
-	"github.com/containerd/containerd/cio"
-	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
+
+	"github.com/containerd/containerd/cio"
+	"github.com/containerd/containerd/cmd/ctr/commands"
 )
 
 var attachCommand = cli.Command{

--- a/cmd/ctr/commands/tasks/checkpoint.go
+++ b/cmd/ctr/commands/tasks/checkpoint.go
@@ -20,12 +20,13 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/runtime/linux/runctypes"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
-	"github.com/urfave/cli"
 )
 
 var checkpointCommand = cli.Command{

--- a/cmd/ctr/commands/tasks/delete.go
+++ b/cmd/ctr/commands/tasks/delete.go
@@ -19,11 +19,12 @@ package tasks
 import (
 	gocontext "context"
 
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/log"
-	"github.com/urfave/cli"
 )
 
 var deleteCommand = cli.Command{

--- a/cmd/ctr/commands/tasks/exec.go
+++ b/cmd/ctr/commands/tasks/exec.go
@@ -23,12 +23,13 @@ import (
 	"os"
 
 	"github.com/containerd/console"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/oci"
-	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
 )
 
 var execCommand = cli.Command{

--- a/cmd/ctr/commands/tasks/kill.go
+++ b/cmd/ctr/commands/tasks/kill.go
@@ -21,13 +21,14 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/cmd/ctr/commands"
 	gocni "github.com/containerd/go-cni"
 	"github.com/containerd/typeurl"
 	"github.com/moby/sys/signal"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/cmd/ctr/commands"
 )
 
 const defaultSignal = "SIGTERM"

--- a/cmd/ctr/commands/tasks/list.go
+++ b/cmd/ctr/commands/tasks/list.go
@@ -21,9 +21,10 @@ import (
 	"os"
 	"text/tabwriter"
 
+	"github.com/urfave/cli"
+
 	tasks "github.com/containerd/containerd/api/services/tasks/v1"
 	"github.com/containerd/containerd/cmd/ctr/commands"
-	"github.com/urfave/cli"
 )
 
 var listCommand = cli.Command{

--- a/cmd/ctr/commands/tasks/metrics.go
+++ b/cmd/ctr/commands/tasks/metrics.go
@@ -26,9 +26,10 @@ import (
 	wstats "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats"
 	v1 "github.com/containerd/cgroups/stats/v1"
 	v2 "github.com/containerd/cgroups/v2/stats"
-	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/typeurl"
 	"github.com/urfave/cli"
+
+	"github.com/containerd/containerd/cmd/ctr/commands"
 )
 
 func init() {

--- a/cmd/ctr/commands/tasks/pause.go
+++ b/cmd/ctr/commands/tasks/pause.go
@@ -17,8 +17,9 @@
 package tasks
 
 import (
-	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/urfave/cli"
+
+	"github.com/containerd/containerd/cmd/ctr/commands"
 )
 
 var pauseCommand = cli.Command{

--- a/cmd/ctr/commands/tasks/ps.go
+++ b/cmd/ctr/commands/tasks/ps.go
@@ -22,9 +22,10 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/typeurl"
 	"github.com/urfave/cli"
+
+	"github.com/containerd/containerd/cmd/ctr/commands"
 )
 
 var psCommand = cli.Command{

--- a/cmd/ctr/commands/tasks/resume.go
+++ b/cmd/ctr/commands/tasks/resume.go
@@ -17,8 +17,9 @@
 package tasks
 
 import (
-	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/urfave/cli"
+
+	"github.com/containerd/containerd/cmd/ctr/commands"
 )
 
 var resumeCommand = cli.Command{

--- a/cmd/ctr/commands/tasks/start.go
+++ b/cmd/ctr/commands/tasks/start.go
@@ -20,11 +20,12 @@ import (
 	"errors"
 
 	"github.com/containerd/console"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/cmd/ctr/commands"
-	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
 )
 
 var startCommand = cli.Command{

--- a/cmd/ctr/commands/tasks/tasks_unix.go
+++ b/cmd/ctr/commands/tasks/tasks_unix.go
@@ -27,11 +27,12 @@ import (
 	"os/signal"
 
 	"github.com/containerd/console"
+	"github.com/urfave/cli"
+	"golang.org/x/sys/unix"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/log"
-	"github.com/urfave/cli"
-	"golang.org/x/sys/unix"
 )
 
 var platformStartFlags = []cli.Flag{

--- a/cmd/ctr/commands/tasks/tasks_windows.go
+++ b/cmd/ctr/commands/tasks/tasks_windows.go
@@ -23,10 +23,11 @@ import (
 	"time"
 
 	"github.com/containerd/console"
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/log"
-	"github.com/urfave/cli"
 )
 
 var platformStartFlags = []cli.Flag{}

--- a/cmd/ctr/commands/version/version.go
+++ b/cmd/ctr/commands/version/version.go
@@ -20,9 +20,10 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/version"
-	"github.com/urfave/cli"
 )
 
 // Command is a cli command to output the client and containerd server version

--- a/cmd/ctr/main.go
+++ b/cmd/ctr/main.go
@@ -20,9 +20,10 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd/cmd/ctr/app"
 	"github.com/containerd/containerd/pkg/seed"
-	"github.com/urfave/cli"
 )
 
 var pluginCmds = []cli.Command{}

--- a/cmd/gen-manpages/main.go
+++ b/cmd/gen-manpages/main.go
@@ -23,9 +23,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/urfave/cli"
+
 	"github.com/containerd/containerd/cmd/containerd/command"
 	"github.com/containerd/containerd/cmd/ctr/app"
-	"github.com/urfave/cli"
 )
 
 func main() {

--- a/container.go
+++ b/container.go
@@ -24,6 +24,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/containerd/fifo"
+	"github.com/containerd/typeurl"
+	ver "github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/opencontainers/selinux/go-selinux/label"
+
 	"github.com/containerd/containerd/api/services/tasks/v1"
 	"github.com/containerd/containerd/api/types"
 	tasktypes "github.com/containerd/containerd/api/types/task"
@@ -34,11 +40,6 @@ import (
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/protobuf"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
-	"github.com/containerd/fifo"
-	"github.com/containerd/typeurl"
-	ver "github.com/opencontainers/image-spec/specs-go"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/opencontainers/selinux/go-selinux/label"
 )
 
 const (

--- a/container_checkpoint_opts.go
+++ b/container_checkpoint_opts.go
@@ -23,6 +23,9 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/opencontainers/go-digest"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	tasks "github.com/containerd/containerd/api/services/tasks/v1"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/diff"
@@ -32,8 +35,6 @@ import (
 	"github.com/containerd/containerd/protobuf/proto"
 	"github.com/containerd/containerd/rootfs"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
-	"github.com/opencontainers/go-digest"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 var (

--- a/container_opts.go
+++ b/container_opts.go
@@ -22,6 +22,10 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/containerd/typeurl"
+	"github.com/opencontainers/image-spec/identity"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
@@ -30,9 +34,6 @@ import (
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/protobuf"
 	"github.com/containerd/containerd/snapshots"
-	"github.com/containerd/typeurl"
-	"github.com/opencontainers/image-spec/identity"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // DeleteOpts allows the caller to set options for the deletion of a container

--- a/container_opts_unix.go
+++ b/container_opts_unix.go
@@ -26,10 +26,11 @@ import (
 	"path/filepath"
 	"syscall"
 
+	"github.com/opencontainers/image-spec/identity"
+
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/mount"
-	"github.com/opencontainers/image-spec/identity"
 )
 
 // WithRemappedSnapshot creates a new snapshot and remaps the uid/gid for the

--- a/container_restore_opts.go
+++ b/container_restore_opts.go
@@ -21,13 +21,14 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/opencontainers/image-spec/identity"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/protobuf/proto"
 	ptypes "github.com/containerd/containerd/protobuf/types"
-	"github.com/opencontainers/image-spec/identity"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 var (

--- a/containerstore.go
+++ b/containerstore.go
@@ -21,14 +21,15 @@ import (
 	"errors"
 	"io"
 
+	"github.com/containerd/typeurl"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	containersapi "github.com/containerd/containerd/api/services/containers/v1"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/protobuf"
 	ptypes "github.com/containerd/containerd/protobuf/types"
-	"github.com/containerd/typeurl"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 type remoteContainers struct {

--- a/content/helpers.go
+++ b/content/helpers.go
@@ -25,10 +25,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/log"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/log"
 )
 
 // maxResets is the no.of times the Copy() method can tolerate a reset of the body

--- a/content/helpers_test.go
+++ b/content/helpers_test.go
@@ -25,9 +25,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/containerd/containerd/errdefs"
 	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/containerd/containerd/errdefs"
 )
 
 type copySource struct {

--- a/content/local/store.go
+++ b/content/local/store.go
@@ -28,11 +28,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/filters"
 	"github.com/containerd/containerd/log"
-	"github.com/sirupsen/logrus"
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"

--- a/content/local/writer.go
+++ b/content/local/writer.go
@@ -26,10 +26,11 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/opencontainers/go-digest"
+
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
-	"github.com/opencontainers/go-digest"
 )
 
 // writer represents a write transaction against the blob store.

--- a/content/proxy/content_reader.go
+++ b/content/proxy/content_reader.go
@@ -19,8 +19,9 @@ package proxy
 import (
 	"context"
 
-	contentapi "github.com/containerd/containerd/api/services/content/v1"
 	digest "github.com/opencontainers/go-digest"
+
+	contentapi "github.com/containerd/containerd/api/services/content/v1"
 )
 
 type remoteReaderAt struct {

--- a/content/proxy/content_store.go
+++ b/content/proxy/content_store.go
@@ -20,13 +20,14 @@ import (
 	"context"
 	"io"
 
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	contentapi "github.com/containerd/containerd/api/services/content/v1"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/protobuf"
 	protobuftypes "github.com/containerd/containerd/protobuf/types"
-	digest "github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 type proxyContentStore struct {

--- a/content/proxy/content_writer.go
+++ b/content/proxy/content_writer.go
@@ -21,11 +21,12 @@ import (
 	"fmt"
 	"io"
 
+	digest "github.com/opencontainers/go-digest"
+
 	contentapi "github.com/containerd/containerd/api/services/content/v1"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/protobuf"
-	digest "github.com/opencontainers/go-digest"
 )
 
 type remoteWriter struct {

--- a/content/testsuite/testsuite.go
+++ b/content/testsuite/testsuite.go
@@ -28,13 +28,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log/logtest"
 	"github.com/containerd/containerd/pkg/testutil"
-	"github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/stretchr/testify/assert"
 )
 
 const (

--- a/contrib/apparmor/apparmor.go
+++ b/contrib/apparmor/apparmor.go
@@ -25,9 +25,10 @@ import (
 	"fmt"
 	"os"
 
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/oci"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // WithProfile sets the provided apparmor profile to the spec

--- a/contrib/apparmor/apparmor_unsupported.go
+++ b/contrib/apparmor/apparmor_unsupported.go
@@ -23,9 +23,10 @@ import (
 	"context"
 	"errors"
 
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/oci"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // WithProfile sets the provided apparmor profile to the spec

--- a/contrib/fuzz/diff_fuzzer.go
+++ b/contrib/fuzz/diff_fuzzer.go
@@ -21,11 +21,12 @@ import (
 	"os"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/content/local"
 	"github.com/containerd/containerd/diff/apply"
 	"github.com/containerd/containerd/diff/walking"
 	"github.com/containerd/containerd/mount"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func FuzzDiffApply(data []byte) int {

--- a/contrib/fuzz/exchange_fuzzer.go
+++ b/contrib/fuzz/exchange_fuzzer.go
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
 	eventstypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/events"
 	"github.com/containerd/containerd/events/exchange"

--- a/contrib/fuzz/fuzz_images.go
+++ b/contrib/fuzz/fuzz_images.go
@@ -20,10 +20,11 @@ import (
 	"os"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/content/local"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/platforms"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func FuzzImagesCheck(data []byte) int {

--- a/contrib/nvidia/nvidia.go
+++ b/contrib/nvidia/nvidia.go
@@ -23,10 +23,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/containerd/containerd/containers"
-	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	exec "golang.org/x/sys/execabs"
+
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/oci"
 )
 
 // NvidiaCLI is the path to the Nvidia helper binary

--- a/contrib/seccomp/seccomp.go
+++ b/contrib/seccomp/seccomp.go
@@ -22,9 +22,10 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/oci"
-	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // WithProfile receives the name of a file stored on disk comprising a json

--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -24,8 +24,9 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	"github.com/containerd/containerd/contrib/seccomp/kernelversion"
 	"github.com/opencontainers/runtime-spec/specs-go"
+
+	"github.com/containerd/containerd/contrib/seccomp/kernelversion"
 )
 
 func arches() []specs.Arch {

--- a/diff.go
+++ b/diff.go
@@ -19,6 +19,10 @@ package containerd
 import (
 	"context"
 
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
 	diffapi "github.com/containerd/containerd/api/services/diff/v1"
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/diff"
@@ -26,9 +30,6 @@ import (
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/protobuf"
 	ptypes "github.com/containerd/containerd/protobuf/types"
-	"github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // DiffService handles the computation and application of diffs

--- a/diff/apply/apply.go
+++ b/diff/apply/apply.go
@@ -22,13 +22,14 @@ import (
 	"io"
 	"time"
 
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
+
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/diff"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
-	digest "github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 )
 
 // NewFileSystemApplier returns an applier which simply mounts

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -21,9 +21,10 @@ import (
 	"io"
 	"time"
 
-	"github.com/containerd/containerd/mount"
 	"github.com/containerd/typeurl"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/mount"
 )
 
 // Config is used to hold parameters needed for a diff operation

--- a/diff/lcow/lcow.go
+++ b/diff/lcow/lcow.go
@@ -30,6 +30,10 @@ import (
 
 	"github.com/Microsoft/go-winio/pkg/security"
 	"github.com/Microsoft/hcsshim/ext4/tar2ext4"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
+
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/diff"
 	"github.com/containerd/containerd/errdefs"
@@ -37,9 +41,6 @@ import (
 	"github.com/containerd/containerd/metadata"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/plugin"
-	digest "github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 )
 
 const (

--- a/diff/stream.go
+++ b/diff/stream.go
@@ -22,10 +22,11 @@ import (
 	"io"
 	"os"
 
-	"github.com/containerd/containerd/archive/compression"
-	"github.com/containerd/containerd/images"
 	"github.com/containerd/typeurl"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/archive/compression"
+	"github.com/containerd/containerd/images"
 )
 
 var (

--- a/diff/stream_unix.go
+++ b/diff/stream_unix.go
@@ -28,10 +28,11 @@ import (
 	"os"
 	"sync"
 
-	"github.com/containerd/containerd/protobuf"
-	"github.com/containerd/containerd/protobuf/proto"
 	"github.com/containerd/typeurl"
 	exec "golang.org/x/sys/execabs"
+
+	"github.com/containerd/containerd/protobuf"
+	"github.com/containerd/containerd/protobuf/proto"
 )
 
 // NewBinaryProcessor returns a binary processor for use with processing content streams

--- a/diff/stream_windows.go
+++ b/diff/stream_windows.go
@@ -27,11 +27,12 @@ import (
 	"sync"
 
 	winio "github.com/Microsoft/go-winio"
-	"github.com/containerd/containerd/protobuf"
-	"github.com/containerd/containerd/protobuf/proto"
 	"github.com/containerd/typeurl"
 	"github.com/sirupsen/logrus"
 	exec "golang.org/x/sys/execabs"
+
+	"github.com/containerd/containerd/protobuf"
+	"github.com/containerd/containerd/protobuf/proto"
 )
 
 const processorPipe = "STREAM_PROCESSOR_PIPE"

--- a/diff/walking/differ.go
+++ b/diff/walking/differ.go
@@ -25,6 +25,9 @@ import (
 	"math/rand"
 	"time"
 
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/archive"
 	"github.com/containerd/containerd/archive/compression"
 	"github.com/containerd/containerd/content"
@@ -32,8 +35,6 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
-	digest "github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 type walkingDiff struct {

--- a/diff/windows/windows.go
+++ b/diff/windows/windows.go
@@ -28,6 +28,10 @@ import (
 	"time"
 
 	"github.com/Microsoft/go-winio"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
+
 	"github.com/containerd/containerd/archive"
 	"github.com/containerd/containerd/archive/compression"
 	"github.com/containerd/containerd/content"
@@ -38,9 +42,6 @@ import (
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/plugin"
-	"github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 )
 
 func init() {

--- a/events.go
+++ b/events.go
@@ -19,11 +19,12 @@ package containerd
 import (
 	"context"
 
+	"github.com/containerd/typeurl"
+
 	eventsapi "github.com/containerd/containerd/api/services/events/v1"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/events"
 	"github.com/containerd/containerd/protobuf"
-	"github.com/containerd/typeurl"
 )
 
 // EventService handles the publish, forward and subscribe of events.

--- a/events/exchange/exchange.go
+++ b/events/exchange/exchange.go
@@ -22,15 +22,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/typeurl"
+	goevents "github.com/docker/go-events"
+	"github.com/sirupsen/logrus"
+
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/events"
 	"github.com/containerd/containerd/filters"
 	"github.com/containerd/containerd/identifiers"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/namespaces"
-	"github.com/containerd/typeurl"
-	goevents "github.com/docker/go-events"
-	"github.com/sirupsen/logrus"
 )
 
 // Exchange broadcasts events

--- a/events/exchange/exchange_test.go
+++ b/events/exchange/exchange_test.go
@@ -22,13 +22,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/typeurl"
+	"github.com/google/go-cmp/cmp"
+
 	eventstypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/events"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/protobuf"
-	"github.com/containerd/typeurl"
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestExchangeBasic(t *testing.T) {

--- a/gc/scheduler/scheduler_test.go
+++ b/gc/scheduler/scheduler_test.go
@@ -22,8 +22,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/containerd/gc"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/containerd/containerd/gc"
 )
 
 func TestPauseThreshold(t *testing.T) {

--- a/grpc.go
+++ b/grpc.go
@@ -19,8 +19,9 @@ package containerd
 import (
 	"context"
 
-	"github.com/containerd/containerd/namespaces"
 	"google.golang.org/grpc"
+
+	"github.com/containerd/containerd/namespaces"
 )
 
 type namespaceInterceptor struct {

--- a/image.go
+++ b/image.go
@@ -24,6 +24,11 @@ import (
 	"strings"
 	"sync/atomic"
 
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/identity"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/sync/semaphore"
+
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/diff"
 	"github.com/containerd/containerd/errdefs"
@@ -32,10 +37,6 @@ import (
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/rootfs"
 	"github.com/containerd/containerd/snapshots"
-	"github.com/opencontainers/go-digest"
-	"github.com/opencontainers/image-spec/identity"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"golang.org/x/sync/semaphore"
 )
 
 // Image describes an image used by containers

--- a/image_store.go
+++ b/image_store.go
@@ -19,14 +19,15 @@ package containerd
 import (
 	"context"
 
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	imagesapi "github.com/containerd/containerd/api/services/images/v1"
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/protobuf"
 	ptypes "github.com/containerd/containerd/protobuf/types"
-	"github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 type remoteImages struct {

--- a/images/archive/exporter.go
+++ b/images/archive/exporter.go
@@ -25,13 +25,14 @@ import (
 	"path"
 	"sort"
 
+	digest "github.com/opencontainers/go-digest"
+	ocispecs "github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/platforms"
-	digest "github.com/opencontainers/go-digest"
-	ocispecs "github.com/opencontainers/image-spec/specs-go"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 type exportOptions struct {

--- a/images/archive/importer.go
+++ b/images/archive/importer.go
@@ -27,15 +27,16 @@ import (
 	"io"
 	"path"
 
+	digest "github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/archive/compression"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/platforms"
-	digest "github.com/opencontainers/go-digest"
-	specs "github.com/opencontainers/image-spec/specs-go"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 type importOpts struct {

--- a/images/archive/reference.go
+++ b/images/archive/reference.go
@@ -20,9 +20,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/opencontainers/go-digest"
+
 	"github.com/containerd/containerd/reference"
 	distref "github.com/containerd/containerd/reference/docker"
-	"github.com/opencontainers/go-digest"
 )
 
 // FilterRefPrefix restricts references to having the given image

--- a/images/converter/default.go
+++ b/images/converter/default.go
@@ -24,13 +24,14 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/images"
-	"github.com/containerd/containerd/platforms"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/platforms"
 )
 
 // ConvertFunc returns a converted content descriptor.

--- a/images/converter/uncompress/uncompress.go
+++ b/images/converter/uncompress/uncompress.go
@@ -21,13 +21,14 @@ import (
 	"fmt"
 	"io"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/archive/compression"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/images/converter"
 	"github.com/containerd/containerd/labels"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 var _ converter.ConvertFunc = LayerConvertFunc

--- a/images/diffid.go
+++ b/images/diffid.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"io"
 
-	"github.com/containerd/containerd/archive/compression"
-	"github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/labels"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
+
+	"github.com/containerd/containerd/archive/compression"
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/labels"
 )
 
 // GetDiffID gets the diff ID of the layer blob descriptor.

--- a/images/handlers.go
+++ b/images/handlers.go
@@ -22,12 +22,13 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/platforms"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/platforms"
 )
 
 var (

--- a/images/image.go
+++ b/images/image.go
@@ -23,12 +23,13 @@ import (
 	"sort"
 	"time"
 
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/platforms"
-	digest "github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // Image provides the model for how containerd views container images.

--- a/images/importexport.go
+++ b/images/importexport.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"io"
 
-	"github.com/containerd/containerd/content"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/content"
 )
 
 // Importer is the interface for image importer.

--- a/images/mediatypes.go
+++ b/images/mediatypes.go
@@ -22,8 +22,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/containerd/containerd/errdefs"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/errdefs"
 )
 
 // mediatype definitions for image components handled in containerd.

--- a/import.go
+++ b/import.go
@@ -21,13 +21,14 @@ import (
 	"encoding/json"
 	"io"
 
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/images/archive"
 	"github.com/containerd/containerd/platforms"
-	digest "github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 type importOpts struct {

--- a/integration/client/client_test.go
+++ b/integration/client/client_test.go
@@ -26,6 +26,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/identity"
+	"github.com/sirupsen/logrus"
+	exec "golang.org/x/sys/execabs"
+
 	. "github.com/containerd/containerd"
 	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/errdefs"
@@ -36,10 +41,6 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/pkg/testutil"
 	"github.com/containerd/containerd/platforms"
-	"github.com/opencontainers/go-digest"
-	"github.com/opencontainers/image-spec/identity"
-	"github.com/sirupsen/logrus"
-	exec "golang.org/x/sys/execabs"
 )
 
 var (

--- a/integration/client/client_ttrpc_test.go
+++ b/integration/client/client_ttrpc_test.go
@@ -21,13 +21,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/ttrpc"
+	"github.com/stretchr/testify/assert"
+
 	v1 "github.com/containerd/containerd/api/services/ttrpc/events/v1"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/pkg/ttrpcutil"
 	"github.com/containerd/containerd/protobuf"
 	"github.com/containerd/containerd/protobuf/types"
-	"github.com/containerd/ttrpc"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestClientTTRPC_New(t *testing.T) {

--- a/integration/client/container_fuzzer.go
+++ b/integration/client/container_fuzzer.go
@@ -31,9 +31,10 @@ import (
 	"time"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	exec "golang.org/x/sys/execabs"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
-	exec "golang.org/x/sys/execabs"
 )
 
 var (

--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -32,6 +32,10 @@ import (
 
 	"github.com/containerd/cgroups"
 	cgroupsv2 "github.com/containerd/cgroups/v2"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	exec "golang.org/x/sys/execabs"
+	"golang.org/x/sys/unix"
+
 	. "github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/containers"
@@ -41,9 +45,6 @@ import (
 	"github.com/containerd/containerd/runtime/linux/runctypes"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/containerd/containerd/sys"
-	"github.com/opencontainers/runtime-spec/specs-go"
-	exec "golang.org/x/sys/execabs"
-	"golang.org/x/sys/unix"
 )
 
 const testUserNSImage = "ghcr.io/containerd/alpine:3.14.0"

--- a/integration/client/container_test.go
+++ b/integration/client/container_test.go
@@ -29,6 +29,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/go-runc"
+	"github.com/containerd/typeurl"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/require"
+	exec "golang.org/x/sys/execabs"
+
 	. "github.com/containerd/containerd"
 	apievents "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/cio"
@@ -43,11 +49,6 @@ import (
 	gogotypes "github.com/containerd/containerd/protobuf/types"
 	_ "github.com/containerd/containerd/runtime"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
-	"github.com/containerd/go-runc"
-	"github.com/containerd/typeurl"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/stretchr/testify/require"
-	exec "golang.org/x/sys/execabs"
 )
 
 func empty() cio.Creator {

--- a/integration/client/convert_test.go
+++ b/integration/client/convert_test.go
@@ -19,13 +19,14 @@ package client
 import (
 	"testing"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+
 	. "github.com/containerd/containerd"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/images/converter"
 	"github.com/containerd/containerd/images/converter/uncompress"
 	"github.com/containerd/containerd/platforms"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/stretchr/testify/assert"
 )
 
 // TestConvert creates an image from testImage, with the following conversion:

--- a/integration/client/daemon.go
+++ b/integration/client/daemon.go
@@ -25,8 +25,9 @@ import (
 	"sync"
 	"syscall"
 
-	. "github.com/containerd/containerd"
 	exec "golang.org/x/sys/execabs"
+
+	. "github.com/containerd/containerd"
 )
 
 type daemon struct {

--- a/integration/client/daemon_config_linux_test.go
+++ b/integration/client/daemon_config_linux_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/containerd/cgroups"
+
 	. "github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/plugin"

--- a/integration/client/helpers_unix_test.go
+++ b/integration/client/helpers_unix_test.go
@@ -23,10 +23,11 @@ import (
 	"context"
 	"fmt"
 
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/oci"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 const newLine = "\n"

--- a/integration/client/helpers_windows_test.go
+++ b/integration/client/helpers_windows_test.go
@@ -22,10 +22,11 @@ import (
 	"io"
 	"strconv"
 
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/oci"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 const newLine = "\r\n"

--- a/integration/client/image_test.go
+++ b/integration/client/image_test.go
@@ -23,12 +23,13 @@ import (
 	"strings"
 	"testing"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	. "github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	imagelist "github.com/containerd/containerd/integration/images"
 	"github.com/containerd/containerd/platforms"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func TestImageIsUnpacked(t *testing.T) {

--- a/integration/client/lease_test.go
+++ b/integration/client/lease_test.go
@@ -20,12 +20,13 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/opencontainers/image-spec/identity"
+
 	. "github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	imagelist "github.com/containerd/containerd/integration/images"
 	"github.com/containerd/containerd/leases"
-	"github.com/opencontainers/image-spec/identity"
 )
 
 func TestLeaseResources(t *testing.T) {

--- a/integration/client/restart_monitor_test.go
+++ b/integration/client/restart_monitor_test.go
@@ -30,14 +30,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/typeurl"
+	exec "golang.org/x/sys/execabs"
+
 	. "github.com/containerd/containerd"
 	eventtypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/pkg/testutil"
 	"github.com/containerd/containerd/runtime/restart"
 	srvconfig "github.com/containerd/containerd/services/server/config"
-	"github.com/containerd/typeurl"
-	exec "golang.org/x/sys/execabs"
 )
 
 // the following nolint is for shutting up gometalinter on non-linux.

--- a/integration/container_restart_test.go
+++ b/integration/container_restart_test.go
@@ -19,9 +19,10 @@ package integration
 import (
 	"testing"
 
-	"github.com/containerd/containerd/integration/images"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/containerd/containerd/integration/images"
 )
 
 // Test to verify container can be restarted

--- a/integration/container_stats_test.go
+++ b/integration/container_stats_test.go
@@ -23,10 +23,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/containerd/integration/images"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/integration/images"
 )
 
 // Test to verify for a container ID

--- a/integration/container_stop_test.go
+++ b/integration/container_stop_test.go
@@ -22,10 +22,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/containerd/integration/images"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/integration/images"
 )
 
 func TestSharedPidMultiProcessContainerStop(t *testing.T) {

--- a/integration/container_update_resources_test.go
+++ b/integration/container_update_resources_test.go
@@ -28,12 +28,13 @@ import (
 
 	"github.com/containerd/cgroups"
 	cgroupsv2 "github.com/containerd/cgroups/v2"
-	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/integration/images"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/integration/images"
 )
 
 func checkMemoryLimit(t *testing.T, spec *runtimespec.Spec, memLimit int64) {

--- a/integration/container_volume_test.go
+++ b/integration/container_volume_test.go
@@ -23,10 +23,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/containerd/integration/images"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/integration/images"
 )
 
 func createRegularFile(basePath, content string) (string, error) {

--- a/integration/container_without_image_ref_test.go
+++ b/integration/container_without_image_ref_test.go
@@ -19,10 +19,11 @@ package integration
 import (
 	"testing"
 
-	"github.com/containerd/containerd/integration/images"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/integration/images"
 )
 
 // Test container lifecycle can work without image references.

--- a/integration/containerd_image_test.go
+++ b/integration/containerd_image_test.go
@@ -23,13 +23,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/integration/images"
 	"github.com/containerd/containerd/namespaces"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // Test to test the CRI plugin should see image pulled into containerd directly.

--- a/integration/duplicate_name_test.go
+++ b/integration/duplicate_name_test.go
@@ -19,8 +19,9 @@ package integration
 import (
 	"testing"
 
-	"github.com/containerd/containerd/integration/images"
 	"github.com/stretchr/testify/require"
+
+	"github.com/containerd/containerd/integration/images"
 )
 
 func TestDuplicateName(t *testing.T) {

--- a/integration/failpoint/cmd/cni-bridge-fp/main_linux.go
+++ b/integration/failpoint/cmd/cni-bridge-fp/main_linux.go
@@ -25,11 +25,12 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"github.com/containerd/containerd/pkg/failpoint"
 	"github.com/containerd/continuity"
 	"github.com/containernetworking/cni/pkg/invoke"
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/version"
+
+	"github.com/containerd/containerd/pkg/failpoint"
 )
 
 const delegatedPlugin = "bridge"

--- a/integration/failpoint/cmd/containerd-shim-runc-fp-v1/plugin_linux.go
+++ b/integration/failpoint/cmd/containerd-shim-runc-fp-v1/plugin_linux.go
@@ -24,6 +24,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/containerd/ttrpc"
+
 	taskapi "github.com/containerd/containerd/api/runtime/task/v2"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/pkg/failpoint"
@@ -31,7 +33,6 @@ import (
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/runtime/v2/runc/task"
 	"github.com/containerd/containerd/runtime/v2/shim"
-	"github.com/containerd/ttrpc"
 )
 
 const (

--- a/integration/image_load_test.go
+++ b/integration/image_load_test.go
@@ -21,10 +21,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/containerd/integration/images"
 	"github.com/stretchr/testify/require"
 	exec "golang.org/x/sys/execabs"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/integration/images"
 )
 
 // Test to load an image from tarball.

--- a/integration/image_pull_timeout_test.go
+++ b/integration/image_pull_timeout_test.go
@@ -33,6 +33,10 @@ import (
 	"testing"
 	"time"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/leases"
@@ -40,9 +44,6 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	criconfig "github.com/containerd/containerd/pkg/cri/config"
 	criserver "github.com/containerd/containerd/pkg/cri/server"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/stretchr/testify/assert"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 var (

--- a/integration/imagefs_info_test.go
+++ b/integration/imagefs_info_test.go
@@ -22,10 +22,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/containerd/integration/images"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/integration/images"
 )
 
 func TestImageFSInfo(t *testing.T) {

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -33,6 +33,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	exec "golang.org/x/sys/execabs"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/containers"
 	cri "github.com/containerd/containerd/integration/cri-api/pkg/apis"
@@ -43,13 +51,6 @@ import (
 	"github.com/containerd/containerd/pkg/cri/constants"
 	"github.com/containerd/containerd/pkg/cri/server"
 	"github.com/containerd/containerd/pkg/cri/util"
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	exec "golang.org/x/sys/execabs"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 const (

--- a/integration/pod_dualstack_test.go
+++ b/integration/pod_dualstack_test.go
@@ -25,10 +25,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/containerd/integration/images"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/integration/images"
 )
 
 func TestPodDualStack(t *testing.T) {

--- a/integration/pod_hostname_test.go
+++ b/integration/pod_hostname_test.go
@@ -24,10 +24,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/containerd/integration/images"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/integration/images"
 )
 
 func TestPodHostname(t *testing.T) {

--- a/integration/remote/remote_image.go
+++ b/integration/remote/remote_image.go
@@ -42,8 +42,9 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"k8s.io/klog/v2"
 
-	internalapi "github.com/containerd/containerd/integration/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	internalapi "github.com/containerd/containerd/integration/cri-api/pkg/apis"
 
 	"github.com/containerd/containerd/integration/remote/util"
 )

--- a/integration/remote/remote_runtime.go
+++ b/integration/remote/remote_runtime.go
@@ -43,10 +43,11 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"k8s.io/klog/v2"
 
-	internalapi "github.com/containerd/containerd/integration/cri-api/pkg/apis"
 	"k8s.io/component-base/logs/logreduction"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	utilexec "k8s.io/utils/exec"
+
+	internalapi "github.com/containerd/containerd/integration/cri-api/pkg/apis"
 
 	"github.com/containerd/containerd/integration/remote/util"
 )

--- a/integration/restart_test.go
+++ b/integration/restart_test.go
@@ -24,11 +24,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/integration/images"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/integration/images"
 )
 
 // Restart test must run sequentially.

--- a/integration/sandbox_run_rollback_test.go
+++ b/integration/sandbox_run_rollback_test.go
@@ -36,9 +36,10 @@ import (
 	"github.com/stretchr/testify/require"
 	criapiv1 "k8s.io/cri-api/pkg/apis/runtime/v1"
 
+	"github.com/containerd/typeurl"
+
 	"github.com/containerd/containerd/pkg/cri/store/sandbox"
 	"github.com/containerd/containerd/pkg/failpoint"
-	"github.com/containerd/typeurl"
 )
 
 const (

--- a/integration/shim_dial_unix_test.go
+++ b/integration/shim_dial_unix_test.go
@@ -31,9 +31,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/ttrpc"
+
 	v1shimcli "github.com/containerd/containerd/runtime/v1/shim/client"
 	v2shimcli "github.com/containerd/containerd/runtime/v2/shim"
-	"github.com/containerd/ttrpc"
 )
 
 const abstractSocketPrefix = "\x00"

--- a/integration/truncindex_test.go
+++ b/integration/truncindex_test.go
@@ -20,10 +20,11 @@ import (
 	goruntime "runtime"
 	"testing"
 
-	"github.com/containerd/containerd/integration/images"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/integration/images"
 )
 
 func genTruncIndex(normalName string) string {

--- a/integration/volume_copy_up_test.go
+++ b/integration/volume_copy_up_test.go
@@ -24,9 +24,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/containerd/integration/images"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/containerd/containerd/integration/images"
 )
 
 const (

--- a/integration/windows_device_test.go
+++ b/integration/windows_device_test.go
@@ -26,10 +26,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/containerd/integration/images"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/integration/images"
 )
 
 func TestWindowsDevice(t *testing.T) {

--- a/integration/windows_hostprocess_test.go
+++ b/integration/windows_hostprocess_test.go
@@ -25,11 +25,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/containerd/integration/images"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 	v1 "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/integration/images"
 )
 
 type hpcAction func(*testing.T, string, *v1.ContainerConfig)

--- a/integration/windows_rootfs_size_test.go
+++ b/integration/windows_rootfs_size_test.go
@@ -28,10 +28,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/containerd/integration/images"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/integration/images"
 )
 
 func TestWindowsRootfsSize(t *testing.T) {

--- a/log/logtest/context.go
+++ b/log/logtest/context.go
@@ -24,8 +24,9 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/containerd/containerd/log"
 	"github.com/sirupsen/logrus"
+
+	"github.com/containerd/containerd/log"
 )
 
 // WithT adds a logging hook for the given test

--- a/metadata/boltutil/helpers.go
+++ b/metadata/boltutil/helpers.go
@@ -20,11 +20,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/containerd/typeurl"
+	bolt "go.etcd.io/bbolt"
+
 	"github.com/containerd/containerd/protobuf"
 	"github.com/containerd/containerd/protobuf/proto"
 	"github.com/containerd/containerd/protobuf/types"
-	"github.com/containerd/typeurl"
-	bolt "go.etcd.io/bbolt"
 )
 
 var (

--- a/metadata/containers.go
+++ b/metadata/containers.go
@@ -23,6 +23,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/containerd/typeurl"
+	bolt "go.etcd.io/bbolt"
+
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/filters"
@@ -32,8 +35,6 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/protobuf/proto"
 	"github.com/containerd/containerd/protobuf/types"
-	"github.com/containerd/typeurl"
-	bolt "go.etcd.io/bbolt"
 )
 
 type containerStore struct {

--- a/metadata/containers_test.go
+++ b/metadata/containers_test.go
@@ -25,6 +25,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/typeurl"
+	"github.com/google/go-cmp/cmp"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	bolt "go.etcd.io/bbolt"
+
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/filters"
@@ -32,12 +39,6 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/protobuf"
 	"github.com/containerd/containerd/protobuf/types"
-	"github.com/containerd/typeurl"
-	"github.com/google/go-cmp/cmp"
-	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	bolt "go.etcd.io/bbolt"
 )
 
 func init() {

--- a/metadata/content.go
+++ b/metadata/content.go
@@ -25,6 +25,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	bolt "go.etcd.io/bbolt"
+
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/filters"
@@ -32,9 +36,6 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/metadata/boltutil"
 	"github.com/containerd/containerd/namespaces"
-	digest "github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	bolt "go.etcd.io/bbolt"
 )
 
 type contentStore struct {

--- a/metadata/content_test.go
+++ b/metadata/content_test.go
@@ -25,6 +25,10 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	bolt "go.etcd.io/bbolt"
+
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/content/local"
 	"github.com/containerd/containerd/content/testsuite"
@@ -32,9 +36,6 @@ import (
 	"github.com/containerd/containerd/labels"
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/namespaces"
-	"github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	bolt "go.etcd.io/bbolt"
 )
 
 func createContentStore(ctx context.Context, root string, opts ...DBOpt) (context.Context, content.Store, func() error, error) {

--- a/metadata/db.go
+++ b/metadata/db.go
@@ -26,11 +26,12 @@ import (
 	"sync/atomic"
 	"time"
 
+	bolt "go.etcd.io/bbolt"
+
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/gc"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/snapshots"
-	bolt "go.etcd.io/bbolt"
 )
 
 const (

--- a/metadata/db_test.go
+++ b/metadata/db_test.go
@@ -29,6 +29,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	bolt "go.etcd.io/bbolt"
+
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/content/local"
@@ -41,11 +47,6 @@ import (
 	"github.com/containerd/containerd/protobuf/types"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/containerd/snapshots/native"
-	"github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	bolt "go.etcd.io/bbolt"
 )
 
 type testOptions struct {

--- a/metadata/gc.go
+++ b/metadata/gc.go
@@ -24,9 +24,10 @@ import (
 	"strings"
 	"time"
 
+	bolt "go.etcd.io/bbolt"
+
 	"github.com/containerd/containerd/gc"
 	"github.com/containerd/containerd/log"
-	bolt "go.etcd.io/bbolt"
 )
 
 const (

--- a/metadata/gc_test.go
+++ b/metadata/gc_test.go
@@ -25,12 +25,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/containerd/gc"
-	"github.com/containerd/containerd/metadata/boltutil"
 	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	bolt "go.etcd.io/bbolt"
+
+	"github.com/containerd/containerd/gc"
+	"github.com/containerd/containerd/metadata/boltutil"
 )
 
 func TestResourceMax(t *testing.T) {

--- a/metadata/images.go
+++ b/metadata/images.go
@@ -25,15 +25,16 @@ import (
 	"sync/atomic"
 	"time"
 
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	bolt "go.etcd.io/bbolt"
+
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/filters"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/labels"
 	"github.com/containerd/containerd/metadata/boltutil"
 	"github.com/containerd/containerd/namespaces"
-	digest "github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	bolt "go.etcd.io/bbolt"
 )
 
 type imageStore struct {

--- a/metadata/images_test.go
+++ b/metadata/images_test.go
@@ -23,11 +23,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/filters"
 	"github.com/containerd/containerd/images"
-	"github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func TestImagesList(t *testing.T) {

--- a/metadata/leases.go
+++ b/metadata/leases.go
@@ -24,13 +24,14 @@ import (
 	"sync/atomic"
 	"time"
 
+	digest "github.com/opencontainers/go-digest"
+	bolt "go.etcd.io/bbolt"
+
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/filters"
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/metadata/boltutil"
 	"github.com/containerd/containerd/namespaces"
-	digest "github.com/opencontainers/go-digest"
-	bolt "go.etcd.io/bbolt"
 )
 
 // leaseManager manages the create/delete lifecycle of leases

--- a/metadata/leases_test.go
+++ b/metadata/leases_test.go
@@ -22,9 +22,10 @@ import (
 	"fmt"
 	"testing"
 
+	bolt "go.etcd.io/bbolt"
+
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/leases"
-	bolt "go.etcd.io/bbolt"
 )
 
 func TestLeases(t *testing.T) {

--- a/metadata/namespaces.go
+++ b/metadata/namespaces.go
@@ -21,11 +21,12 @@ import (
 	"fmt"
 	"strings"
 
+	bolt "go.etcd.io/bbolt"
+
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/identifiers"
 	l "github.com/containerd/containerd/labels"
 	"github.com/containerd/containerd/namespaces"
-	bolt "go.etcd.io/bbolt"
 )
 
 type namespaceStore struct {

--- a/metadata/namespaces_test.go
+++ b/metadata/namespaces_test.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/containerd/containerd/containers"
-	"github.com/containerd/containerd/namespaces"
-	"github.com/containerd/containerd/protobuf/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/bbolt"
+
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/protobuf/types"
 )
 
 func TestCreateDelete(t *testing.T) {

--- a/metadata/plugin/plugin.go
+++ b/metadata/plugin/plugin.go
@@ -22,6 +22,8 @@ import (
 	"path/filepath"
 	"time"
 
+	bolt "go.etcd.io/bbolt"
+
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
@@ -29,7 +31,6 @@ import (
 	"github.com/containerd/containerd/pkg/timeout"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/snapshots"
-	bolt "go.etcd.io/bbolt"
 )
 
 const (

--- a/metadata/sandbox.go
+++ b/metadata/sandbox.go
@@ -23,14 +23,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/typeurl"
+	"go.etcd.io/bbolt"
+
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/filters"
 	"github.com/containerd/containerd/identifiers"
 	"github.com/containerd/containerd/metadata/boltutil"
 	"github.com/containerd/containerd/namespaces"
 	api "github.com/containerd/containerd/sandbox"
-	"github.com/containerd/typeurl"
-	"go.etcd.io/bbolt"
 )
 
 type sandboxStore struct {

--- a/metadata/sandbox_test.go
+++ b/metadata/sandbox_test.go
@@ -19,11 +19,12 @@ package metadata
 import (
 	"testing"
 
+	"github.com/containerd/typeurl"
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/protobuf/types"
 	api "github.com/containerd/containerd/sandbox"
-	"github.com/containerd/typeurl"
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestSandboxCreate(t *testing.T) {

--- a/metadata/snapshot.go
+++ b/metadata/snapshot.go
@@ -24,6 +24,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	bolt "go.etcd.io/bbolt"
+
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/filters"
 	"github.com/containerd/containerd/labels"
@@ -32,7 +34,6 @@ import (
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/snapshots"
-	bolt "go.etcd.io/bbolt"
 )
 
 const (

--- a/metadata/snapshot_test.go
+++ b/metadata/snapshot_test.go
@@ -27,6 +27,8 @@ import (
 	"testing"
 	"time"
 
+	bolt "go.etcd.io/bbolt"
+
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/filters"
 	"github.com/containerd/containerd/mount"
@@ -35,7 +37,6 @@ import (
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/containerd/snapshots/native"
 	"github.com/containerd/containerd/snapshots/testsuite"
-	bolt "go.etcd.io/bbolt"
 )
 
 func newTestSnapshotter(ctx context.Context, root string) (snapshots.Snapshotter, func() error, error) {

--- a/metrics/cgroups/cgroups.go
+++ b/metrics/cgroups/cgroups.go
@@ -21,13 +21,14 @@ package cgroups
 
 import (
 	"github.com/containerd/cgroups"
+	metrics "github.com/docker/go-metrics"
+
 	"github.com/containerd/containerd/events"
 	v1 "github.com/containerd/containerd/metrics/cgroups/v1"
 	v2 "github.com/containerd/containerd/metrics/cgroups/v2"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/runtime"
-	metrics "github.com/docker/go-metrics"
 )
 
 // Config for the cgroups monitor

--- a/metrics/cgroups/metrics_test.go
+++ b/metrics/cgroups/metrics_test.go
@@ -27,16 +27,18 @@ import (
 	"time"
 
 	"github.com/containerd/cgroups"
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/containerd/containerd/metrics/cgroups/common"
 	v1 "github.com/containerd/containerd/metrics/cgroups/v1"
 	v2 "github.com/containerd/containerd/metrics/cgroups/v2"
 	v1types "github.com/containerd/containerd/metrics/types/v1"
 	v2types "github.com/containerd/containerd/metrics/types/v2"
 	"github.com/containerd/containerd/protobuf"
-	"github.com/prometheus/client_golang/prometheus"
+
+	metrics "github.com/docker/go-metrics"
 
 	"github.com/containerd/containerd/protobuf/types"
-	metrics "github.com/docker/go-metrics"
 )
 
 // TestRegressionIssue6772 should not have dead-lock when Collect and Add run

--- a/metrics/cgroups/v1/blkio.go
+++ b/metrics/cgroups/v1/blkio.go
@@ -22,9 +22,10 @@ package v1
 import (
 	"strconv"
 
-	v1 "github.com/containerd/containerd/metrics/types/v1"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
+
+	v1 "github.com/containerd/containerd/metrics/types/v1"
 )
 
 var blkioMetrics = []*metric{

--- a/metrics/cgroups/v1/cgroups.go
+++ b/metrics/cgroups/v1/cgroups.go
@@ -23,6 +23,9 @@ import (
 	"context"
 
 	"github.com/containerd/cgroups"
+	"github.com/docker/go-metrics"
+	"github.com/sirupsen/logrus"
+
 	eventstypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/events"
@@ -30,8 +33,6 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/runtime"
 	"github.com/containerd/containerd/runtime/v1/linux"
-	"github.com/docker/go-metrics"
-	"github.com/sirupsen/logrus"
 )
 
 // NewTaskMonitor returns a new cgroups monitor

--- a/metrics/cgroups/v1/cpu.go
+++ b/metrics/cgroups/v1/cpu.go
@@ -22,9 +22,10 @@ package v1
 import (
 	"strconv"
 
-	v1 "github.com/containerd/containerd/metrics/types/v1"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
+
+	v1 "github.com/containerd/containerd/metrics/types/v1"
 )
 
 var cpuMetrics = []*metric{

--- a/metrics/cgroups/v1/hugetlb.go
+++ b/metrics/cgroups/v1/hugetlb.go
@@ -20,9 +20,10 @@
 package v1
 
 import (
-	v1 "github.com/containerd/containerd/metrics/types/v1"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
+
+	v1 "github.com/containerd/containerd/metrics/types/v1"
 )
 
 var hugetlbMetrics = []*metric{

--- a/metrics/cgroups/v1/memory.go
+++ b/metrics/cgroups/v1/memory.go
@@ -20,9 +20,10 @@
 package v1
 
 import (
-	v1 "github.com/containerd/containerd/metrics/types/v1"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
+
+	v1 "github.com/containerd/containerd/metrics/types/v1"
 )
 
 var memoryMetrics = []*metric{

--- a/metrics/cgroups/v1/metric.go
+++ b/metrics/cgroups/v1/metric.go
@@ -20,9 +20,10 @@
 package v1
 
 import (
-	v1 "github.com/containerd/containerd/metrics/types/v1"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
+
+	v1 "github.com/containerd/containerd/metrics/types/v1"
 )
 
 // IDName is the name that is used to identify the id being collected in the metric

--- a/metrics/cgroups/v1/metrics.go
+++ b/metrics/cgroups/v1/metrics.go
@@ -25,15 +25,16 @@ import (
 	"sync"
 
 	"github.com/containerd/cgroups"
+	"github.com/containerd/typeurl"
+	"github.com/docker/go-metrics"
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/containerd/containerd/log"
 	cmetrics "github.com/containerd/containerd/metrics"
 	"github.com/containerd/containerd/metrics/cgroups/common"
 	v1 "github.com/containerd/containerd/metrics/types/v1"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/pkg/timeout"
-	"github.com/containerd/typeurl"
-	"github.com/docker/go-metrics"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Trigger will be called when an event happens and provides the cgroup

--- a/metrics/cgroups/v1/pids.go
+++ b/metrics/cgroups/v1/pids.go
@@ -20,9 +20,10 @@
 package v1
 
 import (
-	v1 "github.com/containerd/containerd/metrics/types/v1"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
+
+	v1 "github.com/containerd/containerd/metrics/types/v1"
 )
 
 var pidMetrics = []*metric{

--- a/metrics/cgroups/v2/cgroups.go
+++ b/metrics/cgroups/v2/cgroups.go
@@ -22,9 +22,10 @@ package v2
 import (
 	"context"
 
+	"github.com/docker/go-metrics"
+
 	"github.com/containerd/containerd/events"
 	"github.com/containerd/containerd/runtime"
-	"github.com/docker/go-metrics"
 )
 
 // NewTaskMonitor returns a new cgroups monitor

--- a/metrics/cgroups/v2/cpu.go
+++ b/metrics/cgroups/v2/cpu.go
@@ -20,9 +20,10 @@
 package v2
 
 import (
-	v2 "github.com/containerd/containerd/metrics/types/v2"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
+
+	v2 "github.com/containerd/containerd/metrics/types/v2"
 )
 
 var cpuMetrics = []*metric{

--- a/metrics/cgroups/v2/io.go
+++ b/metrics/cgroups/v2/io.go
@@ -22,9 +22,10 @@ package v2
 import (
 	"strconv"
 
-	v2 "github.com/containerd/containerd/metrics/types/v2"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
+
+	v2 "github.com/containerd/containerd/metrics/types/v2"
 )
 
 var ioMetrics = []*metric{

--- a/metrics/cgroups/v2/memory.go
+++ b/metrics/cgroups/v2/memory.go
@@ -20,9 +20,10 @@
 package v2
 
 import (
-	v2 "github.com/containerd/containerd/metrics/types/v2"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
+
+	v2 "github.com/containerd/containerd/metrics/types/v2"
 )
 
 var memoryMetrics = []*metric{

--- a/metrics/cgroups/v2/metric.go
+++ b/metrics/cgroups/v2/metric.go
@@ -20,9 +20,10 @@
 package v2
 
 import (
-	v2 "github.com/containerd/containerd/metrics/types/v2"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
+
+	v2 "github.com/containerd/containerd/metrics/types/v2"
 )
 
 // IDName is the name that is used to identify the id being collected in the metric

--- a/metrics/cgroups/v2/metrics.go
+++ b/metrics/cgroups/v2/metrics.go
@@ -24,15 +24,16 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/containerd/typeurl"
+	"github.com/docker/go-metrics"
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/containerd/containerd/log"
 	cmetrics "github.com/containerd/containerd/metrics"
 	"github.com/containerd/containerd/metrics/cgroups/common"
 	v2 "github.com/containerd/containerd/metrics/types/v2"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/pkg/timeout"
-	"github.com/containerd/typeurl"
-	"github.com/docker/go-metrics"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // NewCollector registers the collector with the provided namespace and returns it so

--- a/metrics/cgroups/v2/pids.go
+++ b/metrics/cgroups/v2/pids.go
@@ -20,9 +20,10 @@
 package v2
 
 import (
-	v2 "github.com/containerd/containerd/metrics/types/v2"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
+
+	v2 "github.com/containerd/containerd/metrics/types/v2"
 )
 
 var pidMetrics = []*metric{

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -19,9 +19,10 @@ package metrics
 import (
 	"time"
 
+	goMetrics "github.com/docker/go-metrics"
+
 	"github.com/containerd/containerd/pkg/timeout"
 	"github.com/containerd/containerd/version"
-	goMetrics "github.com/docker/go-metrics"
 )
 
 const (

--- a/mount/fmountat_linux.go
+++ b/mount/fmountat_linux.go
@@ -22,8 +22,9 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/containerd/containerd/log"
 	"golang.org/x/sys/unix"
+
+	"github.com/containerd/containerd/log"
 )
 
 // fMountat performs mount from the provided directory.

--- a/oci/client.go
+++ b/oci/client.go
@@ -19,9 +19,10 @@ package oci
 import (
 	"context"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/snapshots"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // Client interface used by SpecOpt

--- a/oci/spec.go
+++ b/oci/spec.go
@@ -24,8 +24,9 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/platforms"
 
-	"github.com/containerd/containerd/containers"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+
+	"github.com/containerd/containerd/containers"
 )
 
 const (

--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -28,16 +28,17 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/containerd/continuity/fs"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/opencontainers/runc/libcontainer/user"
+	"github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/platforms"
-	"github.com/containerd/continuity/fs"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/opencontainers/runc/libcontainer/user"
-	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // SpecOpts sets spec specific information to a newly generated OCI spec

--- a/oci/spec_opts_linux.go
+++ b/oci/spec_opts_linux.go
@@ -21,10 +21,11 @@ import (
 	"fmt"
 
 	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/pkg/cap"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // WithHostDevices adds all the hosts device nodes to the container's spec

--- a/oci/spec_opts_linux_test.go
+++ b/oci/spec_opts_linux_test.go
@@ -23,12 +23,13 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/containerd/containerd/containers"
-	"github.com/containerd/containerd/pkg/testutil"
 	"github.com/containerd/continuity/fs/fstest"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/unix"
+
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/pkg/testutil"
 )
 
 // nolint:gosec

--- a/oci/spec_opts_test.go
+++ b/oci/spec_opts_test.go
@@ -33,13 +33,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/containerd/containerd/content"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
+	"github.com/containerd/containerd/content"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/namespaces"
-	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 type blob []byte

--- a/oci/spec_opts_unix_test.go
+++ b/oci/spec_opts_unix_test.go
@@ -23,10 +23,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/containerd/containerd/containers"
-	"github.com/containerd/containerd/namespaces"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/namespaces"
 )
 
 func TestWithImageConfigNoEnv(t *testing.T) {

--- a/oci/spec_test.go
+++ b/oci/spec_test.go
@@ -21,10 +21,11 @@ import (
 	"runtime"
 	"testing"
 
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/pkg/testutil"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 func TestGenerateSpec(t *testing.T) {

--- a/oci/utils_unix.go
+++ b/oci/utils_unix.go
@@ -25,9 +25,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/containerd/containerd/pkg/userns"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
+
+	"github.com/containerd/containerd/pkg/userns"
 )
 
 // ErrNotADevice denotes that a file is not a valid linux device.

--- a/pkg/cri/config/config_test.go
+++ b/pkg/cri/config/config_test.go
@@ -21,8 +21,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/containerd/containerd/plugin"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/containerd/containerd/plugin"
 )
 
 func TestValidateConfig(t *testing.T) {

--- a/pkg/cri/config/config_unix.go
+++ b/pkg/cri/config/config_unix.go
@@ -22,9 +22,10 @@ package config
 import (
 	"time"
 
+	"github.com/pelletier/go-toml"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/pkg/cri/streaming"
-	"github.com/pelletier/go-toml"
 )
 
 // DefaultConfig returns default configurations of cri plugin.

--- a/pkg/cri/cri.go
+++ b/pkg/cri/cri.go
@@ -22,14 +22,15 @@ import (
 	"os"
 	"path/filepath"
 
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
+	"k8s.io/klog/v2"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/pkg/cri/sbserver"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/plugin"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
-	"k8s.io/klog/v2"
 
 	criconfig "github.com/containerd/containerd/pkg/cri/config"
 	"github.com/containerd/containerd/pkg/cri/constants"

--- a/pkg/cri/io/container_io.go
+++ b/pkg/cri/io/container_io.go
@@ -22,8 +22,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/containerd/containerd/cio"
 	"github.com/sirupsen/logrus"
+
+	"github.com/containerd/containerd/cio"
 
 	"github.com/containerd/containerd/pkg/cri/util"
 	cioutil "github.com/containerd/containerd/pkg/ioutil"

--- a/pkg/cri/io/exec_io.go
+++ b/pkg/cri/io/exec_io.go
@@ -20,8 +20,9 @@ import (
 	"io"
 	"sync"
 
-	"github.com/containerd/containerd/cio"
 	"github.com/sirupsen/logrus"
+
+	"github.com/containerd/containerd/cio"
 
 	cioutil "github.com/containerd/containerd/pkg/ioutil"
 )

--- a/pkg/cri/io/helpers.go
+++ b/pkg/cri/io/helpers.go
@@ -24,8 +24,9 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/containerd/containerd/cio"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/cio"
 )
 
 // AttachOptions specifies how to attach to a container.

--- a/pkg/cri/opts/container.go
+++ b/pkg/cri/opts/container.go
@@ -25,13 +25,14 @@ import (
 	goruntime "runtime"
 	"strings"
 
+	"github.com/containerd/continuity/fs"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/snapshots"
-	"github.com/containerd/continuity/fs"
 )
 
 // WithNewSnapshot wraps `containerd.WithNewSnapshot` so that if creating the

--- a/pkg/cri/opts/spec.go
+++ b/pkg/cri/opts/spec.go
@@ -23,11 +23,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/containerd/containerd/containers"
-	"github.com/containerd/containerd/oci"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/oci"
 )
 
 // DefaultSandboxCPUshares is default cpu shares for sandbox container.

--- a/pkg/cri/opts/spec_linux.go
+++ b/pkg/cri/opts/spec_linux.go
@@ -28,15 +28,16 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/containerd/containerd/containers"
-	"github.com/containerd/containerd/log"
-	"github.com/containerd/containerd/mount"
-	"github.com/containerd/containerd/oci"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/oci"
 
 	"github.com/containerd/containerd/pkg/cri/util"
 	osinterface "github.com/containerd/containerd/pkg/os"

--- a/pkg/cri/opts/spec_windows.go
+++ b/pkg/cri/opts/spec_windows.go
@@ -24,10 +24,11 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/containerd/containerd/containers"
-	"github.com/containerd/containerd/oci"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/oci"
 
 	osinterface "github.com/containerd/containerd/pkg/os"
 )

--- a/pkg/cri/opts/spec_windows_test.go
+++ b/pkg/cri/opts/spec_windows_test.go
@@ -22,14 +22,15 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/containerd/containerd/containers"
-	"github.com/containerd/containerd/namespaces"
-	"github.com/containerd/containerd/oci"
-	osinterface "github.com/containerd/containerd/pkg/os"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/oci"
+	osinterface "github.com/containerd/containerd/pkg/os"
 )
 
 func TestWithDevices(t *testing.T) {

--- a/pkg/cri/sbserver/blockio_linux.go
+++ b/pkg/cri/sbserver/blockio_linux.go
@@ -22,10 +22,11 @@ package sbserver
 import (
 	"fmt"
 
-	"github.com/containerd/containerd/services/tasks"
 	"github.com/intel/goresctrl/pkg/blockio"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
+
+	"github.com/containerd/containerd/services/tasks"
 )
 
 // blockIOClassFromAnnotations examines container and pod annotations of a

--- a/pkg/cri/sbserver/container_attach.go
+++ b/pkg/cri/sbserver/container_attach.go
@@ -21,10 +21,11 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/log"
 	"k8s.io/client-go/tools/remotecommand"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/log"
 
 	cio "github.com/containerd/containerd/pkg/cri/io"
 )

--- a/pkg/cri/sbserver/container_create_linux.go
+++ b/pkg/cri/sbserver/container_create_linux.go
@@ -26,15 +26,16 @@ import (
 	"strings"
 
 	"github.com/containerd/cgroups"
-	"github.com/containerd/containerd/contrib/apparmor"
-	"github.com/containerd/containerd/contrib/seccomp"
-	"github.com/containerd/containerd/oci"
-	"github.com/containerd/containerd/snapshots"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/contrib/apparmor"
+	"github.com/containerd/containerd/contrib/seccomp"
+	"github.com/containerd/containerd/oci"
+	"github.com/containerd/containerd/snapshots"
 
 	"github.com/containerd/containerd/pkg/cri/annotations"
 	"github.com/containerd/containerd/pkg/cri/config"

--- a/pkg/cri/sbserver/container_create_linux_test.go
+++ b/pkg/cri/sbserver/container_create_linux_test.go
@@ -27,17 +27,18 @@ import (
 	"testing"
 
 	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
-	"github.com/containerd/containerd/containers"
-	"github.com/containerd/containerd/contrib/apparmor"
-	"github.com/containerd/containerd/contrib/seccomp"
-	"github.com/containerd/containerd/mount"
-	"github.com/containerd/containerd/oci"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/contrib/apparmor"
+	"github.com/containerd/containerd/contrib/seccomp"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/oci"
 
 	"github.com/containerd/containerd/pkg/cap"
 	"github.com/containerd/containerd/pkg/cri/annotations"

--- a/pkg/cri/sbserver/container_create_other.go
+++ b/pkg/cri/sbserver/container_create_other.go
@@ -20,11 +20,12 @@
 package sbserver
 
 import (
-	"github.com/containerd/containerd/oci"
-	"github.com/containerd/containerd/snapshots"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/oci"
+	"github.com/containerd/containerd/snapshots"
 
 	"github.com/containerd/containerd/pkg/cri/config"
 )

--- a/pkg/cri/sbserver/container_create_windows.go
+++ b/pkg/cri/sbserver/container_create_windows.go
@@ -21,11 +21,12 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/containerd/containerd/oci"
-	"github.com/containerd/containerd/snapshots"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/oci"
+	"github.com/containerd/containerd/snapshots"
 
 	"github.com/containerd/containerd/pkg/cri/annotations"
 	"github.com/containerd/containerd/pkg/cri/config"

--- a/pkg/cri/sbserver/container_execsync.go
+++ b/pkg/cri/sbserver/container_execsync.go
@@ -24,13 +24,14 @@ import (
 	"syscall"
 	"time"
 
+	"k8s.io/client-go/tools/remotecommand"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	"github.com/containerd/containerd"
 	containerdio "github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/oci"
-	"k8s.io/client-go/tools/remotecommand"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	cio "github.com/containerd/containerd/pkg/cri/io"
 	"github.com/containerd/containerd/pkg/cri/util"

--- a/pkg/cri/sbserver/container_execsync_test.go
+++ b/pkg/cri/sbserver/container_execsync_test.go
@@ -20,8 +20,9 @@ import (
 	"bytes"
 	"testing"
 
-	cioutil "github.com/containerd/containerd/pkg/ioutil"
 	"github.com/stretchr/testify/assert"
+
+	cioutil "github.com/containerd/containerd/pkg/ioutil"
 )
 
 func TestCWWrite(t *testing.T) {

--- a/pkg/cri/sbserver/container_remove.go
+++ b/pkg/cri/sbserver/container_remove.go
@@ -22,12 +22,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/sirupsen/logrus"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
 	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
-	"github.com/sirupsen/logrus"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // RemoveContainer removes the container.

--- a/pkg/cri/sbserver/container_start.go
+++ b/pkg/cri/sbserver/container_start.go
@@ -23,14 +23,15 @@ import (
 	"io"
 	"time"
 
-	"github.com/containerd/containerd"
-	containerdio "github.com/containerd/containerd/cio"
-	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/log"
 	"github.com/containerd/nri"
 	v1 "github.com/containerd/nri/types/v1"
 	"github.com/sirupsen/logrus"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd"
+	containerdio "github.com/containerd/containerd/cio"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/log"
 
 	cio "github.com/containerd/containerd/pkg/cri/io"
 	containerstore "github.com/containerd/containerd/pkg/cri/store/container"

--- a/pkg/cri/sbserver/container_stats.go
+++ b/pkg/cri/sbserver/container_stats.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/containerd/containerd/api/services/tasks/v1"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/api/services/tasks/v1"
 )
 
 // ContainerStats returns stats of the container. If the container does not

--- a/pkg/cri/sbserver/container_stats_list.go
+++ b/pkg/cri/sbserver/container_stats_list.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"fmt"
 
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	"github.com/containerd/containerd/api/services/tasks/v1"
 	"github.com/containerd/containerd/api/types"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
 )

--- a/pkg/cri/sbserver/container_stats_list_linux.go
+++ b/pkg/cri/sbserver/container_stats_list_linux.go
@@ -20,12 +20,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/containerd/typeurl"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	"github.com/containerd/containerd/api/types"
 	v1 "github.com/containerd/containerd/metrics/types/v1"
 	v2 "github.com/containerd/containerd/metrics/types/v2"
 	"github.com/containerd/containerd/protobuf"
-	"github.com/containerd/typeurl"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
 	"github.com/containerd/containerd/pkg/cri/store/stats"

--- a/pkg/cri/sbserver/container_stats_list_linux_test.go
+++ b/pkg/cri/sbserver/container_stats_list_linux_test.go
@@ -23,9 +23,10 @@ import (
 
 	v1 "github.com/containerd/cgroups/stats/v1"
 	v2 "github.com/containerd/cgroups/v2/stats"
-	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
 	"github.com/stretchr/testify/assert"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
 )
 
 func TestGetWorkingSet(t *testing.T) {

--- a/pkg/cri/sbserver/container_stats_list_other.go
+++ b/pkg/cri/sbserver/container_stats_list_other.go
@@ -22,9 +22,10 @@ package sbserver
 import (
 	"fmt"
 
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/errdefs"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
 )

--- a/pkg/cri/sbserver/container_stats_list_windows.go
+++ b/pkg/cri/sbserver/container_stats_list_windows.go
@@ -21,9 +21,10 @@ import (
 	"fmt"
 
 	wstats "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats"
-	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/typeurl"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/api/types"
 
 	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
 )

--- a/pkg/cri/sbserver/events.go
+++ b/pkg/cri/sbserver/events.go
@@ -23,6 +23,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/containerd/typeurl"
+	"github.com/sirupsen/logrus"
+	"k8s.io/utils/clock"
+
 	"github.com/containerd/containerd"
 	eventtypes "github.com/containerd/containerd/api/events"
 	containerdio "github.com/containerd/containerd/cio"
@@ -33,9 +37,6 @@ import (
 	sandboxstore "github.com/containerd/containerd/pkg/cri/store/sandbox"
 	ctrdutil "github.com/containerd/containerd/pkg/cri/util"
 	"github.com/containerd/containerd/protobuf"
-	"github.com/containerd/typeurl"
-	"github.com/sirupsen/logrus"
-	"k8s.io/utils/clock"
 )
 
 const (

--- a/pkg/cri/sbserver/events_test.go
+++ b/pkg/cri/sbserver/events_test.go
@@ -20,12 +20,13 @@ import (
 	"testing"
 	"time"
 
-	eventtypes "github.com/containerd/containerd/api/events"
-	"github.com/containerd/containerd/protobuf"
 	"github.com/containerd/typeurl"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	testingclock "k8s.io/utils/clock/testing"
+
+	eventtypes "github.com/containerd/containerd/api/events"
+	"github.com/containerd/containerd/protobuf"
 )
 
 // TestBackOff tests the logic of backOff struct.

--- a/pkg/cri/sbserver/helpers_linux.go
+++ b/pkg/cri/sbserver/helpers_linux.go
@@ -28,15 +28,16 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/moby/sys/mountinfo"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"golang.org/x/sys/unix"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/pkg/apparmor"
 	"github.com/containerd/containerd/pkg/seccomp"
 	"github.com/containerd/containerd/pkg/seutil"
-	"github.com/moby/sys/mountinfo"
-	"github.com/opencontainers/runtime-spec/specs-go"
-	"golang.org/x/sys/unix"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 const (

--- a/pkg/cri/sbserver/helpers_test.go
+++ b/pkg/cri/sbserver/helpers_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/typeurl"
+
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/oci"
@@ -34,7 +36,6 @@ import (
 	"github.com/containerd/containerd/reference/docker"
 	"github.com/containerd/containerd/runtime/linux/runctypes"
 	runcoptions "github.com/containerd/containerd/runtime/v2/runc/options"
-	"github.com/containerd/typeurl"
 
 	imagedigest "github.com/opencontainers/go-digest"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"

--- a/pkg/cri/sbserver/imagefs_info_test.go
+++ b/pkg/cri/sbserver/imagefs_info_test.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"testing"
 
-	snapshot "github.com/containerd/containerd/snapshots"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	snapshot "github.com/containerd/containerd/snapshots"
 
 	snapshotstore "github.com/containerd/containerd/pkg/cri/store/snapshot"
 )

--- a/pkg/cri/sbserver/instrumented_service.go
+++ b/pkg/cri/sbserver/instrumented_service.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"errors"
 
-	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/log"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 	runtime_alpha "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/log"
 
 	ctrdutil "github.com/containerd/containerd/pkg/cri/util"
 )

--- a/pkg/cri/sbserver/opts.go
+++ b/pkg/cri/sbserver/opts.go
@@ -19,10 +19,11 @@ package sbserver
 import (
 	"context"
 
-	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/log"
 	"github.com/containerd/nri"
 	v1 "github.com/containerd/nri/types/v1"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/log"
 )
 
 // WithNRISandboxDelete calls delete for a sandbox'd task

--- a/pkg/cri/sbserver/podsandbox/container_linux.go
+++ b/pkg/cri/sbserver/podsandbox/container_linux.go
@@ -24,9 +24,10 @@ import (
 	"strconv"
 	"strings"
 
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	"github.com/containerd/containerd/contrib/seccomp"
 	"github.com/containerd/containerd/oci"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 const (

--- a/pkg/cri/sbserver/podsandbox/controller.go
+++ b/pkg/cri/sbserver/podsandbox/controller.go
@@ -21,6 +21,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/sirupsen/logrus"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	"github.com/containerd/containerd"
 	api "github.com/containerd/containerd/api/services/sandbox/v1"
 	"github.com/containerd/containerd/errdefs"
@@ -32,8 +35,6 @@ import (
 	osinterface "github.com/containerd/containerd/pkg/os"
 	"github.com/containerd/containerd/protobuf"
 	"github.com/containerd/containerd/sandbox"
-	"github.com/sirupsen/logrus"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // CRIService interface contains things required by controller, but not yet refactored from criService.

--- a/pkg/cri/sbserver/podsandbox/helpers.go
+++ b/pkg/cri/sbserver/podsandbox/helpers.go
@@ -25,6 +25,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/typeurl"
+	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/containers"
 	clabels "github.com/containerd/containerd/labels"
@@ -38,9 +42,6 @@ import (
 	"github.com/containerd/containerd/reference/docker"
 	"github.com/containerd/containerd/runtime/linux/runctypes"
 	runcoptions "github.com/containerd/containerd/runtime/v2/runc/options"
-	"github.com/containerd/typeurl"
-	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 
 	runhcsoptions "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
 	imagedigest "github.com/opencontainers/go-digest"

--- a/pkg/cri/sbserver/podsandbox/helpers_linux.go
+++ b/pkg/cri/sbserver/podsandbox/helpers_linux.go
@@ -28,15 +28,16 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/containerd/containerd/log"
-	"github.com/containerd/containerd/mount"
-	"github.com/containerd/containerd/pkg/seccomp"
-	"github.com/containerd/containerd/pkg/seutil"
 	"github.com/moby/sys/mountinfo"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"golang.org/x/sys/unix"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/pkg/seccomp"
+	"github.com/containerd/containerd/pkg/seutil"
 )
 
 const (

--- a/pkg/cri/sbserver/podsandbox/helpers_test.go
+++ b/pkg/cri/sbserver/podsandbox/helpers_test.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/containerd/typeurl"
+
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/oci"
 	criconfig "github.com/containerd/containerd/pkg/cri/config"
@@ -30,7 +32,6 @@ import (
 	"github.com/containerd/containerd/reference/docker"
 	"github.com/containerd/containerd/runtime/linux/runctypes"
 	runcoptions "github.com/containerd/containerd/runtime/v2/runc/options"
-	"github.com/containerd/typeurl"
 
 	imagedigest "github.com/opencontainers/go-digest"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"

--- a/pkg/cri/sbserver/podsandbox/opts.go
+++ b/pkg/cri/sbserver/podsandbox/opts.go
@@ -19,10 +19,11 @@ package podsandbox
 import (
 	"context"
 
-	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/log"
 	"github.com/containerd/nri"
 	v1 "github.com/containerd/nri/types/v1"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/log"
 )
 
 // WithNRISandboxDelete calls delete for a sandbox'd task

--- a/pkg/cri/sbserver/podsandbox/sandbox_run.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_run.go
@@ -21,6 +21,13 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/containerd/nri"
+	v1 "github.com/containerd/nri/types/v1"
+	"github.com/containerd/typeurl"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/opencontainers/selinux/go-selinux"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	"github.com/containerd/containerd"
 	api "github.com/containerd/containerd/api/services/sandbox/v1"
 	containerdio "github.com/containerd/containerd/cio"
@@ -33,12 +40,6 @@ import (
 	ctrdutil "github.com/containerd/containerd/pkg/cri/util"
 	"github.com/containerd/containerd/protobuf"
 	"github.com/containerd/containerd/snapshots"
-	"github.com/containerd/nri"
-	v1 "github.com/containerd/nri/types/v1"
-	"github.com/containerd/typeurl"
-	"github.com/davecgh/go-spew/spew"
-	"github.com/opencontainers/selinux/go-selinux"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func init() {

--- a/pkg/cri/sbserver/podsandbox/sandbox_run_linux.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_run_linux.go
@@ -22,14 +22,15 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/oci"
-	"github.com/containerd/containerd/plugin"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux"
 	"golang.org/x/sys/unix"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/oci"
+	"github.com/containerd/containerd/plugin"
 
 	"github.com/containerd/containerd/pkg/cri/annotations"
 	customopts "github.com/containerd/containerd/pkg/cri/opts"

--- a/pkg/cri/sbserver/podsandbox/sandbox_run_other.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_run_other.go
@@ -20,11 +20,12 @@
 package podsandbox
 
 import (
-	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/oci"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/oci"
 )
 
 func (c *Controller) sandboxContainerSpec(id string, config *runtime.PodSandboxConfig,

--- a/pkg/cri/sbserver/podsandbox/sandbox_run_windows.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_run_windows.go
@@ -20,11 +20,12 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/oci"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/oci"
 
 	"github.com/containerd/containerd/pkg/cri/annotations"
 	customopts "github.com/containerd/containerd/pkg/cri/opts"

--- a/pkg/cri/sbserver/podsandbox/sandbox_stop.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_stop.go
@@ -21,13 +21,14 @@ import (
 	"fmt"
 	"syscall"
 
+	"github.com/sirupsen/logrus"
+
 	eventtypes "github.com/containerd/containerd/api/events"
 	api "github.com/containerd/containerd/api/services/sandbox/v1"
 	"github.com/containerd/containerd/errdefs"
 	sandboxstore "github.com/containerd/containerd/pkg/cri/store/sandbox"
 	ctrdutil "github.com/containerd/containerd/pkg/cri/util"
 	"github.com/containerd/containerd/protobuf"
-	"github.com/sirupsen/logrus"
 )
 
 func (c *Controller) Stop(ctx context.Context, sandboxID string) (*api.ControllerStopResponse, error) {

--- a/pkg/cri/sbserver/rdt_linux.go
+++ b/pkg/cri/sbserver/rdt_linux.go
@@ -22,9 +22,10 @@ package sbserver
 import (
 	"fmt"
 
-	"github.com/containerd/containerd/services/tasks"
 	"github.com/intel/goresctrl/pkg/rdt"
 	"github.com/sirupsen/logrus"
+
+	"github.com/containerd/containerd/services/tasks"
 )
 
 // rdtClassFromAnnotations examines container and pod annotations of a

--- a/pkg/cri/sbserver/restart.go
+++ b/pkg/cri/sbserver/restart.go
@@ -25,15 +25,16 @@ import (
 	"sync"
 	"time"
 
+	"github.com/containerd/typeurl"
+	"golang.org/x/sync/errgroup"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	"github.com/containerd/containerd"
 	containerdio "github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/errdefs"
 	containerdimages "github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/platforms"
-	"github.com/containerd/typeurl"
-	"golang.org/x/sync/errgroup"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	cio "github.com/containerd/containerd/pkg/cri/io"
 	containerstore "github.com/containerd/containerd/pkg/cri/store/container"

--- a/pkg/cri/sbserver/sandbox_portforward_linux.go
+++ b/pkg/cri/sbserver/sandbox_portforward_linux.go
@@ -23,8 +23,9 @@ import (
 	"net"
 	"time"
 
-	"github.com/containerd/containerd/log"
 	"github.com/containernetworking/plugins/pkg/ns"
+
+	"github.com/containerd/containerd/log"
 
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )

--- a/pkg/cri/sbserver/sandbox_run.go
+++ b/pkg/cri/sbserver/sandbox_run.go
@@ -27,13 +27,14 @@ import (
 	"strings"
 	"time"
 
-	eventtypes "github.com/containerd/containerd/api/events"
-	"github.com/containerd/containerd/protobuf"
-	sb "github.com/containerd/containerd/sandbox"
 	"github.com/containerd/go-cni"
 	"github.com/containerd/typeurl"
 	"github.com/sirupsen/logrus"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	eventtypes "github.com/containerd/containerd/api/events"
+	"github.com/containerd/containerd/protobuf"
+	sb "github.com/containerd/containerd/sandbox"
 
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/pkg/cri/annotations"

--- a/pkg/cri/sbserver/sandbox_stats_list.go
+++ b/pkg/cri/sbserver/sandbox_stats_list.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"fmt"
 
-	sandboxstore "github.com/containerd/containerd/pkg/cri/store/sandbox"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	sandboxstore "github.com/containerd/containerd/pkg/cri/store/sandbox"
 )
 
 // ListPodSandboxStats returns stats of all ready sandboxes.

--- a/pkg/cri/sbserver/sandbox_status.go
+++ b/pkg/cri/sbserver/sandbox_status.go
@@ -22,11 +22,12 @@ import (
 	"fmt"
 	goruntime "runtime"
 
-	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/go-cni"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/errdefs"
 
 	sandboxstore "github.com/containerd/containerd/pkg/cri/store/sandbox"
 )

--- a/pkg/cri/sbserver/sandbox_stop.go
+++ b/pkg/cri/sbserver/sandbox_stop.go
@@ -22,8 +22,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/containerd/containerd/log"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/log"
 
 	sandboxstore "github.com/containerd/containerd/pkg/cri/store/sandbox"
 )

--- a/pkg/cri/sbserver/service.go
+++ b/pkg/cri/sbserver/service.go
@@ -26,6 +26,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/containerd/go-cni"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtime_alpha "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/pkg/cri/sbserver/podsandbox"
@@ -33,11 +39,6 @@ import (
 	"github.com/containerd/containerd/pkg/kmutex"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/sandbox"
-	"github.com/containerd/go-cni"
-	"github.com/sirupsen/logrus"
-	"google.golang.org/grpc"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
-	runtime_alpha "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 
 	"github.com/containerd/containerd/pkg/cri/store/label"
 

--- a/pkg/cri/sbserver/service_linux.go
+++ b/pkg/cri/sbserver/service_linux.go
@@ -19,11 +19,12 @@ package sbserver
 import (
 	"fmt"
 
-	"github.com/containerd/containerd/pkg/cap"
-	"github.com/containerd/containerd/pkg/userns"
 	"github.com/containerd/go-cni"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/sirupsen/logrus"
+
+	"github.com/containerd/containerd/pkg/cap"
+	"github.com/containerd/containerd/pkg/userns"
 )
 
 // networkAttachCount is the minimum number of networks the PodSandbox

--- a/pkg/cri/sbserver/service_test.go
+++ b/pkg/cri/sbserver/service_test.go
@@ -21,10 +21,11 @@ import (
 	"os"
 	"testing"
 
-	"github.com/containerd/containerd/oci"
 	"github.com/containerd/go-cni"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/containerd/containerd/oci"
 
 	criconfig "github.com/containerd/containerd/pkg/cri/config"
 	servertesting "github.com/containerd/containerd/pkg/cri/server/testing"

--- a/pkg/cri/sbserver/snapshots.go
+++ b/pkg/cri/sbserver/snapshots.go
@@ -21,9 +21,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/containerd/containerd/errdefs"
 	snapshot "github.com/containerd/containerd/snapshots"
-	"github.com/sirupsen/logrus"
 
 	snapshotstore "github.com/containerd/containerd/pkg/cri/store/snapshot"
 	ctrdutil "github.com/containerd/containerd/pkg/cri/util"

--- a/pkg/cri/sbserver/status.go
+++ b/pkg/cri/sbserver/status.go
@@ -22,8 +22,9 @@ import (
 	"fmt"
 	goruntime "runtime"
 
-	"github.com/containerd/containerd/log"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/log"
 )
 
 // networkNotReadyReason is the reason reported when network is not ready.

--- a/pkg/cri/sbserver/streaming_test.go
+++ b/pkg/cri/sbserver/streaming_test.go
@@ -19,8 +19,9 @@ package sbserver
 import (
 	"testing"
 
-	"github.com/containerd/containerd/pkg/cri/config"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/containerd/containerd/pkg/cri/config"
 )
 
 func TestValidateStreamServer(t *testing.T) {

--- a/pkg/cri/sbserver/update_runtime_config.go
+++ b/pkg/cri/sbserver/update_runtime_config.go
@@ -25,8 +25,9 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/containerd/containerd/log"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/log"
 )
 
 // cniConfigTemplate contains the values containerd will overwrite

--- a/pkg/cri/sbserver/version.go
+++ b/pkg/cri/sbserver/version.go
@@ -19,9 +19,10 @@ package sbserver
 import (
 	"context"
 
-	"github.com/containerd/containerd/version"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 	runtime_alpha "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+
+	"github.com/containerd/containerd/version"
 
 	"github.com/containerd/containerd/pkg/cri/constants"
 )

--- a/pkg/cri/server/blockio_linux.go
+++ b/pkg/cri/server/blockio_linux.go
@@ -22,10 +22,11 @@ package server
 import (
 	"fmt"
 
-	"github.com/containerd/containerd/services/tasks"
 	"github.com/intel/goresctrl/pkg/blockio"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
+
+	"github.com/containerd/containerd/services/tasks"
 )
 
 // blockIOClassFromAnnotations examines container and pod annotations of a

--- a/pkg/cri/server/container_attach.go
+++ b/pkg/cri/server/container_attach.go
@@ -21,10 +21,11 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/log"
 	"k8s.io/client-go/tools/remotecommand"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/log"
 
 	cio "github.com/containerd/containerd/pkg/cri/io"
 )

--- a/pkg/cri/server/container_create_linux.go
+++ b/pkg/cri/server/container_create_linux.go
@@ -26,15 +26,16 @@ import (
 	"strings"
 
 	"github.com/containerd/cgroups"
-	"github.com/containerd/containerd/contrib/apparmor"
-	"github.com/containerd/containerd/contrib/seccomp"
-	"github.com/containerd/containerd/oci"
-	"github.com/containerd/containerd/snapshots"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	selinux "github.com/opencontainers/selinux/go-selinux"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/contrib/apparmor"
+	"github.com/containerd/containerd/contrib/seccomp"
+	"github.com/containerd/containerd/oci"
+	"github.com/containerd/containerd/snapshots"
 
 	"github.com/containerd/containerd/pkg/cri/annotations"
 	"github.com/containerd/containerd/pkg/cri/config"

--- a/pkg/cri/server/container_create_linux_test.go
+++ b/pkg/cri/server/container_create_linux_test.go
@@ -27,17 +27,18 @@ import (
 	"testing"
 
 	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
-	"github.com/containerd/containerd/containers"
-	"github.com/containerd/containerd/contrib/apparmor"
-	"github.com/containerd/containerd/contrib/seccomp"
-	"github.com/containerd/containerd/mount"
-	"github.com/containerd/containerd/oci"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/contrib/apparmor"
+	"github.com/containerd/containerd/contrib/seccomp"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/oci"
 
 	"github.com/containerd/containerd/pkg/cap"
 	"github.com/containerd/containerd/pkg/cri/annotations"

--- a/pkg/cri/server/container_create_other.go
+++ b/pkg/cri/server/container_create_other.go
@@ -20,11 +20,12 @@
 package server
 
 import (
-	"github.com/containerd/containerd/oci"
-	"github.com/containerd/containerd/snapshots"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/oci"
+	"github.com/containerd/containerd/snapshots"
 
 	"github.com/containerd/containerd/pkg/cri/config"
 )

--- a/pkg/cri/server/container_create_windows.go
+++ b/pkg/cri/server/container_create_windows.go
@@ -21,11 +21,12 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/containerd/containerd/oci"
-	"github.com/containerd/containerd/snapshots"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/oci"
+	"github.com/containerd/containerd/snapshots"
 
 	"github.com/containerd/containerd/pkg/cri/annotations"
 	"github.com/containerd/containerd/pkg/cri/config"

--- a/pkg/cri/server/container_execsync.go
+++ b/pkg/cri/server/container_execsync.go
@@ -24,13 +24,14 @@ import (
 	"syscall"
 	"time"
 
+	"k8s.io/client-go/tools/remotecommand"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	"github.com/containerd/containerd"
 	containerdio "github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/oci"
-	"k8s.io/client-go/tools/remotecommand"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	cio "github.com/containerd/containerd/pkg/cri/io"
 	"github.com/containerd/containerd/pkg/cri/util"

--- a/pkg/cri/server/container_execsync_test.go
+++ b/pkg/cri/server/container_execsync_test.go
@@ -20,8 +20,9 @@ import (
 	"bytes"
 	"testing"
 
-	cioutil "github.com/containerd/containerd/pkg/ioutil"
 	"github.com/stretchr/testify/assert"
+
+	cioutil "github.com/containerd/containerd/pkg/ioutil"
 )
 
 func TestCWWrite(t *testing.T) {

--- a/pkg/cri/server/container_remove.go
+++ b/pkg/cri/server/container_remove.go
@@ -22,12 +22,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/sirupsen/logrus"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
 	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
-	"github.com/sirupsen/logrus"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // RemoveContainer removes the container.

--- a/pkg/cri/server/container_start.go
+++ b/pkg/cri/server/container_start.go
@@ -23,14 +23,15 @@ import (
 	"io"
 	"time"
 
-	"github.com/containerd/containerd"
-	containerdio "github.com/containerd/containerd/cio"
-	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/log"
 	"github.com/containerd/nri"
 	v1 "github.com/containerd/nri/types/v1"
 	"github.com/sirupsen/logrus"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd"
+	containerdio "github.com/containerd/containerd/cio"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/log"
 
 	cio "github.com/containerd/containerd/pkg/cri/io"
 	containerstore "github.com/containerd/containerd/pkg/cri/store/container"

--- a/pkg/cri/server/container_stats.go
+++ b/pkg/cri/server/container_stats.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"fmt"
 
-	tasks "github.com/containerd/containerd/api/services/tasks/v1"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	tasks "github.com/containerd/containerd/api/services/tasks/v1"
 )
 
 // ContainerStats returns stats of the container. If the container does not

--- a/pkg/cri/server/container_stats_list.go
+++ b/pkg/cri/server/container_stats_list.go
@@ -23,9 +23,10 @@ import (
 
 	"github.com/containerd/containerd/pkg/cri/store/stats"
 
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	tasks "github.com/containerd/containerd/api/services/tasks/v1"
 	"github.com/containerd/containerd/api/types"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
 )

--- a/pkg/cri/server/container_stats_list_linux.go
+++ b/pkg/cri/server/container_stats_list_linux.go
@@ -20,12 +20,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/containerd/typeurl"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	"github.com/containerd/containerd/api/types"
 	v1 "github.com/containerd/containerd/metrics/types/v1"
 	v2 "github.com/containerd/containerd/metrics/types/v2"
 	"github.com/containerd/containerd/protobuf"
-	"github.com/containerd/typeurl"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
 )

--- a/pkg/cri/server/container_stats_list_other.go
+++ b/pkg/cri/server/container_stats_list_other.go
@@ -22,9 +22,10 @@ package server
 import (
 	"fmt"
 
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/errdefs"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
 )

--- a/pkg/cri/server/container_stats_list_test.go
+++ b/pkg/cri/server/container_stats_list_test.go
@@ -20,8 +20,9 @@ import (
 	"testing"
 	"time"
 
-	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
 	"github.com/stretchr/testify/assert"
+
+	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
 )
 
 func TestContainerMetricsCPUNanoCoreUsage(t *testing.T) {

--- a/pkg/cri/server/container_stats_list_windows.go
+++ b/pkg/cri/server/container_stats_list_windows.go
@@ -21,9 +21,10 @@ import (
 	"fmt"
 
 	wstats "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats"
-	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/typeurl"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/api/types"
 
 	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
 )

--- a/pkg/cri/server/container_update_resources.go
+++ b/pkg/cri/server/container_update_resources.go
@@ -24,13 +24,14 @@ import (
 	gocontext "context"
 	"fmt"
 
+	"github.com/containerd/typeurl"
+	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
-	"github.com/containerd/typeurl"
-	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
 	ctrdutil "github.com/containerd/containerd/pkg/cri/util"

--- a/pkg/cri/server/events.go
+++ b/pkg/cri/server/events.go
@@ -23,6 +23,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/containerd/typeurl"
+	"github.com/sirupsen/logrus"
+	"k8s.io/utils/clock"
+
 	"github.com/containerd/containerd"
 	eventtypes "github.com/containerd/containerd/api/events"
 	containerdio "github.com/containerd/containerd/cio"
@@ -33,9 +37,6 @@ import (
 	sandboxstore "github.com/containerd/containerd/pkg/cri/store/sandbox"
 	ctrdutil "github.com/containerd/containerd/pkg/cri/util"
 	"github.com/containerd/containerd/protobuf"
-	"github.com/containerd/typeurl"
-	"github.com/sirupsen/logrus"
-	"k8s.io/utils/clock"
 )
 
 const (

--- a/pkg/cri/server/events_test.go
+++ b/pkg/cri/server/events_test.go
@@ -20,12 +20,13 @@ import (
 	"testing"
 	"time"
 
-	eventtypes "github.com/containerd/containerd/api/events"
-	"github.com/containerd/containerd/protobuf"
 	"github.com/containerd/typeurl"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	testingclock "k8s.io/utils/clock/testing"
+
+	eventtypes "github.com/containerd/containerd/api/events"
+	"github.com/containerd/containerd/protobuf"
 )
 
 // TestBackOff tests the logic of backOff struct.

--- a/pkg/cri/server/helpers.go
+++ b/pkg/cri/server/helpers.go
@@ -24,6 +24,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/containerd/typeurl"
+	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/errdefs"
@@ -37,9 +41,6 @@ import (
 	"github.com/containerd/containerd/reference/docker"
 	"github.com/containerd/containerd/runtime/linux/runctypes"
 	runcoptions "github.com/containerd/containerd/runtime/v2/runc/options"
-	"github.com/containerd/typeurl"
-	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 
 	runhcsoptions "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
 	imagedigest "github.com/opencontainers/go-digest"

--- a/pkg/cri/server/helpers_linux.go
+++ b/pkg/cri/server/helpers_linux.go
@@ -28,16 +28,17 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/containerd/containerd/log"
-	"github.com/containerd/containerd/mount"
-	"github.com/containerd/containerd/pkg/apparmor"
-	"github.com/containerd/containerd/pkg/seccomp"
-	"github.com/containerd/containerd/pkg/seutil"
 	"github.com/moby/sys/mountinfo"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"golang.org/x/sys/unix"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/pkg/apparmor"
+	"github.com/containerd/containerd/pkg/seccomp"
+	"github.com/containerd/containerd/pkg/seutil"
 )
 
 const (

--- a/pkg/cri/server/helpers_test.go
+++ b/pkg/cri/server/helpers_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/typeurl"
+
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/oci"
@@ -34,7 +36,6 @@ import (
 	"github.com/containerd/containerd/reference/docker"
 	"github.com/containerd/containerd/runtime/linux/runctypes"
 	runcoptions "github.com/containerd/containerd/runtime/v2/runc/options"
-	"github.com/containerd/typeurl"
 
 	imagedigest "github.com/opencontainers/go-digest"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"

--- a/pkg/cri/server/imagefs_info_test.go
+++ b/pkg/cri/server/imagefs_info_test.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"testing"
 
-	snapshot "github.com/containerd/containerd/snapshots"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	snapshot "github.com/containerd/containerd/snapshots"
 
 	snapshotstore "github.com/containerd/containerd/pkg/cri/store/snapshot"
 )

--- a/pkg/cri/server/instrumented_service.go
+++ b/pkg/cri/server/instrumented_service.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"errors"
 
-	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/log"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 	runtime_alpha "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/log"
 
 	ctrdutil "github.com/containerd/containerd/pkg/cri/util"
 )

--- a/pkg/cri/server/opts.go
+++ b/pkg/cri/server/opts.go
@@ -19,10 +19,11 @@ package server
 import (
 	"context"
 
-	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/log"
 	"github.com/containerd/nri"
 	v1 "github.com/containerd/nri/types/v1"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/log"
 )
 
 // WithNRISandboxDelete calls delete for a sandbox'd task

--- a/pkg/cri/server/rdt_linux.go
+++ b/pkg/cri/server/rdt_linux.go
@@ -22,9 +22,10 @@ package server
 import (
 	"fmt"
 
-	"github.com/containerd/containerd/services/tasks"
 	"github.com/intel/goresctrl/pkg/rdt"
 	"github.com/sirupsen/logrus"
+
+	"github.com/containerd/containerd/services/tasks"
 )
 
 // rdtClassFromAnnotations examines container and pod annotations of a

--- a/pkg/cri/server/restart.go
+++ b/pkg/cri/server/restart.go
@@ -25,15 +25,16 @@ import (
 	"sync"
 	"time"
 
+	"github.com/containerd/typeurl"
+	"golang.org/x/sync/errgroup"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	"github.com/containerd/containerd"
 	containerdio "github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/errdefs"
 	containerdimages "github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/platforms"
-	"github.com/containerd/typeurl"
-	"golang.org/x/sync/errgroup"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	cio "github.com/containerd/containerd/pkg/cri/io"
 	containerstore "github.com/containerd/containerd/pkg/cri/store/container"

--- a/pkg/cri/server/sandbox_portforward_linux.go
+++ b/pkg/cri/server/sandbox_portforward_linux.go
@@ -23,8 +23,9 @@ import (
 	"net"
 	"time"
 
-	"github.com/containerd/containerd/log"
 	"github.com/containernetworking/plugins/pkg/ns"
+
+	"github.com/containerd/containerd/log"
 
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )

--- a/pkg/cri/server/sandbox_run_linux.go
+++ b/pkg/cri/server/sandbox_run_linux.go
@@ -22,14 +22,15 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/oci"
-	"github.com/containerd/containerd/plugin"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	selinux "github.com/opencontainers/selinux/go-selinux"
 	"golang.org/x/sys/unix"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/oci"
+	"github.com/containerd/containerd/plugin"
 
 	"github.com/containerd/containerd/pkg/cri/annotations"
 	customopts "github.com/containerd/containerd/pkg/cri/opts"

--- a/pkg/cri/server/sandbox_run_other.go
+++ b/pkg/cri/server/sandbox_run_other.go
@@ -20,11 +20,12 @@
 package server
 
 import (
-	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/oci"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/oci"
 )
 
 func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxConfig,

--- a/pkg/cri/server/sandbox_run_windows.go
+++ b/pkg/cri/server/sandbox_run_windows.go
@@ -20,11 +20,12 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/oci"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/oci"
 
 	"github.com/containerd/containerd/pkg/cri/annotations"
 	customopts "github.com/containerd/containerd/pkg/cri/opts"

--- a/pkg/cri/server/sandbox_stats_list.go
+++ b/pkg/cri/server/sandbox_stats_list.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"fmt"
 
-	sandboxstore "github.com/containerd/containerd/pkg/cri/store/sandbox"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	sandboxstore "github.com/containerd/containerd/pkg/cri/store/sandbox"
 )
 
 // ListPodSandboxStats returns stats of all ready sandboxes.

--- a/pkg/cri/server/sandbox_status.go
+++ b/pkg/cri/server/sandbox_status.go
@@ -22,11 +22,12 @@ import (
 	"fmt"
 	goruntime "runtime"
 
-	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/errdefs"
 	cni "github.com/containerd/go-cni"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/errdefs"
 
 	sandboxstore "github.com/containerd/containerd/pkg/cri/store/sandbox"
 )

--- a/pkg/cri/server/sandbox_stop.go
+++ b/pkg/cri/server/sandbox_stop.go
@@ -23,11 +23,12 @@ import (
 	"syscall"
 	"time"
 
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	eventtypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/protobuf"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	sandboxstore "github.com/containerd/containerd/pkg/cri/store/sandbox"
 	ctrdutil "github.com/containerd/containerd/pkg/cri/util"

--- a/pkg/cri/server/service.go
+++ b/pkg/cri/server/service.go
@@ -26,16 +26,17 @@ import (
 	"sync"
 	"time"
 
-	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/oci"
-	"github.com/containerd/containerd/pkg/cri/streaming"
-	"github.com/containerd/containerd/pkg/kmutex"
-	"github.com/containerd/containerd/plugin"
 	cni "github.com/containerd/go-cni"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 	runtime_alpha "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/oci"
+	"github.com/containerd/containerd/pkg/cri/streaming"
+	"github.com/containerd/containerd/pkg/kmutex"
+	"github.com/containerd/containerd/plugin"
 
 	"github.com/containerd/containerd/pkg/cri/store/label"
 

--- a/pkg/cri/server/service_linux.go
+++ b/pkg/cri/server/service_linux.go
@@ -19,11 +19,12 @@ package server
 import (
 	"fmt"
 
-	"github.com/containerd/containerd/pkg/cap"
-	"github.com/containerd/containerd/pkg/userns"
 	cni "github.com/containerd/go-cni"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/sirupsen/logrus"
+
+	"github.com/containerd/containerd/pkg/cap"
+	"github.com/containerd/containerd/pkg/userns"
 )
 
 // networkAttachCount is the minimum number of networks the PodSandbox

--- a/pkg/cri/server/service_test.go
+++ b/pkg/cri/server/service_test.go
@@ -21,10 +21,11 @@ import (
 	"os"
 	"testing"
 
-	"github.com/containerd/containerd/oci"
 	"github.com/containerd/go-cni"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/containerd/containerd/oci"
 
 	criconfig "github.com/containerd/containerd/pkg/cri/config"
 	servertesting "github.com/containerd/containerd/pkg/cri/server/testing"

--- a/pkg/cri/server/snapshots.go
+++ b/pkg/cri/server/snapshots.go
@@ -21,9 +21,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/containerd/containerd/errdefs"
 	snapshot "github.com/containerd/containerd/snapshots"
-	"github.com/sirupsen/logrus"
 
 	snapshotstore "github.com/containerd/containerd/pkg/cri/store/snapshot"
 	ctrdutil "github.com/containerd/containerd/pkg/cri/util"

--- a/pkg/cri/server/status.go
+++ b/pkg/cri/server/status.go
@@ -22,8 +22,9 @@ import (
 	"fmt"
 	goruntime "runtime"
 
-	"github.com/containerd/containerd/log"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/log"
 )
 
 // networkNotReadyReason is the reason reported when network is not ready.

--- a/pkg/cri/server/streaming_test.go
+++ b/pkg/cri/server/streaming_test.go
@@ -19,8 +19,9 @@ package server
 import (
 	"testing"
 
-	"github.com/containerd/containerd/pkg/cri/config"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/containerd/containerd/pkg/cri/config"
 )
 
 func TestValidateStreamServer(t *testing.T) {

--- a/pkg/cri/server/update_runtime_config.go
+++ b/pkg/cri/server/update_runtime_config.go
@@ -25,8 +25,9 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/containerd/containerd/log"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"github.com/containerd/containerd/log"
 )
 
 // cniConfigTemplate contains the values containerd will overwrite

--- a/pkg/cri/server/version.go
+++ b/pkg/cri/server/version.go
@@ -19,9 +19,10 @@ package server
 import (
 	"context"
 
-	"github.com/containerd/containerd/version"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 	runtime_alpha "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+
+	"github.com/containerd/containerd/version"
 
 	"github.com/containerd/containerd/pkg/cri/constants"
 )

--- a/pkg/cri/util/image_test.go
+++ b/pkg/cri/util/image_test.go
@@ -19,8 +19,9 @@ package util
 import (
 	"testing"
 
-	"github.com/containerd/containerd/reference"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/containerd/containerd/reference"
 )
 
 func TestNormalizeImageRef(t *testing.T) {

--- a/pkg/kmutex/kmutex_test.go
+++ b/pkg/kmutex/kmutex_test.go
@@ -25,8 +25,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/containerd/pkg/seed"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/containerd/containerd/pkg/seed"
 )
 
 func init() {

--- a/pkg/netns/netns_linux.go
+++ b/pkg/netns/netns_linux.go
@@ -39,10 +39,11 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/containerd/containerd/mount"
 	cnins "github.com/containernetworking/plugins/pkg/ns"
 	"github.com/moby/sys/symlink"
 	"golang.org/x/sys/unix"
+
+	"github.com/containerd/containerd/mount"
 )
 
 // Some of the following functions are migrated from

--- a/pkg/oom/v1/v1.go
+++ b/pkg/oom/v1/v1.go
@@ -25,12 +25,13 @@ import (
 	"sync"
 
 	"github.com/containerd/cgroups"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+
 	eventstypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/pkg/oom"
 	"github.com/containerd/containerd/runtime"
 	"github.com/containerd/containerd/runtime/v2/shim"
-	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 )
 
 // New returns an epoll implementation that listens to OOM events

--- a/pkg/oom/v2/v2.go
+++ b/pkg/oom/v2/v2.go
@@ -24,11 +24,12 @@ import (
 	"fmt"
 
 	cgroupsv2 "github.com/containerd/cgroups/v2"
+	"github.com/sirupsen/logrus"
+
 	eventstypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/pkg/oom"
 	"github.com/containerd/containerd/runtime"
 	"github.com/containerd/containerd/runtime/v2/shim"
-	"github.com/sirupsen/logrus"
 )
 
 // New returns an implementation that listens to OOM events

--- a/pkg/os/mount_linux.go
+++ b/pkg/os/mount_linux.go
@@ -17,8 +17,9 @@
 package os
 
 import (
-	"github.com/containerd/containerd/mount"
 	"golang.org/x/sys/unix"
+
+	"github.com/containerd/containerd/mount"
 )
 
 // Mount will call unix.Mount to mount the file.

--- a/pkg/process/deleted_state.go
+++ b/pkg/process/deleted_state.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 
 	"github.com/containerd/console"
+
 	"github.com/containerd/containerd/errdefs"
 	google_protobuf "github.com/containerd/containerd/protobuf/types"
 )

--- a/pkg/process/exec.go
+++ b/pkg/process/exec.go
@@ -32,11 +32,12 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/containerd/console"
-	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/pkg/stdio"
 	"github.com/containerd/fifo"
 	runc "github.com/containerd/go-runc"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/pkg/stdio"
 )
 
 type execProcess struct {

--- a/pkg/process/init.go
+++ b/pkg/process/init.go
@@ -31,14 +31,15 @@ import (
 	"time"
 
 	"github.com/containerd/console"
-	"github.com/containerd/containerd/log"
-	"github.com/containerd/containerd/mount"
-	"github.com/containerd/containerd/pkg/stdio"
-	google_protobuf "github.com/containerd/containerd/protobuf/types"
 	"github.com/containerd/fifo"
 	runc "github.com/containerd/go-runc"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
+
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/pkg/stdio"
+	google_protobuf "github.com/containerd/containerd/protobuf/types"
 )
 
 // Init represents an initial process for a container

--- a/pkg/process/init_state.go
+++ b/pkg/process/init_state.go
@@ -24,9 +24,10 @@ import (
 	"errors"
 	"fmt"
 
-	google_protobuf "github.com/containerd/containerd/protobuf/types"
 	runc "github.com/containerd/go-runc"
 	"github.com/sirupsen/logrus"
+
+	google_protobuf "github.com/containerd/containerd/protobuf/types"
 )
 
 type initState interface {

--- a/pkg/process/io.go
+++ b/pkg/process/io.go
@@ -31,13 +31,14 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/containerd/containerd/log"
-	"github.com/containerd/containerd/namespaces"
-	"github.com/containerd/containerd/pkg/stdio"
 	"github.com/containerd/fifo"
 	runc "github.com/containerd/go-runc"
 	"github.com/hashicorp/go-multierror"
 	exec "golang.org/x/sys/execabs"
+
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/pkg/stdio"
 )
 
 const binaryIOProcTermTimeout = 12 * time.Second // Give logger process solid 10 seconds for cleanup

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/containerd/console"
+
 	"github.com/containerd/containerd/pkg/stdio"
 )
 

--- a/pkg/process/utils.go
+++ b/pkg/process/utils.go
@@ -31,9 +31,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/containerd/containerd/errdefs"
 	runc "github.com/containerd/go-runc"
 	"golang.org/x/sys/unix"
+
+	"github.com/containerd/containerd/errdefs"
 )
 
 const (

--- a/pkg/testutil/helpers_unix.go
+++ b/pkg/testutil/helpers_unix.go
@@ -24,8 +24,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/containerd/containerd/mount"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/containerd/containerd/mount"
 )
 
 // Unmount unmounts a given mountPoint and sets t.Error if it fails

--- a/pkg/ttrpcutil/client.go
+++ b/pkg/ttrpcutil/client.go
@@ -23,9 +23,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/containerd/ttrpc"
+
 	v1 "github.com/containerd/containerd/api/services/ttrpc/events/v1"
 	"github.com/containerd/containerd/pkg/dialer"
-	"github.com/containerd/ttrpc"
 )
 
 const ttrpcDialTimeout = 5 * time.Second

--- a/pkg/unpack/unpacker.go
+++ b/pkg/unpack/unpacker.go
@@ -27,6 +27,13 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/identity"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/semaphore"
+
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/diff"
 	"github.com/containerd/containerd/errdefs"
@@ -36,12 +43,6 @@ import (
 	"github.com/containerd/containerd/pkg/kmutex"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/snapshots"
-	"github.com/opencontainers/go-digest"
-	"github.com/opencontainers/image-spec/identity"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
-	"golang.org/x/sync/errgroup"
-	"golang.org/x/sync/semaphore"
 )
 
 const (

--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -114,8 +114,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/containerd/containerd/errdefs"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/errdefs"
 )
 
 var (

--- a/plugin/context.go
+++ b/plugin/context.go
@@ -21,9 +21,10 @@ import (
 	"fmt"
 	"path/filepath"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/events/exchange"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // InitContext is used for plugin initialization

--- a/pull.go
+++ b/pull.go
@@ -21,6 +21,9 @@ import (
 	"errors"
 	"fmt"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/sync/semaphore"
+
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/pkg/unpack"
@@ -28,8 +31,6 @@ import (
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/containerd/containerd/remotes/docker/schema1" //nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"golang.org/x/sync/semaphore"
 )
 
 // Pull downloads the provided content into containerd's content store

--- a/remotes/docker/authorizer.go
+++ b/remotes/docker/authorizer.go
@@ -25,11 +25,12 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/remotes/docker/auth"
 	remoteerrors "github.com/containerd/containerd/remotes/errors"
-	"github.com/sirupsen/logrus"
 )
 
 type dockerAuthorizer struct {

--- a/remotes/docker/config/hosts.go
+++ b/remotes/docker/config/hosts.go
@@ -32,10 +32,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pelletier/go-toml"
+
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/remotes/docker"
-	"github.com/pelletier/go-toml"
 )
 
 // UpdateClientFunc is a function that lets you to amend http Client behavior used by registry clients.

--- a/remotes/docker/converter.go
+++ b/remotes/docker/converter.go
@@ -22,12 +22,13 @@ import (
 	"encoding/json"
 	"fmt"
 
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/remotes"
-	digest "github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // LegacyConfigMediaType should be replaced by OCI image spec.

--- a/remotes/docker/converter_fuzz.go
+++ b/remotes/docker/converter_fuzz.go
@@ -24,10 +24,11 @@ import (
 	"os"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	"github.com/containerd/containerd/content/local"
-	"github.com/containerd/containerd/log"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
+
+	"github.com/containerd/containerd/content/local"
+	"github.com/containerd/containerd/log"
 )
 
 func FuzzConvertManifest(data []byte) int {

--- a/remotes/docker/fetcher.go
+++ b/remotes/docker/fetcher.go
@@ -26,10 +26,11 @@ import (
 	"net/url"
 	"strings"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 type dockerFetcher struct {

--- a/remotes/docker/handler.go
+++ b/remotes/docker/handler.go
@@ -22,12 +22,13 @@ import (
 	"net/url"
 	"strings"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/labels"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/reference"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 var (

--- a/remotes/docker/pusher.go
+++ b/remotes/docker/pusher.go
@@ -26,14 +26,15 @@ import (
 	"strings"
 	"time"
 
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/remotes"
 	remoteserrors "github.com/containerd/containerd/remotes/errors"
-	digest "github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 type dockerPusher struct {

--- a/remotes/docker/pusher_test.go
+++ b/remotes/docker/pusher_test.go
@@ -29,12 +29,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/remotes"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/remotes"
 )
 
 func TestGetManifestPath(t *testing.T) {

--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -27,6 +27,10 @@ import (
 	"path"
 	"strings"
 
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
+
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
@@ -35,9 +39,6 @@ import (
 	"github.com/containerd/containerd/remotes/docker/schema1" //nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
 	remoteerrors "github.com/containerd/containerd/remotes/errors"
 	"github.com/containerd/containerd/version"
-	digest "github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/remotes/docker/resolver_test.go
+++ b/remotes/docker/resolver_test.go
@@ -31,11 +31,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/containerd/remotes"
-	"github.com/containerd/containerd/remotes/docker/auth"
 	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/remotes"
+	"github.com/containerd/containerd/remotes/docker/auth"
 )
 
 func TestHTTPResolver(t *testing.T) {

--- a/remotes/docker/schema1/converter.go
+++ b/remotes/docker/schema1/converter.go
@@ -32,16 +32,17 @@ import (
 	"sync"
 	"time"
 
+	digest "github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/containerd/containerd/archive/compression"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/remotes"
-	digest "github.com/opencontainers/go-digest"
-	specs "github.com/opencontainers/image-spec/specs-go"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"golang.org/x/sync/errgroup"
 )
 
 const (

--- a/remotes/docker/scope_test.go
+++ b/remotes/docker/scope_test.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/containerd/containerd/reference"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/containerd/containerd/reference"
 )
 
 func TestRepositoryScope(t *testing.T) {

--- a/remotes/docker/status.go
+++ b/remotes/docker/status.go
@@ -20,9 +20,10 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/moby/locker"
+
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
-	"github.com/moby/locker"
 )
 
 // Status of a content operation

--- a/remotes/handlers.go
+++ b/remotes/handlers.go
@@ -24,14 +24,15 @@ import (
 	"strings"
 	"sync"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/semaphore"
+
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/platforms"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
-	"golang.org/x/sync/semaphore"
 )
 
 type refKeyPrefix struct{}

--- a/remotes/handlers_test.go
+++ b/remotes/handlers_test.go
@@ -23,11 +23,12 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/content/local"
 	"github.com/containerd/containerd/images"
-	"github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func TestContextCustomKeyPrefix(t *testing.T) {

--- a/remotes/resolver.go
+++ b/remotes/resolver.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"io"
 
-	"github.com/containerd/containerd/content"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/content"
 )
 
 // Resolver provides remotes based on a locator.

--- a/rootfs/apply.go
+++ b/rootfs/apply.go
@@ -23,14 +23,15 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/identity"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/diff"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/snapshots"
-	"github.com/opencontainers/go-digest"
-	"github.com/opencontainers/image-spec/identity"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // Layer represents the descriptors for a layer diff. These descriptions

--- a/rootfs/diff.go
+++ b/rootfs/diff.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"fmt"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/diff"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/snapshots"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // CreateDiff creates a layer diff for the given snapshot identifier from the

--- a/rootfs/init.go
+++ b/rootfs/init.go
@@ -22,10 +22,11 @@ import (
 	"fmt"
 	"os"
 
+	digest "github.com/opencontainers/go-digest"
+
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/snapshots"
-	digest "github.com/opencontainers/go-digest"
 )
 
 var (

--- a/runtime/opts/opts_linux.go
+++ b/runtime/opts/opts_linux.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/containerd/cgroups"
 	cgroupsv2 "github.com/containerd/cgroups/v2"
+
 	"github.com/containerd/containerd/namespaces"
 )
 

--- a/runtime/restart/monitor/change.go
+++ b/runtime/restart/monitor/change.go
@@ -23,10 +23,11 @@ import (
 	"strconv"
 	"syscall"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/runtime/restart"
-	"github.com/sirupsen/logrus"
 )
 
 type stopChange struct {

--- a/runtime/restart/monitor/monitor.go
+++ b/runtime/restart/monitor/monitor.go
@@ -23,11 +23,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/runtime/restart"
-	"github.com/sirupsen/logrus"
 )
 
 type duration struct {

--- a/runtime/restart/restart.go
+++ b/runtime/restart/restart.go
@@ -36,10 +36,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/containers"
-	"github.com/sirupsen/logrus"
 )
 
 const (

--- a/runtime/restart/restart_test.go
+++ b/runtime/restart/restart_test.go
@@ -19,8 +19,9 @@ package restart
 import (
 	"testing"
 
-	"github.com/containerd/containerd"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/containerd/containerd"
 )
 
 func TestNewRestartPolicy(t *testing.T) {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/containerd/containerd/mount"
 	"github.com/containerd/typeurl"
+
+	"github.com/containerd/containerd/mount"
 )
 
 // IO holds process IO information

--- a/runtime/v1/linux/bundle.go
+++ b/runtime/v1/linux/bundle.go
@@ -27,11 +27,12 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/containerd/containerd/events/exchange"
 	"github.com/containerd/containerd/runtime/linux/runctypes"
 	"github.com/containerd/containerd/runtime/v1/shim"
 	"github.com/containerd/containerd/runtime/v1/shim/client"
-	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // loadBundle loads an existing bundle from disk

--- a/runtime/v1/linux/bundle_test.go
+++ b/runtime/v1/linux/bundle_test.go
@@ -28,11 +28,12 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/containerd/containerd/oci"
 	"github.com/containerd/continuity/testutil"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/containerd/containerd/oci"
 )
 
 func TestNewBundle(t *testing.T) {

--- a/runtime/v1/linux/process.go
+++ b/runtime/v1/linux/process.go
@@ -23,13 +23,14 @@ import (
 	"context"
 	"errors"
 
+	"github.com/containerd/ttrpc"
+
 	eventstypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/api/types/task"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/protobuf"
 	"github.com/containerd/containerd/runtime"
 	shim "github.com/containerd/containerd/runtime/v1/shim/v1"
-	"github.com/containerd/ttrpc"
 )
 
 // Process implements a linux process

--- a/runtime/v1/linux/runtime.go
+++ b/runtime/v1/linux/runtime.go
@@ -28,6 +28,12 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/containerd/go-runc"
+	"github.com/containerd/typeurl"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+
 	eventstypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/containers"
@@ -47,11 +53,6 @@ import (
 	"github.com/containerd/containerd/runtime/linux/runctypes"
 	v1 "github.com/containerd/containerd/runtime/v1"
 	"github.com/containerd/containerd/runtime/v1/shim/v1"
-	"github.com/containerd/go-runc"
-	"github.com/containerd/typeurl"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 )
 
 var (

--- a/runtime/v1/linux/task.go
+++ b/runtime/v1/linux/task.go
@@ -26,6 +26,8 @@ import (
 	"sync"
 
 	"github.com/containerd/cgroups"
+	"github.com/containerd/ttrpc"
+
 	eventstypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/events/exchange"
@@ -36,7 +38,6 @@ import (
 	"github.com/containerd/containerd/runtime"
 	"github.com/containerd/containerd/runtime/v1/shim/client"
 	"github.com/containerd/containerd/runtime/v1/shim/v1"
-	"github.com/containerd/ttrpc"
 )
 
 // Task on a linux based system

--- a/runtime/v1/shim/client/client.go
+++ b/runtime/v1/shim/client/client.go
@@ -33,6 +33,11 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/containerd/ttrpc"
+	"github.com/sirupsen/logrus"
+	exec "golang.org/x/sys/execabs"
+	"golang.org/x/sys/unix"
+
 	"github.com/containerd/containerd/events"
 	"github.com/containerd/containerd/log"
 	ptypes "github.com/containerd/containerd/protobuf/types"
@@ -40,10 +45,6 @@ import (
 	"github.com/containerd/containerd/runtime/v1/shim"
 	shimapi "github.com/containerd/containerd/runtime/v1/shim/v1"
 	"github.com/containerd/containerd/sys"
-	"github.com/containerd/ttrpc"
-	"github.com/sirupsen/logrus"
-	exec "golang.org/x/sys/execabs"
-	"golang.org/x/sys/unix"
 )
 
 var empty = &ptypes.Empty{}

--- a/runtime/v1/shim/service.go
+++ b/runtime/v1/shim/service.go
@@ -28,6 +28,13 @@ import (
 	"sync"
 
 	"github.com/containerd/console"
+	runc "github.com/containerd/go-runc"
+	"github.com/containerd/typeurl"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	eventstypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/api/types/task"
 	"github.com/containerd/containerd/errdefs"
@@ -43,12 +50,6 @@ import (
 	"github.com/containerd/containerd/runtime/linux/runctypes"
 	shimapi "github.com/containerd/containerd/runtime/v1/shim/v1"
 	"github.com/containerd/containerd/sys/reaper"
-	runc "github.com/containerd/go-runc"
-	"github.com/containerd/typeurl"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 var (

--- a/runtime/v1/shim/service_linux.go
+++ b/runtime/v1/shim/service_linux.go
@@ -27,9 +27,10 @@ import (
 	"syscall"
 
 	"github.com/containerd/console"
+	"github.com/containerd/fifo"
+
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/pkg/process"
-	"github.com/containerd/fifo"
 )
 
 type linuxPlatform struct {

--- a/runtime/v1/shim/service_unix.go
+++ b/runtime/v1/shim/service_unix.go
@@ -29,9 +29,10 @@ import (
 	"syscall"
 
 	"github.com/containerd/console"
+	"github.com/containerd/fifo"
+
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/pkg/process"
-	"github.com/containerd/fifo"
 )
 
 type unixPlatform struct {

--- a/runtime/v2/binary.go
+++ b/runtime/v2/binary.go
@@ -26,6 +26,9 @@ import (
 	gruntime "runtime"
 	"strings"
 
+	"github.com/containerd/ttrpc"
+	"github.com/sirupsen/logrus"
+
 	"github.com/containerd/containerd/api/runtime/task/v2"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/namespaces"
@@ -34,8 +37,6 @@ import (
 	"github.com/containerd/containerd/protobuf/types"
 	"github.com/containerd/containerd/runtime"
 	client "github.com/containerd/containerd/runtime/v2/shim"
-	"github.com/containerd/ttrpc"
-	"github.com/sirupsen/logrus"
 )
 
 type shimBinaryConfig struct {

--- a/runtime/v2/bundle.go
+++ b/runtime/v2/bundle.go
@@ -22,11 +22,12 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/containerd/typeurl"
+	"github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/containerd/containerd/identifiers"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/namespaces"
-	"github.com/containerd/typeurl"
-	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 const configFilename = "config.json"

--- a/runtime/v2/bundle_linux_test.go
+++ b/runtime/v2/bundle_linux_test.go
@@ -26,13 +26,14 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/containerd/containerd/namespaces"
-	"github.com/containerd/containerd/oci"
-	"github.com/containerd/containerd/pkg/testutil"
 	"github.com/containerd/typeurl"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/oci"
+	"github.com/containerd/containerd/pkg/testutil"
 )
 
 func TestNewBundle(t *testing.T) {

--- a/runtime/v2/manager.go
+++ b/runtime/v2/manager.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"sync"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/events/exchange"
@@ -38,7 +40,6 @@ import (
 	"github.com/containerd/containerd/runtime"
 	shimbinary "github.com/containerd/containerd/runtime/v2/shim"
 	"github.com/containerd/containerd/sandbox"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // Config for the v2 runtime

--- a/runtime/v2/process.go
+++ b/runtime/v2/process.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"errors"
 
+	"github.com/containerd/ttrpc"
+
 	"github.com/containerd/containerd/api/runtime/task/v2"
 	tasktypes "github.com/containerd/containerd/api/types/task"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/protobuf"
 	"github.com/containerd/containerd/runtime"
-	"github.com/containerd/ttrpc"
 )
 
 type process struct {

--- a/runtime/v2/runc/container.go
+++ b/runtime/v2/runc/container.go
@@ -30,6 +30,9 @@ import (
 	"github.com/containerd/cgroups"
 	cgroupsv2 "github.com/containerd/cgroups/v2"
 	"github.com/containerd/console"
+	"github.com/containerd/typeurl"
+	"github.com/sirupsen/logrus"
+
 	"github.com/containerd/containerd/api/runtime/task/v2"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/mount"
@@ -37,8 +40,6 @@ import (
 	"github.com/containerd/containerd/pkg/process"
 	"github.com/containerd/containerd/pkg/stdio"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
-	"github.com/containerd/typeurl"
-	"github.com/sirupsen/logrus"
 )
 
 // NewContainer returns a new runc container

--- a/runtime/v2/runc/manager/manager_linux.go
+++ b/runtime/v2/runc/manager/manager_linux.go
@@ -29,6 +29,11 @@ import (
 
 	"github.com/containerd/cgroups"
 	cgroupsv2 "github.com/containerd/cgroups/v2"
+	runcC "github.com/containerd/go-runc"
+	"github.com/containerd/typeurl"
+	exec "golang.org/x/sys/execabs"
+	"golang.org/x/sys/unix"
+
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/namespaces"
@@ -39,10 +44,6 @@ import (
 	"github.com/containerd/containerd/runtime/v2/runc"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/containerd/containerd/runtime/v2/shim"
-	runcC "github.com/containerd/go-runc"
-	"github.com/containerd/typeurl"
-	exec "golang.org/x/sys/execabs"
-	"golang.org/x/sys/unix"
 )
 
 // NewShimManager returns an implementation of the shim manager

--- a/runtime/v2/runc/pause/sandbox.go
+++ b/runtime/v2/runc/pause/sandbox.go
@@ -22,9 +22,10 @@ package pause
 import (
 	"context"
 
-	"github.com/containerd/containerd/pkg/shutdown"
 	"github.com/containerd/ttrpc"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/containerd/containerd/pkg/shutdown"
 
 	api "github.com/containerd/containerd/api/runtime/sandbox/v1"
 	"github.com/containerd/containerd/plugin"

--- a/runtime/v2/runc/platform.go
+++ b/runtime/v2/runc/platform.go
@@ -30,10 +30,11 @@ import (
 	"syscall"
 
 	"github.com/containerd/console"
+	"github.com/containerd/fifo"
+
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/pkg/process"
 	"github.com/containerd/containerd/pkg/stdio"
-	"github.com/containerd/fifo"
 )
 
 var bufPool = sync.Pool{

--- a/runtime/v2/runc/task/service.go
+++ b/runtime/v2/runc/task/service.go
@@ -27,6 +27,11 @@ import (
 
 	"github.com/containerd/cgroups"
 	cgroupsv2 "github.com/containerd/cgroups/v2"
+	runcC "github.com/containerd/go-runc"
+	"github.com/containerd/ttrpc"
+	"github.com/containerd/typeurl"
+	"github.com/sirupsen/logrus"
+
 	eventstypes "github.com/containerd/containerd/api/events"
 	taskAPI "github.com/containerd/containerd/api/runtime/task/v2"
 	"github.com/containerd/containerd/api/types/task"
@@ -45,10 +50,6 @@ import (
 	"github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/containerd/containerd/runtime/v2/shim"
 	"github.com/containerd/containerd/sys/reaper"
-	runcC "github.com/containerd/go-runc"
-	"github.com/containerd/ttrpc"
-	"github.com/containerd/typeurl"
-	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/runtime/v2/runc/util.go
+++ b/runtime/v2/runc/util.go
@@ -25,11 +25,12 @@ import (
 	"os"
 	"path/filepath"
 
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
+
 	"github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/runtime"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 )
 
 // GetTopic converts an event from an interface type to the specific

--- a/runtime/v2/runc/v1/service.go
+++ b/runtime/v2/runc/v1/service.go
@@ -31,6 +31,12 @@ import (
 	"time"
 
 	"github.com/containerd/cgroups"
+	runcC "github.com/containerd/go-runc"
+	"github.com/containerd/typeurl"
+	"github.com/sirupsen/logrus"
+	exec "golang.org/x/sys/execabs"
+	"golang.org/x/sys/unix"
+
 	eventstypes "github.com/containerd/containerd/api/events"
 	taskAPI "github.com/containerd/containerd/api/runtime/task/v2"
 	"github.com/containerd/containerd/api/types/task"
@@ -49,11 +55,6 @@ import (
 	"github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/containerd/containerd/runtime/v2/shim"
 	"github.com/containerd/containerd/sys/reaper"
-	runcC "github.com/containerd/go-runc"
-	"github.com/containerd/typeurl"
-	"github.com/sirupsen/logrus"
-	exec "golang.org/x/sys/execabs"
-	"golang.org/x/sys/unix"
 )
 
 var (

--- a/runtime/v2/shim.go
+++ b/runtime/v2/shim.go
@@ -25,6 +25,10 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/containerd/ttrpc"
+	"github.com/hashicorp/go-multierror"
+	"github.com/sirupsen/logrus"
+
 	eventstypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/api/runtime/task/v2"
 	"github.com/containerd/containerd/api/types"
@@ -38,9 +42,6 @@ import (
 	ptypes "github.com/containerd/containerd/protobuf/types"
 	"github.com/containerd/containerd/runtime"
 	client "github.com/containerd/containerd/runtime/v2/shim"
-	"github.com/containerd/ttrpc"
-	"github.com/hashicorp/go-multierror"
-	"github.com/sirupsen/logrus"
 )
 
 const (

--- a/runtime/v2/shim/publisher.go
+++ b/runtime/v2/shim/publisher.go
@@ -21,13 +21,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/containerd/ttrpc"
+	"github.com/sirupsen/logrus"
+
 	v1 "github.com/containerd/containerd/api/services/ttrpc/events/v1"
 	"github.com/containerd/containerd/events"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/pkg/ttrpcutil"
 	"github.com/containerd/containerd/protobuf"
-	"github.com/containerd/ttrpc"
-	"github.com/sirupsen/logrus"
 )
 
 const (

--- a/runtime/v2/shim/shim.go
+++ b/runtime/v2/shim/shim.go
@@ -29,6 +29,9 @@ import (
 	"runtime/debug"
 	"time"
 
+	"github.com/containerd/ttrpc"
+	"github.com/sirupsen/logrus"
+
 	shimapi "github.com/containerd/containerd/api/runtime/task/v2"
 	"github.com/containerd/containerd/events"
 	"github.com/containerd/containerd/log"
@@ -38,8 +41,6 @@ import (
 	"github.com/containerd/containerd/protobuf"
 	"github.com/containerd/containerd/protobuf/proto"
 	"github.com/containerd/containerd/version"
-	"github.com/containerd/ttrpc"
-	"github.com/sirupsen/logrus"
 )
 
 // Publisher for events

--- a/runtime/v2/shim/shim_linux.go
+++ b/runtime/v2/shim/shim_linux.go
@@ -17,8 +17,9 @@
 package shim
 
 import (
-	"github.com/containerd/containerd/sys/reaper"
 	"github.com/containerd/ttrpc"
+
+	"github.com/containerd/containerd/sys/reaper"
 )
 
 func newServer(opts ...ttrpc.ServerOpt) (*ttrpc.Server, error) {

--- a/runtime/v2/shim/shim_unix.go
+++ b/runtime/v2/shim/shim_unix.go
@@ -28,10 +28,11 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/containerd/containerd/sys/reaper"
 	"github.com/containerd/fifo"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
+
+	"github.com/containerd/containerd/sys/reaper"
 )
 
 // setupSignals creates a new signal handler for all signals and sets the shim as a

--- a/runtime/v2/shim/util.go
+++ b/runtime/v2/shim/util.go
@@ -27,11 +27,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/ttrpc"
+	exec "golang.org/x/sys/execabs"
+
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/protobuf/proto"
 	"github.com/containerd/containerd/protobuf/types"
-	"github.com/containerd/ttrpc"
-	exec "golang.org/x/sys/execabs"
 )
 
 type CommandConfig struct {

--- a/sandbox.go
+++ b/sandbox.go
@@ -22,12 +22,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/containerd/typeurl"
+
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/protobuf"
 	"github.com/containerd/containerd/protobuf/types"
 	api "github.com/containerd/containerd/sandbox"
-	"github.com/containerd/typeurl"
 )
 
 // Sandbox is a high level client to containerd's sandboxes.

--- a/sandbox/helpers.go
+++ b/sandbox/helpers.go
@@ -17,10 +17,11 @@
 package sandbox
 
 import (
+	"github.com/containerd/typeurl"
+
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/protobuf"
 	gogo_types "github.com/containerd/containerd/protobuf/types"
-	"github.com/containerd/typeurl"
 )
 
 // ToProto will map Sandbox struct to it's protobuf definition

--- a/sandbox/store.go
+++ b/sandbox/store.go
@@ -21,8 +21,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/typeurl"
+
+	"github.com/containerd/containerd/errdefs"
 )
 
 // Sandbox is an object stored in metadata database

--- a/services/containers/helpers.go
+++ b/services/containers/helpers.go
@@ -17,11 +17,12 @@
 package containers
 
 import (
+	"github.com/containerd/typeurl"
+
 	api "github.com/containerd/containerd/api/services/containers/v1"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/protobuf"
 	"github.com/containerd/containerd/protobuf/types"
-	"github.com/containerd/typeurl"
 )
 
 func containersToProto(containers []containers.Container) []*api.Container {

--- a/services/containers/local.go
+++ b/services/containers/local.go
@@ -20,6 +20,12 @@ import (
 	"context"
 	"io"
 
+	bolt "go.etcd.io/bbolt"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	grpcm "google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
 	eventstypes "github.com/containerd/containerd/api/events"
 	api "github.com/containerd/containerd/api/services/containers/v1"
 	"github.com/containerd/containerd/containers"
@@ -29,11 +35,6 @@ import (
 	"github.com/containerd/containerd/plugin"
 	ptypes "github.com/containerd/containerd/protobuf/types"
 	"github.com/containerd/containerd/services"
-	bolt "go.etcd.io/bbolt"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	grpcm "google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/status"
 )
 
 func init() {

--- a/services/containers/service.go
+++ b/services/containers/service.go
@@ -21,11 +21,12 @@ import (
 	"errors"
 	"io"
 
+	"google.golang.org/grpc"
+
 	api "github.com/containerd/containerd/api/services/containers/v1"
 	"github.com/containerd/containerd/plugin"
 	ptypes "github.com/containerd/containerd/protobuf/types"
 	"github.com/containerd/containerd/services"
-	"google.golang.org/grpc"
 )
 
 func init() {

--- a/services/content/contentserver/contentserver.go
+++ b/services/content/contentserver/contentserver.go
@@ -22,18 +22,19 @@ import (
 	"io"
 	"sync"
 
-	api "github.com/containerd/containerd/api/services/content/v1"
-	"github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/log"
-	"github.com/containerd/containerd/protobuf"
-	ptypes "github.com/containerd/containerd/protobuf/types"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	api "github.com/containerd/containerd/api/services/content/v1"
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/protobuf"
+	ptypes "github.com/containerd/containerd/protobuf/types"
 )
 
 type service struct {

--- a/services/content/store.go
+++ b/services/content/store.go
@@ -19,13 +19,14 @@ package content
 import (
 	"context"
 
+	digest "github.com/opencontainers/go-digest"
+
 	eventstypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/events"
 	"github.com/containerd/containerd/metadata"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/services"
-	digest "github.com/opencontainers/go-digest"
 )
 
 // store wraps content.Store with proper event published.

--- a/services/diff/local.go
+++ b/services/diff/local.go
@@ -20,6 +20,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/containerd/typeurl"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"google.golang.org/grpc"
+
 	diffapi "github.com/containerd/containerd/api/services/diff/v1"
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/diff"
@@ -27,10 +32,6 @@ import (
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/services"
-	"github.com/containerd/typeurl"
-	"github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"google.golang.org/grpc"
 )
 
 type config struct {

--- a/services/diff/service.go
+++ b/services/diff/service.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"errors"
 
+	"google.golang.org/grpc"
+
 	diffapi "github.com/containerd/containerd/api/services/diff/v1"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/services"
-	"google.golang.org/grpc"
 )
 
 func init() {

--- a/services/events/service.go
+++ b/services/events/service.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/containerd/ttrpc"
+	"google.golang.org/grpc"
+
 	api "github.com/containerd/containerd/api/services/events/v1"
 	apittrpc "github.com/containerd/containerd/api/services/ttrpc/events/v1"
 	"github.com/containerd/containerd/errdefs"
@@ -28,8 +31,6 @@ import (
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/protobuf"
 	ptypes "github.com/containerd/containerd/protobuf/types"
-	"github.com/containerd/ttrpc"
-	"google.golang.org/grpc"
 )
 
 func init() {

--- a/services/images/helpers.go
+++ b/services/images/helpers.go
@@ -17,12 +17,13 @@
 package images
 
 import (
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	imagesapi "github.com/containerd/containerd/api/services/images/v1"
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/protobuf"
-	"github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func imagesToProto(images []images.Image) []*imagesapi.Image {

--- a/services/images/local.go
+++ b/services/images/local.go
@@ -19,6 +19,10 @@ package images
 import (
 	"context"
 
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	eventstypes "github.com/containerd/containerd/api/events"
 	imagesapi "github.com/containerd/containerd/api/services/images/v1"
 	"github.com/containerd/containerd/errdefs"
@@ -30,9 +34,6 @@ import (
 	"github.com/containerd/containerd/plugin"
 	ptypes "github.com/containerd/containerd/protobuf/types"
 	"github.com/containerd/containerd/services"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 func init() {

--- a/services/images/service.go
+++ b/services/images/service.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"errors"
 
+	"google.golang.org/grpc"
+
 	imagesapi "github.com/containerd/containerd/api/services/images/v1"
 	"github.com/containerd/containerd/plugin"
 	ptypes "github.com/containerd/containerd/protobuf/types"
 	"github.com/containerd/containerd/services"
-	"google.golang.org/grpc"
 )
 
 func init() {

--- a/services/introspection/local.go
+++ b/services/introspection/local.go
@@ -22,6 +22,12 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/google/uuid"
+	"google.golang.org/genproto/googleapis/rpc/code"
+	rpc "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
+
 	api "github.com/containerd/containerd/api/services/introspection/v1"
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/errdefs"
@@ -29,11 +35,6 @@ import (
 	"github.com/containerd/containerd/plugin"
 	ptypes "github.com/containerd/containerd/protobuf/types"
 	"github.com/containerd/containerd/services"
-	"github.com/google/uuid"
-	"google.golang.org/genproto/googleapis/rpc/code"
-	rpc "google.golang.org/genproto/googleapis/rpc/status"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/status"
 )
 
 func init() {

--- a/services/introspection/service.go
+++ b/services/introspection/service.go
@@ -20,11 +20,12 @@ import (
 	context "context"
 	"errors"
 
+	"google.golang.org/grpc"
+
 	api "github.com/containerd/containerd/api/services/introspection/v1"
 	"github.com/containerd/containerd/plugin"
 	ptypes "github.com/containerd/containerd/protobuf/types"
 	"github.com/containerd/containerd/services"
-	"google.golang.org/grpc"
 )
 
 func init() {

--- a/services/leases/service.go
+++ b/services/leases/service.go
@@ -19,13 +19,14 @@ package leases
 import (
 	"context"
 
+	"google.golang.org/grpc"
+
 	api "github.com/containerd/containerd/api/services/leases/v1"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/protobuf"
 	ptypes "github.com/containerd/containerd/protobuf/types"
-	"google.golang.org/grpc"
 )
 
 func init() {

--- a/services/namespaces/local.go
+++ b/services/namespaces/local.go
@@ -20,6 +20,11 @@ import (
 	"context"
 	"strings"
 
+	bolt "go.etcd.io/bbolt"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	eventstypes "github.com/containerd/containerd/api/events"
 	api "github.com/containerd/containerd/api/services/namespaces/v1"
 	"github.com/containerd/containerd/errdefs"
@@ -29,10 +34,6 @@ import (
 	"github.com/containerd/containerd/plugin"
 	ptypes "github.com/containerd/containerd/protobuf/types"
 	"github.com/containerd/containerd/services"
-	bolt "go.etcd.io/bbolt"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 func init() {

--- a/services/namespaces/service.go
+++ b/services/namespaces/service.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"errors"
 
+	"google.golang.org/grpc"
+
 	api "github.com/containerd/containerd/api/services/namespaces/v1"
 	"github.com/containerd/containerd/plugin"
 	ptypes "github.com/containerd/containerd/protobuf/types"
 	"github.com/containerd/containerd/services"
-	"google.golang.org/grpc"
 )
 
 func init() {

--- a/services/sandbox/controller_local.go
+++ b/services/sandbox/controller_local.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"google.golang.org/grpc"
+
 	runtimeAPI "github.com/containerd/containerd/api/runtime/sandbox/v1"
 	api "github.com/containerd/containerd/api/services/sandbox/v1"
 	"github.com/containerd/containerd/errdefs"
@@ -31,7 +33,6 @@ import (
 	v2 "github.com/containerd/containerd/runtime/v2"
 	"github.com/containerd/containerd/sandbox"
 	"github.com/containerd/containerd/services"
-	"google.golang.org/grpc"
 )
 
 func init() {

--- a/services/sandbox/controller_service.go
+++ b/services/sandbox/controller_service.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"errors"
 
+	"google.golang.org/grpc"
+
 	api "github.com/containerd/containerd/api/services/sandbox/v1"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/services"
-	"google.golang.org/grpc"
 )
 
 func init() {

--- a/services/sandbox/store_local.go
+++ b/services/sandbox/store_local.go
@@ -19,8 +19,9 @@ package sandbox
 import (
 	"context"
 
-	"github.com/containerd/containerd/services"
 	"google.golang.org/grpc"
+
+	"github.com/containerd/containerd/services"
 
 	api "github.com/containerd/containerd/api/services/sandbox/v1"
 	"github.com/containerd/containerd/api/types"

--- a/services/server/namespace.go
+++ b/services/server/namespace.go
@@ -19,8 +19,9 @@ package server
 import (
 	"context"
 
-	"github.com/containerd/containerd/namespaces"
 	"google.golang.org/grpc"
+
+	"github.com/containerd/containerd/namespaces"
 )
 
 func unaryNamespaceInterceptor(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {

--- a/services/server/server.go
+++ b/services/server/server.go
@@ -33,6 +33,16 @@ import (
 	"sync"
 	"time"
 
+	"github.com/containerd/ttrpc"
+	"github.com/docker/go-metrics"
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+
 	csapi "github.com/containerd/containerd/api/services/content/v1"
 	ssapi "github.com/containerd/containerd/api/services/snapshots/v1"
 	"github.com/containerd/containerd/content/local"
@@ -47,15 +57,6 @@ import (
 	srvconfig "github.com/containerd/containerd/services/server/config"
 	ssproxy "github.com/containerd/containerd/snapshots/proxy"
 	"github.com/containerd/containerd/sys"
-	"github.com/containerd/ttrpc"
-	"github.com/docker/go-metrics"
-	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
-	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/backoff"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 // CreateTopLevelDirectories creates the top-level root and state directories.

--- a/services/server/server_linux.go
+++ b/services/server/server_linux.go
@@ -22,11 +22,12 @@ import (
 
 	"github.com/containerd/cgroups"
 	cgroupsv2 "github.com/containerd/cgroups/v2"
+	"github.com/containerd/ttrpc"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/containerd/containerd/log"
 	srvconfig "github.com/containerd/containerd/services/server/config"
 	"github.com/containerd/containerd/sys"
-	"github.com/containerd/ttrpc"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // apply sets config settings on the server process

--- a/services/server/server_test.go
+++ b/services/server/server_test.go
@@ -19,8 +19,9 @@ package server
 import (
 	"testing"
 
-	srvconfig "github.com/containerd/containerd/services/server/config"
 	"github.com/stretchr/testify/assert"
+
+	srvconfig "github.com/containerd/containerd/services/server/config"
 )
 
 const testPath = "/tmp/path/for/testing"

--- a/services/server/server_unsupported.go
+++ b/services/server/server_unsupported.go
@@ -22,8 +22,9 @@ package server
 import (
 	"context"
 
-	srvconfig "github.com/containerd/containerd/services/server/config"
 	"github.com/containerd/ttrpc"
+
+	srvconfig "github.com/containerd/containerd/services/server/config"
 )
 
 func apply(_ context.Context, _ *srvconfig.Config) error {

--- a/services/server/server_windows.go
+++ b/services/server/server_windows.go
@@ -19,8 +19,9 @@ package server
 import (
 	"context"
 
-	srvconfig "github.com/containerd/containerd/services/server/config"
 	"github.com/containerd/ttrpc"
+
+	srvconfig "github.com/containerd/containerd/services/server/config"
 )
 
 func apply(_ context.Context, _ *srvconfig.Config) error {

--- a/services/snapshots/service.go
+++ b/services/snapshots/service.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 
+	"google.golang.org/grpc"
+
 	snapshotsapi "github.com/containerd/containerd/api/services/snapshots/v1"
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/errdefs"
@@ -30,7 +32,6 @@ import (
 	ptypes "github.com/containerd/containerd/protobuf/types"
 	"github.com/containerd/containerd/services"
 	"github.com/containerd/containerd/snapshots"
-	"google.golang.org/grpc"
 )
 
 func init() {

--- a/services/tasks/local.go
+++ b/services/tasks/local.go
@@ -26,6 +26,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/typeurl"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	api "github.com/containerd/containerd/api/services/tasks/v1"
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/api/types/task"
@@ -48,12 +55,6 @@ import (
 	"github.com/containerd/containerd/runtime/linux/runctypes"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/containerd/containerd/services"
-	"github.com/containerd/typeurl"
-	"github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 var (

--- a/services/tasks/service.go
+++ b/services/tasks/service.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"errors"
 
+	"google.golang.org/grpc"
+
 	api "github.com/containerd/containerd/api/services/tasks/v1"
 	"github.com/containerd/containerd/plugin"
 	ptypes "github.com/containerd/containerd/protobuf/types"
 	"github.com/containerd/containerd/services"
-	"google.golang.org/grpc"
 )
 
 var (

--- a/services/version/service.go
+++ b/services/version/service.go
@@ -19,11 +19,12 @@ package version
 import (
 	"context"
 
+	"google.golang.org/grpc"
+
 	api "github.com/containerd/containerd/api/services/version/v1"
 	"github.com/containerd/containerd/plugin"
 	ptypes "github.com/containerd/containerd/protobuf/types"
 	ctrdversion "github.com/containerd/containerd/version"
-	"google.golang.org/grpc"
 )
 
 var _ api.VersionServer = &service{}

--- a/signals.go
+++ b/signals.go
@@ -22,10 +22,11 @@ import (
 	"fmt"
 	"syscall"
 
-	"github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/images"
 	"github.com/moby/sys/signal"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/images"
 )
 
 // StopSignalLabel is a well-known containerd label for storing the stop

--- a/snapshots/btrfs/btrfs_test.go
+++ b/snapshots/btrfs/btrfs_test.go
@@ -30,14 +30,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/continuity/testutil/loopback"
+	exec "golang.org/x/sys/execabs"
+	"golang.org/x/sys/unix"
+
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/pkg/testutil"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/containerd/snapshots/testsuite"
-	"github.com/containerd/continuity/testutil/loopback"
-	exec "golang.org/x/sys/execabs"
-	"golang.org/x/sys/unix"
 )
 
 func boltSnapshotter(t *testing.T) func(context.Context, string) (snapshots.Snapshotter, func() error, error) {

--- a/snapshots/devmapper/dmsetup/dmsetup.go
+++ b/snapshots/devmapper/dmsetup/dmsetup.go
@@ -29,9 +29,10 @@ import (
 	"strconv"
 	"strings"
 
-	blkdiscard "github.com/containerd/containerd/snapshots/devmapper/blkdiscard"
 	exec "golang.org/x/sys/execabs"
 	"golang.org/x/sys/unix"
+
+	blkdiscard "github.com/containerd/containerd/snapshots/devmapper/blkdiscard"
 )
 
 const (

--- a/snapshots/devmapper/dmsetup/dmsetup_test.go
+++ b/snapshots/devmapper/dmsetup/dmsetup_test.go
@@ -24,11 +24,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/containerd/containerd/mount"
-	"github.com/containerd/containerd/pkg/testutil"
 	"github.com/docker/go-units"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/unix"
+
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/pkg/testutil"
 )
 
 const (

--- a/snapshots/devmapper/pool_device_test.go
+++ b/snapshots/devmapper/pool_device_test.go
@@ -27,13 +27,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/containerd/mount"
-	"github.com/containerd/containerd/pkg/testutil"
-	"github.com/containerd/containerd/snapshots/devmapper/dmsetup"
 	"github.com/docker/go-units"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	exec "golang.org/x/sys/execabs"
+
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/pkg/testutil"
+	"github.com/containerd/containerd/snapshots/devmapper/dmsetup"
 )
 
 const (

--- a/snapshots/devmapper/snapshotter.go
+++ b/snapshots/devmapper/snapshotter.go
@@ -28,15 +28,16 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/hashicorp/go-multierror"
+	"github.com/sirupsen/logrus"
+	exec "golang.org/x/sys/execabs"
+
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/containerd/snapshots/devmapper/dmsetup"
 	"github.com/containerd/containerd/snapshots/storage"
-	"github.com/hashicorp/go-multierror"
-	"github.com/sirupsen/logrus"
-	exec "golang.org/x/sys/execabs"
 )
 
 type fsType string

--- a/snapshots/lcow/lcow.go
+++ b/snapshots/lcow/lcow.go
@@ -34,14 +34,15 @@ import (
 
 	winfs "github.com/Microsoft/go-winio/pkg/fs"
 	"github.com/Microsoft/hcsshim/pkg/go-runhcs"
+	"github.com/containerd/continuity/fs"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/containerd/snapshots/storage"
-	"github.com/containerd/continuity/fs"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func init() {

--- a/snapshots/overlay/overlay.go
+++ b/snapshots/overlay/overlay.go
@@ -27,13 +27,14 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/containerd/continuity/fs"
+	"github.com/sirupsen/logrus"
+
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/containerd/snapshots/overlay/overlayutils"
 	"github.com/containerd/containerd/snapshots/storage"
-	"github.com/containerd/continuity/fs"
-	"github.com/sirupsen/logrus"
 )
 
 // upperdirKey is a key of an optional label to each snapshot.

--- a/snapshots/overlay/overlayutils/check.go
+++ b/snapshots/overlay/overlayutils/check.go
@@ -24,10 +24,11 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/containerd/continuity/fs"
+
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/pkg/userns"
-	"github.com/containerd/continuity/fs"
 )
 
 // SupportsMultipleLowerDir checks if the system supports multiple lowerdirs,

--- a/snapshots/overlay/overlayutils/check_test.go
+++ b/snapshots/overlay/overlayutils/check_test.go
@@ -22,9 +22,10 @@ package overlayutils
 import (
 	"testing"
 
-	"github.com/containerd/containerd/pkg/testutil"
 	"github.com/containerd/continuity/testutil/loopback"
 	exec "golang.org/x/sys/execabs"
+
+	"github.com/containerd/containerd/pkg/testutil"
 )
 
 func testOverlaySupported(t testing.TB, expected bool, mkfs ...string) {

--- a/snapshots/storage/bolt.go
+++ b/snapshots/storage/bolt.go
@@ -24,11 +24,12 @@ import (
 	"strings"
 	"time"
 
+	bolt "go.etcd.io/bbolt"
+
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/filters"
 	"github.com/containerd/containerd/metadata/boltutil"
 	"github.com/containerd/containerd/snapshots"
-	bolt "go.etcd.io/bbolt"
 )
 
 var (

--- a/snapshots/storage/metastore.go
+++ b/snapshots/storage/metastore.go
@@ -26,8 +26,9 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/containerd/containerd/snapshots"
 	bolt "go.etcd.io/bbolt"
+
+	"github.com/containerd/containerd/snapshots"
 )
 
 // Transactor is used to finalize an active transaction.

--- a/snapshots/storage/metastore_test.go
+++ b/snapshots/storage/metastore_test.go
@@ -23,10 +23,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/snapshots"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/snapshots"
 )
 
 type testFunc func(context.Context, *testing.T, *MetaStore)

--- a/snapshots/testsuite/helpers.go
+++ b/snapshots/testsuite/helpers.go
@@ -22,9 +22,10 @@ import (
 	"math/rand"
 	"os"
 
+	"github.com/containerd/continuity/fs/fstest"
+
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/snapshots"
-	"github.com/containerd/continuity/fs/fstest"
 )
 
 func applyToMounts(m []mount.Mount, work string, a fstest.Applier) (err error) {

--- a/snapshots/testsuite/issues.go
+++ b/snapshots/testsuite/issues.go
@@ -23,8 +23,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/continuity/fs/fstest"
+
+	"github.com/containerd/containerd/snapshots"
 )
 
 // Checks which cover former issues found in older layering models.

--- a/snapshots/testsuite/testsuite.go
+++ b/snapshots/testsuite/testsuite.go
@@ -28,14 +28,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/continuity/fs/fstest"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log/logtest"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/pkg/testutil"
 	"github.com/containerd/containerd/snapshots"
-	"github.com/containerd/continuity/fs/fstest"
-	"github.com/stretchr/testify/assert"
 )
 
 // SnapshotterFunc is used in SnapshotterSuite

--- a/snapshots/windows/windows.go
+++ b/snapshots/windows/windows.go
@@ -34,6 +34,9 @@ import (
 	winfs "github.com/Microsoft/go-winio/pkg/fs"
 	"github.com/Microsoft/hcsshim"
 	"github.com/Microsoft/hcsshim/pkg/ociwclayer"
+	"github.com/containerd/continuity/fs"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
@@ -41,8 +44,6 @@ import (
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/containerd/snapshots/storage"
-	"github.com/containerd/continuity/fs"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func init() {

--- a/sys/oom_linux.go
+++ b/sys/oom_linux.go
@@ -22,8 +22,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/containerd/containerd/pkg/userns"
 	"golang.org/x/sys/unix"
+
+	"github.com/containerd/containerd/pkg/userns"
 )
 
 const (

--- a/sys/oom_linux_test.go
+++ b/sys/oom_linux_test.go
@@ -23,10 +23,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/containerd/pkg/userns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	exec "golang.org/x/sys/execabs"
+
+	"github.com/containerd/containerd/pkg/userns"
 )
 
 func TestSetPositiveOomScoreAdjustment(t *testing.T) {

--- a/task.go
+++ b/task.go
@@ -28,6 +28,12 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/containerd/typeurl"
+	digest "github.com/opencontainers/go-digest"
+	is "github.com/opencontainers/image-spec/specs-go"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/containerd/containerd/api/services/tasks/v1"
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/cio"
@@ -43,11 +49,6 @@ import (
 	"github.com/containerd/containerd/rootfs"
 	"github.com/containerd/containerd/runtime/linux/runctypes"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
-	"github.com/containerd/typeurl"
-	digest "github.com/opencontainers/go-digest"
-	is "github.com/opencontainers/image-spec/specs-go"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // UnknownExitStatus is returned when containerd is unable to

--- a/task_opts.go
+++ b/task_opts.go
@@ -23,6 +23,9 @@ import (
 	"fmt"
 	"syscall"
 
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
@@ -30,8 +33,6 @@ import (
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/runtime/linux/runctypes"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // NewTaskOpts allows the caller to set options on a new task

--- a/tracing/plugin/otlp.go
+++ b/tracing/plugin/otlp.go
@@ -23,9 +23,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/containerd/containerd/log"
-	"github.com/containerd/containerd/plugin"
-	"github.com/containerd/containerd/tracing"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
@@ -36,6 +33,10 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/plugin"
+	"github.com/containerd/containerd/tracing"
 )
 
 const exporterPlugin = "otlp"


### PR DESCRIPTION
The -local flag allows us to separate imports that originate from github.com/containerd/containerd from other imports, making it more clear where various imports come from.

Files can be formatted using the following command:

```
goimports -w -local github.com/containerd/containerd
```

To reformat all Go source files (excluding vendor and .pb.go):

```
goimports -w -local github.com/containerd/containerd \
  $(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "*.pb.go")
```