### PR TITLE
Fix restarting containers that are being paused

### DIFF
--- a/runtime/restart/monitor/monitor.go
+++ b/runtime/restart/monitor/monitor.go
@@ -171,9 +171,15 @@ func (m *monitor) monitor(ctx context.Context) ([]change, error) {
 		// which will result in an `on-failure` restart policy reconcile error.
 		switch desiredStatus {
 		case containerd.Running:
+			switch status.Status {
+			case containerd.Paused, containerd.Pausing:
+				continue
+			default:
+			}
 			if !restart.Reconcile(status, labels) {
 				continue
 			}
+
 			restartCount, _ := strconv.Atoi(labels[restart.CountLabel])
 			changes = append(changes, &startChange{
 				container: c,


### PR DESCRIPTION
<!--The monitor is polled to get the container, when there will be some exceptions for tasks with the following status.
* **"Created"**: will restart again and `containerd.io/restart.count` label +1
```bash
# we use nerdctl to reproduce it more simply, but of course it is possible to use ctr
$ nerdctl run -d  --restart=always ubuntu:latest sleep 10000

$ # Execute once per second, about 15 times
$ nerdctl run -d  --restart=always ubuntu:latest sleep 10000
$ ... # There may be an error —— "FATA[0000] OCI runtime start failed: cannot start a container that has stopped: unknown", but it is also caused by the restart monitor

$ # View containers that have been restarted once
$ nerdctl ps --filter label=containerd.io/restart.count
CONTAINER ID    IMAGE                              COMMAND          CREATED           STATUS    PORTS    NAMES
1ae72b80d098    docker.io/library/ubuntu:latest    "sleep 10000"    58 seconds ago    Up                 ubuntu-1ae72
e9da1beb4d83    docker.io/library/ubuntu:latest    "sleep 10000"    48 seconds ago    Up                 ubuntu-e9da1

$ nerdctl inspect 1ae72b80d098 | grep restart.count
                "containerd.io/restart.count": "1",
```

* **"Pause"**: The container cannot be paused using nerdctl or ctr, because it will restart the container
```bash
$ nerdctl run -d  --restart=always ubuntu:latest sleep 10000
86b74ce03e8063904fb6b4d99c791c86d9fa4b251e7daf3da1b20ecab23fed10
$ nerdctl pause 86b74ce03e
$ # sleep 5s, In the interval you can also run `ctr tasks ls` or `nerdctl ps -a` to check the status

$ nerdctl ps # Oh no, the container was restarted
CONTAINER ID    IMAGE                              COMMAND          CREATED           STATUS    PORTS    NAMES
86b74ce03e80    docker.io/library/ubuntu:latest    "sleep 10000"    38 seconds ago    Up                 ubuntu-86b74
```

When dealing with containers that expect a Running status, it seems reasonable to restrict the current task status to Stop so that there are no wrong restarts.
-->
fix: https://github.com/containerd/containerd/issues/8095