### PR TITLE
add k8s 1.29 and 1.30preview to support table

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,6 @@ containerd is designed to be embedded into a larger system, rather than being us
 
 ## Announcements
 
-### Hello Kubernetes v1.24!
-The containerd project would like to announce containerd [v1.6.4](https://github.com/containerd/containerd/releases/tag/v1.6.4). While other prior releases are supported, this latest release and the containerd [v1.5.11](https://github.com/containerd/containerd/releases/tag/v1.5.11) release are recommended for Kubernetes v1.24.
-
-We felt it important to announce this, particularly in view of [the dockershim removal from this release of Kubernetes](https://kubernetes.io/blog/2022/05/03/dockershim-historical-context/).
-
-It should be noted here that moving to CRI integrations has been in the plan for many years.  `containerd` began as part of `Docker` and was donated to `CNCF`. `containerd` remains in use today by Docker/moby/buildkit etc., and has many other [adopters](https://github.com/containerd/containerd/blob/main/ADOPTERS.md). `containerd` has a namespace that isolates use of `containerd` from various clients/adopters. The Kubernetes namespace is appropriately named `k8s.io`. The CRI API and `containerd` CRI plugin project has, from the start, been an effort to reduce the impact surface for Kubernetes container runtime integration. If you can't tell, we are excited to see this come to fruition.
-
-If you have any concerns or questions, we will be here to answer them in [issues, discussions, and/or on slack](#communication). Below you will find information/detail about our [CRI Integration](#cri) implementation.
-
-For containerd users already on v1.6.0-v1.6.3, there are known issues addressed by [v1.6.4](https://github.com/containerd/containerd/releases/tag/v1.6.4). The issues are primarily related to [CNI setup](https://github.com/kubernetes/website/blob/dev-1.24/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/troubleshooting-cni-plugin-related-errors.md)
-
 ### Now Recruiting
 
 We are a large inclusive OSS project that is welcoming help of any kind shape or form:

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -138,13 +138,13 @@ for the list of actively tested versions. Kubernetes only supports n-3 minor
 release versions and containerd will ensure there is always a supported version
 of containerd for every supported version of Kubernetes.
 
-| Kubernetes Version | containerd Version | CRI Version     |
-|--------------------|--------------------|-----------------|
-| 1.24               | 1.7.0+, 1.6.4+     | v1, v1alpha2    |
-| 1.25               | 1.7.0+, 1.6.4+     | v1, v1alpha2 ** |
-| 1.26               | 1.7.0+, 1.6.15+    | v1              |
-| 1.27               | 1.7.0+, 1.6.15+    | v1              |
-| 1.28               | 1.7.0+, 1.6.15+    | v1              |
+| Kubernetes Version | containerd Version            | CRI Version     |
+|--------------------|-------------------------------|-----------------|
+| 1.26               | 1.7.0+, 1.6.15+               | v1, v1alpha2 ** |
+| 1.27               | 1.7.0+, 1.6.15+               | v1              |
+| 1.28               | 1.7.0+, 1.6.15+               | v1              |
+| 1.29               | 1.7.11+, 1.6.27+              | v1              |
+| 1.30(wip)          | 2.0(wip), 1.7.13+, 1.6.28+    | v1              |
 
 ** Note: containerd v1.6.*, and v1.7.* support CRI v1 and v1alpha2 through EOL as those releases continue to support older versions of k8s, cloud providers, and other clients using CRI v1alpha2. CRI v1alpha2 is deprecated in v1.7 and will be removed in containerd v2.0.
 


### PR DESCRIPTION
Updating our kubernetes support table for k8s v1.29, and adding a row for the 1.30 alpha that is expected to roughly coincide with our 2.0 release schedule. 