### PR TITLE
Add Docker Hub authentication example

### DIFF
--- a/docs/cri/registry.md
+++ b/docs/cri/registry.md
@@ -41,6 +41,25 @@ not specified by Kubernetes via CRI.
 
 After modifying this config, you need to restart the `containerd` service.
 
+### Configure Docker Hub Credentials Example
+
+You may want to configure Docker Hub credentials to pull images from Docker Hub.
+This allows you to pull public and private images from Docker Hub without hitting rate limits.
+
+To configure Docker Hub credentials, modify `/etc/containerd/config.toml` as follows:
+
+```toml
+[plugins."io.containerd.grpc.v1.cri".registry.configs."registry-1.docker.io".auth]
+  username = "example-username"
+  password = "example-password"
+```
+
+Restart the `containerd` service: `sudo systemctl restart containerd`.
+
+Verify your configuration: `crictl info`
+
+Verify that you can pull images from Docker Hub: `crictl pull busybox`
+
 ### Configure Registry Credentials Example - GCR with Service Account Key Authentication
 
 If you don't already have Google Container Registry (GCR) set-up then you need to do the following steps:


### PR DESCRIPTION
Document how to configure `containerd` to authenticate to a Docker Hub registry.

Resolves https://github.com/containerd/containerd/issues/8612