### PR TITLE
mv internal/cri/util/deep_copy.go pkg/marshalutil/

### DIFF
--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -44,6 +44,7 @@ import (
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 	"github.com/containerd/containerd/v2/internal/cri/util"
 	"github.com/containerd/containerd/v2/pkg/blockio"
+	"github.com/containerd/containerd/v2/pkg/marshalutil"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/platforms"
 )
@@ -404,7 +405,7 @@ func (c *criService) runtimeSpec(id string, platform platforms.Platform, baseSpe
 		}
 
 		spec := oci.Spec{}
-		if err := util.DeepCopy(&spec, &baseSpec); err != nil {
+		if err := marshalutil.DeepCopy(&spec, &baseSpec); err != nil {
 			return nil, fmt.Errorf("failed to clone OCI spec: %w", err)
 		}
 

--- a/internal/cri/server/container_update_resources_linux.go
+++ b/internal/cri/server/container_update_resources_linux.go
@@ -25,7 +25,7 @@ import (
 
 	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
 	"github.com/containerd/containerd/v2/internal/cri/opts"
-	"github.com/containerd/containerd/v2/internal/cri/util"
+	"github.com/containerd/containerd/v2/pkg/marshalutil"
 )
 
 // updateOCIResource updates container resource limit.
@@ -34,7 +34,7 @@ func updateOCIResource(ctx context.Context, spec *runtimespec.Spec, r *runtime.U
 
 	// Copy to make sure old spec is not changed.
 	var cloned runtimespec.Spec
-	if err := util.DeepCopy(&cloned, spec); err != nil {
+	if err := marshalutil.DeepCopy(&cloned, spec); err != nil {
 		return nil, fmt.Errorf("failed to deep copy: %w", err)
 	}
 	if cloned.Linux == nil {

--- a/internal/cri/server/container_update_resources_windows.go
+++ b/internal/cri/server/container_update_resources_windows.go
@@ -25,7 +25,7 @@ import (
 
 	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
 	"github.com/containerd/containerd/v2/internal/cri/opts"
-	"github.com/containerd/containerd/v2/internal/cri/util"
+	"github.com/containerd/containerd/v2/pkg/marshalutil"
 )
 
 // updateOCIResource updates container resource limit.
@@ -34,7 +34,7 @@ func updateOCIResource(ctx context.Context, spec *runtimespec.Spec, r *runtime.U
 
 	// Copy to make sure old spec is not changed.
 	var cloned runtimespec.Spec
-	if err := util.DeepCopy(&cloned, spec); err != nil {
+	if err := marshalutil.DeepCopy(&cloned, spec); err != nil {
 		return nil, fmt.Errorf("failed to deep copy: %w", err)
 	}
 	if cloned.Windows == nil {

--- a/internal/cri/server/podsandbox/helpers.go
+++ b/internal/cri/server/podsandbox/helpers.go
@@ -36,6 +36,7 @@ import (
 	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
 	ctrdutil "github.com/containerd/containerd/v2/internal/cri/util"
 	clabels "github.com/containerd/containerd/v2/pkg/labels"
+	"github.com/containerd/containerd/v2/pkg/marshalutil"
 	"github.com/containerd/containerd/v2/pkg/oci"
 )
 
@@ -165,7 +166,7 @@ func (c *Controller) runtimeSpec(id string, baseSpecFile string, opts ...oci.Spe
 		}
 
 		spec := oci.Spec{}
-		if err := ctrdutil.DeepCopy(&spec, &baseSpec); err != nil {
+		if err := marshalutil.DeepCopy(&spec, &baseSpec); err != nil {
 			return nil, fmt.Errorf("failed to clone OCI spec: %w", err)
 		}
 

--- a/pkg/marshalutil/deep_copy.go
+++ b/pkg/marshalutil/deep_copy.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package util
+package marshalutil
 
 import (
 	"encoding/json"

--- a/pkg/marshalutil/deep_copy_test.go
+++ b/pkg/marshalutil/deep_copy_test.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package util
+package marshalutil
 
 import (
 	"testing"


### PR DESCRIPTION
DeepCopy is depended by nerdctl too

https://github.com/search?q=repo%3Acontainerd%2Fnerdctl%20DeepCopy&type=code