### PR TITLE
release: add .dockerignore to fix repeated builds

### DIFF
--- a/.github/workflows/release/Dockerfile
+++ b/.github/workflows/release/Dockerfile
@@ -56,7 +56,7 @@ RUN \
 # check git working tree after build
 RUN \
 	export GIT_STATUS_OUTPUT=$(git status --porcelain) && \
-	test -z $GIT_STATUS_OUTPUT || (echo $GIT_STATUS_OUTPUT && exit 1)
+	test -z $GIT_STATUS_OUTPUT || (echo "repository contains uncommitted changes" && exit 1)
 
 FROM scratch AS release
 COPY --from=target /go/src/github.com/containerd/containerd/releases/ /

--- a/.github/workflows/release/Dockerfile.dockerignore
+++ b/.github/workflows/release/Dockerfile.dockerignore
@@ -1,0 +1,19 @@
+# Exclude files that may cause cache-busts. These are generally expected
+# to be in a global .gitignore, but still can cause the build-cache to
+# be invalidated.
+**/.DS_Store
+
+# exclusions below are copied from .gitignore at the root of the repository
+# when updating, consider updating .gitignore accordingly.
+
+/bin/
+/man/
+coverage.txt
+profile.out
+containerd.test
+_site/
+# Allow repeated builds without copying back previous builds
+releases/*.tar.gz
+releases/*.tar.gz.sha256sum
+_output/
+.vagrant/


### PR DESCRIPTION
Ignore previous release-artifacts so that repeated builds rebuild them. Before this patch, building the dockerfile multiple times would rebuild the binaries, but would not produce a new release-artifact (`.tar.gz`), because the make target would not trigger if the file was already present.

With this patch, existing release-artifacts are no longer copied into the Dockerfile, which prevents this, as well as saving some time copying files that won't be used.

I also added `.DS_Store` files to the ignore-file. These files are generated on macOS when navigating the filesystem, and would cause the build to fail if present, as well as invalidating the build-cache;

    docker buildx build --build-arg RELEASE_VER=main --build-arg UBUNTU_VERSION=22.04 --build-arg GO_VERSION=1.21.5 -f .github/workflows/release/Dockerfile -o releases/ .
    ...
     > [target 4/4] RUN     export GIT_STATUS_OUTPUT=$(git status --porcelain) &&   test -z $GIT_STATUS_OUTPUT || (echo $GIT_STATUS_OUTPUT && exit 1):
    0.118 ++ git status --porcelain
    1.405 + export 'GIT_STATUS_OUTPUT=?? .DS_Store
    1.405 ?? .github/.DS_Store
    ...
    1.407 + test -z gc .DS_Store gc .github/.DS_Store gc api/.DS_Store gc api/api/ gc api/runtime/.DS_Store gc api/services/.DS_Store gc api/types/.DS_Store gc archive/.DS_Store gc cmd/.DS_Store gc cmd/containerd-shim-runc-v2/.DS_Store gc cmd/containerd-shim-runc-v2/vendor/ gc cmd/containerd/.DS_Store gc cmd/ctr/.DS_Store gc content/.DS_Store gc contrib/.DS_Store gc contrib/ansible/.DS_Store gc contrib/seccomp/.DS_Store gc diff/.DS_Store gc docs/.DS_Store gc docs/historical/.DS_Store gc events/.DS_Store gc gc/.DS_Store gc images/.DS_Store gc images/converter/.DS_Store gc integration/.DS_Store gc integration/cri-api/.DS_Store gc integration/failpoint/.DS_Store gc integration/images/.DS_Store gc integration/remote/.DS_Store gc leases/.DS_Store gc metadata/.DS_Store gc metrics/.DS_Store gc metrics/cgroups/.DS_Store gc metrics/types/.DS_Store gc pkg/.DS_Store gc pkg/cri/.DS_Store gc pkg/oom/.DS_Store gc pkg/transfer/.DS_Store gc plugins/.DS_Store gc protobuf/.DS_Store gc releases/.DS_Store
    1.407 /bin/bash: line 1: test: too many arguments
    1.408 + echo gc .DS_Store gc .github/.DS_Store gc api/.DS_Store gc api/api/ gc api/runtime/.DS_Store gc api/services/.DS_Store gc api/types/.DS_Store gc archive/.DS_Store gc cmd/.DS_Store gc cmd/containerd-shim-runc-v2/.DS_Store gc cmd/containerd-shim-runc-v2/vendor/ gc cmd/containerd/.DS_Store gc cmd/ctr/.DS_Store gc content/.DS_Store gc contrib/.DS_Store gc contrib/ansible/.DS_Store gc contrib/seccomp/.DS_Store gc diff/.DS_Store gc docs/.DS_Store gc docs/historical/.DS_Store gc events/.DS_Store gc gc/.DS_Store gc images/.DS_Store gc images/converter/.DS_Store gc integration/.DS_Store gc integration/cri-api/.DS_Store gc integration/failpoint/.DS_Store gc integration/images/.DS_Store gc integration/remote/.DS_Store gc leases/.DS_Store gc metadata/.DS_Store gc metrics/.DS_Store gc metrics/cgroups/.DS_Store gc metrics/types/.DS_Store gc pkg/.DS_Store gc pkg/cri/.DS_Store gc pkg/oom/.DS_Store gc pkg/transfer/.DS_Store gc plugins/.DS_Store gc protobuf/.DS_Store gc releases/.DS_Store
    1.408 + exit 1
    1.408 gc .DS_Store gc .github/.DS_Store gc api/.DS_Store gc api/api/ gc api/runtime/.DS_Store gc api/services/.DS_Store gc api/types/.DS_Store gc archive/.DS_Store gc cmd/.DS_Store gc cmd/containerd-shim-runc-v2/.DS_Store gc cmd/containerd-shim-runc-v2/vendor/ gc cmd/containerd/.DS_Store gc cmd/ctr/.DS_Store gc content/.DS_Store gc contrib/.DS_Store gc contrib/ansible/.DS_Store gc contrib/seccomp/.DS_Store gc diff/.DS_Store gc docs/.DS_Store gc docs/historical/.DS_Store gc events/.DS_Store gc gc/.DS_Store gc images/.DS_Store gc images/converter/.DS_Store gc integration/.DS_Store gc integration/cri-api/.DS_Store gc integration/failpoint/.DS_Store gc integration/images/.DS_Store gc integration/remote/.DS_Store gc leases/.DS_Store gc metadata/.DS_Store gc metrics/.DS_Store gc metrics/cgroups/.DS_Store gc metrics/types/.DS_Store gc pkg/.DS_Store gc pkg/cri/.DS_Store gc pkg/oom/.DS_Store gc pkg/transfer/.DS_Store gc plugins/.DS_Store gc protobuf/.DS_Store gc releases/.DS_Store

Finally, I removed a redundant "echo", which causes (as seen above) the list of uncommitted files to be printed twice (or three times even). We already print the list of files, as well as print the `test -z` command that is executed, which includes the list of files (`$GIT_STATUS_OUTPUT`). With this patch applied;

    6.307 + test -z gc .DS_Store gc .github/.DS_Store gc api/.DS_Store gc api/api/ gc api/runtime/.DS_Store gc api/services/.DS_Store gc api/types/.DS_Store gc archive/.DS_Store gc cmd/.DS_Store gc cmd/containerd-shim-runc-v2/.DS_Store gc cmd/containerd-shim-runc-v2/vendor/ gc cmd/containerd/.DS_Store gc cmd/ctr/.DS_Store gc content/.DS_Store gc contrib/.DS_Store gc contrib/ansible/.DS_Store gc contrib/seccomp/.DS_Store gc diff/.DS_Store gc docs/.DS_Store gc docs/historical/.DS_Store gc events/.DS_Store gc gc/.DS_Store gc images/.DS_Store gc images/converter/.DS_Store gc integration/.DS_Store gc integration/cri-api/.DS_Store gc integration/failpoint/.DS_Store gc integration/images/.DS_Store gc integration/remote/.DS_Store gc leases/.DS_Store gc metadata/.DS_Store gc metrics/.DS_Store gc metrics/cgroups/.DS_Store gc metrics/types/.DS_Store gc pkg/.DS_Store gc pkg/cri/.DS_Store gc pkg/oom/.DS_Store gc pkg/transfer/.DS_Store gc plugins/.DS_Store gc protobuf/.DS_Store gc releases/.DS_Store
    6.307 /bin/bash: line 1: test: too many arguments
    6.308 + echo 'git repository contains uncommitted changes'
    6.308 + exit 1
    6.308 git repository contains uncommitted changes