### PR TITLE
sandbox: use sandboxService in CRI plugin instead of calling controller API directly

### DIFF
--- a/integration/build_local_containerd_helper_test.go
+++ b/integration/build_local_containerd_helper_test.go
@@ -129,7 +129,6 @@ func buildLocalContainerdClient(t *testing.T, tmpDir string, tweakInitFn tweakPl
 		containerd.WithDefaultNamespace(constants.K8sContainerdNamespace),
 		containerd.WithDefaultPlatform(platforms.Default()),
 		containerd.WithInMemoryServices(lastInitContext),
-		containerd.WithInMemorySandboxControllers(lastInitContext),
 	)
 	require.NoError(t, err)
 

--- a/internal/cri/config/config.go
+++ b/internal/cri/config/config.go
@@ -277,7 +277,7 @@ type ImageConfig struct {
 	//   "base": "docker.io/library/ubuntu:latest"
 	// Migrated from:
 	// (PluginConfig).SandboxImage string `toml:"sandbox_image" json:"sandboxImage"`
-	PinnedImages map[string]string
+	PinnedImages map[string]string `toml:"pinned_images" json:"pinned_images"`
 
 	// RuntimePlatforms is map between the runtime and the image platform to
 	// use for that runtime. When resolving an image for a runtime, this

--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -63,12 +63,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 		return nil, fmt.Errorf("failed to find sandbox id %q: %w", r.GetPodSandboxId(), err)
 	}
 
-	controller, err := c.sandboxService.SandboxController(sandbox.Config, sandbox.RuntimeHandler)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get sandbox controller: %w", err)
-	}
-
-	cstatus, err := controller.Status(ctx, sandbox.ID, false)
+	cstatus, err := c.sandboxService.SandboxStatus(ctx, sandbox.Sandboxer, sandbox.ID, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get controller status: %w", err)
 	}
@@ -150,7 +145,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 		}
 	}()
 
-	platform, err := controller.Platform(ctx, sandboxID)
+	platform, err := c.sandboxService.SandboxPlatform(ctx, sandbox.Sandboxer, sandboxID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query sandbox platform: %w", err)
 	}

--- a/internal/cri/server/container_stats_list.go
+++ b/internal/cri/server/container_stats_list.go
@@ -68,15 +68,12 @@ func (c *criService) getMetricsHandler(ctx context.Context, sandboxID string) (m
 	if err != nil {
 		return nil, fmt.Errorf("failed to find sandbox id %q: %w", sandboxID, err)
 	}
-	controller, err := c.sandboxService.SandboxController(sandbox.Config, sandbox.RuntimeHandler)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get sandbox controller: %w", err)
-	}
+
 	// Grab the platform that this containers sandbox advertises. Reason being, even if
 	// the host may be {insert platform}, if it virtualizes or emulates a different platform
 	// it will return stats in that format, and we need to handle the conversion logic based
 	// off of this info.
-	p, err := controller.Platform(ctx, sandboxID)
+	p, err := c.sandboxService.SandboxPlatform(ctx, sandbox.Sandboxer, sandboxID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cri/server/podsandbox/controller_test.go
+++ b/internal/cri/server/podsandbox/controller_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	containerd "github.com/containerd/containerd/v2/client"
 	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
 	"github.com/containerd/containerd/v2/internal/cri/server/podsandbox/types"
 	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
@@ -63,10 +62,7 @@ func Test_Status(t *testing.T) {
 		CreatedAt: createdAt,
 	})
 	sb.Metadata = sandboxstore.Metadata{ID: sandboxID}
-	err := controller.store.Save(sb)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, controller.store.Save(sb))
 	s, err := controller.Status(context.Background(), sandboxID, false)
 	if err != nil {
 		t.Fatal(err)
@@ -75,7 +71,8 @@ func Test_Status(t *testing.T) {
 	assert.Equal(t, s.CreatedAt, createdAt)
 	assert.Equal(t, s.State, sandboxstore.StateReady.String())
 
-	sb.Exit(*containerd.NewExitStatus(exitStatus, exitedAt, nil))
+	assert.NoError(t, sb.Exit(exitStatus, exitedAt))
+
 	exit, err := controller.Wait(context.Background(), sandboxID)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/cri/server/podsandbox/recover.go
+++ b/internal/cri/server/podsandbox/recover.go
@@ -134,8 +134,9 @@ func (c *Controller) RecoverContainer(ctx context.Context, cntr containerd.Conta
 	}
 	if ch != nil {
 		go func() {
-			code, exitTime, err := c.waitSandboxExit(ctrdutil.NamespacedContext(), podSandbox, ch)
-			podSandbox.Exit(*containerd.NewExitStatus(code, exitTime, err))
+			if err := c.waitSandboxExit(ctrdutil.NamespacedContext(), podSandbox, ch); err != nil {
+				log.G(context.Background()).Warnf("failed to wait pod sandbox exit %v", err)
+			}
 		}()
 	}
 

--- a/internal/cri/server/podsandbox/recover.go
+++ b/internal/cri/server/podsandbox/recover.go
@@ -22,16 +22,17 @@ import (
 	goruntime "runtime"
 	"time"
 
+	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	containerd "github.com/containerd/containerd/v2/client"
 	sandbox2 "github.com/containerd/containerd/v2/core/sandbox"
+	"github.com/containerd/containerd/v2/internal/cri/config"
 	"github.com/containerd/containerd/v2/internal/cri/server/podsandbox/types"
 	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
 	ctrdutil "github.com/containerd/containerd/v2/internal/cri/util"
 	"github.com/containerd/containerd/v2/pkg/netns"
-	"github.com/containerd/errdefs"
 )
 
 // loadContainerTimeout is the default timeout for loading a container/sandbox.
@@ -144,6 +145,7 @@ func (c *Controller) RecoverContainer(ctx context.Context, cntr containerd.Conta
 
 	sandbox = sandboxstore.NewSandbox(*meta, s)
 	sandbox.Container = cntr
+	sandbox.Sandboxer = string(config.ModePodSandbox)
 
 	// Load network namespace.
 	sandbox.NetNS = getNetNS(meta)

--- a/internal/cri/server/podsandbox/recover_test.go
+++ b/internal/cri/server/podsandbox/recover_test.go
@@ -403,7 +403,7 @@ func TestRecoverContainer(t *testing.T) {
 
 		pSb := controller.store.Get(cont.ID())
 		assert.NotNil(t, pSb)
-		assert.Equal(t, c.expectedState, pSb.State, "%s state is not expected", cont.ID())
+		assert.Equal(t, c.expectedState, pSb.Status.Get().State, "%s state is not expected", cont.ID())
 
 		if c.expectedExitCode > 0 {
 			cont.t.waitExitCh <- struct{}{}

--- a/internal/cri/server/podsandbox/sandbox_status.go
+++ b/internal/cri/server/podsandbox/sandbox_status.go
@@ -36,17 +36,14 @@ func (c *Controller) Status(ctx context.Context, sandboxID string, verbose bool)
 	if sb == nil {
 		return sandbox.ControllerStatus{}, fmt.Errorf("unable to find sandbox %q: %w", sandboxID, errdefs.ErrNotFound)
 	}
-
+	status := sb.Status.Get()
 	cstatus := sandbox.ControllerStatus{
 		SandboxID: sandboxID,
-		Pid:       sb.Pid,
-		State:     sb.State.String(),
-		CreatedAt: sb.CreatedAt,
+		Pid:       status.Pid,
+		State:     status.State.String(),
+		CreatedAt: status.CreatedAt,
+		ExitedAt:  status.ExitedAt,
 		Extra:     nil,
-	}
-	exitStatus := sb.GetExitStatus()
-	if exitStatus != nil {
-		cstatus.ExitedAt = exitStatus.ExitTime()
 	}
 
 	if verbose {
@@ -64,7 +61,7 @@ func (c *Controller) Status(ctx context.Context, sandboxID string, verbose bool)
 // toCRISandboxInfo converts internal container object information to CRI sandbox status response info map.
 func toCRISandboxInfo(ctx context.Context, sb *types.PodSandbox) (map[string]string, error) {
 	si := &critypes.SandboxInfo{
-		Pid:            sb.Pid,
+		Pid:            sb.Status.Get().Pid,
 		Config:         sb.Metadata.Config,
 		RuntimeHandler: sb.Metadata.RuntimeHandler,
 		CNIResult:      sb.Metadata.CNIResult,

--- a/internal/cri/server/podsandbox/types/podsandbox_test.go
+++ b/internal/cri/server/podsandbox/types/podsandbox_test.go
@@ -1,0 +1,73 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package types
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/containerd/containerd/v2/internal/cri/store/sandbox"
+)
+
+func Test_PodSandbox(t *testing.T) {
+	p := NewPodSandbox("test", sandbox.Status{State: sandbox.StateUnknown})
+	assert.Equal(t, p.Status.Get().State, sandbox.StateUnknown)
+	assert.Equal(t, p.ID, "test")
+	p.Metadata = sandbox.Metadata{ID: "test", NetNSPath: "/test"}
+	createAt := time.Now()
+	assert.NoError(t, p.Status.Update(func(status sandbox.Status) (sandbox.Status, error) {
+		status.State = sandbox.StateReady
+		status.Pid = uint32(100)
+		status.CreatedAt = createAt
+		return status, nil
+	}))
+	status := p.Status.Get()
+	assert.Equal(t, status.State, sandbox.StateReady)
+	assert.Equal(t, status.Pid, uint32(100))
+	assert.Equal(t, status.CreatedAt, createAt)
+
+	exitAt := time.Now().Add(time.Second)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*500)
+		defer cancel()
+		_, err := p.Wait(ctx)
+		assert.Equal(t, err, ctx.Err())
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		exitStatus, err := p.Wait(context.Background())
+		assert.Equal(t, err, nil)
+		code, exitTime, err := exitStatus.Result()
+		assert.Equal(t, err, nil)
+		assert.Equal(t, code, uint32(128))
+		assert.Equal(t, exitTime, exitAt)
+	}()
+	time.Sleep(time.Second)
+	if err := p.Exit(uint32(128), exitAt); err != nil {
+		t.Fatalf("failed to set exit of pod sandbox %v", err)
+	}
+	wg.Wait()
+}

--- a/internal/cri/server/sandbox_remove.go
+++ b/internal/cri/server/sandbox_remove.go
@@ -79,13 +79,7 @@ func (c *criService) RemovePodSandbox(ctx context.Context, r *runtime.RemovePodS
 		}
 	}
 
-	// Use sandbox controller to delete sandbox
-	controller, err := c.sandboxService.SandboxController(sandbox.Config, sandbox.RuntimeHandler)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get sandbox controller: %w", err)
-	}
-
-	if err := controller.Shutdown(ctx, id); err != nil && !errdefs.IsNotFound(err) {
+	if err := c.sandboxService.ShutdownSandbox(ctx, sandbox.Sandboxer, id); err != nil && !errdefs.IsNotFound(err) {
 		return nil, fmt.Errorf("failed to delete sandbox %q: %w", id, err)
 	}
 

--- a/internal/cri/server/sandbox_status.go
+++ b/internal/cri/server/sandbox_status.go
@@ -41,17 +41,12 @@ func (c *criService) PodSandboxStatus(ctx context.Context, r *runtime.PodSandbox
 		return nil, fmt.Errorf("failed to get sandbox ip: %w", err)
 	}
 
-	controller, err := c.sandboxService.SandboxController(sandbox.Config, sandbox.RuntimeHandler)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get sandbox controller: %w", err)
-	}
-
 	var (
 		createdAt time.Time
 		state     string
 		info      map[string]string
 	)
-	cstatus, err := controller.Status(ctx, sandbox.ID, r.GetVerbose())
+	cstatus, err := c.sandboxService.SandboxStatus(ctx, sandbox.Sandboxer, sandbox.ID, r.GetVerbose())
 	if err != nil {
 		// If the shim died unexpectedly (segfault etc.) let's set the state as
 		// NOTREADY and not just error out to make k8s and clients like crictl

--- a/internal/cri/server/sandbox_stop.go
+++ b/internal/cri/server/sandbox_stop.go
@@ -68,13 +68,7 @@ func (c *criService) stopPodSandbox(ctx context.Context, sandbox sandboxstore.Sa
 	// Only stop sandbox container when it's running or unknown.
 	state := sandbox.Status.Get().State
 	if state == sandboxstore.StateReady || state == sandboxstore.StateUnknown {
-		// Use sandbox controller to stop sandbox
-		controller, err := c.sandboxService.SandboxController(sandbox.Config, sandbox.RuntimeHandler)
-		if err != nil {
-			return fmt.Errorf("failed to get sandbox controller: %w", err)
-		}
-
-		if err := controller.Stop(ctx, id); err != nil {
+		if err := c.sandboxService.StopSandbox(ctx, sandbox.Sandboxer, id); err != nil {
 			// Log and ignore the error if controller already removed the sandbox
 			if errdefs.IsNotFound(err) {
 				log.G(ctx).Warnf("sandbox %q is not found when stopping it", id)

--- a/internal/cri/server/service_test.go
+++ b/internal/cri/server/service_test.go
@@ -19,10 +19,12 @@ package server
 import (
 	"context"
 
+	"github.com/containerd/errdefs"
 	"github.com/containerd/go-cni"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"github.com/containerd/platforms"
 
 	"github.com/containerd/containerd/v2/api/types"
+	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/sandbox"
 	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
@@ -32,13 +34,39 @@ import (
 	"github.com/containerd/containerd/v2/internal/registrar"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	ostesting "github.com/containerd/containerd/v2/pkg/os/testing"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/platforms"
 )
 
 type fakeSandboxService struct{}
 
-func (f *fakeSandboxService) SandboxController(config *runtime.PodSandboxConfig, runtimeHandler string) (sandbox.Controller, error) {
+func (f *fakeSandboxService) CreateSandbox(ctx context.Context, info sandbox.Sandbox, opts ...sandbox.CreateOpt) error {
+	return errdefs.ErrNotImplemented
+}
+
+func (f *fakeSandboxService) StartSandbox(ctx context.Context, sandboxer string, sandboxID string) (sandbox.ControllerInstance, error) {
+	return sandbox.ControllerInstance{}, errdefs.ErrNotImplemented
+}
+
+func (f *fakeSandboxService) StopSandbox(ctx context.Context, sandboxer, sandboxID string, opts ...sandbox.StopOpt) error {
+	return errdefs.ErrNotImplemented
+}
+
+func (f *fakeSandboxService) ShutdownSandbox(ctx context.Context, sandboxer string, sandboxID string) error {
+	return errdefs.ErrNotImplemented
+}
+
+func (f *fakeSandboxService) WaitSandbox(ctx context.Context, sandboxer string, sandboxID string) (<-chan containerd.ExitStatus, error) {
+	return nil, errdefs.ErrNotImplemented
+}
+
+func (f *fakeSandboxService) SandboxStatus(ctx context.Context, sandboxer string, sandboxID string, verbose bool) (sandbox.ControllerStatus, error) {
+	return sandbox.ControllerStatus{}, errdefs.ErrNotImplemented
+}
+
+func (f *fakeSandboxService) SandboxPlatform(ctx context.Context, sandboxer string, sandboxID string) (platforms.Platform, error) {
+	return platforms.DefaultSpec(), nil
+}
+
+func (f *fakeSandboxService) SandboxController(sandboxer string) (sandbox.Controller, error) {
 	return &fakeSandboxController{}, nil
 }
 

--- a/internal/cri/store/sandbox/sandbox.go
+++ b/internal/cri/store/sandbox/sandbox.go
@@ -37,6 +37,8 @@ type Sandbox struct {
 	Status StatusStorage
 	// Container is the containerd sandbox container client.
 	Container containerd.Container
+	// Sandboxer is the sandbox controller name of the sandbox
+	Sandboxer string
 	// CNI network namespace client.
 	// For hostnetwork pod, this is always nil;
 	// For non hostnetwork pod, this should never be nil.


### PR DESCRIPTION
To make codes clean, CRI can store a Sandbox client in each sandbox in cache, and call the APIs in the client directly, so that we don't need to find the Controller everytime we need to call APIs of sandbox controller.