### PR TITLE
support gzip and zstd HTTP transport compression to fetch remote resources

### DIFF
--- a/remotes/docker/fetcher.go
+++ b/remotes/docker/fetcher.go
@@ -17,6 +17,8 @@
 package docker
 
 import (
+	"compress/flate"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -25,10 +27,12 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"unicode"
 
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
+	"github.com/klauspost/compress/zstd"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -251,6 +255,7 @@ func (r dockerFetcher) open(ctx context.Context, req *request, mediatype string,
 	} else {
 		req.header.Set("Accept", strings.Join([]string{mediatype, `*/*`}, ", "))
 	}
+	req.header.Set("Accept-Encoding", "zstd, gzip")
 
 	if offset > 0 {
 		// Note: "Accept-Ranges: bytes" cannot be trusted as some endpoints
@@ -309,5 +314,32 @@ func (r dockerFetcher) open(ctx context.Context, req *request, mediatype string,
 		}
 	}
 
-	return resp.Body, nil
+	body := resp.Body
+	encoding := strings.FieldsFunc(resp.Header.Get("Content-Encoding"), func(r rune) bool {
+		return unicode.IsSpace(r) || r == ','
+	})
+	for i := len(encoding) - 1; i >= 0; i-- {
+		algorithm := strings.ToLower(encoding[i])
+		switch algorithm {
+		case "zstd":
+			r, err := zstd.NewReader(body)
+			if err != nil {
+				return nil, err
+			}
+			body = r.IOReadCloser()
+		case "gzip":
+			body, err = gzip.NewReader(body)
+			if err != nil {
+				return nil, err
+			}
+		case "deflate":
+			body = flate.NewReader(body)
+		case "":
+			// no content-encoding applied, use raw body
+		default:
+			return nil, errors.New("unsupported Content-Encoding algorithm: " + algorithm)
+		}
+	}
+
+	return body, nil
 }


### PR DESCRIPTION
Golang `net/http` already transparently supports gzip compression.
This adds support for zstd compression