### PR TITLE
Allow containerd on Windows 11 to use Windows Server 2022 images

### DIFF
--- a/platforms/defaults_windows.go
+++ b/platforms/defaults_windows.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Microsoft/hcsshim/osversion"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/sys/windows"
 )
@@ -70,7 +71,7 @@ func (m windowsmatcher) Match(p specs.Platform) bool {
 					return false
 				}
 
-				if (major == 10 && minor == 0 && build >= 20348) ||
+				if (major == 10 && minor == 0 && build >= osversion.V21H2Server) ||
 					(major == 10 && minor > 0) {
 					// Windows 11 client machines are implicitly
 					// compatible with 10.0.20348 (LTSC2022), even

--- a/platforms/defaults_windows_test.go
+++ b/platforms/defaults_windows_test.go
@@ -80,6 +80,7 @@ func TestMatchComparerMatch_WCOW(t *testing.T) {
 		defaultMatcher: &matcher{
 			Platform: Normalize(DefaultSpec()),
 		},
+		isClientOS: false,
 	}
 	for _, test := range []struct {
 		platform imagespec.Platform
@@ -158,6 +159,7 @@ func TestMatchComparerMatch_LCOW(t *testing.T) {
 			},
 			),
 		},
+		isClientOS: false,
 	}
 	for _, test := range []struct {
 		platform imagespec.Platform
@@ -210,6 +212,7 @@ func TestMatchComparerLess(t *testing.T) {
 		defaultMatcher: &matcher{
 			Platform: Normalize(DefaultSpec()),
 		},
+		isClientOS: false,
 	}
 	platforms := []imagespec.Platform{
 		{
@@ -261,6 +264,101 @@ func TestMatchComparerLess(t *testing.T) {
 			Architecture: "amd64",
 			OS:           "windows",
 			OSVersion:    "10.0.17762.1",
+		},
+	}
+	sort.SliceStable(platforms, func(i, j int) bool {
+		return m.Less(platforms[i], platforms[j])
+	})
+	assert.Equal(t, expected, platforms)
+}
+
+func TestMatchComparerClientOSMatch(t *testing.T) {
+	m := windowsmatcher{
+		Platform:        DefaultSpec(),
+		osVersionPrefix: "10.0.22000",
+		defaultMatcher: &matcher{
+			Platform: Normalize(DefaultSpec()),
+		},
+		isClientOS: true,
+	}
+	for _, test := range []struct {
+		platform imagespec.Platform
+		match    bool
+	}{
+		{
+			platform: imagespec.Platform{
+				Architecture: "amd64",
+				OS:           "windows",
+				OSVersion:    "10.0.17763.2114",
+			},
+			match: false,
+		},
+		{
+			platform: imagespec.Platform{
+				Architecture: "amd64",
+				OS:           "windows",
+				OSVersion:    "10.0.20348.169",
+			},
+			match: true,
+		},
+		{
+			platform: imagespec.Platform{
+				Architecture: "amd64",
+				OS:           "windows",
+				OSVersion:    "10.0.22000",
+			},
+			match: true,
+		},
+		{
+			platform: imagespec.Platform{
+				Architecture: "amd64",
+				OS:           "windows",
+			},
+			match: true,
+		},
+		{
+			platform: imagespec.Platform{
+				Architecture: "amd64",
+				OS:           "linux",
+			},
+			match: false,
+		},
+	} {
+		assert.Equal(t, test.match, m.Match(test.platform), "should match %b, %s to %s", test.match, m.Platform, test.platform)
+	}
+}
+
+func TestMatchComparerClientOSPriority(t *testing.T) {
+	m := windowsmatcher{
+		Platform:        DefaultSpec(),
+		osVersionPrefix: "10.0.22000",
+		defaultMatcher: &matcher{
+			Platform: Normalize(DefaultSpec()),
+		},
+		isClientOS: true,
+	}
+	platforms := []imagespec.Platform{
+		{
+			Architecture: "amd64",
+			OS:           "windows",
+			OSVersion:    "10.0.20348.169",
+		},
+		{
+			Architecture: "amd64",
+			OS:           "windows",
+			OSVersion:    "10.0.22000",
+		},
+	}
+	expected := []imagespec.Platform{
+		{
+			Architecture: "amd64",
+			OS:           "windows",
+			OSVersion:    "10.0.22000",
+		},
+		{
+			Architecture: "amd64",
+			OS:           "windows",
+			OSVersion:    "10.0.20348.169",
 		},
 	}
 	sort.SliceStable(platforms, func(i, j int) bool {

--- a/platforms/defaults_windows_test.go
+++ b/platforms/defaults_windows_test.go
@@ -273,7 +273,7 @@ func TestMatchComparerLess(t *testing.T) {
 }
 
 func TestMatchComparerClientOSMatch(t *testing.T) {
-	m := windowsmatcher{
+	m1 := windowsmatcher{
 		Platform:        DefaultSpec(),
 		osVersionPrefix: "10.0.22000",
 		defaultMatcher: &matcher{
@@ -281,6 +281,16 @@ func TestMatchComparerClientOSMatch(t *testing.T) {
 		},
 		isClientOS: true,
 	}
+
+	m2 := windowsmatcher{
+		Platform:        DefaultSpec(),
+		osVersionPrefix: "10.0.22621",
+		defaultMatcher: &matcher{
+			Platform: Normalize(DefaultSpec()),
+		},
+		isClientOS: true,
+	}
+
 	for _, test := range []struct {
 		platform imagespec.Platform
 		match    bool
@@ -324,14 +334,23 @@ func TestMatchComparerClientOSMatch(t *testing.T) {
 			match: false,
 		},
 	} {
-		assert.Equal(t, test.match, m.Match(test.platform), "should match %b, %s to %s", test.match, m.Platform, test.platform)
+		assert.Equal(t, test.match, m1.Match(test.platform), "should match %b, %s to %s", test.match, m1.Platform, test.platform)
+		assert.Equal(t, test.match, m2.Match(test.platform), "should match %b, %s to %s", test.match, m2.Platform, test.platform)
 	}
 }
 
 func TestMatchComparerClientOSPriority(t *testing.T) {
-	m := windowsmatcher{
+	m1 := windowsmatcher{
 		Platform:        DefaultSpec(),
 		osVersionPrefix: "10.0.22000",
+		defaultMatcher: &matcher{
+			Platform: Normalize(DefaultSpec()),
+		},
+		isClientOS: true,
+	}
+	m2 := windowsmatcher{
+		Platform:        DefaultSpec(),
+		osVersionPrefix: "10.0.22621",
 		defaultMatcher: &matcher{
 			Platform: Normalize(DefaultSpec()),
 		},
@@ -362,7 +381,11 @@ func TestMatchComparerClientOSPriority(t *testing.T) {
 		},
 	}
 	sort.SliceStable(platforms, func(i, j int) bool {
-		return m.Less(platforms[i], platforms[j])
+		return m1.Less(platforms[i], platforms[j])
+	})
+	assert.Equal(t, expected, platforms)
+	sort.SliceStable(platforms, func(i, j int) bool {
+		return m2.Less(platforms[i], platforms[j])
 	})
 	assert.Equal(t, expected, platforms)
 }

--- a/platforms/platforms_windows.go
+++ b/platforms/platforms_windows.go
@@ -18,7 +18,23 @@ package platforms
 
 import (
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/sys/windows/registry"
 )
+
+func isClientOS() bool {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows NT\CurrentVersion`, registry.QUERY_VALUE)
+	if err != nil {
+		return false
+	}
+	defer k.Close()
+
+	installationType, _, err := k.GetStringValue("InstallationType")
+	if err != nil {
+		return false
+	}
+
+	return installationType == "Client"
+}
 
 // NewMatcher returns a Windows matcher that will match on osVersionPrefix if
 // the platform is Windows otherwise use the default matcher
@@ -30,5 +46,6 @@ func newDefaultMatcher(platform specs.Platform) Matcher {
 		defaultMatcher: &matcher{
 			Platform: Normalize(platform),
 		},
+		isClientOS: isClientOS(),
 	}
 }


### PR DESCRIPTION
Windows 11 clients support running process-isolated containers of 10.0.20348 and above. Or to put it another way, Windows 11 clients can run Windows Server 2022 containers even when their build numbers don't match. Docker Engine already supports this scenario; this change updates containerd to make it also support this scenario.

The [container/OS version compatibility page](https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility?tabs=windows-server-2022%2Cwindows-11#windows-client-host-os-compatibility) documents this level of compatibility between the client OS and server OS versions.

I didn't explicitly add support for Windows 10 clients as the current version of Windows 10 is no longer compatible with the LTSC2019 container images, and there's no way to downgrade a Windows 10 install to the required version. Windows 11 compatibility with LTSC2022 is much more stable in practice than Windows 10, and Microsoft is committed to permitting any combination of Windows Server 2022 images and Windows 11 clients as outlined in the [Windows Server 2022 and beyond for containers blog post](https://techcommunity.microsoft.com/t5/containers/windows-server-2022-and-beyond-for-containers/ba-p/2712487).