### PR TITLE
[1.7] Unpacks should check and do fetch if content not present in all cases

### DIFF
--- a/pkg/unpack/unpacker.go
+++ b/pkg/unpack/unpacker.go
@@ -284,6 +284,36 @@ func (u *Unpacker) unpack(
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	doFetchFn := func(i int) error {
+		if fetchErr == nil {
+			fetchErr = make(chan error, 1)
+			fetchOffset = i
+			fetchC = make([]chan struct{}, len(layers)-fetchOffset)
+			for i := range fetchC {
+				fetchC[i] = make(chan struct{})
+			}
+
+			go func(i int) {
+				err := u.fetch(ctx, h, layers[i:], fetchC)
+				if err != nil {
+					fetchErr <- err
+				}
+				close(fetchErr)
+			}(i)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case err := <-fetchErr:
+			if err != nil {
+				return err
+			}
+		case <-fetchC[i-fetchOffset]:
+		}
+		return nil
+	}
+
 	doUnpackFn := func(i int, desc ocispec.Descriptor) error {
 		parent := identity.ChainID(chain)
 		chain = append(chain, diffIDs[i])
@@ -296,8 +326,14 @@ func (u *Unpacker) unpack(
 		defer unlock()
 
 		if _, err := sn.Stat(ctx, chainID); err == nil {
-			// no need to handle
-			return nil
+			if _, err := cs.Info(ctx, desc.Digest); err == nil {
+				// no need to handle
+				return nil
+			} else if errdefs.IsNotFound(err) {
+				return doFetchFn(i)
+			} else {
+				return fmt.Errorf("failed to get content info %s: %w", desc.Digest.String(), err)
+			}
 		} else if !errdefs.IsNotFound(err) {
 			return fmt.Errorf("failed to stat snapshot %s: %w", chainID, err)
 		}
@@ -349,33 +385,9 @@ func (u *Unpacker) unpack(
 			}
 		}
 
-		if fetchErr == nil {
-			fetchErr = make(chan error, 1)
-			fetchOffset = i
-			fetchC = make([]chan struct{}, len(layers)-fetchOffset)
-			for i := range fetchC {
-				fetchC[i] = make(chan struct{})
-			}
-
-			go func(i int) {
-				err := u.fetch(ctx, h, layers[i:], fetchC)
-				if err != nil {
-					fetchErr <- err
-				}
-				close(fetchErr)
-			}(i)
-		}
-
-		select {
-		case <-ctx.Done():
+		if err := doFetchFn(i); err != nil {
 			cleanup.Do(ctx, abort)
-			return ctx.Err()
-		case err := <-fetchErr:
-			if err != nil {
-				cleanup.Do(ctx, abort)
-				return err
-			}
-		case <-fetchC[i-fetchOffset]:
+			return err
 		}
 
 		diff, err := a.Apply(ctx, desc, mounts, unpack.ApplyOpts...)


### PR DESCRIPTION
This patch adds an additional check in the unpack logic to "always" fetch the content if not present. This handles a case that can lead to incomplete images (images that have the RootFs in the snapshot but have a different digest in their oci config) and prevent snapshotters other than the default from working.

In terms of code changes...
1) extracts doFetchFn from existing fetch logic and pulls it up above doUnpackFn
2) In do UnpackFn, after the sn.Stat check we also check cs.Info and if not found will call doFetchFn.
3) Existing fetch logic later in UnpackFn is unchanged but instead called via doFetchFn.

Fixes #8674 

Signed-off-by: Simon Kaegi [simon_kaegi@ca.ibm.com](mailto:simon_kaegi@ca.ibm.com)