### PR TITLE
Add release notes for v1.7.10

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.7.9+unknown"
+	Version = "1.7.10+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Welcome to the v1.7.10 release of containerd!

The tenth patch release for containerd 1.7 contains various fixes and updates.
### Notable Updates
* **Enhance container image unpack client logs** ([#9379](https://github.com/containerd/containerd/pull/9379))
* **cri: fix using the pinned label to pin image** ([#9381](https://github.com/containerd/containerd/pull/9381))
* **fix: ImagePull should close http connection if there is no available data to read.** ([#9409](https://github.com/containerd/containerd/pull/9409))

See the changelog for complete list of changes

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Wei Fu
* Austin Vazquez
* Iceber Gu
* Iceber Gu
* Phil Estes
* Samuel Karp
* ruiwen-zhao

### Changes
<details><summary>10 commits</summary>
<p>

  * [`ed87f8b4c`](https://github.com/containerd/containerd/commit/ed87f8b4c2a9c4566c22a8b8b104b949db774128) Add release notes for v1.7.10
* [release/1.7] fix: ImagePull should close http connection if there is no available data to read. ([#9409](https://github.com/containerd/containerd/pull/9409))
  * [`206806128`](https://github.com/containerd/containerd/commit/206806128917276994f0949dc599e4c8b8ad8f14) remotes/docker: close connection if no more data
  * [`328493962`](https://github.com/containerd/containerd/commit/32849396263f9c68f7c4f43a2abc1319488546de) integration: reproduce #9347
  * [`d1aab27cb`](https://github.com/containerd/containerd/commit/d1aab27cbd8ae75d90ad962a256d6af092dcf451) fix: deflake TestCRIImagePullTimeout/HoldingContentOpenWriter
* [release/1.7] cri: fix using the pinned label to pin image ([#9381](https://github.com/containerd/containerd/pull/9381))
  * [`a2b16d7f9`](https://github.com/containerd/containerd/commit/a2b16d7f9cd44f81ebdcffe92dee107b2ebdca8a) cri: fix update of pinned label for images
  * [`8dc861844`](https://github.com/containerd/containerd/commit/8dc8618442ad99a254de79200c89eb12284dac6e) cri: fix using the pinned label to pin image
* [release/1.7] Enhance container image unpack client logs ([#9379](https://github.com/containerd/containerd/pull/9379))
  * [`5930a3750`](https://github.com/containerd/containerd/commit/5930a3750c5db69abf7668e4df003aae8f0beace) Enhance container image unpack client logs
</p>
</details>

### Dependency Changes

This release has no dependency changes

Previous release can be found at [v1.7.9](https://github.com/containerd/containerd/releases/tag/v1.7.9)