### PR TITLE
[release/1.7] Unpack fetch all

### DIFF
--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -100,24 +100,25 @@ command. As part of this process, we do the following:
 			}
 
 			var sopts []image.StoreOpt
-			if !context.Bool("all-platforms") {
-				var p []ocispec.Platform
-				for _, s := range context.StringSlice("platform") {
-					ps, err := platforms.Parse(s)
-					if err != nil {
-						return fmt.Errorf("unable to parse platform %s: %w", s, err)
-					}
-					p = append(p, ps)
+
+			var p []ocispec.Platform
+			for _, s := range context.StringSlice("platform") {
+				ps, err := platforms.Parse(s)
+				if err != nil {
+					return fmt.Errorf("unable to parse platform %s: %w", s, err)
 				}
+				p = append(p, ps)
+			}
+
+			// Set unpack configuration
+			for _, platform := range p {
+				sopts = append(sopts, image.WithUnpack(platform, context.String("snapshotter")))
+			}
+			if !context.Bool("all-platforms") {
 				if len(p) == 0 {
 					p = append(p, platforms.DefaultSpec())
 				}
 				sopts = append(sopts, image.WithPlatforms(p...))
-
-				// Set unpack configuration
-				for _, platform := range p {
-					sopts = append(sopts, image.WithUnpack(platform, context.String("snapshotter")))
-				}
 			}
 			// TODO: Support unpack for all platforms..?
 			// Pass in a *?


### PR DESCRIPTION
When a set of layers are provided to the unpacker, then the unpacker should still fetch them regardless of whether they will be used for unpack. The image handler filters are responsible for removing content which is not intended to be fetched. Currently there is no way to use an unpacker and also fetch all platforms.

This fixes an issues where the transfer service pull could error out if specifying all platforms but only providing an unpack configuration for a subset.

Backports #10202