### PR TITLE
Support device path mapping and permission in ctr

### DIFF
--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -350,7 +350,20 @@ func NewContainer(ctx context.Context, client *containerd.Client, cliContext *cl
 				cdiDeviceIDs = append(cdiDeviceIDs, dev)
 				continue
 			}
-			opts = append(opts, oci.WithDevices(dev, "", "rwm"))
+			parts := strings.Split(dev, ":")
+			if len(parts) > 3 {
+				return nil, errors.New("--device requires the format 'hostpath:containerpath:permission', while containerpath and permission are optional")
+			}
+			dev = parts[0]
+			containerPath := ""
+			if len(parts) > 1 {
+				containerPath = parts[1]
+			}
+			permissions := "rwm"
+			if len(parts) > 2 {
+				permissions = parts[2]
+			}
+			opts = append(opts, oci.WithDevices(dev, containerPath, permissions))
 		}
 		if len(cdiDeviceIDs) > 0 {
 			opts = append(opts, withStaticCDIRegistry())


### PR DESCRIPTION
issue: https://github.com/containerd/containerd/issues/5046

Usage:
   UNIX:
```
      ctr run --device=<PATH>
      ctr run --device=<HOST PATH>:<CONTAINER PATH>
      ctr run --device=<HOST PATH>:<CONTAINER PATH>:<PERMISSION>
```
  Window: (Support cli to set HOST PATH, don't to set CONTAINER PATH)
```
     ctr run --device=IDType://ID
``` 
Use the `:` symbol as the device separator. In this issue https://github.com/moby/moby/issues/8604, it is discussed that it is difficult to design this separator in the cli. Currently, docker only supports the `:` symbol。