### PR TITLE
Fix TestUpdateContainerResources_Memory* on cgroup v2 hosts

### DIFF
--- a/integration/container_update_resources_test.go
+++ b/integration/container_update_resources_test.go
@@ -81,7 +81,7 @@ func getCgroupSwapLimitForTask(t *testing.T, task containerd.Task) uint64 {
 		if err != nil {
 			t.Fatal(err)
 		}
-		return stat.Memory.SwapLimit
+		return stat.Memory.SwapLimit + stat.Memory.UsageLimit
 	}
 	cgroup, err := cgroup1.Load(cgroup1.PidPath(int(task.Pid())))
 	if err != nil {
@@ -171,11 +171,6 @@ func TestUpdateContainerResources_MemorySwap(t *testing.T) {
 	expectedBaseSwap := baseSwapLimit
 	expectedIncreasedSwap := increasedSwapLimit
 
-	if cgroups.Mode() == cgroups.Unified {
-		expectedBaseSwap = baseSwapLimit - memoryLimit
-		expectedIncreasedSwap = increasedSwapLimit - memoryLimit
-	}
-
 	t.Log("Create a container with memory limit but no swap")
 	cnConfig := ContainerConfig(
 		"container",
@@ -237,9 +232,6 @@ func TestUpdateContainerResources_MemoryLimit(t *testing.T) {
 	EnsureImageExists(t, pauseImage)
 
 	expectedSwapLimit := func(memoryLimit int64) *int64 {
-		if cgroups.Mode() == cgroups.Unified {
-			memoryLimit = 0
-		}
 		return &memoryLimit
 	}
 


### PR DESCRIPTION
Fix #7890

Tested on Ubuntu 22.10, with swapon and swapoff:
```console
$ GITHUB_WORKSPACE="" ENABLE_CRI_SANDBOXES="" CONTAINERD_RUNTIME=io.containerd.runc.v2 FOCUS=TestUpdateContainerResources_Memory make cri-integration
...
=== RUN   TestUpdateContainerResources_MemorySwap
    container_update_resources_test.go:161: Create a sandbox
INFO[0000] Using the following image list: {Alpine:docker.io/library/alpine:latest BusyBox:docker.io/library/busybox:latest Pause:registry.k8s.io/pause:3.8 ResourceConsumer:registry.k8s.io/e2e-test-images/resource-consumer:1.10 VolumeCopyUp:ghcr.io/containerd/volume-copy-up:2.1 VolumeOwnership:ghcr.io/containerd/volume-ownership:2.1}
    main_test.go:663: Image "registry.k8s.io/pause:3.8" already exists, not pulling.
    container_update_resources_test.go:174: Create a container with memory limit but no swap
    container_update_resources_test.go:186: Check memory limit in container OCI spec
    container_update_resources_test.go:194: Check memory limit in container OCI spec
    container_update_resources_test.go:200: Start the container
    container_update_resources_test.go:205: Check memory limit in cgroup
    container_update_resources_test.go:211: Update container memory limit after started
    container_update_resources_test.go:217: Check memory limit in container OCI spec
    container_update_resources_test.go:222: Check memory limit in cgroup
--- PASS: TestUpdateContainerResources_MemorySwap (0.88s)
=== RUN   TestUpdateContainerResources_MemoryLimit
    container_update_resources_test.go:228: Create a sandbox
    main_test.go:663: Image "registry.k8s.io/pause:3.8" already exists, not pulling.
    container_update_resources_test.go:238: Create a container with memory limit
    container_update_resources_test.go:249: Check memory limit in container OCI spec
    container_update_resources_test.go:257: Update container memory limit after created
    container_update_resources_test.go:263: Check memory limit in container OCI spec
    container_update_resources_test.go:269: Start the container
    container_update_resources_test.go:274: Check memory limit in cgroup
    container_update_resources_test.go:280: Update container memory limit after started
    container_update_resources_test.go:286: Check memory limit in container OCI spec
    container_update_resources_test.go:292: Check memory limit in cgroup
--- PASS: TestUpdateContainerResources_MemoryLimit (0.91s)
PASS
```
