### PR TITLE
Export garbage collection labels

### DIFF
--- a/client.go
+++ b/client.go
@@ -49,6 +49,7 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/leases"
 	leasesproxy "github.com/containerd/containerd/leases/proxy"
+	"github.com/containerd/containerd/metadata/gclabels"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/pkg/dialer"
 	"github.com/containerd/containerd/platforms"
@@ -537,7 +538,7 @@ func (c *Client) Restore(ctx context.Context, id string, checkpoint Image, opts 
 func writeIndex(ctx context.Context, index *ocispec.Index, client *Client, ref string) (d ocispec.Descriptor, err error) {
 	labels := map[string]string{}
 	for i, m := range index.Manifests {
-		labels[fmt.Sprintf("containerd.io/gc.ref.content.%d", i)] = m.Digest.String()
+		labels[fmt.Sprintf("%s.%d", gclabels.LabelGCRefContent, i)] = m.Digest.String()
 	}
 	data, err := json.Marshal(index)
 	if err != nil {

--- a/cmd/ctr/commands/content/prune.go
+++ b/cmd/ctr/commands/content/prune.go
@@ -25,13 +25,14 @@ import (
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/metadata/gclabels"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
 const (
-	layerPrefix   = "containerd.io/gc.ref.content.l."
-	contentPrefix = "containerd.io/gc.ref.content."
+	layerPrefix   = gclabels.LabelGCRefContent + ".l."
+	contentPrefix = gclabels.LabelGCRefContent + "."
 )
 
 var pruneFlags = []cli.Flag{

--- a/cmd/ctr/commands/images/mount.go
+++ b/cmd/ctr/commands/images/mount.go
@@ -24,6 +24,7 @@ import (
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/leases"
+	"github.com/containerd/containerd/metadata/gclabels"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/platforms"
 	"github.com/opencontainers/image-spec/identity"
@@ -76,7 +77,7 @@ When you are done, use the unmount command.
 			leases.WithID(target),
 			leases.WithExpiration(24*time.Hour),
 			leases.WithLabels(map[string]string{
-				"containerd.io/gc.ref.snapshot." + snapshotter: target,
+				gclabels.LabelGCRefSnap + "." + snapshotter: target,
 			}),
 		)
 		if err != nil && !errdefs.IsAlreadyExists(err) {

--- a/cmd/ctr/commands/snapshots/snapshots.go
+++ b/cmd/ctr/commands/snapshots/snapshots.go
@@ -25,12 +25,12 @@ import (
 	"path/filepath"
 	"strings"
 	"text/tabwriter"
-	"time"
 
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/diff"
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/metadata/gclabels"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/pkg/progress"
 	"github.com/containerd/containerd/rootfs"
@@ -135,7 +135,7 @@ var diffCommand = cli.Command{
 		snapshotter := client.SnapshotService(context.GlobalString("snapshotter"))
 
 		if context.Bool("keep") {
-			labels["containerd.io/gc.root"] = time.Now().UTC().Format(time.RFC3339)
+			labels[gclabels.LabelGCRoot] = gclabels.TimestampNow()
 		}
 		opts := []diff.Opt{
 			diff.WithMediaType(context.String("media-type")),
@@ -303,7 +303,7 @@ var prepareCommand = cli.Command{
 
 		snapshotter := client.SnapshotService(context.GlobalString("snapshotter"))
 		labels := map[string]string{
-			"containerd.io/gc.root": time.Now().UTC().Format(time.RFC3339),
+			gclabels.LabelGCRoot: gclabels.TimestampNow(),
 		}
 
 		mounts, err := snapshotter.Prepare(ctx, key, parent, snapshots.WithLabels(labels))
@@ -419,7 +419,7 @@ var commitCommand = cli.Command{
 		defer cancel()
 		snapshotter := client.SnapshotService(context.GlobalString("snapshotter"))
 		labels := map[string]string{
-			"containerd.io/gc.root": time.Now().UTC().Format(time.RFC3339),
+			gclabels.LabelGCRoot: gclabels.TimestampNow(),
 		}
 		return snapshotter.Commit(ctx, key, active, snapshots.WithLabels(labels))
 	},

--- a/content/testsuite/testsuite.go
+++ b/content/testsuite/testsuite.go
@@ -31,6 +31,7 @@ import (
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log/logtest"
+	"github.com/containerd/containerd/metadata/gclabels"
 	"github.com/containerd/containerd/pkg/testutil"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -143,7 +144,7 @@ func makeTest(t *testing.T, name string, storeFn func(ctx context.Context, root 
 }
 
 var labels = map[string]string{
-	"containerd.io/gc.root": time.Now().UTC().Format(time.RFC3339),
+	gclabels.LabelGCRoot: gclabels.TimestampNow(),
 }
 
 func checkContentStoreWriter(ctx context.Context, t *testing.T, cs content.Store) {
@@ -594,12 +595,12 @@ func checkLabels(ctx context.Context, t *testing.T, cs content.Store) {
 		t.Fatalf("Failed to write: %+v", err)
 	}
 
-	rootTime := time.Now().UTC().Format(time.RFC3339)
+	rootTime := gclabels.TimestampNow()
 	labels := map[string]string{
 		"k1": "v1",
 		"k2": "v2",
 
-		"containerd.io/gc.root": rootTime,
+		gclabels.LabelGCRoot: rootTime,
 	}
 
 	preCommit := time.Now()
@@ -636,7 +637,7 @@ func checkLabels(ctx context.Context, t *testing.T, cs content.Store) {
 	info.Labels = map[string]string{
 		"k1": "v1",
 
-		"containerd.io/gc.root": rootTime,
+		gclabels.LabelGCRoot: rootTime,
 	}
 	preUpdate = time.Now()
 	if _, err := cs.Update(ctx, info, "labels.k3", "labels.k1"); err != nil {

--- a/docs/garbage-collection.md
+++ b/docs/garbage-collection.md
@@ -108,6 +108,8 @@ The supported garbage collection labels are:
 | `containerd.io/gc.expire` | _timestamp_ formatted as [rfc3339](https://tools.ietf.org/html/rfc3339) | Leases | When to expire the lease. The garbage collector will delete the lease after expiration. |
 | `containerd.io/gc.flat` | _nonempty_ | Leases | Ignore label references of leased resources. This only applies when the reference is originating from the lease, if the leased resources are referenced elsewhere, then their label references will be used. |
 
+These labels are exported in the [gclabels](https://godoc.org/github.com/containerd/containerd/metadata/gclabels) package.
+
 ## Garbage Collection configuration
 
 The garbage collector (gc) is scheduled on a background goroutine and runs based

--- a/image.go
+++ b/image.go
@@ -30,6 +30,7 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/labels"
+	"github.com/containerd/containerd/metadata/gclabels"
 	"github.com/containerd/containerd/pkg/kmutex"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/rootfs"
@@ -227,7 +228,7 @@ func (i *image) Usage(ctx context.Context, opts ...UsageOpt) (int64, error) {
 
 			if config.snapshots {
 				for k, v := range info.Labels {
-					const prefix = "containerd.io/gc.ref.snapshot."
+					const prefix = gclabels.LabelGCRefSnap + "."
 					if !strings.HasPrefix(k, prefix) {
 						continue
 					}
@@ -427,11 +428,11 @@ func (i *image) Unpack(ctx context.Context, snapshotterName string, opts ...Unpa
 	cinfo := content.Info{
 		Digest: desc.Digest,
 		Labels: map[string]string{
-			fmt.Sprintf("containerd.io/gc.ref.snapshot.%s", snapshotterName): rootFS,
+			gclabels.LabelGCRefSnap + "." + snapshotterName: rootFS,
 		},
 	}
 
-	_, err = cs.Update(ctx, cinfo, fmt.Sprintf("labels.containerd.io/gc.ref.snapshot.%s", snapshotterName))
+	_, err = cs.Update(ctx, cinfo, "labels."+gclabels.LabelGCRefSnap+"."+snapshotterName)
 	return err
 }
 

--- a/images/mediatypes.go
+++ b/images/mediatypes.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/metadata/gclabels"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -190,19 +191,19 @@ func IsKnownConfig(mt string) bool {
 func ChildGCLabels(desc ocispec.Descriptor) []string {
 	mt := desc.MediaType
 	if IsKnownConfig(mt) {
-		return []string{"containerd.io/gc.ref.content.config"}
+		return []string{gclabels.LabelGCRefContent + ".config"}
 	}
 
 	switch mt {
 	case MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest:
-		return []string{"containerd.io/gc.ref.content.m."}
+		return []string{gclabels.LabelGCRefContent + ".m."}
 	}
 
 	if IsLayerType(mt) {
-		return []string{"containerd.io/gc.ref.content.l."}
+		return []string{gclabels.LabelGCRefContent + ".l."}
 	}
 
-	return []string{"containerd.io/gc.ref.content."}
+	return []string{gclabels.LabelGCRefContent + "."}
 }
 
 // ChildGCLabelsFilterLayers returns the labels for a given descriptor to

--- a/leases/lease.go
+++ b/leases/lease.go
@@ -19,6 +19,8 @@ package leases
 import (
 	"context"
 	"time"
+
+	"github.com/containerd/containerd/metadata/gclabels"
 )
 
 // Opt is used to set options on a lease
@@ -84,7 +86,7 @@ func WithExpiration(d time.Duration) Opt {
 		if l.Labels == nil {
 			l.Labels = map[string]string{}
 		}
-		l.Labels["containerd.io/gc.expire"] = time.Now().Add(d).Format(time.RFC3339)
+		l.Labels[gclabels.LabelGCExpire] = gclabels.TimestampFuture(d)
 
 		return nil
 	}

--- a/leases/lease_test.go
+++ b/leases/lease_test.go
@@ -19,6 +19,7 @@ package leases
 import (
 	"testing"
 
+	"github.com/containerd/containerd/metadata/gclabels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -35,10 +36,10 @@ func TestWithLabels(t *testing.T) {
 		name: "AddLabelsToEmptyMap",
 		uut:  &Lease{},
 		labels: map[string]string{
-			"containerd.io/gc.root": "2015-12-04T00:00:00Z",
+			gclabels.LabelGCRoot: "2015-12-04T00:00:00Z",
 		},
 		expected: map[string]string{
-			"containerd.io/gc.root": "2015-12-04T00:00:00Z",
+			gclabels.LabelGCRoot: "2015-12-04T00:00:00Z",
 		},
 	}
 
@@ -46,17 +47,17 @@ func TestWithLabels(t *testing.T) {
 		name: "AddLabelsToNonEmptyMap",
 		uut: &Lease{
 			Labels: map[string]string{
-				"containerd.io/gc.expire": "2015-12-05T00:00:00Z",
+				gclabels.LabelGCExpire: "2015-12-05T00:00:00Z",
 			},
 		},
 		labels: map[string]string{
-			"containerd.io/gc.root":                   "2015-12-04T00:00:00Z",
-			"containerd.io/gc.ref.snapshot.overlayfs": "sha256:87806a591ce894ff5c699c28fe02093d6cdadd6b1ad86819acea05ccb212ff3d",
+			gclabels.LabelGCRoot:                   "2015-12-04T00:00:00Z",
+			gclabels.LabelGCRefSnap + ".overlayfs": "sha256:87806a591ce894ff5c699c28fe02093d6cdadd6b1ad86819acea05ccb212ff3d",
 		},
 		expected: map[string]string{
-			"containerd.io/gc.root":                   "2015-12-04T00:00:00Z",
-			"containerd.io/gc.ref.snapshot.overlayfs": "sha256:87806a591ce894ff5c699c28fe02093d6cdadd6b1ad86819acea05ccb212ff3d",
-			"containerd.io/gc.expire":                 "2015-12-05T00:00:00Z",
+			gclabels.LabelGCRoot:                   "2015-12-04T00:00:00Z",
+			gclabels.LabelGCRefSnap + ".overlayfs": "sha256:87806a591ce894ff5c699c28fe02093d6cdadd6b1ad86819acea05ccb212ff3d",
+			gclabels.LabelGCExpire:                 "2015-12-05T00:00:00Z",
 		},
 	}
 

--- a/metadata/db_test.go
+++ b/metadata/db_test.go
@@ -27,7 +27,6 @@ import (
 	"runtime/pprof"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/content"
@@ -37,6 +36,7 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/log/logtest"
+	"github.com/containerd/containerd/metadata/gclabels"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/protobuf/types"
 	"github.com/containerd/containerd/snapshots"
@@ -352,7 +352,7 @@ func TestMetadataCollector(t *testing.T) {
 			blob(bytesFor(1), true),
 			blob(bytesFor(2), false),
 			blob(bytesFor(3), true),
-			blob(bytesFor(4), false, "containerd.io/gc.root", time.Now().String()),
+			blob(bytesFor(4), false, gclabels.LabelGCRoot, gclabels.TimestampNow()),
 			newSnapshot("1", "", false, false),
 			newSnapshot("2", "1", false, false),
 			newSnapshot("3", "2", false, false),
@@ -362,10 +362,10 @@ func TestMetadataCollector(t *testing.T) {
 			image("image-1", digestFor(2)),
 
 			// Test lease preservation
-			blob(bytesFor(5), false, "containerd.io/gc.ref.content.0", digestFor(6).String()),
+			blob(bytesFor(5), false, gclabels.LabelGCRefContent+".0", digestFor(6).String()),
 			blob(bytesFor(6), false),
 			blob(bytesFor(7), false),
-			newSnapshot("6", "", false, false, "containerd.io/gc.ref.content.0", digestFor(7).String()),
+			newSnapshot("6", "", false, false, gclabels.LabelGCRefContent+".0", digestFor(7).String()),
 			lease("lease-1", []leases.Resource{
 				{
 					ID:   digestFor(5).String(),
@@ -378,10 +378,10 @@ func TestMetadataCollector(t *testing.T) {
 			}, false),
 
 			// Test flat lease
-			blob(bytesFor(8), false, "containerd.io/gc.ref.content.0", digestFor(9).String()),
+			blob(bytesFor(8), false, gclabels.LabelGCRefContent+".0", digestFor(9).String()),
 			blob(bytesFor(9), true),
 			blob(bytesFor(10), true),
-			newSnapshot("7", "", false, false, "containerd.io/gc.ref.content.0", digestFor(10).String()),
+			newSnapshot("7", "", false, false, gclabels.LabelGCRefContent+".0", digestFor(10).String()),
 			newSnapshot("8", "7", false, false),
 			newSnapshot("9", "8", false, false),
 			lease("lease-2", []leases.Resource{
@@ -393,11 +393,11 @@ func TestMetadataCollector(t *testing.T) {
 					ID:   "9",
 					Type: "snapshots/native",
 				},
-			}, false, "containerd.io/gc.flat", time.Now().String()),
+			}, false, gclabels.LabelGCFlat, gclabels.TimestampNow()),
 
 			// Test Collectible Resource
-			blob(bytesFor(11), false, "containerd.io/gc.ref.test", "test1"),
-			blob(bytesFor(12), true, "containerd.io/gc.ref.test", "test2"),
+			blob(bytesFor(11), false, gclabels.LabelGCRef+".test", "test1"),
+			blob(bytesFor(12), true, gclabels.LabelGCRef+".test", "test2"),
 			lease("lease-3", []leases.Resource{
 				{
 					ID:   digestFor(11).String(),

--- a/metadata/gclabels/gclabels.go
+++ b/metadata/gclabels/gclabels.go
@@ -1,0 +1,47 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Labels that affect garbage collection.
+// Documented at https://github.com/containerd/containerd/blob/main/docs/garbage-collection.md
+package gclabels
+
+import "time"
+
+const (
+	LabelGCRoot       = "containerd.io/gc.root"         // Keep this object and anything it references.
+	LabelGCRef        = "containerd.io/gc.ref"          // This resource references another resource.
+	LabelGCRefSnap    = "containerd.io/gc.ref.snapshot" // This resource references an identified snapshot from a particular snapshotter.
+	LabelGCRefContent = "containerd.io/gc.ref.content"  // This resource references a content blob identified by digest, with optional user defined label key.
+	LabelGCExpire     = "containerd.io/gc.expire"       // This lease expires after the given time in RFC3339 format
+	LabelGCFlat       = "containerd.io/gc.flat"         // Ignore label references of leased resources.
+)
+
+var (
+	LabelGCRootBytes       = []byte(LabelGCRoot)       // Keep this object and anything it references.
+	LabelGCRefBytes        = []byte(LabelGCRef)        // This resource references another resource.
+	LabelGCRefSnapBytes    = []byte(LabelGCRefSnap)    // This resource references an identified snapshot from a particular snapshotter.
+	LabelGCRefContentBytes = []byte(LabelGCRefContent) // This resource references a content blob identified by digest, with optional user defined label key.
+	LabelGCExpireBytes     = []byte(LabelGCExpire)     // This lease expires after the given time in RFC3339 format
+	LabelGCFlatBytes       = []byte(LabelGCFlat)       // Ignore label references of leased resources.
+)
+
+func TimestampNow() string {
+	return time.Now().UTC().Format(time.RFC3339)
+}
+
+func TimestampFuture(d time.Duration) string {
+	return time.Now().Add(d).UTC().Format(time.RFC3339)
+}

--- a/pkg/unpack/unpacker.go
+++ b/pkg/unpack/unpacker.go
@@ -34,6 +34,7 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/labels"
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/metadata/gclabels"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/pkg/cleanup"
 	"github.com/containerd/containerd/pkg/kmutex"
@@ -429,10 +430,10 @@ func (u *Unpacker) unpack(
 	cinfo := content.Info{
 		Digest: config.Digest,
 		Labels: map[string]string{
-			fmt.Sprintf("containerd.io/gc.ref.snapshot.%s", unpack.SnapshotterKey): chainID,
+			gclabels.LabelGCRefSnap + "." + unpack.SnapshotterKey: chainID,
 		},
 	}
-	_, err = cs.Update(ctx, cinfo, fmt.Sprintf("labels.containerd.io/gc.ref.snapshot.%s", unpack.SnapshotterKey))
+	_, err = cs.Update(ctx, cinfo, "labels."+gclabels.LabelGCRefSnap+"."+unpack.SnapshotterKey)
 	if err != nil {
 		return err
 	}

--- a/remotes/docker/converter.go
+++ b/remotes/docker/converter.go
@@ -25,6 +25,7 @@ import (
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/metadata/gclabels"
 	"github.com/containerd/containerd/remotes"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -76,7 +77,7 @@ func ConvertManifest(ctx context.Context, store content.Store, desc ocispec.Desc
 
 	labels := map[string]string{}
 	for i, c := range append([]ocispec.Descriptor{manifest.Config}, manifest.Layers...) {
-		labels[fmt.Sprintf("containerd.io/gc.ref.content.%d", i)] = c.Digest.String()
+		labels[fmt.Sprintf("%s.%d", gclabels.LabelGCRefContent, i)] = c.Digest.String()
 	}
 
 	ref := remotes.MakeRefKey(ctx, desc)

--- a/remotes/docker/schema1/converter.go
+++ b/remotes/docker/schema1/converter.go
@@ -38,6 +38,7 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/labels"
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/metadata/gclabels"
 	"github.com/containerd/containerd/remotes"
 	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go"
@@ -211,9 +212,9 @@ func (c *Converter) Convert(ctx context.Context, opts ...ConvertOpt) (ocispec.De
 	}
 
 	labels := map[string]string{}
-	labels["containerd.io/gc.ref.content.0"] = manifest.Config.Digest.String()
+	labels[gclabels.LabelGCRefContent+".0"] = manifest.Config.Digest.String()
 	for i, ch := range manifest.Layers {
-		labels[fmt.Sprintf("containerd.io/gc.ref.content.%d", i+1)] = ch.Digest.String()
+		labels[fmt.Sprintf("%s.%d", gclabels.LabelGCRefContent, i+1)] = ch.Digest.String()
 	}
 
 	ref := remotes.MakeRefKey(ctx, desc)


### PR DESCRIPTION
### Problem
https://github.com/containerd/containerd/blob/2353574aa9c5d6d481f3d824abf98e00020a3777/metadata/gc.go#L59-L66
These labels are defined here and used within the metadata package, but they are not exported so the strings are duplicated dozens of times across the containerd module ([github search](https://github.com/search?q=repo%3Acontainerd%2Fcontainerd%20containerd.io%2Fgc.&type=code)), and hundreds of times across the container ecosystem ([github search](https://github.com/search?type=code&auto_enroll=true&q=containerd.io%2Fgc.+language%3AGo+-repo%3Acontainerd%2Fcontainerd)). Many of these uses include suffixes and prefixes directly, making it non-obvious that they are based on the same underlying label standard.

### Solution
I have exported both string and byte slice versions of these label strings from a new package, and used them in all of the relevant places in this repo.

### Additional Changes
Removed the trailing dots for consistency between the label constants, added them at use sites for more readable string operations (concatenation, `Sprintf`, etc)

Rearranged label variable names to match the labels (`FooBar` instead of `BarFoo` for "foo.bar")

Added exported functions to produce timestamps in the format required by `gc.expire` and typically used for `gc.root`.

Replaced some Sprintf() with string concatenation, leaving Sprintf() that combines strings with other types.

Replaced some algorithmic use of byte slices with strings, including changing comparisons.

### Package name

Directly exporting the labels is not viable because that would introduce import cycles between metadata and many other packages.

I am not attached to the `gclabels` package name, but did reject some alternatives:
* `labels` already exists at `containerd/labels` which leads to needing aliases to use both
* `metadatalabels` is long and repeats the parent directory name

A simpler alternative would be to just put these in [`containerd/labels`](https://github.com/containerd/containerd/blob/2353574aa9c5d6d481f3d824abf98e00020a3777/labels/labels.go) but that seems unnecessarily broad.

### Future work

I intend to replace these strings in my own projects with the new exported constants. I will likely submit PRs to other projects as well.

It might make sense to also expose a function for doing the `+ "." + suffix` operation that is pretty common when working with the ref labels.