### PR TITLE
Remove redundant nil check

### DIFF
--- a/container.go
+++ b/container.go
@@ -275,15 +275,13 @@ func (c *container) NewTask(ctx context.Context, ioCreate cio.Creator, opts ...N
 			return nil, err
 		}
 	}
-	if info.RootFS != nil {
-		for _, m := range info.RootFS {
-			request.Rootfs = append(request.Rootfs, &types.Mount{
-				Type:    m.Type,
-				Source:  m.Source,
-				Target:  m.Target,
-				Options: m.Options,
-			})
-		}
+	for _, m := range info.RootFS {
+		request.Rootfs = append(request.Rootfs, &types.Mount{
+			Type:    m.Type,
+			Source:  m.Source,
+			Target:  m.Target,
+			Options: m.Options,
+		})
 	}
 	request.RuntimePath = info.RuntimePath
 	if info.Options != nil {

--- a/remotes/docker/config/hosts.go
+++ b/remotes/docker/config/hosts.go
@@ -193,29 +193,27 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
 					}
 				}
 
-				if host.clientPairs != nil {
-					for _, pair := range host.clientPairs {
-						certPEMBlock, err := os.ReadFile(pair[0])
-						if err != nil {
-							return nil, fmt.Errorf("unable to read CERT file %q: %w", pair[0], err)
-						}
-						var keyPEMBlock []byte
-						if pair[1] != "" {
-							keyPEMBlock, err = os.ReadFile(pair[1])
-							if err != nil {
-								return nil, fmt.Errorf("unable to read CERT file %q: %w", pair[1], err)
-							}
-						} else {
-							// Load key block from same PEM file
-							keyPEMBlock = certPEMBlock
-						}
-						cert, err := tls.X509KeyPair(certPEMBlock, keyPEMBlock)
-						if err != nil {
-							return nil, fmt.Errorf("failed to load X509 key pair: %w", err)
-						}
-
-						tlsConfig.Certificates = append(tlsConfig.Certificates, cert)
+				for _, pair := range host.clientPairs {
+					certPEMBlock, err := os.ReadFile(pair[0])
+					if err != nil {
+						return nil, fmt.Errorf("unable to read CERT file %q: %w", pair[0], err)
 					}
+					var keyPEMBlock []byte
+					if pair[1] != "" {
+						keyPEMBlock, err = os.ReadFile(pair[1])
+						if err != nil {
+							return nil, fmt.Errorf("unable to read CERT file %q: %w", pair[1], err)
+						}
+					} else {
+						// Load key block from same PEM file
+						keyPEMBlock = certPEMBlock
+					}
+					cert, err := tls.X509KeyPair(certPEMBlock, keyPEMBlock)
+					if err != nil {
+						return nil, fmt.Errorf("failed to load X509 key pair: %w", err)
+					}
+
+					tlsConfig.Certificates = append(tlsConfig.Certificates, cert)
 				}
 
 				c := *client


### PR DESCRIPTION
From the Go docs:

>  1. ..."For a nil slice, the number of iterations is 0." https://go.dev/ref/spec#For_range

Both `info.RootFS` and `host.clientPairs` are slices. Therefore, an additional nil check for before the loop is unnecessary.