### PR TITLE
[release 1.6] remotes/docker: Fix MountedFrom prefixed with target repository

### DIFF
--- a/remotes/docker/pusher.go
+++ b/remotes/docker/pusher.go
@@ -192,7 +192,7 @@ func (p dockerPusher) push(ctx context.Context, desc ocispec.Descriptor, ref str
 				resp.Body.Close()
 				resp = nil
 			case http.StatusCreated:
-				mountedFrom = path.Join(p.refspec.Locator, fromRepo)
+				mountedFrom = path.Join(p.refspec.Hostname(), fromRepo)
 			}
 		}
 

--- a/remotes/docker/pusher_test.go
+++ b/remotes/docker/pusher_test.go
@@ -163,9 +163,9 @@ func samplePusher(t *testing.T) (dockerPusher, *uploadableMockRegistry, StatusTr
 	return dockerPusher{
 		dockerBase: &dockerBase{
 			refspec: reference.Spec{
-				Locator: "sample",
+				Locator: "example.com/samplerepository:latest",
 			},
-			repository: "sample",
+			repository: "samplerepository",
 			hosts: []RegistryHost{
 				{
 					Client:       s.Client(),
@@ -176,7 +176,7 @@ func samplePusher(t *testing.T) (dockerPusher, *uploadableMockRegistry, StatusTr
 				},
 			},
 		},
-		object:  "sample",
+		object:  "latest",
 		tracker: tracker,
 	}, reg, tracker, s.Close
 }
@@ -354,7 +354,7 @@ func Test_dockerPusher_push(t *testing.T) {
 				ref:               fmt.Sprintf("layer2-%s", layerContentDigest.String()),
 				unavailableOnFail: false,
 				annotations: map[string]string{
-					distributionSourceLabelKey("sample"): "always-mount",
+					distributionSourceLabelKey("example.com"): "always-mount",
 				},
 			},
 			checkerFunc: func(writer *pushWriter) bool {
@@ -368,7 +368,7 @@ func Test_dockerPusher_push(t *testing.T) {
 			},
 			wantErr: fmt.Errorf("content %v on remote: %w", digest.FromBytes(layerContent), errdefs.ErrAlreadyExists),
 			wantStatus: &PushStatus{
-				MountedFrom: "sample/always-mount",
+				MountedFrom: "example.com/always-mount",
 				Exists:      false,
 			},
 		},
@@ -383,7 +383,7 @@ func Test_dockerPusher_push(t *testing.T) {
 				ref:               fmt.Sprintf("layer3-%s", layerContentDigest.String()),
 				unavailableOnFail: false,
 				annotations: map[string]string{
-					distributionSourceLabelKey("sample"): "never-mount",
+					distributionSourceLabelKey("example.com"): "never-mount",
 				},
 			},
 			checkerFunc: func(writer *pushWriter) bool {


### PR DESCRIPTION
`MountedFrom` was prefixed with the whole target repository instead of just the registry hostname.

Also adjust the test cases to use the registry hostname.

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>
(cherry picked from commit 859c2651e5f3e8a76c1b427a1be99b76d7169b46)

backport: https://github.com/containerd/containerd/pull/9187