### PR TITLE
Move GenerateRuntimeOptions() to pkg/cri/config

### DIFF
--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -24,10 +24,15 @@ import (
 	"time"
 
 	"github.com/containerd/log"
+	"github.com/pelletier/go-toml/v2"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
+	runhcsoptions "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
 	"github.com/containerd/containerd/v2/pkg/cri/annotations"
 	"github.com/containerd/containerd/v2/pkg/deprecation"
+	runtimeoptions "github.com/containerd/containerd/v2/pkg/runtimeoptions/v1"
+	"github.com/containerd/containerd/v2/plugins"
+	runcoptions "github.com/containerd/containerd/v2/runtime/v2/runc/options"
 )
 
 const (
@@ -531,4 +536,41 @@ func hostAccessingSandbox(config *runtime.PodSandboxConfig) bool {
 	}
 
 	return false
+}
+
+// GenerateRuntimeOptions generates runtime options from cri plugin config.
+func GenerateRuntimeOptions(r Runtime) (interface{}, error) {
+	if r.Options == nil {
+		return nil, nil
+	}
+
+	b, err := toml.Marshal(r.Options)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal TOML blob for runtime %q: %w", r.Type, err)
+	}
+
+	options := getRuntimeOptionsType(r.Type)
+	if err := toml.Unmarshal(b, options); err != nil {
+		return nil, err
+	}
+
+	// For generic configuration, if no config path specified (preserving old behavior), pass
+	// the whole TOML configuration section to the runtime.
+	if runtimeOpts, ok := options.(*runtimeoptions.Options); ok && runtimeOpts.ConfigPath == "" {
+		runtimeOpts.ConfigBody = b
+	}
+
+	return options, nil
+}
+
+// getRuntimeOptionsType gets empty runtime options by the runtime type name.
+func getRuntimeOptionsType(t string) interface{} {
+	switch t {
+	case plugins.RuntimeRuncV2:
+		return &runcoptions.Options{}
+	case plugins.RuntimeRunhcsV1:
+		return &runhcsoptions.Options{}
+	default:
+		return &runtimeoptions.Options{}
+	}
 }

--- a/pkg/cri/server/helpers_test.go
+++ b/pkg/cri/server/helpers_test.go
@@ -175,7 +175,7 @@ systemd_cgroup = true
 	} {
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
-			opts, err := generateRuntimeOptions(test.r)
+			opts, err := criconfig.GenerateRuntimeOptions(test.r)
 			assert.NoError(t, err)
 			assert.Equal(t, test.expectedOptions, opts)
 		})

--- a/pkg/cri/server/runtime_config_linux.go
+++ b/pkg/cri/server/runtime_config_linux.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"sort"
 
+	criconfig "github.com/containerd/containerd/v2/pkg/cri/config"
 	"github.com/containerd/containerd/v2/pkg/systemd"
 	runcoptions "github.com/containerd/containerd/v2/runtime/v2/runc/options"
 	"github.com/containerd/log"
@@ -48,7 +49,7 @@ func (c *criService) getCgroupDriver(ctx context.Context) runtime.CgroupDriver {
 	})
 
 	for _, handler := range handlerNames {
-		opts, err := generateRuntimeOptions(c.config.ContainerdConfig.Runtimes[handler])
+		opts, err := criconfig.GenerateRuntimeOptions(c.config.ContainerdConfig.Runtimes[handler])
 		if err != nil {
 			log.G(ctx).Debugf("failed to parse runtime handler options for %q", handler)
 			continue

--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -96,7 +96,7 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 
 	runtimeStart := time.Now()
 	// Retrieve runtime options
-	runtimeOpts, err := generateRuntimeOptions(ociRuntime)
+	runtimeOpts, err := criconfig.GenerateRuntimeOptions(ociRuntime)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate sandbox runtime options: %w", err)
 	}

--- a/plugins/types.go
+++ b/plugins/types.go
@@ -75,6 +75,9 @@ const (
 	// RuntimeRuncV2 is the runc runtime that supports multiple containers per shim
 	RuntimeRuncV2 = "io.containerd.runc.v2"
 
+	// RuntimeRunhcsV1 is the runtime type for runhcs.
+	RuntimeRunhcsV1 = "io.containerd.runhcs.v1"
+
 	DeprecationsPlugin = "deprecations"
 )
 


### PR DESCRIPTION
This PR moves GenerateRuntimeOptions() to the cri config package as this function is directly accessing information from the structures defined in pkg/cri/config/config.go anyway.

Also, this change will be useful to have for the image pull per runtime class feature where we would need to initialize list of platform matchers for each runtime.  