### PR TITLE
fix release `ticker` correctly in `HandleProgress`

### DIFF
--- a/pkg/transfer/local/progress.go
+++ b/pkg/transfer/local/progress.go
@@ -87,6 +87,7 @@ func (j *ProgressTracker) HandleProgress(ctx context.Context, pf transfer.Progre
 	// Instead of ticker, just delay
 	jobs := map[digest.Digest]*jobStatus{}
 	tc := time.NewTicker(time.Millisecond * 300)
+	defer tc.Stop()
 
 	update := func() {
 		// TODO: Filter by references


### PR DESCRIPTION
Need to release `ticker` when `HandleProgress` has finished. 

It will cause memory leak if we do not stop it.