### PR TITLE
core/runtime: Check shim PluginInfo to enforce idmap support

### DIFF
--- a/cmd/containerd-shim-runc-v2/process/init.go
+++ b/cmd/containerd-shim-runc-v2/process/init.go
@@ -21,7 +21,6 @@ package process
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -142,12 +141,6 @@ func (p *Init) Create(ctx context.Context, r *CreateConfig) error {
 		opts.ConsoleSocket = socket
 	}
 
-	// runc ignores silently features it doesn't know about, so for things that this is
-	// problematic let's check if this runc version supports them.
-	if err := p.validateRuncFeatures(ctx, r.Bundle); err != nil {
-		return fmt.Errorf("failed to detect OCI runtime features: %w", err)
-	}
-
 	if err := p.runtime.Create(ctx, r.ID, r.Bundle, opts); err != nil {
 		return p.runtimeError(err, "OCI runtime create failed")
 	}
@@ -178,60 +171,6 @@ func (p *Init) Create(ctx context.Context, r *CreateConfig) error {
 		return fmt.Errorf("failed to retrieve OCI runtime container pid: %w", err)
 	}
 	p.pid = pid
-	return nil
-}
-
-func (p *Init) validateRuncFeatures(ctx context.Context, bundle string) error {
-	// TODO: We should remove the logic from here and rebase on #8509.
-	// This way we can avoid the call to readConfig() here and the call to p.runtime.Features()
-	// in validateIDMapMounts().
-	// But that PR is not yet merged nor it is clear if it will be refactored.
-	// Do this contained hack for now.
-	spec, err := readConfig(bundle)
-	if err != nil {
-		return fmt.Errorf("failed to read config: %w", err)
-	}
-
-	if err := p.validateIDMapMounts(ctx, spec); err != nil {
-		return fmt.Errorf("OCI runtime doesn't support idmap mounts: %w", err)
-	}
-
-	return nil
-}
-
-func (p *Init) validateIDMapMounts(ctx context.Context, spec *specs.Spec) error {
-	var used bool
-	for _, m := range spec.Mounts {
-		if m.UIDMappings != nil || m.GIDMappings != nil {
-			used = true
-			break
-		}
-		if sliceContainsStr(m.Options, "idmap") || sliceContainsStr(m.Options, "ridmap") {
-			used = true
-			break
-		}
-	}
-
-	if !used {
-		return nil
-	}
-
-	// From here onwards, we require idmap mounts. So if we fail to check, we return an error.
-	features, err := p.runtime.Features(ctx)
-	if err != nil {
-		// If the features command is not implemented, then runc is too old.
-		return fmt.Errorf("features command failed: %w", err)
-
-	}
-
-	if features.Linux.MountExtensions == nil || features.Linux.MountExtensions.IDMap == nil {
-		return errors.New("missing `mountExtensions.idmap` entry in `features` command")
-	}
-
-	if enabled := features.Linux.MountExtensions.IDMap.Enabled; enabled == nil || !*enabled {
-		return errors.New("idmap mounts not supported")
-	}
-
 	return nil
 }
 
@@ -555,13 +494,4 @@ func withConditionalIO(c stdio.Stdio) runc.IOOpt {
 		o.OpenStdout = c.Stdout != ""
 		o.OpenStderr = c.Stderr != ""
 	}
-}
-
-func sliceContainsStr(s []string, str string) bool {
-	for _, s := range s {
-		if s == str {
-			return true
-		}
-	}
-	return false
 }

--- a/cmd/containerd-shim-runc-v2/process/utils.go
+++ b/cmd/containerd-shim-runc-v2/process/utils.go
@@ -21,7 +21,6 @@ package process
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -32,7 +31,6 @@ import (
 
 	"github.com/containerd/errdefs"
 	runc "github.com/containerd/go-runc"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
 )
 
@@ -41,8 +39,6 @@ const (
 	RuncRoot = "/run/containerd/runc"
 	// InitPidFile name of the file that contains the init pid
 	InitPidFile = "init.pid"
-	// configFile is the name of the runc config file
-	configFile = "config.json"
 )
 
 // safePid is a thread safe wrapper for pid.
@@ -187,24 +183,4 @@ func stateName(v interface{}) string {
 		return "stopped"
 	}
 	panic(fmt.Errorf("invalid state %v", v))
-}
-
-func readConfig(path string) (spec *specs.Spec, err error) {
-	cfg := filepath.Join(path, configFile)
-	f, err := os.Open(cfg)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("JSON specification file %s not found", cfg)
-		}
-		return nil, err
-	}
-	defer f.Close()
-
-	if err = json.NewDecoder(f).Decode(&spec); err != nil {
-		return nil, fmt.Errorf("failed to parse config: %w", err)
-	}
-	if spec == nil {
-		return nil, errors.New("config cannot be null")
-	}
-	return spec, nil
 }


### PR DESCRIPTION
This commit gets rid of the TODO by moving the check to use the pluginInfo() infrastructure (#9442).

The check is only enforced for shims that return info that can be read as type runtime.Features. For shims that don't provide that, we just ignore it, as those shims might not be affected by this.

NOTE: Since Kubernetes 1.30, the kubelet checks that the container runtime supports all the features for user namespaces (iow, it checks idmap mounts support too) and, if the runtime doesn't support them, it just rejects the pod creation without sending it to the runtime. That makes it less of an issue, as this PR is not really needed now for kubernetes >= 1.30 workloads. However, it is the right thing to do (we shouldn't rely on k8s doing it, we should check it here too), and it is still relevant for kubernetes < 1.30 and workloads not using Kubernetes.

cc @AkihiroSuda 