### PR TITLE
[release/1.7] fix: shimv1 leak issue

### DIFF
--- a/runtime/v1/linux/task.go
+++ b/runtime/v1/linux/task.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	cgroups "github.com/containerd/cgroups/v3/cgroup1"
@@ -94,7 +95,14 @@ func (t *Task) Delete(ctx context.Context) (*runtime.Exit, error) {
 	rsp, shimErr := t.shim.Delete(ctx, empty)
 	if shimErr != nil {
 		shimErr = errdefs.FromGRPC(shimErr)
-		if !errdefs.IsNotFound(shimErr) {
+		if !errdefs.IsNotFound(shimErr) &&
+			// NOTE: The last Detete call has deleted the init process
+			// record in shim service. However, the last call took
+			// so long and then the client side canceled the call.
+			// After the client retries the Delete, the shim service
+			// doesn't find the init process and returns `container
+			// must be created`. We should tolerate this issue.
+			!(errdefs.IsFailedPrecondition(shimErr) && strings.Contains(shimErr.Error(), "container must be created")) {
 			return nil, shimErr
 		}
 	}


### PR DESCRIPTION
```go
// Delete the initial process and container
func (s *Service) Delete(ctx context.Context, r *ptypes.Empty) (*shimapi.DeleteResponse, error) {
        p, err := s.getInitProcess()
        if err != nil {
                return nil, err
        }
        if err := p.Delete(ctx); err != nil {
                return nil, errdefs.ToGRPC(err)
        }

	// The client might canceled the request but the shim service still
	// moved on. The `delete(s.processes, s.id)` was executed
	// successfully. So the next Delete call will return `container
	// must be created` error. The client side should ignore this
	// issue.

        s.mu.Lock()
        delete(s.processes, s.id)
        s.mu.Unlock()
        s.platform.Close()
        return &shimapi.DeleteResponse{
                ExitStatus: uint32(p.ExitStatus()),
                ExitedAt:   protobuf.ToTimestamp(p.ExitedAt()),
                Pid:        uint32(p.Pid()),
        }, nil
}
```

introduced by #9003
fixes: #9309