### PR TITLE
oci: Add WithDomainname

### DIFF
--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -274,6 +274,14 @@ func WithHostname(name string) SpecOpts {
 	}
 }
 
+// WithDomainname sets the container's NIS domain name
+func WithDomainname(name string) SpecOpts {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
+		s.Domainname = name
+		return nil
+	}
+}
+
 // WithMounts appends mounts
 func WithMounts(mounts []specs.Mount) SpecOpts {
 	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {

--- a/pkg/cri/sbserver/container_create_test.go
+++ b/pkg/cri/sbserver/container_create_test.go
@@ -412,11 +412,17 @@ func TestBaseRuntimeSpec(t *testing.T) {
 		},
 	}
 
-	out, err := c.runtimeSpec("id1", "/etc/containerd/cri-base.json", oci.WithHostname("new"))
+	out, err := c.runtimeSpec(
+		"id1",
+		"/etc/containerd/cri-base.json",
+		oci.WithHostname("new-host"),
+		oci.WithDomainname("new-domain"),
+	)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "1.0.2", out.Version)
-	assert.Equal(t, "new", out.Hostname)
+	assert.Equal(t, "new-host", out.Hostname)
+	assert.Equal(t, "new-domain", out.Domainname)
 
 	// Make sure original base spec not changed
 	assert.NotEqual(t, out, c.baseOCISpecs["/etc/containerd/cri-base.json"])

--- a/pkg/cri/server/container_create_test.go
+++ b/pkg/cri/server/container_create_test.go
@@ -412,11 +412,17 @@ func TestBaseRuntimeSpec(t *testing.T) {
 		},
 	}
 
-	out, err := c.runtimeSpec("id1", "/etc/containerd/cri-base.json", oci.WithHostname("new"))
+	out, err := c.runtimeSpec(
+		"id1",
+		"/etc/containerd/cri-base.json",
+		oci.WithHostname("new-host"),
+		oci.WithDomainname("new-domain"),
+	)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "1.0.2", out.Version)
-	assert.Equal(t, "new", out.Hostname)
+	assert.Equal(t, "new-host", out.Hostname)
+	assert.Equal(t, "new-domain", out.Domainname)
 
 	// Make sure original base spec not changed
 	assert.NotEqual(t, out, c.baseOCISpecs["/etc/containerd/cri-base.json"])


### PR DESCRIPTION
A domainname field was recently added to the OCI spec. Prior to this folks would need to set this with a sysctl, but now runtimes should be able to setdomainname(2). There's an [open change to runc](https://github.com/opencontainers/runc/pull/3600) at the moment to add support for this so I've just left testing as a couple spec validations in CRI until that's in and usable.