### PR TITLE
[release/1.7] Use different containerd sock address in tests

### DIFF
--- a/integration/client/client.go
+++ b/integration/client/client.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/log/logtest"
 	"github.com/containerd/containerd/namespaces"
 )
@@ -41,7 +40,7 @@ var (
 )
 
 func init() {
-	flag.StringVar(&address, "address", defaults.DefaultAddress, "The address to the containerd socket for use in the tests")
+	flag.StringVar(&address, "address", defaultAddress, "The address to the containerd socket for use in the tests")
 }
 
 func testContext(t testing.TB) (context.Context, context.CancelFunc) {

--- a/integration/client/client_windows.go
+++ b/integration/client/client_windows.go
@@ -1,0 +1,39 @@
+//go:build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+   Copyright 2024 The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+const (
+	defaultAddress = `\\.\pipe\containerd-containerd-test`
+)

--- a/integration/client/client_windows_test.go
+++ b/integration/client/client_windows_test.go
@@ -25,10 +25,6 @@ import (
 	_ "github.com/Microsoft/hcsshim/test/functional/manifest" // For rsrc_amd64.syso
 )
 
-const (
-	defaultAddress = `\\.\pipe\containerd-containerd-test`
-)
-
 var (
 	defaultRoot           = filepath.Join(os.Getenv("programfiles"), "containerd", "root-test")
 	defaultState          = filepath.Join(os.Getenv("programfiles"), "containerd", "state-test")


### PR DESCRIPTION
(cherry picked from commit 5b6ae0f796f3d6e3e499d37785e93e167aef0fe1)

P.S: This is a direct cherry-pick without any additional change.