### PR TITLE
[release/1.6] cri: propagate deprecation list to runtime status

### DIFF
--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -303,6 +303,9 @@ type PluginConfig struct {
 	// and if it is not overwritten by PodSandboxConfig
 	// Note that currently default is set to disabled but target change it in future together with EnableUnprivilegedPorts
 	EnableUnprivilegedICMP bool `toml:"enable_unprivileged_icmp" json:"enableUnprivilegedICMP"`
+	// IgnoreDeprecationWarnings is the list of the deprecation IDs (such as "io.containerd.deprecation/pull-schema-1-image")
+	// that should be ignored for checking "ContainerdHasNoDeprecationWarnings" condition.
+	IgnoreDeprecationWarnings []string `toml:"ignore_deprecation_warnings" json:"ignoreDeprecationWarnings"`
 }
 
 // X509KeyPairStreaming contains the x509 configuration for streaming

--- a/pkg/cri/server/status.go
+++ b/pkg/cri/server/status.go
@@ -21,7 +21,9 @@ import (
 	"fmt"
 	goruntime "runtime"
 
+	"github.com/containerd/containerd/api/services/introspection/v1"
 	"github.com/containerd/containerd/log"
+	ptypes "github.com/gogo/protobuf/types"
 	"golang.org/x/net/context"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
@@ -94,5 +96,51 @@ func (c *criService) Status(ctx context.Context, r *runtime.StatusRequest) (*run
 		}
 		resp.Info["lastCNILoadStatus"] = defaultStatus
 	}
+	intro, err := c.client.IntrospectionService().Server(ctx, &ptypes.Empty{})
+	if err != nil {
+		return nil, err
+	}
+	cond, err := runtimeConditionContainerdHasNoDeprecationWarnings(intro.Deprecations, c.config.IgnoreDeprecationWarnings)
+	if err != nil {
+		return nil, err
+	}
+	resp.Status.Conditions = append(resp.Status.Conditions, cond)
 	return resp, nil
 }
+
+func runtimeConditionContainerdHasNoDeprecationWarnings(deprecations []*introspection.DeprecationWarning, ignore []string) (*runtime.RuntimeCondition, error) {
+	cond := &runtime.RuntimeCondition{
+		Type:   ContainerdHasNoDeprecationWarnings,
+		Status: true,
+	}
+	ignoreM := make(map[string]struct{})
+	for _, f := range ignore {
+		ignoreM[f] = struct{}{}
+	}
+	messages := make(map[string]string) // key: id, value: message
+	for _, d := range deprecations {
+		if _, ok := ignoreM[d.ID]; !ok {
+			messages[d.ID] = d.Message
+		}
+	}
+	if len(messages) > 0 {
+		cond.Status = false
+		cond.Reason = ContainerdHasDeprecationWarnings
+		messageJ, err := json.Marshal(messages)
+		if err != nil {
+			return nil, err
+		}
+		cond.Message = string(messageJ) // Arbitrary string
+	}
+	return cond, nil
+}
+
+const (
+	// ContainerdHasNoDeprecationWarnings is a string for [runtime.RuntimeCondition.Type].
+	ContainerdHasNoDeprecationWarnings = "ContainerdHasNoDeprecationWarnings"
+
+	// ContainerdHasDeprecationWarnings is a string for [runtime.RuntimeCondition.Reason].
+	// CamelCase is demanded by the spec.
+	// https://github.com/kubernetes/cri-api/blob/v0.29.1/pkg/apis/runtime/v1/api.proto#L1514
+	ContainerdHasDeprecationWarnings = "ContainerdHasDeprecationWarnings"
+)

--- a/pkg/cri/server/status_test.go
+++ b/pkg/cri/server/status_test.go
@@ -1,0 +1,50 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"testing"
+
+	"github.com/containerd/containerd/api/services/introspection/v1"
+	"github.com/stretchr/testify/assert"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+func TestRuntimeConditionContainerdHasNoDeprecationWarnings(t *testing.T) {
+	deprecations := []*introspection.DeprecationWarning{
+		{
+			ID:      "io.containerd.deprecation/foo",
+			Message: "foo",
+		},
+	}
+
+	cond, err := runtimeConditionContainerdHasNoDeprecationWarnings(deprecations, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, &runtime.RuntimeCondition{
+		Type:    ContainerdHasNoDeprecationWarnings,
+		Status:  false,
+		Reason:  ContainerdHasDeprecationWarnings,
+		Message: `{"io.containerd.deprecation/foo":"foo"}`,
+	}, cond)
+
+	cond, err = runtimeConditionContainerdHasNoDeprecationWarnings(deprecations, []string{"io.containerd.deprecation/foo"})
+	assert.NoError(t, err)
+	assert.Equal(t, &runtime.RuntimeCondition{
+		Type:   ContainerdHasNoDeprecationWarnings,
+		Status: true,
+	}, cond)
+}


### PR DESCRIPTION
Cherry-pick (non-clean):
- #9767