### PR TITLE
Prepare release notes for 2.0.0-beta.0

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -3,9 +3,11 @@ Abhinandan Prativadi <abhi@docker.com> <aprativadi@gmail.com>
 Ace-Tang <aceapril@126.com>
 Adam Korcz <adam@adalogics.com> <Adam@adalogics.com>
 Aditi Sharma <adi.sky17@gmail.com> <sharmaad@vmware.com>
+Akhil Mohan <akhilerm@gmail.com> <makhil@vmware.com>
 Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp> <suda.akihiro@lab.ntt.co.jp>
 Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp> <suda.kyoto@gmail.com>
 Allen Sun <shlallen1990@gmail.com> <allensun@AllenSundeMacBook-Pro.local>
+Alex Ellis <alexellis2@gmail.com>
 Alexander Morozov <lk4d4math@gmail.com> <lk4d4@docker.com>
 Antonio Ojea <antonio.ojea.garcia@gmail.com> <aojea@google.com>
 Antonio Ojea <antonio.ojea.garcia@gmail.com> <aojea@redhat.com>
@@ -26,8 +28,10 @@ Cory Bennett <cbennett@netflix.com>
 Cristian Staretu <cristian.staretu@gmail.com>
 Cristian Staretu <cristian.staretu@gmail.com> <unclejack@users.noreply.github.com>
 Daniel Dao <dqminh89@gmail.com>
+Danny Canter <danny@dcantah.dev> <danny_canter@apple.com>
 Derek McGowan <derek@mcg.dev> <derek@mcgstyle.net>
 Edgar Lee <edgarl@netflix.com> <edgar.lee@docker.com>
+Enrico Weigelt <info@metux.net>
 Eric Ernst <eric@amperecomputing.com> <eric.ernst@intel.com>
 Eric Lin <linxiulei@gmail.com> <exlin@google.com>
 Eric Ren <renzhen.rz@linux.alibaba.com> <renzhen@linux.alibaba.com>
@@ -69,17 +73,21 @@ Lorenz Brun <lorenz@brun.one> <lorenz@nexantic.com>
 Luc Perkins <lucperkins@gmail.com>
 James Sturtevant <jsturtevant@gmail.com> <jstur@microsoft.com>
 Jiajun Jiang <levinxo@gmail.com>
+Jin Dong <djdongjin95@gmail.com> <jin.dong@databricks.com>
 Julien Balestra <julien.balestra@datadoghq.com>
 Jun Lin Chen <webmaster@mc256.com> <1913688+mc256@users.noreply.github.com>
 Justin Cormack <justin.cormack@docker.com> <justin@specialbusservice.com>
 Justin Terry <juterry@microsoft.com>
 Justin Terry <juterry@microsoft.com> <jterry75@users.noreply.github.com>
 Kante <kerthcet@gmail.com>
+Kazuyoshi Kato <kato.kazuyoshi@gmail.com>
+Kazuyoshi Kato <kato.kazuyoshi@gmail.com> <kaz@fly.io>
 Kazuyoshi Kato <kato.kazuyoshi@gmail.com> <katokazu@amazon.com>
 Kenfe-Mickaël Laventure <mickael.laventure@gmail.com>
 Kevin Kern <kaiwentan@harmonycloud.cn>
 Kevin Parsons <kevpar@microsoft.com> <kevpar@users.noreply.github.com>
 Kevin Xu <cming.xu@gmail.com>
+Kirtana Ashok <kiashok@microsoft.com> <Kirtana.Ashok@microsoft.com>
 Kitt Hsu <kitt.hsu@gmail.com>
 Kohei Tokunaga <ktokunaga.mail@gmail.com>
 Krasi Georgiev <krasi.root@gmail.com> <krasi@vip-consult.solutions>
@@ -89,6 +97,7 @@ lengrongfu <1275177125@qq.com>
 Li Yuxuan <liyuxuan04@baidu.com> <darfux@163.com>
 Lifubang <lifubang@aliyun.com> <lifubang@acmcoder.com>
 Lu Jingxiao <lujingxiao@huawei.com>
+Mahamed Ali <cy@borg.dev>
 Maksym Pavlenko <pavlenko.maksym@gmail.com> <865334+mxpv@users.noreply.github.com>
 Maksym Pavlenko <pavlenko.maksym@gmail.com> <makpav@amazon.com>
 Maksym Pavlenko <pavlenko.maksym@gmail.com> <mxpv@apple.com>
@@ -96,6 +105,7 @@ Mario Hros <spam@k3a.me>
 Mario Hros <spam@k3a.me> <root@k3a.me>
 Mario Macias <mariomac@gmail.com> <mmacias@newrelic.com>
 Mark Gordon <msg555@gmail.com>
+Markus Lehtonen <markus.lehtonen@intel.com> <markus.lehtonen@linux.intel.com>
 Marvin Giessing <marvin.giessing@gmail.com>
 Mathis Michel <mathis.michel@outlook.de>
 Michael Crosby <crosbymichael@gmail.com> <michael@thepasture.io>
@@ -108,6 +118,7 @@ Ning Li <ning.a.li@transwarp.io>
 ningmingxiao <ning.mingxiao@zte.com.cn>
 Nishchay Kumar <mrawesomenix@gmail.com>
 Oliver Stenbom <oliver@stenbom.eu> <ostenbom@pivotal.io>
+Pan Yibo <mstmdev@gmail.com>
 Phil Estes <estesp@gmail.com> <estesp@linux.vnet.ibm.com>
 Phil Estes <estesp@gmail.com> <estesp@amazon.com>
 Qian Zhang <cosmoer@qq.com>
@@ -147,6 +158,7 @@ wangzhan <wang.zhan@smartx.com>
 Wei Fu <fuweid89@gmail.com>
 Wei Fu <fuweid89@gmail.com> <fhfuwei@163.com>
 wen chen <wen.chen@daocloud.io>
+William Chen <willchen.005@gmail.com> <root@DESKTOP-HIQTJ3R.localdomain>
 Xiaodong Zhang <a4012017@sina.com>
 Xuean Yan <yan.xuean@zte.com.cn>
 Yang Yang <yang8518296@163.com>
@@ -155,6 +167,7 @@ Yuxing Liu <starnop@163.com>
 Zechun Chen <zechun.chen@daocloud.io>
 zhang he <zhanghe9702@163.com>
 Zhang Wei <zhangwei555@huawei.com>
+zhangpeng <zhangpeng63@baidu.com>
 zhangyadong <zhangyadong.0808@bytedance.com>
 Zhenguang Zhu <zhengguang.zhu@daocloud.io>
 Zhiyu Li <payall4u@qq.com>

--- a/releases/v2.0.0-beta.toml
+++ b/releases/v2.0.0-beta.toml
@@ -1,0 +1,33 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release
+previous = "v1.7.0"
+
+pre_release = true
+
+preface = """\
+The first major release of containerd 2.x focuses on the continued stability of
+containerd's core feature set with an easy upgrade from containerd 1.x. This
+release includes the stabilization of new features added in the last 1.x release
+as well as the removal of features which were deprecated in 1.x. The goal is to
+support the vast community of containerd users well into the future along with
+their ever increasing deployment footprints and variety of use cases.
+"""
+
+postface = """\
+### Which file should I download?
+* `containerd-<VERSION>-<OS>-<ARCH>.tar.gz`:         ✅Recommended. Dynamically linked with glibc 2.31 (Ubuntu 20.04).
+* `containerd-static-<VERSION>-<OS>-<ARCH>.tar.gz`:  Statically linked. Expected to be used on non-glibc Linux distributions. Not position-independent.
+
+In addition to containerd, typically you will have to install [runc](https://github.com/opencontainers/runc/releases)
+and [CNI plugins](https://github.com/containernetworking/plugins/releases) from their official sites too.
+
+See also the [Getting Started](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) documentation.
+"""
+
+override_deps."github.com/containerd/log".previous = "cf9777876edf6a4aa230c739bc7eec5ab8349e9c"

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.7.0+unknown"
+	Version = "2.0.0-beta.0+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
This is an early draft for the 2.0.0 release notes but will let us start cutting the beta releases.

The checked in release notes are shorter and will utilize https://github.com/containerd/release-tool/pull/45 for generating the highlight notes which were included in the checked in version in prior releases. These are generated from pull request titles and labels, currently the notes look like...

---

Welcome to the v2.0.0-beta.0 release of containerd!  
*This is a pre-release of containerd*

The first major release of containerd 2.x focuses on the continued stability of
containerd's core feature set with an easy upgrade from containerd 1.x. This
release includes the stabilization of new features added in the last 1.x release
as well as the removal of features which were deprecated in 1.x. The goal is to
support the vast community of containerd users well into the future along with
their ever increasing deployment footprints and variety of use cases.

### Highlights

* Expose usage of deprecated features ([#9258](https://github.com/containerd/containerd/pull/9258))
* Switch runc shim to task service v3 and fix restore ([#9233](https://github.com/containerd/containerd/pull/9233))
* Add sandboxer configuration and move sandbox controllers to plugins ([#8268](https://github.com/containerd/containerd/pull/8268))
* Use Intel ISA-L's igzip if available ([#9200](https://github.com/containerd/containerd/pull/9200))
* Generalize plugin library ([#9214](https://github.com/containerd/containerd/pull/9214))
* Introduce top level config migration ([#9223](https://github.com/containerd/containerd/pull/9223))
* Add image delete target ([#8989](https://github.com/containerd/containerd/pull/8989))
* Use github.com/containerd/log ([#9086](https://github.com/containerd/containerd/pull/9086))
* Add support for image expiration during garbage collection ([#9022](https://github.com/containerd/containerd/pull/9022))
* Reduce the contention between ref lock and boltdb lock in content store ([#8792](https://github.com/containerd/containerd/pull/8792))
* Remove the CriuPath field from runc's options ([#8279](https://github.com/containerd/containerd/pull/8279))
* Remove support for config.toml `version = 1` ([#8275](https://github.com/containerd/containerd/pull/8275))
* Remove "containerd.io/restart.logpath" label ([#8264](https://github.com/containerd/containerd/pull/8264))
* Remove `aufs` snapshotter ([#8263](https://github.com/containerd/containerd/pull/8263))

#### Container Runtime Interface (CRI)

* Remove non-sandboxed CRI implementation ([#9228](https://github.com/containerd/containerd/pull/9228))
* Add image verifier transfer service plugin system based on a binary directory ([#8493](https://github.com/containerd/containerd/pull/8493))
* Use sandboxed CRI by default ([#8994](https://github.com/containerd/containerd/pull/8994))
* Implement RuntimeConfig CRI call ([#8722](https://github.com/containerd/containerd/pull/8722))
* Remove CRI v1alpha2 ([#8276](https://github.com/containerd/containerd/pull/8276))

#### Runtime

* Remove `io.containerd.runtime.v1.linux` and `io.containerd.runc.v1` ([#8262](https://github.com/containerd/containerd/pull/8262))

#### Breaking

* Implement RuntimeConfig CRI call ([#8722](https://github.com/containerd/containerd/pull/8722))
* Remove CRI v1alpha2 ([#8276](https://github.com/containerd/containerd/pull/8276))
* Remove `io.containerd.runtime.v1.linux` and `io.containerd.runc.v1` ([#8262](https://github.com/containerd/containerd/pull/8262))
* Remove "containerd.io/restart.logpath" label ([#8264](https://github.com/containerd/containerd/pull/8264))
* Remove `aufs` snapshotter ([#8263](https://github.com/containerd/containerd/pull/8263))

#### Deprecations

* Deprecate go-plugin configuration option ([#9238](https://github.com/containerd/containerd/pull/9238))
* CNI conf_template in CRI is no longer deprecated ([#8637](https://github.com/containerd/containerd/pull/8637))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Derek McGowan
* Wei Fu
* Akihiro Suda
* Phil Estes
* Sebastiaan van Stijn
* Maksym Pavlenko
* Samuel Karp
* Kazuyoshi Kato
* Rodrigo Campos
* Danny Canter
* Gabriel Adrian Samfira
* Iceber Gu
* Jin Dong
* Bjorn Neergaard
* Austin Vazquez
* Mike Brown
* Paul "TBBle" Hampson
* Kirtana Ashok
* Krisztian Litkey
* Abel Feng
* rongfu.leng
* Enrico Weigelt
* Kohei Tokunaga
* Ilya Hanov
* Marat Radchenko
* Akhil Mohan
* Cardy.Tang
* Hsing-Yu (David) Chen
* James Sturtevant
* Justin Chadwell
* Markus Lehtonen
* Nashwan Azhari
* Shingo Omura
* helen
* Aditi Sharma
* Brian Goff
* Charity Kathure
* Henry Wang
* Kay Yan
* Laura Brehm
* Vinayak Goyal
* Artem Khramov
* Brad Davidson
* Bryant Biggs
* Chen Yiyang
* Cory Snider
* Davanum Srinivas
* Ed Bartosh
* Ethan Lowman
* James Jenkins
* Jiang Liu
* Jordan Liggitt
* June Rhodes
* Mahamed Ali
* Michael Crosby
* Paweł Gronowski
* Peteris Rudzusiks
* Sam Edwards
* Samruddhi Khandale
* Steve Griffith
* VERNOU Cédric
* hang.jiang
* jerryzhuang
* Aaron Lehmann
* Aditya Ramani
* Alex Couture-Beil
* Alex Ellis
* Alexandru Matei
* Amir M. Ghazanfari
* Antonio Huete Jimenez
* Ben Foster
* Bin Xin
* BinBin He
* Brennan Kinney
* Craig Ingram
* Daisy Rong
* Djordje Lukic
* Edgar Lee
* Eng Zer Jun
* Etienne Champetier
* Evan Lezar
* Fahed Dorgaa
* Gary McDonald
* Jan Dubois
* Jiongchi Yu
* Kern Walster
* Maksim An
* Milas Bowman
* Pan Yibo
* Qasim Sarfraz
* Qiutong Song
* Robbie Buxton
* Robert-André Mauchin
* Shukui Yang
* Tianon Gravi
* Tony Fang
* Tõnis Tiigi
* Wang Xinwen
* William Chen
* charles-chenzz
* chschumacher1994
* guangli.bao
* ningmingxiao
* pigletfly
* wangxiang
* zhangpeng
* zhaojizhuang
* zounengren

### Dependency Changes

* **dario.cat/mergo**                                                       v1.0.0 **_new_**
* **github.com/AdaLogics/go-fuzz-headers**                                  1f10f66a31bf -> ced1acdcaa24
* **github.com/AdamKorcz/go-118-fuzz-build**                                5330a85ea652 -> 8075edf89bb0
* **github.com/Microsoft/go-winio**                                         v0.6.0 -> v0.6.1
* **github.com/Microsoft/hcsshim**                                          v0.10.0-rc.7 -> v0.12.0-rc.0
* **github.com/cenkalti/backoff/v4**                                        v4.2.0 -> v4.2.1
* **github.com/container-orchestrated-devices/container-device-interface**  v0.5.4 -> v0.6.1
* **github.com/containerd/cgroups/v3**                                      v3.0.1 -> v3.0.2
* **github.com/containerd/continuity**                                      v0.3.0 -> v0.4.2
* **github.com/containerd/go-runc**                                         v1.0.0 -> v1.1.0
* **github.com/containerd/log**                                             v0.1.0 **_new_**
* **github.com/containerd/nri**                                             v0.3.0 -> v0.5.0
* **github.com/containerd/ttrpc**                                           v1.2.1 -> v1.2.2
* **github.com/containerd/typeurl/v2**                                      v2.1.0 -> v2.1.1
* **github.com/containernetworking/plugins**                                v1.2.0 -> v1.3.0
* **github.com/distribution/reference**                                     v0.5.0 **_new_**
* **github.com/emicklei/go-restful/v3**                                     v3.10.1 -> v3.10.2
* **github.com/go-logr/logr**                                               v1.2.3 -> v1.2.4
* **github.com/golang/protobuf**                                            v1.5.2 -> v1.5.3
* **github.com/google/uuid**                                                v1.3.0 -> v1.3.1
* **github.com/grpc-ecosystem/go-grpc-middleware**                          v1.3.0 -> v1.4.0
* **github.com/grpc-ecosystem/grpc-gateway/v2**                             v2.7.0 -> v2.16.2
* **github.com/klauspost/compress**                                         v1.16.0 -> v1.17.2
* **github.com/klauspost/cpuid/v2**                                         v2.0.4 -> v2.2.5
* **github.com/minio/sha256-simd**                                          v1.0.0 -> v1.0.1
* **github.com/moby/sys/user**                                              v0.1.0 **_new_**
* **github.com/opencontainers/image-spec**                                  3a7f492d3f1b -> v1.1.0-rc5
* **github.com/opencontainers/runtime-spec**                                v1.1.0-rc.1 -> 4fec88fd00a4
* **github.com/opencontainers/runtime-tools**                               946c877fa809 -> 2e043c6bd626
* **github.com/pelletier/go-toml/v2**                                       v2.1.0 **_new_**
* **github.com/prometheus/client_golang**                                   v1.14.0 -> v1.16.0
* **github.com/prometheus/client_model**                                    v0.3.0 -> v0.4.0
* **github.com/prometheus/common**                                          v0.37.0 -> v0.44.0
* **github.com/prometheus/procfs**                                          v0.8.0 -> v0.10.1
* **github.com/sirupsen/logrus**                                            v1.9.0 -> v1.9.3
* **github.com/stretchr/testify**                                           v1.8.2 -> v1.8.4
* **github.com/urfave/cli**                                                 v1.22.12 -> v1.22.14
* **github.com/vishvananda/netns**                                          2eb08e3e575f -> v0.0.4
* **golang.org/x/crypto**                                                   v0.1.0 -> v0.14.0
* **golang.org/x/mod**                                                      v0.7.0 -> v0.12.0
* **golang.org/x/net**                                                      v0.7.0 -> v0.17.0
* **golang.org/x/oauth2**                                                   v0.4.0 -> v0.10.0
* **golang.org/x/sync**                                                     v0.1.0 -> v0.3.0
* **golang.org/x/sys**                                                      v0.6.0 -> v0.13.0
* **golang.org/x/term**                                                     v0.5.0 -> v0.13.0
* **golang.org/x/text**                                                     v0.7.0 -> v0.13.0
* **golang.org/x/time**                                                     90d013bbcef8 -> v0.3.0
* **golang.org/x/tools**                                                    v0.5.0 -> v0.11.0
* **google.golang.org/genproto**                                            7f2fa6fef1f4 -> 659f7aaaa771
* **google.golang.org/genproto/googleapis/api**                             23370e0ffb3e **_new_**
* **google.golang.org/genproto/googleapis/rpc**                             23370e0ffb3e **_new_**
* **google.golang.org/grpc**                                                v1.53.0 -> v1.58.3
* **google.golang.org/protobuf**                                            v1.28.1 -> v1.31.0
* **gopkg.in/square/go-jose.v2**                                            v2.5.1 -> v2.6.0
* **k8s.io/api**                                                            v0.26.2 -> v0.28.2
* **k8s.io/apimachinery**                                                   v0.26.2 -> v0.28.2
* **k8s.io/apiserver**                                                      v0.26.2 -> v0.28.2
* **k8s.io/client-go**                                                      v0.26.2 -> v0.28.2
* **k8s.io/component-base**                                                 v0.26.2 -> v0.28.2
* **k8s.io/cri-api**                                                        v0.26.2 -> v0.28.2
* **k8s.io/klog/v2**                                                        v2.90.1 -> v2.100.1
* **k8s.io/kubelet**                                                        v0.28.2 **_new_**
* **k8s.io/utils**                                                          a5ecb0141aa5 -> d93618cff8a2
* **sigs.k8s.io/json**                                                      f223a00ba0e2 -> bc3834ca7abd

Previous release can be found at [v1.7.0](https://github.com/containerd/containerd/releases/tag/v1.7.0)
### Which file should I download?
* `containerd-<VERSION>-<OS>-<ARCH>.tar.gz`:         ✅Recommended. Dynamically linked with glibc 2.31 (Ubuntu 20.04).
* `containerd-static-<VERSION>-<OS>-<ARCH>.tar.gz`:  Statically linked. Expected to be used on non-glibc Linux distributions. Not position-independent.

In addition to containerd, typically you will have to install [runc](https://github.com/opencontainers/runc/releases)
and [CNI plugins](https://github.com/containernetworking/plugins/releases) from their official sites too.

See also the [Getting Started](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) documentation.
