### PR TITLE
[release/1.5] Fix retry logic within devmapper device deactivation

### DIFF
--- a/snapshots/devmapper/pool_device.go
+++ b/snapshots/devmapper/pool_device.go
@@ -76,6 +76,15 @@ func NewPoolDevice(ctx context.Context, config *Config) (*PoolDevice, error) {
 	return poolDevice, nil
 }
 
+func skipRetry(err error) bool {
+	if err == nil {
+		return true // skip retry if no error
+	} else if !errors.Is(err, unix.EBUSY) {
+		return true // skip retry if error is not due to device or resource busy
+	}
+	return false
+}
+
 func retry(ctx context.Context, f func() error) error {
 	var (
 		maxRetries = 100
@@ -85,9 +94,8 @@ func retry(ctx context.Context, f func() error) error {
 
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		retryErr = f()
-		if retryErr == nil {
-			return nil
-		} else if retryErr != unix.EBUSY {
+
+		if skipRetry(retryErr) {
 			return retryErr
 		}
 


### PR DESCRIPTION
Cherry-pick this bug fix [#8075 ](https://github.com/containerd/containerd/pull/8075) into 1.6 branch

Signed-off-by: Swagat Bora <sbora@amazon.com>
(cherry picked from commit 6ae3e5df6a9dda573e57f06610474848431ba2cb)

Signed-off-by: Swagat Bora <sbora@amazon.com>