### PR TITLE
Add `--quiet` option in `ctr` commands

### DIFF
--- a/cmd/ctr/commands/content/fetch.go
+++ b/cmd/ctr/commands/content/fetch.go
@@ -131,7 +131,7 @@ func NewFetchConfig(ctx context.Context, clicontext *cli.Context) (*FetchConfig,
 		Labels:    clicontext.StringSlice("label"),
 		TraceHTTP: clicontext.Bool("http-trace"),
 	}
-	if !clicontext.GlobalBool("debug") {
+	if !clicontext.GlobalBool("debug") && !clicontext.Bool("quiet") {
 		config.ProgressOutput = os.Stdout
 	}
 	if !clicontext.Bool("all-platforms") {

--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -83,6 +83,10 @@ command. As part of this process, we do the following:
 			Name:  "local",
 			Usage: "Fetch content from local client rather than using transfer service",
 		},
+		cli.BoolFlag{
+			Name:  "quiet,q",
+			Usage: "Suppress verbose output",
+		},
 	),
 	Action: func(context *cli.Context) error {
 		var (
@@ -97,6 +101,8 @@ command. As part of this process, we do the following:
 			return err
 		}
 		defer cancel()
+
+		quiet := context.Bool("quiet")
 
 		if !context.BoolT("local") {
 			ch, err := commands.NewStaticCredentials(ctx, context, ref)
@@ -180,7 +186,9 @@ command. As part of this process, we do the following:
 
 		start := time.Now()
 		for _, platform := range p {
-			fmt.Printf("unpacking %s %s...\n", platforms.Format(platform), img.Target.Digest)
+			if !quiet {
+				fmt.Printf("unpacking %s %s...\n", platforms.Format(platform), img.Target.Digest)
+			}
 			i := containerd.NewImageWithPlatform(client, img, platforms.Only(platform))
 			err = i.Unpack(ctx, context.String("snapshotter"))
 			if err != nil {
@@ -192,10 +200,14 @@ command. As part of this process, we do the following:
 					return err
 				}
 				chainID := identity.ChainID(diffIDs).String()
-				fmt.Printf("image chain ID: %s\n", chainID)
+				if !quiet {
+					fmt.Printf("image chain ID: %s\n", chainID)
+				}
 			}
 		}
-		fmt.Printf("done: %s\t\n", time.Since(start))
+		if !quiet {
+			fmt.Printf("done: %s\t\n", time.Since(start))
+		}
 		return nil
 	},
 }


### PR DESCRIPTION
When using the ctr pull image in some environments, such as Ansible, the process output is too much and not very useful, like:

```
TASK [download : Download_container | Download image if required] **************
task path: /builds/kargo-ci/kubernetes-sigs-kubespray/roles/download/tasks/download_container.yml:57
changed: [instance-2] => {"attempts": 1, "changed": true, "cmd": ["/usr/local/bin/ctr", "-n", "k8s.io", "images", "pull", "quay.io/kubespray/k8s-netchecker-server:v1.2.2"], "delta": "0:00:03.299060", "end": "2023-12-04 11:36:56.997388", "msg": "", "rc": 0, "start": "2023-12-04 11:36:53.698328", "stderr": "", "stderr_lines": [], "stdout": "quay.io/kubespray/k8s-netchecker-server:v1.2.2: resolving      |\u001b[32m\u001b[0m--------------------------------------| \nelapsed: 0.1 s                                  total:   0.0 B (0.0 B/s)                                         \nquay.io/kubespray/k8s-netchecker-server:v1.2.2: resolving      |\u001b[32m\u001b[0m--------------------------------------| \nelapsed: 0.2 s                                  total:   0.0 B (0.0 B/s)                                         \nquay.io/kubespray/k8s-netchecker-server:v1.2.2: resolving      |\u001b[32m\u001b[0m--------------------------------------| \nelapsed: 0.3 s                                  total:   0.0 B (0.0 B/s)                                         \nquay.io/kubespray/k8s-netchecker-server:v1.2.2: resolving      |\u001b[32m\u001b[0m--------------------------------------| \nelapsed: 0.4 s                                  total:   0.0 B (0.0 B/s)                                         \nquay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nmanifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/951.0 B \nelapsed: 0.5 s                                                                    total:   0.0 B (0.0 B/s)                                         \nquay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nmanifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/951.0 B \nelapsed: 0.6 s                                                                    total:   0.0 B (0.0 B/s)                                         \nquay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nmanifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/951.0 B \nelapsed: 0.7 s                                                                    total:   0.0 B (0.0 B/s)                                         \nquay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nmanifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/951.0 B \nelapsed: 0.8 s                                                                    total:   0.0 B (0.0 B/s)                                         \nquay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nmanifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: downloading    |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m|  951.0 B/951.0 B \nelapsed: 0.9 s                                                                    total:  951.0  (1.0 KiB/s)                                       \nquay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nmanifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nconfig-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/3.4 KiB  \nlayer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/8.4 MiB  \nlayer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/2.3 MiB  \nlayer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/19.6 MiB \nelapsed: 1.0 s                                                                    total:  951.0  (949.0 B/s)                                       \nquay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nmanifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nconfig-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/3.4 KiB  \nlayer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/8.4 MiB  \nlayer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/2.3 MiB  \nlayer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/19.6 MiB \nelapsed: 1.1 s                                                                    total:  951.0  (863.0 B/s)                                       \nquay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nmanifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nconfig-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/3.4 KiB \nlayer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/8.4 MiB \nlayer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/19.6 MiB \nelapsed: 1.2 s                                                                    total:  2.3 Mi (1.9 MiB/s)                                       \nquay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nmanifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nconfig-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/3.4 KiB \nlayer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/8.4 MiB \nlayer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    downloading    |\u001b[32m++++++++++++++++++++++++++++++++++\u001b[0m----| 18.0 MiB/19.6 MiB \nelapsed: 1.3 s                                                                    total:  20.3 M (15.6 MiB/s)                                      \nquay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nmanifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nconfig-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   downloading    |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m|  3.4 KiB/3.4 KiB \nlayer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    downloading    |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m|  8.4 MiB/8.4 MiB \nlayer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    downloading    |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| 19.6 MiB/19.6 MiB \nelapsed: 1.4 s                                                                    total:  30.3 M (21.6 MiB/s)                                      \nquay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nmanifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nconfig-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   downloading    |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m|  3.4 KiB/3.4 KiB \nlayer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    downloading    |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m|  8.4 MiB/8.4 MiB \nlayer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    waiting        |\u001b[32m\u001b[0m--------------------------------------| \nelapsed: 1.5 s                                                                    total:  10.7 M (7.1 MiB/s)                                       \nquay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nmanifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nconfig-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   downloading    |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m|  3.4 KiB/3.4 KiB \nlayer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    downloading    |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m|  8.4 MiB/8.4 MiB \nlayer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    waiting        |\u001b[32m\u001b[0m--------------------------------------| \nelapsed: 1.6 s                                                                    total:  10.7 M (6.7 MiB/s)                                       \nquay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nmanifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nconfig-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nelapsed: 1.7 s                                                                    total:  10.7 M (6.3 MiB/s)                                       \nunpacking linux/amd64 sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b...\ndone: 1.578566004s\t", "stdout_lines": ["quay.io/kubespray/k8s-netchecker-server:v1.2.2: resolving      |\u001b[32m\u001b[0m--------------------------------------| ", "elapsed: 0.1 s                                  total:   0.0 B (0.0 B/s)                                         ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2: resolving      |\u001b[32m\u001b[0m--------------------------------------| ", "elapsed: 0.2 s                                  total:   0.0 B (0.0 B/s)                                         ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2: resolving      |\u001b[32m\u001b[0m--------------------------------------| ", "elapsed: 0.3 s                                  total:   0.0 B (0.0 B/s)                                         ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2: resolving      |\u001b[32m\u001b[0m--------------------------------------| ", "elapsed: 0.4 s                                  total:   0.0 B (0.0 B/s)                                         ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "manifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/951.0 B ", "elapsed: 0.5 s                                                                    total:   0.0 B (0.0 B/s)                                         ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "manifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/951.0 B ", "elapsed: 0.6 s                                                                    total:   0.0 B (0.0 B/s)                                         ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "manifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/951.0 B ", "elapsed: 0.7 s                                                                    total:   0.0 B (0.0 B/s)                                         ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "manifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/951.0 B ", "elapsed: 0.8 s                                                                    total:   0.0 B (0.0 B/s)                                         ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "manifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: downloading    |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m|  951.0 B/951.0 B ", "elapsed: 0.9 s                                                                    total:  951.0  (1.0 KiB/s)                                       ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "manifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "config-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/3.4 KiB  ", "layer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/8.4 MiB  ", "layer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/2.3 MiB  ", "layer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/19.6 MiB ", "elapsed: 1.0 s                                                                    total:  951.0  (949.0 B/s)                                       ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "manifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "config-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/3.4 KiB  ", "layer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/8.4 MiB  ", "layer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/2.3 MiB  ", "layer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/19.6 MiB ", "elapsed: 1.1 s                                                                    total:  951.0  (863.0 B/s)                                       ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "manifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "config-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/3.4 KiB ", "layer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/8.4 MiB ", "layer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/19.6 MiB ", "elapsed: 1.2 s                                                                    total:  2.3 Mi (1.9 MiB/s)                                       ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "manifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "config-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/3.4 KiB ", "layer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/8.4 MiB ", "layer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    downloading    |\u001b[32m++++++++++++++++++++++++++++++++++\u001b[0m----| 18.0 MiB/19.6 MiB ", "elapsed: 1.3 s                                                                    total:  20.3 M (15.6 MiB/s)                                      ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "manifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "config-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   downloading    |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m|  3.4 KiB/3.4 KiB ", "layer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    downloading    |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m|  8.4 MiB/8.4 MiB ", "layer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    downloading    |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| 19.6 MiB/19.6 MiB ", "elapsed: 1.4 s                                                                    total:  30.3 M (21.6 MiB/s)                                      ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "manifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "config-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   downloading    |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m|  3.4 KiB/3.4 KiB ", "layer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    downloading    |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m|  8.4 MiB/8.4 MiB ", "layer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    waiting        |\u001b[32m\u001b[0m--------------------------------------| ", "elapsed: 1.5 s                                                                    total:  10.7 M (7.1 MiB/s)                                       ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "manifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "config-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   downloading    |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m|  3.4 KiB/3.4 KiB ", "layer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    downloading    |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m|  8.4 MiB/8.4 MiB ", "layer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    waiting        |\u001b[32m\u001b[0m--------------------------------------| ", "elapsed: 1.6 s                                                                    total:  10.7 M (6.7 MiB/s)                                       ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "manifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "config-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "elapsed: 1.7 s                                                                    total:  10.7 M (6.3 MiB/s)                                       ", "unpacking linux/amd64 sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b...", "done: 1.578566004s\t"]}
changed: [instance-1] => {"attempts": 1, "changed": true, "cmd": ["/usr/local/bin/ctr", "-n", "k8s.io", "images", "pull", "quay.io/kubespray/k8s-netchecker-server:v1.2.2"], "delta": "0:00:03.278852", "end": "2023-12-04 11:36:57.004438", "msg": "", "rc": 0, "start": "2023-12-04 11:36:53.725586", "stderr": "", "stderr_lines": [], "stdout": "quay.io/kubespray/k8s-netchecker-server:v1.2.2: resolving      |\u001b[32m\u001b[0m--------------------------------------| \nelapsed: 0.1 s                                  total:   0.0 B (0.0 B/s)                                         \nquay.io/kubespray/k8s-netchecker-server:v1.2.2: resolving      |\u001b[32m\u001b[0m--------------------------------------| \nelapsed: 0.2 s                                  total:   0.0 B (0.0 B/s)                                         \nquay.io/kubespray/k8s-netchecker-server:v1.2.2: resolving      |\u001b[32m\u001b[0m--------------------------------------| \nelapsed: 0.3 s                                  total:   0.0 B (0.0 B/s)                                         \nquay.io/kubespray/k8s-netchecker-server:v1.2.2: resolving      |\u001b[32m\u001b[0m--------------------------------------| \nelapsed: 0.4 s                                  total:   0.0 B (0.0 B/s)                                         \nquay.io/kubespray/k8s-netchecker-server:v1.2.2: resolving      |\u001b[32m\u001b[0m--------------------------------------| \nelapsed: 0.5 s                                  total:   0.0 B (0.0 B/s)                                         \nquay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nmanifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/951.0 B \nelapsed: 0.6 s                                                                    total:   0.0 B (0.0 B/s)                                         \nquay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nmanifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/951.0 B \nelapsed: 0.7 s                                                                    total:   0.0 B (0.0 B/s)                                         \nquay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nmanifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/951.0 B \nelapsed: 0.8 s                                                                    total:   0.0 B (0.0 B/s)                                         \nquay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nmanifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/951.0 B \nelapsed: 0.9 s                                                                    total:   0.0 B (0.0 B/s)                                         \nquay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nmanifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/2.3 MiB  \nlayer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/8.4 MiB  \nconfig-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/3.4 KiB  \nlayer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/19.6 MiB \nelapsed: 1.0 s                                                                    total:  951.0  (949.0 B/s)                                       \nquay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nmanifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/2.3 MiB  \nlayer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/8.4 MiB  \nconfig-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/3.4 KiB  \nlayer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/19.6 MiB \nelapsed: 1.1 s                                                                    total:  951.0  (864.0 B/s)                                       \nquay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nmanifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/8.4 MiB  \nconfig-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/3.4 KiB  \nlayer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/19.6 MiB \nelapsed: 1.2 s                                                                    total:  2.3 Mi (1.9 MiB/s)                                       \nquay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nmanifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/8.4 MiB  \nconfig-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/3.4 KiB  \nlayer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    downloading    |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| 19.6 MiB/19.6 MiB \nelapsed: 1.3 s                                                                    total:  21.9 M (16.8 MiB/s)                                      \nquay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nmanifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    downloading    |\u001b[32m++++++++++++++++++++++\u001b[0m----------------|  5.0 MiB/8.4 MiB  \nconfig-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   downloading    |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m|  3.4 KiB/3.4 KiB  \nlayer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    downloading    |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| 19.6 MiB/19.6 MiB \nelapsed: 1.4 s                                                                    total:  26.9 M (19.2 MiB/s)                                      \nquay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nmanifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    downloading    |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m|  8.4 MiB/8.4 MiB \nconfig-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nelapsed: 1.5 s                                                                    total:  30.3 M (20.2 MiB/s)                                      \nquay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nmanifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    waiting        |\u001b[32m\u001b[0m--------------------------------------| \nconfig-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nelapsed: 1.6 s                                                                    total:  21.9 M (13.7 MiB/s)                                      \nquay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nmanifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nconfig-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nlayer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| \nelapsed: 1.7 s                                                                    total:  21.9 M (12.9 MiB/s)                                      \nunpacking linux/amd64 sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b...\ndone: 1.556861697s\t", "stdout_lines": ["quay.io/kubespray/k8s-netchecker-server:v1.2.2: resolving      |\u001b[32m\u001b[0m--------------------------------------| ", "elapsed: 0.1 s                                  total:   0.0 B (0.0 B/s)                                         ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2: resolving      |\u001b[32m\u001b[0m--------------------------------------| ", "elapsed: 0.2 s                                  total:   0.0 B (0.0 B/s)                                         ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2: resolving      |\u001b[32m\u001b[0m--------------------------------------| ", "elapsed: 0.3 s                                  total:   0.0 B (0.0 B/s)                                         ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2: resolving      |\u001b[32m\u001b[0m--------------------------------------| ", "elapsed: 0.4 s                                  total:   0.0 B (0.0 B/s)                                         ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2: resolving      |\u001b[32m\u001b[0m--------------------------------------| ", "elapsed: 0.5 s                                  total:   0.0 B (0.0 B/s)                                         ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "manifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/951.0 B ", "elapsed: 0.6 s                                                                    total:   0.0 B (0.0 B/s)                                         ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "manifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/951.0 B ", "elapsed: 0.7 s                                                                    total:   0.0 B (0.0 B/s)                                         ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "manifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/951.0 B ", "elapsed: 0.8 s                                                                    total:   0.0 B (0.0 B/s)                                         ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "manifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/951.0 B ", "elapsed: 0.9 s                                                                    total:   0.0 B (0.0 B/s)                                         ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "manifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/2.3 MiB  ", "layer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/8.4 MiB  ", "config-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/3.4 KiB  ", "layer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/19.6 MiB ", "elapsed: 1.0 s                                                                    total:  951.0  (949.0 B/s)                                       ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "manifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/2.3 MiB  ", "layer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/8.4 MiB  ", "config-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/3.4 KiB  ", "layer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/19.6 MiB ", "elapsed: 1.1 s                                                                    total:  951.0  (864.0 B/s)                                       ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "manifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/8.4 MiB  ", "config-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/3.4 KiB  ", "layer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/19.6 MiB ", "elapsed: 1.2 s                                                                    total:  2.3 Mi (1.9 MiB/s)                                       ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "manifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/8.4 MiB  ", "config-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   downloading    |\u001b[32m\u001b[0m--------------------------------------|    0.0 B/3.4 KiB  ", "layer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    downloading    |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| 19.6 MiB/19.6 MiB ", "elapsed: 1.3 s                                                                    total:  21.9 M (16.8 MiB/s)                                      ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "manifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    downloading    |\u001b[32m++++++++++++++++++++++\u001b[0m----------------|  5.0 MiB/8.4 MiB  ", "config-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   downloading    |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m|  3.4 KiB/3.4 KiB  ", "layer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    downloading    |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| 19.6 MiB/19.6 MiB ", "elapsed: 1.4 s                                                                    total:  26.9 M (19.2 MiB/s)                                      ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "manifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    downloading    |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m|  8.4 MiB/8.4 MiB ", "config-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "elapsed: 1.5 s                                                                    total:  30.3 M (20.2 MiB/s)                                      ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "manifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    waiting        |\u001b[32m\u001b[0m--------------------------------------| ", "config-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "elapsed: 1.6 s                                                                    total:  21.9 M (13.7 MiB/s)                                      ", "quay.io/kubespray/k8s-netchecker-server:v1.2.2:                                   resolved       |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "manifest-sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b: done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:534e72e7cedcc7f1a7643fa9ec34706f32de866e663874a1f58bdd059ccd859d:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:2a715132c430252152628800f4b1fa1cf6ba204b232dfb4206e4d5471f75e2b2:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "config-sha256:3fe402881a14307b8d56a81a0e123d9a433f8502ac1d77d311123f3c022772ec:   done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "layer-sha256:16708e34354589f10d0f402e59f7251e0a685a98c1497dffbd84cce4a11a62d6:    done           |\u001b[32m++++++++++++++++++++++++++++++++++++++\u001b[0m| ", "elapsed: 1.7 s                                                                    total:  21.9 M (12.9 MiB/s)                                      ", "unpacking linux/amd64 sha256:3275fe78b906b62155b3f1268bf706994aee0d4eab7b8eaa3af3cfb4a2c0c43b...", "done: 1.556861697s\t"]}
Monday 04 December 2023  11:36:57 +0000 (0:00:03.796)       0:05:27.209 ******* 
Monday 04 December 2023  11:36:57 +0000 (0:00:00.191)       0:05:27.401 ******* 
Monday 04 December 2023  11:36:57 +0000 (0:00:00.227)       0:05:27.629 ******* 
Monday 04 December 2023  11:36:57 +0000 (0:00:00.236)       0:05:27.865 ******* 
```

So, the PR is to add the quiet option to the `ctr image pull` command like the docker to make the output message more straightforward.


fix: https://github.com/containerd/containerd/issues/9467