### PR TITLE
Support sparsefiles Copy in blockfile snapshotter

### DIFF
--- a/plugins/snapshots/blockfile/plugin/plugin.go
+++ b/plugins/snapshots/blockfile/plugin/plugin.go
@@ -43,6 +43,9 @@ type Config struct {
 	// RecreateScratch always recreates the specified `ScratchFile`
 	// on initialization of the plugin instead of using an existing.
 	RecreateScratch bool `toml:"recreate_scratch"`
+
+	// CopySparse create sparse files when copy when is 'false'
+	CopySparse bool `toml:"copy_sparse"`
 }
 
 func init() {
@@ -73,6 +76,7 @@ func init() {
 				opts = append(opts, blockfile.WithMountOptions(config.MountOptions))
 			}
 			opts = append(opts, blockfile.WithRecreateScratch(config.RecreateScratch))
+			opts = append(opts, blockfile.WithCopySparse(config.CopySparse))
 
 			ic.Meta.Exports[plugins.SnapshotterRootDir] = root
 			return blockfile.NewSnapshotter(root, opts...)


### PR DESCRIPTION
Adds the ability to copy sparse files and can be configured in the config.

In the Go language, `io.Copy` is equivalent to `cp --sparse=never xxx`, so sparse files copy are not currently supported. Each layer file will occupy the full block file size by default.

