### PR TITLE
Add support for pulling Wasm OCI artifacts

### DIFF
--- a/cmd/ctr/commands/run/run_windows.go
+++ b/cmd/ctr/commands/run/run_windows.go
@@ -165,6 +165,18 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 			}
 			opts = append(opts, oci.WithWindowsDevice(idType, devID))
 		}
+
+		imageSpec, err := image.Spec(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if imageSpec.OS == "wasi" {
+			manifest, err := images.Manifest(ctx, image.ContentStore(), image.Target(), nil)
+			if err != nil {
+				return nil, err
+			}
+			opts = append(opts, oci.WithWasmLayers(manifest.Layers))
+		}
 	}
 
 	if context.Bool("cni") {

--- a/cmd/ctr/commands/run/run_windows.go
+++ b/cmd/ctr/commands/run/run_windows.go
@@ -25,6 +25,7 @@ import (
 	"github.com/containerd/console"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cmd/ctr/commands"
+	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/pkg/netns"
 	"github.com/containerd/containerd/snapshots"

--- a/images/mediatypes.go
+++ b/images/mediatypes.go
@@ -57,6 +57,12 @@ const (
 
 	MediaTypeImageLayerEncrypted     = ocispec.MediaTypeImageLayer + "+encrypted"
 	MediaTypeImageLayerGzipEncrypted = ocispec.MediaTypeImageLayerGzip + "+encrypted"
+
+	// OCI media types
+
+	MediaTypeWasmLayerModule    = "application/vnd.w3c.wasm.module.v1+wasm"
+	MediaTypeWasmLayerComponent = "application/vnd.w3c.wasm.component.v1+wasm"
+	MediaTypeWasmLayerConfig    = "application/vnd.wasm.component.config.v1+yaml"
 )
 
 // DiffCompression returns the compression as defined by the layer diff media

--- a/images/mediatypes.go
+++ b/images/mediatypes.go
@@ -58,11 +58,8 @@ const (
 	MediaTypeImageLayerEncrypted     = ocispec.MediaTypeImageLayer + "+encrypted"
 	MediaTypeImageLayerGzipEncrypted = ocispec.MediaTypeImageLayerGzip + "+encrypted"
 
-	// OCI media types
-
-	MediaTypeWasmLayerModule    = "application/vnd.w3c.wasm.module.v1+wasm"
-	MediaTypeWasmLayerComponent = "application/vnd.w3c.wasm.component.v1+wasm"
-	MediaTypeWasmLayerConfig    = "application/vnd.wasm.component.config.v1+yaml"
+	// WASM media types
+	MediaTypeWasmLayerComponent = "application/vnd.bytecodealliance.wasm.component.layer.v0+wasm"
 )
 
 // DiffCompression returns the compression as defined by the layer diff media

--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -1677,9 +1677,6 @@ func WithWasmLayers(descriptors []v1.Descriptor) SpecOpts {
 		}
 		for _, descriptor := range descriptors {
 			switch descriptor.MediaType {
-			case images.MediaTypeWasmLayerModule, images.MediaTypeWasmLayerConfig:
-				// should only be one of each
-				s.Annotations[descriptor.MediaType] = descriptor.Digest.String()
 			case images.MediaTypeWasmLayerComponent:
 				// there could be more than one component to make up a module
 				modules := descriptor.Digest.String()


### PR DESCRIPTION
This adds the ability to pass OCI artifact information to the shim via annotations.  This came up as part of https://github.com/containerd/runwasi/issues/108 and https://github.com/bytecodealliance/registry/pull/87 in Runwasi.  It solves challenges for Runwasi like:

- Single artifact that is cross-platform.
- Each Wasm component is uniquely addressable, allowing for de-duplication while storing.
- avoid WASM modules and components in the [root file system](https://github.com/containerd/runwasi/issues/106#issuecomment-1523433276)
- Hard to tell what files are used for the Wasm components (and how to pass that information in current image config) and which are required for the filesystem of the runtime
- work with pre-compiled [wasm modules ](https://github.com/containerd/runwasi/pull/44)

I've shared a document with the wasm groups on an approach and other things tried.  You can read more details in https://docs.google.com/document/d/11shgC3l6gplBjWF1VJCWvN_9do51otscAm0hBDGSSAc/edit

I've got a demo to view at https://1drv.ms/v/s!AgI8NTf7Sd1R-ZU5FH523s3CGiYvuQ?e=m6EZTb

## additional information
I have a few questions about the best way to bring this in now and have commented on the PR it's self but looking for feedback.  Thanks!

Runwasi requires some changes: https://github.com/containerd/runwasi/pull/147
Sample way to build an artifact: https://github.com/containerd/runwasi/tree/main/crates/oci-tar-builder#executable-usage

Example Artifact:

```
regctl manifest get localhost:5000/wasi-demo-oci:module
Name:                                localhost:5000/wasi-demo-oci:module
MediaType:                           application/vnd.oci.image.manifest.v1+json
Digest:                              sha256:869fb6029e26713160d7626dce140f1275f591a694203509cb1e047e746daac8
Annotations:
  io.containerd.image.name:          localhost:5000/wasi-demo-app
  org.opencontainers.image.ref.name: 5000/wasi-demo-app
Total Size:                          2.565MB

Config:
  Digest:                            sha256:707ef07a1143cfdf20af52979d835d5cfc86acc9634edb79d28b89a1edbdc452
  MediaType:                         application/vnd.oci.image.config.v1+json
  Size:                              118B

Layers:

  Digest:                            sha256:b434ff20f62697465e24a52e3573ee9c212e3a171e18e0821bbb464b14fdbbf9
  MediaType:                         application/vnd.w3c.wasm.module.v1+wasm
  Size:                              2.565MB
```