### PR TITLE
image/label: print more characters of label keys

### DIFF
--- a/labels/validate.go
+++ b/labels/validate.go
@@ -24,15 +24,18 @@ import (
 
 const (
 	maxSize = 4096
+	// maximum length of key portion of error message if len of key + len of value > maxSize
+	keyMaxLen = 64
 )
 
 // Validate a label's key and value are under 4096 bytes
 func Validate(k, v string) error {
-	if (len(k) + len(v)) > maxSize {
-		if len(k) > 10 {
-			k = k[:10]
+	total := len(k) + len(v)
+	if total > maxSize {
+		if len(k) > keyMaxLen {
+			k = k[:keyMaxLen]
 		}
-		return fmt.Errorf("label key and value greater than maximum size (%d bytes), key: %s: %w", maxSize, k, errdefs.ErrInvalidArgument)
+		return fmt.Errorf("label key and value length (%d bytes) greater than maximum size (%d bytes), key: %s: %w", total, maxSize, k, errdefs.ErrInvalidArgument)
 	}
 	return nil
 }

--- a/labels/validate_test.go
+++ b/labels/validate_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/containerd/containerd/errdefs"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestValidLabels(t *testing.T) {
@@ -50,4 +51,30 @@ func TestInvalidLabels(t *testing.T) {
 			t.Fatal("error should be an invalid label error")
 		}
 	}
+}
+
+func TestLongKey(t *testing.T) {
+	key := strings.Repeat("s", keyMaxLen+1)
+	value := strings.Repeat("v", maxSize-len(key))
+
+	err := Validate(key, value)
+	assert.Equal(t, err, nil)
+
+	key = strings.Repeat("s", keyMaxLen+12)
+	value = strings.Repeat("v", maxSize-len(key)+1)
+
+	err = Validate(key, value)
+	assert.ErrorIs(t, err, errdefs.ErrInvalidArgument)
+
+	key = strings.Repeat("s", keyMaxLen-1)
+	value = strings.Repeat("v", maxSize-len(key))
+
+	err = Validate(key, value)
+	assert.Equal(t, err, nil)
+
+	key = strings.Repeat("s", keyMaxLen-1)
+	value = strings.Repeat("v", maxSize-len(key)-1)
+
+	err = Validate(key, value)
+	assert.Equal(t, err, nil)
 }


### PR DESCRIPTION
Like stargz and nydus remote snapshotter, some snapshots lables are introduced and passed to snapshotter from containerd automatically. The label keys' lengths are all longer than 10. Most of them are around 40-50 chars.

The limitation of 10 characters makes it harder to debug what label is not appropriate. So we'd better print more of the wrong label.

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>