### PR TITLE
shim v2: should support containerd/rust-extensions.

### DIFF
--- a/client/task.go
+++ b/client/task.go
@@ -690,7 +690,7 @@ func isCheckpointPathExist(runtime string, v interface{}) bool {
 	}
 
 	switch runtime {
-	case plugins.RuntimeRuncV2:
+	case plugins.RuntimeRuncV2, plugins.RuntimeRuncV2Rs:
 		if opts, ok := v.(*options.CheckpointOptions); ok && opts.ImagePath != "" {
 			return true
 		}

--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -619,7 +619,7 @@ func GenerateRuntimeOptions(r Runtime) (interface{}, error) {
 // getRuntimeOptionsType gets empty runtime options by the runtime type name.
 func getRuntimeOptionsType(t string) interface{} {
 	switch t {
-	case plugins.RuntimeRuncV2:
+	case plugins.RuntimeRuncV2, plugins.RuntimeRuncV2Rs:
 		return &runcoptions.Options{}
 	case plugins.RuntimeRunhcsV1:
 		return &runhcsoptions.Options{}

--- a/plugins/types.go
+++ b/plugins/types.go
@@ -75,6 +75,10 @@ const (
 	// RuntimeRuncV2 is the runc runtime that supports multiple containers per shim
 	RuntimeRuncV2 = "io.containerd.runc.v2"
 
+	// RuntimeRuncV2Rs is the runc runtime that supports multiple containers per shim which
+	// written by rust.
+	RuntimeRuncV2Rs = "io.containerd.runc.v2-rs"
+
 	// RuntimeRunhcsV1 is the runtime type for runhcs.
 	RuntimeRunhcsV1 = "io.containerd.runhcs.v1"
 


### PR DESCRIPTION
    If we set up [plugins." io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
    field, rust shim will get an error but goshim will not. This is because if we use
    goshim, containerd will send the Options struct in oci.pb.go, but if we use rust shim,
    containerd will send the Options struct in api.pb.go. The Options struct in oci.pb.go
    will use the proto method to send all the fields, but api.pb.go will use toml to send
    all the fields. Rust shim deal with the input from containerd using proto method, so
    containerd should use oci.pb.go's Options struct when we use rust shim.