### PR TITLE
replace deprecated sets.string with sets.set

### DIFF
--- a/pkg/cri/server/bandwidth/linux.go
+++ b/pkg/cri/server/bandwidth/linux.go
@@ -90,7 +90,7 @@ func (t *tcShaper) nextClassID() (int, error) {
 	}
 
 	scanner := bufio.NewScanner(bytes.NewBuffer(data))
-	classes := sets.String{}
+	classes := sets.Set[string]{}
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		// skip empty lines


### PR DESCRIPTION
sets.String got marked as deprecated: https://github.com/kubernetes/kubernetes/pull/112377
