### PR TITLE
Update ginkgo to match cri-tools' version

### DIFF
--- a/script/setup/install-critools
+++ b/script/setup/install-critools
@@ -29,7 +29,7 @@ if (( $EUID != 0 )); then
 fi
 
 cd "$(go env GOPATH)"
-go install github.com/onsi/ginkgo/v2/ginkgo@v2.4.0
+go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.2
 
 : "${CRITEST_COMMIT:=$(cat "${script_dir}/critools-version")}"
 : "${DESTDIR:=""}"


### PR DESCRIPTION
critools 1.27.0 uses ginkgo 2.9.2 https://github.com/kubernetes-sigs/cri-tools/blob/v1.27.0/go.mod#L12.

This can avoid those ginkgo warning in CI (https://github.com/containerd/containerd/pull/8752#issuecomment-1611334816).

https://github.com/containerd/containerd/actions/runs/5401559918/jobs/9811676884