### PR TITLE
feat: grace terminating period for cri requests

### DIFF
--- a/content/local/store_unix.go
+++ b/content/local/store_unix.go
@@ -20,8 +20,14 @@ package local
 
 import (
 	"os"
+	"sync"
 	"syscall"
 	"time"
+)
+
+var (
+	// FlyingReqWg for grace-termination
+	FlyingReqWg sync.WaitGroup
 )
 
 func getATime(fi os.FileInfo) time.Time {

--- a/pkg/grpc/interceptor/flyingrequest.go
+++ b/pkg/grpc/interceptor/flyingrequest.go
@@ -1,0 +1,65 @@
+package interceptor
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"regexp"
+	"sync"
+
+	"google.golang.org/grpc"
+)
+
+var SoftBypassNewReq bool
+
+const (
+	// as "/runtime.v1alpha2.RuntimeService/StopPodSandbox"
+	CriDistinctString = `^/runtime\.(.+)\.RuntimeService`
+)
+
+var reg *regexp.Regexp
+
+func init() {
+	reg = regexp.MustCompile(CriDistinctString)
+}
+
+// RequestCountDecider is a user-provided function for deciding whether count a request is flying.
+type RequestCountDecider func(ctx context.Context, fullMethodName string, servingObject interface{}) bool
+
+// FlyingRequestCountInterceptor returns a new unary server interceptors that counts the flying requests.
+func FlyingRequestCountInterceptor(decider RequestCountDecider, wq *sync.WaitGroup) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		if SoftBypassNewReq && findoutCriRequest(info.FullMethod) {
+			return nil, fmt.Errorf("service entering lame duck status,all request will bypass")
+		}
+		if decider(ctx, info.FullMethod, info.Server) {
+			wq.Add(1)
+			defer wq.Done()
+		}
+		resp, err := handler(ctx, req)
+		return resp, err
+	}
+}
+
+func FlyingReqCountDecider(ctx context.Context, fullMethodName string, servingObject interface{}) bool {
+	methodName := path.Base(fullMethodName)
+	switch methodName {
+	case
+		"RunPodSandbox",
+		"StartPodSandbox",
+		"StopPodSandbox",
+		"RemovePodSandbox",
+		"CreateContainer",
+		"StartContainer",
+		"StopContainer",
+		"RemoveContainer",
+		"PauseContainer",
+		"UnpauseContainer":
+		return true
+	default:
+		return false
+	}
+}
+func findoutCriRequest(fullMethodName string) bool {
+	return reg.MatchString(fullMethodName)
+}

--- a/services/server/server.go
+++ b/services/server/server.go
@@ -44,6 +44,7 @@ import (
 	"github.com/containerd/containerd/events/exchange"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/pkg/dialer"
+	"github.com/containerd/containerd/pkg/grpc/interceptor"
 	"github.com/containerd/containerd/pkg/timeout"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/plugin"
@@ -131,6 +132,7 @@ func New(ctx context.Context, config *srvconfig.Config) (*Server, error) {
 			otelgrpc.UnaryServerInterceptor(),
 			grpc_prometheus.UnaryServerInterceptor,
 			unaryNamespaceInterceptor,
+			interceptor.FlyingRequestCountInterceptor(interceptor.FlyingReqCountDecider, &local.FlyingReqWg),
 		)),
 	}
 	if config.GRPC.MaxRecvMsgSize > 0 {


### PR DESCRIPTION
Add configurable timeout for graceful cri shutdown. flying cri requests will be dumped after configured timeout