### PR TITLE
transfer: Platform matcher should match multiple platforms

### DIFF
--- a/plugins/transfer/plugin.go
+++ b/plugins/transfer/plugin.go
@@ -94,7 +94,7 @@ func init() {
 				}
 
 				var applier diff.Applier
-				target := platforms.OnlyStrict(p)
+				target := platforms.Only(p)
 				if uc.Differ != "" {
 					inst, err := ic.GetByID(plugins.DiffPlugin, uc.Differ)
 					if err != nil {


### PR DESCRIPTION
This allows arm64 to pull armhf images.
Before this change the transfer service would reject pulls for armhf on
an arm64 machine, or indeed any such platform variant mismatches.

I would argue that its a bit weird for the transfer service to reject a
pull at all since there are legitamate reasons to want to pull images
for other architectures, however that's a more philosophical change.

In the case where I ran into this, I have an arm64 machine running
an armhf containerd in an armhf container (for running some basic sanity
checks during packaging).
Tests started failing once `ctr` was moved to use the transfer service
by default.

Fixes #9980