### PR TITLE
epoch: fix unit test when SOURCE_DATE_EPOCH is set

### DIFF
--- a/pkg/epoch/epoch.go
+++ b/pkg/epoch/epoch.go
@@ -34,7 +34,7 @@ const SourceDateEpochEnv = "SOURCE_DATE_EPOCH"
 // If the env var is not set, SourceDateEpoch returns nil without an error.
 func SourceDateEpoch() (*time.Time, error) {
 	v, ok := os.LookupEnv(SourceDateEpochEnv)
-	if !ok {
+	if !ok || v == "" {
 		return nil, nil // not an error
 	}
 	i64, err := strconv.ParseInt(v, 10, 64)

--- a/pkg/epoch/epoch_test.go
+++ b/pkg/epoch/epoch_test.go
@@ -36,10 +36,24 @@ func rightAfter(t1, t2 time.Time) bool {
 func TestSourceDateEpoch(t *testing.T) {
 	if s, ok := os.LookupEnv(SourceDateEpochEnv); ok {
 		t.Logf("%s is already set to %q, unsetting", SourceDateEpochEnv, s)
+		// see https://github.com/golang/go/issues/52817#issuecomment-1131339120
 		t.Setenv(SourceDateEpochEnv, "")
+		os.Unsetenv(SourceDateEpochEnv)
 	}
 
 	t.Run("WithoutSourceDateEpoch", func(t *testing.T) {
+		vp, err := SourceDateEpoch()
+		require.NoError(t, err)
+		require.Nil(t, vp)
+
+		now := time.Now()
+		v := SourceDateEpochOrNow()
+		require.True(t, rightAfter(now, v))
+	})
+
+	t.Run("WithEmptySourceDateEpoch", func(t *testing.T) {
+		t.Setenv(SourceDateEpochEnv, "")
+
 		vp, err := SourceDateEpoch()
 		require.NoError(t, err)
 		require.Nil(t, vp)


### PR DESCRIPTION
Fixes https://github.com/containerd/containerd/issues/8200

Before this change, the following invocations would cause the unit test to fail:

```
$ SOURCE_DATE_EPOCH="" go test -v ./pkg/epoch
=== RUN   TestSourceDateEpoch
    epoch_test.go:38: SOURCE_DATE_EPOCH is already set to "", unsetting
=== RUN   TestSourceDateEpoch/WithoutSourceDateEpoch
    epoch_test.go:44: 
        	Error Trace:	/home/samuelkarp/go/src/github.com/containerd/containerd/pkg/epoch/epoch_test.go:44
        	Error:      	Received unexpected error:
        	            	invalid SOURCE_DATE_EPOCH value "": strconv.ParseInt: parsing "": invalid syntax
        	Test:       	TestSourceDateEpoch/WithoutSourceDateEpoch
=== RUN   TestSourceDateEpoch/WithSourceDateEpoch
=== RUN   TestSourceDateEpoch/WithInvalidSourceDateEpoch
time="2023-03-03T14:54:13-08:00" level=warning msg="Invalid SOURCE_DATE_EPOCH" error="invalid SOURCE_DATE_EPOCH value \"foo\": strconv.ParseInt: parsing \"foo\": invalid syntax"
--- FAIL: TestSourceDateEpoch (0.00s)
    --- FAIL: TestSourceDateEpoch/WithoutSourceDateEpoch (0.00s)
    --- PASS: TestSourceDateEpoch/WithSourceDateEpoch (0.00s)
    --- PASS: TestSourceDateEpoch/WithInvalidSourceDateEpoch (0.00s)
FAIL
FAIL	github.com/containerd/containerd/pkg/epoch	0.004s
FAIL
```

```
$ SOURCE_DATE_EPOCH="asdfasdf" go test -v ./pkg/epoch
=== RUN   TestSourceDateEpoch
    epoch_test.go:38: SOURCE_DATE_EPOCH is already set to "asdfasdf", unsetting
=== RUN   TestSourceDateEpoch/WithoutSourceDateEpoch
    epoch_test.go:44: 
        	Error Trace:	/home/samuelkarp/go/src/github.com/containerd/containerd/pkg/epoch/epoch_test.go:44
        	Error:      	Received unexpected error:
        	            	invalid SOURCE_DATE_EPOCH value "": strconv.ParseInt: parsing "": invalid syntax
        	Test:       	TestSourceDateEpoch/WithoutSourceDateEpoch
=== RUN   TestSourceDateEpoch/WithSourceDateEpoch
=== RUN   TestSourceDateEpoch/WithInvalidSourceDateEpoch
time="2023-03-03T14:54:03-08:00" level=warning msg="Invalid SOURCE_DATE_EPOCH" error="invalid SOURCE_DATE_EPOCH value \"foo\": strconv.ParseInt: parsing \"foo\": invalid syntax"
--- FAIL: TestSourceDateEpoch (0.00s)
    --- FAIL: TestSourceDateEpoch/WithoutSourceDateEpoch (0.00s)
    --- PASS: TestSourceDateEpoch/WithSourceDateEpoch (0.00s)
    --- PASS: TestSourceDateEpoch/WithInvalidSourceDateEpoch (0.00s)
FAIL
FAIL	github.com/containerd/containerd/pkg/epoch	0.005s
FAIL
```

After this change, both scenarios pass.