### PR TITLE
[release/1.7] pod: CreatedAt time will be 269 years ago while creating cri network failed.

### DIFF
--- a/pkg/cri/sbserver/sandbox_run.go
+++ b/pkg/cri/sbserver/sandbox_run.go
@@ -120,7 +120,8 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 			RuntimeHandler: r.GetRuntimeHandler(),
 		},
 		sandboxstore.Status{
-			State: sandboxstore.StateUnknown,
+			State:     sandboxstore.StateUnknown,
+			CreatedAt: time.Now().UTC(),
 		},
 	)
 

--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -96,7 +96,8 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 			RuntimeHandler: r.GetRuntimeHandler(),
 		},
 		sandboxstore.Status{
-			State: sandboxstore.StateUnknown,
+			State:     sandboxstore.StateUnknown,
+			CreatedAt: time.Now().UTC(),
 		},
 	)
 


### PR DESCRIPTION
Cherry-pick
- #9673 

There was no merge conflict, but the commit was amended to cover sbserver.