### PR TITLE
[release/1.6] backport: ro option for userxattr mount check + cherry-pick: Fix ro mount option being passed

### DIFF
--- a/snapshots/overlay/overlayutils/check.go
+++ b/snapshots/overlay/overlayutils/check.go
@@ -176,6 +176,7 @@ func NeedsUserXAttr(d string) (bool, error) {
 	}
 
 	opts := []string{
+		"ro",
 		fmt.Sprintf("lowerdir=%s:%s,upperdir=%s,workdir=%s", filepath.Join(td, "lower2"), filepath.Join(td, "lower1"), filepath.Join(td, "upper"), filepath.Join(td, "work")),
 		"userxattr",
 	}


### PR DESCRIPTION
Backport of #8852 to create the effect of adding #7008 to `release/1.6` (which was never done), and then applying the recent fix in #8852 so that both issues are solved for this LTS branch.
------

"ro" was not parsed out of the string, so it was passed as part of data to mount().
This would lead to mount() returning an invalid argument code. Separate out the "ro" option, much like "userxattr", which will allow the MS-RDONLY mountflag to get set.

Signed-off-by: Ben Foster <bpfoster@gmail.com>
(cherry picked from commit f3daf32c73656c5baa93acdca323295c61113cc3)