### PR TITLE
Process from the oldest issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -33,3 +33,5 @@ jobs:
           close-pr-message: 'This PR was closed because it has been stalled for 7 days with no activity.'
           # Enable dry-run when changing this file from a PR.
           debug-only: github.event_name == 'pull_request'
+          # Process from the oldest issues and PRs.
+          ascending: true


### PR DESCRIPTION
Because we have a lot of open issues/PRs, processing them from the recent ones doesn't work. It consumes all `operations-per-run` before reaching to the end.