### PR TITLE
integration/client: add timeout to `TestShimOOMScore`

### DIFF
--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -1412,5 +1412,9 @@ func TestShimOOMScore(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	<-statusC
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for task exit event")
+	case <-statusC:
+	}
 }


### PR DESCRIPTION
I noticed while fixing up https://github.com/containerd/containerd/pull/8617 that `TestShimOOMScore` has no timeout, making it so that if it never receives the task exit event it's expecting, the test hangs for (many) minutes.