### PR TITLE
Binary IO: distinguish io process termination vs ready notification s…

### DIFF
--- a/pkg/process/io.go
+++ b/pkg/process/io.go
@@ -296,7 +296,7 @@ func NewBinaryIO(ctx context.Context, id string, uri *url.URL) (_ runc.IO, err e
 
 	// wait for the logging binary to be ready
 	b := make([]byte, 1)
-	if _, err := r.Read(b); err != nil && err != io.EOF {
+	if _, err := r.Read(b); err != nil {
 		return nil, fmt.Errorf("failed to read from logging binary: %w", err)
 	}
 

--- a/runtime/v2/logging/logging_unix.go
+++ b/runtime/v2/logging/logging_unix.go
@@ -46,7 +46,10 @@ func Run(fn LoggerFunc) {
 	signal.Notify(sigCh, unix.SIGTERM)
 
 	go func() {
-		errCh <- fn(ctx, config, wait.Close)
+		errCh <- fn(ctx, config, func() error {
+			wait.Write([]byte{0})
+			return wait.Close()
+		})
 	}()
 
 	for {

--- a/runtime/v2/logging/logging_windows.go
+++ b/runtime/v2/logging/logging_windows.go
@@ -83,7 +83,10 @@ func runInternal(fn LoggerFunc) error {
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
 
 	go func() {
-		errCh <- fn(ctx, config, wait.Close)
+		errCh <- fn(ctx, config, func() error {
+			wait.Write([]byte{0})
+			return wait.Close()
+		})
 	}()
 
 	for {


### PR DESCRIPTION
Binary IO: distinguish io process termination vs ready notification

I started the discussion #8424 to clarify the expected early termination behavior of a binary IO process. This PR is created to address the 1st issue in that thread.

Today the notification of a `ready` state of the IO process is by closing the wait pipe. However in case of unexpected early process termination the result is also the pipe close. 

It would be useful to distinguish these two scenarios and intentionally fail the container creation if the IO process terminates at early stage (before the `ready` notification).