### PR TITLE
[release/1.7] CI: Mingw testaroo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,12 @@ jobs:
 
       - uses: actions/checkout@v3
 
+      # NOTE(aznashwan): starting with Golang 1.21, the windows-2019 GitHub runner's
+      # builtin MinGW version leads to DLL loading errors during runtime.
+      - name: Upgrade MinGW on Windows 2019
+        if: matrix.os == 'windows-2019'
+        run: choco upgrade mingw
+
       - name: Make
         run: |
           make build
@@ -264,6 +270,12 @@ jobs:
           echo "${{ github.workspace }}/src/github.com/kubernetes-sigs/cri-tools/build/bin/windows/amd64" >> $GITHUB_PATH
 
       - run: script/setup/install-dev-tools
+
+      # NOTE(aznashwan): starting with Golang 1.21, the windows-2019 GitHub runner's
+      # builtin MinGW version leads to DLL loading errors during runtime.
+      - name: Upgrade MinGW on Windows 2019
+        if: matrix.os == 'windows-2019'
+        run: choco upgrade mingw
 
       - name: Binaries
         env:


### PR DESCRIPTION
Testing to see if this fixes the link issues in release/1.7

The default version of MinGW and GCC on the GitHub-hosted Windows 2019 runners compile fine but lead to linker errors during runtime.

(cherry picked from commit c883410c96d0318eddcb8c97ea35e484396758e7)