### PR TITLE
feat. Extending hosts-dir feature w/ wildcard matching

### DIFF
--- a/core/remotes/docker/config/config_unix.go
+++ b/core/remotes/docker/config/config_unix.go
@@ -31,8 +31,14 @@ func hostPaths(root, host string) (hosts []string) {
 
 	hosts = append(hosts,
 		filepath.Join(root, host),
-		filepath.Join(root, "_default"),
 	)
+
+	wildcards := hostDirectoryScanWildcards(root, host)
+	if len(wildcards) > 0 {
+		hosts = append(hosts, wildcards...)
+	}
+
+	hosts = append(hosts, "_default")
 
 	return
 }

--- a/core/remotes/docker/config/config_windows.go
+++ b/core/remotes/docker/config/config_windows.go
@@ -30,8 +30,14 @@ func hostPaths(root, host string) (hosts []string) {
 
 	hosts = append(hosts,
 		filepath.Join(root, strings.Replace(host, ":", "", -1)),
-		filepath.Join(root, "_default"),
 	)
+
+	wildcards := hostDirectoryScanWildcards(root, host)
+	for _, w := range wildcards {
+		hosts = append(hosts, strings.Replace(w, ":", "", -1))
+	}
+
+	hosts = append(hosts, filepath.Join(root, "_default"))
 
 	return
 }

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -190,6 +190,31 @@ $ cat /etc/containerd/certs.d/_default/hosts.toml
 server = "https://registry.example.com"
 ```
 
+### Setup Wildcard Mirror for Registries
+
+This is an example of using a mirror for registries using a wildcard prefix pattern.
+
+Multiple wildcard patterns can be used to match. Given the following:
+
+```
+$ tree /etc/containerd/certs.d
+/etc/containerd/certs.d
+└── _.registry.io
+    └── hosts.toml
+└── _.io
+    └── hosts.toml
+└── _default
+    └── hosts.toml
+```
+
+A host such as `test.regsitry.io` would try the hosts configs in the following order `_.registry.io` -> `_.io` -> `_default`.
+
+Where-as, a host such as `test.docker.io` would try the hosts configs `_.io`, and `_default`.
+
+The directories are sorted in descending order based on path length, meaning that `_.registry.io` should always take
+precedence over `_.io`.
+
+
 ### Bypass TLS Verification Example
 
 To bypass the TLS verification for a private registry at `192.168.31.250:5000`


### PR DESCRIPTION
- This supports multi-tenant registries who support multiple registries using the same host domain.

This is a redo of the previous PR #7758  and  Addresses #7757.



