### PR TITLE
go.mod: update github.com/containerd/nri.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/containerd/go-cni v1.1.6
 	github.com/containerd/go-runc v1.0.0
 	github.com/containerd/imgcrypt v1.1.5-0.20220421044638-8ba028dca028
-	github.com/containerd/nri v0.2.0
+	github.com/containerd/nri v0.2.1-0.20230131001841-b3cabdec0657
 	github.com/containerd/ttrpc v1.1.1-0.20220420014843-944ef4a40df3
 	github.com/containerd/typeurl v1.0.3-0.20220422153119-7f6e6d160d67
 	github.com/containerd/zfs v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,8 @@ github.com/containerd/imgcrypt v1.1.5-0.20220421044638-8ba028dca028/go.mod h1:Lo
 github.com/containerd/nri v0.0.0-20201007170849-eb1350a75164/go.mod h1:+2wGSDGFYfE5+So4M5syatU0N0f0LbWpuqyMi4/BE8c=
 github.com/containerd/nri v0.0.0-20210316161719-dbaa18c31c14/go.mod h1:lmxnXF6oMkbqs39FiCt1s0R2HSMhcLel9vNL3m4AaeY=
 github.com/containerd/nri v0.1.0/go.mod h1:lmxnXF6oMkbqs39FiCt1s0R2HSMhcLel9vNL3m4AaeY=
-github.com/containerd/nri v0.2.0 h1:gSHG+SyKvWp5xJxyXbx2miR0ajssuOImr52Z2lt/GKI=
-github.com/containerd/nri v0.2.0/go.mod h1:Q2u9Sudol4IkJ6YK0gShznKMxM6Un0Y3O4Wslf5Nerg=
+github.com/containerd/nri v0.2.1-0.20230131001841-b3cabdec0657 h1:mUUkDOlFTZXCQupsMlHbQflPVxbj1sT6YOSz/hvT4wE=
+github.com/containerd/nri v0.2.1-0.20230131001841-b3cabdec0657/go.mod h1:Q2u9Sudol4IkJ6YK0gShznKMxM6Un0Y3O4Wslf5Nerg=
 github.com/containerd/stargz-snapshotter/estargz v0.4.1/go.mod h1:x7Q9dg9QYb4+ELgxmo4gBUeJB0tl5dqH1Sdz0nJU1QM=
 github.com/containerd/ttrpc v0.0.0-20190828154514-0e0f228740de/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
 github.com/containerd/ttrpc v0.0.0-20190828172938-92c8520ef9f8/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=

--- a/integration/client/go.sum
+++ b/integration/client/go.sum
@@ -518,7 +518,7 @@ github.com/containerd/go-runc v0.0.0-20201020171139-16b287bc67d0/go.mod h1:cNU0Z
 github.com/containerd/go-runc v1.0.0 h1:oU+lLv1ULm5taqgV/CJivypVODI4SUz1znWjv3nNYS0=
 github.com/containerd/go-runc v1.0.0/go.mod h1:cNU0ZbCgCQVZK4lgG3P+9tn9/PaJNmoDXPpoJhDR+Ok=
 github.com/containerd/imgcrypt v1.1.5-0.20220421044638-8ba028dca028/go.mod h1:LorQnPtzL/T0IyCeftcsMEO7AqxUDbdO8j/tSUpgxvo=
-github.com/containerd/nri v0.2.0/go.mod h1:Q2u9Sudol4IkJ6YK0gShznKMxM6Un0Y3O4Wslf5Nerg=
+github.com/containerd/nri v0.2.1-0.20230131001841-b3cabdec0657/go.mod h1:Q2u9Sudol4IkJ6YK0gShznKMxM6Un0Y3O4Wslf5Nerg=
 github.com/containerd/stargz-snapshotter/estargz v0.4.1/go.mod h1:x7Q9dg9QYb4+ELgxmo4gBUeJB0tl5dqH1Sdz0nJU1QM=
 github.com/containerd/stargz-snapshotter/estargz v0.12.1/go.mod h1:12VUuCq3qPq4y8yUW+l5w3+oXV3cx2Po3KSe/SmPGqw=
 github.com/containerd/ttrpc v1.0.2/go.mod h1:UAxOpgT9ziI0gJrmKvgcZivgxOp8iFPSk8httJEt98Y=

--- a/vendor/github.com/containerd/nri/README.md
+++ b/vendor/github.com/containerd/nri/README.md
@@ -1,4 +1,4 @@
-## Node Resource Interface, Revisited
+# Node Resource Interface, Revisited
 
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/containerd/nri)](https://pkg.go.dev/github.com/containerd/nri)
 [![Build Status](https://github.com/containerd/nri/workflows/CI/badge.svg)](https://github.com/containerd/nri/actions?query=workflow%3ACI)
@@ -7,7 +7,7 @@
 
 *This project is currently in DRAFT status*
 
-### Goal
+## Goal
 
 NRI allows plugging domain- or vendor-specific custom logic into OCI-
 compatible runtimes. This logic can make controlled changes to containers
@@ -23,7 +23,7 @@ The goal is to enable NRI support in the most commonly used OCI runtimes,
 [containerd](https://github.com/containerd/containerd) and
 [CRI-O](https://github.com/cri-o/cri-o).
 
-### Background
+## Background
 
 The revisited API is a major rewrite of NRI. It changes the scope of NRI
 and how it gets integrated into runtimes. It reworks how plugins are
@@ -43,7 +43,7 @@ JSON requests and responses NRI is defined as a formal, protobuf-based
 result in improved communication efficiency with lower per-message overhead,
 and enable straightforward implementation of stateful NRI plugins.
 
-### Components
+## Components
 
 The NRI implementation consists of a number of components. The core of
 these are essential for implementing working end-to-end NRI support in
@@ -62,7 +62,7 @@ implement useful functionality in real world scenarios. [A few](plugins/differ)
 serve as practical examples of how the stub library can be used to implement
 NRI plugins.
 
-### Protocol, Plugin API
+## Protocol, Plugin API
 
 The core of NRI is defined by a protobuf [protocol definition](pkg/api/api.proto)
 of the low-level plugin API. The API defines two services, Runtime and Plugin.
@@ -83,7 +83,7 @@ provides functions for
   - hooking the plugin into pod/container lifecycle events
   - shutting down the plugin
 
-#### Plugin Registration
+### Plugin Registration
 
 Before a plugin can start receiving and processing container events, it needs
 to register itself with NRI. During registration the plugin and NRI perform a
@@ -114,7 +114,7 @@ Once the handshake sequence is over and the plugin has registered with NRI,
 it will start receiving pod and container lifecycle events according to its
 subscription.
 
-#### Pod Data and Available Lifecycle Events
+### Pod Data and Available Lifecycle Events
 
 <details>
 <summary>NRI Pod Lifecycle Events</summary>
@@ -140,7 +140,7 @@ The following pieces of pod metadata are available to plugins in NRI:
   - cgroup parent directory
   - runtime handler name
 
-#### Container Data and Available Lifecycle Events
+### Container Data and Available Lifecycle Events
 
 <details>
 <summary>NRI Container Lifecycle Events</summary>
@@ -203,7 +203,7 @@ The following pieces of container metadata are available to plugins in NRI:
 Apart from data identifying the container, these pieces of information
 represent the corresponding data in the container's OCI Spec.
 
-#### Container Adjustment
+### Container Adjustment
 
 During container creation plugins can request changes to the following
 container parameters:
@@ -236,7 +236,7 @@ container parameters:
       - Block I/O class
       - RDT class
 
-#### Container Updates
+### Container Updates
 
 Once a container has been created plugins can request updates to them.
 These updates can be requested in response to another containers creation
@@ -268,7 +268,7 @@ can be updated this way:
     - RDT class
 
 
-### Runtime Adaptation
+## Runtime Adaptation
 
 The NRI [runtime adaptation](pkg/adaptation) package is the interface
 runtimes use to integrate to NRI and interact with NRI plugins. It
@@ -283,7 +283,7 @@ into a single one. While combining responses, the package detects any
 unintentional conflicting changes made by multiple plugins to a single
 container and flags such an event as an error to the runtime.
 
-### Wrapped OCI Spec Generator
+## Wrapped OCI Spec Generator
 
 The [OCI Spec generator](pkg/runtime-tools/generate) package wraps the
 [corresponding package](https://github.com/opencontainers/runtime-tools/tree/master/generate)
@@ -291,7 +291,7 @@ and adds functions for applying NRI container adjustments and updates to
 OCI Specs. This package can be used by runtime NRI integration code to
 apply NRI responses to containers.
 
-### Plugin Stub Library
+## Plugin Stub Library
 
 The plugin stub hides many of the low-level details of implementing an NRI
 plugin. It takes care of connection establishment, plugin registration,
@@ -299,7 +299,7 @@ configuration, and event subscription. All [sample plugins](pkg/plugins)
 are implemented using the stub. Any of these can be used as a tutorial on
 how the stub library should be used.
 
-### Sample Plugins
+## Sample Plugins
 
 The following sample plugins exist for NRI:
 
@@ -311,3 +311,14 @@ The following sample plugins exist for NRI:
 
 Please see the documentation of these plugins for further details
 about what and how each of these plugins can be used for.
+
+## Project details
+
+nri is a containerd sub-project, licensed under the [Apache 2.0 license](./LICENSE).
+As a containerd sub-project, you will find the:
+
+ * [Project governance](https://github.com/containerd/project/blob/main/GOVERNANCE.md),
+ * [Maintainers](https://github.com/containerd/project/blob/main/MAINTAINERS),
+ * and [Contributing guidelines](https://github.com/containerd/project/blob/main/CONTRIBUTING.md)
+
+information in our [`containerd/project`](https://github.com/containerd/project) repository.

--- a/vendor/github.com/containerd/nri/pkg/adaptation/adaptation.go
+++ b/vendor/github.com/containerd/nri/pkg/adaptation/adaptation.go
@@ -109,6 +109,13 @@ func WithSocketPath(path string) Option {
 func New(name, version string, syncFn SyncFn, updateFn UpdateFn, opts ...Option) (*Adaptation, error) {
 	var err error
 
+	if syncFn == nil {
+		return nil, fmt.Errorf("failed to create NRI adaptation, nil SyncFn")
+	}
+	if updateFn == nil {
+		return nil, fmt.Errorf("failed to create NRI adaptation, nil UpdateFn")
+	}
+
 	r := &Adaptation{
 		name:       name,
 		version:    version,
@@ -328,7 +335,7 @@ func (r *Adaptation) startPlugins() (retErr error) {
 
 		id := ids[i]
 
-		p, err := newLaunchedPlugin(r.pluginPath, id, name, configs[i])
+		p, err := r.newLaunchedPlugin(r.pluginPath, id, name, configs[i])
 		if err != nil {
 			return fmt.Errorf("failed to start NRI plugin %q: %w", name, err)
 		}
@@ -408,7 +415,7 @@ func (r *Adaptation) acceptPluginConnections(l net.Listener) error {
 				return
 			}
 
-			p, err := newExternalPlugin(conn)
+			p, err := r.newExternalPlugin(conn)
 			if err != nil {
 				log.Errorf(ctx, "failed to create external plugin: %v", err)
 				continue

--- a/vendor/github.com/containerd/nri/pkg/adaptation/plugin_linux.go
+++ b/vendor/github.com/containerd/nri/pkg/adaptation/plugin_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/vendor/github.com/containerd/nri/pkg/adaptation/plugin_other.go
+++ b/vendor/github.com/containerd/nri/pkg/adaptation/plugin_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 /*
    Copyright The containerd Authors.

--- a/vendor/github.com/containerd/nri/pkg/net/socketpair_unix.go
+++ b/vendor/github.com/containerd/nri/pkg/net/socketpair_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/vendor/github.com/containerd/nri/pkg/net/socketpair_windows.go
+++ b/vendor/github.com/containerd/nri/pkg/net/socketpair_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
    Copyright The containerd Authors.

--- a/vendor/github.com/containerd/nri/pkg/runtime-tools/generate/helpers_linux.go
+++ b/vendor/github.com/containerd/nri/pkg/runtime-tools/generate/helpers_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/vendor/github.com/containerd/nri/pkg/runtime-tools/generate/helpers_other.go
+++ b/vendor/github.com/containerd/nri/pkg/runtime-tools/generate/helpers_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 /*
    Copyright The containerd Authors.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -125,7 +125,7 @@ github.com/containerd/go-runc
 ## explicit; go 1.16
 github.com/containerd/imgcrypt
 github.com/containerd/imgcrypt/images/encryption
-# github.com/containerd/nri v0.2.0
+# github.com/containerd/nri v0.2.1-0.20230131001841-b3cabdec0657
 ## explicit; go 1.18
 github.com/containerd/nri
 github.com/containerd/nri/pkg/adaptation


### PR DESCRIPTION
Pull in NRI [commit b3cabdec0657](https://github.com/containerd/nri/commit/b3cabdec06578b193da387b1bee4fd23aea8808e) to fix a recently discovered panic/crash.