### PR TITLE
devmapper plugin: skip plugin when not configured

### DIFF
--- a/snapshots/devmapper/plugin/plugin.go
+++ b/snapshots/devmapper/plugin/plugin.go
@@ -20,6 +20,7 @@ package plugin
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/plugin"
@@ -40,7 +41,7 @@ func init() {
 			}
 
 			if config.PoolName == "" {
-				return nil, errors.New("devmapper not configured")
+				return nil, fmt.Errorf("devmapper not configured: %w", plugin.ErrSkipPlugin)
 			}
 
 			if config.RootPath == "" {


### PR DESCRIPTION
This is not really an error in most cases as most people do not use devmapper, however this shows up as an error in the logs and in the plugin service when querying the plugins.
