### PR TITLE
Add platform image labels for image pull per runtime class

### DIFF
--- a/core/images/image.go
+++ b/core/images/image.go
@@ -27,7 +27,9 @@ import (
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
+	distribution "github.com/distribution/reference"
 	digest "github.com/opencontainers/go-digest"
+	imagedigest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -434,4 +436,19 @@ func ConfigPlatform(ctx context.Context, provider content.Provider, configDesc o
 		return ocispec.Platform{}, err
 	}
 	return platforms.Normalize(imagePlatform), nil
+}
+
+// GetRepoDigestAndTag returns image repoDigest and repoTag of the named image reference.
+func GetRepoDigestAndTag(namedRef distribution.Named, digest imagedigest.Digest, schema1 bool) (string, string) {
+	var repoTag, repoDigest string
+	if _, ok := namedRef.(distribution.NamedTagged); ok {
+		repoTag = namedRef.String()
+	}
+	if _, ok := namedRef.(distribution.Canonical); ok {
+		repoDigest = namedRef.String()
+	} else if !schema1 {
+		// digest is not actual repo digest for schema1 image.
+		repoDigest = namedRef.Name() + "@" + digest.String()
+	}
+	return repoDigest, repoTag
 }

--- a/core/transfer/image/imagestore.go
+++ b/core/transfer/image/imagestore.go
@@ -18,6 +18,7 @@ package image
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/containerd/typeurl/v2"
@@ -32,7 +33,9 @@ import (
 	"github.com/containerd/containerd/v2/core/streaming"
 	"github.com/containerd/containerd/v2/core/transfer"
 	"github.com/containerd/containerd/v2/core/transfer/plugins"
+	ctrdlabels "github.com/containerd/containerd/v2/pkg/labels"
 	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
 	"github.com/containerd/platforms"
 )
 
@@ -212,8 +215,55 @@ func (is *Store) ImageFilter(h images.HandlerFunc, cs content.Store) images.Hand
 	return h
 }
 
-func (is *Store) Store(ctx context.Context, desc ocispec.Descriptor, store images.Store) ([]images.Image, error) {
+// checkUnpackAndAddPlatformLabel checks if the requested image has been successfully
+// unpacked for the requested platforms. If yes, platform image labels are added
+// to indicate what platforms the image has been pulled for. This becomes important
+// to support image pull per runtime class where an image could be pulled for different
+// platforms.
+func (is *Store) checkUnpackAndAddPlatformLabel(ctx context.Context, desc ocispec.Descriptor, store images.Store, content content.Provider) error {
+	for _, platformSpec := range is.platforms {
+		platformMatcher := platforms.Only(platformSpec)
+
+		// Check if required layers were pulled and unpacked successfully.
+		manifest, err := images.Manifest(ctx, content, desc, platformMatcher)
+		if err != nil {
+			log.G(ctx).Infof("Image %v not unpacked for platform %v. Skip adding image label.", is.imageName, platformSpec)
+		}
+		imageLayers := []ocispec.Descriptor{}
+		for _, ociLayer := range manifest.Layers {
+			if images.IsLayerType(ociLayer.MediaType) {
+				imageLayers = append(imageLayers, ociLayer)
+			}
+		}
+
+		diffIDs, err := images.RootFS(ctx, content, manifest.Config)
+		if err != nil {
+			return fmt.Errorf("error while getting diffTDs for %v", is.imageName)
+		}
+		if len(diffIDs) != len(imageLayers) {
+			return errors.New("mismatched image rootfs and manifest layers")
+		}
+
+		// Add platform image label
+		platform := platforms.Format(platformSpec)
+		platformImageLabel := fmt.Sprintf(ctrdlabels.PlatformLabelFormat, ctrdlabels.PlatformLabelPrefix, platform)
+
+		if is.imageLabels == nil {
+			is.imageLabels = map[string]string{}
+		}
+		is.imageLabels[platformImageLabel] = platform
+	}
+	return nil
+}
+
+func (is *Store) Store(ctx context.Context, desc ocispec.Descriptor, store images.Store, content content.Provider) ([]images.Image, error) {
 	var imgs []images.Image
+
+	// Check if unpack was successful and set platform image labels.
+	err := is.checkUnpackAndAddPlatformLabel(ctx, desc, store, content)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update containerd image store for %v", is.imageName)
+	}
 
 	// If import ref type, store references from annotation or prefix
 	if refSource, ok := desc.Annotations["io.containerd.import.ref-source"]; ok {

--- a/core/transfer/image/imagestore_test.go
+++ b/core/transfer/image/imagestore_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/images/imagetest"
 	"github.com/containerd/errdefs"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -224,7 +225,8 @@ func TestStore(t *testing.T) {
 				desc.Annotations["io.containerd.import.ref-source"] = "annotation"
 			}
 			t.Run(name, func(t *testing.T) {
-				imgs, err := testCase.ImageStore.Store(context.Background(), desc, newSimpleImageStore())
+				ctx := context.Background()
+				imgs, err := testCase.ImageStore.Store(ctx, desc, newSimpleImageStore(), imagetest.NewContentStore(ctx, t))
 				if err != nil {
 					if testCase.Err == nil {
 						t.Fatal(err)

--- a/core/transfer/local/import.go
+++ b/core/transfer/local/import.go
@@ -129,7 +129,7 @@ func (ts *localTransferService) importStream(ctx context.Context, i transfer.Ima
 
 	for _, desc := range descriptors {
 		desc := desc
-		imgs, err := is.Store(ctx, desc, ts.images)
+		imgs, err := is.Store(ctx, desc, ts.images, ts.content)
 		if err != nil {
 			if errdefs.IsNotFound(err) {
 				log.G(ctx).Infof("No images store for %s", desc.Digest)

--- a/core/transfer/local/pull.go
+++ b/core/transfer/local/pull.go
@@ -231,7 +231,7 @@ func (ts *localTransferService) pull(ctx context.Context, ir transfer.ImageFetch
 		}
 	}
 
-	imgs, err := is.Store(ctx, desc, ts.images)
+	imgs, err := is.Store(ctx, desc, ts.images, ts.content)
 	if err != nil {
 		return err
 	}

--- a/core/transfer/local/tag.go
+++ b/core/transfer/local/tag.go
@@ -34,6 +34,6 @@ func (ts *localTransferService) tag(ctx context.Context, ig transfer.ImageGetter
 		return err
 	}
 
-	_, err = is.Store(ctx, img.Target, ts.images)
+	_, err = is.Store(ctx, img.Target, ts.images, ts.content)
 	return err
 }

--- a/core/transfer/transfer.go
+++ b/core/transfer/transfer.go
@@ -61,7 +61,7 @@ type ImageFilterer interface {
 // the provided descriptor. The descriptor may be any type of manifest
 // including an index with multiple image references.
 type ImageStorer interface {
-	Store(context.Context, ocispec.Descriptor, images.Store) ([]images.Image, error)
+	Store(context.Context, ocispec.Descriptor, images.Store, content.Provider) ([]images.Image, error)
 }
 
 // ImageGetter is type which returns an image from an image store

--- a/defaults/defaults_unix.go
+++ b/defaults/defaults_unix.go
@@ -34,4 +34,6 @@ const (
 	DefaultFIFODir = "/run/containerd/fifo"
 	// DefaultConfigDir is the default location for config files.
 	DefaultConfigDir = "/etc/containerd"
+	// DefaultRuntimeHandlerName is the default runtime handler
+	DefaultRuntimeHandlerName = "runc"
 )

--- a/defaults/defaults_windows.go
+++ b/defaults/defaults_windows.go
@@ -43,4 +43,6 @@ const (
 	DefaultFIFODir = ""
 	// DefaultRuntime is the default windows runtime
 	DefaultRuntime = "io.containerd.runhcs.v1"
+	// DefaultRuntimeHandlerName is the default runtime handler on windows
+	DefaultRuntimeHandlerName = "runhcs-wcow-process"
 )

--- a/internal/cri/server/images/image_pull_test.go
+++ b/internal/cri/server/images/image_pull_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
+	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/internal/cri/annotations"
 	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
 	"github.com/containerd/containerd/v2/internal/cri/labels"
@@ -478,7 +479,7 @@ func TestGetRepoDigestAndTag(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			named, err := docker.ParseDockerRef(test.ref)
 			assert.NoError(t, err)
-			repoDigest, repoTag := getRepoDigestAndTag(named, digest, test.schema1)
+			repoDigest, repoTag := images.GetRepoDigestAndTag(named, digest, test.schema1)
 			assert.Equal(t, test.expectedRepoDigest, repoDigest)
 			assert.Equal(t, test.expectedRepoTag, repoTag)
 		})

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -18,12 +18,21 @@ package labels
 
 // LabelUncompressed is added to compressed layer contents.
 // The value is digest of the uncompressed content.
-const LabelUncompressed = "containerd.io/uncompressed"
+const (
+	LabelUncompressed = "containerd.io/uncompressed"
 
-// LabelSharedNamespace is added to a namespace to allow that namespaces
-// contents to be shared.
-const LabelSharedNamespace = "containerd.io/namespace.shareable"
+	// LabelSharedNamespace is added to a namespace to allow that namespaces
+	// contents to be shared.
+	LabelSharedNamespace = "containerd.io/namespace.shareable"
 
-// LabelDistributionSource is added to content to indicate its origin.
-// e.g., "containerd.io/distribution.source.docker.io=library/redis"
-const LabelDistributionSource = "containerd.io/distribution.source"
+	// LabelDistributionSource is added to content to indicate its origin.
+	// e.g., "containerd.io/distribution.source.docker.io=library/redis"
+	LabelDistributionSource = "containerd.io/distribution.source"
+
+	// PlatformLabelPrefix is common prefix for indicating what platforms
+	// an image has been pulled for
+	PlatformLabelPrefix = "containerd.io/imagePulledForPlatform"
+
+	// PlatformLabelFormat is the format for the platform image label
+	PlatformLabelFormat = "%s.%s"
+)


### PR DESCRIPTION
This PR contains an isolated change to add platform labels to an image being pulled. This becomes important to support image pull per runtime class where an image could be pulled for different platforms. The platform label would help to identify the platform the image is currently being pulled for.
The change targets images being pulled both through CRI and transfer service.

**Note**: Changes for supporting image pull per runtime class (KEP 4216) will be submitted in smaller chunks to make reviewing easier. This is a first part to the series of changes needed to full support KEP 4216. Will be sending out more as each of them get checked in.