### PR TITLE
add default enable unprivileged icmp/ports

### DIFF
--- a/pkg/cri/config/config_unix.go
+++ b/pkg/cri/config/config_unix.go
@@ -102,5 +102,7 @@ func DefaultConfig() PluginConfig {
 		CDISpecDirs:              []string{"/etc/cdi", "/var/run/cdi"},
 		ImagePullProgressTimeout: time.Minute.String(),
 		DrainExecSyncIOTimeout:   "0s",
+		EnableUnprivilegedPorts:  true,
+		EnableUnprivilegedICMP:   true,
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/containerd/containerd/issues/6924

current we add verify kernel version when enable unprivileged https://github.com/containerd/containerd/pull/9172, so we can default enable unprivileged icmp and ports.