### PR TITLE
pkg/cri/config: fix Mirrors deprecation comment

### DIFF
--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -206,7 +206,7 @@ type Registry struct {
 	ConfigPath string `toml:"config_path" json:"configPath"`
 	// Mirrors are namespace to mirror mapping for all namespaces.
 	// This option will not be used when ConfigPath is provided.
-	// DEPRECATED: Use ConfigPath instead. Remove in containerd 1.7.
+	// DEPRECATED: Use ConfigPath instead. Remove in containerd 2.0.
 	Mirrors map[string]Mirror `toml:"mirrors" json:"mirrors"`
 	// Configs are configs for each registry.
 	// The key is the domain name or IP of the registry.


### PR DESCRIPTION
The config registry mirror is still in version 1.7 and may plan to delete at 2.0

”Removal of this and other deprecations are not immediate. Yes, we've been considering removing all v1 deprecations when we move to v2, yes perhaps EOY perhaps sometime next year. We've been discussing the possibility of providing migration tooling for config and metadata. It is just as likely we will attempt to carry v1 and early v2 release versions of certain services (esp. CRI) at the same time to allow for opt in testing. The hosts.toml config is very similar to docker hosts.toml, if that helps.
"
from the https://github.com/kubernetes/kubernetes/issues/110312#issuecomment-1146040643_ 
And https://github.com/containerd/containerd/blame/main/docs/cri/registry.md#L14 is also showd " remove in containerd 2.0"

The comments may mislead the developers, such as  [kubespray](https://github.com/kubernetes-sigs/kubespray/pull/9743), so fix it.

If the PR is wrong, please comment on it, thank you very much.

Signed-off-by: Kay Yan [kay.yan@daocloud.io](mailto:kay.yan@daocloud.io)
