### PR TITLE
Add ctr command to produce current local platform string

### DIFF
--- a/cmd/ctr/app/main.go
+++ b/cmd/ctr/app/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/containerd/containerd/cmd/ctr/commands/leases"
 	namespacesCmd "github.com/containerd/containerd/cmd/ctr/commands/namespaces"
 	ociCmd "github.com/containerd/containerd/cmd/ctr/commands/oci"
+	"github.com/containerd/containerd/cmd/ctr/commands/platform"
 	"github.com/containerd/containerd/cmd/ctr/commands/plugins"
 	"github.com/containerd/containerd/cmd/ctr/commands/pprof"
 	"github.com/containerd/containerd/cmd/ctr/commands/run"
@@ -121,6 +122,7 @@ containerd CLI
 		sandboxes.Command,
 		info.Command,
 		deprecations.Command,
+		platform.Command,
 	}, extraCmds...)
 	app.Before = func(context *cli.Context) error {
 		if context.GlobalBool("debug") {

--- a/cmd/ctr/commands/platform/platform.go
+++ b/cmd/ctr/commands/platform/platform.go
@@ -1,0 +1,37 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you		p :=
+ may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package platform
+
+import (
+	"fmt"
+	"github.com/containerd/containerd/platforms"
+	"github.com/urfave/cli"
+	"os"
+	"text/tabwriter"
+)
+
+// Command is a cli command that outputs current platform
+var Command = cli.Command{
+	Name:  "platform",
+	Usage: "Provides information about current local platform",
+	Action: func(context *cli.Context) error {
+		w := tabwriter.NewWriter(os.Stdout, 4, 8, 4, ' ', 0)
+		fmt.Fprintf(w, "%s\n", platforms.Format(platforms.DefaultSpec()))
+		return w.Flush()
+	},
+}


### PR DESCRIPTION
addresses issue #8141
example:
```
$ ctr platform
linux/amd64
```