### PR TITLE
[release/1.7 backport] Move logrus setup code to log package

### DIFF
--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -36,7 +36,6 @@ import (
 	srvconfig "github.com/containerd/containerd/services/server/config"
 	"github.com/containerd/containerd/sys"
 	"github.com/containerd/containerd/version"
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"google.golang.org/grpc/grpclog"
 )
@@ -150,7 +149,7 @@ can be used and modified as necessary as a custom configuration.`
 		// Stop if we are registering or unregistering against Windows SCM.
 		stop, err := registerUnregisterService(config.Root)
 		if err != nil {
-			logrus.Fatal(err)
+			log.L.Fatal(err)
 		}
 		if stop {
 			return nil
@@ -203,7 +202,7 @@ can be used and modified as necessary as a custom configuration.`
 
 			// Launch as a Windows Service if necessary
 			if err := launchService(server, done); err != nil {
-				logrus.Fatal(err)
+				log.L.Fatal(err)
 			}
 			select {
 			case <-ctx.Done():
@@ -352,11 +351,7 @@ func setLogLevel(context *cli.Context, config *srvconfig.Config) error {
 		l = config.Debug.Level
 	}
 	if l != "" {
-		lvl, err := logrus.ParseLevel(l)
-		if err != nil {
-			return err
-		}
-		logrus.SetLevel(lvl)
+		return log.SetLevel(l)
 	}
 	return nil
 }
@@ -367,21 +362,7 @@ func setLogFormat(config *srvconfig.Config) error {
 		f = log.TextFormat
 	}
 
-	switch f {
-	case log.TextFormat:
-		logrus.SetFormatter(&logrus.TextFormatter{
-			TimestampFormat: log.RFC3339NanoFixed,
-			FullTimestamp:   true,
-		})
-	case log.JSONFormat:
-		logrus.SetFormatter(&logrus.JSONFormatter{
-			TimestampFormat: log.RFC3339NanoFixed,
-		})
-	default:
-		return fmt.Errorf("unknown log format: %s", f)
-	}
-
-	return nil
+	return log.SetFormat(f)
 }
 
 func dumpStacks(writeToFile bool) {
@@ -396,7 +377,7 @@ func dumpStacks(writeToFile bool) {
 		bufferLen *= 2
 	}
 	buf = buf[:stackSize]
-	logrus.Infof("=== BEGIN goroutine stack dump ===\n%s\n=== END goroutine stack dump ===", buf)
+	log.L.Infof("=== BEGIN goroutine stack dump ===\n%s\n=== END goroutine stack dump ===", buf)
 
 	if writeToFile {
 		// Also write to file to aid gathering diagnostics
@@ -407,6 +388,6 @@ func dumpStacks(writeToFile bool) {
 		}
 		defer f.Close()
 		f.WriteString(string(buf))
-		logrus.Infof("goroutine stack dump written to %s", name)
+		log.L.Infof("goroutine stack dump written to %s", name)
 	}
 }

--- a/log/context.go
+++ b/log/context.go
@@ -18,6 +18,7 @@ package log
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/sirupsen/logrus"
 )
@@ -38,6 +39,9 @@ type (
 
 	// Fields type to pass to `WithFields`, alias from `logrus`.
 	Fields = logrus.Fields
+
+	// Level is a logging level
+	Level = logrus.Level
 )
 
 const (
@@ -50,7 +54,51 @@ const (
 
 	// JSONFormat represents the JSON logging format
 	JSONFormat = "json"
+
+	// TraceLevel level.
+	TraceLevel = logrus.TraceLevel
+
+	// DebugLevel level.
+	DebugLevel = logrus.DebugLevel
+
+	// InfoLevel level.
+	InfoLevel = logrus.InfoLevel
 )
+
+// SetLevel sets log level globally.
+func SetLevel(level string) error {
+	lvl, err := logrus.ParseLevel(level)
+	if err != nil {
+		return err
+	}
+
+	logrus.SetLevel(lvl)
+	return nil
+}
+
+// GetLevel returns the current log level.
+func GetLevel() Level {
+	return logrus.GetLevel()
+}
+
+// SetFormat sets log output format
+func SetFormat(format string) error {
+	switch format {
+	case TextFormat:
+		logrus.SetFormatter(&logrus.TextFormatter{
+			TimestampFormat: RFC3339NanoFixed,
+			FullTimestamp:   true,
+		})
+	case JSONFormat:
+		logrus.SetFormatter(&logrus.JSONFormatter{
+			TimestampFormat: RFC3339NanoFixed,
+		})
+	default:
+		return fmt.Errorf("unknown log format: %s", format)
+	}
+
+	return nil
+}
 
 // WithLogger returns a new context with the provided logger. Use in
 // combination with logger.WithField(s) for great effect.

--- a/pkg/cri/cri.go
+++ b/pkg/cri/cri.go
@@ -30,7 +30,6 @@ import (
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/plugin"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 	"k8s.io/klog/v2"
 
 	criconfig "github.com/containerd/containerd/pkg/cri/config"
@@ -112,24 +111,21 @@ func initCRIService(ic *plugin.InitContext) (interface{}, error) {
 
 // Set glog level.
 func setGLogLevel() error {
-	l := logrus.GetLevel()
+	l := log.GetLevel()
 	fs := flag.NewFlagSet("klog", flag.PanicOnError)
 	klog.InitFlags(fs)
 	if err := fs.Set("logtostderr", "true"); err != nil {
 		return err
 	}
 	switch l {
-	case logrus.TraceLevel:
+	case log.TraceLevel:
 		return fs.Set("v", "5")
-	case logrus.DebugLevel:
+	case log.DebugLevel:
 		return fs.Set("v", "4")
-	case logrus.InfoLevel:
+	case log.InfoLevel:
 		return fs.Set("v", "2")
-	// glog doesn't support following filters. Defaults to v=0.
-	case logrus.WarnLevel:
-	case logrus.ErrorLevel:
-	case logrus.FatalLevel:
-	case logrus.PanicLevel:
+	default:
+		// glog doesn't support other filters. Defaults to v=0.
 	}
 	return nil
 }

--- a/runtime/v2/binary.go
+++ b/runtime/v2/binary.go
@@ -25,8 +25,6 @@ import (
 	"path/filepath"
 	gruntime "runtime"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/containerd/containerd/api/runtime/task/v2"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/namespaces"
@@ -64,8 +62,8 @@ type binary struct {
 
 func (b *binary) Start(ctx context.Context, opts *types.Any, onClose func()) (_ *shim, err error) {
 	args := []string{"-id", b.bundle.ID}
-	switch logrus.GetLevel() {
-	case logrus.DebugLevel, logrus.TraceLevel:
+	switch log.GetLevel() {
+	case log.DebugLevel, log.TraceLevel:
 		args = append(args, "-debug")
 	}
 	args = append(args, "start")
@@ -163,8 +161,8 @@ func (b *binary) Delete(ctx context.Context) (*runtime.Exit, error) {
 		"-id", b.bundle.ID,
 		"-bundle", b.bundle.Path,
 	}
-	switch logrus.GetLevel() {
-	case logrus.DebugLevel, logrus.TraceLevel:
+	switch log.GetLevel() {
+	case log.DebugLevel, log.TraceLevel:
 		args = append(args, "-debug")
 	}
 	args = append(args, "delete")


### PR DESCRIPTION
we're in the process of adopting the containerd/log package in moby; getting more types in the release branches helps with the transition :)

- backport of https://github.com/containerd/containerd/pull/8441

(cherry picked from commit 370be0c18f52a026eb08e6b381518f3ae68b3969)
