### PR TITLE
fuzz: update go fuzz to directly instantiate server

### DIFF
--- a/contrib/fuzz/builtins.go
+++ b/contrib/fuzz/builtins.go
@@ -1,0 +1,50 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fuzz
+
+import (
+	// base containerd imports
+	_ "github.com/containerd/containerd/diff/walking/plugin"
+	_ "github.com/containerd/containerd/events/plugin"
+	_ "github.com/containerd/containerd/gc/scheduler"
+	_ "github.com/containerd/containerd/leases/plugin"
+	_ "github.com/containerd/containerd/metadata/plugin"
+	_ "github.com/containerd/containerd/pkg/cri"
+	_ "github.com/containerd/containerd/pkg/nri/plugin"
+	_ "github.com/containerd/containerd/plugins/imageverifier"
+	_ "github.com/containerd/containerd/plugins/sandbox"
+	_ "github.com/containerd/containerd/plugins/streaming"
+	_ "github.com/containerd/containerd/plugins/transfer"
+	_ "github.com/containerd/containerd/runtime/restart/monitor"
+	_ "github.com/containerd/containerd/runtime/v2"
+	_ "github.com/containerd/containerd/services/containers"
+	_ "github.com/containerd/containerd/services/content"
+	_ "github.com/containerd/containerd/services/diff"
+	_ "github.com/containerd/containerd/services/events"
+	_ "github.com/containerd/containerd/services/healthcheck"
+	_ "github.com/containerd/containerd/services/images"
+	_ "github.com/containerd/containerd/services/introspection"
+	_ "github.com/containerd/containerd/services/leases"
+	_ "github.com/containerd/containerd/services/namespaces"
+	_ "github.com/containerd/containerd/services/opt"
+	_ "github.com/containerd/containerd/services/sandbox"
+	_ "github.com/containerd/containerd/services/snapshots"
+	_ "github.com/containerd/containerd/services/streaming"
+	_ "github.com/containerd/containerd/services/tasks"
+	_ "github.com/containerd/containerd/services/transfer"
+	_ "github.com/containerd/containerd/services/version"
+)

--- a/contrib/fuzz/builtins_linux.go
+++ b/contrib/fuzz/builtins_linux.go
@@ -1,0 +1,27 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fuzz
+
+import (
+	// Linux specific imports
+	_ "github.com/containerd/containerd/metrics/cgroups"
+	_ "github.com/containerd/containerd/metrics/cgroups/v2"
+	_ "github.com/containerd/containerd/runtime/v2/runc/options"
+	_ "github.com/containerd/containerd/snapshots/blockfile/plugin"
+	_ "github.com/containerd/containerd/snapshots/native/plugin"
+	_ "github.com/containerd/containerd/snapshots/overlay/plugin"
+)

--- a/contrib/fuzz/builtins_unix.go
+++ b/contrib/fuzz/builtins_unix.go
@@ -1,0 +1,25 @@
+//go:build darwin || freebsd || solaris
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fuzz
+
+import (
+	// Unix specific imports
+	_ "github.com/containerd/containerd/snapshots/blockfile/plugin"
+	_ "github.com/containerd/containerd/snapshots/native/plugin"
+)

--- a/contrib/fuzz/builtins_windows.go
+++ b/contrib/fuzz/builtins_windows.go
@@ -1,0 +1,25 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fuzz
+
+import (
+	// Windows specific imports
+	_ "github.com/containerd/containerd/diff/lcow"
+	_ "github.com/containerd/containerd/diff/windows"
+	_ "github.com/containerd/containerd/snapshots/lcow"
+	_ "github.com/containerd/containerd/snapshots/windows"
+)

--- a/contrib/fuzz/containerd_import_fuzzer.go
+++ b/contrib/fuzz/containerd_import_fuzzer.go
@@ -22,14 +22,7 @@ import (
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
 
 	"github.com/containerd/containerd"
-	_ "github.com/containerd/containerd/cmd/containerd/builtins"
 	"github.com/containerd/containerd/namespaces"
-)
-
-const (
-	defaultRoot    = "/var/lib/containerd"
-	defaultState   = "/tmp/containerd"
-	defaultAddress = "/tmp/containerd/containerd.sock"
 )
 
 func fuzzContext() (context.Context, context.CancelFunc) {


### PR DESCRIPTION
Avoid importing the cmd libraries and create the server instance directly from the server library.

Removes the dependency on cmd which is blocking the submodule PR.