### PR TITLE
[release/1.6] Prepare release notes for v1.6.15

### DIFF
--- a/releases/v1.6.15.toml
+++ b/releases/v1.6.15.toml
@@ -1,0 +1,20 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release
+previous = "v1.6.14"
+
+pre_release = false
+
+preface = """\
+The fifteenth patch release for containerd 1.6 fixes an issue with CNI in the CRI plugin
+
+### Notable Updates
+
+* **Fix no CNI info for pod sandbox on restart in CRI plugin** ([#7848](https://github.com/containerd/containerd/pull/7848))
+
+See the changelog for complete list of changes"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.14+unknown"
+	Version = "1.6.15+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generate notes

----
containerd 1.6.15

Welcome to the v1.6.15 release of containerd!

The fifteenth patch release for containerd 1.6 fixes an issue with CNI in the CRI plugin

### Notable Updates

* **Fix no CNI info for pod sandbox on restart in CRI plugin** ([#7848](https://github.com/containerd/containerd/pull/7848))

See the changelog for complete list of changes

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Derek McGowan
* Akihiro Suda
* Danny Canter
* Wei Fu

### Changes
<details><summary>5 commits</summary>
<p>

  * [`883899eae`](https://github.com/containerd/containerd/commit/883899eaed4ab95e3c415b5937438b4439796bfc) Prepare release notes for v1.6.15
* [release/1.6] integration/images: switch away from Docker Hub to avoid rate limit ([#7900](https://github.com/containerd/containerd/pull/7900))
  * [`0f4062c9b`](https://github.com/containerd/containerd/commit/0f4062c9be0155861a1907dd1e1fe54b38c1d5ac) integration/images: switch away from Docker Hub to avoid rate limit
* [release/1.6] CRI: Fix no CNI info for pod sandbox on restart ([#7848](https://github.com/containerd/containerd/pull/7848))
  * [`f16447e2d`](https://github.com/containerd/containerd/commit/f16447e2d495d77c03c6644e78877cd3596ef523) CRI: Fix no CNI info for pod sandbox on restart
</p>
</details>

### Dependency Changes

This release has no dependency changes

Previous release can be found at [v1.6.14](https://github.com/containerd/containerd/releases/tag/v1.6.14)

