### PR TITLE
[WIP] Preunpack right after downloading

### DIFF
--- a/content/local/store.go
+++ b/content/local/store.go
@@ -128,6 +128,18 @@ func (s *store) ReaderAt(ctx context.Context, desc ocispec.Descriptor) (content.
 		return nil, fmt.Errorf("calculating blob path for ReaderAt: %w", err)
 	}
 
+	// TODO (ikema): refactor this to a preunpacked store
+	// BEGIN OF PREUNPACK READING
+	tmpOverlayfsFolder := "/var/lib/containerd/tmpoverlayfs/blobs/"
+	fsPreUnpackPath := tmpOverlayfsFolder + desc.Digest.String() + ".unpack"
+	bpInfo, err := os.Stat(fsPreUnpackPath)
+	if err == nil && !bpInfo.IsDir() {
+		log.G(ctx).Infof("PREUNPACK [CONTENT] path before: %s", p)
+		p = fsPreUnpackPath
+		log.G(ctx).Infof("PREUNPACK [CONTENT] path after: %s", p)
+	}
+	// END OF PREUNPACK READING
+
 	reader, err := OpenReader(p)
 	if err != nil {
 		return nil, fmt.Errorf("blob %s expected at %s: %w", desc.Digest, p, err)

--- a/ikeTest.sh
+++ b/ikeTest.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# restart containerd
+sudo kill $(pidof containerd)
+
+# Compile
+make BUILDTAGS=no_btrfs GODEBUG=true
+
+# Start containerd and download redis
+sudo bin/containerd --log-level=debug &
+echo sleep for 5 seconds
+sleep 5
+
+# List images, remove old image
+sudo /usr/local/bin/crictl images list
+sudo /usr/local/bin/crictl rmi docker.io/library/redis:alpine
+sudo /usr/local/bin/crictl rmi busybox
+# Download new image
+sudo /usr/local/bin/crictl pull docker.io/library/redis:alpine
+
+ls -alt /var/lib/containerd/tmpoverlayfs/blobs/


### PR DESCRIPTION
This is a WIP PR to  get feedback from community


Related issue: https://github.com/containerd/containerd/issues/8881

Hight level idea of pre-unpacking is to decompress the fetched layer right away in parallel in goroutine (as oppose to decompress in serial later on)


* [Producer] Create prefetched layer
   * `pkg/unpacker.go`:  Generate the preunpacked 
* [Consumer] Use prefetched layer
   *  `diff.Apply` -> `diff.apply_linux.apply` -> `archive.tar.Apply()` -> `archive.tar.applyNative()`
* [Wiring]
   * `archive/tar_opts.go` : Add UsePreunpackedLayer related config
* Convention
  * Preunpacked layer are stored in `/var/lib/containerd/tmpoverlayfs/blobs/DIGEST.unpack`
  * `.unpack` file contains the following
    * Line 1: sha256sum
    * Line 2: size of tar
    * Line 3 and beyond: List of diff 