### PR TITLE
Use the Go toolchain in CI matrix to build binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-go
+        with:
+          go-version: ${{ matrix.go-version }}
       - name: Make
         run: |
           make build


### PR DESCRIPTION
### Issue

The binaries job in CI is not respecting the Go version specified in the matrix.

![image](https://github.com/containerd/containerd/assets/55906459/4313484a-e7dd-4748-a00b-023a0cb953ed)

### Description
This change updates the binaries job in CI to use the Go version specified in the matrix.

### Testing

![image](https://github.com/containerd/containerd/assets/55906459/225ef282-1b98-4a1f-927a-939046eb241f)
