### PR TITLE
[release/1.6 backport] Upgrade GitHub actions packages in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,10 +99,10 @@ jobs:
           path: src/github.com/containerd/containerd
 
       - name: Setup buildx instance
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         with:
           use: true
-      - uses: crazy-max/ghaction-github-runtime@v1 # sets up needed vars for caching to github
+      - uses: crazy-max/ghaction-github-runtime@v2 # sets up needed vars for caching to github
       - name: Make
         shell: bash
         run: |


### PR DESCRIPTION
Resolve NodeJS 12 and command deprecation warnings by upgrading docker/setup-buildx-action and crazy-max/ghaction-github-runtime packages.

[https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)
[https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)


(cherry picked from commit 14a38e12b78c857ebb01ffb724ab604ca9ffdc38)

clean cherry pick of #7794