### PR TITLE
dependabot: enable groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,19 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      golang-x:
+        patterns:
+          - "golang.org/x/*"
+      k8s:
+        patterns:
+          - "k8s.io/*"
+      moby-sys:
+        patterns:
+          - "github.com/moby/sys/*"
+      otel:
+        patterns:
+          - "go.opentelemetry.io/*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
See https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/