### PR TITLE
Remove walker diff plugin for Windows

### DIFF
--- a/cmd/containerd/builtins/builtins.go
+++ b/cmd/containerd/builtins/builtins.go
@@ -21,7 +21,6 @@ import (
 	_ "github.com/containerd/containerd/v2/core/runtime/v2"
 	_ "github.com/containerd/containerd/v2/pkg/events/plugin"
 	_ "github.com/containerd/containerd/v2/pkg/nri/plugin"
-	_ "github.com/containerd/containerd/v2/plugins/diff/walking/plugin"
 	_ "github.com/containerd/containerd/v2/plugins/gc"
 	_ "github.com/containerd/containerd/v2/plugins/imageverifier"
 	_ "github.com/containerd/containerd/v2/plugins/leases"

--- a/cmd/containerd/builtins/builtins_freebsd.go
+++ b/cmd/containerd/builtins/builtins_freebsd.go
@@ -19,3 +19,5 @@ package builtins
 // Temporarily removed while plugin package is moved, to be added back
 // before 2.0.
 //import _ "github.com/containerd/zfs/plugin"
+
+import _ "github.com/containerd/containerd/v2/plugins/diff/walking/plugin"

--- a/cmd/containerd/builtins/builtins_linux.go
+++ b/cmd/containerd/builtins/builtins_linux.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/containerd/containerd/v2/core/metrics/cgroups"
 	_ "github.com/containerd/containerd/v2/core/metrics/cgroups/v2"
 	_ "github.com/containerd/containerd/v2/core/runtime/v2/runc/options"
+	_ "github.com/containerd/containerd/v2/plugins/diff/walking/plugin"
 	_ "github.com/containerd/containerd/v2/plugins/snapshots/blockfile/plugin"
 	_ "github.com/containerd/containerd/v2/plugins/snapshots/native/plugin"
 	_ "github.com/containerd/containerd/v2/plugins/snapshots/overlay/plugin"

--- a/cmd/containerd/builtins/builtins_unix.go
+++ b/cmd/containerd/builtins/builtins_unix.go
@@ -19,6 +19,7 @@
 package builtins
 
 import (
+	_ "github.com/containerd/containerd/v2/plugins/diff/walking/plugin"
 	_ "github.com/containerd/containerd/v2/plugins/snapshots/blockfile/plugin"
 	_ "github.com/containerd/containerd/v2/plugins/snapshots/native/plugin"
 )


### PR DESCRIPTION
The walker plugin isn't used on Windows so it shouldn't be loaded. It results in:

```
ctr: rpc error: code = Unknown desc = failed to extract layer sha256:14cf21987a8be92c5cd8ca93777bdf9535cd176cc50ff972ab8f93e884fe7e30: failed to mount C:\Users\jstur\AppData\Local\Temp\containerd-mount4084806450: no Files folder in layer 2081
```

Fixes https://github.com/containerd/containerd/issues/8563

After https://github.com/containerd/containerd/pull/9432 the local transfer service fails to pull Windows containers because it incorrectly selects the wrong differ. See https://github.com/containerd/containerd/issues/8563 for details on the failures with the transfer service.

The issue arises because the `platform.Parse`/`Format` doesn't pass the all the required info and would be fixed by https://github.com/containerd/containerd/pull/9609 allowing it to select the correct differ. In this case we still can't use the walker so we should remove it from Windows default configuration.



