### PR TITLE
Run failpoints tests only for runc

### DIFF
--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -1426,8 +1426,8 @@ func TestShimOOMScore(t *testing.T) {
 // status after container.NewTask. It's used to simulate that the runc-init
 // might be killed by oom-kill.
 func TestIssue9103(t *testing.T) {
-	if os.Getenv("RUNC_FLAVOR") == "crun" {
-		t.Skip("skip it when using crun")
+	if f := os.Getenv("RUNC_FLAVOR"); f != "" && f != "runc" {
+		t.Skip("test requires runc")
 	}
 
 	client, err := newClient(t, address)

--- a/integration/client/container_test.go
+++ b/integration/client/container_test.go
@@ -795,8 +795,8 @@ func TestKillContainerDeletedByRunc(t *testing.T) {
 
 	// We skip this case when runtime is crun.
 	// More information in https://github.com/containerd/containerd/pull/4214#discussion_r422769497
-	if os.Getenv("RUNC_FLAVOR") == "crun" {
-		t.Skip("skip it when using crun")
+	if f := os.Getenv("RUNC_FLAVOR"); f != "" && f != "runc" {
+		t.Skip("test requires runc")
 	}
 
 	client, err := newClient(t, address)


### PR DESCRIPTION
In current implementation, there a few tests specific to `runc-fp`, so we have the following check to exclude them for `crun`:

```go
if os.Getenv("RUNC_FLAVOR") == "crun" {
    t.Skip("skip it when using crun")
}
```

We also run tests for rust-shim in rust-extensions and these tests fail.
This PR flips the logic for `RUNC_FLAVOR` env, so we don't have to pretend to be `crun`.