### PR TITLE
[release/1.7 backport] make repositories of install dependencies configurable

### DIFF
--- a/script/setup/install-cni
+++ b/script/setup/install-cni
@@ -24,6 +24,7 @@ set -eu -o pipefail
 CNI_COMMIT=${1:-$(go list -f "{{.Version}}" -m github.com/containernetworking/plugins)}
 CNI_DIR=${DESTDIR:=''}/opt/cni
 CNI_CONFIG_DIR=${DESTDIR}/etc/cni/net.d
+: "${CNI_REPO:=https://github.com/containernetworking/plugins.git}"
 
 # e2e and Cirrus will fail with "sudo: command not found"
 SUDO=''
@@ -32,7 +33,7 @@ if (( $EUID != 0 )); then
 fi
 
 TMPROOT=$(mktemp -d)
-git clone https://github.com/containernetworking/plugins.git "${TMPROOT}"/plugins
+git clone "${CNI_REPO}" "${TMPROOT}"/plugins
 pushd "${TMPROOT}"/plugins
 git checkout "$CNI_COMMIT"
 ./build_linux.sh

--- a/script/setup/install-critools
+++ b/script/setup/install-critools
@@ -33,9 +33,10 @@ go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.2
 
 : "${CRITEST_COMMIT:=$(cat "${script_dir}/critools-version")}"
 : "${DESTDIR:=""}"
+: "${CRI_TOOLS_REPO:=https://github.com/kubernetes-sigs/cri-tools.git}"
 
 TMPROOT=$(mktemp -d)
-git clone https://github.com/kubernetes-sigs/cri-tools.git "${TMPROOT}/cri-tools"
+git clone "${CRI_TOOLS_REPO}" "${TMPROOT}/cri-tools"
 pushd "${TMPROOT}"/cri-tools
 git checkout "$CRITEST_COMMIT"
 make

--- a/script/setup/install-runc
+++ b/script/setup/install-runc
@@ -31,9 +31,10 @@ fi
 function install_runc() {
 	# When updating runc-version, consider updating the runc module in go.mod as well
 	: "${RUNC_VERSION:=$(cat "${script_dir}/runc-version")}"
+	: "${RUNC_REPO:=https://github.com/opencontainers/runc.git}"
 
 	TMPROOT=$(mktemp -d)
-	git clone https://github.com/opencontainers/runc.git "${TMPROOT}"/runc
+	git clone "${RUNC_REPO}" "${TMPROOT}"/runc
 	pushd "${TMPROOT}"/runc
 	git checkout "${RUNC_VERSION}"
 	make BUILDTAGS='seccomp' runc
@@ -44,7 +45,8 @@ function install_runc() {
 
 function install_crun() {
 	: "${CRUN_VERSION:=$(cat "${script_dir}/crun-version")}"
-	$SUDO curl -S -o /usr/local/sbin/runc -L https://github.com/containers/crun/releases/download/"${CRUN_VERSION}"/crun-"${CRUN_VERSION}"-linux-"$(go env GOARCH)"
+	: "${CRUN_REPO:=https://github.com/containers/crun}"
+	$SUDO curl -S -o /usr/local/sbin/runc -L "${CRUN_REPO}"/releases/download/"${CRUN_VERSION}"/crun-"${CRUN_VERSION}"-linux-"$(go env GOARCH)"
 	$SUDO chmod +x /usr/local/sbin/runc
 }
 


### PR DESCRIPTION
make repositories of dependencies like runc, crun, cni and critools configurable


(cherry picked from commit 7a0ad09a0d5edcd40555a998e0e065e6dda43acc)

clean cherry-pick of #9021 