### PR TITLE
Update tracing documentation to add details about manual instrumentation

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -96,7 +96,7 @@ In Containerd, a thin wrapper library defined in `tracing/tracing.go` provides a
 
 To create a new span, use the `tracing.StartSpan()` method. You should already have a global TracerProvider set by configuring `io.containerd.tracing.processor.v1.otlp` plugin, else this will only create an instance of a NoopSpan{}.
 
-```
+```go
 func CreateContainer(ctx context.Context, r *runtime.CreateContainerRequest) error {
     ctx, span := tracing.StartSpan(ctx,
         tracing.Name(criSpanPrefix, "CreateContainer") // name of the span
@@ -112,7 +112,7 @@ Mark the span complete at the end of workflow by calling `Span.End()`. In the ab
 
 You can add additional attributes to the span using `Span.SetAttributes()`. Attributes can be added during span creation (by passing `tracing.WithAttribute()` to tracing.StartSpan()) or at any other time during the lifecycle of a span before it has completed.
 
-```
+```go
 func CreateContainer(ctx context.Context, r *runtime.CreateContainerRequest) error {
     ctx, span := tracing.StartSpan(ctx,
         tracing.Name(criSpanPrefix, "CreateContainer")
@@ -135,7 +135,7 @@ func CreateContainer(ctx context.Context, r *runtime.CreateContainerRequest) err
 Use `Span.AddEvent()` to add an event to an existing span. A [span event](https://opentelemetry.io/docs/instrumentation/go/manual/#events) is a specific occurrence within a span, such as the completion of an operation or the occurrence of an error. Span events can be used to provide additional information about the operation represented by the span, and can be used for debugging or performance analysis.
 
 The below example shows how we can add an event to the span to mark the execution of an NRI hook.
-```
+```go
 func CreateContainer(ctx context.Context, r *runtime.CreateContainerRequest) error {
     span := tracing.SpanFromContext(ctx) // get the current span from context
     ...
@@ -146,7 +146,6 @@ func CreateContainer(ctx context.Context, r *runtime.CreateContainerRequest) err
 
         err = c.nri.postCreateContainer(ctx, &sandbox, &container)
         if err != nil {
-            span.RecordError("NRI postCreateContainer request failed") //record error
 			log.G(ctx).WithError(err).Errorf("NRI post-create notification failed")
 		}
 
@@ -162,6 +161,34 @@ func CreateContainer(ctx context.Context, r *runtime.CreateContainerRequest) err
 	return &runtime.CreateContainerResponse{ContainerId: id}, nil
 }
 ```
+
+### Recording errors in a span
+You can  use `Span.RecordError()` to record an error as an exception span event for this span. The `RecordError` function does not automatically set a span’s status to Error, so if you wish to consider the span tracking a failed operation you should use `Span.SetStatus(err error)` to record the error and also set the span status to Error.
+
+To record an error:
+```go
+span := tracing.SpanFromContext(ctx)
+defer span.End()
+...
+err = c.nri.postCreateContainer(ctx, &sandbox, &container)
+if err != nil {
+    span.RecordError(err) //record error
+	log.G(ctx).WithError(err).Errorf("NRI post-create notification failed")
+}
+```
+
+To record an error and also set the span status:
+```go
+span := tracing.SpanFromContext(ctx)
+defer span.End()
+...
+err = c.nri.postCreateContainer(ctx, &sandbox, &container)
+if err != nil {
+    span.SetStatus(err) //record error and set status
+	log.G(ctx).WithError(err).Errorf("NRI post-create notification failed")
+}
+```
+
 ## Naming Convention
 
 OpenTelemetry maintains a set of recommended [semantic conventions](https://opentelemetry.io/docs/reference/specification/overview/#semantic-conventions) for different types of telemetry data, such as traces and metrics, to help users of the OpenTelemetry libraries and tools to collect and use telemetry data in a consistent and interoperable way.


### PR DESCRIPTION
Add a **Manual instrumentation** section in `docs/tracing.md` and added details about how to use the tracing APIs to manual instrument spans in containerd.

Also added a section to list the naming conventions to follow.

Signed-off-by: Swagat Bora <sbora@amazon.com>