### PR TITLE
Update ctr shim subcommand to task v3

### DIFF
--- a/cmd/ctr/commands/shim/shim.go
+++ b/cmd/ctr/commands/shim/shim.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 
 	"github.com/containerd/console"
-	"github.com/containerd/containerd/api/runtime/task/v2"
+	"github.com/containerd/containerd/api/runtime/task/v3"
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	ptypes "github.com/containerd/containerd/v2/pkg/protobuf/types"
@@ -232,7 +232,7 @@ var execCommand = &cli.Command{
 	},
 }
 
-func getTaskService(context *cli.Context) (task.TaskService, error) {
+func getTaskService(context *cli.Context) (task.TTRPCTaskService, error) {
 	id := context.String("id")
 	if id == "" {
 		return nil, fmt.Errorf("container id must be specified")
@@ -255,7 +255,7 @@ func getTaskService(context *cli.Context) (task.TaskService, error) {
 			// TODO(stevvooe): This actually leaks the connection. We were leaking it
 			// before, so may not be a huge deal.
 
-			return task.NewTaskClient(client), nil
+			return task.NewTTRPCTaskClient(client), nil
 		}
 	}
 


### PR DESCRIPTION
Fix `ctr shim` command.

The shim command is broken due to task API version upgrade.

* Before change
```
$ sudo bin/ctr shim --id test state
ctr: rpc error: code = Unimplemented desc = service containerd.task.v2.Task
```

* After change
```
$ sudo bin/ctr shim --id test state
{
    "id": "test",
    "bundle": "/run/containerd/io.containerd.runtime.v2.task/default/test",
    "pid": 285466,
    "status": 2,
    "stdin": "/run/containerd/fifo/3865965001/test-stdin",
    "stdout": "/run/containerd/fifo/3865965001/test-stdout",
    "terminal": true,
    "exited_at": {
        "seconds": -62135596800
    }
}
```