### PR TITLE
Add copts.defaultRuntime to NewWithConn() when it is specify the ops.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -196,6 +196,14 @@ func NewWithConn(conn *grpc.ClientConn, opts ...Opt) (*Client, error) {
 		c.platform = platforms.Default()
 	}
 
+	if copts.defaultRuntime != "" {
+		c.runtime = copts.defaultRuntime
+	}
+
+	if copts.services != nil {
+		c.services = *copts.services
+	}
+
 	// check namespace labels for default runtime
 	if copts.defaultRuntime == "" && c.defaultns != "" {
 		if label, err := c.GetLabel(context.Background(), defaults.DefaultRuntimeNSLabel); err != nil {


### PR DESCRIPTION
/kind cleanup
/kind bug

We should not omit the ```copts.defaultRuntime``` when it is actually passd in from the Outer of Method ```func NewWithConn(```

Demo code: 
```
import (
	containerd "github.com/containerd/containerd/v2/client"
) 
func main(){
xxx

containerd.NewWithConn(xxx)

xxx
}

```
If before conn has set the runtime , when use the containerd.NewWithConn() , will drop the before runtime set , and use default set .

