### PR TITLE
Set plugin meta info with the default method.

### DIFF
--- a/diff/lcow/lcow.go
+++ b/diff/lcow/lcow.go
@@ -25,7 +25,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"runtime"
 	"time"
 
 	"github.com/Microsoft/go-winio/pkg/security"
@@ -36,6 +35,7 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/metadata"
 	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/plugin"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -60,10 +60,7 @@ func init() {
 				return nil, err
 			}
 
-			ic.Meta.Platforms = append(ic.Meta.Platforms, ocispec.Platform{
-				OS:           "linux",
-				Architecture: runtime.GOARCH,
-			})
+			ic.Meta.Platforms = append(ic.Meta.Platforms, platforms.DefaultSpec())
 			return NewWindowsLcowDiff(md.(*metadata.DB).ContentStore())
 		},
 	})

--- a/snapshots/lcow/lcow.go
+++ b/snapshots/lcow/lcow.go
@@ -26,7 +26,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -37,11 +36,11 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/containerd/snapshots/storage"
 	"github.com/containerd/continuity/fs"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func init() {
@@ -49,10 +48,7 @@ func init() {
 		Type: plugin.SnapshotPlugin,
 		ID:   "windows-lcow",
 		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
-			ic.Meta.Platforms = append(ic.Meta.Platforms, ocispec.Platform{
-				OS:           "linux",
-				Architecture: runtime.GOARCH,
-			})
+			ic.Meta.Platforms = append(ic.Meta.Platforms, platforms.DefaultSpec())
 			return NewSnapshotter(ic.Root)
 		},
 	})


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

The code ```platforms.DefaultSpec()``` is used by most of places besides the "diff/lcow/lcow.go" and "snapshots/lcow/lcow.go".
Maybe we can unify it with the default method..