### PR TITLE
feat: replace mcr.microsoft.com registry to ghcr.io/containerd registry

### DIFF
--- a/integration/client/client_windows_test.go
+++ b/integration/client/client_windows_test.go
@@ -42,30 +42,30 @@ func init() {
 	b := osversion.Build()
 	switch b {
 	case osversion.RS1:
-		testImage = "mcr.microsoft.com/windows/nanoserver:sac2016"
+		testImage = "ghcr.io/containerd/windows/nanoserver:sac2016"
 	case osversion.RS3:
-		testImage = "mcr.microsoft.com/windows/nanoserver:1709"
+		testImage = "ghcr.io/containerd/windows/nanoserver:1709"
 	case osversion.RS4:
-		testImage = "mcr.microsoft.com/windows/nanoserver:1803"
+		testImage = "ghcr.io/containerd/windows/nanoserver:1803"
 	case osversion.RS5:
-		testImage = "mcr.microsoft.com/windows/nanoserver:1809"
+		testImage = "ghcr.io/containerd/windows/nanoserver:1809"
 	case osversion.V19H1:
-		testImage = "mcr.microsoft.com/windows/nanoserver:1903"
+		testImage = "ghcr.io/containerd/windows/nanoserver:1903"
 	case osversion.V19H2:
-		testImage = "mcr.microsoft.com/windows/nanoserver:1909"
+		testImage = "ghcr.io/containerd/windows/nanoserver:1909"
 	case osversion.V20H1:
-		testImage = "mcr.microsoft.com/windows/nanoserver:2004"
+		testImage = "ghcr.io/containerd/windows/nanoserver:2004"
 	case osversion.V20H2:
-		testImage = "mcr.microsoft.com/windows/nanoserver:20H2"
+		testImage = "ghcr.io/containerd/windows/nanoserver:20H2"
 	case osversion.V21H2Server:
-		testImage = "mcr.microsoft.com/windows/nanoserver:ltsc2022"
+		testImage = "ghcr.io/containerd/windows/nanoserver:ltsc2022"
 	default:
 		// Due to some efforts in improving down-level compatibility for Windows containers (see
 		// https://techcommunity.microsoft.com/t5/containers/windows-server-2022-and-beyond-for-containers/ba-p/2712487)
 		// the ltsc2022 image should continue to work on builds ws2022 and onwards (Windows 11 for example). With this in mind,
 		// if there's no mapping for the host build just use the Windows Server 2022 image.
 		if b > osversion.V21H2Server {
-			testImage = "mcr.microsoft.com/windows/nanoserver:ltsc2022"
+			testImage = "ghcr.io/containerd/windows/nanoserver:ltsc2022"
 			return
 		}
 		fmt.Println("No test image defined for Windows build version:", b)

--- a/integration/client/image_test.go
+++ b/integration/client/image_test.go
@@ -235,7 +235,7 @@ func TestImageSupportedBySnapshotter_Error(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		unsupportedImage = "registry.k8s.io/pause-amd64:3.2"
 	} else {
-		unsupportedImage = "mcr.microsoft.com/windows/nanoserver:1809"
+		unsupportedImage = "ghcr.io/containerd/windows/nanoserver:1809"
 	}
 
 	ctx, cancel := testContext(t)

--- a/integration/sandbox_clean_remove_windows_test.go
+++ b/integration/sandbox_clean_remove_windows_test.go
@@ -52,30 +52,30 @@ func getTestImage() (string, error) {
 
 	switch buildNum {
 	case osversion.RS1:
-		return "mcr.microsoft.com/windows/nanoserver:sac2016", nil
+		return "ghcr.io/containerd/windows/nanoserver:sac2016", nil
 	case osversion.RS3:
-		return "mcr.microsoft.com/windows/nanoserver:1709", nil
+		return "ghcr.io/containerd/windows/nanoserver:1709", nil
 	case osversion.RS4:
-		return "mcr.microsoft.com/windows/nanoserver:1803", nil
+		return "ghcr.io/containerd/windows/nanoserver:1803", nil
 	case osversion.RS5:
-		return "mcr.microsoft.com/windows/nanoserver:1809", nil
+		return "ghcr.io/containerd/windows/nanoserver:1809", nil
 	case osversion.V19H1:
-		return "mcr.microsoft.com/windows/nanoserver:1903", nil
+		return "ghcr.io/containerd/windows/nanoserver:1903", nil
 	case osversion.V19H2:
-		return "mcr.microsoft.com/windows/nanoserver:1909", nil
+		return "ghcr.io/containerd/windows/nanoserver:1909", nil
 	case osversion.V20H1:
-		return "mcr.microsoft.com/windows/nanoserver:2004", nil
+		return "ghcr.io/containerd/windows/nanoserver:2004", nil
 	case osversion.V20H2:
-		return "mcr.microsoft.com/windows/nanoserver:20H2", nil
+		return "ghcr.io/containerd/windows/nanoserver:20H2", nil
 	case osversion.V21H2Server:
-		return "mcr.microsoft.com/windows/nanoserver:ltsc2022", nil
+		return "ghcr.io/containerd/windows/nanoserver:ltsc2022", nil
 	default:
 		// Due to some efforts in improving down-level compatibility for Windows containers (see
 		// https://techcommunity.microsoft.com/t5/containers/windows-server-2022-and-beyond-for-containers/ba-p/2712487)
 		// the ltsc2022 image should continue to work on builds ws2022 and onwards (Windows 11 for example). With this in mind,
 		// if there's no mapping for the host build just use the Windows Server 2022 image.
 		if buildNum > osversion.V21H2Server {
-			return "mcr.microsoft.com/windows/nanoserver:ltsc2022", nil
+			return "ghcr.io/containerd/windows/nanoserver:ltsc2022", nil
 		}
 		return "", fmt.Errorf("No test image defined for Windows build version: %s", b)
 	}


### PR DESCRIPTION
create a process to mirror container images from 3rd parties into our ghcr.io/containerd domain.

issue: https://github.com/containerd/containerd/issues/8898