### PR TITLE
[release/1.6] support fetching containerd from non public GCS buckets

### DIFF
--- a/contrib/gce/configure.sh
+++ b/contrib/gce/configure.sh
@@ -104,6 +104,15 @@ if [ -f "${CONTAINERD_HOME}/${CONTAINERD_ENV_METADATA}" ]; then
   source "${CONTAINERD_HOME}/${CONTAINERD_ENV_METADATA}"
 fi
 
+# GCS_BUCKET_TOKEN_METADATA is the metadata key for the GCS bucket token
+GCS_BUCKET_TOKEN_METADATA="GCS_BUCKET_TOKEN"
+# GCS_BUCKET_TOKEN should have read access to the bucket from which
+# containerd artifacts need to be downloaded
+GCS_BUCKET_TOKEN=$(fetch_metadata "${GCS_BUCKET_TOKEN_METADATA}")
+if [[ -n "${GCS_BUCKET_TOKEN}" ]]; then
+  HEADERS=(-H "Authorization: Bearer ${GCS_BUCKET_TOKEN}")
+fi
+
 # CONTAINERD_PKG_PREFIX is the prefix of the cri-containerd tarball name.
 # By default use the release tarball with cni built in.
 pkg_prefix=${CONTAINERD_PKG_PREFIX:-"cri-containerd-cni"}
@@ -126,7 +135,7 @@ else
 
   # TODO(random-liu): Put version into the metadata instead of
   # deciding it in cloud init. This may cause issue to reboot test.
-  version=$(curl -f --ipv4 --retry 6 --retry-delay 3 --silent --show-error \
+  version=$(curl -X GET "${HEADERS[@]}" -f --ipv4 --retry 6 --retry-delay 3 --silent --show-error \
     https://storage.googleapis.com/${deploy_path}/latest)
 fi
 
@@ -152,7 +161,7 @@ else
     echo "${TARBALL_GCS_NAME} is preloaded"
   else
     # Download and untar the release tar ball.
-    curl -f --ipv4 -Lo "${TARBALL}" --connect-timeout 20 --max-time 300 --retry 6 --retry-delay 10 "${TARBALL_GCS_PATH}"
+    curl -X GET "${HEADERS[@]}" -f --ipv4 -Lo "${TARBALL}" --connect-timeout 20 --max-time 300 --retry 6 --retry-delay 10 "${TARBALL_GCS_PATH}"
     tar xvf "${TARBALL}"
     rm -f "${TARBALL}"
   fi

--- a/contrib/gce/configure.sh
+++ b/contrib/gce/configure.sh
@@ -104,6 +104,7 @@ if [ -f "${CONTAINERD_HOME}/${CONTAINERD_ENV_METADATA}" ]; then
   source "${CONTAINERD_HOME}/${CONTAINERD_ENV_METADATA}"
 fi
 
+set +x
 # GCS_BUCKET_TOKEN_METADATA is the metadata key for the GCS bucket token
 GCS_BUCKET_TOKEN_METADATA="GCS_BUCKET_TOKEN"
 # GCS_BUCKET_TOKEN should have read access to the bucket from which
@@ -112,6 +113,7 @@ GCS_BUCKET_TOKEN=$(fetch_metadata "${GCS_BUCKET_TOKEN_METADATA}")
 if [[ -n "${GCS_BUCKET_TOKEN}" ]]; then
   HEADERS=(-H "Authorization: Bearer ${GCS_BUCKET_TOKEN}")
 fi
+set -x
 
 # CONTAINERD_PKG_PREFIX is the prefix of the cri-containerd tarball name.
 # By default use the release tarball with cni built in.
@@ -135,7 +137,7 @@ else
 
   # TODO(random-liu): Put version into the metadata instead of
   # deciding it in cloud init. This may cause issue to reboot test.
-  version=$(curl -X GET "${HEADERS[@]}" -f --ipv4 --retry 6 --retry-delay 3 --silent --show-error \
+  version=$(set +x; curl -X GET "${HEADERS[@]}" -f --ipv4 --retry 6 --retry-delay 3 --silent --show-error \
     https://storage.googleapis.com/${deploy_path}/latest)
 fi
 
@@ -161,7 +163,8 @@ else
     echo "${TARBALL_GCS_NAME} is preloaded"
   else
     # Download and untar the release tar ball.
-    curl -X GET "${HEADERS[@]}" -f --ipv4 -Lo "${TARBALL}" --connect-timeout 20 --max-time 300 --retry 6 --retry-delay 10 "${TARBALL_GCS_PATH}"
+    $(set +x; curl -X GET "${HEADERS[@]}" -f --ipv4 -Lo "${TARBALL}" --connect-timeout 20 --max-time 300 --retry 6 \
+      --retry-delay 10 "${TARBALL_GCS_PATH}")
     tar xvf "${TARBALL}"
     rm -f "${TARBALL}"
   fi


### PR DESCRIPTION
cherry pick https://github.com/containerd/containerd/pull/7771 (not clean)

add support to fetch and download containerd tarball from GCS buckets that require authentication.
GCS_BUCKET_TOKEN should have read access to the bucket from which artifacts are to be fetched. The token is expected to be present in the instance metadata of the VM, similar to other node environment variables

To use this in tests from kubernetes, a new node env can be added as follows [here](https://github.com/kubernetes/test-infra/blob/master/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml#L179).  <your_gcs_bucket_token> can be fetched from a secret or from an env.

```
-node-env=GCS_BUCKET_TOKEN=<your_gcs_bucket_token>
```


#### Notes for reviewer:
The backport of these changes were tried in https://github.com/containerd/containerd/pull/7823, but caused CI failure in kubernetes test jobs and was hence immediately reverted in https://github.com/containerd/containerd/pull/7830. Raising this PR to figure out what caused the test failures and debug it. 