### PR TITLE
mediatypes: support zstd compression

### DIFF
--- a/core/images/mediatypes.go
+++ b/core/images/mediatypes.go
@@ -34,6 +34,7 @@ const (
 	MediaTypeDockerSchema2Layer            = "application/vnd.docker.image.rootfs.diff.tar"
 	MediaTypeDockerSchema2LayerForeign     = "application/vnd.docker.image.rootfs.foreign.diff.tar"
 	MediaTypeDockerSchema2LayerGzip        = "application/vnd.docker.image.rootfs.diff.tar.gzip"
+	MediaTypeDockerSchema2LayerZstd        = "application/vnd.docker.image.rootfs.diff.tar.zstd"
 	MediaTypeDockerSchema2LayerForeignGzip = "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip"
 	MediaTypeDockerSchema2Config           = "application/vnd.docker.container.image.v1+json"
 	MediaTypeDockerSchema2Manifest         = "application/vnd.docker.distribution.manifest.v2+json"
@@ -81,6 +82,12 @@ func DiffCompression(ctx context.Context, mediaType string) (string, error) {
 			return "", nil
 		}
 		return "gzip", nil
+	case MediaTypeDockerSchema2LayerZstd:
+		if len(ext) > 0 {
+			// Type is wrapped
+			return "", nil
+		}
+		return "zstd", nil
 	case ocispec.MediaTypeImageLayer, ocispec.MediaTypeImageLayerNonDistributable: //nolint:staticcheck // Non-distributable layers are deprecated
 		if len(ext) > 0 {
 			switch ext[len(ext)-1] {
@@ -132,7 +139,7 @@ func IsLayerType(mt string) bool {
 	// Parse Docker media types, strip off any + suffixes first
 	switch base, _ := parseMediaTypes(mt); base {
 	case MediaTypeDockerSchema2Layer, MediaTypeDockerSchema2LayerGzip,
-		MediaTypeDockerSchema2LayerForeign, MediaTypeDockerSchema2LayerForeignGzip:
+		MediaTypeDockerSchema2LayerForeign, MediaTypeDockerSchema2LayerForeignGzip, MediaTypeDockerSchema2LayerZstd:
 		return true
 	}
 	return false


### PR DESCRIPTION
This PR enables to support zstd compression over docker media types.

Before this change, containerd is unable to pull zstd compressed images and is returning the following error log:
```
ATA[0005] pulling image: failed to pull and unpack image "registry.somewhere.io/image:jb-zstd": failed to extract layer sha256:2be6f9ac9ccbcab5c4ea65a6ff0df74002b910d8a52e9147cf1dbc0a38f01azz: failed to get stream processor for application/vnd.docker.image.rootfs.diff.tar.zstd: no processor for media-type: unknown 
``` 