### PR TITLE
ctr/containers: add some container creation flags

### DIFF
--- a/cmd/ctr/commands/commands.go
+++ b/cmd/ctr/commands/commands.go
@@ -213,6 +213,14 @@ var (
 			Name:  "user,u",
 			Usage: "username or user id, group optional (format: <name|uid>[:<group|gid>])",
 		},
+		cli.StringFlag{
+			Name:  "cgroup",
+			Usage: "cgroup path (To disable use of cgroup, set to \"\" explicitly)",
+		},
+		cli.StringFlag{
+			Name:  "platform",
+			Usage: "run image for specific platform",
+		},
 	}
 )
 

--- a/cmd/ctr/commands/commands_unix.go
+++ b/cmd/ctr/commands/commands_unix.go
@@ -23,24 +23,69 @@ import (
 )
 
 func init() {
-	ContainerFlags = append(ContainerFlags, cli.BoolFlag{
-		Name:  "rootfs",
-		Usage: "use custom rootfs that is not managed by containerd snapshotter",
-	}, cli.BoolFlag{
-		Name:  "no-pivot",
-		Usage: "disable use of pivot-root (linux only)",
-	}, cli.Int64Flag{
-		Name:  "cpu-quota",
-		Usage: "limit CPU CFS quota",
-		Value: -1,
-	}, cli.Uint64Flag{
-		Name:  "cpu-period",
-		Usage: "limit CPU CFS period",
-	}, cli.StringFlag{
-		Name:  "rootfs-propagation",
-		Usage: "set the propagation of the container rootfs",
-	}, cli.StringSliceFlag{
-		Name:  "device",
-		Usage: "file path to a device to add to the container; or a path to a directory tree of devices to add to the container",
-	})
+	ContainerFlags = append(ContainerFlags,
+		cli.BoolFlag{
+			Name:  "rootfs",
+			Usage: "use custom rootfs that is not managed by containerd snapshotter",
+		},
+		cli.StringFlag{
+			Name:  "rootfs-propagation",
+			Usage: "set the propagation of the container rootfs",
+		},
+		cli.BoolFlag{
+			Name:  "no-pivot",
+			Usage: "disable use of pivot-root (linux only)",
+		},
+		cli.Float64Flag{
+			Name:  "cpus",
+			Usage: "set the CFS cpu quota",
+			Value: 0.0,
+		},
+		cli.IntFlag{
+			Name:  "cpu-shares",
+			Usage: "set the cpu shares",
+			Value: 1024,
+		},
+		cli.Int64Flag{
+			Name:  "cpu-quota",
+			Usage: "limit CPU CFS quota",
+			Value: -1,
+		},
+		cli.Uint64Flag{
+			Name:  "cpu-period",
+			Usage: "limit CPU CFS period",
+		},
+		cli.StringSliceFlag{
+			Name:  "device",
+			Usage: "file path to a device to add to the container; or a path to a directory tree of devices to add to the container",
+		},
+		cli.BoolFlag{
+			Name:  "privileged-without-host-devices",
+			Usage: "don't pass all host devices to privileged container",
+		},
+		cli.StringFlag{
+			Name:  "runc-binary",
+			Usage: "specify runc-compatible binary",
+		},
+		cli.StringFlag{
+			Name:  "runc-root",
+			Usage: "specify runc-compatible root",
+		},
+		cli.BoolFlag{
+			Name:  "runc-systemd-cgroup",
+			Usage: "start runc with systemd cgroup manager",
+		},
+		cli.BoolFlag{
+			Name:  "remap-labels",
+			Usage: "provide the user namespace ID remapping to the snapshotter via label options; requires snapshotter support",
+		},
+		cli.StringFlag{
+			Name:  "uidmap",
+			Usage: "run inside a user namespace with the specified UID mapping range; specified with the format `container-uid:host-uid:length`",
+		},
+		cli.StringFlag{
+			Name:  "gidmap",
+			Usage: "run inside a user namespace with the specified GID mapping range; specified with the format `container-gid:host-gid:length`",
+		},
+	)
 }

--- a/cmd/ctr/commands/commands_windows.go
+++ b/cmd/ctr/commands/commands_windows.go
@@ -33,8 +33,14 @@ func init() {
 		cli.Uint64Flag{
 			Name:  "cpu-max",
 			Usage: "The number of processor cycles threads in a container can use per 10,000 cycles. Set to a percentage times 100. Between 1 and 10,000",
-		}, cli.StringSliceFlag{
+		},
+		cli.StringSliceFlag{
 			Name:  "device",
 			Usage: "identifier of a device to add to the container  (e.g. class://5B45201D-F2F2-4F3B-85BB-30FF1F953599)",
-		})
+		},
+		cli.BoolFlag{
+			Name:  "isolated",
+			Usage: "run the container with vm isolation",
+		},
+	)
 }

--- a/cmd/ctr/commands/run/run.go
+++ b/cmd/ctr/commands/run/run.go
@@ -111,21 +111,12 @@ var Command = cli.Command{
 			Name:  "fifo-dir",
 			Usage: "directory used for storing IO FIFOs",
 		},
-		cli.StringFlag{
-			Name:  "cgroup",
-			Usage: "cgroup path (To disable use of cgroup, set to \"\" explicitly)",
-		},
-		cli.StringFlag{
-			Name:  "platform",
-			Usage: "run image for specific platform",
-		},
 		cli.BoolFlag{
 			Name:  "cni",
 			Usage: "enable cni networking for the container",
 		},
-	}, append(platformRunFlags,
-		append(append(commands.SnapshotterFlags, []cli.Flag{commands.SnapshotterLabels}...),
-			commands.ContainerFlags...)...)...),
+	}, append(append(commands.SnapshotterFlags, []cli.Flag{commands.SnapshotterLabels}...),
+		commands.ContainerFlags...)...),
 	Action: func(context *cli.Context) error {
 		var (
 			err error

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -44,47 +44,6 @@ import (
 	"github.com/urfave/cli"
 )
 
-var platformRunFlags = []cli.Flag{
-	cli.StringFlag{
-		Name:  "runc-binary",
-		Usage: "specify runc-compatible binary",
-	},
-	cli.StringFlag{
-		Name:  "runc-root",
-		Usage: "specify runc-compatible root",
-	},
-	cli.BoolFlag{
-		Name:  "runc-systemd-cgroup",
-		Usage: "start runc with systemd cgroup manager",
-	},
-	cli.StringFlag{
-		Name:  "uidmap",
-		Usage: "run inside a user namespace with the specified UID mapping range; specified with the format `container-uid:host-uid:length`",
-	},
-	cli.StringFlag{
-		Name:  "gidmap",
-		Usage: "run inside a user namespace with the specified GID mapping range; specified with the format `container-gid:host-gid:length`",
-	},
-	cli.BoolFlag{
-		Name:  "remap-labels",
-		Usage: "provide the user namespace ID remapping to the snapshotter via label options; requires snapshotter support",
-	},
-	cli.BoolFlag{
-		Name:  "privileged-without-host-devices",
-		Usage: "don't pass all host devices to privileged container",
-	},
-	cli.Float64Flag{
-		Name:  "cpus",
-		Usage: "set the CFS cpu quota",
-		Value: 0.0,
-	},
-	cli.IntFlag{
-		Name:  "cpu-shares",
-		Usage: "set the cpu shares",
-		Value: 1024,
-	},
-}
-
 // NewContainer creates a new container
 func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli.Context) (containerd.Container, error) {
 	var (

--- a/cmd/ctr/commands/run/run_windows.go
+++ b/cmd/ctr/commands/run/run_windows.go
@@ -33,13 +33,6 @@ import (
 	"github.com/urfave/cli"
 )
 
-var platformRunFlags = []cli.Flag{
-	cli.BoolFlag{
-		Name:  "isolated",
-		Usage: "run the container with vm isolation",
-	},
-}
-
 // NewContainer creates a new container
 func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli.Context) (containerd.Container, error) {
 	var (


### PR DESCRIPTION
The `ctr container create` and `ctr run` commands use **NewContainer** to create a container based on cmd flags.
The flags used by **NewContainer** are common to both `ctr container create` and `ctr run`.

But in addition to `ContainerFlags`, there are many flags defined in their own commands, which mean that the flags for creating containers need to be maintained in multiple places, and there are many flags missing from the `ctr containers create` now.

We now maintain all falgs used by **NewContainer** in `ContainerFlags`, so that new flags related to container creation can be added to `ContainerFlags` and the corresponding logic added to **NewContainers**.

**This PR makes chagnes to NewContainer and container flags:**
* Move the flags associated with **NewContainer** in `ctr run` to `ContainerFlags`

**Changes to command behavior:**
* `ctr container create` adds support for the following flags
    * `--cgroup`, `--platform`
    * **unix**: `--cpus`, `--cpu-shares`, `--privileged-without-host-devices`, `--runc-binary`, `--runc-root`, `--runc-systemd-cgroup`, `--uidmap`, `--gidmap`
    * **windows**: `--isolated`

**`ctr run` flags and functions have not changed**

NOTES: `--cni` can also be added to ContainerFlags, requiring a change to `ctr task start`'s support for cni, which is relatively independent, so a new pr will be committed.
