### PR TITLE
include image name in error message

### DIFF
--- a/client/image.go
+++ b/client/image.go
@@ -335,7 +335,7 @@ func (i *image) Unpack(ctx context.Context, snapshotterName string, opts ...Unpa
 	for _, layer := range layers {
 		unpacked, err = rootfs.ApplyLayerWithOpts(ctx, layer, chain, sn, a, config.SnapshotOpts, config.ApplyOpts)
 		if err != nil {
-			return err
+			return fmt.Errorf("apply layer error for %q: %w", i.Name(), err)
 		}
 
 		if unpacked {


### PR DESCRIPTION
When trouble shooting the soci-snapshotter, i ran into this error message:

```
Jan 15 03:41:52 ip-172-31-34-36.ec2.internal containerd[61824]: time="2024-01-15T03:41:52.716007163Z" level=info msg="apply failure, attempting cleanup" error="failed to extract layer sha256:961e93cda9dd918dbe26aca24cccd6c5db05176850d2c53476d881df5d0d4816: failed to get reader from content store: content digest sha256:9457426d68990df190301d2e20b8450c4f67d7559bdb7ded6c40d41ced6731f7: not found" key="extract-708941494-FkPj sha256:961e93cda9dd918dbe26aca24cccd6c5db05176850d2c53476d881df5d0d4816"
```
it would have been easier to debug if the image name was apparent in the error message itself (instead of trying to track down all the SHA's for layer id? digest? etc)