### PR TITLE
CRI: de-deprecate `cni.conf_template`

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -387,7 +387,6 @@ The deprecated properties in [`config.toml`](./docs/cri/config.md) are shown in 
 | Property Group                                                       | Property                     | Deprecation release | Target release for removal | Recommendation                                  |
 |----------------------------------------------------------------------|------------------------------|---------------------|----------------------------|-------------------------------------------------|
 |`[plugins."io.containerd.grpc.v1.cri"]`                               | `systemd_cgroup`             | containerd v1.3     | containerd v2.0 ✅         | Use `SystemdCgroup` in runc options (see below) |
-|`[plugins."io.containerd.grpc.v1.cri".cni]`                           | `conf_template`              | containerd v1.?     | containerd v2.0            | Create a CNI config in `/etc/cni/net.d`         |
 |`[plugins."io.containerd.grpc.v1.cri".containerd]`                    | `untrusted_workload_runtime` | containerd v1.2     | containerd v2.0 ✅         | Create `untrusted` runtime in `runtimes`        |
 |`[plugins."io.containerd.grpc.v1.cri".containerd]`                    | `default_runtime`            | containerd v1.3     | containerd v2.0 ✅         | Use `default_runtime_name`                      |
 |`[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.*]`         | `runtime_engine`             | containerd v1.3     | containerd v2.0 ✅         | Use runtime v2                                  |
@@ -396,6 +395,11 @@ The deprecated properties in [`config.toml`](./docs/cri/config.md) are shown in 
 |`[plugins."io.containerd.grpc.v1.cri".registry]`                      | `auths`                      | containerd v1.3     | containerd v2.0            | Use [`ImagePullSecrets`](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/). See also [#8228](https://github.com/containerd/containerd/issues/8228). |
 |`[plugins."io.containerd.grpc.v1.cri".registry]`                      | `configs`                    | containerd v1.5     | containerd v2.0            | Use [`config_path`](./docs/hosts.md)            |
 |`[plugins."io.containerd.grpc.v1.cri".registry]`                      | `mirrors`                    | containerd v1.5     | containerd v2.0            | Use [`config_path`](./docs/hosts.md)            |
+
+> **Note**
+>
+> CNI Config Template (`plugins."io.containerd.grpc.v1.cri".cni.conf_template`) was once deprecated in v1.7.0,
+> but its deprecation was cancelled in v1.7.2.
 
 <details><summary>Example: runc option <code>SystemdCgroup</code></summary><p>
 

--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -402,9 +402,6 @@ version = 2
     # If this is set, containerd will generate a cni config file from the
     # template. Otherwise, containerd will wait for the system admin or cni
     # daemon to drop the config file into the conf_dir.
-    # This is a temporary backward-compatible solution for kubenet users
-    # who don't have a cni daemonset in production yet.
-    # This will be deprecated when kubenet is deprecated.
     # See the "CNI Config Template" section for more details.
     conf_template = ""
     # ip_pref specifies the strategy to use when selecting the main IP address for a pod.
@@ -502,12 +499,6 @@ runtime will be used. For example, see
 [Create an untrusted pod using Kata Containers](https://github.com/kata-containers/kata-containers/blob/main/docs/how-to/containerd-kata.md#kata-containers-as-the-runtime-for-untrusted-workload).
 
 ## CNI Config Template
-
-Ideally the cni config should be placed by system admin or cni daemon like calico,
-weaveworks etc. However, there are still users using [kubenet](https://kubernetes.io/docs/concepts/cluster-administration/network-plugins/#kubenet)
-today, who don't have a cni daemonset in production. The cni config template is
-a temporary backward-compatible solution for them. This is expected to be
-deprecated when kubenet is deprecated.
 
 The cni config template uses the [golang
 template](https://golang.org/pkg/text/template/) format. Currently supported

--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -140,12 +140,9 @@ type CniConfig struct {
 	// When it is set, containerd will get cidr(s) from kubelet to replace {{.PodCIDR}},
 	// {{.PodCIDRRanges}} or {{.Routes}} in the template, and write the config into
 	// NetworkPluginConfDir.
-	// Ideally the cni config should be placed by system admin or cni daemon like calico,
-	// weaveworks etc. However, there are still users using kubenet
-	// (https://kubernetes.io/docs/concepts/cluster-administration/network-plugins/#kubenet)
-	// today, who don't have a cni daemonset in production. NetworkPluginConfTemplate is
-	// a temporary backward-compatible solution for them.
-	// DEPRECATED: use CNI configs
+	//
+	// NetworkPluginConfTemplate was once deprecated in containerd v1.7.0,
+	// but its deprecation was cancelled in v1.7.2.
 	NetworkPluginConfTemplate string `toml:"conf_template" json:"confTemplate"`
 	// IPPreference specifies the strategy to use when selecting the main IP address for a pod.
 	//


### PR DESCRIPTION
This was once deprecated in v1.7.0, but it turned out to be still useful.

Partially revert #8241
Close #8596