### PR TITLE
[release/1.6] Prepare release notes for v1.6.19

### DIFF
--- a/releases/v1.6.19.toml
+++ b/releases/v1.6.19.toml
@@ -1,0 +1,20 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release
+previous = "v1.6.18"
+
+pre_release = false
+
+preface = """\
+The nineteenth patch release for containerd 1.6 contains runtime fixes and additions for Windows platforms
+
+### Notable Updates
+
+* **Update hcsshim to v0.9.7 to include fix for graceful termination and pause containers ([#8153](https://github.com/containerd/containerd/pull/8153))
+
+See the changelog for complete list of changes"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.18+unknown"
+	Version = "1.6.19+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Welcome to the v1.6.19 release of containerd!

The nineteenth patch release for containerd 1.6 contains runtime fixes and additions for Windows platforms

### Notable Updates

* Update hcsshim to v0.9.7 to include fix for graceful termination and pause containers ([#8153](https://github.com/containerd/containerd/pull/8153))

See the changelog for complete list of changes

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Kirtana Ashok

### Changes
<details><summary>2 commits</summary>
<p>

* [release/1.6] go.mod: Bump hcsshim to v0.9.7 ([#8153](https://github.com/containerd/containerd/pull/8153))
  * [`f488a6241`](https://github.com/containerd/containerd/commit/f488a6241b7fa87746026de1a947c57d311751e8) Update hcsshim tag to v0.9.7
</p>
</details>

### Dependency Changes

* **github.com/Microsoft/hcsshim**  v0.9.6 -> v0.9.7

Previous release can be found at [v1.6.18](https://github.com/containerd/containerd/releases/tag/v1.6.18)