### PR TITLE
Add exports to proxy plugin config

### DIFF
--- a/services/server/config/config.go
+++ b/services/server/config/config.go
@@ -235,9 +235,10 @@ type CgroupConfig struct {
 
 // ProxyPlugin provides a proxy plugin configuration
 type ProxyPlugin struct {
-	Type     string `toml:"type"`
-	Address  string `toml:"address"`
-	Platform string `toml:"platform"`
+	Type     string            `toml:"type"`
+	Address  string            `toml:"address"`
+	Platform string            `toml:"platform"`
+	Exports  map[string]string `toml:"exports"`
 }
 
 // Decode unmarshals a plugin specific configuration by plugin id

--- a/services/server/server.go
+++ b/services/server/server.go
@@ -491,11 +491,17 @@ func LoadPlugins(ctx context.Context, config *srvconfig.Config) ([]plugin.Regist
 			p = platforms.DefaultSpec()
 		}
 
+		exports := pp.Exports
+		if exports == nil {
+			exports = map[string]string{}
+		}
+		exports["address"] = address
+
 		registry.Register(&plugin.Registration{
 			Type: t,
 			ID:   name,
 			InitFn: func(ic *plugin.InitContext) (interface{}, error) {
-				ic.Meta.Exports["address"] = address
+				ic.Meta.Exports = exports
 				ic.Meta.Platforms = append(ic.Meta.Platforms, p)
 				conn, err := clients.getClient(address)
 				if err != nil {


### PR DESCRIPTION
Allows external plugins to define exports.

Relevant for allowing external snapshotters to indicate the root directory such as for #9216 