### PR TITLE
`ctr contents ls` sorts the labels of the content

### DIFF
--- a/cmd/ctr/commands/content/content.go
+++ b/cmd/ctr/commands/content/content.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -211,6 +212,7 @@ var (
 					for k, v := range info.Labels {
 						labelStrings = append(labelStrings, strings.Join([]string{k, v}, "="))
 					}
+					sort.Strings(labelStrings)
 					labels := strings.Join(labelStrings, ",")
 					if labels == "" {
 						labels = "-"


### PR DESCRIPTION
The current `ctr content list` will print the labels in random order due to the map, and the result will be different each time it is executed, which is inconvenient to use.

Now the labels are sorted to ensure that the result is the same each time