### PR TITLE
[release/1.6] CRI: Fix no CNI info for pod sandbox on restart

### DIFF
--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -295,7 +295,8 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 			// Update spec of the container
 			containerd.UpdateContainerOpts(containerd.WithSpec(spec)),
 			// Update sandbox metadata to include NetNS info
-			containerd.UpdateContainerOpts(containerd.WithContainerExtension(sandboxMetadataExtension, &sandbox.Metadata))); err != nil {
+			containerd.UpdateContainerOpts(containerd.WithContainerExtension(sandboxMetadataExtension, &sandbox.Metadata)),
+		); err != nil {
 			return nil, fmt.Errorf("failed to update the network namespace for the sandbox container %q: %w", id, err)
 		}
 
@@ -323,6 +324,14 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		// SandboxStatus request.
 		if err := c.setupPodNetwork(ctx, &sandbox); err != nil {
 			return nil, fmt.Errorf("failed to setup network for sandbox %q: %w", id, err)
+		}
+
+		// Update metadata here to save CNI result and pod IPs to disk.
+		if err := container.Update(ctx,
+			// Update sandbox metadata to include NetNS info
+			containerd.UpdateContainerOpts(containerd.WithContainerExtension(sandboxMetadataExtension, &sandbox.Metadata)),
+		); err != nil {
+			return nil, fmt.Errorf("failed to update the network namespace for the sandbox container %q: %w", id, err)
 		}
 
 		sandboxCreateNetworkTimer.UpdateSince(netStart)


### PR DESCRIPTION
🍒pick: 3ee6dd5c1bca441d1ec4988cbaebadbfbcfde525

Due to when we were updating the pod sandboxes underlying container object, the pointer to the sandbox would have the right info, but the on-disk representation of the data was behind. This would cause the data returned from loading any sandboxes after a restart to have no CNI result or IP information for the pod.

This change does an additional update to the on-disk container info right after we invoke the CNI plugin so the metadata for the CNI result and other networking information is properly flushed to disk.