### PR TITLE
gotestsum match go version 1.19

### DIFF
--- a/script/setup/install-gotestsum
+++ b/script/setup/install-gotestsum
@@ -14,4 +14,4 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-GO111MODULE=on go install gotest.tools/gotestsum@v1.7.0
+GO111MODULE=on go install gotest.tools/gotestsum@v1.8.2


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

Now the ci go-version is "1.19.3".
Maybe change the gotestsum to the v1.8.2 for match go1.19.
[gotestsum release](https://github.com/gotestyourself/gotestsum/releases/tag/v1.8.2)
