### PR TITLE
runtime/v2: improve / cleanup some logs

### DIFF
--- a/core/runtime/v2/shim.go
+++ b/core/runtime/v2/shim.go
@@ -126,10 +126,11 @@ func cleanupAfterDeadShim(ctx context.Context, id string, rt *runtime.NSMap[Shim
 	ctx, cancel := timeout.WithContext(ctx, cleanupTimeout)
 	defer cancel()
 
-	log.G(ctx).WithField("id", id).Warn("cleaning up after shim disconnected")
 	response, err := binaryCall.Delete(ctx)
 	if err != nil {
 		log.G(ctx).WithError(err).WithField("id", id).Warn("failed to clean up after shim disconnected")
+	} else {
+		log.G(ctx).WithField("id", id).Info("cleaned up after shim disconnected")
 	}
 
 	if _, err := rt.Get(ctx, id); err != nil {


### PR DESCRIPTION
### runtime/v2/binary.Delete: improve cleanup logs to prevent ambiguity

When cleaning up shims with debug logging enabled, shims would print a debug log.
However, the `binary.Delete()` code considered any output to be a "warning", and
logging it as such (WARN level).

Due to the output being included in the log message itself (as a literal string),
the log entry ended up being ambiguous, as it was logged as _warning_, but the
shim uses structured logs, which contains the log-level as a field ("level=debug");

    WARN[2023-12-07T11:50:33.260848385Z] cleanup warnings time="2023-12-07T11:50:33Z" level=debug msg="starting signal loop" namespace=moby pid=325 runtime=io.containerd.runc.v2  namespace=moby

This patch updates the log-entry to include the shim's stderr as a structured
field ("stderr"), as well as including the command that produced the output.
This makes the output less ambiguous, but at the cost of being less readable.

With this patch applied:

    WARN[2023-12-07T11:51:58.999045840Z] shim cleanup warnings   cmd="/usr/local/bin/containerd-shim-runc-v2 -namespace moby -address /var/run/docker/containerd/containerd.sock -publish-binary /usr/local/bin/containerd -id bb96d2b1ee125aeb430e81505b08206>

Given that we can't tell if output is produced due to "expected" logging,
or due to "unexpected" flows, we could also consider changing this log
to be logged at either `info` or `debug` level.

While updating, I also updated all logs to include an "id" field, so that
logs can be more easily correlated.


### runtime/v2/shim: cleanupAfterDeadShim don't WARN when cleaning up shim

cleanupAfterDeadShim is called in various code-paths; in most of those cases,
it's part of the regular ("happy path") flow, but the cleanup steps was
unconditionally logged at the "Warn" debug level;

    DEBU[2023-12-07T08:52:33.188952469Z] Sending kill signal 3 to container bb96d2b1ee125aeb430e81505b08206301abd7d449727a2c584fc72906b6af10
    ...
    INFO[2023-12-07T08:52:33.253708177Z] shim disconnected                             id=bb96d2b1ee125aeb430e81505b08206301abd7d449727a2c584fc72906b6af10 namespace=moby
    INFO[2023-12-07T08:52:33.253744719Z] ignoring event                                container=bb96d2b1ee125aeb430e81505b08206301abd7d449727a2c584fc72906b6af10 module=libcontainerd namespace=moby topic=/tasks/delete type="*events.TaskDelete"
    WARN[2023-12-07T08:52:33.253769219Z] cleaning up after shim disconnected           id=bb96d2b1ee125aeb430e81505b08206301abd7d449727a2c584fc72906b6af10 namespace=moby
    INFO[2023-12-07T08:52:33.253784427Z] cleaning up dead shim                         namespace=moby

At a glance, the only "unhappy" path already logs an Error before proceeding
with cleaning up the shim ("unable to load shim: (ID)")
https://github.com/containerd/containerd/blob/148d21b1ae0718b75718a09ecb307bb874270f59/runtime/v2/shim_load.go#L152-L156

If an error occurred when cleaning up, this log would also be logged twice;
once "before" attempting to cleanup, and once after the error occurred.

This patch changes the log-level for this message to "Info", as it's part
of the regular flow, and not a warning, and makes the log conditional; it
is now logged after a successful cleanup, and omitted if a failure occurred.

### runtime/v2/shim: ShimManager.loadShims: use structured logs

This function produced various logs in a loop, all related to a single ID,
but not all logs contained an "id" field, and some logs included the ID
as part of the log message (not as a structured "id" field).

This patch creates a logger instance for each iteration, setting the id
field, so that each log contains the ID associated with the operation.