### PR TITLE
Cirrus CI: configure apt-get to wait for locks

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -26,8 +26,9 @@ task:
       # v7.0.0 does not boot. v6.0.0 was not released.
       BOX: rockylinux/8@5.0.0
   install_libvirt_vagrant_script: |
-    apt-get update
-    apt-get install -y libvirt-daemon libvirt-daemon-system vagrant vagrant-libvirt
+    # if another process is keeping a lock, wait for 60 seconds for it to release the lock.
+    apt-get -o DPkg::Lock::Timeout=60 update
+    apt-get -o DPkg::Lock::Timeout=60 install -y libvirt-daemon libvirt-daemon-system vagrant vagrant-libvirt
     systemctl enable --now libvirtd
 
   vagrant_cache:
@@ -61,8 +62,9 @@ task:
     memory: 16G
 
   install_libvirt_vagrant_script: |
-    apt-get update
-    apt-get install -y libvirt-daemon libvirt-daemon-system vagrant vagrant-libvirt
+    # if another process is keeping a lock, wait for 60 seconds for it to release the lock.
+    apt-get -o DPkg::Lock::Timeout=60 update
+    apt-get -o DPkg::Lock::Timeout=60 install -y libvirt-daemon libvirt-daemon-system vagrant vagrant-libvirt
     systemctl enable --now libvirtd
 
   vagrant_cache:


### PR DESCRIPTION
- addresses https://github.com/containerd/containerd/pull/8714#issuecomment-1619859423

I saw Cirrus CI / Vagrant BOX:rockylinux/8@5.0.0 failing during setting up Vagrant, which may be due to other scripts provisioning the machine;

    Reading package lists...
    apt-get install -y libvirt-daemon libvirt-daemon-system vagrant vagrant-libvirt
    E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 2496 (apt-get)
    E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?

Configure dpkg to wait for locks to be released instead of failing. I used 60 second as timeout, which is relatively long, but given that the Vagrant checks are known to take some time to run, is probably fine.