### PR TITLE
Remove most logrus import

### DIFF
--- a/cmd/containerd/command/main_windows.go
+++ b/cmd/containerd/command/main_windows.go
@@ -114,7 +114,7 @@ func init() {
 		if hook, err := etwlogrus.NewHookFromProvider(provider); err == nil {
 			logrus.AddHook(hook)
 		} else {
-			logrus.Error(err)
+			log.L.Error(err)
 		}
 	}
 }

--- a/cmd/ctr/app/main.go
+++ b/cmd/ctr/app/main.go
@@ -37,9 +37,9 @@ import (
 	"github.com/containerd/containerd/cmd/ctr/commands/tasks"
 	versionCmd "github.com/containerd/containerd/cmd/ctr/commands/version"
 	"github.com/containerd/containerd/defaults"
+	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/version"
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"google.golang.org/grpc/grpclog"
 )
@@ -121,7 +121,7 @@ containerd CLI
 	}, extraCmds...)
 	app.Before = func(context *cli.Context) error {
 		if context.GlobalBool("debug") {
-			logrus.SetLevel(logrus.DebugLevel)
+			return log.SetLevel("debug")
 		}
 		return nil
 	}

--- a/cmd/ctr/commands/content/prune.go
+++ b/cmd/ctr/commands/content/prune.go
@@ -25,7 +25,6 @@ import (
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/log"
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -66,7 +65,7 @@ var pruneReferencesCommand = cli.Command{
 
 		dryRun := clicontext.Bool("dry")
 		if dryRun {
-			log.G(ctx).Logger.SetLevel(logrus.DebugLevel)
+			log.G(ctx).Logger.SetLevel(log.DebugLevel)
 			log.G(ctx).Debug("dry run, no changes will be applied")
 		}
 

--- a/content/local/store.go
+++ b/content/local/store.go
@@ -32,7 +32,6 @@ import (
 	"github.com/containerd/containerd/filters"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/pkg/randutil"
-	"github.com/sirupsen/logrus"
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -555,7 +554,7 @@ func (s *store) writer(ctx context.Context, ref string, total int64, expected di
 			total = status.Total
 			offset = status.Offset
 		} else {
-			logrus.Infof("failed to resume the status from path %s: %s. will recreate them", path, err.Error())
+			log.G(ctx).Infof("failed to resume the status from path %s: %s. will recreate them", path, err.Error())
 		}
 	}
 

--- a/contrib/fuzz/archive_fuzzer.go
+++ b/contrib/fuzz/archive_fuzzer.go
@@ -24,7 +24,7 @@ import (
 	"path"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	"github.com/sirupsen/logrus"
+	"github.com/containerd/containerd/log"
 
 	"github.com/containerd/containerd/archive"
 	"github.com/containerd/containerd/content/local"
@@ -42,7 +42,7 @@ func FuzzApply(data []byte) int {
 	// if the input is random.
 	//
 	// level=warning msg="ignored xattr ... in archive" error="operation not supported"
-	log.G(ctx).Logger.SetLevel(logrus.PanicLevel)
+	log.G(ctx).Logger.SetLevel(log.PanicLevel)
 
 	f := fuzz.NewConsumer(data)
 	iters, err := f.GetInt()

--- a/images/converter/default.go
+++ b/images/converter/default.go
@@ -26,10 +26,10 @@ import (
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/platforms"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -123,7 +123,7 @@ func (c *defaultConverter) convert(ctx context.Context, cs content.Store, desc o
 			newDesc.Annotations = nil
 		}
 	}
-	logrus.WithField("old", desc).WithField("new", newDesc).Debugf("converted")
+	log.G(ctx).WithField("old", desc).WithField("new", newDesc).Debugf("converted")
 	return newDesc, nil
 }
 

--- a/integration/images/image_list.go
+++ b/integration/images/image_list.go
@@ -22,8 +22,8 @@ import (
 	"os"
 	"sync"
 
+	"github.com/containerd/containerd/log"
 	"github.com/pelletier/go-toml"
-	"github.com/sirupsen/logrus"
 )
 
 var imageListFile = flag.String("image-list", "", "The TOML file containing the non-default images to be used in tests.")
@@ -58,7 +58,7 @@ func initImages(imageListFile string) {
 	}
 
 	if imageListFile != "" {
-		logrus.Infof("loading image list from file: %s", imageListFile)
+		log.L.Infof("loading image list from file: %s", imageListFile)
 
 		fileContent, err := os.ReadFile(imageListFile)
 		if err != nil {
@@ -71,7 +71,7 @@ func initImages(imageListFile string) {
 		}
 	}
 
-	logrus.Infof("Using the following image list: %+v", imageList)
+	log.L.Infof("Using the following image list: %+v", imageList)
 	imageMap = initImageMap(imageList)
 }
 

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -39,12 +39,12 @@ import (
 	_ "github.com/containerd/containerd/integration/images" // Keep this around to parse `imageListFile` command line var
 	"github.com/containerd/containerd/integration/remote"
 	dialer "github.com/containerd/containerd/integration/remote/util"
+	"github.com/containerd/containerd/log"
 	criconfig "github.com/containerd/containerd/pkg/cri/config"
 	"github.com/containerd/containerd/pkg/cri/constants"
 	"github.com/containerd/containerd/pkg/cri/server"
 	"github.com/containerd/containerd/pkg/cri/util"
 	"github.com/opencontainers/selinux/go-selinux"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	exec "golang.org/x/sys/execabs"
@@ -72,7 +72,7 @@ var containerdBin = flag.String("containerd-bin", "containerd", "The containerd 
 func TestMain(m *testing.M) {
 	flag.Parse()
 	if err := ConnectDaemons(); err != nil {
-		logrus.WithError(err).Fatalf("Failed to connect daemons")
+		log.L.WithError(err).Fatalf("Failed to connect daemons")
 	}
 	os.Exit(m.Run())
 }

--- a/metrics/cgroups/v1/oom.go
+++ b/metrics/cgroups/v1/oom.go
@@ -25,9 +25,9 @@ import (
 	"golang.org/x/sys/unix"
 
 	cgroups "github.com/containerd/cgroups/v3/cgroup1"
+	"github.com/containerd/containerd/log"
 	metrics "github.com/docker/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sirupsen/logrus"
 )
 
 func newOOMCollector(ns *metrics.Namespace) (*oomCollector, error) {
@@ -116,7 +116,7 @@ func (o *oomCollector) start() {
 			if err == unix.EINTR {
 				continue
 			}
-			logrus.WithError(err).Error("cgroups: epoll wait failed, OOM notifications disabled")
+			log.L.WithError(err).Error("cgroups: epoll wait failed, OOM notifications disabled")
 			return
 		}
 		for i := 0; i < n; i++ {

--- a/pkg/cri/io/container_io.go
+++ b/pkg/cri/io/container_io.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/log"
-	"github.com/sirupsen/logrus"
 
 	"github.com/containerd/containerd/pkg/cri/util"
 	cioutil "github.com/containerd/containerd/pkg/ioutil"
@@ -161,7 +160,7 @@ func (c *ContainerIO) Attach(opts AttachOptions) {
 				c.stdin.Close()
 				// Also closes the containerd side.
 				if err := opts.CloseStdin(); err != nil {
-					logrus.WithError(err).Errorf("Failed to close stdin for container %q", c.id)
+					log.L.WithError(err).Errorf("Failed to close stdin for container %q", c.id)
 				}
 			} else {
 				if opts.Stdout != nil {
@@ -177,7 +176,7 @@ func (c *ContainerIO) Attach(opts AttachOptions) {
 
 	attachStream := func(key string, close <-chan struct{}) {
 		<-close
-		logrus.Infof("Attach stream %q closed", key)
+		log.L.Infof("Attach stream %q closed", key)
 		// Make sure stdin gets closed.
 		if stdinStreamRC != nil {
 			stdinStreamRC.Close()

--- a/pkg/cri/io/logger.go
+++ b/pkg/cri/io/logger.go
@@ -23,9 +23,9 @@ import (
 	"io"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
+	"github.com/containerd/containerd/log"
 	cioutil "github.com/containerd/containerd/pkg/ioutil"
 )
 
@@ -51,7 +51,7 @@ func NewDiscardLogger() io.WriteCloser {
 // maxLen is the max length limit of a line. A line longer than the
 // limit will be cut into multiple lines.
 func NewCRILogger(path string, w io.Writer, stream StreamType, maxLen int) (io.WriteCloser, <-chan struct{}) {
-	logrus.Debugf("Start writing stream %q to log file %q", stream, path)
+	log.L.Debugf("Start writing stream %q to log file %q", stream, path)
 	prc, pwc := io.Pipe()
 	stop := make(chan struct{})
 	go func() {
@@ -147,7 +147,7 @@ func redirectLogs(path string, rc io.ReadCloser, w io.Writer, s StreamType, maxL
 			outputEntries.Inc()
 			outputBytes.Inc(float64(n))
 		} else {
-			logrus.WithError(err).Errorf("Fail to write %q log to log file %q", s, path)
+			log.L.WithError(err).Errorf("Fail to write %q log to log file %q", s, path)
 			// Continue on write error to drain the container output.
 		}
 	}
@@ -167,9 +167,9 @@ func redirectLogs(path string, rc io.ReadCloser, w io.Writer, s StreamType, maxL
 		}
 		if err != nil {
 			if err == io.EOF {
-				logrus.Debugf("Getting EOF from stream %q while redirecting to log file %q", s, path)
+				log.L.Debugf("Getting EOF from stream %q while redirecting to log file %q", s, path)
 			} else {
-				logrus.WithError(err).Errorf("An error occurred when redirecting stream %q to log file %q", s, path)
+				log.L.WithError(err).Errorf("An error occurred when redirecting stream %q to log file %q", s, path)
 			}
 			if length == 0 {
 				// No content left to write, break.
@@ -209,5 +209,5 @@ func redirectLogs(path string, rc io.ReadCloser, w io.Writer, s StreamType, maxL
 			break
 		}
 	}
-	logrus.Debugf("Finish redirecting stream %q to log file %q", s, path)
+	log.L.Debugf("Finish redirecting stream %q to log file %q", s, path)
 }

--- a/pkg/cri/sbserver/images/service.go
+++ b/pkg/cri/sbserver/images/service.go
@@ -29,7 +29,6 @@ import (
 	"github.com/containerd/containerd/pkg/kmutex"
 	"github.com/containerd/containerd/reference/docker"
 	imagedigest "github.com/opencontainers/go-digest"
-	"github.com/sirupsen/logrus"
 )
 
 type CRIImageService struct {
@@ -64,7 +63,7 @@ func NewService(config criconfig.Config, imageFSPath string, client *containerd.
 	}
 
 	// Start snapshot stats syncer, it doesn't need to be stopped.
-	logrus.Info("Start snapshots syncer")
+	log.L.Info("Start snapshots syncer")
 	snapshotsSyncer := newSnapshotsSyncer(
 		svc.snapshotStore,
 		svc.client.SnapshotService(svc.config.ContainerdConfig.Snapshotter),

--- a/pkg/cri/sbserver/podsandbox/helpers.go
+++ b/pkg/cri/sbserver/podsandbox/helpers.go
@@ -33,7 +33,6 @@ import (
 	ctrdutil "github.com/containerd/containerd/pkg/cri/util"
 	"github.com/containerd/containerd/reference/docker"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 
 	imagedigest "github.com/opencontainers/go-digest"
 )
@@ -111,7 +110,7 @@ func buildLabels(configLabels, imageConfigLabels map[string]string, containerTyp
 		} else {
 			// In case the image label is invalid, we output a warning and skip adding it to the
 			// container.
-			logrus.WithError(err).Warnf("unable to add image label with key %s to the container", k)
+			log.L.WithError(err).Warnf("unable to add image label with key %s to the container", k)
 		}
 	}
 	// labels from the CRI request (config) will override labels in the image config

--- a/pkg/cri/sbserver/podsandbox/sandbox_stop.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_stop.go
@@ -22,10 +22,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	eventtypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/log"
 	sandboxstore "github.com/containerd/containerd/pkg/cri/store/sandbox"
 	ctrdutil "github.com/containerd/containerd/pkg/cri/util"
 	"github.com/containerd/containerd/protobuf"
@@ -98,7 +97,7 @@ func (c *Controller) stopSandboxContainer(ctx context.Context, sandbox sandboxst
 					ExitStatus: exitStatus,
 					ExitedAt:   protobuf.ToTimestamp(exitedAt),
 				}
-				logrus.WithError(err).Errorf("Failed to wait sandbox exit %+v", e)
+				log.G(ctx).WithError(err).Errorf("Failed to wait sandbox exit %+v", e)
 				// TODO: how to backoff
 				c.cri.BackOffEvent(id, e)
 			}

--- a/pkg/cri/server/helpers.go
+++ b/pkg/cri/server/helpers.go
@@ -41,7 +41,6 @@ import (
 	runcoptions "github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/containerd/typeurl/v2"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 
 	runhcsoptions "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
 	imagedigest "github.com/opencontainers/go-digest"
@@ -519,7 +518,7 @@ func (c *criService) generateAndSendContainerEvent(ctx context.Context, containe
 	}
 	containerStatuses, err := c.getContainerStatuses(ctx, sandboxID)
 	if err != nil {
-		logrus.Errorf("Failed to get container statuses for container event for sandboxID %q: %v", sandboxID, err)
+		log.G(ctx).Errorf("Failed to get container statuses for container event for sandboxID %q: %v", sandboxID, err)
 	}
 
 	event := runtime.ContainerEventResponse{
@@ -535,7 +534,7 @@ func (c *criService) generateAndSendContainerEvent(ctx context.Context, containe
 	case c.containerEventsChan <- event:
 	default:
 		containerEventsDroppedCount.Inc()
-		logrus.Debugf("containerEventsChan is full, discarding event %+v", event)
+		log.G(ctx).Debugf("containerEventsChan is full, discarding event %+v", event)
 	}
 }
 

--- a/pkg/cri/server/service.go
+++ b/pkg/cri/server/service.go
@@ -36,7 +36,6 @@ import (
 	"github.com/containerd/containerd/pkg/kmutex"
 	"github.com/containerd/containerd/plugin"
 	cni "github.com/containerd/go-cni"
-	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
@@ -304,10 +303,10 @@ func (c *criService) Run(ready func()) error {
 // Close stops the CRI service.
 // TODO(random-liu): Make close synchronous.
 func (c *criService) Close() error {
-	logrus.Info("Stop CRI service")
+	log.L.Info("Stop CRI service")
 	for name, h := range c.cniNetConfMonitor {
 		if err := h.stop(); err != nil {
-			logrus.WithError(err).Errorf("failed to stop cni network conf monitor for %s", name)
+			log.L.WithError(err).Errorf("failed to stop cni network conf monitor for %s", name)
 		}
 	}
 	c.eventMonitor.stop()

--- a/pkg/epoch/epoch.go
+++ b/pkg/epoch/epoch.go
@@ -23,7 +23,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"github.com/containerd/containerd/log"
 )
 
 // SourceDateEpochEnv is the SOURCE_DATE_EPOCH env var.
@@ -49,7 +49,7 @@ func SourceDateEpoch() (*time.Time, error) {
 func SourceDateEpochOrNow() time.Time {
 	epoch, err := SourceDateEpoch()
 	if err != nil {
-		logrus.WithError(err).Warnf("Invalid %s", SourceDateEpochEnv)
+		log.L.WithError(err).Warnf("Invalid %s", SourceDateEpochEnv)
 	}
 	if epoch != nil {
 		return *epoch

--- a/pkg/nri/domain.go
+++ b/pkg/nri/domain.go
@@ -25,7 +25,6 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/namespaces"
 	nri "github.com/containerd/nri/pkg/adaptation"
-	"github.com/sirupsen/logrus"
 )
 
 // Domain implements the functions the generic NRI interface needs to
@@ -57,10 +56,10 @@ type Domain interface {
 func RegisterDomain(d Domain) {
 	err := domains.add(d)
 	if err != nil {
-		logrus.WithError(err).Fatalf("Failed to register namespace %q with NRI", d.GetName())
+		log.L.WithError(err).Fatalf("Failed to register namespace %q with NRI", d.GetName())
 	}
 
-	logrus.Infof("Registered namespace %q with NRI", d.GetName())
+	log.L.Infof("Registered namespace %q with NRI", d.GetName())
 }
 
 type domainTable struct {

--- a/pkg/nri/nri.go
+++ b/pkg/nri/nri.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 
 	"github.com/containerd/containerd/log"
-	"github.com/sirupsen/logrus"
 
 	"github.com/containerd/containerd/version"
 	nri "github.com/containerd/nri/pkg/adaptation"
@@ -110,7 +109,7 @@ func New(cfg *Config) (API, error) {
 	}
 
 	if cfg.Disable {
-		logrus.Info("NRI interface is disabled by configuration.")
+		log.L.Info("NRI interface is disabled by configuration.")
 		return l, nil
 	}
 
@@ -132,7 +131,7 @@ func New(cfg *Config) (API, error) {
 
 	l.state = make(map[string]State)
 
-	logrus.Info("created NRI interface")
+	log.L.Info("created NRI interface")
 
 	return l, nil
 }

--- a/pkg/oom/v1/v1.go
+++ b/pkg/oom/v1/v1.go
@@ -25,10 +25,10 @@ import (
 
 	"github.com/containerd/cgroups/v3/cgroup1"
 	eventstypes "github.com/containerd/containerd/api/events"
+	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/pkg/oom"
 	"github.com/containerd/containerd/runtime"
 	"github.com/containerd/containerd/runtime/v2/shim"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
@@ -79,7 +79,7 @@ func (e *epoller) Run(ctx context.Context) {
 				if err == unix.EINTR {
 					continue
 				}
-				logrus.WithError(err).Error("cgroups: epoll wait")
+				log.G(ctx).WithError(err).Error("cgroups: epoll wait")
 			}
 			for i := 0; i < n; i++ {
 				e.process(ctx, uintptr(events[i].Fd))
@@ -130,7 +130,7 @@ func (e *epoller) process(ctx context.Context, fd uintptr) {
 	if err := e.publisher.Publish(ctx, runtime.TaskOOMEventTopic, &eventstypes.TaskOOM{
 		ContainerID: i.id,
 	}); err != nil {
-		logrus.WithError(err).Error("publish OOM event")
+		log.G(ctx).WithError(err).Error("publish OOM event")
 	}
 }
 

--- a/pkg/oom/v2/v2.go
+++ b/pkg/oom/v2/v2.go
@@ -24,10 +24,10 @@ import (
 
 	cgroupsv2 "github.com/containerd/cgroups/v3/cgroup2"
 	eventstypes "github.com/containerd/containerd/api/events"
+	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/pkg/oom"
 	"github.com/containerd/containerd/runtime"
 	"github.com/containerd/containerd/runtime/v2/shim"
-	"github.com/sirupsen/logrus"
 )
 
 // New returns an implementation that listens to OOM events
@@ -74,7 +74,7 @@ func (w *watcher) Run(ctx context.Context) {
 				if err := w.publisher.Publish(ctx, runtime.TaskOOMEventTopic, &eventstypes.TaskOOM{
 					ContainerID: i.id,
 				}); err != nil {
-					logrus.WithError(err).Error("publish OOM event")
+					log.G(ctx).WithError(err).Error("publish OOM event")
 				}
 			}
 			if i.ev.OOMKill > 0 {
@@ -106,7 +106,7 @@ func (w *watcher) Add(id string, cgx interface{}) error {
 					i.err = err
 					w.itemCh <- i
 					// we no longer get any event/err when we got an err
-					logrus.WithError(err).Warn("error from *cgroupsv2.Manager.EventChan")
+					log.L.WithError(err).Warn("error from *cgroupsv2.Manager.EventChan")
 				}
 				return
 			}

--- a/pkg/process/init_state.go
+++ b/pkg/process/init_state.go
@@ -23,9 +23,9 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/containerd/containerd/log"
 	google_protobuf "github.com/containerd/containerd/protobuf/types"
 	runc "github.com/containerd/go-runc"
-	"github.com/sirupsen/logrus"
 )
 
 type initState interface {
@@ -341,7 +341,7 @@ func (s *pausedState) SetExited(status int) {
 	s.p.setExited(status)
 
 	if err := s.p.runtime.Resume(context.Background(), s.p.id); err != nil {
-		logrus.WithError(err).Error("resuming exited container from paused state")
+		log.L.WithError(err).Error("resuming exited container from paused state")
 	}
 
 	if err := s.transition("stopped"); err != nil {

--- a/remotes/docker/converter_fuzz.go
+++ b/remotes/docker/converter_fuzz.go
@@ -26,7 +26,6 @@ import (
 	"github.com/containerd/containerd/content/local"
 	"github.com/containerd/containerd/log"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 )
 
 func FuzzConvertManifest(data []byte) int {
@@ -34,7 +33,7 @@ func FuzzConvertManifest(data []byte) int {
 
 	// Do not log the message below
 	// level=warning msg="do nothing for media type: ..."
-	log.G(ctx).Logger.SetLevel(logrus.PanicLevel)
+	log.G(ctx).Logger.SetLevel(log.PanicLevel)
 
 	f := fuzz.NewConsumer(data)
 	desc := ocispec.Descriptor{}

--- a/runtime/restart/restart.go
+++ b/runtime/restart/restart.go
@@ -39,7 +39,7 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/containers"
-	"github.com/sirupsen/logrus"
+	"github.com/containerd/containerd/log"
 )
 
 const (
@@ -119,7 +119,7 @@ func (rp *Policy) MaximumRetryCount() int {
 func Reconcile(status containerd.Status, labels map[string]string) bool {
 	rp, err := NewPolicy(labels[PolicyLabel])
 	if err != nil {
-		logrus.WithError(err).Error("policy reconcile")
+		log.L.WithError(err).Error("policy reconcile")
 		return false
 	}
 	switch rp.Name() {
@@ -128,7 +128,7 @@ func Reconcile(status containerd.Status, labels map[string]string) bool {
 	case "on-failure":
 		restartCount, err := strconv.Atoi(labels[CountLabel])
 		if err != nil && labels[CountLabel] != "" {
-			logrus.WithError(err).Error("policy reconcile")
+			log.L.WithError(err).Error("policy reconcile")
 			return false
 		}
 		if status.ExitStatus != 0 && (rp.maximumRetryCount == 0 || restartCount < rp.maximumRetryCount) {

--- a/runtime/v2/shim/shim.go
+++ b/runtime/v2/shim/shim.go
@@ -167,7 +167,7 @@ func setLogger(ctx context.Context, id string) (context.Context, error) {
 		FullTimestamp:   true,
 	})
 	if debugFlag {
-		l.Logger.SetLevel(logrus.DebugLevel)
+		l.Logger.SetLevel(log.DebugLevel)
 	}
 	f, err := openLog(ctx, id)
 	if err != nil {
@@ -235,13 +235,13 @@ func run(ctx context.Context, manager Manager, name string, config Config) error
 	// Handle explicit actions
 	switch action {
 	case "delete":
-		if debugFlag {
-			logrus.SetLevel(logrus.DebugLevel)
-		}
 		logger := log.G(ctx).WithFields(log.Fields{
 			"pid":       os.Getpid(),
 			"namespace": namespaceFlag,
 		})
+		if debugFlag {
+			logger.Logger.SetLevel(log.DebugLevel)
+		}
 		go reap(ctx, logger, signals)
 		ss, err := manager.Stop(ctx, id)
 		if err != nil {
@@ -350,7 +350,7 @@ func run(ctx context.Context, manager Manager, name string, config Config) error
 		}
 
 		if src, ok := instance.(TTRPCService); ok {
-			logrus.WithField("id", id).Debug("registering ttrpc service")
+			log.G(ctx).WithField("id", id).Debug("registering ttrpc service")
 			ttrpcServices = append(ttrpcServices, src)
 
 		}
@@ -432,7 +432,7 @@ func serve(ctx context.Context, server *ttrpc.Server, signals chan os.Signal, sh
 	return reap(ctx, logger, signals)
 }
 
-func dumpStacks(logger *logrus.Entry) {
+func dumpStacks(logger *log.Entry) {
 	var (
 		buf       []byte
 		stackSize int

--- a/runtime/v2/shim/shim_unix.go
+++ b/runtime/v2/shim/shim_unix.go
@@ -27,6 +27,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/sys/reaper"
 	"github.com/containerd/fifo"
 	"github.com/sirupsen/logrus"
@@ -66,7 +67,7 @@ func serveListener(path string) (net.Listener, error) {
 	if err != nil {
 		return nil, err
 	}
-	logrus.WithField("socket", path).Debug("serving api on socket")
+	log.L.WithField("socket", path).Debug("serving api on socket")
 	return l, nil
 }
 

--- a/snapshots/benchsuite/benchmark_test.go
+++ b/snapshots/benchsuite/benchmark_test.go
@@ -30,9 +30,9 @@ import (
 	"time"
 
 	"github.com/containerd/continuity/fs/fstest"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/containerd/snapshots/devmapper"
@@ -54,7 +54,9 @@ func init() {
 	flag.StringVar(&nativeRootPath, "native.rootPath", "", "Root dir for native snapshotter")
 
 	// Avoid mixing benchmark output and INFO messages
-	logrus.SetLevel(logrus.ErrorLevel)
+	if err := log.SetLevel("error"); err != nil {
+		panic(fmt.Sprintf("failed to set up log level: %v", err))
+	}
 }
 
 func BenchmarkNative(b *testing.B) {

--- a/snapshots/devmapper/snapshotter_test.go
+++ b/snapshots/devmapper/snapshotter_test.go
@@ -27,9 +27,9 @@ import (
 	"time"
 
 	"github.com/containerd/continuity/fs/fstest"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/pkg/testutil"
@@ -41,7 +41,7 @@ import (
 func TestSnapshotterSuite(t *testing.T) {
 	testutil.RequiresRoot(t)
 
-	logrus.SetLevel(logrus.DebugLevel)
+	assert.NoError(t, log.SetLevel("debug"))
 
 	snapshotterFn := func(ctx context.Context, root string) (snapshots.Snapshotter, func() error, error) {
 		poolName := fmt.Sprintf("containerd-snapshotter-suite-pool-%d", time.Now().Nanosecond())
@@ -138,7 +138,7 @@ func TestMkfsXfsNonDefault(t *testing.T) {
 func TestMultipleXfsMounts(t *testing.T) {
 	testutil.RequiresRoot(t)
 
-	logrus.SetLevel(logrus.DebugLevel)
+	assert.NoError(t, log.SetLevel("debug"))
 
 	ctx := context.Background()
 	ctx = namespaces.WithNamespace(ctx, "testsuite")

--- a/snapshots/overlay/overlay.go
+++ b/snapshots/overlay/overlay.go
@@ -32,7 +32,6 @@ import (
 	"github.com/containerd/containerd/snapshots/overlay/overlayutils"
 	"github.com/containerd/containerd/snapshots/storage"
 	"github.com/containerd/continuity/fs"
-	"github.com/sirupsen/logrus"
 )
 
 // upperdirKey is a key of an optional label to each snapshot.
@@ -137,7 +136,7 @@ func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
 		// figure out whether "userxattr" option is recognized by the kernel && needed
 		userxattr, err := overlayutils.NeedsUserXAttr(root)
 		if err != nil {
-			logrus.WithError(err).Warnf("cannot detect whether \"userxattr\" option needs to be used, assuming to be %v", userxattr)
+			log.L.WithError(err).Warnf("cannot detect whether \"userxattr\" option needs to be used, assuming to be %v", userxattr)
 		}
 		if userxattr {
 			config.mountOptions = append(config.mountOptions, "userxattr")


### PR DESCRIPTION
Similar to https://github.com/containerd/containerd/pull/8481, this PR cleans most logrus import and usage. After this only a few are left (mostly in tracing plugin and shim) related to logrus hook.

It contains the following changes:

1. `logrus.Warn/Info/Error` -> `log.L` (if no ctx) or `log.G(ctx)` (if has ctx)
2. `logrus.XXXLevel` -> `log.XXXLevel`
3. `logrus.SetLevel(log.DebugLevel)` -> `err := log.SetLevel("debug")`.

