### PR TITLE
update codeql-action to v2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       # Override language selection by uncommenting this and choosing your languages
       # with:
       #   languages: go, javascript, csharp, python, cpp, java
@@ -42,4 +42,4 @@ jobs:
         make
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -49,6 +49,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@5f532563584d71fdef14ee64d17bafb34f751ce5 # tag=v1.0.26
+        uses: github/codeql-action/upload-sarif@cc7986c02bac29104a72998e67239bb5ee2ee110 # tag=v2.1.28
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
The current codeql version `v1` that is being used in the github actions are stated for deprecation on 7-Dec-2022 [Ref](https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/). 
Currently it shows as a [warning](https://github.com/containerd/containerd/actions/runs/3291270028/jobs/5425207233#step:4:8) in the github action runs.

Updating the versions to v2 for the codeql actions. The version for `codeql-action/upload-sarif` is pinned to commit corresponding to tag `v2.1.28` as per the recommendation in this [PR](https://github.com/containerd/containerd/pull/7404#discussion_r975623463)

Signed-off-by: Akhil Mohan <makhil@vmware.com>