### PR TITLE
[release/1.7] Resolve docker.NewResolver race condition

### DIFF
--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -148,7 +148,11 @@ func NewResolver(options ResolverOptions) remotes.Resolver {
 
 	if options.Headers == nil {
 		options.Headers = make(http.Header)
+	} else {
+		// make a copy of the headers to avoid race due to concurrent map write
+		options.Headers = options.Headers.Clone()
 	}
+
 	if _, ok := options.Headers["User-Agent"]; !ok {
 		options.Headers.Set("User-Agent", "containerd/"+version.Version)
 	}

--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -152,7 +152,6 @@ func NewResolver(options ResolverOptions) remotes.Resolver {
 		// make a copy of the headers to avoid race due to concurrent map write
 		options.Headers = options.Headers.Clone()
 	}
-
 	if _, ok := options.Headers["User-Agent"]; !ok {
 		options.Headers.Set("User-Agent", "containerd/"+version.Version)
 	}
@@ -547,9 +546,10 @@ func (r *request) do(ctx context.Context) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header = http.Header{} // headers need to be copied to avoid concurrent map access
-	for k, v := range r.header {
-		req.Header[k] = v
+	if r.header == nil {
+		req.Header = http.Header{}
+	} else {
+		req.Header = r.header.Clone() // headers need to be copied to avoid concurrent map access
 	}
 	if r.body != nil {
 		body, err := r.body()


### PR DESCRIPTION
Backport #8748 to 1.7

Fix #8742

It can be reproduced with the added test:

```shell
# without the change:
$ go test -race ./remotes/docker/...
?       github.com/containerd/containerd/remotes/docker/schema1 [no test files]
==================
WARNING: DATA RACE
Read at 0x00c0003e08a0 by goroutine 189:
  runtime.mapaccess2_faststr()
      /usr/local/go/src/runtime/map_faststr.go:108 +0x0
  github.com/containerd/containerd/remotes/docker.NewResolver()
      /home/azureuser/code/containerd/remotes/docker/resolver.go:157 +0x22c
  github.com/containerd/containerd/remotes/docker.runBasicTest()
...

# with the change
$ go test -race ./remotes/docker/...
?       github.com/containerd/containerd/remotes/docker/schema1 [no test files]
ok      github.com/containerd/containerd/remotes/docker 0.677s
ok      github.com/containerd/containerd/remotes/docker/auth    (cached)
ok      github.com/containerd/containerd/remotes/docker/config  0.046s
```