### PR TITLE
fix: podsandbox depends on Lease plugin

### DIFF
--- a/pkg/cri/server/podsandbox/controller.go
+++ b/pkg/cri/server/podsandbox/controller.go
@@ -48,6 +48,7 @@ func init() {
 		ID:   "podsandbox",
 		Requires: []plugin.Type{
 			plugins.EventPlugin,
+			plugins.LeasePlugin,
 			plugins.ServicePlugin,
 		},
 		InitFn: func(ic *plugin.InitContext) (interface{}, error) {


### PR DESCRIPTION
introduced by 09723a61755ffe5312ac7f0f65949f10b5931b91

----

The lease plugin doesn't have service type. So, like image/container apis, they needs lease plugin.

```
=== CONT  TestCRIImagePullTimeout/HoldingContentOpenWriter
    log_hook.go:47: time="2023-11-17T23:32:54.448668709+08:00" level=info msg="metadata content store policy set" func=plugin.init.1.func1 file="/home/fuwei/go/src/github.com/containerd/containerd/metadata/plugin/plugin.go:134" policy=shared testcase=TestCRIImagePullTimeout/HoldingContentOpenWriter
    build_local_containerd_helper_test.go:120:
                Error Trace:    /home/fuwei/go/src/github.com/containerd/containerd/integration/build_local_containerd_helper_test.go:120
                                                        /home/fuwei/go/src/github.com/containerd/containerd/integration/image_pull_timeout_test.go:113
                Error:          Received unexpected error:
                                unable to load CRI service base dependencies: failed to get "io.containerd.lease.v1" plugin: no plugins registered for io.containerd.lease.v1: plugin: not found
                Test:           TestCRIImagePullTimeout/HoldingContentOpenWriter
    build_local_containerd_helper_test.go:120:
                Error Trace:    /home/fuwei/go/src/github.com/containerd/containerd/integration/build_local_containerd_helper_test.go:120
                                                        /home/fuwei/go/src/github.com/containerd/containerd/integration/image_pull_timeout_test.go:113
                Error:          Received unexpected error:
                                unable to load CRI service base dependencies: failed to get "io.containerd.lease.v1" plugin: no plugins registered for io.containerd.lease.v1: plugin: not found
                Test:           TestCRIImagePullTimeout/HoldingContentOpenWriter
    build_local_containerd_helper_test.go:132:
                Error Trace:    /home/fuwei/go/src/github.com/containerd/containerd/integration/build_local_containerd_helper_test.go:132
                                                        /home/fuwei/go/src/github.com/containerd/containerd/integration/image_pull_timeout_test.go:113
                Error:          Received unexpected error:
                                unable to load CRI service base dependencies: failed to get "io.containerd.lease.v1" plugin: no plugins registered for io.containerd.lease.v1: plugin: not found
                Test:           TestCRIImagePullTimeout/HoldingContentOpenWriter
```