### PR TITLE
docs: Authorizer.Authorize could return ErrUnexpectedStatus

### DIFF
--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -71,6 +71,9 @@ type Authorizer interface {
 	// unmodified. It may also add an `Authorization` header as
 	//  "bearer <some bearer token>"
 	//  "basic <base64 encoded credentials>"
+	//
+	// It may return remotes/errors.ErrUnexpectedStatus, which for example,
+	// can be used by the caller to find out the status code returned by the registry.
 	Authorize(context.Context, *http.Request) error
 
 	// AddResponses adds a 401 response for the authorizer to consider when


### PR DESCRIPTION
I was interested in the status code returned by the registry, so I traced some code to find `ErrUnexpectedStatus`, and maybe that info can be made more accessible.

Signed-off-by: Hsing-Yu (David) Chen <davidhsingyuchen@gmail.com>