### PR TITLE
Initialize sandbox controller list on CRI server creation

### DIFF
--- a/pkg/cri/server/test_config.go
+++ b/pkg/cri/server/test_config.go
@@ -40,6 +40,7 @@ var testConfig = criconfig.Config{
 				"runc": {
 					Type:        "runc",
 					Snapshotter: "overlayfs",
+					Sandboxer:   "shim",
 				},
 			},
 		},


### PR DESCRIPTION
Avoid calling out to the client to get a sandbox controller and instead setup the list of controllers on initialization. This fixes a test failure which does not set the client.