### PR TITLE
pkg/epoch: fix Y2038 on 32-bit hosts

### DIFF
--- a/pkg/epoch/epoch.go
+++ b/pkg/epoch/epoch.go
@@ -73,7 +73,7 @@ func ParseSourceDateEpoch(sourceDateEpoch string) (*time.Time, error) {
 
 // SetSourceDateEpoch sets the SOURCE_DATE_EPOCH env var.
 func SetSourceDateEpoch(tm time.Time) {
-	_ = os.Setenv(SourceDateEpochEnv, strconv.Itoa(int(tm.Unix())))
+	_ = os.Setenv(SourceDateEpochEnv, fmt.Sprintf("%d", tm.Unix()))
 }
 
 // UnsetSourceDateEpoch unsets the SOURCE_DATE_EPOCH env var.

--- a/pkg/epoch/epoch_test.go
+++ b/pkg/epoch/epoch_test.go
@@ -17,9 +17,9 @@
 package epoch
 
 import (
+	"fmt"
 	"os"
 	"runtime"
-	"strconv"
 	"testing"
 	"time"
 
@@ -85,7 +85,7 @@ func TestSourceDateEpoch(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, vp.Equal(sourceDateEpoch.UTC()))
 
-		vp, err = ParseSourceDateEpoch(strconv.Itoa(int(sourceDateEpoch.Unix())))
+		vp, err = ParseSourceDateEpoch(fmt.Sprintf("%d", sourceDateEpoch.Unix()))
 		require.NoError(t, err)
 		require.True(t, vp.Equal(sourceDateEpoch))
 


### PR DESCRIPTION
`strconv.Itoa(int(tm.Unix()))` rounds the time to 32-bit int on 32-bit hosts