### PR TITLE
Cleanup protobuild config

### DIFF
--- a/Protobuild.toml
+++ b/Protobuild.toml
@@ -13,15 +13,6 @@ generators = ["go"]
   # This is the default.
   after = ["/usr/local/include", "/usr/include"]
 
-[[overrides]]
-# enable ttrpc and disable fieldpath and grpc for the shim
-prefixes = [
-    "github.com/containerd/containerd/runtime/v1/shim/v1",
-    "github.com/containerd/containerd/api/runtime/task/v2",
-    "github.com/containerd/containerd/api/runtime/sandbox/v1",
-]
-generators = ["go", "go-ttrpc"]
-
 [[descriptors]]
 prefix = "github.com/containerd/containerd/runtime/v2/runc/options"
 target = "runtime/v2/runc/options/next.pb.txt"

--- a/api/Protobuild.toml
+++ b/api/Protobuild.toml
@@ -29,7 +29,6 @@ generators = ["go", "go-ttrpc", "go-fieldpath"]
 [[overrides]]
 # enable ttrpc and disable fieldpath and grpc for the shim
 prefixes = [
-  "github.com/containerd/containerd/runtime/v1/shim/v1",
   "github.com/containerd/containerd/api/runtime/task/v2",
 ]
 generators = ["go", "go-ttrpc"]


### PR DESCRIPTION
* `github.com/containerd/containerd/runtime/v1/shim/v1` has been removed

* The api's overrides configuration only needs to be in the *api/Protobuild.toml* file