### PR TITLE
[release/1.6] Prepare release notes for v1.6.20

### DIFF
--- a/releases/v1.6.20.toml
+++ b/releases/v1.6.20.toml
@@ -1,0 +1,27 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release
+previous = "v1.6.19"
+
+pre_release = false
+
+preface = """\
+The twentieth patch release for containerd 1.6 contains various fixes and updates.
+
+### Notable Updates
+
+* **Disable looking up usernames and groupnames on host** ([#8230](https://github.com/containerd/containerd/pull/8230))
+* **Add support for Windows ArgsEscaped images** ([#8273](https://github.com/containerd/containerd/pull/8273))
+* **Update hcsshim to v0.9.8** ([#8274](https://github.com/containerd/containerd/pull/8274))
+* **Fix debug flag in shim** ([#8288](https://github.com/containerd/containerd/pull/8288))
+* **Add `WithReadonlyTempMount` to support readonly temporary mounts** ([#8299](https://github.com/containerd/containerd/pull/8299))
+* **Update ttrpc to fix file descriptor leak** ([#8308](https://github.com/containerd/containerd/pull/8308))
+* **Update runc binary to v1.1.5** ([#8324](https://github.com/containerd/containerd/pull/8324))
+* **Update image config to support ArgsEscaped** ([#8306](https://github.com/containerd/containerd/pull/8306))
+
+See the changelog for complete list of changes"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.19+unknown"
+	Version = "1.6.20+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
See generated release notes below

----

Welcome to the v1.6.20 release of containerd!

The twentieth patch release for containerd 1.6 contains various fixes and updates.

### Notable Updates

* **Disable looking up usernames and groupnames on host** ([#8230](https://github.com/containerd/containerd/pull/8230))
* **Add support for Windows ArgsEscaped images** ([#8273](https://github.com/containerd/containerd/pull/8273))
* **Update hcsshim to v0.9.8** ([#8274](https://github.com/containerd/containerd/pull/8274))
* **Fix debug flag in shim** ([#8288](https://github.com/containerd/containerd/pull/8288))
* **Add `WithReadonlyTempMount` to support readonly temporary mounts** ([#8299](https://github.com/containerd/containerd/pull/8299))
* **Update ttrpc to fix file descriptor leak** ([#8308](https://github.com/containerd/containerd/pull/8308))

See the changelog for complete list of changes

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Sebastiaan van Stijn
* Maksym Pavlenko
* Derek McGowan
* Akihiro Suda
* Eng Zer Jun
* Kazuyoshi Kato
* Phil Estes
* Abirdcfly
* Gabriel Adrian Samfira
* Henry Wang
* Justin Terry
* Kang.Zhang
* Kirtana Ashok
* Laura Brehm
* Luca Comellini
* Paul "TBBle" Hampson
* Wei Fu
* ningmingxiao
* wanglei

### Changes
<details><summary>40 commits</summary>
<p>

  * [`877a540b6`](https://github.com/containerd/containerd/commit/877a540b68c734c5222a63e2409d9b6551d3d637) Prepare release notes for v1.6.20
* [release/1.6 backport] Add `WithReadonlyTempMount` to create readonly temporary mounts ([#8299](https://github.com/containerd/containerd/pull/8299))
  * [`8cead6594`](https://github.com/containerd/containerd/commit/8cead659440376c4a821d702f73c392f1c7fb8ce) Add `WithReadonlyTempMount` to create readonly temporary mounts
* [release/1.6] Adds support for Windows ArgsEscaped images ([#8273](https://github.com/containerd/containerd/pull/8273))
  * [`f0dc0297d`](https://github.com/containerd/containerd/commit/f0dc0297d02e223d997fc992496b07006c0c4a69) Adds support for Windows ArgsEscaped images
* [release/1.6]go.mod: Bump hcsshim tag to v0.9.8 ([#8274](https://github.com/containerd/containerd/pull/8274))
  * [`5981a24e2`](https://github.com/containerd/containerd/commit/5981a24e21a039c84f532c0e1ada85077c4101f1) Update hcsshim tag to v0.9.8
* [1.6] shim: fix debug flag not working ([#8288](https://github.com/containerd/containerd/pull/8288))
  * [`28f1e32e3`](https://github.com/containerd/containerd/commit/28f1e32e3b1b167eeab8890d67ed57817b3da29b) shim: fix debug flag not working
* [release/1.6] cherry-pick: Update go-restful to v3 ([#8271](https://github.com/containerd/containerd/pull/8271))
  * [`5a8ea75df`](https://github.com/containerd/containerd/commit/5a8ea75df7d2956cd711e4445eea9b6aac070835) Update go-restful to v3
  * [`59bdc1d5a`](https://github.com/containerd/containerd/commit/59bdc1d5a77ec7d5d57c66395de1bd2c1e27a55f) go.mod: update to github.com/emicklei/go-restful/v3 v3.7.3
* [release/1.6] Go 1.19.7 ([#8238](https://github.com/containerd/containerd/pull/8238))
  * [`86e0bd9e3`](https://github.com/containerd/containerd/commit/86e0bd9e3966ae686d7ab0a99a60f0212837028d) Go 1.19.7
* [release/1.6 backport] archive: disable looking up usernames and groupnames on the host ([#8230](https://github.com/containerd/containerd/pull/8230))
  * [`063ad2f19`](https://github.com/containerd/containerd/commit/063ad2f1949168fed35a5609d6a0c01c529da346) archive: disable looking up usernames and groupnames on the host
* [release/1.6 backport] assorted linting, and golang update-related changes ([#8229](https://github.com/containerd/containerd/pull/8229))
  * [`9cbea6fe7`](https://github.com/containerd/containerd/commit/9cbea6fe783f6ec6086bd85477ed2df659f10988) Enable dupword linter
  * [`c73f1abff`](https://github.com/containerd/containerd/commit/c73f1abff73657ea78d8a4762ff1b60324597896) Bump golangci-lint to v1.50.1
  * [`f198f7724`](https://github.com/containerd/containerd/commit/f198f7724d6d83261ba83f830d65103169608fc7) update golangci-lint to v1.49.0
  * [`e6179af1e`](https://github.com/containerd/containerd/commit/e6179af1ea994e1bdcc2c03f65223fa7256d9024) remove unneeded nolint-comments (nolintlint), disable deprecated linters
  * [`77160e6b5`](https://github.com/containerd/containerd/commit/77160e6b592ef44e4e800fac7736742dcf521f9c) [release/1.6] adjust some nolint comments
  * [`95655f4ce`](https://github.com/containerd/containerd/commit/95655f4ceedc29e44f13bb5b6b702f319c207b43) clean-up "nolint" comments, remove unused ones
  * [`9f0617ecc`](https://github.com/containerd/containerd/commit/9f0617ecc46ab189b2bd7d4839d89327f75b75ba) pkg/cri/(server|sbserver): criService.getTLSConfig() add TODO to verify nolint
  * [`e66397d83`](https://github.com/containerd/containerd/commit/e66397d838fa69e2653eba67e5e9ac081c84c69b) golangci-lint: sort linters in config file
  * [`682a567e9`](https://github.com/containerd/containerd/commit/682a567e9eb86c1a538067ad5bb36b2d6b59d4fc) linting: address gosec G112/G114
  * [`627f563e6`](https://github.com/containerd/containerd/commit/627f563e6d61d2ca98f77eef6322babf9f53553c) chore: remove duplicate word in comments
  * [`efb88a8bb`](https://github.com/containerd/containerd/commit/efb88a8bbcdbefe6b7c820aee5b41257af1fd093) pkg/cri/streaming: increase ReadHeaderTimeout
  * [`45f055df6`](https://github.com/containerd/containerd/commit/45f055df6617a5c05c494e6870694c8c11c13711) Update protobuf definitions
  * [`584707524`](https://github.com/containerd/containerd/commit/584707524ac08d5f5284fd76ded25f3845886587) Run gofmt 1.19
  * [`f33e38572`](https://github.com/containerd/containerd/commit/f33e38572758e178a7e57344983c139ac87a138e) Switch to Go 1.19
  * [`fc10cd23a`](https://github.com/containerd/containerd/commit/fc10cd23adc555c559b42e5c996bfb212cc4b50e) remove duplicate
  * [`7cbb9e746`](https://github.com/containerd/containerd/commit/7cbb9e746128e4ab87ee28bb6f833df928048fb0) Update linters to use t.Setenv
  * [`4347a3265`](https://github.com/containerd/containerd/commit/4347a3265a895d9f30602dc7dcb83c00e762892b) Use t.Setenv instead of os.Setenv
  * [`10357eab5`](https://github.com/containerd/containerd/commit/10357eab5f89aa875ff2fec3500416d86807d1da) Address some timeout issues in the Windows CI
  * [`977ce8ef5`](https://github.com/containerd/containerd/commit/977ce8ef508d5cdbf4d549458a0cc46cd14f7833) Enable gosec linter for golangci-lint
  * [`c23945c5f`](https://github.com/containerd/containerd/commit/c23945c5fab20269c98aa17337a247f6e9ec9175) test: remove redundant `mountPoint`
  * [`588ed91d3`](https://github.com/containerd/containerd/commit/588ed91d3fb93c77118e35ca09e73227ed81d3ff) test: use `T.TempDir` to create temporary test directory
  * [`c2ed63c86`](https://github.com/containerd/containerd/commit/c2ed63c86cacc0cf5e2e2729d2478c0c0385c039) Remove hardcoded /tmp in tempfile paths
  * [`7e382c516`](https://github.com/containerd/containerd/commit/7e382c516f80ea71aa9086d2cb9c0e83ec155222) fix Implicit memory aliasing in for loop
</p>
</details>

### Dependency Changes

* **github.com/Microsoft/hcsshim**       v0.9.7 -> v0.9.8
* **github.com/emicklei/go-restful/v3**  v3.7.3 **_new_**

Previous release can be found at [v1.6.19](https://github.com/containerd/containerd/releases/tag/v1.6.19)