### PR TITLE
Remove duplicated `writeIndex` func

### DIFF
--- a/client.go
+++ b/client.go
@@ -546,6 +546,19 @@ func writeIndex(ctx context.Context, index *ocispec.Index, client *Client, ref s
 	return writeContent(ctx, client.ContentStore(), ocispec.MediaTypeImageIndex, ref, bytes.NewReader(data), content.WithLabels(labels))
 }
 
+func decodeIndex(ctx context.Context, store content.Provider, desc ocispec.Descriptor) (*ocispec.Index, error) {
+	var index ocispec.Index
+	p, err := content.ReadBlob(ctx, store, desc)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(p, &index); err != nil {
+		return nil, err
+	}
+
+	return &index, nil
+}
+
 // GetLabel gets a label value from namespace store
 // If there is no default label, an empty string returned with nil error
 func (c *Client) GetLabel(ctx context.Context, label string) (string, error) {

--- a/import.go
+++ b/import.go
@@ -18,10 +18,8 @@ package containerd
 
 import (
 	"context"
-	"encoding/json"
 	"io"
 
-	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/images/archive"
@@ -167,13 +165,8 @@ func (c *Client) Import(ctx context.Context, reader io.Reader, opts ...ImportOpt
 			return images.Children(ctx, cs, desc)
 		}
 
-		p, err := content.ReadBlob(ctx, cs, desc)
+		idx, err := decodeIndex(ctx, cs, desc)
 		if err != nil {
-			return nil, err
-		}
-
-		var idx ocispec.Index
-		if err := json.Unmarshal(p, &idx); err != nil {
 			return nil, err
 		}
 

--- a/task_opts.go
+++ b/task_opts.go
@@ -18,18 +18,15 @@ package containerd
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"syscall"
 
 	"github.com/containerd/containerd/api/types"
-	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -77,19 +74,6 @@ func WithTaskCheckpoint(im Image) NewTaskOpts {
 		}
 		return fmt.Errorf("checkpoint not found in index %s", id)
 	}
-}
-
-func decodeIndex(ctx context.Context, store content.Provider, desc imagespec.Descriptor) (*imagespec.Index, error) {
-	var index imagespec.Index
-	p, err := content.ReadBlob(ctx, store, desc)
-	if err != nil {
-		return nil, err
-	}
-	if err := json.Unmarshal(p, &index); err != nil {
-		return nil, err
-	}
-
-	return &index, nil
 }
 
 // WithCheckpointName sets the image name for the checkpoint


### PR DESCRIPTION
This PR removes `task.writeIndex` which is duplicated with the same helper in `client.go` (`writeIndex`).

Also move `decodeIndex` to `client.go` to collocate it with `writeIndex`. 