### PR TITLE
[release/1.6 backport] Make checkContainerTimestamps less strict on Windows

### DIFF
--- a/metadata/containers_test.go
+++ b/metadata/containers_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 	"time"
 
@@ -693,7 +694,12 @@ func checkContainerTimestamps(t *testing.T, c *containers.Container, now time.Ti
 	} else {
 		// ensure that updatedat is always after createdat
 		if !c.UpdatedAt.After(c.CreatedAt) {
-			t.Fatalf("timestamp for updatedat not after createdat: %v <= %v", c.UpdatedAt, c.CreatedAt)
+			if runtime.GOOS == "windows" && c.UpdatedAt == c.CreatedAt {
+				// Windows' time.Now resolution is lower than Linux, due to Go.
+				// https://github.com/golang/go/issues/31160
+			} else {
+				t.Fatalf("timestamp for updatedat not after createdat: %v <= %v", c.UpdatedAt, c.CreatedAt)
+			}
 		}
 	}
 


### PR DESCRIPTION
- backport of https://github.com/containerd/containerd/pull/7350
- addresses https://github.com/containerd/containerd/pull/8822#issuecomment-1635747185

This assertion is flaky on Windows.
Because of Go, Windows' time.Now resolution is lower than Linux.


(cherry picked from commit 407703f092f7cb920314d1e271fe67829b4beb30)