### PR TITLE
[release/1.7] Add noexec nodev and nosuid to sandbox /etc/resolv.conf mount bind.

### DIFF
--- a/pkg/cri/sbserver/podsandbox/sandbox_run_linux.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_run_linux.go
@@ -117,7 +117,7 @@ func (c *Controller) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 			Source:      c.getResolvPath(id),
 			Destination: resolvConfPath,
 			Type:        "bind",
-			Options:     []string{"rbind", "ro"},
+			Options:     []string{"rbind", "ro", "nosuid", "nodev", "noexec"},
 		},
 	}))
 

--- a/pkg/cri/sbserver/podsandbox/sandbox_run_linux_test.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_run_linux_test.go
@@ -91,6 +91,14 @@ func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConf
 			assert.NotEqual(t, "", spec.Process.SelinuxLabel)
 			assert.NotEqual(t, "", spec.Linux.MountLabel)
 		}
+
+		assert.Contains(t, spec.Mounts, runtimespec.Mount{
+			Source:      "/test/root/sandboxes/test-id/resolv.conf",
+			Destination: resolvConfPath,
+			Type:        "bind",
+			Options:     []string{"rbind", "ro", "nosuid", "nodev", "noexec"},
+		})
+
 	}
 	return config, imageConfig, specCheck
 }

--- a/pkg/cri/server/sandbox_run_linux.go
+++ b/pkg/cri/server/sandbox_run_linux.go
@@ -135,7 +135,7 @@ func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 			Source:      c.getResolvPath(id),
 			Destination: resolvConfPath,
 			Type:        "bind",
-			Options:     []string{"rbind", "ro"},
+			Options:     []string{"rbind", "ro", "nosuid", "nodev", "noexec"},
 		},
 	}))
 

--- a/pkg/cri/server/sandbox_run_linux_test.go
+++ b/pkg/cri/server/sandbox_run_linux_test.go
@@ -91,6 +91,14 @@ func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConf
 			assert.NotEqual(t, "", spec.Process.SelinuxLabel)
 			assert.NotEqual(t, "", spec.Linux.MountLabel)
 		}
+
+		assert.Contains(t, spec.Mounts, runtimespec.Mount{
+			Source:      "/test/root/sandboxes/test-id/resolv.conf",
+			Destination: resolvConfPath,
+			Type:        "bind",
+			Options:     []string{"rbind", "ro", "nosuid", "nodev", "noexec"},
+		})
+
 	}
 	return config, imageConfig, specCheck
 }


### PR DESCRIPTION
If you are running a pod with user namespace enabled you might see EPERM errors while mounting resolv.conf without these options.

This was discovered while we were debugging: https://github.com/opencontainers/runc/issues/3770

cherry-pick: https://github.com/containerd/containerd/pull/8309