### PR TITLE
CDI: Add support Edit Container Mount for kata/runtime-rs using direct volume in K8S/CSI scenario

### DIFF
--- a/pkg/cri/sbserver/container_create_linux.go
+++ b/pkg/cri/sbserver/container_create_linux.go
@@ -106,7 +106,10 @@ func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageCon
 		specOpts = append(specOpts, seccompSpecOpts)
 	}
 	if c.config.EnableCDI {
-		specOpts = append(specOpts, customopts.WithCDI(config.Annotations, config.CDIDevices))
+		CDIDevices := config.CDIDevices
+		devices := customopts.GenerateCDIDevicesOpts(config.GetMounts())
+		CDIDevices = append(CDIDevices, devices...)
+		specOpts = append(specOpts, customopts.WithCDI(config.Annotations, CDIDevices))
 	}
 	return specOpts, nil
 }

--- a/pkg/cri/server/container_create_linux.go
+++ b/pkg/cri/server/container_create_linux.go
@@ -436,9 +436,14 @@ func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageCon
 	if seccompSpecOpts != nil {
 		specOpts = append(specOpts, seccompSpecOpts)
 	}
+
 	if c.config.EnableCDI {
-		specOpts = append(specOpts, customopts.WithCDI(config.Annotations, config.CDIDevices))
+		CDIDevices := config.CDIDevices
+		devices := customopts.GenerateCDIDevicesOpts(config.GetMounts())
+		CDIDevices = append(CDIDevices, devices...)
+		specOpts = append(specOpts, customopts.WithCDI(config.Annotations, CDIDevices))
 	}
+
 	return specOpts, nil
 }
 


### PR DESCRIPTION
CDI: Add support Edit Container Mount for kata/runtime-rs using direct volume
    
Try to use CDI to 'patch up' the Container Mount for kata/runtime-rs
using direct volume in K8S/CSI scenario.

related issue and PR as below:
CDI issue: https://github.com/cncf-tags/container-device-interface/issues/162
CDI Mount PR: https://github.com/cncf-tags/container-device-interface/pull/169

Fixes: #9203

Signed-off-by: alex.lyn <alex.lyn@antgroup.com>