### PR TITLE
Fix media type not found issue in checkpoint & restore

### DIFF
--- a/cmd/ctr/commands/containers/checkpoint.go
+++ b/cmd/ctr/commands/containers/checkpoint.go
@@ -60,6 +60,7 @@ var checkpointCommand = cli.Command{
 		defer cancel()
 		opts := []containerd.CheckpointOpts{
 			containerd.WithCheckpointRuntime,
+			containerd.WithCheckpointTask,
 		}
 
 		if context.Bool("image") {
@@ -67,9 +68,6 @@ var checkpointCommand = cli.Command{
 		}
 		if context.Bool("rw") {
 			opts = append(opts, containerd.WithCheckpointRW)
-		}
-		if context.Bool("task") {
-			opts = append(opts, containerd.WithCheckpointTask)
 		}
 		container, err := client.LoadContainer(ctx, id)
 		if err != nil {

--- a/services/tasks/local.go
+++ b/services/tasks/local.go
@@ -697,7 +697,9 @@ func (l *local) writeContent(ctx context.Context, mediaType, ref string, r io.Re
 		return nil, err
 	}
 	if err := writer.Commit(ctx, 0, ""); err != nil {
-		return nil, err
+		if !errdefs.IsAlreadyExists(err) {
+			return nil, err
+		}
 	}
 	return &types.Descriptor{
 		MediaType:   mediaType,


### PR DESCRIPTION
Address https://github.com/containerd/containerd/issues/7980

I found at least two scenarios would lead to `ctr: media type not found`

1. Checkpoint phase - first checkpoint action will dump 3 layers(1.1KiB total). But 2nd checkpoint action now miss those 3 layers(only 484B in total).

```
hehe-first-snap                      application/vnd.oci.image.index.v1+json                   sha256:43683ef5326f1a20cf406008382c00e2940d6e09a3e10e57bc93edd792196e55 1.1 KiB  linux/amd64                                                                                             
hehe-second-snap                application/vnd.oci.image.index.v1+json                   sha256:22b499dddf4bb3cd6bba83c96bd2d9111e013c01bb7387976cc8e822dcdf9977 484.0 B  linux/amd64
```

```
application/vnd.containerd.container.criu.checkpoint.criu.tar
application/vnd.containerd.container.checkpoint.config.v1+proto
application/vnd.containerd.container.checkpoint.options.v1+proto
```

commands to reproduce
```
ctr c checkpoint --task counter counter-snap
ctr c restore counter01 counter-snap
```

This is due to the logic here. If the layer has been committed locally, it should include the layers but not silently skip them. Otherwise, restore will not find the layer for sure. 
https://github.com/containerd/containerd/blob/8cb00f45c973b017f403d05d4d208ab2971ff335/services/tasks/local.go#L699-L701


2. checkpoint makes `tasks` optional, however, in restore process, runtime config is required. optional `--task` makes no sense and this should be included as the default option.

```
ctr c checkpoint counter counter-snap
ctr c restore counter01 counter-snap
```

https://github.com/containerd/containerd/blob/8cb00f45c973b017f403d05d4d208ab2971ff335/cmd/ctr/commands/containers/checkpoint.go#L71-L73

https://github.com/containerd/containerd/blob/8cb00f45c973b017f403d05d4d208ab2971ff335/cmd/ctr/commands/containers/restore.go#L74-L77