### PR TITLE
pkg/process: Check using idmap mount options too

### DIFF
--- a/cmd/containerd-shim-runc-v2/process/init.go
+++ b/cmd/containerd-shim-runc-v2/process/init.go
@@ -206,6 +206,10 @@ func (p *Init) validateIDMapMounts(ctx context.Context, spec *specs.Spec) error 
 			used = true
 			break
 		}
+		if sliceContainsStr(m.Options, "idmap") || sliceContainsStr(m.Options, "ridmap") {
+			used = true
+			break
+		}
 	}
 
 	if !used {
@@ -551,4 +555,13 @@ func withConditionalIO(c stdio.Stdio) runc.IOOpt {
 		o.OpenStdout = c.Stdout != ""
 		o.OpenStderr = c.Stderr != ""
 	}
+}
+
+func sliceContainsStr(s []string, str string) bool {
+	for _, s := range s {
+		if s == str {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
The runtime-spec just merged this PR:
	https://github.com/opencontainers/runtime-spec/pull/1224

This means that it is now possible to request idmap mounts by specifying "idmap" or "ridmap" in the mount options, without any mappings.

Let's add a check to see if they are requested in that way too.