### PR TITLE
Fix: Correct the spelling of repository within the NRI plugin documentation.

### DIFF
--- a/docs/NRI.md
+++ b/docs/NRI.md
@@ -13,7 +13,7 @@ use to integrate to and interact with NRI and plugins. In principle
 any NRI plugin should be able to work with NRI-enabled runtimes.
 
 For a detailed description of NRI and its capabilities please take a
-look at the [NRI respository](https://github.com/containerd/nri).
+look at the [NRI repository](https://github.com/containerd/nri).
 
 ## Containerd NRI Integration
 


### PR DESCRIPTION
These changes fix a spelling error found within the NRI plugin documentation (`NRI.md`) kept within the `docs` project directory.

In `docs/NRI.md`, the following spelling mistake was resolved:
* a misspelled word `respository` has been corrected to `repository`, [following Merriam-Webster's spelling of the word](https://www.merriam-webster.com/dictionary/repository).