### PR TITLE
Enhance container image unpack client logs

### DIFF
--- a/pkg/unpack/unpacker.go
+++ b/pkg/unpack/unpacker.go
@@ -235,6 +235,7 @@ func (u *Unpacker) unpack(
 	ctx := u.ctx
 	ctx, layerSpan := tracing.StartSpan(ctx, tracing.Name(unpackSpanPrefix, "unpack"))
 	defer layerSpan.End()
+	unpackStart := time.Now()
 	p, err := content.ReadBlob(ctx, u.content, config)
 	if err != nil {
 		return err
@@ -411,6 +412,7 @@ func (u *Unpacker) unpack(
 
 	for i, desc := range layers {
 		_, layerSpan := tracing.StartSpan(ctx, tracing.Name(unpackSpanPrefix, "unpackLayer"))
+		unpackLayerStart := time.Now()
 		layerSpan.SetAttributes(
 			tracing.Attribute("layer.media.type", desc.MediaType),
 			tracing.Attribute("layer.media.size", desc.Size),
@@ -422,6 +424,10 @@ func (u *Unpacker) unpack(
 			return err
 		}
 		layerSpan.End()
+		log.G(ctx).WithFields(log.Fields{
+			"layer":    desc.Digest,
+			"duration": time.Since(unpackLayerStart),
+		}).Debug("layer unpacked")
 	}
 
 	chainID := identity.ChainID(chain).String()
@@ -436,8 +442,9 @@ func (u *Unpacker) unpack(
 		return err
 	}
 	log.G(ctx).WithFields(log.Fields{
-		"config":  config.Digest,
-		"chainID": chainID,
+		"config":   config.Digest,
+		"chainID":  chainID,
+		"duration": time.Since(unpackStart),
 	}).Debug("image unpacked")
 
 	return nil


### PR DESCRIPTION
#### Issue: #9370 

#### Description:
Adds debug message per layer unpacking and adds duration field to the existing image unpacking debug message.

#### Testing:

Enabled debug logging and pulled a remote container image using containerd client.

```
DEBU[0002] layer unpacked                                duration=1.85479628s layer="sha256:ee649e0574bc181056f3ad7d6cfbbf11df90636ee21663254099ee9b61f7daa1"
DEBU[0002] image unpacked                                chainID="sha256:f0d9a81fc6ee8ceecb397caab06f344911c5e6cb7f9ab2830a151852f2d36041" config="sha256:c8cd5ac90067a1bd4ecd9569d4fc873a9a2d905c13be255cb8a8a76f4b499988" duration=1.857971524s
```

Signed-off-by: Austin Vazquez <macedonv@amazon.com>