### PR TITLE
[release/1.6 backport] release: Add "cri-containerd.DEPRECATED.txt" in the deprecated cri-containerd-* bundles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,22 +332,26 @@ install-cri-deps: $(BINARIES)
 	@$(INSTALL) $(BINARIES) $(CRIDIR)/bin
 endif
 
+$(CRIDIR)/cri-containerd.DEPRECATED.txt:
+	@mkdir -p $(CRIDIR)
+	@$(INSTALL) -m 644 releases/cri-containerd.DEPRECATED.txt $@
+
 ifeq ($(GOOS),windows)
-releases/$(CRIRELEASE).tar.gz: install-cri-deps
+releases/$(CRIRELEASE).tar.gz: install-cri-deps $(CRIDIR)/cri-containerd.DEPRECATED.txt
 	@echo "$(WHALE) $@"
 	@cd $(CRIDIR) && tar -czf ../../releases/$(CRIRELEASE).tar.gz *
 
-releases/$(CRICNIRELEASE).tar.gz: install-cri-deps
+releases/$(CRICNIRELEASE).tar.gz: install-cri-deps $(CRIDIR)/cri-containerd.DEPRECATED.txt
 	@echo "$(WHALE) $@"
 	@cd $(CRIDIR) && tar -czf ../../releases/$(CRICNIRELEASE).tar.gz *
 else
-releases/$(CRIRELEASE).tar.gz: install-cri-deps
+releases/$(CRIRELEASE).tar.gz: install-cri-deps $(CRIDIR)/cri-containerd.DEPRECATED.txt
 	@echo "$(WHALE) $@"
-	@tar -czf releases/$(CRIRELEASE).tar.gz -C $(CRIDIR) etc/crictl.yaml etc/systemd usr opt/containerd
+	@tar -czf releases/$(CRIRELEASE).tar.gz -C $(CRIDIR) cri-containerd.DEPRECATED.txt etc/crictl.yaml etc/systemd usr opt/containerd
 
-releases/$(CRICNIRELEASE).tar.gz: install-cri-deps
+releases/$(CRICNIRELEASE).tar.gz: install-cri-deps $(CRIDIR)/cri-containerd.DEPRECATED.txt
 	@echo "$(WHALE) $@"
-	@tar -czf releases/$(CRICNIRELEASE).tar.gz -C $(CRIDIR) etc usr opt
+	@tar -czf releases/$(CRICNIRELEASE).tar.gz -C $(CRIDIR) cri-containerd.DEPRECATED.txt etc usr opt
 endif
 
 cri-release: releases/$(CRIRELEASE).tar.gz

--- a/releases/cri-containerd.DEPRECATED.txt
+++ b/releases/cri-containerd.DEPRECATED.txt
@@ -1,0 +1,12 @@
+The "cri-containerd-(cni-)-VERSION-OS-ARCH.tar.gz" release bundle has been deprecated since containerd 1.6,
+does not work on some Linux distributions, and will be removed in containerd 2.0.
+
+Instead of this, install the following components separately, either from the binary or from the source:
+* containerd:  https://github.com/containerd/containerd/releases
+* runc:        https://github.com/opencontainers/runc/releases
+* CNI plugins: https://github.com/containernetworking/plugins/releases
+
+The CRI plugin has been included in containerd since containerd 1.1.
+
+See also the "Getting started" document:
+https://github.com/containerd/containerd/blob/main/docs/getting-started.md


### PR DESCRIPTION
- backport of https://github.com/containerd/containerd/pull/8019

(cherry picked from commit b473c2922f6fb8e2d7dca86d4717a7dfbba03032)

----

Add the following document (`"cri-containerd.DEPRECATED.txt"`) in the deprecated `cri-containerd-*` bundles, to provide more visibility:

```
The "cri-containerd-(cni-)-VERSION-OS-ARCH.tar.gz" release bundle has been deprecated since containerd 1.6,
does not work on some Linux distributions, and will be removed in containerd 2.0.

Instead of this, install the following components separately, either from the binary or from the source:
* containerd:  https://github.com/containerd/containerd/releases
* runc:        https://github.com/opencontainers/runc/releases
* CNI plugins: https://github.com/containernetworking/plugins/releases

The CRI plugin has been included in containerd since containerd 1.1.

See also the "Getting started" document:
https://github.com/containerd/containerd/blob/main/docs/getting-started.md
```

The `*.md` file extension is intentionally avoided for doubleclickability with `notepad.exe`, `TextEdit.app`, etc.

