### PR TITLE
Update required Go version in BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -14,7 +14,7 @@ This doc includes:
 
 To build the `containerd` daemon, and the `ctr` simple test client, the following build system dependencies are required:
 
-* Go 1.17.x or above
+* Go 1.18.x or above
 * Protoc 3.x compiler and headers (download at the [Google protobuf releases page](https://github.com/protocolbuffers/protobuf/releases))
 * Btrfs headers and libraries for your distribution. Note that building the btrfs driver can be disabled via the build tag `no_btrfs`, removing this dependency.
 


### PR DESCRIPTION
Our main branch no longer builds successfully with Go 1.17.

Signed-off-by: Phil Estes <estesp@amazon.com>