### PR TITLE
go.mod: go 1.22

### DIFF
--- a/.github/actions/install-go/action.yml
+++ b/.github/actions/install-go/action.yml
@@ -3,7 +3,7 @@ description: "Reusable action to install Go, so there is one place to bump Go ve
 inputs:
   go-version:
     required: true
-    default: "1.21.9"
+    default: "1.22.2"
     description: "Go version to install"
 
 runs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 name: Release
 
 env:
-  GO_VERSION: "1.21.9"
+  GO_VERSION: "1.22.2"
 
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -25,7 +25,7 @@ A codespace will open in a web-based version of Visual Studio Code. The [dev con
 
 To build the `containerd` daemon, and the `ctr` simple test client, the following build system dependencies are required:
 
-* Go 1.21.x or above
+* Go 1.22.x or above
 * Protoc 3.x compiler and headers (download at the [Google protobuf releases page](https://github.com/protocolbuffers/protobuf/releases))
 * Btrfs headers and libraries for your distribution. Note that building the btrfs driver can be disabled via the build tag `no_btrfs`, removing this dependency.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -104,7 +104,7 @@ EOF
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.21.9",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.22.2",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -29,7 +29,7 @@
 #   docker run --privileged containerd-test
 # ------------------------------------------------------------------------------
 
-ARG GOLANG_VERSION=1.21.9
+ARG GOLANG_VERSION=1.22.2
 ARG GOLANG_IMAGE=golang
 
 FROM ${GOLANG_IMAGE}:${GOLANG_VERSION} AS golang

--- a/contrib/fuzz/oss_fuzz_build.sh
+++ b/contrib/fuzz/oss_fuzz_build.sh
@@ -43,11 +43,11 @@ go run main.go $SRC/containerd/images
 
 apt-get update && apt-get install -y wget
 cd $SRC
-wget --quiet https://go.dev/dl/go1.21.9.linux-amd64.tar.gz
+wget --quiet https://go.dev/dl/go1.22.2.linux-amd64.tar.gz
 
 mkdir temp-go
 rm -rf /root/.go/*
-tar -C temp-go/ -xzf go1.21.9.linux-amd64.tar.gz
+tar -C temp-go/ -xzf go1.22.2.linux-amd64.tar.gz
 mv temp-go/go/* /root/.go/
 cd $SRC/containerd
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/containerd/v2
 
-go 1.21
+go 1.22.0
 
 require (
 	dario.cat/mergo v1.0.0

--- a/script/setup/install-runc
+++ b/script/setup/install-runc
@@ -34,11 +34,18 @@ function install_runc() {
 	: "${RUNC_REPO:=https://github.com/opencontainers/runc.git}"
 
 	TMPROOT=$(mktemp -d)
+	# runc is incompatible with Go 1.22 on glibc-based distros
+	# https://github.com/opencontainers/runc/issues/4233
+	GO121DIR="${TMPROOT}"/go121
+	mkdir -p "${GO121DIR}"
+	GOBIN="${GO121DIR}" go install golang.org/dl/go1.21.9@latest
+	GO121="${GO121DIR}"/go1.21.9
+	$GO121 download
 	git clone "${RUNC_REPO}" "${TMPROOT}"/runc
 	pushd "${TMPROOT}"/runc
 	git checkout "${RUNC_VERSION}"
-	make BUILDTAGS='seccomp' runc
-	$SUDO make install
+	make GO=$GO121 BUILDTAGS='seccomp' runc
+	$SUDO make GO=$GO121 install
 	popd
 	rm -fR "${TMPROOT}"
 }

--- a/script/setup/prepare_env_windows.ps1
+++ b/script/setup/prepare_env_windows.ps1
@@ -5,7 +5,7 @@
 # lived test environment.
 Set-MpPreference -DisableRealtimeMonitoring:$true
 
-$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.21.9"; make = ""; nssm = "" }
+$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.22.2"; make = ""; nssm = "" }
 
 Write-Host "Downloading chocolatey package"
 curl.exe -L "https://packages.chocolatey.org/chocolatey.0.10.15.nupkg" -o 'c:\choco.zip'


### PR DESCRIPTION
Depended by k8s.io/cri-api >= v0.30.0 (Kubernetes v1.30)
https://github.com/kubernetes/cri-api/blob/v0.30.0/go.mod#L5


- #10019
- #10108