### PR TITLE
cri: fix issues caused by converting the image reference

### DIFF
--- a/pkg/cri/sbserver/images/image_pull.go
+++ b/pkg/cri/sbserver/images/image_pull.go
@@ -328,6 +328,11 @@ func (c *CRIImageService) getLabels(ctx context.Context, name string) map[string
 // in containerd. If the reference is not managed by the cri plugin, the function also
 // generates necessary metadata for the image and make it managed.
 func (c *CRIImageService) UpdateImage(ctx context.Context, r string) error {
+	if ref, err := distribution.ParseAnyReference(r); err == nil && ref.String() != r {
+		log.G(ctx).Infof("Ignore inconsistent image ref, the image(%s) is parsed as %q", r, ref.String())
+		return nil
+	}
+
 	img, err := c.client.GetImage(ctx, r)
 	if err != nil && !errdefs.IsNotFound(err) {
 		return fmt.Errorf("get image by reference: %w", err)

--- a/pkg/cri/server/image_pull.go
+++ b/pkg/cri/server/image_pull.go
@@ -311,6 +311,11 @@ func (c *criService) getLabels(ctx context.Context, name string) map[string]stri
 // in containerd. If the reference is not managed by the cri plugin, the function also
 // generates necessary metadata for the image and make it managed.
 func (c *criService) updateImage(ctx context.Context, r string) error {
+	if ref, err := distribution.ParseAnyReference(r); err == nil && ref.String() != r {
+		log.G(ctx).Infof("Ignore inconsistent image ref, the image(%s) is parsed as %q", r, ref.String())
+		return nil
+	}
+
 	img, err := c.client.GetImage(ctx, r)
 	if err != nil && !errdefs.IsNotFound(err) {
 		return fmt.Errorf("get image by reference: %w", err)

--- a/pkg/cri/server/image_pull.go
+++ b/pkg/cri/server/image_pull.go
@@ -311,33 +311,46 @@ func (c *criService) getLabels(ctx context.Context, name string) map[string]stri
 // in containerd. If the reference is not managed by the cri plugin, the function also
 // generates necessary metadata for the image and make it managed.
 func (c *criService) updateImage(ctx context.Context, r string) error {
-	if ref, err := distribution.ParseAnyReference(r); err == nil && ref.String() != r {
-		log.G(ctx).Infof("Ignore inconsistent image ref, the image(%s) is parsed as %q", r, ref.String())
-		return nil
-	}
-
 	img, err := c.client.GetImage(ctx, r)
 	if err != nil && !errdefs.IsNotFound(err) {
 		return fmt.Errorf("get image by reference: %w", err)
 	}
-	if err == nil && img.Labels()[crilabels.ImageLabelKey] != crilabels.ImageLabelValue {
-		// Make sure the image has the image id as its unique
-		// identifier that references the image in its lifetime.
-		configDesc, err := img.Config(ctx)
-		if err != nil {
-			return fmt.Errorf("get image id: %w", err)
+	if err == nil {
+		if ref, err := distribution.ParseAnyReference(r); err == nil && ref.String() != r {
+			log.G(ctx).Infof("Ignore inconsistent image ref, the image(%s) is parsed as %q", r, ref.String())
+
+			if _, ok := img.Labels()[crilabels.ImageLabelKey]; ok {
+				image := containerdimages.Image{
+					Name:   img.Name(),
+					Labels: img.Labels(),
+				}
+				delete(image.Labels, crilabels.ImageLabelKey)
+				if _, err := c.client.ImageService().Update(ctx, image, "labels."+crilabels.ImageLabelKey); err != nil {
+					return fmt.Errorf("delete image label(%s) for %q: %w", crilabels.ImageLabelKey, r, err)
+				}
+			}
+			return nil
 		}
-		id := configDesc.Digest.String()
-		labels := c.getLabels(ctx, id)
-		if err := c.createImageReference(ctx, id, img.Target(), labels); err != nil {
-			return fmt.Errorf("create image id reference %q: %w", id, err)
-		}
-		if err := c.imageStore.Update(ctx, id); err != nil {
-			return fmt.Errorf("update image store for %q: %w", id, err)
-		}
-		// The image id is ready, add the label to mark the image as managed.
-		if err := c.createImageReference(ctx, r, img.Target(), labels); err != nil {
-			return fmt.Errorf("create managed label: %w", err)
+
+		if img.Labels()[crilabels.ImageLabelKey] != crilabels.ImageLabelValue {
+			// Make sure the image has the image id as its unique
+			// identifier that references the image in its lifetime.
+			configDesc, err := img.Config(ctx)
+			if err != nil {
+				return fmt.Errorf("get image id: %w", err)
+			}
+			id := configDesc.Digest.String()
+			labels := c.getLabels(ctx, id)
+			if err := c.createImageReference(ctx, id, img.Target(), labels); err != nil {
+				return fmt.Errorf("create image id reference %q: %w", id, err)
+			}
+			if err := c.imageStore.Update(ctx, id); err != nil {
+				return fmt.Errorf("update image store for %q: %w", id, err)
+			}
+			// The image id is ready, add the label to mark the image as managed.
+			if err := c.createImageReference(ctx, r, img.Target(), labels); err != nil {
+				return fmt.Errorf("create managed label: %w", err)
+			}
 		}
 	}
 	// If the image is not found, we should continue updating the cache,

--- a/pkg/cri/store/image/image.go
+++ b/pkg/cri/store/image/image.go
@@ -212,7 +212,7 @@ func (s *store) add(img Image) error {
 		return nil
 	}
 	// Or else, merge and sort the references.
-	i.References = docker.Sort(util.MergeStringSlices(i.References, img.References))
+	i.References = docker.StrictSort(util.MergeStringSlices(i.References, img.References))
 	i.Pinned = i.Pinned || img.Pinned
 	s.images[img.ID] = i
 	return nil


### PR DESCRIPTION
fix: https://github.com/containerd/containerd/issues/8848

As https://github.com/containerd/containerd/issues/8848#issuecomment-1649211628, the cri plugin's conversion of containerd image references causes a lot of issues.

After thinking about multiple implementations, I want the cri plugin to ignore images whose references are converted, and these images do not set the `io.cri-containerd.image=managed` label.