### PR TITLE
Set LimitNOFILE=1048576 in containerd.service

### DIFF
--- a/containerd.service
+++ b/containerd.service
@@ -31,6 +31,8 @@ RestartSec=5
 # in the kernel. We recommend using cgroups to do container-local accounting.
 LimitNPROC=infinity
 LimitCORE=infinity
+# 1048576 (soft and hard) was the default before systemd 240
+LimitNOFILE=1048576
 
 # Comment TasksMax if your systemd version does not supports it.
 # Only systemd 226 and above support this version.


### PR DESCRIPTION
LimitNOFILE was either 1048576 or infinity since 2017 https://github.com/containerd/containerd/commit/b009642e1accccb128e96652ee019d4a01eddbfc
This means soft limit was at a minimum 1048576 since then.

Since systemd 240, infinity is 1073741816 which causes issue, and we must for sure lower the hard limit.

Removing LimitNOFILE is equivalent to 1024:524288, which is the standard on the host,
but was not containerd default since 2017, so when AWS recently tried they had to revert:
https://github.com/awslabs/amazon-eks-ami/issues/1551

1048576:1048576 has been good since 2017, use that.