### PR TITLE
improve container Task comment

### DIFF
--- a/container.go
+++ b/container.go
@@ -61,8 +61,13 @@ type Container interface {
 	Spec(context.Context) (*oci.Spec, error)
 	// Task returns the current task for the container
 	//
+	// If cio.Load options are passed the client will Load the IO for the running
+	// task.
+	//
 	// If cio.Attach options are passed the client will reattach to the IO for the running
-	// task. If no task exists for the container a NotFound error is returned
+	// task.
+	//
+	// If no task exists for the container a NotFound error is returned
 	//
 	// Clients must make sure that only one reader is attached to the task and consuming
 	// the output from the task's fifos


### PR DESCRIPTION
[Task(context.Context, cio.Attach) (Task, error)](https://github.com/containerd/containerd/blob/main/container.go#L62-L69) comment does not explicitly mention that we can load the IO for the running task.

this confusion occured [here](https://github.com/containerd/nerdctl/pull/2128#discussion_r1151888490)

**expected improvement :**
Add comment to explicitly mention that it is possible to Load the IO for the running task