### PR TITLE
[release/1.6] carry #9557 - enable ARM CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,11 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12, windows-2019]
+        os: [ubuntu-20.04, actuated-arm64-4cpu-16gb, macos-12, windows-2019]
 
     steps:
       - name: Install dependencies
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'actuated-arm64-4cpu-16gb'
         run: |
           sudo apt-get update
           sudo apt-get install -y libbtrfs-dev
@@ -232,11 +232,11 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12, windows-2019, windows-2022]
+        os: [ubuntu-20.04, actuated-arm64-4cpu-16gb, macos-12, windows-2019, windows-2022]
         go-version: ["1.20.13", "1.21.6"]
     steps:
       - name: Install dependencies
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'actuated-arm64-4cpu-16gb'
         run: |
           sudo apt-get update
           sudo apt-get install -y libbtrfs-dev
@@ -347,7 +347,7 @@ jobs:
 
   integration-linux:
     name: Linux Integration
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 40
     needs: [linters, protos, man]
 
@@ -361,6 +361,13 @@ jobs:
             runc: crun
           - runtime: io.containerd.runtime.v1.linux
             runc: crun
+          # runc.v1 doesn't support cgroupv2
+          - runtime: io.containerd.runc.v1
+            os: actuated-arm64-4cpu-16gb
+          # shim.v1 doesn't support cgroupv2
+          - runtime: io.containerd.runtime.v1.linux
+            os: actuated-arm64-4cpu-16gb
+        os: [ubuntu-20.04, actuated-arm64-4cpu-16gb]
 
     env:
       GOTEST: gotestsum --
@@ -375,7 +382,7 @@ jobs:
         env:
           RUNC_FLAVOR: ${{ matrix.runc }}
         run: |
-          sudo apt-get install -y gperf libbtrfs-dev
+          sudo apt-get install -y gperf libbtrfs-dev dmsetup strace xfsprogs
           script/setup/install-seccomp
           script/setup/install-runc
           script/setup/install-cni $(grep containernetworking/plugins go.mod | awk '{print $2}')
@@ -383,6 +390,10 @@ jobs:
           script/setup/install-failpoint-binaries
 
       - name: Install criu
+        # NOTE: Required actuated enable CONFIG_CHECKPOINT_RESTORE
+        #
+        # REF: https://criu.org/Linux_kernel
+        if: matrix.os != 'actuated-arm64-4cpu-16gb'
         run: |
           sudo add-apt-repository ppa:criu/ppa
           sudo apt-get update
@@ -467,6 +478,12 @@ jobs:
           mount
           df
           losetup -l
+      - name: Kernel Message
+        if: failure()
+        run: |
+          sudo lsmod
+          sudo dmesg -T -f kern
+
       - uses: actions/upload-artifact@v3
         if: always()
         with:

--- a/integration/container_update_resources_test.go
+++ b/integration/container_update_resources_test.go
@@ -270,11 +270,8 @@ func TestUpdateContainerResources_MemoryLimit(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Check memory limit in cgroup")
-	cgroup, err := cgroups.Load(cgroups.V1, cgroups.PidPath(int(task.Pid())))
-	require.NoError(t, err)
-	stat, err := cgroup.Stat(cgroups.IgnoreNotExist)
-	require.NoError(t, err)
-	assert.Equal(t, uint64(400*1024*1024), stat.Memory.Usage.Limit)
+	memLimit := getCgroupMemoryLimitForTask(t, task)
+	assert.Equal(t, uint64(400*1024*1024), memLimit)
 	swapLimit := getCgroupSwapLimitForTask(t, task)
 	assert.Equal(t, uint64(400*1024*1024), swapLimit)
 
@@ -291,9 +288,8 @@ func TestUpdateContainerResources_MemoryLimit(t *testing.T) {
 	checkMemorySwapLimit(t, spec, expectedSwapLimit(800*1024*1024))
 
 	t.Log("Check memory limit in cgroup")
-	stat, err = cgroup.Stat(cgroups.IgnoreNotExist)
-	require.NoError(t, err)
-	assert.Equal(t, uint64(800*1024*1024), stat.Memory.Usage.Limit)
+	memLimit = getCgroupMemoryLimitForTask(t, task)
+	assert.Equal(t, uint64(800*1024*1024), memLimit)
 	swapLimit = getCgroupSwapLimitForTask(t, task)
 	assert.Equal(t, uint64(800*1024*1024), swapLimit)
 }

--- a/script/setup/install-cni
+++ b/script/setup/install-cni
@@ -37,8 +37,8 @@ git clone "${CNI_REPO}" "${TMPROOT}"/plugins
 pushd "${TMPROOT}"/plugins
 git checkout "$CNI_COMMIT"
 ./build_linux.sh
-mkdir -p $CNI_DIR
-cp -r ./bin $CNI_DIR
+$SUDO mkdir -p $CNI_DIR
+$SUDO cp -r ./bin $CNI_DIR
 $SUDO mkdir -p $CNI_CONFIG_DIR
 $SUDO cat << EOF | $SUDO tee $CNI_CONFIG_DIR/10-containerd-net.conflist
 {

--- a/script/setup/install-critools
+++ b/script/setup/install-critools
@@ -25,7 +25,9 @@ script_dir="$(cd -- "$(dirname -- "$0")" > /dev/null 2>&1; pwd -P)"
 # e2e will fail with "sudo: command not found"
 SUDO=''
 if (( $EUID != 0 )); then
-    SUDO='sudo'
+    # The actuated ARM64 env needs PATH=$PATH to get `go` path. Otherwise
+    # `make install` recipe will fail.
+    SUDO="sudo -E PATH=$PATH"
 fi
 
 cd "$(go env GOPATH)"


### PR DESCRIPTION
Carry #9557 

Cherry: 

* https://github.com/containerd/containerd/pull/9456 
* https://github.com/containerd/containerd/pull/6595 : arm64 runner enables cgroupv2 and we need to backport this fix as well.