### PR TITLE
push: always inherit distribution sources from parent

### DIFF
--- a/remotes/handlers.go
+++ b/remotes/handlers.go
@@ -342,8 +342,15 @@ func annotateDistributionSourceHandler(f images.HandlerFunc, provider content.In
 			return children, nil
 		}
 
-		// parentInfo can be used to inherit info for non-existent blobs
-		var parentInfo *content.Info
+		parentSourceAnnotations := desc.Annotations
+		var parentLabels map[string]string
+		if pi, err := provider.Info(ctx, desc.Digest); err != nil {
+			if !errdefs.IsNotFound(err) {
+				return nil, err
+			}
+		} else {
+			parentLabels = pi.Labels
+		}
 
 		for i := range children {
 			child := children[i]
@@ -353,32 +360,35 @@ func annotateDistributionSourceHandler(f images.HandlerFunc, provider content.In
 				if !errdefs.IsNotFound(err) {
 					return nil, err
 				}
-				if parentInfo == nil {
-					pi, err := provider.Info(ctx, desc.Digest)
-					if err != nil {
-						return nil, err
-					}
-					parentInfo = &pi
-				}
-				// Blob may not exist locally, annotate with parent labels for cross repo
-				// mount or fetch. Parent sources may apply to all children since most
-				// registries enforce that children exist before the manifests.
-				info = *parentInfo
 			}
+			copyDistributionSourceLabels(info.Labels, &child)
 
-			for k, v := range info.Labels {
-				if !strings.HasPrefix(k, labels.LabelDistributionSource+".") {
-					continue
-				}
-
-				if child.Annotations == nil {
-					child.Annotations = map[string]string{}
-				}
-				child.Annotations[k] = v
-			}
+			// Annotate with parent labels for cross repo mount or fetch.
+			// Parent sources may apply to all children since most registries
+			// enforce that children exist before the manifests.
+			copyDistributionSourceLabels(parentSourceAnnotations, &child)
+			copyDistributionSourceLabels(parentLabels, &child)
 
 			children[i] = child
 		}
 		return children, nil
+	}
+}
+
+func copyDistributionSourceLabels(from map[string]string, to *ocispec.Descriptor) {
+	for k, v := range from {
+		if !strings.HasPrefix(k, labels.LabelDistributionSource+".") {
+			continue
+		}
+
+		if to.Annotations == nil {
+			to.Annotations = make(map[string]string)
+		} else {
+			// Only propagate the parent label if the child doesn't already have it.
+			if _, has := to.Annotations[k]; has {
+				continue
+			}
+		}
+		to.Annotations[k] = v
 	}
 }


### PR DESCRIPTION
- related to: https://github.com/containerd/containerd/pull/9029

Propagate parent distribution source labels to each of its children even if they're not missing. This allows to cross-repo mount blobs when the child content has different distribution source label from its parent manifest/index. This could happen when different parts of image were fetched from different sources.

This extends the behavior from https://github.com/containerd/containerd/pull/9029 to all content (not only the missing content).