### PR TITLE
services/server, runtime/v2/shim: use structured log for plugin ID

### DIFF
--- a/runtime/v2/shim/shim.go
+++ b/runtime/v2/shim/shim.go
@@ -319,7 +319,7 @@ func run(ctx context.Context, manager Manager, config Config) error {
 
 	for _, p := range registry.Graph(func(*plugin.Registration) bool { return false }) {
 		pID := p.URI()
-		log.G(ctx).WithField("type", p.Type).Infof("loading plugin %q...", pID)
+		log.G(ctx).WithFields(log.Fields{"id": pID, "type": p.Type}).Info("loading plugin")
 
 		initContext := plugin.NewContext(
 			ctx,
@@ -353,7 +353,7 @@ func run(ctx context.Context, manager Manager, config Config) error {
 		instance, err := result.Instance()
 		if err != nil {
 			if plugin.IsSkipPlugin(err) {
-				log.G(ctx).WithError(err).WithField("type", p.Type).Infof("skip loading plugin %q...", pID)
+				log.G(ctx).WithFields(log.Fields{"id": pID, "type": p.Type, "error": err}).Info("skip loading plugin")
 				continue
 			}
 			return fmt.Errorf("failed to load plugin %s: %w", pID, err)

--- a/runtime/v2/shim/shim.go
+++ b/runtime/v2/shim/shim.go
@@ -318,8 +318,8 @@ func run(ctx context.Context, manager Manager, name string, config Config) error
 	)
 
 	for _, p := range registry.Graph(func(*plugin.Registration) bool { return false }) {
-		id := p.URI()
-		log.G(ctx).WithField("type", p.Type).Infof("loading plugin %q...", id)
+		pID := p.URI()
+		log.G(ctx).WithField("type", p.Type).Infof("loading plugin %q...", pID)
 
 		initContext := plugin.NewContext(
 			ctx,
@@ -353,14 +353,14 @@ func run(ctx context.Context, manager Manager, name string, config Config) error
 		instance, err := result.Instance()
 		if err != nil {
 			if plugin.IsSkipPlugin(err) {
-				log.G(ctx).WithError(err).WithField("type", p.Type).Infof("skip loading plugin %q...", id)
+				log.G(ctx).WithError(err).WithField("type", p.Type).Infof("skip loading plugin %q...", pID)
 				continue
 			}
-			return fmt.Errorf("failed to load plugin %s: %w", id, err)
+			return fmt.Errorf("failed to load plugin %s: %w", pID, err)
 		}
 
 		if src, ok := instance.(TTRPCService); ok {
-			log.G(ctx).WithField("id", id).Debug("registering ttrpc service")
+			log.G(ctx).WithField("id", pID).Debug("registering ttrpc service")
 			ttrpcServices = append(ttrpcServices, src)
 
 		}

--- a/runtime/v2/shim/shim.go
+++ b/runtime/v2/shim/shim.go
@@ -189,13 +189,13 @@ func Run(ctx context.Context, manager Manager, opts ...BinaryOpts) {
 
 	ctx = log.WithLogger(ctx, log.G(ctx).WithField("runtime", manager.Name()))
 
-	if err := run(ctx, manager, "", config); err != nil {
+	if err := run(ctx, manager, config); err != nil {
 		fmt.Fprintf(os.Stderr, "%s: %s", manager.Name(), err)
 		os.Exit(1)
 	}
 }
 
-func run(ctx context.Context, manager Manager, name string, config Config) error {
+func run(ctx context.Context, manager Manager, config Config) error {
 	parseFlags()
 	if versionFlag {
 		fmt.Printf("%s:\n", filepath.Base(os.Args[0]))

--- a/services/server/config/config_test.go
+++ b/services/server/config/config_test.go
@@ -86,7 +86,7 @@ func TestResolveImports(t *testing.T) {
 	tempDir := t.TempDir()
 
 	for _, filename := range []string{"config_1.toml", "config_2.toml", "test.toml"} {
-		err := os.WriteFile(filepath.Join(tempDir, filename), []byte(""), 0600)
+		err := os.WriteFile(filepath.Join(tempDir, filename), []byte(""), 0o600)
 		assert.NoError(t, err)
 	}
 
@@ -118,7 +118,7 @@ root = "/var/lib/containerd"
 	tempDir := t.TempDir()
 
 	path := filepath.Join(tempDir, "config.toml")
-	err := os.WriteFile(path, []byte(data), 0600)
+	err := os.WriteFile(path, []byte(data), 0o600)
 	assert.NoError(t, err)
 
 	var out Config
@@ -147,10 +147,10 @@ disabled_plugins = ["io.containerd.v1.xyz"]
 
 	tempDir := t.TempDir()
 
-	err := os.WriteFile(filepath.Join(tempDir, "data1.toml"), []byte(data1), 0600)
+	err := os.WriteFile(filepath.Join(tempDir, "data1.toml"), []byte(data1), 0o600)
 	assert.NoError(t, err)
 
-	err = os.WriteFile(filepath.Join(tempDir, "data2.toml"), []byte(data2), 0600)
+	err = os.WriteFile(filepath.Join(tempDir, "data2.toml"), []byte(data2), 0o600)
 	assert.NoError(t, err)
 
 	var out Config
@@ -175,10 +175,10 @@ imports = ["data1.toml", "data2.toml"]
 `
 	tempDir := t.TempDir()
 
-	err := os.WriteFile(filepath.Join(tempDir, "data1.toml"), []byte(data1), 0600)
+	err := os.WriteFile(filepath.Join(tempDir, "data1.toml"), []byte(data1), 0o600)
 	assert.NoError(t, err)
 
-	err = os.WriteFile(filepath.Join(tempDir, "data2.toml"), []byte(data2), 0600)
+	err = os.WriteFile(filepath.Join(tempDir, "data2.toml"), []byte(data2), 0o600)
 	assert.NoError(t, err)
 
 	var out Config
@@ -207,7 +207,7 @@ version = 2
 	tempDir := t.TempDir()
 
 	path := filepath.Join(tempDir, "config.toml")
-	err := os.WriteFile(path, []byte(data), 0600)
+	err := os.WriteFile(path, []byte(data), 0o600)
 	assert.NoError(t, err)
 
 	var out Config
@@ -230,7 +230,7 @@ func TestDecodePluginInV1Config(t *testing.T) {
 `
 
 	path := filepath.Join(t.TempDir(), "config.toml")
-	err := os.WriteFile(path, []byte(data), 0600)
+	err := os.WriteFile(path, []byte(data), 0o600)
 	assert.NoError(t, err)
 
 	var out Config

--- a/services/server/server.go
+++ b/services/server/server.go
@@ -341,12 +341,12 @@ func New(ctx context.Context, config *srvconfig.Config) (*Server, error) {
 // recordConfigDeprecations attempts to record use of any deprecated config field.  Failures are logged and ignored.
 func recordConfigDeprecations(ctx context.Context, config *srvconfig.Config, set *plugin.Set) {
 	// record any detected deprecations without blocking server startup
-	plugin := set.Get(plugins.WarningPlugin, plugins.DeprecationsPlugin)
-	if plugin == nil {
+	p := set.Get(plugins.WarningPlugin, plugins.DeprecationsPlugin)
+	if p == nil {
 		log.G(ctx).Warn("failed to find warning service to record deprecations")
 		return
 	}
-	instance, err := plugin.Instance()
+	instance, err := p.Instance()
 	if err != nil {
 		log.G(ctx).WithError(err).Warn("failed to load warning service to record deprecations")
 		return

--- a/services/server/server.go
+++ b/services/server/server.go
@@ -81,16 +81,16 @@ func CreateTopLevelDirectories(config *srvconfig.Config) error {
 		return errors.New("root and state must be different paths")
 	}
 
-	if err := sys.MkdirAllWithACL(config.Root, 0711); err != nil {
+	if err := sys.MkdirAllWithACL(config.Root, 0o711); err != nil {
 		return err
 	}
 
-	if err := sys.MkdirAllWithACL(config.State, 0711); err != nil {
+	if err := sys.MkdirAllWithACL(config.State, 0o711); err != nil {
 		return err
 	}
 
 	if config.TempDir != "" {
-		if err := sys.MkdirAllWithACL(config.TempDir, 0711); err != nil {
+		if err := sys.MkdirAllWithACL(config.TempDir, 0o711); err != nil {
 			return err
 		}
 		if runtime.GOOS == "windows" {


### PR DESCRIPTION
Also some minor refactor/fixes;

### services/server: gofumpt

### services/server: rename var that collided with import

### services/server: use structured log for plugin ID

These logs were already using structured logs, so include "id" as a field,
which also prevents the id being quoted (and escaped when printing);

    time="2023-11-15T11:30:23.745574884Z" level=info msg="loading plugin \"io.containerd.internal.v1.shutdown\"..." runtime=io.containerd.runc.v2 type=io.containerd.internal.v1
    time="2023-11-15T11:30:23.745612425Z" level=info msg="loading plugin \"io.containerd.ttrpc.v1.pause\"..." runtime=io.containerd.runc.v2 type=io.containerd.ttrpc.v1
    time="2023-11-15T11:30:23.745620884Z" level=info msg="loading plugin \"io.containerd.event.v1.publisher\"..." runtime=io.containerd.runc.v2 type=io.containerd.event.v1
    time="2023-11-15T11:30:23.745625925Z" level=info msg="loading plugin \"io.containerd.ttrpc.v1.task\"..." runtime=io.containerd.runc.v2 type=io.containerd.ttrpc.v1

Also updated some changed `WithError().WithField()` calls, to prevent some
overhead.

### runtime/v2/shim: rename var that shadowed package var

### runtime/v2/shim: run(): remove unused "name" argument

### runtime/v2/shim: use structured log for plugin ID

These logs were already using structured logs, so include "id" as a field,
which also prevents the id being quoted (and escaped when printing);

    time="2023-11-15T11:30:23.745574884Z" level=info msg="loading plugin \"io.containerd.internal.v1.shutdown\"..." runtime=io.containerd.runc.v2 type=io.containerd.internal.v1
    time="2023-11-15T11:30:23.745612425Z" level=info msg="loading plugin \"io.containerd.ttrpc.v1.pause\"..." runtime=io.containerd.runc.v2 type=io.containerd.ttrpc.v1
    time="2023-11-15T11:30:23.745620884Z" level=info msg="loading plugin \"io.containerd.event.v1.publisher\"..." runtime=io.containerd.runc.v2 type=io.containerd.event.v1
    time="2023-11-15T11:30:23.745625925Z" level=info msg="loading plugin \"io.containerd.ttrpc.v1.task\"..." runtime=io.containerd.runc.v2 type=io.containerd.ttrpc.v1

Also updated some changed `WithError().WithField()` calls, to prevent some
overhead.
