### PR TITLE
Support gzip and zstd HTTP transport compression to fetch remote resources

### DIFF
--- a/remotes/docker/fetcher_test.go
+++ b/remotes/docker/fetcher_test.go
@@ -17,6 +17,9 @@
 package docker
 
 import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -28,6 +31,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -111,6 +115,152 @@ func TestFetcherOpen(t *testing.T) {
 	_, err = f.open(ctx, req, "", 20)
 	if err == nil {
 		t.Fatal("expected error opening with invalid server response")
+	}
+}
+
+func TestContentEncoding(t *testing.T) {
+	t.Parallel()
+
+	zstdEncode := func(in []byte) []byte {
+		var b bytes.Buffer
+		zw, err := zstd.NewWriter(&b)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = zw.Write(in)
+		if err != nil {
+			t.Fatal()
+		}
+		err = zw.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return b.Bytes()
+	}
+	gzipEncode := func(in []byte) []byte {
+		var b bytes.Buffer
+		gw := gzip.NewWriter(&b)
+		_, err := gw.Write(in)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = gw.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return b.Bytes()
+	}
+	flateEncode := func(in []byte) []byte {
+		var b bytes.Buffer
+		dw, err := flate.NewWriter(&b, -1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = dw.Write(in)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = dw.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return b.Bytes()
+	}
+
+	tests := []struct {
+		encodingFuncs  []func([]byte) []byte
+		encodingHeader string
+	}{
+		{
+			encodingFuncs:  []func([]byte) []byte{},
+			encodingHeader: "",
+		},
+		{
+			encodingFuncs:  []func([]byte) []byte{zstdEncode},
+			encodingHeader: "zstd",
+		},
+		{
+			encodingFuncs:  []func([]byte) []byte{gzipEncode},
+			encodingHeader: "gzip",
+		},
+		{
+			encodingFuncs:  []func([]byte) []byte{flateEncode},
+			encodingHeader: "deflate",
+		},
+		{
+			encodingFuncs:  []func([]byte) []byte{zstdEncode, gzipEncode},
+			encodingHeader: "zstd,gzip",
+		},
+		{
+			encodingFuncs:  []func([]byte) []byte{gzipEncode, flateEncode},
+			encodingHeader: "gzip,deflate",
+		},
+		{
+			encodingFuncs:  []func([]byte) []byte{gzipEncode, zstdEncode},
+			encodingHeader: "gzip,zstd",
+		},
+		{
+			encodingFuncs:  []func([]byte) []byte{gzipEncode, zstdEncode, flateEncode},
+			encodingHeader: "gzip,zstd,deflate",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.encodingHeader, func(t *testing.T) {
+			t.Parallel()
+			content := make([]byte, 128)
+			rand.New(rand.NewSource(1)).Read(content)
+
+			s := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+				compressedContent := content
+				for _, enc := range tc.encodingFuncs {
+					compressedContent = enc(compressedContent)
+				}
+				rw.Header().Set("content-length", fmt.Sprintf("%d", len(compressedContent)))
+				rw.Header().Set("Content-Encoding", tc.encodingHeader)
+				rw.Write(compressedContent)
+			}))
+			defer s.Close()
+
+			u, err := url.Parse(s.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			f := dockerFetcher{&dockerBase{
+				repository: "nonempty",
+			}}
+
+			host := RegistryHost{
+				Client: s.Client(),
+				Host:   u.Host,
+				Scheme: u.Scheme,
+				Path:   u.Path,
+			}
+
+			req := f.request(host, http.MethodGet)
+
+			rc, err := f.open(context.Background(), req, "", 0)
+			if err != nil {
+				t.Fatalf("failed to open for encoding %s: %+v", tc.encodingHeader, err)
+			}
+			b, err := io.ReadAll(rc)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expected := content
+			if len(b) != len(expected) {
+				t.Errorf("unexpected length %d, expected %d", len(b), len(expected))
+				return
+			}
+			for i, c := range expected {
+				if b[i] != c {
+					t.Errorf("unexpected byte %x at %d, expected %x", b[i], i, c)
+					return
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Golang net/http already transparently supports gzip compression.
This adds support for zstd compression

-----------------

This PR takes over https://github.com/containerd/containerd/pull/7563 since @ndeloof is no longer working on this as per https://github.com/containerd/containerd/pull/7563#discussion_r1107591429.

Also took the chance to address some small comments in the previous PR.
