### PR TITLE
Fix sandbox API when calling sandboxed shims

### DIFF
--- a/pkg/cri/sbserver/podsandbox/sandbox_run.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_run.go
@@ -86,7 +86,7 @@ func (c *Controller) Start(ctx context.Context, id string) (resp *api.Controller
 		return nil, fmt.Errorf("failed to get image from containerd %q: %w", image.ID, err)
 	}
 
-	ociRuntime, err := c.getSandboxRuntime(config, sandboxInfo.Runtime.Name)
+	ociRuntime, err := c.getSandboxRuntime(config, metadata.RuntimeHandler)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get sandbox runtime: %w", err)
 	}
@@ -263,6 +263,7 @@ func (c *Controller) Start(ctx context.Context, id string) (resp *api.Controller
 		SandboxID: id,
 		Pid:       task.Pid(),
 		CreatedAt: protobuf.ToTimestamp(info.CreatedAt),
+		Labels:    labels,
 	}
 
 	return resp, nil

--- a/pkg/cri/sbserver/service.go
+++ b/pkg/cri/sbserver/service.go
@@ -27,14 +27,12 @@ import (
 	"time"
 
 	"github.com/containerd/containerd"
-	sandboxapi "github.com/containerd/containerd/api/services/sandbox/v1"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/pkg/cri/sbserver/podsandbox"
 	"github.com/containerd/containerd/pkg/cri/streaming"
 	"github.com/containerd/containerd/pkg/kmutex"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/sandbox"
-	"github.com/containerd/containerd/sandbox/proxy"
 	runtime_alpha "github.com/containerd/containerd/third_party/k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"github.com/containerd/go-cni"
 	"github.com/sirupsen/logrus"
@@ -191,7 +189,7 @@ func NewCRIService(config criconfig.Config, client *containerd.Client) (CRIServi
 
 	// Load all sandbox controllers(pod sandbox controller and remote shim controller)
 	c.sandboxControllers[criconfig.ModePodSandbox] = podsandbox.New(config, client, c.sandboxStore, c.os, c, c.baseOCISpecs)
-	c.sandboxControllers[criconfig.ModeShim] = proxy.NewSandboxController(sandboxapi.NewControllerClient(client.Conn()))
+	c.sandboxControllers[criconfig.ModeShim] = client.SandboxController()
 
 	return c, nil
 }

--- a/services/sandbox/controller_local.go
+++ b/services/sandbox/controller_local.go
@@ -112,6 +112,7 @@ func (c *controllerLocal) Create(ctx context.Context, in *api.ControllerCreateRe
 		Rootfs:     in.Rootfs,
 		Options:    in.Options,
 	}); err != nil {
+		// TODO: Delete sandbox shim here.
 		return nil, fmt.Errorf("failed to start sandbox %s: %w", in.SandboxID, err)
 	}
 


### PR DESCRIPTION
This PR fixes sandbox API so it can properly call sandboxed shims.
Also refactored and removed duplicated code from `podsandbox` package.

--

Added a few commits to further decouple sbserver from pause container (and left bunch of todos for the remaining work)