### PR TITLE
fix gcp containerd installation script

### DIFF
--- a/contrib/gce/configure.sh
+++ b/contrib/gce/configure.sh
@@ -110,6 +110,7 @@ GCS_BUCKET_TOKEN_METADATA="GCS_BUCKET_TOKEN"
 # GCS_BUCKET_TOKEN should have read access to the bucket from which
 # containerd artifacts need to be downloaded
 GCS_BUCKET_TOKEN=$(fetch_metadata "${GCS_BUCKET_TOKEN_METADATA}")
+declare -a HEADERS
 if [[ -n "${GCS_BUCKET_TOKEN}" ]]; then
   HEADERS=(-H "Authorization: Bearer ${GCS_BUCKET_TOKEN}")
 fi


### PR DESCRIPTION
declare HEADERS array before using it so that unbound variable error is not hit during variable expansion.

The containerd installation as part of [sig-node-containerd#containerd-e2e-ubuntu](https://testgrid.k8s.io/sig-node-containerd#containerd-e2e-ubuntu) is failing with the following error
```
ar 24 04:48:16.209506 bootstrap-e2e-master configure.sh[1009]: ++ set +x
Mar 24 04:48:16.209612 bootstrap-e2e-master configure.sh[1009]: /home/containerd/configure.sh: line 148: HEADERS[@]: unbound variable
Mar 24 04:48:16.209860 bootstrap-e2e-master configure.sh[1009]: + version=
Mar 24 04:48:16.210240 bootstrap-e2e-master systemd[1]: containerd-installation.service: Main process exited, code=exited, status=1/FAILURE
Mar 24 04:48:16.210331 bootstrap-e2e-master systemd[1]: containerd-installation.service: Failed with result 'exit-code'.
Mar 24 04:48:16.210868 bootstrap-e2e-master systemd[1]: Failed to start Download and install containerd binaries and configurations..
Mar 24 04:48:16.211068 bootstrap-e2e-master systemd[1]: containerd-installation.service: Consumed 210ms CPU time
```

Ref : https://github.com/kubernetes/kubernetes/issues/116873