### PR TITLE
pkg/cri/server: sub-test uses array and capture range var

### DIFF
--- a/pkg/cri/server/container_create_windows_test.go
+++ b/pkg/cri/server/container_create_windows_test.go
@@ -213,33 +213,39 @@ func TestHostProcessRequirements(t *testing.T) {
 	containerConfig, sandboxConfig, imageConfig, _ := getCreateContainerTestData()
 	ociRuntime := config.Runtime{}
 	c := newTestCRIService()
-	for desc, test := range map[string]struct {
+	for _, test := range []struct {
+		desc                 string
 		containerHostProcess bool
 		sandboxHostProcess   bool
 		expectError          bool
 	}{
-		"hostprocess container in non-hostprocess sandbox should fail": {
+		{
+			desc:                 "hostprocess container in non-hostprocess sandbox should fail",
 			containerHostProcess: true,
 			sandboxHostProcess:   false,
 			expectError:          true,
 		},
-		"hostprocess container in hostprocess sandbox should be fine": {
+		{
+			desc:                 "hostprocess container in hostprocess sandbox should be fine",
 			containerHostProcess: true,
 			sandboxHostProcess:   true,
 			expectError:          false,
 		},
-		"non-hostprocess container in hostprocess sandbox should fail": {
+		{
+			desc:                 "non-hostprocess container in hostprocess sandbox should fail",
 			containerHostProcess: false,
 			sandboxHostProcess:   true,
 			expectError:          true,
 		},
-		"non-hostprocess container in non-hostprocess sandbox should be fine": {
+		{
+			desc:                 "non-hostprocess container in non-hostprocess sandbox should be fine",
 			containerHostProcess: false,
 			sandboxHostProcess:   false,
 			expectError:          false,
 		},
 	} {
-		t.Run(desc, func(t *testing.T) {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
 			containerConfig.Windows.SecurityContext.HostProcess = test.containerHostProcess
 			sandboxConfig.Windows.SecurityContext = &runtime.WindowsSandboxSecurityContext{
 				HostProcess: test.sandboxHostProcess,
@@ -262,7 +268,8 @@ func TestEntrypointAndCmdForArgsEscaped(t *testing.T) {
 	nsPath := "test-ns"
 	c := newTestCRIService()
 
-	for name, test := range map[string]struct {
+	for _, test := range []struct {
+		name                string
 		imgEntrypoint       []string
 		imgCmd              []string
 		command             []string
@@ -272,7 +279,8 @@ func TestEntrypointAndCmdForArgsEscaped(t *testing.T) {
 		ArgsEscaped         bool
 	}{
 		// override image entrypoint and cmd in shell form with container args and verify expected runtime spec
-		"TestShellFormImgEntrypointCmdWithCtrArgs": {
+		{
+			name:                "TestShellFormImgEntrypointCmdWithCtrArgs",
 			imgEntrypoint:       []string{`"C:\My Folder\MyProcess.exe" -arg1 "test value"`},
 			imgCmd:              []string{`cmd -args "hello world"`},
 			command:             nil,
@@ -282,7 +290,8 @@ func TestEntrypointAndCmdForArgsEscaped(t *testing.T) {
 			ArgsEscaped:         true,
 		},
 		// check image entrypoint and cmd in shell form without overriding with container command and args and verify expected runtime spec
-		"TestShellFormImgEntrypointCmdWithoutCtrArgs": {
+		{
+			name:                "TestShellFormImgEntrypointCmdWithoutCtrArgs",
 			imgEntrypoint:       []string{`"C:\My Folder\MyProcess.exe" -arg1 "test value"`},
 			imgCmd:              []string{`cmd -args "hello world"`},
 			command:             nil,
@@ -292,7 +301,8 @@ func TestEntrypointAndCmdForArgsEscaped(t *testing.T) {
 			ArgsEscaped:         true,
 		},
 		// override image entrypoint and cmd by container command and args in shell form and verify expected runtime spec
-		"TestShellFormImgEntrypointCmdWithCtrEntrypointAndArgs": {
+		{
+			name:                "TestShellFormImgEntrypointCmdWithCtrEntrypointAndArgs",
 			imgEntrypoint:       []string{`"C:\My Folder\MyProcess.exe" -arg1 "test value"`},
 			imgCmd:              []string{`cmd -args "hello world"`},
 			command:             []string{`C:\My Folder\MyProcess.exe`, "-arg1", "additional test value"},
@@ -302,7 +312,8 @@ func TestEntrypointAndCmdForArgsEscaped(t *testing.T) {
 			ArgsEscaped:         true,
 		},
 		// override image cmd by container args in exec form and verify expected runtime spec
-		"TestExecFormImgEntrypointCmdWithCtrArgs": {
+		{
+			name:                "TestExecFormImgEntrypointCmdWithCtrArgs",
 			imgEntrypoint:       []string{`C:\My Folder\MyProcess.exe`, "-arg1", "test value"},
 			imgCmd:              []string{"cmd", "-args", "hello world"},
 			command:             nil,
@@ -312,7 +323,8 @@ func TestEntrypointAndCmdForArgsEscaped(t *testing.T) {
 			ArgsEscaped:         false,
 		},
 		// check image entrypoint and cmd in exec form without overriding with container command and args and verify expected runtime spec
-		"TestExecFormImgEntrypointCmdWithoutCtrArgs": {
+		{
+			name:                "TestExecFormImgEntrypointCmdWithoutCtrArgs",
 			imgEntrypoint:       []string{`C:\My Folder\MyProcess.exe`, "-arg1", "test value"},
 			imgCmd:              []string{"cmd", "-args", "hello world"},
 			command:             nil,
@@ -322,7 +334,8 @@ func TestEntrypointAndCmdForArgsEscaped(t *testing.T) {
 			ArgsEscaped:         false,
 		},
 	} {
-		t.Run(name, func(t *testing.T) {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
 			imageConfig := &imagespec.ImageConfig{
 				Entrypoint:  test.imgEntrypoint,
 				Cmd:         test.imgCmd,

--- a/pkg/cri/server/container_list_test.go
+++ b/pkg/cri/server/container_list_test.go
@@ -101,18 +101,22 @@ func TestFilterContainers(t *testing.T) {
 			Labels:       map[string]string{"c": "d"},
 		},
 	}
-	for desc, test := range map[string]struct {
+	for _, test := range []struct {
+		desc   string
 		filter *runtime.ContainerFilter
 		expect []*runtime.Container
 	}{
-		"no filter": {
+		{
+			desc:   "no filter",
 			expect: testContainers,
 		},
-		"id filter": {
+		{
+			desc:   "id filter",
 			filter: &runtime.ContainerFilter{Id: "2"},
 			expect: []*runtime.Container{testContainers[1]},
 		},
-		"state filter": {
+		{
+			desc: "state filter",
 			filter: &runtime.ContainerFilter{
 				State: &runtime.ContainerStateValue{
 					State: runtime.ContainerState_CONTAINER_EXITED,
@@ -120,17 +124,20 @@ func TestFilterContainers(t *testing.T) {
 			},
 			expect: []*runtime.Container{testContainers[1]},
 		},
-		"label filter": {
+		{
+			desc: "label filter",
 			filter: &runtime.ContainerFilter{
 				LabelSelector: map[string]string{"a": "b"},
 			},
 			expect: []*runtime.Container{testContainers[1]},
 		},
-		"sandbox id filter": {
+		{
+			desc:   "sandbox id filter",
 			filter: &runtime.ContainerFilter{PodSandboxId: "s-2"},
 			expect: []*runtime.Container{testContainers[1], testContainers[2]},
 		},
-		"mixed filter not matched": {
+		{
+			desc: "mixed filter not matched",
 			filter: &runtime.ContainerFilter{
 				Id:            "1",
 				PodSandboxId:  "s-2",
@@ -138,7 +145,8 @@ func TestFilterContainers(t *testing.T) {
 			},
 			expect: []*runtime.Container{},
 		},
-		"mixed filter matched": {
+		{
+			desc: "mixed filter matched",
 			filter: &runtime.ContainerFilter{
 				PodSandboxId: "s-2",
 				State: &runtime.ContainerStateValue{
@@ -149,9 +157,10 @@ func TestFilterContainers(t *testing.T) {
 			expect: []*runtime.Container{testContainers[2]},
 		},
 	} {
-		t.Run(desc, func(t *testing.T) {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
 			filtered := c.filterCRIContainers(testContainers, test.filter)
-			assert.Equal(t, test.expect, filtered, desc)
+			assert.Equal(t, test.expect, filtered, test.desc)
 		})
 	}
 }
@@ -287,46 +296,54 @@ func TestListContainers(t *testing.T) {
 		assert.NoError(t, c.containerStore.Add(container))
 	}
 
-	for testdesc, testdata := range map[string]struct {
+	for _, testdata := range []struct {
+		desc   string
 		filter *runtime.ContainerFilter
 		expect []*runtime.Container
 	}{
-		"test without filter": {
+		{
+			desc:   "test without filter",
 			filter: &runtime.ContainerFilter{},
 			expect: expectedContainers,
 		},
-		"test filter by sandboxid": {
+		{
+			desc: "test filter by sandboxid",
 			filter: &runtime.ContainerFilter{
 				PodSandboxId: "s-1abcdef1234",
 			},
 			expect: expectedContainers[:3],
 		},
-		"test filter by truncated sandboxid": {
+		{
+			desc: "test filter by truncated sandboxid",
 			filter: &runtime.ContainerFilter{
 				PodSandboxId: "s-1",
 			},
 			expect: expectedContainers[:3],
 		},
-		"test filter by containerid": {
+		{
+			desc: "test filter by containerid",
 			filter: &runtime.ContainerFilter{
 				Id: "c-1container",
 			},
 			expect: expectedContainers[:1],
 		},
-		"test filter by truncated containerid": {
+		{
+			desc: "test filter by truncated containerid",
 			filter: &runtime.ContainerFilter{
 				Id: "c-1",
 			},
 			expect: expectedContainers[:1],
 		},
-		"test filter by containerid and sandboxid": {
+		{
+			desc: "test filter by containerid and sandboxid",
 			filter: &runtime.ContainerFilter{
 				Id:           "c-1container",
 				PodSandboxId: "s-1abcdef1234",
 			},
 			expect: expectedContainers[:1],
 		},
-		"test filter by truncated containerid and truncated sandboxid": {
+		{
+			desc: "test filter by truncated containerid and truncated sandboxid",
 			filter: &runtime.ContainerFilter{
 				Id:           "c-1",
 				PodSandboxId: "s-1",
@@ -334,7 +351,8 @@ func TestListContainers(t *testing.T) {
 			expect: expectedContainers[:1],
 		},
 	} {
-		t.Run(testdesc, func(t *testing.T) {
+		testdata := testdata
+		t.Run(testdata.desc, func(t *testing.T) {
 			resp, err := c.ListContainers(context.Background(), &runtime.ListContainersRequest{Filter: testdata.filter})
 			assert.NoError(t, err)
 			require.NotNil(t, resp)

--- a/pkg/cri/server/container_remove_test.go
+++ b/pkg/cri/server/container_remove_test.go
@@ -29,25 +29,29 @@ import (
 // state correctly.
 func TestSetContainerRemoving(t *testing.T) {
 	testID := "test-id"
-	for desc, test := range map[string]struct {
+	for _, test := range []struct {
+		desc      string
 		status    containerstore.Status
 		expectErr bool
 	}{
-		"should return error when container is in running state": {
+		{
+			desc: "should return error when container is in running state",
 			status: containerstore.Status{
 				CreatedAt: time.Now().UnixNano(),
 				StartedAt: time.Now().UnixNano(),
 			},
 			expectErr: true,
 		},
-		"should return error when container is in starting state": {
+		{
+			desc: "should return error when container is in starting state",
 			status: containerstore.Status{
 				CreatedAt: time.Now().UnixNano(),
 				Starting:  true,
 			},
 			expectErr: true,
 		},
-		"should return error when container is in removing state": {
+		{
+			desc: "should return error when container is in removing state",
 			status: containerstore.Status{
 				CreatedAt:  time.Now().UnixNano(),
 				StartedAt:  time.Now().UnixNano(),
@@ -56,7 +60,8 @@ func TestSetContainerRemoving(t *testing.T) {
 			},
 			expectErr: true,
 		},
-		"should not return error when container is not running and removing": {
+		{
+			desc: "should not return error when container is not running and removing",
 			status: containerstore.Status{
 				CreatedAt:  time.Now().UnixNano(),
 				StartedAt:  time.Now().UnixNano(),
@@ -65,7 +70,8 @@ func TestSetContainerRemoving(t *testing.T) {
 			expectErr: false,
 		},
 	} {
-		t.Run(desc, func(t *testing.T) {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
 			container, err := containerstore.NewContainer(
 				containerstore.Metadata{ID: testID},
 				containerstore.WithFakeStatus(test.status),

--- a/pkg/cri/server/container_start_test.go
+++ b/pkg/cri/server/container_start_test.go
@@ -29,25 +29,29 @@ import (
 // state correctly.
 func TestSetContainerStarting(t *testing.T) {
 	testID := "test-id"
-	for desc, test := range map[string]struct {
+	for _, test := range []struct {
+		desc      string
 		status    containerstore.Status
 		expectErr bool
 	}{
 
-		"should not return error when container is in created state": {
+		{
+			desc: "should not return error when container is in created state",
 			status: containerstore.Status{
 				CreatedAt: time.Now().UnixNano(),
 			},
 			expectErr: false,
 		},
-		"should return error when container is in running state": {
+		{
+			desc: "should return error when container is in running state",
 			status: containerstore.Status{
 				CreatedAt: time.Now().UnixNano(),
 				StartedAt: time.Now().UnixNano(),
 			},
 			expectErr: true,
 		},
-		"should return error when container is in exited state": {
+		{
+			desc: "should return error when container is in exited state",
 			status: containerstore.Status{
 				CreatedAt:  time.Now().UnixNano(),
 				StartedAt:  time.Now().UnixNano(),
@@ -55,7 +59,8 @@ func TestSetContainerStarting(t *testing.T) {
 			},
 			expectErr: true,
 		},
-		"should return error when container is in unknown state": {
+		{
+			desc: "should return error when container is in unknown state",
 			status: containerstore.Status{
 				CreatedAt:  0,
 				StartedAt:  0,
@@ -63,14 +68,16 @@ func TestSetContainerStarting(t *testing.T) {
 			},
 			expectErr: true,
 		},
-		"should return error when container is in starting state": {
+		{
+			desc: "should return error when container is in starting state",
 			status: containerstore.Status{
 				CreatedAt: time.Now().UnixNano(),
 				Starting:  true,
 			},
 			expectErr: true,
 		},
-		"should return error when container is in removing state": {
+		{
+			desc: "should return error when container is in removing state",
 			status: containerstore.Status{
 				CreatedAt: time.Now().UnixNano(),
 				Removing:  true,
@@ -78,7 +85,8 @@ func TestSetContainerStarting(t *testing.T) {
 			expectErr: true,
 		},
 	} {
-		t.Run(desc, func(t *testing.T) {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
 			container, err := containerstore.NewContainer(
 				containerstore.Metadata{ID: testID},
 				containerstore.WithFakeStatus(test.status),

--- a/pkg/cri/server/container_stats_list_linux_test.go
+++ b/pkg/cri/server/container_stats_list_linux_test.go
@@ -28,22 +28,26 @@ import (
 )
 
 func TestGetWorkingSet(t *testing.T) {
-	for desc, test := range map[string]struct {
+	for _, test := range []struct {
+		desc     string
 		memory   *v1.MemoryStat
 		expected uint64
 	}{
-		"nil memory usage": {
+		{
+			desc:     "nil memory usage",
 			memory:   &v1.MemoryStat{},
 			expected: 0,
 		},
-		"memory usage higher than inactive_total_file": {
+		{
+			desc: "memory usage higher than inactive_total_file",
 			memory: &v1.MemoryStat{
 				TotalInactiveFile: 1000,
 				Usage:             &v1.MemoryEntry{Usage: 2000},
 			},
 			expected: 1000,
 		},
-		"memory usage lower than inactive_total_file": {
+		{
+			desc: "memory usage lower than inactive_total_file",
 			memory: &v1.MemoryStat{
 				TotalInactiveFile: 2000,
 				Usage:             &v1.MemoryEntry{Usage: 1000},
@@ -51,7 +55,8 @@ func TestGetWorkingSet(t *testing.T) {
 			expected: 0,
 		},
 	} {
-		t.Run(desc, func(t *testing.T) {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
 			got := getWorkingSet(test.memory)
 			assert.Equal(t, test.expected, got)
 		})
@@ -59,22 +64,26 @@ func TestGetWorkingSet(t *testing.T) {
 }
 
 func TestGetWorkingSetV2(t *testing.T) {
-	for desc, test := range map[string]struct {
+	for _, test := range []struct {
+		desc     string
 		memory   *v2.MemoryStat
 		expected uint64
 	}{
-		"nil memory usage": {
+		{
+			desc:     "nil memory usage",
 			memory:   &v2.MemoryStat{},
 			expected: 0,
 		},
-		"memory usage higher than inactive_total_file": {
+		{
+			desc: "memory usage higher than inactive_total_file",
 			memory: &v2.MemoryStat{
 				InactiveFile: 1000,
 				Usage:        2000,
 			},
 			expected: 1000,
 		},
-		"memory usage lower than inactive_total_file": {
+		{
+			desc: "memory usage lower than inactive_total_file",
 			memory: &v2.MemoryStat{
 				InactiveFile: 2000,
 				Usage:        1000,
@@ -82,7 +91,8 @@ func TestGetWorkingSetV2(t *testing.T) {
 			expected: 0,
 		},
 	} {
-		t.Run(desc, func(t *testing.T) {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
 			got := getWorkingSetV2(test.memory)
 			assert.Equal(t, test.expected, got)
 		})
@@ -90,13 +100,15 @@ func TestGetWorkingSetV2(t *testing.T) {
 }
 
 func TestGetAvailableBytes(t *testing.T) {
-	for desc, test := range map[string]struct {
+	for _, test := range []struct {
+		desc            string
 		memory          *v1.MemoryStat
 		workingSetBytes uint64
 		expected        uint64
 	}{
 
-		"no limit": {
+		{
+			desc: "no limit",
 			memory: &v1.MemoryStat{
 				Usage: &v1.MemoryEntry{
 					Limit: math.MaxUint64, // no limit
@@ -106,7 +118,8 @@ func TestGetAvailableBytes(t *testing.T) {
 			workingSetBytes: 500,
 			expected:        0,
 		},
-		"with limit": {
+		{
+			desc: "with limit",
 			memory: &v1.MemoryStat{
 				Usage: &v1.MemoryEntry{
 					Limit: 5000,
@@ -117,7 +130,8 @@ func TestGetAvailableBytes(t *testing.T) {
 			expected:        5000 - 500,
 		},
 	} {
-		t.Run(desc, func(t *testing.T) {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
 			got := getAvailableBytes(test.memory, test.workingSetBytes)
 			assert.Equal(t, test.expected, got)
 		})
@@ -125,13 +139,15 @@ func TestGetAvailableBytes(t *testing.T) {
 }
 
 func TestGetAvailableBytesV2(t *testing.T) {
-	for desc, test := range map[string]struct {
+	for _, test := range []struct {
+		desc            string
 		memory          *v2.MemoryStat
 		workingSetBytes uint64
 		expected        uint64
 	}{
 
-		"no limit": {
+		{
+			desc: "no limit",
 			memory: &v2.MemoryStat{
 				UsageLimit: math.MaxUint64, // no limit
 				Usage:      1000,
@@ -139,7 +155,8 @@ func TestGetAvailableBytesV2(t *testing.T) {
 			workingSetBytes: 500,
 			expected:        0,
 		},
-		"with limit": {
+		{
+			desc: "with limit",
 			memory: &v2.MemoryStat{
 				UsageLimit: 5000,
 				Usage:      1000,
@@ -148,7 +165,8 @@ func TestGetAvailableBytesV2(t *testing.T) {
 			expected:        5000 - 500,
 		},
 	} {
-		t.Run(desc, func(t *testing.T) {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
 			got := getAvailableBytesV2(test.memory, test.workingSetBytes)
 			assert.Equal(t, test.expected, got)
 		})
@@ -159,11 +177,13 @@ func TestContainerMetricsMemory(t *testing.T) {
 	c := newTestCRIService()
 	timestamp := time.Now()
 
-	for desc, test := range map[string]struct {
+	for _, test := range []struct {
+		desc     string
 		metrics  interface{}
 		expected *runtime.MemoryUsage
 	}{
-		"v1 metrics - no memory limit": {
+		{
+			desc: "v1 metrics - no memory limit",
 			metrics: &v1.Metrics{
 				Memory: &v1.MemoryStat{
 					Usage: &v1.MemoryEntry{
@@ -186,7 +206,8 @@ func TestContainerMetricsMemory(t *testing.T) {
 				MajorPageFaults: &runtime.UInt64Value{Value: 12},
 			},
 		},
-		"v1 metrics - memory limit": {
+		{
+			desc: "v1 metrics - memory limit",
 			metrics: &v1.Metrics{
 				Memory: &v1.MemoryStat{
 					Usage: &v1.MemoryEntry{
@@ -209,7 +230,8 @@ func TestContainerMetricsMemory(t *testing.T) {
 				MajorPageFaults: &runtime.UInt64Value{Value: 12},
 			},
 		},
-		"v2 metrics - memory limit": {
+		{
+			desc: "v2 metrics - memory limit",
 			metrics: &v2.Metrics{
 				Memory: &v2.MemoryStat{
 					Usage:        1000,
@@ -229,7 +251,8 @@ func TestContainerMetricsMemory(t *testing.T) {
 				MajorPageFaults: &runtime.UInt64Value{Value: 12},
 			},
 		},
-		"v2 metrics - no memory limit": {
+		{
+			desc: "v2 metrics - no memory limit",
 			metrics: &v2.Metrics{
 				Memory: &v2.MemoryStat{
 					Usage:        1000,
@@ -250,7 +273,8 @@ func TestContainerMetricsMemory(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(desc, func(t *testing.T) {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
 			got, err := c.memoryContainerStats("ID", test.metrics, timestamp)
 			assert.NoError(t, err)
 			assert.Equal(t, test.expected, got)

--- a/pkg/cri/server/container_stats_list_test.go
+++ b/pkg/cri/server/container_stats_list_test.go
@@ -30,20 +30,23 @@ func TestContainerMetricsCPUNanoCoreUsage(t *testing.T) {
 	secondAfterTimeStamp := timestamp.Add(time.Second)
 	ID := "ID"
 
-	for desc, test := range map[string]struct {
+	for _, test := range []struct {
+		desc                        string
 		firstCPUValue               uint64
 		secondCPUValue              uint64
 		expectedNanoCoreUsageFirst  uint64
 		expectedNanoCoreUsageSecond uint64
 	}{
-		"metrics": {
+		{
+			desc:                        "metrics",
 			firstCPUValue:               50,
 			secondCPUValue:              500,
 			expectedNanoCoreUsageFirst:  0,
 			expectedNanoCoreUsageSecond: 450,
 		},
 	} {
-		t.Run(desc, func(t *testing.T) {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
 			container, err := containerstore.NewContainer(
 				containerstore.Metadata{ID: ID},
 			)

--- a/pkg/cri/server/container_status_test.go
+++ b/pkg/cri/server/container_status_test.go
@@ -85,7 +85,8 @@ func getContainerStatusTestData() (*containerstore.Metadata, *containerstore.Sta
 }
 
 func TestToCRIContainerStatus(t *testing.T) {
-	for desc, test := range map[string]struct {
+	for _, test := range []struct {
+		desc           string
 		startedAt      int64
 		finishedAt     int64
 		exitCode       int32
@@ -94,14 +95,17 @@ func TestToCRIContainerStatus(t *testing.T) {
 		expectedState  runtime.ContainerState
 		expectedReason string
 	}{
-		"container created": {
+		{
+			desc:          "container created",
 			expectedState: runtime.ContainerState_CONTAINER_CREATED,
 		},
-		"container running": {
+		{
+			desc:          "container running",
 			startedAt:     time.Now().UnixNano(),
 			expectedState: runtime.ContainerState_CONTAINER_RUNNING,
 		},
-		"container exited with reason": {
+		{
+			desc:           "container exited with reason",
 			startedAt:      time.Now().UnixNano(),
 			finishedAt:     time.Now().UnixNano(),
 			exitCode:       1,
@@ -110,7 +114,8 @@ func TestToCRIContainerStatus(t *testing.T) {
 			expectedState:  runtime.ContainerState_CONTAINER_EXITED,
 			expectedReason: "test-reason",
 		},
-		"container exited with exit code 0 without reason": {
+		{
+			desc:           "container exited with exit code 0 without reason",
 			startedAt:      time.Now().UnixNano(),
 			finishedAt:     time.Now().UnixNano(),
 			exitCode:       0,
@@ -118,7 +123,8 @@ func TestToCRIContainerStatus(t *testing.T) {
 			expectedState:  runtime.ContainerState_CONTAINER_EXITED,
 			expectedReason: completeExitReason,
 		},
-		"container exited with non-zero exit code without reason": {
+		{
+			desc:           "container exited with non-zero exit code without reason",
 			startedAt:      time.Now().UnixNano(),
 			finishedAt:     time.Now().UnixNano(),
 			exitCode:       1,
@@ -127,7 +133,8 @@ func TestToCRIContainerStatus(t *testing.T) {
 			expectedReason: errorExitReason,
 		},
 	} {
-		t.Run(desc, func(t *testing.T) {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
 
 			metadata, status, _, expected := getContainerStatusTestData()
 			// Update status with test case.
@@ -151,7 +158,7 @@ func TestToCRIContainerStatus(t *testing.T) {
 			containerStatus := toCRIContainerStatus(container,
 				expected.Image,
 				expected.ImageRef)
-			assert.Equal(t, expected, containerStatus, desc)
+			assert.Equal(t, expected, containerStatus, test.desc)
 		})
 	}
 }
@@ -173,7 +180,8 @@ func TestToCRIContainerInfo(t *testing.T) {
 }
 
 func TestContainerStatus(t *testing.T) {
-	for desc, test := range map[string]struct {
+	for _, test := range []struct {
+		desc          string
 		exist         bool
 		imageExist    bool
 		startedAt     int64
@@ -182,18 +190,21 @@ func TestContainerStatus(t *testing.T) {
 		expectedState runtime.ContainerState
 		expectErr     bool
 	}{
-		"container created": {
+		{
+			desc:          "container created",
 			exist:         true,
 			imageExist:    true,
 			expectedState: runtime.ContainerState_CONTAINER_CREATED,
 		},
-		"container running": {
+		{
+			desc:          "container running",
 			exist:         true,
 			imageExist:    true,
 			startedAt:     time.Now().UnixNano(),
 			expectedState: runtime.ContainerState_CONTAINER_RUNNING,
 		},
-		"container exited": {
+		{
+			desc:          "container exited",
 			exist:         true,
 			imageExist:    true,
 			startedAt:     time.Now().UnixNano(),
@@ -201,18 +212,21 @@ func TestContainerStatus(t *testing.T) {
 			reason:        "test-reason",
 			expectedState: runtime.ContainerState_CONTAINER_EXITED,
 		},
-		"container not exist": {
+		{
+			desc:       "container not exist",
 			exist:      false,
 			imageExist: true,
 			expectErr:  true,
 		},
-		"image not exist": {
+		{
+			desc:       "image not exist",
 			exist:      false,
 			imageExist: false,
 			expectErr:  true,
 		},
 	} {
-		t.Run(desc, func(t *testing.T) {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
 			c := newTestCRIService()
 			metadata, status, image, expected := getContainerStatusTestData()
 			// Update status with test case.

--- a/pkg/cri/server/container_stop_test.go
+++ b/pkg/cri/server/container_stop_test.go
@@ -28,13 +28,15 @@ import (
 
 func TestWaitContainerStop(t *testing.T) {
 	id := "test-id"
-	for desc, test := range map[string]struct {
+	for _, test := range []struct {
+		desc      string
 		status    *containerstore.Status
 		cancel    bool
 		timeout   time.Duration
 		expectErr bool
 	}{
-		"should return error if timeout exceeds": {
+		{
+			desc: "should return error if timeout exceeds",
 			status: &containerstore.Status{
 				CreatedAt: time.Now().UnixNano(),
 				StartedAt: time.Now().UnixNano(),
@@ -42,7 +44,8 @@ func TestWaitContainerStop(t *testing.T) {
 			timeout:   200 * time.Millisecond,
 			expectErr: true,
 		},
-		"should return error if context is cancelled": {
+		{
+			desc: "should return error if context is cancelled",
 			status: &containerstore.Status{
 				CreatedAt: time.Now().UnixNano(),
 				StartedAt: time.Now().UnixNano(),
@@ -51,7 +54,8 @@ func TestWaitContainerStop(t *testing.T) {
 			cancel:    true,
 			expectErr: true,
 		},
-		"should not return error if container is stopped before timeout": {
+		{
+			desc: "should not return error if container is stopped before timeout",
 			status: &containerstore.Status{
 				CreatedAt:  time.Now().UnixNano(),
 				StartedAt:  time.Now().UnixNano(),
@@ -61,7 +65,8 @@ func TestWaitContainerStop(t *testing.T) {
 			expectErr: false,
 		},
 	} {
-		t.Run(desc, func(t *testing.T) {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
 			c := newTestCRIService()
 			container, err := containerstore.NewContainer(
 				containerstore.Metadata{ID: id},
@@ -81,7 +86,7 @@ func TestWaitContainerStop(t *testing.T) {
 				ctx = timeoutCtx
 			}
 			err = c.waitContainerStop(ctx, container)
-			assert.Equal(t, test.expectErr, err != nil, desc)
+			assert.Equal(t, test.expectErr, err != nil, test.desc)
 		})
 	}
 }

--- a/pkg/cri/server/container_update_resources_linux_test.go
+++ b/pkg/cri/server/container_update_resources_linux_test.go
@@ -38,13 +38,15 @@ func TestUpdateOCILinuxResource(t *testing.T) {
 		}
 		return nil
 	}
-	for desc, test := range map[string]struct {
+	for _, test := range []struct {
+		desc      string
 		spec      *runtimespec.Spec
 		request   *runtime.UpdateContainerResourcesRequest
 		expected  *runtimespec.Spec
 		expectErr bool
 	}{
-		"should be able to update each resource": {
+		{
+			desc: "should be able to update each resource",
 			spec: &runtimespec.Spec{
 				Process: &runtimespec.Process{OOMScoreAdj: oomscoreadj},
 				Linux: &runtimespec.Linux{
@@ -93,7 +95,8 @@ func TestUpdateOCILinuxResource(t *testing.T) {
 				},
 			},
 		},
-		"should skip empty fields": {
+		{
+			desc: "should skip empty fields",
 			spec: &runtimespec.Spec{
 				Process: &runtimespec.Process{OOMScoreAdj: oomscoreadj},
 				Linux: &runtimespec.Linux{
@@ -139,7 +142,8 @@ func TestUpdateOCILinuxResource(t *testing.T) {
 				},
 			},
 		},
-		"should be able to fill empty fields": {
+		{
+			desc: "should be able to fill empty fields",
 			spec: &runtimespec.Spec{
 				Process: &runtimespec.Process{OOMScoreAdj: oomscoreadj},
 				Linux: &runtimespec.Linux{
@@ -180,7 +184,8 @@ func TestUpdateOCILinuxResource(t *testing.T) {
 				},
 			},
 		},
-		"should be able to patch the unified map": {
+		{
+			desc: "should be able to patch the unified map",
 			spec: &runtimespec.Spec{
 				Process: &runtimespec.Process{OOMScoreAdj: oomscoreadj},
 				Linux: &runtimespec.Linux{
@@ -230,7 +235,8 @@ func TestUpdateOCILinuxResource(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(desc, func(t *testing.T) {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
 			config := criconfig.Config{
 				PluginConfig: criconfig.PluginConfig{
 					TolerateMissingHugetlbController: true,

--- a/pkg/cri/server/helpers_linux_test.go
+++ b/pkg/cri/server/helpers_linux_test.go
@@ -29,32 +29,38 @@ import (
 
 func TestGetCgroupsPath(t *testing.T) {
 	testID := "test-id"
-	for desc, test := range map[string]struct {
+	for _, test := range []struct {
+		desc          string
 		cgroupsParent string
 		expected      string
 	}{
-		"should support regular cgroup path": {
+		{
+			desc:          "should support regular cgroup path",
 			cgroupsParent: "/a/b",
 			expected:      "/a/b/test-id",
 		},
-		"should support systemd cgroup path": {
+		{
+			desc:          "should support systemd cgroup path",
 			cgroupsParent: "/a.slice/b.slice",
-			expected:      "b.slice:cri-containerd:test-id",
-		},
-		"should support tailing slash for regular cgroup path": {
+			expected:      "b.slice:cri-containerd:test-id"},
+		{
+			desc:          "should support tailing slash for regular cgroup path",
 			cgroupsParent: "/a/b/",
 			expected:      "/a/b/test-id",
 		},
-		"should support tailing slash for systemd cgroup path": {
+		{
+			desc:          "should support tailing slash for systemd cgroup path",
 			cgroupsParent: "/a.slice/b.slice/",
 			expected:      "b.slice:cri-containerd:test-id",
 		},
-		"should treat root cgroup as regular cgroup path": {
+		{
+			desc:          "should treat root cgroup as regular cgroup path",
 			cgroupsParent: "/",
 			expected:      "/test-id",
 		},
 	} {
-		t.Run(desc, func(t *testing.T) {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
 			got := getCgroupsPath(test.cgroupsParent, testID)
 			assert.Equal(t, test.expected, got)
 		})

--- a/pkg/cri/server/image_pull_test.go
+++ b/pkg/cri/server/image_pull_test.go
@@ -37,23 +37,29 @@ func TestParseAuth(t *testing.T) {
 	base64.StdEncoding.Encode(testAuth, []byte(testUser+":"+testPasswd))
 	invalidAuth := make([]byte, testAuthLen)
 	base64.StdEncoding.Encode(invalidAuth, []byte(testUser+"@"+testPasswd))
-	for desc, test := range map[string]struct {
+	for _, test := range []struct {
+		desc           string
 		auth           *runtime.AuthConfig
 		host           string
 		expectedUser   string
 		expectedSecret string
 		expectErr      bool
 	}{
-		"should not return error if auth config is nil": {},
-		"should not return error if empty auth is provided for access to anonymous registry": {
+		{
+			desc: "should not return error if auth config is nil",
+		},
+		{
+			desc:      "should not return error if empty auth is provided for access to anonymous registry",
 			auth:      &runtime.AuthConfig{},
 			expectErr: false,
 		},
-		"should support identity token": {
+		{
+			desc:           "should support identity token",
 			auth:           &runtime.AuthConfig{IdentityToken: "abcd"},
 			expectedSecret: "abcd",
 		},
-		"should support username and password": {
+		{
+			desc: "should support username and password",
 			auth: &runtime.AuthConfig{
 				Username: testUser,
 				Password: testPasswd,
@@ -61,16 +67,19 @@ func TestParseAuth(t *testing.T) {
 			expectedUser:   testUser,
 			expectedSecret: testPasswd,
 		},
-		"should support auth": {
+		{
+			desc:           "should support auth",
 			auth:           &runtime.AuthConfig{Auth: string(testAuth)},
 			expectedUser:   testUser,
 			expectedSecret: testPasswd,
 		},
-		"should return error for invalid auth": {
+		{
+			desc:      "should return error for invalid auth",
 			auth:      &runtime.AuthConfig{Auth: string(invalidAuth)},
 			expectErr: true,
 		},
-		"should return empty auth if server address doesn't match": {
+		{
+			desc: "should return empty auth if server address doesn't match",
 			auth: &runtime.AuthConfig{
 				Username:      testUser,
 				Password:      testPasswd,
@@ -80,7 +89,8 @@ func TestParseAuth(t *testing.T) {
 			expectedUser:   "",
 			expectedSecret: "",
 		},
-		"should return auth if server address matches": {
+		{
+			desc: "should return auth if server address matches",
 			auth: &runtime.AuthConfig{
 				Username:      testUser,
 				Password:      testPasswd,
@@ -90,7 +100,8 @@ func TestParseAuth(t *testing.T) {
 			expectedUser:   testUser,
 			expectedSecret: testPasswd,
 		},
-		"should return auth if server address is not specified": {
+		{
+			desc: "should return auth if server address is not specified",
 			auth: &runtime.AuthConfig{
 				Username: testUser,
 				Password: testPasswd,
@@ -100,7 +111,8 @@ func TestParseAuth(t *testing.T) {
 			expectedSecret: testPasswd,
 		},
 	} {
-		t.Run(desc, func(t *testing.T) {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
 			u, s, err := ParseAuth(test.auth, test.host)
 			assert.Equal(t, test.expectErr, err != nil)
 			assert.Equal(t, test.expectedUser, u)
@@ -110,12 +122,14 @@ func TestParseAuth(t *testing.T) {
 }
 
 func TestRegistryEndpoints(t *testing.T) {
-	for desc, test := range map[string]struct {
+	for _, test := range []struct {
+		desc     string
 		mirrors  map[string]criconfig.Mirror
 		host     string
 		expected []string
 	}{
-		"no mirror configured": {
+		{
+			desc: "no mirror configured",
 			mirrors: map[string]criconfig.Mirror{
 				"registry-1.io": {
 					Endpoints: []string{
@@ -129,7 +143,8 @@ func TestRegistryEndpoints(t *testing.T) {
 				"https://registry-3.io",
 			},
 		},
-		"mirror configured": {
+		{
+			desc: "mirror configured",
 			mirrors: map[string]criconfig.Mirror{
 				"registry-3.io": {
 					Endpoints: []string{
@@ -145,7 +160,8 @@ func TestRegistryEndpoints(t *testing.T) {
 				"https://registry-3.io",
 			},
 		},
-		"wildcard mirror configured": {
+		{
+			desc: "wildcard mirror configured",
 			mirrors: map[string]criconfig.Mirror{
 				"*": {
 					Endpoints: []string{
@@ -161,7 +177,8 @@ func TestRegistryEndpoints(t *testing.T) {
 				"https://registry-3.io",
 			},
 		},
-		"host should take precedence if both host and wildcard mirrors are configured": {
+		{
+			desc: "host should take precedence if both host and wildcard mirrors are configured",
 			mirrors: map[string]criconfig.Mirror{
 				"*": {
 					Endpoints: []string{
@@ -180,7 +197,8 @@ func TestRegistryEndpoints(t *testing.T) {
 				"https://registry-3.io",
 			},
 		},
-		"default endpoint in list with http": {
+		{
+			desc: "default endpoint in list with http",
 			mirrors: map[string]criconfig.Mirror{
 				"registry-3.io": {
 					Endpoints: []string{
@@ -197,7 +215,8 @@ func TestRegistryEndpoints(t *testing.T) {
 				"http://registry-3.io",
 			},
 		},
-		"default endpoint in list with https": {
+		{
+			desc: "default endpoint in list with https",
 			mirrors: map[string]criconfig.Mirror{
 				"registry-3.io": {
 					Endpoints: []string{
@@ -214,7 +233,8 @@ func TestRegistryEndpoints(t *testing.T) {
 				"https://registry-3.io",
 			},
 		},
-		"default endpoint in list with path": {
+		{
+			desc: "default endpoint in list with path",
 			mirrors: map[string]criconfig.Mirror{
 				"registry-3.io": {
 					Endpoints: []string{
@@ -231,7 +251,8 @@ func TestRegistryEndpoints(t *testing.T) {
 				"https://registry-3.io/path",
 			},
 		},
-		"miss scheme endpoint in list with path": {
+		{
+			desc: "miss scheme endpoint in list with path",
 			mirrors: map[string]criconfig.Mirror{
 				"registry-3.io": {
 					Endpoints: []string{
@@ -249,7 +270,8 @@ func TestRegistryEndpoints(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(desc, func(t *testing.T) {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
 			c := newTestCRIService()
 			c.config.Registry.Mirrors = test.mirrors
 			got, err := c.registryEndpoints(test.host)
@@ -260,52 +282,64 @@ func TestRegistryEndpoints(t *testing.T) {
 }
 
 func TestDefaultScheme(t *testing.T) {
-	for desc, test := range map[string]struct {
+	for _, test := range []struct {
+		desc     string
 		host     string
 		expected string
 	}{
-		"should use http by default for localhost": {
+		{
+			desc:     "should use http by default for localhost",
 			host:     "localhost",
 			expected: "http",
 		},
-		"should use http by default for localhost with port": {
+		{
+			desc:     "should use http by default for localhost with port",
 			host:     "localhost:8080",
 			expected: "http",
 		},
-		"should use http by default for 127.0.0.1": {
+		{
+			desc:     "should use http by default for 127.0.0.1",
 			host:     "127.0.0.1",
 			expected: "http",
 		},
-		"should use http by default for 127.0.0.1 with port": {
+		{
+			desc:     "should use http by default for 127.0.0.1 with port",
 			host:     "127.0.0.1:8080",
 			expected: "http",
 		},
-		"should use http by default for ::1": {
+		{
+			desc:     "should use http by default for ::1",
 			host:     "::1",
 			expected: "http",
 		},
-		"should use http by default for ::1 with port": {
+		{
+			desc:     "should use http by default for ::1 with port",
 			host:     "[::1]:8080",
 			expected: "http",
 		},
-		"should use https by default for remote host": {
+		{
+			desc:     "should use https by default for remote host",
 			host:     "remote",
 			expected: "https",
 		},
-		"should use https by default for remote host with port": {
+		{
+			desc:     "should use https by default for remote host with port",
 			host:     "remote:8080",
 			expected: "https",
 		},
-		"should use https by default for remote ip": {
+		{
+			desc:     "should use https by default for remote ip",
 			host:     "8.8.8.8",
 			expected: "https",
 		},
-		"should use https by default for remote ip with port": {
+		{
+			desc:     "should use https by default for remote ip with port",
 			host:     "8.8.8.8:8080",
 			expected: "https",
 		},
 	} {
-		t.Run(desc, func(t *testing.T) {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
 			got := defaultScheme(test.host)
 			assert.Equal(t, test.expected, got)
 		})
@@ -313,20 +347,24 @@ func TestDefaultScheme(t *testing.T) {
 }
 
 func TestEncryptedImagePullOpts(t *testing.T) {
-	for desc, test := range map[string]struct {
+	for _, test := range []struct {
+		desc         string
 		keyModel     string
 		expectedOpts int
 	}{
-		"node key model should return one unpack opt": {
+		{
+			desc:         "node key model should return one unpack opt",
 			keyModel:     criconfig.KeyModelNode,
 			expectedOpts: 1,
 		},
-		"no key model selected should default to node key model": {
+		{
+			desc:         "no key model selected should default to node key model",
 			keyModel:     "",
 			expectedOpts: 0,
 		},
 	} {
-		t.Run(desc, func(t *testing.T) {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
 			c := newTestCRIService()
 			c.config.ImageDecryption.KeyModel = test.keyModel
 			got := len(c.encryptedImagesPullOpts())
@@ -382,6 +420,7 @@ func TestSnapshotterFromPodSandboxConfig(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			cri := newTestCRIService()
 			cri.config.ContainerdConfig.Snapshotter = defaultSnashotter

--- a/pkg/cri/server/sandbox_list_test.go
+++ b/pkg/cri/server/sandbox_list_test.go
@@ -53,31 +53,36 @@ func TestToCRISandbox(t *testing.T) {
 		Annotations:    config.GetAnnotations(),
 		RuntimeHandler: "test-runtime-handler",
 	}
-	for desc, test := range map[string]struct {
+	for _, test := range []struct {
+		desc          string
 		state         sandboxstore.State
 		expectedState runtime.PodSandboxState
 	}{
-		"sandbox state ready": {
+		{
+			desc:          "sandbox state ready",
 			state:         sandboxstore.StateReady,
 			expectedState: runtime.PodSandboxState_SANDBOX_READY,
 		},
-		"sandbox state not ready": {
+		{
+			desc:          "sandbox state not ready",
 			state:         sandboxstore.StateNotReady,
 			expectedState: runtime.PodSandboxState_SANDBOX_NOTREADY,
 		},
-		"sandbox state unknown": {
+		{
+			desc:          "sandbox state unknown",
 			state:         sandboxstore.StateUnknown,
 			expectedState: runtime.PodSandboxState_SANDBOX_NOTREADY,
 		},
 	} {
-		t.Run(desc, func(t *testing.T) {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
 			status := sandboxstore.Status{
 				CreatedAt: createdAt,
 				State:     test.state,
 			}
 			expect.State = test.expectedState
 			s := toCRISandbox(meta, status)
-			assert.Equal(t, expect, s, desc)
+			assert.Equal(t, expect, s, test.desc)
 		})
 	}
 }
@@ -157,22 +162,27 @@ func TestFilterSandboxes(t *testing.T) {
 		assert.NoError(t, c.sandboxStore.Add(sb))
 	}
 
-	for desc, test := range map[string]struct {
+	for _, test := range []struct {
+		desc   string
 		filter *runtime.PodSandboxFilter
 		expect []*runtime.PodSandbox
 	}{
-		"no filter": {
+		{
+			desc:   "no filter",
 			expect: testSandboxes,
 		},
-		"id filter": {
+		{
+			desc:   "id filter",
 			filter: &runtime.PodSandboxFilter{Id: "2abcdef"},
 			expect: []*runtime.PodSandbox{testSandboxes[1]},
 		},
-		"truncid filter": {
+		{
+			desc:   "truncid filter",
 			filter: &runtime.PodSandboxFilter{Id: "2"},
 			expect: []*runtime.PodSandbox{testSandboxes[1]},
 		},
-		"state filter": {
+		{
+			desc: "state filter",
 			filter: &runtime.PodSandboxFilter{
 				State: &runtime.PodSandboxStateValue{
 					State: runtime.PodSandboxState_SANDBOX_READY,
@@ -180,20 +190,23 @@ func TestFilterSandboxes(t *testing.T) {
 			},
 			expect: []*runtime.PodSandbox{testSandboxes[0], testSandboxes[2]},
 		},
-		"label filter": {
+		{
+			desc: "label filter",
 			filter: &runtime.PodSandboxFilter{
 				LabelSelector: map[string]string{"a": "b"},
 			},
 			expect: []*runtime.PodSandbox{testSandboxes[1]},
 		},
-		"mixed filter not matched": {
+		{
+			desc: "mixed filter not matched",
 			filter: &runtime.PodSandboxFilter{
 				Id:            "1",
 				LabelSelector: map[string]string{"a": "b"},
 			},
 			expect: []*runtime.PodSandbox{},
 		},
-		"mixed filter matched": {
+		{
+			desc: "mixed filter matched",
 			filter: &runtime.PodSandboxFilter{
 				State: &runtime.PodSandboxStateValue{
 					State: runtime.PodSandboxState_SANDBOX_READY,
@@ -203,9 +216,10 @@ func TestFilterSandboxes(t *testing.T) {
 			expect: []*runtime.PodSandbox{testSandboxes[2]},
 		},
 	} {
-		t.Run(desc, func(t *testing.T) {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
 			filtered := c.filterCRISandboxes(testSandboxes, test.filter)
-			assert.Equal(t, test.expect, filtered, desc)
+			assert.Equal(t, test.expect, filtered, test.desc)
 		})
 	}
 }

--- a/pkg/cri/server/sandbox_run_linux_test.go
+++ b/pkg/cri/server/sandbox_run_linux_test.go
@@ -117,12 +117,14 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 		Size:        10,
 	}
 
-	for desc, test := range map[string]struct {
+	for _, test := range []struct {
+		desc         string
 		configChange func(*runtime.PodSandboxConfig)
 		specCheck    func(*testing.T, *runtimespec.Spec)
 		expectErr    bool
 	}{
-		"spec should reflect original config": {
+		{
+			desc: "spec should reflect original config",
 			specCheck: func(t *testing.T, spec *runtimespec.Spec) {
 				// runtime spec should have expected namespaces enabled by default.
 				require.NotNil(t, spec.Linux)
@@ -146,7 +148,8 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 				})
 			},
 		},
-		"host namespace": {
+		{
+			desc: "host namespace",
 			configChange: func(c *runtime.PodSandboxConfig) {
 				c.Linux.SecurityContext = &runtime.LinuxSandboxSecurityContext{
 					NamespaceOptions: &runtime.NamespaceOption{
@@ -178,7 +181,8 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 				assert.NotContains(t, spec.Linux.Sysctl["net.ipv4.ping_group_range"], "0 2147483647")
 			},
 		},
-		"user namespace": {
+		{
+			desc: "user namespace",
 			configChange: func(c *runtime.PodSandboxConfig) {
 				c.Linux.SecurityContext = &runtime.LinuxSandboxSecurityContext{
 					NamespaceOptions: &runtime.NamespaceOption{
@@ -200,7 +204,8 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 
 			},
 		},
-		"user namespace mode node and mappings": {
+		{
+			desc: "user namespace mode node and mappings",
 			configChange: func(c *runtime.PodSandboxConfig) {
 				c.Linux.SecurityContext = &runtime.LinuxSandboxSecurityContext{
 					NamespaceOptions: &runtime.NamespaceOption{
@@ -214,7 +219,8 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 			},
 			expectErr: true,
 		},
-		"user namespace with several mappings": {
+		{
+			desc: "user namespace with several mappings",
 			configChange: func(c *runtime.PodSandboxConfig) {
 				c.Linux.SecurityContext = &runtime.LinuxSandboxSecurityContext{
 					NamespaceOptions: &runtime.NamespaceOption{
@@ -228,7 +234,8 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 			},
 			expectErr: true,
 		},
-		"user namespace with uneven mappings": {
+		{
+			desc: "user namespace with uneven mappings",
 			configChange: func(c *runtime.PodSandboxConfig) {
 				c.Linux.SecurityContext = &runtime.LinuxSandboxSecurityContext{
 					NamespaceOptions: &runtime.NamespaceOption{
@@ -242,7 +249,8 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 			},
 			expectErr: true,
 		},
-		"user namespace mode container": {
+		{
+			desc: "user namespace mode container",
 			configChange: func(c *runtime.PodSandboxConfig) {
 				c.Linux.SecurityContext = &runtime.LinuxSandboxSecurityContext{
 					NamespaceOptions: &runtime.NamespaceOption{
@@ -254,7 +262,8 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 			},
 			expectErr: true,
 		},
-		"user namespace mode target": {
+		{
+			desc: "user namespace mode target",
 			configChange: func(c *runtime.PodSandboxConfig) {
 				c.Linux.SecurityContext = &runtime.LinuxSandboxSecurityContext{
 					NamespaceOptions: &runtime.NamespaceOption{
@@ -266,7 +275,8 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 			},
 			expectErr: true,
 		},
-		"user namespace unknown mode": {
+		{
+			desc: "user namespace unknown mode",
 			configChange: func(c *runtime.PodSandboxConfig) {
 				c.Linux.SecurityContext = &runtime.LinuxSandboxSecurityContext{
 					NamespaceOptions: &runtime.NamespaceOption{
@@ -278,7 +288,8 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 			},
 			expectErr: true,
 		},
-		"should set supplemental groups correctly": {
+		{
+			desc: "should set supplemental groups correctly",
 			configChange: func(c *runtime.PodSandboxConfig) {
 				c.Linux.SecurityContext = &runtime.LinuxSandboxSecurityContext{
 					SupplementalGroups: []int64{1111, 2222},
@@ -290,7 +301,8 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 				assert.Contains(t, spec.Process.User.AdditionalGids, uint32(2222))
 			},
 		},
-		"should overwrite default sysctls": {
+		{
+			desc: "should overwrite default sysctls",
 			configChange: func(c *runtime.PodSandboxConfig) {
 				c.Linux.Sysctls = map[string]string{
 					"net.ipv4.ip_unprivileged_port_start": "500",
@@ -303,7 +315,8 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 				assert.Contains(t, spec.Linux.Sysctl["net.ipv4.ping_group_range"], "1 1000")
 			},
 		},
-		"sandbox sizing annotations should be set if LinuxContainerResources were provided": {
+		{
+			desc: "sandbox sizing annotations should be set if LinuxContainerResources were provided",
 			configChange: func(c *runtime.PodSandboxConfig) {
 				c.Linux.Resources = &v1.LinuxContainerResources{
 					CpuPeriod:          100,
@@ -331,7 +344,8 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 				assert.EqualValues(t, "1024", value)
 			},
 		},
-		"sandbox sizing annotations should not be set if LinuxContainerResources were not provided": {
+		{
+			desc: "sandbox sizing annotations should not be set if LinuxContainerResources were not provided",
 			specCheck: func(t *testing.T, spec *runtimespec.Spec) {
 				_, ok := spec.Annotations[annotations.SandboxCPUPeriod]
 				assert.False(t, ok)
@@ -343,7 +357,8 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 				assert.False(t, ok)
 			},
 		},
-		"sandbox sizing annotations are zero if the resources are set to 0": {
+		{
+			desc: "sandbox sizing annotations are zero if the resources are set to 0",
 			configChange: func(c *runtime.PodSandboxConfig) {
 				c.Linux.Resources = &v1.LinuxContainerResources{}
 			},
@@ -363,7 +378,8 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(desc, func(t *testing.T) {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
 			c := newTestCRIService()
 			c.config.EnableUnprivilegedICMP = true
 			c.config.EnableUnprivilegedPorts = true
@@ -392,13 +408,15 @@ func TestSetupSandboxFiles(t *testing.T) {
 		testID       = "test-id"
 		realhostname = "test-real-hostname"
 	)
-	for desc, test := range map[string]struct {
+	for _, test := range []struct {
+		desc          string
 		dnsConfig     *runtime.DNSConfig
 		hostname      string
 		ipcMode       runtime.NamespaceMode
 		expectedCalls []ostesting.CalledDetail
 	}{
-		"should check host /dev/shm existence when ipc mode is NODE": {
+		{
+			desc:    "should check host /dev/shm existence when ipc mode is NODE",
 			ipcMode: runtime.NamespaceMode_NODE,
 			expectedCalls: []ostesting.CalledDetail{
 				{
@@ -434,7 +452,8 @@ func TestSetupSandboxFiles(t *testing.T) {
 				},
 			},
 		},
-		"should create new /etc/resolv.conf if DNSOptions is set": {
+		{
+			desc: "should create new /etc/resolv.conf if DNSOptions is set",
 			dnsConfig: &runtime.DNSConfig{
 				Servers:  []string{"8.8.8.8"},
 				Searches: []string{"114.114.114.114"},
@@ -477,7 +496,8 @@ options timeout:1
 				},
 			},
 		},
-		"should create sandbox shm when ipc namespace mode is not NODE": {
+		{
+			desc:    "should create sandbox shm when ipc namespace mode is not NODE",
 			ipcMode: runtime.NamespaceMode_POD,
 			expectedCalls: []ostesting.CalledDetail{
 				{
@@ -520,7 +540,8 @@ options timeout:1
 				},
 			},
 		},
-		"should create /etc/hostname when hostname is set": {
+		{
+			desc:     "should create /etc/hostname when hostname is set",
 			hostname: "test-hostname",
 			ipcMode:  runtime.NamespaceMode_NODE,
 			expectedCalls: []ostesting.CalledDetail{
@@ -555,7 +576,8 @@ options timeout:1
 			},
 		},
 	} {
-		t.Run(desc, func(t *testing.T) {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
 			c := newTestCRIService()
 			c.os.(*ostesting.FakeOS).HostnameFn = func() (string, error) {
 				return realhostname, nil
@@ -586,15 +608,19 @@ options timeout:1
 }
 
 func TestParseDNSOption(t *testing.T) {
-	for desc, test := range map[string]struct {
+	for _, test := range []struct {
+		desc            string
 		servers         []string
 		searches        []string
 		options         []string
 		expectedContent string
 		expectErr       bool
 	}{
-		"empty dns options should return empty content": {},
-		"non-empty dns options should return correct content": {
+		{
+			desc: "empty dns options should return empty content",
+		},
+		{
+			desc:     "non-empty dns options should return correct content",
 			servers:  []string{"8.8.8.8", "server.google.com"},
 			searches: []string{"114.114.114.114"},
 			options:  []string{"timeout:1"},
@@ -604,7 +630,8 @@ nameserver server.google.com
 options timeout:1
 `,
 		},
-		"expanded dns config should return correct content on modern libc (e.g. glibc 2.26 and above)": {
+		{
+			desc:    "expanded dns config should return correct content on modern libc (e.g. glibc 2.26 and above)",
 			servers: []string{"8.8.8.8", "server.google.com"},
 			searches: []string{
 				"server0.google.com",
@@ -623,7 +650,8 @@ options timeout:1
 `,
 		},
 	} {
-		t.Run(desc, func(t *testing.T) {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
 			resolvContent, err := parseDNSOptions(test.servers, test.searches, test.options)
 			if test.expectErr {
 				assert.Error(t, err)

--- a/pkg/cri/server/sandbox_status_test.go
+++ b/pkg/cri/server/sandbox_status_test.go
@@ -87,24 +87,29 @@ func TestPodSandboxStatus(t *testing.T) {
 		Annotations:    config.GetAnnotations(),
 		RuntimeHandler: "test-runtime-handler",
 	}
-	for desc, test := range map[string]struct {
+	for _, test := range []struct {
+		desc          string
 		state         sandboxstore.State
 		expectedState runtime.PodSandboxState
 	}{
-		"sandbox state ready": {
+		{
+			desc:          "sandbox state ready",
 			state:         sandboxstore.StateReady,
 			expectedState: runtime.PodSandboxState_SANDBOX_READY,
 		},
-		"sandbox state not ready": {
+		{
+			desc:          "sandbox state not ready",
 			state:         sandboxstore.StateNotReady,
 			expectedState: runtime.PodSandboxState_SANDBOX_NOTREADY,
 		},
-		"sandbox state unknown": {
+		{
+			desc:          "sandbox state unknown",
 			state:         sandboxstore.StateUnknown,
 			expectedState: runtime.PodSandboxState_SANDBOX_NOTREADY,
 		},
 	} {
-		t.Run(desc, func(t *testing.T) {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
 			status := sandboxstore.Status{
 				CreatedAt: createdAt,
 				State:     test.state,

--- a/pkg/cri/server/sandbox_stop_test.go
+++ b/pkg/cri/server/sandbox_stop_test.go
@@ -28,30 +28,35 @@ import (
 
 func TestWaitSandboxStop(t *testing.T) {
 	id := "test-id"
-	for desc, test := range map[string]struct {
+	for _, test := range []struct {
+		desc      string
 		state     sandboxstore.State
 		cancel    bool
 		timeout   time.Duration
 		expectErr bool
 	}{
-		"should return error if timeout exceeds": {
+		{
+			desc:      "should return error if timeout exceeds",
 			state:     sandboxstore.StateReady,
 			timeout:   200 * time.Millisecond,
 			expectErr: true,
 		},
-		"should return error if context is cancelled": {
+		{
+			desc:      "should return error if context is cancelled",
 			state:     sandboxstore.StateReady,
 			timeout:   time.Hour,
 			cancel:    true,
 			expectErr: true,
 		},
-		"should not return error if sandbox is stopped before timeout": {
+		{
+			desc:      "should not return error if sandbox is stopped before timeout",
 			state:     sandboxstore.StateNotReady,
 			timeout:   time.Hour,
 			expectErr: false,
 		},
 	} {
-		t.Run(desc, func(t *testing.T) {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
 			c := newTestCRIService()
 			sandbox := sandboxstore.NewSandbox(
 				sandboxstore.Metadata{ID: id},
@@ -69,7 +74,7 @@ func TestWaitSandboxStop(t *testing.T) {
 				ctx = timeoutCtx
 			}
 			err := c.waitSandboxStop(ctx, sandbox)
-			assert.Equal(t, test.expectErr, err != nil, desc)
+			assert.Equal(t, test.expectErr, err != nil, test.desc)
 		})
 	}
 }

--- a/pkg/cri/server/streaming_test.go
+++ b/pkg/cri/server/streaming_test.go
@@ -24,12 +24,14 @@ import (
 )
 
 func TestValidateStreamServer(t *testing.T) {
-	for desc, test := range map[string]struct {
+	for _, test := range []struct {
+		desc string
 		*criService
 		tlsMode   streamListenerMode
 		expectErr bool
 	}{
-		"should pass with default withoutTLS": {
+		{
+			desc: "should pass with default withoutTLS",
 			criService: &criService{
 				config: config.Config{
 					PluginConfig: config.DefaultConfig(),
@@ -38,7 +40,8 @@ func TestValidateStreamServer(t *testing.T) {
 			tlsMode:   withoutTLS,
 			expectErr: false,
 		},
-		"should pass with x509KeyPairTLS": {
+		{
+			desc: "should pass with x509KeyPairTLS",
 			criService: &criService{
 				config: config.Config{
 					PluginConfig: config.PluginConfig{
@@ -53,7 +56,8 @@ func TestValidateStreamServer(t *testing.T) {
 			tlsMode:   x509KeyPairTLS,
 			expectErr: false,
 		},
-		"should pass with selfSign": {
+		{
+			desc: "should pass with selfSign",
 			criService: &criService{
 				config: config.Config{
 					PluginConfig: config.PluginConfig{
@@ -64,7 +68,8 @@ func TestValidateStreamServer(t *testing.T) {
 			tlsMode:   selfSignTLS,
 			expectErr: false,
 		},
-		"should return error with X509 keypair but not EnableTLSStreaming": {
+		{
+			desc: "should return error with X509 keypair but not EnableTLSStreaming",
 			criService: &criService{
 				config: config.Config{
 					PluginConfig: config.PluginConfig{
@@ -79,7 +84,8 @@ func TestValidateStreamServer(t *testing.T) {
 			tlsMode:   -1,
 			expectErr: true,
 		},
-		"should return error with X509 TLSCertFile empty": {
+		{
+			desc: "should return error with X509 TLSCertFile empty",
 			criService: &criService{
 				config: config.Config{
 					PluginConfig: config.PluginConfig{
@@ -94,7 +100,8 @@ func TestValidateStreamServer(t *testing.T) {
 			tlsMode:   -1,
 			expectErr: true,
 		},
-		"should return error with X509 TLSKeyFile empty": {
+		{
+			desc: "should return error with X509 TLSKeyFile empty",
 			criService: &criService{
 				config: config.Config{
 					PluginConfig: config.PluginConfig{
@@ -109,7 +116,8 @@ func TestValidateStreamServer(t *testing.T) {
 			tlsMode:   -1,
 			expectErr: true,
 		},
-		"should return error without EnableTLSStreaming and only TLSCertFile set": {
+		{
+			desc: "should return error without EnableTLSStreaming and only TLSCertFile set",
 			criService: &criService{
 				config: config.Config{
 					PluginConfig: config.PluginConfig{
@@ -124,7 +132,8 @@ func TestValidateStreamServer(t *testing.T) {
 			tlsMode:   -1,
 			expectErr: true,
 		},
-		"should return error without EnableTLSStreaming and only TLSKeyFile set": {
+		{
+			desc: "should return error without EnableTLSStreaming and only TLSKeyFile set",
 			criService: &criService{
 				config: config.Config{
 					PluginConfig: config.PluginConfig{
@@ -140,7 +149,8 @@ func TestValidateStreamServer(t *testing.T) {
 			expectErr: true,
 		},
 	} {
-		t.Run(desc, func(t *testing.T) {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
 			tlsMode, err := getStreamListenerMode(test.criService)
 			if test.expectErr {
 				assert.Error(t, err)

--- a/pkg/cri/server/update_runtime_config_test.go
+++ b/pkg/cri/server/update_runtime_config_test.go
@@ -70,29 +70,35 @@ func TestUpdateRuntimeConfig(t *testing.T) {
 }`
 	)
 
-	for name, test := range map[string]struct {
+	for _, test := range []struct {
+		name            string
 		noTemplate      bool
 		emptyCIDR       bool
 		networkReady    bool
 		expectCNIConfig bool
 	}{
-		"should not generate cni config if cidr is empty": {
+		{
+			name:            "should not generate cni config if cidr is empty",
 			emptyCIDR:       true,
 			expectCNIConfig: false,
 		},
-		"should not generate cni config if template file is not specified": {
+		{
+			name:            "should not generate cni config if template file is not specified",
 			noTemplate:      true,
 			expectCNIConfig: false,
 		},
-		"should not generate cni config if network is ready": {
+		{
+			name:            "should not generate cni config if network is ready",
 			networkReady:    true,
 			expectCNIConfig: false,
 		},
-		"should generate cni config if template is specified and cidr is provided": {
+		{
+			name:            "should generate cni config if template is specified and cidr is provided",
 			expectCNIConfig: true,
 		},
 	} {
-		t.Run(name, func(t *testing.T) {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
 			testDir := t.TempDir()
 			templateName := filepath.Join(testDir, "template")
 			err := os.WriteFile(templateName, []byte(testTemplate), 0666)


### PR DESCRIPTION
Using array to build sub-tests is to avoid random pick. The shuffle thing should be handled by go-test framework. And we should capture range var before runing sub-test.

Signed-off-by: Wei Fu <fuweid89@gmail.com>