### PR TITLE
remotes: FetchByDigest: propagate media type from config to desc

### DIFF
--- a/cmd/ctr/commands/content/content.go
+++ b/cmd/ctr/commands/content/content.go
@@ -491,10 +491,11 @@ var (
 				if err != nil {
 					return err
 				}
-				rc, _, err := fetcherByDigest.FetchByDigest(ctx, dgst, remotes.WithMediaType(context.String("media-type")))
+				rc, desc, err := fetcherByDigest.FetchByDigest(ctx, dgst, remotes.WithMediaType(context.String("media-type")))
 				if err != nil {
 					return err
 				}
+				log.G(ctx).Debugf("desc=%+v", desc)
 				_, err = io.Copy(os.Stdout, rc)
 				rc.Close()
 				if err != nil {

--- a/core/remotes/docker/fetcher.go
+++ b/core/remotes/docker/fetcher.go
@@ -256,6 +256,9 @@ func (r dockerFetcher) FetchByDigest(ctx context.Context, dgst digest.Digest, op
 		Digest:    dgst,
 		Size:      sz,
 	}
+	if config.Mediatype != "" {
+		desc.MediaType = config.Mediatype
+	}
 	return seeker, desc, nil
 }
 


### PR DESCRIPTION
A media type string passed via `WithMediaType()` was not propagated to a descriptor returned by `FetchByDigest()`.

Follow-up to:
- #8744