### PR TITLE
CRI: Comment cleanup/misc fixes

### DIFF
--- a/pkg/cri/server/service_linux.go
+++ b/pkg/cri/server/service_linux.go
@@ -92,7 +92,7 @@ func (c *criService) initPlatform() (err error) {
 		reg := cdi.GetRegistry()
 		err = reg.Configure(cdi.WithSpecDirs(c.config.CDISpecDirs...))
 		if err != nil {
-			return fmt.Errorf("failed to configure CDI registry")
+			return fmt.Errorf("failed to configure CDI registry: %w", err)
 		}
 	}
 

--- a/pkg/cri/server/service_other.go
+++ b/pkg/cri/server/service_other.go
@@ -22,12 +22,13 @@ import (
 	cni "github.com/containerd/go-cni"
 )
 
-// initPlatform handles linux specific initialization for the CRI service.
+// initPlatform handles initialization for the CRI service on non-Windows and non-Linux
+// platforms.
 func (c *criService) initPlatform() error {
 	return nil
 }
 
-// cniLoadOptions returns cni load options for the linux.
+// cniLoadOptions returns cni load options for non-Windows and non-Linux platforms.
 func (c *criService) cniLoadOptions() []cni.Opt {
 	return []cni.Opt{}
 }

--- a/pkg/cri/server/service_windows.go
+++ b/pkg/cri/server/service_windows.go
@@ -26,7 +26,7 @@ import (
 // attaches to
 const windowsNetworkAttachCount = 1
 
-// initPlatform handles linux specific initialization for the CRI service.
+// initPlatform handles Windows specific initialization for the CRI service.
 func (c *criService) initPlatform() error {
 	pluginDirs := map[string]string{
 		defaultNetworkPlugin: c.config.NetworkPluginConfDir,


### PR DESCRIPTION
Comments in initPlatform for Windows states that the options were Linux specific. Additionally properly wrap an error after trying to setup CDI on Linux.