### PR TITLE
delete checkout branch in doc

### DIFF
--- a/docs/NRI.md
+++ b/docs/NRI.md
@@ -115,7 +115,6 @@ on github, compiling it and starting it up.
 ```bash
 git clone https://github.com/containerd/nri
 cd nri
-git checkout pr/proto/draft
 make
 ./build/bin/logger -idx 00
 ```


### PR DESCRIPTION
branch "pr/proto/draft" in NRI doesn't exist anymore it's better to delete this line