### PR TITLE
Enable GitHub Actions local Linux CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,6 +462,7 @@ jobs:
         env:
           RUNC_FLAVOR: ${{ matrix.runc }}
         run: |
+          sudo apt-get update
           sudo apt-get install -y gperf libbtrfs-dev
           script/setup/install-seccomp
           script/setup/install-runc
@@ -471,7 +472,7 @@ jobs:
 
       - name: Install criu
         run: |
-          sudo add-apt-repository ppa:criu/ppa
+          sudo add-apt-repository -y ppa:criu/ppa
           sudo apt-get update
           sudo apt-get install -y criu
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,8 +43,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo add-apt-repository "deb [arch=arm64,s390x,ppc64el,riscv64] http://ports.ubuntu.com/ubuntu-ports/ $(lsb_release -sc) main" || true
-          sudo add-apt-repository "deb [arch=arm64,s390x,ppc64el,riscv64] http://ports.ubuntu.com/ubuntu-ports/ $(lsb_release -sc)-updates main" || true
+          sudo add-apt-repository -y "deb [arch=arm64,s390x,ppc64el,riscv64] http://ports.ubuntu.com/ubuntu-ports/ $(lsb_release -sc) main" || true
+          sudo add-apt-repository -y "deb [arch=arm64,s390x,ppc64el,riscv64] http://ports.ubuntu.com/ubuntu-ports/ $(lsb_release -sc)-updates main" || true
 
           sudo dpkg --add-architecture arm64
           sudo dpkg --add-architecture s390x


### PR DESCRIPTION
Resolves minor issues when running GitHub Actions CI locally using nektos/act for Linux jobs.

Sync package index and automatic yes to apt repository prompts.

Tested using the following:

```
act --job integration-linux --privileged --secret GITHUB_TOKEN
act --job linux --privileged --secret GITHUB_TOKEN
```

Still have a few issues with one or two test suites, e.g. mounts and snapshots/overlay, however it has proven useful for fast feedback checks of CI updates.

Signed-off-by: Austin Vazquez <macedonv@amazon.com>