### PR TITLE
Replace `atomicBool` with the standard library `atomic.Bool`

### DIFF
--- a/pkg/process/init.go
+++ b/pkg/process/init.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/containerd/console"
@@ -62,7 +63,7 @@ type Init struct {
 	io       *processIO
 	runtime  *runc.Runc
 	// pausing preserves the pausing state.
-	pausing      *atomicBool
+	pausing      atomic.Bool
 	status       int
 	exited       time.Time
 	pid          int
@@ -97,7 +98,6 @@ func New(id string, runtime *runc.Runc, stdio stdio.Stdio) *Init {
 	p := &Init{
 		id:        id,
 		runtime:   runtime,
-		pausing:   new(atomicBool),
 		stdio:     stdio,
 		status:    0,
 		waitBlock: make(chan struct{}),
@@ -240,7 +240,7 @@ func (p *Init) ExitedAt() time.Time {
 
 // Status of the process
 func (p *Init) Status(ctx context.Context) (string, error) {
-	if p.pausing.get() {
+	if p.pausing.Load() {
 		return "pausing", nil
 	}
 

--- a/pkg/process/init_state.go
+++ b/pkg/process/init_state.go
@@ -235,12 +235,12 @@ func (s *runningState) transition(name string) error {
 }
 
 func (s *runningState) Pause(ctx context.Context) error {
-	s.p.pausing.set(true)
+	s.p.pausing.Store(true)
 	// NOTE "pausing" will be returned in the short window
 	// after `transition("paused")`, before `pausing` is reset
 	// to false. That doesn't break the state machine, just
 	// delays the "paused" state a little bit.
-	defer s.p.pausing.set(false)
+	defer s.p.pausing.Store(false)
 
 	if err := s.p.runtime.Pause(ctx, s.p.id); err != nil {
 		return s.p.runtimeError(err, "OCI runtime pause failed")

--- a/pkg/process/utils.go
+++ b/pkg/process/utils.go
@@ -27,7 +27,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/containerd/containerd/errdefs"
@@ -52,20 +51,6 @@ func (s *safePid) get() int {
 	s.Lock()
 	defer s.Unlock()
 	return s.pid
-}
-
-type atomicBool int32
-
-func (ab *atomicBool) set(b bool) {
-	if b {
-		atomic.StoreInt32((*int32)(ab), 1)
-	} else {
-		atomic.StoreInt32((*int32)(ab), 0)
-	}
-}
-
-func (ab *atomicBool) get() bool {
-	return atomic.LoadInt32((*int32)(ab)) == 1
 }
 
 // TODO(mlaventure): move to runc package?


### PR DESCRIPTION
Code optimization:
* Remove `atomicBool` from `pkg/process/utils.go` and use standard library `atomic.Bool`