### PR TITLE
[release/1.7] Fix net.ipv4.ping_group_range with userns

### DIFF
--- a/pkg/cri/sbserver/podsandbox/sandbox_run_linux.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_run_linux.go
@@ -148,6 +148,9 @@ func (c *Controller) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 		if c.config.EnableUnprivilegedPorts && !ipUnprivilegedPortStart {
 			sysctls["net.ipv4.ip_unprivileged_port_start"] = "0"
 		}
+		// TODO (rata): We need to set this only if the pod will
+		// **not** use user namespaces either.
+		// This will be done when user namespaces is ported to sbserver.
 		if c.config.EnableUnprivilegedICMP && !pingGroupRange && !userns.RunningInUserNS() {
 			sysctls["net.ipv4.ping_group_range"] = "0 2147483647"
 		}

--- a/pkg/cri/server/sandbox_run_linux.go
+++ b/pkg/cri/server/sandbox_run_linux.go
@@ -97,6 +97,7 @@ func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 
 	usernsOpts := nsOptions.GetUsernsOptions()
 	uids, gids, err := parseUsernsIDs(usernsOpts)
+	var usernsEnabled bool
 	if err != nil {
 		return nil, fmt.Errorf("user namespace configuration: %w", err)
 	}
@@ -107,6 +108,7 @@ func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 			specOpts = append(specOpts, customopts.WithoutNamespace(runtimespec.UserNamespace))
 		case runtime.NamespaceMode_POD:
 			specOpts = append(specOpts, oci.WithUserNamespace(uids, gids))
+			usernsEnabled = true
 		default:
 			return nil, fmt.Errorf("unsupported user namespace mode: %q", mode)
 		}
@@ -166,7 +168,7 @@ func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 		if c.config.EnableUnprivilegedPorts && !ipUnprivilegedPortStart {
 			sysctls["net.ipv4.ip_unprivileged_port_start"] = "0"
 		}
-		if c.config.EnableUnprivilegedICMP && !pingGroupRange && !userns.RunningInUserNS() {
+		if c.config.EnableUnprivilegedICMP && !pingGroupRange && !userns.RunningInUserNS() && !usernsEnabled {
 			sysctls["net.ipv4.ping_group_range"] = "0 2147483647"
 		}
 	}

--- a/pkg/cri/server/sandbox_run_linux_test.go
+++ b/pkg/cri/server/sandbox_run_linux_test.go
@@ -146,6 +146,26 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 				})
 			},
 		},
+		"spec shouldn't have ping_group_range if userns are in use": {
+			configChange: func(c *runtime.PodSandboxConfig) {
+				c.Linux.SecurityContext = &runtime.LinuxSandboxSecurityContext{
+					NamespaceOptions: &runtime.NamespaceOption{
+						UsernsOptions: &runtime.UserNamespace{
+							Mode: runtime.NamespaceMode_POD,
+							Uids: []*runtime.IDMapping{&idMap},
+							Gids: []*runtime.IDMapping{&idMap},
+						},
+					},
+				}
+			},
+			specCheck: func(t *testing.T, spec *runtimespec.Spec) {
+				require.NotNil(t, spec.Linux)
+				assert.Contains(t, spec.Linux.Namespaces, runtimespec.LinuxNamespace{
+					Type: runtimespec.UserNamespace,
+				})
+				assert.NotContains(t, spec.Linux.Sysctl["net.ipv4.ping_group_range"], "0 2147483647")
+			},
+		},
 		"host namespace": {
 			configChange: func(c *runtime.PodSandboxConfig) {
 				c.Linux.SecurityContext = &runtime.LinuxSandboxSecurityContext{


### PR DESCRIPTION
This is a backport of #8779 for release/1.7. This bug was triggered with containerd 1.7.1 and k3s, so backporting it to the 1.7 branch