### PR TITLE
fix(docs): fix duplicate instructions for windows installation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -107,24 +107,20 @@ To install containerd and its dependencies from the source, see [`BUILDING.md`](
 
 ## Installing containerd on Windows
 
-From a PowerShell session run the following commands:
+From an elevated PowerShell session (_running as Admin_) run the following commands:
 
 ```PowerShell
 # If containerd previously installed run:
 Stop-Service containerd
 
 # Download and extract desired containerd Windows binaries
-$Version="1.7.13" # update to your preferred version
-curl.exe -L https://github.com/containerd/containerd/releases/download/v$Version/containerd-$Version-windows-amd64.tar.gz -o containerd-windows-amd64.tar.gz
-tar.exe xvf .\containerd-windows-amd64.tar.gz
-
-# Copy and configure
-Copy-Item -Path ".\bin" -Destination "$Env:ProgramFiles\containerd" -Recurse -Container:$false -Force
-cd $Env:ProgramFiles\containerd\
-.\containerd.exe config default | Out-File config.toml -Encoding ascii
+$Version="1.7.13"	# update to your preferred version
+$Arch = "amd64"	# arm64 also available
+curl.exe -LO https://github.com/containerd/containerd/releases/download/v$Version/containerd-$Version-windows-$Arch.tar.gz
+tar.exe xvf .\containerd-$Version-windows-amd64.tar.gz
 
 # Copy
-Copy-Item -Path .\bin\* -Destination (New-Item -Type Directory $Env:ProgramFiles\containerd -Force) -Recurse -Force
+Copy-Item -Path .\bin -Destination $Env:ProgramFiles\containerd -Recurse -Force
 
 # add the binaries (containerd.exe, ctr.exe) in $env:Path
 $Path = [Environment]::GetEnvironmentVariable("PATH", "Machine") + [IO.Path]::PathSeparator + "$Env:ProgramFiles\containerd"


### PR DESCRIPTION
This commit fixes the duplicate copy and configure steps for the Windows powershell scripts.

fixes #9887

It also adds the architecture as a variable in preparation for the ARM64 support that is coming.