### PR TITLE
[doc]Update external repo links that changed default branch to main

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,3 +1,3 @@
 ## containerd Community Code of Conduct
 
-containerd follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+containerd follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).

--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -301,7 +301,7 @@ version = 2
       #
       # For the naming convention of annotation keys, please reference:
       # * Kubernetes: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
-      # * OCI: https://github.com/opencontainers/image-spec/blob/master/annotations.md
+      # * OCI: https://github.com/opencontainers/image-spec/blob/main/annotations.md
       pod_annotations = []
 
       # container_annotations is a list of container annotations passed through to the OCI config of the containers.

--- a/docs/rootless.md
+++ b/docs/rootless.md
@@ -15,7 +15,7 @@ $ containerd-rootless-setuptool.sh install
 $ nerdctl run -d --restart=always --name nginx -p 8080:80 nginx:alpine
 ```
 
-See https://github.com/containerd/nerdctl/blob/master/docs/rootless.md for the further information.
+See [nerdctl/docs/rootless.md](https://github.com/containerd/nerdctl/blob/main/docs/rootless.md) for further information.
 
 ## "Hard way"
 
@@ -33,7 +33,7 @@ $ rootlesskit --net=slirp4netns --copy-up=/etc --copy-up=/run \
 ```
 
 * `--net=slirp4netns --copy-up=/etc` is only required when you want to unshare network namespaces.
-  See [RootlessKit documentation](https://github.com/rootless-containers/rootlesskit/blob/v0.14.1/docs/network.md) for the further information about the network drivers.
+  See [RootlessKit documentation](https://github.com/rootless-containers/rootlesskit/blob/v0.14.1/docs/network.md) for further information about the network drivers.
 * `--copy-up=/DIR` mounts a writable tmpfs on `/DIR` with symbolic links to the files under the `/DIR` on the parent namespace
   so that the user can add/remove files under `/DIR` in the mount namespace.
   `--copy-up=/etc` and `--copy-up=/run` are needed on typical setup.

--- a/pkg/netns/netns_linux.go
+++ b/pkg/netns/netns_linux.go
@@ -46,7 +46,7 @@ import (
 )
 
 // Some of the following functions are migrated from
-// https://github.com/containernetworking/plugins/blob/master/pkg/testutils/netns_linux.go
+// https://github.com/containernetworking/plugins/blob/main/pkg/testutils/netns_linux.go
 
 // newNS creates a new persistent (bind-mounted) network namespace and returns the
 // path to the network namespace.


### PR DESCRIPTION
The code base links to few external repos whose default branch changed from master to main. 

Although those links still work(github will redirect to the new default branch), seems it's better to update the link. 

Verified updated links work OK through browser. 

Signed-off-by: Tony Fang nhfang@amazon.com