### PR TITLE
[release/1.7] Prepare release notes for 1.7.6

### DIFF
--- a/releases/v1.7.6.toml
+++ b/releases/v1.7.6.toml
@@ -1,0 +1,36 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.7.5"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The sixth patch release for containerd 1.7 contains various fixes and updates.
+
+### Notable Updates
+
+* **Fix log package for clients overwriting the global logger** ([#9032](https://github.com/containerd/containerd/pull/9032))
+* **Fix blockfile snapshotter copy on Darwin** ([#9047](https://github.com/containerd/containerd/pull/9047))
+* **Add support for Linux usernames on non-Linux platforms** ([#9015](https://github.com/containerd/containerd/pull/9015))
+* **Update Windows platform matcher to invoke stable ABI compability function** ([#9069](https://github.com/containerd/containerd/pull/9069))
+* **Update Golang to 1.20.8** ([#9074](https://github.com/containerd/containerd/pull/9074))
+* **Update push to inherit distribution sources from parent** ([#9084](https://github.com/containerd/containerd/pull/9084))
+
+See the changelog for complete list of changes"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.7.5+unknown"
+	Version = "1.7.6+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
See generated notes https://gist.github.com/dmcgowan/b08faac622b051c72b282b9e63610998

----

Welcome to the v1.7.6 release of containerd!

The sixth patch release for containerd 1.7 contains various fixes and updates.

### Notable Updates

* **Fix log package for clients overwriting the global logger** ([#9032](https://github.com/containerd/containerd/pull/9032))
* **Fix blockfile snapshotter copy on Darwin** ([#9047](https://github.com/containerd/containerd/pull/9047))
* **Add support for Linux usernames on non-Linux platforms** ([#9015](https://github.com/containerd/containerd/pull/9015))
* **Update Windows platform matcher to invoke stable ABI compability function** ([#9069](https://github.com/containerd/containerd/pull/9069))
* **Update Golang to 1.20.8** ([#9074](https://github.com/containerd/containerd/pull/9074))
* **Update push to inherit distribution sources from parent** ([#9084](https://github.com/containerd/containerd/pull/9084))

See the changelog for complete list of changes

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.