### PR TITLE
Add fallback for windows platforms without osversion

### DIFF
--- a/platforms/defaults_windows.go
+++ b/platforms/defaults_windows.go
@@ -50,7 +50,10 @@ func (m windowsmatcher) Match(p specs.Platform) bool {
 	match := m.defaultMatcher.Match(p)
 
 	if match && m.OS == "windows" {
-		return strings.HasPrefix(p.OSVersion, m.osVersionPrefix) && m.defaultMatcher.Match(p)
+		if strings.HasPrefix(p.OSVersion, m.osVersionPrefix) {
+			return true
+		}
+		return p.OSVersion == ""
 	}
 
 	return match

--- a/platforms/defaults_windows_test.go
+++ b/platforms/defaults_windows_test.go
@@ -128,7 +128,7 @@ func TestMatchComparerMatch_WCOW(t *testing.T) {
 				Architecture: "amd64",
 				OS:           "windows",
 			},
-			match: false,
+			match: true,
 		},
 		{
 			platform: imagespec.Platform{
@@ -251,11 +251,11 @@ func TestMatchComparerLess(t *testing.T) {
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    "10.0.17764.1",
 		},
 		{
 			Architecture: "amd64",
 			OS:           "windows",
+			OSVersion:    "10.0.17764.1",
 		},
 		{
 			Architecture: "amd64",

--- a/platforms/platforms_windows_test.go
+++ b/platforms/platforms_windows_test.go
@@ -19,9 +19,23 @@ package platforms
 import (
 	"testing"
 
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNormalize(t *testing.T) {
 	require.Equal(t, DefaultSpec(), Normalize(DefaultSpec()))
+}
+
+func TestFallbackOnOSVersion(t *testing.T) {
+	p := specs.Platform{
+		OS:           "windows",
+		Architecture: "amd64",
+		OSVersion:    "99.99.99.99",
+	}
+
+	other := specs.Platform{OS: p.OS, Architecture: p.Architecture}
+
+	m := NewMatcher(p)
+	require.True(t, m.Match(other))
 }


### PR DESCRIPTION
The background for this change:

1. Windows host-process containers do not have an OS version set
2. Buildx v0.10 started pushing manifest lists by default, but it never has the OSVersion in the platform data (not that there is any way to specify what particular OS version you want). The change means that containerd cannot run images created with the new buildx on Windows because there is no matching OSVersion in the list of manifests.

Fixes #8070
Fixes #7431