### PR TITLE
Update default platform matcher when ctr import

### DIFF
--- a/cmd/ctr/commands/images/import.go
+++ b/cmd/ctr/commands/images/import.go
@@ -267,7 +267,7 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 
 			for _, img := range imgs {
 				if platformMatcher == nil { // if platform not specified use default.
-					platformMatcher = platforms.Default()
+					platformMatcher = platforms.DefaultStrict()
 				}
 				image := containerd.NewImageWithPlatform(client, img, platformMatcher)
 


### PR DESCRIPTION
When platorm option was not set, ctr export would use platforms.DefaultStrict() , but ctr import would use platforms.Default(). For x86_64 platform, the matching result is not as expected. I don't think it's reasonable. Therefore, I update default platform matcher when ctr import to platforms.DefaultStrict().
