### PR TITLE
Improve doc of func NewNetNS

### DIFF
--- a/pkg/netns/netns_linux.go
+++ b/pkg/netns/netns_linux.go
@@ -177,11 +177,17 @@ type NetNS struct {
 }
 
 // NewNetNS creates a network namespace.
+// The name of the network namespace is randomly generated.
+// The returned netns is created under baseDir, with its path
+// following the pattern "baseDir/<generated-name>".
 func NewNetNS(baseDir string) (*NetNS, error) {
 	return NewNetNSFromPID(baseDir, 0)
 }
 
-// NewNetNS returns the netns from pid or a new netns if pid is 0.
+// NewNetNSFromPID returns the netns from pid or a new netns if pid is 0.
+// The name of the network namespace is randomly generated.
+// The returned netns is created under baseDir, with its path
+// following the pattern "baseDir/<generated-name>".
 func NewNetNSFromPID(baseDir string, pid uint32) (*NetNS, error) {
 	path, err := newNS(baseDir, pid)
 	if err != nil {


### PR DESCRIPTION
Improve godoc for func `NewNetNS` and `NewNetNSFromPID`.

Fixes: #8923 

The current doc is unclear about the name of the created netns, and the meaning of `baseDir`. The godoc is updated with the clarity.
