### PR TITLE
Add a default differ for Windows that matches the snapshotter when using transfer service

### DIFF
--- a/defaults/defaults_differ_windows.go
+++ b/defaults/defaults_differ_windows.go
@@ -17,8 +17,7 @@
 package defaults
 
 const (
-	// DefaultSnapshotter will set the default snapshotter for the platform.
-	// This will be based on the client compilation target, so take that into
-	// account when choosing this value.
-	DefaultSnapshotter = "windows"
+	// DefaultDiffer will set the default differ for the platform.
+	// This differ should be compatible with the windows snapshotter.
+	DefaultDiffer = "windows"
 )

--- a/plugins/transfer/plugin.go
+++ b/plugins/transfer/plugin.go
@@ -22,7 +22,6 @@ import (
 	"github.com/containerd/containerd/v2/core/diff"
 	"github.com/containerd/containerd/v2/core/leases"
 	"github.com/containerd/containerd/v2/core/metadata"
-	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/pkg/imageverifier"
 	"github.com/containerd/containerd/v2/pkg/transfer/local"
 	"github.com/containerd/containerd/v2/pkg/unpack"
@@ -81,12 +80,7 @@ func init() {
 			// If UnpackConfiguration is not defined, set the default.
 			// If UnpackConfiguration is defined and empty, ignore.
 			if config.UnpackConfiguration == nil {
-				config.UnpackConfiguration = []unpackConfiguration{
-					{
-						Platform:    platforms.Format(platforms.DefaultSpec()),
-						Snapshotter: defaults.DefaultSnapshotter,
-					},
-				}
+				config.UnpackConfiguration = defaultUnpackConfig()
 			}
 			for _, uc := range config.UnpackConfiguration {
 				p, err := platforms.Parse(uc.Platform)
@@ -122,7 +116,7 @@ func init() {
 							continue
 						}
 						if applier != nil {
-							log.G(ic.Context).Warnf("multiple differs match for platform, set `differ` option to choose, skipping %q", name)
+							log.G(ic.Context).Warnf("multiple differs match for platform, set `differ` option to choose, skipping %q", plugin.Registration.ID)
 							continue
 						}
 						inst, err := plugin.Instance()

--- a/plugins/transfer/plugin_defaults_other.go
+++ b/plugins/transfer/plugin_defaults_other.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 /*
    Copyright The containerd Authors.
 
@@ -14,12 +16,18 @@
    limitations under the License.
 */
 
-package defaults
+package transfer
 
-const (
-	// DefaultSnapshotter will set the default snapshotter for the platform.
-	// This will be based on the client compilation target, so take that into
-	// account when choosing this value.
-	DefaultSnapshotter = "windows"
-	DefaultDiffer      = "windows"
+import (
+	"github.com/containerd/containerd/v2/defaults"
+	"github.com/containerd/platforms"
 )
+
+func defaultUnpackConfig() []unpackConfiguration {
+	return []unpackConfiguration{
+		{
+			Platform:    platforms.Format(platforms.DefaultSpec()),
+			Snapshotter: defaults.DefaultSnapshotter,
+		},
+	}
+}

--- a/plugins/transfer/plugin_defaults_windows.go
+++ b/plugins/transfer/plugin_defaults_windows.go
@@ -14,12 +14,19 @@
    limitations under the License.
 */
 
-package defaults
+package transfer
 
-const (
-	// DefaultSnapshotter will set the default snapshotter for the platform.
-	// This will be based on the client compilation target, so take that into
-	// account when choosing this value.
-	DefaultSnapshotter = "windows"
-	DefaultDiffer      = "windows"
+import (
+	"github.com/containerd/containerd/v2/defaults"
+	"github.com/containerd/platforms"
 )
+
+func defaultUnpackConfig() []unpackConfiguration {
+	return []unpackConfiguration{
+		{
+			Platform:    platforms.Format(platforms.DefaultSpec()),
+			Snapshotter: defaults.DefaultSnapshotter,
+			Differ:      defaults.DefaultDiffer,
+		},
+	}
+}


### PR DESCRIPTION
When using the transfer service on Windows 2022+ the additional differ causes the following error:

```
ctr -n k8s.io i pull docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess
docker.io/sigwindowstools/kube proxy:v1.        fetching image content
└──manifest (c48ba3477127)                      already exists
   ├──config (066f734ecf45)                     already exists
   ├──layer (034b2f457cdf)                      already exists
   ├──layer (ada5b21af3a9)                      already exists
   ├──layer (ed001f67f319)                      already exists
   └──layer (5cbcfd29d56a)                      already exists
application/vnd.docker.distribution.manifest.v2+json sha256:c48ba34771272db7411cd5151f2af179577d135e747c4f0f11c9e13250d69ca4
Pulling from OCI Registry (docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess)     elapsed: 0.4 s  total:  110.8   (305.1 MiB/s)
ctr: rpc error: code = Unimplemented desc = method Transfer not implemented for containerd.types.transfer.OCIRegistry to containerd.types.transfer.ImageStore
```