### PR TITLE
[release/1.6] migrate to community owned bucket for node e2e tests

### DIFF
--- a/contrib/gce/configure.sh
+++ b/contrib/gce/configure.sh
@@ -114,7 +114,7 @@ if [ "${CONTAINERD_TEST:-"false"}"  != "true" ]; then
   # CONTAINERD_VERSION is the cri-containerd version to use.
   version=${CONTAINERD_VERSION:-""}
 else
-  deploy_path=${CONTAINERD_DEPLOY_PATH:-"cri-containerd-staging"}
+  deploy_path=${CONTAINERD_DEPLOY_PATH:-"k8s-staging-cri-tools"}
 
   # PULL_REFS_METADATA is the metadata key of PULL_REFS from prow.
   PULL_REFS_METADATA="PULL_REFS"

--- a/test/push.sh
+++ b/test/push.sh
@@ -21,7 +21,7 @@ set -o pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 
 # DEPLOY_BUCKET is the gcs bucket where the tarball should be stored in.
-DEPLOY_BUCKET=${DEPLOY_BUCKET:-"cri-containerd-staging"}
+DEPLOY_BUCKET=${DEPLOY_BUCKET:-"k8s-staging-cri-tools"}
 # DEPLOY_DIR is the directory in the gcs bucket to store the tarball.
 DEPLOY_DIR=${DEPLOY_DIR:-""}
 # BUILD_DIR is the directory of the build out.


### PR DESCRIPTION
Part of:
- kubernetes/test-infra#29995
- kubernetes/test-infra#30153

Backport of #8862

(cherry picked from commit 98974117b36a3752c74bb3ba743968efbd10707e)