### PR TITLE
[release/1.6] fix the task setting the runtime path

### DIFF
--- a/container.go
+++ b/container.go
@@ -279,6 +279,7 @@ func (c *container) NewTask(ctx context.Context, ioCreate cio.Creator, opts ...N
 			})
 		}
 	}
+	request.RuntimePath = info.RuntimePath
 	if info.Options != nil {
 		any, err := typeurl.MarshalAny(info.Options)
 		if err != nil {

--- a/integration/client/container_test.go
+++ b/integration/client/container_test.go
@@ -212,6 +212,10 @@ func TestContainerStartWithAbsRuntimePath(t *testing.T) {
 	}
 	defer client.Close()
 
+	if client.Runtime() == plugin.RuntimeLinuxV1 {
+		t.Skip("test relies on runtime v2")
+	}
+
 	var (
 		image       Image
 		ctx, cancel = testContext(t)

--- a/integration/client/container_test.go
+++ b/integration/client/container_test.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"syscall"
@@ -42,6 +43,7 @@ import (
 	"github.com/containerd/containerd/plugin"
 	_ "github.com/containerd/containerd/runtime"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
+	"github.com/containerd/continuity/fs"
 	"github.com/containerd/go-runc"
 	"github.com/containerd/typeurl"
 	gogotypes "github.com/gogo/protobuf/types"
@@ -137,6 +139,130 @@ func TestContainerStart(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer task.Delete(ctx)
+
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if runtime.GOOS != "windows" {
+		// task.Pid not implemented on Windows
+		if pid := task.Pid(); pid < 1 {
+			t.Errorf("invalid task pid %d", pid)
+		}
+	}
+
+	if err := task.Start(ctx); err != nil {
+		t.Error(err)
+		task.Delete(ctx)
+		return
+	}
+	status := <-statusC
+	code, _, err := status.Result()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != 7 {
+		t.Errorf("expected status 7 from wait but received %d", code)
+	}
+
+	deleteStatus, err := task.Delete(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ec := deleteStatus.ExitCode(); ec != 7 {
+		t.Errorf("expected status 7 from delete but received %d", ec)
+	}
+}
+
+func readShimPath(taskID string) (string, error) {
+	runtime := fmt.Sprintf("%s.%s", plugin.RuntimePluginV2, "task")
+	shimBinaryNamePath := filepath.Join(defaultState, runtime, testNamespace, taskID, "shim-binary-path")
+
+	shimPath, err := os.ReadFile(shimBinaryNamePath)
+	if err != nil {
+		return "", err
+	}
+	return string(shimPath), nil
+}
+
+func copyShim(shimPath string) (string, error) {
+	tempPath := filepath.Join(os.TempDir(), filepath.Base(shimPath))
+	if err := fs.CopyFile(tempPath, shimPath); err != nil {
+		return "", err
+	}
+
+	fi, err := os.Stat(shimPath)
+	if err != nil {
+		return "", err
+	}
+	if err := os.Chmod(tempPath, fi.Mode().Perm()); err != nil {
+		return "", err
+	}
+
+	return tempPath, nil
+}
+
+func TestContainerStartWithAbsRuntimePath(t *testing.T) {
+	t.Parallel()
+
+	client, err := newClient(t, address)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	var (
+		image       Image
+		ctx, cancel = testContext(t)
+		id          = t.Name()
+	)
+	defer cancel()
+
+	image, err = client.GetImage(ctx, testImage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	container, err := client.NewContainer(ctx, id, WithNewSnapshot(id, image), WithNewSpec(oci.WithImageConfig(image), withExitStatus(7)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer container.Delete(ctx, WithSnapshotCleanup)
+
+	// create a temp task to read the default shim path
+	task, err := container.NewTask(ctx, empty())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defaultShimPath, err := readShimPath(task.ID())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// remove the temp task
+	if _, err := task.Delete(ctx, WithProcessKill); err != nil {
+		t.Fatal(err)
+	}
+
+	tempShimPath, err := copyShim(defaultShimPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tempShimPath)
+
+	task, err = container.NewTask(ctx, empty(), WithRuntimePath(tempShimPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	shimPath, err := readShimPath(task.ID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if shimPath != tempShimPath {
+		t.Fatalf("The task's shim path is %s, does not used the specified runtime path: %s", shimPath, tempShimPath)
+	}
 
 	statusC, err := task.Wait(ctx)
 	if err != nil {

--- a/integration/client/go.mod
+++ b/integration/client/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/containerd/cgroups v1.0.4
 	// the actual version of containerd is replaced with the code at the root of this repository
 	github.com/containerd/containerd v1.6.1
+	github.com/containerd/continuity v0.3.0
 	github.com/containerd/go-runc v1.0.0
 	github.com/containerd/ttrpc v1.1.1
 	github.com/containerd/typeurl v1.0.2

--- a/task.go
+++ b/task.go
@@ -139,6 +139,11 @@ type TaskInfo struct {
 	RootFS []mount.Mount
 	// Options hold runtime specific settings for task creation
 	Options interface{}
+	// RuntimePath is an absolute path that can be used to overwrite path
+	// to a shim runtime binary.
+	RuntimePath string
+
+	// runtime is the runtime name for the container, and cannot be changed.
 	runtime string
 }
 

--- a/task_opts.go
+++ b/task_opts.go
@@ -49,7 +49,7 @@ func WithRootFS(mounts []mount.Mount) NewTaskOpts {
 // instead of resolving it from runtime name.
 func WithRuntimePath(absRuntimePath string) NewTaskOpts {
 	return func(ctx context.Context, client *Client, info *TaskInfo) error {
-		info.runtime = absRuntimePath
+		info.RuntimePath = absRuntimePath
 		return nil
 	}
 }


### PR DESCRIPTION
cherry-pick: https://github.com/containerd/containerd/pull/8208


Added a new commit https://github.com/containerd/containerd/commit/e8840f688ae402bef461963321d63cf9cf6fbb34 that skips TestContainerStartWithAbsRuntimePath if the runtime is v1