### PR TITLE
[release/1.7] Backport use Go toolchain in CI matrix to build binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-go
-
+        with:
+          go-version: ${{ matrix.go-version }}
       - name: Make
         run: |
           make build


### PR DESCRIPTION
### Issue

#9946

(cherry picked from commit 7ac9d6909c6b75fbf345368fee8a4b5764c5df27)

clean cherry-pick of #9946