### PR TITLE
Makefile: allow overriding the binary executable target dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ ROOTDIR=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 # The files will be installed under `$(DESTDIR)/$(PREFIX)`.
 # The convention of `DESTDIR` was changed in containerd v1.6.
 PREFIX        ?= /usr/local
+BINDIR        ?= $(PREFIX)/bin
 DATADIR       ?= $(PREFIX)/share
 MANDIR        ?= $(DATADIR)/man
 
@@ -408,12 +409,12 @@ clean-test: ## clean up debris from previously failed tests
 
 install: ## install binaries
 	@echo "$(WHALE) $@ $(BINARIES)"
-	@$(INSTALL) -d $(DESTDIR)$(PREFIX)/bin
-	@$(INSTALL) $(BINARIES) $(DESTDIR)$(PREFIX)/bin
+	@$(INSTALL) -d $(DESTDIR)$(BINDIR)
+	@$(INSTALL) $(BINARIES) $(DESTDIR)$(BINDIR)
 
 uninstall:
 	@echo "$(WHALE) $@"
-	@rm -f $(addprefix $(DESTDIR)$(PREFIX)/bin/,$(notdir $(BINARIES)))
+	@rm -f $(addprefix $(DESTDIR)$(BINDIR)/,$(notdir $(BINARIES)))
 
 ifeq ($(GOOS),windows)
 install-deps:


### PR DESCRIPTION
Distros tend to change this to specific locations (eg. on MVCC installs), therefore introduce a generic environment variable that's a common practise since 30+ years and thus already well known and supported by distros.