### PR TITLE
[release/1.6] Prepare release notes for v1.6.18

### DIFF
--- a/releases/v1.6.18.toml
+++ b/releases/v1.6.18.toml
@@ -1,0 +1,24 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release
+previous = "v1.6.17"
+
+pre_release = false
+
+preface = """\
+The eighteenth patch release for containerd 1.6 includes fixes for CVE-2023-25153 and CVE-2023-25173
+along with a security update for Go.
+
+### Notable Updates
+
+* **Fix OCI image importer memory exhaustion** ([GHSA-259w-8hf6-59c2](https://github.com/containerd/containerd/security/advisories/GHSA-259w-8hf6-59c2))
+* **Fix supplementary groups not being set up properly** ([GHSA-hmfx-3pcx-653p](https://github.com/containerd/containerd/security/advisories/GHSA-hmfx-3pcx-653p))
+* **Revert removal of `/sbin/apparmor_parser` check** ([#8087](https://github.com/containerd/containerd/pull/8087))
+* **Update Go to 1.19.6** ([#8111](https://github.com/containerd/containerd/pull/8111))
+
+See the changelog for complete list of changes"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.17+unknown"
+	Version = "1.6.18+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated release notes

----

containerd 1.6.18

Welcome to the v1.6.18 release of containerd!

The eighteenth patch release for containerd 1.6 includes fixes for CVE-2023-25153 and CVE-2023-25173
along with a security update for Go.

### Notable Updates

* **Fix OCI image importer memory exhaustion** ([GHSA-259w-8hf6-59c2](https://github.com/containerd/containerd/security/advisories/GHSA-259w-8hf6-59c2))
* **Fix supplementary groups not being set up properly** ([GHSA-hmfx-3pcx-653p](https://github.com/containerd/containerd/security/advisories/GHSA-hmfx-3pcx-653p))
* **Revert removal of `/sbin/apparmor_parser` check** ([#8087](https://github.com/containerd/containerd/pull/8087))
* **Update Go to 1.19.6** ([#8111](https://github.com/containerd/containerd/pull/8111))

See the changelog for complete list of changes

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Akihiro Suda
* Ye Sijun
* Derek McGowan
* Samuel Karp
* Bjorn Neergaard
* Wei Fu
* Brian Goff
* Iceber Gu
* Kazuyoshi Kato
* Phil Estes
* Swagat Bora

### Changes
<details><summary>23 commits</summary>
<p>

  * [`44e61d764`](https://github.com/containerd/containerd/commit/44e61d7641f71f44353263306a4967276933173b) Add release notes for v1.6.18
* Github Security Advisory [GHSA-hmfx-3pcx-653p](https://github.com/containerd/containerd/security/advisories/GHSA-hmfx-3pcx-653p)
  * [`286a01f35`](https://github.com/containerd/containerd/commit/286a01f350a2298b4fdd7e2a0b31c04db3937ea8) oci: fix additional GIDs
  * [`301823453`](https://github.com/containerd/containerd/commit/301823453d788ce409e222e88a27d7faf2c2093d) oci: fix loop iterator aliasing
  * [`0070ab70f`](https://github.com/containerd/containerd/commit/0070ab70fa58045d25fc6ebab27edcae328e38f1) oci: skip checking gid for WithAppendAdditionalGroups
  * [`16d52de64`](https://github.com/containerd/containerd/commit/16d52de64d9b0b0e4bf7e11226199281561a3d96) refactor: reduce duplicate code
  * [`b45e30292`](https://github.com/containerd/containerd/commit/b45e30292ce9b214158fa403a6165aabbf5b23f0) add WithAdditionalGIDs test
  * [`0a06c284a`](https://github.com/containerd/containerd/commit/0a06c284aec5860a58a803b5da83def3462dc3a0) add WithAppendAdditionalGroups helper
* Github Security Advisory [GHSA-259w-8hf6-59c2](https://github.com/containerd/containerd/security/advisories/GHSA-259w-8hf6-59c2)
  * [`84936fd1f`](https://github.com/containerd/containerd/commit/84936fd1f6a0670ab8c7665cb87fae6b87b0b908) importer: stream oci-layout and manifest.json
* [1.6] Add fallback for windows platforms without osversion ([#8106](https://github.com/containerd/containerd/pull/8106))
  * [`b327af6a4`](https://github.com/containerd/containerd/commit/b327af6a4f635611d8b59beec94db0beace48063) Add fallback for windows platforms without osversion
* [release/1.6] Go 1.19.6 ([#8111](https://github.com/containerd/containerd/pull/8111))
  * [`54ead5b7b`](https://github.com/containerd/containerd/commit/54ead5b7b71a0f458566e42eac28eb274286af47) Go 1.19.6
* [release/1.6] ctr/run: flags --detach and --rm cannot be specified together ([#8094](https://github.com/containerd/containerd/pull/8094))
  * [`2b4b35ab4`](https://github.com/containerd/containerd/commit/2b4b35ab49b0cea79f76c4f52923c74cfc26ccfb) ctr/run: flags --detach and --rm cannot be specified together
* [release/1.6] Fix retry logic within devmapper device deactivation ([#8088](https://github.com/containerd/containerd/pull/8088))
  * [`d5284157b`](https://github.com/containerd/containerd/commit/d5284157b8af78a2d85e78bd3106695a4e4c995b) Fix retry logic within devmapper device deactivation
* [release/1.6 backport] Revert `apparmor_parser` regression  ([#8087](https://github.com/containerd/containerd/pull/8087))
  * [`624ff636b`](https://github.com/containerd/containerd/commit/624ff636b8b463fc48e6ba3c861f98a0c00dbb71) pkg/apparmor: clarify Godoc
  * [`3a0a35b36`](https://github.com/containerd/containerd/commit/3a0a35b36297685d1a38bfa823005a2cb77a40dd) Revert "Don't check for apparmor_parser to be present"
* [release/1.6] CI: skip some jobs when `repo != containerd/containerd` ([#8083](https://github.com/containerd/containerd/pull/8083))
  * [`664a938a3`](https://github.com/containerd/containerd/commit/664a938a33ccbbc0ab70ca5f9455e452b910e767) CI: skip some jobs when `repo != containerd/containerd`
</p>
</details>

### Dependency Changes

This release has no dependency changes

Previous release can be found at [v1.6.17](https://github.com/containerd/containerd/releases/tag/v1.6.17)

