### PR TITLE
fix the task setting the runtime path

### DIFF
--- a/container.go
+++ b/container.go
@@ -281,6 +281,7 @@ func (c *container) NewTask(ctx context.Context, ioCreate cio.Creator, opts ...N
 			})
 		}
 	}
+	request.RuntimePath = info.RuntimePath
 	if info.Options != nil {
 		any, err := typeurl.MarshalAny(info.Options)
 		if err != nil {

--- a/integration/client/go.mod
+++ b/integration/client/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Microsoft/hcsshim/test v0.0.0-20210408205431-da33ecd607e1
 	github.com/containerd/cgroups/v3 v3.0.1
 	github.com/containerd/containerd v1.7.0-beta.0 // see replace; the actual version of containerd is replaced with the code at the root of this repository
+	github.com/containerd/continuity v0.3.0
 	github.com/containerd/go-runc v1.0.0
 	github.com/containerd/ttrpc v1.2.1
 	github.com/containerd/typeurl/v2 v2.1.0
@@ -27,7 +28,6 @@ require (
 	github.com/cilium/ebpf v0.9.1 // indirect
 	github.com/containerd/cgroups v1.1.0 // indirect
 	github.com/containerd/console v1.0.3 // indirect
-	github.com/containerd/continuity v0.3.0 // indirect
 	github.com/containerd/fifo v1.1.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect

--- a/task.go
+++ b/task.go
@@ -139,6 +139,11 @@ type TaskInfo struct {
 	RootFS []mount.Mount
 	// Options hold runtime specific settings for task creation
 	Options interface{}
+	// RuntimePath is an absolute path that can be used to overwrite path
+	// to a shim runtime binary.
+	RuntimePath string
+
+	// runtime is the runtime name for the container, and cannot be changed.
 	runtime string
 }
 

--- a/task_opts.go
+++ b/task_opts.go
@@ -48,7 +48,7 @@ func WithRootFS(mounts []mount.Mount) NewTaskOpts {
 // instead of resolving it from runtime name.
 func WithRuntimePath(absRuntimePath string) NewTaskOpts {
 	return func(ctx context.Context, client *Client, info *TaskInfo) error {
-		info.runtime = absRuntimePath
+		info.RuntimePath = absRuntimePath
 		return nil
 	}
 }


### PR DESCRIPTION
fix: https://github.com/containerd/containerd/issues/8207

https://github.com/containerd/containerd/blob/5da7e2c097952bce07ed5874355dedff72c9c343/pkg/cri/server/container_start.go#L124-L126

Although the runtime path is set in the cri server, the runtime path is not set to the `request` in the NewTask

Add `TaskInfo.RuntimePath` field to prevent overwriting `TaskInfo.runtime`, directly overwriting TaskInfo.runtime may cause exceptions to other `NewTaskOpts`