### PR TITLE
avoid "any" as variable name

### DIFF
--- a/cmd/containerd/command/publish.go
+++ b/cmd/containerd/command/publish.go
@@ -78,11 +78,11 @@ func getEventPayload(r io.Reader) (*types.Any, error) {
 	if err != nil {
 		return nil, err
 	}
-	var any types.Any
-	if err := proto.Unmarshal(data, &any); err != nil {
+	var payload types.Any
+	if err := proto.Unmarshal(data, &payload); err != nil {
 		return nil, err
 	}
-	return &any, nil
+	return &payload, nil
 }
 
 func connectEvents(address string) (eventsapi.EventsClient, error) {

--- a/container.go
+++ b/container.go
@@ -255,9 +255,8 @@ func (c *container) NewTask(ctx context.Context, ioCreate cio.Creator, opts ...N
 		}
 		for _, m := range mounts {
 			if spec.Linux != nil && spec.Linux.MountLabel != "" {
-				context := label.FormatMountLabel("", spec.Linux.MountLabel)
-				if context != "" {
-					m.Options = append(m.Options, context)
+				if ml := label.FormatMountLabel("", spec.Linux.MountLabel); ml != "" {
+					m.Options = append(m.Options, ml)
 				}
 			}
 			request.Rootfs = append(request.Rootfs, &types.Mount{
@@ -288,11 +287,11 @@ func (c *container) NewTask(ctx context.Context, ioCreate cio.Creator, opts ...N
 	}
 	request.RuntimePath = info.RuntimePath
 	if info.Options != nil {
-		any, err := typeurl.MarshalAny(info.Options)
+		o, err := typeurl.MarshalAny(info.Options)
 		if err != nil {
 			return nil, err
 		}
-		request.Options = protobuf.FromAny(any)
+		request.Options = protobuf.FromAny(o)
 	}
 	t := &task{
 		client: c.client,
@@ -455,7 +454,7 @@ func loadFifos(response *tasks.GetResponse) *cio.FIFOSet {
 			// we ignore errors here because we don't
 			// want to remove the directory if it isn't
 			// empty
-			os.Remove(dir)
+			_ = os.Remove(dir)
 		}
 		return err
 	}

--- a/container_checkpoint_opts.go
+++ b/container_checkpoint_opts.go
@@ -58,13 +58,13 @@ func WithCheckpointImage(ctx context.Context, client *Client, c *containers.Cont
 
 // WithCheckpointTask includes the running task
 func WithCheckpointTask(ctx context.Context, client *Client, c *containers.Container, index *imagespec.Index, copts *options.CheckpointOptions) error {
-	any, err := protobuf.MarshalAnyToProto(copts)
+	opt, err := protobuf.MarshalAnyToProto(copts)
 	if err != nil {
 		return nil
 	}
 	task, err := client.TaskService().Checkpoint(ctx, &tasks.CheckpointTaskRequest{
 		ContainerID: c.ID,
-		Options:     any,
+		Options:     opt,
 	})
 	if err != nil {
 		return err
@@ -80,7 +80,7 @@ func WithCheckpointTask(ctx context.Context, client *Client, c *containers.Conta
 		})
 	}
 	// save copts
-	data, err := proto.Marshal(any)
+	data, err := proto.Marshal(opt)
 	if err != nil {
 		return err
 	}
@@ -100,8 +100,8 @@ func WithCheckpointTask(ctx context.Context, client *Client, c *containers.Conta
 // WithCheckpointRuntime includes the container runtime info
 func WithCheckpointRuntime(ctx context.Context, client *Client, c *containers.Container, index *imagespec.Index, copts *options.CheckpointOptions) error {
 	if c.Runtime.Options != nil && c.Runtime.Options.GetValue() != nil {
-		any := protobuf.FromAny(c.Runtime.Options)
-		data, err := proto.Marshal(any)
+		opt := protobuf.FromAny(c.Runtime.Options)
+		data, err := proto.Marshal(opt)
 		if err != nil {
 			return err
 		}

--- a/container_opts.go
+++ b/container_opts.go
@@ -58,18 +58,18 @@ type InfoConfig struct {
 func WithRuntime(name string, options interface{}) NewContainerOpts {
 	return func(ctx context.Context, client *Client, c *containers.Container) error {
 		var (
-			any typeurl.Any
-			err error
+			opts typeurl.Any
+			err  error
 		)
 		if options != nil {
-			any, err = typeurl.MarshalAny(options)
+			opts, err = typeurl.MarshalAny(options)
 			if err != nil {
 				return err
 			}
 		}
 		c.Runtime = containers.RuntimeInfo{
 			Name:    name,
-			Options: any,
+			Options: opts,
 		}
 		return nil
 	}
@@ -299,7 +299,7 @@ func WithContainerExtension(name string, extension interface{}) NewContainerOpts
 			return fmt.Errorf("extension key must not be zero-length: %w", errdefs.ErrInvalidArgument)
 		}
 
-		any, err := typeurl.MarshalAny(extension)
+		ext, err := typeurl.MarshalAny(extension)
 		if err != nil {
 			if errors.Is(err, typeurl.ErrNotFound) {
 				return fmt.Errorf("extension %q is not registered with the typeurl package, see `typeurl.Register`: %w", name, err)
@@ -310,7 +310,7 @@ func WithContainerExtension(name string, extension interface{}) NewContainerOpts
 		if c.Extensions == nil {
 			c.Extensions = make(map[string]typeurl.Any)
 		}
-		c.Extensions[name] = any
+		c.Extensions[name] = ext
 		return nil
 	}
 }

--- a/events.go
+++ b/events.go
@@ -46,13 +46,13 @@ type eventRemote struct {
 }
 
 func (e *eventRemote) Publish(ctx context.Context, topic string, event events.Event) error {
-	any, err := typeurl.MarshalAny(event)
+	evt, err := typeurl.MarshalAny(event)
 	if err != nil {
 		return err
 	}
 	req := &eventsapi.PublishRequest{
 		Topic: topic,
-		Event: protobuf.FromAny(any),
+		Event: protobuf.FromAny(evt),
 	}
 	if _, err := e.client.Publish(ctx, req); err != nil {
 		return errdefs.FromGRPC(err)

--- a/integration/sandbox_run_rollback_test.go
+++ b/integration/sandbox_run_rollback_test.go
@@ -311,9 +311,9 @@ func TestRunPodSandboxAndTeardownCNISlow(t *testing.T) {
 		t.Log("Get sandbox container")
 		c, err := GetContainer(sb.Id)
 		require.NoError(t, err)
-		any, ok := c.Extensions["io.cri-containerd.sandbox.metadata"]
+		md, ok := c.Extensions["io.cri-containerd.sandbox.metadata"]
 		require.True(t, ok, "sandbox metadata should exist in extension")
-		i, err := typeurl.UnmarshalAny(any)
+		i, err := typeurl.UnmarshalAny(md)
 		require.NoError(t, err)
 		require.IsType(t, &sandbox.Metadata{}, i)
 		metadata, ok := i.(*sandbox.Metadata)

--- a/metadata/containers.go
+++ b/metadata/containers.go
@@ -337,17 +337,17 @@ func readContainer(container *containers.Container, bkt *bolt.Bucket) error {
 				container.Runtime.Name = string(n)
 			}
 
-			any, err := boltutil.ReadAny(rbkt, bucketKeyOptions)
+			o, err := boltutil.ReadAny(rbkt, bucketKeyOptions)
 			if err != nil {
 				return err
 			}
-			container.Runtime.Options = any
+			container.Runtime.Options = o
 		case string(bucketKeySpec):
-			var any types.Any
-			if err := proto.Unmarshal(v, &any); err != nil {
+			var spec types.Any
+			if err := proto.Unmarshal(v, &spec); err != nil {
 				return err
 			}
-			container.Spec = &any
+			container.Spec = &spec
 		case string(bucketKeySnapshotKey):
 			container.SnapshotKey = string(v)
 		case string(bucketKeySnapshotter):

--- a/pkg/cri/sbserver/container_update_resources.go
+++ b/pkg/cri/sbserver/container_update_resources.go
@@ -143,12 +143,12 @@ func (c *criService) updateContainerResources(ctx context.Context,
 
 // updateContainerSpec updates container spec.
 func updateContainerSpec(ctx context.Context, cntr containerd.Container, spec *runtimespec.Spec) error {
-	any, err := typeurl.MarshalAny(spec)
+	s, err := typeurl.MarshalAny(spec)
 	if err != nil {
 		return fmt.Errorf("failed to marshal spec %+v: %w", spec, err)
 	}
 	if err := cntr.Update(ctx, func(ctx gocontext.Context, client *containerd.Client, c *containers.Container) error {
-		c.Spec = any
+		c.Spec = s
 		return nil
 	}); err != nil {
 		return fmt.Errorf("failed to update container spec: %w", err)

--- a/pkg/cri/sbserver/events.go
+++ b/pkg/cri/sbserver/events.go
@@ -281,9 +281,9 @@ func (em *eventMonitor) start() <-chan error {
 				ids := em.backOff.getExpiredIDs()
 				for _, id := range ids {
 					queue := em.backOff.deBackOff(id)
-					for i, any := range queue.events {
-						if err := em.handleEvent(any); err != nil {
-							log.L.WithError(err).Errorf("Failed to handle backOff event %+v for %s", any, id)
+					for i, evt := range queue.events {
+						if err := em.handleEvent(evt); err != nil {
+							log.L.WithError(err).Errorf("Failed to handle backOff event %+v for %s", evt, id)
 							em.backOff.reBackOff(id, queue.events[i:], queue.duration)
 							break
 						}

--- a/pkg/cri/sbserver/events_test.go
+++ b/pkg/cri/sbserver/events_test.go
@@ -80,9 +80,9 @@ func TestBackOff(t *testing.T) {
 	t.Logf("Should be able to check if the container is in backOff state")
 	for k, queue := range inputQueues {
 		for _, e := range queue.events {
-			any, err := typeurl.MarshalAny(e)
+			evt, err := typeurl.MarshalAny(e)
 			assert.NoError(t, err)
-			key, _, err := convertEvent(any)
+			key, _, err := convertEvent(evt)
 			assert.NoError(t, err)
 			assert.Equal(t, k, key)
 			assert.Equal(t, actual.isInBackOff(key), true)

--- a/pkg/cri/sbserver/podsandbox/sandbox_run_test.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_run_test.go
@@ -159,9 +159,9 @@ func TestTypeurlMarshalUnmarshalSandboxMeta(t *testing.T) {
 				test.configChange(meta.Config)
 			}
 
-			any, err := typeurl.MarshalAny(meta)
+			md, err := typeurl.MarshalAny(meta)
 			assert.NoError(t, err)
-			data, err := typeurl.UnmarshalAny(any)
+			data, err := typeurl.UnmarshalAny(md)
 			assert.NoError(t, err)
 			assert.IsType(t, &sandboxstore.Metadata{}, data)
 			curMeta, ok := data.(*sandboxstore.Metadata)

--- a/pkg/cri/server/container_update_resources.go
+++ b/pkg/cri/server/container_update_resources.go
@@ -142,12 +142,12 @@ func (c *criService) updateContainerResources(ctx context.Context,
 
 // updateContainerSpec updates container spec.
 func updateContainerSpec(ctx context.Context, cntr containerd.Container, spec *runtimespec.Spec) error {
-	any, err := typeurl.MarshalAny(spec)
+	s, err := typeurl.MarshalAny(spec)
 	if err != nil {
 		return fmt.Errorf("failed to marshal spec %+v: %w", spec, err)
 	}
 	if err := cntr.Update(ctx, func(ctx gocontext.Context, client *containerd.Client, c *containers.Container) error {
-		c.Spec = any
+		c.Spec = s
 		return nil
 	}); err != nil {
 		return fmt.Errorf("failed to update container spec: %w", err)

--- a/pkg/cri/server/events.go
+++ b/pkg/cri/server/events.go
@@ -282,9 +282,9 @@ func (em *eventMonitor) start() <-chan error {
 				ids := em.backOff.getExpiredIDs()
 				for _, id := range ids {
 					queue := em.backOff.deBackOff(id)
-					for i, any := range queue.events {
-						if err := em.handleEvent(any); err != nil {
-							logrus.WithError(err).Errorf("Failed to handle backOff event %+v for %s", any, id)
+					for i, evt := range queue.events {
+						if err := em.handleEvent(evt); err != nil {
+							logrus.WithError(err).Errorf("Failed to handle backOff event %+v for %s", evt, id)
 							em.backOff.reBackOff(id, queue.events[i:], queue.duration)
 							break
 						}

--- a/pkg/cri/server/events_test.go
+++ b/pkg/cri/server/events_test.go
@@ -80,9 +80,9 @@ func TestBackOff(t *testing.T) {
 	t.Logf("Should be able to check if the container is in backOff state")
 	for k, queue := range inputQueues {
 		for _, e := range queue.events {
-			any, err := typeurl.MarshalAny(e)
+			evt, err := typeurl.MarshalAny(e)
 			assert.NoError(t, err)
-			key, _, err := convertEvent(any)
+			key, _, err := convertEvent(evt)
 			assert.NoError(t, err)
 			assert.Equal(t, k, key)
 			assert.Equal(t, actual.isInBackOff(key), true)

--- a/pkg/cri/server/sandbox_run_test.go
+++ b/pkg/cri/server/sandbox_run_test.go
@@ -162,9 +162,9 @@ func TestTypeurlMarshalUnmarshalSandboxMeta(t *testing.T) {
 				test.configChange(meta.Config)
 			}
 
-			any, err := typeurl.MarshalAny(meta)
+			md, err := typeurl.MarshalAny(meta)
 			assert.NoError(t, err)
-			data, err := typeurl.UnmarshalAny(any)
+			data, err := typeurl.UnmarshalAny(md)
 			assert.NoError(t, err)
 			assert.IsType(t, &sandboxstore.Metadata{}, data)
 			curMeta, ok := data.(*sandboxstore.Metadata)

--- a/pkg/transfer/archive/exporter.go
+++ b/pkg/transfer/archive/exporter.go
@@ -144,9 +144,9 @@ func (iis *ImageExportStream) MarshalAny(ctx context.Context, sm streaming.Strea
 	return typeurl.MarshalAny(s)
 }
 
-func (iis *ImageExportStream) UnmarshalAny(ctx context.Context, sm streaming.StreamGetter, any typeurl.Any) error {
+func (iis *ImageExportStream) UnmarshalAny(ctx context.Context, sm streaming.StreamGetter, anyType typeurl.Any) error {
 	var s transfertypes.ImageExportStream
-	if err := typeurl.UnmarshalTo(any, &s); err != nil {
+	if err := typeurl.UnmarshalTo(anyType, &s); err != nil {
 		return err
 	}
 

--- a/pkg/transfer/archive/importer.go
+++ b/pkg/transfer/archive/importer.go
@@ -84,9 +84,9 @@ func (iis *ImageImportStream) MarshalAny(ctx context.Context, sm streaming.Strea
 	return typeurl.MarshalAny(s)
 }
 
-func (iis *ImageImportStream) UnmarshalAny(ctx context.Context, sm streaming.StreamGetter, any typeurl.Any) error {
+func (iis *ImageImportStream) UnmarshalAny(ctx context.Context, sm streaming.StreamGetter, anyType typeurl.Any) error {
 	var s transferapi.ImageImportStream
-	if err := typeurl.UnmarshalTo(any, &s); err != nil {
+	if err := typeurl.UnmarshalTo(anyType, &s); err != nil {
 		return err
 	}
 

--- a/pkg/transfer/registry/registry.go
+++ b/pkg/transfer/registry/registry.go
@@ -261,11 +261,11 @@ func (cc *credCallback) GetCredentials(ctx context.Context, ref, host string) (C
 		Host:      host,
 		Reference: ref,
 	}
-	any, err := typeurl.MarshalAny(ar)
+	anyType, err := typeurl.MarshalAny(ar)
 	if err != nil {
 		return Credentials{}, err
 	}
-	if err := cc.stream.Send(any); err != nil {
+	if err := cc.stream.Send(anyType); err != nil {
 		return Credentials{}, err
 	}
 	resp, err := cc.stream.Recv()

--- a/pkg/transfer/streaming/writer.go
+++ b/pkg/transfer/streaming/writer.go
@@ -42,14 +42,14 @@ func WriteByteStream(ctx context.Context, stream streaming.Stream) io.WriteClose
 			default:
 			}
 
-			any, err := stream.Recv()
+			anyType, err := stream.Recv()
 			if err != nil {
 				if !errors.Is(err, io.EOF) && !errors.Is(err, context.Canceled) {
 					log.G(ctx).WithError(err).Error("send byte stream ended without EOF")
 				}
 				return
 			}
-			i, err := typeurl.UnmarshalAny(any)
+			i, err := typeurl.UnmarshalAny(anyType)
 			if err != nil {
 				log.G(ctx).WithError(err).Error("failed to unmarshal stream object")
 				continue
@@ -102,19 +102,19 @@ func (wbs *writeByteStream) Write(p []byte) (n int, err error) {
 			max = remaining
 		}
 		// TODO: continue
-		//remaining = remaining - int32(n)
+		// remaining = remaining - int32(n)
 
 		data := &transferapi.Data{
 			Data: p[:max],
 		}
-		var any typeurl.Any
-		any, err = typeurl.MarshalAny(data)
+		var anyType typeurl.Any
+		anyType, err = typeurl.MarshalAny(data)
 		if err != nil {
 			log.G(wbs.ctx).WithError(err).Errorf("failed to marshal data for send")
 			// TODO: Send error message on stream before close to allow remote side to return error
 			return
 		}
-		if err = wbs.stream.Send(any); err != nil {
+		if err = wbs.stream.Send(anyType); err != nil {
 			log.G(wbs.ctx).WithError(err).Errorf("send failed")
 			return
 		}

--- a/protobuf/any.go
+++ b/protobuf/any.go
@@ -39,9 +39,9 @@ func FromAny(from typeurl.Any) *anypb.Any {
 
 // MarshalAnyToProto converts an arbitrary interface to github.com/containerd/containerd/protobuf/types.Any.
 func MarshalAnyToProto(from interface{}) (*anypb.Any, error) {
-	any, err := typeurl.MarshalAny(from)
+	anyType, err := typeurl.MarshalAny(from)
 	if err != nil {
 		return nil, err
 	}
-	return FromAny(any), nil
+	return FromAny(anyType), nil
 }

--- a/runtime/v2/shim/publisher.go
+++ b/runtime/v2/shim/publisher.go
@@ -110,7 +110,7 @@ func (l *RemoteEventsPublisher) Publish(ctx context.Context, topic string, event
 	if err != nil {
 		return err
 	}
-	any, err := protobuf.MarshalAnyToProto(event)
+	evt, err := protobuf.MarshalAnyToProto(event)
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func (l *RemoteEventsPublisher) Publish(ctx context.Context, topic string, event
 			Timestamp: protobuf.ToTimestamp(time.Now()),
 			Namespace: ns,
 			Topic:     topic,
-			Event:     any,
+			Event:     evt,
 		},
 		ctx: ctx,
 	}

--- a/sandbox.go
+++ b/sandbox.go
@@ -222,19 +222,19 @@ func WithSandboxSpec(s *oci.Spec, opts ...oci.SpecOpts) NewSandboxOpts {
 }
 
 // WithSandboxExtension attaches an extension to sandbox
-func WithSandboxExtension(name string, ext interface{}) NewSandboxOpts {
+func WithSandboxExtension(name string, extension interface{}) NewSandboxOpts {
 	return func(ctx context.Context, client *Client, s *api.Sandbox) error {
 		if s.Extensions == nil {
 			s.Extensions = make(map[string]typeurl.Any)
 		}
 
-		any, err := typeurl.MarshalAny(ext)
+		ext, err := typeurl.MarshalAny(extension)
 		if err != nil {
 			return fmt.Errorf("failed to marshal sandbox extension: %w", err)
 		}
 
-		s.Extensions[name] = any
-		return err
+		s.Extensions[name] = ext
+		return nil
 	}
 }
 

--- a/services/transfer/service.go
+++ b/services/transfer/service.go
@@ -94,7 +94,7 @@ func (s *service) Transfer(ctx context.Context, req *transferapi.TransferRequest
 			defer stream.Close()
 
 			pf := func(p transfer.Progress) {
-				any, err := typeurl.MarshalAny(&transferTypes.Progress{
+				progress, err := typeurl.MarshalAny(&transferTypes.Progress{
 					Event:    p.Event,
 					Name:     p.Name,
 					Parents:  p.Parents,
@@ -105,7 +105,7 @@ func (s *service) Transfer(ctx context.Context, req *transferapi.TransferRequest
 					log.G(ctx).WithError(err).Warnf("event could not be marshaled: %v/%v", p.Event, p.Name)
 					return
 				}
-				if err := stream.Send(any); err != nil {
+				if err := stream.Send(progress); err != nil {
 					log.G(ctx).WithError(err).Warnf("event not sent: %v/%v", p.Event, p.Name)
 					return
 				}

--- a/task.go
+++ b/task.go
@@ -365,7 +365,7 @@ func (t *task) Exec(ctx context.Context, id string, spec *specs.Process, ioCreat
 			i.Close()
 		}
 	}()
-	any, err := protobuf.MarshalAnyToProto(spec)
+	pSpec, err := protobuf.MarshalAnyToProto(spec)
 	if err != nil {
 		return nil, err
 	}
@@ -377,7 +377,7 @@ func (t *task) Exec(ctx context.Context, id string, spec *specs.Process, ioCreat
 		Stdin:       cfg.Stdin,
 		Stdout:      cfg.Stdout,
 		Stderr:      cfg.Stderr,
-		Spec:        any,
+		Spec:        pSpec,
 	}
 	if _, err := t.client.TaskService().Exec(ctx, request); err != nil {
 		i.Cancel()
@@ -465,11 +465,11 @@ func (t *task) Checkpoint(ctx context.Context, opts ...CheckpointTaskOpts) (Imag
 	}
 	request.ParentCheckpoint = i.ParentCheckpoint.String()
 	if i.Options != nil {
-		any, err := protobuf.MarshalAnyToProto(i.Options)
+		o, err := protobuf.MarshalAnyToProto(i.Options)
 		if err != nil {
 			return nil, err
 		}
-		request.Options = any
+		request.Options = o
 	}
 
 	status, err := t.Status(ctx)
@@ -550,11 +550,11 @@ func (t *task) Update(ctx context.Context, opts ...UpdateTaskOpts) error {
 		}
 	}
 	if i.Resources != nil {
-		any, err := typeurl.MarshalAny(i.Resources)
+		r, err := typeurl.MarshalAny(i.Resources)
 		if err != nil {
 			return err
 		}
-		request.Resources = protobuf.FromAny(any)
+		request.Resources = protobuf.FromAny(r)
 	}
 	if i.Annotations != nil {
 		request.Annotations = i.Annotations


### PR DESCRIPTION
Avoid shadowing / confusion with Go's "any" built-in type.