### PR TITLE
CRI: add image distribution helper to share registry credential

### DIFF
--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -152,8 +152,8 @@ version = 2
   tolerate_missing_hugetlb_controller = true
 
   # ignore_image_defined_volumes ignores volumes defined by the image. Useful for better resource
-	# isolation, security and early detection of issues in the mount configuration when using
-	# ReadOnlyRootFilesystem since containers won't silently mount a temporary volume.
+  # isolation, security and early detection of issues in the mount configuration when using
+  # ReadOnlyRootFilesystem since containers won't silently mount a temporary volume.
   ignore_image_defined_volumes = false
 
   # netns_mounts_under_state_dir places all mounts for network namespaces under StateDir/netns
@@ -280,6 +280,10 @@ version = 2
     # 'plugins."io.containerd.grpc.v1.cri".containerd.default_runtime' is the runtime to use in containerd.
     # DEPRECATED: use `default_runtime_name` and `plugins."io.containerd.grpc.v1.cri".containerd.runtimes` instead.
     [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
+
+    # Binary plugin helps share the registry credentials to remote snapshotter enabling it to directly access the registry.
+    [plugins."io.containerd.grpc.v1.cri".containerd.image_distribution_helper]
+      bin_path = ""
 
     # 'plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime' is a runtime to run untrusted workloads on it.
     # DEPRECATED: use `untrusted` runtime in `plugins."io.containerd.grpc.v1.cri".containerd.runtimes` instead.

--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -113,6 +113,9 @@ type ContainerdConfig struct {
 	// IgnoreRdtNotEnabledErrors is a boolean flag to ignore RDT related errors
 	// when RDT support has not been enabled.
 	IgnoreRdtNotEnabledErrors bool `toml:"ignore_rdt_not_enabled_errors" json:"ignoreRdtNotEnabledErrors"`
+
+	// A binary plugin shares the registry credentials to remote snapshotter
+	ImageDistributionHelper ImageDistributionHelper `toml:"image_distribution_helper"`
 }
 
 // CniConfig contains toml config related to cni
@@ -338,6 +341,10 @@ type PluginConfig struct {
 	//
 	// For example, the value can be '5h', '2h30m', '10s'.
 	DrainExecSyncIOTimeout string `toml:"drain_exec_sync_io_timeout" json:"drainExecSyncIOTimeout"`
+}
+
+type ImageDistributionHelper struct {
+	BinaryPath string `toml:"bin_path"`
 }
 
 // X509KeyPairStreaming contains the x509 configuration for streaming

--- a/pkg/cri/sbserver/images/image_distribution_helper.go
+++ b/pkg/cri/sbserver/images/image_distribution_helper.go
@@ -1,0 +1,78 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package images
+
+import (
+	"bytes"
+	"encoding/json"
+	"os/exec"
+
+	"github.com/containerd/containerd/pkg/cri/config"
+	"github.com/pkg/errors"
+	v1 "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+type ImagePullCreds struct {
+	Host   string `json:"host"`
+	User   string `json:"user"`
+	Secret string `json:"secret"`
+}
+
+func ImageDistributionHelperEnabled(c *config.Config) bool {
+	return c.ImageDistributionHelper.BinaryPath != ""
+}
+
+func GetImageDistributionHelperBinary(c *config.Config) string {
+	return c.ImageDistributionHelper.BinaryPath
+}
+
+func prepareCreds(host string, auth *v1.AuthConfig) ([]byte, error) {
+	user, secret, err := ParseAuth(auth, host)
+	if err != nil {
+		return nil, errors.Wrap(err, "parse auth")
+	}
+
+	pullCreds := ImagePullCreds{
+
+		Host:   host,
+		User:   user,
+		Secret: secret,
+	}
+
+	jo, err := json.Marshal(&pullCreds)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal credential")
+	}
+
+	return jo, nil
+}
+
+func InvokeImageDistributionHelper(c *config.Config, host string, auth *v1.AuthConfig) error {
+	creds, err := prepareCreds(host, auth)
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command(GetImageDistributionHelperBinary(c))
+	cmd.Stdin = bytes.NewBuffer(creds)
+
+	if err := cmd.Run(); err != nil {
+		return errors.Wrap(err, "invoke image distribution hook")
+	}
+
+	return nil
+}

--- a/pkg/cri/sbserver/images/image_pull.go
+++ b/pkg/cri/sbserver/images/image_pull.go
@@ -183,6 +183,14 @@ func (c *CRIImageService) PullImage(ctx context.Context, r *runtime.PullImageReq
 	}
 
 	pullReporter.start(pctx)
+
+	if ImageDistributionHelperEnabled(&c.config) && r.Auth != nil {
+		host := distribution.Domain(namedRef)
+		if err := InvokeImageDistributionHelper(&c.config, host, r.Auth); err != nil {
+			log.G(ctx).WithError(err).Warnf("Invoke image distribution helper failed")
+		}
+	}
+
 	image, err := c.client.Pull(pctx, ref, pullOpts...)
 	pcancel()
 	if err != nil {

--- a/pkg/cri/server/image_distribution_helper.go
+++ b/pkg/cri/server/image_distribution_helper.go
@@ -1,0 +1,77 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"os/exec"
+
+	"github.com/containerd/containerd/pkg/cri/config"
+	"github.com/pkg/errors"
+	v1 "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+type ImagePullCreds struct {
+	Host   string `json:"host"`
+	User   string `json:"user"`
+	Secret string `json:"secret"`
+}
+
+func ImageDistributionHelperEnabled(c *config.Config) bool {
+	return c.ImageDistributionHelper.BinaryPath != ""
+}
+
+func GetImageDistributionHelperBinary(c *config.Config) string {
+	return c.ImageDistributionHelper.BinaryPath
+}
+
+func prepareCreds(host string, auth *v1.AuthConfig) ([]byte, error) {
+	user, secret, err := ParseAuth(auth, host)
+	if err != nil {
+		return nil, errors.Wrap(err, "parse auth")
+	}
+
+	pullCreds := ImagePullCreds{
+		Host:   host,
+		User:   user,
+		Secret: secret,
+	}
+
+	jo, err := json.Marshal(&pullCreds)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal credential")
+	}
+
+	return jo, nil
+}
+
+func InvokeImageDistributionHelper(c *config.Config, host string, auth *v1.AuthConfig) error {
+	creds, err := prepareCreds(host, auth)
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command(GetImageDistributionHelperBinary(c))
+	cmd.Stdin = bytes.NewBuffer(creds)
+
+	if err := cmd.Run(); err != nil {
+		return errors.Wrap(err, "invoke image distribution hook")
+	}
+
+	return nil
+}

--- a/pkg/cri/server/image_distribution_helper_test.go
+++ b/pkg/cri/server/image_distribution_helper_test.go
@@ -1,0 +1,86 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	criconfig "github.com/containerd/containerd/pkg/cri/config"
+	"github.com/containerd/containerd/services/server/config"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+func TestPrepareCreds(t *testing.T) {
+	auth := v1.AuthConfig{
+		Username: "useruser",
+		Password: "userpassword",
+	}
+
+	data, err := prepareCreds("ghcr.io", &auth)
+	assert.NoError(t, err)
+
+	creds := ImagePullCreds{}
+
+	err = json.Unmarshal(data, &creds)
+	assert.NoError(t, err)
+
+	assert.Equal(t, creds, ImagePullCreds{Host: "ghcr.io", User: "useruser", Secret: "userpassword"})
+}
+
+func TestLoadConfig(t *testing.T) {
+	c := `
+version = 2
+root = "/var/lib/containerd"
+state = "/run/containerd"
+
+[grpc]
+  max_recv_message_size = 16777216
+  max_send_message_size = 16777216
+
+[debug]
+  address = "/run/containerd/debug.sock"
+
+[plugins."io.containerd.grpc.v1.cri"]
+  stream_server_address = "127.0.0.1"
+  max_container_log_line_size = -1
+  disable_cgroup = false
+  [plugins."io.containerd.grpc.v1.cri".containerd]
+    default_runtime_name = "runc"
+    [plugins."io.containerd.grpc.v1.cri".containerd.image_distribution_helper]
+      bin_path = "/opt/containerd-idp-nydus"
+	`
+
+	tmpFile, err := os.CreateTemp("", "config_test.toml")
+	assert.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	tmpFile.Write([]byte(c))
+
+	var containerdConfig config.Config
+
+	config.LoadConfig(tmpFile.Name(), &containerdConfig)
+
+	data := containerdConfig.Plugins["io.containerd.grpc.v1.cri"]
+
+	var criConfig criconfig.Config
+	err = data.Unmarshal(&criConfig)
+	assert.NoError(t, err)
+	assert.Equal(t, GetImageDistributionHelperBinary(&criConfig), "/opt/containerd-idp-nydus")
+}

--- a/pkg/cri/server/image_pull.go
+++ b/pkg/cri/server/image_pull.go
@@ -180,6 +180,14 @@ func (c *criService) PullImage(ctx context.Context, r *runtime.PullImageRequest)
 	}
 
 	pullReporter.start(pctx)
+
+	if ImageDistributionHelperEnabled(&c.config) && r.Auth != nil {
+		host := distribution.Domain(namedRef)
+		if err := InvokeImageDistributionHelper(&c.config, host, r.Auth); err != nil {
+			log.G(ctx).WithError(err).Warnf("Invoke image distribution helper failed")
+		}
+	}
+
 	image, err := c.client.Pull(pctx, ref, pullOpts...)
 	pcancel()
 	if err != nil {


### PR DESCRIPTION
Remote snapshotter might download image layers on-demand a.k.a lazy-load. So it needs the registry credential to access the registry.

This change tries to add a containerd binary plugin called image distribution helper to share the credential to remote snapshotters before the image is pulled.

This PR tries to implement what we discussed in https://github.com/containerd/containerd/issues/5105.

It can benefit current remote snapshotters like stargz, nydus, overlaybd, and soci

to enable the plugin, add an item to containerd's config file

```toml
    [plugins."io.containerd.grpc.v1.cri".containerd.image_distribution_helper]
      bin_path = "/opt/containerd-idp-nydus"
```

TODO:
- [x] More detailed documents should be added to introduce the plugin
- [x] More tests should be accompanied 