### PR TITLE
chore: fix the syntax error for the note of image-pull

### DIFF
--- a/pull.go
+++ b/pull.go
@@ -139,7 +139,7 @@ func (c *Client) Pull(ctx context.Context, ref string, opts ...RemoteOpt) (_ Ima
 		return nil, err
 	}
 
-	// NOTE(fuweid): unpacker defers blobs download. before create image
+	// NOTE(fuweid): unpacker defers blobs download. before creating image
 	// record in ImageService, should wait for unpacking(including blobs
 	// download).
 	var ur unpack.Result


### PR DESCRIPTION
Just fix the syntax error for the note of image-pull, which has no user-facing changes.