### PR TITLE
Fix invalid event filter in podsandbox

### DIFF
--- a/internal/cri/server/podsandbox/controller.go
+++ b/internal/cri/server/podsandbox/controller.go
@@ -90,7 +90,7 @@ func init() {
 			eventMonitor := events.NewEventMonitor(&podSandboxEventHandler{
 				controller: &c,
 			})
-			eventMonitor.Subscribe(client, []string{`topic="/tasks/exit"`})
+			eventMonitor.Subscribe(client, []string{`topic=="/tasks/exit"`})
 			eventMonitor.Start()
 			c.eventMonitor = eventMonitor
 


### PR DESCRIPTION
The pod sandbox currently uses an invalid filter for subscribing to exit events. This is likely causing a bug somewhere but can be seen with these messages. Valid operators can be seen in https://github.com/containerd/containerd/blob/main/pkg/filters/filter.go.
```
time="2024-03-13T01:25:47.093712531Z" level=error msg="Failed to handle event stream" error="failed parsing subscription filters: filters: parse error: [topic >|=|< \"/tasks/exit\"]: unsupported operator \"=\": invalid argument"
```
