### PR TITLE
[release/1.5] feat: support import image for specific platform

### DIFF
--- a/cmd/ctr/commands/images/import.go
+++ b/cmd/ctr/commands/images/import.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/images/archive"
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/platforms"
 	"github.com/urfave/cli"
 )
 
@@ -69,6 +70,10 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 			Usage: "imports content for all platforms, false by default",
 		},
 		cli.BoolFlag{
+			Name:  "platform",
+			Usage: "imports content for specific platform",
+		},
+		cli.BoolFlag{
 			Name:  "no-unpack",
 			Usage: "skip unpacking the images, false by default",
 		},
@@ -80,8 +85,9 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 
 	Action: func(context *cli.Context) error {
 		var (
-			in   = context.Args().First()
-			opts []containerd.ImportOpt
+			in             = context.Args().First()
+			opts           []containerd.ImportOpt
+			platformMacher platforms.MatchComparer
 		)
 
 		prefix := context.String("base-name")
@@ -103,6 +109,15 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 
 		if context.Bool("compress-blobs") {
 			opts = append(opts, containerd.WithImportCompression())
+		}
+
+		if platform := context.String("platform"); platform != "" {
+			platSpec, err := platforms.Parse(platform)
+			if err != nil {
+				return err
+			}
+			platformMacher = platforms.Only(platSpec)
+			opts = append(opts, containerd.WithImportPlatform(platformMacher))
 		}
 
 		opts = append(opts, containerd.WithAllPlatforms(context.Bool("all-platforms")))
@@ -135,8 +150,10 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 			log.G(ctx).Debugf("unpacking %d images", len(imgs))
 
 			for _, img := range imgs {
-				// TODO: Allow configuration of the platform
-				image := containerd.NewImage(client, img)
+				if platformMacher == nil { // if platform not specified use default.
+					platformMacher = platforms.Default()
+				}
+				image := containerd.NewImageWithPlatform(client, img, platformMacher)
 
 				// TODO: Show unpack status
 				fmt.Printf("unpacking %s (%s)...", img.Name, img.Target.Digest)

--- a/cmd/ctr/commands/images/import.go
+++ b/cmd/ctr/commands/images/import.go
@@ -69,7 +69,7 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 			Name:  "all-platforms",
 			Usage: "imports content for all platforms, false by default",
 		},
-		cli.BoolFlag{
+		cli.StringFlag{
 			Name:  "platform",
 			Usage: "imports content for specific platform",
 		},


### PR DESCRIPTION
Included both commits from PR #6070

  fix: wrong flag type

  Signed-off-by: jonyhy <yun.hao@daocloud.io>
  (cherry picked from commit 933ddaa6f870e10b1164d7a4a442c0e026ba7975)
  Signed-off-by: Gavin Inglis <giinglis@amazon.com>

  feat: support import image for specific platform

  Signed-off-by: jonyhy <yun.hao@daocloud.io>
  (cherry picked from commit da16d492cd07ee7089aa8b000ba48f494f193147)
  Signed-off-by: Gavin Inglis <giinglis@amazon.com>