### PR TITLE
cri: fix using the labels to pin image

### DIFF
--- a/pkg/cri/store/image/image.go
+++ b/pkg/cri/store/image/image.go
@@ -213,6 +213,7 @@ func (s *store) add(img Image) error {
 	}
 	// Or else, merge and sort the references.
 	i.References = docker.Sort(util.MergeStringSlices(i.References, img.References))
+	i.Pinned = i.Pinned || img.Pinned
 	s.images[img.ID] = i
 	return nil
 }


### PR DESCRIPTION
A image usually has multiple references, so as long as one of the references has `io.cri-containerd.pinned=pinned` label, then the image is pinned.

Reproducing current issues
```bash
$ ctr -n k8s.io images pull --label=io.cri-containerd.pinned=pinned docker.io/library/busybox:1.36
$ crictl --debug images
// ignore something
&Image{Id:sha256:a416a98b71e224a31ee99cff8e16063554498227d2b696152a9c3e0aa65e5824,RepoTags:[docker.io/library/busybox:1.36],RepoDigests:[],Size_:2224229,Uid:nil,Username:,Spec:nil,Pinned:false,}
```

> Of course, if we ctr manually remove the image reference containing the label, `Pinned` will still be true, but will become false after restarting.
> 
> Although it would be possible to set Pinned strictly based on the labels of the image references, it would be complicated to keep track of each image reference, and I'm not sure it's necessary to do so.