### PR TITLE
[release/1.7] Fix issue with empty host tree in hosts.toml

### DIFF
--- a/remotes/docker/config/hosts.go
+++ b/remotes/docker/config/hosts.go
@@ -20,7 +20,6 @@ package config
 import (
 	"context"
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -531,7 +530,7 @@ func parseHostConfig(server string, baseDir string, config hostFileConfig) (host
 func getSortedHosts(root *toml.Tree) ([]string, error) {
 	iter, ok := root.Get("host").(*toml.Tree)
 	if !ok {
-		return nil, errors.New("invalid `host` tree")
+		return nil, nil
 	}
 
 	list := append([]string{}, iter.Keys()...)


### PR DESCRIPTION
Fixes: https://github.com/containerd/containerd/issues/10027

```release-note
Allow hosts.toml to contain only root-level fields without an explicit [host] section
```