### PR TITLE
doc: update CI signal information in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ Binaries are generated from `main` branch every night for `Linux` and `Windows`.
 
 Please be aware: nightly builds might have critical bugs, it's not recommended for use in production and no support provided.
 
+## Kubernetes (k8s) CI Dashboard Group
+
+The [k8s CI dashboard group for containerd](https://testgrid.k8s.io/containerd) contains test results regarding
+the health of kubernetes when run against main and a number of containerd release branches.
+
+- [containerd-periodics](https://testgrid.k8s.io/containerd-periodic)
+
 ## Runtime Requirements
 
 Runtime requirements for containerd are very minimal. Most interactions with

--- a/releases/README.md
+++ b/releases/README.md
@@ -1,5 +1,14 @@
 ## containerd release process
 
+### containerd CI signal
+The [testgrid dashboard](https://testgrid.k8s.io/containerd-periodic) for containerd shows the current state of the
+containerd periodic build and test jobs. For cutting a release from branch `release/1.x`, the following should be
+verified:
+- `containerd-build-1.x` in [containerd-periodics](https://testgrid.k8s.io/containerd-periodic) should be passing.
+- [CI](https://github.com/containerd/containerd/actions/workflows/ci.yml) should be green for `release/1.x` branch.
+
+### Steps for making the release
+
 1. Create release pull request with release notes and updated versions.
 
    1. Compile release notes detailing features added since the last release and


### PR DESCRIPTION
- add the new testgrid dashboard information into the release doc and readme so that it can act as CI signal for a containerd release