### PR TITLE
[release/1.7] Update golangci-lint to v1.56.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.51.1
+          version: v1.54.2
           skip-cache: true
           args: --timeout=8m
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.55.2
+          version: v1.56.1
           skip-cache: true
           args: --timeout=8m
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.54.2
+          version: v1.55.2
           skip-cache: true
           args: --timeout=8m
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,6 +32,24 @@ issues:
     - path: 'archive[\\/]tarheader[\\/]'
       # conversion is necessary on Linux, unnecessary on macOS
       text: "unnecessary conversion"
+    - linters:
+        - revive
+      text: "if-return"
+    - linters:
+        - revive
+      text: "empty-block"
+    - linters:
+        - revive
+      text: "superfluous-else"
+    - linters:
+        - revive
+      text: "unused-parameter"
+    - linters:
+        - revive
+      text: "unreachable-code"
+    - linters:
+        - revive
+      text: "redefines-builtin-id"
 
     # FIXME temporarily suppress deprecation warnings for the logs package. See https://github.com/containerd/containerd/pull/9086
     - text: "SA1019: log\\.(G|L|Fields|Entry|RFC3339NanoFixed|Level|TraceLevel|DebugLevel|InfoLevel|WarnLevel|ErrorLevel|FatalLevel|PanicLevel|SetLevel|GetLevel|OutputFormat|TextFormat|JSONFormat|SetFormat|WithLogger|GetLogger)"

--- a/content/helpers_test.go
+++ b/content/helpers_test.go
@@ -143,6 +143,7 @@ func TestCopy(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
+		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			err := Copy(context.Background(),
 				&testcase.writer,

--- a/integration/remote/util/util_windows.go
+++ b/integration/remote/util/util_windows.go
@@ -117,9 +117,8 @@ func parseEndpoint(endpoint string) (string, string, error) {
 		return "npipe", fmt.Sprintf("//%s%s", host, u.Path), nil
 	} else if u.Scheme == "" {
 		return "", "", fmt.Errorf("Using %q as endpoint is deprecated, please consider using full url format", endpoint)
-	} else {
-		return u.Scheme, "", fmt.Errorf("protocol %q not supported", u.Scheme)
 	}
+	return u.Scheme, "", fmt.Errorf("protocol %q not supported", u.Scheme)
 }
 
 var tickCount = syscall.NewLazyDLL("kernel32.dll").NewProc("GetTickCount64")

--- a/metadata/containers_test.go
+++ b/metadata/containers_test.go
@@ -619,6 +619,7 @@ func TestContainersCreateUpdateDelete(t *testing.T) {
 			},
 		},
 	} {
+		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			testcase.original.ID = testcase.name
 			if testcase.input.ID == "" {

--- a/metadata/images_test.go
+++ b/metadata/images_test.go
@@ -479,6 +479,7 @@ func TestImagesCreateUpdateDelete(t *testing.T) {
 			cause: errdefs.ErrNotFound,
 		},
 	} {
+		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			testcase.original.Name = testcase.name
 			if testcase.input.Name == "" {

--- a/pkg/cri/sbserver/image_pull.go
+++ b/pkg/cri/sbserver/image_pull.go
@@ -379,7 +379,8 @@ func (c *criService) getTLSConfig(registryTLSConfig criconfig.TLSConfig) (*tls.C
 		if len(cert.Certificate) != 0 {
 			tlsConfig.Certificates = []tls.Certificate{cert}
 		}
-		tlsConfig.BuildNameToCertificate() //nolint:staticcheck // TODO(thaJeztah): verify if we should ignore the deprecation; see https://github.com/containerd/containerd/pull/7349/files#r990644833
+		// TODO(thaJeztah): verify if we should ignore the deprecation; see https://github.com/containerd/containerd/pull/7349/files#r990644833
+		tlsConfig.BuildNameToCertificate() //nolint:staticcheck
 	}
 
 	if registryTLSConfig.CAFile != "" {

--- a/pkg/cri/server/image_pull.go
+++ b/pkg/cri/server/image_pull.go
@@ -381,7 +381,8 @@ func (c *criService) getTLSConfig(registryTLSConfig criconfig.TLSConfig) (*tls.C
 		if len(cert.Certificate) != 0 {
 			tlsConfig.Certificates = []tls.Certificate{cert}
 		}
-		tlsConfig.BuildNameToCertificate() //nolint:staticcheck // TODO(thaJeztah): verify if we should ignore the deprecation; see https://github.com/containerd/containerd/pull/7349/files#r990644833
+		// TODO(thaJeztah): verify if we should ignore the deprecation; see https://github.com/containerd/containerd/pull/7349/files#r990644833
+		tlsConfig.BuildNameToCertificate() //nolint:staticcheck
 	}
 
 	if registryTLSConfig.CAFile != "" {

--- a/remotes/docker/config/hosts.go
+++ b/remotes/docker/config/hosts.go
@@ -365,7 +365,6 @@ func parseHostsFile(baseDir string, b []byte) ([]hostConfig, error) {
 
 	// HACK: we want to keep toml parsing structures private in this package, however go-toml ignores private embedded types.
 	// so we remap it to a public type within the func body, so technically it's public, but not possible to import elsewhere.
-	//nolint:unused
 	type HostFileConfig = hostFileConfig
 
 	c := struct {

--- a/script/setup/install-dev-tools
+++ b/script/setup/install-dev-tools
@@ -23,7 +23,7 @@ set -eu -o pipefail
 go install github.com/containerd/protobuild@v0.3.0
 go install github.com/containerd/protobuild/cmd/go-fix-acronym@v0.3.0
 go install github.com/cpuguy83/go-md2man/v2@v2.0.2
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2
 go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28
 go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
 go install github.com/containerd/ttrpc/cmd/protoc-gen-go-ttrpc@5cc9169d1fc1a8292866224ae09dc47827801874

--- a/script/setup/install-dev-tools
+++ b/script/setup/install-dev-tools
@@ -23,7 +23,7 @@ set -eu -o pipefail
 go install github.com/containerd/protobuild@v0.3.0
 go install github.com/containerd/protobuild/cmd/go-fix-acronym@v0.3.0
 go install github.com/cpuguy83/go-md2man/v2@v2.0.2
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
 go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28
 go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
 go install github.com/containerd/ttrpc/cmd/protoc-gen-go-ttrpc@5cc9169d1fc1a8292866224ae09dc47827801874

--- a/tracing/plugin/otlp.go
+++ b/tracing/plugin/otlp.go
@@ -141,10 +141,9 @@ func newExporter(ctx context.Context, cfg *OTLPConfig) (*otlptrace.Exporter, err
 			opts = append(opts, otlptracegrpc.WithInsecure())
 		}
 		return otlptracegrpc.New(ctx, opts...)
-	} else {
-		// Other protocols such as "http/json" are not supported.
-		return nil, fmt.Errorf("OpenTelemetry protocol %q : %w", cfg.Protocol, errdefs.ErrNotImplemented)
 	}
+	// Other protocols such as "http/json" are not supported.
+	return nil, fmt.Errorf("OpenTelemetry protocol %q : %w", cfg.Protocol, errdefs.ErrNotImplemented)
 }
 
 // newTracer configures protocol-agonostic tracing settings such as

--- a/tracing/plugin/otlp_test.go
+++ b/tracing/plugin/otlp_test.go
@@ -70,6 +70,7 @@ func TestNewExporter(t *testing.T) {
 			output: errdefs.ErrNotImplemented,
 		},
 	} {
+		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Logf("input: %v", testcase.input)
 


### PR DESCRIPTION
update golangci-ilnt to v1.56.1

Not a clean cherry-pick of:
(cherry picked from commit 6e2c915a441f32eb82f2af5743626470eab96753)
(cherry picked from commit 9fc407d8cf534d1b2c25698cd790e85a9935109c)
(cherry picked from commit 6a759713ad8cc88a802727280d17fe5a5b798966)

Changes in commit 926ceb036223d8ac05cd918c7a4c0825bb9c0640 will be no longer required once we move completely to go version > 1.22.0