### PR TITLE
RELEASES.md: de-deprecation of CNI conf_template will be v1.7.3

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -404,7 +404,7 @@ The deprecated properties in [`config.toml`](./docs/cri/config.md) are shown in 
 > **Note**
 >
 > CNI Config Template (`plugins."io.containerd.grpc.v1.cri".cni.conf_template`) was once deprecated in v1.7.0,
-> but its deprecation was cancelled in v1.7.2.
+> but its deprecation was cancelled in v1.7.3.
 
 <details><summary>Example: runc option <code>SystemdCgroup</code></summary><p>
 

--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -145,7 +145,7 @@ type CniConfig struct {
 	// need to fetch the node object through some external process (which has scalability, auth, complexity issues).
 	// It is currently heavily used in kubernetes-containerd CI testing
 	// NetworkPluginConfTemplate was once deprecated in containerd v1.7.0,
-	// but its deprecation was cancelled in v1.7.2.
+	// but its deprecation was cancelled in v1.7.3.
 	NetworkPluginConfTemplate string `toml:"conf_template" json:"confTemplate"`
 	// IPPreference specifies the strategy to use when selecting the main IP address for a pod.
 	//


### PR DESCRIPTION
Cherry-pick of PR #8606 missed the v1.7.2 milestone:
- #8638 