### PR TITLE
Move PLEG events for pause container under podsandbox package

### DIFF
--- a/pkg/cri/sbserver/podsandbox/controller.go
+++ b/pkg/cri/sbserver/podsandbox/controller.go
@@ -46,6 +46,10 @@ type CRIService interface {
 
 	// TODO: we should implement Event backoff in Controller.
 	BackOffEvent(id string, event interface{})
+
+	// TODO: refactor event generator for PLEG.
+	// GenerateAndSendContainerEvent is called by controller for sandbox container events.
+	GenerateAndSendContainerEvent(ctx context.Context, containerID string, sandboxID string, eventType runtime.ContainerEventType)
 }
 
 type Controller struct {

--- a/pkg/cri/sbserver/podsandbox/sandbox_delete.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_delete.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
 	"github.com/containerd/containerd"
 	api "github.com/containerd/containerd/api/services/sandbox/v1"
 	"github.com/containerd/containerd/errdefs"
@@ -57,6 +59,11 @@ func (c *Controller) Shutdown(ctx context.Context, sandboxID string) (*api.Contr
 			log.G(ctx).Tracef("Sandbox controller Delete called for sandbox container %q that does not exist", sandboxID)
 		}
 	}
+
+	c.sandboxStore.Delete(sandboxID)
+
+	// Send CONTAINER_DELETED event with ContainerId equal to SandboxId.
+	c.cri.GenerateAndSendContainerEvent(ctx, sandboxID, sandboxID, runtime.ContainerEventType_CONTAINER_DELETED_EVENT)
 
 	return &api.ControllerShutdownResponse{}, nil
 }

--- a/pkg/cri/sbserver/sandbox_remove.go
+++ b/pkg/cri/sbserver/sandbox_remove.go
@@ -104,9 +104,6 @@ func (c *criService) RemovePodSandbox(ctx context.Context, r *runtime.RemovePodS
 	// Release the sandbox name reserved for the sandbox.
 	c.sandboxNameIndex.ReleaseByKey(id)
 
-	// Send CONTAINER_DELETED event with ContainerId equal to SandboxId.
-	c.generateAndSendContainerEvent(ctx, id, id, runtime.ContainerEventType_CONTAINER_DELETED_EVENT)
-
 	sandboxRemoveTimer.WithValues(sandbox.RuntimeHandler).UpdateSince(start)
 
 	return &runtime.RemovePodSandboxResponse{}, nil

--- a/pkg/cri/sbserver/sandbox_run.go
+++ b/pkg/cri/sbserver/sandbox_run.go
@@ -272,11 +272,6 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		return nil, fmt.Errorf("failed to add sandbox %+v into store: %w", sandbox, err)
 	}
 
-	// Send CONTAINER_CREATED event with both ContainerId and SandboxId equal to SandboxId.
-	// Note that this has to be done after sandboxStore.Add() because we need to get
-	// SandboxStatus from the store and include it in the event.
-	c.generateAndSendContainerEvent(ctx, id, id, runtime.ContainerEventType_CONTAINER_CREATED_EVENT)
-
 	// start the monitor after adding sandbox into the store, this ensures
 	// that sandbox is in the store, when event monitor receives the TaskExit event.
 	//
@@ -299,9 +294,6 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		}
 		c.eventMonitor.backOff.enBackOff(id, e)
 	}()
-
-	// Send CONTAINER_STARTED event with ContainerId equal to SandboxId.
-	c.generateAndSendContainerEvent(ctx, id, id, runtime.ContainerEventType_CONTAINER_STARTED_EVENT)
 
 	sandboxRuntimeCreateTimer.WithValues(labels["oci_runtime_type"]).UpdateSince(runtimeStart)
 

--- a/pkg/cri/sbserver/service.go
+++ b/pkg/cri/sbserver/service.go
@@ -17,6 +17,7 @@
 package sbserver
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -204,6 +205,12 @@ func NewCRIService(config criconfig.Config, client *containerd.Client) (CRIServi
 // TODO: get rid of this.
 func (c *criService) BackOffEvent(id string, event interface{}) {
 	c.eventMonitor.backOff.enBackOff(id, event)
+}
+
+// GenerateAndSendContainerEvent is a temporary workaround to send PLEG events from podsandbopx/ controller
+// TODO: refactor PLEG event generator so both podsandbox/ controller and CRI service can access it.
+func (c *criService) GenerateAndSendContainerEvent(ctx context.Context, containerID string, sandboxID string, eventType runtime.ContainerEventType) {
+	c.generateAndSendContainerEvent(ctx, containerID, sandboxID, eventType)
 }
 
 // Register registers all required services onto a specific grpc server.


### PR DESCRIPTION
We should not generate PLEG container events for sandboxes unless its `podsandbox` containers.

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>