### PR TITLE
Fix `ip_pref` configuration option

### DIFF
--- a/pkg/cri/sbserver/sandbox_run.go
+++ b/pkg/cri/sbserver/sandbox_run.go
@@ -612,7 +612,7 @@ func selectPodIPs(ctx context.Context, configs []*cni.IPConfig, preference strin
 		}
 	case "ipv6":
 		for i, ip := range configs {
-			if ip.IP.To16() != nil {
+			if ip.IP.To4() == nil {
 				return ipString(ip), append(extra, toStrings(configs[i+1:])...)
 			}
 			extra = append(extra, ipString(ip))

--- a/pkg/cri/sbserver/sandbox_run_test.go
+++ b/pkg/cri/sbserver/sandbox_run_test.go
@@ -145,7 +145,7 @@ func TestSelectPodIP(t *testing.T) {
 		},
 		{
 			desc:                  "ipv6 should be picked even if ipv4 comes first",
-			ips:                   []string{"2001:db8:85a3::8a2e:370:7334", "192.168.17.43"},
+			ips:                   []string{"192.168.17.43", "2001:db8:85a3::8a2e:370:7334"},
 			expectedIP:            "2001:db8:85a3::8a2e:370:7334",
 			expectedAdditionalIPs: []string{"192.168.17.43"},
 			pref:                  "ipv6",

--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -692,7 +692,7 @@ func selectPodIPs(ctx context.Context, configs []*cni.IPConfig, preference strin
 		}
 	case "ipv6":
 		for i, ip := range configs {
-			if ip.IP.To16() != nil {
+			if ip.IP.To4() == nil {
 				return ipString(ip), append(extra, toStrings(configs[i+1:])...)
 			}
 			extra = append(extra, ipString(ip))

--- a/pkg/cri/server/sandbox_run_test.go
+++ b/pkg/cri/server/sandbox_run_test.go
@@ -293,7 +293,7 @@ func TestSelectPodIP(t *testing.T) {
 		},
 		{
 			desc:                  "ipv6 should be picked even if ipv4 comes first",
-			ips:                   []string{"2001:db8:85a3::8a2e:370:7334", "192.168.17.43"},
+			ips:                   []string{"192.168.17.43", "2001:db8:85a3::8a2e:370:7334"},
 			expectedIP:            "2001:db8:85a3::8a2e:370:7334",
 			expectedAdditionalIPs: []string{"192.168.17.43"},
 			pref:                  "ipv6",


### PR DESCRIPTION
Currently, `containerd` treats `ip_pref = "ipv6"` the same as `ip_pref = "cni"`, because the loop meant to select the first IPv6 address instead selects the first IP address of any kind.

This problem has been allowed to go unnoticed because the test case said to check the behavior when the first input address is an IPv4 address is actually providing an IPv6 address first.

This PR corrects both of the above.