### PR TITLE
[release/1.6 backport] Add cleanup package for context management during cleanup

### DIFF
--- a/pkg/cleanup/context.go
+++ b/pkg/cleanup/context.go
@@ -1,0 +1,52 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package providing utilies to help cleanup
+package cleanup
+
+import (
+	"context"
+	"time"
+)
+
+type clearCancel struct {
+	context.Context
+}
+
+func (cc clearCancel) Deadline() (deadline time.Time, ok bool) {
+	return
+}
+
+func (cc clearCancel) Done() <-chan struct{} {
+	return nil
+}
+
+func (cc clearCancel) Err() error {
+	return nil
+}
+
+// Background creates a new context which clears out the parent errors
+func Background(ctx context.Context) context.Context {
+	return clearCancel{ctx}
+}
+
+// Do runs the provided function with a context in which the
+// errors are cleared out and will timeout after 10 seconds.
+func Do(ctx context.Context, do func(context.Context)) {
+	ctx, cancel := context.WithTimeout(clearCancel{ctx}, 10*time.Second)
+	do(ctx)
+	cancel()
+}

--- a/pkg/cleanup/context_test.go
+++ b/pkg/cleanup/context_test.go
@@ -1,0 +1,58 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cleanup
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBackground(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var k struct{}
+	v := "incontext"
+	ctx = context.WithValue(ctx, k, v)
+
+	assert.Nil(t, contextError(ctx))
+	assert.Equal(t, ctx.Value(k), v)
+
+	cancel()
+	assert.Error(t, contextError(ctx))
+	assert.Equal(t, ctx.Value(k), v)
+
+	// cleanup context should no longer be canceled
+	ctx = Background(ctx)
+	assert.Nil(t, contextError(ctx))
+	assert.Equal(t, ctx.Value(k), v)
+
+	// cleanup contexts can be rewrapped in cancel context
+	ctx, cancel = context.WithCancel(ctx)
+	cancel()
+	assert.Error(t, contextError(ctx))
+	assert.Equal(t, ctx.Value(k), v)
+}
+
+func contextError(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		return nil
+	}
+}

--- a/runtime/v1/linux/bundle.go
+++ b/runtime/v1/linux/bundle.go
@@ -184,7 +184,7 @@ func (b *bundle) Delete() error {
 	if err2 == nil {
 		return err
 	}
-	return fmt.Errorf("Failed to remove both bundle and workdir locations: %v: %w", err2, err)
+	return fmt.Errorf("failed to remove both bundle and workdir locations: %v: %w", err2, err)
 }
 
 func (b *bundle) legacyShimAddress(namespace string) string {

--- a/runtime/v1/linux/runtime.go
+++ b/runtime/v1/linux/runtime.go
@@ -38,6 +38,7 @@ import (
 	"github.com/containerd/containerd/metadata"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/pkg/cleanup"
 	"github.com/containerd/containerd/pkg/process"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/plugin"
@@ -165,6 +166,10 @@ func (r *Runtime) Create(ctx context.Context, id string, opts runtime.CreateOpts
 	if err != nil {
 		return nil, err
 	}
+	ctx = log.WithLogger(ctx, log.G(ctx).WithError(err).WithFields(logrus.Fields{
+		"id":        id,
+		"namespace": namespace,
+	}))
 
 	if err := identifiers.Validate(id); err != nil {
 		return nil, fmt.Errorf("invalid task id: %w", err)
@@ -206,11 +211,8 @@ func (r *Runtime) Create(ctx context.Context, id string, opts runtime.CreateOpts
 				return
 			}
 
-			if err = r.cleanupAfterDeadShim(context.Background(), bundle, namespace, id); err != nil {
-				log.G(ctx).WithError(err).WithFields(logrus.Fields{
-					"id":        id,
-					"namespace": namespace,
-				}).Warn("failed to clean up after killed shim")
+			if err = r.cleanupAfterDeadShim(cleanup.Background(ctx), bundle, namespace, id); err != nil {
+				log.G(ctx).WithError(err).Warn("failed to clean up after killed shim")
 			}
 		}
 		shimopt = ShimRemote(r.config, r.address, cgroup, exitHandler)
@@ -222,8 +224,7 @@ func (r *Runtime) Create(ctx context.Context, id string, opts runtime.CreateOpts
 	}
 	defer func() {
 		if err != nil {
-			deferCtx, deferCancel := context.WithTimeout(
-				namespaces.WithNamespace(context.TODO(), namespace), cleanupTimeout)
+			deferCtx, deferCancel := context.WithTimeout(cleanup.Background(ctx), cleanupTimeout)
 			defer deferCancel()
 			if kerr := s.KillShim(deferCtx); kerr != nil {
 				log.G(ctx).WithError(kerr).Error("failed to kill shim")
@@ -359,6 +360,11 @@ func (r *Runtime) loadTasks(ctx context.Context, ns string) ([]*Task, error) {
 			filepath.Join(r.root, ns, id),
 		)
 		ctx = namespaces.WithNamespace(ctx, ns)
+		ctx = log.WithLogger(ctx, log.G(ctx).WithError(err).WithFields(logrus.Fields{
+			"id":        id,
+			"namespace": ns,
+		}))
+
 		pid, _ := runc.ReadPidFile(filepath.Join(bundle.path, process.InitPidFile))
 		shimExit := make(chan struct{})
 		s, err := bundle.NewShimClient(ctx, ns, ShimConnect(r.config, func() {
@@ -374,10 +380,7 @@ func (r *Runtime) loadTasks(ctx context.Context, ns string) ([]*Task, error) {
 			}
 		}), nil)
 		if err != nil {
-			log.G(ctx).WithError(err).WithFields(logrus.Fields{
-				"id":        id,
-				"namespace": ns,
-			}).Error("connecting to shim")
+			log.G(ctx).WithError(err).Error("connecting to shim")
 			err := r.cleanupAfterDeadShim(ctx, bundle, ns, id)
 			if err != nil {
 				log.G(ctx).WithError(err).WithField("bundle", bundle.path).
@@ -402,11 +405,8 @@ func (r *Runtime) loadTasks(ctx context.Context, ns string) ([]*Task, error) {
 		}
 		shimStdoutLog, err := v1.OpenShimStdoutLog(ctx, logDirPath)
 		if err != nil {
-			log.G(ctx).WithError(err).WithFields(logrus.Fields{
-				"id":         id,
-				"namespace":  ns,
-				"logDirPath": logDirPath,
-			}).Error("opening shim stdout log pipe")
+			log.G(ctx).WithError(err).WithField("logDirPath", logDirPath).
+				Error("opening shim stdout log pipe")
 			continue
 		}
 		if r.config.ShimDebug {
@@ -417,11 +417,8 @@ func (r *Runtime) loadTasks(ctx context.Context, ns string) ([]*Task, error) {
 
 		shimStderrLog, err := v1.OpenShimStderrLog(ctx, logDirPath)
 		if err != nil {
-			log.G(ctx).WithError(err).WithFields(logrus.Fields{
-				"id":         id,
-				"namespace":  ns,
-				"logDirPath": logDirPath,
-			}).Error("opening shim stderr log pipe")
+			log.G(ctx).WithError(err).WithField("logDirPath", logDirPath).
+				Error("opening shim stderr log pipe")
 			continue
 		}
 		if r.config.ShimDebug {
@@ -441,13 +438,9 @@ func (r *Runtime) loadTasks(ctx context.Context, ns string) ([]*Task, error) {
 }
 
 func (r *Runtime) cleanupAfterDeadShim(ctx context.Context, bundle *bundle, ns, id string) error {
-	log.G(ctx).WithFields(logrus.Fields{
-		"id":        id,
-		"namespace": ns,
-	}).Warn("cleaning up after shim dead")
+	log.G(ctx).Warn("cleaning up after shim dead")
 
 	pid, _ := runc.ReadPidFile(filepath.Join(bundle.path, process.InitPidFile))
-	ctx = namespaces.WithNamespace(ctx, ns)
 	if err := r.terminate(ctx, bundle, ns, id); err != nil {
 		if r.config.ShimDebug {
 			return fmt.Errorf("failed to terminate task, leaving bundle for debugging: %w", err)

--- a/unpacker.go
+++ b/unpacker.go
@@ -214,9 +214,11 @@ func (u *unpacker) unpack(
 
 		select {
 		case <-ctx.Done():
+			abort()
 			return ctx.Err()
 		case err := <-fetchErr:
 			if err != nil {
+				abort()
 				return err
 			}
 		case <-fetchC[i-fetchOffset]:

--- a/unpacker.go
+++ b/unpacker.go
@@ -32,6 +32,7 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/pkg/cleanup"
 	"github.com/containerd/containerd/pkg/kmutex"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/snapshots"
@@ -214,11 +215,11 @@ func (u *unpacker) unpack(
 
 		select {
 		case <-ctx.Done():
-			abort(context.Background()) // Cleanup context
+			cleanup.Do(ctx, abort)
 			return ctx.Err()
 		case err := <-fetchErr:
 			if err != nil {
-				abort(ctx)
+				cleanup.Do(ctx, abort)
 				return err
 			}
 		case <-fetchC[i-fetchOffset]:
@@ -226,16 +227,16 @@ func (u *unpacker) unpack(
 
 		diff, err := a.Apply(ctx, desc, mounts, u.config.ApplyOpts...)
 		if err != nil {
-			abort(ctx)
+			cleanup.Do(ctx, abort)
 			return fmt.Errorf("failed to extract layer %s: %w", diffIDs[i], err)
 		}
 		if diff.Digest != diffIDs[i] {
-			abort(ctx)
+			cleanup.Do(ctx, abort)
 			return fmt.Errorf("wrong diff id calculated on extraction %q", diffIDs[i])
 		}
 
 		if err = sn.Commit(ctx, chainID, key, opts...); err != nil {
-			abort(ctx)
+			cleanup.Do(ctx, abort)
 			if errdefs.IsAlreadyExists(err) {
 				return nil
 			}


### PR DESCRIPTION
### [release/1.6] client.newUnpacker: call abort() on ctx.Cancel() and fetchErr

This code did not call "abort" on ctx.Cancel() and fetchErr before
commit 8017daa12dd4159e90701bedd1caaa9be5fb0357
https://github.com/containerd/containerd/blob/030c1ac1caa49f88cd572a43a053fb3b7007f94b/unpacker.go#L215-L241

But after the code was moved to pkg/unpacker, abort calls were added;
https://github.com/containerd/containerd/blob/8017daa12dd4159e90701bedd1caaa9be5fb0357/pkg/unpack/unpacker.go#L353-L381

That code is not part of the 1.6 branch, so applying it here.


and backport of

- https://github.com/containerd/containerd/pull/7859
- https://github.com/containerd/containerd/pull/7861

---


:warning: Conflicts in:

- metadata/db.go
- pkg/unpack/unpacker.go (due to https://github.com/dmcgowan/containerd/commit/8017daa12dd4159e90701bedd1caaa9be5fb0357 missing)
- runtime/v2/shim.go

Conflicts:

```patch
diff --cc metadata/db.go
index 2d9cbf31a,60a65b5b4..000000000
--- a/metadata/db.go
+++ b/metadata/db.go
@@@ -26,9 -26,13 +26,14 @@@ import
  	"sync/atomic"
  	"time"

 -	eventstypes "github.com/containerd/containerd/api/events"
  	"github.com/containerd/containerd/content"
 -	"github.com/containerd/containerd/events"
  	"github.com/containerd/containerd/gc"
  	"github.com/containerd/containerd/log"
++<<<<<<< HEAD
++=======
+ 	"github.com/containerd/containerd/namespaces"
+ 	"github.com/containerd/containerd/pkg/cleanup"
++>>>>>>> b550526cc (Use cleanup.Background instead of context.Background for cleanup)
  	"github.com/containerd/containerd/snapshots"
  	bolt "go.etcd.io/bbolt"
  )
diff --cc runtime/v2/shim.go
index 456ffb440,3f1c84b87..000000000
--- a/runtime/v2/shim.go
+++ b/runtime/v2/shim.go
@@@ -32,15 -32,13 +32,13 @@@ import
  	"github.com/containerd/containerd/events/exchange"
  	"github.com/containerd/containerd/identifiers"
  	"github.com/containerd/containerd/log"
- 	"github.com/containerd/containerd/namespaces"
  	"github.com/containerd/containerd/pkg/timeout"
 -	"github.com/containerd/containerd/protobuf"
 -	ptypes "github.com/containerd/containerd/protobuf/types"
  	"github.com/containerd/containerd/runtime"
  	client "github.com/containerd/containerd/runtime/v2/shim"
 +	"github.com/containerd/containerd/runtime/v2/task"
  	"github.com/containerd/ttrpc"
 +	ptypes "github.com/gogo/protobuf/types"
  	"github.com/hashicorp/go-multierror"
- 	"github.com/sirupsen/logrus"
  )

  const (
@@@ -131,11 -126,10 +129,15 @@@ func loadShim(ctx context.Context, bund
  	if _, err := s.PID(ctx); err != nil {
  		return nil, err
  	}
 -	return shim, nil
 +	return s, nil
  }

++<<<<<<< HEAD
 +func cleanupAfterDeadShim(ctx context.Context, id, ns string, rt *runtime.TaskList, events *exchange.Exchange, binaryCall *binary) {
 +	ctx = namespaces.WithNamespace(ctx, ns)
++=======
+ func cleanupAfterDeadShim(ctx context.Context, id string, rt *runtime.NSMap[ShimInstance], events *exchange.Exchange, binaryCall *binary) {
++>>>>>>> b550526cc (Use cleanup.Background instead of context.Background for cleanup)
  	ctx, cancel := timeout.WithContext(ctx, cleanupTimeout)
  	defer cancel()

* Unmerged path pkg/unpack/unpacker.go
```


I applied the pkg/unpack/unpacker.go changes to `/unpacker.go` instead

I also noticed that not all calls to `cleanupAfterDeadShim` use `cleanup.Background` (not sure if that's intentional?)

```bash
git grep cleanupAfterDeadShim
runtime/v1/linux/runtime.go:                    if err = r.cleanupAfterDeadShim(cleanup.Background(ctx), bundle, namespace, id); err != nil {
runtime/v1/linux/runtime.go:                    if err := r.cleanupAfterDeadShim(ctx, bundle, ns, id); err != nil {
runtime/v1/linux/runtime.go:                    err := r.cleanupAfterDeadShim(ctx, bundle, ns, id)
runtime/v2/manager.go:          cleanupAfterDeadShim(cleanup.Background(ctx), id, m.shims, m.events, b)
runtime/v2/shim.go:func cleanupAfterDeadShim(ctx context.Context, id string, rt *runtime.TaskList, events *exchange.Exchange, binaryCall *binary) {
runtime/v2/shim_load.go:                        cleanupAfterDeadShim(cleanup.Background(ctx), id, m.shims, m.events, binaryCall)
runtime/v2/shim_load.go:                        cleanupAfterDeadShim(ctx, id, m.shims, m.events, binaryCall)
```


I'll keep this one in draft for now, perhaps @dmcgowan should have a look