### PR TITLE
cri: skip updating resources for containers in the Exiting state.

### DIFF
--- a/integration/pleg_notready_linux_test.go
+++ b/integration/pleg_notready_linux_test.go
@@ -72,7 +72,7 @@ func TestFixPlegNotready(t *testing.T) {
 		MemoryLimitInBytes: int64(64 * 1024 * 1024),
 	}, nil)
 
-	// waiting for the dead-lock happend
+	// waiting for the dead-lock happened
 	time.Sleep(5 * time.Second)
 
 	// list containers after update resource
@@ -94,6 +94,4 @@ func listContainers(t *testing.T, timeout int) error {
 	case <-doneCh:
 		return err
 	}
-
-	return nil
 }

--- a/integration/pleg_notready_linux_test.go
+++ b/integration/pleg_notready_linux_test.go
@@ -1,0 +1,99 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/v2/integration/images"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+// TestFixPlegNotready is used to verify root cause of kubelet pleg notready.
+func TestFixPlegNotready(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.Background(), "k8s.io")
+
+	t.Logf("Create a pod config and run sandbox container")
+	sbID, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "fix_pleg_notready")
+
+	shimCli := connectToShim(ctx, t, sbID)
+
+	t.Logf("Create a container config and run container in a pod")
+	pauseImage := images.Get(images.Pause)
+	EnsureImageExists(t, pauseImage)
+
+	containerConfig := ContainerConfig("container1", pauseImage)
+	cnID, err := runtimeService.CreateContainer(sbID, containerConfig, sbConfig)
+	require.NoError(t, err)
+	require.NoError(t, runtimeService.StartContainer(cnID))
+
+	delayInSec := 10
+	t.Logf("[shim pid: %d]: Injecting %d seconds delay to umount2 syscall",
+		shimPid(ctx, t, shimCli),
+		delayInSec)
+
+	injectDelayToUmount2(ctx, t, shimCli, delayInSec /* CRI plugin uses 10 seconds to delete task */)
+
+	// stop the container, the shim will be blocked in deleting task
+	t.Log("Stop container with timeout 1s")
+
+	go runtimeService.StopContainer(cnID, 1)
+
+	// make sure `umount2` present in strace's stdout
+	time.Sleep(2 * time.Second)
+
+	// list container before update resource
+	t.Log("List containers before update resource with timeout 1s")
+	require.NoError(t, listContainers(t, 1), "The ListContainers should be done without error")
+
+	// update the container resource, the update will be blocked.
+	// in the kubernetes, this will be called by kubelet for every 10 second by default.
+	t.Log("Update container resource")
+	go runtimeService.UpdateContainerResources(cnID, &runtime.LinuxContainerResources{
+		MemoryLimitInBytes: int64(64 * 1024 * 1024),
+	}, nil)
+
+	// waiting for the dead-lock happend
+	time.Sleep(5 * time.Second)
+
+	// list containers after update resource
+	t.Log("List containers after update resource  with timeout 1s")
+	require.NoError(t, listContainers(t, 1), "The ListContainers should be done without error with timeout 1s")
+}
+
+func listContainers(t *testing.T, timeout int) error {
+	var err error
+	doneCh := make(chan struct{})
+	go func() {
+		_, err = runtimeService.ListContainers(&runtime.ContainerFilter{})
+		doneCh <- struct{}{}
+	}()
+
+	select {
+	case <-time.After(time.Duration(timeout) * time.Second):
+		return errors.New("deadline exceeded")
+	case <-doneCh:
+		return err
+	}
+
+	return nil
+}

--- a/internal/cri/server/container_update_resources.go
+++ b/internal/cri/server/container_update_resources.go
@@ -86,6 +86,11 @@ func (c *criService) updateContainerResources(ctx context.Context,
 		return newStatus, fmt.Errorf("container %q is in removing state", id)
 	}
 
+	// Do not update the container when there is an exit in progress.
+	if status.Exiting {
+		return newStatus, fmt.Errorf("container %q is in exiting state", id)
+	}
+
 	// Update container spec. If the container is not started yet, updating
 	// spec makes sure that the resource limits are correct when start;
 	// if the container is already started, updating spec is still required,

--- a/internal/cri/store/container/status.go
+++ b/internal/cri/store/container/status.go
@@ -90,6 +90,8 @@ type Status struct {
 	// Starting indicates that the container is in starting state.
 	// This field doesn't need to be checkpointed.
 	Starting bool `json:"-"`
+	// Exiting indicates that the container is in exiting state.
+	Exiting bool `json:"-"`
 	// Removing indicates that the container is in removing state.
 	// This field doesn't need to be checkpointed.
 	Removing bool `json:"-"`


### PR DESCRIPTION
In https://github.com/containerd/containerd/issues/9770, I investigated further and found that `PLEG NotReady`
is more likely to occur when there are containers exit.

The problem is the shim service accquired the lock already
for an exiting container to delete task.
At the same time invoke the `ContainerUpdateResource` for this
exiting container will be blocked by `task.Update`.
And this will also block status get for this container.

Although we can use `volatile` for overlay in kernel >=5.10
to avoid this situation happen.
But maybe there are many node running in kernel versions prior to 5.10.
Maybe it's neccessary to improve this in containerd.

The following improvements can fix this,
1. Introduce an additional `Exiting` state in the container status.
2. When a container exits, update its status to `Exiting`
in the container exit event handler.
3. Skip updating resources for contianers that are in the `Exiting` state.