### PR TITLE
Bump Go to 1.19

### DIFF
--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -41,13 +41,13 @@ jobs:
         working-directory: src/github.com/containerd/containerd
 
     steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: "1.19.4"
-
       - uses: actions/checkout@v3
         with:
           path: src/github.com/containerd/containerd
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: src/github.com/containerd/containerd/go.mod
 
       - name: Set env
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,6 @@ on:
       - main
       - "release/**"
 
-env:
-  # Go version we currently use to build containerd across all CI.
-  # Note: don't forget to update `Binaries` step, as it contains the matrix of all supported Go versions.
-  GO_VERSION: "1.19.4"
-
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read
 
@@ -40,11 +35,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libbtrfs-dev
 
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
-      - uses: actions/checkout@v3
       - uses: golangci/golangci-lint-action@v3
         with:
           version: v1.50.1
@@ -60,14 +55,14 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
       - uses: actions/checkout@v3
         with:
           path: src/github.com/containerd/containerd
           fetch-depth: 100
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: src/github.com/containerd/containerd/go.mod
 
       - uses: containerd/project-checks@v1
         with:
@@ -92,13 +87,13 @@ jobs:
         working-directory: src/github.com/containerd/containerd
 
     steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
       - uses: actions/checkout@v3
         with:
           path: src/github.com/containerd/containerd
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: src/github.com/containerd/containerd/go.mod
 
       - name: Set env
         shell: bash
@@ -124,10 +119,10 @@ jobs:
     timeout-minutes: 5
 
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
-      - uses: actions/checkout@v3
+          go-version-file: go.mod
       - run: go install github.com/cpuguy83/go-md2man/v2@v2.0.2
       - run: make man
 
@@ -164,10 +159,10 @@ jobs:
             goarm: "7"
 
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
-      - uses: actions/checkout@v3
+          go-version-file: go.mod
       - run: |
           set -e -x
 
@@ -238,17 +233,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-12, windows-2019, windows-2022]
-        go-version: ["1.19.4", "1.18.9"]
     steps:
       - name: Install dependencies
         if: matrix.os == 'ubuntu-20.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y libbtrfs-dev
-
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ${{ matrix.go-version }}
 
       - name: Set env
         shell: bash
@@ -259,6 +249,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           path: src/github.com/containerd/containerd
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: src/github.com/containerd/containerd/go.mod
 
       - name: Make
         run: |
@@ -289,13 +283,13 @@ jobs:
         working-directory: src/github.com/containerd/containerd
 
     steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
       - uses: actions/checkout@v3
         with:
           path: src/github.com/containerd/containerd
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: src/github.com/containerd/containerd/go.mod
+
 
       - uses: actions/checkout@v3
         with:
@@ -452,11 +446,10 @@ jobs:
     env:
       GOTEST: gotestsum --
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - uses: actions/checkout@v3
+          go-version-file: go.mod
 
       - name: Install containerd dependencies
         env:
@@ -599,10 +592,10 @@ jobs:
       GOTEST: gotestsum --
 
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
-      - uses: actions/checkout@v3
+          go-version-file: go.mod
       - run: script/setup/install-gotestsum
       - run: script/setup/install-teststat
       - name: Tests

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.4
+          go-version-file: go.mod
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -38,8 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
-      - uses: actions/checkout@v3
+          go-version-file: go.mod
       - run: script/go-test-fuzz.sh

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -26,13 +26,13 @@ jobs:
         working-directory: src/github.com/containerd/containerd
 
     steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: "1.19.4"
-
       - uses: actions/checkout@v3
         with:
           path: src/github.com/containerd/containerd
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: src/github.com/containerd/containerd/go.mod
 
       - name: Set env
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,9 +6,6 @@ on:
     paths:
       - ".github/workflows/nightly.yml"
 
-env:
-  GO_VERSION: "1.19.4"
-
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read
 
@@ -23,13 +20,13 @@ jobs:
         working-directory: src/github.com/containerd/containerd
 
     steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
       - uses: actions/checkout@v3
         with:
           path: src/github.com/containerd/containerd
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: src/github.com/containerd/containerd/go.mod
 
       - name: Set env
         shell: bash
@@ -161,13 +158,13 @@ jobs:
         working-directory: src/github.com/containerd/containerd
 
     steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
       - uses: actions/checkout@v3
         with:
           path: src/github.com/containerd/containerd
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: src/github.com/containerd/containerd/go.mod
 
       - name: Set env
         shell: bash

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -14,7 +14,7 @@ This doc includes:
 
 To build the `containerd` daemon, and the `ctr` simple test client, the following build system dependencies are required:
 
-* Go 1.18.x or above
+* Go 1.19.x or above
 * Protoc 3.x compiler and headers (download at the [Google protobuf releases page](https://github.com/protocolbuffers/protobuf/releases))
 * Btrfs headers and libraries for your distribution. Note that building the btrfs driver can be disabled via the build tag `no_btrfs`, removing this dependency.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/containerd
 
-go 1.18
+go 1.19
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20221118232415-3345c89a7c72

--- a/integration/client/go.mod
+++ b/integration/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/containerd/integration/client
 
-go 1.18
+go 1.19
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20221118232415-3345c89a7c72


### PR DESCRIPTION
Changes:
- Bumps the version of Go to `1.19`
- Updates CI to read the version of Go from `go.mod`

Go 1.19 is required for #7803 (see [here](https://github.com/containerd/containerd/actions/runs/3692686149/jobs/6251889876#step:6:12))