### PR TITLE
runtime docs: Clarify delete cwd behavior

### DIFF
--- a/runtime/v2/README.md
+++ b/runtime/v2/README.md
@@ -67,9 +67,9 @@ The delete command MUST accept the following flags:
 * `-address` the address of the containerd's main socket
 * `-publish-binary` the binary path to publish events back to containerd
 * `-id` the id of the container
-* `-bundle` the path to the bundle to delete. On non-Windows platforms this will match `cwd`
+* `-bundle` the path to the bundle to delete. On non-Windows and non-FreeBSD platforms this will match `cwd`
 
-The delete command will be executed in the container's bundle as its `cwd` except for on the Windows platform.
+The delete command will be executed in the container's bundle as its `cwd` except for on Windows and FreeBSD platforms.
 
 ### Host Level Shim Configuration
 

--- a/runtime/v2/binary.go
+++ b/runtime/v2/binary.go
@@ -146,7 +146,7 @@ func (b *binary) Delete(ctx context.Context) (*runtime.Exit, error) {
 	log.G(ctx).Info("cleaning up dead shim")
 
 	// On Windows and FreeBSD, the current working directory of the shim should
-	// not be the bundle path during the delete operation.  Instead, we invoke
+	// not be the bundle path during the delete operation. Instead, we invoke
 	// with the default work dir and forward the bundle path on the cmdline.
 	// Windows cannot delete the current working directory while an executable
 	// is in use with it. On FreeBSD, fork/exec can fail.


### PR DESCRIPTION
Noticed the cwd behavior noted for Windows also applies to FreeBSD now.

https://github.com/containerd/containerd/blob/f82ae8a9225728969b66926a7128d1aa3040a257/runtime/v2/binary.go#L154
