### PR TITLE
[release/1.6 backport] Harden GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -20,7 +20,7 @@ on:
         default: westeurope
 
 permissions:
-  packages: write
+  contents: read
 
 env:
   AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUB_ID }}
@@ -30,6 +30,8 @@ env:
 
 jobs:
   images:
+    permissions:
+      packages: write
     name: "Build volume test images"
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,17 @@ env:
   # Note: don't forget to update `Binaries` step, as it contains the matrix of all supported Go versions.
   GO_VERSION: '1.18.9'
 
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
 jobs:
   #
   # golangci-lint
   #
   linters:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for golangci/golangci-lint-action to fetch pull requests
     name: Linters
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,9 +10,16 @@ on:
       - main
       - 'release/**'
 
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
 jobs:
   CodeQL-Build:
 
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/analyze to upload SARIF results
     strategy:
       fail-fast: false
 

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -9,6 +9,8 @@ on:
       image:
         description: "Target image name (override)"
 
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
 
 jobs:
   mirror:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,6 +9,9 @@ on:
 env:
   GO_VERSION: '1.18.9'
 
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
 jobs:
   linux:
     name: Linux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ name: Containerd Release
 env:
   GO_VERSION: '1.18.9'
 
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
 jobs:
   check:
     name: Check Signed Tag
@@ -127,6 +130,8 @@ jobs:
 
   release:
     name: Create containerd Release
+    permissions:
+      contents: write
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     needs: [build, check]

--- a/.github/workflows/windows-periodic-trigger.yml
+++ b/.github/workflows/windows-periodic-trigger.yml
@@ -7,9 +7,16 @@ on:
   schedule:
     - cron: "0 1 * * *"
 
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
 jobs:
 
   triggerWinIntegration:
+    # NOTE: the following permissions are required by `google-github-actions/auth`:
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     if: github.repository == 'containerd/containerd'
     # NOTE(aznashwan, 11/24/21): GitHub actions do not currently support referencing
     # or evaluating any kind of variables in the `uses` clause, but this will

--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -27,6 +27,8 @@ env:
   RESOURCE_CONSUMER_TESTING_IMAGE_REF: "registry.k8s.io/e2e-test-images/resource-consumer:1.10"
   WEBSERVER_TESTING_IMAGE_REF: "registry.k8s.io/e2e-test-images/nginx:1.14-2"
 
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
 
 jobs:
   winIntegration:


### PR DESCRIPTION
- partial backport of https://github.com/containerd/containerd/pull/7599 (some files are not in the release/1.6 branch)

(cherry picked from commit a270d6e8ae1a9575d21283bafc60967f6ed40d3f)
