### PR TITLE
Don't run CI on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,14 +3,8 @@ on:
   # When added to a merge queue.
   # See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions
   merge_group:
-  push:
-    branches:
-      - main
-      - "release/**"
   pull_request:
-    branches:
-      - main
-      - "release/**"
+    branches: ['main', 'release/**']
 
 env:
   # Go version we currently use to build containerd across all CI.


### PR DESCRIPTION
Remove `push` event (e.g. don't run the CI once merged). Instead it'll be added to the merge queue and built from there.

https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions