### PR TITLE
Fix broken link for CRI plugin in docs

### DIFF
--- a/docs/cri/architecture.md
+++ b/docs/cri/architecture.md
@@ -1,7 +1,7 @@
 # Architecture of The CRI Plugin
 This document describes the architecture of the `cri` plugin for `containerd`.
 
-This plugin is an implementation of Kubernetes [container runtime interface (CRI)](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1alpha2/api.proto). Containerd operates on the same node as the [Kubelet](https://kubernetes.io/docs/reference/generated/kubelet/). The `cri` plugin inside containerd handles all CRI service requests from the Kubelet and uses containerd internals to manage containers and container images.
+This plugin is an implementation of Kubernetes [container runtime interface (CRI)](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.proto). Containerd operates on the same node as the [Kubelet](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/). The `cri` plugin inside containerd handles all CRI service requests from the Kubelet and uses containerd internals to manage containers and container images.
 
 The `cri` plugin uses containerd to manage the full container lifecycle and all container images. As also shown below, `cri` manages pod networking via [CNI](https://github.com/containernetworking/cni) (another CNCF project).
 


### PR DESCRIPTION
while reading the architecture of CRI plugin in docs noticed that the link is broken

Signed-off-by: Aman Sharma <amansh@vmware.com>