### PR TITLE
sandbox: update sandbox resource before/after task creation/deletion

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -911,7 +911,7 @@ func (c *Client) RuntimeInfo(ctx context.Context, runtimePath string, runtimeOpt
 
 	s := c.IntrospectionService()
 
-	resp, err := s.PluginInfo(ctx, string(plugins.RuntimePluginV2), "task", rr)
+	resp, err := s.PluginInfo(ctx, string(plugins.ShimPlugin), "manager", rr)
 	if err != nil {
 		return nil, err
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -732,7 +732,7 @@ func (c *Client) SandboxController(name string) sandbox.Controller {
 	}
 	c.connMu.Lock()
 	defer c.connMu.Unlock()
-	return sandboxproxy.NewSandboxController(sandboxsapi.NewControllerClient(c.conn))
+	return sandboxproxy.NewSandboxController(sandboxsapi.NewControllerClient(c.conn), name)
 }
 
 // VersionService returns the underlying VersionClient

--- a/client/services.go
+++ b/client/services.go
@@ -230,27 +230,3 @@ func WithInMemoryServices(ic *plugin.InitContext) Opt {
 		return nil
 	}
 }
-
-func WithInMemorySandboxControllers(ic *plugin.InitContext) Opt {
-	return func(c *clientOpts) error {
-		sc := make(map[string]sandbox.Controller)
-		sandboxers, err := ic.GetByType(plugins.SandboxControllerPlugin)
-		if err != nil {
-			return err
-		}
-		for name, p := range sandboxers {
-			sc[name] = p.(sandbox.Controller)
-		}
-
-		podSandboxers, err := ic.GetByType(plugins.PodSandboxPlugin)
-		if err != nil {
-			return err
-		}
-		for name, p := range podSandboxers {
-			sc[name] = p.(sandbox.Controller)
-		}
-
-		c.services.sandboxers = sc
-		return nil
-	}
-}

--- a/client/services.go
+++ b/client/services.go
@@ -163,6 +163,13 @@ func WithSandboxStore(client sandbox.Store) ServicesOpt {
 	}
 }
 
+// WithSandboxControllers sets the sandbox controllers.
+func WithSandboxControllers(sandboxers map[string]sandbox.Controller) ServicesOpt {
+	return func(s *services) {
+		s.sandboxers = sandboxers
+	}
+}
+
 // WithInMemoryServices is suitable for cases when there is need to use containerd's client from
 // another (in-memory) containerd plugin (such as CRI).
 func WithInMemoryServices(ic *plugin.InitContext) Opt {

--- a/client/services.go
+++ b/client/services.go
@@ -233,14 +233,23 @@ func WithInMemoryServices(ic *plugin.InitContext) Opt {
 
 func WithInMemorySandboxControllers(ic *plugin.InitContext) Opt {
 	return func(c *clientOpts) error {
+		sc := make(map[string]sandbox.Controller)
 		sandboxers, err := ic.GetByType(plugins.SandboxControllerPlugin)
 		if err != nil {
 			return err
 		}
-		sc := make(map[string]sandbox.Controller)
 		for name, p := range sandboxers {
 			sc[name] = p.(sandbox.Controller)
 		}
+
+		podSandboxers, err := ic.GetByType(plugins.PodSandboxPlugin)
+		if err != nil {
+			return err
+		}
+		for name, p := range podSandboxers {
+			sc[name] = p.(sandbox.Controller)
+		}
+
 		c.services.sandboxers = sc
 		return nil
 	}

--- a/cmd/containerd/server/server.go
+++ b/cmd/containerd/server/server.go
@@ -511,7 +511,7 @@ func LoadPlugins(ctx context.Context, config *srvconfig.Config) ([]plugin.Regist
 		case string(plugins.SandboxControllerPlugin), "sandbox":
 			t = plugins.SandboxControllerPlugin
 			f = func(conn *grpc.ClientConn) interface{} {
-				return sbproxy.NewSandboxController(sbapi.NewControllerClient(conn))
+				return sbproxy.NewSandboxController(sbapi.NewControllerClient(conn), name)
 			}
 		case string(plugins.DiffPlugin), "diff":
 			t = plugins.DiffPlugin

--- a/core/runtime/v2/connection.go
+++ b/core/runtime/v2/connection.go
@@ -1,0 +1,142 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package v2
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/containerd/log"
+	"github.com/containerd/ttrpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/containerd/containerd/v2/pkg/dialer"
+	shimclient "github.com/containerd/containerd/v2/pkg/shim"
+)
+
+// makeConnection creates a new TTRPC or GRPC connection object from address.
+// address can be either a socket path for TTRPC or JSON serialized BootstrapParams.
+func makeConnection(ctx context.Context, id string, params shimclient.BootstrapParams, onClose func()) (_ io.Closer, retErr error) {
+	log.G(ctx).WithFields(log.Fields{
+		"address":  params.Address,
+		"protocol": params.Protocol,
+		"version":  params.Version,
+	}).Infof("connecting to shim %s", id)
+
+	switch strings.ToLower(params.Protocol) {
+	case "ttrpc":
+		conn, err := shimclient.Connect(params.Address, shimclient.AnonReconnectDialer)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create TTRPC connection: %w", err)
+		}
+		defer func() {
+			if retErr != nil {
+				conn.Close()
+			}
+		}()
+
+		return ttrpc.NewClient(conn, ttrpc.WithOnClose(onClose)), nil
+	case "grpc":
+		gopts := []grpc.DialOption{
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		}
+		return grpcDialContext(params.Address, onClose, gopts...)
+	default:
+		return nil, fmt.Errorf("unexpected protocol: %q", params.Protocol)
+	}
+}
+
+// grpcDialContext and the underlying grpcConn type exist solely
+// so we can have something similar to ttrpc.WithOnClose to have
+// a callback run when the connection is severed or explicitly closed.
+func grpcDialContext(
+	address string,
+	onClose func(),
+	gopts ...grpc.DialOption,
+) (*grpcConn, error) {
+	// If grpc.WithBlock is specified in gopts this causes the connection to block waiting for
+	// a connection regardless of if the socket exists or has a listener when Dial begins. This
+	// specific behavior of WithBlock is mostly undesirable for shims, as if the socket isn't
+	// there when we go to load/connect there's likely an issue. However, getting rid of WithBlock is
+	// also undesirable as we don't want the background connection behavior, we want to ensure
+	// a connection before moving on. To bring this in line with the ttrpc connection behavior
+	// lets do an initial dial to ensure the shims socket is actually available. stat wouldn't suffice
+	// here as if the shim exited unexpectedly its socket may still be on the filesystem, but it'd return
+	// ECONNREFUSED which grpc.DialContext will happily trudge along through for the full timeout.
+	//
+	// This is especially helpful on restart of containerd as if the shim died while containerd
+	// was down, we end up waiting the full timeout.
+	conn, err := net.DialTimeout("unix", address, time.Second*10)
+	if err != nil {
+		return nil, err
+	}
+	conn.Close()
+
+	target := dialer.DialAddress(address)
+	client, err := grpc.NewClient(target, gopts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GRPC connection: %w", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		gctx := context.Background()
+		sourceState := connectivity.Ready
+		for {
+			if client.WaitForStateChange(gctx, sourceState) {
+				state := client.GetState()
+				if state == connectivity.Idle || state == connectivity.Shutdown {
+					break
+				}
+				// Could be transient failure. Lets see if we can get back to a working
+				// state.
+				log.G(gctx).WithFields(log.Fields{
+					"state": state,
+					"addr":  target,
+				}).Warn("shim grpc connection unexpected state")
+				sourceState = state
+			}
+		}
+		onClose()
+		close(done)
+	}()
+
+	return &grpcConn{
+		ClientConn:  client,
+		onCloseDone: done,
+	}, nil
+}
+
+type grpcConn struct {
+	*grpc.ClientConn
+	onCloseDone chan struct{}
+}
+
+func (gc *grpcConn) UserOnCloseWait(ctx context.Context) error {
+	select {
+	case <-gc.onCloseDone:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/core/runtime/v2/process.go
+++ b/core/runtime/v2/process.go
@@ -30,7 +30,7 @@ import (
 
 type process struct {
 	id   string
-	shim *shimTask
+	task *remoteTask
 }
 
 func (p *process) ID() string {
@@ -38,9 +38,9 @@ func (p *process) ID() string {
 }
 
 func (p *process) Kill(ctx context.Context, signal uint32, _ bool) error {
-	_, err := p.shim.task.Kill(ctx, &task.KillRequest{
+	_, err := p.task.client.Kill(ctx, &task.KillRequest{
 		Signal: signal,
-		ID:     p.shim.ID(),
+		ID:     p.task.id,
 		ExecID: p.id,
 	})
 	if err != nil {
@@ -67,8 +67,8 @@ func statusFromProto(from tasktypes.Status) runtime.Status {
 }
 
 func (p *process) State(ctx context.Context) (runtime.State, error) {
-	response, err := p.shim.task.State(ctx, &task.StateRequest{
-		ID:     p.shim.ID(),
+	response, err := p.task.client.State(ctx, &task.StateRequest{
+		ID:     p.task.id,
 		ExecID: p.id,
 	})
 	if err != nil {
@@ -91,8 +91,8 @@ func (p *process) State(ctx context.Context) (runtime.State, error) {
 
 // ResizePty changes the side of the process's PTY to the provided width and height
 func (p *process) ResizePty(ctx context.Context, size runtime.ConsoleSize) error {
-	_, err := p.shim.task.ResizePty(ctx, &task.ResizePtyRequest{
-		ID:     p.shim.ID(),
+	_, err := p.task.client.ResizePty(ctx, &task.ResizePtyRequest{
+		ID:     p.task.id,
 		ExecID: p.id,
 		Width:  size.Width,
 		Height: size.Height,
@@ -105,8 +105,8 @@ func (p *process) ResizePty(ctx context.Context, size runtime.ConsoleSize) error
 
 // CloseIO closes the provided IO pipe for the process
 func (p *process) CloseIO(ctx context.Context) error {
-	_, err := p.shim.task.CloseIO(ctx, &task.CloseIORequest{
-		ID:     p.shim.ID(),
+	_, err := p.task.client.CloseIO(ctx, &task.CloseIORequest{
+		ID:     p.task.id,
 		ExecID: p.id,
 		Stdin:  true,
 	})
@@ -118,8 +118,8 @@ func (p *process) CloseIO(ctx context.Context) error {
 
 // Start the process
 func (p *process) Start(ctx context.Context) error {
-	_, err := p.shim.task.Start(ctx, &task.StartRequest{
-		ID:     p.shim.ID(),
+	_, err := p.task.client.Start(ctx, &task.StartRequest{
+		ID:     p.task.id,
 		ExecID: p.id,
 	})
 	if err != nil {
@@ -130,8 +130,8 @@ func (p *process) Start(ctx context.Context) error {
 
 // Wait on the process to exit and return the exit status and timestamp
 func (p *process) Wait(ctx context.Context) (*runtime.Exit, error) {
-	response, err := p.shim.task.Wait(ctx, &task.WaitRequest{
-		ID:     p.shim.ID(),
+	response, err := p.task.client.Wait(ctx, &task.WaitRequest{
+		ID:     p.task.id,
 		ExecID: p.id,
 	})
 	if err != nil {
@@ -144,8 +144,8 @@ func (p *process) Wait(ctx context.Context) (*runtime.Exit, error) {
 }
 
 func (p *process) Delete(ctx context.Context) (*runtime.Exit, error) {
-	response, err := p.shim.task.Delete(ctx, &task.DeleteRequest{
-		ID:     p.shim.ID(),
+	response, err := p.task.client.Delete(ctx, &task.DeleteRequest{
+		ID:     p.task.id,
 		ExecID: p.id,
 	})
 	if err != nil {

--- a/core/runtime/v2/shim.go
+++ b/core/runtime/v2/shim.go
@@ -22,32 +22,21 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/connectivity"
-	"google.golang.org/grpc/credentials/insecure"
-
-	eventstypes "github.com/containerd/containerd/api/events"
-	task "github.com/containerd/containerd/api/runtime/task/v3"
-	"github.com/containerd/containerd/api/types"
-	"github.com/containerd/containerd/v2/core/events/exchange"
-	"github.com/containerd/containerd/v2/core/runtime"
-	"github.com/containerd/containerd/v2/pkg/atomicfile"
-	"github.com/containerd/containerd/v2/pkg/dialer"
-	"github.com/containerd/containerd/v2/pkg/identifiers"
-	"github.com/containerd/containerd/v2/pkg/protobuf"
-	ptypes "github.com/containerd/containerd/v2/pkg/protobuf/types"
-	client "github.com/containerd/containerd/v2/pkg/shim"
-	"github.com/containerd/containerd/v2/pkg/timeout"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/ttrpc"
-	"github.com/containerd/typeurl/v2"
+
+	eventstypes "github.com/containerd/containerd/api/events"
+	"github.com/containerd/containerd/v2/core/events/exchange"
+	"github.com/containerd/containerd/v2/core/runtime"
+	"github.com/containerd/containerd/v2/pkg/atomicfile"
+	"github.com/containerd/containerd/v2/pkg/protobuf"
+	client "github.com/containerd/containerd/v2/pkg/shim"
+	"github.com/containerd/containerd/v2/pkg/timeout"
 )
 
 const (
@@ -60,6 +49,101 @@ func init() {
 	timeout.Set(loadTimeout, 5*time.Second)
 	timeout.Set(cleanupTimeout, 5*time.Second)
 	timeout.Set(shutdownTimeout, 3*time.Second)
+}
+
+// ShimInstance represents running shim process managed by ShimManager.
+type ShimInstance interface {
+	io.Closer
+
+	// ID of the shim.
+	ID() string
+	// Namespace of this shim.
+	Namespace() string
+	// Bundle is a file system path to shim's bundle.
+	Bundle() string
+	// Client returns the underlying TTRPC or GRPC client object for this shim.
+	// The underlying object can be either *ttrpc.Client or grpc.ClientConnInterface.
+	Client() any
+	// Delete will close the client and remove bundle from disk.
+	Delete(ctx context.Context) error
+	// Endpoint returns shim's endpoint information,
+	// including address, and version.
+	// Note that the address is in the form of ttrpc+unix://path/to/sock or grpc+vsock://cid:port
+	Endpoint() (string, int)
+}
+
+type shim struct {
+	bundle  *Bundle
+	client  any
+	address string
+	version int
+}
+
+var _ ShimInstance = (*shim)(nil)
+
+// ID of the shim/task
+func (s *shim) ID() string {
+	return s.bundle.ID
+}
+
+func (s *shim) Endpoint() (string, int) {
+	return s.address, s.version
+}
+
+func (s *shim) Namespace() string {
+	return s.bundle.Namespace
+}
+
+func (s *shim) Bundle() string {
+	return s.bundle.Path
+}
+
+func (s *shim) Client() any {
+	return s.client
+}
+
+// Close closes the underlying client connection.
+func (s *shim) Close() error {
+	if ttrpcClient, ok := s.client.(*ttrpc.Client); ok {
+		return ttrpcClient.Close()
+	}
+
+	if grpcClient, ok := s.client.(*grpcConn); ok {
+		return grpcClient.Close()
+	}
+
+	return nil
+}
+
+func (s *shim) Delete(ctx context.Context) error {
+	var result []error
+
+	if ttrpcClient, ok := s.client.(*ttrpc.Client); ok {
+		if err := ttrpcClient.Close(); err != nil {
+			result = append(result, fmt.Errorf("failed to close ttrpc client: %w", err))
+		}
+
+		if err := ttrpcClient.UserOnCloseWait(ctx); err != nil {
+			result = append(result, fmt.Errorf("close wait error: %w", err))
+		}
+	}
+
+	if grpcClient, ok := s.client.(*grpcConn); ok {
+		if err := grpcClient.Close(); err != nil {
+			result = append(result, fmt.Errorf("failed to close grpc client: %w", err))
+		}
+
+		if err := grpcClient.UserOnCloseWait(ctx); err != nil {
+			result = append(result, fmt.Errorf("close wait error: %w", err))
+		}
+	}
+
+	if err := s.bundle.Delete(); err != nil {
+		log.G(ctx).WithField("id", s.ID()).WithError(err).Error("failed to delete bundle")
+		result = append(result, fmt.Errorf("failed to delete bundle: %w", err))
+	}
+
+	return errors.Join(result...)
 }
 
 func loadShim(ctx context.Context, bundle *Bundle, onClose func()) (_ ShimInstance, retErr error) {
@@ -175,26 +259,6 @@ func cleanupAfterDeadShim(ctx context.Context, id string, rt *runtime.NSMap[Shim
 // CurrentShimVersion is the latest shim version supported by containerd (e.g. TaskService v3).
 const CurrentShimVersion = 3
 
-// ShimInstance represents running shim process managed by ShimManager.
-type ShimInstance interface {
-	io.Closer
-
-	// ID of the shim.
-	ID() string
-	// Namespace of this shim.
-	Namespace() string
-	// Bundle is a file system path to shim's bundle.
-	Bundle() string
-	// Client returns the underlying TTRPC or GRPC client object for this shim.
-	// The underlying object can be either *ttrpc.Client or grpc.ClientConnInterface.
-	Client() any
-	// Delete will close the client and remove bundle from disk.
-	Delete(ctx context.Context) error
-	// Endpoint returns shim's endpoint information,
-	// including address and version.
-	Endpoint() (string, int)
-}
-
 func parseStartResponse(response []byte) (client.BootstrapParams, error) {
 	var params client.BootstrapParams
 
@@ -250,516 +314,4 @@ func readBootstrapParams(path string) (client.BootstrapParams, error) {
 	}
 
 	return parseStartResponse(data)
-}
-
-// makeConnection creates a new TTRPC or GRPC connection object from address.
-// address can be either a socket path for TTRPC or JSON serialized BootstrapParams.
-func makeConnection(ctx context.Context, id string, params client.BootstrapParams, onClose func()) (_ io.Closer, retErr error) {
-	log.G(ctx).WithFields(log.Fields{
-		"address":  params.Address,
-		"protocol": params.Protocol,
-		"version":  params.Version,
-	}).Infof("connecting to shim %s", id)
-
-	switch strings.ToLower(params.Protocol) {
-	case "ttrpc":
-		conn, err := client.Connect(params.Address, client.AnonReconnectDialer)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create TTRPC connection: %w", err)
-		}
-		defer func() {
-			if retErr != nil {
-				conn.Close()
-			}
-		}()
-
-		return ttrpc.NewClient(conn, ttrpc.WithOnClose(onClose)), nil
-	case "grpc":
-		gopts := []grpc.DialOption{
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-		}
-		return grpcDialContext(params.Address, onClose, gopts...)
-	default:
-		return nil, fmt.Errorf("unexpected protocol: %q", params.Protocol)
-	}
-}
-
-// grpcDialContext and the underlying grpcConn type exist solely
-// so we can have something similar to ttrpc.WithOnClose to have
-// a callback run when the connection is severed or explicitly closed.
-func grpcDialContext(
-	address string,
-	onClose func(),
-	gopts ...grpc.DialOption,
-) (*grpcConn, error) {
-	// If grpc.WithBlock is specified in gopts this causes the connection to block waiting for
-	// a connection regardless of if the socket exists or has a listener when Dial begins. This
-	// specific behavior of WithBlock is mostly undesirable for shims, as if the socket isn't
-	// there when we go to load/connect there's likely an issue. However, getting rid of WithBlock is
-	// also undesirable as we don't want the background connection behavior, we want to ensure
-	// a connection before moving on. To bring this in line with the ttrpc connection behavior
-	// lets do an initial dial to ensure the shims socket is actually available. stat wouldn't suffice
-	// here as if the shim exited unexpectedly its socket may still be on the filesystem, but it'd return
-	// ECONNREFUSED which grpc.DialContext will happily trudge along through for the full timeout.
-	//
-	// This is especially helpful on restart of containerd as if the shim died while containerd
-	// was down, we end up waiting the full timeout.
-	conn, err := net.DialTimeout("unix", address, time.Second*10)
-	if err != nil {
-		return nil, err
-	}
-	conn.Close()
-
-	target := dialer.DialAddress(address)
-	client, err := grpc.NewClient(target, gopts...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create GRPC connection: %w", err)
-	}
-
-	done := make(chan struct{})
-	go func() {
-		gctx := context.Background()
-		sourceState := connectivity.Ready
-		for {
-			if client.WaitForStateChange(gctx, sourceState) {
-				state := client.GetState()
-				if state == connectivity.Idle || state == connectivity.Shutdown {
-					break
-				}
-				// Could be transient failure. Lets see if we can get back to a working
-				// state.
-				log.G(gctx).WithFields(log.Fields{
-					"state": state,
-					"addr":  target,
-				}).Warn("shim grpc connection unexpected state")
-				sourceState = state
-			}
-		}
-		onClose()
-		close(done)
-	}()
-
-	return &grpcConn{
-		ClientConn:  client,
-		onCloseDone: done,
-	}, nil
-}
-
-type grpcConn struct {
-	*grpc.ClientConn
-	onCloseDone chan struct{}
-}
-
-func (gc *grpcConn) UserOnCloseWait(ctx context.Context) error {
-	select {
-	case <-gc.onCloseDone:
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-}
-
-type shim struct {
-	bundle  *Bundle
-	client  any
-	address string
-	version int
-}
-
-var _ ShimInstance = (*shim)(nil)
-
-// ID of the shim/task
-func (s *shim) ID() string {
-	return s.bundle.ID
-}
-
-func (s *shim) Endpoint() (string, int) {
-	return s.address, s.version
-}
-
-func (s *shim) Namespace() string {
-	return s.bundle.Namespace
-}
-
-func (s *shim) Bundle() string {
-	return s.bundle.Path
-}
-
-func (s *shim) Client() any {
-	return s.client
-}
-
-// Close closes the underlying client connection.
-func (s *shim) Close() error {
-	if ttrpcClient, ok := s.client.(*ttrpc.Client); ok {
-		return ttrpcClient.Close()
-	}
-
-	if grpcClient, ok := s.client.(*grpcConn); ok {
-		return grpcClient.Close()
-	}
-
-	return nil
-}
-
-func (s *shim) Delete(ctx context.Context) error {
-	var result []error
-
-	if ttrpcClient, ok := s.client.(*ttrpc.Client); ok {
-		if err := ttrpcClient.Close(); err != nil {
-			result = append(result, fmt.Errorf("failed to close ttrpc client: %w", err))
-		}
-
-		if err := ttrpcClient.UserOnCloseWait(ctx); err != nil {
-			result = append(result, fmt.Errorf("close wait error: %w", err))
-		}
-	}
-
-	if grpcClient, ok := s.client.(*grpcConn); ok {
-		if err := grpcClient.Close(); err != nil {
-			result = append(result, fmt.Errorf("failed to close grpc client: %w", err))
-		}
-
-		if err := grpcClient.UserOnCloseWait(ctx); err != nil {
-			result = append(result, fmt.Errorf("close wait error: %w", err))
-		}
-	}
-
-	if err := s.bundle.Delete(); err != nil {
-		log.G(ctx).WithField("id", s.ID()).WithError(err).Error("failed to delete bundle")
-		result = append(result, fmt.Errorf("failed to delete bundle: %w", err))
-	}
-
-	return errors.Join(result...)
-}
-
-var _ runtime.Task = &shimTask{}
-
-// shimTask wraps shim process and adds task service client for compatibility with existing shim manager.
-type shimTask struct {
-	ShimInstance
-	task TaskServiceClient
-}
-
-func newShimTask(shim ShimInstance) (*shimTask, error) {
-	_, version := shim.Endpoint()
-	taskClient, err := NewTaskClient(shim.Client(), version)
-	if err != nil {
-		return nil, err
-	}
-
-	return &shimTask{
-		ShimInstance: shim,
-		task:         taskClient,
-	}, nil
-}
-
-func (s *shimTask) Shutdown(ctx context.Context) error {
-	_, err := s.task.Shutdown(ctx, &task.ShutdownRequest{
-		ID: s.ID(),
-	})
-	if err != nil && !errors.Is(err, ttrpc.ErrClosed) {
-		return errdefs.FromGRPC(err)
-	}
-	return nil
-}
-
-func (s *shimTask) waitShutdown(ctx context.Context) error {
-	ctx, cancel := timeout.WithContext(ctx, shutdownTimeout)
-	defer cancel()
-	return s.Shutdown(ctx)
-}
-
-// PID of the task
-func (s *shimTask) PID(ctx context.Context) (uint32, error) {
-	response, err := s.task.Connect(ctx, &task.ConnectRequest{
-		ID: s.ID(),
-	})
-	if err != nil {
-		return 0, errdefs.FromGRPC(err)
-	}
-
-	return response.TaskPid, nil
-}
-
-func (s *shimTask) delete(ctx context.Context, sandboxed bool, removeTask func(ctx context.Context, id string)) (*runtime.Exit, error) {
-	response, shimErr := s.task.Delete(ctx, &task.DeleteRequest{
-		ID: s.ID(),
-	})
-	if shimErr != nil {
-		log.G(ctx).WithField("id", s.ID()).WithError(shimErr).Debug("failed to delete task")
-		if !errors.Is(shimErr, ttrpc.ErrClosed) {
-			shimErr = errdefs.FromGRPC(shimErr)
-			if !errdefs.IsNotFound(shimErr) {
-				return nil, shimErr
-			}
-		}
-	}
-
-	// NOTE: If the shim has been killed and ttrpc connection has been
-	// closed, the shimErr will not be nil. For this case, the event
-	// subscriber, like moby/moby, might have received the exit or delete
-	// events. Just in case, we should allow ttrpc-callback-on-close to
-	// send the exit and delete events again. And the exit status will
-	// depend on result of shimV2.Delete.
-	//
-	// If not, the shim has been delivered the exit and delete events.
-	// So we should remove the record and prevent duplicate events from
-	// ttrpc-callback-on-close.
-	//
-	// TODO: It's hard to guarantee that the event is unique and sent only
-	// once. The moby/moby should not rely on that assumption that there is
-	// only one exit event. The moby/moby should handle the duplicate events.
-	//
-	// REF: https://github.com/containerd/containerd/issues/4769
-	if shimErr == nil {
-		removeTask(ctx, s.ID())
-	}
-
-	// Don't shutdown sandbox as there may be other containers running.
-	// Let controller decide when to shutdown.
-	if !sandboxed {
-		if err := s.waitShutdown(ctx); err != nil {
-			// FIXME(fuweid):
-			//
-			// If the error is context canceled, should we use context.TODO()
-			// to wait for it?
-			log.G(ctx).WithField("id", s.ID()).WithError(err).Error("failed to shutdown shim task and the shim might be leaked")
-		}
-	}
-
-	if err := s.ShimInstance.Delete(ctx); err != nil {
-		log.G(ctx).WithField("id", s.ID()).WithError(err).Error("failed to delete shim")
-	}
-
-	// remove self from the runtime task list
-	// this seems dirty but it cleans up the API across runtimes, tasks, and the service
-	removeTask(ctx, s.ID())
-
-	if shimErr != nil {
-		return nil, shimErr
-	}
-
-	return &runtime.Exit{
-		Status:    response.ExitStatus,
-		Timestamp: protobuf.FromTimestamp(response.ExitedAt),
-		Pid:       response.Pid,
-	}, nil
-}
-
-func (s *shimTask) Create(ctx context.Context, opts runtime.CreateOpts) (runtime.Task, error) {
-	topts := opts.TaskOptions
-	if topts == nil || topts.GetValue() == nil {
-		topts = opts.RuntimeOptions
-	}
-	request := &task.CreateTaskRequest{
-		ID:         s.ID(),
-		Bundle:     s.Bundle(),
-		Stdin:      opts.IO.Stdin,
-		Stdout:     opts.IO.Stdout,
-		Stderr:     opts.IO.Stderr,
-		Terminal:   opts.IO.Terminal,
-		Checkpoint: opts.Checkpoint,
-		Options:    typeurl.MarshalProto(topts),
-	}
-	for _, m := range opts.Rootfs {
-		request.Rootfs = append(request.Rootfs, &types.Mount{
-			Type:    m.Type,
-			Source:  m.Source,
-			Target:  m.Target,
-			Options: m.Options,
-		})
-	}
-
-	_, err := s.task.Create(ctx, request)
-	if err != nil {
-		return nil, errdefs.FromGRPC(err)
-	}
-
-	return s, nil
-}
-
-func (s *shimTask) Pause(ctx context.Context) error {
-	if _, err := s.task.Pause(ctx, &task.PauseRequest{
-		ID: s.ID(),
-	}); err != nil {
-		return errdefs.FromGRPC(err)
-	}
-	return nil
-}
-
-func (s *shimTask) Resume(ctx context.Context) error {
-	if _, err := s.task.Resume(ctx, &task.ResumeRequest{
-		ID: s.ID(),
-	}); err != nil {
-		return errdefs.FromGRPC(err)
-	}
-	return nil
-}
-
-func (s *shimTask) Start(ctx context.Context) error {
-	_, err := s.task.Start(ctx, &task.StartRequest{
-		ID: s.ID(),
-	})
-	if err != nil {
-		return errdefs.FromGRPC(err)
-	}
-	return nil
-}
-
-func (s *shimTask) Kill(ctx context.Context, signal uint32, all bool) error {
-	if _, err := s.task.Kill(ctx, &task.KillRequest{
-		ID:     s.ID(),
-		Signal: signal,
-		All:    all,
-	}); err != nil {
-		return errdefs.FromGRPC(err)
-	}
-	return nil
-}
-
-func (s *shimTask) Exec(ctx context.Context, id string, opts runtime.ExecOpts) (runtime.ExecProcess, error) {
-	if err := identifiers.Validate(id); err != nil {
-		return nil, fmt.Errorf("invalid exec id %s: %w", id, err)
-	}
-	request := &task.ExecProcessRequest{
-		ID:       s.ID(),
-		ExecID:   id,
-		Stdin:    opts.IO.Stdin,
-		Stdout:   opts.IO.Stdout,
-		Stderr:   opts.IO.Stderr,
-		Terminal: opts.IO.Terminal,
-		Spec:     opts.Spec,
-	}
-	if _, err := s.task.Exec(ctx, request); err != nil {
-		return nil, errdefs.FromGRPC(err)
-	}
-	return &process{
-		id:   id,
-		shim: s,
-	}, nil
-}
-
-func (s *shimTask) Pids(ctx context.Context) ([]runtime.ProcessInfo, error) {
-	resp, err := s.task.Pids(ctx, &task.PidsRequest{
-		ID: s.ID(),
-	})
-	if err != nil {
-		return nil, errdefs.FromGRPC(err)
-	}
-	var processList []runtime.ProcessInfo
-	for _, p := range resp.Processes {
-		processList = append(processList, runtime.ProcessInfo{
-			Pid:  p.Pid,
-			Info: p.Info,
-		})
-	}
-	return processList, nil
-}
-
-func (s *shimTask) ResizePty(ctx context.Context, size runtime.ConsoleSize) error {
-	_, err := s.task.ResizePty(ctx, &task.ResizePtyRequest{
-		ID:     s.ID(),
-		Width:  size.Width,
-		Height: size.Height,
-	})
-	if err != nil {
-		return errdefs.FromGRPC(err)
-	}
-	return nil
-}
-
-func (s *shimTask) CloseIO(ctx context.Context) error {
-	_, err := s.task.CloseIO(ctx, &task.CloseIORequest{
-		ID:    s.ID(),
-		Stdin: true,
-	})
-	if err != nil {
-		return errdefs.FromGRPC(err)
-	}
-	return nil
-}
-
-func (s *shimTask) Wait(ctx context.Context) (*runtime.Exit, error) {
-	taskPid, err := s.PID(ctx)
-	if err != nil {
-		return nil, err
-	}
-	response, err := s.task.Wait(ctx, &task.WaitRequest{
-		ID: s.ID(),
-	})
-	if err != nil {
-		return nil, errdefs.FromGRPC(err)
-	}
-	return &runtime.Exit{
-		Pid:       taskPid,
-		Timestamp: protobuf.FromTimestamp(response.ExitedAt),
-		Status:    response.ExitStatus,
-	}, nil
-}
-
-func (s *shimTask) Checkpoint(ctx context.Context, path string, options *ptypes.Any) error {
-	request := &task.CheckpointTaskRequest{
-		ID:      s.ID(),
-		Path:    path,
-		Options: options,
-	}
-	if _, err := s.task.Checkpoint(ctx, request); err != nil {
-		return errdefs.FromGRPC(err)
-	}
-	return nil
-}
-
-func (s *shimTask) Update(ctx context.Context, resources *ptypes.Any, annotations map[string]string) error {
-	if _, err := s.task.Update(ctx, &task.UpdateTaskRequest{
-		ID:          s.ID(),
-		Resources:   resources,
-		Annotations: annotations,
-	}); err != nil {
-		return errdefs.FromGRPC(err)
-	}
-	return nil
-}
-
-func (s *shimTask) Stats(ctx context.Context) (*ptypes.Any, error) {
-	response, err := s.task.Stats(ctx, &task.StatsRequest{
-		ID: s.ID(),
-	})
-	if err != nil {
-		return nil, errdefs.FromGRPC(err)
-	}
-	return response.Stats, nil
-}
-
-func (s *shimTask) Process(ctx context.Context, id string) (runtime.ExecProcess, error) {
-	p := &process{
-		id:   id,
-		shim: s,
-	}
-	if _, err := p.State(ctx); err != nil {
-		return nil, err
-	}
-	return p, nil
-}
-
-func (s *shimTask) State(ctx context.Context) (runtime.State, error) {
-	response, err := s.task.State(ctx, &task.StateRequest{
-		ID: s.ID(),
-	})
-	if err != nil {
-		if !errors.Is(err, ttrpc.ErrClosed) {
-			return runtime.State{}, errdefs.FromGRPC(err)
-		}
-		return runtime.State{}, errdefs.ErrNotFound
-	}
-	return runtime.State{
-		Pid:        response.Pid,
-		Status:     statusFromProto(response.Status),
-		Stdin:      response.Stdin,
-		Stdout:     response.Stdout,
-		Stderr:     response.Stderr,
-		Terminal:   response.Terminal,
-		ExitStatus: response.ExitStatus,
-		ExitedAt:   protobuf.FromTimestamp(response.ExitedAt),
-	}, nil
 }

--- a/core/runtime/v2/shim_load.go
+++ b/core/runtime/v2/shim_load.go
@@ -18,105 +18,43 @@ package v2
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
-	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/internal/cleanup"
-	"github.com/containerd/containerd/v2/pkg/namespaces"
-	"github.com/containerd/containerd/v2/pkg/timeout"
 )
 
 // LoadExistingShims loads existing shims from the path specified by stateDir
 // rootDir is for cleaning up the unused paths of removed shims.
 func (m *ShimManager) LoadExistingShims(ctx context.Context, stateDir string, rootDir string) error {
-	nsDirs, err := os.ReadDir(stateDir)
-	if err != nil {
-		return err
-	}
-	for _, nsd := range nsDirs {
-		if !nsd.IsDir() {
-			continue
-		}
-		ns := nsd.Name()
-		// skip hidden directories
-		if len(ns) > 0 && ns[0] == '.' {
-			continue
-		}
-		log.G(ctx).WithField("namespace", ns).Debug("loading tasks in namespace")
-		if err := m.loadShims(namespaces.WithNamespace(ctx, ns), stateDir); err != nil {
-			log.G(ctx).WithField("namespace", ns).WithError(err).Error("loading tasks in namespace")
-			continue
-		}
-		if err := m.cleanupWorkDirs(namespaces.WithNamespace(ctx, ns), rootDir); err != nil {
-			log.G(ctx).WithField("namespace", ns).WithError(err).Error("cleanup working directory in namespace")
-			continue
-		}
-	}
-	return nil
-}
-
-func (m *ShimManager) loadShims(ctx context.Context, stateDir string) error {
-	ns, err := namespaces.NamespaceRequired(ctx)
-	if err != nil {
-		return err
-	}
-	ctx = log.WithLogger(ctx, log.G(ctx).WithField("namespace", ns))
-
-	shimDirs, err := os.ReadDir(filepath.Join(stateDir, ns))
-	if err != nil {
-		return err
-	}
-	for _, sd := range shimDirs {
-		if !sd.IsDir() {
-			continue
-		}
-		id := sd.Name()
-		// skip hidden directories
-		if len(id) > 0 && id[0] == '.' {
-			continue
-		}
-		bundle, err := LoadBundle(ctx, stateDir, id)
-		if err != nil {
-			// fine to return error here, it is a programmer error if the context
-			// does not have a namespace
-			return err
-		}
-		// fast path
-		f, err := os.Open(bundle.Path)
-		if err != nil {
-			bundle.Delete()
-			log.G(ctx).WithError(err).Errorf("fast path read bundle path for %s", bundle.Path)
-			continue
-		}
-
-		bf, err := f.Readdirnames(-1)
-		f.Close()
-		if err != nil {
-			bundle.Delete()
-			log.G(ctx).WithError(err).Errorf("fast path read bundle path for %s", bundle.Path)
-			continue
-		}
-		if len(bf) == 0 {
-			bundle.Delete()
-			continue
-		}
-		if err := m.loadShim(ctx, bundle); err != nil {
+	if err := TraversBundles(ctx, stateDir, func(ctx context.Context, bundle *Bundle) error {
+		if err := m.loadShim(ctx, bundle, func(instance ShimInstance) error {
+			return nil
+		}); err != nil {
 			log.G(ctx).WithError(err).Errorf("failed to load shim %s", bundle.Path)
 			bundle.Delete()
-			continue
 		}
-
+		return nil
+	}); err != nil {
+		return err
 	}
+	TraversWorkDirs(ctx, rootDir, func(ctx context.Context, ns, dir string) error {
+		if _, err := m.shims.Get(ctx, dir); err != nil {
+			path := filepath.Join(rootDir, ns, dir)
+			if err := os.RemoveAll(path); err != nil {
+				log.G(ctx).WithError(err).Errorf("cleanup working dir %s", path)
+			}
+		}
+		return nil
+	})
 	return nil
 }
 
-func (m *ShimManager) loadShim(ctx context.Context, bundle *Bundle) error {
+func (m *ShimManager) loadShim(ctx context.Context, bundle *Bundle, check func(ShimInstance) error) error {
 	var (
 		runtime string
 		id      = bundle.ID
@@ -156,8 +94,7 @@ func (m *ShimManager) loadShim(ctx context.Context, bundle *Bundle) error {
 			ttrpcAddress: m.containerdTTRPCAddress,
 			env:          m.env,
 		})
-	// TODO: It seems we can only call loadShim here if it is a sandbox shim?
-	shim, err := loadShimTask(ctx, bundle, func() {
+	shim, err := loadAndCheckShim(ctx, bundle, check, func() {
 		log.G(ctx).WithField("id", id).Info("shim disconnected")
 
 		cleanupAfterDeadShim(cleanup.Background(ctx), id, m.shims, m.events, binaryCall)
@@ -168,76 +105,21 @@ func (m *ShimManager) loadShim(ctx context.Context, bundle *Bundle) error {
 		cleanupAfterDeadShim(ctx, id, m.shims, m.events, binaryCall)
 		return fmt.Errorf("unable to load shim %q: %w", id, err)
 	}
-
-	// There are 3 possibilities for the loaded shim here:
-	// 1. It could be a shim that is running a task.
-	// 2. It could be a sandbox shim.
-	// 3. Or it could be a shim that was created for running a task but
-	// something happened (probably a containerd crash) and the task was never
-	// created. This shim process should be cleaned up here. Look at
-	// containerd/containerd#6860 for further details.
-
-	_, sgetErr := m.sandboxStore.Get(ctx, id)
-	pInfo, pidErr := shim.Pids(ctx)
-	if sgetErr != nil && errors.Is(sgetErr, errdefs.ErrNotFound) && (len(pInfo) == 0 || errors.Is(pidErr, errdefs.ErrNotFound)) {
-		log.G(ctx).WithField("id", id).Info("cleaning leaked shim process")
-		// We are unable to get Pids from the shim and it's not a sandbox
-		// shim. We should clean it up her.
-		// No need to do anything for removeTask since we never added this shim.
-		shim.delete(ctx, false, func(ctx context.Context, id string) {})
-	} else {
-		m.shims.Add(ctx, shim.ShimInstance)
+	if err := m.shims.Add(ctx, shim); err != nil {
+		return err
 	}
 	return nil
 }
 
-func loadShimTask(ctx context.Context, bundle *Bundle, onClose func()) (_ *shimTask, retErr error) {
+func loadAndCheckShim(ctx context.Context, bundle *Bundle, check func(ShimInstance) error, onClose func()) (_ ShimInstance, retErr error) {
 	shim, err := loadShim(ctx, bundle, onClose)
 	if err != nil {
 		return nil, err
 	}
 	// Check connectivity, TaskService is the only required service, so create a temp one to check connection.
-	s, err := newShimTask(shim)
-	if err != nil {
+	if err := check(shim); err != nil {
 		return nil, err
 	}
 
-	ctx, cancel := timeout.WithContext(ctx, loadTimeout)
-	defer cancel()
-
-	if _, err := s.PID(ctx); err != nil {
-		return nil, err
-	}
-	return s, nil
-}
-
-func (m *ShimManager) cleanupWorkDirs(ctx context.Context, rootDir string) error {
-	ns, err := namespaces.NamespaceRequired(ctx)
-	if err != nil {
-		return err
-	}
-
-	f, err := os.Open(filepath.Join(rootDir, ns))
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	dirs, err := f.Readdirnames(-1)
-	if err != nil {
-		return err
-	}
-
-	for _, dir := range dirs {
-		// if the task was not loaded, cleanup and empty working directory
-		// this can happen on a reboot where /run for the bundle state is cleaned up
-		// but that persistent working dir is left
-		if _, err := m.shims.Get(ctx, dir); err != nil {
-			path := filepath.Join(rootDir, ns, dir)
-			if err := os.RemoveAll(path); err != nil {
-				log.G(ctx).WithError(err).Errorf("cleanup working dir %s", path)
-			}
-		}
-	}
-	return nil
+	return shim, nil
 }

--- a/core/runtime/v2/task_manager.go
+++ b/core/runtime/v2/task_manager.go
@@ -17,29 +17,19 @@
 package v2
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
-	"slices"
+	"path/filepath"
 
+	"github.com/containerd/containerd/v2/core/runtime"
+	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
 	"github.com/containerd/platforms"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
-	"github.com/containerd/typeurl/v2"
-	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/opencontainers/runtime-spec/specs-go/features"
-
-	apitypes "github.com/containerd/containerd/api/types"
-
-	"github.com/containerd/containerd/v2/core/runtime"
-	"github.com/containerd/containerd/v2/internal/cleanup"
-	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
-	"github.com/containerd/containerd/v2/pkg/timeout"
-	"github.com/containerd/containerd/v2/plugins"
 )
 
 // TaskConfig for the runtime task manager
@@ -54,6 +44,7 @@ func init() {
 		ID:   "task",
 		Requires: []plugin.Type{
 			plugins.ShimPlugin,
+			plugins.SandboxControllerPlugin,
 		},
 		Config: &TaskConfig{
 			Platforms: defaultPlatforms(),
@@ -72,41 +63,57 @@ func init() {
 				return nil, err
 			}
 			shimManager := shimManagerI.(*ShimManager)
+
+			sandboxedTaskManager, err := NewSandboxedTaskManager(ic)
+			if err != nil {
+				return nil, err
+			}
+			shimedTaskManager := &ShimTaskManager{
+				shimManager: shimManager,
+			}
+
 			root, state := ic.Properties[plugins.PropertyRootDir], ic.Properties[plugins.PropertyStateDir]
 			for _, d := range []string{root, state} {
 				if err := os.MkdirAll(d, 0711); err != nil {
 					return nil, err
 				}
 			}
-			return NewTaskManager(ic.Context, root, state, shimManager)
+
+			return NewTaskManager(ic.Context, root, state, shimedTaskManager, sandboxedTaskManager)
 		},
 	})
 }
 
-// TaskManager wraps task service client on top of shim manager.
+// TaskManager wraps task service client on top of ShimTaskManager or SandboxedTaskManager.
 type TaskManager struct {
-	root    string
-	state   string
-	manager *ShimManager
+	root                 string
+	state                string
+	shimTaskManager      *ShimTaskManager
+	sandboxedTaskManager *SandboxedTaskManager
 }
 
-// NewTaskManager creates a new task manager instance.
+// NewTaskManager creates a new task TaskManager instance.
 // root is the rootDir of TaskManager plugin to store persistent data
 // state is the stateDir of TaskManager plugin to store transient data
 // shims is  ShimManager for TaskManager to create/delete shims
-func NewTaskManager(ctx context.Context, root, state string, shims *ShimManager) (*TaskManager, error) {
-	if err := shims.LoadExistingShims(ctx, state, root); err != nil {
-		return nil, fmt.Errorf("failed to load existing shims for task manager")
-	}
+func NewTaskManager(ctx context.Context,
+	root, state string,
+	shimTaskManager *ShimTaskManager,
+	sandboxedTaskManager *SandboxedTaskManager) (*TaskManager, error) {
+
 	m := &TaskManager{
-		root:    root,
-		state:   state,
-		manager: shims,
+		root:                 root,
+		state:                state,
+		shimTaskManager:      shimTaskManager,
+		sandboxedTaskManager: sandboxedTaskManager,
+	}
+	if err := m.loadExistingTasks(ctx, state, root); err != nil {
+		return nil, fmt.Errorf("failed to load existing shims for task manager")
 	}
 	return m, nil
 }
 
-// ID of the task manager
+// ID of the task shimTaskManager
 func (m *TaskManager) ID() string {
 	return plugins.RuntimePluginV2.String() + ".task"
 }
@@ -123,207 +130,90 @@ func (m *TaskManager) Create(ctx context.Context, taskID string, opts runtime.Cr
 		}
 	}()
 
-	shim, err := m.manager.Start(ctx, taskID, bundle, opts)
-	if err != nil {
-		return nil, fmt.Errorf("failed to start shim: %w", err)
-	}
-
-	// Cast to shim task and call task service to create a new container task instance.
-	// This will not be required once shim service / client implemented.
-	shimTask, err := newShimTask(shim)
-	if err != nil {
-		return nil, err
-	}
-
-	// runc ignores silently features it doesn't know about, so for things that this is
-	// problematic let's check if this runc version supports them.
-	if err := m.validateRuntimeFeatures(ctx, opts); err != nil {
-		return nil, fmt.Errorf("failed to validate OCI runtime features: %w", err)
-	}
-
-	t, err := shimTask.Create(ctx, opts)
-	if err != nil {
-		// NOTE: ctx contains required namespace information.
-		m.manager.shims.Delete(ctx, taskID)
-
-		dctx, cancel := timeout.WithContext(cleanup.Background(ctx), cleanupTimeout)
-		defer cancel()
-
-		sandboxed := opts.SandboxID != ""
-		_, errShim := shimTask.delete(dctx, sandboxed, func(context.Context, string) {})
-		if errShim != nil {
-			if errdefs.IsDeadlineExceeded(errShim) {
-				dctx, cancel = timeout.WithContext(cleanup.Background(ctx), cleanupTimeout)
-				defer cancel()
-			}
-
-			shimTask.Shutdown(dctx)
-			shimTask.Close()
+	if len(opts.SandboxID) > 0 {
+		// if err==ErrCanNotHandle, we should fallback to the shim
+		if t, err := m.sandboxedTaskManager.Create(ctx, taskID, bundle, opts); err != ErrCanNotHandle {
+			return t, err
 		}
-
-		return nil, fmt.Errorf("failed to create shim task: %w", err)
 	}
-
-	return t, nil
+	return m.shimTaskManager.Create(ctx, taskID, bundle, opts)
 }
 
 // Get a specific task
 func (m *TaskManager) Get(ctx context.Context, id string) (runtime.Task, error) {
-	shim, err := m.manager.shims.Get(ctx, id)
-	if err != nil {
-		return nil, err
+	t, err := m.sandboxedTaskManager.Get(ctx, id)
+	if errdefs.IsNotFound(err) {
+		t, err = m.shimTaskManager.Get(ctx, id)
+		if err != nil {
+			return nil, err
+		}
 	}
-	return newShimTask(shim)
+	return t, err
 }
 
 // Tasks lists all tasks
 func (m *TaskManager) Tasks(ctx context.Context, all bool) ([]runtime.Task, error) {
-	shims, err := m.manager.shims.GetAll(ctx, all)
+	var tasks []runtime.Task
+	sts, err := m.sandboxedTaskManager.GetAll(ctx, all)
 	if err != nil {
 		return nil, err
 	}
-	out := make([]runtime.Task, len(shims))
-	for i := range shims {
-		newClient, err := newShimTask(shims[i])
-		if err != nil {
-			return nil, err
-		}
-		out[i] = newClient
+	tasks = append(tasks, sts...)
+	shimedTasks, err := m.shimTaskManager.GetAll(ctx, all)
+	if err != nil {
+		return nil, err
 	}
-	return out, nil
+	tasks = append(tasks, shimedTasks...)
+	return tasks, nil
 }
 
 // Delete deletes the task and shim instance
 func (m *TaskManager) Delete(ctx context.Context, taskID string) (*runtime.Exit, error) {
-	shim, err := m.manager.shims.Get(ctx, taskID)
-	if err != nil {
-		return nil, err
+	exit, err := m.sandboxedTaskManager.Delete(ctx, taskID)
+	if !errdefs.IsNotFound(err) {
+		return exit, err
 	}
-
-	container, err := m.manager.containers.Get(ctx, taskID)
-	if err != nil {
-		return nil, err
-	}
-
-	shimTask, err := newShimTask(shim)
-	if err != nil {
-		return nil, err
-	}
-
-	sandboxed := container.SandboxID != ""
-
-	exit, err := shimTask.delete(ctx, sandboxed, func(ctx context.Context, id string) {
-		m.manager.shims.Delete(ctx, id)
-	})
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to delete task: %w", err)
-	}
-
-	return exit, nil
+	return m.shimTaskManager.Delete(ctx, taskID)
 }
 
-func (m *TaskManager) PluginInfo(ctx context.Context, request interface{}) (interface{}, error) {
-	req, ok := request.(*apitypes.RuntimeRequest)
-	if !ok {
-		return nil, fmt.Errorf("unknown request type %T: %w", request, errdefs.ErrNotImplemented)
-	}
-
-	runtimePath, err := m.manager.resolveRuntimePath(req.RuntimePath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve runtime path: %w", err)
-	}
-	var optsB []byte
-	if req.Options != nil {
-		optsB, err = proto.Marshal(req.Options)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal %s: %w", req.Options.TypeUrl, err)
+func (m *TaskManager) loadExistingTasks(ctx context.Context, stateDir string, rootDir string) error {
+	if err := TraversBundles(ctx, stateDir, func(ctx context.Context, bundle *Bundle) error {
+		// Read sandbox ID this task belongs to.
+		// it will return ErrorNotExit if it is not a sandboxed task
+		sbID, err := os.ReadFile(filepath.Join(bundle.Path, "sandbox"))
+		if err == nil {
+			loadErr := m.sandboxedTaskManager.Load(ctx, string(sbID), bundle)
+			if loadErr != nil && loadErr != ErrCanNotHandle {
+				log.G(ctx).WithError(loadErr).Errorf("failed to load %s", bundle.Path)
+			}
+			// if loadErr == ErrCanNotHandle, should fallback to the shim load
+			if loadErr == nil {
+				return nil
+			}
 		}
-	}
-	var stderr bytes.Buffer
-	cmd := exec.CommandContext(ctx, runtimePath, "-info")
-	cmd.Stdin = bytes.NewReader(optsB)
-	cmd.Stderr = &stderr
-	stdout, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("failed to run %v: %w (stderr: %q)", cmd.Args, err, stderr.String())
-	}
-	var info apitypes.RuntimeInfo
-	if err = proto.Unmarshal(stdout, &info); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal stdout from %v into %T: %w", cmd.Args, &info, err)
-	}
-	return &info, nil
-}
+		if !errors.Is(err, os.ErrNotExist) {
+			bundle.Delete()
+			return err
+		}
 
-func (m *TaskManager) validateRuntimeFeatures(ctx context.Context, opts runtime.CreateOpts) error {
-	var spec specs.Spec
-	if err := typeurl.UnmarshalTo(opts.Spec, &spec); err != nil {
-		return fmt.Errorf("unmarshal spec: %w", err)
-	}
-
-	// Only ask for the PluginInfo if idmap mounts are used.
-	if !usesIDMapMounts(spec) {
+		if err := m.shimTaskManager.Load(ctx, bundle); err != nil {
+			log.G(ctx).WithError(err).Errorf("failed to load shim %s", bundle.Path)
+			return err
+		}
 		return nil
+	}); err != nil {
+		return err
 	}
-
-	topts := opts.TaskOptions
-	if topts == nil || topts.GetValue() == nil {
-		topts = opts.RuntimeOptions
-	}
-
-	pInfo, err := m.PluginInfo(ctx, &apitypes.RuntimeRequest{RuntimePath: opts.Runtime, Options: typeurl.MarshalProto(topts)})
-	if err != nil {
-		return fmt.Errorf("runtime info: %w", err)
-	}
-
-	pluginInfo, ok := pInfo.(*apitypes.RuntimeInfo)
-	if !ok {
-		return fmt.Errorf("invalid runtime info type: %T", pInfo)
-	}
-
-	feat, err := typeurl.UnmarshalAny(pluginInfo.Features)
-	if err != nil {
-		return fmt.Errorf("unmarshal runtime features: %w", err)
-	}
-
-	// runc-compatible runtimes silently ignores features it doesn't know about. But ignoring
-	// our request to use idmap mounts can break permissions in the volume, so let's make sure
-	// it supports it. For more info, see:
-	//	https://github.com/opencontainers/runtime-spec/pull/1219
-	//
-	features, ok := feat.(*features.Features)
-	if !ok {
-		// Leave alone non runc-compatible runtimes that don't provide the features info,
-		// they might not be affected by this.
+	if err := TraversWorkDirs(ctx, rootDir, func(ctx context.Context, ns, dir string) error {
+		if _, err := m.Get(ctx, dir); err != nil {
+			path := filepath.Join(rootDir, ns, dir)
+			if err := os.RemoveAll(path); err != nil {
+				log.G(ctx).WithError(err).Errorf("cleanup working dir %s", path)
+			}
+		}
 		return nil
-	}
-
-	if err := supportsIDMapMounts(features); err != nil {
-		return fmt.Errorf("idmap mounts not supported: %w", err)
-	}
-
-	return nil
-}
-
-func usesIDMapMounts(spec specs.Spec) bool {
-	for _, m := range spec.Mounts {
-		if m.UIDMappings != nil || m.GIDMappings != nil {
-			return true
-		}
-		if slices.Contains(m.Options, "idmap") || slices.Contains(m.Options, "ridmap") {
-			return true
-		}
-
-	}
-	return false
-}
-
-func supportsIDMapMounts(features *features.Features) error {
-	if features.Linux.MountExtensions == nil || features.Linux.MountExtensions.IDMap == nil {
-		return errors.New("missing `mountExtensions.idmap` entry in `features` command")
-	}
-	if enabled := features.Linux.MountExtensions.IDMap.Enabled; enabled == nil || !*enabled {
-		return errors.New("entry `mountExtensions.idmap.Enabled` in `features` command not present or disabled")
+	}); err != nil {
+		return err
 	}
 	return nil
 }

--- a/core/runtime/v2/task_remote.go
+++ b/core/runtime/v2/task_remote.go
@@ -1,0 +1,267 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package v2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/containerd/errdefs"
+	"github.com/containerd/ttrpc"
+	"github.com/containerd/typeurl/v2"
+
+	"github.com/containerd/containerd/api/runtime/task/v3"
+	"github.com/containerd/containerd/api/types"
+	"github.com/containerd/containerd/v2/core/runtime"
+	"github.com/containerd/containerd/v2/pkg/identifiers"
+	"github.com/containerd/containerd/v2/pkg/protobuf"
+	ptypes "github.com/containerd/containerd/v2/pkg/protobuf/types"
+)
+
+type remoteTask struct {
+	id     string
+	client TaskServiceClient
+}
+
+func (r *remoteTask) Create(ctx context.Context, bundle string, opts runtime.CreateOpts) error {
+	topts := opts.TaskOptions
+	if topts == nil || topts.GetValue() == nil {
+		topts = opts.RuntimeOptions
+	}
+	request := &task.CreateTaskRequest{
+		ID:         r.id,
+		Bundle:     bundle,
+		Stdin:      opts.IO.Stdin,
+		Stdout:     opts.IO.Stdout,
+		Stderr:     opts.IO.Stderr,
+		Terminal:   opts.IO.Terminal,
+		Checkpoint: opts.Checkpoint,
+		Options:    typeurl.MarshalProto(topts),
+	}
+	for _, m := range opts.Rootfs {
+		request.Rootfs = append(request.Rootfs, &types.Mount{
+			Type:    m.Type,
+			Source:  m.Source,
+			Target:  m.Target,
+			Options: m.Options,
+		})
+	}
+
+	_, err := r.client.Create(ctx, request)
+	if err != nil {
+		return errdefs.FromGRPC(err)
+	}
+
+	return nil
+}
+
+func (r *remoteTask) State(ctx context.Context) (runtime.State, error) {
+	response, err := r.client.State(ctx, &task.StateRequest{
+		ID: r.id,
+	})
+	if err != nil {
+		if !errors.Is(err, ttrpc.ErrClosed) {
+			return runtime.State{}, errdefs.FromGRPC(err)
+		}
+		return runtime.State{}, errdefs.ErrNotFound
+	}
+	return runtime.State{
+		Pid:        response.Pid,
+		Status:     statusFromProto(response.Status),
+		Stdin:      response.Stdin,
+		Stdout:     response.Stdout,
+		Stderr:     response.Stderr,
+		Terminal:   response.Terminal,
+		ExitStatus: response.ExitStatus,
+		ExitedAt:   protobuf.FromTimestamp(response.ExitedAt),
+	}, nil
+}
+
+func (r *remoteTask) Kill(ctx context.Context, signal uint32, all bool) error {
+	if _, err := r.client.Kill(ctx, &task.KillRequest{
+		ID:     r.id,
+		Signal: signal,
+		All:    all,
+	}); err != nil {
+		return errdefs.FromGRPC(err)
+	}
+	return nil
+}
+
+func (r *remoteTask) ResizePty(ctx context.Context, size runtime.ConsoleSize) error {
+	_, err := r.client.ResizePty(ctx, &task.ResizePtyRequest{
+		ID:     r.id,
+		Width:  size.Width,
+		Height: size.Height,
+	})
+	if err != nil {
+		return errdefs.FromGRPC(err)
+	}
+	return nil
+}
+
+func (r *remoteTask) CloseIO(ctx context.Context) error {
+	_, err := r.client.CloseIO(ctx, &task.CloseIORequest{
+		ID:    r.id,
+		Stdin: true,
+	})
+	if err != nil {
+		return errdefs.FromGRPC(err)
+	}
+	return nil
+}
+
+func (r *remoteTask) Start(ctx context.Context) error {
+	_, err := r.client.Start(ctx, &task.StartRequest{
+		ID: r.id,
+	})
+	if err != nil {
+		return errdefs.FromGRPC(err)
+	}
+	return nil
+}
+
+func (r *remoteTask) Wait(ctx context.Context) (*runtime.Exit, error) {
+	taskPid, err := r.PID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	response, err := r.client.Wait(ctx, &task.WaitRequest{
+		ID: r.id,
+	})
+	if err != nil {
+		return nil, errdefs.FromGRPC(err)
+	}
+	return &runtime.Exit{
+		Pid:       taskPid,
+		Timestamp: protobuf.FromTimestamp(response.ExitedAt),
+		Status:    response.ExitStatus,
+	}, nil
+}
+
+func (r *remoteTask) PID(ctx context.Context) (uint32, error) {
+	response, err := r.client.Connect(ctx, &task.ConnectRequest{
+		ID: r.id,
+	})
+	if err != nil {
+		return 0, errdefs.FromGRPC(err)
+	}
+
+	return response.TaskPid, nil
+}
+
+func (r *remoteTask) Pause(ctx context.Context) error {
+	if _, err := r.client.Pause(ctx, &task.PauseRequest{
+		ID: r.id,
+	}); err != nil {
+		return errdefs.FromGRPC(err)
+	}
+	return nil
+}
+
+func (r *remoteTask) Resume(ctx context.Context) error {
+	if _, err := r.client.Resume(ctx, &task.ResumeRequest{
+		ID: r.id,
+	}); err != nil {
+		return errdefs.FromGRPC(err)
+	}
+	return nil
+}
+
+func (r *remoteTask) Exec(ctx context.Context, id string, opts runtime.ExecOpts) (runtime.ExecProcess, error) {
+	if err := identifiers.Validate(id); err != nil {
+		return nil, fmt.Errorf("invalid exec id %s: %w", id, err)
+	}
+	request := &task.ExecProcessRequest{
+		ID:       r.id,
+		ExecID:   id,
+		Stdin:    opts.IO.Stdin,
+		Stdout:   opts.IO.Stdout,
+		Stderr:   opts.IO.Stderr,
+		Terminal: opts.IO.Terminal,
+		Spec:     opts.Spec,
+	}
+	if _, err := r.client.Exec(ctx, request); err != nil {
+		return nil, errdefs.FromGRPC(err)
+	}
+	return &process{
+		id:   id,
+		task: r,
+	}, nil
+}
+
+func (r *remoteTask) Pids(ctx context.Context) ([]runtime.ProcessInfo, error) {
+	resp, err := r.client.Pids(ctx, &task.PidsRequest{
+		ID: r.id,
+	})
+	if err != nil {
+		return nil, errdefs.FromGRPC(err)
+	}
+	var processList []runtime.ProcessInfo
+	for _, p := range resp.Processes {
+		processList = append(processList, runtime.ProcessInfo{
+			Pid:  p.Pid,
+			Info: p.Info,
+		})
+	}
+	return processList, nil
+}
+
+func (r *remoteTask) Checkpoint(ctx context.Context, path string, opts *ptypes.Any) error {
+	request := &task.CheckpointTaskRequest{
+		ID:      r.id,
+		Path:    path,
+		Options: opts,
+	}
+	if _, err := r.client.Checkpoint(ctx, request); err != nil {
+		return errdefs.FromGRPC(err)
+	}
+	return nil
+}
+
+func (r *remoteTask) Update(ctx context.Context, resources *ptypes.Any, annotations map[string]string) error {
+	if _, err := r.client.Update(ctx, &task.UpdateTaskRequest{
+		ID:          r.id,
+		Resources:   resources,
+		Annotations: annotations,
+	}); err != nil {
+		return errdefs.FromGRPC(err)
+	}
+	return nil
+}
+
+func (r *remoteTask) Process(ctx context.Context, id string) (runtime.ExecProcess, error) {
+	p := &process{
+		id:   id,
+		task: r,
+	}
+	if _, err := p.State(ctx); err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+func (r *remoteTask) Stats(ctx context.Context) (*ptypes.Any, error) {
+	response, err := r.client.Stats(ctx, &task.StatsRequest{
+		ID: r.id,
+	})
+	if err != nil {
+		return nil, errdefs.FromGRPC(err)
+	}
+	return response.Stats, nil
+}

--- a/core/runtime/v2/task_sandboxed.go
+++ b/core/runtime/v2/task_sandboxed.go
@@ -1,0 +1,261 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package v2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/containerd/containerd/api/runtime/task/v3"
+	"github.com/containerd/containerd/v2/core/metadata"
+	"github.com/containerd/containerd/v2/core/runtime"
+	"github.com/containerd/containerd/v2/core/sandbox"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/containerd/containerd/v2/pkg/protobuf"
+	shimclient "github.com/containerd/containerd/v2/pkg/shim"
+	"github.com/containerd/containerd/v2/plugins"
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
+	"github.com/containerd/plugin"
+	"github.com/containerd/ttrpc"
+)
+
+var ErrCanNotHandle = errors.New("can not handle this task")
+
+type SandboxedTaskManager struct {
+	sandboxStore       sandbox.Store
+	sandboxControllers map[string]sandbox.Controller
+	tasks              *runtime.NSMap[*sandboxedTask]
+}
+
+func NewSandboxedTaskManager(ic *plugin.InitContext) (*SandboxedTaskManager, error) {
+	m, err := ic.GetSingle(plugins.MetadataPlugin)
+	if err != nil {
+		return nil, err
+	}
+	sandboxStore := metadata.NewSandboxStore(m.(*metadata.DB))
+
+	scs, err := ic.GetByType(plugins.SandboxControllerPlugin)
+	if err != nil {
+		return nil, err
+	}
+	sandboxControllers := make(map[string]sandbox.Controller)
+	for name, p := range scs {
+		sandboxControllers[name] = p.(sandbox.Controller)
+	}
+
+	return &SandboxedTaskManager{
+		sandboxStore:       sandboxStore,
+		sandboxControllers: sandboxControllers,
+		tasks:              runtime.NewNSMap[*sandboxedTask](),
+	}, nil
+}
+
+func (s *SandboxedTaskManager) Create(ctx context.Context, taskID string, bundle *Bundle, opts runtime.CreateOpts) (runtime.Task, error) {
+	if len(opts.SandboxID) == 0 {
+		return nil, fmt.Errorf("no sandbox id specified for task %s", taskID)
+	}
+	sb, err := s.loadSandbox(ctx, opts.SandboxID)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := namespaces.NamespaceRequired(ctx); err != nil {
+		return nil, err
+	}
+
+	// Write sandbox ID this task belongs to.
+	if err := os.WriteFile(filepath.Join(bundle.Path, "sandbox"), []byte(opts.SandboxID), 0600); err != nil {
+		return nil, err
+	}
+
+	if opts.Address == "" {
+		return nil, fmt.Errorf("address of task api should not be empty for sandboxed task")
+	}
+
+	// The address returned from sandbox controller should be in the form like ttrpc+unix://<uds-path>
+	// or grpc+vsock://<cid>:<port>, we should get the protocol from the url first.
+	protocol, address, ok := strings.Cut(opts.Address, "+")
+	if !ok {
+		return nil, fmt.Errorf("the scheme of sandbox address should be in " +
+			" the form of <protocol>+<unix|vsock|tcp>, i.e. ttrpc+unix or grpc+vsock")
+	}
+	params := shimclient.BootstrapParams{
+		Version:  int(opts.Version),
+		Protocol: protocol,
+		Address:  address,
+	}
+
+	// Save bootstrap configuration (so containerd can restore shims after restart).
+	if err := writeBootstrapParams(filepath.Join(bundle.Path, "bootstrap.json"), params); err != nil {
+		return nil, fmt.Errorf("failed to write bootstrap.json: %w", err)
+	}
+
+	sandboxedTask, err := newSandboxedTask(ctx, sb, taskID, bundle, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to new sandboxed task: %w", err)
+	}
+	err = sandboxedTask.Create(ctx, bundle.Path, opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create sandboxed task: %w", err)
+	}
+	s.tasks.Add(ctx, sandboxedTask)
+	return sandboxedTask, nil
+}
+
+func (s *SandboxedTaskManager) Load(ctx context.Context, sandboxID string, bundle *Bundle) error {
+	sb, err := s.loadSandbox(ctx, sandboxID)
+	if err != nil {
+		return fmt.Errorf("failed to get sandbox %s: %w", sandboxID, err)
+	}
+
+	filePath := filepath.Join(bundle.Path, "bootstrap.json")
+	params, err := readBootstrapParams(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to restore connection parameter from %s: %w", filePath, err)
+	}
+
+	sandboxedTask, err := newSandboxedTask(ctx, sb, bundle.ID, bundle, params)
+	if err != nil {
+		return fmt.Errorf("failed to new sandboxed task: %w", err)
+	}
+	return s.tasks.Add(ctx, sandboxedTask)
+}
+
+func (s *SandboxedTaskManager) Get(ctx context.Context, id string) (runtime.Task, error) {
+	return s.tasks.Get(ctx, id)
+}
+
+func (s *SandboxedTaskManager) GetAll(ctx context.Context, all bool) ([]runtime.Task, error) {
+	var tasks []runtime.Task
+	ts, err := s.tasks.GetAll(ctx, all)
+	if err != nil {
+		return tasks, err
+	}
+	for _, t := range ts {
+		tasks = append(tasks, t)
+	}
+	return tasks, nil
+}
+
+func (s *SandboxedTaskManager) Delete(ctx context.Context, taskID string) (*runtime.Exit, error) {
+	st, err := s.tasks.Get(ctx, taskID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, taskErr := st.client.Delete(ctx, &task.DeleteRequest{
+		ID: taskID,
+	})
+	if taskErr != nil {
+		log.G(ctx).WithField("id", taskID).WithError(taskErr).Debug("failed to delete task")
+		if !errors.Is(taskErr, ttrpc.ErrClosed) {
+			taskErr = errdefs.FromGRPC(taskErr)
+			if !errdefs.IsNotFound(taskErr) {
+				return nil, taskErr
+			}
+		}
+	}
+
+	if err := st.bundle.Delete(); err != nil {
+		log.G(ctx).WithField("id", taskID).WithError(err).Error("failed to delete bundle")
+	}
+
+	s.tasks.Delete(ctx, taskID)
+
+	if taskErr != nil {
+		return nil, errdefs.ErrNotFound
+	}
+	return &runtime.Exit{
+		Status:    resp.ExitStatus,
+		Timestamp: protobuf.FromTimestamp(resp.ExitedAt),
+		Pid:       resp.Pid,
+	}, nil
+}
+
+// loadSandbox loads sandboxes created by sandbox controller,
+// so the pause container and the podsandbox is excluded.
+func (s *SandboxedTaskManager) loadSandbox(ctx context.Context, sandboxID string) (sandbox.Sandbox, error) {
+	sb, err := s.sandboxStore.Get(ctx, sandboxID)
+	if err != nil {
+		// If the sandbox is created in a previous version,
+		// there is a possibility that it is stored in db as a pause container rather than a sandbox,
+		// so we can only return ErrCanNotHandle here so that TaskManager can fallback to the legacy logic.
+		if errdefs.IsNotFound(err) {
+			return sandbox.Sandbox{}, ErrCanNotHandle
+		}
+		return sandbox.Sandbox{}, fmt.Errorf("failed to get sandbox %s: %w", sandboxID, err)
+	}
+	if sb.Sandboxer == "podsandbox" {
+		return sandbox.Sandbox{}, ErrCanNotHandle
+	}
+	return sb, nil
+}
+
+func newSandboxedTask(
+	ctx context.Context,
+	sandbox sandbox.Sandbox,
+	taskID string,
+	bundle *Bundle,
+	params shimclient.BootstrapParams) (*sandboxedTask, error) {
+	ns, err := namespaces.NamespaceRequired(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := makeConnection(ctx, taskID, params, func() {})
+
+	if err != nil {
+		return nil, fmt.Errorf("can not connect %v: %w", params, err)
+	}
+
+	taskClient, err := NewTaskClient(conn, params.Version)
+	if err != nil {
+		return nil, err
+	}
+	t := &sandboxedTask{
+		namespace: ns,
+		sandbox:   sandbox,
+		remoteTask: &remoteTask{
+			id:     taskID,
+			client: taskClient,
+		},
+		bundle: bundle,
+	}
+
+	return t, nil
+}
+
+// sandboxedTask wraped task running in a sandbox.
+type sandboxedTask struct {
+	namespace string
+	sandbox   sandbox.Sandbox
+	bundle    *Bundle
+	*remoteTask
+}
+
+func (s *sandboxedTask) ID() string {
+	return s.remoteTask.id
+}
+
+func (s *sandboxedTask) Namespace() string {
+	return s.namespace
+}

--- a/core/runtime/v2/task_sandboxed.go
+++ b/core/runtime/v2/task_sandboxed.go
@@ -23,12 +23,15 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/containerd/containerd/api/runtime/task/v3"
+	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/v2/core/metadata"
 	"github.com/containerd/containerd/v2/core/runtime"
 	"github.com/containerd/containerd/v2/core/sandbox"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/containerd/v2/pkg/protobuf"
 	shimclient "github.com/containerd/containerd/v2/pkg/shim"
 	"github.com/containerd/containerd/v2/plugins"
@@ -36,7 +39,18 @@ import (
 	"github.com/containerd/log"
 	"github.com/containerd/plugin"
 	"github.com/containerd/ttrpc"
+	"github.com/containerd/typeurl/v2"
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
+
+const (
+	// TasksKey is the key used for storing tasks information in the sandbox extensions
+	TasksKey = "tasks"
+)
+
+func init() {
+	typeurl.Register(&Tasks{}, "github.com/containerd/containerd", "Tasks")
+}
 
 var ErrCanNotHandle = errors.New("can not handle this task")
 
@@ -193,26 +207,34 @@ func (s *SandboxedTaskManager) Delete(ctx context.Context, taskID string) (*runt
 
 // loadSandbox loads sandboxes created by sandbox controller,
 // so the pause container and the podsandbox is excluded.
-func (s *SandboxedTaskManager) loadSandbox(ctx context.Context, sandboxID string) (sandbox.Sandbox, error) {
+func (s *SandboxedTaskManager) loadSandbox(ctx context.Context, sandboxID string) (*sandboxClient, error) {
 	sb, err := s.sandboxStore.Get(ctx, sandboxID)
 	if err != nil {
 		// If the sandbox is created in a previous version,
 		// there is a possibility that it is stored in db as a pause container rather than a sandbox,
 		// so we can only return ErrCanNotHandle here so that TaskManager can fallback to the legacy logic.
 		if errdefs.IsNotFound(err) {
-			return sandbox.Sandbox{}, ErrCanNotHandle
+			return nil, ErrCanNotHandle
 		}
-		return sandbox.Sandbox{}, fmt.Errorf("failed to get sandbox %s: %w", sandboxID, err)
+		return nil, fmt.Errorf("failed to get sandbox %s: %w", sandboxID, err)
 	}
 	if sb.Sandboxer == "podsandbox" {
-		return sandbox.Sandbox{}, ErrCanNotHandle
+		return nil, ErrCanNotHandle
 	}
-	return sb, nil
+	sbController, ok := s.sandboxControllers[sb.Sandboxer]
+	if !ok {
+		return nil, fmt.Errorf("can not find sandbox controller by %s", sb.Sandboxer)
+	}
+	return &sandboxClient{
+		id:         sandboxID,
+		store:      s.sandboxStore,
+		controller: sbController,
+	}, nil
 }
 
 func newSandboxedTask(
 	ctx context.Context,
-	sandbox sandbox.Sandbox,
+	sandboxHandle *sandboxClient,
 	taskID string,
 	bundle *Bundle,
 	params shimclient.BootstrapParams) (*sandboxedTask, error) {
@@ -232,8 +254,8 @@ func newSandboxedTask(
 		return nil, err
 	}
 	t := &sandboxedTask{
-		namespace: ns,
-		sandbox:   sandbox,
+		namespace:     ns,
+		sandboxHandle: sandboxHandle,
 		remoteTask: &remoteTask{
 			id:     taskID,
 			client: taskClient,
@@ -244,12 +266,19 @@ func newSandboxedTask(
 	return t, nil
 }
 
-// sandboxedTask wraped task running in a sandbox.
+// sandboxedTask is a wrapped task that is running in a sandbox.
 type sandboxedTask struct {
-	namespace string
-	sandbox   sandbox.Sandbox
-	bundle    *Bundle
+	namespace     string
+	sandboxHandle *sandboxClient
+	bundle        *Bundle
 	*remoteTask
+}
+
+type sandboxClient struct {
+	id         string
+	store      sandbox.Store
+	controller sandbox.Controller
+	mu         sync.Mutex
 }
 
 func (s *sandboxedTask) ID() string {
@@ -258,4 +287,224 @@ func (s *sandboxedTask) ID() string {
 
 func (s *sandboxedTask) Namespace() string {
 	return s.namespace
+}
+
+// Create wrap the Create API call of task with update of the sandbox extension
+func (s *sandboxedTask) Create(ctx context.Context, bundle string, opts runtime.CreateOpts) error {
+	if err := s.sandboxHandle.UpdateTasksExtension(ctx, func(ts *Tasks) error {
+		var spec oci.Spec
+		if err := typeurl.UnmarshalTo(opts.Spec, &spec); err != nil {
+			return err
+		}
+		var rootfs []*types.Mount
+		for _, m := range opts.Rootfs {
+			rootfs = append(rootfs, &types.Mount{
+				Type:    m.Type,
+				Source:  m.Source,
+				Target:  m.Target,
+				Options: m.Options,
+			})
+		}
+		ts.addTask(Task{
+			TaskID:    s.id,
+			Spec:      &spec,
+			Rootfs:    rootfs,
+			Stdin:     opts.IO.Stdin,
+			Stdout:    opts.IO.Stdout,
+			Stderr:    opts.IO.Stderr,
+			Processes: nil,
+		})
+		return nil
+	}); err != nil {
+		return err
+	}
+	// Then call Task Create api in sandbox to create the task inside sandbox
+	if err := s.remoteTask.Create(ctx, s.bundle.Path, opts); err != nil {
+		// if it is error, we need to roll back the change of sandbox
+		if e := s.sandboxHandle.UpdateTasksExtension(ctx, func(ts *Tasks) error {
+			ts.removeTask(s.id)
+			return nil
+		}); e != nil {
+			log.G(ctx).Warnf("failed to rollback task extension %s in sandbox %s: %v", s.ID(), s.sandboxHandle.id, e)
+		}
+		return err
+	}
+	return nil
+}
+
+// Exec wrap the Exec API call with update of the sandbox extension
+func (s *sandboxedTask) Exec(ctx context.Context, id string, opts runtime.ExecOpts) (runtime.ExecProcess, error) {
+	if err := s.sandboxHandle.UpdateTasksExtension(ctx, func(ts *Tasks) error {
+		return ts.updateTask(s.id, func(t *Task) error {
+			var spec specs.Process
+			if err := typeurl.UnmarshalTo(opts.Spec, &spec); err != nil {
+				return err
+			}
+			t.addProcess(Process{
+				ExecID: id,
+				Spec:   &spec,
+				Stdin:  opts.IO.Stdin,
+				Stdout: opts.IO.Stdout,
+				Stderr: opts.IO.Stderr,
+			})
+			return nil
+		})
+	}); err != nil {
+		return nil, err
+	}
+
+	p, err := s.remoteTask.Exec(ctx, id, opts)
+	if err != nil {
+		if removeErr := s.sandboxHandle.UpdateTasksExtension(ctx, func(ts *Tasks) error {
+			return ts.updateTask(s.id, func(t *Task) error {
+				t.removeProcess(id)
+				return nil
+			})
+		}); removeErr != nil {
+			log.G(ctx).Warnf("failed to remove exec task resource %s %s in sandbox %s: %v", s.ID(), id, s.sandboxHandle.id, removeErr)
+		}
+		return nil, err
+	}
+	return &sandboxedProcess{
+		ExecProcess: p,
+		task:        s,
+	}, nil
+}
+
+// sandboxedProcess wrapped exec process that is running in a sandbox.
+type sandboxedProcess struct {
+	runtime.ExecProcess
+	task *sandboxedTask
+}
+
+// Delete wrap the Delete of the process with sandbox update
+func (p *sandboxedProcess) Delete(ctx context.Context) (*runtime.Exit, error) {
+	exit, err := p.ExecProcess.Delete(ctx)
+	if err != nil && errdefs.IsNotFound(err) {
+		return nil, err
+	}
+	err = p.task.sandboxHandle.UpdateTasksExtension(ctx, func(ts *Tasks) error {
+		return ts.updateTask(p.task.id, func(t *Task) error {
+			t.removeProcess(p.ID())
+			return nil
+		})
+	})
+	if err != nil {
+		return nil, errdefs.FromGRPC(err)
+	}
+	return exit, nil
+}
+
+// UpdateTasksExtension update the extension of sandbox with the key "tasks"
+func (s *sandboxClient) UpdateTasksExtension(ctx context.Context, update func(ts *Tasks) error) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var tasks Tasks
+	sb, err := s.store.Get(ctx, s.id)
+	if err != nil {
+		return err
+	}
+	err = sb.GetExtension(TasksKey, &tasks)
+	if err != nil && !errdefs.IsNotFound(err) {
+		return err
+	}
+	if err = update(&tasks); err != nil {
+		return err
+	}
+	if err = sb.AddExtension(TasksKey, &tasks); err != nil {
+		return err
+	}
+	old, err := s.store.Update(ctx, sb, "extensions."+TasksKey)
+	if err != nil {
+		return err
+	}
+	if err := s.controller.Update(ctx, sb.ID, sb, "extensions."+TasksKey); err != nil {
+		// Rollback the change in sandbox store if controller update failed
+		if _, err := s.store.Update(ctx, old, "extensions."+TasksKey); err != nil {
+			log.G(ctx).Warnf("failed to rollback when update tasks of sandbox %s extensions: %v", s.id, err)
+		}
+		return err
+	}
+	return nil
+}
+
+// Tasks is the task information list that is stored in sandbox metadata
+type Tasks struct {
+	Tasks []Task `json:"tasks,omitempty"`
+}
+
+func (ts *Tasks) addTask(t Task) {
+	ts.Tasks = append(ts.Tasks, t)
+}
+
+func (ts *Tasks) removeTask(taskID string) {
+	idx := ts.findTaskByID(taskID)
+	if idx < 0 {
+		return
+	}
+	ts.Tasks = append(ts.Tasks[:idx], ts.Tasks[idx+1:]...)
+}
+
+func (ts *Tasks) updateTask(taskID string, update func(*Task) error) error {
+	idx := ts.findTaskByID(taskID)
+	if idx < 0 {
+		return errdefs.ErrNotFound
+	}
+	if err := update(&ts.Tasks[idx]); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (ts *Tasks) findTaskByID(taskID string) int {
+	for idx, t := range ts.Tasks {
+		if t.TaskID == taskID {
+			return idx
+		}
+	}
+	return -1
+}
+
+// Task is the information of a task that is stored in sandbox metadata.
+type Task struct {
+	TaskID string `json:"task_id,omitempty"`
+	// Spec is the oci spec of the task
+	Spec *oci.Spec `json:"spec,omitempty"`
+	// Rootfs is the mount information of the task's rootfs.
+	Rootfs []*types.Mount `json:"rootfs,omitempty"`
+	Stdin  string         `json:"stdin,omitempty"`
+	Stdout string         `json:"stdout,omitempty"`
+	Stderr string         `json:"stderr,omitempty"`
+	// Processes is information of processes that is running under the task
+	Processes []Process `json:"processes,omitempty"`
+}
+
+func (t *Task) addProcess(process Process) {
+	t.Processes = append(t.Processes, process)
+}
+
+func (t *Task) removeProcess(execID string) {
+	idx := t.findProcessByID(execID)
+	if idx < 0 {
+		return
+	}
+	t.Processes = append(t.Processes[:idx], t.Processes[idx+1:]...)
+}
+
+func (t *Task) findProcessByID(execID string) int {
+	for idx, p := range t.Processes {
+		if p.ExecID == execID {
+			return idx
+		}
+	}
+	return -1
+}
+
+// Process is the information of a process that is running inside a sandbox
+type Process struct {
+	ExecID string         `json:"exec_id,omitempty"`
+	Spec   *specs.Process `json:"spec,omitempty"`
+	Stdin  string         `json:"stdin,omitempty"`
+	Stdout string         `json:"stdout,omitempty"`
+	Stderr string         `json:"stderr,omitempty"`
 }

--- a/core/runtime/v2/task_shim.go
+++ b/core/runtime/v2/task_shim.go
@@ -1,0 +1,338 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package v2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
+	"github.com/containerd/ttrpc"
+	"github.com/containerd/typeurl/v2"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-spec/specs-go/features"
+
+	"github.com/containerd/containerd/api/runtime/task/v3"
+	apitypes "github.com/containerd/containerd/api/types"
+	"github.com/containerd/containerd/v2/core/runtime"
+	"github.com/containerd/containerd/v2/internal/cleanup"
+	"github.com/containerd/containerd/v2/pkg/protobuf"
+	"github.com/containerd/containerd/v2/pkg/timeout"
+)
+
+type ShimTaskManager struct {
+	shimManager *ShimManager
+}
+
+func (m *ShimTaskManager) Create(ctx context.Context, taskID string, bundle *Bundle, opts runtime.CreateOpts) (runtime.Task, error) {
+	shim, err := m.shimManager.Start(ctx, taskID, bundle, opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start shim: %w", err)
+	}
+
+	// Cast to shim task and call task service to create a new container task instance.
+	// This will not be required once shim service / client implemented.
+	shimTask, err := newShimTask(shim)
+	if err != nil {
+		return nil, err
+	}
+
+	// runc ignores silently features it doesn't know about, so for things that this is
+	// problematic let's check if this runc version supports them.
+	if err := m.validateRuntimeFeatures(ctx, opts); err != nil {
+		return nil, fmt.Errorf("failed to validate OCI runtime features: %w", err)
+	}
+
+	err = shimTask.Create(ctx, bundle.Path, opts)
+	if err != nil {
+		// NOTE: ctx contains required namespace information.
+		m.shimManager.shims.Delete(ctx, taskID)
+
+		dctx, cancel := timeout.WithContext(cleanup.Background(ctx), cleanupTimeout)
+		defer cancel()
+
+		_, errShim := shimTask.delete(dctx, func(context.Context, string) {})
+		if errShim != nil {
+			if errdefs.IsDeadlineExceeded(errShim) {
+				dctx, cancel = timeout.WithContext(cleanup.Background(ctx), cleanupTimeout)
+				defer cancel()
+			}
+
+			shimTask.Shutdown(dctx)
+			shimTask.Close()
+		}
+
+		return nil, fmt.Errorf("failed to create shim task: %w", err)
+	}
+
+	return shimTask, nil
+}
+
+func (m *ShimTaskManager) Load(ctx context.Context, bundle *Bundle) error {
+	return m.shimManager.loadShim(ctx, bundle, func(instance ShimInstance) error {
+		s, err := newShimTask(instance)
+		if err != nil {
+			return err
+		}
+		ctx, cancel := timeout.WithContext(ctx, loadTimeout)
+		defer cancel()
+		if _, err := s.PID(ctx); err != nil {
+			return err
+		}
+
+		// There are 2 possibilities for the loaded shim here:
+		// 1. It could be a shim that is running a task.
+		// 2. Or it could be a shim that was created for running a task but
+		// something happened (probably a containerd crash) and the task was never
+		// created. This shim process should be cleaned up here. Look at
+		// containerd/containerd#6860 for further details.
+		pInfo, pidErr := s.Pids(ctx)
+		if len(pInfo) == 0 || errors.Is(pidErr, errdefs.ErrNotFound) {
+			log.G(ctx).WithField("id", s.ID()).Info("cleaning leaked shim process")
+			return err
+		}
+
+		return nil
+	})
+}
+
+func (m *ShimTaskManager) Get(ctx context.Context, id string) (runtime.Task, error) {
+	shim, err := m.shimManager.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return newShimTask(shim)
+}
+
+func (m *ShimTaskManager) GetAll(ctx context.Context, all bool) ([]runtime.Task, error) {
+	var tasks []runtime.Task
+	shims, err := m.shimManager.shims.GetAll(ctx, all)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, s := range shims {
+		st, err := newShimTask(s)
+		if err != nil {
+			return nil, err
+		}
+		tasks = append(tasks, st)
+	}
+	return tasks, nil
+}
+
+func (m *ShimTaskManager) Delete(ctx context.Context, taskID string) (*runtime.Exit, error) {
+	shim, err := m.shimManager.shims.Get(ctx, taskID)
+	if err != nil {
+		return nil, err
+	}
+
+	shimTask, err := newShimTask(shim)
+	if err != nil {
+		return nil, err
+	}
+
+	exit, err := shimTask.delete(ctx, func(ctx context.Context, id string) {
+		m.shimManager.shims.Delete(ctx, id)
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to delete task: %w", err)
+	}
+
+	return exit, nil
+}
+
+var _ runtime.Task = &shimTask{}
+
+// shimTask wraps shim process and adds task service client for compatibility with existing shim manager.
+type shimTask struct {
+	ShimInstance
+	*remoteTask
+}
+
+func newShimTask(shim ShimInstance) (*shimTask, error) {
+	_, version := shim.Endpoint()
+	taskClient, err := NewTaskClient(shim.Client(), version)
+	if err != nil {
+		return nil, err
+	}
+
+	return &shimTask{
+		ShimInstance: shim,
+		remoteTask: &remoteTask{
+			id:     shim.ID(),
+			client: taskClient,
+		},
+	}, nil
+}
+
+func (s *shimTask) Shutdown(ctx context.Context) error {
+	_, err := s.remoteTask.client.Shutdown(ctx, &task.ShutdownRequest{
+		ID: s.ID(),
+	})
+	if err != nil && !errors.Is(err, ttrpc.ErrClosed) {
+		return errdefs.FromGRPC(err)
+	}
+	return nil
+}
+
+func (s *shimTask) waitShutdown(ctx context.Context) error {
+	ctx, cancel := timeout.WithContext(ctx, shutdownTimeout)
+	defer cancel()
+	return s.Shutdown(ctx)
+}
+
+func (s *shimTask) delete(ctx context.Context, removeTask func(ctx context.Context, id string)) (*runtime.Exit, error) {
+	response, shimErr := s.remoteTask.client.Delete(ctx, &task.DeleteRequest{
+		ID: s.ID(),
+	})
+	if shimErr != nil {
+		log.G(ctx).WithField("id", s.ID()).WithError(shimErr).Debug("failed to delete task")
+		if !errors.Is(shimErr, ttrpc.ErrClosed) {
+			shimErr = errdefs.FromGRPC(shimErr)
+			if !errdefs.IsNotFound(shimErr) {
+				return nil, shimErr
+			}
+		}
+	}
+
+	// NOTE: If the shim has been killed and ttrpc connection has been
+	// closed, the shimErr will not be nil. For this case, the event
+	// subscriber, like moby/moby, might have received the exit or delete
+	// events. Just in case, we should allow ttrpc-callback-on-close to
+	// send the exit and delete events again. And the exit status will
+	// depend on result of shimV2.Delete.
+	//
+	// If not, the shim has been delivered the exit and delete events.
+	// So we should remove the record and prevent duplicate events from
+	// ttrpc-callback-on-close.
+	//
+	// TODO: It's hard to guarantee that the event is unique and sent only
+	// once. The moby/moby should not rely on that assumption that there is
+	// only one exit event. The moby/moby should handle the duplicate events.
+	//
+	// REF: https://github.com/containerd/containerd/issues/4769
+	if shimErr == nil {
+		removeTask(ctx, s.ID())
+	}
+
+	if err := s.waitShutdown(ctx); err != nil {
+		// FIXME(fuweid):
+		//
+		// If the error is context canceled, should we use context.TODO()
+		// to wait for it?
+		log.G(ctx).WithField("id", s.ID()).WithError(err).Error("failed to shutdown shim task and the shim might be leaked")
+	}
+
+	if err := s.ShimInstance.Delete(ctx); err != nil {
+		log.G(ctx).WithField("id", s.ID()).WithError(err).Error("failed to delete shim")
+	}
+
+	// remove self from the runtime task list
+	// this seems dirty but it cleans up the API across runtimes, tasks, and the service
+	removeTask(ctx, s.ID())
+
+	if shimErr != nil {
+		return nil, shimErr
+	}
+
+	return &runtime.Exit{
+		Status:    response.ExitStatus,
+		Timestamp: protobuf.FromTimestamp(response.ExitedAt),
+		Pid:       response.Pid,
+	}, nil
+}
+
+func (m *ShimTaskManager) validateRuntimeFeatures(ctx context.Context, opts runtime.CreateOpts) error {
+	var spec specs.Spec
+	if err := typeurl.UnmarshalTo(opts.Spec, &spec); err != nil {
+		return fmt.Errorf("unmarshal spec: %w", err)
+	}
+
+	// Only ask for the PluginInfo if idmap mounts are used.
+	if !usesIDMapMounts(spec) {
+		return nil
+	}
+
+	topts := opts.TaskOptions
+	if topts == nil || topts.GetValue() == nil {
+		topts = opts.RuntimeOptions
+	}
+
+	pInfo, err := m.shimManager.PluginInfo(ctx, &apitypes.RuntimeRequest{
+		RuntimePath: opts.Runtime,
+		Options:     typeurl.MarshalProto(topts),
+	})
+	if err != nil {
+		return fmt.Errorf("runtime info: %w", err)
+	}
+
+	pluginInfo, ok := pInfo.(*apitypes.RuntimeInfo)
+	if !ok {
+		return fmt.Errorf("invalid runtime info type: %T", pInfo)
+	}
+
+	feat, err := typeurl.UnmarshalAny(pluginInfo.Features)
+	if err != nil {
+		return fmt.Errorf("unmarshal runtime features: %w", err)
+	}
+
+	// runc-compatible runtimes silently ignores features it doesn't know about. But ignoring
+	// our request to use idmap mounts can break permissions in the volume, so let's make sure
+	// it supports it. For more info, see:
+	//	https://github.com/opencontainers/runtime-spec/pull/1219
+	//
+	features, ok := feat.(*features.Features)
+	if !ok {
+		// Leave alone non runc-compatible runtimes that don't provide the features info,
+		// they might not be affected by this.
+		return nil
+	}
+
+	if err := supportsIDMapMounts(features); err != nil {
+		return fmt.Errorf("idmap mounts not supported: %w", err)
+	}
+
+	return nil
+}
+
+func usesIDMapMounts(spec specs.Spec) bool {
+	for _, m := range spec.Mounts {
+		if m.UIDMappings != nil || m.GIDMappings != nil {
+			return true
+		}
+		if slices.Contains(m.Options, "idmap") || slices.Contains(m.Options, "ridmap") {
+			return true
+		}
+
+	}
+	return false
+}
+
+func supportsIDMapMounts(features *features.Features) error {
+	if features.Linux.MountExtensions == nil || features.Linux.MountExtensions.IDMap == nil {
+		return errors.New("missing `mountExtensions.idmap` entry in `features` command")
+	}
+	if enabled := features.Linux.MountExtensions.IDMap.Enabled; enabled == nil || !*enabled {
+		return errors.New("entry `mountExtensions.idmap.Enabled` in `features` command not present or disabled")
+	}
+	return nil
+}

--- a/core/sandbox/proxy/controller.go
+++ b/core/sandbox/proxy/controller.go
@@ -33,14 +33,15 @@ import (
 
 // remoteSandboxController is a low level GRPC client for containerd's sandbox controller service
 type remoteSandboxController struct {
-	client api.ControllerClient
+	client        api.ControllerClient
+	sandboxerName string
 }
 
 var _ sandbox.Controller = (*remoteSandboxController)(nil)
 
 // NewSandboxController creates a client for a sandbox controller
-func NewSandboxController(client api.ControllerClient) sandbox.Controller {
-	return &remoteSandboxController{client: client}
+func NewSandboxController(client api.ControllerClient, name string) sandbox.Controller {
+	return &remoteSandboxController{client: client, sandboxerName: name}
 }
 
 func (s *remoteSandboxController) Create(ctx context.Context, sandboxInfo sandbox.Sandbox, opts ...sandbox.CreateOpt) error {
@@ -62,6 +63,7 @@ func (s *remoteSandboxController) Create(ctx context.Context, sandboxInfo sandbo
 		NetnsPath:   options.NetNSPath,
 		Annotations: options.Annotations,
 		Sandbox:     &apiSandbox,
+		Sandboxer:   s.sandboxerName,
 	})
 	if err != nil {
 		return errdefs.FromGRPC(err)
@@ -71,7 +73,10 @@ func (s *remoteSandboxController) Create(ctx context.Context, sandboxInfo sandbo
 }
 
 func (s *remoteSandboxController) Start(ctx context.Context, sandboxID string) (sandbox.ControllerInstance, error) {
-	resp, err := s.client.Start(ctx, &api.ControllerStartRequest{SandboxID: sandboxID})
+	resp, err := s.client.Start(ctx, &api.ControllerStartRequest{
+		SandboxID: sandboxID,
+		Sandboxer: s.sandboxerName,
+	})
 	if err != nil {
 		return sandbox.ControllerInstance{}, errdefs.FromGRPC(err)
 	}
@@ -87,7 +92,10 @@ func (s *remoteSandboxController) Start(ctx context.Context, sandboxID string) (
 }
 
 func (s *remoteSandboxController) Platform(ctx context.Context, sandboxID string) (imagespec.Platform, error) {
-	resp, err := s.client.Platform(ctx, &api.ControllerPlatformRequest{SandboxID: sandboxID})
+	resp, err := s.client.Platform(ctx, &api.ControllerPlatformRequest{
+		SandboxID: sandboxID,
+		Sandboxer: s.sandboxerName,
+	})
 	if err != nil {
 		return imagespec.Platform{}, errdefs.FromGRPC(err)
 	}
@@ -105,7 +113,10 @@ func (s *remoteSandboxController) Stop(ctx context.Context, sandboxID string, op
 	for _, opt := range opts {
 		opt(&soptions)
 	}
-	req := &api.ControllerStopRequest{SandboxID: sandboxID}
+	req := &api.ControllerStopRequest{
+		SandboxID: sandboxID,
+		Sandboxer: s.sandboxerName,
+	}
 	if soptions.Timeout != nil {
 		req.TimeoutSecs = uint32(soptions.Timeout.Seconds())
 	}
@@ -118,7 +129,10 @@ func (s *remoteSandboxController) Stop(ctx context.Context, sandboxID string, op
 }
 
 func (s *remoteSandboxController) Shutdown(ctx context.Context, sandboxID string) error {
-	_, err := s.client.Shutdown(ctx, &api.ControllerShutdownRequest{SandboxID: sandboxID})
+	_, err := s.client.Shutdown(ctx, &api.ControllerShutdownRequest{
+		SandboxID: sandboxID,
+		Sandboxer: s.sandboxerName,
+	})
 	if err != nil {
 		return errdefs.FromGRPC(err)
 	}
@@ -135,7 +149,10 @@ func (s *remoteSandboxController) Wait(ctx context.Context, sandboxID string) (s
 		retryInterval time.Duration = 128
 	)
 	for {
-		resp, err = s.client.Wait(ctx, &api.ControllerWaitRequest{SandboxID: sandboxID})
+		resp, err = s.client.Wait(ctx, &api.ControllerWaitRequest{
+			SandboxID: sandboxID,
+			Sandboxer: s.sandboxerName,
+		})
 		if err != nil {
 			grpcErr := errdefs.FromGRPC(err)
 			if !errdefs.IsUnavailable(grpcErr) {
@@ -161,7 +178,11 @@ func (s *remoteSandboxController) Wait(ctx context.Context, sandboxID string) (s
 }
 
 func (s *remoteSandboxController) Status(ctx context.Context, sandboxID string, verbose bool) (sandbox.ControllerStatus, error) {
-	resp, err := s.client.Status(ctx, &api.ControllerStatusRequest{SandboxID: sandboxID, Verbose: verbose})
+	resp, err := s.client.Status(ctx, &api.ControllerStatusRequest{
+		SandboxID: sandboxID,
+		Verbose:   verbose,
+		Sandboxer: s.sandboxerName,
+	})
 	if err != nil {
 		return sandbox.ControllerStatus{}, errdefs.FromGRPC(err)
 	}
@@ -179,7 +200,10 @@ func (s *remoteSandboxController) Status(ctx context.Context, sandboxID string, 
 }
 
 func (s *remoteSandboxController) Metrics(ctx context.Context, sandboxID string) (*types.Metric, error) {
-	resp, err := s.client.Metrics(ctx, &api.ControllerMetricsRequest{SandboxID: sandboxID})
+	resp, err := s.client.Metrics(ctx, &api.ControllerMetricsRequest{
+		SandboxID: sandboxID,
+		Sandboxer: s.sandboxerName,
+	})
 	if err != nil {
 		return nil, errdefs.FromGRPC(err)
 	}

--- a/internal/cri/server/podsandbox/controller.go
+++ b/internal/cri/server/podsandbox/controller.go
@@ -46,7 +46,7 @@ import (
 
 func init() {
 	registry.Register(&plugin.Registration{
-		Type: plugins.SandboxControllerPlugin,
+		Type: plugins.PodSandboxPlugin,
 		ID:   "podsandbox",
 		Requires: []plugin.Type{
 			plugins.EventPlugin,

--- a/internal/cri/server/restart.go
+++ b/internal/cri/server/restart.go
@@ -111,12 +111,11 @@ func (c *criService) recover(ctx context.Context) error {
 		}
 
 		var (
-			state      = sandboxstore.StateUnknown
-			controller = c.client.SandboxController(sbx.Sandboxer)
-			endpoint   sandboxstore.Endpoint
+			state    = sandboxstore.StateUnknown
+			endpoint sandboxstore.Endpoint
 		)
 
-		status, err := controller.Status(ctx, sbx.ID, false)
+		status, err := c.sandboxService.SandboxStatus(ctx, sbx.Sandboxer, sbx.ID, false)
 		if err != nil {
 			log.G(ctx).
 				WithError(err).

--- a/internal/cri/server/service.go
+++ b/internal/cri/server/service.go
@@ -417,7 +417,7 @@ func introspectRuntimeFeatures(ctx context.Context, intro introspection.Service,
 		}
 	}
 
-	infoResp, err := intro.PluginInfo(ctx, string(plugins.RuntimePluginV2), "task", rr)
+	infoResp, err := intro.PluginInfo(ctx, string(plugins.ShimPlugin), "manager", rr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call PluginInfo: %w", err)
 	}

--- a/plugins/cri/cri.go
+++ b/plugins/cri/cri.go
@@ -119,7 +119,6 @@ func initCRIService(ic *plugin.InitContext) (interface{}, error) {
 		containerd.WithDefaultNamespace(constants.K8sContainerdNamespace),
 		containerd.WithDefaultPlatform(platforms.Default()),
 		containerd.WithInMemoryServices(ic),
-		containerd.WithInMemorySandboxControllers(ic),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create containerd client: %w", err)

--- a/plugins/cri/cri.go
+++ b/plugins/cri/cri.go
@@ -48,6 +48,7 @@ func init() {
 		ID:   "cri",
 		Requires: []plugin.Type{
 			plugins.CRIServicePlugin,
+			plugins.PodSandboxPlugin,
 			plugins.SandboxControllerPlugin,
 			plugins.NRIApiPlugin,
 			plugins.EventPlugin,
@@ -237,12 +238,20 @@ func getNRIAPI(ic *plugin.InitContext) nriservice.API {
 }
 
 func getSandboxControllers(ic *plugin.InitContext) (map[string]sandbox.Controller, error) {
+	sc := make(map[string]sandbox.Controller)
 	sandboxers, err := ic.GetByType(plugins.SandboxControllerPlugin)
 	if err != nil {
 		return nil, err
 	}
-	sc := make(map[string]sandbox.Controller)
 	for name, p := range sandboxers {
+		sc[name] = p.(sandbox.Controller)
+	}
+
+	podSandboxers, err := ic.GetByType(plugins.PodSandboxPlugin)
+	if err != nil {
+		return nil, err
+	}
+	for name, p := range podSandboxers {
 		sc[name] = p.(sandbox.Controller)
 	}
 	return sc, nil

--- a/plugins/services/sandbox/controller_service.go
+++ b/plugins/services/sandbox/controller_service.go
@@ -43,17 +43,26 @@ func init() {
 		Type: plugins.GRPCPlugin,
 		ID:   "sandbox-controllers",
 		Requires: []plugin.Type{
+			plugins.PodSandboxPlugin,
 			plugins.SandboxControllerPlugin,
 			plugins.EventPlugin,
 		},
 		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
-			sandboxers, err := ic.GetByType(plugins.SandboxControllerPlugin)
+			sc := make(map[string]sandbox.Controller)
+
+			sandboxers, err := ic.GetByType(plugins.PodSandboxPlugin)
 			if err != nil {
 				return nil, err
 			}
-
-			sc := make(map[string]sandbox.Controller)
 			for name, p := range sandboxers {
+				sc[name] = p.(sandbox.Controller)
+			}
+
+			sandboxersV2, err := ic.GetByType(plugins.SandboxControllerPlugin)
+			if err != nil {
+				return nil, err
+			}
+			for name, p := range sandboxersV2 {
 				sc[name] = p.(sandbox.Controller)
 			}
 

--- a/plugins/types.go
+++ b/plugins/types.go
@@ -63,6 +63,8 @@ const (
 	TransferPlugin plugin.Type = "io.containerd.transfer.v1"
 	// SandboxStorePlugin implements a sandbox store
 	SandboxStorePlugin plugin.Type = "io.containerd.sandbox.store.v1"
+	// PodSandboxPlugin is a special sandbox controller which use pause container as a sandbox.
+	PodSandboxPlugin plugin.Type = "io.containerd.podsandbox.controller.v1"
 	// SandboxControllerPlugin implements a sandbox controller
 	SandboxControllerPlugin plugin.Type = "io.containerd.sandbox.controller.v1"
 	// ImageVerifierPlugin implements an image verifier service


### PR DESCRIPTION
For sandboxed Task, we call the task api directly into the sandbox. For some kind of sandbox, we may have to update the resources of the sandbox before/after task creation or deletion, and it has to be done outside the sandbox, so we rely on the sandbox controller to update the resources of the sandbox.