### PR TITLE
Talking points around changing the network namespace name to SandboxName (or another value)

### DIFF
--- a/pkg/cri/sbserver/sandbox_run.go
+++ b/pkg/cri/sbserver/sandbox_run.go
@@ -154,7 +154,7 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 			netnsMountDir = filepath.Join(c.config.StateDir, "netns")
 		}
 
-		sandbox.NetNS, err = netns.NewNetNS(netnsMountDir, name)
+		sandbox.NetNS, err = netns.NewNetNS(netnsMountDir, fmt.Sprintf("cni-%s", name))
 		if err != nil {
 			return nil, fmt.Errorf("failed to create network namespace for sandbox %q: %w", id, err)
 		}

--- a/pkg/cri/sbserver/sandbox_run.go
+++ b/pkg/cri/sbserver/sandbox_run.go
@@ -154,15 +154,7 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 			netnsMountDir = filepath.Join(c.config.StateDir, "netns")
 		}
 
-		uid := config.GetMetadata().GetUid()
-
-		nsName, err := netns.BuildNetnsName(uid)
-
-		if err != nil {
-			return nil, err
-		}
-
-		sandbox.NetNS, err = netns.NewNetNS(netnsMountDir, nsName)
+		sandbox.NetNS, err = netns.NewNetNS(netnsMountDir, name)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create network namespace for sandbox %q: %w", id, err)
 		}

--- a/pkg/cri/sbserver/sandbox_run.go
+++ b/pkg/cri/sbserver/sandbox_run.go
@@ -153,7 +153,16 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		if c.config.NetNSMountsUnderStateDir {
 			netnsMountDir = filepath.Join(c.config.StateDir, "netns")
 		}
-		sandbox.NetNS, err = netns.NewNetNS(netnsMountDir)
+
+		uid := config.GetMetadata().GetUid()
+
+		nsName, err := netns.BuildNetnsName(uid)
+
+		if err != nil {
+			return nil, err
+		}
+
+		sandbox.NetNS, err = netns.NewNetNS(netnsMountDir, nsName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create network namespace for sandbox %q: %w", id, err)
 		}

--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -282,15 +282,7 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 			netnsMountDir = filepath.Join(c.config.StateDir, "netns")
 		}
 
-		uid := config.GetMetadata().GetUid()
-
-		nsName, err := netns.BuildNetnsName(uid)
-
-		if err != nil {
-			return nil, err
-		}
-
-		sandbox.NetNS, err = netns.NewNetNS(netnsMountDir, nsName)
+		sandbox.NetNS, err = netns.NewNetNS(netnsMountDir, name)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create network namespace for sandbox %q: %w", id, err)
 		}
@@ -408,15 +400,7 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 			netnsMountDir = filepath.Join(c.config.StateDir, "netns")
 		}
 
-		uid := config.GetMetadata().GetUid()
-
-		nsName, err := netns.BuildNetnsName(uid)
-
-		if err != nil {
-			return nil, err
-		}
-
-		sandbox.NetNS, err = netns.NewNetNSFromPID(netnsMountDir, nsName, task.Pid())
+		sandbox.NetNS, err = netns.NewNetNSFromPID(netnsMountDir, name, task.Pid())
 		if err != nil {
 			return nil, fmt.Errorf("failed to create network namespace for sandbox %q: %w", id, err)
 		}

--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -282,7 +282,7 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 			netnsMountDir = filepath.Join(c.config.StateDir, "netns")
 		}
 
-		sandbox.NetNS, err = netns.NewNetNS(netnsMountDir, name)
+		sandbox.NetNS, err = netns.NewNetNS(netnsMountDir, fmt.Sprintf("cni-%s", name))
 		if err != nil {
 			return nil, fmt.Errorf("failed to create network namespace for sandbox %q: %w", id, err)
 		}
@@ -400,7 +400,7 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 			netnsMountDir = filepath.Join(c.config.StateDir, "netns")
 		}
 
-		sandbox.NetNS, err = netns.NewNetNSFromPID(netnsMountDir, name, task.Pid())
+		sandbox.NetNS, err = netns.NewNetNSFromPID(netnsMountDir, fmt.Sprintf("cni-%s", name), task.Pid())
 		if err != nil {
 			return nil, fmt.Errorf("failed to create network namespace for sandbox %q: %w", id, err)
 		}

--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -281,7 +281,16 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		if c.config.NetNSMountsUnderStateDir {
 			netnsMountDir = filepath.Join(c.config.StateDir, "netns")
 		}
-		sandbox.NetNS, err = netns.NewNetNS(netnsMountDir)
+
+		uid := config.GetMetadata().GetUid()
+
+		nsName, err := netns.BuildNetnsName(uid)
+
+		if err != nil {
+			return nil, err
+		}
+
+		sandbox.NetNS, err = netns.NewNetNS(netnsMountDir, nsName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create network namespace for sandbox %q: %w", id, err)
 		}
@@ -398,7 +407,16 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		if c.config.NetNSMountsUnderStateDir {
 			netnsMountDir = filepath.Join(c.config.StateDir, "netns")
 		}
-		sandbox.NetNS, err = netns.NewNetNSFromPID(netnsMountDir, task.Pid())
+
+		uid := config.GetMetadata().GetUid()
+
+		nsName, err := netns.BuildNetnsName(uid)
+
+		if err != nil {
+			return nil, err
+		}
+
+		sandbox.NetNS, err = netns.NewNetNSFromPID(netnsMountDir, nsName, task.Pid())
 		if err != nil {
 			return nil, fmt.Errorf("failed to create network namespace for sandbox %q: %w", id, err)
 		}

--- a/pkg/netns/netns_linux.go
+++ b/pkg/netns/netns_linux.go
@@ -32,7 +32,6 @@
 package netns
 
 import (
-	"crypto/rand"
 	"fmt"
 	"os"
 	"path"
@@ -130,24 +129,6 @@ func newNS(baseDir, name string, pid uint32) (nsPath string, err error) {
 	}
 
 	return nsPath, nil
-}
-
-func BuildNetnsName(value string) (string, error) {
-
-	if value == "" {
-		b := make([]byte, 16)
-
-		_, err := rand.Read(b)
-		if err != nil {
-			return "", fmt.Errorf("failed to generate random netns name: %w", err)
-		}
-
-		nsName := fmt.Sprintf("cni-%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
-
-		return nsName, nil
-	} else {
-		return fmt.Sprintf("cni-%s", value), nil
-	}
 }
 
 // unmountNS unmounts the NS held by the netns object. unmountNS is idempotent.

--- a/pkg/netns/netns_other.go
+++ b/pkg/netns/netns_other.go
@@ -30,12 +30,12 @@ type NetNS struct {
 }
 
 // NewNetNS creates a network namespace.
-func NewNetNS(baseDir string) (*NetNS, error) {
+func NewNetNS(baseDir, name string) (*NetNS, error) {
 	return nil, errNotImplementedOnUnix
 }
 
 // NewNetNS returns the netns from pid or a new netns if pid is 0.
-func NewNetNSFromPID(baseDir string, pid uint32) (*NetNS, error) {
+func NewNetNSFromPID(baseDir, name string, pid uint32) (*NetNS, error) {
 	return nil, errNotImplementedOnUnix
 }
 

--- a/pkg/netns/netns_windows.go
+++ b/pkg/netns/netns_windows.go
@@ -30,7 +30,7 @@ type NetNS struct {
 }
 
 // NewNetNS creates a network namespace for the sandbox.
-func NewNetNS(baseDir string) (*NetNS, error) {
+func NewNetNS(baseDir, name string) (*NetNS, error) {
 	temp := hcn.HostComputeNamespace{}
 	hcnNamespace, err := temp.Create()
 	if err != nil {
@@ -41,7 +41,7 @@ func NewNetNS(baseDir string) (*NetNS, error) {
 }
 
 // NewNetNSFromPID returns the netns from pid or a new netns if pid is 0.
-func NewNetNSFromPID(baseDir string, pid uint32) (*NetNS, error) {
+func NewNetNSFromPID(baseDir, name string, pid uint32) (*NetNS, error) {
 	return nil, errNotImplementedOnWindows
 }
 


### PR DESCRIPTION
Currently the network namespace path is randomly generated, and I am proposing we change it to a value that is accessible from the Pod specification. This is to make development and troubleshooting easier. To figure out the network namespace path for troubleshooting you need to use crictl and inspectp on the pod id. A few other ways exist. For development, the current approach for getting the network namespace is having a custom cni plugin cache the network namespace to disk or interrogating the cni cache. Setting the network namespace path to something that a user could easily use kubectl or another means makes life easier. 

-=Draft Code=-
Troubleshooting with proposal:
UID=$(kubectl get pods -n <namespace> <pod-name> -o jsonpath='{.metadata.uid}')
ip netns exec $UID tshark -i eth0
