### PR TITLE
CRI: remove duplicated snapshotters code

### DIFF
--- a/pkg/cri/sbserver/image_pull.go
+++ b/pkg/cri/sbserver/image_pull.go
@@ -42,10 +42,10 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
 	containerdimages "github.com/containerd/containerd/images"
-	"github.com/containerd/containerd/labels"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/pkg/cri/annotations"
 	criconfig "github.com/containerd/containerd/pkg/cri/config"
+	snpkg "github.com/containerd/containerd/pkg/snapshotters"
 	distribution "github.com/containerd/containerd/reference/docker"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/containerd/containerd/remotes/docker/config"
@@ -171,7 +171,7 @@ func (c *criService) PullImage(ctx context.Context, r *runtime.PullImageRequest)
 	pullOpts = append(pullOpts, c.encryptedImagesPullOpts()...)
 	if !c.config.ContainerdConfig.DisableSnapshotAnnotations {
 		pullOpts = append(pullOpts,
-			containerd.WithImageHandlerWrapper(appendInfoHandlerWrapper(ref)))
+			containerd.WithImageHandlerWrapper(snpkg.AppendInfoHandlerWrapper(ref)))
 	}
 
 	if c.config.ContainerdConfig.DiscardUnpackedLayers {
@@ -551,76 +551,6 @@ func (c *criService) encryptedImagesPullOpts() []containerd.RemoteOpt {
 		return []containerd.RemoteOpt{opt}
 	}
 	return nil
-}
-
-const (
-	// targetRefLabel is a label which contains image reference and will be passed
-	// to snapshotters.
-	targetRefLabel = "containerd.io/snapshot/cri.image-ref"
-	// targetManifestDigestLabel is a label which contains manifest digest and will be passed
-	// to snapshotters.
-	targetManifestDigestLabel = "containerd.io/snapshot/cri.manifest-digest"
-	// targetLayerDigestLabel is a label which contains layer digest and will be passed
-	// to snapshotters.
-	targetLayerDigestLabel = "containerd.io/snapshot/cri.layer-digest"
-	// targetImageLayersLabel is a label which contains layer digests contained in
-	// the target image and will be passed to snapshotters for preparing layers in
-	// parallel. Skipping some layers is allowed and only affects performance.
-	targetImageLayersLabel = "containerd.io/snapshot/cri.image-layers"
-)
-
-// appendInfoHandlerWrapper makes a handler which appends some basic information
-// of images like digests for manifest and their child layers as annotations during unpack.
-// These annotations will be passed to snapshotters as labels. These labels will be
-// used mainly by stargz-based snapshotters for querying image contents from the
-// registry.
-func appendInfoHandlerWrapper(ref string) func(f containerdimages.Handler) containerdimages.Handler {
-	return func(f containerdimages.Handler) containerdimages.Handler {
-		return containerdimages.HandlerFunc(func(ctx context.Context, desc imagespec.Descriptor) ([]imagespec.Descriptor, error) {
-			children, err := f.Handle(ctx, desc)
-			if err != nil {
-				return nil, err
-			}
-			switch desc.MediaType {
-			case imagespec.MediaTypeImageManifest, containerdimages.MediaTypeDockerSchema2Manifest:
-				for i := range children {
-					c := &children[i]
-					if containerdimages.IsLayerType(c.MediaType) {
-						if c.Annotations == nil {
-							c.Annotations = make(map[string]string)
-						}
-						c.Annotations[targetRefLabel] = ref
-						c.Annotations[targetLayerDigestLabel] = c.Digest.String()
-						c.Annotations[targetImageLayersLabel] = getLayers(ctx, targetImageLayersLabel, children[i:], labels.Validate)
-						c.Annotations[targetManifestDigestLabel] = desc.Digest.String()
-					}
-				}
-			}
-			return children, nil
-		})
-	}
-}
-
-// getLayers returns comma-separated digests based on the passed list of
-// descriptors. The returned list contains as many digests as possible as well
-// as meets the label validation.
-func getLayers(ctx context.Context, key string, descs []imagespec.Descriptor, validate func(k, v string) error) (layers string) {
-	var item string
-	for _, l := range descs {
-		if containerdimages.IsLayerType(l.MediaType) {
-			item = l.Digest.String()
-			if layers != "" {
-				item = "," + item
-			}
-			// This avoids the label hits the size limitation.
-			if err := validate(key, layers+item); err != nil {
-				log.G(ctx).WithError(err).WithField("label", key).Debugf("%q is omitted in the layers list", l.Digest.String())
-				break
-			}
-			layers += item
-		}
-	}
-	return
 }
 
 const (

--- a/pkg/cri/sbserver/image_pull_test.go
+++ b/pkg/cri/sbserver/image_pull_test.go
@@ -20,11 +20,8 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"strings"
 	"testing"
 
-	"github.com/opencontainers/go-digest"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
@@ -334,51 +331,6 @@ func TestEncryptedImagePullOpts(t *testing.T) {
 			c.config.ImageDecryption.KeyModel = test.keyModel
 			got := len(c.encryptedImagesPullOpts())
 			assert.Equal(t, test.expectedOpts, got)
-		})
-	}
-}
-
-func TestImageLayersLabel(t *testing.T) {
-	sampleKey := "sampleKey"
-	sampleDigest, err := digest.Parse("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-	assert.NoError(t, err)
-	sampleMaxSize := 300
-	sampleValidate := func(k, v string) error {
-		if (len(k) + len(v)) > sampleMaxSize {
-			return fmt.Errorf("invalid: %q: %q", k, v)
-		}
-		return nil
-	}
-
-	tests := []struct {
-		name      string
-		layersNum int
-		wantNum   int
-	}{
-		{
-			name:      "valid number of layers",
-			layersNum: 2,
-			wantNum:   2,
-		},
-		{
-			name:      "many layers",
-			layersNum: 5, // hits sampleMaxSize (300 chars).
-			wantNum:   4, // layers should be omitted for avoiding invalid label.
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var sampleLayers []imagespec.Descriptor
-			for i := 0; i < tt.layersNum; i++ {
-				sampleLayers = append(sampleLayers, imagespec.Descriptor{
-					MediaType: imagespec.MediaTypeImageLayerGzip,
-					Digest:    sampleDigest,
-				})
-			}
-			gotS := getLayers(context.Background(), sampleKey, sampleLayers, sampleValidate)
-			got := len(strings.Split(gotS, ","))
-			assert.Equal(t, tt.wantNum, got)
 		})
 	}
 }


### PR DESCRIPTION
The snapshotter annotation definitions and related functions have been public in the new package snapshotter. So we can safely remove the duplicated code from CRI.