### PR TITLE
Add file name to device type check failure message

### DIFF
--- a/pkg/oci/utils_unix.go
+++ b/pkg/oci/utils_unix.go
@@ -30,6 +30,7 @@ import (
 )
 
 // ErrNotADevice denotes that a file is not a valid linux device.
+// When checking this error, use errors.Is(err, oci.ErrNotADevice)
 var ErrNotADevice = errors.New("not a device node")
 
 // Testing dependencies
@@ -53,6 +54,10 @@ func getDevices(path, containerPath string) ([]specs.LinuxDevice, error) {
 	if !stat.IsDir() {
 		dev, err := DeviceFromPath(path)
 		if err != nil {
+			// wrap error with detailed path and container path when it is ErrNotADevice
+			if err == ErrNotADevice {
+				return nil, fmt.Errorf("get device path: %q containerPath: %q error: %w", path, containerPath, err)
+			}
 			return nil, err
 		}
 		if containerPath != "" {


### PR DESCRIPTION
Issue:
https://github.com/containerd/containerd/issues/9857

With this fix, we have such new error message:
 
>time="2024-02-22T16:12:00.555149600Z" level=error msg="CreateContainer within sandbox "d23af3219cb27228623cf8168ec27e64e836ed44f2b2f9cf784f0529a7f92e1e" for &ContainerMetadata{Name:compute,Attempt:0,} failed" error="failed to generate container "c6c1877ec55219a3726c589dc280f6f79dbbeff3b21efa243bf96fb89481d04d" spec: failed to generate spec: get device path: /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/publish/pvc-3c1b28fb-683e-4bf5-9869-c9107a0f1732/20291c6b-62c3-4456-be8a-fbeac118ec19 containerPath: /dev/disk-0 error: not a device node"

Added information like `/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/publish/pvc-3c1b28fb-683e-4bf5-9869-c9107a0f1732/20291c6b-62c3-4456-be8a-fbeac118ec19` is very help for toubleshooting.

This PR is an alternative to PR https://github.com/containerd/containerd/pull/9424 (sorry, after committing PR 9858, found 9424), it does not change the return value of public function `DeviceFromPath`, but instead, wrap the error of `getDevices`, and `errors.Is(err, oci.ErrNotADevice)` returns true for this re-wrapped error.