### PR TITLE
feat: add list container ids api

### DIFF
--- a/api/services/containers/v1/containers.pb.go
+++ b/api/services/containers/v1/containers.pb.go
@@ -314,6 +314,7 @@ type ListContainersRequest struct {
 	//
 	// If filters is zero-length or nil, all items will be returned.
 	Filters []string `protobuf:"bytes,1,rep,name=filters,proto3" json:"filters,omitempty"`
+	Quiet	bool	 `protobuf:"bytes,2,name=quiet,proto3" json:"quiet,omitempty"`
 }
 
 func (x *ListContainersRequest) Reset() {

--- a/api/services/containers/v1/containers.proto
+++ b/api/services/containers/v1/containers.proto
@@ -138,6 +138,7 @@ message ListContainersRequest {
 	//
 	// If filters is zero-length or nil, all items will be returned.
 	repeated string filters = 1;
+	bool quiet = 2;
 }
 
 message ListContainersResponse {

--- a/cmd/ctr/commands/containers/containers.go
+++ b/cmd/ctr/commands/containers/containers.go
@@ -102,16 +102,17 @@ var listCommand = cli.Command{
 			Usage: "Print only the container id",
 		},
 	},
-	Action: func(context *cli.Context) error {
+	Action: func(cliContext *cli.Context) error {
 		var (
-			filters = context.Args()
-			quiet   = context.Bool("quiet")
+			filters = cliContext.Args()
+			quiet   = cliContext.Bool("quiet")
 		)
-		client, ctx, cancel, err := commands.NewClient(context)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
 		defer cancel()
+		ctx = context.WithValue(ctx, "list_container_quiet", quiet)
 		containers, err := client.Containers(ctx, filters...)
 		if err != nil {
 			return err

--- a/cmd/ctr/commands/containers/containers.go
+++ b/cmd/ctr/commands/containers/containers.go
@@ -19,6 +19,7 @@ package containers
 import (
 	"context"
 	"fmt"
+	"github.com/containerd/containerd/metadata"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -112,7 +113,7 @@ var listCommand = cli.Command{
 			return err
 		}
 		defer cancel()
-		ctx = context.WithValue(ctx, "list_container_quiet", quiet)
+		ctx = context.WithValue(ctx, metadata.QuietListKey, quiet)
 		containers, err := client.Containers(ctx, filters...)
 		if err != nil {
 			return err

--- a/containers/containers.go
+++ b/containers/containers.go
@@ -97,6 +97,9 @@ type Store interface {
 	// store, an error will be returned.
 	Get(ctx context.Context, id string) (Container, error)
 
+	// ListQuietly returns containers with id only.
+	ListQuietly(ctx context.Context) ([]Container, error)
+
 	// List returns containers that match one or more of the provided filters.
 	List(ctx context.Context, filters ...string) ([]Container, error)
 

--- a/containers/containers.go
+++ b/containers/containers.go
@@ -97,8 +97,8 @@ type Store interface {
 	// store, an error will be returned.
 	Get(ctx context.Context, id string) (Container, error)
 
-	// ListQuietly returns containers with id only.
-	ListQuietly(ctx context.Context) ([]Container, error)
+	// ListIds returns containers with id only.
+	ListIds(ctx context.Context) ([]Container, error)
 
 	// List returns containers that match one or more of the provided filters.
 	List(ctx context.Context, filters ...string) ([]Container, error)

--- a/containerstore.go
+++ b/containerstore.go
@@ -55,6 +55,11 @@ func (r *remoteContainers) Get(ctx context.Context, id string) (containers.Conta
 	return containerFromProto(resp.Container), nil
 }
 
+func (r *remoteContainers) ListIds(ctx context.Context) ([]containers.Container, error) {
+	ctx = context.WithValue(ctx, "list_container_quiet", true)
+	return r.List(ctx)
+}
+
 func (r *remoteContainers) List(ctx context.Context, filters ...string) ([]containers.Container, error) {
 	containers, err := r.stream(ctx, filters...)
 	if err != nil {
@@ -73,7 +78,7 @@ func (r *remoteContainers) list(ctx context.Context, filters ...string) ([]conta
 	if err != nil {
 		return nil, errdefs.FromGRPC(err)
 	}
-	return containersFromProto(resp.Containers), nil
+	return containersFromProto(ctx, resp.Containers), nil
 }
 
 var errStreamNotAvailable = errors.New("streaming api not available")
@@ -103,7 +108,12 @@ func (r *remoteContainers) stream(ctx context.Context, filters ...string) ([]con
 		case <-ctx.Done():
 			return containers, ctx.Err()
 		default:
-			containers = append(containers, containerFromProto(c.Container))
+			fromProtoFunc := containerFromProto
+			quiet, ok := ctx.Value("list_container_quiet").(*bool)
+			if !ok || !*quiet {
+				fromProtoFunc = containerFromProtoWithIdOnly
+			}
+			containers = append(containers, fromProtoFunc(c.Container))
 		}
 	}
 }
@@ -170,6 +180,12 @@ func containerToProto(container *containers.Container) *containersapi.Container 
 	}
 }
 
+func containerFromProtoWithIdOnly(containerpb *containersapi.Container) containers.Container {
+	return containers.Container{
+		ID: containerpb.ID,
+	}
+}
+
 func containerFromProto(containerpb *containersapi.Container) containers.Container {
 	var runtime containers.RuntimeInfo
 	if containerpb.Runtime != nil {
@@ -198,12 +214,18 @@ func containerFromProto(containerpb *containersapi.Container) containers.Contain
 	}
 }
 
-func containersFromProto(containerspb []*containersapi.Container) []containers.Container {
+func containersFromProto(ctx context.Context, containerspb []*containersapi.Container) []containers.Container {
 	var containers []containers.Container
+
+	fromProtoFunc := containerFromProto
+	quiet, ok := ctx.Value("list_container_quiet").(*bool)
+	if !ok || !*quiet {
+		fromProtoFunc = containerFromProtoWithIdOnly
+	}
 
 	for _, container := range containerspb {
 		container := container
-		containers = append(containers, containerFromProto(container))
+		containers = append(containers, fromProtoFunc(container))
 	}
 
 	return containers

--- a/metadata/containers.go
+++ b/metadata/containers.go
@@ -73,6 +73,11 @@ func (s *containerStore) Get(ctx context.Context, id string) (containers.Contain
 	return container, nil
 }
 
+func (s *containerStore) ListQuietly(ctx context.Context) ([]containers.Container, error) {
+	ctx = context.WithValue(ctx, "list_container_quiet", true)
+	return s.List(ctx)
+}
+
 func (s *containerStore) List(ctx context.Context, fs ...string) ([]containers.Container, error) {
 	namespace, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {

--- a/metadata/containers.go
+++ b/metadata/containers.go
@@ -93,9 +93,10 @@ func (s *containerStore) List(ctx context.Context, fs ...string) ([]containers.C
 
 	var m []containers.Container
 
-	quiet, ok := ctx.Value("list_container_quiet").(*bool)
-	if !ok {
-		*quiet = false
+	var quiet = false
+	quietPtr, ok := ctx.Value(QuietListKey).(*bool)
+	if ok {
+		quiet = *quietPtr
 	}
 
 	if err := view(ctx, s.db, func(tx *bolt.Tx) error {
@@ -111,7 +112,7 @@ func (s *containerStore) List(ctx context.Context, fs ...string) ([]containers.C
 			}
 			container := containers.Container{ID: string(k)}
 
-			if *quiet {
+			if quiet {
 				//  quiet mode will return id directly, and filters won't work
 				m = append(m, container)
 				return nil

--- a/metadata/containers.go
+++ b/metadata/containers.go
@@ -73,7 +73,7 @@ func (s *containerStore) Get(ctx context.Context, id string) (containers.Contain
 	return container, nil
 }
 
-func (s *containerStore) ListQuietly(ctx context.Context) ([]containers.Container, error) {
+func (s *containerStore) ListIds(ctx context.Context) ([]containers.Container, error) {
 	ctx = context.WithValue(ctx, "list_container_quiet", true)
 	return s.List(ctx)
 }

--- a/metadata/containers.go
+++ b/metadata/containers.go
@@ -40,6 +40,8 @@ type containerStore struct {
 	db *DB
 }
 
+const QuietListKey = "list_container_quiet"
+
 // NewContainerStore returns a Store backed by an underlying bolt DB
 func NewContainerStore(db *DB) containers.Store {
 	return &containerStore{
@@ -74,7 +76,7 @@ func (s *containerStore) Get(ctx context.Context, id string) (containers.Contain
 }
 
 func (s *containerStore) ListIds(ctx context.Context) ([]containers.Container, error) {
-	ctx = context.WithValue(ctx, "list_container_quiet", true)
+	ctx = context.WithValue(ctx, QuietListKey, true)
 	return s.List(ctx)
 }
 

--- a/services/containers/helpers.go
+++ b/services/containers/helpers.go
@@ -28,8 +28,8 @@ import (
 
 func containersToProto(ctx context.Context, containers []containers.Container) []*api.Container {
 	toProtoFunc := containerToProto
-	quiet, ok := ctx.Value(metadata.QuietListKey).(*bool)
-	if !ok || !*quiet {
+	quietPtr, ok := ctx.Value(metadata.QuietListKey).(*bool)
+	if !ok || !*quietPtr {
 		toProtoFunc = containerToProtoWithIdOnly
 	}
 	var containerspb []*api.Container


### PR DESCRIPTION
Current list containers api fetches all containers' detail info (spec, extensions, etc.).

In my case, I need to filter container by some field in spec, like `environment variables` or `process args`, which can not be filterd by current list api directly. So I listed all containers and then do my custom filter by each. I found that it may cause OOM issue when list containers with all infomation filled, since my program running in a memory limited container environment (64MB).

This PR adds a function `ListIds`, it will return  container list with id field only, and then we can query each container details by id sepreately, instead of fetch all containers with full infomation at once, which may consumes lots of memory.