### PR TITLE
CI: Vagrant: pin rockylinux/8 to v5.0.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,7 +23,8 @@ task:
     HOME: /root
     matrix:
       BOX: fedora/37-cloud-base
-      BOX: rockylinux/8
+      # v7.0.0 does not boot. v6.0.0 was not released.
+      BOX: rockylinux/8@5.0.0
   install_libvirt_vagrant_script: |
     apt-get update
     apt-get install -y libvirt-daemon libvirt-daemon-system vagrant vagrant-libvirt

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,8 +17,9 @@
 
 # Vagrantfile for Fedora and EL
 Vagrant.configure("2") do |config|
-  config.vm.box = ENV["BOX"] || "fedora/37-cloud-base"
-  config.vm.box_version = ENV["BOX_VERSION"]
+  config.vm.box = ENV["BOX"] ? ENV["BOX"].split("@")[0] : "fedora/37-cloud-base"
+  # BOX_VERSION is deprecated. Use "BOX=<BOX>@<BOX_VERSION>".
+  config.vm.box_version = ENV["BOX_VERSION"] || (ENV["BOX"].split("@")[1] if ENV["BOX"])
 
   memory = 4096
   cpus = 2


### PR DESCRIPTION
v7.0.0 does not boot. v6.0.0 was not released.