### PR TITLE
cri: propagate deprecation list to runtime status

### DIFF
--- a/internal/cri/config/config.go
+++ b/internal/cri/config/config.go
@@ -394,6 +394,10 @@ type RuntimeConfig struct {
 	//
 	// For example, the value can be '5h', '2h30m', '10s'.
 	DrainExecSyncIOTimeout string `toml:"drain_exec_sync_io_timeout" json:"drainExecSyncIOTimeout"`
+
+	// IgnoreDeprecationWarnings is the list of the deprecation IDs (such as "io.containerd.deprecation/pull-schema-1-image")
+	// that should be ignored for checking "ContainerdHasNoDeprecationWarnings" condition.
+	IgnoreDeprecationWarnings []string `toml:"ignore_deprecation_warnings" json:"ignoreDeprecationWarnings"`
 }
 
 // X509KeyPairStreaming contains the x509 configuration for streaming

--- a/internal/cri/server/status_test.go
+++ b/internal/cri/server/status_test.go
@@ -1,0 +1,50 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"testing"
+
+	"github.com/containerd/containerd/v2/api/services/introspection/v1"
+	"github.com/stretchr/testify/assert"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+func TestRuntimeConditionContainerdHasNoDeprecationWarnings(t *testing.T) {
+	deprecations := []*introspection.DeprecationWarning{
+		{
+			ID:      "io.containerd.deprecation/foo",
+			Message: "foo",
+		},
+	}
+
+	cond, err := runtimeConditionContainerdHasNoDeprecationWarnings(deprecations, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, &runtime.RuntimeCondition{
+		Type:    ContainerdHasNoDeprecationWarnings,
+		Status:  false,
+		Reason:  ContainerdHasDeprecationWarnings,
+		Message: `{"io.containerd.deprecation/foo":"foo"}`,
+	}, cond)
+
+	cond, err = runtimeConditionContainerdHasNoDeprecationWarnings(deprecations, []string{"io.containerd.deprecation/foo"})
+	assert.NoError(t, err)
+	assert.Equal(t, &runtime.RuntimeCondition{
+		Type:   ContainerdHasNoDeprecationWarnings,
+		Status: true,
+	}, cond)
+}


### PR DESCRIPTION
Propagate the deprecation list to CRI runtime conditions.

```console
# crictl info                       
{                                                                                
  "status": {                                                                                                                                                      
    "conditions": [                                                              
      {                          
        "type": "RuntimeReady",   
        "status": true,                
        "reason": "",            
        "message": ""           
      },                        
      {                        
        "type": "NetworkReady",                                                  
        "status": true,              
        "reason": "",                                                            
        "message": ""                  
      },                              
      {                              
        "type": "ContainerdHasNoDeprecationWarnings",                            
        "status": false,                                                         
        "reason": "ContainerdHasDeprecationWarnings",                                                                                                              
        "message": "{\"io.containerd.deprecation/pull-schema-1-image\":\"Schema 1 images are deprecated since containerd v1.7 and removed in containerd v2.0. Since
 containerd v1.7.8, schema 1 images are identified by the \\\"io.containerd.image/converted-docker-schema1\\\" label.\"}"                                          
      }                                
    ]                                  
  }, 
...
}      
```

The propagated conditions are visible via `crictl info`, but not visible via `kubectl get nodes -o yaml` yet, although the CRI API says "These conditions will be exposed to users to help them understand the status of the system".

https://github.com/kubernetes/cri-api/blob/v0.29.1/pkg/apis/runtime/v1/api.proto#L1505-L1509
- https://github.com/kubernetes/kubernetes/issues/123148
- https://github.com/kubernetes/kubernetes/pull/123155