### PR TITLE
[diff] Introduce a concurrent reader to optimize unpark

### DIFF
--- a/pkg/ioutil/con_reader.go
+++ b/pkg/ioutil/con_reader.go
@@ -1,0 +1,159 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ioutil
+
+import (
+	"errors"
+	"io"
+	"sync"
+)
+
+const defaultBufSize = 32 * 1024
+
+var ErrClosed = errors.New("closed reader")
+
+var bufPool = &sync.Pool{
+	New: func() interface{} { return newReaderBuf(defaultBufSize) },
+}
+
+type readerBuf struct {
+	buf  []byte
+	r, n int
+	err  error
+}
+
+func newReaderBuf(customBufSize int) *readerBuf {
+	return &readerBuf{buf: make([]byte, customBufSize), n: 0, err: nil}
+}
+
+func (rb *readerBuf) Buffered() int {
+	return rb.n - rb.r
+}
+
+func (rb *readerBuf) Read(p []byte) (n int, err error) {
+	pn := len(p)
+	buffered := rb.Buffered()
+	if pn < buffered {
+		n = copy(p, rb.buf[rb.r:rb.r+pn])
+		rb.r += n
+		return n, nil
+	}
+	// Large read, empty buffer
+	n = copy(p[:buffered], rb.buf[rb.r:])
+	rb.r += n
+	return n, rb.err
+}
+
+func (rb *readerBuf) ReadFrom(r io.Reader) (n int64, err error) {
+	rb.n, rb.err = r.Read(rb.buf)
+	return int64(rb.n), rb.err
+}
+
+func (rb *readerBuf) Reset() {
+	rb.r = 0
+	rb.n = 0
+	rb.err = nil
+}
+
+// The conReader provides a concurrent Reader.
+// It will start a goroutine in the background to read data into the// buffer, then send buffer to chan, The foreground conReader will
+// receive the buffer from chan and return it to the caller.
+// NOTE: The conReader itself is not concurrency safe.
+// NOTE: The conReader must be eventually closed by the caller,
+// to avoid goroutine leakage.
+type conReader struct {
+	buf     *readerBuf
+	ch      chan *readerBuf
+	wg      *sync.WaitGroup
+	quit    chan struct{}
+	err     error
+	bufPool bool
+}
+
+func NewConReader(r io.Reader) io.ReadCloser {
+	return newConReader(r, 0, 8)
+}
+
+func newConReader(r io.Reader, customBufSize int, chanSize int) io.ReadCloser {
+	ch := make(chan *readerBuf, chanSize)
+	wg := &sync.WaitGroup{}
+	quit := make(chan struct{})
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		for {
+			var buf *readerBuf
+			if customBufSize > 0 {
+				buf = newReaderBuf(customBufSize)
+			} else {
+				buf = bufPool.Get().(*readerBuf)
+			}
+			_, err := buf.ReadFrom(r)
+
+			select {
+			case <-quit:
+				return
+			case ch <- buf:
+			}
+
+			if err != nil {
+				return
+			}
+		}
+	}()
+	return &conReader{buf: nil, ch: ch, wg: wg, quit: quit, err: nil, bufPool: !(customBufSize > 0)}
+}
+
+func (cr *conReader) Read(p []byte) (n int, err error) {
+	if cr.err != nil {
+		return 0, cr.err
+	}
+	need := len(p)
+
+	for n < need {
+		if cr.buf == nil {
+			select {
+			case buf := <-cr.ch:
+				cr.buf = buf
+			case <-cr.quit:
+				return n, ErrClosed
+			}
+		}
+
+		br, err := cr.buf.Read(p[n:])
+		n += br
+		if cr.buf.Buffered() == 0 {
+			cr.err = err
+			if cr.bufPool {
+				cr.buf.Reset()
+				bufPool.Put(cr.buf)
+			}
+			cr.buf = nil
+		}
+		if err != nil {
+			return n, err
+		}
+	}
+	return n, err
+}
+
+func (cr *conReader) Close() error {
+	close(cr.quit)
+	cr.wg.Wait()
+	return nil
+}

--- a/pkg/ioutil/con_reader_test.go
+++ b/pkg/ioutil/con_reader_test.go
@@ -1,0 +1,110 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ioutil
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConReader(t *testing.T) {
+	src := bytes.NewBufferString("abc")
+
+	con := newConReader(src, 4, 0)
+
+	dst := make([]byte, 1)
+
+	n, err := con.Read(dst)
+	assert.Equal(t, 1, n)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("a"), dst)
+
+	n, err = con.Read(dst)
+	assert.Equal(t, 1, n)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("b"), dst)
+
+	con.Close()
+
+	n, err = con.Read(dst)
+	assert.Equal(t, 1, n)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, []byte("c"), dst)
+
+	n, err = con.Read(dst)
+	assert.Equal(t, 0, n)
+	assert.Equal(t, ErrClosed, err)
+	assert.Equal(t, []byte("c"), dst)
+}
+
+func TestConReaderShortBuffer(t *testing.T) {
+	src := bytes.NewBufferString("aaaaaaaaaabbbbbbbbbbcccccccccc")
+
+	con := newConReader(src, 4, 10)
+
+	dst := make([]byte, 10)
+	n, err := con.Read(dst)
+	assert.Equal(t, 10, n)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("aaaaaaaaaa"), dst)
+
+	dst = make([]byte, 15)
+	n, err = con.Read(dst)
+	assert.Equal(t, 15, n)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("bbbbbbbbbbccccc"), dst)
+
+	n, err = con.Read(dst)
+	assert.Equal(t, 5, n)
+	assert.Equal(t, io.EOF, err)
+	assert.Equal(t, []byte("ccccc"), dst[:n])
+
+	n, err = con.Read(dst)
+	assert.Equal(t, 0, n)
+	assert.Equal(t, io.EOF, err)
+	assert.Equal(t, []byte("ccccc"), dst[:5])
+}
+
+func TestConReaderClose(t *testing.T) {
+	src := bytes.NewBufferString("aaaaaaaaaabbbbbbbbbbcccccccccc")
+
+	// If channel size is not zero, When conReader is closed, the return error
+	// is Uncertain. It depends on the select to choose quit chan or buf chan.
+	con := newConReader(src, 4, 0)
+
+	dst := make([]byte, 10)
+	n, err := con.Read(dst)
+	assert.Equal(t, 10, n)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("aaaaaaaaaa"), dst)
+
+	con.Close()
+
+	dst = make([]byte, 15)
+	n, err = con.Read(dst)
+	assert.Equal(t, 2, n)
+	assert.Equal(t, ErrClosed, err)
+	assert.Equal(t, []byte("bb"), dst[:n])
+
+	n, err = con.Read(dst)
+	assert.Equal(t, 0, n)
+	assert.Equal(t, ErrClosed, err)
+	assert.Equal(t, []byte("bb"), dst[:2])
+}


### PR DESCRIPTION
The concurrent reader will start a goroutine in the background to read data into the buffer, then send buffer to chan. the foreground Reader will receive the buffer from chan and return it to the caller.
This makes decompression and untar process in parallel. 

### Optimization results:
Use `ctr I pull busybox:latest` and collect the output `done: xxx ms`.

| image | image size | now | conReader | % improvement |
| --- | --- | --- | --- | --- |
| bysubox | 4.86MB | 52.458629ms| 48.593998ms |  7.36702% |
| coredns | 53.6MB | 246.313598ms | 227.530718ms | 7.6256% |
| nginx | 142MB | 983.486548ms | 876.264884ms | 10.9022% |
| openjdk | 470MB | 2.254758463s | 1.997340339s | 11.4167% |
| node | 1GB | 7.076312855s | 5.490200976s | 22.4144% |

Testing CPU/Memory usage with `node` images. 
Details for `node` images.

```
KEY                                                                     SIZE      INODES 
sha256:6d7140527100b8a0b62be606f36279d068bc6a0fa52a415f02d8dd8930e4a226 20.0 KiB  5      
sha256:4017cd6327da64d694e907023bd3b27cf7073ced8456e88014989b41cdacba41 7.3 MiB   32     
sha256:37cd3570fe018fbedb5359582a8d749c9ba8a3806519649433cef62df9656b3a 165.0 MiB 5545   
sha256:6c57c349090475e4c491e2c774e2cb25cd949db386d5bc0ac605908b65d10584 396.0 KiB 24     
sha256:230c3b2acf5c7ce5ccbc11c5292092a5af0ce5b1e366228eee031eb9c84ed0dc 532.3 MiB 12785  
sha256:34349aaf2e7f75c266222ea09df6e2bef39fea73640d191dfc5d271d390103fc 159.9 MiB 6197   
sha256:f51029f953be13d297d2bc2dd7c56c0a84c77cd7bd6672837a01c4571c7cf5fa 19.4 MiB  502    
sha256:2fab58d5cf486ed4ca265634fde3c8b4a046ade908d9b1d5405d8dfce6d12413 12.3 MiB  958    
sha256:ae56c0c5405b3d38a59b5ec5dfe5db36e8b6ff6ca8595851f903cde13e709282 134.7 MiB 7248 
```
### CPU usage

* now
![image](https://github.com/containerd/containerd/assets/8768126/ee2c8440-ebc9-424e-a5bc-22fd32d6e88b)
* conReader
![image](https://github.com/containerd/containerd/assets/8768126/16cae61e-a02f-446d-ac8a-b8b19d96f319)

### Memory usage
Testing with `node` images.
* now
![image](https://github.com/containerd/containerd/assets/8768126/7608d605-1a2d-413c-9d9f-8959cc1f7f89)
![image](https://github.com/containerd/containerd/assets/8768126/02130cea-b04f-4ab3-89ee-6782422ec29d)

* conReader
![image](https://github.com/containerd/containerd/assets/8768126/40b3878a-15e9-4c9f-951f-c241a4f8c7e7)
![image](https://github.com/containerd/containerd/assets/8768126/d83de1b5-d682-4a0e-bd54-c3a27d037953)

