### PR TITLE
Support registry mirror endpoints with custom namespace

### DIFF
--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -310,6 +310,14 @@ non-compliant OCI registries which are missing the `/v2` prefix.
 override_path = true
 ```
 
+## namespace field
+
+`namespace` specifies the namespace registry server hosts the images.
+
+```
+namespace = "custom-namespace"
+```
+
 ## host field(s) (in the toml table format)
 
 `[host]."https://namespace"` and `[host].http://namespace` entries in the

--- a/remotes/docker/config/hosts.go
+++ b/remotes/docker/config/hosts.go
@@ -321,6 +321,9 @@ type hostFileConfig struct {
 	// API root endpoint.
 	OverridePath bool `toml:"override_path"`
 
+	// Namespace indicates the namespace registry server hosts the images.
+	Namespace string `toml:"namespace"`
+
 	// TODO: Credentials: helper? name? username? alternate domain? token?
 }
 
@@ -400,6 +403,10 @@ func parseHostConfig(server string, baseDir string, config hostFileConfig) (host
 			}
 		} else if !config.OverridePath {
 			u.Path = "/v2"
+		}
+		if len(config.Namespace) > 0 {
+			ns := strings.TrimPrefix(config.Namespace, "/")
+			u.Path += "/" + ns
 		}
 		result.path = u.Path
 	}

--- a/remotes/docker/config/hosts_test.go
+++ b/remotes/docker/config/hosts_test.go
@@ -110,6 +110,10 @@ ca = "/etc/path/default"
 
 [host."https://noprefixnoncompliant.registry"]
   override_path = true
+
+[host."https://test-4.registry"]
+  capabilities = ["pull", "resolve", "push"]
+  namespace = "test-namespace"
 `
 	var tb, fb = true, false
 	expected := []hostConfig{
@@ -174,6 +178,12 @@ ca = "/etc/path/default"
 		{
 			scheme:       "https",
 			host:         "noprefixnoncompliant.registry",
+			capabilities: allCaps,
+		},
+		{
+			scheme:       "https",
+			host:         "test-4.registry",
+			path:         "/v2/test-namespace",
 			capabilities: allCaps,
 		},
 		{


### PR DESCRIPTION
* Add a new field "namespace" in the hosts config toml file, this field can be used to specify the namespace used in the registry server.
* This avoids users to use host url like "https://test-2.registry/v2/test-namespace", they are not aware of adding v2 between domain and path