### PR TITLE
test: update upgrade test suite in integration

### DIFF
--- a/integration/cri-api/pkg/apis/services.go
+++ b/integration/cri-api/pkg/apis/services.go
@@ -120,7 +120,7 @@ type RuntimeService interface {
 	// UpdateRuntimeConfig updates runtime configuration if specified
 	UpdateRuntimeConfig(runtimeConfig *runtimeapi.RuntimeConfig, opts ...grpc.CallOption) error
 	// Status returns the status of the runtime.
-	Status(opts ...grpc.CallOption) (*runtimeapi.RuntimeStatus, error)
+	Status(opts ...grpc.CallOption) (*runtimeapi.StatusResponse, error)
 	// RuntimeConfig returns configuration information of the runtime.
 	// A couple of notes:
 	//   - The RuntimeConfigRequest object is not to be confused with the contents of UpdateRuntimeConfigRequest.

--- a/integration/issue7496_shutdown_linux_test.go
+++ b/integration/issue7496_shutdown_linux_test.go
@@ -51,7 +51,7 @@ func TestIssue7496_ShouldRetryShutdown(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("Connect to the shim %s", sbID)
-	shimCli := connectToShim(ctx, t, sbID)
+	shimCli := connectToShim(ctx, t, containerdEndpoint, 3, sbID)
 
 	t.Logf("Log shim %s's pid: %d", sbID, shimPid(ctx, t, shimCli))
 

--- a/integration/release_upgrade_utils_linux_test.go
+++ b/integration/release_upgrade_utils_linux_test.go
@@ -91,8 +91,10 @@ func gitLsRemoteCtrdTags(t *testing.T, pattern string) (_tags []string) {
 	cmd := exec.Command("git", "ls-remote", "--tags", "--exit-code",
 		"https://github.com/containerd/containerd.git", pattern)
 
-	out, err := cmd.Output()
-	require.NoError(t, err, "failed to list tags by pattern %s", pattern)
+	t.Logf("Running %s", cmd.String())
+
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "failed to list tags by pattern %s: %s", pattern, string(out))
 
 	// output is like
 	//

--- a/integration/remote/remote_runtime.go
+++ b/integration/remote/remote_runtime.go
@@ -513,12 +513,12 @@ func (r *RuntimeService) UpdateRuntimeConfig(runtimeConfig *runtimeapi.RuntimeCo
 }
 
 // Status returns the status of the runtime.
-func (r *RuntimeService) Status(opts ...grpc.CallOption) (*runtimeapi.RuntimeStatus, error) {
+func (r *RuntimeService) Status(opts ...grpc.CallOption) (*runtimeapi.StatusResponse, error) {
 	klog.V(10).Infof("[RuntimeService] Status (timeout=%v)", r.timeout)
 	ctx, cancel := getContextWithTimeout(r.timeout)
 	defer cancel()
 
-	resp, err := r.runtimeClient.Status(ctx, &runtimeapi.StatusRequest{}, opts...)
+	resp, err := r.runtimeClient.Status(ctx, &runtimeapi.StatusRequest{Verbose: true}, opts...)
 	if err != nil {
 		klog.Errorf("Status from runtime service failed: %v", err)
 		return nil, err
@@ -532,7 +532,7 @@ func (r *RuntimeService) Status(opts ...grpc.CallOption) (*runtimeapi.RuntimeSta
 		return nil, errors.New(errorMessage)
 	}
 
-	return resp.Status, nil
+	return resp, nil
 }
 
 // RuntimeConfig returns the CgroupDriver of the runtime.


### PR DESCRIPTION
Summary:

* Add some helper functions to reduce duplicate code in upgrade testsuite
* Change Runtime.Status proto so that we can dump CRI configuration by API
* Add some checkers to ensure there is no leaky resources after upgrade
* Add failpoint in existing recover case: new release containerd should take over dead shim correctly
* Add new case to check new release containerd can parse metric data from existing shim created by previous release.

Closes: #3757 

> NOTE: We should create new issue to track test suite in windows platform. For linux, I think we can close #3757 if this one is acceptable.