### PR TITLE
adds mediatype to oci index record

### DIFF
--- a/core/images/archive/exporter.go
+++ b/core/images/archive/exporter.go
@@ -466,6 +466,7 @@ func ociIndexRecord(manifests []ocispec.Descriptor) tarRecord {
 		Versioned: ocispecs.Versioned{
 			SchemaVersion: 2,
 		},
+		MediaType: ocispec.MediaTypeImageIndex,
 		Manifests: manifests,
 	}
 


### PR DESCRIPTION
While digging into [buildkit issue #4595](https://github.com/moby/buildkit/issues/4595), we noticed that this would also be appropriate to add into containerd to better match spec. 