### PR TITLE
CRI: Snapshotter per runtime handler adjustments

### DIFF
--- a/pkg/cri/sbserver/images/image_pull.go
+++ b/pkg/cri/sbserver/images/image_pull.go
@@ -757,10 +757,10 @@ func (c *CRIImageService) snapshotterFromPodSandboxConfig(ctx context.Context, i
 	// TODO: Find other way to retrieve sandbox runtime, this must belong to the Runtime part of the CRI.
 	ociRuntime, err := c.getSandboxRuntime(s, runtimeHandler)
 	if err != nil {
-		return "", fmt.Errorf("experimental: failed to get sandbox runtime for %s, err: %+v", runtimeHandler, err)
+		return "", fmt.Errorf("experimental: failed to get sandbox runtime for %s: %w", runtimeHandler, err)
 	}
 
-	snapshotter = c.RuntimeSnapshotter(context.Background(), ociRuntime)
+	snapshotter = c.RuntimeSnapshotter(ctx, ociRuntime)
 	log.G(ctx).Infof("experimental: PullImage %q for runtime %s, using snapshotter %s", imageRef, runtimeHandler, snapshotter)
 	return snapshotter, nil
 }

--- a/pkg/cri/sbserver/images/image_pull_test.go
+++ b/pkg/cri/sbserver/images/image_pull_test.go
@@ -19,7 +19,6 @@ package images
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
 	"testing"
 
 	docker "github.com/distribution/reference"
@@ -383,7 +382,7 @@ func TestSnapshotterFromPodSandboxConfig(t *testing.T) {
 		desc              string
 		podSandboxConfig  *runtime.PodSandboxConfig
 		expectSnapshotter string
-		expectErr         error
+		expectErr         bool
 	}{
 		{
 			desc:              "should return default snapshotter for nil podSandboxConfig",
@@ -408,7 +407,7 @@ func TestSnapshotterFromPodSandboxConfig(t *testing.T) {
 					annotations.RuntimeHandler: "runtime-not-exists",
 				},
 			},
-			expectErr:         fmt.Errorf(`experimental: failed to get sandbox runtime for runtime-not-exists, err: no runtime for "runtime-not-exists" is configured`),
+			expectErr:         true,
 			expectSnapshotter: "",
 		},
 		{
@@ -432,7 +431,9 @@ func TestSnapshotterFromPodSandboxConfig(t *testing.T) {
 			}
 			snapshotter, err := cri.snapshotterFromPodSandboxConfig(context.Background(), "test-image", tt.podSandboxConfig)
 			assert.Equal(t, tt.expectSnapshotter, snapshotter)
-			assert.Equal(t, tt.expectErr, err)
+			if tt.expectErr {
+				assert.Error(t, err)
+			}
 		})
 	}
 }

--- a/pkg/cri/server/image_pull.go
+++ b/pkg/cri/server/image_pull.go
@@ -729,10 +729,10 @@ func (c *criService) snapshotterFromPodSandboxConfig(ctx context.Context, imageR
 
 	ociRuntime, err := c.getSandboxRuntime(s, runtimeHandler)
 	if err != nil {
-		return "", fmt.Errorf("experimental: failed to get sandbox runtime for %s, err: %+v", runtimeHandler, err)
+		return "", fmt.Errorf("experimental: failed to get sandbox runtime for %s: %w", runtimeHandler, err)
 	}
 
-	snapshotter = c.runtimeSnapshotter(context.Background(), ociRuntime)
+	snapshotter = c.runtimeSnapshotter(ctx, ociRuntime)
 	log.G(ctx).Infof("experimental: PullImage %q for runtime %s, using snapshotter %s", imageRef, runtimeHandler, snapshotter)
 	return snapshotter, nil
 }

--- a/pkg/cri/server/image_pull_test.go
+++ b/pkg/cri/server/image_pull_test.go
@@ -19,7 +19,6 @@ package server
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
 	"testing"
 
 	"github.com/containerd/containerd/pkg/cri/annotations"
@@ -381,7 +380,7 @@ func TestSnapshotterFromPodSandboxConfig(t *testing.T) {
 		desc              string
 		podSandboxConfig  *runtime.PodSandboxConfig
 		expectSnapshotter string
-		expectErr         error
+		expectErr         bool
 	}{
 		{
 			desc:              "should return default snapshotter for nil podSandboxConfig",
@@ -406,7 +405,7 @@ func TestSnapshotterFromPodSandboxConfig(t *testing.T) {
 					annotations.RuntimeHandler: "runtime-not-exists",
 				},
 			},
-			expectErr:         fmt.Errorf(`experimental: failed to get sandbox runtime for runtime-not-exists, err: no runtime for "runtime-not-exists" is configured`),
+			expectErr:         true,
 			expectSnapshotter: "",
 		},
 		{
@@ -431,7 +430,9 @@ func TestSnapshotterFromPodSandboxConfig(t *testing.T) {
 			}
 			snapshotter, err := cri.snapshotterFromPodSandboxConfig(context.Background(), "test-image", tt.podSandboxConfig)
 			assert.Equal(t, tt.expectSnapshotter, snapshotter)
-			assert.Equal(t, tt.expectErr, err)
+			if tt.expectErr {
+				assert.Error(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Pass the passed in context into some nested function calls, and wrap errors instead of %+v.