### PR TITLE
[release/1.6] Prepare release notes for v1.6.17

### DIFF
--- a/releases/v1.6.17.toml
+++ b/releases/v1.6.17.toml
@@ -1,0 +1,23 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release
+previous = "v1.6.16"
+
+pre_release = false
+
+preface = """\
+The seventeenth patch release for containerd 1.6 includes various updates.
+
+### Notable Updates
+
+* **Add network plugin metrics** ([#8018](https://github.com/containerd/containerd/pull/8018))
+* **Update mkdir permission on /etc/cni to 0755 instead of 0700** ([#8030](https://github.com/containerd/containerd/pull/8030))
+* **Export remote snapshotter label handler** ([#8054](https://github.com/containerd/containerd/pull/8054))
+* **Add support for default hosts.toml configuration** ([#8065](https://github.com/containerd/containerd/pull/8065))
+
+See the changelog for complete list of changes"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.16+unknown"
+	Version = "1.6.17+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated release notes

----

containerd 1.6.17

Welcome to the v1.6.17 release of containerd!

The seventeenth patch release for containerd 1.6 includes various updates.

### Notable Updates

* **Add network plugin metrics** ([#8018](https://github.com/containerd/containerd/pull/8018))
* **Update mkdir permission on /etc/cni to 0755 instead of 0700** ([#8030](https://github.com/containerd/containerd/pull/8030))
* **Export remote snapshotter label handler** ([#8054](https://github.com/containerd/containerd/pull/8054))
* **Add support for default hosts.toml configuration** ([#8065](https://github.com/containerd/containerd/pull/8065))

See the changelog for complete list of changes

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Akihiro Suda
* Derek McGowan
* Jess
* Antonio Ojea
* Kohei Tokunaga
* Phil Estes
* Wei Fu

### Changes
<details><summary>10 commits</summary>
<p>

  * [`a1aa9b900`](https://github.com/containerd/containerd/commit/a1aa9b900ce9e276a210a48aa5dc8b8832a44c2e) Prepare release notes for v1.6.17
* [1.6] Backport default registry hosts config ([#8065](https://github.com/containerd/containerd/pull/8065))
  * [`1436641b8`](https://github.com/containerd/containerd/commit/1436641b8dc77f24f4ec57d238344bc6bb857081) Support default hosts.toml configuration
  * [`87acecd04`](https://github.com/containerd/containerd/commit/87acecd0409103c266c5eda932e809e6717e7859) Update hosts doc
* [release/1.6 backport] Export remote snapshotter label handler ([#8054](https://github.com/containerd/containerd/pull/8054))
  * [`a6544ed7d`](https://github.com/containerd/containerd/commit/a6544ed7dc114b7542041eea91abbc7fe9a466a0) Export remote snapshotter label handler
* [release/1.6] cri: mkdir /etc/cni with 0755, not 0700 ([#8030](https://github.com/containerd/containerd/pull/8030))
  * [`ae02a24a3`](https://github.com/containerd/containerd/commit/ae02a24a39ddd6764eb7f98de677f11d8bdd1919) cri: mkdir /etc/cni with 0755, not 0700
* [release/1.6] add network plugin metrics ([#8018](https://github.com/containerd/containerd/pull/8018))
  * [`6c6cc5ec1`](https://github.com/containerd/containerd/commit/6c6cc5ec107f10ccf4d4acbfe89d572a52d58a92) add network plugin metrics
</p>
</details>

### Dependency Changes

This release has no dependency changes

Previous release can be found at [v1.6.16](https://github.com/containerd/containerd/releases/tag/v1.6.16)

