### PR TITLE
pkg/epoch: extract parsing SOURCE_DATE_EPOCH to a function

### DIFF
--- a/pkg/epoch/epoch.go
+++ b/pkg/epoch/epoch.go
@@ -60,10 +60,10 @@ func SourceDateEpochOrNow() time.Time {
 
 // SetSourceDateEpoch sets the SOURCE_DATE_EPOCH env var.
 func SetSourceDateEpoch(tm time.Time) {
-	os.Setenv(SourceDateEpochEnv, fmt.Sprintf("%d", tm.Unix()))
+	_ = os.Setenv(SourceDateEpochEnv, strconv.Itoa(int(tm.Unix())))
 }
 
 // UnsetSourceDateEpoch unsets the SOURCE_DATE_EPOCH env var.
 func UnsetSourceDateEpoch() {
-	os.Unsetenv(SourceDateEpochEnv)
+	_ = os.Unsetenv(SourceDateEpochEnv)
 }

--- a/pkg/epoch/epoch.go
+++ b/pkg/epoch/epoch.go
@@ -37,12 +37,11 @@ func SourceDateEpoch() (*time.Time, error) {
 	if !ok || v == "" {
 		return nil, nil // not an error
 	}
-	i64, err := strconv.ParseInt(v, 10, 64)
+	t, err := ParseSourceDateEpoch(v)
 	if err != nil {
-		return nil, fmt.Errorf("invalid %s value %q: %w", SourceDateEpochEnv, v, err)
+		return nil, fmt.Errorf("invalid %s value: %w", SourceDateEpochEnv, err)
 	}
-	unix := time.Unix(i64, 0).UTC()
-	return &unix, nil
+	return t, nil
 }
 
 // SourceDateEpochOrNow returns the SOURCE_DATE_EPOCH time if available,
@@ -56,6 +55,20 @@ func SourceDateEpochOrNow() time.Time {
 		return *epoch
 	}
 	return time.Now().UTC()
+}
+
+// ParseSourceDateEpoch parses the given source date epoch, as *time.Time.
+// It returns an error if sourceDateEpoch is empty or not well-formatted.
+func ParseSourceDateEpoch(sourceDateEpoch string) (*time.Time, error) {
+	if sourceDateEpoch == "" {
+		return nil, fmt.Errorf("value is empty")
+	}
+	i64, err := strconv.ParseInt(sourceDateEpoch, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid value: %w", err)
+	}
+	unix := time.Unix(i64, 0).UTC()
+	return &unix, nil
 }
 
 // SetSourceDateEpoch sets the SOURCE_DATE_EPOCH env var.

--- a/pkg/epoch/epoch_test.go
+++ b/pkg/epoch/epoch_test.go
@@ -26,11 +26,15 @@ import (
 )
 
 func rightAfter(t1, t2 time.Time) bool {
+	if t2.Equal(t1) {
+		return true
+	}
+	threshold := 10 * time.Millisecond
 	if runtime.GOOS == "windows" {
 		// Low timer resolution on Windows
-		return (t2.After(t1) && t2.Before(t1.Add(100*time.Millisecond))) || t2.Equal(t1)
+		threshold *= 10
 	}
-	return t2.After(t1) && t2.Before(t1.Add(10*time.Millisecond))
+	return t2.After(t1) && t2.Before(t1.Add(threshold))
 }
 
 func TestSourceDateEpoch(t *testing.T) {
@@ -46,9 +50,9 @@ func TestSourceDateEpoch(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, vp)
 
-		now := time.Now()
+		now := time.Now().UTC()
 		v := SourceDateEpochOrNow()
-		require.True(t, rightAfter(now, v))
+		require.True(t, rightAfter(now, v), "now: %s, v: %s", now, v)
 	})
 
 	t.Run("WithEmptySourceDateEpoch", func(t *testing.T) {
@@ -58,9 +62,9 @@ func TestSourceDateEpoch(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, vp)
 
-		now := time.Now()
+		now := time.Now().UTC()
 		v := SourceDateEpochOrNow()
-		require.True(t, rightAfter(now, v))
+		require.True(t, rightAfter(now, v), "now: %s, v: %s", now, v)
 	})
 
 	t.Run("WithSourceDateEpoch", func(t *testing.T) {
@@ -85,8 +89,8 @@ func TestSourceDateEpoch(t *testing.T) {
 		require.ErrorContains(t, err, "invalid SOURCE_DATE_EPOCH value")
 		require.Nil(t, vp)
 
-		now := time.Now()
+		now := time.Now().UTC()
 		v := SourceDateEpochOrNow()
-		require.True(t, rightAfter(now, v))
+		require.True(t, rightAfter(now, v), "now: %s, v: %s", now, v)
 	})
 }


### PR DESCRIPTION
- related: https://github.com/docker/buildx/pull/1908


### pkg/epoch: replace some fmt.Sprintfs with strconv

Teeny-tiny optimizations:

    BenchmarkSprintf-10       37735996    32.31  ns/op  0 B/op  0 allocs/op
    BenchmarkItoa-10         591945836     2.031 ns/op  0 B/op  0 allocs/op
    BenchmarkFormatUint-10   593701444     2.014 ns/op  0 B/op  0 allocs/op

### pkg/epoch: fix tests on macOS

These tests were failing on my macOS; could be the precision issue (like on
Windows), or just because they're "too fast".

    === RUN   TestSourceDateEpoch/WithoutSourceDateEpoch
        epoch_test.go:51: 
                Error Trace:	/Users/thajeztah/go/src/github.com/containerd/containerd/pkg/epoch/epoch_test.go:51
                Error:      	Should be true
                Test:       	TestSourceDateEpoch/WithoutSourceDateEpoch
                Messages:   	now: 2023-06-23 11:47:09.93118 +0000 UTC, v: 2023-06-23 11:47:09.93118 +0000 UTC

This patch:

- updates the rightAfter utility to allow the timestamps to be "equal"
- updates the asserts to provide some details about the timestamps
- uses UTC for the value we're comparing to, to match the timestamps
  that are generated.


### pkg/epoch: extract parsing SOURCE_DATE_EPOCH to a function

This introduces a ParseSourceDateEpoch function, which can be used
to parse "SOURCE_DATE_EPOCH" values for situations where those
values are not passed through an env-var (or the env-var has been
read through other means).