### PR TITLE
Platform matcher: allow for running of newer Win images under Hyper-V.

### DIFF
--- a/platforms/defaults_windows.go
+++ b/platforms/defaults_windows.go
@@ -22,12 +22,19 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Microsoft/hcsshim/osversion"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows"
 )
 
 // DefaultSpec returns the current platform's default platform specification.
 func DefaultSpec() specs.Platform {
+	// NOTE: `windows.RtlGetNtVersionNumbers()` fetches the real version numbers of the
+	// underlying Windows OS, while `windows.GetVersion()` might return different results
+	// based on the binary being manifested and/or being run in compatibility mode.
+	// `hcsshim.osversion.Get()` uses the latter call, so we must explicitly call
+	// `RtlGetNtVersionNumbers()` here ourselves.
 	major, minor, build := windows.RtlGetNtVersionNumbers()
 	return specs.Platform{
 		OS:           runtime.GOOS,
@@ -38,54 +45,132 @@ func DefaultSpec() specs.Platform {
 	}
 }
 
-type windowsmatcher struct {
-	specs.Platform
-	osVersionPrefix string
-	defaultMatcher  Matcher
+// defaultWindowsMatcher is the default Matcher for Windows platforms.
+//
+// On pre-RS5 hosts, the default matcher compares a given platforms' build number so it exactly
+// matches the expected build number, alongside the default OS type/architecture checks.
+//
+// On hosts which are RS5+ and should be able to run any newer/older Windows images under
+// Hyper-V isolation, only the OS type/architecture are checked.
+//
+// https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility#windows-server-host-os-compatibility
+type defaultWindowsMatcher struct {
+	innerPlatform  specs.Platform
+	defaultMatcher Matcher
 }
 
-// Match matches platform with the same windows major, minor
-// and build version.
-func (m windowsmatcher) Match(p specs.Platform) bool {
+// Match matches platforms based on their Windows build numbers coinciding, alongside the
+// default matcher's rules for matching OS type, CPU architecture, and CPU variant.
+// If the matcher's reference platform's build number is greater or equal to RS5 (1809),
+// the build number constraint is dropped, as any older/newer images should be usable
+// under Hyper-V isolation regardless of the reference platform.
+func (m defaultWindowsMatcher) Match(p specs.Platform) bool {
 	match := m.defaultMatcher.Match(p)
 
-	if match && m.OS == "windows" {
-		return strings.HasPrefix(p.OSVersion, m.osVersionPrefix) && m.defaultMatcher.Match(p)
+	if match && m.innerPlatform.OS == "windows" {
+		innerOsv, _, err := osVersionFromString(m.innerPlatform.OSVersion)
+		if err != nil {
+			logrus.Warnf("failed to parse inner Windows platform string %q for comparison: %s", m.innerPlatform.OSVersion, err)
+		}
+
+		if innerOsv != nil && innerOsv.Build >= osversion.RS5 {
+			// On RS5+ hosts, it is possible to run newer/older Windows container images under
+			// Hyper-V isolation without any added constraints:
+			return true
+		}
+
+		osv, _, err := osVersionFromString(p.OSVersion)
+		if err != nil {
+			logrus.Warnf("failed to parse Windows platform string %q for comparison: %s", p.OSVersion, err)
+		}
+
+		// If any of the Windows version strings are unparseable, give benefit of the doubt:
+		if innerOsv == nil || osv == nil {
+			return true
+		}
+
+		return innerOsv.Build == osv.Build
 	}
 
 	return match
 }
 
 // Less sorts matched platforms in front of other platforms.
-// For matched platforms, it puts platforms with larger revision
-// number in front.
-func (m windowsmatcher) Less(p1, p2 specs.Platform) bool {
+// For matched platforms, it puts platforms with larger build number in front.
+// If the build numbers happen to coincide, any revision specifier is also taken into account.
+func (m defaultWindowsMatcher) Less(p1, p2 specs.Platform) bool {
 	m1, m2 := m.Match(p1), m.Match(p2)
+
 	if m1 && m2 {
-		r1, r2 := revision(p1.OSVersion), revision(p2.OSVersion)
-		return r1 > r2
+		osv1, rev1, err := osVersionFromString(p1.OSVersion)
+		if err != nil {
+			logrus.Warnf("failed to parse Windows platform string %q for comparison: %s", p1.OSVersion, err)
+			// Rank  p1 < p2. (thus presuming p2 is parse-able)
+			return true
+		}
+
+		osv2, rev2, err := osVersionFromString(p2.OSVersion)
+		if err != nil {
+			logrus.Warnf("failed to parse Windows platform string %q for comparison: %s", p2.OSVersion, err)
+			// Rank p1 > p2, considering p1 is parse-able and p2 isn't.
+			return false
+		}
+
+		// If builds coincide, order by revision number:
+		if osv1.Build == osv2.Build {
+			if rev1 == 0 {
+				return true
+			}
+			return rev1 < rev2
+		}
+
+		return osv1.Build < osv2.Build
 	}
+
 	return m1 && !m2
 }
 
-func revision(v string) int {
-	parts := strings.Split(v, ".")
-	if len(parts) < 4 {
-		return 0
+// osVersionFromString returns an `osversion.OSVersion` for the provided Windows version string.
+// E.g: "10.1.234" => OSVersion { Major: 10, Minor: 1, Build: 234 }
+func osVersionFromString(version string) (*osversion.OSVersion, uint32, error) {
+	var revision uint32
+	splitVersion := strings.Split(version, ".")
+	numParts := len(splitVersion)
+	// Major.Minor.Build[.Revision]
+	if numParts < 3 || numParts > 4 {
+		return nil, revision, fmt.Errorf("Windows version string must contain either 3 or 4 dot-separated integers, got %q", version)
 	}
-	r, err := strconv.Atoi(parts[3])
-	if err != nil {
-		return 0
-	}
-	return r
-}
 
-func prefix(v string) string {
-	parts := strings.Split(v, ".")
-	if len(parts) < 4 {
-		return v
+	// Major.Minor.Build = uint8.uint8.uint16
+	majorU64, err := strconv.ParseUint(splitVersion[0], 10, 8)
+	if err != nil {
+		return nil, revision, fmt.Errorf("failed to parse major version number %q from version string %q: %s", splitVersion[0], version, err)
 	}
-	return strings.Join(parts[0:3], ".")
+	minorU64, err := strconv.ParseUint(splitVersion[1], 10, 8)
+	if err != nil {
+		return nil, revision, fmt.Errorf("failed to parse minor version number %q from version string %q: %s", splitVersion[1], version, err)
+	}
+	buildU64, err := strconv.ParseUint(splitVersion[2], 10, 16)
+	if err != nil {
+		return nil, revision, fmt.Errorf("failed to parse build version number %q from version string %q: %s", splitVersion[2], version, err)
+	}
+
+	if numParts == 4 && splitVersion[3] != "" {
+		rev, err := strconv.ParseUint(splitVersion[3], 10, 32)
+		if err != nil {
+			return nil, revision, fmt.Errorf("failed to parse revision number %q from version string %q: %s", splitVersion[3], version, err)
+		}
+		revision = uint32(rev)
+	}
+
+	// Main version is represented by uint32 which is in "reverse" (Build ++ Minor ++ Major)
+	var versionU64 = (buildU64 << 16) & (minorU64 << 8) & majorU64
+	return &osversion.OSVersion{
+		Version:      uint32(versionU64),
+		MajorVersion: uint8(majorU64),
+		MinorVersion: uint8(minorU64),
+		Build:        uint16(buildU64),
+	}, revision, nil
 }
 
 // Default returns the current platform's default platform specification.

--- a/platforms/defaults_windows_test.go
+++ b/platforms/defaults_windows_test.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/Microsoft/hcsshim/osversion"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/windows"
@@ -71,22 +72,31 @@ func TestDefaultMatchComparer(t *testing.T) {
 
 }
 
-func TestMatchComparerMatch_WCOW(t *testing.T) {
-	major, minor, build := windows.RtlGetNtVersionNumbers()
-	buildStr := fmt.Sprintf("%d.%d.%d", major, minor, build)
-	m := windowsmatcher{
-		Platform:        DefaultSpec(),
-		osVersionPrefix: buildStr,
+// Tests whether the Windows matcher works as expected for Windows releases
+// older than RS5, which always require that the Host build number exactly
+// match the image OS build number.
+func TestMatchComparerMatch_WCOW_PreRS5(t *testing.T) {
+	// NOTE: major/minor version numbers are irrelevant, only build number is checked.
+	// Mask the build number with a pre-RS5 build:
+	build := osversion.RS5 - 1
+	buildStr := fmt.Sprintf("10.11.%d", build)
+
+	samePlatformSpec := DefaultSpec()
+	samePlatformSpec.OSVersion = buildStr
+
+	m := defaultWindowsMatcher{
+		innerPlatform: samePlatformSpec,
 		defaultMatcher: &matcher{
-			Platform: Normalize(DefaultSpec()),
+			Platform: Normalize(samePlatformSpec),
 		},
 	}
+
 	for _, test := range []struct {
 		platform imagespec.Platform
 		match    bool
 	}{
 		{
-			platform: DefaultSpec(),
+			platform: samePlatformSpec,
 			match:    true,
 		},
 		{
@@ -109,8 +119,8 @@ func TestMatchComparerMatch_WCOW(t *testing.T) {
 			platform: imagespec.Platform{
 				Architecture: "amd64",
 				OS:           "windows",
-				// Use an nonexistent Windows build so we don't get a match. Ws2019's build is 17763/
-				OSVersion: "10.0.17762.1",
+				// Try a build number smaller than the current one:
+				OSVersion: fmt.Sprintf("10.0.%d.1", build-1),
 			},
 			match: false,
 		},
@@ -118,9 +128,8 @@ func TestMatchComparerMatch_WCOW(t *testing.T) {
 			platform: imagespec.Platform{
 				Architecture: "amd64",
 				OS:           "windows",
-				// Use an nonexistent Windows build so we don't get a match. Ws2019's build is 17763/
-				OSVersion: "10.0.17764.1",
-			},
+				// Try a build number larger than the current one:
+				OSVersion: fmt.Sprintf("10.0.%d.1", build+1)},
 			match: false,
 		},
 		{
@@ -128,7 +137,8 @@ func TestMatchComparerMatch_WCOW(t *testing.T) {
 				Architecture: "amd64",
 				OS:           "windows",
 			},
-			match: false,
+			// If there is no platform.OSVersion, we assume it can run:
+			match: true,
 		},
 		{
 			platform: imagespec.Platform{
@@ -138,19 +148,96 @@ func TestMatchComparerMatch_WCOW(t *testing.T) {
 			match: false,
 		},
 	} {
-		assert.Equal(t, test.match, m.Match(test.platform), "should match: %t, %s to %s", test.match, m.Platform, test.platform)
+		assert.Equal(t, test.match, m.Match(test.platform), "should match: %t, %s to %s", test.match, m.innerPlatform, test.platform)
+	}
+}
+
+// Tests whether the Windows matcher works as expected for RS5 and above
+// hosts, which should allow running any older/newer Windows version
+// if using Hyper-V isolation.
+func TestMatchComparerMatch_WCOW_RS5(t *testing.T) {
+	// NOTE: major/minor version numbers are irrelevant, only build number is checked.
+	// Mask the build number with an RS5:
+	build := osversion.RS5
+	buildStr := fmt.Sprintf("10.11.%d", build)
+
+	samePlatformSpec := DefaultSpec()
+	samePlatformSpec.OSVersion = buildStr
+
+	m := defaultWindowsMatcher{
+		innerPlatform: samePlatformSpec,
+		defaultMatcher: &matcher{
+			Platform: Normalize(samePlatformSpec),
+		},
+	}
+
+	for _, test := range []struct {
+		platform imagespec.Platform
+		match    bool
+	}{
+		{
+			platform: samePlatformSpec,
+			match:    true,
+		},
+		{
+			platform: imagespec.Platform{
+				Architecture: "amd64",
+				OS:           "windows",
+				OSVersion:    buildStr + ".1",
+			},
+			match: true,
+		},
+		{
+			platform: imagespec.Platform{
+				Architecture: "amd64",
+				OS:           "windows",
+				OSVersion:    buildStr + ".2",
+			},
+			match: true,
+		},
+		{
+			platform: imagespec.Platform{
+				Architecture: "amd64",
+				OS:           "windows",
+				// Try a build number smaller than the current one:
+				OSVersion: fmt.Sprintf("10.0.%d.1", build-1),
+			},
+			match: true,
+		},
+		{
+			platform: imagespec.Platform{
+				Architecture: "amd64",
+				OS:           "windows",
+				// Try a build number larger than the current one:
+				OSVersion: fmt.Sprintf("10.0.%d.1", build+1)},
+			match: true,
+		},
+		{
+			platform: imagespec.Platform{
+				Architecture: "amd64",
+				OS:           "windows",
+				// No OSVersion set at all.
+			},
+			match: true,
+		},
+		{
+			platform: imagespec.Platform{
+				Architecture: "amd64",
+				OS:           "linux",
+			},
+			match: false,
+		},
+	} {
+		assert.Equal(t, test.match, m.Match(test.platform), "should match: %t, %s to %s", test.match, m.innerPlatform, test.platform)
 	}
 }
 
 func TestMatchComparerMatch_LCOW(t *testing.T) {
-	major, minor, build := windows.RtlGetNtVersionNumbers()
-	buildStr := fmt.Sprintf("%d.%d.%d", major, minor, build)
-	m := windowsmatcher{
-		Platform: imagespec.Platform{
+	m := defaultWindowsMatcher{
+		innerPlatform: imagespec.Platform{
 			OS:           "linux",
 			Architecture: "amd64",
 		},
-		osVersionPrefix: "",
 		defaultMatcher: &matcher{
 			Platform: Normalize(imagespec.Platform{
 				OS:           "linux",
@@ -178,7 +265,8 @@ func TestMatchComparerMatch_LCOW(t *testing.T) {
 			platform: imagespec.Platform{
 				Architecture: "amd64",
 				OS:           "windows",
-				OSVersion:    buildStr + ".2",
+				// Use an nonexistent Windows build so we don't get a match. Ws2019's build is 17763.
+				OSVersion: "10.0.17762",
 			},
 			match: false,
 		},
@@ -186,7 +274,7 @@ func TestMatchComparerMatch_LCOW(t *testing.T) {
 			platform: imagespec.Platform{
 				Architecture: "amd64",
 				OS:           "windows",
-				// Use an nonexistent Windows build so we don't get a match. Ws2019's build is 17763/
+				// Use an nonexistent Windows build so we don't get a match. Ws2019's build is 17763.
 				OSVersion: "10.0.17762.1",
 			},
 			match: false,
@@ -199,18 +287,34 @@ func TestMatchComparerMatch_LCOW(t *testing.T) {
 			match: true,
 		},
 	} {
-		assert.Equal(t, test.match, m.Match(test.platform), "should match %b, %s to %s", test.match, m.Platform, test.platform)
+		assert.Equal(t, test.match, m.Match(test.platform), "should match %b, %s to %s", test.match, m.innerPlatform, test.platform)
 	}
 }
 
-func TestMatchComparerLess(t *testing.T) {
-	m := windowsmatcher{
-		Platform:        DefaultSpec(),
-		osVersionPrefix: "10.0.17763",
+func TestMatchComparerLessPreRS5(t *testing.T) {
+	defaultSpec := DefaultSpec()
+
+	// Mask the build number with something less than RS5.
+	// Note that because the `Less()` method mixes matching logic with the comparison logic
+	// (i.e. it compares only successful matches to the current host), comparing a matching
+	// and a non-matching version behaves counterintuitively. (e.g. it'll state 10.0.17764
+	// is larger than 10.0.17762 when running on a 17764, but will claim otherwise on a 17762)
+	// Here we force an internal version much smaller than the ones provided in the testcases
+	// to avoid mixing the matching and comparing logic together.
+	build := osversion.RS5 / 2
+	defaultSpec.OSVersion = fmt.Sprintf("10.11.%d", build)
+	m := defaultWindowsMatcher{
+		innerPlatform: defaultSpec,
 		defaultMatcher: &matcher{
-			Platform: Normalize(DefaultSpec()),
+			Platform: defaultSpec,
 		},
 	}
+
+	match0 := fmt.Sprintf("10.0.%d", build)
+	match1 := fmt.Sprintf("10.0.%d.10", build)
+	match2 := fmt.Sprintf("10.0.%d.20", build)
+	match3 := fmt.Sprintf("10.0.%d.30", build)
+
 	platforms := []imagespec.Platform{
 		{
 			Architecture: "amd64",
@@ -224,30 +328,88 @@ func TestMatchComparerLess(t *testing.T) {
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    "10.0.17763.1",
+			OSVersion:    match0,
 		},
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    "10.0.17763.2",
+			OSVersion:    "10.0.17763.3",
 		},
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    "10.0.17762.1",
+			OSVersion:    match3,
+		},
+		{
+			Architecture: "amd64",
+			OS:           "windows",
+			OSVersion:    match1,
+		},
+		{
+			Architecture: "amd64",
+			OS:           "windows",
+			OSVersion:    "10.0.17762.2",
+		},
+		{
+			Architecture: "amd64",
+			OS:           "windows",
+			OSVersion:    match2,
 		},
 	}
-	expected := []imagespec.Platform{
+	// NOTE: because `Less()` mixes matching and comparison logic together, the ordering
+	// of any platforms whose build number does not coincide with the matcher's inner
+	// build number is at the mercy of the particular sorting algorithm being used.
+	// (i.e. comparing two non-host-matching platforms will yield `false` in both cases).
+	// In this sense, we can only validate that the supported matches are correctly ordered
+	// and come in front of any non-matches.
+	rankedMatches := []imagespec.Platform{
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    "10.0.17763.2",
+			// NOTE: having no OSVersion will lead to a match.
 		},
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    "10.0.17763.1",
+			OSVersion:    match0,
 		},
+		{
+			Architecture: "amd64",
+			OS:           "windows",
+			OSVersion:    match1,
+		},
+		{
+			Architecture: "amd64",
+			OS:           "windows",
+			OSVersion:    match2,
+		},
+		{
+			Architecture: "amd64",
+			OS:           "windows",
+			OSVersion:    match3,
+		},
+	}
+	sort.SliceStable(platforms, func(i, j int) bool {
+		return m.Less(platforms[i], platforms[j])
+	})
+	assert.Equal(t, rankedMatches, platforms[:len(rankedMatches)])
+}
+
+func TestMatchComparerLessPostRS5(t *testing.T) {
+	defaultSpec := DefaultSpec()
+
+	// NOTE: major/minor version numbers are irrelevant, only build number is checked.
+	// Mask the build number with an RS5:
+	build := osversion.RS5
+	defaultSpec.OSVersion = fmt.Sprintf("10.11.%d", build)
+	m := defaultWindowsMatcher{
+		innerPlatform: defaultSpec,
+		defaultMatcher: &matcher{
+			Platform: defaultSpec,
+		},
+	}
+
+	platforms := []imagespec.Platform{
 		{
 			Architecture: "amd64",
 			OS:           "windows",
@@ -260,11 +422,139 @@ func TestMatchComparerLess(t *testing.T) {
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    "10.0.17762.1",
+			OSVersion:    "10.0.17763.3",
+		},
+		{
+			Architecture: "amd64",
+			OS:           "windows",
+			OSVersion:    "10.0.17763.2",
+		},
+		{
+			Architecture: "amd64",
+			OS:           "windows",
+			OSVersion:    "10.0.17762.2",
+		},
+	}
+	expected := []imagespec.Platform{
+		{
+			Architecture: "amd64",
+			OS:           "windows",
+		},
+		{
+			Architecture: "amd64",
+			OS:           "windows",
+			OSVersion:    "10.0.17762.2",
+		},
+		{
+			Architecture: "amd64",
+			OS:           "windows",
+			OSVersion:    "10.0.17763.2",
+		},
+		{
+			Architecture: "amd64",
+			OS:           "windows",
+			OSVersion:    "10.0.17763.3",
+		},
+		{
+			Architecture: "amd64",
+			OS:           "windows",
+			OSVersion:    "10.0.17764.1",
 		},
 	}
 	sort.SliceStable(platforms, func(i, j int) bool {
 		return m.Less(platforms[i], platforms[j])
 	})
 	assert.Equal(t, expected, platforms)
+}
+
+func TestOsVersionFromString(t *testing.T) {
+	for _, test := range []struct {
+		input         string
+		osv           osversion.OSVersion
+		revision      uint32
+		expectedError string
+	}{
+		{
+			input: "1.2.3.4",
+			osv: osversion.OSVersion{
+				MajorVersion: 1,
+				MinorVersion: 2,
+				Build:        3,
+			},
+			revision:      4,
+			expectedError: "",
+		},
+		{
+			input: "1.2.3",
+			osv: osversion.OSVersion{
+				MajorVersion: 1,
+				MinorVersion: 2,
+				Build:        3,
+			},
+			revision:      0,
+			expectedError: "",
+		},
+		{
+			input: "1.2.3.",
+			osv: osversion.OSVersion{
+				MajorVersion: 1,
+				MinorVersion: 2,
+				Build:        3,
+			},
+			// NOTE: should ignore incomplete revision but still work
+			revision:      0,
+			expectedError: "",
+		},
+		{
+			input:         "",
+			expectedError: "Windows version string must contain either 3 or 4 dot-separated integers",
+		},
+		{
+			input:         "1",
+			expectedError: "Windows version string must contain either 3 or 4 dot-separated integers",
+		},
+		{
+			input:         "1.",
+			expectedError: "Windows version string must contain either 3 or 4 dot-separated integers",
+		},
+		{
+			input:         "1..",
+			expectedError: "failed to parse minor version number",
+		},
+		{
+			input:         ".1.",
+			expectedError: "failed to parse major version number",
+		},
+		{
+			input:         "..1",
+			expectedError: "failed to parse major version number",
+		},
+		{
+			input:         "XYZ.2.3.4",
+			expectedError: "failed to parse major version number",
+		},
+		{
+			input:         "1.XYZ.3.4",
+			expectedError: "failed to parse minor version number",
+		},
+		{
+			input:         "1.2.XYZ.4",
+			expectedError: "failed to parse build version number",
+		},
+		{
+			input:         "1.2.3.XYZ",
+			expectedError: "failed to parse revision number",
+		},
+	} {
+		osv, rev, err := osVersionFromString(test.input)
+		if test.expectedError == "" {
+			assert.Equal(t, test.osv.MajorVersion, osv.MajorVersion)
+			assert.Equal(t, test.osv.MinorVersion, osv.MinorVersion)
+			assert.Equal(t, test.osv.Build, osv.Build)
+			assert.Equal(t, test.revision, rev)
+		} else {
+			assert.NotNil(t, err)
+			assert.ErrorContains(t, err, test.expectedError)
+		}
+	}
 }

--- a/platforms/defaults_windows_test.go
+++ b/platforms/defaults_windows_test.go
@@ -409,11 +409,36 @@ func TestMatchComparerLessPostRS5(t *testing.T) {
 		},
 	}
 
+	// Exact build number match:
+	match0 := fmt.Sprintf("10.0.%d", build)
+	// Exact build number match plus revision number:
+	match1 := fmt.Sprintf("10.0.%d.10", build)
+	// Minor build number difference:
+	match2 := fmt.Sprintf("10.0.%d.20", build+1)
+	// Minor build number difference with relevant revision:
+	submatch2 := fmt.Sprintf("10.0.%d.30", build+1)
+	// Major build number difference:
+	match3 := fmt.Sprintf("10.0.%d.30", build-10)
+	// A larger build number than the host, but should come before `match3` since
+	// the absolute difference in build version between the matches and the host
+	// make the countermatch more enticing:
+	countermatch3 := fmt.Sprintf("10.0.%d.30", build+3)
+
 	platforms := []imagespec.Platform{
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    "10.0.17764.1",
+			OSVersion:    match0,
+		},
+		{
+			Architecture: "amd64",
+			OS:           "windows",
+			OSVersion:    countermatch3,
+		},
+		{
+			Architecture: "amd64",
+			OS:           "windows",
+			OSVersion:    submatch2,
 		},
 		{
 			Architecture: "amd64",
@@ -422,17 +447,17 @@ func TestMatchComparerLessPostRS5(t *testing.T) {
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    "10.0.17763.3",
+			OSVersion:    match1,
 		},
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    "10.0.17763.2",
+			OSVersion:    match3,
 		},
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    "10.0.17762.2",
+			OSVersion:    match2,
 		},
 	}
 	expected := []imagespec.Platform{
@@ -443,22 +468,32 @@ func TestMatchComparerLessPostRS5(t *testing.T) {
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    "10.0.17762.2",
+			OSVersion:    match0,
 		},
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    "10.0.17763.2",
+			OSVersion:    match1,
 		},
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    "10.0.17763.3",
+			OSVersion:    match2,
 		},
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    "10.0.17764.1",
+			OSVersion:    submatch2,
+		},
+		{
+			Architecture: "amd64",
+			OS:           "windows",
+			OSVersion:    countermatch3,
+		},
+		{
+			Architecture: "amd64",
+			OS:           "windows",
+			OSVersion:    match3,
 		},
 	}
 	sort.SliceStable(platforms, func(i, j int) bool {

--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -71,7 +71,7 @@
 //
 // An example of a common specifier is `linux/amd64`. If the host has a default
 // of runtime that matches this, the user can simply provide the component that
-// matters. For example, if a image provides amd64 and arm64 support, the
+// matters. For example, if an image provides amd64 and arm64 support, the
 // operating system, `linux` can be inferred, so they only have to provide
 // `arm64` or `amd64`. Similar behavior is implemented for operating systems,
 // where the architecture may be known but a runtime may support images from

--- a/platforms/platforms_windows.go
+++ b/platforms/platforms_windows.go
@@ -20,13 +20,20 @@ import (
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// NewMatcher returns a Windows matcher that will match on osVersionPrefix if
-// the platform is Windows otherwise use the default matcher
+// newDefaultMatcher returns an instance of the Windows matcher for the proived platform specs.
+//
+// If the reference platform is pre-RS5 (< 18.09), the default matcher compares a given
+// platforms' build number so it exactly matches the expected build number, alongside
+// the default OS type/architecture checks.
+//
+// If comparing against RS5+, which should be able to run any newer/older Windows images under
+// Hyper-V isolation, only the OS type/architecture are checked.
+//
+// https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility#windows-server-host-os-compatibility
+
 func newDefaultMatcher(platform specs.Platform) Matcher {
-	prefix := prefix(platform.OSVersion)
-	return windowsmatcher{
-		Platform:        platform,
-		osVersionPrefix: prefix,
+	return defaultWindowsMatcher{
+		innerPlatform: platform,
 		defaultMatcher: &matcher{
 			Platform: Normalize(platform),
 		},


### PR DESCRIPTION
Following the addition of Hyper-V isolation, it should be possible for Windows hosts to run container images which are older or newer than the host build if the Windows host is version RS5 (1809) or above.

This patch updates the Windows platform matching logic to allow for build number mismatches between Windows images and hosts iff the host version is at least RS5.

Signed-off-by: Nashwan Azhari <nazhari@cloudbasesolutions.com>