### PR TITLE
cmd: containerd: allow building w/o systemd notify

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -120,6 +120,8 @@ make generate
 >   * `no_btrfs`: A build tag disables building the Btrfs snapshot driver.
 >   * `no_devmapper`: A build tag disables building the device mapper snapshot driver.
 >   * `no_zfs`: A build tag disables building the ZFS snapshot driver.
+> * platform
+>   * `no_systemd`: disables any systemd specific code
 >
 > For example, adding `BUILDTAGS=no_btrfs` to your environment before calling the **binaries**
 > Makefile target will disable the btrfs driver within the containerd Go build.

--- a/cmd/containerd/command/notify_no_systemd.go
+++ b/cmd/containerd/command/notify_no_systemd.go
@@ -1,0 +1,33 @@
+//go:build linux && no_systemd
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package command
+
+import (
+	"context"
+)
+
+// notifyReady notifies systemd that the daemon is ready to serve requests
+func notifyReady(ctx context.Context) error {
+	return nil
+}
+
+// notifyStopping notifies systemd that the daemon is about to be stopped
+func notifyStopping(ctx context.Context) error {
+	return nil
+}

--- a/cmd/containerd/command/notify_systemd.go
+++ b/cmd/containerd/command/notify_systemd.go
@@ -1,3 +1,5 @@
+//go:build linux && !no_systemd
+
 /*
    Copyright The containerd Authors.
 


### PR DESCRIPTION
Make the rather obscure systemd notification build-time optional by setting 'no_systemd' tag and so skip dependencies on around 9kLoC vendor code.