### PR TITLE
[release/1.6] add sandbox Annotations to NRI Request 

### DIFF
--- a/pkg/cri/server/container_start.go
+++ b/pkg/cri/server/container_start.go
@@ -152,8 +152,9 @@ func (c *criService) StartContainer(ctx context.Context, r *runtime.StartContain
 	}
 	if nric != nil {
 		nriSB := &nri.Sandbox{
-			ID:     sandboxID,
-			Labels: sandbox.Config.Labels,
+			ID:          sandboxID,
+			Labels:      sandbox.Config.Labels,
+			Annotations: sandbox.Config.Annotations,
 		}
 		if _, err := nric.InvokeWithSandbox(ctx, task, v1.Create, nriSB); err != nil {
 			return nil, fmt.Errorf("nri invoke: %w", err)

--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -374,8 +374,9 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	}
 	if nric != nil {
 		nriSB := &nri.Sandbox{
-			ID:     id,
-			Labels: config.Labels,
+			ID:          id,
+			Labels:      config.Labels,
+			Annotations: config.Annotations,
 		}
 		if _, err := nric.InvokeWithSandbox(ctx, task, v1.Create, nriSB); err != nil {
 			return nil, fmt.Errorf("nri invoke: %w", err)


### PR DESCRIPTION
Currently, containerd 1.6.x only passes `pod.Labels` to NRI (0.1.0), but in some situations we prefer to set `Pod.Spec.Annotations` instead of `Pod.Spec.Labels`.

This PR adds the Sandbox `Annotations` to the `Request` to the NRI plugin.

The corresponding update for NRI 0.1.0 is https://github.com/containerd/nri/pull/60.