### PR TITLE
CRI: "Fix" imageFSPath behavior

### DIFF
--- a/pkg/cri/cri.go
+++ b/pkg/cri/cri.go
@@ -47,6 +47,7 @@ func init() {
 		Requires: []plugin.Type{
 			plugins.EventPlugin,
 			plugins.ServicePlugin,
+			plugins.SnapshotPlugin,
 			plugins.NRIApiPlugin,
 		},
 		InitFn: initCRIService,

--- a/plugins/types.go
+++ b/plugins/types.go
@@ -82,3 +82,7 @@ const (
 	// PropertyGRPCAddress is the ttrpc address used for client connections to containerd
 	PropertyTTRPCAddress = "io.containerd.plugin.ttrpc.address"
 )
+
+const (
+	SnapshotterRootDir = "root"
+)

--- a/snapshots/blockfile/plugin/plugin.go
+++ b/snapshots/blockfile/plugin/plugin.go
@@ -74,6 +74,7 @@ func init() {
 			}
 			opts = append(opts, blockfile.WithRecreateScratch(config.RecreateScratch))
 
+			ic.Meta.Exports[plugins.SnapshotterRootDir] = root
 			return blockfile.NewSnapshotter(root, opts...)
 		},
 	})

--- a/snapshots/btrfs/plugin/plugin.go
+++ b/snapshots/btrfs/plugin/plugin.go
@@ -54,7 +54,7 @@ func init() {
 				root = config.RootPath
 			}
 
-			ic.Meta.Exports = map[string]string{"root": root}
+			ic.Meta.Exports[plugins.SnapshotterRootDir] = root
 			return btrfs.NewSnapshotter(root)
 		},
 	})

--- a/snapshots/devmapper/plugin/plugin.go
+++ b/snapshots/devmapper/plugin/plugin.go
@@ -50,6 +50,7 @@ func init() {
 				config.RootPath = ic.Properties[plugins.PropertyRootDir]
 			}
 
+			ic.Meta.Exports[plugins.SnapshotterRootDir] = config.RootPath
 			return devmapper.NewSnapshotter(ic.Context, config)
 		},
 	})

--- a/snapshots/native/plugin/plugin.go
+++ b/snapshots/native/plugin/plugin.go
@@ -50,6 +50,7 @@ func init() {
 				root = config.RootPath
 			}
 
+			ic.Meta.Exports[plugins.SnapshotterRootDir] = root
 			return native.NewSnapshotter(root)
 		},
 	})

--- a/snapshots/overlay/plugin/plugin.go
+++ b/snapshots/overlay/plugin/plugin.go
@@ -92,7 +92,7 @@ func init() {
 				ic.Meta.Capabilities = append(ic.Meta.Capabilities, capaOnlyRemapIds)
 			}
 
-			ic.Meta.Exports["root"] = root
+			ic.Meta.Exports[plugins.SnapshotterRootDir] = root
 			return overlay.NewSnapshotter(root, oOpts...)
 		},
 	})


### PR DESCRIPTION
This was spurred by seeing:

```
"Failed to get the info of the filesystem with mountpoint"
err="no such file or directory" mountpoint="/path/to/io.containerd.snapshotter.v1.native"
```

in the kubelets logs. This is due to the imageFSPath for the CRI plugin assuming all of the snapshotters are located under the default location that gets passed on plugin initialization. Several of the snapshotters offer the ability to set different root paths and override this however, and afaict for remote snapshotters it's entirely up to them so this location can be wrong in some cases.

This change exports the root path for the remaining built-in snapshotters that allow you to change their location, and then uses the introspection API to grab the path.
 
Now `ImageFSInfo` on my host returns:
```
containerd sudo crictl -t 20s imagefsinfo
{
  "status": {
    "timestamp": "1697024624876142000",
    "fsId": {
      "mountpoint": "/Users/dcantah/containerd/blockfile"
    },
    "usedBytes": {
      "value": "0"
    },
    "inodesUsed": {
      "value": "0"
    }
  }
}
```
