### PR TITLE
Return correct error if CRIU binary is missing

### DIFF
--- a/internal/cri/server/container_checkpoint_linux.go
+++ b/internal/cri/server/container_checkpoint_linux.go
@@ -41,8 +41,6 @@ import (
 	ptypes "github.com/containerd/containerd/v2/protobuf/types"
 	"github.com/containerd/log"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/containerd/containerd/v2/client"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -73,8 +71,17 @@ func (c *criService) CheckpointContainer(ctx context.Context, r *runtime.Checkpo
 		// This is the wrong error message and needs to be adapted once
 		// Kubernetes (the e2e_node/checkpoint) test has been changed to
 		// handle too old or missing CRIU error messages.
-		log.G(ctx).WithError(err).Errorf("Failed to checkpoint container %q", r.GetContainerId())
-		return nil, status.Errorf(codes.Unimplemented, "method CheckpointContainer not implemented")
+		errorMessage := fmt.Sprintf(
+			"CRIU binary not found or too old (<%d). Failed to checkpoint container %q",
+			podCriuVersion,
+			r.GetContainerId(),
+		)
+		log.G(ctx).WithError(err).Errorf(errorMessage)
+		return nil, fmt.Errorf(
+			"%s: %w",
+			errorMessage,
+			err,
+		)
 	}
 
 	container, err := c.containerStore.Get(r.GetContainerId())


### PR DESCRIPTION
For the first version of containerd's "Forensic Container Checkpointing" support the error message if the CRIU binary is not found was deliberately wrong to not break Kubernetes e2e_node tests.

Now that the e2e_node tests have been adapted, containerd can return the correct error message.

Depends on https://github.com/kubernetes/kubernetes/pull/123886