### PR TITLE
Validate userns container config is consistent with sandbox userns config

### DIFF
--- a/pkg/cri/server/container_create_linux.go
+++ b/pkg/cri/server/container_create_linux.go
@@ -316,6 +316,12 @@ func (c *criService) containerSpec(
 		return nil, fmt.Errorf("user namespace configuration: %w", err)
 	}
 
+	// Check sandbox userns config is consistent with container config.
+	sandboxUsernsOpts := sandboxConfig.GetLinux().GetSecurityContext().GetNamespaceOptions().GetUsernsOptions()
+	if !sameUsernsConfig(sandboxUsernsOpts, nsOpts.GetUsernsOptions()) {
+		return nil, fmt.Errorf("user namespace config for sandbox is different from container. Sandbox userns config: %v - Container userns config: %v", sandboxUsernsOpts, nsOpts.GetUsernsOptions())
+	}
+
 	specOpts = append(specOpts,
 		customopts.WithOOMScoreAdj(config, c.config.RestrictOOMScoreAdj),
 		customopts.WithPodNamespaces(securityContext, sandboxPid, targetPid, uids, gids),

--- a/pkg/cri/server/container_create_linux_test.go
+++ b/pkg/cri/server/container_create_linux_test.go
@@ -895,11 +895,11 @@ func TestUserNamespace(t *testing.T) {
 			spec, err := c.containerSpec(testID, testSandboxID, testPid, "", testContainerName, testImageName, containerConfig, sandboxConfig, imageConfig, nil, ociRuntime)
 
 			if test.err {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Nil(t, spec)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, spec.Linux.UIDMappings, test.expUIDMapping)
 			assert.Equal(t, spec.Linux.GIDMappings, test.expGIDMapping)
 

--- a/pkg/cri/server/helpers_linux.go
+++ b/pkg/cri/server/helpers_linux.go
@@ -319,15 +319,12 @@ func parseUsernsIDs(userns *runtime.UserNamespace) (uids, gids []specs.LinuxIDMa
 		return nil, nil, nil
 	}
 
-	uidRuntimeMap := userns.GetUids()
-	gidRuntimeMap := userns.GetGids()
-
-	uids, err := parseUsernsIDMap(uidRuntimeMap)
+	uids, err := parseUsernsIDMap(userns.GetUids())
 	if err != nil {
 		return nil, nil, fmt.Errorf("UID mapping: %w", err)
 	}
 
-	gids, err = parseUsernsIDMap(gidRuntimeMap)
+	gids, err = parseUsernsIDMap(userns.GetGids())
 	if err != nil {
 		return nil, nil, fmt.Errorf("GID mapping: %w", err)
 	}


### PR DESCRIPTION
This is a follow-up to address one item of this comment by @fuweid: https://github.com/containerd/containerd/pull/7679#pullrequestreview-1231373767

The first commit fixes an issue running the tests (assert vs require, so the function result can be nil by mistake instead of failing early).

The second commit is the follow-up itself. I didn't use reflect, as it _might_ be too slow to use on the container creation path. But this means we need to update sameUsernsConfig() if the runtime.UserNamespace type changes. Let me know if you prefer to use reflect here.

The third commit just removes a variable that is not really helpful. It is a cosmetic change, no functional change.