### PR TITLE
fix: increase ImagePullProgressTimeout as 10min

### DIFF
--- a/pkg/cri/config/config_unix.go
+++ b/pkg/cri/config/config_unix.go
@@ -19,8 +19,6 @@
 package config
 
 import (
-	"time"
-
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/pelletier/go-toml/v2"
 	"k8s.io/kubelet/pkg/cri/streaming"
@@ -100,7 +98,7 @@ func DefaultConfig() PluginConfig {
 		},
 		EnableCDI:                false,
 		CDISpecDirs:              []string{"/etc/cdi", "/var/run/cdi"},
-		ImagePullProgressTimeout: time.Minute.String(),
+		ImagePullProgressTimeout: "10m0s",
 		DrainExecSyncIOTimeout:   "0s",
 	}
 }

--- a/pkg/cri/config/config_windows.go
+++ b/pkg/cri/config/config_windows.go
@@ -19,7 +19,6 @@ package config
 import (
 	"os"
 	"path/filepath"
-	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"k8s.io/kubelet/pkg/cri/streaming"
@@ -84,7 +83,7 @@ func DefaultConfig() PluginConfig {
 		ImageDecryption: ImageDecryption{
 			KeyModel: KeyModelNode,
 		},
-		ImagePullProgressTimeout: time.Minute.String(),
+		ImagePullProgressTimeout: "10m0s",
 		DrainExecSyncIOTimeout:   "0s",
 	}
 }


### PR DESCRIPTION
https://github.com/containerd/containerd/pull/6150 defines ImagePullProgressTimeout  as 1min, while this default timeout is sometimes too small when 1) pulling image is slow 2) big image layer extraction on the local disk costing more time 3) pulling big image, this PR tries to increase ImagePullProgressTimeout as 10min