### PR TITLE
[release/1.7] tasks: emit warning for v1 runtime and runc v1 runtime

### DIFF
--- a/pkg/deprecation/deprecation.go
+++ b/pkg/deprecation/deprecation.go
@@ -35,6 +35,8 @@ const (
 	CRIAPIV1Alpha2 Warning = Prefix + "cri-api-v1alpha2"
 	// AUFSSnapshotter is a warning for the use of the aufs snapshotter
 	AUFSSnapshotter Warning = Prefix + "aufs-snapshotter"
+	// RuntimeV1 is a warning for the io.containerd.runtime.v1.linux runtime
+	RuntimeV1 Warning = Prefix + "runtime-v1"
 )
 
 var messages = map[Warning]string{
@@ -49,6 +51,7 @@ var messages = map[Warning]string{
 		"Use `config_path` instead.",
 	CRIAPIV1Alpha2:  "CRI API v1alpha2 is deprecated since containerd v1.7 and removed in containerd v2.0. Use CRI API v1 instead.",
 	AUFSSnapshotter: "The aufs snapshotter is deprecated since containerd v1.5 and removed in containerd v2.0. Use the overlay snapshotter instead.",
+	RuntimeV1:       "The `io.containerd.runtime.v1.linux` runtime is deprecated since containerd v1.4 and removed in containerd v2.0. Use the `io.containerd.runc.v2` runtime instead.",
 }
 
 // Valid checks whether a given Warning is valid

--- a/pkg/deprecation/deprecation.go
+++ b/pkg/deprecation/deprecation.go
@@ -37,6 +37,8 @@ const (
 	AUFSSnapshotter Warning = Prefix + "aufs-snapshotter"
 	// RuntimeV1 is a warning for the io.containerd.runtime.v1.linux runtime
 	RuntimeV1 Warning = Prefix + "runtime-v1"
+	// RuntimeRuncV1 is a warning for the io.containerd.runc.v1 runtime
+	RuntimeRuncV1 Warning = Prefix + "runtime-runc-v1"
 )
 
 var messages = map[Warning]string{
@@ -52,6 +54,7 @@ var messages = map[Warning]string{
 	CRIAPIV1Alpha2:  "CRI API v1alpha2 is deprecated since containerd v1.7 and removed in containerd v2.0. Use CRI API v1 instead.",
 	AUFSSnapshotter: "The aufs snapshotter is deprecated since containerd v1.5 and removed in containerd v2.0. Use the overlay snapshotter instead.",
 	RuntimeV1:       "The `io.containerd.runtime.v1.linux` runtime is deprecated since containerd v1.4 and removed in containerd v2.0. Use the `io.containerd.runc.v2` runtime instead.",
+	RuntimeRuncV1:   "The `io.containerd.runc.v1` runtime is deprecated since containerd v1.4 and removed in containerd v2.0. Use the `io.containerd.runc.v2` runtime instead.",
 }
 
 // Valid checks whether a given Warning is valid

--- a/services/tasks/local.go
+++ b/services/tasks/local.go
@@ -40,6 +40,7 @@ import (
 	"github.com/containerd/containerd/metadata"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/pkg/blockio"
+	"github.com/containerd/containerd/pkg/deprecation"
 	"github.com/containerd/containerd/pkg/rdt"
 	"github.com/containerd/containerd/pkg/timeout"
 	"github.com/containerd/containerd/plugin"
@@ -50,6 +51,8 @@ import (
 	"github.com/containerd/containerd/runtime/linux/runctypes"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/containerd/containerd/services"
+	"github.com/containerd/containerd/services/warning"
+
 	"github.com/containerd/typeurl/v2"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -117,6 +120,11 @@ func initFunc(ic *plugin.InitContext) (interface{}, error) {
 		monitor = runtime.NewNoopMonitor()
 	}
 
+	w, err := ic.Get(plugin.WarningPlugin)
+	if err != nil {
+		return nil, err
+	}
+
 	db := m.(*metadata.DB)
 	l := &local{
 		runtimes:   runtimes,
@@ -125,6 +133,7 @@ func initFunc(ic *plugin.InitContext) (interface{}, error) {
 		publisher:  ep.(events.Publisher),
 		monitor:    monitor.(runtime.TaskMonitor),
 		v2Runtime:  v2r.(runtime.PlatformRuntime),
+		warnings:   w.(warning.Service),
 	}
 	for _, r := range runtimes {
 		tasks, err := r.Tasks(ic.Context, true)
@@ -161,6 +170,7 @@ type local struct {
 
 	monitor   runtime.TaskMonitor
 	v2Runtime runtime.PlatformRuntime
+	warnings  warning.Service
 }
 
 func (l *local) Create(ctx context.Context, r *api.CreateTaskRequest, _ ...grpc.CallOption) (*api.CreateTaskResponse, error) {
@@ -221,11 +231,10 @@ func (l *local) Create(ctx context.Context, r *api.CreateTaskRequest, _ ...grpc.
 			Options: m.Options,
 		})
 	}
-	if strings.HasPrefix(container.Runtime.Name, "io.containerd.runtime.v1.") {
-		log.G(ctx).Warn("runtime v1 is deprecated since containerd v1.4, consider using runtime v2")
-	} else if container.Runtime.Name == plugin.RuntimeRuncV1 {
+	if container.Runtime.Name == plugin.RuntimeRuncV1 {
 		log.G(ctx).Warnf("%q is deprecated since containerd v1.4, consider using %q", plugin.RuntimeRuncV1, plugin.RuntimeRuncV2)
 	}
+	l.emitRuntimeWarning(ctx, container.Runtime.Name)
 	rtime, err := l.getRuntime(container.Runtime.Name)
 	if err != nil {
 		return nil, err
@@ -255,6 +264,13 @@ func (l *local) Create(ctx context.Context, r *api.CreateTaskRequest, _ ...grpc.
 	}, nil
 }
 
+func (l *local) emitRuntimeWarning(ctx context.Context, runtime string) {
+	switch runtime {
+	case plugin.RuntimeLinuxV1:
+		log.G(ctx).Warnf("%q is deprecated since containerd v1.4 and will be removed in containerd v2.0, use %q instead", plugin.RuntimeLinuxV1, plugin.RuntimeRuncV2)
+		l.warnings.Emit(ctx, deprecation.RuntimeV1)
+	}
+}
 func (l *local) Start(ctx context.Context, r *api.StartRequest, _ ...grpc.CallOption) (*api.StartResponse, error) {
 	t, err := l.getTask(ctx, r.ContainerID)
 	if err != nil {

--- a/services/tasks/local.go
+++ b/services/tasks/local.go
@@ -231,9 +231,6 @@ func (l *local) Create(ctx context.Context, r *api.CreateTaskRequest, _ ...grpc.
 			Options: m.Options,
 		})
 	}
-	if container.Runtime.Name == plugin.RuntimeRuncV1 {
-		log.G(ctx).Warnf("%q is deprecated since containerd v1.4, consider using %q", plugin.RuntimeRuncV1, plugin.RuntimeRuncV2)
-	}
 	l.emitRuntimeWarning(ctx, container.Runtime.Name)
 	rtime, err := l.getRuntime(container.Runtime.Name)
 	if err != nil {
@@ -269,6 +266,9 @@ func (l *local) emitRuntimeWarning(ctx context.Context, runtime string) {
 	case plugin.RuntimeLinuxV1:
 		log.G(ctx).Warnf("%q is deprecated since containerd v1.4 and will be removed in containerd v2.0, use %q instead", plugin.RuntimeLinuxV1, plugin.RuntimeRuncV2)
 		l.warnings.Emit(ctx, deprecation.RuntimeV1)
+	case plugin.RuntimeRuncV1:
+		log.G(ctx).Warnf("%q is deprecated since containerd v1.4 and will be removed in containerd v2.0, use %q instead", plugin.RuntimeRuncV1, plugin.RuntimeRuncV2)
+		l.warnings.Emit(ctx, deprecation.RuntimeRuncV1)
 	}
 }
 func (l *local) Start(ctx context.Context, r *api.StartRequest, _ ...grpc.CallOption) (*api.StartResponse, error) {

--- a/services/tasks/local_darwin.go
+++ b/services/tasks/local_darwin.go
@@ -27,6 +27,7 @@ var tasksServiceRequires = []plugin.Type{
 	plugin.RuntimePluginV2,
 	plugin.MetadataPlugin,
 	plugin.TaskMonitorPlugin,
+	plugin.WarningPlugin,
 }
 
 // loadV1Runtimes on darwin returns an empty map. There are no v1 runtimes

--- a/services/tasks/local_freebsd.go
+++ b/services/tasks/local_freebsd.go
@@ -26,6 +26,7 @@ var tasksServiceRequires = []plugin.Type{
 	plugin.RuntimePluginV2,
 	plugin.MetadataPlugin,
 	plugin.TaskMonitorPlugin,
+	plugin.WarningPlugin,
 }
 
 // loadV1Runtimes on FreeBSD returns an empty map. There are no v1 runtimes

--- a/services/tasks/local_unix.go
+++ b/services/tasks/local_unix.go
@@ -32,6 +32,7 @@ var tasksServiceRequires = []plugin.Type{
 	plugin.RuntimePluginV2,
 	plugin.MetadataPlugin,
 	plugin.TaskMonitorPlugin,
+	plugin.WarningPlugin,
 }
 
 func loadV1Runtimes(ic *plugin.InitContext) (map[string]runtime.PlatformRuntime, error) {

--- a/services/tasks/local_windows.go
+++ b/services/tasks/local_windows.go
@@ -26,6 +26,7 @@ var tasksServiceRequires = []plugin.Type{
 	plugin.RuntimePluginV2,
 	plugin.MetadataPlugin,
 	plugin.TaskMonitorPlugin,
+	plugin.WarningPlugin,
 }
 
 // loadV1Runtimes on Windows V2 returns an empty map. There are no v1 runtimes


### PR DESCRIPTION
Part of https://github.com/containerd/containerd/issues/9312

```
$ sudo bin/ctr deprecations list
ID                                           LAST OCCURRENCE                   MESSAGE    
io.containerd.deprecation/runtime-v1         2023-12-01T07:26:57.614014991Z    The `io.containerd.runtime.v1.linux` runtime is deprecated since containerd v1.4 and removed in containerd v2.0. Use the `io.containerd.runc.v2` runtime instead.
io.containerd.deprecation/runtime-runc-v1    2023-12-01T07:27:34.505898489Z    The `io.containerd.runc.v1` runtime is deprecated since containerd v1.4 and removed in containerd v2.0. Use the `io.containerd.runc.v2` runtime instead.

```