### PR TITLE
[overlay] add configurable mount options to overlay snapshotter

### DIFF
--- a/snapshots/overlay/overlay_test.go
+++ b/snapshots/overlay/overlay_test.go
@@ -70,7 +70,7 @@ func TestOverlay(t *testing.T) {
 				testOverlayOverlayRead(t, newSnapshotter)
 			})
 			t.Run("TestOverlayView", func(t *testing.T) {
-				testOverlayView(t, newSnapshotter)
+				testOverlayView(t, newSnapshotterWithOpts(append(opts, WithMountOptions([]string{"volatile"}))...))
 			})
 		})
 	}
@@ -329,7 +329,7 @@ func testOverlayView(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
 	}
 
 	supportsIndex := supportsIndex()
-	expectedOptions := 2
+	expectedOptions := 3
 	if !supportsIndex {
 		expectedOptions--
 	}
@@ -346,12 +346,15 @@ func testOverlayView(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
 	}
 	lowers := getParents(ctx, o, root, "/tmp/view2")
 	expected = fmt.Sprintf("lowerdir=%s:%s", lowers[0], lowers[1])
-	optIdx := 1
+	optIdx := 2
 	if !supportsIndex {
 		optIdx--
 	}
 	if userxattr {
 		optIdx++
+	}
+	if m.Options[0] != "volatile" {
+		t.Error("expected option first option to be provided option \"volatile\"")
 	}
 	if m.Options[optIdx] != expected {
 		t.Errorf("expected option %q but received %q", expected, m.Options[optIdx])

--- a/snapshots/overlay/plugin/plugin.go
+++ b/snapshots/overlay/plugin/plugin.go
@@ -32,6 +32,9 @@ type Config struct {
 	RootPath      string `toml:"root_path"`
 	UpperdirLabel bool   `toml:"upperdir_label"`
 	SyncRemove    bool   `toml:"sync_remove"`
+
+	// MountOptions are options used for the overlay mount (not used on bind mounts)
+	MountOptions []string `toml:"mount_options"`
 }
 
 func init() {
@@ -58,6 +61,10 @@ func init() {
 			}
 			if !config.SyncRemove {
 				oOpts = append(oOpts, overlay.AsynchronousRemove)
+			}
+
+			if len(config.MountOptions) > 0 {
+				oOpts = append(oOpts, overlay.WithMountOptions(config.MountOptions))
 			}
 
 			ic.Meta.Exports["root"] = root


### PR DESCRIPTION
Allows default mount options to be provided through configuration. This allows configurations to use options supported by the kernel without requiring an update to the overlay plugin.

Note: this still wouldn't be appropriate for the volatile option, an additional change would be necessary to strip the "volatile" option on temp mounts.  Such as https://github.com/containerd/containerd/pull/8402/files#diff-5adff636c3210a8801cbc84d4431a5ee66e8bab1985a88fd59c6e895b604914c