### PR TITLE
Sandbox: Change to mount.Mount for CreateOptions

### DIFF
--- a/plugins/sandbox/controller.go
+++ b/plugins/sandbox/controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/containerd/containerd/events"
 	"github.com/containerd/containerd/events/exchange"
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/runtime"
@@ -144,7 +145,7 @@ func (c *controllerLocal) Create(ctx context.Context, sandboxID string, opts ...
 	if _, err := svc.CreateSandbox(ctx, &runtimeAPI.CreateSandboxRequest{
 		SandboxID:  sandboxID,
 		BundlePath: shim.Bundle(),
-		Rootfs:     coptions.Rootfs,
+		Rootfs:     mount.ToProto(coptions.Rootfs),
 		Options:    options,
 		NetnsPath:  coptions.NetNSPath,
 	}); err != nil {

--- a/sandbox/controller.go
+++ b/sandbox/controller.go
@@ -22,12 +22,13 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/api/types"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/typeurl/v2"
 )
 
 type CreateOptions struct {
-	Rootfs []*types.Mount
+	Rootfs []mount.Mount
 	// Options are used to pass arbitrary options to the shim when creating a new sandbox.
 	// CRI will use this to pass PodSandboxConfig.
 	// Don't confuse this with Runtime options, which are passed at shim instance start
@@ -39,8 +40,7 @@ type CreateOptions struct {
 type CreateOpt func(*CreateOptions) error
 
 // WithRootFS is used to create a sandbox with the provided rootfs mount
-// TODO: Switch to mount.Mount once target added
-func WithRootFS(m []*types.Mount) CreateOpt {
+func WithRootFS(m []mount.Mount) CreateOpt {
 	return func(co *CreateOptions) error {
 		co.Rootfs = m
 		return nil

--- a/sandbox/proxy/controller.go
+++ b/sandbox/proxy/controller.go
@@ -22,6 +22,7 @@ import (
 	api "github.com/containerd/containerd/api/services/sandbox/v1"
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/sandbox"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -46,7 +47,7 @@ func (s *remoteSandboxController) Create(ctx context.Context, sandboxID string, 
 	}
 	_, err := s.client.Create(ctx, &api.ControllerCreateRequest{
 		SandboxID: sandboxID,
-		Rootfs:    options.Rootfs,
+		Rootfs:    mount.ToProto(options.Rootfs),
 		Options: &anypb.Any{
 			TypeUrl: options.Options.GetTypeUrl(),
 			Value:   options.Options.GetValue(),


### PR DESCRIPTION
We'd wanted to swap to mount.Mount after target was introduced. That time is now :)

This funnily enough was what led to the rabbit hole of https://github.com/containerd/containerd/pull/8757 as I didn't want to add local from/toProto functions *again* just for this.