### PR TITLE
docs: explain how to cherry-pick a merge commit for backports

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -193,6 +193,13 @@ process:
 	```console
 	$ git cherry-pick -xsS <commit>
 	```
+
+   (Tips) If you see an error similar to the following one, add `-m 1` to the `git cherry-pick` command.
+   ```sh
+   error: commit 9e834e761aaed9733ee2aed0329960b21ba1e61e is a merge but no -m option was given.
+   fatal: cherry-pick failed
+   ```
+
    (Optional) If other commits exist in the main branch which are related
    to the cherry-picked commit; eg: fixes to the main PR. It is recommended
    to cherry-pick those commits also into this same `my-backport-branch`.


### PR DESCRIPTION
`1` is chosen because that's the branch that's merged into (i.e., `main`), and that's what we want.

Folks can also read the Git documentation or [this Stackoverflow post](https://stackoverflow.com/questions/40148442/mainline-parent-number-when-cherry-picking-merge-commits) to understand what merge parent number is and which one should be chosen, but having this tip at hand may save some time there.

That said, feel free to close this PR if this is too general to appear in containerd's doc, thanks!