### PR TITLE
Add action to add PRs to project

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -1,0 +1,18 @@
+name: Add pull requests to review project
+
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add Pull Request to project
+    runs-on: ubuntu-latest
+    permissions:
+      repository-projects: write
+    steps:
+      - uses: actions/add-to-project@v0.4.0
+        with:
+          project-url: https://github.com/orgs/containerd/projects/5
+          github-token: ${{ secrets.GHA_ADD_TO_PROJECT }}


### PR DESCRIPTION
Adds new workflow to run when a PR is open to add it to the pull request project. PRs can be triaged from the board https://github.com/orgs/containerd/projects/5