### PR TITLE
labels: Add LabelDistributionSource

### DIFF
--- a/integration/client/image_test.go
+++ b/integration/client/image_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	imagelist "github.com/containerd/containerd/integration/images"
+	"github.com/containerd/containerd/labels"
 	"github.com/containerd/containerd/platforms"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -105,7 +106,7 @@ func TestImagePullWithDistSourceLabel(t *testing.T) {
 	defer client.ImageService().Delete(ctx, imageName)
 
 	cs := client.ContentStore()
-	key := fmt.Sprintf("containerd.io/distribution.source.%s", source)
+	key := labels.LabelDistributionSource + "." + source
 
 	// only check the target platform
 	childrenHandler := images.LimitManifests(images.ChildrenHandler(cs), pMatcher, 1)

--- a/labels/labels.go
+++ b/labels/labels.go
@@ -23,3 +23,7 @@ const LabelUncompressed = "containerd.io/uncompressed"
 // LabelSharedNamespace is added to a namespace to allow that namespaces
 // contents to be shared.
 const LabelSharedNamespace = "containerd.io/namespace.shareable"
+
+// LabelDistributionSource is added to content to indicate its origin.
+// e.g., "containerd.io/distribution.source.docker.io=library/redis"
+const LabelDistributionSource = "containerd.io/distribution.source"

--- a/remotes/docker/handler.go
+++ b/remotes/docker/handler.go
@@ -30,11 +30,6 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-var (
-	// labelDistributionSource describes the source blob comes from.
-	labelDistributionSource = "containerd.io/distribution.source"
-)
-
 // AppendDistributionSourceLabel updates the label of blob with distribution source.
 func AppendDistributionSourceLabel(manager content.Manager, ref string) (images.HandlerFunc, error) {
 	refspec, err := reference.Parse(ref)
@@ -108,7 +103,7 @@ func appendDistributionSourceLabel(originLabel, repo string) string {
 }
 
 func distributionSourceLabelKey(source string) string {
-	return fmt.Sprintf("%s.%s", labelDistributionSource, source)
+	return fmt.Sprintf("%s.%s", labels.LabelDistributionSource, source)
 }
 
 // selectRepositoryMountCandidate will select the repo which has longest

--- a/remotes/docker/handler_test.go
+++ b/remotes/docker/handler_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/containerd/containerd/labels"
 	"github.com/containerd/containerd/reference"
 )
 
@@ -69,7 +70,7 @@ func TestAppendDistributionLabel(t *testing.T) {
 }
 
 func TestDistributionSourceLabelKey(t *testing.T) {
-	expected := "containerd.io/distribution.source.testsource"
+	expected := labels.LabelDistributionSource + ".testsource"
 	if got := distributionSourceLabelKey("testsource"); !reflect.DeepEqual(got, expected) {
 		t.Fatalf("expected %v, but got %v", expected, got)
 	}
@@ -116,12 +117,12 @@ func TestSelectRepositoryMountCandidate(t *testing.T) {
 		},
 		{
 			refspec:  reference.Spec{Locator: "user@host/path"},
-			source:   map[string]string{"containerd.io/distribution.source.host": "foo,path,bar"},
+			source:   map[string]string{labels.LabelDistributionSource + ".host": "foo,path,bar"},
 			expected: "bar",
 		},
 		{
 			refspec:  reference.Spec{Locator: "user@host/path"},
-			source:   map[string]string{"containerd.io/distribution.source.host": "foo,bar,path"},
+			source:   map[string]string{labels.LabelDistributionSource + ".host": "foo,bar,path"},
 			expected: "bar",
 		},
 	} {

--- a/remotes/handlers.go
+++ b/remotes/handlers.go
@@ -28,6 +28,7 @@ import (
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/labels"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/platforms"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -367,7 +368,7 @@ func annotateDistributionSourceHandler(f images.HandlerFunc, manager content.Man
 			}
 
 			for k, v := range info.Labels {
-				if !strings.HasPrefix(k, "containerd.io/distribution.source.") {
+				if !strings.HasPrefix(k, labels.LabelDistributionSource+".") {
 					continue
 				}
 


### PR DESCRIPTION
Add a public const for "containerd.io/distribution.source" in `labels` package and replace hardcoded usages.