### PR TITLE
Remove error check from ctr: with spec config file, only container id should be provided

### DIFF
--- a/cmd/ctr/commands/run/run.go
+++ b/cmd/ctr/commands/run/run.go
@@ -140,9 +140,6 @@ var Command = cli.Command{
 
 		if config {
 			id = context.Args().First()
-			if context.NArg() > 1 {
-				return errors.New("with spec config file, only container id should be provided")
-			}
 		} else {
 			id = context.Args().Get(1)
 			ref = context.Args().First()


### PR DESCRIPTION
This PR removes `with spec config file, only container id should be provided` error check from `ctr`, which requires no other parameters besides `--config` and `id`.

There are certain parameters that are still valid to pass with `--config` (like `--runtime`, `--runtime-config-path`, etc).

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>