### PR TITLE
parsing ref consistently for refCache, including adding `docker.io/library` prefix

### DIFF
--- a/pkg/cri/store/image/image.go
+++ b/pkg/cri/store/image/image.go
@@ -19,6 +19,7 @@ package image
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/containerd/containerd"
@@ -84,6 +85,14 @@ func (s *Store) Update(ctx context.Context, ref string) error {
 		if err != nil {
 			return fmt.Errorf("get image info from containerd: %w", err)
 		}
+	}
+	// parsing ref consistently for refCache, including adding `docker.io/library` prefix
+	if !strings.HasPrefix(ref, "sha256:") {
+		namedRef, err := docker.ParseDockerRef(ref)
+		if err != nil {
+			return fmt.Errorf("failed to parse image reference %q: %w", ref, err)
+		}
+		ref = namedRef.String()
 	}
 	return s.update(ref, img)
 }

--- a/pkg/cri/store/image/image.go
+++ b/pkg/cri/store/image/image.go
@@ -96,7 +96,6 @@ func (s *Store) update(ref string, img *Image) error {
 	switch refName {
 	case string(imagedigest.SHA256), string(imagedigest.SHA512), string(imagedigest.SHA384):
 		//  a digested reference
-		break
 	default:
 		// parsing ref consistently for refCache, including adding `docker.io/library` prefix
 		namedRef, err := docker.ParseDockerRef(ref)

--- a/pkg/cri/store/image/image_test.go
+++ b/pkg/cri/store/image/image_test.go
@@ -143,7 +143,7 @@ func TestImageStore(t *testing.T) {
 	image := Image{
 		ID:         id,
 		ChainID:    "test-chain-id-1",
-		References: []string{"containerd.io/ref-1"},
+		References: []string{"containerd.io/ref-1:latest"},
 		Size:       10,
 	}
 	assert := assertlib.New(t)
@@ -168,14 +168,14 @@ func TestImageStore(t *testing.T) {
 			image: &Image{
 				ID:         id,
 				ChainID:    "test-chain-id-1",
-				References: []string{"containerd.io/ref-2"},
+				References: []string{"containerd.io/ref-2:latest"},
 				Size:       10,
 			},
 			expected: []Image{
 				{
 					ID:         id,
 					ChainID:    "test-chain-id-1",
-					References: []string{"containerd.io/ref-1", "containerd.io/ref-2"},
+					References: []string{"containerd.io/ref-1:latest", "containerd.io/ref-2:latest"},
 					Size:       10,
 				},
 			},
@@ -185,7 +185,7 @@ func TestImageStore(t *testing.T) {
 			image: &Image{
 				ID:         newID,
 				ChainID:    "test-chain-id-2",
-				References: []string{"containerd.io/ref-2"},
+				References: []string{"containerd.io/ref-2:latest"},
 				Size:       20,
 			},
 			expected: []Image{
@@ -193,7 +193,7 @@ func TestImageStore(t *testing.T) {
 				{
 					ID:         newID,
 					ChainID:    "test-chain-id-2",
-					References: []string{"containerd.io/ref-2"},
+					References: []string{"containerd.io/ref-2:latest"},
 					Size:       20,
 				},
 			},
@@ -203,14 +203,14 @@ func TestImageStore(t *testing.T) {
 			image: &Image{
 				ID:         newID,
 				ChainID:    "test-chain-id-2",
-				References: []string{"containerd.io/ref-1"},
+				References: []string{"containerd.io/ref-1:latest"},
 				Size:       20,
 			},
 			expected: []Image{
 				{
 					ID:         newID,
 					ChainID:    "test-chain-id-2",
-					References: []string{"containerd.io/ref-1"},
+					References: []string{"containerd.io/ref-1:latest"},
 					Size:       20,
 				},
 			},


### PR DESCRIPTION
Fixes #7698

For the refCache below, the ref needs to be consistent.

There is a test case in  #7698, I can quickly reproduce it with the second method there. 

Before restarting and importing image, the refCahe is using `ref: import-2022-11-28@sha256:c8a01d8610c642f0e6b83af5f6185b3eed34e322354be5a515da1a21453ac966"` and crictl cannot remove it correctly.

After restarting containerd, the cache became `ref: docker.io/library/import-2022-11-28@sha256:c8a01d8610c642f0e6b83af5f6185b3eed34e322354be5a515da1a21453ac966"` and crictl can remove it correctly.


----

I add another cleanup in `services/images/local.go` without `docker.io/library/` prefix.
- see https://github.com/containerd/containerd/pull/7728#issuecomment-1351174499