### PR TITLE
Checkpoint the task and container create image of the same format

### DIFF
--- a/container.go
+++ b/container.go
@@ -378,6 +378,9 @@ func (c *container) Checkpoint(ctx context.Context, ref string, opts ...Checkpoi
 	i := images.Image{
 		Name:   ref,
 		Target: desc,
+		Labels: map[string]string{
+			"containerd.io/checkpoint": "true",
+		},
 	}
 	checkpoint, err := c.client.ImageService().Create(ctx, i)
 	if err != nil {

--- a/task.go
+++ b/task.go
@@ -487,7 +487,7 @@ func (t *task) Checkpoint(ctx context.Context, opts ...CheckpointTaskOpts) (Imag
 	}
 	// if checkpoint image path passed, jump checkpoint image,
 	// return an empty image
-	if isCheckpointPathExist(cr.Runtime.Name, i.Options) {
+	if isCheckpointPathExist(i.Options) {
 		return NewImage(t.client, images.Image{}), nil
 	}
 
@@ -688,18 +688,10 @@ func writeContent(ctx context.Context, store content.Ingester, mediaType, ref st
 	}, nil
 }
 
-// isCheckpointPathExist only suitable for runc runtime now
-func isCheckpointPathExist(runtime string, v interface{}) bool {
-	if v == nil {
-		return false
+func isCheckpointPathExist(v interface{}) bool {
+	switch opts := v.(type) {
+	case *options.CheckpointOptions:
+		return opts != nil && opts.ImagePath != ""
 	}
-
-	switch runtime {
-	case plugin.RuntimeRuncV2:
-		if opts, ok := v.(*options.CheckpointOptions); ok && opts.ImagePath != "" {
-			return true
-		}
-	}
-
 	return false
 }


### PR DESCRIPTION
The checkpoint image created by the `ctr task checkpoint <id>` command cannot be restored by `ctr container restore` or any other commands.

The image created by the `ctr task checkpoint` command is now in the same format as the image created by the `ctr container checkpoint` command and is compatible with the past format.

The `ctr task checkpoint <id>` command is equivalent to `ctr container container --rw --live --image <id> <image_name>`