### PR TITLE
factor out cgroup1/cgroup2/wstats specifics

### DIFF
--- a/cmd/ctr/commands/tasks/metrics.go
+++ b/cmd/ctr/commands/tasks/metrics.go
@@ -23,11 +23,7 @@ import (
 	"os"
 	"text/tabwriter"
 
-	wstats "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats"
-	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
-	v2 "github.com/containerd/cgroups/v3/cgroup2/stats"
 	"github.com/containerd/containerd/cmd/ctr/commands"
-	"github.com/containerd/typeurl/v2"
 	"github.com/urfave/cli"
 )
 
@@ -69,18 +65,13 @@ var metricsCommand = cli.Command{
 		}
 
 		var data interface{}
-		switch {
-		case typeurl.Is(metric.Data, (*v1.Metrics)(nil)):
-			data = &v1.Metrics{}
-		case typeurl.Is(metric.Data, (*v2.Metrics)(nil)):
-			data = &v2.Metrics{}
-		case typeurl.Is(metric.Data, (*wstats.Statistics)(nil)):
-			data = &wstats.Statistics{}
-		default:
-			return errors.New("cannot convert metric data to cgroups.Metrics or windows.Statistics")
-		}
-		if err := typeurl.UnmarshalTo(metric.Data, data); err != nil {
-			return err
+
+		if data = allocMetricCgroup1(metric); data == nil {
+			if data = allocMetricCgroup2(metric); data == nil {
+				if data = allocMetricWstats(metric); data == nil {
+					return errors.New("cannot convert metric data to cgroups.Metrics or windows.Statistics")
+				}
+			}
 		}
 
 		switch context.String(formatFlag) {
@@ -88,14 +79,9 @@ var metricsCommand = cli.Command{
 			w := tabwriter.NewWriter(os.Stdout, 1, 8, 4, ' ', 0)
 			fmt.Fprintf(w, "ID\tTIMESTAMP\t\n")
 			fmt.Fprintf(w, "%s\t%s\t\n\n", metric.ID, metric.Timestamp)
-			switch v := data.(type) {
-			case *v1.Metrics:
-				printCgroupMetricsTable(w, v)
-			case *v2.Metrics:
-				printCgroup2MetricsTable(w, v)
-			case *wstats.Statistics:
-				printWindowsStats(w, v)
-			}
+			printCgroup1MetricsTable(w, data)
+			printCgroup2MetricsTable(w, data)
+			printWindowsStats(w, data)
 			return w.Flush()
 		case formatJSON:
 			marshaledJSON, err := json.MarshalIndent(data, "", "  ")
@@ -108,97 +94,4 @@ var metricsCommand = cli.Command{
 			return errors.New("format must be table or json")
 		}
 	},
-}
-
-func printCgroupMetricsTable(w *tabwriter.Writer, data *v1.Metrics) {
-	fmt.Fprintf(w, "METRIC\tVALUE\t\n")
-	if data.Memory != nil {
-		fmt.Fprintf(w, "memory.usage_in_bytes\t%d\t\n", data.Memory.Usage.Usage)
-		fmt.Fprintf(w, "memory.limit_in_bytes\t%d\t\n", data.Memory.Usage.Limit)
-		fmt.Fprintf(w, "memory.stat.cache\t%d\t\n", data.Memory.TotalCache)
-	}
-	if data.CPU != nil {
-		fmt.Fprintf(w, "cpuacct.usage\t%d\t\n", data.CPU.Usage.Total)
-		fmt.Fprintf(w, "cpuacct.usage_percpu\t%v\t\n", data.CPU.Usage.PerCPU)
-	}
-	if data.Pids != nil {
-		fmt.Fprintf(w, "pids.current\t%v\t\n", data.Pids.Current)
-		fmt.Fprintf(w, "pids.limit\t%v\t\n", data.Pids.Limit)
-	}
-}
-
-func printCgroup2MetricsTable(w *tabwriter.Writer, data *v2.Metrics) {
-	fmt.Fprintf(w, "METRIC\tVALUE\t\n")
-	if data.Pids != nil {
-		fmt.Fprintf(w, "pids.current\t%v\t\n", data.Pids.Current)
-		fmt.Fprintf(w, "pids.limit\t%v\t\n", data.Pids.Limit)
-	}
-	if data.CPU != nil {
-		fmt.Fprintf(w, "cpu.usage_usec\t%v\t\n", data.CPU.UsageUsec)
-		fmt.Fprintf(w, "cpu.user_usec\t%v\t\n", data.CPU.UserUsec)
-		fmt.Fprintf(w, "cpu.system_usec\t%v\t\n", data.CPU.SystemUsec)
-		fmt.Fprintf(w, "cpu.nr_periods\t%v\t\n", data.CPU.NrPeriods)
-		fmt.Fprintf(w, "cpu.nr_throttled\t%v\t\n", data.CPU.NrThrottled)
-		fmt.Fprintf(w, "cpu.throttled_usec\t%v\t\n", data.CPU.ThrottledUsec)
-	}
-	if data.Memory != nil {
-		fmt.Fprintf(w, "memory.usage\t%v\t\n", data.Memory.Usage)
-		fmt.Fprintf(w, "memory.usage_limit\t%v\t\n", data.Memory.UsageLimit)
-		fmt.Fprintf(w, "memory.swap_usage\t%v\t\n", data.Memory.SwapUsage)
-		fmt.Fprintf(w, "memory.swap_limit\t%v\t\n", data.Memory.SwapLimit)
-	}
-}
-
-func printWindowsStats(w *tabwriter.Writer, windowsStats *wstats.Statistics) {
-	if windowsStats.GetLinux() != nil {
-		stats := windowsStats.GetLinux()
-		printCgroupMetricsTable(w, stats)
-	} else if windowsStats.GetWindows() != nil {
-		printWindowsContainerStatistics(w, windowsStats.GetWindows())
-	}
-	// Print VM stats if its isolated
-	if windowsStats.VM != nil {
-		printWindowsVMStatistics(w, windowsStats.VM)
-	}
-}
-
-func printWindowsContainerStatistics(w *tabwriter.Writer, stats *wstats.WindowsContainerStatistics) {
-	fmt.Fprintf(w, "METRIC\tVALUE\t\n")
-	fmt.Fprintf(w, "timestamp\t%s\t\n", stats.Timestamp)
-	fmt.Fprintf(w, "start_time\t%s\t\n", stats.ContainerStartTime)
-	fmt.Fprintf(w, "uptime_ns\t%d\t\n", stats.UptimeNS)
-	if stats.Processor != nil {
-		fmt.Fprintf(w, "cpu.total_runtime_ns\t%d\t\n", stats.Processor.TotalRuntimeNS)
-		fmt.Fprintf(w, "cpu.runtime_user_ns\t%d\t\n", stats.Processor.RuntimeUserNS)
-		fmt.Fprintf(w, "cpu.runtime_kernel_ns\t%d\t\n", stats.Processor.RuntimeKernelNS)
-	}
-	if stats.Memory != nil {
-		fmt.Fprintf(w, "memory.commit_bytes\t%d\t\n", stats.Memory.MemoryUsageCommitBytes)
-		fmt.Fprintf(w, "memory.commit_peak_bytes\t%d\t\n", stats.Memory.MemoryUsageCommitPeakBytes)
-		fmt.Fprintf(w, "memory.private_working_set_bytes\t%d\t\n", stats.Memory.MemoryUsagePrivateWorkingSetBytes)
-	}
-	if stats.Storage != nil {
-		fmt.Fprintf(w, "storage.read_count_normalized\t%d\t\n", stats.Storage.ReadCountNormalized)
-		fmt.Fprintf(w, "storage.read_size_bytes\t%d\t\n", stats.Storage.ReadSizeBytes)
-		fmt.Fprintf(w, "storage.write_count_normalized\t%d\t\n", stats.Storage.WriteCountNormalized)
-		fmt.Fprintf(w, "storage.write_size_bytes\t%d\t\n", stats.Storage.WriteSizeBytes)
-	}
-}
-
-func printWindowsVMStatistics(w *tabwriter.Writer, stats *wstats.VirtualMachineStatistics) {
-	fmt.Fprintf(w, "METRIC\tVALUE\t\n")
-	if stats.Processor != nil {
-		fmt.Fprintf(w, "vm.cpu.total_runtime_ns\t%d\t\n", stats.Processor.TotalRuntimeNS)
-	}
-	if stats.Memory != nil {
-		fmt.Fprintf(w, "vm.memory.working_set_bytes\t%d\t\n", stats.Memory.WorkingSetBytes)
-		fmt.Fprintf(w, "vm.memory.virtual_node_count\t%d\t\n", stats.Memory.VirtualNodeCount)
-		fmt.Fprintf(w, "vm.memory.available\t%d\t\n", stats.Memory.VmMemory.AvailableMemory)
-		fmt.Fprintf(w, "vm.memory.available_buffer\t%d\t\n", stats.Memory.VmMemory.AvailableMemoryBuffer)
-		fmt.Fprintf(w, "vm.memory.reserved\t%d\t\n", stats.Memory.VmMemory.ReservedMemory)
-		fmt.Fprintf(w, "vm.memory.assigned\t%d\t\n", stats.Memory.VmMemory.AssignedMemory)
-		fmt.Fprintf(w, "vm.memory.slp_active\t%t\t\n", stats.Memory.VmMemory.SlpActive)
-		fmt.Fprintf(w, "vm.memory.balancing_enabled\t%t\t\n", stats.Memory.VmMemory.BalancingEnabled)
-		fmt.Fprintf(w, "vm.memory.dm_operation_in_progress\t%t\t\n", stats.Memory.VmMemory.DmOperationInProgress)
-	}
 }

--- a/cmd/ctr/commands/tasks/metrics_cgroup1.go
+++ b/cmd/ctr/commands/tasks/metrics_cgroup1.go
@@ -1,0 +1,53 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package tasks
+
+import (
+	"fmt"
+	"text/tabwriter"
+
+	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
+	"github.com/containerd/containerd/api/types"
+	"github.com/containerd/typeurl/v2"
+)
+
+func printCgroup1MetricsTable(w *tabwriter.Writer, data interface{}) {
+	switch data := data.(type) {
+	case *v1.Metrics:
+		fmt.Fprintf(w, "METRIC\tVALUE\t\n")
+		if data.Memory != nil {
+			fmt.Fprintf(w, "memory.usage_in_bytes\t%d\t\n", data.Memory.Usage.Usage)
+			fmt.Fprintf(w, "memory.limit_in_bytes\t%d\t\n", data.Memory.Usage.Limit)
+			fmt.Fprintf(w, "memory.stat.cache\t%d\t\n", data.Memory.TotalCache)
+		}
+		if data.CPU != nil {
+			fmt.Fprintf(w, "cpuacct.usage\t%d\t\n", data.CPU.Usage.Total)
+			fmt.Fprintf(w, "cpuacct.usage_percpu\t%v\t\n", data.CPU.Usage.PerCPU)
+		}
+		if data.Pids != nil {
+			fmt.Fprintf(w, "pids.current\t%v\t\n", data.Pids.Current)
+			fmt.Fprintf(w, "pids.limit\t%v\t\n", data.Pids.Limit)
+		}
+	}
+}
+
+func allocMetricCgroup1(metric *types.Metric) interface{} {
+	if typeurl.Is(metric.Data, (*v1.Metrics)(nil)) {
+		return &v1.Metrics{}
+	}
+	return nil
+}

--- a/cmd/ctr/commands/tasks/metrics_cgroup2.go
+++ b/cmd/ctr/commands/tasks/metrics_cgroup2.go
@@ -1,0 +1,58 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package tasks
+
+import (
+	"fmt"
+	"text/tabwriter"
+
+	v2 "github.com/containerd/cgroups/v3/cgroup2/stats"
+	"github.com/containerd/containerd/api/types"
+	"github.com/containerd/typeurl/v2"
+)
+
+func printCgroup2MetricsTable(w *tabwriter.Writer, data interface{}) {
+	switch data := data.(type) {
+	case *v2.Metrics:
+		fmt.Fprintf(w, "METRIC\tVALUE\t\n")
+		if data.Pids != nil {
+			fmt.Fprintf(w, "pids.current\t%v\t\n", data.Pids.Current)
+			fmt.Fprintf(w, "pids.limit\t%v\t\n", data.Pids.Limit)
+		}
+		if data.CPU != nil {
+			fmt.Fprintf(w, "cpu.usage_usec\t%v\t\n", data.CPU.UsageUsec)
+			fmt.Fprintf(w, "cpu.user_usec\t%v\t\n", data.CPU.UserUsec)
+			fmt.Fprintf(w, "cpu.system_usec\t%v\t\n", data.CPU.SystemUsec)
+			fmt.Fprintf(w, "cpu.nr_periods\t%v\t\n", data.CPU.NrPeriods)
+			fmt.Fprintf(w, "cpu.nr_throttled\t%v\t\n", data.CPU.NrThrottled)
+			fmt.Fprintf(w, "cpu.throttled_usec\t%v\t\n", data.CPU.ThrottledUsec)
+		}
+		if data.Memory != nil {
+			fmt.Fprintf(w, "memory.usage\t%v\t\n", data.Memory.Usage)
+			fmt.Fprintf(w, "memory.usage_limit\t%v\t\n", data.Memory.UsageLimit)
+			fmt.Fprintf(w, "memory.swap_usage\t%v\t\n", data.Memory.SwapUsage)
+			fmt.Fprintf(w, "memory.swap_limit\t%v\t\n", data.Memory.SwapLimit)
+		}
+	}
+}
+
+func allocMetricCgroup2(metric *types.Metric) interface{} {
+	if typeurl.Is(metric.Data, (*v2.Metrics)(nil)) {
+		return &v2.Metrics{}
+	}
+	return nil
+}

--- a/cmd/ctr/commands/tasks/metrics_win.go
+++ b/cmd/ctr/commands/tasks/metrics_win.go
@@ -1,0 +1,90 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package tasks
+
+import (
+	"fmt"
+	"text/tabwriter"
+
+	wstats "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats"
+	"github.com/containerd/containerd/api/types"
+	"github.com/containerd/typeurl/v2"
+)
+
+func printWindowsStats(w *tabwriter.Writer, windowsStats interface{}) {
+	switch windowsStats := windowsStats.(type) {
+	case *wstats.Statistics:
+		if windowsStats.GetLinux() != nil {
+			stats := windowsStats.GetLinux()
+			printCgroup1MetricsTable(w, stats)
+		} else if windowsStats.GetWindows() != nil {
+			printWindowsContainerStatistics(w, windowsStats.GetWindows())
+		}
+		// Print VM stats if its isolated
+		if windowsStats.VM != nil {
+			printWindowsVMStatistics(w, windowsStats.VM)
+		}
+	}
+}
+
+func printWindowsContainerStatistics(w *tabwriter.Writer, stats *wstats.WindowsContainerStatistics) {
+	fmt.Fprintf(w, "METRIC\tVALUE\t\n")
+	fmt.Fprintf(w, "timestamp\t%s\t\n", stats.Timestamp)
+	fmt.Fprintf(w, "start_time\t%s\t\n", stats.ContainerStartTime)
+	fmt.Fprintf(w, "uptime_ns\t%d\t\n", stats.UptimeNS)
+	if stats.Processor != nil {
+		fmt.Fprintf(w, "cpu.total_runtime_ns\t%d\t\n", stats.Processor.TotalRuntimeNS)
+		fmt.Fprintf(w, "cpu.runtime_user_ns\t%d\t\n", stats.Processor.RuntimeUserNS)
+		fmt.Fprintf(w, "cpu.runtime_kernel_ns\t%d\t\n", stats.Processor.RuntimeKernelNS)
+	}
+	if stats.Memory != nil {
+		fmt.Fprintf(w, "memory.commit_bytes\t%d\t\n", stats.Memory.MemoryUsageCommitBytes)
+		fmt.Fprintf(w, "memory.commit_peak_bytes\t%d\t\n", stats.Memory.MemoryUsageCommitPeakBytes)
+		fmt.Fprintf(w, "memory.private_working_set_bytes\t%d\t\n", stats.Memory.MemoryUsagePrivateWorkingSetBytes)
+	}
+	if stats.Storage != nil {
+		fmt.Fprintf(w, "storage.read_count_normalized\t%d\t\n", stats.Storage.ReadCountNormalized)
+		fmt.Fprintf(w, "storage.read_size_bytes\t%d\t\n", stats.Storage.ReadSizeBytes)
+		fmt.Fprintf(w, "storage.write_count_normalized\t%d\t\n", stats.Storage.WriteCountNormalized)
+		fmt.Fprintf(w, "storage.write_size_bytes\t%d\t\n", stats.Storage.WriteSizeBytes)
+	}
+}
+
+func printWindowsVMStatistics(w *tabwriter.Writer, stats *wstats.VirtualMachineStatistics) {
+	fmt.Fprintf(w, "METRIC\tVALUE\t\n")
+	if stats.Processor != nil {
+		fmt.Fprintf(w, "vm.cpu.total_runtime_ns\t%d\t\n", stats.Processor.TotalRuntimeNS)
+	}
+	if stats.Memory != nil {
+		fmt.Fprintf(w, "vm.memory.working_set_bytes\t%d\t\n", stats.Memory.WorkingSetBytes)
+		fmt.Fprintf(w, "vm.memory.virtual_node_count\t%d\t\n", stats.Memory.VirtualNodeCount)
+		fmt.Fprintf(w, "vm.memory.available\t%d\t\n", stats.Memory.VmMemory.AvailableMemory)
+		fmt.Fprintf(w, "vm.memory.available_buffer\t%d\t\n", stats.Memory.VmMemory.AvailableMemoryBuffer)
+		fmt.Fprintf(w, "vm.memory.reserved\t%d\t\n", stats.Memory.VmMemory.ReservedMemory)
+		fmt.Fprintf(w, "vm.memory.assigned\t%d\t\n", stats.Memory.VmMemory.AssignedMemory)
+		fmt.Fprintf(w, "vm.memory.slp_active\t%t\t\n", stats.Memory.VmMemory.SlpActive)
+		fmt.Fprintf(w, "vm.memory.balancing_enabled\t%t\t\n", stats.Memory.VmMemory.BalancingEnabled)
+		fmt.Fprintf(w, "vm.memory.dm_operation_in_progress\t%t\t\n", stats.Memory.VmMemory.DmOperationInProgress)
+	}
+}
+
+func allocMetricWstats(metric *types.Metric) interface{} {
+	if typeurl.Is(metric.Data, (*wstats.Statistics)(nil)) {
+		return &wstats.Statistics{}
+	}
+	return nil
+}

--- a/pkg/cri/opts/spec_cgroup1_linux.go
+++ b/pkg/cri/opts/spec_cgroup1_linux.go
@@ -1,0 +1,40 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package opts
+
+import (
+	"os"
+	"sync"
+)
+
+var (
+	_cgroupv1HasHugetlbOnce sync.Once
+	_cgroupv1HasHugetlb     bool
+)
+
+// cgroupv1HasHugetlb returns whether the hugetlb controller is present on
+// cgroup v1.
+func cgroupv1HasHugetlb() bool {
+	_cgroupv1HasHugetlbOnce.Do(func() {
+		if _, err := os.ReadDir("/sys/fs/cgroup/hugetlb"); err != nil {
+			_cgroupv1HasHugetlb = false
+		} else {
+			_cgroupv1HasHugetlb = true
+		}
+	})
+	return _cgroupv1HasHugetlb
+}

--- a/pkg/cri/opts/spec_cgroup2_linux.go
+++ b/pkg/cri/opts/spec_cgroup2_linux.go
@@ -1,0 +1,41 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package opts
+
+import (
+	"os"
+	"strings"
+	"sync"
+)
+
+var (
+	_cgroupv2HasHugetlbOnce sync.Once
+	_cgroupv2HasHugetlb     bool
+)
+
+// cgroupv2HasHugetlb returns whether the hugetlb controller is present on
+// cgroup v2.
+func cgroupv2HasHugetlb() bool {
+	_cgroupv2HasHugetlbOnce.Do(func() {
+		controllers, err := os.ReadFile("/sys/fs/cgroup/cgroup.controllers")
+		if err != nil {
+			return
+		}
+		_cgroupv2HasHugetlb = strings.Contains(string(controllers), "hugetlb")
+	})
+	return _cgroupv2HasHugetlb
+}

--- a/pkg/cri/opts/spec_linux.go
+++ b/pkg/cri/opts/spec_linux.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"syscall"
 
@@ -87,39 +86,9 @@ func isHugetlbControllerPresent() bool {
 }
 
 var (
-	_cgroupv1HasHugetlbOnce sync.Once
-	_cgroupv1HasHugetlb     bool
-	_cgroupv2HasHugetlbOnce sync.Once
-	_cgroupv2HasHugetlb     bool
-	isUnifiedOnce           sync.Once
-	isUnified               bool
+	isUnifiedOnce sync.Once
+	isUnified     bool
 )
-
-// cgroupv1HasHugetlb returns whether the hugetlb controller is present on
-// cgroup v1.
-func cgroupv1HasHugetlb() bool {
-	_cgroupv1HasHugetlbOnce.Do(func() {
-		if _, err := os.ReadDir("/sys/fs/cgroup/hugetlb"); err != nil {
-			_cgroupv1HasHugetlb = false
-		} else {
-			_cgroupv1HasHugetlb = true
-		}
-	})
-	return _cgroupv1HasHugetlb
-}
-
-// cgroupv2HasHugetlb returns whether the hugetlb controller is present on
-// cgroup v2.
-func cgroupv2HasHugetlb() bool {
-	_cgroupv2HasHugetlbOnce.Do(func() {
-		controllers, err := os.ReadFile("/sys/fs/cgroup/cgroup.controllers")
-		if err != nil {
-			return
-		}
-		_cgroupv2HasHugetlb = strings.Contains(string(controllers), "hugetlb")
-	})
-	return _cgroupv2HasHugetlb
-}
 
 // IsCgroup2UnifiedMode returns whether we are running in cgroup v2 unified mode.
 func IsCgroup2UnifiedMode() bool {

--- a/pkg/cri/sbserver/container_stats_list.go
+++ b/pkg/cri/sbserver/container_stats_list.go
@@ -349,15 +349,13 @@ func (c *criService) linuxContainerMetrics(
 
 	if stats != nil {
 		var data interface{}
-		switch {
-		case typeurl.Is(stats.Data, (*cg1.Metrics)(nil)):
-			data = &cg1.Metrics{}
-		case typeurl.Is(stats.Data, (*cg2.Metrics)(nil)):
-			data = &cg2.Metrics{}
-		case typeurl.Is(stats.Data, (*wstats.Statistics)(nil)):
-			data = &wstats.Statistics{}
-		default:
-			return nil, errors.New("cannot convert metric data to cgroups.Metrics or windows.Statistics")
+
+		if data = allocMetricCgroup1(stats); data == nil {
+			if data = allocMetricCgroup2(stats); data == nil {
+				if data = allocMetricWstat(stats); data == nil {
+					return nil, errors.New("cannot convert metric data to cgroups.Metrics or windows.Statistics")
+				}
+			}
 		}
 
 		if err := typeurl.UnmarshalTo(stats.Data, data); err != nil {

--- a/pkg/cri/sbserver/container_stats_list_cgroup1.go
+++ b/pkg/cri/sbserver/container_stats_list_cgroup1.go
@@ -1,0 +1,30 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package sbserver
+
+import (
+	cg1 "github.com/containerd/cgroups/v3/cgroup1/stats"
+	"github.com/containerd/containerd/api/types"
+	"github.com/containerd/typeurl/v2"
+)
+
+func allocMetricCgroup1(stats *types.Metric) interface{} {
+	if typeurl.Is(stats.Data, (*cg1.Metrics)(nil)) {
+		return &cg1.Metrics{}
+	}
+	return nil
+}

--- a/pkg/cri/sbserver/container_stats_list_cgroup2.go
+++ b/pkg/cri/sbserver/container_stats_list_cgroup2.go
@@ -1,0 +1,30 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package sbserver
+
+import (
+	cg2 "github.com/containerd/cgroups/v3/cgroup2/stats"
+	"github.com/containerd/containerd/api/types"
+	"github.com/containerd/typeurl/v2"
+)
+
+func allocMetricCgroup2(stats *types.Metric) interface{} {
+	if typeurl.Is(stats.Data, (*cg2.Metrics)(nil)) {
+		return &cg2.Metrics{}
+	}
+	return nil
+}

--- a/pkg/cri/sbserver/container_stats_list_wstat.go
+++ b/pkg/cri/sbserver/container_stats_list_wstat.go
@@ -1,0 +1,30 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package sbserver
+
+import (
+	wstats "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats"
+	"github.com/containerd/containerd/api/types"
+	"github.com/containerd/typeurl/v2"
+)
+
+func allocMetricWstat(stats *types.Metric) interface{} {
+	if typeurl.Is(stats.Data, (*wstats.Statistics)(nil)) {
+		return &wstats.Statistics{}
+	}
+	return nil
+}


### PR DESCRIPTION
Factoring out specific handlings for cgroup1, cgroup2, wstats, so we have a cleaner code separation,
and later able to make some of them, eg. legacy cgroup1 optional (by subsequent patches).