### PR TITLE
Draft: Sync file when pull image

### DIFF
--- a/archive/tar.go
+++ b/archive/tar.go
@@ -350,8 +350,11 @@ func createTarFile(ctx context.Context, path, extractDir string, hdr *tar.Header
 		}
 
 		_, err = copyBuffered(ctx, file, reader)
-		if err1 := file.Close(); err == nil {
-			err = err1
+
+		for _, op := range []func() error{file.Sync, file.Close} {
+			if opErr := op(); err == nil {
+				err = opErr
+			}
 		}
 		if err != nil {
 			return err


### PR DESCRIPTION
Fix https://github.com/containerd/containerd/issues/8409

Sync files when unpack content to prevent the situation where files are empty after kernel panic. 
It may slow down the download of the image.
I'm not sure if this is the best choice, so I mark it with WIP.