### PR TITLE
[release/1.7] fix: cio.Cancel() should close the pipes

### DIFF
--- a/cio/io_unix.go
+++ b/cio/io_unix.go
@@ -98,7 +98,14 @@ func copyIO(fifos *FIFOSet, ioset *Streams) (*cio, error) {
 		config:  fifos.Config,
 		wg:      wg,
 		closers: append(pipes.closers(), fifos),
-		cancel:  cancel,
+		cancel: func() {
+			cancel()
+			for _, c := range pipes.closers() {
+				if c != nil {
+					c.Close()
+				}
+			}
+		},
 	}, nil
 }
 


### PR DESCRIPTION
PR is a backport for #8334 (82ec62b).