### PR TITLE
[release/1.6] Add release notes for v1.6.23

### DIFF
--- a/releases/v1.6.23.toml
+++ b/releases/v1.6.23.toml
@@ -1,0 +1,35 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.6.22"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The twenty-third patch release for containerd 1.6 contains various fixes and updates.
+
+### Notable Updates
+
+* **Add stable ABI support in windows platform matcher + update hcsshim tag ([#8854](https://github.com/containerd/containerd/pull/8854))
+* **cri: Don't use rel path for image volumes ([#8927](https://github.com/containerd/containerd/pull/8927))
+* **Upgrade GitHub actions packages in release workflow ([#8908](https://github.com/containerd/containerd/pull/8908))
+* **update to go1.19.12 ([#8905](https://github.com/containerd/containerd/pull/8905))
+* **backport: ro option for userxattr mount check + cherry-pick: Fix ro mount option being passed ([#8888](https://github.com/containerd/containerd/pull/8888))
+
+See the changelog for complete list of changes"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.22+unknown"
+	Version = "1.6.23+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Welcome to the v1.6.23 release of containerd!

The twenty-third patch release for containerd 1.6 contains various fixes and updates.

### Notable Updates

See the changelog for complete list of changes

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Kirtana Ashok
* Maksym Pavlenko
* Austin Vazquez
* Ben Foster
* Mike Brown
* Phil Estes
* Rodrigo Campos
* Sebastiaan van Stijn
* Wei Fu

### Changes
<details><summary>11 commits</summary>
<p>

* [release/1.6] Add stable ABI support in windows platform matcher + update hcsshim tag ([#8854](https://github.com/containerd/containerd/pull/8854))
  * [`f51bf1960`](https://github.com/containerd/containerd/commit/f51bf19608714bc052a38fc2dc0920b30244aec7) Add support for stable ABI windows versions
  * [`43a02c0b2`](https://github.com/containerd/containerd/commit/43a02c0b286d77d9455055b2453cbab57c55811b) Update hcsshim tag to v0.9.10
*  [release/1.6] cri: Don't use rel path for image volumes ([#8927](https://github.com/containerd/containerd/pull/8927))
  * [`cc5b0a21b`](https://github.com/containerd/containerd/commit/cc5b0a21b438acd750f9779d3b3c4e68879bed50) cri: Don't use rel path for image volumes
* [release/1.6 backport] Upgrade GitHub actions packages in release workflow ([#8908](https://github.com/containerd/containerd/pull/8908))
  * [`4238cff1c`](https://github.com/containerd/containerd/commit/4238cff1cfd43711c71f769b7129c6f8832ef507) Upgrade GitHub actions packages in release workflow
* [release/1.6] update to go1.19.12 ([#8905](https://github.com/containerd/containerd/pull/8905))
  * [`00d1092b7`](https://github.com/containerd/containerd/commit/00d1092b78c3405daf3cc4ced8075ca5ca2903a8) update to go1.19.12
* [release/1.6] backport: ro option for userxattr mount check + cherry-pick: Fix ro mount option being passed ([#8888](https://github.com/containerd/containerd/pull/8888))
  * [`47d73b2de`](https://github.com/containerd/containerd/commit/47d73b2de65c806d93e19879ae86787b6f3735d6) Fix ro mount option being passed
</p>
</details>

### Dependency Changes

* **github.com/Microsoft/hcsshim**  v0.9.8 -> v0.9.10

Previous release can be found at [v1.6.22](https://github.com/containerd/containerd/releases/tag/v1.6.22)