### PR TITLE
Require plugins to succeed after registering readiness

### DIFF
--- a/services/server/server.go
+++ b/services/server/server.go
@@ -31,6 +31,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	csapi "github.com/containerd/containerd/api/services/content/v1"
@@ -205,6 +206,7 @@ func New(ctx context.Context, config *srvconfig.Config) (*Server, error) {
 	for _, p := range plugins {
 		id := p.URI()
 		log.G(ctx).WithField("type", p.Type).Infof("loading plugin %q...", id)
+		var mustSucceed int32
 
 		initContext := plugin.NewContext(
 			ctx,
@@ -215,7 +217,10 @@ func New(ctx context.Context, config *srvconfig.Config) (*Server, error) {
 		)
 		initContext.Address = config.GRPC.Address
 		initContext.TTRPCAddress = config.TTRPC.Address
-		initContext.RegisterReadiness = s.RegisterReadiness
+		initContext.RegisterReadiness = func() func() {
+			atomic.StoreInt32(&mustSucceed, 1)
+			return s.RegisterReadiness()
+		}
 
 		// load the plugin specific configuration if it is provided
 		if p.Config != nil {
@@ -239,6 +244,10 @@ func New(ctx context.Context, config *srvconfig.Config) (*Server, error) {
 			}
 			if _, ok := required[id]; ok {
 				return nil, fmt.Errorf("load required plugin %s: %w", id, err)
+			}
+			// If readiness was registered during initialization, the plugin cannot fail
+			if atomic.LoadInt32(&mustSucceed) != 0 {
+				return nil, fmt.Errorf("plugin failed after registering readiness %s: %w", id, err)
 			}
 			continue
 		}


### PR DESCRIPTION
When readiness is registered on initialization, the plugin must not fail. When such a plugin fails, containerd will hang on the readiness condition.

fixes #9139
