### PR TITLE
Upgrade GitHub actions packages in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,10 +97,10 @@ jobs:
           path: src/github.com/containerd/containerd
 
       - name: Setup buildx instance
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         with:
           use: true
-      - uses: crazy-max/ghaction-github-runtime@v1 # sets up needed vars for caching to github
+      - uses: crazy-max/ghaction-github-runtime@v2 # sets up needed vars for caching to github
       - name: Make
         shell: bash
         run: |
@@ -135,7 +135,7 @@ jobs:
     needs: [build, check]
     steps:
       - name: Download builds and release notes
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: builds
       - name: Create Release


### PR DESCRIPTION
Resolve NodeJS 12 and command deprecation warnings by upgrading docker/setup-buildx-action and crazy-max/ghaction-github-runtime packages.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Last release: https://github.com/containerd/containerd/actions/runs/3643283543
Related-issue: https://github.com/containerd/project/issues/95

- [x] Test release [run](https://github.com/austinvazquez/containerd/actions/runs/3663314486)

Signed-off-by: Austin Vazquez <macedonv@amazon.com>