### PR TITLE
[1.6] Add fallback for windows platforms without osversion

### DIFF
--- a/platforms/defaults_windows.go
+++ b/platforms/defaults_windows.go
@@ -46,10 +46,14 @@ type matchComparer struct {
 
 // Match matches platform with the same windows major, minor
 // and build version.
-func (m matchComparer) Match(p imagespec.Platform) bool {
-	if m.defaults.Match(p) {
-		// TODO(windows): Figure out whether OSVersion is deprecated.
-		return strings.HasPrefix(p.OSVersion, m.osVersionPrefix)
+func (m matchComparer) Match(p specs.Platform) bool {
+	match := m.defaults.Match(p)
+
+	if match && p.OS == "windows" {
+		if strings.HasPrefix(p.OSVersion, m.osVersionPrefix) {
+			return true
+		}
+		return p.OSVersion == ""
 	}
 	return false
 }

--- a/platforms/defaults_windows_test.go
+++ b/platforms/defaults_windows_test.go
@@ -104,7 +104,7 @@ func TestMatchComparerMatch(t *testing.T) {
 				Architecture: "amd64",
 				OS:           "windows",
 			},
-			match: false,
+			match: true,
 		},
 	} {
 		assert.Equal(t, test.match, m.Match(test.platform))
@@ -159,11 +159,11 @@ func TestMatchComparerLess(t *testing.T) {
 		{
 			Architecture: "amd64",
 			OS:           "windows",
-			OSVersion:    "10.0.17764.1",
 		},
 		{
 			Architecture: "amd64",
 			OS:           "windows",
+			OSVersion:    "10.0.17764.1",
 		},
 		{
 			Architecture: "amd64",

--- a/platforms/platforms_windows_test.go
+++ b/platforms/platforms_windows_test.go
@@ -19,9 +19,23 @@ package platforms
 import (
 	"testing"
 
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNormalize(t *testing.T) {
 	require.Equal(t, DefaultSpec(), Normalize(DefaultSpec()))
+}
+
+func TestFallbackOnOSVersion(t *testing.T) {
+	p := specs.Platform{
+		OS:           "windows",
+		Architecture: "amd64",
+		OSVersion:    "99.99.99.99",
+	}
+
+	other := specs.Platform{OS: p.OS, Architecture: p.Architecture}
+
+	m := NewMatcher(p)
+	require.True(t, m.Match(other))
 }


### PR DESCRIPTION
The background for this change:

1. Windows host-process containers do not have an OS version set
2. Buildx v0.10 started pushing manifest lists by default, but it never has the OSVersion in the platform data (not that there is any way to specify what particular OS version you want). The change means that containerd cannot run images created with the new buildx on Windows because there is no matching OSVersion in the list of manifests.


(cherry picked from commit 8442521645bac4a3198a1dce56ca08147f7a8e59)