### PR TITLE
[release/1.6] Handle unsupported config versions

### DIFF
--- a/services/server/config/config.go
+++ b/services/server/config/config.go
@@ -99,9 +99,15 @@ func (c *Config) GetVersion() int {
 func (c *Config) ValidateV2() error {
 	version := c.GetVersion()
 	if version < 2 {
-		logrus.Warnf("containerd config version `%d` has been deprecated and will be removed in containerd v2.0, please switch to version `2`, "+
-			"see https://github.com/containerd/containerd/blob/main/docs/PLUGINS.md#version-header", version)
+		logrus.Warnf("containerd config version `%d` has been deprecated and will be converted on each startup in containerd v2.0, "+
+			"use `containerd config migrate` after upgrading to containerd 2.0 to avoid conversion on startup", version)
 		return nil
+	}
+	if version > 2 {
+		logrus.Errorf("containerd config version `%d` is not supported, the max version is `2`, "+
+			"use `containerd config default` to generate a new config or manually revert to version `2`", version)
+		return fmt.Errorf("unsupported config version `%d`", version)
+
 	}
 	for _, p := range c.DisabledPlugins {
 		if len(strings.Split(p, ".")) < 4 {


### PR DESCRIPTION
Once 2.0 is released, the config version is bumped to 3 which is backwards incompatible with version 2. While we do not need to handle version 3 in 1.6 and 1.7 release, we should error out if the config version is higher than the max supported version. This will provide a clear error when an unsupported config version is used rather have containerd subtly error or use an unexpected configuration.

Backport of #10165