### PR TITLE
Add a new image label if it is docker schema 1

### DIFF
--- a/integration/containerd_image_test.go
+++ b/integration/containerd_image_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	goruntime "runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -233,4 +235,42 @@ func TestContainerdSandboxImage(t *testing.T) {
 	require.NotNil(t, pimg)
 	t.Log("verify pinned field is set for pause image")
 	assert.True(t, pimg.Pinned)
+}
+
+func TestContainerdImageWithDockerSchema1(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("Skipped on Windows because the test image is not a multi-platform one.")
+	}
+
+	var testImage = images.Get(images.DockerSchema1)
+	digest := strings.Split(testImage, "@")[1]
+	ctx := context.Background()
+
+	t.Logf("make sure the test image doesn't exist in the cri plugin")
+	i, err := imageService.ImageStatus(&runtime.ImageSpec{Image: testImage})
+	require.NoError(t, err)
+	if i != nil {
+		require.NoError(t, imageService.RemoveImage(&runtime.ImageSpec{Image: testImage}))
+	}
+
+	t.Logf("pull the image into containerd")
+	//nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
+	_, err = containerdClient.Pull(ctx, testImage, containerd.WithPullUnpack, containerd.WithSchema1Conversion)
+	require.NoError(t, err)
+	defer func() {
+		// Make sure the image is cleaned up in any case.
+		if err := containerdClient.ImageService().Delete(ctx, testImage); err != nil {
+			assert.True(t, errdefs.IsNotFound(err), err)
+		}
+		assert.NoError(t, imageService.RemoveImage(&runtime.ImageSpec{Image: testImage}))
+	}()
+
+	imgByRef, err := containerdClient.GetImage(ctx, testImage)
+	require.NoError(t, err)
+
+	t.Logf("the image should be marked as managed")
+	assert.Equal(t, "managed", imgByRef.Labels()["io.cri-containerd.image"])
+
+	t.Logf("the image should be marked as dokcker schema1 with its original digest")
+	assert.Equal(t, digest, imgByRef.Labels()["io.containerd.image/converted-docker-schema1"])
 }

--- a/integration/images/image_list.go
+++ b/integration/images/image_list.go
@@ -37,6 +37,7 @@ type ImageList struct {
 	VolumeCopyUp     string
 	VolumeOwnership  string
 	ArgsEscaped      string
+	DockerSchema1    string
 }
 
 var (
@@ -55,6 +56,7 @@ func initImages(imageListFile string) {
 		VolumeCopyUp:     "ghcr.io/containerd/volume-copy-up:2.2",
 		VolumeOwnership:  "ghcr.io/containerd/volume-ownership:2.1",
 		ArgsEscaped:      "cplatpublic.azurecr.io/args-escaped-test-image-ns:1.0",
+		DockerSchema1:    "registry.k8s.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff",
 	}
 
 	if imageListFile != "" {
@@ -92,6 +94,8 @@ const (
 	VolumeOwnership
 	// ArgsEscaped tests image for ArgsEscaped windows bug
 	ArgsEscaped
+	// DockerSchema1 image with docker schema 1
+	DockerSchema1
 )
 
 func initImageMap(imageList ImageList) map[int]string {
@@ -103,6 +107,7 @@ func initImageMap(imageList ImageList) map[int]string {
 	images[VolumeCopyUp] = imageList.VolumeCopyUp
 	images[VolumeOwnership] = imageList.VolumeOwnership
 	images[ArgsEscaped] = imageList.ArgsEscaped
+	images[DockerSchema1] = imageList.DockerSchema1
 	return images
 }
 

--- a/pull.go
+++ b/pull.go
@@ -34,7 +34,8 @@ import (
 )
 
 const (
-	pullSpanPrefix = "pull"
+	pullSpanPrefix                 = "pull"
+	convertedDockerSchema1LabelKey = "io.containerd.image/converted-docker-schema1"
 )
 
 // Pull downloads the provided content into containerd's content store
@@ -189,9 +190,10 @@ func (c *Client) fetch(ctx context.Context, rCtx *RemoteContext, ref string, lim
 	var (
 		handler images.Handler
 
-		isConvertible bool
-		converterFunc func(context.Context, ocispec.Descriptor) (ocispec.Descriptor, error)
-		limiter       *semaphore.Weighted
+		isConvertible         bool
+		originalSchema1Digest string
+		converterFunc         func(context.Context, ocispec.Descriptor) (ocispec.Descriptor, error)
+		limiter               *semaphore.Weighted
 	)
 
 	if desc.MediaType == images.MediaTypeDockerSchema1Manifest && rCtx.ConvertSchema1 {
@@ -204,6 +206,8 @@ func (c *Client) fetch(ctx context.Context, rCtx *RemoteContext, ref string, lim
 		converterFunc = func(ctx context.Context, _ ocispec.Descriptor) (ocispec.Descriptor, error) {
 			return schema1Converter.Convert(ctx)
 		}
+
+		originalSchema1Digest = desc.Digest.String()
 	} else {
 		// Get all the children for a descriptor
 		childrenHandler := images.ChildrenHandler(store)
@@ -268,6 +272,13 @@ func (c *Client) fetch(ctx context.Context, rCtx *RemoteContext, ref string, lim
 		if desc, err = converterFunc(ctx, desc); err != nil {
 			return images.Image{}, err
 		}
+	}
+
+	if originalSchema1Digest != "" {
+		if rCtx.Labels == nil {
+			rCtx.Labels = make(map[string]string)
+		}
+		rCtx.Labels[convertedDockerSchema1LabelKey] = originalSchema1Digest
 	}
 
 	return images.Image{


### PR DESCRIPTION
Resolve https://github.com/containerd/containerd/issues/9202

This PR adds a new image label if it is docker schema 1. With the new label, users can find the docker schema1 usage by running `ctr images`


## Local Test

```
$ sudo /usr/local/bin/crictl pull docker.io/progrium/stress:latest
$ sudo ctr -n k8s.io images ls
REF                                                                     TYPE                                       DIGEST                                                                  SIZE     PLATFORMS   LABELS                                                                                                                                               
docker.io/progrium/stress:latest                                        application/vnd.oci.image.manifest.v1+json sha256:fe33932960bfb41cab97a147e7c38e0c787424dd374deba976dd6e9803fb3666 86.5 MiB linux/amd64 io.containerd.image/converted-docker-schema1=sha256:e34d56d60f5caae79333cee395aae93b74791d50e3841986420d23c2ee4697bf,io.cri-containerd.image=managed 
sha256:9d98b4a6b6d1fe7346174111650132fd189b9153fb48a94a7b898f55f9d15a17 application/vnd.oci.image.manifest.v1+json sha256:fe33932960bfb41cab97a147e7c38e0c787424dd374deba976dd6e9803fb3666 86.5 MiB linux/amd64 io.cri-containerd.image=managed
```

```
$ sudo bin/ctr image pull docker.io/progrium/stress:latest
$ sudo bin/ctr image ls
REF                              TYPE                                       DIGEST                                                                  SIZE     PLATFORMS   LABELS                                                                                                               
docker.io/progrium/stress:latest application/vnd.oci.image.manifest.v1+json sha256:fe33932960bfb41cab97a147e7c38e0c787424dd374deba976dd6e9803fb3666 86.5 MiB linux/amd64 io.containerd.image/converted-docker-schema1=sha256:e34d56d60f5caae79333cee395aae93b74791d50e3841986420d23c2ee4697bf
```