### PR TITLE
shim: change ttrpcService and ttrpcServerOptioner to exported interfaces

### DIFF
--- a/integration/failpoint/cmd/containerd-shim-runc-fp-v1/plugin_linux.go
+++ b/integration/failpoint/cmd/containerd-shim-runc-fp-v1/plugin_linux.go
@@ -72,8 +72,11 @@ func init() {
 			}, nil
 		},
 	})
-
 }
+
+var (
+	_ = shim.TTRPCServerOptioner(&taskServiceWithFp{})
+)
 
 type taskServiceWithFp struct {
 	fps   map[string]*failpoint.Failpoint

--- a/runtime/v2/example/example.go
+++ b/runtime/v2/example/example.go
@@ -77,6 +77,10 @@ func newTaskService(ctx context.Context, publisher shim.Publisher, sd shutdown.S
 	return &exampleTaskService{}, nil
 }
 
+var (
+	_ = shim.TTRPCService(&exampleTaskService{})
+)
+
 type exampleTaskService struct {
 }
 

--- a/runtime/v2/runc/pause/sandbox.go
+++ b/runtime/v2/runc/pause/sandbox.go
@@ -25,6 +25,7 @@ import (
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/pkg/shutdown"
+	"github.com/containerd/containerd/runtime/v2/shim"
 	"github.com/containerd/ttrpc"
 
 	api "github.com/containerd/containerd/api/runtime/sandbox/v1"
@@ -51,12 +52,15 @@ func init() {
 	})
 }
 
+var (
+	_ = shim.TTRPCService(&pauseService{})
+	_ = api.TTRPCSandboxService(&pauseService{})
+)
+
 // pauseService is an extension for task v2 runtime to support Pod "pause" containers via sandbox API.
 type pauseService struct {
 	shutdown shutdown.Service
 }
-
-var _ api.TTRPCSandboxService = (*pauseService)(nil)
 
 func (p *pauseService) RegisterTTRPC(server *ttrpc.Server) error {
 	api.RegisterTTRPCSandboxService(server, p)

--- a/runtime/v2/runc/task/service.go
+++ b/runtime/v2/runc/task/service.go
@@ -53,7 +53,7 @@ import (
 )
 
 var (
-	_     = (taskAPI.TaskService)(&service{})
+	_     = shim.TTRPCService(&service{})
 	empty = &ptypes.Empty{}
 )
 

--- a/runtime/v2/shim/shim.go
+++ b/runtime/v2/shim/shim.go
@@ -100,12 +100,12 @@ type Config struct {
 	NoSetupLogger bool
 }
 
-type ttrpcService interface {
+type TTRPCService interface {
 	RegisterTTRPC(*ttrpc.Server) error
 }
 
-type ttrpcServerOptioner interface {
-	ttrpcService
+type TTRPCServerOptioner interface {
+	TTRPCService
 
 	UnaryInterceptor() ttrpc.UnaryServerInterceptor
 }
@@ -302,7 +302,7 @@ func run(ctx context.Context, manager Manager, name string, config Config) error
 
 	var (
 		initialized   = plugin.NewPluginSet()
-		ttrpcServices = []ttrpcService{}
+		ttrpcServices = []TTRPCService{}
 
 		ttrpcUnaryInterceptors = []ttrpc.UnaryServerInterceptor{}
 	)
@@ -349,13 +349,13 @@ func run(ctx context.Context, manager Manager, name string, config Config) error
 			return fmt.Errorf("failed to load plugin %s: %w", id, err)
 		}
 
-		if src, ok := instance.(ttrpcService); ok {
+		if src, ok := instance.(TTRPCService); ok {
 			logrus.WithField("id", id).Debug("registering ttrpc service")
 			ttrpcServices = append(ttrpcServices, src)
 
 		}
 
-		if src, ok := instance.(ttrpcServerOptioner); ok {
+		if src, ok := instance.(TTRPCServerOptioner); ok {
 			ttrpcUnaryInterceptors = append(ttrpcUnaryInterceptors, src.UnaryInterceptor())
 		}
 	}


### PR DESCRIPTION
Set `shim.ttrpcService` and `shim.ttrpcServerOptioner` to exported interfaces so that implementers can use them to check.

for https://github.com/containerd/containerd/pull/8746#discussion_r1243436939