### PR TITLE
fix: check for tmpfs when evaluating if userxattr is needed

### DIFF
--- a/snapshots/overlay/overlayutils/check.go
+++ b/snapshots/overlay/overlayutils/check.go
@@ -23,12 +23,18 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 
 	kernel "github.com/containerd/containerd/contrib/seccomp/kernelversion"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/pkg/userns"
 	"github.com/containerd/continuity/fs"
+)
+
+const (
+	// see https://man7.org/linux/man-pages/man2/statfs.2.html
+	tmpfsMagic = 0x01021994
 )
 
 // SupportsMultipleLowerDir checks if the system supports multiple lowerdirs,
@@ -88,6 +94,21 @@ func Supported(root string) error {
 	return SupportsMultipleLowerDir(root)
 }
 
+// IsPathOnTmpfs returns whether the path is on a tmpfs or not.
+//
+// It uses statfs to check if the fs type is TMPFS_MAGIC (0x01021994)
+// see https://man7.org/linux/man-pages/man2/statfs.2.html
+func IsPathOnTmpfs(d string) bool {
+	stat := syscall.Statfs_t{}
+	err := syscall.Statfs(d, &stat)
+	if err != nil {
+		log.L.WithError(err).Warnf("Could not retrieve statfs for %v", d)
+		return false
+	}
+
+	return stat.Type == tmpfsMagic
+}
+
 // NeedsUserXAttr returns whether overlayfs should be mounted with the "userxattr" mount option.
 //
 // The "userxattr" option is needed for mounting overlayfs inside a user namespace with kernel >= 5.11.
@@ -111,6 +132,11 @@ func NeedsUserXAttr(d string) (bool, error) {
 	if !userns.RunningInUserNS() {
 		// we are the real root (i.e., the root in the initial user NS),
 		// so we do never need "userxattr" opt.
+		return false, nil
+	}
+
+	// userxattr not permitted on tmpfs https://man7.org/linux/man-pages/man5/tmpfs.5.html
+	if IsPathOnTmpfs(d) {
 		return false, nil
 	}
 


### PR DESCRIPTION
Fixes #7770
It uses [statfs](https://man7.org/linux/man-pages/man2/statfs.2.html) to check if the dir provided to [NeedsUserXAttr](https://github.com/containerd/containerd/blob/0fa51f54dfee239c606b837aaa8c8ae6b28a9c4a/snapshots/overlay/overlayutils/check.go#L110) function is on a tempfs.

For detail information see #7770