### PR TITLE
Add stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,35 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: "0 0 * * *" # Every day at midnight
+  pull_request:
+    paths:
+      - '.github/workflows/stale.yml'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        # All stale bot options: https://github.com/actions/stale#all-options
+        with:
+          # Idle number of days before marking issues/PRs stale
+          days-before-stale: 90
+          # Idle number of days before closing stale issues/PRs
+          days-before-close: 7
+          # Only issues/PRs with ANY of these labels are checked
+          any-of-labels: 'status/more-info-needed,status/needs-update'
+          # Comment on the staled issues
+          stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          # Comment on the staled PRs
+          stale-pr-message: 'This PR is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          # Comment on the staled issues while closed
+          close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
+          # Comment on the staled PRs while closed
+          close-pr-message: 'This PR was closed because it has been stalled for 7 days with no activity.'
+          # Enable dry-run when changing this file from a PR.
+          debug-only: github.event_name == 'pull_request'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,9 +24,9 @@ jobs:
           # Only issues/PRs with ANY of these labels are checked
           any-of-labels: 'status/more-info-needed,status/needs-update'
           # Comment on the staled issues
-          stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. This issue will be closed in 7 days unless new comments are made or the stale label is removed.'
           # Comment on the staled PRs
-          stale-pr-message: 'This PR is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          stale-pr-message: 'This PR is stale because it has been open 90 days with no activity. This PR will be closed in 7 days unless new comments are made or the stale label is removed.'
           # Comment on the staled issues while closed
           close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
           # Comment on the staled PRs while closed


### PR DESCRIPTION
This PR adds a stale bot to manage stale PRs/issues.

- After 90 days of inactivity
  + The bot will check PRs/issues with `status/more-info-needed` and `status/needs-update` labels.
  + Add `Stale` label
  + Comment: `This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 7 days.`
- After another 7 days
  + Close PR/issue
  + Message: `This issue was closed because it has been stalled for 7 days with no activity.`
