### PR TITLE
[release/1.6] Add stable ABI support in windows platform matcher + update hcsshim tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20210715213245-6c3934b029d8
 	github.com/Microsoft/go-winio v0.5.2
-	github.com/Microsoft/hcsshim v0.9.8
+	github.com/Microsoft/hcsshim v0.9.10
 	github.com/containerd/aufs v1.0.0
 	github.com/containerd/btrfs v1.0.0
 	github.com/containerd/cgroups v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/Microsoft/hcsshim v0.8.20/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwT
 github.com/Microsoft/hcsshim v0.8.21/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwTOcER2fw4I4=
 github.com/Microsoft/hcsshim v0.8.23/go.mod h1:4zegtUJth7lAvFyc6cH2gGQ5B3OFQim01nnU2M8jKDg=
 github.com/Microsoft/hcsshim v0.9.2/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
-github.com/Microsoft/hcsshim v0.9.8 h1:lf7xxK2+Ikbj9sVf2QZsouGjRjEp2STj1yDHgoVtU5k=
-github.com/Microsoft/hcsshim v0.9.8/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
+github.com/Microsoft/hcsshim v0.9.10 h1:TxXGNmcbQxBKVWvjvTocNb6jrPyeHlk5EiDhhgHgggs=
+github.com/Microsoft/hcsshim v0.9.10/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
 github.com/Microsoft/hcsshim/test v0.0.0-20201218223536-d3e5debf77da/go.mod h1:5hlzMzRKMLyo42nCZ9oml8AdTlq/0cvIaBv6tK1RehU=
 github.com/Microsoft/hcsshim/test v0.0.0-20210227013316-43a75bb4edd3/go.mod h1:mw7qgWloBUl75W/gVH3cQszUg1+gUITj7D6NY7ywVnY=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=

--- a/integration/client/go.mod
+++ b/integration/client/go.mod
@@ -3,7 +3,7 @@ module github.com/containerd/containerd/integration/client
 go 1.15
 
 require (
-	github.com/Microsoft/hcsshim v0.9.8
+	github.com/Microsoft/hcsshim v0.9.10
 	github.com/Microsoft/hcsshim/test v0.0.0-20210408205431-da33ecd607e1
 	github.com/containerd/cgroups v1.0.4
 	// the actual version of containerd is replaced with the code at the root of this repository

--- a/integration/client/go.sum
+++ b/integration/client/go.sum
@@ -56,8 +56,8 @@ github.com/Microsoft/hcsshim v0.8.15/go.mod h1:x38A4YbHbdxJtc0sF6oIz+RG0npwSCAvn
 github.com/Microsoft/hcsshim v0.8.20/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwTOcER2fw4I4=
 github.com/Microsoft/hcsshim v0.9.2/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
 github.com/Microsoft/hcsshim v0.9.6/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
-github.com/Microsoft/hcsshim v0.9.8 h1:lf7xxK2+Ikbj9sVf2QZsouGjRjEp2STj1yDHgoVtU5k=
-github.com/Microsoft/hcsshim v0.9.8/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
+github.com/Microsoft/hcsshim v0.9.10 h1:TxXGNmcbQxBKVWvjvTocNb6jrPyeHlk5EiDhhgHgggs=
+github.com/Microsoft/hcsshim v0.9.10/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
 github.com/Microsoft/hcsshim/test v0.0.0-20210408205431-da33ecd607e1 h1:pVKfKyPkXna29XlGjxSr9J0A7vNucOUHZ/2ClcTWalw=
 github.com/Microsoft/hcsshim/test v0.0.0-20210408205431-da33ecd607e1/go.mod h1:Cmvnhlie15Ha2UYrJs9EhgSx76Bq9RV2FgfEiT78GhI=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=

--- a/platforms/defaults_windows.go
+++ b/platforms/defaults_windows.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Microsoft/hcsshim/osversion"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/sys/windows"
@@ -50,12 +51,33 @@ func (m matchComparer) Match(p specs.Platform) bool {
 	match := m.defaults.Match(p)
 
 	if match && p.OS == "windows" {
-		if strings.HasPrefix(p.OSVersion, m.osVersionPrefix) {
+		// HPC containers do not have OS version filled
+		if p.OSVersion == "" {
 			return true
 		}
-		return p.OSVersion == ""
+
+		hostOsVersion := getOSVersion(m.osVersionPrefix)
+		ctrOsVersion := getOSVersion(p.OSVersion)
+		return osversion.CheckHostAndContainerCompat(hostOsVersion, ctrOsVersion)
 	}
 	return false
+}
+
+func getOSVersion(osVersionPrefix string) osversion.OSVersion {
+	parts := strings.Split(osVersionPrefix, ".")
+	if len(parts) < 3 {
+		return osversion.OSVersion{}
+	}
+
+	majorVersion, _ := strconv.Atoi(parts[0])
+	minorVersion, _ := strconv.Atoi(parts[1])
+	buildNumber, _ := strconv.Atoi(parts[2])
+
+	return osversion.OSVersion{
+		MajorVersion: uint8(majorVersion),
+		MinorVersion: uint8(minorVersion),
+		Build:        uint16(buildNumber),
+	}
 }
 
 // Less sorts matched platforms in front of other platforms.

--- a/vendor/github.com/Microsoft/hcsshim/osversion/platform_compat_windows.go
+++ b/vendor/github.com/Microsoft/hcsshim/osversion/platform_compat_windows.go
@@ -1,0 +1,35 @@
+package osversion
+
+// List of stable ABI compliant ltsc releases
+// Note: List must be sorted in ascending order
+var compatLTSCReleases = []uint16{
+	V21H2Server,
+}
+
+// CheckHostAndContainerCompat checks if given host and container
+// OS versions are compatible.
+// It includes support for stable ABI compliant versions as well.
+// Every release after WS 2022 will support the previous ltsc
+// container image. Stable ABI is in preview mode for windows 11 client.
+// Refer: https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility?tabs=windows-server-2022%2Cwindows-10#windows-server-host-os-compatibility
+func CheckHostAndContainerCompat(host, ctr OSVersion) bool {
+	// check major minor versions of host and guest
+	if host.MajorVersion != ctr.MajorVersion ||
+		host.MinorVersion != ctr.MinorVersion {
+		return false
+	}
+
+	// If host is < WS 2022, exact version match is required
+	if host.Build < V21H2Server {
+		return host.Build == ctr.Build
+	}
+
+	var supportedLtscRelease uint16
+	for i := len(compatLTSCReleases) - 1; i >= 0; i-- {
+		if host.Build >= compatLTSCReleases[i] {
+			supportedLtscRelease = compatLTSCReleases[i]
+			break
+		}
+	}
+	return ctr.Build >= supportedLtscRelease && ctr.Build <= host.Build
+}

--- a/vendor/github.com/Microsoft/hcsshim/osversion/windowsbuilds.go
+++ b/vendor/github.com/Microsoft/hcsshim/osversion/windowsbuilds.go
@@ -44,7 +44,15 @@ const (
 
 	// V21H2Server corresponds to Windows Server 2022 (ltsc2022).
 	V21H2Server = 20348
+	// LTSC2022 (Windows Server 2022) is an alias for [V21H2Server]
+	LTSC2022 = V21H2Server
 
 	// V21H2Win11 corresponds to Windows 11 (original release).
 	V21H2Win11 = 22000
+
+	// V22H2Win10 corresponds to Windows 10 (2022 Update).
+	V22H2Win10 = 19045
+
+	// V22H2Win11 corresponds to Windows 11 (2022 Update).
+	V22H2Win11 = 22621
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -11,7 +11,7 @@ github.com/Microsoft/go-winio/pkg/fs
 github.com/Microsoft/go-winio/pkg/guid
 github.com/Microsoft/go-winio/pkg/security
 github.com/Microsoft/go-winio/vhd
-# github.com/Microsoft/hcsshim v0.9.8
+# github.com/Microsoft/hcsshim v0.9.10
 ## explicit; go 1.13
 github.com/Microsoft/hcsshim
 github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options


### PR DESCRIPTION
This PR does the following:

- Update hcsshim tag to 0.9.10 + go mod tidy/vendor

- Uses the function introduced by https://github.com/microsoft/hcsshim/pull/1843 to invoke stable ABI compliant function in windows platform matcher. (In this PR, this change is limited to platforms/default_windows.go file. platform/default_windows_test.go file has some new tests added).
Exact platform match is required for OS Versions < WS2022. The exact version match is not needed in versions > WS2022 due to stable ABI compliance.
