### PR TITLE
.github: disable cache for actions/setup-go@v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false # see actions/setup-go#368
 
       - uses: actions/checkout@v3
       - uses: golangci/golangci-lint-action@v3
@@ -61,6 +62,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false # see actions/setup-go#368
 
       - uses: actions/checkout@v3
         with:
@@ -94,6 +96,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false # see actions/setup-go#368
 
       - uses: actions/checkout@v3
         with:
@@ -126,6 +129,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false # see actions/setup-go#368
       - uses: actions/checkout@v3
       - run: go install github.com/cpuguy83/go-md2man/v2@v2.0.2
       - run: make man
@@ -159,6 +163,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false # see actions/setup-go#368
       - uses: actions/checkout@v3
       - run: |
           set -e -x
@@ -215,6 +220,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
+          cache: false # see actions/setup-go#368
 
       - uses: actions/checkout@v3
 
@@ -249,6 +255,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false # see actions/setup-go#368
 
       - uses: actions/checkout@v3
         with:
@@ -404,6 +411,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false # see actions/setup-go#368
 
       - uses: actions/checkout@v3
 
@@ -528,6 +536,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false # see actions/setup-go#368
       - uses: actions/checkout@v3
       - run: script/setup/install-gotestsum
       - run: script/setup/install-teststat


### PR DESCRIPTION
https://github.com/actions/setup-go/issues/368 and https://github.com/opencontainers/runc/pull/3820#issuecomment-1501426479 discuss issues with the cache key for actions/setup-go@v4.  Rather than reverting the upgrade to v4 (per discussion in https://github.com/containerd/containerd/pull/8372), disable caching explicitly.