### PR TITLE
[release/1.7] Prepare release notes for v1.7.8

### DIFF
--- a/releases/v1.7.8.toml
+++ b/releases/v1.7.8.toml
@@ -1,0 +1,35 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.7.7"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The eighth patch release for containerd 1.7 contains various fixes and updates.
+
+### Notable Updates
+
+* **Fix ambiguous TLS fallback** ([#9299](https://github.com/containerd/containerd/pull/9299))
+* **Update Go to 1.20.10** ([#9265](https://github.com/containerd/containerd/pull/9265))
+* **Add a new image label on converted schema 1 images** ([#9252](https://github.com/containerd/containerd/pull/9252))
+* **Fix handling for missing basic auth credentials** ([#9235](https://github.com/containerd/containerd/pull/9235))
+* **Fix potential deadlock in create handler for containerd-shim-runc-v2** ([#9209](https://github.com/containerd/containerd/pull/9209))
+
+See the changelog for complete list of changes"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.7.7+unknown"
+	Version = "1.7.8+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated notes

----

Welcome to the v1.7.8 release of containerd!

The eighth patch release for containerd 1.7 contains various fixes and updates.

### Notable Updates

* **Fix ambiguous TLS fallback** ([#9299](https://github.com/containerd/containerd/pull/9299))
* **Update Go to 1.20.10** ([#9265](https://github.com/containerd/containerd/pull/9265))
* **Add a new image label on converted schema 1 images** ([#9252](https://github.com/containerd/containerd/pull/9252))
* **Fix handling for missing basic auth credentials** ([#9235](https://github.com/containerd/containerd/pull/9235))
* **Fix potential deadlock in create handler for containerd-shim-runc-v2** ([#9209](https://github.com/containerd/containerd/pull/9209))

See the changelog for complete list of changes

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Sebastiaan van Stijn
* Derek McGowan
* Phil Estes
* Chen Yiyang
* Wei Fu
* Akihiro Suda
* Maksym Pavlenko
* Marat Radchenko
* Milas Bowman
* Qiutong Song
* Samuel Karp

### Changes
<details><summary>26 commits</summary>
<p>

  * [`48dbdf871`](https://github.com/containerd/containerd/commit/48dbdf871b43ca94f243779bd641fcda49c94f66) Prepare release notes for v1.7.8
* [release/1.7] Fix ambiguous tls fallback ([#9299](https://github.com/containerd/containerd/pull/9299))
  * [`68abc543b`](https://github.com/containerd/containerd/commit/68abc543b1eb4a8196842de6c83115ba4e5698b0) Check scheme and host of request on push redirect
  * [`35c7634e3`](https://github.com/containerd/containerd/commit/35c7634e33651053a934bbcb831c90ddc65ede2e) Avoid TLS fallback when protocol is not ambiguous
* [release/1.7] vendor: google.golang.org/grpc v1.58.3 ([#9281](https://github.com/containerd/containerd/pull/9281))
  * [`f36948cad`](https://github.com/containerd/containerd/commit/f36948cad712b9f813518ceaa5ac5441b6e10347) vendor: gRPC v1.58.3
* [release/1.7 backport] vendor: golang.org/x/net v0.17.0 ([#9276](https://github.com/containerd/containerd/pull/9276))
  * [`c67a53190`](https://github.com/containerd/containerd/commit/c67a5319050614a947c9e5c133e44164e487a223) vendor: golang.org/x/net v0.17.0
  * [`71f4b36ca`](https://github.com/containerd/containerd/commit/71f4b36ca7a420d53a9f6c1b3f846a4a94b739de) vendor: golang.org/x/text v0.13.0
  * [`a7b3b7090`](https://github.com/containerd/containerd/commit/a7b3b70909a99f47845b74a3dbe58032c17bd1e0) vendor: golang.org/x/sys v0.13.0
* [release/1.7] vendor: google.golang.org/grpc v1.56.3 ([#9248](https://github.com/containerd/containerd/pull/9248))
  * [`26736d6e1`](https://github.com/containerd/containerd/commit/26736d6e1af5f45386ae9382a6a951aee33c9ca7) vendor: google.golang.org/grpc v1.56.3
  * [`54a69a6e4`](https://github.com/containerd/containerd/commit/54a69a6e448d61fe88ad90bd476f8f65cf21277f) vendor: golang.org/x/oauth2 v0.7.0
  * [`ac15a7f5b`](https://github.com/containerd/containerd/commit/ac15a7f5b9da1b45ffc66bb8ccdcaed2f571c73a) vendor: google.golang.org/protobuf v1.30.0
* [release/1.7] update to go1.20.10, test go1.21.3 ([#9265](https://github.com/containerd/containerd/pull/9265))
  * [`2479c3321`](https://github.com/containerd/containerd/commit/2479c332173014f3086d9b016214c536a7c03f39) [release/1.7] update to go1.20.10, test go1.21.3
  * [`11f40e9d8`](https://github.com/containerd/containerd/commit/11f40e9d80409b8dfa9dcb3eb81934e08384dd8e) [release/1.7] update to go1.20.9, test go1.21.2
* [release/1.7] Add a new image label if it is docker schema 1 ([#9252](https://github.com/containerd/containerd/pull/9252))
  * [`cac1bab79`](https://github.com/containerd/containerd/commit/cac1bab797ed8d1245bff49aa90e6c80d8714899) Add a new image label if it is docker schema 1
* [release/1.7] remotes: add handling for missing basic auth credentials ([#9235](https://github.com/containerd/containerd/pull/9235))
  * [`6cd2cc4a8`](https://github.com/containerd/containerd/commit/6cd2cc4a8f035162e06d5ffbf868c540e7eb40eb) remotes: add handling for missing basic auth credentials
* [release/1.7 backport] containerd-shim-runc-v2: avoid potential deadlock in create handler ([#9209](https://github.com/containerd/containerd/pull/9209))
  * [`d0a1fedb5`](https://github.com/containerd/containerd/commit/d0a1fedb5a4828daddff330a345780d0222e47e8) *: add runc-fp as runc wrapper to inject failpoint
  * [`04491240a`](https://github.com/containerd/containerd/commit/04491240af1766337e0fbb5145405f74a39f5ad5) containerd-shim-runc-v2: avoid potential deadlock in create handler
  * [`6982a0df5`](https://github.com/containerd/containerd/commit/6982a0df5bc0d31ae82f0810518550006bf90931) containerd-shim-runc-v2: remove unnecessary `s.getContainer()`
  * [`0e2320398`](https://github.com/containerd/containerd/commit/0e2320398f0fb9974232ef68ea70625645f42661) Uncopypaste parsing of OCI Bundle spec file
</p>
</details>

### Dependency Changes

* **golang.org/x/crypto**                        v0.11.0 -> v0.14.0
* **golang.org/x/mod**                           v0.9.0 -> v0.11.0
* **golang.org/x/net**                           v0.13.0 -> v0.17.0
* **golang.org/x/oauth2**                        v0.4.0 -> v0.10.0
* **golang.org/x/sync**                          v0.1.0 -> v0.3.0
* **golang.org/x/sys**                           v0.10.0 -> v0.13.0
* **golang.org/x/term**                          v0.10.0 -> v0.13.0
* **golang.org/x/text**                          v0.11.0 -> v0.13.0
* **golang.org/x/tools**                         v0.7.0 -> v0.10.0
* **google.golang.org/genproto**                 7f2fa6fef1f4 -> 782d3b101e98
* **google.golang.org/genproto/googleapis/api**  782d3b101e98 **_new_**
* **google.golang.org/genproto/googleapis/rpc**  782d3b101e98 **_new_**
* **google.golang.org/grpc**                     v1.53.0 -> v1.58.3
* **google.golang.org/protobuf**                 v1.29.1 -> v1.31.0

Previous release can be found at [v1.7.7](https://github.com/containerd/containerd/releases/tag/v1.7.7)

