### PR TITLE
Run CRI services as containerd plugins

### DIFF
--- a/contrib/fuzz/cri_sbserver_fuzzer.go
+++ b/contrib/fuzz/cri_sbserver_fuzzer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/containerd/containerd"
 	criconfig "github.com/containerd/containerd/pkg/cri/config"
 	"github.com/containerd/containerd/pkg/cri/sbserver"
+	"github.com/containerd/containerd/pkg/cri/sbserver/images"
 )
 
 func FuzzCRISandboxServer(data []byte) int {
@@ -37,7 +38,12 @@ func FuzzCRISandboxServer(data []byte) int {
 	}
 	defer client.Close()
 
-	c, err := sbserver.NewCRIService(criconfig.Config{}, client, nil)
+	imageService, err := images.NewService(criconfig.Config{}, client)
+	if err != nil {
+		panic(err)
+	}
+
+	c, err := sbserver.NewCRIService(criconfig.Config{}, imageService, client, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/cri/sbserver/base/cri_base.go
+++ b/pkg/cri/sbserver/base/cri_base.go
@@ -1,0 +1,118 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package base
+
+import (
+	"flag"
+	"fmt"
+	"path/filepath"
+
+	"k8s.io/klog/v2"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/log"
+	criconfig "github.com/containerd/containerd/pkg/cri/config"
+	"github.com/containerd/containerd/pkg/cri/constants"
+	"github.com/containerd/containerd/platforms"
+	"github.com/containerd/containerd/plugin"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// CRIBase contains common dependencies for CRI's runtime, image, and podsandbox services.
+type CRIBase struct {
+	// Config contains all configurations.
+	Config criconfig.Config
+	// Client is an instance of the containerd client
+	Client *containerd.Client
+}
+
+func init() {
+	config := criconfig.DefaultConfig()
+
+	// Base plugin that other CRI services depend on.
+	plugin.Register(&plugin.Registration{
+		Type:   plugin.GRPCPlugin,
+		ID:     "cri",
+		Config: &config,
+		Requires: []plugin.Type{
+			plugin.EventPlugin,
+			plugin.ServicePlugin,
+			plugin.NRIApiPlugin,
+		},
+		InitFn: initCRIBase,
+	})
+}
+
+func initCRIBase(ic *plugin.InitContext) (interface{}, error) {
+	ic.Meta.Platforms = []imagespec.Platform{platforms.DefaultSpec()}
+	ic.Meta.Exports = map[string]string{"CRIVersion": constants.CRIVersion}
+	ctx := ic.Context
+	pluginConfig := ic.Config.(*criconfig.PluginConfig)
+	if err := criconfig.ValidatePluginConfig(ctx, pluginConfig); err != nil {
+		return nil, fmt.Errorf("invalid plugin config: %w", err)
+	}
+
+	c := criconfig.Config{
+		PluginConfig:       *pluginConfig,
+		ContainerdRootDir:  filepath.Dir(ic.Root),
+		ContainerdEndpoint: ic.Address,
+		RootDir:            ic.Root,
+		StateDir:           ic.State,
+	}
+	log.G(ctx).Infof("Start cri plugin with config %+v", c)
+
+	if err := setGLogLevel(); err != nil {
+		return nil, fmt.Errorf("failed to set glog level: %w", err)
+	}
+
+	log.G(ctx).Info("Connect containerd service")
+	client, err := containerd.New(
+		"",
+		containerd.WithDefaultNamespace(constants.K8sContainerdNamespace),
+		containerd.WithDefaultPlatform(platforms.Default()),
+		containerd.WithInMemoryServices(ic),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create containerd client: %w", err)
+	}
+
+	return &CRIBase{
+		Config: c,
+		Client: client,
+	}, nil
+}
+
+// Set glog level.
+func setGLogLevel() error {
+	l := log.GetLevel()
+	fs := flag.NewFlagSet("klog", flag.PanicOnError)
+	klog.InitFlags(fs)
+	if err := fs.Set("logtostderr", "true"); err != nil {
+		return err
+	}
+	switch l {
+	case log.TraceLevel:
+		return fs.Set("v", "5")
+	case log.DebugLevel:
+		return fs.Set("v", "4")
+	case log.InfoLevel:
+		return fs.Set("v", "2")
+	default:
+		// glog doesn't support other filters. Defaults to v=0.
+	}
+	return nil
+}

--- a/pkg/cri/sbserver/container_status_test.go
+++ b/pkg/cri/sbserver/container_status_test.go
@@ -286,6 +286,8 @@ func (s *fakeImageService) LocalResolve(refOrID string) (imagestore.Image, error
 	return imagestore.Image{}, errors.New("not implemented")
 }
 
+func (s *fakeImageService) ImageFSPath() string { return "" }
+
 func patchExceptedWithState(expected *runtime.ContainerStatus, state runtime.ContainerState) {
 	expected.State = state
 	switch state {


### PR DESCRIPTION
This PR refactors CRI service to run image service, runtime service, and pod sandbox controller as containerd plugins (previously these were instantiated manually). The former one is a prerequisite for work happening in https://github.com/containerd/containerd/pull/8268.

This change introduces `cri-base` internal plugin to maintain common dependencies between CRI (config, stores, etc) services. Higher level GRPC plugins add it as a dependency.

```bash
❯ sudo ./bin/ctr plugins ls | grep cri
io.containerd.internal.v1              cri-base                     darwin/arm64/v8    ok
io.containerd.grpc.v1                  cri-image-service            -                  ok
io.containerd.grpc.v1                  cri-runtime-service          -                  ok
io.containerd.grpc.v1                  cri-podsandbox-controller    -                  ok
```


Dependencies:
```text
CRI base (loads configuration and validates environment)
^   ^---- Image CRI service
|           ^
|           |
|--------- Runtime CRI service (depends on base + calls image service)
|           ^
|           |
+--------- Pod sandbox service (depends on base + runtime service (events)).

```