### PR TITLE
Don't require vagrant tests in merge queues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -632,7 +632,7 @@ jobs:
     name: Report required job statuses
     runs-on: ubuntu-latest
     # List job dependencies which are required to pass status checks in order to be merged via merge queue.
-    needs: [linters, project, protos, binaries, integration-linux, integration-windows, integration-vagrant, tests-cri-in-userns, tests-mac-os]
+    needs: [linters, project, protos, binaries, integration-linux, integration-windows, tests-cri-in-userns, tests-mac-os]
     if: ${{ always() }}
     steps:
       - run: exit 1


### PR DESCRIPTION
We have a few jobs on CI that are quite flaky lately (examples [1](https://github.com/containerd/containerd/pull/10075), [2](https://github.com/containerd/containerd/pull/10151)), which makes merging PR particularly challenging:

<img width="885" alt="image" src="https://github.com/containerd/containerd/assets/865334/dbc290eb-ac06-4782-937c-378758e01935">

Since we run full suite of tests in each PR anyway, I think we could ease merge queue requirements a bit and remove vagrants tests for now.

