### PR TITLE
Use specs Platform instead of generated API

### DIFF
--- a/pkg/cri/sbserver/container_create.go
+++ b/pkg/cri/sbserver/container_create.go
@@ -33,7 +33,6 @@ import (
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/oci"
@@ -45,6 +44,7 @@ import (
 	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
 	"github.com/containerd/containerd/pkg/cri/util"
 	ctrdutil "github.com/containerd/containerd/pkg/cri/util"
+	"github.com/containerd/containerd/platforms"
 )
 
 func init() {
@@ -407,7 +407,7 @@ const (
 
 // buildContainerSpec build container's OCI spec depending on controller's target platform OS.
 func (c *criService) buildContainerSpec(
-	platform *types.Platform,
+	platform platforms.Platform,
 	id string,
 	sandboxID string,
 	sandboxPid uint32,

--- a/pkg/cri/sbserver/container_create_test.go
+++ b/pkg/cri/sbserver/container_create_test.go
@@ -22,7 +22,8 @@ import (
 	goruntime "runtime"
 	"testing"
 
-	"github.com/containerd/containerd/api/types"
+	"github.com/containerd/containerd/platforms"
+
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
@@ -35,7 +36,7 @@ import (
 	"github.com/containerd/containerd/pkg/cri/opts"
 )
 
-var currentPlatform = &types.Platform{OS: goruntime.GOOS, Architecture: goruntime.GOARCH}
+var currentPlatform = platforms.DefaultSpec()
 
 func checkMount(t *testing.T, mounts []runtimespec.Mount, src, dest, typ string,
 	contains, notcontains []string) {

--- a/pkg/cri/sbserver/podsandbox/controller.go
+++ b/pkg/cri/sbserver/podsandbox/controller.go
@@ -19,13 +19,14 @@ package podsandbox
 import (
 	"context"
 	"fmt"
-	goruntime "runtime"
 	"time"
+
+	"github.com/sirupsen/logrus"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/containerd/containerd"
 	eventtypes "github.com/containerd/containerd/api/events"
 	api "github.com/containerd/containerd/api/services/sandbox/v1"
-	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/oci"
 	criconfig "github.com/containerd/containerd/pkg/cri/config"
@@ -33,10 +34,9 @@ import (
 	sandboxstore "github.com/containerd/containerd/pkg/cri/store/sandbox"
 	ctrdutil "github.com/containerd/containerd/pkg/cri/util"
 	osinterface "github.com/containerd/containerd/pkg/os"
+	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/protobuf"
 	"github.com/containerd/containerd/sandbox"
-	"github.com/sirupsen/logrus"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 // CRIService interface contains things required by controller, but not yet refactored from criService.
@@ -86,11 +86,8 @@ func New(
 
 var _ sandbox.Controller = (*Controller)(nil)
 
-func (c *Controller) Platform(_ctx context.Context, _sandboxID string) (*types.Platform, error) {
-	return &types.Platform{
-		OS:           goruntime.GOOS,
-		Architecture: goruntime.GOARCH,
-	}, nil
+func (c *Controller) Platform(_ctx context.Context, _sandboxID string) (platforms.Platform, error) {
+	return platforms.DefaultSpec(), nil
 }
 
 func (c *Controller) Wait(ctx context.Context, sandboxID string) (*api.ControllerWaitResponse, error) {

--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -114,13 +114,17 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/containerd/containerd/errdefs"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/errdefs"
 )
 
 var (
 	specifierRe = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
 )
+
+// Platform is a type alias for convenience, so there is no need to import image-spec package everywhere.
+type Platform = specs.Platform
 
 // Matcher matches platforms specifications, provided by an image or runtime.
 type Matcher interface {

--- a/sandbox/controller.go
+++ b/sandbox/controller.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	"github.com/containerd/containerd/api/services/sandbox/v1"
-	"github.com/containerd/containerd/api/types"
+	"github.com/containerd/containerd/platforms"
 )
 
 // Controller is an interface to manage sandboxes at runtime.
@@ -33,7 +33,7 @@ type Controller interface {
 	Start(ctx context.Context, sandboxID string) (*sandbox.ControllerStartResponse, error)
 	// Platform returns target sandbox OS that will be used by Controller.
 	// containerd will rely on this to generate proper OCI spec.
-	Platform(_ctx context.Context, _sandboxID string) (*types.Platform, error)
+	Platform(_ctx context.Context, _sandboxID string) (platforms.Platform, error)
 	// Stop will stop sandbox instance
 	Stop(ctx context.Context, sandboxID string) (*sandbox.ControllerStopResponse, error)
 	// Wait blocks until sandbox process exits.

--- a/sandbox/proxy/controller.go
+++ b/sandbox/proxy/controller.go
@@ -20,8 +20,8 @@ import (
 	"context"
 
 	api "github.com/containerd/containerd/api/services/sandbox/v1"
-	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/platforms"
 	sb "github.com/containerd/containerd/sandbox"
 )
 
@@ -55,13 +55,18 @@ func (s *remoteSandboxController) Start(ctx context.Context, sandboxID string) (
 	return resp, nil
 }
 
-func (s *remoteSandboxController) Platform(ctx context.Context, sandboxID string) (*types.Platform, error) {
+func (s *remoteSandboxController) Platform(ctx context.Context, sandboxID string) (platforms.Platform, error) {
 	resp, err := s.client.Platform(ctx, &api.ControllerPlatformRequest{SandboxID: sandboxID})
 	if err != nil {
-		return nil, errdefs.FromGRPC(err)
+		return platforms.Platform{}, errdefs.FromGRPC(err)
 	}
 
-	return resp.GetPlatform(), nil
+	platform := resp.GetPlatform()
+	return platforms.Platform{
+		Architecture: platform.GetArchitecture(),
+		OS:           platform.GetOS(),
+		Variant:      platform.GetVariant(),
+	}, nil
 }
 
 func (s *remoteSandboxController) Stop(ctx context.Context, sandboxID string) (*api.ControllerStopResponse, error) {


### PR DESCRIPTION
Follow up for https://github.com/containerd/containerd/pull/7928
We should expose Go types in interfaces instead of using generated API.
This PR replaces `types.Platform` with specs `Platform`.

I will follow up with `Controller` changes separately.

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>