### PR TITLE
notify readiness when registered plugins are ready

### DIFF
--- a/pkg/cri/cri.go
+++ b/pkg/cri/cri.go
@@ -54,6 +54,7 @@ func init() {
 }
 
 func initCRIService(ic *plugin.InitContext) (interface{}, error) {
+	ready := ic.RegisterReadiness()
 	ic.Meta.Platforms = []imagespec.Platform{platforms.DefaultSpec()}
 	ic.Meta.Exports = map[string]string{"CRIVersion": constants.CRIVersion}
 	ctx := ic.Context
@@ -99,7 +100,7 @@ func initCRIService(ic *plugin.InitContext) (interface{}, error) {
 	}
 
 	go func() {
-		if err := s.Run(); err != nil {
+		if err := s.Run(ready); err != nil {
 			log.G(ctx).WithError(err).Fatal("Failed to run CRI service")
 		}
 		// TODO(random-liu): Whether and how we can stop containerd.

--- a/pkg/cri/sbserver/service.go
+++ b/pkg/cri/sbserver/service.go
@@ -63,7 +63,7 @@ type CRIService interface {
 	// Closer is used by containerd to gracefully stop cri service.
 	io.Closer
 
-	Run() error
+	Run(ready func()) error
 
 	Register(*grpc.Server) error
 }
@@ -237,7 +237,7 @@ func (c *criService) RegisterTCP(s *grpc.Server) error {
 }
 
 // Run starts the CRI service.
-func (c *criService) Run() error {
+func (c *criService) Run(ready func()) error {
 	log.L.Info("Start subscribing containerd event")
 	c.eventMonitor.subscribe(c.client)
 
@@ -291,6 +291,7 @@ func (c *criService) Run() error {
 
 	// Set the server as initialized. GRPC services could start serving traffic.
 	c.initialized.Store(true)
+	ready()
 
 	var eventMonitorErr, streamServerErr, cniNetConfMonitorErr error
 	// Stop the whole CRI service if any of the critical service exits.

--- a/pkg/cri/server/service.go
+++ b/pkg/cri/server/service.go
@@ -62,7 +62,7 @@ type CRIService interface {
 	// Closer is used by containerd to gracefully stop cri service.
 	io.Closer
 
-	Run() error
+	Run(ready func()) error
 
 	Register(*grpc.Server) error
 }
@@ -203,7 +203,7 @@ func (c *criService) RegisterTCP(s *grpc.Server) error {
 }
 
 // Run starts the CRI service.
-func (c *criService) Run() error {
+func (c *criService) Run(ready func()) error {
 	log.L.Info("Start subscribing containerd event")
 	c.eventMonitor.subscribe(c.client)
 
@@ -266,6 +266,7 @@ func (c *criService) Run() error {
 
 	// Set the server as initialized. GRPC services could start serving traffic.
 	c.initialized.Store(true)
+	ready()
 
 	var eventMonitorErr, streamServerErr, cniNetConfMonitorErr error
 	// Stop the whole CRI service if any of the critical service exits.

--- a/plugin/context.go
+++ b/plugin/context.go
@@ -28,12 +28,13 @@ import (
 
 // InitContext is used for plugin initialization
 type InitContext struct {
-	Context      context.Context
-	Root         string
-	State        string
-	Config       interface{}
-	Address      string
-	TTRPCAddress string
+	Context           context.Context
+	Root              string
+	State             string
+	Config            interface{}
+	Address           string
+	TTRPCAddress      string
+	RegisterReadiness func() func()
 
 	// deprecated: will be removed in 2.0, use plugin.EventType
 	Events *exchange.Exchange

--- a/services/server/server.go
+++ b/services/server/server.go
@@ -218,6 +218,7 @@ func New(ctx context.Context, config *srvconfig.Config) (*Server, error) {
 		initContext.Events = events
 		initContext.Address = config.GRPC.Address
 		initContext.TTRPCAddress = config.TTRPC.Address
+		initContext.RegisterReadiness = s.RegisterReadiness
 
 		// load the plugin specific configuration if it is provided
 		if p.Config != nil {
@@ -293,6 +294,7 @@ type Server struct {
 	tcpServer   *grpc.Server
 	config      *srvconfig.Config
 	plugins     []*plugin.Plugin
+	ready       sync.WaitGroup
 }
 
 // ServeGRPC provides the containerd grpc APIs on the provided listener
@@ -368,6 +370,17 @@ func (s *Server) Stop() {
 				Error("failed to close plugin")
 		}
 	}
+}
+
+func (s *Server) RegisterReadiness() func() {
+	s.ready.Add(1)
+	return func() {
+		s.ready.Done()
+	}
+}
+
+func (s *Server) Wait() {
+	s.ready.Wait()
 }
 
 // LoadPlugins loads all plugins into containerd and generates an ordered graph


### PR DESCRIPTION
Fix: [#8468](https://github.com/containerd/containerd/issues/8468)

Added `RegisterReadiness` func to `InitContext` to allow plugins to register themselves as required plugins which will be waited for the readiness before systemd notification is sent. This PR only registers CRI plugin to address [#8468](https://github.com/containerd/containerd/issues/8468).