### PR TITLE
ctr/tasks: support remapped UID/GID

### DIFF
--- a/cmd/ctr/commands/run/run.go
+++ b/cmd/ctr/commands/run/run.go
@@ -186,7 +186,7 @@ var Command = cli.Command{
 			}
 		}
 
-		opts := getNewTaskOpts(context)
+		opts := tasks.GetNewTaskOpts(context)
 		ioOpts := []cio.Opt{cio.WithFIFODir(context.String("fifo-dir"))}
 		task, err := tasks.NewTask(ctx, client, container, context.String("checkpoint"), con, context.Bool("null-io"), context.String("log-uri"), ioOpts, opts...)
 		if err != nil {

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -40,7 +40,6 @@ import (
 	"github.com/containerd/containerd/snapshots"
 	"github.com/intel/goresctrl/pkg/blockio"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -429,30 +428,6 @@ func getRuntimeOptions(context *cli.Context) (interface{}, error) {
 	}
 
 	return nil, nil
-}
-
-func getNewTaskOpts(context *cli.Context) []containerd.NewTaskOpts {
-	var (
-		tOpts []containerd.NewTaskOpts
-	)
-	if context.Bool("no-pivot") {
-		tOpts = append(tOpts, containerd.WithNoPivotRoot)
-	}
-	if uidmap := context.String("uidmap"); uidmap != "" {
-		uidMap, err := parseIDMapping(uidmap)
-		if err != nil {
-			logrus.WithError(err).Warn("unable to parse uidmap; defaulting to uid 0 IO ownership")
-		}
-		tOpts = append(tOpts, containerd.WithUIDOwner(uidMap.HostID))
-	}
-	if gidmap := context.String("gidmap"); gidmap != "" {
-		gidMap, err := parseIDMapping(gidmap)
-		if err != nil {
-			logrus.WithError(err).Warn("unable to parse gidmap; defaulting to gid 0 IO ownership")
-		}
-		tOpts = append(tOpts, containerd.WithGIDOwner(gidMap.HostID))
-	}
-	return tOpts
 }
 
 func parseIDMapping(mapping string) (specs.LinuxIDMapping, error) {

--- a/cmd/ctr/commands/run/run_windows.go
+++ b/cmd/ctr/commands/run/run_windows.go
@@ -182,10 +182,6 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 	return client.NewContainer(ctx, id, cOpts...)
 }
 
-func getNewTaskOpts(_ *cli.Context) []containerd.NewTaskOpts {
-	return nil
-}
-
 func getNetNSPath(ctx gocontext.Context, t containerd.Task) (string, error) {
 	s, err := t.Spec(ctx)
 	if err != nil {

--- a/cmd/ctr/commands/tasks/start.go
+++ b/cmd/ctr/commands/tasks/start.go
@@ -78,7 +78,7 @@ var startCommand = cli.Command{
 		}
 		var (
 			tty    = spec.Process.Terminal
-			opts   = getNewTaskOpts(context)
+			opts   = GetNewTaskOpts(context)
 			ioOpts = []cio.Opt{cio.WithFIFODir(context.String("fifo-dir"))}
 		)
 		var con console.Console

--- a/cmd/ctr/commands/tasks/tasks_unix.go
+++ b/cmd/ctr/commands/tasks/tasks_unix.go
@@ -79,6 +79,20 @@ func NewTask(ctx gocontext.Context, client *containerd.Client, container contain
 		}
 		opts = append(opts, containerd.WithTaskCheckpoint(im))
 	}
+
+	spec, err := container.Spec(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if spec.Linux != nil {
+		if len(spec.Linux.UIDMappings) != 0 {
+			opts = append(opts, containerd.WithUIDOwner(spec.Linux.UIDMappings[0].HostID))
+		}
+		if len(spec.Linux.GIDMappings) != 0 {
+			opts = append(opts, containerd.WithGIDOwner(spec.Linux.GIDMappings[0].HostID))
+		}
+	}
+
 	var ioCreator cio.Creator
 	if con != nil {
 		if nullIO {
@@ -106,7 +120,8 @@ func NewTask(ctx gocontext.Context, client *containerd.Client, container contain
 	return t, nil
 }
 
-func getNewTaskOpts(context *cli.Context) []containerd.NewTaskOpts {
+// GetNewTaskOpts resolves containerd.NewTaskOpts from cli.Context
+func GetNewTaskOpts(context *cli.Context) []containerd.NewTaskOpts {
 	if context.Bool("no-pivot") {
 		return []containerd.NewTaskOpts{containerd.WithNoPivotRoot}
 	}

--- a/cmd/ctr/commands/tasks/tasks_windows.go
+++ b/cmd/ctr/commands/tasks/tasks_windows.go
@@ -82,6 +82,7 @@ func NewTask(ctx gocontext.Context, client *containerd.Client, container contain
 	return container.NewTask(ctx, ioCreator)
 }
 
-func getNewTaskOpts(_ *cli.Context) []containerd.NewTaskOpts {
+// GetNewTaskOpts resolves containerd.NewTaskOpts from cli.Context
+func GetNewTaskOpts(_ *cli.Context) []containerd.NewTaskOpts {
 	return nil
 }


### PR DESCRIPTION
`ctr tasks start` supports resolving to uid/gid mappings from spec.

For `ctr run`, the NewContainer function will also set the uid/gid mapping.
https://github.com/containerd/containerd/blob/6c8c4271661d658c381a97cebd53e3b382bb17dd/cmd/ctr/commands/run/run_unix.go#L162-L173

For uid/gid mappings that already exist in the container spec, there is no need for the `ctr tasks start` command to ignore it
