### PR TITLE
Add --no-unpack to ctr images pull

### DIFF
--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -66,8 +66,12 @@ command. As part of this process, we do the following:
 			Usage: "Pull metadata for all platforms",
 		},
 		cli.BoolFlag{
+			Name:  "no-unpack",
+			Usage: "skip unpacking the images, cannot be used with --print-chainid, false by default",
+		},		
+		cli.BoolFlag{
 			Name:  "print-chainid",
-			Usage: "Print the resulting image's chain ID",
+			Usage: "Print the resulting image's chain ID, cannot be used with --no-unpack, false by default",
 		},
 		cli.IntFlag{
 			Name:  "max-concurrent-downloads",
@@ -84,6 +88,12 @@ command. As part of this process, we do the following:
 		)
 		if ref == "" {
 			return fmt.Errorf("please provide an image reference to pull")
+		}
+
+		if context.Bool("print-chainid") {
+			if context.Bool("no-unpack") {
+				return fmt.Errorf("--print-chainid and --no-unpack are incompatible options")
+			}
 		}
 
 		client, ctx, cancel, err := commands.NewClient(context)
@@ -151,7 +161,9 @@ command. As part of this process, we do the following:
 			return err
 		}
 
-		log.G(ctx).WithField("image", ref).Debug("unpacking")
+		if !context.Bool("no-unpack") {
+			log.G(ctx).WithField("image", ref).Debug("unpacking")
+		}
 
 		// TODO: Show unpack status
 
@@ -176,19 +188,21 @@ command. As part of this process, we do the following:
 
 		start := time.Now()
 		for _, platform := range p {
-			fmt.Printf("unpacking %s %s...\n", platforms.Format(platform), img.Target.Digest)
 			i := containerd.NewImageWithPlatform(client, img, platforms.Only(platform))
-			err = i.Unpack(ctx, context.String("snapshotter"))
-			if err != nil {
-				return err
-			}
-			if context.Bool("print-chainid") {
-				diffIDs, err := i.RootFS(ctx)
+			if !context.Bool("no-unpack") {
+				fmt.Printf("unpacking %s %s...\n", platforms.Format(platform), img.Target.Digest)
+				err = i.Unpack(ctx, context.String("snapshotter"))
 				if err != nil {
 					return err
 				}
-				chainID := identity.ChainID(diffIDs).String()
-				fmt.Printf("image chain ID: %s\n", chainID)
+				if context.Bool("print-chainid") {
+					diffIDs, err := i.RootFS(ctx)
+					if err != nil {
+						return err
+					}
+					chainID := identity.ChainID(diffIDs).String()
+					fmt.Printf("image chain ID: %s\n", chainID)
+				}
 			}
 		}
 		fmt.Printf("done: %s\t\n", time.Since(start))

--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -68,7 +68,7 @@ command. As part of this process, we do the following:
 		cli.BoolFlag{
 			Name:  "no-unpack",
 			Usage: "skip unpacking the images, cannot be used with --print-chainid, false by default",
-		},		
+		},
 		cli.BoolFlag{
 			Name:  "print-chainid",
 			Usage: "Print the resulting image's chain ID, cannot be used with --no-unpack, false by default",


### PR DESCRIPTION
This adds a --no-unpack flag to `ctr images pull` equivalent to the flag available on `ctr images import`, for the same reasons discussed in https://github.com/containerd/containerd/issues/3258.

In https://github.com/awslabs/amazon-eks-ami, we're working on caching images to improve node startup times; and we'd like to fetch the content with `pull` instead of `import`, without creating snapshots in the process.