### PR TITLE
Remove events from init context

### DIFF
--- a/events/plugin/plugin.go
+++ b/events/plugin/plugin.go
@@ -17,6 +17,7 @@
 package plugin
 
 import (
+	"github.com/containerd/containerd/events/exchange"
 	"github.com/containerd/containerd/plugin"
 )
 
@@ -25,8 +26,7 @@ func init() {
 		Type: plugin.EventPlugin,
 		ID:   "exchange",
 		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
-			// TODO: In 2.0, create exchange since ic.Events will be removed
-			return ic.Events, nil
+			return exchange.NewExchange(), nil
 		},
 	})
 }

--- a/integration/build_local_containerd_helper_test.go
+++ b/integration/build_local_containerd_helper_test.go
@@ -31,7 +31,6 @@ import (
 	srvconfig "github.com/containerd/containerd/services/server/config"
 
 	_ "github.com/containerd/containerd/diff/walking/plugin"
-	"github.com/containerd/containerd/events/exchange"
 	_ "github.com/containerd/containerd/events/plugin"
 	_ "github.com/containerd/containerd/gc/scheduler"
 	_ "github.com/containerd/containerd/leases/plugin"
@@ -72,9 +71,6 @@ func buildLocalContainerdClient(t *testing.T, tmpDir string) *containerd.Client 
 
 	// init plugins
 	var (
-		// TODO: Remove this in 2.0 and let event plugin crease it
-		events = exchange.NewExchange()
-
 		initialized = plugin.NewPluginSet()
 
 		// NOTE: plugin.Set doesn't provide the way to get all the same
@@ -97,7 +93,6 @@ func buildLocalContainerdClient(t *testing.T, tmpDir string) *containerd.Client 
 			config.Root,
 			config.State,
 		)
-		initContext.Events = events
 
 		// load the plugin specific configuration if it is provided
 		if p.Config != nil {

--- a/integration/client/go.mod
+++ b/integration/client/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect

--- a/integration/client/go.sum
+++ b/integration/client/go.sum
@@ -742,7 +742,6 @@ github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avu
 github.com/docker/docker-credential-helpers v0.6.4/go.mod h1:ofX3UI0Gz1TteYBjtgs07O36Pyasyp66D2uKT7H8W1c=
 github.com/docker/docker-credential-helpers v0.7.0/go.mod h1:rETQfLdHNT3foU5kuNkFR1R1V12OJRRO5lzt2D1b5X0=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
-github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c h1:+pKlWGMw7gf6bQ+oDZB4KHQFypsfjYlq/C4rfL7D3g8=
 github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c/go.mod h1:Uw6UezgYA44ePAFQYUehOuCzmy5zmg/+nl2ZfMWGkpA=
 github.com/docker/go-metrics v0.0.1/go.mod h1:cG1hvH2utMXtqgqqYE9plW6lDxS3/5ayHzueweSI3Vw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=

--- a/metadata/plugin/plugin.go
+++ b/metadata/plugin/plugin.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/events"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/metadata"
 	"github.com/containerd/containerd/pkg/timeout"
@@ -85,6 +86,7 @@ func init() {
 		ID:   "bolt",
 		Requires: []plugin.Type{
 			plugin.ContentPlugin,
+			plugin.EventPlugin,
 			plugin.SnapshotPlugin,
 		},
 		Config: &BoltConfig{
@@ -115,6 +117,11 @@ func init() {
 					continue
 				}
 				snapshotters[name] = sn.(snapshots.Snapshotter)
+			}
+
+			ep, err := ic.Get(plugin.EventPlugin)
+			if err != nil {
+				return nil, err
 			}
 
 			shared := true
@@ -163,7 +170,7 @@ func init() {
 			}
 
 			dbopts := []metadata.DBOpt{
-				metadata.WithEventsPublisher(ic.Events),
+				metadata.WithEventsPublisher(ep.(events.Publisher)),
 			}
 
 			if !shared {

--- a/plugin/context.go
+++ b/plugin/context.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 
 	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/events/exchange"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -36,10 +35,8 @@ type InitContext struct {
 	TTRPCAddress      string
 	RegisterReadiness func() func()
 
-	// deprecated: will be removed in 2.0, use plugin.EventType
-	Events *exchange.Exchange
-
-	Meta *Meta // plugins can fill in metadata at init.
+	// Meta is metadata plugins can fill in at init
+	Meta *Meta
 
 	plugins *Set
 }

--- a/services/images/local.go
+++ b/services/images/local.go
@@ -41,6 +41,7 @@ func init() {
 		Type: plugin.ServicePlugin,
 		ID:   services.ImagesService,
 		Requires: []plugin.Type{
+			plugin.EventPlugin,
 			plugin.MetadataPlugin,
 			plugin.GCPlugin,
 		},
@@ -54,9 +55,14 @@ func init() {
 				return nil, err
 			}
 
+			ep, err := ic.Get(plugin.EventPlugin)
+			if err != nil {
+				return nil, err
+			}
+
 			return &local{
 				store:     metadata.NewImageStore(m.(*metadata.DB)),
-				publisher: ic.Events,
+				publisher: ep.(events.Publisher),
 				gc:        g.(gcScheduler),
 			}, nil
 		},

--- a/services/server/server.go
+++ b/services/server/server.go
@@ -41,7 +41,6 @@ import (
 	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/diff"
 	diffproxy "github.com/containerd/containerd/diff/proxy"
-	"github.com/containerd/containerd/events/exchange"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/pkg/dialer"
 	"github.com/containerd/containerd/pkg/timeout"
@@ -196,8 +195,6 @@ func New(ctx context.Context, config *srvconfig.Config) (*Server, error) {
 			ttrpcServer: ttrpcServer,
 			config:      config,
 		}
-		// TODO: Remove this in 2.0 and let event plugin crease it
-		events      = exchange.NewExchange()
 		initialized = plugin.NewPluginSet()
 		required    = make(map[string]struct{})
 	)
@@ -215,7 +212,6 @@ func New(ctx context.Context, config *srvconfig.Config) (*Server, error) {
 			config.Root,
 			config.State,
 		)
-		initContext.Events = events
 		initContext.Address = config.GRPC.Address
 		initContext.TTRPCAddress = config.TTRPC.Address
 		initContext.RegisterReadiness = s.RegisterReadiness


### PR DESCRIPTION
Events from the init context have been replaced by the events plugin and marked for removal in 2.0.