### PR TITLE
[1.7 backport] Fix panic when remote differ returns empty result

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -105,6 +105,9 @@ func (r *diffRemote) Compare(ctx context.Context, a, b []mount.Mount, opts ...di
 }
 
 func toDescriptor(d *types.Descriptor) ocispec.Descriptor {
+	if d == nil {
+		return ocispec.Descriptor{}
+	}
 	return ocispec.Descriptor{
 		MediaType:   d.MediaType,
 		Digest:      digest.Digest(d.Digest),


### PR DESCRIPTION
- backport of https://github.com/containerd/containerd/pull/8460

⚠️ I had to adjust the patch because 3784c1c9170d8f3af247f95a34817250a1ca2b93 (https://github.com/containerd/containerd/pull/8399) is not in the 1.7 branch, and moved this function from diff.go to proxy/diff.go

^^ I also don't know if that means that this patch is not needed without the other PR in this branch (/cc @dmcgowan)



(cherry picked from commit 0d975230e1862110d7885d490bc8d20c9caada30)