### PR TITLE
Vagrantfile: fix comments about SELinux

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -222,8 +222,8 @@ EOF
     SHELL
   end
 
-  # SELinux is permissive by default (via provisioning) in this VM. To re-run with SELinux enforcing:
-  #   vagrant up --provision-with=selinux-enforcing,test-integration
+  # SELinux is Enforcing by default (via provisioning) in this VM. To re-run with SELinux disabled:
+  #   SELINUX=Disabled vagrant up --provision-with=selinux,test-integration
   #
   config.vm.provision "test-integration", type: "shell", run: "never" do |sh|
     sh.upload_path = "/tmp/test-integration"
@@ -245,8 +245,8 @@ EOF
     SHELL
   end
 
-  # SELinux is permissive by default (via provisioning) in this VM. To re-run with SELinux enforcing:
-  #   vagrant up --provision-with=selinux-enforcing,test-cri
+  # SELinux is Enforcing by default (via provisioning) in this VM. To re-run with SELinux disabled:
+  #   SELINUX=Disabled vagrant up --provision-with=selinux,test-cri
   #
   config.vm.provision "test-cri", type: "shell", run: "never" do |sh|
     sh.upload_path = "/tmp/test-cri"


### PR DESCRIPTION
SELinux has been enforcing since commit a7f24b29c20fa4c4257a8f5ea15922e8bb53450c (PR #4698, v1.5.0)
