### PR TITLE
[release/1.7] Add WithMetaStore to overlay snapshotter and missing unpacker.Wait for image import

### DIFF
--- a/pkg/transfer/local/import.go
+++ b/pkg/transfer/local/import.go
@@ -113,8 +113,18 @@ func (ts *localTransferService) importStream(ctx context.Context, i transfer.Ima
 	}
 
 	if err := images.WalkNotEmpty(ctx, handler, index); err != nil {
+		if unpacker != nil {
+			// wait for unpacker to cleanup
+			unpacker.Wait()
+		}
 		// TODO: Handle Not Empty as a special case on the input
 		return err
+	}
+
+	if unpacker != nil {
+		if _, err = unpacker.Wait(); err != nil {
+			return err
+		}
 	}
 
 	for _, desc := range descriptors {


### PR DESCRIPTION
Fixes #9826 

Backports the following PRs to `release/1.7`:
- https://github.com/containerd/containerd/pull/8945
- https://github.com/containerd/containerd/pull/9028

Unblocks https://github.com/k3s-io/k3s/pull/9319



