### PR TITLE
fetch: Use data from descriptor when available.

### DIFF
--- a/content/helpers.go
+++ b/content/helpers.go
@@ -59,6 +59,10 @@ func NewReader(ra ReaderAt) io.Reader {
 //
 // Avoid using this for large blobs, such as layers.
 func ReadBlob(ctx context.Context, provider Provider, desc ocispec.Descriptor) ([]byte, error) {
+	if int64(len(desc.Data)) == desc.Size && digest.FromBytes(desc.Data) == desc.Digest {
+		return desc.Data, nil
+	}
+
 	ra, err := provider.ReaderAt(ctx, desc)
 	if err != nil {
 		return nil, err

--- a/remotes/handlers.go
+++ b/remotes/handlers.go
@@ -17,6 +17,7 @@
 package remotes
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -137,6 +138,10 @@ func Fetch(ctx context.Context, ingester content.Ingester, fetcher Fetcher, desc
 			return fmt.Errorf("failed commit on ref %q: %w", ws.Ref, err)
 		}
 		return err
+	}
+
+	if desc.Size == int64(len(desc.Data)) {
+		return content.Copy(ctx, cw, bytes.NewReader(desc.Data), desc.Size, desc.Digest)
 	}
 
 	rc, err := fetcher.Fetch(ctx, desc)


### PR DESCRIPTION
OCI added support for a `data` field in a descriptor. This field is expected to contain the content being pointed to by the descriptor.

As an example of this see: [docker.io/tianon/true@sha256:434c266719c0dc4e936294efa36f66aed4f50a414ea495a234dce16454153478](https://explore.ggcr.dev/?image=tianon/true@sha256:434c266719c0dc4e936294efa36f66aed4f50a414ea495a234dce16454153478)

```json
{
        "config": {
                "data": "ewoJImFyY2hpdGVjdHVyZSI6ICJhbWQ2NCIsCgkiY29uZmlnIjogewoJCSJDbWQiOiBbCgkJCSIvdHJ1ZSIKCQldCgl9LAoJImNyZWF0ZWQiOiAiMjAxNC0wMS0yNVQyMzoxMTowOVoiLAoJImhpc3RvcnkiOiBbCgkJewoJCQkiY3JlYXRlZCI6ICIyMDE0LTAxLTI1VDIzOjExOjA5WiIsCgkJCSJjcmVhdGVkX2J5IjogIm5hc20gLW8gL3RydWUgaHR0cHM6Ly9naXRodWIuY29tL3RpYW5vbi9kb2NrZXJmaWxlcy9ibG9iLzRhMWRkMjM0ZmEyZTY3MWM5MjljMDk5Mjk3MDliZjMzYWZmZGM1OTcvdHJ1ZS90cnVlLmFzbSIKCQl9CgldLAoJIm9zIjogImxpbnV4IiwKCSJyb290ZnMiOiB7CgkJImRpZmZfaWRzIjogWwoJCQkic2hhMjU2OjBmZjNiOTFiZGYyMWVjZGYyZjJmM2Q0MzcyYzIwOThhMTRkYmUwNmNkNjc4ZThmMGE4NWZkNDkwMmQwMGUyZTIiCgkJXSwKCQkidHlwZSI6ICJsYXllcnMiCgl9Cn0K",
                "digest": "sha256:a181593bfa4535abc8b6ee849bb4d7ba67ac80487285b29ff30f5f1f4040ff24",
                "mediaType": "application/vnd.oci.image.config.v1+json",
                "size": 453
        },
        "layers": [
                {
                        "data": "H4sIAAAAAAAA/yopKk1loDEwMDQwMDc3ZTCAAHTawNDchMHQxNjMzMTI2MDECKTe0MyIQcGA1g4DgdLiksQiBgOK7UL33BAB9a4+bkyMjHA+E4MdA4hXweAA5jtg0ePAYMEA0wGiWdFkkekaKK8GLq8AJjfY8LNS0RujYBSMglEwCkgEgAAAAP//MqdJrQAIAAA=",
                        "digest": "sha256:46e21c7cfe177aec58c290f7a47589897415c5ce1f64acf4485ef267813f396c",
                        "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
                        "size": 146
                }
        ],
        "mediaType": "application/vnd.oci.image.manifest.v1+json",
        "schemaVersion": 2
}

```

With this change there is no need to fetch either the config or the layer because the data is already in the manifest.

ref: https://github.com/opencontainers/image-spec/pull/826
