### PR TITLE
Disable windows-2019 integration test temporarily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022]
+        os: [windows-2022] # windows-2019 is temporarily removed until mingw issue fixed
 
     defaults:
       run:


### PR DESCRIPTION
Disable windows-2019 integration tests until mingw issue is fixed.

Better disable test than merge with red tests. Re-enable this with fix.