### PR TITLE
fix: Add `containerd` to the message type reference

### DIFF
--- a/api/runtime/sandbox/v1/sandbox.proto
+++ b/api/runtime/sandbox/v1/sandbox.proto
@@ -145,5 +145,5 @@ message SandboxMetricsRequest {
 }
 
 message SandboxMetricsResponse {
-	types.Metric metrics = 1;
+	containerd.types.Metric metrics = 1;
 }


### PR DESCRIPTION
Similar to the other types:
 - https://github.com/bryantbiggs/containerd/blob/c3694aaf879e7e1b6f17c6e723a1e46cc5e94f01/api/runtime/sandbox/v1/sandbox.proto#L67
 - https://github.com/bryantbiggs/containerd/blob/c3694aaf879e7e1b6f17c6e723a1e46cc5e94f01/api/runtime/sandbox/v1/sandbox.proto#L89
 
Without this, we are unable to derive the correct source for the Metric type in https://github.com/containerd/rust-extensions