### PR TITLE
Fix race between stream registration and use

### DIFF
--- a/services/streaming/service.go
+++ b/services/streaming/service.go
@@ -74,17 +74,20 @@ func (s *service) Stream(srv api.Streaming_StreamServer) error {
 	if err != nil {
 		return err
 	}
-	if err := srv.Send(protobuf.FromAny(response)); err != nil {
-		return err
-	}
 
 	cc := make(chan struct{})
 	ss := &serviceStream{
 		s:  srv,
 		cc: cc,
 	}
+
 	log.G(srv.Context()).WithField("stream", i.ID).Debug("registering stream")
 	if err := s.manager.Register(srv.Context(), i.ID, ss); err != nil {
+		return err
+	}
+
+	// Send response packet after registering stream
+	if err := srv.Send(protobuf.FromAny(response)); err != nil {
 		return err
 	}
 

--- a/transfer.go
+++ b/transfer.go
@@ -32,6 +32,12 @@ import (
 )
 
 func (c *Client) Transfer(ctx context.Context, src interface{}, dest interface{}, opts ...transfer.Opt) error {
+	ctx, done, err := c.WithLease(ctx)
+	if err != nil {
+		return err
+	}
+	defer done(ctx)
+
 	return proxy.NewTransferrer(transferapi.NewTransferClient(c.conn), c.streamCreator()).Transfer(ctx, src, dest, opts...)
 }
 


### PR DESCRIPTION
Prevent a race where a client may attempt to use a stream before it is registered.

Addresses #7885