### PR TITLE
[release/1.6] Fix runc shim to only defer init process exits

### DIFF
--- a/runtime/v2/runc/task/service.go
+++ b/runtime/v2/runc/task/service.go
@@ -677,7 +677,8 @@ func (s *service) processExits() {
 		// process.
 		var cps, skipped []containerProcess
 		for _, cp := range s.running[e.Pid] {
-			if s.pendingExecs[cp.Container] != 0 {
+			_, init := cp.Process.(*process.Init)
+			if init && s.pendingExecs[cp.Container] != 0 {
 				// This exit relates to a container for which we have pending execs. In
 				// order to ensure order between execs and the init process for a given
 				// container, skip processing this exit here and let the `handleStarted`


### PR DESCRIPTION
Backports https://github.com/containerd/containerd/pull/9999

(cherry picked from commit 6d00c3ada8b094aa3a2aa73a396cd2243de3f59f)