### PR TITLE
Add handling of a '.' commondir and bounds checking to mount_linux

### DIFF
--- a/mount/mount_linux.go
+++ b/mount/mount_linux.go
@@ -274,13 +274,16 @@ func compactLowerdirOption(opts []string) (string, []string) {
 	// in order to avoid to get snapshots/x, should be back to parent dir.
 	// however, there is assumption that the common dir is ${root}/io.containerd.v1.overlayfs/snapshots.
 	commondir = path.Dir(commondir)
-	if commondir == "/" {
+	if commondir == "/" || commondir == "." {
 		return "", opts
 	}
 	commondir = commondir + "/"
 
 	newdirs := make([]string, 0, len(dirs))
 	for _, dir := range dirs {
+		if len(dir) <= len(commondir) {
+			return "", opts
+		}
 		newdirs = append(newdirs, dir[len(commondir):])
 	}
 

--- a/mount/mount_linux_test.go
+++ b/mount/mount_linux_test.go
@@ -84,6 +84,13 @@ func TestCompactLowerdirOption(t *testing.T) {
 			"",
 			[]string{"lowerdir=/snapshots/1/fs:/other_snapshots/1/fs"},
 		},
+
+		// if common dir is .
+		{
+			[]string{"lowerdir=a:aaa"},
+			"",
+			[]string{"lowerdir=a:aaa"},
+		},
 	}
 
 	for i, tc := range tcases {


### PR DESCRIPTION
This PR adds handling and a test case for a `commondir` of `.` which could cause a `slice bounds out of range` error when compacting `lowerdir`. 

This was reported by OSS-Fuzz: https://oss-fuzz.com/testcase-detail/6548471126818816