### PR TITLE
[release/1.6 backport] containerd-shim-runc-v2: avoid potential deadlock in create handler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,6 +233,11 @@ bin/cni-bridge-fp: integration/failpoint/cmd/cni-bridge-fp FORCE
 	@echo "$(WHALE) $@"
 	@$(GO) build ${GO_BUILD_FLAGS} -o $@ ./integration/failpoint/cmd/cni-bridge-fp
 
+# build runc-fp as runc wrapper to support failpoint, only used by integration test
+bin/runc-fp: integration/failpoint/cmd/runc-fp FORCE
+	@echo "$(WHALE) $@"
+	@$(GO) build ${GO_BUILD_FLAGS} -o $@ ./integration/failpoint/cmd/runc-fp
+
 benchmark: ## run benchmarks tests
 	@echo "$(WHALE) $@"
 	@$(GO) test ${TESTFLAGS} -bench . -run Benchmark -test.root

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -200,6 +200,19 @@ EOF
       SHELL
   end
 
+  config.vm.provision "install-failpoint-binaries", type: "shell",  run: "once" do |sh|
+      sh.upload_path = "/tmp/vagrant-install-failpoint-binaries"
+      sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        source /etc/environment
+        source /etc/profile.d/sh.local
+        set -eux -o pipefail
+        ${GOPATH}/src/github.com/containerd/containerd/script/setup/install-failpoint-binaries
+        chcon -v -t container_runtime_exec_t $(type -ap containerd-shim-runc-fp-v1)
+        containerd-shim-runc-fp-v1 -v
+      SHELL
+  end
+
   # SELinux is Enforcing by default.
   # To set SELinux as Disabled on a VM that has already been provisioned:
   #   SELINUX=Disabled vagrant up --provision-with=selinux

--- a/cmd/containerd/command/oci-hook.go
+++ b/cmd/containerd/command/oci-hook.go
@@ -25,7 +25,8 @@ import (
 	"syscall"
 	"text/template"
 
-	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/containerd/containerd/oci"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/urfave/cli"
 )
 
@@ -37,7 +38,8 @@ var ociHook = cli.Command{
 		if err != nil {
 			return err
 		}
-		spec, err := loadSpec(state.Bundle)
+		specFile := filepath.Join(state.Bundle, oci.ConfigFilename)
+		spec, err := loadSpec(specFile)
 		if err != nil {
 			return err
 		}
@@ -56,14 +58,16 @@ var ociHook = cli.Command{
 	},
 }
 
+// hookSpec is a shallow version of [oci.Spec] containing only the
+// fields we need for the hook. We use a shallow struct to reduce
+// the overhead of unmarshaling.
 type hookSpec struct {
-	Root struct {
-		Path string `json:"path"`
-	} `json:"root"`
+	// Root configures the container's root filesystem.
+	Root *specs.Root `json:"root,omitempty"`
 }
 
-func loadSpec(bundle string) (*hookSpec, error) {
-	f, err := os.Open(filepath.Join(bundle, "config.json"))
+func loadSpec(path string) (*hookSpec, error) {
+	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}

--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -41,7 +41,9 @@ import (
 	"github.com/containerd/containerd/runtime/linux/runctypes"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/containerd/containerd/sys"
+
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/require"
 	exec "golang.org/x/sys/execabs"
 	"golang.org/x/sys/unix"
 )
@@ -1492,5 +1494,85 @@ func TestShimOOMScore(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("timeout waiting for task exit event")
 	case <-statusC:
+	}
+}
+
+// TestIssue9103 is used as regression case for issue 9103.
+//
+// The runc-fp will kill the init process so that the shim should return stopped
+// status after container.NewTask. It's used to simulate that the runc-init
+// might be killed by oom-kill.
+func TestIssue9103(t *testing.T) {
+	if os.Getenv("RUNC_FLAVOR") == "crun" {
+		t.Skip("skip it when using crun")
+	}
+	if getRuntimeVersion() == "v1" {
+		t.Skip("skip it when using shim v1")
+	}
+
+	client, err := newClient(t, address)
+	require.NoError(t, err)
+	defer client.Close()
+
+	var (
+		image       Image
+		ctx, cancel = testContext(t)
+		id          = t.Name()
+	)
+	defer cancel()
+
+	image, err = client.GetImage(ctx, testImage)
+	require.NoError(t, err)
+
+	for idx, tc := range []struct {
+		desc           string
+		cntrOpts       []NewContainerOpts
+		expectedStatus ProcessStatus
+	}{
+		{
+			desc: "should be created status",
+			cntrOpts: []NewContainerOpts{
+				WithNewSpec(oci.WithImageConfig(image),
+					withProcessArgs("sleep", "30"),
+				),
+			},
+			expectedStatus: Created,
+		},
+		{
+			desc: "should be stopped status if init has been killed",
+			cntrOpts: []NewContainerOpts{
+				WithNewSpec(oci.WithImageConfig(image),
+					withProcessArgs("sleep", "30"),
+					oci.WithAnnotations(map[string]string{
+						"oci.runc.failpoint.profile": "issue9103",
+					}),
+				),
+				WithRuntime(client.Runtime(), &options.Options{
+					BinaryName: "runc-fp",
+				}),
+			},
+			expectedStatus: Stopped,
+		},
+	} {
+		tc := tc
+		tName := fmt.Sprintf("%s%d", id, idx)
+		t.Run(tc.desc, func(t *testing.T) {
+			container, err := client.NewContainer(ctx, tName,
+				append([]NewContainerOpts{WithNewSnapshot(tName, image)}, tc.cntrOpts...)...,
+			)
+			require.NoError(t, err)
+			defer container.Delete(ctx, WithSnapshotCleanup)
+
+			cctx, ccancel := context.WithTimeout(ctx, 30*time.Second)
+			task, err := container.NewTask(cctx, empty())
+			ccancel()
+			require.NoError(t, err)
+
+			defer task.Delete(ctx, WithProcessKill)
+
+			status, err := task.Status(ctx)
+			require.NoError(t, err)
+			require.Equal(t, status.Status, tc.expectedStatus)
+		})
 	}
 }

--- a/integration/client/go.mod
+++ b/integration/client/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 	github.com/sirupsen/logrus v1.9.3
+	github.com/stretchr/testify v1.8.4
 	golang.org/x/sys v0.7.0
 	gotest.tools/v3 v3.5.0
 )
@@ -28,6 +29,7 @@ require (
 	github.com/containerd/fifo v1.0.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/godbus/dbus/v5 v5.0.6 // indirect
@@ -45,6 +47,7 @@ require (
 	github.com/opencontainers/selinux v1.10.1 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
@@ -52,6 +55,7 @@ require (
 	google.golang.org/genproto v0.0.0-20220502173005-c8bf987b8c21 // indirect
 	google.golang.org/grpc v1.50.1 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace (

--- a/integration/client/go.sum
+++ b/integration/client/go.sum
@@ -1040,6 +1040,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/integration/failpoint/cmd/containerd-shim-runc-fp-v1/plugin_linux.go
+++ b/integration/failpoint/cmd/containerd-shim-runc-fp-v1/plugin_linux.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -35,8 +34,6 @@ import (
 )
 
 const (
-	ociConfigFilename = "config.json"
-
 	failpointPrefixKey = "io.containerd.runtime.v2.shim.failpoint."
 )
 
@@ -113,15 +110,10 @@ func newFailpointFromOCIAnnotation() (map[string]*failpoint.Failpoint, error) {
 		return nil, fmt.Errorf("failed to get current working dir: %w", err)
 	}
 
-	configPath := filepath.Join(cwd, ociConfigFilename)
-	data, err := os.ReadFile(configPath)
+	configPath := filepath.Join(cwd, oci.ConfigFilename)
+	spec, err := oci.ReadSpec(configPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read %v: %w", configPath, err)
-	}
-
-	var spec oci.Spec
-	if err := json.Unmarshal(data, &spec); err != nil {
-		return nil, fmt.Errorf("failed to parse oci.Spec(%v): %w", string(data), err)
+		return nil, err
 	}
 
 	res := make(map[string]*failpoint.Failpoint)

--- a/integration/failpoint/cmd/runc-fp/issue9103.go
+++ b/integration/failpoint/cmd/runc-fp/issue9103.go
@@ -1,0 +1,69 @@
+//go:build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// issue9103KillInitAfterCreate kills the runc.Init process after creating
+// command returns successfully.
+//
+// REF: https://github.com/containerd/containerd/issues/9103
+func issue9103KillInitAfterCreate(ctx context.Context, method invoker) error {
+	isCreated := strings.Contains(strings.Join(os.Args, ","), ",create,")
+
+	if err := method(ctx); err != nil {
+		return err
+	}
+
+	if !isCreated {
+		return nil
+	}
+
+	initPidPath := "init.pid"
+	data, err := os.ReadFile(initPidPath)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", initPidPath, err)
+	}
+
+	pid, err := strconv.Atoi(string(data))
+	if err != nil {
+		return fmt.Errorf("failed to get init pid from string %s: %w", string(data), err)
+	}
+
+	if pid <= 0 {
+		return fmt.Errorf("unexpected init pid %v", pid)
+	}
+
+	if err := syscall.Kill(pid, syscall.SIGKILL); err != nil {
+		return fmt.Errorf("failed to kill the init pid %v: %w", pid, err)
+	}
+
+	// Ensure that the containerd-shim has received the SIGCHLD and start
+	// to cleanup
+	time.Sleep(3 * time.Second)
+	return nil
+}

--- a/integration/failpoint/cmd/runc-fp/main.go
+++ b/integration/failpoint/cmd/runc-fp/main.go
@@ -1,0 +1,108 @@
+//go:build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"github.com/containerd/containerd/oci"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	failpointProfileKey = "oci.runc.failpoint.profile"
+)
+
+type invoker func(context.Context) error
+
+type invokerInterceptor func(context.Context, invoker) error
+
+var (
+	failpointProfiles = map[string]invokerInterceptor{
+		"issue9103": issue9103KillInitAfterCreate,
+	}
+)
+
+// setupLog setups messages into log file.
+func setupLog() {
+	// containerd/go-runc always add --log option
+	idx := 2
+	for ; idx < len(os.Args); idx++ {
+		if os.Args[idx] == "--log" {
+			break
+		}
+	}
+
+	if idx >= len(os.Args)-1 || os.Args[idx] != "--log" {
+		panic("option --log required")
+	}
+
+	logFile := os.Args[idx+1]
+	f, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_SYNC, 0o644)
+	if err != nil {
+		panic(fmt.Errorf("failed to open %s: %w", logFile, err))
+	}
+
+	logrus.SetOutput(f)
+	logrus.SetFormatter(new(logrus.JSONFormatter))
+}
+
+func main() {
+	setupLog()
+
+	fpProfile, err := failpointProfileFromOCIAnnotation()
+	if err != nil {
+		logrus.WithError(err).Fatal("failed to get failpoint profile")
+	}
+
+	ctx := context.Background()
+	if err := fpProfile(ctx, defaultRuncInvoker); err != nil {
+		logrus.WithError(err).Fatal("failed to exec failpoint profile")
+	}
+}
+
+// defaultRuncInvoker is to call the runc command with same arguments.
+func defaultRuncInvoker(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, "runc", os.Args[1:]...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Pdeathsig: syscall.SIGKILL}
+	return cmd.Run()
+}
+
+// failpointProfileFromOCIAnnotation gets the profile from OCI annotations.
+func failpointProfileFromOCIAnnotation() (invokerInterceptor, error) {
+	spec, err := oci.ReadSpec(oci.ConfigFilename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s: %w", oci.ConfigFilename, err)
+	}
+
+	profileName, ok := spec.Annotations[failpointProfileKey]
+	if !ok {
+		return nil, fmt.Errorf("failpoint profile is required")
+	}
+
+	fp, ok := failpointProfiles[profileName]
+	if !ok {
+		return nil, fmt.Errorf("no such failpoint profile %s", profileName)
+	}
+	return fp, nil
+}

--- a/oci/spec.go
+++ b/oci/spec.go
@@ -18,6 +18,8 @@ package oci
 
 import (
 	"context"
+	"encoding/json"
+	"os"
 	"path/filepath"
 	"runtime"
 
@@ -42,6 +44,22 @@ var (
 // Spec is a type alias to the OCI runtime spec to allow third part SpecOpts
 // to be created without the "issues" with go vendoring and package imports
 type Spec = specs.Spec
+
+const ConfigFilename = "config.json"
+
+// ReadSpec deserializes JSON into an OCI runtime Spec from a given path.
+func ReadSpec(path string) (*Spec, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var s Spec
+	if err := json.NewDecoder(f).Decode(&s); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
 
 // GenerateSpec will generate a default spec from the provided image
 // for use as a containerd container

--- a/runtime/v2/bundle.go
+++ b/runtime/v2/bundle.go
@@ -25,9 +25,8 @@ import (
 	"github.com/containerd/containerd/identifiers"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/oci"
 )
-
-const configFilename = "config.json"
 
 // LoadBundle loads an existing bundle from disk
 func LoadBundle(ctx context.Context, root, id string) (*Bundle, error) {
@@ -101,7 +100,7 @@ func NewBundle(ctx context.Context, root, state, id string, spec []byte) (b *Bun
 		return nil, err
 	}
 	// write the spec to the bundle
-	err = os.WriteFile(filepath.Join(b.Path, configFilename), spec, 0666)
+	err = os.WriteFile(filepath.Join(b.Path, oci.ConfigFilename), spec, 0666)
 	return b, err
 }
 

--- a/runtime/v2/runc/task/service.go
+++ b/runtime/v2/runc/task/service.go
@@ -461,7 +461,7 @@ func (s *service) Pids(ctx context.Context, r *taskAPI.PidsRequest) (*taskAPI.Pi
 	if err != nil {
 		return nil, err
 	}
-	pids, err := s.getContainerPids(ctx, r.ID)
+	pids, err := s.getContainerPids(ctx, container)
 	if err != nil {
 		return nil, errdefs.ToGRPC(err)
 	}
@@ -663,16 +663,12 @@ func (s *service) handleProcessExit(e runcC.Exit, c *runc.Container, p process.P
 	})
 }
 
-func (s *service) getContainerPids(ctx context.Context, id string) ([]uint32, error) {
-	container, err := s.getContainer(id)
-	if err != nil {
-		return nil, err
-	}
+func (s *service) getContainerPids(ctx context.Context, container *runc.Container) ([]uint32, error) {
 	p, err := container.Process("")
 	if err != nil {
 		return nil, errdefs.ToGRPC(err)
 	}
-	ps, err := p.(*process.Init).Runtime().Ps(ctx, id)
+	ps, err := p.(*process.Init).Runtime().Ps(ctx, container.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/v2/runc/task/service.go
+++ b/runtime/v2/runc/task/service.go
@@ -136,11 +136,14 @@ type containerProcess struct {
 // that its exit can be handled efficiently. If the process has already exited,
 // it handles the exit immediately. handleStarted should be called after the
 // event announcing the start of the process has been published.
+// Note that handleStarted needs to be aware of whether s.mu is already held
+// when it is called. If s.mu has been held, we don't need to lock it when
+// calling handleProcessExit.
 //
 // The returned cleanup closure releases resources used to handle early exits.
 // It must be called before the caller of preStart returns, otherwise severe
 // memory leaks will occur.
-func (s *service) preStart(c *runc.Container) (handleStarted func(*runc.Container, process.Process), cleanup func()) {
+func (s *service) preStart(c *runc.Container) (handleStarted func(*runc.Container, process.Process, bool), cleanup func()) {
 	exits := make(map[int][]runcC.Exit)
 
 	s.lifecycleMu.Lock()
@@ -164,7 +167,7 @@ func (s *service) preStart(c *runc.Container) (handleStarted func(*runc.Containe
 		}
 	}
 
-	handleStarted = func(c *runc.Container, p process.Process) {
+	handleStarted = func(c *runc.Container, p process.Process, muLocked bool) {
 		var pid int
 		if p != nil {
 			pid = p.Pid()
@@ -179,7 +182,13 @@ func (s *service) preStart(c *runc.Container) (handleStarted func(*runc.Containe
 		} else if exited {
 			s.lifecycleMu.Unlock()
 			for _, ee := range ees {
-				s.handleProcessExit(ee, c, p)
+				if muLocked {
+					s.handleProcessExit(ee, c, p)
+				} else {
+					s.mu.Lock()
+					s.handleProcessExit(ee, c, p)
+					s.mu.Unlock()
+				}
 			}
 		} else {
 			s.running[pid] = append(s.running[pid], containerProcess{
@@ -234,7 +243,7 @@ func (s *service) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) (_ *
 	// could happen would also cause the container.Pid() call above to
 	// nil-deference panic.
 	proc, _ := container.Process("")
-	handleStarted(container, proc)
+	handleStarted(container, proc, true)
 
 	return &taskAPI.CreateTaskResponse{
 		Pid: uint32(container.Pid()),
@@ -261,7 +270,7 @@ func (s *service) Start(ctx context.Context, r *taskAPI.StartRequest) (*taskAPI.
 	defer cleanup()
 	p, err := container.Start(ctx, r)
 	if err != nil {
-		handleStarted(container, p)
+		handleStarted(container, p, false)
 		return nil, errdefs.ToGRPC(err)
 	}
 
@@ -301,7 +310,7 @@ func (s *service) Start(ctx context.Context, r *taskAPI.StartRequest) (*taskAPI.
 			Pid:         uint32(p.Pid()),
 		})
 	}
-	handleStarted(container, p)
+	handleStarted(container, p, false)
 	return &taskAPI.StartResponse{
 		Pid: uint32(p.Pid()),
 	}, nil
@@ -630,7 +639,9 @@ func (s *service) processExits() {
 		s.lifecycleMu.Unlock()
 
 		for _, cp := range cps {
+			s.mu.Lock()
 			s.handleProcessExit(e, cp.Container, cp.Process)
+			s.mu.Unlock()
 		}
 	}
 }
@@ -639,10 +650,8 @@ func (s *service) send(evt interface{}) {
 	s.events <- evt
 }
 
+// s.mu must be locked when calling handleProcessExit
 func (s *service) handleProcessExit(e runcC.Exit, c *runc.Container, p process.Process) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	if ip, ok := p.(*process.Init); ok {
 		// Ensure all children are killed
 		if runc.ShouldKillAllOnExit(s.context, c.Bundle) {

--- a/runtime/v2/runc/util.go
+++ b/runtime/v2/runc/util.go
@@ -21,14 +21,13 @@ package runc
 
 import (
 	"context"
-	"encoding/json"
-	"os"
 	"path/filepath"
 
 	"github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/runtime"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 )
 
@@ -65,18 +64,14 @@ func GetTopic(e interface{}) string {
 // ShouldKillAllOnExit reads the bundle's OCI spec and returns true if
 // there is an error reading the spec or if the container has a private PID namespace
 func ShouldKillAllOnExit(ctx context.Context, bundlePath string) bool {
-	var bundleSpec specs.Spec
-	bundleConfigContents, err := os.ReadFile(filepath.Join(bundlePath, "config.json"))
+	spec, err := oci.ReadSpec(filepath.Join(bundlePath, oci.ConfigFilename))
 	if err != nil {
 		log.G(ctx).WithError(err).Error("shouldKillAllOnExit: failed to read config.json")
 		return true
 	}
-	if err := json.Unmarshal(bundleConfigContents, &bundleSpec); err != nil {
-		log.G(ctx).WithError(err).Error("shouldKillAllOnExit: failed to unmarshal bundle json")
-		return true
-	}
-	if bundleSpec.Linux != nil {
-		for _, ns := range bundleSpec.Linux.Namespaces {
+
+	if spec.Linux != nil {
+		for _, ns := range spec.Linux.Namespaces {
 			if ns.Type == specs.PIDNamespace && ns.Path == "" {
 				return false
 			}

--- a/script/setup/install-failpoint-binaries
+++ b/script/setup/install-failpoint-binaries
@@ -33,3 +33,7 @@ sudo install bin/cni-bridge-fp "${CNI_BIN_DIR}"
 SHIM_BIN_DIR=${SHIM_BIN_DIR:-"/usr/local/bin"}
 make bin/containerd-shim-runc-fp-v1
 sudo install bin/containerd-shim-runc-fp-v1 "${SHIM_BIN_DIR}"
+
+RUNCFP_BIN_DIR=${RUNCFP_BIN_DIR:-"/usr/local/bin"}
+make bin/runc-fp
+sudo install bin/runc-fp "${RUNCFP_BIN_DIR}"


### PR DESCRIPTION
- relates to https://github.com/containerd/containerd/pull/8617
- backports https://github.com/containerd/containerd/pull/8780
- backports https://github.com/containerd/containerd/pull/9104
- fixes https://github.com/containerd/containerd/issues/9103


---


After pr #8617, create handler of containerd-shim-runc-v2 will
call handleStarted() to record the init process and handle its exit.
Although init process wouldn't quit so early in normal circumstances.
But if this screnario occurs, handleStarted() will call
handleProcessExit(), which will cause deadlock because create() had
acquired s.mu, and handleProcessExit() will try to lock it again.

So I add handleProcessExitNoLock() function which will not lock s.mu.
It can safely be called in create handler without deadlock.