### PR TITLE
.github/workflows: add dmesg step for integration-linux 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -508,6 +508,10 @@ jobs:
           mount
           df
           losetup -l
+      - name: Kernel Message
+        if: failure()
+        run: sudo dmesg -T -f kern
+
       - uses: actions/upload-artifact@v3
         if: always()
         with:


### PR DESCRIPTION
It will be easy to debug flaky testcase if we can provide kernel log by `dmesg -T -f kern`.