### PR TITLE
shim: Create pid-file with 0644 permissions

### DIFF
--- a/runtime/v2/shim/util.go
+++ b/runtime/v2/shim/util.go
@@ -126,7 +126,7 @@ func WritePidFile(path string, pid int) error {
 	if err != nil {
 		return err
 	}
-	f, err := atomicfile.New(path, 0o666)
+	f, err := atomicfile.New(path, 0o644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes ae7021300

In ae7021300 the WritePidFile and WriteAddress functions were changed to use AtomicFile instead of os.CreateFile. However, AtomicFile creates a temporary file and then changes its permissions with os.Chmod which alters the previously observed behavior of os.CreateFile which takes the system's umask into account.

This means that on Linux-based systems these files suddenly became world writable (#9363). The address file has since been removed, but pid-file was still created as world writable. This commit explicitly requests 0644 permissions as even on systems without default umask of 0022 there is no reason to have these two files world writable.


(cherry picked from commit 088d5cfbd23f06727c9d872dbe690f00d4f9be53)