### PR TITLE
[release/1.6 backport] Use version 2 configuration format in docs

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -233,35 +233,16 @@ to load.
 #### Configuration
 
 Plugins are configured using the `[plugins]` section of containerd's config.
-Every plugin can have its own section using the pattern `[plugins.<plugin id>]`.
+Every plugin can have its own section using the pattern `[plugins."<plugin type>.<plugin id>"]`.
 
 example configuration
 ```
+version = 2
+
 [plugins]
-  [plugins.cgroups]
+  [plugins."io.containerd.monitor.v1.cgroups"]
     no_prometheus = false
-  [plugins.cri]
-    stream_server_address = ""
-    stream_server_port = "10010"
-    enable_selinux = false
-    sandbox_image = "k8s.gcr.io/pause:3.6"
-    stats_collect_period = 10
-    systemd_cgroup = false
-    [plugins.cri.containerd]
-      snapshotter = "overlayfs"
-      [plugins.cri.containerd.default_runtime]
-        runtime_type = "io.containerd.runtime.v1.linux"
-        runtime_engine = ""
-        runtime_root = ""
-      [plugins.cri.containerd.untrusted_workload_runtime]
-        runtime_type = ""
-        runtime_engine = ""
-        runtime_root = ""
-    [plugins.cri.cni]
-      bin_dir = "/opt/cni/bin"
-      conf_dir = "/etc/cni/net.d"
-    [plugins.cri.registry]
-      [plugins.cri.registry.mirrors]
-        [plugins.cri.registry.mirrors."docker.io"]
-          endpoint = ["https://registry-1.docker.io"]
 ```
+
+To see full configuration example run `containerd config default`.
+If you want to get the configuration combined with your configuration, run `containerd config dump`.

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -50,7 +50,9 @@ section for your given plugin `[proxy_plugins.myplugin]`. The `address` must
 refer to a local socket file which the containerd process has access to. The
 currently supported types are `snapshot` and `content`.
 
-```
+```toml
+version = 2
+
 [proxy_plugins]
   [proxy_plugins.customsnapshot]
     type = "snapshot"
@@ -236,7 +238,7 @@ Plugins are configured using the `[plugins]` section of containerd's config.
 Every plugin can have its own section using the pattern `[plugins."<plugin type>.<plugin id>"]`.
 
 example configuration
-```
+```toml
 version = 2
 
 [plugins]
@@ -246,3 +248,26 @@ version = 2
 
 To see full configuration example run `containerd config default`.
 If you want to get the configuration combined with your configuration, run `containerd config dump`.
+
+##### Version header
+
+containerd has two configuration versions:
+- Version 2 (Recommended): Introduced in containerd 1.3.
+- Version 1 (Default): Introduced in containerd 1.0. Deprecated and will be removed in containerd 2.0.
+
+A configuration with Version 2 must have `version = 2` header, and must have
+fully qualified plugin IDs in the `[plugins]` section:
+```toml
+version = 2
+
+[plugins]
+  [plugins."io.containerd.monitor.v1.cgroups"]
+    no_prometheus = false
+```
+
+A configuration with Version 1 may not have `version` header, and does not need fully qualified plugin IDs.
+```toml
+[plugins]
+  [plugins.cgroups]
+    no_prometheus = false
+```

--- a/docs/garbage-collection.md
+++ b/docs/garbage-collection.md
@@ -140,8 +140,9 @@ configuration is under the `scheduler` plugin.
 
 The default configuration is represented as...
 ```.toml
+version = 2
 [plugins]
-  [plugins.scheduler]
+  [plugins."io.containerd.gc.v1.scheduler"]
     pause_threshold = 0.02
     deletion_threshold = 0
     mutation_threshold = 100

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -34,6 +34,8 @@ been **DEPRECATED**._ You should now point your registry `config_path` to the pa
 
 Modify your `config.toml` (default location: `/etc/containerd/config.toml`) as follows:
 ```toml
+version = 2
+
 [plugins."io.containerd.grpc.v1.cri".registry]
    config_path = "/etc/containerd/certs.d"
 ```

--- a/docs/man/containerd-config.toml.5.md
+++ b/docs/man/containerd-config.toml.5.md
@@ -155,7 +155,7 @@ the main config.
 
 The following is a complete **config.toml** default configuration example:
 
-```
+```toml
 version = 2
 
 root = "/var/lib/containerd"
@@ -182,7 +182,7 @@ imports = ["/etc/containerd/runtime_*.toml", "./debug.toml"]
   path = ""
 
 [plugins]
-  [[plugins."io.containerd.monitor.v1.cgroups"]
+  [plugins."io.containerd.monitor.v1.cgroups"]
     no_prometheus = false
   [plugins."io.containerd.service.v1.diff-service"]
     default = ["walking"]

--- a/docs/man/containerd-config.toml.5.md
+++ b/docs/man/containerd-config.toml.5.md
@@ -87,7 +87,7 @@ documentation.
 
 - **[plugins."io.containerd.monitor.v1.cgroups"]** has one option __no_prometheus__ (Default: **false**)
 - **[plugins."io.containerd.service.v1.diff-service"]** has one option __default__, a list by default set to **["walking"]**
-- **[plugins.linux]** has several options for configuring the runtime, shim, and related options:
+- **[plugins."io.containerd.runtime.v1.linux"]** has several options for configuring the runtime, shim, and related options:
   - **shim** specifies the shim binary (Default: **"containerd-shim"**),
   - **runtime** is the OCI compliant runtime binary (Default: **"runc"**),
   - **runtime_root** is the root directory used by the runtime (Default: **""**),
@@ -186,7 +186,7 @@ imports = ["/etc/containerd/runtime_*.toml", "./debug.toml"]
     no_prometheus = false
   [plugins."io.containerd.service.v1.diff-service"]
     default = ["walking"]
-  [plugins.linux]
+  [plugins."io.containerd.runtime.v1.linux"]
     shim = "containerd-shim"
     runtime = "runc"
     runtime_root = ""

--- a/docs/man/containerd-config.toml.5.md
+++ b/docs/man/containerd-config.toml.5.md
@@ -1,4 +1,4 @@
-# /etc/containerd/config.toml 5 08/08/2018
+# /etc/containerd/config.toml 5 04/05/2022
 
 ## NAME
 
@@ -85,8 +85,8 @@ The following plugins are enabled by default and their settings are shown below.
 Plugins that are not enabled by default will provide their own configuration values
 documentation.
 
-- **[plugins.cgroup]** has one option __no_prometheus__ (Default: **false**)
-- **[plugins.diff]** has one option __default__, a list by default set to **["walking"]**
+- **[plugins."io.containerd.monitor.v1.cgroups"]** has one option __no_prometheus__ (Default: **false**)
+- **[plugins."io.containerd.service.v1.diff-service"]** has one option __default__, a list by default set to **["walking"]**
 - **[plugins.linux]** has several options for configuring the runtime, shim, and related options:
   - **shim** specifies the shim binary (Default: **"containerd-shim"**),
   - **runtime** is the OCI compliant runtime binary (Default: **"runc"**),
@@ -99,7 +99,7 @@ documentation.
   - **mutation_threshold** guarantees GC is scheduled after n number of database mutations (Default: **100**),
   - **schedule_delay** defines the delay after trigger event before scheduling a GC (Default **"0ms"** [immediate]),
   - **startup_delay** defines the delay after startup before scheduling a GC (Default **"100ms"**)
-- **[plugins."io.containerd.runtime-shim.v2.shim"]** specifies options for configuring the runtime shim:
+- **[plugins."io.containerd.runtime.v2.task"]** specifies options for configuring the runtime shim:
   - **platforms** specifies the list of supported platforms
   - **sched_core** Core scheduling is a feature that allows only trusted tasks
     to run concurrently on cpus sharing compute resources (eg: hyperthreads on
@@ -156,6 +156,8 @@ the main config.
 The following is a complete **config.toml** default configuration example:
 
 ```
+version = 2
+
 root = "/var/lib/containerd"
 state = "/run/containerd"
 oom_score = 0
@@ -180,9 +182,9 @@ imports = ["/etc/containerd/runtime_*.toml", "./debug.toml"]
   path = ""
 
 [plugins]
-  [plugins.cgroups]
+  [[plugins."io.containerd.monitor.v1.cgroups"]
     no_prometheus = false
-  [plugins.diff]
+  [plugins."io.containerd.service.v1.diff-service"]
     default = ["walking"]
   [plugins.linux]
     shim = "containerd-shim"
@@ -190,13 +192,13 @@ imports = ["/etc/containerd/runtime_*.toml", "./debug.toml"]
     runtime_root = ""
     no_shim = false
     shim_debug = false
-  [plugins.scheduler]
+  [plugins."io.containerd.gc.v1.scheduler"]
     pause_threshold = 0.02
     deletion_threshold = 0
     mutation_threshold = 100
     schedule_delay = 0
     startup_delay = "100ms"
-  [plugins."io.containerd.runtime-shim.v2.shim"]
+  [plugins."io.containerd.runtime.v2.task"]
     platforms = ["linux/amd64"]
     sched_core = true
   [plugins."io.containerd.service.v1.tasks-service"]

--- a/docs/managed-opt.md
+++ b/docs/managed-opt.md
@@ -11,7 +11,9 @@ Configuration:
 
 *containerd config:*
 ```toml
-[plugins.opt]
+version = 2
+
+[plugins."io.containerd.internal.v1.opt"]
 	path = "/opt/mypath"
 
 ```

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -205,7 +205,9 @@ See [containerd's Plugin documentation](./PLUGINS.md)
 The linux runtime allows a few options to be set to configure the shim and the runtime that you are using.
 
 ```toml
-[plugins.linux]
+version = 2
+
+[plugins."io.containerd.runtime.v1.linux"]
 	# shim binary name/path
 	shim = ""
 	# runtime binary name/path

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -154,6 +154,8 @@ They should not be tampered with as corruption and bugs can and will happen.
 External apps reading or watching changes in these directories have been known to cause `EBUSY` and stale file handles when containerd and/or its plugins try to cleanup resources.
 
 ```toml
+version = 2
+
 # persistent data location
 root = "/var/lib/containerd"
 # runtime state information
@@ -229,6 +231,8 @@ Both modes share backing data, while "shared" will reduce total bandwidth across
 The default is "shared". While this is largely the most desired policy, one can change to "isolated" mode with the following configuration:
 
 ```toml
-[plugins.bolt]
+version = 2
+
+[plugins."io.containerd.metadata.v1.bolt"]
 	content_sharing_policy = "isolated"
 ```

--- a/docs/stream_processors.md
+++ b/docs/stream_processors.md
@@ -33,6 +33,8 @@ Processor Fields:
 * `args` - Arguments passed to the processor binary.
 
 ```toml
+version = 2
+
 [stream_processors]
   [stream_processors."io.containerd.processor.v1.pigz"]
 	accepts = ["application/vnd.docker.image.rootfs.diff.tar.gzip"]

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -9,6 +9,8 @@ By configuring `io.containerd.tracing.processor.v1.otlp` plugin.
 containerd daemon can send traces to the specified OpenTelemetry endpoint.
 
 ```toml
+version = 2
+
 [plugins."io.containerd.tracing.processor.v1.otlp"]
     endpoint = "http://localhost:4318"
 ```
@@ -26,6 +28,8 @@ The sampling ratio and the service name on the traces could be configured by
 `io.containerd.internal.v1.tracing` plugin.
 
 ```toml
+version = 2
+
 [plugins."io.containerd.internal.v1.tracing"]
     sampling_ratio = 1.0
     service_name = "containerd"

--- a/snapshots/devmapper/README.md
+++ b/snapshots/devmapper/README.md
@@ -10,10 +10,12 @@ This file is typically located at `/etc/containerd/config.toml`.
 
 Here's minimal sample entry that can be made in the configuration file:
 
-```
+```toml
+version = 2
+
 [plugins]
   ...
-  [plugins.devmapper]
+  [plugins."io.containerd.snapshotter.v1.devmapper"]
     pool_name = "containerd-pool"
     base_image_size = "8192MB"
   ...


### PR DESCRIPTION
backport of:

- https://github.com/containerd/containerd/commit/195fc74244043d4ca3fd47cb2498e77fb6df95ec
- https://github.com/containerd/containerd/pull/6613
- https://github.com/containerd/containerd/pull/7174


Also had to add an extra commit for this branch, because 84cebafe8f6e69bbd1d9b80873eedd95847b9214 removed the "plugins.linux" example from the docs, so the follow-up commit didn't update that part of the docs (195fc74244043d4ca3fd47cb2498e77fb6df95ec)