### PR TITLE
Don't unmount on Darwin when deleting bundle

### DIFF
--- a/runtime/v2/bundle.go
+++ b/runtime/v2/bundle.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/containerd/containerd/identifiers"
 	"github.com/containerd/containerd/mount"
@@ -128,8 +129,10 @@ type Bundle struct {
 func (b *Bundle) Delete() error {
 	work, werr := os.Readlink(filepath.Join(b.Path, "work"))
 	rootfs := filepath.Join(b.Path, "rootfs")
-	if err := mount.UnmountAll(rootfs, 0); err != nil {
-		return fmt.Errorf("unmount rootfs %s: %w", rootfs, err)
+	if runtime.GOOS != "darwin" {
+		if err := mount.UnmountAll(rootfs, 0); err != nil {
+			return fmt.Errorf("unmount rootfs %s: %w", rootfs, err)
+		}
 	}
 	if err := os.Remove(rootfs); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to remove bundle rootfs: %w", err)


### PR DESCRIPTION
When calling `Bundle.Delete` on Darwin, it attempts to unmount rootfs, which is not supported. This PR skips unmount for this platform, just deleting the directory would be sufficient.

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>