### PR TITLE
[release/1.7 backport] Update Go to 1.20.6,1.19.11

### DIFF
--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.20.5"
+          go-version: "1.20.6"
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 env:
   # Go version we currently use to build containerd across all CI.
   # Note: don't forget to update `Binaries` step, as it contains the matrix of all supported Go versions.
-  GO_VERSION: "1.20.5"
+  GO_VERSION: "1.20.6"
 
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read
@@ -207,7 +207,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-12, windows-2019, windows-2022]
-        go-version: ["1.20.5", "1.19.10"]
+        go-version: ["1.20.6", "1.19.11"]
     steps:
       - uses: actions/setup-go@v3
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.20.5
+          go-version: 1.20.6
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.20.5"
+          go-version: "1.20.6"
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,7 +7,7 @@ on:
       - ".github/workflows/nightly.yml"
 
 env:
-  GO_VERSION: "1.20.5"
+  GO_VERSION: "1.20.6"
 
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 name: Release
 
 env:
-  GO_VERSION: "1.20.5"
+  GO_VERSION: "1.20.6"
 
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -101,7 +101,7 @@ EOF
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.20.5",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.20.6",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -29,7 +29,7 @@
 #   docker run --privileged containerd-test
 # ------------------------------------------------------------------------------
 
-ARG GOLANG_VERSION=1.20.5
+ARG GOLANG_VERSION=1.20.6
 ARG GOLANG_IMAGE=golang
 
 FROM ${GOLANG_IMAGE}:${GOLANG_VERSION} AS golang

--- a/script/setup/prepare_env_windows.ps1
+++ b/script/setup/prepare_env_windows.ps1
@@ -5,7 +5,7 @@
 # lived test environment.
 Set-MpPreference -DisableRealtimeMonitoring:$true
 
-$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.20.5"; make = ""; nssm = "" }
+$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.20.6"; make = ""; nssm = "" }
 
 Write-Host "Downloading chocolatey package"
 curl.exe -L "https://packages.chocolatey.org/chocolatey.0.10.15.nupkg" -o 'c:\choco.zip'


### PR DESCRIPTION
- backport of https://github.com/containerd/containerd/pull/8804


go1.20.6 (released 2023-07-11) includes a security fix to the net/http package, as well as bug fixes to the compiler, cgo, the cover tool, the go command, the runtime, and the crypto/ecdsa, go/build, go/printer, net/mail, and text/template packages. See the Go 1.20.6 milestone on our issue tracker for details.

https://github.com/golang/go/issues?q=milestone%3AGo1.20.6+label%3ACherryPickApproved

Full diff: https://github.com/golang/go/compare/go1.20.5...go1.20.6

These minor releases include 1 security fixes following the security policy:

- net/http: insufficient sanitization of Host header

The HTTP/1 client did not fully validate the contents of the Host header. A maliciously crafted Host header could inject additional headers or entire requests. The HTTP/1 client now refuses to send requests containing an invalid Request.Host or Request.URL.Host value.

Thanks to Bartek Nowotarski for reporting this issue.

Includes security fixes for CVE-2023-29406 and Go issue https://go.dev/issue/60374


(cherry picked from commit 52ef3468bcdb971a22ec2288808f14cc763f3c7b)