### PR TITLE
Rewrite verify-go-modules.sh in Python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -476,7 +476,7 @@ verify-vendor: ## verify if all the go.mod/go.sum files are up-to-date
 	@(cd ${TMPDIR}/containerd/integration/client && ${GO} mod tidy)
 	@diff -r -u -q ${ROOTDIR} ${TMPDIR}/containerd
 	@rm -rf ${TMPDIR}
-	@${ROOTDIR}/script/verify-go-modules.sh integration/client
+	@${ROOTDIR}/script/verify-go-modules.py integration/client
 
 
 help: ## this help

--- a/cmd/verify-go-mod/main.go
+++ b/cmd/verify-go-mod/main.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/mod/modfile"
+)
+
+func readGoMod(path string) (map[string]string, map[string]string, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	mod1, err := modfile.Parse(path, b, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	require := make(map[string]string)
+	replace := make(map[string]string)
+	for _, req := range mod1.Require {
+		require[req.Mod.Path] = req.Mod.Version
+	}
+	for _, rep := range mod1.Replace {
+		replace[rep.Old.Path] = rep.Old.Path + rep.Old.Version
+	}
+	return require, replace, err
+}
+
+func realMain() error {
+	require1, replace1, err := readGoMod("go.mod")
+	if err != nil {
+		return err
+	}
+
+	dir := os.Args[1]
+	require2, replace2, err := readGoMod(filepath.Join(dir, "go.mod"))
+	if err != nil {
+		return err
+	}
+
+	var errors int
+
+	for path, v2 := range require2 {
+		if v1, ok := require1[path]; ok && v1 != v2 {
+			fmt.Fprintf(os.Stderr, "%s has different values in the go.mod files require section:", path)
+			fmt.Fprintf(os.Stderr, "%s in root go.mod %s in %s/go.mod\n", v1, v2, dir)
+			errors++
+		}
+	}
+
+	for path, v2 := range replace2 {
+		if v1, ok := replace1[path]; ok && v1 != v2 {
+			fmt.Fprintf(os.Stderr, "%s has different values in the go.mod files replace section:", path)
+			fmt.Fprintf(os.Stderr, "%s in root go.mod %s in %s/go.mod\n", v1, v2, dir)
+			errors++
+		}
+	}
+
+	for path := range replace1 {
+		if _, ok := replace2[path]; !ok {
+			fmt.Fprintf(os.Stderr, "%s has an entry in root go.mod replace section, ", path)
+			fmt.Fprintf(os.Stderr, "but is missing from replace section in %s/go.mod\n", dir)
+			errors++
+		}
+	}
+
+	if errors > 0 {
+		return fmt.Errorf("%d errors", errors)
+	}
+
+	return nil
+}
+
+func main() {
+	err := realMain()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
+}

--- a/script/verify-go-modules.py
+++ b/script/verify-go-modules.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+#
+# verifies if the require and replace directives for two go.mod files are in sync
+#
+import subprocess
+import sys
+import json
+
+def read_go_mod(cwd='.'):
+  out = subprocess.run(['go', 'mod', 'edit', '-json'], cwd=cwd, capture_output=True)
+  file = json.loads(out.stdout)
+  requires = {}
+  replaces = {}
+  for mod in file['Require']:
+    requires[mod['Path']] = mod['Version']
+  for mod in file['Replace']:
+    replaces[mod['Old']['Path']] = mod['New']['Path'] + (mod['New'].get('Version') or '')
+  return requires, replaces
+
+mod_dir = sys.argv[1]
+requires1, replaces1 = read_go_mod()
+requires2, replaces2 = read_go_mod(mod_dir)
+errors = 0
+
+# iterate through the second go.mod's require section and ensure that all items
+# have the same values in the root go.mod require section
+for k in requires2:
+  if (k in requires1) and (requires1[k] != requires2[k]):
+    print(f"{k} has different values in the go.mod files require section:" \
+          f"{requires1[k]} in root go.mod {requires2[k]} in {mod_dir}/go.mod")
+    errors += 1
+
+# iterate through the second go.mod's replace section and ensure that all items
+# have the same values in the root go.mod's replace section. Except for the
+# containerd/containerd which we know will be different
+for k in replaces2:
+  if (k in replaces1) and (replaces1[k] != replaces2[k]):
+    print(f"{k} has different values in the go.mod files replace section:" \
+          f"{replaces1[k]} in root go.mod {replaces2[k]} in {mod_dir}/go.mod")
+    errors += 1
+
+# iterate through the root go.mod's replace section and ensure that all the
+# same items are present in the second go.mod's replace section and nothing is missing
+for k in replaces1:
+  if not replaces2[k]:
+    print(f"{k} has an entry in root go.mod replace section, but is missing from" \
+          f" replace section in {mod_dir}/go.mod")
+    errors += 1
+
+sys.exit(errors != 0)


### PR DESCRIPTION
verify-go-modules.sh is relatively complex and currently not portable (see #7853).

This change rewrites the script in Python for better maintainability.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>