### PR TITLE
maintenance: Remove WithWindowsNetworkNamespace from pkg/cri

### DIFF
--- a/pkg/cri/opts/spec_windows.go
+++ b/pkg/cri/opts/spec_windows.go
@@ -32,21 +32,6 @@ import (
 	osinterface "github.com/containerd/containerd/pkg/os"
 )
 
-// WithWindowsNetworkNamespace sets windows network namespace for container.
-// TODO(windows): Move this into container/containerd.
-func WithWindowsNetworkNamespace(path string) oci.SpecOpts {
-	return func(ctx context.Context, client oci.Client, c *containers.Container, s *runtimespec.Spec) error {
-		if s.Windows == nil {
-			s.Windows = &runtimespec.Windows{}
-		}
-		if s.Windows.Network == nil {
-			s.Windows.Network = &runtimespec.WindowsNetwork{}
-		}
-		s.Windows.Network.NetworkNamespace = path
-		return nil
-	}
-}
-
 // namedPipePath returns true if the given path is to a named pipe.
 func namedPipePath(p string) bool {
 	return strings.HasPrefix(p, `\\.\pipe\`)

--- a/pkg/cri/sbserver/container_create_windows.go
+++ b/pkg/cri/sbserver/container_create_windows.go
@@ -85,7 +85,7 @@ func (c *criService) containerSpec(
 		// Clear the root location since hcsshim expects it.
 		// NOTE: readonly rootfs doesn't work on windows.
 		customopts.WithoutRoot,
-		customopts.WithWindowsNetworkNamespace(netNSPath),
+		oci.WithWindowsNetworkNamespace(netNSPath),
 		oci.WithHostname(sandboxConfig.GetHostname()),
 	)
 

--- a/pkg/cri/sbserver/podsandbox/sandbox_run_windows.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_run_windows.go
@@ -51,7 +51,7 @@ func (c *Controller) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 		// Clear the root location since hcsshim expects it.
 		// NOTE: readonly rootfs doesn't work on windows.
 		customopts.WithoutRoot,
-		customopts.WithWindowsNetworkNamespace(nsPath),
+		oci.WithWindowsNetworkNamespace(nsPath),
 	)
 
 	specOpts = append(specOpts, customopts.WithWindowsDefaultSandboxShares)

--- a/pkg/cri/server/container_create_windows.go
+++ b/pkg/cri/server/container_create_windows.go
@@ -85,7 +85,7 @@ func (c *criService) containerSpec(
 		// Clear the root location since hcsshim expects it.
 		// NOTE: readonly rootfs doesn't work on windows.
 		customopts.WithoutRoot,
-		customopts.WithWindowsNetworkNamespace(netNSPath),
+		oci.WithWindowsNetworkNamespace(netNSPath),
 		oci.WithHostname(sandboxConfig.GetHostname()),
 	)
 

--- a/pkg/cri/server/sandbox_run_windows.go
+++ b/pkg/cri/server/sandbox_run_windows.go
@@ -51,7 +51,7 @@ func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 		// Clear the root location since hcsshim expects it.
 		// NOTE: readonly rootfs doesn't work on windows.
 		customopts.WithoutRoot,
-		customopts.WithWindowsNetworkNamespace(nsPath),
+		oci.WithWindowsNetworkNamespace(nsPath),
 	)
 
 	specOpts = append(specOpts, customopts.WithWindowsDefaultSandboxShares)


### PR DESCRIPTION
Was perusing around for a different TODO and saw one in pkg/cri/opts that stated that `WithWindowsNetworkNamespace` should be moved to the main containerd pkg. This was done in #6304 already (well, to the /oci pkg) so we're good to get rid of the CRI version. This additionally swaps all uses of `WithWindowsNetworkNamespace` to the oci packages impl.