### PR TITLE
Add process_vm read and write calls to default seccomp profile

### DIFF
--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -489,7 +489,11 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 		kernelversion.KernelVersion{Kernel: 4, Major: 8}); err == nil {
 		if ok {
 			s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
-				Names:  []string{"ptrace"},
+				Names: []string{
+					"process_vm_read",
+					"process_vm_write",
+					"ptrace",
+				},
 				Action: specs.ActAllow,
 				Args:   []specs.LinuxSeccompArg{},
 			})


### PR DESCRIPTION
Follow up to 94faa70df4d78538605bb492010954a7e3bec67a. The commit referenced allowed `ptrace` calls in the default seccomp profile following the usual tracing security checks in for Kernels newer than 4.8. Kernels prior to this version are susceptible to [CVE-2019-2054](https://github.com/advisories/GHSA-qgfr-27qf-f323).  Moby's default had allowed for `ptrace` for kernels newer than 4.8 at the time the commit was created. The current [seccomp default](https://github.com/moby/moby/blob/master/profiles/seccomp/default_linux.go#L405-L417) has been updated to include `process_vm_read` and `process_vm_write`. Mirror that policy to complete the classic ptrace set of APIs.

Signed-off-by: Juan Sebastian Hoyos Ayala <juan.s.hoyos@outlook.com>