### PR TITLE
import/export: Support references to missing content 

### DIFF
--- a/content/helpers.go
+++ b/content/helpers.go
@@ -320,3 +320,14 @@ func copyWithBuffer(dst io.Writer, src io.Reader) (written int64, err error) {
 	}
 	return
 }
+
+// Exists returns whether an attempt to access the content would not error out
+// with an ErrNotFound error. It will return an encountered error if it was
+// different than ErrNotFound.
+func Exists(ctx context.Context, provider InfoProvider, desc ocispec.Descriptor) (bool, error) {
+	_, err := provider.Info(ctx, desc.Digest)
+	if errdefs.IsNotFound(err) {
+		return false, nil
+	}
+	return err == nil, err
+}


### PR DESCRIPTION
Allow importing/exporting archives which doesn't have all the referenced blobs. 
This allows to export/import an image with only some of the platforms available locally while still persisting the full index.

> The blobs directory MAY be missing referenced blobs, in which case the missing blobs SHOULD be fulfilled by an external blob store.

https://github.com/opencontainers/image-spec/blob/v1.0/image-layout.md#blobs
