### PR TITLE
[release/1.6] Go 1.19.7

### DIFF
--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19.6'
+          go-version: '1.19.7'
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 env:
   # Go version we currently use to build containerd across all CI.
   # Note: don't forget to update `Binaries` step, as it contains the matrix of all supported Go versions.
-  GO_VERSION: '1.19.6'
+  GO_VERSION: '1.19.7'
 
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read
@@ -233,7 +233,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-12, windows-2019, windows-2022]
-        go-version: ["1.17.13", "1.19.6"]
+        go-version: ["1.17.13", "1.19.7"]
     steps:
       - name: Install dependencies
         if: matrix.os == 'ubuntu-20.04'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
 
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.19.6
+        go-version: 1.19.7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19.6'
+          go-version: '1.19.7'
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,7 +7,7 @@ on:
       - '.github/workflows/nightly.yml'
 
 env:
-  GO_VERSION: '1.19.6'
+  GO_VERSION: '1.19.7'
 
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 name: Containerd Release
 
 env:
-  GO_VERSION: '1.19.6'
+  GO_VERSION: '1.19.7'
 
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -93,7 +93,7 @@ EOF
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.19.6",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.19.7",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -10,7 +10,7 @@
 #
 # docker build -t containerd-test --build-arg RUNC_VERSION=v1.0.0-rc94 -f Dockerfile.test ../
 
-ARG GOLANG_VERSION=1.19.6
+ARG GOLANG_VERSION=1.19.7
 ARG GOLANG_IMAGE=golang
 
 FROM ${GOLANG_IMAGE}:${GOLANG_VERSION} AS golang

--- a/script/setup/prepare_env_windows.ps1
+++ b/script/setup/prepare_env_windows.ps1
@@ -5,7 +5,7 @@
 # lived test environment.
 Set-MpPreference -DisableRealtimeMonitoring:$true
 
-$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.19.6"; make = ""; nssm = "" }
+$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.19.7"; make = ""; nssm = "" }
 
 Write-Host "Downloading chocolatey package"
 curl.exe -L "https://packages.chocolatey.org/chocolatey.0.10.15.nupkg" -o 'c:\choco.zip'


### PR DESCRIPTION
> go1.19.7 (released 2023-03-07) includes a security fix to the crypto/elliptic package,
> as well as bug fixes to the linker, the runtime, and the crypto/x509 and syscall
> packages.
> See the Go 1.19.7 milestone on our issue tracker for details.

https://go.dev/doc/devel/release#go1.19.minor