### PR TITLE
Fix unbound variable used by Prow

### DIFF
--- a/test/build.sh
+++ b/test/build.sh
@@ -34,6 +34,9 @@ make clean
 # Build CRI+CNI release
 make BUILDTAGS="seccomp no_btrfs no_devmapper no_zfs" cri-cni-release
 
+# DEPLOY_DIR is the directory in the gcs bucket to store the tarball.
+DEPLOY_DIR=${DEPLOY_DIR:-""}
+
 BUILDDIR=$(mktemp -d)
 cleanup() {
   if [[ ${BUILDDIR} == /tmp/* ]]; then


### PR DESCRIPTION
/cc @dims 

The change in https://github.com/kubernetes/test-infra/pull/29824 failed because of an unbound variable.

Now, this change requires some changes in the jobs that grab containerd binaries from GCS.

```
 REDACTED  C02CW0CDP3YY  ~  Desktop  Git  test-infra   kubetest2  1⚑  $  grep -r containerd-staging .
./jobs/e2e_node/containerd/containerd-release-1.7/env:CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging/containerd/release-1.7'
./jobs/e2e_node/containerd/containerd-release-1.6/env:CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging/containerd/release-1.6'
./jobs/e2e_node/containerd/containerd-release-1.6-presubmit/env:CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging'
./jobs/e2e_node/containerd/containerd-main-presubmit/env:CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging'
./jobs/e2e_node/containerd/containerd-release-1.7-presubmit/env:CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging'
./jobs/e2e_node/containerd/containerd-main/systemd/env:CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging/containerd/master'
./jobs/e2e_node/containerd/containerd-main/cgroupv1/env-cgroupv1:CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging/containerd/master'
./jobs/e2e_node/containerd/containerd-main/env:CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging/containerd/master'
./jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2:CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging/containerd/master'
```

I could add the variable back but I'm not sure it is really needed and containerd did change its branch from master to main.

Old GCS Path: gs://cri-containerd-staging/containerd/master/*
New GCS Path: gs://cri-containerd-staging/containerd/*