### PR TITLE
cri: Shadow variables to avoid t.Parallel() issues

### DIFF
--- a/pkg/cri/server/container_create_linux_test.go
+++ b/pkg/cri/server/container_create_linux_test.go
@@ -888,6 +888,8 @@ func TestUserNamespace(t *testing.T) {
 			err: true,
 		},
 	} {
+		desc := desc
+		test := test
 		t.Run(desc, func(t *testing.T) {
 			containerConfig.Linux.SecurityContext.NamespaceOptions = &runtime.NamespaceOption{UsernsOptions: test.userNS}
 			spec, err := c.containerSpec(testID, testSandboxID, testPid, "", testContainerName, testImageName, containerConfig, sandboxConfig, imageConfig, nil, ociRuntime)


### PR DESCRIPTION
This is the first follow-up PR that after #7679 is merged. 

This was suggested here:
	https://github.com/containerd/containerd/pull/7679#discussion_r1058171608

Signed-off-by: Rodrigo Campos <rodrigoca@microsoft.com>