### PR TITLE
CRI: Mirror generic toml runtime config under server

### DIFF
--- a/pkg/cri/server/helpers.go
+++ b/pkg/cri/server/helpers.go
@@ -359,6 +359,16 @@ func generateRuntimeOptions(r criconfig.Runtime, c criconfig.Config) (interface{
 	if err := optionsTree.Unmarshal(options); err != nil {
 		return nil, err
 	}
+
+	// For generic configuration, if no config path specified (preserving old behavior), pass
+	// the whole TOML configuration section to the runtime.
+	if runtimeOpts, ok := options.(*runtimeoptions.Options); ok && runtimeOpts.ConfigPath == "" {
+		runtimeOpts.ConfigBody, err = optionsTree.Marshal()
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal TOML blob for runtime %q: %v", r.Type, err)
+		}
+	}
+
 	return options, nil
 }
 


### PR DESCRIPTION
In https://github.com/containerd/containerd/pull/7764 it was made so that generic runtime options in the containerd toml config file would get passed to shims regardless of if containerd knew of the type beforehand and could supply the struct. However, this was only added for the sandbox server fork here and not the regular ol' CRI server. This change just mirrors the parts that need to be plopped in pkg/cri/server