### PR TITLE
docs: fix a typo in tracing documentation

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -3,7 +3,7 @@
 containerd supports OpenTelemetry tracing since v1.6.0.
 Tracing currently targets only gRPC calls.
 
-## Sending traces from containerd deamon
+## Sending traces from containerd daemon
 
 By configuring `io.containerd.tracing.processor.v1.otlp` plugin.
 containerd daemon can send traces to the specified OpenTelemetry endpoint.


### PR DESCRIPTION
It should be "daemon"

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>