### PR TITLE
Fix race condition in `ctr task exec`

### DIFF
--- a/cmd/ctr/commands/tasks/tasks_unix.go
+++ b/cmd/ctr/commands/tasks/tasks_unix.go
@@ -69,9 +69,7 @@ func HandleConsoleResize(ctx context.Context, task resizer, con console.Console)
 
 // NewTask creates a new task
 func NewTask(ctx context.Context, client *containerd.Client, container containerd.Container, checkpoint string, con console.Console, nullIO bool, logURI string, ioOpts []cio.Opt, opts ...containerd.NewTaskOpts) (containerd.Task, error) {
-	stdinC := &stdinCloser{
-		stdin: os.Stdin,
-	}
+	stdinC := cio.NewStdinCloser(os.Stdin)
 	if checkpoint != "" {
 		im, err := client.GetImage(ctx, checkpoint)
 		if err != nil {
@@ -114,9 +112,9 @@ func NewTask(ctx context.Context, client *containerd.Client, container container
 	if err != nil {
 		return nil, err
 	}
-	stdinC.closer = func() {
+	stdinC.SetCloser(func() {
 		t.CloseIO(ctx, containerd.WithStdinCloser)
-	}
+	})
 	return t, nil
 }
 

--- a/pkg/cio/io.go
+++ b/pkg/cio/io.go
@@ -354,3 +354,40 @@ func Load(set *FIFOSet) (IO, error) {
 func (p *pipes) closers() []io.Closer {
 	return []io.Closer{p.Stdin, p.Stdout, p.Stderr}
 }
+
+type StdinCloser struct {
+	stdin  *os.File
+	mutex  *sync.Mutex
+	closed bool
+	closer func()
+}
+
+func NewStdinCloser(stdin *os.File) *StdinCloser {
+	return &StdinCloser{
+		stdin: stdin,
+		mutex: &sync.Mutex{},
+	}
+}
+
+func (s *StdinCloser) SetCloser(closer func()) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.closer = closer
+	if s.closed {
+		s.closer()
+	}
+}
+
+func (s *StdinCloser) Read(p []byte) (int, error) {
+	n, err := s.stdin.Read(p)
+	if err == io.EOF {
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
+		s.closed = true
+		if s.closer != nil {
+			s.closer()
+		}
+	}
+	return n, err
+}


### PR DESCRIPTION
Currently there is possiblity that we'll close the stdin before it gets opened. If that happens stdin won't be closed and exec will hang forever.

To fix that we need to make sure that closing io will be executed (by introducing proper mutex guards) and it will be done after stdin gets opened.

More details can be found in the issue #4489

FYI we initially discover this bug when we used [firecracker-containerd](https://github.com/firecracker-microvm/firecracker-containerd) by running exec with stdin which gets closed really fast like  
```
echo 123 | ctr --address /run/firecracker-containerd/containerd.sock t exec --exec-id rand-$RANDOM test cat
```  
Because of latency difference it might be harder to reproduce this issue with plain containerd
