### PR TITLE
cri: add sandbox image name to annotations

### DIFF
--- a/internal/cri/annotations/annotations.go
+++ b/internal/cri/annotations/annotations.go
@@ -78,6 +78,9 @@ const (
 	// ImageName is the name of the image used to create the container
 	ImageName = "io.kubernetes.cri.image-name"
 
+	// SandboxImageName is the name of the sandbox image
+	SandboxImageName = "io.kubernetes.cri.podsandbox.image-name"
+
 	// PodAnnotations are the annotations of the pod
 	PodAnnotations = "io.kubernetes.cri.pod-annotations"
 
@@ -110,11 +113,15 @@ func DefaultCRIAnnotations(
 	ctrType := ContainerTypeContainer
 	if sandbox {
 		ctrType = ContainerTypeSandbox
-		// Sandbox log dir only gets passed for sandboxes, the other metadata always
+		// Sandbox log dir and sandbox image name get passed for sandboxes, the other metadata always
 		// gets sent however.
-		opts = append(opts, customopts.WithAnnotation(SandboxLogDir, config.GetLogDirectory()))
+		opts = append(
+			opts,
+			customopts.WithAnnotation(SandboxLogDir, config.GetLogDirectory()),
+			customopts.WithAnnotation(SandboxImageName, imageName),
+		)
 	} else {
-		// Image name and container name only get passed for containers.s
+		// Image name and container name get passed for containers.
 		opts = append(
 			opts,
 			customopts.WithAnnotation(ContainerName, containerName),

--- a/internal/cri/server/podsandbox/sandbox_run.go
+++ b/internal/cri/server/podsandbox/sandbox_run.go
@@ -75,10 +75,7 @@ func (c *Controller) Start(ctx context.Context, id string) (cin sandbox.Controll
 		labels = map[string]string{}
 	)
 
-	sandboxImage := c.imageService.PinnedImage("sandbox")
-	if sandboxImage == "" {
-		sandboxImage = criconfig.DefaultSandboxImage
-	}
+	sandboxImage := c.getSandboxImageName()
 	// Ensure sandbox container image snapshot.
 	image, err := c.ensureImageExists(ctx, sandboxImage, config, metadata.RuntimeHandler)
 	if err != nil {
@@ -320,4 +317,16 @@ func (c *Controller) ensureImageExists(ctx context.Context, ref string, config *
 		return nil, fmt.Errorf("failed to get image %q after pulling: %w", imageID, err)
 	}
 	return &newImage, nil
+}
+
+func (c *Controller) getSandboxImageName() string {
+	// returns the name of the sandbox image used to scope pod shared resources used by the pod's containers,
+	// if empty return the default sandbox image.
+	if c.imageService != nil {
+		sandboxImage := c.imageService.PinnedImage("sandbox")
+		if sandboxImage != "" {
+			return sandboxImage
+		}
+	}
+	return criconfig.DefaultSandboxImage
 }

--- a/internal/cri/server/podsandbox/sandbox_run_linux.go
+++ b/internal/cri/server/podsandbox/sandbox_run_linux.go
@@ -193,7 +193,7 @@ func (c *Controller) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 		specOpts = append(specOpts, customopts.WithAnnotation(pKey, pValue))
 	}
 
-	specOpts = append(specOpts, annotations.DefaultCRIAnnotations(id, "", "", config, true)...)
+	specOpts = append(specOpts, annotations.DefaultCRIAnnotations(id, "", c.getSandboxImageName(), config, true)...)
 
 	return c.runtimeSpec(id, "", specOpts...)
 }

--- a/internal/cri/server/podsandbox/sandbox_run_other.go
+++ b/internal/cri/server/podsandbox/sandbox_run_other.go
@@ -29,7 +29,7 @@ import (
 
 func (c *Controller) sandboxContainerSpec(id string, config *runtime.PodSandboxConfig,
 	imageConfig *imagespec.ImageConfig, nsPath string, runtimePodAnnotations []string) (_ *runtimespec.Spec, retErr error) {
-	return c.runtimeSpec(id, "", annotations.DefaultCRIAnnotations(id, "", "", config, true)...)
+	return c.runtimeSpec(id, "", annotations.DefaultCRIAnnotations(id, "", c.getSandboxImageName(), config, true)...)
 }
 
 // sandboxContainerSpecOpts generates OCI spec options for

--- a/internal/cri/server/podsandbox/sandbox_run_windows.go
+++ b/internal/cri/server/podsandbox/sandbox_run_windows.go
@@ -81,8 +81,9 @@ func (c *Controller) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 	}
 
 	specOpts = append(specOpts, customopts.WithAnnotation(annotations.WindowsHostProcess, strconv.FormatBool(config.GetWindows().GetSecurityContext().GetHostProcess())))
+
 	specOpts = append(specOpts,
-		annotations.DefaultCRIAnnotations(id, "", "", config, true)...,
+		annotations.DefaultCRIAnnotations(id, "", c.getSandboxImageName(), config, true)...,
 	)
 
 	return c.runtimeSpec(id, "", specOpts...)


### PR DESCRIPTION
We are working on a feature to enable the guest image pulling on the confidential-containers, and we would greatly appreciate containerd’s assistance in this matter. we hope containerd could share the pause image name and add it to the annotations so that we can pass it to the guest.
   
Fixes: #9418