### PR TITLE
[release/1.6] Fix compile from version control system (source) use case

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -141,3 +141,7 @@ replace (
 	github.com/urfave/cli => github.com/urfave/cli v1.22.1
 	google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200224152610-e50cd9704f63
 )
+
+// Workaround for indirect dependency no longer being available.
+// https://github.com/containerd/containerd/issues/9969
+exclude github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f

--- a/go.sum
+++ b/go.sum
@@ -658,7 +658,6 @@ github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS4
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
-github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
 github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=


### PR DESCRIPTION
### Issue
Resolves #9969

The module github.com/mitchellh/osext is no longer available via source. The issue is it is currently a indirect dependency via containerd/aufs@v1.0.0 (see https://github.com/containerd/aufs/issues/49#issuecomment-2024098076) and Microsoft/hcsshim@v0.9.10.

### Description
This change excludes the github.com/mitchellh/osext indirect dependency to resolve compile from source use case issue due to dependency no longer being available.

### Testing

```
go clean -modcache
export GOPROXY=direct
go mod tidy
go mod vendor
```

### Additional context
* Go mod exclude directive - https://go.dev/doc/modules/gomod-ref#exclude