### PR TITLE
Make argument validation of `mount.UnmountRecursive` compatible to `mount.UnmountAll`

### DIFF
--- a/mount/mount_unix.go
+++ b/mount/mount_unix.go
@@ -27,6 +27,9 @@ import (
 // UnmountRecursive unmounts the target and all mounts underneath, starting
 // with the deepest mount first.
 func UnmountRecursive(target string, flags int) error {
+	if target == "" {
+		return nil
+	}
 	mounts, err := mountinfo.GetMounts(mountinfo.PrefixFilter(target))
 	if err != nil {
 		return err


### PR DESCRIPTION
This commit fixes the cleanup failure of containers with custom location of rootfs.

Recently `mount.UnmountAll` invocations have been relaced by [`mount.UnmountRecursive`](https://github.com/containerd/containerd/blob/e307f87971391efb47eef4487e93be4cfd36fe85/mount/mount_unix.go#L29). When `""`(empty path) is passed to `mount.UnmountAll`, it simply ignores that path and returns immediately without error. However, `mount.UnmountRecursive` accepts such argument and try to perform unmounting on the root directory. Containers with custom rootfs location cause invocations of `mount.UnmountRecursive` with `""`. https://github.com/containerd/containerd/blob/e307f87971391efb47eef4487e93be4cfd36fe85/pkg/process/init.go#L310
It results in cleanup failure of containers and unmounting of mountpoints under `"/"` (if shim process has privilege). This commit tries to fix this issue by fixing `mount.UnmountRecursive` to return immediately when `""` (empty path) is passed. IIUC this is the same behaviour with `mount.UnmountAll`.

Reproducer:
NOTE: the following can result in unmounting of mountpoints on the host so should run in the sandboxed environemnt.

```
ctr i pull ghcr.io/containerd/busybox:1.36
mkdir -p /tmp/rootfs
ctr i mount --rw ghcr.io/containerd/busybox:1.36 /tmp/rootfs
ctr run --rootfs /tmp/rootfs foo /bin/echo hello
```

Then it hangs after "hello" is printed and mountpoints under `"/"` will be unmounted.

```
# ctr version
Client:
  Version:  v1.7.0-beta.3-29-ge307f8797
  Revision: e307f87971391efb47eef4487e93be4cfd36fe85
  Go version: go1.19.2

Server:
  Version:  v1.7.0-beta.3-29-ge307f8797
  Revision: e307f87971391efb47eef4487e93be4cfd36fe85
  UUID: e324e475-8abf-495e-bfb4-0197add33abc
```
