### PR TITLE
Add HostsFromHostDir() to remotes/docker/config

### DIFF
--- a/core/remotes/docker/config/hosts.go
+++ b/core/remotes/docker/config/hosts.go
@@ -284,6 +284,19 @@ func HostDirFromRoot(root string) func(string) (string, error) {
 	}
 }
 
+// HostsFromHostDir returns hosts based at the given hostDir
+func HostsFromHostDir(ctx context.Context, hostDir string) ([]string, error) {
+	hostconfigs, err := loadHostDir(ctx, hostDir)
+	if err != nil {
+		return nil, err
+	}
+	var hosts []string
+	for _, h := range hostconfigs {
+		hosts = append(hosts, h.host)
+	}
+	return hosts, nil
+}
+
 // hostDirectory converts ":port" to "_port_" in directory names
 func hostDirectory(host string) string {
 	idx := strings.LastIndex(host, ":")


### PR DESCRIPTION
related: https://github.com/containerd/nerdctl/issues/2844

- `remotes/docker/config` package provides `ConfigureHosts()` and `HostDirFromRoot()` functions only.
- But, its caller cannot know the actual hosts from a host. It causes that the caller cannot call `ConfigureHosts()` method with its proper Credentials.
- If it provides `HostsFromHostDir()`, nerdctl can find the proper credential for a image.

e.g.
https://github.com/containerd/nerdctl/blob/40fe8b6211b0ec3cc200fe53512b557559701a29/pkg/imgutil/dockerconfigresolver/dockerconfigresolver.go#L116-L122

```go
		if ho.HostDir != nil {
			hosts := dockerconfig.HostsFromHostDir(ctx, refHostname)  // <- what I want to achieve.
			for _, host := hosts {
				authCreds, err := NewAuthCreds(host)
				if err != nil {
					return nil, err
				}
				if authCreds != nil {
					ho.Credentials = authCreds
					break
				}
			}
		} else {
			authCreds, err := NewAuthCreds(refHostname)
			if err != nil {
				return nil, err
			}
			ho.Credentials = authCreds
		}
```