### PR TITLE
[release/1.6] CI: Pass GITHUB_TOKEN to containerd/project-checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,10 @@ jobs:
           path: src/github.com/containerd/containerd
           fetch-depth: 100
 
-      - uses: containerd/project-checks@v1
+      - uses: containerd/project-checks@v1.1.0
         with:
           working-directory: src/github.com/containerd/containerd
+          repo-access-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: verify go modules and vendor directory
         run: |


### PR DESCRIPTION
Backport #7913

----
Previously the project-checks action was failing sometimes due to hitting GitHub API rate limits. Since no token was supplied, the rate limits were only 60 requests/hour keyed off the IP address of the runner.

Now, passing GITHUB_TOKEN secret through to project-checks, we have a limit of 1000 requests/hour for the whole repo. This should alleviate the rate limits that were being seen.

I believe it is safe to pass this secret as project-checks is also owned by the containerd organization. The secret is also scoped to the actions run, and is invalidated upon completion.

project-checks version is also updated to the version that supports repo-access-token input.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>
(cherry picked from commit 79d09c69b4e4799e35b1d97718ab70351fe82164)
Signed-off-by: Derek McGowan <derek@mcg.dev>