### PR TITLE
pkg/cri: optimize slice initialization

### DIFF
--- a/pkg/cri/sbserver/helpers.go
+++ b/pkg/cri/sbserver/helpers.go
@@ -478,7 +478,7 @@ func copyResourcesToStatus(spec *runtimespec.Spec, status containerstore.Status)
 		}
 
 		if spec.Linux.Resources.HugepageLimits != nil {
-			hugepageLimits := make([]*runtime.HugepageLimit, 0)
+			hugepageLimits := make([]*runtime.HugepageLimit, 0, len(spec.Linux.Resources.HugepageLimits))
 			for _, l := range spec.Linux.Resources.HugepageLimits {
 				hugepageLimits = append(hugepageLimits, &runtime.HugepageLimit{
 					PageSize: l.Pagesize,

--- a/pkg/cri/server/helpers.go
+++ b/pkg/cri/server/helpers.go
@@ -476,7 +476,7 @@ func copyResourcesToStatus(spec *runtimespec.Spec, status containerstore.Status)
 		}
 
 		if spec.Linux.Resources.HugepageLimits != nil {
-			hugepageLimits := make([]*runtime.HugepageLimit, 0)
+			hugepageLimits := make([]*runtime.HugepageLimit, 0, len(spec.Linux.Resources.HugepageLimits))
 			for _, l := range spec.Linux.Resources.HugepageLimits {
 				hugepageLimits = append(hugepageLimits, &runtime.HugepageLimit{
 					PageSize: l.Pagesize,

--- a/pkg/cri/store/container/status.go
+++ b/pkg/cri/store/container/status.go
@@ -219,7 +219,7 @@ func deepCopyOf(s Status) Status {
 	}
 	copy.Resources = &runtime.ContainerResources{}
 	if s.Resources != nil && s.Resources.Linux != nil {
-		hugepageLimits := make([]*runtime.HugepageLimit, 0)
+		hugepageLimits := make([]*runtime.HugepageLimit, 0, len(s.Resources.Linux.HugepageLimits))
 		for _, l := range s.Resources.Linux.HugepageLimits {
 			if l != nil {
 				hugepageLimits = append(hugepageLimits, &runtime.HugepageLimit{


### PR DESCRIPTION
- relates to https://github.com/containerd/containerd/pull/7661/files#r1085825940

Some of this code was originally added in b7b1200dd3716c88312f6ce8fafdb2c2881edb29, which likely meant to initialize the slice with a length to reduce allocations, however, instead of initializing with a zero-length and a capacity, it initialized the slice with a fixed length, which was corrected in commit 0c63c42f8183d13c2c106c01f5bb3560d39b3295.

This patch initializes the slice with a zero-length and expected capacity.
