### PR TITLE
log/logtest: add `testcase` as debug field

### DIFF
--- a/log/logtest/context.go
+++ b/log/logtest/context.go
@@ -52,5 +52,5 @@ func WithT(ctx context.Context, t testing.TB) context.Context {
 		},
 	})
 
-	return log.WithLogger(ctx, logrus.NewEntry(l))
+	return log.WithLogger(ctx, logrus.NewEntry(l).WithField("testcase", t.Name()))
 }


### PR DESCRIPTION
It is hard to tell where the `log_hook` log comes from, when we run test parallelly. Add test name as field as debug purpose.

```
log_hook.go:47: time="2023-01-29T13:09:37.687070239+08:00" level=debug msg=fetch func=remotes.Fetch file="/home/fuwei/go/src/github.com/containerd/containerd/remotes/handlers.go:114" digest="sha256:ea362f368469f909a95f9a6e54ebe0121ce0a8e3c30583dd9c5fb35b14544dec" mediatype=application/vnd.docker.image.rootfs.diff.tar.gzip size=28566425 testcase=TestCRIImagePullTimeout/NoDataTransferred
```

REF: #8024

Signed-off-by: Wei Fu <fuweid89@gmail.com>