### PR TITLE
replace some hardcoded strings with ocispec consts

### DIFF
--- a/images/archive/exporter.go
+++ b/images/archive/exporter.go
@@ -320,10 +320,9 @@ func blobRecord(cs content.Provider, desc ocispec.Descriptor, opts *blobRecordOp
 	if opts != nil && opts.blobFilter != nil && !opts.blobFilter(desc) {
 		return tarRecord{}
 	}
-	path := path.Join("blobs", desc.Digest.Algorithm().String(), desc.Digest.Encoded())
 	return tarRecord{
 		Header: &tar.Header{
-			Name:     path,
+			Name:     path.Join(ocispec.ImageBlobsDir, desc.Digest.Algorithm().String(), desc.Digest.Encoded()),
 			Mode:     0444,
 			Size:     desc.Size,
 			Typeflag: tar.TypeReg,
@@ -403,7 +402,7 @@ func ociIndexRecord(manifests []ocispec.Descriptor) tarRecord {
 
 	return tarRecord{
 		Header: &tar.Header{
-			Name:     "index.json",
+			Name:     ocispec.ImageIndexFile,
 			Mode:     0644,
 			Size:     int64(len(b)),
 			Typeflag: tar.TypeReg,
@@ -443,10 +442,9 @@ func manifestsRecord(ctx context.Context, store content.Provider, manifests map[
 		if err := dgst.Validate(); err != nil {
 			return tarRecord{}, err
 		}
-		mfsts[i].Config = path.Join("blobs", dgst.Algorithm().String(), dgst.Encoded())
+		mfsts[i].Config = path.Join(ocispec.ImageBlobsDir, dgst.Algorithm().String(), dgst.Encoded())
 		for _, l := range manifest.Layers {
-			path := path.Join("blobs", l.Digest.Algorithm().String(), l.Digest.Encoded())
-			mfsts[i].Layers = append(mfsts[i].Layers, path)
+			mfsts[i].Layers = append(mfsts[i].Layers, path.Join(ocispec.ImageBlobsDir, l.Digest.Algorithm().String(), l.Digest.Encoded()))
 		}
 
 		for _, name := range m.names {

--- a/images/archive/importer.go
+++ b/images/archive/importer.go
@@ -133,7 +133,7 @@ func ImportIndex(ctx context.Context, store content.Store, reader io.Reader, opt
 			return ocispec.Descriptor{}, fmt.Errorf("unsupported OCI version %s", ociLayout.Version)
 		}
 
-		idx, ok := blobs["index.json"]
+		idx, ok := blobs[ocispec.ImageIndexFile]
 		if !ok {
 			return ocispec.Descriptor{}, fmt.Errorf("missing index.json in OCI layout %s", ocispec.ImageLayoutVersion)
 		}

--- a/integration/client/export_test.go
+++ b/integration/client/export_test.go
@@ -171,10 +171,10 @@ func assertOCITar(t *testing.T, r io.Reader, docker bool) {
 			t.Error(err)
 			continue
 		}
-		if h.Name == "oci-layout" {
+		if h.Name == ocispec.ImageLayoutFile {
 			foundOCILayout = true
 		}
-		if h.Name == "index.json" {
+		if h.Name == ocispec.ImageIndexFile {
 			foundIndexJSON = true
 		}
 		if h.Name == "manifest.json" {

--- a/integration/client/import_test.go
+++ b/integration/client/import_test.go
@@ -260,19 +260,19 @@ func TestImport(t *testing.T) {
 		{
 			Name: "OCI-BadFormat",
 			Writer: tartest.TarAll(
-				tc.File("oci-layout", []byte(`{"imageLayoutVersion":"2.0.0"}`), 0644),
+				tc.File(ocispec.ImageLayoutFile, []byte(`{"imageLayoutVersion":"2.0.0"}`), 0644),
 			),
 		},
 		{
 			Name: "OCI",
 			Writer: tartest.TarAll(
-				tc.Dir("blobs", 0755),
-				tc.Dir("blobs/sha256", 0755),
-				tc.File("blobs/sha256/"+d1.Encoded(), b1, 0644),
-				tc.File("blobs/sha256/"+d2.Encoded(), c1, 0644),
-				tc.File("blobs/sha256/"+d3.Encoded(), m1, 0644),
-				tc.File("index.json", createIndex(m1, "latest", "docker.io/lib/img:ok"), 0644),
-				tc.File("oci-layout", []byte(`{"imageLayoutVersion":"1.0.0"}`), 0644),
+				tc.Dir(ocispec.ImageBlobsDir, 0755),
+				tc.Dir(ocispec.ImageBlobsDir+"/sha256", 0755),
+				tc.File(ocispec.ImageBlobsDir+"/sha256/"+d1.Encoded(), b1, 0644),
+				tc.File(ocispec.ImageBlobsDir+"/sha256/"+d2.Encoded(), c1, 0644),
+				tc.File(ocispec.ImageBlobsDir+"/sha256/"+d3.Encoded(), m1, 0644),
+				tc.File(ocispec.ImageIndexFile, createIndex(m1, "latest", "docker.io/lib/img:ok"), 0644),
+				tc.File(ocispec.ImageLayoutFile, []byte(`{"imageLayoutVersion":"`+ocispec.ImageLayoutVersion+`"}`), 0644),
 			),
 			Check: func(t *testing.T, imgs []images.Image) {
 				names := []string{
@@ -287,13 +287,13 @@ func TestImport(t *testing.T) {
 		{
 			Name: "OCIPrefixName",
 			Writer: tartest.TarAll(
-				tc.Dir("blobs", 0755),
-				tc.Dir("blobs/sha256", 0755),
-				tc.File("blobs/sha256/"+d1.Encoded(), b1, 0644),
-				tc.File("blobs/sha256/"+d2.Encoded(), c1, 0644),
-				tc.File("blobs/sha256/"+d3.Encoded(), m1, 0644),
-				tc.File("index.json", createIndex(m1, "latest", "docker.io/lib/img:ok"), 0644),
-				tc.File("oci-layout", []byte(`{"imageLayoutVersion":"1.0.0"}`), 0644),
+				tc.Dir(ocispec.ImageBlobsDir, 0755),
+				tc.Dir(ocispec.ImageBlobsDir+"/sha256", 0755),
+				tc.File(ocispec.ImageBlobsDir+"/sha256/"+d1.Encoded(), b1, 0644),
+				tc.File(ocispec.ImageBlobsDir+"/sha256/"+d2.Encoded(), c1, 0644),
+				tc.File(ocispec.ImageBlobsDir+"/sha256/"+d3.Encoded(), m1, 0644),
+				tc.File(ocispec.ImageIndexFile, createIndex(m1, "latest", "docker.io/lib/img:ok"), 0644),
+				tc.File(ocispec.ImageLayoutFile, []byte(`{"imageLayoutVersion":"`+ocispec.ImageLayoutVersion+`"}`), 0644),
 			),
 			Check: func(t *testing.T, imgs []images.Image) {
 				names := []string{
@@ -311,13 +311,13 @@ func TestImport(t *testing.T) {
 		{
 			Name: "OCIPrefixName2",
 			Writer: tartest.TarAll(
-				tc.Dir("blobs", 0755),
-				tc.Dir("blobs/sha256", 0755),
-				tc.File("blobs/sha256/"+d1.Encoded(), b1, 0644),
-				tc.File("blobs/sha256/"+d2.Encoded(), c1, 0644),
-				tc.File("blobs/sha256/"+d3.Encoded(), m1, 0644),
-				tc.File("index.json", createIndex(m1, "latest", "localhost:5000/myimage:old", "docker.io/lib/img:ok"), 0644),
-				tc.File("oci-layout", []byte(`{"imageLayoutVersion":"1.0.0"}`), 0644),
+				tc.Dir(ocispec.ImageBlobsDir, 0755),
+				tc.Dir(ocispec.ImageBlobsDir+"/sha256", 0755),
+				tc.File(ocispec.ImageBlobsDir+"/sha256/"+d1.Encoded(), b1, 0644),
+				tc.File(ocispec.ImageBlobsDir+"/sha256/"+d2.Encoded(), c1, 0644),
+				tc.File(ocispec.ImageBlobsDir+"/sha256/"+d3.Encoded(), m1, 0644),
+				tc.File(ocispec.ImageIndexFile, createIndex(m1, "latest", "localhost:5000/myimage:old", "docker.io/lib/img:ok"), 0644),
+				tc.File(ocispec.ImageLayoutFile, []byte(`{"imageLayoutVersion":"`+ocispec.ImageLayoutVersion+`"}`), 0644),
 			),
 			Check: func(t *testing.T, imgs []images.Image) {
 				names := []string{
@@ -530,14 +530,14 @@ func TestTransferImport(t *testing.T) {
 		t.Run(testCase.Name, func(t *testing.T) {
 			tc := tartest.TarContext{}
 			files := []tartest.WriterToTar{
-				tc.Dir("blobs", 0755),
-				tc.Dir("blobs/sha256", 0755),
+				tc.Dir(ocispec.ImageBlobsDir, 0755),
+				tc.Dir(ocispec.ImageBlobsDir+"/sha256", 0755),
 			}
 
 			descs, tws := createImages(tc, testCase.Images...)
 			files = append(files, tws...)
 
-			files = append(files, tc.File("oci-layout", []byte(`{"imageLayoutVersion":"1.0.0"}`), 0644))
+			files = append(files, tc.File(ocispec.ImageLayoutFile, []byte(`{"imageLayoutVersion":"`+ocispec.ImageLayoutVersion+`"}`), 0644))
 
 			r := tartest.TarFromWriterTo(tartest.TarAll(files...))
 
@@ -629,13 +629,13 @@ func createImages(tc tartest.TarContext, imageNames ...string) (descs map[string
 			}
 			seed := hash64(image)
 			bb, b := createContent(128, seed)
-			tw = append(tw, tc.File("blobs/sha256/"+b.Encoded(), bb, 0644))
+			tw = append(tw, tc.File(ocispec.ImageBlobsDir+"/sha256/"+b.Encoded(), bb, 0644))
 
 			cb, c := createConfig("linux", "amd64", image)
-			tw = append(tw, tc.File("blobs/sha256/"+c.Encoded(), cb, 0644))
+			tw = append(tw, tc.File(ocispec.ImageBlobsDir+"/sha256/"+c.Encoded(), cb, 0644))
 
 			mb, m, _ := createManifest(cb, [][]byte{bb})
-			tw = append(tw, tc.File("blobs/sha256/"+m.Encoded(), mb, 0644))
+			tw = append(tw, tc.File(ocispec.ImageBlobsDir+"/sha256/"+m.Encoded(), mb, 0644))
 
 			annotations := map[string]string{}
 			if image != "" {
@@ -671,7 +671,7 @@ func createImages(tc tartest.TarContext, imageNames ...string) (descs map[string
 		Size:      int64(len(ib)),
 		MediaType: ocispec.MediaTypeImageIndex,
 	}
-	tw = append(tw, tc.File("index.json", ib, 0644))
+	tw = append(tw, tc.File(ocispec.ImageIndexFile, ib, 0644))
 
 	var idxName string
 	if len(imageNames) > 0 {


### PR DESCRIPTION
- depends on https://github.com/containerd/containerd/pull/9251

### vendor: github.com/opencontainers/image-spec v1.1.0-rc5

full diff: https://github.com/opencontainers/image-spec/compare/v1.1.0-rc4...v1.1.0-rc5

### images/archive: replace hardcoded strings for OCI-spec consts

### integration/client: replace hardcoded strings for OCI-spec consts