### PR TITLE
[release/1.5] CRI: Fix no CNI info for pod sandbox on restart

### DIFF
--- a/integration/restart_test.go
+++ b/integration/restart_test.go
@@ -160,6 +160,21 @@ func TestContainerdRestart(t *testing.T) {
 		for _, loaded := range loadedSandboxes {
 			if s.id == loaded.Id {
 				assert.Equal(t, s.state, loaded.State)
+
+				// See https://github.com/containerd/containerd/issues/7843 for details.
+				// Test that CNI result and sandbox IPs are still present after restart.
+				if loaded.State == runtime.PodSandboxState_SANDBOX_READY {
+					status, info, err := SandboxInfo(loaded.Id)
+					require.NoError(t, err)
+
+					// Check that the NetNS didn't close on us, that we still have
+					// the CNI result, and that we still have the IP we were given
+					// for this pod.
+					require.False(t, info.NetNSClosed)
+					require.NotNil(t, info.CNIResult)
+					require.NotNil(t, status.Network)
+					require.NotEmpty(t, status.Network.Ip)
+				}
 				break
 			}
 		}


### PR DESCRIPTION
🍒pick: 3ee6dd5c1bca441d1ec4988cbaebadbfbcfde525

Due to when we were updating the pod sandboxes underlying container object, the pointer to the sandbox would have the right info, but the on-disk representation of the data was behind. This would cause the data returned from loading any sandboxes after a restart to have no CNI result or IP information for the pod.

This change does an additional update to the on-disk container info right after we invoke the CNI plugin so the metadata for the CNI result and other networking information is properly flushed to disk.