### PR TITLE
Enable dupword linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - unconvert
     - unused
     - vet
+    - dupword # Checks for duplicate words in the source code
   disable:
     - errcheck
 
@@ -34,7 +35,7 @@ linters-settings:
     # The following issues surfaced when `gosec` linter
     # was enabled. They are temporarily excluded to unblock
     # the existing workflow, but still to be addressed by
-    # by future works.
+    # future works.
     excludes:
       - G204
       - G305

--- a/cio/io_unix_test.go
+++ b/cio/io_unix_test.go
@@ -240,7 +240,7 @@ func TestLogURIGenerator(t *testing.T) {
 		{
 			scheme: "binary",
 			path:   "C:\\path\\to\\binary",
-			// NOTE: Windows paths should not be be parse-able outside of Windows:
+			// NOTE: Windows paths should not be parse-able outside of Windows:
 			err: "must be absolute",
 		},
 	})

--- a/cmd/containerd-stress/density.go
+++ b/cmd/containerd-stress/density.go
@@ -204,6 +204,7 @@ type Stat struct {
 }
 
 func parseStat(data string) (stat Stat, err error) {
+	//nolint:dupword
 	// From proc(5), field 2 could contain space and is inside `(` and `)`.
 	// The following is an example:
 	// 89653 (gunicorn: maste) S 89630 89653 89653 0 -1 4194560 29689 28896 0 3 146 32 76 19 20 0 1 0 2971844 52965376 3920 18446744073709551615 1 1 0 0 0 0 0 16781312 137447943 0 0 0 17 1 0 0 0 0 0 0 0 0 0 0 0 0 0

--- a/content/local/store.go
+++ b/content/local/store.go
@@ -505,6 +505,7 @@ func (s *store) resumeStatus(ref string, total int64, digester digest.Digester) 
 		return status, fmt.Errorf("provided total differs from status: %v != %v", total, status.Total)
 	}
 
+	//nolint:dupword
 	// TODO(stevvooe): slow slow slow!!, send to goroutine or use resumable hashes
 	fp, err := os.Open(data)
 	if err != nil {

--- a/errdefs/grpc_test.go
+++ b/errdefs/grpc_test.go
@@ -42,6 +42,7 @@ func TestGRPCRoundTrip(t *testing.T) {
 			input: ErrNotFound,
 			cause: ErrNotFound,
 		},
+		//nolint:dupword
 		{
 			input: fmt.Errorf("test test test: %w", ErrFailedPrecondition),
 			cause: ErrFailedPrecondition,

--- a/images/converter/default.go
+++ b/images/converter/default.go
@@ -132,7 +132,7 @@ func copyDesc(desc ocispec.Descriptor) *ocispec.Descriptor {
 	return &descCopy
 }
 
-// convertLayer converts image image layers if c.layerConvertFunc is set.
+// convertLayer converts image layers if c.layerConvertFunc is set.
 //
 // c.layerConvertFunc can be nil, e.g., for converting Docker media types to OCI ones.
 func (c *defaultConverter) convertLayer(ctx context.Context, cs content.Store, desc ocispec.Descriptor) (*ocispec.Descriptor, error) {

--- a/metadata/db.go
+++ b/metadata/db.go
@@ -283,7 +283,7 @@ func (m *DB) RegisterMutationCallback(fn func(bool)) {
 // RegisterCollectibleResource registers a resource type which can be
 // referenced by metadata resources and garbage collected.
 // Collectible Resources are useful ephemeral resources which need to
-// to be tracked by go away after reboot or process restart.
+// be tracked by go away after reboot or process restart.
 //
 // A few limitations to consider:
 //   - Collectible Resources cannot reference other resources.

--- a/pkg/cap/cap_linux_test.go
+++ b/pkg/cap/cap_linux_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+//nolint:dupword
 const procPIDStatus = `Name:   cat
 Umask:  0022
 State:  R (running)

--- a/pkg/cri/sbserver/container_create.go
+++ b/pkg/cri/sbserver/container_create.go
@@ -366,7 +366,7 @@ func (c *criService) runtimeSpec(id string, baseSpecFile string, opts ...oci.Spe
 }
 
 // Overrides the default snapshotter if Snapshotter is set for this runtime.
-// See See https://github.com/containerd/containerd/issues/6657
+// See https://github.com/containerd/containerd/issues/6657
 func (c *criService) runtimeSnapshotter(ctx context.Context, ociRuntime criconfig.Runtime) string {
 	if ociRuntime.Snapshotter == "" {
 		return c.config.ContainerdConfig.Snapshotter

--- a/pkg/cri/sbserver/instrumented_service.go
+++ b/pkg/cri/sbserver/instrumented_service.go
@@ -1537,7 +1537,7 @@ func (in *instrumentedService) UpdateRuntimeConfig(ctx context.Context, r *runti
 		if err != nil {
 			log.G(ctx).WithError(err).Error("UpdateRuntimeConfig failed")
 		} else {
-			log.G(ctx).Debug("UpdateRuntimeConfig returns returns successfully")
+			log.G(ctx).Debug("UpdateRuntimeConfig returns successfully")
 		}
 	}()
 	res, err = in.c.UpdateRuntimeConfig(ctrdutil.WithNamespace(ctx), r)
@@ -1553,7 +1553,7 @@ func (in *instrumentedAlphaService) UpdateRuntimeConfig(ctx context.Context, r *
 		if err != nil {
 			log.G(ctx).WithError(err).Error("UpdateRuntimeConfig failed")
 		} else {
-			log.G(ctx).Debug("UpdateRuntimeConfig returns returns successfully")
+			log.G(ctx).Debug("UpdateRuntimeConfig returns successfully")
 		}
 	}()
 	// converts request and response for earlier CRI version to call and get response from the current version

--- a/pkg/cri/sbserver/podsandbox/helpers.go
+++ b/pkg/cri/sbserver/podsandbox/helpers.go
@@ -216,7 +216,7 @@ func (c *Controller) runtimeSpec(id string, baseSpecFile string, opts ...oci.Spe
 }
 
 // Overrides the default snapshotter if Snapshotter is set for this runtime.
-// See See https://github.com/containerd/containerd/issues/6657
+// See https://github.com/containerd/containerd/issues/6657
 func (c *Controller) runtimeSnapshotter(ctx context.Context, ociRuntime criconfig.Runtime) string {
 	if ociRuntime.Snapshotter == "" {
 		return c.config.ContainerdConfig.Snapshotter

--- a/pkg/cri/server/container_create.go
+++ b/pkg/cri/server/container_create.go
@@ -377,7 +377,7 @@ func (c *criService) runtimeSpec(id string, baseSpecFile string, opts ...oci.Spe
 }
 
 // Overrides the default snapshotter if Snapshotter is set for this runtime.
-// See See https://github.com/containerd/containerd/issues/6657
+// See https://github.com/containerd/containerd/issues/6657
 func (c *criService) runtimeSnapshotter(ctx context.Context, ociRuntime criconfig.Runtime) string {
 	if ociRuntime.Snapshotter == "" {
 		return c.config.ContainerdConfig.Snapshotter

--- a/pkg/cri/server/instrumented_service.go
+++ b/pkg/cri/server/instrumented_service.go
@@ -1537,7 +1537,7 @@ func (in *instrumentedService) UpdateRuntimeConfig(ctx context.Context, r *runti
 		if err != nil {
 			log.G(ctx).WithError(err).Error("UpdateRuntimeConfig failed")
 		} else {
-			log.G(ctx).Debug("UpdateRuntimeConfig returns returns successfully")
+			log.G(ctx).Debug("UpdateRuntimeConfig returns successfully")
 		}
 	}()
 	res, err = in.c.UpdateRuntimeConfig(ctrdutil.WithNamespace(ctx), r)
@@ -1553,7 +1553,7 @@ func (in *instrumentedAlphaService) UpdateRuntimeConfig(ctx context.Context, r *
 		if err != nil {
 			log.G(ctx).WithError(err).Error("UpdateRuntimeConfig failed")
 		} else {
-			log.G(ctx).Debug("UpdateRuntimeConfig returns returns successfully")
+			log.G(ctx).Debug("UpdateRuntimeConfig returns successfully")
 		}
 	}()
 	// converts request and response for earlier CRI version to call and get response from the current version

--- a/reference/docker/normalize.go
+++ b/reference/docker/normalize.go
@@ -119,7 +119,7 @@ func splitDockerDomain(name string) (domain, remainder string) {
 }
 
 // familiarizeName returns a shortened version of the name familiar
-// to to the Docker UI. Familiar names have the default domain
+// to the Docker UI. Familiar names have the default domain
 // "docker.io" and "library/" repository prefix removed.
 // For example, "docker.io/library/redis" will have the familiar
 // name "redis" and "docker.io/dmcgowan/myapp" will be "dmcgowan/myapp".


### PR DESCRIPTION
`dupword` linter prevents duplicated words in the source code.
This PR updates `.golangci.yml` and removes some duplicates.

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>