### PR TITLE
ci-fix: pin the mingw version 12.2.0.3042023

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,8 @@ jobs:
       # builtin MinGW version leads to DLL loading errors during runtime.
       - name: Upgrade MinGW on Windows 2019
         if: matrix.os == 'windows-2019'
-        run: choco upgrade mingw
+        run: |
+          choco upgrade mingw --version=12.2.0.3042023
 
       - name: Make
         run: |
@@ -279,7 +280,8 @@ jobs:
       # builtin MinGW version leads to DLL loading errors during runtime.
       - name: Upgrade MinGW on Windows 2019
         if: matrix.os == 'windows-2019'
-        run: choco upgrade mingw
+        run: |
+          choco upgrade mingw --version=12.2.0.3042023
 
       - name: Binaries
         env:


### PR DESCRIPTION
After using mingw v13.1.0, windows 2019 CI fails.

```bash
shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
  env:
    GO_VERSION: 1.21.1
Cannot find file at '..\\lib\mingw\tools\install\mingw[6](https://github.com/containerd/containerd/actions/runs/6380072801/job/17314029501?pr=9177#step:5:6)4\bin\mingw32-make.exe' (C:\ProgramData\Chocolatey\lib\mingw\tools\install\mingw64\bin\mingw32-make.exe). This usually indicates a missing or moved file.
Cannot find file at '..\\lib\mingw\tools\install\mingw64\bin\mingw32-make.exe' (C:\ProgramData\Chocolatey\lib\mingw\tools\install\mingw64\bin\mingw32-make.exe). This usually indicates a missing or moved file.
```

No idea why the make command is not found. Pin the version to fix it.

REF: https://github.com/containerd/containerd/actions/runs/6380072801/job/17314029501?pr=9177