### PR TITLE
remotes: support pushing blob in chunked

### DIFF
--- a/remotes/docker/pusher_test.go
+++ b/remotes/docker/pusher_test.go
@@ -17,6 +17,7 @@
 package docker
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -71,7 +72,7 @@ func TestGetManifestPath(t *testing.T) {
 func TestPusherErrClosedRetry(t *testing.T) {
 	ctx := context.Background()
 
-	p, reg, _, done := samplePusher(t)
+	_, p, reg, _, done := samplePusher(t)
 	defer done()
 
 	layerContent := []byte("test")
@@ -90,7 +91,7 @@ func TestPusherErrClosedRetry(t *testing.T) {
 func TestPusherHTTPFallback(t *testing.T) {
 	ctx := logtest.WithT(context.Background(), t)
 
-	p, reg, _, done := samplePusher(t)
+	_, p, reg, _, done := samplePusher(t)
 	defer done()
 
 	reg.uploadable = true
@@ -126,7 +127,7 @@ func TestPusherHTTPFallback(t *testing.T) {
 // TestPusherErrReset tests the push method if the request needs to be retried
 // i.e when ErrReset occurs
 func TestPusherErrReset(t *testing.T) {
-	p, reg, _, done := samplePusher(t)
+	_, p, reg, _, done := samplePusher(t)
 	defer done()
 
 	p.object = "latest@sha256:55d31f3af94c797b65b310569803cacc1c9f4a34bf61afcdc8138f89345c8308"
@@ -187,9 +188,9 @@ func tryUpload(ctx context.Context, t *testing.T, p dockerPusher, layerContent [
 	return cw.Commit(ctx, 0, "")
 }
 
-func samplePusher(t *testing.T) (dockerPusher, *uploadableMockRegistry, StatusTrackLocker, func()) {
+func samplePusher(t *testing.T) (remotes.Resolver, dockerPusher, *uploadableMockRegistry, StatusTrackLocker, func()) {
 	reg := &uploadableMockRegistry{
-		availableContents: make([]string, 0),
+		availableContents: make(map[string]bool),
 	}
 	s := httptest.NewServer(reg)
 	u, err := url.Parse(s.URL)
@@ -197,21 +198,28 @@ func samplePusher(t *testing.T) (dockerPusher, *uploadableMockRegistry, StatusTr
 		t.Fatal(err)
 	}
 	tracker := NewInMemoryTracker()
-	return dockerPusher{
+	hosts := []RegistryHost{
+		{
+			Client:       s.Client(),
+			Host:         u.Host,
+			Scheme:       u.Scheme,
+			Path:         u.Path,
+			Capabilities: HostCapabilityPull | HostCapabilityPush | HostCapabilityResolve,
+		},
+	}
+	resolver := NewResolver(ResolverOptions{
+		Hosts: func(string) ([]RegistryHost, error) {
+			return hosts, nil
+		},
+		Tracker: tracker,
+	})
+	return resolver, dockerPusher{
 		dockerBase: &dockerBase{
 			refspec: reference.Spec{
 				Locator: "example.com/samplerepository:latest",
 			},
 			repository: "samplerepository",
-			hosts: []RegistryHost{
-				{
-					Client:       s.Client(),
-					Host:         u.Host,
-					Scheme:       u.Scheme,
-					Path:         u.Path,
-					Capabilities: HostCapabilityPush | HostCapabilityResolve,
-				},
-			},
+			hosts:      hosts,
 		},
 		object:  "latest",
 		tracker: tracker,
@@ -223,7 +231,8 @@ var blobUploadRegexp = regexp.MustCompile(`/([a-z0-9]+)/blobs/uploads/(.*)`)
 
 // uploadableMockRegistry provides minimal registry APIs which are enough to serve requests from dockerPusher.
 type uploadableMockRegistry struct {
-	availableContents []string
+	tempContents      bytes.Buffer
+	availableContents map[string]bool
 	uploadable        bool
 	putHandlerFunc    func(w http.ResponseWriter, r *http.Request) bool
 	locationPrefix    string
@@ -260,7 +269,8 @@ func (u *uploadableMockRegistry) defaultHandler(w http.ResponseWriter, r *http.R
 
 			dgstr := digest.Canonical.Digester()
 
-			if _, err := io.Copy(dgstr.Hash(), r.Body); err != nil {
+			n, err := io.Copy(dgstr.Hash(), r.Body)
+			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
@@ -272,26 +282,54 @@ func (u *uploadableMockRegistry) defaultHandler(w http.ResponseWriter, r *http.R
 				return
 			}
 
-			u.availableContents = append(u.availableContents, dgstr.Digest().String())
+			if n > 0 {
+				u.availableContents[dgstr.Digest().String()] = true
+			}
+
 			w.WriteHeader(http.StatusAccepted)
 			return
 		}
 	} else if r.Method == http.MethodPut {
 		mfstMatches := manifestRegexp.FindStringSubmatch(r.URL.Path)
 		if len(mfstMatches) != 0 || strings.HasPrefix(r.URL.Path, "/upload") {
-			dgstr := digest.Canonical.Digester()
-			if _, err := io.Copy(dgstr.Hash(), r.Body); err != nil {
-				w.WriteHeader(http.StatusInternalServerError)
-				return
+			contentRange := r.Header.Get("Content-Range")
+			if contentRange == "" {
+				dgstr := digest.Canonical.Digester()
+				if _, err := io.Copy(dgstr.Hash(), r.Body); err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				u.availableContents[dgstr.Digest().String()] = true
+				w.Header().Set("Docker-Content-Digest", dgstr.Digest().String())
+				w.WriteHeader(http.StatusCreated)
+			} else {
+				if _, err := io.Copy(&u.tempContents, r.Body); err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				dgstr := digest.Canonical.Digester()
+				if _, err := io.Copy(dgstr.Hash(), &u.tempContents); err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				u.availableContents[dgstr.Digest().String()] = true
+				w.WriteHeader(http.StatusCreated)
 			}
-			u.availableContents = append(u.availableContents, dgstr.Digest().String())
-			w.Header().Set("Docker-Content-Digest", dgstr.Digest().String())
-			w.WriteHeader(http.StatusCreated)
 			return
 		} else if r.URL.Path == "/cannotupload" {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
+	} else if r.Method == http.MethodPatch {
+		if _, err := io.Copy(&u.tempContents, r.Body); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		rangeHeader := r.Header.Get("Content-Range")
+		w.Header().Set("Range", rangeHeader)
+		w.Header().Set("Location", u.locationPrefix+"/upload")
+		w.WriteHeader(http.StatusAccepted)
+		return
 	} else if r.Method == http.MethodHead {
 		var content string
 		// check for both manifest and blob paths
@@ -315,17 +353,12 @@ func (u *uploadableMockRegistry) defaultHandler(w http.ResponseWriter, r *http.R
 
 // checks if the content is already present in the registry
 func (u *uploadableMockRegistry) isContentAlreadyExist(c string) bool {
-	for _, ct := range u.availableContents {
-		if ct == c {
-			return true
-		}
-	}
-	return false
+	return u.availableContents[c]
 }
 
 func Test_dockerPusher_push(t *testing.T) {
 
-	p, reg, tracker, done := samplePusher(t)
+	resolver, p, reg, tracker, done := samplePusher(t)
 	defer done()
 
 	reg.uploadable = true
@@ -344,6 +377,7 @@ func Test_dockerPusher_push(t *testing.T) {
 		ref               string
 		unavailableOnFail bool
 		annotations       map[string]string
+		chunkSize         int64
 	}
 	tests := []struct {
 		name             string
@@ -450,15 +484,42 @@ func Test_dockerPusher_push(t *testing.T) {
 			},
 		},
 		{
-			name: "trying to push a blob layer",
+			name: "trying to push a blob layer in monolithic",
 			dp:   p,
 			// Not needed to set the base object as it is used to generate path only in case of manifests
 			// dockerBaseObject:
 			args: args{
-				content:           layerContent,
+				content:           append(layerContent, []byte("-in-monolithic")...),
 				mediatype:         ocispec.MediaTypeImageLayer,
-				ref:               fmt.Sprintf("layer-%s", layerContentDigest.String()),
+				ref:               fmt.Sprintf("layer-%s", digest.FromBytes(append(layerContent, []byte("-in-monolithic")...)).String()),
 				unavailableOnFail: false,
+			},
+			checkerFunc: func(writer *pushWriter) bool {
+				select {
+				case resp := <-writer.respC:
+					// 201 should be the response code when uploading a new blob
+					return resp.StatusCode == http.StatusCreated
+				case <-writer.errC:
+					return false
+				}
+			},
+			wantErr: nil,
+			wantStatus: &PushStatus{
+				MountedFrom: "",
+				Exists:      false,
+			},
+		},
+		{
+			name: "trying to push a blob layer in chunked",
+			dp:   p,
+			// Not needed to set the base object as it is used to generate path only in case of manifests
+			// dockerBaseObject:
+			args: args{
+				content:           append(layerContent, []byte("-in-chunked")...),
+				mediatype:         ocispec.MediaTypeImageLayer,
+				ref:               fmt.Sprintf("layer-%s", digest.FromBytes(append(layerContent, []byte("-in-chunked")...)).String()),
+				unavailableOnFail: false,
+				chunkSize:         5,
 			},
 			checkerFunc: func(writer *pushWriter) bool {
 				select {
@@ -487,6 +548,7 @@ func Test_dockerPusher_push(t *testing.T) {
 			}
 
 			test.dp.object = test.dockerBaseObject
+			test.dp.dockerBase.hosts[0].ChunkSize = test.args.chunkSize
 
 			got, err := test.dp.push(context.Background(), desc, test.args.ref, test.args.unavailableOnFail)
 
@@ -513,6 +575,9 @@ func Test_dockerPusher_push(t *testing.T) {
 
 			// test whether a proper response has been received after the push operation
 			assert.True(t, test.checkerFunc(pw))
+
+			_, _, err = resolver.Resolve(context.Background(), fmt.Sprintf("example.com/samplerepository@%s", digest.FromBytes(test.args.content)))
+			assert.NoError(t, err)
 
 		})
 	}

--- a/remotes/docker/registry.go
+++ b/remotes/docker/registry.go
@@ -74,6 +74,7 @@ type RegistryHost struct {
 	Path         string
 	Capabilities HostCapabilities
 	Header       http.Header
+	ChunkSize    int64
 }
 
 func (h RegistryHost) isProxy(refhost string) bool {
@@ -115,6 +116,7 @@ type registryOpts struct {
 	plainHTTP  func(string) (bool, error)
 	host       func(string) (string, error)
 	client     *http.Client
+	chunkSize  int64
 }
 
 // RegistryOpt defines a registry default option
@@ -149,6 +151,14 @@ func WithClient(c *http.Client) RegistryOpt {
 	}
 }
 
+// WithChunkSize configures the chunk size on pushing a blob in chunked,
+// it only works on Pusher.
+func WithChunkSize(cz int64) RegistryOpt {
+	return func(opts *registryOpts) {
+		opts.chunkSize = cz
+	}
+}
+
 // ConfigureDefaultRegistries is used to create a default configuration for
 // registries. For more advanced configurations or per-domain setups,
 // the RegistryHosts interface should be used directly.
@@ -167,6 +177,7 @@ func ConfigureDefaultRegistries(ropts ...RegistryOpt) RegistryHosts {
 			Scheme:       "https",
 			Path:         "/v2",
 			Capabilities: HostCapabilityPull | HostCapabilityResolve | HostCapabilityPush,
+			ChunkSize:    opts.chunkSize,
 		}
 
 		if config.Client == nil {


### PR DESCRIPTION
Add `WithChunkSize` option for RegistryOpt to support pushing blob in specified chunk size.

This option is useful if the registry's HTTP gateway limits the maximum payload size per HTTP request.

It's a basic implementation of https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pushing-a-blob-in-chunks