### PR TITLE
[release/1.6 backport] release/Dockerfile: set DEBIAN_FRONTEND=noninteractive

### DIFF
--- a/.github/workflows/release/Dockerfile
+++ b/.github/workflows/release/Dockerfile
@@ -23,6 +23,7 @@ FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.1.0@sha256:76a8510b1798f66fcc87e7
 FROM --platform=$BUILDPLATFORM ${BASE_IMAGE} AS base
 COPY --from=xx / /
 SHELL ["/bin/bash", "-xec"]
+ENV DEBIAN_FRONTEND=noninteractive
 RUN	apt-get update && \
 	apt-get install -y dpkg-dev git make pkg-config
 ARG TARGETPLATFORM


### PR DESCRIPTION
- backport of https://github.com/containerd/containerd/pull/7969


A build was hanging with `UBUNTU_VERSION=20.04`
```
...
 => [base 3/5] RUN APT-GET update &&  apt-get install -y dpkg-dev git make pkg-config                                                                            73.2s
 => => # questions will narrow this down by presenting a list of cities, representing
 => => # the time zones in which they are located.
 => => #   1. Africa      4. Australia  7. Atlantic  10. Pacific  13. Etc
 => => #   2. America     5. Arctic     8. Europe    11. SystemV
 => => #   3. Antarctica  6. Asia       9. Indian    12. US
 => => # Geographic area:
...

```

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
(cherry picked from commit d1e1a164604ef900a067d9b293b791d5e0daf75f)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>