### PR TITLE
[release/1.6] Prepare release notes for v1.6.27

### DIFF
--- a/releases/v1.6.27.toml
+++ b/releases/v1.6.27.toml
@@ -1,0 +1,41 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.6.26"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The twenty-seventh patch release for containerd 1.6 contains various fixes and updates.
+
+### Notable Updates
+
+* **Improve `/etc/group` handling when appending groups** ([#9543](https://github.com/containerd/containerd/pull/9543))
+* **Update runc binary to v1.1.11** ([#9597](https://github.com/containerd/containerd/pull/9597))
+* **Remove runc import** ([#9606](https://github.com/containerd/containerd/pull/9606))
+* **Update shim pidfile permissions to 0644** ([#9613](https://github.com/containerd/containerd/pull/9613))
+* **Update Go version to 1.20.13** ([#9625](https://github.com/containerd/containerd/pull/9625))
+
+### Deprecation Warnings
+
+* **Emit deprecation warning for CRIU config usage** ([#9448](https://github.com/containerd/containerd/pull/9448))
+* **Emit deprecation warning for some CRI configs** ([#9447](https://github.com/containerd/containerd/pull/9447))
+* **Emit deprecation warning for `containerd.io/restart.logpath` label usage** ([#9572](https://github.com/containerd/containerd/pull/9572))
+
+See the changelog for complete list of changes"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.26+unknown"
+	Version = "1.6.27+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Prepare release notes for v1.6.27

----

Welcome to the v1.6.27 release of containerd!

The twenty-seventh patch release for containerd 1.6 contains various fixes and updates.

### Notable Updates

* **Improve `/etc/group` handling when appending groups** ([#9543](https://github.com/containerd/containerd/pull/9543))
* **Update runc binary to v1.1.11** ([#9597](https://github.com/containerd/containerd/pull/9597))
* **Remove runc import** ([#9606](https://github.com/containerd/containerd/pull/9606))
* **Update shim pidfile permissions to 0644** ([#9613](https://github.com/containerd/containerd/pull/9613))
* **Update Go version to 1.20.13** ([#9625](https://github.com/containerd/containerd/pull/9625))

### Deprecation Warnings

* **Emit deprecation warning for CRIU config usage** ([#9448](https://github.com/containerd/containerd/pull/9448))
* **Emit deprecation warning for some CRI configs** ([#9447](https://github.com/containerd/containerd/pull/9447))
* **Emit deprecation warning for `containerd.io/restart.logpath` label usage** ([#9572](https://github.com/containerd/containerd/pull/9572))

See the changelog for complete list of changes

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Samuel Karp
* Akihiro Suda
* Derek McGowan
* Sebastiaan van Stijn
* Djordje Lukic
* Jaroslav Jindrak
* Kay Yan
* Maksym Pavlenko
* Phil Estes
* Wei Fu
* ruiwen-zhao

### Changes
<details><summary>25 commits</summary>
<p>

  * [`d0edecf28`](https://github.com/containerd/containerd/commit/d0edecf28b51b35cfb549e3d18467bd2087fb0e7) Prepare release notes for v1.6.27
* [release/1.6] update to go1.20.13, test go1.21.6 ([#9625](https://github.com/containerd/containerd/pull/9625))
  * [`32a515211`](https://github.com/containerd/containerd/commit/32a515211d03771e3a35bf7bcb4b114bf1131ada) update to go1.20.13, test go1.21.6
* [release/1.6 backport] shim: Create pid-file with 0644 permissions ([#9613](https://github.com/containerd/containerd/pull/9613))
  * [`37de14d95`](https://github.com/containerd/containerd/commit/37de14d9562db48f9b66f37b10fa3e704455ae25) shim: Create pid-file with 0644 permissions
* [release/1.6 backport] remove github.com/opencontainers/runc dependency ([#9606](https://github.com/containerd/containerd/pull/9606))
  * [`3938d63de`](https://github.com/containerd/containerd/commit/3938d63de4737668ccec1f5eaf552c58a5d32057) remove github.com/opencontainers/runc dependency
* [release/1.6 backport] update runc binary to v1.1.11 ([#9597](https://github.com/containerd/containerd/pull/9597))
  * [`9a9b11f73`](https://github.com/containerd/containerd/commit/9a9b11f733f778ce6171396d0c95e2b68cca5e21) update runc binary to v1.1.11
* [release/1.6 backport] go.mod: dario.cat/mergo v1.0.0 ([#9570](https://github.com/containerd/containerd/pull/9570))
  * [`6cd8e17ab`](https://github.com/containerd/containerd/commit/6cd8e17aba91d9f46f9e1a27b6381744e6cafe48) go.mod: dario.cat/mergo v1.0.0
  * [`4f8ff5154`](https://github.com/containerd/containerd/commit/4f8ff5154abd2127d148fb11ca54feb6f0fb47af) go.mod: github.com/imdario/mergo v0.3.13
* [release/1.6] restart: containerd.io/restart.logpath warning ([#9572](https://github.com/containerd/containerd/pull/9572))
  * [`d24d263a4`](https://github.com/containerd/containerd/commit/d24d263a42f51dca398070be1f8268fd53fe6cc9) restart: containerd.io/restart.logpath warning
* [release/1.6 backport] WithAppendAdditionalGroups: better /etc/group handling ([#9543](https://github.com/containerd/containerd/pull/9543))
  * [`9489c0eb0`](https://github.com/containerd/containerd/commit/9489c0eb0e7e51d90a0c2b5b4f5cbe23936d95ca) WithAppendAdditionalGroups: better /etc/group handling
* [release/1.6] cri: add deprecation warnings for deprecated CRI configs ([#9547](https://github.com/containerd/containerd/pull/9547))
  * [`713065793`](https://github.com/containerd/containerd/commit/713065793592c0f877c81712a6f310f3d730bf07) deprecation: fix missing spaces in warnings
  * [`de0cc92a7`](https://github.com/containerd/containerd/commit/de0cc92a793b84118356715503243a2b9664dfa5) cri: add deprecation warning for runtime_root
  * [`833b94149`](https://github.com/containerd/containerd/commit/833b94149b6fd4faa6d4719ef7926257f5b2b098) cri: add deprecation warning for rutnime_engine
  * [`47de3d63d`](https://github.com/containerd/containerd/commit/47de3d63df0e5ffa522dfc2b6cb5b2d472879f28) cri: add deprecation warning for default_runtime
  * [`d421b8fda`](https://github.com/containerd/containerd/commit/d421b8fda9d0d303e1b90a13f378e6fffe7d9187) cri: add warning for untrusted_workload_runtime
  * [`802cb64b0`](https://github.com/containerd/containerd/commit/802cb64b00aab14d0f2edb45c9b89eef0016dc1c) cri: add warning for old form of systemd_cgroup
* [release/1.6] Add warning for CRIU config usage ([#9546](https://github.com/containerd/containerd/pull/9546))
  * [`f8447466c`](https://github.com/containerd/containerd/commit/f8447466ccd8277083fefeb6db91194c4559ed0b) Add warning for CRIU config usage
</p>
</details>

### Dependency Changes

* **dario.cat/mergo**           v1.0.0 **_new_**
* **github.com/moby/sys/user**  v0.1.0 **_new_**

Previous release can be found at [v1.6.26](https://github.com/containerd/containerd/releases/tag/v1.6.26)


