### PR TITLE
[sandbox] Use options to pass PodSandboxConfig to shims

### DIFF
--- a/pkg/cri/sbserver/sandbox_run.go
+++ b/pkg/cri/sbserver/sandbox_run.go
@@ -225,7 +225,7 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 
 	runtimeStart := time.Now()
 
-	if err := controller.Create(ctx, id); err != nil {
+	if err := controller.Create(ctx, id, sb.WithOptions(config)); err != nil {
 		return nil, fmt.Errorf("failed to create sandbox %q: %w", id, err)
 	}
 


### PR DESCRIPTION
Allow sandboxed shims access `PodSandboxConfig` when creating a sandbox, this way shims can configure many things - DNS, ports, etc.

/cc @dcantah this might be useful for your use case too.

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>