### PR TITLE
Remove "containerd.io/restart.logpath" label (deprecated since v1.5)

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -375,7 +375,7 @@ The deprecated features are shown in the following table:
 | Runc V1 implementation of Runtime V2 (`io.containerd.runc.v1`)                   | containerd v1.4     | containerd v2.0            | Use `io.containerd.runc.v2`              |
 | config.toml `version = 1`                                                        | containerd v1.5     | containerd v2.0            | Use config.toml `version = 2`            |
 | Built-in `aufs` snapshotter                                                      | containerd v1.5     | containerd v2.0 ✅         | Use `overlayfs` snapshotter              |
-| Container label `containerd.io/restart.logpath`                                  | containerd v1.5     | containerd v2.0            | Use `containerd.io/restart.loguri` label |
+| Container label `containerd.io/restart.logpath`                                  | containerd v1.5     | containerd v2.0 ✅         | Use `containerd.io/restart.loguri` label |
 | `cri-containerd-*.tar.gz` release bundles                                        | containerd v1.6     | containerd v2.0            | Use `containerd-*.tar.gz` bundles        |
 | Pulling Schema 1 images (`application/vnd.docker.distribution.manifest.v1+json`) | containerd v1.7     | containerd v2.0            | Use Schema 2 or OCI images               |
 | CRI `v1alpha2`                                                                   | containerd v1.7     | containerd v2.0            | Use CRI `v1`                             |

--- a/runtime/restart/monitor/change.go
+++ b/runtime/restart/monitor/change.go
@@ -26,7 +26,6 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/runtime/restart"
-	"github.com/sirupsen/logrus"
 )
 
 type stopChange struct {
@@ -41,9 +40,6 @@ type startChange struct {
 	container containerd.Container
 	logURI    string
 	count     int
-
-	// Deprecated(in release 1.5): but recognized now, prefer to use logURI
-	logPath string
 }
 
 func (s *startChange) apply(ctx context.Context, client *containerd.Client) error {
@@ -55,13 +51,6 @@ func (s *startChange) apply(ctx context.Context, client *containerd.Client) erro
 			return fmt.Errorf("failed to parse %v into url: %w", s.logURI, err)
 		}
 		log = cio.LogURI(uri)
-	} else if s.logPath != "" {
-		log = cio.LogFile(s.logPath)
-	}
-
-	if s.logURI != "" && s.logPath != "" {
-		logrus.Warnf("LogPathLabel=%v has been deprecated, using LogURILabel=%v",
-			s.logPath, s.logURI)
 	}
 
 	if s.count > 0 {

--- a/runtime/restart/monitor/monitor.go
+++ b/runtime/restart/monitor/monitor.go
@@ -175,9 +175,11 @@ func (m *monitor) monitor(ctx context.Context) ([]change, error) {
 				continue
 			}
 			restartCount, _ := strconv.Atoi(labels[restart.CountLabel])
+			if labels["containerd.io/restart.logpath"] != "" {
+				logrus.Warn(`Label "containerd.io/restart.logpath" is no longer supported since containerd v2.0. Use "containerd.io/restart.loguri" instead.`)
+			}
 			changes = append(changes, &startChange{
 				container: c,
-				logPath:   labels[restart.LogPathLabel],
 				logURI:    labels[restart.LogURILabel],
 				count:     restartCount + 1,
 			})

--- a/runtime/restart/restart.go
+++ b/runtime/restart/restart.go
@@ -54,11 +54,6 @@ const (
 	CountLabel = "containerd.io/restart.count"
 	// ExplicitlyStoppedLabel sets the restart explicitly stopped label for a container
 	ExplicitlyStoppedLabel = "containerd.io/restart.explicitly-stopped"
-
-	// LogPathLabel sets the restart log path label for a container
-	//
-	// Deprecated(in release 1.5): use LogURILabel
-	LogPathLabel = "containerd.io/restart.logpath"
 )
 
 // Policy represents the restart policies of a container.
@@ -188,17 +183,6 @@ func WithFileLogURI(path string) func(context.Context, *containerd.Client, *cont
 	return WithLogURI(uri)
 }
 
-// WithLogPath sets the log path for a container
-//
-// Deprecated(in release 1.5): use WithLogURI with "file://<path>" URI.
-func WithLogPath(path string) func(context.Context, *containerd.Client, *containers.Container) error {
-	return func(_ context.Context, _ *containerd.Client, c *containers.Container) error {
-		ensureLabels(c)
-		c.Labels[LogPathLabel] = path
-		return nil
-	}
-}
-
 // WithStatus sets the status for a container
 func WithStatus(status containerd.ProcessStatus) func(context.Context, *containerd.Client, *containers.Container) error {
 	return func(_ context.Context, _ *containerd.Client, c *containers.Container) error {
@@ -224,7 +208,6 @@ func WithNoRestarts(_ context.Context, _ *containerd.Client, c *containers.Conta
 	}
 	delete(c.Labels, StatusLabel)
 	delete(c.Labels, PolicyLabel)
-	delete(c.Labels, LogPathLabel)
 	delete(c.Labels, LogURILabel)
 	return nil
 }


### PR DESCRIPTION
"containerd.io/restart.logpath" has been deprecated since containerd v1.5, in favor of "containerd.io/restart.loguri":
https://github.com/containerd/containerd/blob/v1.7.0/RELEASES.md#deprecated-features