### PR TITLE
fix: 'failed to resolve symlink' error messaging

### DIFF
--- a/pkg/cri/opts/spec_windows_opts.go
+++ b/pkg/cri/opts/spec_windows_opts.go
@@ -67,9 +67,10 @@ func parseMount(osi osinterface.OS, mount *runtime.Mount) (*runtimespec.Mount, e
 			}
 		}
 		var err error
+		originalSrc := src
 		src, err = osi.ResolveSymbolicLink(src)
 		if err != nil {
-			return nil, fmt.Errorf("failed to resolve symlink %q: %w", src, err)
+			return nil, fmt.Errorf("failed to resolve symlink '%q' (resolved to '%q'): %w", originalSrc, src, err)
 		}
 		// hcsshim requires clean path, especially '/' -> '\'. Additionally,
 		// for the destination, absolute paths should have the C: prefix.

--- a/pkg/cri/opts/spec_windows_opts.go
+++ b/pkg/cri/opts/spec_windows_opts.go
@@ -70,7 +70,7 @@ func parseMount(osi osinterface.OS, mount *runtime.Mount) (*runtimespec.Mount, e
 		originalSrc := src
 		src, err = osi.ResolveSymbolicLink(src)
 		if err != nil {
-			return nil, fmt.Errorf("failed to resolve symlink '%q' (resolved to '%q'): %w", originalSrc, src, err)
+			return nil, fmt.Errorf("failed to resolve symlink %q: %w", originalSrc, err)
 		}
 		// hcsshim requires clean path, especially '/' -> '\'. Additionally,
 		// for the destination, absolute paths should have the C: prefix.


### PR DESCRIPTION
This error message currently does not provide useful information, because the `src` value that is interleaved will have been overridden by the call to `osi.ResolveSymbolicLink`. This stores the original `src` before the `osi.ResolveSymbolicLink` call so the error message can be useful.