### PR TITLE
[release/1.7] Use LOOP_CONFIGURE when creating loop devices

### DIFF
--- a/mount/losetup_linux.go
+++ b/mount/losetup_linux.go
@@ -35,13 +35,6 @@ const (
 	ebusyString = "device or resource busy"
 )
 
-type LoopConfig struct {
-	Fd        uint32
-	BlockSize uint32
-	Info      unix.LoopInfo64
-	Reserved  [8]uint64
-}
-
 // LoopParams parameters to control loop device setup
 type LoopParams struct {
 	// Loop device should forbid write

--- a/mount/losetup_linux.go
+++ b/mount/losetup_linux.go
@@ -21,9 +21,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"syscall"
 	"time"
-	"unsafe"
 
 	kernel "github.com/containerd/containerd/contrib/seccomp/kernelversion"
 	"github.com/containerd/containerd/pkg/randutil"
@@ -35,8 +33,6 @@ const (
 	loopDevFormat   = "/dev/loop%d"
 
 	ebusyString = "device or resource busy"
-
-	loopConfigureIoctl = 0x4c0a
 )
 
 type LoopConfig struct {
@@ -44,15 +40,6 @@ type LoopConfig struct {
 	BlockSize uint32
 	Info      unix.LoopInfo64
 	Reserved  [8]uint64
-}
-
-func ioctlConfigure(fd int, value *LoopConfig) error {
-	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), uintptr(loopConfigureIoctl), uintptr(unsafe.Pointer(value)))
-	if err == 0 {
-		return nil
-	}
-
-	return err
 }
 
 // LoopParams parameters to control loop device setup
@@ -107,7 +94,7 @@ func setupLoopDev(backingFile, loopDev string, param LoopParams) (_ *os.File, re
 
 	fiveDotEight := kernel.KernelVersion{Kernel: 5, Major: 8}
 	if ok, err := kernel.GreaterEqualThan(fiveDotEight); err == nil && ok {
-		config := LoopConfig{
+		config := unix.LoopConfig{
 			Fd: uint32(back.Fd()),
 		}
 
@@ -124,7 +111,7 @@ func setupLoopDev(backingFile, loopDev string, param LoopParams) (_ *os.File, re
 			config.Info.Flags |= unix.LO_FLAGS_DIRECT_IO
 		}
 
-		if err := ioctlConfigure(int(loop.Fd()), &config); err != nil {
+		if err := unix.IoctlLoopConfigure(int(loop.Fd()), &config); err != nil {
 			return nil, fmt.Errorf("failed to configure loop device: %s: %w", loopDev, err)
 		}
 


### PR DESCRIPTION
### Issue
Optimization for creating loop devices on kernels >= 5.8 would be nice to have in release/1.7.

### Description
This change backports #9211 and follow on changes #9805, #9813 to release/1.7.

Signed-off-by: Austin Vazquez <macedonv@amazon.com>