### PR TITLE
cri: call RegisterReadiness after NewCRIService

### DIFF
--- a/pkg/cri/cri.go
+++ b/pkg/cri/cri.go
@@ -54,7 +54,6 @@ func init() {
 }
 
 func initCRIService(ic *plugin.InitContext) (interface{}, error) {
-	ready := ic.RegisterReadiness()
 	ic.Meta.Platforms = []imagespec.Platform{platforms.DefaultSpec()}
 	ic.Meta.Exports = map[string]string{"CRIVersion": constants.CRIVersion}
 	ctx := ic.Context
@@ -99,6 +98,8 @@ func initCRIService(ic *plugin.InitContext) (interface{}, error) {
 		return nil, fmt.Errorf("failed to create CRI service: %w", err)
 	}
 
+	// RegisterReadiness() must be called after NewCRIService(): https://github.com/containerd/containerd/issues/9163
+	ready := ic.RegisterReadiness()
 	go func() {
 		if err := s.Run(ready); err != nil {
 			log.G(ctx).WithError(err).Fatal("Failed to run CRI service")


### PR DESCRIPTION
`NewCRIService()` may easily fail and its error has to be ignored unless the CRI plugin is in the `required_plugins` list.

Now this has to be called before `RegisterReadiness()`, as PR #9153 `Require plugins to succeed after registering readiness` was merged on 2023-09-29.

Fix #9163: `[Regression in main (2023-09-29)]: containerd-rootless.sh doesn't start up`