### PR TITLE
fix: allow attaching to any combination of stdin/stdout/stderr

### DIFF
--- a/cio/io.go
+++ b/cio/io.go
@@ -166,6 +166,15 @@ func NewAttach(opts ...Opt) Attach {
 		if fifos == nil {
 			return nil, fmt.Errorf("cannot attach, missing fifos")
 		}
+		if streams.Stdin == nil {
+			fifos.Stdin = ""
+		}
+		if streams.Stdout == nil {
+			fifos.Stdout = ""
+		}
+		if streams.Stderr == nil {
+			fifos.Stderr = ""
+		}
 		return copyIO(fifos, streams)
 	}
 }


### PR DESCRIPTION
Before this PR, if a stdin/stdout/stderr stream is nil, and the corresponding FIFO is not an empty string, a panic will occur when `Read`/`Write` of the nil stream is invoked in `io.CopyBuffer`.