### PR TITLE
Makefile: make hardcoded config defaults build-time-customizable

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -87,7 +87,9 @@ sudo make install
 ```
 
 The install prefix can be changed by passing the `PREFIX` variable (defaults
-to `/usr/local`).
+to `/usr/local`). The local state dir can be changed via `LOCALSTATEDIR` (defaults
+to `/var`). The run state dir can be changed via `RUNSTATEDIR` (defaults to `/var`).
+All installation pathes are derived from these variables.
 
 Note: if you set one of these vars, set them to the same values on all make stages
 (build as well as install).

--- a/defaults/defaults_unix.go
+++ b/defaults/defaults_unix.go
@@ -18,7 +18,7 @@
 
 package defaults
 
-const (
+var (
 	// DefaultRootDir is the default location used by containerd to store
 	// persistent data
 	DefaultRootDir = "/var/lib/containerd"

--- a/runtime/v2/shim/util_unix.go
+++ b/runtime/v2/shim/util_unix.go
@@ -62,7 +62,7 @@ func AdjustOOMScore(pid int) error {
 	return nil
 }
 
-const socketRoot = defaults.DefaultStateDir
+var socketRoot = defaults.DefaultStateDir
 
 // SocketAddress returns a socket address
 func SocketAddress(ctx context.Context, socketPath, id string) (string, error) {


### PR DESCRIPTION
The defaults/defaults_unix.go file contains a bunch of defaults which distros or site local installs might wanna customize. In order to allow that w/o individual patching, changing the consts into vars and override them via linker flags from Makefile.