### PR TITLE
Improve/fix ansible playbook for debian and ubuntu

### DIFF
--- a/contrib/ansible/cri-containerd.yaml
+++ b/contrib/ansible/cri-containerd.yaml
@@ -3,8 +3,8 @@
   become: true
   tasks:
     - include_vars: vars/vars.yaml # Contains tasks variables for installer
-    - include_tasks: tasks/bootstrap_ubuntu.yaml # Contains tasks bootstrap components for ubuntu systems
-      when: ansible_distribution == "Ubuntu"
+    - include_tasks: tasks/bootstrap_debian_ubuntu.yaml # Contains tasks bootstrap components for debian/ubuntu systems
+      when: ansible_os_family == "Debian"
     - include_tasks: tasks/bootstrap_centos.yaml # Contains tasks bootstrap components for centos systems
       when: ansible_distribution == "CentOS"
     - include_tasks: tasks/k8s.yaml # Contains tasks kubernetes component installation
@@ -31,17 +31,17 @@
         name: net.ipv4.ip_forward
         value: 1
 
-    - name: "Check kubelet args in kubelet config (Ubuntu)"
+    - name: "Check kubelet args in kubelet config ({{ ansible_distribution }})"
       shell: grep "^Environment=\"KUBELET_EXTRA_ARGS=" /usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf || true
       register: check_args
-      when: ansible_distribution == "Ubuntu"
+      when: ansible_os_family == "Debian"
 
-    - name: "Add runtime args in kubelet conf (Ubuntu)"
+    - name: "Add runtime args in kubelet conf ({{ ansible_distribution }})"
       lineinfile:
         dest: "/usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf"
         line: "Environment=\"KUBELET_EXTRA_ARGS= --runtime-cgroups=/system.slice/containerd.service --container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock\""
         insertafter: '\[Service\]'
-      when: ansible_distribution == "Ubuntu" and check_args.stdout == ""
+      when: ansible_os_family == "Debian" and check_args.stdout == ""
 
     - name: "Check kubelet args in kubelet config (CentOS)"
       shell: grep "^Environment=\"KUBELET_EXTRA_ARGS=" /usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf || true

--- a/contrib/ansible/cri-containerd.yaml
+++ b/contrib/ansible/cri-containerd.yaml
@@ -32,13 +32,13 @@
         value: 1
 
     - name: "Check kubelet args in kubelet config (Ubuntu)"
-      shell: grep "^Environment=\"KUBELET_EXTRA_ARGS=" /etc/systemd/system/kubelet.service.d/10-kubeadm.conf || true
+      shell: grep "^Environment=\"KUBELET_EXTRA_ARGS=" /usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf || true
       register: check_args
       when: ansible_distribution == "Ubuntu"
 
     - name: "Add runtime args in kubelet conf (Ubuntu)"
       lineinfile:
-        dest: "/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
+        dest: "/usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf"
         line: "Environment=\"KUBELET_EXTRA_ARGS= --runtime-cgroups=/system.slice/containerd.service --container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock\""
         insertafter: '\[Service\]'
       when: ansible_distribution == "Ubuntu" and check_args.stdout == ""

--- a/contrib/ansible/tasks/bootstrap_debian_ubuntu.yaml
+++ b/contrib/ansible/tasks/bootstrap_debian_ubuntu.yaml
@@ -1,5 +1,5 @@
 ---
-- name: "Install required packages on Ubuntu"
+- name: "Install required packages on {{ ansible_distribution }}"
   package:
     name: "{{ item }}"
     state: latest
@@ -7,6 +7,5 @@
       - unzip
       - tar
       - apt-transport-https
-      - btrfs-tools
       - libseccomp2
       - util-linux

--- a/contrib/ansible/tasks/k8s.yaml
+++ b/contrib/ansible/tasks/k8s.yaml
@@ -1,13 +1,22 @@
 ---
+- name: "Get kubernetes latest stable release version"
+  command: >
+      curl -L -s https://dl.k8s.io/release/stable.txt
+  changed_when: false
+  register: k8s_stable_release
+
+- set_fact: 
+    k8s_stable_release={{ k8s_stable_release.stdout | regex_replace('^v([0-9])+\\.([0-9]+)\\.[0-9]+', 'v\\1.\\2') }}
+
 - name: "Add gpg key (Ubuntu)"
   apt_key:
-    url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
+    url: "https://pkgs.k8s.io/core:/stable:/{{ k8s_stable_release }}/deb/Release.key"
     state: present
   when: ansible_distribution == "Ubuntu"
 
 - name: "Add kubernetes source list (Ubuntu)"
   apt_repository:
-    repo: "deb http://apt.kubernetes.io/ kubernetes-{{ ansible_distribution_release }} main"
+    repo: "deb https://pkgs.k8s.io/core:/stable:/{{ k8s_stable_release }}/deb/ /"
     state: present
     filename: "kubernetes"
   when: ansible_distribution == "Ubuntu"
@@ -44,7 +53,9 @@
   when: ansible_distribution == "CentOS"
 
 - name: "Install kubelet, kubeadm, kubectl (Ubuntu)"
-  apt: name={{item}} state=installed
+  apt:
+    name: "{{item}}"
+    state: present
   with_items:
     - kubelet
     - kubeadm

--- a/contrib/ansible/tasks/k8s.yaml
+++ b/contrib/ansible/tasks/k8s.yaml
@@ -8,23 +8,23 @@
 - set_fact: 
     k8s_stable_release={{ k8s_stable_release.stdout | regex_replace('^v([0-9])+\\.([0-9]+)\\.[0-9]+', 'v\\1.\\2') }}
 
-- name: "Add gpg key (Ubuntu)"
+- name: "Add gpg key ({{ ansible_distribution }})"
   apt_key:
     url: "https://pkgs.k8s.io/core:/stable:/{{ k8s_stable_release }}/deb/Release.key"
     state: present
-  when: ansible_distribution == "Ubuntu"
+  when: ansible_os_family == "Debian"
 
-- name: "Add kubernetes source list (Ubuntu)"
+- name: "Add kubernetes source list ({{ ansible_distribution }})"
   apt_repository:
     repo: "deb https://pkgs.k8s.io/core:/stable:/{{ k8s_stable_release }}/deb/ /"
     state: present
     filename: "kubernetes"
-  when: ansible_distribution == "Ubuntu"
+  when: ansible_os_family == "Debian"
 
-- name: "Update the repository cache (Ubuntu)"
+- name: "Update the repository cache ({{ ansible_distribution }})"
   apt:
     update_cache: yes
-  when: ansible_distribution == "Ubuntu"
+  when: ansible_os_family == "Debian"
 
 - name: "Add Kubernetes repository and install gpg key (CentOS)"
   yum_repository:
@@ -52,7 +52,7 @@
     - kubectl
   when: ansible_distribution == "CentOS"
 
-- name: "Install kubelet, kubeadm, kubectl (Ubuntu)"
+- name: "Install kubelet, kubeadm, kubectl ({{ ansible_distribution }})"
   apt:
     name: "{{item}}"
     state: present
@@ -60,4 +60,4 @@
     - kubelet
     - kubeadm
     - kubectl
-  when: ansible_distribution == "Ubuntu"
+  when: ansible_os_family == "Debian"


### PR DESCRIPTION
Fix existing ansible playbook for Ubuntu:
* change k8s apt repositories to follow k8s instructions (cf. https://kubernetes.io/blog/2023/08/31/legacy-package-repository-deprecation/)
* fix wrong path for kubelet service

Extend existing playbook to work with debian distribution.