### PR TITLE
Fix ctr push image can't show right rate 

### DIFF
--- a/remotes/docker/pusher.go
+++ b/remotes/docker/pusher.go
@@ -138,9 +138,7 @@ func (p dockerPusher) push(ctx context.Context, desc ocispec.Descriptor, ref str
 				p.tracker.SetStatus(ref, Status{
 					Committed: true,
 					Status: content.Status{
-						Ref:    ref,
-						Total:  desc.Size,
-						Offset: desc.Size,
+						Ref: ref,
 						// TODO: Set updated time?
 					},
 				})

--- a/remotes/handlers.go
+++ b/remotes/handlers.go
@@ -283,10 +283,6 @@ func SkipNonDistributableBlobs(f images.HandlerFunc) images.HandlerFunc {
 			return nil, images.ErrSkipDesc
 		}
 
-		if images.IsLayerType(desc.MediaType) {
-			return nil, nil
-		}
-
 		children, err := f(ctx, desc)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Relate to the https://github.com/containerd/nerdctl/issues/2279,
The ctr has the same issue.

## Issue Description

I push the local image to harbor with ctr  , and ctr nerdctl shows the wrong upload rate .

![企业微信截图_16868230159951](https://github.com/containerd/containerd/assets/1469319/63b29467-674e-467a-96dc-a6e8ddf97a86)

The command line show the rate of upload is 374 B/s, But the actual upload speed is much greater.

## Issue Fixed

The issue is because of layer upload process bar is skipped. So the PR is to fix it. And If the layer exists in the registry, the upload size is 0.

![企业微信截图_16868233734747](https://github.com/containerd/containerd/assets/1469319/e41e42af-9cf0-47ba-bcc2-a6532640e3f5)

After the Fix the rate of upload is 318 KB/s, It's correct.

The PR can also fix the `nerctl push`
