### PR TITLE
[1.6] Add Fields type alias to log package

### DIFF
--- a/log/context.go
+++ b/log/context.go
@@ -35,6 +35,9 @@ var (
 
 type (
 	loggerKey struct{}
+
+	// Fields type to pass to `WithFields`, alias from `logrus`.
+	Fields = logrus.Fields
 )
 
 const (


### PR DESCRIPTION
Partial backport of https://github.com/containerd/containerd/pull/8143, to make consuming `github.com/containerd/containerd/log` easier for those on the 1.6 LTS branch. Given the original commit is large and invasive, it seemed better to go for the direct result, rather than make a dirty cherry-pick (and miss many usages in this branch).

Motivated in large part by https://github.com/moby/moby/pull/45799, but likely useful to other projects as well.

The original PR body is reproduced below:

---

When logging with custom fields, like:
 
```go
log.G(ctx).WithFields(logrus.Fields{ ... })...
```
 
you're forced to do two imports
 
```go
"github.com/containerd/containerd/log"
"github.com/sirupsen/logrus"
```
 
This PR adds a type alias to log package, so we end up with just one import:
 
```go
"github.com/containerd/containerd/log"
 
log.G(ctx).WithFields(log.Fields{})
```
 
Which often reduces the number of imports and makes log package a bit nicer.

