### PR TITLE
update to go1.21.3, go1.20.10

### DIFF
--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.21.2"
+          go-version: "1.21.3"
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.21.1"
+          go-version: "1.21.2"
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 env:
   # Go version we currently use to build containerd across all CI.
   # Note: don't forget to update `Binaries` step, as it contains the matrix of all supported Go versions.
-  GO_VERSION: "1.21.2"
+  GO_VERSION: "1.21.3"
 
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read
@@ -209,7 +209,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, macos-12, windows-2019, windows-2022]
-        go-version: ["1.20.9", "1.21.2"]
+        go-version: ["1.20.10", "1.21.3"]
     steps:
       - uses: actions/setup-go@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 env:
   # Go version we currently use to build containerd across all CI.
   # Note: don't forget to update `Binaries` step, as it contains the matrix of all supported Go versions.
-  GO_VERSION: "1.21.1"
+  GO_VERSION: "1.21.2"
 
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read
@@ -209,7 +209,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, macos-12, windows-2019, windows-2022]
-        go-version: ["1.20.8", "1.21.1"]
+        go-version: ["1.20.9", "1.21.2"]
     steps:
       - uses: actions/setup-go@v4
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.21.2
+          go-version: 1.21.3
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.21.1
+          go-version: 1.21.2
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.21.1"
+          go-version: "1.21.2"
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.21.2"
+          go-version: "1.21.3"
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,7 +7,7 @@ on:
       - ".github/workflows/nightly.yml"
 
 env:
-  GO_VERSION: "1.21.1"
+  GO_VERSION: "1.21.2"
 
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,7 +7,7 @@ on:
       - ".github/workflows/nightly.yml"
 
 env:
-  GO_VERSION: "1.21.2"
+  GO_VERSION: "1.21.3"
 
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 name: Release
 
 env:
-  GO_VERSION: "1.21.2"
+  GO_VERSION: "1.21.3"
 
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 name: Release
 
 env:
-  GO_VERSION: "1.21.1"
+  GO_VERSION: "1.21.2"
 
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -104,7 +104,7 @@ EOF
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.21.1",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.21.2",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -104,7 +104,7 @@ EOF
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.21.2",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.21.3",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -29,7 +29,7 @@
 #   docker run --privileged containerd-test
 # ------------------------------------------------------------------------------
 
-ARG GOLANG_VERSION=1.21.2
+ARG GOLANG_VERSION=1.21.3
 ARG GOLANG_IMAGE=golang
 
 FROM ${GOLANG_IMAGE}:${GOLANG_VERSION} AS golang

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -29,7 +29,7 @@
 #   docker run --privileged containerd-test
 # ------------------------------------------------------------------------------
 
-ARG GOLANG_VERSION=1.21.1
+ARG GOLANG_VERSION=1.21.2
 ARG GOLANG_IMAGE=golang
 
 FROM ${GOLANG_IMAGE}:${GOLANG_VERSION} AS golang

--- a/contrib/fuzz/oss_fuzz_build.sh
+++ b/contrib/fuzz/oss_fuzz_build.sh
@@ -43,11 +43,11 @@ go run main.go $SRC/containerd/images
 
 apt-get update && apt-get install -y wget
 cd $SRC
-wget --quiet https://go.dev/dl/go1.21.2.linux-amd64.tar.gz
+wget --quiet https://go.dev/dl/go1.21.3.linux-amd64.tar.gz
 
 mkdir temp-go
 rm -rf /root/.go/*
-tar -C temp-go/ -xzf go1.21.2.linux-amd64.tar.gz
+tar -C temp-go/ -xzf go1.21.3.linux-amd64.tar.gz
 mv temp-go/go/* /root/.go/
 cd $SRC/containerd
 

--- a/contrib/fuzz/oss_fuzz_build.sh
+++ b/contrib/fuzz/oss_fuzz_build.sh
@@ -43,11 +43,11 @@ go run main.go $SRC/containerd/images
 
 apt-get update && apt-get install -y wget
 cd $SRC
-wget --quiet https://go.dev/dl/go1.21.1.linux-amd64.tar.gz
+wget --quiet https://go.dev/dl/go1.21.2.linux-amd64.tar.gz
 
 mkdir temp-go
 rm -rf /root/.go/*
-tar -C temp-go/ -xzf go1.21.1.linux-amd64.tar.gz
+tar -C temp-go/ -xzf go1.21.2.linux-amd64.tar.gz
 mv temp-go/go/* /root/.go/
 cd $SRC/containerd
 

--- a/script/setup/prepare_env_windows.ps1
+++ b/script/setup/prepare_env_windows.ps1
@@ -5,7 +5,7 @@
 # lived test environment.
 Set-MpPreference -DisableRealtimeMonitoring:$true
 
-$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.21.2"; make = ""; nssm = "" }
+$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.21.3"; make = ""; nssm = "" }
 
 Write-Host "Downloading chocolatey package"
 curl.exe -L "https://packages.chocolatey.org/chocolatey.0.10.15.nupkg" -o 'c:\choco.zip'

--- a/script/setup/prepare_env_windows.ps1
+++ b/script/setup/prepare_env_windows.ps1
@@ -5,7 +5,7 @@
 # lived test environment.
 Set-MpPreference -DisableRealtimeMonitoring:$true
 
-$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.21.1"; make = ""; nssm = "" }
+$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.21.2"; make = ""; nssm = "" }
 
 Write-Host "Downloading chocolatey package"
 curl.exe -L "https://packages.chocolatey.org/chocolatey.0.10.15.nupkg" -o 'c:\choco.zip'


### PR DESCRIPTION
### update to go1.21.2, go1.20.9

go1.21.2 (released 2023-10-05) includes one security fixes to the cmd/go package,
as well as bug fixes to the compiler, the go command, the linker, the runtime,
and the runtime/metrics package. See the Go 1.21.2 milestone on our issue
tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.21.2+label%3ACherryPickApproved

full diff: https://github.com/golang/go/compare/go1.21.1...go1.21.2


From the security mailing:

[security] Go 1.21.2 and Go 1.20.9 are released

Hello gophers,

We have just released Go versions 1.21.2 and 1.20.9, minor point releases.

These minor releases include 1 security fixes following the security policy:

- cmd/go: line directives allows arbitrary execution during build

  "//line" directives can be used to bypass the restrictions on "//go:cgo_"
  directives, allowing blocked linker and compiler flags to be passed during
  compliation. This can result in unexpected execution of arbitrary code when
  running "go build". The line directive requires the absolute path of the file in
  which the directive lives, which makes exploting this issue significantly more
  complex.

  This is CVE-2023-39323 and Go issue https://go.dev/issue/63211.

-----

### update to go1.21.3. gp1.20.10

go1.21.3 (released 2023-10-10) includes a security fix to the net/http package.
See the Go 1.21.3 milestone on our issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.21.3+label%3ACherryPickApproved

full diff: https://github.com/golang/go/compare/go1.21.2...go1.21.3


From the security mailing:

[security] Go 1.21.3 and Go 1.20.10 are released

Hello gophers,

We have just released Go versions 1.21.3 and 1.20.10, minor point releases.

These minor releases include 1 security fixes following the security policy:

- net/http: rapid stream resets can cause excessive work

  A malicious HTTP/2 client which rapidly creates requests and
  immediately resets them can cause excessive server resource consumption.
  While the total number of requests is bounded to the
  http2.Server.MaxConcurrentStreams setting, resetting an in-progress
  request allows the attacker to create a new request while the existing
  one is still executing.
  
  HTTP/2 servers now bound the number of simultaneously executing
  handler goroutines to the stream concurrency limit. New requests
  arriving when at the limit (which can only happen after the client
  has reset an existing, in-flight request) will be queued until a
  handler exits. If the request queue grows too large, the server
  will terminate the connection.
  
  This issue is also fixed in golang.org/x/net/http2 v0.17.0,
  for users manually configuring HTTP/2.
  
  The default stream concurrency limit is 250 streams (requests)
  per HTTP/2 connection. This value may be adjusted using the
  golang.org/x/net/http2 package; see the Server.MaxConcurrentStreams
  setting and the ConfigureServer function.
  
  This is CVE-2023-39325 and Go issue https://go.dev/issue/63417.
  This is also tracked by CVE-2023-44487.