### PR TITLE
[release/1.7] fix(cri): fix unexpected order of mounts since go 1.19

### DIFF
--- a/pkg/cri/opts/spec_darwin_opts.go
+++ b/pkg/cri/opts/spec_darwin_opts.go
@@ -58,7 +58,7 @@ func WithDarwinMounts(osi osinterface.OS, config *runtime.ContainerConfig, extra
 
 		// Sort mounts in number of parts. This ensures that high level mounts don't
 		// shadow other mounts.
-		sort.Sort(orderedMounts(mounts))
+		sort.Stable(orderedMounts(mounts))
 
 		// Copy all mounts from default mounts, except for
 		// - mounts overridden by supplied mount;

--- a/pkg/cri/opts/spec_linux_opts.go
+++ b/pkg/cri/opts/spec_linux_opts.go
@@ -65,7 +65,7 @@ func WithMounts(osi osinterface.OS, config *runtime.ContainerConfig, extra []*ru
 
 		// Sort mounts in number of parts. This ensures that high level mounts don't
 		// shadow other mounts.
-		sort.Sort(orderedMounts(mounts))
+		sort.Stable(orderedMounts(mounts))
 
 		// Mount cgroup into the container as readonly, which inherits docker's behavior.
 		s.Mounts = append(s.Mounts, runtimespec.Mount{

--- a/pkg/cri/opts/spec_windows_opts.go
+++ b/pkg/cri/opts/spec_windows_opts.go
@@ -127,7 +127,7 @@ func WithWindowsMounts(osi osinterface.OS, config *runtime.ContainerConfig, extr
 
 		// Sort mounts in number of parts. This ensures that high level mounts don't
 		// shadow other mounts.
-		sort.Sort(orderedMounts(mounts))
+		sort.Stable(orderedMounts(mounts))
 
 		// Copy all mounts from default mounts, except for
 		// mounts overridden by supplied mount;


### PR DESCRIPTION
backport #10021 

cc @estesp @mxpv 