### PR TITLE
integration/client: Rework withBytesBuffers

### DIFF
--- a/integration/client/container_checkpoint_test.go
+++ b/integration/client/container_checkpoint_test.go
@@ -488,7 +488,7 @@ func TestCheckpointRestoreWithImagePath(t *testing.T) {
 
 	stdout := bytes.NewBuffer(nil)
 	spec.Process.Args = []string{"ps", "-ef"}
-	process, err := ntask.Exec(ctx, t.Name()+"_exec", spec.Process, cio.NewCreator(withByteBuffers(stdout)))
+	process, err := ntask.Exec(ctx, t.Name()+"_exec", spec.Process, cio.NewCreator(withStdout(stdout)))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -897,8 +897,7 @@ func TestContainerKillAll(t *testing.T) {
 	}
 	defer container.Delete(ctx, WithSnapshotCleanup)
 
-	stdout := bytes.NewBuffer(nil)
-	task, err := container.NewTask(ctx, cio.NewCreator(withByteBuffers(stdout)))
+	task, err := container.NewTask(ctx, cio.NullIO)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/client/container_test.go
+++ b/integration/client/container_test.go
@@ -323,7 +323,7 @@ func TestContainerOutput(t *testing.T) {
 	defer container.Delete(ctx, WithSnapshotCleanup)
 
 	stdout := bytes.NewBuffer(nil)
-	task, err := container.NewTask(ctx, cio.NewCreator(withByteBuffers(stdout)))
+	task, err := container.NewTask(ctx, cio.NewCreator(withStdout(stdout)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -355,12 +355,11 @@ func TestContainerOutput(t *testing.T) {
 	}
 }
 
-func withByteBuffers(stdout io.Writer) cio.Opt {
-	// TODO: could this use io.Discard?
+func withStdout(stdout io.Writer) cio.Opt {
 	return func(streams *cio.Streams) {
-		streams.Stdin = new(bytes.Buffer)
+		streams.Stdin = bytes.NewReader(nil)
 		streams.Stdout = stdout
-		streams.Stderr = new(bytes.Buffer)
+		streams.Stderr = io.Discard
 	}
 }
 
@@ -1259,7 +1258,7 @@ func TestContainerHostname(t *testing.T) {
 	defer container.Delete(ctx, WithSnapshotCleanup)
 
 	stdout := bytes.NewBuffer(nil)
-	task, err := container.NewTask(ctx, cio.NewCreator(withByteBuffers(stdout)))
+	task, err := container.NewTask(ctx, cio.NewCreator(withStdout(stdout)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1864,7 +1863,7 @@ func TestContainerExecLargeOutputWithTTY(t *testing.T) {
 		stdout := bytes.NewBuffer(nil)
 
 		execID := t.Name() + "_exec"
-		process, err := task.Exec(ctx, execID, processSpec, cio.NewCreator(withByteBuffers(stdout), withProcessTTY()))
+		process, err := task.Exec(ctx, execID, processSpec, cio.NewCreator(withStdout(stdout), withProcessTTY()))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2273,8 +2272,7 @@ func initContainerAndCheckChildrenDieOnKill(t *testing.T, opts ...oci.SpecOpts) 
 	}
 	defer container.Delete(ctx, WithSnapshotCleanup)
 
-	stdout := bytes.NewBuffer(nil)
-	task, err := container.NewTask(ctx, cio.NewCreator(withByteBuffers(stdout)))
+	task, err := container.NewTask(ctx, cio.NullIO)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2618,7 +2616,7 @@ func TestContainerUsername(t *testing.T) {
 	defer container.Delete(ctx, WithSnapshotCleanup)
 
 	buf := bytes.NewBuffer(nil)
-	task, err := container.NewTask(ctx, cio.NewCreator(withByteBuffers(buf)))
+	task, err := container.NewTask(ctx, cio.NewCreator(withStdout(buf)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2670,7 +2668,7 @@ func TestContainerPTY(t *testing.T) {
 	defer container.Delete(ctx, WithSnapshotCleanup)
 
 	buf := bytes.NewBuffer(nil)
-	task, err := container.NewTask(ctx, cio.NewCreator(withByteBuffers(buf), withProcessTTY()))
+	task, err := container.NewTask(ctx, cio.NewCreator(withStdout(buf), withProcessTTY()))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
All of the tests using this didn't need stdin/err (one of them not even stdout), so we can just leave them "empty" and change to a withStdout naming to make it more obvious.