### PR TITLE
integration: revisit TestIssue9103

### DIFF
--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -1453,7 +1453,7 @@ func TestIssue9103(t *testing.T) {
 			desc: "should be created status",
 			cntrOpts: []NewContainerOpts{
 				WithNewSpec(oci.WithImageConfig(image),
-					withProcessArgs("sleep", "30"),
+					withProcessArgs("sleep", "inf"),
 				),
 			},
 			expectedStatus: Created,
@@ -1462,7 +1462,7 @@ func TestIssue9103(t *testing.T) {
 			desc: "should be stopped status if init has been killed",
 			cntrOpts: []NewContainerOpts{
 				WithNewSpec(oci.WithImageConfig(image),
-					withProcessArgs("sleep", "30"),
+					withProcessArgs("sleep", "inf"),
 					oci.WithAnnotations(map[string]string{
 						"oci.runc.failpoint.profile": "issue9103",
 					}),
@@ -1492,7 +1492,7 @@ func TestIssue9103(t *testing.T) {
 
 			status, err := task.Status(ctx)
 			require.NoError(t, err)
-			require.Equal(t, status.Status, tc.expectedStatus)
+			require.Equal(t, tc.expectedStatus, status.Status)
 		})
 	}
 }


### PR DESCRIPTION
Container execution and task context timeout are both set to 30 seconds, which introduces the opportunity for a race condition.  Allow the container to run indefinitely (sleep inf) so that an exit does not race with the task timeout.

I _think_ this helps with https://github.com/containerd/containerd/issues/9334.  This same commit against `release/1.6` seems to be more reliable (I reran CI on https://github.com/containerd/containerd/pull/9335 several times to check).  Opening this against `main` and then will cherry-pick back.