### PR TITLE
[transfer] Add lease to transfer to preserve streams during transfer

### DIFF
--- a/transfer.go
+++ b/transfer.go
@@ -32,6 +32,12 @@ import (
 )
 
 func (c *Client) Transfer(ctx context.Context, src interface{}, dest interface{}, opts ...transfer.Opt) error {
+	ctx, done, err := c.WithLease(ctx)
+	if err != nil {
+		return err
+	}
+	defer done(ctx)
+
 	return proxy.NewTransferrer(transferapi.NewTransferClient(c.conn), c.streamCreator()).Transfer(ctx, src, dest, opts...)
 }
 


### PR DESCRIPTION
Streams may be garbage collected between creation and use without the use of a lease.

To address #7884

There is also one other possible race between sending the ack message and registering a stream if this does not fully address the flaky test.