### PR TITLE
ci: bump up golangci-lint to v1.55.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.54.2
+          version: v1.55.0
           skip-cache: true
           args: --timeout=8m
 

--- a/integration/remote/util/util_windows.go
+++ b/integration/remote/util/util_windows.go
@@ -117,9 +117,8 @@ func parseEndpoint(endpoint string) (string, string, error) {
 		return "npipe", fmt.Sprintf("//%s%s", host, u.Path), nil
 	} else if u.Scheme == "" {
 		return "", "", fmt.Errorf("Using %q as endpoint is deprecated, please consider using full url format", endpoint)
-	} else {
-		return u.Scheme, "", fmt.Errorf("protocol %q not supported", u.Scheme)
 	}
+	return u.Scheme, "", fmt.Errorf("protocol %q not supported", u.Scheme)
 }
 
 var tickCount = syscall.NewLazyDLL("kernel32.dll").NewProc("GetTickCount64")


### PR DESCRIPTION
Release note of golangci-lint v1.55.0: https://github.com/golangci/golangci-lint/releases/tag/v1.55.0