### PR TITLE
Bump seccomp version to be the same as one in runc repo

### DIFF
--- a/script/setup/install-seccomp
+++ b/script/setup/install-seccomp
@@ -22,7 +22,7 @@ set -eu -o pipefail
 
 set -x
 
-export SECCOMP_VERSION=2.5.1
+export SECCOMP_VERSION=2.5.4
 SECCOMP_PATH=$(mktemp -d)
 export SECCOMP_PATH
 curl -fsSL "https://github.com/seccomp/libseccomp/releases/download/v${SECCOMP_VERSION}/libseccomp-${SECCOMP_VERSION}.tar.gz" | tar -xzC "$SECCOMP_PATH" --strip-components=1


### PR DESCRIPTION
Looks like the runc folks bumped almost a year ago

- https://github.com/search?q=repo%3Aopencontainers%2Frunc%202.5.4&type=code
- https://github.com/opencontainers/runc/pull/3481/files

Context: query on slack - https://cloud-native.slack.com/archives/CGEQHPYF4/p1684243817550399