### PR TITLE
.github: windows should use fix critool version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,7 @@ jobs:
         with:
           repository: kubernetes-sigs/cri-tools
           path: src/github.com/kubernetes-sigs/cri-tools
+          fetch-depth: 0
 
       - name: Set env
         run: |
@@ -257,7 +258,9 @@ jobs:
         run: |
           set -o xtrace
           mingw32-make.exe binaries
+          CRITEST_VERSION=$(cat script/setup/critools-version)
           cd ../../kubernetes-sigs/cri-tools
+          git checkout "${CRITEST_VERSION}"
           make critest
 
       - run: script/setup/install-cni-windows


### PR DESCRIPTION
It's trying to fix CI issue https://github.com/containerd/containerd/pull/9855

https://github.com/containerd/containerd/actions/runs/8015987871/job/21897145968?pr=9855

> NOTE: Maybe we should maintain a script to download critools, like what we do in linux platform. cc @kiashok 



