### PR TITLE
Change PushContent to require only Provider

### DIFF
--- a/remotes/handlers.go
+++ b/remotes/handlers.go
@@ -198,7 +198,10 @@ func push(ctx context.Context, provider content.Provider, pusher Pusher, desc oc
 //
 // Base handlers can be provided which will be called before any push specific
 // handlers.
-func PushContent(ctx context.Context, pusher Pusher, desc ocispec.Descriptor, store content.Store, limiter *semaphore.Weighted, platform platforms.MatchComparer, wrapper func(h images.Handler) images.Handler) error {
+//
+// If the passed in content.Provider is also a content.Manager then this will
+// also annotate the distribution sources in the manager.
+func PushContent(ctx context.Context, pusher Pusher, desc ocispec.Descriptor, store content.Provider, limiter *semaphore.Weighted, platform platforms.MatchComparer, wrapper func(h images.Handler) images.Handler) error {
 
 	var m sync.Mutex
 	manifests := []ocispec.Descriptor{}
@@ -225,13 +228,14 @@ func PushContent(ctx context.Context, pusher Pusher, desc ocispec.Descriptor, st
 
 	platformFilterhandler := images.FilterPlatforms(images.ChildrenHandler(store), platform)
 
-	annotateHandler := annotateDistributionSourceHandler(platformFilterhandler, store)
+	var handler images.Handler
+	if m, ok := store.(content.Manager); ok {
+		annotateHandler := annotateDistributionSourceHandler(platformFilterhandler, m)
+		handler = images.Handlers(annotateHandler, filterHandler, pushHandler)
+	} else {
+		handler = images.Handlers(platformFilterhandler, filterHandler, pushHandler)
+	}
 
-	var handler images.Handler = images.Handlers(
-		annotateHandler,
-		filterHandler,
-		pushHandler,
-	)
 	if wrapper != nil {
 		handler = wrapper(handler)
 	}


### PR DESCRIPTION
Before this required a full content.Store so that it could annotate distribution sources.
With this change PushContent can be used with just a content.Provider. If the content.Provider is also a content.Manager then distribution sources will be updated accordingly.

This allows people to use this function with a significantly implementation.

---

I was trying to use remotes.PushContent to implement push directly from an OCI tarball only to realize this wants the full content.Store which I had no interest in implementing for a read-only tarball.