### PR TITLE
Add container monitor plugin type for restart

### DIFF
--- a/plugins/types.go
+++ b/plugins/types.go
@@ -38,7 +38,9 @@ const (
 	// SnapshotPlugin implements a snapshotter
 	SnapshotPlugin plugin.Type = "io.containerd.snapshotter.v1"
 	// TaskMonitorPlugin implements a task monitor
-	TaskMonitorPlugin plugin.Type = "io.containerd.monitor.v1"
+	TaskMonitorPlugin plugin.Type = "io.containerd.monitor.task.v1"
+	// TaskMonitorPlugin implements a container monitor
+	ContainerMonitorPlugin plugin.Type = "io.containerd.monitor.container.v1"
 	// DiffPlugin implements a differ
 	DiffPlugin plugin.Type = "io.containerd.differ.v1"
 	// MetadataPlugin implements a metadata store


### PR DESCRIPTION
Adds a plugin type for container monitor. This avoids making the internal plugin type require service plugins since internal plugins should be loaded earlier.
Rename the task monitor type to avoid confusion.
Add config migration for new plugin types to pass existing migration tests.