### PR TITLE
[release/1.6] cri: stop recommending disable_cgroup

### DIFF
--- a/pkg/cri/server/service_linux.go
+++ b/pkg/cri/server/service_linux.go
@@ -33,8 +33,8 @@ const networkAttachCount = 2
 // initPlatform handles linux specific initialization for the CRI service.
 func (c *criService) initPlatform() (err error) {
 	if userns.RunningInUserNS() {
-		if !(c.config.DisableCgroup && !c.apparmorEnabled() && c.config.RestrictOOMScoreAdj) {
-			logrus.Warn("Running containerd in a user namespace typically requires disable_cgroup, disable_apparmor, restrict_oom_score_adj set to be true")
+		if c.apparmorEnabled() || !c.config.RestrictOOMScoreAdj {
+			logrus.Warn("Running CRI plugin in a user namespace typically requires disable_apparmor and restrict_oom_score_adj to be true")
 		}
 	}
 


### PR DESCRIPTION
Cherry-pick (non-clean):
- #9158