### PR TITLE
doc: Update containerd-config.8.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -538,7 +538,7 @@ jobs:
       fail-fast: false
       matrix:
         box:
-          - fedora/38-cloud-base
+          - fedora/39-cloud-base
           - rockylinux/8@8.0.0
     env:
       BOX: ${{ matrix.box }}

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,7 @@
 
 # Vagrantfile for Fedora and EL
 Vagrant.configure("2") do |config|
-  config.vm.box = ENV["BOX"] ? ENV["BOX"].split("@")[0] : "fedora/38-cloud-base"
+  config.vm.box = ENV["BOX"] ? ENV["BOX"].split("@")[0] : "fedora/39-cloud-base"
   # BOX_VERSION is deprecated. Use "BOX=<BOX>@<BOX_VERSION>".
   config.vm.box_version = ENV["BOX_VERSION"] || (ENV["BOX"].split("@")[1] if ENV["BOX"])
 

--- a/docs/man/containerd-config.8.md
+++ b/docs/man/containerd-config.8.md
@@ -10,22 +10,28 @@ containerd config [command]
 
 ## DESCRIPTION
 
-The *containerd config* command has one subcommand, named *default*, which
-will display on standard output the default containerd config for this version
-of the containerd daemon.
+containerd config command used for generating config file in TOML format.  
 
-This output can be piped to a __containerd-config.toml(5)__ file and placed in
+these commands' output can be piped to a __containerd-config.toml(5)__ file and placed in
 **/etc/containerd** to be used as the configuration for containerd on daemon
 startup. The configuration can be placed in any filesystem location and used
-with the **--config** option to the containerd daemon as well.
+with the **--config** option to the containerd daemon as well.  
 
 See __containerd-config.toml(5)__ for more information on the containerd
 configuration options.
 
+
+
 ## OPTIONS
 
 **default**
-: This subcommand will output the TOML formatted containerd configuration to standard output
+: This subcommand will generate the default containerd configuration 
+
+**dump**
+: This subcommand will dump the config file of system with other subconfig files.
+
+**migrate**
+: This subcommand gets your current config file and migrate it to the latest version but ___does not___ migrate subconfig files.
 
 ## BUGS
 

--- a/docs/man/containerd-config.8.md
+++ b/docs/man/containerd-config.8.md
@@ -10,12 +10,12 @@ containerd config [command]
 
 ## DESCRIPTION
 
-containerd config command used for generating config file in TOML format.  
+containerd config command used for generating config file in TOML format.
 
 these commands' output can be piped to a __containerd-config.toml(5)__ file and placed in
 **/etc/containerd** to be used as the configuration for containerd on daemon
 startup. The configuration can be placed in any filesystem location and used
-with the **--config** option to the containerd daemon as well.  
+with the **--config** option to the containerd daemon as well.
 
 See __containerd-config.toml(5)__ for more information on the containerd
 configuration options.
@@ -25,7 +25,7 @@ configuration options.
 ## OPTIONS
 
 **default**
-: This subcommand will generate the default containerd configuration 
+: This subcommand will generate the default containerd configuration.
 
 **dump**
 : This subcommand will dump the config file of system with other subconfig files.


### PR DESCRIPTION


four things changed

1. explaining of "config default" command was in the description that i delete it (there was another one in option section) add first line of description
2. change explaining of "config default" in options
3. add explaining of "config dump" and "config migrate" to option section

