### PR TITLE
cri: Fix umarshal metrics

### DIFF
--- a/pkg/cri/sbserver/container_stats_list_linux.go
+++ b/pkg/cri/sbserver/container_stats_list_linux.go
@@ -17,12 +17,15 @@
 package sbserver
 
 import (
+	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
+	wstats "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats"
+	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
+	v2 "github.com/containerd/cgroups/v3/cgroup2/stats"
 	"github.com/containerd/containerd/api/types"
-	v1 "github.com/containerd/containerd/metrics/types/v1"
-	v2 "github.com/containerd/containerd/metrics/types/v2"
 	"github.com/containerd/containerd/protobuf"
 	"github.com/containerd/typeurl/v2"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -59,18 +62,29 @@ func (c *criService) containerMetrics(
 	}
 
 	if stats != nil {
-		s, err := typeurl.UnmarshalAny(stats.Data)
-		if err != nil {
+		var data interface{}
+		switch {
+		case typeurl.Is(stats.Data, (*v1.Metrics)(nil)):
+			data = &v1.Metrics{}
+		case typeurl.Is(stats.Data, (*v2.Metrics)(nil)):
+			data = &v2.Metrics{}
+		case typeurl.Is(stats.Data, (*wstats.Statistics)(nil)):
+			data = &wstats.Statistics{}
+		default:
+			return nil, errors.New("cannot convert metric data to cgroups.Metrics or windows.Statistics")
+		}
+
+		if err := typeurl.UnmarshalTo(stats.Data, data); err != nil {
 			return nil, fmt.Errorf("failed to extract container metrics: %w", err)
 		}
 
-		cpuStats, err := c.cpuContainerStats(meta.ID, false /* isSandbox */, s, protobuf.FromTimestamp(stats.Timestamp))
+		cpuStats, err := c.cpuContainerStats(meta.ID, false /* isSandbox */, data, protobuf.FromTimestamp(stats.Timestamp))
 		if err != nil {
 			return nil, fmt.Errorf("failed to obtain cpu stats: %w", err)
 		}
 		cs.Cpu = cpuStats
 
-		memoryStats, err := c.memoryContainerStats(meta.ID, s, protobuf.FromTimestamp(stats.Timestamp))
+		memoryStats, err := c.memoryContainerStats(meta.ID, data, protobuf.FromTimestamp(stats.Timestamp))
 		if err != nil {
 			return nil, fmt.Errorf("failed to obtain memory stats: %w", err)
 		}
@@ -151,7 +165,7 @@ func (c *criService) cpuContainerStats(ID string, isSandbox bool, stats interfac
 			}, nil
 		}
 	default:
-		return nil, fmt.Errorf("unexpected metrics type: %v", metrics)
+		return nil, fmt.Errorf("unexpected metrics type: %T from %s", metrics, reflect.TypeOf(metrics).Elem().PkgPath())
 	}
 	return nil, nil
 }
@@ -193,7 +207,7 @@ func (c *criService) memoryContainerStats(ID string, stats interface{}, timestam
 			}, nil
 		}
 	default:
-		return nil, fmt.Errorf("unexpected metrics type: %v", metrics)
+		return nil, fmt.Errorf("unexpected metrics type: %T from %s", metrics, reflect.TypeOf(metrics).Elem().PkgPath())
 	}
 	return nil, nil
 }

--- a/pkg/cri/server/container_stats_list_linux.go
+++ b/pkg/cri/server/container_stats_list_linux.go
@@ -17,12 +17,15 @@
 package server
 
 import (
+	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
+	wstats "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats"
+	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
+	v2 "github.com/containerd/cgroups/v3/cgroup2/stats"
 	"github.com/containerd/containerd/api/types"
-	v1 "github.com/containerd/containerd/metrics/types/v1"
-	v2 "github.com/containerd/containerd/metrics/types/v2"
 	"github.com/containerd/containerd/protobuf"
 	"github.com/containerd/typeurl/v2"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -59,18 +62,29 @@ func (c *criService) containerMetrics(
 	}
 
 	if stats != nil {
-		s, err := typeurl.UnmarshalAny(stats.Data)
-		if err != nil {
+		var data interface{}
+		switch {
+		case typeurl.Is(stats.Data, (*v1.Metrics)(nil)):
+			data = &v1.Metrics{}
+		case typeurl.Is(stats.Data, (*v2.Metrics)(nil)):
+			data = &v2.Metrics{}
+		case typeurl.Is(stats.Data, (*wstats.Statistics)(nil)):
+			data = &wstats.Statistics{}
+		default:
+			return nil, errors.New("cannot convert metric data to cgroups.Metrics or windows.Statistics")
+		}
+
+		if err := typeurl.UnmarshalTo(stats.Data, data); err != nil {
 			return nil, fmt.Errorf("failed to extract container metrics: %w", err)
 		}
 
-		cpuStats, err := c.cpuContainerStats(meta.ID, false /* isSandbox */, s, protobuf.FromTimestamp(stats.Timestamp))
+		cpuStats, err := c.cpuContainerStats(meta.ID, false /* isSandbox */, data, protobuf.FromTimestamp(stats.Timestamp))
 		if err != nil {
 			return nil, fmt.Errorf("failed to obtain cpu stats: %w", err)
 		}
 		cs.Cpu = cpuStats
 
-		memoryStats, err := c.memoryContainerStats(meta.ID, s, protobuf.FromTimestamp(stats.Timestamp))
+		memoryStats, err := c.memoryContainerStats(meta.ID, data, protobuf.FromTimestamp(stats.Timestamp))
 		if err != nil {
 			return nil, fmt.Errorf("failed to obtain memory stats: %w", err)
 		}
@@ -152,7 +166,7 @@ func (c *criService) cpuContainerStats(ID string, isSandbox bool, stats interfac
 			}, nil
 		}
 	default:
-		return nil, fmt.Errorf("unexpected metrics type: %v", metrics)
+		return nil, fmt.Errorf("unexpected metrics type: %T from %s", metrics, reflect.TypeOf(metrics).Elem().PkgPath())
 	}
 	return nil, nil
 }
@@ -194,7 +208,7 @@ func (c *criService) memoryContainerStats(ID string, stats interface{}, timestam
 			}, nil
 		}
 	default:
-		return nil, fmt.Errorf("unexpected metrics type: %v", metrics)
+		return nil, fmt.Errorf("unexpected metrics type: %T from %s", metrics, reflect.TypeOf(metrics).Elem().PkgPath())
 	}
 	return nil, nil
 }


### PR DESCRIPTION
This is essentially the same change as https://github.com/containerd/containerd/pull/8302, but for the CRI server. 

Without this fix, the kubelet fails to collects stats with:

`time="2023-05-03T00:47:28.890947681Z" level=error msg="ListContainerStats failed" error="failed to convert to cri containerd stats format: failed to decode container metrics for \"6fb75f811841004943a338064d05f643b797afac8c09786551a0d5c0865c20b7\": failed to obtain cpu stats: unexpected metrics type: &Metrics{Pids:&PidsStat{Current:13,Limit:18446744073709551615,XXX_unrecognized:[],},CPU:&CPUStat{UsageUsec:1224890,UserUsec:1179817,SystemUsec:45073,NrPeriods:0,NrThrottled:0,ThrottledUsec:0,XXX_unrecognized:[],},Memory:&MemoryStat{Anon:12480512,File:8192,KernelStack:212992,Slab:260032,Sock:12288,Shmem:0,FileMapped:0,FileDirty:8192,FileWriteback:0,AnonThp:0,InactiveAnon:12476416,ActiveAnon:4096,InactiveFile:0,ActiveFile:8192,Unevictable:0,SlabReclaimable:92992,SlabUnreclaimable:167040,Pgfault:5710,Pgmajfault:0,WorkingsetRefault:0,WorkingsetActivate:0,WorkingsetNodereclaim:0,Pgrefill:0,Pgscan:0,Pgsteal:0,Pgactivate:2,Pgdeactivate:0,Pglazyfree:1,Pglazyfreed:0,ThpFaultAlloc:0,ThpCollapseAlloc:0,Usage:13189120,UsageLimit:18446744073709551615,SwapUsage:0,SwapLimit:18446744073709551615,XXX_unrecognized:[],},Rdma:&RdmaStat{Current:[]*RdmaEntry{},Limit:[]*RdmaEntry{},XXX_unrecognized:[],},Io:&IOStat{Usage:[]*IOEntry{},XXX_unrecognized:[],},Hugetlb:[]*HugeTlbStat{&HugeTlbStat{Current:0,Max:18446744073709551615,Pagesize:2MB,XXX_unrecognized:[],},&HugeTlbStat{Current:0,Max:18446744073709551615,Pagesize:1GB,XXX_unrecognized:[],},},MemoryEvents:&MemoryEvents{Low:0,High:0,Max:0,Oom:0,OomKill:0,XXX_unrecognized:[],},XXX_unrecognized:[],}"`