### PR TITLE
Fix: when a task is exiting, ctr delete container may failed with ErrTaskNotExists

### DIFF
--- a/cmd/ctr/commands/containers/containers.go
+++ b/cmd/ctr/commands/containers/containers.go
@@ -194,16 +194,21 @@ func deleteContainer(ctx context.Context, client *containerd.Client, id string, 
 	}
 	status, err := task.Status(ctx)
 	if err != nil {
+		if errdefs.IsNotFound(err) {
+			return container.Delete(ctx, opts...)
+		}
 		return err
 	}
 	if status.Status == containerd.Stopped || status.Status == containerd.Created {
 		if _, err := task.Delete(ctx); err != nil {
+			if errdefs.IsNotFound(err) {
+				return container.Delete(ctx, opts...)
+			}
 			return err
 		}
 		return container.Delete(ctx, opts...)
 	}
 	return fmt.Errorf("cannot delete a non stopped container: %v", status)
-
 }
 
 var setLabelsCommand = cli.Command{


### PR DESCRIPTION
When a task is exiting, ctr delete container may failed with ErrTaskNotExists.

Reproduce code
```
ctr -n k8s.io task kill f4acd86b00525da693ce50204d8746dbfd1b8d0b9b76c1178d61c29a6e3dfe63
ctr -n k8s.io c rm f4acd86b00525da693ce50204d8746dbfd1b8d0b9b76c1178d61c29a6e3dfe63
```

output:
```
time="2022-11-04T14:25:10+08:00" level=error msg="failed to delete container \"f4acd86b00525da693ce50204d8746dbfd1b8d0b9b76c1178d61c29a6e3dfe63\"" error="task f4acd86b00525da693ce50204d8746dbfd1b8d0b9b76c1178d61c29a6e3dfe63 not found: not found"
ctr: task f4acd86b00525da693ce50204d8746dbfd1b8d0b9b76c1178d61c29a6e3dfe63 not found: not found
```

In the `ctr` deleteContainer, it should ignore the not found error.