### PR TITLE
otel: support resource from env variables

### DIFF
--- a/pkg/tracing/plugin/otlp.go
+++ b/pkg/tracing/plugin/otlp.go
@@ -155,6 +155,8 @@ func newTracer(ctx context.Context, config *TraceConfig, procs []trace.SpanProce
 			// Service name used to displace traces in backends
 			semconv.ServiceNameKey.String(config.ServiceName),
 		),
+		// pull attributes from OTEL_RESOURCE_ATTRIBUTES and OTEL_SERVICE_NAME environment variables
+		resource.WithFromEnv(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create resource: %w", err)


### PR DESCRIPTION
This PR enables the setting of official OpenTelemetry environment variables, enhancing integration with larger products like Datadog.

A specific example is configuring the hostname differently, using the one returned from the host `resource.WithHost()`.

Currently, my hostname is set as:
```
cat /etc/hostname
ip-10-1-2-3
```

And the AWS IMDS:
```
curl 169.254.169.254/latest/meta-data/hostname
ip-10-1-2-3.ec2.internal
```

This PR allows to configure the [following entries](https://github.com/open-telemetry/opentelemetry-specification/blob/5d9cef817415a15aaa4883e184a38adec79096ed/specification/configuration/sdk-environment-variables.md?plain=1#L88-L96).
