### PR TITLE
replace deprecated Prestart to CreateRuntime hook

### DIFF
--- a/contrib/nvidia/nvidia.go
+++ b/contrib/nvidia/nvidia.go
@@ -87,7 +87,7 @@ func WithGPUs(opts ...Opts) oci.SpecOpts {
 		if s.Hooks == nil {
 			s.Hooks = &specs.Hooks{}
 		}
-		s.Hooks.Prestart = append(s.Hooks.Prestart, specs.Hook{
+		s.Hooks.CreateRuntime = append(s.Hooks.CreateRuntime, specs.Hook{
 			Path: c.OCIHookPath,
 			Args: append([]string{
 				"containerd",

--- a/integration/client/container_test.go
+++ b/integration/client/container_test.go
@@ -1737,7 +1737,7 @@ func TestContainerHook(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		s.Hooks.Prestart = []specs.Hook{
+		s.Hooks.CreateRuntime = []specs.Hook{
 			{
 				Path: path,
 				Args: []string{


### PR DESCRIPTION
Prestart Hook is deprecated and can be replaced with CreateRuntime hook; As we update the runtime-spec version to v1.2.0.

