### PR TITLE
Harden GITHUB_TOKEN permissions for OSSF Scorecard

### DIFF
--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -20,7 +20,7 @@ on:
         default: westeurope
 
 permissions:
-  packages: write
+  contents: read
 
 env:
   AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUB_ID }}
@@ -30,6 +30,8 @@ env:
 
 jobs:
   images:
+    permissions:
+      packages: write
     name: "Build volume test images"
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,17 @@ env:
   # Note: don't forget to update `Binaries` step, as it contains the matrix of all supported Go versions.
   GO_VERSION: "1.19.2"
 
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
 jobs:
   #
   # golangci-lint
   #
   linters:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for golangci/golangci-lint-action to fetch pull requests
     name: Linters
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,9 +10,16 @@ on:
       - main
       - 'release/**'
 
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
 jobs:
   CodeQL-Build:
 
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/analyze to upload SARIF results
     strategy:
       fail-fast: false
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,5 +1,8 @@
 name: Fuzzing
 on: [pull_request]
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
 jobs:
   # Run all fuzzing tests. Some of them use Go 1.18's testing.F.
   # Others use https://github.com/AdaLogics/go-fuzz-headers.

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -9,6 +9,9 @@ on:
       image:
         description: "Target image name (override)"
 
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
 jobs:
   mirror:
     name: "Mirror Image"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,6 +9,9 @@ on:
 env:
   GO_VERSION: '1.19.2'
 
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
 jobs:
   linux:
     name: Linux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ name: Containerd Release
 env:
   GO_VERSION: '1.19.2'
 
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
 jobs:
   check:
     name: Check Signed Tag
@@ -123,6 +126,8 @@ jobs:
 
   release:
     name: Create containerd Release
+    permissions:
+      contents: write
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     needs: [build, check]

--- a/.github/workflows/windows-hyperv-periodic-trigger.yml
+++ b/.github/workflows/windows-hyperv-periodic-trigger.yml
@@ -7,9 +7,16 @@ on:
   schedule:
     - cron: "0 1 * * *"
 
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
 jobs:
 
   triggerWinIntegration:
+    # NOTE: the following permissions are required by `google-github-actions/auth`:
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     if: github.repository == 'containerd/containerd'
     # NOTE(aznashwan, 11/24/21): GitHub actions do not currently support referencing
     # or evaluating any kind of variables in the `uses` clause, but this will

--- a/.github/workflows/windows-hyperv-periodic.yml
+++ b/.github/workflows/windows-hyperv-periodic.yml
@@ -28,6 +28,8 @@ env:
   WEBSERVER_TESTING_IMAGE_REF: "k8s.gcr.io/e2e-test-images/nginx:1.14-2"
   HCSSHIM_TAG: "master"
 
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
 
 jobs:
   winIntegration:

--- a/.github/workflows/windows-periodic-trigger.yml
+++ b/.github/workflows/windows-periodic-trigger.yml
@@ -7,9 +7,16 @@ on:
   schedule:
     - cron: "0 1 * * *"
 
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
 jobs:
 
   triggerWinIntegration:
+    # NOTE: the following permissions are required by `google-github-actions/auth`:
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     if: github.repository == 'containerd/containerd'
     # NOTE(aznashwan, 11/24/21): GitHub actions do not currently support referencing
     # or evaluating any kind of variables in the `uses` clause, but this will

--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -27,6 +27,8 @@ env:
   RESOURCE_CONSUMER_TESTING_IMAGE_REF: "registry.k8s.io/e2e-test-images/resource-consumer:1.10"
   WEBSERVER_TESTING_IMAGE_REF: "registry.k8s.io/e2e-test-images/nginx:1.14-2"
 
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
 
 jobs:
   winIntegration:


### PR DESCRIPTION
Hi all! I took a look at the OpenSSF Scorecard results for the containerd repo and noticed it was getting a 0/10 for the GitHub workflow token permissions check.

I followed the guidance from the scorecard tool to apply the changes in this PR. Some were automated recommendations from their linked Step Security tool, and others I applied manually based on the warnings. 

The summary of the changes is adding:
* Top level permissions for workflows that had none.
* Least privilege Job level permissions based on the knowledgebase from Step Security for certain jobs

This is still getting a 0/10 for the check due to two remaining warnings (that I'll share) but the Aggregate score increased against my fork by 1.7 points.

The remaining 2 warnings are that the `build-test-images.yml` and `images.yml` workflows have `jobLevel` permissions with `packages: write` which [causes a large reduction](https://github.com/ossf/scorecard/blob/main/docs/checks.md#write-permissions-causing-a-large-reduction) in points unless the job "utilizes a recognized packaging action or command". Not sure if there's a scorecard bug here or if there's another way or suggestion you all may have to clear those issues up and get full credit here. 

Signed-off-by: Craig Ingram <cjingram@google.com>