### PR TITLE
Prepare release notes for v1.6.14

### DIFF
--- a/releases/v1.6.14.toml
+++ b/releases/v1.6.14.toml
@@ -1,0 +1,20 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release
+previous = "v1.6.13"
+
+pre_release = false
+
+preface = """\
+The fourteenth patch release for containerd 1.6 fixes a regression in the CRI plugin related to swap
+
+### Notable Updates
+
+* **Fix `memory.memsw.limit_in_bytes: no such file or directory` error in CRI plugin** ([#7838](https://github.com/containerd/containerd/pull/7838))
+
+See the changelog for complete list of changes"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.13+unknown"
+	Version = "1.6.14+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
After #7838 

Generated Release Notes
----
containerd 1.6.14

Welcome to the v1.6.14 release of containerd!

The fourteenth patch release for containerd 1.6 fixes a regression in the CRI plugin related to swap

### Notable Updates

* **Fix `memory.memsw.limit_in_bytes: no such file or directory` error in CRI plugin** ([#7838](https://github.com/containerd/containerd/pull/7838))

See the changelog for complete list of changes

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Akhil Mohan
* Derek McGowan
* Kazuyoshi Kato

### Changes
<details><summary>3 commits</summary>
<p>

  * [`1347d7c87`](https://github.com/containerd/containerd/commit/1347d7c87b01fb27b44a8c3f16b1e8c18ca656bc) Prepare release notes for v1.6.14
* Revert "[release/1.6] support fetching containerd from non public GCS buckets" ([#7830](https://github.com/containerd/containerd/pull/7830))
  * [`e8b22c100`](https://github.com/containerd/containerd/commit/e8b22c100b33e4f9eab68050a2b75deb7f0fadf1) Revert "[release/1.6] support fetching containerd from non public GCS buckets"
</p>
</details>

### Dependency Changes

This release has no dependency changes

Previous release can be found at [v1.6.13](https://github.com/containerd/containerd/releases/tag/v1.6.13)
