### PR TITLE
[release/1.6] cri: PodSandboxStatus should tolerate missing task

### DIFF
--- a/pkg/cri/server/sandbox_status.go
+++ b/pkg/cri/server/sandbox_status.go
@@ -155,12 +155,14 @@ func toCRISandboxInfo(ctx context.Context, sandbox sandboxstore.Sandbox) (map[st
 
 	var processStatus containerd.ProcessStatus
 	if task != nil {
-		taskStatus, err := task.Status(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get task status: %w", err)
+		if taskStatus, err := task.Status(ctx); err != nil {
+			if !errdefs.IsNotFound(err) {
+				return nil, fmt.Errorf("failed to get task status: %w", err)
+			}
+			processStatus = containerd.Unknown
+		} else {
+			processStatus = taskStatus.Status
 		}
-
-		processStatus = taskStatus.Status
 	}
 
 	si := &SandboxInfo{


### PR DESCRIPTION
Backport of https://github.com/containerd/containerd/pull/7535

Cherry pick was clean except for the sbserver file, which was removed.