### PR TITLE
[release/1.7] cri: Don't use rel path for image volumes

### DIFF
--- a/pkg/cri/server/container_create.go
+++ b/pkg/cri/server/container_create.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	goruntime "runtime"
 	"time"
 
 	"github.com/containerd/typeurl/v2"
@@ -325,6 +326,11 @@ func (c *criService) volumeMounts(containerRootDir string, criMounts []*runtime.
 		}
 		volumeID := util.GenerateID()
 		src := filepath.Join(containerRootDir, "volumes", volumeID)
+		if !filepath.IsAbs(dst) && goruntime.GOOS != "windows" {
+			oldDst := dst
+			dst = filepath.Join("/", dst)
+			log.L.Debugf("Volume destination %q is not absolute, converted to %q", oldDst, dst)
+		}
 		// addOCIBindMounts will create these volumes.
 		mounts = append(mounts, &runtime.Mount{
 			ContainerPath:  dst,


### PR DESCRIPTION
This is a backport of: #8885 for 1.7. 

---

Runc 1.1 throws a warning when using rel destination paths, and runc 1.2 is planning to thow an error (i.e. won't start the container).

Let's just make this an abs path in the only place it might not be: the mounts created due to `VOLUME` directives in the Dockerfile.

Signed-off-by: Rodrigo Campos <rodrigoca@microsoft.com>
(cherry picked from commit 2d64ab8d79a0bb18a089de37a5fbfc8eb5ab720d)