### PR TITLE
[release/1.6] Stats() shouldn't assume s.container is non-nil

### DIFF
--- a/runtime/v2/runc/v1/service.go
+++ b/runtime/v2/runc/v1/service.go
@@ -597,7 +597,11 @@ func (s *service) Shutdown(ctx context.Context, r *taskAPI.ShutdownRequest) (*pt
 }
 
 func (s *service) Stats(ctx context.Context, r *taskAPI.StatsRequest) (*taskAPI.StatsResponse, error) {
-	cgx := s.container.Cgroup()
+	container, err := s.getContainer()
+	if err != nil {
+		return nil, err
+	}
+	cgx := container.Cgroup()
 	if cgx == nil {
 		return nil, errdefs.ToGRPCf(errdefs.ErrNotFound, "cgroup does not exist")
 	}


### PR DESCRIPTION
Like other exported methods, Stats() shouldn't assume s.container is non-nil.

Fixes #7468.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>
(cherry picked from commit 49a54e23cb2db8080c40383abcc180d45f0efea5)
Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>