### PR TITLE
fix: `ctr images check -q` outputs not unpacked images

### DIFF
--- a/cmd/ctr/commands/images/images.go
+++ b/cmd/ctr/commands/images/images.go
@@ -300,7 +300,7 @@ var checkCommand = cli.Command{
 					size,
 					unpacked)
 			} else {
-				if complete {
+				if complete && unpacked {
 					fmt.Println(image.Name())
 				}
 			}


### PR DESCRIPTION
`ctr images check -q` shouldn't output images which were not unpacked.