### PR TITLE
[release/1.6] Fix CRI snapshotter root path when not under containerd root

### DIFF
--- a/pkg/cri/cri.go
+++ b/pkg/cri/cri.go
@@ -55,6 +55,7 @@ func init() {
 			plugin.EventPlugin,
 			plugin.ServicePlugin,
 			plugin.WarningPlugin,
+			plugin.SnapshotPlugin,
 		},
 		InitFn: initCRIService,
 	})

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -92,6 +92,10 @@ const (
 	DeprecationsPlugin = "deprecations"
 )
 
+const (
+	SnapshotterRootDir = "root"
+)
+
 // Registration contains information for registering a plugin
 type Registration struct {
 	// Type of the plugin

--- a/services/server/config/config.go
+++ b/services/server/config/config.go
@@ -164,8 +164,9 @@ type CgroupConfig struct {
 
 // ProxyPlugin provides a proxy plugin configuration
 type ProxyPlugin struct {
-	Type    string `toml:"type"`
-	Address string `toml:"address"`
+	Type     string `toml:"type"`
+	Address  string `toml:"address"`
+	Platform string `toml:"platform"`
 }
 
 // BoltConfig defines the configuration values for the bolt plugin, which is

--- a/services/server/config/config.go
+++ b/services/server/config/config.go
@@ -164,9 +164,10 @@ type CgroupConfig struct {
 
 // ProxyPlugin provides a proxy plugin configuration
 type ProxyPlugin struct {
-	Type     string `toml:"type"`
-	Address  string `toml:"address"`
-	Platform string `toml:"platform"`
+	Type     string            `toml:"type"`
+	Address  string            `toml:"address"`
+	Platform string            `toml:"platform"`
+	Exports  map[string]string `toml:"exports"`
 }
 
 // BoltConfig defines the configuration values for the bolt plugin, which is

--- a/services/server/server.go
+++ b/services/server/server.go
@@ -39,6 +39,7 @@ import (
 	metrics "github.com/docker/go-metrics"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	bolt "go.etcd.io/bbolt"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
@@ -59,6 +60,7 @@ import (
 	"github.com/containerd/containerd/pkg/deprecation"
 	"github.com/containerd/containerd/pkg/dialer"
 	"github.com/containerd/containerd/pkg/timeout"
+	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/plugin"
 	srvconfig "github.com/containerd/containerd/services/server/config"
 	"github.com/containerd/containerd/services/warning"
@@ -549,6 +551,8 @@ func LoadPlugins(ctx context.Context, config *srvconfig.Config) ([]*plugin.Regis
 			f func(*grpc.ClientConn) interface{}
 
 			address = pp.Address
+			p       v1.Platform
+			err     error
 		)
 
 		switch pp.Type {
@@ -567,12 +571,21 @@ func LoadPlugins(ctx context.Context, config *srvconfig.Config) ([]*plugin.Regis
 		default:
 			log.G(ctx).WithField("type", pp.Type).Warn("unknown proxy plugin type")
 		}
+		if pp.Platform != "" {
+			p, err = platforms.Parse(pp.Platform)
+			if err != nil {
+				log.G(ctx).WithError(err).WithField("plugin", name).Warn("skipping proxy platform with bad platform")
+			}
+		} else {
+			p = platforms.DefaultSpec()
+		}
 
 		plugin.Register(&plugin.Registration{
 			Type: t,
 			ID:   name,
 			InitFn: func(ic *plugin.InitContext) (interface{}, error) {
 				ic.Meta.Exports["address"] = address
+				ic.Meta.Platforms = append(ic.Meta.Platforms, p)
 				conn, err := clients.getClient(address)
 				if err != nil {
 					return nil, err

--- a/services/server/server.go
+++ b/services/server/server.go
@@ -580,11 +580,17 @@ func LoadPlugins(ctx context.Context, config *srvconfig.Config) ([]*plugin.Regis
 			p = platforms.DefaultSpec()
 		}
 
+		exports := pp.Exports
+		if exports == nil {
+			exports = map[string]string{}
+		}
+		exports["address"] = address
+
 		plugin.Register(&plugin.Registration{
 			Type: t,
 			ID:   name,
 			InitFn: func(ic *plugin.InitContext) (interface{}, error) {
-				ic.Meta.Exports["address"] = address
+				ic.Meta.Exports = exports
 				ic.Meta.Platforms = append(ic.Meta.Platforms, p)
 				conn, err := clients.getClient(address)
 				if err != nil {

--- a/snapshots/btrfs/plugin/plugin.go
+++ b/snapshots/btrfs/plugin/plugin.go
@@ -53,7 +53,7 @@ func init() {
 				root = config.RootPath
 			}
 
-			ic.Meta.Exports = map[string]string{"root": root}
+			ic.Meta.Exports[plugin.SnapshotterRootDir] = root
 			return btrfs.NewSnapshotter(root)
 		},
 	})

--- a/snapshots/devmapper/plugin/plugin.go
+++ b/snapshots/devmapper/plugin/plugin.go
@@ -48,6 +48,7 @@ func init() {
 				config.RootPath = ic.Root
 			}
 
+			ic.Meta.Exports[plugin.SnapshotterRootDir] = config.RootPath
 			return devmapper.NewSnapshotter(ic.Context, config)
 		},
 	})

--- a/snapshots/native/plugin/plugin.go
+++ b/snapshots/native/plugin/plugin.go
@@ -48,6 +48,7 @@ func init() {
 				root = config.RootPath
 			}
 
+			ic.Meta.Exports[plugin.SnapshotterRootDir] = root
 			return native.NewSnapshotter(root)
 		},
 	})

--- a/snapshots/overlay/plugin/plugin.go
+++ b/snapshots/overlay/plugin/plugin.go
@@ -68,7 +68,7 @@ func init() {
 				oOpts = append(oOpts, overlay.WithMountOptions(config.MountOptions))
 			}
 
-			ic.Meta.Exports["root"] = root
+			ic.Meta.Exports[plugin.SnapshotterRootDir] = root
 			return overlay.NewSnapshotter(root, oOpts...)
 		},
 	})


### PR DESCRIPTION
Fixes https://github.com/containerd/containerd/issues/10095 in 1.6
Related to the release/1.7 backport #10096

This PR backports 4 changes:

1. https://github.com/containerd/containerd/pull/8417 - Allows proxy plugins to have platforms (not strictly necessary to fix the issue, but I thought it would be less weird to keep this than to take a newer change to ProxyPlugins without the older one)
2. https://github.com/containerd/containerd/pull/9253 - Allows proxy plugins to have exports (e.g. root)
3. https://github.com/containerd/containerd/pull/10073 - Exports root paths for a number of snapshotters that didn't already have them
4. https://github.com/containerd/containerd/pull/9216 - Uses exported root key for snapshotter root if present.

The result of this is that you can tell containerd about a remote snapshotter's root like:

```
[proxy_plugins.soci]
type = "snapshot"
address = "/run/soci-snapshotter-grpc/soci-snapshotter-grpc.sock"
[proxy_plugins.soci.exports]
root = "/var/lib/soci-snapshotter-grpc"
```

which will be correctly reported by CRI which unblocks the kubelet from enforcing ephemeral-storage limits and doing image garbage collection.