### PR TITLE
Add a thin wrapper around otel Span object

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -82,7 +82,6 @@ func clientWithTrace() error {
     defer cancel()
 
     ctx, span := tracing.StartSpan(ctx, "OPERATION NAME")
-    defer tracing.StopSpan(span)
+    defer span.End()
     ...
 }
-```

--- a/pkg/cri/sbserver/helpers.go
+++ b/pkg/cri/sbserver/helpers.go
@@ -97,9 +97,7 @@ const (
 	runtimeRunhcsV1 = "io.containerd.runhcs.v1"
 
 	// name prefix for CRI sbserver specific spans
-	criSbServerSpanPrefix = "pkg.cri.sbserver"
-
-	spanDelimiter = "."
+	criSpanPrefix = "pkg.cri.sbserver"
 )
 
 // makeSandboxName generates sandbox name from sandbox metadata. The name
@@ -505,11 +503,4 @@ func copyResourcesToStatus(spec *runtimespec.Spec, status containerstore.Status)
 		// TODO: Figure out how to get RootfsSizeInBytes
 	}
 	return status
-}
-
-func makeSpanName(funcName string) string {
-	return strings.Join([]string{
-		criSbServerSpanPrefix,
-		funcName,
-	}, spanDelimiter)
 }

--- a/pkg/cri/sbserver/image_pull.go
+++ b/pkg/cri/sbserver/image_pull.go
@@ -94,7 +94,7 @@ import (
 
 // PullImage pulls an image with authentication config.
 func (c *criService) PullImage(ctx context.Context, r *runtime.PullImageRequest) (*runtime.PullImageResponse, error) {
-	span := tracing.CurrentSpan(ctx)
+	span := tracing.SpanFromContext(ctx)
 	imageRef := r.GetImage().GetImage()
 	namedRef, err := distribution.ParseDockerRef(imageRef)
 	if err != nil {
@@ -136,8 +136,8 @@ func (c *criService) PullImage(ctx context.Context, r *runtime.PullImageRequest)
 	}
 	log.G(ctx).Debugf("PullImage %q with snapshotter %s", ref, snapshotter)
 	span.SetAttributes(
-		tracing.SpanAttribute("image.ref", ref),
-		tracing.SpanAttribute("snapshotter.name", snapshotter),
+		tracing.Attribute("image.ref", ref),
+		tracing.Attribute("snapshotter.name", snapshotter),
 	)
 
 	pullOpts := []containerd.RemoteOpt{

--- a/pkg/cri/sbserver/image_remove.go
+++ b/pkg/cri/sbserver/image_remove.go
@@ -34,7 +34,7 @@ import (
 // Remove the whole image no matter the it's image id or reference. This is the
 // semantic defined in CRI now.
 func (c *criService) RemoveImage(ctx context.Context, r *runtime.RemoveImageRequest) (*runtime.RemoveImageResponse, error) {
-	span := tracing.CurrentSpan(ctx)
+	span := tracing.SpanFromContext(ctx)
 	image, err := c.localResolve(r.GetImage().GetImage())
 	if err != nil {
 		if errdefs.IsNotFound(err) {
@@ -44,7 +44,7 @@ func (c *criService) RemoveImage(ctx context.Context, r *runtime.RemoveImageRequ
 		}
 		return nil, fmt.Errorf("can not resolve %q locally: %w", r.GetImage().GetImage(), err)
 	}
-	span.SetAttributes(tracing.SpanAttribute("image.id", image.ID))
+	span.SetAttributes(tracing.Attribute("image.id", image.ID))
 	// Remove all image references.
 	for i, ref := range image.References {
 		var opts []images.DeleteOpt

--- a/pkg/cri/sbserver/image_status.go
+++ b/pkg/cri/sbserver/image_status.go
@@ -34,7 +34,7 @@ import (
 // TODO(random-liu): We should change CRI to distinguish image id and image spec. (See
 // kubernetes/kubernetes#46255)
 func (c *criService) ImageStatus(ctx context.Context, r *runtime.ImageStatusRequest) (*runtime.ImageStatusResponse, error) {
-	span := tracing.CurrentSpan(ctx)
+	span := tracing.SpanFromContext(ctx)
 	image, err := c.localResolve(r.GetImage().GetImage())
 	if err != nil {
 		if errdefs.IsNotFound(err) {
@@ -44,7 +44,7 @@ func (c *criService) ImageStatus(ctx context.Context, r *runtime.ImageStatusRequ
 		}
 		return nil, fmt.Errorf("can not resolve %q locally: %w", r.GetImage().GetImage(), err)
 	}
-	span.SetAttributes(tracing.SpanAttribute("image.id", image.ID))
+	span.SetAttributes(tracing.Attribute("image.id", image.ID))
 	// TODO(random-liu): [P0] Make sure corresponding snapshot exists. What if snapshot
 	// doesn't exist?
 

--- a/pkg/cri/sbserver/instrumented_service.go
+++ b/pkg/cri/sbserver/instrumented_service.go
@@ -932,8 +932,8 @@ func (in *instrumentedService) PullImage(ctx context.Context, r *runtime.PullIma
 	if err := in.checkInitialized(); err != nil {
 		return nil, err
 	}
-	ctx, span := tracing.StartSpan(ctx, makeSpanName("PullImage"))
-	defer tracing.StopSpan(span)
+	ctx, span := tracing.StartSpan(ctx, tracing.Name(criSpanPrefix, "PullImage"))
+	defer span.End()
 	log.G(ctx).Infof("PullImage %q", r.GetImage().GetImage())
 	defer func() {
 		if err != nil {
@@ -942,7 +942,7 @@ func (in *instrumentedService) PullImage(ctx context.Context, r *runtime.PullIma
 			log.G(ctx).Infof("PullImage %q returns image reference %q",
 				r.GetImage().GetImage(), res.GetImageRef())
 		}
-		tracing.SetSpanStatus(span, err)
+		span.SetStatus(err)
 	}()
 	res, err = in.c.PullImage(ctrdutil.WithNamespace(ctx), r)
 	return res, errdefs.ToGRPC(err)
@@ -952,8 +952,8 @@ func (in *instrumentedAlphaService) PullImage(ctx context.Context, r *runtime_al
 	if err := in.checkInitialized(); err != nil {
 		return nil, err
 	}
-	ctx, span := tracing.StartSpan(ctx, makeSpanName("PullImage"))
-	defer tracing.StopSpan(span)
+	ctx, span := tracing.StartSpan(ctx, tracing.Name(criSpanPrefix, "PullImage"))
+	defer span.End()
 	log.G(ctx).Infof("PullImage %q", r.GetImage().GetImage())
 	defer func() {
 		if err != nil {
@@ -962,7 +962,7 @@ func (in *instrumentedAlphaService) PullImage(ctx context.Context, r *runtime_al
 			log.G(ctx).Infof("PullImage %q returns image reference %q",
 				r.GetImage().GetImage(), res.GetImageRef())
 		}
-		tracing.SetSpanStatus(span, err)
+		span.SetStatus(err)
 	}()
 	// converts request and response for earlier CRI version to call and get response from the current version
 	var v1r runtime.PullImageRequest
@@ -993,8 +993,8 @@ func (in *instrumentedService) ListImages(ctx context.Context, r *runtime.ListIm
 	if err := in.checkInitialized(); err != nil {
 		return nil, err
 	}
-	ctx, span := tracing.StartSpan(ctx, makeSpanName("ListImages"))
-	defer tracing.StopSpan(span)
+	ctx, span := tracing.StartSpan(ctx, tracing.Name(criSpanPrefix, "ListImages"))
+	defer span.End()
 	log.G(ctx).Tracef("ListImages with filter %+v", r.GetFilter())
 	defer func() {
 		if err != nil {
@@ -1003,7 +1003,7 @@ func (in *instrumentedService) ListImages(ctx context.Context, r *runtime.ListIm
 			log.G(ctx).Tracef("ListImages with filter %+v returns image list %+v",
 				r.GetFilter(), res.GetImages())
 		}
-		tracing.SetSpanStatus(span, err)
+		span.SetStatus(err)
 	}()
 	res, err = in.c.ListImages(ctrdutil.WithNamespace(ctx), r)
 	return res, errdefs.ToGRPC(err)
@@ -1013,8 +1013,8 @@ func (in *instrumentedAlphaService) ListImages(ctx context.Context, r *runtime_a
 	if err := in.checkInitialized(); err != nil {
 		return nil, err
 	}
-	ctx, span := tracing.StartSpan(ctx, makeSpanName("ListImages"))
-	defer tracing.StopSpan(span)
+	ctx, span := tracing.StartSpan(ctx, tracing.Name(criSpanPrefix, "ListImages"))
+	defer span.End()
 	log.G(ctx).Tracef("ListImages with filter %+v", r.GetFilter())
 	defer func() {
 		if err != nil {
@@ -1023,7 +1023,7 @@ func (in *instrumentedAlphaService) ListImages(ctx context.Context, r *runtime_a
 			log.G(ctx).Tracef("ListImages with filter %+v returns image list %+v",
 				r.GetFilter(), res.GetImages())
 		}
-		tracing.SetSpanStatus(span, err)
+		span.SetStatus(err)
 	}()
 	// converts request and response for earlier CRI version to call and get response from the current version
 	var v1r runtime.ListImagesRequest
@@ -1054,8 +1054,8 @@ func (in *instrumentedService) ImageStatus(ctx context.Context, r *runtime.Image
 	if err := in.checkInitialized(); err != nil {
 		return nil, err
 	}
-	ctx, span := tracing.StartSpan(ctx, makeSpanName("ImageStatus"))
-	defer tracing.StopSpan(span)
+	ctx, span := tracing.StartSpan(ctx, tracing.Name(criSpanPrefix, "ImageStatus"))
+	defer span.End()
 	log.G(ctx).Tracef("ImageStatus for %q", r.GetImage().GetImage())
 	defer func() {
 		if err != nil {
@@ -1064,7 +1064,7 @@ func (in *instrumentedService) ImageStatus(ctx context.Context, r *runtime.Image
 			log.G(ctx).Tracef("ImageStatus for %q returns image status %+v",
 				r.GetImage().GetImage(), res.GetImage())
 		}
-		tracing.SetSpanStatus(span, err)
+		span.SetStatus(err)
 	}()
 	res, err = in.c.ImageStatus(ctrdutil.WithNamespace(ctx), r)
 	return res, errdefs.ToGRPC(err)
@@ -1074,8 +1074,8 @@ func (in *instrumentedAlphaService) ImageStatus(ctx context.Context, r *runtime_
 	if err := in.checkInitialized(); err != nil {
 		return nil, err
 	}
-	ctx, span := tracing.StartSpan(ctx, makeSpanName("ImageStatus"))
-	defer tracing.StopSpan(span)
+	ctx, span := tracing.StartSpan(ctx, tracing.Name(criSpanPrefix, "ImageStatus"))
+	defer span.End()
 	log.G(ctx).Tracef("ImageStatus for %q", r.GetImage().GetImage())
 	defer func() {
 		if err != nil {
@@ -1084,7 +1084,7 @@ func (in *instrumentedAlphaService) ImageStatus(ctx context.Context, r *runtime_
 			log.G(ctx).Tracef("ImageStatus for %q returns image status %+v",
 				r.GetImage().GetImage(), res.GetImage())
 		}
-		tracing.SetSpanStatus(span, err)
+		span.SetStatus(err)
 	}()
 	// converts request and response for earlier CRI version to call and get response from the current version
 	var v1r runtime.ImageStatusRequest
@@ -1115,8 +1115,8 @@ func (in *instrumentedService) RemoveImage(ctx context.Context, r *runtime.Remov
 	if err := in.checkInitialized(); err != nil {
 		return nil, err
 	}
-	ctx, span := tracing.StartSpan(ctx, makeSpanName("RemoveImage"))
-	defer tracing.StopSpan(span)
+	ctx, span := tracing.StartSpan(ctx, tracing.Name(criSpanPrefix, "RemoveImage"))
+	defer span.End()
 	log.G(ctx).Infof("RemoveImage %q", r.GetImage().GetImage())
 	defer func() {
 		if err != nil {
@@ -1124,7 +1124,7 @@ func (in *instrumentedService) RemoveImage(ctx context.Context, r *runtime.Remov
 		} else {
 			log.G(ctx).Infof("RemoveImage %q returns successfully", r.GetImage().GetImage())
 		}
-		tracing.SetSpanStatus(span, err)
+		span.SetStatus(err)
 	}()
 	res, err := in.c.RemoveImage(ctrdutil.WithNamespace(ctx), r)
 	return res, errdefs.ToGRPC(err)
@@ -1134,8 +1134,8 @@ func (in *instrumentedAlphaService) RemoveImage(ctx context.Context, r *runtime_
 	if err := in.checkInitialized(); err != nil {
 		return nil, err
 	}
-	ctx, span := tracing.StartSpan(ctx, makeSpanName("RemoveImage"))
-	defer tracing.StopSpan(span)
+	ctx, span := tracing.StartSpan(ctx, tracing.Name(criSpanPrefix, "RemoveImage"))
+	defer span.End()
 	log.G(ctx).Infof("RemoveImage %q", r.GetImage().GetImage())
 	defer func() {
 		if err != nil {
@@ -1143,7 +1143,7 @@ func (in *instrumentedAlphaService) RemoveImage(ctx context.Context, r *runtime_
 		} else {
 			log.G(ctx).Infof("RemoveImage %q returns successfully", r.GetImage().GetImage())
 		}
-		tracing.SetSpanStatus(span, err)
+		span.SetStatus(err)
 	}()
 	// converts request and response for earlier CRI version to call and get response from the current version
 	var v1r runtime.RemoveImageRequest
@@ -1174,8 +1174,8 @@ func (in *instrumentedService) ImageFsInfo(ctx context.Context, r *runtime.Image
 	if err := in.checkInitialized(); err != nil {
 		return nil, err
 	}
-	ctx, span := tracing.StartSpan(ctx, makeSpanName("ImageFsInfo"))
-	defer tracing.StopSpan(span)
+	ctx, span := tracing.StartSpan(ctx, tracing.Name(criSpanPrefix, "ImageFsInfo"))
+	defer span.End()
 	log.G(ctx).Debugf("ImageFsInfo")
 	defer func() {
 		if err != nil {
@@ -1183,7 +1183,7 @@ func (in *instrumentedService) ImageFsInfo(ctx context.Context, r *runtime.Image
 		} else {
 			log.G(ctx).Debugf("ImageFsInfo returns filesystem info %+v", res.ImageFilesystems)
 		}
-		tracing.SetSpanStatus(span, err)
+		span.SetStatus(err)
 	}()
 	res, err = in.c.ImageFsInfo(ctrdutil.WithNamespace(ctx), r)
 	return res, errdefs.ToGRPC(err)
@@ -1193,8 +1193,8 @@ func (in *instrumentedAlphaService) ImageFsInfo(ctx context.Context, r *runtime_
 	if err := in.checkInitialized(); err != nil {
 		return nil, err
 	}
-	ctx, span := tracing.StartSpan(ctx, makeSpanName("ImageFsInfo"))
-	defer tracing.StopSpan(span)
+	ctx, span := tracing.StartSpan(ctx, tracing.Name(criSpanPrefix, "ImageFsInfo"))
+	defer span.End()
 	log.G(ctx).Debugf("ImageFsInfo")
 	defer func() {
 		if err != nil {
@@ -1202,7 +1202,7 @@ func (in *instrumentedAlphaService) ImageFsInfo(ctx context.Context, r *runtime_
 		} else {
 			log.G(ctx).Debugf("ImageFsInfo returns filesystem info %+v", res.ImageFilesystems)
 		}
-		tracing.SetSpanStatus(span, err)
+		span.SetStatus(err)
 	}()
 	// converts request and response for earlier CRI version to call and get response from the current version
 	var v1r runtime.ImageFsInfoRequest

--- a/pkg/cri/server/helpers.go
+++ b/pkg/cri/server/helpers.go
@@ -94,9 +94,7 @@ const (
 	runtimeRunhcsV1 = "io.containerd.runhcs.v1"
 
 	// name prefix for CRI server specific spans
-	criServerSpanPrefix = "pkg.cri.server"
-
-	spanDelimiter = "."
+	criSpanPrefix = "pkg.cri.server"
 )
 
 // makeSandboxName generates sandbox name from sandbox metadata. The name
@@ -514,11 +512,4 @@ func copyResourcesToStatus(spec *runtimespec.Spec, status containerstore.Status)
 		// TODO: Figure out how to get RootfsSizeInBytes
 	}
 	return status
-}
-
-func makeSpanName(funcName string) string {
-	return strings.Join([]string{
-		criServerSpanPrefix,
-		funcName,
-	}, spanDelimiter)
 }

--- a/pkg/cri/server/image_pull.go
+++ b/pkg/cri/server/image_pull.go
@@ -94,7 +94,7 @@ import (
 
 // PullImage pulls an image with authentication config.
 func (c *criService) PullImage(ctx context.Context, r *runtime.PullImageRequest) (*runtime.PullImageResponse, error) {
-	span := tracing.CurrentSpan(ctx)
+	span := tracing.SpanFromContext(ctx)
 	imageRef := r.GetImage().GetImage()
 	namedRef, err := distribution.ParseDockerRef(imageRef)
 	if err != nil {
@@ -136,8 +136,8 @@ func (c *criService) PullImage(ctx context.Context, r *runtime.PullImageRequest)
 	}
 	log.G(ctx).Debugf("PullImage %q with snapshotter %s", ref, snapshotter)
 	span.SetAttributes(
-		tracing.SpanAttribute("image.ref", ref),
-		tracing.SpanAttribute("snapshotter.name", snapshotter),
+		tracing.Attribute("image.ref", ref),
+		tracing.Attribute("snapshotter.name", snapshotter),
 	)
 	pullOpts := []containerd.RemoteOpt{
 		containerd.WithSchema1Conversion, //nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.

--- a/pkg/cri/server/image_remove.go
+++ b/pkg/cri/server/image_remove.go
@@ -34,7 +34,7 @@ import (
 // Remove the whole image no matter the it's image id or reference. This is the
 // semantic defined in CRI now.
 func (c *criService) RemoveImage(ctx context.Context, r *runtime.RemoveImageRequest) (*runtime.RemoveImageResponse, error) {
-	span := tracing.CurrentSpan(ctx)
+	span := tracing.SpanFromContext(ctx)
 	image, err := c.localResolve(r.GetImage().GetImage())
 	if err != nil {
 		if errdefs.IsNotFound(err) {
@@ -44,7 +44,7 @@ func (c *criService) RemoveImage(ctx context.Context, r *runtime.RemoveImageRequ
 		}
 		return nil, fmt.Errorf("can not resolve %q locally: %w", r.GetImage().GetImage(), err)
 	}
-	span.SetAttributes(tracing.SpanAttribute("image.id", image.ID))
+	span.SetAttributes(tracing.Attribute("image.id", image.ID))
 	// Remove all image references.
 	for i, ref := range image.References {
 		var opts []images.DeleteOpt

--- a/pkg/cri/server/image_status.go
+++ b/pkg/cri/server/image_status.go
@@ -34,7 +34,7 @@ import (
 // TODO(random-liu): We should change CRI to distinguish image id and image spec. (See
 // kubernetes/kubernetes#46255)
 func (c *criService) ImageStatus(ctx context.Context, r *runtime.ImageStatusRequest) (*runtime.ImageStatusResponse, error) {
-	span := tracing.CurrentSpan(ctx)
+	span := tracing.SpanFromContext(ctx)
 	image, err := c.localResolve(r.GetImage().GetImage())
 	if err != nil {
 		if errdefs.IsNotFound(err) {
@@ -44,7 +44,7 @@ func (c *criService) ImageStatus(ctx context.Context, r *runtime.ImageStatusRequ
 		}
 		return nil, fmt.Errorf("can not resolve %q locally: %w", r.GetImage().GetImage(), err)
 	}
-	span.SetAttributes(tracing.SpanAttribute("image.id", image.ID))
+	span.SetAttributes(tracing.Attribute("image.id", image.ID))
 	// TODO(random-liu): [P0] Make sure corresponding snapshot exists. What if snapshot
 	// doesn't exist?
 

--- a/pkg/cri/server/instrumented_service.go
+++ b/pkg/cri/server/instrumented_service.go
@@ -932,8 +932,8 @@ func (in *instrumentedService) PullImage(ctx context.Context, r *runtime.PullIma
 	if err := in.checkInitialized(); err != nil {
 		return nil, err
 	}
-	ctx, span := tracing.StartSpan(ctx, makeSpanName("PullImage"))
-	defer tracing.StopSpan(span)
+	ctx, span := tracing.StartSpan(ctx, tracing.Name(criSpanPrefix, "PullImage"))
+	defer span.End()
 	log.G(ctx).Infof("PullImage %q", r.GetImage().GetImage())
 	defer func() {
 		if err != nil {
@@ -942,7 +942,7 @@ func (in *instrumentedService) PullImage(ctx context.Context, r *runtime.PullIma
 			log.G(ctx).Infof("PullImage %q returns image reference %q",
 				r.GetImage().GetImage(), res.GetImageRef())
 		}
-		tracing.SetSpanStatus(span, err)
+		span.SetStatus(err)
 	}()
 	res, err = in.c.PullImage(ctrdutil.WithNamespace(ctx), r)
 	return res, errdefs.ToGRPC(err)
@@ -952,8 +952,8 @@ func (in *instrumentedAlphaService) PullImage(ctx context.Context, r *runtime_al
 	if err := in.checkInitialized(); err != nil {
 		return nil, err
 	}
-	ctx, span := tracing.StartSpan(ctx, makeSpanName("PullImage"))
-	defer tracing.StopSpan(span)
+	ctx, span := tracing.StartSpan(ctx, tracing.Name(criSpanPrefix, "PullImage"))
+	defer span.End()
 	log.G(ctx).Infof("PullImage %q", r.GetImage().GetImage())
 	defer func() {
 		if err != nil {
@@ -962,7 +962,7 @@ func (in *instrumentedAlphaService) PullImage(ctx context.Context, r *runtime_al
 			log.G(ctx).Infof("PullImage %q returns image reference %q",
 				r.GetImage().GetImage(), res.GetImageRef())
 		}
-		tracing.SetSpanStatus(span, err)
+		span.SetStatus(err)
 	}()
 	// converts request and response for earlier CRI version to call and get response from the current version
 	var v1r runtime.PullImageRequest
@@ -993,8 +993,8 @@ func (in *instrumentedService) ListImages(ctx context.Context, r *runtime.ListIm
 	if err := in.checkInitialized(); err != nil {
 		return nil, err
 	}
-	ctx, span := tracing.StartSpan(ctx, makeSpanName("ListImages"))
-	defer tracing.StopSpan(span)
+	ctx, span := tracing.StartSpan(ctx, tracing.Name(criSpanPrefix, "ListImages"))
+	defer span.End()
 	log.G(ctx).Tracef("ListImages with filter %+v", r.GetFilter())
 	defer func() {
 		if err != nil {
@@ -1003,7 +1003,7 @@ func (in *instrumentedService) ListImages(ctx context.Context, r *runtime.ListIm
 			log.G(ctx).Tracef("ListImages with filter %+v returns image list %+v",
 				r.GetFilter(), res.GetImages())
 		}
-		tracing.SetSpanStatus(span, err)
+		span.SetStatus(err)
 	}()
 	res, err = in.c.ListImages(ctrdutil.WithNamespace(ctx), r)
 	return res, errdefs.ToGRPC(err)
@@ -1013,8 +1013,8 @@ func (in *instrumentedAlphaService) ListImages(ctx context.Context, r *runtime_a
 	if err := in.checkInitialized(); err != nil {
 		return nil, err
 	}
-	ctx, span := tracing.StartSpan(ctx, makeSpanName("ListImages"))
-	defer tracing.StopSpan(span)
+	ctx, span := tracing.StartSpan(ctx, tracing.Name(criSpanPrefix, "ListImages"))
+	defer span.End()
 	log.G(ctx).Tracef("ListImages with filter %+v", r.GetFilter())
 	defer func() {
 		if err != nil {
@@ -1023,7 +1023,7 @@ func (in *instrumentedAlphaService) ListImages(ctx context.Context, r *runtime_a
 			log.G(ctx).Tracef("ListImages with filter %+v returns image list %+v",
 				r.GetFilter(), res.GetImages())
 		}
-		tracing.SetSpanStatus(span, err)
+		span.SetStatus(err)
 	}()
 	// converts request and response for earlier CRI version to call and get response from the current version
 	var v1r runtime.ListImagesRequest
@@ -1054,8 +1054,8 @@ func (in *instrumentedService) ImageStatus(ctx context.Context, r *runtime.Image
 	if err := in.checkInitialized(); err != nil {
 		return nil, err
 	}
-	ctx, span := tracing.StartSpan(ctx, makeSpanName("ImageStatus"))
-	defer tracing.StopSpan(span)
+	ctx, span := tracing.StartSpan(ctx, tracing.Name(criSpanPrefix, "ImageStatus"))
+	defer span.End()
 	log.G(ctx).Tracef("ImageStatus for %q", r.GetImage().GetImage())
 	defer func() {
 		if err != nil {
@@ -1064,7 +1064,7 @@ func (in *instrumentedService) ImageStatus(ctx context.Context, r *runtime.Image
 			log.G(ctx).Tracef("ImageStatus for %q returns image status %+v",
 				r.GetImage().GetImage(), res.GetImage())
 		}
-		tracing.SetSpanStatus(span, err)
+		span.SetStatus(err)
 	}()
 	res, err = in.c.ImageStatus(ctrdutil.WithNamespace(ctx), r)
 	return res, errdefs.ToGRPC(err)
@@ -1074,8 +1074,8 @@ func (in *instrumentedAlphaService) ImageStatus(ctx context.Context, r *runtime_
 	if err := in.checkInitialized(); err != nil {
 		return nil, err
 	}
-	ctx, span := tracing.StartSpan(ctx, makeSpanName("ImageStatus"))
-	defer tracing.StopSpan(span)
+	ctx, span := tracing.StartSpan(ctx, tracing.Name(criSpanPrefix, "ImageStatus"))
+	defer span.End()
 	log.G(ctx).Tracef("ImageStatus for %q", r.GetImage().GetImage())
 	defer func() {
 		if err != nil {
@@ -1084,7 +1084,7 @@ func (in *instrumentedAlphaService) ImageStatus(ctx context.Context, r *runtime_
 			log.G(ctx).Tracef("ImageStatus for %q returns image status %+v",
 				r.GetImage().GetImage(), res.GetImage())
 		}
-		tracing.SetSpanStatus(span, err)
+		span.SetStatus(err)
 	}()
 	// converts request and response for earlier CRI version to call and get response from the current version
 	var v1r runtime.ImageStatusRequest
@@ -1115,8 +1115,8 @@ func (in *instrumentedService) RemoveImage(ctx context.Context, r *runtime.Remov
 	if err := in.checkInitialized(); err != nil {
 		return nil, err
 	}
-	ctx, span := tracing.StartSpan(ctx, makeSpanName("RemoveImage"))
-	defer tracing.StopSpan(span)
+	ctx, span := tracing.StartSpan(ctx, tracing.Name(criSpanPrefix, "RemoveImage"))
+	defer span.End()
 	log.G(ctx).Infof("RemoveImage %q", r.GetImage().GetImage())
 	defer func() {
 		if err != nil {
@@ -1124,7 +1124,7 @@ func (in *instrumentedService) RemoveImage(ctx context.Context, r *runtime.Remov
 		} else {
 			log.G(ctx).Infof("RemoveImage %q returns successfully", r.GetImage().GetImage())
 		}
-		tracing.SetSpanStatus(span, err)
+		span.SetStatus(err)
 	}()
 	res, err := in.c.RemoveImage(ctrdutil.WithNamespace(ctx), r)
 	return res, errdefs.ToGRPC(err)
@@ -1134,8 +1134,8 @@ func (in *instrumentedAlphaService) RemoveImage(ctx context.Context, r *runtime_
 	if err := in.checkInitialized(); err != nil {
 		return nil, err
 	}
-	ctx, span := tracing.StartSpan(ctx, makeSpanName("RemoveImage"))
-	defer tracing.StopSpan(span)
+	ctx, span := tracing.StartSpan(ctx, tracing.Name(criSpanPrefix, "RemoveImage"))
+	defer span.End()
 	log.G(ctx).Infof("RemoveImage %q", r.GetImage().GetImage())
 	defer func() {
 		if err != nil {
@@ -1143,7 +1143,7 @@ func (in *instrumentedAlphaService) RemoveImage(ctx context.Context, r *runtime_
 		} else {
 			log.G(ctx).Infof("RemoveImage %q returns successfully", r.GetImage().GetImage())
 		}
-		tracing.SetSpanStatus(span, err)
+		span.SetStatus(err)
 	}()
 	// converts request and response for earlier CRI version to call and get response from the current version
 	var v1r runtime.RemoveImageRequest
@@ -1174,8 +1174,8 @@ func (in *instrumentedService) ImageFsInfo(ctx context.Context, r *runtime.Image
 	if err := in.checkInitialized(); err != nil {
 		return nil, err
 	}
-	ctx, span := tracing.StartSpan(ctx, makeSpanName("ImageFsInfo"))
-	defer tracing.StopSpan(span)
+	ctx, span := tracing.StartSpan(ctx, tracing.Name(criSpanPrefix, "ImageFsInfo"))
+	defer span.End()
 	log.G(ctx).Debugf("ImageFsInfo")
 	defer func() {
 		if err != nil {
@@ -1183,7 +1183,7 @@ func (in *instrumentedService) ImageFsInfo(ctx context.Context, r *runtime.Image
 		} else {
 			log.G(ctx).Debugf("ImageFsInfo returns filesystem info %+v", res.ImageFilesystems)
 		}
-		tracing.SetSpanStatus(span, err)
+		span.SetStatus(err)
 	}()
 	res, err = in.c.ImageFsInfo(ctrdutil.WithNamespace(ctx), r)
 	return res, errdefs.ToGRPC(err)
@@ -1193,8 +1193,8 @@ func (in *instrumentedAlphaService) ImageFsInfo(ctx context.Context, r *runtime_
 	if err := in.checkInitialized(); err != nil {
 		return nil, err
 	}
-	ctx, span := tracing.StartSpan(ctx, makeSpanName("ImageFsInfo"))
-	defer tracing.StopSpan(span)
+	ctx, span := tracing.StartSpan(ctx, tracing.Name(criSpanPrefix, "ImageFsInfo"))
+	defer span.End()
 	log.G(ctx).Debugf("ImageFsInfo")
 	defer func() {
 		if err != nil {
@@ -1202,7 +1202,7 @@ func (in *instrumentedAlphaService) ImageFsInfo(ctx context.Context, r *runtime_
 		} else {
 			log.G(ctx).Debugf("ImageFsInfo returns filesystem info %+v", res.ImageFilesystems)
 		}
-		tracing.SetSpanStatus(span, err)
+		span.SetStatus(err)
 	}()
 	// converts request and response for earlier CRI version to call and get response from the current version
 	var v1r runtime.ImageFsInfoRequest

--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -571,18 +571,18 @@ func (r *request) do(ctx context.Context) (*http.Response, error) {
 	}
 	_, httpSpan := tracing.StartSpan(
 		ctx,
-		"remotes.docker.resolver.HTTPRequest",
+		tracing.Name("remotes.docker.resolver", "HTTPRequest"),
 		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
 		oteltrace.WithAttributes(semconv.HTTPClientAttributesFromHTTPRequest(req)...),
 	)
 	resp, err := client.Do(req)
 	if err != nil {
-		httpSpan.RecordError(err)
-		tracing.StopSpan(httpSpan)
+		httpSpan.SetStatus(err)
+		httpSpan.End()
 		return nil, fmt.Errorf("failed to do request: %w", err)
 	}
 	httpSpan.SetAttributes(semconv.HTTPAttributesFromHTTPStatusCode(resp.StatusCode)...)
-	tracing.StopSpan(httpSpan)
+	httpSpan.End()
 	log.G(ctx).WithFields(responseFields(resp)).Debug("fetch response received")
 	return resp, nil
 }

--- a/tracing/helpers.go
+++ b/tracing/helpers.go
@@ -19,9 +19,18 @@ package tracing
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"go.opentelemetry.io/otel/attribute"
 )
+
+const (
+	spanDelimiter = "."
+)
+
+func makeSpanName(names ...string) string {
+	return strings.Join(names, spanDelimiter)
+}
 
 func any(k string, v interface{}) attribute.KeyValue {
 	if v == nil {

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -25,35 +25,62 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// StartSpan starts child span in a context.
-func StartSpan(ctx context.Context, opName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+// StartSan starts child span in a context.
+func StartSpan(ctx context.Context, opName string, opts ...trace.SpanStartOption) (context.Context, *Span) {
+	tracer := otel.Tracer("")
 	if parent := trace.SpanFromContext(ctx); parent != nil && parent.SpanContext().IsValid() {
-		return parent.TracerProvider().Tracer("").Start(ctx, opName, opts...)
+		tracer = parent.TracerProvider().Tracer("")
 	}
-	return otel.Tracer("").Start(ctx, opName, opts...)
+	ctx, span := tracer.Start(ctx, opName, opts...)
+	return ctx, &Span{otelSpan: span}
 }
 
-// StopSpan ends the span specified
-func StopSpan(span trace.Span) {
-	span.End()
+// SpanFromContext returns the current Span from the context.
+func SpanFromContext(ctx context.Context) *Span {
+	return &Span{
+		otelSpan: trace.SpanFromContext(ctx),
+	}
 }
 
-// CurrentSpan returns current span from context or noopSpan if no span exists.
-func CurrentSpan(ctx context.Context) trace.Span {
-	return trace.SpanFromContext(ctx)
+// Span is wrapper around otel trace.Span.
+// Span is the individual component of a trace. It represents a
+// single named and timed operation of a workflow that is traced.
+type Span struct {
+	otelSpan trace.Span
+}
+
+// End completes the span.
+func (s *Span) End() {
+	s.otelSpan.End()
+}
+
+// AddEvent adds an event with provided name and options.
+func (s *Span) AddEvent(name string, options ...trace.EventOption) {
+	s.otelSpan.AddEvent(name, options...)
 }
 
 // SetSpanStatus sets the status of the current span.
 // If an error is encountered, it records the error and sets span status to Error.
-func SetSpanStatus(span trace.Span, err error) {
+func (s *Span) SetStatus(err error) {
 	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
+		s.otelSpan.RecordError(err)
+		s.otelSpan.SetStatus(codes.Error, err.Error())
 	} else {
-		span.SetStatus(codes.Ok, "")
+		s.otelSpan.SetStatus(codes.Ok, "")
 	}
 }
 
-func SpanAttribute(k string, v interface{}) attribute.KeyValue {
+// SetAttributes sets kv as attributes of the span.
+func (s *Span) SetAttributes(kv ...attribute.KeyValue) {
+	s.otelSpan.SetAttributes(kv...)
+}
+
+// Name sets the span name by joining a list of strings in dot separated format.
+func Name(names ...string) string {
+	return makeSpanName(names...)
+}
+
+// Attribute takes a key value pair and returns attribute.KeyValue type.
+func Attribute(k string, v interface{}) attribute.KeyValue {
 	return any(k, v)
 }


### PR DESCRIPTION
Follow up to the one of the comments in https://github.com/containerd/containerd/pull/7453#discussion_r1012470485

This PR wraps the otel Span object and implements related methods which is used during tracing instrumentation.

Also, adds a new SpanName method as discussed in https://github.com/containerd/containerd to add a common seaprator in span names /pull/7453#discussion_r1012469550 

Signed-off-by: Swagat Bora <sbora@amazon.com>