### PR TITLE
Fix panic when differ returns empty result

### DIFF
--- a/diff/proxy/differ.go
+++ b/diff/proxy/differ.go
@@ -100,6 +100,9 @@ func (r *diffRemote) Compare(ctx context.Context, a, b []mount.Mount, opts ...di
 }
 
 func toDescriptor(d *types.Descriptor) ocispec.Descriptor {
+	if d == nil {
+		return ocispec.Descriptor{}
+	}
 	return ocispec.Descriptor{
 		MediaType:   d.MediaType,
 		Digest:      digest.Digest(d.Digest),


### PR DESCRIPTION
Unexpected results should not cause panic