### PR TITLE
cri: validate if sandbox task is in correct state during creating container

### DIFF
--- a/pkg/cri/server/container_create.go
+++ b/pkg/cri/server/container_create.go
@@ -60,6 +60,16 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	if err != nil {
 		return nil, fmt.Errorf("failed to get sandbox container task: %w", err)
 	}
+
+	// Validate if the sandbox task is in correct state in case that its pid is ZERO.
+	ss, err := s.Status(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get status of sandbox container task: %w", err)
+	}
+	if ss.Status == containerd.Unknown {
+		return nil, fmt.Errorf("sandbox container task is in wrong state 'unknown'")
+	}
+
 	sandboxPid := s.Pid()
 
 	// Generate unique id and name for the container and reserve the name.


### PR DESCRIPTION
When getting shim's state times out, method `Task()` returns with success and an unknown state task response. The client should be aware of the unknown task state and process the situation very carefully.

If we don't validate the task response, the sandbox task pid is ZERO which is later passed to the business container and requests it to join the namespace like `/proc/0/ns/ipc`

An error message has been caught:
```
306-2d08-4325-b876-79112929737f)"), skipping: failed to "StartContainer" for "cp-cmd" with RunContainerError: "failed to create containerd task: OCI runtime create failed: container_linux.go:364: creating new parent process
s caused: container_linux.go:2005: running lstat on namespace path \"/proc/0/ns/ipc\" caused: lstat /proc/0/ns/ipc: no such file or directory: unknown"
```