### PR TITLE
Remove support for config.toml `version = 1`

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -373,7 +373,7 @@ The deprecated features are shown in the following table:
 |----------------------------------------------------------------------------------|---------------------|----------------------------|------------------------------------------|
 | Runtime V1 API and implementation (`io.containerd.runtime.v1.linux`)             | containerd v1.4     | containerd v2.0 ✅         | Use `io.containerd.runc.v2`              |
 | Runc V1 implementation of Runtime V2 (`io.containerd.runc.v1`)                   | containerd v1.4     | containerd v2.0 ✅         | Use `io.containerd.runc.v2`              |
-| config.toml `version = 1`                                                        | containerd v1.5     | containerd v2.0            | Use config.toml `version = 2`            |
+| config.toml `version = 1`                                                        | containerd v1.5     | containerd v2.0 ✅         | Use config.toml `version = 2`            |
 | Built-in `aufs` snapshotter                                                      | containerd v1.5     | containerd v2.0 ✅         | Use `overlayfs` snapshotter              |
 | Container label `containerd.io/restart.logpath`                                  | containerd v1.5     | containerd v2.0 ✅         | Use `containerd.io/restart.loguri` label |
 | `cri-containerd-*.tar.gz` release bundles                                        | containerd v1.6     | containerd v2.0            | Use `containerd-*.tar.gz` bundles        |

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -253,7 +253,7 @@ If you want to get the configuration combined with your configuration, run `cont
 
 containerd has two configuration versions:
 - Version 2 (Recommended): Introduced in containerd 1.3.
-- Version 1 (Default): Introduced in containerd 1.0. Deprecated and will be removed in containerd 2.0.
+- Version 1 (Default): Introduced in containerd 1.0. Removed in containerd 2.0.
 
 A configuration with Version 2 must have `version = 2` header, and must have
 fully qualified plugin IDs in the `[plugins]` section:

--- a/services/server/config/config_test.go
+++ b/services/server/config/config_test.go
@@ -226,10 +226,5 @@ func TestDecodePluginInV1Config(t *testing.T) {
 
 	var out Config
 	err = LoadConfig(path, &out)
-	assert.NoError(t, err)
-
-	pluginConfig := map[string]interface{}{}
-	_, err = out.Decode(&plugin.Registration{ID: "linux", Config: &pluginConfig})
-	assert.NoError(t, err)
-	assert.Equal(t, true, pluginConfig["shim_debug"])
+	assert.ErrorContains(t, err, "config version `1` is no longer supported")
 }


### PR DESCRIPTION
`version = 1` has been deprecated since containerd v1.5, and replaced by `version = 2`.

https://github.com/containerd/containerd/blob/main/docs/PLUGINS.md#version-header