### PR TITLE
add verify kernel version when enable unprivileged

### DIFF
--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -449,5 +449,8 @@ func ValidatePluginConfig(ctx context.Context, c *PluginConfig) ([]deprecation.W
 			return warnings, fmt.Errorf("invalid `drain_exec_sync_io_timeout`: %w", err)
 		}
 	}
+	if err := ValidateEnableUnprivileged(ctx, c); err != nil {
+		return warnings, err
+	}
 	return warnings, nil
 }

--- a/pkg/cri/config/config_kernel_linux.go
+++ b/pkg/cri/config/config_kernel_linux.go
@@ -1,0 +1,43 @@
+//go:build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	kernel "github.com/containerd/containerd/v2/contrib/seccomp/kernelversion"
+)
+
+var kernelGreaterEqualThan = kernel.GreaterEqualThan
+
+func ValidateEnableUnprivileged(ctx context.Context, c *PluginConfig) error {
+	if c.EnableUnprivilegedICMP || c.EnableUnprivilegedPorts {
+		fourDotEleven := kernel.KernelVersion{Kernel: 4, Major: 11}
+		ok, err := kernelGreaterEqualThan(fourDotEleven)
+		if err != nil {
+			return fmt.Errorf("check current system kernel version error: %w", err)
+		}
+		if !ok {
+			return errors.New("unprivileged_icmp and unprivileged_port require kernel version greater than or equal to 4.11")
+		}
+	}
+	return nil
+}

--- a/pkg/cri/config/config_kernel_linux_test.go
+++ b/pkg/cri/config/config_kernel_linux_test.go
@@ -1,0 +1,104 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package config
+
+import (
+	"context"
+	"testing"
+
+	kernel "github.com/containerd/containerd/v2/contrib/seccomp/kernelversion"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateEnableUnprivileged(t *testing.T) {
+	origKernelGreaterEqualThan := kernelGreaterEqualThan
+	t.Cleanup(func() {
+		kernelGreaterEqualThan = origKernelGreaterEqualThan
+	})
+
+	tests := []struct {
+		name          string
+		config        *PluginConfig
+		kernelGreater bool
+		expectedErr   string
+	}{
+		{
+			name: "disable unprivileged_icmp and unprivileged_port",
+			config: &PluginConfig{
+				ContainerdConfig: ContainerdConfig{
+					DefaultRuntimeName: RuntimeDefault,
+					Runtimes: map[string]Runtime{
+						RuntimeDefault: {
+							Type: "default",
+						},
+					},
+				},
+				EnableUnprivilegedICMP:  false,
+				EnableUnprivilegedPorts: false,
+			},
+			expectedErr: "",
+		},
+		{
+			name: "enable unprivileged_icmp or unprivileged_port, but kernel version is smaller than 4.11",
+			config: &PluginConfig{
+				ContainerdConfig: ContainerdConfig{
+					DefaultRuntimeName: RuntimeDefault,
+					Runtimes: map[string]Runtime{
+						RuntimeDefault: {
+							Type: "default",
+						},
+					},
+				},
+				EnableUnprivilegedICMP:  true,
+				EnableUnprivilegedPorts: true,
+			},
+			kernelGreater: false,
+			expectedErr:   "unprivileged_icmp and unprivileged_port require kernel version greater than or equal to 4.11",
+		},
+		{
+			name: "enable unprivileged_icmp or unprivileged_port, but kernel version is greater than or equal 4.11",
+			config: &PluginConfig{
+				ContainerdConfig: ContainerdConfig{
+					DefaultRuntimeName: RuntimeDefault,
+					Runtimes: map[string]Runtime{
+						RuntimeDefault: {
+							Type: "default",
+						},
+					},
+				},
+				EnableUnprivilegedICMP:  true,
+				EnableUnprivilegedPorts: true,
+			},
+			kernelGreater: true,
+			expectedErr:   "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			kernelGreaterEqualThan = func(minVersion kernel.KernelVersion) (bool, error) {
+				return test.kernelGreater, nil
+			}
+			err := ValidateEnableUnprivileged(context.Background(), test.config)
+			if test.expectedErr != "" {
+				assert.Equal(t, err.Error(), test.expectedErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/cri/config/config_kernel_other.go
+++ b/pkg/cri/config/config_kernel_other.go
@@ -1,0 +1,27 @@
+//go:build !linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package config
+
+import (
+	"context"
+)
+
+func ValidateEnableUnprivileged(ctx context.Context, c *PluginConfig) error {
+	return nil
+}


### PR DESCRIPTION
Fixes: https://github.com/containerd/containerd/issues/8636

add verify when enable  unprivileged kernel version whether less than 4.11. 