### PR TITLE
[release/1.6] Prepare release notes for v1.6.24

### DIFF
--- a/releases/v1.6.24.toml
+++ b/releases/v1.6.24.toml
@@ -1,0 +1,35 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.6.23"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The twenty-fourth patch release for containerd 1.6 contains various fixes and updates.
+
+### Notable Updates
+
+* **CRI: fix leaked shim caused by high IO pressure** ([#9004](https://github.com/containerd/containerd/pull/9004))
+* **Update to go1.20.8** ([#9073](https://github.com/containerd/containerd/pull/9073))
+* **Update runc to v1.1.9** ([#8966](https://github.com/containerd/containerd/pull/8966))
+* **Backport: add configurable mount options to overlay snapshotter** ([#8961](https://github.com/containerd/containerd/pull/8961))
+* **log: cleanups and improvements to decouple more from logrus** ([#9002](https://github.com/containerd/containerd/pull/9002))
+
+See the changelog for complete list of changes"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.23+unknown"
+	Version = "1.6.24+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Welcome to the v1.6.24 release of containerd!

The twenty-fourth patch release for containerd 1.6 contains various fixes and updates.

### Notable Updates

* **CRI: fix leaked shim caused by high IO pressure** ([#9004](https://github.com/containerd/containerd/pull/9004))
* **Update to go1.20.8** ([#9073](https://github.com/containerd/containerd/pull/9073))
* **Update runc to v1.1.9** ([#8966](https://github.com/containerd/containerd/pull/8966))
* **Backport: add configurable mount options to overlay snapshotter** ([#8961](https://github.com/containerd/containerd/pull/8961))
* **log: cleanups and improvements to decouple more from logrus** ([#9002](https://github.com/containerd/containerd/pull/9002))

See the changelog for complete list of changes

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Sebastiaan van Stijn
* Akihiro Suda
* Wei Fu
* Akhil Mohan
* Derek McGowan
* Cardy.Tang
* Danny Canter
* Kazuyoshi Kato
* Mike Brown
* Phil Estes
* Samuel Karp

### Changes
<details><summary>44 commits</summary>
<p>

  * [`cdd59290d`](https://github.com/containerd/containerd/commit/cdd59290d051ffd8b5e730f96930c42cad65beac) Prepare release notes for v1.6.24
* [release/1.6 backport] log: cleanups and improvements to decouple more from logrus ([#9002](https://github.com/containerd/containerd/pull/9002))
  * [`33c2d88e7`](https://github.com/containerd/containerd/commit/33c2d88e7809eb42b0e9711c29a35c25a12dc18c) Revert "log: define G() as a function instead of a variable"
  * [`0a7f2975e`](https://github.com/containerd/containerd/commit/0a7f2975efbad7baddb31c36fb142db2a793534c) log: swap logrus functions with their equivalent on default logger
  * [`9d175a19b`](https://github.com/containerd/containerd/commit/9d175a19b7cbe165cb6285c891b384d518e2686b) log: add package documentation and summary of package's purpose
  * [`96fb65529`](https://github.com/containerd/containerd/commit/96fb655290f286eb818bf70f08555cd64ba8e780) log: make Fields type a generic map[string]any
  * [`bace17e2e`](https://github.com/containerd/containerd/commit/bace17e2ead161c06fdd670be532f0c042071bd7) log: add log.Entry type
  * [`dd127885f`](https://github.com/containerd/containerd/commit/dd127885feacdeefc554d7042c49e01002809864) log: define OutputFormat type
  * [`5b4cf2329`](https://github.com/containerd/containerd/commit/5b4cf23295581c70b92db1dc7c30114bc1a8f3c8) log: define G() as a function instead of a variable
  * [`ee1b4a1e2`](https://github.com/containerd/containerd/commit/ee1b4a1e2f844a45c0ba784273501bc490e77aa2) log: add all log-levels that are accepted
  * [`d563a411f`](https://github.com/containerd/containerd/commit/d563a411facc32c8287136d53ca0a744f991f3b4) log: group "enum" consts and touch-up docs
  * [`6e8f4555b`](https://github.com/containerd/containerd/commit/6e8f4555b3f3f155ee9ffe5f3e7cf8e8c2ee10a6) log: WithLogger: remove redundant intermediate var
  * [`c19325559`](https://github.com/containerd/containerd/commit/c193255597662b8a7f16479dd454ba3dd728a3c4) log: SetFormat: include returns in switch
  * [`c3c22f8cb`](https://github.com/containerd/containerd/commit/c3c22f8cbc5b3687bdee79266602bff51e61c84a) log: remove gotest.tools dependency
* [release/1.6] update to go1.20.8 ([#9073](https://github.com/containerd/containerd/pull/9073))
  * [`a2c294800`](https://github.com/containerd/containerd/commit/a2c294800ec11447b497bf7452bbbfba06c0168d) [release/1.6] update to go1.20.8
* [release/1.6 backport] make repositories of install dependencies configurable ([#9024](https://github.com/containerd/containerd/pull/9024))
  * [`0da8dcaa7`](https://github.com/containerd/containerd/commit/0da8dcaa7c93c0b708c375a32328a7b85fd668d8) make repositories of install dependencies configurable
* [release/1.6 backport] update Golang to go1.20.7, minimum version go1.19 ([#9020](https://github.com/containerd/containerd/pull/9020))
  * [`8e6a9de5b`](https://github.com/containerd/containerd/commit/8e6a9de5b5291b97684e948be096317611b37930) update to go1.20.7, go1.19.12
  * [`8b2eb371f`](https://github.com/containerd/containerd/commit/8b2eb371f958f1bfc5bcab5ee70bcad18b2e5efc) Update Go to 1.20.6,1.19.11
  * [`cff669c7a`](https://github.com/containerd/containerd/commit/cff669c7aab055d6b46bbb27fd044aba5e1453d8) update go to go1.20.5, go1.19.10
  * [`f34a22de9`](https://github.com/containerd/containerd/commit/f34a22de99b57e30cd33d3769e3765950475ba07) update go to go1.20.4, go1.19.9
  * [`e8e73065e`](https://github.com/containerd/containerd/commit/e8e73065ec668097067d37381399a80c8107fae1) update go to go1.20.3, go1.19.8
  * [`9b3f950d6`](https://github.com/containerd/containerd/commit/9b3f950d607c3a6c2a3c1b8740c87338a986e203) Go 1.20.2
  * [`17d03ac68`](https://github.com/containerd/containerd/commit/17d03ac681f61cd83c2bc7239956504c25ceb2f4) Go 1.20.1
  * [`861f65447`](https://github.com/containerd/containerd/commit/861f65447c4cc59b2b91e441b24f1c80a730ce2b) go.mod: go 1.19
  * [`81fa93784`](https://github.com/containerd/containerd/commit/81fa937842ac2501f777e23cddab8c7a573bd318) Stop using math/rand.Read and rand.Seed (deprecated in Go 1.20)
  * [`70dc11a6c`](https://github.com/containerd/containerd/commit/70dc11a6c1258891aa281815bb94d4bdc1194fe7) lint: remove `//nolint:dupword` that are no longer needed
  * [`fec784a06`](https://github.com/containerd/containerd/commit/fec784a06ad4276574dfb16ff631f9839f3b676c) lint: silence "SA1019: tar.TypeRegA has been deprecated... (staticheck)"
  * [`6648df1ad`](https://github.com/containerd/containerd/commit/6648df1ada2575df6adcaf295b611d966d3308d7) lint: silence "type `HostFileConfig` is unused (unused)"
  * [`e6b268bc7`](https://github.com/containerd/containerd/commit/e6b268bc703b5903de719533a8fbe0307767342c) golangci-lint v1.51.1
  * [`c552ccf67`](https://github.com/containerd/containerd/commit/c552ccf6769245e1531212505fa75e89f6f6ff1c) go.mod: golang.org/x/sync v0.1.0
* [releases/1.6] *: fix leaked shim caused by high IO pressure ([#9004](https://github.com/containerd/containerd/pull/9004))
  * [`d00af5c3e`](https://github.com/containerd/containerd/commit/d00af5c3ea1a290112b3a56bee31023ef1d2019d) integration: issue7496 case should work for runc.v2 only
  * [`583696e4e`](https://github.com/containerd/containerd/commit/583696e4e0b055b8a0f860b9ed7f31f0f3127ff4) Vagrantfile: add strace tool
  * [`ab21d60d2`](https://github.com/containerd/containerd/commit/ab21d60d27d1d7c87423e9b4ecb076358762e89b) pkg/cri/server: add criService as argument when handle exit event
  * [`a229883cb`](https://github.com/containerd/containerd/commit/a229883cb1bffecbd8bd4d41ab19c99110bbd189) pkg/cri/server: fix leaked shim issue
  * [`d8f824200`](https://github.com/containerd/containerd/commit/d8f824200cdc39410bf9a4d110073186d6864f64) integration: add case to reproduce #7496
* [release/1.6] Cherry-pick: [overlay] add configurable mount options to overlay snapshotter ([#8961](https://github.com/containerd/containerd/pull/8961))
  * [`8cd40e1d0`](https://github.com/containerd/containerd/commit/8cd40e1d0f13e5ddfef13833b265f6dfa298ec69) Add configurable mount options to overlay
  * [`453fa397a`](https://github.com/containerd/containerd/commit/453fa397a1f0f00871ff1ca4314b65e898e33661) feat: make overlay sync removal configurable
* [release/1.6 backport] update runc binary to v1.1.9 ([#8966](https://github.com/containerd/containerd/pull/8966))
  * [`4cb7764df`](https://github.com/containerd/containerd/commit/4cb7764df8025d0a6edb34f6b69daf6c2abe6ad0) update runc binary to v1.1.9
</p>
</details>

### Dependency Changes

* **golang.org/x/sync**  036812b2e83c -> v0.1.0

Previous release can be found at [v1.6.23](https://github.com/containerd/containerd/releases/tag/v1.6.23)