### PR TITLE
[release/1.7] *: enable ARM64 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12, windows-2019]
+        os: [ubuntu-20.04, actuated-arm64-4cpu-16gb, macos-12, windows-2019]
 
     steps:
       - uses: actions/setup-go@v3
@@ -206,7 +206,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12, windows-2019, windows-2022]
+        os: [ubuntu-20.04, actuated-arm64-4cpu-16gb, macos-12, windows-2019, windows-2022]
         go-version: ["1.20.12", "1.21.5"]
     steps:
       - uses: actions/setup-go@v3
@@ -383,7 +383,7 @@ jobs:
 
   integration-linux:
     name: Linux Integration
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 40
     needs: [project, linters, protos, man]
 
@@ -396,11 +396,16 @@ jobs:
           - io.containerd.runc.v2
         runc: [runc, crun]
         enable_cri_sandboxes: ["", "sandboxed"]
+        os: [ubuntu-20.04, actuated-arm64-4cpu-16gb]
         exclude:
           - runtime: io.containerd.runc.v1
             runc: crun
           - runtime: io.containerd.runtime.v1.linux
             runc: crun
+          - runtime: io.containerd.runc.v1
+            os: actuated-arm64-4cpu-16gb
+          - runtime: io.containerd.runtime.v1.linux
+            os: actuated-arm64-4cpu-16gb
 
     env:
       GOTEST: gotestsum --
@@ -416,7 +421,7 @@ jobs:
           RUNC_FLAVOR: ${{ matrix.runc }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y gperf
+          sudo apt-get install -y gperf dmsetup strace xfsprogs
           script/setup/install-seccomp
           script/setup/install-runc
           script/setup/install-cni $(grep containernetworking/plugins go.mod | awk '{print $2}')
@@ -424,6 +429,10 @@ jobs:
           script/setup/install-failpoint-binaries
 
       - name: Install criu
+        # NOTE: Required actuated enable CONFIG_CHECKPOINT_RESTORE
+        #
+        # REF: https://criu.org/Linux_kernel
+        if: matrix.os != 'actuated-arm64-4cpu-16gb'
         run: |
           sudo add-apt-repository -y ppa:criu/ppa
           sudo apt-get update
@@ -510,6 +519,13 @@ jobs:
           mount
           df
           losetup -l
+
+      - name: Kernel Message
+        if: failure()
+        run: |
+          sudo lsmod
+          sudo dmesg -T -f kern
+
       - uses: actions/upload-artifact@v3
         if: always()
         with:

--- a/script/setup/install-critools
+++ b/script/setup/install-critools
@@ -25,7 +25,9 @@ script_dir="$(cd -- "$(dirname -- "$0")" > /dev/null 2>&1; pwd -P)"
 # e2e will fail with "sudo: command not found"
 SUDO=''
 if (( $EUID != 0 )); then
-    SUDO='sudo'
+    # The actuated ARM64 env needs PATH=$PATH to get `go` path. Otherwise
+    # `make install` recipe will fail.
+    SUDO="sudo -E PATH=$PATH"
 fi
 
 cd "$(go env GOPATH)"


### PR DESCRIPTION
There are many Kubernetes clusters running on ARM64. Enable ARM64 runner is to commit to support ARM64 platform officially.


(cherry picked from commit cb5a48e6453da65c4b8e5694ec5ed88f72b19737)

not a clean cherry-pick of #9456 