### PR TITLE
Add IsNotFound case to ListPodSandboxStats

### DIFF
--- a/internal/cri/server/sandbox_stats_list.go
+++ b/internal/cri/server/sandbox_stats_list.go
@@ -39,7 +39,7 @@ func (c *criService) ListPodSandboxStats(
 	for _, sandbox := range sandboxes {
 		sandboxStats, err := c.podSandboxStats(ctx, sandbox)
 		switch {
-		case errdefs.IsUnavailable(err):
+		case errdefs.IsUnavailable(err), errdefs.IsNotFound(err):
 			log.G(ctx).WithField("podsandboxid", sandbox.ID).Debugf("failed to get pod sandbox stats, this is likely a transient error: %v", err)
 		case err != nil:
 			errs = append(errs, fmt.Errorf("failed to decode sandbox container metrics for sandbox %q: %w", sandbox.ID, err))


### PR DESCRIPTION
Should hopefully fix #10013. It seems we can end up in a spot where the sandbox store still has a listing for a pod, whereas containerds underlying store has removed it. It might be better to shield the caller (k8s) from these transient errors.