### PR TITLE
Fix Flaky Windows CRI Integration test on TestContainerConsumedStats

### DIFF
--- a/integration/container_stats_test.go
+++ b/integration/container_stats_test.go
@@ -103,8 +103,14 @@ func TestContainerConsumedStats(t *testing.T) {
 		if err != nil {
 			return false, err
 		}
-		if s.GetWritableLayer().GetTimestamp() > 0 {
-			return true, nil
+		if goruntime.GOOS == "windows" {
+			if s.GetMemory().GetWorkingSetBytes().GetValue() > 0 {
+				return true, nil
+			}
+		} else {
+			if s.GetWritableLayer().GetTimestamp() > 0 {
+				return true, nil
+			}
 		}
 		return false, nil
 	}, time.Second, 30*time.Second))


### PR DESCRIPTION
Fix #7936  - random failures on Windows CRI Integration test TestContainerConsumedStats(context timeout).

This PR is to reapply the previous [commit](https://github.com/containerd/containerd/pull/7892/commits/76d68b080ef69407129a5925ae5b97f1c9010dea) change on [TestContainerConsumedStats](https://github.com/containerd/containerd/pull/7892/commits/76d68b080ef69407129a5925ae5b97f1c9010dea#diff-2885e285816541779f8967567923949ba6195e3a517479cef9813c813ac63d1dL106) back to Windows platform. 

Signed-off-by: Tony Fang <nenghui.fang@gmail.com>