### PR TITLE
pkg/dialer: minor fix on dialer function for windows

### DIFF
--- a/pkg/dialer/dialer_windows.go
+++ b/pkg/dialer/dialer_windows.go
@@ -17,8 +17,11 @@
 package dialer
 
 import (
+	"fmt"
 	"net"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	winio "github.com/Microsoft/go-winio"
@@ -29,10 +32,16 @@ func isNoent(err error) bool {
 }
 
 func dialer(address string, timeout time.Duration) (net.Conn, error) {
+	address = strings.TrimPrefix(filepath.ToSlash(address), "npipe://")
 	return winio.DialPipe(address, &timeout)
 }
 
-// DialAddress returns the dial address
+// DialAddress returns the dial address with npipe:// prepended to the
+// provided address
 func DialAddress(address string) string {
+	address = filepath.ToSlash(address)
+	if !strings.HasPrefix(address, "npipe://") {
+		address = fmt.Sprintf("npipe://%s", address)
+	}
 	return address
 }


### PR DESCRIPTION
This commit fixes the dialer function to make sure that "npipe://" prefix is trimmed, just like the way it is done in the Unix counterpart, `./dialer_unix.go:50`

This will also unblock some downstream work going on in buildkit; setting up integration tests to run on Windows - https://github.com/moby/buildkit/pull/4432

/cc. @gabriel-samfira 