### PR TITLE
can set up the network serially by CNI plugins

### DIFF
--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -143,6 +143,9 @@ type CniConfig struct {
 	// be loaded from the cni config directory by go-cni. Set the value to 0 to
 	// load all config files (no arbitrary limit). The legacy default value is 1.
 	NetworkPluginMaxConfNum int `toml:"max_conf_num" json:"maxConfNum"`
+	// NetworkPluginSetupSerially is a boolean flag to specify whether containerd sets up networks serially
+	// if there are multiple CNI plugin config files existing and NetworkPluginMaxConfNum is larger than 1.
+	NetworkPluginSetupSerially bool `toml:"setup_serially" json:"setupSerially"`
 	// NetworkPluginConfTemplate is the file path of golang template used to generate
 	// cni config.
 	// When it is set, containerd will get cidr(s) from kubelet to replace {{.PodCIDR}},

--- a/pkg/cri/config/config_unix.go
+++ b/pkg/cri/config/config_unix.go
@@ -66,10 +66,11 @@ func DefaultConfig() PluginConfig {
 	tree, _ := toml.Load(defaultRuncV2Opts)
 	return PluginConfig{
 		CniConfig: CniConfig{
-			NetworkPluginBinDir:       "/opt/cni/bin",
-			NetworkPluginConfDir:      "/etc/cni/net.d",
-			NetworkPluginMaxConfNum:   1, // only one CNI plugin config file will be loaded
-			NetworkPluginConfTemplate: "",
+			NetworkPluginBinDir:        "/opt/cni/bin",
+			NetworkPluginConfDir:       "/etc/cni/net.d",
+			NetworkPluginMaxConfNum:    1, // only one CNI plugin config file will be loaded
+			NetworkPluginSetupSerially: false,
+			NetworkPluginConfTemplate:  "",
 		},
 		ContainerdConfig: ContainerdConfig{
 			Snapshotter:        containerd.DefaultSnapshotter,

--- a/pkg/cri/config/config_windows.go
+++ b/pkg/cri/config/config_windows.go
@@ -29,10 +29,11 @@ import (
 func DefaultConfig() PluginConfig {
 	return PluginConfig{
 		CniConfig: CniConfig{
-			NetworkPluginBinDir:       filepath.Join(os.Getenv("ProgramFiles"), "containerd", "cni", "bin"),
-			NetworkPluginConfDir:      filepath.Join(os.Getenv("ProgramFiles"), "containerd", "cni", "conf"),
-			NetworkPluginMaxConfNum:   1,
-			NetworkPluginConfTemplate: "",
+			NetworkPluginBinDir:        filepath.Join(os.Getenv("ProgramFiles"), "containerd", "cni", "bin"),
+			NetworkPluginConfDir:       filepath.Join(os.Getenv("ProgramFiles"), "containerd", "cni", "conf"),
+			NetworkPluginMaxConfNum:    1,
+			NetworkPluginSetupSerially: false,
+			NetworkPluginConfTemplate:  "",
 		},
 		ContainerdConfig: ContainerdConfig{
 			Snapshotter:        containerd.DefaultSnapshotter,


### PR DESCRIPTION
Signed-off-by: Fei Su <sofat1989@126.com>

```release-note
can set up the network serially by CNI plugins
```
Indeed we have two CNI plugins which have independent CNI configuration files. For example
```
tnet.conf ztio.conf
```
We want to run these two plugins serially. because running CNI plugin in `ztio.conf` will depend on some configurations set by the CNI plugin in `tnet.conf`.

By default, containerd will run them parallelly. So it may fail randomly.

For CNI interface, there is a function `SetupSerially` reserved for setting up serially. So we want that there is a flag in the config file of containerd to control this.

The expected config in config.toml:
```
[plugins."io.containerd.grpc.v1.cri".cni]
      max_conf_num = 2
      setup_serially = true
```



