### PR TITLE
Remove unused process.Mount and CreateConfig.Rootfs

### DIFF
--- a/pkg/process/types.go
+++ b/pkg/process/types.go
@@ -20,20 +20,11 @@ import (
 	google_protobuf "github.com/containerd/containerd/protobuf/types"
 )
 
-// Mount holds filesystem mount configuration
-type Mount struct {
-	Type    string
-	Source  string
-	Target  string
-	Options []string
-}
-
 // CreateConfig hold task creation configuration
 type CreateConfig struct {
 	ID               string
 	Bundle           string
 	Runtime          string
-	Rootfs           []Mount
 	Terminal         bool
 	Stdin            string
 	Stdout           string

--- a/runtime/v2/runc/container.go
+++ b/runtime/v2/runc/container.go
@@ -59,18 +59,8 @@ func NewContainer(ctx context.Context, platform stdio.Platform, r *task.CreateTa
 		}
 	}
 
-	var pmounts []process.Mount
-	for _, m := range r.Rootfs {
-		pmounts = append(pmounts, process.Mount{
-			Type:    m.Type,
-			Source:  m.Source,
-			Target:  m.Target,
-			Options: m.Options,
-		})
-	}
-
 	rootfs := ""
-	if len(pmounts) > 0 {
+	if len(r.Rootfs) > 0 {
 		rootfs = filepath.Join(r.Bundle, "rootfs")
 		if err := os.Mkdir(rootfs, 0711); err != nil && !os.IsExist(err) {
 			return nil, err
@@ -81,7 +71,6 @@ func NewContainer(ctx context.Context, platform stdio.Platform, r *task.CreateTa
 		ID:               r.ID,
 		Bundle:           r.Bundle,
 		Runtime:          opts.BinaryName,
-		Rootfs:           pmounts,
 		Terminal:         r.Terminal,
 		Stdin:            r.Stdin,
 		Stdout:           r.Stdout,
@@ -100,12 +89,12 @@ func NewContainer(ctx context.Context, platform stdio.Platform, r *task.CreateTa
 	}
 
 	var mounts []mount.Mount
-	for _, pm := range pmounts {
+	for _, m := range r.Rootfs {
 		mounts = append(mounts, mount.Mount{
-			Type:    pm.Type,
-			Source:  pm.Source,
-			Target:  pm.Target,
-			Options: pm.Options,
+			Type:    m.Type,
+			Source:  m.Source,
+			Target:  m.Target,
+			Options: m.Options,
 		})
 	}
 	defer func() {


### PR DESCRIPTION
While working on #7840, I noticed `process.Mount` and related code to be all unused. `process.CreateConfig` isn't serialized anywhere, so removing it seems safe.

---

Signed-off-by: Edgar Lee <edgarhinshunlee@gmail.com>