### PR TITLE
Bump golangci-lint to v1.50.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.49.0
+          version: v1.50.1
           skip-cache: true
           args: --timeout=8m
 

--- a/script/setup/install-dev-tools
+++ b/script/setup/install-dev-tools
@@ -14,7 +14,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-
 #
 # Install developer tools to $GOBIN (or $GOPATH/bin if unset)
 #
@@ -24,7 +23,7 @@ set -eu -o pipefail
 go install github.com/containerd/protobuild@v0.2.0
 go install github.com/containerd/protobuild/cmd/go-fix-acronym@v0.2.0
 go install github.com/cpuguy83/go-md2man/v2@v2.0.2
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
 go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28
 go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
 go install github.com/containerd/ttrpc/cmd/protoc-gen-go-ttrpc@944ef4a40df3446714a823207972b7d9858ffac5


### PR DESCRIPTION
Bumps golangci-lint from `v1.49.0` to `v1.50.1`