### PR TITLE
[release/1.6 backport] shim: Create pid-file with 0644 permissions

### DIFF
--- a/runtime/v2/shim/util.go
+++ b/runtime/v2/shim/util.go
@@ -120,7 +120,7 @@ func WritePidFile(path string, pid int) error {
 	if err != nil {
 		return err
 	}
-	f, err := atomicfile.New(path, 0o666)
+	f, err := atomicfile.New(path, 0o644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- backport of https://github.com/containerd/containerd/pull/9571
- relates to https://github.com/containerd/containerd/pull/8609 / https://github.com/containerd/containerd/pull/8826

Fixes ae7021300

In ae7021300 the WritePidFile and WriteAddress functions were changed to use AtomicFile instead of os.CreateFile. However, AtomicFile creates a temporary file and then changes its permissions with os.Chmod which alters the previously observed behavior of os.CreateFile which takes the system's umask into account.

This means that on Linux-based systems these files suddenly became world writable (#9363). The address file has since been removed, but pid-file was still created as world writable. This commit explicitly requests 0644 permissions as even on systems without default umask of 0022 there is no reason to have these two files world writable.


(cherry picked from commit 9d328410a5c7bab106fe81cd37a36e4534ce9205)