### PR TITLE
remove select

### DIFF
--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -193,10 +193,7 @@ can be used and modified as necessary as a custom configuration.`
 
 			server, err := server.New(ctx, config)
 			if err != nil {
-				select {
-				case chsrv <- srvResp{err: err}:
-				case <-ctx.Done():
-				}
+				chsrv <- srvResp{err: err}
 				return
 			}
 


### PR DESCRIPTION
The check of ctx.Done is omitted, because there is no need to check whether it is closed, which can save some time and memory