### PR TITLE
Vagrantfile: install-rootless-podman: remove `setenforce 0`

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -303,8 +303,6 @@ EOF
 [registries.search]
 registries = ['docker.io']
 EOF
-        # Disable SELinux to allow overlayfs
-        setenforce 0
     SHELL
   end
 


### PR DESCRIPTION
rootless overlayfs is compatible with SELinux since kernel 5.13
