### PR TITLE
nri: skip nri plugin when NRI is disabled in config

### DIFF
--- a/pkg/nri/nri.go
+++ b/pkg/nri/nri.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 
 	"github.com/containerd/log"
+	"github.com/containerd/plugin"
 
 	"github.com/containerd/containerd/v2/version"
 	nri "github.com/containerd/nri/pkg/adaptation"
@@ -104,13 +105,12 @@ var _ API = &local{}
 
 // New creates an instance of the NRI interface with the given configuration.
 func New(cfg *Config) (API, error) {
-	l := &local{
-		cfg: cfg,
+	if cfg.Disable {
+		return nil, fmt.Errorf("NRI interface is disabled by configuration: %w", plugin.ErrSkipPlugin)
 	}
 
-	if cfg.Disable {
-		log.L.Info("NRI interface is disabled by configuration.")
-		return l, nil
+	l := &local{
+		cfg: cfg,
 	}
 
 	var (

--- a/pkg/nri/nri_test.go
+++ b/pkg/nri/nri_test.go
@@ -1,0 +1,44 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package nri
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/containerd/plugin"
+)
+
+func TestValidateConfig(t *testing.T) {
+	{
+		config := DefaultConfig()
+		config.Disable = true
+		if _, err := New(config); err == nil {
+			t.Fatalf("nri plugin should skip when disable is true")
+		} else if !strings.Contains(err.Error(), plugin.ErrSkipPlugin.Error()) {
+			t.Fatal(err)
+		}
+	}
+
+	{
+		config := DefaultConfig()
+		config.Disable = false
+		if _, err := New(config); err != nil {
+			t.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Starting containerd using this NRI configuration
```
  [plugins.'io.containerd.nri.v1.nri']
    disable = true
    ...
```
`getNRIAPI` should return nil when NRI disabled.
https://github.com/containerd/containerd/blob/9f8b8453349714a45d2dcb7d4f1bf216f35d2dca/pkg/cri/cri.go#L112-L116
Currently the `nri.New` function returns a nil error even when NRI is disabled, and containerd produced the following log:
```
INFO[2024-01-09T12:06:39.022903020Z] using experimental NRI integration - disable nri plugin to prevent this
``` 
The `nri` plugin is still ok although NRI is disabled.
```
[root@devnode ~]# ctr plugin ls | egrep 'skip|nri'
io.containerd.snapshotter.v1           blockfile                linux/amd64    skip
io.containerd.snapshotter.v1           devmapper                linux/amd64    skip
io.containerd.nri.v1                   nri                      -              ok
```


After modifying the `nri.New` function to return the specific error `plugin.ErrSkipPlugin` when NRI is disabled, containerd produced the following log message:
```
INFO[2024-01-09T12:24:44.517961113Z] NRI service not found, NRI support disabled
```
As expected, the nri plugin is skipped when NRI is disabled.
```
[root@devnode ~]# ctr plugin ls | egrep 'skip|nri'
io.containerd.snapshotter.v1           blockfile                linux/amd64    skip
io.containerd.snapshotter.v1           devmapper                linux/amd64    skip
io.containerd.nri.v1                   nri                      -              skip
[root@devnode ~]# ctr plugin ls -d id==nri
Type:      io.containerd.nri.v1
ID:        nri
Error:
           Code:        Unknown
           Message:     NRI interface is disabled by configuration: skip plugin
```