### PR TITLE
cri: make read-only mounts recursively read-only

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -461,6 +461,25 @@ version = 2
 
 </p></details>
 
+## Other breaking changes
+### containerd v2.0
+#### CRI plugin treats read-only mounts recursively read-only
+Starting with containerd v2.0, the CRI plugin treats read-only mounts
+as recursively read-only mounts when running on Linux kernel v5.12 or later.
+
+To rollback to the legacy behavior that corresponds to containerd v1.x,
+set the following config:
+```toml
+version = 2
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+  # treat_ro_mounts_as_rro ("Enabled"|"IfPossible"|"Disabled")
+  # treats read-only mounts as recursive read-only mounts.
+  # An empty string means "IfPossible".
+  # "Enabled" requires Linux kernel v5.12 or later.
+  # This configuration does not apply to non-volume mounts such as "/sys/fs/cgroup".
+  treat_ro_mounts_as_rro = "Disabled"
+```
+
 ## Experimental features
 
 Experimental features are new features added to containerd which do not have the

--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -369,6 +369,14 @@ version = 2
       # See https://github.com/containerd/containerd/issues/6657 for context.
       snapshotter = ""
 
+      # treat_ro_mounts_as_rro ("Enabled"|"IfPossible"|"Disabled")
+      # treats read-only mounts as recursive read-only mounts.
+      # An empty string means "IfPossible".
+      # "Enabled" requires Linux kernel v5.12 or later.
+      # Introduced in containerd v2.0.
+      # This configuration does not apply to non-volume mounts such as "/sys/fs/cgroup".
+      treat_ro_mounts_as_rro = ""
+
       # 'plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options' is options specific to
       # "io.containerd.runc.v1" and "io.containerd.runc.v2". Its corresponding options type is:
       #   https://github.com/containerd/containerd/blob/v1.3.2/runtime/v2/runc/options/oci.pb.go#L26 .

--- a/integration/container_volume_linux_test.go
+++ b/integration/container_volume_linux_test.go
@@ -1,0 +1,149 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/containerd/containerd/v2/integration/images"
+	"github.com/containerd/containerd/v2/pkg/kernelversion"
+	"github.com/opencontainers/selinux/go-selinux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+func testReadonlyMounts(t *testing.T, mode string, expectRRO bool) {
+	workDir := t.TempDir()
+	mntSrcDir := filepath.Join(workDir, "mnt") // "/mnt" in the container
+	require.NoError(t, os.MkdirAll(mntSrcDir, 0755))
+	tmpfsDir := filepath.Join(mntSrcDir, "tmpfs") // "/mnt/tmpfs" in the container
+	require.NoError(t, os.MkdirAll(tmpfsDir, 0755))
+	tmpfsMount := mount.Mount{
+		Type:   "tmpfs",
+		Source: "none",
+	}
+	require.NoError(t, tmpfsMount.Mount(tmpfsDir))
+	t.Cleanup(func() {
+		require.NoError(t, mount.UnmountAll(tmpfsDir, 0))
+	})
+
+	podLogDir := filepath.Join(workDir, "podLogDir")
+	require.NoError(t, os.MkdirAll(podLogDir, 0755))
+
+	config := `version = 2
+`
+	if mode != "" {
+		config += fmt.Sprintf(`
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+  treat_ro_mount_as_rro = %q
+`, mode)
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "config.toml"),
+		[]byte(config), 0644))
+	ctrdProc := newCtrdProc(t, "containerd", workDir)
+	t.Cleanup(func() {
+		cleanupPods(t, ctrdProc.criRuntimeService(t))
+		require.NoError(t, ctrdProc.kill(syscall.SIGTERM))
+		require.NoError(t, ctrdProc.wait(5*time.Minute))
+		if t.Failed() {
+			dumpFileContent(t, ctrdProc.logPath())
+		}
+	})
+	runtimeServiceOrig, imageServiceOrig := runtimeService, imageService
+	runtimeService, imageService = ctrdProc.criRuntimeService(t), ctrdProc.criImageService(t)
+	t.Cleanup(func() {
+		runtimeService, imageService = runtimeServiceOrig, imageServiceOrig
+	})
+	require.NoError(t, ctrdProc.isReady())
+
+	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "test-ro-mounts",
+		WithPodLogDirectory(podLogDir),
+	)
+
+	testImage := images.Get(images.BusyBox)
+	EnsureImageExists(t, testImage)
+
+	containerName := "test-container"
+	cnConfig := ContainerConfig(
+		containerName,
+		testImage,
+		WithCommand("/bin/touch", "/mnt/tmpfs/file"),
+		WithLogPath(containerName),
+		func(c *runtime.ContainerConfig) {
+			c.Mounts = append(c.Mounts, &runtime.Mount{
+				HostPath:       mntSrcDir,
+				ContainerPath:  "/mnt",
+				SelinuxRelabel: selinux.GetEnabled(),
+				Readonly:       true,
+			})
+		},
+	)
+
+	cn, err := runtimeService.CreateContainer(sb, cnConfig, sbConfig)
+	require.NoError(t, err)
+
+	t.Log("Start the container")
+	require.NoError(t, runtimeService.StartContainer(cn))
+
+	t.Log("Wait for container to finish running")
+	exitCode := -1
+	require.NoError(t, Eventually(func() (bool, error) {
+		s, err := runtimeService.ContainerStatus(cn)
+		if err != nil {
+			return false, err
+		}
+		if s.GetState() == runtime.ContainerState_CONTAINER_EXITED {
+			exitCode = int(s.ExitCode)
+			return true, nil
+		}
+		return false, nil
+	}, time.Second, 30*time.Second))
+
+	output, err := os.ReadFile(filepath.Join(podLogDir, containerName))
+	assert.NoError(t, err)
+	t.Logf("exitCode=%d, output=%q", exitCode, output)
+
+	if expectRRO {
+		require.NotEqual(t, 0, exitCode)
+		require.Contains(t, string(output), "stderr F touch: /mnt/tmpfs/file: Read-only file system\n")
+	} else {
+		require.Equal(t, 0, exitCode)
+	}
+}
+
+func TestReadonlyMounts(t *testing.T) {
+	kernelSupportsRRO, err := kernelversion.GreaterEqualThan(kernelversion.KernelVersion{Kernel: 5, Major: 12})
+	require.NoError(t, err)
+	t.Run("Default", func(t *testing.T) {
+		testReadonlyMounts(t, "", kernelSupportsRRO)
+	})
+	t.Run("Disabled", func(t *testing.T) {
+		testReadonlyMounts(t, "Disabled", false)
+	})
+	if kernelSupportsRRO {
+		t.Run("Enabled", func(t *testing.T) {
+			testReadonlyMounts(t, "Enabled", true)
+		})
+	}
+}

--- a/pkg/cri/config/config_kernel_linux.go
+++ b/pkg/cri/config/config_kernel_linux.go
@@ -41,3 +41,13 @@ func ValidateEnableUnprivileged(ctx context.Context, c *RuntimeConfig) error {
 	}
 	return nil
 }
+
+var kernelSupportsRro bool
+
+func init() {
+	var err error
+	kernelSupportsRro, err = kernelGreaterEqualThan(kernel.KernelVersion{Kernel: 5, Major: 12})
+	if err != nil {
+		panic(fmt.Errorf("check current system kernel version error: %w", err))
+	}
+}

--- a/pkg/cri/config/config_kernel_other.go
+++ b/pkg/cri/config/config_kernel_other.go
@@ -25,3 +25,5 @@ import (
 func ValidateEnableUnprivileged(ctx context.Context, c *RuntimeConfig) error {
 	return nil
 }
+
+var kernelSupportsRro bool

--- a/pkg/cri/config/config_test.go
+++ b/pkg/cri/config/config_test.go
@@ -222,7 +222,7 @@ func TestValidateConfig(t *testing.T) {
 		t.Run(desc, func(t *testing.T) {
 			var warnings []deprecation.Warning
 			if test.runtimeConfig != nil {
-				w, err := ValidateRuntimeConfig(context.Background(), test.runtimeConfig)
+				w, err := ValidateRuntimeConfig(context.Background(), test.runtimeConfig, nil)
 				if test.runtimeExpectedErr != "" {
 					assert.Contains(t, err.Error(), test.runtimeExpectedErr)
 				} else {

--- a/pkg/cri/opts/spec_linux_opts.go
+++ b/pkg/cri/opts/spec_linux_opts.go
@@ -38,8 +38,14 @@ import (
 	"github.com/containerd/log"
 )
 
+// RuntimeConfig is a subset of [github.com/containerd/containerd/v2/pkg/cri/config].
+// Needed for avoiding circular imports.
+type RuntimeConfig struct {
+	TreatRoMountsAsRro bool // only applies to volumes
+}
+
 // WithMounts sorts and adds runtime and CRI mounts to the spec
-func WithMounts(osi osinterface.OS, config *runtime.ContainerConfig, extra []*runtime.Mount, mountLabel string) oci.SpecOpts {
+func WithMounts(osi osinterface.OS, config *runtime.ContainerConfig, extra []*runtime.Mount, mountLabel string, rtConfig *RuntimeConfig) oci.SpecOpts {
 	return func(ctx context.Context, client oci.Client, _ *containers.Container, s *runtimespec.Spec) (err error) {
 		// mergeMounts merge CRI mounts with extra mounts. If a mount destination
 		// is mounted by both a CRI mount and an extra mount, the CRI mount will
@@ -67,6 +73,7 @@ func WithMounts(osi osinterface.OS, config *runtime.ContainerConfig, extra []*ru
 		sort.Sort(orderedMounts(mounts))
 
 		// Mount cgroup into the container as readonly, which inherits docker's behavior.
+		// TreatRoMountsAsRro does not apply here, as /sys/fs/cgroup is not a volume.
 		s.Mounts = append(s.Mounts, runtimespec.Mount{
 			Source:      "cgroup",
 			Destination: "/sys/fs/cgroup",
@@ -148,10 +155,25 @@ func WithMounts(osi osinterface.OS, config *runtime.ContainerConfig, extra []*ru
 				options = append(options, "rprivate")
 			}
 
+			var srcIsDir bool
+			if srcSt, err := osi.Stat(src); err != nil {
+				if errors.Is(err, os.ErrNotExist) { // happens when osi is FakeOS
+					srcIsDir = true // assume src to be dir
+				} else {
+					return fmt.Errorf("failed to stat mount source %q: %w", src, err)
+				}
+			} else if srcSt != nil { // srcSt can be nil when osi is FakeOS
+				srcIsDir = srcSt.IsDir()
+			}
+
 			// NOTE(random-liu): we don't change all mounts to `ro` when root filesystem
 			// is readonly. This is different from docker's behavior, but make more sense.
 			if mount.GetReadonly() {
-				options = append(options, "ro")
+				if rtConfig != nil && rtConfig.TreatRoMountsAsRro && srcIsDir {
+					options = append(options, "rro")
+				} else {
+					options = append(options, "ro")
+				}
 			} else {
 				options = append(options, "rw")
 			}

--- a/pkg/cri/server/container_create.go
+++ b/pkg/cri/server/container_create.go
@@ -683,7 +683,9 @@ func (c *criService) buildLinuxSpec(
 		}
 	}()
 
-	specOpts = append(specOpts, customopts.WithMounts(c.os, config, extraMounts, mountLabel))
+	specOpts = append(specOpts, customopts.WithMounts(c.os, config, extraMounts, mountLabel, &customopts.RuntimeConfig{
+		TreatRoMountsAsRro: ociRuntime.TreatRoMountsAsRroResolved,
+	}))
 
 	if !c.config.DisableProcMount {
 		// Change the default masked/readonly paths to empty slices

--- a/pkg/cri/server/container_create_linux_test.go
+++ b/pkg/cri/server/container_create_linux_test.go
@@ -597,7 +597,7 @@ func TestMountPropagation(t *testing.T) {
 			var spec runtimespec.Spec
 			spec.Linux = &runtimespec.Linux{}
 
-			err := opts.WithMounts(c.os, config, []*runtime.Mount{test.criMount}, "")(context.Background(), nil, nil, &spec)
+			err := opts.WithMounts(c.os, config, []*runtime.Mount{test.criMount}, "", nil)(context.Background(), nil, nil, &spec)
 			if test.expectErr {
 				require.Error(t, err)
 			} else {

--- a/plugins/cri/runtime/plugin.go
+++ b/plugins/cri/runtime/plugin.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 
+	introspectionapi "github.com/containerd/containerd/v2/api/services/introspection/v1"
 	"github.com/containerd/log"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
@@ -35,6 +36,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/cri/constants"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/containerd/v2/plugins"
+	"github.com/containerd/containerd/v2/plugins/services"
 	"github.com/containerd/containerd/v2/plugins/services/warning"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
@@ -50,6 +52,7 @@ func init() {
 		Config: &config,
 		Requires: []plugin.Type{
 			plugins.WarningPlugin,
+			plugins.ServicePlugin,
 		},
 		ConfigMigration: func(ctx context.Context, version int, pluginConfigs map[string]interface{}) error {
 			if version >= srvconfig.CurrentConfigVersion {
@@ -73,7 +76,18 @@ func initCRIRuntime(ic *plugin.InitContext) (interface{}, error) {
 	ic.Meta.Exports = map[string]string{"CRIVersion": constants.CRIVersion}
 	ctx := ic.Context
 	pluginConfig := ic.Config.(*criconfig.RuntimeConfig)
-	if warnings, err := criconfig.ValidateRuntimeConfig(ctx, pluginConfig); err != nil {
+
+	introspectionService, err := ic.GetByID(plugins.ServicePlugin, services.IntrospectionService)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get plugin (%q, %q): %w",
+			plugins.ServicePlugin, services.IntrospectionService, err)
+	}
+	introspectionClient, ok := introspectionService.(introspectionapi.IntrospectionClient)
+	if !ok {
+		return nil, fmt.Errorf("%+v does not implement IntrospectionClient interfae", introspectionService)
+	}
+
+	if warnings, err := criconfig.ValidateRuntimeConfig(ctx, pluginConfig, introspectionClient); err != nil {
 		return nil, fmt.Errorf("invalid plugin config: %w", err)
 	} else if len(warnings) > 0 {
 		ws, err := ic.GetSingle(plugins.WarningPlugin)


### PR DESCRIPTION
Prior to this commit, `readOnly` volumes were not recursively read-only and could result in compromise of data;
e.g., even if `/mnt` was mounted as read-only, its submounts such as `/mnt/usbstorage` were not read-only.

This commit utilizes runc's "rro" bind mount option to make read-only bind mounts literally read-only. The "rro" bind mount options is implemented by calling `mount_setattr(2)` with `MOUNT_ATTR_RDONLY` and `AT_RECURSIVE`.

The "rro" bind mount options requires kernel >= 5.12, with runc >= 1.1 or a compatible runtime such as crun >= 1.4.

When the "rro" bind mount options is not available, containerd falls back to the legacy non-recursive read-only mounts by default.

The behavior is configurable via `/etc/containerd/config.toml`:
```toml
version = 2
[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
  # treat_ro_mounts_as_rro ("Enabled"|"IfPossible"|"Disabled")
  # treats read-only mounts as recursive read-only mounts.
  # An empty string means "IfPossible".
  # "Enabled" requires Linux kernel v5.12 or later.
  # This configuration does not apply to non-volume mounts such as "/sys/fs/cgroup".
  treat_ro_mounts_as_rro = ""
```

Replaces:
- kubernetes/enhancements#3857
- kubernetes/enhancements#3858

Note: this change does not affect non-CRI clients such as ctr, nerdctl, and Docker/Moby. RRO mounts have been supported since nerdctl v0.14 (containerd/nerdctl#511) and Docker v25 (moby/moby#45278).