### PR TITLE
bump go version to 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/containerd
 
-go 1.18
+go 1.19
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20221118232415-3345c89a7c72


### PR DESCRIPTION
There are a lot of projects that have been upgraded to 1.19, and it's time for us to upgrade too?
