### PR TITLE
Add Syself Autopilot to adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -58,6 +58,8 @@ including the Balena project listed below.
 
 **_[Actuated](https://actuated.dev)** - Actuated is a platform for running self-hosted CI in securely-isolated Firecracker VMs. Actuated uses containerd's image pulling facility to distribute and update the root filesystem for VMs for CI agents.
 
+**_[Syself Autopilot](https://syself.com)** - Syself Autopilot is a simplified Kubernetes platform based on Cluster API that can run on various providers. Syself Autopilot uses containerd as the default CRI runtime.
+
 **_Other Projects_** - While the above list provides a cross-section of well known uses of containerd, the simplicity and clear API layer for containerd has inspired many smaller projects around providing simple container management platforms. Several examples of building higher layer functionality on top of the containerd base have come from various containerd community participants:
  - Michael Crosby's [boss](https://github.com/crosbymichael/boss) project,
  - Evan Hazlett's [stellar](https://github.com/ehazlett/stellar) project,


### PR DESCRIPTION
Adds Syself Autopilot to adopters. Syself Autopilot is a managed kubernetes solution that uses containerd as the default CRI runtime. Added at the end since it's a commercial adopter.