### PR TITLE
Support OpenTelemetry in ctr

### DIFF
--- a/cmd/ctr/app/trace.go
+++ b/cmd/ctr/app/trace.go
@@ -1,0 +1,60 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/sdk/resource"
+	"go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+)
+
+func newTraceProvider(ctx context.Context, endpoint string) (*trace.TracerProvider, error) {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := []otlptracehttp.Option{otlptracehttp.WithEndpoint(u.Host)}
+	if u.Scheme == "http" {
+		opts = append(opts, otlptracehttp.WithInsecure())
+	} else if u.Scheme == "https" {
+		// Do nothing. HTTPS is the default
+	} else {
+		return nil, fmt.Errorf("%s is not supported", u.Scheme)
+	}
+
+	exp, err := otlptracehttp.New(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+	res, err := resource.New(ctx,
+		resource.WithHost(),
+		resource.WithAttributes(semconv.ServiceNameKey.String("ctr")),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return trace.NewTracerProvider(
+		trace.WithSpanProcessor(trace.NewBatchSpanProcessor(exp)),
+		trace.WithResource(res),
+	), nil
+}


### PR DESCRIPTION
This change adds OpenTelemetry support in ctr. ctr is a debugging/development tool and seeing all calls from there is useful.

<img width="1201" alt="ctr-images-pull" src="https://user-images.githubusercontent.com/19111/208755653-9ca5153f-bb20-4d6f-bdea-fd06ef537b19.png">
