### PR TITLE
Remove rootfsSizeInGBLabel and replaced it by rootfsSizeInBytesLabel

### DIFF
--- a/snapshots/lcow/lcow.go
+++ b/snapshots/lcow/lcow.go
@@ -59,7 +59,7 @@ func init() {
 }
 
 const (
-	rootfsSizeLabel           = "containerd.io/snapshot/io.microsoft.container.storage.rootfs.size-gb"
+	rootfsSizeInBytesLabel    = "containerd.io/snapshot/windows/rootfs.sizebytes"
 	rootfsLocLabel            = "containerd.io/snapshot/io.microsoft.container.storage.rootfs.location"
 	reuseScratchLabel         = "containerd.io/snapshot/io.microsoft.container.storage.reuse-scratch"
 	reuseScratchOwnerKeyLabel = "containerd.io/snapshot/io.microsoft.owner.key"
@@ -356,9 +356,9 @@ func (s *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 				}
 			} else {
 				var sizeGB int
-				if sizeGBstr, ok := snapshotInfo.Labels[rootfsSizeLabel]; ok {
-					i64, _ := strconv.ParseInt(sizeGBstr, 10, 32)
-					sizeGB = int(i64)
+				if sizeGBstr, ok := snapshotInfo.Labels[rootfsSizeInBytesLabel]; ok {
+					i64, _ := strconv.ParseInt(sizeGBstr, 10, 64)
+					sizeGB = int(i64) / (1024 * 1024 * 1024)
 				}
 
 				scratchLocation := snapshotInfo.Labels[rootfsLocLabel]

--- a/snapshots/windows/windows.go
+++ b/snapshots/windows/windows.go
@@ -61,8 +61,6 @@ const (
 	uvmScratchLabel = "containerd.io/snapshot/io.microsoft.vm.storage.scratch"
 	// Label to control a containers scratch space size (sandbox.vhdx).
 	//
-	// Deprecated: use rootfsSizeInBytesLabel
-	rootfsSizeInGBLabel = "containerd.io/snapshot/io.microsoft.container.storage.rootfs.size-gb"
 	// rootfsSizeInBytesLabel is a label to control a Windows containers scratch space
 	// size in bytes.
 	rootfsSizeInBytesLabel = "containerd.io/snapshot/windows/rootfs.sizebytes"
@@ -375,16 +373,6 @@ func (s *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 			}
 
 			var sizeInBytes uint64
-			if sizeGBstr, ok := snapshotInfo.Labels[rootfsSizeInGBLabel]; ok {
-				log.G(ctx).Warnf("%q label is deprecated, please use %q instead.", rootfsSizeInGBLabel, rootfsSizeInBytesLabel)
-
-				sizeInGB, err := strconv.ParseUint(sizeGBstr, 10, 32)
-				if err != nil {
-					return fmt.Errorf("failed to parse label %q=%q: %w", rootfsSizeInGBLabel, sizeGBstr, err)
-				}
-				sizeInBytes = sizeInGB * 1024 * 1024 * 1024
-			}
-
 			// Prefer the newer label in bytes over the deprecated Windows specific GB variant.
 			if sizeBytesStr, ok := snapshotInfo.Labels[rootfsSizeInBytesLabel]; ok {
 				sizeInBytes, err = strconv.ParseUint(sizeBytesStr, 10, 64)


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

/kind cleanup
/kind bug

Remove deprecated internal field rootfsSizeInGBLabel and replaced it by rootfsSizeInBytesLabel ```containerd.io/snapshot/windows/rootfs.sizebytes```.
And change the read label in ```snapshotInfo.Labels``` , not the key ```"containerd.io/snapshot/io.microsoft.container.storage.rootfs.size-gb"```