### PR TITLE
delete timeout to keep events in order

### DIFF
--- a/sys/reaper/reaper_unix.go
+++ b/sys/reaper/reaper_unix.go
@@ -71,10 +71,7 @@ func Reap() error {
 			Status:    e.Status,
 		})
 
-		select {
-		case <-done:
-		case <-time.After(1 * time.Second):
-		}
+		<-done
 	}
 	return err
 }


### PR DESCRIPTION
after this commit was merged https://github.com/containerd/containerd/commit/ded713010c745c6e0010d7e0cec4dccd995e1a42 chan c is not easy to fill up.
if c is full ,after 1s c is still full, if generate many  exited events will generate may  goroutines in Default.notify func.
```
func (m *Monitor) Subscribe() chan runc.Exit {
	c := make(chan runc.Exit, bufferSize)
	m.Lock()
	m.subscribers[c] = &subscriber{
		c: c,
	}
	m.Unlock()
	return c
}
```
these go routines will compete chan c ,notify msg  will not keep original order in chan c.
```
func Reap() error {
	now := time.Now()
	exits, err := reap(false)
	for _, e := range exits {
		done := Default.notify(runc.Exit{
			Timestamp: now,
			Pid:       e.Pid,
			Status:    e.Status,
		})

		select {
		case <-done:
		case <-time.After(1 * time.Second):
		}
	}
	return err
}
```
I think we can delete case <-time.After(1 * time.Second) to keep msg  in order 
cc @corhere @laurazard @thaJeztah