### PR TITLE
[WIP] Introduce credential plugin

### DIFF
--- a/pkg/transfer/transfer.go
+++ b/pkg/transfer/transfer.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/remotes/docker"
 )
 
 type Transferrer interface {
@@ -31,7 +32,7 @@ type Transferrer interface {
 }
 
 type ImageResolver interface {
-	Resolve(ctx context.Context) (name string, desc ocispec.Descriptor, err error)
+	Resolver(ctx context.Context, ropts docker.ResolverOptions) (Resolver, error)
 }
 
 type ImageFetcher interface {
@@ -42,6 +43,10 @@ type ImageFetcher interface {
 
 type ImagePusher interface {
 	Pusher(context.Context, ocispec.Descriptor) (Pusher, error)
+}
+
+type Resolver interface {
+	Resolve(ctx context.Context) (name string, desc ocispec.Descriptor, err error)
 }
 
 type Fetcher interface {

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -90,6 +90,8 @@ const (
 	SandboxStorePlugin Type = "io.containerd.sandbox.store.v1"
 	// SandboxControllerPlugin implements a sandbox controller
 	SandboxControllerPlugin Type = "io.containerd.sandbox.controller.v1"
+	// CredentialPlugin implements a credential manager
+	CredentialPlugin Type = "io.containerd.credential.v1" // #nosec G101
 )
 
 const (

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -92,6 +92,8 @@ const (
 	SandboxControllerPlugin Type = "io.containerd.sandbox.controller.v1"
 	// CredentialPlugin implements a credential manager
 	CredentialPlugin Type = "io.containerd.credential.v1" // #nosec G101
+	// RegistryPlugin implements a registry service
+	RegistryPlugin Type = "io.containerd.registry.v1"
 )
 
 const (

--- a/plugins/credential/credential.go
+++ b/plugins/credential/credential.go
@@ -1,0 +1,34 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package credential
+
+import (
+	"context"
+)
+
+type AuthInfo struct {
+	Host     string
+	Username string
+	Secret   string
+}
+
+type Credential interface {
+	Store(ctx context.Context, auth AuthInfo) error
+	Get(ctx context.Context, host string) (AuthInfo, error)
+	Delete(ctx context.Context, auth AuthInfo) error
+	List(ctx context.Context) ([]AuthInfo, error)
+}

--- a/plugins/credential/docker.go
+++ b/plugins/credential/docker.go
@@ -1,0 +1,61 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package credential
+
+import (
+	"context"
+	"errors"
+
+	"github.com/containerd/containerd/plugin"
+)
+
+type Config struct {
+	CredsStore string `json:"credsStore"`
+}
+
+func init() {
+	plugin.Register(&plugin.Registration{
+		Type:     plugin.CredentialPlugin,
+		ID:       "docker-compatible",
+		Config:   &Config{},
+		Requires: []plugin.Type{},
+		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
+			config, ok := ic.Config.(*Config)
+			if !ok {
+				return nil, errors.New("invalid docker credential plugin configuration")
+			}
+			return &dockerStore{CredsStore: config.CredsStore}, nil
+		},
+	})
+}
+
+type dockerStore struct {
+	CredsStore string
+}
+
+func (d *dockerStore) Store(ctx context.Context, auth AuthInfo) error {
+	return nil
+}
+func (d *dockerStore) Get(ctx context.Context, host string) (AuthInfo, error) {
+	return AuthInfo{}, nil
+}
+func (d *dockerStore) Delete(ctx context.Context, auth AuthInfo) error {
+	return nil
+}
+func (d *dockerStore) List(ctx context.Context) ([]AuthInfo, error) {
+	return nil, nil
+}

--- a/plugins/transfer/plugin.go
+++ b/plugins/transfer/plugin.go
@@ -45,6 +45,7 @@ func init() {
 			plugin.LeasePlugin,
 			plugin.MetadataPlugin,
 			plugin.DiffPlugin,
+			plugin.RegistryPlugin,
 		},
 		Config: defaultConfig(),
 		InitFn: func(ic *plugin.InitContext) (interface{}, error) {

--- a/remotes/docker/config/hosts_test.go
+++ b/remotes/docker/config/hosts_test.go
@@ -112,7 +112,7 @@ ca = "/etc/path/default"
   override_path = true
 `
 	var tb, fb = true, false
-	expected := []hostConfig{
+	expected := []HostConfig{
 		{
 			scheme:       "https",
 			host:         "mirror.registry",
@@ -211,14 +211,14 @@ func TestLoadCertFiles(t *testing.T) {
 	dir := t.TempDir()
 
 	type testCase struct {
-		input hostConfig
+		input HostConfig
 	}
 	cases := map[string]testCase{
 		"crt only": {
-			input: hostConfig{host: "testing.io", caCerts: []string{filepath.Join(dir, "testing.io", "ca.crt")}},
+			input: HostConfig{host: "testing.io", caCerts: []string{filepath.Join(dir, "testing.io", "ca.crt")}},
 		},
 		"crt and cert pair": {
-			input: hostConfig{
+			input: HostConfig{
 				host:    "testing.io",
 				caCerts: []string{filepath.Join(dir, "testing.io", "ca.crt")},
 				clientPairs: [][2]string{
@@ -230,7 +230,7 @@ func TestLoadCertFiles(t *testing.T) {
 			},
 		},
 		"cert pair only": {
-			input: hostConfig{
+			input: HostConfig{
 				host: "testing.io",
 				clientPairs: [][2]string{
 					{
@@ -266,7 +266,7 @@ func TestLoadCertFiles(t *testing.T) {
 				}
 			}
 
-			configs, err := loadHostDir(context.Background(), hostDir)
+			configs, err := LoadHostDir(context.Background(), hostDir)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -301,7 +301,7 @@ func compareRegistryHost(j, k docker.RegistryHost) bool {
 	return true
 }
 
-func compareHostConfig(j, k hostConfig) bool {
+func compareHostConfig(j, k HostConfig) bool {
 	if j.scheme != k.scheme {
 		return false
 	}
@@ -359,7 +359,7 @@ func compareHostConfig(j, k hostConfig) bool {
 	return true
 }
 
-func printHostConfig(hc []hostConfig) string {
+func printHostConfig(hc []HostConfig) string {
 	b := bytes.NewBuffer(nil)
 	for i := range hc {
 		fmt.Fprintf(b, "\t[%d]\tscheme: %q\n", i, hc[i].scheme)

--- a/remotes/docker/config/service.go
+++ b/remotes/docker/config/service.go
@@ -1,0 +1,128 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/plugin"
+	"github.com/containerd/containerd/plugins/credential"
+	"github.com/containerd/containerd/remotes/docker"
+
+	//"github.com/containerd/containerd/remotes/docker/config"
+	"github.com/containerd/containerd/services"
+)
+
+type Config struct {
+	ConfigPath string `toml:"config_path" json:"configPath"`
+}
+
+func init() {
+	plugin.Register(&plugin.Registration{
+		Type:   plugin.ServicePlugin,
+		ID:     services.RegistryService,
+		Config: &Config{},
+		Requires: []plugin.Type{
+			plugin.CredentialPlugin,
+		},
+		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
+			plugins, err := ic.GetByType(plugin.CredentialPlugin)
+			if err != nil {
+				return nil, err
+			}
+
+			m := make(map[string]credential.Credential, len(plugins))
+			for _, p := range plugins {
+				i, err := p.Instance()
+				if err != nil {
+					return nil, err
+				}
+				m[p.Registration.ID] = i.(credential.Credential)
+			}
+			config, ok := ic.Config.(*Config)
+			if !ok {
+				return nil, errors.New("invalid registry service configuration")
+			}
+			if len(config.ConfigPath) == 0 {
+				// TODO
+				config.ConfigPath = "/etc/containerd/certs.d/"
+			}
+
+			return &Manager{plugins: m, configPath: config.ConfigPath}, nil
+		},
+	})
+}
+
+type Manager struct {
+	plugins    map[string]credential.Credential
+	configPath string
+}
+
+func (m *Manager) RegistryHosts(ctx context.Context, opt HostOptions) docker.RegistryHosts {
+	paths := filepath.SplitList(m.configPath)
+	hostDirFn := hostDirFromRoots(paths)
+	opt.HostDir = hostDirFn
+	if opt.Credentials == nil {
+		opt.Credentials = func(host string) (string, string, error) {
+			dir, err := hostDirFn(host)
+			if err != nil && !errdefs.IsNotFound(err) {
+				return "", "", err
+			}
+			hosts, err := LoadHostDir(ctx, dir)
+			if err != nil {
+				return "", "", err
+			}
+			for _, h := range hosts {
+				if h.host != host {
+					continue
+				}
+				// read only, not need lock
+				cred, ok := m.plugins[h.credentialPlugin]
+				if !ok {
+					return "", "", fmt.Errorf("not found credential plugin %q", h.credentialPlugin)
+				}
+				a, err := cred.Get(context.Background(), host)
+				if err != nil {
+					return "", "", err
+				}
+				return a.Username, a.Secret, nil
+			}
+			return "", "", nil
+		}
+	}
+	return ConfigureHosts(ctx, opt)
+}
+
+func hostDirFromRoots(roots []string) func(string) (string, error) {
+	rootfn := make([]func(string) (string, error), len(roots))
+	for i := range roots {
+		rootfn[i] = HostDirFromRoot(roots[i])
+	}
+	return func(host string) (dir string, err error) {
+		for _, fn := range rootfn {
+			dir, err = fn(host)
+			if (err != nil && !errdefs.IsNotFound(err)) || (dir != "") {
+				break
+			}
+		}
+		return
+	}
+}

--- a/services/services.go
+++ b/services/services.go
@@ -35,4 +35,6 @@ const (
 	IntrospectionService = "introspection-service"
 	// Streaming service is the id of the streaming service
 	StreamingService = "streaming-service"
+	// RegistryService is id of registry service.
+	RegistryService = "registry-service"
 )


### PR DESCRIPTION
- Added a plugin type, CredentialPlugin. 
It is used for credential management. CredentialPlugin can be a docker-compatible helper. e.g. [docker-credential-helpers](https://github.com/docker/docker-credential-helpers), or  some other implementation.
 

- A RegistryService of ServicePlugin type is introduced to manage CredentialPlugin. 
RegistryService parse Registry Configuration. And select different Plugins according to pre-host configurations in hosts.toml. It can be used by the transfer service. It can also be used by CRI in the future, instead of the Image Registry configuration of CRI.

This PR is used to support the Plugin mechanism mentioned in #8228. Consider compatibility with #8476 afterward.


