### PR TITLE
s390x: build and package s390x bin in release assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,8 @@ jobs:
             goarch: ppc64le
           - goos: linux
             goarch: riscv64
+          - goos: linux
+            goarch: s390x
           - goos: freebsd
             goarch: amd64
           - goos: freebsd
@@ -194,6 +196,11 @@ jobs:
             packages+=" crossbuild-essential-riscv64"
             echo "CGO_ENABLED=1" >> $GITHUB_ENV
             echo "CC=riscv64-linux-gnu-gcc" >> $GITHUB_ENV
+            ;;
+          linux/s390x)
+            packages+=" crossbuild-essential-s390x"
+            echo "CGO_ENABLED=1" >> $GITHUB_ENV
+            echo "CC=s390x-linux-gnu-gcc" >> $GITHUB_ENV
             ;;
           windows/arm/v7)
             echo "CGO_ENABLED=0" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,8 @@ jobs:
             dockerfile-platform: linux/arm64
           - dockerfile-ubuntu: 18.04
             dockerfile-platform: linux/ppc64le
+          - dockerfile-ubuntu: 18.04
+            dockerfile-platform: linux/s390x
           # riscv64 isn't supported by Ubuntu 18.04
           - dockerfile-ubuntu: 22.04
             dockerfile-platform: linux/riscv64


### PR DESCRIPTION
Fix: #7612 , there is nightly build available for s390x, could we package it in release assets without testing same as other projects which are lack of s390x machine for testing? 

Signed-off-by: huoqifeng <huoqif@cn.ibm.com>