### PR TITLE
[releases/1.6] *: fix leaked shim caused by high IO pressure

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -70,6 +70,7 @@ Vagrant.configure("2") do |config|
             libselinux-devel \
             lsof \
             make \
+            strace \
             ${INSTALL_PACKAGES}
     SHELL
   end

--- a/integration/issue7496_linux_test.go
+++ b/integration/issue7496_linux_test.go
@@ -41,6 +41,15 @@ import (
 //
 // NOTE: https://github.com/containerd/containerd/issues/8931 is the same issue.
 func TestIssue7496(t *testing.T) {
+	t.Logf("Checking CRI config's default runtime")
+	criCfg, err := CRIConfig()
+	require.NoError(t, err)
+
+	typ := criCfg.ContainerdConfig.Runtimes[criCfg.ContainerdConfig.DefaultRuntimeName].Type
+	if !strings.HasSuffix(typ, "runc.v2") {
+		t.Skipf("default runtime should be runc.v2, but it's not: %s", typ)
+	}
+
 	ctx := namespaces.WithNamespace(context.Background(), "k8s.io")
 
 	t.Logf("Create a pod config and run sandbox container")

--- a/integration/issue7496_linux_test.go
+++ b/integration/issue7496_linux_test.go
@@ -1,0 +1,171 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/runtime/v2/shim"
+	apitask "github.com/containerd/containerd/runtime/v2/task"
+	"github.com/containerd/ttrpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	exec "golang.org/x/sys/execabs"
+)
+
+// TestIssue7496 is used to reproduce https://github.com/containerd/containerd/issues/7496
+//
+// NOTE: https://github.com/containerd/containerd/issues/8931 is the same issue.
+func TestIssue7496(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "k8s.io")
+
+	t.Logf("Create a pod config and run sandbox container")
+	sbConfig := PodSandboxConfig("sandbox", "issue7496")
+	sbID, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
+	require.NoError(t, err)
+
+	shimCli := connectToShim(ctx, t, sbID)
+
+	delayInSec := 12
+	t.Logf("[shim pid: %d]: Injecting %d seconds delay to umount2 syscall",
+		shimPid(ctx, t, shimCli),
+		delayInSec)
+
+	doneCh := injectDelayToUmount2(ctx, t, shimCli, delayInSec /* CRI plugin uses 10 seconds to delete task */)
+
+	t.Logf("Create a container config and run container in a pod")
+	pauseImage := GetImage(Pause)
+	EnsureImageExists(t, pauseImage)
+
+	containerConfig := ContainerConfig("pausecontainer", pauseImage)
+	cnID, err := runtimeService.CreateContainer(sbID, containerConfig, sbConfig)
+	require.NoError(t, err)
+	require.NoError(t, runtimeService.StartContainer(cnID))
+
+	t.Logf("Start to StopPodSandbox and RemovePodSandbox")
+	ctx, cancelFn := context.WithTimeout(ctx, 3*time.Minute)
+	defer cancelFn()
+	for {
+		select {
+		case <-ctx.Done():
+			require.NoError(t, ctx.Err(), "The StopPodSandbox should be done in time")
+		default:
+		}
+
+		err := runtimeService.StopPodSandbox(sbID)
+		if err != nil {
+			t.Logf("Failed to StopPodSandbox: %v", err)
+			continue
+		}
+
+		err = runtimeService.RemovePodSandbox(sbID)
+		if err == nil {
+			break
+		}
+		t.Logf("Failed to RemovePodSandbox: %v", err)
+		time.Sleep(1 * time.Second)
+	}
+
+	t.Logf("PodSandbox %s has been deleted and start to wait for strace exit", sbID)
+	select {
+	case <-time.After(15 * time.Second):
+		resp, err := shimCli.Connect(ctx, &apitask.ConnectRequest{})
+		assert.Error(t, err, "should failed to call shim connect API")
+
+		t.Errorf("Strace doesn't exit in time")
+
+		t.Logf("Cleanup the shim (pid: %d)", resp.ShimPid)
+		syscall.Kill(int(resp.ShimPid), syscall.SIGKILL)
+		<-doneCh
+	case <-doneCh:
+	}
+}
+
+// injectDelayToUmount2 uses strace(1) to inject delay on umount2 syscall to
+// simulate IO pressure because umount2 might force kernel to syncfs, for
+// example, umount overlayfs rootfs which doesn't with volatile.
+//
+// REF: https://man7.org/linux/man-pages/man1/strace.1.html
+func injectDelayToUmount2(ctx context.Context, t *testing.T, shimCli apitask.TaskService, delayInSec int) chan struct{} {
+	pid := shimPid(ctx, t, shimCli)
+
+	doneCh := make(chan struct{})
+
+	cmd := exec.CommandContext(ctx, "strace",
+		"-p", strconv.Itoa(int(pid)), "-f", // attach to all the threads
+		"--detach-on=execve", // stop to attach runc child-processes
+		"--trace=umount2",    // only trace umount2 syscall
+		"-e", "inject=umount2:delay_enter="+strconv.Itoa(delayInSec)+"s",
+	)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Pdeathsig: syscall.SIGKILL}
+
+	pipeR, pipeW := io.Pipe()
+	cmd.Stdout = pipeW
+	cmd.Stderr = pipeW
+
+	require.NoError(t, cmd.Start())
+
+	// ensure that strace has attached to the shim
+	readyCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+
+		bufReader := bufio.NewReader(pipeR)
+		_, err := bufReader.Peek(1)
+		assert.NoError(t, err, "failed to ensure that strace has attached to shim")
+
+		close(readyCh)
+		io.Copy(os.Stdout, bufReader)
+		t.Logf("Strace has exited")
+	}()
+
+	go func() {
+		defer pipeW.Close()
+		assert.NoError(t, cmd.Wait(), "strace should exit with zero code")
+	}()
+
+	<-readyCh
+	return doneCh
+}
+
+func connectToShim(ctx context.Context, t *testing.T, id string) apitask.TaskService {
+	addr, err := shim.SocketAddress(ctx, containerdEndpoint, id)
+	require.NoError(t, err)
+	addr = strings.TrimPrefix(addr, "unix://")
+
+	conn, err := net.Dial("unix", addr)
+	require.NoError(t, err)
+
+	client := ttrpc.NewClient(conn)
+	return apitask.NewTaskClient(client)
+}
+
+func shimPid(ctx context.Context, t *testing.T, shimCli apitask.TaskService) uint32 {
+	resp, err := shimCli.Connect(ctx, &apitask.ConnectRequest{})
+	require.NoError(t, err)
+	return resp.ShimPid
+}

--- a/pkg/cri/server/container_stop.go
+++ b/pkg/cri/server/container_stop.go
@@ -77,7 +77,7 @@ func (c *criService) stopContainer(ctx context.Context, container containerstore
 		}
 		// Don't return for unknown state, some cleanup needs to be done.
 		if state == runtime.ContainerState_CONTAINER_UNKNOWN {
-			return cleanupUnknownContainer(ctx, id, container)
+			return cleanupUnknownContainer(ctx, id, container, c)
 		}
 		return nil
 	}
@@ -92,7 +92,7 @@ func (c *criService) stopContainer(ctx context.Context, container containerstore
 			if !errdefs.IsNotFound(err) {
 				return fmt.Errorf("failed to wait for task for %q: %w", id, err)
 			}
-			return cleanupUnknownContainer(ctx, id, container)
+			return cleanupUnknownContainer(ctx, id, container, c)
 		}
 
 		exitCtx, exitCancel := context.WithCancel(context.Background())
@@ -195,7 +195,7 @@ func (c *criService) waitContainerStop(ctx context.Context, container containers
 }
 
 // cleanupUnknownContainer cleanup stopped container in unknown state.
-func cleanupUnknownContainer(ctx context.Context, id string, cntr containerstore.Container) error {
+func cleanupUnknownContainer(ctx context.Context, id string, cntr containerstore.Container, c *criService) error {
 	// Reuse handleContainerExit to do the cleanup.
 	return handleContainerExit(ctx, &eventtypes.TaskExit{
 		ContainerID: id,
@@ -203,5 +203,5 @@ func cleanupUnknownContainer(ctx context.Context, id string, cntr containerstore
 		Pid:         0,
 		ExitStatus:  unknownExitCode,
 		ExitedAt:    time.Now(),
-	}, cntr)
+	}, cntr, c)
 }

--- a/pkg/cri/server/events.go
+++ b/pkg/cri/server/events.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/containerd/containerd"
 	eventtypes "github.com/containerd/containerd/api/events"
+	apitasks "github.com/containerd/containerd/api/services/tasks/v1"
 	containerdio "github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/events"
@@ -391,6 +392,51 @@ func handleContainerExit(ctx context.Context, e *eventtypes.TaskExit, cntr conta
 			// Move on to make sure container status is updated.
 		}
 	}
+
+	// NOTE: Both sb.Container.Task and task.Delete interface always ensures
+	// that the status of target task. However, the interfaces return
+	// ErrNotFound, which doesn't mean that the shim instance doesn't exist.
+	//
+	// There are two caches for task in containerd:
+	//
+	//   1. io.containerd.service.v1.tasks-service
+	//   2. io.containerd.runtime.v2.task
+	//
+	// First one is to maintain the shim connection and shutdown the shim
+	// in Delete API. And the second one is to maintain the lifecycle of
+	// task in shim server.
+	//
+	// So, if the shim instance is running and task has been deleted in shim
+	// server, the sb.Container.Task and task.Delete will receive the
+	// ErrNotFound. If we don't delete the shim instance in io.containerd.service.v1.tasks-service,
+	// shim will be leaky.
+	//
+	// Based on containerd/containerd#7496 issue, when host is under IO
+	// pressure, the umount2 syscall will take more than 10 seconds so that
+	// the CRI plugin will cancel this task.Delete call. However, the shim
+	// server isn't aware about this. After return from umount2 syscall, the
+	// shim server continue delete the task record. And then CRI plugin
+	// retries to delete task and retrieves ErrNotFound and marks it as
+	// stopped. Therefore, The shim is leaky.
+	//
+	// It's hard to handle the connection lost or request canceled cases in
+	// shim server. We should call Delete API to io.containerd.service.v1.tasks-service
+	// to ensure that shim instance is shutdown.
+	//
+	// REF:
+	// 1. https://github.com/containerd/containerd/issues/7496#issuecomment-1671100968
+	// 2. https://github.com/containerd/containerd/issues/8931
+	if errdefs.IsNotFound(err) {
+		_, err = c.client.TaskService().Delete(ctx, &apitasks.DeleteTaskRequest{ContainerID: cntr.Container.ID()})
+		if err != nil {
+			err = errdefs.FromGRPC(err)
+			if !errdefs.IsNotFound(err) {
+				return fmt.Errorf("failed to cleanup container %s in task-service: %w", cntr.Container.ID(), err)
+			}
+		}
+		logrus.Infof("Ensure that container %s in task-service has been cleanup successfully", cntr.Container.ID())
+	}
+
 	err = cntr.Status.UpdateSync(func(status containerstore.Status) (containerstore.Status, error) {
 		if status.FinishedAt == 0 {
 			status.Pid = 0
@@ -430,6 +476,50 @@ func handleSandboxExit(ctx context.Context, e *eventtypes.TaskExit, sb sandboxst
 			}
 			// Move on to make sure container status is updated.
 		}
+	}
+
+	// NOTE: Both sb.Container.Task and task.Delete interface always ensures
+	// that the status of target task. However, the interfaces return
+	// ErrNotFound, which doesn't mean that the shim instance doesn't exist.
+	//
+	// There are two caches for task in containerd:
+	//
+	//   1. io.containerd.service.v1.tasks-service
+	//   2. io.containerd.runtime.v2.task
+	//
+	// First one is to maintain the shim connection and shutdown the shim
+	// in Delete API. And the second one is to maintain the lifecycle of
+	// task in shim server.
+	//
+	// So, if the shim instance is running and task has been deleted in shim
+	// server, the sb.Container.Task and task.Delete will receive the
+	// ErrNotFound. If we don't delete the shim instance in io.containerd.service.v1.tasks-service,
+	// shim will be leaky.
+	//
+	// Based on containerd/containerd#7496 issue, when host is under IO
+	// pressure, the umount2 syscall will take more than 10 seconds so that
+	// the CRI plugin will cancel this task.Delete call. However, the shim
+	// server isn't aware about this. After return from umount2 syscall, the
+	// shim server continue delete the task record. And then CRI plugin
+	// retries to delete task and retrieves ErrNotFound and marks it as
+	// stopped. Therefore, The shim is leaky.
+	//
+	// It's hard to handle the connection lost or request canceled cases in
+	// shim server. We should call Delete API to io.containerd.service.v1.tasks-service
+	// to ensure that shim instance is shutdown.
+	//
+	// REF:
+	// 1. https://github.com/containerd/containerd/issues/7496#issuecomment-1671100968
+	// 2. https://github.com/containerd/containerd/issues/8931
+	if errdefs.IsNotFound(err) {
+		_, err = c.client.TaskService().Delete(ctx, &apitasks.DeleteTaskRequest{ContainerID: sb.Container.ID()})
+		if err != nil {
+			err = errdefs.FromGRPC(err)
+			if !errdefs.IsNotFound(err) {
+				return fmt.Errorf("failed to cleanup sandbox %s in task-service: %w", sb.Container.ID(), err)
+			}
+		}
+		logrus.Infof("Ensure that sandbox %s in task-service has been cleanup successfully", sb.Container.ID())
 	}
 	err = sb.Status.Update(func(status sandboxstore.Status) (sandboxstore.Status, error) {
 		status.State = sandboxstore.StateNotReady

--- a/pkg/cri/server/sandbox_stop.go
+++ b/pkg/cri/server/sandbox_stop.go
@@ -119,7 +119,7 @@ func (c *criService) stopSandboxContainer(ctx context.Context, sandbox sandboxst
 		}
 		// Don't return for unknown state, some cleanup needs to be done.
 		if state == sandboxstore.StateUnknown {
-			return cleanupUnknownSandbox(ctx, id, sandbox)
+			return cleanupUnknownSandbox(ctx, id, sandbox, c)
 		}
 		return nil
 	}
@@ -135,7 +135,7 @@ func (c *criService) stopSandboxContainer(ctx context.Context, sandbox sandboxst
 			if !errdefs.IsNotFound(err) {
 				return fmt.Errorf("failed to wait for task: %w", err)
 			}
-			return cleanupUnknownSandbox(ctx, id, sandbox)
+			return cleanupUnknownSandbox(ctx, id, sandbox, c)
 		}
 
 		exitCtx, exitCancel := context.WithCancel(context.Background())
@@ -197,7 +197,7 @@ func (c *criService) teardownPodNetwork(ctx context.Context, sandbox sandboxstor
 }
 
 // cleanupUnknownSandbox cleanup stopped sandbox in unknown state.
-func cleanupUnknownSandbox(ctx context.Context, id string, sandbox sandboxstore.Sandbox) error {
+func cleanupUnknownSandbox(ctx context.Context, id string, sandbox sandboxstore.Sandbox, c *criService) error {
 	// Reuse handleSandboxExit to do the cleanup.
 	return handleSandboxExit(ctx, &eventtypes.TaskExit{
 		ContainerID: id,
@@ -205,5 +205,5 @@ func cleanupUnknownSandbox(ctx context.Context, id string, sandbox sandboxstore.
 		Pid:         0,
 		ExitStatus:  unknownExitCode,
 		ExitedAt:    time.Now(),
-	}, sandbox)
+	}, sandbox, c)
 }


### PR DESCRIPTION
Cherry-pick: https://github.com/containerd/containerd/pull/8954

[integration: add case to reproduce](https://github.com/containerd/containerd/commit/d8f824200cdc39410bf9a4d110073186d6864f64) https://github.com/containerd/containerd/issues/7496: Update: change imports and use pb's field instead of GetXXX.

[pkg/cri/server: add criService as argument when handle exit event](https://github.com/containerd/containerd/commit/ab21d60d27d1d7c87423e9b4ecb076358762e89b): The patch doesn't work with releases/1.6. It needs to add criService as argument when handle exit event.

[integration: issue7496 case should work for runc.v2 only](https://github.com/containerd/containerd/pull/9004/commits/c91469f76404b753ba249188593391e937f6a701): The test case should skip when the default runtime is runc.v1 or io.containerd.runtime.v1.linux.