### PR TITLE
Simplify closing bundle dir fd

### DIFF
--- a/runtime/v2/shim_load.go
+++ b/runtime/v2/shim_load.go
@@ -91,13 +91,12 @@ func (m *ShimManager) loadShims(ctx context.Context) error {
 		}
 
 		bf, err := f.Readdirnames(-1)
+		f.Close()
 		if err != nil {
-			f.Close()
 			bundle.Delete()
 			log.G(ctx).WithError(err).Errorf("fast path read bundle path for %s", bundle.Path)
 			continue
 		}
-		f.Close()
 		if len(bf) == 0 {
 			bundle.Delete()
 			continue


### PR DESCRIPTION
Follow-up to #8489. We don't need to call Close in the err and success cases, we can just do it after Readdirnames returns.

Thanks @fuweid 