### PR TITLE
[release/1.6]contrib/apparmor: remove code related to apparmor_parser version

### DIFF
--- a/contrib/apparmor/apparmor_test.go
+++ b/contrib/apparmor/apparmor_test.go
@@ -23,92 +23,9 @@ import (
 	"testing"
 )
 
-type versionExpected struct {
-	output  string
-	version int
-}
-
-func TestParseVersion(t *testing.T) {
-	versions := []versionExpected{
-		{
-			output: `AppArmor parser version 2.10
-Copyright (C) 1999-2008 Novell Inc.
-Copyright 2009-2012 Canonical Ltd.
-`,
-			version: 210000,
-		},
-		{
-			output: `AppArmor parser version 2.8
-Copyright (C) 1999-2008 Novell Inc.
-Copyright 2009-2012 Canonical Ltd.
-`,
-			version: 208000,
-		},
-		{
-			output: `AppArmor parser version 2.20
-Copyright (C) 1999-2008 Novell Inc.
-Copyright 2009-2012 Canonical Ltd.
-`,
-			version: 220000,
-		},
-		{
-			output: `AppArmor parser version 2.05
-Copyright (C) 1999-2008 Novell Inc.
-Copyright 2009-2012 Canonical Ltd.
-`,
-			version: 205000,
-		},
-		{
-			output: `AppArmor parser version 2.9.95
-Copyright (C) 1999-2008 Novell Inc.
-Copyright 2009-2012 Canonical Ltd.
-`,
-			version: 209095,
-		},
-		{
-			output: `AppArmor parser version 3.14.159
-Copyright (C) 1999-2008 Novell Inc.
-Copyright 2009-2012 Canonical Ltd.
-`,
-			version: 314159,
-		},
-		{
-			output: `AppArmor parser version 3.0.0-beta1
-Copyright (C) 1999-2008 Novell Inc.
-Copyright 2009-2018 Canonical Ltd.
-`,
-			version: 300000,
-		},
-		{
-			output: `AppArmor parser version 3.0.0-beta1-foo-bar
-Copyright (C) 1999-2008 Novell Inc.
-Copyright 2009-2018 Canonical Ltd.
-`,
-			version: 300000,
-		},
-		{
-			output: `AppArmor parser version 2.7.0~rc2
-Copyright (C) 1999-2008 Novell Inc.
-Copyright 2009-2018 Canonical Ltd.
-`,
-			version: 207000,
-		},
-	}
-
-	for _, v := range versions {
-		version, err := parseVersion(v.output)
-		if err != nil {
-			t.Fatalf("expected error to be nil for %#v, got: %v", v, err)
-		}
-		if version != v.version {
-			t.Fatalf("expected version to be %d, was %d, for: %#v\n", v.version, version, v)
-		}
-	}
-}
-
 func TestDumpDefaultProfile(t *testing.T) {
-	if _, err := getVersion(); err != nil {
-		t.Skipf("AppArmor not available: %+v", err)
+	if _, err := aaParser("--version"); err != nil {
+		t.Skipf("apparmor_parser not available: %+v", err)
 	}
 	name := "test-dump-default-profile"
 	prof, err := DumpDefaultProfile(name)


### PR DESCRIPTION
- [X] follow-up to https://github.com/containerd/containerd/pull/8068

This code was no longer used now that the version-dependent rules were
removed from the template in https://github.com/containerd/containerd/commit/30c893ec5cba64de1bca0a2a9d3f92423f3ec0d7.

Ref PR: https://github.com/containerd/containerd/pull/8069
Fixes: https://github.com/containerd/containerd/issues/9464