### PR TITLE
Initial split of sandboxed CRI service

### DIFF
--- a/pkg/cri/sbserver/container_create.go
+++ b/pkg/cri/sbserver/container_create.go
@@ -107,7 +107,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 
 	// Prepare container image snapshot. For container, the image should have
 	// been pulled before creating the container, so do not ensure the image.
-	image, err := c.localResolve(config.GetImage().GetImage())
+	image, err := c.LocalResolve(config.GetImage().GetImage())
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve image %q: %w", config.GetImage().GetImage(), err)
 	}
@@ -213,7 +213,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 
 	// Set snapshotter before any other options.
 	opts := []containerd.NewContainerOpts{
-		containerd.WithSnapshotter(c.runtimeSnapshotter(ctx, ociRuntime)),
+		containerd.WithSnapshotter(c.RuntimeSnapshotter(ctx, ociRuntime)),
 		// Prepare container rootfs. This is always writeable even if
 		// the container wants a readonly rootfs since we want to give
 		// the runtime (runc) a chance to modify (e.g. to create mount
@@ -398,17 +398,6 @@ func (c *criService) runtimeSpec(id string, platform platforms.Platform, baseSpe
 	}
 
 	return spec, nil
-}
-
-// Overrides the default snapshotter if Snapshotter is set for this runtime.
-// See https://github.com/containerd/containerd/issues/6657
-func (c *criService) runtimeSnapshotter(ctx context.Context, ociRuntime criconfig.Runtime) string {
-	if ociRuntime.Snapshotter == "" {
-		return c.config.ContainerdConfig.Snapshotter
-	}
-
-	log.G(ctx).Debugf("Set snapshotter for runtime %s to %s", ociRuntime.Type, ociRuntime.Snapshotter)
-	return ociRuntime.Snapshotter
 }
 
 const (

--- a/pkg/cri/sbserver/container_create_test.go
+++ b/pkg/cri/sbserver/container_create_test.go
@@ -435,35 +435,3 @@ func TestBaseRuntimeSpec(t *testing.T) {
 
 	assert.Equal(t, filepath.Join("/", constants.K8sContainerdNamespace, "id1"), out.Linux.CgroupsPath)
 }
-
-func TestRuntimeSnapshotter(t *testing.T) {
-	defaultRuntime := config.Runtime{
-		Snapshotter: "",
-	}
-
-	fooRuntime := config.Runtime{
-		Snapshotter: "devmapper",
-	}
-
-	for desc, test := range map[string]struct {
-		runtime           config.Runtime
-		expectSnapshotter string
-	}{
-		"should return default snapshotter when runtime.Snapshotter is not set": {
-			runtime:           defaultRuntime,
-			expectSnapshotter: config.DefaultConfig().Snapshotter,
-		},
-		"should return overridden snapshotter when runtime.Snapshotter is set": {
-			runtime:           fooRuntime,
-			expectSnapshotter: "devmapper",
-		},
-	} {
-		t.Run(desc, func(t *testing.T) {
-			cri := newTestCRIService()
-			cri.config = config.Config{
-				PluginConfig: config.DefaultConfig(),
-			}
-			assert.Equal(t, test.expectSnapshotter, cri.runtimeSnapshotter(context.Background(), test.runtime))
-		})
-	}
-}

--- a/pkg/cri/sbserver/container_stats_list_linux.go
+++ b/pkg/cri/sbserver/container_stats_list_linux.go
@@ -37,7 +37,7 @@ func (c *criService) containerMetrics(
 ) (*runtime.ContainerStats, error) {
 	var cs runtime.ContainerStats
 	var usedBytes, inodesUsed uint64
-	sn, err := c.snapshotStore.Get(meta.ID)
+	sn, err := c.GetSnapshot(meta.ID)
 	// If snapshotstore doesn't have cached snapshot information
 	// set WritableLayer usage to zero
 	if err == nil {

--- a/pkg/cri/sbserver/container_stats_list_windows.go
+++ b/pkg/cri/sbserver/container_stats_list_windows.go
@@ -34,7 +34,7 @@ func (c *criService) containerMetrics(
 ) (*runtime.ContainerStats, error) {
 	var cs runtime.ContainerStats
 	var usedBytes, inodesUsed uint64
-	sn, err := c.snapshotStore.Get(meta.ID)
+	sn, err := c.GetSnapshot(meta.ID)
 	// If snapshotstore doesn't have cached snapshot information
 	// set WritableLayer usage to zero
 	if err == nil {

--- a/pkg/cri/sbserver/container_status.go
+++ b/pkg/cri/sbserver/container_status.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/pkg/cri/sbserver/images"
 	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
 
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
@@ -42,13 +43,13 @@ func (c *criService) ContainerStatus(ctx context.Context, r *runtime.ContainerSt
 	// * ImageRef in container status is repo digest.
 	spec := container.Config.GetImage()
 	imageRef := container.ImageRef
-	image, err := c.imageStore.Get(imageRef)
+	image, err := c.GetImage(imageRef)
 	if err != nil {
 		if !errdefs.IsNotFound(err) {
 			return nil, fmt.Errorf("failed to get image %q: %w", imageRef, err)
 		}
 	} else {
-		repoTags, repoDigests := parseImageReferences(image.References)
+		repoTags, repoDigests := images.ParseImageReferences(image.References)
 		if len(repoTags) > 0 {
 			// Based on current behavior of dockershim, this field should be
 			// image tag.

--- a/pkg/cri/sbserver/container_status_test.go
+++ b/pkg/cri/sbserver/container_status_test.go
@@ -18,9 +18,12 @@ package sbserver
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
+	criconfig "github.com/containerd/containerd/pkg/cri/config"
+	snapshotstore "github.com/containerd/containerd/pkg/cri/store/snapshot"
 	"github.com/stretchr/testify/assert"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
@@ -228,8 +231,9 @@ func TestContainerStatus(t *testing.T) {
 				assert.NoError(t, c.containerStore.Add(container))
 			}
 			if test.imageExist {
-				c.imageStore, err = imagestore.NewFakeStore([]imagestore.Image{*image})
+				imageStore, err := imagestore.NewFakeStore([]imagestore.Image{*image})
 				assert.NoError(t, err)
+				c.imageService = &fakeImageService{imageStore: imageStore}
 			}
 			resp, err := c.ContainerStatus(context.Background(), &runtime.ContainerStatusRequest{ContainerId: container.ID})
 			if test.expectErr {
@@ -245,6 +249,27 @@ func TestContainerStatus(t *testing.T) {
 			assert.Equal(t, expected, resp.GetStatus())
 		})
 	}
+}
+
+type fakeImageService struct {
+	runtime.ImageServiceServer
+	imageStore *imagestore.Store
+}
+
+func (s *fakeImageService) RuntimeSnapshotter(ctx context.Context, ociRuntime criconfig.Runtime) string {
+	return ""
+}
+
+func (s *fakeImageService) UpdateImage(ctx context.Context, r string) error { return nil }
+
+func (s *fakeImageService) GetImage(id string) (imagestore.Image, error) { return s.imageStore.Get(id) }
+
+func (s *fakeImageService) GetSnapshot(key string) (snapshotstore.Snapshot, error) {
+	return snapshotstore.Snapshot{}, errors.New("not implemented")
+}
+
+func (s *fakeImageService) LocalResolve(refOrID string) (imagestore.Image, error) {
+	return imagestore.Image{}, errors.New("not implemented")
 }
 
 func patchExceptedWithState(expected *runtime.ContainerStatus, state runtime.ContainerState) {

--- a/pkg/cri/sbserver/container_stop.go
+++ b/pkg/cri/sbserver/container_stop.go
@@ -133,7 +133,7 @@ func (c *criService) stopContainer(ctx context.Context, container containerstore
 			// default SIGTERM is still better than returning error and leaving
 			// the container unstoppable. (See issue #990)
 			// TODO(random-liu): Remove this logic when containerd 1.2 is deprecated.
-			image, err := c.imageStore.Get(container.ImageRef)
+			image, err := c.GetImage(container.ImageRef)
 			if err != nil {
 				if !errdefs.IsNotFound(err) {
 					return fmt.Errorf("failed to get image %q: %w", container.ImageRef, err)

--- a/pkg/cri/sbserver/events.go
+++ b/pkg/cri/sbserver/events.go
@@ -350,13 +350,13 @@ func (em *eventMonitor) handleEvent(any interface{}) error {
 		}
 	case *eventtypes.ImageCreate:
 		logrus.Infof("ImageCreate event %+v", e)
-		return em.c.updateImage(ctx, e.Name)
+		return em.c.UpdateImage(ctx, e.Name)
 	case *eventtypes.ImageUpdate:
 		logrus.Infof("ImageUpdate event %+v", e)
-		return em.c.updateImage(ctx, e.Name)
+		return em.c.UpdateImage(ctx, e.Name)
 	case *eventtypes.ImageDelete:
 		logrus.Infof("ImageDelete event %+v", e)
-		return em.c.updateImage(ctx, e.Name)
+		return em.c.UpdateImage(ctx, e.Name)
 	}
 
 	return nil

--- a/pkg/cri/sbserver/images/image_list.go
+++ b/pkg/cri/sbserver/images/image_list.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package sbserver
+package images
 
 import (
 	"context"
@@ -25,7 +25,7 @@ import (
 // ListImages lists existing images.
 // TODO(random-liu): Add image list filters after CRI defines this more clear, and kubelet
 // actually needs it.
-func (c *criService) ListImages(ctx context.Context, r *runtime.ListImagesRequest) (*runtime.ListImagesResponse, error) {
+func (c *CRIImageService) ListImages(ctx context.Context, r *runtime.ListImagesRequest) (*runtime.ListImagesResponse, error) {
 	imagesInStore := c.imageStore.List()
 
 	var images []*runtime.Image

--- a/pkg/cri/sbserver/images/image_list_test.go
+++ b/pkg/cri/sbserver/images/image_list_test.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package sbserver
+package images
 
 import (
 	"context"

--- a/pkg/cri/sbserver/images/image_remove.go
+++ b/pkg/cri/sbserver/images/image_remove.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package sbserver
+package images
 
 import (
 	"context"
@@ -33,9 +33,9 @@ import (
 // TODO(random-liu): We should change CRI to distinguish image id and image spec.
 // Remove the whole image no matter the it's image id or reference. This is the
 // semantic defined in CRI now.
-func (c *criService) RemoveImage(ctx context.Context, r *runtime.RemoveImageRequest) (*runtime.RemoveImageResponse, error) {
+func (c *CRIImageService) RemoveImage(ctx context.Context, r *runtime.RemoveImageRequest) (*runtime.RemoveImageResponse, error) {
 	span := tracing.SpanFromContext(ctx)
-	image, err := c.localResolve(r.GetImage().GetImage())
+	image, err := c.LocalResolve(r.GetImage().GetImage())
 	if err != nil {
 		if errdefs.IsNotFound(err) {
 			span.AddEvent(err.Error())

--- a/pkg/cri/sbserver/images/image_status.go
+++ b/pkg/cri/sbserver/images/image_status.go
@@ -14,16 +14,19 @@
    limitations under the License.
 */
 
-package sbserver
+package images
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
 	imagestore "github.com/containerd/containerd/pkg/cri/store/image"
+	"github.com/containerd/containerd/reference/docker"
 	"github.com/containerd/containerd/tracing"
 
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -33,9 +36,9 @@ import (
 // ImageStatus returns the status of the image, returns nil if the image isn't present.
 // TODO(random-liu): We should change CRI to distinguish image id and image spec. (See
 // kubernetes/kubernetes#46255)
-func (c *criService) ImageStatus(ctx context.Context, r *runtime.ImageStatusRequest) (*runtime.ImageStatusResponse, error) {
+func (c *CRIImageService) ImageStatus(ctx context.Context, r *runtime.ImageStatusRequest) (*runtime.ImageStatusResponse, error) {
 	span := tracing.SpanFromContext(ctx)
-	image, err := c.localResolve(r.GetImage().GetImage())
+	image, err := c.LocalResolve(r.GetImage().GetImage())
 	if err != nil {
 		if errdefs.IsNotFound(err) {
 			span.AddEvent(err.Error())
@@ -62,7 +65,7 @@ func (c *criService) ImageStatus(ctx context.Context, r *runtime.ImageStatusRequ
 
 // toCRIImage converts internal image object to CRI runtime.Image.
 func toCRIImage(image imagestore.Image) *runtime.Image {
-	repoTags, repoDigests := parseImageReferences(image.References)
+	repoTags, repoDigests := ParseImageReferences(image.References)
 	runtimeImage := &runtime.Image{
 		Id:          image.ID,
 		RepoTags:    repoTags,
@@ -78,6 +81,43 @@ func toCRIImage(image imagestore.Image) *runtime.Image {
 	return runtimeImage
 }
 
+// getUserFromImage gets uid or user name of the image user.
+// If user is numeric, it will be treated as uid; or else, it is treated as user name.
+func getUserFromImage(user string) (*int64, string) {
+	// return both empty if user is not specified in the image.
+	if user == "" {
+		return nil, ""
+	}
+	// split instances where the id may contain user:group
+	user = strings.Split(user, ":")[0]
+	// user could be either uid or user name. Try to interpret as numeric uid.
+	uid, err := strconv.ParseInt(user, 10, 64)
+	if err != nil {
+		// If user is non numeric, assume it's user name.
+		return nil, user
+	}
+	// If user is a numeric uid.
+	return &uid, ""
+}
+
+// ParseImageReferences parses a list of arbitrary image references and returns
+// the repotags and repodigests
+func ParseImageReferences(refs []string) ([]string, []string) {
+	var tags, digests []string
+	for _, ref := range refs {
+		parsed, err := docker.ParseAnyReference(ref)
+		if err != nil {
+			continue
+		}
+		if _, ok := parsed.(docker.Canonical); ok {
+			digests = append(digests, parsed.String())
+		} else if _, ok := parsed.(docker.Tagged); ok {
+			tags = append(tags, parsed.String())
+		}
+	}
+	return tags, digests
+}
+
 // TODO (mikebrow): discuss moving this struct and / or constants for info map for some or all of these fields to CRI
 type verboseImageInfo struct {
 	ChainID   string          `json:"chainID"`
@@ -85,7 +125,7 @@ type verboseImageInfo struct {
 }
 
 // toCRIImageInfo converts internal image object information to CRI image status response info map.
-func (c *criService) toCRIImageInfo(ctx context.Context, image *imagestore.Image, verbose bool) (map[string]string, error) {
+func (c *CRIImageService) toCRIImageInfo(ctx context.Context, image *imagestore.Image, verbose bool) (map[string]string, error) {
 	if !verbose {
 		return nil, nil
 	}

--- a/pkg/cri/sbserver/images/imagefs_info.go
+++ b/pkg/cri/sbserver/images/imagefs_info.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package sbserver
+package images
 
 import (
 	"context"
@@ -25,7 +25,7 @@ import (
 
 // ImageFsInfo returns information of the filesystem that is used to store images.
 // TODO(windows): Usage for windows is always 0 right now. Support this for windows.
-func (c *criService) ImageFsInfo(ctx context.Context, r *runtime.ImageFsInfoRequest) (*runtime.ImageFsInfoResponse, error) {
+func (c *CRIImageService) ImageFsInfo(ctx context.Context, r *runtime.ImageFsInfoRequest) (*runtime.ImageFsInfoResponse, error) {
 	snapshots := c.snapshotStore.List()
 	timestamp := time.Now().UnixNano()
 	var usedBytes, inodesUsed uint64

--- a/pkg/cri/sbserver/images/imagefs_info_test.go
+++ b/pkg/cri/sbserver/images/imagefs_info_test.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package sbserver
+package images
 
 import (
 	"context"

--- a/pkg/cri/sbserver/images/metrics.go
+++ b/pkg/cri/sbserver/images/metrics.go
@@ -1,0 +1,46 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package images
+
+import (
+	"github.com/docker/go-metrics"
+	prom "github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	imagePulls           metrics.LabeledCounter
+	inProgressImagePulls metrics.Gauge
+	//  pull duration / (image size / 1MBi)
+	imagePullThroughput prom.Histogram
+)
+
+func init() {
+	// these CRI metrics record latencies for successful operations around a sandbox and container's lifecycle.
+	ns := metrics.NewNamespace("containerd", "cri_sandboxed", nil)
+
+	imagePulls = ns.NewLabeledCounter("image_pulls", "succeeded and failed counters", "status")
+	inProgressImagePulls = ns.NewGauge("in_progress_image_pulls", "in progress pulls", metrics.Total)
+	imagePullThroughput = prom.NewHistogram(
+		prom.HistogramOpts{
+			Name:    "image_pulling_throughput",
+			Help:    "image pull throughput",
+			Buckets: prom.DefBuckets,
+		},
+	)
+
+	metrics.Register(ns)
+}

--- a/pkg/cri/sbserver/images/service.go
+++ b/pkg/cri/sbserver/images/service.go
@@ -1,0 +1,134 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package images
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/log"
+	criconfig "github.com/containerd/containerd/pkg/cri/config"
+	imagestore "github.com/containerd/containerd/pkg/cri/store/image"
+	snapshotstore "github.com/containerd/containerd/pkg/cri/store/snapshot"
+	"github.com/containerd/containerd/pkg/kmutex"
+	"github.com/containerd/containerd/reference/docker"
+	imagedigest "github.com/opencontainers/go-digest"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// imageLabelKey is the label key indicating the image is managed by cri plugin.
+	imageLabelKey = "io.cri-containerd.image"
+	// imageLabelValue is the label value indicating the image is managed by cri plugin.
+	imageLabelValue = "managed"
+)
+
+type CRIImageService struct {
+	// config contains all configurations.
+	config criconfig.Config
+	// client is an instance of the containerd client
+	client *containerd.Client
+	// imageFSPath is the path to image filesystem.
+	imageFSPath string
+	// imageStore stores all resources associated with images.
+	imageStore *imagestore.Store
+	// snapshotStore stores information of all snapshots.
+	snapshotStore *snapshotstore.Store
+	// unpackDuplicationSuppressor is used to make sure that there is only
+	// one in-flight fetch request or unpack handler for a given descriptor's
+	// or chain ID.
+	unpackDuplicationSuppressor kmutex.KeyedLocker
+}
+
+func NewService(config criconfig.Config, imageFSPath string, client *containerd.Client) (*CRIImageService, error) {
+	svc := CRIImageService{
+		config:                      config,
+		client:                      client,
+		imageStore:                  imagestore.NewStore(client),
+		imageFSPath:                 imageFSPath,
+		snapshotStore:               snapshotstore.NewStore(),
+		unpackDuplicationSuppressor: kmutex.New(),
+	}
+
+	if client.SnapshotService(svc.config.ContainerdConfig.Snapshotter) == nil {
+		return nil, fmt.Errorf("failed to find snapshotter %q", svc.config.ContainerdConfig.Snapshotter)
+	}
+
+	// Start snapshot stats syncer, it doesn't need to be stopped.
+	logrus.Info("Start snapshots syncer")
+	snapshotsSyncer := newSnapshotsSyncer(
+		svc.snapshotStore,
+		svc.client.SnapshotService(svc.config.ContainerdConfig.Snapshotter),
+		time.Duration(svc.config.StatsCollectPeriod)*time.Second,
+	)
+	snapshotsSyncer.start()
+
+	return &svc, nil
+}
+
+// LocalResolve resolves image reference locally and returns corresponding image metadata. It
+// returns errdefs.ErrNotFound if the reference doesn't exist.
+func (c *CRIImageService) LocalResolve(refOrID string) (imagestore.Image, error) {
+	getImageID := func(refOrId string) string {
+		if _, err := imagedigest.Parse(refOrID); err == nil {
+			return refOrID
+		}
+		return func(ref string) string {
+			// ref is not image id, try to resolve it locally.
+			// TODO(random-liu): Handle this error better for debugging.
+			normalized, err := docker.ParseDockerRef(ref)
+			if err != nil {
+				return ""
+			}
+			id, err := c.imageStore.Resolve(normalized.String())
+			if err != nil {
+				return ""
+			}
+			return id
+		}(refOrID)
+	}
+
+	imageID := getImageID(refOrID)
+	if imageID == "" {
+		// Try to treat ref as imageID
+		imageID = refOrID
+	}
+	return c.imageStore.Get(imageID)
+}
+
+// RuntimeSnapshotter overrides the default snapshotter if Snapshotter is set for this runtime.
+// See https://github.com/containerd/containerd/issues/6657
+func (c *CRIImageService) RuntimeSnapshotter(ctx context.Context, ociRuntime criconfig.Runtime) string {
+	if ociRuntime.Snapshotter == "" {
+		return c.config.ContainerdConfig.Snapshotter
+	}
+
+	log.G(ctx).Debugf("Set snapshotter for runtime %s to %s", ociRuntime.Type, ociRuntime.Snapshotter)
+	return ociRuntime.Snapshotter
+}
+
+// GetImage gets image metadata by image id.
+func (c *CRIImageService) GetImage(id string) (imagestore.Image, error) {
+	return c.imageStore.Get(id)
+}
+
+// GetSnapshot returns the snapshot with specified key.
+func (c *CRIImageService) GetSnapshot(key string) (snapshotstore.Snapshot, error) {
+	return c.snapshotStore.Get(key)
+}

--- a/pkg/cri/sbserver/images/service_test.go
+++ b/pkg/cri/sbserver/images/service_test.go
@@ -1,0 +1,128 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package images
+
+import (
+	"context"
+	"testing"
+
+	"github.com/containerd/containerd/errdefs"
+	criconfig "github.com/containerd/containerd/pkg/cri/config"
+	imagestore "github.com/containerd/containerd/pkg/cri/store/image"
+	snapshotstore "github.com/containerd/containerd/pkg/cri/store/snapshot"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testImageFSPath = "/test/image/fs/path"
+	testRootDir     = "/test/root"
+	testStateDir    = "/test/state"
+	// Use an image id as test sandbox image to avoid image name resolve.
+	// TODO(random-liu): Change this to image name after we have complete image
+	// management unit test framework.
+	testSandboxImage = "sha256:c75bebcdd211f41b3a460c7bf82970ed6c75acaab9cd4c9a4e125b03ca113798"
+)
+
+// newTestCRIService creates a fake criService for test.
+func newTestCRIService() *CRIImageService {
+	return &CRIImageService{
+		config:        testConfig,
+		imageFSPath:   testImageFSPath,
+		imageStore:    imagestore.NewStore(nil),
+		snapshotStore: snapshotstore.NewStore(),
+	}
+}
+
+var testConfig = criconfig.Config{
+	RootDir:  testRootDir,
+	StateDir: testStateDir,
+	PluginConfig: criconfig.PluginConfig{
+		SandboxImage:                     testSandboxImage,
+		TolerateMissingHugetlbController: true,
+	},
+}
+
+func TestLocalResolve(t *testing.T) {
+	image := imagestore.Image{
+		ID:      "sha256:c75bebcdd211f41b3a460c7bf82970ed6c75acaab9cd4c9a4e125b03ca113799",
+		ChainID: "test-chain-id-1",
+		References: []string{
+			"docker.io/library/busybox:latest",
+			"docker.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
+		},
+		Size: 10,
+	}
+	c := newTestCRIService()
+	var err error
+	c.imageStore, err = imagestore.NewFakeStore([]imagestore.Image{image})
+	assert.NoError(t, err)
+
+	for _, ref := range []string{
+		"sha256:c75bebcdd211f41b3a460c7bf82970ed6c75acaab9cd4c9a4e125b03ca113799",
+		"busybox",
+		"busybox:latest",
+		"busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
+		"library/busybox",
+		"library/busybox:latest",
+		"library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
+		"docker.io/busybox",
+		"docker.io/busybox:latest",
+		"docker.io/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
+		"docker.io/library/busybox",
+		"docker.io/library/busybox:latest",
+		"docker.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
+	} {
+		img, err := c.LocalResolve(ref)
+		assert.NoError(t, err)
+		assert.Equal(t, image, img)
+	}
+	img, err := c.LocalResolve("randomid")
+	assert.Equal(t, errdefs.IsNotFound(err), true)
+	assert.Equal(t, imagestore.Image{}, img)
+}
+
+func TestRuntimeSnapshotter(t *testing.T) {
+	defaultRuntime := criconfig.Runtime{
+		Snapshotter: "",
+	}
+
+	fooRuntime := criconfig.Runtime{
+		Snapshotter: "devmapper",
+	}
+
+	for desc, test := range map[string]struct {
+		runtime           criconfig.Runtime
+		expectSnapshotter string
+	}{
+		"should return default snapshotter when runtime.Snapshotter is not set": {
+			runtime:           defaultRuntime,
+			expectSnapshotter: criconfig.DefaultConfig().Snapshotter,
+		},
+		"should return overridden snapshotter when runtime.Snapshotter is set": {
+			runtime:           fooRuntime,
+			expectSnapshotter: "devmapper",
+		},
+	} {
+		t.Run(desc, func(t *testing.T) {
+			cri := newTestCRIService()
+			cri.config = criconfig.Config{
+				PluginConfig: criconfig.DefaultConfig(),
+			}
+			assert.Equal(t, test.expectSnapshotter, cri.RuntimeSnapshotter(context.Background(), test.runtime))
+		})
+	}
+}

--- a/pkg/cri/sbserver/images/snapshots.go
+++ b/pkg/cri/sbserver/images/snapshots.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package sbserver
+package images
 
 import (
 	"context"

--- a/pkg/cri/sbserver/metrics.go
+++ b/pkg/cri/sbserver/metrics.go
@@ -18,7 +18,6 @@ package sbserver
 
 import (
 	"github.com/docker/go-metrics"
-	prom "github.com/prometheus/client_golang/prometheus"
 )
 
 var (
@@ -39,11 +38,6 @@ var (
 	networkPluginOperations        metrics.LabeledCounter
 	networkPluginOperationsErrors  metrics.LabeledCounter
 	networkPluginOperationsLatency metrics.LabeledTimer
-
-	imagePulls           metrics.LabeledCounter
-	inProgressImagePulls metrics.Gauge
-	//  pull duration / (image size / 1MBi)
-	imagePullThroughput prom.Histogram
 )
 
 func init() {
@@ -67,16 +61,6 @@ func init() {
 	networkPluginOperations = ns.NewLabeledCounter("network_plugin_operations_total", "cumulative number of network plugin operations by operation type", "operation_type")
 	networkPluginOperationsErrors = ns.NewLabeledCounter("network_plugin_operations_errors_total", "cumulative number of network plugin operations by operation type", "operation_type")
 	networkPluginOperationsLatency = ns.NewLabeledTimer("network_plugin_operations_duration_seconds", "latency in seconds of network plugin operations. Broken down by operation type", "operation_type")
-
-	imagePulls = ns.NewLabeledCounter("image_pulls", "succeeded and failed counters", "status")
-	inProgressImagePulls = ns.NewGauge("in_progress_image_pulls", "in progress pulls", metrics.Total)
-	imagePullThroughput = prom.NewHistogram(
-		prom.HistogramOpts{
-			Name:    "image_pulling_throughput",
-			Help:    "image pull throughput",
-			Buckets: prom.DefBuckets,
-		},
-	)
 
 	metrics.Register(ns)
 }

--- a/pkg/cri/sbserver/podsandbox/helpers.go
+++ b/pkg/cri/sbserver/podsandbox/helpers.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"path"
 	"path/filepath"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/containerd/containerd"
@@ -101,25 +99,6 @@ func (c *Controller) toContainerdImage(ctx context.Context, image imagestore.Ima
 		return nil, fmt.Errorf("invalid image with no reference %q", image.ID)
 	}
 	return c.client.GetImage(ctx, image.References[0])
-}
-
-// getUserFromImage gets uid or user name of the image user.
-// If user is numeric, it will be treated as uid; or else, it is treated as user name.
-func getUserFromImage(user string) (*int64, string) {
-	// return both empty if user is not specified in the image.
-	if user == "" {
-		return nil, ""
-	}
-	// split instances where the id may contain user:group
-	user = strings.Split(user, ":")[0]
-	// user could be either uid or user name. Try to interpret as numeric uid.
-	uid, err := strconv.ParseInt(user, 10, 64)
-	if err != nil {
-		// If user is non numeric, assume it's user name.
-		return nil, user
-	}
-	// If user is a numeric uid.
-	return &uid, ""
 }
 
 // buildLabel builds the labels from config to be passed to containerd

--- a/pkg/cri/sbserver/podsandbox/helpers_test.go
+++ b/pkg/cri/sbserver/podsandbox/helpers_test.go
@@ -29,46 +29,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestGetUserFromImage tests the logic of getting image uid or user name of image user.
-func TestGetUserFromImage(t *testing.T) {
-	newI64 := func(i int64) *int64 { return &i }
-	for c, test := range map[string]struct {
-		user string
-		uid  *int64
-		name string
-	}{
-		"no gid": {
-			user: "0",
-			uid:  newI64(0),
-		},
-		"uid/gid": {
-			user: "0:1",
-			uid:  newI64(0),
-		},
-		"empty user": {
-			user: "",
-		},
-		"multiple separators": {
-			user: "1:2:3",
-			uid:  newI64(1),
-		},
-		"root username": {
-			user: "root:root",
-			name: "root",
-		},
-		"username": {
-			user: "test:test",
-			name: "test",
-		},
-	} {
-		t.Run(c, func(t *testing.T) {
-			actualUID, actualName := getUserFromImage(test.user)
-			assert.Equal(t, test.uid, actualUID)
-			assert.Equal(t, test.name, actualName)
-		})
-	}
-}
-
 func TestGetRepoDigestAndTag(t *testing.T) {
 	digest := imagedigest.Digest("sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582")
 	for desc, test := range map[string]struct {

--- a/pkg/cri/sbserver/restart.go
+++ b/pkg/cri/sbserver/restart.go
@@ -519,7 +519,7 @@ func (c *criService) loadImages(ctx context.Context, cImages []containerd.Image)
 				log.G(ctx).Warnf("The image %s is not unpacked.", i.Name())
 				// TODO(random-liu): Consider whether we should try unpack here.
 			}
-			if err := c.updateImage(ctx, i.Name()); err != nil {
+			if err := c.UpdateImage(ctx, i.Name()); err != nil {
 				log.G(ctx).WithError(err).Warnf("Failed to update reference for image %q", i.Name())
 				return
 			}

--- a/pkg/cri/sbserver/sandbox_stats_windows.go
+++ b/pkg/cri/sbserver/sandbox_stats_windows.go
@@ -151,7 +151,7 @@ func (c *criService) toPodSandboxStats(sandbox sandboxstore.Sandbox, statsMap ma
 		// If snapshotstore doesn't have cached snapshot information
 		// set WritableLayer usage to zero
 		var usedBytes uint64
-		sn, err := c.snapshotStore.Get(cntr.ID)
+		sn, err := c.GetSnapshot(cntr.ID)
 		if err == nil {
 			usedBytes = sn.Size
 		}

--- a/pkg/cri/sbserver/service.go
+++ b/pkg/cri/sbserver/service.go
@@ -26,15 +26,16 @@ import (
 	"path/filepath"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/pkg/cri/instrument"
 	"github.com/containerd/containerd/pkg/cri/nri"
+	"github.com/containerd/containerd/pkg/cri/sbserver/images"
 	"github.com/containerd/containerd/pkg/cri/sbserver/podsandbox"
+	imagestore "github.com/containerd/containerd/pkg/cri/store/image"
+	snapshotstore "github.com/containerd/containerd/pkg/cri/store/snapshot"
 	"github.com/containerd/containerd/pkg/cri/streaming"
-	"github.com/containerd/containerd/pkg/kmutex"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/sandbox"
 	"github.com/containerd/go-cni"
@@ -46,9 +47,7 @@ import (
 
 	criconfig "github.com/containerd/containerd/pkg/cri/config"
 	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
-	imagestore "github.com/containerd/containerd/pkg/cri/store/image"
 	sandboxstore "github.com/containerd/containerd/pkg/cri/store/sandbox"
-	snapshotstore "github.com/containerd/containerd/pkg/cri/store/snapshot"
 	ctrdutil "github.com/containerd/containerd/pkg/cri/util"
 	osinterface "github.com/containerd/containerd/pkg/os"
 	"github.com/containerd/containerd/pkg/registrar"
@@ -69,8 +68,23 @@ type CRIService interface {
 	Register(*grpc.Server) error
 }
 
+// imageService specifies dependencies to image service.
+type imageService interface {
+	runtime.ImageServiceServer
+
+	RuntimeSnapshotter(ctx context.Context, ociRuntime criconfig.Runtime) string
+
+	UpdateImage(ctx context.Context, r string) error
+
+	GetImage(id string) (imagestore.Image, error)
+	GetSnapshot(key string) (snapshotstore.Snapshot, error)
+
+	LocalResolve(refOrID string) (imagestore.Image, error)
+}
+
 // criService implements CRIService.
 type criService struct {
+	imageService
 	// config contains all configurations.
 	config criconfig.Config
 	// imageFSPath is the path to image filesystem.
@@ -90,10 +104,6 @@ type criService struct {
 	// containerNameIndex stores all container names and make sure each
 	// name is unique.
 	containerNameIndex *registrar.Registrar
-	// imageStore stores all resources associated with images.
-	imageStore *imagestore.Store
-	// snapshotStore stores information of all snapshots.
-	snapshotStore *snapshotstore.Store
 	// netPlugin is used to setup and teardown network when run/stop pod sandbox.
 	netPlugin map[string]cni.CNI
 	// client is an instance of the containerd client
@@ -113,10 +123,6 @@ type criService struct {
 	// allCaps is the list of the capabilities.
 	// When nil, parsed from CapEff of /proc/self/status.
 	allCaps []string //nolint:nolintlint,unused // Ignore on non-Linux
-	// unpackDuplicationSuppressor is used to make sure that there is only
-	// one in-flight fetch request or unpack handler for a given descriptor's
-	// or chain ID.
-	unpackDuplicationSuppressor kmutex.KeyedLocker
 	// containerEventsChan is used to capture container events and send them
 	// to the caller of GetContainerEvents.
 	containerEventsChan chan runtime.ContainerEventResponse
@@ -128,30 +134,36 @@ type criService struct {
 func NewCRIService(config criconfig.Config, client *containerd.Client, nri *nri.API) (CRIService, error) {
 	var err error
 	labels := label.NewStore()
+
+	if client.SnapshotService(config.ContainerdConfig.Snapshotter) == nil {
+		return nil, fmt.Errorf("failed to find snapshotter %q", config.ContainerdConfig.Snapshotter)
+	}
+
+	imageFSPath := imageFSPath(config.ContainerdRootDir, config.ContainerdConfig.Snapshotter)
+	logrus.Infof("Get image filesystem path %q", imageFSPath)
+
+	// TODO: expose this as a separate containerd plugin.
+	imageService, err := images.NewService(config, imageFSPath, client)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create CRI image service: %w", err)
+	}
+
 	c := &criService{
-		config:                      config,
-		client:                      client,
-		os:                          osinterface.RealOS{},
-		sandboxStore:                sandboxstore.NewStore(labels),
-		containerStore:              containerstore.NewStore(labels),
-		imageStore:                  imagestore.NewStore(client),
-		snapshotStore:               snapshotstore.NewStore(),
-		sandboxNameIndex:            registrar.NewRegistrar(),
-		containerNameIndex:          registrar.NewRegistrar(),
-		netPlugin:                   make(map[string]cni.CNI),
-		unpackDuplicationSuppressor: kmutex.New(),
-		sandboxControllers:          make(map[criconfig.SandboxControllerMode]sandbox.Controller),
+		imageService:       imageService,
+		config:             config,
+		client:             client,
+		imageFSPath:        imageFSPath,
+		os:                 osinterface.RealOS{},
+		sandboxStore:       sandboxstore.NewStore(labels),
+		containerStore:     containerstore.NewStore(labels),
+		sandboxNameIndex:   registrar.NewRegistrar(),
+		containerNameIndex: registrar.NewRegistrar(),
+		netPlugin:          make(map[string]cni.CNI),
+		sandboxControllers: make(map[criconfig.SandboxControllerMode]sandbox.Controller),
 	}
 
 	// TODO: figure out a proper channel size.
 	c.containerEventsChan = make(chan runtime.ContainerEventResponse, 1000)
-
-	if client.SnapshotService(c.config.ContainerdConfig.Snapshotter) == nil {
-		return nil, fmt.Errorf("failed to find snapshotter %q", c.config.ContainerdConfig.Snapshotter)
-	}
-
-	c.imageFSPath = imageFSPath(config.ContainerdRootDir, config.ContainerdConfig.Snapshotter)
-	logrus.Infof("Get image filesystem path %q", c.imageFSPath)
 
 	if err := c.initPlatform(); err != nil {
 		return nil, fmt.Errorf("initialize platform: %w", err)
@@ -189,7 +201,7 @@ func NewCRIService(config criconfig.Config, client *containerd.Client, nri *nri.
 	}
 
 	// Load all sandbox controllers(pod sandbox controller and remote shim controller)
-	c.sandboxControllers[criconfig.ModePodSandbox] = podsandbox.New(config, client, c.sandboxStore, c.os, c, c.baseOCISpecs)
+	c.sandboxControllers[criconfig.ModePodSandbox] = podsandbox.New(config, client, c.sandboxStore, c.os, c, imageService, c.baseOCISpecs)
 	c.sandboxControllers[criconfig.ModeShim] = client.SandboxController()
 
 	c.nri = nri
@@ -237,15 +249,6 @@ func (c *criService) Run() error {
 	// Start event handler.
 	logrus.Info("Start event monitor")
 	eventMonitorErrCh := c.eventMonitor.start()
-
-	// Start snapshot stats syncer, it doesn't need to be stopped.
-	logrus.Info("Start snapshots syncer")
-	snapshotsSyncer := newSnapshotsSyncer(
-		c.snapshotStore,
-		c.client.SnapshotService(c.config.ContainerdConfig.Snapshotter),
-		time.Duration(c.config.StatsCollectPeriod)*time.Second,
-	)
-	snapshotsSyncer.start()
 
 	// Start CNI network conf syncers
 	cniNetConfMonitorErrCh := make(chan error, len(c.cniNetConfMonitor))

--- a/pkg/cri/sbserver/service_test.go
+++ b/pkg/cri/sbserver/service_test.go
@@ -29,10 +29,8 @@ import (
 	criconfig "github.com/containerd/containerd/pkg/cri/config"
 	servertesting "github.com/containerd/containerd/pkg/cri/server/testing"
 	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
-	imagestore "github.com/containerd/containerd/pkg/cri/store/image"
 	"github.com/containerd/containerd/pkg/cri/store/label"
 	sandboxstore "github.com/containerd/containerd/pkg/cri/store/sandbox"
-	snapshotstore "github.com/containerd/containerd/pkg/cri/store/snapshot"
 	ostesting "github.com/containerd/containerd/pkg/os/testing"
 	"github.com/containerd/containerd/pkg/registrar"
 )
@@ -41,12 +39,10 @@ import (
 func newTestCRIService() *criService {
 	labels := label.NewStore()
 	return &criService{
+		imageService:       &fakeImageService{},
 		config:             testConfig,
-		imageFSPath:        testImageFSPath,
 		os:                 ostesting.NewFakeOS(),
 		sandboxStore:       sandboxstore.NewStore(labels),
-		imageStore:         imagestore.NewStore(nil),
-		snapshotStore:      snapshotstore.NewStore(),
 		sandboxNameIndex:   registrar.NewRegistrar(),
 		containerStore:     containerstore.NewStore(labels),
 		containerNameIndex: registrar.NewRegistrar(),

--- a/pkg/cri/sbserver/test_config.go
+++ b/pkg/cri/sbserver/test_config.go
@@ -25,7 +25,6 @@ const (
 	// TODO(random-liu): Change this to image name after we have complete image
 	// management unit test framework.
 	testSandboxImage = "sha256:c75bebcdd211f41b3a460c7bf82970ed6c75acaab9cd4c9a4e125b03ca113798"
-	testImageFSPath  = "/test/image/fs/path"
 )
 
 var testConfig = criconfig.Config{


### PR DESCRIPTION
CRI is one of the largest plugins in containerd.

This PR extracts CRI image management into a separate package (`pkg/cri/sbserver/images`, which implements `runtime.ImageServiceServer`), so both CRI runtime service and `podsandbox/` controller can now use it as a dependency.

The ultimate goal of this is to run CRI as a set of smaller containerd plugins (like image service + runtime service), so it's easier to maintain (will follow up with plugin PR once we release 1.7 to avoid breaking APIs).