### PR TITLE
snapshots: emit deprecation warning for aufs

### DIFF
--- a/pkg/deprecation/deprecation.go
+++ b/pkg/deprecation/deprecation.go
@@ -33,6 +33,8 @@ const (
 	CRIRegistryConfigs Warning = Prefix + "cri-registry-configs"
 	// CRIAPIV1Alpha2 is a warning for the use of CRI-API v1alpha2
 	CRIAPIV1Alpha2 Warning = Prefix + "cri-api-v1alpha2"
+	// AUFSSnapshotter is a warning for the use of the aufs snapshotter
+	AUFSSnapshotter Warning = Prefix + "aufs-snapshotter"
 )
 
 var messages = map[Warning]string{
@@ -45,7 +47,8 @@ var messages = map[Warning]string{
 		"Use `ImagePullSecrets` instead.",
 	CRIRegistryConfigs: "The `configs` property of `[plugins.\"io.containerd.grpc.v1.cri\".registry]` is deprecated since containerd v1.5 and will be removed in containerd v2.0." +
 		"Use `config_path` instead.",
-	CRIAPIV1Alpha2: "CRI API v1alpha2 is deprecated since containerd v1.7 and removed in containerd v2.0. Use CRI API v1 instead.",
+	CRIAPIV1Alpha2:  "CRI API v1alpha2 is deprecated since containerd v1.7 and removed in containerd v2.0. Use CRI API v1 instead.",
+	AUFSSnapshotter: "The aufs snapshotter is deprecated since containerd v1.5 and removed in containerd v2.0. Use the overlay snapshotter instead.",
 }
 
 // Valid checks whether a given Warning is valid


### PR DESCRIPTION
aufs snapshotter is already removed from main, so this PR is directly against 1.7.  However, the approach here is a bit weird, and I'm open to feedback on doing it differently if that's warranted.  Here's the weirdness:

* aufs snapshotter is in a [separate repo](https://github.com/containerd/aufs) and currently depends on [containerd 1.6.12](https://github.com/containerd/aufs/blob/36df6cc13054a939870810c1b497bdb81bb031d7/go.mod#L6)
* The plugin itself has no dependencies
* Adding a dependency on the warning service would require:
  * an update to containerd 1.6 adding the new warning ID (and, preferably, a release)
  * updating the go module dependency in the aufs snapshotter
  * adding a dependency to the plugin
  * finally, updating the dependency in the containerd 1.6 and 1.7 release branches

So instead of that, I added the warning service as a dependency of the snapshot service, and emit the warning from there.  It's certainly less elegant, but it was many fewer steps.