### PR TITLE
Add support for overlay volatile option

### DIFF
--- a/mount/temp.go
+++ b/mount/temp.go
@@ -58,6 +58,24 @@ func WithTempMount(ctx context.Context, mounts []Mount, f func(root string) erro
 			}
 		}
 	}()
+
+	// The volatile option of overlayfs doesn't allow to mount again using the
+	// same upper / work dirs. Since it's a temp mount, avoid using that
+	// option here.
+	// TODO: Make this logic conditional once the kernel supports reusing
+	// overlayfs volatile mounts.
+	for _, m := range mounts {
+		if m.Type != "overlay" {
+			continue
+		}
+		for i, opt := range m.Options {
+			if opt == "volatile" {
+				m.Options[i] = ""
+				break
+			}
+		}
+	}
+
 	if uerr = All(mounts, root); uerr != nil {
 		return fmt.Errorf("failed to mount %s: %w", root, uerr)
 	}

--- a/snapshots/overlay/plugin/plugin.go
+++ b/snapshots/overlay/plugin/plugin.go
@@ -31,6 +31,7 @@ type Config struct {
 	// Root directory for the plugin
 	RootPath      string `toml:"root_path"`
 	UpperdirLabel bool   `toml:"upperdir_label"`
+	Volatile      bool   `toml:"volatile"`
 }
 
 func init() {
@@ -54,6 +55,10 @@ func init() {
 			var oOpts []overlay.Opt
 			if config.UpperdirLabel {
 				oOpts = append(oOpts, overlay.WithUpperdirLabel)
+			}
+
+			if config.Volatile {
+				oOpts = append(oOpts, overlay.Volatile)
 			}
 
 			ic.Meta.Exports["root"] = root


### PR DESCRIPTION
This PR enables volatile overlayfs mounts following the same implementation as https://github.com/containerd/containerd/pull/4785

- Updates the code inline with surrounding code changes since the PR was originally proposed 
- Fixes a comment typo 'ommit' to 'omit' as raised on the original PR
- Add a SupportsVolatileMount func in overlayutils to test if volatile mounts are available from the NewSnapshotter func

@rata 