### PR TITLE
CI: bump up golangci-lint to v1.58.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: ./.github/actions/install-go
       - uses: golangci/golangci-lint-action@v5
         with:
-          version: v1.56.1
+          version: v1.58.0
           skip-cache: true
           args: --timeout=8m
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,7 +13,7 @@ linters:
     - tenv # Detects using os.Setenv instead of t.Setenv since Go 1.17
     - unconvert
     - unused
-    - vet
+    - govet
     - dupword # Checks for duplicate words in the source code
   disable:
     - errcheck
@@ -76,12 +76,13 @@ linters-settings:
   nolintlint:
     allow-unused: true
 
-run:
-  timeout: 8m
-  skip-dirs:
+  exclude-dirs:
     - api
     - cluster
     - docs
     - docs/man
     - releases
     - test # e2e scripts
+
+run:
+  timeout: 8m


### PR DESCRIPTION
golangci-lint v1.58.0: https://github.com/golangci/golangci-lint/releases/tag/v1.58.0

This also fixes the following warnings:

```
WARN [config_reader] The configuration option `run.skip-dirs` is deprecated, please use `issues.exclude-dirs`.
WARN [lintersdb] The name "vet" is deprecated. The linter has been renamed to: govet.
```