### PR TITLE
Sandbox: Correct/add some fields to Status()

### DIFF
--- a/plugins/sandbox/controller.go
+++ b/plugins/sandbox/controller.go
@@ -271,7 +271,9 @@ func (c *controllerLocal) Status(ctx context.Context, sandboxID string, verbose 
 		SandboxID: resp.GetSandboxID(),
 		Pid:       resp.GetPid(),
 		State:     resp.GetState(),
-		ExitedAt:  resp.GetCreatedAt().AsTime(),
+		Info:      resp.GetInfo(),
+		CreatedAt: resp.GetCreatedAt().AsTime(),
+		ExitedAt:  resp.GetExitedAt().AsTime(),
 		Extra:     resp.GetExtra(),
 	}, nil
 }


### PR DESCRIPTION
CreatedAt was being used as the ExitedAt timestamp, and Info from the shim response wasn't being set on the response.