### PR TITLE
cri: Stat host sandbox files before adding them

### DIFF
--- a/internal/cri/server/container_create_test.go
+++ b/internal/cri/server/container_create_test.go
@@ -733,32 +733,21 @@ func TestLinuxContainerMounts(t *testing.T) {
 			expectedMounts:  nil,
 		},
 		{
-			desc: "should skip hostname mount if the old sandbox doesn't have hostname file",
+			desc: "should skip sandbox mounts if the old sandbox doesn't have sandbox file",
 			statFn: func(path string) (os.FileInfo, error) {
-				assert.Equal(t, filepath.Join(testRootDir, sandboxesDir, testSandboxID, "hostname"), path)
-				return nil, errors.New("random error")
+				sandboxRootDir := filepath.Join(testRootDir, sandboxesDir, testSandboxID)
+				sandboxStateDir := filepath.Join(testStateDir, sandboxesDir, testSandboxID)
+				switch path {
+				case filepath.Join(sandboxRootDir, "hostname"), filepath.Join(sandboxRootDir, "hosts"),
+					filepath.Join(sandboxRootDir, "resolv.conf"), filepath.Join(sandboxStateDir, "shm"):
+					return nil, errors.New("random error")
+				default:
+					t.Fatalf("expected sandbox files, got: %s", path)
+				}
+				return nil, nil
 			},
 			securityContext: &runtime.LinuxContainerSecurityContext{},
-			expectedMounts: []*runtime.Mount{
-				{
-					ContainerPath:  "/etc/hosts",
-					HostPath:       filepath.Join(testRootDir, sandboxesDir, testSandboxID, "hosts"),
-					Readonly:       false,
-					SelinuxRelabel: true,
-				},
-				{
-					ContainerPath:  resolvConfPath,
-					HostPath:       filepath.Join(testRootDir, sandboxesDir, testSandboxID, "resolv.conf"),
-					Readonly:       false,
-					SelinuxRelabel: true,
-				},
-				{
-					ContainerPath:  "/dev/shm",
-					HostPath:       filepath.Join(testStateDir, sandboxesDir, testSandboxID, "shm"),
-					Readonly:       false,
-					SelinuxRelabel: true,
-				},
-			},
+			expectedMounts:  nil,
 		},
 	} {
 		test := test


### PR DESCRIPTION
As `setupSandboxFiles` was done in sandbox controller, it is difficult for CRI server to know if the remote controller did when creating container. If the controller didn't, CRI would add a OCI mount whose hostPath doesn't exist!

![image](https://github.com/containerd/containerd/assets/25223859/681eff66-c9d7-4457-8b10-af4e845451b8)



To make it safe, CRI createContainer should check if the hostPath exist.