### PR TITLE
fix(cri): fix unexpected order of mounts since go 1.19

### DIFF
--- a/internal/cri/opts/spec_darwin_opts.go
+++ b/internal/cri/opts/spec_darwin_opts.go
@@ -58,7 +58,7 @@ func WithDarwinMounts(osi osinterface.OS, config *runtime.ContainerConfig, extra
 
 		// Sort mounts in number of parts. This ensures that high level mounts don't
 		// shadow other mounts.
-		sort.Sort(orderedMounts(mounts))
+		sort.Stable(orderedMounts(mounts))
 
 		// Copy all mounts from default mounts, except for
 		// - mounts overridden by supplied mount;

--- a/internal/cri/opts/spec_linux_opts.go
+++ b/internal/cri/opts/spec_linux_opts.go
@@ -65,7 +65,7 @@ func WithMounts(osi osinterface.OS, config *runtime.ContainerConfig, extra []*ru
 
 		// Sort mounts in number of parts. This ensures that high level mounts don't
 		// shadow other mounts.
-		sort.Sort(orderedMounts(mounts))
+		sort.Stable(orderedMounts(mounts))
 
 		// Mount cgroup into the container as readonly, which inherits docker's behavior.
 		s.Mounts = append(s.Mounts, runtimespec.Mount{

--- a/internal/cri/opts/spec_windows_opts.go
+++ b/internal/cri/opts/spec_windows_opts.go
@@ -128,7 +128,7 @@ func WithWindowsMounts(osi osinterface.OS, config *runtime.ContainerConfig, extr
 
 		// Sort mounts in number of parts. This ensures that high level mounts don't
 		// shadow other mounts.
-		sort.Sort(orderedMounts(mounts))
+		sort.Stable(orderedMounts(mounts))
 
 		// Copy all mounts from default mounts, except for
 		// mounts overridden by supplied mount;


### PR DESCRIPTION
Since the commit of https://github.com/golang/go/commit/72e77a7f41bbf45d466119444307fd3ae996e257 in Golang 1.19, the order of mounts is unexpected. In some situations, this leads to unexpected results.

This PR changes `sort.Sort()` to `sort.Stable()` to keep the order of mounts stable after sorting.

Fix https://github.com/containerd/containerd/issues/9978