### PR TITLE
[release/1.6] Move high volume event logs to Trace level

### DIFF
--- a/events/exchange/exchange.go
+++ b/events/exchange/exchange.go
@@ -69,7 +69,7 @@ func (e *Exchange) Forward(ctx context.Context, envelope *events.Envelope) (err 
 		if err != nil {
 			logger.WithError(err).Error("error forwarding event")
 		} else {
-			logger.Debug("event forwarded")
+			logger.Trace("event forwarded")
 		}
 	}()
 
@@ -114,7 +114,7 @@ func (e *Exchange) Publish(ctx context.Context, topic string, event events.Event
 		if err != nil {
 			logger.WithError(err).Error("error publishing event")
 		} else {
-			logger.Debug("event published")
+			logger.Trace("event published")
 		}
 	}()
 


### PR DESCRIPTION
(cherry picked from commit 4dcf089fa30ebc3a733edbaedc79130c21a9b887)