### PR TITLE
[release/1.6] Backport test release on PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,14 @@
 on:
   push:
+    branches:
+      - main
+      - "release/**"
     tags:
-      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+  pull_request:
+    branches:
+      - main
+      - "release/**"
 
 name: Containerd Release
 
@@ -14,6 +21,7 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 jobs:
   check:
     name: Check Signed Tag
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-20.04
     timeout-minutes: 5
     outputs:
@@ -57,7 +65,6 @@ jobs:
   build:
     name: Build Release Binaries
     runs-on: ubuntu-20.04
-    needs: [check]
     timeout-minutes: 30
     strategy:
       matrix:
@@ -87,10 +94,9 @@ jobs:
 
       - uses: ./src/github.com/containerd/containerd/.github/actions/install-go
 
-      - name: Set env
+      - name: Set RELEASE_VER
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         shell: bash
-        env:
-          MOS: ubuntu-20.04
         run: |
           releasever=${{ github.ref }}
           releasever="${releasever#refs/tags/}"
@@ -129,6 +135,7 @@ jobs:
 
   release:
     name: Create containerd Release
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
     runs-on: ubuntu-20.04


### PR DESCRIPTION
### Issue
#9890 backported some CI updates to release/1.6. This included a change to the release workflow which removed the environment variable for the Go version because the workflows were moved to use the install Go composite action. The issue is the environment variable was still needed for the build job in the release workflow. The result was the v1.6.29 (#9950) release could not be completed and a fix had to be rolled forward in v1.6.30 (#9952).

### Description

This change will run the release workflow on PR to release/1.6 branch to catch issues from changes to the release workflow.

(cherry picked from commit ffabc8a296691418d07f042d489987b67d0ddde1)

Partial cherry-pick of #7968

### Testing
Status check failed before #9952 which includes release workflow fix.

![image](https://github.com/containerd/containerd/assets/55906459/a9e361ae-c9a4-4119-981e-d12332215ace)
