### PR TITLE
Handle failure when stopping a sandbox

### DIFF
--- a/plugins/sandbox/controller.go
+++ b/plugins/sandbox/controller.go
@@ -201,12 +201,18 @@ func (c *controllerLocal) Stop(ctx context.Context, sandboxID string, opts ...sa
 	}
 
 	svc, err := c.getSandbox(ctx, sandboxID)
+	if errdefs.IsNotFound(err) {
+		return nil
+	}
 	if err != nil {
 		return err
 	}
 
 	if _, err := svc.StopSandbox(ctx, req); err != nil {
-		return fmt.Errorf("failed to stop sandbox: %w", errdefs.FromGRPC(err))
+		err = errdefs.FromGRPC(err)
+		if !errdefs.IsNotFound(err) && !errdefs.IsUnavailable(err) {
+			return fmt.Errorf("failed to stop sandbox: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
When using a grpc shim, if a scenario arises where both containerd and the shim process are killed, a situation arises where calls to `StopPodSandbox` after a containerd restart would fail citing reasons that the sandbox can't be found or a connection cannot be made to it.

This change treats such situations as non-failure cases so that the cleanup process can continue.