### PR TITLE
Add Fields type alias to log package

### DIFF
--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -174,7 +174,7 @@ can be used and modified as necessary as a custom configuration.`
 			log.G(ctx).WithError(w).Warn("cleanup temp mount")
 		}
 
-		log.G(ctx).WithFields(logrus.Fields{
+		log.G(ctx).WithFields(log.Fields{
 			"version":  version.Version,
 			"revision": version.Revision,
 		}).Info("starting containerd")

--- a/cmd/ctr/commands/content/prune.go
+++ b/cmd/ctr/commands/content/prune.go
@@ -81,7 +81,7 @@ var pruneReferencesCommand = cli.Command{
 
 			for k := range info.Labels {
 				if isLayerLabel(k) {
-					log.G(ctx).WithFields(logrus.Fields{
+					log.G(ctx).WithFields(log.Fields{
 						"digest": info.Digest,
 						"label":  k,
 					}).Debug("Removing label")

--- a/diff/apply/apply.go
+++ b/diff/apply/apply.go
@@ -28,7 +28,6 @@ import (
 	"github.com/containerd/containerd/mount"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 )
 
 // NewFileSystemApplier returns an applier which simply mounts
@@ -52,7 +51,7 @@ func (s *fsApplier) Apply(ctx context.Context, desc ocispec.Descriptor, mounts [
 	t1 := time.Now()
 	defer func() {
 		if err == nil {
-			log.G(ctx).WithFields(logrus.Fields{
+			log.G(ctx).WithFields(log.Fields{
 				"d":      time.Since(t1),
 				"digest": desc.Digest,
 				"size":   desc.Size,

--- a/diff/lcow/lcow.go
+++ b/diff/lcow/lcow.go
@@ -39,7 +39,6 @@ import (
 	"github.com/containerd/containerd/plugin"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -99,7 +98,7 @@ func (s windowsLcowDiff) Apply(ctx context.Context, desc ocispec.Descriptor, mou
 	t1 := time.Now()
 	defer func() {
 		if err == nil {
-			log.G(ctx).WithFields(logrus.Fields{
+			log.G(ctx).WithFields(log.Fields{
 				"d":      time.Since(t1),
 				"digest": desc.Digest,
 				"size":   desc.Size,

--- a/diff/windows/windows.go
+++ b/diff/windows/windows.go
@@ -42,7 +42,6 @@ import (
 	"github.com/containerd/containerd/plugin"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 )
 
 func init() {
@@ -94,7 +93,7 @@ func (s windowsDiff) Apply(ctx context.Context, desc ocispec.Descriptor, mounts 
 	t1 := time.Now()
 	defer func() {
 		if err == nil {
-			log.G(ctx).WithFields(logrus.Fields{
+			log.G(ctx).WithFields(log.Fields{
 				"d":      time.Since(t1),
 				"digest": desc.Digest,
 				"size":   desc.Size,
@@ -295,7 +294,7 @@ func (s windowsDiff) Compare(ctx context.Context, lower, upper []mount.Mount, op
 		Digest:    info.Digest,
 	}
 
-	log.G(ctx).WithFields(logrus.Fields{
+	log.G(ctx).WithFields(log.Fields{
 		"d":     time.Since(t1),
 		"dgst":  desc.Digest,
 		"size":  desc.Size,

--- a/events/exchange/exchange.go
+++ b/events/exchange/exchange.go
@@ -30,7 +30,6 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/typeurl/v2"
 	goevents "github.com/docker/go-events"
-	"github.com/sirupsen/logrus"
 )
 
 // Exchange broadcasts events
@@ -59,7 +58,7 @@ func (e *Exchange) Forward(ctx context.Context, envelope *events.Envelope) (err 
 	}
 
 	defer func() {
-		logger := log.G(ctx).WithFields(logrus.Fields{
+		logger := log.G(ctx).WithFields(log.Fields{
 			"topic": envelope.Topic,
 			"ns":    envelope.Namespace,
 			"type":  envelope.Event.GetTypeUrl(),
@@ -103,7 +102,7 @@ func (e *Exchange) Publish(ctx context.Context, topic string, event events.Event
 	envelope.Event = encoded
 
 	defer func() {
-		logger := log.G(ctx).WithFields(logrus.Fields{
+		logger := log.G(ctx).WithFields(log.Fields{
 			"topic": envelope.Topic,
 			"ns":    envelope.Namespace,
 			"type":  envelope.Event.GetTypeUrl(),

--- a/integration/client/client_test.go
+++ b/integration/client/client_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 	exec "golang.org/x/sys/execabs"
@@ -123,7 +122,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// allow comparison with containerd under test
-	log.G(ctx).WithFields(logrus.Fields{
+	log.G(ctx).WithFields(log.Fields{
 		"version":     version.Version,
 		"revision":    version.Revision,
 		"runtime":     os.Getenv("TEST_RUNTIME"),

--- a/integration/client/go.mod
+++ b/integration/client/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b
 	github.com/opencontainers/runtime-spec v1.0.3-0.20220825212826-86290f6a00fb
-	github.com/sirupsen/logrus v1.9.0
+	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/stretchr/testify v1.8.1
 	go.opentelemetry.io/otel v1.12.0
 	go.opentelemetry.io/otel/sdk v1.12.0

--- a/log/context.go
+++ b/log/context.go
@@ -35,6 +35,9 @@ var (
 
 type (
 	loggerKey struct{}
+
+	// Fields type to pass to `WithFields`, alias from `logrus`.
+	Fields = logrus.Fields
 )
 
 const (

--- a/pkg/transfer/local/pull.go
+++ b/pkg/transfer/local/pull.go
@@ -29,7 +29,6 @@ import (
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 )
 
 func (ts *localTransferService) pull(ctx context.Context, ir transfer.ImageFetcher, is transfer.ImageStorer, tops *transfer.Config) error {
@@ -223,7 +222,7 @@ func (ts *localTransferService) pull(ctx context.Context, ir transfer.ImageFetch
 
 func fetchHandler(ingester content.Ingester, fetcher remotes.Fetcher, pt *ProgressTracker) images.HandlerFunc {
 	return func(ctx context.Context, desc ocispec.Descriptor) (subdescs []ocispec.Descriptor, err error) {
-		ctx = log.WithLogger(ctx, log.G(ctx).WithFields(logrus.Fields{
+		ctx = log.WithLogger(ctx, log.G(ctx).WithFields(log.Fields{
 			"digest":    desc.Digest,
 			"mediatype": desc.MediaType,
 			"size":      desc.Size,

--- a/pkg/unpack/unpacker.go
+++ b/pkg/unpack/unpacker.go
@@ -43,7 +43,6 @@ import (
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 )
@@ -437,7 +436,7 @@ func (u *Unpacker) unpack(
 	if err != nil {
 		return err
 	}
-	log.G(ctx).WithFields(logrus.Fields{
+	log.G(ctx).WithFields(log.Fields{
 		"config":  config.Digest,
 		"chainID": chainID,
 	}).Debug("image unpacked")

--- a/remotes/docker/authorizer.go
+++ b/remotes/docker/authorizer.go
@@ -29,7 +29,6 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/remotes/docker/auth"
 	remoteerrors "github.com/containerd/containerd/remotes/errors"
-	"github.com/sirupsen/logrus"
 )
 
 type dockerAuthorizer struct {
@@ -312,7 +311,7 @@ func (ah *authHandler) doBearerAuth(ctx context.Context) (token, refreshToken st
 					}
 					return resp.Token, resp.RefreshToken, nil
 				}
-				log.G(ctx).WithFields(logrus.Fields{
+				log.G(ctx).WithFields(log.Fields{
 					"status": errStatus.Status,
 					"body":   string(errStatus.Body),
 				}).Debugf("token request failed")

--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -38,7 +38,6 @@ import (
 	"github.com/containerd/containerd/version"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -647,7 +646,7 @@ func (r *request) String() string {
 	return r.host.Scheme + "://" + r.host.Host + r.path
 }
 
-func requestFields(req *http.Request) logrus.Fields {
+func requestFields(req *http.Request) log.Fields {
 	fields := map[string]interface{}{
 		"request.method": req.Method,
 	}
@@ -665,10 +664,10 @@ func requestFields(req *http.Request) logrus.Fields {
 		}
 	}
 
-	return logrus.Fields(fields)
+	return log.Fields(fields)
 }
 
-func responseFields(resp *http.Response) logrus.Fields {
+func responseFields(resp *http.Response) log.Fields {
 	fields := map[string]interface{}{
 		"response.status": resp.Status,
 	}
@@ -683,7 +682,7 @@ func responseFields(resp *http.Response) logrus.Fields {
 		}
 	}
 
-	return logrus.Fields(fields)
+	return log.Fields(fields)
 }
 
 // IsLocalhost checks if the registry host is local.

--- a/remotes/handlers.go
+++ b/remotes/handlers.go
@@ -31,7 +31,6 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/platforms"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -91,7 +90,7 @@ func MakeRefKey(ctx context.Context, desc ocispec.Descriptor) string {
 // recursive fetch.
 func FetchHandler(ingester content.Ingester, fetcher Fetcher) images.HandlerFunc {
 	return func(ctx context.Context, desc ocispec.Descriptor) (subdescs []ocispec.Descriptor, err error) {
-		ctx = log.WithLogger(ctx, log.G(ctx).WithFields(logrus.Fields{
+		ctx = log.WithLogger(ctx, log.G(ctx).WithFields(log.Fields{
 			"digest":    desc.Digest,
 			"mediatype": desc.MediaType,
 			"size":      desc.Size,
@@ -157,7 +156,7 @@ func Fetch(ctx context.Context, ingester content.Ingester, fetcher Fetcher, desc
 // using a writer from the pusher.
 func PushHandler(pusher Pusher, provider content.Provider) images.HandlerFunc {
 	return func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-		ctx = log.WithLogger(ctx, log.G(ctx).WithFields(logrus.Fields{
+		ctx = log.WithLogger(ctx, log.G(ctx).WithFields(log.Fields{
 			"digest":    desc.Digest,
 			"mediatype": desc.MediaType,
 			"size":      desc.Size,

--- a/runtime/v1/linux/runtime.go
+++ b/runtime/v1/linux/runtime.go
@@ -50,7 +50,6 @@ import (
 	"github.com/containerd/go-runc"
 	"github.com/containerd/typeurl/v2"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
@@ -166,7 +165,7 @@ func (r *Runtime) Create(ctx context.Context, id string, opts runtime.CreateOpts
 	if err != nil {
 		return nil, err
 	}
-	ctx = log.WithLogger(ctx, log.G(ctx).WithError(err).WithFields(logrus.Fields{
+	ctx = log.WithLogger(ctx, log.G(ctx).WithError(err).WithFields(log.Fields{
 		"id":        id,
 		"namespace": namespace,
 	}))
@@ -361,7 +360,7 @@ func (r *Runtime) loadTasks(ctx context.Context, ns string) ([]*Task, error) {
 			filepath.Join(r.root, ns, id),
 		)
 		ctx = namespaces.WithNamespace(ctx, ns)
-		ctx = log.WithLogger(ctx, log.G(ctx).WithError(err).WithFields(logrus.Fields{
+		ctx = log.WithLogger(ctx, log.G(ctx).WithError(err).WithFields(log.Fields{
 			"id":        id,
 			"namespace": ns,
 		}))
@@ -489,7 +488,7 @@ func (r *Runtime) terminate(ctx context.Context, bundle *bundle, ns, id string) 
 		log.G(ctx).WithError(err).Warnf("delete runtime state %s", id)
 	}
 	if err := mount.Unmount(filepath.Join(bundle.path, "rootfs"), 0); err != nil {
-		log.G(ctx).WithError(err).WithFields(logrus.Fields{
+		log.G(ctx).WithError(err).WithFields(log.Fields{
 			"path": bundle.path,
 			"id":   id,
 		}).Warnf("unmount task rootfs")

--- a/runtime/v1/shim/client/client.go
+++ b/runtime/v1/shim/client/client.go
@@ -40,7 +40,6 @@ import (
 	shimapi "github.com/containerd/containerd/runtime/v1/shim/v1"
 	"github.com/containerd/containerd/sys"
 	"github.com/containerd/ttrpc"
-	"github.com/sirupsen/logrus"
 	exec "golang.org/x/sys/execabs"
 	"golang.org/x/sys/unix"
 )
@@ -115,7 +114,7 @@ func WithStart(binary, address, daemonAddress, cgroup string, debug bool, exitHa
 			socket.Close()
 			RemoveSocket(address)
 		}()
-		log.G(ctx).WithFields(logrus.Fields{
+		log.G(ctx).WithFields(log.Fields{
 			"pid":     cmd.Process.Pid,
 			"address": address,
 			"debug":   debug,
@@ -132,7 +131,7 @@ func WithStart(binary, address, daemonAddress, cgroup string, debug bool, exitHa
 			if err := setCgroup(cgroup, cmd); err != nil {
 				return nil, nil, err
 			}
-			log.G(ctx).WithFields(logrus.Fields{
+			log.G(ctx).WithFields(log.Fields{
 				"pid":     cmd.Process.Pid,
 				"address": address,
 			}).Infof("shim placed in cgroup %s", cgroup)

--- a/runtime/v1/shim/service.go
+++ b/runtime/v1/shim/service.go
@@ -82,7 +82,7 @@ func NewService(config Config, publisher events.Publisher) (*Service, error) {
 		return nil, fmt.Errorf("shim namespace cannot be empty")
 	}
 	ctx := namespaces.WithNamespace(context.Background(), config.Namespace)
-	ctx = log.WithLogger(ctx, logrus.WithFields(logrus.Fields{
+	ctx = log.WithLogger(ctx, logrus.WithFields(log.Fields{
 		"namespace": config.Namespace,
 		"path":      config.Path,
 		"pid":       os.Getpid(),

--- a/runtime/v2/shim/shim.go
+++ b/runtime/v2/shim/shim.go
@@ -315,7 +315,7 @@ func run(ctx context.Context, manager Manager, initFunc Init, name string, confi
 		if debugFlag {
 			logrus.SetLevel(logrus.DebugLevel)
 		}
-		logger := log.G(ctx).WithFields(logrus.Fields{
+		logger := log.G(ctx).WithFields(log.Fields{
 			"pid":       os.Getpid(),
 			"namespace": namespaceFlag,
 		})
@@ -494,7 +494,7 @@ func serve(ctx context.Context, server *ttrpc.Server, signals chan os.Signal, sh
 			log.G(ctx).WithError(err).Fatal("containerd-shim: ttrpc server failure")
 		}
 	}()
-	logger := log.G(ctx).WithFields(logrus.Fields{
+	logger := log.G(ctx).WithFields(log.Fields{
 		"pid":       os.Getpid(),
 		"path":      path,
 		"namespace": namespaceFlag,

--- a/services/content/contentserver/contentserver.go
+++ b/services/content/contentserver/contentserver.go
@@ -30,7 +30,6 @@ import (
 	ptypes "github.com/containerd/containerd/protobuf/types"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -295,7 +294,7 @@ func (s *service) Write(session api.Content_WriteServer) (err error) {
 		return status.Errorf(codes.InvalidArgument, "first message must have a reference")
 	}
 
-	fields := logrus.Fields{
+	fields := log.Fields{
 		"ref": ref,
 	}
 	total = req.Total

--- a/snapshots/btrfs/btrfs.go
+++ b/snapshots/btrfs/btrfs.go
@@ -363,7 +363,7 @@ func (b *snapshotter) Remove(ctx context.Context, key string) (err error) {
 		if restore { // means failed to commit transaction
 			// Attempt to restore source
 			if err1 := btrfs.SubvolSnapshot(source, removed, readonly); err1 != nil {
-				log.G(ctx).WithFields(logrus.Fields{
+				log.G(ctx).WithFields(log.Fields{
 					logrus.ErrorKey: err1,
 					"subvolume":     source,
 					"renamed":       removed,

--- a/snapshots/devmapper/snapshotter.go
+++ b/snapshots/devmapper/snapshotter.go
@@ -34,7 +34,6 @@ import (
 	"github.com/containerd/containerd/snapshots/devmapper/dmsetup"
 	"github.com/containerd/containerd/snapshots/storage"
 	"github.com/hashicorp/go-multierror"
-	"github.com/sirupsen/logrus"
 	exec "golang.org/x/sys/execabs"
 )
 
@@ -201,7 +200,7 @@ func (s *Snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, er
 
 // Prepare creates thin device for an active snapshot identified by key
 func (s *Snapshotter) Prepare(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
-	log.G(ctx).WithFields(logrus.Fields{"key": key, "parent": parent}).Debug("prepare")
+	log.G(ctx).WithFields(log.Fields{"key": key, "parent": parent}).Debug("prepare")
 
 	var (
 		mounts []mount.Mount
@@ -218,7 +217,7 @@ func (s *Snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 
 // View creates readonly thin device for the given snapshot key
 func (s *Snapshotter) View(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
-	log.G(ctx).WithFields(logrus.Fields{"key": key, "parent": parent}).Debug("view")
+	log.G(ctx).WithFields(log.Fields{"key": key, "parent": parent}).Debug("view")
 
 	var (
 		mounts []mount.Mount
@@ -237,7 +236,7 @@ func (s *Snapshotter) View(ctx context.Context, key, parent string, opts ...snap
 // Block device unmount operation captures snapshot changes by itself, so no
 // additional actions needed within Commit operation.
 func (s *Snapshotter) Commit(ctx context.Context, name, key string, opts ...snapshots.Opt) error {
-	log.G(ctx).WithFields(logrus.Fields{"name": name, "key": key}).Debug("commit")
+	log.G(ctx).WithFields(log.Fields{"name": name, "key": key}).Debug("commit")
 
 	return s.store.WithTransaction(ctx, true, func(ctx context.Context) error {
 		id, snapInfo, _, err := storage.GetInfo(ctx, key)


### PR DESCRIPTION
When logging with custom fields, like:

```go
log.G(ctx).WithFields(logrus.Fields{ ... })...
```

you're forced to do two imports

```go
"github.com/containerd/containerd/log"
"github.com/sirupsen/logrus"
```

This PR adds a type alias to log package, so we end up with just one import:

```go
"github.com/containerd/containerd/log"

log.G(ctx).WithFields(log.Fields{})
```

Which often reduces the number of imports and makes log package a bit nicer.