### PR TITLE
Publish update/create events from Transfer service

### DIFF
--- a/pkg/transfer/image/imagestore_test.go
+++ b/pkg/transfer/image/imagestore_test.go
@@ -224,7 +224,7 @@ func TestStore(t *testing.T) {
 				desc.Annotations["io.containerd.import.ref-source"] = "annotation"
 			}
 			t.Run(name, func(t *testing.T) {
-				imgs, err := testCase.ImageStore.Store(context.Background(), desc, newSimpleImageStore())
+				imgs, err := testCase.ImageStore.Store(context.Background(), desc, newSimpleImageStore(), nil)
 				if err != nil {
 					if testCase.Err == nil {
 						t.Fatal(err)

--- a/pkg/transfer/local/import.go
+++ b/pkg/transfer/local/import.go
@@ -129,7 +129,7 @@ func (ts *localTransferService) importStream(ctx context.Context, i transfer.Ima
 
 	for _, desc := range descriptors {
 		desc := desc
-		imgs, err := is.Store(ctx, desc, ts.images)
+		imgs, err := is.Store(ctx, desc, ts.images, ts.publisher)
 		if err != nil {
 			if errdefs.IsNotFound(err) {
 				log.G(ctx).Infof("No images store for %s", desc.Digest)

--- a/pkg/transfer/local/pull.go
+++ b/pkg/transfer/local/pull.go
@@ -231,7 +231,7 @@ func (ts *localTransferService) pull(ctx context.Context, ir transfer.ImageFetch
 		}
 	}
 
-	imgs, err := is.Store(ctx, desc, ts.images)
+	imgs, err := is.Store(ctx, desc, ts.images, ts.publisher)
 	if err != nil {
 		return err
 	}

--- a/pkg/transfer/local/tag.go
+++ b/pkg/transfer/local/tag.go
@@ -34,6 +34,6 @@ func (ts *localTransferService) tag(ctx context.Context, ig transfer.ImageGetter
 		return err
 	}
 
-	_, err = is.Store(ctx, img.Target, ts.images)
+	_, err = is.Store(ctx, img.Target, ts.images, ts.publisher)
 	return err
 }

--- a/pkg/transfer/transfer.go
+++ b/pkg/transfer/transfer.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/pkg/events"
 )
 
 type Transferrer interface {
@@ -61,7 +62,7 @@ type ImageFilterer interface {
 // the provided descriptor. The descriptor may be any type of manifest
 // including an index with multiple image references.
 type ImageStorer interface {
-	Store(context.Context, ocispec.Descriptor, images.Store) ([]images.Image, error)
+	Store(context.Context, ocispec.Descriptor, images.Store, events.Publisher) ([]images.Image, error)
 }
 
 // ImageGetter is type which returns an image from an image store


### PR DESCRIPTION
Publish update/create events from Transfer service to update CRI's image store.

xref: https://github.com/containerd/containerd/issues/9725