### PR TITLE
Use UnmarshalTo instead of UnmarshalAny when dealing with cgroup metrics.

### DIFF
--- a/metrics/cgroups/v1/metrics.go
+++ b/metrics/cgroups/v1/metrics.go
@@ -148,16 +148,12 @@ func (c *Collector) collect(entry entry, ch chan<- prometheus.Metric, block bool
 		return
 	}
 
-	data, err := typeurl.UnmarshalAny(stats)
-	if err != nil {
+	s := &v1.Metrics{}
+	if err := typeurl.UnmarshalTo(stats, s); err != nil {
 		log.L.WithError(err).Errorf("unmarshal stats for %s", t.ID())
 		return
 	}
-	s, ok := data.(*v1.Metrics)
-	if !ok {
-		log.L.WithError(err).Errorf("invalid metric type for %s", t.ID())
-		return
-	}
+
 	ns := entry.ns
 	if ns == nil {
 		ns = c.ns

--- a/metrics/cgroups/v2/metrics.go
+++ b/metrics/cgroups/v2/metrics.go
@@ -141,16 +141,12 @@ func (c *Collector) collect(entry entry, ch chan<- prometheus.Metric, block bool
 		return
 	}
 
-	data, err := typeurl.UnmarshalAny(stats)
-	if err != nil {
+	s := &v2.Metrics{}
+	if err := typeurl.UnmarshalTo(stats, s); err != nil {
 		log.L.WithError(err).Errorf("unmarshal stats for %s", t.ID())
 		return
 	}
-	s, ok := data.(*v2.Metrics)
-	if !ok {
-		log.L.WithError(err).Errorf("invalid metric type for %s", t.ID())
-		return
-	}
+
 	ns := entry.ns
 	if ns == nil {
 		ns = c.ns


### PR DESCRIPTION
After encountering the issue here: https://github.com/containerd/containerd/issues/9052, it appears that the type assertion was failing as the typeof data was an `interface{}` despite the concrete type being a pointer to `v1.Metrics`. We can instead unmarshal the data directly into the expected type variable which _appears_ to work as expected.