### PR TITLE
doc: change containerd-config.8.md

### DIFF
--- a/docs/man/containerd-config.8.md
+++ b/docs/man/containerd-config.8.md
@@ -10,22 +10,28 @@ containerd config [command]
 
 ## DESCRIPTION
 
-The *containerd config* command has one subcommand, named *default*, which
-will display on standard output the default containerd config for this version
-of the containerd daemon.
+containerd config command used for generating config file in TOML format.  
 
-This output can be piped to a __containerd-config.toml(5)__ file and placed in
+these commands' output can be piped to a __containerd-config.toml(5)__ file and placed in
 **/etc/containerd** to be used as the configuration for containerd on daemon
 startup. The configuration can be placed in any filesystem location and used
-with the **--config** option to the containerd daemon as well.
+with the **--config** option to the containerd daemon as well.  
 
 See __containerd-config.toml(5)__ for more information on the containerd
 configuration options.
 
+
+
 ## OPTIONS
 
 **default**
-: This subcommand will output the TOML formatted containerd configuration to standard output
+: This subcommand will generate the default containerd configuration 
+
+**dump**
+: This subcommand will dump the config file of system with other subconfig files.
+
+**migrate**
+: This subcommand gets your current config file and migrate it to the latest version but ___does not___ migrate subconfig files.
 
 ## BUGS
 


### PR DESCRIPTION
four things changed
1. explaining of "config default" command was in the description that i delete it (there was another one in option section)
2. add first line of description
3. change explaining of "config default" in options  
4. add explaining of "config dump" and "config migrate" to option section 