### PR TITLE
use consistent alias for OCI image spec

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ linters:
     - gofmt
     - goimports
     - gosec
+    - importas
     - ineffassign
     - misspell
     - nolintlint
@@ -52,6 +53,14 @@ issues:
       text: "redefines-builtin-id"
 
 linters-settings:
+  importas:
+    # Do not allow unaliased imports of aliased packages.
+    no-unaliased: true
+
+    alias:
+      - pkg: github.com/opencontainers/image-spec/specs-go/v1
+        alias: ocispec
+
   gosec:
     # The following issues surfaced when `gosec` linter
     # was enabled. They are temporarily excluded to unblock

--- a/cmd/ctr/commands/plugins/plugins.go
+++ b/cmd/ctr/commands/plugins/plugins.go
@@ -27,7 +27,7 @@ import (
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/platforms"
 	pluginutils "github.com/containerd/containerd/plugin"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/urfave/cli"
 	"google.golang.org/grpc/codes"
 )
@@ -149,7 +149,7 @@ var listCommand = cli.Command{
 func prettyPlatforms(pspb []*types.Platform) string {
 	psm := map[string]struct{}{}
 	for _, p := range pspb {
-		psm[platforms.Format(v1.Platform{
+		psm[platforms.Format(ocispec.Platform{
 			OS:           p.OS,
 			Architecture: p.Architecture,
 			Variant:      p.Variant,

--- a/container_checkpoint_opts.go
+++ b/container_checkpoint_opts.go
@@ -33,7 +33,7 @@ import (
 	"github.com/containerd/containerd/rootfs"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/opencontainers/go-digest"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 var (
@@ -44,10 +44,10 @@ var (
 )
 
 // CheckpointOpts are options to manage the checkpoint operation
-type CheckpointOpts func(context.Context, *Client, *containers.Container, *imagespec.Index, *options.CheckpointOptions) error
+type CheckpointOpts func(context.Context, *Client, *containers.Container, *ocispec.Index, *options.CheckpointOptions) error
 
 // WithCheckpointImage includes the container image in the checkpoint
-func WithCheckpointImage(ctx context.Context, client *Client, c *containers.Container, index *imagespec.Index, copts *options.CheckpointOptions) error {
+func WithCheckpointImage(ctx context.Context, client *Client, c *containers.Container, index *ocispec.Index, copts *options.CheckpointOptions) error {
 	ir, err := client.ImageService().Get(ctx, c.Image)
 	if err != nil {
 		return err
@@ -57,7 +57,7 @@ func WithCheckpointImage(ctx context.Context, client *Client, c *containers.Cont
 }
 
 // WithCheckpointTask includes the running task
-func WithCheckpointTask(ctx context.Context, client *Client, c *containers.Container, index *imagespec.Index, copts *options.CheckpointOptions) error {
+func WithCheckpointTask(ctx context.Context, client *Client, c *containers.Container, index *ocispec.Index, copts *options.CheckpointOptions) error {
 	any, err := protobuf.MarshalAnyToProto(copts)
 	if err != nil {
 		return nil
@@ -71,7 +71,7 @@ func WithCheckpointTask(ctx context.Context, client *Client, c *containers.Conta
 	}
 	for _, d := range task.Descriptors {
 		platformSpec := platforms.DefaultSpec()
-		index.Manifests = append(index.Manifests, imagespec.Descriptor{
+		index.Manifests = append(index.Manifests, ocispec.Descriptor{
 			MediaType:   d.MediaType,
 			Size:        d.Size,
 			Digest:      digest.Digest(d.Digest),
@@ -89,7 +89,7 @@ func WithCheckpointTask(ctx context.Context, client *Client, c *containers.Conta
 	if err != nil {
 		return err
 	}
-	desc.Platform = &imagespec.Platform{
+	desc.Platform = &ocispec.Platform{
 		OS:           runtime.GOOS,
 		Architecture: runtime.GOARCH,
 	}
@@ -98,7 +98,7 @@ func WithCheckpointTask(ctx context.Context, client *Client, c *containers.Conta
 }
 
 // WithCheckpointRuntime includes the container runtime info
-func WithCheckpointRuntime(ctx context.Context, client *Client, c *containers.Container, index *imagespec.Index, copts *options.CheckpointOptions) error {
+func WithCheckpointRuntime(ctx context.Context, client *Client, c *containers.Container, index *ocispec.Index, copts *options.CheckpointOptions) error {
 	if c.Runtime.Options != nil && c.Runtime.Options.GetValue() != nil {
 		any := protobuf.FromAny(c.Runtime.Options)
 		data, err := proto.Marshal(any)
@@ -110,7 +110,7 @@ func WithCheckpointRuntime(ctx context.Context, client *Client, c *containers.Co
 		if err != nil {
 			return err
 		}
-		desc.Platform = &imagespec.Platform{
+		desc.Platform = &ocispec.Platform{
 			OS:           runtime.GOOS,
 			Architecture: runtime.GOARCH,
 		}
@@ -120,7 +120,7 @@ func WithCheckpointRuntime(ctx context.Context, client *Client, c *containers.Co
 }
 
 // WithCheckpointRW includes the rw in the checkpoint
-func WithCheckpointRW(ctx context.Context, client *Client, c *containers.Container, index *imagespec.Index, copts *options.CheckpointOptions) error {
+func WithCheckpointRW(ctx context.Context, client *Client, c *containers.Container, index *ocispec.Index, copts *options.CheckpointOptions) error {
 	diffOpts := []diff.Opt{
 		diff.WithReference(fmt.Sprintf("checkpoint-rw-%s", c.SnapshotKey)),
 	}
@@ -134,7 +134,7 @@ func WithCheckpointRW(ctx context.Context, client *Client, c *containers.Contain
 		return err
 
 	}
-	rw.Platform = &imagespec.Platform{
+	rw.Platform = &ocispec.Platform{
 		OS:           runtime.GOOS,
 		Architecture: runtime.GOARCH,
 	}
@@ -143,13 +143,13 @@ func WithCheckpointRW(ctx context.Context, client *Client, c *containers.Contain
 }
 
 // WithCheckpointTaskExit causes the task to exit after checkpoint
-func WithCheckpointTaskExit(ctx context.Context, client *Client, c *containers.Container, index *imagespec.Index, copts *options.CheckpointOptions) error {
+func WithCheckpointTaskExit(ctx context.Context, client *Client, c *containers.Container, index *ocispec.Index, copts *options.CheckpointOptions) error {
 	copts.Exit = true
 	return nil
 }
 
 // GetIndexByMediaType returns the index in a manifest for the specified media type
-func GetIndexByMediaType(index *imagespec.Index, mt string) (*imagespec.Descriptor, error) {
+func GetIndexByMediaType(index *ocispec.Index, mt string) (*ocispec.Descriptor, error) {
 	for _, d := range index.Manifests {
 		if d.MediaType == mt {
 			return &d, nil

--- a/container_opts.go
+++ b/container_opts.go
@@ -32,7 +32,7 @@ import (
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/typeurl/v2"
 	"github.com/opencontainers/image-spec/identity"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // DeleteOpts allows the caller to set options for the deletion of a container
@@ -121,11 +121,11 @@ func WithImageConfigLabels(image Image) NewContainerOpts {
 			return err
 		}
 		var (
-			ociimage v1.Image
-			config   v1.ImageConfig
+			ociimage ocispec.Image
+			config   ocispec.ImageConfig
 		)
 		switch ic.MediaType {
-		case v1.MediaTypeImageConfig, images.MediaTypeDockerSchema2Config:
+		case ocispec.MediaTypeImageConfig, images.MediaTypeDockerSchema2Config:
 			p, err := content.ReadBlob(ctx, image.ContentStore(), ic)
 			if err != nil {
 				return err

--- a/container_restore_opts.go
+++ b/container_restore_opts.go
@@ -27,7 +27,7 @@ import (
 	"github.com/containerd/containerd/protobuf/proto"
 	ptypes "github.com/containerd/containerd/protobuf/types"
 	"github.com/opencontainers/image-spec/identity"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 var (
@@ -40,10 +40,10 @@ var (
 )
 
 // RestoreOpts are options to manage the restore operation
-type RestoreOpts func(context.Context, string, *Client, Image, *imagespec.Index) NewContainerOpts
+type RestoreOpts func(context.Context, string, *Client, Image, *ocispec.Index) NewContainerOpts
 
 // WithRestoreImage restores the image for the container
-func WithRestoreImage(ctx context.Context, id string, client *Client, checkpoint Image, index *imagespec.Index) NewContainerOpts {
+func WithRestoreImage(ctx context.Context, id string, client *Client, checkpoint Image, index *ocispec.Index) NewContainerOpts {
 	return func(ctx context.Context, client *Client, c *containers.Container) error {
 		name, ok := index.Annotations[checkpointImageNameLabel]
 		if !ok || name == "" {
@@ -74,7 +74,7 @@ func WithRestoreImage(ctx context.Context, id string, client *Client, checkpoint
 }
 
 // WithRestoreRuntime restores the runtime for the container
-func WithRestoreRuntime(ctx context.Context, id string, client *Client, checkpoint Image, index *imagespec.Index) NewContainerOpts {
+func WithRestoreRuntime(ctx context.Context, id string, client *Client, checkpoint Image, index *ocispec.Index) NewContainerOpts {
 	return func(ctx context.Context, client *Client, c *containers.Container) error {
 		name, ok := index.Annotations[checkpointRuntimeNameLabel]
 		if !ok {
@@ -109,7 +109,7 @@ func WithRestoreRuntime(ctx context.Context, id string, client *Client, checkpoi
 }
 
 // WithRestoreSpec restores the spec from the checkpoint for the container
-func WithRestoreSpec(ctx context.Context, id string, client *Client, checkpoint Image, index *imagespec.Index) NewContainerOpts {
+func WithRestoreSpec(ctx context.Context, id string, client *Client, checkpoint Image, index *ocispec.Index) NewContainerOpts {
 	return func(ctx context.Context, client *Client, c *containers.Container) error {
 		m, err := GetIndexByMediaType(index, images.MediaTypeContainerd1CheckpointConfig)
 		if err != nil {
@@ -130,10 +130,10 @@ func WithRestoreSpec(ctx context.Context, id string, client *Client, checkpoint 
 }
 
 // WithRestoreRW restores the rw layer from the checkpoint for the container
-func WithRestoreRW(ctx context.Context, id string, client *Client, checkpoint Image, index *imagespec.Index) NewContainerOpts {
+func WithRestoreRW(ctx context.Context, id string, client *Client, checkpoint Image, index *ocispec.Index) NewContainerOpts {
 	return func(ctx context.Context, client *Client, c *containers.Container) error {
 		// apply rw layer
-		rw, err := GetIndexByMediaType(index, imagespec.MediaTypeImageLayerGzip)
+		rw, err := GetIndexByMediaType(index, ocispec.MediaTypeImageLayerGzip)
 		if err != nil {
 			return err
 		}

--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -35,7 +35,7 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/continuity/fs"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runc/libcontainer/user"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
@@ -376,11 +376,11 @@ func WithImageConfigArgs(image Image, args []string) SpecOpts {
 		}
 		var (
 			imageConfigBytes []byte
-			ociimage         v1.Image
-			config           v1.ImageConfig
+			ociimage         ocispec.Image
+			config           ocispec.ImageConfig
 		)
 		switch ic.MediaType {
-		case v1.MediaTypeImageConfig, images.MediaTypeDockerSchema2Config:
+		case ocispec.MediaTypeImageConfig, images.MediaTypeDockerSchema2Config:
 			var err error
 			imageConfigBytes, err = content.ReadBlob(ctx, image.ContentStore(), ic)
 			if err != nil {

--- a/pkg/cri/cri.go
+++ b/pkg/cri/cri.go
@@ -29,7 +29,7 @@ import (
 	nriservice "github.com/containerd/containerd/pkg/nri"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/plugin"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"k8s.io/klog/v2"
 
 	criconfig "github.com/containerd/containerd/pkg/cri/config"
@@ -54,7 +54,7 @@ func init() {
 }
 
 func initCRIService(ic *plugin.InitContext) (interface{}, error) {
-	ic.Meta.Platforms = []imagespec.Platform{platforms.DefaultSpec()}
+	ic.Meta.Platforms = []ocispec.Platform{platforms.DefaultSpec()}
 	ic.Meta.Exports = map[string]string{"CRIVersion": constants.CRIVersion}
 	ctx := ic.Context
 	pluginConfig := ic.Config.(*criconfig.PluginConfig)

--- a/pkg/cri/opts/spec_nonwindows.go
+++ b/pkg/cri/opts/spec_nonwindows.go
@@ -24,12 +24,12 @@ import (
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/oci"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
-func WithProcessCommandLineOrArgsForWindows(config *runtime.ContainerConfig, image *imagespec.ImageConfig) oci.SpecOpts {
+func WithProcessCommandLineOrArgsForWindows(config *runtime.ContainerConfig, image *ocispec.ImageConfig) oci.SpecOpts {
 	return func(ctx context.Context, client oci.Client, c *containers.Container, s *runtimespec.Spec) (err error) {
 		return errdefs.ErrNotImplemented
 	}

--- a/pkg/cri/opts/spec_opts.go
+++ b/pkg/cri/opts/spec_opts.go
@@ -25,7 +25,7 @@ import (
 	"sort"
 	"strings"
 
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
@@ -56,7 +56,7 @@ func WithoutRoot(ctx context.Context, client oci.Client, c *containers.Container
 }
 
 // WithProcessArgs sets the process args on the spec based on the image and runtime config
-func WithProcessArgs(config *runtime.ContainerConfig, image *imagespec.ImageConfig) oci.SpecOpts {
+func WithProcessArgs(config *runtime.ContainerConfig, image *ocispec.ImageConfig) oci.SpecOpts {
 	return func(ctx context.Context, client oci.Client, c *containers.Container, s *runtimespec.Spec) (err error) {
 		command, args := config.GetCommand(), config.GetArgs()
 		// The following logic is migrated from https://github.com/moby/moby/blob/master/daemon/commit.go

--- a/pkg/cri/opts/spec_windows.go
+++ b/pkg/cri/opts/spec_windows.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/oci"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/windows"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -43,7 +43,7 @@ func escapeAndCombineArgsWindows(args []string) string {
 // and runtime config
 // If image.ArgsEscaped field is set, this function sets the process command line and if not, it sets the
 // process args field
-func WithProcessCommandLineOrArgsForWindows(config *runtime.ContainerConfig, image *imagespec.ImageConfig) oci.SpecOpts {
+func WithProcessCommandLineOrArgsForWindows(config *runtime.ContainerConfig, image *ocispec.ImageConfig) oci.SpecOpts {
 	if image.ArgsEscaped { //nolint:staticcheck // ArgsEscaped is deprecated
 		return func(ctx context.Context, client oci.Client, c *containers.Container, s *runtimespec.Spec) (err error) {
 			// firstArgFromImg is a flag that is returned to indicate that the first arg in the slice comes from either the

--- a/pkg/cri/sbserver/container_create.go
+++ b/pkg/cri/sbserver/container_create.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/containerd/typeurl/v2"
 	"github.com/davecgh/go-spew/spew"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/opencontainers/selinux/go-selinux/label"
@@ -337,7 +337,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 // volumeMounts sets up image volumes for container. Rely on the removal of container
 // root directory to do cleanup. Note that image volume will be skipped, if there is criMounts
 // specified with the same destination.
-func (c *criService) volumeMounts(containerRootDir string, criMounts []*runtime.Mount, config *imagespec.ImageConfig) []*runtime.Mount {
+func (c *criService) volumeMounts(containerRootDir string, criMounts []*runtime.Mount, config *ocispec.ImageConfig) []*runtime.Mount {
 	if len(config.Volumes) == 0 {
 		return nil
 	}
@@ -448,7 +448,7 @@ func generateUserString(username string, uid, gid *runtime.Int64Value) (string, 
 func (c *criService) platformSpecOpts(
 	platform platforms.Platform,
 	config *runtime.ContainerConfig,
-	imageConfig *imagespec.ImageConfig,
+	imageConfig *ocispec.ImageConfig,
 ) ([]oci.SpecOpts, error) {
 	var specOpts []oci.SpecOpts
 
@@ -502,7 +502,7 @@ func (c *criService) buildContainerSpec(
 	imageName string,
 	config *runtime.ContainerConfig,
 	sandboxConfig *runtime.PodSandboxConfig,
-	imageConfig *imagespec.ImageConfig,
+	imageConfig *ocispec.ImageConfig,
 	extraMounts []*runtime.Mount,
 	ociRuntime criconfig.Runtime,
 ) (_ *runtimespec.Spec, retErr error) {
@@ -581,7 +581,7 @@ func (c *criService) buildLinuxSpec(
 	imageName string,
 	config *runtime.ContainerConfig,
 	sandboxConfig *runtime.PodSandboxConfig,
-	imageConfig *imagespec.ImageConfig,
+	imageConfig *ocispec.ImageConfig,
 	extraMounts []*runtime.Mount,
 	ociRuntime criconfig.Runtime,
 ) (_ []oci.SpecOpts, retErr error) {
@@ -813,7 +813,7 @@ func (c *criService) buildWindowsSpec(
 	imageName string,
 	config *runtime.ContainerConfig,
 	sandboxConfig *runtime.PodSandboxConfig,
-	imageConfig *imagespec.ImageConfig,
+	imageConfig *ocispec.ImageConfig,
 	extraMounts []*runtime.Mount,
 	ociRuntime criconfig.Runtime,
 ) (_ []oci.SpecOpts, retErr error) {
@@ -907,7 +907,7 @@ func (c *criService) buildDarwinSpec(
 	imageName string,
 	config *runtime.ContainerConfig,
 	sandboxConfig *runtime.PodSandboxConfig,
-	imageConfig *imagespec.ImageConfig,
+	imageConfig *ocispec.ImageConfig,
 	extraMounts []*runtime.Mount,
 	ociRuntime criconfig.Runtime,
 ) (_ []oci.SpecOpts, retErr error) {

--- a/pkg/cri/sbserver/container_create_linux.go
+++ b/pkg/cri/sbserver/container_create_linux.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"strings"
 
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/containerd/containerd/contrib/apparmor"
@@ -51,7 +51,7 @@ const (
 	seccompDefaultProfile = dockerDefault
 )
 
-func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageConfig *imagespec.ImageConfig) ([]oci.SpecOpts, error) {
+func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageConfig *ocispec.ImageConfig) ([]oci.SpecOpts, error) {
 	var (
 		specOpts []oci.SpecOpts
 		err      error

--- a/pkg/cri/sbserver/container_create_linux_test.go
+++ b/pkg/cri/sbserver/container_create_linux_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/platforms"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/stretchr/testify/assert"
@@ -50,7 +50,7 @@ import (
 )
 
 func getCreateContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandboxConfig,
-	*imagespec.ImageConfig, func(*testing.T, string, string, uint32, *runtimespec.Spec)) {
+	*ocispec.ImageConfig, func(*testing.T, string, string, uint32, *runtimespec.Spec)) {
 	config := &runtime.ContainerConfig{
 		Metadata: &runtime.ContainerMetadata{
 			Name:    "test-name",
@@ -113,7 +113,7 @@ func getCreateContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandbox
 			SecurityContext: &runtime.LinuxSandboxSecurityContext{},
 		},
 	}
-	imageConfig := &imagespec.ImageConfig{
+	imageConfig := &ocispec.ImageConfig{
 		Env:        []string{"ik1=iv1", "ik2=iv2", "ik3=iv3=iv3bis", "ik4=iv4=iv4bis=boop"},
 		Entrypoint: []string{"/entrypoint"},
 		Cmd:        []string{"cmd"},
@@ -925,9 +925,9 @@ func TestGenerateSeccompSecurityProfileSpecOpts(t *testing.T) {
 			defaultProfile: runtimeDefault,
 			specOpts:       seccomp.WithDefaultProfile(),
 		},
-		//-----------------------------------------------
+		// -----------------------------------------------
 		// now buckets for the SecurityProfile variants
-		//-----------------------------------------------
+		// -----------------------------------------------
 		{
 			desc:      "sp should return error if seccomp is specified when seccomp is not supported",
 			disable:   true,
@@ -1095,9 +1095,9 @@ func TestGenerateApparmorSpecOpts(t *testing.T) {
 			profile:   "test-profile",
 			expectErr: true,
 		},
-		//--------------------------------------
+		// --------------------------------------
 		// buckets for SecurityProfile struct
-		//--------------------------------------
+		// --------------------------------------
 		{
 			desc:      "sp should return error if apparmor is specified when apparmor is not supported",
 			disable:   true,

--- a/pkg/cri/sbserver/container_create_other.go
+++ b/pkg/cri/sbserver/container_create_other.go
@@ -19,14 +19,14 @@
 package sbserver
 
 import (
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/snapshots"
 )
 
-func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageConfig *imagespec.ImageConfig) ([]oci.SpecOpts, error) {
+func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageConfig *ocispec.ImageConfig) ([]oci.SpecOpts, error) {
 	return []oci.SpecOpts{}, nil
 }
 

--- a/pkg/cri/sbserver/container_create_other_test.go
+++ b/pkg/cri/sbserver/container_create_other_test.go
@@ -21,7 +21,7 @@ package sbserver
 import (
 	"testing"
 
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -33,7 +33,7 @@ import (
 var _ = checkMount
 
 func getCreateContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandboxConfig,
-	*imagespec.ImageConfig, func(*testing.T, string, string, uint32, *runtimespec.Spec)) {
+	*ocispec.ImageConfig, func(*testing.T, string, string, uint32, *runtimespec.Spec)) {
 	config := &runtime.ContainerConfig{
 		Metadata: &runtime.ContainerMetadata{
 			Name:    "test-name",
@@ -76,7 +76,7 @@ func getCreateContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandbox
 		},
 		Annotations: map[string]string{"c": "d"},
 	}
-	imageConfig := &imagespec.ImageConfig{
+	imageConfig := &ocispec.ImageConfig{
 		Env:        []string{"ik1=iv1", "ik2=iv2", "ik3=iv3=iv3bis", "ik4=iv4=iv4bis=boop"},
 		Entrypoint: []string{"/entrypoint"},
 		Cmd:        []string{"cmd"},

--- a/pkg/cri/sbserver/container_create_test.go
+++ b/pkg/cri/sbserver/container_create_test.go
@@ -27,7 +27,7 @@ import (
 	ostesting "github.com/containerd/containerd/pkg/os/testing"
 	"github.com/containerd/containerd/platforms"
 
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -283,7 +283,7 @@ func TestVolumeMounts(t *testing.T) {
 	} {
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
-			config := &imagespec.ImageConfig{
+			config := &ocispec.ImageConfig{
 				Volumes: test.imageVolumes,
 			}
 			c := newTestCRIService()

--- a/pkg/cri/sbserver/container_create_windows.go
+++ b/pkg/cri/sbserver/container_create_windows.go
@@ -19,7 +19,7 @@ package sbserver
 import (
 	"fmt"
 
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/containerd/containerd/oci"
@@ -27,7 +27,7 @@ import (
 )
 
 // No extra spec options needed for windows.
-func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageConfig *imagespec.ImageConfig) ([]oci.SpecOpts, error) {
+func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageConfig *ocispec.ImageConfig) ([]oci.SpecOpts, error) {
 	return nil, nil
 }
 

--- a/pkg/cri/sbserver/container_create_windows_test.go
+++ b/pkg/cri/sbserver/container_create_windows_test.go
@@ -19,7 +19,7 @@ package sbserver
 import (
 	"testing"
 
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -29,7 +29,7 @@ import (
 )
 
 func getCreateContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandboxConfig,
-	*imagespec.ImageConfig, func(*testing.T, string, string, uint32, *runtimespec.Spec)) {
+	*ocispec.ImageConfig, func(*testing.T, string, string, uint32, *runtimespec.Spec)) {
 	config := &runtime.ContainerConfig{
 		Metadata: &runtime.ContainerMetadata{
 			Name:    "test-name",
@@ -87,7 +87,7 @@ func getCreateContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandbox
 		Hostname:    "test-hostname",
 		Annotations: map[string]string{"c": "d"},
 	}
-	imageConfig := &imagespec.ImageConfig{
+	imageConfig := &ocispec.ImageConfig{
 		Env:        []string{"ik1=iv1", "ik2=iv2", "ik3=iv3=iv3bis", "ik4=iv4=iv4bis=boop"},
 		Entrypoint: []string{"/entrypoint"},
 		Cmd:        []string{"cmd"},

--- a/pkg/cri/sbserver/images/image_list_test.go
+++ b/pkg/cri/sbserver/images/image_list_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -39,8 +39,8 @@ func TestListImages(t *testing.T) {
 				"gcr.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
 			},
 			Size: 1000,
-			ImageSpec: imagespec.Image{
-				Config: imagespec.ImageConfig{
+			ImageSpec: ocispec.Image{
+				Config: ocispec.ImageConfig{
 					User: "root",
 				},
 			},
@@ -53,8 +53,8 @@ func TestListImages(t *testing.T) {
 				"gcr.io/library/alpine@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
 			},
 			Size: 2000,
-			ImageSpec: imagespec.Image{
-				Config: imagespec.ImageConfig{
+			ImageSpec: ocispec.Image{
+				Config: ocispec.ImageConfig{
 					User: "1234:1234",
 				},
 			},
@@ -67,8 +67,8 @@ func TestListImages(t *testing.T) {
 				"gcr.io/library/ubuntu@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
 			},
 			Size: 3000,
-			ImageSpec: imagespec.Image{
-				Config: imagespec.ImageConfig{
+			ImageSpec: ocispec.Image{
+				Config: ocispec.ImageConfig{
 					User: "nobody",
 				},
 			},

--- a/pkg/cri/sbserver/images/image_pull.go
+++ b/pkg/cri/sbserver/images/image_pull.go
@@ -38,7 +38,7 @@ import (
 	"github.com/containerd/imgcrypt"
 	"github.com/containerd/imgcrypt/images/encryption"
 	imagedigest "github.com/opencontainers/go-digest"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/containerd/containerd"
@@ -138,7 +138,7 @@ func (c *CRIImageService) PullImage(ctx context.Context, r *runtime.PullImageReq
 		})
 		isSchema1    bool
 		imageHandler containerdimages.HandlerFunc = func(_ context.Context,
-			desc imagespec.Descriptor) ([]imagespec.Descriptor, error) {
+			desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 			if desc.MediaType == containerdimages.MediaTypeDockerSchema1Manifest {
 				isSchema1 = true
 			}
@@ -285,7 +285,7 @@ func ParseAuth(auth *runtime.AuthConfig, host string) (string, string, error) {
 // Note that because create and update are not finished in one transaction, there could be race. E.g.
 // the image reference is deleted by someone else after create returns already exists, but before update
 // happens.
-func (c *CRIImageService) createImageReference(ctx context.Context, name string, desc imagespec.Descriptor) error {
+func (c *CRIImageService) createImageReference(ctx context.Context, name string, desc ocispec.Descriptor) error {
 	img := containerdimages.Image{
 		Name:   name,
 		Target: desc,

--- a/pkg/cri/sbserver/images/image_status.go
+++ b/pkg/cri/sbserver/images/image_status.go
@@ -29,7 +29,7 @@ import (
 	"github.com/containerd/containerd/reference/docker"
 	"github.com/containerd/containerd/tracing"
 
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -120,8 +120,8 @@ func ParseImageReferences(refs []string) ([]string, []string) {
 
 // TODO (mikebrow): discuss moving this struct and / or constants for info map for some or all of these fields to CRI
 type verboseImageInfo struct {
-	ChainID   string          `json:"chainID"`
-	ImageSpec imagespec.Image `json:"imageSpec"`
+	ChainID   string        `json:"chainID"`
+	ImageSpec ocispec.Image `json:"imageSpec"`
 }
 
 // toCRIImageInfo converts internal image object information to CRI image status response info map.

--- a/pkg/cri/sbserver/images/image_status_test.go
+++ b/pkg/cri/sbserver/images/image_status_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -38,8 +38,8 @@ func TestImageStatus(t *testing.T) {
 			"gcr.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
 		},
 		Size: 1234,
-		ImageSpec: imagespec.Image{
-			Config: imagespec.ImageConfig{
+		ImageSpec: ocispec.Image{
+			Config: ocispec.ImageConfig{
 				User: "user:group",
 			},
 		},

--- a/pkg/cri/sbserver/podsandbox/sandbox_run_linux.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_run_linux.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 
 	"github.com/containerd/containerd/oci"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux"
 	"golang.org/x/sys/unix"
@@ -35,7 +35,7 @@ import (
 )
 
 func (c *Controller) sandboxContainerSpec(id string, config *runtime.PodSandboxConfig,
-	imageConfig *imagespec.ImageConfig, nsPath string, runtimePodAnnotations []string) (_ *runtimespec.Spec, retErr error) {
+	imageConfig *ocispec.ImageConfig, nsPath string, runtimePodAnnotations []string) (_ *runtimespec.Spec, retErr error) {
 	// Creates a spec Generator with the default spec.
 	// TODO(random-liu): [P1] Compare the default settings with docker and containerd default.
 	specOpts := []oci.SpecOpts{
@@ -180,7 +180,7 @@ func (c *Controller) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 
 // sandboxContainerSpecOpts generates OCI spec options for
 // the sandbox container.
-func (c *Controller) sandboxContainerSpecOpts(config *runtime.PodSandboxConfig, imageConfig *imagespec.ImageConfig) ([]oci.SpecOpts, error) {
+func (c *Controller) sandboxContainerSpecOpts(config *runtime.PodSandboxConfig, imageConfig *ocispec.ImageConfig) ([]oci.SpecOpts, error) {
 	var (
 		securityContext = config.GetLinux().GetSecurityContext()
 		specOpts        []oci.SpecOpts

--- a/pkg/cri/sbserver/podsandbox/sandbox_run_linux_test.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_run_linux_test.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"testing"
 
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/stretchr/testify/assert"
@@ -35,7 +35,7 @@ import (
 	ostesting "github.com/containerd/containerd/pkg/os/testing"
 )
 
-func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConfig, func(*testing.T, string, *runtimespec.Spec)) {
+func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *ocispec.ImageConfig, func(*testing.T, string, *runtimespec.Spec)) {
 	config := &runtime.PodSandboxConfig{
 		Metadata: &runtime.PodSandboxMetadata{
 			Name:      "test-name",
@@ -51,7 +51,7 @@ func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConf
 			CgroupParent: "/test/cgroup/parent",
 		},
 	}
-	imageConfig := &imagespec.ImageConfig{
+	imageConfig := &ocispec.ImageConfig{
 		Env:        []string{"a=b", "c=d"},
 		Entrypoint: []string{"/pause"},
 		Cmd:        []string{"forever"},

--- a/pkg/cri/sbserver/podsandbox/sandbox_run_other.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_run_other.go
@@ -21,19 +21,19 @@ package podsandbox
 import (
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/pkg/cri/annotations"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func (c *Controller) sandboxContainerSpec(id string, config *runtime.PodSandboxConfig,
-	imageConfig *imagespec.ImageConfig, nsPath string, runtimePodAnnotations []string) (_ *runtimespec.Spec, retErr error) {
+	imageConfig *ocispec.ImageConfig, nsPath string, runtimePodAnnotations []string) (_ *runtimespec.Spec, retErr error) {
 	return c.runtimeSpec(id, "", annotations.DefaultCRIAnnotations(id, "", "", config, true)...)
 }
 
 // sandboxContainerSpecOpts generates OCI spec options for
 // the sandbox container.
-func (c *Controller) sandboxContainerSpecOpts(config *runtime.PodSandboxConfig, imageConfig *imagespec.ImageConfig) ([]oci.SpecOpts, error) {
+func (c *Controller) sandboxContainerSpecOpts(config *runtime.PodSandboxConfig, imageConfig *ocispec.ImageConfig) ([]oci.SpecOpts, error) {
 	return []oci.SpecOpts{}, nil
 }
 

--- a/pkg/cri/sbserver/podsandbox/sandbox_run_other_test.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_run_other_test.go
@@ -21,14 +21,14 @@ package podsandbox
 import (
 	"testing"
 
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
-func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConfig, func(*testing.T, string, *runtimespec.Spec)) {
+func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *ocispec.ImageConfig, func(*testing.T, string, *runtimespec.Spec)) {
 	config := &runtime.PodSandboxConfig{}
-	imageConfig := &imagespec.ImageConfig{}
+	imageConfig := &ocispec.ImageConfig{}
 	specCheck := func(t *testing.T, id string, spec *runtimespec.Spec) {
 	}
 	return config, imageConfig, specCheck

--- a/pkg/cri/sbserver/podsandbox/sandbox_run_test.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_run_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/containerd/typeurl/v2"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -42,13 +42,13 @@ func TestSandboxContainerSpec(t *testing.T) {
 		desc              string
 		configChange      func(*runtime.PodSandboxConfig)
 		podAnnotations    []string
-		imageConfigChange func(*imagespec.ImageConfig)
+		imageConfigChange func(*ocispec.ImageConfig)
 		specCheck         func(*testing.T, *runtimespec.Spec)
 		expectErr         bool
 	}{
 		{
 			desc: "should return error when entrypoint and cmd are empty",
-			imageConfigChange: func(c *imagespec.ImageConfig) {
+			imageConfigChange: func(c *ocispec.ImageConfig) {
 				c.Entrypoint = nil
 				c.Cmd = nil
 			},

--- a/pkg/cri/sbserver/podsandbox/sandbox_run_windows.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_run_windows.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 
 	"github.com/containerd/containerd/oci"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
@@ -30,7 +30,7 @@ import (
 )
 
 func (c *Controller) sandboxContainerSpec(id string, config *runtime.PodSandboxConfig,
-	imageConfig *imagespec.ImageConfig, nsPath string, runtimePodAnnotations []string) (*runtimespec.Spec, error) {
+	imageConfig *ocispec.ImageConfig, nsPath string, runtimePodAnnotations []string) (*runtimespec.Spec, error) {
 	// Creates a spec Generator with the default spec.
 	specOpts := []oci.SpecOpts{
 		oci.WithEnv(imageConfig.Env),
@@ -88,7 +88,7 @@ func (c *Controller) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 }
 
 // No sandbox container spec options for windows yet.
-func (c *Controller) sandboxContainerSpecOpts(config *runtime.PodSandboxConfig, imageConfig *imagespec.ImageConfig) ([]oci.SpecOpts, error) {
+func (c *Controller) sandboxContainerSpecOpts(config *runtime.PodSandboxConfig, imageConfig *ocispec.ImageConfig) ([]oci.SpecOpts, error) {
 	return nil, nil
 }
 

--- a/pkg/cri/sbserver/podsandbox/sandbox_run_windows_test.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_run_windows_test.go
@@ -19,7 +19,7 @@ package podsandbox
 import (
 	"testing"
 
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -28,7 +28,7 @@ import (
 	"github.com/containerd/containerd/pkg/cri/opts"
 )
 
-func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConfig, func(*testing.T, string, *runtimespec.Spec)) {
+func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *ocispec.ImageConfig, func(*testing.T, string, *runtimespec.Spec)) {
 	config := &runtime.PodSandboxConfig{
 		Metadata: &runtime.PodSandboxMetadata{
 			Name:      "test-name",
@@ -48,7 +48,7 @@ func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConf
 			},
 		},
 	}
-	imageConfig := &imagespec.ImageConfig{
+	imageConfig := &ocispec.ImageConfig{
 		Env:        []string{"a=b", "c=d"},
 		Entrypoint: []string{"/pause"},
 		Cmd:        []string{"forever"},

--- a/pkg/cri/server/container_create.go
+++ b/pkg/cri/server/container_create.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/containerd/typeurl/v2"
 	"github.com/davecgh/go-spew/spew"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	selinux "github.com/opencontainers/selinux/go-selinux"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -310,7 +310,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 // volumeMounts sets up image volumes for container. Rely on the removal of container
 // root directory to do cleanup. Note that image volume will be skipped, if there is criMounts
 // specified with the same destination.
-func (c *criService) volumeMounts(containerRootDir string, criMounts []*runtime.Mount, config *imagespec.ImageConfig) []*runtime.Mount {
+func (c *criService) volumeMounts(containerRootDir string, criMounts []*runtime.Mount, config *ocispec.ImageConfig) []*runtime.Mount {
 	if len(config.Volumes) == 0 {
 		return nil
 	}

--- a/pkg/cri/server/container_create_linux.go
+++ b/pkg/cri/server/container_create_linux.go
@@ -30,7 +30,7 @@ import (
 	"github.com/containerd/containerd/contrib/seccomp"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/snapshots"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	selinux "github.com/opencontainers/selinux/go-selinux"
 	"github.com/opencontainers/selinux/go-selinux/label"
@@ -123,7 +123,7 @@ func (c *criService) containerSpec(
 	imageName string,
 	config *runtime.ContainerConfig,
 	sandboxConfig *runtime.PodSandboxConfig,
-	imageConfig *imagespec.ImageConfig,
+	imageConfig *ocispec.ImageConfig,
 	extraMounts []*runtime.Mount,
 	ociRuntime config.Runtime,
 ) (_ *runtimespec.Spec, retErr error) {
@@ -344,7 +344,7 @@ func (c *criService) containerSpec(
 	return c.runtimeSpec(id, ociRuntime.BaseRuntimeSpec, specOpts...)
 }
 
-func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageConfig *imagespec.ImageConfig) ([]oci.SpecOpts, error) {
+func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageConfig *ocispec.ImageConfig) ([]oci.SpecOpts, error) {
 	var specOpts []oci.SpecOpts
 	securityContext := config.GetLinux().GetSecurityContext()
 	// Set container username. This could only be done by containerd, because it needs

--- a/pkg/cri/server/container_create_linux_test.go
+++ b/pkg/cri/server/container_create_linux_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/containerd/containerd/contrib/seccomp"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/oci"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/stretchr/testify/assert"
@@ -50,7 +50,7 @@ import (
 )
 
 func getCreateContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandboxConfig,
-	*imagespec.ImageConfig, func(*testing.T, string, string, uint32, *runtimespec.Spec)) {
+	*ocispec.ImageConfig, func(*testing.T, string, string, uint32, *runtimespec.Spec)) {
 	config := &runtime.ContainerConfig{
 		Metadata: &runtime.ContainerMetadata{
 			Name:    "test-name",
@@ -113,7 +113,7 @@ func getCreateContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandbox
 			SecurityContext: &runtime.LinuxSandboxSecurityContext{},
 		},
 	}
-	imageConfig := &imagespec.ImageConfig{
+	imageConfig := &ocispec.ImageConfig{
 		Env:        []string{"ik1=iv1", "ik2=iv2", "ik3=iv3=iv3bis", "ik4=iv4=iv4bis=boop"},
 		Entrypoint: []string{"/entrypoint"},
 		Cmd:        []string{"cmd"},
@@ -1110,9 +1110,9 @@ func TestGenerateSeccompSecurityProfileSpecOpts(t *testing.T) {
 			defaultProfile: runtimeDefault,
 			specOpts:       seccomp.WithDefaultProfile(),
 		},
-		//-----------------------------------------------
+		// -----------------------------------------------
 		// now buckets for the SecurityProfile variants
-		//-----------------------------------------------
+		// -----------------------------------------------
 		{
 			desc:      "sp should return error if seccomp is specified when seccomp is not supported",
 			disable:   true,
@@ -1279,9 +1279,9 @@ func TestGenerateApparmorSpecOpts(t *testing.T) {
 			profile:   "test-profile",
 			expectErr: true,
 		},
-		//--------------------------------------
+		// --------------------------------------
 		// buckets for SecurityProfile struct
-		//--------------------------------------
+		// --------------------------------------
 		{
 			desc:      "sp should return error if apparmor is specified when apparmor is not supported",
 			disable:   true,

--- a/pkg/cri/server/container_create_other.go
+++ b/pkg/cri/server/container_create_other.go
@@ -21,7 +21,7 @@ package server
 import (
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/snapshots"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
@@ -44,7 +44,7 @@ func (c *criService) containerSpec(
 	imageName string,
 	config *runtime.ContainerConfig,
 	sandboxConfig *runtime.PodSandboxConfig,
-	imageConfig *imagespec.ImageConfig,
+	imageConfig *ocispec.ImageConfig,
 	extraMounts []*runtime.Mount,
 	ociRuntime config.Runtime,
 ) (_ *runtimespec.Spec, retErr error) {
@@ -52,7 +52,7 @@ func (c *criService) containerSpec(
 	return c.runtimeSpec(sandboxID, ociRuntime.BaseRuntimeSpec, specOpts...)
 }
 
-func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageConfig *imagespec.ImageConfig) ([]oci.SpecOpts, error) {
+func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageConfig *ocispec.ImageConfig) ([]oci.SpecOpts, error) {
 	return []oci.SpecOpts{}, nil
 }
 

--- a/pkg/cri/server/container_create_other_test.go
+++ b/pkg/cri/server/container_create_other_test.go
@@ -21,7 +21,7 @@ package server
 import (
 	"testing"
 
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
@@ -30,10 +30,10 @@ import (
 var _ = checkMount
 
 func getCreateContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandboxConfig,
-	*imagespec.ImageConfig, func(*testing.T, string, string, uint32, *runtimespec.Spec)) {
+	*ocispec.ImageConfig, func(*testing.T, string, string, uint32, *runtimespec.Spec)) {
 	config := &runtime.ContainerConfig{}
 	sandboxConfig := &runtime.PodSandboxConfig{}
-	imageConfig := &imagespec.ImageConfig{}
+	imageConfig := &ocispec.ImageConfig{}
 	specCheck := func(t *testing.T, id string, sandboxID string, sandboxPid uint32, spec *runtimespec.Spec) {
 	}
 	return config, sandboxConfig, imageConfig, specCheck

--- a/pkg/cri/server/container_create_test.go
+++ b/pkg/cri/server/container_create_test.go
@@ -22,7 +22,7 @@ import (
 	goruntime "runtime"
 	"testing"
 
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -276,7 +276,7 @@ func TestVolumeMounts(t *testing.T) {
 	} {
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
-			config := &imagespec.ImageConfig{
+			config := &ocispec.ImageConfig{
 				Volumes: test.imageVolumes,
 			}
 			c := newTestCRIService()

--- a/pkg/cri/server/container_create_windows.go
+++ b/pkg/cri/server/container_create_windows.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strconv"
 
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
@@ -47,7 +47,7 @@ func (c *criService) containerSpec(
 	imageName string,
 	config *runtime.ContainerConfig,
 	sandboxConfig *runtime.PodSandboxConfig,
-	imageConfig *imagespec.ImageConfig,
+	imageConfig *ocispec.ImageConfig,
 	extraMounts []*runtime.Mount,
 	ociRuntime config.Runtime,
 ) (*runtimespec.Spec, error) {
@@ -135,7 +135,7 @@ func (c *criService) containerSpec(
 }
 
 // No extra spec options needed for windows.
-func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageConfig *imagespec.ImageConfig) ([]oci.SpecOpts, error) {
+func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageConfig *ocispec.ImageConfig) ([]oci.SpecOpts, error) {
 	return nil, nil
 }
 

--- a/pkg/cri/server/container_create_windows_test.go
+++ b/pkg/cri/server/container_create_windows_test.go
@@ -19,7 +19,7 @@ package server
 import (
 	"testing"
 
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -44,7 +44,7 @@ func getSandboxConfig() *runtime.PodSandboxConfig {
 }
 
 func getCreateContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandboxConfig,
-	*imagespec.ImageConfig, func(*testing.T, string, string, uint32, *runtimespec.Spec)) {
+	*ocispec.ImageConfig, func(*testing.T, string, string, uint32, *runtimespec.Spec)) {
 	config := &runtime.ContainerConfig{
 		Metadata: &runtime.ContainerMetadata{
 			Name:    "test-name",
@@ -92,7 +92,7 @@ func getCreateContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandbox
 		},
 	}
 	sandboxConfig := getSandboxConfig()
-	imageConfig := &imagespec.ImageConfig{
+	imageConfig := &ocispec.ImageConfig{
 		Env:        []string{"ik1=iv1", "ik2=iv2", "ik3=iv3=iv3bis", "ik4=iv4=iv4bis=boop"},
 		Entrypoint: []string{"/entrypoint"},
 		Cmd:        []string{"cmd"},
@@ -336,7 +336,7 @@ func TestEntrypointAndCmdForArgsEscaped(t *testing.T) {
 	} {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			imageConfig := &imagespec.ImageConfig{
+			imageConfig := &ocispec.ImageConfig{
 				Entrypoint:  test.imgEntrypoint,
 				Cmd:         test.imgCmd,
 				ArgsEscaped: test.ArgsEscaped,

--- a/pkg/cri/server/image_list_test.go
+++ b/pkg/cri/server/image_list_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -39,8 +39,8 @@ func TestListImages(t *testing.T) {
 				"gcr.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
 			},
 			Size: 1000,
-			ImageSpec: imagespec.Image{
-				Config: imagespec.ImageConfig{
+			ImageSpec: ocispec.Image{
+				Config: ocispec.ImageConfig{
 					User: "root",
 				},
 			},
@@ -53,8 +53,8 @@ func TestListImages(t *testing.T) {
 				"gcr.io/library/alpine@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
 			},
 			Size: 2000,
-			ImageSpec: imagespec.Image{
-				Config: imagespec.ImageConfig{
+			ImageSpec: ocispec.Image{
+				Config: ocispec.ImageConfig{
 					User: "1234:1234",
 				},
 			},
@@ -67,8 +67,8 @@ func TestListImages(t *testing.T) {
 				"gcr.io/library/ubuntu@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
 			},
 			Size: 3000,
-			ImageSpec: imagespec.Image{
-				Config: imagespec.ImageConfig{
+			ImageSpec: ocispec.Image{
+				Config: ocispec.ImageConfig{
 					User: "nobody",
 				},
 			},

--- a/pkg/cri/server/image_pull.go
+++ b/pkg/cri/server/image_pull.go
@@ -36,7 +36,7 @@ import (
 
 	"github.com/containerd/imgcrypt"
 	"github.com/containerd/imgcrypt/images/encryption"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/containerd/containerd"
@@ -136,7 +136,7 @@ func (c *criService) PullImage(ctx context.Context, r *runtime.PullImageRequest)
 		})
 		isSchema1    bool
 		imageHandler containerdimages.HandlerFunc = func(_ context.Context,
-			desc imagespec.Descriptor) ([]imagespec.Descriptor, error) {
+			desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 			if desc.MediaType == containerdimages.MediaTypeDockerSchema1Manifest {
 				isSchema1 = true
 			}
@@ -267,7 +267,7 @@ func ParseAuth(auth *runtime.AuthConfig, host string) (string, string, error) {
 // Note that because create and update are not finished in one transaction, there could be race. E.g.
 // the image reference is deleted by someone else after create returns already exists, but before update
 // happens.
-func (c *criService) createImageReference(ctx context.Context, name string, desc imagespec.Descriptor) error {
+func (c *criService) createImageReference(ctx context.Context, name string, desc ocispec.Descriptor) error {
 	img := containerdimages.Image{
 		Name:   name,
 		Target: desc,

--- a/pkg/cri/server/image_status.go
+++ b/pkg/cri/server/image_status.go
@@ -26,7 +26,7 @@ import (
 	imagestore "github.com/containerd/containerd/pkg/cri/store/image"
 	"github.com/containerd/containerd/tracing"
 
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -80,8 +80,8 @@ func toCRIImage(image imagestore.Image) *runtime.Image {
 
 // TODO (mikebrow): discuss moving this struct and / or constants for info map for some or all of these fields to CRI
 type verboseImageInfo struct {
-	ChainID   string          `json:"chainID"`
-	ImageSpec imagespec.Image `json:"imageSpec"`
+	ChainID   string        `json:"chainID"`
+	ImageSpec ocispec.Image `json:"imageSpec"`
 }
 
 // toCRIImageInfo converts internal image object information to CRI image status response info map.

--- a/pkg/cri/server/image_status_test.go
+++ b/pkg/cri/server/image_status_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -38,8 +38,8 @@ func TestImageStatus(t *testing.T) {
 			"gcr.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
 		},
 		Size: 1234,
-		ImageSpec: imagespec.Image{
-			Config: imagespec.ImageConfig{
+		ImageSpec: ocispec.Image{
+			Config: ocispec.ImageConfig{
 				User: "user:group",
 			},
 		},

--- a/pkg/cri/server/sandbox_run_linux.go
+++ b/pkg/cri/server/sandbox_run_linux.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/snapshots"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	selinux "github.com/opencontainers/selinux/go-selinux"
 	"golang.org/x/sys/unix"
@@ -36,7 +36,7 @@ import (
 )
 
 func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxConfig,
-	imageConfig *imagespec.ImageConfig, nsPath string, runtimePodAnnotations []string) (_ *runtimespec.Spec, retErr error) {
+	imageConfig *ocispec.ImageConfig, nsPath string, runtimePodAnnotations []string) (_ *runtimespec.Spec, retErr error) {
 	// Creates a spec Generator with the default spec.
 	// TODO(random-liu): [P1] Compare the default settings with docker and containerd default.
 	specOpts := []oci.SpecOpts{
@@ -198,7 +198,7 @@ func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 
 // sandboxContainerSpecOpts generates OCI spec options for
 // the sandbox container.
-func (c *criService) sandboxContainerSpecOpts(config *runtime.PodSandboxConfig, imageConfig *imagespec.ImageConfig) ([]oci.SpecOpts, error) {
+func (c *criService) sandboxContainerSpecOpts(config *runtime.PodSandboxConfig, imageConfig *ocispec.ImageConfig) ([]oci.SpecOpts, error) {
 	var (
 		securityContext = config.GetLinux().GetSecurityContext()
 		specOpts        []oci.SpecOpts

--- a/pkg/cri/server/sandbox_run_linux_test.go
+++ b/pkg/cri/server/sandbox_run_linux_test.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"testing"
 
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/stretchr/testify/assert"
@@ -35,7 +35,7 @@ import (
 	ostesting "github.com/containerd/containerd/pkg/os/testing"
 )
 
-func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConfig, func(*testing.T, string, *runtimespec.Spec)) {
+func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *ocispec.ImageConfig, func(*testing.T, string, *runtimespec.Spec)) {
 	config := &runtime.PodSandboxConfig{
 		Metadata: &runtime.PodSandboxMetadata{
 			Name:      "test-name",
@@ -51,7 +51,7 @@ func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConf
 			CgroupParent: "/test/cgroup/parent",
 		},
 	}
-	imageConfig := &imagespec.ImageConfig{
+	imageConfig := &ocispec.ImageConfig{
 		Env:        []string{"a=b", "c=d"},
 		Entrypoint: []string{"/pause"},
 		Cmd:        []string{"forever"},

--- a/pkg/cri/server/sandbox_run_other.go
+++ b/pkg/cri/server/sandbox_run_other.go
@@ -22,19 +22,19 @@ import (
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/pkg/cri/annotations"
 	"github.com/containerd/containerd/snapshots"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxConfig,
-	imageConfig *imagespec.ImageConfig, nsPath string, runtimePodAnnotations []string) (_ *runtimespec.Spec, retErr error) {
+	imageConfig *ocispec.ImageConfig, nsPath string, runtimePodAnnotations []string) (_ *runtimespec.Spec, retErr error) {
 	return c.runtimeSpec(id, "", annotations.DefaultCRIAnnotations(id, "", "", config, true)...)
 }
 
 // sandboxContainerSpecOpts generates OCI spec options for
 // the sandbox container.
-func (c *criService) sandboxContainerSpecOpts(config *runtime.PodSandboxConfig, imageConfig *imagespec.ImageConfig) ([]oci.SpecOpts, error) {
+func (c *criService) sandboxContainerSpecOpts(config *runtime.PodSandboxConfig, imageConfig *ocispec.ImageConfig) ([]oci.SpecOpts, error) {
 	return []oci.SpecOpts{}, nil
 }
 

--- a/pkg/cri/server/sandbox_run_other_test.go
+++ b/pkg/cri/server/sandbox_run_other_test.go
@@ -21,14 +21,14 @@ package server
 import (
 	"testing"
 
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
-func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConfig, func(*testing.T, string, *runtimespec.Spec)) {
+func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *ocispec.ImageConfig, func(*testing.T, string, *runtimespec.Spec)) {
 	config := &runtime.PodSandboxConfig{}
-	imageConfig := &imagespec.ImageConfig{}
+	imageConfig := &ocispec.ImageConfig{}
 	specCheck := func(t *testing.T, id string, spec *runtimespec.Spec) {
 	}
 	return config, imageConfig, specCheck

--- a/pkg/cri/server/sandbox_run_test.go
+++ b/pkg/cri/server/sandbox_run_test.go
@@ -24,7 +24,7 @@ import (
 
 	cni "github.com/containerd/go-cni"
 	"github.com/containerd/typeurl/v2"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -45,13 +45,13 @@ func TestSandboxContainerSpec(t *testing.T) {
 		desc              string
 		configChange      func(*runtime.PodSandboxConfig)
 		podAnnotations    []string
-		imageConfigChange func(*imagespec.ImageConfig)
+		imageConfigChange func(*ocispec.ImageConfig)
 		specCheck         func(*testing.T, *runtimespec.Spec)
 		expectErr         bool
 	}{
 		{
 			desc: "should return error when entrypoint and cmd are empty",
-			imageConfigChange: func(c *imagespec.ImageConfig) {
+			imageConfigChange: func(c *ocispec.ImageConfig) {
 				c.Entrypoint = nil
 				c.Cmd = nil
 			},

--- a/pkg/cri/server/sandbox_run_windows.go
+++ b/pkg/cri/server/sandbox_run_windows.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/snapshots"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
@@ -31,7 +31,7 @@ import (
 )
 
 func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxConfig,
-	imageConfig *imagespec.ImageConfig, nsPath string, runtimePodAnnotations []string) (*runtimespec.Spec, error) {
+	imageConfig *ocispec.ImageConfig, nsPath string, runtimePodAnnotations []string) (*runtimespec.Spec, error) {
 	// Creates a spec Generator with the default spec.
 	specOpts := []oci.SpecOpts{
 		oci.WithEnv(imageConfig.Env),
@@ -89,7 +89,7 @@ func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 }
 
 // No sandbox container spec options for windows yet.
-func (c *criService) sandboxContainerSpecOpts(config *runtime.PodSandboxConfig, imageConfig *imagespec.ImageConfig) ([]oci.SpecOpts, error) {
+func (c *criService) sandboxContainerSpecOpts(config *runtime.PodSandboxConfig, imageConfig *ocispec.ImageConfig) ([]oci.SpecOpts, error) {
 	return nil, nil
 }
 

--- a/pkg/cri/server/sandbox_run_windows_test.go
+++ b/pkg/cri/server/sandbox_run_windows_test.go
@@ -19,7 +19,7 @@ package server
 import (
 	"testing"
 
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -28,7 +28,7 @@ import (
 	"github.com/containerd/containerd/pkg/cri/opts"
 )
 
-func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConfig, func(*testing.T, string, *runtimespec.Spec)) {
+func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *ocispec.ImageConfig, func(*testing.T, string, *runtimespec.Spec)) {
 	config := &runtime.PodSandboxConfig{
 		Metadata: &runtime.PodSandboxMetadata{
 			Name:      "test-name",
@@ -48,7 +48,7 @@ func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConf
 			},
 		},
 	}
-	imageConfig := &imagespec.ImageConfig{
+	imageConfig := &ocispec.ImageConfig{
 		Env:        []string{"a=b", "c=d"},
 		Entrypoint: []string{"/pause"},
 		Cmd:        []string{"forever"},

--- a/pkg/cri/store/image/image.go
+++ b/pkg/cri/store/image/image.go
@@ -29,7 +29,7 @@ import (
 	imagedigest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/go-digest/digestset"
 	imageidentity "github.com/opencontainers/image-spec/identity"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // Image contains all resources associated with the image. All fields
@@ -44,7 +44,7 @@ type Image struct {
 	// Size is the compressed size of the image.
 	Size int64
 	// ImageSpec is the oci image structure which describes basic information about the image.
-	ImageSpec imagespec.Image
+	ImageSpec ocispec.Image
 }
 
 // Store stores all images.

--- a/pkg/snapshotters/annotations_test.go
+++ b/pkg/snapshotters/annotations_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	digest "github.com/opencontainers/go-digest"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -59,10 +59,10 @@ func TestImageLayersLabel(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			sampleLayers := make([]imagespec.Descriptor, 0, tt.layersNum)
+			sampleLayers := make([]ocispec.Descriptor, 0, tt.layersNum)
 			for i := 0; i < tt.layersNum; i++ {
-				sampleLayers = append(sampleLayers, imagespec.Descriptor{
-					MediaType: imagespec.MediaTypeImageLayerGzip,
+				sampleLayers = append(sampleLayers, ocispec.Descriptor{
+					MediaType: ocispec.MediaTypeImageLayerGzip,
 					Digest:    sampleDigest,
 				})
 			}

--- a/pkg/transfer/archive/exporter.go
+++ b/pkg/transfer/archive/exporter.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	"github.com/containerd/typeurl/v2"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/containerd/containerd/api/types"
 	transfertypes "github.com/containerd/containerd/api/types/transfer"
@@ -43,7 +43,7 @@ func init() {
 
 type ExportOpt func(*ImageExportStream)
 
-func WithPlatform(p v1.Platform) ExportOpt {
+func WithPlatform(p ocispec.Platform) ExportOpt {
 	return func(s *ImageExportStream) {
 		s.platforms = append(s.platforms, p)
 	}
@@ -77,7 +77,7 @@ type ImageExportStream struct {
 	stream    io.WriteCloser
 	mediaType string
 
-	platforms                 []v1.Platform
+	platforms                 []ocispec.Platform
 	allPlatforms              bool
 	skipCompatibilityManifest bool
 	skipNonDistributable      bool
@@ -156,9 +156,9 @@ func (iis *ImageExportStream) UnmarshalAny(ctx context.Context, sm streaming.Str
 		return err
 	}
 
-	var specified []v1.Platform
+	var specified []ocispec.Platform
 	for _, p := range s.Platforms {
-		specified = append(specified, v1.Platform{
+		specified = append(specified, ocispec.Platform{
 			OS:           p.OS,
 			Architecture: p.Architecture,
 			Variant:      p.Variant,

--- a/platforms/compare.go
+++ b/platforms/compare.go
@@ -20,7 +20,7 @@ import (
 	"strconv"
 	"strings"
 
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // MatchComparer is able to match and compare platforms to
@@ -28,19 +28,19 @@ import (
 type MatchComparer interface {
 	Matcher
 
-	Less(specs.Platform, specs.Platform) bool
+	Less(ocispec.Platform, ocispec.Platform) bool
 }
 
 // platformVector returns an (ordered) vector of appropriate specs.Platform
 // objects to try matching for the given platform object (see platforms.Only).
-func platformVector(platform specs.Platform) []specs.Platform {
-	vector := []specs.Platform{platform}
+func platformVector(platform ocispec.Platform) []ocispec.Platform {
+	vector := []ocispec.Platform{platform}
 
 	switch platform.Architecture {
 	case "amd64":
 		if amd64Version, err := strconv.Atoi(strings.TrimPrefix(platform.Variant, "v")); err == nil && amd64Version > 1 {
 			for amd64Version--; amd64Version >= 1; amd64Version-- {
-				vector = append(vector, specs.Platform{
+				vector = append(vector, ocispec.Platform{
 					Architecture: platform.Architecture,
 					OS:           platform.OS,
 					OSVersion:    platform.OSVersion,
@@ -49,7 +49,7 @@ func platformVector(platform specs.Platform) []specs.Platform {
 				})
 			}
 		}
-		vector = append(vector, specs.Platform{
+		vector = append(vector, ocispec.Platform{
 			Architecture: "386",
 			OS:           platform.OS,
 			OSVersion:    platform.OSVersion,
@@ -58,7 +58,7 @@ func platformVector(platform specs.Platform) []specs.Platform {
 	case "arm":
 		if armVersion, err := strconv.Atoi(strings.TrimPrefix(platform.Variant, "v")); err == nil && armVersion > 5 {
 			for armVersion--; armVersion >= 5; armVersion-- {
-				vector = append(vector, specs.Platform{
+				vector = append(vector, ocispec.Platform{
 					Architecture: platform.Architecture,
 					OS:           platform.OS,
 					OSVersion:    platform.OSVersion,
@@ -72,7 +72,7 @@ func platformVector(platform specs.Platform) []specs.Platform {
 		if variant == "" {
 			variant = "v8"
 		}
-		vector = append(vector, platformVector(specs.Platform{
+		vector = append(vector, platformVector(ocispec.Platform{
 			Architecture: "arm",
 			OS:           platform.OS,
 			OSVersion:    platform.OSVersion,
@@ -91,7 +91,7 @@ func platformVector(platform specs.Platform) []specs.Platform {
 // For arm/v7, will also match arm/v6 and arm/v5
 // For arm/v6, will also match arm/v5
 // For amd64, will also match 386
-func Only(platform specs.Platform) MatchComparer {
+func Only(platform ocispec.Platform) MatchComparer {
 	return Ordered(platformVector(Normalize(platform))...)
 }
 
@@ -103,13 +103,13 @@ func Only(platform specs.Platform) MatchComparer {
 //
 // OnlyStrict matches non-canonical forms.
 // So, "arm64" matches "arm/64/v8".
-func OnlyStrict(platform specs.Platform) MatchComparer {
+func OnlyStrict(platform ocispec.Platform) MatchComparer {
 	return Ordered(Normalize(platform))
 }
 
 // Ordered returns a platform MatchComparer which matches any of the platforms
 // but orders them in order they are provided.
-func Ordered(platforms ...specs.Platform) MatchComparer {
+func Ordered(platforms ...ocispec.Platform) MatchComparer {
 	matchers := make([]Matcher, len(platforms))
 	for i := range platforms {
 		matchers[i] = NewMatcher(platforms[i])
@@ -121,7 +121,7 @@ func Ordered(platforms ...specs.Platform) MatchComparer {
 
 // Any returns a platform MatchComparer which matches any of the platforms
 // with no preference for ordering.
-func Any(platforms ...specs.Platform) MatchComparer {
+func Any(platforms ...ocispec.Platform) MatchComparer {
 	matchers := make([]Matcher, len(platforms))
 	for i := range platforms {
 		matchers[i] = NewMatcher(platforms[i])
@@ -139,7 +139,7 @@ type orderedPlatformComparer struct {
 	matchers []Matcher
 }
 
-func (c orderedPlatformComparer) Match(platform specs.Platform) bool {
+func (c orderedPlatformComparer) Match(platform ocispec.Platform) bool {
 	for _, m := range c.matchers {
 		if m.Match(platform) {
 			return true
@@ -148,7 +148,7 @@ func (c orderedPlatformComparer) Match(platform specs.Platform) bool {
 	return false
 }
 
-func (c orderedPlatformComparer) Less(p1 specs.Platform, p2 specs.Platform) bool {
+func (c orderedPlatformComparer) Less(p1 ocispec.Platform, p2 ocispec.Platform) bool {
 	for _, m := range c.matchers {
 		p1m := m.Match(p1)
 		p2m := m.Match(p2)
@@ -166,7 +166,7 @@ type anyPlatformComparer struct {
 	matchers []Matcher
 }
 
-func (c anyPlatformComparer) Match(platform specs.Platform) bool {
+func (c anyPlatformComparer) Match(platform ocispec.Platform) bool {
 	for _, m := range c.matchers {
 		if m.Match(platform) {
 			return true
@@ -175,7 +175,7 @@ func (c anyPlatformComparer) Match(platform specs.Platform) bool {
 	return false
 }
 
-func (c anyPlatformComparer) Less(p1, p2 specs.Platform) bool {
+func (c anyPlatformComparer) Less(p1, p2 ocispec.Platform) bool {
 	var p1m, p2m bool
 	for _, m := range c.matchers {
 		if !p1m && m.Match(p1) {
@@ -194,10 +194,10 @@ func (c anyPlatformComparer) Less(p1, p2 specs.Platform) bool {
 
 type allPlatformComparer struct{}
 
-func (allPlatformComparer) Match(specs.Platform) bool {
+func (allPlatformComparer) Match(ocispec.Platform) bool {
 	return true
 }
 
-func (allPlatformComparer) Less(specs.Platform, specs.Platform) bool {
+func (allPlatformComparer) Less(ocispec.Platform, ocispec.Platform) bool {
 	return false
 }

--- a/platforms/defaults_darwin.go
+++ b/platforms/defaults_darwin.go
@@ -21,12 +21,12 @@ package platforms
 import (
 	"runtime"
 
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // DefaultSpec returns the current platform's default platform specification.
-func DefaultSpec() specs.Platform {
-	return specs.Platform{
+func DefaultSpec() ocispec.Platform {
+	return ocispec.Platform{
 		OS:           runtime.GOOS,
 		Architecture: runtime.GOARCH,
 		// The Variant field will be empty if arch != ARM.
@@ -36,7 +36,7 @@ func DefaultSpec() specs.Platform {
 
 // Default returns the default matcher for the platform.
 func Default() MatchComparer {
-	return Ordered(DefaultSpec(), specs.Platform{
+	return Ordered(DefaultSpec(), ocispec.Platform{
 		// darwin runtime also supports Linux binary via runu/LKL
 		OS:           "linux",
 		Architecture: runtime.GOARCH,

--- a/platforms/defaults_freebsd.go
+++ b/platforms/defaults_freebsd.go
@@ -19,12 +19,12 @@ package platforms
 import (
 	"runtime"
 
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // DefaultSpec returns the current platform's default platform specification.
-func DefaultSpec() specs.Platform {
-	return specs.Platform{
+func DefaultSpec() ocispec.Platform {
+	return ocispec.Platform{
 		OS:           runtime.GOOS,
 		Architecture: runtime.GOARCH,
 		// The Variant field will be empty if arch != ARM.
@@ -34,7 +34,7 @@ func DefaultSpec() specs.Platform {
 
 // Default returns the default matcher for the platform.
 func Default() MatchComparer {
-	return Ordered(DefaultSpec(), specs.Platform{
+	return Ordered(DefaultSpec(), ocispec.Platform{
 		OS:           "linux",
 		Architecture: runtime.GOARCH,
 		// The Variant field will be empty if arch != ARM.

--- a/platforms/defaults_unix.go
+++ b/platforms/defaults_unix.go
@@ -21,12 +21,12 @@ package platforms
 import (
 	"runtime"
 
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // DefaultSpec returns the current platform's default platform specification.
-func DefaultSpec() specs.Platform {
-	return specs.Platform{
+func DefaultSpec() ocispec.Platform {
+	return ocispec.Platform{
 		OS:           runtime.GOOS,
 		Architecture: runtime.GOARCH,
 		// The Variant field will be empty if arch != ARM.

--- a/platforms/defaults_unix_test.go
+++ b/platforms/defaults_unix_test.go
@@ -23,11 +23,11 @@ import (
 	"runtime"
 	"testing"
 
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func TestDefault(t *testing.T) {
-	expected := specs.Platform{
+	expected := ocispec.Platform{
 		OS:           runtime.GOOS,
 		Architecture: runtime.GOARCH,
 		Variant:      cpuVariant(),

--- a/platforms/defaults_windows.go
+++ b/platforms/defaults_windows.go
@@ -22,14 +22,14 @@ import (
 	"strconv"
 	"strings"
 
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/sys/windows"
 )
 
 // DefaultSpec returns the current platform's default platform specification.
-func DefaultSpec() specs.Platform {
+func DefaultSpec() ocispec.Platform {
 	major, minor, build := windows.RtlGetNtVersionNumbers()
-	return specs.Platform{
+	return ocispec.Platform{
 		OS:           runtime.GOOS,
 		Architecture: runtime.GOARCH,
 		OSVersion:    fmt.Sprintf("%d.%d.%d", major, minor, build),
@@ -39,14 +39,14 @@ func DefaultSpec() specs.Platform {
 }
 
 type windowsmatcher struct {
-	specs.Platform
+	ocispec.Platform
 	osVersionPrefix string
 	defaultMatcher  Matcher
 }
 
 // Match matches platform with the same windows major, minor
 // and build version.
-func (m windowsmatcher) Match(p specs.Platform) bool {
+func (m windowsmatcher) Match(p ocispec.Platform) bool {
 	match := m.defaultMatcher.Match(p)
 
 	if match && m.OS == "windows" {
@@ -62,7 +62,7 @@ func (m windowsmatcher) Match(p specs.Platform) bool {
 // Less sorts matched platforms in front of other platforms.
 // For matched platforms, it puts platforms with larger revision
 // number in front.
-func (m windowsmatcher) Less(p1, p2 specs.Platform) bool {
+func (m windowsmatcher) Less(p1, p2 ocispec.Platform) bool {
 	m1, m2 := m.Match(p1), m.Match(p2)
 	if m1 && m2 {
 		r1, r2 := revision(p1.OSVersion), revision(p2.OSVersion)

--- a/platforms/defaults_windows_test.go
+++ b/platforms/defaults_windows_test.go
@@ -23,14 +23,14 @@ import (
 	"sort"
 	"testing"
 
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/windows"
 )
 
 func TestDefault(t *testing.T) {
 	major, minor, build := windows.RtlGetNtVersionNumbers()
-	expected := imagespec.Platform{
+	expected := ocispec.Platform{
 		OS:           runtime.GOOS,
 		Architecture: runtime.GOARCH,
 		OSVersion:    fmt.Sprintf("%d.%d.%d", major, minor, build),
@@ -51,7 +51,7 @@ func TestDefaultMatchComparer(t *testing.T) {
 	defaultMatcher := Default()
 
 	for _, test := range []struct {
-		platform imagespec.Platform
+		platform ocispec.Platform
 		match    bool
 	}{
 		{
@@ -59,7 +59,7 @@ func TestDefaultMatchComparer(t *testing.T) {
 			match:    true,
 		},
 		{
-			platform: imagespec.Platform{
+			platform: ocispec.Platform{
 				OS:           "linux",
 				Architecture: runtime.GOARCH,
 			},
@@ -82,7 +82,7 @@ func TestMatchComparerMatch_WCOW(t *testing.T) {
 		},
 	}
 	for _, test := range []struct {
-		platform imagespec.Platform
+		platform ocispec.Platform
 		match    bool
 	}{
 		{
@@ -90,7 +90,7 @@ func TestMatchComparerMatch_WCOW(t *testing.T) {
 			match:    true,
 		},
 		{
-			platform: imagespec.Platform{
+			platform: ocispec.Platform{
 				Architecture: "amd64",
 				OS:           "windows",
 				OSVersion:    buildStr + ".1",
@@ -98,7 +98,7 @@ func TestMatchComparerMatch_WCOW(t *testing.T) {
 			match: true,
 		},
 		{
-			platform: imagespec.Platform{
+			platform: ocispec.Platform{
 				Architecture: "amd64",
 				OS:           "windows",
 				OSVersion:    buildStr + ".2",
@@ -106,7 +106,7 @@ func TestMatchComparerMatch_WCOW(t *testing.T) {
 			match: true,
 		},
 		{
-			platform: imagespec.Platform{
+			platform: ocispec.Platform{
 				Architecture: "amd64",
 				OS:           "windows",
 				// Use an nonexistent Windows build so we don't get a match. Ws2019's build is 17763/
@@ -115,7 +115,7 @@ func TestMatchComparerMatch_WCOW(t *testing.T) {
 			match: false,
 		},
 		{
-			platform: imagespec.Platform{
+			platform: ocispec.Platform{
 				Architecture: "amd64",
 				OS:           "windows",
 				// Use an nonexistent Windows build so we don't get a match. Ws2019's build is 17763/
@@ -124,14 +124,14 @@ func TestMatchComparerMatch_WCOW(t *testing.T) {
 			match: false,
 		},
 		{
-			platform: imagespec.Platform{
+			platform: ocispec.Platform{
 				Architecture: "amd64",
 				OS:           "windows",
 			},
 			match: true,
 		},
 		{
-			platform: imagespec.Platform{
+			platform: ocispec.Platform{
 				Architecture: "amd64",
 				OS:           "linux",
 			},
@@ -146,13 +146,13 @@ func TestMatchComparerMatch_LCOW(t *testing.T) {
 	major, minor, build := windows.RtlGetNtVersionNumbers()
 	buildStr := fmt.Sprintf("%d.%d.%d", major, minor, build)
 	m := windowsmatcher{
-		Platform: imagespec.Platform{
+		Platform: ocispec.Platform{
 			OS:           "linux",
 			Architecture: "amd64",
 		},
 		osVersionPrefix: "",
 		defaultMatcher: &matcher{
-			Platform: Normalize(imagespec.Platform{
+			Platform: Normalize(ocispec.Platform{
 				OS:           "linux",
 				Architecture: "amd64",
 			},
@@ -160,7 +160,7 @@ func TestMatchComparerMatch_LCOW(t *testing.T) {
 		},
 	}
 	for _, test := range []struct {
-		platform imagespec.Platform
+		platform ocispec.Platform
 		match    bool
 	}{
 		{
@@ -168,14 +168,14 @@ func TestMatchComparerMatch_LCOW(t *testing.T) {
 			match:    false,
 		},
 		{
-			platform: imagespec.Platform{
+			platform: ocispec.Platform{
 				Architecture: "amd64",
 				OS:           "windows",
 			},
 			match: false,
 		},
 		{
-			platform: imagespec.Platform{
+			platform: ocispec.Platform{
 				Architecture: "amd64",
 				OS:           "windows",
 				OSVersion:    buildStr + ".2",
@@ -183,7 +183,7 @@ func TestMatchComparerMatch_LCOW(t *testing.T) {
 			match: false,
 		},
 		{
-			platform: imagespec.Platform{
+			platform: ocispec.Platform{
 				Architecture: "amd64",
 				OS:           "windows",
 				// Use an nonexistent Windows build so we don't get a match. Ws2019's build is 17763/
@@ -192,7 +192,7 @@ func TestMatchComparerMatch_LCOW(t *testing.T) {
 			match: false,
 		},
 		{
-			platform: imagespec.Platform{
+			platform: ocispec.Platform{
 				Architecture: "amd64",
 				OS:           "linux",
 			},
@@ -211,7 +211,7 @@ func TestMatchComparerLess(t *testing.T) {
 			Platform: Normalize(DefaultSpec()),
 		},
 	}
-	platforms := []imagespec.Platform{
+	platforms := []ocispec.Platform{
 		{
 			Architecture: "amd64",
 			OS:           "windows",
@@ -237,7 +237,7 @@ func TestMatchComparerLess(t *testing.T) {
 			OSVersion:    "10.0.17762.1",
 		},
 	}
-	expected := []imagespec.Platform{
+	expected := []ocispec.Platform{
 		{
 			Architecture: "amd64",
 			OS:           "windows",

--- a/platforms/platforms_other.go
+++ b/platforms/platforms_other.go
@@ -19,11 +19,11 @@
 package platforms
 
 import (
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // NewMatcher returns the default Matcher for containerd
-func newDefaultMatcher(platform specs.Platform) Matcher {
+func newDefaultMatcher(platform ocispec.Platform) Matcher {
 	return &matcher{
 		Platform: Normalize(platform),
 	}

--- a/platforms/platforms_test.go
+++ b/platforms/platforms_test.go
@@ -22,7 +22,7 @@ import (
 	"runtime"
 	"testing"
 
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func TestParseSelector(t *testing.T) {
@@ -39,8 +39,8 @@ func TestParseSelector(t *testing.T) {
 	for _, testcase := range []struct {
 		skip      bool
 		input     string
-		expected  specs.Platform
-		matches   []specs.Platform
+		expected  ocispec.Platform
+		matches   []ocispec.Platform
 		formatted string
 	}{
 		// While wildcards are a valid use case for platform selection,
@@ -50,7 +50,7 @@ func TestParseSelector(t *testing.T) {
 		{
 			skip:  true,
 			input: "*",
-			expected: specs.Platform{
+			expected: ocispec.Platform{
 				OS:           "*",
 				Architecture: "*",
 			},
@@ -59,7 +59,7 @@ func TestParseSelector(t *testing.T) {
 		{
 			skip:  true,
 			input: "linux/*",
-			expected: specs.Platform{
+			expected: ocispec.Platform{
 				OS:           "linux",
 				Architecture: "*",
 			},
@@ -68,11 +68,11 @@ func TestParseSelector(t *testing.T) {
 		{
 			skip:  true,
 			input: "*/arm64",
-			expected: specs.Platform{
+			expected: ocispec.Platform{
 				OS:           "*",
 				Architecture: "arm64",
 			},
-			matches: []specs.Platform{
+			matches: []ocispec.Platform{
 				{
 					OS:           "*",
 					Architecture: "aarch64",
@@ -92,11 +92,11 @@ func TestParseSelector(t *testing.T) {
 		},
 		{
 			input: "linux/arm64",
-			expected: specs.Platform{
+			expected: ocispec.Platform{
 				OS:           "linux",
 				Architecture: "arm64",
 			},
-			matches: []specs.Platform{
+			matches: []ocispec.Platform{
 				{
 					OS:           "linux",
 					Architecture: "aarch64",
@@ -116,12 +116,12 @@ func TestParseSelector(t *testing.T) {
 		},
 		{
 			input: "linux/arm64/v8",
-			expected: specs.Platform{
+			expected: ocispec.Platform{
 				OS:           "linux",
 				Architecture: "arm64",
 				Variant:      "v8",
 			},
-			matches: []specs.Platform{
+			matches: []ocispec.Platform{
 				{
 					OS:           "linux",
 					Architecture: "aarch64",
@@ -143,11 +143,11 @@ func TestParseSelector(t *testing.T) {
 			// but we leave the variant blank. This will represent the vast
 			// majority of arm images.
 			input: "linux/arm",
-			expected: specs.Platform{
+			expected: ocispec.Platform{
 				OS:           "linux",
 				Architecture: "arm",
 			},
-			matches: []specs.Platform{
+			matches: []ocispec.Platform{
 				{
 					OS:           "linux",
 					Architecture: "arm",
@@ -167,12 +167,12 @@ func TestParseSelector(t *testing.T) {
 		},
 		{
 			input: "linux/arm/v6",
-			expected: specs.Platform{
+			expected: ocispec.Platform{
 				OS:           "linux",
 				Architecture: "arm",
 				Variant:      "v6",
 			},
-			matches: []specs.Platform{
+			matches: []ocispec.Platform{
 				{
 					OS:           "linux",
 					Architecture: "armel",
@@ -182,12 +182,12 @@ func TestParseSelector(t *testing.T) {
 		},
 		{
 			input: "linux/arm/v7",
-			expected: specs.Platform{
+			expected: ocispec.Platform{
 				OS:           "linux",
 				Architecture: "arm",
 				Variant:      "v7",
 			},
-			matches: []specs.Platform{
+			matches: []ocispec.Platform{
 				{
 					OS:           "linux",
 					Architecture: "arm",
@@ -201,7 +201,7 @@ func TestParseSelector(t *testing.T) {
 		},
 		{
 			input: "arm",
-			expected: specs.Platform{
+			expected: ocispec.Platform{
 				OS:           defaultOS,
 				Architecture: "arm",
 			},
@@ -209,7 +209,7 @@ func TestParseSelector(t *testing.T) {
 		},
 		{
 			input: "armel",
-			expected: specs.Platform{
+			expected: ocispec.Platform{
 				OS:           defaultOS,
 				Architecture: "arm",
 				Variant:      "v6",
@@ -218,7 +218,7 @@ func TestParseSelector(t *testing.T) {
 		},
 		{
 			input: "armhf",
-			expected: specs.Platform{
+			expected: ocispec.Platform{
 				OS:           defaultOS,
 				Architecture: "arm",
 			},
@@ -226,7 +226,7 @@ func TestParseSelector(t *testing.T) {
 		},
 		{
 			input: "Aarch64",
-			expected: specs.Platform{
+			expected: ocispec.Platform{
 				OS:           defaultOS,
 				Architecture: "arm64",
 			},
@@ -234,7 +234,7 @@ func TestParseSelector(t *testing.T) {
 		},
 		{
 			input: "x86_64",
-			expected: specs.Platform{
+			expected: ocispec.Platform{
 				OS:           defaultOS,
 				Architecture: "amd64",
 			},
@@ -242,7 +242,7 @@ func TestParseSelector(t *testing.T) {
 		},
 		{
 			input: "Linux/x86_64",
-			expected: specs.Platform{
+			expected: ocispec.Platform{
 				OS:           "linux",
 				Architecture: "amd64",
 			},
@@ -250,7 +250,7 @@ func TestParseSelector(t *testing.T) {
 		},
 		{
 			input: "i386",
-			expected: specs.Platform{
+			expected: ocispec.Platform{
 				OS:           defaultOS,
 				Architecture: "386",
 			},
@@ -258,7 +258,7 @@ func TestParseSelector(t *testing.T) {
 		},
 		{
 			input: "linux",
-			expected: specs.Platform{
+			expected: ocispec.Platform{
 				OS:           "linux",
 				Architecture: defaultArch,
 				Variant:      defaultVariant,
@@ -267,7 +267,7 @@ func TestParseSelector(t *testing.T) {
 		},
 		{
 			input: "s390x",
-			expected: specs.Platform{
+			expected: ocispec.Platform{
 				OS:           defaultOS,
 				Architecture: "s390x",
 			},
@@ -275,7 +275,7 @@ func TestParseSelector(t *testing.T) {
 		},
 		{
 			input: "linux/s390x",
-			expected: specs.Platform{
+			expected: ocispec.Platform{
 				OS:           "linux",
 				Architecture: "s390x",
 			},
@@ -283,7 +283,7 @@ func TestParseSelector(t *testing.T) {
 		},
 		{
 			input: "macOS",
-			expected: specs.Platform{
+			expected: ocispec.Platform{
 				OS:           "darwin",
 				Architecture: defaultArch,
 				Variant:      defaultVariant,

--- a/platforms/platforms_windows.go
+++ b/platforms/platforms_windows.go
@@ -17,12 +17,12 @@
 package platforms
 
 import (
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // NewMatcher returns a Windows matcher that will match on osVersionPrefix if
 // the platform is Windows otherwise use the default matcher
-func newDefaultMatcher(platform specs.Platform) Matcher {
+func newDefaultMatcher(platform ocispec.Platform) Matcher {
 	prefix := prefix(platform.OSVersion)
 	return windowsmatcher{
 		Platform:        platform,

--- a/platforms/platforms_windows_test.go
+++ b/platforms/platforms_windows_test.go
@@ -19,7 +19,7 @@ package platforms
 import (
 	"testing"
 
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,13 +28,13 @@ func TestNormalize(t *testing.T) {
 }
 
 func TestFallbackOnOSVersion(t *testing.T) {
-	p := specs.Platform{
+	p := ocispec.Platform{
 		OS:           "windows",
 		Architecture: "amd64",
 		OSVersion:    "99.99.99.99",
 	}
 
-	other := specs.Platform{OS: p.OS, Architecture: p.Architecture}
+	other := ocispec.Platform{OS: p.OS, Architecture: p.Architecture}
 
 	m := NewMatcher(p)
 	require.True(t, m.Match(other))

--- a/services/server/server.go
+++ b/services/server/server.go
@@ -54,7 +54,7 @@ import (
 	"github.com/docker/go-metrics"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
@@ -398,7 +398,7 @@ func LoadPlugins(ctx context.Context, config *srvconfig.Config) ([]*plugin.Regis
 			f func(*grpc.ClientConn) interface{}
 
 			address = pp.Address
-			p       v1.Platform
+			p       ocispec.Platform
 			err     error
 		)
 

--- a/signals.go
+++ b/signals.go
@@ -25,7 +25,7 @@ import (
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
 	"github.com/moby/sys/signal"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // StopSignalLabel is a well-known containerd label for storing the stop
@@ -58,11 +58,11 @@ func GetOCIStopSignal(ctx context.Context, image Image, defaultSignal string) (s
 		return "", err
 	}
 	var (
-		ociimage v1.Image
-		config   v1.ImageConfig
+		ociimage ocispec.Image
+		config   ocispec.ImageConfig
 	)
 	switch ic.MediaType {
-	case v1.MediaTypeImageConfig, images.MediaTypeDockerSchema2Config:
+	case ocispec.MediaTypeImageConfig, images.MediaTypeDockerSchema2Config:
 		p, err := content.ReadBlob(ctx, image.ContentStore(), ic)
 		if err != nil {
 			return "", err

--- a/task_opts.go
+++ b/task_opts.go
@@ -29,7 +29,7 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -79,8 +79,8 @@ func WithTaskCheckpoint(im Image) NewTaskOpts {
 	}
 }
 
-func decodeIndex(ctx context.Context, store content.Provider, desc imagespec.Descriptor) (*imagespec.Index, error) {
-	var index imagespec.Index
+func decodeIndex(ctx context.Context, store content.Provider, desc ocispec.Descriptor) (*ocispec.Index, error) {
+	var index ocispec.Index
 	p, err := content.ReadBlob(ctx, store, desc)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Various variations of aliases were used for the OCI image-spec, which increases cognitive overload, making the code slightly more difficult to read.

This patch:

- updates the alias to be the same everywhere ("ocispec" seems to be the most commonly used alias accross projects; also see https://github.com/moby/moby/pull/45490)
- adds a linter to validate / enforce using the same alias.