### PR TITLE
FreeBSD: set default runtime

### DIFF
--- a/defaults/defaults_freebsd.go
+++ b/defaults/defaults_freebsd.go
@@ -1,0 +1,22 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package defaults
+
+const (
+	// DefaultRuntime is the default freebsd runtime
+	DefaultRuntime = "wtf.sbk.runj.v1"
+)

--- a/defaults/defaults_linux.go
+++ b/defaults/defaults_linux.go
@@ -1,0 +1,22 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package defaults
+
+const (
+	// DefaultRuntime is the default linux runtime
+	DefaultRuntime = "io.containerd.runc.v2"
+)

--- a/defaults/defaults_unix.go
+++ b/defaults/defaults_unix.go
@@ -32,8 +32,6 @@ const (
 	// DefaultFIFODir is the default location used by client-side cio library
 	// to store FIFOs.
 	DefaultFIFODir = "/run/containerd/fifo"
-	// DefaultRuntime is the default linux runtime
-	DefaultRuntime = "io.containerd.runc.v2"
 	// DefaultConfigDir is the default location for config files.
 	DefaultConfigDir = "/etc/containerd"
 )


### PR DESCRIPTION
@samuelkarp's https://github.com/samuelkarp/runj is a de facto default FreeBSD runtime.

This change creates a set of defaults for FreeBSD setting `wtf.sbk.runj.v1` as the default runtime.