### PR TITLE
Bump up golangci-lint to v1.55.2 and tiny fix on .golangci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.55.0
+          version: v1.55.2
           skip-cache: true
           args: --timeout=8m
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -81,9 +81,7 @@ run:
   skip-dirs:
     - api
     - cluster
-    - design
     - docs
     - docs/man
     - releases
-    - reports
     - test # e2e scripts


### PR DESCRIPTION
golangci-lint v1.55.2: https://github.com/golangci/golangci-lint/releases/tag/v1.55.2

This PR also fixes  .golangci.yml not to contain directories that don't exist.