### PR TITLE
[sandbox] Optimize metadata Schema notes to correctly match metadata structures

### DIFF
--- a/metadata/buckets.go
+++ b/metadata/buckets.go
@@ -54,72 +54,86 @@
 //
 //   - a namespace in a schema bucket cannot be named "version"
 //
-//     └──v1                                        - Schema version bucket
-//     ├──version : <varint>                     - Latest version, see migrations
-//     ╘══*namespace*
-//     ├──labels
-//     │  ╘══*key* : <string>                 - Label value
-//     ├──image
-//     │  ╘══*image name*
-//     │     ├──createdat : <binary time>     - Created at
-//     │     ├──updatedat : <binary time>     - Updated at
-//     │     ├──target
-//     │     │  ├──digest : <digest>          - Descriptor digest
-//     │     │  ├──mediatype : <string>       - Descriptor media type
-//     │     │  └──size : <varint>            - Descriptor size
-//     │     └──labels
-//     │        ╘══*key* : <string>           - Label value
-//     ├──containers
-//     │  ╘══*container id*
-//     │     ├──createdat : <binary time>     - Created at
-//     │     ├──updatedat : <binary time>     - Updated at
-//     │     ├──spec : <binary>               - Proto marshaled spec
-//     │     ├──image : <string>              - Image name
-//     │     ├──snapshotter : <string>        - Snapshotter name
-//     │     ├──snapshotKey : <string>        - Snapshot key
-//     │     ├──runtime
-//     │     │  ├──name : <string>            - Runtime name
-//     │     │  ├──extensions
-//     │     │  │  ╘══*name* : <binary>       - Proto marshaled extension
-//     │     │  └──options : <binary>         - Proto marshaled options
-//     │     └──labels
-//     │        ╘══*key* : <string>           - Label value
-//     ├──snapshots
-//     │  ╘══*snapshotter*
-//     │     ╘══*snapshot key*
-//     │        ├──name : <string>            - Snapshot name in backend
-//     │        ├──createdat : <binary time>  - Created at
-//     │        ├──updatedat : <binary time>  - Updated at
-//     │        ├──parent : <string>          - Parent snapshot name
-//     │        ├──children
-//     │        │  ╘══*snapshot key* : <nil>  - Child snapshot reference
-//     │        └──labels
-//     │           ╘══*key* : <string>        - Label value
-//     ├──content
-//     │  ├──blob
-//     │  │  ╘══*blob digest*
-//     │  │     ├──createdat : <binary time>  - Created at
-//     │  │     ├──updatedat : <binary time>  - Updated at
-//     │  │     ├──size : <varint>            - Blob size
-//     │  │     └──labels
-//     │  │        ╘══*key* : <string>        - Label value
-//     │  └──ingests
-//     │     ╘══*ingest reference*
-//     │        ├──ref : <string>             - Ingest reference in backend
-//     │        ├──expireat : <binary time>   - Time to expire ingest
-//     │        └──expected : <digest>        - Expected commit digest
-//     └──leases
-//     ╘══*lease id*
-//     ├──createdat : <binary time>     - Created at
-//     ├──labels
-//     │  ╘══*key* : <string>           - Label value
-//     ├──snapshots
-//     │  ╘══*snapshotter*
-//     │     ╘══*snapshot key* : <nil>  - Snapshot reference
-//     ├──content
-//     │  ╘══*blob digest* : <nil>      - Content blob reference
-//     └──ingests
-//     ╘══*ingest reference* : <nil> - Content ingest reference
+/*
+ └──v1                                        - Schema version bucket
+    ├──version : <varint>                     - Latest version, see migrations
+    ╘══*namespace*
+	  ├──labels
+	  │  ╘══*key* : <string>                 - Label value
+	  ├──image
+	  │  ╘══*image name*
+	  │     ├──createdat : <binary time>     - Created at
+	  │     ├──updatedat : <binary time>     - Updated at
+	  │     ├──target
+	  │     │  ├──digest : <digest>          - Descriptor digest
+	  │     │  ├──mediatype : <string>       - Descriptor media type
+	  │     │  └──size : <varint>            - Descriptor size
+	  │     └──labels
+	  │        ╘══*key* : <string>           - Label value
+	  ├──containers
+	  │  ╘══*container id*
+	  │     ├──createdat : <binary time>     - Created at
+	  │     ├──updatedat : <binary time>     - Updated at
+	  │     ├──spec : <binary>               - Proto marshaled spec
+	  │     ├──image : <string>              - Image name
+	  │     ├──snapshotter : <string>        - Snapshotter name
+	  │     ├──snapshotKey : <string>        - Snapshot key
+	  │     ├──runtime
+	  │     │  ├──name : <string>            - Runtime name
+	  │     │  └──options : <binary>         - Proto marshaled options
+	  │     ├──extensions
+	  │     │     ╘══*name* : <binary>       - Proto marshaled extension
+	  │     └──labels
+	  │        ╘══*key* : <string>           - Label value
+	  ├──snapshots
+	  │  ╘══*snapshotter*
+	  │     ╘══*snapshot key*
+	  │        ├──name : <string>            - Snapshot name in backend
+	  │        ├──createdat : <binary time>  - Created at
+	  │        ├──updatedat : <binary time>  - Updated at
+	  │        ├──parent : <string>          - Parent snapshot name
+	  │        ├──children
+	  │        │  ╘══*snapshot key* : <nil>  - Child snapshot reference
+	  │        └──labels
+	  │           ╘══*key* : <string>        - Label value
+	  ├──content
+	  │  ├──blob
+	  │  │  ╘══*blob digest*
+	  │  │     ├──createdat : <binary time>  - Created at
+	  │  │     ├──updatedat : <binary time>  - Updated at
+	  │  │     ├──size : <varint>            - Blob size
+	  │  │     └──labels
+	  │  │        ╘══*key* : <string>        - Label value
+	  │  └──ingests
+	  │     ╘══*ingest reference*
+	  │        ├──ref : <string>             - Ingest reference in backend
+	  │        ├──expireat : <binary time>   - Time to expire ingest
+	  │        └──expected : <digest>        - Expected commit digest
+	  ├──sandboxes
+	  │  ╘══*sandbox id*
+	  │     ├──createdat : <binary time>     - Created at
+	  │     ├──updatedat : <binary time>     - Updated at
+	  │     ├──spec : <binary>               - Proto marshaled spec
+	  │     ├──runtime
+	  │     │  ├──name : <string>            - Runtime name
+	  │     │  └──options : <binary>         - Proto marshaled options
+	  │     ├──extensions
+	  │     │  ╘══*name* : <binary>       - Proto marshaled extension
+	  │     └──labels
+	  │        ╘══*key* : <string>           - Label value
+	  └──leases
+	     ╘══*lease id*
+	         ├──createdat : <binary time>     - Created at
+	         ├──labels
+	         │  ╘══*key* : <string>           - Label value
+	         ├──snapshots
+	         │  ╘══*snapshotter*
+	         │     ╘══*snapshot key* : <nil>  - Snapshot reference
+	         ├──content
+	         │  ╘══*blob digest* : <nil>      - Content blob reference
+	         └─────ingests
+	               ╘══*ingest reference* : <nil> - Content ingest reference
+*/
 package metadata
 
 import (


### PR DESCRIPTION
Related Sandbox API #6703 and some optimization

1. Add sandboxes object
2. Optimize indentation of parent and child objects
3. replace `//` to `/* ..*/` to avoid go fmt