### PR TITLE
[release/1.7] Add IsNotFound case to ListPodSandboxStats

### DIFF
--- a/pkg/cri/server/sandbox_stats_list.go
+++ b/pkg/cri/server/sandbox_stats_list.go
@@ -40,7 +40,7 @@ func (c *criService) ListPodSandboxStats(
 	for _, sandbox := range sandboxes {
 		sandboxStats, err := c.podSandboxStats(ctx, sandbox)
 		switch {
-		case errdefs.IsUnavailable(err):
+		case errdefs.IsUnavailable(err), errdefs.IsNotFound(err):
 			log.G(ctx).WithField("podsandboxid", sandbox.ID).Debugf("failed to get pod sandbox stats, this is likely a transient error: %v", err)
 		case err != nil:
 			errs = multierror.Append(errs, fmt.Errorf("failed to decode sandbox container metrics for sandbox %q: %w", sandbox.ID, err))


### PR DESCRIPTION
#### Original description
Fixes #10013. It seems we can end up in a spot where the sandbox store still has a listing for a pod, whereas containerds underlying store has removed it. It might be better to shield the caller (k8s) from these transient errors.


(cherry picked from commit 2474a99c3084aa2c2239a827130c1972bf7724c5)