### PR TITLE
Modify loopback size

### DIFF
--- a/snapshots/blockfile/blockfile_loopsetup_test.go
+++ b/snapshots/blockfile/blockfile_loopsetup_test.go
@@ -36,7 +36,7 @@ func setupSnapshotter(t *testing.T) ([]Opt, error) {
 
 	loopbackSize := int64(8 << 20) // 8 MB
 	if os.Getpagesize() > 4096 {
-		loopbackSize = int64(650 << 20) // 650 MB
+		loopbackSize = int64(16 << 20) // 16 MB
 	}
 
 	scratch := filepath.Join(t.TempDir(), "scratch")


### PR DESCRIPTION
Modify the loopback size in the blockfile snapshotter test setup. Set the loopback size to 16MB when the page size is greater than 4096. This prevents smaller storage devices from running out of free space while the test is running. Addresses issue #8767.