### PR TITLE
Fix a goroutine leak in CRI code

### DIFF
--- a/pkg/cri/sbserver/container_attach.go
+++ b/pkg/cri/sbserver/container_attach.go
@@ -43,7 +43,7 @@ func (c *criService) Attach(ctx context.Context, r *runtime.AttachRequest) (*run
 }
 
 func (c *criService) attachContainer(ctx context.Context, id string, stdin io.Reader, stdout, stderr io.WriteCloser,
-	tty bool, resize <-chan remotecommand.TerminalSize) error {
+	tty bool, resize io.Reader) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	// Get container from our container store.

--- a/pkg/cri/sbserver/container_execsync.go
+++ b/pkg/cri/sbserver/container_execsync.go
@@ -107,7 +107,7 @@ type execOptions struct {
 	stdout  io.WriteCloser
 	stderr  io.WriteCloser
 	tty     bool
-	resize  <-chan remotecommand.TerminalSize
+	resize  io.Reader
 	timeout time.Duration
 }
 

--- a/pkg/cri/sbserver/streaming.go
+++ b/pkg/cri/sbserver/streaming.go
@@ -19,8 +19,10 @@ package sbserver
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/containerd/containerd/log"
 	"io"
 	"math"
 	"net"
@@ -127,7 +129,7 @@ func newStreamRuntime(c *criService) streaming.Runtime {
 // Exec executes a command inside the container. exec.ExitError is returned if the command
 // returns non-zero exit code.
 func (s *streamRuntime) Exec(containerID string, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser,
-	tty bool, resize <-chan remotecommand.TerminalSize) error {
+	tty bool, resize io.Reader) error {
 	exitCode, err := s.c.execInContainer(ctrdutil.NamespacedContext(), containerID, execOptions{
 		cmd:    cmd,
 		stdin:  stdin,
@@ -149,7 +151,7 @@ func (s *streamRuntime) Exec(containerID string, cmd []string, stdin io.Reader, 
 }
 
 func (s *streamRuntime) Attach(containerID string, in io.Reader, out, err io.WriteCloser, tty bool,
-	resize <-chan remotecommand.TerminalSize) error {
+	resize io.Reader) error {
 	return s.c.attachContainer(ctrdutil.NamespacedContext(), containerID, in, out, err, tty, resize)
 }
 
@@ -161,29 +163,30 @@ func (s *streamRuntime) PortForward(podSandboxID string, port int32, stream io.R
 	return s.c.portForward(ctx, podSandboxID, port, stream)
 }
 
-// handleResizing spawns a goroutine that processes the resize channel, calling resizeFunc for each
-// remotecommand.TerminalSize received from the channel.
-func handleResizing(ctx context.Context, resize <-chan remotecommand.TerminalSize, resizeFunc func(size remotecommand.TerminalSize)) {
+// handleResizing spawns a goroutine that processes the resize stream, calling resizeFunc for each
+// remotecommand.TerminalSize received from it.
+func handleResizing(ctx context.Context, resize io.Reader, resizeFunc func(size remotecommand.TerminalSize)) {
 	if resize == nil {
 		return
 	}
 
 	go func() {
 		defer runtime.HandleCrash()
+		decoder := json.NewDecoder(resize)
 
-		for {
-			select {
-			case <-ctx.Done():
+		for ctx.Err() == nil {
+			size := remotecommand.TerminalSize{}
+			err := decoder.Decode(&size)
+			if err != nil {
+				if err != io.EOF {
+					log.G(ctx).WithError(err).Error("Failed to read the console resize channel")
+				}
 				return
-			case size, ok := <-resize:
-				if !ok {
-					return
-				}
-				if size.Height < 1 || size.Width < 1 {
-					continue
-				}
-				resizeFunc(size)
 			}
+			if size.Height < 1 || size.Width < 1 {
+				continue
+			}
+			resizeFunc(size)
 		}
 	}()
 }

--- a/pkg/cri/sbserver/streaming.go
+++ b/pkg/cri/sbserver/streaming.go
@@ -22,12 +22,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/containerd/containerd/log"
 	"io"
 	"math"
 	"net"
 	"os"
 	"time"
+
+	"github.com/containerd/containerd/log"
 
 	k8snet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/runtime"

--- a/pkg/cri/server/container_attach.go
+++ b/pkg/cri/server/container_attach.go
@@ -43,7 +43,7 @@ func (c *criService) Attach(ctx context.Context, r *runtime.AttachRequest) (*run
 }
 
 func (c *criService) attachContainer(ctx context.Context, id string, stdin io.Reader, stdout, stderr io.WriteCloser,
-	tty bool, resize <-chan remotecommand.TerminalSize) error {
+	tty bool, resize io.Reader) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	// Get container from our container store.

--- a/pkg/cri/server/container_execsync.go
+++ b/pkg/cri/server/container_execsync.go
@@ -107,7 +107,7 @@ type execOptions struct {
 	stdout  io.WriteCloser
 	stderr  io.WriteCloser
 	tty     bool
-	resize  <-chan remotecommand.TerminalSize
+	resize  io.Reader
 	timeout time.Duration
 }
 

--- a/pkg/cri/server/streaming.go
+++ b/pkg/cri/server/streaming.go
@@ -22,12 +22,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/containerd/containerd/log"
 	"io"
 	"math"
 	"net"
 	"os"
 	"time"
+
+	"github.com/containerd/containerd/log"
 
 	k8snet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/runtime"

--- a/pkg/cri/streaming/remotecommand/exec.go
+++ b/pkg/cri/streaming/remotecommand/exec.go
@@ -43,7 +43,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	remotecommandconsts "k8s.io/apimachinery/pkg/util/remotecommand"
 	"k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/tools/remotecommand"
 	utilexec "k8s.io/utils/exec"
 )
 
@@ -51,7 +50,7 @@ import (
 type Executor interface {
 	// ExecInContainer executes a command in a container in the pod, copying data
 	// between in/out/err and the container's stdin/stdout/stderr.
-	ExecInContainer(name string, uid types.UID, container string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize, timeout time.Duration) error
+	ExecInContainer(name string, uid types.UID, container string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool, resize io.Reader, timeout time.Duration) error
 }
 
 // ServeExec handles requests to execute a command in a container. After
@@ -65,7 +64,7 @@ func ServeExec(w http.ResponseWriter, req *http.Request, executor Executor, podN
 	}
 	defer ctx.conn.Close()
 
-	err := executor.ExecInContainer(podName, uid, container, cmd, ctx.stdinStream, ctx.stdoutStream, ctx.stderrStream, ctx.tty, ctx.resizeChan, 0)
+	err := executor.ExecInContainer(podName, uid, container, cmd, ctx.stdinStream, ctx.stdoutStream, ctx.stderrStream, ctx.tty, ctx.resizeStream, 0)
 	if err != nil {
 		if exitErr, ok := err.(utilexec.ExitError); ok && exitErr.Exited() {
 			rc := exitErr.ExitStatus()

--- a/pkg/cri/streaming/server.go
+++ b/pkg/cri/streaming/server.go
@@ -49,7 +49,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 	remotecommandconsts "k8s.io/apimachinery/pkg/util/remotecommand"
-	"k8s.io/client-go/tools/remotecommand"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/containerd/containerd/pkg/cri/streaming/portforward"
@@ -78,8 +77,8 @@ type Server interface {
 
 // Runtime is the interface to execute the commands and provide the streams.
 type Runtime interface {
-	Exec(containerID string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error
-	Attach(containerID string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error
+	Exec(containerID string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool, resize io.Reader) error
+	Attach(containerID string, in io.Reader, out, err io.WriteCloser, tty bool, resize io.Reader) error
 	PortForward(podSandboxID string, port int32, stream io.ReadWriteCloser) error
 }
 
@@ -388,11 +387,11 @@ var _ remotecommandserver.Executor = &criAdapter{}
 var _ remotecommandserver.Attacher = &criAdapter{}
 var _ portforward.PortForwarder = &criAdapter{}
 
-func (a *criAdapter) ExecInContainer(podName string, podUID types.UID, container string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize, timeout time.Duration) error {
+func (a *criAdapter) ExecInContainer(podName string, podUID types.UID, container string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool, resize io.Reader, timeout time.Duration) error {
 	return a.Runtime.Exec(container, cmd, in, out, err, tty, resize)
 }
 
-func (a *criAdapter) AttachContainer(podName string, podUID types.UID, container string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
+func (a *criAdapter) AttachContainer(podName string, podUID types.UID, container string, in io.Reader, out, err io.WriteCloser, tty bool, resize io.Reader) error {
 	return a.Runtime.Attach(container, in, out, err, tty, resize)
 }
 


### PR DESCRIPTION
Fixes: #7415

[This code](https://github.com/containerd/containerd/blob/40a94641eddab2568650af0fca1835148db1d7a9/pkg/cri/streaming/remotecommand/httpstream.go#L438) creates a channel to write resize stream updates to, but if the exec call completes with an error, the goroutine reading from it ([here](https://github.com/containerd/containerd/blob/40a94641eddab2568650af0fca1835148db1d7a9/pkg/cri/server/streaming.go#L166-L189)) is never created. Hence `channel <- size` blocks forever. This adds about 1 megabyte to containerd memory, for each failed exec call.

Removed the offending goroutine, as it does nothing useful anyway. (The consuming goroutine can read from the stream directly) As a side effect, now resize channel is processed for websocket connections as well. (Currently, it is set [here](https://github.com/containerd/containerd/blob/40a94641eddab2568650af0fca1835148db1d7a9/pkg/cri/streaming/remotecommand/websocket.go#L137) but never read from)

I looked into adding tests for this, but it's not straightforward. Currently there are no tests covering containerd cri exec or attach flows, except for k8s cri-tools critest. So I verified manually that both exec and attach work instead.


Signed-off-by: Nikita Rybak <nikita.rybak@gmail.com>