### PR TITLE
[release/1.6] Prepare v1.6.16

### DIFF
--- a/releases/v1.6.16.toml
+++ b/releases/v1.6.16.toml
@@ -1,0 +1,23 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release
+previous = "v1.6.15"
+
+pre_release = false
+
+preface = """\
+The sixteenth patch release for containerd 1.6 includes various bug fixes and updates.
+
+### Notable Updates
+
+* **Fix push error propagation** ([#7990](https://github.com/containerd/containerd/pull/7990))
+* **Fix slice append error with HugepageLimits for Linux** ([#7995](https://github.com/containerd/containerd/pull/7995))
+* **Update default seccomp profile for PKU and CAP_SYS_NICE** ([#8001](https://github.com/containerd/containerd/pull/8001))
+* **Fix overlayfs error when upperdirlabel option is set** ([#8002](https://github.com/containerd/containerd/pull/8002))
+
+See the changelog for complete list of changes"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.15+unknown"
+	Version = "1.6.16+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
generated release notes

----

containerd 1.6.16

Welcome to the v1.6.16 release of containerd!

The sixteenth patch release for containerd 1.6 includes various bug fixes and updates.

### Notable Updates

* **Fix push error propagation** ([#7990](https://github.com/containerd/containerd/pull/7990))
* **Fix slice append error with HugepageLimits for Linux** ([#7995](https://github.com/containerd/containerd/pull/7995))
* **Update default seccomp profile for PKU and CAP_SYS_NICE** ([#8001](https://github.com/containerd/containerd/pull/8001))
* **Fix overlayfs error when upperdirlabel option is set** ([#8002](https://github.com/containerd/containerd/pull/8002))

See the changelog for complete list of changes

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Akihiro Suda
* Samuel Karp
* Sebastiaan van Stijn
* Derek McGowan
* Phil Estes
* Craig Ingram
* Justin Chadwell
* Qasim Sarfraz
* Wei Fu
* bin liu
* cardy.tang
* rongfu.leng

### Changes
<details><summary>29 commits</summary>
<p>

  * [`d3c595aa3`](https://github.com/containerd/containerd/commit/d3c595aa387e2d7ad3cd08313579ec86c876f738) Prepare release notes for v1.6.16
* [release/1.6 backport] Fix tx closed error when upperdirlabel specified ([#8002](https://github.com/containerd/containerd/pull/8002))
  * [`8c704036a`](https://github.com/containerd/containerd/commit/8c704036a81b13b25ab7073e2715075b6ec39e94) Fix tx closed error when upperdirlabel specified
* [release/1.6 backport] assorted test-fixes ([#8000](https://github.com/containerd/containerd/pull/8000))
  * [`91a68edd7`](https://github.com/containerd/containerd/commit/91a68edd775bba554a9eac7e04898b22069db5aa) cri: Fix TestUpdateOCILinuxResource for host w/o swap controller
  * [`5594f706e`](https://github.com/containerd/containerd/commit/5594f706e67462c4a29f68e6958341ba35d06826) Fix TestUpdateContainerResources_Memory* on cgroup v2 hosts
* [release/1.6 backport] seccomp updates ([#8001](https://github.com/containerd/containerd/pull/8001))
  * [`7037f5313`](https://github.com/containerd/containerd/commit/7037f531304821b7b1943f2c7821d94035b54d76) seccomp: add get_mempolicy, mbind, set_mempolicy, with CAP_SYS_NICE
  * [`d22919a1c`](https://github.com/containerd/containerd/commit/d22919a1cb8180885a6f38fa7851a487aebd2440) seccomp: seccomp: add syscalls related to PKU in default policy
* [release/1.6 backport] Harden GITHUB_TOKEN permissions ([#7999](https://github.com/containerd/containerd/pull/7999))
  * [`8b8a21fe4`](https://github.com/containerd/containerd/commit/8b8a21fe4dbc7b940a802cb8d099a4084dae6ee9) Harden GITHUB_TOKEN permissions
* [release/1.6 backport] assorted updates to Vagrantfile ([#7996](https://github.com/containerd/containerd/pull/7996))
  * [`8009948bb`](https://github.com/containerd/containerd/commit/8009948bb2dee8eb2c021d8a467572927ed0657d) Vagrantfile: fix comments about SELinux
  * [`550424f92`](https://github.com/containerd/containerd/commit/550424f929d7f9ae8fd59bd520719d0d8f00f2b3) Vagrantfile: install-rootless-podman: remove `setenforce 0`
  * [`2c32f8559`](https://github.com/containerd/containerd/commit/2c32f85599ec121702329ffddd50f99dbe491370) CI: update Fedora to 37
  * [`556bb0cc8`](https://github.com/containerd/containerd/commit/556bb0cc8a01ece740d28749bcc6d76360117167) Vagrantfile: explicitly specify rsync as the shared folder driver
  * [`edfac1834`](https://github.com/containerd/containerd/commit/edfac183479d3a98147d1652b4ee198f522330a5) fix install cni script
  * [`91d5e53fb`](https://github.com/containerd/containerd/commit/91d5e53fbc3d5acfdd8ca4328cec1a20359b22f8) Vagrantfile: dump containerd log after critest
* [release/1.6 backport] Fix slice append error ([#7995](https://github.com/containerd/containerd/pull/7995))
  * [`ab193eb20`](https://github.com/containerd/containerd/commit/ab193eb20bade0c7fff74a33a3b91f2517af05c6) pkg/cri: optimize slice initialization
  * [`e6cf5ec58`](https://github.com/containerd/containerd/commit/e6cf5ec58d395332985f15084527676d70b21f1c) Fix slice append error
* [release/1.6] update to go1.18.10 ([#7992](https://github.com/containerd/containerd/pull/7992))
  * [`6a8a6531f`](https://github.com/containerd/containerd/commit/6a8a6531fd4f778089376749386c934b436484f7) [release/1.6] update to go1.18.10
* [release/1.6 backport] release/Dockerfile: set DEBIAN_FRONTEND=noninteractive ([#7991](https://github.com/containerd/containerd/pull/7991))
  * [`d0dc7988a`](https://github.com/containerd/containerd/commit/d0dc7988ab9b30be8a05fae1fc064164418e653d) release/Dockerfile: set DEBIAN_FRONTEND=noninteractive
* [release/1.6 backport] pushWriter: correctly propagate errors ([#7990](https://github.com/containerd/containerd/pull/7990))
  * [`1584c2581`](https://github.com/containerd/containerd/commit/1584c2581017414e673e4df05f63bc6b67edd424) pushWriter: correctly propagate errors
* [release/1.6] mod: update github.com/pelletier/go-toml@v1.9.5 ([#7942](https://github.com/containerd/containerd/pull/7942))
  * [`545f22091`](https://github.com/containerd/containerd/commit/545f220910082c4236a8751854c640e7f7dc3e69) mod: update github.com/pelletier/go-toml@v1.9.5
</p>
</details>

### Dependency Changes

* **github.com/pelletier/go-toml**  v1.9.3 -> v1.9.5

Previous release can be found at [v1.6.15](https://github.com/containerd/containerd/releases/tag/v1.6.15)

