### PR TITLE
integration: Add grpc.WithBlock to remote services

### DIFF
--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -78,8 +78,7 @@ func TestMain(m *testing.M) {
 }
 
 // ConnectDaemons connect cri plugin and containerd, and initialize the clients.
-func ConnectDaemons() error {
-	var err error
+func ConnectDaemons() (err error) {
 	runtimeService, err = remote.NewRuntimeService(*criEndpoint, timeout)
 	if err != nil {
 		return fmt.Errorf("failed to create runtime service: %w", err)
@@ -87,17 +86,6 @@ func ConnectDaemons() error {
 	imageService, err = remote.NewImageService(*criEndpoint, timeout)
 	if err != nil {
 		return fmt.Errorf("failed to create image service: %w", err)
-	}
-	// Since CRI grpc client doesn't have `WithBlock` specified, we
-	// need to check whether it is actually connected.
-	// TODO(#6069) Use grpc options to block on connect and remove for this list containers request.
-	_, err = runtimeService.ListContainers(&runtime.ContainerFilter{})
-	if err != nil {
-		return fmt.Errorf("failed to list containers: %w", err)
-	}
-	_, err = imageService.ListImages(&runtime.ImageFilter{})
-	if err != nil {
-		return fmt.Errorf("failed to list images: %w", err)
 	}
 	// containerdEndpoint is the same with criEndpoint now
 	containerdEndpoint = strings.TrimPrefix(*criEndpoint, "unix://")

--- a/integration/remote/remote_image.go
+++ b/integration/remote/remote_image.go
@@ -69,6 +69,7 @@ func NewImageService(endpoint string, connectionTimeout time.Duration) (internal
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithContextDialer(dialer),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)),
+		grpc.WithBlock(),
 	)
 	if err != nil {
 		klog.Errorf("Connect remote image service %s failed: %v", addr, err)

--- a/integration/remote/remote_runtime.go
+++ b/integration/remote/remote_runtime.go
@@ -78,6 +78,7 @@ func NewRuntimeService(endpoint string, connectionTimeout time.Duration) (intern
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithContextDialer(dialer),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)),
+		grpc.WithBlock(),
 	)
 	if err != nil {
 		klog.Errorf("Connect remote runtime %s failed: %v", addr, err)


### PR DESCRIPTION
Add grpc.WithBlock() to CRI services. Not sure we gained anything from connecting in the background, and there was a weird use of ListImages and ListContainers right after connecting the services to check if the connection went through alright that this eliminates.