### PR TITLE
Log response body for Unexpected HTTP Status from the Registry API

### DIFF
--- a/core/remotes/docker/auth/fetch.go
+++ b/core/remotes/docker/auth/fetch.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	remoteserrors "github.com/containerd/containerd/v2/core/remotes/errors"
+	remoteserrors "github.com/containerd/containerd/v2/core/remotes/docker/errors"
 	"github.com/containerd/containerd/v2/version"
 	"github.com/containerd/log"
 )

--- a/core/remotes/docker/authorizer.go
+++ b/core/remotes/docker/authorizer.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/v2/core/remotes/docker/auth"
-	remoteerrors "github.com/containerd/containerd/v2/core/remotes/errors"
+	remoteerrors "github.com/containerd/containerd/v2/core/remotes/docker/errors"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 )
@@ -322,7 +322,7 @@ func (ah *authHandler) doBearerAuth(ctx context.Context) (token, refreshToken st
 				}
 				log.G(ctx).WithFields(log.Fields{
 					"status": errStatus.Status,
-					"body":   string(errStatus.Body),
+					"body":   errStatus.Body,
 				}).Debugf("token request failed")
 			}
 			return "", "", err

--- a/core/remotes/docker/authorizer.go
+++ b/core/remotes/docker/authorizer.go
@@ -322,7 +322,7 @@ func (ah *authHandler) doBearerAuth(ctx context.Context) (token, refreshToken st
 				}
 				log.G(ctx).WithFields(log.Fields{
 					"status": errStatus.Status,
-					"body":   errStatus.Body,
+					"body":   errStatus.Body.Error(),
 				}).Debugf("token request failed")
 			}
 			return "", "", err

--- a/core/remotes/docker/errors/errcode.go
+++ b/core/remotes/docker/errors/errcode.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package docker
+package errors
 
 import (
 	"encoding/json"

--- a/core/remotes/docker/errors/errdesc.go
+++ b/core/remotes/docker/errors/errdesc.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package docker
+package errors
 
 import (
 	"fmt"

--- a/core/remotes/docker/errors/errors.go
+++ b/core/remotes/docker/errors/errors.go
@@ -36,7 +36,7 @@ type ErrUnexpectedStatus struct {
 func (e ErrUnexpectedStatus) Error() string {
 	errorMessage := fmt.Sprintf("unexpected status from %s request to %s: %s", e.RequestMethod, e.RequestURL, e.Status)
 	if e.Body.Len() > 0 {
-		errorMessage += fmt.Sprintf(" - Server message: %+v", e.Body)
+		errorMessage += fmt.Sprintf("\n%s", e.Body.Error())
 	}
 	return errorMessage
 }

--- a/core/remotes/docker/fetcher.go
+++ b/core/remotes/docker/fetcher.go
@@ -30,8 +30,10 @@ import (
 
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/remotes"
+	remoteerrors "github.com/containerd/containerd/v2/core/remotes/docker/errors"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+
 	"github.com/klauspost/compress/zstd"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -296,7 +298,7 @@ func (r dockerFetcher) open(ctx context.Context, req *request, mediatype string,
 		if resp.StatusCode == http.StatusNotFound {
 			return nil, fmt.Errorf("content at %v not found: %w", req.String(), errdefs.ErrNotFound)
 		}
-		var registryErr Errors
+		var registryErr remoteerrors.Errors
 		if err := json.NewDecoder(resp.Body).Decode(&registryErr); err != nil || registryErr.Len() < 1 {
 			return nil, fmt.Errorf("unexpected status code %v: %v", req.String(), resp.Status)
 		}

--- a/core/remotes/docker/fetcher_test.go
+++ b/core/remotes/docker/fetcher_test.go
@@ -31,6 +31,7 @@ import (
 	"strconv"
 	"testing"
 
+	remoteerrors "github.com/containerd/containerd/v2/core/remotes/docker/errors"
 	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/assert"
 )
@@ -279,8 +280,8 @@ func TestDockerFetcherOpen(t *testing.T) {
 		{
 			name:         "should return status and error.message if it exists if the registry request fails",
 			mockedStatus: 500,
-			mockedErr: Errors{Error{
-				Code:    ErrorCodeUnknown,
+			mockedErr: remoteerrors.Errors{remoteerrors.Error{
+				Code:    remoteerrors.ErrorCodeUnknown,
 				Message: "Test Error",
 			}},
 			want:                   nil,

--- a/core/remotes/docker/pusher.go
+++ b/core/remotes/docker/pusher.go
@@ -149,7 +149,7 @@ func (p dockerPusher) push(ctx context.Context, desc ocispec.Descriptor, ref str
 			}
 		} else if resp.StatusCode != http.StatusNotFound {
 			err := remoteserrors.NewUnexpectedStatusErr(resp)
-			log.G(ctx).WithField("resp", resp).WithField("body", err.(remoteserrors.ErrUnexpectedStatus).Body).Debug("unexpected response")
+			log.G(ctx).WithField("resp", resp).WithField("body", err.(remoteserrors.ErrUnexpectedStatus).Body.Error()).Debug("unexpected response")
 			resp.Body.Close()
 			return nil, err
 		}
@@ -220,7 +220,7 @@ func (p dockerPusher) push(ctx context.Context, desc ocispec.Descriptor, ref str
 			return nil, fmt.Errorf("content %v on remote: %w", desc.Digest, errdefs.ErrAlreadyExists)
 		default:
 			err := remoteserrors.NewUnexpectedStatusErr(resp)
-			log.G(ctx).WithField("resp", resp).WithField("body", err.(remoteserrors.ErrUnexpectedStatus).Body).Debug("unexpected response")
+			log.G(ctx).WithField("resp", resp).WithField("body", err.(remoteserrors.ErrUnexpectedStatus).Body.Error()).Debug("unexpected response")
 			return nil, err
 		}
 
@@ -295,7 +295,7 @@ func (p dockerPusher) push(ctx context.Context, desc ocispec.Descriptor, ref str
 		case http.StatusOK, http.StatusCreated, http.StatusNoContent:
 		default:
 			err := remoteserrors.NewUnexpectedStatusErr(resp)
-			log.G(ctx).WithField("resp", resp).WithField("body", err.(remoteserrors.ErrUnexpectedStatus).Body).Debug("unexpected response")
+			log.G(ctx).WithField("resp", resp).WithField("body", err.(remoteserrors.ErrUnexpectedStatus).Body.Error()).Debug("unexpected response")
 			pushw.setError(err)
 			return
 		}

--- a/core/remotes/docker/pusher.go
+++ b/core/remotes/docker/pusher.go
@@ -31,7 +31,7 @@ import (
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/remotes"
-	remoteserrors "github.com/containerd/containerd/v2/core/remotes/errors"
+	remoteserrors "github.com/containerd/containerd/v2/core/remotes/docker/errors"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	digest "github.com/opencontainers/go-digest"
@@ -149,7 +149,7 @@ func (p dockerPusher) push(ctx context.Context, desc ocispec.Descriptor, ref str
 			}
 		} else if resp.StatusCode != http.StatusNotFound {
 			err := remoteserrors.NewUnexpectedStatusErr(resp)
-			log.G(ctx).WithField("resp", resp).WithField("body", string(err.(remoteserrors.ErrUnexpectedStatus).Body)).Debug("unexpected response")
+			log.G(ctx).WithField("resp", resp).WithField("body", err.(remoteserrors.ErrUnexpectedStatus).Body).Debug("unexpected response")
 			resp.Body.Close()
 			return nil, err
 		}
@@ -220,7 +220,7 @@ func (p dockerPusher) push(ctx context.Context, desc ocispec.Descriptor, ref str
 			return nil, fmt.Errorf("content %v on remote: %w", desc.Digest, errdefs.ErrAlreadyExists)
 		default:
 			err := remoteserrors.NewUnexpectedStatusErr(resp)
-			log.G(ctx).WithField("resp", resp).WithField("body", string(err.(remoteserrors.ErrUnexpectedStatus).Body)).Debug("unexpected response")
+			log.G(ctx).WithField("resp", resp).WithField("body", err.(remoteserrors.ErrUnexpectedStatus).Body).Debug("unexpected response")
 			return nil, err
 		}
 
@@ -295,7 +295,7 @@ func (p dockerPusher) push(ctx context.Context, desc ocispec.Descriptor, ref str
 		case http.StatusOK, http.StatusCreated, http.StatusNoContent:
 		default:
 			err := remoteserrors.NewUnexpectedStatusErr(resp)
-			log.G(ctx).WithField("resp", resp).WithField("body", string(err.(remoteserrors.ErrUnexpectedStatus).Body)).Debug("unexpected response")
+			log.G(ctx).WithField("resp", resp).WithField("body", err.(remoteserrors.ErrUnexpectedStatus).Body).Debug("unexpected response")
 			pushw.setError(err)
 			return
 		}

--- a/core/remotes/docker/resolver.go
+++ b/core/remotes/docker/resolver.go
@@ -30,8 +30,8 @@ import (
 
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/remotes"
+	remoteerrors "github.com/containerd/containerd/v2/core/remotes/docker/errors"
 	"github.com/containerd/containerd/v2/core/remotes/docker/schema1" //nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
-	remoteerrors "github.com/containerd/containerd/v2/core/remotes/errors"
 	"github.com/containerd/containerd/v2/pkg/reference"
 	"github.com/containerd/containerd/v2/pkg/tracing"
 	"github.com/containerd/containerd/v2/version"

--- a/core/remotes/docker/resolver_test.go
+++ b/core/remotes/docker/resolver_test.go
@@ -34,7 +34,7 @@ import (
 
 	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/containerd/containerd/v2/core/remotes/docker/auth"
-	remoteerrors "github.com/containerd/containerd/v2/core/remotes/errors"
+	remoteerrors "github.com/containerd/containerd/v2/core/remotes/docker/errors"
 	"github.com/containerd/errdefs"
 	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go"

--- a/core/remotes/errors/errors.go
+++ b/core/remotes/errors/errors.go
@@ -33,7 +33,11 @@ type ErrUnexpectedStatus struct {
 }
 
 func (e ErrUnexpectedStatus) Error() string {
-	return fmt.Sprintf("unexpected status from %s request to %s: %s", e.RequestMethod, e.RequestURL, e.Status)
+	errorMessage := fmt.Sprintf("unexpected status from %s request to %s: %s", e.RequestMethod, e.RequestURL, e.Status)
+	if len(e.Body) > 0 {
+		errorMessage += fmt.Sprintf("\nResponse Body: %s", string(e.Body))
+	}
+	return errorMessage
 }
 
 // NewUnexpectedStatusErr creates an ErrUnexpectedStatus from HTTP response


### PR DESCRIPTION
## Description

Enhanced error messages in the `ErrUnexpectedStatus` type to include [response body details](https://docker-docs.uclv.cu/registry/spec/api/#errors) when available. This improvement provides more comprehensive information for handling unexpected HTTP status errors from the registry API.

## Actual behavior

Working with an immutable repository in AWS ECR, trying to overwrite an existing tag would result in a non-actionable error message.

```
docker buildx build --platform linux/amd64,linux/arm64 -t my.ecr.registry/team/image:master --push .

------
 > exporting to image:
------
ERROR: failed to solve: failed to push my.ecr.registry/team/image:master: failed commit on ref "index-sha256:930ca213bf3ca959d58b809b3d2e112aeef663163584da557b7567eef2c8c626": unexpected status from PUT request to https://my.ecr.registry/v2/team/image/manifests/master: 400 Bad Request
```

## Expected behavior

Alongside the HTTP code status, printing the body would help understand the root cause of the failure. e.g.
```
Response body: { "errors": [{ "code": "TAG_INVALID", "message": "The image tag 'pr-194-2' already exists in the 'my_namespace/team/image' repository and cannot be overwritten because the repository is immutable."}] }
```
