### PR TITLE
Resolve Scorecards GitHub Actions workflow warnings

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # tag=v3.0.0
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
         with:
           persist-credentials: false
 


### PR DESCRIPTION
Allow actions/checkout in scorecards workflow to use latest v3 commit.
Resolves `save-state` command usage warnings.

Latest run: https://github.com/containerd/containerd/actions/runs/3510597304/jobs/5880546790

Related issue: https://github.com/containerd/project/issues/95

Signed-off-by: Austin Vazquez <macedonv@amazon.com>