### PR TITLE
CheckRuntime(): fix panic and simplify logic

### DIFF
--- a/client.go
+++ b/client.go
@@ -825,7 +825,7 @@ func CheckRuntime(current, expected string) bool {
 	cp := strings.Split(current, ".")
 	l := len(cp)
 	for i, p := range strings.Split(expected, ".") {
-		if i > l {
+		if i > l-1 {
 			return false
 		}
 		if p != cp[i] {

--- a/client.go
+++ b/client.go
@@ -818,21 +818,12 @@ func (c *Client) getSnapshotter(ctx context.Context, name string) (snapshots.Sna
 	return s, nil
 }
 
-// CheckRuntime returns true if the current runtime matches the expected
-// runtime. Providing various parts of the runtime schema will match those
-// parts of the expected runtime
-func CheckRuntime(current, expected string) bool {
-	cp := strings.Split(current, ".")
-	l := len(cp)
-	for i, p := range strings.Split(expected, ".") {
-		if i > l-1 {
-			return false
-		}
-		if p != cp[i] {
-			return false
-		}
+// CheckRuntime returns true if the current runtime matches the expected prefix.
+func CheckRuntime(current, prefix string) bool {
+	if current == "" || prefix == "" {
+		return false
 	}
-	return true
+	return current == prefix || strings.HasPrefix(current, strings.TrimSuffix(prefix, ".")+".")
 }
 
 // GetSnapshotterSupportedPlatforms returns a platform matchers which represents the

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,60 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package containerd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckRuntime(t *testing.T) {
+	tests := []struct {
+		current, prefix string
+		out             bool
+	}{
+		{current: "", prefix: ".", out: false},
+		{current: ".", prefix: "", out: true},
+		{current: "....b.c.d", prefix: "", out: true},
+		{current: "....b.c.d", prefix: ".", out: true},
+		{current: "a.b.c.d", prefix: "a.b.c", out: true},
+		{current: "a.b.c.d.", prefix: "a.b.c", out: true},
+		{current: "a.b.c", prefix: "a.b.c.d", out: false},
+		{current: "a.b.c", prefix: "a.b.c.d.", out: false},
+		{current: "a.b.c.", prefix: "a.b.c", out: true},
+		{current: "....", prefix: "....", out: true},
+		{current: "....", prefix: ".", out: true},
+		{current: "a....", prefix: "a", out: true},
+		{current: "a.b...", prefix: "a", out: true},
+		{current: "a..foo..bar...", prefix: "a", out: true},
+		{current: "", prefix: "io.containerd", out: false},
+		{current: "io.containerd", prefix: "", out: false},
+		{current: "io.containerd", prefix: "io", out: true},
+		{current: "io.containerd.runc", prefix: "io.containerd", out: true},
+		{current: "io.containerd.runc.v1", prefix: "io.containerd", out: true},
+		{current: "io.containerd", prefix: "io.containerd.runc", out: false},
+		{current: "io.containerd", prefix: "io.containerd.runc.v1", out: false},
+		{current: "io.containerdruncv1", prefix: "io.containerd", out: false},
+		{current: "io.containerd", prefix: "io.containerd", out: true},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.current+"/"+tc.prefix, func(t *testing.T) {
+			assert.Equal(t, tc.out, CheckRuntime(tc.current, tc.prefix))
+		})
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -28,8 +28,8 @@ func TestCheckRuntime(t *testing.T) {
 		out             bool
 	}{
 		{current: "", prefix: ".", out: false},
-		{current: ".", prefix: "", out: true},
-		{current: "....b.c.d", prefix: "", out: true},
+		{current: ".", prefix: "", out: false},
+		{current: "....b.c.d", prefix: "", out: false},
 		{current: "....b.c.d", prefix: ".", out: true},
 		{current: "a.b.c.d", prefix: "a.b.c", out: true},
 		{current: "a.b.c.d.", prefix: "a.b.c", out: true},

--- a/services/tasks/local.go
+++ b/services/tasks/local.go
@@ -817,19 +817,11 @@ func getRestorePath(runtime string, option *ptypes.Any) (string, error) {
 	return restorePath, nil
 }
 
-// checkRuntime returns true if the current runtime matches the expected
-// runtime. Providing various parts of the runtime schema will match those
-// parts of the expected runtime
-func checkRuntime(current, expected string) bool {
-	cp := strings.Split(current, ".")
-	l := len(cp)
-	for i, p := range strings.Split(expected, ".") {
-		if i > l {
-			return false
-		}
-		if p != cp[i] {
-			return false
-		}
+// checkRuntime returns true if the current runtime matches the expected prefix.
+// It is a copy of [github.com/containerd/containerd.CheckRuntime].
+func checkRuntime(current, prefix string) bool {
+	if current == "" || prefix == "" {
+		return false
 	}
-	return true
+	return current == prefix || strings.HasPrefix(current, strings.TrimSuffix(prefix, ".")+".")
 }


### PR DESCRIPTION
### CheckRuntime(): fix panic

There was an off-by-one error in the check, resulting in a panic if "expected" was longer than "current";

    CheckRuntime("a.b.c", "a.b.c.d")
    panic: runtime error: index out of range [3] with length 3

### CheckRuntime(): simplify logic

The intent of this function was to check if a given runtime has
the expected prefix. This patch updates the function to;

- disallow empty strings (either "current" or "expected")
- check for prefix or full match, making the code slightly more
  readable on intent.
- adds some more descriptive tests
