### PR TITLE
NRI integration tests only for Linux

### DIFF
--- a/integration/nri_linux_test.go
+++ b/integration/nri_linux_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	goruntime "runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -55,10 +54,6 @@ var (
 
 // skipNriTestIfNecessary skips NRI tests if necessary.
 func skipNriTestIfNecessary(t *testing.T, extraSkipChecks ...map[string]bool) {
-	if goruntime.GOOS != "linux" {
-		t.Skip("Not running on linux")
-	}
-
 	if selinux.GetEnabled() {
 		// https://github.com/containerd/containerd/pull/7892#issuecomment-1369825603
 		t.Skip("SELinux relabeling is not supported for NRI yet")


### PR DESCRIPTION
Currently all the NRI tests are targeted only for Linux platform.  All the tests start with 
```
	if goruntime.GOOS != "linux" {
		t.Skip("Not running on linux")
	}
```
 Change the `nri_test.go` file to `nri_linux_test.go` so it will be explicitly built only for Linux to eliminate confusing Windows [CRI Integration test message](https://github.com/containerd/containerd/actions/runs/3841117456/jobs/6541013311).

```
=== RUN   TestNriPluginSetup
    nri_test.go:59: Not running on linux
--- SKIP: TestNriPluginSetup (0.00s)
=== RUN   TestNriPluginSynchronization
    nri_test.go:59: Not running on linux
--- SKIP: TestNriPluginSynchronization (0.00s)
=== RUN   TestNriMountInjection
    nri_test.go:59: Not running on linux
--- SKIP: TestNriMountInjection (0.00s)
=== RUN   TestNriEnvironmentInjection
    nri_test.go:59: Not running on linux
--- SKIP: TestNriEnvironmentInjection (0.00s)
=== RUN   TestNriAnnotationInjection
    nri_test.go:59: Not running on linux
--- SKIP: TestNriAnnotationInjection (0.00s)
=== RUN   TestNriLinuxDeviceInjection
    nri_test.go:59: Not running on linux
--- SKIP: TestNriLinuxDeviceInjection (0.00s)
=== RUN   TestNriLinuxCpusetAdjustment
    nri_test.go:1221: failed to read /sys/devices/system/cpu/online: open /sys/devices/system/cpu/online: The system cannot find the path specified.
    nri_test.go:59: Not running on linux
--- SKIP: TestNriLinuxCpusetAdjustment (0.00s)
=== RUN   TestNriLinuxMemsetAdjustment
    nri_test.go:1221: failed to read /sys/devices/system/node/has_normal_memory: open /sys/devices/system/node/has_normal_memory: The system cannot find the path specified.
    nri_test.go:59: Not running on linux
--- SKIP: TestNriLinuxMemsetAdjustment (0.00s)
=== RUN   TestNriLinuxCpusetAdjustmentUpdate
    nri_test.go:1221: failed to read /sys/devices/system/cpu/online: open /sys/devices/system/cpu/online: The system cannot find the path specified.
    nri_test.go:59: Not running on linux
--- SKIP: TestNriLinuxCpusetAdjustmentUpdate (0.00s)
=== RUN   TestNriLinuxMemsetAdjustmentUpdate
    nri_test.go:1221: failed to read /sys/devices/system/node/has_normal_memory: open /sys/devices/system/node/has_normal_memory: The system cannot find the path specified.
    nri_test.go:59: Not running on linux
--- SKIP: TestNriLinuxMemsetAdjustmentUpdate (0.00s)
=== RUN   TestNriPluginContainerdRestart
    nri_test.go:59: Not running on linux
--- SKIP: TestNriPluginContainerdRestart (0.00s)
```

Signed-off-by: Tony Fang <nenghui.fang@gmail.com>


