### PR TITLE
images: use mediatype helpers

### DIFF
--- a/images/archive/exporter.go
+++ b/images/archive/exporter.go
@@ -170,8 +170,7 @@ func Export(ctx context.Context, store content.Provider, writer io.Writer, opts 
 	dManifests := map[digest.Digest]*exportManifest{}
 	resolvedIndex := map[digest.Digest]digest.Digest{}
 	for _, desc := range eo.manifests {
-		switch desc.MediaType {
-		case images.MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest:
+		if images.IsManifestType(desc.MediaType) {
 			mt, ok := dManifests[desc.Digest]
 			if !ok {
 				// TODO(containerd): Skip if already added
@@ -191,7 +190,7 @@ func Export(ctx context.Context, store content.Provider, writer io.Writer, opts 
 			if name != "" {
 				mt.names = append(mt.names, name)
 			}
-		case images.MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
+		} else if images.IsIndexType(desc.MediaType) {
 			d, ok := resolvedIndex[desc.Digest]
 			if !ok {
 				if err := desc.Digest.Validate(); err != nil {
@@ -255,7 +254,7 @@ func Export(ctx context.Context, store content.Provider, writer io.Writer, opts 
 				}
 
 			}
-		default:
+		} else {
 			return fmt.Errorf("only manifests may be exported: %w", errdefs.ErrInvalidArgument)
 		}
 	}

--- a/images/handlers.go
+++ b/images/handlers.go
@@ -294,8 +294,8 @@ func LimitManifests(f HandlerFunc, m platforms.MatchComparer, n int) HandlerFunc
 			return children, err
 		}
 
-		switch desc.MediaType {
-		case ocispec.MediaTypeImageIndex, MediaTypeDockerSchema2ManifestList:
+		// only limit manifests from an index
+		if IsIndexType(desc.MediaType) {
 			sort.SliceStable(children, func(i, j int) bool {
 				if children[i].Platform == nil {
 					return false
@@ -314,8 +314,6 @@ func LimitManifests(f HandlerFunc, m platforms.MatchComparer, n int) HandlerFunc
 					children = children[:n]
 				}
 			}
-		default:
-			// only limit manifests from an index
 		}
 		return children, nil
 	}

--- a/images/image.go
+++ b/images/image.go
@@ -321,7 +321,6 @@ func Check(ctx context.Context, provider content.Provider, image ocispec.Descrip
 
 // Children returns the immediate children of content described by the descriptor.
 func Children(ctx context.Context, provider content.Provider, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-	var descs []ocispec.Descriptor
 	if IsManifestType(desc.MediaType) {
 		p, err := content.ReadBlob(ctx, provider, desc)
 		if err != nil {
@@ -339,8 +338,7 @@ func Children(ctx context.Context, provider content.Provider, desc ocispec.Descr
 			return nil, err
 		}
 
-		descs = append(descs, manifest.Config)
-		descs = append(descs, manifest.Layers...)
+		return append([]ocispec.Descriptor{manifest.Config}, manifest.Layers...), nil
 	} else if IsIndexType(desc.MediaType) {
 		p, err := content.ReadBlob(ctx, provider, desc)
 		if err != nil {
@@ -356,16 +354,12 @@ func Children(ctx context.Context, provider content.Provider, desc ocispec.Descr
 			return nil, err
 		}
 
-		descs = append(descs, index.Manifests...)
-	} else {
-		if IsLayerType(desc.MediaType) || IsKnownConfig(desc.MediaType) {
-			// childless data types.
-			return nil, nil
-		}
+		return append([]ocispec.Descriptor{}, index.Manifests...), nil
+	} else if !IsLayerType(desc.MediaType) && !IsKnownConfig(desc.MediaType) {
+		// Layers and configs are childless data types and should not be logged.
 		log.G(ctx).Debugf("encountered unknown type %v; children may not be fetched", desc.MediaType)
 	}
-
-	return descs, nil
+	return nil, nil
 }
 
 // unknownDocument represents a manifest, manifest list, or index that has not
@@ -378,9 +372,10 @@ type unknownDocument struct {
 	FSLayers  json.RawMessage `json:"fsLayers,omitempty"` // schema 1
 }
 
-// validateMediaType returns an error if the byte slice is invalid JSON or if
-// the media type identifies the blob as one format but it contains elements of
-// another format.
+// validateMediaType returns an error if the byte slice is invalid JSON,
+// if the format of the blob is not supported, or if the media type
+// identifies the blob as one format, but it identifies itself as, or
+// contains elements of another format.
 func validateMediaType(b []byte, mt string) error {
 	var doc unknownDocument
 	if err := json.Unmarshal(b, &doc); err != nil {
@@ -389,15 +384,10 @@ func validateMediaType(b []byte, mt string) error {
 	if len(doc.FSLayers) != 0 {
 		return fmt.Errorf("media-type: schema 1 not supported")
 	}
-	if IsManifestType(mt) {
-		if len(doc.Manifests) != 0 || IsIndexType(doc.MediaType) {
-			return fmt.Errorf("media-type: expected manifest but found index (%s)", mt)
-		}
-	} else if IsIndexType(mt) {
-		if len(doc.Config) != 0 || len(doc.Layers) != 0 || IsManifestType(doc.MediaType) {
-			return fmt.Errorf("media-type: expected index but found manifest (%s)", mt)
-		}
-
+	if IsManifestType(mt) && (len(doc.Manifests) != 0 || IsIndexType(doc.MediaType)) {
+		return fmt.Errorf("media-type: expected manifest but found index (%s)", mt)
+	} else if IsIndexType(mt) && (len(doc.Config) != 0 || len(doc.Layers) != 0 || IsManifestType(doc.MediaType)) {
+		return fmt.Errorf("media-type: expected index but found manifest (%s)", mt)
 	}
 	return nil
 }


### PR DESCRIPTION
By aligning with the `mediatypes.go` helpers, there is a single source of truth for the mediatype checks in the `images/` package tree, and we can remove some case statements. By dropping case statements, branching logic can be simplified and made more obvious, with less nesting.