### PR TITLE
remove logs from platforms

### DIFF
--- a/platforms/cpuinfo.go
+++ b/platforms/cpuinfo.go
@@ -17,7 +17,7 @@
 package platforms
 
 import (
-	"fmt"
+	"log"
 	"runtime"
 	"sync"
 )
@@ -34,7 +34,7 @@ func cpuVariant() string {
 			var err error
 			cpuVariantValue, err = getCPUVariant()
 			if err != nil {
-				panic(fmt.Sprintf("Error getCPUVariant for OS %s: %v", runtime.GOOS, err))
+				log.Printf("Error getCPUVariant for OS %s: %v", runtime.GOOS, err)
 			}
 		}
 	})

--- a/platforms/cpuinfo.go
+++ b/platforms/cpuinfo.go
@@ -17,10 +17,9 @@
 package platforms
 
 import (
+	"fmt"
 	"runtime"
 	"sync"
-
-	"github.com/containerd/containerd/log"
 )
 
 // Present the ARM instruction set architecture, eg: v7, v8
@@ -35,7 +34,7 @@ func cpuVariant() string {
 			var err error
 			cpuVariantValue, err = getCPUVariant()
 			if err != nil {
-				log.L.Errorf("Error getCPUVariant for OS %s: %v", runtime.GOOS, err)
+				panic(fmt.Sprintf("Error getCPUVariant for OS %s: %v", runtime.GOOS, err))
 			}
 		}
 	})


### PR DESCRIPTION
remove `github.com/containerd/containerd/log` package from the platforms package ;so the platforms package is not dependent on the containerd repository.

This will also help with the containerd API extraction that is planned. 

Ref :[[1]]( https://cloud-native.slack.com/archives/CGEQHPYF4/p1673821609964589 )

Signed-off-by: Akhil Mohan <akhilerm@gmail.com>