### PR TITLE
fix windows default path overwrite issue

### DIFF
--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -190,7 +190,9 @@ func WithEnv(environmentVariables []string) SpecOpts {
 // WithDefaultPathEnv sets the $PATH environment variable to the
 // default PATH defined in this package.
 func WithDefaultPathEnv(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
-	s.Process.Env = replaceOrAppendEnvValues(s.Process.Env, defaultUnixEnv)
+	if s.Linux != nil {
+		s.Process.Env = replaceOrAppendEnvValues(s.Process.Env, defaultUnixEnv)
+	}
 	return nil
 }
 

--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -193,7 +193,6 @@ func WithDefaultPathEnv(_ context.Context, _ Client, _ *containers.Container, s 
 	if s.Linux != nil {
 		s.Process.Env = replaceOrAppendEnvValues(s.Process.Env, defaultUnixEnv)
 	}
-
 	return nil
 }
 

--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -193,6 +193,7 @@ func WithDefaultPathEnv(_ context.Context, _ Client, _ *containers.Container, s 
 	if s.Linux != nil {
 		s.Process.Env = replaceOrAppendEnvValues(s.Process.Env, defaultUnixEnv)
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
Fixes:   #https://github.com/containerd/nerdctl/issues/2485

Windows Containers have a default path already configured at bootup. [WithDefaultPathEnv](https://github.com/containerd/containerd/blob/d015c99b2ec990c914a4b4546ec10d61cd947ab0/oci/spec_opts.go#L193C58-L193C72%60) overwrites this with a unix path