### PR TITLE
[release/1.6] *: enable ARM64 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,11 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12, windows-2019]
+        os: [ubuntu-20.04, actuated-arm64-4cpu-16gb, macos-12, windows-2019]
 
     steps:
       - name: Install dependencies
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'actuated-arm64-4cpu-16gb'
         run: |
           sudo apt-get update
           sudo apt-get install -y libbtrfs-dev
@@ -232,11 +232,11 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12, windows-2019, windows-2022]
+        os: [ubuntu-20.04, actuated-arm64-4cpu-16gb, macos-12, windows-2019, windows-2022]
         go-version: ["1.20.12", "1.21.5"]
     steps:
       - name: Install dependencies
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'actuated-arm64-4cpu-16gb'
         run: |
           sudo apt-get update
           sudo apt-get install -y libbtrfs-dev
@@ -347,7 +347,7 @@ jobs:
 
   integration-linux:
     name: Linux Integration
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 40
     needs: [linters, protos, man]
 
@@ -356,11 +356,16 @@ jobs:
       matrix:
         runtime: [io.containerd.runtime.v1.linux, io.containerd.runc.v1, io.containerd.runc.v2]
         runc: [runc, crun]
+        os: [ubuntu-20.04, actuated-arm64-4cpu-16gb]
         exclude:
           - runtime: io.containerd.runc.v1
             runc: crun
           - runtime: io.containerd.runtime.v1.linux
             runc: crun
+          - runtime: io.containerd.runc.v1
+            os: actuated-arm64-4cpu-16gb
+          - runtime: io.containerd.runtime.v1.linux
+            os: actuated-arm64-4cpu-16gb
 
     env:
       GOTEST: gotestsum --
@@ -375,7 +380,7 @@ jobs:
         env:
           RUNC_FLAVOR: ${{ matrix.runc }}
         run: |
-          sudo apt-get install -y gperf libbtrfs-dev
+          sudo apt-get install -y gperf libbtrfs-dev dmsetup strace xfsprogs
           script/setup/install-seccomp
           script/setup/install-runc
           script/setup/install-cni $(grep containernetworking/plugins go.mod | awk '{print $2}')
@@ -383,6 +388,10 @@ jobs:
           script/setup/install-failpoint-binaries
 
       - name: Install criu
+        # NOTE: Required actuated enable CONFIG_CHECKPOINT_RESTORE
+        #
+        # REF: https://criu.org/Linux_kernel
+        if: matrix.os != 'actuated-arm64-4cpu-16gb'
         run: |
           sudo add-apt-repository ppa:criu/ppa
           sudo apt-get update
@@ -467,6 +476,13 @@ jobs:
           mount
           df
           losetup -l
+
+      - name: Kernel Message
+        if: failure()
+        run: |
+          sudo lsmod
+          sudo dmesg -T -f kern
+
       - uses: actions/upload-artifact@v3
         if: always()
         with:

--- a/script/setup/install-cni
+++ b/script/setup/install-cni
@@ -37,8 +37,8 @@ git clone "${CNI_REPO}" "${TMPROOT}"/plugins
 pushd "${TMPROOT}"/plugins
 git checkout "$CNI_COMMIT"
 ./build_linux.sh
-mkdir -p $CNI_DIR
-cp -r ./bin $CNI_DIR
+$SUDO mkdir -p $CNI_DIR
+$SUDO cp -r ./bin $CNI_DIR
 $SUDO mkdir -p $CNI_CONFIG_DIR
 $SUDO cat << EOF | $SUDO tee $CNI_CONFIG_DIR/10-containerd-net.conflist
 {

--- a/script/setup/install-critools
+++ b/script/setup/install-critools
@@ -25,7 +25,9 @@ script_dir="$(cd -- "$(dirname -- "$0")" > /dev/null 2>&1; pwd -P)"
 # e2e will fail with "sudo: command not found"
 SUDO=''
 if (( $EUID != 0 )); then
-    SUDO='sudo'
+    # The actuated ARM64 env needs PATH=$PATH to get `go` path. Otherwise
+    # `make install` recipe will fail.
+    SUDO="sudo -E PATH=$PATH"
 fi
 
 cd "$(go env GOPATH)"


### PR DESCRIPTION
There are many Kubernetes clusters running on ARM64. Enable ARM64 runner is to commit to support ARM64 platform officially.

runc.v1 and runtime.v1 runtime tests are skipped on arm64 runners because they doesnot support cgroupv2; arm64 nodes has only ubuntu22.04 at the moment, and ubuntu22.04 has cgroupv2 enabled and cgroupv1 disabled by default.


(cherry picked from commit cb5a48e6453da65c4b8e5694ec5ed88f72b19737)

Not a clean cherry-pick of #9456 