### PR TITLE
raise warning if ns is missing

### DIFF
--- a/cmd/ctr/commands/namespaces/namespaces.go
+++ b/cmd/ctr/commands/namespaces/namespaces.go
@@ -173,8 +173,10 @@ var removeCommand = &cli.Command{
 					}
 					log.G(ctx).WithError(err).Errorf("unable to delete %v", target)
 					continue
+				} else {
+					log.G(ctx).WithError(err).Warnf("namespace %v not found", target)
+					continue
 				}
-
 			}
 
 			fmt.Println(target)


### PR DESCRIPTION
Currently there's no difference in output whether ns is existed or not.
This minor pr helps improve UX.