### PR TITLE
pkg/cri: should ignore no sandbox bucket

### DIFF
--- a/metadata/sandbox.go
+++ b/metadata/sandbox.go
@@ -239,6 +239,9 @@ func (s *sandboxStore) Delete(ctx context.Context, id string) error {
 		}
 
 		if err := buckets.DeleteBucket([]byte(id)); err != nil {
+			if err == bbolt.ErrBucketNotFound {
+				err = errdefs.ErrNotFound
+			}
 			return fmt.Errorf("failed to delete sandbox %q: %w", id, err)
 		}
 

--- a/pkg/cri/server/sandbox_remove.go
+++ b/pkg/cri/server/sandbox_remove.go
@@ -105,7 +105,10 @@ func (c *criService) RemovePodSandbox(ctx context.Context, r *runtime.RemovePodS
 	c.sandboxStore.Delete(id)
 
 	if err := c.client.SandboxStore().Delete(ctx, id); err != nil {
-		return nil, fmt.Errorf("failed to remove sandbox metadata from store: %w", err)
+		if !errdefs.IsNotFound(err) {
+			return nil, fmt.Errorf("failed to remove sandbox metadata from store: %w", err)
+		}
+		log.G(ctx).WithError(err).Warnf("failed to delete sandbox metadata from store: %q maybe recovered from v1.x release", id)
 	}
 
 	// Release the sandbox name reserved for the sandbox.


### PR DESCRIPTION
The sandbox might be recovered from v1.x release. It doesn't have metadata bucket. We should ignore the not-found error.

How to reproduce the issue:

```bash
➜  containerd git:(main) sudo ctr version
Client:
  Version:  1.6.22
  Revision: 8165feabfdfe38c65b599c4993d227328c231fca
  Go version: go1.19.11

Server:
  Version:  1.6.22
  Revision: 8165feabfdfe38c65b599c4993d227328c231fca
  UUID: be4216aa-8a2e-4305-9186-efeacd2d9a17

➜  containerd git:(main) cat /tmp/pod.json
{
    "metadata": {
        "name": "nginx-sandbox",
        "namespace": "default",
        "attempt": 1,
        "uid": "hdishd83djaidwnduwk28bcsb"
    },
    "log_directory": "/tmp",
    "linux": {
    }
}

➜  containerd git:(main) sudo crictl runp /tmp/pod.json
616ea1cc657c57e80abf74e707a8177878ac2ec1ab7c346b4adb7bc0fadf986e
➜  containerd git:(main) sudo crictl pods
POD ID              CREATED             STATE               NAME                NAMESPACE           ATTEMPT             RUNTIME
616ea1cc657c5       9 seconds ago       Ready               nginx-sandbox       default             1                   (default)

➜  containerd git:(main) make BUILDTAGS=no_btrfs
➜  containerd git:(main) sudo PREFIX=/usr make install
+ install bin/ctr bin/containerd bin/containerd-stress bin/containerd-shim-runc-v2

➜  containerd git:(main) sudo systemctl restart containerd
➜  containerd git:(main) sudo ctr version
Client:
  Version:  v1.7.0-943-g980767551
  Revision: 9807675518e7ac399c730347c618348a2f4f365c
  Go version: go1.20.10

Server:
  Version:  v1.7.0-943-g980767551
  Revision: 9807675518e7ac399c730347c618348a2f4f365c
  UUID: be4216aa-8a2e-4305-9186-efeacd2d9a17

➜  containerd git:(main) sudo crictl stopp  616ea1cc657c5
Stopped sandbox 616ea1cc657c5

➜  containerd git:(main) sudo crictl rmp 616ea1cc657c5
E1019 14:03:37.885162 2052643 remote_runtime.go:295] "RemovePodSandbox from runtime service failed" err="rpc error: code = Unknown desc = failed to remove sandbox metadata from store: failed to delete sandbox \"616ea1cc657c57e80abf74e707a8177878ac2ec1ab7c346b4adb7bc0fadf986e\": bucket not found" podSandboxID="616ea1cc657c5"
removing the pod sandbox "616ea1cc657c5": rpc error: code = Unknown desc = failed to remove sandbox metadata from store: failed to delete sandbox "616ea1cc657c57e80abf74e707a8177878ac2ec1ab7c346b4adb7bc0fadf986e": bucket not found
```

REF: https://github.com/containerd/containerd/pull/9262