### PR TITLE
Fix problems with the golangci-lint check that reported

### DIFF
--- a/archive/tar.go
+++ b/archive/tar.go
@@ -340,8 +340,6 @@ func createTarFile(ctx context.Context, path, extractDir string, hdr *tar.Header
 				return err
 			}
 		}
-
-	//nolint:staticcheck // TypeRegA is deprecated but we may still receive an external tar with TypeRegA
 	case tar.TypeReg, tar.TypeRegA:
 		file, err := openFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, hdrInfo.Mode())
 		if err != nil {

--- a/images/archive/importer.go
+++ b/images/archive/importer.go
@@ -94,8 +94,6 @@ func ImportIndex(ctx context.Context, store content.Store, reader io.Reader, opt
 		if hdr.Typeflag == tar.TypeSymlink {
 			symlinks[hdr.Name] = path.Join(path.Dir(hdr.Name), hdr.Linkname)
 		}
-
-		//nolint:staticcheck // TypeRegA is deprecated but we may still receive an external tar with TypeRegA
 		if hdr.Typeflag != tar.TypeReg && hdr.Typeflag != tar.TypeRegA {
 			if hdr.Typeflag != tar.TypeDir {
 				log.G(ctx).WithField("file", hdr.Name).Debug("file type ignored")


### PR DESCRIPTION
Signed-off-by: Zechun Chen <zechun.chen@daocloud.io>

Resolve the following problems with the golangci-lint check that reported
```bash
➜  containerd git:(main) ✗ golangci-lint run -c .golangci.yml
images/archive/importer.go:98:3: directive `//nolint:staticcheck // TypeRegA is deprecated but we may still receive an external tar with TypeRegA` is unused for linter "staticcheck" (nolintlint)
                //nolint:staticcheck // TypeRegA is deprecated but we may still receive an external tar with TypeRegA
                ^
archive/tar.go:344:2: directive `//nolint:staticcheck // TypeRegA is deprecated but we may still receive an external tar with TypeRegA` is unused for linter "staticcheck" (nolintlint)
        //nolint:staticcheck // TypeRegA is deprecated but we may still receive an external tar with TypeRegA
        ^
```