### PR TITLE
fix `ctr tasks kill` does not remove cni network under windows

### DIFF
--- a/cmd/ctr/commands/run/run_windows.go
+++ b/cmd/ctr/commands/run/run_windows.go
@@ -131,6 +131,8 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 				return nil, err
 			}
 			opts = append(opts, oci.WithWindowsNetworkNamespace(ns.GetPath()))
+			cniMeta := &commands.NetworkMetaData{EnableCni: true}
+			cOpts = append(cOpts, containerd.WithContainerExtension(commands.CtrCniMetadataExtension, cniMeta))
 		}
 		if context.Bool("isolated") {
 			opts = append(opts, oci.WithWindowsHyperV)


### PR DESCRIPTION
related pr: https://github.com/containerd/containerd/pull/6670

Keep the same extra information settings as in unix:
https://github.com/containerd/containerd/blob/6c8c4271661d658c381a97cebd53e3b382bb17dd/cmd/ctr/commands/run/run_unix.go#L242-L244