### PR TITLE
Fix for k8s nfs related tests probably caused by `ulimit` changes

### DIFF
--- a/contrib/gce/configure.sh
+++ b/contrib/gce/configure.sh
@@ -250,6 +250,12 @@ fi
 echo "export PATH=${CONTAINERD_HOME}/usr/local/bin/:${CONTAINERD_HOME}/usr/local/sbin/:\$PATH" > \
   /etc/profile.d/containerd_env.sh
 
+mkdir -p /etc/systemd/system/containerd.service.d/
+cat >> /etc/systemd/system/containerd.service.d/override.conf <<EOF
+[Service]
+LimitNOFILE=1048576
+EOF
+
 # Run extra init script for test.
 if [ "${CONTAINERD_TEST:-"false"}"  == "true" ]; then
   # EXTRA_INIT_SCRIPT is the name of the extra init script after being downloaded.


### PR DESCRIPTION
on 2/7 the k8s upstream jobs picked up a new version of ubuntu kernel and some of the NFS related jobs started failing:
- https://testgrid.k8s.io/sig-node-containerd#containerd-e2e-ubuntu&width=20
- https://testgrid.k8s.io/sig-node-containerd#image-validation-ubuntu-e2e&width=20

We had the same issue with `kops` based tests as well which we fixed by setting `LimitNOFILE` explicitly to a known previous value:
https://github.com/kubernetes/kops/pull/16329

So we want to see if fixing this in the install scripts for the CI jobs works for us. Also note the pending PR here:
https://github.com/containerd/containerd/pull/9660

and the note back from 2019:
https://github.com/containerd/containerd/issues/3201#issuecomment-481720276