### PR TITLE
[release/1.7] Prepare release notes for v1.7.2

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -76,6 +76,7 @@ Justin Terry <juterry@microsoft.com>
 Justin Terry <juterry@microsoft.com> <jterry75@users.noreply.github.com>
 Kante <kerthcet@gmail.com>
 Kazuyoshi Kato <kato.kazuyoshi@gmail.com> <katokazu@amazon.com>
+Kazuyoshi Kato <kato.kazuyoshi@gmail.com> <kaz@fly.io>
 Kenfe-Mickaël Laventure <mickael.laventure@gmail.com>
 Kevin Kern <kaiwentan@harmonycloud.cn>
 Kevin Parsons <kevpar@microsoft.com> <kevpar@users.noreply.github.com>

--- a/releases/v1.7.2.toml
+++ b/releases/v1.7.2.toml
@@ -1,0 +1,27 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release
+previous = "v1.7.1"
+
+pre_release = false
+
+preface = """\
+The second patch release for containerd 1.7 includes enhancements to CRI sandbox mode,
+Windows snapshot mounting support, and CRI and container IO bug fixes.
+
+### CRI/Sandbox Updates
+* **Publish sandbox events** ([#8613](https://github.com/containerd/containerd/pull/8613))
+* **Make stats respect sandbox's platform** ([#8604](https://github.com/containerd/containerd/pull/8604))
+
+### Other Notable Updates
+* **Mount snapshots on Windows** ([#8616](https://github.com/containerd/containerd/pull/8616))
+* **Notify readiness when registered plugins are ready** ([#8584](https://github.com/containerd/containerd/pull/8584))
+* **Fix cio.Cancel() should close pipes** ([#8624](https://github.com/containerd/containerd/pull/8624))
+* **CDI: Use CRI Config.CDIDevices field for CDI injection** ([#8519](https://github.com/containerd/containerd/pull/8519))
+
+See the changelog for complete list of changes"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.7.1+unknown"
+	Version = "1.7.2+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Full notes: https://gist.github.com/dcantah/a36f91855eb96f412c912896829b8c13

containerd 1.7.2

Welcome to the v1.7.2 release of containerd!

The second patch release for containerd 1.7 includes enhancements to CRI sandbox mode, 
Windows snapshot mounting support, and CRI and container IO bug fixes.

### CRI/Sandbox Updates
* **Publish sandbox events** ([#8613](https://github.com/containerd/containerd/pull/8613))
* **Make stats respect sandbox's platform** ([#8604](https://github.com/containerd/containerd/pull/8604))

### Other Notable Updates
* **Mount snapshots on Windows** ([#8616](https://github.com/containerd/containerd/pull/8616))
* **Notify readiness when registered plugins are ready** ([#8584](https://github.com/containerd/containerd/pull/8584))
* **Fix cio.Cancel() should close pipes** ([#8624](https://github.com/containerd/containerd/pull/8624))
* **CDI: Use CRI Config.CDIDevices field for CDI injection** ([#8519](https://github.com/containerd/containerd/pull/8519))

See the changelog for complete list of changes

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Gabriel Adrian Samfira
* Paul "TBBle" Hampson
* Derek McGowan
* Maksym Pavlenko
* Phil Estes
* Austin Vazquez
* Akihiro Suda
* Danny Canter
* Kazuyoshi Kato
* Samuel Karp
* Sebastiaan van Stijn
* Ed Bartosh
* Henry Wang
* Hsing-Yu (David) Chen
* Jan Dubois
* Kazuyoshi Kato
* Mike Brown
* Wei Fu
* helen
