### PR TITLE
Add release notes for v1.7.10

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -50,7 +50,7 @@ haoyun <yun.hao@daocloud.io>
 Harry Zhang <harryz@hyper.sh> <harryzhang@zju.edu.cn>
 Hu Shuai <hus.fnst@cn.fujitsu.com>
 Hu Shuai <hus.fnst@cn.fujitsu.com> <hushuaiia@qq.com>
-Iceber Gu <wei.cai-nat@daocloud.io>
+Iceber Gu <wei.cai-nat@daocloud.io> <caiwei95@hotmail.com>
 Jaana Burcu Dogan <burcujdogan@gmail.com> <jbd@golang.org>
 Jess Valarezo <valarezo.jessica@gmail.com>
 Jess Valarezo <valarezo.jessica@gmail.com> <jessica.valarezo@docker.com>

--- a/releases/v1.7.10.toml
+++ b/releases/v1.7.10.toml
@@ -1,0 +1,31 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.7.9"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The tenth patch release for containerd 1.7 contains various fixes and updates.
+### Notable Updates
+* **Enhance container image unpack client logs** ([#9379](https://github.com/containerd/containerd/pull/9379))
+* **cri: fix using the pinned label to pin image** ([#9381](https://github.com/containerd/containerd/pull/9381))
+* **fix: ImagePull should close http connection if there is no available data to read.** ([#9409](https://github.com/containerd/containerd/pull/9409))
+
+See the changelog for complete list of changes"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.7.9+unknown"
+	Version = "1.7.10+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Welcome to the v1.7.10 release of containerd!

The tenth patch release for containerd 1.7 contains various fixes and updates.
### Notable Updates
* **Enhance container image unpack client logs** ([#9379](https://github.com/containerd/containerd/pull/9379))
* **cri: fix using the pinned label to pin image** ([#9381](https://github.com/containerd/containerd/pull/9381))
* **fix: ImagePull should close http connection if there is no available data to read.** ([#9409](https://github.com/containerd/containerd/pull/9409))

See the changelog for complete list of changes

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Wei Fu
* Iceber Gu
* Austin Vazquez
* Phil Estes
* Samuel Karp
* ruiwen-zhao

### Changes
<details><summary>10 commits</summary>
<p>

  * [`377ad831e`](https://github.com/containerd/containerd/commit/377ad831e966f592a7c711cc9589ba4151c72b7c) Add release notes for v1.7.10
* [release/1.7] fix: ImagePull should close http connection if there is no available data to read. ([#9409](https://github.com/containerd/containerd/pull/9409))
  * [`206806128`](https://github.com/containerd/containerd/commit/206806128917276994f0949dc599e4c8b8ad8f14) remotes/docker: close connection if no more data
  * [`328493962`](https://github.com/containerd/containerd/commit/32849396263f9c68f7c4f43a2abc1319488546de) integration: reproduce #9347
  * [`d1aab27cb`](https://github.com/containerd/containerd/commit/d1aab27cbd8ae75d90ad962a256d6af092dcf451) fix: deflake TestCRIImagePullTimeout/HoldingContentOpenWriter
* [release/1.7] cri: fix using the pinned label to pin image ([#9381](https://github.com/containerd/containerd/pull/9381))
  * [`a2b16d7f9`](https://github.com/containerd/containerd/commit/a2b16d7f9cd44f81ebdcffe92dee107b2ebdca8a) cri: fix update of pinned label for images
  * [`8dc861844`](https://github.com/containerd/containerd/commit/8dc8618442ad99a254de79200c89eb12284dac6e) cri: fix using the pinned label to pin image
* [release/1.7] Enhance container image unpack client logs ([#9379](https://github.com/containerd/containerd/pull/9379))
  * [`5930a3750`](https://github.com/containerd/containerd/commit/5930a3750c5db69abf7668e4df003aae8f0beace) Enhance container image unpack client logs
</p>
</details>

### Dependency Changes

This release has no dependency changes

Previous release can be found at [v1.7.9](https://github.com/containerd/containerd/releases/tag/v1.7.9)