### PR TITLE
Move GetTopic function out of runc shim

### DIFF
--- a/runtime/events.go
+++ b/runtime/events.go
@@ -16,6 +16,11 @@
 
 package runtime
 
+import (
+	"github.com/containerd/containerd/api/events"
+	"github.com/containerd/containerd/log"
+)
+
 const (
 	// TaskCreateEventTopic for task create
 	TaskCreateEventTopic = "/tasks/create"
@@ -40,3 +45,33 @@ const (
 	// TaskUnknownTopic for unknown task events
 	TaskUnknownTopic = "/tasks/?"
 )
+
+// GetTopic converts an event from an interface type to the specific
+// event topic id
+func GetTopic(e interface{}) string {
+	switch e.(type) {
+	case *events.TaskCreate:
+		return TaskCreateEventTopic
+	case *events.TaskStart:
+		return TaskStartEventTopic
+	case *events.TaskOOM:
+		return TaskOOMEventTopic
+	case *events.TaskExit:
+		return TaskExitEventTopic
+	case *events.TaskDelete:
+		return TaskDeleteEventTopic
+	case *events.TaskExecAdded:
+		return TaskExecAddedEventTopic
+	case *events.TaskExecStarted:
+		return TaskExecStartedEventTopic
+	case *events.TaskPaused:
+		return TaskPausedEventTopic
+	case *events.TaskResumed:
+		return TaskResumedEventTopic
+	case *events.TaskCheckpointed:
+		return TaskCheckpointedEventTopic
+	default:
+		log.L.Warnf("no topic for type %#v", e)
+	}
+	return TaskUnknownTopic
+}

--- a/runtime/v2/runc/task/service.go
+++ b/runtime/v2/runc/task/service.go
@@ -42,6 +42,7 @@ import (
 	"github.com/containerd/containerd/pkg/userns"
 	"github.com/containerd/containerd/protobuf"
 	ptypes "github.com/containerd/containerd/protobuf/types"
+	"github.com/containerd/containerd/runtime"
 	"github.com/containerd/containerd/runtime/v2/runc"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/containerd/containerd/runtime/v2/shim"
@@ -687,7 +688,7 @@ func (s *service) forward(ctx context.Context, publisher shim.Publisher) {
 	ns, _ := namespaces.Namespace(ctx)
 	ctx = namespaces.WithNamespace(context.Background(), ns)
 	for e := range s.events {
-		err := publisher.Publish(ctx, runc.GetTopic(e), e)
+		err := publisher.Publish(ctx, runtime.GetTopic(e), e)
 		if err != nil {
 			log.G(ctx).WithError(err).Error("post event")
 		}

--- a/runtime/v2/runc/util.go
+++ b/runtime/v2/runc/util.go
@@ -24,42 +24,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/log"
-	"github.com/containerd/containerd/runtime"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 )
-
-// GetTopic converts an event from an interface type to the specific
-// event topic id
-func GetTopic(e interface{}) string {
-	switch e.(type) {
-	case *events.TaskCreate:
-		return runtime.TaskCreateEventTopic
-	case *events.TaskStart:
-		return runtime.TaskStartEventTopic
-	case *events.TaskOOM:
-		return runtime.TaskOOMEventTopic
-	case *events.TaskExit:
-		return runtime.TaskExitEventTopic
-	case *events.TaskDelete:
-		return runtime.TaskDeleteEventTopic
-	case *events.TaskExecAdded:
-		return runtime.TaskExecAddedEventTopic
-	case *events.TaskExecStarted:
-		return runtime.TaskExecStartedEventTopic
-	case *events.TaskPaused:
-		return runtime.TaskPausedEventTopic
-	case *events.TaskResumed:
-		return runtime.TaskResumedEventTopic
-	case *events.TaskCheckpointed:
-		return runtime.TaskCheckpointedEventTopic
-	default:
-		logrus.Warnf("no topic for type %#v", e)
-	}
-	return runtime.TaskUnknownTopic
-}
 
 // ShouldKillAllOnExit reads the bundle's OCI spec and returns true if
 // there is an error reading the spec or if the container has a private PID namespace


### PR DESCRIPTION
Every shim implementation needs to select a correct publisher topic when posting events, so move it out of Linux-only runc code to the place where other shims can also use it

Otherwise, shims have to copy-paste this code. For example, see runj: https://github.com/samuelkarp/runj/blob/8158e558a361aff1f265a8feed7ad765da5c61b5/containerd/shim.go#L144-L172