### PR TITLE
fix panic when containerd-stress density --count 0

### DIFF
--- a/cmd/containerd-stress/density.go
+++ b/cmd/containerd-stress/density.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -47,6 +48,15 @@ var densityCommand = cli.Command{
 		},
 	},
 	Action: func(cliContext *cli.Context) error {
+		var (
+			pids  []uint32
+			count = cliContext.Int("count")
+		)
+
+		if count < 1 {
+			return errors.New("count cannot be less than one")
+		}
+
 		config := config{
 			Address:     cliContext.GlobalString("address"),
 			Duration:    cliContext.GlobalDuration("duration"),
@@ -76,10 +86,6 @@ var densityCommand = cli.Command{
 		s := make(chan os.Signal, 1)
 		signal.Notify(s, syscall.SIGTERM, syscall.SIGINT)
 
-		var (
-			pids  []uint32
-			count = cliContext.Int("count")
-		)
 	loop:
 		for i := 0; i < count+1; i++ {
 			select {


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

/kind bug

Fix panic , when user input --count 0 or <0 meaningless number.

before is :
![image](https://user-images.githubusercontent.com/12080746/205262108-d92c5cba-8f58-4b7d-8467-ca56ae784dd5.png)

fix after is:
<img width="687" alt="企业微信截图_c3dd8f40-052d-4548-889d-5143eda7932d" src="https://user-images.githubusercontent.com/12080746/205261910-cff8074f-4f52-43cc-98ea-046e1701583f.png">
