### PR TITLE
migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -23,9 +23,9 @@ env:
   DEFAULT_ADMIN_USERNAME: azureuser
   SSH_OPTS: "-o ServerAliveInterval=20 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
   REMOTE_VM_BIN_PATH: "c:\\containerd\\bin"
-  BUSYBOX_TESTING_IMAGE_REF: "k8s.gcr.io/e2e-test-images/busybox:1.29-2"
-  RESOURCE_CONSUMER_TESTING_IMAGE_REF: "k8s.gcr.io/e2e-test-images/resource-consumer:1.10"
-  WEBSERVER_TESTING_IMAGE_REF: "k8s.gcr.io/e2e-test-images/nginx:1.14-2"
+  BUSYBOX_TESTING_IMAGE_REF: "registry.k8s.io/e2e-test-images/busybox:1.29-2"
+  RESOURCE_CONSUMER_TESTING_IMAGE_REF: "registry.k8s.io/e2e-test-images/resource-consumer:1.10"
+  WEBSERVER_TESTING_IMAGE_REF: "registry.k8s.io/e2e-test-images/nginx:1.14-2"
 
 
 jobs:

--- a/contrib/ansible/cri-containerd.yaml
+++ b/contrib/ansible/cri-containerd.yaml
@@ -61,6 +61,6 @@
     # TODO This needs to be removed once we have consistent concurrent pull results
     - name: "Pre-pull pause container image"
       shell: |
-        /usr/local/bin/ctr pull k8s.gcr.io/pause:3.6
+        /usr/local/bin/ctr pull registry.k8s.io/pause:3.6
         /usr/local/bin/crictl --runtime-endpoint unix:///run/containerd/containerd.sock \
-        pull k8s.gcr.io/pause:3.6
+        pull registry.k8s.io/pause:3.6

--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -40,7 +40,7 @@ version = 2
   selinux_category_range = 1024
 
   # sandbox_image is the image used by sandbox container.
-  sandbox_image = "k8s.gcr.io/pause:3.6"
+  sandbox_image = "registry.k8s.io/pause:3.6"
 
   # stats_collect_period is the period (in seconds) of snapshots stats collection.
   stats_collect_period = 10

--- a/docs/cri/crictl.md
+++ b/docs/cri/crictl.md
@@ -59,29 +59,29 @@ command. With the load command you inject a container image into the container
 runtime from a file. First you need to create a container image tarball. For
 example to create an image tarball for a pause container using Docker:
 ```console
-$ docker pull k8s.gcr.io/pause:3.6
+$ docker pull registry.k8s.io/pause:3.6
   3.6: Pulling from pause
   fbe1a72f5dcd: Pull complete
   Digest: sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db
-  Status: Downloaded newer image for k8s.gcr.io/pause:3.6
-  k8s.gcr.io/pause:3.6
-$ docker save k8s.gcr.io/pause:3.6 -o pause.tar
+  Status: Downloaded newer image for registry.k8s.io/pause:3.6
+  registry.k8s.io/pause:3.6
+$ docker save registry.k8s.io/pause:3.6 -o pause.tar
 ```
 Then use `ctr` to load the container image into the container runtime:
 ```console
 # The cri plugin uses the "k8s.io" containerd namespace.
 $ sudo ctr -n=k8s.io images import pause.tar
-  Loaded image: k8s.gcr.io/pause:3.6
+  Loaded image: registry.k8s.io/pause:3.6
 ```
 List images and inspect the pause image:
 ```console
 $ sudo crictl images
 IMAGE                       TAG                 IMAGE ID            SIZE
 docker.io/library/busybox   latest              f6e427c148a76       728kB
-k8s.gcr.io/pause            3.6                 ed210e3e4a5ba       683kB
+registry.k8s.io/pause       3.6                 ed210e3e4a5ba       683kB
 $ sudo crictl inspecti ed210e3e4a5ba
   ... displays information about the pause image.
-$ sudo crictl inspecti k8s.gcr.io/pause:3.6
+$ sudo crictl inspecti registry.k8s.io/pause:3.6
   ... displays information about the pause image.
 ```
 
@@ -201,7 +201,7 @@ $ crictl info
       }
     },
     "streamServerPort": "10010",
-    "sandboxImage": "k8s.gcr.io/pause:3.6",
+    "sandboxImage": "registry.k8s.io/pause:3.6",
     "statsCollectPeriod": 10,
     "containerdRootDir": "/var/lib/containerd",
     "containerdEndpoint": "unix:///run/containerd/containerd.sock",

--- a/integration/client/client_test.go
+++ b/integration/client/client_test.go
@@ -383,7 +383,7 @@ func TestImagePullSomePlatforms(t *testing.T) {
 
 	// Note: Must be different to the image used in TestImagePullAllPlatforms
 	// or it will see the content pulled by that, and fail.
-	img, err := client.Fetch(ctx, "k8s.gcr.io/e2e-test-images/busybox:1.29-2", opts...)
+	img, err := client.Fetch(ctx, "registry.k8s.io/e2e-test-images/busybox:1.29-2", opts...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/client/image_test.go
+++ b/integration/client/image_test.go
@@ -79,7 +79,7 @@ func TestImageIsUnpacked(t *testing.T) {
 
 func TestImagePullWithDistSourceLabel(t *testing.T) {
 	var (
-		source   = "k8s.gcr.io"
+		source   = "registry.k8s.io"
 		repoName = "pause"
 		tag      = "3.6"
 	)
@@ -231,7 +231,7 @@ func TestImageUsage(t *testing.T) {
 func TestImageSupportedBySnapshotter_Error(t *testing.T) {
 	var unsupportedImage string
 	if runtime.GOOS == "windows" {
-		unsupportedImage = "k8s.gcr.io/pause-amd64:3.2"
+		unsupportedImage = "registry.k8s.io/pause-amd64:3.2"
 	} else {
 		unsupportedImage = "mcr.microsoft.com/windows/nanoserver:1809"
 	}

--- a/integration/common.go
+++ b/integration/common.go
@@ -49,8 +49,8 @@ func initImages(imageListFile string) {
 	imageList = ImageList{
 		Alpine:           "docker.io/library/alpine:latest",
 		BusyBox:          "docker.io/library/busybox:latest",
-		Pause:            "k8s.gcr.io/pause:3.6",
-		ResourceConsumer: "k8s.gcr.io/e2e-test-images/resource-consumer:1.10",
+		Pause:            "registry.k8s.io/pause:3.6",
+		ResourceConsumer: "registry.k8s.io/e2e-test-images/resource-consumer:1.10",
 		VolumeCopyUp:     "ghcr.io/containerd/volume-copy-up:2.1",
 		VolumeOwnership:  "ghcr.io/containerd/volume-ownership:2.1",
 	}

--- a/integration/image_list.sample.toml
+++ b/integration/image_list.sample.toml
@@ -1,5 +1,5 @@
 alpine = "docker.io/library/alpine:latest"
 busybox = "docker.io/library/busybox:latest"
-pause = "k8s.gcr.io/pause:3.6"
+pause = "registry.k8s.io/pause:3.6"
 VolumeCopyUp = "ghcr.io/containerd/volume-copy-up:2.1"
 VolumeOwnership = "ghcr.io/containerd/volume-ownership:2.1"

--- a/pkg/cri/config/config_unix.go
+++ b/pkg/cri/config/config_unix.go
@@ -92,7 +92,7 @@ func DefaultConfig() PluginConfig {
 			TLSKeyFile:  "",
 			TLSCertFile: "",
 		},
-		SandboxImage:                     "k8s.gcr.io/pause:3.6",
+		SandboxImage:                     "registry.k8s.io/pause:3.6",
 		StatsCollectPeriod:               10,
 		SystemdCgroup:                    false,
 		MaxContainerLogLineSize:          16 * 1024,

--- a/pkg/cri/config/config_windows.go
+++ b/pkg/cri/config/config_windows.go
@@ -52,7 +52,7 @@ func DefaultConfig() PluginConfig {
 			TLSKeyFile:  "",
 			TLSCertFile: "",
 		},
-		SandboxImage:              "k8s.gcr.io/pause:3.6",
+		SandboxImage:              "registry.k8s.io/pause:3.6",
 		StatsCollectPeriod:        10,
 		MaxContainerLogLineSize:   16 * 1024,
 		MaxConcurrentDownloads:    3,


### PR DESCRIPTION
Cherry-pick of https://github.com/containerd/containerd/pull/7038

Signed-off-by: Paco Xu <paco.xu@daocloud.io>
(cherry picked from commit 9525b3148a3b6213a7a80f8f1e1fd016b9301669)
Signed-off-by: Sergey Kanzhelev <S.Kanzhelev@live.com>