### PR TITLE
platforms: clarify docs for amd64/arm64 variant normalization

### DIFF
--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -102,6 +102,9 @@
 // unless it is explicitly provided. This is treated as equivalent to armhf. A
 // previous architecture, armel, will be normalized to arm/v6.
 //
+// Similarly, the most common arm64 version v8, and most common amd64 version v1
+// are represented without the variant.
+//
 // While these normalizations are provided, their support on arm platforms has
 // not yet been fully implemented and tested.
 package platforms


### PR DESCRIPTION
Clarify the docs about how normalization is performed for `amd64/arm64`. There are no functional changes as this is already the behavior in the implementation.

ref: https://github.com/moby/buildkit/issues/4082