### PR TITLE
log: Introduce fields for log package

### DIFF
--- a/cmd/ctr/commands/content/content.go
+++ b/cmd/ctr/commands/content/content.go
@@ -422,7 +422,7 @@ var (
 				return err
 			}
 
-			ctx = log.WithLogger(ctx, log.G(ctx).WithField("ref", ref))
+			ctx = log.WithLogger(ctx, log.G(ctx).WithField(log.Ref, ref))
 
 			log.G(ctx).Debugf("resolving")
 			name, desc, err := resolver.Resolve(ctx, ref)
@@ -468,7 +468,7 @@ var (
 				return err
 			}
 
-			ctx = log.WithLogger(ctx, log.G(ctx).WithField("ref", ref))
+			ctx = log.WithLogger(ctx, log.G(ctx).WithField(log.Ref, ref))
 
 			log.G(ctx).Debugf("resolving")
 			fetcher, err := resolver.Fetcher(ctx, ref)
@@ -527,7 +527,7 @@ var (
 				return err
 			}
 
-			ctx = log.WithLogger(ctx, log.G(ctx).WithField("ref", ref))
+			ctx = log.WithLogger(ctx, log.G(ctx).WithField(log.Ref, ref))
 
 			log.G(ctx).Debugf("resolving")
 			pusher, err := resolver.Pusher(ctx, ref)

--- a/cmd/ctr/commands/content/fetch.go
+++ b/cmd/ctr/commands/content/fetch.go
@@ -184,7 +184,7 @@ func Fetch(ctx context.Context, client *containerd.Client, ref string, config *F
 		return nil, nil
 	})
 
-	log.G(pctx).WithField("image", ref).Debug("fetching")
+	log.G(pctx).WithField(log.Image, ref).Debug("fetching")
 	labels := commands.LabelArgs(config.Labels)
 	opts := []containerd.RemoteOpt{
 		containerd.WithPullLabels(labels),

--- a/cmd/ctr/commands/content/prune.go
+++ b/cmd/ctr/commands/content/prune.go
@@ -82,8 +82,8 @@ var pruneReferencesCommand = cli.Command{
 			for k := range info.Labels {
 				if isLayerLabel(k) {
 					log.G(ctx).WithFields(log.Fields{
-						"digest": info.Digest,
-						"label":  k,
+						log.Digest: info.Digest,
+						"label":    k,
 					}).Debug("Removing label")
 					if dryRun {
 						continue

--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -157,7 +157,7 @@ command. As part of this process, we do the following:
 			return err
 		}
 
-		log.G(ctx).WithField("image", ref).Debug("unpacking")
+		log.G(ctx).WithField(log.Image, ref).Debug("unpacking")
 
 		// TODO: Show unpack status
 

--- a/cmd/ctr/commands/images/push.go
+++ b/cmd/ctr/commands/images/push.go
@@ -168,7 +168,7 @@ var pushCommand = cli.Command{
 		eg.Go(func() error {
 			defer close(doneCh)
 
-			log.G(ctx).WithField("image", ref).WithField("digest", desc.Digest).Debug("pushing")
+			log.G(ctx).WithField(log.Image, ref).WithField(log.Digest, desc.Digest).Debug("pushing")
 
 			jobHandler := images.HandlerFunc(func(ctx gocontext.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 				if !context.Bool("allow-non-distributable-blobs") && images.IsNonDistributable(desc.MediaType) {

--- a/cmd/ctr/commands/resolver.go
+++ b/cmd/ctr/commands/resolver.go
@@ -191,7 +191,7 @@ func (t DebugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 func NewDebugClientTrace(ctx gocontext.Context) *httptrace.ClientTrace {
 	return &httptrace.ClientTrace{
 		DNSStart: func(dnsInfo httptrace.DNSStartInfo) {
-			log.G(ctx).WithField("host", dnsInfo.Host).Debugf("DNS lookup")
+			log.G(ctx).WithField(log.Host, dnsInfo.Host).Debugf("DNS lookup")
 		},
 		DNSDone: func(dnsInfo httptrace.DNSDoneInfo) {
 			if dnsInfo.Err != nil {

--- a/content/helpers.go
+++ b/content/helpers.go
@@ -162,7 +162,7 @@ func Copy(ctx context.Context, cw Writer, or io.Reader, size int64, expected dig
 
 	for i := 0; i < maxResets; i++ {
 		if i >= 1 {
-			log.G(ctx).WithField("digest", expected).Debugf("retrying copy due to reset")
+			log.G(ctx).WithField(log.Digest, expected).Debugf("retrying copy due to reset")
 		}
 		copied, err := copyWithBuffer(cw, r)
 		if errors.Is(err, ErrReset) {
@@ -202,7 +202,7 @@ func Copy(ctx context.Context, cw Writer, or io.Reader, size int64, expected dig
 		return nil
 	}
 
-	log.G(ctx).WithField("digest", expected).Errorf("failed to copy after %d retries", maxResets)
+	log.G(ctx).WithField(log.Digest, expected).Errorf("failed to copy after %d retries", maxResets)
 	return fmt.Errorf("failed to copy after %d retries", maxResets)
 }
 

--- a/content/local/store.go
+++ b/content/local/store.go
@@ -265,7 +265,7 @@ func (s *store) Walk(ctx context.Context, fn content.WalkFunc, fs ...string) err
 		dgst := digest.NewDigestFromEncoded(alg, filepath.Base(path))
 		if err := dgst.Validate(); err != nil {
 			// log error but don't report
-			log.L.WithError(err).WithField("path", path).Error("invalid digest for blob path")
+			log.L.WithError(err).WithField(log.Path, path).Error("invalid digest for blob path")
 			// if we see this, it could mean some sort of corruption of the
 			// store or extra paths not expected previously.
 		}
@@ -356,7 +356,7 @@ func (s *store) WalkStatusRefs(ctx context.Context, fn func(string) error) error
 
 		ref, err := readFileString(rf)
 		if err != nil {
-			log.G(ctx).WithError(err).WithField("path", rf).Error("failed to read ingest ref")
+			log.G(ctx).WithError(err).WithField(log.Path, rf).Error("failed to read ingest ref")
 			continue
 		}
 

--- a/content/local/writer.go
+++ b/content/local/writer.go
@@ -128,7 +128,7 @@ func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest,
 	if _, err := os.Stat(target); err == nil {
 		// collision with the target file!
 		if err := os.RemoveAll(w.path); err != nil {
-			log.G(ctx).WithField("ref", w.ref).WithField("path", w.path).Error("failed to remove ingest directory")
+			log.G(ctx).WithField(log.Ref, w.ref).WithField(log.Path, w.path).Error("failed to remove ingest directory")
 		}
 		return fmt.Errorf("content %v: %w", dgst, errdefs.ErrAlreadyExists)
 	}
@@ -143,17 +143,17 @@ func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest,
 
 	commitTime := time.Now()
 	if err := os.Chtimes(target, commitTime, commitTime); err != nil {
-		log.G(ctx).WithField("digest", dgst).Error("failed to change file time to commit time")
+		log.G(ctx).WithField(log.Digest, dgst).Error("failed to change file time to commit time")
 	}
 
 	// clean up!!
 	if err := os.RemoveAll(w.path); err != nil {
-		log.G(ctx).WithField("ref", w.ref).WithField("path", w.path).Error("failed to remove ingest directory")
+		log.G(ctx).WithField(log.Ref, w.ref).WithField(log.Path, w.path).Error("failed to remove ingest directory")
 	}
 
 	if w.s.ls != nil && base.Labels != nil {
 		if err := w.s.ls.Set(dgst, base.Labels); err != nil {
-			log.G(ctx).WithField("digest", dgst).Error("failed to set labels")
+			log.G(ctx).WithField(log.Digest, dgst).Error("failed to set labels")
 		}
 	}
 
@@ -166,7 +166,7 @@ func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest,
 	// NOTE: Windows does not support this operation
 	if runtime.GOOS != "windows" {
 		if err := os.Chmod(target, (fi.Mode()&os.ModePerm)&^0333); err != nil {
-			log.G(ctx).WithField("ref", w.ref).Error("failed to make readonly")
+			log.G(ctx).WithField(log.Ref, w.ref).Error("failed to make readonly")
 		}
 	}
 

--- a/diff/apply/apply.go
+++ b/diff/apply/apply.go
@@ -52,10 +52,10 @@ func (s *fsApplier) Apply(ctx context.Context, desc ocispec.Descriptor, mounts [
 	defer func() {
 		if err == nil {
 			log.G(ctx).WithFields(log.Fields{
-				"d":      time.Since(t1),
-				"digest": desc.Digest,
-				"size":   desc.Size,
-				"media":  desc.MediaType,
+				"d":           time.Since(t1),
+				log.Digest:    desc.Digest,
+				log.Size:      desc.Size,
+				log.MediaType: desc.MediaType,
 			}).Debugf("diff applied")
 		}
 	}()

--- a/diff/lcow/lcow.go
+++ b/diff/lcow/lcow.go
@@ -99,10 +99,10 @@ func (s windowsLcowDiff) Apply(ctx context.Context, desc ocispec.Descriptor, mou
 	defer func() {
 		if err == nil {
 			log.G(ctx).WithFields(log.Fields{
-				"d":      time.Since(t1),
-				"digest": desc.Digest,
-				"size":   desc.Size,
-				"media":  desc.MediaType,
+				"d":           time.Since(t1),
+				log.Digest:    desc.Digest,
+				log.Size:      desc.Size,
+				log.MediaType: desc.MediaType,
 			}).Debugf("diff applied")
 		}
 	}()

--- a/diff/walking/differ.go
+++ b/diff/walking/differ.go
@@ -120,7 +120,7 @@ func (s *walkingDiff) Compare(ctx context.Context, lower, upper []mount.Mount, o
 					cw.Close()
 					if newReference {
 						if abortErr := s.store.Abort(ctx, config.Reference); abortErr != nil {
-							log.G(ctx).WithError(abortErr).WithField("ref", config.Reference).Warnf("failed to delete diff upload")
+							log.G(ctx).WithError(abortErr).WithField(log.Ref, config.Reference).Warnf("failed to delete diff upload")
 						}
 					}
 				}

--- a/diff/windows/windows.go
+++ b/diff/windows/windows.go
@@ -94,10 +94,10 @@ func (s windowsDiff) Apply(ctx context.Context, desc ocispec.Descriptor, mounts 
 	defer func() {
 		if err == nil {
 			log.G(ctx).WithFields(log.Fields{
-				"d":      time.Since(t1),
-				"digest": desc.Digest,
-				"size":   desc.Size,
-				"media":  desc.MediaType,
+				"d":           time.Since(t1),
+				log.Digest:    desc.Digest,
+				log.Size:      desc.Size,
+				log.MediaType: desc.MediaType,
 			}).Debug("diff applied")
 		}
 	}()
@@ -218,7 +218,7 @@ func (s windowsDiff) Compare(ctx context.Context, lower, upper []mount.Mount, op
 			cw.Close()
 			if newReference {
 				if abortErr := s.store.Abort(ctx, config.Reference); abortErr != nil {
-					log.G(ctx).WithError(abortErr).WithField("ref", config.Reference).Warnf("failed to delete diff upload")
+					log.G(ctx).WithError(abortErr).WithField(log.Ref, config.Reference).Warnf("failed to delete diff upload")
 				}
 			}
 		}
@@ -295,10 +295,10 @@ func (s windowsDiff) Compare(ctx context.Context, lower, upper []mount.Mount, op
 	}
 
 	log.G(ctx).WithFields(log.Fields{
-		"d":     time.Since(t1),
-		"dgst":  desc.Digest,
-		"size":  desc.Size,
-		"media": desc.MediaType,
+		"d":           time.Since(t1),
+		log.Digest:    desc.Digest,
+		log.Size:      desc.Size,
+		log.MediaType: desc.MediaType,
 	}).Debug("diff created")
 
 	return desc, nil

--- a/integration/client/client_test.go
+++ b/integration/client/client_test.go
@@ -148,7 +148,7 @@ func TestMain(m *testing.M) {
 	testSnapshotter = snapshotter
 
 	// pull a seed image
-	log.G(ctx).WithField("image", testImage).Info("start to pull seed image")
+	log.G(ctx).WithField(log.Image, testImage).Info("start to pull seed image")
 	if _, err = client.Pull(ctx, testImage, WithPullUnpack); err != nil {
 		ctrd.Kill()
 		ctrd.Wait()

--- a/log/fields.go
+++ b/log/fields.go
@@ -19,26 +19,30 @@ package log
 // Often used fields for structured logging.
 const (
 	// Images/content
-	ChainID = "chainid"
-	Digest  = "digest"
-	Ref     = "ref"
-	URL     = "url"
+	ChainID   = "chainid"
+	Name      = "name" // NOTE: Used in snapshotter contexts also.
+	Image     = "image"
+	Digest    = "digest"
+	Host      = "host"
+	MediaType = "mediatype"
+	Ref       = "ref"
+	Size      = "size"
+	URL       = "url"
 
-	// Transfer
-	Stream = "stream"
-
-	// Containerd
+	// Containerd/services
 	ID        = "id"
 	Namespace = "namespace"
 	Request   = "req"
+	Stream    = "stream"
 
 	// Snapshots
-	Snapshotter = "snapshotter"
-	Path        = "path"
+	Key         = "key" // NOTE: There's small uses of this in a non-snapshot context.
 	Parent      = "parent"
-	Key         = "key"
-	Name        = "name"
+	Snapshotter = "snapshotter"
 
 	// CRI
 	PodSandboxID = "podsandboxid"
+
+	// Misc.
+	Path = "path"
 )

--- a/log/fields.go
+++ b/log/fields.go
@@ -1,0 +1,44 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package log
+
+// Often used fields for structured logging.
+const (
+	// Images/content
+	ChainID = "chainid"
+	Digest  = "digest"
+	Ref     = "ref"
+	URL     = "url"
+
+	// Transfer
+	Stream = "stream"
+
+	// Containerd
+	ID        = "id"
+	Namespace = "namespace"
+	Request   = "req"
+
+	// Snapshots
+	Snapshotter = "snapshotter"
+	Path        = "path"
+	Parent      = "parent"
+	Key         = "key"
+	Name        = "name"
+
+	// CRI
+	PodSandboxID = "podsandboxid"
+)

--- a/metadata/content.go
+++ b/metadata/content.go
@@ -869,7 +869,7 @@ func (cs *contentStore) garbageCollect(ctx context.Context) (d time.Duration, er
 			if err := cs.Store.Delete(ctx, info.Digest); err != nil {
 				return err
 			}
-			log.G(ctx).WithField("digest", info.Digest).Debug("removed content")
+			log.G(ctx).WithField(log.Digest, info.Digest).Debug("removed content")
 		}
 		return nil
 	})
@@ -889,7 +889,7 @@ func (cs *contentStore) garbageCollect(ctx context.Context) (d time.Duration, er
 				if err := cs.Store.Abort(ctx, ref); err != nil {
 					return err
 				}
-				log.G(ctx).WithField("ref", ref).Debug("cleanup aborting ingest")
+				log.G(ctx).WithField(log.Ref, ref).Debug("cleanup aborting ingest")
 			}
 			return nil
 		})
@@ -904,7 +904,7 @@ func (cs *contentStore) garbageCollect(ctx context.Context) (d time.Duration, er
 				if err = cs.Store.Abort(ctx, status.Ref); err != nil {
 					return
 				}
-				log.G(ctx).WithField("ref", status.Ref).Debug("cleanup aborting ingest")
+				log.G(ctx).WithField(log.Ref, status.Ref).Debug("cleanup aborting ingest")
 			}
 		}
 	}

--- a/metadata/db.go
+++ b/metadata/db.go
@@ -422,7 +422,7 @@ func (m *DB) GarbageCollect(ctx context.Context) (gc.Stats, error) {
 		stats.SnapshotD = map[string]time.Duration{}
 		wg.Add(len(m.dirtySS))
 		for snapshotterName := range m.dirtySS {
-			log.G(ctx).WithField("snapshotter", snapshotterName).Debug("schedule snapshotter cleanup")
+			log.G(ctx).WithField(log.Snapshotter, snapshotterName).Debug("schedule snapshotter cleanup")
 			go func(snapshotterName string) {
 				st1 := time.Now()
 				m.cleanupSnapshotter(ctx, snapshotterName)
@@ -516,7 +516,7 @@ func (m *DB) cleanupSnapshotter(ctx context.Context, name string) (time.Duration
 	}
 
 	d, err := sn.garbageCollect(ctx)
-	logger := log.G(ctx).WithField("snapshotter", name)
+	logger := log.G(ctx).WithField(log.Snapshotter, name)
 	if err != nil {
 		logger.WithError(err).Warn("snapshot garbage collection failed")
 	} else {

--- a/metadata/gc.go
+++ b/metadata/gc.go
@@ -607,7 +607,7 @@ func (c *gcContext) remove(ctx context.Context, tx *bolt.Tx, node gc.Node) (inte
 			cbkt = cbkt.Bucket(bucketKeyObjectBlob)
 		}
 		if cbkt != nil {
-			log.G(ctx).WithField("key", node.Key).Debug("remove content")
+			log.G(ctx).WithField(log.Key, node.Key).Debug("remove content")
 			return nil, cbkt.DeleteBucket([]byte(node.Key))
 		}
 	case ResourceSnapshot:
@@ -619,7 +619,7 @@ func (c *gcContext) remove(ctx context.Context, tx *bolt.Tx, node gc.Node) (inte
 			}
 			ssbkt := sbkt.Bucket([]byte(ss))
 			if ssbkt != nil {
-				log.G(ctx).WithField("key", key).WithField("snapshotter", ss).Debug("remove snapshot")
+				log.G(ctx).WithField(log.Key, key).WithField(log.Snapshotter, ss).Debug("remove snapshot")
 				return &eventstypes.SnapshotRemove{
 					Key:         key,
 					Snapshotter: ss,
@@ -637,7 +637,7 @@ func (c *gcContext) remove(ctx context.Context, tx *bolt.Tx, node gc.Node) (inte
 			ibkt = ibkt.Bucket(bucketKeyObjectIngests)
 		}
 		if ibkt != nil {
-			log.G(ctx).WithField("ref", node.Key).Debug("remove ingest")
+			log.G(ctx).WithField(log.Ref, node.Key).Debug("remove ingest")
 			return nil, ibkt.DeleteBucket([]byte(node.Key))
 		}
 	default:
@@ -645,7 +645,7 @@ func (c *gcContext) remove(ctx context.Context, tx *bolt.Tx, node gc.Node) (inte
 		if ok {
 			cc.Remove(node)
 		} else {
-			log.G(ctx).WithField("ref", node.Key).WithField("type", node.Type).Info("no remove defined for resource")
+			log.G(ctx).WithField(log.Ref, node.Key).WithField("type", node.Type).Info("no remove defined for resource")
 		}
 	}
 

--- a/metadata/snapshot.go
+++ b/metadata/snapshot.go
@@ -233,7 +233,7 @@ func (s *snapshotter) Update(ctx context.Context, info snapshots.Info, fieldpath
 		return nil
 	}); err != nil {
 		if updated {
-			log.G(ctx).WithField("snapshotter", s.name).WithField("key", local.Name).WithError(err).Error("transaction failed after updating snapshot backend")
+			log.G(ctx).WithField(log.Snapshotter, s.name).WithField(log.Key, local.Name).WithError(err).Error("transaction failed after updating snapshot backend")
 		}
 		return snapshots.Info{}, err
 	}
@@ -498,7 +498,7 @@ func (s *snapshotter) createSnapshot(ctx context.Context, key, parent string, re
 		// If the created reference is not stored, attempt clean up
 		if created != "" {
 			if err := s.Snapshotter.Remove(ctx, created); err != nil {
-				log.G(ctx).WithField("snapshotter", s.name).WithField("key", created).WithError(err).Error("failed to cleanup unreferenced snapshot")
+				log.G(ctx).WithField(log.Snapshotter, s.name).WithField(log.Key, created).WithError(err).Error("failed to cleanup unreferenced snapshot")
 			}
 		}
 		return nil, rerr
@@ -611,7 +611,7 @@ func (s *snapshotter) Commit(ctx context.Context, name, key string, opts ...snap
 		// sync data is higher and may require manual cleanup.
 		if err := s.Snapshotter.Commit(ctx, nameKey, bkey, inheritedOpt); err != nil {
 			if errdefs.IsNotFound(err) {
-				log.G(ctx).WithField("snapshotter", s.name).WithField("key", key).WithError(err).Error("uncommittable snapshot: missing in backend, snapshot should be removed")
+				log.G(ctx).WithField(log.Snapshotter, s.name).WithField(log.Key, key).WithError(err).Error("uncommittable snapshot: missing in backend, snapshot should be removed")
 			}
 			// NOTE: Consider handling already exists here from the backend. Currently
 			// already exists from the backend may be confusing to the client since it
@@ -628,7 +628,7 @@ func (s *snapshotter) Commit(ctx context.Context, name, key string, opts ...snap
 		return nil
 	}); err != nil {
 		if bname != "" {
-			log.G(ctx).WithField("snapshotter", s.name).WithField("key", key).WithField("bname", bname).WithError(err).Error("uncommittable snapshot: transaction failed after commit, snapshot should be removed")
+			log.G(ctx).WithField(log.Snapshotter, s.name).WithField(log.Key, key).WithField("bname", bname).WithError(err).Error("uncommittable snapshot: transaction failed after commit, snapshot should be removed")
 
 		}
 		return err
@@ -956,14 +956,14 @@ func (s *snapshotter) pruneBranch(ctx context.Context, node *treeNode) error {
 	}
 
 	if node.remove {
-		logger := log.G(ctx).WithField("snapshotter", s.name)
+		logger := log.G(ctx).WithField(log.Snapshotter, s.name)
 		if err := s.Snapshotter.Remove(ctx, node.info.Name); err != nil {
 			if !errdefs.IsFailedPrecondition(err) {
 				return err
 			}
-			logger.WithError(err).WithField("key", node.info.Name).Warnf("failed to remove snapshot")
+			logger.WithError(err).WithField(log.Key, node.info.Name).Warnf("failed to remove snapshot")
 		} else {
-			logger.WithField("key", node.info.Name).Debug("removed snapshot")
+			logger.WithField(log.Key, node.info.Name).Debug("removed snapshot")
 		}
 	}
 

--- a/pkg/cri/sbserver/images/image_pull.go
+++ b/pkg/cri/sbserver/images/image_pull.go
@@ -620,7 +620,7 @@ func (reporter *pullProgressReporter) start(ctx context.Context) {
 			case <-ticker.C:
 				activeReqs, bytesRead := reporter.reqReporter.status()
 
-				log.G(ctx).WithField("ref", reporter.ref).
+				log.G(ctx).WithField(log.Ref, reporter.ref).
 					WithField("activeReqs", activeReqs).
 					WithField("totalBytesRead", bytesRead).
 					WithField("lastSeenBytesRead", lastSeenBytesRead).

--- a/pkg/cri/sbserver/podsandbox/sandbox_run.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_run.go
@@ -60,7 +60,7 @@ func (c *Controller) Start(ctx context.Context, id string) (cin sandbox.Controll
 	var cleanupErr error
 	defer func() {
 		if retErr != nil && cleanupErr != nil {
-			log.G(ctx).WithField("id", id).WithError(cleanupErr).Errorf("failed to fully teardown sandbox resources after earlier error: %s", retErr)
+			log.G(ctx).WithField(log.ID, id).WithError(cleanupErr).Errorf("failed to fully teardown sandbox resources after earlier error: %s", retErr)
 			retErr = multierror.Append(retErr, CleanupErr{cleanupErr})
 		}
 	}()
@@ -95,7 +95,7 @@ func (c *Controller) Start(ctx context.Context, id string) (cin sandbox.Controll
 	if err != nil {
 		return cin, fmt.Errorf("failed to get sandbox runtime: %w", err)
 	}
-	log.G(ctx).WithField("podsandboxid", id).Debugf("use OCI runtime %+v", ociRuntime)
+	log.G(ctx).WithField(log.PodSandboxID, id).Debugf("use OCI runtime %+v", ociRuntime)
 
 	labels["oci_runtime_type"] = ociRuntime.Type
 
@@ -107,7 +107,7 @@ func (c *Controller) Start(ctx context.Context, id string) (cin sandbox.Controll
 	if err != nil {
 		return cin, fmt.Errorf("failed to generate sandbox container spec: %w", err)
 	}
-	log.G(ctx).WithField("podsandboxid", id).Debugf("sandbox container spec: %#+v", spew.NewFormatter(spec))
+	log.G(ctx).WithField(log.PodSandboxID, id).Debugf("sandbox container spec: %#+v", spew.NewFormatter(spec))
 
 	metadata.ProcessLabel = spec.Process.SelinuxLabel
 	defer func() {

--- a/pkg/cri/sbserver/sandbox_run.go
+++ b/pkg/cri/sbserver/sandbox_run.go
@@ -61,7 +61,7 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		return nil, errors.New("sandbox config must include metadata")
 	}
 	name := makeSandboxName(metadata)
-	log.G(ctx).WithField("podsandboxid", id).Debugf("generated id for sandbox name %q", name)
+	log.G(ctx).WithField(log.PodSandboxID, id).Debugf("generated id for sandbox name %q", name)
 
 	// cleanupErr records the last error returned by the critical cleanup operations in deferred functions,
 	// like CNI teardown and stopping the running sandbox task.
@@ -358,7 +358,7 @@ func (c *criService) setupPodNetwork(ctx context.Context, sandbox *sandboxstore.
 	if err != nil {
 		return fmt.Errorf("get cni namespace options: %w", err)
 	}
-	log.G(ctx).WithField("podsandboxid", id).Debugf("begin cni setup")
+	log.G(ctx).WithField(log.PodSandboxID, id).Debugf("begin cni setup")
 	netStart := time.Now()
 	if c.config.CniConfig.NetworkPluginSetupSerially {
 		result, err = netPlugin.SetupSerially(ctx, id, path, opts...)
@@ -602,8 +602,8 @@ func logDebugCNIResult(ctx context.Context, sandboxID string, result *cni.Result
 	}
 	cniResult, err := json.Marshal(result)
 	if err != nil {
-		log.G(ctx).WithField("podsandboxid", sandboxID).WithError(err).Errorf("Failed to marshal CNI result: %v", err)
+		log.G(ctx).WithField(log.PodSandboxID, sandboxID).WithError(err).Errorf("Failed to marshal CNI result: %v", err)
 		return
 	}
-	log.G(ctx).WithField("podsandboxid", sandboxID).Debugf("cni result: %s", string(cniResult))
+	log.G(ctx).WithField(log.PodSandboxID, sandboxID).Debugf("cni result: %s", string(cniResult))
 }

--- a/pkg/cri/sbserver/sandbox_stats_windows.go
+++ b/pkg/cri/sbserver/sandbox_stats_windows.go
@@ -318,7 +318,7 @@ func getUsageNanoCores(usageCoreNanoSeconds uint64, oldStats *stats.ContainerSta
 func windowsNetworkUsage(ctx context.Context, sandbox sandboxstore.Sandbox, timestamp time.Time) *runtime.WindowsNetworkUsage {
 	eps, err := hcn.GetNamespaceEndpointIds(sandbox.NetNSPath)
 	if err != nil {
-		log.G(ctx).WithField("podsandboxid", sandbox.ID).WithError(err).Errorf("unable to retrieve windows endpoint metrics for netNsPath: %v", sandbox.NetNSPath)
+		log.G(ctx).WithField(log.PodSandboxID, sandbox.ID).WithError(err).Errorf("unable to retrieve windows endpoint metrics for netNsPath: %v", sandbox.NetNSPath)
 		return nil
 	}
 	networkUsage := &runtime.WindowsNetworkUsage{

--- a/pkg/cri/server/image_pull.go
+++ b/pkg/cri/server/image_pull.go
@@ -593,7 +593,7 @@ func (reporter *pullProgressReporter) start(ctx context.Context) {
 			case <-ticker.C:
 				activeReqs, bytesRead := reporter.reqReporter.status()
 
-				log.G(ctx).WithField("ref", reporter.ref).
+				log.G(ctx).WithField(log.Ref, reporter.ref).
 					WithField("activeReqs", activeReqs).
 					WithField("totalBytesRead", bytesRead).
 					WithField("lastSeenBytesRead", lastSeenBytesRead).

--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -65,7 +65,7 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		return nil, errors.New("sandbox config must include metadata")
 	}
 	name := makeSandboxName(metadata)
-	log.G(ctx).WithField("podsandboxid", id).Debugf("generated id for sandbox name %q", name)
+	log.G(ctx).WithField(log.PodSandboxID, id).Debugf("generated id for sandbox name %q", name)
 
 	// cleanupErr records the last error returned by the critical cleanup operations in deferred functions,
 	// like CNI teardown and stopping the running sandbox task.
@@ -113,7 +113,7 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	if err != nil {
 		return nil, fmt.Errorf("failed to get sandbox runtime: %w", err)
 	}
-	log.G(ctx).WithField("podsandboxid", id).Debugf("use OCI runtime %+v", ociRuntime)
+	log.G(ctx).WithField(log.PodSandboxID, id).Debugf("use OCI runtime %+v", ociRuntime)
 
 	runtimeStart := time.Now()
 	// Create sandbox container.
@@ -125,7 +125,7 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate sandbox container spec: %w", err)
 	}
-	log.G(ctx).WithField("podsandboxid", id).Debugf("sandbox container spec: %#+v", spew.NewFormatter(spec))
+	log.G(ctx).WithField(log.PodSandboxID, id).Debugf("sandbox container spec: %#+v", spew.NewFormatter(spec))
 	sandbox.ProcessLabel = spec.Process.SelinuxLabel
 	defer func() {
 		if retErr != nil {
@@ -544,7 +544,7 @@ func (c *criService) setupPodNetwork(ctx context.Context, sandbox *sandboxstore.
 	if err != nil {
 		return fmt.Errorf("get cni namespace options: %w", err)
 	}
-	log.G(ctx).WithField("podsandboxid", id).Debugf("begin cni setup")
+	log.G(ctx).WithField(log.PodSandboxID, id).Debugf("begin cni setup")
 	netStart := time.Now()
 	if c.config.CniConfig.NetworkPluginSetupSerially {
 		result, err = netPlugin.SetupSerially(ctx, id, path, opts...)
@@ -769,8 +769,8 @@ func logDebugCNIResult(ctx context.Context, sandboxID string, result *cni.Result
 	}
 	cniResult, err := json.Marshal(result)
 	if err != nil {
-		log.G(ctx).WithField("podsandboxid", sandboxID).WithError(err).Errorf("Failed to marshal CNI result: %v", err)
+		log.G(ctx).WithField(log.PodSandboxID, sandboxID).WithError(err).Errorf("Failed to marshal CNI result: %v", err)
 		return
 	}
-	log.G(ctx).WithField("podsandboxid", sandboxID).Debugf("cni result: %s", string(cniResult))
+	log.G(ctx).WithField(log.PodSandboxID, sandboxID).Debugf("cni result: %s", string(cniResult))
 }

--- a/pkg/cri/server/sandbox_stats_windows.go
+++ b/pkg/cri/server/sandbox_stats_windows.go
@@ -316,7 +316,7 @@ func getUsageNanoCores(usageCoreNanoSeconds uint64, oldStats *stats.ContainerSta
 func windowsNetworkUsage(ctx context.Context, sandbox sandboxstore.Sandbox, timestamp time.Time) *runtime.WindowsNetworkUsage {
 	eps, err := hcn.GetNamespaceEndpointIds(sandbox.NetNSPath)
 	if err != nil {
-		log.G(ctx).WithField("podsandboxid", sandbox.ID).WithError(err).Errorf("unable to retrieve windows endpoint metrics for netNsPath: %v", sandbox.NetNSPath)
+		log.G(ctx).WithField(log.PodSandboxID, sandbox.ID).WithError(err).Errorf("unable to retrieve windows endpoint metrics for netNsPath: %v", sandbox.NetNSPath)
 		return nil
 	}
 	networkUsage := &runtime.WindowsNetworkUsage{

--- a/pkg/snapshotters/annotations.go
+++ b/pkg/snapshotters/annotations.go
@@ -87,7 +87,7 @@ func getLayers(ctx context.Context, key string, descs []ocispec.Descriptor, vali
 			}
 			// This avoids the label hits the size limitation.
 			if err := validate(key, layers+item); err != nil {
-				log.G(ctx).WithError(err).WithField("label", key).WithField("digest", l.Digest.String()).Debug("omitting digest in the layers list")
+				log.G(ctx).WithError(err).WithField("label", key).WithField(log.Digest, l.Digest.String()).Debug("omitting digest in the layers list")
 				break
 			}
 			layers += item

--- a/pkg/transfer/archive/exporter.go
+++ b/pkg/transfer/archive/exporter.go
@@ -152,7 +152,7 @@ func (iis *ImageExportStream) UnmarshalAny(ctx context.Context, sm streaming.Str
 
 	stream, err := sm.Get(ctx, s.Stream)
 	if err != nil {
-		log.G(ctx).WithError(err).WithField("stream", s.Stream).Debug("failed to get export stream")
+		log.G(ctx).WithError(err).WithField(log.Stream, s.Stream).Debug("failed to get export stream")
 		return err
 	}
 

--- a/pkg/transfer/archive/importer.go
+++ b/pkg/transfer/archive/importer.go
@@ -92,7 +92,7 @@ func (iis *ImageImportStream) UnmarshalAny(ctx context.Context, sm streaming.Str
 
 	stream, err := sm.Get(ctx, s.Stream)
 	if err != nil {
-		log.G(ctx).WithError(err).WithField("stream", s.Stream).Debug("failed to get import stream")
+		log.G(ctx).WithError(err).WithField(log.Stream, s.Stream).Debug("failed to get import stream")
 		return err
 	}
 

--- a/pkg/transfer/local/pull.go
+++ b/pkg/transfer/local/pull.go
@@ -230,9 +230,9 @@ func (ts *localTransferService) pull(ctx context.Context, ir transfer.ImageFetch
 func fetchHandler(ingester content.Ingester, fetcher remotes.Fetcher, pt *ProgressTracker) images.HandlerFunc {
 	return func(ctx context.Context, desc ocispec.Descriptor) (subdescs []ocispec.Descriptor, err error) {
 		ctx = log.WithLogger(ctx, log.G(ctx).WithFields(log.Fields{
-			"digest":    desc.Digest,
-			"mediatype": desc.MediaType,
-			"size":      desc.Size,
+			log.Digest:    desc.Digest,
+			log.MediaType: desc.MediaType,
+			log.Size:      desc.Size,
 		}))
 
 		switch desc.MediaType {

--- a/pkg/transfer/registry/registry.go
+++ b/pkg/transfer/registry/registry.go
@@ -216,7 +216,7 @@ func (r *OCIRegistry) UnmarshalAny(ctx context.Context, sm streaming.StreamGette
 		if sid := s.Resolver.AuthStream; sid != "" {
 			stream, err := sm.Get(ctx, sid)
 			if err != nil {
-				log.G(ctx).WithError(err).WithField("stream", sid).Debug("failed to get auth stream")
+				log.G(ctx).WithError(err).WithField(log.Stream, sid).Debug("failed to get auth stream")
 				return err
 			}
 			r.creds = &credCallback{

--- a/pkg/unpack/unpacker.go
+++ b/pkg/unpack/unpacker.go
@@ -326,7 +326,10 @@ func (u *Unpacker) unpack(
 							return fmt.Errorf("failed to stat snapshot %s: %w", chainID, err)
 						}
 						// Try again, this should be rare, log it
-						log.G(ctx).WithField("key", key).WithField("chainid", chainID).Debug("extraction snapshot already exists, chain id not found")
+						log.G(ctx).WithFields(log.Fields{
+							log.Key:     key,
+							log.ChainID: chainID,
+						}).Debug("extraction snapshot already exists, chain id not found")
 					} else {
 						// no need to handle, snapshot now found with chain id
 						return nil
@@ -437,8 +440,8 @@ func (u *Unpacker) unpack(
 		return err
 	}
 	log.G(ctx).WithFields(log.Fields{
-		"config":  config.Digest,
-		"chainID": chainID,
+		"config":    config.Digest,
+		log.ChainID: chainID,
 	}).Debug("image unpacked")
 
 	return nil

--- a/remotes/docker/auth/fetch.go
+++ b/remotes/docker/auth/fetch.go
@@ -60,7 +60,7 @@ func GenerateTokenOptions(ctx context.Context, host, username, secret string, c 
 	if ok {
 		to.Scopes = append(to.Scopes, strings.Split(scope, " ")...)
 	} else {
-		log.G(ctx).WithField("host", host).Debug("no scope specified for token auth challenge")
+		log.G(ctx).WithField(log.Host, host).Debug("no scope specified for token auth challenge")
 	}
 
 	return to, nil

--- a/remotes/docker/fetcher.go
+++ b/remotes/docker/fetcher.go
@@ -38,7 +38,7 @@ type dockerFetcher struct {
 }
 
 func (r dockerFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.ReadCloser, error) {
-	ctx = log.WithLogger(ctx, log.G(ctx).WithField("digest", desc.Digest))
+	ctx = log.WithLogger(ctx, log.G(ctx).WithField(log.Digest, desc.Digest))
 
 	hosts := r.filterHosts(HostCapabilityPull)
 	if len(hosts) == 0 {
@@ -62,7 +62,7 @@ func (r dockerFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.R
 				log.G(ctx).Debug("non-http(s) alternative url is unsupported")
 				continue
 			}
-			ctx = log.WithLogger(ctx, log.G(ctx).WithField("url", u))
+			ctx = log.WithLogger(ctx, log.G(ctx).WithField(log.URL, u))
 			log.G(ctx).Info("request")
 
 			// Try this first, parse it
@@ -177,7 +177,7 @@ func (r dockerFetcher) createGetReq(ctx context.Context, host RegistryHost, ps .
 
 func (r dockerFetcher) FetchByDigest(ctx context.Context, dgst digest.Digest) (io.ReadCloser, ocispec.Descriptor, error) {
 	var desc ocispec.Descriptor
-	ctx = log.WithLogger(ctx, log.G(ctx).WithField("digest", dgst))
+	ctx = log.WithLogger(ctx, log.G(ctx).WithField(log.Digest, dgst))
 
 	hosts := r.filterHosts(HostCapabilityPull)
 	if len(hosts) == 0 {

--- a/remotes/docker/pusher.go
+++ b/remotes/docker/pusher.go
@@ -114,7 +114,7 @@ func (p dockerPusher) push(ctx context.Context, desc ocispec.Descriptor, ref str
 	req := p.request(host, http.MethodHead, existCheck...)
 	req.header.Set("Accept", strings.Join([]string{desc.MediaType, `*/*`}, ", "))
 
-	log.G(ctx).WithField("url", req.String()).Debugf("checking and pushing to")
+	log.G(ctx).WithField(log.URL, req.String()).Debugf("checking and pushing to")
 
 	resp, err := req.doWithRetries(ctx, nil)
 	if err != nil {
@@ -241,7 +241,7 @@ func (p dockerPusher) push(ctx context.Context, desc ocispec.Descriptor, ref str
 
 				lhost.Scheme = lurl.Scheme
 				lhost.Host = lurl.Host
-				log.G(ctx).WithField("host", lhost.Host).WithField("scheme", lhost.Scheme).Debug("upload changed destination")
+				log.G(ctx).WithField(log.Host, lhost.Host).WithField("scheme", lhost.Scheme).Debug("upload changed destination")
 
 				// Strip authorizer if change to host or scheme
 				lhost.Authorizer = nil

--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -274,7 +274,7 @@ func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocisp
 
 	for _, u := range paths {
 		for _, host := range hosts {
-			ctx := log.WithLogger(ctx, log.G(ctx).WithField("host", host.Host))
+			ctx := log.WithLogger(ctx, log.G(ctx).WithField(log.Host, host.Host))
 
 			req := base.request(host, http.MethodHead, u...)
 			if err := req.addNamespace(base.refspec.Hostname()); err != nil {
@@ -392,7 +392,7 @@ func (r *dockerResolver) Resolve(ctx context.Context, ref string) (string, ocisp
 				Size:      size,
 			}
 
-			log.G(ctx).WithField("desc.digest", desc.Digest).Debug("resolved")
+			log.G(ctx).WithField(log.Digest, desc.Digest).Debug("resolved")
 			return ref, desc, nil
 		}
 	}
@@ -559,7 +559,7 @@ func (r *request) do(ctx context.Context) (*http.Response, error) {
 		}
 	}
 
-	ctx = log.WithLogger(ctx, log.G(ctx).WithField("url", u))
+	ctx = log.WithLogger(ctx, log.G(ctx).WithField(log.URL, u))
 	log.G(ctx).WithFields(requestFields(req)).Debug("do request")
 	if err := r.authorize(ctx, req); err != nil {
 		return nil, fmt.Errorf("failed to authorize: %w", err)

--- a/remotes/docker/schema1/converter.go
+++ b/remotes/docker/schema1/converter.go
@@ -358,7 +358,7 @@ func (c *Converter) fetchBlob(ctx context.Context, desc ocispec.Descriptor) erro
 	}
 
 	if compressMethod == compression.Uncompressed {
-		log.G(ctx).WithField("id", desc.Digest).Debugf("changed media type for uncompressed schema1 layer blob")
+		log.G(ctx).WithField(log.ID, desc.Digest).Debugf("changed media type for uncompressed schema1 layer blob")
 		desc.MediaType = images.MediaTypeDockerSchema2Layer
 	}
 
@@ -403,14 +403,14 @@ func (c *Converter) reuseLabelBlobState(ctx context.Context, desc ocispec.Descri
 
 	isEmpty, err := strconv.ParseBool(emptyVal)
 	if err != nil {
-		log.G(ctx).WithField("id", desc.Digest).Warnf("failed to parse bool from label %s: %v", labelDockerSchema1EmptyLayer, isEmpty)
+		log.G(ctx).WithField(log.ID, desc.Digest).Warnf("failed to parse bool from label %s: %v", labelDockerSchema1EmptyLayer, isEmpty)
 		return false, nil
 	}
 
 	bState := blobState{empty: isEmpty}
 
 	if bState.diffID, err = digest.Parse(diffID); err != nil {
-		log.G(ctx).WithField("id", desc.Digest).Warnf("failed to parse digest from label %s: %v", labels.LabelUncompressed, diffID)
+		log.G(ctx).WithField(log.ID, desc.Digest).Warnf("failed to parse digest from label %s: %v", labels.LabelUncompressed, diffID)
 		return false, nil
 	}
 

--- a/rootfs/apply.go
+++ b/rootfs/apply.go
@@ -150,11 +150,11 @@ func applyLayers(ctx context.Context, layers []Layer, chain []digest.Digest, sn 
 	defer func() {
 		if err != nil {
 			if !errdefs.IsAlreadyExists(err) {
-				log.G(ctx).WithError(err).WithField("key", key).Infof("apply failure, attempting cleanup")
+				log.G(ctx).WithError(err).WithField(log.Key, key).Infof("apply failure, attempting cleanup")
 			}
 
 			if rerr := sn.Remove(ctx, key); rerr != nil {
-				log.G(ctx).WithError(rerr).WithField("key", key).Warnf("extraction snapshot removal failed")
+				log.G(ctx).WithError(rerr).WithField(log.Key, key).Warnf("extraction snapshot removal failed")
 			}
 		}
 	}()

--- a/runtime/v2/manager.go
+++ b/runtime/v2/manager.go
@@ -248,7 +248,7 @@ func (m *ShimManager) startShim(ctx context.Context, bundle *Bundle, id string, 
 	if err != nil {
 		return nil, err
 	}
-	ctx = log.WithLogger(ctx, log.G(ctx).WithField("namespace", ns))
+	ctx = log.WithLogger(ctx, log.G(ctx).WithField(log.Namespace, ns))
 
 	topts := opts.TaskOptions
 	if topts == nil || topts.GetValue() == nil {
@@ -267,7 +267,7 @@ func (m *ShimManager) startShim(ctx context.Context, bundle *Bundle, id string, 
 		schedCore:    m.schedCore,
 	})
 	shim, err := b.Start(ctx, protobuf.FromAny(topts), func() {
-		log.G(ctx).WithField("id", id).Info("shim disconnected")
+		log.G(ctx).WithField(log.ID, id).Info("shim disconnected")
 
 		cleanupAfterDeadShim(cleanup.Background(ctx), id, m.shims, m.events, b)
 		// Remove self from the runtime task list. Even though the cleanupAfterDeadShim()

--- a/runtime/v2/runc/task/service.go
+++ b/runtime/v2/runc/task/service.go
@@ -647,7 +647,7 @@ func (s *service) handleProcessExit(e runcC.Exit, c *runc.Container, p process.P
 		// Ensure all children are killed
 		if runc.ShouldKillAllOnExit(s.context, c.Bundle) {
 			if err := ip.KillAll(s.context); err != nil {
-				log.G(s.context).WithError(err).WithField("id", ip.ID()).
+				log.G(s.context).WithError(err).WithField(log.ID, ip.ID()).
 					Error("failed to kill init's children")
 			}
 		}

--- a/runtime/v2/shim.go
+++ b/runtime/v2/shim.go
@@ -150,10 +150,10 @@ func cleanupAfterDeadShim(ctx context.Context, id string, rt *runtime.NSMap[Shim
 	ctx, cancel := timeout.WithContext(ctx, cleanupTimeout)
 	defer cancel()
 
-	log.G(ctx).WithField("id", id).Warn("cleaning up after shim disconnected")
+	log.G(ctx).WithField(log.ID, id).Warn("cleaning up after shim disconnected")
 	response, err := binaryCall.Delete(ctx)
 	if err != nil {
-		log.G(ctx).WithError(err).WithField("id", id).Warn("failed to clean up after shim disconnected")
+		log.G(ctx).WithError(err).WithField(log.ID, id).Warn("failed to clean up after shim disconnected")
 	}
 
 	if _, err := rt.Get(ctx, id); err != nil {
@@ -379,7 +379,7 @@ func (s *shim) Delete(ctx context.Context) error {
 	}
 
 	if err := s.bundle.Delete(); err != nil {
-		log.G(ctx).WithField("id", s.ID()).WithError(err).Error("failed to delete bundle")
+		log.G(ctx).WithField(log.ID, s.ID()).WithError(err).Error("failed to delete bundle")
 		result = multierror.Append(result, fmt.Errorf("failed to delete bundle: %w", err))
 	}
 
@@ -439,7 +439,7 @@ func (s *shimTask) delete(ctx context.Context, sandboxed bool, removeTask func(c
 		ID: s.ID(),
 	})
 	if shimErr != nil {
-		log.G(ctx).WithField("id", s.ID()).WithError(shimErr).Debug("failed to delete task")
+		log.G(ctx).WithField(log.ID, s.ID()).WithError(shimErr).Debug("failed to delete task")
 		if !errors.Is(shimErr, ttrpc.ErrClosed) {
 			shimErr = errdefs.FromGRPC(shimErr)
 			if !errdefs.IsNotFound(shimErr) {
@@ -466,12 +466,12 @@ func (s *shimTask) delete(ctx context.Context, sandboxed bool, removeTask func(c
 	// Let controller decide when to shutdown.
 	if !sandboxed {
 		if err := s.waitShutdown(ctx); err != nil {
-			log.G(ctx).WithField("id", s.ID()).WithError(err).Error("failed to shutdown shim task")
+			log.G(ctx).WithField(log.ID, s.ID()).WithError(err).Error("failed to shutdown shim task")
 		}
 	}
 
 	if err := s.ShimInstance.Delete(ctx); err != nil {
-		log.G(ctx).WithField("id", s.ID()).WithError(err).Error("failed to delete shim")
+		log.G(ctx).WithField(log.ID, s.ID()).WithError(err).Error("failed to delete shim")
 	}
 
 	// remove self from the runtime task list

--- a/runtime/v2/shim/shim.go
+++ b/runtime/v2/shim/shim.go
@@ -239,8 +239,8 @@ func run(ctx context.Context, manager Manager, name string, config Config) error
 			logrus.SetLevel(logrus.DebugLevel)
 		}
 		logger := log.G(ctx).WithFields(log.Fields{
-			"pid":       os.Getpid(),
-			"namespace": namespaceFlag,
+			"pid":         os.Getpid(),
+			log.Namespace: namespaceFlag,
 		})
 		go reap(ctx, logger, signals)
 		ss, err := manager.Stop(ctx, id)
@@ -350,7 +350,7 @@ func run(ctx context.Context, manager Manager, name string, config Config) error
 		}
 
 		if src, ok := instance.(ttrpcService); ok {
-			logrus.WithField("id", id).Debug("registering ttrpc service")
+			logrus.WithField(log.ID, id).Debug("registering ttrpc service")
 			ttrpcServices = append(ttrpcServices, src)
 
 		}
@@ -418,9 +418,9 @@ func serve(ctx context.Context, server *ttrpc.Server, signals chan os.Signal, sh
 		}
 	}()
 	logger := log.G(ctx).WithFields(log.Fields{
-		"pid":       os.Getpid(),
-		"path":      path,
-		"namespace": namespaceFlag,
+		"pid":         os.Getpid(),
+		log.Path:      path,
+		log.Namespace: namespaceFlag,
 	})
 	go func() {
 		for range dump {

--- a/runtime/v2/shim_load.go
+++ b/runtime/v2/shim_load.go
@@ -43,13 +43,13 @@ func (m *ShimManager) loadExistingTasks(ctx context.Context) error {
 		if len(ns) > 0 && ns[0] == '.' {
 			continue
 		}
-		log.G(ctx).WithField("namespace", ns).Debug("loading tasks in namespace")
+		log.G(ctx).WithField(log.Namespace, ns).Debug("loading tasks in namespace")
 		if err := m.loadShims(namespaces.WithNamespace(ctx, ns)); err != nil {
-			log.G(ctx).WithField("namespace", ns).WithError(err).Error("loading tasks in namespace")
+			log.G(ctx).WithField(log.Namespace, ns).WithError(err).Error("loading tasks in namespace")
 			continue
 		}
 		if err := m.cleanupWorkDirs(namespaces.WithNamespace(ctx, ns)); err != nil {
-			log.G(ctx).WithField("namespace", ns).WithError(err).Error("cleanup working directory in namespace")
+			log.G(ctx).WithField(log.Namespace, ns).WithError(err).Error("cleanup working directory in namespace")
 			continue
 		}
 	}
@@ -61,7 +61,7 @@ func (m *ShimManager) loadShims(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	ctx = log.WithLogger(ctx, log.G(ctx).WithField("namespace", ns))
+	ctx = log.WithLogger(ctx, log.G(ctx).WithField(log.Namespace, ns))
 
 	shimDirs, err := os.ReadDir(filepath.Join(m.state, ns))
 	if err != nil {
@@ -142,7 +142,7 @@ func (m *ShimManager) loadShims(ctx context.Context) error {
 				schedCore:    m.schedCore,
 			})
 		instance, err := loadShim(ctx, bundle, func() {
-			log.G(ctx).WithField("id", id).Info("shim disconnected")
+			log.G(ctx).WithField(log.ID, id).Info("shim disconnected")
 
 			cleanupAfterDeadShim(cleanup.Background(ctx), id, m.shims, m.events, binaryCall)
 			// Remove self from the runtime task list.
@@ -168,7 +168,7 @@ func (m *ShimManager) loadShims(ctx context.Context) error {
 		_, sgetErr := m.sandboxStore.Get(ctx, id)
 		pInfo, pidErr := shim.Pids(ctx)
 		if sgetErr != nil && errors.Is(sgetErr, errdefs.ErrNotFound) && (len(pInfo) == 0 || errors.Is(pidErr, errdefs.ErrNotFound)) {
-			log.G(ctx).WithField("id", id).Info("cleaning leaked shim process")
+			log.G(ctx).WithField(log.ID, id).Info("cleaning leaked shim process")
 			// We are unable to get Pids from the shim and it's not a sandbox
 			// shim. We should clean it up her.
 			// No need to do anything for removeTask since we never added this shim.

--- a/services/content/contentserver/contentserver.go
+++ b/services/content/contentserver/contentserver.go
@@ -132,7 +132,7 @@ func (s *service) List(req *api.ListContentRequest, session api.Content_ListServ
 }
 
 func (s *service) Delete(ctx context.Context, req *api.DeleteContentRequest) (*ptypes.Empty, error) {
-	log.G(ctx).WithField("digest", req.Digest).Debugf("delete content")
+	log.G(ctx).WithField(log.Digest, req.Digest).Debugf("delete content")
 	dg, err := digest.Parse(req.Digest)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, err.Error())
@@ -295,7 +295,7 @@ func (s *service) Write(session api.Content_WriteServer) (err error) {
 	}
 
 	fields := log.Fields{
-		"ref": ref,
+		log.Ref: ref,
 	}
 	total = req.Total
 	expected = digest.Digest(req.Expected)

--- a/services/images/local.go
+++ b/services/images/local.go
@@ -105,7 +105,7 @@ func (l *local) List(ctx context.Context, req *imagesapi.ListImagesRequest, _ ..
 }
 
 func (l *local) Create(ctx context.Context, req *imagesapi.CreateImageRequest, _ ...grpc.CallOption) (*imagesapi.CreateImageResponse, error) {
-	log.G(ctx).WithField("name", req.Image.Name).WithField("target", req.Image.Target.Digest).Debugf("create image")
+	log.G(ctx).WithField(log.Name, req.Image.Name).WithField("target", req.Image.Target.Digest).Debugf("create image")
 	if req.Image.Name == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "Image.Name required")
 	}
@@ -174,7 +174,7 @@ func (l *local) Update(ctx context.Context, req *imagesapi.UpdateImageRequest, _
 }
 
 func (l *local) Delete(ctx context.Context, req *imagesapi.DeleteImageRequest, _ ...grpc.CallOption) (*ptypes.Empty, error) {
-	log.G(ctx).WithField("name", req.Name).Debugf("delete image")
+	log.G(ctx).WithField(log.Name, req.Name).Debugf("delete image")
 
 	if err := l.store.Delete(ctx, req.Name); err != nil {
 		return nil, errdefs.ToGRPC(err)

--- a/services/sandbox/controller_service.go
+++ b/services/sandbox/controller_service.go
@@ -73,7 +73,7 @@ func (s *controllerService) Register(server *grpc.Server) error {
 }
 
 func (s *controllerService) Create(ctx context.Context, req *api.ControllerCreateRequest) (*api.ControllerCreateResponse, error) {
-	log.G(ctx).WithField("req", req).Debug("create sandbox")
+	log.G(ctx).WithField(log.Request, req).Debug("create sandbox")
 	// TODO: Rootfs
 	err := s.local.Create(ctx, req.GetSandboxID(), sandbox.WithOptions(req.GetOptions()))
 	if err != nil {
@@ -92,7 +92,7 @@ func (s *controllerService) Create(ctx context.Context, req *api.ControllerCreat
 }
 
 func (s *controllerService) Start(ctx context.Context, req *api.ControllerStartRequest) (*api.ControllerStartResponse, error) {
-	log.G(ctx).WithField("req", req).Debug("start sandbox")
+	log.G(ctx).WithField(log.Request, req).Debug("start sandbox")
 	inst, err := s.local.Start(ctx, req.GetSandboxID())
 	if err != nil {
 		return &api.ControllerStartResponse{}, errdefs.ToGRPC(err)
@@ -113,12 +113,12 @@ func (s *controllerService) Start(ctx context.Context, req *api.ControllerStartR
 }
 
 func (s *controllerService) Stop(ctx context.Context, req *api.ControllerStopRequest) (*api.ControllerStopResponse, error) {
-	log.G(ctx).WithField("req", req).Debug("delete sandbox")
+	log.G(ctx).WithField(log.Request, req).Debug("delete sandbox")
 	return &api.ControllerStopResponse{}, errdefs.ToGRPC(s.local.Stop(ctx, req.GetSandboxID()))
 }
 
 func (s *controllerService) Wait(ctx context.Context, req *api.ControllerWaitRequest) (*api.ControllerWaitResponse, error) {
-	log.G(ctx).WithField("req", req).Debug("wait sandbox")
+	log.G(ctx).WithField(log.Request, req).Debug("wait sandbox")
 	exitStatus, err := s.local.Wait(ctx, req.GetSandboxID())
 	if err != nil {
 		return &api.ControllerWaitResponse{}, errdefs.ToGRPC(err)
@@ -139,7 +139,7 @@ func (s *controllerService) Wait(ctx context.Context, req *api.ControllerWaitReq
 }
 
 func (s *controllerService) Status(ctx context.Context, req *api.ControllerStatusRequest) (*api.ControllerStatusResponse, error) {
-	log.G(ctx).WithField("req", req).Debug("sandbox status")
+	log.G(ctx).WithField(log.Request, req).Debug("sandbox status")
 	cstatus, err := s.local.Status(ctx, req.GetSandboxID(), req.GetVerbose())
 	if err != nil {
 		return &api.ControllerStatusResponse{}, errdefs.ToGRPC(err)
@@ -159,12 +159,12 @@ func (s *controllerService) Status(ctx context.Context, req *api.ControllerStatu
 }
 
 func (s *controllerService) Shutdown(ctx context.Context, req *api.ControllerShutdownRequest) (*api.ControllerShutdownResponse, error) {
-	log.G(ctx).WithField("req", req).Debug("shutdown sandbox")
+	log.G(ctx).WithField(log.Request, req).Debug("shutdown sandbox")
 	return &api.ControllerShutdownResponse{}, errdefs.ToGRPC(s.local.Shutdown(ctx, req.GetSandboxID()))
 }
 
 func (s *controllerService) Metrics(ctx context.Context, req *api.ControllerMetricsRequest) (*api.ControllerMetricsResponse, error) {
-	log.G(ctx).WithField("req", req).Debug("sandbox metrics")
+	log.G(ctx).WithField(log.Request, req).Debug("sandbox metrics")
 
 	metrics, err := s.local.Metrics(ctx, req.GetSandboxID())
 	if err != nil {

--- a/services/sandbox/store_service.go
+++ b/services/sandbox/store_service.go
@@ -60,7 +60,7 @@ func (s *sandboxService) Register(server *grpc.Server) error {
 }
 
 func (s *sandboxService) Create(ctx context.Context, req *api.StoreCreateRequest) (*api.StoreCreateResponse, error) {
-	log.G(ctx).WithField("req", req).Debug("create sandbox")
+	log.G(ctx).WithField(log.Request, req).Debug("create sandbox")
 	sb, err := s.store.Create(ctx, sandbox.FromProto(req.Sandbox))
 	if err != nil {
 		return nil, errdefs.ToGRPC(err)
@@ -70,7 +70,7 @@ func (s *sandboxService) Create(ctx context.Context, req *api.StoreCreateRequest
 }
 
 func (s *sandboxService) Update(ctx context.Context, req *api.StoreUpdateRequest) (*api.StoreUpdateResponse, error) {
-	log.G(ctx).WithField("req", req).Debug("update sandbox")
+	log.G(ctx).WithField(log.Request, req).Debug("update sandbox")
 
 	sb, err := s.store.Update(ctx, sandbox.FromProto(req.Sandbox), req.Fields...)
 	if err != nil {
@@ -81,7 +81,7 @@ func (s *sandboxService) Update(ctx context.Context, req *api.StoreUpdateRequest
 }
 
 func (s *sandboxService) List(ctx context.Context, req *api.StoreListRequest) (*api.StoreListResponse, error) {
-	log.G(ctx).WithField("req", req).Debug("list sandboxes")
+	log.G(ctx).WithField(log.Request, req).Debug("list sandboxes")
 
 	resp, err := s.store.List(ctx, req.Filters...)
 	if err != nil {
@@ -97,7 +97,7 @@ func (s *sandboxService) List(ctx context.Context, req *api.StoreListRequest) (*
 }
 
 func (s *sandboxService) Get(ctx context.Context, req *api.StoreGetRequest) (*api.StoreGetResponse, error) {
-	log.G(ctx).WithField("req", req).Debug("get sandbox")
+	log.G(ctx).WithField(log.Request, req).Debug("get sandbox")
 	resp, err := s.store.Get(ctx, req.SandboxID)
 	if err != nil {
 		return nil, errdefs.ToGRPC(err)
@@ -108,7 +108,7 @@ func (s *sandboxService) Get(ctx context.Context, req *api.StoreGetRequest) (*ap
 }
 
 func (s *sandboxService) Delete(ctx context.Context, req *api.StoreDeleteRequest) (*api.StoreDeleteResponse, error) {
-	log.G(ctx).WithField("req", req).Debug("delete sandbox")
+	log.G(ctx).WithField(log.Request, req).Debug("delete sandbox")
 	if err := s.store.Delete(ctx, req.SandboxID); err != nil {
 		return nil, errdefs.ToGRPC(err)
 	}

--- a/services/server/server.go
+++ b/services/server/server.go
@@ -353,7 +353,7 @@ func (s *Server) Stop() {
 		p := s.plugins[i]
 		instance, err := p.Instance()
 		if err != nil {
-			log.L.WithError(err).WithField("id", p.Registration.URI()).
+			log.L.WithError(err).WithField(log.ID, p.Registration.URI()).
 				Error("could not get plugin instance")
 			continue
 		}
@@ -362,7 +362,7 @@ func (s *Server) Stop() {
 			continue
 		}
 		if err := closer.Close(); err != nil {
-			log.L.WithError(err).WithField("id", p.Registration.URI()).
+			log.L.WithError(err).WithField(log.ID, p.Registration.URI()).
 				Error("failed to close plugin")
 		}
 	}

--- a/services/snapshots/service.go
+++ b/services/snapshots/service.go
@@ -86,7 +86,7 @@ func (s *service) Register(gs *grpc.Server) error {
 }
 
 func (s *service) Prepare(ctx context.Context, pr *snapshotsapi.PrepareSnapshotRequest) (*snapshotsapi.PrepareSnapshotResponse, error) {
-	log.G(ctx).WithField("parent", pr.Parent).WithField("key", pr.Key).Debugf("prepare snapshot")
+	log.G(ctx).WithField(log.Parent, pr.Parent).WithField(log.Key, pr.Key).Debugf("prepare snapshot")
 	sn, err := s.getSnapshotter(pr.Snapshotter)
 	if err != nil {
 		return nil, err
@@ -107,7 +107,7 @@ func (s *service) Prepare(ctx context.Context, pr *snapshotsapi.PrepareSnapshotR
 }
 
 func (s *service) View(ctx context.Context, pr *snapshotsapi.ViewSnapshotRequest) (*snapshotsapi.ViewSnapshotResponse, error) {
-	log.G(ctx).WithField("parent", pr.Parent).WithField("key", pr.Key).Debugf("prepare view snapshot")
+	log.G(ctx).WithField(log.Parent, pr.Parent).WithField(log.Key, pr.Key).Debugf("prepare view snapshot")
 	sn, err := s.getSnapshotter(pr.Snapshotter)
 	if err != nil {
 		return nil, err
@@ -126,7 +126,7 @@ func (s *service) View(ctx context.Context, pr *snapshotsapi.ViewSnapshotRequest
 }
 
 func (s *service) Mounts(ctx context.Context, mr *snapshotsapi.MountsRequest) (*snapshotsapi.MountsResponse, error) {
-	log.G(ctx).WithField("key", mr.Key).Debugf("get snapshot mounts")
+	log.G(ctx).WithField(log.Key, mr.Key).Debugf("get snapshot mounts")
 	sn, err := s.getSnapshotter(mr.Snapshotter)
 	if err != nil {
 		return nil, err
@@ -142,7 +142,7 @@ func (s *service) Mounts(ctx context.Context, mr *snapshotsapi.MountsRequest) (*
 }
 
 func (s *service) Commit(ctx context.Context, cr *snapshotsapi.CommitSnapshotRequest) (*ptypes.Empty, error) {
-	log.G(ctx).WithField("key", cr.Key).WithField("name", cr.Name).Debugf("commit snapshot")
+	log.G(ctx).WithField(log.Key, cr.Key).WithField(log.Name, cr.Name).Debugf("commit snapshot")
 	sn, err := s.getSnapshotter(cr.Snapshotter)
 	if err != nil {
 		return nil, err
@@ -160,7 +160,7 @@ func (s *service) Commit(ctx context.Context, cr *snapshotsapi.CommitSnapshotReq
 }
 
 func (s *service) Remove(ctx context.Context, rr *snapshotsapi.RemoveSnapshotRequest) (*ptypes.Empty, error) {
-	log.G(ctx).WithField("key", rr.Key).Debugf("remove snapshot")
+	log.G(ctx).WithField(log.Key, rr.Key).Debugf("remove snapshot")
 	sn, err := s.getSnapshotter(rr.Snapshotter)
 	if err != nil {
 		return nil, err
@@ -174,7 +174,7 @@ func (s *service) Remove(ctx context.Context, rr *snapshotsapi.RemoveSnapshotReq
 }
 
 func (s *service) Stat(ctx context.Context, sr *snapshotsapi.StatSnapshotRequest) (*snapshotsapi.StatSnapshotResponse, error) {
-	log.G(ctx).WithField("key", sr.Key).Debugf("stat snapshot")
+	log.G(ctx).WithField(log.Key, sr.Key).Debugf("stat snapshot")
 	sn, err := s.getSnapshotter(sr.Snapshotter)
 	if err != nil {
 		return nil, err
@@ -189,7 +189,7 @@ func (s *service) Stat(ctx context.Context, sr *snapshotsapi.StatSnapshotRequest
 }
 
 func (s *service) Update(ctx context.Context, sr *snapshotsapi.UpdateSnapshotRequest) (*snapshotsapi.UpdateSnapshotResponse, error) {
-	log.G(ctx).WithField("key", sr.Info.Name).Debugf("update snapshot")
+	log.G(ctx).WithField(log.Key, sr.Info.Name).Debugf("update snapshot")
 	sn, err := s.getSnapshotter(sr.Snapshotter)
 	if err != nil {
 		return nil, err

--- a/services/streaming/service.go
+++ b/services/streaming/service.go
@@ -84,7 +84,7 @@ func (s *service) Stream(srv api.Streaming_StreamServer) error {
 		cc: cc,
 	}
 
-	log.G(srv.Context()).WithField("stream", i.ID).Debug("registering stream")
+	log.G(srv.Context()).WithField(log.Stream, i.ID).Debug("registering stream")
 	if err := s.manager.Register(srv.Context(), i.ID, ss); err != nil {
 		return err
 	}

--- a/services/tasks/local.go
+++ b/services/tasks/local.go
@@ -379,7 +379,7 @@ func addTasks(ctx context.Context, r *api.ListTasksResponse, tasks []runtime.Tas
 		tt, err := getProcessState(ctx, t)
 		if err != nil {
 			if !errdefs.IsNotFound(err) { // handle race with deletion
-				log.G(ctx).WithError(err).WithField("id", t.ID()).Error("converting task to protobuf")
+				log.G(ctx).WithError(err).WithField(log.ID, t.ID()).Error("converting task to protobuf")
 			}
 			continue
 		}

--- a/snapshots/blockfile/blockfile.go
+++ b/snapshots/blockfile/blockfile.go
@@ -312,7 +312,7 @@ func (o *snapshotter) Remove(ctx context.Context, key string) (err error) {
 		if renamed != "" && restore {
 			if err1 := os.Rename(renamed, path); err1 != nil {
 				// May cause inconsistent data on disk
-				log.G(ctx).WithError(err1).WithField("path", renamed).Error("failed to rename after failed commit")
+				log.G(ctx).WithError(err1).WithField(log.Path, renamed).Error("failed to rename after failed commit")
 			}
 		}
 		return err
@@ -320,7 +320,7 @@ func (o *snapshotter) Remove(ctx context.Context, key string) (err error) {
 	if renamed != "" {
 		if err := os.Remove(renamed); err != nil {
 			// Must be cleaned up, any "rm-*" could be removed if no active transactions
-			log.G(ctx).WithError(err).WithField("path", renamed).Warnf("failed to remove root filesystem")
+			log.G(ctx).WithError(err).WithField(log.Path, renamed).Warnf("failed to remove root filesystem")
 		}
 	}
 

--- a/snapshots/devmapper/pool_device.go
+++ b/snapshots/devmapper/pool_device.go
@@ -160,7 +160,7 @@ func (p *PoolDevice) ensureDeviceStates(ctx context.Context) error {
 	for _, dev := range faultyDevices {
 		log.G(ctx).
 			WithField("dev_id", dev.DeviceID).
-			WithField("parent", dev.ParentName).
+			WithField(log.Parent, dev.ParentName).
 			WithField("error", dev.Error).
 			Warnf("devmapper device %q has invalid state %q, marking as faulty", dev.Name, dev.State)
 

--- a/snapshots/devmapper/snapshotter.go
+++ b/snapshots/devmapper/snapshotter.go
@@ -105,7 +105,7 @@ func NewSnapshotter(ctx context.Context, config *Config) (*Snapshotter, error) {
 
 // Stat returns the info for an active or committed snapshot from store
 func (s *Snapshotter) Stat(ctx context.Context, key string) (snapshots.Info, error) {
-	log.G(ctx).WithField("key", key).Debug("stat")
+	log.G(ctx).WithField(log.Key, key).Debug("stat")
 
 	var (
 		info snapshots.Info
@@ -135,7 +135,7 @@ func (s *Snapshotter) Update(ctx context.Context, info snapshots.Info, fieldpath
 
 // Usage returns the resource usage of an active or committed snapshot excluding the usage of parent snapshots.
 func (s *Snapshotter) Usage(ctx context.Context, key string) (snapshots.Usage, error) {
-	log.G(ctx).WithField("key", key).Debug("usage")
+	log.G(ctx).WithField(log.Key, key).Debug("usage")
 
 	var (
 		id    string
@@ -177,7 +177,7 @@ func (s *Snapshotter) Usage(ctx context.Context, key string) (snapshots.Usage, e
 
 // Mounts return the list of mounts for the active or view snapshot
 func (s *Snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, error) {
-	log.G(ctx).WithField("key", key).Debug("mounts")
+	log.G(ctx).WithField(log.Key, key).Debug("mounts")
 
 	var (
 		snap storage.Snapshot
@@ -200,7 +200,10 @@ func (s *Snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, er
 
 // Prepare creates thin device for an active snapshot identified by key
 func (s *Snapshotter) Prepare(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
-	log.G(ctx).WithFields(log.Fields{"key": key, "parent": parent}).Debug("prepare")
+	log.G(ctx).WithFields(log.Fields{
+		log.Key:    key,
+		log.Parent: parent,
+	}).Debug("prepare")
 
 	var (
 		mounts []mount.Mount
@@ -217,7 +220,10 @@ func (s *Snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 
 // View creates readonly thin device for the given snapshot key
 func (s *Snapshotter) View(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
-	log.G(ctx).WithFields(log.Fields{"key": key, "parent": parent}).Debug("view")
+	log.G(ctx).WithFields(log.Fields{
+		log.Key:    key,
+		log.Parent: parent,
+	}).Debug("view")
 
 	var (
 		mounts []mount.Mount
@@ -236,7 +242,10 @@ func (s *Snapshotter) View(ctx context.Context, key, parent string, opts ...snap
 // Block device unmount operation captures snapshot changes by itself, so no
 // additional actions needed within Commit operation.
 func (s *Snapshotter) Commit(ctx context.Context, name, key string, opts ...snapshots.Opt) error {
-	log.G(ctx).WithFields(log.Fields{"name": name, "key": key}).Debug("commit")
+	log.G(ctx).WithFields(log.Fields{
+		"name":  name,
+		log.Key: key,
+	}).Debug("commit")
 
 	return s.store.WithTransaction(ctx, true, func(ctx context.Context) error {
 		id, snapInfo, _, err := storage.GetInfo(ctx, key)
@@ -293,7 +302,7 @@ func (s *Snapshotter) Commit(ctx context.Context, name, key string, opts ...snap
 
 // Remove removes thin device and snapshot metadata by key
 func (s *Snapshotter) Remove(ctx context.Context, key string) error {
-	log.G(ctx).WithField("key", key).Debug("remove")
+	log.G(ctx).WithField(log.Key, key).Debug("remove")
 
 	return s.store.WithTransaction(ctx, true, func(ctx context.Context) error {
 		return s.removeDevice(ctx, key)

--- a/snapshots/lcow/lcow.go
+++ b/snapshots/lcow/lcow.go
@@ -230,7 +230,7 @@ func (s *snapshotter) Remove(ctx context.Context, key string) (err error) {
 		if restore { // failed to commit
 			if err1 := os.Rename(renamed, path); err1 != nil {
 				// May cause inconsistent data on disk
-				log.G(ctx).WithError(err1).WithField("path", renamed).Error("Failed to rename after failed commit")
+				log.G(ctx).WithError(err1).WithField(log.Path, renamed).Error("Failed to rename after failed commit")
 			}
 		}
 		return err
@@ -238,7 +238,7 @@ func (s *snapshotter) Remove(ctx context.Context, key string) (err error) {
 
 	if err = os.RemoveAll(renamed); err != nil {
 		// Must be cleaned up, any "rm-*" could be removed if no active transactions
-		log.G(ctx).WithError(err).WithField("path", renamed).Warnf("Failed to remove root filesystem")
+		log.G(ctx).WithError(err).WithField(log.Path, renamed).Warnf("Failed to remove root filesystem")
 	}
 
 	return nil

--- a/snapshots/native/native.go
+++ b/snapshots/native/native.go
@@ -189,7 +189,7 @@ func (o *snapshotter) Remove(ctx context.Context, key string) (err error) {
 		if renamed != "" && restore {
 			if err1 := os.Rename(renamed, path); err1 != nil {
 				// May cause inconsistent data on disk
-				log.G(ctx).WithError(err1).WithField("path", renamed).Error("failed to rename after failed commit")
+				log.G(ctx).WithError(err1).WithField(log.Path, renamed).Error("failed to rename after failed commit")
 			}
 		}
 		return err
@@ -197,7 +197,7 @@ func (o *snapshotter) Remove(ctx context.Context, key string) (err error) {
 	if renamed != "" {
 		if err := os.RemoveAll(renamed); err != nil {
 			// Must be cleaned up, any "rm-*" could be removed if no active transactions
-			log.G(ctx).WithError(err).WithField("path", renamed).Warnf("failed to remove root filesystem")
+			log.G(ctx).WithError(err).WithField(log.Path, renamed).Warnf("failed to remove root filesystem")
 		}
 	}
 

--- a/snapshots/overlay/overlay.go
+++ b/snapshots/overlay/overlay.go
@@ -286,7 +286,7 @@ func (o *snapshotter) Remove(ctx context.Context, key string) (err error) {
 		if err == nil {
 			for _, dir := range removals {
 				if err := os.RemoveAll(dir); err != nil {
-					log.G(ctx).WithError(err).WithField("path", dir).Warn("failed to remove directory")
+					log.G(ctx).WithError(err).WithField(log.Path, dir).Warn("failed to remove directory")
 				}
 			}
 		}
@@ -336,7 +336,7 @@ func (o *snapshotter) Cleanup(ctx context.Context) error {
 
 	for _, dir := range cleanup {
 		if err := os.RemoveAll(dir); err != nil {
-			log.G(ctx).WithError(err).WithField("path", dir).Warn("failed to remove directory")
+			log.G(ctx).WithError(err).WithField(log.Path, dir).Warn("failed to remove directory")
 		}
 	}
 
@@ -400,7 +400,7 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 			}
 			if path != "" {
 				if err1 := os.RemoveAll(path); err1 != nil {
-					log.G(ctx).WithError(err1).WithField("path", path).Error("failed to reclaim snapshot directory, directory may need removal")
+					log.G(ctx).WithError(err1).WithField(log.Path, path).Error("failed to reclaim snapshot directory, directory may need removal")
 					err = fmt.Errorf("failed to remove path: %v: %w", err1, err)
 				}
 			}

--- a/snapshots/windows/windows.go
+++ b/snapshots/windows/windows.go
@@ -277,7 +277,7 @@ func (s *snapshotter) Remove(ctx context.Context, key string) error {
 		if restore { // failed to commit
 			if err1 := os.Rename(renamed, path); err1 != nil {
 				// May cause inconsistent data on disk
-				log.G(ctx).WithError(err1).WithField("path", renamed).Error("Failed to rename after failed commit")
+				log.G(ctx).WithError(err1).WithField(log.Path, renamed).Error("Failed to rename after failed commit")
 			}
 		}
 		return err
@@ -285,7 +285,7 @@ func (s *snapshotter) Remove(ctx context.Context, key string) error {
 
 	if err = hcsshim.DestroyLayer(s.info, renamedID); err != nil {
 		// Must be cleaned up, any "rm-*" could be removed if no active transactions
-		log.G(ctx).WithError(err).WithField("path", renamed).Warnf("Failed to remove root filesystem")
+		log.G(ctx).WithError(err).WithField(log.Path, renamed).Warnf("Failed to remove root filesystem")
 	}
 
 	return nil


### PR DESCRIPTION
This is a very simple change to host structured logging fields we use very often throughout containerd (think "ref", "digest", "snapshotter", "image"). I find this a nice addition to help not introduce new logs that sway from the terminology and field names we have built up over the years. This was on my mind as we look to migrate off of logrus to another structured logging solution; it'd be nice to have a place to host commonly used fields throughout containerd for whenever we migrate to {insert other logging package}.

This change also edits the existing logrus logs to use the fields which is mostly harmless even if we're getting rid of the dep potentially. It'll be easier if we do want this change if the fields are already present on our existing logging solution.

#### Note
Some alternatives to just adding new symbols to the log package could be a dedicated log fields package (/log/fields or /log/logfields) also. I find it helps to distinguish the logging packages current job of being a nice wrapper around our current structured logging solution, and fields to be used for logs themselves, but not sure there's much gain in likely having to import two packages to log common items. 