### PR TITLE
Fix unpacker link in remote snapshotter docs

### DIFF
--- a/docs/remote-snapshotter.md
+++ b/docs/remote-snapshotter.md
@@ -87,7 +87,7 @@ if _, err := client.Pull(ctx, ref,
 
 The containerd client queries remote snapshots to the underlying remote snapshotter using snapshotter APIs.
 This section describes the high-level overview of how snapshotter APIs are used for remote snapshots functionality, with some piece of pseudo-codes that describe the simplified logic implemented in the containerd client.
-For more details, see [`unpacker.go`](../pkg/unpack/unpacker.go) that implements this logic.
+For more details, see [`unpacker.go`](../core/unpack/unpacker.go) that implements this logic.
 
 During image pull, the containerd client calls `Prepare` API with the label `containerd.io/snapshot.ref`.
 This is a containerd-defined label which contains ChainID that targets a committed snapshot that the client is trying to prepare.


### PR DESCRIPTION
### Issue:
N/A

### Description:
Remote snapshotter document update for unpacker link to point to new location after refactor.

### Testing:

Links workflow passes in fork.

#### Before
<img width="1281" alt="image" src="https://github.com/containerd/containerd/assets/55906459/de08c285-7ff1-423f-a7be-6085f5d99507">

#### After
<img width="1334" alt="image" src="https://github.com/containerd/containerd/assets/55906459/750c155b-cbfe-46d3-8681-4ca9608ad957">
