### PR TITLE
[release/1.7] Add release notes for v1.7.9

### DIFF
--- a/releases/v1.7.9.toml
+++ b/releases/v1.7.9.toml
@@ -1,0 +1,38 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.7.8"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The ninth patch release for containerd 1.7 contains various fixes and updates.
+
+### Notable Updates
+
+* **update runc binary to v1.1.10::** ([#9359](https://github.com/containerd/containerd/pull/9359))
+* **vendor: upgrade OpenTelemetry to v1.19.0 / v0.45.0** ([#9301](https://github.com/containerd/containerd/pull/9301))
+* **Expose usage of cri-api v1alpha2** ([#9336](https://github.com/containerd/containerd/pull/9336))
+* **integration: deflake TestIssue9103** ([#9354](https://github.com/containerd/containerd/pull/9354))
+* **fix: shimv1 leak issue** ([#9344](https://github.com/containerd/containerd/pull/9344))
+* **cri: add deprecation warnings for mirrors, auths, and configs** ([#9327](https://github.com/containerd/containerd/pull/9327))
+* **Update hcsshim tag to v0.11.4** ([#9326](https://github.com/containerd/containerd/pull/9326))
+* **Expose usage of deprecated features** ([#9315](https://github.com/containerd/containerd/pull/9315))
+
+See the changelog for complete list of changes"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.7.8+unknown"
+	Version = "1.7.9+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Welcome to the v1.7.9 release of containerd!

The ninth patch release for containerd 1.7 contains various fixes and updates.

### Notable Updates

* **update runc binary to v1.1.10::** ([#9359](https://github.com/containerd/containerd/pull/9359))
* **vendor: upgrade OpenTelemetry to v1.19.0 / v0.45.0** ([#9301](https://github.com/containerd/containerd/pull/9301))
* **Expose usage of cri-api v1alpha2** ([#9336](https://github.com/containerd/containerd/pull/9336))
* **integration: deflake TestIssue9103** ([#9354](https://github.com/containerd/containerd/pull/9354))
* **fix: shimv1 leak issue** ([#9344](https://github.com/containerd/containerd/pull/9344))
* **cri: add deprecation warnings for mirrors, auths, and configs** ([#9327](https://github.com/containerd/containerd/pull/9327))
* **Update hcsshim tag to v0.11.4** ([#9326](https://github.com/containerd/containerd/pull/9326))
* **Expose usage of deprecated features** ([#9315](https://github.com/containerd/containerd/pull/9315))

See the changelog for complete list of changes

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Samuel Karp
* Kazuyoshi Kato
* Wei Fu
* Kirtana Ashok
* Milas Bowman
* Sebastiaan van Stijn
* ruiwen-zhao

### Changes
<details><summary>26 commits</summary>
<p>

* [release/1.7 backport] update runc binary to v1.1.10 ([#9359](https://github.com/containerd/containerd/pull/9359))
  * [`eff291713`](https://github.com/containerd/containerd/commit/eff29171398e411ab054367f6d9f1892b9d70f67) update runc binary to v1.1.10
* [release/1.7] vendor: upgrade OpenTelemetry to v1.19.0 / v0.45.0 ([#9301](https://github.com/containerd/containerd/pull/9301))
  * [`bd9428ff7`](https://github.com/containerd/containerd/commit/bd9428ff711bda05efecddafe8ca07f568cd994e) vendor: upgrade OpenTelemetry to v1.19.0 / v0.45.0
* [release/1.7] Expose usage of cri-api v1alpha2 ([#9336](https://github.com/containerd/containerd/pull/9336))
  * [`d62cba40c`](https://github.com/containerd/containerd/commit/d62cba40c833f0dacb58084749105fd6cd61283a) Expose usage of cri-api v1alpha2
* [release/1.7] integration: deflake TestIssue9103 ([#9354](https://github.com/containerd/containerd/pull/9354))
  * [`5dbc258a8`](https://github.com/containerd/containerd/commit/5dbc258a81c236040b7ff27382f812c7179d6cd3) integration: deflake TestIssue9103
* [release/1.7] fix: shimv1 leak issue ([#9344](https://github.com/containerd/containerd/pull/9344))
  * [`449912857`](https://github.com/containerd/containerd/commit/449912857d8191c986537af00325d9999922fce3) fix: shimv1 leak issue
* [release/1.7] cri: add deprecation warnings for mirrors, auths, and configs ([#9327](https://github.com/containerd/containerd/pull/9327))
  * [`152c57e91`](https://github.com/containerd/containerd/commit/152c57e918a8374ce2fa20d4eb6ba5896a314529) cri: add deprecation warning for configs
  * [`689a1036d`](https://github.com/containerd/containerd/commit/689a1036dda32e79643b151f632c8da5bac2f149) cri: add deprecation warning for auths
  * [`8c38975bf`](https://github.com/containerd/containerd/commit/8c38975bf22f138f00ddf0fafd4803bbade098a3) cri: add deprecation warning for mirrors
  * [`1fbce40c4`](https://github.com/containerd/containerd/commit/1fbce40c4a7dfad845770580eb146ea2fc64cc46) cri: add ability to emit deprecation warnings
* [release/1.7] Update hcsshim tag to v0.11.4 ([#9326](https://github.com/containerd/containerd/pull/9326))
  * [`73f15bdb6`](https://github.com/containerd/containerd/commit/73f15bdb63e25a13bf99f192f39984e22bc7dbc9) Update hcsshim tag to v0.11.4
* [release/1.7] Expose usage of deprecated features ([#9315](https://github.com/containerd/containerd/pull/9315))
  * [`60d48ffea`](https://github.com/containerd/containerd/commit/60d48ffea657d7d7059dcf497c75d3347e1fd1ab) ctr: new deprecations command
  * [`74a06671a`](https://github.com/containerd/containerd/commit/74a06671ab9396ee94cfee2a588c5d0e170fb698) plugin: record deprecation for dynamic plugins
  * [`fa5f3c91a`](https://github.com/containerd/containerd/commit/fa5f3c91a946795de0173e10a5a3eba4c18aa4c3) server: add ability to record config deprecations
  * [`f7880e7f0`](https://github.com/containerd/containerd/commit/f7880e7f0873024d5307a16d4db8c7a2f360ad49) pull: record deprecation warning for schema 1
  * [`1dd2f2c02`](https://github.com/containerd/containerd/commit/1dd2f2c028bc0bf9b9301a142e09488815c2fb95) introspection: add support for deprecations
  * [`aaf000c18`](https://github.com/containerd/containerd/commit/aaf000c18c047895a891a5dfc7127dc87c034fc9) api/introspection: deprecation warnings in server
  * [`9b7ceee54`](https://github.com/containerd/containerd/commit/9b7ceee540206e6ff6f690676566a73f4f8d443f) warning: new service for deprecations
  * [`b708f8bfa`](https://github.com/containerd/containerd/commit/b708f8bfadcbf95e2acba22ffdeb7d8f8a974151) deprecation: new package for deprecations
</p>
</details>

### Dependency Changes

* **github.com/Microsoft/hcsshim**                                                 v0.11.1 -> v0.11.4
* **github.com/cenkalti/backoff/v4**                                               v4.2.0 -> v4.2.1
* **github.com/go-logr/logr**                                                      v1.2.3 -> v1.2.4
* **github.com/grpc-ecosystem/grpc-gateway/v2**                                    v2.7.0 -> v2.16.0
* **go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc**  v0.40.0 -> v0.45.0
* **go.opentelemetry.io/otel**                                                     v1.14.0 -> v1.19.0
* **go.opentelemetry.io/otel/exporters/otlp/otlptrace**                            v1.14.0 -> v1.19.0
* **go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc**              v1.14.0 -> v1.19.0
* **go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp**              v1.14.0 -> v1.19.0
* **go.opentelemetry.io/otel/metric**                                              v0.37.0 -> v1.19.0
* **go.opentelemetry.io/otel/sdk**                                                 v1.14.0 -> v1.19.0
* **go.opentelemetry.io/otel/trace**                                               v1.14.0 -> v1.19.0
* **go.opentelemetry.io/proto/otlp**                                               v0.19.0 -> v1.0.0

Previous release can be found at [v1.7.8](https://github.com/containerd/containerd/releases/tag/v1.7.8)