### PR TITLE
doc: fixed windows installation typo

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -116,7 +116,7 @@ curl.exe -L https://github.com/containerd/containerd/releases/download/v$Version
 tar.exe xvf .\containerd-windows-amd64.tar.gz
 
 # Copy and configure
-Copy-Item -Path ".\bin\" -Destination "$Env:ProgramFiles\containerd" -Recurse -Force
+Copy-Item -Path ".\bin\*" -Destination "$Env:ProgramFiles\containerd" -Recurse -Force
 cd $Env:ProgramFiles\containerd\
 .\containerd.exe config default | Out-File config.toml -Encoding ascii
 


### PR DESCRIPTION
For windows binary installation we need binaries in `$Env:ProgramFiles\containerd`, the current command adds the binaries in `$Env:ProgramFiles\containerd\bin`.