### PR TITLE
Update codeql-action/upload-sarif dependency in scorecards workflow

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -49,6 +49,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@03e7845b7bfcd5e7fb63d1ae8c61b0e791134fab # tag=v2.22.11
+        uses: github/codeql-action/upload-sarif@e8893c57a1f3a2b659b6b55564fdfdbbd2982911 # tag=v3.24.0
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Issue:
N/A

Description:
Fixes scorecards workflow showing NodeJS 16 deprecation warnings.

Testing performed:

Ran scorecards workflow in fork:

Before
![image](https://github.com/containerd/containerd/assets/55906459/a0e9882b-8f05-46a1-bd7c-3152088e4baf)

After
![image](https://github.com/containerd/containerd/assets/55906459/0f4365b0-3c61-4dbe-a0b5-43cf7f987c20)

Unclear why this was not picked up by the dependabot automation, this [commit](https://github.com/containerd/containerd/commit/f9303d04ded5dc1c560ef23a1b87c66ae24a0579) seems to suggest it should have gone from v2 to v3.