### PR TITLE
Add max shim version environment variable

### DIFF
--- a/runtime/v2/shim/shim.go
+++ b/runtime/v2/shim/shim.go
@@ -149,6 +149,7 @@ const (
 	ttrpcAddressEnv = "TTRPC_ADDRESS"
 	grpcAddressEnv  = "GRPC_ADDRESS"
 	namespaceEnv    = "NAMESPACE"
+	maxVersionEnv   = "MAX_SHIM_VERSION"
 )
 
 func parseFlags() {

--- a/runtime/v2/shim/util.go
+++ b/runtime/v2/shim/util.go
@@ -68,6 +68,7 @@ func Command(ctx context.Context, config *CommandConfig) (*exec.Cmd, error) {
 	cmd.Env = append(
 		os.Environ(),
 		"GOMAXPROCS=2",
+		fmt.Sprintf("%s=2", maxVersionEnv),
 		fmt.Sprintf("%s=%s", ttrpcAddressEnv, config.TTRPCAddress),
 		fmt.Sprintf("%s=%s", grpcAddressEnv, config.Address),
 		fmt.Sprintf("%s=%s", namespaceEnv, ns),


### PR DESCRIPTION
Adds environment variable to shim start command. I forgot to add this one in the previous PR.