### PR TITLE
runtime/shim: fix the nil checkpoint options

### DIFF
--- a/runtime/v2/runc/container.go
+++ b/runtime/v2/runc/container.go
@@ -470,13 +470,12 @@ func (c *Container) Checkpoint(ctx context.Context, r *task.CheckpointTaskReques
 	if err != nil {
 		return err
 	}
-	var opts *options.CheckpointOptions
+
+	var opts options.CheckpointOptions
 	if r.Options != nil {
-		v, err := typeurl.UnmarshalAny(r.Options)
-		if err != nil {
+		if err := typeurl.UnmarshalTo(r.Options, &opts); err != nil {
 			return err
 		}
-		opts = v.(*options.CheckpointOptions)
 	}
 	return p.(*process.Init).Checkpoint(ctx, &process.CheckpointConfig{
 		Path:                     r.Path,


### PR DESCRIPTION
When `(*task.CheckpointTaskRequest).Options` is nil, it will panic
```
Apr 14 23:39:33 caiwei-master containerd[1219760]: panic: runtime error: invalid memory address or nil pointer dereference
Apr 14 23:39:33 caiwei-master containerd[1219760]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x79b9c0]
Apr 14 23:39:33 caiwei-master containerd[1219760]: goroutine 97 [running]:
Apr 14 23:39:33 caiwei-master containerd[1219760]: github.com/containerd/containerd/runtime/v2/runc.(*Container).Checkpoint(0xc00020c540?, {0xb706c0, 0xc000242060}, 0xc000340050)
Apr 14 23:39:33 caiwei-master containerd[1219760]:         /Users/icebergu/workspace/containerd/runtime/v2/runc/container.go:483 +0xc0
Apr 14 23:39:33 caiwei-master containerd[1219760]: github.com/containerd/containerd/runtime/v2/runc/task.(*service).Checkpoint(0xa2fc00?, {0xb706c0, 0xc000242060}, 0xc000340050)
Apr 14 23:39:33 caiwei-master containerd[1219760]:         /Users/icebergu/workspace/containerd/runtime/v2/runc/task/service.go:411 +0x53
Apr 14 23:39:33 caiwei-master containerd[1219760]: github.com/containerd/containerd/api/runtime/task/v2.RegisterTaskService.func8({0xb706c0, 0xc000242060}, 0xc0002a6040)
Apr 14 23:39:33 caiwei-master containerd[1219760]:         /Users/icebergu/workspace/containerd/api/runtime/task/v2/shim_ttrpc.pb.go:88 +0x98
Apr 14 23:39:33 caiwei-master containerd[1219760]: github.com/containerd/ttrpc.defaultServerInterceptor({0xb706c0?, 0xc000242060?}, 0xc0000c6181?, 0x7faa7d657f38?, 0x8?)
Apr 14 23:39:33 caiwei-master containerd[1219760]:         /Users/icebergu/workspace/containerd/vendor/github.com/containerd/ttrpc/interceptor.go:52 +0x26
Apr 14 23:39:33 caiwei-master containerd[1219760]: github.com/containerd/ttrpc.(*serviceSet).unaryCall(0xc0000b65b8, {0xb706c0, 0xc000242060}, 0xc0000c6120?, 0x49f72a3?, {0xc0000c6000, 0x24, 0x30})
Apr 14 23:39:33 caiwei-master containerd[1219760]:         /Users/icebergu/workspace/containerd/vendor/github.com/containerd/ttrpc/services.go:75 +0xe5
Apr 14 23:39:33 caiwei-master containerd[1219760]: github.com/containerd/ttrpc.(*serviceSet).handle.func1()
Apr 14 23:39:33 caiwei-master containerd[1219760]:         /Users/icebergu/workspace/containerd/vendor/github.com/containerd/ttrpc/services.go:118 +0x16d
Apr 14 23:39:33 caiwei-master containerd[1219760]: created by github.com/containerd/ttrpc.(*serviceSet).handle
Apr 14 23:39:33 caiwei-master containerd[1219760]:         /Users/icebergu/workspace/containerd/vendor/github.com/containerd/ttrpc/services.go:111 +0x17b
```