### PR TITLE
Snapshotters: Export the root path

### DIFF
--- a/plugins/snapshots/blockfile/plugin/plugin.go
+++ b/plugins/snapshots/blockfile/plugin/plugin.go
@@ -74,6 +74,7 @@ func init() {
 			}
 			opts = append(opts, blockfile.WithRecreateScratch(config.RecreateScratch))
 
+			ic.Meta.Exports[plugins.SnapshotterRootDir] = root
 			return blockfile.NewSnapshotter(root, opts...)
 		},
 	})

--- a/plugins/snapshots/btrfs/plugin/plugin.go
+++ b/plugins/snapshots/btrfs/plugin/plugin.go
@@ -54,7 +54,7 @@ func init() {
 				root = config.RootPath
 			}
 
-			ic.Meta.Exports = map[string]string{"root": root}
+			ic.Meta.Exports[plugins.SnapshotterRootDir] = root
 			return btrfs.NewSnapshotter(root)
 		},
 	})

--- a/plugins/snapshots/devmapper/plugin/plugin.go
+++ b/plugins/snapshots/devmapper/plugin/plugin.go
@@ -50,6 +50,7 @@ func init() {
 				config.RootPath = ic.Properties[plugins.PropertyRootDir]
 			}
 
+			ic.Meta.Exports[plugins.SnapshotterRootDir] = config.RootPath
 			return devmapper.NewSnapshotter(ic.Context, config)
 		},
 	})

--- a/plugins/snapshots/native/plugin/plugin.go
+++ b/plugins/snapshots/native/plugin/plugin.go
@@ -50,6 +50,7 @@ func init() {
 				root = config.RootPath
 			}
 
+			ic.Meta.Exports[plugins.SnapshotterRootDir] = root
 			return native.NewSnapshotter(root)
 		},
 	})

--- a/plugins/snapshots/overlay/plugin/plugin.go
+++ b/plugins/snapshots/overlay/plugin/plugin.go
@@ -92,7 +92,7 @@ func init() {
 				ic.Meta.Capabilities = append(ic.Meta.Capabilities, capaOnlyRemapIDs)
 			}
 
-			ic.Meta.Exports["root"] = root
+			ic.Meta.Exports[plugins.SnapshotterRootDir] = root
 			return overlay.NewSnapshotter(root, oOpts...)
 		},
 	})

--- a/plugins/types.go
+++ b/plugins/types.go
@@ -93,3 +93,7 @@ const (
 	// PropertyTTRPCAddress is the ttrpc address used for client connections to containerd
 	PropertyTTRPCAddress = "io.containerd.plugin.ttrpc.address"
 )
+
+const (
+	SnapshotterRootDir = "root"
+)


### PR DESCRIPTION
Some of the snapshotters that allow you to change their root location were already doing this, this just makes all of them follow the same pattern so the value can be accessed via introspection.