### PR TITLE
ctr: images inspect

### DIFF
--- a/cmd/ctr/commands/images/images.go
+++ b/cmd/ctr/commands/images/images.go
@@ -42,6 +42,7 @@ var Command = cli.Command{
 		checkCommand,
 		exportCommand,
 		importCommand,
+		inspectCommand,
 		listCommand,
 		mountCommand,
 		unmountCommand,

--- a/cmd/ctr/commands/images/inspect.go
+++ b/cmd/ctr/commands/images/inspect.go
@@ -1,0 +1,65 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package images
+
+import (
+	"os"
+
+	"github.com/containerd/containerd/cmd/ctr/commands"
+	"github.com/containerd/containerd/pkg/display"
+	"github.com/urfave/cli"
+)
+
+var inspectCommand = cli.Command{
+	Name:        "inspect",
+	Aliases:     []string{"i"},
+	Usage:       "inspect an image",
+	ArgsUsage:   "<image> [flags]",
+	Description: `Inspect an image`,
+	Flags: []cli.Flag{
+		cli.BoolFlag{
+			Name:  "content",
+			Usage: "Show JSON content",
+		},
+	},
+	Action: func(clicontext *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(clicontext)
+		if err != nil {
+			return err
+		}
+		defer cancel()
+		var (
+			ref        = clicontext.Args().First()
+			imageStore = client.ImageService()
+			cs         = client.ContentStore()
+		)
+
+		img, err := imageStore.Get(ctx, ref)
+		if err != nil {
+			return err
+		}
+
+		opts := []display.PrintOpt{
+			display.WithWriter(os.Stdout),
+		}
+		if clicontext.Bool("content") {
+			opts = append(opts, display.Verbose)
+		}
+
+		return display.NewImageTreePrinter(opts...).PrintImageTree(ctx, img, cs)
+	},
+}

--- a/pkg/display/manifest_printer.go
+++ b/pkg/display/manifest_printer.go
@@ -1,0 +1,211 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package display
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/images"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// TreeFormat is used to format tree based output using 4 values.
+// Each value must display with the same total width to format correctly.
+//
+// MiddleDrop is used to show a child element which is not the last child
+// LastDrop is used to show the last child element
+// SkipLine is used for displaying data from a previous child before the next child
+// Spacer is used to display child data for the last child
+type TreeFormat struct {
+	MiddleDrop string
+	LastDrop   string
+	SkipLine   string
+	Spacer     string
+}
+
+// LineTreeFormat uses line drawing characters to format a tree
+//
+// TreeRoot
+// ├── First child       # MiddleDrop =  "├── "
+// │   Skipped line      # SkipLine = "│   "
+// └── Last child        # LastDrop = "└── "
+// ....└── Only child    # Spacer="....", LastDrop = "└── "
+var LineTreeFormat = TreeFormat{
+	MiddleDrop: "├── ",
+	LastDrop:   "└── ",
+	SkipLine:   "│   ",
+	Spacer:     "    ",
+}
+
+type ContentReader interface {
+	content.Provider
+
+	Info(ctx context.Context, dgst digest.Digest) (content.Info, error)
+}
+
+type ImageTreePrinter struct {
+	verbose bool
+	w       io.Writer
+	format  TreeFormat
+}
+
+type PrintOpt func(*ImageTreePrinter)
+
+func Verbose(p *ImageTreePrinter) {
+	p.verbose = true
+}
+
+func WithWriter(w io.Writer) PrintOpt {
+	return func(p *ImageTreePrinter) {
+		p.w = w
+	}
+}
+
+func WithFormat(format TreeFormat) PrintOpt {
+	return func(p *ImageTreePrinter) {
+		p.format = format
+	}
+}
+
+func NewImageTreePrinter(opts ...PrintOpt) *ImageTreePrinter {
+	p := &ImageTreePrinter{
+		verbose: false,
+		w:       os.Stdout,
+		format:  LineTreeFormat,
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	return p
+}
+
+// PrintImageTree prints an image and all its sub elements
+func (p *ImageTreePrinter) PrintImageTree(ctx context.Context, img images.Image, store ContentReader) error {
+	fmt.Fprintln(p.w, img.Name)
+	subchild := p.format.SkipLine
+	fmt.Fprintf(p.w, "%s Created: %s\n", subchild, img.CreatedAt)
+	fmt.Fprintf(p.w, "%s Updated: %s\n", subchild, img.UpdatedAt)
+	for k, v := range img.Labels {
+		fmt.Fprintf(p.w, "%s Label %q: %q\n", subchild, k, v)
+	}
+	return p.printManifestTree(ctx, img.Target, store, p.format.LastDrop, p.format.Spacer)
+}
+
+// PrintManifestTree prints a manifest and all its sub elements
+func (p *ImageTreePrinter) PrintManifestTree(ctx context.Context, desc ocispec.Descriptor, store ContentReader) error {
+	// start displaying tree from the root descriptor perspective, which is a single child view
+	return p.printManifestTree(ctx, desc, store, p.format.LastDrop, p.format.Spacer)
+}
+
+func (p *ImageTreePrinter) printManifestTree(ctx context.Context, desc ocispec.Descriptor, store ContentReader, prefix, childprefix string) error {
+	subprefix := childprefix + p.format.MiddleDrop
+	subchild := childprefix + p.format.SkipLine
+	fmt.Fprintf(p.w, "%s%s @%s (%d bytes)\n", prefix, desc.MediaType, desc.Digest, desc.Size)
+
+	if desc.Platform != nil && desc.Platform.Architecture != "" {
+		// TODO: Use containerd platform library to format
+		fmt.Fprintf(p.w, "%s Platform: %s/%s\n", subchild, desc.Platform.OS, desc.Platform.Architecture)
+	}
+	b, err := content.ReadBlob(ctx, store, desc)
+	if err != nil {
+		return err
+	}
+	if err := p.showContent(ctx, store, desc, subchild); err != nil {
+		return err
+	}
+
+	switch desc.MediaType {
+	case images.MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest:
+		var manifest ocispec.Manifest
+		if err := json.Unmarshal(b, &manifest); err != nil {
+			return err
+		}
+
+		if len(manifest.Layers) == 0 {
+			subprefix = childprefix + p.format.LastDrop
+			subchild = childprefix + p.format.Spacer
+		}
+		fmt.Fprintf(p.w, "%s%s @%s (%d bytes)\n", subprefix, manifest.Config.MediaType, manifest.Config.Digest, manifest.Config.Size)
+
+		if err := p.showContent(ctx, store, manifest.Config, subchild); err != nil {
+			return err
+		}
+
+		for i := range manifest.Layers {
+			if len(manifest.Layers) == i+1 {
+				subprefix = childprefix + p.format.LastDrop
+			}
+			fmt.Fprintf(p.w, "%s%s @%s (%d bytes)\n", subprefix, manifest.Layers[i].MediaType, manifest.Layers[i].Digest, manifest.Layers[i].Size)
+		}
+
+	case images.MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
+		var idx ocispec.Index
+		if err := json.Unmarshal(b, &idx); err != nil {
+			return err
+		}
+
+		for i := range idx.Manifests {
+			if len(idx.Manifests) == i+1 {
+				subprefix = childprefix + p.format.LastDrop
+				subchild = childprefix + p.format.Spacer
+			}
+			if err := p.printManifestTree(ctx, idx.Manifests[i], store, subprefix, subchild); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (p *ImageTreePrinter) showContent(ctx context.Context, store ContentReader, desc ocispec.Descriptor, prefix string) error {
+	if p.verbose {
+		info, err := store.Info(ctx, desc.Digest)
+		if err != nil {
+			return err
+		}
+		if len(info.Labels) > 0 {
+			fmt.Fprintf(p.w, "%s┌────────Labels─────────\n", prefix)
+			for k, v := range info.Labels {
+				fmt.Fprintf(p.w, "%s│%q: %q\n", prefix, k, v)
+			}
+			fmt.Fprintf(p.w, "%s└───────────────────────\n", prefix)
+		}
+	}
+	if p.verbose && strings.HasSuffix(desc.MediaType, "json") {
+		// Print content for config
+		cb, err := content.ReadBlob(ctx, store, desc)
+		if err != nil {
+			return err
+		}
+		dst := bytes.NewBuffer(nil)
+		json.Indent(dst, cb, prefix+"│", "   ")
+		fmt.Fprintf(p.w, "%s┌────────Content────────\n", prefix)
+		fmt.Fprintf(p.w, "%s│%s\n", prefix, strings.TrimSpace(dst.String()))
+		fmt.Fprintf(p.w, "%s└───────────────────────\n", prefix)
+	}
+	return nil
+}


### PR DESCRIPTION
This tool is helpful for debugging and generally inspecting image content

 Example output
```
$ ctr images inspect docker.io/library/alpine:latest
docker.io/library/alpine:latest
│    Created: 2023-04-16 07:55:00.700351928 +0000 UTC
│    Updated: 2023-08-22 22:51:11.741909909 +0000 UTC
└── application/vnd.docker.distribution.manifest.list.v2+json @sha256:7144f7bab3d4c2648d7e59409f15ec52a18006a128c733fcff20d3a4a54ba44a (1638 bytes)
    ├── application/vnd.docker.distribution.manifest.v2+json @sha256:c5c5fda71656f28e49ac9c5416b3643eaa6a108a8093151d6d1afc9463be8e33 (528 bytes)
    │   │    Platform: linux/amd64
    │   ├── application/vnd.docker.container.image.v1+json @sha256:7e01a0d0a1dcd9e539f8e9bbd80106d59efbdf97293b3d38f5d7a34501526cdb (1471 bytes)
    │   └── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:7264a8db6415046d36d16ba98b79778e18accee6ffa71850405994cffa9be7de (3401613 bytes)
    ├── application/vnd.docker.distribution.manifest.v2+json @sha256:f748290eb66ad6f938e25dd348acfb3527a422e280b7547b1cdfaf38d4492c4b (528 bytes)
    │   │    Platform: linux/arm
    │   ├── application/vnd.docker.container.image.v1+json @sha256:356611740cdf40c86deca25938174419285840acc3cd4efc686984aca13a6eae (1485 bytes)
    │   └── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:af09961d4a43b504efc76e38b50918977c28be73eeb8b926247783a00e8b9f2f (3144809 bytes)
    ├── application/vnd.docker.distribution.manifest.v2+json @sha256:16e86b2388774982fbdf230101a72201691b1f97cb0066c2099abf30dd7e6d59 (528 bytes)
    │   │    Platform: linux/arm
    │   ├── application/vnd.docker.container.image.v1+json @sha256:6c452a75f07bb8133ea359408e744412a14eb0a73e44953459da673d13910472 (1483 bytes)
    │   └── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:f8dec92eec42224ef9e6ca9c6207ea6b9195dcf93d06bd5ceff0f814b62bf064 (2899480 bytes)
    ├── application/vnd.docker.distribution.manifest.v2+json @sha256:b312e4b0e2c665d634602411fcb7c2699ba748c36f59324457bc17de485f36f6 (528 bytes)
    │   │    Platform: linux/arm64
    │   ├── application/vnd.docker.container.image.v1+json @sha256:f6648c04cd6ce95adc05b3aa55265007b95d64d508755be8506cee652792952c (1487 bytes)
    │   └── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:9fda8d8052c61740409c4bea888859c141fd8cc3f58ac61943144ff6d1681b2d (3330767 bytes)
    ├── application/vnd.docker.distribution.manifest.v2+json @sha256:1fd62556954250bac80d601a196bb7fd480ceba7c10e94dd8fd4c6d1c08783d5 (528 bytes)
    │   │    Platform: linux/386
    │   ├── application/vnd.docker.container.image.v1+json @sha256:38a6a8764e0eac402b8acbc62da67f583915df9b8af1352e2f8425d8705779e1 (1469 bytes)
    │   └── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:95dc695758361a4038a2d9026959d72e1f531114edb0341be7ce47d912ef069e (3235144 bytes)
    ├── application/vnd.docker.distribution.manifest.v2+json @sha256:c75ede79e457d6454bca6fc51967a247a4b9daff9f31197cfbef69b1a651cada (528 bytes)
    │   │    Platform: linux/ppc64le
    │   ├── application/vnd.docker.container.image.v1+json @sha256:ada3b5c8c9898f5fb3276784449b187125a050b4291c2e8eb712b5da359239cb (1474 bytes)
    │   └── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:55353ca330e9474ce7b858eca6842bb540ef4a70b2981c2ed47eefb9ef4253ad (3346251 bytes)
    └── application/vnd.docker.distribution.manifest.v2+json @sha256:5febc00b4d2a84af2a077bc34ea90659b6570110a54253f19c5dca8164b1dbf6 (528 bytes)
        │    Platform: linux/s390x
        ├── application/vnd.docker.container.image.v1+json @sha256:12b7c1198431ded6e715b8b5b80ceb22f91e50d9535b832bd05fc9494a2be66e (1472 bytes)
        └── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:8bed2eae372fe236061920d89ae1ce89695a12df84989113bcc7ce4bd9774456 (3214195 bytes)
```

Or show all content (abridged)
```
$ ctr images inspect docker.io/library/alpine:latest --content
docker.io/library/alpine:latest
│    Created: 2023-04-16 07:55:00.700351928 +0000 UTC
│    Updated: 2023-08-22 22:51:11.741909909 +0000 UTC
└── application/vnd.docker.distribution.manifest.list.v2+json @sha256:7144f7bab3d4c2648d7e59409f15ec52a18006a128c733fcff20d3a4a54ba44a (1638 bytes)
    │   ┌────────Labels─────────
    │   │"containerd.io/gc.ref.content.m.0": "sha256:c5c5fda71656f28e49ac9c5416b3643eaa6a108a8093151d6d1afc9463be8e33"
    │   │"containerd.io/distribution.source.docker.io": "library/alpine"
    │   │"containerd.io/gc.ref.content.m.6": "sha256:5febc00b4d2a84af2a077bc34ea90659b6570110a54253f19c5dca8164b1dbf6"
    │   │"containerd.io/gc.ref.content.m.5": "sha256:c75ede79e457d6454bca6fc51967a247a4b9daff9f31197cfbef69b1a651cada"
    │   │"containerd.io/gc.ref.content.m.4": "sha256:1fd62556954250bac80d601a196bb7fd480ceba7c10e94dd8fd4c6d1c08783d5"
    │   │"containerd.io/gc.ref.content.m.3": "sha256:b312e4b0e2c665d634602411fcb7c2699ba748c36f59324457bc17de485f36f6"
    │   │"containerd.io/gc.ref.content.m.2": "sha256:16e86b2388774982fbdf230101a72201691b1f97cb0066c2099abf30dd7e6d59"
    │   │"containerd.io/gc.ref.content.m.1": "sha256:f748290eb66ad6f938e25dd348acfb3527a422e280b7547b1cdfaf38d4492c4b"
    │   └───────────────────────
    │   ┌────────Content────────
    │   │{
    │   │   "manifests": [
    │   │      {
    │   │         "digest": "sha256:c5c5fda71656f28e49ac9c5416b3643eaa6a108a8093151d6d1afc9463be8e33",
    │   │         "mediaType": "application\/vnd.docker.distribution.manifest.v2+json",
    │   │         "platform": {
    │   │            "architecture": "amd64",
    │   │            "os": "linux"
    │   │         },
    │   │         "size": 528
    │   │      },
    │   │      {
    │   │         "digest": "sha256:f748290eb66ad6f938e25dd348acfb3527a422e280b7547b1cdfaf38d4492c4b",
    │   │         "mediaType": "application\/vnd.docker.distribution.manifest.v2+json",
    │   │         "platform": {
    │   │            "architecture": "arm",
    │   │            "os": "linux",
    │   │            "variant": "v6"
    │   │         },
    │   │         "size": 528
    │   │      },
    │   │      {
    │   │         "digest": "sha256:16e86b2388774982fbdf230101a72201691b1f97cb0066c2099abf30dd7e6d59",
    │   │         "mediaType": "application\/vnd.docker.distribution.manifest.v2+json",
    │   │         "platform": {
    │   │            "architecture": "arm",
    │   │            "os": "linux",
    │   │            "variant": "v7"
    │   │         },
    │   │         "size": 528
    │   │      },
    │   │      {
    │   │         "digest": "sha256:b312e4b0e2c665d634602411fcb7c2699ba748c36f59324457bc17de485f36f6",
    │   │         "mediaType": "application\/vnd.docker.distribution.manifest.v2+json",
    │   │         "platform": {
    │   │            "architecture": "arm64",
    │   │            "os": "linux",
    │   │            "variant": "v8"
    │   │         },
    │   │         "size": 528
    │   │      },
    │   │      {
    │   │         "digest": "sha256:1fd62556954250bac80d601a196bb7fd480ceba7c10e94dd8fd4c6d1c08783d5",
    │   │         "mediaType": "application\/vnd.docker.distribution.manifest.v2+json",
    │   │         "platform": {
    │   │            "architecture": "386",
    │   │            "os": "linux"
    │   │         },
    │   │         "size": 528
    │   │      },
    │   │      {
    │   │         "digest": "sha256:c75ede79e457d6454bca6fc51967a247a4b9daff9f31197cfbef69b1a651cada",
    │   │         "mediaType": "application\/vnd.docker.distribution.manifest.v2+json",
    │   │         "platform": {
    │   │            "architecture": "ppc64le",
    │   │            "os": "linux"
    │   │         },
    │   │         "size": 528
    │   │      },
    │   │      {
    │   │         "digest": "sha256:5febc00b4d2a84af2a077bc34ea90659b6570110a54253f19c5dca8164b1dbf6",
    │   │         "mediaType": "application\/vnd.docker.distribution.manifest.v2+json",
    │   │         "platform": {
    │   │            "architecture": "s390x",
    │   │            "os": "linux"
    │   │         },
    │   │         "size": 528
    │   │      }
    │   │   ],
    │   │   "mediaType": "application\/vnd.docker.distribution.manifest.list.v2+json",
    │   │   "schemaVersion": 2
    │   │}
    │   └───────────────────────
    ├── application/vnd.docker.distribution.manifest.v2+json @sha256:c5c5fda71656f28e49ac9c5416b3643eaa6a108a8093151d6d1afc9463be8e33 (528 bytes)
    │   │    Platform: linux/amd64
    │   │   ┌────────Labels─────────
    │   │   │"containerd.io/distribution.source.docker.io": "library/alpine"
    │   │   │"containerd.io/gc.ref.content.l.0": "sha256:7264a8db6415046d36d16ba98b79778e18accee6ffa71850405994cffa9be7de"
    │   │   │"containerd.io/gc.ref.content.config": "sha256:7e01a0d0a1dcd9e539f8e9bbd80106d59efbdf97293b3d38f5d7a34501526cdb"
    │   │   └───────────────────────
    │   │   ┌────────Content────────
    │   │   │{
    │   │   │   "schemaVersion": 2,
    │   │   │   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
    │   │   │   "config": {
    │   │   │      "mediaType": "application/vnd.docker.container.image.v1+json",
    │   │   │      "size": 1471,
    │   │   │      "digest": "sha256:7e01a0d0a1dcd9e539f8e9bbd80106d59efbdf97293b3d38f5d7a34501526cdb"
    │   │   │   },
    │   │   │   "layers": [
    │   │   │      {
    │   │   │         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
    │   │   │         "size": 3401613,
    │   │   │         "digest": "sha256:7264a8db6415046d36d16ba98b79778e18accee6ffa71850405994cffa9be7de"
    │   │   │      }
    │   │   │   ]
    │   │   │}
    │   │   └───────────────────────
    │   ├── application/vnd.docker.container.image.v1+json @sha256:7e01a0d0a1dcd9e539f8e9bbd80106d59efbdf97293b3d38f5d7a34501526cdb (1471 bytes)
    │   │   ┌────────Labels─────────
    │   │   │"containerd.io/distribution.source.docker.io": "library/alpine"
    │   │   └───────────────────────
    │   │   ┌────────Content────────
    │   │   │{
    │   │   │   "architecture": "amd64",
    │   │   │   "config": {
    │   │   │      "Hostname": "",
    │   │   │      "Domainname": "",
    │   │   │      "User": "",
    │   │   │      "AttachStdin": false,
    │   │   │      "AttachStdout": false,
    │   │   │      "AttachStderr": false,
    │   │   │      "Tty": false,
    │   │   │      "OpenStdin": false,
    │   │   │      "StdinOnce": false,
    │   │   │      "Env": [
    │   │   │         "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
    │   │   │      ],
    │   │   │      "Cmd": [
    │   │   │         "/bin/sh"
    │   │   │      ],
    │   │   │      "Image": "sha256:39dfd593e04b939e16d3a426af525cad29b8fc7410b06f4dbad8528b45e1e5a9",
    │   │   │      "Volumes": null,
    │   │   │      "WorkingDir": "",
    │   │   │      "Entrypoint": null,
    │   │   │      "OnBuild": null,
    │   │   │      "Labels": null
    │   │   │   },
    │   │   │   "container": "ba09fe2c8f99faad95871d467a22c96f4bc8166bd01ce0a7c28dd5472697bfd1",
    │   │   │   "container_config": {
    │   │   │      "Hostname": "ba09fe2c8f99",
    │   │   │      "Domainname": "",
    │   │   │      "User": "",
    │   │   │      "AttachStdin": false,
    │   │   │      "AttachStdout": false,
    │   │   │      "AttachStderr": false,
    │   │   │      "Tty": false,
    │   │   │      "OpenStdin": false,
    │   │   │      "StdinOnce": false,
    │   │   │      "Env": [
    │   │   │         "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
    │   │   │      ],
    │   │   │      "Cmd": [
    │   │   │         "/bin/sh",
    │   │   │         "-c",
    │   │   │         "#(nop) ",
    │   │   │         "CMD [\"/bin/sh\"]"
    │   │   │      ],
    │   │   │      "Image": "sha256:39dfd593e04b939e16d3a426af525cad29b8fc7410b06f4dbad8528b45e1e5a9",
    │   │   │      "Volumes": null,
    │   │   │      "WorkingDir": "",
    │   │   │      "Entrypoint": null,
    │   │   │      "OnBuild": null,
    │   │   │      "Labels": {}
    │   │   │   },
    │   │   │   "created": "2023-08-07T19:20:20.894140623Z",
    │   │   │   "docker_version": "20.10.23",
    │   │   │   "history": [
    │   │   │      {
    │   │   │         "created": "2023-08-07T19:20:20.71894984Z",
    │   │   │         "created_by": "/bin/sh -c #(nop) ADD file:32ff5e7a78b890996ee4681cc0a26185d3e9acdb4eb1e2aaccb2411f922fed6b in / "
    │   │   │      },
    │   │   │      {
    │   │   │         "created": "2023-08-07T19:20:20.894140623Z",
    │   │   │         "created_by": "/bin/sh -c #(nop)  CMD [\"/bin/sh\"]",
    │   │   │         "empty_layer": true
    │   │   │      }
    │   │   │   ],
    │   │   │   "os": "linux",
    │   │   │   "rootfs": {
    │   │   │      "type": "layers",
    │   │   │      "diff_ids": [
    │   │   │         "sha256:4693057ce2364720d39e57e85a5b8e0bd9ac3573716237736d6470ec5b7b7230"
    │   │   │      ]
    │   │   │   }
    │   │   │}
    │   │   └───────────────────────
    │   └── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:7264a8db6415046d36d16ba98b79778e18accee6ffa71850405994cffa9be7de (3401613 bytes)
...
```