### PR TITLE
[release/1.5] cherry-pick: Migrate away from GitHub actions set-output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         id: contentrel
         run: |
           RELEASEVER=${{ github.ref }}
-          echo "::set-output name=stringver::${RELEASEVER#refs/tags/v}"
+          echo "stringver=${RELEASEVER#refs/tags/v}" >> $GITHUB_OUTPUT
           git tag -l ${RELEASEVER#refs/tags/} -n20000 | tail -n +3 | cut -c 5- >release-notes.md
         working-directory: src/github.com/containerd/containerd
 


### PR DESCRIPTION
Migrate from set-output call to write to new GITHUB_OUTPUT environment file.

Related issue: https://github.com/containerd/containerd/issues/7580

Signed-off-by: Austin Vazquez <macedonv@amazon.com>
(cherry picked from commit be3987a92d6e5f10ba07a3b9925c26f3c66921cb)