### PR TITLE
Add support for enabling cgroup namespace for legacy and hybrid mode

### DIFF
--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -289,6 +289,11 @@ type PluginConfig struct {
 	// DisableCgroup indicates to disable the cgroup support.
 	// This is useful when the containerd does not have permission to access cgroup.
 	DisableCgroup bool `toml:"disable_cgroup" json:"disableCgroup"`
+	// EnableCgroupNamespace indicates to enable the cgroup namespace in non-unified cgroup mode.
+	// This is useful when containerd is running on a machine with non-unified cgroup.
+	// Note: The cgroup namespace is enabled by default in unified cgroup mode and
+	// was not be affected by this entry. https://github.com/containerd/cri/pull/1371
+	EnableCgroupNamespace bool `toml:"enable_cgroup_namespace" json:"enableCgroupNamespace"`
 	// DisableApparmor indicates to disable the apparmor support.
 	// This is useful when the containerd does not have permission to access Apparmor.
 	DisableApparmor bool `toml:"disable_apparmor" json:"disableApparmor"`

--- a/pkg/cri/sbserver/helpers_linux.go
+++ b/pkg/cri/sbserver/helpers_linux.go
@@ -224,3 +224,7 @@ func modifyProcessLabel(runtimeType string, spec *specs.Spec) error {
 func isUnifiedCgroupsMode() bool {
 	return cgroups.Mode() == cgroups.Unified
 }
+
+func isCgroupsAvailable() bool {
+	return cgroups.Mode() != cgroups.Unavailable
+}

--- a/pkg/cri/sbserver/helpers_other.go
+++ b/pkg/cri/sbserver/helpers_other.go
@@ -45,3 +45,7 @@ func modifyProcessLabel(runtimeType string, spec *specs.Spec) error {
 func isUnifiedCgroupsMode() bool {
 	return false
 }
+
+func isCgroupsAvailable() bool {
+	return false
+}

--- a/pkg/cri/sbserver/helpers_windows.go
+++ b/pkg/cri/sbserver/helpers_windows.go
@@ -170,3 +170,7 @@ func modifyProcessLabel(runtimeType string, spec *specs.Spec) error {
 func isUnifiedCgroupsMode() bool {
 	return false
 }
+
+func isCgroupsAvailable() bool {
+	return false
+}


### PR DESCRIPTION
We now enable the cgroup namespace by default when the machine's cgroup is running in unified mode. But in some situations we hope to be able to enable this feature for `legacy` or `hybrid` mode.

This PR adds a new configuration entry for cri:
```toml
enable_cgroups = true
```
The default is `false` to maintain compatibility.

Note: The cgroup namespace is enabled by default in unified cgroup mode and was not be affected by this entry. https://github.com/containerd/cri/pull/1371