### PR TITLE
leases: add WithLabel

### DIFF
--- a/cmd/ctr/commands/images/mount.go
+++ b/cmd/ctr/commands/images/mount.go
@@ -75,9 +75,7 @@ When you are done, use the unmount command.
 		ctx, done, err := client.WithLease(ctx,
 			leases.WithID(target),
 			leases.WithExpiration(24*time.Hour),
-			leases.WithLabels(map[string]string{
-				"containerd.io/gc.ref.snapshot." + snapshotter: target,
-			}),
+			leases.WithLabel("containerd.io/gc.ref.snapshot."+snapshotter, target),
 		)
 		if err != nil && !errdefs.IsAlreadyExists(err) {
 			return err

--- a/leases/lease.go
+++ b/leases/lease.go
@@ -65,6 +65,19 @@ func SynchronousDelete(ctx context.Context, o *DeleteOptions) error {
 	return nil
 }
 
+// WithLabel sets a label on a lease, and merges it with existing labels.
+// It overwrites the existing value of the given label (if present).
+func WithLabel(label, value string) Opt {
+	return func(l *Lease) error {
+		if l.Labels == nil {
+			l.Labels = map[string]string{label: value}
+			return nil
+		}
+		l.Labels[label] = value
+		return nil
+	}
+}
+
 // WithLabels merges labels on a lease
 func WithLabels(labels map[string]string) Opt {
 	return func(l *Lease) error {

--- a/leases/lease_test.go
+++ b/leases/lease_test.go
@@ -24,60 +24,47 @@ import (
 )
 
 func TestWithLabels(t *testing.T) {
-	type unitTest struct {
+	testcases := []struct {
 		name     string
 		uut      *Lease
 		labels   map[string]string
 		expected map[string]string
-	}
-
-	addLabelsToEmptyMap := &unitTest{
-		name: "AddLabelsToEmptyMap",
-		uut:  &Lease{},
-		labels: map[string]string{
-			"containerd.io/gc.root": "2015-12-04T00:00:00Z",
-		},
-		expected: map[string]string{
-			"containerd.io/gc.root": "2015-12-04T00:00:00Z",
-		},
-	}
-
-	addLabelsToNonEmptyMap := &unitTest{
-		name: "AddLabelsToNonEmptyMap",
-		uut: &Lease{
-			Labels: map[string]string{
-				"containerd.io/gc.expire": "2015-12-05T00:00:00Z",
+	}{
+		{
+			name: "AddLabelsToEmptyMap",
+			uut:  &Lease{},
+			labels: map[string]string{
+				"containerd.io/gc.root": "2015-12-04T00:00:00Z",
+			},
+			expected: map[string]string{
+				"containerd.io/gc.root": "2015-12-04T00:00:00Z",
 			},
 		},
-		labels: map[string]string{
-			"containerd.io/gc.root":                   "2015-12-04T00:00:00Z",
-			"containerd.io/gc.ref.snapshot.overlayfs": "sha256:87806a591ce894ff5c699c28fe02093d6cdadd6b1ad86819acea05ccb212ff3d",
-		},
-		expected: map[string]string{
-			"containerd.io/gc.root":                   "2015-12-04T00:00:00Z",
-			"containerd.io/gc.ref.snapshot.overlayfs": "sha256:87806a591ce894ff5c699c28fe02093d6cdadd6b1ad86819acea05ccb212ff3d",
-			"containerd.io/gc.expire":                 "2015-12-05T00:00:00Z",
+		{
+			name: "AddLabelsToNonEmptyMap",
+			uut: &Lease{
+				Labels: map[string]string{
+					"containerd.io/gc.expire": "2015-12-05T00:00:00Z",
+				},
+			},
+			labels: map[string]string{
+				"containerd.io/gc.root":                   "2015-12-04T00:00:00Z",
+				"containerd.io/gc.ref.snapshot.overlayfs": "sha256:87806a591ce894ff5c699c28fe02093d6cdadd6b1ad86819acea05ccb212ff3d",
+			},
+			expected: map[string]string{
+				"containerd.io/gc.root":                   "2015-12-04T00:00:00Z",
+				"containerd.io/gc.ref.snapshot.overlayfs": "sha256:87806a591ce894ff5c699c28fe02093d6cdadd6b1ad86819acea05ccb212ff3d",
+				"containerd.io/gc.expire":                 "2015-12-05T00:00:00Z",
+			},
 		},
 	}
 
-	testcases := []*unitTest{
-		addLabelsToEmptyMap,
-		addLabelsToNonEmptyMap,
-	}
-
-	for _, testcase := range testcases {
-		testcase := testcase
-
-		t.Run(testcase.name, func(t *testing.T) {
-			f := WithLabels(testcase.labels)
-
-			err := f(testcase.uut)
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := WithLabels(tc.labels)(tc.uut)
 			require.NoError(t, err)
-
-			for k, v := range testcase.expected {
-				assert.Contains(t, testcase.uut.Labels, k)
-				assert.Equal(t, v, testcase.uut.Labels[k])
-			}
+			assert.Equal(t, tc.uut.Labels, tc.expected)
 		})
 	}
 }


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/46383#discussion_r1321652839


### leases: cleanup TestWithLabels

- don't define a type, but just an ad-hoc struct
- use a single slice with test-cases; this allows IDE's to pick up the
  table as a test-table (which allows (re-)running individual tests)
- make use of testify's assert.Equal to compare the results, instead
  of a DIY loop over the expected values.

### leases: add WithLabel

This adds a new WithLabel function, which allows to set a single label on
a lease, without having to first construct an intermediate `map[string]string`.
