### PR TITLE
adopters.md: remove Eliot project

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -32,8 +32,6 @@ including the Balena project listed below.
 
 **_Rancher's Rio project_** - Rancher Labs [Rio](https://github.com/rancher/rio) project uses containerd as the runtime for a combined Kubernetes, Istio, and container "Cloud Native Container Distribution" platform.
 
-**_Eliot_** - The [Eliot](https://github.com/ernoaapa/eliot) container project for IoT device container management uses containerd as the runtime.
-
 **_Balena_** - Resin's [Balena](https://github.com/resin-os/balena) container engine, based on moby/moby but for edge, embedded, and IoT use cases, uses the containerd and runc stack in the same way that the Docker engine uses containerd.
 
 **_LinuxKit_** - the Moby project's [LinuxKit](https://github.com/linuxkit/linuxkit) for building secure, minimal Linux OS images in a container-native model uses containerd as the core runtime for system and service containers.


### PR DESCRIPTION
remove project from ADOPTERS as it is now inactive.

Follow up of : https://github.com/containerd/containerd.io/pull/203