### PR TITLE
cri: pod decryption key model

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/containerd/zfs v1.1.0
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.2.0
+	github.com/containers/ocicrypt v1.1.6
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c
@@ -91,7 +92,6 @@ require (
 	github.com/cilium/ebpf v0.9.1 // indirect
 	github.com/containerd/cgroups v1.1.0 // indirect
 	github.com/containerd/typeurl v1.0.2 // indirect
-	github.com/containers/ocicrypt v1.1.6 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect

--- a/pkg/cri/annotations/annotations.go
+++ b/pkg/cri/annotations/annotations.go
@@ -90,6 +90,10 @@ const (
 
 	// WindowsHostProcess is used by hcsshim to identify windows pods that are running HostProcesses
 	WindowsHostProcess = "microsoft.com/hostprocess-container"
+
+	// PodImageDecryptionConfig is used to specify the decryption config of image layers used in the pod.
+	// They are in format protocol:keyfile. For instance, jwe:/path/to/key.pem or pgp:admin@example.com or pkcs7:/path/to/x509-file.
+	PodImageDecryptionConfig = "io.containerd.cri.decryption-key"
 )
 
 // DefaultCRIAnnotations are the default set of CRI annotations to

--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -418,6 +418,9 @@ const (
 	// KeyModelNode is the key model where key for encrypted images reside
 	// on the worker nodes
 	KeyModelNode = "node"
+	// KeyModelPod is the key model where key for encrypted images reside
+	// in annotations on pod config
+	KeyModelPod = "pod"
 )
 
 // ValidatePluginConfig validates the given plugin configuration.

--- a/vendor/github.com/containers/ocicrypt/config/pkcs11config/config.go
+++ b/vendor/github.com/containers/ocicrypt/config/pkcs11config/config.go
@@ -1,0 +1,124 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package pkcs11config
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/containers/ocicrypt/crypto/pkcs11"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+)
+
+// OcicryptConfig represents the format of an imgcrypt.conf config file
+type OcicryptConfig struct {
+	Pkcs11Config pkcs11.Pkcs11Config `yaml:"pkcs11"`
+}
+
+const CONFIGFILE = "ocicrypt.conf"
+const ENVVARNAME = "OCICRYPT_CONFIG"
+
+// parseConfigFile parses a configuration file; it is not an error if the configuration file does
+// not exist, so no error is returned.
+// A config file may look like this:
+// module-directories:
+//   - /usr/lib64/pkcs11/
+//   - /usr/lib/pkcs11/
+// allowed-module-paths:
+//   - /usr/lib64/pkcs11/
+//   - /usr/lib/pkcs11/
+func parseConfigFile(filename string) (*OcicryptConfig, error) {
+	// a non-existent config file is not an error
+	_, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	ic := &OcicryptConfig{}
+	err = yaml.Unmarshal(data, ic)
+	return ic, err
+}
+
+// getConfiguration tries to read the configuration file at the following locations
+// 1) ${OCICRYPT_CONFIG} == "internal": use internal default allow-all policy
+// 2) ${OCICRYPT_CONFIG}
+// 3) ${XDG_CONFIG_HOME}/ocicrypt-pkcs11.conf
+// 4) ${HOME}/.config/ocicrypt-pkcs11.conf
+// 5) /etc/ocicrypt-pkcs11.conf
+// If no configuration file could be found or read a null pointer is returned
+func getConfiguration() (*OcicryptConfig, error) {
+	filename := os.Getenv(ENVVARNAME)
+	if len(filename) > 0 {
+		if filename == "internal" {
+			return getDefaultCryptoConfigOpts()
+		}
+		ic, err := parseConfigFile(filename)
+		if err != nil || ic != nil {
+			return ic, err
+		}
+	}
+	envvar := os.Getenv("XDG_CONFIG_HOME")
+	if len(envvar) > 0 {
+		ic, err := parseConfigFile(path.Join(envvar, CONFIGFILE))
+		if err != nil || ic != nil {
+			return ic, err
+		}
+	}
+	envvar = os.Getenv("HOME")
+	if len(envvar) > 0 {
+		ic, err := parseConfigFile(path.Join(envvar, ".config", CONFIGFILE))
+		if err != nil || ic != nil {
+			return ic, err
+		}
+	}
+	return parseConfigFile(path.Join("etc", CONFIGFILE))
+}
+
+// getDefaultCryptoConfigOpts returns default crypto config opts needed for pkcs11 module access
+func getDefaultCryptoConfigOpts() (*OcicryptConfig, error) {
+	mdyaml := pkcs11.GetDefaultModuleDirectoriesYaml("")
+	config := fmt.Sprintf("module-directories:\n"+
+		"%s"+
+		"allowed-module-paths:\n"+
+		"%s", mdyaml, mdyaml)
+	p11conf, err := pkcs11.ParsePkcs11ConfigFile([]byte(config))
+	return &OcicryptConfig{
+		Pkcs11Config: *p11conf,
+	}, err
+}
+
+// GetUserPkcs11Config gets the user's Pkcs11Conig either from a configuration file or if none is
+// found the default ones are returned
+func GetUserPkcs11Config() (*pkcs11.Pkcs11Config, error) {
+	fmt.Print("Note: pkcs11 support is currently experimental\n")
+	ic, err := getConfiguration()
+	if err != nil {
+		return &pkcs11.Pkcs11Config{}, err
+	}
+	if ic == nil {
+		return &pkcs11.Pkcs11Config{}, errors.New("No ocicrypt config file was found")
+	}
+	return &ic.Pkcs11Config, nil
+}

--- a/vendor/github.com/containers/ocicrypt/helpers/parse_helpers.go
+++ b/vendor/github.com/containers/ocicrypt/helpers/parse_helpers.go
@@ -1,0 +1,380 @@
+package helpers
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/containers/ocicrypt"
+	encconfig "github.com/containers/ocicrypt/config"
+	"github.com/containers/ocicrypt/config/pkcs11config"
+	"github.com/containers/ocicrypt/crypto/pkcs11"
+	encutils "github.com/containers/ocicrypt/utils"
+
+	"github.com/pkg/errors"
+)
+
+// processRecipientKeys sorts the array of recipients by type. Recipients may be either
+// x509 certificates, public keys, or PGP public keys identified by email address or name
+func processRecipientKeys(recipients []string) ([][]byte, [][]byte, [][]byte, [][]byte, [][]byte, [][]byte, error) {
+	var (
+		gpgRecipients [][]byte
+		pubkeys       [][]byte
+		x509s         [][]byte
+		pkcs11Pubkeys [][]byte
+		pkcs11Yamls   [][]byte
+		keyProviders  [][]byte
+	)
+
+	for _, recipient := range recipients {
+
+		idx := strings.Index(recipient, ":")
+		if idx < 0 {
+			return nil, nil, nil, nil, nil, nil, errors.New("Invalid recipient format")
+		}
+
+		protocol := recipient[:idx]
+		value := recipient[idx+1:]
+
+		switch protocol {
+		case "pgp":
+			gpgRecipients = append(gpgRecipients, []byte(value))
+
+		case "jwe":
+			tmp, err := ioutil.ReadFile(value)
+			if err != nil {
+				return nil, nil, nil, nil, nil, nil, errors.Wrap(err, "Unable to read file")
+			}
+			if !encutils.IsPublicKey(tmp) {
+				return nil, nil, nil, nil, nil, nil, errors.New("File provided is not a public key")
+			}
+			pubkeys = append(pubkeys, tmp)
+
+		case "pkcs7":
+			tmp, err := ioutil.ReadFile(value)
+			if err != nil {
+				return nil, nil, nil, nil, nil, nil, errors.Wrap(err, "Unable to read file")
+			}
+			if !encutils.IsCertificate(tmp) {
+				return nil, nil, nil, nil, nil, nil, errors.New("File provided is not an x509 cert")
+			}
+			x509s = append(x509s, tmp)
+
+		case "pkcs11":
+			tmp, err := ioutil.ReadFile(value)
+			if err != nil {
+				return nil, nil, nil, nil, nil, nil, errors.Wrap(err, "Unable to read file")
+			}
+			if encutils.IsPkcs11PublicKey(tmp) {
+				pkcs11Yamls = append(pkcs11Yamls, tmp)
+			} else if encutils.IsPublicKey(tmp) {
+				pkcs11Pubkeys = append(pkcs11Pubkeys, tmp)
+			} else {
+				return nil, nil, nil, nil, nil, nil, errors.New("Provided file is not a public key")
+			}
+
+		case "provider":
+			keyProviders = append(keyProviders, []byte(value))
+
+		default:
+			return nil, nil, nil, nil, nil, nil, errors.New("Provided protocol not recognized")
+		}
+	}
+	return gpgRecipients, pubkeys, x509s, pkcs11Pubkeys, pkcs11Yamls, keyProviders, nil
+}
+
+// processx509Certs processes x509 certificate files
+func processx509Certs(keys []string) ([][]byte, error) {
+	var x509s [][]byte
+	for _, key := range keys {
+		fileName := strings.Split(key, ":")[0]
+		if _, err := os.Stat(fileName); os.IsNotExist(err) {
+			continue
+		}
+		tmp, err := ioutil.ReadFile(fileName)
+		if err != nil {
+			return nil, errors.Wrap(err, "Unable to read file")
+		}
+		if !encutils.IsCertificate(tmp) {
+			continue
+		}
+		x509s = append(x509s, tmp)
+
+	}
+	return x509s, nil
+}
+
+// processPwdString process a password that may be in any of the following formats:
+// - file=<passwordfile>
+// - pass=<password>
+// - fd=<filedescriptor>
+// - <password>
+func processPwdString(pwdString string) ([]byte, error) {
+	if strings.HasPrefix(pwdString, "file=") {
+		return ioutil.ReadFile(pwdString[5:])
+	} else if strings.HasPrefix(pwdString, "pass=") {
+		return []byte(pwdString[5:]), nil
+	} else if strings.HasPrefix(pwdString, "fd=") {
+		fdStr := pwdString[3:]
+		fd, err := strconv.Atoi(fdStr)
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not parse file descriptor %s", fdStr)
+		}
+		f := os.NewFile(uintptr(fd), "pwdfile")
+		if f == nil {
+			return nil, fmt.Errorf("%s is not a valid file descriptor", fdStr)
+		}
+		defer f.Close()
+		pwd := make([]byte, 64)
+		n, err := f.Read(pwd)
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not read from file descriptor")
+		}
+		return pwd[:n], nil
+	}
+	return []byte(pwdString), nil
+}
+
+// processPrivateKeyFiles sorts the different types of private key files; private key files may either be
+// private keys or GPG private key ring files. The private key files may include the password for the
+// private key and take any of the following forms:
+// - <filename>
+// - <filename>:file=<passwordfile>
+// - <filename>:pass=<password>
+// - <filename>:fd=<filedescriptor>
+// - <filename>:<password>
+// - keyprovider:<...>
+func processPrivateKeyFiles(keyFilesAndPwds []string) ([][]byte, [][]byte, [][]byte, [][]byte, [][]byte, [][]byte, error) {
+	var (
+		gpgSecretKeyRingFiles [][]byte
+		gpgSecretKeyPasswords [][]byte
+		privkeys              [][]byte
+		privkeysPasswords     [][]byte
+		pkcs11Yamls           [][]byte
+		keyProviders          [][]byte
+		err                   error
+	)
+	// keys needed for decryption in case of adding a recipient
+	for _, keyfileAndPwd := range keyFilesAndPwds {
+		var password []byte
+
+		// treat "provider" protocol separately
+		if strings.HasPrefix(keyfileAndPwd, "provider:") {
+			keyProviders = append(keyProviders, []byte(keyfileAndPwd[len("provider:"):]))
+			continue
+		}
+		parts := strings.Split(keyfileAndPwd, ":")
+		if len(parts) == 2 {
+			password, err = processPwdString(parts[1])
+			if err != nil {
+				return nil, nil, nil, nil, nil, nil, err
+			}
+		}
+
+		keyfile := parts[0]
+		tmp, err := ioutil.ReadFile(keyfile)
+		if err != nil {
+			return nil, nil, nil, nil, nil, nil, err
+		}
+		isPrivKey, err := encutils.IsPrivateKey(tmp, password)
+		if encutils.IsPasswordError(err) {
+			return nil, nil, nil, nil, nil, nil, err
+		}
+
+		if encutils.IsPkcs11PrivateKey(tmp) {
+			pkcs11Yamls = append(pkcs11Yamls, tmp)
+		} else if isPrivKey {
+			privkeys = append(privkeys, tmp)
+			privkeysPasswords = append(privkeysPasswords, password)
+		} else if encutils.IsGPGPrivateKeyRing(tmp) {
+			gpgSecretKeyRingFiles = append(gpgSecretKeyRingFiles, tmp)
+			gpgSecretKeyPasswords = append(gpgSecretKeyPasswords, password)
+		} else {
+			// ignore if file is not recognized, so as not to error if additional
+			// metadata/cert files exists
+			continue
+		}
+	}
+	return gpgSecretKeyRingFiles, gpgSecretKeyPasswords, privkeys, privkeysPasswords, pkcs11Yamls, keyProviders, nil
+}
+
+// CreateDecryptCryptoConfig creates the CryptoConfig object that contains the necessary
+// information to perform decryption from command line options.
+func CreateDecryptCryptoConfig(keys []string, decRecipients []string) (encconfig.CryptoConfig, error) {
+	ccs := []encconfig.CryptoConfig{}
+
+	// x509 cert is needed for PKCS7 decryption
+	_, _, x509s, _, _, _, err := processRecipientKeys(decRecipients)
+	if err != nil {
+		return encconfig.CryptoConfig{}, err
+	}
+
+	// x509 certs can also be passed in via keys
+	x509FromKeys, err := processx509Certs(keys)
+	if err != nil {
+		return encconfig.CryptoConfig{}, err
+	}
+	x509s = append(x509s, x509FromKeys...)
+
+	gpgSecretKeyRingFiles, gpgSecretKeyPasswords, privKeys, privKeysPasswords, pkcs11Yamls, keyProviders, err := processPrivateKeyFiles(keys)
+	if err != nil {
+		return encconfig.CryptoConfig{}, err
+	}
+
+	if len(gpgSecretKeyRingFiles) > 0 {
+		gpgCc, err := encconfig.DecryptWithGpgPrivKeys(gpgSecretKeyRingFiles, gpgSecretKeyPasswords)
+		if err != nil {
+			return encconfig.CryptoConfig{}, err
+		}
+		ccs = append(ccs, gpgCc)
+	}
+
+	/* TODO: Add in GPG client query for secret keys in the future.
+	_, err = createGPGClient(context)
+	gpgInstalled := err == nil
+	if gpgInstalled {
+		if len(gpgSecretKeyRingFiles) == 0 && len(privKeys) == 0 && len(pkcs11Yamls) == 0 && len(keyProviders) == 0 && descs != nil {
+			// Get pgp private keys from keyring only if no private key was passed
+			gpgPrivKeys, gpgPrivKeyPasswords, err := getGPGPrivateKeys(context, gpgSecretKeyRingFiles, descs, true)
+			if err != nil {
+				return encconfig.CryptoConfig{}, err
+			}
+
+			gpgCc, err := encconfig.DecryptWithGpgPrivKeys(gpgPrivKeys, gpgPrivKeyPasswords)
+			if err != nil {
+				return encconfig.CryptoConfig{}, err
+			}
+			ccs = append(ccs, gpgCc)
+
+		} else if len(gpgSecretKeyRingFiles) > 0 {
+			gpgCc, err := encconfig.DecryptWithGpgPrivKeys(gpgSecretKeyRingFiles, gpgSecretKeyPasswords)
+			if err != nil {
+				return encconfig.CryptoConfig{}, err
+			}
+			ccs = append(ccs, gpgCc)
+
+		}
+	}
+	*/
+
+	if len(x509s) > 0 {
+		x509sCc, err := encconfig.DecryptWithX509s(x509s)
+		if err != nil {
+			return encconfig.CryptoConfig{}, err
+		}
+		ccs = append(ccs, x509sCc)
+	}
+	if len(privKeys) > 0 {
+		privKeysCc, err := encconfig.DecryptWithPrivKeys(privKeys, privKeysPasswords)
+		if err != nil {
+			return encconfig.CryptoConfig{}, err
+		}
+		ccs = append(ccs, privKeysCc)
+	}
+	if len(pkcs11Yamls) > 0 {
+		p11conf, err := pkcs11config.GetUserPkcs11Config()
+		if err != nil {
+			return encconfig.CryptoConfig{}, err
+		}
+		pkcs11PrivKeysCc, err := encconfig.DecryptWithPkcs11Yaml(p11conf, pkcs11Yamls)
+		if err != nil {
+			return encconfig.CryptoConfig{}, err
+		}
+		ccs = append(ccs, pkcs11PrivKeysCc)
+	}
+	if len(keyProviders) > 0 {
+		keyProviderCc, err := encconfig.DecryptWithKeyProvider(keyProviders)
+		if err != nil {
+			return encconfig.CryptoConfig{}, err
+		}
+		ccs = append(ccs, keyProviderCc)
+	}
+	return encconfig.CombineCryptoConfigs(ccs), nil
+}
+
+// CreateCryptoConfig from the list of recipient strings and list of key paths of private keys
+func CreateCryptoConfig(recipients []string, keys []string) (encconfig.CryptoConfig, error) {
+	var decryptCc *encconfig.CryptoConfig
+	ccs := []encconfig.CryptoConfig{}
+	if len(keys) > 0 {
+		dcc, err := CreateDecryptCryptoConfig(keys, []string{})
+		if err != nil {
+			return encconfig.CryptoConfig{}, err
+		}
+		decryptCc = &dcc
+		ccs = append(ccs, dcc)
+	}
+
+	if len(recipients) > 0 {
+		gpgRecipients, pubKeys, x509s, pkcs11Pubkeys, pkcs11Yamls, keyProvider, err := processRecipientKeys(recipients)
+		if err != nil {
+			return encconfig.CryptoConfig{}, err
+		}
+		encryptCcs := []encconfig.CryptoConfig{}
+
+		// Create GPG client with guessed GPG version and default homedir
+		gpgClient, err := ocicrypt.NewGPGClient("", "")
+		gpgInstalled := err == nil
+		if len(gpgRecipients) > 0 && gpgInstalled {
+			gpgPubRingFile, err := gpgClient.ReadGPGPubRingFile()
+			if err != nil {
+				return encconfig.CryptoConfig{}, err
+			}
+
+			gpgCc, err := encconfig.EncryptWithGpg(gpgRecipients, gpgPubRingFile)
+			if err != nil {
+				return encconfig.CryptoConfig{}, err
+			}
+			encryptCcs = append(encryptCcs, gpgCc)
+		}
+
+		// Create Encryption Crypto Config
+		if len(x509s) > 0 {
+			pkcs7Cc, err := encconfig.EncryptWithPkcs7(x509s)
+			if err != nil {
+				return encconfig.CryptoConfig{}, err
+			}
+			encryptCcs = append(encryptCcs, pkcs7Cc)
+		}
+		if len(pubKeys) > 0 {
+			jweCc, err := encconfig.EncryptWithJwe(pubKeys)
+			if err != nil {
+				return encconfig.CryptoConfig{}, err
+			}
+			encryptCcs = append(encryptCcs, jweCc)
+		}
+		var p11conf *pkcs11.Pkcs11Config
+		if len(pkcs11Yamls) > 0 || len(pkcs11Pubkeys) > 0 {
+			p11conf, err = pkcs11config.GetUserPkcs11Config()
+			if err != nil {
+				return encconfig.CryptoConfig{}, err
+			}
+			pkcs11Cc, err := encconfig.EncryptWithPkcs11(p11conf, pkcs11Pubkeys, pkcs11Yamls)
+			if err != nil {
+				return encconfig.CryptoConfig{}, err
+			}
+			encryptCcs = append(encryptCcs, pkcs11Cc)
+		}
+
+		if len(keyProvider) > 0 {
+			keyProviderCc, err := encconfig.EncryptWithKeyProvider(keyProvider)
+			if err != nil {
+				return encconfig.CryptoConfig{}, err
+			}
+			encryptCcs = append(encryptCcs, keyProviderCc)
+		}
+		ecc := encconfig.CombineCryptoConfigs(encryptCcs)
+		if decryptCc != nil {
+			ecc.EncryptConfig.AttachDecryptConfig(decryptCc.DecryptConfig)
+		}
+		ccs = append(ccs, ecc)
+	}
+
+	if len(ccs) > 0 {
+		return encconfig.CombineCryptoConfigs(ccs), nil
+	} else {
+		return encconfig.CryptoConfig{}, nil
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -184,7 +184,9 @@ github.com/containers/ocicrypt
 github.com/containers/ocicrypt/blockcipher
 github.com/containers/ocicrypt/config
 github.com/containers/ocicrypt/config/keyprovider-config
+github.com/containers/ocicrypt/config/pkcs11config
 github.com/containers/ocicrypt/crypto/pkcs11
+github.com/containers/ocicrypt/helpers
 github.com/containers/ocicrypt/keywrap
 github.com/containers/ocicrypt/keywrap/jwe
 github.com/containers/ocicrypt/keywrap/keyprovider


### PR DESCRIPTION
# Pull Request Summary

This pull request introduces the capability to decrypt models using the "pod" key in the CRI plugin.

Currently, the decryption of image layers is limited to keys that are pre-existing on the node. 
However, it may be impractical to prepopulate every node with the required keys. Additionally, the use of custom [key providers](https://github.com/containers/ocicrypt/blob/main/docs/keyprovider.md) to decrypt layers is not supported.

The pod key model addresses these limitations by leveraging the `io.containerd.cri.decryption-key` annotation set on the pod. This annotation helps determine the specific key to be used for decrypting the entire pod.
