### PR TITLE
Integration: Align empty IO func on Windows

### DIFF
--- a/integration/client/container_test.go
+++ b/integration/client/container_test.go
@@ -53,11 +53,6 @@ import (
 )
 
 func empty() cio.Creator {
-	// TODO (@mlaventure) windows searches for pipes
-	// when none are provided
-	if runtime.GOOS == "windows" {
-		return cio.NewCreator(cio.WithStdio, cio.WithTerminal)
-	}
 	return cio.NullIO
 }
 


### PR DESCRIPTION
I think NullIO is fine on Windows now. We have it as an option in ctr, it's used for the pod sandbox container in CRI, and the code doesn't listen on pipes if the fifo paths are empty. Lets see if CI agrees..