### PR TITLE
[release/1.7 backport] go.mod: github.com/containerd/continuity v0.4.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containerd/btrfs/v2 v2.0.0
 	github.com/containerd/cgroups/v3 v3.0.2
 	github.com/containerd/console v1.0.3
-	github.com/containerd/continuity v0.4.2-0.20230616210509-1e0d26eb2381
+	github.com/containerd/continuity v0.4.2
 	github.com/containerd/fifo v1.1.0
 	github.com/containerd/go-cni v1.1.9
 	github.com/containerd/go-runc v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -234,8 +234,8 @@ github.com/containerd/continuity v0.0.0-20201208142359-180525291bb7/go.mod h1:kR
 github.com/containerd/continuity v0.0.0-20210208174643-50096c924a4e/go.mod h1:EXlVlkqNba9rJe3j7w3Xa924itAMLgZH4UD/Q4PExuQ=
 github.com/containerd/continuity v0.1.0/go.mod h1:ICJu0PwR54nI0yPEnJ6jcS+J7CZAUXrLh8lPo2knzsM=
 github.com/containerd/continuity v0.2.2/go.mod h1:pWygW9u7LtS1o4N/Tn0FoCFDIXZ7rxcMX7HX1Dmibvk=
-github.com/containerd/continuity v0.4.2-0.20230616210509-1e0d26eb2381 h1:a5jOuoZHKBi2oH9JsfNqrrPpHhmrYU0NAte3M/EPudw=
-github.com/containerd/continuity v0.4.2-0.20230616210509-1e0d26eb2381/go.mod h1:F6PTNCKepoxEaXLQp3wDAjygEnImnZ/7o4JzpodfroQ=
+github.com/containerd/continuity v0.4.2 h1:v3y/4Yz5jwnvqPKJJ+7Wf93fyWoCB3F5EclWG023MDM=
+github.com/containerd/continuity v0.4.2/go.mod h1:F6PTNCKepoxEaXLQp3wDAjygEnImnZ/7o4JzpodfroQ=
 github.com/containerd/fifo v0.0.0-20180307165137-3d5202aec260/go.mod h1:ODA38xgv3Kuk8dQz2ZQXpnv/UZZUHUCL7pnLehbXgQI=
 github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448/go.mod h1:ODA38xgv3Kuk8dQz2ZQXpnv/UZZUHUCL7pnLehbXgQI=
 github.com/containerd/fifo v0.0.0-20200410184934-f15a3290365b/go.mod h1:jPQ2IAeZRCYxpS/Cm1495vGFww6ecHmMk1YJH2Q5ln0=

--- a/integration/client/go.mod
+++ b/integration/client/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Microsoft/hcsshim/test v0.0.0-20210408205431-da33ecd607e1
 	github.com/containerd/cgroups/v3 v3.0.2
 	github.com/containerd/containerd v1.7.0 // see replace; the actual version of containerd is replaced with the code at the root of this repository
-	github.com/containerd/continuity v0.4.2-0.20230616210509-1e0d26eb2381
+	github.com/containerd/continuity v0.4.2
 	github.com/containerd/go-runc v1.0.0
 	github.com/containerd/ttrpc v1.2.2
 	github.com/containerd/typeurl/v2 v2.1.1

--- a/integration/client/go.sum
+++ b/integration/client/go.sum
@@ -657,8 +657,8 @@ github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARu
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=
 github.com/containerd/continuity v0.0.0-20210208174643-50096c924a4e/go.mod h1:EXlVlkqNba9rJe3j7w3Xa924itAMLgZH4UD/Q4PExuQ=
 github.com/containerd/continuity v0.3.0/go.mod h1:wJEAIwKOm/pBZuBd0JmeTvnLquTB1Ag8espWhkykbPM=
-github.com/containerd/continuity v0.4.2-0.20230616210509-1e0d26eb2381 h1:a5jOuoZHKBi2oH9JsfNqrrPpHhmrYU0NAte3M/EPudw=
-github.com/containerd/continuity v0.4.2-0.20230616210509-1e0d26eb2381/go.mod h1:F6PTNCKepoxEaXLQp3wDAjygEnImnZ/7o4JzpodfroQ=
+github.com/containerd/continuity v0.4.2 h1:v3y/4Yz5jwnvqPKJJ+7Wf93fyWoCB3F5EclWG023MDM=
+github.com/containerd/continuity v0.4.2/go.mod h1:F6PTNCKepoxEaXLQp3wDAjygEnImnZ/7o4JzpodfroQ=
 github.com/containerd/fifo v1.0.0/go.mod h1:ocF/ME1SX5b1AOlWi9r677YJmCPSwwWnQ9O123vzpE4=
 github.com/containerd/fifo v1.1.0 h1:4I2mbh5stb1u6ycIABlBw9zgtlK8viPI9QkQNRQEEmY=
 github.com/containerd/fifo v1.1.0/go.mod h1:bmC4NWMbXlt2EZ0Hc7Fx7QzTFxgPID13eH0Qu+MAb2o=

--- a/vendor/github.com/containerd/continuity/devices/mknod_freebsd.go
+++ b/vendor/github.com/containerd/continuity/devices/mknod_freebsd.go
@@ -1,5 +1,5 @@
-//go:build freebsd
-// +build freebsd
+//go:build freebsd || dragonfly
+// +build freebsd dragonfly
 
 /*
    Copyright The containerd Authors.

--- a/vendor/github.com/containerd/continuity/driver/lchmod_unix.go
+++ b/vendor/github.com/containerd/continuity/driver/lchmod_unix.go
@@ -1,5 +1,5 @@
-//go:build darwin || freebsd || netbsd || openbsd || solaris
-// +build darwin freebsd netbsd openbsd solaris
+//go:build darwin || freebsd || netbsd || openbsd || dragonfly || solaris
+// +build darwin freebsd netbsd openbsd dragonfly solaris
 
 /*
    Copyright The containerd Authors.

--- a/vendor/github.com/containerd/continuity/fs/copy_unix.go
+++ b/vendor/github.com/containerd/continuity/fs/copy_unix.go
@@ -1,5 +1,5 @@
-//go:build darwin || freebsd || openbsd || netbsd || solaris
-// +build darwin freebsd openbsd netbsd solaris
+//go:build darwin || freebsd || openbsd || netbsd || dragonfly || solaris
+// +build darwin freebsd openbsd netbsd dragonfly solaris
 
 /*
    Copyright The containerd Authors.

--- a/vendor/github.com/containerd/continuity/fs/stat_atim.go
+++ b/vendor/github.com/containerd/continuity/fs/stat_atim.go
@@ -1,5 +1,5 @@
-//go:build linux || openbsd || solaris
-// +build linux openbsd solaris
+//go:build linux || openbsd || dragonfly || solaris
+// +build linux openbsd dragonfly solaris
 
 /*
    Copyright The containerd Authors.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -104,7 +104,7 @@ github.com/containerd/cgroups/v3/cgroup2/stats
 # github.com/containerd/console v1.0.3
 ## explicit; go 1.13
 github.com/containerd/console
-# github.com/containerd/continuity v0.4.2-0.20230616210509-1e0d26eb2381
+# github.com/containerd/continuity v0.4.2
 ## explicit; go 1.19
 github.com/containerd/continuity
 github.com/containerd/continuity/devices


### PR DESCRIPTION
Cherry-pick (non-clean):
- https://github.com/containerd/containerd/pull/9011