### PR TITLE
Invoke stable ABI compliant platform check in windows matcher

### DIFF
--- a/pkg/transfer/streaming/stream.go
+++ b/pkg/transfer/streaming/stream.go
@@ -164,7 +164,7 @@ func ReceiveStream(ctx context.Context, stream streaming.Stream) io.Reader {
 			}
 			anyType, err := stream.Recv()
 			if err != nil {
-				if errors.Is(err, io.EOF) {
+				if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) {
 					err = nil
 				} else {
 					err = fmt.Errorf("received failed: %w", err)

--- a/platforms/defaults_windows.go
+++ b/platforms/defaults_windows.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Microsoft/hcsshim/osversion"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/sys/windows"
 )
@@ -50,13 +51,34 @@ func (m windowsmatcher) Match(p specs.Platform) bool {
 	match := m.defaultMatcher.Match(p)
 
 	if match && m.OS == "windows" {
-		if strings.HasPrefix(p.OSVersion, m.osVersionPrefix) {
+		// HPC containers do not have OS version filled
+		if p.OSVersion == "" {
 			return true
 		}
-		return p.OSVersion == ""
+
+		hostOsVersion := GetOsVersion(m.osVersionPrefix)
+		ctrOsVersion := GetOsVersion(p.OSVersion)
+		return osversion.CheckHostAndContainerCompat(hostOsVersion, ctrOsVersion)
 	}
 
 	return match
+}
+
+func GetOsVersion(osVersionPrefix string) osversion.OSVersion {
+	parts := strings.Split(osVersionPrefix, ".")
+	if len(parts) < 3 {
+		return osversion.OSVersion{}
+	}
+
+	majorVersion, _ := strconv.Atoi(parts[0])
+	minorVersion, _ := strconv.Atoi(parts[1])
+	buildNumber, _ := strconv.Atoi(parts[2])
+
+	return osversion.OSVersion{
+		MajorVersion: uint8(majorVersion),
+		MinorVersion: uint8(minorVersion),
+		Build:        uint16(buildNumber),
+	}
 }
 
 // Less sorts matched platforms in front of other platforms.

--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -213,6 +213,10 @@ func Parse(specifier string) (specs.Platform, error) {
 				p.Variant = cpuVariant()
 			}
 
+			if p.OS == "windows" {
+				p.OSVersion = GetWindowsOsVersion()
+			}
+
 			return p, nil
 		}
 
@@ -235,6 +239,10 @@ func Parse(specifier string) (specs.Platform, error) {
 			p.Variant = ""
 		}
 
+		if p.OS == "windows" {
+			p.OSVersion = GetWindowsOsVersion()
+		}
+
 		return p, nil
 	case 3:
 		// we have a fully specified variant, this is rare
@@ -242,6 +250,10 @@ func Parse(specifier string) (specs.Platform, error) {
 		p.Architecture, p.Variant = normalizeArch(parts[1], parts[2])
 		if p.Architecture == "arm64" && p.Variant == "" {
 			p.Variant = "v8"
+		}
+
+		if p.OS == "windows" {
+			p.OSVersion = GetWindowsOsVersion()
 		}
 
 		return p, nil

--- a/platforms/platforms_other.go
+++ b/platforms/platforms_other.go
@@ -28,3 +28,7 @@ func newDefaultMatcher(platform specs.Platform) Matcher {
 		Platform: Normalize(platform),
 	}
 }
+
+func GetWindowsOsVersion() string {
+	return ""
+}

--- a/platforms/platforms_windows.go
+++ b/platforms/platforms_windows.go
@@ -17,7 +17,10 @@
 package platforms
 
 import (
+	"fmt"
+
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/sys/windows"
 )
 
 // NewMatcher returns a Windows matcher that will match on osVersionPrefix if
@@ -31,4 +34,9 @@ func newDefaultMatcher(platform specs.Platform) Matcher {
 			Platform: Normalize(platform),
 		},
 	}
+}
+
+func GetWindowsOsVersion() string {
+	major, minor, build := windows.RtlGetNtVersionNumbers()
+	return fmt.Sprintf("%d.%d.%d", major, minor, build)
 }


### PR DESCRIPTION
This PR does the following:

-  Uses the function introduced by https://github.com/microsoft/hcsshim/pull/1821 to invoke stable ABI compliant function in windows platform matcher.  (In this PR, this change is limited to platforms/default_windows.go file. platform/default_windows_test.go file has some new tests added).
Exact platform match is required for OS Versions < WS2022. The exact version match is not needed in versions > WS2022 due to stable ABI compliance. 