### PR TITLE
fix port-forward error info

### DIFF
--- a/pkg/cri/sbserver/helpers.go
+++ b/pkg/cri/sbserver/helpers.go
@@ -136,6 +136,7 @@ func (c *criService) getSandboxDevShm(id string) string {
 
 // makeSandboxName generates sandbox name from sandbox metadata. The name
 // generated is unique as long as sandbox metadata is unique.
+// If you modify the way the name is generated, you need to modify this method at the same time, streaming.SplitSandboxName
 func makeSandboxName(s *runtime.PodSandboxMetadata) string {
 	return strings.Join([]string{
 		s.Name,                       // 0

--- a/pkg/cri/sbserver/helpers_test.go
+++ b/pkg/cri/sbserver/helpers_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/containerd/containerd/oci"
 	criconfig "github.com/containerd/containerd/pkg/cri/config"
 	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
+	"github.com/containerd/containerd/pkg/cri/streaming"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/protobuf/types"
 	runcoptions "github.com/containerd/containerd/runtime/v2/runc/options"
@@ -558,4 +559,19 @@ func TestHostNetwork(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_makeSandboxName(t *testing.T) {
+	sandboxName := makeSandboxName(&runtime.PodSandboxMetadata{
+		Name:      "nginx",
+		Uid:       "1234567890",
+		Namespace: "default",
+		Attempt:   0,
+	})
+	assert.Equal(t, "nginx_default_1234567890_0", sandboxName)
+	metadata := streaming.SplitSandboxName(sandboxName)
+	assert.Equal(t, "nginx", metadata.Name)
+	assert.Equal(t, "1234567890", metadata.Uid)
+	assert.Equal(t, "default", metadata.Namespace)
+	assert.Equal(t, uint32(0), metadata.Attempt)
 }


### PR DESCRIPTION
issue: https://github.com/containerd/containerd/issues/8490
issue: https://github.com/kubernetes/kubernetes/issues/117076

Apart from obtaining the pod name by modifying the interface of CRI, it is also possible to obtain the pod name by modifying the runtime. This is one of the implementations, which seems better as it does not require modifying CRI.