### PR TITLE
[cri] podSandboxStats should return errdefs.ErrUnavailable without wrapping

### DIFF
--- a/internal/cri/server/sandbox_stats_linux.go
+++ b/internal/cri/server/sandbox_stats_linux.go
@@ -38,7 +38,8 @@ func (c *criService) podSandboxStats(
 	meta := sandbox.Metadata
 
 	if sandbox.Status.Get().State != sandboxstore.StateReady {
-		return nil, fmt.Errorf("failed to get pod sandbox stats since sandbox container %q is not in ready state: %w", meta.ID, errdefs.ErrUnavailable)
+		log.G(ctx).WithField("podsandboxid", sandbox.ID).Debugf("failed to get pod sandbox stats since sandbox container %q is not in ready state", meta.ID)
+		return nil, errdefs.ErrUnavailable
 	}
 
 	stats, err := metricsForSandbox(sandbox)


### PR DESCRIPTION
kubelet is calling CRI's `ListPodSandboxStats`, when this method is looping through sandbox(es), it calls `podSandboxStats` and expects to get info about sandboxes that are `StateReady`. 

`ListPodSandboxStats` expects `errdefs.ErrUnavailable` when sandbox is NOT `StateReady`. But in the current implementation, the ErrUnavailable is wrapped into another one using `fmt.Errorf` so the `ListPodSandboxStats` fails fast without skipping the sandboxes that are not ready.

from: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-alpha-enabled-default/1762909002125021184
test: `Kubernetes e2e suite: [It] [sig-node] NodeProblemDetector [NodeFeature:NodeProblemDetector] should run without error`
log snippet:
```
STEP: Gather node-problem-detector cpu and memory stats - k8s.io/kubernetes/test/e2e/node/node_problem_detector.go:192 @ 02/28/24 17:19:35.031
I0228 17:19:36.098816 10590 node_problem_detector.go:380] Unexpected error: 
    <*errors.StatusError | 0xc004515040>: 
    an error on the server ("Internal Error: failed to list pod stats: rpc error: code = NotFound desc = failed to decode sandbox container metrics for sandbox \"2c95299f99fa7b8a03e66be60d2a4ddd51bf2501d08d2bcf7f6ba8203f57c6de\": no running task found: task bc6c3f30a0a61641cbe56bdbfb867e195b463f92609505972ee2880dbe4826d8 not found: not found") has prevented the request from succeeding (get nodes bootstrap-e2e-minion-group-1526:10250)
    {
        ErrStatus: 
            code: 500
            details:
              causes:
              - message: 'Internal Error: failed to list pod stats: rpc error: code = NotFound
                  desc = failed to decode sandbox container metrics for sandbox "2c95299f99fa7b8a03e66be60d2a4ddd51bf2501d08d2bcf7f6ba8203f57c6de":
                  no running task found: task bc6c3f30a0a61641cbe56bdbfb867e195b463f92609505972ee2880dbe4826d8
                  not found: not found'
                reason: UnexpectedServerResponse
              kind: nodes
              name: bootstrap-e2e-minion-group-1526:10250
            message: 'an error on the server ("Internal Error: failed to list pod stats: rpc error:
              code = NotFound desc = failed to decode sandbox container metrics for sandbox \"2c95299f99fa7b8a03e66be60d2a4ddd51bf2501d08d2bcf7f6ba8203f57c6de\":
              no running task found: task bc6c3f30a0a61641cbe56bdbfb867e195b463f92609505972ee2880dbe4826d8
              not found: not found") has prevented the request from succeeding (get nodes bootstrap-e2e-minion-group-1526:10250)'
            metadata: {}
            reason: InternalError
            status: Failure,
    }
[FAILED] an error on the server ("Internal Error: failed to list pod stats: rpc error: code = NotFound desc = failed to decode sandbox container metrics for sandbox \"2c95299f99fa7b8a03e66be60d2a4ddd51bf2501d08d2bcf7f6ba8203f57c6de\": no running task found: task bc6c3f30a0a61641cbe56bdbfb867e195b463f92609505972ee2880dbe4826d8 not found: not found") has prevented the request from succeeding (get nodes bootstrap-e2e-minion-group-1526:10250)
```