### PR TITLE
cri support restart exited containers

### DIFF
--- a/internal/cri/server/container_start.go
+++ b/internal/cri/server/container_start.go
@@ -117,10 +117,14 @@ func (c *criService) StartContainer(ctx context.Context, r *runtime.StartContain
 			}
 		}
 	}()
-	if _, err := os.Stat(cntr.IO.Config().Stdin); err != nil && os.IsNotExist(err) {
-		// cleanup old fifos tempdir
-		cntr.IO.Close()
-
+	if cntr.IO != nil {
+		if _, err := os.Stat(cntr.IO.Config().Stdin); err != nil && os.IsNotExist(err) {
+			// cleanup old fifos tempdir
+			cntr.IO.Close()
+			cntr.IO = nil
+		}
+	}
+	if cntr.IO == nil {
 		cntr.IO = containerIO
 		// update container IO into container store
 		// OR, tempdir for fifos will be remained when handleContainerExit

--- a/internal/cri/server/container_start_test.go
+++ b/internal/cri/server/container_start_test.go
@@ -56,7 +56,7 @@ func TestSetContainerStarting(t *testing.T) {
 				StartedAt:  time.Now().UnixNano(),
 				FinishedAt: time.Now().UnixNano(),
 			},
-			expectErr: true,
+			expectErr: false,
 		},
 		{
 			desc: "should return error when container is in unknown state",

--- a/internal/cri/store/container/container.go
+++ b/internal/cri/store/container/container.go
@@ -211,3 +211,26 @@ func (s *Store) Delete(id string) {
 	s.idIndex.Delete(id)
 	delete(s.containers, id)
 }
+
+// UpdateContainerIO update container IO
+// useful when using StartContainer
+func (s *Store) UpdateContainerIO(id string, io *cio.ContainerIO) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	id, err := s.idIndex.Get(id)
+	if err != nil {
+		if err == truncindex.ErrNotExist {
+			err = errdefs.ErrNotFound
+		}
+		return err
+	}
+
+	if _, ok := s.containers[id]; !ok {
+		return errdefs.ErrNotFound
+	}
+
+	c := s.containers[id]
+	c.IO = io
+	s.containers[id] = c
+	return nil
+}


### PR DESCRIPTION

![image](https://github.com/containerd/containerd/assets/13235242/65248d96-0614-4cef-a012-f4de72135ced)

In production environment, users may want to restart containers, those in the Exited state, instead of creating new containers. Docker can do it.