### PR TITLE
runtime restart : code clean for deprecated code. (`LogPathLabel = "containerd.io/restart.logpath"`)

### DIFF
--- a/runtime/restart/monitor/change.go
+++ b/runtime/restart/monitor/change.go
@@ -26,7 +26,6 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/runtime/restart"
-	"github.com/sirupsen/logrus"
 )
 
 type stopChange struct {
@@ -41,9 +40,6 @@ type startChange struct {
 	container containerd.Container
 	logURI    string
 	count     int
-
-	// Deprecated(in release 1.5): but recognized now, prefer to use logURI
-	logPath string
 }
 
 func (s *startChange) apply(ctx context.Context, client *containerd.Client) error {
@@ -55,13 +51,6 @@ func (s *startChange) apply(ctx context.Context, client *containerd.Client) erro
 			return fmt.Errorf("failed to parse %v into url: %w", s.logURI, err)
 		}
 		log = cio.LogURI(uri)
-	} else if s.logPath != "" {
-		log = cio.LogFile(s.logPath)
-	}
-
-	if s.logURI != "" && s.logPath != "" {
-		logrus.Warnf("LogPathLabel=%v has been deprecated, using LogURILabel=%v",
-			s.logPath, s.logURI)
 	}
 
 	if s.count > 0 {

--- a/runtime/restart/monitor/monitor.go
+++ b/runtime/restart/monitor/monitor.go
@@ -177,7 +177,6 @@ func (m *monitor) monitor(ctx context.Context) ([]change, error) {
 			restartCount, _ := strconv.Atoi(labels[restart.CountLabel])
 			changes = append(changes, &startChange{
 				container: c,
-				logPath:   labels[restart.LogPathLabel],
 				logURI:    labels[restart.LogURILabel],
 				count:     restartCount + 1,
 			})

--- a/runtime/restart/restart.go
+++ b/runtime/restart/restart.go
@@ -37,7 +37,6 @@ import (
 	"strings"
 
 	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/containers"
 	"github.com/sirupsen/logrus"
 )
@@ -54,11 +53,6 @@ const (
 	CountLabel = "containerd.io/restart.count"
 	// ExplicitlyStoppedLabel sets the restart explicitly stopped label for a container
 	ExplicitlyStoppedLabel = "containerd.io/restart.explicitly-stopped"
-
-	// LogPathLabel sets the restart log path label for a container
-	//
-	// Deprecated(in release 1.5): use LogURILabel
-	LogPathLabel = "containerd.io/restart.logpath"
 )
 
 // Policy represents the restart policies of a container.
@@ -162,43 +156,6 @@ func WithLogURIString(uriString string) func(context.Context, *containerd.Client
 	}
 }
 
-// WithBinaryLogURI sets the binary-type log uri for a container.
-//
-// Deprecated(in release 1.5): use WithLogURI
-func WithBinaryLogURI(binary string, args map[string]string) func(context.Context, *containerd.Client, *containers.Container) error {
-	uri, err := cio.LogURIGenerator("binary", binary, args)
-	if err != nil {
-		return func(context.Context, *containerd.Client, *containers.Container) error {
-			return err
-		}
-	}
-	return WithLogURI(uri)
-}
-
-// WithFileLogURI sets the file-type log uri for a container.
-//
-// Deprecated(in release 1.5): use WithLogURI
-func WithFileLogURI(path string) func(context.Context, *containerd.Client, *containers.Container) error {
-	uri, err := cio.LogURIGenerator("file", path, nil)
-	if err != nil {
-		return func(context.Context, *containerd.Client, *containers.Container) error {
-			return err
-		}
-	}
-	return WithLogURI(uri)
-}
-
-// WithLogPath sets the log path for a container
-//
-// Deprecated(in release 1.5): use WithLogURI with "file://<path>" URI.
-func WithLogPath(path string) func(context.Context, *containerd.Client, *containers.Container) error {
-	return func(_ context.Context, _ *containerd.Client, c *containers.Container) error {
-		ensureLabels(c)
-		c.Labels[LogPathLabel] = path
-		return nil
-	}
-}
-
 // WithStatus sets the status for a container
 func WithStatus(status containerd.ProcessStatus) func(context.Context, *containerd.Client, *containers.Container) error {
 	return func(_ context.Context, _ *containerd.Client, c *containers.Container) error {
@@ -224,7 +181,6 @@ func WithNoRestarts(_ context.Context, _ *containerd.Client, c *containers.Conta
 	}
 	delete(c.Labels, StatusLabel)
 	delete(c.Labels, PolicyLabel)
-	delete(c.Labels, LogPathLabel)
 	delete(c.Labels, LogURILabel)
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: yanggang [gang.yang@daocloud.io](mailto:gang.yang@daocloud.io)

/kind cleanup

Delete deprecated code for runtime restart logic.