### PR TITLE
Prepare release notes for v1.5.15

### DIFF
--- a/releases/v1.5.15.toml
+++ b/releases/v1.5.15.toml
@@ -1,0 +1,23 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release
+previous = "v1.5.14"
+
+pre_release = false
+
+preface = """\
+The fifteenth patch release for containerd 1.5 includes various fixes including a
+fix for a long time issue with CNI resource leakage.
+
+### Notable Updates
+
+* **Fix CNI leaks by changing pod network setup order in CRI plugin** ([#7464](https://github.com/containerd/containerd/pull/7464))
+* **Fix request retry on push** ([#7479](https://github.com/containerd/containerd/pull/7479))
+* **Fix lease labels unexpectedly overwriting expiration** ([#7746](https://github.com/containerd/containerd/pull/7746))
+
+See the changelog for complete list of changes"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.5.14+unknown"
+	Version = "1.5.15+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated release notes
----
containerd 1.5.15

Welcome to the v1.5.15 release of containerd!

The fifteenth patch release for containerd 1.5 includes various fixes including a
long time issue with CNI resource leakage.

### Notable Updates

* **Fix CNI leaks by changing pod network setup order in CRI plugin** ([#7464](https://github.com/containerd/containerd/pull/7464))
* **Fix request retry on push** ([#7479](https://github.com/containerd/containerd/pull/7479))
* **Fix lease labels unexpectedly overwriting expiration** ([#7746](https://github.com/containerd/containerd/pull/7746))

See the changelog for complete list of changes

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Akihiro Suda
* Sebastiaan van Stijn
* Wei Fu
* Derek McGowan
* Phil Estes
* Kazuyoshi Kato
* Hajime Tazaki
* Qiutong Song
* Austin Vazquez
* Samuel Karp
* jonyhy
* Akhil Mohan
* Gabriel Adrian Samfira
* Gavin Inglis
* Tobias Klauser
* Yasin Turan
* rongfu.leng

### Changes
<details><summary>33 commits</summary>
<p>

  * Prepare release notes for v1.5.15
* [release/1.5] cherry-pick: Fix order of operations when setting lease labels ([#7746](https://github.com/containerd/containerd/pull/7746))
  * Fix order of operations when setting lease labels
* [release/1.5] go.mod: use golang_protobuf_extensions v1.0.4 to prevent incompatible versions ([#7722](https://github.com/containerd/containerd/pull/7722))
  * [release/1.5] go.mod: use golang_protobuf_extensions v1.0.4
* [release/1.5] retry request on writer reset ([#7479](https://github.com/containerd/containerd/pull/7479))
  * fix pusher concurrent close channel
  * retry request on writer reset
* [release/1.5] Setup pod network after creating the sandbox container ([#7464](https://github.com/containerd/containerd/pull/7464))
  * Update container with sandbox metadata after NetNS is created
  * Add integration tests with failpoint
  * Persist container and sandbox if resource cleanup fails, like teardownPodNetwork
* [release/1.5] ctr export strictly match default platform ([#7649](https://github.com/containerd/containerd/pull/7649))
  * ctr export strictly match default platform
* [release/1.5] update to Go 1.18.8 to address CVE-2022-41716 ([#7633](https://github.com/containerd/containerd/pull/7633))
  * [release/1.5] update to Go 1.18.8 to address CVE-2022-41716
* [release/1.5] ctr import: strictly match platform ([#7593](https://github.com/containerd/containerd/pull/7593))
  * ctr import: strictly match platform
* [release/1.5] Upgrade containerd/continuity from v0.1.0 to v0.3.0 ([#7555](https://github.com/containerd/containerd/pull/7555))
  * Upgrade containerd/continuity from v0.1.0 to v0.3.0
* [release/1.5] feat: support import image for specific platform ([#7595](https://github.com/containerd/containerd/pull/7595))
  * fix: wrong flag type
  * feat: support import image for specific platform
* [release/1.5] cherry-pick: Migrate away from GitHub actions set-output ([#7583](https://github.com/containerd/containerd/pull/7583))
  * Migrate away from GitHub actions set-output
* [release/1.5] test: introduce failpoint control to runc-shimv2 and cni  ([#7578](https://github.com/containerd/containerd/pull/7578))
  * integration: Add injected failpoint testing for RunPodSandbox
  * integration: simplify CNI-fp and add README.md
  * pkg/failpoint: add FreeBSD link and update pkg doc
  * integration: CNI bridge wrapper with failpoint
  * pkg/failpoint: add DelegatedEval API
  * bin/ctr,integration: new runc-shim with failpoint
  * pkg/failpoint: init failpoint package
</p>
</details>

### Changes from containerd/continuity
<details><summary>56 commits</summary>
<p>

* go.mod: update dependencies (take 2) ([#204](https://github.com/containerd/continuity/pull/204))
  * go.mod: update dependencies (take 2)
* Revert "go.mod: update dependencies" ([#205](https://github.com/containerd/continuity/pull/205))
  * Revert "go.mod: update dependencies"
  * go.mod: update dependencies
  * cmd/continuity: remove FUSE for macOS
* Various small fix-ups ([#202](https://github.com/containerd/continuity/pull/202))
  * README: update badges and links
  * golangci-lint: replace "golint" with "revive"
  * sysx: remove unused sysx/generate.sh script
  * fs: fix minor linting and gofmt issue
* update authors and mailmap ([#201](https://github.com/containerd/continuity/pull/201))
  * update authors and mailmap
* move cmd/continuity to its own go module ([#200](https://github.com/containerd/continuity/pull/200))
  * move cmd/continuity to its own go module
  * remove version package
  * move continuityfs -> cmd/continuity/continuityfs
  * move commands -> cmd/continuity/commands
  * go.mod: update logrus to v1.8.1
* CI: resolve Go path before sudoing ; Remove deprecated io/ioutil (except ioutil.ReadDir)  ([#198](https://github.com/containerd/continuity/pull/198))
  * CI: resolve Go path before sudoing
  * CI: modernize Go setup
  * Remove deprecated io/ioutil (except ioutil.ReadDir)
* fs.CopyDir: support sockets and pipes ([#197](https://github.com/containerd/continuity/pull/197))
  * fs.CopyDir: support sockets and pipes
* Fix wrapping errors ([#196](https://github.com/containerd/continuity/pull/196))
  * fs: fix wrapping nil err
  * fmt.Errorf: use %w, not %v to wrap errors
* fs: use syscall.Timespec.Unix ([#193](https://github.com/containerd/continuity/pull/193))
  * fs: use syscall.Timespec.Unix
* Update CI Go version to 1.17 ([#192](https://github.com/containerd/continuity/pull/192))
  * Update CI Go version to 1.17
* Build containerd/continuity on multiple Unix OSes ([#190](https://github.com/containerd/continuity/pull/190))
  * Build containerd/continuity on multiple Unix OSes
* Do not log errors before returning them ([#191](https://github.com/containerd/continuity/pull/191))
  * Do not log errors before returning them
* Copy Windows file metadata ([#188](https://github.com/containerd/continuity/pull/188))
  * Copy Windows file metadata
* fix fmt.Errorf("%w", err) on err == nil ([#187](https://github.com/containerd/continuity/pull/187))
  * fix fmt.Errorf("%w", err) on err == nil
* Remove direct dependency on github.com/pkg/errors ([#185](https://github.com/containerd/continuity/pull/185))
  * run gofmt with Go 1.17
  * remove direct dependency on github.com/pkg/errors
* Fix darwin issues ([#186](https://github.com/containerd/continuity/pull/186))
  * update AUTHORS
  * darwin: use utimensat syscall instead of utimes
  * fix darwin usage of du command
* go.mod: bazil.org/fuse v0.0.0-20200407214033-5883e5a4b5125 ([#161](https://github.com/containerd/continuity/pull/161))
  * go.mod: bazil.org/fuse v0.0.0-20200407214033-5883e5a4b5125
* fs/stat: add FreeBSD, and cleanup some nolint-comments ([#184](https://github.com/containerd/continuity/pull/184))
  * reformat nolint comments
  * fs/stat: add FreeBSD
* Rename branch from master to main ([#182](https://github.com/containerd/continuity/pull/182))
  * Rename branch from master to main
* testutil/loopback: print more debug info ([#180](https://github.com/containerd/continuity/pull/180))
  * testutil/loopback: print more debug info
</p>
</details>

### Dependency Changes

* **github.com/Microsoft/go-winio**     v0.4.17 -> v0.5.2
* **github.com/containerd/continuity**  v0.1.0 -> v0.3.0
* **google.golang.org/protobuf**        v1.27.1 **_new_**

Previous release can be found at [v1.5.14](https://github.com/containerd/containerd/releases/tag/v1.5.14)
