### PR TITLE
[release/1.6] cri: make swapping disabled with memory limit

### DIFF
--- a/pkg/cri/opts/spec_linux.go
+++ b/pkg/cri/opts/spec_linux.go
@@ -447,6 +447,10 @@ func WithResources(resources *runtime.LinuxContainerResources, tolerateMissingHu
 		}
 		if limit != 0 {
 			s.Linux.Resources.Memory.Limit = &limit
+			// swap/memory limit should be equal to prevent container from swapping by default
+			if swapLimit == 0 {
+				s.Linux.Resources.Memory.Swap = &limit
+			}
 		}
 		if swapLimit != 0 {
 			s.Linux.Resources.Memory.Swap = &swapLimit

--- a/pkg/cri/server/container_update_resources_linux_test.go
+++ b/pkg/cri/server/container_update_resources_linux_test.go
@@ -70,7 +70,10 @@ func TestUpdateOCILinuxResource(t *testing.T) {
 				Process: &runtimespec.Process{OOMScoreAdj: oomscoreadj},
 				Linux: &runtimespec.Linux{
 					Resources: &runtimespec.LinuxResources{
-						Memory: &runtimespec.LinuxMemory{Limit: proto.Int64(54321)},
+						Memory: &runtimespec.LinuxMemory{
+							Limit: proto.Int64(54321),
+							Swap:  proto.Int64(54321),
+						},
 						CPU: &runtimespec.LinuxCPU{
 							Shares: proto.Uint64(4444),
 							Quota:  proto.Int64(5555),
@@ -113,7 +116,10 @@ func TestUpdateOCILinuxResource(t *testing.T) {
 				Process: &runtimespec.Process{OOMScoreAdj: oomscoreadj},
 				Linux: &runtimespec.Linux{
 					Resources: &runtimespec.LinuxResources{
-						Memory: &runtimespec.LinuxMemory{Limit: proto.Int64(54321)},
+						Memory: &runtimespec.LinuxMemory{
+							Limit: proto.Int64(54321),
+							Swap:  proto.Int64(54321),
+						},
 						CPU: &runtimespec.LinuxCPU{
 							Shares: proto.Uint64(4444),
 							Quota:  proto.Int64(5555),
@@ -151,7 +157,10 @@ func TestUpdateOCILinuxResource(t *testing.T) {
 				Process: &runtimespec.Process{OOMScoreAdj: oomscoreadj},
 				Linux: &runtimespec.Linux{
 					Resources: &runtimespec.LinuxResources{
-						Memory: &runtimespec.LinuxMemory{Limit: proto.Int64(54321)},
+						Memory: &runtimespec.LinuxMemory{
+							Limit: proto.Int64(54321),
+							Swap:  proto.Int64(54321),
+						},
 						CPU: &runtimespec.LinuxCPU{
 							Shares: proto.Uint64(4444),
 							Quota:  proto.Int64(5555),
@@ -197,7 +206,10 @@ func TestUpdateOCILinuxResource(t *testing.T) {
 				Process: &runtimespec.Process{OOMScoreAdj: oomscoreadj},
 				Linux: &runtimespec.Linux{
 					Resources: &runtimespec.LinuxResources{
-						Memory: &runtimespec.LinuxMemory{Limit: proto.Int64(54321)},
+						Memory: &runtimespec.LinuxMemory{
+							Limit: proto.Int64(54321),
+							Swap:  proto.Int64(54321),
+						},
 						CPU: &runtimespec.LinuxCPU{
 							Shares: proto.Uint64(4444),
 							Quota:  proto.Int64(5555),


### PR DESCRIPTION
Cherry pick for ["cri: make swapping disabled with memory limit"](https://github.com/containerd/containerd/pull/7783)