### PR TITLE
[release/1.7] [cri] Windows Pod Stats: Add a check to skip stats for containers that are not running

### DIFF
--- a/pkg/cri/sbserver/sandbox_stats_windows.go
+++ b/pkg/cri/sbserver/sandbox_stats_windows.go
@@ -129,6 +129,11 @@ func (c *criService) toPodSandboxStats(sandbox sandboxstore.Sandbox, statsMap ma
 	for _, cntr := range containers {
 		containerMetric := statsMap[cntr.ID]
 
+		if cntr.Status.Get().State() != runtime.ContainerState_CONTAINER_RUNNING {
+			// containers that are just created, in a failed state or exited (init containers) will not have stats
+			continue
+		}
+
 		if containerMetric == nil {
 			return nil, nil, fmt.Errorf("failed to find metrics for container with id %s: %w", cntr.ID, err)
 		}


### PR DESCRIPTION
backport for #8633

Cherry-pick of 28a5199ff61ad4d90cbb692b2bdc4bc0ba30b43b

need slight modification of tests due to 1.7 missing refactor of the tests (https://github.com/containerd/containerd/commit/4192ca8f8cd6e35d56b65818cef4131c72be10f9)