### PR TITLE
Revert "log: define G() as a function instead of a variable"

### DIFF
--- a/log/context.go
+++ b/log/context.go
@@ -44,6 +44,12 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// G is a shorthand for [GetLogger].
+//
+// We may want to define this locally to a package to get package tagged log
+// messages.
+var G = GetLogger
+
 // L is an alias for the standard logger.
 var L = &Entry{
 	Logger: logrus.StandardLogger(),
@@ -169,11 +175,6 @@ func WithLogger(ctx context.Context, logger *Entry) context.Context {
 // GetLogger retrieves the current logger from the context. If no logger is
 // available, the default logger is returned.
 func GetLogger(ctx context.Context) *Entry {
-	return G(ctx)
-}
-
-// G is a shorthand for [GetLogger].
-func G(ctx context.Context) *Entry {
 	if logger := ctx.Value(loggerKey{}); logger != nil {
 		return logger.(*Entry)
 	}


### PR DESCRIPTION
- updates https://github.com/containerd/containerd/pull/8894

This reverts commit 778ac302b27278b25bb2dabfc1cda99780cbc60b.

(slightly modified, due to changes that were merged after that).

The reverted commit had two elements;

- Make `G` an actual function to improve the documentation
- Prevent `G` from being overwritten externally

From the commit that's reverted:

> The `G` variable is exported, and not expected to be overwritten
> externally. Defining it as a function also documents it as a function
> on https://pkg.go.dev, instead of a variable; https://pkg.go.dev/github.com/containerd/containerd@v1.6.22/log#pkg-variables

While it's unclear if the ability to replace the implementation was _intentional_, it's this part that some external consumers were (ab)using.

We should look into that part in a follow-up, and design for this, for example by providing a utility to replace the logger, and properly document that.

In the meantime, let's revert the change.