### PR TITLE
Update instrumentation fuzzer with new flag

### DIFF
--- a/contrib/fuzz/oss_fuzz_build.sh
+++ b/contrib/fuzz/oss_fuzz_build.sh
@@ -39,7 +39,7 @@ compile_fuzzers() {
 
 # This is from https://github.com/AdamKorcz/instrumentation
 cd $SRC/instrumentation
-go run main.go $SRC/containerd/images
+go run main.go --target_dir $SRC/containerd/images
 
 apt-get update && apt-get install -y wget
 cd $SRC


### PR DESCRIPTION
Related to switching from AdamKorcz/instrumentation@dev to main branch; this change is required to make the switch and pass CI in google/oss-fuzz: https://github.com/google/oss-fuzz/pull/11953