### PR TITLE
CI: update Rocky Linux to 8.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -531,8 +531,7 @@ jobs:
       matrix:
         box:
           - fedora/38-cloud-base
-          # v7.0.0 does not boot. v6.0.0 was not released.
-          - rockylinux/8@5.0.0
+          - rockylinux/8@8.0.0
     env:
       BOX: ${{ matrix.box }}
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,11 +29,13 @@ Vagrant.configure("2") do |config|
     v.cpus = cpus
     # Needs env var VAGRANT_EXPERIMENTAL="disks"
     o.vm.disk :disk, size: "#{disk_size}GB", primary: true
+    v.customize ["modifyvm", :id, "--firmware", "efi"]
   end
   config.vm.provider :libvirt do |v|
     v.memory = memory
     v.cpus = cpus
     v.machine_virtual_size = disk_size
+    v.loader = "/usr/share/OVMF/OVMF_CODE.fd"
   end
 
   config.vm.synced_folder ".", "/vagrant", type: "rsync"

--- a/script/resize-vagrant-root.sh
+++ b/script/resize-vagrant-root.sh
@@ -34,6 +34,8 @@ if [[ "$df_line" =~ ^/dev/([a-z]+)([0-9+]) ]]; then
         echo "Unknown filesystem: $df_line"
         exit 1
     fi
+elif [[ "$df_line" =~ ^/dev/mapper/ ]]; then
+    echo "TODO: support device mapper: $df_line"
 else
     echo "Failed to parse: $df_line"
     exit 1


### PR DESCRIPTION
- UEFI now has to be enabled
- The root device is now `/dev/mapper/rocky-root`. The resize script doesn't work for `/dev/mapper/*` yet, but the test passes without resizing it.