### PR TITLE
[release/1.7] cri: memory.memsw.limit_in_bytes: no such file or directory

### DIFF
--- a/pkg/cri/opts/spec_linux_opts.go
+++ b/pkg/cri/opts/spec_linux_opts.go
@@ -330,7 +330,7 @@ func WithResources(resources *runtime.LinuxContainerResources, tolerateMissingHu
 				s.Linux.Resources.Memory.Swap = &limit
 			}
 		}
-		if swapLimit != 0 {
+		if swapLimit != 0 && SwapControllerAvailable() {
 			s.Linux.Resources.Memory.Swap = &swapLimit
 		}
 


### PR DESCRIPTION
If kubelet passes the swap limit (default memory limit = swap limit ), it is configured for container irrespective if the node supports swap.


(cherry picked from commit 06f18c69d22b81fe040596d50f32d6bca2079a3d)