### PR TITLE
[release/1.6] Disable OOM set score unpriv test temporarily

### DIFF
--- a/sys/oom_linux_test.go
+++ b/sys/oom_linux_test.go
@@ -48,6 +48,9 @@ func TestSetNegativeOomScoreAdjustmentWhenPrivileged(t *testing.T) {
 }
 
 func TestSetNegativeOomScoreAdjustmentWhenUnprivilegedHasNoEffect(t *testing.T) {
+	// TODO: remove skip once we have determined cause of failure in GHA (2024-03-06)
+	t.Skip("test consistently failing in GitHub Actions")
+
 	if runningPrivileged() && !userns.RunningInUserNS() {
 		t.Skip("needs to be run as non-root or in user namespace")
 		return


### PR DESCRIPTION
Temporary skip while we find root cause of GHA environment changes causing failure.


(cherry picked from commit 723306d0ed80ce2ca01f8782daa673ca3db4645c)