### PR TITLE
Move config version to version package

### DIFF
--- a/cmd/containerd/command/config.go
+++ b/cmd/containerd/command/config.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/pkg/timeout"
+	"github.com/containerd/containerd/v2/version"
 	"github.com/containerd/plugin/registry"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pelletier/go-toml/v2"
@@ -69,7 +70,7 @@ func outputConfig(ctx gocontext.Context, config *srvconfig.Config) error {
 	// when a config without a version is loaded from disk and has no version
 	// set, we assume it's a v1 config.  But when generating new configs via
 	// this command, generate the max configuration version
-	config.Version = srvconfig.CurrentConfigVersion
+	config.Version = version.ConfigVersion
 
 	return toml.NewEncoder(os.Stdout).SetIndentTables(true).Encode(config)
 }
@@ -112,7 +113,7 @@ var configCommand = cli.Command{
 					return err
 				}
 
-				if config.Version < srvconfig.CurrentConfigVersion {
+				if config.Version < version.ConfigVersion {
 					plugins := registry.Graph(srvconfig.V2DisabledFilter(config.DisabledPlugins))
 					for _, p := range plugins {
 						if p.ConfigMigration != nil {
@@ -145,7 +146,7 @@ var configCommand = cli.Command{
 					}
 				}
 
-				config.Version = srvconfig.CurrentConfigVersion
+				config.Version = version.ConfigVersion
 
 				return toml.NewEncoder(os.Stdout).SetIndentTables(true).Encode(config)
 			},
@@ -155,7 +156,7 @@ var configCommand = cli.Command{
 
 func platformAgnosticDefaultConfig() *srvconfig.Config {
 	return &srvconfig.Config{
-		Version: srvconfig.CurrentConfigVersion,
+		Version: version.ConfigVersion,
 		Root:    defaults.DefaultRootDir,
 		State:   defaults.DefaultStateDir,
 		GRPC: srvconfig.GRPCConfig{

--- a/cmd/containerd/server/config/config.go
+++ b/cmd/containerd/server/config/config.go
@@ -36,13 +36,11 @@ import (
 	"dario.cat/mergo"
 	"github.com/pelletier/go-toml/v2"
 
+	"github.com/containerd/containerd/v2/version"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/plugin"
 )
-
-// CurrentConfigVersion is the max config version which is supported
-const CurrentConfigVersion = 3
 
 // migrations hold the migration functions for every prior containerd config version
 var migrations = []func(context.Context, *Config) error{
@@ -115,8 +113,8 @@ type StreamProcessor struct {
 
 // ValidateVersion validates the config for a v2 file
 func (c *Config) ValidateVersion() error {
-	if c.Version > CurrentConfigVersion {
-		return fmt.Errorf("expected containerd config version equal to or less than `%d`, got `%d`", CurrentConfigVersion, c.Version)
+	if c.Version > version.ConfigVersion {
+		return fmt.Errorf("expected containerd config version equal to or less than `%d`, got `%d`", version.ConfigVersion, c.Version)
 	}
 
 	for _, p := range c.DisabledPlugins {
@@ -135,7 +133,7 @@ func (c *Config) ValidateVersion() error {
 
 // MigrateConfig will convert the config to the latest version before using
 func (c *Config) MigrateConfig(ctx context.Context) error {
-	for c.Version < CurrentConfigVersion {
+	for c.Version < version.ConfigVersion {
 		if m := migrations[c.Version]; m != nil {
 			if err := m(ctx, c); err != nil {
 				return err

--- a/cmd/containerd/server/config/config_test.go
+++ b/cmd/containerd/server/config/config_test.go
@@ -25,12 +25,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/containerd/containerd/v2/version"
 	"github.com/containerd/log/logtest"
 )
 
 func TestMigrations(t *testing.T) {
-	if len(migrations) != CurrentConfigVersion {
-		t.Fatalf("Migration missing, expected %d migrations, only %d defined", CurrentConfigVersion, len(migrations))
+	if len(migrations) != version.ConfigVersion {
+		t.Fatalf("Migration missing, expected %d migrations, only %d defined", version.ConfigVersion, len(migrations))
 	}
 }
 

--- a/cmd/containerd/server/server_test.go
+++ b/cmd/containerd/server/server_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	srvconfig "github.com/containerd/containerd/v2/cmd/containerd/server/config"
+	"github.com/containerd/containerd/v2/version"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
 	"github.com/stretchr/testify/assert"
@@ -61,7 +62,7 @@ func TestMigration(t *testing.T) {
 	registry.Reset()
 	defer registry.Reset()
 
-	version := srvconfig.CurrentConfigVersion - 1
+	configVersion := version.ConfigVersion - 1
 
 	type testConfig struct {
 		Migrated    string `toml:"migrated"`
@@ -109,7 +110,7 @@ func TestMigration(t *testing.T) {
 			return nil, nil
 		},
 		ConfigMigration: func(ctx context.Context, v int, plugins map[string]interface{}) error {
-			if v != version {
+			if v != configVersion {
 				t.Errorf("unxpected version: %d", v)
 			}
 			t1, ok := plugins["io.containerd.test.t1"]
@@ -133,7 +134,7 @@ func TestMigration(t *testing.T) {
 	})
 
 	config := &srvconfig.Config{}
-	config.Version = version
+	config.Version = configVersion
 	config.Plugins = map[string]interface{}{
 		"io.containerd.test.t1": map[string]interface{}{
 			"migrated":    "migrate me",

--- a/contrib/fuzz/daemon.go
+++ b/contrib/fuzz/daemon.go
@@ -27,6 +27,7 @@ import (
 	"github.com/containerd/containerd/v2/cmd/containerd/server/config"
 	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/pkg/sys"
+	"github.com/containerd/containerd/v2/version"
 	"github.com/containerd/log"
 )
 
@@ -51,7 +52,7 @@ func startDaemon() {
 		defer close(errC)
 
 		srvconfig := &config.Config{
-			Version: config.CurrentConfigVersion,
+			Version: version.ConfigVersion,
 			Root:    defaultRoot,
 			State:   defaultState,
 			Debug: config.Debug{

--- a/plugins/cri/cri.go
+++ b/plugins/cri/cri.go
@@ -26,7 +26,6 @@ import (
 	"github.com/containerd/plugin/registry"
 
 	containerd "github.com/containerd/containerd/v2/client"
-	srvconfig "github.com/containerd/containerd/v2/cmd/containerd/server/config"
 	"github.com/containerd/containerd/v2/core/sandbox"
 	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
 	"github.com/containerd/containerd/v2/internal/cri/constants"
@@ -36,6 +35,7 @@ import (
 	nriservice "github.com/containerd/containerd/v2/pkg/nri"
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/containerd/v2/plugins/services/warning"
+	"github.com/containerd/containerd/v2/version"
 	"github.com/containerd/platforms"
 
 	"google.golang.org/grpc"
@@ -61,8 +61,8 @@ func init() {
 			plugins.WarningPlugin,
 		},
 		Config: &defaultConfig,
-		ConfigMigration: func(ctx context.Context, version int, pluginConfigs map[string]interface{}) error {
-			if version >= srvconfig.CurrentConfigVersion {
+		ConfigMigration: func(ctx context.Context, configVersion int, pluginConfigs map[string]interface{}) error {
+			if configVersion >= version.ConfigVersion {
 				return nil
 			}
 			const pluginName = string(plugins.GRPCPlugin) + ".cri"

--- a/plugins/cri/images/plugin.go
+++ b/plugins/cri/images/plugin.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 
 	containerd "github.com/containerd/containerd/v2/client"
-	srvconfig "github.com/containerd/containerd/v2/cmd/containerd/server/config"
 	"github.com/containerd/containerd/v2/core/metadata"
 	"github.com/containerd/containerd/v2/core/snapshots"
 	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
@@ -30,6 +29,7 @@ import (
 	"github.com/containerd/containerd/v2/internal/cri/server/images"
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/containerd/v2/plugins/services/warning"
+	"github.com/containerd/containerd/v2/version"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
 	"github.com/containerd/plugin"
@@ -154,8 +154,8 @@ func init() {
 	})
 }
 
-func configMigration(ctx context.Context, version int, pluginConfigs map[string]interface{}) error {
-	if version >= srvconfig.CurrentConfigVersion {
+func configMigration(ctx context.Context, configVersion int, pluginConfigs map[string]interface{}) error {
+	if configVersion >= version.ConfigVersion {
 		return nil
 	}
 	original, ok := pluginConfigs[string(plugins.GRPCPlugin)+".cri"]

--- a/plugins/cri/runtime/plugin.go
+++ b/plugins/cri/runtime/plugin.go
@@ -30,12 +30,12 @@ import (
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	"k8s.io/klog/v2"
 
-	srvconfig "github.com/containerd/containerd/v2/cmd/containerd/server/config"
 	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
 	"github.com/containerd/containerd/v2/internal/cri/constants"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/containerd/v2/plugins/services/warning"
+	"github.com/containerd/containerd/v2/version"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
 )
@@ -51,8 +51,8 @@ func init() {
 		Requires: []plugin.Type{
 			plugins.WarningPlugin,
 		},
-		ConfigMigration: func(ctx context.Context, version int, pluginConfigs map[string]interface{}) error {
-			if version >= srvconfig.CurrentConfigVersion {
+		ConfigMigration: func(ctx context.Context, configVersion int, pluginConfigs map[string]interface{}) error {
+			if configVersion >= version.ConfigVersion {
 				return nil
 			}
 			c, ok := pluginConfigs[string(plugins.GRPCPlugin)+".cri"]

--- a/version/version.go
+++ b/version/version.go
@@ -32,3 +32,9 @@ var (
 	// GoVersion is Go tree's version.
 	GoVersion = runtime.Version()
 )
+
+// ConfigVersion is the current highest supported configuration version.
+// This version is used by the main configuration as well as all plugins.
+// Any configuration less than this version which has structural changes
+// should migrate the configuration structures used by this version.
+const ConfigVersion = 3


### PR DESCRIPTION
Moving the config version prevents needing to importing config from under `cmd` into `plugins` or `internal`. Even if we move `config` out of `cmd`  to `internal`, we will still want the version accessible for importers to handle config migration.