### PR TITLE
ctr export strictly matching

### DIFF
--- a/cmd/ctr/commands/images/export.go
+++ b/cmd/ctr/commands/images/export.go
@@ -80,7 +80,7 @@ When '--all-platforms' is given all images in a manifest list must be available.
 			}
 			exportOpts = append(exportOpts, archive.WithPlatform(platforms.Ordered(all...)))
 		} else {
-			exportOpts = append(exportOpts, archive.WithPlatform(platforms.Default()))
+			exportOpts = append(exportOpts, archive.WithPlatform(platforms.DefaultStrict()))
 		}
 
 		if context.Bool("all-platforms") {


### PR DESCRIPTION
When attempting to export an image without providing a specific platform(s)( eg: `ctr i export <output.tar> <image_ref>`) , ctr returns an error: ```ctr: content digest sha256:<hash>: not found``` . ctr exports default matcher [platforms.Default() ](https://github.com/containerd/containerd/blob/8167751f569c9374a6c3ef5b39a42629577a543a/platforms/defaults_unix.go#L39), uses the [Only()](https://github.com/containerd/containerd/blob/8167751f569c9374a6c3ef5b39a42629577a543a/platforms/compare.go#L94) match comparer which matches for a single platform and all its variants (IE linux/amd64 _and_ linux/386). The index/manifest list that is pulled when using ```ctr i pull <image_ref>```( without providing ```--all-platforms``` or `--platform` options) only pulls the platform that is relevant to the users machine(eg: only linux/amd64). Although the manifest contains references to different platforms only the default(host machines platform) content is pulled. The export function matches loosely against the different platformed manifests and as a result fails when attempting to retrieve manifest content that does not exist (eg: for an amd/64 machine the manifest for 386 does not exist for an image pulled, at least, without specifying it explicitly when pulling/using the all platforms option).


This commit changes the behavior to adopt strictly matching platform using [platforms.DefaultStrict()](https://github.com/containerd/containerd/blob/main/platforms/defaults.go)  which would match only with a single type of a platform (eg: only amd/64) using the [OnlyStrict()](https://github.com/containerd/containerd/blob/8167751f569c9374a6c3ef5b39a42629577a543a/platforms/compare.go#L106) match comparer when exporting without the `--platform`  or `--all-platform` options. This change is similar to that introduced in this PR- https://github.com/containerd/containerd/pull/6906 which addresses a similar bug for ctr import - https://github.com/containerd/containerd/issues/6441.

Fixes: #5895

Signed-off-by: Yasin Turan <turyasin@amazon.com>