### PR TITLE
Prepare release notes for v1.6.11

### DIFF
--- a/releases/v1.6.11.toml
+++ b/releases/v1.6.11.toml
@@ -1,0 +1,22 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release
+previous = "v1.6.10"
+
+pre_release = false
+
+preface = """\
+The eleventh patch release for containerd 1.6 contains a various fixes and updates.
+
+### Notable Updates
+* **Add pod UID annotation in CRI plugin** ([#7735](https://github.com/containerd/containerd/pull/7735))
+* **Fix nil pointer deference for Windows containers in CRI plugin** ([#7737](https://github.com/containerd/containerd/pull/7737))
+* **Fix lease labels unexpectedly overwriting expiration** ([#7745](https://github.com/containerd/containerd/pull/7745))
+* **Fix for simultaneous diff creation using the same parent snapshot** ([#7756](https://github.com/containerd/containerd/pull/7756))
+
+See the changelog for complete list of changes"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.10+unknown"
+	Version = "1.6.11+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated release notes
------
containerd 1.6.11

Welcome to the v1.6.11 release of containerd!

The eleventh patch release for containerd 1.6 contains a various fixes and updates.

### Notable Updates
* **Add POD UID annotation in CRI plugin** ([#7735](https://github.com/containerd/containerd/pull/7735))
* **Fix nil pointer deference for Windows containers in CRI plugin** ([#7737](https://github.com/containerd/containerd/pull/7737))
* **Fix lease labels unexpectedly overwriting expiration** ([#7745](https://github.com/containerd/containerd/pull/7745))
* **Fix for simultaneous diff creation using the same parent snapshot** ([#7756](https://github.com/containerd/containerd/pull/7756))

See the changelog for complete list of changes

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Derek McGowan
* Wei Fu
* Austin Vazquez
* Kirtana Ashok
* Maksym Pavlenko
* Phil Estes
* Qasim Sarfraz
* Sebastiaan van Stijn
* cosmoer

### Changes
<details><summary>11 commits</summary>
<p>

  * Prepare release notes for v1.6.11
* [release/1.6] fix: support simultaneous create diff for same parent snapshot ([#7756](https://github.com/containerd/containerd/pull/7756))
  * fix: support simultaneous create diff for same parent snapshot
* [release/1.6] cherry-pick: Fix order of operations when setting lease labels ([#7745](https://github.com/containerd/containerd/pull/7745))
  * Fix order of operations when setting lease labels
* [release/1.6] Added nullptr checks to pkg/cri/server and sbserver ([#7737](https://github.com/containerd/containerd/pull/7737))
  * Added nullptr checks to pkg/cri/server and sbserver
* [release/1.6] cri: add pod uid annotation ([#7735](https://github.com/containerd/containerd/pull/7735))
  * cri: add pod uid annotation
* [release/1.6] go.mod: use golang_protobuf_extensions v1.0.4 to prevent incompatible versions ([#7723](https://github.com/containerd/containerd/pull/7723))
  * [release/1.6] go.mod: use golang_protobuf_extensions v1.0.4
</p>
</details>

### Dependency Changes

This release has no dependency changes

Previous release can be found at [v1.6.10](https://github.com/containerd/containerd/releases/tag/v1.6.10)