### PR TITLE
containerd-stress: use config address for CRI test

### DIFF
--- a/cmd/containerd-stress/main.go
+++ b/cmd/containerd-stress/main.go
@@ -264,13 +264,12 @@ func serve(c config) error {
 
 func criTest(c config) error {
 	var (
-		timeout     = 1 * time.Minute
-		wg          sync.WaitGroup
-		ctx         = namespaces.WithNamespace(context.Background(), stressNs)
-		criEndpoint = "unix:///run/containerd/containerd.sock"
+		timeout = 1 * time.Minute
+		wg      sync.WaitGroup
+		ctx     = namespaces.WithNamespace(context.Background(), stressNs)
 	)
 
-	client, err := remote.NewRuntimeService(criEndpoint, timeout)
+	client, err := remote.NewRuntimeService(c.Address, timeout)
 	if err != nil {
 		return fmt.Errorf("failed to create runtime service: %w", err)
 	}


### PR DESCRIPTION
This change removes the hard-coded containerd endpoint for CRI test
and use the address in the config which would honor the CLI flag.