### PR TITLE
Reused errdefs define error

### DIFF
--- a/oci/spec_opts_test.go
+++ b/oci/spec_opts_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/errdefs"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
@@ -93,41 +94,41 @@ func (i fakeImage) ContentStore() content.Store {
 func (i fakeImage) ReaderAt(ctx context.Context, dec ocispec.Descriptor) (content.ReaderAt, error) {
 	blob, found := i.blobs[dec.Digest.String()]
 	if !found {
-		return nil, errors.New("not found")
+		return nil, errdefs.ErrNotFound
 	}
 	return blob, nil
 }
 
 func (i fakeImage) Info(ctx context.Context, dgst digest.Digest) (content.Info, error) {
-	return content.Info{}, errors.New("not implemented")
+	return content.Info{}, errdefs.ErrNotImplemented
 }
 
 func (i fakeImage) Update(ctx context.Context, info content.Info, fieldpaths ...string) (content.Info, error) {
-	return content.Info{}, errors.New("not implemented")
+	return content.Info{}, errdefs.ErrNotImplemented
 }
 
 func (i fakeImage) Walk(ctx context.Context, fn content.WalkFunc, filters ...string) error {
-	return errors.New("not implemented")
+	return errdefs.ErrNotImplemented
 }
 
 func (i fakeImage) Delete(ctx context.Context, dgst digest.Digest) error {
-	return errors.New("not implemented")
+	return errdefs.ErrNotImplemented
 }
 
 func (i fakeImage) Status(ctx context.Context, ref string) (content.Status, error) {
-	return content.Status{}, errors.New("not implemented")
+	return content.Status{}, errdefs.ErrNotImplemented
 }
 
 func (i fakeImage) ListStatuses(ctx context.Context, filters ...string) ([]content.Status, error) {
-	return nil, errors.New("not implemented")
+	return nil, errdefs.ErrNotImplemented
 }
 
 func (i fakeImage) Abort(ctx context.Context, ref string) error {
-	return errors.New("not implemented")
+	return errdefs.ErrNotImplemented
 }
 
 func (i fakeImage) Writer(ctx context.Context, opts ...content.WriterOpt) (content.Writer, error) {
-	return nil, errors.New("not implemented")
+	return nil, errdefs.ErrNotImplemented
 }
 
 func TestReplaceOrAppendEnvValues(t *testing.T) {

--- a/snapshots/devmapper/metadata.go
+++ b/snapshots/devmapper/metadata.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/containerd/containerd/errdefs"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -50,9 +51,9 @@ var (
 
 var (
 	// ErrNotFound represents an error returned when object not found in meta store
-	ErrNotFound = errors.New("not found")
+	ErrNotFound = errdefs.ErrNotFound
 	// ErrAlreadyExists represents an error returned when object can't be duplicated in meta store
-	ErrAlreadyExists = errors.New("object already exists")
+	ErrAlreadyExists = errdefs.ErrAlreadyExists
 )
 
 // PoolMetadata keeps device info for the given thin-pool device, generates next available device ids,


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

Reused define error in package 'errdefs' , like ```errdefs.ErrNotFound and errdefs.ErrAlreadyExists, errdefs.ErrNotImplemented```