### PR TITLE
sandbox: make podsandbox controller plugin type of PodSandboxPlugin

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -753,7 +753,7 @@ func (c *Client) SandboxController(name string) sandbox.Controller {
 	}
 	c.connMu.Lock()
 	defer c.connMu.Unlock()
-	return sandboxproxy.NewSandboxController(sandboxsapi.NewControllerClient(c.conn))
+	return sandboxproxy.NewSandboxController(sandboxsapi.NewControllerClient(c.conn), name)
 }
 
 // VersionService returns the underlying VersionClient

--- a/client/services.go
+++ b/client/services.go
@@ -230,27 +230,3 @@ func WithInMemoryServices(ic *plugin.InitContext) Opt {
 		return nil
 	}
 }
-
-func WithInMemorySandboxControllers(ic *plugin.InitContext) Opt {
-	return func(c *clientOpts) error {
-		sc := make(map[string]sandbox.Controller)
-		sandboxers, err := ic.GetByType(plugins.SandboxControllerPlugin)
-		if err != nil {
-			return err
-		}
-		for name, p := range sandboxers {
-			sc[name] = p.(sandbox.Controller)
-		}
-
-		podSandboxers, err := ic.GetByType(plugins.PodSandboxPlugin)
-		if err != nil {
-			return err
-		}
-		for name, p := range podSandboxers {
-			sc[name] = p.(sandbox.Controller)
-		}
-
-		c.services.sandboxers = sc
-		return nil
-	}
-}

--- a/client/services.go
+++ b/client/services.go
@@ -233,14 +233,23 @@ func WithInMemoryServices(ic *plugin.InitContext) Opt {
 
 func WithInMemorySandboxControllers(ic *plugin.InitContext) Opt {
 	return func(c *clientOpts) error {
+		sc := make(map[string]sandbox.Controller)
 		sandboxers, err := ic.GetByType(plugins.SandboxControllerPlugin)
 		if err != nil {
 			return err
 		}
-		sc := make(map[string]sandbox.Controller)
 		for name, p := range sandboxers {
 			sc[name] = p.(sandbox.Controller)
 		}
+
+		podSandboxers, err := ic.GetByType(plugins.PodSandboxPlugin)
+		if err != nil {
+			return err
+		}
+		for name, p := range podSandboxers {
+			sc[name] = p.(sandbox.Controller)
+		}
+
 		c.services.sandboxers = sc
 		return nil
 	}

--- a/cmd/containerd/server/server.go
+++ b/cmd/containerd/server/server.go
@@ -510,7 +510,7 @@ func LoadPlugins(ctx context.Context, config *srvconfig.Config) ([]plugin.Regist
 		case string(plugins.SandboxControllerPlugin), "sandbox":
 			t = plugins.SandboxControllerPlugin
 			f = func(conn *grpc.ClientConn) interface{} {
-				return sbproxy.NewSandboxController(sbapi.NewControllerClient(conn))
+				return sbproxy.NewSandboxController(sbapi.NewControllerClient(conn), name)
 			}
 		case string(plugins.DiffPlugin), "diff":
 			t = plugins.DiffPlugin

--- a/internal/cri/server/podsandbox/controller.go
+++ b/internal/cri/server/podsandbox/controller.go
@@ -46,7 +46,7 @@ import (
 
 func init() {
 	registry.Register(&plugin.Registration{
-		Type: plugins.SandboxControllerPlugin,
+		Type: plugins.PodSandboxPlugin,
 		ID:   "podsandbox",
 		Requires: []plugin.Type{
 			plugins.EventPlugin,

--- a/internal/cri/server/restart.go
+++ b/internal/cri/server/restart.go
@@ -111,12 +111,11 @@ func (c *criService) recover(ctx context.Context) error {
 		}
 
 		var (
-			state      = sandboxstore.StateUnknown
-			controller = c.client.SandboxController(sbx.Sandboxer)
-			endpoint   sandboxstore.Endpoint
+			state    = sandboxstore.StateUnknown
+			endpoint sandboxstore.Endpoint
 		)
 
-		status, err := controller.Status(ctx, sbx.ID, false)
+		status, err := c.sandboxService.SandboxStatus(ctx, sbx.Sandboxer, sbx.ID, false)
 		if err != nil {
 			log.G(ctx).
 				WithError(err).

--- a/plugins/cri/cri.go
+++ b/plugins/cri/cri.go
@@ -119,7 +119,6 @@ func initCRIService(ic *plugin.InitContext) (interface{}, error) {
 		containerd.WithDefaultNamespace(constants.K8sContainerdNamespace),
 		containerd.WithDefaultPlatform(platforms.Default()),
 		containerd.WithInMemoryServices(ic),
-		containerd.WithInMemorySandboxControllers(ic),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create containerd client: %w", err)

--- a/plugins/cri/cri.go
+++ b/plugins/cri/cri.go
@@ -48,6 +48,7 @@ func init() {
 		ID:   "cri",
 		Requires: []plugin.Type{
 			plugins.CRIServicePlugin,
+			plugins.PodSandboxPlugin,
 			plugins.SandboxControllerPlugin,
 			plugins.NRIApiPlugin,
 			plugins.EventPlugin,
@@ -237,12 +238,20 @@ func getNRIAPI(ic *plugin.InitContext) nriservice.API {
 }
 
 func getSandboxControllers(ic *plugin.InitContext) (map[string]sandbox.Controller, error) {
+	sc := make(map[string]sandbox.Controller)
 	sandboxers, err := ic.GetByType(plugins.SandboxControllerPlugin)
 	if err != nil {
 		return nil, err
 	}
-	sc := make(map[string]sandbox.Controller)
 	for name, p := range sandboxers {
+		sc[name] = p.(sandbox.Controller)
+	}
+
+	podSandboxers, err := ic.GetByType(plugins.PodSandboxPlugin)
+	if err != nil {
+		return nil, err
+	}
+	for name, p := range podSandboxers {
 		sc[name] = p.(sandbox.Controller)
 	}
 	return sc, nil

--- a/plugins/services/sandbox/controller_service.go
+++ b/plugins/services/sandbox/controller_service.go
@@ -41,17 +41,26 @@ func init() {
 		Type: plugins.GRPCPlugin,
 		ID:   "sandbox-controllers",
 		Requires: []plugin.Type{
+			plugins.PodSandboxPlugin,
 			plugins.SandboxControllerPlugin,
 			plugins.EventPlugin,
 		},
 		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
-			sandboxers, err := ic.GetByType(plugins.SandboxControllerPlugin)
+			sc := make(map[string]sandbox.Controller)
+
+			sandboxers, err := ic.GetByType(plugins.PodSandboxPlugin)
 			if err != nil {
 				return nil, err
 			}
-
-			sc := make(map[string]sandbox.Controller)
 			for name, p := range sandboxers {
+				sc[name] = p.(sandbox.Controller)
+			}
+
+			sandboxersV2, err := ic.GetByType(plugins.SandboxControllerPlugin)
+			if err != nil {
+				return nil, err
+			}
+			for name, p := range sandboxersV2 {
 				sc[name] = p.(sandbox.Controller)
 			}
 

--- a/plugins/types.go
+++ b/plugins/types.go
@@ -63,6 +63,8 @@ const (
 	TransferPlugin plugin.Type = "io.containerd.transfer.v1"
 	// SandboxStorePlugin implements a sandbox store
 	SandboxStorePlugin plugin.Type = "io.containerd.sandbox.store.v1"
+	// PodSandboxPlugin is a special sandbox controller which use pause container as a sandbox.
+	PodSandboxPlugin plugin.Type = "io.containerd.podsandbox.controller.v1"
 	// SandboxControllerPlugin implements a sandbox controller
 	SandboxControllerPlugin plugin.Type = "io.containerd.sandbox.controller.v1"
 	// ImageVerifierPlugin implements an image verifier service


### PR DESCRIPTION
We can not handle the task in the pod sandbox as a sandboxed Task because podsandbox controller rely on task plugin to create pause container, If the task handle rely on podsandbox controller, it will make a cyclic dependency of plugins.

So In this PR, We add a new PodSandboxPlugin type for the podsandbox controller, Shim sandbox controller and other user defined sandbox controllers will be kind of SandboxControllerPlugin. and the subsequent PR of sandboxed Task will rely on this PR to handle sandboxed Task in sandbox of SandboxControllerPlugin.