### PR TITLE
[release/1.6] Prepare release notes for v1.6.13

### DIFF
--- a/releases/v1.6.13.toml
+++ b/releases/v1.6.13.toml
@@ -1,0 +1,26 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release
+previous = "v1.6.12"
+
+pre_release = false
+
+preface = """\
+The thirteenth patch release for containerd 1.6 contains various fixes and updates.
+
+### Notable Updates
+
+* **Update overlay snapshotter to check for tmpfs when evaluating usage of userxattr** ([#7788](https://github.com/containerd/containerd/pull/7788))
+* **Update hcsschim to v0.9.6 to fix resource leak on exec** ([#7808](https://github.com/containerd/containerd/pull/7808))
+* **Make swapping disabled with memory limit in CRI plugin** ([#7815](https://github.com/containerd/containerd/pull/7815))
+* **Allow clients to remove created tasks with PID 0** ([#7816](https://github.com/containerd/containerd/pull/7816))
+* **Fix concurrent map iteration and map write in CRI port forwarding** ([#7819](https://github.com/containerd/containerd/pull/7819))
+* **Check for nil `HugepageLimits` to avoid panic in CRI plugin** ([#7820](https://github.com/containerd/containerd/pull/7820))
+
+
+See the changelog for complete list of changes"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.12+unknown"
+	Version = "1.6.13+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated notes
----
containerd 1.6.13

Welcome to the v1.6.13 release of containerd!

The thirteenth patch release for containerd 1.6 contains a various fixes and updates.

### Notable Updates

* **Update overlay snapshotter to check for tmpfs when evaluating usage of userxattr** ([#7788](https://github.com/containerd/containerd/pull/7788))
* **Update hcsschim to v0.9.6 to fix resource leak on exec** ([#7808](https://github.com/containerd/containerd/pull/7808))
* **Make swapping disabled with memory limit in CRI plugin** ([#7815](https://github.com/containerd/containerd/pull/7815))
* **Allow clients to remove created tasks with PID 0** ([#7816](https://github.com/containerd/containerd/pull/7816))
* **Fix concurrent map iteration and map write in CRI port forwarding** ([#7819](https://github.com/containerd/containerd/pull/7819))
* **Check for nil `HugepageLimits` to avoid panic in CRI plugin** ([#7820](https://github.com/containerd/containerd/pull/7820))


See the changelog for complete list of changes

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Derek McGowan
* Phil Estes
* Kazuyoshi Kato
* Maksym Pavlenko
* Akhil Mohan
* Akihiro Suda
* Gavin Inglis
* Kirtana Ashok
* Mike Brown
* Qasim Sarfraz
* Shinichi Morimoto
* chaunceyjiang
* mathis-m

### Changes
<details><summary>21 commits</summary>
<p>

  * Prepare release notes for v1.6.13
* [release/1.6] nil check to avoid panic on upgrade ([#7820](https://github.com/containerd/containerd/pull/7820))
  * nil check to avoid panic on upgrade
* [release/1.6] concurrent map iteration and map write ([#7819](https://github.com/containerd/containerd/pull/7819))
  * fatal error: concurrent map iteration and map write
* [release/1.6] allow client to remove created tasks with PID 0 ([#7816](https://github.com/containerd/containerd/pull/7816))
  * allow client to remove created tasks with PID 0
* [release/1.6] cri: make swapping disabled with memory limit ([#7815](https://github.com/containerd/containerd/pull/7815))
  * cri: make swapping disabled with memory limit
* [release/1.6] go.mod: Bump hcsshim to v0.9.6 ([#7808](https://github.com/containerd/containerd/pull/7808))
  * Bump hcsshim to v0.9.6
* [release/1.6] Cherry pick GitHub actions workflow updates 1.6 ([#7713](https://github.com/containerd/containerd/pull/7713))
  * update codeql-action to v2
  * Upgrade actions/upload-artifact from v2 to v3
  * Move up actions versions to prep for deprecation
  * CI: update GHA instances from Ubuntu 18.04 to 20.04
  * Use global env variable to specify Go version on CI
  * Rework permission handling in scripts
  * fix pool_device_test.go
* [release/1.6] fix: check for tmpfs when evaluating if userxattr should be used ([#7788](https://github.com/containerd/containerd/pull/7788))
  * fix: check for tmpfs when evaluating if userxattr should be used
</p>
</details>

### Dependency Changes

* **github.com/Microsoft/hcsshim**  v0.9.5 -> v0.9.6

Previous release can be found at [v1.6.12](https://github.com/containerd/containerd/releases/tag/v1.6.12)
