### PR TITLE
cri: update WithoutDefaultSecuritySettings comment

### DIFF
--- a/pkg/cri/opts/spec_opts.go
+++ b/pkg/cri/opts/spec_opts.go
@@ -161,7 +161,7 @@ func WithoutDefaultSecuritySettings(_ context.Context, _ oci.Client, c *containe
 	if s.Linux != nil {
 		s.Linux.Seccomp = nil
 	}
-	// Remove default rlimits (See issue #515)
+	// Remove default rlimits (See https://github.com/containerd/cri/issues/515)
 	s.Process.Rlimits = nil
 	return nil
 }


### PR DESCRIPTION
This pointer to an issue never got updated after the CRI plugin was absorbed into the main containerd repo as an in-tree plugin.