### PR TITLE
Fix image workflow

### DIFF
--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -144,7 +144,7 @@ jobs:
           scp -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.PUBLIC_IP }}:/Users/azureuser/.docker/key.pem $HOME/.docker/key.pem
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -9,7 +9,7 @@ on:
       azure_windows_image_id:
         description: Windows image URN to deploy
         required: true
-        default: MicrosoftWindowsServer:WindowsServer:2022-datacenter:20348.350.2111030009
+        default: MicrosoftWindowsServer:WindowsServer:2022-datacenter:latest
       azure_vm_size:
         description: Windows image builder VM size
         required: true

--- a/integration/images/volume-copy-up/Makefile
+++ b/integration/images/volume-copy-up/Makefile
@@ -81,7 +81,7 @@ sub-container-%:
 container: .container-${OS}-$(ARCH)
 
 .container-linux-$(ARCH):
-	docker buildx build --pull --output=type=${OUTPUT_TYPE} --platform ${OS}/${ARCH} \
+	docker buildx build --provenance=false --pull --output=type=${OUTPUT_TYPE} --platform ${OS}/${ARCH} \
 		-t $(IMAGE)-${OS}-${ARCH} --build-arg BASE=${BASE} .
 
 .container-windows-$(ARCH):

--- a/integration/images/volume-ownership/Makefile
+++ b/integration/images/volume-ownership/Makefile
@@ -87,7 +87,7 @@ sub-container-%:
 container: .container-${OS}-$(ARCH)
 
 .container-linux-$(ARCH):
-	docker buildx build --pull --output=type=${OUTPUT_TYPE} --platform ${OS}/${ARCH} \
+	docker buildx build --provenance=false --pull --output=type=${OUTPUT_TYPE} --platform ${OS}/${ARCH} \
 		-t $(IMAGE)-${OS}-${ARCH} --build-arg BASE=${BASE} .
 
 .container-windows-$(ARCH):


### PR DESCRIPTION
This change updates the default windows image SKU used to the ```latest``` tag. This should always be around, and should be regularly updated to something close to the actual latest image available. For generating images, the ```latest``` tag should be safe to use.

We also disable provenance. See: https://github.com/docker/buildx/issues/1509#issuecomment-1378454396 

One important note before triggering this workflow. Github has introduced a new permissions system for ```ghcr.io```. Before running this workflow, someone with write access to the repo will have to navigate to https://ghcr.io/containerd/volume-copy-up and https://ghcr.io/containerd/volume-ownership and click on ```Package settings``` on the right hand side. Once there, under ```Actions repository access```, you will need to add ```containerd/containerd``` as a repository, with ```write``` access.