### PR TITLE
fix container discarding event

### DIFF
--- a/pkg/cri/server/metrics.go
+++ b/pkg/cri/server/metrics.go
@@ -29,12 +29,11 @@ var (
 	sandboxRuntimeStopTimer   metrics.LabeledTimer
 	sandboxRemoveTimer        metrics.LabeledTimer
 
-	containerListTimer          metrics.Timer
-	containerRemoveTimer        metrics.LabeledTimer
-	containerCreateTimer        metrics.LabeledTimer
-	containerStopTimer          metrics.LabeledTimer
-	containerStartTimer         metrics.LabeledTimer
-	containerEventsDroppedCount metrics.Counter
+	containerListTimer   metrics.Timer
+	containerRemoveTimer metrics.LabeledTimer
+	containerCreateTimer metrics.LabeledTimer
+	containerStopTimer   metrics.LabeledTimer
+	containerStartTimer  metrics.LabeledTimer
 
 	networkPluginOperations        metrics.LabeledCounter
 	networkPluginOperationsErrors  metrics.LabeledCounter
@@ -58,7 +57,6 @@ func init() {
 	containerCreateTimer = ns.NewLabeledTimer("container_create", "time to create a container", "runtime")
 	containerStopTimer = ns.NewLabeledTimer("container_stop", "time to stop a container", "runtime")
 	containerStartTimer = ns.NewLabeledTimer("container_start", "time to start a container", "runtime")
-	containerEventsDroppedCount = ns.NewCounter("container_events_dropped", "count container discarding event total from server start")
 
 	networkPluginOperations = ns.NewLabeledCounter("network_plugin_operations_total", "cumulative number of network plugin operations by operation type", "operation_type")
 	networkPluginOperationsErrors = ns.NewLabeledCounter("network_plugin_operations_errors_total", "cumulative number of network plugin operations by operation type", "operation_type")


### PR DESCRIPTION
use crictl create 1000 containers and containerEventsChan will full, then don't call GetContainerEvents to  consume events, events will lost. will show "containerEventsChan is full, discarding event ..."
issue:https://github.com/containerd/containerd/issues/8892