### PR TITLE
[release/1.6] Require plugins to succeed after registering readiness 

### DIFF
--- a/pkg/cri/cri.go
+++ b/pkg/cri/cri.go
@@ -59,7 +59,6 @@ func init() {
 }
 
 func initCRIService(ic *plugin.InitContext) (interface{}, error) {
-	ready := ic.RegisterReadiness()
 	ic.Meta.Platforms = []imagespec.Platform{platforms.DefaultSpec()}
 	ic.Meta.Exports = map[string]string{"CRIVersion": constants.CRIVersion, "CRIVersionAlpha": constants.CRIVersionAlpha}
 	ctx := ic.Context
@@ -102,6 +101,8 @@ func initCRIService(ic *plugin.InitContext) (interface{}, error) {
 		return nil, fmt.Errorf("failed to create CRI service: %w", err)
 	}
 
+	// RegisterReadiness() must be called after NewCRIService(): https://github.com/containerd/containerd/issues/9163
+	ready := ic.RegisterReadiness()
 	go func() {
 		if err := s.Run(ready); err != nil {
 			log.G(ctx).WithError(err).Fatal("Failed to run CRI service")


### PR DESCRIPTION
Fixes hang when plugin which registers readiness fail. Additional fix in CRI to register readiness later on in its initialization.

Backport https://github.com/containerd/containerd/pull/9153 https://github.com/containerd/containerd/pull/9164