### PR TITLE
Update cli --help output for consistency

### DIFF
--- a/cmd/containerd-stress/main.go
+++ b/cmd/containerd-stress/main.go
@@ -62,6 +62,11 @@ func init() {
 	if err := setRlimit(); err != nil {
 		panic(err)
 	}
+
+	cli.HelpFlag = cli.BoolFlag{
+		Name:  "help, h",
+		Usage: "Show help",
+	}
 }
 
 type worker interface {

--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -57,6 +57,14 @@ func init() {
 	cli.VersionPrinter = func(c *cli.Context) {
 		fmt.Println(c.App.Name, version.Package, c.App.Version, version.Revision)
 	}
+	cli.VersionFlag = cli.BoolFlag{
+		Name:  "version, v",
+		Usage: "Print the version",
+	}
+	cli.HelpFlag = cli.BoolFlag{
+		Name:  "help, h",
+		Usage: "Show help",
+	}
 }
 
 // App returns a *cli.App instance.

--- a/cmd/ctr/app/main.go
+++ b/cmd/ctr/app/main.go
@@ -55,6 +55,14 @@ func init() {
 	cli.VersionPrinter = func(c *cli.Context) {
 		fmt.Println(c.App.Name, version.Package, c.App.Version)
 	}
+	cli.VersionFlag = cli.BoolFlag{
+		Name:  "version, v",
+		Usage: "Print the version",
+	}
+	cli.HelpFlag = cli.BoolFlag{
+		Name:  "help, h",
+		Usage: "Show help",
+	}
 }
 
 // New returns a *cli.App instance.

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -35,19 +35,19 @@ generate the default configuration for containerd. The output of that command
 can be used and modified as necessary as a custom configuration.
 
 COMMANDS:
-   config    information on the containerd config
-   publish   binary to publish events to containerd
-   oci-hook  provides a base for OCI runtime hooks to allow arguments to be injected.
+   config    Information on the containerd config
+   publish   Binary to publish events to containerd
+   oci-hook  Provides a base for OCI runtime hooks to allow arguments to be injected.
    help, h   Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-   --config value, -c value     path to the configuration file (default: "/etc/containerd/config.toml")
-   --log-level value, -l value  set the logging level [trace, debug, info, warn, error, fatal, panic]
-   --address value, -a value    address for containerd's GRPC server
+   --config value, -c value     Path to the configuration file (default: "/etc/containerd/config.toml")
+   --log-level value, -l value  Set the logging level [trace, debug, info, warn, error, fatal, panic]
+   --address value, -a value    Address for containerd's GRPC server
    --root value                 containerd root directory
    --state value                containerd state directory
-   --help, -h                   show help
-   --version, -v                print the version
+   --help, -h                   Show help
+   --version, -v                Print the version
 
 ```
 


### PR DESCRIPTION
Minor enhancement to the CLI `containerd`, `ctr`, and `containerd-stress` printed output when running with the `--help` flag. 
Ensures those `--help` output descriptions are consistently uppercase (minus those starting with containerd)  in addition to the `ops.md` doc reference to the `containerd --help` output is accurate.