### PR TITLE
pushWriter: correctly propagate errors

### DIFF
--- a/remotes/docker/pusher.go
+++ b/remotes/docker/pusher.go
@@ -380,17 +380,24 @@ func (pw *pushWriter) Write(p []byte) (n int, err error) {
 
 			// If content has already been written, the bytes
 			// cannot be written and the caller must reset
-			if status.Offset > 0 {
-				status.Offset = 0
-				status.UpdatedAt = time.Now()
-				pw.tracker.SetStatus(pw.ref, status)
-				return 0, content.ErrReset
-			}
+			status.Offset = 0
+			status.UpdatedAt = time.Now()
+			pw.tracker.SetStatus(pw.ref, status)
+			return 0, content.ErrReset
 		default:
 		}
 	}
 
 	n, err = pw.pipe.Write(p)
+	if errors.Is(err, io.ErrClosedPipe) {
+		// if the pipe is closed, we might have the original error on the error
+		// channel - so we should try and get it
+		select {
+		case err2 := <-pw.errC:
+			err = err2
+		default:
+		}
+	}
 	status.Offset += int64(n)
 	status.UpdatedAt = time.Now()
 	pw.tracker.SetStatus(pw.ref, status)
@@ -431,7 +438,7 @@ func (pw *pushWriter) Digest() digest.Digest {
 
 func (pw *pushWriter) Commit(ctx context.Context, size int64, expected digest.Digest, opts ...content.Opt) error {
 	// Check whether read has already thrown an error
-	if _, err := pw.pipe.Write([]byte{}); err != nil && err != io.ErrClosedPipe {
+	if _, err := pw.pipe.Write([]byte{}); err != nil && !errors.Is(err, io.ErrClosedPipe) {
 		return fmt.Errorf("pipe error before commit: %w", err)
 	}
 
@@ -442,9 +449,7 @@ func (pw *pushWriter) Commit(ctx context.Context, size int64, expected digest.Di
 	var resp *http.Response
 	select {
 	case err := <-pw.errC:
-		if err != nil {
-			return err
-		}
+		return err
 	case resp = <-pw.respC:
 		defer resp.Body.Close()
 	case p, ok := <-pw.pipeC:
@@ -456,18 +461,17 @@ func (pw *pushWriter) Commit(ctx context.Context, size int64, expected digest.Di
 		}
 		pw.pipe.CloseWithError(content.ErrReset)
 		pw.pipe = p
+
+		// If content has already been written, the bytes
+		// cannot be written again and the caller must reset
 		status, err := pw.tracker.GetStatus(pw.ref)
 		if err != nil {
 			return err
 		}
-		// If content has already been written, the bytes
-		// cannot be written again and the caller must reset
-		if status.Offset > 0 {
-			status.Offset = 0
-			status.UpdatedAt = time.Now()
-			pw.tracker.SetStatus(pw.ref, status)
-			return content.ErrReset
-		}
+		status.Offset = 0
+		status.UpdatedAt = time.Now()
+		pw.tracker.SetStatus(pw.ref, status)
+		return content.ErrReset
 	}
 
 	// 201 is specified return status, some registries return


### PR DESCRIPTION
:bug: Fixes https://github.com/containerd/containerd/issues/7972

In the refactor from #6995, the error handling was substantially reworked, and changed the types of errors returned - this caused issues in retry logic downstream in BuildKit (see https://github.com/docker/build-push-action/issues/761). BuildKit uses this error result from this function [to determine whether to retry the push or not](https://github.com/jedevc/buildkit/blob/40bc1b316f6ce2be69ed522dc6d531ef1d3323e8/util/resolver/retryhandler/retry.go#L54-L76).

Notably, in the case of a network error, instead of propagating the error through to return from `pushWriter.Write` (as previously), it would be propagated through to `pushWriter.Commit` - however, this is too late, since we've already closed the `io.Pipe` by the time we would have reached this function. Therefore, we get the generic error message `"io: read/write on closed pipe"` for *every network error* - this seems to be the issue in https://github.com/containerd/containerd/issues/7972, likely there is some other underlying network error, but it is not shown.

This patch corrects this behavior to ensure that the correct error object is always returned as early as possible:

1. Track the corresponding `io.PipeReader` for the `pushWriter` -- on any error, we `CloseWithError` the `Reader`, to ensure that the next `Write` or `Commit` to the `Writer` returns the desired error. This applies for both network errors from `request.doWithRetries`, as well as for the `ErrReset`s.
2. Remove the error channel - we don't need this any more, errors are instead clearly tracked through the `CloseWithError` function.
3. Always reset the content, even if the offset is already 0. The previous patch could fallthrough out of the switch statement, and attempt to access a nil response object.

I've also slightly refactored the test to work with the new symbols, and to explicitly test with the commit function, since it took me a while to manually verify that I hadn't broken the logic of the test.

---

Finally, I've verified that this fix works with BuildKit:

- The BuildKit vendoring commit: https://github.com/moby/buildkit/compare/master...jedevc:buildkit:containerd-fix-push-error-propogate (using the commit cherry-picked to v1.6.15, which is what BuildKit uses)
- The green CI run! https://github.com/jedevc/buildkit-actions-testing/actions/runs/3987862482/jobs/6838242268  - Compare this to the previous flaky CI runs https://github.com/jedevc/buildkit-actions-testing/actions/runs/3985045036

---

I'm not 100% confident in this code, so hopefully some experienced maintainers can weigh in :heart:. I think while the changes are complex and difficult to verify, I think they do need to be cherry-picked across since the previous changes break heavily on the v1.6 branch