### PR TITLE
[release/1.6 backport] Fix slice append error

### DIFF
--- a/pkg/cri/server/helpers.go
+++ b/pkg/cri/server/helpers.go
@@ -470,7 +470,7 @@ func copyResourcesToStatus(spec *runtimespec.Spec, status containerstore.Status)
 		}
 
 		if spec.Linux.Resources.HugepageLimits != nil {
-			hugepageLimits := make([]*runtime.HugepageLimit, 0)
+			hugepageLimits := make([]*runtime.HugepageLimit, 0, len(spec.Linux.Resources.HugepageLimits))
 			for _, l := range spec.Linux.Resources.HugepageLimits {
 				hugepageLimits = append(hugepageLimits, &runtime.HugepageLimit{
 					PageSize: l.Pagesize,

--- a/pkg/cri/server/helpers.go
+++ b/pkg/cri/server/helpers.go
@@ -470,7 +470,7 @@ func copyResourcesToStatus(spec *runtimespec.Spec, status containerstore.Status)
 		}
 
 		if spec.Linux.Resources.HugepageLimits != nil {
-			hugepageLimits := make([]*runtime.HugepageLimit, len(spec.Linux.Resources.HugepageLimits))
+			hugepageLimits := make([]*runtime.HugepageLimit, 0)
 			for _, l := range spec.Linux.Resources.HugepageLimits {
 				hugepageLimits = append(hugepageLimits, &runtime.HugepageLimit{
 					PageSize: l.Pagesize,

--- a/pkg/cri/store/container/status.go
+++ b/pkg/cri/store/container/status.go
@@ -220,7 +220,7 @@ func deepCopyOf(s Status) Status {
 	}
 	copy.Resources = &runtime.ContainerResources{}
 	if s.Resources != nil && s.Resources.Linux != nil {
-		hugepageLimits := make([]*runtime.HugepageLimit, len(s.Resources.Linux.HugepageLimits))
+		hugepageLimits := make([]*runtime.HugepageLimit, 0)
 		for _, l := range s.Resources.Linux.HugepageLimits {
 			if l != nil {
 				hugepageLimits = append(hugepageLimits, &runtime.HugepageLimit{

--- a/pkg/cri/store/container/status.go
+++ b/pkg/cri/store/container/status.go
@@ -220,7 +220,7 @@ func deepCopyOf(s Status) Status {
 	}
 	copy.Resources = &runtime.ContainerResources{}
 	if s.Resources != nil && s.Resources.Linux != nil {
-		hugepageLimits := make([]*runtime.HugepageLimit, 0)
+		hugepageLimits := make([]*runtime.HugepageLimit, 0, len(s.Resources.Linux.HugepageLimits))
 		for _, l := range s.Resources.Linux.HugepageLimits {
 			if l != nil {
 				hugepageLimits = append(hugepageLimits, &runtime.HugepageLimit{


### PR DESCRIPTION
- backport of https://github.com/containerd/containerd/pull/7661
- (partial) backport of https://github.com/containerd/containerd/pull/7994 (the `sbserver` is not in the 1.6 branch)

In golang when copy a slice, if the slice is initialized with a desired length, then appending to it will cause the size double.

(cherry picked from commit 0c63c42f8183d13c2c106c01f5bb3560d39b3295)
