### PR TITLE
complement sub-command note for containerd-main

### DIFF
--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -68,7 +68,7 @@ func App() *cli.App {
 	app.Usage = usage
 	app.Description = `
 containerd is a high performance container runtime whose daemon can be started
-by using this command. If none of the *config*, *publish*, or *help* commands
+by using this command. If none of the *config*, *publish*, *oci-hook*, or *help* commands
 are specified, the default action of the **containerd** command is to start the
 containerd daemon in the foreground.
 


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

There have "oci-hook" sub-command , but the describe info is wrong for that..
