### PR TITLE
add harbor rc for issuing a token in the comments

### DIFF
--- a/remotes/docker/authorizer.go
+++ b/remotes/docker/authorizer.go
@@ -304,6 +304,7 @@ func (ah *authHandler) doBearerAuth(ctx context.Context) (token, refreshToken st
 				// As of September 2017, GCR is known to return 404.
 				// As of February 2018, JFrog Artifactory is known to return 401.
 				// As of January 2022, ACR is known to return 400.
+				// As of May 2023, Harbor is known to return 405.
 				if (errStatus.StatusCode == 405 && to.Username != "") || errStatus.StatusCode == 404 || errStatus.StatusCode == 401 || errStatus.StatusCode == 400 {
 					resp, err := auth.FetchToken(ctx, ah.client, ah.header, to)
 					if err != nil {


### PR DESCRIPTION
When attempting to issue a token, Harbor is returning a 405 error for the POST request.