### PR TITLE
[release/1.6 backport] fix protobuf aarch64

### DIFF
--- a/script/setup/install-protobuf
+++ b/script/setup/install-protobuf
@@ -28,7 +28,7 @@ PROTOBUF_DIR=$(mktemp -d)
 case $GOARCH in
 
 arm64)
-	wget -O "$PROTOBUF_DIR/protobuf" "https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VERSION/protoc-$PROTOBUF_VERSION-linux-aarch64.zip"
+	wget -O "$PROTOBUF_DIR/protobuf" "https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VERSION/protoc-$PROTOBUF_VERSION-linux-aarch_64.zip"
 	unzip "$PROTOBUF_DIR/protobuf" -d /usr/local
 	;;
 


### PR DESCRIPTION
- backport of https://github.com/containerd/containerd/pull/7237

(cherry picked from commit 426fcfbc5281b0f1912584f086f9de04682c583a)