### PR TITLE
golangci-lint: enable depguard to prevent re-introducing libcontainer

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 linters:
   enable:
+    - depguard # Checks for dependencies that should not be (re)introduced. See "linter-settings" for further details.
     - exportloopref # Checks for pointers to enclosing loop variables
     - gofmt
     - goimports
@@ -54,6 +55,13 @@ issues:
       text: "redefines-builtin-id"
 
 linters-settings:
+  depguard:
+    rules:
+      main:
+        deny:
+          - pkg: github.com/opencontainers/runc
+            desc: We don't want to depend on runc (libcontainer), unless there is no other option; see https://github.com/opencontainers/runc/issues/3028.
+
   gosec:
     # The following issues surfaced when `gosec` linter
     # was enabled. They are temporarily excluded to unblock


### PR DESCRIPTION
- [x] depends on https://github.com/containerd/containerd/pull/9045
- [x] depends on / relates to https://github.com/containerd/containerd/pull/9114
- relates to https://github.com/opencontainers/runc/issues/3028