### PR TITLE
[release/1.7] Prepare release notes for v1.7.11

### DIFF
--- a/releases/v1.7.11.toml
+++ b/releases/v1.7.11.toml
@@ -1,0 +1,45 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.7.10"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The eleventh patch release for containerd 1.7 contains various fixes and updates including
+one security issue.
+
+### Notable Updates
+
+* **Fix Windows default path overwrite issue** ([#9440](https://github.com/containerd/containerd/pull/9440))
+* **Update push to always inherit distribution sources from parent** ([#9452](https://github.com/containerd/containerd/pull/9452))
+* **Update shim to use net dial for gRPC shim sockets** ([#9458](https://github.com/containerd/containerd/pull/9458))
+* **Fix otel version incompatibility** ([#9483](https://github.com/containerd/containerd/pull/9483))
+* **Fix Windows snapshotter blocking snapshot GC on remove failure** ([#9482](https://github.com/containerd/containerd/pull/9482))
+* **Mask `/sys/devices/virtual/powercap` path in runtime spec and deny in default apparmor profile** ([GHSA-7ww5-4wqc-m92c](https://github.com/containerd/containerd/security/advisories/GHSA-7ww5-4wqc-m92c))
+
+### Deprecation Warnings
+
+* **Emit deprecation warning for AUFS snapshotter** ([#9436](https://github.com/containerd/containerd/pull/9436))
+* **Emit deprecation warning for v1 runtime** ([#9450](https://github.com/containerd/containerd/pull/9450))
+* **Emit deprecation warning for deprecated CRI configs** ([#9469](https://github.com/containerd/containerd/pull/9469))
+* **Emit deprecation warning for CRI v1alpha1 usage** ([#9479](https://github.com/containerd/containerd/pull/9479))
+* **Emit deprecation warning for CRIU config in CRI** ([#9481](https://github.com/containerd/containerd/pull/9481))
+
+See the changelog for complete list of changes"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.7.10+unknown"
+	Version = "1.7.11+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated release notes

---

containerd 1.7.11

Welcome to the v1.7.11 release of containerd!

The eleventh patch release for containerd 1.7 contains various fixes and updates including
one security issue.

### Notable Updates

* **Fix Windows default path overwrite issue** ([#9440](https://github.com/containerd/containerd/pull/9440))
* **Update push to always inherit distribution sources from parent** ([#9452](https://github.com/containerd/containerd/pull/9452))
* **Update shim to use net dial for gRPC shim sockets** ([#9458](https://github.com/containerd/containerd/pull/9458))
* **Fix otel version incompatibility** ([#9483](https://github.com/containerd/containerd/pull/9483))
* **Fix Windows snapshotter blocking snapshot GC on remove failure** ([#9482](https://github.com/containerd/containerd/pull/9482))
* **Mask `/sys/devices/virtual/powercap` path in runtime spec and deny in default apparmor profile** ([GHSA-7ww5-4wqc-m92c](https://github.com/containerd/containerd/security/advisories/GHSA-7ww5-4wqc-m92c))

### Deprecation Warnings

* **Emit deprecation warning for AUFS snapshotter** ([#9436](https://github.com/containerd/containerd/pull/9436))
* **Emit deprecation warning for v1 runtime** ([#9450](https://github.com/containerd/containerd/pull/9450))
* **Emit deprecation warning for deprecated CRI configs** ([#9469](https://github.com/containerd/containerd/pull/9469))
* **Emit deprecation warning for CRI v1alpha1 usage** ([#9479](https://github.com/containerd/containerd/pull/9479))
* **Emit deprecation warning for CRIU config in CRI** ([#9481](https://github.com/containerd/containerd/pull/9481))

See the changelog for complete list of changes

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Samuel Karp
* Derek McGowan
* Phil Estes
* Bjorn Neergaard
* Danny Canter
* ruiwen-zhao
* Akihiro Suda
* Amit Barve
* Charity Kathure
* Maksym Pavlenko
* Milas Bowman
* Paweł Gronowski
* Wei Fu

### Changes
<details><summary>35 commits</summary>
<p>

  * [`dfae68bc3`](https://github.com/containerd/containerd/commit/dfae68bc3e614a091d0a468c9026da370e3de0d9) Prepare release notes for v1.7.11
* Github Security Advisory [GHSA-7ww5-4wqc-m92c](https://github.com/containerd/containerd/security/advisories/GHSA-7ww5-4wqc-m92c)
  * [`cb804da21`](https://github.com/containerd/containerd/commit/cb804da2101074c769a2a327597c9595b38bb4f0) contrib/apparmor: deny /sys/devices/virtual/powercap
  * [`40162a576`](https://github.com/containerd/containerd/commit/40162a576232b7d95325f85334590ea295d2ed2e) oci/spec: deny /sys/devices/virtual/powercap
* [release/1.7] Don't block snapshot garbage collection on Remove failures ([#9482](https://github.com/containerd/containerd/pull/9482))
  * [`ed7c6895b`](https://github.com/containerd/containerd/commit/ed7c6895bd3b33ccc7cfbc8cbd43f6a31333328a) Don't block snapshot garbage collection on Remove failures
* [release/1.7] Add warning for CRIU config usage ([#9481](https://github.com/containerd/containerd/pull/9481))
  * [`1fdefdd22`](https://github.com/containerd/containerd/commit/1fdefdd2242fcf704a11f1d6b5149e056ce98ed3) Add warning for CRIU config usage
* [release/1.7] Fix otel version incompatibility ([#9483](https://github.com/containerd/containerd/pull/9483))
  * [`f8f659e66`](https://github.com/containerd/containerd/commit/f8f659e66c6ec56fef092dced085d129c0e67176) Add HTTP client update function to tracing library
  * [`807ddd658`](https://github.com/containerd/containerd/commit/807ddd658b4cd6c0325204e7a19a4561a10906d2) fix(tracing): use latest version of semconv
* [release/1.7] Add cri-api v1alpha2 usage warning to all api calls ([#9479](https://github.com/containerd/containerd/pull/9479))
  * [`dc45bc838`](https://github.com/containerd/containerd/commit/dc45bc8381fa2cd903e871c81ce7b4c08e82ca3b) Add cri-api v1alpha2 usage warning to all api calls
* [release/1.7] cri: add deprecation warnings for deprecated CRI configs ([#9469](https://github.com/containerd/containerd/pull/9469))
  * [`9d1bad62e`](https://github.com/containerd/containerd/commit/9d1bad62e16f31e0b06c75e1007a623879529a6d) deprecation: fix missing spaces in warnings
  * [`51a604c07`](https://github.com/containerd/containerd/commit/51a604c0733437f4b7a20aa5ec1e6d4b4f0ab96e) cri: add deprecation warning for runtime_root
  * [`8040e74bf`](https://github.com/containerd/containerd/commit/8040e74bf8e6c25c02bb461b82f482cff24ce611) cri: add deprecation warning for rutnime_engine
  * [`99adc40eb`](https://github.com/containerd/containerd/commit/99adc40eb28db7cb93c378ff8bceb8e77559ae09) cri: add deprecation warning for default_runtime
  * [`afef7ec64`](https://github.com/containerd/containerd/commit/afef7ec646910ce1db3e824bfe17848428f3b47b) cri: add warning for untrusted_workload_runtime
  * [`6220dc190`](https://github.com/containerd/containerd/commit/6220dc1909883119a960bc96c496ae2361b94749) cri: add warning for old form of systemd_cgroup
* [release/1.7] runtime/v2: net.Dial gRPC shim sockets before trying grpc ([#9458](https://github.com/containerd/containerd/pull/9458))
  * [`80f96cd18`](https://github.com/containerd/containerd/commit/80f96cd188949bd9fa16256a8ff0b858ef692f20) runtime/v2: net.Dial gRPC shim sockets before trying grpc
* [release/1.7] tasks: emit warning for v1 runtime and runc v1 runtime ([#9450](https://github.com/containerd/containerd/pull/9450))
  * [`f471bb2b8`](https://github.com/containerd/containerd/commit/f471bb2b8e5a902ad8901c7c0db85ecead8c1730) tasks: emit warning for runc v1 runtime
  * [`329e1d487`](https://github.com/containerd/containerd/commit/329e1d487e7cc5c2773a2472df56b6eb75ae9194) tasks: emit warning for v1 runtime
* [release/1.7] push: always inherit distribution sources from parent ([#9452](https://github.com/containerd/containerd/pull/9452))
  * [`4464fde12`](https://github.com/containerd/containerd/commit/4464fde12985d98a9edbf124c54afa1156415572) push: always inherit distribution sources from parent
* [release/1.7] Update tar tests to run on Darwin ([#9451](https://github.com/containerd/containerd/pull/9451))
  * [`7e069ee25`](https://github.com/containerd/containerd/commit/7e069ee25868e5c8a67610720f8280c3451a3103) Update tar tests to run on Darwin
* [release/1.7] ctr: Add sandbox flag to ctr run ([#9449](https://github.com/containerd/containerd/pull/9449))
  * [`5fc0e4e61`](https://github.com/containerd/containerd/commit/5fc0e4e6151dafa4d5ca8837f3d99b6a8e816866) ctr: Add sandbox flag to ctr run
* [release/1.7] Windows default path overwrite fix ([#9440](https://github.com/containerd/containerd/pull/9440))
  * [`31fe03764`](https://github.com/containerd/containerd/commit/31fe03764c436677a1db9be24c25f7c11780eceb) Fix windows default path overwrite issue
* [release/1.7] snapshots: emit deprecation warning for aufs ([#9436](https://github.com/containerd/containerd/pull/9436))
  * [`625b35e4b`](https://github.com/containerd/containerd/commit/625b35e4bb26ee021713f2692143bf37f9a98bdd) snapshots: emit deprecation warning for aufs
</p>
</details>

### Dependency Changes

* **github.com/felixge/httpsnoop**                                   v1.0.3 **_new_**
* **go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp**  v0.45.0 **_new_**

Previous release can be found at [v1.7.10](https://github.com/containerd/containerd/releases/tag/v1.7.10)
