### PR TITLE
add snapshot mountinfo for cri containerstatus interface

### DIFF
--- a/pkg/cri/server/container_status.go
+++ b/pkg/cri/server/container_status.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/mount"
 	containerstore "github.com/containerd/containerd/pkg/cri/store/container"

--- a/pkg/cri/server/container_status.go
+++ b/pkg/cri/server/container_status.go
@@ -69,7 +69,7 @@ func (c *criService) ContainerStatus(ctx context.Context, r *runtime.ContainerSt
 		}
 		status.CreatedAt = info.CreatedAt.UnixNano()
 	}
-	snapshot, err := c.snapshotStore.Get(r.GetContainerId())
+	snapshot, err := c.snapshotStore.Get(status.GetId())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get container snapshot info: %w", err)
 	}

--- a/pkg/cri/server/container_status_test.go
+++ b/pkg/cri/server/container_status_test.go
@@ -18,9 +18,10 @@ package server
 
 import (
 	"context"
-	snapshotstore "github.com/containerd/containerd/pkg/cri/store/snapshot"
 	"testing"
 	"time"
+
+	snapshotstore "github.com/containerd/containerd/pkg/cri/store/snapshot"
 
 	"github.com/stretchr/testify/assert"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"

--- a/pkg/cri/server/container_status_test.go
+++ b/pkg/cri/server/container_status_test.go
@@ -18,6 +18,7 @@ package server
 
 import (
 	"context"
+	snapshotstore "github.com/containerd/containerd/pkg/cri/store/snapshot"
 	"testing"
 	"time"
 
@@ -173,7 +174,7 @@ func TestToCRIContainerInfo(t *testing.T) {
 	assert.NoError(t, err)
 
 	info, err := toCRIContainerInfo(context.Background(),
-		container,
+		container, snapshotstore.Snapshot{},
 		false)
 	assert.NoError(t, err)
 	assert.Nil(t, info)

--- a/pkg/cri/server/snapshots.go
+++ b/pkg/cri/server/snapshots.go
@@ -104,6 +104,11 @@ func (s *snapshotsSyncer) sync() error {
 			}
 			continue
 		}
+		mounts, err := s.snapshotter.Mounts(ctx, info.Name)
+		if err != nil {
+			log.L.WithError(err).Errorf("Failed to get mounts for snapshot %q", info.Name)
+		}
+		sn.Mounts = mounts
 		sn.Size = uint64(usage.Size)
 		sn.Inodes = uint64(usage.Inodes)
 		s.store.Add(sn)

--- a/pkg/cri/server/snapshots.go
+++ b/pkg/cri/server/snapshots.go
@@ -106,7 +106,7 @@ func (s *snapshotsSyncer) sync() error {
 		}
 		mounts, err := s.snapshotter.Mounts(ctx, info.Name)
 		if err != nil {
-			log.L.WithError(err).Errorf("Failed to get mounts for snapshot %q", info.Name)
+			log.L.WithError(err).Warningf("Failed to get mounts for snapshot %q,info %q.", info.Name, info.Kind)
 		}
 		sn.Mounts = mounts
 		sn.Size = uint64(usage.Size)

--- a/pkg/cri/store/snapshot/snapshot.go
+++ b/pkg/cri/store/snapshot/snapshot.go
@@ -17,10 +17,11 @@
 package snapshot
 
 import (
+	"sync"
+
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/mount"
 	snapshot "github.com/containerd/containerd/snapshots"
-	"sync"
 )
 
 // Snapshot contains the information about the snapshot.

--- a/pkg/cri/store/snapshot/snapshot.go
+++ b/pkg/cri/store/snapshot/snapshot.go
@@ -17,10 +17,10 @@
 package snapshot
 
 import (
-	"sync"
-
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/mount"
 	snapshot "github.com/containerd/containerd/snapshots"
+	"sync"
 )
 
 // Snapshot contains the information about the snapshot.
@@ -36,6 +36,8 @@ type Snapshot struct {
 	// Timestamp is latest update time (in nanoseconds) of the snapshot
 	// information.
 	Timestamp int64
+	// Mounts is the mount detail of the snapshot
+	Mounts []mount.Mount
 }
 
 // Store stores all snapshots.


### PR DESCRIPTION
Some log collection components run on nodes in the form of a daemonset, and they collect container logs by calling the runtime interface to obtain the path of files inside the container on the host. With the Docker client, container rootfs path can be obtained, including the **UpperDir**. We hope to obtain similar information through the containerd cri serve.

Docker
```
        "GraphDriver": {
            "Data": {
                "LowerDir": "",
                "MergedDir": "",
                "UpperDir": "",
                "WorkDir": ""
            },
            "Name": "overlay2"
        },
```

containerd
```
ctr -n=k8s.io snapshot m overlayfs 06c9a374196385728e0a5065cf65f70b88c8fe03a5ac8b6866e0b1d175781576
mount -t overlay overlay overlayfs -o index=off,workdir=/home/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/6371/work,upperdir=/home/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/6371/fs,lowerdir=/home/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/6365/fs:/home/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/6359/fs:/home/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/6358/fs:/home/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/6178/fs:/home/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/6177/fs:/home/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/6176/fs:/home/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/6174/fs:/home/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/6172/fs:/home/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/6168/fs:/home/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/6167/fs:/home/containerd/root/io.containerd.snapshotter.v1.overlayfs/snapshots/4745/fs
```

fixes: https://github.com/containerd/containerd/issues/8794