### PR TITLE
allow client to remove created tasks with PID 0

### DIFF
--- a/task.go
+++ b/task.go
@@ -311,6 +311,11 @@ func (t *task) Delete(ctx context.Context, opts ...ProcessDeleteOpts) (*ExitStat
 			// On windows Created is akin to Stopped
 			break
 		}
+		if t.pid == 0 {
+			// allow for deletion of created tasks with PID 0
+			// https://github.com/containerd/containerd/issues/7357
+			break
+		}
 		fallthrough
 	default:
 		return nil, fmt.Errorf("task must be stopped before deletion: %s: %w", status.Status, errdefs.ErrFailedPrecondition)


### PR DESCRIPTION
Fixes #7357

If a container is restored from a checkpoint that has a configuration error, the task for the restored container is created, but fails to start and is left in the state CREATED with a PID of 0. 

In the original issue, the induced error comes from call to `task.Start`:

```
ctr: OCI runtime restore failed: namespace {"not" ""} does not exist: unknown
```

The main task created from a *restored* container will always be PID 0 before the task is explicitly started

https://github.com/containerd/containerd/blob/e1abaeb3862827d3f507c092d5c1c99e0968a8fc/cmd/ctr/commands/containers/restore.go#L107

I had originally intended to make a change on the go-runc side to prevent PID 0 tasks from even being created, but given that restored tasks are assigned a PID at `task.Start`, that would have been a breaking change.

If the task fails to start in this case, the task will be left in the CREATED state with PID 0. Before this change, the only way to remove this task was to find the PID of the shim monitoring the task and kill that process. Now, `ctr t rm <task>` will work on tasks that result in the CREATED state with PID 0.

Signed-off-by: Gavin Inglis <giinglis@amazon.com>