### PR TITLE
Update CRI to use transfer service for image pull by default

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -37,6 +37,7 @@ import (
 	sandboxsapi "github.com/containerd/containerd/api/services/sandbox/v1"
 	snapshotsapi "github.com/containerd/containerd/api/services/snapshots/v1"
 	"github.com/containerd/containerd/api/services/tasks/v1"
+	transferapi "github.com/containerd/containerd/api/services/transfer/v1"
 	versionservice "github.com/containerd/containerd/api/services/version/v1"
 	apitypes "github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/v2/core/containers"
@@ -55,6 +56,8 @@ import (
 	sandboxproxy "github.com/containerd/containerd/v2/core/sandbox/proxy"
 	"github.com/containerd/containerd/v2/core/snapshots"
 	snproxy "github.com/containerd/containerd/v2/core/snapshots/proxy"
+	"github.com/containerd/containerd/v2/core/transfer"
+	transferproxy "github.com/containerd/containerd/v2/core/transfer/proxy"
 	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/pkg/dialer"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
@@ -750,6 +753,16 @@ func (c *Client) SandboxController(name string) sandbox.Controller {
 	c.connMu.Lock()
 	defer c.connMu.Unlock()
 	return sandboxproxy.NewSandboxController(sandboxsapi.NewControllerClient(c.conn), name)
+}
+
+// TranferService returns the underlying transferrer
+func (c *Client) TransferService() transfer.Transferrer {
+	if c.transferService != nil {
+		return c.transferService
+	}
+	c.connMu.Lock()
+	defer c.connMu.Unlock()
+	return transferproxy.NewTransferrer(transferapi.NewTransferClient(c.conn), c.streamCreator())
 }
 
 // VersionService returns the underlying VersionClient

--- a/core/transfer/registry/registry.go
+++ b/core/transfer/registry/registry.go
@@ -93,6 +93,7 @@ func NewOCIRegistry(ctx context.Context, ref string, opts ...Opt) (*OCIRegistry,
 			return nil, err
 		}
 	}
+
 	hostOptions := config.HostOptions{}
 	if ropts.hostDir != "" {
 		hostOptions.HostDir = config.HostDirFromRoot(ropts.hostDir)
@@ -111,10 +112,12 @@ func NewOCIRegistry(ctx context.Context, ref string, opts ...Opt) (*OCIRegistry,
 	if ropts.defaultScheme != "" {
 		hostOptions.DefaultScheme = ropts.defaultScheme
 	}
+
 	resolver := docker.NewResolver(docker.ResolverOptions{
 		Hosts:   config.ConfigureHosts(ctx, hostOptions),
 		Headers: ropts.headers,
 	})
+
 	return &OCIRegistry{
 		reference:     ref,
 		headers:       ropts.headers,

--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -185,6 +185,7 @@ version = 3
     image_pull_progress_timeout = '5m0s'
     image_pull_with_sync_fs = false
     stats_collect_period = 10
+    use_local_image_pull = false
 
     [plugins.'io.containerd.cri.v1.images'.pinned_images]
       sandbox = 'registry.k8s.io/pause:3.10'
@@ -329,22 +330,14 @@ version = 2
   tolerate_missing_hugetlb_controller = true
 
   # ignore_image_defined_volumes ignores volumes defined by the image. Useful for better resource
-	# isolation, security and early detection of issues in the mount configuration when using
-	# ReadOnlyRootFilesystem since containers won't silently mount a temporary volume.
+  # isolation, security and early detection of issues in the mount configuration when using
+  # ReadOnlyRootFilesystem since containers won't silently mount a temporary volume.
   ignore_image_defined_volumes = false
 
   # netns_mounts_under_state_dir places all mounts for network namespaces under StateDir/netns
   # instead of being placed under the hardcoded directory /var/run/netns. Changing this setting
   # requires that all containers are deleted.
   netns_mounts_under_state_dir = false
-
-  # 'plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming' contains a x509 valid key pair to stream with tls.
-  [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
-    # tls_cert_file is the filepath to the certificate paired with the "tls_key_file"
-    tls_cert_file = ""
-
-    # tls_key_file is the filepath to the private key paired with the "tls_cert_file"
-    tls_key_file = ""
 
   # max_container_log_line_size is the maximum log line size in bytes for a container.
   # Log line longer than the limit will be split into multiple lines. -1 means no
@@ -419,6 +412,14 @@ version = 2
   #
   # For example, the value can be '5h', '2h30m', '10s'.
   drain_exec_sync_io_timeout = "0s"
+
+  # 'plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming' contains a x509 valid key pair to stream with tls.
+  [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
+    # tls_cert_file is the filepath to the certificate paired with the "tls_key_file"
+    tls_cert_file = ""
+
+    # tls_key_file is the filepath to the private key paired with the "tls_cert_file"
+    tls_key_file = ""
 
   # 'plugins."io.containerd.grpc.v1.cri".containerd' contains config related to containerd
   [plugins."io.containerd.grpc.v1.cri".containerd]

--- a/integration/build_local_containerd_helper_test.go
+++ b/integration/build_local_containerd_helper_test.go
@@ -55,6 +55,7 @@ import (
 	_ "github.com/containerd/containerd/v2/plugins/services/snapshots"
 	_ "github.com/containerd/containerd/v2/plugins/services/tasks"
 	_ "github.com/containerd/containerd/v2/plugins/services/version"
+	_ "github.com/containerd/containerd/v2/plugins/transfer"
 
 	"github.com/stretchr/testify/require"
 )

--- a/integration/build_local_containerd_helper_test_linux.go
+++ b/integration/build_local_containerd_helper_test_linux.go
@@ -18,7 +18,9 @@ package integration
 
 import (
 	// Register for linux platforms
+	_ "github.com/containerd/containerd/v2/plugins/imageverifier"    // WithInMemoryServices will fail otherwise
 	_ "github.com/containerd/containerd/v2/plugins/sandbox"          // WithInMemoryServices will fail otherwise
 	_ "github.com/containerd/containerd/v2/plugins/services/sandbox" // WithInMemoryServices will fail otherwise
 	_ "github.com/containerd/containerd/v2/plugins/snapshots/overlay/plugin"
+	_ "github.com/containerd/containerd/v2/plugins/streaming" // WithInMemoryServices will fail otherwise
 )

--- a/integration/client/restart_monitor_test.go
+++ b/integration/client/restart_monitor_test.go
@@ -125,9 +125,9 @@ func TestRestartMonitor(t *testing.T) {
 	)
 
 	configTOML := fmt.Sprintf(`
-version = 2
+version = 3
 [plugins]
-  [plugins."io.containerd.internal.v1.restart"]
+  [plugins."io.containerd.monitor.container.v1.restart"]
 	  interval = "%s"
 `, interval.String())
 	client, _, cleanup := newDaemonWithConfig(t, configTOML)

--- a/internal/cri/server/images/image_pull_test.go
+++ b/internal/cri/server/images/image_pull_test.go
@@ -20,15 +20,18 @@ import (
 	"context"
 	"encoding/base64"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/containerd/platforms"
 
+	"github.com/containerd/containerd/v2/core/transfer"
 	"github.com/containerd/containerd/v2/internal/cri/annotations"
 	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
 	"github.com/containerd/containerd/v2/internal/cri/labels"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func TestParseAuth(t *testing.T) {
@@ -487,6 +490,250 @@ func TestImageGetLabels(t *testing.T) {
 			labels := criService.getLabels(context.Background(), tt.pullImageName)
 			assert.Equal(t, tt.expectedLabel, labels)
 
+		})
+	}
+}
+
+func TestTransferProgressReporter(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		setup    func(*transferProgressReporter) chan struct{}
+		progress []transfer.Progress
+		check    func(*testing.T, *transferProgressReporter, <-chan struct{})
+	}{
+		{
+			name: "PullImageWithCompleteEvent",
+			progress: []transfer.Progress{
+				{
+					Name: "layer1",
+					Desc: &ocispec.Descriptor{
+						MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+						Digest:    "sha256:abcdef",
+						Size:      1000,
+					},
+					Total:    1000,
+					Progress: 500,
+					Event:    "downloading",
+				},
+				{
+					Name: "layer1",
+					Desc: &ocispec.Descriptor{
+						MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+						Digest:    "sha256:abcdef",
+						Size:      1000,
+					},
+					Total:    1000,
+					Progress: 1000,
+					Event:    "complete",
+				},
+			},
+			check: func(t *testing.T, r *transferProgressReporter, cancelCalled <-chan struct{}) {
+				activeReqs, totalBytesRead := r.reqReporter.status()
+				assert.Equal(t, int32(0), activeReqs, "Expected 0 active requests")
+				assert.Equal(t, uint64(1000), totalBytesRead, "Expected 1000 bytes read")
+			},
+		},
+		{
+			name: "FinishedDownloadingWithNoCompleteEvent",
+			progress: []transfer.Progress{
+				{
+					Name: "layer1",
+					Desc: &ocispec.Descriptor{
+						MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+						Digest:    "sha256:abcdef",
+						Size:      1000,
+					},
+					Total:    1000,
+					Progress: 500,
+					Event:    "downloading",
+				},
+				{
+					Name: "layer1",
+					Desc: &ocispec.Descriptor{
+						MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+						Digest:    "sha256:abcdef",
+						Size:      1000,
+					},
+					Total:    1000,
+					Progress: 1000,
+					Event:    "downloading",
+				},
+			},
+			check: func(t *testing.T, r *transferProgressReporter, cancelCalled <-chan struct{}) {
+				activeReqs, totalBytesRead := r.reqReporter.status()
+				assert.Equal(t, int32(0), activeReqs, "Expected 0 active requests")
+				assert.Equal(t, uint64(1000), totalBytesRead, "Expected 1000 bytes read")
+			},
+		},
+		{
+			name: "NilDescriptorInProgressNode",
+			progress: []transfer.Progress{
+				{
+					Name:     "layer1",
+					Total:    1000,
+					Progress: 500,
+					Event:    "downloading",
+				},
+			},
+			check: func(t *testing.T, r *transferProgressReporter, cancelCalled <-chan struct{}) {
+				assert.Equal(t, int32(0), r.reqReporter.activeReqs, "Expected zero active request")
+				assert.Equal(t, uint64(0), r.reqReporter.totalBytesRead, "Expected zero bytes read")
+			},
+		},
+		{
+			name: "EmptyTotalInProgressNode",
+			progress: []transfer.Progress{
+				{
+					Name: "layer1",
+					Desc: &ocispec.Descriptor{
+						MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+						Digest:    "sha256:abcdef",
+						Size:      1000,
+					},
+					Total:    0,
+					Progress: 500,
+					Event:    "downloading",
+				},
+			},
+			check: func(t *testing.T, r *transferProgressReporter, cancelCalled <-chan struct{}) {
+				activeReqs, totalBytesRead := r.reqReporter.status()
+				assert.Equal(t, int32(0), activeReqs, "Expected zero active request")
+				assert.Equal(t, uint64(0), totalBytesRead, "Expected zero bytes read")
+			},
+		},
+		{
+			name: "TimeoutDuringPull",
+			setup: func(r *transferProgressReporter) chan struct{} {
+				r.timeout = 100 * time.Millisecond
+
+				cancelCalled := make(chan struct{})
+				originalCancel := r.cancel
+				r.cancel = func() {
+					originalCancel()
+					close(cancelCalled)
+				}
+
+				return cancelCalled
+			},
+			progress: []transfer.Progress{
+				{
+					Name: "layer1",
+					Desc: &ocispec.Descriptor{
+						MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+						Digest:    "sha256:abcdef",
+						Size:      1000,
+					},
+					Total:    1000,
+					Progress: 500,
+					Event:    "downloading",
+				},
+				{
+					Name: "layer1",
+					Desc: &ocispec.Descriptor{
+						MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+						Digest:    "sha256:abcdef",
+						Size:      1000,
+					},
+					Total:    1000,
+					Progress: 500,
+					Event:    "downloading",
+				},
+				{
+					Name: "layer1",
+					Desc: &ocispec.Descriptor{
+						MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+						Digest:    "sha256:abcdef",
+						Size:      1000,
+					},
+					Total:    1000,
+					Progress: 500,
+					Event:    "downloading",
+				},
+			},
+			check: func(t *testing.T, r *transferProgressReporter, cancelCalled <-chan struct{}) {
+				select {
+				case <-cancelCalled:
+					// Expected behavior: cancel was called
+				case <-time.After(150 * time.Millisecond):
+					t.Error("Cancel function was not called within the expected timeframe")
+				}
+			},
+		},
+		{
+			name: "MultipleRequests",
+			progress: []transfer.Progress{
+				{
+					Name: "layer1",
+					Desc: &ocispec.Descriptor{
+						MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+						Digest:    "sha256:abcdef1",
+						Size:      1000,
+					},
+					Total:    1000,
+					Progress: 500,
+					Event:    "downloading",
+				},
+				{
+					Name: "layer2",
+					Desc: &ocispec.Descriptor{
+						MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+						Digest:    "sha256:abcdef2",
+						Size:      2000,
+					},
+					Total:    2000,
+					Progress: 1000,
+					Event:    "downloading",
+				},
+				{
+					Name: "layer1",
+					Desc: &ocispec.Descriptor{
+						MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+						Digest:    "sha256:abcdef1",
+						Size:      1000,
+					},
+					Total:    1000,
+					Progress: 1000,
+					Event:    "complete",
+				},
+			},
+			check: func(t *testing.T, r *transferProgressReporter, cancelCalled <-chan struct{}) {
+				activeReqs, totalBytesRead := r.reqReporter.status()
+				assert.Equal(t, int32(1), activeReqs, "Expected one active request")
+				assert.Equal(t, uint64(2000), totalBytesRead, "Expected 2000 bytes read")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			reporter := &transferProgressReporter{
+				reqReporter: pullRequestReporter{},
+				pc:          make(chan transfer.Progress),
+				statuses:    make(map[string]*transfer.Progress),
+				ref:         "test-image:latest",
+				timeout:     30 * time.Second,
+				cancel:      cancel,
+			}
+
+			var cancelCalled chan struct{}
+			if tt.setup != nil {
+				cancelCalled = tt.setup(reporter)
+			}
+
+			go reporter.start(ctx)
+
+			for _, progress := range tt.progress {
+				reporter.pc <- progress
+				time.Sleep(50 * time.Millisecond) // Allow some time for processing
+			}
+
+			if tt.check != nil {
+				tt.check(t, reporter, cancelCalled)
+			}
 		})
 	}
 }

--- a/internal/cri/server/images/service.go
+++ b/internal/cri/server/images/service.go
@@ -24,16 +24,17 @@ import (
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/core/transfer"
 	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
 	imagestore "github.com/containerd/containerd/v2/internal/cri/store/image"
 	snapshotstore "github.com/containerd/containerd/v2/internal/cri/store/snapshot"
 	"github.com/containerd/containerd/v2/internal/kmutex"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
+
 	docker "github.com/distribution/reference"
 	imagedigest "github.com/opencontainers/go-digest"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
-
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -65,6 +66,8 @@ type CRIImageService struct {
 	imageStore *imagestore.Store
 	// snapshotStore stores information of all snapshots.
 	snapshotStore *snapshotstore.Store
+	// transferrer is used to pull image with transfer service
+	transferrer transfer.Transferrer
 	// unpackDuplicationSuppressor is used to make sure that there is only
 	// one in-flight fetch request or unpack handler for a given descriptor's
 	// or chain ID.
@@ -87,6 +90,8 @@ type CRIImageServiceOptions struct {
 	Snapshotters map[string]snapshots.Snapshotter
 
 	Client imageClient
+
+	Transferrer transfer.Transferrer
 }
 
 // NewService creates a new CRI Image Service
@@ -108,6 +113,7 @@ func NewService(config criconfig.ImageConfig, options *CRIImageServiceOptions) (
 		imageFSPaths:                options.ImageFSPaths,
 		runtimePlatforms:            options.RuntimePlatforms,
 		snapshotStore:               snapshotstore.NewStore(),
+		transferrer:                 options.Transferrer,
 		unpackDuplicationSuppressor: kmutex.New(),
 	}
 

--- a/plugins/transfer/plugin.go
+++ b/plugins/transfer/plugin.go
@@ -140,6 +140,11 @@ func init() {
 					return nil, fmt.Errorf("no matching diff plugins: %w", errdefs.ErrNotFound)
 				}
 
+				// If CheckPlatformSupported is false, we will match all platforms
+				if !config.CheckPlatformSupported {
+					target = platforms.All
+				}
+
 				up := unpack.Platform{
 					Platform:           target,
 					SnapshotterKey:     uc.Snapshotter,
@@ -163,6 +168,9 @@ type transferConfig struct {
 	// MaxConcurrentUploadedLayers is the max concurrent uploads for push
 	MaxConcurrentUploadedLayers int `toml:"max_concurrent_uploaded_layers"`
 
+	// CheckPlatformSupported enables platform check specified in UnpackConfiguration
+	CheckPlatformSupported bool `toml:"check_platform_supported"`
+
 	// UnpackConfiguration is used to read config from toml
 	UnpackConfiguration []unpackConfiguration `toml:"unpack_config,omitempty"`
 
@@ -185,5 +193,6 @@ func defaultConfig() *transferConfig {
 	return &transferConfig{
 		MaxConcurrentDownloads:      3,
 		MaxConcurrentUploadedLayers: 3,
+		CheckPlatformSupported:      false,
 	}
 }

--- a/plugins/types.go
+++ b/plugins/types.go
@@ -29,7 +29,7 @@ const (
 	RuntimePlugin plugin.Type = "io.containerd.runtime.v1"
 	// RuntimePluginV2 implements a runtime v2
 	RuntimePluginV2 plugin.Type = "io.containerd.runtime.v2"
-	// ServicePlugin implements a internal service
+	// ServicePlugin implements an internal service
 	ServicePlugin plugin.Type = "io.containerd.service.v1"
 	// GRPCPlugin implements a grpc service
 	GRPCPlugin plugin.Type = "io.containerd.grpc.v1"
@@ -55,7 +55,7 @@ const (
 	LeasePlugin plugin.Type = "io.containerd.lease.v1"
 	// StreamingPlugin implements a stream manager
 	StreamingPlugin plugin.Type = "io.containerd.streaming.v1"
-	// TracingProcessorPlugin implements a open telemetry span processor
+	// TracingProcessorPlugin implements an open telemetry span processor
 	TracingProcessorPlugin plugin.Type = "io.containerd.tracing.processor.v1"
 	// NRIApiPlugin implements the NRI adaptation interface for containerd.
 	NRIApiPlugin plugin.Type = "io.containerd.nri.v1"


### PR DESCRIPTION
This PR is to update CRI to optionally use transfer service for image pull.  

Part of #8227 

1. Create a new CRI config `ImagePullWithTransferService` to specify whether to use transfer service for image pull
2. Move CRI image pull related configs to server side, i.e. transfer service. 


The PR is still in progress, put out to for early review and utilize CI for integration tests. 
