### PR TITLE
Prevent GC from schedule itself with 0 period.

### DIFF
--- a/plugins/gc/scheduler.go
+++ b/plugins/gc/scheduler.go
@@ -234,6 +234,7 @@ func schedule(d time.Duration) (<-chan time.Time, *time.Time) {
 }
 
 func (s *gcScheduler) run(ctx context.Context) {
+	const minimumGCTime = float64(5 * time.Millisecond)
 	var (
 		schedC <-chan time.Time
 
@@ -331,6 +332,11 @@ func (s *gcScheduler) run(ctx context.Context) {
 			// runtime in between gc to reach the pause threshold.
 			// Pause threshold is always 0.0 < threshold <= 0.5
 			avg := float64(gcTimeSum) / float64(collections)
+			// Enforce that avg is no less than minimumGCTime
+			// to prevent immediate rescheduling
+			if avg < minimumGCTime {
+				avg = minimumGCTime
+			}
 			interval = time.Duration(avg/s.pauseThreshold - avg)
 		}
 


### PR DESCRIPTION
On startup `gcTimeSum` might work fast and return `0`, so on this case the algorithm turns in infinity loop which simple consume CPU on timer which fires without any interval.

Closes: https://github.com/containerd/containerd/issues/5089