### PR TITLE
cri: pin the sandbox image by comparing to config.SandboxImage

### DIFF
--- a/integration/containerd_image_test.go
+++ b/integration/containerd_image_test.go
@@ -221,13 +221,6 @@ func TestContainerdImageInOtherNamespaces(t *testing.T) {
 
 func TestContainerdSandboxImage(t *testing.T) {
 	var pauseImage = images.Get(images.Pause)
-	ctx := context.Background()
-
-	t.Log("make sure the pause image exist")
-	pauseImg, err := containerdClient.GetImage(ctx, pauseImage)
-	require.NoError(t, err)
-	t.Log("ensure correct labels are set on pause image")
-	assert.Equal(t, "pinned", pauseImg.Labels()["io.cri-containerd.pinned"])
 
 	t.Log("pause image should be seen by cri plugin")
 	pimg, err := imageService.ImageStatus(&runtime.ImageSpec{Image: pauseImage})

--- a/pkg/cri/store/image/image.go
+++ b/pkg/cri/store/image/image.go
@@ -117,6 +117,17 @@ func (s *Store) Update(ctx context.Context, ref string) error {
 	return s.update(ref, img)
 }
 
+// PinImage sets pinned image for a reference.
+func (s *Store) PinImage(ctx context.Context, ref string) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	id, ok := s.refCache[ref]
+	if !ok {
+		return errdefs.ErrNotFound
+	}
+	return s.store.pin(id, ref)
+}
+
 // update updates the internal cache. img == nil means that
 // the image does not exist in containerd.
 func (s *Store) update(ref string, img *Image) error {


### PR DESCRIPTION
When the `pause` image is already in the k8s.io namespace, it is not recognized correctly as the PinnedImage, and when I update the pause image in the containerd config, the old pause is still PinnedImage, which may cause the old pause image not to be cleaned up

The `pause` image sets the PinnedImage by image reference instead of the pinned label, so that the currently set sandbox image is recognized as the PinnedImage, and the pinned label is only used when the user manually sets the pinned image.

This fixes the issue of recognizing existing pause images and also prevents old pause images from being recognized as PinnedImage.