### PR TITLE
fix: modify streaming io url and add docs of sandboxer and io_type

### DIFF
--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -369,6 +369,17 @@ version = 2
       # See https://github.com/containerd/containerd/issues/6657 for context.
       snapshotter = ""
 
+      # sandboxer is the sandbox controller for the runtime.
+      # The default sandbox controller is the podsandbox controller, which create a "pause" container as a sandbox.
+      # We can create our own "shim" sandbox controller by implementing the sandbox api defined in runtime/sandbox/v1/sandbox.proto in our shim, and specifiy the sandboxer to "shim" here.
+      # We can also run a grpc or ttrpc server to serve the sandbox controller API defined in services/sandbox/v1/sandbox.proto, and define a ProxyPlugin of "sandbox" type, and specify the name of the ProxyPlugin here.
+      sandboxer = ""
+
+      # io_type is the way containerd get stdin/stdout/stderr from container or the execed process.
+      # The default value is "fifo", in which containerd will create a set of named pipes and transfer io by them.
+      # Currently the value of "streaming" is supported, in this way, sandbox should serve streaming api defined in services/streaming/v1/streaming.proto, and containerd will connect to sandbox's endpoint and create a set of streams to it, as channels to transfer io of container or process.
+      io_type = ""
+
       # 'plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options' is options specific to
       # "io.containerd.runc.v1" and "io.containerd.runc.v2". Its corresponding options type is:
       #   https://github.com/containerd/containerd/blob/v1.3.2/runtime/v2/runc/options/oci.pb.go#L26 .

--- a/internal/cri/io/container_io.go
+++ b/internal/cri/io/container_io.go
@@ -73,6 +73,17 @@ func WithNewFIFOs(root string, tty, stdin bool) ContainerIOOpts {
 }
 
 // WithStreams creates new streams for the container io.
+// The stream address is in format of `protocol://address?stream_id=xyz`.
+// It allocates ContainerID-stdin, ContainerID-stdout and ContainerID-stderr as streaming IDs.
+// For example, that advertiser address of shim is `ttrpc+unix:///run/demo.sock` and container ID is `app`.
+// There are three streams if stdin is enabled and TTY is disabled.
+//
+//   - Stdin: ttrpc+unix:///run/demo.sock?stream_id=app-stdin
+//   - Stdout: ttrpc+unix:///run/demo.sock?stream_id=app-stdout
+//   - stderr: ttrpc+unix:///run/demo.sock?stream_id=app-stderr
+//
+// The streaming IDs will be used as unique key to establish stream tunnel.
+// And it should support reconnection with the same streaming ID if containerd restarts.
 func WithStreams(address string, tty, stdin bool) ContainerIOOpts {
 	return func(c *ContainerIO) error {
 		if address == "" {

--- a/internal/cri/io/exec_io.go
+++ b/internal/cri/io/exec_io.go
@@ -55,6 +55,17 @@ func NewFifoExecIO(id, root string, tty, stdin bool) (*ExecIO, error) {
 }
 
 // NewStreamExecIO creates exec io with streaming.
+// The stream address is in format of `protocol://address?stream_id=xyz`.
+// It allocates ExecID-stdin, ExecID-stdout and ExecID-stderr as streaming IDs.
+// For example, that advertiser address of shim is `ttrpc+unix:///run/demo.sock` and exec ID is `app`.
+// There are three streams if stdin is enabled and TTY is disabled.
+//
+//   - Stdin: ttrpc+unix:///run/demo.sock?stream_id=app-stdin
+//   - Stdout: ttrpc+unix:///run/demo.sock?stream_id=app-stdout
+//   - stderr: ttrpc+unix:///run/demo.sock?stream_id=app-stderr
+//
+// The streaming IDs will be used as unique key to establish stream tunnel.
+// And it should support reconnection with the same streaming ID if containerd restarts.
 func NewStreamExecIO(id, address string, tty, stdin bool) (*ExecIO, error) {
 	fifos, err := newStreams(address, id, tty, stdin)
 	if err != nil {


### PR DESCRIPTION
sandbox address should be in the form of
<ttrpc|grpc>+<unix|vsock|hvsock>://<uds-path|vsock-cid:vsock-port|uds-path:hvsock-port> 
for example: ttrpc+hvsock:///run/test.hvsock:1024
or: grpc+vsock://1111111:1024
and the Stdin/Stdout/Stderr will add a `streaming_id` as a parameter of the url result form is:
<ttrpc|grpc>+<unix|vsock|hvsock>://<uds-path|vsock-cid:vsock-port|uds-path:hvsock-port>?streaming_id=<stream-id> for example ttrpc+hvsock:///run/test.hvsock:1024?streaming_id=111111 or grpc+vsock://1111111:1024?streaming_id=222222

Change the current logic of add a `streaming` in the path, because unix domain socket or hybrid vsock alread have the path field and add a `streaming` suffix makes the logic complecated.

