### PR TITLE
[release/1.6 backport] assorted test-fixes

### DIFF
--- a/integration/container_update_resources_test.go
+++ b/integration/container_update_resources_test.go
@@ -80,7 +80,7 @@ func getCgroupSwapLimitForTask(t *testing.T, task containerd.Task) uint64 {
 		if err != nil {
 			t.Fatal(err)
 		}
-		return stat.Memory.SwapLimit
+		return stat.Memory.SwapLimit + stat.Memory.UsageLimit
 	}
 	cgroup, err := cgroups.Load(cgroups.V1, cgroups.PidPath(int(task.Pid())))
 	if err != nil {
@@ -169,11 +169,6 @@ func TestUpdateContainerResources_MemorySwap(t *testing.T) {
 	expectedBaseSwap := baseSwapLimit
 	expectedIncreasedSwap := increasedSwapLimit
 
-	if cgroups.Mode() == cgroups.Unified {
-		expectedBaseSwap = baseSwapLimit - memoryLimit
-		expectedIncreasedSwap = increasedSwapLimit - memoryLimit
-	}
-
 	t.Log("Create a container with memory limit but no swap")
 	cnConfig := ContainerConfig(
 		"container",
@@ -235,9 +230,6 @@ func TestUpdateContainerResources_MemoryLimit(t *testing.T) {
 	EnsureImageExists(t, pauseImage)
 
 	expectedSwapLimit := func(memoryLimit int64) *int64 {
-		if cgroups.Mode() == cgroups.Unified {
-			memoryLimit = 0
-		}
 		return &memoryLimit
 	}
 

--- a/pkg/cri/opts/spec_linux.go
+++ b/pkg/cri/opts/spec_linux.go
@@ -409,7 +409,8 @@ var (
 	swapControllerAvailabilityOnce sync.Once
 )
 
-func swapControllerAvailable() bool {
+// SwapControllerAvailable returns true if the swap controller is available
+func SwapControllerAvailable() bool {
 	swapControllerAvailabilityOnce.Do(func() {
 		const warn = "Failed to detect the availability of the swap controller, assuming not available"
 		p := "/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes"
@@ -479,7 +480,7 @@ func WithResources(resources *runtime.LinuxContainerResources, tolerateMissingHu
 		if limit != 0 {
 			s.Linux.Resources.Memory.Limit = &limit
 			// swap/memory limit should be equal to prevent container from swapping by default
-			if swapLimit == 0 && swapControllerAvailable() {
+			if swapLimit == 0 && SwapControllerAvailable() {
 				s.Linux.Resources.Memory.Swap = &limit
 			}
 		}

--- a/pkg/cri/server/container_update_resources_linux_test.go
+++ b/pkg/cri/server/container_update_resources_linux_test.go
@@ -26,11 +26,18 @@ import (
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	criconfig "github.com/containerd/containerd/pkg/cri/config"
+	criopts "github.com/containerd/containerd/pkg/cri/opts"
 )
 
 func TestUpdateOCILinuxResource(t *testing.T) {
 	oomscoreadj := new(int)
 	*oomscoreadj = -500
+	expectedSwap := func(swap int64) *int64 {
+		if criopts.SwapControllerAvailable() {
+			return &swap
+		}
+		return nil
+	}
 	for desc, test := range map[string]struct {
 		spec      *runtimespec.Spec
 		request   *runtime.UpdateContainerResourcesRequest
@@ -72,7 +79,7 @@ func TestUpdateOCILinuxResource(t *testing.T) {
 					Resources: &runtimespec.LinuxResources{
 						Memory: &runtimespec.LinuxMemory{
 							Limit: proto.Int64(54321),
-							Swap:  proto.Int64(54321),
+							Swap:  expectedSwap(54321),
 						},
 						CPU: &runtimespec.LinuxCPU{
 							Shares: proto.Uint64(4444),
@@ -118,7 +125,7 @@ func TestUpdateOCILinuxResource(t *testing.T) {
 					Resources: &runtimespec.LinuxResources{
 						Memory: &runtimespec.LinuxMemory{
 							Limit: proto.Int64(54321),
-							Swap:  proto.Int64(54321),
+							Swap:  expectedSwap(54321),
 						},
 						CPU: &runtimespec.LinuxCPU{
 							Shares: proto.Uint64(4444),
@@ -159,7 +166,7 @@ func TestUpdateOCILinuxResource(t *testing.T) {
 					Resources: &runtimespec.LinuxResources{
 						Memory: &runtimespec.LinuxMemory{
 							Limit: proto.Int64(54321),
-							Swap:  proto.Int64(54321),
+							Swap:  expectedSwap(54321),
 						},
 						CPU: &runtimespec.LinuxCPU{
 							Shares: proto.Uint64(4444),
@@ -208,7 +215,7 @@ func TestUpdateOCILinuxResource(t *testing.T) {
 					Resources: &runtimespec.LinuxResources{
 						Memory: &runtimespec.LinuxMemory{
 							Limit: proto.Int64(54321),
-							Swap:  proto.Int64(54321),
+							Swap:  expectedSwap(54321),
 						},
 						CPU: &runtimespec.LinuxCPU{
 							Shares: proto.Uint64(4444),


### PR DESCRIPTION
backports of:

- (partial backport, as the sbserver is not in 1.6) https://github.com/containerd/containerd/pull/7946
- https://github.com/containerd/containerd/pull/7893