### PR TITLE
[release/1.7] backport: fix default working directory `hostProcess`

### DIFF
--- a/pkg/cri/sbserver/container_create.go
+++ b/pkg/cri/sbserver/container_create.go
@@ -855,6 +855,8 @@ func (c *criService) buildWindowsSpec(
 		specOpts = append(specOpts, oci.WithProcessCwd(config.GetWorkingDir()))
 	} else if imageConfig.WorkingDir != "" {
 		specOpts = append(specOpts, oci.WithProcessCwd(imageConfig.WorkingDir))
+	} else if cntrHpc {
+		specOpts = append(specOpts, oci.WithProcessCwd(`C:\hpc`))
 	}
 
 	if config.GetTty() {


### PR DESCRIPTION
Per https://github.com/kubernetes/enhancements/tree/master/keps/sig-windows/1981-windows-privileged-container-support#container-mounts the default working directory for `hostProcess` containers should be `C:\hpc`, however the current default is set to windows default which is `C:\`.

Signed-off-by: Maksim An <maksiman@microsoft.com>
(cherry picked from commit c7ea06a69bdf9147758353b4eb12bb78240fbda8)