### PR TITLE
[release/1.7] Enable CDI by default

### DIFF
--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -220,7 +220,13 @@ version = 2
   # enable_cdi enables support of the Container Device Interface (CDI)
   # For more details about CDI and the syntax of CDI Spec files please refer to
   # https://github.com/container-orchestrated-devices/container-device-interface.
-  enable_cdi = false
+  # TODO: Deprecate this option when either Dynamic Resource Allocation(DRA)
+  # or CDI support for the Device Plugins are graduated to GA.
+  # `Dynamic Resource Allocation` KEP:
+  # https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/3063-dynamic-resource-allocation
+  # `Add CDI devices to device plugin API` KEP:
+  # https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4009-add-cdi-devices-to-device-plugin-api
+  enable_cdi = true
 
   # cdi_spec_dirs is the list of directories to scan for CDI spec files
   # For more details about CDI configuration please refer to

--- a/pkg/cri/config/config_unix.go
+++ b/pkg/cri/config/config_unix.go
@@ -105,7 +105,7 @@ func DefaultConfig() PluginConfig {
 		ImageDecryption: ImageDecryption{
 			KeyModel: KeyModelNode,
 		},
-		EnableCDI:                false,
+		EnableCDI:                true,
 		CDISpecDirs:              []string{"/etc/cdi", "/var/run/cdi"},
 		ImagePullProgressTimeout: defaultImagePullProgressTimeoutDuration.String(),
 		DrainExecSyncIOTimeout:   "0s",


### PR DESCRIPTION
(cherry picked from commit c8e8a093ce3dd9231173042e9828a679972f5d6b)

Reasoning here is the same as for [original PR](https://github.com/containerd/containerd/pull/9621):

- CDI support is required by the [Kubernetes Device Plugin framework](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4009-add-cdi-devices-to-device-plugin-api)
- The support is [enabled by default in the Kubernetes 1.29](https://github.com/kubernetes/kubernetes/blob/v1.29.0/pkg/features/kube_features.go#L1047).

It would be great to have it enabled by default in Containerd.