### PR TITLE
[release/1.6] ctr import: strictly match platform

### DIFF
--- a/cmd/ctr/commands/images/import.go
+++ b/cmd/ctr/commands/images/import.go
@@ -89,9 +89,9 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 
 	Action: func(context *cli.Context) error {
 		var (
-			in             = context.Args().First()
-			opts           []containerd.ImportOpt
-			platformMacher platforms.MatchComparer
+			in              = context.Args().First()
+			opts            []containerd.ImportOpt
+			platformMatcher platforms.MatchComparer
 		)
 
 		prefix := context.String("base-name")
@@ -126,8 +126,8 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 			if err != nil {
 				return err
 			}
-			platformMacher = platforms.Only(platSpec)
-			opts = append(opts, containerd.WithImportPlatform(platformMacher))
+			platformMatcher = platforms.OnlyStrict(platSpec)
+			opts = append(opts, containerd.WithImportPlatform(platformMatcher))
 		}
 
 		opts = append(opts, containerd.WithAllPlatforms(context.Bool("all-platforms")))
@@ -160,10 +160,10 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 			log.G(ctx).Debugf("unpacking %d images", len(imgs))
 
 			for _, img := range imgs {
-				if platformMacher == nil { // if platform not specified use default.
-					platformMacher = platforms.Default()
+				if platformMatcher == nil { // if platform not specified use default.
+					platformMatcher = platforms.Default()
 				}
-				image := containerd.NewImageWithPlatform(client, img, platformMacher)
+				image := containerd.NewImageWithPlatform(client, img, platformMatcher)
 
 				// TODO: Show unpack status
 				fmt.Printf("unpacking %s (%s)...", img.Name, img.Target.Digest)


### PR DESCRIPTION
Currently, ctr import will use loose matching as defined by platforms.Only(), meaning in the case of platform linux/amd64 as in issue#6441, importing will also match linux/386 platform on the image-to-be-imported's index. However, that image-to-be-imported may not have both the linux/amd64 and linux/386 platform contents, resulting in a failure to unpack the image. This change makes that check strict such that the requested platform to import for is the only platform content imported. Both ctr pull and ctr export will treat the platform option as strict, so this change makes ctr import consistent with those.

resolves #6441

Signed-off-by: Gavin Inglis <giinglis@amazon.com>
(cherry picked from commit 2c98a7b099b00316c0331a91927e54f85d4ec187)
Signed-off-by: Gavin Inglis <giinglis@amazon.com>