### PR TITLE
Add mount options to blockfile snapshotter

### DIFF
--- a/snapshots/blockfile/blockfile_loopsetup_test.go
+++ b/snapshots/blockfile/blockfile_loopsetup_test.go
@@ -66,6 +66,8 @@ func setupSnapshotter(t *testing.T) ([]Opt, error) {
 
 	return []Opt{
 		WithScratchFile(scratch),
+		WithFSType("ext4"),
+		WithMountOptions([]string{"loop", "sync"}),
 	}, nil
 }
 

--- a/snapshots/blockfile/plugin/plugin.go
+++ b/snapshots/blockfile/plugin/plugin.go
@@ -34,6 +34,9 @@ type Config struct {
 
 	// FSType is the filesystem type for the mount
 	FSType string `toml:"fs_type"`
+
+	// MountOptions are options used for the mount
+	MountOptions []string `toml:"mount_options"`
 }
 
 func init() {
@@ -59,6 +62,9 @@ func init() {
 			}
 			if config.FSType != "" {
 				opts = append(opts, blockfile.WithFSType(config.FSType))
+			}
+			if len(config.MountOptions) > 0 {
+				opts = append(opts, blockfile.WithMountOptions(config.MountOptions))
 			}
 
 			return blockfile.NewSnapshotter(root, opts...)


### PR DESCRIPTION
Makes the mount options configurable but default to ["loop"]. Allows adding base options for the mounts, such as "sync".