### PR TITLE
Refactor: Removing inherently flaky and unused SourceDateEpochOrNow function.

### DIFF
--- a/pkg/epoch/epoch.go
+++ b/pkg/epoch/epoch.go
@@ -22,8 +22,6 @@ import (
 	"os"
 	"strconv"
 	"time"
-
-	"github.com/containerd/containerd/log"
 )
 
 // SourceDateEpochEnv is the SOURCE_DATE_EPOCH env var.
@@ -42,19 +40,6 @@ func SourceDateEpoch() (*time.Time, error) {
 		return nil, fmt.Errorf("invalid %s value: %w", SourceDateEpochEnv, err)
 	}
 	return t, nil
-}
-
-// SourceDateEpochOrNow returns the SOURCE_DATE_EPOCH time if available,
-// otherwise returns the current time.
-func SourceDateEpochOrNow() time.Time {
-	epoch, err := SourceDateEpoch()
-	if err != nil {
-		log.L.WithError(err).Warnf("Invalid %s", SourceDateEpochEnv)
-	}
-	if epoch != nil {
-		return *epoch
-	}
-	return time.Now().UTC()
 }
 
 // ParseSourceDateEpoch parses the given source date epoch, as *time.Time.

--- a/pkg/epoch/epoch_test.go
+++ b/pkg/epoch/epoch_test.go
@@ -19,24 +19,11 @@ package epoch
 import (
 	"fmt"
 	"os"
-	"runtime"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
-
-func rightAfter(t1, t2 time.Time) bool {
-	if t2.Equal(t1) {
-		return true
-	}
-	threshold := 10 * time.Millisecond
-	if runtime.GOOS == "windows" {
-		// Low timer resolution on Windows
-		threshold *= 10
-	}
-	return t2.After(t1) && t2.Before(t1.Add(threshold))
-}
 
 func TestSourceDateEpoch(t *testing.T) {
 	if s, ok := os.LookupEnv(SourceDateEpochEnv); ok {
@@ -50,10 +37,6 @@ func TestSourceDateEpoch(t *testing.T) {
 		vp, err := SourceDateEpoch()
 		require.NoError(t, err)
 		require.Nil(t, vp)
-
-		now := time.Now().UTC()
-		v := SourceDateEpochOrNow()
-		require.True(t, rightAfter(now, v), "now: %s, v: %s", now, v)
 	})
 
 	t.Run("WithEmptySourceDateEpoch", func(t *testing.T) {
@@ -67,10 +50,6 @@ func TestSourceDateEpoch(t *testing.T) {
 		vp, err = ParseSourceDateEpoch(emptyValue)
 		require.Error(t, err, "value is empty")
 		require.Nil(t, vp)
-
-		now := time.Now().UTC()
-		v := SourceDateEpochOrNow()
-		require.True(t, rightAfter(now, v), "now: %s, v: %s", now, v)
 	})
 
 	t.Run("WithSourceDateEpoch", func(t *testing.T) {
@@ -88,9 +67,6 @@ func TestSourceDateEpoch(t *testing.T) {
 		vp, err = ParseSourceDateEpoch(fmt.Sprintf("%d", sourceDateEpoch.Unix()))
 		require.NoError(t, err)
 		require.True(t, vp.Equal(sourceDateEpoch))
-
-		v := SourceDateEpochOrNow()
-		require.True(t, v.Equal(sourceDateEpoch))
 	})
 
 	t.Run("WithInvalidSourceDateEpoch", func(t *testing.T) {
@@ -104,9 +80,5 @@ func TestSourceDateEpoch(t *testing.T) {
 		vp, err = ParseSourceDateEpoch(invalidValue)
 		require.ErrorContains(t, err, "invalid value:")
 		require.Nil(t, vp)
-
-		now := time.Now().UTC()
-		v := SourceDateEpochOrNow()
-		require.True(t, rightAfter(now, v), "now: %s, v: %s", now, v)
 	})
 }


### PR DESCRIPTION
Ref: #9090 

Removing SourceDateEpochOrNow() as it's both unused and inherently causes "flaky" test failures due to reliance on timer resolution of the underlying operating system as decided here: https://github.com/containerd/containerd/issues/9090#issuecomment-1721437930
