### PR TITLE
Resolve Go cache warnings in GitHub Actions CI

### DIFF
--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -41,13 +41,14 @@ jobs:
         working-directory: src/github.com/containerd/containerd
 
     steps:
-      - uses: actions/setup-go@v4
-        with:
-          go-version: "1.20.3"
-
       - uses: actions/checkout@v3
         with:
           path: src/github.com/containerd/containerd
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.20.3"
+          cache-dependency-path: src/github.com/containerd/containerd
 
       - name: Set env
         shell: bash

--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -41,7 +41,7 @@ jobs:
         working-directory: src/github.com/containerd/containerd
 
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: "1.20.3"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,11 @@ jobs:
         os: [ubuntu-20.04, macos-12, windows-2019]
 
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - uses: actions/checkout@v3
       - uses: golangci/golangci-lint-action@v3
         with:
           version: v1.51.1
@@ -55,14 +55,15 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
       - uses: actions/checkout@v3
         with:
           path: src/github.com/containerd/containerd
           fetch-depth: 100
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: src/github.com/containerd/containerd
 
       - uses: containerd/project-checks@v1.1.0
         with:
@@ -88,13 +89,14 @@ jobs:
         working-directory: src/github.com/containerd/containerd
 
     steps:
-      - uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
       - uses: actions/checkout@v3
         with:
           path: src/github.com/containerd/containerd
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: src/github.com/containerd/containerd
 
       - name: Set env
         shell: bash
@@ -120,10 +122,10 @@ jobs:
     timeout-minutes: 5
 
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-      - uses: actions/checkout@v3
       - run: go install github.com/cpuguy83/go-md2man/v2@v2.0.2
       - run: make man
 
@@ -153,10 +155,10 @@ jobs:
             goarm: "7"
 
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-      - uses: actions/checkout@v3
       - run: |
           set -e -x
 
@@ -209,11 +211,11 @@ jobs:
         os: [ubuntu-20.04, macos-12, windows-2019, windows-2022]
         go-version: ["1.20.3", "1.19.8"]
     steps:
+      - uses: actions/checkout@v3
+
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
-
-      - uses: actions/checkout@v3
 
       - name: Make
         run: |
@@ -243,13 +245,14 @@ jobs:
         working-directory: src/github.com/containerd/containerd
 
     steps:
-      - uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
       - uses: actions/checkout@v3
         with:
           path: src/github.com/containerd/containerd
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: src/github.com/containerd/containerd
 
       - uses: actions/checkout@v3
         with:
@@ -398,11 +401,11 @@ jobs:
     env:
       GOTEST: gotestsum --
     steps:
+      - uses: actions/checkout@v3
+
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      - uses: actions/checkout@v3
 
       - name: Install containerd dependencies
         env:
@@ -522,10 +525,10 @@ jobs:
       GOTEST: gotestsum --
 
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-      - uses: actions/checkout@v3
       - run: script/setup/install-gotestsum
       - run: script/setup/install-teststat
       - name: Tests

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.20.3
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -40,10 +40,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
           # FIXME: go-fuzz fails with Go 1.20: `cgo_unix_cgo_res.cgo2.c:(.text+0x32): undefined reference to `__res_search'`
           # https://github.com/containerd/containerd/pull/8103#issuecomment-1429256152
           go-version: 1.18
-      - uses: actions/checkout@v3
       - run: script/go-test-fuzz.sh

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           # FIXME: go-fuzz fails with Go 1.20: `cgo_unix_cgo_res.cgo2.c:(.text+0x32): undefined reference to `__res_search'`
           # https://github.com/containerd/containerd/pull/8103#issuecomment-1429256152

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -26,7 +26,7 @@ jobs:
         working-directory: src/github.com/containerd/containerd
 
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: "1.20.3"
 

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -26,13 +26,14 @@ jobs:
         working-directory: src/github.com/containerd/containerd
 
     steps:
-      - uses: actions/setup-go@v4
-        with:
-          go-version: "1.20.3"
-
       - uses: actions/checkout@v3
         with:
           path: src/github.com/containerd/containerd
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.20.3"
+          cache-dependency-path: src/github.com/containerd/containerd
 
       - name: Set env
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,13 +23,14 @@ jobs:
         working-directory: src/github.com/containerd/containerd
 
     steps:
-      - uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
       - uses: actions/checkout@v3
         with:
           path: src/github.com/containerd/containerd
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: src/github.com/containerd/containerd
 
       - name: Set env
         shell: bash
@@ -156,13 +157,14 @@ jobs:
         working-directory: src/github.com/containerd/containerd
 
     steps:
-      - uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
       - uses: actions/checkout@v3
         with:
           path: src/github.com/containerd/containerd
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: src/github.com/containerd/containerd
 
       - name: Set env
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,7 +23,7 @@ jobs:
         working-directory: src/github.com/containerd/containerd
 
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -156,7 +156,7 @@ jobs:
         working-directory: src/github.com/containerd/containerd
 
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
 


### PR DESCRIPTION
Release [v4.0.0](https://github.com/actions/setup-go/releases/tag/v4.0.0) of actions/setup-go enabled Go cache by default. This has resulted in some warnings showing up in CI workflows for cache restore failures.

A recent [CI workflow run](https://github.com/containerd/containerd/actions/runs/4681406232) is showing up to 28 instances of 
```
Restore cache failed: Dependencies file is not found in /home/runner/work/containerd/containerd. Supported file pattern: go.sum
```

This warning can be resolved by performing checkout before setup-go and specifying the `cache-dependency-path` when checkout step specifies a working-directory.

This pull request also includes a preliminary commit to upgrade all workflows to `actions/setup-go@v4` to proactively resolve future occurrences of this issue.

Signed-off-by: Austin Vazquez <macedonv@amazon.com>