### PR TITLE
oci: partially restore comment on read-only mounts for uid/gid uses

### DIFF
--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -683,6 +683,10 @@ func WithUser(userstr string) SpecOpts {
 				return err
 			}
 
+			// Use a read-only mount when trying to get user/group information
+			// from the container's rootfs. Since the option does read operation
+			// only, we append ReadOnly mount option to prevent the Linux kernel
+			// from syncing whole filesystem in umount syscall.
 			return mount.WithReadonlyTempMount(ctx, mounts, f)
 		default:
 			return fmt.Errorf("invalid USER value %s", userstr)
@@ -743,6 +747,10 @@ func WithUserID(uid uint32) SpecOpts {
 			return err
 		}
 
+		// Use a read-only mount when trying to get user/group information
+		// from the container's rootfs. Since the option does read operation
+		// only, we append ReadOnly mount option to prevent the Linux kernel
+		// from syncing whole filesystem in umount syscall.
 		return mount.WithReadonlyTempMount(ctx, mounts, setUser)
 	}
 }
@@ -787,6 +795,10 @@ func WithUsername(username string) SpecOpts {
 				return err
 			}
 
+			// Use a read-only mount when trying to get user/group information
+			// from the container's rootfs. Since the option does read operation
+			// only, we append ReadOnly mount option to prevent the Linux kernel
+			// from syncing whole filesystem in umount syscall.
 			return mount.WithReadonlyTempMount(ctx, mounts, setUser)
 		} else if s.Windows != nil {
 			s.Process.User.Username = username
@@ -865,6 +877,10 @@ func WithAdditionalGIDs(userstr string) SpecOpts {
 			return err
 		}
 
+		// Use a read-only mount when trying to get user/group information
+		// from the container's rootfs. Since the option does read operation
+		// only, we append ReadOnly mount option to prevent the Linux kernel
+		// from syncing whole filesystem in umount syscall.
 		return mount.WithReadonlyTempMount(ctx, mounts, setAdditionalGids)
 	}
 }
@@ -926,6 +942,10 @@ func WithAppendAdditionalGroups(groups ...string) SpecOpts {
 			return err
 		}
 
+		// Use a read-only mount when trying to get user/group information
+		// from the container's rootfs. Since the option does read operation
+		// only, we append ReadOnly mount option to prevent the Linux kernel
+		// from syncing whole filesystem in umount syscall.
 		return mount.WithReadonlyTempMount(ctx, mounts, setAdditionalGids)
 	}
 }


### PR DESCRIPTION
- relates to https://github.com/containerd/containerd/pull/8259
- relates to https://github.com/containerd/containerd/pull/8351 https://github.com/containerd/containerd/pull/8351#pullrequestreview-1375706340



Commit cab056226fd8cece14d334ebb4f9084d0e3a7f47 removed the tryReadonlyMounts utility, in favor of mounts.ReadOnlyMounts() that was added in commit daa3a7665eaa2e33a965376106e02d358925c132.

That change made part of the comment redundant, because mounts.ReadOnlyMounts handles both overlayfs read-only mounts (by skipping the workdir mounts), and sets the "ro" option for other mount-types, but the reason why we're using a read-only mount is still relevant, so restoring that part of the comment.
