### PR TITLE
ctr: use transfer service by default

### DIFF
--- a/cmd/ctr/commands/images/export.go
+++ b/cmd/ctr/commands/images/export.go
@@ -61,7 +61,7 @@ When '--all-platforms' is given all images in a manifest list must be available.
 			Name:  "all-platforms",
 			Usage: "Exports content from all platforms",
 		},
-		cli.BoolTFlag{
+		cli.BoolFlag{
 			Name:  "local",
 			Usage: "Run export locally rather than through transfer API",
 		},
@@ -93,7 +93,7 @@ When '--all-platforms' is given all images in a manifest list must be available.
 		}
 		defer w.Close()
 
-		if !context.BoolT("local") {
+		if !context.Bool("local") {
 			pf, done := ProgressHandler(ctx, os.Stdout)
 			defer done()
 

--- a/cmd/ctr/commands/images/import.go
+++ b/cmd/ctr/commands/images/import.go
@@ -86,7 +86,7 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 			Name:  "no-unpack",
 			Usage: "Skip unpacking the images, cannot be used with --discard-unpacked-layers, false by default",
 		},
-		cli.BoolTFlag{
+		cli.BoolFlag{
 			Name:  "local",
 			Usage: "Run import locally rather than through transfer API",
 		},
@@ -113,7 +113,7 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 		}
 		defer cancel()
 
-		if !context.BoolT("local") {
+		if !context.Bool("local") {
 			var opts []image.StoreOpt
 			prefix := context.String("base-name")
 			var overwrite bool

--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -79,7 +79,7 @@ command. As part of this process, we do the following:
 			Name:  "max-concurrent-downloads",
 			Usage: "Set the max concurrent downloads for each pull",
 		},
-		cli.BoolTFlag{
+		cli.BoolFlag{
 			Name:  "local",
 			Usage: "Fetch content from local client rather than using transfer service",
 		},
@@ -98,7 +98,7 @@ command. As part of this process, we do the following:
 		}
 		defer cancel()
 
-		if !context.BoolT("local") {
+		if !context.Bool("local") {
 			ch, err := commands.NewStaticCredentials(ctx, context, ref)
 			if err != nil {
 				return err

--- a/cmd/ctr/commands/images/push.go
+++ b/cmd/ctr/commands/images/push.go
@@ -71,7 +71,7 @@ var pushCommand = cli.Command{
 	}, cli.IntFlag{
 		Name:  "max-concurrent-uploaded-layers",
 		Usage: "Set the max concurrent uploaded layers for each push",
-	}, cli.BoolTFlag{
+	}, cli.BoolFlag{
 		Name:  "local",
 		Usage: "Push content from local client rather than using transfer service",
 	}, cli.BoolFlag{
@@ -95,7 +95,7 @@ var pushCommand = cli.Command{
 		}
 		defer cancel()
 
-		if !context.BoolT("local") {
+		if !context.Bool("local") {
 			ch, err := commands.NewStaticCredentials(ctx, context, ref)
 			if err != nil {
 				return err

--- a/cmd/ctr/commands/images/tag.go
+++ b/cmd/ctr/commands/images/tag.go
@@ -37,7 +37,7 @@ var tagCommand = cli.Command{
 			Name:  "force",
 			Usage: "Force target_ref to be created, regardless if it already exists",
 		},
-		cli.BoolTFlag{
+		cli.BoolFlag{
 			Name:  "local",
 			Usage: "Run tag locally rather than through transfer API",
 		},
@@ -63,7 +63,7 @@ var tagCommand = cli.Command{
 		}
 		defer cancel()
 
-		if !context.BoolT("local") {
+		if !context.Bool("local") {
 			for _, targetRef := range context.Args()[1:] {
 				if !context.Bool("skip-reference-check") {
 					if _, err := reference.ParseAnyReference(targetRef); err != nil {


### PR DESCRIPTION
Prior to this commit, `--local=false` had to be explicitly specified to opt-in to the transfer service