### PR TITLE
Add From/ToProto helpers 

### DIFF
--- a/contrib/diffservice/service.go
+++ b/contrib/diffservice/service.go
@@ -50,7 +50,7 @@ func (s *service) Apply(ctx context.Context, er *diffapi.ApplyRequest) (*diffapi
 		ocidesc ocispec.Descriptor
 		err     error
 		desc    = toDescriptor(er.Diff)
-		mounts  = toMounts(er.Mounts)
+		mounts  = mount.FromProto(er.Mounts)
 	)
 
 	var opts []diff.ApplyOpt
@@ -79,8 +79,8 @@ func (s *service) Diff(ctx context.Context, dr *diffapi.DiffRequest) (*diffapi.D
 	var (
 		ocidesc ocispec.Descriptor
 		err     error
-		aMounts = toMounts(dr.Left)
-		bMounts = toMounts(dr.Right)
+		aMounts = mount.FromProto(dr.Left)
+		bMounts = mount.FromProto(dr.Right)
 	)
 
 	var opts []diff.Opt
@@ -106,19 +106,6 @@ func (s *service) Diff(ctx context.Context, dr *diffapi.DiffRequest) (*diffapi.D
 	return &diffapi.DiffResponse{
 		Diff: fromDescriptor(ocidesc),
 	}, nil
-}
-
-func toMounts(apim []*types.Mount) []mount.Mount {
-	mounts := make([]mount.Mount, len(apim))
-	for i, m := range apim {
-		mounts[i] = mount.Mount{
-			Type:    m.Type,
-			Source:  m.Source,
-			Target:  m.Target,
-			Options: m.Options,
-		}
-	}
-	return mounts
 }
 
 func toDescriptor(d *types.Descriptor) ocispec.Descriptor {

--- a/contrib/diffservice/service.go
+++ b/contrib/diffservice/service.go
@@ -20,12 +20,11 @@ import (
 	"context"
 
 	diffapi "github.com/containerd/containerd/api/services/diff/v1"
-	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/diff"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/oci"
 	"github.com/containerd/typeurl/v2"
-	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -49,7 +48,7 @@ func (s *service) Apply(ctx context.Context, er *diffapi.ApplyRequest) (*diffapi
 	var (
 		ocidesc ocispec.Descriptor
 		err     error
-		desc    = toDescriptor(er.Diff)
+		desc    = oci.DescriptorFromProto(er.Diff)
 		mounts  = mount.FromProto(er.Mounts)
 	)
 
@@ -68,7 +67,7 @@ func (s *service) Apply(ctx context.Context, er *diffapi.ApplyRequest) (*diffapi
 	}
 
 	return &diffapi.ApplyResponse{
-		Applied: fromDescriptor(ocidesc),
+		Applied: oci.DescriptorToProto(ocidesc),
 	}, nil
 }
 
@@ -104,24 +103,6 @@ func (s *service) Diff(ctx context.Context, dr *diffapi.DiffRequest) (*diffapi.D
 	}
 
 	return &diffapi.DiffResponse{
-		Diff: fromDescriptor(ocidesc),
+		Diff: oci.DescriptorToProto(ocidesc),
 	}, nil
-}
-
-func toDescriptor(d *types.Descriptor) ocispec.Descriptor {
-	return ocispec.Descriptor{
-		MediaType:   d.MediaType,
-		Digest:      digest.Digest(d.Digest),
-		Size:        d.Size,
-		Annotations: d.Annotations,
-	}
-}
-
-func fromDescriptor(d ocispec.Descriptor) *types.Descriptor {
-	return &types.Descriptor{
-		MediaType:   d.MediaType,
-		Digest:      d.Digest.String(),
-		Size:        d.Size,
-		Annotations: d.Annotations,
-	}
 }

--- a/contrib/snapshotservice/service.go
+++ b/contrib/snapshotservice/service.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	snapshotsapi "github.com/containerd/containerd/api/services/snapshots/v1"
-	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/protobuf"
@@ -51,7 +50,7 @@ func (s service) Prepare(ctx context.Context, pr *snapshotsapi.PrepareSnapshotRe
 	}
 
 	return &snapshotsapi.PrepareSnapshotResponse{
-		Mounts: fromMounts(mounts),
+		Mounts: mount.ToProto(mounts),
 	}, nil
 }
 
@@ -65,7 +64,7 @@ func (s service) View(ctx context.Context, pr *snapshotsapi.ViewSnapshotRequest)
 		return nil, errdefs.ToGRPC(err)
 	}
 	return &snapshotsapi.ViewSnapshotResponse{
-		Mounts: fromMounts(mounts),
+		Mounts: mount.ToProto(mounts),
 	}, nil
 }
 
@@ -75,7 +74,7 @@ func (s service) Mounts(ctx context.Context, mr *snapshotsapi.MountsRequest) (*s
 		return nil, errdefs.ToGRPC(err)
 	}
 	return &snapshotsapi.MountsResponse{
-		Mounts: fromMounts(mounts),
+		Mounts: mount.ToProto(mounts),
 	}, nil
 }
 
@@ -197,19 +196,6 @@ func fromInfo(info snapshots.Info) *snapshotsapi.Info {
 		UpdatedAt: protobuf.ToTimestamp(info.Updated),
 		Labels:    info.Labels,
 	}
-}
-
-func fromMounts(mounts []mount.Mount) []*types.Mount {
-	out := make([]*types.Mount, len(mounts))
-	for i, m := range mounts {
-		out[i] = &types.Mount{
-			Type:    m.Type,
-			Source:  m.Source,
-			Target:  m.Target,
-			Options: m.Options,
-		}
-	}
-	return out
 }
 
 func toInfo(info *snapshotsapi.Info) snapshots.Info {

--- a/contrib/snapshotservice/service.go
+++ b/contrib/snapshotservice/service.go
@@ -22,7 +22,6 @@ import (
 	snapshotsapi "github.com/containerd/containerd/api/services/snapshots/v1"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/mount"
-	"github.com/containerd/containerd/protobuf"
 	ptypes "github.com/containerd/containerd/protobuf/types"
 	"github.com/containerd/containerd/snapshots"
 )
@@ -104,16 +103,16 @@ func (s service) Stat(ctx context.Context, sr *snapshotsapi.StatSnapshotRequest)
 		return nil, errdefs.ToGRPC(err)
 	}
 
-	return &snapshotsapi.StatSnapshotResponse{Info: fromInfo(info)}, nil
+	return &snapshotsapi.StatSnapshotResponse{Info: snapshots.InfoToProto(info)}, nil
 }
 
 func (s service) Update(ctx context.Context, sr *snapshotsapi.UpdateSnapshotRequest) (*snapshotsapi.UpdateSnapshotResponse, error) {
-	info, err := s.sn.Update(ctx, toInfo(sr.Info), sr.UpdateMask.GetPaths()...)
+	info, err := s.sn.Update(ctx, snapshots.InfoFromProto(sr.Info), sr.UpdateMask.GetPaths()...)
 	if err != nil {
 		return nil, errdefs.ToGRPC(err)
 	}
 
-	return &snapshotsapi.UpdateSnapshotResponse{Info: fromInfo(info)}, nil
+	return &snapshotsapi.UpdateSnapshotResponse{Info: snapshots.InfoToProto(info)}, nil
 }
 
 func (s service) List(sr *snapshotsapi.ListSnapshotsRequest, ss snapshotsapi.Snapshots_ListServer) error {
@@ -126,7 +125,7 @@ func (s service) List(sr *snapshotsapi.ListSnapshotsRequest, ss snapshotsapi.Sna
 		}
 	)
 	err := s.sn.Walk(ss.Context(), func(ctx context.Context, info snapshots.Info) error {
-		buffer = append(buffer, fromInfo(info))
+		buffer = append(buffer, snapshots.InfoToProto(info))
 
 		if len(buffer) >= 100 {
 			if err := sendBlock(buffer); err != nil {
@@ -175,46 +174,4 @@ func (s service) Cleanup(ctx context.Context, cr *snapshotsapi.CleanupRequest) (
 	}
 
 	return empty, nil
-}
-
-func fromKind(kind snapshots.Kind) snapshotsapi.Kind {
-	if kind == snapshots.KindActive {
-		return snapshotsapi.Kind_ACTIVE
-	}
-	if kind == snapshots.KindView {
-		return snapshotsapi.Kind_VIEW
-	}
-	return snapshotsapi.Kind_COMMITTED
-}
-
-func fromInfo(info snapshots.Info) *snapshotsapi.Info {
-	return &snapshotsapi.Info{
-		Name:      info.Name,
-		Parent:    info.Parent,
-		Kind:      fromKind(info.Kind),
-		CreatedAt: protobuf.ToTimestamp(info.Created),
-		UpdatedAt: protobuf.ToTimestamp(info.Updated),
-		Labels:    info.Labels,
-	}
-}
-
-func toInfo(info *snapshotsapi.Info) snapshots.Info {
-	return snapshots.Info{
-		Name:    info.Name,
-		Parent:  info.Parent,
-		Kind:    toKind(info.Kind),
-		Created: protobuf.FromTimestamp(info.CreatedAt),
-		Updated: protobuf.FromTimestamp(info.UpdatedAt),
-		Labels:  info.Labels,
-	}
-}
-
-func toKind(kind snapshotsapi.Kind) snapshots.Kind {
-	if kind == snapshotsapi.Kind_ACTIVE {
-		return snapshots.KindActive
-	}
-	if kind == snapshotsapi.Kind_VIEW {
-		return snapshots.KindView
-	}
-	return snapshots.KindCommitted
 }

--- a/diff/proxy/differ.go
+++ b/diff/proxy/differ.go
@@ -60,7 +60,7 @@ func (r *diffRemote) Apply(ctx context.Context, desc ocispec.Descriptor, mounts 
 
 	req := &diffapi.ApplyRequest{
 		Diff:     fromDescriptor(desc),
-		Mounts:   fromMounts(mounts),
+		Mounts:   mount.ToProto(mounts),
 		Payloads: payloads,
 	}
 	resp, err := r.client.Apply(ctx, req)
@@ -85,8 +85,8 @@ func (r *diffRemote) Compare(ctx context.Context, a, b []mount.Mount, opts ...di
 		sourceDateEpoch = timestamppb.New(*config.SourceDateEpoch)
 	}
 	req := &diffapi.DiffRequest{
-		Left:            fromMounts(a),
-		Right:           fromMounts(b),
+		Left:            mount.ToProto(a),
+		Right:           mount.ToProto(b),
 		MediaType:       config.MediaType,
 		Ref:             config.Reference,
 		Labels:          config.Labels,
@@ -118,17 +118,4 @@ func fromDescriptor(d ocispec.Descriptor) *types.Descriptor {
 		Size:        d.Size,
 		Annotations: d.Annotations,
 	}
-}
-
-func fromMounts(mounts []mount.Mount) []*types.Mount {
-	apiMounts := make([]*types.Mount, len(mounts))
-	for i, m := range mounts {
-		apiMounts[i] = &types.Mount{
-			Type:    m.Type,
-			Source:  m.Source,
-			Target:  m.Target,
-			Options: m.Options,
-		}
-	}
-	return apiMounts
 }

--- a/mount/mount.go
+++ b/mount/mount.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/continuity/fs"
 )
 
@@ -129,4 +130,34 @@ func readonlyOverlay(opt []string) []string {
 		}
 	}
 	return out
+}
+
+// ToProto converts from [Mount] to the containerd
+// APIs protobuf definition of a Mount.
+func ToProto(mounts []Mount) []*types.Mount {
+	apiMounts := make([]*types.Mount, len(mounts))
+	for i, m := range mounts {
+		apiMounts[i] = &types.Mount{
+			Type:    m.Type,
+			Source:  m.Source,
+			Target:  m.Target,
+			Options: m.Options,
+		}
+	}
+	return apiMounts
+}
+
+// FromProto converts from the protobuf definition [types.Mount] to
+// [Mount].
+func FromProto(mm []*types.Mount) []Mount {
+	mounts := make([]Mount, len(mm))
+	for i, m := range mm {
+		mounts[i] = Mount{
+			Type:    m.Type,
+			Source:  m.Source,
+			Target:  m.Target,
+			Options: m.Options,
+		}
+	}
+	return mounts
 }

--- a/oci/spec.go
+++ b/oci/spec.go
@@ -21,8 +21,11 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runtime-spec/specs-go"
 
+	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/platforms"
@@ -219,4 +222,26 @@ func populateDefaultDarwinSpec(s *Spec) error {
 		Process: &specs.Process{Cwd: "/"},
 	}
 	return nil
+}
+
+// DescriptorFromProto converts containerds protobuf [types.Descriptor]
+// to the OCI image specs [ocispec.Descriptor].
+func DescriptorFromProto(d *types.Descriptor) ocispec.Descriptor {
+	return ocispec.Descriptor{
+		MediaType:   d.MediaType,
+		Digest:      digest.Digest(d.Digest),
+		Size:        d.Size,
+		Annotations: d.Annotations,
+	}
+}
+
+// DescriptorToProto converts the OCI image specs [ocispec.Descriptor]
+// to containerds protobuf [types.Descriptor].
+func DescriptorToProto(d ocispec.Descriptor) *types.Descriptor {
+	return &types.Descriptor{
+		MediaType:   d.MediaType,
+		Digest:      d.Digest.String(),
+		Size:        d.Size,
+		Annotations: d.Annotations,
+	}
 }

--- a/pkg/transfer/archive/exporter.go
+++ b/pkg/transfer/archive/exporter.go
@@ -156,15 +156,7 @@ func (iis *ImageExportStream) UnmarshalAny(ctx context.Context, sm streaming.Str
 		return err
 	}
 
-	var specified []v1.Platform
-	for _, p := range s.Platforms {
-		specified = append(specified, v1.Platform{
-			OS:           p.OS,
-			Architecture: p.Architecture,
-			Variant:      p.Variant,
-		})
-	}
-
+	specified := platforms.FromProto(s.Platforms)
 	iis.stream = tstreaming.WriteByteStream(ctx, stream)
 	iis.mediaType = s.MediaType
 	iis.platforms = specified

--- a/pkg/transfer/image/imagestore.go
+++ b/pkg/transfer/image/imagestore.go
@@ -363,7 +363,7 @@ func (is *Store) MarshalAny(context.Context, streaming.StreamCreator) (typeurl.A
 		Labels:          is.imageLabels,
 		ManifestLimit:   uint32(is.manifestLimit),
 		AllMetadata:     is.allMetadata,
-		Platforms:       platformsToProto(is.platforms),
+		Platforms:       platforms.ToProto(is.platforms),
 		ExtraReferences: referencesToProto(is.extraReferences),
 		Unpacks:         unpackToProto(is.unpacks),
 	}
@@ -380,35 +380,11 @@ func (is *Store) UnmarshalAny(ctx context.Context, sm streaming.StreamGetter, a 
 	is.imageLabels = s.Labels
 	is.manifestLimit = int(s.ManifestLimit)
 	is.allMetadata = s.AllMetadata
-	is.platforms = platformFromProto(s.Platforms)
+	is.platforms = platforms.FromProto(s.Platforms)
 	is.extraReferences = referencesFromProto(s.ExtraReferences)
 	is.unpacks = unpackFromProto(s.Unpacks)
 
 	return nil
-}
-
-func platformsToProto(platforms []ocispec.Platform) []*types.Platform {
-	ap := make([]*types.Platform, len(platforms))
-	for i := range platforms {
-		p := types.Platform{
-			OS:           platforms[i].OS,
-			Architecture: platforms[i].Architecture,
-			Variant:      platforms[i].Variant,
-		}
-
-		ap[i] = &p
-	}
-	return ap
-}
-
-func platformFromProto(platforms []*types.Platform) []ocispec.Platform {
-	op := make([]ocispec.Platform, len(platforms))
-	for i := range platforms {
-		op[i].OS = platforms[i].OS
-		op[i].Architecture = platforms[i].Architecture
-		op[i].Variant = platforms[i].Variant
-	}
-	return op
 }
 
 func referencesToProto(references []Reference) []*transfertypes.ImageReference {

--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -116,6 +116,7 @@ import (
 
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 
+	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/errdefs"
 )
 
@@ -261,4 +262,31 @@ func Normalize(platform specs.Platform) specs.Platform {
 	platform.Architecture, platform.Variant = normalizeArch(platform.Architecture, platform.Variant)
 
 	return platform
+}
+
+// ToProto converts from a slice of [Platform] to a slice of
+// the protobuf definition [types.Platform].
+func ToProto(platforms []Platform) []*types.Platform {
+	ap := make([]*types.Platform, len(platforms))
+	for i := range platforms {
+		p := types.Platform{
+			OS:           platforms[i].OS,
+			Architecture: platforms[i].Architecture,
+			Variant:      platforms[i].Variant,
+		}
+		ap[i] = &p
+	}
+	return ap
+}
+
+// FromProto converts a slice of the protobuf definition [types.Platform]
+// to a slice of [Platform].
+func FromProto(platforms []*types.Platform) []Platform {
+	op := make([]Platform, len(platforms))
+	for i := range platforms {
+		op[i].OS = platforms[i].OS
+		op[i].Architecture = platforms[i].Architecture
+		op[i].Variant = platforms[i].Variant
+	}
+	return op
 }

--- a/services/diff/local.go
+++ b/services/diff/local.go
@@ -98,7 +98,7 @@ func (l *local) Apply(ctx context.Context, er *diffapi.ApplyRequest, _ ...grpc.C
 		ocidesc ocispec.Descriptor
 		err     error
 		desc    = toDescriptor(er.Diff)
-		mounts  = toMounts(er.Mounts)
+		mounts  = mount.FromProto(er.Mounts)
 	)
 
 	var opts []diff.ApplyOpt
@@ -131,8 +131,8 @@ func (l *local) Diff(ctx context.Context, dr *diffapi.DiffRequest, _ ...grpc.Cal
 	var (
 		ocidesc ocispec.Descriptor
 		err     error
-		aMounts = toMounts(dr.Left)
-		bMounts = toMounts(dr.Right)
+		aMounts = mount.FromProto(dr.Left)
+		bMounts = mount.FromProto(dr.Right)
 	)
 
 	var opts []diff.Opt
@@ -163,19 +163,6 @@ func (l *local) Diff(ctx context.Context, dr *diffapi.DiffRequest, _ ...grpc.Cal
 	return &diffapi.DiffResponse{
 		Diff: fromDescriptor(ocidesc),
 	}, nil
-}
-
-func toMounts(apim []*types.Mount) []mount.Mount {
-	mounts := make([]mount.Mount, len(apim))
-	for i, m := range apim {
-		mounts[i] = mount.Mount{
-			Type:    m.Type,
-			Source:  m.Source,
-			Target:  m.Target,
-			Options: m.Options,
-		}
-	}
-	return mounts
 }
 
 func toDescriptor(d *types.Descriptor) ocispec.Descriptor {

--- a/services/diff/local.go
+++ b/services/diff/local.go
@@ -21,14 +21,13 @@ import (
 	"fmt"
 
 	diffapi "github.com/containerd/containerd/api/services/diff/v1"
-	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/diff"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/services"
 	"github.com/containerd/typeurl/v2"
-	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"google.golang.org/grpc"
 )
@@ -97,7 +96,7 @@ func (l *local) Apply(ctx context.Context, er *diffapi.ApplyRequest, _ ...grpc.C
 	var (
 		ocidesc ocispec.Descriptor
 		err     error
-		desc    = toDescriptor(er.Diff)
+		desc    = oci.DescriptorFromProto(er.Diff)
 		mounts  = mount.FromProto(er.Mounts)
 	)
 
@@ -122,7 +121,7 @@ func (l *local) Apply(ctx context.Context, er *diffapi.ApplyRequest, _ ...grpc.C
 	}
 
 	return &diffapi.ApplyResponse{
-		Applied: fromDescriptor(ocidesc),
+		Applied: oci.DescriptorToProto(ocidesc),
 	}, nil
 
 }
@@ -161,24 +160,6 @@ func (l *local) Diff(ctx context.Context, dr *diffapi.DiffRequest, _ ...grpc.Cal
 	}
 
 	return &diffapi.DiffResponse{
-		Diff: fromDescriptor(ocidesc),
+		Diff: oci.DescriptorToProto(ocidesc),
 	}, nil
-}
-
-func toDescriptor(d *types.Descriptor) ocispec.Descriptor {
-	return ocispec.Descriptor{
-		MediaType:   d.MediaType,
-		Digest:      digest.Digest(d.Digest),
-		Size:        d.Size,
-		Annotations: d.Annotations,
-	}
-}
-
-func fromDescriptor(d ocispec.Descriptor) *types.Descriptor {
-	return &types.Descriptor{
-		MediaType:   d.MediaType,
-		Digest:      d.Digest.String(),
-		Size:        d.Size,
-		Annotations: d.Annotations,
-	}
 }

--- a/services/introspection/local.go
+++ b/services/introspection/local.go
@@ -24,9 +24,9 @@ import (
 	"sync"
 
 	api "github.com/containerd/containerd/api/services/introspection/v1"
-	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/filters"
+	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/plugin"
 	ptypes "github.com/containerd/containerd/protobuf/types"
 	"github.com/containerd/containerd/services"
@@ -189,15 +189,6 @@ func adaptPlugin(o interface{}) filters.Adaptor {
 func pluginsToPB(plugins []*plugin.Plugin) []*api.Plugin {
 	var pluginsPB []*api.Plugin
 	for _, p := range plugins {
-		var platforms []*types.Platform
-		for _, p := range p.Meta.Platforms {
-			platforms = append(platforms, &types.Platform{
-				OS:           p.OS,
-				Architecture: p.Architecture,
-				Variant:      p.Variant,
-			})
-		}
-
 		var requires []string
 		for _, r := range p.Registration.Requires {
 			requires = append(requires, r.String())
@@ -231,7 +222,7 @@ func pluginsToPB(plugins []*plugin.Plugin) []*api.Plugin {
 			Type:         p.Registration.Type.String(),
 			ID:           p.Registration.ID,
 			Requires:     requires,
-			Platforms:    platforms,
+			Platforms:    platforms.ToProto(p.Meta.Platforms),
 			Capabilities: p.Meta.Capabilities,
 			Exports:      p.Meta.Exports,
 			InitErr:      initErr,

--- a/services/snapshots/service.go
+++ b/services/snapshots/service.go
@@ -25,7 +25,6 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/plugin"
-	"github.com/containerd/containerd/protobuf"
 	ptypes "github.com/containerd/containerd/protobuf/types"
 	"github.com/containerd/containerd/services"
 	"github.com/containerd/containerd/snapshots"
@@ -184,7 +183,7 @@ func (s *service) Stat(ctx context.Context, sr *snapshotsapi.StatSnapshotRequest
 		return nil, errdefs.ToGRPC(err)
 	}
 
-	return &snapshotsapi.StatSnapshotResponse{Info: fromInfo(info)}, nil
+	return &snapshotsapi.StatSnapshotResponse{Info: snapshots.InfoToProto(info)}, nil
 }
 
 func (s *service) Update(ctx context.Context, sr *snapshotsapi.UpdateSnapshotRequest) (*snapshotsapi.UpdateSnapshotResponse, error) {
@@ -194,12 +193,12 @@ func (s *service) Update(ctx context.Context, sr *snapshotsapi.UpdateSnapshotReq
 		return nil, err
 	}
 
-	info, err := sn.Update(ctx, toInfo(sr.Info), sr.UpdateMask.GetPaths()...)
+	info, err := sn.Update(ctx, snapshots.InfoFromProto(sr.Info), sr.UpdateMask.GetPaths()...)
 	if err != nil {
 		return nil, errdefs.ToGRPC(err)
 	}
 
-	return &snapshotsapi.UpdateSnapshotResponse{Info: fromInfo(info)}, nil
+	return &snapshotsapi.UpdateSnapshotResponse{Info: snapshots.InfoToProto(info)}, nil
 }
 
 func (s *service) List(sr *snapshotsapi.ListSnapshotsRequest, ss snapshotsapi.Snapshots_ListServer) error {
@@ -217,7 +216,7 @@ func (s *service) List(sr *snapshotsapi.ListSnapshotsRequest, ss snapshotsapi.Sn
 		}
 	)
 	err = sn.Walk(ss.Context(), func(ctx context.Context, info snapshots.Info) error {
-		buffer = append(buffer, fromInfo(info))
+		buffer = append(buffer, snapshots.InfoToProto(info))
 
 		if len(buffer) >= 100 {
 			if err := sendBlock(buffer); err != nil {
@@ -253,7 +252,7 @@ func (s *service) Usage(ctx context.Context, ur *snapshotsapi.UsageRequest) (*sn
 		return nil, errdefs.ToGRPC(err)
 	}
 
-	return fromUsage(usage), nil
+	return snapshots.UsageToProto(usage), nil
 }
 
 func (s *service) Cleanup(ctx context.Context, cr *snapshotsapi.CleanupRequest) (*ptypes.Empty, error) {
@@ -273,53 +272,4 @@ func (s *service) Cleanup(ctx context.Context, cr *snapshotsapi.CleanupRequest) 
 	}
 
 	return empty, nil
-}
-
-func fromKind(kind snapshots.Kind) snapshotsapi.Kind {
-	if kind == snapshots.KindActive {
-		return snapshotsapi.Kind_ACTIVE
-	}
-	if kind == snapshots.KindView {
-		return snapshotsapi.Kind_VIEW
-	}
-	return snapshotsapi.Kind_COMMITTED
-}
-
-func fromInfo(info snapshots.Info) *snapshotsapi.Info {
-	return &snapshotsapi.Info{
-		Name:      info.Name,
-		Parent:    info.Parent,
-		Kind:      fromKind(info.Kind),
-		CreatedAt: protobuf.ToTimestamp(info.Created),
-		UpdatedAt: protobuf.ToTimestamp(info.Updated),
-		Labels:    info.Labels,
-	}
-}
-
-func fromUsage(usage snapshots.Usage) *snapshotsapi.UsageResponse {
-	return &snapshotsapi.UsageResponse{
-		Inodes: usage.Inodes,
-		Size:   usage.Size,
-	}
-}
-
-func toInfo(info *snapshotsapi.Info) snapshots.Info {
-	return snapshots.Info{
-		Name:    info.Name,
-		Parent:  info.Parent,
-		Kind:    toKind(info.Kind),
-		Created: protobuf.FromTimestamp(info.CreatedAt),
-		Updated: protobuf.FromTimestamp(info.UpdatedAt),
-		Labels:  info.Labels,
-	}
-}
-
-func toKind(kind snapshotsapi.Kind) snapshots.Kind {
-	if kind == snapshotsapi.Kind_ACTIVE {
-		return snapshots.KindActive
-	}
-	if kind == snapshotsapi.Kind_VIEW {
-		return snapshots.KindView
-	}
-	return snapshots.KindCommitted
 }

--- a/services/snapshots/service.go
+++ b/services/snapshots/service.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 
 	snapshotsapi "github.com/containerd/containerd/api/services/snapshots/v1"
-	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
@@ -102,7 +101,7 @@ func (s *service) Prepare(ctx context.Context, pr *snapshotsapi.PrepareSnapshotR
 	}
 
 	return &snapshotsapi.PrepareSnapshotResponse{
-		Mounts: fromMounts(mounts),
+		Mounts: mount.ToProto(mounts),
 	}, nil
 }
 
@@ -121,7 +120,7 @@ func (s *service) View(ctx context.Context, pr *snapshotsapi.ViewSnapshotRequest
 		return nil, errdefs.ToGRPC(err)
 	}
 	return &snapshotsapi.ViewSnapshotResponse{
-		Mounts: fromMounts(mounts),
+		Mounts: mount.ToProto(mounts),
 	}, nil
 }
 
@@ -137,7 +136,7 @@ func (s *service) Mounts(ctx context.Context, mr *snapshotsapi.MountsRequest) (*
 		return nil, errdefs.ToGRPC(err)
 	}
 	return &snapshotsapi.MountsResponse{
-		Mounts: fromMounts(mounts),
+		Mounts: mount.ToProto(mounts),
 	}, nil
 }
 
@@ -302,19 +301,6 @@ func fromUsage(usage snapshots.Usage) *snapshotsapi.UsageResponse {
 		Inodes: usage.Inodes,
 		Size:   usage.Size,
 	}
-}
-
-func fromMounts(mounts []mount.Mount) []*types.Mount {
-	out := make([]*types.Mount, len(mounts))
-	for i, m := range mounts {
-		out[i] = &types.Mount{
-			Type:    m.Type,
-			Source:  m.Source,
-			Target:  m.Target,
-			Options: m.Options,
-		}
-	}
-	return out
 }
 
 func toInfo(info *snapshotsapi.Info) snapshots.Info {

--- a/snapshots/proxy/proxy.go
+++ b/snapshots/proxy/proxy.go
@@ -21,7 +21,6 @@ import (
 	"io"
 
 	snapshotsapi "github.com/containerd/containerd/api/services/snapshots/v1"
-	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/protobuf"
@@ -89,7 +88,7 @@ func (p *proxySnapshotter) Mounts(ctx context.Context, key string) ([]mount.Moun
 	if err != nil {
 		return nil, errdefs.FromGRPC(err)
 	}
-	return toMounts(resp.Mounts), nil
+	return mount.FromProto(resp.Mounts), nil
 }
 
 func (p *proxySnapshotter) Prepare(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
@@ -108,7 +107,7 @@ func (p *proxySnapshotter) Prepare(ctx context.Context, key, parent string, opts
 	if err != nil {
 		return nil, errdefs.FromGRPC(err)
 	}
-	return toMounts(resp.Mounts), nil
+	return mount.FromProto(resp.Mounts), nil
 }
 
 func (p *proxySnapshotter) View(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
@@ -127,7 +126,7 @@ func (p *proxySnapshotter) View(ctx context.Context, key, parent string, opts ..
 	if err != nil {
 		return nil, errdefs.FromGRPC(err)
 	}
-	return toMounts(resp.Mounts), nil
+	return mount.FromProto(resp.Mounts), nil
 }
 
 func (p *proxySnapshotter) Commit(ctx context.Context, name, key string, opts ...snapshots.Opt) error {
@@ -218,19 +217,6 @@ func toUsage(resp *snapshotsapi.UsageResponse) snapshots.Usage {
 		Inodes: resp.Inodes,
 		Size:   resp.Size,
 	}
-}
-
-func toMounts(mm []*types.Mount) []mount.Mount {
-	mounts := make([]mount.Mount, len(mm))
-	for i, m := range mm {
-		mounts[i] = mount.Mount{
-			Type:    m.Type,
-			Source:  m.Source,
-			Target:  m.Target,
-			Options: m.Options,
-		}
-	}
-	return mounts
 }
 
 func fromKind(kind snapshots.Kind) snapshotsapi.Kind {

--- a/snapshots/proxy/proxy.go
+++ b/snapshots/proxy/proxy.go
@@ -23,7 +23,6 @@ import (
 	snapshotsapi "github.com/containerd/containerd/api/services/snapshots/v1"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/mount"
-	"github.com/containerd/containerd/protobuf"
 	protobuftypes "github.com/containerd/containerd/protobuf/types"
 	"github.com/containerd/containerd/snapshots"
 )
@@ -51,14 +50,14 @@ func (p *proxySnapshotter) Stat(ctx context.Context, key string) (snapshots.Info
 	if err != nil {
 		return snapshots.Info{}, errdefs.FromGRPC(err)
 	}
-	return toInfo(resp.Info), nil
+	return snapshots.InfoFromProto(resp.Info), nil
 }
 
 func (p *proxySnapshotter) Update(ctx context.Context, info snapshots.Info, fieldpaths ...string) (snapshots.Info, error) {
 	resp, err := p.client.Update(ctx,
 		&snapshotsapi.UpdateSnapshotRequest{
 			Snapshotter: p.snapshotterName,
-			Info:        fromInfo(info),
+			Info:        snapshots.InfoToProto(info),
 			UpdateMask: &protobuftypes.FieldMask{
 				Paths: fieldpaths,
 			},
@@ -66,7 +65,7 @@ func (p *proxySnapshotter) Update(ctx context.Context, info snapshots.Info, fiel
 	if err != nil {
 		return snapshots.Info{}, errdefs.FromGRPC(err)
 	}
-	return toInfo(resp.Info), nil
+	return snapshots.InfoFromProto(resp.Info), nil
 }
 
 func (p *proxySnapshotter) Usage(ctx context.Context, key string) (snapshots.Usage, error) {
@@ -77,7 +76,7 @@ func (p *proxySnapshotter) Usage(ctx context.Context, key string) (snapshots.Usa
 	if err != nil {
 		return snapshots.Usage{}, errdefs.FromGRPC(err)
 	}
-	return toUsage(resp), nil
+	return snapshots.UsageFromProto(resp), nil
 }
 
 func (p *proxySnapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, error) {
@@ -173,7 +172,7 @@ func (p *proxySnapshotter) Walk(ctx context.Context, fn snapshots.WalkFunc, fs .
 			return nil
 		}
 		for _, info := range resp.Info {
-			if err := fn(ctx, toInfo(info)); err != nil {
+			if err := fn(ctx, snapshots.InfoFromProto(info)); err != nil {
 				return err
 			}
 		}
@@ -189,53 +188,4 @@ func (p *proxySnapshotter) Cleanup(ctx context.Context) error {
 		Snapshotter: p.snapshotterName,
 	})
 	return errdefs.FromGRPC(err)
-}
-
-func toKind(kind snapshotsapi.Kind) snapshots.Kind {
-	if kind == snapshotsapi.Kind_ACTIVE {
-		return snapshots.KindActive
-	}
-	if kind == snapshotsapi.Kind_VIEW {
-		return snapshots.KindView
-	}
-	return snapshots.KindCommitted
-}
-
-func toInfo(info *snapshotsapi.Info) snapshots.Info {
-	return snapshots.Info{
-		Name:    info.Name,
-		Parent:  info.Parent,
-		Kind:    toKind(info.Kind),
-		Created: protobuf.FromTimestamp(info.CreatedAt),
-		Updated: protobuf.FromTimestamp(info.UpdatedAt),
-		Labels:  info.Labels,
-	}
-}
-
-func toUsage(resp *snapshotsapi.UsageResponse) snapshots.Usage {
-	return snapshots.Usage{
-		Inodes: resp.Inodes,
-		Size:   resp.Size,
-	}
-}
-
-func fromKind(kind snapshots.Kind) snapshotsapi.Kind {
-	if kind == snapshots.KindActive {
-		return snapshotsapi.Kind_ACTIVE
-	}
-	if kind == snapshots.KindView {
-		return snapshotsapi.Kind_VIEW
-	}
-	return snapshotsapi.Kind_COMMITTED
-}
-
-func fromInfo(info snapshots.Info) *snapshotsapi.Info {
-	return &snapshotsapi.Info{
-		Name:      info.Name,
-		Parent:    info.Parent,
-		Kind:      fromKind(info.Kind),
-		CreatedAt: protobuf.ToTimestamp(info.Created),
-		UpdatedAt: protobuf.ToTimestamp(info.Updated),
-		Labels:    info.Labels,
-	}
 }


### PR DESCRIPTION
In many of the core packages we have local types, and then their corresponding over the wire structures used for folks interacting via GRPC. In all these cases we have duplicated code that handles the conversions from our internal types to the generated structures. Ideally these conversions could just live next to the definitions for the internal types, and that's what this change sets out to do. I split this into four commits to make it easier if some of these aren't wanted, but the commits contain helpers to do conversions for:

1. mount (Mount)
2. oci (Descriptor)
3. snapshots (Kind, Usage, Info)
4. platforms ([]Platform)