### PR TITLE
Increase CI workflow timeout on Windows.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,7 @@ jobs:
   integration-windows:
     name: Windows Integration
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 50
+    timeout-minutes: 90
     needs: [project, linters, protos, man]
     env:
       GOTEST: gotestsum --


### PR DESCRIPTION
This patch is meant to prevent test timeouts on Windows as [new tests are added/enabled](https://github.com/containerd/containerd/actions/runs/4298442869/jobs/7492617454) on it.