### PR TITLE
[release/1.5] update to go1.18.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.18.8]
+        go-version: [1.18.9]
         os: [ubuntu-18.04, macos-12, windows-2019]
 
     steps:
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.8'
+          go-version: '1.18.9'
 
       - uses: actions/checkout@v2
         with:
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.8'
+          go-version: '1.18.9'
 
       - uses: actions/checkout@v2
         with:
@@ -104,7 +104,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.8'
+          go-version: '1.18.9'
       - uses: actions/checkout@v2
       - run: go install github.com/cpuguy83/go-md2man/v2@v2.0.1
       - run: make man
@@ -138,7 +138,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.8'
+          go-version: '1.18.9'
       - uses: actions/checkout@v2
       - run: |
           set -e -x
@@ -195,7 +195,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-12, windows-2019]
-        go-version: ['1.18.8']
+        go-version: ['1.18.9']
 
     steps:
       - uses: actions/setup-go@v2
@@ -237,7 +237,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.8'
+          go-version: '1.18.9'
 
       - uses: actions/checkout@v2
         with:
@@ -326,7 +326,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.8'
+          go-version: '1.18.9'
 
       - uses: actions/checkout@v2
 
@@ -468,7 +468,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.8'
+          go-version: '1.18.9'
       - uses: actions/checkout@v2
       - run: sudo -E PATH=$PATH script/setup/install-gotestsum
       - name: Tests

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.8'
+          go-version: '1.18.9'
 
       - uses: actions/checkout@v2
         with:
@@ -135,7 +135,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18.8'
+          go-version: '1.18.9'
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.18.8'
+          go-version: '1.18.9'
 
       - name: Set env
         shell: bash

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,7 +77,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.18.8",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.18.9",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -10,7 +10,7 @@
 #
 # docker build -t containerd-test --build-arg RUNC_VERSION=v1.0.0-rc93 -f Dockerfile.test ../
 
-ARG GOLANG_VERSION=1.18.8
+ARG GOLANG_VERSION=1.18.9
 
 FROM golang:${GOLANG_VERSION} AS golang-base
 RUN mkdir -p /go/src/github.com/containerd/containerd


### PR DESCRIPTION
- relates to https://github.com/containerd/containerd/pull/7765


Includes security fixes for net/http (CVE-2022-41717, CVE-2022-41720), and os (CVE-2022-41720).

These minor releases include 2 security fixes following the security policy:

- os, net/http: avoid escapes from os.DirFS and http.Dir on Windows

  The os.DirFS function and http.Dir type provide access to a tree of files rooted at a given directory. These functions permitted access to Windows device files under that root. For example, os.DirFS("C:/tmp").Open("COM1") would open the COM1 device. Both os.DirFS and http.Dir only provide read-only filesystem access.

  In addition, on Windows, an os.DirFS for the directory \(the root of the current drive) can permit a maliciously crafted path to escape from the drive and access any path on the system.

  The behavior of os.DirFS("") has changed. Previously, an empty root was treated equivalently to "/", so os.DirFS("").Open("tmp") would open the path "/tmp". This now returns an error.

  This is CVE-2022-41720 and Go issue https://go.dev/issue/56694.

- net/http: limit canonical header cache by bytes, not entries

  An attacker can cause excessive memory growth in a Go server accepting HTTP/2 requests.

  HTTP/2 server connections contain a cache of HTTP header keys sent by the client. While the total number of entries in this cache is capped, an attacker sending very large keys can cause the server to allocate approximately 64 MiB per open connection.

  This issue is also fixed in golang.org/x/net/http2 vX.Y.Z, for users manually configuring HTTP/2.

  Thanks to Josselin Costanzi for reporting this issue.

  This is CVE-2022-41717 and Go issue https://go.dev/issue/56350.

View the release notes for more information:
https://go.dev/doc/devel/release#go1.18.9

And the milestone on the issue tracker:
https://github.com/golang/go/issues?q=milestone%3AGo1.18.9+label%3ACherryPickApproved

Full diff: https://github.com/golang/go/compare/go1.18.8...go1.18.9

The golang.org/x/net fix is in https://github.com/golang/net/commit/1e63c2f08a10a150fa02c50ece89b340ae64efe4

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>