### PR TITLE
Makefile: allow REVISION be overwritten by environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ TEST_IMAGE_LIST ?=
 
 # Used to populate variables in version package.
 VERSION ?= $(shell git describe --match 'v[0-9]*' --dirty='.m' --always)
-REVISION=$(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi)
+REVISION ?= $(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi)
 PACKAGE=github.com/containerd/containerd
 SHIM_CGO_ENABLED ?= 0
 


### PR DESCRIPTION
Required for distros that wanna use their local version and can't have some (possibly failing) git commands being run here.