### PR TITLE
ci: make artifact name unique in linux integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -569,7 +569,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: TestResults ${{ matrix.runtime }} ${{matrix.runc}}
+          name: TestResults ${{ matrix.runtime }} ${{matrix.runc}} ${{ matrix.os }}
           path: |
             *-junit.xml
             *-gotest.json


### PR DESCRIPTION
actions/upload-artifact@v4 marks artifacts as immutable. Thus, tests which use matrix should have a unique artifact name while using upload-artifact github action

Ref: https://github.com/actions/upload-artifact/releases/tag/v4.0.0

Artifact name modified as per the migration steps here https://github.com/actions/upload-artifact/blob/1eb3cb2b3e0f29609092a73eb033bb759a334595/docs/MIGRATION.md?plain=1#L47