### PR TITLE
Fix ctr crash when pulling with --http-dump and --http-trace simultaneously

### DIFF
--- a/cmd/ctr/commands/resolver.go
+++ b/cmd/ctr/commands/resolver.go
@@ -200,7 +200,12 @@ func NewDebugClientTrace(ctx gocontext.Context) *httptrace.ClientTrace {
 			}
 		},
 		GotConn: func(connInfo httptrace.GotConnInfo) {
-			log.G(ctx).WithField("reused", connInfo.Reused).WithField("remote_addr", connInfo.Conn.RemoteAddr().String()).Debugf("Connection successful")
+			remoteAddr := "<nil>"
+			if addr := connInfo.Conn.RemoteAddr(); addr != nil {
+				remoteAddr = addr.String()
+			}
+
+			log.G(ctx).WithField("reused", connInfo.Reused).WithField("remote_addr", remoteAddr).Debugf("Connection successful")
 		},
 	}
 }


### PR DESCRIPTION
This PR fixes ctr crash when pulling with `--http-dump` and `--http-trace` simultaneously.

```
❯ sudo -E ./bin/ctr images pull --http-dump --http-trace docker.io/library/nginx:latest
2022/11/01 16:27:47 Unsolicited response received on idle HTTP channel starting with "HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n"; err=<nil>
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x46debec]

goroutine 1 [running]:
github.com/containerd/containerd/cmd/ctr/commands.NewDebugClientTrace.func3({{0x4b62e90?, 0xc00048a3e0?}, 0x0?, 0x4a?, 0x0?})
	/Users/mxpv/Github/containerd/main/cmd/ctr/commands/resolver.go:203 +0x14c
net/http.(*Transport).getConn(0xc0003e8280, 0xc000494340, {{}, 0x0, {0x4a0496b, 0x4}, {0xc00016a090, 0x17}, 0x0})
	/usr/local/Cellar/go/1.19.1/libexec/src/net/http/transport.go:1381 +0x79c
net/http.(*Transport).roundTrip(0xc0003e8280, 0xc00023c200)
	/usr/local/Cellar/go/1.19.1/libexec/src/net/http/transport.go:582 +0x75e
net/http.(*Transport).RoundTrip(...)
	/usr/local/Cellar/go/1.19.1/libexec/src/net/http/roundtrip.go:17
net/http/httputil.DumpRequestOut(0xc00023c100, 0x0?)
	/usr/local/Cellar/go/1.19.1/libexec/src/net/http/httputil/dump.go:146 +0x737
github.com/containerd/containerd/cmd/ctr/commands.DebugTransport.RoundTrip({{0x4b585e0?, 0xc0003e8140?}, {0x4b583c0?, 0xc000014098?}}, 0x0?)
	/Users/mxpv/Github/containerd/main/cmd/ctr/commands/resolver.go:162 +0x5e
net/http.send(0xc00023c100, {0x4b572c0, 0xc00048a2c0}, {0x49edf20?, 0x1?, 0x0?})
	/usr/local/Cellar/go/1.19.1/libexec/src/net/http/client.go:251 +0x5f7
net/http.(*Client).send(0xc00048f560, 0xc00023c100, {0x2d4f9500?, 0x110?, 0x0?})
	/usr/local/Cellar/go/1.19.1/libexec/src/net/http/client.go:175 +0x9b
net/http.(*Client).do(0xc00048f560, 0xc00023c100)
	/usr/local/Cellar/go/1.19.1/libexec/src/net/http/client.go:715 +0x8fc
net/http.(*Client).Do(...)
	/usr/local/Cellar/go/1.19.1/libexec/src/net/http/client.go:581
github.com/containerd/containerd/remotes/docker.(*request).do(0xc0004a0990, {0x4b5ea68, 0xc00048f3b0})
	/Users/mxpv/Github/containerd/main/remotes/docker/resolver.go:570 +0x596
github.com/containerd/containerd/remotes/docker.(*request).doWithRetries(0x4b5ea68?, {0x4b5ea68, 0xc00048f3b0}, {0x0, 0x0, 0x0})
	/Users/mxpv/Github/containerd/main/remotes/docker/resolver.go:579 +0x4a
github.com/containerd/containerd/remotes/docker.(*dockerResolver).Resolve(0xc00048ebd0, {0x4b5e9c0, 0xc0004941c0}, {0x7ff7bfeff91f, 0x1e})
	/Users/mxpv/Github/containerd/main/remotes/docker/resolver.go:280 +0xcb3
github.com/containerd/containerd.(*Client).fetch(0xc0000131d0?, {0x4b5e9c0, 0xc0004941c0}, 0xc000481450, {0x7ff7bfeff91f, 0x1e}, _)
	/Users/mxpv/Github/containerd/main/pull.go:155 +0xeb
github.com/containerd/containerd.(*Client).Fetch(0x0?, {0x4b5e9c0, 0xc0004941c0}, {0x7ff7bfeff91f, 0x1e}, {0xc000494240, _, _})
	/Users/mxpv/Github/containerd/main/client.go:419 +0x5e5
github.com/containerd/containerd/cmd/ctr/commands/content.Fetch({0x4b5ea68, 0xc00048eb10}, 0xc00023d400, {0x7ff7bfeff91f, 0x1e}, 0xc0004a07e0)
	/Users/mxpv/Github/containerd/main/cmd/ctr/commands/content/fetch.go:209 +0x84d
github.com/containerd/containerd/cmd/ctr/commands/images.glob..func9(0xc000250dc0)
	/Users/mxpv/Github/containerd/main/cmd/ctr/commands/images/pull.go:95 +0x1e5
github.com/urfave/cli.HandleAction({0x48af660?, 0x4a60630?}, 0x4?)
	/Users/mxpv/Github/containerd/main/vendor/github.com/urfave/cli/app.go:524 +0x50
github.com/urfave/cli.Command.Run({{0x4a04af3, 0x4}, {0x0, 0x0}, {0x0, 0x0, 0x0}, {0x4a1ab00, 0x1b}, {0x0, ...}, ...}, ...)
	/Users/mxpv/Github/containerd/main/vendor/github.com/urfave/cli/command.go:173 +0x65b
github.com/urfave/cli.(*App).RunAsSubcommand(0xc0004336c0, 0xc000250b00)
	/Users/mxpv/Github/containerd/main/vendor/github.com/urfave/cli/app.go:405 +0x91b
github.com/urfave/cli.Command.startApp({{0x4a0660e, 0x6}, {0x0, 0x0}, {0x5123980, 0x2, 0x2}, {0x4a0d2ef, 0xd}, {0x0, ...}, ...}, ...)
	/Users/mxpv/Github/containerd/main/vendor/github.com/urfave/cli/command.go:378 +0x6e7
github.com/urfave/cli.Command.Run({{0x4a0660e, 0x6}, {0x0, 0x0}, {0x5123980, 0x2, 0x2}, {0x4a0d2ef, 0xd}, {0x0, ...}, ...}, ...)
	/Users/mxpv/Github/containerd/main/vendor/github.com/urfave/cli/command.go:102 +0x825
github.com/urfave/cli.(*App).Run(0xc000433500, {0xc0000361e0, 0x6, 0x6})
	/Users/mxpv/Github/containerd/main/vendor/github.com/urfave/cli/app.go:277 +0x8a7
main.main()
	/Users/mxpv/Github/containerd/main/cmd/ctr/main.go:37 +0x125
```

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>