### PR TITLE
Retry client connection in  waitForStart

### DIFF
--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -1006,7 +1006,7 @@ func TestDaemonRestartWithRunningShim(t *testing.T) {
 		t.Errorf(`first task.Wait() should have failed with "transport is closing"`)
 	}
 
-	waitCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	waitCtx, cancel := context.WithTimeout(ctx, 4*time.Second)
 	c, err := ctrd.waitForStart(waitCtx)
 	cancel()
 	if err != nil {


### PR DESCRIPTION
Issue: #7422
* Increased context timeout to 4 sec
* Retry client connection errors until context deadline in `waitForStart`


Signed-off-by: Swagat Bora <sbora@amazon.com>