### PR TITLE
CI: skip some jobs when `repo != containerd/containerd`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
   #
   project:
     name: Project Checks
+    if: github.repository == 'containerd/containerd'
     runs-on: ubuntu-20.04
     timeout-minutes: 5
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,6 +15,7 @@ permissions: # added using https://github.com/step-security/secure-workflows
 
 jobs:
   CodeQL-Build:
+    if: github.repository == 'containerd/containerd'
     permissions:
       actions: read # for github/codeql-action/init to get workflow details
       contents: read # for actions/checkout to fetch code

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -8,6 +8,7 @@ jobs:
   # Others use https://github.com/AdaLogics/go-fuzz-headers.
   ci_fuzz:
     name: CI Fuzz
+    if: github.repository == 'containerd/containerd'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -35,6 +36,7 @@ jobs:
   # runnable with go test -fuzz.
   go_test_fuzz:
     name : go test -fuzz
+    if: github.repository == 'containerd/containerd'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
For running CI in a non-upstream repo
