### PR TITLE
make runc 1.1 for oss_fuzz_build.sh

### DIFF
--- a/contrib/fuzz/oss_fuzz_build.sh
+++ b/contrib/fuzz/oss_fuzz_build.sh
@@ -75,7 +75,7 @@ export GOARCH=amd64
 
 # Build runc
 cd $SRC/
-git clone https://github.com/opencontainers/runc --branch release-1.0
+git clone https://github.com/opencontainers/runc --branch release-1.1
 cd runc
 make
 make install


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

As go.mod import runc 1.1.4 , So change the ```contrib/fuzz/oss_fuzz_build.sh``` to follow branch 1.1  