### PR TITLE
Pass down runtime options as JSON

### DIFF
--- a/internal/cri/config/config.go
+++ b/internal/cri/config/config.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -773,6 +774,16 @@ func GenerateRuntimeOptions(r Runtime) (interface{}, error) {
 	// For generic configuration, if no config path specified (preserving old behavior), pass
 	// the whole TOML configuration section to the runtime.
 	if runtimeOpts, ok := options.(*runtimeoptions.Options); ok && runtimeOpts.ConfigPath == "" {
+		if runtimeOpts.TypeUrl != "" {
+			body, err := json.Marshal(r.Options)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal config body as JSON for runtime %q: %v", r.Type, err)
+			}
+
+			runtimeOpts.ConfigBody = body
+			return options, nil
+		}
+
 		runtimeOpts.ConfigBody = b
 	}
 

--- a/pkg/runtimeoptions/v1/api.pb.go
+++ b/pkg/runtimeoptions/v1/api.pb.go
@@ -32,8 +32,10 @@ type Options struct {
 	// ConfigPath specifies the filesystem location of the config file
 	// used by the runtime.
 	ConfigPath string `protobuf:"bytes,2,opt,name=config_path,json=configPath,proto3" json:"config_path,omitempty"`
-	// Blob specifies an in-memory TOML blob passed from containerd's configuration section
-	// for this runtime. This will be used if config_path is not specified.
+	// Blob specifies an in-memory blob passed from containerd's configuration section
+	// for this runtime. If the typeurl is specified, this will be a JSON blob which can be
+	// interpreted as the type represented by the typeurl. Otherwise, this will be a TOML
+	// blob. This will be used if config_path is not specified.
 	ConfigBody []byte `protobuf:"bytes,3,opt,name=config_body,json=configBody,proto3" json:"config_body,omitempty"`
 }
 

--- a/pkg/runtimeoptions/v1/api.proto
+++ b/pkg/runtimeoptions/v1/api.proto
@@ -11,7 +11,9 @@ message Options {
 	// ConfigPath specifies the filesystem location of the config file
 	// used by the runtime.
 	string config_path = 2;
-	// Blob specifies an in-memory TOML blob passed from containerd's configuration section
-	// for this runtime. This will be used if config_path is not specified.
+	// Blob specifies an in-memory blob passed from containerd's configuration section
+	// for this runtime. If the typeurl is specified, this will be a JSON blob which can be
+	// interpreted as the type represented by the typeurl. Otherwise, this will be a TOML
+	// blob. This will be used if config_path is not specified.
 	bytes config_body = 3;
 }


### PR DESCRIPTION
Allow generic runtime config options to be passed to the shim as json instead of toml. This allows the use of the typeurl to interpret the runtime options. Addresses issue #8246. 