### PR TITLE
Integration: Change to grpc.NewClient

### DIFF
--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -656,9 +656,7 @@ func RawRuntimeClient() (runtime.RuntimeServiceClient, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get dialer: %w", err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	conn, err := grpc.DialContext(ctx, addr,
+	conn, err := grpc.NewClient(addr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithContextDialer(dialer),
 	)

--- a/integration/remote/remote_image.go
+++ b/integration/remote/remote_image.go
@@ -33,7 +33,6 @@ limitations under the License.
 package remote
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -62,10 +61,7 @@ func NewImageService(endpoint string, connectionTimeout time.Duration) (internal
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), connectionTimeout)
-	defer cancel()
-
-	conn, err := grpc.DialContext(ctx, addr,
+	conn, err := grpc.NewClient(addr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithContextDialer(dialer),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)),

--- a/integration/remote/remote_runtime.go
+++ b/integration/remote/remote_runtime.go
@@ -70,10 +70,8 @@ func NewRuntimeService(endpoint string, connectionTimeout time.Duration) (intern
 	if err != nil {
 		return nil, err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), connectionTimeout)
-	defer cancel()
 
-	conn, err := grpc.DialContext(ctx, addr,
+	conn, err := grpc.NewClient(addr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithContextDialer(dialer),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)),


### PR DESCRIPTION
Fun times: In grpc 1.63 `grpc.Dial` and a few of the options we use (`grpc.WithBlock`) are deprecated in favor of the no-IO variant `grpc.NewClient`. The uses in the integration tests should be easy to swap however as they don't use `grpc.WithBlock` anyways, so that's what this change aims to do. This also removes some `context.WithTimeout`'s as I don't see anywhere the context is actually used in `grpc.Dial` if you don't also specify `grpc.WithBlock` (and it's especially not used now with `grpc.NewClient` as it doesn't even take in a context).