### PR TITLE
[release/1.7] cherry-pick: Fix ro mount option being passed

### DIFF
--- a/snapshots/overlay/overlayutils/check.go
+++ b/snapshots/overlay/overlayutils/check.go
@@ -175,7 +175,8 @@ func NeedsUserXAttr(d string) (bool, error) {
 	}
 
 	opts := []string{
-		fmt.Sprintf("ro,lowerdir=%s:%s,upperdir=%s,workdir=%s", filepath.Join(td, "lower2"), filepath.Join(td, "lower1"), filepath.Join(td, "upper"), filepath.Join(td, "work")),
+		"ro",
+		fmt.Sprintf("lowerdir=%s:%s,upperdir=%s,workdir=%s", filepath.Join(td, "lower2"), filepath.Join(td, "lower1"), filepath.Join(td, "upper"), filepath.Join(td, "work")),
 		"userxattr",
 	}
 


### PR DESCRIPTION
Clean cherry pick of f3daf32c73656c5baa93acdca323295c61113cc3 (#8852) into `release/1.7`
-------

"ro" was not parsed out of the string, so it was passed as part of data to mount().
This would lead to mount() returning an invalid argument code. Separate out the "ro" option, much like "userxattr", which will allow the MS-RDONLY mountflag to get set.

Signed-off-by: Ben Foster <bpfoster@gmail.com>
(cherry picked from commit f3daf32c73656c5baa93acdca323295c61113cc3)