### PR TITLE
[release/1.7] Cherry-pick: [overlay] add configurable mount options to overlay snapshotter

### DIFF
--- a/snapshots/overlay/overlay_test.go
+++ b/snapshots/overlay/overlay_test.go
@@ -70,7 +70,7 @@ func TestOverlay(t *testing.T) {
 				testOverlayOverlayRead(t, newSnapshotter)
 			})
 			t.Run("TestOverlayView", func(t *testing.T) {
-				testOverlayView(t, newSnapshotter)
+				testOverlayView(t, newSnapshotterWithOpts(append(opts, WithMountOptions([]string{"volatile"}))...))
 			})
 		})
 	}
@@ -329,7 +329,7 @@ func testOverlayView(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
 	}
 
 	supportsIndex := supportsIndex()
-	expectedOptions := 2
+	expectedOptions := 3
 	if !supportsIndex {
 		expectedOptions--
 	}
@@ -346,12 +346,15 @@ func testOverlayView(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
 	}
 	lowers := getParents(ctx, o, root, "/tmp/view2")
 	expected = fmt.Sprintf("lowerdir=%s:%s", lowers[0], lowers[1])
-	optIdx := 1
+	optIdx := 2
 	if !supportsIndex {
 		optIdx--
 	}
 	if userxattr {
 		optIdx++
+	}
+	if m.Options[0] != "volatile" {
+		t.Error("expected option first option to be provided option \"volatile\"")
 	}
 	if m.Options[optIdx] != expected {
 		t.Errorf("expected option %q but received %q", expected, m.Options[optIdx])

--- a/snapshots/overlay/plugin/plugin.go
+++ b/snapshots/overlay/plugin/plugin.go
@@ -32,6 +32,9 @@ type Config struct {
 	RootPath      string `toml:"root_path"`
 	UpperdirLabel bool   `toml:"upperdir_label"`
 	SyncRemove    bool   `toml:"sync_remove"`
+
+	// MountOptions are options used for the overlay mount (not used on bind mounts)
+	MountOptions []string `toml:"mount_options"`
 }
 
 func init() {
@@ -58,6 +61,10 @@ func init() {
 			}
 			if !config.SyncRemove {
 				oOpts = append(oOpts, overlay.AsynchronousRemove)
+			}
+
+			if len(config.MountOptions) > 0 {
+				oOpts = append(oOpts, overlay.WithMountOptions(config.MountOptions))
 			}
 
 			ic.Meta.Exports["root"] = root

--- a/snapshots/overlay/plugin/plugin.go
+++ b/snapshots/overlay/plugin/plugin.go
@@ -31,6 +31,7 @@ type Config struct {
 	// Root directory for the plugin
 	RootPath      string `toml:"root_path"`
 	UpperdirLabel bool   `toml:"upperdir_label"`
+	SyncRemove    bool   `toml:"sync_remove"`
 }
 
 func init() {
@@ -55,9 +56,12 @@ func init() {
 			if config.UpperdirLabel {
 				oOpts = append(oOpts, overlay.WithUpperdirLabel)
 			}
+			if !config.SyncRemove {
+				oOpts = append(oOpts, overlay.AsynchronousRemove)
+			}
 
 			ic.Meta.Exports["root"] = root
-			return overlay.NewSnapshotter(root, append(oOpts, overlay.AsynchronousRemove)...)
+			return overlay.NewSnapshotter(root, oOpts...)
 		},
 	})
 }


### PR DESCRIPTION
We have several issues related to umount which can cause unexpected IO pressure. Backporting https://github.com/containerd/containerd/pull/8676 is kind of workaround for the users who are using release/1.7. They can add volatile option to avoid syncfs in the kernel (>=5.10).

Related issues: https://github.com/containerd/containerd/issues/8698, https://github.com/containerd/containerd/issues/7496, https://github.com/containerd/containerd/issues/8931, https://github.com/containerd/containerd/issues/8647 (In https://github.com/containerd/containerd/issues/8647, the container in pods failed to start and kubelet kept restart it and there were a lot of umount syscall when containerd deleted the tasks)

Cherry-pick: https://github.com/containerd/containerd/pull/8676 https://github.com/containerd/containerd/pull/8542