### PR TITLE
fix unable to checkpoint the container more than once

### DIFF
--- a/services/tasks/local.go
+++ b/services/tasks/local.go
@@ -664,7 +664,7 @@ func (l *local) writeContent(ctx context.Context, mediaType, ref string, r io.Re
 	if err != nil {
 		return nil, err
 	}
-	if err := writer.Commit(ctx, 0, ""); err != nil {
+	if err := writer.Commit(ctx, 0, ""); err != nil && !errdefs.IsAlreadyExists(err) {
 		return nil, err
 	}
 	return &types.Descriptor{


### PR DESCRIPTION
when we call `ctr container checkpoint --task <container> <checkpoint-image>` multiple times to checkpoint the container, the checkpoint image will not  include `MediaTypeContainerd1CheckpointConfig`, `MediaTypeContainerd1Checkpoint ` and `MediaTypeContainerd1CheckpointOptions` layers

The checkpoint image content before fixing:
```json
{
    "schemaVersion":2,
    "manifests":[
        {
            "mediaType":"application/vnd.docker.distribution.manifest.v2+json",
            "digest":"sha256:1a893424c6b027d8a00695250292acaedfe8934ecde540810eb3d95791f29b83",
            "size":737,
            "annotations":{
                "io.containerd.image.name":"docker.io/library/ubuntu:latest",
                "org.opencontainers.image.ref.name":"latest"
            }
        },
        {
            "mediaType":"application/vnd.oci.image.layer.v1.tar+gzip",
            "digest":"sha256:f17dd931073b2c7c15fea1aabe34addde6aa303dfcb70ad4ac64b2fb8a79f9ae",
            "size":198,
            "platform":{
                "architecture":"amd64",
                "os":"linux"
            }
        }
    ],
    "annotations":{
        "io.containerd.checkpoint.runtime":"io.containerd.runc.v2",
        "io.containerd.checkpoint.snapshotter":"overlayfs",
        "org.opencontainers.image.ref.name":"docker.io/library/ubuntu:latest"
    }
}
```

after fixing:
```json
{
    "schemaVersion":2,
    "manifests":[
        {
            "mediaType":"application/vnd.docker.distribution.manifest.v2+json",
            "digest":"sha256:1a893424c6b027d8a00695250292acaedfe8934ecde540810eb3d95791f29b83",
            "size":737,
            "annotations":{
                "io.containerd.image.name":"docker.io/library/ubuntu:latest",
                "org.opencontainers.image.ref.name":"latest"
            }
        },
        {
            "mediaType":"application/vnd.oci.image.layer.v1.tar+gzip",
            "digest":"sha256:fc158742548d6fbf612b7a7ad15a4dcdbde0b7e067047f2d86482c4114dc2183",
            "size":127,
            "platform":{
                "architecture":"amd64",
                "os":"linux"
            }
        },
        {
            "mediaType":"application/vnd.containerd.container.criu.checkpoint.criu.tar",
            "digest":"sha256:7b3ebf3e04c587c4b703c87ae92fa491a74f1352f9a4fa90c65d8a08baf3e717",
            "size":727040,
            "platform":{
                "architecture":"amd64",
                "os":"linux"
            }
        },
        {
            "mediaType":"application/vnd.containerd.container.checkpoint.config.v1+proto",
            "digest":"sha256:4a9bdf2f2c32b9c13cd50e8668ee1f33d16883804ba0030bd9917447e31dfa20",
            "size":2882,
            "platform":{
                "architecture":"amd64",
                "os":"linux"
            }
        },
        {
            "mediaType":"application/vnd.containerd.container.checkpoint.options.v1+proto",
            "digest":"sha256:7d3151453569712d136c98a8cce017f677b6a39c5114c6f570c0ea2f5a4bce68",
            "size":42,
            "platform":{
                "architecture":"amd64",
                "os":"linux"
            }
        }
    ],
    "annotations":{
        "io.containerd.checkpoint.runtime":"io.containerd.runc.v2",
        "io.containerd.checkpoint.snapshotter":"overlayfs",
        "org.opencontainers.image.ref.name":"docker.io/library/ubuntu:latest"
    }
}
```
