### PR TITLE
[release/1.6] Prepare release notes for v1.6.25

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -29,6 +29,8 @@ Eric Ernst <eric@amperecomputing.com> <eric.ernst@intel.com>
 Eric Ren <renzhen.rz@linux.alibaba.com> <renzhen@linux.alibaba.com>
 Eric Ren <renzhen.rz@linux.alibaba.com> <renzhen.rz@alibaba-linux.com>
 Eric Ren <renzhen.rz@linux.alibaba.com> <renzhen.rz@alibaba-inc.com>
+Fabian Hoffmann <extern.fabian.hoffmann@cariad.technology>
+Fabian Hoffmann <extern.fabian.hoffmann@cariad.technology> <35104465+FabHof@users.noreply.github.com>
 Fabiano Fidêncio <fidencio@redhat.com> <fabiano.fidencio@intel.com>
 Fahed Dorgaa <fahed.dorgaa@gmail.com>
 Frank Yang <yyb196@gmail.com>
@@ -43,7 +45,7 @@ haoyun <yun.hao@daocloud.io>
 Harry Zhang <harryz@hyper.sh> <harryzhang@zju.edu.cn>
 Hu Shuai <hus.fnst@cn.fujitsu.com>
 Hu Shuai <hus.fnst@cn.fujitsu.com> <hushuaiia@qq.com>
-Iceber Gu <wei.cai-nat@daocloud.io>
+Iceber Gu <wei.cai-nat@daocloud.io> <caiwei95@hotmail.com>
 Jaana Burcu Dogan <burcujdogan@gmail.com> <jbd@golang.org>
 Jess Valarezo <valarezo.jessica@gmail.com>
 Jess Valarezo <valarezo.jessica@gmail.com> <jessica.valarezo@docker.com>

--- a/releases/v1.6.25.toml
+++ b/releases/v1.6.25.toml
@@ -1,0 +1,51 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.6.24"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The twenty-fifth patch release for containerd 1.6 contains various fixes and updates.
+
+### Notable Updates
+
+* **Check whether content did not needs to be pushed to remote registry and cross-repo mounted or already existed** ([#9111](https://github.com/containerd/containerd/pull/9111))
+* **Soft deprecate log package** ([#9105](https://github.com/containerd/containerd/pull/9105))
+* **Always try to establish tls connection when tls configured** ([#9189](https://github.com/containerd/containerd/pull/9189))
+* **CRI: stop recommending disable_cgroup** ([#9169](https://github.com/containerd/containerd/pull/9169))
+* **Allow for images with artifacts layers to pull** ([#9150](https://github.com/containerd/containerd/pull/9150))
+* **Require plugins to succeed after registering readiness** ([#9166](https://github.com/containerd/containerd/pull/9166))
+* **Avoid potential deadlock in create handler in containerd-shim-runc-v2** ([#9210](https://github.com/containerd/containerd/pull/9210))
+* **Add handling for missing basic auth credentials** ([#9236](https://github.com/containerd/containerd/pull/9236))
+* **Add a new image label if it is docker schema 1** ([#9267](https://github.com/containerd/containerd/pull/9267))
+* **Fix ambiguous tls fallback** ([#9300](https://github.com/containerd/containerd/pull/9300))
+* **Expose usage of deprecated features** ([#9329](https://github.com/containerd/containerd/pull/9329))
+* **Fix shimv1 leak issue** ([#9345](https://github.com/containerd/containerd/pull/9345))
+* **Go version update to 1.20.10**([#9264](https://github.com/containerd/containerd/pull/9264))
+* **Update runc to v1.1.10** ([#9360](https://github.com/containerd/containerd/pull/9360))
+* **CRI: fix using the pinned label to pin image** ([#9382](https://github.com/containerd/containerd/pull/9382))
+
+See the changelog for complete list of changes"""
+
+# override dependency of containerd/log
+[override_deps]
+    [override_deps."github.com/containerd/log"]
+        # commit sha in containerd/log corresponding to the last commit in v1.6.24
+        previous="cf9777876edf6a4aa230c739bc7eec5ab8349e9c"

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.24+unknown"
+	Version = "1.6.25+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
containerd 1.6.25

Welcome to the v1.6.25 release of containerd!

The twenty-fifth patch release for containerd 1.6 contains various fixes and updates.

### Notable Updates

* **Check whether content did not needs to be pushed to remote registry and cross-repo mounted or already existed** ([#9111](https://github.com/containerd/containerd/pull/9111))
* **Soft deprecate log package** ([#9105](https://github.com/containerd/containerd/pull/9105))
* **Always try to establish tls connection when tls configured** ([#9189](https://github.com/containerd/containerd/pull/9189))
* **CRI: stop recommending disable_cgroup** ([#9169](https://github.com/containerd/containerd/pull/9169))
* **Allow for images with artifacts layers to pull** ([#9150](https://github.com/containerd/containerd/pull/9150))
* **Require plugins to succeed after registering readiness** ([#9166](https://github.com/containerd/containerd/pull/9166))
* **Avoid potential deadlock in create handler in containerd-shim-runc-v2** ([#9210](https://github.com/containerd/containerd/pull/9210))
* **Add handling for missing basic auth credentials** ([#9236](https://github.com/containerd/containerd/pull/9236))
* **Add a new image label if it is docker schema 1** ([#9267](https://github.com/containerd/containerd/pull/9267))
* **Fix ambiguous tls fallback** ([#9300](https://github.com/containerd/containerd/pull/9300))
* **Expose usage of deprecated features** ([#9329](https://github.com/containerd/containerd/pull/9329))
* **Fix shimv1 leak issue** ([#9345](https://github.com/containerd/containerd/pull/9345))
* **Go version update to 1.20.10**([#9264](https://github.com/containerd/containerd/pull/9264))
* **Update runc to v1.1.10** ([#9360](https://github.com/containerd/containerd/pull/9360))
* **CRI: fix using the pinned label to pin image** ([#9382](https://github.com/containerd/containerd/pull/9382))

See the changelog for complete list of changes

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Samuel Karp
* Derek McGowan
* Sebastiaan van Stijn
* Wei Fu
* Phil Estes
* Kazuyoshi Kato
* Akhil Mohan
* Akihiro Suda
* Chen Yiyang
* Fabian Hoffmann
* Iceber Gu
* Mike Brown
* Paweł Gronowski
* Austin Vazquez
* Fahed Dorgaa
* James Sturtevant
* Kern Walster
* Marat Radchenko
* Qiutong Song
* Tony Fouchard
* ruiwen-zhao

### Changes
<details><summary>80 commits</summary>
<p>

  * [`9d8a8cbe9`](https://github.com/containerd/containerd/commit/9d8a8cbe9389bb0beeb36346402466b199c56a59) Prepare release notes for v1.6.25
  * [`e959889d3`](https://github.com/containerd/containerd/commit/e959889d31526e3a7519dfd31c26a054b7ccaac3) update mailmap
  * [`0187d48d8`](https://github.com/containerd/containerd/commit/0187d48d887ff2b1801e9194236352387426d8e1) cri: fix update of pinned label for images
  * [`5a42189f6`](https://github.com/containerd/containerd/commit/5a42189f64fb5d02bb4cbb8faa3b3b769b8ce2b6) cri: fix using the pinned label to pin image
* [Release/1.6] vendor: golang.org/x/net v0.17.0 ([#9387](https://github.com/containerd/containerd/pull/9387))
  * [`fb5568608`](https://github.com/containerd/containerd/commit/fb5568608079ed772381c52297e474c9f951d285) vendor: golang.org/x/net v0.17.0
  * [`61ad86f6f`](https://github.com/containerd/containerd/commit/61ad86f6f9ce78c67a4ece671e1b91be080dcf61) vendor: golang.org/x/text v0.13.0
  * [`4b431c844`](https://github.com/containerd/containerd/commit/4b431c8441f38049d266a69da7e2a7045af5f2dc) vendor: golang.org/x/sys v0.13.0
* [Release/1.6] CVE-2022-1996 fix for go-restful ([#9385](https://github.com/containerd/containerd/pull/9385))
  * [`62d402275`](https://github.com/containerd/containerd/commit/62d402275cdee9748c08690156f9ccb724d7c061) Remove CVE-2022-1996 from containerd binary upgrading go-restful to 2.16.0
* [release/1.6] Enhance container image unpack client logs ([#9380](https://github.com/containerd/containerd/pull/9380))
  * [`3e68bf65a`](https://github.com/containerd/containerd/commit/3e68bf65af4405c517b4292a24781dc4e1419ac8) Enhance container image unpack client logs
* [release/1.6] update github.com/containerd/nri v0.1.1 ([#9107](https://github.com/containerd/containerd/pull/9107))
  * [`0dd65c826`](https://github.com/containerd/containerd/commit/0dd65c826ebcaf2376c4d38d3bbe99345bf64b86) [release/1.6] update github.com/containerd/nri v0.1.1
* [release/1.6 backport] update runc binary to v1.1.10 ([#9360](https://github.com/containerd/containerd/pull/9360))
  * [`c73be2446`](https://github.com/containerd/containerd/commit/c73be2446e4414c701e7fce7b8f391c3dd113e8b) update runc binary to v1.1.10
* [release/1.6] Expose usage of cri-api v1alpha2 ([#9357](https://github.com/containerd/containerd/pull/9357))
  * [`746bcf2eb`](https://github.com/containerd/containerd/commit/746bcf2ebb7950dafe89a0dcf8db48b428fdd2d1) Expose usage of cri-api v1alpha2
* [release/1.6] fix: shimv1 leak issue ([#9345](https://github.com/containerd/containerd/pull/9345))
  * [`8b51a95fb`](https://github.com/containerd/containerd/commit/8b51a95fb2b05dd3a2c00f16606656300cc8a1cf) fix: shimv1 leak issue
* [release/1.6] update to go1.20.10, test go1.21.3 ([#9264](https://github.com/containerd/containerd/pull/9264))
  * [`6741f819b`](https://github.com/containerd/containerd/commit/6741f819bfe4e8da485af2d0e1c7b134b40543b2) [release/1.6] update to go1.20.10, test go1.21.3
  * [`49615a0e9`](https://github.com/containerd/containerd/commit/49615a0e9e6f10fc0c13d509d2fc86f3bed63adc) [release/1.6] update to go1.20.9, test go1.21.2
* [release/1.6] cri: add deprecation warnings for mirrors, auths, and configs ([#9355](https://github.com/containerd/containerd/pull/9355))
  * [`b68204e53`](https://github.com/containerd/containerd/commit/b68204e53b39cb705e85283a8f4f2f6082ac484c) cri: add deprecation warning for configs
  * [`ae8c58319`](https://github.com/containerd/containerd/commit/ae8c58319d8144e583f7f3796a074b9090ae16e8) cri: add deprecation warning for auths
  * [`455edcad2`](https://github.com/containerd/containerd/commit/455edcad2cb5f414ef67001f0bdae9f9440cfad8) cri: add deprecation warning for mirrors
  * [`878823f4d`](https://github.com/containerd/containerd/commit/878823f4d26c4b1c823e6d194521b3e9d1309add) cri: add ability to emit deprecation warnings
* [release/1.6] deprecation: new package for deprecations ([#9329](https://github.com/containerd/containerd/pull/9329))
  * [`477b7d6a1`](https://github.com/containerd/containerd/commit/477b7d6a1a8a4c8731605316e7f67b6bdb742bd8) ctr: new deprecations command
  * [`24068b813`](https://github.com/containerd/containerd/commit/24068b813360602d59bc31b766fe79c5d3e82fb6) dynamic: record deprecation for dynamic plugins
  * [`218c7a1df`](https://github.com/containerd/containerd/commit/218c7a1df9ba3d2b28bbde72b772ccb3c3c061ed) server: add ability to record config deprecations
  * [`dfb9e1deb`](https://github.com/containerd/containerd/commit/dfb9e1deb9e749380518fdc6c732c55e5e2230a4) pull: record deprecation warning for schema 1
  * [`90b42da6f`](https://github.com/containerd/containerd/commit/90b42da6f4496d2be76d462a5300cac92f0a07ef) introspection: add support for deprecations
  * [`0b6766b37`](https://github.com/containerd/containerd/commit/0b6766b3741274e0a2c73eb96378d9cb8381b97d) api/introspection: deprecation warnings in server
  * [`de3cb4c18`](https://github.com/containerd/containerd/commit/de3cb4c18660abcb3d2e4b1d8dec0085e3d51077) warning: new service for deprecations
  * [`da1b4419b`](https://github.com/containerd/containerd/commit/da1b4419b25f35315ca297d2b058d2655f9d25fd) deprecation: new package for deprecations
* [release/1.6] integration: deflake TestIssue9103 ([#9353](https://github.com/containerd/containerd/pull/9353))
  * [`bca8a3f65`](https://github.com/containerd/containerd/commit/bca8a3f653d234e5356ab445eca9f6da0316ab77) integration: deflake TestIssue9103
* [release/1.6] ci: Use Vagrant on ubuntu-latest-4-cores ([#9332](https://github.com/containerd/containerd/pull/9332))
  * [`0985f7a43`](https://github.com/containerd/containerd/commit/0985f7a43db3e69a0c6d67d39b9397e5af71deca) ci: Use Vagrant on ubuntu-latest-4-cores
* [release/1.6] Fix ambiguous tls fallback ([#9300](https://github.com/containerd/containerd/pull/9300))
  * [`5dd64301c`](https://github.com/containerd/containerd/commit/5dd64301c89ad1e428a746f0e90d9d72b45fe1b8) Check scheme and host of request on push redirect
  * [`51df21d09`](https://github.com/containerd/containerd/commit/51df21d09ebfac3e3470529fe1372ca22496e606) Avoid TLS fallback when protocol is not ambiguous
* [release/1.6] Add a new image label if it is docker schema 1 ([#9267](https://github.com/containerd/containerd/pull/9267))
  * [`8108f0d03`](https://github.com/containerd/containerd/commit/8108f0d036be2c36f7fc69dd85286d299ee0bf7b) Add a new image label if it is docker schema 1
* [release/1.6 backport] fix protobuf aarch64 ([#9284](https://github.com/containerd/containerd/pull/9284))
  * [`5376afb3d`](https://github.com/containerd/containerd/commit/5376afb3dbec05541b018e361f1343f20dec3ada) fix protobuf aarch64
* [release/1.6] remotes: add handling for missing basic auth credentials ([#9236](https://github.com/containerd/containerd/pull/9236))
  * [`e529741d3`](https://github.com/containerd/containerd/commit/e529741d3f102c7b558255d0e8b053c4e0858bc1) remotes: add handling for missing basic auth credentials
  * [`ca45b92f4`](https://github.com/containerd/containerd/commit/ca45b92f4388ec7d0aa023f305891ec527b64484) Add ErrUnexpectedStatus to resolver
  * [`77c0175b4`](https://github.com/containerd/containerd/commit/77c0175b4269da0b409e1434576c1f86bf9a869c) Improve ErrUnexpectedStatus default string
* [release/1.6] Update x/net to 0.13 ([#9130](https://github.com/containerd/containerd/pull/9130))
  * [`275fc594d`](https://github.com/containerd/containerd/commit/275fc594d8cf462d647b7c2f4dbfd2c8812d87ed) Bump x/net to 0.13
* [release/1.6] Require plugins to succeed after registering readiness  ([#9166](https://github.com/containerd/containerd/pull/9166))
  * [`5223bf39a`](https://github.com/containerd/containerd/commit/5223bf39a636be1d347f9d73be2131e102922695) Require plugins to succeed after registering readiness
  * [`8f5eba314`](https://github.com/containerd/containerd/commit/8f5eba3148d91023df4277c705debb199fa85c57) cri: call RegisterReadiness after NewCRIService
* [release/1.6 backport] containerd-shim-runc-v2: avoid potential deadlock in create handler ([#9210](https://github.com/containerd/containerd/pull/9210))
  * [`7b61862e7`](https://github.com/containerd/containerd/commit/7b61862e7c3e3410318bb723671954b101acec33) *: add runc-fp as runc wrapper to inject failpoint
  * [`5238a6470`](https://github.com/containerd/containerd/commit/5238a6470ca921fe7e47f25b022ea815a1d6f9b4) containerd-shim-runc-v2: avoid potential deadlock in create handler
  * [`65e908ee1`](https://github.com/containerd/containerd/commit/65e908ee1370432a09c81d8f7bc7568ff3d7e784) containerd-shim-runc-v2: remove unnecessary `s.getContainer()`
  * [`1dd9acecb`](https://github.com/containerd/containerd/commit/1dd9acecb85860e374b750d908b33c44e4f75564) Uncopypaste parsing of OCI Bundle spec file
  * [`71c89ddf2`](https://github.com/containerd/containerd/commit/71c89ddf24b05743d9be6b12907dc22719ef769d) [release/1.6]: Vagrantfile: install failpoint binaries
* [release/1.6] cri: stop recommending disable_cgroup ([#9169](https://github.com/containerd/containerd/pull/9169))
  * [`7a0c8b6b7`](https://github.com/containerd/containerd/commit/7a0c8b6b750cbd2bf2377f1d4961609ea1ec6667) cri: stop recommending disable_cgroup
* [release/1.6] Allow for images with artifacts to pull ([#9150](https://github.com/containerd/containerd/pull/9150))
  * [`8066dd81c`](https://github.com/containerd/containerd/commit/8066dd81ca673fcf4c8887069769592ba9fd694d) Allow for images with artifacts to pull
* [release 1.6] remotes/docker: Fix MountedFrom prefixed with target repository ([#9192](https://github.com/containerd/containerd/pull/9192))
  * [`2fffc344a`](https://github.com/containerd/containerd/commit/2fffc344ad661b37a3dae6102b47f887c946f105) remotes/docker: Fix MountedFrom prefixed with target repository
* [release/1.6] remotes: always try to establish tls connection when tls configured ([#9189](https://github.com/containerd/containerd/pull/9189))
  * [`6b5912220`](https://github.com/containerd/containerd/commit/6b591222096f12902ca8269668b36093edcc1899) remotes: always try to establish tls connection when tls configured
* [release/1.6] Build binaries with 1.21.1 ([#9180](https://github.com/containerd/containerd/pull/9180))
  * [`37c758de1`](https://github.com/containerd/containerd/commit/37c758de159bce9544e65fefc81019af9fb0be69) Build binaries with 1.21.1
* [release/1.6 backport] alias log package to github.com/containerd/log v0.1.0 ([#9105](https://github.com/containerd/containerd/pull/9105))
  * [`f1591cc9b`](https://github.com/containerd/containerd/commit/f1591cc9b9d7f1b73f1c50cdca0ca577959eed48) alias log package to github.com/containerd/log v0.1.0
  * [`f68d2d93b`](https://github.com/containerd/containerd/commit/f68d2d93b8c815b8687b85c932a8de2960ad2db7) vendor: golang.org/x/sys v0.7.0
  * [`f305fb233`](https://github.com/containerd/containerd/commit/f305fb233db9764fcd9e83e9078fee213202c3ff) vendor: github.com/stretchr/testify v1.8.4
  * [`4e24a30af`](https://github.com/containerd/containerd/commit/4e24a30af397b0d4dd6a417467eede3386381516) vendor: github.com/sirupsen/logrus v1.9.3
* [release/1.6] remotes/docker: Add MountedFrom and Exists push status ([#9111](https://github.com/containerd/containerd/pull/9111))
  * [`b66c818ba`](https://github.com/containerd/containerd/commit/b66c818ba6bd9e4fe139a6f9d988b3724c7a54ec) remotes/docker: Add MountedFrom and Exists push status
</p>
</details>

### Changes from containerd/log
<details><summary>9 commits</summary>
<p>

* Update golangci to 1.49 ([#1](https://github.com/containerd/log/pull/1))
  * [`89c9a54`](https://github.com/containerd/log/commit/89c9a54561e8736fddc519cf033d936de65ebe67) Update golangci to 1.49
  * [`cf26711`](https://github.com/containerd/log/commit/cf267115d825238992448dbe1cd6cd440c934d8a) Update description in README
  * [`f9f250c`](https://github.com/containerd/log/commit/f9f250cc3a5d033c759b715aa09ff7cdbfc19500) Add project details
  * [`fb7fe3d`](https://github.com/containerd/log/commit/fb7fe3d663dee55b38f2ab094d9ac794dcacba40) Add github CI flow
  * [`7e13034`](https://github.com/containerd/log/commit/7e13034365475c99956f31770c43e296fc6d1a98) Add go module
  * [`16a3c76`](https://github.com/containerd/log/commit/16a3c768269b03fe62fff34d3a76528335a35064) Rename log import from logtest
  * [`698c398`](https://github.com/containerd/log/commit/698c39829fd9372465cb2537db16a7346afb9f31) Add README
  * [`87c83c4`](https://github.com/containerd/log/commit/87c83c42bbd22c5f1d3725fc5006b35217b4629a) Add license file
</p>
</details>

### Changes from containerd/nri
<details><summary>3 commits</summary>
<p>

* [release/0.1 backport] remove containerd as dependency ([#58](https://github.com/containerd/nri/pull/58))
  * [`4275101`](https://github.com/containerd/nri/commit/42751010c8e875a07117c74bfe57c011ae491594) Task: fix typo in godoc
  * [`f6acbf1`](https://github.com/containerd/nri/commit/f6acbf1dc5b357d216af8ffca9d26dd0db3e4ef1) remove containerd as dependency
</p>
</details>

### Dependency Changes

* **github.com/containerd/log**       v0.1.0 **_new_**
* **github.com/containerd/nri**       v0.1.0 -> v0.1.1
* **github.com/emicklei/go-restful**  v2.9.5 -> v2.16.0
* **github.com/sirupsen/logrus**      v1.9.0 -> v1.9.3
* **github.com/stretchr/testify**     v1.8.1 -> v1.8.4
* **golang.org/x/crypto**             3147a52a75dd -> v0.14.0
* **golang.org/x/net**                v0.8.0 -> v0.17.0
* **golang.org/x/sys**                v0.6.0 -> v0.13.0
* **golang.org/x/term**               v0.6.0 -> v0.13.0
* **golang.org/x/text**               v0.8.0 -> v0.13.0

Previous release can be found at [v1.6.24](https://github.com/containerd/containerd/releases/tag/v1.6.24)

