### PR TITLE
runtime/shim: get logger from context 

### DIFF
--- a/pkg/oom/v1/v1.go
+++ b/pkg/oom/v1/v1.go
@@ -25,10 +25,10 @@ import (
 
 	"github.com/containerd/cgroups/v3/cgroup1"
 	eventstypes "github.com/containerd/containerd/api/events"
+	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/pkg/oom"
 	"github.com/containerd/containerd/runtime"
 	"github.com/containerd/containerd/runtime/v2/shim"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
@@ -79,7 +79,7 @@ func (e *epoller) Run(ctx context.Context) {
 				if err == unix.EINTR {
 					continue
 				}
-				logrus.WithError(err).Error("cgroups: epoll wait")
+				log.G(ctx).WithError(err).Error("cgroups: epoll wait")
 			}
 			for i := 0; i < n; i++ {
 				e.process(ctx, uintptr(events[i].Fd))
@@ -130,7 +130,7 @@ func (e *epoller) process(ctx context.Context, fd uintptr) {
 	if err := e.publisher.Publish(ctx, runtime.TaskOOMEventTopic, &eventstypes.TaskOOM{
 		ContainerID: i.id,
 	}); err != nil {
-		logrus.WithError(err).Error("publish OOM event")
+		log.G(ctx).WithError(err).Error("publish OOM event")
 	}
 }
 

--- a/pkg/oom/v2/v2.go
+++ b/pkg/oom/v2/v2.go
@@ -24,6 +24,7 @@ import (
 
 	cgroupsv2 "github.com/containerd/cgroups/v3/cgroup2"
 	eventstypes "github.com/containerd/containerd/api/events"
+	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/pkg/oom"
 	"github.com/containerd/containerd/runtime"
 	"github.com/containerd/containerd/runtime/v2/shim"
@@ -74,7 +75,7 @@ func (w *watcher) Run(ctx context.Context) {
 				if err := w.publisher.Publish(ctx, runtime.TaskOOMEventTopic, &eventstypes.TaskOOM{
 					ContainerID: i.id,
 				}); err != nil {
-					logrus.WithError(err).Error("publish OOM event")
+					log.G(ctx).WithError(err).Error("publish OOM event")
 				}
 			}
 			if i.ev.OOMKill > 0 {

--- a/runtime/v2/runc/util.go
+++ b/runtime/v2/runc/util.go
@@ -28,7 +28,6 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/runtime"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 )
 
 // GetTopic converts an event from an interface type to the specific
@@ -56,9 +55,8 @@ func GetTopic(e interface{}) string {
 	case *events.TaskCheckpointed:
 		return runtime.TaskCheckpointedEventTopic
 	default:
-		logrus.Warnf("no topic for type %#v", e)
+		return runtime.TaskUnknownTopic
 	}
-	return runtime.TaskUnknownTopic
 }
 
 // ShouldKillAllOnExit reads the bundle's OCI spec and returns true if

--- a/runtime/v2/shim/shim_windows.go
+++ b/runtime/v2/shim/shim_windows.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/ttrpc"
-	"github.com/sirupsen/logrus"
 )
 
 func setupSignals(config Config) (chan os.Signal, error) {
@@ -42,15 +41,15 @@ func subreaper() error {
 func setupDumpStacks(dump chan<- os.Signal) {
 }
 
-func serveListener(path string) (net.Listener, error) {
+func serveListener(ctx context.Context, path string) (net.Listener, error) {
 	return nil, errdefs.ErrNotImplemented
 }
 
-func reap(ctx context.Context, logger *logrus.Entry, signals chan os.Signal) error {
+func reap(ctx context.Context, signals chan os.Signal) error {
 	return errdefs.ErrNotImplemented
 }
 
-func handleExitSignals(ctx context.Context, logger *logrus.Entry, cancel context.CancelFunc) {
+func handleExitSignals(ctx context.Context, cancel context.CancelFunc) {
 }
 
 func openLog(ctx context.Context, _ string) (io.Writer, error) {


### PR DESCRIPTION
The logs for `shim-runc-v2` need to carry the runtime fields
```
level=info msg="loading plugin \"io.containerd.event.v1.publisher\"..." runtime=io.containerd.runc.v2 type=io.containerd.event.v1
```
But if we use logrus directly, the logs will not carry the runtime field, e.g. 
https://github.com/containerd/containerd/blob/6ec1c591dd927edaeaacbc11d229568ca61f02b9/runtime/v2/shim/shim.go#L443
log print
```
level=debug msg="registering ttrpc service" id=io.containerd.ttrpc.v1.task
```

Now use log.G(ctx) instead of logrus to print the logs, so that we can use the logger with the runtime fields.
```
level=debug msg="registering ttrpc service" id=io.containerd.ttrpc.v1.task runtime=io.containerd.runc.v2
```

But this does not fix the problem perfectly, because for example the `go-runc` and `cgroups` libraries do not have context info, which would prevent the use of log.G(ctx).
Perhaps logrus support for something like setting basic fields(`logrus.SetBaseFields`) would solve this problem, but logrus is in maintenance-mode and will not be introducing new features.

However, I think it would make sense to replace logrus with log.G(ctx) whenever possible.