### PR TITLE
Add multi-subscriber support to GetContainerEvents CRI API

### DIFF
--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -60,6 +60,7 @@ const (
 
 var (
 	runtimeService     cri.RuntimeService
+	runtimeService2    cri.RuntimeService // to test GetContainerEvents broadcast
 	imageService       cri.ImageManagerService
 	containerdClient   *containerd.Client
 	containerdEndpoint string
@@ -84,6 +85,10 @@ func ConnectDaemons() error {
 	if err != nil {
 		return fmt.Errorf("failed to create runtime service: %w", err)
 	}
+	runtimeService2, err = remote.NewRuntimeService(*criEndpoint, timeout)
+	if err != nil {
+		return fmt.Errorf("failed to create runtime service: %w", err)
+	}
 	imageService, err = remote.NewImageService(*criEndpoint, timeout)
 	if err != nil {
 		return fmt.Errorf("failed to create image service: %w", err)
@@ -92,6 +97,10 @@ func ConnectDaemons() error {
 	// need to check whether it is actually connected.
 	// TODO(#6069) Use grpc options to block on connect and remove for this list containers request.
 	_, err = runtimeService.ListContainers(&runtime.ContainerFilter{})
+	if err != nil {
+		return fmt.Errorf("failed to list containers: %w", err)
+	}
+	_, err = runtimeService2.ListContainers(&runtime.ContainerFilter{})
 	if err != nil {
 		return fmt.Errorf("failed to list containers: %w", err)
 	}

--- a/pkg/cri/server/service.go
+++ b/pkg/cri/server/service.go
@@ -130,6 +130,8 @@ type criService struct {
 	nri *nri.API
 	// sandboxService is the sandbox related service for CRI
 	sandboxService sandboxService
+	// containerEventsClients keeps a map of connected stream clients
+	containerEventsClients sync.Map
 }
 
 // NewCRIService returns a new instance of CRIService
@@ -279,6 +281,10 @@ func (c *criService) Run(ready func()) error {
 			close(cniNetConfMonitorErrCh)
 		}()
 	}
+
+	// Start events broadcaster.
+	log.L.Info("Start events broadcaster")
+	go c.broadcastEvents()
 
 	// Start streaming server.
 	log.L.Info("Start streaming server")


### PR DESCRIPTION
This pull request addresses issue #7318 by introducing events broadcasting to the current implementation. 

The `integration/container_event_test.go` is extended to demonstrate the broadcasting capabilities of two simultaneous connected clients.