### PR TITLE
Chore: Simplify some syscall error checks

### DIFF
--- a/pkg/dialer/dialer_unix.go
+++ b/pkg/dialer/dialer_unix.go
@@ -19,9 +19,9 @@
 package dialer
 
 import (
+	"errors"
 	"fmt"
 	"net"
-	"os"
 	"strings"
 	"syscall"
 	"time"
@@ -34,16 +34,7 @@ func DialAddress(address string) string {
 }
 
 func isNoent(err error) bool {
-	if err != nil {
-		if nerr, ok := err.(*net.OpError); ok {
-			if serr, ok := nerr.Err.(*os.SyscallError); ok {
-				if serr.Err == syscall.ENOENT {
-					return true
-				}
-			}
-		}
-	}
-	return false
+	return errors.Is(err, syscall.ENOENT)
 }
 
 func dialer(address string, timeout time.Duration) (net.Conn, error) {


### PR DESCRIPTION
This just replaces some type casts to check whether a few dial errors are a specific syscall with the stdlibs errors.As/errors.Is pals.