### PR TITLE
[release/1.7] Support encoded characters in hosts table key

### DIFF
--- a/remotes/docker/config/hosts.go
+++ b/remotes/docker/config/hosts.go
@@ -20,6 +20,7 @@ package config
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -392,6 +393,14 @@ func parseHostsFile(baseDir string, b []byte) ([]hostConfig, error) {
 	// Parse hosts array
 	for _, host := range orderedHosts {
 		config := c.HostConfigs[host]
+
+		// Decode any escaped characters in the table key.
+		// This allows for URLs that contain characters that are not valid in table keys.
+		// For example, RFC2732 IPv6 literal host addresses.
+		var decodedHost string
+		if err := json.Unmarshal([]byte(`"`+host+`"`), &decodedHost); err == nil {
+			host = decodedHost
+		}
 
 		parsed, err := parseHostConfig(host, baseDir, config)
 		if err != nil {


### PR DESCRIPTION
Fixes https://github.com/containerd/containerd/issues/10055

Allows escaping invalid table keys, for example the braces required to specify an IPv6 literal URL:

```toml
[host."https://\u005Bfd7c:53a5:aef5::242:ac11:7\u005D/v2"]
  capabilities = ["pull", "resolve"]
  skip_verify = true
```

This is about the most minimal fix I can come up with. Other options would probably require adding a new field to override the hostname, similar to OverridePath but for the hostname. go-toml is super helpful and does not expose any functions for decoding core types, so we use the json decoder for that since it also supports toml's `\uXXXX` format.

Honestly this datastructure should have been a table list with a `server` field for each entry, rather than trying to get clever and put the server URL in the table key. Using a list would have also avoided all the weirdness with having to re-parse the tree to get the key order from line numbers in the file.

```toml
[[host]]
  server = "https://[fd7c:53a5:aef5::242:ac11:7]/v2"
  capabilities = ["pull", "resolve"]
  skip_verify = true
```