### PR TITLE
[release/1.6 backport] Fix panic when remote differ returns empty result

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -86,6 +86,9 @@ func (r *diffRemote) Compare(ctx context.Context, a, b []mount.Mount, opts ...di
 }
 
 func toDescriptor(d *types.Descriptor) ocispec.Descriptor {
+	if d == nil {
+		return ocispec.Descriptor{}
+	}
 	return ocispec.Descriptor{
 		MediaType:   d.MediaType,
 		Digest:      d.Digest,


### PR DESCRIPTION
- backport of https://github.com/containerd/containerd/pull/8460

⚠️ I had to adjust the patch because 3784c1c9170d8f3af247f95a34817250a1ca2b93 (https://github.com/containerd/containerd/pull/8399) is not in the 1.6 branch, and moved this function from diff.go to proxy/diff.go


(cherry picked from commit 0d975230e1862110d7885d490bc8d20c9caada30)