### PR TITLE
Simplify `content.Copy` logic

### DIFF
--- a/services/content/contentserver/contentserver.go
+++ b/services/content/contentserver/contentserver.go
@@ -40,12 +40,15 @@ type service struct {
 	api.UnimplementedContentServer
 }
 
-var bufPool = sync.Pool{
-	New: func() interface{} {
-		buffer := make([]byte, 1<<20)
-		return &buffer
-	},
-}
+var (
+	empty   = &ptypes.Empty{}
+	bufPool = sync.Pool{
+		New: func() interface{} {
+			buffer := make([]byte, 1<<20)
+			return &buffer
+		},
+	}
+)
 
 // New returns the content GRPC server
 func New(cs content.Store) api.ContentServer {
@@ -101,12 +104,7 @@ func (s *service) List(req *api.ListContentRequest, session api.Content_ListServ
 	)
 
 	if err := s.store.Walk(session.Context(), func(info content.Info) error {
-		buffer = append(buffer, &api.Info{
-			Digest:    info.Digest.String(),
-			Size:      info.Size,
-			CreatedAt: protobuf.ToTimestamp(info.CreatedAt),
-			Labels:    info.Labels,
-		})
+		buffer = append(buffer, infoToGRPC(info))
 
 		if len(buffer) >= 100 {
 			if err := sendBlock(buffer); err != nil {
@@ -142,7 +140,7 @@ func (s *service) Delete(ctx context.Context, req *api.DeleteContentRequest) (*p
 		return nil, errdefs.ToGRPC(err)
 	}
 
-	return &ptypes.Empty{}, nil
+	return empty, nil
 }
 
 func (s *service) Read(req *api.ReadContentRequest, session api.Content_ReadServer) error {
@@ -449,7 +447,7 @@ func (s *service) Abort(ctx context.Context, req *api.AbortRequest) (*ptypes.Emp
 		return nil, errdefs.ToGRPC(err)
 	}
 
-	return &ptypes.Empty{}, nil
+	return empty, nil
 }
 
 func infoToGRPC(info content.Info) *api.Info {


### PR DESCRIPTION
`content.Copy` is a little verbose due to `cw.Status() + seekReader` being repeated 3 times. This PR (1st commit) remove extra duplications.

The second commit is a minor change to `contentserver`: 1. use the `infoToGRPC` helper; 2. predefine a empty var instead of creating a new one in every return, similar to other packages. It's a minor change so I just included in this PR as a separate commit. I can create a separate PR or remove it from this PR if that's better.

Thanks