### PR TITLE
[release/1.7 backport] integration/client: add timeout to `TestShimOOMScore`

### DIFF
--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -1492,5 +1492,9 @@ func TestShimOOMScore(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	<-statusC
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for task exit event")
+	case <-statusC:
+	}
 }


### PR DESCRIPTION
backports https://github.com/containerd/containerd/pull/8664