### PR TITLE
[release/1.6] update test box to fedora 37

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -513,7 +513,7 @@ jobs:
         # We can enable crun again when we get a better CI infra.
         runc: [runc]
         # Fedora is for testing cgroup v2 functionality, Rocky Linux is for testing on an enterprise-grade environment
-        box: ["fedora/36-cloud-base", "rockylinux/8"]
+        box: ["fedora/37-cloud-base", "rockylinux/8"]
     env:
       GOTEST: gotestsum --
     steps:


### PR DESCRIPTION
update vagrant box to fedora 37 as fedora 36 went EOL on 16-05-2023