### PR TITLE
Revert commit that changed LimitNOFILE to infinity to avoid regressions

### DIFF
--- a/containerd.service
+++ b/containerd.service
@@ -32,7 +32,7 @@ RestartSec=5
 # in the kernel. We recommend using cgroups to do container-local accounting.
 LimitNPROC=infinity
 LimitCORE=infinity
-LimitNOFILE=infinity
+LimitNOFILE=1048576
 # Comment TasksMax if your systemd version does not supports it.
 # Only systemd 226 and above support this version.
 TasksMax=infinity


### PR DESCRIPTION
Hi there,

This PR is _reverting_ the change introduced by the following PR: https://github.com/containerd/containerd/pull/4475

In our case we experienced an issue with it with RHEL 9 and Rocky 9. The system would OOMKill processes running in containers (spawned via Kubernetes, using containerd)

With the limit set to INFINITY the system would become either unresponsive if unlucky, or the process would be killed, similar to below.

```
[  550.295416] oom-kill:constraint=CONSTRAINT_NONE,nodemask=(null),cpuset=kubelet,mems_allowed=0,global_oom,task_memcg=/kubepods/besteffort/podfa0597df-8678-412b-b116-d2a8b906ddfd/fa785a2bb7a371c01590584ca74615e800c37b6e6984351f00a6bee11b918f2c,task=mysqld,pid=7654,uid=0
[  550.295443] Out of memory: Killed process 7654 (mysqld) total-vm:16827684kB, anon-rss:15376132kB, file-rss:4kB, shmem-rss:0kB, UID:0 pgtables:30220kB oom_score_adj:1000
[  550.413393] oom_reaper: reaped process 7654 (mysqld), now anon-rss:0kB, file-rss:0kB, shmem-rss:0kB
[  560.824936] coredns invoked oom-killer: gfp_mask=0x1100cca(GFP_HIGHUSER_MOVABLE), order=0, oom_score_adj=996
```

This is a very lightweight mysql server, on a very beefy node getting killed right away. This also happened with java stuff, uwsgi, and other processes we have automated tests with.

We tried with Kubernetes 1.24, and 1.21, with cgroups v2 and v1, later tried kubernetes on docker, where it worked. Which led us to the discovery that docker is using `LimitNOFILE=1048576` and containerd is using `LimitNOFILE=infinity` by default. 

Others have been running into this as well, for example:

* https://github.com/containerd/containerd/issues/3201
* https://github.com/containerd/containerd/issues/6707

We can work around it, but I believe simply reverting the change will make life easier for others, and maybe therefore worth doing? It would have saved me personally a couple of days troubleshooting.