### PR TITLE
add nofallback field in mirrors config to control whether fallback to origin registry when pulling from mirrors failed

### DIFF
--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -193,6 +193,9 @@ type Mirror struct {
 	// with host specified.
 	// The scheme, host and path from the endpoint URL will be used.
 	Endpoints []string `toml:"endpoint" json:"endpoint"`
+	// NoFallback field controls whether to fallback to the initial registry
+	// when pulling a mirror failed from mirror registry.
+	NoFallback bool `toml:"nofallback" json:"nofallback"`
 }
 
 // AuthConfig contains the config related to authentication to a specific registry

--- a/pkg/cri/server/images/image_pull.go
+++ b/pkg/cri/server/images/image_pull.go
@@ -496,11 +496,14 @@ func addDefaultScheme(endpoint string) (string, error) {
 // It also supports wildcard host matching with `*`.
 func (c *CRIImageService) registryEndpoints(host string) ([]string, error) {
 	var endpoints []string
+	var nofallback bool
 	_, ok := c.config.Registry.Mirrors[host]
 	if ok {
 		endpoints = c.config.Registry.Mirrors[host].Endpoints
+		nofallback = c.config.Registry.Mirrors[host].NoFallback
 	} else {
 		endpoints = c.config.Registry.Mirrors["*"].Endpoints
+		nofallback = c.config.Registry.Mirrors["*"].NoFallback
 	}
 	defaultHost, err := docker.DefaultHost(host)
 	if err != nil {
@@ -522,6 +525,9 @@ func (c *CRIImageService) registryEndpoints(host string) ([]string, error) {
 			// Do not add default if the endpoint already exists.
 			return endpoints, nil
 		}
+	}
+	if nofallback {
+		return endpoints, nil
 	}
 	return append(endpoints, defaultScheme(defaultHost)+"://"+defaultHost), nil
 }

--- a/pkg/cri/server/images/image_pull_test.go
+++ b/pkg/cri/server/images/image_pull_test.go
@@ -163,6 +163,23 @@ func TestRegistryEndpoints(t *testing.T) {
 			},
 		},
 		{
+			desc: "mirror configured nofallback",
+			mirrors: map[string]criconfig.Mirror{
+				"registry-3.io": {
+					Endpoints: []string{
+						"https://registry-1.io",
+						"https://registry-2.io",
+					},
+					NoFallback: true,
+				},
+			},
+			host: "registry-3.io",
+			expected: []string{
+				"https://registry-1.io",
+				"https://registry-2.io",
+			},
+		},
+		{
 			desc: "wildcard mirror configured",
 			mirrors: map[string]criconfig.Mirror{
 				"*": {


### PR DESCRIPTION
fix: #9206 

Like the link above says, we had a similar need, and then I implemented a version that controls whether or not to fallback to the original repository via an added configuration item, and I tested it locally. Please help to check if there is any problem.


