### PR TITLE
[release/1.7] Prevent GC from schedule itself with 0 period.

### DIFF
--- a/gc/scheduler/scheduler.go
+++ b/gc/scheduler/scheduler.go
@@ -246,6 +246,7 @@ func schedule(d time.Duration) (<-chan time.Time, *time.Time) {
 }
 
 func (s *gcScheduler) run(ctx context.Context) {
+	const minimumGCTime = float64(5 * time.Millisecond)
 	var (
 		schedC <-chan time.Time
 
@@ -343,6 +344,11 @@ func (s *gcScheduler) run(ctx context.Context) {
 			// runtime in between gc to reach the pause threshold.
 			// Pause threshold is always 0.0 < threshold <= 0.5
 			avg := float64(gcTimeSum) / float64(collections)
+			// Enforce that avg is no less than minimumGCTime
+			// to prevent immediate rescheduling
+			if avg < minimumGCTime {
+				avg = minimumGCTime
+			}
 			interval = time.Duration(avg/s.pauseThreshold - avg)
 		}
 


### PR DESCRIPTION
On startup `gcTimeSum` might work fast and return `0`, so on this case the algorithm turns in infinity loop which simple consume CPU on timer which fires without any interval.

Use `5ms` as fallback to have interval `245ms` for that case.

Backport of https://github.com/containerd/containerd/pull/9795 into 1.7 branch

Closes: https://github.com/containerd/containerd/issues/5089
