### PR TITLE
[release/1.7 backport] Update ginkgo to match cri-tools' version

### DIFF
--- a/script/setup/install-critools
+++ b/script/setup/install-critools
@@ -29,7 +29,7 @@ if (( $EUID != 0 )); then
 fi
 
 cd "$(go env GOPATH)"
-go install github.com/onsi/ginkgo/v2/ginkgo@v2.4.0
+go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.2
 
 : "${CRITEST_COMMIT:=$(cat "${script_dir}/critools-version")}"
 : "${DESTDIR:=""}"


### PR DESCRIPTION
cherry pick https://github.com/containerd/containerd/pull/8758

Update ginkgo version to match cri-tools and avoid deprecation warning in CI.