### PR TITLE
Add logging related metrics to Containerd CRI plugin

### DIFF
--- a/pkg/cri/io/metrics.go
+++ b/pkg/cri/io/metrics.go
@@ -1,0 +1,42 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package io
+
+import "github.com/docker/go-metrics"
+
+var (
+	inputEntries  metrics.Counter
+	outputEntries metrics.Counter
+	inputBytes    metrics.Counter
+	outputBytes   metrics.Counter
+	splitEntries  metrics.Counter
+)
+
+func init() {
+	// These CRI metrics record input and output logging volume.
+	ns := metrics.NewNamespace("containerd", "cri", nil)
+
+	inputEntries = ns.NewCounter("input_entries", "Number of log entries received")
+	outputEntries = ns.NewCounter("output_entries", "Number of log entries successfully written to disk")
+	inputBytes = ns.NewCounter("input_bytes", "Size of logs received")
+	outputBytes = ns.NewCounter("output_bytes", "Size of logs successfully written to disk")
+	splitEntries = ns.NewCounter("split_entries", "Number of extra log entries created by splitting the "+
+		"original log entry. This happens when the original log entry exceeds length limit. "+
+		"This metric does not count the original log entry.")
+
+	metrics.Register(ns)
+}


### PR DESCRIPTION
This PR adds logging related metrics in the Containerd CRI plugin. Metrics are per Containerd instance. Metrics can be used to estimate logging completeness of Containerd and logging completeness of logging pipeline (when combined with logging agent metrics). See design details below.

# Context

```mermaid
graph LR
A[Customer Workload] -- Output --> B((stdout/stderr))
B -- Retrive --> C[Containerd]
C -- Output --> D((disk))
D -- Retrive --> E[Logging Agent]
E -- Output --> F[Sink]
G[Log Rotator] -- Rotate --> D
```
The graph above shows a common architecture of a logging pipeline. Customer workloads output their logs to stdout/stderr. [Containerd](https://containerd.io/) reads those logs and outputs them to log files on disk. Logging agents read log files from disk and exports logs to various sinks (e.g., stdout, [Cloud Logging](https://cloud.google.com/logging)). In the meantime, [log rotator](https://g3doc.corp.google.com/cloud/kubernetes/g3doc/subgroup/logging/log-rotation.md?cl=head) rotates files on disk to prevent logs from overflowing disks.

In the logging pipeline above, logs could be missed or duplicated in any stages of the pipeline. For example, Containerd might fail to read a log or output the log to disk, which could cause potential log loss. Another example we encountered in the past is that logging agents could duplicate logs unexpectedly during a node restart

# Motivation

Adding logging related instrumentation in Containerd helps us achieve following two goals:

*   Estimate logging completeness of Containerd
*   Estimate logging completeness on disk before logs are registered by the logging agent

Currently we have zero visibility into these two areas. See the section below for details about how we use the proposed Containerd metrics to achieve the goals above.

# Detailed Design

## Logging Related Metrics

We will calculate the following metrics in the Containerd [CRI plugin](https://github.com/containerd/containerd/tree/main/pkg/cri). Metrics are per Containerd instance.

1. **containerd_cri_input_entries_total**: Number of log entries Containerd receives
    
2.  **containerd_cri_input_bytes_total**: Size of logs Containerd receives
    
3.  **containerd_cri_output_entries_total**: Number of log entries Containerd successfully writes to disks
    
4.  **containerd_cri_output_bytes_total**: Size of logs Containerd successfully writes to disks
5.  **containerd_cri_split_entries_total**: Number of extra log entries created by splitting the original log entry. This happens when the original log entry exceeds the length limit. This metric does not count the original log entry.

## Usage of metrics

This section discusses some use cases of logging metrics. The number corresponds to the metrics number listed above.

### Estimate logging completeness of Containerd

This can be achieved by comparing input_entries [1], output_entries [3] and split_entries [5]. In the case of no log processing errors, input_entries + split_entries = output_entries.

input_bytes [2] and output_bytes [4] can also be used for the estimation. However, it won’t be accurate because the Containerd CRI plugin adds additional metadata to log entries.

### Estimate logging completeness on disk

This estimates logging loss/duplication after logs leave Containerd but before they are registered by logging agents. The estimation can be achieved by comparing Containerd output logging metrics ([3] and [4]) with logging agent input metrics.

### Estimate logging volume on the node
This can be achieved via output_bytes_total [4].

### Estimate logging completeness of the entire pipeline
This can be achieved by comparing Containerd input logging metrics with logging agent output metrics.

## Example metrics

Following metrics are collected by deploying a custom binary of Containerd to a GKE node.

```
$ curl http://127.0.0.1:1338/v1/metrics | egrep "input_entries"
# HELP containerd_cri_input_entries_total Number of log entries received
# TYPE containerd_cri_input_entries_total counter
containerd_cri_input_entries_total 26
 
$ curl http://127.0.0.1:1338/v1/metrics | egrep "output_entries"
# HELP containerd_cri_output_entries_total Number of log entries successfully written to disks
# TYPE containerd_cri_output_entries_total counter
containerd_cri_output_entries_total 26
 
$ curl http://127.0.0.1:1338/v1/metrics | egrep "input_bytes"
# HELP containerd_cri_input_bytes_total Size of logs received
# TYPE containerd_cri_input_bytes_total counter
containerd_cri_input_bytes_total 2933
 
$ curl http://127.0.0.1:1338/v1/metrics | egrep "output_bytes"
# HELP containerd_cri_output_bytes_total Size of logs successfully written to disks
# TYPE containerd_cri_output_bytes_total counter
containerd_cri_output_bytes_total 4141
 
 
$ curl http://127.0.0.1:1338/v1/metrics | egrep "split_entries"
# HELP containerd_cri_split_entries_total Number of extra log entries created by splitting the original log entry. This happens when the original log entry exceeds length limit. This metric does not count the original log entry.
# TYPE containerd_cri_split_entries_total counter
containerd_cri_split_entries_total 0
```