### PR TITLE
Prepare release notes for v1.7.14

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -2,6 +2,7 @@ Abhinandan Prativadi <abhi@docker.com>
 Abhinandan Prativadi <abhi@docker.com> <aprativadi@gmail.com>
 Ace-Tang <aceapril@126.com>
 Adam Korcz <adam@adalogics.com> <Adam@adalogics.com>
+Akhil Mohan <akhilerm@gmail.com> <akhil.mohan@broadcom.com>
 Aditi Sharma <adi.sky17@gmail.com> <sharmaad@vmware.com>
 Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp> <suda.akihiro@lab.ntt.co.jp>
 Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp> <suda.kyoto@gmail.com>

--- a/releases/v1.7.14.toml
+++ b/releases/v1.7.14.toml
@@ -1,0 +1,26 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.7.13"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The fourteenth patch release for containerd 1.7 contains various fixes and updates.
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.7.13+unknown"
+	Version = "1.7.14+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
See test run at https://github.com/dmcgowan/containerd/actions/runs/8208946909 which verifies build release changes work. Uses new release tool highlights.

----

containerd 1.7.14

Welcome to the v1.7.14 release of containerd!

The fourteenth patch release for containerd 1.7 contains various fixes and updates.

### Highlights

* Update builds to use go 1.21.8 ([#9933](https://github.com/containerd/containerd/pull/9933))
* Fix various timing issues with docker pusher ([#9921](https://github.com/containerd/containerd/pull/9921))
* Register imagePullThroughput and count with MiB ([#9855](https://github.com/containerd/containerd/pull/9855))
* Move high volume event logs to Trace level ([#9823](https://github.com/containerd/containerd/pull/9823))

#### Container Runtime Interface (CRI)

* Handle pod transition states gracefully while listing pod stats ([#9905](https://github.com/containerd/containerd/pull/9905))

#### Runtime

* Update runc-shim to process exec exits before init ([#9928](https://github.com/containerd/containerd/pull/9928))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Wei Fu
* Derek McGowan
* Maksym Pavlenko
* Krisztian Litkey
* Akihiro Suda
* Justin Chadwell
* Sebastiaan van Stijn
* Phil Estes
* Kirtana Ashok
* Akhil Mohan
* Austin Vazquez
* Etienne Champetier
* Jordan Liggitt
* Kohei Tokunaga
* Mike Brown
* Samuel Karp
* Davanum Srinivas
* Edgar Lee
* Henry Wang
* James Sturtevant
* Laura Brehm
* Nashwan Azhari
* Robbie Buxton
* Robert-André Mauchin
* Shukui Yang

### Changes
<details><summary>69 commits</summary>
<p>

  * [`1babe6b58`](https://github.com/containerd/containerd/commit/1babe6b582911fe90b93fc01491f2f4b130b7a3a) Prepare release notes for v1.7.14
* Backport use Go toolchain in CI matrix to build binaries ([#9951](https://github.com/containerd/containerd/pull/9951))
  * [`a9bbbefcf`](https://github.com/containerd/containerd/commit/a9bbbefcf2feba3eaf1da39b70ed28032a7d8a65) Use the Go toolchain in CI matrix to build binaries
* Update builds to use go 1.21.8 ([#9933](https://github.com/containerd/containerd/pull/9933))
  * [`1ca9a643a`](https://github.com/containerd/containerd/commit/1ca9a643a1ad206f074300e235c959213854fff1) update to go 1.21.8, 1.22.1
* Move inline PS scripts into files ([#9938](https://github.com/containerd/containerd/pull/9938))
  * [`39caf532e`](https://github.com/containerd/containerd/commit/39caf532e7f60ff21050221fda627bab02de2ce8) Move inline PS scripts into files
* Disable OOM set score unpriv test temporarily ([#9944](https://github.com/containerd/containerd/pull/9944))
  * [`630226bb4`](https://github.com/containerd/containerd/commit/630226bb431ec98dbfca279c3416abf5047d9858) Disable OOM set score unpriv test temporarily
* Update runc-shim to process exec exits before init ([#9928](https://github.com/containerd/containerd/pull/9928))
  * [`de7b6bae9`](https://github.com/containerd/containerd/commit/de7b6bae9e2e44676ae63a13ab130812a6db56b6) runc-shim: process exec exits before init
* update to go 1.21.6, test 1.22.0 ([#9860](https://github.com/containerd/containerd/pull/9860))
  * [`3b3e537ea`](https://github.com/containerd/containerd/commit/3b3e537eab7f81e32f34c95833caa2af9bc8753f) Uninstall mingw before attempting upgrade
  * [`9e24388b2`](https://github.com/containerd/containerd/commit/9e24388b209e519d7cc3805b3266b9a4a82e59cc) CI: Explicitly upgrade MinGW on Windows 2019 GitHub runners.
  * [`5b23a4127`](https://github.com/containerd/containerd/commit/5b23a412759f27465906f86196c686cd0925be15) seccomp, apparmor: add go:noinline
  * [`753422ac1`](https://github.com/containerd/containerd/commit/753422ac11e3485b14a62bfdfcc75a0001f3dd70) Drop go 1.20 and build against 1.22
  * [`a2d64218c`](https://github.com/containerd/containerd/commit/a2d64218c5a5abc676556925d63b222dbd606469) Fix windows integration tests
  * [`6379dd6f4`](https://github.com/containerd/containerd/commit/6379dd6f428fc3f55cb4625d7741b84751d42278) Update workflow files to install Go via composite action
  * [`a5c0d061c`](https://github.com/containerd/containerd/commit/a5c0d061cd3a4154f31fd5a5c8a4f77da5da1dcd) Extract a composite action to install Go
* Fix various timing issues with docker pusher ([#9921](https://github.com/containerd/containerd/pull/9921))
  * [`52a1402df`](https://github.com/containerd/containerd/commit/52a1402df64ca286b5084b1b150c4219343ad6d7) copy: prevent potential deadlock if close before fully written
  * [`872746386`](https://github.com/containerd/containerd/commit/872746386237b1076f8449a7f7d3d5a07ed30a42) copy: setError should imply Close
  * [`a8004007a`](https://github.com/containerd/containerd/commit/a8004007a2ababa6ac7dbf508edf1c49faf06110) copy: remove max number of ErrResets
  * [`0465472ed`](https://github.com/containerd/containerd/commit/0465472ed3807b6dcf785d160783019e3fed5cf6) pushWriter: refactor reset pipe logic into separate function
  * [`2577207cc`](https://github.com/containerd/containerd/commit/2577207cc0611f36e582111f88f16fd5ae777068) copy: improve error detection from closed pipes
  * [`d081da86b`](https://github.com/containerd/containerd/commit/d081da86bfc3b1b65efacdefba0e48aadaac4d91) copy: check if writer was closed before setting a pipe
  * [`2a25c085b`](https://github.com/containerd/containerd/commit/2a25c085b21e074667bf6ded0dbb6ebf892a889c) copy: remove wrapping io.NopCloser from push writer pipe
* Register imagePullThroughput and count with MiB ([#9855](https://github.com/containerd/containerd/pull/9855))
  * [`711cebd48`](https://github.com/containerd/containerd/commit/711cebd484d44da363ca451cdaaad0c6ec9810d2) Register imagePullThroughput and count with MiB
* Update golangci-lint to v1.56.1 ([#9900](https://github.com/containerd/containerd/pull/9900))
  * [`926ceb036`](https://github.com/containerd/containerd/commit/926ceb036223d8ac05cd918c7a4c0825bb9c0640) fix golangci-lint errors
  * [`4030ae235`](https://github.com/containerd/containerd/commit/4030ae2350fee10557fe52a5b8f86761afb01a1d) Update golangci-lint to v1.56.1
  * [`6620d6bfd`](https://github.com/containerd/containerd/commit/6620d6bfd7c5e6e8ffc0c6047c3602ac0ab05a16) ci: bump up golangci-lint to v1.55.2
  * [`b16ca72b2`](https://github.com/containerd/containerd/commit/b16ca72b2e1e105e475537a450f0c6509e95ca32) Bump up golangci-lint to v1.54.2
* Handle pod transition states gracefully while listing pod stats ([#9905](https://github.com/containerd/containerd/pull/9905))
  * [`39db3f18b`](https://github.com/containerd/containerd/commit/39db3f18b29ab9efb671404a1030628af560c614) adjust test cases to run for windows
  * [`579d8b463`](https://github.com/containerd/containerd/commit/579d8b463bd9cdcdc4425ac7279033056c1d0433) [cri] Handle Windows pod transitions gracefully
* Backport GitHub actions package updates ([#9876](https://github.com/containerd/containerd/pull/9876))
  * [`8d6f0f2ae`](https://github.com/containerd/containerd/commit/8d6f0f2aecd6962163fbaac6f6d2bbb6e12e9c85) build(deps): bump golangci/golangci-lint-action from 3 to 4
  * [`7929592b9`](https://github.com/containerd/containerd/commit/7929592b96e2e4e2e0150a890048f612b623fb7d) build(deps): bump actions/upload-artifact from 3 to 4
  * [`e11de777d`](https://github.com/containerd/containerd/commit/e11de777dcfdf5914b102830d66e6fbed6ceea7d) build(deps): bump crazy-max/ghaction-github-runtime from 2 to 3
  * [`2b40a4074`](https://github.com/containerd/containerd/commit/2b40a40741dfa865683f25d76ac4e03457449ecc) build(deps): bump actions/checkout from 3 to 4
  * [`22feefa57`](https://github.com/containerd/containerd/commit/22feefa570111de80812a493685fb767c3a6c6b4) build(deps): bump actions/setup-go from 3 to 5
  * [`b96aa4012`](https://github.com/containerd/containerd/commit/b96aa4012d4a491869f26f570f9dfbbf1835eb70) build(deps): bump actions/upload-artifact from 1 to 3
  * [`97763f91d`](https://github.com/containerd/containerd/commit/97763f91d6e8013d5c1e2c5ad7214cd956808742) build(deps): bump docker/setup-buildx-action from 2 to 3
  * [`6875bb14f`](https://github.com/containerd/containerd/commit/6875bb14f1841de6d89c689a2e393697c1e6c89c) build(deps): bump github/codeql-action from 2 to 3
  * [`87f9adb6b`](https://github.com/containerd/containerd/commit/87f9adb6b9ed2bd9a0b72879c5a9bc5eb1b51586) build(deps): bump actions/download-artifact from 3 to 4
* .github: windows should use fix critool version ([#9874](https://github.com/containerd/containerd/pull/9874))
  * [`d9c099a9a`](https://github.com/containerd/containerd/commit/d9c099a9ac39956aee0a720be8b3b6af8861351b) .github: windows should use fix critool version
* ci: update crun version to 1.14.3 ([#9850](https://github.com/containerd/containerd/pull/9850))
  * [`dc594b01d`](https://github.com/containerd/containerd/commit/dc594b01d28d3a6a896b66274fb75b1f54aecaa3) ci: update crun version to 1.14.3
* Add WithMetaStore to overlay snapshotter and missing unpacker.Wait for image import ([#9837](https://github.com/containerd/containerd/pull/9837))
  * [`8fe0b26f1`](https://github.com/containerd/containerd/commit/8fe0b26f198163fb88a6bd194382c502d5756fb1) Add missing unpacker.Wait for image import
  * [`31ea2d7d9`](https://github.com/containerd/containerd/commit/31ea2d7d9114fee156f37dc9e6f38538aca58447) Add WithMetaStore to overlay snapshotter to allow bringing your own
* Move high volume event logs to Trace level ([#9823](https://github.com/containerd/containerd/pull/9823))
  * [`982e0cffb`](https://github.com/containerd/containerd/commit/982e0cffbeb31768655ba1ed89620e27551fc49f) Move high volume event logs to Trace level
* cri: propagate deprecation list to runtime status ([#9818](https://github.com/containerd/containerd/pull/9818))
  * [`c79ffa277`](https://github.com/containerd/containerd/commit/c79ffa2773d29e81f7a905fc1242301c5ee7e556) cri: propagate deprecation list to runtime status
* ctr: print deprecation warnings on every invocation ([#9820](https://github.com/containerd/containerd/pull/9820))
  * [`eaebe23de`](https://github.com/containerd/containerd/commit/eaebe23de407600ff81b9466165294eacc3575f5) ctr: print deprecation warnings on every invocation
* bug fix: make sure cri image is pinned when it is pulled outside cri ([#9784](https://github.com/containerd/containerd/pull/9784))
  * [`26c057423`](https://github.com/containerd/containerd/commit/26c057423c614deb0c510ceea84ed22bbe4f7f1d) bug fix: make sure cri image is pinned when it is pulled outside cri
* go.{mod,sum}: update NRI dependency, fixing a potential fd double close error. ([#9783](https://github.com/containerd/containerd/pull/9783))
  * [`d3e997556`](https://github.com/containerd/containerd/commit/d3e9975563f4dd2182526188f6c2331a192a07d5) go.{mod,sum}: update NRI dependency, re-vendor.
* Add option to perform syncfs after pull ([#9769](https://github.com/containerd/containerd/pull/9769))
  * [`ea0a92ec3`](https://github.com/containerd/containerd/commit/ea0a92ec30c9e61bd45b777a27ee4849b1716522) *: introduce image_pull_with_sync_fs in CRI
  * [`4caf44032`](https://github.com/containerd/containerd/commit/4caf44032b61ecef0c2e38eb38395a3969377296) api: introduce sync_fs to diff.ApplyRequest
* Move certain debug logs to trace logs ([#9761](https://github.com/containerd/containerd/pull/9761))
  * [`3f75af7bf`](https://github.com/containerd/containerd/commit/3f75af7bf20fc6d1456e282e31c51d32d086b9ec) Move certain debug logs to trace logs
</p>
</details>

### Changes from containerd/nri
<details><summary>23 commits</summary>
<p>

* socketpair_windows: remove implementation for now ([containerd/nri#69](https://github.com/containerd/nri/pull/69))
  * [`e47f09b`](https://github.com/containerd/nri/commit/e47f09b2abe155cf5c0caaf7d0df7651447d2660) socketpair_windows: remove implementation for now
* adaptation, stub: allow extra ttrpc client and server options. ([containerd/nri#67](https://github.com/containerd/nri/pull/67))
  * [`45b9e3f`](https://github.com/containerd/nri/commit/45b9e3f1437fff2bb9bc26d89da34ee1b298cc86) plugins: update dependencies.
  * [`f600cf6`](https://github.com/containerd/nri/commit/f600cf681e94c8f8b65dead5e57fe0981571bea9) go.{mod,sum}: update dependencies.
  * [`13ee978`](https://github.com/containerd/nri/commit/13ee97879885d8fe4c0dbbf5c0a04716a8654247) pkg/stub: add support for extra ttrpc options.
  * [`c4e2f81`](https://github.com/containerd/nri/commit/c4e2f81f94b35bee5b9d35c80f28490b6f3ebb76) pkg/adaptation: add support for extra ttrpc options.
* socketpair_unix: avoid double close(), set FD_CLOEXEC ([containerd/nri#66](https://github.com/containerd/nri/pull/66))
  * [`5d0b52b`](https://github.com/containerd/nri/commit/5d0b52bc45c998c5fcb1a60a7289f86d9c92f836) sockerpair_unix: avoid double close(), set FD_CLOEXEC
* Task: fix typo in godoc ([containerd/nri#61](https://github.com/containerd/nri/pull/61))
  * [`ae7840b`](https://github.com/containerd/nri/commit/ae7840bf9910649194e1a556b8cc7a66bc19d817) Task: fix typo in godoc
* Take pkg/hooks from github.com/containers/common (carry 46) ([containerd/nri#55](https://github.com/containerd/nri/pull/55))
  * [`b4ac58c`](https://github.com/containerd/nri/commit/b4ac58c1a5b0cffa51448ed060095dd5dc6f4b54) Take pkg/hooks from github.com/containers/common
* gha: remove GOPATH and workingdir, update actions/setup-go@v4, actions/checkout@v4 ([containerd/nri#53](https://github.com/containerd/nri/pull/53))
  * [`ee96969`](https://github.com/containerd/nri/commit/ee969691b8e4bdc2b7c3e384b22c203fcf948ab7) gha: update actions/checkout@v4
  * [`7b33fbf`](https://github.com/containerd/nri/commit/7b33fbf7685a7c0d27d186f89f6027373e54e3f0) gha: update actions/setup-go@v4
  * [`e33ac3e`](https://github.com/containerd/nri/commit/e33ac3e43394ead24dbb4a407dd76c00c5780737) gha: remove working-dir and GOPATH
* remove containerd as dependency ([containerd/nri#51](https://github.com/containerd/nri/pull/51))
  * [`da8a7e5`](https://github.com/containerd/nri/commit/da8a7e53614c60c106f824caf3d120ea582a0cbe) remove containerd as dependency
* make plugins/ulimit-adjuster a separate module ([containerd/nri#54](https://github.com/containerd/nri/pull/54))
  * [`934815e`](https://github.com/containerd/nri/commit/934815e56ede6d603d1b17cbce86ad98a973eaf1) make plugins/ulimit-adjuster a separate module
* scripts: fix protobuf URL on arm64 ([containerd/nri#52](https://github.com/containerd/nri/pull/52))
  * [`9b43daa`](https://github.com/containerd/nri/commit/9b43daaeceae6750053c5693a15edc59819886b9) scripts: fix protobuf URL on arm64
</p>
</details>

### Changes from containerd/ttrpc
<details><summary>21 commits</summary>
<p>

* Fix streaming with empty payloads ([containerd/ttrpc#157](https://github.com/containerd/ttrpc/pull/157))
  * [`44ca009`](https://github.com/containerd/ttrpc/commit/44ca0096e1b2b638ead24b4898cc34aa3b603926) Add comment
  * [`6615f15`](https://github.com/containerd/ttrpc/commit/6615f159bad5b522b7322408fcf5ae8bb58b0843) Fix linter
  * [`dea99e9`](https://github.com/containerd/ttrpc/commit/dea99e9d052d7b86500e6e3f9e6a214d2111d1a9) Fix handling of empty payloads
  * [`336fc1b`](https://github.com/containerd/ttrpc/commit/336fc1b6b472ea8df89cd109b7e8dfb99fe8828e) Add integration test to reproduce issue with empty payloads
* Bump google.golang.org/grpc from 1.57.0 to 1.57.1 ([containerd/ttrpc#156](https://github.com/containerd/ttrpc/pull/156))
  * [`1e51c46`](https://github.com/containerd/ttrpc/commit/1e51c4681df2ab54ad15226a125228ac7639d2e0) Bump google.golang.org/grpc from 1.57.0 to 1.57.1
* Bump golang.org/x/net from 0.10.0 to 0.17.0 ([containerd/ttrpc#155](https://github.com/containerd/ttrpc/pull/155))
  * [`bea960d`](https://github.com/containerd/ttrpc/commit/bea960d9fea8eb25d11ff5e024c734e46a9a6c3e) Bump golang.org/x/net from 0.10.0 to 0.17.0
* Implement support for unary interceptor chaining. ([containerd/ttrpc#152](https://github.com/containerd/ttrpc/pull/152))
  * [`40f227d`](https://github.com/containerd/ttrpc/commit/40f227ddbb9e05bf4d04179991f809df0546c6f6) server: implement UnaryServerInterceptor chaining.
  * [`f984c9b`](https://github.com/containerd/ttrpc/commit/f984c9b178e595292d4a6934ce229c9854c2fe77) client: implement UnaryClientInterceptor chaining.
* Fix grammar in comment for UserOnCloseWait. ([containerd/ttrpc#153](https://github.com/containerd/ttrpc/pull/153))
  * [`8ca4110`](https://github.com/containerd/ttrpc/commit/8ca4110ebc91819c5b0e2f17c9ded818b2462c50) Fix comment for UserOnCloseWait.
* Bump genproto dependency ([containerd/ttrpc#154](https://github.com/containerd/ttrpc/pull/154))
  * [`a2fbc14`](https://github.com/containerd/ttrpc/commit/a2fbc14815b5a707579072aa0edaa59bdaf762f9) go.mod: google.golang.org/genproto/googleapis/rpc v0.0.0-20230731190214-cbb8c96f2d6d
  * [`cf2b85d`](https://github.com/containerd/ttrpc/commit/cf2b85de12df0368cf0c6a24446b25c079caf0f5) go.mod: bump to supported go version
* server_test: wait for OnClose in TestClientEOF. ([containerd/ttrpc#150](https://github.com/containerd/ttrpc/pull/150))
  * [`e0cd801`](https://github.com/containerd/ttrpc/commit/e0cd8011167557f2ddb1b976e604cfd94d8b393d) server_test: wait for OnClose in TestClientEOF.
* .github: give more slack for build+tests. ([containerd/ttrpc#151](https://github.com/containerd/ttrpc/pull/151))
  * [`8d47846`](https://github.com/containerd/ttrpc/commit/8d4784675e72e1880aa5bb9c817875891e670d41) .github: give more slack for build+tests.
</p>
</details>

### Dependency Changes

* **github.com/containerd/nri**                  v0.4.0 -> v0.6.0
* **github.com/containerd/ttrpc**                v1.2.2 -> v1.2.3
* **google.golang.org/genproto/googleapis/rpc**  782d3b101e98 -> cbb8c96f2d6d

Previous release can be found at [v1.7.13](https://github.com/containerd/containerd/releases/tag/v1.7.13)


