### PR TITLE
Update go-restful to v3.10.1 in release/1.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c
 	github.com/docker/go-metrics v0.0.1
 	github.com/docker/go-units v0.4.0
-	github.com/emicklei/go-restful/v3 v3.7.3
+	github.com/emicklei/go-restful/v3 v3.10.1
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/gogo/googleapis v1.4.0
 	github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -351,8 +351,8 @@ github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkg
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
-github.com/emicklei/go-restful/v3 v3.7.3 h1:06a5brwUhivED9WAFB3Q1JZDhirpnHlCdEVhGz3PSfc=
-github.com/emicklei/go-restful/v3 v3.7.3/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/emicklei/go-restful/v3 v3.10.1 h1:rc42Y5YTp7Am7CS630D7JmhRjq4UlEUuEKfrDac4bSQ=
+github.com/emicklei/go-restful/v3 v3.10.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/integration/client/go.sum
+++ b/integration/client/go.sum
@@ -197,7 +197,7 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
-github.com/emicklei/go-restful/v3 v3.7.3/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/emicklei/go-restful/v3 v3.10.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/vendor/github.com/emicklei/go-restful/v3/CHANGES.md
+++ b/vendor/github.com/emicklei/go-restful/v3/CHANGES.md
@@ -1,5 +1,30 @@
 # Change history of go-restful
 
+## [v3.10.1] - 2022-11-19
+
+- fix broken 3.10.0 by using path package for joining paths
+
+## [v3.10.0] - 2022-10-11 - BROKEN
+
+- changed tokenizer to match std route match behavior; do not trimright the path (#511)
+- Add MIME_ZIP (#512)
+- Add MIME_ZIP and HEADER_ContentDisposition (#513)
+- Changed how to get query parameter issue #510
+
+## [v3.9.0] - 2022-07-21
+
+- add support for http.Handler implementations to work as FilterFunction, issue #504 (thanks to https://github.com/ggicci)
+
+## [v3.8.0] - 2022-06-06
+
+- use exact matching of allowed domain entries, issue #489 (#493)
+	- this changes fixes [security] Authorization Bypass Through User-Controlled Key
+	  by changing the behaviour of the AllowedDomains setting in the CORS filter.
+	  To support the previous behaviour, the CORS filter type now has a AllowedDomainFunc
+	  callback mechanism which is called when a simple domain match fails. 
+- add test and fix for POST without body and Content-type, issue #492 (#496)
+- [Minor] Bad practice to have a mix of Receiver types. (#491)
+
 ## [v3.7.2] - 2021-11-24
 
 - restored FilterChain (#482 by SVilgelm)

--- a/vendor/github.com/emicklei/go-restful/v3/README.md
+++ b/vendor/github.com/emicklei/go-restful/v3/README.md
@@ -84,6 +84,7 @@ func (u UserResource) findUser(request *restful.Request, response *restful.Respo
 - Route errors produce HTTP 404/405/406/415 errors, customizable using ServiceErrorHandler(...)
 - Configurable (trace) logging
 - Customizable gzip/deflate readers and writers using CompressorProvider registration
+- Inject your own http.Handler using the `HttpMiddlewareHandlerToFilter` function
 
 ## How to customize
 There are several hooks to customize the behavior of the go-restful package.
@@ -94,12 +95,11 @@ There are several hooks to customize the behavior of the go-restful package.
 - Trace logging
 - Compression
 - Encoders for other serializers
-- Use [jsoniter](https://github.com/json-iterator/go) by build this package using a tag, e.g. `go build -tags=jsoniter .`
-
-TODO: write examples of these.
+- Use [jsoniter](https://github.com/json-iterator/go) by building this package using a build tag, e.g. `go build -tags=jsoniter .` 
 
 ## Resources
 
+- [Example programs](./examples)
 - [Example posted on blog](http://ernestmicklei.com/2012/11/go-restful-first-working-example/)
 - [Design explained on blog](http://ernestmicklei.com/2012/11/go-restful-api-design/)
 - [sourcegraph](https://sourcegraph.com/github.com/emicklei/go-restful)
@@ -108,4 +108,4 @@ TODO: write examples of these.
 
 Type ```git shortlog -s``` for a full list of contributors.
 
-© 2012 - 2021, http://ernestmicklei.com. MIT License. Contributions are welcome.
+© 2012 - 2022, http://ernestmicklei.com. MIT License. Contributions are welcome.

--- a/vendor/github.com/emicklei/go-restful/v3/SECURITY.md
+++ b/vendor/github.com/emicklei/go-restful/v3/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| v3.7.x     | :white_check_mark: |
+| < v3.0.1   | :x:                |
+
+## Reporting a Vulnerability
+
+Create an Issue and put the label `[security]` in the title of the issue.
+Valid reported security issues are expected to be solved within a week.

--- a/vendor/github.com/emicklei/go-restful/v3/compress.go
+++ b/vendor/github.com/emicklei/go-restful/v3/compress.go
@@ -83,7 +83,11 @@ func (c *CompressingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error
 }
 
 // WantsCompressedResponse reads the Accept-Encoding header to see if and which encoding is requested.
-func wantsCompressedResponse(httpRequest *http.Request) (bool, string) {
+// It also inspects the httpWriter whether its content-encoding is already set (non-empty).
+func wantsCompressedResponse(httpRequest *http.Request, httpWriter http.ResponseWriter) (bool, string) {
+	if contentEncoding := httpWriter.Header().Get(HEADER_ContentEncoding); contentEncoding != "" {
+		return false, ""
+	}
 	header := httpRequest.Header.Get(HEADER_AcceptEncoding)
 	gi := strings.Index(header, ENCODING_GZIP)
 	zi := strings.Index(header, ENCODING_DEFLATE)

--- a/vendor/github.com/emicklei/go-restful/v3/constants.go
+++ b/vendor/github.com/emicklei/go-restful/v3/constants.go
@@ -7,12 +7,14 @@ package restful
 const (
 	MIME_XML   = "application/xml"          // Accept or Content-Type used in Consumes() and/or Produces()
 	MIME_JSON  = "application/json"         // Accept or Content-Type used in Consumes() and/or Produces()
+	MIME_ZIP   = "application/zip"          // Accept or Content-Type used in Consumes() and/or Produces()
 	MIME_OCTET = "application/octet-stream" // If Content-Type is not present in request, use the default
 
 	HEADER_Allow                         = "Allow"
 	HEADER_Accept                        = "Accept"
 	HEADER_Origin                        = "Origin"
 	HEADER_ContentType                   = "Content-Type"
+	HEADER_ContentDisposition            = "Content-Disposition"
 	HEADER_LastModified                  = "Last-Modified"
 	HEADER_AcceptEncoding                = "Accept-Encoding"
 	HEADER_ContentEncoding               = "Content-Encoding"

--- a/vendor/github.com/emicklei/go-restful/v3/container.go
+++ b/vendor/github.com/emicklei/go-restful/v3/container.go
@@ -261,7 +261,7 @@ func (c *Container) dispatch(httpWriter http.ResponseWriter, httpRequest *http.R
 			contentEncodingEnabled = *route.contentEncodingEnabled
 		}
 		if contentEncodingEnabled {
-			doCompress, encoding := wantsCompressedResponse(httpRequest)
+			doCompress, encoding := wantsCompressedResponse(httpRequest, httpWriter)
 			if doCompress {
 				var err error
 				writer, err = NewCompressingResponseWriter(httpWriter, encoding)
@@ -288,8 +288,8 @@ func (c *Container) dispatch(httpWriter http.ResponseWriter, httpRequest *http.R
 		allFilters = append(allFilters, webService.filters...)
 		allFilters = append(allFilters, route.Filters...)
 		chain := FilterChain{
-			Filters: allFilters,
-			Target: route.Function,
+			Filters:       allFilters,
+			Target:        route.Function,
 			ParameterDocs: route.ParameterDocs,
 			Operation:     route.Operation,
 		}
@@ -332,7 +332,7 @@ func (c *Container) ServeHTTP(httpWriter http.ResponseWriter, httpRequest *http.
 		}
 	}()
 
-	doCompress, encoding := wantsCompressedResponse(httpRequest)
+	doCompress, encoding := wantsCompressedResponse(httpRequest, httpWriter)
 	if doCompress {
 		var err error
 		writer, err = NewCompressingResponseWriter(httpWriter, encoding)
@@ -365,7 +365,7 @@ func (c *Container) Handle(pattern string, handler http.Handler) {
 		}()
 
 		if c.contentEncodingEnabled {
-			doCompress, encoding := wantsCompressedResponse(httpRequest)
+			doCompress, encoding := wantsCompressedResponse(httpRequest, httpWriter)
 			if doCompress {
 				var err error
 				writer, err = NewCompressingResponseWriter(httpWriter, encoding)

--- a/vendor/github.com/emicklei/go-restful/v3/filter_adapter.go
+++ b/vendor/github.com/emicklei/go-restful/v3/filter_adapter.go
@@ -1,0 +1,21 @@
+package restful
+
+import (
+	"net/http"
+)
+
+// HttpMiddlewareHandler is a function that takes a http.Handler and returns a http.Handler
+type HttpMiddlewareHandler func(http.Handler) http.Handler
+
+// HttpMiddlewareHandlerToFilter converts a HttpMiddlewareHandler to a FilterFunction.
+func HttpMiddlewareHandlerToFilter(middleware HttpMiddlewareHandler) FilterFunction {
+	return func(req *Request, resp *Response, chain *FilterChain) {
+		next := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			req.Request = r
+			resp.ResponseWriter = rw
+			chain.ProcessFilter(req, resp)
+		})
+
+		middleware(next).ServeHTTP(resp.ResponseWriter, req.Request)
+	}
+}

--- a/vendor/github.com/emicklei/go-restful/v3/jsr311.go
+++ b/vendor/github.com/emicklei/go-restful/v3/jsr311.go
@@ -151,6 +151,16 @@ func (r RouterJSR311) detectRoute(routes []Route, httpRequest *http.Request) (*R
 		for _, candidate := range previous {
 			available = append(available, candidate.Produces...)
 		}
+		// if POST,PUT,PATCH without body
+		method, length := httpRequest.Method, httpRequest.Header.Get("Content-Length")
+		if (method == http.MethodPost ||
+			method == http.MethodPut ||
+			method == http.MethodPatch) && length == "" {
+			return nil, NewError(
+				http.StatusUnsupportedMediaType,
+				fmt.Sprintf("415: Unsupported Media Type\n\nAvailable representations: %s", strings.Join(available, ", ")),
+			)
+		}
 		return nil, NewError(
 			http.StatusNotAcceptable,
 			fmt.Sprintf("406: Not Acceptable\n\nAvailable representations: %s", strings.Join(available, ", ")),

--- a/vendor/github.com/emicklei/go-restful/v3/parameter.go
+++ b/vendor/github.com/emicklei/go-restful/v3/parameter.go
@@ -22,6 +22,9 @@ const (
 	// FormParameterKind = indicator of Request parameter type "form"
 	FormParameterKind
 
+	// MultiPartFormParameterKind = indicator of Request parameter type "multipart/form-data"
+	MultiPartFormParameterKind
+
 	// CollectionFormatCSV comma separated values `foo,bar`
 	CollectionFormatCSV = CollectionFormat("csv")
 
@@ -105,6 +108,11 @@ func (p *Parameter) beHeader() *Parameter {
 
 func (p *Parameter) beForm() *Parameter {
 	p.data.Kind = FormParameterKind
+	return p
+}
+
+func (p *Parameter) beMultiPartForm() *Parameter {
+	p.data.Kind = MultiPartFormParameterKind
 	return p
 }
 

--- a/vendor/github.com/emicklei/go-restful/v3/request.go
+++ b/vendor/github.com/emicklei/go-restful/v3/request.go
@@ -31,7 +31,8 @@ func NewRequest(httpRequest *http.Request) *Request {
 // a "Unable to unmarshal content of type:" response is returned.
 // Valid values are restful.MIME_JSON and restful.MIME_XML
 // Example:
-// 	restful.DefaultRequestContentType(restful.MIME_JSON)
+//
+//	restful.DefaultRequestContentType(restful.MIME_JSON)
 func DefaultRequestContentType(mime string) {
 	defaultRequestContentType = mime
 }
@@ -48,7 +49,7 @@ func (r *Request) PathParameters() map[string]string {
 
 // QueryParameter returns the (first) Query parameter value by its name
 func (r *Request) QueryParameter(name string) string {
-	return r.Request.FormValue(name)
+	return r.Request.URL.Query().Get(name)
 }
 
 // QueryParameters returns the all the query parameters values by name

--- a/vendor/github.com/emicklei/go-restful/v3/response.go
+++ b/vendor/github.com/emicklei/go-restful/v3/response.go
@@ -109,6 +109,9 @@ func (r *Response) EntityWriter() (EntityReaderWriter, bool) {
 		if DefaultResponseMimeType == MIME_XML {
 			return entityAccessRegistry.accessorAt(MIME_XML)
 		}
+		if DefaultResponseMimeType == MIME_ZIP {
+			return entityAccessRegistry.accessorAt(MIME_ZIP)
+		}
 		// Fallback to whatever the route says it can produce.
 		// https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
 		for _, each := range r.routeProduces {

--- a/vendor/github.com/emicklei/go-restful/v3/route.go
+++ b/vendor/github.com/emicklei/go-restful/v3/route.go
@@ -164,11 +164,11 @@ func tokenizePath(path string) []string {
 	if "/" == path {
 		return nil
 	}
-	return strings.Split(strings.Trim(path, "/"), "/")
+	return strings.Split(strings.TrimLeft(path, "/"), "/")
 }
 
 // for debugging
-func (r Route) String() string {
+func (r *Route) String() string {
 	return r.Method + " " + r.Path
 }
 
@@ -176,3 +176,5 @@ func (r Route) String() string {
 func (r *Route) EnableContentEncoding(enabled bool) {
 	r.contentEncodingEnabled = &enabled
 }
+
+var TrimRightSlashEnabled = false

--- a/vendor/github.com/emicklei/go-restful/v3/route_builder.go
+++ b/vendor/github.com/emicklei/go-restful/v3/route_builder.go
@@ -7,6 +7,7 @@ package restful
 import (
 	"fmt"
 	"os"
+	"path"
 	"reflect"
 	"runtime"
 	"strings"
@@ -46,11 +47,12 @@ type RouteBuilder struct {
 // Do evaluates each argument with the RouteBuilder itself.
 // This allows you to follow DRY principles without breaking the fluent programming style.
 // Example:
-// 		ws.Route(ws.DELETE("/{name}").To(t.deletePerson).Do(Returns200, Returns500))
 //
-//		func Returns500(b *RouteBuilder) {
-//			b.Returns(500, "Internal Server Error", restful.ServiceError{})
-//		}
+//	ws.Route(ws.DELETE("/{name}").To(t.deletePerson).Do(Returns200, Returns500))
+//
+//	func Returns500(b *RouteBuilder) {
+//		b.Returns(500, "Internal Server Error", restful.ServiceError{})
+//	}
 func (b *RouteBuilder) Do(oneArgBlocks ...func(*RouteBuilder)) *RouteBuilder {
 	for _, each := range oneArgBlocks {
 		each(b)
@@ -352,7 +354,7 @@ func (b *RouteBuilder) Build() Route {
 }
 
 func concatPath(path1, path2 string) string {
-	return strings.TrimRight(path1, "/") + "/" + strings.TrimLeft(path2, "/")
+	return path.Join(path1, path2)
 }
 
 var anonymousFuncCount int32

--- a/vendor/github.com/emicklei/go-restful/v3/web_service.go
+++ b/vendor/github.com/emicklei/go-restful/v3/web_service.go
@@ -165,6 +165,18 @@ func FormParameter(name, description string) *Parameter {
 	return p
 }
 
+// MultiPartFormParameter creates a new Parameter of kind Form (using multipart/form-data) for documentation purposes.
+// It is initialized as required with string as its DataType.
+func (w *WebService) MultiPartFormParameter(name, description string) *Parameter {
+	return MultiPartFormParameter(name, description)
+}
+
+func MultiPartFormParameter(name, description string) *Parameter {
+	p := &Parameter{&ParameterData{Name: name, Description: description, Required: false, DataType: "string"}}
+	p.beMultiPartForm()
+	return p
+}
+
 // Route creates a new Route using the RouteBuilder and add to the ordered list of Routes.
 func (w *WebService) Route(builder *RouteBuilder) *WebService {
 	w.routesLock.Lock()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -178,7 +178,7 @@ github.com/docker/go-units
 ## explicit
 github.com/emicklei/go-restful
 github.com/emicklei/go-restful/log
-# github.com/emicklei/go-restful/v3 v3.7.3
+# github.com/emicklei/go-restful/v3 v3.10.1
 ## explicit; go 1.13
 github.com/emicklei/go-restful/v3
 github.com/emicklei/go-restful/v3/log


### PR DESCRIPTION
I cherry-picked #8221 and ran `go mod tidy` and `go mod vendor` like #8271. Silences a false alert about [CVE-2022-1996](https://github.com/advisories/GHSA-r48q-9g5r-8q2h). containerd is not affected by this CVE.

Resolves #8168