### PR TITLE
cri: memory.memsw.limit_in_bytes: no such file or directory

### DIFF
--- a/pkg/cri/opts/spec_linux_opts.go
+++ b/pkg/cri/opts/spec_linux_opts.go
@@ -329,7 +329,7 @@ func WithResources(resources *runtime.LinuxContainerResources, tolerateMissingHu
 				s.Linux.Resources.Memory.Swap = &limit
 			}
 		}
-		if swapLimit != 0 {
+		if swapLimit != 0 && SwapControllerAvailable() {
 			s.Linux.Resources.Memory.Swap = &swapLimit
 		}
 


### PR DESCRIPTION
If kubelet passes the swap limit (default memory limit = swap limit ), it is configured for container irrespective if the node supports swap. This results in following error:

```
Jul 20 18:14:22.460: INFO: At 2023-07-20 17:58:34 +0000 UTC - event for coredns-5dd5756b68-6fvpf: {kubelet ip-10-0-116-157.us-west-2.compute.internal} Failed: Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error setting cgroup config for procHooks process: open /sys/fs/cgroup/memory/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod05d8a876_3004_479d_baa8_eac4f3309f4d.slice/cri-containerd-coredns.scope/memory.memsw.limit_in_bytes: no such file or directory: unknown
```

The reason this is coming to surface now is kubelet ([recently](https://github.com/kubernetes/kubernetes/pull/118764)) by default sets [memory limit = swap limit](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go#L340) even without `NodeSwap=true` feature gate is enabled. [[1]](https://github.com/kubernetes/kubernetes/pull/118764/files) [[2]](https://github.com/kubernetes/kubernetes/pull/118764/files#diff-f42b5c2632abe72391ae4fa91f7b51ebeb6266c7e10f6d6f472663cf97a493e8R114-R115) [[3]](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go#L338)

Fixes: #8855 
Related: https://github.com/kubernetes/kubernetes/pull/119486