### PR TITLE
fix ctr delete images flag `--sync`

### DIFF
--- a/cmd/ctr/commands/images/images.go
+++ b/cmd/ctr/commands/images/images.go
@@ -333,9 +333,9 @@ var removeCommand = cli.Command{
 			exitErr    error
 			imageStore = client.ImageService()
 		)
-		for i, target := range context.Args() {
+		for _, target := range context.Args() {
 			var opts []images.DeleteOpt
-			if context.Bool("sync") && i == context.NArg()-1 {
+			if context.Bool("sync") {
 				opts = append(opts, images.SynchronousDelete())
 			}
 			if err := imageStore.Delete(ctx, target, opts...); err != nil {


### PR DESCRIPTION
If we need delete two or more images, the `--sync` is not work to those imges except last image.

command:
```shell
ctr i rm docker.io/library/nginx:latest docker.io/library/nginx:1.21 --sync
```

I don't know wether there is other meanings there, please correct me if I understand this wrong.