### PR TITLE
endpoint listeners: improve the error message when running as non root

### DIFF
--- a/pkg/sys/socket_unix.go
+++ b/pkg/sys/socket_unix.go
@@ -61,7 +61,7 @@ func GetLocalListener(path string, uid, gid int) (net.Listener, error) {
 
 	if err := os.Chown(path, uid, gid); err != nil {
 		l.Close()
-		return nil, err
+		return nil, fmt.Errorf("%w uid(%d) gid(%d)", err, uid, gid)
 	}
 
 	return l, nil


### PR DESCRIPTION
This PR is enhancing the error message when running containerd in userland when misconfiguring the uid/gid in the toml ttrpc & grpc sections.

When unsetting uid & gid, they're defaulting to 0 which is root.

A good userland configuration would look like:
```toml
[ttrpc]
    address = "/tmp/ttrpc.sock"
    uid = 1000
    gid = 1000

[grpc]
    address = "/tmp/grpc.sock"
    uid = 1000
    gid = 1000
```

Before:
```
containerd: failed to get listener for main ttrpc endpoint: chown /home/jb/go/src/github.com/containerd/containerd/bin/run/ttrpc.sock: operation not permitted
``` 

After:
```
containerd: failed to get listener for main ttrpc endpoint: chown /home/jb/go/src/github.com/containerd/containerd/bin/run/ttrpc.sock: operation not permitted uid(0) gid(0)
``` 