### PR TITLE
release: Ubuntu 18.04 -> 20.04 (glibc 2.27 -> 2.31)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,19 +69,20 @@ jobs:
     strategy:
       matrix:
         include:
-          # Choose an old release of Ubuntu to avoid glibc issue https://github.com/containerd/containerd/issues/7255
-          - dockerfile-ubuntu: 18.04
+          # Ubuntu 22.04 can't be used until we drop support for binary compatibility with dynamically-linked glibc 2.17 (CentOS 7).
+          # https://github.com/containerd/containerd/issues/7255
+          # https://github.com/containerd/containerd/issues/7961
+          - dockerfile-ubuntu: 20.04
             dockerfile-platform: linux/amd64
-          - dockerfile-ubuntu: 18.04
+          - dockerfile-ubuntu: 20.04
             dockerfile-platform: linux/arm64
-          - dockerfile-ubuntu: 18.04
+          - dockerfile-ubuntu: 20.04
             dockerfile-platform: linux/ppc64le
-          - dockerfile-ubuntu: 18.04
+          - dockerfile-ubuntu: 20.04
             dockerfile-platform: linux/s390x
-          # riscv64 isn't supported by Ubuntu 18.04
-          - dockerfile-ubuntu: 22.04
+          - dockerfile-ubuntu: 20.04
             dockerfile-platform: linux/riscv64
-          - dockerfile-ubuntu: 18.04
+          - dockerfile-ubuntu: 20.04
             dockerfile-platform: windows/amd64
     steps:
       - name: Set RELEASE_VER

--- a/.github/workflows/release/Dockerfile
+++ b/.github/workflows/release/Dockerfile
@@ -12,8 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-# UBUNTU_VERSION can be set to 18.04 (bionic), 20.04 (focal), or 22.04 (jammy)
-ARG UBUNTU_VERSION=18.04
+# UBUNTU_VERSION can be set to 18.04 (bionic, DEPRECATED), 20.04 (focal), or 22.04 (jammy)
+ARG UBUNTU_VERSION=20.04
 ARG BASE_IMAGE=ubuntu:${UBUNTU_VERSION}
 ARG GO_VERSION
 ARG GO_IMAGE=golang:${GO_VERSION}

--- a/releases/v1.7.0-beta.toml
+++ b/releases/v1.7.0-beta.toml
@@ -119,7 +119,7 @@ See the changelog for complete list of changes"""
 
 postface = """\
 ### Which file should I download?
-* `containerd-<VERSION>-<OS>-<ARCH>.tar.gz`:         ✅Recommended. Dynamically linked with glibc 2.27 (Ubuntu 18.04).
+* `containerd-<VERSION>-<OS>-<ARCH>.tar.gz`:         ✅Recommended. Dynamically linked with glibc 2.31 (Ubuntu 20.04).
 * `containerd-static-<VERSION>-<OS>-<ARCH>.tar.gz`:  Statically linked. Expected to be used on non-glibc Linux distributions. Not position-independent.
 * `cri-containerd-<VERSION>-<OS>-<ARCH>.tar.gz`:     (Deprecated)
 * `cri-containerd-cni-<VERSION>-<OS>-<ARCH>.tar.gz`: (Deprecated)


### PR DESCRIPTION
Ubuntu 18.04 will reach its End of Standard Support in April 2023: https://wiki.ubuntu.com/Releases

By updating Ubuntu from 18.04 to 20.04, the dynamically-linked glibc version is bumped up from 2.27 to 2.31.
The dynamically linked containerd binary still seems to be compatible with CentOS 7 (glibc 2.17).

The runc binary in the `cri-containerd(-cni)-<VERSION>-linux-<ARCH>.tar.gz` bundle no longer works on CentOS 7, though, but this is acceptable, as the `cri-containerd(-cni)` bundle has been deprecated since containerd 1.6.

```
$ ldd /usr/local/sbin/runc
        linux-vdso.so.1 =>  (0x00007fffee9c4000)
        libpthread.so.0 => /lib64/libpthread.so.0 (0x00007eff48721000)
        libseccomp.so.2 => /lib64/libseccomp.so.2 (0x00007eff484e0000)
        libc.so.6 => /lib64/libc.so.6 (0x00007eff48112000)
        /lib64/ld-linux-x86-64.so.2 (0x00007eff492cb000)
$ /usr/local/sbin/runc
/usr/local/sbin/runc: symbol lookup error: /usr/local/sbin/runc: undefined symbol: seccomp_notify_respond
```

Fix #7961
