### PR TITLE
Update HTTP fallback to better account for TLS timeout and previous attempts

### DIFF
--- a/cmd/ctr/commands/resolver.go
+++ b/cmd/ctr/commands/resolver.go
@@ -149,6 +149,11 @@ func resolverDefaultTLS(clicontext *cli.Context) (*tls.Config, error) {
 		config.Certificates = []tls.Certificate{keyPair}
 	}
 
+	// If nothing was set, return nil rather than empty config
+	if !config.InsecureSkipVerify && config.RootCAs == nil && config.Certificates == nil {
+		return nil, nil
+	}
+
 	return config, nil
 }
 

--- a/core/remotes/docker/config/hosts.go
+++ b/core/remotes/docker/config/hosts.go
@@ -244,7 +244,7 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
 
 			// When TLS has been configured for the operation or host and
 			// the protocol from the port number is ambiguous, use the
-			// docker.HTTPFallback roundtripper to catch TLS errors and re-attempt the
+			// docker.NewHTTPFallback roundtripper to catch TLS errors and re-attempt the
 			// request as http. This allows preference for https when configured but
 			// also catches TLS errors early enough in the request to avoid sending
 			// the request twice or consuming the request body.
@@ -253,7 +253,7 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
 				if port != "" && port != "80" {
 					log.G(ctx).WithField("host", host.host).Info("host will try HTTPS first since it is configured for HTTP with a TLS configuration, consider changing host to HTTPS or removing unused TLS configuration")
 					host.scheme = "https"
-					rhosts[i].Client.Transport = docker.HTTPFallback{RoundTripper: rhosts[i].Client.Transport}
+					rhosts[i].Client.Transport = docker.NewHTTPFallback(rhosts[i].Client.Transport)
 				}
 			}
 

--- a/core/remotes/docker/config/hosts_test.go
+++ b/core/remotes/docker/config/hosts_test.go
@@ -472,11 +472,11 @@ func TestHTTPFallback(t *testing.T) {
 			if testHosts[0].Scheme != tc.expectedScheme {
 				t.Fatalf("expected %s scheme for localhost with tls config, got %q", tc.expectedScheme, testHosts[0].Scheme)
 			}
-			_, ok := testHosts[0].Client.Transport.(docker.HTTPFallback)
-			if tc.usesFallback && !ok {
+			_, defaultTransport := testHosts[0].Client.Transport.(*http.Transport)
+			if tc.usesFallback && defaultTransport {
 				t.Fatal("expected http fallback configured for defaulted localhost endpoint")
-			} else if ok && !tc.usesFallback {
-				t.Fatal("expected no http fallback configured for defaulted localhost endpoint")
+			} else if !defaultTransport && !tc.usesFallback {
+				t.Fatalf("expected no http fallback configured for defaulted localhost endpoint")
 			}
 		})
 	}

--- a/core/remotes/docker/pusher_test.go
+++ b/core/remotes/docker/pusher_test.go
@@ -110,7 +110,7 @@ func TestPusherHTTPFallback(t *testing.T) {
 	if client.Transport == nil {
 		client.Transport = http.DefaultTransport
 	}
-	client.Transport = HTTPFallback{client.Transport}
+	client.Transport = NewHTTPFallback(client.Transport)
 	p.hosts[0].Client = client
 	phost := p.hosts[0].Host
 	p.hosts[0].Authorizer = NewDockerAuthorizer(WithAuthCreds(func(host string) (string, string, error) {


### PR DESCRIPTION
A few relevant changes here to make the HTTP fallback more robust:
- Handle TLS handshake timeout, as some HTTP servers may just not return anything to the TLS handshake attempt
- If a previous fallback has already occurred with the same host using the same transport, immediately fallback to HTTP and do not copy the body
- Avoid returning an empty TLS configuration when no TLS has been configured in ctr, this avoids a TLS configuration always set and forcing fallback when using ctr


Fixes #10014