### PR TITLE
[release/1.7] CRI: Support Linux usernames for !linux platforms

### DIFF
--- a/pkg/cri/sbserver/container_create_linux_test.go
+++ b/pkg/cri/sbserver/container_create_linux_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/containerd/containerd/contrib/seccomp"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/oci"
+	"github.com/containerd/containerd/platforms"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux"
@@ -1398,7 +1399,7 @@ additional-group-for-root:x:22222:root
 			require.NoError(t, err)
 
 			spec.Root.Path = tempRootDir // simulating /etc/{passwd, group}
-			opts, err := c.containerSpecOpts(containerConfig, imageConfig)
+			opts, err := c.platformSpecOpts(platforms.DefaultSpec(), containerConfig, imageConfig)
 			require.NoError(t, err)
 			oci.ApplyOpts(ctx, nil, testContainer, spec, opts...)
 


### PR DESCRIPTION
Backport: https://github.com/containerd/containerd/pull/8464

The oci.WithUser option was being applied in container_create_linux.go instead of the cross plat buildLinuxSpec method. There's been recent work to try and make every spec option that can be applied on any platform able to do so, and this falls under that. However, WithUser on linux platforms relies on the containers SnapshotKey being filled out, which means the spec option needs to be applied during container creation.

To make this a little more generic, I've created a new platformSpecOpts method that handles any spec opts that rely on runtime state (rootfs mounted for example) for some platforms, or just platform options that we still don't have workarounds for to be able to specify them for other platforms (apparmor, seccomp etc.) by internally calling the already existing containerSpecOpts method.


(cherry picked from commit 66307d0b4eb9b0b2c890592dbd425274d97e1bd7)