### PR TITLE
Add cpuset flags to 'ctr run'

### DIFF
--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -86,6 +86,10 @@ var platformRunFlags = []cli.Flag{
 		Name:  "cpuset-cpus",
 		Usage: "Set the CPUs the container will run in (e.g., 1-2,4)",
 	},
+	cli.StringFlag{
+		Name:  "cpuset-mems",
+		Usage: "Set the memory nodes the container will run in (e.g., 1-2,4)",
+	},
 }
 
 // NewContainer creates a new container
@@ -299,6 +303,10 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 
 		if cpusetCpus := context.String("cpuset-cpus"); len(cpusetCpus) > 0 {
 			opts = append(opts, oci.WithCPUs(cpusetCpus))
+		}
+
+		if cpusetMems := context.String("cpuset-mems"); len(cpusetMems) > 0 {
+			opts = append(opts, oci.WithCPUsMems(cpusetMems))
 		}
 
 		if shares := context.Int("cpu-shares"); shares > 0 {

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -82,6 +82,10 @@ var platformRunFlags = []cli.Flag{
 		Usage: "Set the cpu shares",
 		Value: 1024,
 	},
+	cli.StringFlag{
+		Name:  "cpuset-cpus",
+		Usage: "Set the CPUs the container will run in (e.g., 1-2,4)",
+	},
 }
 
 // NewContainer creates a new container
@@ -291,6 +295,10 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 				quota  = int64(cpus * 100000.0)
 			)
 			opts = append(opts, oci.WithCPUCFS(quota, period))
+		}
+
+		if cpusetCpus := context.String("cpuset-cpus"); len(cpusetCpus) > 0 {
+			opts = append(opts, oci.WithCPUs(cpusetCpus))
 		}
 
 		if shares := context.Int("cpu-shares"); shares > 0 {


### PR DESCRIPTION
This pull request adds two new flags to `ctr run` command. The flags allow specifying [cpuset](https://www.kernel.org/doc/Documentation/cgroup-v1/cpusets.txt) details. "cpus" defines the CPU cores the container is allowed to use, while "mems" defines the memory nodes. Having these flags in ctr allows testing cpu and memory pinning capabilities.