### PR TITLE
Fix usages of `mountinfo.PrefixFilter`

### DIFF
--- a/mount/lookup_unix.go
+++ b/mount/lookup_unix.go
@@ -20,18 +20,15 @@ package mount
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"github.com/moby/sys/mountinfo"
 )
 
 // Lookup returns the mount info corresponds to the path.
 func Lookup(dir string) (Info, error) {
-	dir = filepath.Clean(dir)
-
-	resolvedDir, err := filepath.EvalSymlinks(dir)
+	resolvedDir, err := CanonicalizePath(dir)
 	if err != nil {
-		return Info{}, fmt.Errorf("failed to resolve symlink for %q: %w", dir, err)
+		return Info{}, err
 	}
 
 	m, err := mountinfo.GetMounts(mountinfo.ParentsFilter(resolvedDir))

--- a/mount/mount.go
+++ b/mount/mount.go
@@ -18,6 +18,7 @@ package mount
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/containerd/containerd/api/types"
@@ -67,6 +68,18 @@ func UnmountMounts(mounts []Mount, target string, flags int) error {
 		}
 	}
 	return nil
+}
+
+// CanonicalizePath makes path absolute and resolves symlinks in it.
+// Path must exist.
+func CanonicalizePath(path string) (string, error) {
+	// Abs also does Clean, so we do not need to call it separately
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.EvalSymlinks(path)
 }
 
 // ReadOnly returns a boolean value indicating whether this mount has the "ro"

--- a/mount/mount_unix.go
+++ b/mount/mount_unix.go
@@ -30,6 +30,12 @@ func UnmountRecursive(target string, flags int) error {
 	if target == "" {
 		return nil
 	}
+
+	target, err := CanonicalizePath(target)
+	if err != nil {
+		return err
+	}
+
 	mounts, err := mountinfo.GetMounts(mountinfo.PrefixFilter(target))
 	if err != nil {
 		return err

--- a/pkg/cri/sbserver/helpers_linux.go
+++ b/pkg/cri/sbserver/helpers_linux.go
@@ -65,6 +65,11 @@ func openLogFile(path string) (*os.File, error) {
 // unmountRecursive unmounts the target and all mounts underneath, starting with
 // the deepest mount first.
 func unmountRecursive(ctx context.Context, target string) error {
+	target, err := mount.CanonicalizePath(target)
+	if err != nil {
+		return err
+	}
+
 	toUnmount, err := mountinfo.GetMounts(mountinfo.PrefixFilter(target))
 	if err != nil {
 		return err

--- a/pkg/cri/sbserver/podsandbox/helpers_linux.go
+++ b/pkg/cri/sbserver/podsandbox/helpers_linux.go
@@ -143,6 +143,11 @@ func (c *Controller) seccompEnabled() bool {
 // unmountRecursive unmounts the target and all mounts underneath, starting with
 // the deepest mount first.
 func unmountRecursive(ctx context.Context, target string) error {
+	target, err := mount.CanonicalizePath(target)
+	if err != nil {
+		return err
+	}
+
 	toUnmount, err := mountinfo.GetMounts(mountinfo.PrefixFilter(target))
 	if err != nil {
 		return err

--- a/pkg/cri/server/helpers_linux.go
+++ b/pkg/cri/server/helpers_linux.go
@@ -164,6 +164,11 @@ func openLogFile(path string) (*os.File, error) {
 // unmountRecursive unmounts the target and all mounts underneath, starting with
 // the deepest mount first.
 func unmountRecursive(ctx context.Context, target string) error {
+	target, err := mount.CanonicalizePath(target)
+	if err != nil {
+		return err
+	}
+
 	toUnmount, err := mountinfo.GetMounts(mountinfo.PrefixFilter(target))
 	if err != nil {
 		return err


### PR DESCRIPTION
Fix usages of `mountinfo.PrefixFilter`

It says: The prefix path **must be absolute, have all symlinks resolved, and cleaned**. But those requirements are violated in lots of places.

What happens when it is given a non-canonicalized path is that `mountinfo.GetMounts` will not find mounts.

The trivial case is:
```
$ mkdir a && ln -s a b && mkdir b/c b/d && mount --bind b/c b/d && cat /proc/mounts | grep -- '[ab]/d'
/dev/sdd3 /home/user/a/d ext4 rw,noatime,discard 0 0
```
We asked to bind-mount b/c to b/d, but ended up with mount in a/d.
So, mount table always contains canonicalized mount points, and it is an error to look for non-canonicalized paths in it.

Signed-off-by: Marat Radchenko <marat@slonopotamus.org>