### PR TITLE
fix: cio.Cancel() should close the pipes

### DIFF
--- a/cio/io_unix.go
+++ b/cio/io_unix.go
@@ -98,7 +98,14 @@ func copyIO(fifos *FIFOSet, ioset *Streams) (*cio, error) {
 		config:  fifos.Config,
 		wg:      wg,
 		closers: append(pipes.closers(), fifos),
-		cancel:  cancel,
+		cancel: func() {
+			cancel()
+			for _, c := range pipes.closers() {
+				if c != nil {
+					c.Close()
+				}
+			}
+		},
 	}, nil
 }
 


### PR DESCRIPTION
PR fixes #8326 ([tested locally on my side](https://github.com/containerd/nerdctl/pull/2128#issuecomment-1491209753)). I'm not an expert of containerd though, so I'm not 100% sure if this has any negative side effects, and I appreciate any guidance on how this should be approached, thanks!