### PR TITLE
Unpack fetch all

### DIFF
--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -106,20 +106,20 @@ command. As part of this process, we do the following:
 			}
 
 			var sopts []image.StoreOpt
+			p, err := platforms.ParseAll(context.StringSlice("platform"))
+			if err != nil {
+				return err
+			}
+
+			// Set unpack configuration
+			for _, platform := range p {
+				sopts = append(sopts, image.WithUnpack(platform, context.String("snapshotter")))
+			}
 			if !context.Bool("all-platforms") {
-				p, err := platforms.ParseAll(context.StringSlice("platform"))
-				if err != nil {
-					return err
-				}
 				if len(p) == 0 {
 					p = append(p, platforms.DefaultSpec())
 				}
 				sopts = append(sopts, image.WithPlatforms(p...))
-
-				// Set unpack configuration
-				for _, platform := range p {
-					sopts = append(sopts, image.WithUnpack(platform, context.String("snapshotter")))
-				}
 			}
 			// TODO: Support unpack for all platforms..?
 			// Pass in a *?

--- a/core/unpack/unpacker.go
+++ b/core/unpack/unpacker.go
@@ -262,7 +262,8 @@ func (u *Unpacker) unpack(
 	}
 
 	if unpack == nil {
-		return fmt.Errorf("unpacker does not support platform %s for image %s", imgPlatform, config.Digest)
+		log.G(ctx).WithField("image", config.Digest).WithField("platform", platforms.Format(imgPlatform)).Debugf("unpacker does not support platform, only fetching layers")
+		return u.fetch(ctx, h, layers, nil)
 	}
 
 	atomic.AddInt32(&u.unpacks, 1)
@@ -460,12 +461,18 @@ func (u *Unpacker) fetch(ctx context.Context, h images.Handler, layers []ocispec
 			tracing.Attribute("layer.media.digest", desc.Digest.String()),
 		)
 		desc := desc
-		i := i
+		var ch chan struct{}
+		if done != nil {
+			ch = done[i]
+		}
+
 		if err := u.acquire(ctx); err != nil {
 			return err
 		}
 
 		eg.Go(func() error {
+			defer layerSpan.End()
+
 			unlock, err := u.lockBlobDescriptor(ctx2, desc)
 			if err != nil {
 				u.release()
@@ -480,11 +487,12 @@ func (u *Unpacker) fetch(ctx context.Context, h images.Handler, layers []ocispec
 			if err != nil && !errors.Is(err, images.ErrSkipDesc) {
 				return err
 			}
-			close(done[i])
+			if ch != nil {
+				close(ch)
+			}
 
 			return nil
 		})
-		layerSpan.End()
 	}
 
 	return eg.Wait()


### PR DESCRIPTION
When a set of layers are provided to the unpacker, then the unpacker should still fetch them regardless of whether they will be used for unpack. The image handler filters are responsible for removing content which is not intended to be fetched. Currently there is no way to use an unpacker and also fetch all platforms.

Now that we have a more expressive unpacker configuration, we could update the ctr options to be clearer.