### PR TITLE
[release/1.5] Prepare release notes for v1.5.17

### DIFF
--- a/releases/v1.5.17.toml
+++ b/releases/v1.5.17.toml
@@ -1,0 +1,22 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release
+previous = "v1.5.16"
+
+pre_release = false
+
+preface = """\
+The seventeenth patch release for containerd 1.5 includes various fixes and updates.
+
+### Notable Updates
+
+* **Update shim to fail fast on dial error** ([#7953](https://github.com/containerd/containerd/pull/7953))
+* **Fix no CNI info for pod sandbox on restart** ([#7849](https://github.com/containerd/containerd/pull/7849))
+* **Fix push error propagation** ([#7998](https://github.com/containerd/containerd/pull/7998))
+
+See the changelog for complete list of changes"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.5.16+unknown"
+	Version = "1.5.17+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated release notes

----

containerd 1.5.17

Welcome to the v1.5.17 release of containerd!

The seventeenth patch release for containerd 1.5 includes various fixes and updates.

### Notable Updates

* **Update shim to fail fast on dial error** ([#7953](https://github.com/containerd/containerd/pull/7953))
* **Fix no CNI info for pod sandbox on restart** ([#7849](https://github.com/containerd/containerd/pull/7849))
* **Fix push error propagation** ([#7998](https://github.com/containerd/containerd/pull/7998))

See the changelog for complete list of changes

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Derek McGowan
* Akihiro Suda
* Wei Fu
* Danny Canter
* Justin Chadwell
* Kirtana Ashok
* Phil Estes
* Samuel Karp
* Sebastiaan van Stijn

### Changes
<details><summary>13 commits</summary>
<p>

  * [`40a4d58de`](https://github.com/containerd/containerd/commit/40a4d58def141d5ed970dc9f4cf85d11bb91b67c) Prepare release notes for v1.5.17
* [release/1.5] integration/images: switch away from Docker Hub to avoid rate limit ([#8009](https://github.com/containerd/containerd/pull/8009))
  * [`d44769ad6`](https://github.com/containerd/containerd/commit/d44769ad6d7cc54595732ee145c4a69036500c6d) integration/images: switch away from Docker Hub to avoid rate limit
* [release/1.5 backport] pushWriter: correctly propagate errors ([#7998](https://github.com/containerd/containerd/pull/7998))
  * [`1e848038d`](https://github.com/containerd/containerd/commit/1e848038df0df71c5aa60cca856378ac7031d298) pushWriter: correctly propagate errors
* [release/1.5] update to go1.18.10 ([#7993](https://github.com/containerd/containerd/pull/7993))
  * [`464c2fb7a`](https://github.com/containerd/containerd/commit/464c2fb7adeb1bdac5f53d5b1bd6dd051c698c77) [release/1.5] update to go1.18.10
* [release/1.5] runtime: should fail fast if dial error on shim ([#7953](https://github.com/containerd/containerd/pull/7953))
  * [`7473711de`](https://github.com/containerd/containerd/commit/7473711debe58363d53c9fb5b4b7937ac5123712) runtime: should fail fast if dial error on shim
* [release/1.5] CRI: Fix no CNI info for pod sandbox on restart ([#7849](https://github.com/containerd/containerd/pull/7849))
  * [`23c2a863e`](https://github.com/containerd/containerd/commit/23c2a863e338c6e1ddb2bb56d1b2e35f118f5284) CRI: Fix no CNI info for pod sandbox on restart
* [release/1.5] go.mod: Bump hcsshim to v0.8.25 ([#7817](https://github.com/containerd/containerd/pull/7817))
  * [`1c5d8d142`](https://github.com/containerd/containerd/commit/1c5d8d1422c0226d4b9b0814af124bb0ef61b9aa) [release/1.5] Bump shim tag to v0.8.25
</p>
</details>

### Dependency Changes

* **github.com/Microsoft/hcsshim**  v0.8.24 -> v0.8.25

Previous release can be found at [v1.5.16](https://github.com/containerd/containerd/releases/tag/v1.5.16)

