### PR TITLE
sandbox: do retry for wait to remote sandbox controller

### DIFF
--- a/internal/cri/server/events.go
+++ b/internal/cri/server/events.go
@@ -53,7 +53,7 @@ func (c *criService) startSandboxExitMonitor(ctx context.Context, id string, exi
 		case exitRes := <-exitCh:
 			exitStatus, exitedAt, err := exitRes.Result()
 			if err != nil {
-				log.L.WithError(err).Errorf("failed to get task exit status for %q", id)
+				log.L.WithError(err).Errorf("failed to get sandbox status for %q", id)
 				exitStatus = unknownExitCode
 				exitedAt = time.Now()
 			}


### PR DESCRIPTION
For remote sandbox controllers, the controller process may restart, we have to retry if the error indicates that it is the grpc disconnection.