### PR TITLE
Add support for user namespaces in stateless pods (KEP-127)

### DIFF
--- a/client.go
+++ b/client.go
@@ -866,3 +866,21 @@ func toPlatforms(pt []*apitypes.Platform) []ocispec.Platform {
 	}
 	return platforms
 }
+
+// GetSnapshotterCapabilities returns the capabilities of a snapshotter.
+func (c *Client) GetSnapshotterCapabilities(ctx context.Context, snapshotterName string) ([]string, error) {
+	filters := []string{fmt.Sprintf("type==%s, id==%s", plugin.SnapshotPlugin, snapshotterName)}
+	in := c.IntrospectionService()
+
+	resp, err := in.Plugins(ctx, filters)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(resp.Plugins) <= 0 {
+		return nil, fmt.Errorf("inspection service could not find snapshotter %s plugin", snapshotterName)
+	}
+
+	sn := resp.Plugins[0]
+	return sn.Capabilities, nil
+}

--- a/container_opts.go
+++ b/container_opts.go
@@ -224,6 +224,11 @@ func WithNewSnapshot(id string, i Image, opts ...snapshots.Opt) NewContainerOpts
 		if err != nil {
 			return err
 		}
+
+		parent, err = resolveSnapshotOptions(ctx, client, c.Snapshotter, s, parent, opts...)
+		if err != nil {
+			return err
+		}
 		if _, err := s.Prepare(ctx, id, parent, opts...); err != nil {
 			return err
 		}
@@ -265,6 +270,11 @@ func WithNewSnapshotView(id string, i Image, opts ...snapshots.Opt) NewContainer
 			return err
 		}
 		s, err := client.getSnapshotter(ctx, c.Snapshotter)
+		if err != nil {
+			return err
+		}
+
+		parent, err = resolveSnapshotOptions(ctx, client, c.Snapshotter, s, parent, opts...)
 		if err != nil {
 			return err
 		}

--- a/integration/pod_userns_linux_test.go
+++ b/integration/pod_userns_linux_test.go
@@ -1,0 +1,169 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/integration/images"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	exec "golang.org/x/sys/execabs"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+func TestPodUserNS(t *testing.T) {
+	containerID := uint32(0)
+	hostID := uint32(65536)
+	size := uint32(65536)
+	for name, test := range map[string]struct {
+		sandboxOpts   []PodSandboxOpts
+		containerOpts []ContainerOpts
+		checkOutput   func(t *testing.T, output string)
+		expectErr     bool
+	}{
+		"userns uid mapping": {
+			sandboxOpts: []PodSandboxOpts{
+				WithPodUserNs(containerID, hostID, size),
+			},
+			containerOpts: []ContainerOpts{
+				WithUserNamespace(containerID, hostID, size),
+				WithCommand("cat", "/proc/self/uid_map"),
+			},
+			checkOutput: func(t *testing.T, output string) {
+				// The output should contain the length of the userns requested.
+				assert.Contains(t, output, fmt.Sprint(size))
+			},
+		},
+		"userns gid mapping": {
+			sandboxOpts: []PodSandboxOpts{
+				WithPodUserNs(containerID, hostID, size),
+			},
+			containerOpts: []ContainerOpts{
+				WithUserNamespace(containerID, hostID, size),
+				WithCommand("cat", "/proc/self/gid_map"),
+			},
+			checkOutput: func(t *testing.T, output string) {
+				// The output should contain the length of the userns requested.
+				assert.Contains(t, output, fmt.Sprint(size))
+			},
+		},
+		"rootfs permissions": {
+			sandboxOpts: []PodSandboxOpts{
+				WithPodUserNs(containerID, hostID, size),
+			},
+			containerOpts: []ContainerOpts{
+				WithUserNamespace(containerID, hostID, size),
+				// Prints numeric UID and GID for path.
+				// For example, if UID and GID is 0 it will print: =0=0=
+				// We add the "=" signs so we use can assert.Contains() and be sure
+				// the UID/GID is 0 and not things like 100 (that contain 0).
+				// We can't use assert.Equal() easily as it contains timestamp, etc.
+				WithCommand("stat", "-c", "'=%u=%g='", "/root/"),
+			},
+			checkOutput: func(t *testing.T, output string) {
+				// The UID and GID should be 0 (root) if the chown/remap is done correctly.
+				assert.Contains(t, output, "=0=0=")
+			},
+		},
+		"fails with several mappings": {
+			sandboxOpts: []PodSandboxOpts{
+				WithPodUserNs(containerID, hostID, size),
+				WithPodUserNs(containerID*2, hostID*2, size*2),
+			},
+			expectErr: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if os.Getenv("ENABLE_CRI_SANDBOXES") == "'sandboxed'" {
+				t.Skip("skipping test: userns not supported/needed in sanboxed runtimes")
+			}
+			cmd := exec.Command("true")
+			cmd.SysProcAttr = &syscall.SysProcAttr{
+				Cloneflags: syscall.CLONE_NEWUSER,
+			}
+			if err := cmd.Run(); err != nil {
+				t.Skip("skipping test: user namespaces are unavailable")
+			}
+
+			testPodLogDir := t.TempDir()
+			sandboxOpts := append(test.sandboxOpts, WithPodLogDirectory(testPodLogDir))
+			t.Log("Create a sandbox with userns")
+			sbConfig := PodSandboxConfig("sandbox", "userns", sandboxOpts...)
+			sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
+			if err != nil {
+				if !test.expectErr {
+					t.Fatalf("Unexpected RunPodSandbox error: %v", err)
+				}
+				return
+			}
+			// Make sure the sandbox is cleaned up.
+			defer func() {
+				assert.NoError(t, runtimeService.StopPodSandbox(sb))
+				assert.NoError(t, runtimeService.RemovePodSandbox(sb))
+			}()
+			if test.expectErr {
+				t.Fatalf("Expected RunPodSandbox to return error")
+			}
+
+			var (
+				testImage     = images.Get(images.BusyBox)
+				containerName = "test-container"
+			)
+
+			EnsureImageExists(t, testImage)
+
+			containerOpts := append(test.containerOpts,
+				WithLogPath(containerName),
+			)
+			t.Log("Create a container for userns")
+			cnConfig := ContainerConfig(
+				containerName,
+				testImage,
+				containerOpts...,
+			)
+			cn, err := runtimeService.CreateContainer(sb, cnConfig, sbConfig)
+			require.NoError(t, err)
+
+			t.Log("Start the container")
+			require.NoError(t, runtimeService.StartContainer(cn))
+
+			t.Log("Wait for container to finish running")
+			require.NoError(t, Eventually(func() (bool, error) {
+				s, err := runtimeService.ContainerStatus(cn)
+				if err != nil {
+					return false, err
+				}
+				if s.GetState() == runtime.ContainerState_CONTAINER_EXITED {
+					return true, nil
+				}
+				return false, nil
+			}, time.Second, 30*time.Second))
+
+			content, err := os.ReadFile(filepath.Join(testPodLogDir, containerName))
+			assert.NoError(t, err)
+
+			t.Log("Running check function")
+			test.checkOutput(t, string(content))
+		})
+	}
+}

--- a/pkg/cri/sbserver/container_create_linux.go
+++ b/pkg/cri/sbserver/container_create_linux.go
@@ -313,7 +313,8 @@ func (c *criService) containerSpec(
 
 	specOpts = append(specOpts,
 		customopts.WithOOMScoreAdj(config, c.config.RestrictOOMScoreAdj),
-		customopts.WithPodNamespaces(securityContext, sandboxPid, targetPid),
+		// TODO: This is a hack to make this compile. We should move userns support to sbserver.
+		customopts.WithPodNamespaces(securityContext, sandboxPid, targetPid, nil, nil),
 		customopts.WithSupplementalGroups(supplementalGroups),
 		customopts.WithAnnotation(annotations.ContainerType, annotations.ContainerTypeContainer),
 		customopts.WithAnnotation(annotations.SandboxID, sandboxID),

--- a/pkg/cri/server/container_create.go
+++ b/pkg/cri/server/container_create.go
@@ -184,7 +184,10 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	log.G(ctx).Debugf("Container %q spec: %#+v", id, spew.NewFormatter(spec))
 
 	// Grab any platform specific snapshotter opts.
-	sOpts := snapshotterOpts(c.config.ContainerdConfig.Snapshotter, config)
+	sOpts, err := snapshotterOpts(c.config.ContainerdConfig.Snapshotter, config)
+	if err != nil {
+		return nil, err
+	}
 
 	// Set snapshotter before any other options.
 	opts := []containerd.NewContainerOpts{

--- a/pkg/cri/server/container_create_linux.go
+++ b/pkg/cri/server/container_create_linux.go
@@ -601,6 +601,7 @@ func generateUserString(username string, uid, gid *runtime.Int64Value) (string, 
 }
 
 // snapshotterOpts returns any Linux specific snapshotter options for the rootfs snapshot
-func snapshotterOpts(snapshotterName string, config *runtime.ContainerConfig) []snapshots.Opt {
-	return []snapshots.Opt{}
+func snapshotterOpts(snapshotterName string, config *runtime.ContainerConfig) ([]snapshots.Opt, error) {
+	nsOpts := config.GetLinux().GetSecurityContext().GetNamespaceOptions()
+	return snapshotterRemapOpts(nsOpts)
 }

--- a/pkg/cri/server/container_create_linux.go
+++ b/pkg/cri/server/container_create_linux.go
@@ -311,9 +311,14 @@ func (c *criService) containerSpec(
 		targetPid = status.Pid
 	}
 
+	uids, gids, err := parseUsernsIDs(nsOpts.GetUsernsOptions())
+	if err != nil {
+		return nil, fmt.Errorf("user namespace configuration: %w", err)
+	}
+
 	specOpts = append(specOpts,
 		customopts.WithOOMScoreAdj(config, c.config.RestrictOOMScoreAdj),
-		customopts.WithPodNamespaces(securityContext, sandboxPid, targetPid),
+		customopts.WithPodNamespaces(securityContext, sandboxPid, targetPid, uids, gids),
 		customopts.WithSupplementalGroups(supplementalGroups),
 		customopts.WithAnnotation(annotations.ContainerType, annotations.ContainerTypeContainer),
 		customopts.WithAnnotation(annotations.SandboxID, sandboxID),

--- a/pkg/cri/server/container_create_other.go
+++ b/pkg/cri/server/container_create_other.go
@@ -55,6 +55,6 @@ func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageCon
 }
 
 // snapshotterOpts returns snapshotter options for the rootfs snapshot
-func snapshotterOpts(snapshotterName string, config *runtime.ContainerConfig) []snapshots.Opt {
-	return []snapshots.Opt{}
+func snapshotterOpts(snapshotterName string, config *runtime.ContainerConfig) ([]snapshots.Opt, error) {
+	return []snapshots.Opt{}, nil
 }

--- a/pkg/cri/server/container_create_windows.go
+++ b/pkg/cri/server/container_create_windows.go
@@ -145,7 +145,7 @@ func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageCon
 }
 
 // snapshotterOpts returns any Windows specific snapshotter options for the r/w layer
-func snapshotterOpts(snapshotterName string, config *runtime.ContainerConfig) []snapshots.Opt {
+func snapshotterOpts(snapshotterName string, config *runtime.ContainerConfig) ([]snapshots.Opt, error) {
 	var opts []snapshots.Opt
 
 	switch snapshotterName {
@@ -160,5 +160,5 @@ func snapshotterOpts(snapshotterName string, config *runtime.ContainerConfig) []
 		}
 	}
 
-	return opts
+	return opts, nil
 }

--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"math"
 	"path/filepath"
+	goruntime "runtime"
 	"strings"
 	"time"
 
@@ -244,8 +245,27 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		return nil, fmt.Errorf("failed to get sandbox container info: %w", err)
 	}
 
+	userNsEnabled := false
+	if goruntime.GOOS != "windows" {
+		usernsOpts := config.GetLinux().GetSecurityContext().GetNamespaceOptions().GetUsernsOptions()
+		if usernsOpts != nil && usernsOpts.GetMode() == runtime.NamespaceMode_POD {
+			userNsEnabled = true
+		}
+	}
+
 	// Setup the network namespace if host networking wasn't requested.
-	if !hostNetwork(config) {
+	if !hostNetwork(config) && !userNsEnabled {
+		// XXX: We do c&p of this code later for the podNetwork && userNsEnabled case too.
+		// We can't move this to a function, as the defer calls need to be executed if other
+		// errors are returned in this function. So, we would need more refactors to move
+		// this code to a function and the idea was to not change the current code for
+		// !userNsEnabled case, therefore doing it would defeat the purpose.
+		//
+		// The difference between the cases is the use of netns.NewNetNS() vs
+		// netns.NewNetNSFromPID() and we verify the task is still running in the other case.
+		//
+		// To simplify this, in the future, we should just remove this case (podNetwork &&
+		// !userNsEnabled) and just keep the other case (podNetwork && userNsEnabled).
 		netStart := time.Now()
 
 		// If it is not in host network namespace then create a namespace and set the sandbox
@@ -351,6 +371,88 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	exitCh, err := task.Wait(ctrdutil.NamespacedContext())
 	if err != nil {
 		return nil, fmt.Errorf("failed to wait for sandbox container task: %w", err)
+	}
+
+	if !hostNetwork(config) && userNsEnabled {
+		// If userns is enabled, then the netns was created by the OCI runtime
+		// when creating "task". The OCI runtime needs to create the netns
+		// because, if userns is in use, the netns needs to be owned by the
+		// userns. So, let the OCI runtime just handle this for us.
+		// If the netns is not owned by the userns several problems will happen.
+		// For instance, the container will lack permission (even if
+		// capabilities are present) to modify the netns or, even worse, the OCI
+		// runtime will fail to mount sysfs:
+		// 	https://github.com/torvalds/linux/commit/7dc5dbc879bd0779924b5132a48b731a0bc04a1e#diff-4839664cd0c8eab716e064323c7cd71fR1164
+		netStart := time.Now()
+
+		// If it is not in host network namespace then create a namespace and set the sandbox
+		// handle. NetNSPath in sandbox metadata and NetNS is non empty only for non host network
+		// namespaces. If the pod is in host network namespace then both are empty and should not
+		// be used.
+		var netnsMountDir = "/var/run/netns"
+		if c.config.NetNSMountsUnderStateDir {
+			netnsMountDir = filepath.Join(c.config.StateDir, "netns")
+		}
+		sandbox.NetNS, err = netns.NewNetNSFromPID(netnsMountDir, task.Pid())
+		if err != nil {
+			return nil, fmt.Errorf("failed to create network namespace for sandbox %q: %w", id, err)
+		}
+
+		// Verify task is still in created state.
+		if st, err := task.Status(ctx); err != nil || st.Status != containerd.Created {
+			return nil, fmt.Errorf("failed to create pod sandbox %q: err is %v - status is %q and is expected %q", id, err, st.Status, containerd.Created)
+		}
+		sandbox.NetNSPath = sandbox.NetNS.GetPath()
+
+		defer func() {
+			// Remove the network namespace only if all the resource cleanup is done.
+			if retErr != nil && cleanupErr == nil {
+				if cleanupErr = sandbox.NetNS.Remove(); cleanupErr != nil {
+					log.G(ctx).WithError(cleanupErr).Errorf("Failed to remove network namespace %s for sandbox %q", sandbox.NetNSPath, id)
+					return
+				}
+				sandbox.NetNSPath = ""
+			}
+		}()
+
+		// Update network namespace in the container's spec
+		c.updateNetNamespacePath(spec, sandbox.NetNSPath)
+
+		if err := container.Update(ctx,
+			// Update spec of the container
+			containerd.UpdateContainerOpts(containerd.WithSpec(spec)),
+			// Update sandbox metadata to include NetNS info
+			containerd.UpdateContainerOpts(containerd.WithContainerExtension(sandboxMetadataExtension, &sandbox.Metadata))); err != nil {
+			return nil, fmt.Errorf("failed to update the network namespace for the sandbox container %q: %w", id, err)
+		}
+
+		// Define this defer to teardownPodNetwork prior to the setupPodNetwork function call.
+		// This is because in setupPodNetwork the resource is allocated even if it returns error, unlike other resource creation functions.
+		defer func() {
+			// Teardown the network only if all the resource cleanup is done.
+			if retErr != nil && cleanupErr == nil {
+				deferCtx, deferCancel := ctrdutil.DeferContext()
+				defer deferCancel()
+				// Teardown network if an error is returned.
+				if cleanupErr = c.teardownPodNetwork(deferCtx, sandbox); cleanupErr != nil {
+					log.G(ctx).WithError(cleanupErr).Errorf("Failed to destroy network for sandbox %q", id)
+				}
+			}
+		}()
+
+		// Setup network for sandbox.
+		// Certain VM based solutions like clear containers (Issue containerd/cri-containerd#524)
+		// rely on the assumption that CRI shim will not be querying the network namespace to check the
+		// network states such as IP.
+		// In future runtime implementation should avoid relying on CRI shim implementation details.
+		// In this case however caching the IP will add a subtle performance enhancement by avoiding
+		// calls to network namespace of the pod to query the IP of the veth interface on every
+		// SandboxStatus request.
+		if err := c.setupPodNetwork(ctx, &sandbox); err != nil {
+			return nil, fmt.Errorf("failed to setup network for sandbox %q: %w", id, err)
+		}
+
+		sandboxCreateNetworkTimer.UpdateSince(netStart)
 	}
 
 	if c.nri.isEnabled() {

--- a/pkg/cri/server/sandbox_run_linux.go
+++ b/pkg/cri/server/sandbox_run_linux.go
@@ -25,6 +25,7 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/plugin"
+	"github.com/containerd/containerd/snapshots"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	selinux "github.com/opencontainers/selinux/go-selinux"
@@ -357,4 +358,11 @@ func (c *criService) updateNetNamespacePath(spec *runtimespec.Spec, nsPath strin
 			break
 		}
 	}
+}
+
+// sandboxSnapshotterOpts generates any platform specific snapshotter options
+// for a sandbox container.
+func sandboxSnapshotterOpts(config *runtime.PodSandboxConfig) ([]snapshots.Opt, error) {
+	nsOpts := config.GetLinux().GetSecurityContext().GetNamespaceOptions()
+	return snapshotterRemapOpts(nsOpts)
 }

--- a/pkg/cri/server/sandbox_run_linux_test.go
+++ b/pkg/cri/server/sandbox_run_linux_test.go
@@ -98,6 +98,17 @@ func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConf
 func TestLinuxSandboxContainerSpec(t *testing.T) {
 	testID := "test-id"
 	nsPath := "test-cni"
+	idMap := runtime.IDMapping{
+		HostId:      1000,
+		ContainerId: 1000,
+		Length:      10,
+	}
+	expIDMap := runtimespec.LinuxIDMapping{
+		HostID:      1000,
+		ContainerID: 1000,
+		Size:        10,
+	}
+
 	for desc, test := range map[string]struct {
 		configChange func(*runtime.PodSandboxConfig)
 		specCheck    func(*testing.T, *runtimespec.Spec)
@@ -122,6 +133,9 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 				})
 				assert.Contains(t, spec.Linux.Sysctl["net.ipv4.ip_unprivileged_port_start"], "0")
 				assert.Contains(t, spec.Linux.Sysctl["net.ipv4.ping_group_range"], "0 2147483647")
+				assert.NotContains(t, spec.Linux.Namespaces, runtimespec.LinuxNamespace{
+					Type: runtimespec.UserNamespace,
+				})
 			},
 		},
 		"host namespace": {
@@ -149,9 +163,112 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 				assert.NotContains(t, spec.Linux.Namespaces, runtimespec.LinuxNamespace{
 					Type: runtimespec.IPCNamespace,
 				})
+				assert.NotContains(t, spec.Linux.Namespaces, runtimespec.LinuxNamespace{
+					Type: runtimespec.UserNamespace,
+				})
 				assert.NotContains(t, spec.Linux.Sysctl["net.ipv4.ip_unprivileged_port_start"], "0")
 				assert.NotContains(t, spec.Linux.Sysctl["net.ipv4.ping_group_range"], "0 2147483647")
 			},
+		},
+		"user namespace": {
+			configChange: func(c *runtime.PodSandboxConfig) {
+				c.Linux.SecurityContext = &runtime.LinuxSandboxSecurityContext{
+					NamespaceOptions: &runtime.NamespaceOption{
+						UsernsOptions: &runtime.UserNamespace{
+							Mode: runtime.NamespaceMode_POD,
+							Uids: []*runtime.IDMapping{&idMap},
+							Gids: []*runtime.IDMapping{&idMap},
+						},
+					},
+				}
+			},
+			specCheck: func(t *testing.T, spec *runtimespec.Spec) {
+				require.NotNil(t, spec.Linux)
+				assert.Contains(t, spec.Linux.Namespaces, runtimespec.LinuxNamespace{
+					Type: runtimespec.UserNamespace,
+				})
+				require.Equal(t, spec.Linux.UIDMappings, []runtimespec.LinuxIDMapping{expIDMap})
+				require.Equal(t, spec.Linux.GIDMappings, []runtimespec.LinuxIDMapping{expIDMap})
+
+			},
+		},
+		"user namespace mode node and mappings": {
+			configChange: func(c *runtime.PodSandboxConfig) {
+				c.Linux.SecurityContext = &runtime.LinuxSandboxSecurityContext{
+					NamespaceOptions: &runtime.NamespaceOption{
+						UsernsOptions: &runtime.UserNamespace{
+							Mode: runtime.NamespaceMode_NODE,
+							Uids: []*runtime.IDMapping{&idMap},
+							Gids: []*runtime.IDMapping{&idMap},
+						},
+					},
+				}
+			},
+			expectErr: true,
+		},
+		"user namespace with several mappings": {
+			configChange: func(c *runtime.PodSandboxConfig) {
+				c.Linux.SecurityContext = &runtime.LinuxSandboxSecurityContext{
+					NamespaceOptions: &runtime.NamespaceOption{
+						UsernsOptions: &runtime.UserNamespace{
+							Mode: runtime.NamespaceMode_NODE,
+							Uids: []*runtime.IDMapping{&idMap, &idMap},
+							Gids: []*runtime.IDMapping{&idMap, &idMap},
+						},
+					},
+				}
+			},
+			expectErr: true,
+		},
+		"user namespace with uneven mappings": {
+			configChange: func(c *runtime.PodSandboxConfig) {
+				c.Linux.SecurityContext = &runtime.LinuxSandboxSecurityContext{
+					NamespaceOptions: &runtime.NamespaceOption{
+						UsernsOptions: &runtime.UserNamespace{
+							Mode: runtime.NamespaceMode_NODE,
+							Uids: []*runtime.IDMapping{&idMap, &idMap},
+							Gids: []*runtime.IDMapping{&idMap},
+						},
+					},
+				}
+			},
+			expectErr: true,
+		},
+		"user namespace mode container": {
+			configChange: func(c *runtime.PodSandboxConfig) {
+				c.Linux.SecurityContext = &runtime.LinuxSandboxSecurityContext{
+					NamespaceOptions: &runtime.NamespaceOption{
+						UsernsOptions: &runtime.UserNamespace{
+							Mode: runtime.NamespaceMode_CONTAINER,
+						},
+					},
+				}
+			},
+			expectErr: true,
+		},
+		"user namespace mode target": {
+			configChange: func(c *runtime.PodSandboxConfig) {
+				c.Linux.SecurityContext = &runtime.LinuxSandboxSecurityContext{
+					NamespaceOptions: &runtime.NamespaceOption{
+						UsernsOptions: &runtime.UserNamespace{
+							Mode: runtime.NamespaceMode_TARGET,
+						},
+					},
+				}
+			},
+			expectErr: true,
+		},
+		"user namespace unknown mode": {
+			configChange: func(c *runtime.PodSandboxConfig) {
+				c.Linux.SecurityContext = &runtime.LinuxSandboxSecurityContext{
+					NamespaceOptions: &runtime.NamespaceOption{
+						UsernsOptions: &runtime.UserNamespace{
+							Mode: runtime.NamespaceMode(100),
+						},
+					},
+				}
+			},
+			expectErr: true,
 		},
 		"should set supplemental groups correctly": {
 			configChange: func(c *runtime.PodSandboxConfig) {

--- a/pkg/cri/server/sandbox_run_other.go
+++ b/pkg/cri/server/sandbox_run_other.go
@@ -21,6 +21,7 @@ package server
 import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
+	"github.com/containerd/containerd/snapshots"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -55,4 +56,10 @@ func (c *criService) taskOpts(runtimeType string) []containerd.NewTaskOpts {
 }
 
 func (c *criService) updateNetNamespacePath(spec *runtimespec.Spec, nsPath string) {
+}
+
+// sandboxSnapshotterOpts generates any platform specific snapshotter options
+// for a sandbox container.
+func sandboxSnapshotterOpts(config *runtime.PodSandboxConfig) ([]snapshots.Opt, error) {
+	return []snapshots.Opt{}, nil
 }

--- a/pkg/cri/server/sandbox_run_windows.go
+++ b/pkg/cri/server/sandbox_run_windows.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
+	"github.com/containerd/containerd/snapshots"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -115,4 +116,9 @@ func (c *criService) taskOpts(runtimeType string) []containerd.NewTaskOpts {
 
 func (c *criService) updateNetNamespacePath(spec *runtimespec.Spec, nsPath string) {
 	spec.Windows.Network.NetworkNamespace = nsPath
+}
+
+// No sandbox snapshotter options needed for windows.
+func sandboxSnapshotterOpts(config *runtime.PodSandboxConfig) ([]snapshots.Opt, error) {
+	return []snapshots.Opt{}, nil
 }

--- a/pkg/netns/netns_other.go
+++ b/pkg/netns/netns_other.go
@@ -35,6 +35,11 @@ func NewNetNS(baseDir string) (*NetNS, error) {
 	return nil, errNotImplementedOnUnix
 }
 
+// NewNetNS returns the netns from pid or a new netns if pid is 0.
+func NewNetNSFromPID(baseDir string, pid uint32) (*NetNS, error) {
+	return nil, errNotImplementedOnUnix
+}
+
 // LoadNetNS loads existing network namespace.
 func LoadNetNS(path string) *NetNS {
 	return &NetNS{path: path}

--- a/pkg/netns/netns_windows.go
+++ b/pkg/netns/netns_windows.go
@@ -16,14 +16,20 @@
 
 package netns
 
-import "github.com/Microsoft/hcsshim/hcn"
+import (
+	"errors"
+
+	"github.com/Microsoft/hcsshim/hcn"
+)
+
+var errNotImplementedOnWindows = errors.New("not implemented on windows")
 
 // NetNS holds network namespace for sandbox
 type NetNS struct {
 	path string
 }
 
-// NewNetNS creates a network namespace for the sandbox
+// NewNetNS creates a network namespace for the sandbox.
 func NewNetNS(baseDir string) (*NetNS, error) {
 	temp := hcn.HostComputeNamespace{}
 	hcnNamespace, err := temp.Create()
@@ -32,6 +38,11 @@ func NewNetNS(baseDir string) (*NetNS, error) {
 	}
 
 	return &NetNS{path: hcnNamespace.Id}, nil
+}
+
+// NewNetNS returns the netns from pid or a new netns if pid is 0.
+func NewNetNSFromPID(baseDir string, pid uint32) (*NetNS, error) {
+	return nil, errNotImplementedOnWindows
 }
 
 // LoadNetNS loads existing network namespace.

--- a/snapshots/snapshotter.go
+++ b/snapshots/snapshotter.go
@@ -33,6 +33,11 @@ const (
 	UnpackKeyFormat       = UnpackKeyPrefix + "-%s %s"
 	inheritedLabelsPrefix = "containerd.io/snapshot/"
 	labelSnapshotRef      = "containerd.io/snapshot.ref"
+
+	// LabelSnapshotUIDMapping is the label used for UID mappings
+	LabelSnapshotUIDMapping = "containerd.io/snapshot/uidmapping"
+	// LabelSnapshotGIDMapping is the label used for GID mappings
+	LabelSnapshotGIDMapping = "containerd.io/snapshot/gidmapping"
 )
 
 // Kind identifies the kind of snapshot.

--- a/snapshotter_opts_unix.go
+++ b/snapshotter_opts_unix.go
@@ -19,9 +19,14 @@
 package containerd
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/containerd/containerd/snapshots"
+)
+
+const (
+	capabRemapIDs = "remap-ids"
 )
 
 // WithRemapperLabels creates the labels used by any supporting snapshotter
@@ -29,7 +34,77 @@ import (
 // supported by the fuse-overlayfs snapshotter
 func WithRemapperLabels(ctrUID, hostUID, ctrGID, hostGID, length uint32) snapshots.Opt {
 	return snapshots.WithLabels(map[string]string{
-		"containerd.io/snapshot/uidmapping": fmt.Sprintf("%d:%d:%d", ctrUID, hostUID, length),
-		"containerd.io/snapshot/gidmapping": fmt.Sprintf("%d:%d:%d", ctrGID, hostGID, length),
-	})
+		snapshots.LabelSnapshotUIDMapping: fmt.Sprintf("%d:%d:%d", ctrUID, hostUID, length),
+		snapshots.LabelSnapshotGIDMapping: fmt.Sprintf("%d:%d:%d", ctrGID, hostGID, length)})
+}
+
+func resolveSnapshotOptions(ctx context.Context, client *Client, snapshotterName string, snapshotter snapshots.Snapshotter, parent string, opts ...snapshots.Opt) (string, error) {
+	capabs, err := client.GetSnapshotterCapabilities(ctx, snapshotterName)
+	if err != nil {
+		return "", err
+	}
+
+	for _, capab := range capabs {
+		if capab == capabRemapIDs {
+			// Snapshotter supports ID remapping, we don't need to do anything.
+			return parent, nil
+		}
+	}
+
+	var local snapshots.Info
+	for _, opt := range opts {
+		opt(&local)
+	}
+
+	needsRemap := false
+	var uidMap, gidMap string
+
+	if value, ok := local.Labels[snapshots.LabelSnapshotUIDMapping]; ok {
+		needsRemap = true
+		uidMap = value
+	}
+	if value, ok := local.Labels[snapshots.LabelSnapshotGIDMapping]; ok {
+		needsRemap = true
+		gidMap = value
+	}
+
+	if !needsRemap {
+		return parent, nil
+	}
+
+	var ctrUID, hostUID, length uint32
+	_, err = fmt.Sscanf(uidMap, "%d:%d:%d", &ctrUID, &hostUID, &length)
+	if err != nil {
+		return "", fmt.Errorf("uidMap unparsable: %w", err)
+	}
+
+	var ctrGID, hostGID, lengthGID uint32
+	_, err = fmt.Sscanf(gidMap, "%d:%d:%d", &ctrGID, &hostGID, &lengthGID)
+	if err != nil {
+		return "", fmt.Errorf("gidMap unparsable: %w", err)
+	}
+
+	if ctrUID != 0 || ctrGID != 0 {
+		return "", fmt.Errorf("Container UID/GID of 0 only supported currently (%d/%d)", ctrUID, ctrGID)
+	}
+
+	// TODO(dgl): length isn't taken into account for the intermediate snapshot id.
+	usernsID := fmt.Sprintf("%s-%d-%d", parent, hostUID, hostGID)
+	if _, err := snapshotter.Stat(ctx, usernsID); err == nil {
+		return usernsID, nil
+	}
+	mounts, err := snapshotter.Prepare(ctx, usernsID+"-remap", parent)
+	if err != nil {
+		return "", err
+	}
+	// TODO(dgl): length isn't taken into account here yet either.
+	if err := remapRootFS(ctx, mounts, hostUID, hostGID); err != nil {
+		snapshotter.Remove(ctx, usernsID+"-remap")
+		return "", err
+	}
+	if err := snapshotter.Commit(ctx, usernsID, usernsID+"-remap"); err != nil {
+		return "", err
+	}
+
+	return usernsID, nil
 }

--- a/snapshotter_opts_windows.go
+++ b/snapshotter_opts_windows.go
@@ -1,0 +1,27 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package containerd
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/snapshots"
+)
+
+func resolveSnapshotOptions(ctx context.Context, client *Client, snapshotterName string, snapshotter snapshots.Snapshotter, parent string, opts ...snapshots.Opt) (string, error) {
+	return parent, nil
+}


### PR DESCRIPTION
Hi!

This PR implements support for user namespace in Kubernetes pods. I'm opening the PR to see if you think this approach is sound, I'll add tests later, of course, but don't need to wait on that to see if this direction makes sense.

The 3 subitems listed in #7063 are solved in some way here, but not all possible solutions are implemented. In particular:
 * The netns problem: it is solved in the first commit (Let OCI runtime create netns when userns is used) and, as requested by Mike Brown in a community meeting, I left intact the code-path that are used today.
 * Ownership of the rootfs: three possible solutions are listed there. I chose just to take the commits from PR #7310, that uses a chown and adds the notion of capabilities, to say if some snapshotter supports idmap mounts (support for idmap not implemented). I've squashed the commits in that PR, rebased, fixed conflicts and just improve some code-paths based on my PoC patches. We opened a different PR for those changes first as we thought it may make sense to merge it before, but now that this PR is open, I think we can superseede that PR.
 * Just implement userns support: this is done in commit "cri: Support pods with user namespaces"

The other solutions listed in the issue for the ownership of the rootfs are fuse and idmap mounts. I'm not particularly interested in fuse solutions, as that changes the stack a lot and we just prefer to use idmap mounts/chown. We can implement idmap mounts in the future with this capability commits included (this probably will need to be probed at runtime, as support depends on the kernel and fs being used. I haven't checked how sound these commits are regarding runtime discovery, those were written by @dgl). There is an earlier attempt to use idmap mounts for the rootfs too: https://github.com/containerd/containerd/pull/5890, I haven't looked into merging that with the capabilities approach.

While it is not needed, it will be nice to also merge #7141 for 1.7 too, as that reduced the storage overhead when using userns (we only create inodes and hardlink instead of a full blown copy of the rootfs _for each pod_). Probably it reduces the pod startup latency too :)

As a side note, I noted there is `pkg/cri/server` and `pkg/cri/sbserver` that seems to be a c&p with some small changes. I've only implemented support for userns in pkg/cri/server but it is trivial to duplicate the code in sbserver. See commit "WIP: Fix sbserver compilation". I wasn't sure if that is desirable or not. Just let me know :)

To review, consider reviewing commit by commit. Each commit is atomic and has clear explanations.

To test this, a k8s 1.25+ cluster and the field "hostUsers: false" in the pod.spec should be enough. Feel free to reach out to me on slack if there hit any issue to test this.

I'll try to join the next community meeting in case someone wants to discuss this in more detail.

TODO:
- [x] unit tests for userns in _linux.go files (containers and sandbox)
- [x] Check if we can add unit tests for userns in non-linux files (containers and sandbox)
- [ ] Check if we can add unit tests for remapped snapshot (@dgl can you look into this?)
- [x] integration tests

Fixes: #7063

cc @rodnymolina @dgl 