### PR TITLE
adding cni metadata to the container in the `ctr run --config`

### DIFF
--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -239,10 +239,6 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 			opts = append(opts, oci.WithAnnotations(annos))
 		}
 
-		if context.Bool("cni") {
-			cniMeta := &commands.NetworkMetaData{EnableCni: true}
-			cOpts = append(cOpts, containerd.WithContainerExtension(commands.CtrCniMetadataExtension, cniMeta))
-		}
 		if caps := context.StringSlice("cap-add"); len(caps) > 0 {
 			for _, cap := range caps {
 				if !strings.HasPrefix(cap, "CAP_") {
@@ -373,6 +369,11 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 		if hostname := context.String("hostname"); hostname != "" {
 			opts = append(opts, oci.WithHostname(hostname))
 		}
+	}
+
+	if context.Bool("cni") {
+		cniMeta := &commands.NetworkMetaData{EnableCni: true}
+		cOpts = append(cOpts, containerd.WithContainerExtension(commands.CtrCniMetadataExtension, cniMeta))
 	}
 
 	runtimeOpts, err := getRuntimeOptions(context)

--- a/cmd/ctr/commands/run/run_windows.go
+++ b/cmd/ctr/commands/run/run_windows.go
@@ -131,8 +131,6 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 				return nil, err
 			}
 			opts = append(opts, oci.WithWindowsNetworkNamespace(ns.GetPath()))
-			cniMeta := &commands.NetworkMetaData{EnableCni: true}
-			cOpts = append(cOpts, containerd.WithContainerExtension(commands.CtrCniMetadataExtension, cniMeta))
 		}
 		if context.Bool("isolated") {
 			opts = append(opts, oci.WithWindowsHyperV)
@@ -163,6 +161,11 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 			}
 			opts = append(opts, oci.WithWindowsDevice(idType, devID))
 		}
+	}
+
+	if context.Bool("cni") {
+		cniMeta := &commands.NetworkMetaData{EnableCni: true}
+		cOpts = append(cOpts, containerd.WithContainerExtension(commands.CtrCniMetadataExtension, cniMeta))
 	}
 
 	runtime := context.String("runtime")


### PR DESCRIPTION
When using `ctr run --cni --config`, the cni metadata is not set to the container,  so the `ctr task kill` does not remove the cni network