### PR TITLE
cni: pass in the cgroupPath capability argument

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/containerd/console v1.0.3
 	github.com/containerd/continuity v0.3.0
 	github.com/containerd/fifo v1.0.0
-	github.com/containerd/go-cni v1.1.6
+	github.com/containerd/go-cni v1.1.9-0.20230211172349-6603d5bd8941
 	github.com/containerd/go-runc v1.0.0
 	github.com/containerd/imgcrypt v1.1.5-0.20220421044638-8ba028dca028
 	github.com/containerd/nri v0.2.1-0.20230131001841-b3cabdec0657

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/containerd/go-cni v1.0.1/go.mod h1:+vUpYxKvAF72G9i1WoDOiPGRtQpqsNW/ZH
 github.com/containerd/go-cni v1.0.2/go.mod h1:nrNABBHzu0ZwCug9Ije8hL2xBCYh/pjfMb1aZGrrohk=
 github.com/containerd/go-cni v1.1.0/go.mod h1:Rflh2EJ/++BA2/vY5ao3K6WJRR/bZKsX123aPk+kUtA=
 github.com/containerd/go-cni v1.1.3/go.mod h1:Rflh2EJ/++BA2/vY5ao3K6WJRR/bZKsX123aPk+kUtA=
-github.com/containerd/go-cni v1.1.6 h1:el5WPymG5nRRLQF1EfB97FWob4Tdc8INg8RZMaXWZlo=
-github.com/containerd/go-cni v1.1.6/go.mod h1:BWtoWl5ghVymxu6MBjg79W9NZrCRyHIdUtk4cauMe34=
+github.com/containerd/go-cni v1.1.9-0.20230211172349-6603d5bd8941 h1:5dA/FSSk54LtYPYcNGZfzgbmHOWYWjSjfZFGEO3SbRQ=
+github.com/containerd/go-cni v1.1.9-0.20230211172349-6603d5bd8941/go.mod h1:XYrZJ1d5W6E2VOvjffL3IZq0Dz6bsVlERHbekNK90PM=
 github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3/go.mod h1:IV7qH3hrUgRmyYrtgEeGWJfWbgcHL9CSRruz2Vqcph0=
 github.com/containerd/go-runc v0.0.0-20190911050354-e029b79d8cda/go.mod h1:IV7qH3hrUgRmyYrtgEeGWJfWbgcHL9CSRruz2Vqcph0=
 github.com/containerd/go-runc v0.0.0-20200220073739-7016d3ce2328/go.mod h1:PpyHrqVs8FTi9vpyHwPwiNEGaACDxT/N/pLcvMSRA9g=

--- a/integration/client/go.sum
+++ b/integration/client/go.sum
@@ -514,7 +514,7 @@ github.com/containerd/continuity v0.3.0/go.mod h1:wJEAIwKOm/pBZuBd0JmeTvnLquTB1A
 github.com/containerd/fifo v1.0.0 h1:6PirWBr9/L7GDamKr+XM0IeUFXu5mf3M/BPpH9gaLBU=
 github.com/containerd/fifo v1.0.0/go.mod h1:ocF/ME1SX5b1AOlWi9r677YJmCPSwwWnQ9O123vzpE4=
 github.com/containerd/go-cni v1.1.3/go.mod h1:Rflh2EJ/++BA2/vY5ao3K6WJRR/bZKsX123aPk+kUtA=
-github.com/containerd/go-cni v1.1.6/go.mod h1:BWtoWl5ghVymxu6MBjg79W9NZrCRyHIdUtk4cauMe34=
+github.com/containerd/go-cni v1.1.9-0.20230211172349-6603d5bd8941/go.mod h1:XYrZJ1d5W6E2VOvjffL3IZq0Dz6bsVlERHbekNK90PM=
 github.com/containerd/go-runc v0.0.0-20200220073739-7016d3ce2328/go.mod h1:PpyHrqVs8FTi9vpyHwPwiNEGaACDxT/N/pLcvMSRA9g=
 github.com/containerd/go-runc v0.0.0-20201020171139-16b287bc67d0/go.mod h1:cNU0ZbCgCQVZK4lgG3P+9tn9/PaJNmoDXPpoJhDR+Ok=
 github.com/containerd/go-runc v1.0.0 h1:oU+lLv1ULm5taqgV/CJivypVODI4SUz1znWjv3nNYS0=
@@ -534,7 +534,6 @@ github.com/containerd/typeurl/v2 v2.1.0 h1:yNAhJvbNEANt7ck48IlEGOxP7YAp6LLpGn5jZ
 github.com/containerd/typeurl/v2 v2.1.0/go.mod h1:IDp2JFvbwZ31H8dQbEIY7sDl2L3o3HZj1hsSQlywkQ0=
 github.com/containerd/zfs v1.0.0/go.mod h1:m+m51S1DvAP6r3FcmYCp54bQ34pyOwTieQDNRIRHsFY=
 github.com/containernetworking/cni v1.0.1/go.mod h1:AKuhXbN5EzmD4yTNtfSsX3tPcmtrBI6QcRV0NiNt15Y=
-github.com/containernetworking/cni v1.1.1/go.mod h1:sDpYKmGVENF3s6uvMvGgldDWeG8dMxakj/u+i9ht9vw=
 github.com/containernetworking/cni v1.1.2/go.mod h1:sDpYKmGVENF3s6uvMvGgldDWeG8dMxakj/u+i9ht9vw=
 github.com/containernetworking/plugins v1.2.0/go.mod h1:/VjX4uHecW5vVimFa1wkG4s+r/s9qIfPdqlLF4TW8c4=
 github.com/containers/ocicrypt v1.1.3/go.mod h1:xpdkbVAuaH3WzbEabUd5yDsl9SwJA5pABH85425Es2g=

--- a/pkg/cri/sbserver/sandbox_run.go
+++ b/pkg/cri/sbserver/sandbox_run.go
@@ -396,6 +396,10 @@ func cniNamespaceOpts(id string, config *runtime.PodSandboxConfig) ([]cni.Namesp
 		opts = append(opts, cni.WithCapabilityDNS(*dns))
 	}
 
+	if cgroup := config.GetLinux().GetCgroupParent(); cgroup != "" {
+		opts = append(opts, cni.WithCapabilityCgroupPath(cgroup))
+	}
+
 	return opts, nil
 }
 

--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -597,6 +597,10 @@ func cniNamespaceOpts(id string, config *runtime.PodSandboxConfig) ([]cni.Namesp
 		opts = append(opts, cni.WithCapabilityDNS(*dns))
 	}
 
+	if cgroup := config.GetLinux().GetCgroupParent(); cgroup != "" {
+		opts = append(opts, cni.WithCapabilityCgroupPath(cgroup))
+	}
+
 	return opts, nil
 }
 

--- a/vendor/github.com/containerd/go-cni/.golangci.yml
+++ b/vendor/github.com/containerd/go-cni/.golangci.yml
@@ -1,7 +1,5 @@
 linters:
   enable:
-    - structcheck
-    - varcheck
     - staticcheck
     - unconvert
     - gofmt

--- a/vendor/github.com/containerd/go-cni/namespace_opts.go
+++ b/vendor/github.com/containerd/go-cni/namespace_opts.go
@@ -50,6 +50,14 @@ func WithCapabilityDNS(dns DNS) NamespaceOpts {
 	}
 }
 
+// WithCapabilityCgroupPath passes in the cgroup path capability.
+func WithCapabilityCgroupPath(cgroupPath string) NamespaceOpts {
+	return func(c *Namespace) error {
+		c.capabilityArgs["cgroupPath"] = cgroupPath
+		return nil
+	}
+}
+
 // WithCapability support well-known capabilities
 // https://www.cni.dev/docs/conventions/#well-known-capabilities
 func WithCapability(name string, capability interface{}) NamespaceOpts {

--- a/vendor/github.com/containerd/go-cni/result.go
+++ b/vendor/github.com/containerd/go-cni/result.go
@@ -32,13 +32,18 @@ type IPConfig struct {
 // Result contains the network information returned by CNI.Setup
 //
 // a) Interfaces list. Depending on the plugin, this can include the sandbox
-//    (eg, container or hypervisor) interface name and/or the host interface
-//    name, the hardware addresses of each interface, and details about the
-//    sandbox (if any) the interface is in.
+//
+//	(eg, container or hypervisor) interface name and/or the host interface
+//	name, the hardware addresses of each interface, and details about the
+//	sandbox (if any) the interface is in.
+//
 // b) IP configuration assigned to each  interface. The IPv4 and/or IPv6 addresses,
-//    gateways, and routes assigned to sandbox and/or host interfaces.
+//
+//	gateways, and routes assigned to sandbox and/or host interfaces.
+//
 // c) DNS information. Dictionary that includes DNS information for nameservers,
-//     domain, search domains and options.
+//
+//	domain, search domains and options.
 type Result struct {
 	Interfaces map[string]*Config
 	DNS        []types.DNS

--- a/vendor/github.com/containerd/go-cni/testutils.go
+++ b/vendor/github.com/containerd/go-cni/testutils.go
@@ -18,14 +18,13 @@ package cni
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
 )
 
 func makeTmpDir(prefix string) (string, error) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), prefix)
+	tmpDir, err := os.MkdirTemp("", prefix)
 	if err != nil {
 		return "", err
 	}

--- a/vendor/github.com/containerd/go-cni/types.go
+++ b/vendor/github.com/containerd/go-cni/types.go
@@ -17,12 +17,9 @@
 package cni
 
 const (
-	CNIPluginName        = "cni"
-	DefaultNetDir        = "/etc/cni/net.d"
-	DefaultCNIDir        = "/opt/cni/bin"
-	DefaultMaxConfNum    = 1
-	VendorCNIDirTemplate = "%s/opt/%s/bin"
-	DefaultPrefix        = "eth"
+	CNIPluginName     = "cni"
+	DefaultMaxConfNum = 1
+	DefaultPrefix     = "eth"
 )
 
 type config struct {

--- a/vendor/github.com/containerd/go-cni/types_others.go
+++ b/vendor/github.com/containerd/go-cni/types_others.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cni
+
+const (
+	DefaultNetDir        = "/etc/cni/net.d"
+	DefaultCNIDir        = "/opt/cni/bin"
+	VendorCNIDirTemplate = "%s/opt/%s/bin"
+)

--- a/vendor/github.com/containerd/go-cni/types_windows.go
+++ b/vendor/github.com/containerd/go-cni/types_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cni
+
+const (
+	DefaultNetDir = "C:\\Program Files\\containerd\\cni\\conf"
+	DefaultCNIDir = "C:\\Program Files\\containerd\\cni\\bin"
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -115,8 +115,8 @@ github.com/containerd/continuity/testutil/loopback
 # github.com/containerd/fifo v1.0.0
 ## explicit; go 1.13
 github.com/containerd/fifo
-# github.com/containerd/go-cni v1.1.6
-## explicit; go 1.17
+# github.com/containerd/go-cni v1.1.9-0.20230211172349-6603d5bd8941
+## explicit; go 1.19
 github.com/containerd/go-cni
 # github.com/containerd/go-runc v1.0.0
 ## explicit; go 1.13


### PR DESCRIPTION
There is a new CNI capability argument, cgroupPath, where runtimes can pass cgroup paths to CNI plugins.

(see: https://github.com/containernetworking/cni/pull/936)

Implement that.

Signed-off-by: Casey Callendrello <cdc@isovalent.com>