### PR TITLE
Use mediatype helpers in more places

### DIFF
--- a/container_opts.go
+++ b/container_opts.go
@@ -120,24 +120,24 @@ func WithImageConfigLabels(image Image) NewContainerOpts {
 		if err != nil {
 			return err
 		}
+		if !images.IsConfigType(ic.MediaType) {
+			return fmt.Errorf("unknown image config media type %s", ic.MediaType)
+		}
+
 		var (
 			ociimage v1.Image
 			config   v1.ImageConfig
 		)
-		switch ic.MediaType {
-		case v1.MediaTypeImageConfig, images.MediaTypeDockerSchema2Config:
-			p, err := content.ReadBlob(ctx, image.ContentStore(), ic)
-			if err != nil {
-				return err
-			}
-
-			if err := json.Unmarshal(p, &ociimage); err != nil {
-				return err
-			}
-			config = ociimage.Config
-		default:
-			return fmt.Errorf("unknown image config media type %s", ic.MediaType)
+		p, err := content.ReadBlob(ctx, image.ContentStore(), ic)
+		if err != nil {
+			return err
 		}
+
+		if err = json.Unmarshal(p, &ociimage); err != nil {
+			return err
+		}
+		config = ociimage.Config
+
 		c.Labels = config.Labels
 		return nil
 	}

--- a/integration/client/export_test.go
+++ b/integration/client/export_test.go
@@ -116,8 +116,7 @@ func TestExportDockerManifest(t *testing.T) {
 	// test single-platform export
 	var result ocispec.Descriptor
 	err = images.Walk(ctx, images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-		switch desc.MediaType {
-		case images.MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest:
+		if images.IsManifestType(desc.MediaType) {
 			p, err := content.ReadBlob(ctx, client.ContentStore(), desc)
 			if err != nil {
 				return nil, err
@@ -132,7 +131,7 @@ func TestExportDockerManifest(t *testing.T) {
 				result = desc
 			}
 			return nil, nil
-		case images.MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
+		} else if images.IsIndexType(desc.MediaType) {
 			p, err := content.ReadBlob(ctx, client.ContentStore(), desc)
 			if err != nil {
 				return nil, err

--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -376,26 +376,24 @@ func WithImageConfigArgs(image Image, args []string) SpecOpts {
 		if err != nil {
 			return err
 		}
+		if !images.IsConfigType(ic.MediaType) {
+			return fmt.Errorf("unknown image config media type %s", ic.MediaType)
+		}
+
 		var (
 			imageConfigBytes []byte
 			ociimage         v1.Image
 			config           v1.ImageConfig
 		)
-		switch ic.MediaType {
-		case v1.MediaTypeImageConfig, images.MediaTypeDockerSchema2Config:
-			var err error
-			imageConfigBytes, err = content.ReadBlob(ctx, image.ContentStore(), ic)
-			if err != nil {
-				return err
-			}
-
-			if err := json.Unmarshal(imageConfigBytes, &ociimage); err != nil {
-				return err
-			}
-			config = ociimage.Config
-		default:
-			return fmt.Errorf("unknown image config media type %s", ic.MediaType)
+		imageConfigBytes, err = content.ReadBlob(ctx, image.ContentStore(), ic)
+		if err != nil {
+			return err
 		}
+
+		if err = json.Unmarshal(imageConfigBytes, &ociimage); err != nil {
+			return err
+		}
+		config = ociimage.Config
 
 		appendOSMounts(s, ociimage.OS)
 		setProcess(s)

--- a/pkg/display/manifest_printer.go
+++ b/pkg/display/manifest_printer.go
@@ -135,8 +135,7 @@ func (p *ImageTreePrinter) printManifestTree(ctx context.Context, desc ocispec.D
 		return err
 	}
 
-	switch desc.MediaType {
-	case images.MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest:
+	if images.IsManifestType(desc.MediaType) {
 		var manifest ocispec.Manifest
 		if err := json.Unmarshal(b, &manifest); err != nil {
 			return err
@@ -158,8 +157,7 @@ func (p *ImageTreePrinter) printManifestTree(ctx context.Context, desc ocispec.D
 			}
 			fmt.Fprintf(p.w, "%s%s @%s (%d bytes)\n", subprefix, manifest.Layers[i].MediaType, manifest.Layers[i].Digest, manifest.Layers[i].Size)
 		}
-
-	case images.MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
+	} else if images.IsIndexType(desc.MediaType) {
 		var idx ocispec.Index
 		if err := json.Unmarshal(b, &idx); err != nil {
 			return err

--- a/pkg/snapshotters/annotations.go
+++ b/pkg/snapshotters/annotations.go
@@ -55,8 +55,7 @@ func AppendInfoHandlerWrapper(ref string) func(f images.Handler) images.Handler 
 			if err != nil {
 				return nil, err
 			}
-			switch desc.MediaType {
-			case ocispec.MediaTypeImageManifest, images.MediaTypeDockerSchema2Manifest:
+			if images.IsManifestType(desc.MediaType) {
 				for i := range children {
 					c := &children[i]
 					if images.IsLayerType(c.MediaType) {

--- a/pkg/unpack/unpacker.go
+++ b/pkg/unpack/unpacker.go
@@ -179,8 +179,7 @@ func (u *Unpacker) Unpack(h images.Handler) images.Handler {
 			return children, err
 		}
 
-		switch desc.MediaType {
-		case images.MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest:
+		if images.IsManifestType(desc.MediaType) {
 			var nonLayers []ocispec.Descriptor
 			var manifestLayers []ocispec.Descriptor
 			// Split layers from non-layers, layers will be handled after
@@ -203,7 +202,7 @@ func (u *Unpacker) Unpack(h images.Handler) images.Handler {
 			lock.Unlock()
 
 			children = nonLayers
-		case images.MediaTypeDockerSchema2Config, ocispec.MediaTypeImageConfig:
+		} else if images.IsConfigType(desc.MediaType) {
 			lock.Lock()
 			l := layers[desc.Digest]
 			lock.Unlock()

--- a/remotes/docker/converter.go
+++ b/remotes/docker/converter.go
@@ -41,9 +41,7 @@ const LegacyConfigMediaType = "application/octet-stream"
 // 1. original manifest will be deleted by next gc round.
 // 2. don't cover manifest list.
 func ConvertManifest(ctx context.Context, store content.Store, desc ocispec.Descriptor) (ocispec.Descriptor, error) {
-	if !(desc.MediaType == images.MediaTypeDockerSchema2Manifest ||
-		desc.MediaType == ocispec.MediaTypeImageManifest) {
-
+	if !images.IsManifestType(desc.MediaType) {
 		log.G(ctx).Warnf("do nothing for media type: %s", desc.MediaType)
 		return desc, nil
 	}

--- a/remotes/docker/fetcher.go
+++ b/remotes/docker/fetcher.go
@@ -94,10 +94,8 @@ func (r dockerFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.R
 		}
 
 		// Try manifests endpoints for manifests types
-		switch desc.MediaType {
-		case images.MediaTypeDockerSchema2Manifest, images.MediaTypeDockerSchema2ManifestList,
-			images.MediaTypeDockerSchema1Manifest,
-			ocispec.MediaTypeImageManifest, ocispec.MediaTypeImageIndex:
+		if images.IsManifestType(desc.MediaType) || images.IsIndexType(desc.MediaType) ||
+			desc.MediaType == images.MediaTypeDockerSchema1Manifest {
 
 			var firstErr error
 			for _, host := range r.hosts {

--- a/remotes/docker/pusher.go
+++ b/remotes/docker/pusher.go
@@ -103,12 +103,10 @@ func (p dockerPusher) push(ctx context.Context, desc ocispec.Descriptor, ref str
 		host       = hosts[0]
 	)
 
-	switch desc.MediaType {
-	case images.MediaTypeDockerSchema2Manifest, images.MediaTypeDockerSchema2ManifestList,
-		ocispec.MediaTypeImageManifest, ocispec.MediaTypeImageIndex:
+	if images.IsManifestType(desc.MediaType) || images.IsIndexType(desc.MediaType) {
 		isManifest = true
 		existCheck = getManifestPath(p.object, desc.Digest)
-	default:
+	} else {
 		existCheck = []string{"blobs", desc.Digest.String()}
 	}
 

--- a/remotes/handlers.go
+++ b/remotes/handlers.go
@@ -71,17 +71,17 @@ func MakeRefKey(ctx context.Context, desc ocispec.Descriptor) string {
 		}
 	}
 
-	switch mt := desc.MediaType; {
-	case mt == images.MediaTypeDockerSchema2Manifest || mt == ocispec.MediaTypeImageManifest:
+	switch {
+	case images.IsManifestType(desc.MediaType):
 		return "manifest-" + key
-	case mt == images.MediaTypeDockerSchema2ManifestList || mt == ocispec.MediaTypeImageIndex:
+	case images.IsIndexType(desc.MediaType):
 		return "index-" + key
-	case images.IsLayerType(mt):
+	case images.IsLayerType(desc.MediaType):
 		return "layer-" + key
-	case images.IsKnownConfig(mt):
+	case images.IsKnownConfig(desc.MediaType):
 		return "config-" + key
 	default:
-		log.G(ctx).Warnf("reference for unknown type: %s", mt)
+		log.G(ctx).Warnf("reference for unknown type: %s", desc.MediaType)
 		return "unknown-" + key
 	}
 }
@@ -214,20 +214,18 @@ func PushContent(ctx context.Context, pusher Pusher, desc ocispec.Descriptor, st
 	indexStack := []ocispec.Descriptor{}
 
 	filterHandler := images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-		switch desc.MediaType {
-		case images.MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest:
+		if images.IsManifestType(desc.MediaType) {
 			m.Lock()
 			manifests = append(manifests, desc)
 			m.Unlock()
 			return nil, images.ErrStopHandler
-		case images.MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
+		} else if images.IsIndexType(desc.MediaType) {
 			m.Lock()
 			indexStack = append(indexStack, desc)
 			m.Unlock()
 			return nil, images.ErrStopHandler
-		default:
-			return nil, nil
 		}
+		return nil, nil
 	})
 
 	pushHandler := PushHandler(pusher, store)
@@ -319,20 +317,17 @@ func FilterManifestByPlatformHandler(f images.HandlerFunc, m platforms.Matcher) 
 		}
 
 		var descs []ocispec.Descriptor
-		switch desc.MediaType {
-		case images.MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest:
+		if images.IsManifestType(desc.MediaType) {
 			if m.Match(*desc.Platform) {
 				descs = children
 			} else {
 				for _, child := range children {
-					if child.MediaType == images.MediaTypeDockerSchema2Config ||
-						child.MediaType == ocispec.MediaTypeImageConfig {
-
+					if images.IsConfigType(child.MediaType) {
 						descs = append(descs, child)
 					}
 				}
 			}
-		default:
+		} else {
 			descs = children
 		}
 		return descs, nil
@@ -350,10 +345,7 @@ func annotateDistributionSourceHandler(f images.HandlerFunc, provider content.In
 
 		// Distribution source is only used for config or blob but may be inherited from
 		// a manifest or manifest list
-		switch desc.MediaType {
-		case images.MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest,
-			images.MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
-		default:
+		if !images.IsManifestType(desc.MediaType) && !images.IsIndexType(desc.MediaType) {
 			return children, nil
 		}
 

--- a/signals.go
+++ b/signals.go
@@ -57,24 +57,23 @@ func GetOCIStopSignal(ctx context.Context, image Image, defaultSignal string) (s
 	if err != nil {
 		return "", err
 	}
+	if !images.IsConfigType(ic.MediaType) {
+		return "", fmt.Errorf("unknown image config media type %s", ic.MediaType)
+	}
+
 	var (
 		ociimage v1.Image
 		config   v1.ImageConfig
 	)
-	switch ic.MediaType {
-	case v1.MediaTypeImageConfig, images.MediaTypeDockerSchema2Config:
-		p, err := content.ReadBlob(ctx, image.ContentStore(), ic)
-		if err != nil {
-			return "", err
-		}
-
-		if err := json.Unmarshal(p, &ociimage); err != nil {
-			return "", err
-		}
-		config = ociimage.Config
-	default:
-		return "", fmt.Errorf("unknown image config media type %s", ic.MediaType)
+	p, err := content.ReadBlob(ctx, image.ContentStore(), ic)
+	if err != nil {
+		return "", err
 	}
+
+	if err = json.Unmarshal(p, &ociimage); err != nil {
+		return "", err
+	}
+	config = ociimage.Config
 
 	if config.StopSignal == "" {
 		return defaultSignal, nil


### PR DESCRIPTION
- Follow-up to https://github.com/containerd/containerd/pull/9154

Take advantage of the mediatype helpers from the `images` package throughout the rest of the project, also taking the opportunity to simplify some conditional logic where possible.