### PR TITLE
fix(docs): minor fix on the windows installation steps

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -116,7 +116,7 @@ curl.exe -L https://github.com/containerd/containerd/releases/download/v$Version
 tar.exe xvf .\containerd-windows-amd64.tar.gz
 
 # Copy and configure
-Copy-Item -Path ".\bin\*" -Destination "$Env:ProgramFiles\containerd" -Recurse -Force
+Copy-Item -Path ".\bin\*" -Destination "$Env:ProgramFiles\containerd" -Recurse -Container:$false -Force
 cd $Env:ProgramFiles\containerd\
 .\containerd.exe config default | Out-File config.toml -Encoding ascii
 


### PR DESCRIPTION
If this command is used without the parameter "-Container:$false" and the "containerd" directory does not already exist all files will be merged into a single "containerd" file instead of a new directory.