### PR TITLE
Makefile: fix overriding go command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ ifdef SKIPTESTS
 endif
 
 #Replaces ":" (*nix), ";" (windows) with newline for easy parsing
-GOPATHS=$(shell go env GOPATH | tr ":" "\n" | tr ";" "\n")
+GOPATHS=$(shell $(GO) env GOPATH | tr ":" "\n" | tr ";" "\n")
 
 TESTFLAGS_RACE=
 GO_BUILD_FLAGS=


### PR DESCRIPTION
There still was one place that's calling the `go` command directly instead of using the $(GO) variable.

Fixes: 9ea25634bddccbcd4c45a7e552a147ff7f50aaab