### PR TITLE
Fix config import relative path glob

### DIFF
--- a/cmd/containerd/server/config/config.go
+++ b/cmd/containerd/server/config/config.go
@@ -375,6 +375,11 @@ func resolveImports(parent string, imports []string) ([]string, error) {
 	var out []string
 
 	for _, path := range imports {
+		path = filepath.Clean(path)
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(filepath.Dir(parent), path)
+		}
+
 		if strings.Contains(path, "*") {
 			matches, err := filepath.Glob(path)
 			if err != nil {
@@ -383,11 +388,6 @@ func resolveImports(parent string, imports []string) ([]string, error) {
 
 			out = append(out, matches...)
 		} else {
-			path = filepath.Clean(path)
-			if !filepath.IsAbs(path) {
-				path = filepath.Join(filepath.Dir(parent), path)
-			}
-
 			out = append(out, path)
 		}
 	}

--- a/cmd/containerd/server/config/config_test.go
+++ b/cmd/containerd/server/config/config_test.go
@@ -104,6 +104,17 @@ func TestResolveImports(t *testing.T) {
 		filepath.Join(tempDir, "test.toml"),
 		filepath.Join(tempDir, "current.toml"),
 	})
+
+	t.Run("GlobRelativePath", func(t *testing.T) {
+		imports, err := resolveImports(filepath.Join(tempDir, "root.toml"), []string{
+			"config_*.toml", // Glob files from working dir
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, imports, []string{
+			filepath.Join(tempDir, "config_1.toml"),
+			filepath.Join(tempDir, "config_2.toml"),
+		})
+	})
 }
 
 func TestLoadSingleConfig(t *testing.T) {


### PR DESCRIPTION
### Summary

Closes #9745 

### Notes

Previously, resolveImports would apply a glob filter if the path contained any '*', or otherwise convert relative paths to absolute. This meant that it was impossible to specify globs with paths relative to the main config file.

This commit first resolves relative to absolute paths, then applies the glob filter (if any). A test case is added to ensure that this now works as expected.