### PR TITLE
[release/1.6] allow client to remove created tasks with PID 0

### DIFF
--- a/task.go
+++ b/task.go
@@ -310,6 +310,11 @@ func (t *task) Delete(ctx context.Context, opts ...ProcessDeleteOpts) (*ExitStat
 			// On windows Created is akin to Stopped
 			break
 		}
+		if t.pid == 0 {
+			// allow for deletion of created tasks with PID 0
+			// https://github.com/containerd/containerd/issues/7357
+			break
+		}
 		fallthrough
 	default:
 		return nil, fmt.Errorf("task must be stopped before deletion: %s: %w", status.Status, errdefs.ErrFailedPrecondition)


### PR DESCRIPTION
cherry-pick https://github.com/containerd/containerd/pull/7787/commits/80839f11e2ea6759eed4b5e616d65cb59258a5f3

If a container is restored from a checkpoint that has a configuration error, the task for the restored container is created, but fails to start and is left in the state CREATED with a PID of 0. Before this change, the only way to remove this task was to find the PID of the shim monitoring the task and kill that process. Now, ctr t rm <task> will work on tasks that result in the CREATED state with PID 0.

Signed-off-by: Gavin Inglis <giinglis@amazon.com>
(cherry picked from commit 80839f11e2ea6759eed4b5e616d65cb59258a5f3)
Signed-off-by: Gavin Inglis <giinglis@amazon.com>