### PR TITLE
Include userns info in cri/server PodSandboxStatus

### DIFF
--- a/internal/cri/server/sandbox_status.go
+++ b/internal/cri/server/sandbox_status.go
@@ -134,11 +134,7 @@ func toCRISandboxStatus(meta sandboxstore.Metadata, status string, createdAt tim
 		},
 		Linux: &runtime.LinuxPodSandboxStatus{
 			Namespaces: &runtime.Namespace{
-				Options: &runtime.NamespaceOption{
-					Network: nsOpts.GetNetwork(),
-					Pid:     nsOpts.GetPid(),
-					Ipc:     nsOpts.GetIpc(),
-				},
+				Options: nsOpts,
 			},
 		},
 		Labels:         meta.Config.GetLabels(),

--- a/internal/cri/server/sandbox_status_test.go
+++ b/internal/cri/server/sandbox_status_test.go
@@ -31,6 +31,13 @@ func TestPodSandboxStatus(t *testing.T) {
 		id = "test-id"
 		ip = "10.10.10.10"
 	)
+	idmap := []*runtime.IDMapping{
+		{
+			ContainerId: 0,
+			HostId:      100,
+			Length:      1,
+		},
+	}
 	additionalIPs := []string{"8.8.8.8", "2001:db8:85a3::8a2e:370:7334"}
 	createdAt := time.Now()
 	config := &runtime.PodSandboxConfig{
@@ -46,6 +53,11 @@ func TestPodSandboxStatus(t *testing.T) {
 					Network: runtime.NamespaceMode_NODE,
 					Pid:     runtime.NamespaceMode_CONTAINER,
 					Ipc:     runtime.NamespaceMode_POD,
+					UsernsOptions: &runtime.UserNamespace{
+						Uids: idmap,
+						Gids: idmap,
+						Mode: runtime.NamespaceMode_POD,
+					},
 				},
 			},
 		},
@@ -80,6 +92,11 @@ func TestPodSandboxStatus(t *testing.T) {
 					Network: runtime.NamespaceMode_NODE,
 					Pid:     runtime.NamespaceMode_CONTAINER,
 					Ipc:     runtime.NamespaceMode_POD,
+					UsernsOptions: &runtime.UserNamespace{
+						Uids: idmap,
+						Gids: idmap,
+						Mode: runtime.NamespaceMode_POD,
+					},
 				},
 			},
 		},


### PR DESCRIPTION
We added support for userns but we weren't showing it in the
PodSandboxStatus.

Let's just show the whole nsOpts, so we don't forget in the future
either if something else inside there changes.

Please note that this will expose the content of nsOpts.TargetId that we
weren't exposing before. But that seemed like a bug to me.