### PR TITLE
[release/1.6] cherry-pick: No more nondistributable layers in MS registry

### DIFF
--- a/integration/client/convert_test.go
+++ b/integration/client/convert_test.go
@@ -80,10 +80,6 @@ func TestConvert(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, l := range mani.Layers {
-		if plats[0].OS == "windows" {
-			assert.Equal(t, ocispec.MediaTypeImageLayerNonDistributable, l.MediaType)
-		} else {
-			assert.Equal(t, ocispec.MediaTypeImageLayer, l.MediaType)
-		}
+		assert.Equal(t, ocispec.MediaTypeImageLayer, l.MediaType)
 	}
 }


### PR DESCRIPTION
Microsoft announced the removal of nondistributable layers from their images today. This makes the convert test fail since it assumes the first layer is nondistributable on Windows during the test.

Signed-off-by: Phil Estes <estesp@amazon.com>
(cherry picked from commit 38b0f970f01846fb201a1bbe0dded1ad5c61b44f)