### PR TITLE
fuzzing: improve archive fuzzer

### DIFF
--- a/contrib/fuzz/archive_fuzzer.go
+++ b/contrib/fuzz/archive_fuzzer.go
@@ -82,6 +82,7 @@ func FuzzImportIndex(data []byte) int {
 		return 0
 	}
 	if shouldRequireLayoutOrManifest {
+		hasLayoutOrManifest := false
 		tr := tar.NewReader(r)
 		for {
 			hdr, err := tr.Next()
@@ -93,13 +94,12 @@ func FuzzImportIndex(data []byte) int {
 			}
 			hdrName := path.Clean(hdr.Name)
 			switch hdrName {
-			case ocispec.ImageLayoutFile:
-				break
-			case "manifest.json":
-				break
-			default:
-				return 0
+			case ocispec.ImageLayoutFile, "manifest.json":
+				hasLayoutOrManifest = true
 			}
+		}
+		if !hasLayoutOrManifest {
+			return 0
 		}
 	}
 	tmpdir, err := os.MkdirTemp("", "fuzzing-")


### PR DESCRIPTION
Currently the fuzzer does not check all the files in the tar archive which it should. This pr fixes that.

Signed-off-by: AdamKorcz <adam@adalogics.com>