### PR TITLE
[release/1.7] Prepare release notes for v1.7.17

### DIFF
--- a/releases/v1.7.17.toml
+++ b/releases/v1.7.17.toml
@@ -1,0 +1,26 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.7.16"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The seventeenth patch release for containerd 1.7 contains various fixes and updates.
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.7.16+unknown"
+	Version = "1.7.17+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated release notes

----

Welcome to the v1.7.17 release of containerd!

The seventeenth patch release for containerd 1.7 contains various fixes and updates.

### Highlights

* Use LOOP_CONFIGURE when creating loop devices ([#10209](https://github.com/containerd/containerd/pull/10209))
* Update unpacker to fetch all provided content ([#10233](https://github.com/containerd/containerd/pull/10233))
* Preserve CL_UNPRIVILEGED locked flags during remount of bind mounts ([#10210](https://github.com/containerd/containerd/pull/10210))
* Update metadata snapshotter to lease on already exists ([#10198](https://github.com/containerd/containerd/pull/10198))
* Handle unsupported config versions ([#10165](https://github.com/containerd/containerd/pull/10165))
* Fix deadlock when writing to pipe blocks ([containerd/ttrpc#168](https://github.com/containerd/ttrpc/pull/168))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Stefan Berger
* Derek McGowan
* Austin Vazquez
* Alexandru Matei
* Maksym Pavlenko
* Akihiro Suda
* Bryant Biggs
* Kevin Parsons
* Kirtana Ashok
* Phil Estes
* Kazuyoshi Kato
* Kohei Tokunaga
* Swagat Bora

### Changes
<details><summary>41 commits</summary>
<p>

* Use LOOP_CONFIGURE when creating loop devices ([#10209](https://github.com/containerd/containerd/pull/10209))
  * [`803aaa680`](https://github.com/containerd/containerd/commit/803aaa6801d808289e9a25a2f05fc9710b2ed39b) Remove internal LoopConfig struct
  * [`7bd3be948`](https://github.com/containerd/containerd/commit/7bd3be9487050fccc29df94bf3f9f005589121bc) Swap internal ioctl implementation with golang.org/x/sys
  * [`a0739dc0e`](https://github.com/containerd/containerd/commit/a0739dc0e800fa002b451ff425cb8aeb9f880d02) Use LOOP_CONFIGURE when creating loop devices
* Unpack fetch all ([#10233](https://github.com/containerd/containerd/pull/10233))
  * [`1573ea598`](https://github.com/containerd/containerd/commit/1573ea598e00c1b942946958ea451062557d74d7) Update ctr image pull all platforms
  * [`32b594f1b`](https://github.com/containerd/containerd/commit/32b594f1b2420fe7633802ee9a2225e9fd7e5c70) Update unpacker to always fetch all
* Update hcsshim tag to v0.11.5 ([#10232](https://github.com/containerd/containerd/pull/10232))
  * [`5a03a3aee`](https://github.com/containerd/containerd/commit/5a03a3aeee0b4be59a556ba145ebe09492812544) Update hcsshim tag to v0.11.5
* Update ttrpc tag to 1.2.4 ([#10221](https://github.com/containerd/containerd/pull/10221))
  * [`9a1eda40f`](https://github.com/containerd/containerd/commit/9a1eda40f8c7cfa1f69642bf66a50a9740fca01f) update ttrpc tag to 1.2.4
* Preserve CL_UNPRIVILEGED locked flags during remount of bind mounts ([#10210](https://github.com/containerd/containerd/pull/10210))
  * [`ad85652fa`](https://github.com/containerd/containerd/commit/ad85652fa17b405b8b6bf97756c65291e97ac5d6) Preserve CL_UNPRIVILEGED locked flags during remount of bind mounts
* Update instrumentation fuzzer with new flag ([#10229](https://github.com/containerd/containerd/pull/10229))
  * [`582f3f43d`](https://github.com/containerd/containerd/commit/582f3f43d5392132d99e6f0cc50e403b7f0d781c) Update instrumentation fuzzer with new flag
* vendor: github.com/containerd/imgcrypt@v1.1.8 ([#10215](https://github.com/containerd/containerd/pull/10215))
  * [`a5d13689b`](https://github.com/containerd/containerd/commit/a5d13689b97f62ca172636bc2360e6c9f36120e2) vendor: github.com/containerd/imgcrypt@v1.1.8
* vendor: golang.org/x/net@v0.23.0 ([#10211](https://github.com/containerd/containerd/pull/10211))
  * [`f853bc129`](https://github.com/containerd/containerd/commit/f853bc1292751ca7c5e12b9a3faa300039e21e34) vendor: golang.org/x/net@v0.23.0
  * [`837972979`](https://github.com/containerd/containerd/commit/837972979fffd6f0624b354bd68b75906ad530cc) vendor: golang.org/x/net@v0.21.0
  * [`56aa87792`](https://github.com/containerd/containerd/commit/56aa877926c7a2a4be0683bc48c05b0b65ae9c8e) vendor: golang.org/x/net@v0.20.0
  * [`4e6335ebd`](https://github.com/containerd/containerd/commit/4e6335ebdf3ba54bf89d652c326b2127dd88639f) vendor: golang.org/x/net@v0.19.0
  * [`1c6c745c6`](https://github.com/containerd/containerd/commit/1c6c745c60acf808c99644e8bafa3a8d367c076c) vendor: golang.org/x/term@v0.17.0
  * [`1077d38c9`](https://github.com/containerd/containerd/commit/1077d38c9fe83db9720e01aea253de8ff3525b3d) vendor: golang.org/x/sys@v0.18.0
* Update tooling to Go 1.21.10, 1.22.3 for net/http bug fixes ([#10207](https://github.com/containerd/containerd/pull/10207))
  * [`c53b635f9`](https://github.com/containerd/containerd/commit/c53b635f927a905ff431a51d12f42f4f5c36d959) Update toolchain to Go 1.21.10 and 1.22.3
* vendor: golang.org/x/crypto@v0.18.0 ([#10204](https://github.com/containerd/containerd/pull/10204))
  * [`4b52104f0`](https://github.com/containerd/containerd/commit/4b52104f0cfbcb4f6ad3cf4f80bc3c34919b03de) vendor: golang.org/x/crypto@v0.18.0
  * [`2f65c83b0`](https://github.com/containerd/containerd/commit/2f65c83b0b80796f7b3b30bebc5354b293c14a74) vendor: golang.org/x/term@v0.16.0
  * [`8a76171f7`](https://github.com/containerd/containerd/commit/8a76171f76de63dce2f85946fdfeb3d3f79cd2fc) vendor: golang.org/x/sys@v0.16.0
  * [`d45778523`](https://github.com/containerd/containerd/commit/d45778523cb2454fcb57a36c5c0c1c447267ca44) vendor: golang.org/x/term@v0.15.0, golang.org/x/text@v0.14.0
  * [`24038de8c`](https://github.com/containerd/containerd/commit/24038de8c1c285f3ebc7c1c81564409703a03ac9) vendor: golang.org/x/sys@v0.15.0
* Update metadata snapshotter to lease on already exists ([#10198](https://github.com/containerd/containerd/pull/10198))
  * [`eb930375c`](https://github.com/containerd/containerd/commit/eb930375ca25680660e424eeefbcab8920543aa2) Add lease test for metadata snapshotter
  * [`9f6c61ab9`](https://github.com/containerd/containerd/commit/9f6c61ab927bb34136636e3e560831e155bea958) Update metadata snapshotter to lease on exists
* Update grpc and image-spec dependencies ([#10180](https://github.com/containerd/containerd/pull/10180))
  * [`24dd403ab`](https://github.com/containerd/containerd/commit/24dd403abb141917934493ee9170bffee14cb305) Update image-spec to v1.1.0
  * [`189b69e24`](https://github.com/containerd/containerd/commit/189b69e247f0f852ef261421d6730beaecb2502b) go.mod: github.com/opencontainers/image-spec v1.1.0-rc3
  * [`388fb336b`](https://github.com/containerd/containerd/commit/388fb336b0a458e2cf64212072743e622a3f44c7) Update grpc to v1.59.0
* Handle unsupported config versions ([#10165](https://github.com/containerd/containerd/pull/10165))
  * [`00347b7fa`](https://github.com/containerd/containerd/commit/00347b7fa50b73d23399c8197c76a1343c901bf3) Add check for unsupported config versions
</p>
</details>

### Changes from containerd/imgcrypt
<details><summary>53 commits</summary>
<p>

* CHANGES: Updated CHANGES document for 1.1.8 release ([containerd/imgcrypt#122](https://github.com/containerd/imgcrypt/pull/122))
  * [`956b4d3`](https://github.com/containerd/imgcrypt/commit/956b4d3fe3ed647032725bf1585f68b2a38b2b13) CHANGES: Updated CHANGES document for 1.1.8 release
* Synchronize enc-ctr with upstream ctr from containerd v1.6.23 and use containerd v1.6.23 in dependency ([containerd/imgcrypt#120](https://github.com/containerd/imgcrypt/pull/120))
  * [`9e8e1c1`](https://github.com/containerd/imgcrypt/commit/9e8e1c1df3660f869c7fbd49135a8cd6bf91fe7c) ctr: Sync code with containerd v1.6.23 ctr
  * [`7d2cca5`](https://github.com/containerd/imgcrypt/commit/7d2cca5efde78e5c5bce11e831d61077cf9166e1) build(deps): bump containerd from 1.6.20 to 1.6.23
* Synchronize enc-ctr with upstream ctr from containerd v1.6.20 ([containerd/imgcrypt#119](https://github.com/containerd/imgcrypt/pull/119))
  * [`0f2559e`](https://github.com/containerd/imgcrypt/commit/0f2559e3c9bb4c80ea422560af2bdb1334d70f88) ctr: Sync code with containerd v1.6.20 ctr
  * [`c48dd78`](https://github.com/containerd/imgcrypt/commit/c48dd787005e197c12e924727ea2b0be75a6e66b) cmd: Copy IntToInt32Array into img package and use it
* Update to ocicrypt 1.1.8 and minimum go 1.20 ([containerd/imgcrypt#118](https://github.com/containerd/imgcrypt/pull/118))
  * [`6d48a4e`](https://github.com/containerd/imgcrypt/commit/6d48a4ecc325e1aaf531110b5aa9beece4eafc4c) build(deps): bump ocicrypt from 1.1.7 to 1.1.8
  * [`1bc94a2`](https://github.com/containerd/imgcrypt/commit/1bc94a206e90d4f79dbb137c922b32b71662c78b) github: Use golangci-lint v1.54.1 and adjust config file
  * [`9065f1d`](https://github.com/containerd/imgcrypt/commit/9065f1da9e4f607df34eff64d6e24530f7b3a136) github: Test with go 1.21 and go 1.20
  * [`74986f3`](https://github.com/containerd/imgcrypt/commit/74986f3687f84523a4612bd7c6975463b68b3b10) go.mod: Require go 1.20
* build(deps): bump google.golang.org/grpc from 1.47.0 to 1.53.0 ([containerd/imgcrypt#117](https://github.com/containerd/imgcrypt/pull/117))
  * [`a2a8273`](https://github.com/containerd/imgcrypt/commit/a2a82731875004f0dd33dff929201456e3f702e1) build(deps): bump google.golang.org/grpc from 1.47.0 to 1.53.0
* test: Test creating and running of container with key file missing ([containerd/imgcrypt#116](https://github.com/containerd/imgcrypt/pull/116))
  * [`286470a`](https://github.com/containerd/imgcrypt/commit/286470a95699ac0cb19a3de79a7a215cafc8f2c7) test: Test creating and running of container with key file missing
* Fix some issues in the test script ([containerd/imgcrypt#115](https://github.com/containerd/imgcrypt/pull/115))
  * [`aa517cc`](https://github.com/containerd/imgcrypt/commit/aa517cc77654cf517cc7bba5529b07da92f033dc) test: Fix order of parameters and remove unnecessary key parameter
  * [`ec72311`](https://github.com/containerd/imgcrypt/commit/ec7231185e276feb10f5b4b974ade62a81d5e9ad) test: Add comments to test case
  * [`2959ec0`](https://github.com/containerd/imgcrypt/commit/2959ec0ec47786956223715812f40eb9e7301786) test: To be able to run testLocalKeys alone add missing env variable
* build(deps): upgrade github.com/containerd/containerd from 1.6.18 to … ([containerd/imgcrypt#112](https://github.com/containerd/imgcrypt/pull/112))
  * [`a7f2760`](https://github.com/containerd/imgcrypt/commit/a7f2760c719863cc015e4638090db4ef23daecd1) build(deps): upgrade github.com/containerd/containerd from 1.6.18 to 1.6.20
* ci: Update golangci-lint to v1.52.2 ([containerd/imgcrypt#113](https://github.com/containerd/imgcrypt/pull/113))
  * [`002abac`](https://github.com/containerd/imgcrypt/commit/002abac5a58aebef74a13bb7e30302b01f07b419) images: Change 'any' to 'anything' to avoid clash with built-in type 'any'
  * [`5780ecc`](https://github.com/containerd/imgcrypt/commit/5780ecc88b4b08c4f1d8e6372869e39ab1fcbf35) images: Replace unused function parameters with '_'
  * [`7dc8592`](https://github.com/containerd/imgcrypt/commit/7dc85928e244990cb3371c63d2a8caae5189b757) ci: Update golangci-lint to v1.52.2
* build(deps): bump github.com/opencontainers/runc from 1.1.2 to 1.1.5 ([containerd/imgcrypt#109](https://github.com/containerd/imgcrypt/pull/109))
  * [`90e4f77`](https://github.com/containerd/imgcrypt/commit/90e4f77bdc085a6f6d426380fa7cf0227ea03173) build(deps): bump github.com/opencontainers/runc from 1.1.2 to 1.1.5
* Abandon go 1.18 (end-of-life) and use 1.19 and 1.20 in tests ([containerd/imgcrypt#110](https://github.com/containerd/imgcrypt/pull/110))
  * [`8fc037f`](https://github.com/containerd/imgcrypt/commit/8fc037fd2de0e6106a3e8da655be22a1d4da719c) tests: Upgrade toml written by test case to version 2
  * [`0b31beb`](https://github.com/containerd/imgcrypt/commit/0b31beb1c7b6391b50ff44d9a71bed452bcebf2d) ci: Run tests with go 1.19 and 1.20 (abandon 1.18)
  * [`523674c`](https://github.com/containerd/imgcrypt/commit/523674c781c15e461afe52d8086deb4dd0d61466) build(deps): Update to minimum required go v1.19
* Update to golang.org/x/net@v0.7.0 and github.com/containers/ocicrypt@v1.1.7 ([containerd/imgcrypt#107](https://github.com/containerd/imgcrypt/pull/107))
  * [`96a2314`](https://github.com/containerd/imgcrypt/commit/96a2314e83ba412568800a7dd84789f59f1310ec) build(deps): Upgrade to github.com/containers/ocicrypt@v1.1.7
  * [`1c50555`](https://github.com/containerd/imgcrypt/commit/1c5055514add4b6715cb4da0a127f8200d0d190a) bulid(deps): Update to golang.org/x/net@v0.7.0
  * [`9645d39`](https://github.com/containerd/imgcrypt/commit/9645d39f070c7f6728ec4e1831fbede7ebd512ec) build(deps): Update to minimum required go v1.18
* build(deps): bump github.com/containerd/containerd from 1.6.12 to 1.6.18 ([containerd/imgcrypt#106](https://github.com/containerd/imgcrypt/pull/106))
  * [`8daaa45`](https://github.com/containerd/imgcrypt/commit/8daaa45a63100dc95430fc22eb2b5e95772b245f) build(deps): bump github.com/containerd/containerd from 1.6.12 to 1.6.18
* README: Fix a typo ([containerd/imgcrypt#105](https://github.com/containerd/imgcrypt/pull/105))
  * [`12e84f5`](https://github.com/containerd/imgcrypt/commit/12e84f51fb70e1fb2bcc624206f707b48671b352) README: Fix a typo
* build(deps): bump github.com/containerd/containerd from 1.6.8 to 1.6.12 ([containerd/imgcrypt#103](https://github.com/containerd/imgcrypt/pull/103))
  * [`4e5a73e`](https://github.com/containerd/imgcrypt/commit/4e5a73e393254df6091fc9b3bf54371be778060f) build(deps): bump github.com/containerd/containerd from 1.6.8 to 1.6.12
* Update golangci-lint to v1.50.1 ([containerd/imgcrypt#101](https://github.com/containerd/imgcrypt/pull/101))
  * [`16a071b`](https://github.com/containerd/imgcrypt/commit/16a071b983f1777ff6391be0d44e80370fd58bf9) Update golangci-lint to v1.50.1
* Remove references to package io/ioutil ([containerd/imgcrypt#100](https://github.com/containerd/imgcrypt/pull/100))
  * [`981a3fd`](https://github.com/containerd/imgcrypt/commit/981a3fdd5a755a1521337010bec47874753508cb) Remove references to package io/ioutil
* Update GitHub actions CI workflow ([containerd/imgcrypt#99](https://github.com/containerd/imgcrypt/pull/99))
  * [`06827a1`](https://github.com/containerd/imgcrypt/commit/06827a1d8664a277fed24a41cd1566c197f58814) Update containerd project checks package in CI
  * [`f6a39e1`](https://github.com/containerd/imgcrypt/commit/f6a39e1bcd21af406254aa5da1e7f89f26e914cd) Update GitHub actions packages in CI workflow
  * [`6383351`](https://github.com/containerd/imgcrypt/commit/6383351756ec706b0f6aeea1a9dfc737c71bece7) Update GitHub actions CI workflow OS runner images
* CI/CD: Run CodeQL on PRs and once a month ([containerd/imgcrypt#98](https://github.com/containerd/imgcrypt/pull/98))
  * [`b6e16db`](https://github.com/containerd/imgcrypt/commit/b6e16db881eef08e0bb58d0885bfad8339c97f2f) CI/CD: Run CodeQL on PRs and once a month
</p>
</details>

### Changes from containerd/ttrpc
<details><summary>10 commits</summary>
<p>

* Bump google.golang.org/protobuf from 1.31.0 to 1.33.0 ([containerd/ttrpc#166](https://github.com/containerd/ttrpc/pull/166))
  * [`272c857`](https://github.com/containerd/ttrpc/commit/272c8575a6e6fd169a08ca94a1b77dbce433119c) Bump google.golang.org/protobuf from 1.31.0 to 1.33.0
* Fix deadlock when writing to pipe blocks ([containerd/ttrpc#168](https://github.com/containerd/ttrpc/pull/168))
  * [`1b4f6f8`](https://github.com/containerd/ttrpc/commit/1b4f6f8edba5f374f1afbf10d7666136286806e7) client: Fix deadlock when writing to pipe blocks
* Bump golang.org/x/net from 0.17.0 to 0.23.0 ([containerd/ttrpc#167](https://github.com/containerd/ttrpc/pull/167))
  * [`13b8289`](https://github.com/containerd/ttrpc/commit/13b8289864f297c6fe1f973016012ce1495ee1b9) Bump golang.org/x/net from 0.17.0 to 0.23.0
* Update GitHub Actions CI to resolve deprecation warnings ([containerd/ttrpc#161](https://github.com/containerd/ttrpc/pull/161))
  * [`589a593`](https://github.com/containerd/ttrpc/commit/589a593abc38264094c47baf83bc69b2cff37524) Update GitHub Actions CI to resolve deprecation warnings
* Fix proto3 generation error ([containerd/ttrpc#158](https://github.com/containerd/ttrpc/pull/158))
  * [`73b6a91`](https://github.com/containerd/ttrpc/commit/73b6a9156d6dc4644c94f5a683219ba8aac9fb18) Add optional feature in protobuf compiler
</p>
</details>

### Dependency Changes

* **github.com/Microsoft/go-winio**              v0.6.1 -> v0.6.2
* **github.com/Microsoft/hcsshim**               v0.11.4 -> v0.11.5
* **github.com/containerd/imgcrypt**             v1.1.7 -> v1.1.8
* **github.com/containerd/ttrpc**                v1.2.3 -> v1.2.4
* **github.com/containers/ocicrypt**             v1.1.6 -> v1.1.10
* **github.com/go-jose/go-jose/v3**              v3.0.3 **_new_**
* **github.com/google/uuid**                     v1.3.0 -> v1.3.1
* **github.com/opencontainers/image-spec**       3a7f492d3f1b -> v1.1.0
* **github.com/stefanberger/go-pkcs11uri**       78d3cae3a980 -> 78284954bff6
* **golang.org/x/crypto**                        v0.14.0 -> v0.21.0
* **golang.org/x/mod**                           v0.11.0 -> v0.12.0
* **golang.org/x/net**                           v0.17.0 -> v0.23.0
* **golang.org/x/oauth2**                        v0.10.0 -> v0.11.0
* **golang.org/x/sys**                           v0.13.0 -> v0.18.0
* **golang.org/x/term**                          v0.13.0 -> v0.18.0
* **golang.org/x/text**                          v0.13.0 -> v0.14.0
* **google.golang.org/genproto**                 782d3b101e98 -> b8732ec3820d
* **google.golang.org/genproto/googleapis/api**  782d3b101e98 -> b8732ec3820d
* **google.golang.org/genproto/googleapis/rpc**  cbb8c96f2d6d -> b8732ec3820d
* **google.golang.org/grpc**                     v1.58.3 -> v1.59.0

Previous release can be found at [v1.7.16](https://github.com/containerd/containerd/releases/tag/v1.7.16)

