### PR TITLE
Windows Integration: Switch Azure-based CI to vanilla 2019 image.

### DIFF
--- a/.github/workflows/windows-hyperv-periodic.yml
+++ b/.github/workflows/windows-hyperv-periodic.yml
@@ -46,7 +46,7 @@ jobs:
         win_ver: [ltsc2019, ltsc2022]
         include:
         - win_ver: ltsc2019
-          AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2019-Datacenter-with-Containers-smalldisk:17763.4131.230311"
+          AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2019-Datacenter:17763.4377.230505"
           AZURE_RESOURCE_GROUP: ctrd-integration-ltsc2019-${{ github.run_id }}
           GOOGLE_BUCKET: "containerd-integration/logs/windows-ltsc2019-hyperv/"
         - win_ver: ltsc2022
@@ -128,17 +128,14 @@ jobs:
             exit 1
           fi
 
-      - name: InstallAdditionalFeaturesWS2022
-        if: ${{ matrix.win_ver == 'ltsc2022' }}
+      - name: InstallAdditionalFeaturesWS
         run: |
           ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }} "powershell.exe -command { Install-WindowsFeature -Name 'Containers' }"
-          # NOTE(aznashwan): the 2022 image needs Hyper-V to be explicitly enabled:
+          # NOTE(aznashwan): the images need Hyper-V to be explicitly enabled:
           ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }} "powershell.exe -command { Install-WindowsFeature -Name Hyper-V -IncludeAllSubFeature -IncludeManagementTools }"
           ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }} "shutdown.exe /r /t 0"
 
-
       - name: WaitForVMToRestart
-        if: ${{ matrix.win_ver == 'ltsc2022' }}
         timeout-minutes: 5
         run: |
           # give the vm 30 seconds to actually stop. SSH server might actually respond while server is shutting down.
@@ -149,11 +146,16 @@ jobs:
           done
           echo "Connection reestablished. VM restarted succesfully."
 
-      - name: CreateNatNetworkWS2022
-        if: ${{ matrix.win_ver == 'ltsc2022' }}
+      - name: CreateNatNetwork
+        # NOTE: creating the NAT network leads to temporary network outage on 2019 with Hyper-V.
+        continue-on-error: true
         run: |
           ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }} "powershell.exe -command { curl.exe -L 'https://raw.githubusercontent.com/microsoft/SDN/master/Kubernetes/windows/hns.psm1' -o hns.psm1 }"
           ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }} "powershell.exe -command { Import-Module .\hns.psm1 ; New-HnsNetwork -Type NAT -Name nat -AddressPrefix 172.19.208.0/20 -Gateway 172.19.208.1 }"
+
+      - name: EnsureNatNetworkExists
+        run: |
+           ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }} 'powershell.exe -command { Import-Module .\hns.psm1; if ([string]::IsNullOrWhiteSpace($(Get-HnsNetwork -Detailed))) { echo "No HNS network named nat!"; exit 1 } }'
 
       - name: PrepareTestingEnv
         run: |

--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -45,7 +45,7 @@ jobs:
         win_ver: [ltsc2019, ltsc2022]
         include:
         - win_ver: ltsc2019
-          AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2019-Datacenter-with-Containers-smalldisk:17763.4131.230311"
+          AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2019-Datacenter:17763.4377.230505"
           AZURE_RESOURCE_GROUP: ctrd-integration-ltsc2019-${{ github.run_id }}
           GOOGLE_BUCKET: "containerd-integration/logs/windows-ltsc2019/"
         - win_ver: ltsc2022
@@ -128,13 +128,11 @@ jobs:
             exit 1
           fi
 
-      - name: InstallContainerFeatureWS2022
-        if: ${{ matrix.win_ver == 'ltsc2022' }}
+      - name: InstallContainerFeature
         run: |
           ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }} "powershell.exe -command { Install-WindowsFeature -Name 'Containers' -Restart }"
 
       - name: WaitForVMToRestart
-        if: ${{ matrix.win_ver == 'ltsc2022' }}
         timeout-minutes: 5
         run: |
           # give the vm 30 seconds to actually stop. SSH server might actually respond while server is shutting down.
@@ -145,8 +143,7 @@ jobs:
           done
           echo "Connection reestablished. VM restarted succesfully."
 
-      - name: CreateNatNetworkWS2022
-        if: ${{ matrix.win_ver == 'ltsc2022' }}
+      - name: CreateNatNetwork
         run: |
           ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }} "powershell.exe -command { curl.exe -L 'https://raw.githubusercontent.com/microsoft/SDN/master/Kubernetes/windows/hns.psm1' -o hns.psm1 }"
           ssh -i $HOME/.ssh/id_rsa ${{ env.SSH_OPTS }} azureuser@${{ env.VM_PUB_IP }} "powershell.exe -command { Import-Module .\hns.psm1 ; New-HnsNetwork -Type NAT -Name nat -AddressPrefix 172.19.208.0/20 -Gateway 172.19.208.1 }"


### PR DESCRIPTION
This patch switches the Azure-based Windows workflows to using the vanilla `2019-Datacenter` Azure SKU following the deprecation of the old specialized `2019-Datacenter-with-Containers-smalldisk` SKU which was previously used.