### PR TITLE
use local variable for rt when iterating collectors

### DIFF
--- a/metadata/gc.go
+++ b/metadata/gc.go
@@ -141,6 +141,7 @@ func startGCContext(ctx context.Context, collectors map[gc.ResourceType]Collecto
 	if len(collectors) > 0 {
 		contexts = map[gc.ResourceType]CollectionContext{}
 		for rt, collector := range collectors {
+			rt := rt
 			c, err := collector.StartCollection(ctx)
 			if err != nil {
 				// Only skipping this resource this round


### PR DESCRIPTION
Use local variable for rt when iterating collectors

When iterating collectors, rt should be stored in a local variable. Otherwise `gcnode` could contain random types.

In the sample debugging output below, the rt value should be 11 in my case, but it has value 8 instead, which is the stream resource.

```
time="2023-01-13T21:28:06.129285403Z" level=debug msg="[GC] key: containerd.io/gc.ref.network, ks: containerd.io/gc.ref.network.cni-loopback/lo, vs: default/cni-loopback/8ddd3dce5cb55a7e32c27d2b69878c3fd9b946bdc73749a081621bf91e47b90f/lo, rt: 8"
```

Signed-off-by: Henry Wang <henwang@amazon.com>