### PR TITLE
Clean Unmount

### DIFF
--- a/mount/mount_linux.go
+++ b/mount/mount_linux.go
@@ -136,8 +136,8 @@ func isFUSE(dir string) bool {
 // https://github.com/containerd/containerd/pull/3765#discussion_r342083514
 func unmountFUSE(target string) error {
 	var err error
-	for _, helperBinary := range []string{"fusermount3", "fusermount"} {
-		cmd := exec.Command(helperBinary, "-u", target)
+	for _, helperBinary := range []string{"fusermount3", "fusermount", "fuser"} {
+		cmd := exec.Command(helperBinary, "-u -k", target)
 		err = cmd.Run()
 		if err == nil {
 			return nil


### PR DESCRIPTION
some machines does not have fusermount, thus we are using `fuser` with killing all the processes accessing it to umount, this will keep the container running, while do a clean unmount. 
```
root@n223-247-006:~# fusermount --help
-bash: fusermount: command not found
root@n223-247-006:~# fusermount3 --help
-bash: fusermount3: command not found
root@n223-247-006:~/test# fuser --help
fuser: Invalid option --help
Usage: fuser [-fIMuvw] [-a|-s] [-4|-6] [-c|-m|-n SPACE]
             [-k [-i] [-SIGNAL]] NAME...
       fuser -l
       fuser -V
Show which processes use the named files, sockets, or filesystems.

  -a,--all              display unused files too
  -i,--interactive      ask before killing (ignored without -k)
  -I,--inode            use always inodes to compare files
  -k,--kill             kill processes accessing the named file
  -l,--list-signals     list available signal names
  -m,--mount            show all processes using the named filesystems or
                        block device
  -M,--ismountpoint     fulfill request only if NAME is a mount point
  -n,--namespace SPACE  search in this name space (file, udp, or tcp)
  -s,--silent           silent operation
  -SIGNAL               send this signal instead of SIGKILL
  -u,--user             display user IDs
  -v,--verbose          verbose output
  -w,--writeonly        kill only processes with write access
  -V,--version          display version information
  -4,--ipv4             search IPv4 sockets only
  -6,--ipv6             search IPv6 sockets only
  -                     reset options

  udp/tcp names: [local_port][,[rmt_host][,[rmt_port]]]


```

1. in terminal 1, start a container
```
root@n223-247-006:~/containerd# ctr run docker.io/library/redis:alpine redis
1:C 07 Mar 2023 23:41:42.307 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
1:C 07 Mar 2023 23:41:42.307 # Redis version=7.0.9, bits=64, commit=00000000, modified=0, pid=1, just started
1:C 07 Mar 2023 23:41:42.307 # Warning: no config file specified, using the default config. In order to specify a config file use redis-server /path/to/redis.conf
1:M 07 Mar 2023 23:41:42.308 # You requested maxclients of 10000 requiring at least 10032 max file descriptors.
1:M 07 Mar 2023 23:41:42.308 # Server can't set maximum open files to 10032 because of OS error: Operation not permitted.
1:M 07 Mar 2023 23:41:42.308 # Current maximum open files is 1024. maxclients has been reduced to 992 to compensate for low ulimit. If you need higher maxclients increase 'ulimit -n'.
1:M 07 Mar 2023 23:41:42.308 * monotonic clock: POSIX clock_gettime
1:M 07 Mar 2023 23:41:42.308 * Running mode=standalone, port=6379.
1:M 07 Mar 2023 23:41:42.308 # Server initialized
1:M 07 Mar 2023 23:41:42.308 # WARNING Memory overcommit must be enabled! Without it, a background save or replication may fail under low memory condition. Being disabled, it can can also cause failures without low memory condition, see https://github.com/jemalloc/jemalloc/issues/1328. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
1:M 07 Mar 2023 23:41:42.309 * Ready to accept connections
```

2. in terminal 2

```
root@n223-247-006:~# ls ./test 
root@n223-247-006:~# ctr c list 
CONTAINER    IMAGE                              RUNTIME                  
redis        docker.io/library/redis:alpine     io.containerd.runc.v2    
ubuntu       docker.io/library/ubuntu:latest    io.containerd.runc.v2    
```
double check again 
```
root@n223-247-006:~# ctr images mount docker.io/library/redis:alpine ./test 
sha256:42bcbd783d4639b1ba39e09f3d884016c035092d687b4c5f37fdb102346c9aea
./test
root@n223-247-006:~# ctr c list 
CONTAINER    IMAGE                              RUNTIME                  
redis        docker.io/library/redis:alpine     io.containerd.runc.v2    
ubuntu       docker.io/library/ubuntu:latest    io.containerd.runc.v2    
root@n223-247-006:~# ctr images unmount ./test 
./test
root@n223-247-006:~# ctr c list 
CONTAINER    IMAGE                              RUNTIME                  
redis        docker.io/library/redis:alpine     io.containerd.runc.v2    
ubuntu       docker.io/library/ubuntu:latest    io.containerd.runc.v2    
 ```

Signed-off-by : wenhuizhang <wenhui@gwmail.gwu.edu>