### PR TITLE
[release/1.7 Build binaries with 1.21.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-12, windows-2019, windows-2022]
-        go-version: ["1.20.8", "1.19.12"]
+        go-version: ["1.20.8", "1.21.1"]
     steps:
       - name: Install dependencies
         if: matrix.os == 'ubuntu-20.04'


### PR DESCRIPTION
1.19 is end of life, continue to run with 1.20 but ensure builds with 1.21.


Backport of #9167 to 1.6