### PR TITLE
bug fix: make sure cri image is pinned when it is pulled outside cri

### DIFF
--- a/integration/containerd_image_test.go
+++ b/integration/containerd_image_test.go
@@ -237,6 +237,35 @@ func TestContainerdSandboxImage(t *testing.T) {
 	assert.True(t, pimg.Pinned)
 }
 
+func TestContainerdSandboxImagePulledOutsideCRI(t *testing.T) {
+	var pauseImage = images.Get(images.Pause)
+	ctx := context.Background()
+
+	t.Log("make sure the pause image does not exist")
+	imageService.RemoveImage(&runtime.ImageSpec{Image: pauseImage})
+
+	t.Log("pull pause image")
+	_, err := containerdClient.Pull(ctx, pauseImage)
+	assert.NoError(t, err)
+
+	t.Log("pause image should be seen by cri plugin")
+	var pimg *runtime.Image
+	require.NoError(t, Eventually(func() (bool, error) {
+		pimg, err = imageService.ImageStatus(&runtime.ImageSpec{Image: pauseImage})
+		return pimg != nil, err
+	}, time.Second, 10*time.Second))
+
+	t.Log("verify pinned field is set for pause image")
+	assert.True(t, pimg.Pinned)
+
+	t.Log("make sure the pause image exist")
+	pauseImg, err := containerdClient.GetImage(ctx, pauseImage)
+	require.NoError(t, err)
+
+	t.Log("ensure correct labels are set on pause image")
+	assert.Equal(t, "pinned", pauseImg.Labels()["io.cri-containerd.pinned"])
+}
+
 func TestContainerdImageWithDockerSchema1(t *testing.T) {
 	if goruntime.GOOS == "windows" {
 		t.Skip("Skipped on Windows because the test image is not a multi-platform one.")


### PR DESCRIPTION
Fixes: #9726 

Update the `CRIImageService.UpdateImage` routine to pass image ref to `getLabels` so that a CRI image could be correctly pinned if it's pulled outside of CRI, e.g. via `ctr image pull`.