### PR TITLE
Change to Readdirnames for some cases

### DIFF
--- a/content/local/store.go
+++ b/content/local/store.go
@@ -295,10 +295,9 @@ func (s *store) ListStatuses(ctx context.Context, fs ...string) ([]content.Statu
 	if err != nil {
 		return nil, err
 	}
-
 	defer fp.Close()
 
-	fis, err := fp.Readdir(-1)
+	fis, err := fp.Readdirnames(-1)
 	if err != nil {
 		return nil, err
 	}
@@ -310,7 +309,7 @@ func (s *store) ListStatuses(ctx context.Context, fs ...string) ([]content.Statu
 
 	var active []content.Status
 	for _, fi := range fis {
-		p := filepath.Join(s.root, "ingest", fi.Name())
+		p := filepath.Join(s.root, "ingest", fi)
 		stat, err := s.status(p)
 		if err != nil {
 			if !os.IsNotExist(err) {
@@ -345,16 +344,15 @@ func (s *store) WalkStatusRefs(ctx context.Context, fn func(string) error) error
 	if err != nil {
 		return err
 	}
-
 	defer fp.Close()
 
-	fis, err := fp.Readdir(-1)
+	fis, err := fp.Readdirnames(-1)
 	if err != nil {
 		return err
 	}
 
 	for _, fi := range fis {
-		rf := filepath.Join(s.root, "ingest", fi.Name(), "ref")
+		rf := filepath.Join(s.root, "ingest", fi, "ref")
 
 		ref, err := readFileString(rf)
 		if err != nil {

--- a/pkg/cri/opts/container.go
+++ b/pkg/cri/opts/container.go
@@ -121,7 +121,13 @@ func WithVolumes(volumeMounts map[string]string) containerd.NewContainerOpts {
 // copyExistingContents copies from the source to the destination and
 // ensures the ownership is appropriately set.
 func copyExistingContents(source, destination string) error {
-	dstList, err := os.ReadDir(destination)
+	f, err := os.Open(destination)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	dstList, err := f.Readdirnames(-1)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
There was a couple uses of Readdir/ReadDir here where the only thing the return value was used for was the Name of the entry. This is exactly what Readdirnames returns, so we can avoid the overhead of making/returning a bunch of interfaces and calling lstat everytime in the case of Readdir(-1).

https://cs.opensource.google/go/go/+/refs/tags/go1.20.4:src/os/dir_unix.go;l=114-137