### PR TITLE
Update golangci-lint version to v1.56.1 and resolve warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: ./.github/actions/install-go
       - uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.55.2
+          version: v1.56.1
           skip-cache: true
           args: --timeout=8m
 

--- a/client/snapshotter_opts_unix.go
+++ b/client/snapshotter_opts_unix.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	capaRemapIDs     = "remap-ids"
-	capaOnlyRemapIds = "only-remap-ids"
+	capaOnlyRemapIDs = "only-remap-ids"
 )
 
 // WithRemapperLabels creates the labels used by any supporting snapshotter
@@ -75,7 +75,7 @@ func resolveSnapshotOptions(ctx context.Context, client *Client, snapshotterName
 
 	capaOnlyRemap := false
 	for _, capa := range capabs {
-		if capa == capaOnlyRemapIds {
+		if capa == capaOnlyRemapIDs {
 			capaOnlyRemap = true
 		}
 	}

--- a/plugins/snapshots/overlay/overlay.go
+++ b/plugins/snapshots/overlay/overlay.go
@@ -45,7 +45,7 @@ type SnapshotterConfig struct {
 	upperdirLabel bool
 	ms            MetaStore
 	mountOptions  []string
-	remapIds      bool
+	remapIDs      bool
 	slowChown     bool
 }
 
@@ -94,8 +94,8 @@ func WithMetaStore(ms MetaStore) Opt {
 	}
 }
 
-func WithRemapIds(config *SnapshotterConfig) error {
-	config.remapIds = true
+func WithRemapIDs(config *SnapshotterConfig) error {
+	config.remapIDs = true
 	return nil
 }
 
@@ -110,7 +110,7 @@ type snapshotter struct {
 	asyncRemove   bool
 	upperdirLabel bool
 	options       []string
-	remapIds      bool
+	remapIDs      bool
 	slowChown     bool
 }
 
@@ -167,7 +167,7 @@ func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
 		asyncRemove:   config.asyncRemove,
 		upperdirLabel: config.upperdirLabel,
 		options:       config.mountOptions,
-		remapIds:      config.remapIds,
+		remapIDs:      config.remapIDs,
 		slowChown:     config.slowChown,
 	}, nil
 }
@@ -573,7 +573,7 @@ func (o *snapshotter) prepareDirectory(ctx context.Context, snapshotDir string, 
 func (o *snapshotter) mounts(s storage.Snapshot, info snapshots.Info) []mount.Mount {
 	var options []string
 
-	if o.remapIds {
+	if o.remapIDs {
 		if v, ok := info.Labels[snapshots.LabelSnapshotUIDMapping]; ok {
 			options = append(options, fmt.Sprintf("uidmap=%s", v))
 		}

--- a/plugins/snapshots/overlay/overlay_test.go
+++ b/plugins/snapshots/overlay/overlay_test.go
@@ -54,7 +54,7 @@ func TestOverlay(t *testing.T) {
 		// default in init()
 		"AsynchronousRemove": {AsynchronousRemove},
 		// idmapped mounts enabled
-		"WithRemapIds": {WithRemapIds},
+		"WithRemapIDs": {WithRemapIDs},
 	}
 
 	for optsName, opts := range optTestCases {
@@ -211,7 +211,7 @@ func testOverlayRemappedBind(t *testing.T, newSnapshotter testsuite.SnapshotterF
 		t.Fatal(err)
 	}
 
-	if sn, ok := o.(*snapshotter); !ok || !sn.remapIds {
+	if sn, ok := o.(*snapshotter); !ok || !sn.remapIDs {
 		t.Skip("overlayfs doesn't support idmapped mounts")
 	}
 
@@ -316,7 +316,7 @@ func testOverlayRemappedActive(t *testing.T, newSnapshotter testsuite.Snapshotte
 		t.Fatal(err)
 	}
 
-	if sn, ok := o.(*snapshotter); !ok || !sn.remapIds {
+	if sn, ok := o.(*snapshotter); !ok || !sn.remapIDs {
 		t.Skip("overlayfs doesn't support idmapped mounts")
 	}
 
@@ -390,7 +390,7 @@ func testOverlayRemappedInvalidMapping(t *testing.T, newSnapshotter testsuite.Sn
 		t.Fatal(err)
 	}
 
-	if sn, ok := o.(*snapshotter); !ok || !sn.remapIds {
+	if sn, ok := o.(*snapshotter); !ok || !sn.remapIDs {
 		t.Skip("overlayfs doesn't support idmapped mounts")
 	}
 

--- a/plugins/snapshots/overlay/plugin/plugin.go
+++ b/plugins/snapshots/overlay/plugin/plugin.go
@@ -30,8 +30,8 @@ import (
 )
 
 const (
-	capaRemapIds     = "remap-ids"
-	capaOnlyRemapIds = "only-remap-ids"
+	capaRemapIDs     = "remap-ids"
+	capaOnlyRemapIDs = "only-remap-ids"
 )
 
 // Config represents configuration for the overlay plugin.
@@ -80,16 +80,16 @@ func init() {
 				oOpts = append(oOpts, overlay.WithMountOptions(config.MountOptions))
 			}
 			if ok, err := overlayutils.SupportsIDMappedMounts(); err == nil && ok {
-				oOpts = append(oOpts, overlay.WithRemapIds)
-				ic.Meta.Capabilities = append(ic.Meta.Capabilities, capaRemapIds)
+				oOpts = append(oOpts, overlay.WithRemapIDs)
+				ic.Meta.Capabilities = append(ic.Meta.Capabilities, capaRemapIDs)
 			}
 
 			if config.SlowChown {
 				oOpts = append(oOpts, overlay.WithSlowChown)
 			} else {
-				// If slowChown is false, we use capaOnlyRemapIds to signal we only
+				// If slowChown is false, we use capaOnlyRemapIDs to signal we only
 				// allow idmap mounts.
-				ic.Meta.Capabilities = append(ic.Meta.Capabilities, capaOnlyRemapIds)
+				ic.Meta.Capabilities = append(ic.Meta.Capabilities, capaOnlyRemapIDs)
 			}
 
 			ic.Meta.Exports["root"] = root


### PR DESCRIPTION
Issue:
N/A

Description:
This change updates golangci-lint to v1.56.1 which has Go 1.22 support.

Additionally it renames some internal variables and a public facing overlay snapshotter option to resolve revive lint warnings.

Testing:
Lint is successful on all platforms