### PR TITLE
fix default working directory `hostProcess`

### DIFF
--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -858,6 +858,8 @@ func (c *criService) buildWindowsSpec(
 		specOpts = append(specOpts, oci.WithProcessCwd(config.GetWorkingDir()))
 	} else if imageConfig.WorkingDir != "" {
 		specOpts = append(specOpts, oci.WithProcessCwd(imageConfig.WorkingDir))
+	} else if cntrHpc {
+		specOpts = append(specOpts, oci.WithProcessCwd(`C:\hpc`))
 	}
 
 	if config.GetTty() {


### PR DESCRIPTION
Per https://github.com/kubernetes/enhancements/tree/master/keps/sig-windows/1981-windows-privileged-container-support#container-mounts
the default working directory for `hostProcess` containers should be `C:\hpc`,
however the current default is set to windows default which is `C:\`.