### PR TITLE
CRI sbserver: Respect verbose flag for PodSandboxStatus

### DIFF
--- a/pkg/cri/sbserver/sandbox_status.go
+++ b/pkg/cri/sbserver/sandbox_status.go
@@ -57,10 +57,12 @@ func (c *criService) PodSandboxStatus(ctx context.Context, r *runtime.PodSandbox
 		status.CreatedAt = sandboxInfo.CreatedAt.UnixNano()
 	}
 
-	return &runtime.PodSandboxStatusResponse{
-		Status: status,
-		Info:   cstatus.Info,
-	}, nil
+	resp := &runtime.PodSandboxStatusResponse{Status: status}
+	if r.GetVerbose() {
+		resp.Info = cstatus.Info
+	}
+
+	return resp, nil
 }
 
 func (c *criService) getIPs(sandbox sandboxstore.Sandbox) (string, []string, error) {


### PR DESCRIPTION
The sbserver didn't respect the verbose flag and would always return the extra info.