### PR TITLE
content: Add InfoReaderProvider

### DIFF
--- a/content/content.go
+++ b/content/content.go
@@ -108,6 +108,12 @@ type Status struct {
 // WalkFunc defines the callback for a blob walk.
 type WalkFunc func(Info) error
 
+// InfoReaderProvider provides both info and reader for the specific content.
+type InfoReaderProvider interface {
+	InfoProvider
+	Provider
+}
+
 // InfoProvider provides info for content inspection.
 type InfoProvider interface {
 	// Info will return metadata about content available in the content store.

--- a/images/archive/exporter.go
+++ b/images/archive/exporter.go
@@ -148,7 +148,7 @@ func WithSkipNonDistributableBlobs() ExportOpt {
 // The manifest itself is excluded only if it's not present locally.
 // This allows to export multi-platform images if not all platforms are present
 // while still persisting the multi-platform index.
-func WithSkipMissing(store ContentProvider) ExportOpt {
+func WithSkipMissing(store content.InfoReaderProvider) ExportOpt {
 	return func(ctx context.Context, o *exportOptions) error {
 		o.blobRecordOptions.childrenHandler = images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) (subdescs []ocispec.Descriptor, err error) {
 			children, err := images.Children(ctx, store, desc)
@@ -211,14 +211,8 @@ func copySourceLabels(ctx context.Context, infoProvider content.InfoProvider, de
 	return desc, nil
 }
 
-// ContentProvider provides both content and info about content
-type ContentProvider interface {
-	content.Provider
-	content.InfoProvider
-}
-
 // Export implements Exporter.
-func Export(ctx context.Context, store ContentProvider, writer io.Writer, opts ...ExportOpt) error {
+func Export(ctx context.Context, store content.InfoReaderProvider, writer io.Writer, opts ...ExportOpt) error {
 	var eo exportOptions
 	for _, opt := range opts {
 		if err := opt(ctx, &eo); err != nil {

--- a/images/usage/calculator.go
+++ b/images/usage/calculator.go
@@ -75,13 +75,7 @@ func WithManifestUsage() Opt {
 	}
 }
 
-// ContentProvider provides both content and info about content
-type ContentProvider interface {
-	content.Provider
-	content.InfoProvider
-}
-
-func CalculateImageUsage(ctx context.Context, i images.Image, provider ContentProvider, opts ...Opt) (int64, error) {
+func CalculateImageUsage(ctx context.Context, i images.Image, provider content.InfoReaderProvider, opts ...Opt) (int64, error) {
 	var config usageOptions
 	for _, opt := range opts {
 		if err := opt(&config); err != nil {

--- a/pkg/cri/store/image/image.go
+++ b/pkg/cri/store/image/image.go
@@ -32,7 +32,6 @@ import (
 	docker "github.com/distribution/reference"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"github.com/opencontainers/go-digest"
 	imagedigest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/go-digest/digestset"
 	imageidentity "github.com/opencontainers/image-spec/identity"
@@ -56,12 +55,6 @@ type Image struct {
 	Pinned bool
 }
 
-// InfoProvider provides both content and info about content
-type InfoProvider interface {
-	content.Provider
-	Info(ctx context.Context, dgst digest.Digest) (content.Info, error)
-}
-
 // Store stores all images.
 type Store struct {
 	lock sync.RWMutex
@@ -72,7 +65,7 @@ type Store struct {
 	images images.Store
 
 	// content provider
-	provider InfoProvider
+	provider content.InfoReaderProvider
 
 	// platform represents the currently supported platform for images
 	// TODO: Make this store multi-platform
@@ -83,7 +76,7 @@ type Store struct {
 }
 
 // NewStore creates an image store.
-func NewStore(img images.Store, provider InfoProvider, platform platforms.MatchComparer) *Store {
+func NewStore(img images.Store, provider content.InfoReaderProvider, platform platforms.MatchComparer) *Store {
 	return &Store{
 		refCache: make(map[string]string),
 		images:   img,

--- a/pkg/display/manifest_printer.go
+++ b/pkg/display/manifest_printer.go
@@ -58,11 +58,6 @@ var LineTreeFormat = TreeFormat{
 	Spacer:     "    ",
 }
 
-type ContentReader interface {
-	content.Provider
-	content.InfoProvider
-}
-
 type ImageTreePrinter struct {
 	verbose bool
 	w       io.Writer
@@ -101,7 +96,7 @@ func NewImageTreePrinter(opts ...PrintOpt) *ImageTreePrinter {
 }
 
 // PrintImageTree prints an image and all its sub elements
-func (p *ImageTreePrinter) PrintImageTree(ctx context.Context, img images.Image, store ContentReader) error {
+func (p *ImageTreePrinter) PrintImageTree(ctx context.Context, img images.Image, store content.InfoReaderProvider) error {
 	fmt.Fprintln(p.w, img.Name)
 	subchild := p.format.SkipLine
 	fmt.Fprintf(p.w, "%s Created: %s\n", subchild, img.CreatedAt)
@@ -113,12 +108,12 @@ func (p *ImageTreePrinter) PrintImageTree(ctx context.Context, img images.Image,
 }
 
 // PrintManifestTree prints a manifest and all its sub elements
-func (p *ImageTreePrinter) PrintManifestTree(ctx context.Context, desc ocispec.Descriptor, store ContentReader) error {
+func (p *ImageTreePrinter) PrintManifestTree(ctx context.Context, desc ocispec.Descriptor, store content.InfoReaderProvider) error {
 	// start displaying tree from the root descriptor perspective, which is a single child view
 	return p.printManifestTree(ctx, desc, store, p.format.LastDrop, p.format.Spacer)
 }
 
-func (p *ImageTreePrinter) printManifestTree(ctx context.Context, desc ocispec.Descriptor, store ContentReader, prefix, childprefix string) error {
+func (p *ImageTreePrinter) printManifestTree(ctx context.Context, desc ocispec.Descriptor, store content.InfoReaderProvider, prefix, childprefix string) error {
 	subprefix := childprefix + p.format.MiddleDrop
 	subchild := childprefix + p.format.SkipLine
 	fmt.Fprintf(p.w, "%s%s @%s (%d bytes)\n", prefix, desc.MediaType, desc.Digest, desc.Size)
@@ -177,7 +172,7 @@ func (p *ImageTreePrinter) printManifestTree(ctx context.Context, desc ocispec.D
 	return nil
 }
 
-func (p *ImageTreePrinter) showContent(ctx context.Context, store ContentReader, desc ocispec.Descriptor, prefix string) error {
+func (p *ImageTreePrinter) showContent(ctx context.Context, store content.InfoReaderProvider, desc ocispec.Descriptor, prefix string) error {
 	if p.verbose {
 		info, err := store.Info(ctx, desc.Digest)
 		if err != nil {


### PR DESCRIPTION
The interface that combines both content.InfoProvider and content.Provider was duplicated in multiple places - create one directly in `content` package and use it instead.