### PR TITLE
Fix process_vm_* syscall names in seccomp

### DIFF
--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -490,8 +490,8 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 		if ok {
 			s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
 				Names: []string{
-					"process_vm_read",
-					"process_vm_write",
+					"process_vm_readv",
+					"process_vm_writev",
 					"ptrace",
 				},
 				Action: specs.ActAllow,


### PR DESCRIPTION
In #7693 we added two ptrace related syscalls for kernels >= 4.8, however I believe the syscall names had a minor typo.

Both the [man page](https://man7.org/linux/man-pages/man2/process_vm_readv.2.html) and the [docker seccomp default](https://github.com/moby/moby/blob/master/profiles/seccomp/default_linux.go#L405-L417) that was being compared show the syscalls are named:

`process_vm_readv`
`process_vm_writev` 

(This is also the syscall name we use later in this file when `CAP_SYS_PTRACE` is checked [here](https://github.com/containerd/containerd/blob/main/contrib/seccomp/seccomp_default.go#L639-L640))

It may be worth trying to confirm (using [a toy program](https://gist.github.com/FergusInLondon/fec6aebabc3c9e61e284983618f40730) that uses the `process_vm_ready` syscall) that this now provides the expected behavior if someone can help with that.


Signed-off-by: Craig Ingram <cjingram@google.com>