### PR TITLE
[release/1.7] cri: add deprecation warnings for deprecated CRI configs

### DIFF
--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -433,6 +433,7 @@ func ValidatePluginConfig(ctx context.Context, c *PluginConfig) ([]deprecation.W
 		if _, ok := c.ContainerdConfig.Runtimes[RuntimeUntrusted]; ok {
 			return warnings, fmt.Errorf("conflicting definitions: configuration includes both `untrusted_workload_runtime` and `runtimes[%q]`", RuntimeUntrusted)
 		}
+		warnings = append(warnings, deprecation.CRIUntrustedWorkloadRuntime)
 		c.ContainerdConfig.Runtimes[RuntimeUntrusted] = c.ContainerdConfig.UntrustedWorkloadRuntime
 	}
 

--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -473,6 +473,7 @@ func ValidatePluginConfig(ctx context.Context, c *PluginConfig) ([]deprecation.W
 			if r.Type != plugin.RuntimeLinuxV1 {
 				return warnings, fmt.Errorf("`runtime_engine` only works for runtime %s", plugin.RuntimeLinuxV1)
 			}
+			warnings = append(warnings, deprecation.CRIRuntimeEngine)
 			log.G(ctx).Warning("`runtime_engine` is deprecated, please use runtime `options` instead")
 		}
 		if r.Root != "" {

--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -439,6 +439,7 @@ func ValidatePluginConfig(ctx context.Context, c *PluginConfig) ([]deprecation.W
 
 	// Validation for deprecated default_runtime field.
 	if c.ContainerdConfig.DefaultRuntime.Type != "" {
+		warnings = append(warnings, deprecation.CRIDefaultRuntime)
 		log.G(ctx).Warning("`default_runtime` is deprecated, please use `default_runtime_name` to reference the default configuration you have defined in `runtimes`")
 		c.ContainerdConfig.DefaultRuntimeName = RuntimeDefault
 		c.ContainerdConfig.Runtimes[RuntimeDefault] = c.ContainerdConfig.DefaultRuntime

--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -480,6 +480,7 @@ func ValidatePluginConfig(ctx context.Context, c *PluginConfig) ([]deprecation.W
 			if r.Type != plugin.RuntimeLinuxV1 {
 				return warnings, fmt.Errorf("`runtime_root` only works for runtime %s", plugin.RuntimeLinuxV1)
 			}
+			warnings = append(warnings, deprecation.CRIRuntimeRoot)
 			log.G(ctx).Warning("`runtime_root` is deprecated, please use runtime `options` instead")
 		}
 		if !r.PrivilegedWithoutHostDevices && r.PrivilegedWithoutHostDevicesAllDevicesAllowed {

--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -456,6 +456,7 @@ func ValidatePluginConfig(ctx context.Context, c *PluginConfig) ([]deprecation.W
 		if c.ContainerdConfig.Runtimes[c.ContainerdConfig.DefaultRuntimeName].Type != plugin.RuntimeLinuxV1 {
 			return warnings, fmt.Errorf("`systemd_cgroup` only works for runtime %s", plugin.RuntimeLinuxV1)
 		}
+		warnings = append(warnings, deprecation.CRISystemdCgroupV1)
 		log.G(ctx).Warning("`systemd_cgroup` is deprecated, please use runtime `options` instead")
 	}
 	if c.NoPivot {

--- a/pkg/cri/config/config_test.go
+++ b/pkg/cri/config/config_test.go
@@ -146,6 +146,7 @@ func TestValidateConfig(t *testing.T) {
 					},
 				},
 			},
+			warnings: []deprecation.Warning{deprecation.CRISystemdCgroupV1},
 		},
 		"deprecated systemd_cgroup for v2 runtime": {
 			config: &PluginConfig{

--- a/pkg/cri/config/config_test.go
+++ b/pkg/cri/config/config_test.go
@@ -67,6 +67,7 @@ func TestValidateConfig(t *testing.T) {
 					},
 				},
 			},
+			warnings: []deprecation.Warning{deprecation.CRIUntrustedWorkloadRuntime},
 		},
 		"both untrusted_workload_runtime and runtime[untrusted]": {
 			config: &PluginConfig{

--- a/pkg/cri/config/config_test.go
+++ b/pkg/cri/config/config_test.go
@@ -110,6 +110,7 @@ func TestValidateConfig(t *testing.T) {
 					},
 				},
 			},
+			warnings: []deprecation.Warning{deprecation.CRIDefaultRuntime},
 		},
 		"no default_runtime_name": {
 			config:      &PluginConfig{},

--- a/pkg/cri/config/config_test.go
+++ b/pkg/cri/config/config_test.go
@@ -267,6 +267,7 @@ func TestValidateConfig(t *testing.T) {
 					},
 				},
 			},
+			warnings: []deprecation.Warning{deprecation.CRIRuntimeRoot},
 		},
 		"deprecated runtime_root for v2 runtime": {
 			config: &PluginConfig{

--- a/pkg/cri/config/config_test.go
+++ b/pkg/cri/config/config_test.go
@@ -227,6 +227,7 @@ func TestValidateConfig(t *testing.T) {
 					},
 				},
 			},
+			warnings: []deprecation.Warning{deprecation.CRIRuntimeEngine},
 		},
 		"deprecated runtime_engine for v2 runtime": {
 			config: &PluginConfig{

--- a/pkg/deprecation/deprecation.go
+++ b/pkg/deprecation/deprecation.go
@@ -65,11 +65,11 @@ var messages = map[Warning]string{
 		"Use a v2 runtime and `options` instead.",
 	CRIRuntimeRoot: "The `runtime_root` property of [plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.*] is deprecated since containerd v1.3 and will be removed in containerd v2.0. " +
 		"Use a v2 runtime and `options.Root` instead.",
-	CRIRegistryMirrors: "The `mirrors` property of `[plugins.\"io.containerd.grpc.v1.cri\".registry]` is deprecated since containerd v1.5 and will be removed in containerd v2.0." +
+	CRIRegistryMirrors: "The `mirrors` property of `[plugins.\"io.containerd.grpc.v1.cri\".registry]` is deprecated since containerd v1.5 and will be removed in containerd v2.0. " +
 		"Use `config_path` instead.",
-	CRIRegistryAuths: "The `auths` property of `[plugins.\"io.containerd.grpc.v1.cri\".registry]` is deprecated since containerd v1.3 and will be removed in containerd v2.0." +
+	CRIRegistryAuths: "The `auths` property of `[plugins.\"io.containerd.grpc.v1.cri\".registry]` is deprecated since containerd v1.3 and will be removed in containerd v2.0. " +
 		"Use `ImagePullSecrets` instead.",
-	CRIRegistryConfigs: "The `configs` property of `[plugins.\"io.containerd.grpc.v1.cri\".registry]` is deprecated since containerd v1.5 and will be removed in containerd v2.0." +
+	CRIRegistryConfigs: "The `configs` property of `[plugins.\"io.containerd.grpc.v1.cri\".registry]` is deprecated since containerd v1.5 and will be removed in containerd v2.0. " +
 		"Use `config_path` instead.",
 	CRIAPIV1Alpha2:  "CRI API v1alpha2 is deprecated since containerd v1.7 and removed in containerd v2.0. Use CRI API v1 instead.",
 	AUFSSnapshotter: "The aufs snapshotter is deprecated since containerd v1.5 and removed in containerd v2.0. Use the overlay snapshotter instead.",

--- a/pkg/deprecation/deprecation.go
+++ b/pkg/deprecation/deprecation.go
@@ -27,6 +27,8 @@ const (
 	GoPluginLibrary Warning = Prefix + "go-plugin-library"
 	// CRISystemdCgroupV1 is a warning for the `systemd_cgroup` property
 	CRISystemdCgroupV1 Warning = Prefix + "cri-systemd-cgroup-v1"
+	// CRIUntrustedWorkloadRuntime is a warning for the `untrusted_workload_runtime` property
+	CRIUntrustedWorkloadRuntime Warning = Prefix + "cri-untrusted-workload-runtime"
 	// CRIRegistryMirrors is a warning for the use of the `mirrors` property
 	CRIRegistryMirrors Warning = Prefix + "cri-registry-mirrors"
 	// CRIRegistryAuths is a warning for the use of the `auths` property
@@ -49,6 +51,8 @@ var messages = map[Warning]string{
 	GoPluginLibrary: "Dynamically-linked Go plugins as containerd runtimes will be deprecated in containerd v2.0 and removed in containerd v2.1.",
 	CRISystemdCgroupV1: "The `systemd_cgroup` property (old form) of `[plugins.\"io.containerd.grpc.v1.cri\"] is deprecated since containerd v1.3 and will be removed in containerd v2.0. " +
 		"Use `SystemdCgroup` in [plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.runc.options] options instead.",
+	CRIUntrustedWorkloadRuntime: "The `untrusted_workload_runtime` property of [plugins.\"io.containerd.grpc.v1.cri\".containerd] is deprecated since containerd v1.2 and will be removed in containerd v2.0. " +
+		"Create an `untrusted` runtime in `runtimes` instead.",
 	CRIRegistryMirrors: "The `mirrors` property of `[plugins.\"io.containerd.grpc.v1.cri\".registry]` is deprecated since containerd v1.5 and will be removed in containerd v2.0." +
 		"Use `config_path` instead.",
 	CRIRegistryAuths: "The `auths` property of `[plugins.\"io.containerd.grpc.v1.cri\".registry]` is deprecated since containerd v1.3 and will be removed in containerd v2.0." +

--- a/pkg/deprecation/deprecation.go
+++ b/pkg/deprecation/deprecation.go
@@ -33,6 +33,8 @@ const (
 	CRIDefaultRuntime Warning = Prefix + "cri-default-runtime"
 	// CRIRuntimeEngine is a warning for the `runtime_engine` property
 	CRIRuntimeEngine Warning = Prefix + "cri-runtime-engine"
+	// CRIRuntimeRoot is a warning for the `runtime_root` property
+	CRIRuntimeRoot Warning = Prefix + "cri-runtime-root"
 	// CRIRegistryMirrors is a warning for the use of the `mirrors` property
 	CRIRegistryMirrors Warning = Prefix + "cri-registry-mirrors"
 	// CRIRegistryAuths is a warning for the use of the `auths` property
@@ -61,6 +63,8 @@ var messages = map[Warning]string{
 		"Use `default_runtime_name` instead.",
 	CRIRuntimeEngine: "The `runtime_engine` property of [plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.*] is deprecated since containerd v1.3 and will be removed in containerd v2.0. " +
 		"Use a v2 runtime and `options` instead.",
+	CRIRuntimeRoot: "The `runtime_root` property of [plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.*] is deprecated since containerd v1.3 and will be removed in containerd v2.0. " +
+		"Use a v2 runtime and `options.Root` instead.",
 	CRIRegistryMirrors: "The `mirrors` property of `[plugins.\"io.containerd.grpc.v1.cri\".registry]` is deprecated since containerd v1.5 and will be removed in containerd v2.0." +
 		"Use `config_path` instead.",
 	CRIRegistryAuths: "The `auths` property of `[plugins.\"io.containerd.grpc.v1.cri\".registry]` is deprecated since containerd v1.3 and will be removed in containerd v2.0." +

--- a/pkg/deprecation/deprecation.go
+++ b/pkg/deprecation/deprecation.go
@@ -31,6 +31,8 @@ const (
 	CRIUntrustedWorkloadRuntime Warning = Prefix + "cri-untrusted-workload-runtime"
 	// CRIDefaultRuntime is a warning for the `default_runtime` property
 	CRIDefaultRuntime Warning = Prefix + "cri-default-runtime"
+	// CRIRuntimeEngine is a warning for the `runtime_engine` property
+	CRIRuntimeEngine Warning = Prefix + "cri-runtime-engine"
 	// CRIRegistryMirrors is a warning for the use of the `mirrors` property
 	CRIRegistryMirrors Warning = Prefix + "cri-registry-mirrors"
 	// CRIRegistryAuths is a warning for the use of the `auths` property
@@ -57,6 +59,8 @@ var messages = map[Warning]string{
 		"Create an `untrusted` runtime in `runtimes` instead.",
 	CRIDefaultRuntime: "The `default_runtime` property of [plugins.\"io.containerd.grpc.v1.cri\".containerd] is deprecated since containerd v1.3 and will be removed in containerd v2.0. " +
 		"Use `default_runtime_name` instead.",
+	CRIRuntimeEngine: "The `runtime_engine` property of [plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.*] is deprecated since containerd v1.3 and will be removed in containerd v2.0. " +
+		"Use a v2 runtime and `options` instead.",
 	CRIRegistryMirrors: "The `mirrors` property of `[plugins.\"io.containerd.grpc.v1.cri\".registry]` is deprecated since containerd v1.5 and will be removed in containerd v2.0." +
 		"Use `config_path` instead.",
 	CRIRegistryAuths: "The `auths` property of `[plugins.\"io.containerd.grpc.v1.cri\".registry]` is deprecated since containerd v1.3 and will be removed in containerd v2.0." +

--- a/pkg/deprecation/deprecation.go
+++ b/pkg/deprecation/deprecation.go
@@ -25,6 +25,8 @@ const (
 	PullSchema1Image Warning = Prefix + "pull-schema-1-image"
 	// GoPluginLibrary is a warning for the use of dynamic library Go plugins
 	GoPluginLibrary Warning = Prefix + "go-plugin-library"
+	// CRISystemdCgroupV1 is a warning for the `systemd_cgroup` property
+	CRISystemdCgroupV1 Warning = Prefix + "cri-systemd-cgroup-v1"
 	// CRIRegistryMirrors is a warning for the use of the `mirrors` property
 	CRIRegistryMirrors Warning = Prefix + "cri-registry-mirrors"
 	// CRIRegistryAuths is a warning for the use of the `auths` property
@@ -45,6 +47,8 @@ var messages = map[Warning]string{
 	PullSchema1Image: "Schema 1 images are deprecated since containerd v1.7 and removed in containerd v2.0. " +
 		`Since containerd v1.7.8, schema 1 images are identified by the "io.containerd.image/converted-docker-schema1" label.`,
 	GoPluginLibrary: "Dynamically-linked Go plugins as containerd runtimes will be deprecated in containerd v2.0 and removed in containerd v2.1.",
+	CRISystemdCgroupV1: "The `systemd_cgroup` property (old form) of `[plugins.\"io.containerd.grpc.v1.cri\"] is deprecated since containerd v1.3 and will be removed in containerd v2.0. " +
+		"Use `SystemdCgroup` in [plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.runc.options] options instead.",
 	CRIRegistryMirrors: "The `mirrors` property of `[plugins.\"io.containerd.grpc.v1.cri\".registry]` is deprecated since containerd v1.5 and will be removed in containerd v2.0." +
 		"Use `config_path` instead.",
 	CRIRegistryAuths: "The `auths` property of `[plugins.\"io.containerd.grpc.v1.cri\".registry]` is deprecated since containerd v1.3 and will be removed in containerd v2.0." +

--- a/pkg/deprecation/deprecation.go
+++ b/pkg/deprecation/deprecation.go
@@ -29,6 +29,8 @@ const (
 	CRISystemdCgroupV1 Warning = Prefix + "cri-systemd-cgroup-v1"
 	// CRIUntrustedWorkloadRuntime is a warning for the `untrusted_workload_runtime` property
 	CRIUntrustedWorkloadRuntime Warning = Prefix + "cri-untrusted-workload-runtime"
+	// CRIDefaultRuntime is a warning for the `default_runtime` property
+	CRIDefaultRuntime Warning = Prefix + "cri-default-runtime"
 	// CRIRegistryMirrors is a warning for the use of the `mirrors` property
 	CRIRegistryMirrors Warning = Prefix + "cri-registry-mirrors"
 	// CRIRegistryAuths is a warning for the use of the `auths` property
@@ -53,6 +55,8 @@ var messages = map[Warning]string{
 		"Use `SystemdCgroup` in [plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.runc.options] options instead.",
 	CRIUntrustedWorkloadRuntime: "The `untrusted_workload_runtime` property of [plugins.\"io.containerd.grpc.v1.cri\".containerd] is deprecated since containerd v1.2 and will be removed in containerd v2.0. " +
 		"Create an `untrusted` runtime in `runtimes` instead.",
+	CRIDefaultRuntime: "The `default_runtime` property of [plugins.\"io.containerd.grpc.v1.cri\".containerd] is deprecated since containerd v1.3 and will be removed in containerd v2.0. " +
+		"Use `default_runtime_name` instead.",
 	CRIRegistryMirrors: "The `mirrors` property of `[plugins.\"io.containerd.grpc.v1.cri\".registry]` is deprecated since containerd v1.5 and will be removed in containerd v2.0." +
 		"Use `config_path` instead.",
 	CRIRegistryAuths: "The `auths` property of `[plugins.\"io.containerd.grpc.v1.cri\".registry]` is deprecated since containerd v1.3 and will be removed in containerd v2.0." +


### PR DESCRIPTION
Part of #9312 

This is the rest of the CRI configs that are deprecated other than `CriuPath`, which is separate (it's a runc option in the v2 runtimes).