### PR TITLE
seccomp: kernel 6.7

### DIFF
--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -64,6 +64,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				"alarm",
 				"bind",
 				"brk",
+				"cachestat", // kernel v6.5, libseccomp v2.5.5
 				"capget",
 				"capset",
 				"chdir",
@@ -109,6 +110,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				"fchdir",
 				"fchmod",
 				"fchmodat",
+				"fchmodat2", // kernel v6.6, libseccomp v2.5.5
 				"fchown",
 				"fchown32",
 				"fchownat",
@@ -130,8 +132,11 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				"ftruncate",
 				"ftruncate64",
 				"futex",
+				"futex_requeue", // kernel v6.7, libseccomp v2.5.5
 				"futex_time64",
+				"futex_wait", // kernel v6.7, libseccomp v2.5.5
 				"futex_waitv",
+				"futex_wake", // kernel v6.7, libseccomp v2.5.5
 				"futimesat",
 				"getcpu",
 				"getcwd",
@@ -214,6 +219,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				"mlock",
 				"mlock2",
 				"mlockall",
+				"map_shadow_stack", // kernel v6.6, libseccomp v2.5.5
 				"mmap",
 				"mmap2",
 				"mprotect",
@@ -671,6 +677,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 					"get_mempolicy",
 					"mbind",
 					"set_mempolicy",
+					"set_mempolicy_home_node", // kernel v5.17, libseccomp v2.5.4
 				},
 				Action: specs.ActAllow,
 				Args:   []specs.LinuxSeccompArg{},


### PR DESCRIPTION
The following syscalls were added since kernel v5.16 (34f7173491c45cca5c19643b54cc6f9fe0f92f04):
- v5.17 (libseccomp v2.5.4): set_mempolicy_home_node
- v6.5  (libseccomp v2.5.5): cachestat
- v6.6  (libseccomp v2.5.5): fchmodat2, map_shadow_stack
- v6.7  (libseccomp v2.5.5): futex_wake, futex_wait, futex_requeue

[Not covered in this commit]
- v6.8-rc1: statmount, listmount, lsm_get_self_attr, lsm_set_self_attr, lsm_list_modules

ref:
- `syscalls: update the syscall list for Linux v5.17` (libseccomp v2.5.4) https://github.com/seccomp/libseccomp/commit/d83cb7ac252db91e9ca9c372ea4743e02ba97c50
- `all: update the syscall table for Linux v6.7-rc3`  (libseccomp v2.5.5) https://github.com/seccomp/libseccomp/commit/53267af3fb56eed93a50b8ef92f41825c97a7813