### PR TITLE
Use different containerd sock address for integration test client

### DIFF
--- a/integration/client/client.go
+++ b/integration/client/client.go
@@ -41,7 +41,7 @@ var (
 )
 
 func init() {
-	flag.StringVar(&address, "address", defaults.DefaultAddress, "The address to the containerd socket for use in the tests")
+	flag.StringVar(&address, "address", defaultAddress, "The address to the containerd socket for use in the tests")
 }
 
 func testContext(t testing.TB) (context.Context, context.CancelFunc) {

--- a/integration/client/client_unix.go
+++ b/integration/client/client_unix.go
@@ -18,7 +18,6 @@
 
 package client
 
-//nolint:unused // some variables used for fuzz
 const (
 	defaultRoot    = "/var/lib/containerd-test"
 	defaultState   = "/run/containerd-test"

--- a/integration/client/client_windows.go
+++ b/integration/client/client_windows.go
@@ -1,0 +1,39 @@
+//go:build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+   Copyright 2024 The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+const (
+	defaultAddress = `\\.\pipe\containerd-containerd-test`
+)

--- a/integration/client/client_windows_test.go
+++ b/integration/client/client_windows_test.go
@@ -24,11 +24,6 @@ import (
 	"github.com/Microsoft/hcsshim/osversion"
 )
 
-//nolint:unused // some variables used for fuzz
-const (
-	defaultAddress = `\\.\pipe\containerd-containerd-test`
-)
-
 var (
 	defaultRoot           = filepath.Join(os.Getenv("programfiles"), "containerd", "root-test")
 	defaultState          = filepath.Join(os.Getenv("programfiles"), "containerd", "state-test")


### PR DESCRIPTION
If the containerd/containerd/defaults.DefaultAddress is used , it causes failures if containerd is already running on the default address and the tests are run without the 'no-daemon' flag. 
It would be good to use a different containerd sock address for integration tests