### PR TITLE
Fix slice append error (`spec.Linux.Resources.HugepageLimits`)

### DIFF
--- a/pkg/cri/server/helpers.go
+++ b/pkg/cri/server/helpers.go
@@ -474,7 +474,7 @@ func copyResourcesToStatus(spec *runtimespec.Spec, status containerstore.Status)
 		}
 
 		if spec.Linux.Resources.HugepageLimits != nil {
-			hugepageLimits := make([]*runtime.HugepageLimit, len(spec.Linux.Resources.HugepageLimits))
+			hugepageLimits := make([]*runtime.HugepageLimit, 0)
 			for _, l := range spec.Linux.Resources.HugepageLimits {
 				hugepageLimits = append(hugepageLimits, &runtime.HugepageLimit{
 					PageSize: l.Pagesize,

--- a/pkg/cri/store/container/status.go
+++ b/pkg/cri/store/container/status.go
@@ -219,7 +219,7 @@ func deepCopyOf(s Status) Status {
 	}
 	copy.Resources = &runtime.ContainerResources{}
 	if s.Resources != nil && s.Resources.Linux != nil {
-		hugepageLimits := make([]*runtime.HugepageLimit, len(s.Resources.Linux.HugepageLimits))
+		hugepageLimits := make([]*runtime.HugepageLimit, 0)
 		for _, l := range s.Resources.Linux.HugepageLimits {
 			hugepageLimits = append(hugepageLimits, &runtime.HugepageLimit{
 				PageSize: l.PageSize,


### PR DESCRIPTION
In golang when copying a slice, if the slice is initialized with a desired length, then appending to it will cause the size to double.

Signed-off-by: bin liu <liubin0329@gmail.com>