### PR TITLE
[release/1.7] go.mod: Update cgroups to 3.0.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/container-orchestrated-devices/container-device-interface v0.5.4
 	github.com/containerd/aufs v1.0.0
 	github.com/containerd/btrfs/v2 v2.0.0
-	github.com/containerd/cgroups/v3 v3.0.1
+	github.com/containerd/cgroups/v3 v3.0.2
 	github.com/containerd/console v1.0.3
 	github.com/containerd/continuity v0.4.1
 	github.com/containerd/fifo v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -198,8 +198,8 @@ github.com/containerd/cgroups v1.0.1/go.mod h1:0SJrPIenamHDcZhEcJMNBB85rHcUsw4f2
 github.com/containerd/cgroups v1.0.3/go.mod h1:/ofk34relqNjSGyqPrmEULrO4Sc8LJhvJmWbUCUKqj8=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
-github.com/containerd/cgroups/v3 v3.0.1 h1:4hfGvu8rfGIwVIDd+nLzn/B9ZXx4BcCjzt5ToenJRaE=
-github.com/containerd/cgroups/v3 v3.0.1/go.mod h1:/vtwk1VXrtoa5AaZLkypuOJgA/6DyPMZHJPGQNtlHnw=
+github.com/containerd/cgroups/v3 v3.0.2 h1:f5WFqIVSgo5IZmtTT3qVBo6TzI1ON6sycSBKkymb9L0=
+github.com/containerd/cgroups/v3 v3.0.2/go.mod h1:JUgITrzdFqp42uI2ryGA+ge0ap/nxzYgkGmIcetmErE=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/console v0.0.0-20181022165439-0650fd9eeb50/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/console v0.0.0-20191206165004-02ecf6a7291e/go.mod h1:8Pf4gM6VEbTNRIT26AyyU7hxdQU3MvAvxVI0sc00XBE=

--- a/integration/client/go.mod
+++ b/integration/client/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/Microsoft/hcsshim v0.10.0-rc.8
 	github.com/Microsoft/hcsshim/test v0.0.0-20210408205431-da33ecd607e1
-	github.com/containerd/cgroups/v3 v3.0.1
+	github.com/containerd/cgroups/v3 v3.0.2
 	github.com/containerd/containerd v1.7.0 // see replace; the actual version of containerd is replaced with the code at the root of this repository
 	github.com/containerd/continuity v0.4.1
 	github.com/containerd/go-runc v1.0.0

--- a/integration/client/go.sum
+++ b/integration/client/go.sum
@@ -646,8 +646,8 @@ github.com/containerd/cgroups v1.0.1/go.mod h1:0SJrPIenamHDcZhEcJMNBB85rHcUsw4f2
 github.com/containerd/cgroups v1.0.3/go.mod h1:/ofk34relqNjSGyqPrmEULrO4Sc8LJhvJmWbUCUKqj8=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
-github.com/containerd/cgroups/v3 v3.0.1 h1:4hfGvu8rfGIwVIDd+nLzn/B9ZXx4BcCjzt5ToenJRaE=
-github.com/containerd/cgroups/v3 v3.0.1/go.mod h1:/vtwk1VXrtoa5AaZLkypuOJgA/6DyPMZHJPGQNtlHnw=
+github.com/containerd/cgroups/v3 v3.0.2 h1:f5WFqIVSgo5IZmtTT3qVBo6TzI1ON6sycSBKkymb9L0=
+github.com/containerd/cgroups/v3 v3.0.2/go.mod h1:JUgITrzdFqp42uI2ryGA+ge0ap/nxzYgkGmIcetmErE=
 github.com/containerd/console v0.0.0-20191206165004-02ecf6a7291e/go.mod h1:8Pf4gM6VEbTNRIT26AyyU7hxdQU3MvAvxVI0sc00XBE=
 github.com/containerd/console v1.0.1/go.mod h1:XUsP6YE/mKtz6bxc+I8UiKKTP04qjQL4qcS3XoQ5xkw=
 github.com/containerd/console v1.0.2/go.mod h1:ytZPjGgY2oeTkAONYafi2kSj0aYggsf8acV1PGKCbzQ=

--- a/vendor/github.com/containerd/cgroups/v3/README.md
+++ b/vendor/github.com/containerd/cgroups/v3/README.md
@@ -201,6 +201,27 @@ if err != nil {
 }
 ```
 
+
+### Get and set cgroup type
+```go
+m, err := cgroup2.LoadSystemd("/", "my-cgroup-abc.slice")
+if err != nil {
+    return err
+}
+
+// https://www.kernel.org/doc/html/v5.0/admin-guide/cgroup-v2.html#threads
+cgType, err := m.GetType()
+if err != nil {
+    return err
+}
+fmt.Println(cgType)
+
+err = m.SetType(cgroup2.Threaded)
+if err != nil {
+    return err
+}
+```
+
 ### Attention
 
 All static path should not include `/sys/fs/cgroup/` prefix, it should start with your own cgroups name

--- a/vendor/github.com/containerd/cgroups/v3/cgroup1/blkio.go
+++ b/vendor/github.com/containerd/cgroups/v3/cgroup1/blkio.go
@@ -331,7 +331,6 @@ type deviceKey struct {
 // keyed by major and minor number. Since devices may be mapped multiple times,
 // we err on taking the first occurrence.
 func getDevices(r io.Reader) (map[deviceKey]string, error) {
-
 	var (
 		s       = bufio.NewScanner(r)
 		devices = make(map[deviceKey]string)

--- a/vendor/github.com/containerd/cgroups/v3/cgroup1/cgroup.go
+++ b/vendor/github.com/containerd/cgroups/v3/cgroup1/cgroup.go
@@ -41,7 +41,7 @@ func New(path Path, resources *specs.LinuxResources, opts ...InitOpts) (Cgroup, 
 			return nil, err
 		}
 	}
-	subsystems, err := config.hiearchy()
+	subsystems, err := config.hierarchy()
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func Load(path Path, opts ...InitOpts) (Cgroup, error) {
 		}
 	}
 	var activeSubsystems []Subsystem
-	subsystems, err := config.hiearchy()
+	subsystems, err := config.hierarchy()
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +158,7 @@ func (c *cgroup) subsystemsFilter(subsystems ...Name) []Subsystem {
 		return c.subsystems
 	}
 
-	var filteredSubsystems = []Subsystem{}
+	filteredSubsystems := []Subsystem{}
 	for _, s := range c.subsystems {
 		for _, f := range subsystems {
 			if s.Name() == f {
@@ -259,6 +259,10 @@ func (c *cgroup) Delete() error {
 		// kernel prevents cgroups with running process from being removed, check the tree is empty
 		procs, err := c.processes(s.Name(), true, cgroupProcs)
 		if err != nil {
+			// if the control group does not exist within a subsystem, then proceed to the next subsystem
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
 			return err
 		}
 		if len(procs) > 0 {

--- a/vendor/github.com/containerd/cgroups/v3/cgroup1/control.go
+++ b/vendor/github.com/containerd/cgroups/v3/cgroup1/control.go
@@ -28,7 +28,7 @@ type procType = string
 const (
 	cgroupProcs    procType = "cgroup.procs"
 	cgroupTasks    procType = "tasks"
-	defaultDirPerm          = 0755
+	defaultDirPerm          = 0o755
 )
 
 // defaultFilePerm is a var so that the test framework can change the filemode

--- a/vendor/github.com/containerd/cgroups/v3/cgroup1/memory.go
+++ b/vendor/github.com/containerd/cgroups/v3/cgroup1/memory.go
@@ -472,7 +472,7 @@ func (m *memoryController) memoryEvent(path string, event MemoryEvent) (uintptr,
 	defer evtFile.Close()
 	data := fmt.Sprintf("%d %d %s", efd, evtFile.Fd(), event.Arg())
 	evctlPath := filepath.Join(root, "cgroup.event_control")
-	if err := os.WriteFile(evctlPath, []byte(data), 0700); err != nil {
+	if err := os.WriteFile(evctlPath, []byte(data), 0o700); err != nil {
 		unix.Close(efd)
 		return 0, err
 	}

--- a/vendor/github.com/containerd/cgroups/v3/cgroup1/opts.go
+++ b/vendor/github.com/containerd/cgroups/v3/cgroup1/opts.go
@@ -36,13 +36,13 @@ type InitOpts func(*InitConfig) error
 type InitConfig struct {
 	// InitCheck can be used to check initialization errors from the subsystem
 	InitCheck InitCheck
-	hiearchy  Hierarchy
+	hierarchy Hierarchy
 }
 
 func newInitConfig() *InitConfig {
 	return &InitConfig{
 		InitCheck: RequireDevices,
-		hiearchy:  Default,
+		hierarchy: Default,
 	}
 }
 
@@ -66,7 +66,7 @@ func RequireDevices(s Subsystem, _ Path, _ error) error {
 // The default list is coming from /proc/self/mountinfo.
 func WithHiearchy(h Hierarchy) InitOpts {
 	return func(c *InitConfig) error {
-		c.hiearchy = h
+		c.hierarchy = h
 		return nil
 	}
 }

--- a/vendor/github.com/containerd/cgroups/v3/cgroup1/pids.go
+++ b/vendor/github.com/containerd/cgroups/v3/cgroup1/pids.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 
 	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -67,15 +66,9 @@ func (p *pidsController) Stat(path string, stats *v1.Metrics) error {
 	if err != nil {
 		return err
 	}
-	var max uint64
-	maxData, err := os.ReadFile(filepath.Join(p.Path(path), "pids.max"))
+	max, err := readUint(filepath.Join(p.Path(path), "pids.max"))
 	if err != nil {
 		return err
-	}
-	if maxS := strings.TrimSpace(string(maxData)); maxS != "max" {
-		if max, err = parseUint(maxS, 10, 64); err != nil {
-			return err
-		}
 	}
 	stats.Pids = &v1.PidsStat{
 		Current: current,

--- a/vendor/github.com/containerd/cgroups/v3/cgroup1/rdma.go
+++ b/vendor/github.com/containerd/cgroups/v3/cgroup1/rdma.go
@@ -124,7 +124,6 @@ func toRdmaEntry(strEntries []string) []*v1.RdmaEntry {
 }
 
 func (p *rdmaController) Stat(path string, stats *v1.Metrics) error {
-
 	currentData, err := os.ReadFile(filepath.Join(p.Path(path), "rdma.current"))
 	if err != nil {
 		return err

--- a/vendor/github.com/containerd/cgroups/v3/cgroup1/systemd.go
+++ b/vendor/github.com/containerd/cgroups/v3/cgroup1/systemd.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	SystemdDbus  Name = "systemd"
-	defaultSlice      = "system.slice"
+	defaultSlice Name = "system.slice"
 )
 
 var (
@@ -56,7 +56,7 @@ func Systemd() ([]Subsystem, error) {
 
 func Slice(slice, name string) Path {
 	if slice == "" {
-		slice = defaultSlice
+		slice = string(defaultSlice)
 	}
 	return func(subsystem Name) (string, error) {
 		return filepath.Join(slice, name), nil
@@ -70,7 +70,6 @@ func NewSystemd(root string) (*SystemdController, error) {
 }
 
 type SystemdController struct {
-	mu   sync.Mutex
 	root string
 }
 

--- a/vendor/github.com/containerd/cgroups/v3/cgroup1/utils.go
+++ b/vendor/github.com/containerd/cgroups/v3/cgroup1/utils.go
@@ -18,6 +18,7 @@ package cgroup1
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -131,11 +132,25 @@ func hugePageSizes() ([]string, error) {
 }
 
 func readUint(path string) (uint64, error) {
-	v, err := os.ReadFile(path)
+	f, err := os.Open(path)
 	if err != nil {
 		return 0, err
 	}
-	return parseUint(strings.TrimSpace(string(v)), 10, 64)
+	defer f.Close()
+
+	// We should only need 20 bytes for the max uint64, but for a nice power of 2
+	// lets use 32.
+	b := make([]byte, 32)
+	n, err := f.Read(b)
+	if err != nil {
+		return 0, err
+	}
+	s := string(bytes.TrimSpace(b[:n]))
+	if s == "max" {
+		// Return 0 for the max value to maintain backward compatibility.
+		return 0, nil
+	}
+	return parseUint(s, 10, 64)
 }
 
 func parseUint(s string, base, bitSize int) (uint64, error) {

--- a/vendor/github.com/containerd/cgroups/v3/cgroup1/v1.go
+++ b/vendor/github.com/containerd/cgroups/v3/cgroup1/v1.go
@@ -45,7 +45,7 @@ func Default() ([]Subsystem, error) {
 }
 
 // v1MountPoint returns the mount point where the cgroup
-// mountpoints are mounted in a single hiearchy
+// mountpoints are mounted in a single hierarchy
 func v1MountPoint() (string, error) {
 	f, err := os.Open("/proc/self/mountinfo")
 	if err != nil {

--- a/vendor/github.com/containerd/cgroups/v3/cgroup2/devicefilter.go
+++ b/vendor/github.com/containerd/cgroups/v3/cgroup2/devicefilter.go
@@ -167,7 +167,7 @@ func (p *program) appendDevice(dev specs.LinuxDeviceCgroup) error {
 	}
 	p.insts = append(p.insts, acceptBlock(dev.Allow)...)
 	// set blockSym to the first instruction we added in this iteration
-	p.insts[prevBlockLastIdx+1] = p.insts[prevBlockLastIdx+1].Sym(blockSym)
+	p.insts[prevBlockLastIdx+1] = p.insts[prevBlockLastIdx+1].WithSymbol(blockSym)
 	p.blockID++
 	return nil
 }
@@ -180,7 +180,7 @@ func (p *program) finalize() (asm.Instructions, error) {
 	blockSym := fmt.Sprintf("block-%d", p.blockID)
 	p.insts = append(p.insts,
 		// R0 <- 0
-		asm.Mov.Imm32(asm.R0, 0).Sym(blockSym),
+		asm.Mov.Imm32(asm.R0, 0).WithSymbol(blockSym),
 		asm.Return(),
 	)
 	p.blockID = -1

--- a/vendor/github.com/containerd/cgroups/v3/cgroup2/utils.go
+++ b/vendor/github.com/containerd/cgroups/v3/cgroup2/utils.go
@@ -18,6 +18,7 @@ package cgroup2
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -25,6 +26,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 	"unsafe"
 
@@ -39,7 +41,7 @@ import (
 const (
 	cgroupProcs    = "cgroup.procs"
 	cgroupThreads  = "cgroup.threads"
-	defaultDirPerm = 0755
+	defaultDirPerm = 0o755
 )
 
 // defaultFilePerm is a var so that the test framework can change the filemode
@@ -92,19 +94,13 @@ func parseCgroupProcsFile(path string) ([]uint64, error) {
 	return out, nil
 }
 
-func parseKV(raw string) (string, interface{}, error) {
+func parseKV(raw string) (string, uint64, error) {
 	parts := strings.Fields(raw)
-	switch len(parts) {
-	case 2:
-		v, err := parseUint(parts[1], 10, 64)
-		if err != nil {
-			// if we cannot parse as a uint, parse as a string
-			return parts[0], parts[1], nil
-		}
-		return parts[0], v, nil
-	default:
+	if len(parts) != 2 {
 		return "", 0, ErrInvalidFormat
 	}
+	v, err := parseUint(parts[1], 10, 64)
+	return parts[0], v, err
 }
 
 func parseUint(s string, base, bitSize int) (uint64, error) {
@@ -136,9 +132,7 @@ func parseCgroupFile(path string) (string, error) {
 }
 
 func parseCgroupFromReader(r io.Reader) (string, error) {
-	var (
-		s = bufio.NewScanner(r)
-	)
+	s := bufio.NewScanner(r)
 	for s.Scan() {
 		var (
 			text  = s.Text()
@@ -244,18 +238,28 @@ func ToResources(spec *specs.LinuxResources) *Resources {
 
 // Gets uint64 parsed content of single value cgroup stat file
 func getStatFileContentUint64(filePath string) uint64 {
-	contents, err := os.ReadFile(filePath)
+	f, err := os.Open(filePath)
 	if err != nil {
 		return 0
 	}
-	trimmed := strings.TrimSpace(string(contents))
+	defer f.Close()
+
+	// We expect an unsigned 64 bit integer, or a "max" string
+	// in some cases.
+	buf := make([]byte, 32)
+	n, err := f.Read(buf)
+	if err != nil {
+		return 0
+	}
+
+	trimmed := strings.TrimSpace(string(buf[:n]))
 	if trimmed == "max" {
 		return math.MaxUint64
 	}
 
 	res, err := parseUint(trimmed, 10, 64)
 	if err != nil {
-		logrus.Errorf("unable to parse %q as a uint from Cgroup file %q", string(contents), filePath)
+		logrus.Errorf("unable to parse %q as a uint from Cgroup file %q", trimmed, filePath)
 		return res
 	}
 
@@ -385,56 +389,94 @@ func systemdUnitFromPath(path string) string {
 }
 
 func readHugeTlbStats(path string) []*stats.HugeTlbStat {
-	var usage = []*stats.HugeTlbStat{}
-	var keyUsage = make(map[string]*stats.HugeTlbStat)
-	f, err := os.Open(path)
-	if err != nil {
-		return usage
-	}
-	files, err := f.Readdir(-1)
-	f.Close()
-	if err != nil {
-		return usage
-	}
-
-	for _, file := range files {
-		if strings.Contains(file.Name(), "hugetlb") &&
-			(strings.HasSuffix(file.Name(), "max") || strings.HasSuffix(file.Name(), "current")) {
-			var hugeTlb *stats.HugeTlbStat
-			var ok bool
-			fileName := strings.Split(file.Name(), ".")
-			pageSize := fileName[1]
-			if hugeTlb, ok = keyUsage[pageSize]; !ok {
-				hugeTlb = &stats.HugeTlbStat{}
-			}
-			hugeTlb.Pagesize = pageSize
-			out, err := os.ReadFile(filepath.Join(path, file.Name()))
-			if err != nil {
-				continue
-			}
-			var value uint64
-			stringVal := strings.TrimSpace(string(out))
-			if stringVal == "max" {
-				value = math.MaxUint64
-			} else {
-				value, err = strconv.ParseUint(stringVal, 10, 64)
-			}
-			if err != nil {
-				continue
-			}
-			switch fileName[2] {
-			case "max":
-				hugeTlb.Max = value
-			case "current":
-				hugeTlb.Current = value
-			}
-			keyUsage[pageSize] = hugeTlb
+	hpSizes := hugePageSizes()
+	usage := make([]*stats.HugeTlbStat, len(hpSizes))
+	for idx, pagesize := range hpSizes {
+		usage[idx] = &stats.HugeTlbStat{
+			Max:      getStatFileContentUint64(filepath.Join(path, "hugetlb."+pagesize+".max")),
+			Current:  getStatFileContentUint64(filepath.Join(path, "hugetlb."+pagesize+".current")),
+			Pagesize: pagesize,
 		}
 	}
-	for _, entry := range keyUsage {
-		usage = append(usage, entry)
-	}
 	return usage
+}
+
+var (
+	hPageSizes  []string
+	initHPSOnce sync.Once
+)
+
+// The following idea and implementation is taken pretty much line for line from
+// runc. Because the hugetlb files are well known, and the only variable thrown in
+// the mix is what huge page sizes you have on your host, this lends itself well
+// to doing the work to find the files present once, and then re-using this. This
+// saves a os.Readdirnames(0) call to search for hugeltb files on every `manager.Stat`
+// call.
+// https://github.com/opencontainers/runc/blob/3a2c0c2565644d8a7e0f1dd594a060b21fa96cf1/libcontainer/cgroups/utils.go#L301
+func hugePageSizes() []string {
+	initHPSOnce.Do(func() {
+		dir, err := os.OpenFile("/sys/kernel/mm/hugepages", unix.O_DIRECTORY|unix.O_RDONLY, 0)
+		if err != nil {
+			return
+		}
+		files, err := dir.Readdirnames(0)
+		dir.Close()
+		if err != nil {
+			return
+		}
+
+		hPageSizes, err = getHugePageSizeFromFilenames(files)
+		if err != nil {
+			logrus.Warnf("hugePageSizes: %s", err)
+		}
+	})
+
+	return hPageSizes
+}
+
+func getHugePageSizeFromFilenames(fileNames []string) ([]string, error) {
+	pageSizes := make([]string, 0, len(fileNames))
+	var warn error
+
+	for _, file := range fileNames {
+		// example: hugepages-1048576kB
+		val := strings.TrimPrefix(file, "hugepages-")
+		if len(val) == len(file) {
+			// Unexpected file name: no prefix found, ignore it.
+			continue
+		}
+		// In all known versions of Linux up to 6.3 the suffix is always
+		// "kB". If we find something else, produce an error but keep going.
+		eLen := len(val) - 2
+		val = strings.TrimSuffix(val, "kB")
+		if len(val) != eLen {
+			// Highly unlikely.
+			if warn == nil {
+				warn = errors.New(file + `: invalid suffix (expected "kB")`)
+			}
+			continue
+		}
+		size, err := strconv.Atoi(val)
+		if err != nil {
+			// Highly unlikely.
+			if warn == nil {
+				warn = fmt.Errorf("%s: %w", file, err)
+			}
+			continue
+		}
+		// Model after https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/hugetlb_cgroup.c?id=eff48ddeab782e35e58ccc8853f7386bbae9dec4#n574
+		// but in our case the size is in KB already.
+		if size >= (1 << 20) {
+			val = strconv.Itoa(size>>20) + "GB"
+		} else if size >= (1 << 10) {
+			val = strconv.Itoa(size>>10) + "MB"
+		} else {
+			val += "KB"
+		}
+		pageSizes = append(pageSizes, val)
+	}
+
+	return pageSizes, warn
 }
 
 func getSubreaper() (int, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -94,8 +94,8 @@ github.com/containerd/btrfs/v2
 # github.com/containerd/cgroups v1.1.0
 ## explicit; go 1.17
 github.com/containerd/cgroups/stats/v1
-# github.com/containerd/cgroups/v3 v3.0.1
-## explicit; go 1.17
+# github.com/containerd/cgroups/v3 v3.0.2
+## explicit; go 1.18
 github.com/containerd/cgroups/v3
 github.com/containerd/cgroups/v3/cgroup1
 github.com/containerd/cgroups/v3/cgroup1/stats


### PR DESCRIPTION
This brings in a ton of great improvements, most notably for the containerd daemon is performance improvements for cgroups1 and 2 for gathering stats, as well as some fixes for enabling controllers and deleting v1 cgroups.

Relevant work for the daemon:

1. https://github.com/containerd/cgroups/pull/293
2. https://github.com/containerd/cgroups/pull/296
3. https://github.com/containerd/cgroups/pull/281
4. https://github.com/containerd/cgroups/pull/291
5. https://github.com/containerd/cgroups/pull/278
6. https://github.com/containerd/cgroups/pull/283