### PR TITLE
remove go1.21.9 from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, actuated-arm64-4cpu-16gb, macos-12, windows-2019, windows-2022]
-        go-version: ["1.21.9", "1.22.2"]
+        go-version: ["1.22.2"]
         exclude:
           - os: ${{ github.repository != 'containerd/containerd' && 'actuated-arm64-4cpu-16gb' }}
     steps:


### PR DESCRIPTION
since go.mod got updated to go1.22, 1.22 is the minimum version to build containerd. even if 1.21.9 is the version present on the host, go command will build using 1.22.0 go version.

Ref: https://github.com/akhilerm/containerd/actions/runs/8967614368/job/24625463053#step:4:16, even though 1.21.9 was installed, the final binary was built using 1.22.0 (version from go.mod)