### PR TITLE
Document the default value for host capabilities

### DIFF
--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -266,6 +266,8 @@ capable of performing. Include only the values that apply.
 capabilities =  ["pull", "resolve", "push"]
 ```
 
+If the field is not specified, it defaults to `["pull", "resolve", "push"]`.
+
 capabilities (or Host capabilities) represent the capabilities of the registry host.
 This also represents the set of operations for which the registry host may be trusted
 to perform.


### PR DESCRIPTION
The field seems to default to `["pull", "resolve", "push"]` internally.

https://github.com/containerd/containerd/blob/6e2c915a441f32eb82f2af5743626470eab96753/remotes/docker/config/hosts.go#L409-L424

Specifying default values is recommended, as otherwise end users wonder what is the default value and do I need to specify this optional field.