### PR TITLE
Sandbox API: Move remote impls to /sandbox/proxy

### DIFF
--- a/client.go
+++ b/client.go
@@ -57,6 +57,7 @@ import (
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/containerd/containerd/sandbox"
+	sandboxproxy "github.com/containerd/containerd/sandbox/proxy"
 	"github.com/containerd/containerd/services/introspection"
 	"github.com/containerd/containerd/snapshots"
 	snproxy "github.com/containerd/containerd/snapshots/proxy"
@@ -704,7 +705,7 @@ func (c *Client) SandboxStore() sandbox.Store {
 	}
 	c.connMu.Lock()
 	defer c.connMu.Unlock()
-	return NewRemoteSandboxStore(sandboxsapi.NewStoreClient(c.conn))
+	return sandboxproxy.NewSandboxStore(sandboxsapi.NewStoreClient(c.conn))
 }
 
 // SandboxController returns the underlying sandbox controller client
@@ -714,7 +715,7 @@ func (c *Client) SandboxController() sandbox.Controller {
 	}
 	c.connMu.Lock()
 	defer c.connMu.Unlock()
-	return NewSandboxRemoteController(sandboxsapi.NewControllerClient(c.conn))
+	return sandboxproxy.NewSandboxController(sandboxsapi.NewControllerClient(c.conn))
 }
 
 // VersionService returns the underlying VersionClient

--- a/sandbox/proxy/controller.go
+++ b/sandbox/proxy/controller.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package containerd
+package proxy
 
 import (
 	"context"
@@ -24,19 +24,19 @@ import (
 	sb "github.com/containerd/containerd/sandbox"
 )
 
-// sandboxRemoteController is a low level GRPC client for containerd's sandbox controller service
-type sandboxRemoteController struct {
+// remoteSandboxController is a low level GRPC client for containerd's sandbox controller service
+type remoteSandboxController struct {
 	client api.ControllerClient
 }
 
-var _ sb.Controller = (*sandboxRemoteController)(nil)
+var _ sb.Controller = (*remoteSandboxController)(nil)
 
-// NewSandboxRemoteController creates client for sandbox controller
-func NewSandboxRemoteController(client api.ControllerClient) sb.Controller {
-	return &sandboxRemoteController{client: client}
+// NewSandboxController creates a client for a sandbox controller
+func NewSandboxController(client api.ControllerClient) sb.Controller {
+	return &remoteSandboxController{client: client}
 }
 
-func (s *sandboxRemoteController) Create(ctx context.Context, sandboxID string) error {
+func (s *remoteSandboxController) Create(ctx context.Context, sandboxID string) error {
 	_, err := s.client.Create(ctx, &api.ControllerCreateRequest{SandboxID: sandboxID})
 	if err != nil {
 		return errdefs.FromGRPC(err)
@@ -45,7 +45,7 @@ func (s *sandboxRemoteController) Create(ctx context.Context, sandboxID string) 
 	return nil
 }
 
-func (s *sandboxRemoteController) Start(ctx context.Context, sandboxID string) (*api.ControllerStartResponse, error) {
+func (s *remoteSandboxController) Start(ctx context.Context, sandboxID string) (*api.ControllerStartResponse, error) {
 	resp, err := s.client.Start(ctx, &api.ControllerStartRequest{SandboxID: sandboxID})
 	if err != nil {
 		return nil, errdefs.FromGRPC(err)
@@ -54,7 +54,7 @@ func (s *sandboxRemoteController) Start(ctx context.Context, sandboxID string) (
 	return resp, nil
 }
 
-func (s *sandboxRemoteController) Stop(ctx context.Context, sandboxID string) (*api.ControllerStopResponse, error) {
+func (s *remoteSandboxController) Stop(ctx context.Context, sandboxID string) (*api.ControllerStopResponse, error) {
 	resp, err := s.client.Stop(ctx, &api.ControllerStopRequest{SandboxID: sandboxID})
 	if err != nil {
 		return nil, errdefs.FromGRPC(err)
@@ -63,7 +63,7 @@ func (s *sandboxRemoteController) Stop(ctx context.Context, sandboxID string) (*
 	return resp, nil
 }
 
-func (s *sandboxRemoteController) Delete(ctx context.Context, sandboxID string) (*api.ControllerDeleteResponse, error) {
+func (s *remoteSandboxController) Delete(ctx context.Context, sandboxID string) (*api.ControllerDeleteResponse, error) {
 	resp, err := s.client.Delete(ctx, &api.ControllerDeleteRequest{SandboxID: sandboxID})
 	if err != nil {
 		return nil, errdefs.FromGRPC(err)
@@ -72,7 +72,7 @@ func (s *sandboxRemoteController) Delete(ctx context.Context, sandboxID string) 
 	return resp, nil
 }
 
-func (s *sandboxRemoteController) Wait(ctx context.Context, sandboxID string) (*api.ControllerWaitResponse, error) {
+func (s *remoteSandboxController) Wait(ctx context.Context, sandboxID string) (*api.ControllerWaitResponse, error) {
 	resp, err := s.client.Wait(ctx, &api.ControllerWaitRequest{SandboxID: sandboxID})
 	if err != nil {
 		return nil, errdefs.FromGRPC(err)
@@ -81,7 +81,7 @@ func (s *sandboxRemoteController) Wait(ctx context.Context, sandboxID string) (*
 	return resp, nil
 }
 
-func (s *sandboxRemoteController) Status(ctx context.Context, sandboxID string) (*api.ControllerStatusResponse, error) {
+func (s *remoteSandboxController) Status(ctx context.Context, sandboxID string) (*api.ControllerStatusResponse, error) {
 	resp, err := s.client.Status(ctx, &api.ControllerStatusRequest{SandboxID: sandboxID})
 	if err != nil {
 		return nil, errdefs.FromGRPC(err)

--- a/sandbox/proxy/store.go
+++ b/sandbox/proxy/store.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package containerd
+package proxy
 
 import (
 	"context"
@@ -31,8 +31,8 @@ type remoteSandboxStore struct {
 
 var _ sb.Store = (*remoteSandboxStore)(nil)
 
-// NewRemoteSandboxStore create client for sandbox store
-func NewRemoteSandboxStore(client api.StoreClient) sb.Store {
+// NewSandboxStore create a client for a sandbox store
+func NewSandboxStore(client api.StoreClient) sb.Store {
 	return &remoteSandboxStore{client: client}
 }
 

--- a/services.go
+++ b/services.go
@@ -33,6 +33,7 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/sandbox"
+	"github.com/containerd/containerd/sandbox/proxy"
 	srv "github.com/containerd/containerd/services"
 	"github.com/containerd/containerd/services/introspection"
 	"github.com/containerd/containerd/snapshots"
@@ -167,14 +168,14 @@ func WithIntrospectionService(in introspection.Service) ServicesOpt {
 // WithSandboxStore sets the sandbox store.
 func WithSandboxStore(client sandboxapi.StoreClient) ServicesOpt {
 	return func(s *services) {
-		s.sandboxStore = NewRemoteSandboxStore(client)
+		s.sandboxStore = proxy.NewSandboxStore(client)
 	}
 }
 
 // WithSandboxController sets the sandbox controller.
 func WithSandboxController(client sandboxapi.ControllerClient) ServicesOpt {
 	return func(s *services) {
-		s.sandboxController = NewSandboxRemoteController(client)
+		s.sandboxController = proxy.NewSandboxController(client)
 	}
 }
 


### PR DESCRIPTION
Following how some of the other stores/services are returned in the client package, it makes sense to me to move the remoteFooBars in the sandbox API to a proxy sub-package under /sandbox. Given this has only been in a 1.7 beta, I hope this is fine to move around still.