### PR TITLE
ci: remove libseccomp-dev installation for nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,14 +43,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo add-apt-repository -y "deb [arch=arm64,s390x,ppc64el,riscv64] http://ports.ubuntu.com/ubuntu-ports/ $(lsb_release -sc) main" || true
-          sudo add-apt-repository -y "deb [arch=arm64,s390x,ppc64el,riscv64] http://ports.ubuntu.com/ubuntu-ports/ $(lsb_release -sc)-updates main" || true
-
-          sudo dpkg --add-architecture arm64
-          sudo dpkg --add-architecture s390x
-          sudo dpkg --add-architecture ppc64el
-          sudo dpkg --add-architecture riscv64
-
           sudo apt-get update || true
 
           sudo apt-get install -y \
@@ -58,11 +50,6 @@ jobs:
             crossbuild-essential-s390x \
             crossbuild-essential-ppc64el \
             crossbuild-essential-riscv64 \
-            libseccomp-dev:amd64 \
-            libseccomp-dev:arm64 \
-            libseccomp-dev:s390x \
-            libseccomp-dev:ppc64el \
-            libseccomp-dev:riscv64
 
       - name: Build amd64
         env:


### PR DESCRIPTION
since libseccomp is required only for building runc and we are only building containerd binaries in nightly, the libseccomp-dev dependency is removed