### PR TITLE
Check containerd's readiness before calling critest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -546,30 +546,7 @@ jobs:
           TEST_RUNTIME: ${{ matrix.runtime }}
           ENABLE_CRI_SANDBOXES: ${{ matrix.enable_cri_sandboxes }}
         run: |
-          BDIR="$(mktemp -d -p $PWD)"
-          mkdir -p ${{github.workspace}}/report
-
-          function cleanup() {
-            sudo pkill containerd || true
-
-            echo ::group::containerd logs
-            cat ${{github.workspace}}/report/containerd.log
-            echo ::endgroup::
-
-            sudo -E rm -rf ${BDIR}
-          }
-          trap cleanup EXIT
-
-          mkdir -p ${BDIR}/{root,state}
-          cat > ${BDIR}/config.toml <<EOF
-            version = 2
-            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
-            runtime_type = "${TEST_RUNTIME}"
-          EOF
-          sudo ls /etc/cni/net.d
-          sudo -E PATH=$PATH /usr/local/bin/containerd -a ${BDIR}/c.sock --config ${BDIR}/config.toml --root ${BDIR}/root --state ${BDIR}/state --log-level debug &> ${{github.workspace}}/report/containerd.log &
-          sudo -E PATH=$PATH /usr/local/bin/ctr -a ${BDIR}/c.sock version
-          sudo -E PATH=$PATH critest --report-dir "${{github.workspace}}/report" --runtime-endpoint=unix:///${BDIR}/c.sock --parallel=8
+          sudo -E PATH=$PATH ./script/critest.sh "${{github.workspace}}/report"
 
       # Log the status of this VM to investigate issues like
       # https://github.com/containerd/containerd/issues/4969

--- a/script/critest.sh
+++ b/script/critest.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -eu -o pipefail
+
+report_dir=$1
+
+mkdir -p $report_dir
+BDIR="$(mktemp -d -p $PWD)"
+
+function cleanup() {
+    pkill containerd || true
+    echo ::group::containerd logs
+    cat "$report_dir/containerd.log"
+    echo ::endgroup::
+    rm -rf ${BDIR}
+}
+trap cleanup EXIT
+
+mkdir -p ${BDIR}/{root,state}
+cat > ${BDIR}/config.toml <<EOF
+version = 2
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+runtime_type = "${TEST_RUNTIME}"
+EOF
+ls /etc/cni/net.d
+
+/usr/local/bin/containerd \
+    -a ${BDIR}/c.sock \
+    --config ${BDIR}/config.toml \
+    --root ${BDIR}/root \
+    --state ${BDIR}/state \
+    --log-level debug &> "$report_dir/containerd.log" &
+
+# Make sure containerd is ready before calling critest.
+for i in $(seq 1 10)
+do
+    crictl --runtime-endpoint ${BDIR}/c.sock info && break || sleep 1
+done
+
+critest --report-dir "$report_dir" --runtime-endpoint=unix:///${BDIR}/c.sock --parallel=8


### PR DESCRIPTION
It was assuming containerd was ready right after starting.
But it depends GitHub actions' performance.
    
In addition to that, this commit extracts the script from ci.yml.


Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>