### PR TITLE
[Backport 1.6] Fix config import relative path glob

### DIFF
--- a/services/server/config/config.go
+++ b/services/server/config/config.go
@@ -289,13 +289,18 @@ func loadConfigFile(path string) (*Config, error) {
 }
 
 // resolveImports resolves import strings list to absolute paths list:
-// - If path contains *, glob pattern matching applied
 // - Non abs path is relative to parent config file directory
+// - If path contains *, glob pattern matching applied
 // - Abs paths returned as is
 func resolveImports(parent string, imports []string) ([]string, error) {
 	var out []string
 
 	for _, path := range imports {
+		path := filepath.Clean(path)
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(filepath.Dir(parent), path)
+		}
+
 		if strings.Contains(path, "*") {
 			matches, err := filepath.Glob(path)
 			if err != nil {
@@ -304,11 +309,6 @@ func resolveImports(parent string, imports []string) ([]string, error) {
 
 			out = append(out, matches...)
 		} else {
-			path = filepath.Clean(path)
-			if !filepath.IsAbs(path) {
-				path = filepath.Join(filepath.Dir(parent), path)
-			}
-
 			out = append(out, path)
 		}
 	}

--- a/services/server/config/config_test.go
+++ b/services/server/config/config_test.go
@@ -81,6 +81,17 @@ func TestResolveImports(t *testing.T) {
 		filepath.Join(tempDir, "test.toml"),
 		filepath.Join(tempDir, "current.toml"),
 	})
+
+	t.Run("GlobRelativePath", func(t *testing.T) {
+		imports, err := resolveImports(filepath.Join(tempDir, "root.toml"), []string{
+			"config_*.toml", // Glob files from working dir
+		})
+		assert.NilError(t, err)
+		assert.DeepEqual(t, imports, []string{
+			filepath.Join(tempDir, "config_1.toml"),
+			filepath.Join(tempDir, "config_2.toml"),
+		})
+	})
 }
 
 func TestLoadSingleConfig(t *testing.T) {


### PR DESCRIPTION
## Summary

Backport #9834 to 1.6 branch

## Changes

Previously, resolveImports would apply a glob filter if the path contained any '*', or otherwise convert relative paths to absolute. This meant that it was impossible to specify globs with paths relative to the main config file.

This commit first resolves relative to absolute paths, then applies the glob filter (if any). A test case is added to ensure that this now works as expected.