### PR TITLE
content: add a BlobReadSeeker to allow multipart blob uploads

### DIFF
--- a/core/content/helpers.go
+++ b/core/content/helpers.go
@@ -17,6 +17,7 @@
 package content
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -53,6 +54,31 @@ func NewReader(ra ReaderAt) io.Reader {
 		return rd.Reader()
 	}
 	return io.NewSectionReader(ra, 0, ra.Size())
+}
+
+type nopCloserBytesReader struct {
+	*bytes.Reader
+}
+
+func (*nopCloserBytesReader) Close() error { return nil }
+
+type nopCloserSectionReader struct {
+	*io.SectionReader
+}
+
+func (*nopCloserSectionReader) Close() error { return nil }
+
+// BlobReadSeeker returns a read seeker for the blob from the provider.
+func BlobReadSeeker(ctx context.Context, provider Provider, desc ocispec.Descriptor) (io.ReadSeekCloser, error) {
+	if int64(len(desc.Data)) == desc.Size && digest.FromBytes(desc.Data) == desc.Digest {
+		return &nopCloserBytesReader{bytes.NewReader(desc.Data)}, nil
+	}
+
+	ra, err := provider.ReaderAt(ctx, desc)
+	if err != nil {
+		return nil, err
+	}
+	return &nopCloserSectionReader{io.NewSectionReader(ra, 0, ra.Size())}, nil
 }
 
 // ReadBlob retrieves the entire contents of the blob from the provider.


### PR DESCRIPTION
A downstream library (related to uploading cache blobs in s3) needs a read seeker to be able to do its own multipart upload. 
This flattens the memory usage a lot in our case.

See: https://github.com/moby/buildkit/pull/4551

Feels like this could be an ok addition here, totally understand if you don't want it, or if you want it differently ( happy to update though ! ).


Edit: Here are some logs of a buildkit build with GC logs on:

Before(same image):
```
#31 preparing build cache for export
gc 75 @150.145s 0%: 0.018+1.0+0.004 ms clock, 0.29+0.14/3.9/5.5+0.071 ms cpu, 8344->8344->8344 MB, 8344 MB goal, 0 MB stacks, 0 MB globals, 16 P
gc 76 @150.188s 0%: 0.029+0.99+0.004 ms clock, 0.46+0.26/3.5/7.4+0.065 ms cpu, 8344->8344->8344 MB, 8344 MB goal, 0 MB stacks, 0 MB globals, 16 P
gc 77 @150.536s 0%: 0.035+0.99+0.003 ms clock, 0.57+0.098/3.6/7.6+0.053 ms cpu, 8344->8344->8344 MB, 8344 MB goal, 0 MB stacks, 0 MB globals, 16 P
gc 78 @150.556s 0%: 0.022+2.1+0.13 ms clock, 0.35+0.18/4.2/9.6+2.1 ms cpu, 8344->8349->8345 MB, 8344 MB goal, 0 MB stacks, 0 MB globals, 16 P
gc 79 @150.559s 0%: 0.049+1.7+0.005 ms clock, 0.78+0.15/5.3/5.5+0.091 ms cpu, 8345->8346->8345 MB, 8345 MB goal, 0 MB stacks, 0 MB globals, 16 P
```
After:
```
#31 preparing build cache for export 73.7s done
gc 9 @152.991s 0%: 0.038+0.49+0.063 ms clock, 0.61+0.054/1.0/0.87+1.0 ms cpu, 4->5->2 MB, 5 MB goal, 0 MB stacks, 0 MB globals, 16 P
```