### PR TITLE
core/images/archive: normalizeReference: remove outdated TODO

### DIFF
--- a/core/images/archive/reference.go
+++ b/core/images/archive/reference.go
@@ -72,7 +72,6 @@ func isImagePrefix(s, prefix string) bool {
 }
 
 func normalizeReference(ref string) (string, error) {
-	// TODO: Replace this function to not depend on reference package
 	normalized, err := distref.ParseDockerRef(ref)
 	if err != nil {
 		return "", fmt.Errorf("normalize image ref %q: %w", ref, err)


### PR DESCRIPTION
This TODO was added in 9e6db7195485f70d0798e5aebdb7c96254812be1, at which time the reference package was part of the docker/distribution (registry) repository. The reference package has moved to a standalone module, which has been in use since 492347090250f689230bafd79d73a1647767a598, so this should no longer be a concern.