### PR TITLE
shim client close after create is finished

### DIFF
--- a/runtime/v2/manager.go
+++ b/runtime/v2/manager.go
@@ -429,6 +429,7 @@ func (m *TaskManager) Create(ctx context.Context, taskID string, opts runtime.Cr
 	if err != nil {
 		return nil, err
 	}
+	defer shimTask.Close()
 
 	t, err := shimTask.Create(ctx, opts)
 	if err != nil {
@@ -447,7 +448,6 @@ func (m *TaskManager) Create(ctx context.Context, taskID string, opts runtime.Cr
 			}
 
 			shimTask.Shutdown(dctx)
-			shimTask.Close()
 		}
 
 		return nil, fmt.Errorf("failed to create shim task: %w", err)


### PR DESCRIPTION
make sure that the shim creation task will close the ttrpc connection and the underlying connection