### PR TITLE
try fetch token again when token timeouts

### DIFF
--- a/remotes/docker/authorizer.go
+++ b/remotes/docker/authorizer.go
@@ -153,6 +153,11 @@ func (a *dockerAuthorizer) AddResponses(ctx context.Context, responses []*http.R
 				return err
 			}
 
+			if c.Parameters["error"] == "invalid_token" {
+				log.G(ctx).Debug("caught invalid token, cleanup auth handler and try again")
+				delete(a.handlers, host)
+			}
+
 			// reuse existing handler
 			//
 			// assume that one registry will return the common


### PR DESCRIPTION
when max_concurrent_download is specified, get requests are not sent immediately for all layers. Token might timeout and we need to try to fetch it again.

eg. max_concurrent_download = 3, fooimg:latest has 4 blob layers, network is poor and first 3 layers took 2hr to finish downloading. when 4th layer begins, it tries to reused the token in host(which has already expired), invalid_token err is thrown.