### PR TITLE
Cleanup build constraints

### DIFF
--- a/archive/tar_mostunix.go
+++ b/archive/tar_mostunix.go
@@ -1,5 +1,4 @@
 //go:build !windows && !freebsd
-// +build !windows,!freebsd
 
 /*
    Copyright The containerd Authors.

--- a/archive/tar_test.go
+++ b/archive/tar_test.go
@@ -1,5 +1,4 @@
 //go:build !windows && !darwin
-// +build !windows,!darwin
 
 /*
    Copyright The containerd Authors.

--- a/archive/tar_unix.go
+++ b/archive/tar_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/archive/time_unix.go
+++ b/archive/time_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/cio/io_unix.go
+++ b/cio/io_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/cio/io_unix_test.go
+++ b/cio/io_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/cmd/containerd-shim-runc-v1/main.go
+++ b/cmd/containerd-shim-runc-v1/main.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/cmd/containerd-shim-runc-v2/main.go
+++ b/cmd/containerd-shim-runc-v2/main.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/cmd/containerd-shim/main_unix.go
+++ b/cmd/containerd-shim/main_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/cmd/containerd-stress/rlimit_unix.go
+++ b/cmd/containerd-stress/rlimit_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows && !freebsd
-// +build !windows,!freebsd
 
 /*
    Copyright The containerd Authors.

--- a/cmd/containerd/builtins/aufs_linux.go
+++ b/cmd/containerd/builtins/aufs_linux.go
@@ -1,5 +1,4 @@
 //go:build !no_aufs
-// +build !no_aufs
 
 /*
    Copyright The containerd Authors.

--- a/cmd/containerd/builtins/btrfs_linux.go
+++ b/cmd/containerd/builtins/btrfs_linux.go
@@ -1,5 +1,4 @@
 //go:build !no_btrfs && cgo
-// +build !no_btrfs,cgo
 
 /*
    Copyright The containerd Authors.

--- a/cmd/containerd/builtins/builtins_unix.go
+++ b/cmd/containerd/builtins/builtins_unix.go
@@ -1,5 +1,4 @@
 //go:build darwin || freebsd || solaris
-// +build darwin freebsd solaris
 
 /*
    Copyright The containerd Authors.

--- a/cmd/containerd/builtins/cri.go
+++ b/cmd/containerd/builtins/cri.go
@@ -1,3 +1,5 @@
+//go:build !no_cri
+
 /*
    Copyright The containerd Authors.
 
@@ -14,26 +16,8 @@
    limitations under the License.
 */
 
-package main
+package builtins
 
 import (
-	"fmt"
-	"os"
-
-	"github.com/containerd/containerd/cmd/containerd/command"
-	"github.com/containerd/containerd/pkg/seed"
-
-	_ "github.com/containerd/containerd/cmd/containerd/builtins"
+	_ "github.com/containerd/containerd/pkg/cri"
 )
-
-func init() {
-	seed.WithTimeAndRand()
-}
-
-func main() {
-	app := command.App()
-	if err := app.Run(os.Args); err != nil {
-		fmt.Fprintf(os.Stderr, "containerd: %s\n", err)
-		os.Exit(1)
-	}
-}

--- a/cmd/containerd/builtins/devmapper_linux.go
+++ b/cmd/containerd/builtins/devmapper_linux.go
@@ -1,5 +1,4 @@
 //go:build !no_devmapper
-// +build !no_devmapper
 
 /*
    Copyright The containerd Authors.

--- a/cmd/containerd/builtins/tracing.go
+++ b/cmd/containerd/builtins/tracing.go
@@ -1,5 +1,4 @@
 //go:build !no_tracing
-// +build !no_tracing
 
 /*
    Copyright The containerd Authors.

--- a/cmd/containerd/builtins/zfs_linux.go
+++ b/cmd/containerd/builtins/zfs_linux.go
@@ -1,5 +1,4 @@
 //go:build !no_zfs
-// +build !no_zfs
 
 /*
    Copyright The containerd Authors.

--- a/cmd/containerd/command/main_unix.go
+++ b/cmd/containerd/command/main_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin || freebsd || solaris
-// +build linux darwin freebsd solaris
 
 /*
    Copyright The containerd Authors.

--- a/cmd/containerd/command/notify_unsupported.go
+++ b/cmd/containerd/command/notify_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 /*
    Copyright The containerd Authors.

--- a/cmd/containerd/command/service_unsupported.go
+++ b/cmd/containerd/command/service_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/cmd/ctr/app/main_unix.go
+++ b/cmd/ctr/app/main_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/cmd/ctr/commands/commands_unix.go
+++ b/cmd/ctr/commands/commands_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/cmd/ctr/commands/namespaces/namespaces_other.go
+++ b/cmd/ctr/commands/namespaces/namespaces_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 /*
    Copyright The containerd Authors.

--- a/cmd/ctr/commands/pprof/pprof_unix.go
+++ b/cmd/ctr/commands/pprof/pprof_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/cmd/ctr/commands/shim/io_unix.go
+++ b/cmd/ctr/commands/shim/io_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/cmd/ctr/commands/shim/shim.go
+++ b/cmd/ctr/commands/shim/shim.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/cmd/ctr/commands/signals_notlinux.go
+++ b/cmd/ctr/commands/signals_notlinux.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 /*
    Copyright The containerd Authors.

--- a/cmd/ctr/commands/tasks/tasks_unix.go
+++ b/cmd/ctr/commands/tasks/tasks_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/container_opts_unix.go
+++ b/container_opts_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/defaults/defaults_unix.go
+++ b/defaults/defaults_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows && !darwin
-// +build !windows,!darwin
 
 /*
    Copyright The containerd Authors.

--- a/diff/stream_unix.go
+++ b/diff/stream_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/integration/addition_gids_test.go
+++ b/integration/addition_gids_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/integration/container_update_resources_test.go
+++ b/integration/container_update_resources_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/integration/sandbox_clean_remove_test.go
+++ b/integration/sandbox_clean_remove_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/integration/sandbox_clean_remove_windows_test.go
+++ b/integration/sandbox_clean_remove_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
    Copyright The containerd Authors.

--- a/integration/sandbox_run_rollback_test.go
+++ b/integration/sandbox_run_rollback_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/integration/shim_dial_unix_test.go
+++ b/integration/shim_dial_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/integration/volume_copy_up_unix_test.go
+++ b/integration/volume_copy_up_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/integration/volume_copy_up_windows_test.go
+++ b/integration/volume_copy_up_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
    Copyright The containerd Authors.

--- a/integration/windows_hostprocess_test.go
+++ b/integration/windows_hostprocess_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
    Copyright The containerd Authors.

--- a/integration/windows_rootfs_size_test.go
+++ b/integration/windows_rootfs_size_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
    Copyright The containerd Authors.

--- a/mount/lookup_unix.go
+++ b/mount/lookup_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/mount/lookup_unsupported.go
+++ b/mount/lookup_unsupported.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
    Copyright The containerd Authors.

--- a/mount/mount_unix.go
+++ b/mount/mount_unix.go
@@ -1,5 +1,4 @@
 //go:build darwin || openbsd
-// +build darwin openbsd
 
 /*
    Copyright The containerd Authors.

--- a/mount/temp_unix.go
+++ b/mount/temp_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows && !darwin
-// +build !windows,!darwin
 
 /*
    Copyright The containerd Authors.

--- a/mount/temp_unsupported.go
+++ b/mount/temp_unsupported.go
@@ -1,5 +1,4 @@
 //go:build windows || darwin
-// +build windows darwin
 
 /*
    Copyright The containerd Authors.

--- a/oci/mounts.go
+++ b/oci/mounts.go
@@ -1,5 +1,4 @@
 //go:build !freebsd
-// +build !freebsd
 
 /*
    Copyright The containerd Authors.

--- a/oci/spec_opts_nonlinux.go
+++ b/oci/spec_opts_nonlinux.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 /*
    Copyright The containerd Authors.

--- a/oci/spec_opts_unix.go
+++ b/oci/spec_opts_unix.go
@@ -1,5 +1,4 @@
 //go:build !linux && !windows
-// +build !linux,!windows
 
 /*
    Copyright The containerd Authors.

--- a/oci/spec_opts_unix_test.go
+++ b/oci/spec_opts_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/oci/utils_unix.go
+++ b/oci/utils_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/oci/utils_unix_go116_test.go
+++ b/oci/utils_unix_go116_test.go
@@ -1,5 +1,4 @@
 //go:build !go1.17 && !windows && !darwin
-// +build !go1.17,!windows,!darwin
 
 /*
    Copyright The containerd Authors.

--- a/oci/utils_unix_go117_test.go
+++ b/oci/utils_unix_go117_test.go
@@ -1,5 +1,4 @@
 //go:build go1.17 && !windows && !darwin
-// +build go1.17,!windows,!darwin
 
 /*
    Copyright The containerd Authors.

--- a/oci/utils_unix_test.go
+++ b/oci/utils_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows && !darwin
-// +build !windows,!darwin
 
 /*
    Copyright The containerd Authors.

--- a/oss_fuzz.go
+++ b/oss_fuzz.go
@@ -1,5 +1,4 @@
 //go:build gofuzz
-// +build gofuzz
 
 /*
    Copyright The containerd Authors.

--- a/pkg/cri/config/config_unix.go
+++ b/pkg/cri/config/config_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/pkg/cri/io/helpers_unix.go
+++ b/pkg/cri/io/helpers_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/pkg/cri/server/bandwidth/linux.go
+++ b/pkg/cri/server/bandwidth/linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/pkg/cri/server/blockio_linux.go
+++ b/pkg/cri/server/blockio_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/pkg/cri/server/blockio_stub_linux.go
+++ b/pkg/cri/server/blockio_stub_linux.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 /*
    Copyright The containerd Authors.

--- a/pkg/cri/server/container_create_other.go
+++ b/pkg/cri/server/container_create_other.go
@@ -1,5 +1,4 @@
 //go:build !windows && !linux
-// +build !windows,!linux
 
 /*
    Copyright The containerd Authors.

--- a/pkg/cri/server/container_create_other_test.go
+++ b/pkg/cri/server/container_create_other_test.go
@@ -1,5 +1,4 @@
 //go:build !windows && !linux
-// +build !windows,!linux
 
 /*
    Copyright The containerd Authors.

--- a/pkg/cri/server/container_stats_list_other.go
+++ b/pkg/cri/server/container_stats_list_other.go
@@ -1,5 +1,4 @@
 //go:build !windows && !linux
-// +build !windows,!linux
 
 /*
    Copyright The containerd Authors.

--- a/pkg/cri/server/container_update_resources.go
+++ b/pkg/cri/server/container_update_resources.go
@@ -1,5 +1,4 @@
 //go:build !darwin && !freebsd
-// +build !darwin,!freebsd
 
 /*
    Copyright The containerd Authors.

--- a/pkg/cri/server/container_update_resources_other.go
+++ b/pkg/cri/server/container_update_resources_other.go
@@ -1,5 +1,4 @@
 //go:build !windows && !linux
-// +build !windows,!linux
 
 /*
    Copyright The containerd Authors.

--- a/pkg/cri/server/fuzz.go
+++ b/pkg/cri/server/fuzz.go
@@ -1,5 +1,4 @@
 //go:build gofuzz
-// +build gofuzz
 
 /*
    Copyright The containerd Authors.

--- a/pkg/cri/server/helpers_other.go
+++ b/pkg/cri/server/helpers_other.go
@@ -1,5 +1,4 @@
 //go:build !windows && !linux
-// +build !windows,!linux
 
 /*
    Copyright The containerd Authors.

--- a/pkg/cri/server/rdt_linux.go
+++ b/pkg/cri/server/rdt_linux.go
@@ -1,5 +1,4 @@
 //go:build !no_rdt
-// +build !no_rdt
 
 /*
    Copyright The containerd Authors.

--- a/pkg/cri/server/rdt_stub_linux.go
+++ b/pkg/cri/server/rdt_stub_linux.go
@@ -1,5 +1,4 @@
 //go:build no_rdt
-// +build no_rdt
 
 /*
    Copyright The containerd Authors.

--- a/pkg/cri/server/sandbox_portforward_other.go
+++ b/pkg/cri/server/sandbox_portforward_other.go
@@ -1,5 +1,4 @@
 //go:build !windows && !linux
-// +build !windows,!linux
 
 /*
    Copyright The containerd Authors.

--- a/pkg/cri/server/sandbox_run_other.go
+++ b/pkg/cri/server/sandbox_run_other.go
@@ -1,5 +1,4 @@
 //go:build !windows && !linux
-// +build !windows,!linux
 
 /*
    Copyright The containerd Authors.

--- a/pkg/cri/server/sandbox_run_other_test.go
+++ b/pkg/cri/server/sandbox_run_other_test.go
@@ -1,5 +1,4 @@
 //go:build !windows && !linux
-// +build !windows,!linux
 
 /*
    Copyright The containerd Authors.

--- a/pkg/cri/server/sandbox_stats_other.go
+++ b/pkg/cri/server/sandbox_stats_other.go
@@ -1,5 +1,4 @@
 //go:build !windows && !linux
-// +build !windows,!linux
 
 /*
    Copyright The containerd Authors.

--- a/pkg/cri/server/service_other.go
+++ b/pkg/cri/server/service_other.go
@@ -1,5 +1,4 @@
 //go:build !windows && !linux
-// +build !windows,!linux
 
 /*
    Copyright The containerd Authors.

--- a/pkg/os/mount_other.go
+++ b/pkg/os/mount_other.go
@@ -1,5 +1,4 @@
 //go:build !windows && !linux
-// +build !windows,!linux
 
 /*
    Copyright The containerd Authors.

--- a/pkg/os/mount_unix.go
+++ b/pkg/os/mount_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows && !linux
-// +build !windows,!linux
 
 /*
    Copyright The containerd Authors.

--- a/pkg/os/os_unix.go
+++ b/pkg/os/os_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/pkg/os/testing/fake_os_unix.go
+++ b/pkg/os/testing/fake_os_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/platforms/defaults_darwin.go
+++ b/platforms/defaults_darwin.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 /*
    Copyright The containerd Authors.

--- a/platforms/defaults_unix.go
+++ b/platforms/defaults_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows && !darwin && !freebsd
-// +build !windows,!darwin,!freebsd
 
 /*
    Copyright The containerd Authors.

--- a/platforms/defaults_unix_test.go
+++ b/platforms/defaults_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/platforms/platforms_other.go
+++ b/platforms/platforms_other.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/plugin/plugin_go18.go
+++ b/plugin/plugin_go18.go
@@ -1,5 +1,4 @@
 //go:build go1.8 && !windows && amd64 && !static_build && !gccgo
-// +build go1.8,!windows,amd64,!static_build,!gccgo
 
 /*
    Copyright The containerd Authors.

--- a/plugin/plugin_other.go
+++ b/plugin/plugin_other.go
@@ -1,5 +1,4 @@
 //go:build !go1.8 || windows || !amd64 || static_build || gccgo
-// +build !go1.8 windows !amd64 static_build gccgo
 
 /*
    Copyright The containerd Authors.

--- a/rootfs/init_other.go
+++ b/rootfs/init_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 /*
    Copyright The containerd Authors.

--- a/runtime/v1/shim.go
+++ b/runtime/v1/shim.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/runtime/v1/shim/service.go
+++ b/runtime/v1/shim/service.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/runtime/v1/shim/service_unix.go
+++ b/runtime/v1/shim/service_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows && !linux
-// +build !windows,!linux
 
 /*
    Copyright The containerd Authors.

--- a/runtime/v2/runc/container.go
+++ b/runtime/v2/runc/container.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/runtime/v2/runc/task/service.go
+++ b/runtime/v2/runc/task/service.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/runtime/v2/runc/v1/service.go
+++ b/runtime/v2/runc/v1/service.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/runtime/v2/runc/v2/service.go
+++ b/runtime/v2/runc/v2/service.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/runtime/v2/shim/util_unix.go
+++ b/runtime/v2/shim/util_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/snapshotter_default_unix.go
+++ b/snapshotter_default_unix.go
@@ -1,5 +1,4 @@
 //go:build darwin || freebsd || solaris
-// +build darwin freebsd solaris
 
 /*
    Copyright The containerd Authors.

--- a/snapshotter_opts_unix.go
+++ b/snapshotter_opts_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/sys/filesys_unix.go
+++ b/sys/filesys_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/sys/oom_unsupported.go
+++ b/sys/oom_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 /*
    Copyright The containerd Authors.

--- a/sys/socket_unix.go
+++ b/sys/socket_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/task_opts_unix.go
+++ b/task_opts_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.


### PR DESCRIPTION
1. We no longer need to maintain two versions of build constraints:

`
Go versions 1.16 and earlier used a different syntax for build constraints, with a "// +build" prefix. The gofmt command will add an equivalent //go:build constraint when encountering the older syntax.
`

https://pkg.go.dev/cmd/go#hdr-Build_constraints

2. `no_cri` constraint was not respected.

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>