### PR TITLE
remotes: allow FetchByDigest client to pass mediatype as header

### DIFF
--- a/cmd/ctr/commands/content/content.go
+++ b/cmd/ctr/commands/content/content.go
@@ -451,7 +451,12 @@ var (
 		Usage:       "Retrieve blobs from a remote",
 		ArgsUsage:   "[flags] <remote> [<digest>, ...]",
 		Description: `Fetch blobs by digests from a remote.`,
-		Flags:       commands.RegistryFlags,
+		Flags: append(commands.RegistryFlags, []cli.Flag{
+			cli.StringFlag{
+				Name:  "media-type",
+				Usage: "Specify target mediatype for request header",
+			},
+		}...),
 		Action: func(context *cli.Context) error {
 			var (
 				ref     = context.Args().First()
@@ -486,7 +491,7 @@ var (
 				if err != nil {
 					return err
 				}
-				rc, _, err := fetcherByDigest.FetchByDigest(ctx, dgst)
+				rc, _, err := fetcherByDigest.FetchByDigest(ctx, dgst, remotes.WithMediaType(context.String("media-type")))
 				if err != nil {
 					return err
 				}

--- a/remotes/resolver.go
+++ b/remotes/resolver.go
@@ -65,7 +65,7 @@ type FetcherByDigest interface {
 	// FetcherByDigest usually returns an incomplete descriptor.
 	// Typically, the media type is always set to "application/octet-stream",
 	// and the annotations are unset.
-	FetchByDigest(ctx context.Context, dgst digest.Digest) (io.ReadCloser, ocispec.Descriptor, error)
+	FetchByDigest(ctx context.Context, dgst digest.Digest, opts ...FetchByDigestOpts) (io.ReadCloser, ocispec.Descriptor, error)
 }
 
 // Pusher pushes content
@@ -91,4 +91,21 @@ type PusherFunc func(ctx context.Context, desc ocispec.Descriptor) (content.Writ
 // Push content
 func (fn PusherFunc) Push(ctx context.Context, desc ocispec.Descriptor) (content.Writer, error) {
 	return fn(ctx, desc)
+}
+
+// FetchByDigestConfig provides configuration for fetching content by digest
+type FetchByDigestConfig struct {
+	//Mediatype specifies mediatype header to append for fetch request
+	Mediatype string
+}
+
+// FetchByDigestOpts allows callers to set options for fetch object
+type FetchByDigestOpts func(context.Context, *FetchByDigestConfig) error
+
+// WithMediaType sets the media type header for fetch request
+func WithMediaType(mediatype string) FetchByDigestOpts {
+	return func(ctx context.Context, cfg *FetchByDigestConfig) error {
+		cfg.Mediatype = mediatype
+		return nil
+	}
 }


### PR DESCRIPTION
accept mediatype header is required for some layers, add additional field for client.
Fixes #8743 