### PR TITLE
[release/1.7] fix the task setting the runtime path

### DIFF
--- a/container.go
+++ b/container.go
@@ -281,6 +281,7 @@ func (c *container) NewTask(ctx context.Context, ioCreate cio.Creator, opts ...N
 			})
 		}
 	}
+	request.RuntimePath = info.RuntimePath
 	if info.Options != nil {
 		any, err := typeurl.MarshalAny(info.Options)
 		if err != nil {

--- a/integration/client/container_test.go
+++ b/integration/client/container_test.go
@@ -213,6 +213,10 @@ func TestContainerStartWithAbsRuntimePath(t *testing.T) {
 	}
 	defer client.Close()
 
+	if client.Runtime() == plugin.RuntimeLinuxV1 {
+		t.Skip("test relies on runtime v2")
+	}
+
 	var (
 		image       Image
 		ctx, cancel = testContext(t)

--- a/integration/client/container_test.go
+++ b/integration/client/container_test.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"syscall"
@@ -43,6 +44,7 @@ import (
 	gogotypes "github.com/containerd/containerd/protobuf/types"
 	_ "github.com/containerd/containerd/runtime"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
+	"github.com/containerd/continuity/fs"
 	"github.com/containerd/go-runc"
 	"github.com/containerd/typeurl/v2"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -138,6 +140,130 @@ func TestContainerStart(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer task.Delete(ctx)
+
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if runtime.GOOS != "windows" {
+		// task.Pid not implemented on Windows
+		if pid := task.Pid(); pid < 1 {
+			t.Errorf("invalid task pid %d", pid)
+		}
+	}
+
+	if err := task.Start(ctx); err != nil {
+		t.Error(err)
+		task.Delete(ctx)
+		return
+	}
+	status := <-statusC
+	code, _, err := status.Result()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != 7 {
+		t.Errorf("expected status 7 from wait but received %d", code)
+	}
+
+	deleteStatus, err := task.Delete(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ec := deleteStatus.ExitCode(); ec != 7 {
+		t.Errorf("expected status 7 from delete but received %d", ec)
+	}
+}
+
+func readShimPath(taskID string) (string, error) {
+	runtime := fmt.Sprintf("%s.%s", plugin.RuntimePluginV2, "task")
+	shimBinaryNamePath := filepath.Join(defaultState, runtime, testNamespace, taskID, "shim-binary-path")
+
+	shimPath, err := os.ReadFile(shimBinaryNamePath)
+	if err != nil {
+		return "", err
+	}
+	return string(shimPath), nil
+}
+
+func copyShim(shimPath string) (string, error) {
+	tempPath := filepath.Join(os.TempDir(), filepath.Base(shimPath))
+	if err := fs.CopyFile(tempPath, shimPath); err != nil {
+		return "", err
+	}
+
+	fi, err := os.Stat(shimPath)
+	if err != nil {
+		return "", err
+	}
+	if err := os.Chmod(tempPath, fi.Mode().Perm()); err != nil {
+		return "", err
+	}
+
+	return tempPath, nil
+}
+
+func TestContainerStartWithAbsRuntimePath(t *testing.T) {
+	t.Parallel()
+
+	client, err := newClient(t, address)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	var (
+		image       Image
+		ctx, cancel = testContext(t)
+		id          = t.Name()
+	)
+	defer cancel()
+
+	image, err = client.GetImage(ctx, testImage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	container, err := client.NewContainer(ctx, id, WithNewSnapshot(id, image), WithNewSpec(oci.WithImageConfig(image), withExitStatus(7)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer container.Delete(ctx, WithSnapshotCleanup)
+
+	// create a temp task to read the default shim path
+	task, err := container.NewTask(ctx, empty())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defaultShimPath, err := readShimPath(task.ID())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// remove the temp task
+	if _, err := task.Delete(ctx, WithProcessKill); err != nil {
+		t.Fatal(err)
+	}
+
+	tempShimPath, err := copyShim(defaultShimPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tempShimPath)
+
+	task, err = container.NewTask(ctx, empty(), WithRuntimePath(tempShimPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	shimPath, err := readShimPath(task.ID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if shimPath != tempShimPath {
+		t.Fatalf("The task's shim path is %s, does not used the specified runtime path: %s", shimPath, tempShimPath)
+	}
 
 	statusC, err := task.Wait(ctx)
 	if err != nil {

--- a/integration/client/go.mod
+++ b/integration/client/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Microsoft/hcsshim/test v0.0.0-20210408205431-da33ecd607e1
 	github.com/containerd/cgroups/v3 v3.0.1
 	github.com/containerd/containerd v1.7.0 // see replace; the actual version of containerd is replaced with the code at the root of this repository
+	github.com/containerd/continuity v0.3.0
 	github.com/containerd/go-runc v1.0.0
 	github.com/containerd/ttrpc v1.2.1
 	github.com/containerd/typeurl/v2 v2.1.0
@@ -26,7 +27,6 @@ require (
 	github.com/cilium/ebpf v0.9.1 // indirect
 	github.com/containerd/cgroups v1.1.0 // indirect
 	github.com/containerd/console v1.0.3 // indirect
-	github.com/containerd/continuity v0.3.0 // indirect
 	github.com/containerd/fifo v1.1.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect

--- a/task.go
+++ b/task.go
@@ -140,6 +140,11 @@ type TaskInfo struct {
 	RootFS []mount.Mount
 	// Options hold runtime specific settings for task creation
 	Options interface{}
+	// RuntimePath is an absolute path that can be used to overwrite path
+	// to a shim runtime binary.
+	RuntimePath string
+
+	// runtime is the runtime name for the container, and cannot be changed.
 	runtime string
 }
 

--- a/task_opts.go
+++ b/task_opts.go
@@ -49,7 +49,7 @@ func WithRootFS(mounts []mount.Mount) NewTaskOpts {
 // instead of resolving it from runtime name.
 func WithRuntimePath(absRuntimePath string) NewTaskOpts {
 	return func(ctx context.Context, client *Client, info *TaskInfo) error {
-		info.runtime = absRuntimePath
+		info.RuntimePath = absRuntimePath
 		return nil
 	}
 }


### PR DESCRIPTION
cherry-pick: https://github.com/containerd/containerd/pull/8208


Added a new commit https://github.com/containerd/containerd/commit/c0e128624a8d6a02bb7d2ab3d29369f54791b68e that skips TestContainerStartWithAbsRuntimePath if the runtime is v1