### PR TITLE
[release/1.5] migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/contrib/ansible/cri-containerd.yaml
+++ b/contrib/ansible/cri-containerd.yaml
@@ -61,6 +61,6 @@
     # TODO This needs to be removed once we have consistent concurrent pull results
     - name: "Pre-pull pause container image"
       shell: |
-        /usr/local/bin/ctr pull k8s.gcr.io/pause:3.5
+        /usr/local/bin/ctr pull registry.k8s.io/pause:3.5
         /usr/local/bin/crictl --runtime-endpoint unix:///run/containerd/containerd.sock \
-        pull k8s.gcr.io/pause:3.5
+        pull registry.k8s.io/pause:3.5

--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -40,7 +40,7 @@ version = 2
   selinux_category_range = 1024
 
   # sandbox_image is the image used by sandbox container.
-  sandbox_image = "k8s.gcr.io/pause:3.5"
+  sandbox_image = "registry.k8s.io/pause:3.5"
 
   # stats_collect_period is the period (in seconds) of snapshots stats collection.
   stats_collect_period = 10

--- a/docs/cri/crictl.md
+++ b/docs/cri/crictl.md
@@ -59,29 +59,29 @@ command. With the load command you inject a container image into the container
 runtime from a file. First you need to create a container image tarball. For
 example to create an image tarball for a pause container using Docker:
 ```console
-$ docker pull k8s.gcr.io/pause:3.5
+$ docker pull registry.k8s.io/pause:3.5
   3.5: Pulling from pause
   019d8da33d91: Pull complete
   Digest: sha256:1ff6c18fbef2045af6b9c16bf034cc421a29027b800e4f9b68ae9b1cb3e9ae07
-  Status: Downloaded newer image for k8s.gcr.io/pause:3.5
-  k8s.gcr.io/pause:3.5
-$ docker save k8s.gcr.io/pause:3.5 -o pause.tar
+  Status: Downloaded newer image for registry.k8s.io/pause:3.5
+  registry.k8s.io/pause:3.5
+$ docker save registry.k8s.io/pause:3.5 -o pause.tar
 ```
 Then use `ctr` to load the container image into the container runtime:
 ```console
 # The cri plugin uses the "k8s.io" containerd namespace.
 $ sudo ctr -n=k8s.io images import pause.tar
-  Loaded image: k8s.gcr.io/pause:3.5
+  Loaded image: registry.k8s.io/pause:3.5
 ```
 List images and inspect the pause image:
 ```console
 $ sudo crictl images
 IMAGE                       TAG                 IMAGE ID            SIZE
 docker.io/library/busybox   latest              f6e427c148a76       728kB
-k8s.gcr.io/pause            3.5                 ed210e3e4a5ba       683kB
+registry.k8s.io/pause       3.5                 ed210e3e4a5ba       683kB
 $ sudo crictl inspecti ed210e3e4a5ba
   ... displays information about the pause image.
-$ sudo crictl inspecti k8s.gcr.io/pause:3.5
+$ sudo crictl inspecti registry.k8s.io/pause:3.5
   ... displays information about the pause image.
 ```
 
@@ -201,7 +201,7 @@ $ crictl info
       }
     },
     "streamServerPort": "10010",
-    "sandboxImage": "k8s.gcr.io/pause:3.5",
+    "sandboxImage": "registry.k8s.io/pause:3.5",
     "statsCollectPeriod": 10,
     "containerdRootDir": "/var/lib/containerd",
     "containerdEndpoint": "unix:///run/containerd/containerd.sock",

--- a/integration/client/client_test.go
+++ b/integration/client/client_test.go
@@ -330,7 +330,7 @@ func TestImagePullAllPlatforms(t *testing.T) {
 	defer cancel()
 
 	cs := client.ContentStore()
-	img, err := client.Fetch(ctx, "k8s.gcr.io/pause:3.5")
+	img, err := client.Fetch(ctx, "registry.k8s.io/pause:3.5")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -380,7 +380,7 @@ func TestImagePullSomePlatforms(t *testing.T) {
 
 	// Note: Must be different to the image used in TestImagePullAllPlatforms
 	// or it will see the content pulled by that, and fail.
-	img, err := client.Fetch(ctx, "k8s.gcr.io/pause:3.2", opts...)
+	img, err := client.Fetch(ctx, "registry.k8s.io/pause:3.2", opts...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/client/image_test.go
+++ b/integration/client/image_test.go
@@ -79,7 +79,7 @@ func TestImageIsUnpacked(t *testing.T) {
 
 func TestImagePullWithDistSourceLabel(t *testing.T) {
 	var (
-		source   = "k8s.gcr.io"
+		source   = "registry.k8s.io"
 		repoName = "pause"
 		tag      = "3.5"
 	)
@@ -231,7 +231,7 @@ func TestImageUsage(t *testing.T) {
 func TestImageSupportedBySnapshotter_Error(t *testing.T) {
 	var unsupportedImage string
 	if runtime.GOOS == "windows" {
-		unsupportedImage = "k8s.gcr.io/pause-amd64:3.2"
+		unsupportedImage = "registry.k8s.io/pause-amd64:3.2"
 	} else {
 		unsupportedImage = "mcr.microsoft.com/windows/nanoserver:1809"
 	}

--- a/integration/common.go
+++ b/integration/common.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*
@@ -48,8 +49,8 @@ func initImages(imageListFile string) {
 	imageList = ImageList{
 		Alpine:           "docker.io/library/alpine:latest",
 		BusyBox:          "docker.io/library/busybox:latest",
-		Pause:            "k8s.gcr.io/pause:3.5",
-		ResourceConsumer: "k8s.gcr.io/e2e-test-images/resource-consumer:1.9",
+		Pause:            "registry.k8s.io/pause:3.5",
+		ResourceConsumer: "registry.k8s.io/e2e-test-images/resource-consumer:1.9",
 		VolumeCopyUp:     "gcr.io/k8s-cri-containerd/volume-copy-up:2.0",
 		VolumeOwnership:  "gcr.io/k8s-cri-containerd/volume-ownership:2.0",
 	}

--- a/pkg/cri/config/config_unix.go
+++ b/pkg/cri/config/config_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*
@@ -91,7 +92,7 @@ func DefaultConfig() PluginConfig {
 			TLSKeyFile:  "",
 			TLSCertFile: "",
 		},
-		SandboxImage:                     "k8s.gcr.io/pause:3.5",
+		SandboxImage:                     "registry.k8s.io/pause:3.5",
 		StatsCollectPeriod:               10,
 		SystemdCgroup:                    false,
 		MaxContainerLogLineSize:          16 * 1024,

--- a/pkg/cri/config/config_windows.go
+++ b/pkg/cri/config/config_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*
@@ -54,7 +55,7 @@ func DefaultConfig() PluginConfig {
 			TLSKeyFile:  "",
 			TLSCertFile: "",
 		},
-		SandboxImage:              "k8s.gcr.io/pause:3.5",
+		SandboxImage:              "registry.k8s.io/pause:3.5",
 		StatsCollectPeriod:        10,
 		MaxContainerLogLineSize:   16 * 1024,
 		MaxConcurrentDownloads:    3,


### PR DESCRIPTION
Cherry-pick of https://github.com/containerd/containerd/pull/7038

Signed-off-by: Paco Xu <paco.xu@daocloud.io>
(cherry picked from commit 9525b3148a3b6213a7a80f8f1e1fd016b9301669)
Signed-off-by: Sergey Kanzhelev <S.Kanzhelev@live.com>