### PR TITLE
Remove duplicated TOML duration parsers

### DIFF
--- a/plugins/gc/scheduler.go
+++ b/plugins/gc/scheduler.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/containerd/containerd/v2/internal/tomlext"
 	"github.com/containerd/containerd/v2/pkg/gc"
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/log"
@@ -70,7 +71,7 @@ type config struct {
 	// schedule. Use suffix "ms" for millisecond and "s" for second.
 	//
 	// Default is "0ms"
-	ScheduleDelay duration `toml:"schedule_delay"`
+	ScheduleDelay tomlext.Duration `toml:"schedule_delay"`
 
 	// StartupDelay is the delay duration to do an initial garbage
 	// collection after startup. The initial garbage collection is used to
@@ -79,22 +80,7 @@ type config struct {
 	// "ms" for millisecond and "s" for second.
 	//
 	// Default is "100ms"
-	StartupDelay duration `toml:"startup_delay"`
-}
-
-type duration time.Duration
-
-func (d *duration) UnmarshalText(text []byte) error {
-	ed, err := time.ParseDuration(string(text))
-	if err != nil {
-		return err
-	}
-	*d = duration(ed)
-	return nil
-}
-
-func (d duration) MarshalText() (text []byte, err error) {
-	return []byte(time.Duration(d).String()), nil
+	StartupDelay tomlext.Duration `toml:"startup_delay"`
 }
 
 func init() {
@@ -108,8 +94,8 @@ func init() {
 			PauseThreshold:    0.02,
 			DeletionThreshold: 0,
 			MutationThreshold: 100,
-			ScheduleDelay:     duration(0),
-			StartupDelay:      duration(100 * time.Millisecond),
+			ScheduleDelay:     tomlext.FromStdTime(0),
+			StartupDelay:      tomlext.FromStdTime(100 * time.Millisecond),
 		},
 		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
 			md, err := ic.GetSingle(plugins.MetadataPlugin)

--- a/plugins/gc/scheduler_test.go
+++ b/plugins/gc/scheduler_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/containerd/v2/internal/tomlext"
 	"github.com/containerd/containerd/v2/pkg/gc"
 	"github.com/stretchr/testify/assert"
 )
@@ -152,7 +153,7 @@ func TestStartupDelay(t *testing.T) {
 		cfg          = &config{
 			// Prevent GC from scheduling again before check
 			PauseThreshold: 0.001,
-			StartupDelay:   duration(startupDelay),
+			StartupDelay:   tomlext.Duration(startupDelay),
 		}
 		tc = &testCollector{
 			d: time.Second,


### PR DESCRIPTION
Remove some duplicated duration parsers for TOML.
Consume one from `tomlext` package that we've introduced recently.