### PR TITLE
Disable Links workflow in forks 

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    if: github.repository == 'containerd/containerd'
     name: lychee
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
Should be disabled in forks 

Fixes https://github.com/containerd/containerd/issues/9701