### PR TITLE
[Windows] Use latest VM image in CI to get Windows updates regularly

### DIFF
--- a/.github/workflows/windows-hyperv-periodic.yml
+++ b/.github/workflows/windows-hyperv-periodic.yml
@@ -46,11 +46,11 @@ jobs:
         win_ver: [ltsc2019, ltsc2022]
         include:
         - win_ver: ltsc2019
-          AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2019-Datacenter:17763.4377.230505"
+          AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2019-Datacenter:latest"
           AZURE_RESOURCE_GROUP: ctrd-integration-ltsc2019-${{ github.run_id }}
           GOOGLE_BUCKET: "containerd-integration/logs/windows-ltsc2019-hyperv/"
         - win_ver: ltsc2022
-          AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2022-datacenter-smalldisk-g2:20348.1607.230310"
+          AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2022-datacenter-smalldisk-g2:latest"
           AZURE_RESOURCE_GROUP: ctrd-integration-ltsc2022-${{ github.run_id }}
           GOOGLE_BUCKET: "containerd-integration/logs/windows-ltsc2022-hyperv/"
     runs-on: ubuntu-latest

--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -45,11 +45,11 @@ jobs:
         win_ver: [ltsc2019, ltsc2022]
         include:
         - win_ver: ltsc2019
-          AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2019-Datacenter:17763.4377.230505"
+          AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2019-Datacenter:latest"
           AZURE_RESOURCE_GROUP: ctrd-integration-ltsc2019-${{ github.run_id }}
           GOOGLE_BUCKET: "containerd-integration/logs/windows-ltsc2019/"
         - win_ver: ltsc2022
-          AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2022-datacenter-smalldisk-g2:20348.1607.230310"
+          AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2022-datacenter-smalldisk-g2:latest"
           AZURE_RESOURCE_GROUP: ctrd-integration-ltsc2022-${{ github.run_id }}
           GOOGLE_BUCKET: "containerd-integration/logs/windows-ltsc2022/"
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is a follow up to the [investigation](https://github.com/containerd/containerd/pull/9601#issuecomment-1877679153) found after these jobs started to fail.  

This uses the "latest" tag for the VM image so we get updates regularly with out needing to up date the jobs monthly.

fyi @kiashok 