### PR TITLE
[release/1.6] Build binaries with 1.21.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-12, windows-2019, windows-2022]
-        go-version: ["1.20.8", "1.19.12"]
+        go-version: ["1.20.8", "1.21.1"]
     steps:
       - name: Install dependencies
         if: matrix.os == 'ubuntu-20.04'


### PR DESCRIPTION
go 1.19 is EOL and doesn't work well with windows-2019 in CI.

Cherry-pick from https://github.com/containerd/containerd/pull/9167

This should fix the windows-2019 failures.