### PR TITLE
[release/1.7] Fix compile from version control system (source) use case

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -144,3 +144,7 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 	tags.cncf.io/container-device-interface/specs-go v0.6.0 // indirect
 )
+
+// Workaround for indirect dependency no longer being available.
+// https://github.com/containerd/containerd/issues/9969
+exclude github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f

--- a/go.sum
+++ b/go.sum
@@ -708,7 +708,6 @@ github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS4
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
-github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/mndrix/tap-go v0.0.0-20171203230836-629fa407e90b/go.mod h1:pzzDgJWZ34fGzaAZGFW22KVZDfyrYW+QABMrWnJBnSs=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=


### PR DESCRIPTION
### Issue
Resolves #9969

The module github.com/mitchellh/osext is no longer available via source. The issue is it is currently a indirect dependency via containerd/aufs@v1.0.0 (see https://github.com/containerd/aufs/issues/49#issuecomment-2024098076) and Microsoft/hcsshim@v0.9.10.

### Description
This change excludes the github.com/mitchellh/osext indirect dependency to resolve compile from source use case issue due to dependency no longer being available.

### Testing

```
go clean -modcache
export GOPROXY=direct
go mod tidy
go mod vendor
```

### Additional context
* Go mod exclude directive - https://go.dev/doc/modules/gomod-ref#exclude