### PR TITLE
Bump up golangci-lint to v1.52.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.1
+          version: v1.52.2
           skip-cache: true
           args: --timeout=8m
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,6 +32,24 @@ issues:
     - path: 'archive[\\/]tarheader[\\/]'
       # conversion is necessary on Linux, unnecessary on macOS
       text: "unnecessary conversion"
+    - linters:
+        - revive
+      text: "if-return"
+    - linters:
+        - revive
+      text: "empty-block"
+    - linters:
+        - revive
+      text: "superfluous-else"
+    - linters:
+        - revive
+      text: "unused-parameter"
+    - linters:
+        - revive
+      text: "unreachable-code"
+    - linters:
+        - revive
+      text: "redefines-builtin-id"
 
 linters-settings:
   gosec:

--- a/pkg/cri/sbserver/images/image_pull.go
+++ b/pkg/cri/sbserver/images/image_pull.go
@@ -361,7 +361,8 @@ func (c *CRIImageService) getTLSConfig(registryTLSConfig criconfig.TLSConfig) (*
 		if len(cert.Certificate) != 0 {
 			tlsConfig.Certificates = []tls.Certificate{cert}
 		}
-		tlsConfig.BuildNameToCertificate() //nolint:staticcheck // TODO(thaJeztah): verify if we should ignore the deprecation; see https://github.com/containerd/containerd/pull/7349/files#r990644833
+		// TODO(thaJeztah): verify if we should ignore the deprecation; see https://github.com/containerd/containerd/pull/7349/files#r990644833
+		tlsConfig.BuildNameToCertificate() //nolint:staticcheck
 	}
 
 	if registryTLSConfig.CAFile != "" {

--- a/pkg/cri/server/image_pull.go
+++ b/pkg/cri/server/image_pull.go
@@ -343,7 +343,8 @@ func (c *criService) getTLSConfig(registryTLSConfig criconfig.TLSConfig) (*tls.C
 		if len(cert.Certificate) != 0 {
 			tlsConfig.Certificates = []tls.Certificate{cert}
 		}
-		tlsConfig.BuildNameToCertificate() //nolint:staticcheck // TODO(thaJeztah): verify if we should ignore the deprecation; see https://github.com/containerd/containerd/pull/7349/files#r990644833
+		// TODO(thaJeztah): verify if we should ignore the deprecation; see https://github.com/containerd/containerd/pull/7349/files#r990644833
+		tlsConfig.BuildNameToCertificate() //nolint:staticcheck
 	}
 
 	if registryTLSConfig.CAFile != "" {

--- a/remotes/docker/config/hosts.go
+++ b/remotes/docker/config/hosts.go
@@ -332,7 +332,6 @@ func parseHostsFile(baseDir string, b []byte) ([]hostConfig, error) {
 
 	// HACK: we want to keep toml parsing structures private in this package, however go-toml ignores private embedded types.
 	// so we remap it to a public type within the func body, so technically it's public, but not possible to import elsewhere.
-	//nolint:unused
 	type HostFileConfig = hostFileConfig
 
 	c := struct {

--- a/script/setup/install-dev-tools
+++ b/script/setup/install-dev-tools
@@ -23,7 +23,7 @@ set -eu -o pipefail
 go install github.com/containerd/protobuild@v0.3.0
 go install github.com/containerd/protobuild/cmd/go-fix-acronym@v0.3.0
 go install github.com/cpuguy83/go-md2man/v2@v2.0.2
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
 go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28
 go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
 go install github.com/containerd/ttrpc/cmd/protoc-gen-go-ttrpc@5cc9169d1fc1a8292866224ae09dc47827801874


### PR DESCRIPTION
Release note: https://github.com/golangci/golangci-lint/releases/tag/v1.52.2

`revive` seems to become (very) strict by the following newly added rules (seems related to https://github.com/mgechev/revive/pull/799). Especially `unused-parameter` reports a lot of "unused-parameter" errors (e.g. unused `ctx context.Context` argument on a function)

- if-return
- empty-block
- superfluous-else
- unused-parameter
- unreachable-code
- redefines-builtin-id

This commit disables them for now but let me know if we need them.

This commit also addresses the following linter errors:

```
remotes/docker/config/hosts.go:335:2: directive `//nolint:unused` is unused for linter "unused" (nolintlint)
	//nolint:unused
	^
pkg/cri/server/image_pull.go:346:38: directive `//nolint:staticcheck // TODO(thaJeztah): verify if we should ignore the deprecation; see https://github.com/containerd/containerd/pull/7349/files#r990644833` is unused for linter "staticcheck" (nolintlint)
		tlsConfig.BuildNameToCertificate() //nolint:staticcheck // TODO(thaJeztah): verify if we should ignore the deprecation; see https://github.com/containerd/containerd/pull/7349/files#r990644833
		                                   ^
pkg/cri/sbserver/images/image_pull.go:364:38: directive `//nolint:staticcheck // TODO(thaJeztah): verify if we should ignore the deprecation; see https://github.com/containerd/containerd/pull/7349/files#r990644833` is unused for linter "staticcheck" (nolintlint)
		tlsConfig.BuildNameToCertificate() //nolint:staticcheck // TODO(thaJeztah): verify if we should ignore the deprecation; see https://github.com/containerd/containerd/pull/7349/files#r990644833
```
