### PR TITLE
runc-shim: only defer init process exits

### DIFF
--- a/cmd/containerd-shim-runc-v2/task/service.go
+++ b/cmd/containerd-shim-runc-v2/task/service.go
@@ -678,7 +678,8 @@ func (s *service) processExits() {
 		// process.
 		var cps, skipped []containerProcess
 		for _, cp := range s.running[e.Pid] {
-			if s.pendingExecs[cp.Container] != 0 {
+			_, init := cp.Process.(*process.Init)
+			if init && s.pendingExecs[cp.Container] != 0 {
 				// This exit relates to a container for which we have pending execs. In
 				// order to ensure order between execs and the init process for a given
 				// container, skip processing this exit here and let the `handleStarted`


### PR DESCRIPTION
**What this fixes:**

In order to make sure that we don't publish task exit events for init processes before we do for execs in that container, we added logic to `processExits` in 892dc54bd26f6e8b9aea4672208b1ba2158d8a1b to skip these and let the pending exec's `handleStarted` closure process them.

However, the conditional logic in `processExits` added was faulty - we should only defer processing of exit events related to init processes, not other execs. Due to this missing condition,
892dc54bd26f6e8b9aea4672208b1ba2158d8a1b introduced a bug where, if there are many concurrent execs for the same container/init pid, exec exits are skipped and then never published, resulting in hanging clients.

<details>
<summary>repro + details</summary>

```shell
ctrid=$(docker run -d busybox top)
docker exec $ctrid cat /proc/1/cgroup
docker exec $ctrid cat /proc/self/cgroup &
docker exec $ctrid cat /proc/self/cgroup &
docker exec $ctrid cat /proc/self/cgroup &
docker exec $ctrid cat /proc/self/cgroup &
docker exec $ctrid cat /proc/self/cgroup &
docker exec $ctrid cat /proc/self/cgroup &
wait
```
this hangs without this fix, but works before 892dc54bd26f6e8b9aea4672208b1ba2158d8a1b.

Instrumenting with some logs, we see this issue:
```diff
diff --git a/cmd/containerd-shim-runc-v2/task/service.go b/cmd/containerd-shim-runc-v2/task/service.go
index 666e03603..506cbfe1a 100644
--- a/cmd/containerd-shim-runc-v2/task/service.go
+++ b/cmd/containerd-shim-runc-v2/task/service.go
@@ -210,11 +210,13 @@ func (s *service) preStart(c *runc.Container) (handleStarted func(*runc.Containe
 				}
 			}
 		}
+		log.G(s.context).Info("handleStarted ", pid)
 
 		ees, exited := exits[pid]
 		delete(s.exitSubscribers, &exits)
 		exits = nil
 		if pid == 0 || exited {
+			log.G(s.context).Info("early exit ", pid)
 			s.lifecycleMu.Unlock()
 			for _, ee := range ees {
 				s.handleProcessExit(ee, c, p)
@@ -225,6 +227,7 @@ func (s *service) preStart(c *runc.Container) (handleStarted func(*runc.Containe
 				}
 			}
 		} else {
+			log.G(s.context).Info("running ", pid)
 			// Process start was successful, add to `s.running`.
 			s.running[pid] = append(s.running[pid], containerProcess{
 				Container: c,
@@ -683,6 +686,7 @@ func (s *service) processExits() {
 				// order to ensure order between execs and the init process for a given
 				// container, skip processing this exit here and let the `handleStarted`
 				// closure for the pending exec publish it.
+				log.G(s.context).Info("skipping ", e.Pid)
 				skipped = append(skipped, cp)
 			} else {
 				cps = append(cps, cp)
```

```
TRAC[2024-03-26T13:27:36.805958001Z] event forwarded                               ns=moby topic=/tasks/exec-added type=containerd.events.TaskExecAdded
TRAC[2024-03-26T13:27:36.849531825Z] event forwarded                               ns=moby topic=/tasks/exec-started type=containerd.events.TaskExecStarted
time="2024-03-26T13:27:36.848788403Z" level=info msg="taskExecStarted 625d077662a3fac929e0ecb715c2b8e69468639ee46752fc043de071076a62ba pid 391509" runtime=io.containerd.runc.v2
time="2024-03-26T13:27:36.849284740Z" level=info msg="handleStarted 391509" runtime=io.containerd.runc.v2
time="2024-03-26T13:27:36.849291532Z" level=info msg="running 391509" runtime=io.containerd.runc.v2
time="2024-03-26T13:27:36.850655960Z" level=info msg="skipping 391509" runtime=io.containerd.runc.v2
```
</details>

**What I did:**

This commit adds the missing logic to `processExits`.