### PR TITLE
[release/1.7] Invoke Stable ABI compatibility function in windows platform matcher

### DIFF
--- a/pkg/transfer/streaming/stream.go
+++ b/pkg/transfer/streaming/stream.go
@@ -164,7 +164,7 @@ func ReceiveStream(ctx context.Context, stream streaming.Stream) io.Reader {
 			}
 			any, err := stream.Recv()
 			if err != nil {
-				if errors.Is(err, io.EOF) {
+				if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) {
 					err = nil
 				} else {
 					err = fmt.Errorf("received failed: %w", err)

--- a/platforms/defaults_windows.go
+++ b/platforms/defaults_windows.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Microsoft/hcsshim/osversion"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/sys/windows"
 )
@@ -50,13 +51,34 @@ func (m windowsmatcher) Match(p specs.Platform) bool {
 	match := m.defaultMatcher.Match(p)
 
 	if match && m.OS == "windows" {
-		if strings.HasPrefix(p.OSVersion, m.osVersionPrefix) {
+		// HPC containers do not have OS version filled
+		if p.OSVersion == "" {
 			return true
 		}
-		return p.OSVersion == ""
+
+		hostOsVersion := GetOsVersion(m.osVersionPrefix)
+		ctrOsVersion := GetOsVersion(p.OSVersion)
+		return osversion.CheckHostAndContainerCompat(hostOsVersion, ctrOsVersion)
 	}
 
 	return match
+}
+
+func GetOsVersion(osVersionPrefix string) osversion.OSVersion {
+	parts := strings.Split(osVersionPrefix, ".")
+	if len(parts) < 3 {
+		return osversion.OSVersion{}
+	}
+
+	majorVersion, _ := strconv.Atoi(parts[0])
+	minorVersion, _ := strconv.Atoi(parts[1])
+	buildNumber, _ := strconv.Atoi(parts[2])
+
+	return osversion.OSVersion{
+		MajorVersion: uint8(majorVersion),
+		MinorVersion: uint8(minorVersion),
+		Build:        uint16(buildNumber),
+	}
 }
 
 // Less sorts matched platforms in front of other platforms.

--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -196,6 +196,10 @@ func Parse(specifier string) (specs.Platform, error) {
 				p.Variant = cpuVariant()
 			}
 
+			if p.OS == "windows" {
+				p.OSVersion = GetWindowsOsVersion()
+			}
+
 			return p, nil
 		}
 
@@ -218,6 +222,10 @@ func Parse(specifier string) (specs.Platform, error) {
 			p.Variant = ""
 		}
 
+		if p.OS == "windows" {
+			p.OSVersion = GetWindowsOsVersion()
+		}
+
 		return p, nil
 	case 3:
 		// we have a fully specified variant, this is rare
@@ -225,6 +233,10 @@ func Parse(specifier string) (specs.Platform, error) {
 		p.Architecture, p.Variant = normalizeArch(parts[1], parts[2])
 		if p.Architecture == "arm64" && p.Variant == "" {
 			p.Variant = "v8"
+		}
+
+		if p.OS == "windows" {
+			p.OSVersion = GetWindowsOsVersion()
 		}
 
 		return p, nil

--- a/platforms/platforms_other.go
+++ b/platforms/platforms_other.go
@@ -28,3 +28,7 @@ func newDefaultMatcher(platform specs.Platform) Matcher {
 		Platform: Normalize(platform),
 	}
 }
+
+func GetWindowsOsVersion() string {
+	return ""
+}

--- a/platforms/platforms_windows.go
+++ b/platforms/platforms_windows.go
@@ -17,7 +17,10 @@
 package platforms
 
 import (
+	"fmt"
+
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/sys/windows"
 )
 
 // NewMatcher returns a Windows matcher that will match on osVersionPrefix if
@@ -31,4 +34,9 @@ func newDefaultMatcher(platform specs.Platform) Matcher {
 			Platform: Normalize(platform),
 		},
 	}
+}
+
+func GetWindowsOsVersion() string {
+	major, minor, build := windows.RtlGetNtVersionNumbers()
+	return fmt.Sprintf("%d.%d.%d", major, minor, build)
 }


### PR DESCRIPTION
This PR ports the following commit for stable ABI support to containerd/release/1.7 and fixes dependencies on transfer service.
(cherry picked from commit cfb30a31a8507e4417d42d38c9a99b04fc8af8a9 and 823e0420eb3cd3eebbf15472cda0cfac85da14f6)