### PR TITLE
auth: add span to FetchToken helpers

### DIFF
--- a/core/remotes/docker/auth/fetch.go
+++ b/core/remotes/docker/auth/fetch.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	remoteserrors "github.com/containerd/containerd/v2/core/remotes/errors"
+	"github.com/containerd/containerd/v2/pkg/tracing"
 	"github.com/containerd/containerd/v2/version"
 	"github.com/containerd/log"
 )
@@ -95,6 +96,10 @@ type OAuthTokenResponse struct {
 
 // FetchTokenWithOAuth fetches a token using a POST request
 func FetchTokenWithOAuth(ctx context.Context, client *http.Client, headers http.Header, clientID string, to TokenOptions) (*OAuthTokenResponse, error) {
+	c := *client
+	client = &c
+	tracing.UpdateHTTPClient(client, tracing.Name("remotes.docker.resolver", "FetchTokenWithOAuth"))
+
 	form := url.Values{}
 	if len(to.Scopes) > 0 {
 		form.Set("scope", strings.Join(to.Scopes, " "))
@@ -161,6 +166,10 @@ type FetchTokenResponse struct {
 
 // FetchToken fetches a token using a GET request
 func FetchToken(ctx context.Context, client *http.Client, headers http.Header, to TokenOptions) (*FetchTokenResponse, error) {
+	c := *client
+	client = &c
+	tracing.UpdateHTTPClient(client, tracing.Name("remotes.docker.resolver", "FetchToken"))
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, to.Realm, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Before this, during a call to the docker resolver, we would generate span wrappers for each HTTPRequest correctly, however, as the docker resolver reaches out to the docker authorizer, it could create HTTP requests (for fetching tokens) that would not be wrapped in any span.

This can result in rather confusing traces, e.g. something like:

	remotes.docker.resolver.HTTPRequest
		HTTP HEAD (fetch index, fails with 401)
	HTTP GET (fetch token)
	remotes.docker.resolver.HTTPRequest
		HTTP HEAD (fetch index)
	remotes.docker.resolver.HTTPRequest
		HTTP GET (fetch manifest)

By adding a span into the FetchToken, this trace becomes a little easier to consume:

	remotes.docker.resolver.HTTPRequest
		HTTP HEAD (fetch index, fails with 401)
	remotes.docker.resolver.FetchToken
		HTTP GET (fetch token)
	remotes.docker.resolver.HTTPRequest
		HTTP HEAD (fetch index)
	remotes.docker.resolver.HTTPRequest
		HTTP GET (fetch manifest)

I *think* this is the right kind of approach for this. However, maybe it makes more sense to add this in the `authHandler` instead? Happy to discuss :tada: