### PR TITLE
Exit shim when shutdown manager is done

### DIFF
--- a/runtime/v2/shim/shim.go
+++ b/runtime/v2/shim/shim.go
@@ -377,7 +377,7 @@ func run(ctx context.Context, manager Manager, name string, config Config) error
 	}
 
 	if err := serve(ctx, server, signals, sd.Shutdown); err != nil {
-		if err != shutdown.ErrShutdown {
+		if !errors.Is(err, shutdown.ErrShutdown) {
 			return err
 		}
 	}
@@ -389,10 +389,10 @@ func run(ctx context.Context, manager Manager, name string, config Config) error
 	}
 
 	select {
-	case <-publisher.Done():
+	case <-sd.Done():
 		return nil
 	case <-time.After(5 * time.Second):
-		return errors.New("publisher not closed")
+		return errors.New("shim shutdown timeout")
 	}
 }
 


### PR DESCRIPTION
In current implementation we exit shim entry point when publisher gets closed.

This behavior will ignore all remaining callbacks registered in shutdown manager.
Instead we should wait for shutdown manager to finish execing all callbacks and only after that exit the shim process.