### PR TITLE
Fix the automatically restart issue when using LogURI and Terminal together

### DIFF
--- a/cio/io.go
+++ b/cio/io.go
@@ -241,6 +241,20 @@ func LogURI(uri *url.URL) Creator {
 	}
 }
 
+// TerminalLogURI provides the raw logging URI
+// as well as sets the terminal option to true.
+func TerminalLogURI(uri *url.URL) Creator {
+	return func(_ string) (IO, error) {
+		return &logURI{
+			config: Config{
+				Stdout:   uri.String(),
+				Stderr:   uri.String(),
+				Terminal: true,
+			},
+		}, nil
+	}
+}
+
 // BinaryIO forwards container STDOUT|STDERR directly to a logging binary
 func BinaryIO(binary string, args map[string]string) Creator {
 	return func(_ string) (IO, error) {

--- a/runtime/restart/monitor/change.go
+++ b/runtime/restart/monitor/change.go
@@ -44,13 +44,21 @@ type startChange struct {
 
 func (s *startChange) apply(ctx context.Context, client *containerd.Client) error {
 	log := cio.NullIO
-
+	spec, err := s.container.Spec(ctx)
+	if err != nil {
+		return err
+	}
+	useTTY := spec.Process.Terminal
 	if s.logURI != "" {
 		uri, err := url.Parse(s.logURI)
 		if err != nil {
 			return fmt.Errorf("failed to parse %v into url: %w", s.logURI, err)
 		}
-		log = cio.LogURI(uri)
+		if useTTY {
+			log = cio.TerminalLogURI(uri)
+		} else {
+			log = cio.LogURI(uri)
+		}
 	}
 
 	if s.count > 0 {


### PR DESCRIPTION
The nerdctl run/create --restart always -dt with tty does not automatically restart. When the process of the container be killed, the containerd shows log :
```
error="failed to create shim task: OCI runtime create failed: runc create failed: cannot allocate tty if runc will detach without setting console socket: unknown"
```

Because the spec contains the {terminal : true} , it cannot be started successfully.

So the PR is to fix https://github.com/containerd/nerdctl/issues/2296 , like the same way as https://github.com/containerd/containerd/pull/7673
