### PR TITLE
[release/1.7] Expose usage of cri-api v1alpha2

### DIFF
--- a/contrib/fuzz/cri_sbserver_fuzzer.go
+++ b/contrib/fuzz/cri_sbserver_fuzzer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/containerd/containerd"
 	criconfig "github.com/containerd/containerd/pkg/cri/config"
 	"github.com/containerd/containerd/pkg/cri/sbserver"
+	"github.com/containerd/containerd/pkg/cri/server/testing"
 )
 
 func FuzzCRISandboxServer(data []byte) int {
@@ -37,7 +38,7 @@ func FuzzCRISandboxServer(data []byte) int {
 	}
 	defer client.Close()
 
-	c, err := sbserver.NewCRIService(criconfig.Config{}, client, nil)
+	c, err := sbserver.NewCRIService(criconfig.Config{}, client, nil, testing.NewFakeWarningService())
 	if err != nil {
 		panic(err)
 	}

--- a/contrib/fuzz/cri_server_fuzzer.go
+++ b/contrib/fuzz/cri_server_fuzzer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/containerd/containerd"
 	criconfig "github.com/containerd/containerd/pkg/cri/config"
 	"github.com/containerd/containerd/pkg/cri/server"
+	"github.com/containerd/containerd/pkg/cri/server/testing"
 )
 
 func FuzzCRIServer(data []byte) int {
@@ -37,7 +38,7 @@ func FuzzCRIServer(data []byte) int {
 	}
 	defer client.Close()
 
-	c, err := server.NewCRIService(criconfig.Config{}, client, nil)
+	c, err := server.NewCRIService(criconfig.Config{}, client, nil, testing.NewFakeWarningService())
 	if err != nil {
 		panic(err)
 	}

--- a/integration/image_pull_timeout_test.go
+++ b/integration/image_pull_timeout_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	criconfig "github.com/containerd/containerd/pkg/cri/config"
 	criserver "github.com/containerd/containerd/pkg/cri/server"
+	servertesting "github.com/containerd/containerd/pkg/cri/server/testing"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -471,5 +472,5 @@ func initLocalCRIPlugin(client *containerd.Client, tmpDir string, registryCfg cr
 		RootDir:           filepath.Join(criWorkDir, "root"),
 		StateDir:          filepath.Join(criWorkDir, "state"),
 	}
-	return criserver.NewCRIService(cfg, client, nil)
+	return criserver.NewCRIService(cfg, client, nil, servertesting.NewFakeWarningService())
 }

--- a/pkg/cri/server/service_test.go
+++ b/pkg/cri/server/service_test.go
@@ -17,22 +17,27 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"testing"
 
 	"github.com/containerd/containerd/oci"
+	"github.com/containerd/containerd/third_party/k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"github.com/containerd/go-cni"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/containerd/containerd/pkg/atomic"
 	criconfig "github.com/containerd/containerd/pkg/cri/config"
+	"github.com/containerd/containerd/pkg/cri/instrument"
 	servertesting "github.com/containerd/containerd/pkg/cri/server/testing"
 	containerstore "github.com/containerd/containerd/pkg/cri/store/container"
 	imagestore "github.com/containerd/containerd/pkg/cri/store/image"
 	"github.com/containerd/containerd/pkg/cri/store/label"
 	sandboxstore "github.com/containerd/containerd/pkg/cri/store/sandbox"
 	snapshotstore "github.com/containerd/containerd/pkg/cri/store/snapshot"
+	"github.com/containerd/containerd/pkg/deprecation"
 	ostesting "github.com/containerd/containerd/pkg/os/testing"
 	"github.com/containerd/containerd/pkg/registrar"
 )
@@ -53,6 +58,7 @@ func newTestCRIService() *criService {
 		netPlugin: map[string]cni.CNI{
 			defaultNetworkPlugin: servertesting.NewFakeCNIPlugin(),
 		},
+		initialized: atomic.NewBool(false),
 	}
 }
 
@@ -85,4 +91,19 @@ func TestLoadBaseOCISpec(t *testing.T) {
 
 	assert.Equal(t, "1.0.2", out.Version)
 	assert.Equal(t, "default", out.Hostname)
+}
+
+func TestAlphaCRIWarning(t *testing.T) {
+	ctx := context.Background()
+	ws := servertesting.NewFakeWarningService()
+	c := instrument.NewAlphaService(newTestCRIService(), ws)
+
+	c.Version(ctx, &v1alpha2.VersionRequest{})
+	c.Status(ctx, &v1alpha2.StatusRequest{})
+
+	// Only emit the warning the first time an v1alpha2 api is called.
+	expectedWarnings := []deprecation.Warning{
+		deprecation.CRIAPIV1Alpha2,
+	}
+	assert.Equal(t, expectedWarnings, ws.GetWarnings())
 }

--- a/pkg/cri/server/testing/fake_warning_service.go
+++ b/pkg/cri/server/testing/fake_warning_service.go
@@ -1,0 +1,46 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/pkg/deprecation"
+	"github.com/containerd/containerd/services/warning"
+)
+
+// FakeWarningService is a fake service used for test.
+type FakeWarningService struct {
+	warnings []deprecation.Warning
+}
+
+// NewFakeWarningService create a FakeWarningService.
+func NewFakeWarningService() *FakeWarningService {
+	return &FakeWarningService{warnings: []deprecation.Warning{}}
+}
+
+func (ws *FakeWarningService) Emit(ctx context.Context, w deprecation.Warning) {
+	ws.warnings = append(ws.warnings, w)
+}
+
+func (ws *FakeWarningService) Warnings() []warning.Warning {
+	return nil
+}
+
+func (ws *FakeWarningService) GetWarnings() []deprecation.Warning {
+	return ws.warnings
+}

--- a/pkg/deprecation/deprecation.go
+++ b/pkg/deprecation/deprecation.go
@@ -31,6 +31,8 @@ const (
 	CRIRegistryAuths Warning = Prefix + "cri-registry-auths"
 	// CRIRegistryConfigs is a warning for the use of the `configs` property
 	CRIRegistryConfigs Warning = Prefix + "cri-registry-configs"
+	// CRIAPIV1Alpha2 is a warning for the use of CRI-API v1alpha2
+	CRIAPIV1Alpha2 Warning = Prefix + "cri-api-v1alpha2"
 )
 
 var messages = map[Warning]string{
@@ -43,6 +45,7 @@ var messages = map[Warning]string{
 		"Use `ImagePullSecrets` instead.",
 	CRIRegistryConfigs: "The `configs` property of `[plugins.\"io.containerd.grpc.v1.cri\".registry]` is deprecated since containerd v1.5 and will be removed in containerd v2.0." +
 		"Use `config_path` instead.",
+	CRIAPIV1Alpha2: "CRI API v1alpha2 is deprecated since containerd v1.7 and removed in containerd v2.0. Use CRI API v1 instead.",
 }
 
 // Valid checks whether a given Warning is valid


### PR DESCRIPTION
This PR reports the usage of the deprecated v1alpha2 api by hooking warning service into instrumented_service.

Since v1alpha2 is removed from main, I am submitting the PR directly against release/1.7.