### PR TITLE
ctr: fix parsing mount options

### DIFF
--- a/cmd/ctr/app/main.go
+++ b/cmd/ctr/app/main.go
@@ -86,6 +86,7 @@ stable from release to release of the containerd project.`
 
 containerd CLI
 `
+	app.DisableSliceFlagSeparator = true
 	app.EnableBashCompletion = true
 	app.Flags = []cli.Flag{
 		&cli.BoolFlag{


### PR DESCRIPTION
Set `DisableSliceFlagSeparator = true`

urfave/cli/v2 uses ',' as default string slice separator. That means '--mount type=bind,src=/src,des=/des,options=rbind:rw' will be token as four bind mount options.

Fixes: #10003

reference:
https://github.com/urfave/cli/pull/1582

DisableSliceFlagSeparator is a global setting.

Before updating urfave/cli to v2,  ctr doesn't support to take `--<option>  foo1=bar1,foo2=bar2` as `--<option> foo1=bar1 --<option>  foo2=bar2`.
So I think set `DisableSliceFlagSeparator = true` is compatible with before