### PR TITLE
Add support to set loopback to up

### DIFF
--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -432,6 +432,8 @@ version = 2
     # * ipv6 - select the first ipv6 address
     # * cni - use the order returned by the CNI plugins, returning the first IP address from the results
     ip_pref = "ipv4"
+    # use_internal_loopback specifies if we use the CNI loopback plugin or internal mechanism to set lo to up
+    use_internal_loopback = false
 
   # 'plugins."io.containerd.grpc.v1.cri".image_decryption' contains config related
   # to handling decryption of encrypted container images.

--- a/internal/cri/config/config.go
+++ b/internal/cri/config/config.go
@@ -185,6 +185,8 @@ type CniConfig struct {
 	// * ipv6 - select the first ipv6 address
 	// * cni - use the order returned by the CNI plugins, returning the first IP address from the results
 	IPPreference string `toml:"ip_pref" json:"ipPref"`
+	// UseInternalLoopback specifies if we use the CNI loopback plugin or internal mechanism to set lo to up
+	UseInternalLoopback bool `toml:"use_internal_loopback" json:"useInternalLoopback"`
 }
 
 // Mirror contains the config related to the registry mirror

--- a/internal/cri/config/config_unix.go
+++ b/internal/cri/config/config_unix.go
@@ -77,6 +77,7 @@ func DefaultRuntimeConfig() RuntimeConfig {
 			NetworkPluginMaxConfNum:    1, // only one CNI plugin config file will be loaded
 			NetworkPluginSetupSerially: false,
 			NetworkPluginConfTemplate:  "",
+			UseInternalLoopback:        false,
 		},
 		ContainerdConfig: ContainerdConfig{
 			DefaultRuntimeName: "runc",

--- a/internal/cri/config/config_windows.go
+++ b/internal/cri/config/config_windows.go
@@ -47,6 +47,7 @@ func DefaultRuntimeConfig() RuntimeConfig {
 			NetworkPluginMaxConfNum:    1,
 			NetworkPluginSetupSerially: false,
 			NetworkPluginConfTemplate:  "",
+			UseInternalLoopback:        false,
 		},
 		ContainerdConfig: ContainerdConfig{
 			DefaultRuntimeName: "runhcs-wcow-process",

--- a/internal/cri/server/sandbox_run.go
+++ b/internal/cri/server/sandbox_run.go
@@ -455,7 +455,12 @@ func (c *criService) setupPodNetwork(ctx context.Context, sandbox *sandboxstore.
 	if netPlugin == nil {
 		return errors.New("cni config not initialized")
 	}
-
+	if c.config.UseInternalLoopback {
+		err := c.bringUpLoopback(path)
+		if err != nil {
+			return fmt.Errorf("unable to set lo to up: %w", err)
+		}
+	}
 	opts, err := cniNamespaceOpts(id, config)
 	if err != nil {
 		return fmt.Errorf("get cni namespace options: %w", err)

--- a/internal/cri/server/sandbox_run_linux.go
+++ b/internal/cri/server/sandbox_run_linux.go
@@ -1,0 +1,37 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"fmt"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/vishvananda/netlink"
+)
+
+func (c *criService) bringUpLoopback(netns string) error {
+	if err := ns.WithNetNSPath(netns, func(_ ns.NetNS) error {
+		link, err := netlink.LinkByName("lo")
+		if err != nil {
+			return err
+		}
+		return netlink.LinkSetUp(link)
+	}); err != nil {
+		return fmt.Errorf("error setting loopback interface up: %w", err)
+	}
+	return nil
+}

--- a/internal/cri/server/sandbox_run_other.go
+++ b/internal/cri/server/sandbox_run_other.go
@@ -1,0 +1,23 @@
+//go:build !windows && !linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+func (c *criService) bringUpLoopback(string) error {
+	return nil
+}

--- a/internal/cri/server/sandbox_run_windows.go
+++ b/internal/cri/server/sandbox_run_windows.go
@@ -1,0 +1,21 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+func (c *criService) bringUpLoopback(string) error {
+	return nil
+}


### PR DESCRIPTION
The CNI maintainers intend on deprecating the loopback plugin. This approach where we set the lo interface to up is similar to what CRI-O does. We (@mikebrow ) decided to have a flag to disable/enable and eventually we will go with removing the flags and just always setting the lo interface to up. 