### PR TITLE
[release/1.7] Prepare release notes for v1.7.1

### DIFF
--- a/releases/v1.7.1.toml
+++ b/releases/v1.7.1.toml
@@ -1,0 +1,78 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.7.0"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+This first patch release for containerd 1.7 contains various fixes and updates.
+
+### Notable Updates
+
+* **Update hcsshim tag to v0.10.0-rc.8 ([#8480](https://github.com/containerd/containerd/pull/8480))
+  * [`aaa65e8`](https://github.com/containerd/containerd/commit/aaa65e8c1461ae7187357ea6b7f2807667eada6e) Update hcsshim tag to v0.10.0-rc.8
+* **cri: Fix umarshal metrics ([#8472](https://github.com/containerd/containerd/pull/8472))
+  * [`95ef67e19`](https://github.com/containerd/containerd/commit/95ef67e19552aaec3618cdfa06d6d3ffb57d085b) Fix umarshal metrics for CRI server
+* **fix the task setting the runtime path ([#8453](https://github.com/containerd/containerd/pull/8453))
+  * [`c0e128624`](https://github.com/containerd/containerd/commit/c0e128624a8d6a02bb7d2ab3d29369f54791b68e) skip TestContainerStartWithAbsRuntimePath if the runtime is v1
+  * [`aa3c63c15`](https://github.com/containerd/containerd/commit/aa3c63c15f379eec906cb89f7e1204a42a5d1317) integration: add container start test using abs runtime path
+  * [`d2d9eedb1`](https://github.com/containerd/containerd/commit/d2d9eedb1d1b2d047fbdd847ce7c67724f27bde4) WithRuntimePath uses the TaskInfo.RuntimePath field
+* **Remove entry for container from container store on error  ([#8457](https://github.com/containerd/containerd/pull/8457))
+  * [`6b3ae0129`](https://github.com/containerd/containerd/commit/6b3ae01297d2cb39c8018fc783751baba513b390) Remove entry for container from container store on error
+* **oci: partially restore comment on read-only mounts for uid/gid uses ([#8404](https://github.com/containerd/containerd/pull/8404))
+  * [`1bbf98e53`](https://github.com/containerd/containerd/commit/1bbf98e53ec77bad5dabc2a762f4407e99f527c9) oci: partially restore comment on read-only mounts for uid/gid uses
+* **Fix argsEscaped tests ([#8405](https://github.com/containerd/containerd/pull/8405))
+  * [`a6d336c1f`](https://github.com/containerd/containerd/commit/a6d336c1f6674c2b342d65ca78fba7fac955eaf1) Fix argsEscaped tests
+* **Throw an error if the kubelet requests mounts with uid/gid mappings ([#8211](https://github.com/containerd/containerd/pull/8211))
+  * [`7de8629be`](https://github.com/containerd/containerd/commit/7de8629be0e62c4d8164cd873baf14b64bcbb90b) cri: Throw an error if idmap mounts is requested
+  * [`75ac7e0d8`](https://github.com/containerd/containerd/commit/75ac7e0d8200539ff444b952bc060ffa23582a87) cri: Vendor v0.27.0-beta.0 for mounts uid/gid mappings
+* **go.mod: remove redundant replace, and some cleaning-up ([#8396](https://github.com/containerd/containerd/pull/8396))
+  * [`8f6e86fec`](https://github.com/containerd/containerd/commit/8f6e86fecad5c11871df20e516ae181d7abf4a7c) go.mod: add comment explaining go-fuzz-headers replace rule
+  * [`1ece0cb50`](https://github.com/containerd/containerd/commit/1ece0cb50f7f2f6fc9c59a76ae49227a84a92f1e) go.mod: remove replace for github.com/opencontainers/runtime-tools
+  * [`e9f962187`](https://github.com/containerd/containerd/commit/e9f96218795ef6a527fc8cac550ae90b9b09fe5c) go.mod: integration: use non-pre-release of containerd
+  * [`84393b005`](https://github.com/containerd/containerd/commit/84393b005f76c085ad62c62dff980dc13d13b131) go.mod: integration: move indirect dependencies to the right group
+* **update runc binary to v1.1.6 ([#8386](https://github.com/containerd/containerd/pull/8386))
+  * [`dec2595af`](https://github.com/containerd/containerd/commit/dec2595afe92800fbf8e4e506398b00ff532332f) update runc binary to v1.1.6
+* **oci: Use WithReadonlyTempMount when adding users/groups ([#8358](https://github.com/containerd/containerd/pull/8358))
+  * [`54d12b872`](https://github.com/containerd/containerd/commit/54d12b872132d56feca792051abdce87a2077988) oci: Use WithReadonlyTempMount when adding users/groups
+* **consistently respect value of WithSkipDockerManifest ([#8344](https://github.com/containerd/containerd/pull/8344))
+  * [`1d6641b7c`](https://github.com/containerd/containerd/commit/1d6641b7c92d8854548c7a07bdaa07979ad0eb68) export: add test for WithSkipDockerManifest
+  * [`0e0d84f6b`](https://github.com/containerd/containerd/commit/0e0d84f6bb7a0226480dd5ead7c894175d2edcc8) archive: consistently respect value of WithSkipDockerManifest
+* **Add noexec nodev and nosuid to sandbox /etc/resolv.conf mount bind. ([#8336](https://github.com/containerd/containerd/pull/8336))
+  * [`9b4935d86`](https://github.com/containerd/containerd/commit/9b4935d86436419670febe9695787a3aaf5ceeb7) Update sbserver to add noexec nodev and nosuid to /etc/resolv.conf mount bind.
+  * [`5e953cfa6`](https://github.com/containerd/containerd/commit/5e953cfa62abb90b2c4dc775907cbb276637bfe8) Test to ensure nosuid,nodev,noexec are set on /etc/reolv.conf mount.
+  * [`0aad93f08`](https://github.com/containerd/containerd/commit/0aad93f08ca4da8f33ad709dbe49593f6ff5c59c) Add noexec nodev and nosuid to sandbox /etc/resolv.conf mount bind.
+* **ctr/tasks: fix unmarshal the task metrics for cgroups v1 ([#8335](https://github.com/containerd/containerd/pull/8335))
+  * [`1a64f1b43`](https://github.com/containerd/containerd/commit/1a64f1b4341ebda4b8f8cf67cac543394a10a4c3) ctr/tasks: fix unmarshal the task metrics for cgroups v1
+* **Keep linux mounts for linux sandboxes on Windows/Darwin ([#8331](https://github.com/containerd/containerd/pull/8331))
+  * [`17c52a26d`](https://github.com/containerd/containerd/commit/17c52a26d63d6105e9918fb2d90ff346e4e4c463) Keep linux mounts for linux sandboxes on Windows/Darwin
+* **update runc binary to v1.1.5 ([#8325](https://github.com/containerd/containerd/pull/8325))
+  * [`d81fc15af`](https://github.com/containerd/containerd/commit/d81fc15affe09dbb621be16bda805801a98cab4b) update runc binary to v1.1.5
+  * [`755efbe64`](https://github.com/containerd/containerd/commit/755efbe6402acdaf5832e36b7c6f4e15cc2a406d) go.mod: github.com/opencontainers/runc v1.1.5
+* **Defer uid lookups on Darwin ([#8314](https://github.com/containerd/containerd/pull/8314))
+  * [`90591db47`](https://github.com/containerd/containerd/commit/90591db47c70db29386b8d9e58ffa1005b560dc0) Defer uid lookups on Darwin
+* **Add `WithReadonlyTempMount` to create readonly temporary mounts ([#8300](https://github.com/containerd/containerd/pull/8300))
+  * [`b7d87b190`](https://github.com/containerd/containerd/commit/b7d87b190d013929377bb85df8301fade73b0298) Add `WithReadonlyTempMount` to create readonly temporary mounts
+* **Backport Sandbox/CRI fixes ([#8282](https://github.com/containerd/containerd/pull/8282))
+  * [`1c1b6bcb2`](https://github.com/containerd/containerd/commit/1c1b6bcb2b4a47053855bd7adaed5d9bfdf2a5f5) CRI: Don't always close netConfMonitor channel
+  * [`cf2e454bf`](https://github.com/containerd/containerd/commit/cf2e454bf052bee63c0582552566c96357bd2250) Sandbox: Correct/add some fields to Status()
+  * [`ce68e8e0d`](https://github.com/containerd/containerd/commit/ce68e8e0db47174580fc74ecdeb66c26695ecd0b) Sandbox: Cleanup shim on Start failure
+
+See the changelog for complete list of changes"""


### PR DESCRIPTION
Welcome to the v1.7.1 release of containerd!

This first patch release for containerd 1.7 contains various fixes and updates.

### Notable Updates

* **unmarshal does not return nil object when value is nil
  * [`aaa65e8`](https://github.com/containerd/containerd/commit/aaa65e8c1461ae7187357ea6b7f2807667eada6e) Update hcsshim tag to v0.10.0-rc.8
* **Update hcsshim tag to v0.10.0-rc.8 ([#8480](https://github.com/containerd/containerd/pull/8480))
  * [`aaa65e8`](https://github.com/containerd/containerd/commit/aaa65e8c1461ae7187357ea6b7f2807667eada6e) Update hcsshim tag to v0.10.0-rc.8
* **cri: Fix umarshal metrics ([#8472](https://github.com/containerd/containerd/pull/8472))
  * [`95ef67e19`](https://github.com/containerd/containerd/commit/95ef67e19552aaec3618cdfa06d6d3ffb57d085b) Fix umarshal metrics for CRI server
* **fix the task setting the runtime path ([#8453](https://github.com/containerd/containerd/pull/8453))
  * [`c0e128624`](https://github.com/containerd/containerd/commit/c0e128624a8d6a02bb7d2ab3d29369f54791b68e) skip TestContainerStartWithAbsRuntimePath if the runtime is v1
  * [`aa3c63c15`](https://github.com/containerd/containerd/commit/aa3c63c15f379eec906cb89f7e1204a42a5d1317) integration: add container start test using abs runtime path
  * [`d2d9eedb1`](https://github.com/containerd/containerd/commit/d2d9eedb1d1b2d047fbdd847ce7c67724f27bde4) WithRuntimePath uses the TaskInfo.RuntimePath field
* **Remove entry for container from container store on error  ([#8457](https://github.com/containerd/containerd/pull/8457))
  * [`6b3ae0129`](https://github.com/containerd/containerd/commit/6b3ae01297d2cb39c8018fc783751baba513b390) Remove entry for container from container store on error
* **oci: partially restore comment on read-only mounts for uid/gid uses ([#8404](https://github.com/containerd/containerd/pull/8404))
  * [`1bbf98e53`](https://github.com/containerd/containerd/commit/1bbf98e53ec77bad5dabc2a762f4407e99f527c9) oci: partially restore comment on read-only mounts for uid/gid uses
* **Fix argsEscaped tests ([#8405](https://github.com/containerd/containerd/pull/8405))
  * [`a6d336c1f`](https://github.com/containerd/containerd/commit/a6d336c1f6674c2b342d65ca78fba7fac955eaf1) Fix argsEscaped tests
* **Throw an error if the kubelet requests mounts with uid/gid mappings ([#8211](https://github.com/containerd/containerd/pull/8211))
  * [`7de8629be`](https://github.com/containerd/containerd/commit/7de8629be0e62c4d8164cd873baf14b64bcbb90b) cri: Throw an error if idmap mounts is requested
  * [`75ac7e0d8`](https://github.com/containerd/containerd/commit/75ac7e0d8200539ff444b952bc060ffa23582a87) cri: Vendor v0.27.0-beta.0 for mounts uid/gid mappings
* **go.mod: remove redundant replace, and some cleaning-up ([#8396](https://github.com/containerd/containerd/pull/8396))
  * [`8f6e86fec`](https://github.com/containerd/containerd/commit/8f6e86fecad5c11871df20e516ae181d7abf4a7c) go.mod: add comment explaining go-fuzz-headers replace rule
  * [`1ece0cb50`](https://github.com/containerd/containerd/commit/1ece0cb50f7f2f6fc9c59a76ae49227a84a92f1e) go.mod: remove replace for github.com/opencontainers/runtime-tools
  * [`e9f962187`](https://github.com/containerd/containerd/commit/e9f96218795ef6a527fc8cac550ae90b9b09fe5c) go.mod: integration: use non-pre-release of containerd
  * [`84393b005`](https://github.com/containerd/containerd/commit/84393b005f76c085ad62c62dff980dc13d13b131) go.mod: integration: move indirect dependencies to the right group
* **update runc binary to v1.1.6 ([#8386](https://github.com/containerd/containerd/pull/8386))
  * [`dec2595af`](https://github.com/containerd/containerd/commit/dec2595afe92800fbf8e4e506398b00ff532332f) update runc binary to v1.1.6
* **oci: Use WithReadonlyTempMount when adding users/groups ([#8358](https://github.com/containerd/containerd/pull/8358))
  * [`54d12b872`](https://github.com/containerd/containerd/commit/54d12b872132d56feca792051abdce87a2077988) oci: Use WithReadonlyTempMount when adding users/groups
* **consistently respect value of WithSkipDockerManifest ([#8344](https://github.com/containerd/containerd/pull/8344))
  * [`1d6641b7c`](https://github.com/containerd/containerd/commit/1d6641b7c92d8854548c7a07bdaa07979ad0eb68) export: add test for WithSkipDockerManifest
  * [`0e0d84f6b`](https://github.com/containerd/containerd/commit/0e0d84f6bb7a0226480dd5ead7c894175d2edcc8) archive: consistently respect value of WithSkipDockerManifest
* **Add noexec nodev and nosuid to sandbox /etc/resolv.conf mount bind. ([#8336](https://github.com/containerd/containerd/pull/8336))
  * [`9b4935d86`](https://github.com/containerd/containerd/commit/9b4935d86436419670febe9695787a3aaf5ceeb7) Update sbserver to add noexec nodev and nosuid to /etc/resolv.conf mount bind.
  * [`5e953cfa6`](https://github.com/containerd/containerd/commit/5e953cfa62abb90b2c4dc775907cbb276637bfe8) Test to ensure nosuid,nodev,noexec are set on /etc/reolv.conf mount.
  * [`0aad93f08`](https://github.com/containerd/containerd/commit/0aad93f08ca4da8f33ad709dbe49593f6ff5c59c) Add noexec nodev and nosuid to sandbox /etc/resolv.conf mount bind.
* **ctr/tasks: fix unmarshal the task metrics for cgroups v1 ([#8335](https://github.com/containerd/containerd/pull/8335))
  * [`1a64f1b43`](https://github.com/containerd/containerd/commit/1a64f1b4341ebda4b8f8cf67cac543394a10a4c3) ctr/tasks: fix unmarshal the task metrics for cgroups v1
* **Keep linux mounts for linux sandboxes on Windows/Darwin ([#8331](https://github.com/containerd/containerd/pull/8331))
  * [`17c52a26d`](https://github.com/containerd/containerd/commit/17c52a26d63d6105e9918fb2d90ff346e4e4c463) Keep linux mounts for linux sandboxes on Windows/Darwin
* **update runc binary to v1.1.5 ([#8325](https://github.com/containerd/containerd/pull/8325))
  * [`d81fc15af`](https://github.com/containerd/containerd/commit/d81fc15affe09dbb621be16bda805801a98cab4b) update runc binary to v1.1.5
  * [`755efbe64`](https://github.com/containerd/containerd/commit/755efbe6402acdaf5832e36b7c6f4e15cc2a406d) go.mod: github.com/opencontainers/runc v1.1.5
* **Defer uid lookups on Darwin ([#8314](https://github.com/containerd/containerd/pull/8314))
  * [`90591db47`](https://github.com/containerd/containerd/commit/90591db47c70db29386b8d9e58ffa1005b560dc0) Defer uid lookups on Darwin
* **Add `WithReadonlyTempMount` to create readonly temporary mounts ([#8300](https://github.com/containerd/containerd/pull/8300))
  * [`b7d87b190`](https://github.com/containerd/containerd/commit/b7d87b190d013929377bb85df8301fade73b0298) Add `WithReadonlyTempMount` to create readonly temporary mounts
* **Backport Sandbox/CRI fixes ([#8282](https://github.com/containerd/containerd/pull/8282))
  * [`1c1b6bcb2`](https://github.com/containerd/containerd/commit/1c1b6bcb2b4a47053855bd7adaed5d9bfdf2a5f5) CRI: Don't always close netConfMonitor channel
  * [`cf2e454bf`](https://github.com/containerd/containerd/commit/cf2e454bf052bee63c0582552566c96357bd2250) Sandbox: Correct/add some fields to Status()
  * [`ce68e8e0d`](https://github.com/containerd/containerd/commit/ce68e8e0db47174580fc74ecdeb66c26695ecd0b) Sandbox: Cleanup shim on Start failure

See the changelog for complete list of changes

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Sebastiaan van Stijn
* Akihiro Suda
* Derek McGowan
* Iceber Gu
* Maksym Pavlenko
* Danny Canter
* Phil Estes
* Rodrigo Campos
* Samuel Karp
* Vinayak Goyal
* Justin Chadwell
* Kazuyoshi Kato
* Kirtana Ashok
* Brad Davidson
* Djordje Lukic
* Laura Brehm
* Michael Crosby
* Wei Fu

### Changes
<details><summary>57 commits</summary>
<p>

  * [`a358c2f04`](https://github.com/containerd/containerd/commit/a358c2f04ae8f8e18cb14679488b5d867266affc) Prepare release notes for v1.7.1
* [release/1.7]Update hcsshim tag to v0.10.0-rc.8 ([#8480](https://github.com/containerd/containerd/pull/8480))
  * [`aaa65e8c1`](https://github.com/containerd/containerd/commit/aaa65e8c1461ae7187357ea6b7f2807667eada6e) Update hcsshim tag to v0.10.0-rc.8
* [release/1.7] cri: Fix umarshal metrics ([#8472](https://github.com/containerd/containerd/pull/8472))
  * [`95ef67e19`](https://github.com/containerd/containerd/commit/95ef67e19552aaec3618cdfa06d6d3ffb57d085b) Fix umarshal metrics for CRI server
* [release/1.7 backport] update go to go1.20.4, go1.19.9 ([#8471](https://github.com/containerd/containerd/pull/8471))
  * [`021bba28b`](https://github.com/containerd/containerd/commit/021bba28b50e445c4a0a8e79b458db7116dc50e7) update go to go1.20.4, go1.19.9
* [release/1.7] fix the task setting the runtime path ([#8453](https://github.com/containerd/containerd/pull/8453))
  * [`c0e128624`](https://github.com/containerd/containerd/commit/c0e128624a8d6a02bb7d2ab3d29369f54791b68e) skip TestContainerStartWithAbsRuntimePath if the runtime is v1
  * [`aa3c63c15`](https://github.com/containerd/containerd/commit/aa3c63c15f379eec906cb89f7e1204a42a5d1317) integration: add container start test using abs runtime path
  * [`d2d9eedb1`](https://github.com/containerd/containerd/commit/d2d9eedb1d1b2d047fbdd847ce7c67724f27bde4) WithRuntimePath uses the TaskInfo.RuntimePath field
* [release/1.7] Remove entry for container from container store on error  ([#8457](https://github.com/containerd/containerd/pull/8457))
  * [`6b3ae0129`](https://github.com/containerd/containerd/commit/6b3ae01297d2cb39c8018fc783751baba513b390) Remove entry for container from container store on error
* [release/1.7 backport] update runc binary to v1.1.7 ([#8451](https://github.com/containerd/containerd/pull/8451))
  * [`fae4b6223`](https://github.com/containerd/containerd/commit/fae4b6223a597cf456b63c4272ed85f625eef9f0) update runc binary to v1.1.7
* [release/1.7] cri: Vendor v0.27.1 ([#8444](https://github.com/containerd/containerd/pull/8444))
  * [`571715a9d`](https://github.com/containerd/containerd/commit/571715a9df043d0f75d16dcc17fd0c2c41999290) cri: Vendor v0.27.1
* [release/1.7 backport] oci: partially restore comment on read-only mounts for uid/gid uses ([#8404](https://github.com/containerd/containerd/pull/8404))
  * [`1bbf98e53`](https://github.com/containerd/containerd/commit/1bbf98e53ec77bad5dabc2a762f4407e99f527c9) oci: partially restore comment on read-only mounts for uid/gid uses
* [release/1.7] Fix argsEscaped tests ([#8405](https://github.com/containerd/containerd/pull/8405))
  * [`a6d336c1f`](https://github.com/containerd/containerd/commit/a6d336c1f6674c2b342d65ca78fba7fac955eaf1) Fix argsEscaped tests
* [release/1.7] Throw an error if the kubelet requests mounts with uid/gid mappings ([#8211](https://github.com/containerd/containerd/pull/8211))
  * [`7de8629be`](https://github.com/containerd/containerd/commit/7de8629be0e62c4d8164cd873baf14b64bcbb90b) cri: Throw an error if idmap mounts is requested
  * [`75ac7e0d8`](https://github.com/containerd/containerd/commit/75ac7e0d8200539ff444b952bc060ffa23582a87) cri: Vendor v0.27.0-beta.0 for mounts uid/gid mappings
* [release/1.7] go.mod: remove redundant replace, and some cleaning-up ([#8396](https://github.com/containerd/containerd/pull/8396))
  * [`8f6e86fec`](https://github.com/containerd/containerd/commit/8f6e86fecad5c11871df20e516ae181d7abf4a7c) go.mod: add comment explaining go-fuzz-headers replace rule
  * [`1ece0cb50`](https://github.com/containerd/containerd/commit/1ece0cb50f7f2f6fc9c59a76ae49227a84a92f1e) go.mod: remove replace for github.com/opencontainers/runtime-tools
  * [`e9f962187`](https://github.com/containerd/containerd/commit/e9f96218795ef6a527fc8cac550ae90b9b09fe5c) go.mod: integration: use non-pre-release of containerd
  * [`84393b005`](https://github.com/containerd/containerd/commit/84393b005f76c085ad62c62dff980dc13d13b131) go.mod: integration: move indirect dependencies to the right group
* [release/1.7 backport] update runc binary to v1.1.6 ([#8386](https://github.com/containerd/containerd/pull/8386))
  * [`dec2595af`](https://github.com/containerd/containerd/commit/dec2595afe92800fbf8e4e506398b00ff532332f) update runc binary to v1.1.6
* [release/1.7 backport] oci: Use WithReadonlyTempMount when adding users/groups ([#8358](https://github.com/containerd/containerd/pull/8358))
  * [`54d12b872`](https://github.com/containerd/containerd/commit/54d12b872132d56feca792051abdce87a2077988) oci: Use WithReadonlyTempMount when adding users/groups
* [release/1.7 backport] update go to go1.20.3, go1.19.8 ([#8354](https://github.com/containerd/containerd/pull/8354))
  * [`624327651`](https://github.com/containerd/containerd/commit/6243276515454617f58eafaa85352b6e6fcac96e) update go to go1.20.3, go1.19.8
* [release/1.7] archive: consistently respect value of WithSkipDockerManifest ([#8344](https://github.com/containerd/containerd/pull/8344))
  * [`1d6641b7c`](https://github.com/containerd/containerd/commit/1d6641b7c92d8854548c7a07bdaa07979ad0eb68) export: add test for WithSkipDockerManifest
  * [`0e0d84f6b`](https://github.com/containerd/containerd/commit/0e0d84f6bb7a0226480dd5ead7c894175d2edcc8) archive: consistently respect value of WithSkipDockerManifest
* [release/1.7] Add noexec nodev and nosuid to sandbox /etc/resolv.conf mount bind. ([#8336](https://github.com/containerd/containerd/pull/8336))
  * [`9b4935d86`](https://github.com/containerd/containerd/commit/9b4935d86436419670febe9695787a3aaf5ceeb7) Update sbserver to add noexec nodev and nosuid to /etc/resolv.conf mount bind.
  * [`5e953cfa6`](https://github.com/containerd/containerd/commit/5e953cfa62abb90b2c4dc775907cbb276637bfe8) Test to ensure nosuid,nodev,noexec are set on /etc/reolv.conf mount.
  * [`0aad93f08`](https://github.com/containerd/containerd/commit/0aad93f08ca4da8f33ad709dbe49593f6ff5c59c) Add noexec nodev and nosuid to sandbox /etc/resolv.conf mount bind.
* [release/1.7] ctr/tasks: fix unmarshal the task metrics for cgroups v1 ([#8335](https://github.com/containerd/containerd/pull/8335))
  * [`1a64f1b43`](https://github.com/containerd/containerd/commit/1a64f1b4341ebda4b8f8cf67cac543394a10a4c3) ctr/tasks: fix unmarshal the task metrics for cgroups v1
* [release/1.7] Keep linux mounts for linux sandboxes on Windows/Darwin ([#8331](https://github.com/containerd/containerd/pull/8331))
  * [`17c52a26d`](https://github.com/containerd/containerd/commit/17c52a26d63d6105e9918fb2d90ff346e4e4c463) Keep linux mounts for linux sandboxes on Windows/Darwin
* [release/1.7] update runc binary to v1.1.5 ([#8325](https://github.com/containerd/containerd/pull/8325))
  * [`d81fc15af`](https://github.com/containerd/containerd/commit/d81fc15affe09dbb621be16bda805801a98cab4b) update runc binary to v1.1.5
  * [`755efbe64`](https://github.com/containerd/containerd/commit/755efbe6402acdaf5832e36b7c6f4e15cc2a406d) go.mod: github.com/opencontainers/runc v1.1.5
* [backport 1.7] Defer uid lookups on Darwin ([#8314](https://github.com/containerd/containerd/pull/8314))
  * [`90591db47`](https://github.com/containerd/containerd/commit/90591db47c70db29386b8d9e58ffa1005b560dc0) Defer uid lookups on Darwin
* [release/1.7 backport] Add `WithReadonlyTempMount` to create readonly temporary mounts ([#8300](https://github.com/containerd/containerd/pull/8300))
  * [`b7d87b190`](https://github.com/containerd/containerd/commit/b7d87b190d013929377bb85df8301fade73b0298) Add `WithReadonlyTempMount` to create readonly temporary mounts
* [release/1.7] Backport Sandbox/CRI fixes ([#8282](https://github.com/containerd/containerd/pull/8282))
  * [`1c1b6bcb2`](https://github.com/containerd/containerd/commit/1c1b6bcb2b4a47053855bd7adaed5d9bfdf2a5f5) CRI: Don't always close netConfMonitor channel
  * [`cf2e454bf`](https://github.com/containerd/containerd/commit/cf2e454bf052bee63c0582552566c96357bd2250) Sandbox: Correct/add some fields to Status()
  * [`ce68e8e0d`](https://github.com/containerd/containerd/commit/ce68e8e0db47174580fc74ecdeb66c26695ecd0b) Sandbox: Cleanup shim on Start failure
</p>
</details>

### Dependency Changes

* **github.com/Microsoft/go-winio**            v0.6.0 -> v0.6.1
* **github.com/Microsoft/hcsshim**             v0.10.0-rc.7 -> v0.10.0-rc.8
* **github.com/golang/protobuf**               v1.5.2 -> v1.5.3
* **github.com/opencontainers/runc**           v1.1.4 -> v1.1.5
* **github.com/opencontainers/runtime-tools**  946c877fa809 -> 2e043c6bd626
* **golang.org/x/mod**                         v0.7.0 -> v0.9.0
* **golang.org/x/net**                         v0.7.0 -> v0.8.0
* **golang.org/x/sys**                         v0.6.0 -> v0.7.0
* **golang.org/x/term**                        v0.5.0 -> v0.6.0
* **golang.org/x/text**                        v0.7.0 -> v0.8.0
* **golang.org/x/tools**                       v0.5.0 -> v0.7.0
* **google.golang.org/protobuf**               v1.28.1 -> v1.29.1
* **k8s.io/cri-api**                           v0.26.2 -> v0.27.1

Previous release can be found at [v1.7.0](https://github.com/containerd/containerd/releases/tag/v1.7.0)

> Can we wait for the release of typeurl, it will be released next Monday at the latest. [containerd/typeurl#41 (comment)](https://github.com/containerd/typeurl/pull/41#issuecomment-1535686697)
> 
> I would like to bump typeurl, it fixes the #8392 and shim may panic at checkpoint.

Hi @Iceber a tag for typeurl with your changes have not been cut yet right? 