### PR TITLE
Prepare release notes for v1.7.0 beta.4

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -41,6 +41,7 @@ Fupan Li <lifupan@gmail.com> <fupan.lfp@antfin.com>
 Fupan Li <lifupan@gmail.com> <fupan.lfp@antgroup.com>
 Furkan Türkal <furkan.turkal@trendyol.com>
 Georgia Panoutsakopoulou <gpanoutsak@gmail.com>
+guodong <guodong9211@gmail.com>
 Guangming Wang <guangming.wang@daocloud.io>
 Haiyan Meng <haiyanmeng@google.com>
 haoyun <yun.hao@daocloud.io>
@@ -145,6 +146,7 @@ Xuean Yan <yan.xuean@zte.com.cn>
 Yang Yang <yang8518296@163.com>
 Yue Zhang <zy675793960@yeah.net>
 Yuxing Liu <starnop@163.com>
+Zechun Chen <zechun.chen@daocloud.io>
 zhang he <zhanghe9702@163.com>
 Zhang Wei <zhangwei555@huawei.com>
 zhangyadong <zhangyadong.0808@bytedance.com>

--- a/releases/v1.7.0-beta.toml
+++ b/releases/v1.7.0-beta.toml
@@ -61,6 +61,16 @@ See the [NRI Docs](https://github.com/containerd/containerd/blob/main/docs/NRI.m
 * **Support for cgroups blockio** ([#5490](https://github.com/containerd/containerd/pull/5490))
 * **Add restart policy for enhanced restart manager** ([#6744](https://github.com/containerd/containerd/pull/6744))
 
+#### gRPC Shim Support _(experimental)_
+
+* **Initial gRPC shim support** ([#8052](https://github.com/containerd/containerd/pull/8052))
+
+Adds support for shims to use gRPC in addition to ttrpc. Existing ttrpc shim support is not going
+away and will continue to be recommended for the best performance and lowest shim memory overhead.
+The gRPC support allows implementation of a wider range of shim implementations which may not
+have access to a stable ttrpc library in the implementation language. The shim protocol is also
+updated to allow the shims to specify the protocol which is supported.
+
 #### Road to 2.0
 
 ##### Refactoring
@@ -68,7 +78,7 @@ See the [NRI Docs](https://github.com/containerd/containerd/blob/main/docs/NRI.m
 There are multiple places in the code today which are being targeted for refactoring to make long term support easier and to provide more extension points.
 
 The CRI plugin is the most complex containerd plugin with a wide range of functionality. A major effort in this release and before 2.0 involves moving functionality
-out of the single CRI plugin into smaller-scoped containerd plugins, such that they can be used and tested independenty. The new sandbox and distribution interfaces provide one example of this,
+out of the single CRI plugin into smaller-scoped containerd plugins, such that they can be used and tested independently. The new sandbox and distribution interfaces provide one example of this,
 but it also being done for image and network management.
 
 The version of ttrpc has been updated this release to support streaming, allowing existing grpc services to use ttrpc.
@@ -97,8 +107,9 @@ The 2.0 release will remove any feature deprecated in 1.x. Features deprecated i
 
 #### CRI Updates
 
-* **Support image pull progress timeout** ([#6150](https://github.com/containerd/containerd/pull/6150))
 * **Fix CRI plugin to setup pod network after creating the sandbox container** ([#5904](https://github.com/containerd/containerd/pull/5904))
+* **Support image pull progress timeout** ([#6150](https://github.com/containerd/containerd/pull/6150))
+* **Add experimental support for runtime specific snapshotters** ([#6899](https://github.com/containerd/containerd/pull/6899))
 * **Pass all TOML runtime configuration options from CRI to the runtime** ([#7764](https://github.com/containerd/containerd/pull/7764))
 * **Support for user namespaces in stateless pods ([KEP-127](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/127-user-namespaces)) _(experimental)_** ([#7679](https://github.com/containerd/containerd/pull/7679))
 * **Add network plugin metrics** ([#7858](https://github.com/containerd/containerd/pull/7858))
@@ -114,6 +125,8 @@ The 2.0 release will remove any feature deprecated in 1.x. Features deprecated i
 * **Add support for default registry host configuration** ([#7607](https://github.com/containerd/containerd/pull/7607))
 * **Use github.com/minio/sha256-simd for more efficient sha256 calculation** ([#7732](https://github.com/containerd/containerd/pull/7732))
 * **Make OCI options cross-platform** ([#7928](https://github.com/containerd/containerd/pull/7928))
+* **Update release builds to build from Ubuntu 20.04 with glibc 2.31** ([#8021](https://github.com/containerd/containerd/pull/8021))
+* **Use data field from OCI descriptor when provided for fetch** ([#8076](https://github.com/containerd/containerd/pull/8076))
 
 See the changelog for complete list of changes"""
 

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.7.0-beta.3+unknown"
+	Version = "1.7.0-beta.4+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated notes (See unabridged version in [gist](https://gist.github.com/dmcgowan/18c05d167f0c0c3fe7d1d8839e6ec932))

------

Welcome to the v1.7.0-beta.4 release of containerd!  
*This is a pre-release of containerd*

The eighth major release of containerd includes new functionality alongside many improvements.
This release is intended to be the last major release of containerd 1.x before 2.0.
Some functionality in this release may be considered experimental or unstable, but will become stable or default in 2.0.
This release still adheres to our backwards compability guarantees and users who do not use or enable new functionality should use this release with the same stability expectations.
The previous 1.6 release has also become a long term stable release for users who prefer releases with mostly stability improvements and wish to wait a few releases for new functionality.

_This is a beta release and includes some functionality which is not yet complete. While most APIs are finalized before merge, they are subject to change until the official release._

### Highlights

#### Sandbox API _(experimental)_

The sandbox API provides a new way of managing containerd's shim, providing more flexibility and functionality for multi-container environments such as Pods and VMs.
This API makes it easier to manage these groups of containers at a higher level and offers new extension points for shim implementations and clients.

* **Sandbox API** ([#6703](https://github.com/containerd/containerd/pull/6703))
* **CRI Sandbox API Implementation** ([#7228](https://github.com/containerd/containerd/pull/7228))

#### Transfer Service _(experimental)_

* **Transfer Service** ([#7320](https://github.com/containerd/containerd/pull/7320))

The transfer service provides a simple interface to transfer artifact objects between any source and destination. This allows for
pull and push operations to be done in containerd whether requested from clients or plugins. It is experimental in this release
to allow for further plugin development and integration into existing plugins.

See the [Transfer Docs](https://github.com/containerd/containerd/blob/main/docs/transfer.md)

#### NRI _(experimental)_

* **Extend NRI scope** ([nri#16](https://github.com/containerd/nri/pull/16))
* **Support for updated NRI** ([#6019](https://github.com/containerd/containerd/pull/6019))

The Node Resource Interface is a common framework for plugging extensions into OCI-compatible container runtimes. It provides
basic mechanisms for plugins to track the state of containers and to make limited changes to their configuration.

This release introduces NRI v0.2.0 with an updated plugin interface to cover a wide range of use cases.

See the [NRI Docs](https://github.com/containerd/containerd/blob/main/docs/NRI.md)

#### Platform Support

* **Linux containers on FreeBSD** ([#7000](https://github.com/containerd/containerd/pull/7000))

#### Runtime Features

* **Add support for CDI device injection** ([#6654](https://github.com/containerd/containerd/pull/6654))
* **Support for cgroups blockio** ([#5490](https://github.com/containerd/containerd/pull/5490))
* **Add restart policy for enhanced restart manager** ([#6744](https://github.com/containerd/containerd/pull/6744))

#### gRPC Shim Support _(experimental)_

* **Initial gRPC shim support** ([#8052](https://github.com/containerd/containerd/pull/8052))

Adds support for shims to use gRPC in addition to ttrpc. Existing ttrpc shim support is not going
away and will continue to be recommended for the best performance and lowest shim memory overhead.
The gRPC support allows implementation of a wider range of shim implementations which may not
have access to a stable ttrpc library in the implementation language. The shim protocol is also
updated to allow the shims to specify the protocol which is supported.

#### Road to 2.0

##### Refactoring

There are multiple places in the code today which are being targeted for refactoring to make long term support easier and to provide more extension points.

The CRI plugin is the most complex containerd plugin with a wide range of functionality. A major effort in this release and before 2.0 involves moving functionality
out of the single CRI plugin into smaller-scoped containerd plugins, such that they can be used and tested independenty. The new sandbox and distribution interfaces provide one example of this,
but it also being done for image and network management.

The version of ttrpc has been updated this release to support streaming, allowing existing grpc services to use ttrpc.
Services are being refactored to allow ttrpc implementations, which can be served via shim and accessed using the new sandbox management capability.

* **Remove gogoproto.customtype** ([#6699](https://github.com/containerd/containerd/pull/6699))
* **Remove enumvalue_customname, goproto_enum_prefix and enum_customname** ([#6708](https://github.com/containerd/containerd/pull/6708))
* **Remove all gogoproto extensions** ([#6829](https://github.com/containerd/containerd/pull/6829))
* **Migrate off from github.com/gogo/protobuf** ([#6841](https://github.com/containerd/containerd/pull/6841))
* **ttrpc streaming** ([ttrpc#107](https://github.com/containerd/ttrpc/pull/107))

* **Add unpack interface for client** ([#6749](https://github.com/containerd/containerd/pull/6749))
* **Add collectible resources to metadata gc** ([#6804](https://github.com/containerd/containerd/pull/6804))

##### Configuration

Existing CRI configurations will be supported until 2.0.
Any functionality split out of CRI will have their configuration migrated to new plugins.
Deprecated configuration versions and configurations for deprecated features will be removed in 2.0.

##### Deprecation

The 2.0 release will remove any feature deprecated in 1.x. Features deprecated in this release include.

* **Docker Schema 1 Image Deprecation** ([#6884](https://github.com/containerd/containerd/pull/6884))

#### CRI Updates

* **Support image pull progress timeout** ([#6150](https://github.com/containerd/containerd/pull/6150))
* **Fix CRI plugin to setup pod network after creating the sandbox container** ([#5904](https://github.com/containerd/containerd/pull/5904))
* **Pass all TOML runtime configuration options from CRI to the runtime** ([#7764](https://github.com/containerd/containerd/pull/7764))
* **Support for user namespaces in stateless pods ([KEP-127](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/127-user-namespaces)) _(experimental)_** ([#7679](https://github.com/containerd/containerd/pull/7679))
* **Add network plugin metrics** ([#7858](https://github.com/containerd/containerd/pull/7858))
* **CRI v1alpha2 is deprecated and will be removed from containerd in containerd v2.0; if you are using the CRI API please move up to CRI v1; Kubernetes supports CRI v1 since Kubernetes 1.23** ([#7863](https://github.com/containerd/containerd/pull/7863))

#### Other

* **Support shallow content copy by adding reader option to local content reader at** ([#7414](https://github.com/containerd/containerd/pull/7414))
* **Add NoSameOwner option when unpacking tars** ([#7386](https://github.com/containerd/containerd/pull/7386))
* **Add `FetcherByDigest` for fetching blobs without fetching a manifest** ([#7460](https://github.com/containerd/containerd/pull/7460))
* **Update default seccomp profile to block socket calls to AF_VSOCK** ([#7510](https://github.com/containerd/containerd/pull/7510))
* **Replace fork on mount logic with CLONE_FS** ([#7513](https://github.com/containerd/containerd/pull/7513))
* **Add support for default registry host configuration** ([#7607](https://github.com/containerd/containerd/pull/7607))
* **Use github.com/minio/sha256-simd for more efficient sha256 calculation** ([#7732](https://github.com/containerd/containerd/pull/7732))
* **Make OCI options cross-platform** ([#7928](https://github.com/containerd/containerd/pull/7928))
* **Update release builds to build from Ubuntu 20.04 with glibc 2.31** ([#8021](https://github.com/containerd/containerd/pull/8021))
* **Use data field from OCI descriptor when provided for fetch** ([#8076](https://github.com/containerd/containerd/pull/8076))

See the changelog for complete list of changes

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

_..._

### Changes

_..._

### Dependency Changes

* **github.com/AdaLogics/go-fuzz-headers**                                         6c3934b029d8 -> 1f10f66a31bf
* **github.com/AdamKorcz/go-118-fuzz-build**                                       5330a85ea652 **_new_**
* **github.com/Microsoft/go-winio**                                                v0.5.1 -> v0.6.0
* **github.com/Microsoft/hcsshim**                                                 v0.9.2 -> v0.10.0-rc.5
* **github.com/blang/semver/v4**                                                   v4.0.0 **_new_**
* **github.com/cenkalti/backoff/v4**                                               v4.1.2 -> v4.2.0
* **github.com/cilium/ebpf**                                                       v0.7.0 -> v0.9.1
* **github.com/container-orchestrated-devices/container-device-interface**         v0.5.1 **_new_**
* **github.com/containerd/btrfs/v2**                                               v2.0.0 **_new_**
* **github.com/containerd/cgroups**                                                v1.0.3 -> v1.1.0
* **github.com/containerd/cgroups/v3**                                             v3.0.0 **_new_**
* **github.com/containerd/continuity**                                             v0.2.2 -> v0.3.0
* **github.com/containerd/go-cni**                                                 v1.1.3 -> v1.1.6
* **github.com/containerd/imgcrypt**                                               v1.1.3 -> 8ba028dca028
* **github.com/containerd/nri**                                                    v0.1.0 -> b3cabdec0657
* **github.com/containerd/ttrpc**                                                  v1.1.0 -> 32fab2374638
* **github.com/containerd/typeurl/v2**                                             v2.1.0 **_new_**
* **github.com/containernetworking/cni**                                           v1.0.1 -> v1.1.2
* **github.com/containernetworking/plugins**                                       v1.0.1 -> v1.2.0
* **github.com/containers/ocicrypt**                                               v1.1.2 -> v1.1.3
* **github.com/coreos/go-systemd/v22**                                             v22.3.2 -> v22.5.0
* **github.com/cpuguy83/go-md2man/v2**                                             v2.0.0 -> v2.0.2
* **github.com/cyphar/filepath-securejoin**                                        v0.2.3 **_new_**
* **github.com/docker/go-units**                                                   v0.4.0 -> v0.5.0
* **github.com/emicklei/go-restful/v3**                                            v3.8.0 **_new_**
* **github.com/fsnotify/fsnotify**                                                 v1.4.9 -> v1.6.0
* **github.com/go-logr/logr**                                                      v1.2.2 -> v1.2.3
* **github.com/godbus/dbus/v5**                                                    v5.0.6 -> v5.1.0
* **github.com/google/go-cmp**                                                     v0.5.6 -> v0.5.9
* **github.com/google/uuid**                                                       v1.2.0 -> v1.3.0
* **github.com/grpc-ecosystem/grpc-gateway/v2**                                    v2.7.0 **_new_**
* **github.com/intel/goresctrl**                                                   v0.2.0 -> v0.3.0
* **github.com/klauspost/compress**                                                v1.11.13 -> v1.15.11
* **github.com/klauspost/cpuid/v2**                                                v2.0.4 **_new_**
* **github.com/miekg/pkcs11**                                                      v1.0.3 -> v1.1.1
* **github.com/minio/sha256-simd**                                                 v1.0.0 **_new_**
* **github.com/moby/sys/mountinfo**                                                v0.5.0 -> v0.6.2
* **github.com/moby/sys/sequential**                                               v0.5.0 **_new_**
* **github.com/moby/sys/signal**                                                   v0.6.0 -> v0.7.0
* **github.com/opencontainers/image-spec**                                         693428a734f5 -> 3a7f492d3f1b
* **github.com/opencontainers/runc**                                               v1.1.0 -> v1.1.4
* **github.com/opencontainers/runtime-spec**                                       1c3f411f0417 -> 86290f6a00fb
* **github.com/opencontainers/runtime-tools**                                      946c877fa809 **_new_**
* **github.com/opencontainers/selinux**                                            v1.10.0 -> v1.10.2
* **github.com/pelletier/go-toml**                                                 v1.9.3 -> v1.9.5
* **github.com/prometheus/client_golang**                                          v1.11.0 -> v1.13.0
* **github.com/prometheus/common**                                                 v0.30.0 -> v0.37.0
* **github.com/prometheus/procfs**                                                 v0.7.3 -> v0.8.0
* **github.com/russross/blackfriday/v2**                                           v2.0.1 -> v2.1.0
* **github.com/sirupsen/logrus**                                                   v1.8.1 -> v1.9.0
* **github.com/stretchr/testify**                                                  v1.7.0 -> v1.8.1
* **github.com/syndtr/gocapability**                                               42c35b437635 **_new_**
* **github.com/tchap/go-patricia/v2**                                              v2.3.1 **_new_**
* **github.com/urfave/cli**                                                        v1.22.1 -> v1.22.12
* **github.com/vishvananda/netlink**                                               f5de75959ad5 -> v1.2.1-beta.2
* **go.opencensus.io**                                                             v0.23.0 -> v0.24.0
* **go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc**  v0.28.0 -> v0.37.0
* **go.opentelemetry.io/otel**                                                     v1.3.0 -> v1.12.0
* **go.opentelemetry.io/otel/exporters/otlp/internal/retry**                       v1.3.0 -> v1.12.0
* **go.opentelemetry.io/otel/exporters/otlp/otlptrace**                            v1.3.0 -> v1.12.0
* **go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc**              v1.3.0 -> v1.12.0
* **go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp**              v1.3.0 -> v1.12.0
* **go.opentelemetry.io/otel/metric**                                              v0.34.0 **_new_**
* **go.opentelemetry.io/otel/sdk**                                                 v1.3.0 -> v1.12.0
* **go.opentelemetry.io/otel/trace**                                               v1.3.0 -> v1.12.0
* **go.opentelemetry.io/proto/otlp**                                               v0.11.0 -> v0.19.0
* **golang.org/x/crypto**                                                          32db794688a5 -> v0.1.0
* **golang.org/x/mod**                                                             v0.7.0 **_new_**
* **golang.org/x/net**                                                             fe4d6282115f -> v0.5.0
* **golang.org/x/oauth2**                                                          2bc19b11175f -> 6fdb5e3db783
* **golang.org/x/sync**                                                            036812b2e83c -> v0.1.0
* **golang.org/x/sys**                                                             1d35b9e2eb4e -> v0.5.0
* **golang.org/x/term**                                                            6886f2dfbf5b -> v0.4.0
* **golang.org/x/text**                                                            v0.3.7 -> v0.6.0
* **golang.org/x/time**                                                            1f47c861a9ac -> 90d013bbcef8
* **golang.org/x/tools**                                                           v0.5.0 **_new_**
* **google.golang.org/genproto**                                                   e50cd9704f63 -> 1c016267d619
* **google.golang.org/grpc**                                                       v1.43.0 -> v1.52.3
* **google.golang.org/protobuf**                                                   v1.27.1 -> v1.28.1
* **gopkg.in/yaml.v3**                                                             496545a6307b -> v3.0.1
* **k8s.io/api**                                                                   v0.22.5 -> v0.25.4
* **k8s.io/apimachinery**                                                          v0.22.5 -> v0.25.4
* **k8s.io/apiserver**                                                             v0.22.5 -> v0.25.4
* **k8s.io/client-go**                                                             v0.22.5 -> v0.25.4
* **k8s.io/component-base**                                                        v0.22.5 -> v0.25.4
* **k8s.io/cri-api**                                                               v0.23.1 -> v0.26.0-beta.0
* **k8s.io/klog/v2**                                                               v2.30.0 -> v2.80.1
* **k8s.io/utils**                                                                 cb0fa318a74b -> 8e77b1f39fe2
* **sigs.k8s.io/json**                                                             f223a00ba0e2 **_new_**
* **sigs.k8s.io/structured-merge-diff/v4**                                         v4.1.2 -> v4.2.3
* **sigs.k8s.io/yaml**                                                             v1.2.0 -> v1.3.0

Previous release can be found at [v1.6.0](https://github.com/containerd/containerd/releases/tag/v1.6.0)
### Which file should I download?
* `containerd-<VERSION>-<OS>-<ARCH>.tar.gz`:         ✅Recommended. Dynamically linked with glibc 2.31 (Ubuntu 20.04).
* `containerd-static-<VERSION>-<OS>-<ARCH>.tar.gz`:  Statically linked. Expected to be used on non-glibc Linux distributions. Not position-independent.
* `cri-containerd-<VERSION>-<OS>-<ARCH>.tar.gz`:     (Deprecated)
* `cri-containerd-cni-<VERSION>-<OS>-<ARCH>.tar.gz`: (Deprecated)

In addition to containerd, typically you will have to install [runc](https://github.com/opencontainers/runc/releases)
and [CNI plugins](https://github.com/containernetworking/plugins/releases) from their official sites too.

See also the [Getting Started](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) documentation.
