### PR TITLE
[release/1.6] Prepare release notes for v1.6.26

### DIFF
--- a/releases/v1.6.26.toml
+++ b/releases/v1.6.26.toml
@@ -1,0 +1,39 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.6.25"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The twenty-sixth patch release for containerd 1.6 contains various fixes and updates.
+
+### Notable Updates
+
+* **Fix windows default path overwrite issue** ([#9441](https://github.com/containerd/containerd/pull/9441))
+* **Update push to inherit distribution sources from parent** ([#9453](https://github.com/containerd/containerd/pull/9453))
+* **Mask `/sys/devices/virtual/powercap` path in runtime spec and deny in default apparmor profile** ([GHSA-7ww5-4wqc-m92c](https://github.com/containerd/containerd/security/advisories/GHSA-7ww5-4wqc-m92c))
+
+### Deprecation Warnings
+
+* **Emit deprecation warning for AUFS snapshotter usage** ([#9448](https://github.com/containerd/containerd/pull/9448))
+* **Emit deprecation warning for v1 runtime usage** ([#9468](https://github.com/containerd/containerd/pull/9468))
+* **Emit deprecation warning for CRI v1alpha1 usage** ([#9468](https://github.com/containerd/containerd/pull/9468))
+
+See the changelog for complete list of changes"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.25+unknown"
+	Version = "1.6.26+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated release notes

---

containerd 1.6.26

Welcome to the v1.6.26 release of containerd!

The twenty-sixth patch release for containerd 1.6 contains various fixes and updates.

### Notable Updates

* **Fix windows default path overwrite issue** ([#9441](https://github.com/containerd/containerd/pull/9441))
* **Update push to inherit distribution sources from parent** ([#9453](https://github.com/containerd/containerd/pull/9453))
* **Mask `/sys/devices/virtual/powercap` path in runtime spec and deny in default apparmor profile** ([GHSA-7ww5-4wqc-m92c](https://github.com/containerd/containerd/security/advisories/GHSA-7ww5-4wqc-m92c))

### Deprecation Warnings

* **Emit deprecation warning for AUFS snapshotter usage** ([#9448](https://github.com/containerd/containerd/pull/9448))
* **Emit deprecation warning for v1 runtime usage** ([#9468](https://github.com/containerd/containerd/pull/9468))
* **Emit deprecation warning for CRI v1alpha1 usage** ([#9468](https://github.com/containerd/containerd/pull/9468))

See the changelog for complete list of changes

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Samuel Karp
* Derek McGowan
* Kohei Tokunaga
* Phil Estes
* Bjorn Neergaard
* Sebastiaan van Stijn
* Brian Goff
* Charity Kathure
* Kazuyoshi Kato
* Milas Bowman
* Wei Fu
* ruiwen-zhao

### Changes
<details><summary>29 commits</summary>
<p>

  * [`ac5c5d3e0`](https://github.com/containerd/containerd/commit/ac5c5d3e03ab3c5b8103a1c0bd9931389f7a8fcf) Prepare release notes for v1.6.26
* Github Security Advisory [GHSA-7ww5-4wqc-m92c](https://github.com/containerd/containerd/security/advisories/GHSA-7ww5-4wqc-m92c)
  * [`02f07fe19`](https://github.com/containerd/containerd/commit/02f07fe1994a3ddda3626c1ede2e32bc82b8e426) contrib/apparmor: deny /sys/devices/virtual/powercap
  * [`c94577e78`](https://github.com/containerd/containerd/commit/c94577e78d2924ddeb90d1601e31b50ee3acac48) oci/spec: deny /sys/devices/virtual/powercap
* [release/1.6] update to go1.20.12, test go1.21.5 ([#9472](https://github.com/containerd/containerd/pull/9472))
  * [`7cbdfc92e`](https://github.com/containerd/containerd/commit/7cbdfc92ef38f789f1a2773fa6fac405d361a6cc) update to go1.20.12, test go1.21.5
  * [`024b1cce6`](https://github.com/containerd/containerd/commit/024b1cce6b27f10e00bb9bde33a5fe9563545f8d) update to go1.20.11, test go1.21.4
* [release/1.6] Add cri-api v1alpha2 usage warning to all api calls ([#9484](https://github.com/containerd/containerd/pull/9484))
  * [`64e56bfde`](https://github.com/containerd/containerd/commit/64e56bfde95828660971673d20952f275cc2c0ba) Add cri-api v1alpha2 usage warning to all api calls
* [release/1.6] tasks: emit warning for v1 runtime and runc v1 runtime ([#9468](https://github.com/containerd/containerd/pull/9468))
  * [`efefd3bf3`](https://github.com/containerd/containerd/commit/efefd3bf334b5df0e97bff0be61ba906a9b3b528) tasks: emit warning for runc v1 runtime
  * [`7825689b4`](https://github.com/containerd/containerd/commit/7825689b4c4d68cc1cc3c6dd072c2c2ec7b2d88e) tasks: emit warning for v1 runtime
* [release/1.6] snapshots: emit deprecation warning for aufs ([#9448](https://github.com/containerd/containerd/pull/9448))
  * [`7cfe7052f`](https://github.com/containerd/containerd/commit/7cfe7052f4a2ad97e4e8032469aef588d2f0858c) snapshots: emit deprecation warning for aufs
* [release/1.6] cherry-pick/backport: Update golangci lint ([#9455](https://github.com/containerd/containerd/pull/9455))
  * [`a1ae572a2`](https://github.com/containerd/containerd/commit/a1ae572a2778bf599e93929f5145f707b667f508) Fix linter error with updated linter
  * [`b638791d6`](https://github.com/containerd/containerd/commit/b638791d66b2e34f044f04736632995446b79314) ci: bump up golangci-lint to v1.55.0
  * [`2370a2842`](https://github.com/containerd/containerd/commit/2370a2842318833b16a8274835374d0811c2ed28) Fix linter issues for golangci-lint 1.54.2
  * [`8a65e2e31`](https://github.com/containerd/containerd/commit/8a65e2e31b6710f94be64c7fada727bd2569d16f) Bump up golangci-lint to v1.54.2
  * [`969f8feb2`](https://github.com/containerd/containerd/commit/969f8feb2e0932a9f9c69f1696e552fcdcd2b31b) Bump up golangci-lint to v1.52.2
* [release/1.6] push: inherit distribution sources from parent ([#9453](https://github.com/containerd/containerd/pull/9453))
  * [`66959fdf5`](https://github.com/containerd/containerd/commit/66959fdf50d16520a84fb14c9467c0d87b7f0274) push: inherit distribution sources from parent
  * [`b4dcffcfb`](https://github.com/containerd/containerd/commit/b4dcffcfbff2694796a04243728700b37dc78d8e) content: add InfoProvider interface
  * [`bef4145c1`](https://github.com/containerd/containerd/commit/bef4145c141ad2c37e7797b4dc53b8e429b368ae) Change PushContent to require only Provider
* [release/1.6] Bump google.golang.org/grpc to v1.58.3 ([#9408](https://github.com/containerd/containerd/pull/9408))
  * [`a5fc21060`](https://github.com/containerd/containerd/commit/a5fc21060b5254be9ca28e63c1c5a7364b551ca5) vendor: google.golang.org/grpc v1.58.3
  * [`4fa05b3d8`](https://github.com/containerd/containerd/commit/4fa05b3d83488e4bc81241db1a65ca00fedec45d) Upgrade github.com/klauspost/compress from v1.11.13 to v1.15.9
* [release/1.6] Windows default path overwrite fix ([#9441](https://github.com/containerd/containerd/pull/9441))
  * [`ede0ad5e1`](https://github.com/containerd/containerd/commit/ede0ad5e12826d574623a79b71bb1fbc49e75172) Fix windows default path overwrite issue
</p>
</details>

### Dependency Changes

* **cloud.google.com/go/compute/metadata**  v0.2.3 **_new_**
* **github.com/cespare/xxhash/v2**          v2.1.2 -> v2.2.0
* **github.com/golang/protobuf**            v1.5.2 -> v1.5.3
* **github.com/klauspost/compress**         v1.11.13 -> v1.15.9
* **go.opencensus.io**                      v0.23.0 -> v0.24.0
* **golang.org/x/oauth2**                   2bc19b11175f -> v0.10.0
* **golang.org/x/sync**                     v0.1.0 -> v0.3.0
* **google.golang.org/grpc**                v1.50.1 -> v1.58.3
* **google.golang.org/protobuf**            v1.28.1 -> v1.31.0

Previous release can be found at [v1.6.25](https://github.com/containerd/containerd/releases/tag/v1.6.25)





