### PR TITLE
Fix CimFS plugin init error

### DIFF
--- a/diff/windows/cimfs.go
+++ b/diff/windows/cimfs.go
@@ -51,7 +51,7 @@ func init() {
 			}
 
 			if !cimfs.IsCimFSSupported() {
-				return nil, fmt.Errorf("host windows version doesn't support CimFS")
+				return nil, fmt.Errorf("host windows version doesn't support CimFS: %w", plugin.ErrSkipPlugin)
 			}
 			ic.Meta.Platforms = append(ic.Meta.Platforms, platforms.DefaultSpec())
 			return NewCimDiff(md.(*metadata.DB).ContentStore())

--- a/snapshots/windows/cimfs.go
+++ b/snapshots/windows/cimfs.go
@@ -70,7 +70,7 @@ func init() {
 // NewCimFSSnapshotter returns a new CimFS based windows snapshotter
 func NewCimFSSnapshotter(root string) (snapshots.Snapshotter, error) {
 	if !cimfs.IsCimFSSupported() {
-		return nil, fmt.Errorf("host windows version doesn't support CimFS")
+		return nil, fmt.Errorf("host windows version doesn't support CimFS: %w", plugin.ErrSkipPlugin)
 	}
 
 	baseSn, err := newBaseSnapshotter(root)


### PR DESCRIPTION
CimFS is available only on WS 2022 OS builds with revision >= 2031. This check was added to the CimFS init() function but this causes multiple other plugin loads to fail if the host OS build does not support the above mentioned. Hence moving this function to CimFS operation functions to let the init() go through successfully.