### PR TITLE
snapshots/testsuite: Rename: fix fuse-overlayfs incompatibility

### DIFF
--- a/snapshots/testsuite/issues.go
+++ b/snapshots/testsuite/issues.go
@@ -128,10 +128,16 @@ func checkRename(ss string) func(ctx context.Context, t *testing.T, sn snapshots
 		)
 
 		var applier []fstest.Applier
-		if ss != "overlayfs" {
-			// With neither OVERLAY_FS_REDIRECT_DIR nor redirect_dir,
-			// renaming the directory on the lower directory doesn't work on overlayfs.
-			// https://github.com/torvalds/linux/blob/v5.18/Documentation/filesystems/overlayfs.rst#renaming-directories
+		switch ss {
+		// With neither OVERLAY_FS_REDIRECT_DIR nor redirect_dir,
+		// renaming the directory on the lower directory doesn't work on overlayfs.
+		// https://github.com/torvalds/linux/blob/v5.18/Documentation/filesystems/overlayfs.rst#renaming-directories
+		//
+		// It doesn't work on fuse-overlayfs either.
+		// https://github.com/containerd/fuse-overlayfs-snapshotter/pull/53#issuecomment-1543442048
+		case "overlayfs", "fuse-overlayfs":
+			// NOP
+		default:
 			applier = append(applier, fstest.Rename("/dir1", "/dir2"))
 		}
 		applier = append(


### PR DESCRIPTION
For https://github.com/containerd/fuse-overlayfs-snapshotter/pull/53#issuecomment-1543442048

> CI failing
> 
> ```
> $ go test -exec rootlesskit -test.v -test.root -test.run TestFUSEOverlayFS/Rename
> === RUN   TestFUSEOverlayFS
> === RUN   TestFUSEOverlayFS/Rename
> === PAUSE TestFUSEOverlayFS/Rename
> === CONT  TestFUSEOverlayFS/Rename
>     issues.go:142: Check snapshots failed: failed to create snapshot 2: failed to apply: rename /tmp/snapshot-suite-fuse-overlayfs-2521667602/work/prepare434549372/dir1 /tmp/snapshot-suite-fuse-overlayfs-2521667602/work/prepare434549372/dir2: invalid cross-device link
>     helpers.go:66: drwx------       4096 /tmp/snapshot-suite-fuse-overlayfs-2521667602
>     helpers.go:66: drwxrwxr-x       4096 /tmp/snapshot-suite-fuse-overlayfs-2521667602/root
>     helpers.go:64: -rw-------      65536 /tmp/snapshot-suite-fuse-overlayfs-2521667602/root/metadata.db [ "\x00\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\xed\xda\f\xed\x02\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\a\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\b\x00\x00\x00\x00\x00\x00\x00\f\x00\x00\x00\x00\x00\x00\x00" ...]
>     helpers.go:66: drwx------       4096 /tmp/snapshot-suite-fuse-overlayfs-2521667602/root/snapshots
>     helpers.go:66: drwx------       4096 /tmp/snapshot-suite-fuse-overlayfs-2521667602/root/snapshots/1
>     helpers.go:66: drwxr-xr-x       4096 /tmp/snapshot-suite-fuse-overlayfs-2521667602/root/snapshots/1/fs
>     helpers.go:66: drwx------       4096 /tmp/snapshot-suite-fuse-overlayfs-2521667602/root/snapshots/1/fs/dir1
>     helpers.go:66: drwx------       4096 /tmp/snapshot-suite-fuse-overlayfs-2521667602/root/snapshots/1/fs/somefiles
>     helpers.go:64: -rw-r--r--         15 /tmp/snapshot-suite-fuse-overlayfs-2521667602/root/snapshots/1/fs/somefiles/f1 [ "was here first!" ...]
>     helpers.go:64: -rw-r--r--         19 /tmp/snapshot-suite-fuse-overlayfs-2521667602/root/snapshots/1/fs/somefiles/f2 [ "nothing interesting" ...]
>     helpers.go:66: drwx--x--x       4096 /tmp/snapshot-suite-fuse-overlayfs-2521667602/root/snapshots/1/work
>     helpers.go:66: drwx------       4096 /tmp/snapshot-suite-fuse-overlayfs-2521667602/root/snapshots/3
>     helpers.go:66: drwxr-xr-x       4096 /tmp/snapshot-suite-fuse-overlayfs-2521667602/root/snapshots/3/fs
>     helpers.go:66: drwx--x--x       4096 /tmp/snapshot-suite-fuse-overlayfs-2521667602/root/snapshots/3/work
>     helpers.go:66: drwx------       4096 /tmp/snapshot-suite-fuse-overlayfs-2521667602/root/snapshots/3/work/work
>     helpers.go:66: drwxrwxr-x       4096 /tmp/snapshot-suite-fuse-overlayfs-2521667602/work
> --- FAIL: TestFUSEOverlayFS (0.01s)
>     --- FAIL: TestFUSEOverlayFS/Rename (0.01s)
> FAIL
> [rootlesskit:child ] error: command [/tmp/go-build2417113406/b001/fuse-overlayfs-snapshotter.test -test.paniconexit0 -test.timeout=10m0s -test.v=true -test.root -test.run=TestFUSEOverlayFS/Rename] exited: exit status 1
> [rootlesskit:parent] error: child exited: exit status 1
> exit status 1
> FAIL    github.com/containerd/fuse-overlayfs-snapshotter        0.055s
> ```
> 
> Apparently caused by a regression in containerd v1.7.0-beta.2 [containerd/containerd@d5dd11d](https://github.com/containerd/containerd/commit/d5dd11dcdc3cdfd01576a05c7dbb328575dcf9d7)

