### PR TITLE
replace some basic uses of fmt.Sprintf()

### DIFF
--- a/client.go
+++ b/client.go
@@ -185,7 +185,7 @@ func NewWithConn(conn *grpc.ClientConn, opts ...ClientOpt) (*Client, error) {
 	c := &Client{
 		defaultns: copts.defaultns,
 		conn:      conn,
-		runtime:   fmt.Sprintf("%s.%s", plugin.RuntimePlugin, runtime.GOOS),
+		runtime:   plugin.RuntimePlugin.String() + "." + runtime.GOOS,
 	}
 
 	if copts.defaultPlatform != nil {

--- a/integration/client/container_test.go
+++ b/integration/client/container_test.go
@@ -177,7 +177,7 @@ func TestContainerStart(t *testing.T) {
 }
 
 func readShimPath(taskID string) (string, error) {
-	runtime := fmt.Sprintf("%s.%s", plugin.RuntimePluginV2, "task")
+	runtime := plugin.RuntimePluginV2.String() + ".task"
 	shimBinaryNamePath := filepath.Join(defaultState, runtime, testNamespace, taskID, "shim-binary-path")
 
 	shimPath, err := os.ReadFile(shimBinaryNamePath)

--- a/pkg/cri/sbserver/service.go
+++ b/pkg/cri/sbserver/service.go
@@ -350,7 +350,7 @@ func (c *criService) register(s *grpc.Server) error {
 // imageFSPath returns containerd image filesystem path.
 // Note that if containerd changes directory layout, we also needs to change this.
 func imageFSPath(rootDir, snapshotter string) string {
-	return filepath.Join(rootDir, fmt.Sprintf("%s.%s", plugin.SnapshotPlugin, snapshotter))
+	return filepath.Join(rootDir, plugin.SnapshotPlugin.String()+"."+snapshotter)
 }
 
 func loadOCISpec(filename string) (*oci.Spec, error) {

--- a/pkg/cri/server/service.go
+++ b/pkg/cri/server/service.go
@@ -332,7 +332,7 @@ func (c *criService) register(s *grpc.Server) error {
 // imageFSPath returns containerd image filesystem path.
 // Note that if containerd changes directory layout, we also needs to change this.
 func imageFSPath(rootDir, snapshotter string) string {
-	return filepath.Join(rootDir, fmt.Sprintf("%s.%s", plugin.SnapshotPlugin, snapshotter))
+	return filepath.Join(rootDir, plugin.SnapshotPlugin.String()+"."+snapshotter)
 }
 
 func loadOCISpec(filename string) (*oci.Spec, error) {

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -130,7 +130,7 @@ func (r *Registration) Init(ic *InitContext) *Plugin {
 
 // URI returns the full plugin URI
 func (r *Registration) URI() string {
-	return fmt.Sprintf("%s.%s", r.Type, r.ID)
+	return r.Type.String() + "." + r.ID
 }
 
 var register = struct {

--- a/remotes/docker/handler.go
+++ b/remotes/docker/handler.go
@@ -103,7 +103,7 @@ func appendDistributionSourceLabel(originLabel, repo string) string {
 }
 
 func distributionSourceLabelKey(source string) string {
-	return fmt.Sprintf("%s.%s", labels.LabelDistributionSource, source)
+	return labels.LabelDistributionSource + "." + source
 }
 
 // selectRepositoryMountCandidate will select the repo which has longest

--- a/runtime/v2/manager.go
+++ b/runtime/v2/manager.go
@@ -177,7 +177,7 @@ type ShimManager struct {
 
 // ID of the shim manager
 func (m *ShimManager) ID() string {
-	return fmt.Sprintf("%s.%s", plugin.RuntimePluginV2, "shim")
+	return plugin.RuntimePluginV2.String() + ".shim"
 }
 
 // Start launches a new shim instance
@@ -413,7 +413,7 @@ func NewTaskManager(shims *ShimManager) *TaskManager {
 
 // ID of the task manager
 func (m *TaskManager) ID() string {
-	return fmt.Sprintf("%s.%s", plugin.RuntimePluginV2, "task")
+	return plugin.RuntimePluginV2.String() + ".task"
 }
 
 // Create launches new shim instance and creates new task

--- a/task.go
+++ b/task.go
@@ -311,7 +311,7 @@ func (t *task) Delete(ctx context.Context, opts ...ProcessDeleteOpts) (*ExitStat
 	switch status.Status {
 	case Stopped, Unknown, "":
 	case Created:
-		if t.client.runtime == fmt.Sprintf("%s.%s", plugin.RuntimePlugin, "windows") {
+		if t.client.runtime == plugin.RuntimePlugin.String()+".windows" {
 			// On windows Created is akin to Stopped
 			break
 		}
@@ -328,7 +328,7 @@ func (t *task) Delete(ctx context.Context, opts ...ProcessDeleteOpts) (*ExitStat
 		// io.Wait locks for restored tasks on Windows unless we call
 		// io.Close first (https://github.com/containerd/containerd/issues/5621)
 		// in other cases, preserve the contract and let IO finish before closing
-		if t.client.runtime == fmt.Sprintf("%s.%s", plugin.RuntimePlugin, "windows") {
+		if t.client.runtime == plugin.RuntimePlugin.String()+".windows" {
 			t.io.Close()
 		}
 		// io.Cancel is used to cancel the io goroutine while it is in


### PR DESCRIPTION
Really tiny gains here, and doesn't significantly impact readability:

    BenchmarkSprintf
    BenchmarkSprintf-10    11528700     91.59 ns/op   32 B/op  1 allocs/op
    BenchmarkConcat
    BenchmarkConcat-10    100000000     11.76 ns/op    0 B/op  0 allocs/op