### PR TITLE
Use `go env` to determine GOPATH in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ ifdef SKIPTESTS
 endif
 
 #Replaces ":" (*nix), ";" (windows) with newline for easy parsing
-GOPATHS=$(shell echo ${GOPATH} | tr ":" "\n" | tr ";" "\n")
+GOPATHS=$(shell go env GOPATH | tr ":" "\n" | tr ";" "\n")
 
 TESTFLAGS_RACE=
 GO_BUILD_FLAGS=


### PR DESCRIPTION
Signed-off-by: Nashwan Azhari <nazhari@cloudbasesolutions.com>