### PR TITLE
fuzzing: fix ossfuzz building error

### DIFF
--- a/contrib/fuzz/oss_fuzz_build.sh
+++ b/contrib/fuzz/oss_fuzz_build.sh
@@ -58,6 +58,10 @@ cd ../../
 
 rm -r vendor
 
+# Add temporary CXXFLAGS
+OLDCXXFLAGS=$CXXFLAGS
+export CXXFLAGS="$CXXFLAGS -lresolv"
+
 # Change path of socket since OSS-fuzz does not grant access to /run
 sed -i 's/\/run\/containerd/\/tmp\/containerd/g' $SRC/containerd/defaults/defaults_unix.go
 
@@ -95,3 +99,6 @@ compile_fuzzers '^func FuzzInteg.*data' compile_go_fuzzer vendor
 
 cp $SRC/containerd/contrib/fuzz/*.options $OUT/
 cp $SRC/containerd/contrib/fuzz/*.dict $OUT/
+
+# Resume CXXFLAGS
+export CXXFLAGS=$OLDCXXFLAGS


### PR DESCRIPTION
With the upgrade of go 1.21, current ossfuzz building crashes with the following error message:
```bash
/usr/bin/ld: /usr/bin/ld: DWARF error: invalid or unhandled FORM value: 0x25
fuzz_FuzzLoadDefaultProfile.a(000021.o): in function `_cgo_9c8efe9babca_C2func_res_search':
cgo_unix_cgo_res.cgo2.c:(.text+0x32): undefined reference to `__res_search'
/usr/bin/ld: fuzz_FuzzLoadDefaultProfile.a(000021.o): in function `_cgo_9c8efe9babca_Cfunc_res_search':
cgo_unix_cgo_res.cgo2.c:(.text+0x81): undefined reference to `__res_search'
clang-15: error: linker command failed with exit code 1 (use -v to see invocation)
```
Fix it by adding two CXX environment variables: `lresolv` and `pthread`.

P.S. Same issues only appear on drivers using `compile_go_fuzzer`. Maybe the variables will be not necessary anymore after I migrate all the gofuzz drivers towards go native fuzz drivers.