### PR TITLE
Support default hosts.toml configuration

### DIFF
--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -73,6 +73,9 @@ $ tree /etc/containerd/certs.d
     └── hosts.toml
 ```
 
+Optionally the `_default` registry host namespace can be used as a fallback, if no
+other namespace matches.
+
 The `/v2` portion of the pull request format shown above refers to the version of the
 distribution api. If not included in the pull request, `/v2` is added by default for all
 clients compliant to the distribution specification linked above.
@@ -155,6 +158,21 @@ server = "https://registry-1.docker.io"    # Exclude this to not use upstream
 [host."https://docker-mirror.internal"]
   capabilities = ["pull", "resolve"]
   ca = "docker-mirror.crt"                 # Or absolute path /etc/containerd/certs.d/docker.io/docker-mirror.crt
+```
+
+### Setup Default Mirror for All Registries
+
+```
+$ tree /etc/containerd/certs.d
+/etc/containerd/certs.d
+└── _default
+    └── hosts.toml
+
+$ cat /etc/containerd/certs.d/_default/hosts.toml
+server = "https://registry.example.com"
+
+[host."https://registry.example.com"]
+  capabilities = ["pull", "resolve"]
 ```
 
 ### Bypass TLS Verification Example

--- a/remotes/docker/config/config_unix.go
+++ b/remotes/docker/config/config_unix.go
@@ -24,16 +24,18 @@ import (
 	"path/filepath"
 )
 
-func hostPaths(root, host string) []string {
+func hostPaths(root, host string) (hosts []string) {
 	ch := hostDirectory(host)
-	if ch == host {
-		return []string{filepath.Join(root, host)}
+	if ch != host {
+		hosts = append(hosts, filepath.Join(root, ch))
 	}
 
-	return []string{
-		filepath.Join(root, ch),
+	hosts = append(hosts,
 		filepath.Join(root, host),
-	}
+		filepath.Join(root, "_default"),
+	)
+
+	return
 }
 
 func rootSystemPool() (*x509.CertPool, error) {

--- a/remotes/docker/config/config_windows.go
+++ b/remotes/docker/config/config_windows.go
@@ -22,16 +22,18 @@ import (
 	"strings"
 )
 
-func hostPaths(root, host string) []string {
+func hostPaths(root, host string) (hosts []string) {
 	ch := hostDirectory(host)
-	if ch == host {
-		return []string{filepath.Join(root, host)}
+	if ch != host {
+		hosts = append(hosts, filepath.Join(root, strings.Replace(ch, ":", "", -1)))
 	}
 
-	return []string{
-		filepath.Join(root, strings.Replace(ch, ":", "", -1)),
+	hosts = append(hosts,
 		filepath.Join(root, strings.Replace(host, ":", "", -1)),
-	}
+		filepath.Join(root, "_default"),
+	)
+
+	return
 }
 
 func rootSystemPool() (*x509.CertPool, error) {


### PR DESCRIPTION
Add support for an optional `default` registry hosts config, should no other hosts config match. Discussed in #7597 