### PR TITLE
Allow split configurations by default: import conf/*.toml by default.

### DIFF
--- a/cmd/containerd/command/config.go
+++ b/cmd/containerd/command/config.go
@@ -130,6 +130,7 @@ func platformAgnosticDefaultConfig() *srvconfig.Config {
 		State:            defaults.DefaultStateDir,
 		DisabledPlugins:  []string{},
 		RequiredPlugins:  []string{},
+		Imports:          defaults.DefaultImports,
 		StreamProcessors: streamProcessors(),
 		Imports:          []string{defaults.DefaultConfigIncludePattern},
 		Plugins: map[string]any{

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -35,3 +35,8 @@ const (
 	// DefaultSandboxer defines the default sandboxer to use for creating sandboxes.
 	DefaultSandboxer = "shim"
 )
+
+var (
+	// DefaultImports is the default imports for config files.
+	DefaultImports = []string{"conf/*.toml"}
+)

--- a/docs/man/containerd-config.toml.5.md
+++ b/docs/man/containerd-config.toml.5.md
@@ -180,7 +180,7 @@ documentation.
   "io.containerd.timeout.shim.shutdown" = "3s"
   "io.containerd.timeout.task.state" = "2s" -->
 
-**imports**
+**imports** (Default: ["conf/*.toml"])
 : Imports is a list of additional configuration files to include.
 This allows to split the main configuration file and keep some sections
 separately (for example vendors may keep a custom runtime configuration in a


### PR DESCRIPTION
Distro vendor might want to customize their containerd configuration and might prefer to split it in multiple files. Usually this is done with a /etc/tool.d/*.conf scheme (for example /etc/sysctl.d). This would allow distro to put any toml file in /etc/containerd/conf in Linux to customize the default configuration.