### PR TITLE
container.Checkpoint(), WithRestoreImage(): use ocispec.AnnotationRefName

### DIFF
--- a/client/container.go
+++ b/client/container.go
@@ -42,7 +42,6 @@ import (
 )
 
 const (
-	checkpointImageNameLabel       = "org.opencontainers.image.ref.name"
 	checkpointRuntimeNameLabel     = "io.containerd.checkpoint.runtime"
 	checkpointSnapshotterNameLabel = "io.containerd.checkpoint.snapshotter"
 )
@@ -357,7 +356,7 @@ func (c *container) Checkpoint(ctx context.Context, ref string, opts ...Checkpoi
 	defer done(ctx)
 
 	// add image name to manifest
-	index.Annotations[checkpointImageNameLabel] = img.Name()
+	index.Annotations[ocispec.AnnotationRefName] = img.Name()
 	// add runtime info to index
 	index.Annotations[checkpointRuntimeNameLabel] = info.Runtime.Name
 	// add snapshotter info to index

--- a/client/container_restore_opts.go
+++ b/client/container_restore_opts.go
@@ -45,7 +45,7 @@ type RestoreOpts func(context.Context, string, *Client, Image, *imagespec.Index)
 // WithRestoreImage restores the image for the container
 func WithRestoreImage(ctx context.Context, id string, client *Client, checkpoint Image, index *imagespec.Index) NewContainerOpts {
 	return func(ctx context.Context, client *Client, c *containers.Container) error {
-		name, ok := index.Annotations[checkpointImageNameLabel]
+		name, ok := index.Annotations[imagespec.AnnotationRefName]
 		if !ok || name == "" {
 			return ErrImageNameNotFoundInIndex
 		}


### PR DESCRIPTION
- [x] ~depends on https://github.com/containerd/containerd/pull/8566~ (removed)

instead of a locally defined const