### PR TITLE
fix: 'go routine' should be 'goroutine'

### DIFF
--- a/pkg/cri/sbserver/sandbox_portforward_linux.go
+++ b/pkg/cri/sbserver/sandbox_portforward_linux.go
@@ -64,7 +64,7 @@ func (c *criService) portForward(ctx context.Context, id string, port int32, str
 		// golang has enabled RFC 6555 Fast Fallback (aka HappyEyeballs) by default in 1.12
 		// It means that if a host resolves to both IPv6 and IPv4, it will try to connect to any
 		// of those addresses and use the working connection.
-		// However, the implementation uses go routines to start both connections in parallel,
+		// However, the implementation uses goroutines to start both connections in parallel,
 		// and this cases that the connection is done outside the namespace, so we try to connect
 		// serially.
 		// We try IPv4 first to keep current behavior and we fallback to IPv6 if the connection fails.

--- a/pkg/cri/server/sandbox_portforward_linux.go
+++ b/pkg/cri/server/sandbox_portforward_linux.go
@@ -64,7 +64,7 @@ func (c *criService) portForward(ctx context.Context, id string, port int32, str
 		// golang has enabled RFC 6555 Fast Fallback (aka HappyEyeballs) by default in 1.12
 		// It means that if a host resolves to both IPv6 and IPv4, it will try to connect to any
 		// of those addresses and use the working connection.
-		// However, the implementation uses go routines to start both connections in parallel,
+		// However, the implementation uses goroutines to start both connections in parallel,
 		// and this cases that the connection is done outside the namespace, so we try to connect
 		// serially.
 		// We try IPv4 first to keep current behavior and we fallback to IPv6 if the connection fails.

--- a/pkg/process/init.go
+++ b/pkg/process/init.go
@@ -46,7 +46,7 @@ type Init struct {
 	initState initState
 
 	// mu is used to ensure that `Start()` and `Exited()` calls return in
-	// the right order when invoked in separate go routines.
+	// the right order when invoked in separate goroutines.
 	// This is the case within the shim implementation as it makes use of
 	// the reaper interface.
 	mu sync.Mutex


### PR DESCRIPTION
Signed-off-by: yulng [wei.yang@daocloud.io](mailto:wei.yang@daocloud.io)

Usually, go routine is represented by goroutine

Thanks