### PR TITLE
refactor labels used in cri server

### DIFF
--- a/pkg/cri/labels/labels.go
+++ b/pkg/cri/labels/labels.go
@@ -35,4 +35,6 @@ const (
 	ContainerKindContainer = "container"
 	// ContainerMetadataExtension is an extension name that identify metadata of container in CreateContainerRequest
 	ContainerMetadataExtension = criContainerdPrefix + ".container.metadata"
+	// SandboxMetadataExtension is an extension name that identify metadata of sandbox in CreateContainerRequest
+	SandboxMetadataExtension = criContainerdPrefix + ".sandbox.metadata"
 )

--- a/pkg/cri/labels/labels.go
+++ b/pkg/cri/labels/labels.go
@@ -27,4 +27,12 @@ const (
 	PinnedImageLabelKey = criContainerdPrefix + ".pinned"
 	// PinnedImageLabelValue is the label value indicating the image is pinned.
 	PinnedImageLabelValue = "pinned"
+	// ContainerKindLabel is a label key indicating container is sandbox container or application container
+	ContainerKindLabel = criContainerdPrefix + ".kind"
+	// ContainerKindSandbox is a label value indicating container is sandbox container
+	ContainerKindSandbox = "sandbox"
+	// ContainerKindContainer is a label value indicating container is application container
+	ContainerKindContainer = "container"
+	// ContainerMetadataExtension is an extension name that identify metadata of container in CreateContainerRequest
+	ContainerMetadataExtension = criContainerdPrefix + ".container.metadata"
 )

--- a/pkg/cri/server/container_create.go
+++ b/pkg/cri/server/container_create.go
@@ -40,6 +40,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/cri/annotations"
 	criconfig "github.com/containerd/containerd/v2/pkg/cri/config"
 	cio "github.com/containerd/containerd/v2/pkg/cri/io"
+	crilabels "github.com/containerd/containerd/v2/pkg/cri/labels"
 	customopts "github.com/containerd/containerd/v2/pkg/cri/opts"
 	containerstore "github.com/containerd/containerd/v2/pkg/cri/store/container"
 	"github.com/containerd/containerd/v2/pkg/cri/util"
@@ -260,7 +261,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 		return nil, fmt.Errorf("failed to get container spec opts: %w", err)
 	}
 
-	containerLabels := buildLabels(config.Labels, image.ImageSpec.Config.Labels, containerKindContainer)
+	containerLabels := buildLabels(config.Labels, image.ImageSpec.Config.Labels, crilabels.ContainerKindContainer)
 
 	sandboxInfo, err := c.client.SandboxStore().Get(ctx, sandboxID)
 	if err != nil {
@@ -271,7 +272,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 		containerd.WithSpec(spec, specOpts...),
 		containerd.WithRuntime(sandboxInfo.Runtime.Name, sandboxInfo.Runtime.Options),
 		containerd.WithContainerLabels(containerLabels),
-		containerd.WithContainerExtension(containerMetadataExtension, &meta),
+		containerd.WithContainerExtension(crilabels.ContainerMetadataExtension, &meta),
 	)
 
 	opts = append(opts, containerd.WithSandbox(sandboxID))

--- a/pkg/cri/server/helpers.go
+++ b/pkg/cri/server/helpers.go
@@ -38,6 +38,7 @@ import (
 	"github.com/containerd/containerd/v2/errdefs"
 	clabels "github.com/containerd/containerd/v2/labels"
 	criconfig "github.com/containerd/containerd/v2/pkg/cri/config"
+	crilabels "github.com/containerd/containerd/v2/pkg/cri/labels"
 	containerstore "github.com/containerd/containerd/v2/pkg/cri/store/container"
 	imagestore "github.com/containerd/containerd/v2/pkg/cri/store/image"
 	runtimeoptions "github.com/containerd/containerd/v2/pkg/runtimeoptions/v1"
@@ -70,18 +71,6 @@ const (
 	containersDir = "containers"
 	// Delimiter used to construct container/sandbox names.
 	nameDelimiter = "_"
-
-	// criContainerdPrefix is common prefix for cri-containerd
-	criContainerdPrefix = "io.cri-containerd"
-	// containerKindLabel is a label key indicating container is sandbox container or application container
-	containerKindLabel = criContainerdPrefix + ".kind"
-	// containerKindSandbox is a label value indicating container is sandbox container
-	containerKindSandbox = "sandbox"
-	// containerKindContainer is a label value indicating container is application container
-	containerKindContainer = "container"
-
-	// containerMetadataExtension is an extension name that identify metadata of container in CreateContainerRequest
-	containerMetadataExtension = criContainerdPrefix + ".container.metadata"
 
 	// defaultIfName is the default network interface for the pods
 	defaultIfName = "eth0"
@@ -257,7 +246,7 @@ func buildLabels(configLabels, imageConfigLabels map[string]string, containerTyp
 	for k, v := range configLabels {
 		labels[k] = v
 	}
-	labels[containerKindLabel] = containerType
+	labels[crilabels.ContainerKindLabel] = containerType
 	return labels
 }
 

--- a/pkg/cri/server/helpers_test.go
+++ b/pkg/cri/server/helpers_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containerd/containerd/v2/containers"
 	"github.com/containerd/containerd/v2/oci"
 	criconfig "github.com/containerd/containerd/v2/pkg/cri/config"
+	crilabels "github.com/containerd/containerd/v2/pkg/cri/labels"
 	containerstore "github.com/containerd/containerd/v2/pkg/cri/store/container"
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/containerd/v2/protobuf/types"
@@ -99,16 +100,16 @@ func TestBuildLabels(t *testing.T) {
 		"a": "b",
 		"c": "d",
 	}
-	newLabels := buildLabels(configLabels, imageConfigLabels, containerKindSandbox)
+	newLabels := buildLabels(configLabels, imageConfigLabels, crilabels.ContainerKindSandbox)
 	assert.Len(t, newLabels, 4)
 	assert.Equal(t, "b", newLabels["a"])
 	assert.Equal(t, "d", newLabels["c"])
 	assert.Equal(t, "y", newLabels["d"])
-	assert.Equal(t, containerKindSandbox, newLabels[containerKindLabel])
+	assert.Equal(t, crilabels.ContainerKindSandbox, newLabels[crilabels.ContainerKindLabel])
 	assert.NotContains(t, newLabels, "long-label")
 
 	newLabels["a"] = "e"
-	assert.Empty(t, configLabels[containerKindLabel], "should not add new labels into original label")
+	assert.Empty(t, configLabels[crilabels.ContainerKindLabel], "should not add new labels into original label")
 	assert.Equal(t, "b", configLabels["a"], "change in new labels should not affect original label")
 }
 

--- a/pkg/cri/server/nri.go
+++ b/pkg/cri/server/nri.go
@@ -18,6 +18,7 @@ package server
 
 import (
 	criconfig "github.com/containerd/containerd/v2/pkg/cri/config"
+	crilabels "github.com/containerd/containerd/v2/pkg/cri/labels"
 	cstore "github.com/containerd/containerd/v2/pkg/cri/store/container"
 	sstore "github.com/containerd/containerd/v2/pkg/cri/store/sandbox"
 )
@@ -39,5 +40,5 @@ func (i *criImplementation) ContainerStore() *cstore.Store {
 }
 
 func (i *criImplementation) ContainerMetadataExtensionKey() string {
-	return containerMetadataExtension
+	return crilabels.ContainerMetadataExtension
 }

--- a/pkg/cri/server/podsandbox/helpers.go
+++ b/pkg/cri/server/podsandbox/helpers.go
@@ -28,6 +28,7 @@ import (
 	clabels "github.com/containerd/containerd/v2/labels"
 	"github.com/containerd/containerd/v2/oci"
 	criconfig "github.com/containerd/containerd/v2/pkg/cri/config"
+	crilabels "github.com/containerd/containerd/v2/pkg/cri/labels"
 	imagestore "github.com/containerd/containerd/v2/pkg/cri/store/image"
 	ctrdutil "github.com/containerd/containerd/v2/pkg/cri/util"
 	"github.com/containerd/log"
@@ -43,14 +44,6 @@ const (
 	// directory of the sandbox, all files created for the sandbox will be
 	// placed under this directory.
 	sandboxesDir = "sandboxes"
-	// criContainerdPrefix is common prefix for cri-containerd
-	criContainerdPrefix = "io.cri-containerd"
-	// containerKindLabel is a label key indicating container is sandbox container or application container
-	containerKindLabel = criContainerdPrefix + ".kind"
-	// containerKindSandbox is a label value indicating container is sandbox container
-	containerKindSandbox = "sandbox"
-	// sandboxMetadataExtension is an extension name that identify metadata of sandbox in CreateContainerRequest
-	sandboxMetadataExtension = criContainerdPrefix + ".sandbox.metadata"
 	// MetadataKey is the key used for storing metadata in the sandbox extensions
 	MetadataKey = "metadata"
 )
@@ -117,7 +110,7 @@ func buildLabels(configLabels, imageConfigLabels map[string]string, containerTyp
 	for k, v := range configLabels {
 		labels[k] = v
 	}
-	labels[containerKindLabel] = containerType
+	labels[crilabels.ContainerKindLabel] = containerType
 	return labels
 }
 

--- a/pkg/cri/server/podsandbox/helpers_test.go
+++ b/pkg/cri/server/podsandbox/helpers_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/containerd/containerd/v2/oci"
+	crilabels "github.com/containerd/containerd/v2/pkg/cri/labels"
 	docker "github.com/distribution/reference"
 	imagedigest "github.com/opencontainers/go-digest"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
@@ -85,16 +86,16 @@ func TestBuildLabels(t *testing.T) {
 		"a": "b",
 		"c": "d",
 	}
-	newLabels := buildLabels(configLabels, imageConfigLabels, containerKindSandbox)
+	newLabels := buildLabels(configLabels, imageConfigLabels, crilabels.ContainerKindSandbox)
 	assert.Len(t, newLabels, 4)
 	assert.Equal(t, "b", newLabels["a"])
 	assert.Equal(t, "d", newLabels["c"])
 	assert.Equal(t, "y", newLabels["d"])
-	assert.Equal(t, containerKindSandbox, newLabels[containerKindLabel])
+	assert.Equal(t, crilabels.ContainerKindSandbox, newLabels[crilabels.ContainerKindLabel])
 	assert.NotContains(t, newLabels, "long-label")
 
 	newLabels["a"] = "e"
-	assert.Empty(t, configLabels[containerKindLabel], "should not add new labels into original label")
+	assert.Empty(t, configLabels[crilabels.ContainerKindLabel], "should not add new labels into original label")
 	assert.Equal(t, "b", configLabels["a"], "change in new labels should not affect original label")
 }
 

--- a/pkg/cri/server/podsandbox/recover.go
+++ b/pkg/cri/server/podsandbox/recover.go
@@ -28,6 +28,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/errdefs"
+	crilabels "github.com/containerd/containerd/v2/pkg/cri/labels"
 	sandboxstore "github.com/containerd/containerd/v2/pkg/cri/store/sandbox"
 	ctrdutil "github.com/containerd/containerd/v2/pkg/cri/util"
 	"github.com/containerd/log"
@@ -55,9 +56,9 @@ func (c *Controller) RecoverContainer(ctx context.Context, cntr containerd.Conta
 	if err != nil {
 		return sandbox, fmt.Errorf("failed to get sandbox container extensions: %w", err)
 	}
-	ext, ok := exts[sandboxMetadataExtension]
+	ext, ok := exts[crilabels.SandboxMetadataExtension]
 	if !ok {
-		return sandbox, fmt.Errorf("metadata extension %q not found", sandboxMetadataExtension)
+		return sandbox, fmt.Errorf("metadata extension %q not found", crilabels.SandboxMetadataExtension)
 	}
 	data, err := typeurl.UnmarshalAny(ext)
 	if err != nil {

--- a/pkg/cri/server/podsandbox/sandbox_run.go
+++ b/pkg/cri/server/podsandbox/sandbox_run.go
@@ -34,6 +34,7 @@ import (
 	"github.com/containerd/containerd/v2/errdefs"
 	"github.com/containerd/containerd/v2/pkg/cri/annotations"
 	criconfig "github.com/containerd/containerd/v2/pkg/cri/config"
+	crilabels "github.com/containerd/containerd/v2/pkg/cri/labels"
 	customopts "github.com/containerd/containerd/v2/pkg/cri/opts"
 	sandboxstore "github.com/containerd/containerd/v2/pkg/cri/store/sandbox"
 	ctrdutil "github.com/containerd/containerd/v2/pkg/cri/util"
@@ -133,7 +134,7 @@ func (c *Controller) Start(ctx context.Context, id string) (cin sandbox.Controll
 		return cin, fmt.Errorf("failed to generate sandbox container spec options: %w", err)
 	}
 
-	sandboxLabels := buildLabels(config.Labels, image.ImageSpec.Config.Labels, containerKindSandbox)
+	sandboxLabels := buildLabels(config.Labels, image.ImageSpec.Config.Labels, crilabels.ContainerKindSandbox)
 
 	snapshotterOpt := []snapshots.Opt{snapshots.WithLabels(snapshots.FilterInheritedLabels(config.Annotations))}
 	extraSOpts, err := sandboxSnapshotterOpts(config)
@@ -147,7 +148,7 @@ func (c *Controller) Start(ctx context.Context, id string) (cin sandbox.Controll
 		customopts.WithNewSnapshot(id, containerdImage, snapshotterOpt...),
 		containerd.WithSpec(spec, specOpts...),
 		containerd.WithContainerLabels(sandboxLabels),
-		containerd.WithContainerExtension(sandboxMetadataExtension, &metadata),
+		containerd.WithContainerExtension(crilabels.SandboxMetadataExtension, &metadata),
 		containerd.WithRuntime(ociRuntime.Type, sandboxInfo.Runtime.Options),
 	}
 

--- a/pkg/cri/server/restart.go
+++ b/pkg/cri/server/restart.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containerd/containerd/v2/errdefs"
 	containerdimages "github.com/containerd/containerd/v2/images"
 	criconfig "github.com/containerd/containerd/v2/pkg/cri/config"
+	crilabels "github.com/containerd/containerd/v2/pkg/cri/labels"
 	"github.com/containerd/containerd/v2/pkg/cri/server/podsandbox"
 	"github.com/containerd/containerd/v2/pkg/netns"
 	"github.com/containerd/containerd/v2/platforms"
@@ -55,7 +56,7 @@ import (
 // recover recovers system state from containerd and status checkpoint.
 func (c *criService) recover(ctx context.Context) error {
 	// Recover all sandboxes.
-	sandboxes, err := c.client.Containers(ctx, filterLabel(containerKindLabel, containerKindSandbox))
+	sandboxes, err := c.client.Containers(ctx, filterLabel(crilabels.ContainerKindLabel, crilabels.ContainerKindSandbox))
 	if err != nil {
 		return fmt.Errorf("failed to list sandbox containers: %w", err)
 	}
@@ -146,7 +147,7 @@ func (c *criService) recover(ctx context.Context) error {
 	}
 
 	// Recover all containers.
-	containers, err := c.client.Containers(ctx, filterLabel(containerKindLabel, containerKindContainer))
+	containers, err := c.client.Containers(ctx, filterLabel(crilabels.ContainerKindLabel, crilabels.ContainerKindContainer))
 	if err != nil {
 		return fmt.Errorf("failed to list containers: %w", err)
 	}
@@ -248,9 +249,9 @@ func (c *criService) loadContainer(ctx context.Context, cntr containerd.Containe
 	if err != nil {
 		return container, fmt.Errorf("failed to get container extensions: %w", err)
 	}
-	ext, ok := exts[containerMetadataExtension]
+	ext, ok := exts[crilabels.ContainerMetadataExtension]
 	if !ok {
-		return container, fmt.Errorf("metadata extension %q not found", containerMetadataExtension)
+		return container, fmt.Errorf("metadata extension %q not found", crilabels.ContainerMetadataExtension)
 	}
 	data, err := typeurl.UnmarshalAny(ext)
 	if err != nil {


### PR DESCRIPTION
remove the duplication of labels used in cri/server and move them to a common package cri/labels