### PR TITLE
Revert "[release/1.6] support fetching containerd from non public GCS buckets"

### DIFF
--- a/contrib/gce/configure.sh
+++ b/contrib/gce/configure.sh
@@ -104,17 +104,6 @@ if [ -f "${CONTAINERD_HOME}/${CONTAINERD_ENV_METADATA}" ]; then
   source "${CONTAINERD_HOME}/${CONTAINERD_ENV_METADATA}"
 fi
 
-set +x
-# GCS_BUCKET_TOKEN_METADATA is the metadata key for the GCS bucket token
-GCS_BUCKET_TOKEN_METADATA="GCS_BUCKET_TOKEN"
-# GCS_BUCKET_TOKEN should have read access to the bucket from which
-# containerd artifacts need to be downloaded
-GCS_BUCKET_TOKEN=$(fetch_metadata "${GCS_BUCKET_TOKEN_METADATA}")
-if [[ -n "${GCS_BUCKET_TOKEN}" ]]; then
-  HEADERS=(-H "Authorization: Bearer ${GCS_BUCKET_TOKEN}")
-fi
-set -x
-
 # CONTAINERD_PKG_PREFIX is the prefix of the cri-containerd tarball name.
 # By default use the release tarball with cni built in.
 pkg_prefix=${CONTAINERD_PKG_PREFIX:-"cri-containerd-cni"}
@@ -137,7 +126,7 @@ else
 
   # TODO(random-liu): Put version into the metadata instead of
   # deciding it in cloud init. This may cause issue to reboot test.
-  version=$(set +x; curl -X GET "${HEADERS[@]}" -f --ipv4 --retry 6 --retry-delay 3 --silent --show-error \
+  version=$(curl -f --ipv4 --retry 6 --retry-delay 3 --silent --show-error \
     https://storage.googleapis.com/${deploy_path}/latest)
 fi
 
@@ -163,8 +152,7 @@ else
     echo "${TARBALL_GCS_NAME} is preloaded"
   else
     # Download and untar the release tar ball.
-    $(set +x; curl -X GET "${HEADERS[@]}" -f --ipv4 -Lo "${TARBALL}" --connect-timeout 20 --max-time 300 --retry 6 \
-      --retry-delay 10 "${TARBALL_GCS_PATH}")
+    curl -f --ipv4 -Lo "${TARBALL}" --connect-timeout 20 --max-time 300 --retry 6 --retry-delay 10 "${TARBALL_GCS_PATH}"
     tar xvf "${TARBALL}"
     rm -f "${TARBALL}"
   fi


### PR DESCRIPTION
Reverts containerd/containerd#7823

The changes is causing continuous failure in [containerd-node-e2e-1.6](https://testgrid.k8s.io/sig-node-containerd#containerd-node-e2e-1.6) and [containerd-node-e2e-features-1.6](https://testgrid.k8s.io/sig-node-containerd#containerd-node-e2e-features-1.6), because the actual blob is not getting downloaded as per [logs](https://storage.googleapis.com/kubernetes-jenkins/logs/ci-containerd-node-e2e-1-6/1603606906058838016/artifacts/tmp-node-e2e-3d5a02a8-ubuntu-gke-2204-1-24-v20220623/containerd-installation.log) 