### PR TITLE
deflake: TestContainerPids

### DIFF
--- a/integration/client/client_unix_test.go
+++ b/integration/client/client_unix_test.go
@@ -30,7 +30,19 @@ var (
 	testImage             = images.Get(images.BusyBox)
 	testMultiLayeredImage = images.Get(images.VolumeCopyUp)
 	shortCommand          = withProcessArgs("true")
-	longCommand           = withProcessArgs("/bin/sh", "-c", "while true; do sleep 1d; done")
+	// NOTE: The TestContainerPids needs two running processes in one
+	// container. But busybox:1.36 sh shell, the `sleep` is a builtin.
+	//
+	// 	/bin/sh -c "type sleep"
+	//      sleep is a shell builtin
+	//
+	// We should use `/bin/sleep` instead of `sleep`. And busybox sh shell
+	// will execve directly instead of clone-execve if there is only one
+	// command. There will be only one process in container if we use
+	// '/bin/sh -c "/bin/sleep inf"'.
+	//
+	// So we append `&& exit 0` to force sh shell uses clone-execve.
+	longCommand = withProcessArgs("/bin/sh", "-c", "/bin/sleep inf && exit 0")
 )
 
 func TestImagePullSchema1WithEmptyLayers(t *testing.T) {

--- a/integration/client/client_unix_test.go
+++ b/integration/client/client_unix_test.go
@@ -30,7 +30,7 @@ var (
 	testImage             = images.Get(images.BusyBox)
 	testMultiLayeredImage = images.Get(images.VolumeCopyUp)
 	shortCommand          = withProcessArgs("true")
-	longCommand           = withProcessArgs("/bin/sh", "-c", "while true; do sleep 1; done")
+	longCommand           = withProcessArgs("/bin/sh", "-c", "while true; do sleep 1d; done")
 )
 
 func TestImagePullSchema1WithEmptyLayers(t *testing.T) {

--- a/integration/images/image_list.go
+++ b/integration/images/image_list.go
@@ -48,7 +48,7 @@ var initOnce sync.Once
 func initImages(imageListFile string) {
 	imageList = ImageList{
 		Alpine:           "ghcr.io/containerd/alpine:3.14.0",
-		BusyBox:          "ghcr.io/containerd/busybox:1.28",
+		BusyBox:          "ghcr.io/containerd/busybox:1.36",
 		Pause:            "registry.k8s.io/pause:3.8",
 		ResourceConsumer: "registry.k8s.io/e2e-test-images/resource-consumer:1.10",
 		VolumeCopyUp:     "ghcr.io/containerd/volume-copy-up:2.1",


### PR DESCRIPTION
It is kind of race because `sleep 1s` is short live process.

See: https://github.com/containerd/containerd/issues/7965#issuecomment-1383218025
Fixes: #7965

Signed-off-by: Wei Fu <fuweid89@gmail.com>