### PR TITLE
cri: add config validation for cgroup driver

### DIFF
--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -442,5 +442,10 @@ func ValidatePluginConfig(ctx context.Context, c *PluginConfig) error {
 			return fmt.Errorf("invalid `drain_exec_sync_io_timeout`: %w", err)
 		}
 	}
+
+	// Validate platform-specific configuration
+	if err := validatePlatformSpecific(ctx, c); err != nil {
+		return err
+	}
 	return nil
 }

--- a/pkg/cri/config/helpers.go
+++ b/pkg/cri/config/helpers.go
@@ -1,0 +1,70 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+
+	runhcsoptions "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
+	runtimeoptions "github.com/containerd/containerd/pkg/runtimeoptions/v1"
+	"github.com/containerd/containerd/plugin"
+	runcoptions "github.com/containerd/containerd/runtime/v2/runc/options"
+	"github.com/pelletier/go-toml"
+)
+
+const (
+	// runtimeRunhcsV1 is the runtime type for runhcs.
+	runtimeRunhcsV1 = "io.containerd.runhcs.v1"
+)
+
+// GenerateRuntimeOptions generates runtime options from cri plugin config.
+func GenerateRuntimeOptions(r Runtime) (interface{}, error) {
+	if r.Options == nil {
+		return nil, nil
+	}
+	optionsTree, err := toml.TreeFromMap(r.Options)
+	if err != nil {
+		return nil, err
+	}
+	options := getRuntimeOptionsType(r.Type)
+	if err := optionsTree.Unmarshal(options); err != nil {
+		return nil, err
+	}
+
+	// For generic configuration, if no config path specified (preserving old behavior), pass
+	// the whole TOML configuration section to the runtime.
+	if runtimeOpts, ok := options.(*runtimeoptions.Options); ok && runtimeOpts.ConfigPath == "" {
+		runtimeOpts.ConfigBody, err = optionsTree.Marshal()
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal TOML blob for runtime %q: %v", r.Type, err)
+		}
+	}
+
+	return options, nil
+}
+
+// getRuntimeOptionsType gets empty runtime options by the runtime type name.
+func getRuntimeOptionsType(t string) interface{} {
+	switch t {
+	case plugin.RuntimeRuncV2:
+		return &runcoptions.Options{}
+	case runtimeRunhcsV1:
+		return &runhcsoptions.Options{}
+	default:
+		return &runtimeoptions.Options{}
+	}
+}

--- a/pkg/cri/config/helpers_test.go
+++ b/pkg/cri/config/helpers_test.go
@@ -1,0 +1,101 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/containerd/containerd/plugin"
+	runcoptions "github.com/containerd/containerd/runtime/v2/runc/options"
+	"github.com/pelletier/go-toml"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateRuntimeOptions(t *testing.T) {
+	nilOpts := `
+systemd_cgroup = true
+[containerd]
+  no_pivot = true
+  default_runtime_name = "default"
+[containerd.runtimes.runcv2]
+  runtime_type = "` + plugin.RuntimeRuncV2 + `"
+`
+	nonNilOpts := `
+systemd_cgroup = true
+[containerd]
+  no_pivot = true
+  default_runtime_name = "default"
+[containerd.runtimes.legacy.options]
+  Runtime = "legacy"
+  RuntimeRoot = "/legacy"
+[containerd.runtimes.runc.options]
+  BinaryName = "runc"
+  Root = "/runc"
+  NoNewKeyring = true
+[containerd.runtimes.runcv2]
+  runtime_type = "` + plugin.RuntimeRuncV2 + `"
+[containerd.runtimes.runcv2.options]
+  BinaryName = "runc"
+  Root = "/runcv2"
+  NoNewKeyring = true
+`
+	var nilOptsConfig, nonNilOptsConfig Config
+	tree, err := toml.Load(nilOpts)
+	require.NoError(t, err)
+	err = tree.Unmarshal(&nilOptsConfig)
+	require.NoError(t, err)
+	require.Len(t, nilOptsConfig.Runtimes, 1)
+
+	tree, err = toml.Load(nonNilOpts)
+	require.NoError(t, err)
+	err = tree.Unmarshal(&nonNilOptsConfig)
+	require.NoError(t, err)
+	require.Len(t, nonNilOptsConfig.Runtimes, 3)
+
+	for _, test := range []struct {
+		desc            string
+		r               Runtime
+		c               Config
+		expectedOptions interface{}
+	}{
+		{
+			desc:            "when options is nil, should return nil option for io.containerd.runc.v2",
+			r:               nilOptsConfig.Runtimes["runcv2"],
+			c:               nilOptsConfig,
+			expectedOptions: nil,
+		},
+		{
+			desc: "when options is not nil, should be able to decode for io.containerd.runc.v2",
+			r:    nonNilOptsConfig.Runtimes["runcv2"],
+			c:    nonNilOptsConfig,
+			expectedOptions: &runcoptions.Options{
+				BinaryName:   "runc",
+				Root:         "/runcv2",
+				NoNewKeyring: true,
+			},
+		},
+	} {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			opts, err := GenerateRuntimeOptions(test.r)
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedOptions, opts)
+		})
+	}
+}

--- a/pkg/cri/config/validate_linux.go
+++ b/pkg/cri/config/validate_linux.go
@@ -1,0 +1,58 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package config
+
+import (
+	"context"
+	"fmt"
+
+	runcoptions "github.com/containerd/containerd/runtime/v2/runc/options"
+)
+
+// validatePlatformSpecific validates the platform specific options
+func validatePlatformSpecific(ctx context.Context, c *PluginConfig) error {
+	var systemdCgroup bool
+	var systemdCgroupSettingFound bool
+
+	for k, r := range c.ContainerdConfig.Runtimes {
+		opts, err := GenerateRuntimeOptions(r)
+		if err != nil {
+			return fmt.Errorf("failed to parse runtime options of %q: %w", k, err)
+		}
+
+		if isSystemd, ok := runtimeHandlerHasSystemdCgroup(opts); ok {
+			if systemdCgroupSettingFound && isSystemd != systemdCgroup {
+				return fmt.Errorf("conflicting SystemdCgroup settings found in runtime handler options, all runc runtime configs expected to have the same setting for SystemdCgroup")
+			}
+			systemdCgroup = isSystemd
+			systemdCgroupSettingFound = true
+		}
+	}
+	return nil
+}
+
+func runtimeHandlerHasSystemdCgroup(opts interface{}) (bool, bool) {
+	switch v := opts.(type) {
+	case *runcoptions.Options:
+		systemdCgroup := v.SystemdCgroup
+		if systemdCgroup {
+			return true, true
+		}
+		return false, true
+	}
+	return false, false
+}

--- a/pkg/cri/config/validate_other.go
+++ b/pkg/cri/config/validate_other.go
@@ -1,0 +1,26 @@
+//go:build !linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package config
+
+import "context"
+
+// validatePlatformSpecific validates the platform specific options
+func validatePlatformSpecific(ctx context.Context, c *PluginConfig) error {
+	return nil
+}

--- a/pkg/cri/sbserver/helpers_test.go
+++ b/pkg/cri/sbserver/helpers_test.go
@@ -28,15 +28,11 @@ import (
 
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/oci"
-	criconfig "github.com/containerd/containerd/pkg/cri/config"
 	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
-	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/protobuf/types"
-	runcoptions "github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/containerd/typeurl/v2"
 
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pelletier/go-toml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -110,79 +106,6 @@ func TestBuildLabels(t *testing.T) {
 	newLabels["a"] = "e"
 	assert.Empty(t, configLabels[containerKindLabel], "should not add new labels into original label")
 	assert.Equal(t, "b", configLabels["a"], "change in new labels should not affect original label")
-}
-
-func TestGenerateRuntimeOptions(t *testing.T) {
-	nilOpts := `
-systemd_cgroup = true
-[containerd]
-  no_pivot = true
-  default_runtime_name = "default"
-[containerd.runtimes.runcv2]
-  runtime_type = "` + plugin.RuntimeRuncV2 + `"
-`
-	nonNilOpts := `
-systemd_cgroup = true
-[containerd]
-  no_pivot = true
-  default_runtime_name = "default"
-[containerd.runtimes.legacy.options]
-  Runtime = "legacy"
-  RuntimeRoot = "/legacy"
-[containerd.runtimes.runc.options]
-  BinaryName = "runc"
-  Root = "/runc"
-  NoNewKeyring = true
-[containerd.runtimes.runcv2]
-  runtime_type = "` + plugin.RuntimeRuncV2 + `"
-[containerd.runtimes.runcv2.options]
-  BinaryName = "runc"
-  Root = "/runcv2"
-  NoNewKeyring = true
-`
-	var nilOptsConfig, nonNilOptsConfig criconfig.Config
-	tree, err := toml.Load(nilOpts)
-	require.NoError(t, err)
-	err = tree.Unmarshal(&nilOptsConfig)
-	require.NoError(t, err)
-	require.Len(t, nilOptsConfig.Runtimes, 1)
-
-	tree, err = toml.Load(nonNilOpts)
-	require.NoError(t, err)
-	err = tree.Unmarshal(&nonNilOptsConfig)
-	require.NoError(t, err)
-	require.Len(t, nonNilOptsConfig.Runtimes, 3)
-
-	for _, test := range []struct {
-		desc            string
-		r               criconfig.Runtime
-		c               criconfig.Config
-		expectedOptions interface{}
-	}{
-		{
-			desc:            "when options is nil, should return nil option for io.containerd.runc.v2",
-			r:               nilOptsConfig.Runtimes["runcv2"],
-			c:               nilOptsConfig,
-			expectedOptions: nil,
-		},
-		{
-			desc: "when options is not nil, should be able to decode for io.containerd.runc.v2",
-			r:    nonNilOptsConfig.Runtimes["runcv2"],
-			c:    nonNilOptsConfig,
-			expectedOptions: &runcoptions.Options{
-				BinaryName:   "runc",
-				Root:         "/runcv2",
-				NoNewKeyring: true,
-			},
-		},
-	} {
-		test := test
-		t.Run(test.desc, func(t *testing.T) {
-			opts, err := generateRuntimeOptions(test.r)
-			assert.NoError(t, err)
-			assert.Equal(t, test.expectedOptions, opts)
-		})
-	}
 }
 
 func TestEnvDeduplication(t *testing.T) {

--- a/pkg/cri/sbserver/sandbox_run.go
+++ b/pkg/cri/sbserver/sandbox_run.go
@@ -97,7 +97,7 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 
 	runtimeStart := time.Now()
 	// Retrieve runtime options
-	runtimeOpts, err := generateRuntimeOptions(ociRuntime)
+	runtimeOpts, err := criconfig.GenerateRuntimeOptions(ociRuntime)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate sandbox runtime options: %w", err)
 	}

--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -152,7 +152,7 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 
 	sandboxLabels := buildLabels(config.Labels, image.ImageSpec.Config.Labels, containerKindSandbox)
 
-	runtimeOpts, err := generateRuntimeOptions(ociRuntime)
+	runtimeOpts, err := criconfig.GenerateRuntimeOptions(ociRuntime)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate runtime options: %w", err)
 	}


### PR DESCRIPTION
Reject configuration if conflicting (different) cgroup driver has been configured accross different runtime handlers.