### PR TITLE
keep the lower case letter for flag info

### DIFF
--- a/cmd/ctr/commands/commands.go
+++ b/cmd/ctr/commands/commands.go
@@ -70,7 +70,7 @@ var (
 		cli.StringFlag{
 			Name: "hosts-dir",
 			// compatible with "/etc/docker/certs.d"
-			Usage: "Custom hosts configuration directory",
+			Usage: "custom hosts configuration directory",
 		},
 		cli.StringFlag{
 			Name:  "tlscacert",

--- a/cmd/ctr/commands/commands_unix.go
+++ b/cmd/ctr/commands/commands_unix.go
@@ -32,11 +32,11 @@ func init() {
 		Usage: "disable use of pivot-root (linux only)",
 	}, cli.Int64Flag{
 		Name:  "cpu-quota",
-		Usage: "Limit CPU CFS quota",
+		Usage: "limit CPU CFS quota",
 		Value: -1,
 	}, cli.Uint64Flag{
 		Name:  "cpu-period",
-		Usage: "Limit CPU CFS period",
+		Usage: "limit CPU CFS period",
 	}, cli.StringFlag{
 		Name:  "rootfs-propagation",
 		Usage: "set the propagation of the container rootfs",

--- a/cmd/ctr/commands/images/mount.go
+++ b/cmd/ctr/commands/images/mount.go
@@ -41,11 +41,11 @@ When you are done, use the unmount command.
 	Flags: append(append(commands.RegistryFlags, append(commands.SnapshotterFlags, commands.LabelFlag)...),
 		cli.BoolFlag{
 			Name:  "rw",
-			Usage: "Enable write support on the mount",
+			Usage: "enable write support on the mount",
 		},
 		cli.StringFlag{
 			Name:  "platform",
-			Usage: "Mount the image for the specified platform",
+			Usage: "mount the image for the specified platform",
 			Value: platforms.DefaultString(),
 		},
 	),

--- a/cmd/ctr/commands/images/push.go
+++ b/cmd/ctr/commands/images/push.go
@@ -67,10 +67,10 @@ var pushCommand = cli.Command{
 		Value: &cli.StringSlice{},
 	}, cli.IntFlag{
 		Name:  "max-concurrent-uploaded-layers",
-		Usage: "Set the max concurrent uploaded layers for each push",
+		Usage: "set the max concurrent uploaded layers for each push",
 	}, cli.BoolFlag{
 		Name:  "allow-non-distributable-blobs",
-		Usage: "Allow pushing blobs that are marked as non-distributable",
+		Usage: "allow pushing blobs that are marked as non-distributable",
 	}),
 	Action: func(context *cli.Context) error {
 		var (

--- a/cmd/ctr/commands/snapshots/snapshots.go
+++ b/cmd/ctr/commands/snapshots/snapshots.go
@@ -290,7 +290,7 @@ var prepareCommand = cli.Command{
 		},
 		cli.BoolFlag{
 			Name:  "mounts",
-			Usage: "Print out snapshot mounts as JSON",
+			Usage: "print out snapshot mounts as JSON",
 		},
 	},
 	Action: func(context *cli.Context) error {
@@ -341,7 +341,7 @@ var viewCommand = cli.Command{
 		},
 		cli.BoolFlag{
 			Name:  "mounts",
-			Usage: "Print out snapshot mounts as JSON",
+			Usage: "print out snapshot mounts as JSON",
 		},
 	},
 	Action: func(context *cli.Context) error {


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

We should keep the lower case letter for flag info