### PR TITLE
docs: Update `transfer` service docs to reflect completed implementations for `1.7`

### DIFF
--- a/docs/transfer.md
+++ b/docs/transfer.md
@@ -24,7 +24,12 @@ service Transfer {
 message TransferRequest {
 	google.protobuf.Any source = 1;
 	google.protobuf.Any destination = 2;
-	// + options
+	TransferOptions options = 3;
+}
+
+message TransferOptions {
+ string progress_stream = 1;
+ // Progress min interval
 }
 ```
 
@@ -37,10 +42,10 @@ message TransferRequest {
 | Registry    | Image Store | "pull"      | 1.7 |
 | Image Store | Registry    | "push"      | 1.7 |
 | Object stream (Archive) | Image Store | "import" | 1.7 |
-| Image Store | Object stream (Archive) | "export" | 1.7 (in progress) |
+| Image Store | Object stream (Archive) | "export" | 1.7 |
 | Object stream (Layer) | Mount/Snapshot | "unpack" | Not implemented |
 | Mount/Snapshot | Object stream (Layer) | "diff" | Not implemented |
-| Image Store | Image Store | "tag" | Not implemented |
+| Image Store | Image Store | "tag" | 1.7 |
 | Registry | Registry | mirror registry image | Not implemented |
 
 ### Local containerd daemon support


### PR DESCRIPTION
I believe these are now implemented in 1.7 with the conclusion of https://github.com/containerd/containerd/issues/7592 and its respective PRs that have been merged