### PR TITLE
Enable to configure overlayfs volatile mount option within CRI client

### DIFF
--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -113,6 +113,9 @@ type ContainerdConfig struct {
 	// IgnoreRdtNotEnabledErrors is a boolean flag to ignore RDT related errors
 	// when RDT support has not been enabled.
 	IgnoreRdtNotEnabledErrors bool `toml:"ignore_rdt_not_enabled_errors" json:"ignoreRdtNotEnabledErrors"`
+
+	// Enable volatile for overlayfs snapshotter
+	OverlayFsVolatile bool `toml:"overlayfs_volatile" json:"overlayFsVolatile"`
 }
 
 // CniConfig contains toml config related to cni

--- a/pkg/cri/sbserver/rootfs.go
+++ b/pkg/cri/sbserver/rootfs.go
@@ -1,0 +1,67 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package sbserver
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/snapshots"
+	"github.com/opencontainers/selinux/go-selinux/label"
+)
+
+func setupContainerRootfs(ctx context.Context, container containerd.Container, s snapshots.Snapshotter) ([]mount.Mount, error) {
+	ci, err := container.Info(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if ci.SnapshotKey != "" {
+		if ci.Snapshotter == "" {
+			return nil, fmt.Errorf("unable to resolve rootfs mounts without snapshotter on container: %w", errdefs.ErrInvalidArgument)
+		}
+
+		mounts, err := s.Mounts(ctx, ci.SnapshotKey)
+		if err != nil {
+			return nil, err
+		}
+		spec, err := container.Spec(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for i, m := range mounts {
+			if spec.Linux != nil && spec.Linux.MountLabel != "" {
+				context := label.FormatMountLabel("", spec.Linux.MountLabel)
+				if context != "" {
+					m.Options = append(m.Options, context)
+				}
+			}
+
+			// Add volatile option here, it should be the safest place doing this.
+			if m.Type == "overlay" {
+				mounts[i].Options = append(m.Options, "volatile")
+			}
+		}
+
+		return mounts, nil
+	}
+
+	return nil, errdefs.ErrInvalidArgument
+}

--- a/pkg/cri/server/container_start.go
+++ b/pkg/cri/server/container_start.go
@@ -118,6 +118,15 @@ func (c *criService) StartContainer(ctx context.Context, r *runtime.StartContain
 	if ociRuntime.Path != "" {
 		taskOpts = append(taskOpts, containerd.WithRuntimePath(ociRuntime.Path))
 	}
+
+	if c.config.ContainerdConfig.OverlayFsVolatile {
+		mounts, err := setupContainerRootfs(ctx, container, c.client.SnapshotService(info.Snapshotter))
+		if err != nil {
+			return nil, fmt.Errorf("failed to set up rootfs: %w", err)
+		}
+		taskOpts = append(taskOpts, containerd.WithRootFS(mounts))
+	}
+
 	task, err := container.NewTask(ctx, ioCreation, taskOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create containerd task: %w", err)

--- a/pkg/cri/server/rootfs.go
+++ b/pkg/cri/server/rootfs.go
@@ -1,0 +1,67 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/snapshots"
+	"github.com/opencontainers/selinux/go-selinux/label"
+)
+
+func setupContainerRootfs(ctx context.Context, container containerd.Container, s snapshots.Snapshotter) ([]mount.Mount, error) {
+	ci, err := container.Info(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if ci.SnapshotKey != "" {
+		if ci.Snapshotter == "" {
+			return nil, fmt.Errorf("unable to resolve rootfs mounts without snapshotter on container: %w", errdefs.ErrInvalidArgument)
+		}
+
+		mounts, err := s.Mounts(ctx, ci.SnapshotKey)
+		if err != nil {
+			return nil, err
+		}
+		spec, err := container.Spec(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for i, m := range mounts {
+			if spec.Linux != nil && spec.Linux.MountLabel != "" {
+				context := label.FormatMountLabel("", spec.Linux.MountLabel)
+				if context != "" {
+					m.Options = append(m.Options, context)
+				}
+			}
+
+			// Add volatile option here, it should be the safest place doing this.
+			if m.Type == "overlay" {
+				mounts[i].Options = append(m.Options, "volatile")
+			}
+		}
+
+		return mounts, nil
+	}
+
+	return nil, errdefs.ErrInvalidArgument
+}

--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -352,6 +352,15 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		id, name)
 
 	var taskOpts []containerd.NewTaskOpts
+
+	if c.config.ContainerdConfig.OverlayFsVolatile {
+		mounts, err := setupContainerRootfs(ctx, container, c.client.SnapshotService(info.Snapshotter))
+		if err != nil {
+			return nil, fmt.Errorf("failed to set up sandbox rootfs: %w", err)
+		}
+		taskOpts = append(taskOpts, containerd.WithRootFS(mounts))
+	}
+
 	if ociRuntime.Path != "" {
 		taskOpts = append(taskOpts, containerd.WithRuntimePath(ociRuntime.Path))
 	}


### PR DESCRIPTION
We already had several discussions about enabling overlayfs mount option `volatile` which skips `fssync` against upperdir's file system. The benefit of taking the overlayfs feature in was clearly stated in those discussions.
https://github.com/containerd/containerd/pull/4785
https://github.com/containerd/containerd/issues/6406

Compared with the aforementioned proposals, this solution is more granular and tries to encapsulate the feature only in CRI.
It makes CRI capable of setting up rootfs by itself thus it has a chance to tweak snapshots mounts options and it does not need to change snapshotter's behavior.

Fortunately, containerd's container API allows the client to specify rootfs(mounts slice) when `StartContainer`.

As the rootfs is passed within TaskCreate request to shim who actually mounts the filesystem as rootfs, I suppose it's pretty safe for other critical parts in containerd's core service.

We already convert all temp mounts to "no-upperdir" mounts. Those temp mounts won't result in `fssync`.

The UI is to add a new configuration entry for CRI plugin
```toml
[plugins."io.containerd.grpc.v1.cri".containerd]
overlayfs_volatile = true
```

In the future, if any KEP comes up with enabling certain pod to be marked as `volatile`, we can extend this feature to make it only work for certain pods on the node.