### PR TITLE
[release/1.6 backport] integration/client: add timeout to `TestShimOOMScore`

### DIFF
--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -1488,5 +1488,9 @@ func TestShimOOMScore(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	<-statusC
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for task exit event")
+	case <-statusC:
+	}
 }


### PR DESCRIPTION
backports https://github.com/containerd/containerd/pull/8664