### PR TITLE
Fix containerd port exit monitoring

### DIFF
--- a/pkg/cri/server/service.go
+++ b/pkg/cri/server/service.go
@@ -248,6 +248,11 @@ func (c *criService) Run(ready func()) error {
 		}()
 	}
 
+	// register CRI domain with NRI
+        if err := c.nri.Register(&criImplementation{c}); err != nil {
+                return fmt.Errorf("failed to set up NRI for CRI service: %w", err)
+        }
+
 	// Start streaming server.
 	log.L.Info("Start streaming server")
 	streamServerErrCh := make(chan error)
@@ -258,11 +263,6 @@ func (c *criService) Run(ready func()) error {
 			streamServerErrCh <- err
 		}
 	}()
-
-	// register CRI domain with NRI
-	if err := c.nri.Register(&criImplementation{c}); err != nil {
-		return fmt.Errorf("failed to set up NRI for CRI service: %w", err)
-	}
 
 	// Set the server as initialized. GRPC services could start serving traffic.
 	c.initialized.Store(true)


### PR DESCRIPTION
After starting the NRI plugin, a restart of the container leads to the termination of the listening port.
https://github.com/containerd/containerd/issues/8860

config.toml
```
[plugins."io.containerd.nri.v1.nri"]
    # Enable NRI support in containerd.
    disable = false
    # Allow connections from externally launched NRI plugins.
    disable_connections = false
    # plugin_config_path is the directory to search for plugin-specific configuration.
    plugin_config_path = "/etc/nri/conf.d"
    # plugin_path is the directory to search for plugins to launch on startup.
    plugin_path = "/opt/nri/plugins"
    # plugin_registration_timeout is the timeout for a plugin to register after connection.
    plugin_registration_timeout = "5s"
    # plugin_requst_timeout is the timeout for a plugin to handle an event/request.
    plugin_request_timeout = "300s"
    # socket_path is the path of the NRI socket to create for plugins to connect to.
    socket_path = "/var/run/nri/nri.sock"
```
After enabling the NRI plugin and repeatedly restarting containerd, the issue occurs where the contained process exists but the port exit monitoring fails, resulting in the unavailability of exec and other commands. You can use the following script to reproduce this problem.
```
output_file="containerd_ports.txt"
while true
do
    systemctl restart containerd
    sleep 5s
    containerd_ports=$(netstat -tulnp | grep "containerd" | awk '{print $4}' | awk -F':' '{print $NF}')
    if [ -n "$containerd_ports" ]; then
        echo "containerd listen in port：$containerd_ports" >> "$output_file"
    else
        echo "containerd don't listen in port，exit" >> "$output_file"
        exit 0
    fi
done
```
The root cause of the issue is believed to be the enabling of the NRI plugin, which involves multiple calls to the net library, thereby affecting the port monitoring. To address this, the solution involves moving the enabling of the NRI plugin before the port monitoring, thus avoiding any interference caused by the net library calls within the NRI. This fix will not impact the existing logic.


