### PR TITLE
Move DefaultSnapshotter constants

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -626,7 +626,7 @@ func (c *Client) ContentStore() content.Store {
 func (c *Client) SnapshotService(snapshotterName string) snapshots.Snapshotter {
 	snapshotterName, err := c.resolveSnapshotterName(context.Background(), snapshotterName)
 	if err != nil {
-		snapshotterName = DefaultSnapshotter
+		snapshotterName = defaults.DefaultSnapshotter
 	}
 	if c.snapshotters != nil {
 		return c.snapshotters[snapshotterName]
@@ -801,7 +801,7 @@ func (c *Client) resolveSnapshotterName(ctx context.Context, name string) (strin
 		if label != "" {
 			name = label
 		} else {
-			name = DefaultSnapshotter
+			name = defaults.DefaultSnapshotter
 		}
 	}
 

--- a/cmd/ctr/commands/images/mount.go
+++ b/cmd/ctr/commands/images/mount.go
@@ -22,6 +22,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
+	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/errdefs"
 	"github.com/containerd/containerd/v2/leases"
 	"github.com/containerd/containerd/v2/mount"
@@ -69,7 +70,7 @@ When you are done, use the unmount command.
 
 		snapshotter := context.String("snapshotter")
 		if snapshotter == "" {
-			snapshotter = containerd.DefaultSnapshotter
+			snapshotter = defaults.DefaultSnapshotter
 		}
 
 		ctx, done, err := client.WithLease(ctx,

--- a/cmd/ctr/commands/images/usage.go
+++ b/cmd/ctr/commands/images/usage.go
@@ -23,6 +23,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
+	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/pkg/progress"
 
 	"github.com/opencontainers/image-spec/identity"
@@ -48,7 +49,7 @@ var usageCommand = cli.Command{
 
 		snapshotter := context.String("snapshotter")
 		if snapshotter == "" {
-			snapshotter = containerd.DefaultSnapshotter
+			snapshotter = defaults.DefaultSnapshotter
 		}
 
 		img, err := client.ImageService().Get(ctx, ref)

--- a/defaults/defaults_snapshotter_linux.go
+++ b/defaults/defaults_snapshotter_linux.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package client
+package defaults
 
 const (
 	// DefaultSnapshotter will set the default snapshotter for the platform.

--- a/defaults/defaults_snapshotter_unix.go
+++ b/defaults/defaults_snapshotter_unix.go
@@ -16,7 +16,7 @@
    limitations under the License.
 */
 
-package client
+package defaults
 
 const (
 	// DefaultSnapshotter will set the default snapshotter for the platform.

--- a/defaults/defaults_snapshotter_windows.go
+++ b/defaults/defaults_snapshotter_windows.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package client
+package defaults
 
 const (
 	// DefaultSnapshotter will set the default snapshotter for the platform.

--- a/integration/client/client.go
+++ b/integration/client/client.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"testing"
 
-	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/namespaces"
 	"github.com/containerd/log/logtest"
@@ -37,7 +36,7 @@ const (
 var (
 	address           string
 	ctrdStdioFilePath string
-	testSnapshotter   = containerd.DefaultSnapshotter
+	testSnapshotter   = defaults.DefaultSnapshotter
 	ctrd              = &daemon{}
 )
 

--- a/integration/client/client_test.go
+++ b/integration/client/client_test.go
@@ -129,7 +129,7 @@ func TestMain(m *testing.M) {
 		"snapshotter": os.Getenv("TEST_SNAPSHOTTER"),
 	}).Info("running tests against containerd")
 
-	snapshotter := DefaultSnapshotter
+	snapshotter := defaults.DefaultSnapshotter
 	if ss := os.Getenv("TEST_SNAPSHOTTER"); ss != "" {
 		snapshotter = ss
 	}

--- a/integration/client/image_test.go
+++ b/integration/client/image_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	. "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/errdefs"
 	"github.com/containerd/containerd/v2/images"
 	imagelist "github.com/containerd/containerd/v2/integration/images"
@@ -57,7 +58,7 @@ func TestImageIsUnpacked(t *testing.T) {
 	}
 
 	// Check that image is not unpacked
-	unpacked, err := image.IsUnpacked(ctx, DefaultSnapshotter)
+	unpacked, err := image.IsUnpacked(ctx, defaults.DefaultSnapshotter)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,11 +67,11 @@ func TestImageIsUnpacked(t *testing.T) {
 	}
 
 	// Check that image is unpacked
-	err = image.Unpack(ctx, DefaultSnapshotter)
+	err = image.Unpack(ctx, defaults.DefaultSnapshotter)
 	if err != nil {
 		t.Fatal(err)
 	}
-	unpacked, err = image.IsUnpacked(ctx, DefaultSnapshotter)
+	unpacked, err = image.IsUnpacked(ctx, defaults.DefaultSnapshotter)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,7 +219,7 @@ func TestImageUsage(t *testing.T) {
 		t.Fatalf("Expected actual usage to equal manifest reported usage of %d: got %d", s3, s)
 	}
 
-	err = image.Unpack(ctx, DefaultSnapshotter)
+	err = image.Unpack(ctx, defaults.DefaultSnapshotter)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -256,12 +257,12 @@ func TestImageSupportedBySnapshotter_Error(t *testing.T) {
 	_, err = client.Pull(ctx, unsupportedImage,
 		WithSchema1Conversion,
 		WithPlatform(platforms.DefaultString()),
-		WithPullSnapshotter(DefaultSnapshotter),
+		WithPullSnapshotter(defaults.DefaultSnapshotter),
 		WithPullUnpack,
 		WithUnpackOpts([]UnpackOpt{WithSnapshotterPlatformCheck()}),
 	)
 
 	if err == nil {
-		t.Fatalf("expected unpacking %s for snapshotter %s to fail", unsupportedImage, DefaultSnapshotter)
+		t.Fatalf("expected unpacking %s for snapshotter %s to fail", unsupportedImage, defaults.DefaultSnapshotter)
 	}
 }

--- a/integration/client/snapshot_test.go
+++ b/integration/client/snapshot_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	. "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/snapshots"
 	"github.com/containerd/containerd/v2/snapshots/testsuite"
 )
@@ -31,7 +32,7 @@ func newSnapshotter(ctx context.Context, root string) (snapshots.Snapshotter, fu
 		return nil, nil, err
 	}
 
-	sn := client.SnapshotService(DefaultSnapshotter)
+	sn := client.SnapshotService(defaults.DefaultSnapshotter)
 
 	return sn, func() error {
 		// no need to close remote snapshotter
@@ -44,5 +45,5 @@ func TestSnapshotterClient(t *testing.T) {
 		t.Skip()
 	}
 
-	testsuite.SnapshotterSuite(t, DefaultSnapshotter, newSnapshotter)
+	testsuite.SnapshotterSuite(t, defaults.DefaultSnapshotter, newSnapshotter)
 }

--- a/integration/image_pull_timeout_test.go
+++ b/integration/image_pull_timeout_test.go
@@ -40,6 +40,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/content"
+	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/leases"
 	"github.com/containerd/containerd/v2/namespaces"
 	criconfig "github.com/containerd/containerd/v2/pkg/cri/config"
@@ -476,7 +477,7 @@ func initLocalCRIImageService(client *containerd.Client, tmpDir string, registry
 	containerdRootDir := filepath.Join(tmpDir, "root")
 
 	cfg := criconfig.ImageConfig{
-		Snapshotter:              containerd.DefaultSnapshotter,
+		Snapshotter:              defaults.DefaultSnapshotter,
 		Registry:                 registryCfg,
 		ImagePullProgressTimeout: defaultImagePullProgressTimeout.String(),
 		StatsCollectPeriod:       10,
@@ -484,7 +485,7 @@ func initLocalCRIImageService(client *containerd.Client, tmpDir string, registry
 
 	return images.NewService(cfg, &images.CRIImageServiceOptions{
 		ImageFSPaths: map[string]string{
-			containerd.DefaultSnapshotter: containerdRootDir,
+			defaults.DefaultSnapshotter: containerdRootDir,
 		},
 		RuntimePlatforms: map[string]images.ImagePlatform{},
 		Content:          client.ContentStore(),

--- a/pkg/cri/config/config_unix.go
+++ b/pkg/cri/config/config_unix.go
@@ -19,14 +19,14 @@
 package config
 
 import (
-	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/defaults"
 	"github.com/pelletier/go-toml/v2"
 	"k8s.io/kubelet/pkg/cri/streaming"
 )
 
 func DefaultImageConfig() ImageConfig {
 	return ImageConfig{
-		Snapshotter:                containerd.DefaultSnapshotter,
+		Snapshotter:                defaults.DefaultSnapshotter,
 		DisableSnapshotAnnotations: true,
 		MaxConcurrentDownloads:     3,
 		ImageDecryption: ImageDecryption{

--- a/pkg/cri/config/config_windows.go
+++ b/pkg/cri/config/config_windows.go
@@ -20,13 +20,13 @@ import (
 	"os"
 	"path/filepath"
 
-	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/defaults"
 	"k8s.io/kubelet/pkg/cri/streaming"
 )
 
 func DefaultImageConfig() ImageConfig {
 	return ImageConfig{
-		Snapshotter:            containerd.DefaultSnapshotter,
+		Snapshotter:            defaults.DefaultSnapshotter,
 		StatsCollectPeriod:     10,
 		MaxConcurrentDownloads: 3,
 		ImageDecryption: ImageDecryption{

--- a/pkg/transfer/local/pull.go
+++ b/pkg/transfer/local/pull.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"fmt"
 
-	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/content"
+	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/errdefs"
 	"github.com/containerd/containerd/v2/images"
 	"github.com/containerd/containerd/v2/pkg/transfer"
@@ -286,7 +286,7 @@ func getSupportedPlatform(uc transfer.UnpackConfiguration, supportedPlatforms []
 			// Assume sp.SnapshotterKey is not empty
 			if uc.Snapshotter == sp.SnapshotterKey {
 				return true, sp
-			} else if uc.Snapshotter == "" && sp.SnapshotterKey == containerd.DefaultSnapshotter {
+			} else if uc.Snapshotter == "" && sp.SnapshotterKey == defaults.DefaultSnapshotter {
 				return true, sp
 			}
 		}

--- a/pkg/transfer/local/pull_test.go
+++ b/pkg/transfer/local/pull_test.go
@@ -19,7 +19,7 @@ package local
 import (
 	"testing"
 
-	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/pkg/transfer"
 	"github.com/containerd/containerd/v2/pkg/unpack"
 	"github.com/containerd/containerd/v2/platforms"
@@ -45,7 +45,7 @@ func TestGetSupportedPlatform(t *testing.T) {
 		},
 		{
 			Platform:       platforms.DefaultStrict(),
-			SnapshotterKey: containerd.DefaultSnapshotter,
+			SnapshotterKey: defaults.DefaultSnapshotter,
 		},
 	}
 
@@ -116,7 +116,7 @@ func TestGetSupportedPlatform(t *testing.T) {
 			Match:              true,
 			ExpectedPlatform: transfer.UnpackConfiguration{
 				Platform:    platforms.DefaultSpec(),
-				Snapshotter: containerd.DefaultSnapshotter,
+				Snapshotter: defaults.DefaultSnapshotter,
 			},
 		},
 	} {

--- a/plugins/transfer/plugin.go
+++ b/plugins/transfer/plugin.go
@@ -19,7 +19,7 @@ package transfer
 import (
 	"fmt"
 
-	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/diff"
 	"github.com/containerd/containerd/v2/errdefs"
 	"github.com/containerd/containerd/v2/leases"
@@ -172,7 +172,7 @@ func defaultConfig() *transferConfig {
 		UnpackConfiguration: []unpackConfiguration{
 			{
 				Platform:    platforms.Format(platforms.DefaultSpec()),
-				Snapshotter: containerd.DefaultSnapshotter,
+				Snapshotter: defaults.DefaultSnapshotter,
 			},
 		},
 	}


### PR DESCRIPTION
Move the DefaultSnapshotter constants to the defaults package. Fixes issue #8226.