### PR TITLE
[WIP] KEP-3169: implement SupplementalGroupsPolicy in cri-api

### DIFF
--- a/pkg/cri/sbserver/container_create_linux.go
+++ b/pkg/cri/sbserver/container_create_linux.go
@@ -69,11 +69,11 @@ func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageCon
 		// Image
 		userstr = imageConfig.User
 	}
-	if userstr != "" {
-		specOpts = append(specOpts, oci.WithUser(userstr))
+	if userstr == "" {
+		userstr = "0" // runtime default
 	}
+	specOpts = append(specOpts, oci.WithUser(userstr))
 
-	userstr = "0" // runtime default
 	if securityContext.GetRunAsUsername() != "" {
 		userstr = securityContext.GetRunAsUsername()
 	} else if securityContext.GetRunAsUser() != nil {
@@ -81,8 +81,19 @@ func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageCon
 	} else if imageConfig.User != "" {
 		userstr, _, _ = strings.Cut(imageConfig.User, ":")
 	}
-	specOpts = append(specOpts, customopts.WithAdditionalGIDs(userstr),
-		customopts.WithSupplementalGroups(securityContext.GetSupplementalGroups()))
+
+	policy := runtime.SupplementalGroupsPolicy_Merge
+	if securityContext != nil {
+		policy = securityContext.SupplementalGroupsPolicy
+	}
+	switch policy {
+	case runtime.SupplementalGroupsPolicy_Merge:
+		specOpts = append(specOpts, customopts.WithAdditionalGIDs(userstr), customopts.WithSupplementalGroups(securityContext.GetSupplementalGroups()))
+	case runtime.SupplementalGroupsPolicy_Strict:
+		specOpts = append(specOpts, customopts.WithSupplementalGroups(securityContext.GetSupplementalGroups()))
+	default:
+		return nil, fmt.Errorf("Unsupported SupplementalGroupsPolicy: %s", securityContext.SupplementalGroupsPolicy.String())
+	}
 
 	asp := securityContext.GetApparmor()
 	if asp == nil {

--- a/pkg/cri/sbserver/container_create_linux_test.go
+++ b/pkg/cri/sbserver/container_create_linux_test.go
@@ -1467,7 +1467,7 @@ additional-group-for-root:x:22222:root
 		expected        runtimespec.User
 	}{
 		{
-			desc: "Only SecurityContext was set, SecurityContext defines User",
+			desc: "[SupplementalGroupsPolicy=Merge(default)] Only SecurityContext was set, SecurityContext defines User",
 			securityContext: &runtime.LinuxContainerSecurityContext{
 				RunAsUser:          &runtime.Int64Value{Value: 1000},
 				RunAsGroup:         &runtime.Int64Value{Value: 2000},
@@ -1476,13 +1476,13 @@ additional-group-for-root:x:22222:root
 			expected: runtimespec.User{UID: 1000, GID: 2000, AdditionalGids: []uint32{2000, 3333, 11111}},
 		},
 		{
-			desc:            "Only imageConfig.User was set, imageConfig.User defines User",
+			desc:            "[SupplementalGroupsPolicy=Merge(default)] Only imageConfig.User was set, imageConfig.User defines User",
 			imageConfigUser: "1000",
 			securityContext: nil,
 			expected:        runtimespec.User{UID: 1000, GID: 1000, AdditionalGids: []uint32{1000, 11111}},
 		},
 		{
-			desc:            "Both SecurityContext and ImageConfig.User was set, SecurityContext defines User",
+			desc:            "[SupplementalGroupsPolicy=Merge(default)] Both SecurityContext and ImageConfig.User was set, SecurityContext defines User",
 			imageConfigUser: "0",
 			securityContext: &runtime.LinuxContainerSecurityContext{
 				RunAsUser:          &runtime.Int64Value{Value: 1000},
@@ -1492,8 +1492,44 @@ additional-group-for-root:x:22222:root
 			expected: runtimespec.User{UID: 1000, GID: 2000, AdditionalGids: []uint32{2000, 3333, 11111}},
 		},
 		{
-			desc:     "No SecurityContext nor ImageConfig.User were set, runtime default defines User",
+			desc:     "[SupplementalGroupsPolicy=Merge(default)] No SecurityContext nor ImageConfig.User were set, runtime default defines User",
 			expected: runtimespec.User{UID: 0, GID: 0, AdditionalGids: []uint32{0, 22222}},
+		},
+		{
+			desc: "[SupplementalGroupsPolicy=Strict] Only SecurityContext was set, SecurityContext defines User, AdditionalGids excludes groups for the user defined in the image",
+			securityContext: &runtime.LinuxContainerSecurityContext{
+				RunAsUser:                &runtime.Int64Value{Value: 1000},
+				RunAsGroup:               &runtime.Int64Value{Value: 2000},
+				SupplementalGroups:       []int64{3333},
+				SupplementalGroupsPolicy: runtime.SupplementalGroupsPolicy_Strict,
+			},
+			expected: runtimespec.User{UID: 1000, GID: 2000, AdditionalGids: []uint32{2000, 3333}},
+		},
+		{
+			desc: "[SupplementalGroupsPolicy=Strict] No SecurityContext.RunAsUser and imageConfig.User was set, imageConfig.User defines User, AdditionalGids excludes groups for the user defined in the image",
+			securityContext: &runtime.LinuxContainerSecurityContext{
+				SupplementalGroupsPolicy: runtime.SupplementalGroupsPolicy_Strict,
+			},
+			imageConfigUser: "1000",
+			expected:        runtimespec.User{UID: 1000, GID: 1000, AdditionalGids: []uint32{1000}},
+		},
+		{
+			desc:            "[SupplementalGroupsPolicy=Strict] Both SecurityContext and ImageConfig.User was set, SecurityContext defines User, AdditionalGids excludes groups for the user defined in the image",
+			imageConfigUser: "0",
+			securityContext: &runtime.LinuxContainerSecurityContext{
+				RunAsUser:                &runtime.Int64Value{Value: 1000},
+				RunAsGroup:               &runtime.Int64Value{Value: 2000},
+				SupplementalGroups:       []int64{3333},
+				SupplementalGroupsPolicy: runtime.SupplementalGroupsPolicy_Strict,
+			},
+			expected: runtimespec.User{UID: 1000, GID: 2000, AdditionalGids: []uint32{2000, 3333}},
+		},
+		{
+			desc: "[SupplementalGroupsPolicy=Strict] No SecurityContext.RunAsUser nor ImageConfig.User were set, runtime default defines User, AdditionalGids excludes groups for the user defined in the image",
+			securityContext: &runtime.LinuxContainerSecurityContext{
+				SupplementalGroupsPolicy: runtime.SupplementalGroupsPolicy_Strict,
+			},
+			expected: runtimespec.User{UID: 0, GID: 0, AdditionalGids: []uint32{0}},
 		},
 	} {
 		test := test

--- a/pkg/cri/sbserver/container_status.go
+++ b/pkg/cri/sbserver/container_status.go
@@ -60,7 +60,10 @@ func (c *criService) ContainerStatus(ctx context.Context, r *runtime.ContainerSt
 			imageRef = repoDigests[0]
 		}
 	}
-	status := toCRIContainerStatus(container, spec, imageRef)
+	status, err := toCRIContainerStatus(ctx, container, spec, imageRef)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ContainerStatus: %w", err)
+	}
 	if status.GetCreatedAt() == 0 {
 		// CRI doesn't allow CreatedAt == 0.
 		info, err := container.Container.Info(ctx)
@@ -82,7 +85,7 @@ func (c *criService) ContainerStatus(ctx context.Context, r *runtime.ContainerSt
 }
 
 // toCRIContainerStatus converts internal container object to CRI container status.
-func toCRIContainerStatus(container containerstore.Container, spec *runtime.ImageSpec, imageRef string) *runtime.ContainerStatus {
+func toCRIContainerStatus(ctx context.Context, container containerstore.Container, spec *runtime.ImageSpec, imageRef string) (*runtime.ContainerStatus, error) {
 	meta := container.Metadata
 	status := container.Status.Get()
 	reason := status.Reason
@@ -104,6 +107,11 @@ func toCRIContainerStatus(container containerstore.Container, spec *runtime.Imag
 		st, ft = status.StartedAt, status.FinishedAt
 	}
 
+	runtimeUser, err := toCRIContainerUser(ctx, container)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ConteianerUser: %w", err)
+	}
+
 	return &runtime.ContainerStatus{
 		Id:          meta.ID,
 		Metadata:    meta.Config.GetMetadata(),
@@ -121,7 +129,8 @@ func toCRIContainerStatus(container containerstore.Container, spec *runtime.Imag
 		Mounts:      meta.Config.GetMounts(),
 		LogPath:     meta.LogPath,
 		Resources:   status.Resources,
-	}
+		User:        runtimeUser,
+	}, nil
 }
 
 // ContainerInfo is extra information for a container.

--- a/pkg/cri/sbserver/container_status_linux.go
+++ b/pkg/cri/sbserver/container_status_linux.go
@@ -1,0 +1,53 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package sbserver
+
+import (
+	"context"
+	"fmt"
+
+	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+func toCRIContainerUser(ctx context.Context, container containerstore.Container) (*runtime.ContainerUser, error) {
+	if container.Container == nil {
+		return nil, nil
+	}
+
+	runtimeSpec, err := container.Container.Spec(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get container runtime spec: %w", err)
+	}
+
+	if runtimeSpec.Process == nil {
+		return nil, nil
+	}
+
+	user := runtimeSpec.Process.User
+	supplementalGroups := make([]int64, len(user.AdditionalGids))
+	for _, gid := range user.AdditionalGids {
+		supplementalGroups = append(supplementalGroups, int64(gid))
+	}
+	return &runtime.ContainerUser{
+		Linux: &runtime.LinuxContainerUser{
+			Uid:                int64(user.UID),
+			Gid:                int64(user.GID),
+			SupplementalGroups: supplementalGroups,
+		},
+	}, nil
+}

--- a/pkg/cri/sbserver/container_status_other.go
+++ b/pkg/cri/sbserver/container_status_other.go
@@ -1,0 +1,30 @@
+//go:build !windows && !linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package sbserver
+
+import (
+	"context"
+
+	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+func toCRIContainerUser(ctx context.Context, container containerstore.Container) (*runtime.ContainerUser, error) {
+	return nil, nil
+}

--- a/pkg/cri/sbserver/container_status_test.go
+++ b/pkg/cri/sbserver/container_status_test.go
@@ -158,9 +158,10 @@ func TestToCRIContainerStatus(t *testing.T) {
 			expected.ExitCode = test.exitCode
 			expected.Message = test.message
 			patchExceptedWithState(expected, test.expectedState)
-			containerStatus := toCRIContainerStatus(container,
+			containerStatus, err := toCRIContainerStatus(context.Background(), container,
 				expected.Image,
 				expected.ImageRef)
+			assert.Empty(t, err, test.desc)
 			assert.Equal(t, expected, containerStatus, test.desc)
 		})
 	}

--- a/pkg/cri/sbserver/container_status_windows.go
+++ b/pkg/cri/sbserver/container_status_windows.go
@@ -1,0 +1,21 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package sbserver
+
+func toCRIContainerUser(ctx context.Context, container containerstore.Container) (*runtime.ContainerUser, error) {
+	return nil, nil
+}

--- a/pkg/cri/server/container_create_linux_test.go
+++ b/pkg/cri/server/container_create_linux_test.go
@@ -1653,7 +1653,7 @@ additional-group-for-root:x:22222:root
 		expected        runtimespec.User
 	}{
 		{
-			desc: "Only SecurityContext was set, SecurityContext defines User",
+			desc: "[SupplementalGroupsPolicy=Merge(default)] Only SecurityContext was set, SecurityContext defines User",
 			securityContext: &runtime.LinuxContainerSecurityContext{
 				RunAsUser:          &runtime.Int64Value{Value: 1000},
 				RunAsGroup:         &runtime.Int64Value{Value: 2000},
@@ -1662,13 +1662,13 @@ additional-group-for-root:x:22222:root
 			expected: runtimespec.User{UID: 1000, GID: 2000, AdditionalGids: []uint32{2000, 3333, 11111}},
 		},
 		{
-			desc:            "Only imageConfig.User was set, imageConfig.User defines User",
+			desc:            "[SupplementalGroupsPolicy=Merge(default)] Only imageConfig.User was set, imageConfig.User defines User",
 			imageConfigUser: "1000",
 			securityContext: nil,
 			expected:        runtimespec.User{UID: 1000, GID: 1000, AdditionalGids: []uint32{1000, 11111}},
 		},
 		{
-			desc:            "Both SecurityContext and ImageConfig.User was set, SecurityContext defines User",
+			desc:            "[SupplementalGroupsPolicy=Merge(default)] Both SecurityContext and ImageConfig.User was set, SecurityContext defines User",
 			imageConfigUser: "0",
 			securityContext: &runtime.LinuxContainerSecurityContext{
 				RunAsUser:          &runtime.Int64Value{Value: 1000},
@@ -1678,8 +1678,44 @@ additional-group-for-root:x:22222:root
 			expected: runtimespec.User{UID: 1000, GID: 2000, AdditionalGids: []uint32{2000, 3333, 11111}},
 		},
 		{
-			desc:     "No SecurityContext nor ImageConfig.User were set, runtime default defines User",
+			desc:     "[SupplementalGroupsPolicy=Merge(default)] No SecurityContext nor ImageConfig.User were set, runtime default defines User",
 			expected: runtimespec.User{UID: 0, GID: 0, AdditionalGids: []uint32{0, 22222}},
+		},
+		{
+			desc: "[SupplementalGroupsPolicy=Strict] Only SecurityContext was set, SecurityContext defines User, AdditionalGids excludes groups for the user defined in the image",
+			securityContext: &runtime.LinuxContainerSecurityContext{
+				RunAsUser:                &runtime.Int64Value{Value: 1000},
+				RunAsGroup:               &runtime.Int64Value{Value: 2000},
+				SupplementalGroups:       []int64{3333},
+				SupplementalGroupsPolicy: runtime.SupplementalGroupsPolicy_Strict,
+			},
+			expected: runtimespec.User{UID: 1000, GID: 2000, AdditionalGids: []uint32{2000, 3333}},
+		},
+		{
+			desc: "[SupplementalGroupsPolicy=Strict] No SecurityContext.RunAsUser and imageConfig.User was set, imageConfig.User defines User, AdditionalGids excludes groups for the user defined in the image",
+			securityContext: &runtime.LinuxContainerSecurityContext{
+				SupplementalGroupsPolicy: runtime.SupplementalGroupsPolicy_Strict,
+			},
+			imageConfigUser: "1000",
+			expected:        runtimespec.User{UID: 1000, GID: 1000, AdditionalGids: []uint32{1000}},
+		},
+		{
+			desc:            "[SupplementalGroupsPolicy=Strict] Both SecurityContext and ImageConfig.User was set, SecurityContext defines User, AdditionalGids excludes groups for the user defined in the image",
+			imageConfigUser: "0",
+			securityContext: &runtime.LinuxContainerSecurityContext{
+				RunAsUser:                &runtime.Int64Value{Value: 1000},
+				RunAsGroup:               &runtime.Int64Value{Value: 2000},
+				SupplementalGroups:       []int64{3333},
+				SupplementalGroupsPolicy: runtime.SupplementalGroupsPolicy_Strict,
+			},
+			expected: runtimespec.User{UID: 1000, GID: 2000, AdditionalGids: []uint32{2000, 3333}},
+		},
+		{
+			desc: "[SupplementalGroupsPolicy=Strict] No SecurityContext.RunAsUser nor ImageConfig.User were set, runtime default defines User, AdditionalGids excludes groups for the user defined in the image",
+			securityContext: &runtime.LinuxContainerSecurityContext{
+				SupplementalGroupsPolicy: runtime.SupplementalGroupsPolicy_Strict,
+			},
+			expected: runtimespec.User{UID: 0, GID: 0, AdditionalGids: []uint32{0}},
 		},
 	} {
 		test := test

--- a/pkg/cri/server/container_status_linux.go
+++ b/pkg/cri/server/container_status_linux.go
@@ -1,0 +1,54 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"fmt"
+
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
+)
+
+func toCRIContainerUser(ctx context.Context, container containerstore.Container) (*runtime.ContainerUser, error) {
+	if container.Container == nil {
+		return nil, nil
+	}
+
+	runtimeSpec, err := container.Container.Spec(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get container runtime spec: %w", err)
+	}
+
+	if runtimeSpec.Process == nil {
+		return nil, nil
+	}
+
+	user := runtimeSpec.Process.User
+	supplementalGroups := make([]int64, len(user.AdditionalGids))
+	for _, gid := range user.AdditionalGids {
+		supplementalGroups = append(supplementalGroups, int64(gid))
+	}
+	return &runtime.ContainerUser{
+		Linux: &runtime.LinuxContainerUser{
+			Uid:                int64(user.UID),
+			Gid:                int64(user.GID),
+			SupplementalGroups: supplementalGroups,
+		},
+	}, nil
+}

--- a/pkg/cri/server/container_status_other.go
+++ b/pkg/cri/server/container_status_other.go
@@ -1,0 +1,31 @@
+//go:build !windows && !linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
+)
+
+func toCRIContainerUser(ctx context.Context, container containerstore.Container) (*runtime.ContainerUser, error) {
+	return nil, nil
+}

--- a/pkg/cri/server/container_status_test.go
+++ b/pkg/cri/server/container_status_test.go
@@ -155,9 +155,10 @@ func TestToCRIContainerStatus(t *testing.T) {
 			expected.ExitCode = test.exitCode
 			expected.Message = test.message
 			patchExceptedWithState(expected, test.expectedState)
-			containerStatus := toCRIContainerStatus(container,
+			containerStatus, err := toCRIContainerStatus(context.Background(), container,
 				expected.Image,
 				expected.ImageRef)
+			assert.Empty(t, err, test.desc)
 			assert.Equal(t, expected, containerStatus, test.desc)
 		})
 	}

--- a/pkg/cri/server/container_status_windows.go
+++ b/pkg/cri/server/container_status_windows.go
@@ -1,0 +1,33 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"errors"
+	"fmt"
+
+	wstats "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats"
+	"github.com/containerd/containerd/api/types"
+	"github.com/containerd/typeurl/v2"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
+)
+
+func toCRIContainerUser(ctx context.Context, container containerstore.Container) (*runtime.ContainerUser, error) {
+	return nil, nil
+}


### PR DESCRIPTION
This implements `SupplementalGroupsPolicy`/`ContainerStatus.User` in CRI-API defined in https://github.com/kubernetes/kubernetes/pull/117842

It needs to update `k8s.io/cri-api` version in `go.mod` after https://github.com/kubernetes/kubernetes/pull/117842 is released