### PR TITLE
[release/1.7] remote: Fix HTTPFallback fails when pushing manifest

### DIFF
--- a/remotes/docker/pusher_test.go
+++ b/remotes/docker/pusher_test.go
@@ -17,7 +17,9 @@
 package docker
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -35,6 +37,7 @@ import (
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/log/logtest"
 	"github.com/opencontainers/go-digest"
+	ocispecv "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 )
@@ -181,10 +184,55 @@ func tryUpload(ctx context.Context, t *testing.T, p dockerPusher, layerContent [
 		return err
 	}
 	defer cw.Close()
-	if _, err := cw.Write(layerContent); err != nil {
+	if err := content.Copy(ctx, cw, bytes.NewReader(layerContent), int64(len(layerContent)), desc.Digest); err != nil {
 		return err
 	}
-	return cw.Commit(ctx, 0, "")
+
+	cContent, err := json.Marshal(ocispec.Image{})
+	if err != nil {
+		return err
+	}
+	cdesc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageConfig,
+		Digest:    digest.FromBytes(cContent),
+		Size:      int64(len(cContent)),
+	}
+	cwc, err := p.Writer(ctx, content.WithRef("test-1-c"), content.WithDescriptor(cdesc))
+	if err != nil {
+		return err
+	}
+	defer cwc.Close()
+	if _, err := cwc.Write(cContent); err != nil {
+		return err
+	}
+	if err := content.Copy(ctx, cwc, bytes.NewReader(cContent), int64(len(cContent)), cdesc.Digest); err != nil {
+		return err
+	}
+
+	m := ocispec.Manifest{
+		Versioned: ocispecv.Versioned{SchemaVersion: 1},
+		MediaType: ocispec.MediaTypeImageManifest,
+		Config:    cdesc,
+		Layers:    []ocispec.Descriptor{desc},
+	}
+	mContent, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	mdesc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    digest.FromBytes(mContent),
+		Size:      int64(len(mContent)),
+	}
+	cwm, err := p.Writer(ctx, content.WithRef("test-1-m"), content.WithDescriptor(mdesc))
+	if err != nil {
+		return err
+	}
+	defer cwm.Close()
+	if err := content.Copy(ctx, cwm, bytes.NewReader(mContent), int64(len(mContent)), mdesc.Digest); err != nil {
+		return err
+	}
+	return nil
 }
 
 func samplePusher(t *testing.T) (dockerPusher, *uploadableMockRegistry, StatusTrackLocker, func()) {

--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -722,6 +722,14 @@ func (f HTTPFallback) RoundTrip(r *http.Request) (*http.Response, error) {
 		plainHTTPRequest := *r
 		plainHTTPRequest.URL = &plainHTTPUrl
 
+		if r.Body != nil && r.GetBody != nil {
+			body, err := r.GetBody()
+			if err != nil {
+				return nil, err
+			}
+			plainHTTPRequest.Body = body
+		}
+
 		return f.RoundTripper.RoundTrip(&plainHTTPRequest)
 	}
 


### PR DESCRIPTION
Backporting  #10031

# Description from  #10031

The pusher supports fallback from HTTPS to HTTP using `HTTPFallback`. But the current implementation of `HTTPFallback` doesn't reset the request body on fallback so the body is used twice.  When the pusher uploads the manifest using `HTTPFallback`, it results in `io: read/write on closed pipe` error because the request body is a `*io.PipeReader` that can't be used twice. This commit fixes this issue by modifying `HTTPFallback` to reset the request body on fallback, using `http.Request.GetBody()`.

Reusing the request body didn't happen when uploading the layer because the pusher correctly selects the scheme based on Location header and avoids fallback. This commit also fixes the test to cover the code path of uploading the manifest with fallback.

## Additional information

- The same error is observed also in v1.7.14 so I'll backport this patch to that branch after this is merged to the main branch.
- The error starts to happen after 2a25c085b21e074667bf6ded0dbb6ebf892a889c according to bisect. `*io.PipeReader` is closed before fallback so reusing it results in the explicit error.
- This will also fix that `ctr` + `--plain-http` failed with `io: read/write on closed pipe` error (>= v1.7.14)
  - https://github.com/containerd/stargz-snapshotter/actions/runs/8436798962/job/23199432922?pr=1605#step:4:4116 : `failed to copy: failed to do request: Put "https://registry-alt.test:5000/v2/alpine/manifests/sha256:01344c7e6bf6a4b063eee2c3c83f39ef515e6dea8af546a7a1fc786f3d1a82c0": readfrom tcp 172.18.0.2:40046->172.18.0.4:5000: io: read/write on closed pipe`
