### PR TITLE
cri: add pod uid annotation

### DIFF
--- a/pkg/cri/annotations/annotations.go
+++ b/pkg/cri/annotations/annotations.go
@@ -58,6 +58,11 @@ const (
 	// SandboxNamespace is the name of the namespace of the sandbox (pod)
 	SandboxNamespace = "io.kubernetes.cri.sandbox-namespace"
 
+	// SandboxUID is the uid of the sandbox (pod) passed to CRI via RunPodSanbox,
+	// this field is useful for linking the uid created by the CRI client (e.g. kubelet)
+	// to the internal Sandbox.ID created by the containerd sandbox service
+	SandboxUID = "io.kubernetes.cri.sandbox-uid"
+
 	// SandboxName is the name of the sandbox (pod)
 	SandboxName = "io.kubernetes.cri.sandbox-name"
 

--- a/pkg/cri/sbserver/container_create_linux.go
+++ b/pkg/cri/sbserver/container_create_linux.go
@@ -318,6 +318,7 @@ func (c *criService) containerSpec(
 		customopts.WithAnnotation(annotations.ContainerType, annotations.ContainerTypeContainer),
 		customopts.WithAnnotation(annotations.SandboxID, sandboxID),
 		customopts.WithAnnotation(annotations.SandboxNamespace, sandboxConfig.GetMetadata().GetNamespace()),
+		customopts.WithAnnotation(annotations.SandboxUID, sandboxConfig.GetMetadata().GetUid()),
 		customopts.WithAnnotation(annotations.SandboxName, sandboxConfig.GetMetadata().GetName()),
 		customopts.WithAnnotation(annotations.ContainerName, containerName),
 		customopts.WithAnnotation(annotations.ImageName, imageName),

--- a/pkg/cri/sbserver/container_create_linux_test.go
+++ b/pkg/cri/sbserver/container_create_linux_test.go
@@ -181,6 +181,9 @@ func getCreateContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandbox
 		assert.Contains(t, spec.Annotations, annotations.SandboxNamespace)
 		assert.EqualValues(t, spec.Annotations[annotations.SandboxNamespace], "test-sandbox-ns")
 
+		assert.Contains(t, spec.Annotations, annotations.SandboxUID)
+		assert.EqualValues(t, spec.Annotations[annotations.SandboxUID], "test-sandbox-uid")
+
 		assert.Contains(t, spec.Annotations, annotations.SandboxName)
 		assert.EqualValues(t, spec.Annotations[annotations.SandboxName], "test-sandbox-name")
 

--- a/pkg/cri/sbserver/container_create_windows.go
+++ b/pkg/cri/sbserver/container_create_windows.go
@@ -130,6 +130,7 @@ func (c *criService) containerSpec(
 		customopts.WithAnnotation(annotations.ContainerType, annotations.ContainerTypeContainer),
 		customopts.WithAnnotation(annotations.SandboxID, sandboxID),
 		customopts.WithAnnotation(annotations.SandboxNamespace, sandboxConfig.GetMetadata().GetNamespace()),
+		customopts.WithAnnotation(annotations.SandboxUID, sandboxConfig.GetMetadata().GetUid()),
 		customopts.WithAnnotation(annotations.SandboxName, sandboxConfig.GetMetadata().GetName()),
 		customopts.WithAnnotation(annotations.ContainerName, containerName),
 		customopts.WithAnnotation(annotations.ImageName, imageName),

--- a/pkg/cri/sbserver/container_create_windows_test.go
+++ b/pkg/cri/sbserver/container_create_windows_test.go
@@ -130,6 +130,9 @@ func getCreateContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandbox
 		assert.Contains(t, spec.Annotations, annotations.SandboxNamespace)
 		assert.EqualValues(t, spec.Annotations[annotations.SandboxNamespace], "test-sandbox-ns")
 
+		assert.Contains(t, spec.Annotations, annotations.SandboxUID)
+		assert.EqualValues(t, spec.Annotations[annotations.SandboxUID], "test-sandbox-uid")
+
 		assert.Contains(t, spec.Annotations, annotations.SandboxName)
 		assert.EqualValues(t, spec.Annotations[annotations.SandboxName], "test-sandbox-name")
 

--- a/pkg/cri/sbserver/podsandbox/sandbox_run_linux.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_run_linux.go
@@ -180,6 +180,7 @@ func (c *Controller) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 		customopts.WithAnnotation(annotations.ContainerType, annotations.ContainerTypeSandbox),
 		customopts.WithAnnotation(annotations.SandboxID, id),
 		customopts.WithAnnotation(annotations.SandboxNamespace, config.GetMetadata().GetNamespace()),
+		customopts.WithAnnotation(annotations.SandboxUID, config.GetMetadata().GetUid()),
 		customopts.WithAnnotation(annotations.SandboxName, config.GetMetadata().GetName()),
 		customopts.WithAnnotation(annotations.SandboxLogDir, config.GetLogDirectory()),
 	)

--- a/pkg/cri/sbserver/podsandbox/sandbox_run_linux_test.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_run_linux_test.go
@@ -78,6 +78,9 @@ func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConf
 		assert.Contains(t, spec.Annotations, annotations.SandboxNamespace)
 		assert.EqualValues(t, spec.Annotations[annotations.SandboxNamespace], "test-ns")
 
+		assert.Contains(t, spec.Annotations, annotations.SandboxUID)
+		assert.EqualValues(t, spec.Annotations[annotations.SandboxUID], "test-uid")
+
 		assert.Contains(t, spec.Annotations, annotations.SandboxName)
 		assert.EqualValues(t, spec.Annotations[annotations.SandboxName], "test-name")
 

--- a/pkg/cri/sbserver/podsandbox/sandbox_run_windows.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_run_windows.go
@@ -84,6 +84,7 @@ func (c *Controller) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 		customopts.WithAnnotation(annotations.ContainerType, annotations.ContainerTypeSandbox),
 		customopts.WithAnnotation(annotations.SandboxID, id),
 		customopts.WithAnnotation(annotations.SandboxNamespace, config.GetMetadata().GetNamespace()),
+		customopts.WithAnnotation(annotations.SandboxUID, config.GetMetadata().GetUid()),
 		customopts.WithAnnotation(annotations.SandboxName, config.GetMetadata().GetName()),
 		customopts.WithAnnotation(annotations.SandboxLogDir, config.GetLogDirectory()),
 		customopts.WithAnnotation(annotations.WindowsHostProcess, strconv.FormatBool(config.GetWindows().GetSecurityContext().GetHostProcess())),

--- a/pkg/cri/sbserver/podsandbox/sandbox_run_windows_test.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_run_windows_test.go
@@ -80,6 +80,9 @@ func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConf
 		assert.Contains(t, spec.Annotations, annotations.SandboxNamespace)
 		assert.EqualValues(t, spec.Annotations[annotations.SandboxNamespace], "test-ns")
 
+		assert.Contains(t, spec.Annotations, annotations.SandboxUID)
+		assert.EqualValues(t, spec.Annotations[annotations.SandboxUID], "test-uid")
+
 		assert.Contains(t, spec.Annotations, annotations.SandboxName)
 		assert.EqualValues(t, spec.Annotations[annotations.SandboxName], "test-name")
 

--- a/pkg/cri/server/container_create_linux.go
+++ b/pkg/cri/server/container_create_linux.go
@@ -318,6 +318,7 @@ func (c *criService) containerSpec(
 		customopts.WithAnnotation(annotations.ContainerType, annotations.ContainerTypeContainer),
 		customopts.WithAnnotation(annotations.SandboxID, sandboxID),
 		customopts.WithAnnotation(annotations.SandboxNamespace, sandboxConfig.GetMetadata().GetNamespace()),
+		customopts.WithAnnotation(annotations.SandboxUID, sandboxConfig.GetMetadata().GetUid()),
 		customopts.WithAnnotation(annotations.SandboxName, sandboxConfig.GetMetadata().GetName()),
 		customopts.WithAnnotation(annotations.ContainerName, containerName),
 		customopts.WithAnnotation(annotations.ImageName, imageName),

--- a/pkg/cri/server/container_create_linux_test.go
+++ b/pkg/cri/server/container_create_linux_test.go
@@ -181,6 +181,9 @@ func getCreateContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandbox
 		assert.Contains(t, spec.Annotations, annotations.SandboxNamespace)
 		assert.EqualValues(t, spec.Annotations[annotations.SandboxNamespace], "test-sandbox-ns")
 
+		assert.Contains(t, spec.Annotations, annotations.SandboxUID)
+		assert.EqualValues(t, spec.Annotations[annotations.SandboxUID], "test-sandbox-uid")
+
 		assert.Contains(t, spec.Annotations, annotations.SandboxName)
 		assert.EqualValues(t, spec.Annotations[annotations.SandboxName], "test-sandbox-name")
 

--- a/pkg/cri/server/container_create_windows.go
+++ b/pkg/cri/server/container_create_windows.go
@@ -130,6 +130,7 @@ func (c *criService) containerSpec(
 		customopts.WithAnnotation(annotations.ContainerType, annotations.ContainerTypeContainer),
 		customopts.WithAnnotation(annotations.SandboxID, sandboxID),
 		customopts.WithAnnotation(annotations.SandboxNamespace, sandboxConfig.GetMetadata().GetNamespace()),
+		customopts.WithAnnotation(annotations.SandboxUID, sandboxConfig.GetMetadata().GetUid()),
 		customopts.WithAnnotation(annotations.SandboxName, sandboxConfig.GetMetadata().GetName()),
 		customopts.WithAnnotation(annotations.ContainerName, containerName),
 		customopts.WithAnnotation(annotations.ImageName, imageName),

--- a/pkg/cri/server/container_create_windows_test.go
+++ b/pkg/cri/server/container_create_windows_test.go
@@ -130,6 +130,9 @@ func getCreateContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandbox
 		assert.Contains(t, spec.Annotations, annotations.SandboxNamespace)
 		assert.EqualValues(t, spec.Annotations[annotations.SandboxNamespace], "test-sandbox-ns")
 
+		assert.Contains(t, spec.Annotations, annotations.SandboxUID)
+		assert.EqualValues(t, spec.Annotations[annotations.SandboxUID], "test-sandbox-uid")
+
 		assert.Contains(t, spec.Annotations, annotations.SandboxName)
 		assert.EqualValues(t, spec.Annotations[annotations.SandboxName], "test-sandbox-name")
 

--- a/pkg/cri/server/sandbox_run_linux.go
+++ b/pkg/cri/server/sandbox_run_linux.go
@@ -180,6 +180,7 @@ func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 		customopts.WithAnnotation(annotations.ContainerType, annotations.ContainerTypeSandbox),
 		customopts.WithAnnotation(annotations.SandboxID, id),
 		customopts.WithAnnotation(annotations.SandboxNamespace, config.GetMetadata().GetNamespace()),
+		customopts.WithAnnotation(annotations.SandboxUID, config.GetMetadata().GetUid()),
 		customopts.WithAnnotation(annotations.SandboxName, config.GetMetadata().GetName()),
 		customopts.WithAnnotation(annotations.SandboxLogDir, config.GetLogDirectory()),
 	)

--- a/pkg/cri/server/sandbox_run_linux_test.go
+++ b/pkg/cri/server/sandbox_run_linux_test.go
@@ -78,6 +78,9 @@ func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConf
 		assert.Contains(t, spec.Annotations, annotations.SandboxNamespace)
 		assert.EqualValues(t, spec.Annotations[annotations.SandboxNamespace], "test-ns")
 
+		assert.Contains(t, spec.Annotations, annotations.SandboxUID)
+		assert.EqualValues(t, spec.Annotations[annotations.SandboxUID], "test-uid")
+
 		assert.Contains(t, spec.Annotations, annotations.SandboxName)
 		assert.EqualValues(t, spec.Annotations[annotations.SandboxName], "test-name")
 

--- a/pkg/cri/server/sandbox_run_windows.go
+++ b/pkg/cri/server/sandbox_run_windows.go
@@ -84,6 +84,7 @@ func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 		customopts.WithAnnotation(annotations.ContainerType, annotations.ContainerTypeSandbox),
 		customopts.WithAnnotation(annotations.SandboxID, id),
 		customopts.WithAnnotation(annotations.SandboxNamespace, config.GetMetadata().GetNamespace()),
+		customopts.WithAnnotation(annotations.SandboxUID, config.GetMetadata().GetUid()),
 		customopts.WithAnnotation(annotations.SandboxName, config.GetMetadata().GetName()),
 		customopts.WithAnnotation(annotations.SandboxLogDir, config.GetLogDirectory()),
 		customopts.WithAnnotation(annotations.WindowsHostProcess, strconv.FormatBool(config.GetWindows().GetSecurityContext().GetHostProcess())),

--- a/pkg/cri/server/sandbox_run_windows_test.go
+++ b/pkg/cri/server/sandbox_run_windows_test.go
@@ -80,6 +80,9 @@ func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConf
 		assert.Contains(t, spec.Annotations, annotations.SandboxNamespace)
 		assert.EqualValues(t, spec.Annotations[annotations.SandboxNamespace], "test-ns")
 
+		assert.Contains(t, spec.Annotations, annotations.SandboxUID)
+		assert.EqualValues(t, spec.Annotations[annotations.SandboxUID], "test-uid")
+
 		assert.Contains(t, spec.Annotations, annotations.SandboxName)
 		assert.EqualValues(t, spec.Annotations[annotations.SandboxName], "test-name")
 


### PR DESCRIPTION
Containerd already has annotations for pod name an pod namespace this PR introduces an annotation for pod uid. This will be helpful for projects like inspektor-gadget to simplify getting [metadata ](https://github.com/inspektor-gadget/inspektor-gadget/blob/e332776435abbad634178b3ed2a535d2d330b7e0/pkg/container-collection/options.go#L600)about pods. 