### PR TITLE
[release/1.6] fix: support simultaneous create diff for same parent snapshot

### DIFF
--- a/rootfs/diff.go
+++ b/rootfs/diff.go
@@ -44,7 +44,7 @@ func CreateDiff(ctx context.Context, snapshotID string, sn snapshots.Snapshotter
 		return ocispec.Descriptor{}, err
 	}
 
-	lowerKey := fmt.Sprintf("%s-parent-view", info.Parent)
+	lowerKey := fmt.Sprintf("%s-parent-view-%s", info.Parent, uniquePart())
 	lower, err := sn.View(ctx, lowerKey, info.Parent)
 	if err != nil {
 		return ocispec.Descriptor{}, err
@@ -58,7 +58,7 @@ func CreateDiff(ctx context.Context, snapshotID string, sn snapshots.Snapshotter
 			return ocispec.Descriptor{}, err
 		}
 	} else {
-		upperKey := fmt.Sprintf("%s-view", snapshotID)
+		upperKey := fmt.Sprintf("%s-view-%s", snapshotID, uniquePart())
 		upper, err = sn.View(ctx, upperKey, snapshotID)
 		if err != nil {
 			return ocispec.Descriptor{}, err


### PR DESCRIPTION
Cherry-pick into 1.6:
- https://github.com/containerd/containerd/pull/7204

This makes it possible to run `rootfs.CreateDiff` multiple times simultaneously.

Original PR message:
"""
In CreateDiff function, we wil create view snapshot base on parent snapshot,
view snapshot name is "`<parent snapshot KEY>`-parent-view",

so while, It does not support concurrent operations，other user will be return to the error that the snapshot already exists.

So, we add uniquePart() as a suffix.
"""


(cherry picked from commit 344431cdd48ec19b73fdc5d36f056eb7bee5154b)
Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>