### PR TITLE
Add --no-unpack flag to ctr images pull

### DIFF
--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -161,7 +161,9 @@ command. As part of this process, we do the following:
 			return err
 		}
 
-		log.G(ctx).WithField("image", ref).Debug("unpacking")
+		if !context.Bool("no-unpack") {
+			log.G(ctx).WithField("image", ref).Debug("unpacking")
+		}
 
 		// TODO: Show unpack status
 
@@ -186,9 +188,9 @@ command. As part of this process, we do the following:
 
 		start := time.Now()
 		for _, platform := range p {
-			fmt.Printf("unpacking %s %s...\n", platforms.Format(platform), img.Target.Digest)
 			i := containerd.NewImageWithPlatform(client, img, platforms.Only(platform))
 			if !context.Bool("no-unpack") {
+				fmt.Printf("unpacking %s %s...\n", platforms.Format(platform), img.Target.Digest)
 				err = i.Unpack(ctx, context.String("snapshotter"))
 				if err != nil {
 					return err


### PR DESCRIPTION
This adds a `--no-unpack` flag to `ctr images pull` equivalent to the flag available on `ctr images import`, for the same reasons discussed in https://github.com/containerd/containerd/issues/3258.

In https://github.com/awslabs/amazon-eks-ami, we're working on caching images to improve node startup times; and we'd like to populate our cache with `pull` instead of `import`.