### PR TITLE
Append k8s 1.28 to RELEASES.md

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -136,6 +136,7 @@ of containerd for every supported version of Kubernetes.
 | 1.25               | 1.7.0+, 1.6.4+     | v1, v1alpha2 ** |
 | 1.26               | 1.7.0+, 1.6.15+    | v1              |
 | 1.27               | 1.7.0+, 1.6.15+    | v1              |
+| 1.28               | 1.7.0+, 1.6.15+    | v1              |
 
 ** Note: containerd v1.6.*, and v1.7.* support CRI v1 and v1alpha2 through EOL as those releases continue to support older versions of k8s, cloud providers, and other clients using CRI v1alpha2. CRI v1alpha2 is deprecated in v1.7 and will be removed in containerd v2.0.
 


### PR DESCRIPTION
This PR is supposed to append k8s 1.28 that containerd supports version matrix of Kubernetes in RELEASES.md.