### PR TITLE
fix:dirtyCS Lack of read/write lock protection

### DIFF
--- a/metadata/content.go
+++ b/metadata/content.go
@@ -223,8 +223,9 @@ func (cs *contentStore) Delete(ctx context.Context, dgst digest.Digest) error {
 
 		// Mark content store as dirty for triggering garbage collection
 		atomic.AddUint32(&cs.db.dirty, 1)
+		cs.db.wlock.Lock()
 		cs.db.dirtyCS = true
-
+		cs.db.wlock.Unlock()
 		return nil
 	})
 }


### PR DESCRIPTION
https://github.com/containerd/containerd/blob/20de989afcd2fd4edc20e9b85312e49a8bbe152b/metadata/db.go#L99-L104
Based on the comments and the use in the program, it can be determined that inside this function, the read/write lock protection is missing.

Signed-off-by: jiuker <2818723467@qq.com>