### PR TITLE
ci: enable ubuntu-24 runners

### DIFF
--- a/.github/workflows/api-release.yml
+++ b/.github/workflows/api-release.yml
@@ -15,7 +15,7 @@ jobs:
   check:
     name: Check Signed Tag
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/api/v')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
       stringver: ${{ steps.contentrel.outputs.stringver }}
@@ -60,7 +60,7 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/api/v')
     permissions:
       contents: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: [check]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, actuated-arm64-4cpu-16gb, macos-12, windows-2019]
+        os: [ubuntu-24.04, actuated-arm64-4cpu-16gb, macos-12, windows-2019]
         exclude:
           - os: ${{ github.repository != 'containerd/containerd' && 'actuated-arm64-4cpu-16gb' }}
 
@@ -42,7 +42,7 @@ jobs:
   #
   project:
     name: Project Checks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
 
     steps:
@@ -70,7 +70,7 @@ jobs:
   #
   protos:
     name: Protobuf
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
 
     defaults:
@@ -104,7 +104,7 @@ jobs:
 
   man:
     name: Manpages
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
 
     steps:
@@ -118,7 +118,7 @@ jobs:
   crossbuild:
     name: Crossbuild Binaries
     needs: [project, linters, protos, man]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -190,7 +190,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, actuated-arm64-4cpu-16gb, macos-12, windows-2019, windows-2022]
+        os: [ubuntu-22.04, ubuntu-24.04, actuated-arm64-4cpu-16gb, macos-12, windows-2019, windows-2022]
         go-version: ["1.22.4"]
         exclude:
           - os: ${{ github.repository != 'containerd/containerd' && 'actuated-arm64-4cpu-16gb' }}
@@ -385,7 +385,7 @@ jobs:
         runtime:
           - io.containerd.runc.v2
         runc: [runc, crun]
-        os: [ubuntu-22.04, actuated-arm64-4cpu-16gb]
+        os: [ubuntu-22.04, ubuntu-24.04, actuated-arm64-4cpu-16gb]
         exclude:
           - os: ${{ github.repository != 'containerd/containerd' && 'actuated-arm64-4cpu-16gb' }}
 
@@ -519,7 +519,7 @@ jobs:
 
   integration-vagrant:
     name: Vagrant integration
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     needs: [project, linters, protos, man]
 
@@ -575,7 +575,7 @@ jobs:
   tests-cri-in-userns:
     name: "CRI-in-UserNS"
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     needs: [project, linters, protos, man]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,13 +555,21 @@ jobs:
           # Canonical's Vagrant 2.2.19 dpkg cannot download Fedora 38 image: https://bugs.launchpad.net/vagrant/+bug/2017828
           # So we have to install Vagrant >= 2.3.1 from the upstream: https://github.com/opencontainers/runc/blob/v1.1.8/.cirrus.yml#L41-L49
           curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
-          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com jammy main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
           sudo sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
+          # we use vagrant from jammy since the sources are not yet available in noble
+          sudo tee -a /etc/apt/sources.list.d/ubuntu.sources <<EOF
+          Types: deb deb-src
+          URIs: http://in.archive.ubuntu.com/ubuntu
+          Suites: jammy
+          Components: main restricted universe multiverse
+          Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+          EOF
           sudo apt-get update
           sudo apt-get install -y libvirt-daemon libvirt-daemon-system vagrant
           sudo systemctl enable --now libvirtd
           sudo apt-get build-dep -y vagrant ruby-libvirt
-          sudo apt-get install -y --no-install-recommends libxslt-dev libxml2-dev libvirt-dev ruby-bundler ruby-dev zlib1g-dev
+          sudo apt-get install -y --no-install-recommends libxslt-dev libxml2-dev libvirt-dev ruby-bundler ruby-dev zlib1g-dev ovmf
           sudo vagrant plugin install vagrant-libvirt
       - name: Boot VM
         run: sudo BOX=$BOX vagrant up --no-tty

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,7 +556,7 @@ jobs:
           # So we have to install Vagrant >= 2.3.1 from the upstream: https://github.com/opencontainers/runc/blob/v1.1.8/.cirrus.yml#L41-L49
           curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
           echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-          sudo sed -i 's/^# deb-src/deb-src/' /etc/apt/sources.list
+          sudo sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
           sudo apt-get update
           sudo apt-get install -y libvirt-daemon libvirt-daemon-system vagrant
           sudo systemctl enable --now libvirtd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -557,19 +557,29 @@ jobs:
           curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
           echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com jammy main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
           sudo sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
-          # we use vagrant from jammy since the sources are not yet available in noble
+          # we use vagrant from jammy since the sources are not yet available in noble for vagrant
+          # TODO: once vagrant package sources are available in ubuntu-24 this can be removed
           sudo tee -a /etc/apt/sources.list.d/ubuntu.sources <<EOF
           Types: deb deb-src
-          URIs: http://in.archive.ubuntu.com/ubuntu
+          URIs: http://archive.ubuntu.com/ubuntu
           Suites: jammy
           Components: main restricted universe multiverse
           Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
           EOF
+          echo "" | sudo tee -a /etc/apt/sources.list.d/ubuntu.sources > /dev/null
+          # jammy security needs to be added so that the compatible ovmf package can be fetched
+          sudo tee -a /etc/apt/sources.list.d/ubuntu.sources <<EOF
+          Types: deb deb-src
+          URIs: http://security.archive.ubuntu.com/ubuntu
+          Suites: jammy-security
+          Components: main restricted universe multiverse
+          Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+          EOF
           sudo apt-get update
-          sudo apt-get install -y libvirt-daemon libvirt-daemon-system vagrant
+          sudo apt-get install -y libvirt-daemon libvirt-daemon-system vagrant ovmf=2022.02-3ubuntu0.22.04.2
           sudo systemctl enable --now libvirtd
           sudo apt-get build-dep -y vagrant ruby-libvirt
-          sudo apt-get install -y --no-install-recommends libxslt-dev libxml2-dev libvirt-dev ruby-bundler ruby-dev zlib1g-dev ovmf
+          sudo apt-get install -y --no-install-recommends libxslt-dev libxml2-dev libvirt-dev ruby-bundler ruby-dev zlib1g-dev
           sudo vagrant plugin install vagrant-libvirt
       - name: Boot VM
         run: sudo BOX=$BOX vagrant up --no-tty

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
   check:
     name: Check Signed Tag
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
       stringver: ${{ steps.contentrel.outputs.stringver }}
@@ -137,7 +137,7 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: [build, check]
     steps:

--- a/plugins/snapshots/devmapper/snapshotter_test.go
+++ b/plugins/snapshots/devmapper/snapshotter_test.go
@@ -145,9 +145,10 @@ func TestMultipleXfsMounts(t *testing.T) {
 
 	poolName := fmt.Sprintf("containerd-snapshotter-suite-pool-%d", time.Now().Nanosecond())
 	config := &Config{
-		RootPath:       t.TempDir(),
-		PoolName:       poolName,
-		BaseImageSize:  "16Mb",
+		RootPath: t.TempDir(),
+		PoolName: poolName,
+		// Size for xfs volume is kept at 300Mb because xfsprogs 5.19.0 (>=ubuntu 24.04) enforces a minimum volume size
+		BaseImageSize:  "300Mb",
 		FileSystemType: "xfs",
 	}
 	snapshotter, closer, err := createSnapshotter(ctx, t, config)


### PR DESCRIPTION
- add ubuntu-24 github action runners into the test matrix
- all runners have been updated to ubuntu-24 except the job where release binaries are built. Its still kept at ubuntu-20 for maintaining compatibility


Notes to reviewers:
- The vagrant and ovmf package used is still kept at the ubuntu-22 versions since the vagrant sources are not yet available in the ubuntu-24 repository. 
- The ovmf package is pinned at an older version because newer packages will cause the boot to fail for the VM.  Ref: https://changelogs.ubuntu.com/changelogs/pool/main/e/edk2/edk2_2024.02-2/changelog

```
.
edk2 (2023.11-2) unstable; urgency=medium

  * ovmf: Remove dangling symlink to removed 2M image:
    - /usr/share/OVMF/OVMF_CODE.ms.fd
.
```