### PR TITLE
add cpu-burst param to ctr command

### DIFF
--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -327,6 +327,10 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 			opts = append(opts, oci.WithCPUCFS(quota, period))
 		}
 
+		if burst := context.Uint64("cpu-burst"); burst != 0 {
+			opts = append(opts, oci.WithCPUBurst(burst))
+		}
+
 		joinNs := context.StringSlice("with-ns")
 		for _, ns := range joinNs {
 			nsType, nsPath, ok := strings.Cut(ns, ":")

--- a/oci/spec_opts.go
+++ b/oci/spec_opts.go
@@ -1535,6 +1535,15 @@ func WithCPUCFS(quota int64, period uint64) SpecOpts {
 	}
 }
 
+// WithCPUBurst sets the container's cpu burst
+func WithCPUBurst(burst uint64) SpecOpts {
+	return func(ctx context.Context, _ Client, c *containers.Container, s *Spec) error {
+		setCPU(s)
+		s.Linux.Resources.CPU.Burst = &burst
+		return nil
+	}
+}
+
 // WithCPURT sets the container's realtime scheduling (RT) runtime and period.
 func WithCPURT(runtime int64, period uint64) SpecOpts {
 	return func(ctx context.Context, _ Client, c *containers.Container, s *Spec) error {


### PR DESCRIPTION
Issue: https://github.com/containerd/containerd/issues/9078

Add `cpu-burst` param to ctr command, make it support CPU Burst in containerd.