### PR TITLE
apparmor: Allow confined runc to kill containers

### DIFF
--- a/contrib/apparmor/template.go
+++ b/contrib/apparmor/template.go
@@ -53,6 +53,10 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   umount,
   # Host (privileged) processes may send signals to container processes.
   signal (receive) peer=unconfined,
+  # runc may send signals to container processes.
+  signal (receive) peer=runc,
+  # crun may send signals to container processes.
+  signal (receive) peer=crun,
   # Manager may send signals to container processes.
   signal (receive) peer={{.DaemonProfile}},
   # Container processes may send signals amongst themselves.


### PR DESCRIPTION
/usr/sbin/runc is confined with "runc" profile[1] introduced in AppArmor v4.0.0. This change breaks stopping of containers, because the profile assigned to containers doesn't accept signals from the "runc" peer. AppArmor >= v4.0.0 is currently part of Ubuntu Mantic (23.10) and later.

The issue is reproducible both with nerdctl and ctr clients. In the case of ctr, the --apparmor-default-profile flag has to be specified, otherwise the container processes would inherit the runc profile, which behaves as unconfined, and so the subsequent runc process invoked to stop it would be able to signal it.

  Test commands:

    root@cloudimg:~# nerdctl run -d --name foo nginx:latest
    3d1e74bfe6e7b2912d9223050ae8a81a8f4b73de0846e6d9c956c1e411cdd95a
    root@cloudimg:~# nerdctl stop foo
    FATA[0000] 1 errors:
    unknown error after kill: runc did not terminate successfully: exit status 1: unable to signal init: permission denied
    : unknown

    or

    root@cloudimg:~# ctr pull docker.io/library/nginx:latest
    ...
    root@cloudimg:~# ctr run -d --apparmor-default-profile ctr-default docker.io/library/nginx:latest foo
    root@cloudimg:~# ctr task kill foo
    ctr: unknown error after kill: runc did not terminate successfully: exit status 1: unable to signal init: permission denied
    : unknown

  Relevant syslog messages (with long lines wrapped):

    Apr 23 22:03:12 cloudimg kernel: audit:
      type=1400 audit(1713909792.064:262): apparmor="DENIED"
      operation="signal" class="signal" profile="nerdctl-default"
      pid=13483 comm="runc" requested_mask="receive"
      denied_mask="receive" signal=quit peer="runc"

    or

    Apr 23 22:05:32 cloudimg kernel: audit:
      type=1400 audit(1713909932.106:263): apparmor="DENIED"
      operation="signal" class="signal" profile="ctr-default"
      pid=13574 comm="runc" requested_mask="receive"
      denied_mask="receive" signal=quit peer="runc"

This change extends the default profile with rules that allow receiving signals from processes that run confined with either runc or crun profile (crun[2] is an alternative OCI runtime that's also confined in AppArmor >= v4.0.0, see [1]). It is backward compatible because the peer value is a regular expression (AARE) so the referenced profile doesn't have to exist for this profile to successfully compile and load.

[1] https://gitlab.com/apparmor/apparmor/-/commit/2594d936
[2] https://github.com/containers/crun