### PR TITLE
idmapped: use pidfd to avoid pid reuse issue

### DIFF
--- a/mount/mount_idmapped_linux_test.go
+++ b/mount/mount_idmapped_linux_test.go
@@ -1,0 +1,235 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package mount
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/containerd/continuity/testutil"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+var (
+	testUIDMaps = []syscall.SysProcIDMap{
+		{ContainerID: 1000, HostID: 0, Size: 100},
+		{ContainerID: 5000, HostID: 2000, Size: 100},
+		{ContainerID: 10000, HostID: 3000, Size: 100},
+	}
+
+	testGIDMaps = []syscall.SysProcIDMap{
+		{ContainerID: 1000, HostID: 0, Size: 100},
+		{ContainerID: 5000, HostID: 2000, Size: 100},
+		{ContainerID: 10000, HostID: 3000, Size: 100},
+	}
+)
+
+func TestGetUsernsFD(t *testing.T) {
+	testutil.RequiresRoot(t)
+
+	t.Run("basic", testGetUsernsFDBasic)
+
+	t.Run("when kill child process before write u[g]id maps", testGetUsernsFDKillChildWhenWriteUGIDMaps)
+
+	t.Run("when kill child process after open u[g]id_map file", testGetUsernsFDKillChildAfterOpenUGIDMapFiles)
+
+}
+
+func testGetUsernsFDBasic(t *testing.T) {
+	for idx, tc := range []struct {
+		uidMaps string
+		gidMaps string
+		hasErr  bool
+	}{
+		{
+			uidMaps: "0:1000:100",
+			gidMaps: "0:1000:100",
+			hasErr:  false,
+		},
+		{
+			uidMaps: "100:1000:100",
+			gidMaps: "0:-1:100",
+			hasErr:  true,
+		},
+		{
+			uidMaps: "100:1000:100",
+			gidMaps: "-1:1000:100",
+			hasErr:  true,
+		},
+		{
+			uidMaps: "100:1000:100",
+			gidMaps: "0:1000:-1",
+			hasErr:  true,
+		},
+	} {
+		t.Run(fmt.Sprintf("#%v", idx), func(t *testing.T) {
+			_, err := GetUsernsFD(tc.uidMaps, tc.gidMaps)
+			if tc.hasErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func testGetUsernsFDKillChildWhenWriteUGIDMaps(t *testing.T) {
+	hookFunc := func(reap bool) func(uintptr, *os.File) {
+		return func(_pid uintptr, pidFD *os.File) {
+			err := unix.PidfdSendSignal(int(pidFD.Fd()), unix.SIGKILL, nil, 0)
+			require.NoError(t, err)
+
+			if reap {
+				pidfdWaitid(pidFD)
+			}
+		}
+	}
+
+	for _, tcReap := range []bool{true, false} {
+		t.Run(fmt.Sprintf("#reap=%v", tcReap), func(t *testing.T) {
+			updateTestHookKillForGetUsernsFD(t, nil, hookFunc(tcReap))
+
+			usernsFD, err := getUsernsFD(testUIDMaps, testGIDMaps)
+			require.NoError(t, err)
+			defer usernsFD.Close()
+
+			srcDir, checkFunc := initIDMappedChecker(t, testUIDMaps, testGIDMaps)
+			destDir := t.TempDir()
+			defer func() {
+				require.NoError(t, UnmountAll(destDir, 0))
+			}()
+
+			err = IDMapMount(srcDir, destDir, int(usernsFD.Fd()))
+			usernsFD.Close()
+			require.NoError(t, err)
+			checkFunc(destDir)
+		})
+	}
+
+}
+
+func testGetUsernsFDKillChildAfterOpenUGIDMapFiles(t *testing.T) {
+	hookFunc := func(reap bool) func(uintptr, *os.File) {
+		return func(_pid uintptr, pidFD *os.File) {
+			err := unix.PidfdSendSignal(int(pidFD.Fd()), unix.SIGKILL, nil, 0)
+			require.NoError(t, err)
+
+			if reap {
+				pidfdWaitid(pidFD)
+			}
+		}
+	}
+
+	for _, tc := range []struct {
+		reap     bool
+		expected error
+	}{
+		{
+			reap:     false,
+			expected: nil,
+		},
+		{
+			reap:     true,
+			expected: syscall.ESRCH,
+		},
+	} {
+		t.Run(fmt.Sprintf("#reap=%v", tc.reap), func(t *testing.T) {
+			updateTestHookKillForGetUsernsFD(t, hookFunc(tc.reap), nil)
+
+			usernsFD, err := getUsernsFD(testUIDMaps, testGIDMaps)
+			if tc.expected != nil {
+				require.Error(t, tc.expected, err)
+				return
+			}
+
+			require.NoError(t, err)
+			defer usernsFD.Close()
+
+			srcDir, checkFunc := initIDMappedChecker(t, testUIDMaps, testGIDMaps)
+			destDir := t.TempDir()
+			defer func() {
+				require.NoError(t, UnmountAll(destDir, 0))
+			}()
+
+			err = IDMapMount(srcDir, destDir, int(usernsFD.Fd()))
+			usernsFD.Close()
+			require.NoError(t, err)
+			checkFunc(destDir)
+		})
+	}
+}
+
+func updateTestHookKillForGetUsernsFD(t *testing.T, newBeforeFunc, newAfterFunc func(uintptr, *os.File)) {
+	testHookLock.Lock()
+
+	oldBefore := testHookKillChildBeforePidfdSendSignal
+	oldAfter := testHookKillChildAfterPidfdSendSignal
+	t.Cleanup(func() {
+		testHookKillChildBeforePidfdSendSignal = oldBefore
+		testHookKillChildAfterPidfdSendSignal = oldAfter
+		testHookLock.Unlock()
+	})
+	if newBeforeFunc != nil {
+		testHookKillChildBeforePidfdSendSignal = newBeforeFunc
+	}
+	if newAfterFunc != nil {
+		testHookKillChildAfterPidfdSendSignal = newAfterFunc
+	}
+}
+
+func initIDMappedChecker(t *testing.T, uidMaps, gidMaps []syscall.SysProcIDMap) (_srcDir string, _verifyFunc func(destDir string)) {
+	testutil.RequiresRoot(t)
+
+	srcDir := t.TempDir()
+
+	require.Equal(t, len(uidMaps), len(gidMaps))
+	for idx := range uidMaps {
+		file := filepath.Join(srcDir, fmt.Sprintf("%v", idx))
+
+		f, err := os.Create(file)
+		require.NoError(t, err, fmt.Sprintf("create file %s", file))
+		defer f.Close()
+
+		uid, gid := uidMaps[idx].ContainerID, gidMaps[idx].ContainerID
+		err = f.Chown(uid, gid)
+		require.NoError(t, err, fmt.Sprintf("chown %v:%v for file %s", uid, gid, file))
+	}
+
+	return srcDir, func(destDir string) {
+		for idx := range uidMaps {
+			file := filepath.Join(destDir, fmt.Sprintf("%v", idx))
+
+			f, err := os.Open(file)
+			require.NoError(t, err, fmt.Sprintf("open file %s", file))
+			defer f.Close()
+
+			stat, err := f.Stat()
+			require.NoError(t, err, fmt.Sprintf("stat file %s", file))
+
+			sysStat := stat.Sys().(*syscall.Stat_t)
+
+			uid, gid := uidMaps[idx].HostID, gidMaps[idx].HostID
+			require.Equal(t, uint32(uid), sysStat.Uid, fmt.Sprintf("check file %s uid", file))
+			require.Equal(t, uint32(gid), sysStat.Gid, fmt.Sprintf("check file %s gid", file))
+			t.Logf("IDMapped File %s uid=%v, gid=%v", file, uid, gid)
+		}
+	}
+}

--- a/snapshots/overlay/overlayutils/check.go
+++ b/snapshots/overlay/overlayutils/check.go
@@ -255,13 +255,13 @@ func SupportsIDMappedMounts() (bool, error) {
 	uidmap := fmt.Sprintf("%d:%d:%d", uidMap.ContainerID, uidMap.HostID, uidMap.Size)
 	gidmap := fmt.Sprintf("%d:%d:%d", gidMap.ContainerID, gidMap.HostID, gidMap.Size)
 
-	usernsFd, childProcCleanUp, err := mount.GetUsernsFD(uidmap, gidmap)
+	usernsFd, err := mount.GetUsernsFD(uidmap, gidmap)
 	if err != nil {
 		return false, err
 	}
-	defer childProcCleanUp()
+	defer usernsFd.Close()
 
-	if err = mount.IDMapMount(lowerDir, lowerDir, usernsFd); err != nil {
+	if err = mount.IDMapMount(lowerDir, lowerDir, int(usernsFd.Fd())); err != nil {
 		return false, fmt.Errorf("failed to remap lowerdir %s: %w", lowerDir, err)
 	}
 	defer func() {

--- a/sys/userns_unsafe_linux.go
+++ b/sys/userns_unsafe_linux.go
@@ -22,44 +22,73 @@ import (
 	"unsafe"
 )
 
-// ProcSyncType is used for synchronization
-// between parent and child processes.
-type ProcSyncType uint8
-
-const (
-	// ProcSyncExit tells child "it's time to exit".
-	ProcSyncExit ProcSyncType = 0x1
-)
-
+// ForkUserns is to fork child process with user namespace. It returns child
+// process's pid and pidfd reference to the child process.
+//
+// Precondition: The runtime OS thread must be locked, which is GO runtime
+// requirement.
+//
+// Beside this, the child process sets PR_SET_PDEATHSIG with SIGKILL so that
+// the parent process's OS thread must be locked. Otherwise, the exit event of
+// parent process's OS thread will send kill signal to the child process,
+// even if parent process is still running.
+//
 //go:norace
 //go:noinline
-func ForkUserns(pipeMap [2]int) (pid uintptr, errno syscall.Errno) {
-	var sync ProcSyncType
+func ForkUserns() (_pid uintptr, _pidfd uintptr, _ syscall.Errno) {
+	var (
+		pidfd     uintptr
+		pid, ppid uintptr
+		err       syscall.Errno
+	)
+
+	ppid, _, err = syscall.RawSyscall(uintptr(syscall.SYS_GETPID), 0, 0, 0)
+	if err != 0 {
+		return 0, 0, err
+	}
 
 	beforeFork()
 	if runtime.GOARCH == "s390x" {
-		pid, _, errno = syscall.RawSyscall6(uintptr(syscall.SYS_CLONE), 0, syscall.CLONE_NEWUSER|uintptr(syscall.SIGCHLD), 0, 0, 0, 0)
+		// NOTE:
+		//
+		// On the s390 architectures, the order of the first two
+		// arguments is reversed.
+		//
+		// REF: https://man7.org/linux/man-pages/man2/clone.2.html
+		pid, _, err = syscall.RawSyscall(syscall.SYS_CLONE,
+			0,
+			uintptr(syscall.CLONE_NEWUSER|syscall.SIGCHLD|syscall.CLONE_PIDFD),
+			uintptr(unsafe.Pointer(&pidfd)),
+		)
 	} else {
-		pid, _, errno = syscall.RawSyscall6(uintptr(syscall.SYS_CLONE), syscall.CLONE_NEWUSER|uintptr(syscall.SIGCHLD), 0, 0, 0, 0, 0)
+		pid, _, err = syscall.RawSyscall(syscall.SYS_CLONE,
+			uintptr(syscall.CLONE_NEWUSER|syscall.SIGCHLD|syscall.CLONE_PIDFD),
+			0,
+			uintptr(unsafe.Pointer(&pidfd)),
+		)
 	}
-	if errno != 0 || pid != 0 {
+	if err != 0 || pid != 0 {
 		afterFork()
-		return pid, errno
+		return pid, pidfd, err
 	}
-
 	afterForkInChild()
-	if _, _, errno = syscall.RawSyscall(syscall.SYS_CLOSE, uintptr(pipeMap[1]), 0, 0); errno != 0 {
-		goto err
-	}
-	if _, _, errno = syscall.RawSyscall6(syscall.SYS_PRCTL, syscall.PR_SET_PDEATHSIG, uintptr(syscall.SIGKILL), 0, 0, 0, 0); errno != 0 {
-		goto err
-	}
-	// wait for parent's signal
-	if _, _, errno = syscall.RawSyscall6(syscall.SYS_READ, uintptr(pipeMap[0]), uintptr(unsafe.Pointer(&sync)), unsafe.Sizeof(sync), 0, 0, 0); errno != 0 || sync != ProcSyncExit {
+
+	if _, _, err = syscall.RawSyscall(syscall.SYS_PRCTL, syscall.PR_SET_PDEATHSIG, uintptr(syscall.SIGKILL), 0); err != 0 {
 		goto err
 	}
 
+	pid, _, err = syscall.RawSyscall(syscall.SYS_GETPPID, 0, 0, 0)
+	if err != 0 {
+		goto err
+	}
+
+	// exit if re-parent
+	if pid != ppid {
+		goto err
+	}
+
+	_, _, err = syscall.RawSyscall(syscall.SYS_PPOLL, 0, 0, 0)
 err:
-	syscall.RawSyscall6(syscall.SYS_EXIT, uintptr(errno), 0, 0, 0, 0, 0)
+	syscall.RawSyscall(syscall.SYS_EXIT, uintptr(err), 0, 0)
 	panic("unreachable")
 }


### PR DESCRIPTION
It's followup for #5890.

### 1. Race-condition

The containerd-shim process depends on the mount package to init rootfs
for container. For the container enable user namespace, the mount
package needs to fork child process to get the brand-new user namespace.
However, there are two reapers in one process (described by the
following list) and there are race-condition cases.

1. mount package
2. sys.Reaper as global one which watch all the SIGCHLD.

#### 1.1 [kill(2)][kill] the wrong process 

Currently, we use pipe to ensure that child process is alive. However,
the pide file descriptor can be hold by other process, which the child
process cannot exit by self. We should use [kill(2)][kill] to ensure the
child process exit. But we might kill the wrong process if the child process
might be reaped by containerd-shim and the PID might be reused by other
process.

#### 1.2 [waitid(2)][waitid] on the wrong child process 

```
containerd-shim process:

Goroutine 1(GetUsernsFD):                   Goroutine 2(Reaper)

1. Ready to wait for child process X

                                            2. Received SIGCHLD from X

                                            3. Reaped the zombie child process X

                                            (X has been reused by other child process)

4. Wait on process X

The goroutine 1 will be stuck until the process X has been terminated.
```

#### 1.3 open `/proc/X/ns/user` on the wrong child process

There is also pid-reused risk between opening `/proc/$pid/ns/user` and
writing `/proc/$pid/u[g]id_map`.

```
containerd-shim process:

Goroutine 1(GetUsernsFD):                   Goroutine 2(Reaper)

1. Fork child process X

2. Write /proc/X/uid_map,gid_map

                                            3. Received SIGCHLD from X

                                            4. Reaped the zombie child process X

                                            (X has been reused by other process)

5. Open /proc/X/ns/user file as usernsFD

The usernsFD links to the wrong X!!!
```

### 2. Solution

In order to fix the race-condition, we should use [CLONE_PIDFD][clone2] (Since
Linux v5.2).

When we fork child process `X`, the kernel will return a process file
descriptor `X_PIDFD` referencing to child process `X`. With the pidfd, we can
use [pidfd_send_signal(2)][pidfd_send_signal] (Since Linux v5.1)
to send signal(0) to ensure the child process `X` is alive. If the `X` has
terminated and its PID has been recycled for another process. The
pidfd_send_signal fails with the error ESRCH.

Therefore, we can open `/proc/X/{ns/user,uid_map,gid_map}` file
descriptors as first and then use pidfd_send_signal to check the process
is still alive. If so, we can ensure the file descriptors are valid and
reference to the child process `X`. Even if the `X` PID has been reused
after pidfd_send_signal call, the file descriptors are still valid.

```code
X, pidfd = clone2(CLONE_PIDFD)

usernsFD = open /proc/X/ns/user
uidmapFD = open /proc/X/uid_map
gidmapFD = open /proc/X/gid_map

pidfd_send_signal pidfd, signal(0)
  return err if no such process

== When we arrive here, we can ensure usernsFD/uidmapFD/gidmapFD are correct
== even if X has been reused after pidfd_send_signal call.

update uid/gid mapping by uidmapFD/gidmapFD
return usernsFD
```

And the [waitid(2)][waitid] also supports pidfd type (Since Linux 5.4).
We can use pidfd type waitid to ensure we are waiting for the correct
process. All the PID related race-condition issues can be resolved by
pidfd.

```bash
➜  mount git:(followup-idmapped) pwd
/home/fuwei/go/src/github.com/containerd/containerd/mount

➜  mount git:(followup-idmapped) sudo go test -test.root -run TestGetUsernsFD -count=1000 -failfast -p 100  ./...
PASS
ok      github.com/containerd/containerd/mount  3.446s
```

[kill]: <https://man7.org/linux/man-pages/man2/kill.2.html>
[clone2]: <https://man7.org/linux/man-pages/man2/clone.2.html>
[pidfd_send_signal]: <https://man7.org/linux/man-pages/man2/pidfd_send_signal.2.html>
[waitid]: <https://man7.org/linux/man-pages/man2/waitid.2.html>

Signed-off-by: Wei Fu <fuweid89@gmail.com>