### PR TITLE
CRI: Register metadata store types by definitions

### DIFF
--- a/pkg/cri/sbserver/container_create.go
+++ b/pkg/cri/sbserver/container_create.go
@@ -24,7 +24,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/containerd/typeurl/v2"
 	"github.com/davecgh/go-spew/spew"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
@@ -45,11 +44,6 @@ import (
 	"github.com/containerd/containerd/pkg/cri/util"
 	"github.com/containerd/containerd/platforms"
 )
-
-func init() {
-	typeurl.Register(&containerstore.Metadata{},
-		"github.com/containerd/cri/pkg/store/container", "Metadata")
-}
 
 // CreateContainer creates a new container in the given PodSandbox.
 func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateContainerRequest) (_ *runtime.CreateContainerResponse, retErr error) {

--- a/pkg/cri/sbserver/podsandbox/sandbox_run.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_run.go
@@ -24,7 +24,6 @@ import (
 	imagestore "github.com/containerd/containerd/pkg/cri/store/image"
 	"github.com/containerd/nri"
 	v1 "github.com/containerd/nri/types/v1"
-	"github.com/containerd/typeurl/v2"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/go-multierror"
 	"github.com/opencontainers/selinux/go-selinux"
@@ -42,11 +41,6 @@ import (
 	"github.com/containerd/containerd/sandbox"
 	"github.com/containerd/containerd/snapshots"
 )
-
-func init() {
-	typeurl.Register(&sandboxstore.Metadata{},
-		"github.com/containerd/cri/pkg/store/sandbox", "Metadata")
-}
 
 type CleanupErr struct {
 	error

--- a/pkg/cri/sbserver/sandbox_run.go
+++ b/pkg/cri/sbserver/sandbox_run.go
@@ -43,11 +43,6 @@ import (
 	sb "github.com/containerd/containerd/sandbox"
 )
 
-func init() {
-	typeurl.Register(&sandboxstore.Metadata{},
-		"github.com/containerd/cri/pkg/store/sandbox", "Metadata")
-}
-
 // RunPodSandbox creates and starts a pod-level sandbox. Runtimes should ensure
 // the sandbox is in ready state.
 func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandboxRequest) (_ *runtime.RunPodSandboxResponse, retErr error) {

--- a/pkg/cri/server/container_create.go
+++ b/pkg/cri/server/container_create.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/containerd/typeurl/v2"
 	"github.com/davecgh/go-spew/spew"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
@@ -40,11 +39,6 @@ import (
 	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
 	"github.com/containerd/containerd/pkg/cri/util"
 )
-
-func init() {
-	typeurl.Register(&containerstore.Metadata{},
-		"github.com/containerd/cri/pkg/store/container", "Metadata")
-}
 
 // CreateContainer creates a new container in the given PodSandbox.
 func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateContainerRequest) (_ *runtime.CreateContainerResponse, retErr error) {

--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	cni "github.com/containerd/go-cni"
-	"github.com/containerd/typeurl/v2"
 	"github.com/davecgh/go-spew/spew"
 	selinux "github.com/opencontainers/selinux/go-selinux"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -46,11 +45,6 @@ import (
 	"github.com/containerd/containerd/pkg/netns"
 	"github.com/containerd/containerd/snapshots"
 )
-
-func init() {
-	typeurl.Register(&sandboxstore.Metadata{},
-		"github.com/containerd/cri/pkg/store/sandbox", "Metadata")
-}
 
 // RunPodSandbox creates and starts a pod-level sandbox. Runtimes should ensure
 // the sandbox is in ready state.

--- a/pkg/cri/store/container/metadata.go
+++ b/pkg/cri/store/container/metadata.go
@@ -20,8 +20,14 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/containerd/typeurl/v2"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
+
+func init() {
+	typeurl.Register(&Metadata{},
+		"github.com/containerd/cri/pkg/store/container", "Metadata")
+}
 
 // NOTE(random-liu):
 // 1) Metadata is immutable after created.

--- a/pkg/cri/store/sandbox/metadata.go
+++ b/pkg/cri/store/sandbox/metadata.go
@@ -21,8 +21,14 @@ import (
 	"fmt"
 
 	cni "github.com/containerd/go-cni"
+	"github.com/containerd/typeurl/v2"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
+
+func init() {
+	typeurl.Register(&Metadata{},
+		"github.com/containerd/cri/pkg/store/sandbox", "Metadata")
+}
 
 // NOTE(random-liu):
 // 1) Metadata is immutable after created.


### PR DESCRIPTION
Closes https://github.com/containerd/containerd/issues/8669

Register the types by their definitions so if any outside clients want to unmarshal they'll run the registration.