### PR TITLE
fix(docs): minor fix on the windows installation steps

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -116,7 +116,7 @@ curl.exe -L https://github.com/containerd/containerd/releases/download/v$Version
 tar.exe xvf .\containerd-windows-amd64.tar.gz
 
 # Copy and configure
-Copy-Item -Path ".\bin\" -Destination "$Env:ProgramFiles\containerd" -Recurse -Force
+Copy-Item -Path ".\bin\*" -Destination "$Env:ProgramFiles\containerd" -Recurse -Force
 cd $Env:ProgramFiles\containerd\
 .\containerd.exe config default | Out-File config.toml -Encoding ascii
 


### PR DESCRIPTION
`*` was left out and therefore the `.\bin` directory is also copied over, other than only the files, while the following commands assume the files are copied to `$Env:ProgramFiles\ccontainerd`

Signed-off-by: Anthony Nandaa <profnandaa@gmail.com>