### PR TITLE
archive: set WithModTimeUpperBound when WithSourceDateEpoch is set

### DIFF
--- a/archive/tar_opts.go
+++ b/archive/tar_opts.go
@@ -91,7 +91,10 @@ type WriteDiffOptions struct {
 
 	writeDiffFunc func(context.Context, io.Writer, string, string, WriteDiffOptions) error
 
-	// SourceDateEpoch specifies the timestamp used for whiteouts to provide control for reproducibility.
+	// SourceDateEpoch specifies the following timestamps to provide control for reproducibility.
+	//   - The upper bound timestamp of the diff contents
+	//   - The timestamp of the whiteouts
+	//
 	// See also https://reproducible-builds.org/docs/source-date-epoch/ .
 	SourceDateEpoch *time.Time
 }


### PR DESCRIPTION
`WithModTimeUpperBound` sets the upper bound value of the `ModTime` property of the tar entry structs.

`WithSourceDateEpoch` now implies `WithModTimeUpperBound` too, in addition to `WithWhiteoutTime` (https://github.com/containerd/containerd/pull/7478).

For 
- moby/buildkit#3296
