### PR TITLE
Move high volume event logs to Trace level

### DIFF
--- a/pkg/events/exchange/exchange.go
+++ b/pkg/events/exchange/exchange.go
@@ -67,7 +67,7 @@ func (e *Exchange) Forward(ctx context.Context, envelope *events.Envelope) (err 
 		if err != nil {
 			logger.WithError(err).Error("error forwarding event")
 		} else {
-			logger.Debug("event forwarded")
+			logger.Trace("event forwarded")
 		}
 	}()
 
@@ -111,7 +111,7 @@ func (e *Exchange) Publish(ctx context.Context, topic string, event events.Event
 		if err != nil {
 			logger.WithError(err).Error("error publishing event")
 		} else {
-			logger.Debug("event published")
+			logger.Trace("event published")
 		}
 	}()
 


### PR DESCRIPTION
Move high volume event publishing and forwarding logs to trace logs.