### PR TITLE
Dedup config platform helper

### DIFF
--- a/image.go
+++ b/image.go
@@ -464,29 +464,13 @@ func (i *image) getLayers(ctx context.Context, manifest ocispec.Manifest) ([]roo
 	return layers, nil
 }
 
-func (i *image) getManifestPlatform(ctx context.Context, manifest ocispec.Manifest) (ocispec.Platform, error) {
-	cs := i.ContentStore()
-	p, err := content.ReadBlob(ctx, cs, manifest.Config)
-	if err != nil {
-		return ocispec.Platform{}, err
-	}
-
-	// Technically, this should be ocispec.Image, but we only need the
-	// ocispec.Platform that is embedded in the image struct.
-	var imagePlatform ocispec.Platform
-	if err := json.Unmarshal(p, &imagePlatform); err != nil {
-		return ocispec.Platform{}, err
-	}
-	return platforms.Normalize(imagePlatform), nil
-}
-
 func (i *image) checkSnapshotterSupport(ctx context.Context, snapshotterName string, manifest ocispec.Manifest) error {
 	snapshotterPlatformMatcher, err := i.client.GetSnapshotterSupportedPlatforms(ctx, snapshotterName)
 	if err != nil {
 		return err
 	}
 
-	manifestPlatform, err := i.getManifestPlatform(ctx, manifest)
+	manifestPlatform, err := images.ConfigPlatform(ctx, i.ContentStore(), manifest.Config)
 	if err != nil {
 		return err
 	}

--- a/images/archive/exporter.go
+++ b/images/archive/exporter.go
@@ -439,9 +439,6 @@ func manifestsRecord(ctx context.Context, store content.Provider, manifests map[
 		if err := json.Unmarshal(p, &manifest); err != nil {
 			return tarRecord{}, err
 		}
-		if err := manifest.Config.Digest.Validate(); err != nil {
-			return tarRecord{}, fmt.Errorf("invalid manifest %q: %w", m.manifest.Digest, err)
-		}
 
 		dgst := manifest.Config.Digest
 		if err := dgst.Validate(); err != nil {

--- a/images/image.go
+++ b/images/image.go
@@ -169,19 +169,11 @@ func Manifest(ctx context.Context, provider content.Provider, image ocispec.Desc
 				}
 
 				if desc.Platform == nil {
-					p, err := content.ReadBlob(ctx, provider, manifest.Config)
+					imagePlatform, err := ConfigPlatform(ctx, provider, manifest.Config)
 					if err != nil {
 						return nil, err
 					}
-
-					// Technically, this should be ocispec.Image, but we only need the
-					// ocispec.Platform that is embedded in the image struct.
-					var imagePlatform ocispec.Platform
-					if err := json.Unmarshal(p, &imagePlatform); err != nil {
-						return nil, err
-					}
-
-					if !platform.Match(platforms.Normalize(imagePlatform)) {
+					if !platform.Match(imagePlatform) {
 						return nil, nil
 					}
 
@@ -276,19 +268,11 @@ func Platforms(ctx context.Context, provider content.Provider, image ocispec.Des
 
 		switch desc.MediaType {
 		case MediaTypeDockerSchema2Config, ocispec.MediaTypeImageConfig:
-			p, err := content.ReadBlob(ctx, provider, desc)
+			imagePlatform, err := ConfigPlatform(ctx, provider, desc)
 			if err != nil {
 				return nil, err
 			}
-
-			// Technically, this should be ocispec.Image, but we only need the
-			// ocispec.Platform that is embedded in the image struct.
-			var imagePlatform ocispec.Platform
-			if err := json.Unmarshal(p, &imagePlatform); err != nil {
-				return nil, err
-			}
-
-			platformSpecs = append(platformSpecs, platforms.Normalize(imagePlatform))
+			platformSpecs = append(platformSpecs, imagePlatform)
 		}
 		return nil, nil
 	}), ChildrenHandler(provider)), image)
@@ -440,4 +424,20 @@ func RootFS(ctx context.Context, provider content.Provider, configDesc ocispec.D
 		return nil, err
 	}
 	return config.RootFS.DiffIDs, nil
+}
+
+// ConfigPlatform returns a normalized platform from an image manifest config.
+func ConfigPlatform(ctx context.Context, provider content.Provider, configDesc ocispec.Descriptor) (ocispec.Platform, error) {
+	p, err := content.ReadBlob(ctx, provider, configDesc)
+	if err != nil {
+		return ocispec.Platform{}, err
+	}
+
+	// Technically, this should be ocispec.Image, but we only need the
+	// ocispec.Platform that is embedded in the image struct.
+	var imagePlatform ocispec.Platform
+	if err := json.Unmarshal(p, &imagePlatform); err != nil {
+		return ocispec.Platform{}, err
+	}
+	return platforms.Normalize(imagePlatform), nil
 }


### PR DESCRIPTION
It might be a personal preference, the `ConfigPlatform` helper is duplicated 3 times so might be good to move to a separate helper func.

It also removes a duplicated digest validate call.