### PR TITLE
Remove uses of deprecated go-digest.NewDigestFromHex, go-digest.Digest.Hex

### DIFF
--- a/content/local/store.go
+++ b/content/local/store.go
@@ -262,7 +262,7 @@ func (s *store) Walk(ctx context.Context, fn content.WalkFunc, fs ...string) err
 			return nil
 		}
 
-		dgst := digest.NewDigestFromHex(alg.String(), filepath.Base(path))
+		dgst := digest.NewDigestFromEncoded(alg, filepath.Base(path))
 		if err := dgst.Validate(); err != nil {
 			// log error but don't report
 			log.L.WithError(err).WithField("path", path).Error("invalid digest for blob path")
@@ -628,14 +628,14 @@ func (s *store) blobPath(dgst digest.Digest) (string, error) {
 		return "", fmt.Errorf("cannot calculate blob path from invalid digest: %v: %w", err, errdefs.ErrInvalidArgument)
 	}
 
-	return filepath.Join(s.root, "blobs", dgst.Algorithm().String(), dgst.Hex()), nil
+	return filepath.Join(s.root, "blobs", dgst.Algorithm().String(), dgst.Encoded()), nil
 }
 
 func (s *store) ingestRoot(ref string) string {
 	// we take a digest of the ref to keep the ingest paths constant length.
 	// Note that this is not the current or potential digest of incoming content.
 	dgst := digest.FromString(ref)
-	return filepath.Join(s.root, "ingest", dgst.Hex())
+	return filepath.Join(s.root, "ingest", dgst.Encoded())
 }
 
 // ingestPaths are returned. The paths are the following:

--- a/content/local/store_test.go
+++ b/content/local/store_test.go
@@ -308,7 +308,7 @@ func checkBlobPath(t *testing.T, cs content.Store, dgst digest.Digest) string {
 		t.Fatalf("failed to calculate blob path: %v", err)
 	}
 
-	if path != filepath.Join(cs.(*store).root, "blobs", dgst.Algorithm().String(), dgst.Hex()) {
+	if path != filepath.Join(cs.(*store).root, "blobs", dgst.Algorithm().String(), dgst.Encoded()) {
 		t.Fatalf("unexpected path: %q", path)
 	}
 	fi, err := os.Stat(path)

--- a/contrib/fuzz/content_fuzzer.go
+++ b/contrib/fuzz/content_fuzzer.go
@@ -40,7 +40,7 @@ func checkBlobPath(dgst digest.Digest, root string) error {
 	if err := dgst.Validate(); err != nil {
 		return err
 	}
-	path := filepath.Join(root, "blobs", dgst.Algorithm().String(), dgst.Hex())
+	path := filepath.Join(root, "blobs", dgst.Algorithm().String(), dgst.Encoded())
 	_, err := os.Stat(path)
 	if err != nil {
 		return err


### PR DESCRIPTION
- relates to https://github.com/opencontainers/go-digest/pull/83

Both of these were deprecated in https://github.com/opencontainers/go-digest/commit/55f675811a1b915549933c64571fd86b2676ba76 (https://github.com/opencontainers/go-digest/pull/33), but the format of the GoDoc comments didn't follow the correct format, which caused them not being picked up by tools as "deprecated".

This patch updates uses in the codebase to use the alternatives.
