### PR TITLE
tomlext.Duration add MarshalText method

### DIFF
--- a/pkg/tomlext/toml_v2_util.go
+++ b/pkg/tomlext/toml_v2_util.go
@@ -29,6 +29,10 @@ func (d *Duration) UnmarshalText(b []byte) error {
 	return nil
 }
 
+func (d Duration) MarshalText() (text []byte, err error) {
+	return []byte(time.Duration(d).String()), nil
+}
+
 func ToStdTime(d Duration) time.Duration {
 	return time.Duration(d)
 }


### PR DESCRIPTION
Fix: #9413
`containerd config default` will show the default config.
Before add `tomlext.(*Duration).MarshalText` method the output is 
```
  [plugins.'io.containerd.nri.v1.nri']
    ...
    plugin_registration_timeout = 5000000000
    plugin_request_timeout = 2000000000
    ...
```
`containerd` can not run with this config,
```
[root@containerddev containerd]# ./bin/containerd --config /etc/containerd/config.toml
INFO[2023-11-22T19:37:10.122401987+08:00] starting containerd                           revision=6ed8f01aa1472c9e6179e860f30cb9b6d3977b3d.m version=v2.0.0-beta.0-60-g6ed8f01aa.m
... 
containerd: toml: time: missing unit in duration "5000000000"
``` 
After add `tomlext.(*Duration).MarshalText` method
```
  [plugins.'io.containerd.nri.v1.nri']
    ...
    plugin_registration_timeout = '5s'
    plugin_request_timeout = '2s'
    ...
```