### PR TITLE
Add support for proxy differ

### DIFF
--- a/contrib/diffservice/service.go
+++ b/contrib/diffservice/service.go
@@ -1,0 +1,140 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package diffservice
+
+import (
+	"context"
+
+	diffapi "github.com/containerd/containerd/api/services/diff/v1"
+	"github.com/containerd/containerd/api/types"
+	"github.com/containerd/containerd/diff"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/typeurl/v2"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type service struct {
+	applier  diff.Applier
+	comparer diff.Comparer
+	diffapi.UnimplementedDiffServer
+}
+
+func FromApplierAndComparer(a diff.Applier, c diff.Comparer) diffapi.DiffServer {
+	return &service{
+		applier:  a,
+		comparer: c,
+	}
+}
+func (s *service) Apply(ctx context.Context, er *diffapi.ApplyRequest) (*diffapi.ApplyResponse, error) {
+	if s.applier == nil {
+		return nil, errdefs.ToGRPC(errdefs.ErrNotImplemented)
+	}
+
+	var (
+		ocidesc ocispec.Descriptor
+		err     error
+		desc    = toDescriptor(er.Diff)
+		mounts  = toMounts(er.Mounts)
+	)
+
+	var opts []diff.ApplyOpt
+	if er.Payloads != nil {
+		payloads := make(map[string]typeurl.Any)
+		for k, v := range er.Payloads {
+			payloads[k] = v
+		}
+		opts = append(opts, diff.WithPayloads(payloads))
+	}
+
+	ocidesc, err = s.applier.Apply(ctx, desc, mounts, opts...)
+	if err != nil {
+		return nil, errdefs.ToGRPC(err)
+	}
+
+	return &diffapi.ApplyResponse{
+		Applied: fromDescriptor(ocidesc),
+	}, nil
+}
+
+func (s *service) Diff(ctx context.Context, dr *diffapi.DiffRequest) (*diffapi.DiffResponse, error) {
+	if s.comparer == nil {
+		return nil, errdefs.ToGRPC(errdefs.ErrNotImplemented)
+	}
+	var (
+		ocidesc ocispec.Descriptor
+		err     error
+		aMounts = toMounts(dr.Left)
+		bMounts = toMounts(dr.Right)
+	)
+
+	var opts []diff.Opt
+	if dr.MediaType != "" {
+		opts = append(opts, diff.WithMediaType(dr.MediaType))
+	}
+	if dr.Ref != "" {
+		opts = append(opts, diff.WithReference(dr.Ref))
+	}
+	if dr.Labels != nil {
+		opts = append(opts, diff.WithLabels(dr.Labels))
+	}
+	if dr.SourceDateEpoch != nil {
+		tm := dr.SourceDateEpoch.AsTime()
+		opts = append(opts, diff.WithSourceDateEpoch(&tm))
+	}
+
+	ocidesc, err = s.comparer.Compare(ctx, aMounts, bMounts, opts...)
+	if err != nil {
+		return nil, errdefs.ToGRPC(err)
+	}
+
+	return &diffapi.DiffResponse{
+		Diff: fromDescriptor(ocidesc),
+	}, nil
+}
+
+func toMounts(apim []*types.Mount) []mount.Mount {
+	mounts := make([]mount.Mount, len(apim))
+	for i, m := range apim {
+		mounts[i] = mount.Mount{
+			Type:    m.Type,
+			Source:  m.Source,
+			Target:  m.Target,
+			Options: m.Options,
+		}
+	}
+	return mounts
+}
+
+func toDescriptor(d *types.Descriptor) ocispec.Descriptor {
+	return ocispec.Descriptor{
+		MediaType:   d.MediaType,
+		Digest:      digest.Digest(d.Digest),
+		Size:        d.Size,
+		Annotations: d.Annotations,
+	}
+}
+
+func fromDescriptor(d ocispec.Descriptor) *types.Descriptor {
+	return &types.Descriptor{
+		MediaType:   d.MediaType,
+		Digest:      d.Digest.String(),
+		Size:        d.Size,
+		Annotations: d.Annotations,
+	}
+}

--- a/diff.go
+++ b/diff.go
@@ -17,19 +17,9 @@
 package containerd
 
 import (
-	"context"
-
 	diffapi "github.com/containerd/containerd/api/services/diff/v1"
-	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/diff"
-	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/mount"
-	"github.com/containerd/containerd/pkg/epoch"
-	"github.com/containerd/containerd/protobuf"
-	ptypes "github.com/containerd/containerd/protobuf/types"
-	"github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"google.golang.org/protobuf/types/known/timestamppb"
+	"github.com/containerd/containerd/diff/proxy"
 )
 
 // DiffService handles the computation and application of diffs
@@ -41,96 +31,5 @@ type DiffService interface {
 // NewDiffServiceFromClient returns a new diff service which communicates
 // over a GRPC connection.
 func NewDiffServiceFromClient(client diffapi.DiffClient) DiffService {
-	return &diffRemote{
-		client: client,
-	}
-}
-
-type diffRemote struct {
-	client diffapi.DiffClient
-}
-
-func (r *diffRemote) Apply(ctx context.Context, desc ocispec.Descriptor, mounts []mount.Mount, opts ...diff.ApplyOpt) (ocispec.Descriptor, error) {
-	var config diff.ApplyConfig
-	for _, opt := range opts {
-		if err := opt(ctx, desc, &config); err != nil {
-			return ocispec.Descriptor{}, err
-		}
-	}
-
-	payloads := make(map[string]*ptypes.Any)
-	for k, v := range config.ProcessorPayloads {
-		payloads[k] = protobuf.FromAny(v)
-	}
-
-	req := &diffapi.ApplyRequest{
-		Diff:     fromDescriptor(desc),
-		Mounts:   fromMounts(mounts),
-		Payloads: payloads,
-	}
-	resp, err := r.client.Apply(ctx, req)
-	if err != nil {
-		return ocispec.Descriptor{}, errdefs.FromGRPC(err)
-	}
-	return toDescriptor(resp.Applied), nil
-}
-
-func (r *diffRemote) Compare(ctx context.Context, a, b []mount.Mount, opts ...diff.Opt) (ocispec.Descriptor, error) {
-	var config diff.Config
-	for _, opt := range opts {
-		if err := opt(&config); err != nil {
-			return ocispec.Descriptor{}, err
-		}
-	}
-	if tm := epoch.FromContext(ctx); tm != nil && config.SourceDateEpoch == nil {
-		config.SourceDateEpoch = tm
-	}
-	var sourceDateEpoch *timestamppb.Timestamp
-	if config.SourceDateEpoch != nil {
-		sourceDateEpoch = timestamppb.New(*config.SourceDateEpoch)
-	}
-	req := &diffapi.DiffRequest{
-		Left:            fromMounts(a),
-		Right:           fromMounts(b),
-		MediaType:       config.MediaType,
-		Ref:             config.Reference,
-		Labels:          config.Labels,
-		SourceDateEpoch: sourceDateEpoch,
-	}
-	resp, err := r.client.Diff(ctx, req)
-	if err != nil {
-		return ocispec.Descriptor{}, errdefs.FromGRPC(err)
-	}
-	return toDescriptor(resp.Diff), nil
-}
-
-func toDescriptor(d *types.Descriptor) ocispec.Descriptor {
-	return ocispec.Descriptor{
-		MediaType:   d.MediaType,
-		Digest:      digest.Digest(d.Digest),
-		Size:        d.Size,
-		Annotations: d.Annotations,
-	}
-}
-
-func fromDescriptor(d ocispec.Descriptor) *types.Descriptor {
-	return &types.Descriptor{
-		MediaType:   d.MediaType,
-		Digest:      d.Digest.String(),
-		Size:        d.Size,
-		Annotations: d.Annotations,
-	}
-}
-
-func fromMounts(mounts []mount.Mount) []*types.Mount {
-	apiMounts := make([]*types.Mount, len(mounts))
-	for i, m := range mounts {
-		apiMounts[i] = &types.Mount{
-			Type:    m.Type,
-			Source:  m.Source,
-			Target:  m.Target,
-			Options: m.Options,
-		}
-	}
-	return apiMounts
+	return proxy.NewDiffApplier(client).(DiffService)
 }

--- a/diff/proxy/differ.go
+++ b/diff/proxy/differ.go
@@ -1,0 +1,131 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package proxy
+
+import (
+	"context"
+
+	diffapi "github.com/containerd/containerd/api/services/diff/v1"
+	"github.com/containerd/containerd/api/types"
+	"github.com/containerd/containerd/diff"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/pkg/epoch"
+	"github.com/containerd/containerd/protobuf"
+	ptypes "github.com/containerd/containerd/protobuf/types"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// NewDiffApplier returns a new comparer and applier which communicates
+// over a GRPC connection.
+func NewDiffApplier(client diffapi.DiffClient) interface{} {
+	return &diffRemote{
+		client: client,
+	}
+}
+
+type diffRemote struct {
+	client diffapi.DiffClient
+}
+
+func (r *diffRemote) Apply(ctx context.Context, desc ocispec.Descriptor, mounts []mount.Mount, opts ...diff.ApplyOpt) (ocispec.Descriptor, error) {
+	var config diff.ApplyConfig
+	for _, opt := range opts {
+		if err := opt(ctx, desc, &config); err != nil {
+			return ocispec.Descriptor{}, err
+		}
+	}
+
+	payloads := make(map[string]*ptypes.Any)
+	for k, v := range config.ProcessorPayloads {
+		payloads[k] = protobuf.FromAny(v)
+	}
+
+	req := &diffapi.ApplyRequest{
+		Diff:     fromDescriptor(desc),
+		Mounts:   fromMounts(mounts),
+		Payloads: payloads,
+	}
+	resp, err := r.client.Apply(ctx, req)
+	if err != nil {
+		return ocispec.Descriptor{}, errdefs.FromGRPC(err)
+	}
+	return toDescriptor(resp.Applied), nil
+}
+
+func (r *diffRemote) Compare(ctx context.Context, a, b []mount.Mount, opts ...diff.Opt) (ocispec.Descriptor, error) {
+	var config diff.Config
+	for _, opt := range opts {
+		if err := opt(&config); err != nil {
+			return ocispec.Descriptor{}, err
+		}
+	}
+	if tm := epoch.FromContext(ctx); tm != nil && config.SourceDateEpoch == nil {
+		config.SourceDateEpoch = tm
+	}
+	var sourceDateEpoch *timestamppb.Timestamp
+	if config.SourceDateEpoch != nil {
+		sourceDateEpoch = timestamppb.New(*config.SourceDateEpoch)
+	}
+	req := &diffapi.DiffRequest{
+		Left:            fromMounts(a),
+		Right:           fromMounts(b),
+		MediaType:       config.MediaType,
+		Ref:             config.Reference,
+		Labels:          config.Labels,
+		SourceDateEpoch: sourceDateEpoch,
+	}
+	resp, err := r.client.Diff(ctx, req)
+	if err != nil {
+		return ocispec.Descriptor{}, errdefs.FromGRPC(err)
+	}
+	return toDescriptor(resp.Diff), nil
+}
+
+func toDescriptor(d *types.Descriptor) ocispec.Descriptor {
+	return ocispec.Descriptor{
+		MediaType:   d.MediaType,
+		Digest:      digest.Digest(d.Digest),
+		Size:        d.Size,
+		Annotations: d.Annotations,
+	}
+}
+
+func fromDescriptor(d ocispec.Descriptor) *types.Descriptor {
+	return &types.Descriptor{
+		MediaType:   d.MediaType,
+		Digest:      d.Digest.String(),
+		Size:        d.Size,
+		Annotations: d.Annotations,
+	}
+}
+
+func fromMounts(mounts []mount.Mount) []*types.Mount {
+	apiMounts := make([]*types.Mount, len(mounts))
+	for i, m := range mounts {
+		apiMounts[i] = &types.Mount{
+			Type:    m.Type,
+			Source:  m.Source,
+			Target:  m.Target,
+			Options: m.Options,
+		}
+	}
+	return apiMounts
+}

--- a/services/server/server.go
+++ b/services/server/server.go
@@ -34,11 +34,13 @@ import (
 	"time"
 
 	csapi "github.com/containerd/containerd/api/services/content/v1"
+	diffapi "github.com/containerd/containerd/api/services/diff/v1"
 	ssapi "github.com/containerd/containerd/api/services/snapshots/v1"
 	"github.com/containerd/containerd/content/local"
 	csproxy "github.com/containerd/containerd/content/proxy"
 	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/diff"
+	diffproxy "github.com/containerd/containerd/diff/proxy"
 	"github.com/containerd/containerd/events/exchange"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/pkg/dialer"
@@ -408,6 +410,11 @@ func LoadPlugins(ctx context.Context, config *srvconfig.Config) ([]*plugin.Regis
 			t = plugin.ContentPlugin
 			f = func(conn *grpc.ClientConn) interface{} {
 				return csproxy.NewContentStore(csapi.NewContentClient(conn))
+			}
+		case string(plugin.DiffPlugin), "diff":
+			t = plugin.DiffPlugin
+			f = func(conn *grpc.ClientConn) interface{} {
+				return diffproxy.NewDiffApplier(diffapi.NewDiffClient(conn))
 			}
 		default:
 			log.G(ctx).WithField("type", pp.Type).Warn("unknown proxy plugin type")


### PR DESCRIPTION
Adds support for the "diff" type proxy plugin. This allows for out of process diff plugins to be used using the existing proxy plugin framework. The `contrib` addition makes it easier to implement such plugins, similar to the `snapshotservice` in `contrib`. 

Moves the client proxy out of the client package to a package under `diff`, similar to our other client proxies.

A simple example is at https://gist.github.com/dmcgowan/93a19e4183493b46c5bf8cc3d5be9e59

Since we already have support for multiple differs (similar to how we have support for multiple snapshotters), configuring is easy. Just add the proxy plugin and update the diff service to use it (add it before walking to try the proxy first).

```
...

  [plugins."io.containerd.service.v1.diff-service"]
    default = ["proxydiff", "walking"]

...

[proxy_plugins]

  [proxy_plugins."proxydiff"]
    type = "diff"
    address = "/tmp/proxy.sock"

```