### PR TITLE
add label flags to ctr import

### DIFF
--- a/client/import.go
+++ b/client/import.go
@@ -38,6 +38,7 @@ type importOpts struct {
 	compress        bool
 	discardLayers   bool
 	skipMissing     bool
+	imageLabels     map[string]string
 }
 
 // ImportOpt allows the caller to specify import specific options
@@ -48,6 +49,14 @@ type ImportOpt func(*importOpts) error
 func WithImageRefTranslator(f func(string) string) ImportOpt {
 	return func(c *importOpts) error {
 		c.imageRefT = f
+		return nil
+	}
+}
+
+// WithImageLabels are the image labels to apply to a new image
+func WithImageLabels(labels map[string]string) ImportOpt {
+	return func(c *importOpts) error {
+		c.imageLabels = labels
 		return nil
 	}
 }
@@ -223,7 +232,12 @@ func (c *Client) Import(ctx context.Context, reader io.Reader, opts ...ImportOpt
 	}
 
 	for i := range imgs {
-		img, err := is.Update(ctx, imgs[i], "target")
+		fieldsPath := []string{"target"}
+		if iopts.imageLabels != nil {
+			fieldsPath = append(fieldsPath, "labels")
+			imgs[i].Labels = iopts.imageLabels
+		}
+		img, err := is.Update(ctx, imgs[i], fieldsPath...)
 		if err != nil {
 			if !errdefs.IsNotFound(err) {
 				return nil, err

--- a/cmd/ctr/commands/images/import.go
+++ b/cmd/ctr/commands/images/import.go
@@ -98,7 +98,7 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 			Name:  "discard-unpacked-layers",
 			Usage: "Allow the garbage collector to clean layers up from the content store after unpacking, cannot be used with --no-unpack, false by default",
 		},
-	}, commands.SnapshotterFlags...),
+	}, append(commands.SnapshotterFlags, commands.LabelFlag)...),
 
 	Action: func(context *cli.Context) error {
 		var (
@@ -121,6 +121,11 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 				prefix = fmt.Sprintf("import-%s", time.Now().Format("2006-01-02"))
 				// Allow overwriting auto-generated prefix with named annotation
 				overwrite = true
+			}
+
+			labels := context.StringSlice("label")
+			if len(labels) > 0 {
+				opts = append(opts, image.WithImageLabels(commands.LabelArgs(labels)))
 			}
 
 			if context.Bool("digests") {
@@ -235,6 +240,11 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 				return fmt.Errorf("--discard-unpacked-layers and --no-unpack are incompatible options")
 			}
 			opts = append(opts, containerd.WithDiscardUnpackedLayers())
+		}
+
+		labels := context.StringSlice("label")
+		if len(labels) > 0 {
+			opts = append(opts, containerd.WithImageLabels(commands.LabelArgs(labels)))
 		}
 
 		ctx, done, err := client.WithLease(ctx)


### PR DESCRIPTION
This PR introduces an option for assigning `labels` at the `import` step.

The current implementation provides a way to label images at the pull(fetch) step, and labeling images at the import step reduces additional steps.

related

- https://github.com/kubernetes-sigs/kind/pull/3444 
- https://github.com/kubernetes-sigs/kind/issues/3441


Fixes #9505