### PR TITLE
Makefile: Remove hcsshim related TODO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -417,7 +417,6 @@ uninstall:
 
 ifeq ($(GOOS),windows)
 install-deps:
-	# TODO: need a script for hcshim something like containerd/cri/hack/install/windows/install-hcsshim.sh
 	script/setup/install-critools
 	script/setup/install-cni-windows
 else


### PR DESCRIPTION
There was a todo for the windows variant of dependency installation that hinted at making an install-hcsshim.sh script, however Windows today doesn't rely on a standalone OCI runtime binary that gets invoked by the shim. Rather, container creation/management is all handled by the shim itself in-proc. Due to this, `make` or `make binaries` basically fulfills that purpose as it clones hcsshim and builds the shim along with containerd.

### Note
If anyone knows of some other dependencies that are required (or nice to haves) for windows let me know and we can hi-jack this PR to add them instead.