### PR TITLE
Add release notes for v1.7.16

### DIFF
--- a/releases/v1.7.16.toml
+++ b/releases/v1.7.16.toml
@@ -1,0 +1,26 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.7.15"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The sixteenth patch release for containerd 1.7 contains various fixes and updates.
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.7.15+unknown"
+	Version = "1.7.16+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Welcome to the v1.7.16 release of containerd!



Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Derek McGowan
* Wei Fu
* Danny Canter
* Kazuyoshi Kato
* Maksym Pavlenko
* Phil Estes
* Samuel Karp
* Sebastiaan van Stijn
* Brian Goff
* Kirtana Ashok
* Rodrigo Campos
* Akihiro Suda
* Bin Tang
* David Porter
* Edgar Lee
* Evan Lezar
* Kirill A. Korinsky
* Kohei Tokunaga
* Maksim An
* Paweł Gronowski
* 张钰10307750
* 沈陵

### Changes
<details><summary>44 commits</summary>
<p>

* Fix CRI snapshotter root path when not under containerd root ([#10096](https://github.com/containerd/containerd/pull/10096))
  * [`a8ebceb97`](https://github.com/containerd/containerd/commit/a8ebceb972efdc5ead7535640f531972a95280cb) CRI: "Fix" imageFSPath behavior
  * [`bd423bf84`](https://github.com/containerd/containerd/commit/bd423bf84d2ddef9680f54670a1e6ec2d7a18329) Snapshotters: Export the root path
  * [`8fb6bfa71`](https://github.com/containerd/containerd/commit/8fb6bfa71753481f065e53245707d74473498d78) Add exports to proxy plugin config
  * [`8916e2cf9`](https://github.com/containerd/containerd/commit/8916e2cf9dfa7e1dfe609334540a14a15156bfe6) Add platform config to proxy plugins
* pod: CreatedAt time will be 269 years ago while creating cri network failed. ([#10122](https://github.com/containerd/containerd/pull/10122))
  * [`293f5151d`](https://github.com/containerd/containerd/commit/293f5151d44c8a700a7244fed09c37524a89a82a) pod: CreatedAt time will be 269 years ago while creating cri network failed.
* apparmor: add `signal (receive) peer=/usr/local/bin/rootlesskit,` ([#10116](https://github.com/containerd/containerd/pull/10116))
  * [`af19e746e`](https://github.com/containerd/containerd/commit/af19e746eca65a536d5dc3d732043c22c4b31101) apparmor: add `signal (receive) peer=/usr/local/bin/rootlesskit,`
* update to go1.21.9, go1.22.2 ([#10115](https://github.com/containerd/containerd/pull/10115))
  * [`637d259dd`](https://github.com/containerd/containerd/commit/637d259dd6646d16c71e295e056dec291b506892) update to go1.21.9, go1.22.2
* Update HTTP fallback to better account for TLS timeout and previous attempts ([#10112](https://github.com/containerd/containerd/pull/10112))
  * [`794b0c723`](https://github.com/containerd/containerd/commit/794b0c7239e134d7053daa17842682f0596d55ae) Add deprecated HTTPFallback for package compatibility
  * [`51c649d9d`](https://github.com/containerd/containerd/commit/51c649d9d43d19b0f3f0ac51e331c9e956c337a7) Update HTTPFallback to handle tls handshake timeout
  * [`aa14890ed`](https://github.com/containerd/containerd/commit/aa14890edd027b83800e017261e917c71041c343) Remove empty default tls configuration in ctr
* Add support for HPC port forwarding ([#10008](https://github.com/containerd/containerd/pull/10008))
  * [`3df5d4445`](https://github.com/containerd/containerd/commit/3df5d4445bc6948339bb302d32fa073ae928976b) Add support for HPC port forwarding
* Prevent GC from schedule itself with 0 period. ([#10102](https://github.com/containerd/containerd/pull/10102))
  * [`5c15bf406`](https://github.com/containerd/containerd/commit/5c15bf406da3a40d19ba89c7cd90080047d3793e) Prevent GC from schedule itself with 0 period.
* Include userns info in cri/server PodSandboxStatus ([#9865](https://github.com/containerd/containerd/pull/9865))
  * [`b57dc9fd3`](https://github.com/containerd/containerd/commit/b57dc9fd3690f1bd3b11b96dbf17e1a1bd3476e8) cri/server: Add userns tests in PodSandboxStatus
  * [`6e809ef13`](https://github.com/containerd/containerd/commit/6e809ef13a60c2233ec7e3566228b8a37e67968e) cri: Expose userns in PodSandboxStatus rpc
* mod: bump github.com/containerd/nri@v0.6.1 ([#10097](https://github.com/containerd/containerd/pull/10097))
  * [`395a31901`](https://github.com/containerd/containerd/commit/395a31901512bea37d381decbd37da620bb44c66) mod: bump github.com/containerd/nri@v0.6.1
* fix bug that using invalid token to retry fetching layer ([#10065](https://github.com/containerd/containerd/pull/10065))
  * [`f61de0864`](https://github.com/containerd/containerd/commit/f61de08644b73e7836ac46234b3f6283fc9715dd) fix bug that using invalid token to retry fetching layer
* Bump tags.cncf.io/container-device-interface to v0.7.2 ([#10077](https://github.com/containerd/containerd/pull/10077))
  * [`7a2f49f70`](https://github.com/containerd/containerd/commit/7a2f49f70f1d2cacfededbbf65452d481476bc10) Bump tags.cncf.io/container-device-interface to v0.7.2
* backport: fix default working directory `hostProcess` ([#10071](https://github.com/containerd/containerd/pull/10071))
  * [`989f1ec54`](https://github.com/containerd/containerd/commit/989f1ec54f6764020447b03020b97592312c5f85) fix default working directory `hostProcess`
* fix(cri): fix unexpected order of mounts since go 1.19 ([#10063](https://github.com/containerd/containerd/pull/10063))
  * [`9f774e438`](https://github.com/containerd/containerd/commit/9f774e438b9d96a901adb11e580fa03c6264f667) fix(cri): fix unexpected order of mounts since go 1.19
* Automatically decompress archives for transfer service import ([#9989](https://github.com/containerd/containerd/pull/9989))
  * [`2aec52493`](https://github.com/containerd/containerd/commit/2aec52493f3d67b0fd55a2348b69dd831253933f) Automatically decompress archives for transfer service import
* Use different containerd sock address in tests ([#10056](https://github.com/containerd/containerd/pull/10056))
  * [`8c76e7948`](https://github.com/containerd/containerd/commit/8c76e794820b4923c2a4dd1ccb7f7c89031b7d08) Use different containerd sock address in tests
* remote: Fix HTTPFallback fails when pushing manifest ([#10044](https://github.com/containerd/containerd/pull/10044))
  * [`18f4ad5ee`](https://github.com/containerd/containerd/commit/18f4ad5ee0cb65fa99df752e2ce7d4728b19f9f0) remote: Fix HTTPFallback fails when pushing manifest
* Add support for configuring otel from env and config deprecation notice ([#9992](https://github.com/containerd/containerd/pull/9992))
  * [`600ba8612`](https://github.com/containerd/containerd/commit/600ba86122b0a6c5428429097e3e0f82e9b1f121) vendor: revendor OTEL
  * [`9360e3716`](https://github.com/containerd/containerd/commit/9360e37169f2ba3135f7a6f39a3ab7c9231abbd6) Changes to configuring otel from env only
  * [`f2354894f`](https://github.com/containerd/containerd/commit/f2354894f311b0c9c3651ea239b7cdbc1ee05a18) Deprecate otel configs
* Add IsNotFound case to ListPodSandboxStats ([#10042](https://github.com/containerd/containerd/pull/10042))
  * [`90c309fe2`](https://github.com/containerd/containerd/commit/90c309fe2f6fac7cc620467edf2eeb8b19211067) Add IsNotFound case to ListPodSandboxStats
</p>
</details>

### Changes from containerd/nri
<details><summary>5 commits</summary>
<p>

* Fix deadlock during NRI plugin registration ([containerd/nri#79](https://github.com/containerd/nri/pull/79))
  * [`c4893c7`](https://github.com/containerd/nri/commit/c4893c7e31c35f1b056b5462cb135a9c15f8b8f4) Fix deadlock during NRI plugin registration
* go.mod: github.com/containerd/ttrpc v1.2.3 ([containerd/nri#71](https://github.com/containerd/nri/pull/71))
  * [`02a1d5e`](https://github.com/containerd/nri/commit/02a1d5e23409a3f14efaadc940cf68d37c562272) go.mod: github.com/containerd/ttrpc v1.2.3
  * [`eb3edc4`](https://github.com/containerd/nri/commit/eb3edc4fc0cec888369d0b1c8a254e0f1e19bd77) examples: go mod tidy
</p>
</details>

### Dependency Changes

* **github.com/containerd/nri**                         v0.6.0 -> v0.6.1
* **tags.cncf.io/container-device-interface**           v0.6.2 -> v0.7.2
* **tags.cncf.io/container-device-interface/specs-go**  v0.6.0 -> v0.7.0

Previous release can be found at [v1.7.15](https://github.com/containerd/containerd/releases/tag/v1.7.15)
