### PR TITLE
extract cri runtime configs

### DIFF
--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/containerd/containerd/v2/errdefs"
 	_ "github.com/containerd/containerd/v2/metrics" // import containerd build info
 	"github.com/containerd/containerd/v2/mount"
+	"github.com/containerd/containerd/v2/pkg/cri/server/base"
 	"github.com/containerd/containerd/v2/services/server"
 	srvconfig "github.com/containerd/containerd/v2/services/server/config"
 	"github.com/containerd/containerd/v2/sys"
@@ -133,6 +134,7 @@ can be used and modified as necessary as a custom configuration.`
 				return err
 			}
 		}
+		ctx = base.WithConfigPath(ctx, configPath)
 
 		// Apply flags to the config
 		if err := applyFlags(context, config); err != nil {

--- a/pkg/cri/config/config_runtime.go
+++ b/pkg/cri/config/config_runtime.go
@@ -1,0 +1,233 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package config
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/containerd/containerd/v2/defaults"
+	"github.com/containerd/containerd/v2/oci"
+	"github.com/containerd/containerd/v2/pkg/cri/util"
+	"github.com/containerd/log"
+	"github.com/fsnotify/fsnotify"
+	"github.com/pelletier/go-toml/v2"
+)
+
+var (
+	DefaultRuntimeConfigPath = defaults.DefaultConfigDir + "/runtimes"
+	DefaultRuntimeConfigName = "config.toml"
+)
+
+// CRIRuntimeConfig can auto reload runtimes and BaseOCISpecs data
+type CRIRuntimeConfig struct {
+	runtimeRW sync.RWMutex
+	specRW    sync.RWMutex
+
+	// DefaultRuntimeName is the default runtime name to use from the runtimes table.
+	DefaultRuntimeName string `toml:"default_runtime_name" json:"defaultRuntimeName"`
+
+	// RuntimeConfigPath is a path to the root directory containing runtime
+	// If ConfigPath is set, the config.toml about runtime config content are ignored.
+	RuntimeConfigPath string `toml:"runtime_config_path" json:"configPath"`
+
+	// Runtimes is a map from CRI RuntimeHandler strings, which specify types of runtime
+	// configurations, to the matching configurations.
+	Runtimes map[string]Runtime `toml:"runtimes" json:"runtimes"`
+
+	// BaseOCISpecs contains cached OCI specs loaded via `Runtime.BaseRuntimeSpec`
+	BaseOCISpecs map[string]*oci.Spec
+
+	loadOCISpec func(filename string) (*oci.Spec, error)
+}
+
+func NewRuntimeConfig(runtimeConfigPath, defaultRuntimeName string, loadOCISpec func(filename string) (*oci.Spec, error)) *CRIRuntimeConfig {
+	if runtimeConfigPath == "" {
+		runtimeConfigPath = DefaultRuntimeConfigPath
+	}
+	return &CRIRuntimeConfig{
+		DefaultRuntimeName: defaultRuntimeName,
+		RuntimeConfigPath:  runtimeConfigPath,
+		loadOCISpec:        loadOCISpec,
+	}
+}
+
+// Init init read runtime config dir file and start watch file
+func (rc *CRIRuntimeConfig) Init(ctx context.Context) error {
+	if _, err := os.Stat(rc.RuntimeConfigPath); os.IsNotExist(err) {
+		log.G(ctx).Errorf("can't find %s runtime config path", rc.RuntimeConfigPath)
+		return nil
+	}
+	if rc.Runtimes == nil {
+		rc.Runtimes = make(map[string]Runtime)
+	}
+	err := filepath.Walk(rc.RuntimeConfigPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			log.G(ctx).Errorf("iterate dir error: %+v", err)
+			return err
+		}
+		if info.IsDir() {
+			configFilePath := filepath.Join(path, DefaultRuntimeConfigName)
+			if _, err = os.Stat(configFilePath); os.IsNotExist(err) {
+				log.G(ctx).Warnf("runtime config file not found, path is %s", configFilePath)
+				return nil
+			}
+			runtime, err := rc.loadRuntimeConfig(ctx, info.Name(), configFilePath)
+			if err != nil {
+				log.G(ctx).Errorf("load runtime config error %+v", err)
+				return err
+			}
+			if err = rc.loadOCISpecBase(*runtime); err != nil {
+				log.G(ctx).Errorf("load OCI Spec error %+v from %s", err, runtime.BaseRuntimeSpec)
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	notifyFile, err := util.NewNotifyFile()
+	if err != nil {
+		return err
+	}
+
+	if err = notifyFile.WatchDir(ctx, rc.RuntimeConfigPath, rc.NotifyEventFunc); err != nil {
+		log.G(ctx).Errorf("add notify watch dir error %+v", err)
+		return err
+	}
+
+	if err = validateRuntimeConfig(rc.DefaultRuntimeName, rc.Runtimes); err != nil {
+		log.G(ctx).Errorf("validate runtime config error %+v", err)
+		return err
+	}
+	return err
+}
+
+func (rc *CRIRuntimeConfig) NotifyEventFunc(ctx context.Context, event fsnotify.Event) error {
+	name := event.Name
+	if event.Op&fsnotify.Chmod == fsnotify.Chmod || event.Op&fsnotify.Rename == fsnotify.Rename {
+		return nil
+	}
+	if event.Op&fsnotify.Remove == fsnotify.Remove {
+		dirPath, fileName := filepath.Split(name)
+		if fileName != DefaultRuntimeConfigName {
+			return nil
+		}
+		runtimeHandler := filepath.Base(dirPath)
+		rc.runtimeRW.Lock()
+		defer rc.runtimeRW.Unlock()
+		delete(rc.Runtimes, runtimeHandler)
+		log.G(ctx).Warnf("config.toml file having delete, file path is: %s", name)
+		return nil
+	}
+
+	if event.Op&fsnotify.Create == fsnotify.Create || event.Op&fsnotify.Write == fsnotify.Write {
+		fi, err := os.Stat(name)
+		if err != nil {
+			return err
+		}
+		if fi.IsDir() {
+			return nil
+		}
+		dirPath, fileName := filepath.Split(name)
+		if fileName != DefaultRuntimeConfigName {
+			return nil
+		}
+		runtimeHandler := filepath.Base(dirPath)
+		runtime, err := rc.loadRuntimeConfig(ctx, runtimeHandler, name)
+		if err != nil {
+			log.G(ctx).Errorf("load runtime config error %+v", err)
+			return err
+		}
+		if err = rc.loadOCISpecBase(*runtime); err != nil {
+			log.G(ctx).Errorf("load OCI Spec error %+v from %s", err, runtime.BaseRuntimeSpec)
+			return err
+		}
+	}
+	return nil
+}
+
+func (rc *CRIRuntimeConfig) loadRuntimeConfig(ctx context.Context, handler, configPath string) (*Runtime, error) {
+	rc.runtimeRW.Lock()
+	defer rc.runtimeRW.Unlock()
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		log.G(ctx).Errorf("read runtime config file content error: %+v", err)
+		return nil, err
+	}
+	var runtime Runtime
+	if err = toml.NewDecoder(bytes.NewReader(data)).DisallowUnknownFields().Decode(&runtime); err != nil {
+		var serr *toml.StrictMissingError
+		if errors.As(err, &serr) {
+			for _, derr := range serr.Errors {
+				log.G(ctx).WithFields(log.Fields{
+					"key": strings.Join(derr.Key(), " "),
+				}).WithError(err).Warn("Ignoring unknown key in TOML for plugin")
+			}
+			err = nil
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	rc.Runtimes[handler] = runtime
+	return &runtime, nil
+}
+
+func (rc *CRIRuntimeConfig) loadOCISpecBase(runtime Runtime) error {
+	// TODO add watch BaseRuntimeSpec file
+	if runtime.BaseRuntimeSpec == "" {
+		return nil
+	}
+	// Don't load same file twice
+	rc.specRW.Lock()
+	defer rc.specRW.Unlock()
+	if _, ok := rc.BaseOCISpecs[runtime.BaseRuntimeSpec]; ok {
+		return nil
+	}
+	spec, err := rc.loadOCISpec(runtime.BaseRuntimeSpec)
+	if err != nil {
+		return fmt.Errorf("failed to load base OCI spec from file: %s: %w", runtime.BaseRuntimeSpec, err)
+	}
+	if spec.Process != nil && spec.Process.Capabilities != nil && len(spec.Process.Capabilities.Inheritable) > 0 {
+		log.L.WithField("base_runtime_spec", runtime.BaseRuntimeSpec).Warn("Provided base runtime spec includes inheritable capabilities, which may be unsafe. See CVE-2022-24769 for more details.")
+	}
+	rc.BaseOCISpecs[runtime.BaseRuntimeSpec] = spec
+	return nil
+}
+
+func (rc *CRIRuntimeConfig) GetRuntime(runtime string) (Runtime, bool) {
+	rc.runtimeRW.RLock()
+	defer rc.runtimeRW.RUnlock()
+	v, ok := rc.Runtimes[runtime]
+	return v, ok
+}
+
+func (rc *CRIRuntimeConfig) GetOCISpec(baseRuntimeSpec string) (*oci.Spec, bool) {
+	rc.specRW.RLock()
+	defer rc.specRW.RUnlock()
+	v, ok := rc.BaseOCISpecs[baseRuntimeSpec]
+	return v, ok
+}

--- a/pkg/cri/server/blockio_linux.go
+++ b/pkg/cri/server/blockio_linux.go
@@ -34,7 +34,7 @@ func (c *criService) blockIOClassFromAnnotations(containerName string, container
 	}
 
 	if cls != "" && !blockio.IsEnabled() {
-		if c.config.ContainerdConfig.IgnoreBlockIONotEnabledErrors {
+		if c.criBase.Config.ContainerdConfig.IgnoreBlockIONotEnabledErrors {
 			cls = ""
 			log.L.Debugf("continuing create container %s, ignoring blockio not enabled (%v)", containerName, err)
 		} else {

--- a/pkg/cri/server/container_create_linux.go
+++ b/pkg/cri/server/container_create_linux.go
@@ -90,7 +90,7 @@ func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageCon
 	if ssp == nil {
 		ssp, err = generateSeccompSecurityProfile(
 			securityContext.GetSeccompProfilePath(), //nolint:staticcheck // Deprecated but we don't want to remove yet
-			c.config.UnsetSeccompProfile)
+			c.criBase.Config.UnsetSeccompProfile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate seccomp spec opts: %w", err)
 		}
@@ -105,7 +105,7 @@ func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageCon
 	if seccompSpecOpts != nil {
 		specOpts = append(specOpts, seccompSpecOpts)
 	}
-	if c.config.EnableCDI {
+	if c.criBase.Config.EnableCDI {
 		specOpts = append(specOpts, customopts.WithCDI(config.Annotations, config.CDIDevices))
 	}
 	return specOpts, nil

--- a/pkg/cri/server/container_create_test.go
+++ b/pkg/cri/server/container_create_test.go
@@ -525,7 +525,7 @@ func TestContainerAnnotationPassthroughContainerSpec(t *testing.T) {
 
 func TestBaseRuntimeSpec(t *testing.T) {
 	c := newTestCRIService()
-	c.baseOCISpecs = map[string]*oci.Spec{
+	c.criBase.BaseOCISpecs = map[string]*oci.Spec{
 		"/etc/containerd/cri-base.json": {
 			Version:  "1.0.2",
 			Hostname: "old",
@@ -546,8 +546,8 @@ func TestBaseRuntimeSpec(t *testing.T) {
 	assert.Equal(t, "new-domain", out.Domainname)
 
 	// Make sure original base spec not changed
-	assert.NotEqual(t, out, c.baseOCISpecs["/etc/containerd/cri-base.json"])
-	assert.Equal(t, c.baseOCISpecs["/etc/containerd/cri-base.json"].Hostname, "old")
+	assert.NotEqual(t, out, c.criBase.BaseOCISpecs["/etc/containerd/cri-base.json"])
+	assert.Equal(t, c.criBase.BaseOCISpecs["/etc/containerd/cri-base.json"].Hostname, "old")
 
 	assert.Equal(t, filepath.Join("/", constants.K8sContainerdNamespace, "id1"), out.Linux.CgroupsPath)
 }

--- a/pkg/cri/server/container_execsync.go
+++ b/pkg/cri/server/container_execsync.go
@@ -120,11 +120,11 @@ func (c *criService) execInternal(ctx context.Context, container containerd.Cont
 	var drainExecSyncIOTimeout time.Duration
 	var err error
 
-	if c.config.DrainExecSyncIOTimeout != "" {
-		drainExecSyncIOTimeout, err = time.ParseDuration(c.config.DrainExecSyncIOTimeout)
+	if c.criBase.Config.DrainExecSyncIOTimeout != "" {
+		drainExecSyncIOTimeout, err = time.ParseDuration(c.criBase.Config.DrainExecSyncIOTimeout)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse drain_exec_sync_io_timeout %q: %w",
-				c.config.DrainExecSyncIOTimeout, err)
+				c.criBase.Config.DrainExecSyncIOTimeout, err)
 		}
 	}
 

--- a/pkg/cri/server/container_start.go
+++ b/pkg/cri/server/container_start.go
@@ -109,7 +109,7 @@ func (c *criService) StartContainer(ctx context.Context, r *runtime.StartContain
 		return cntr.IO, nil
 	}
 
-	ociRuntime, err := c.config.GetSandboxRuntime(sandbox.Config, sandbox.Metadata.RuntimeHandler)
+	ociRuntime, err := c.criBase.Config.GetSandboxRuntime(sandbox.Config, sandbox.Metadata.RuntimeHandler)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get sandbox runtime: %w", err)
 	}
@@ -229,10 +229,10 @@ func (c *criService) createContainerLoggers(logPath string, tty bool) (stdout io
 		}()
 		var stdoutCh, stderrCh <-chan struct{}
 		wc := cioutil.NewSerialWriteCloser(f)
-		stdout, stdoutCh = cio.NewCRILogger(logPath, wc, cio.Stdout, c.config.MaxContainerLogLineSize)
+		stdout, stdoutCh = cio.NewCRILogger(logPath, wc, cio.Stdout, c.criBase.Config.MaxContainerLogLineSize)
 		// Only redirect stderr when there is no tty.
 		if !tty {
-			stderr, stderrCh = cio.NewCRILogger(logPath, wc, cio.Stderr, c.config.MaxContainerLogLineSize)
+			stderr, stderrCh = cio.NewCRILogger(logPath, wc, cio.Stderr, c.criBase.Config.MaxContainerLogLineSize)
 		}
 		go func() {
 			if stdoutCh != nil {

--- a/pkg/cri/server/container_stats_list.go
+++ b/pkg/cri/server/container_stats_list.go
@@ -81,7 +81,7 @@ func (c *criService) getMetricsHandler(ctx context.Context, sandboxID string) (m
 		return nil, err
 	}
 
-	ociRuntime, err := c.config.GetSandboxRuntime(sandbox.Config, sandbox.RuntimeHandler)
+	ociRuntime, err := c.criBase.Config.GetSandboxRuntime(sandbox.Config, sandbox.RuntimeHandler)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get runtimeHandler %q: %w", sandbox.RuntimeHandler, err)
 	}

--- a/pkg/cri/server/container_update_resources.go
+++ b/pkg/cri/server/container_update_resources.go
@@ -94,7 +94,7 @@ func (c *criService) updateContainerResources(ctx context.Context,
 	if err != nil {
 		return newStatus, fmt.Errorf("failed to get container spec: %w", err)
 	}
-	newSpec, err := updateOCIResource(ctx, oldSpec, r, c.config)
+	newSpec, err := updateOCIResource(ctx, oldSpec, r, c.criBase.Config)
 	if err != nil {
 		return newStatus, fmt.Errorf("failed to update resource in spec: %w", err)
 	}

--- a/pkg/cri/server/helpers.go
+++ b/pkg/cri/server/helpers.go
@@ -82,13 +82,13 @@ const (
 // getSandboxRootDir returns the root directory for managing sandbox files,
 // e.g. hosts files.
 func (c *criService) getSandboxRootDir(id string) string {
-	return filepath.Join(c.config.RootDir, sandboxesDir, id)
+	return filepath.Join(c.criBase.Config.RootDir, sandboxesDir, id)
 }
 
 // getVolatileSandboxRootDir returns the root directory for managing volatile sandbox files,
 // e.g. named pipes.
 func (c *criService) getVolatileSandboxRootDir(id string) string {
-	return filepath.Join(c.config.StateDir, sandboxesDir, id)
+	return filepath.Join(c.criBase.Config.StateDir, sandboxesDir, id)
 }
 
 // getSandboxHostname returns the hostname file path inside the sandbox root directory.
@@ -138,13 +138,13 @@ func makeContainerName(c *runtime.ContainerMetadata, s *runtime.PodSandboxMetada
 // getContainerRootDir returns the root directory for managing container files,
 // e.g. state checkpoint.
 func (c *criService) getContainerRootDir(id string) string {
-	return filepath.Join(c.config.RootDir, containersDir, id)
+	return filepath.Join(c.criBase.Config.RootDir, containersDir, id)
 }
 
 // getVolatileContainerRootDir returns the root directory for managing volatile container files,
 // e.g. named pipes.
 func (c *criService) getVolatileContainerRootDir(id string) string {
-	return filepath.Join(c.config.StateDir, containersDir, id)
+	return filepath.Join(c.criBase.Config.StateDir, containersDir, id)
 }
 
 // criContainerStateToString formats CRI container state to string.

--- a/pkg/cri/server/helpers_linux.go
+++ b/pkg/cri/server/helpers_linux.go
@@ -44,7 +44,7 @@ import (
 // apparmorEnabled returns true if apparmor is enabled, supported by the host,
 // if apparmor_parser is installed, and if we are not running docker-in-docker.
 func (c *criService) apparmorEnabled() bool {
-	if c.config.DisableApparmor {
+	if c.criBase.Config.DisableApparmor {
 		return false
 	}
 	return apparmor.HostSupports()

--- a/pkg/cri/server/nri.go
+++ b/pkg/cri/server/nri.go
@@ -28,7 +28,7 @@ type criImplementation struct {
 }
 
 func (i *criImplementation) Config() *criconfig.Config {
-	return &i.c.config
+	return &i.c.criBase.Config
 }
 
 func (i *criImplementation) SandboxStore() *sstore.Store {

--- a/pkg/cri/server/podsandbox/controller.go
+++ b/pkg/cri/server/podsandbox/controller.go
@@ -29,8 +29,6 @@ import (
 	eventtypes "github.com/containerd/containerd/v2/api/events"
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/errdefs"
-	"github.com/containerd/containerd/v2/oci"
-	criconfig "github.com/containerd/containerd/v2/pkg/cri/config"
 	"github.com/containerd/containerd/v2/pkg/cri/constants"
 	"github.com/containerd/containerd/v2/pkg/cri/server/base"
 	"github.com/containerd/containerd/v2/pkg/cri/server/images"
@@ -83,9 +81,8 @@ func init() {
 
 			c := Controller{
 				client:       client,
-				config:       criBase.Config,
 				os:           osinterface.RealOS{},
-				baseOCISpecs: criBase.BaseOCISpecs,
+				criBase:      criBase,
 				imageService: imageService,
 				store:        NewStore(),
 			}
@@ -111,7 +108,7 @@ type ImageService interface {
 
 type Controller struct {
 	// config contains all configurations.
-	config criconfig.Config
+	//config criconfig.Config
 	// client is an instance of the containerd client
 	client *containerd.Client
 	// imageService is a dependency to CRI image service.
@@ -122,8 +119,8 @@ type Controller struct {
 	os osinterface.OS
 	// cri is CRI service that provides missing gaps needed by controller.
 	cri CRIService
-	// baseOCISpecs contains cached OCI specs loaded via `Runtime.BaseRuntimeSpec`
-	baseOCISpecs map[string]*oci.Spec
+	// criBase is common dependencies for CRI's runtime
+	criBase *base.CRIBase
 
 	store *Store
 }

--- a/pkg/cri/server/podsandbox/controller_test.go
+++ b/pkg/cri/server/podsandbox/controller_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	criconfig "github.com/containerd/containerd/v2/pkg/cri/config"
+	"github.com/containerd/containerd/v2/pkg/cri/server/base"
 	"github.com/containerd/containerd/v2/pkg/cri/store/label"
 	sandboxstore "github.com/containerd/containerd/v2/pkg/cri/store/sandbox"
 	ostesting "github.com/containerd/containerd/v2/pkg/os/testing"
@@ -50,7 +51,9 @@ var testConfig = criconfig.Config{
 func newControllerService() *Controller {
 	labels := label.NewStore()
 	return &Controller{
-		config:       testConfig,
+		criBase: &base.CRIBase{
+			Config: testConfig,
+		},
 		os:           ostesting.NewFakeOS(),
 		sandboxStore: sandboxstore.NewStore(labels),
 	}

--- a/pkg/cri/server/podsandbox/helpers.go
+++ b/pkg/cri/server/podsandbox/helpers.go
@@ -60,13 +60,13 @@ const (
 // getSandboxRootDir returns the root directory for managing sandbox files,
 // e.g. hosts files.
 func (c *Controller) getSandboxRootDir(id string) string {
-	return filepath.Join(c.config.RootDir, sandboxesDir, id)
+	return filepath.Join(c.criBase.Config.RootDir, sandboxesDir, id)
 }
 
 // getVolatileSandboxRootDir returns the root directory for managing volatile sandbox files,
 // e.g. named pipes.
 func (c *Controller) getVolatileSandboxRootDir(id string) string {
-	return filepath.Join(c.config.StateDir, sandboxesDir, id)
+	return filepath.Join(c.criBase.Config.StateDir, sandboxesDir, id)
 }
 
 // getRepoDigestAngTag returns image repoDigest and repoTag of the named image reference.
@@ -158,7 +158,7 @@ func (c *Controller) runtimeSpec(id string, baseSpecFile string, opts ...oci.Spe
 	container := &containers.Container{ID: id}
 
 	if baseSpecFile != "" {
-		baseSpec, ok := c.baseOCISpecs[baseSpecFile]
+		baseSpec, ok := c.criBase.GetOCISpec(baseSpecFile)
 		if !ok {
 			return nil, fmt.Errorf("can't find base OCI spec %q", baseSpecFile)
 		}
@@ -190,7 +190,7 @@ func (c *Controller) runtimeSpec(id string, baseSpecFile string, opts ...oci.Spe
 // See https://github.com/containerd/containerd/issues/6657
 func (c *Controller) runtimeSnapshotter(ctx context.Context, ociRuntime criconfig.Runtime) string {
 	if ociRuntime.Snapshotter == "" {
-		return c.config.ContainerdConfig.Snapshotter
+		return c.criBase.Config.ContainerdConfig.Snapshotter
 	}
 
 	log.G(ctx).Debugf("Set snapshotter for runtime %s to %s", ociRuntime.Type, ociRuntime.Snapshotter)

--- a/pkg/cri/server/podsandbox/sandbox_run.go
+++ b/pkg/cri/server/podsandbox/sandbox_run.go
@@ -79,9 +79,9 @@ func (c *Controller) Start(ctx context.Context, id string) (cin sandbox.Controll
 	)
 
 	// Ensure sandbox container image snapshot.
-	image, err := c.ensureImageExists(ctx, c.config.SandboxImage, config)
+	image, err := c.ensureImageExists(ctx, c.criBase.Config.SandboxImage, config)
 	if err != nil {
-		return cin, fmt.Errorf("failed to get sandbox image %q: %w", c.config.SandboxImage, err)
+		return cin, fmt.Errorf("failed to get sandbox image %q: %w", c.criBase.Config.SandboxImage, err)
 	}
 
 	containerdImage, err := c.toContainerdImage(ctx, *image)
@@ -89,7 +89,7 @@ func (c *Controller) Start(ctx context.Context, id string) (cin sandbox.Controll
 		return cin, fmt.Errorf("failed to get image from containerd %q: %w", image.ID, err)
 	}
 
-	ociRuntime, err := c.config.GetSandboxRuntime(config, metadata.RuntimeHandler)
+	ociRuntime, err := c.criBase.Config.GetSandboxRuntime(config, metadata.RuntimeHandler)
 	if err != nil {
 		return cin, fmt.Errorf("failed to get sandbox runtime: %w", err)
 	}

--- a/pkg/cri/server/podsandbox/sandbox_run_linux_test.go
+++ b/pkg/cri/server/podsandbox/sandbox_run_linux_test.go
@@ -396,8 +396,8 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			c := newControllerService()
-			c.config.EnableUnprivilegedICMP = true
-			c.config.EnableUnprivilegedPorts = true
+			c.criBase.Config.EnableUnprivilegedICMP = true
+			c.criBase.Config.EnableUnprivilegedPorts = true
 			config, imageConfig, specCheck := getRunPodSandboxTestData()
 			if test.configChange != nil {
 				test.configChange(config)
@@ -681,7 +681,7 @@ options timeout:1
 func TestSandboxDisableCgroup(t *testing.T) {
 	config, imageConfig, _ := getRunPodSandboxTestData()
 	c := newControllerService()
-	c.config.DisableCgroup = true
+	c.criBase.Config.DisableCgroup = true
 	spec, err := c.sandboxContainerSpec("test-id", config, imageConfig, "test-cni", []string{})
 	require.NoError(t, err)
 

--- a/pkg/cri/server/rdt.go
+++ b/pkg/cri/server/rdt.go
@@ -38,7 +38,7 @@ func (c *criService) rdtClassFromAnnotations(containerName string, containerAnno
 	}
 
 	if err != nil {
-		if !rdt.IsEnabled() && c.config.ContainerdConfig.IgnoreRdtNotEnabledErrors {
+		if !rdt.IsEnabled() && c.criBase.Config.ContainerdConfig.IgnoreRdtNotEnabledErrors {
 			log.L.Debugf("continuing create container %s, ignoring rdt not enabled (%v)", containerName, err)
 			return "", nil
 		}

--- a/pkg/cri/server/restart.go
+++ b/pkg/cri/server/restart.go
@@ -197,22 +197,22 @@ func (c *criService) recover(ctx context.Context) error {
 	}{
 		{
 			cntrs:  sandboxes,
-			base:   filepath.Join(c.config.RootDir, sandboxesDir),
+			base:   filepath.Join(c.criBase.Config.RootDir, sandboxesDir),
 			errMsg: "failed to cleanup orphaned sandbox directories",
 		},
 		{
 			cntrs:  sandboxes,
-			base:   filepath.Join(c.config.StateDir, sandboxesDir),
+			base:   filepath.Join(c.criBase.Config.StateDir, sandboxesDir),
 			errMsg: "failed to cleanup orphaned volatile sandbox directories",
 		},
 		{
 			cntrs:  containers,
-			base:   filepath.Join(c.config.RootDir, containersDir),
+			base:   filepath.Join(c.criBase.Config.RootDir, containersDir),
 			errMsg: "failed to cleanup orphaned container directories",
 		},
 		{
 			cntrs:  containers,
-			base:   filepath.Join(c.config.StateDir, containersDir),
+			base:   filepath.Join(c.criBase.Config.StateDir, containersDir),
 			errMsg: "failed to cleanup orphaned volatile container directories",
 		},
 	} {
@@ -424,7 +424,7 @@ func getNetNS(meta *sandboxstore.Metadata) *netns.NetNS {
 
 // loadImages loads images from containerd.
 func (c *criService) loadImages(ctx context.Context, cImages []containerd.Image) {
-	snapshotter := c.config.ContainerdConfig.Snapshotter
+	snapshotter := c.criBase.Config.ContainerdConfig.Snapshotter
 	var wg sync.WaitGroup
 	for _, i := range cImages {
 		wg.Add(1)

--- a/pkg/cri/server/runtime_config_linux.go
+++ b/pkg/cri/server/runtime_config_linux.go
@@ -34,22 +34,22 @@ func (c *criService) getLinuxRuntimeConfig(ctx context.Context) *runtime.LinuxRu
 func (c *criService) getCgroupDriver(ctx context.Context) runtime.CgroupDriver {
 	// Go through the runtime handlers in a predictable order, starting from the
 	// default handler, others sorted in alphabetical order
-	handlerNames := make([]string, 0, len(c.config.ContainerdConfig.Runtimes))
-	for n := range c.config.ContainerdConfig.Runtimes {
+	handlerNames := make([]string, 0, len(c.criBase.Config.ContainerdConfig.Runtimes))
+	for n := range c.criBase.Config.ContainerdConfig.Runtimes {
 		handlerNames = append(handlerNames, n)
 	}
 	sort.Slice(handlerNames, func(i, j int) bool {
-		if handlerNames[i] == c.config.ContainerdConfig.DefaultRuntimeName {
+		if handlerNames[i] == c.criBase.Config.ContainerdConfig.DefaultRuntimeName {
 			return true
 		}
-		if handlerNames[j] == c.config.ContainerdConfig.DefaultRuntimeName {
+		if handlerNames[j] == c.criBase.Config.ContainerdConfig.DefaultRuntimeName {
 			return false
 		}
 		return handlerNames[i] < handlerNames[j]
 	})
 
 	for _, handler := range handlerNames {
-		opts, err := criconfig.GenerateRuntimeOptions(c.config.ContainerdConfig.Runtimes[handler])
+		opts, err := criconfig.GenerateRuntimeOptions(c.criBase.Config.ContainerdConfig.Runtimes[handler])
 		if err != nil {
 			log.G(ctx).Debugf("failed to parse runtime handler options for %q", handler)
 			continue

--- a/pkg/cri/server/runtime_config_linux_test.go
+++ b/pkg/cri/server/runtime_config_linux_test.go
@@ -94,8 +94,8 @@ func TestRuntimeConfig(t *testing.T) {
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			c := newTestCRIService()
-			c.config.PluginConfig.ContainerdConfig.DefaultRuntimeName = test.defaultRuntime
-			c.config.PluginConfig.ContainerdConfig.Runtimes = test.runtimes
+			c.criBase.Config.PluginConfig.ContainerdConfig.DefaultRuntimeName = test.defaultRuntime
+			c.criBase.Config.PluginConfig.ContainerdConfig.Runtimes = test.runtimes
 
 			resp, err := c.RuntimeConfig(context.TODO(), &runtime.RuntimeConfigRequest{})
 			assert.NoError(t, err)

--- a/pkg/cri/server/sandbox_stats_windows.go
+++ b/pkg/cri/server/sandbox_stats_windows.go
@@ -121,7 +121,7 @@ func (c *criService) toPodSandboxStats(sandbox sandboxstore.Sandbox, statsMap ma
 		return nil, nil, fmt.Errorf("failed to find container metric for pod with id %s", sandbox.ID)
 	}
 
-	ociRuntime, err := c.config.GetSandboxRuntime(sandbox.Config, sandbox.RuntimeHandler)
+	ociRuntime, err := c.criBase.Config.GetSandboxRuntime(sandbox.Config, sandbox.RuntimeHandler)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get runtimeHandler %q: %w", sandbox.RuntimeHandler, err)
 	}

--- a/pkg/cri/server/service_test.go
+++ b/pkg/cri/server/service_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/containerd/containerd/v2/api/types"
 	"github.com/containerd/containerd/v2/errdefs"
+	"github.com/containerd/containerd/v2/pkg/cri/server/base"
 	containerstore "github.com/containerd/containerd/v2/pkg/cri/store/container"
 	"github.com/containerd/containerd/v2/pkg/cri/store/label"
 	sandboxstore "github.com/containerd/containerd/v2/pkg/cri/store/sandbox"
@@ -77,9 +78,12 @@ func (f fakeSandboxController) Metrics(ctx context.Context, sandboxID string) (*
 // newTestCRIService creates a fake criService for test.
 func newTestCRIService() *criService {
 	labels := label.NewStore()
+	criBase := &base.CRIBase{
+		Config: testConfig,
+	}
 	return &criService{
 		imageService:       &fakeImageService{},
-		config:             testConfig,
+		criBase:            criBase,
 		os:                 ostesting.NewFakeOS(),
 		sandboxStore:       sandboxstore.NewStore(labels),
 		sandboxNameIndex:   registrar.NewRegistrar(),

--- a/pkg/cri/server/service_windows.go
+++ b/pkg/cri/server/service_windows.go
@@ -29,9 +29,9 @@ const windowsNetworkAttachCount = 1
 // initPlatform handles windows specific initialization for the CRI service.
 func (c *criService) initPlatform() error {
 	pluginDirs := map[string]string{
-		defaultNetworkPlugin: c.config.NetworkPluginConfDir,
+		defaultNetworkPlugin: c.criBase.Config.NetworkPluginConfDir,
 	}
-	for name, conf := range c.config.Runtimes {
+	for name, conf := range c.criBase.Config.Runtimes {
 		if conf.NetworkPluginConfDir != "" {
 			pluginDirs[name] = conf.NetworkPluginConfDir
 		}
@@ -39,9 +39,9 @@ func (c *criService) initPlatform() error {
 
 	c.netPlugin = make(map[string]cni.CNI)
 	for name, dir := range pluginDirs {
-		max := c.config.NetworkPluginMaxConfNum
+		max := c.criBase.Config.NetworkPluginMaxConfNum
 		if name != defaultNetworkPlugin {
-			if m := c.config.Runtimes[name].NetworkPluginMaxConfNum; m != 0 {
+			if m := c.criBase.Config.Runtimes[name].NetworkPluginMaxConfNum; m != 0 {
 				max = m
 			}
 		}
@@ -53,7 +53,7 @@ func (c *criService) initPlatform() error {
 		i, err := cni.New(cni.WithMinNetworkCount(windowsNetworkAttachCount),
 			cni.WithPluginConfDir(dir),
 			cni.WithPluginMaxConfNum(max),
-			cni.WithPluginDir([]string{c.config.NetworkPluginBinDir}))
+			cni.WithPluginDir([]string{c.criBase.Config.NetworkPluginBinDir}))
 		if err != nil {
 			return fmt.Errorf("failed to initialize cni: %w", err)
 		}

--- a/pkg/cri/server/status.go
+++ b/pkg/cri/server/status.go
@@ -58,7 +58,7 @@ func (c *criService) Status(ctx context.Context, r *runtime.StatusRequest) (*run
 		}},
 	}
 	if r.Verbose {
-		configByt, err := json.Marshal(c.config)
+		configByt, err := json.Marshal(c.criBase.Config)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cri/server/streaming.go
+++ b/pkg/cri/server/streaming.go
@@ -46,22 +46,22 @@ const (
 )
 
 func getStreamListenerMode(c *criService) (streamListenerMode, error) {
-	if c.config.EnableTLSStreaming {
-		if c.config.X509KeyPairStreaming.TLSCertFile != "" && c.config.X509KeyPairStreaming.TLSKeyFile != "" {
+	if c.criBase.Config.EnableTLSStreaming {
+		if c.criBase.Config.X509KeyPairStreaming.TLSCertFile != "" && c.criBase.Config.X509KeyPairStreaming.TLSKeyFile != "" {
 			return x509KeyPairTLS, nil
 		}
-		if c.config.X509KeyPairStreaming.TLSCertFile != "" && c.config.X509KeyPairStreaming.TLSKeyFile == "" {
+		if c.criBase.Config.X509KeyPairStreaming.TLSCertFile != "" && c.criBase.Config.X509KeyPairStreaming.TLSKeyFile == "" {
 			return -1, errors.New("must set X509KeyPairStreaming.TLSKeyFile")
 		}
-		if c.config.X509KeyPairStreaming.TLSCertFile == "" && c.config.X509KeyPairStreaming.TLSKeyFile != "" {
+		if c.criBase.Config.X509KeyPairStreaming.TLSCertFile == "" && c.criBase.Config.X509KeyPairStreaming.TLSKeyFile != "" {
 			return -1, errors.New("must set X509KeyPairStreaming.TLSCertFile")
 		}
 		return selfSignTLS, nil
 	}
-	if c.config.X509KeyPairStreaming.TLSCertFile != "" {
+	if c.criBase.Config.X509KeyPairStreaming.TLSCertFile != "" {
 		return -1, errors.New("X509KeyPairStreaming.TLSCertFile is set but EnableTLSStreaming is not set")
 	}
-	if c.config.X509KeyPairStreaming.TLSKeyFile != "" {
+	if c.criBase.Config.X509KeyPairStreaming.TLSKeyFile != "" {
 		return -1, errors.New("X509KeyPairStreaming.TLSKeyFile is set but EnableTLSStreaming is not set")
 	}
 	return withoutTLS, nil
@@ -91,7 +91,7 @@ func newStreamServer(c *criService, addr, port, streamIdleTimeout string) (strea
 	}
 	switch tlsMode {
 	case x509KeyPairTLS:
-		tlsCert, err := tls.LoadX509KeyPair(c.config.X509KeyPairStreaming.TLSCertFile, c.config.X509KeyPairStreaming.TLSKeyFile)
+		tlsCert, err := tls.LoadX509KeyPair(c.criBase.Config.X509KeyPairStreaming.TLSCertFile, c.criBase.Config.X509KeyPairStreaming.TLSKeyFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load x509 key pair for stream server: %w", err)
 		}

--- a/pkg/cri/server/streaming_test.go
+++ b/pkg/cri/server/streaming_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/containerd/containerd/v2/pkg/cri/config"
+	"github.com/containerd/containerd/v2/pkg/cri/server/base"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,8 +34,10 @@ func TestValidateStreamServer(t *testing.T) {
 		{
 			desc: "should pass with default withoutTLS",
 			criService: &criService{
-				config: config.Config{
-					PluginConfig: config.DefaultConfig(),
+				criBase: &base.CRIBase{
+					Config: config.Config{
+						PluginConfig: config.DefaultConfig(),
+					},
 				},
 			},
 			tlsMode:   withoutTLS,
@@ -43,12 +46,14 @@ func TestValidateStreamServer(t *testing.T) {
 		{
 			desc: "should pass with x509KeyPairTLS",
 			criService: &criService{
-				config: config.Config{
-					PluginConfig: config.PluginConfig{
-						EnableTLSStreaming: true,
-						X509KeyPairStreaming: config.X509KeyPairStreaming{
-							TLSKeyFile:  "non-empty",
-							TLSCertFile: "non-empty",
+				criBase: &base.CRIBase{
+					Config: config.Config{
+						PluginConfig: config.PluginConfig{
+							EnableTLSStreaming: true,
+							X509KeyPairStreaming: config.X509KeyPairStreaming{
+								TLSKeyFile:  "non-empty",
+								TLSCertFile: "non-empty",
+							},
 						},
 					},
 				},
@@ -59,9 +64,11 @@ func TestValidateStreamServer(t *testing.T) {
 		{
 			desc: "should pass with selfSign",
 			criService: &criService{
-				config: config.Config{
-					PluginConfig: config.PluginConfig{
-						EnableTLSStreaming: true,
+				criBase: &base.CRIBase{
+					Config: config.Config{
+						PluginConfig: config.PluginConfig{
+							EnableTLSStreaming: true,
+						},
 					},
 				},
 			},
@@ -71,12 +78,14 @@ func TestValidateStreamServer(t *testing.T) {
 		{
 			desc: "should return error with X509 keypair but not EnableTLSStreaming",
 			criService: &criService{
-				config: config.Config{
-					PluginConfig: config.PluginConfig{
-						EnableTLSStreaming: false,
-						X509KeyPairStreaming: config.X509KeyPairStreaming{
-							TLSKeyFile:  "non-empty",
-							TLSCertFile: "non-empty",
+				criBase: &base.CRIBase{
+					Config: config.Config{
+						PluginConfig: config.PluginConfig{
+							EnableTLSStreaming: false,
+							X509KeyPairStreaming: config.X509KeyPairStreaming{
+								TLSKeyFile:  "non-empty",
+								TLSCertFile: "non-empty",
+							},
 						},
 					},
 				},
@@ -87,12 +96,14 @@ func TestValidateStreamServer(t *testing.T) {
 		{
 			desc: "should return error with X509 TLSCertFile empty",
 			criService: &criService{
-				config: config.Config{
-					PluginConfig: config.PluginConfig{
-						EnableTLSStreaming: true,
-						X509KeyPairStreaming: config.X509KeyPairStreaming{
-							TLSKeyFile:  "non-empty",
-							TLSCertFile: "",
+				criBase: &base.CRIBase{
+					Config: config.Config{
+						PluginConfig: config.PluginConfig{
+							EnableTLSStreaming: true,
+							X509KeyPairStreaming: config.X509KeyPairStreaming{
+								TLSKeyFile:  "non-empty",
+								TLSCertFile: "",
+							},
 						},
 					},
 				},
@@ -103,12 +114,14 @@ func TestValidateStreamServer(t *testing.T) {
 		{
 			desc: "should return error with X509 TLSKeyFile empty",
 			criService: &criService{
-				config: config.Config{
-					PluginConfig: config.PluginConfig{
-						EnableTLSStreaming: true,
-						X509KeyPairStreaming: config.X509KeyPairStreaming{
-							TLSKeyFile:  "",
-							TLSCertFile: "non-empty",
+				criBase: &base.CRIBase{
+					Config: config.Config{
+						PluginConfig: config.PluginConfig{
+							EnableTLSStreaming: true,
+							X509KeyPairStreaming: config.X509KeyPairStreaming{
+								TLSKeyFile:  "",
+								TLSCertFile: "non-empty",
+							},
 						},
 					},
 				},
@@ -119,12 +132,14 @@ func TestValidateStreamServer(t *testing.T) {
 		{
 			desc: "should return error without EnableTLSStreaming and only TLSCertFile set",
 			criService: &criService{
-				config: config.Config{
-					PluginConfig: config.PluginConfig{
-						EnableTLSStreaming: false,
-						X509KeyPairStreaming: config.X509KeyPairStreaming{
-							TLSKeyFile:  "",
-							TLSCertFile: "non-empty",
+				criBase: &base.CRIBase{
+					Config: config.Config{
+						PluginConfig: config.PluginConfig{
+							EnableTLSStreaming: false,
+							X509KeyPairStreaming: config.X509KeyPairStreaming{
+								TLSKeyFile:  "",
+								TLSCertFile: "non-empty",
+							},
 						},
 					},
 				},
@@ -135,12 +150,14 @@ func TestValidateStreamServer(t *testing.T) {
 		{
 			desc: "should return error without EnableTLSStreaming and only TLSKeyFile set",
 			criService: &criService{
-				config: config.Config{
-					PluginConfig: config.PluginConfig{
-						EnableTLSStreaming: false,
-						X509KeyPairStreaming: config.X509KeyPairStreaming{
-							TLSKeyFile:  "non-empty",
-							TLSCertFile: "",
+				criBase: &base.CRIBase{
+					Config: config.Config{
+						PluginConfig: config.PluginConfig{
+							EnableTLSStreaming: false,
+							X509KeyPairStreaming: config.X509KeyPairStreaming{
+								TLSKeyFile:  "non-empty",
+								TLSCertFile: "",
+							},
 						},
 					},
 				},

--- a/pkg/cri/server/update_runtime_config.go
+++ b/pkg/cri/server/update_runtime_config.go
@@ -67,7 +67,7 @@ func (c *criService) UpdateRuntimeConfig(ctx context.Context, r *runtime.UpdateR
 		return nil, fmt.Errorf("get routes: %w", err)
 	}
 
-	confTemplate := c.config.NetworkPluginConfTemplate
+	confTemplate := c.criBase.Config.NetworkPluginConfTemplate
 	if confTemplate == "" {
 		log.G(ctx).Info("No cni config template is specified, wait for other system components to drop the config.")
 		return &runtime.UpdateRuntimeConfigResponse{}, nil
@@ -90,7 +90,7 @@ func (c *criService) UpdateRuntimeConfig(ctx context.Context, r *runtime.UpdateR
 		log.G(ctx).Infof("CNI config is successfully loaded, skip generating cni config from template %q", confTemplate)
 		return &runtime.UpdateRuntimeConfigResponse{}, nil
 	}
-	if err := writeCNIConfigFile(ctx, c.config.NetworkPluginConfDir, confTemplate, cidrs[0], cidrs, routes); err != nil {
+	if err := writeCNIConfigFile(ctx, c.criBase.Config.NetworkPluginConfDir, confTemplate, cidrs[0], cidrs, routes); err != nil {
 		return nil, err
 	}
 	return &runtime.UpdateRuntimeConfigResponse{}, nil

--- a/pkg/cri/server/update_runtime_config_test.go
+++ b/pkg/cri/server/update_runtime_config_test.go
@@ -107,7 +107,7 @@ func TestUpdateRuntimeConfig(t *testing.T) {
 			confName := filepath.Join(confDir, cniConfigFileName)
 
 			c := newTestCRIService()
-			c.config.CniConfig = criconfig.CniConfig{
+			c.criBase.Config.CniConfig = criconfig.CniConfig{
 				NetworkPluginConfDir:      confDir,
 				NetworkPluginConfTemplate: templateName,
 			}
@@ -119,7 +119,7 @@ func TestUpdateRuntimeConfig(t *testing.T) {
 				},
 			}
 			if test.noTemplate {
-				c.config.CniConfig.NetworkPluginConfTemplate = ""
+				c.criBase.Config.CniConfig.NetworkPluginConfTemplate = ""
 			}
 			if test.emptyCIDR {
 				req.RuntimeConfig.NetworkConfig.PodCidr = ""

--- a/pkg/cri/util/fsnotify.go
+++ b/pkg/cri/util/fsnotify.go
@@ -1,0 +1,109 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/containerd/log"
+	"github.com/fsnotify/fsnotify"
+)
+
+type NotifyEventFunc func(context.Context, fsnotify.Event) error
+
+type NotifyFile struct {
+	watch *fsnotify.Watcher
+}
+
+func NewNotifyFile() (*NotifyFile, error) {
+	w := new(NotifyFile)
+	watch, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	w.watch = watch
+	return w, nil
+}
+
+func (nf *NotifyFile) WatchFile(ctx context.Context, file string, fc NotifyEventFunc) error {
+	dir, _ := filepath.Split(file)
+	err := nf.watch.Add(dir)
+	go nf.watchEvent(ctx, fc)
+	return err
+}
+
+func (nf *NotifyFile) WatchDir(ctx context.Context, dir string, fc NotifyEventFunc) error {
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if info.IsDir() {
+			path, err := filepath.Abs(path)
+			if err != nil {
+				return err
+			}
+			err = nf.watch.Add(path)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	go nf.watchEvent(ctx, fc)
+	return err
+}
+
+func (nf *NotifyFile) watchEvent(ctx context.Context, fc NotifyEventFunc) {
+	for {
+		select {
+		case <-ctx.Done():
+			log.G(ctx).Infof("exit fsnotify, recive ctx done event")
+			return
+		case ev := <-nf.watch.Events:
+			if ev.Op&fsnotify.Create == fsnotify.Create {
+				file, err := os.Stat(ev.Name)
+				if err == nil && file.IsDir() {
+					nf.watch.Add(ev.Name)
+					log.G(ctx).Infof("event type is create dir, add watch: %s", ev.Name)
+				}
+			}
+
+			if ev.Op&fsnotify.Remove == fsnotify.Remove {
+				fi, err := os.Stat(ev.Name)
+				if err == nil && fi.IsDir() {
+					nf.watch.Remove(ev.Name)
+					log.G(ctx).Infof("event type is delete dir, remove watch: %s", ev.Name)
+				}
+			}
+
+			if ev.Op&fsnotify.Rename == fsnotify.Rename {
+				nf.watch.Remove(ev.Name)
+				log.G(ctx).Infof("event type is rename, remove this watch: %s", ev.Name)
+			}
+			// filter swp file
+			_, fileName := filepath.Split(ev.Name)
+			if fileName[0] == '.' {
+				break
+			}
+			if err := fc(ctx, ev); err != nil {
+				log.G(ctx).Errorf("call NotifyEventFunc function error:%s", err)
+			}
+		case err := <-nf.watch.Errors:
+			log.G(ctx).Errorf("watch event error: %+v", err)
+			return
+		}
+	}
+}


### PR DESCRIPTION
Fixes: https://github.com/containerd/containerd/issues/9296
current use case:
1. set runtime_config_path field to contif.toml file.
```
$ vim config.toml
runtime_config_path=/etc/containerd/runtimes
```

**case1**: add runtime nvidia and change default_runtime_name

- first step: add nvidia config.toml
```
$ mkdir /etc/containerd/runtimes/nvidia
$ vim /etc/containerd/runtimes/nvidia/config.toml
base_runtime_spec = ""
container_annotations = []
pod_annotations = []
privileged_without_host_devices = false
runtime_engine = ""
runtime_root = ""
runtime_type = "io.containerd.runc.v2"

[options]
  BinaryName = "/usr/local/nvidia/toolkit/nvidia-container-runtime"
  CriuImagePath = ""
  CriuPath = ""
  CriuWorkPath = ""
  IoGid = 0
  IoUid = 0
  NoNewKeyring = false
  NoPivotRoot = false
  Root = ""
  ShimCgroup = ""
  SystemdCgroup = true
```

- second step: update default_runtime_name
```
$ vim /etc/containerd/config.toml
default_runtime_name=nvidia
```

Then you can use nvidia's runtime without restarting containerd.

**case2**: update runtime runc and don't change default_runtime_name

```
# set SystemdCgroup is true
$ vim /etc/containerd/runtimes/runc/config.toml
base_runtime_spec = ""
container_annotations = []
pod_annotations = []
privileged_without_host_devices = false
runtime_engine = ""
runtime_root = ""
runtime_type = "io.containerd.runc.v2"

[options]
  BinaryName = ""
  CriuImagePath = ""
  CriuPath = ""
  CriuWorkPath = ""
  IoGid = 0
  IoUid = 0
  NoNewKeyring = false
  NoPivotRoot = false
  Root = ""
  ShimCgroup = ""
  SystemdCgroup = true
```

Then you can use runc runtime without restarting containerd.


**important hint:** 
/etc/containerd/runtimes/{handler}/config.toml file can't config as follows field：
- snapshotter
- NetworkPluginConfDir
- NetworkPluginMaxConfNum


