### PR TITLE
containerd should not print error log that failed to init a tracing processor while the tracing plugin is not loaded

### DIFF
--- a/tracing/plugin/otlp.go
+++ b/tracing/plugin/otlp.go
@@ -160,7 +160,11 @@ func newTracer(ic *plugin.InitContext) (io.Closer, error) {
 	for id, pctx := range ls {
 		p, err := pctx.Instance()
 		if err != nil {
-			log.G(ctx).WithError(err).Errorf("failed to initialize a tracing processor %q", id)
+			if plugin.IsSkipPlugin(err) {
+				log.G(ctx).WithError(err).Infof("skipping tracing processor initialization (no tracing plugin)")
+			} else {
+				log.G(ctx).WithError(err).Errorf("failed to initialize a tracing processor %q", id)
+			}
 			continue
 		}
 		proc := p.(sdktrace.SpanProcessor)


### PR DESCRIPTION
Fix: https://github.com/containerd/containerd/issues/7540

containerd should not try to init a tracing processor when the tracing plugin itself is not loaded

Signed-off-by: Joseph Sheng <jiajun.sheng@microfocus.com>