### PR TITLE
cmd/containerd-shim-runc-v2: Prevent nil pointer dereference

### DIFF
--- a/cmd/containerd-shim-runc-v2/runc/container.go
+++ b/cmd/containerd-shim-runc-v2/runc/container.go
@@ -153,7 +153,7 @@ func NewContainer(ctx context.Context, platform stdio.Platform, r *task.CreateTa
 			}
 			cg, err = cgroupsv2.Load(g)
 			if err != nil {
-				log.G(ctx).WithError(err).Errorf("loading cgroup2 for %d", pid)
+				log.G(ctx).WithError(err).Errorf("loading cgroup2 %q for %d", g, pid)
 			}
 		} else {
 			cg, err = cgroup1.Load(cgroup1.PidPath(pid))
@@ -373,7 +373,7 @@ func (c *Container) Start(ctx context.Context, r *task.StartRequest) (process.Pr
 			}
 			cg, err = cgroupsv2.Load(g)
 			if err != nil {
-				log.G(ctx).WithError(err).Errorf("loading cgroup2 for %d", p.Pid())
+				log.G(ctx).WithError(err).Errorf("loading cgroup2 %q for %d", g, p.Pid())
 			}
 		} else {
 			cg, err = cgroup1.Load(cgroup1.PidPath(p.Pid()))


### PR DESCRIPTION
In case the cgroup detection for a pid fails, the cgroup variable's underlying value will be nil. Using this in a type switch will still trigger the branch for the appropriate type, even if the value is nil.

Add a nil check in all the case arms to avoid a panic like the following:

```text
time="2023-12-19T08:59:12.870893583Z" level=error msg="loading cgroup2 for 334" error="cgroups: invalid group path" runtime=io.containerd.runc.v2
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2ce8b0]

goroutine 65 [running]:
github.com/containerd/cgroups/v3/cgroup2.(*Manager).RootControllers(0x40000750e0?)
        /go/src/containerd/vendor/github.com/containerd/cgroups/v3/cgroup2/manager.go:270 +0x20
github.com/containerd/containerd/v2/cmd/containerd-shim-runc-v2/task.(*service).Start(0x400028e080, {0x727da0, 0x4000380090}, 0x400007e140)
        /go/src/containerd/cmd/containerd-shim-runc-v2/task/service.go:286 +0x1ac
github.com/containerd/containerd/v2/api/runtime/task/v3.RegisterTTRPCTaskService.func3({0x727da0, 0x4000380090}, 0x400003e0a0)
        /go/src/containerd/api/runtime/task/v3/shim_ttrpc.pb.go:53 +0xa0
github.com/containerd/ttrpc.defaultServerInterceptor({0x727da0?, 0x4000380090?}, 0x10?, 0x5977e0?, 0x40002900e0?)
        /go/src/containerd/vendor/github.com/containerd/ttrpc/interceptor.go:52 +0x2c
github.com/containerd/ttrpc.(*serviceSet).unaryCall(0x40000960d8, {0x727da0, 0x4000380090}, 0x40002900c0?, 0x0?, {0x400032a0a0, 0x42, 0x50})
        /go/src/containerd/vendor/github.com/containerd/ttrpc/services.go:75 +0xac
github.com/containerd/ttrpc.(*serviceSet).handle.func1()
        /go/src/containerd/vendor/github.com/containerd/ttrpc/services.go:118 +0x124
created by github.com/containerd/ttrpc.(*serviceSet).handle in goroutine 35
        /go/src/containerd/vendor/github.com/containerd/ttrpc/services.go:111 +0x114
```