### PR TITLE
docs: correct the typo in the documentation

### DIFF
--- a/docs/man/containerd-config.toml.5.md
+++ b/docs/man/containerd-config.toml.5.md
@@ -213,7 +213,7 @@ imports = ["/etc/containerd/runtime_*.toml", "./debug.toml"]
 
 ### Multiple Runtimes
 
-The following is an example partial configuraton with two runtimes:
+The following is an example partial configuration with two runtimes:
 
 ```toml
 [plugins]


### PR DESCRIPTION
## Description
Correct the typo in the documentation from `configuraton ` to `configuration ` 