### PR TITLE
Sandbox API: Add a new mode config for sandbox controller impls

### DIFF
--- a/pkg/cri/config/config_test.go
+++ b/pkg/cri/config/config_test.go
@@ -53,10 +53,12 @@ func TestValidateConfig(t *testing.T) {
 					},
 					Runtimes: map[string]Runtime{
 						RuntimeUntrusted: {
-							Type: "untrusted",
+							Type:        "untrusted",
+							SandboxMode: string(ModePodSandbox),
 						},
 						RuntimeDefault: {
-							Type: "default",
+							Type:        "default",
+							SandboxMode: string(ModePodSandbox),
 						},
 					},
 				},
@@ -97,7 +99,8 @@ func TestValidateConfig(t *testing.T) {
 					DefaultRuntimeName: RuntimeDefault,
 					Runtimes: map[string]Runtime{
 						RuntimeDefault: {
-							Type: "default",
+							Type:        "default",
+							SandboxMode: string(ModePodSandbox),
 						},
 					},
 				},
@@ -133,7 +136,8 @@ func TestValidateConfig(t *testing.T) {
 					DefaultRuntimeName: RuntimeDefault,
 					Runtimes: map[string]Runtime{
 						RuntimeDefault: {
-							Type: plugin.RuntimeLinuxV1,
+							Type:        plugin.RuntimeLinuxV1,
+							SandboxMode: string(ModePodSandbox),
 						},
 					},
 				},
@@ -171,7 +175,8 @@ func TestValidateConfig(t *testing.T) {
 					DefaultRuntimeName: RuntimeDefault,
 					Runtimes: map[string]Runtime{
 						RuntimeDefault: {
-							Type: plugin.RuntimeLinuxV1,
+							Type:        plugin.RuntimeLinuxV1,
+							SandboxMode: string(ModePodSandbox),
 						},
 					},
 				},
@@ -208,8 +213,9 @@ func TestValidateConfig(t *testing.T) {
 					DefaultRuntimeName: RuntimeDefault,
 					Runtimes: map[string]Runtime{
 						RuntimeDefault: {
-							Engine: "runc",
-							Type:   plugin.RuntimeLinuxV1,
+							Engine:      "runc",
+							Type:        plugin.RuntimeLinuxV1,
+							SandboxMode: string(ModePodSandbox),
 						},
 					},
 				},
@@ -246,8 +252,9 @@ func TestValidateConfig(t *testing.T) {
 					DefaultRuntimeName: RuntimeDefault,
 					Runtimes: map[string]Runtime{
 						RuntimeDefault: {
-							Root: "/run/containerd/runc",
-							Type: plugin.RuntimeLinuxV1,
+							Root:        "/run/containerd/runc",
+							Type:        plugin.RuntimeLinuxV1,
+							SandboxMode: string(ModePodSandbox),
 						},
 					},
 				},
@@ -288,7 +295,8 @@ func TestValidateConfig(t *testing.T) {
 					DefaultRuntimeName: RuntimeDefault,
 					Runtimes: map[string]Runtime{
 						RuntimeDefault: {
-							Type: plugin.RuntimeRuncV1,
+							Type:        plugin.RuntimeRuncV1,
+							SandboxMode: string(ModePodSandbox),
 						},
 					},
 				},

--- a/pkg/cri/config/config_unix.go
+++ b/pkg/cri/config/config_unix.go
@@ -77,8 +77,9 @@ func DefaultConfig() PluginConfig {
 			NoPivot:            false,
 			Runtimes: map[string]Runtime{
 				"runc": {
-					Type:    "io.containerd.runc.v2",
-					Options: tree.ToMap(),
+					Type:        "io.containerd.runc.v2",
+					Options:     tree.ToMap(),
+					SandboxMode: string(ModePodSandbox),
 				},
 			},
 			DisableSnapshotAnnotations: true,

--- a/pkg/cri/sbserver/sandbox_remove.go
+++ b/pkg/cri/sbserver/sandbox_remove.go
@@ -80,7 +80,12 @@ func (c *criService) RemovePodSandbox(ctx context.Context, r *runtime.RemovePodS
 		}
 	}
 
-	if _, err := c.sandboxController.Delete(ctx, id); err != nil {
+	// Use sandbox controller to delete sandbox
+	controller, err := c.getSandboxController(sandbox.Config, sandbox.RuntimeHandler)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get sandbox controller: %w", err)
+	}
+	if _, err := controller.Delete(ctx, id); err != nil {
 		return nil, fmt.Errorf("failed to delete sandbox %q: %w", id, err)
 	}
 

--- a/pkg/cri/sbserver/sandbox_stop.go
+++ b/pkg/cri/sbserver/sandbox_stop.go
@@ -64,7 +64,12 @@ func (c *criService) stopPodSandbox(ctx context.Context, sandbox sandboxstore.Sa
 		}
 	}
 
-	if _, err := c.sandboxController.Stop(ctx, id); err != nil {
+	// Use sandbox controller to stop sandbox
+	controller, err := c.getSandboxController(sandbox.Config, sandbox.RuntimeHandler)
+	if err != nil {
+		return fmt.Errorf("failed to get sandbox controller: %w", err)
+	}
+	if _, err := controller.Stop(ctx, id); err != nil {
 		return fmt.Errorf("failed to stop sandbox %q: %w", id, err)
 	}
 

--- a/pkg/cri/sbserver/service_test.go
+++ b/pkg/cri/sbserver/service_test.go
@@ -86,3 +86,17 @@ func TestLoadBaseOCISpec(t *testing.T) {
 	assert.Equal(t, "1.0.2", out.Version)
 	assert.Equal(t, "default", out.Hostname)
 }
+
+func TestValidateMode(t *testing.T) {
+	mode := ""
+	assert.Error(t, ValidateMode(mode))
+
+	mode = "podsandbox"
+	assert.NoError(t, ValidateMode(mode))
+
+	mode = "shim"
+	assert.NoError(t, ValidateMode(mode))
+
+	mode = "nonexistent"
+	assert.Error(t, ValidateMode(mode))
+}


### PR DESCRIPTION
Works for #7312:

Add a new config as sandbox controller mod, which can be either
"podsandbox" or "shim". If empty, set it to default "podsandbox"
when CRI plugin inits.

Signed-off-by: Zhang Tianyang <burning9699@gmail.com>