### PR TITLE
Add missing unpacker.Wait for image import

### DIFF
--- a/pkg/transfer/local/import.go
+++ b/pkg/transfer/local/import.go
@@ -113,8 +113,18 @@ func (ts *localTransferService) importStream(ctx context.Context, i transfer.Ima
 	}
 
 	if err := images.WalkNotEmpty(ctx, handler, index); err != nil {
+		if unpacker != nil {
+			// wait for unpacker to cleanup
+			unpacker.Wait()
+		}
 		// TODO: Handle Not Empty as a special case on the input
 		return err
+	}
+
+	if unpacker != nil {
+		if _, err = unpacker.Wait(); err != nil {
+			return err
+		}
 	}
 
 	for _, desc := range descriptors {


### PR DESCRIPTION
- For remote snapshotters, the unpack phase serves as an important step for preparing the remote snapshot. With the missing `unpacker.Wait`, the snapshotter `Prepare` context is always canceled.
- This patch allows remote snapshotter based archives to be imported via the transfer service or `ctr image import`