### PR TITLE
[release/1.5] integration/images: switch away from Docker Hub to avoid rate limit

### DIFF
--- a/integration/common.go
+++ b/integration/common.go
@@ -47,8 +47,8 @@ var (
 
 func initImages(imageListFile string) {
 	imageList = ImageList{
-		Alpine:           "docker.io/library/alpine:latest",
-		BusyBox:          "docker.io/library/busybox:latest",
+		Alpine:           "ghcr.io/containerd/alpine:3.14.0",
+		BusyBox:          "ghcr.io/containerd/busybox:1.28",
 		Pause:            "registry.k8s.io/pause:3.5",
 		ResourceConsumer: "registry.k8s.io/e2e-test-images/resource-consumer:1.9",
 		VolumeCopyUp:     "gcr.io/k8s-cri-containerd/volume-copy-up:2.0",


### PR DESCRIPTION
Backport https://github.com/containerd/containerd/pull/7888 via :cherries:-pick of https://github.com/containerd/containerd/pull/7900

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
(cherry picked from commit a5ea5935b7e65b189f893eca1e95e501a7aeb716)
Signed-off-by: Derek McGowan <derek@mcg.dev>
(cherry picked from commit 0f4062c9be0155861a1907dd1e1fe54b38c1d5ac)
Signed-off-by: Samuel Karp <samuelkarp@google.com>