### PR TITLE
[release/1.7 backport] [CRI] fix additionalGids: it should fallback to imageConfig.User when securityContext.RunAsUser,RunAsUsername are empty

### DIFF
--- a/pkg/cri/sbserver/container_create_linux.go
+++ b/pkg/cri/sbserver/container_create_linux.go
@@ -73,12 +73,14 @@ func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageCon
 		specOpts = append(specOpts, oci.WithUser(userstr))
 	}
 
+	userstr = "0" // runtime default
 	if securityContext.GetRunAsUsername() != "" {
 		userstr = securityContext.GetRunAsUsername()
-	} else {
-		// Even if RunAsUser is not set, we still call `GetValue` to get uid 0.
-		// Because it is still useful to get additional gids for uid 0.
+	} else if securityContext.GetRunAsUser() != nil {
 		userstr = strconv.FormatInt(securityContext.GetRunAsUser().GetValue(), 10)
+	} else if imageConfig.User != "" {
+		parts := strings.Split(imageConfig.User, ":")
+		userstr = parts[0]
 	}
 	specOpts = append(specOpts, customopts.WithAdditionalGIDs(userstr),
 		customopts.WithSupplementalGroups(securityContext.GetSupplementalGroups()))

--- a/pkg/cri/sbserver/container_create_linux.go
+++ b/pkg/cri/sbserver/container_create_linux.go
@@ -79,8 +79,7 @@ func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageCon
 	} else if securityContext.GetRunAsUser() != nil {
 		userstr = strconv.FormatInt(securityContext.GetRunAsUser().GetValue(), 10)
 	} else if imageConfig.User != "" {
-		parts := strings.Split(imageConfig.User, ":")
-		userstr = parts[0]
+		userstr, _, _ = strings.Cut(imageConfig.User, ":")
 	}
 	specOpts = append(specOpts, customopts.WithAdditionalGIDs(userstr),
 		customopts.WithSupplementalGroups(securityContext.GetSupplementalGroups()))

--- a/pkg/cri/sbserver/container_create_linux_test.go
+++ b/pkg/cri/sbserver/container_create_linux_test.go
@@ -1346,11 +1346,7 @@ alice:x:1000:
 additional-group-for-alice:x:11111:alice
 additional-group-for-root:x:22222:root
 `
-	tempRootDir, err := os.MkdirTemp("", "TestContainerUser-")
-	require.NoError(t, err)
-	if tempRootDir != "" {
-		defer os.RemoveAll(tempRootDir)
-	}
+	tempRootDir := t.TempDir()
 	require.NoError(t,
 		os.MkdirAll(filepath.Join(tempRootDir, "etc"), 0755),
 	)

--- a/pkg/cri/sbserver/container_create_linux_test.go
+++ b/pkg/cri/sbserver/container_create_linux_test.go
@@ -1388,6 +1388,7 @@ additional-group-for-root:x:22222:root
 			expected: runtimespec.User{UID: 0, GID: 0, AdditionalGids: []uint32{0, 22222}},
 		},
 	} {
+		desc := desc
 		t.Run(desc, func(t *testing.T) {
 			containerConfig, sandboxConfig, imageConfig, _ := getCreateContainerTestData()
 			containerConfig.Linux.SecurityContext = test.securityContext

--- a/pkg/cri/sbserver/container_create_linux_test.go
+++ b/pkg/cri/sbserver/container_create_linux_test.go
@@ -1326,6 +1326,90 @@ func TestGenerateUserString(t *testing.T) {
 	}
 }
 
+func TestProcessUser(t *testing.T) {
+	testID := "test-id"
+	testSandboxID := "sandbox-id"
+	testContainerName := "container-name"
+	testPid := uint32(1234)
+	ociRuntime := config.Runtime{}
+	c := newTestCRIService()
+	testContainer := &containers.Container{ID: "64ddfe361f0099f8d59075398feeb3dcb3863b6851df7b946744755066c03e9d"}
+	ctx := context.Background()
+
+	etcPasswd := `
+root:x:0:0:root:/root:/bin/sh
+alice:x:1000:1000:alice:/home/alice:/bin/sh
+` // #nosec G101
+	etcGroup := `
+root:x:0
+alice:x:1000:
+additional-group-for-alice:x:11111:alice
+additional-group-for-root:x:22222:root
+`
+	tempRootDir, err := os.MkdirTemp("", "TestContainerUser-")
+	require.NoError(t, err)
+	if tempRootDir != "" {
+		defer os.RemoveAll(tempRootDir)
+	}
+	require.NoError(t,
+		os.MkdirAll(filepath.Join(tempRootDir, "etc"), 0755),
+	)
+	require.NoError(t,
+		os.WriteFile(filepath.Join(tempRootDir, "etc", "passwd"), []byte(etcPasswd), 0644),
+	)
+	require.NoError(t,
+		os.WriteFile(filepath.Join(tempRootDir, "etc", "group"), []byte(etcGroup), 0644),
+	)
+
+	for desc, test := range map[string]struct {
+		imageConfigUser string
+		securityContext *runtime.LinuxContainerSecurityContext
+		expected        runtimespec.User
+	}{
+		"Only SecurityContext was set, SecurityContext defines User": {
+			securityContext: &runtime.LinuxContainerSecurityContext{
+				RunAsUser:          &runtime.Int64Value{Value: 1000},
+				RunAsGroup:         &runtime.Int64Value{Value: 2000},
+				SupplementalGroups: []int64{3333},
+			},
+			expected: runtimespec.User{UID: 1000, GID: 2000, AdditionalGids: []uint32{2000, 3333, 11111}},
+		},
+		"Only imageConfig.User was set, imageConfig.User defines User": {
+			imageConfigUser: "1000",
+			securityContext: nil,
+			expected:        runtimespec.User{UID: 1000, GID: 1000, AdditionalGids: []uint32{1000, 11111}},
+		},
+		"Both SecurityContext and ImageConfig.User was set, SecurityContext defines User": {
+			imageConfigUser: "0",
+			securityContext: &runtime.LinuxContainerSecurityContext{
+				RunAsUser:          &runtime.Int64Value{Value: 1000},
+				RunAsGroup:         &runtime.Int64Value{Value: 2000},
+				SupplementalGroups: []int64{3333},
+			},
+			expected: runtimespec.User{UID: 1000, GID: 2000, AdditionalGids: []uint32{2000, 3333, 11111}},
+		},
+		"No SecurityContext nor ImageConfig.User were set, runtime default defines User": {
+			expected: runtimespec.User{UID: 0, GID: 0, AdditionalGids: []uint32{0, 22222}},
+		},
+	} {
+		t.Run(desc, func(t *testing.T) {
+			containerConfig, sandboxConfig, imageConfig, _ := getCreateContainerTestData()
+			containerConfig.Linux.SecurityContext = test.securityContext
+			imageConfig.User = test.imageConfigUser
+
+			spec, err := c.buildContainerSpec(currentPlatform, testID, testSandboxID, testPid, "", testContainerName, testImageName, containerConfig, sandboxConfig, imageConfig, nil, ociRuntime)
+			require.NoError(t, err)
+
+			spec.Root.Path = tempRootDir // simulating /etc/{passwd, group}
+			opts, err := c.containerSpecOpts(containerConfig, imageConfig)
+			require.NoError(t, err)
+			oci.ApplyOpts(ctx, nil, testContainer, spec, opts...)
+
+			require.Equal(t, test.expected, spec.Process.User)
+		})
+	}
+}
+
 func TestNonRootUserAndDevices(t *testing.T) {
 	testPid := uint32(1234)
 	c := newTestCRIService()

--- a/pkg/cri/server/container_create_linux.go
+++ b/pkg/cri/server/container_create_linux.go
@@ -366,12 +366,14 @@ func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageCon
 		specOpts = append(specOpts, oci.WithUser(userstr))
 	}
 
+	userstr = "0" // runtime default
 	if securityContext.GetRunAsUsername() != "" {
 		userstr = securityContext.GetRunAsUsername()
-	} else {
-		// Even if RunAsUser is not set, we still call `GetValue` to get uid 0.
-		// Because it is still useful to get additional gids for uid 0.
+	} else if securityContext.GetRunAsUser() != nil {
 		userstr = strconv.FormatInt(securityContext.GetRunAsUser().GetValue(), 10)
+	} else if imageConfig.User != "" {
+		parts := strings.Split(imageConfig.User, ":")
+		userstr = parts[0]
 	}
 	specOpts = append(specOpts, customopts.WithAdditionalGIDs(userstr),
 		customopts.WithSupplementalGroups(securityContext.GetSupplementalGroups()))

--- a/pkg/cri/server/container_create_linux.go
+++ b/pkg/cri/server/container_create_linux.go
@@ -372,8 +372,7 @@ func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageCon
 	} else if securityContext.GetRunAsUser() != nil {
 		userstr = strconv.FormatInt(securityContext.GetRunAsUser().GetValue(), 10)
 	} else if imageConfig.User != "" {
-		parts := strings.Split(imageConfig.User, ":")
-		userstr = parts[0]
+		userstr, _, _ = strings.Cut(imageConfig.User, ":")
 	}
 	specOpts = append(specOpts, customopts.WithAdditionalGIDs(userstr),
 		customopts.WithSupplementalGroups(securityContext.GetSupplementalGroups()))

--- a/pkg/cri/server/container_create_linux_test.go
+++ b/pkg/cri/server/container_create_linux_test.go
@@ -1526,11 +1526,7 @@ alice:x:1000:
 additional-group-for-alice:x:11111:alice
 additional-group-for-root:x:22222:root
 `
-	tempRootDir, err := os.MkdirTemp("", "TestContainerUser-")
-	require.NoError(t, err)
-	if tempRootDir != "" {
-		defer os.RemoveAll(tempRootDir)
-	}
+	tempRootDir := t.TempDir()
 	require.NoError(t,
 		os.MkdirAll(filepath.Join(tempRootDir, "etc"), 0755),
 	)

--- a/pkg/cri/server/container_create_linux_test.go
+++ b/pkg/cri/server/container_create_linux_test.go
@@ -1568,6 +1568,7 @@ additional-group-for-root:x:22222:root
 			expected: runtimespec.User{UID: 0, GID: 0, AdditionalGids: []uint32{0, 22222}},
 		},
 	} {
+		desc := desc
 		t.Run(desc, func(t *testing.T) {
 			containerConfig, sandboxConfig, imageConfig, _ := getCreateContainerTestData()
 			containerConfig.Linux.SecurityContext = test.securityContext

--- a/pkg/cri/server/container_create_linux_test.go
+++ b/pkg/cri/server/container_create_linux_test.go
@@ -1506,6 +1506,90 @@ func TestGenerateUserString(t *testing.T) {
 	}
 }
 
+func TestProcessUser(t *testing.T) {
+	testID := "test-id"
+	testSandboxID := "sandbox-id"
+	testContainerName := "container-name"
+	testPid := uint32(1234)
+	ociRuntime := config.Runtime{}
+	c := newTestCRIService()
+	testContainer := &containers.Container{ID: "64ddfe361f0099f8d59075398feeb3dcb3863b6851df7b946744755066c03e9d"}
+	ctx := context.Background()
+
+	etcPasswd := `
+root:x:0:0:root:/root:/bin/sh
+alice:x:1000:1000:alice:/home/alice:/bin/sh
+` // #nosec G101
+	etcGroup := `
+root:x:0
+alice:x:1000:
+additional-group-for-alice:x:11111:alice
+additional-group-for-root:x:22222:root
+`
+	tempRootDir, err := os.MkdirTemp("", "TestContainerUser-")
+	require.NoError(t, err)
+	if tempRootDir != "" {
+		defer os.RemoveAll(tempRootDir)
+	}
+	require.NoError(t,
+		os.MkdirAll(filepath.Join(tempRootDir, "etc"), 0755),
+	)
+	require.NoError(t,
+		os.WriteFile(filepath.Join(tempRootDir, "etc", "passwd"), []byte(etcPasswd), 0644),
+	)
+	require.NoError(t,
+		os.WriteFile(filepath.Join(tempRootDir, "etc", "group"), []byte(etcGroup), 0644),
+	)
+
+	for desc, test := range map[string]struct {
+		imageConfigUser string
+		securityContext *runtime.LinuxContainerSecurityContext
+		expected        runtimespec.User
+	}{
+		"Only SecurityContext was set, SecurityContext defines User": {
+			securityContext: &runtime.LinuxContainerSecurityContext{
+				RunAsUser:          &runtime.Int64Value{Value: 1000},
+				RunAsGroup:         &runtime.Int64Value{Value: 2000},
+				SupplementalGroups: []int64{3333},
+			},
+			expected: runtimespec.User{UID: 1000, GID: 2000, AdditionalGids: []uint32{2000, 3333, 11111}},
+		},
+		"Only imageConfig.User was set, imageConfig.User defines User": {
+			imageConfigUser: "1000",
+			securityContext: nil,
+			expected:        runtimespec.User{UID: 1000, GID: 1000, AdditionalGids: []uint32{1000, 11111}},
+		},
+		"Both SecurityContext and ImageConfig.User was set, SecurityContext defines User": {
+			imageConfigUser: "0",
+			securityContext: &runtime.LinuxContainerSecurityContext{
+				RunAsUser:          &runtime.Int64Value{Value: 1000},
+				RunAsGroup:         &runtime.Int64Value{Value: 2000},
+				SupplementalGroups: []int64{3333},
+			},
+			expected: runtimespec.User{UID: 1000, GID: 2000, AdditionalGids: []uint32{2000, 3333, 11111}},
+		},
+		"No SecurityContext nor ImageConfig.User were set, runtime default defines User": {
+			expected: runtimespec.User{UID: 0, GID: 0, AdditionalGids: []uint32{0, 22222}},
+		},
+	} {
+		t.Run(desc, func(t *testing.T) {
+			containerConfig, sandboxConfig, imageConfig, _ := getCreateContainerTestData()
+			containerConfig.Linux.SecurityContext = test.securityContext
+			imageConfig.User = test.imageConfigUser
+
+			spec, err := c.containerSpec(testID, testSandboxID, testPid, "", testContainerName, testImageName, containerConfig, sandboxConfig, imageConfig, nil, ociRuntime)
+			require.NoError(t, err)
+
+			spec.Root.Path = tempRootDir // simulating /etc/{passwd, group}
+			opts, err := c.containerSpecOpts(containerConfig, imageConfig)
+			require.NoError(t, err)
+			oci.ApplyOpts(ctx, nil, testContainer, spec, opts...)
+
+			require.Equal(t, test.expected, spec.Process.User)
+		})
+	}
+}
+
 func TestNonRootUserAndDevices(t *testing.T) {
 	testPid := uint32(1234)
 	c := newTestCRIService()


### PR DESCRIPTION
backport of:

- https://github.com/containerd/containerd/pull/8136
- https://github.com/containerd/containerd/pull/8370

---


## What is the issue

I found a bug in setting `runtime.Spec.Process.User.additionalGids` in CRI server/sbserver.

If `LinuxContainerSecurityContext.{RunAsUser,RunAsUsername}` are empty, contained should fallback to the container image's `Config.User` for resolving the primary user and use it to inspect /etc/group in the container image for resolving `additionalGids`. But containerd always fallback to `0`.

__Fortunately, in the use of Kubernetes+containerd, the bug does NOT happen__ because kubelet always fills out `LinuxContainerSecurityContext.RunAsUser` from the image status ([code](https://github.com/kubernetes/kubernetes/blob/40deade20db9abb09c0812878c4fd8fb58af99e7/pkg/kubelet/kuberuntime/kuberuntime_container.go#L306)) when image's `Config.User` is not empty. So [ontainer_create_linux.go#L369-L370](https://github.com/containerd/containerd/blob/8d4f9b6335c1805ca09a04617e549708fb9a4fef/pkg/cri/server/container_create_linux.go#L369-L370) can grab the correct user from the SecurityContext.

However, because [the cri-api spec](https://github.com/kubernetes/cri-api/blob/master/pkg/apis/runtime/v1/api.proto#L866-L868) does not assume the behavior, which fills out `LinuxContainerSecurityContext.RunAsUser` from the image's `Config.User`, I think the code should be fixed.

CRI-O seems to handle this correctly. See [here](https://github.com/haircommander/cri-o/blob/db3b399a8d7dabf7f073db73894bee98311d7909/server/container_create.go#L185-L268).

## Reproduction

### Version
```console
root@primary:~# crictl version
Version:  0.1.0
RuntimeName:  containerd
RuntimeVersion:  1.6.16
RuntimeApiVersion:  v1
```

### Image and Container Spec

The image `everpeace/test:containerd-image-config` is used.

```console
# the image has alice(uid=1000)
root@primary:~# docker run -it --rm everpeace/test:containerd-image-config cat /etc/passwd | grep alice
alice:x:1000:1000::/home/alice:/bin/sh

# In the image
# - root belongs to an additional-group-for-root
# - alice belongs to an additiona-group-for-alice
root@primary:~# docker run -it --rm everpeace/test:containerd-image-config cat /etc/group | grep -e root -e alice
root:x:0:
Alice:x:1000:
additional-group-for-alice:x:10000:alice
additional-group-for-root:x:20000:root

# image specifies "config.user: 1000" (alice)
root@primary:~# crictl inspecti everpeace/test:containerd-image-config
...
  "info": {
    "chainID": "sha256:140469df148ed27972d663207bf92e11d6d11b046647532811ab0f7a297c0cb0",
    "imageSpec": {
      "config": {
        "User": "1000",
...

root@primary:~# cat pod-config.json
{
    "metadata": {
        "name": "test-sandbox",
        "namespace": "default",
        "attempt": 1,
        "uid": "hdishd83djaidwnduwk28bcsx"
    },
    "log_directory": "/tmp/tmp.AqRbZ4eV2s",
    "linux": {
    }
}

root@primary:~# cat container-config.json
{
    "metadata": {
        "name": "test"
    },
    "image": {
        "image": "everpeace/test:containerd-image-config"
    },
    "command": [
        "id"
    ],
    "log_path": "test.0.log",
    "linux": {}
}
```

# The output

```console
# Run the container
root@primary:~# crictl runp pod-config.json 
3323c5e01e65ae0a4663b6e7391eb1e81a6fccb9a6cda07b639e792798cdb11e
root@primary:~# crictl create 3323c5e01e65ae0a4663b6e7391eb1e81a6fccb9a6cda07b639e792798cdb11e container-config.json pod-config.json 
6fa373a9292d86f3cdc43e63feeb298c622a0f092ba3204ac04a541a9ca56cc4
root@primary:~# crictl start 6fa373a9292d86f3cdc43e63feeb298c622a0f092ba3204ac04a541a9ca56cc4
6fa373a9292d86f3cdc43e63feeb298c622a0f092ba3204ac04a541a9ca56cc4
```

```console
# 'additional-group-for-alice' expects to be attached because imageConfig.User=1000(alice).
# However, 'additional-group-gor-root' is attached instead.
root@primary:~# crictl logs 6fa373a9292d86f3cdc43e63feeb298c622a0f092ba3204ac04a541a9ca56cc4
uid=1000(alice) gid=1000(alice) groups=1000(alice),20000(additional-group-for-root)
```

## Notes for reviewers

The current containerd's CRI implementation doesn't follow [the conversion spec config.User to spec.Process.User](https://github.com/thockin/oci-image-spec/blob/98f35dfbd9fd99404a9c29c2ed1231b1c99a43cf/conversion.md#configuser). The containerd's CRI impl
- doesn't support to specify group in `config.User` in the image, and 
- ALWAYS attach groups from the image(/etc/group) when setting `RunAsGroup` in SecurityContext

The issue will be handled in https://github.com/kubernetes/enhancements/issues/3619 separately to avoid breaking changes to the users.