### PR TITLE
[release/1.7] shim: Create pid-file and address with 0644 permissions

### DIFF
--- a/runtime/v2/shim/util.go
+++ b/runtime/v2/shim/util.go
@@ -126,7 +126,7 @@ func WritePidFile(path string, pid int) error {
 	if err != nil {
 		return err
 	}
-	f, err := atomicfile.New(path, 0o666)
+	f, err := atomicfile.New(path, 0o644)
 	if err != nil {
 		return err
 	}

--- a/runtime/v2/shim/util.go
+++ b/runtime/v2/shim/util.go
@@ -144,7 +144,7 @@ func WriteAddress(path, address string) error {
 	if err != nil {
 		return err
 	}
-	f, err := atomicfile.New(path, 0o666)
+	f, err := atomicfile.New(path, 0o644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes ae7021300

In ae7021300 the WritePidFile and WriteAddress functions were changed to use AtomicFile instead of os.CreateFile. However, AtomicFile creates a temporary file and then changes its permissions with os.Chmod which alters the previously observed behavior of os.CreateFile which takes the system's umask into account.

This means that on Linux-based systems these files suddenly became world writable (#9363). This commit explicitly requests 0644 permissions as even on systems without default umask of 0022 there is no reason to have these two files world writable.

This should be affecting only 1.6 (introduced in 1.6.22) and 1.7 as 2.0+ uses boostrap.json to store the address file (not sure about the pid file, but WritePidFile also uses 0666 in release/2.0 and master) and 1.5 does not have ae7021300. We're using 1.7.7 and the bug was reported to me against the address file, so I opened a PR for release/1.7. If you'd like a PR for release/1.6 (or even release/2.0 and main) let me know.

Note: I do not know how this (0666 -> 0644) will affect other systems such as Windows or macOS, but given that prior to ae7021300 both of these files effectively had the 0644 permissions on Linux-based systems without any issues, I thought that explicitly requesting them wouldn't cause problems.