### PR TITLE
feat: make overlay sync removal configurable

### DIFF
--- a/snapshots/overlay/plugin/plugin.go
+++ b/snapshots/overlay/plugin/plugin.go
@@ -31,6 +31,7 @@ type Config struct {
 	// Root directory for the plugin
 	RootPath      string `toml:"root_path"`
 	UpperdirLabel bool   `toml:"upperdir_label"`
+	SyncRemove    bool   `toml:"sync_remove"`
 }
 
 func init() {
@@ -55,9 +56,12 @@ func init() {
 			if config.UpperdirLabel {
 				oOpts = append(oOpts, overlay.WithUpperdirLabel)
 			}
+			if !config.SyncRemove {
+				oOpts = append(oOpts, overlay.AsynchronousRemove)
+			}
 
 			ic.Meta.Exports["root"] = root
-			return overlay.NewSnapshotter(root, append(oOpts, overlay.AsynchronousRemove)...)
+			return overlay.NewSnapshotter(root, oOpts...)
 		},
 	})
 }


### PR DESCRIPTION
currently overlayfs will by default use asyncRemoval for background data, maybe make it configurable when disk usage is sensitive.