### PR TITLE
Update GitHub actions release workflow set output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         id: contentrel
         run: |
           RELEASEVER=${{ github.ref }}
-          echo "::set-output name=stringver::${RELEASEVER#refs/tags/v}"
+          echo "stringver=${RELEASEVER#refs/tags/v}" >> $GITHUB_OUTPUT
           git tag -l ${RELEASEVER#refs/tags/} -n20000 | tail -n +3 | cut -c 5- >release-notes.md
         working-directory: src/github.com/containerd/containerd
 

--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -171,7 +171,7 @@ jobs:
             set -o pipefail
             make integration | tee ${{ env.VM_INTEGRATION_LOGFILE }}
           EOF
-          echo '::set-output name=SUCCEEDED::1'
+          echo 'SUCCEEDED=1' >> $GITHUB_OUTPUT
 
       - name: PrepareRepoList
         run: |
@@ -201,7 +201,7 @@ jobs:
              set -o pipefail
              make cri-integration | tee ${{ env.VM_CRI_INTEGRATION_LOGFILE }}
            EOF
-           echo '::set-output name=SUCCEEDED::1'
+           echo 'SUCCEEDED=1' >> $GITHUB_OUTPUT
 
       - name: GetCritestRepo
         run: |
@@ -230,7 +230,7 @@ jobs:
             set -o pipefail
             c:/cri-tools/build/bin/critest.exe $SKIP --runtime-endpoint='npipe://./pipe/containerd-containerd' --test-images-file='c:/cri-test-images.yaml' --report-dir='c:/Logs' -ginkgo.junit-report="C:\Logs\junit_critest.xml" | tee c:/Logs/critest.log
           EOF
-          echo '::set-output name=SUCCEEDED::1'
+          echo 'SUCCEEDED=1' >> $GITHUB_OUTPUT
 
       - name: PullLogsFromWinNode
         run: |
@@ -253,8 +253,8 @@ jobs:
       - name: AssignGcpCreds
         id: AssignGcpCreds
         run: |
-          echo '::set-output name=GCP_SERVICE_ACCOUNT::${{ secrets.GCP_SERVICE_ACCOUNT }}'
-          echo '::set-output name=GCP_WORKLOAD_IDENTITY_PROVIDER::${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}'
+          echo 'GCP_SERVICE_ACCOUNT=${{ secrets.GCP_SERVICE_ACCOUNT }}' >> $GITHUB_OUTPUT
+          echo 'GCP_WORKLOAD_IDENTITY_PROVIDER=${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}' >> $GITHUB_OUTPUT
 
       - name: AuthGcp
         uses: google-github-actions/auth@v0


### PR DESCRIPTION
Migrate from set-output call to write to new GITHUB_OUTPUT environment file.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Resolves #7580 

Signed-off-by: Austin Vazquez <macedonv@amazon.com>