### PR TITLE
[release/1.6] Prepare v1.6.30

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
 
 name: Containerd Release
 
+env:
+  GO_VERSION: "1.21.8"
+
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read
 

--- a/releases/v1.6.30.toml
+++ b/releases/v1.6.30.toml
@@ -1,0 +1,27 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.6.28"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The thirtieth patch release for containerd 1.6 contains various fixes and updates
+as well as a build fix which prevented the v1.6.29 tag from being released.
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.29+unknown"
+	Version = "1.6.30+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
v1.6.29 had a bug in the release configuration. Since that tag is pushed, we will skip that release and fix it in v1.6.30 tag. Verification that release configuration succeeds https://github.com/dmcgowan/containerd/actions/runs/8208839100. This was my mistake, any change to the release configuration should be tested in fork before pushing upstream.

Keeping 1.6.28 as the previous release for this build.

----

containerd 1.6.30

Welcome to the v1.6.30 release of containerd!

The thirtieth patch release for containerd 1.6 contains various fixes and updates
as well as a build fix which prevented the v1.6.29 tag from being released.

### Highlights

* Update builds to go 1.21.8 ([#9945](https://github.com/containerd/containerd/pull/9945))
* Fix config import relative path glob ([#9835](https://github.com/containerd/containerd/pull/9835))
* Move high volume event logs to Trace level ([#9824](https://github.com/containerd/containerd/pull/9824))
* Move certain debug logs to trace logs ([#9762](https://github.com/containerd/containerd/pull/9762))

#### Container Runtime Interface (CRI)

* Add timeout to drain exec io ([#9768](https://github.com/containerd/containerd/pull/9768))
* Propagate deprecation list to runtime status ([#9819](https://github.com/containerd/containerd/pull/9819))
* Fix image pinning when image is not pulled through cri ([#9785](https://github.com/containerd/containerd/pull/9785))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Akihiro Suda
* Wei Fu
* Derek McGowan
* Maksym Pavlenko
* Phil Estes
* Kirtana Ashok
* Mike Brown
* Akhil Mohan
* Angelos Kolaitis
* Austin Vazquez
* Henry Wang
* Laura Brehm
* Nashwan Azhari
* Sebastiaan van Stijn
* Tony Fang

### Changes
<details><summary>58 commits</summary>
<p>

  * [`8268fc6e9`](https://github.com/containerd/containerd/commit/8268fc6e90f2305410609abf34559ec2f5966c78) Prepare release notes for v1.6.30
  * [`614ca2e12`](https://github.com/containerd/containerd/commit/614ca2e12193ae80afc11beb5a55fc2ae05c8915) Revert go version environment removal
* Prepare release notes for v1.6.29 ([#9950](https://github.com/containerd/containerd/pull/9950))
  * [`9ef6d9d03`](https://github.com/containerd/containerd/commit/9ef6d9d03d8d4124d4e8e28399fef28c137fcc2e) Add release notes for v1.6.29.toml
* use a composite action to install Go ([#9949](https://github.com/containerd/containerd/pull/9949))
  * [`cfbbb510c`](https://github.com/containerd/containerd/commit/cfbbb510c23672daf7711a9afd548801dd741c4a) Use the Go toolchain in CI matrix to build binaries
  * [`f015dbc5a`](https://github.com/containerd/containerd/commit/f015dbc5a3d1f5a6eaefc561130ee5bb05e0d6c5) use composite action in ci workflow
* Update builds to go 1.21.8 ([#9945](https://github.com/containerd/containerd/pull/9945))
  * [`ccf3eb6a2`](https://github.com/containerd/containerd/commit/ccf3eb6a2de426c9cfbb9409c330df79d3dbba0c) update to go 1.21.8, 1.22.1
* Backport easy go install and update go ([#9890](https://github.com/containerd/containerd/pull/9890))
  * [`f6475ea59`](https://github.com/containerd/containerd/commit/f6475ea597b713a27e0b31e5723f3cd315b39eeb) Drop go 1.20 and build against 1.22
  * [`7c45ad092`](https://github.com/containerd/containerd/commit/7c45ad0923f0ea267cb9b66a65dea6fff4e0ff0b) Extract a composite action to install Go
  * [`4f7305414`](https://github.com/containerd/containerd/commit/4f73054149a36ba97263af8ee72e302c7a226906) update to go1.21.6, go1.20.13
  * [`da5a36c37`](https://github.com/containerd/containerd/commit/da5a36c3700ac1142c2451137a362d4c92d1897d) Use testify
  * [`afe6efee3`](https://github.com/containerd/containerd/commit/afe6efee30df36c16dae3f1afe87a8e324a9b031) Revert container_stats_test.go change which caused Windows CRI integration test failure
  * [`370ef115f`](https://github.com/containerd/containerd/commit/370ef115f0e1875bce98326cce4aafd2a953c30b) container_stats_test.go: avoid checking snapshot size
  * [`935720b8c`](https://github.com/containerd/containerd/commit/935720b8c065bddd2dc4372a76225ab0290b449c) Move inline PS scripts into files
  * [`74bae5af8`](https://github.com/containerd/containerd/commit/74bae5af8c853f52b65666682db7d31e9e8d2f02) Uninstall mingw before attempting upgrade
  * [`9b9500bb0`](https://github.com/containerd/containerd/commit/9b9500bb0d45ac1e669a3319039acf7c8359e885) CI: Explicitly upgrade MinGW on Windows 2019 GitHub runners.
  * [`4814f9e48`](https://github.com/containerd/containerd/commit/4814f9e483fc2a0f897cf553ac67b882bc133fbe) seccomp, apparmor: add go:noinline
* Disable OOM set score unpriv test temporarily ([#9943](https://github.com/containerd/containerd/pull/9943))
  * [`c7c8ce6bc`](https://github.com/containerd/containerd/commit/c7c8ce6bcf73cc608b6987f0729f40f93ce443c4) Disable OOM set score unpriv test temporarily
* runc-shim: process exec exits before init ([#9927](https://github.com/containerd/containerd/pull/9927))
  * [`65915f0a2`](https://github.com/containerd/containerd/commit/65915f0a2c0b4d1cb590f39c6cc3b78e7bb75fcb) runc-shim: process exec exits before init
* Backport GitHub actions package updates ([#9877](https://github.com/containerd/containerd/pull/9877))
  * [`e552c8898`](https://github.com/containerd/containerd/commit/e552c889875ecb7fe2e8f5dadac77765f2988932) build(deps): bump golangci/golangci-lint-action from 3 to 4
  * [`888ae152c`](https://github.com/containerd/containerd/commit/888ae152c6eb25eee5b4b533c5fd2f8c3448b609) build(deps): bump actions/cache from 3 to 4
  * [`dd913a0de`](https://github.com/containerd/containerd/commit/dd913a0defb4aa139fe2ab719cf37850ad5c7898) build(deps): bump actions/upload-artifact from 3 to 4
  * [`a250c101a`](https://github.com/containerd/containerd/commit/a250c101afdebcaa7016e50df7670d25e3427700) build(deps): bump actions/download-artifact from 3 to 4
  * [`7c8fd2255`](https://github.com/containerd/containerd/commit/7c8fd2255deaee02ab957a2b05914d01498a7870) build(deps): bump github/codeql-action from 2 to 3
  * [`f325e559e`](https://github.com/containerd/containerd/commit/f325e559e0d93a7990ef1302533d20484d59a50b) build(deps): bump docker/setup-buildx-action from 2 to 3
  * [`1bae160de`](https://github.com/containerd/containerd/commit/1bae160de37a9b37cd8d995e1ffa54247c14f21c) build(deps): bump crazy-max/ghaction-github-runtime from 2 to 3
  * [`3c81dc13b`](https://github.com/containerd/containerd/commit/3c81dc13b45d917e802223b5f80c4559a3b7d969) build(deps): bump actions/upload-artifact from 1 to 3
  * [`9b3b80eea`](https://github.com/containerd/containerd/commit/9b3b80eea1f68de6db0dde7578395995314520e5) build(deps): bump actions/setup-go from 3 to 5
  * [`6b74818d8`](https://github.com/containerd/containerd/commit/6b74818d8908a66ba7ab668f486f1de9c84b1239) build(deps): bump actions/checkout from 3 to 4
* Fix config import relative path glob ([#9835](https://github.com/containerd/containerd/pull/9835))
  * [`0f2068a70`](https://github.com/containerd/containerd/commit/0f2068a70e0824ef7fb13c3e21763428bc58ad40) Fix config import relative path glob
* ci: update crun version to 1.14.3 ([#9851](https://github.com/containerd/containerd/pull/9851))
  * [`89d00db95`](https://github.com/containerd/containerd/commit/89d00db952fbfa9a1425be30895e9615a9d3215f) ci: update crun version to 1.14.3
* Add timeout to drain exec io ([#9768](https://github.com/containerd/containerd/pull/9768))
  * [`aac488730`](https://github.com/containerd/containerd/commit/aac488730fb6b4fec37cdc98d2b834e7033b60ca) *: fix code style issue
  * [`2a38c7e2e`](https://github.com/containerd/containerd/commit/2a38c7e2ebc9e5f1dcca25cb70535e0886e8c620) cri: add config ut for invalid drain io timeout value
  * [`ce213431f`](https://github.com/containerd/containerd/commit/ce213431fd3d413861d705b3d2d28fa83b281e39) integration: add testcase to drain exec IO in time
  * [`b5d52efca`](https://github.com/containerd/containerd/commit/b5d52efca8c1c5494c8ab72c615a4d6ed190b159) cri: disable drain-exec-IO if it is empty timeout
  * [`85bed5863`](https://github.com/containerd/containerd/commit/85bed5863f5313bedd5e6c2319d677124b44cdf5) *: update drainExecSyncIO docs and validate the timeout
  * [`0438e477c`](https://github.com/containerd/containerd/commit/0438e477c35faad18e6b7f3a6b7d8a8f787f5efc) *: add DrainExecSyncIOTimeout config and disable as by default
  * [`fb262317c`](https://github.com/containerd/containerd/commit/fb262317cd66e9f9c2ce12389b658ce042e410cc) *: fix typo and skip exec-io-drain-testcase in win
  * [`f50c9922b`](https://github.com/containerd/containerd/commit/f50c9922b1cc96e8829936509b2bf49ceaa4e5c1) pkg/cri/server: add timeout to drain exec io
* Move high volume event logs to Trace level ([#9824](https://github.com/containerd/containerd/pull/9824))
  * [`99fa35e70`](https://github.com/containerd/containerd/commit/99fa35e7015d487c210d82862b4c807a913d50f2) Move high volume event logs to Trace level
* Propagate deprecation list to runtime status ([#9819](https://github.com/containerd/containerd/pull/9819))
  * [`3785deac4`](https://github.com/containerd/containerd/commit/3785deac4fab3aa30be9a55812dc78b2e1841e29) cri: propagate deprecation list to runtime status
* ctr: print deprecation warnings on every invocation ([#9821](https://github.com/containerd/containerd/pull/9821))
  * [`b7a0b1b8e`](https://github.com/containerd/containerd/commit/b7a0b1b8ed895d1737c7a558cff4dae7f9f7e7df) ctr: print deprecation warnings on every invocation
* Fix image pinning when image is not pulled through cri ([#9785](https://github.com/containerd/containerd/pull/9785))
  * [`2d43994fb`](https://github.com/containerd/containerd/commit/2d43994fb921722002a5043724c6624bfb9d87f0) bug fix: make sure cri image is pinned when it is pulled outside cri
* Move certain debug logs to trace logs ([#9762](https://github.com/containerd/containerd/pull/9762))
  * [`195ef7691`](https://github.com/containerd/containerd/commit/195ef7691ea85cfbcb54693017a6195beddb55dc) Move certain debug logs to trace logs
</p>
</details>

### Dependency Changes

This release has no dependency changes

Previous release can be found at [v1.6.28](https://github.com/containerd/containerd/releases/tag/v1.6.28)

