### PR TITLE
[release/1.6 backport] remotes/docker: ResolverOptions: fix deprecation comments

### DIFF
--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -95,25 +95,30 @@ type ResolverOptions struct {
 	Tracker StatusTracker
 
 	// Authorizer is used to authorize registry requests
-	// Deprecated: use Hosts
+	//
+	// Deprecated: use Hosts.
 	Authorizer Authorizer
 
 	// Credentials provides username and secret given a host.
 	// If username is empty but a secret is given, that secret
 	// is interpreted as a long lived token.
-	// Deprecated: use Hosts
+	//
+	// Deprecated: use Hosts.
 	Credentials func(string) (string, string, error)
 
 	// Host provides the hostname given a namespace.
-	// Deprecated: use Hosts
+	//
+	// Deprecated: use Hosts.
 	Host func(string) (string, error)
 
 	// PlainHTTP specifies to use plain http and not https
-	// Deprecated: use Hosts
+	//
+	// Deprecated: use Hosts.
 	PlainHTTP bool
 
 	// Client is the http client to used when making registry requests
-	// Deprecated: use Hosts
+	//
+	// Deprecated: use Hosts.
 	Client *http.Client
 }
 


### PR DESCRIPTION
- backport of https://github.com/containerd/containerd/pull/8619

Go deprecation comments must be formatted to have an empty comment line before them. Fix the formatting to make sure linters and editors detect that these are deprecated.


(cherry picked from commit 52997ea983fb8b655d4946552369d811fc3770de)