### PR TITLE
Send container events with nil PodSandboxStatus

### DIFF
--- a/pkg/cri/sbserver/events.go
+++ b/pkg/cri/sbserver/events.go
@@ -434,8 +434,6 @@ func handleSandboxExit(ctx context.Context, e *eventtypes.TaskExit, sb sandboxst
 				}
 				// Move on to make sure container status is updated.
 			}
-
-			c.generateAndSendContainerEvent(ctx, sb.ID, sb.ID, runtime.ContainerEventType_CONTAINER_STOPPED_EVENT)
 		}
 	}
 
@@ -449,7 +447,7 @@ func handleSandboxExit(ctx context.Context, e *eventtypes.TaskExit, sb sandboxst
 
 	// Using channel to propagate the information of sandbox stop
 	sb.Stop()
-
+	c.generateAndSendContainerEvent(ctx, sb.ID, sb.ID, runtime.ContainerEventType_CONTAINER_STOPPED_EVENT)
 	return nil
 }
 

--- a/pkg/cri/sbserver/helpers.go
+++ b/pkg/cri/sbserver/helpers.go
@@ -525,10 +525,8 @@ func copyResourcesToStatus(spec *runtimespec.Spec, status containerstore.Status)
 func (c *criService) generateAndSendContainerEvent(ctx context.Context, containerID string, sandboxID string, eventType runtime.ContainerEventType) {
 	podSandboxStatus, err := c.getPodSandboxStatus(ctx, sandboxID)
 	if err != nil {
-		// TODO(https://github.com/containerd/containerd/issues/7785):
-		// Do not skip events with nil PodSandboxStatus.
-		logrus.Errorf("Failed to get podSandbox status for container event for sandboxID %q: %v. Skipping sending the event.", sandboxID, err)
-		return
+		logrus.Warnf("Failed to get podSandbox status for container event for sandboxID %q: %v. Sending the event with nil podSandboxStatus.", sandboxID, err)
+		podSandboxStatus = nil
 	}
 	containerStatuses, err := c.getContainerStatuses(ctx, sandboxID)
 	if err != nil {

--- a/pkg/cri/sbserver/podsandbox/sandbox_delete.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_delete.go
@@ -59,10 +59,10 @@ func (c *Controller) Shutdown(ctx context.Context, sandboxID string) error {
 		}
 	}
 
-	c.sandboxStore.Delete(sandboxID)
-
 	// Send CONTAINER_DELETED event with ContainerId equal to SandboxId.
 	c.cri.GenerateAndSendContainerEvent(ctx, sandboxID, sandboxID, runtime.ContainerEventType_CONTAINER_DELETED_EVENT)
+
+	c.sandboxStore.Delete(sandboxID)
 
 	return nil
 }

--- a/pkg/cri/sbserver/podsandbox/sandbox_run.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_run.go
@@ -159,11 +159,6 @@ func (c *Controller) Start(ctx context.Context, id string) (cin sandbox.Controll
 		}
 	}()
 
-	// Send CONTAINER_CREATED event with both ContainerId and SandboxId equal to SandboxId.
-	// Note that this has to be done after sandboxStore.Add() because we need to get
-	// SandboxStatus from the store and include it in the event.
-	c.cri.GenerateAndSendContainerEvent(ctx, id, id, runtime.ContainerEventType_CONTAINER_CREATED_EVENT)
-
 	// Create sandbox container root directories.
 	sandboxRootDir := c.getSandboxRootDir(id)
 	if err := c.os.MkdirAll(sandboxRootDir, 0755); err != nil {
@@ -263,9 +258,6 @@ func (c *Controller) Start(ctx context.Context, id string) (cin sandbox.Controll
 	if err := task.Start(ctx); err != nil {
 		return cin, fmt.Errorf("failed to start sandbox container task %q: %w", id, err)
 	}
-
-	// Send CONTAINER_STARTED event with ContainerId equal to SandboxId.
-	c.cri.GenerateAndSendContainerEvent(ctx, id, id, runtime.ContainerEventType_CONTAINER_STARTED_EVENT)
 
 	cin.SandboxID = id
 	cin.Pid = task.Pid()

--- a/pkg/cri/sbserver/sandbox_run.go
+++ b/pkg/cri/sbserver/sandbox_run.go
@@ -277,6 +277,11 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		return nil, fmt.Errorf("failed to add sandbox %+v into store: %w", sandbox, err)
 	}
 
+	// Send CONTAINER_CREATED event with both ContainerId and SandboxId equal to SandboxId.
+	// Note that this has to be done after sandboxStore.Add() because we need to get
+	// SandboxStatus from the store and include it in the event.
+	c.generateAndSendContainerEvent(ctx, id, id, runtime.ContainerEventType_CONTAINER_CREATED_EVENT)
+
 	// TODO: Use sandbox client instead
 	exitCh := make(chan containerd.ExitStatus, 1)
 	go func() {
@@ -299,6 +304,9 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	// TaskOOM from containerd may come before sandbox is added to store,
 	// but we don't care about sandbox TaskOOM right now, so it is fine.
 	c.eventMonitor.startSandboxExitMonitor(context.Background(), id, ctrl.Pid, exitCh)
+
+	// Send CONTAINER_STARTED event with ContainerId equal to SandboxId.
+	c.generateAndSendContainerEvent(ctx, id, id, runtime.ContainerEventType_CONTAINER_STARTED_EVENT)
 
 	sandboxRuntimeCreateTimer.WithValues(labels["oci_runtime_type"]).UpdateSince(runtimeStart)
 

--- a/pkg/cri/server/helpers.go
+++ b/pkg/cri/server/helpers.go
@@ -523,10 +523,8 @@ func copyResourcesToStatus(spec *runtimespec.Spec, status containerstore.Status)
 func (c *criService) generateAndSendContainerEvent(ctx context.Context, containerID string, sandboxID string, eventType runtime.ContainerEventType) {
 	podSandboxStatus, err := c.getPodSandboxStatus(ctx, sandboxID)
 	if err != nil {
-		// TODO(https://github.com/containerd/containerd/issues/7785):
-		// Do not skip events with nil PodSandboxStatus.
-		logrus.Errorf("Failed to get podSandbox status for container event for sandboxID %q: %v. Skipping sending the event.", sandboxID, err)
-		return
+		logrus.Warnf("Failed to get podSandbox status for container event for sandboxID %q: %v. Sending the event with nil podSandboxStatus.", sandboxID, err)
+		podSandboxStatus = nil
 	}
 	containerStatuses, err := c.getContainerStatuses(ctx, sandboxID)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: ruiwen-zhao <ruiwen@google.com>

This is a follow up action item of supporting Kubernete's Evented PLEG feature (https://github.com/kubernetes/enhancements/issues/3386). Now that https://github.com/kubernetes/kubernetes/pull/114351 merged, kubelet can handle nil PodSandboxStatus, containerd can send events with nil PodSandboxStatus.

Note that this PR also contains reverting part of https://github.com/containerd/containerd/pull/8007 (i.e. moving PLEG event generation back to sbserver) This is needed because we need the event generation to be in sbserver/ to be able to get PodSandboxStatus. More details in https://github.com/containerd/containerd/pull/8007#issuecomment-1416341393. 


fixes https://github.com/containerd/containerd/issues/7785