### PR TITLE
deprecated: go-plugin library as runtime plugin

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -406,6 +406,7 @@ The deprecated features are shown in the following table:
 | Pulling Schema 1 images (`application/vnd.docker.distribution.manifest.v1+json`) | containerd v1.7     | containerd v2.0            | Use Schema 2 or OCI images               |
 | CRI `v1alpha2`                                                                   | containerd v1.7     | containerd v2.0 ✅         | Use CRI `v1`                             |
 | Legacy CRI implementation of podsandbox support                                  | containerd v2.0     | containerd v2.0 ✅         |                                          |
+| Go-Plugin library (`*.so`) as containerd runtime plugin                          | containerd v2.0     | containerd v2.1            | Use external plugins (proxy or binary)   |
 
 
 ### Deprecated config properties

--- a/services/server/config/config.go
+++ b/services/server/config/config.go
@@ -63,6 +63,8 @@ type Config struct {
 	// TempDir is the path to a directory where to place containerd temporary files
 	TempDir string `toml:"temp"`
 	// PluginDir is the directory for dynamic plugins to be stored
+	//
+	// Deprecated: Please use proxy or binary external plugins.
 	PluginDir string `toml:"plugin_dir"`
 	// GRPC configuration settings
 	GRPC GRPCConfig `toml:"grpc"`

--- a/services/server/server.go
+++ b/services/server/server.go
@@ -431,10 +431,11 @@ func (s *Server) Wait() {
 // of all plugins.
 func LoadPlugins(ctx context.Context, config *srvconfig.Config) ([]plugin.Registration, error) {
 	// load all plugins into containerd
-	path := config.PluginDir
+	path := config.PluginDir //nolint: staticcheck
 	if path == "" {
 		path = filepath.Join(config.Root, "plugins")
 	}
+	log.G(ctx).Warning("`go_plugin` is deprecated, please use `external plugins` instead")
 	if err := dynamic.Load(path); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We, containerd, suggest user to use binary plugins or RPC-based plugins. Since go plugin has too many restrictions, I'm not sure that how many users use the go plugin to extend the core function in the production.

Based on the fact that we put a lot of effort to make external plugins better, suggest to deprecate go-plugin type plugin in v2.0 and remove it in v2.1

REF: https://github.com/containerd/containerd/pull/556