### PR TITLE
Add timeouts to all CI jobs

### DIFF
--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -32,6 +32,8 @@ jobs:
   images:
     name: "Build volume test images"
     runs-on: ubuntu-latest
+    timeout-minutes: 60
+
     defaults:
       run:
         working-directory: src/github.com/containerd/containerd

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,8 @@ jobs:
     # CodeQL runs on ubuntu-latest, windows-latest, and macos-latest
     runs-on: ubuntu-latest
 
+    timeout-minutes: 30
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -6,6 +6,7 @@ jobs:
   ci_fuzz:
     name: CI Fuzz
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - name: Build Fuzzers
       id: build
@@ -32,6 +33,7 @@ jobs:
   go_test_fuzz:
     name : go test -fuzz
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/setup-go@v3
         with:

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -9,11 +9,12 @@ on:
       image:
         description: "Target image name (override)"
 
-
 jobs:
   mirror:
     name: "Mirror Image"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+
     permissions:
       packages: write
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,6 +13,7 @@ jobs:
   linux:
     name: Linux
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     defaults:
       run:
@@ -150,6 +151,7 @@ jobs:
   windows:
     name: Windows
     runs-on: windows-latest
+    timeout-minutes: 30
 
     defaults:
       run:

--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -51,6 +51,7 @@ jobs:
           AZURE_RESOURCE_GROUP: ctrd-integration-ltsc2022-${{ github.run_id }}
           GOOGLE_BUCKET: "containerd-integration/logs/windows-ltsc2022/"
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
I've opened a PR recently and fuzz CI job ran for 5 hours until I noticed and cancelled it (https://github.com/containerd/containerd/actions/runs/3253110550/jobs/5340055841).
I think it'd be sane idea to have timeouts on all CI jobs.
This PR adds `timeout-minutes` (based on recent run times) to avoid wasting node resources.

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>