### PR TITLE
Allow sections of Plugins to be merged, and not overwritten as entire sections.

### DIFF
--- a/cmd/containerd/server/config/config.go
+++ b/cmd/containerd/server/config/config.go
@@ -412,10 +412,6 @@ func mergeConfig(to, from *Config) error {
 	}
 
 	// Replace entire sections instead of merging map's values.
-	for k, v := range from.Plugins {
-		to.Plugins[k] = v
-	}
-
 	for k, v := range from.StreamProcessors {
 		to.StreamProcessors[k] = v
 	}

--- a/cmd/containerd/server/config/config_test.go
+++ b/cmd/containerd/server/config/config_test.go
@@ -17,11 +17,16 @@
 package config
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
+
+	"github.com/pelletier/go-toml/v2"
 
 	"github.com/stretchr/testify/assert"
 
@@ -259,4 +264,72 @@ func TestDecodePluginInV1Config(t *testing.T) {
 	_, err = out.Decode(ctx, "io.containerd.runtime.v2.task", &pluginConfig)
 	assert.NoError(t, err)
 	assert.Equal(t, true, pluginConfig["shim_debug"])
+}
+
+func TestMergingPluginsWithTwoCriDropInConfigs(t *testing.T) {
+	data1 := `
+[plugins."io.containerd.grpc.v1.cri".cni]
+    bin_dir = "/cm/local/apps/kubernetes/current/bin/cni"
+`
+	data2 := `
+[plugins."io.containerd.grpc.v1.cri".registry]
+    config_path = "/cm/local/apps/containerd/var/etc/certs.d"
+`
+	expected := `
+[cni]
+  bin_dir = '/cm/local/apps/kubernetes/current/bin/cni'
+
+[registry]
+  config_path = '/cm/local/apps/containerd/var/etc/certs.d'
+`
+
+	testMergeConfig(t, []string{data1, data2}, expected, "io.containerd.grpc.v1.cri")
+	testMergeConfig(t, []string{data2, data1}, expected, "io.containerd.grpc.v1.cri")
+}
+
+func TestMergingPluginsWithTwoCriCniDropInConfigs(t *testing.T) {
+	data1 := `
+[plugins."io.containerd.grpc.v1.cri".cni]
+    bin_dir = "/cm/local/apps/kubernetes/current/bin/cni"
+`
+	data2 := `
+[plugins."io.containerd.grpc.v1.cri".cni]
+    conf_dir = "/tmp"
+`
+	expected := `
+[cni]
+  bin_dir = '/cm/local/apps/kubernetes/current/bin/cni'
+  conf_dir = '/tmp'
+`
+	testMergeConfig(t, []string{data1, data2}, expected, "io.containerd.grpc.v1.cri")
+}
+
+func testMergeConfig(t *testing.T, inputs []string, expected string, comparePlugin string) {
+	tempDir := t.TempDir()
+	var result Config
+
+	for i, data := range inputs {
+		filename := fmt.Sprintf("data%d.toml", i+1)
+		filepath := filepath.Join(tempDir, filename)
+		err := os.WriteFile(filepath, []byte(data), 0600)
+		assert.NoError(t, err)
+
+		var tempOut Config
+		err = LoadConfig(context.Background(), filepath, &tempOut)
+		assert.NoError(t, err)
+
+		if i == 0 {
+			result = tempOut
+		} else {
+			err = mergeConfig(&result, &tempOut)
+			assert.NoError(t, err)
+		}
+	}
+
+	criPlugin := result.Plugins[comparePlugin]
+	var buf bytes.Buffer
+	if err := toml.NewEncoder(&buf).SetIndentTables(true).Encode(criPlugin); err != nil {
+		panic(err)
+	}
+	assert.Equal(t, strings.TrimLeft(expected, "\n"), buf.String())
 }


### PR DESCRIPTION
Hi all, This is a spin-off from the following PR https://github.com/containerd/containerd/pull/7347 (which I suggest we close, since I'm afraid the long history there, and non-essential improvements that I've included obfuscate the PR.). My hope is, that this more concise PR is easier to review.

This PR focuses on a very small change targetting 2.0.0, and I've included a unit test to demonstrate the difference it makes. Without the code change, the unit test would fail with: [make-test-fail.txt](https://github.com/containerd/containerd/files/14694561/make-test-fail.txt)


**Summary**
The change proposed in this PR allows various drop-in configuration toml files to configure _parts_ of a Plugin.

For example, starting with the following containerd `config.toml`, it includes a bunch of potential drop-in configs:

```
imports = ["/etc/containerd/conf.d/*.toml"]
```

Let's say we have two drop-ins in that directory:

```
$ cat /etc/containerd/conf.d/cni.toml
[plugins."io.containerd.grpc.v1.cri".cni]
    bin_dir = "/cm/local/apps/kubernetes/current/bin/cni"

$ cat /etc/containerd/conf.d/registry.toml
[plugins."io.containerd.grpc.v1.cri".registry]
    config_path = "/cm/local/apps/containerd/var/etc/certs.d"
```

**Current behavior**

The current code in main/2.0.0 would overwrite in this case the whole CRI plugin with the path from `registry.toml`, and the `cni.toml` file would not have any effect. Since lexicographically `registry.toml` comes after `cni.toml`. The configuration effectively in containerd would be:

```
[registry]
  config_path = '/cm/local/apps/containerd/var/etc/certs.d'
```
Note the entire `[cni]` block missing.

A workaround for the drop-in to have the desired effect, we would have to merge / combine both configurations into a single drop-in file, as follows:

```
$ cat /etc/containerd/conf.d/combined.toml

[plugins]
  [plugins."io.containerd.grpc.v1.cri"]
    [plugins."io.containerd.grpc.v1.cri".cni]
      bin_dir = '/cm/local/apps/kubernetes/current/bin/cni'
    [plugins."io.containerd.grpc.v1.cri".registry]
      config_path = '/cm/local/apps/containerd/var/etc/certs.d'
```

Then containerd would indeed have both configuration changes. But the two files had to be merged into one.

**Proposed behavior**

We think it would be more convenient if every component can just focus on writing their own drop-in configuration for containerd. The change in this PR should fix just that, and the two files `cni.toml` and `registry.toml` actually _do_ result in the following.

```
[cni]
  bin_dir = '/cm/local/apps/kubernetes/current/bin/cni'
[registry]
  config_path = '/cm/local/apps/containerd/var/etc/certs.d'
```

This example is already a real example, we have certain conditions that could result in either file to be written `cni.toml` and/or `registry.toml`, or none. But we agree it's a trivial one, but it makes a nice example to start with.

**Motivation**

The NVIDIA GPU operator and Kata Containers write their own drop-in configuration file for containerd.
These also cannot co-exist currently in 2.0.0 without this suggested change. We'd have to again merge these toml files together, which gets into a complicated mess. In our case each Kubernetes operator typically configure their hosts with a drop-in configuration file for containerd using an init container.

**Conclusion**

We're currently at containerd version 1.7.x, but at some point we'll start using 2.0.x, and then it would be really great if we could let go of our patch(es) and just use the upstream containerd from that point on.

Please let me know if this PR is an improvement compared to the old one. And whether or not we can get this merged for 2.0.x.? 

In other PRs, such as my old PR, there seems to be agreement on the usefulness of this change, and at the same time some understandably hesitation, but now that there is a 2.0 release on the horizon, it is perhaps 'safer' to make this change?