### PR TITLE
[release/1.6] Cherry-pick: [overlay] add configurable mount options to overlay snapshotter

### DIFF
--- a/snapshots/overlay/overlay.go
+++ b/snapshots/overlay/overlay.go
@@ -45,6 +45,7 @@ const upperdirKey = "containerd.io/snapshot/overlay.upperdir"
 type SnapshotterConfig struct {
 	asyncRemove   bool
 	upperdirLabel bool
+	mountOptions  []string
 }
 
 // Opt is an option to configure the overlay snapshotter
@@ -68,13 +69,21 @@ func WithUpperdirLabel(config *SnapshotterConfig) error {
 	return nil
 }
 
+// WithMountOptions defines the default mount options used for the overlay mount.
+// NOTE: Options are not applied to bind mounts.
+func WithMountOptions(options []string) Opt {
+	return func(config *SnapshotterConfig) error {
+		config.mountOptions = append(config.mountOptions, options...)
+		return nil
+	}
+}
+
 type snapshotter struct {
 	root          string
 	ms            *storage.MetaStore
 	asyncRemove   bool
 	upperdirLabel bool
-	indexOff      bool
-	userxattr     bool // whether to enable "userxattr" mount option
+	options       []string
 }
 
 // NewSnapshotter returns a Snapshotter which uses overlayfs. The overlayfs
@@ -106,10 +115,20 @@ func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
 	if err := os.Mkdir(filepath.Join(root, "snapshots"), 0700); err != nil && !os.IsExist(err) {
 		return nil, err
 	}
-	// figure out whether "userxattr" option is recognized by the kernel && needed
-	userxattr, err := overlayutils.NeedsUserXAttr(root)
-	if err != nil {
-		logrus.WithError(err).Warnf("cannot detect whether \"userxattr\" option needs to be used, assuming to be %v", userxattr)
+
+	if !hasOption(config.mountOptions, "userxattr", false) {
+		// figure out whether "userxattr" option is recognized by the kernel && needed
+		userxattr, err := overlayutils.NeedsUserXAttr(root)
+		if err != nil {
+			logrus.WithError(err).Warnf("cannot detect whether \"userxattr\" option needs to be used, assuming to be %v", userxattr)
+		}
+		if userxattr {
+			config.mountOptions = append(config.mountOptions, "userxattr")
+		}
+	}
+
+	if !hasOption(config.mountOptions, "index", false) && supportsIndex() {
+		config.mountOptions = append(config.mountOptions, "index=off")
 	}
 
 	return &snapshotter{
@@ -117,9 +136,21 @@ func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
 		ms:            ms,
 		asyncRemove:   config.asyncRemove,
 		upperdirLabel: config.upperdirLabel,
-		indexOff:      supportsIndex(),
-		userxattr:     userxattr,
+		options:       config.mountOptions,
 	}, nil
+}
+
+func hasOption(options []string, key string, hasValue bool) bool {
+	for _, option := range options {
+		if hasValue {
+			if strings.HasPrefix(option, key) && len(option) > len(key) && option[len(key)] == '=' {
+				return true
+			}
+		} else if option == key {
+			return true
+		}
+	}
+	return false
 }
 
 // Stat returns the info for an active or committed snapshot by name or
@@ -507,17 +538,8 @@ func (o *snapshotter) mounts(s storage.Snapshot) []mount.Mount {
 			},
 		}
 	}
-	var options []string
 
-	// set index=off when mount overlayfs
-	if o.indexOff {
-		options = append(options, "index=off")
-	}
-
-	if o.userxattr {
-		options = append(options, "userxattr")
-	}
-
+	options := o.options
 	if s.Kind == snapshots.KindActive {
 		options = append(options,
 			fmt.Sprintf("workdir=%s", o.workPath(s.ID)),

--- a/snapshots/overlay/overlay_test.go
+++ b/snapshots/overlay/overlay_test.go
@@ -71,7 +71,7 @@ func TestOverlay(t *testing.T) {
 				testOverlayOverlayRead(t, newSnapshotter)
 			})
 			t.Run("TestOverlayView", func(t *testing.T) {
-				testOverlayView(t, newSnapshotter)
+				testOverlayView(t, newSnapshotterWithOpts(append(opts, WithMountOptions([]string{"volatile"}))...))
 			})
 		})
 	}
@@ -330,7 +330,7 @@ func testOverlayView(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
 	}
 
 	supportsIndex := supportsIndex()
-	expectedOptions := 2
+	expectedOptions := 3
 	if !supportsIndex {
 		expectedOptions--
 	}
@@ -347,12 +347,15 @@ func testOverlayView(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
 	}
 	lowers := getParents(ctx, o, root, "/tmp/view2")
 	expected = fmt.Sprintf("lowerdir=%s:%s", lowers[0], lowers[1])
-	optIdx := 1
+	optIdx := 2
 	if !supportsIndex {
 		optIdx--
 	}
 	if userxattr {
 		optIdx++
+	}
+	if m.Options[0] != "volatile" {
+		t.Error("expected option first option to be provided option \"volatile\"")
 	}
 	if m.Options[optIdx] != expected {
 		t.Errorf("expected option %q but received %q", expected, m.Options[optIdx])

--- a/snapshots/overlay/plugin/plugin.go
+++ b/snapshots/overlay/plugin/plugin.go
@@ -32,6 +32,7 @@ type Config struct {
 	// Root directory for the plugin
 	RootPath      string `toml:"root_path"`
 	UpperdirLabel bool   `toml:"upperdir_label"`
+	SyncRemove    bool   `toml:"sync_remove"`
 }
 
 func init() {
@@ -56,9 +57,12 @@ func init() {
 			if config.UpperdirLabel {
 				oOpts = append(oOpts, overlay.WithUpperdirLabel)
 			}
+			if !config.SyncRemove {
+				oOpts = append(oOpts, overlay.AsynchronousRemove)
+			}
 
 			ic.Meta.Exports["root"] = root
-			return overlay.NewSnapshotter(root, append(oOpts, overlay.AsynchronousRemove)...)
+			return overlay.NewSnapshotter(root, oOpts...)
 		},
 	})
 }

--- a/snapshots/overlay/plugin/plugin.go
+++ b/snapshots/overlay/plugin/plugin.go
@@ -33,6 +33,9 @@ type Config struct {
 	RootPath      string `toml:"root_path"`
 	UpperdirLabel bool   `toml:"upperdir_label"`
 	SyncRemove    bool   `toml:"sync_remove"`
+
+	// MountOptions are options used for the overlay mount (not used on bind mounts)
+	MountOptions []string `toml:"mount_options"`
 }
 
 func init() {
@@ -59,6 +62,10 @@ func init() {
 			}
 			if !config.SyncRemove {
 				oOpts = append(oOpts, overlay.AsynchronousRemove)
+			}
+
+			if len(config.MountOptions) > 0 {
+				oOpts = append(oOpts, overlay.WithMountOptions(config.MountOptions))
 			}
 
 			ic.Meta.Exports["root"] = root


### PR DESCRIPTION
We have several issues related to `umount` which can cause unexpected IO pressure. Backporting #8676 is kind of workaround for the users who are using release/1.6 LTS. They can add `volatile` option to avoid syncfs in the kernel (>=5.10). 

Related issues: #8698, #7496, #8931, #8647 (In #8647, the container in pods failed to start and kubelet kept restart it and there were a lot of umount syscall when containerd deleted the tasks)

-----

Cherry-pick: #8676 #8542 