### PR TITLE
[WIP] Introduce credential plugin

### DIFF
--- a/cmd/containerd/builtins/builtins.go
+++ b/cmd/containerd/builtins/builtins.go
@@ -19,6 +19,7 @@ package builtins
 // register containerd builtins here
 import (
 	_ "github.com/containerd/containerd/v2/core/runtime/v2"
+	_ "github.com/containerd/containerd/v2/plugins/credential"
 	_ "github.com/containerd/containerd/v2/plugins/events"
 	_ "github.com/containerd/containerd/v2/plugins/gc"
 	_ "github.com/containerd/containerd/v2/plugins/imageverifier"

--- a/core/credential/credential.go
+++ b/core/credential/credential.go
@@ -1,0 +1,72 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package credential
+
+import (
+	"context"
+
+	transfertypes "github.com/containerd/containerd/v2/api/types/transfer"
+)
+
+type CredsStoreType string
+
+const (
+	// KEYCHAIN is macOS
+	KEYCHAIN CredsStoreType = "osxkeychain"
+	// WinCred  on windows
+	WinCred CredsStoreType = "wincred"
+	// PASS on Linux
+	PASS CredsStoreType = "pass"
+	// SecretService is  if it cannot find the "pass"
+	SecretService CredsStoreType = "secretservice"
+	// FILE is base64 encoding in the config files
+	FILE CredsStoreType = "file"
+	// MEMORY is base64 encoding in the memory
+	MEMORY CredsStoreType = "memory"
+)
+
+func (cst CredsStoreType) String() string {
+	return string(cst)
+}
+
+type Credentials struct {
+	Host     string
+	Username string
+	Secret   string
+	Header   string
+}
+
+// Manager is Credential manager plugin core method
+type Manager interface {
+	Store(ctx context.Context, cred Credentials) error
+	Get(ctx context.Context, request *transfertypes.AuthRequest) (*transfertypes.AuthResponse, error)
+	Delete(ctx context.Context, cred Credentials) error
+}
+
+type Auth interface {
+	Get(request transfertypes.AuthRequest) transfertypes.AuthResponse
+}
+
+func NewManager(csType string) Manager {
+	if csType == KEYCHAIN.String() || csType == WinCred.String() || csType == PASS.String() || csType == SecretService.String() {
+		return newDockerCredential(csType)
+	}
+	if csType == MEMORY.String() {
+		return newMemoryStore()
+	}
+	return newFileStore()
+}

--- a/core/credential/credential_docker_helpers.go
+++ b/core/credential/credential_docker_helpers.go
@@ -1,0 +1,66 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package credential
+
+import (
+	"context"
+
+	transfertypes "github.com/containerd/containerd/v2/api/types/transfer"
+	"github.com/docker/docker-credential-helpers/client"
+	"github.com/docker/docker-credential-helpers/credentials"
+)
+
+const (
+	DefaultBinaryNamePrefix = "docker-credential-"
+)
+
+type dockerCredential struct {
+	credentialBinaryName string
+}
+
+func newDockerCredential(credsStore string) Manager {
+	return &dockerCredential{
+		credentialBinaryName: DefaultBinaryNamePrefix + credsStore,
+	}
+}
+
+func (d *dockerCredential) Store(ctx context.Context, cred Credentials) error {
+	shellProgramFunc := client.NewShellProgramFunc(d.credentialBinaryName)
+	return client.Store(shellProgramFunc, &credentials.Credentials{
+		ServerURL: cred.Host,
+		Username:  cred.Username,
+		Secret:    cred.Secret,
+	})
+}
+
+func (d *dockerCredential) Get(ctx context.Context, request *transfertypes.AuthRequest) (*transfertypes.AuthResponse, error) {
+	shellProgramFunc := client.NewShellProgramFunc(d.credentialBinaryName)
+	creds, err := client.Get(shellProgramFunc, request.Host)
+	if err != nil {
+		return &transfertypes.AuthResponse{}, err
+	}
+	return &transfertypes.AuthResponse{
+		AuthType: transfertypes.AuthType_CREDENTIALS,
+		Username: creds.Username,
+		Secret:   creds.Secret,
+	}, nil
+}
+
+func (d *dockerCredential) Delete(ctx context.Context, cred Credentials) error {
+	shellProgramFunc := client.NewShellProgramFunc(d.credentialBinaryName)
+	return client.Erase(shellProgramFunc, cred.Host)
+}

--- a/core/credential/credential_file.go
+++ b/core/credential/credential_file.go
@@ -1,0 +1,208 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package credential
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	transfertypes "github.com/containerd/containerd/v2/api/types/transfer"
+	"github.com/containerd/containerd/v2/defaults"
+)
+
+var (
+	DefaultPath = filepath.Join(defaults.DefaultConfigDir, "auths.json")
+)
+
+type fileStore struct {
+	path string
+	sync.RWMutex
+}
+
+type AuthInfos struct {
+	Auths map[string]map[string]string `json:"auths"`
+}
+
+func newFileStore(filePaths ...string) Manager {
+	filePath := DefaultPath
+	if len(filePaths) > 0 {
+		filePath = filePaths[0]
+	}
+	_, err := os.Stat(filePath)
+	if os.IsNotExist(err) {
+		dir, _ := filepath.Split(filePath)
+		err := os.MkdirAll(dir, os.ModeDir)
+		if err != nil {
+			panic(err)
+		}
+		file, err := os.Create(filePath)
+		if err != nil {
+			panic(err)
+		}
+		file.Close()
+	}
+	return &fileStore{path: filePath}
+}
+
+func (f *fileStore) Store(ctx context.Context, cred Credentials) error {
+	f.Lock()
+	defer f.Unlock()
+	bytes, err := os.ReadFile(f.path)
+	if err != nil {
+		return err
+	}
+
+	var authInfo AuthInfos
+	if len(bytes) > 0 {
+		err = json.Unmarshal(bytes, &authInfo)
+		if err != nil {
+			return err
+		}
+	}
+
+	host := cred.Host
+	parse, err := url.Parse(cred.Host)
+	if err != nil {
+		return err
+	}
+	if parse.Host != "" {
+		host = parse.Host
+	}
+
+	if authInfo.Auths == nil {
+		authInfo.Auths = make(map[string]map[string]string)
+	}
+
+	authInfo.Auths[host] = map[string]string{
+		"auth": EncodeUserNameAndSecret(cred.Username, cred.Secret),
+	}
+
+	bytes, err = json.Marshal(authInfo)
+	if err != nil {
+		return err
+	}
+	err = os.WriteFile(f.path, bytes, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (f *fileStore) Get(ctx context.Context, request *transfertypes.AuthRequest) (*transfertypes.AuthResponse, error) {
+	f.RLock()
+	defer f.RUnlock()
+	bytes, err := os.ReadFile(f.path)
+	if err != nil {
+		return &transfertypes.AuthResponse{}, err
+	}
+
+	var authInfo AuthInfos
+	if len(bytes) > 0 {
+		err = json.Unmarshal(bytes, &authInfo)
+		if err != nil {
+			return &transfertypes.AuthResponse{}, err
+		}
+	}
+
+	parse, err := url.Parse(request.Host)
+	if err != nil {
+		return &transfertypes.AuthResponse{}, err
+	}
+	if parse.Host != "" {
+		request.Host = parse.Host
+	}
+
+	if authInfo.Auths == nil {
+		authInfo.Auths = make(map[string]map[string]string)
+	}
+
+	if auth, ok := authInfo.Auths[request.Host]; ok {
+		userName, secret, err := DecodeUserNameAndSecret(auth["auth"])
+		if err != nil {
+			return &transfertypes.AuthResponse{}, err
+		}
+		return &transfertypes.AuthResponse{
+			AuthType: transfertypes.AuthType_CREDENTIALS,
+			Username: userName,
+			Secret:   secret,
+		}, nil
+	}
+	return &transfertypes.AuthResponse{}, errors.New("not found")
+}
+
+func (f *fileStore) Delete(ctx context.Context, cred Credentials) error {
+	f.Lock()
+	defer f.Unlock()
+	bytes, err := os.ReadFile(f.path)
+	if err != nil {
+		return err
+	}
+
+	var authInfo AuthInfos
+	if len(bytes) > 0 {
+		err = json.Unmarshal(bytes, &authInfo)
+		if err != nil {
+			return err
+		}
+	}
+
+	host := cred.Host
+	parse, err := url.Parse(cred.Host)
+	if err != nil {
+		return err
+	}
+	if parse.Host != "" {
+		host = parse.Host
+	}
+
+	if authInfo.Auths == nil {
+		return nil
+	}
+
+	delete(authInfo.Auths, host)
+	bytes, err = json.Marshal(authInfo)
+	if err != nil {
+		return err
+	}
+	err = os.WriteFile(f.path, bytes, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func EncodeUserNameAndSecret(username, secret string) string {
+	data := fmt.Sprintf("%s:%s", username, secret)
+	return base64.StdEncoding.EncodeToString([]byte(data))
+}
+
+func DecodeUserNameAndSecret(data string) (string, string, error) {
+	bytes, err := base64.StdEncoding.DecodeString(data)
+	if err != nil {
+		return "", "", err
+	}
+	datas := strings.Split(string(bytes), ":")
+	return datas[0], datas[1], err
+}

--- a/core/credential/credential_file_test.go
+++ b/core/credential/credential_file_test.go
@@ -1,0 +1,63 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package credential
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	transfertypes "github.com/containerd/containerd/v2/api/types/transfer"
+)
+
+func Test_fileStore(t *testing.T) {
+	path := "./auths.json"
+	fileStoregeTest := newFileStore(path)
+	defer os.Remove(path)
+	host := "docker.io"
+	expect := Credentials{
+		Host:     host,
+		Username: "username",
+		Secret:   "password",
+	}
+	// add
+	err := fileStoregeTest.Store(context.Background(), expect)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// get
+	got, err := fileStoregeTest.Get(context.TODO(), &transfertypes.AuthRequest{Host: host})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if expect.Username != got.Username || expect.Secret != got.Secret {
+		t.Fatalf("store fail, expect %+v, got +%v", expect, got)
+	}
+
+	// delete
+	err = fileStoregeTest.Delete(context.TODO(), expect)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// get
+	got, err = fileStoregeTest.Get(context.TODO(), &transfertypes.AuthRequest{Host: host})
+	if err == nil {
+		t.Fatalf("expect not found, but found %v", got)
+	}
+}

--- a/core/credential/credential_memory.go
+++ b/core/credential/credential_memory.go
@@ -1,0 +1,72 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package credential
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	transfertypes "github.com/containerd/containerd/v2/api/types/transfer"
+)
+
+type memoryStore struct {
+	creds map[string]*Credentials
+	sync.RWMutex
+}
+
+func newMemoryStore() Manager {
+	return &memoryStore{
+		creds: make(map[string]*Credentials),
+	}
+}
+
+func (m *memoryStore) Store(ctx context.Context, creds Credentials) error {
+	m.Lock()
+	defer m.Unlock()
+	m.creds[creds.Host] = &creds
+	return nil
+}
+
+func (m *memoryStore) Delete(ctx context.Context, cred Credentials) error {
+	m.Lock()
+	defer m.Unlock()
+	delete(m.creds, cred.Host)
+	return nil
+}
+
+func (m *memoryStore) Get(ctx context.Context, request *transfertypes.AuthRequest) (*transfertypes.AuthResponse, error) {
+	m.RLock()
+	defer m.RUnlock()
+	c, ok := m.creds[request.Host]
+	if !ok {
+		return &transfertypes.AuthResponse{}, fmt.Errorf("creds not found for %s", request.Host)
+	}
+	resp := &transfertypes.AuthResponse{}
+	if c.Header != "" {
+		resp.AuthType = transfertypes.AuthType_HEADER
+		resp.Secret = c.Header
+	} else if c.Username != "" {
+		resp.AuthType = transfertypes.AuthType_CREDENTIALS
+		resp.Username = c.Username
+		resp.Secret = c.Secret
+	} else {
+		resp.AuthType = transfertypes.AuthType_REFRESH
+		resp.Secret = c.Secret
+	}
+	return resp, nil
+}

--- a/core/credential/credential_memory_test.go
+++ b/core/credential/credential_memory_test.go
@@ -1,0 +1,64 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package credential
+
+import (
+	"context"
+	"testing"
+
+	transfertypes "github.com/containerd/containerd/v2/api/types/transfer"
+)
+
+func Test_memStore(t *testing.T) {
+	store := newMemoryStore()
+	host := "docker.io"
+	expect := Credentials{
+		Host:     host,
+		Username: "username",
+		Secret:   "password",
+	}
+	// add
+	err := store.Store(context.Background(), expect)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// get
+	got, err := store.Get(context.TODO(), &transfertypes.AuthRequest{
+		Host: host,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if expect.Username != got.Username || expect.Secret != got.Secret {
+		t.Fatalf("store fail, expect %+v, got +%v", expect, got)
+	}
+
+	// delete
+	err = store.Delete(context.TODO(), expect)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// get
+	got, err = store.Get(context.TODO(), &transfertypes.AuthRequest{
+		Host: host,
+	})
+	if err == nil {
+		t.Fatalf("expect not found, but found %v", got)
+	}
+}

--- a/core/remotes/docker/config/hosts.go
+++ b/core/remotes/docker/config/hosts.go
@@ -352,6 +352,8 @@ type hostFileConfig struct {
 	OverridePath bool `toml:"override_path"`
 
 	// TODO: Credentials: helper? name? username? alternate domain? token?
+	// CredsStore is suffix of the program you want to use. eg. osxkeychain、secretservice、wincred、pass、file、memory
+	CredsStore string `toml:"creds_store" json:"credsStore"`
 }
 
 func parseHostsFile(baseDir string, b []byte) ([]hostConfig, error) {

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/distribution/reference v0.5.0
+	github.com/docker/docker-credential-helpers v0.8.1
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c
 	github.com/docker/go-metrics v0.0.1
 	github.com/docker/go-units v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.5.0 h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK2OFGvA0=
 github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
+github.com/docker/docker-credential-helpers v0.8.1 h1:j/eKUktUltBtMzKqmfLB0PAgqYyMHOp5vfsD1807oKo=
+github.com/docker/docker-credential-helpers v0.8.1/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
 github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c h1:+pKlWGMw7gf6bQ+oDZB4KHQFypsfjYlq/C4rfL7D3g8=
 github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c/go.mod h1:Uw6UezgYA44ePAFQYUehOuCzmy5zmg/+nl2ZfMWGkpA=
 github.com/docker/go-metrics v0.0.1 h1:AgB/0SvBxihN0X8OR4SjsblXkbMvalQ8cjmtKQ2rQV8=

--- a/plugins/credential/config.go
+++ b/plugins/credential/config.go
@@ -1,0 +1,57 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package credential
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/containerd/containerd/v2/core/credential"
+)
+
+const (
+	DefaultBinaryPrefix = "/usr/local/bin"
+)
+
+type Config struct {
+	// CredsStore is suffix of the program you want to use. eg. osxkeychain、secretservice、wincred、pass、file、memory
+	CredsStore string `toml:"creds_store"`
+}
+
+// NewDefaultConfig By default, containerd looks for the native binary on each of the platforms,
+// i.e. "osxkeychain" on macOS, "wincred" on windows, and "pass" on Linux.
+// A special case is that on Linux, containerd will fall back to the "secretservice" binary if it cannot find the "pass" binary.
+// If none of these binaries are present, it stores the credentials (i.e. password) in base64 encoding in the config files described above.
+func NewDefaultConfig() *Config {
+	config := defaultConfig()
+	_, err := os.Stat(filepath.Join(DefaultBinaryPrefix, fmt.Sprintf("%s%s", credential.DefaultBinaryNamePrefix, config.CredsStore)))
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return &Config{
+				CredsStore: credential.FILE.String(),
+			}
+		}
+		_, err = os.Stat(filepath.Join(DefaultBinaryPrefix, fmt.Sprintf("%s%s", credential.DefaultBinaryNamePrefix, credential.SecretService)))
+		if err != nil {
+			return &Config{
+				CredsStore: credential.FILE.String(),
+			}
+		}
+	}
+	return &config
+}

--- a/plugins/credential/config_darwin.go
+++ b/plugins/credential/config_darwin.go
@@ -1,0 +1,25 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package credential
+
+import "github.com/containerd/containerd/v2/core/credential"
+
+func defaultConfig() Config {
+	return Config{
+		CredsStore: credential.KEYCHAIN.String(),
+	}
+}

--- a/plugins/credential/config_linux.go
+++ b/plugins/credential/config_linux.go
@@ -1,0 +1,25 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package credential
+
+import "github.com/containerd/containerd/v2/core/credential"
+
+func defaultConfig() Config {
+	return Config{
+		CredsStore: credential.PASS.String(),
+	}
+}

--- a/plugins/credential/config_other.go
+++ b/plugins/credential/config_other.go
@@ -1,0 +1,27 @@
+//go:build !windows && !linux && !darwin
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package credential
+
+import "github.com/containerd/containerd/v2/core/credential"
+
+func defaultConfig() Config {
+	return Config{
+		CredsStore: credential.SecretService.String(),
+	}
+}

--- a/plugins/credential/config_windows.go
+++ b/plugins/credential/config_windows.go
@@ -1,0 +1,25 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package credential
+
+import "github.com/containerd/containerd/v2/core/credential"
+
+func defaultConfig() Config {
+	return Config{
+		CredsStore: credential.WinCred.String(),
+	}
+}

--- a/plugins/credential/credential.go
+++ b/plugins/credential/credential.go
@@ -1,0 +1,43 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package credential
+
+import (
+	"errors"
+
+	"github.com/containerd/containerd/v2/core/credential"
+	"github.com/containerd/containerd/v2/plugins"
+
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
+)
+
+// Register local transfer service plugin
+func init() {
+	registry.Register(&plugin.Registration{
+		Type:   plugins.CredentialPlugin,
+		ID:     "credential",
+		Config: NewDefaultConfig(),
+		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
+			config, ok := ic.Config.(*Config)
+			if !ok {
+				return nil, errors.New("invalid docker credential plugin configuration")
+			}
+			return credential.NewManager(config.CredsStore), nil
+		},
+	})
+}

--- a/plugins/types.go
+++ b/plugins/types.go
@@ -71,6 +71,8 @@ const (
 	WarningPlugin plugin.Type = "io.containerd.warning.v1"
 	// CRIServicePlugin implements a cri service
 	CRIServicePlugin plugin.Type = "io.containerd.cri.v1"
+	// CredentialPlugin implements a credential manager
+	CredentialPlugin plugin.Type = "io.containerd.credential.v1" // #nosec G101
 )
 
 const (

--- a/vendor/github.com/docker/docker-credential-helpers/LICENSE
+++ b/vendor/github.com/docker/docker-credential-helpers/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2016 David Calavera
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/docker/docker-credential-helpers/client/client.go
+++ b/vendor/github.com/docker/docker-credential-helpers/client/client.go
@@ -1,0 +1,114 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/docker/docker-credential-helpers/credentials"
+)
+
+// isValidCredsMessage checks if 'msg' contains invalid credentials error message.
+// It returns whether the logs are free of invalid credentials errors and the error if it isn't.
+// error values can be errCredentialsMissingServerURL or errCredentialsMissingUsername.
+func isValidCredsMessage(msg string) error {
+	if credentials.IsCredentialsMissingServerURLMessage(msg) {
+		return credentials.NewErrCredentialsMissingServerURL()
+	}
+	if credentials.IsCredentialsMissingUsernameMessage(msg) {
+		return credentials.NewErrCredentialsMissingUsername()
+	}
+	return nil
+}
+
+// Store uses an external program to save credentials.
+func Store(program ProgramFunc, creds *credentials.Credentials) error {
+	cmd := program(credentials.ActionStore)
+
+	buffer := new(bytes.Buffer)
+	if err := json.NewEncoder(buffer).Encode(creds); err != nil {
+		return err
+	}
+	cmd.Input(buffer)
+
+	out, err := cmd.Output()
+	if err != nil {
+		if isValidErr := isValidCredsMessage(string(out)); isValidErr != nil {
+			err = isValidErr
+		}
+		return fmt.Errorf("error storing credentials - err: %v, out: `%s`", err, strings.TrimSpace(string(out)))
+	}
+
+	return nil
+}
+
+// Get executes an external program to get the credentials from a native store.
+func Get(program ProgramFunc, serverURL string) (*credentials.Credentials, error) {
+	cmd := program(credentials.ActionGet)
+	cmd.Input(strings.NewReader(serverURL))
+
+	out, err := cmd.Output()
+	if err != nil {
+		if credentials.IsErrCredentialsNotFoundMessage(string(out)) {
+			return nil, credentials.NewErrCredentialsNotFound()
+		}
+
+		if isValidErr := isValidCredsMessage(string(out)); isValidErr != nil {
+			err = isValidErr
+		}
+
+		return nil, fmt.Errorf("error getting credentials - err: %v, out: `%s`", err, strings.TrimSpace(string(out)))
+	}
+
+	resp := &credentials.Credentials{
+		ServerURL: serverURL,
+	}
+
+	if err := json.NewDecoder(bytes.NewReader(out)).Decode(resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// Erase executes a program to remove the server credentials from the native store.
+func Erase(program ProgramFunc, serverURL string) error {
+	cmd := program(credentials.ActionErase)
+	cmd.Input(strings.NewReader(serverURL))
+	out, err := cmd.Output()
+	if err != nil {
+		t := strings.TrimSpace(string(out))
+
+		if isValidErr := isValidCredsMessage(t); isValidErr != nil {
+			err = isValidErr
+		}
+
+		return fmt.Errorf("error erasing credentials - err: %v, out: `%s`", err, t)
+	}
+
+	return nil
+}
+
+// List executes a program to list server credentials in the native store.
+func List(program ProgramFunc) (map[string]string, error) {
+	cmd := program(credentials.ActionList)
+	cmd.Input(strings.NewReader("unused"))
+	out, err := cmd.Output()
+	if err != nil {
+		t := strings.TrimSpace(string(out))
+
+		if isValidErr := isValidCredsMessage(t); isValidErr != nil {
+			err = isValidErr
+		}
+
+		return nil, fmt.Errorf("error listing credentials - err: %v, out: `%s`", err, t)
+	}
+
+	var resp map[string]string
+	if err = json.NewDecoder(bytes.NewReader(out)).Decode(&resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}

--- a/vendor/github.com/docker/docker-credential-helpers/client/command.go
+++ b/vendor/github.com/docker/docker-credential-helpers/client/command.go
@@ -1,0 +1,54 @@
+package client
+
+import (
+	"io"
+	"os"
+	"os/exec"
+)
+
+// Program is an interface to execute external programs.
+type Program interface {
+	Output() ([]byte, error)
+	Input(in io.Reader)
+}
+
+// ProgramFunc is a type of function that initializes programs based on arguments.
+type ProgramFunc func(args ...string) Program
+
+// NewShellProgramFunc creates programs that are executed in a Shell.
+func NewShellProgramFunc(name string) ProgramFunc {
+	return NewShellProgramFuncWithEnv(name, nil)
+}
+
+// NewShellProgramFuncWithEnv creates programs that are executed in a Shell with environment variables
+func NewShellProgramFuncWithEnv(name string, env *map[string]string) ProgramFunc {
+	return func(args ...string) Program {
+		return &Shell{cmd: createProgramCmdRedirectErr(name, args, env)}
+	}
+}
+
+func createProgramCmdRedirectErr(commandName string, args []string, env *map[string]string) *exec.Cmd {
+	programCmd := exec.Command(commandName, args...)
+	if env != nil {
+		for k, v := range *env {
+			programCmd.Env = append(programCmd.Environ(), k+"="+v)
+		}
+	}
+	programCmd.Stderr = os.Stderr
+	return programCmd
+}
+
+// Shell invokes shell commands to talk with a remote credentials-helper.
+type Shell struct {
+	cmd *exec.Cmd
+}
+
+// Output returns responses from the remote credentials-helper.
+func (s *Shell) Output() ([]byte, error) {
+	return s.cmd.Output()
+}
+
+// Input sets the input to send to a remote credentials-helper.
+func (s *Shell) Input(in io.Reader) {
+	s.cmd.Stdin = in
+}

--- a/vendor/github.com/docker/docker-credential-helpers/credentials/credentials.go
+++ b/vendor/github.com/docker/docker-credential-helpers/credentials/credentials.go
@@ -1,0 +1,209 @@
+package credentials
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// Action defines the name of an action (sub-command) supported by a
+// credential-helper binary. It is an alias for "string", and mostly
+// for convenience.
+type Action = string
+
+// List of actions (sub-commands) supported by credential-helper binaries.
+const (
+	ActionStore   Action = "store"
+	ActionGet     Action = "get"
+	ActionErase   Action = "erase"
+	ActionList    Action = "list"
+	ActionVersion Action = "version"
+)
+
+// Credentials holds the information shared between docker and the credentials store.
+type Credentials struct {
+	ServerURL string
+	Username  string
+	Secret    string
+}
+
+// isValid checks the integrity of Credentials object such that no credentials lack
+// a server URL or a username.
+// It returns whether the credentials are valid and the error if it isn't.
+// error values can be errCredentialsMissingServerURL or errCredentialsMissingUsername
+func (c *Credentials) isValid() (bool, error) {
+	if len(c.ServerURL) == 0 {
+		return false, NewErrCredentialsMissingServerURL()
+	}
+
+	if len(c.Username) == 0 {
+		return false, NewErrCredentialsMissingUsername()
+	}
+
+	return true, nil
+}
+
+// CredsLabel holds the way Docker credentials should be labeled as such in credentials stores that allow labelling.
+// That label allows to filter out non-Docker credentials too at lookup/search in macOS keychain,
+// Windows credentials manager and Linux libsecret. Default value is "Docker Credentials"
+var CredsLabel = "Docker Credentials"
+
+// SetCredsLabel is a simple setter for CredsLabel
+func SetCredsLabel(label string) {
+	CredsLabel = label
+}
+
+// Serve initializes the credentials-helper and parses the action argument.
+// This function is designed to be called from a command line interface.
+// It uses os.Args[1] as the key for the action.
+// It uses os.Stdin as input and os.Stdout as output.
+// This function terminates the program with os.Exit(1) if there is an error.
+func Serve(helper Helper) {
+	if len(os.Args) != 2 {
+		_, _ = fmt.Fprintln(os.Stdout, usage())
+		os.Exit(1)
+	}
+
+	switch os.Args[1] {
+	case "--version", "-v":
+		_ = PrintVersion(os.Stdout)
+		os.Exit(0)
+	case "--help", "-h":
+		_, _ = fmt.Fprintln(os.Stdout, usage())
+		os.Exit(0)
+	}
+
+	if err := HandleCommand(helper, os.Args[1], os.Stdin, os.Stdout); err != nil {
+		_, _ = fmt.Fprintln(os.Stdout, err)
+		os.Exit(1)
+	}
+}
+
+func usage() string {
+	return fmt.Sprintf("Usage: %s <store|get|erase|list|version>", Name)
+}
+
+// HandleCommand runs a helper to execute a credential action.
+func HandleCommand(helper Helper, action Action, in io.Reader, out io.Writer) error {
+	switch action {
+	case ActionStore:
+		return Store(helper, in)
+	case ActionGet:
+		return Get(helper, in, out)
+	case ActionErase:
+		return Erase(helper, in)
+	case ActionList:
+		return List(helper, out)
+	case ActionVersion:
+		return PrintVersion(out)
+	default:
+		return fmt.Errorf("%s: unknown action: %s", Name, action)
+	}
+}
+
+// Store uses a helper and an input reader to save credentials.
+// The reader must contain the JSON serialization of a Credentials struct.
+func Store(helper Helper, reader io.Reader) error {
+	scanner := bufio.NewScanner(reader)
+
+	buffer := new(bytes.Buffer)
+	for scanner.Scan() {
+		buffer.Write(scanner.Bytes())
+	}
+
+	if err := scanner.Err(); err != nil && err != io.EOF {
+		return err
+	}
+
+	var creds Credentials
+	if err := json.NewDecoder(buffer).Decode(&creds); err != nil {
+		return err
+	}
+
+	if ok, err := creds.isValid(); !ok {
+		return err
+	}
+
+	return helper.Add(&creds)
+}
+
+// Get retrieves the credentials for a given server url.
+// The reader must contain the server URL to search.
+// The writer is used to write the JSON serialization of the credentials.
+func Get(helper Helper, reader io.Reader, writer io.Writer) error {
+	scanner := bufio.NewScanner(reader)
+
+	buffer := new(bytes.Buffer)
+	for scanner.Scan() {
+		buffer.Write(scanner.Bytes())
+	}
+
+	if err := scanner.Err(); err != nil && err != io.EOF {
+		return err
+	}
+
+	serverURL := strings.TrimSpace(buffer.String())
+	if len(serverURL) == 0 {
+		return NewErrCredentialsMissingServerURL()
+	}
+
+	username, secret, err := helper.Get(serverURL)
+	if err != nil {
+		return err
+	}
+
+	buffer.Reset()
+	err = json.NewEncoder(buffer).Encode(Credentials{
+		ServerURL: serverURL,
+		Username:  username,
+		Secret:    secret,
+	})
+	if err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprint(writer, buffer.String())
+	return nil
+}
+
+// Erase removes credentials from the store.
+// The reader must contain the server URL to remove.
+func Erase(helper Helper, reader io.Reader) error {
+	scanner := bufio.NewScanner(reader)
+
+	buffer := new(bytes.Buffer)
+	for scanner.Scan() {
+		buffer.Write(scanner.Bytes())
+	}
+
+	if err := scanner.Err(); err != nil && err != io.EOF {
+		return err
+	}
+
+	serverURL := strings.TrimSpace(buffer.String())
+	if len(serverURL) == 0 {
+		return NewErrCredentialsMissingServerURL()
+	}
+
+	return helper.Delete(serverURL)
+}
+
+// List returns all the serverURLs of keys in
+// the OS store as a list of strings
+func List(helper Helper, writer io.Writer) error {
+	accts, err := helper.List()
+	if err != nil {
+		return err
+	}
+	return json.NewEncoder(writer).Encode(accts)
+}
+
+// PrintVersion outputs the current version.
+func PrintVersion(writer io.Writer) error {
+	_, _ = fmt.Fprintf(writer, "%s (%s) %s\n", Name, Package, Version)
+	return nil
+}

--- a/vendor/github.com/docker/docker-credential-helpers/credentials/error.go
+++ b/vendor/github.com/docker/docker-credential-helpers/credentials/error.go
@@ -1,0 +1,124 @@
+package credentials
+
+import (
+	"errors"
+	"strings"
+)
+
+const (
+	// ErrCredentialsNotFound standardizes the not found error, so every helper returns
+	// the same message and docker can handle it properly.
+	errCredentialsNotFoundMessage = "credentials not found in native keychain"
+
+	// ErrCredentialsMissingServerURL and ErrCredentialsMissingUsername standardize
+	// invalid credentials or credentials management operations
+	errCredentialsMissingServerURLMessage = "no credentials server URL"
+	errCredentialsMissingUsernameMessage  = "no credentials username"
+)
+
+// errCredentialsNotFound represents an error
+// raised when credentials are not in the store.
+type errCredentialsNotFound struct{}
+
+// Error returns the standard error message
+// for when the credentials are not in the store.
+func (errCredentialsNotFound) Error() string {
+	return errCredentialsNotFoundMessage
+}
+
+// NotFound implements the [ErrNotFound][errdefs.ErrNotFound] interface.
+//
+// [errdefs.ErrNotFound]: https://pkg.go.dev/github.com/docker/docker@v24.0.1+incompatible/errdefs#ErrNotFound
+func (errCredentialsNotFound) NotFound() {}
+
+// NewErrCredentialsNotFound creates a new error
+// for when the credentials are not in the store.
+func NewErrCredentialsNotFound() error {
+	return errCredentialsNotFound{}
+}
+
+// IsErrCredentialsNotFound returns true if the error
+// was caused by not having a set of credentials in a store.
+func IsErrCredentialsNotFound(err error) bool {
+	var target errCredentialsNotFound
+	return errors.As(err, &target)
+}
+
+// IsErrCredentialsNotFoundMessage returns true if the error
+// was caused by not having a set of credentials in a store.
+//
+// This function helps to check messages returned by an
+// external program via its standard output.
+func IsErrCredentialsNotFoundMessage(err string) bool {
+	return strings.TrimSpace(err) == errCredentialsNotFoundMessage
+}
+
+// errCredentialsMissingServerURL represents an error raised
+// when the credentials object has no server URL or when no
+// server URL is provided to a credentials operation requiring
+// one.
+type errCredentialsMissingServerURL struct{}
+
+func (errCredentialsMissingServerURL) Error() string {
+	return errCredentialsMissingServerURLMessage
+}
+
+// InvalidParameter implements the [ErrInvalidParameter][errdefs.ErrInvalidParameter]
+// interface.
+//
+// [errdefs.ErrInvalidParameter]: https://pkg.go.dev/github.com/docker/docker@v24.0.1+incompatible/errdefs#ErrInvalidParameter
+func (errCredentialsMissingServerURL) InvalidParameter() {}
+
+// errCredentialsMissingUsername represents an error raised
+// when the credentials object has no username or when no
+// username is provided to a credentials operation requiring
+// one.
+type errCredentialsMissingUsername struct{}
+
+func (errCredentialsMissingUsername) Error() string {
+	return errCredentialsMissingUsernameMessage
+}
+
+// InvalidParameter implements the [ErrInvalidParameter][errdefs.ErrInvalidParameter]
+// interface.
+//
+// [errdefs.ErrInvalidParameter]: https://pkg.go.dev/github.com/docker/docker@v24.0.1+incompatible/errdefs#ErrInvalidParameter
+func (errCredentialsMissingUsername) InvalidParameter() {}
+
+// NewErrCredentialsMissingServerURL creates a new error for
+// errCredentialsMissingServerURL.
+func NewErrCredentialsMissingServerURL() error {
+	return errCredentialsMissingServerURL{}
+}
+
+// NewErrCredentialsMissingUsername creates a new error for
+// errCredentialsMissingUsername.
+func NewErrCredentialsMissingUsername() error {
+	return errCredentialsMissingUsername{}
+}
+
+// IsCredentialsMissingServerURL returns true if the error
+// was an errCredentialsMissingServerURL.
+func IsCredentialsMissingServerURL(err error) bool {
+	var target errCredentialsMissingServerURL
+	return errors.As(err, &target)
+}
+
+// IsCredentialsMissingServerURLMessage checks for an
+// errCredentialsMissingServerURL in the error message.
+func IsCredentialsMissingServerURLMessage(err string) bool {
+	return strings.TrimSpace(err) == errCredentialsMissingServerURLMessage
+}
+
+// IsCredentialsMissingUsername returns true if the error
+// was an errCredentialsMissingUsername.
+func IsCredentialsMissingUsername(err error) bool {
+	var target errCredentialsMissingUsername
+	return errors.As(err, &target)
+}
+
+// IsCredentialsMissingUsernameMessage checks for an
+// errCredentialsMissingUsername in the error message.
+func IsCredentialsMissingUsernameMessage(err string) bool {
+	return strings.TrimSpace(err) == errCredentialsMissingUsernameMessage
+}

--- a/vendor/github.com/docker/docker-credential-helpers/credentials/helper.go
+++ b/vendor/github.com/docker/docker-credential-helpers/credentials/helper.go
@@ -1,0 +1,14 @@
+package credentials
+
+// Helper is the interface a credentials store helper must implement.
+type Helper interface {
+	// Add appends credentials to the store.
+	Add(*Credentials) error
+	// Delete removes credentials from the store.
+	Delete(serverURL string) error
+	// Get retrieves credentials from the store.
+	// It returns username and secret as strings.
+	Get(serverURL string) (string, string, error)
+	// List returns the stored serverURLs and their associated usernames.
+	List() (map[string]string, error)
+}

--- a/vendor/github.com/docker/docker-credential-helpers/credentials/version.go
+++ b/vendor/github.com/docker/docker-credential-helpers/credentials/version.go
@@ -1,0 +1,16 @@
+package credentials
+
+var (
+	// Name is filled at linking time
+	Name = ""
+
+	// Package is filled at linking time
+	Package = "github.com/docker/docker-credential-helpers"
+
+	// Version holds the complete version number. Filled in at linking time.
+	Version = "v0.0.0+unknown"
+
+	// Revision is filled with the VCS (e.g. git) revision being used to build
+	// the program at linking time.
+	Revision = ""
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -187,6 +187,10 @@ github.com/davecgh/go-spew/spew
 # github.com/distribution/reference v0.5.0
 ## explicit; go 1.20
 github.com/distribution/reference
+# github.com/docker/docker-credential-helpers v0.8.1
+## explicit; go 1.19
+github.com/docker/docker-credential-helpers/client
+github.com/docker/docker-credential-helpers/credentials
 # github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c
 ## explicit
 github.com/docker/go-events


### PR DESCRIPTION
Fixes: https://github.com/containerd/containerd/issues/8228


Added a plugin type, CredentialPlugin.
It is used for credential management. CredentialPlugin is be a [docker-credential-helpers](https://github.com/docker/docker-credential-helpers) compatible, e.g osxkeychain、wincred、pass、secretservice, or some other implementation. e.g. file、memory.  and future compatibility with [kubelet credential provider](https://kubernetes.io/docs/tasks/administer-cluster/kubelet-credential-provider/)

## credential call flow

<img width="750" alt="image" src="https://github.com/containerd/containerd/assets/15009201/70515e30-9d65-4b08-9e88-5f235a9148d7">


1. `Credential Client` Implementation `CredentialHelper` interface. 
2. When call `NewOCIRegistry` this method, use `NewProxyCredentialsClient` to create a `CredentialHelper` instance.
3. When `Transfer Server` callback to `CredentialHelper ` method,  `Credential Client` can call `Credential Server` to get  current host credential.

