### PR TITLE
[release/1.6] Bump hcsshim and go-winio for go1.22 compat

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	dario.cat/mergo v1.0.0
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20210715213245-6c3934b029d8
-	github.com/Microsoft/go-winio v0.5.2
+	github.com/Microsoft/go-winio v0.5.3
 	github.com/Microsoft/hcsshim v0.9.11
 	github.com/containerd/aufs v1.0.0
 	github.com/containerd/btrfs v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	dario.cat/mergo v1.0.0
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20210715213245-6c3934b029d8
 	github.com/Microsoft/go-winio v0.5.2
-	github.com/Microsoft/hcsshim v0.9.10
+	github.com/Microsoft/hcsshim v0.9.11
 	github.com/containerd/aufs v1.0.0
 	github.com/containerd/btrfs v1.0.0
 	github.com/containerd/cgroups v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,7 @@ github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugX
 github.com/Microsoft/go-winio v0.4.17-0.20210211115548-6eac466e5fa3/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.4.17-0.20210324224401-5516f17a5958/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.4.17/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
+github.com/Microsoft/go-winio v0.4.21/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
@@ -78,8 +79,8 @@ github.com/Microsoft/hcsshim v0.8.14/go.mod h1:NtVKoYxQuTLx6gEq0L96c9Ju4JbRJ4nY2
 github.com/Microsoft/hcsshim v0.8.15/go.mod h1:x38A4YbHbdxJtc0sF6oIz+RG0npwSCAvn69iY6URG00=
 github.com/Microsoft/hcsshim v0.8.16/go.mod h1:o5/SZqmR7x9JNKsW3pu+nqHm0MF8vbA+VxGOoXdC600=
 github.com/Microsoft/hcsshim v0.8.21/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwTOcER2fw4I4=
-github.com/Microsoft/hcsshim v0.9.10 h1:TxXGNmcbQxBKVWvjvTocNb6jrPyeHlk5EiDhhgHgggs=
-github.com/Microsoft/hcsshim v0.9.10/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
+github.com/Microsoft/hcsshim v0.9.11 h1:uTbPpycWDEBAttWphYW59GPPQ1EFmaLgQabWKCuzPj4=
+github.com/Microsoft/hcsshim v0.9.11/go.mod h1:qAiPvMgZoM0wpkVg6qMdSEu+1VtI6/qHOOPkTGt8ftQ=
 github.com/Microsoft/hcsshim/test v0.0.0-20201218223536-d3e5debf77da/go.mod h1:5hlzMzRKMLyo42nCZ9oml8AdTlq/0cvIaBv6tK1RehU=
 github.com/Microsoft/hcsshim/test v0.0.0-20210227013316-43a75bb4edd3/go.mod h1:mw7qgWloBUl75W/gVH3cQszUg1+gUITj7D6NY7ywVnY=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ github.com/Microsoft/go-winio v0.4.17-0.20210211115548-6eac466e5fa3/go.mod h1:JP
 github.com/Microsoft/go-winio v0.4.17-0.20210324224401-5516f17a5958/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.4.17/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.4.21/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
-github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
-github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
+github.com/Microsoft/go-winio v0.5.3 h1:YFS1RpkNc47wuNQBGlQNYniUvOIKqtVQ0+MKgZLbxls=
+github.com/Microsoft/go-winio v0.5.3/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/Microsoft/hcsshim v0.8.7-0.20190325164909-8abdbb8205e4/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/Microsoft/hcsshim v0.8.7/go.mod h1:OHd7sQqRFrYd3RmSgbgji+ctCwkbq2wbEYNSzOYtcBQ=

--- a/integration/client/go.mod
+++ b/integration/client/go.mod
@@ -3,7 +3,7 @@ module github.com/containerd/containerd/integration/client
 go 1.19
 
 require (
-	github.com/Microsoft/hcsshim v0.9.10
+	github.com/Microsoft/hcsshim v0.9.11
 	github.com/Microsoft/hcsshim/test v0.0.0-20210408205431-da33ecd607e1
 	github.com/containerd/cgroups v1.0.4
 	// the actual version of containerd is replaced with the code at the root of this repository

--- a/integration/client/go.mod
+++ b/integration/client/go.mod
@@ -23,7 +23,7 @@ require (
 
 require (
 	dario.cat/mergo v1.0.0 // indirect
-	github.com/Microsoft/go-winio v0.5.2 // indirect
+	github.com/Microsoft/go-winio v0.5.3 // indirect
 	github.com/cilium/ebpf v0.7.0 // indirect
 	github.com/containerd/console v1.0.3 // indirect
 	github.com/containerd/fifo v1.0.0 // indirect

--- a/integration/client/go.sum
+++ b/integration/client/go.sum
@@ -109,13 +109,15 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.17-0.20210211115548-6eac466e5fa3/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.4.17/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
+github.com/Microsoft/go-winio v0.4.21/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/hcsshim v0.8.15/go.mod h1:x38A4YbHbdxJtc0sF6oIz+RG0npwSCAvn69iY6URG00=
 github.com/Microsoft/hcsshim v0.8.20/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwTOcER2fw4I4=
 github.com/Microsoft/hcsshim v0.9.6/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
-github.com/Microsoft/hcsshim v0.9.10 h1:TxXGNmcbQxBKVWvjvTocNb6jrPyeHlk5EiDhhgHgggs=
 github.com/Microsoft/hcsshim v0.9.10/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
+github.com/Microsoft/hcsshim v0.9.11 h1:uTbPpycWDEBAttWphYW59GPPQ1EFmaLgQabWKCuzPj4=
+github.com/Microsoft/hcsshim v0.9.11/go.mod h1:qAiPvMgZoM0wpkVg6qMdSEu+1VtI6/qHOOPkTGt8ftQ=
 github.com/Microsoft/hcsshim/test v0.0.0-20210408205431-da33ecd607e1 h1:pVKfKyPkXna29XlGjxSr9J0A7vNucOUHZ/2ClcTWalw=
 github.com/Microsoft/hcsshim/test v0.0.0-20210408205431-da33ecd607e1/go.mod h1:Cmvnhlie15Ha2UYrJs9EhgSx76Bq9RV2FgfEiT78GhI=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=

--- a/integration/client/go.sum
+++ b/integration/client/go.sum
@@ -110,8 +110,9 @@ github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jB
 github.com/Microsoft/go-winio v0.4.17-0.20210211115548-6eac466e5fa3/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.4.17/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.4.21/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
-github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
+github.com/Microsoft/go-winio v0.5.3 h1:YFS1RpkNc47wuNQBGlQNYniUvOIKqtVQ0+MKgZLbxls=
+github.com/Microsoft/go-winio v0.5.3/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/hcsshim v0.8.15/go.mod h1:x38A4YbHbdxJtc0sF6oIz+RG0npwSCAvn69iY6URG00=
 github.com/Microsoft/hcsshim v0.8.20/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwTOcER2fw4I4=
 github.com/Microsoft/hcsshim v0.9.6/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=

--- a/vendor/github.com/Microsoft/hcsshim/.gitattributes
+++ b/vendor/github.com/Microsoft/hcsshim/.gitattributes
@@ -1,1 +1,3 @@
 * text=auto eol=lf
+vendor/** -text
+test/vendor/** -text

--- a/vendor/github.com/Microsoft/hcsshim/.gitignore
+++ b/vendor/github.com/Microsoft/hcsshim/.gitignore
@@ -6,6 +6,7 @@
 
 # Ignore vscode setting files
 .vscode/
+.idea/
 
 # Test binary, build with `go test -c`
 *.test
@@ -23,16 +24,30 @@ service/pkg/
 *.img
 *.vhd
 *.tar.gz
+*.tar
 
 # Make stuff
 .rootfs-done
 bin/*
 rootfs/*
+rootfs-conv/*
 *.o
 /build/
 
 deps/*
 out/*
 
-.idea/
-.vscode/
+# protobuf files
+# only files at root of the repo, otherwise this will cause issues with vendoring
+/protobuf/*
+
+# test results
+test/results
+
+# go workspace files
+go.work
+go.work.sum
+
+# keys and related artifacts
+*.pem
+*.cose

--- a/vendor/github.com/Microsoft/hcsshim/Protobuild.toml
+++ b/vendor/github.com/Microsoft/hcsshim/Protobuild.toml
@@ -17,7 +17,7 @@ plugins = ["grpc", "fieldpath"]
   # Paths that will be added untouched to the end of the includes. We use
   # `/usr/local/include` to pickup the common install location of protobuf.
   # This is the default.
-  after = ["/usr/local/include"]
+  after = [""]
 
 # This section maps protobuf imports to Go packages. These will become
 # `-M` directives in the call to the go protobuf generator.

--- a/vendor/github.com/Microsoft/hcsshim/README.md
+++ b/vendor/github.com/Microsoft/hcsshim/README.md
@@ -75,24 +75,6 @@ certify they either authored the work themselves or otherwise have permission to
 more info, as well as to make sure that you can attest to the rules listed. Our CI uses the [DCO Github app](https://github.com/apps/dco) to ensure
 that all commits in a given PR are signed-off.
 
-### Test Directory (Important to note)
-
-This project has tried to trim some dependencies from the root Go modules file that would be cumbersome to get transitively included if this
-project is being vendored/used as a library. Some of these dependencies were only being used for tests, so the /test directory in this project also has
-its own go.mod file where these are now included to get around this issue. Our tests rely on the code in this project to run, so the test Go modules file
-has a relative path replace directive to pull in the latest hcsshim code that the tests actually touch from this project
-(which is the repo itself on your disk).
-
-```
-replace (
-	github.com/Microsoft/hcsshim => ../
-)
-```
-
-Because of this, for most code changes you may need to run `go mod vendor` + `go mod tidy` in the /test directory in this repository, as the
-CI in this project will check if the files are out of date and will fail if this is true.
-
-
 ## Code of Conduct
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).

--- a/vendor/github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options/runhcs.pb.go
+++ b/vendor/github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options/runhcs.pb.go
@@ -10,6 +10,7 @@ import (
 	github_com_gogo_protobuf_types "github.com/gogo/protobuf/types"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 	time "time"
@@ -25,7 +26,7 @@ var _ = time.Kitchen
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type Options_DebugType int32
 
@@ -162,7 +163,7 @@ func (m *Options) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Options.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -211,7 +212,7 @@ func (m *ProcessDetails) XXX_Marshal(b []byte, deterministic bool) ([]byte, erro
 		return xxx_messageInfo_ProcessDetails.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -308,7 +309,7 @@ var fileDescriptor_b643df6839c75082 = []byte{
 func (m *Options) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -316,131 +317,144 @@ func (m *Options) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Options) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Options) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.Debug {
-		dAtA[i] = 0x8
-		i++
-		if m.Debug {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
-	if m.DebugType != 0 {
-		dAtA[i] = 0x10
-		i++
-		i = encodeVarintRunhcs(dAtA, i, uint64(m.DebugType))
+	if m.IoRetryTimeoutInSec != 0 {
+		i = encodeVarintRunhcs(dAtA, i, uint64(m.IoRetryTimeoutInSec))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x88
 	}
-	if len(m.RegistryRoot) > 0 {
-		dAtA[i] = 0x1a
-		i++
-		i = encodeVarintRunhcs(dAtA, i, uint64(len(m.RegistryRoot)))
-		i += copy(dAtA[i:], m.RegistryRoot)
+	if len(m.LogLevel) > 0 {
+		i -= len(m.LogLevel)
+		copy(dAtA[i:], m.LogLevel)
+		i = encodeVarintRunhcs(dAtA, i, uint64(len(m.LogLevel)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x82
 	}
-	if len(m.SandboxImage) > 0 {
-		dAtA[i] = 0x22
-		i++
-		i = encodeVarintRunhcs(dAtA, i, uint64(len(m.SandboxImage)))
-		i += copy(dAtA[i:], m.SandboxImage)
-	}
-	if len(m.SandboxPlatform) > 0 {
-		dAtA[i] = 0x2a
-		i++
-		i = encodeVarintRunhcs(dAtA, i, uint64(len(m.SandboxPlatform)))
-		i += copy(dAtA[i:], m.SandboxPlatform)
-	}
-	if m.SandboxIsolation != 0 {
-		dAtA[i] = 0x30
-		i++
-		i = encodeVarintRunhcs(dAtA, i, uint64(m.SandboxIsolation))
-	}
-	if len(m.BootFilesRootPath) > 0 {
-		dAtA[i] = 0x3a
-		i++
-		i = encodeVarintRunhcs(dAtA, i, uint64(len(m.BootFilesRootPath)))
-		i += copy(dAtA[i:], m.BootFilesRootPath)
-	}
-	if m.VmProcessorCount != 0 {
-		dAtA[i] = 0x40
-		i++
-		i = encodeVarintRunhcs(dAtA, i, uint64(m.VmProcessorCount))
-	}
-	if m.VmMemorySizeInMb != 0 {
-		dAtA[i] = 0x48
-		i++
-		i = encodeVarintRunhcs(dAtA, i, uint64(m.VmMemorySizeInMb))
-	}
-	if len(m.GPUVHDPath) > 0 {
-		dAtA[i] = 0x52
-		i++
-		i = encodeVarintRunhcs(dAtA, i, uint64(len(m.GPUVHDPath)))
-		i += copy(dAtA[i:], m.GPUVHDPath)
-	}
-	if m.ScaleCpuLimitsToSandbox {
-		dAtA[i] = 0x58
-		i++
-		if m.ScaleCpuLimitsToSandbox {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
-	}
-	if m.DefaultContainerScratchSizeInGb != 0 {
-		dAtA[i] = 0x60
-		i++
-		i = encodeVarintRunhcs(dAtA, i, uint64(m.DefaultContainerScratchSizeInGb))
-	}
-	if m.DefaultVmScratchSizeInGb != 0 {
-		dAtA[i] = 0x68
-		i++
-		i = encodeVarintRunhcs(dAtA, i, uint64(m.DefaultVmScratchSizeInGb))
+	if len(m.NCProxyAddr) > 0 {
+		i -= len(m.NCProxyAddr)
+		copy(dAtA[i:], m.NCProxyAddr)
+		i = encodeVarintRunhcs(dAtA, i, uint64(len(m.NCProxyAddr)))
+		i--
+		dAtA[i] = 0x7a
 	}
 	if m.ShareScratch {
-		dAtA[i] = 0x70
-		i++
+		i--
 		if m.ShareScratch {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
 		}
-		i++
+		i--
+		dAtA[i] = 0x70
 	}
-	if len(m.NCProxyAddr) > 0 {
-		dAtA[i] = 0x7a
-		i++
-		i = encodeVarintRunhcs(dAtA, i, uint64(len(m.NCProxyAddr)))
-		i += copy(dAtA[i:], m.NCProxyAddr)
+	if m.DefaultVmScratchSizeInGb != 0 {
+		i = encodeVarintRunhcs(dAtA, i, uint64(m.DefaultVmScratchSizeInGb))
+		i--
+		dAtA[i] = 0x68
 	}
-	if len(m.LogLevel) > 0 {
-		dAtA[i] = 0x82
-		i++
-		dAtA[i] = 0x1
-		i++
-		i = encodeVarintRunhcs(dAtA, i, uint64(len(m.LogLevel)))
-		i += copy(dAtA[i:], m.LogLevel)
+	if m.DefaultContainerScratchSizeInGb != 0 {
+		i = encodeVarintRunhcs(dAtA, i, uint64(m.DefaultContainerScratchSizeInGb))
+		i--
+		dAtA[i] = 0x60
 	}
-	if m.IoRetryTimeoutInSec != 0 {
-		dAtA[i] = 0x88
-		i++
-		dAtA[i] = 0x1
-		i++
-		i = encodeVarintRunhcs(dAtA, i, uint64(m.IoRetryTimeoutInSec))
+	if m.ScaleCpuLimitsToSandbox {
+		i--
+		if m.ScaleCpuLimitsToSandbox {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x58
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if len(m.GPUVHDPath) > 0 {
+		i -= len(m.GPUVHDPath)
+		copy(dAtA[i:], m.GPUVHDPath)
+		i = encodeVarintRunhcs(dAtA, i, uint64(len(m.GPUVHDPath)))
+		i--
+		dAtA[i] = 0x52
 	}
-	return i, nil
+	if m.VmMemorySizeInMb != 0 {
+		i = encodeVarintRunhcs(dAtA, i, uint64(m.VmMemorySizeInMb))
+		i--
+		dAtA[i] = 0x48
+	}
+	if m.VmProcessorCount != 0 {
+		i = encodeVarintRunhcs(dAtA, i, uint64(m.VmProcessorCount))
+		i--
+		dAtA[i] = 0x40
+	}
+	if len(m.BootFilesRootPath) > 0 {
+		i -= len(m.BootFilesRootPath)
+		copy(dAtA[i:], m.BootFilesRootPath)
+		i = encodeVarintRunhcs(dAtA, i, uint64(len(m.BootFilesRootPath)))
+		i--
+		dAtA[i] = 0x3a
+	}
+	if m.SandboxIsolation != 0 {
+		i = encodeVarintRunhcs(dAtA, i, uint64(m.SandboxIsolation))
+		i--
+		dAtA[i] = 0x30
+	}
+	if len(m.SandboxPlatform) > 0 {
+		i -= len(m.SandboxPlatform)
+		copy(dAtA[i:], m.SandboxPlatform)
+		i = encodeVarintRunhcs(dAtA, i, uint64(len(m.SandboxPlatform)))
+		i--
+		dAtA[i] = 0x2a
+	}
+	if len(m.SandboxImage) > 0 {
+		i -= len(m.SandboxImage)
+		copy(dAtA[i:], m.SandboxImage)
+		i = encodeVarintRunhcs(dAtA, i, uint64(len(m.SandboxImage)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RegistryRoot) > 0 {
+		i -= len(m.RegistryRoot)
+		copy(dAtA[i:], m.RegistryRoot)
+		i = encodeVarintRunhcs(dAtA, i, uint64(len(m.RegistryRoot)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if m.DebugType != 0 {
+		i = encodeVarintRunhcs(dAtA, i, uint64(m.DebugType))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.Debug {
+		i--
+		if m.Debug {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *ProcessDetails) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -448,74 +462,84 @@ func (m *ProcessDetails) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *ProcessDetails) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ProcessDetails) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.ImageName) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintRunhcs(dAtA, i, uint64(len(m.ImageName)))
-		i += copy(dAtA[i:], m.ImageName)
-	}
-	dAtA[i] = 0x12
-	i++
-	i = encodeVarintRunhcs(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdTime(m.CreatedAt)))
-	n1, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.CreatedAt, dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n1
-	if m.KernelTime_100Ns != 0 {
-		dAtA[i] = 0x18
-		i++
-		i = encodeVarintRunhcs(dAtA, i, uint64(m.KernelTime_100Ns))
-	}
-	if m.MemoryCommitBytes != 0 {
-		dAtA[i] = 0x20
-		i++
-		i = encodeVarintRunhcs(dAtA, i, uint64(m.MemoryCommitBytes))
-	}
-	if m.MemoryWorkingSetPrivateBytes != 0 {
-		dAtA[i] = 0x28
-		i++
-		i = encodeVarintRunhcs(dAtA, i, uint64(m.MemoryWorkingSetPrivateBytes))
-	}
-	if m.MemoryWorkingSetSharedBytes != 0 {
-		dAtA[i] = 0x30
-		i++
-		i = encodeVarintRunhcs(dAtA, i, uint64(m.MemoryWorkingSetSharedBytes))
-	}
-	if m.ProcessID != 0 {
-		dAtA[i] = 0x38
-		i++
-		i = encodeVarintRunhcs(dAtA, i, uint64(m.ProcessID))
-	}
-	if m.UserTime_100Ns != 0 {
-		dAtA[i] = 0x40
-		i++
-		i = encodeVarintRunhcs(dAtA, i, uint64(m.UserTime_100Ns))
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.ExecID) > 0 {
-		dAtA[i] = 0x4a
-		i++
+		i -= len(m.ExecID)
+		copy(dAtA[i:], m.ExecID)
 		i = encodeVarintRunhcs(dAtA, i, uint64(len(m.ExecID)))
-		i += copy(dAtA[i:], m.ExecID)
+		i--
+		dAtA[i] = 0x4a
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if m.UserTime_100Ns != 0 {
+		i = encodeVarintRunhcs(dAtA, i, uint64(m.UserTime_100Ns))
+		i--
+		dAtA[i] = 0x40
 	}
-	return i, nil
+	if m.ProcessID != 0 {
+		i = encodeVarintRunhcs(dAtA, i, uint64(m.ProcessID))
+		i--
+		dAtA[i] = 0x38
+	}
+	if m.MemoryWorkingSetSharedBytes != 0 {
+		i = encodeVarintRunhcs(dAtA, i, uint64(m.MemoryWorkingSetSharedBytes))
+		i--
+		dAtA[i] = 0x30
+	}
+	if m.MemoryWorkingSetPrivateBytes != 0 {
+		i = encodeVarintRunhcs(dAtA, i, uint64(m.MemoryWorkingSetPrivateBytes))
+		i--
+		dAtA[i] = 0x28
+	}
+	if m.MemoryCommitBytes != 0 {
+		i = encodeVarintRunhcs(dAtA, i, uint64(m.MemoryCommitBytes))
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.KernelTime_100Ns != 0 {
+		i = encodeVarintRunhcs(dAtA, i, uint64(m.KernelTime_100Ns))
+		i--
+		dAtA[i] = 0x18
+	}
+	n1, err1 := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.CreatedAt, dAtA[i-github_com_gogo_protobuf_types.SizeOfStdTime(m.CreatedAt):])
+	if err1 != nil {
+		return 0, err1
+	}
+	i -= n1
+	i = encodeVarintRunhcs(dAtA, i, uint64(n1))
+	i--
+	dAtA[i] = 0x12
+	if len(m.ImageName) > 0 {
+		i -= len(m.ImageName)
+		copy(dAtA[i:], m.ImageName)
+		i = encodeVarintRunhcs(dAtA, i, uint64(len(m.ImageName)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintRunhcs(dAtA []byte, offset int, v uint64) int {
+	offset -= sovRunhcs(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func (m *Options) Size() (n int) {
 	if m == nil {
@@ -628,14 +652,7 @@ func (m *ProcessDetails) Size() (n int) {
 }
 
 func sovRunhcs(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozRunhcs(x uint64) (n int) {
 	return sovRunhcs(uint64((x << 1) ^ uint64((int64(x) >> 63))))
@@ -673,7 +690,7 @@ func (this *ProcessDetails) String() string {
 	}
 	s := strings.Join([]string{`&ProcessDetails{`,
 		`ImageName:` + fmt.Sprintf("%v", this.ImageName) + `,`,
-		`CreatedAt:` + strings.Replace(strings.Replace(this.CreatedAt.String(), "Timestamp", "types.Timestamp", 1), `&`, ``, 1) + `,`,
+		`CreatedAt:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.CreatedAt), "Timestamp", "types.Timestamp", 1), `&`, ``, 1) + `,`,
 		`KernelTime_100Ns:` + fmt.Sprintf("%v", this.KernelTime_100Ns) + `,`,
 		`MemoryCommitBytes:` + fmt.Sprintf("%v", this.MemoryCommitBytes) + `,`,
 		`MemoryWorkingSetPrivateBytes:` + fmt.Sprintf("%v", this.MemoryWorkingSetPrivateBytes) + `,`,
@@ -1146,10 +1163,7 @@ func (m *Options) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRunhcs
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRunhcs
 			}
 			if (iNdEx + skippy) > l {
@@ -1411,10 +1425,7 @@ func (m *ProcessDetails) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRunhcs
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRunhcs
 			}
 			if (iNdEx + skippy) > l {
@@ -1433,6 +1444,7 @@ func (m *ProcessDetails) Unmarshal(dAtA []byte) error {
 func skipRunhcs(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -1464,10 +1476,8 @@ func skipRunhcs(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -1488,55 +1498,30 @@ func skipRunhcs(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthRunhcs
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthRunhcs
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowRunhcs
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipRunhcs(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthRunhcs
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupRunhcs
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthRunhcs
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthRunhcs = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowRunhcs   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthRunhcs        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowRunhcs          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupRunhcs = fmt.Errorf("proto: unexpected end of group")
 )

--- a/vendor/github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats/stats.pb.go
+++ b/vendor/github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats/stats.pb.go
@@ -11,6 +11,7 @@ import (
 	github_com_gogo_protobuf_types "github.com/gogo/protobuf/types"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 	time "time"
@@ -26,7 +27,7 @@ var _ = time.Kitchen
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type Statistics struct {
 	// Types that are valid to be assigned to Container:
@@ -52,7 +53,7 @@ func (m *Statistics) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Statistics.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -78,10 +79,10 @@ type isStatistics_Container interface {
 }
 
 type Statistics_Windows struct {
-	Windows *WindowsContainerStatistics `protobuf:"bytes,1,opt,name=windows,proto3,oneof"`
+	Windows *WindowsContainerStatistics `protobuf:"bytes,1,opt,name=windows,proto3,oneof" json:"windows,omitempty"`
 }
 type Statistics_Linux struct {
-	Linux *v1.Metrics `protobuf:"bytes,2,opt,name=linux,proto3,oneof"`
+	Linux *v1.Metrics `protobuf:"bytes,2,opt,name=linux,proto3,oneof" json:"linux,omitempty"`
 }
 
 func (*Statistics_Windows) isStatistics_Container() {}
@@ -108,78 +109,12 @@ func (m *Statistics) GetLinux() *v1.Metrics {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*Statistics) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Statistics_OneofMarshaler, _Statistics_OneofUnmarshaler, _Statistics_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*Statistics) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*Statistics_Windows)(nil),
 		(*Statistics_Linux)(nil),
 	}
-}
-
-func _Statistics_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Statistics)
-	// container
-	switch x := m.Container.(type) {
-	case *Statistics_Windows:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Windows); err != nil {
-			return err
-		}
-	case *Statistics_Linux:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Linux); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("Statistics.Container has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _Statistics_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Statistics)
-	switch tag {
-	case 1: // container.windows
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(WindowsContainerStatistics)
-		err := b.DecodeMessage(msg)
-		m.Container = &Statistics_Windows{msg}
-		return true, err
-	case 2: // container.linux
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(v1.Metrics)
-		err := b.DecodeMessage(msg)
-		m.Container = &Statistics_Linux{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _Statistics_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Statistics)
-	// container
-	switch x := m.Container.(type) {
-	case *Statistics_Windows:
-		s := proto.Size(x.Windows)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Statistics_Linux:
-		s := proto.Size(x.Linux)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type WindowsContainerStatistics struct {
@@ -207,7 +142,7 @@ func (m *WindowsContainerStatistics) XXX_Marshal(b []byte, deterministic bool) (
 		return xxx_messageInfo_WindowsContainerStatistics.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -248,7 +183,7 @@ func (m *WindowsContainerProcessorStatistics) XXX_Marshal(b []byte, deterministi
 		return xxx_messageInfo_WindowsContainerProcessorStatistics.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -289,7 +224,7 @@ func (m *WindowsContainerMemoryStatistics) XXX_Marshal(b []byte, deterministic b
 		return xxx_messageInfo_WindowsContainerMemoryStatistics.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -331,7 +266,7 @@ func (m *WindowsContainerStorageStatistics) XXX_Marshal(b []byte, deterministic 
 		return xxx_messageInfo_WindowsContainerStorageStatistics.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -371,7 +306,7 @@ func (m *VirtualMachineStatistics) XXX_Marshal(b []byte, deterministic bool) ([]
 		return xxx_messageInfo_VirtualMachineStatistics.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -410,7 +345,7 @@ func (m *VirtualMachineProcessorStatistics) XXX_Marshal(b []byte, deterministic 
 		return xxx_messageInfo_VirtualMachineProcessorStatistics.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -451,7 +386,7 @@ func (m *VirtualMachineMemoryStatistics) XXX_Marshal(b []byte, deterministic boo
 		return xxx_messageInfo_VirtualMachineMemoryStatistics.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -496,7 +431,7 @@ func (m *VirtualMachineMemory) XXX_Marshal(b []byte, deterministic bool) ([]byte
 		return xxx_messageInfo_VirtualMachineMemory.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -603,7 +538,7 @@ var fileDescriptor_23217f96da3a05cc = []byte{
 func (m *Statistics) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -611,65 +546,89 @@ func (m *Statistics) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Statistics) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Statistics) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.Container != nil {
-		nn1, err := m.Container.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += nn1
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if m.VM != nil {
-		dAtA[i] = 0x1a
-		i++
-		i = encodeVarintStats(dAtA, i, uint64(m.VM.Size()))
-		n2, err := m.VM.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		{
+			size, err := m.VM.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintStats(dAtA, i, uint64(size))
 		}
-		i += n2
+		i--
+		dAtA[i] = 0x1a
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if m.Container != nil {
+		{
+			size := m.Container.Size()
+			i -= size
+			if _, err := m.Container.MarshalTo(dAtA[i:]); err != nil {
+				return 0, err
+			}
+		}
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *Statistics_Windows) MarshalTo(dAtA []byte) (int, error) {
-	i := 0
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Statistics_Windows) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	if m.Windows != nil {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintStats(dAtA, i, uint64(m.Windows.Size()))
-		n3, err := m.Windows.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		{
+			size, err := m.Windows.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintStats(dAtA, i, uint64(size))
 		}
-		i += n3
+		i--
+		dAtA[i] = 0xa
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 func (m *Statistics_Linux) MarshalTo(dAtA []byte) (int, error) {
-	i := 0
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Statistics_Linux) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	if m.Linux != nil {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintStats(dAtA, i, uint64(m.Linux.Size()))
-		n4, err := m.Linux.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		{
+			size, err := m.Linux.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintStats(dAtA, i, uint64(size))
 		}
-		i += n4
+		i--
+		dAtA[i] = 0x12
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 func (m *WindowsContainerStatistics) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -677,71 +636,83 @@ func (m *WindowsContainerStatistics) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *WindowsContainerStatistics) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *WindowsContainerStatistics) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	dAtA[i] = 0xa
-	i++
-	i = encodeVarintStats(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdTime(m.Timestamp)))
-	n5, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Timestamp, dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n5
-	dAtA[i] = 0x12
-	i++
-	i = encodeVarintStats(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdTime(m.ContainerStartTime)))
-	n6, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.ContainerStartTime, dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n6
-	if m.UptimeNS != 0 {
-		dAtA[i] = 0x18
-		i++
-		i = encodeVarintStats(dAtA, i, uint64(m.UptimeNS))
-	}
-	if m.Processor != nil {
-		dAtA[i] = 0x22
-		i++
-		i = encodeVarintStats(dAtA, i, uint64(m.Processor.Size()))
-		n7, err := m.Processor.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n7
-	}
-	if m.Memory != nil {
-		dAtA[i] = 0x2a
-		i++
-		i = encodeVarintStats(dAtA, i, uint64(m.Memory.Size()))
-		n8, err := m.Memory.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n8
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if m.Storage != nil {
-		dAtA[i] = 0x32
-		i++
-		i = encodeVarintStats(dAtA, i, uint64(m.Storage.Size()))
-		n9, err := m.Storage.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		{
+			size, err := m.Storage.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintStats(dAtA, i, uint64(size))
 		}
-		i += n9
+		i--
+		dAtA[i] = 0x32
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if m.Memory != nil {
+		{
+			size, err := m.Memory.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintStats(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x2a
 	}
-	return i, nil
+	if m.Processor != nil {
+		{
+			size, err := m.Processor.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintStats(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x22
+	}
+	if m.UptimeNS != 0 {
+		i = encodeVarintStats(dAtA, i, uint64(m.UptimeNS))
+		i--
+		dAtA[i] = 0x18
+	}
+	n7, err7 := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.ContainerStartTime, dAtA[i-github_com_gogo_protobuf_types.SizeOfStdTime(m.ContainerStartTime):])
+	if err7 != nil {
+		return 0, err7
+	}
+	i -= n7
+	i = encodeVarintStats(dAtA, i, uint64(n7))
+	i--
+	dAtA[i] = 0x12
+	n8, err8 := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Timestamp, dAtA[i-github_com_gogo_protobuf_types.SizeOfStdTime(m.Timestamp):])
+	if err8 != nil {
+		return 0, err8
+	}
+	i -= n8
+	i = encodeVarintStats(dAtA, i, uint64(n8))
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
 }
 
 func (m *WindowsContainerProcessorStatistics) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -749,35 +720,41 @@ func (m *WindowsContainerProcessorStatistics) Marshal() (dAtA []byte, err error)
 }
 
 func (m *WindowsContainerProcessorStatistics) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *WindowsContainerProcessorStatistics) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.TotalRuntimeNS != 0 {
-		dAtA[i] = 0x8
-		i++
-		i = encodeVarintStats(dAtA, i, uint64(m.TotalRuntimeNS))
-	}
-	if m.RuntimeUserNS != 0 {
-		dAtA[i] = 0x10
-		i++
-		i = encodeVarintStats(dAtA, i, uint64(m.RuntimeUserNS))
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if m.RuntimeKernelNS != 0 {
-		dAtA[i] = 0x18
-		i++
 		i = encodeVarintStats(dAtA, i, uint64(m.RuntimeKernelNS))
+		i--
+		dAtA[i] = 0x18
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if m.RuntimeUserNS != 0 {
+		i = encodeVarintStats(dAtA, i, uint64(m.RuntimeUserNS))
+		i--
+		dAtA[i] = 0x10
 	}
-	return i, nil
+	if m.TotalRuntimeNS != 0 {
+		i = encodeVarintStats(dAtA, i, uint64(m.TotalRuntimeNS))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *WindowsContainerMemoryStatistics) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -785,35 +762,41 @@ func (m *WindowsContainerMemoryStatistics) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *WindowsContainerMemoryStatistics) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *WindowsContainerMemoryStatistics) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.MemoryUsageCommitBytes != 0 {
-		dAtA[i] = 0x8
-		i++
-		i = encodeVarintStats(dAtA, i, uint64(m.MemoryUsageCommitBytes))
-	}
-	if m.MemoryUsageCommitPeakBytes != 0 {
-		dAtA[i] = 0x10
-		i++
-		i = encodeVarintStats(dAtA, i, uint64(m.MemoryUsageCommitPeakBytes))
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if m.MemoryUsagePrivateWorkingSetBytes != 0 {
-		dAtA[i] = 0x18
-		i++
 		i = encodeVarintStats(dAtA, i, uint64(m.MemoryUsagePrivateWorkingSetBytes))
+		i--
+		dAtA[i] = 0x18
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if m.MemoryUsageCommitPeakBytes != 0 {
+		i = encodeVarintStats(dAtA, i, uint64(m.MemoryUsageCommitPeakBytes))
+		i--
+		dAtA[i] = 0x10
 	}
-	return i, nil
+	if m.MemoryUsageCommitBytes != 0 {
+		i = encodeVarintStats(dAtA, i, uint64(m.MemoryUsageCommitBytes))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *WindowsContainerStorageStatistics) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -821,40 +804,46 @@ func (m *WindowsContainerStorageStatistics) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *WindowsContainerStorageStatistics) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *WindowsContainerStorageStatistics) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.ReadCountNormalized != 0 {
-		dAtA[i] = 0x8
-		i++
-		i = encodeVarintStats(dAtA, i, uint64(m.ReadCountNormalized))
-	}
-	if m.ReadSizeBytes != 0 {
-		dAtA[i] = 0x10
-		i++
-		i = encodeVarintStats(dAtA, i, uint64(m.ReadSizeBytes))
-	}
-	if m.WriteCountNormalized != 0 {
-		dAtA[i] = 0x18
-		i++
-		i = encodeVarintStats(dAtA, i, uint64(m.WriteCountNormalized))
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if m.WriteSizeBytes != 0 {
-		dAtA[i] = 0x20
-		i++
 		i = encodeVarintStats(dAtA, i, uint64(m.WriteSizeBytes))
+		i--
+		dAtA[i] = 0x20
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if m.WriteCountNormalized != 0 {
+		i = encodeVarintStats(dAtA, i, uint64(m.WriteCountNormalized))
+		i--
+		dAtA[i] = 0x18
 	}
-	return i, nil
+	if m.ReadSizeBytes != 0 {
+		i = encodeVarintStats(dAtA, i, uint64(m.ReadSizeBytes))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.ReadCountNormalized != 0 {
+		i = encodeVarintStats(dAtA, i, uint64(m.ReadCountNormalized))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *VirtualMachineStatistics) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -862,40 +851,50 @@ func (m *VirtualMachineStatistics) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *VirtualMachineStatistics) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *VirtualMachineStatistics) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.Processor != nil {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintStats(dAtA, i, uint64(m.Processor.Size()))
-		n10, err := m.Processor.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n10
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if m.Memory != nil {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintStats(dAtA, i, uint64(m.Memory.Size()))
-		n11, err := m.Memory.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		{
+			size, err := m.Memory.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintStats(dAtA, i, uint64(size))
 		}
-		i += n11
+		i--
+		dAtA[i] = 0x12
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if m.Processor != nil {
+		{
+			size, err := m.Processor.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintStats(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0xa
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *VirtualMachineProcessorStatistics) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -903,25 +902,31 @@ func (m *VirtualMachineProcessorStatistics) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *VirtualMachineProcessorStatistics) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *VirtualMachineProcessorStatistics) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.TotalRuntimeNS != 0 {
-		dAtA[i] = 0x8
-		i++
-		i = encodeVarintStats(dAtA, i, uint64(m.TotalRuntimeNS))
-	}
 	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
-	return i, nil
+	if m.TotalRuntimeNS != 0 {
+		i = encodeVarintStats(dAtA, i, uint64(m.TotalRuntimeNS))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *VirtualMachineMemoryStatistics) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -929,40 +934,48 @@ func (m *VirtualMachineMemoryStatistics) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *VirtualMachineMemoryStatistics) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *VirtualMachineMemoryStatistics) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.WorkingSetBytes != 0 {
-		dAtA[i] = 0x8
-		i++
-		i = encodeVarintStats(dAtA, i, uint64(m.WorkingSetBytes))
-	}
-	if m.VirtualNodeCount != 0 {
-		dAtA[i] = 0x10
-		i++
-		i = encodeVarintStats(dAtA, i, uint64(m.VirtualNodeCount))
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if m.VmMemory != nil {
-		dAtA[i] = 0x1a
-		i++
-		i = encodeVarintStats(dAtA, i, uint64(m.VmMemory.Size()))
-		n12, err := m.VmMemory.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		{
+			size, err := m.VmMemory.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintStats(dAtA, i, uint64(size))
 		}
-		i += n12
+		i--
+		dAtA[i] = 0x1a
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if m.VirtualNodeCount != 0 {
+		i = encodeVarintStats(dAtA, i, uint64(m.VirtualNodeCount))
+		i--
+		dAtA[i] = 0x10
 	}
-	return i, nil
+	if m.WorkingSetBytes != 0 {
+		i = encodeVarintStats(dAtA, i, uint64(m.WorkingSetBytes))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *VirtualMachineMemory) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -970,74 +983,82 @@ func (m *VirtualMachineMemory) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *VirtualMachineMemory) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *VirtualMachineMemory) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.AvailableMemory != 0 {
-		dAtA[i] = 0x8
-		i++
-		i = encodeVarintStats(dAtA, i, uint64(m.AvailableMemory))
-	}
-	if m.AvailableMemoryBuffer != 0 {
-		dAtA[i] = 0x10
-		i++
-		i = encodeVarintStats(dAtA, i, uint64(m.AvailableMemoryBuffer))
-	}
-	if m.ReservedMemory != 0 {
-		dAtA[i] = 0x18
-		i++
-		i = encodeVarintStats(dAtA, i, uint64(m.ReservedMemory))
-	}
-	if m.AssignedMemory != 0 {
-		dAtA[i] = 0x20
-		i++
-		i = encodeVarintStats(dAtA, i, uint64(m.AssignedMemory))
-	}
-	if m.SlpActive {
-		dAtA[i] = 0x28
-		i++
-		if m.SlpActive {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
-	}
-	if m.BalancingEnabled {
-		dAtA[i] = 0x30
-		i++
-		if m.BalancingEnabled {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if m.DmOperationInProgress {
-		dAtA[i] = 0x38
-		i++
+		i--
 		if m.DmOperationInProgress {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
 		}
-		i++
+		i--
+		dAtA[i] = 0x38
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if m.BalancingEnabled {
+		i--
+		if m.BalancingEnabled {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x30
 	}
-	return i, nil
+	if m.SlpActive {
+		i--
+		if m.SlpActive {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x28
+	}
+	if m.AssignedMemory != 0 {
+		i = encodeVarintStats(dAtA, i, uint64(m.AssignedMemory))
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.ReservedMemory != 0 {
+		i = encodeVarintStats(dAtA, i, uint64(m.ReservedMemory))
+		i--
+		dAtA[i] = 0x18
+	}
+	if m.AvailableMemoryBuffer != 0 {
+		i = encodeVarintStats(dAtA, i, uint64(m.AvailableMemoryBuffer))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.AvailableMemory != 0 {
+		i = encodeVarintStats(dAtA, i, uint64(m.AvailableMemory))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintStats(dAtA []byte, offset int, v uint64) int {
+	offset -= sovStats(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func (m *Statistics) Size() (n int) {
 	if m == nil {
@@ -1270,14 +1291,7 @@ func (m *VirtualMachineMemory) Size() (n int) {
 }
 
 func sovStats(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozStats(x uint64) (n int) {
 	return sovStats(uint64((x << 1) ^ uint64((int64(x) >> 63))))
@@ -1288,7 +1302,7 @@ func (this *Statistics) String() string {
 	}
 	s := strings.Join([]string{`&Statistics{`,
 		`Container:` + fmt.Sprintf("%v", this.Container) + `,`,
-		`VM:` + strings.Replace(fmt.Sprintf("%v", this.VM), "VirtualMachineStatistics", "VirtualMachineStatistics", 1) + `,`,
+		`VM:` + strings.Replace(this.VM.String(), "VirtualMachineStatistics", "VirtualMachineStatistics", 1) + `,`,
 		`XXX_unrecognized:` + fmt.Sprintf("%v", this.XXX_unrecognized) + `,`,
 		`}`,
 	}, "")
@@ -1319,12 +1333,12 @@ func (this *WindowsContainerStatistics) String() string {
 		return "nil"
 	}
 	s := strings.Join([]string{`&WindowsContainerStatistics{`,
-		`Timestamp:` + strings.Replace(strings.Replace(this.Timestamp.String(), "Timestamp", "types.Timestamp", 1), `&`, ``, 1) + `,`,
-		`ContainerStartTime:` + strings.Replace(strings.Replace(this.ContainerStartTime.String(), "Timestamp", "types.Timestamp", 1), `&`, ``, 1) + `,`,
+		`Timestamp:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.Timestamp), "Timestamp", "types.Timestamp", 1), `&`, ``, 1) + `,`,
+		`ContainerStartTime:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", this.ContainerStartTime), "Timestamp", "types.Timestamp", 1), `&`, ``, 1) + `,`,
 		`UptimeNS:` + fmt.Sprintf("%v", this.UptimeNS) + `,`,
-		`Processor:` + strings.Replace(fmt.Sprintf("%v", this.Processor), "WindowsContainerProcessorStatistics", "WindowsContainerProcessorStatistics", 1) + `,`,
-		`Memory:` + strings.Replace(fmt.Sprintf("%v", this.Memory), "WindowsContainerMemoryStatistics", "WindowsContainerMemoryStatistics", 1) + `,`,
-		`Storage:` + strings.Replace(fmt.Sprintf("%v", this.Storage), "WindowsContainerStorageStatistics", "WindowsContainerStorageStatistics", 1) + `,`,
+		`Processor:` + strings.Replace(this.Processor.String(), "WindowsContainerProcessorStatistics", "WindowsContainerProcessorStatistics", 1) + `,`,
+		`Memory:` + strings.Replace(this.Memory.String(), "WindowsContainerMemoryStatistics", "WindowsContainerMemoryStatistics", 1) + `,`,
+		`Storage:` + strings.Replace(this.Storage.String(), "WindowsContainerStorageStatistics", "WindowsContainerStorageStatistics", 1) + `,`,
 		`XXX_unrecognized:` + fmt.Sprintf("%v", this.XXX_unrecognized) + `,`,
 		`}`,
 	}, "")
@@ -1375,8 +1389,8 @@ func (this *VirtualMachineStatistics) String() string {
 		return "nil"
 	}
 	s := strings.Join([]string{`&VirtualMachineStatistics{`,
-		`Processor:` + strings.Replace(fmt.Sprintf("%v", this.Processor), "VirtualMachineProcessorStatistics", "VirtualMachineProcessorStatistics", 1) + `,`,
-		`Memory:` + strings.Replace(fmt.Sprintf("%v", this.Memory), "VirtualMachineMemoryStatistics", "VirtualMachineMemoryStatistics", 1) + `,`,
+		`Processor:` + strings.Replace(this.Processor.String(), "VirtualMachineProcessorStatistics", "VirtualMachineProcessorStatistics", 1) + `,`,
+		`Memory:` + strings.Replace(this.Memory.String(), "VirtualMachineMemoryStatistics", "VirtualMachineMemoryStatistics", 1) + `,`,
 		`XXX_unrecognized:` + fmt.Sprintf("%v", this.XXX_unrecognized) + `,`,
 		`}`,
 	}, "")
@@ -1400,7 +1414,7 @@ func (this *VirtualMachineMemoryStatistics) String() string {
 	s := strings.Join([]string{`&VirtualMachineMemoryStatistics{`,
 		`WorkingSetBytes:` + fmt.Sprintf("%v", this.WorkingSetBytes) + `,`,
 		`VirtualNodeCount:` + fmt.Sprintf("%v", this.VirtualNodeCount) + `,`,
-		`VmMemory:` + strings.Replace(fmt.Sprintf("%v", this.VmMemory), "VirtualMachineMemory", "VirtualMachineMemory", 1) + `,`,
+		`VmMemory:` + strings.Replace(this.VmMemory.String(), "VirtualMachineMemory", "VirtualMachineMemory", 1) + `,`,
 		`XXX_unrecognized:` + fmt.Sprintf("%v", this.XXX_unrecognized) + `,`,
 		`}`,
 	}, "")
@@ -1572,10 +1586,7 @@ func (m *Statistics) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthStats
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthStats
 			}
 			if (iNdEx + skippy) > l {
@@ -1819,10 +1830,7 @@ func (m *WindowsContainerStatistics) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthStats
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthStats
 			}
 			if (iNdEx + skippy) > l {
@@ -1930,10 +1938,7 @@ func (m *WindowsContainerProcessorStatistics) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthStats
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthStats
 			}
 			if (iNdEx + skippy) > l {
@@ -2041,10 +2046,7 @@ func (m *WindowsContainerMemoryStatistics) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthStats
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthStats
 			}
 			if (iNdEx + skippy) > l {
@@ -2171,10 +2173,7 @@ func (m *WindowsContainerStorageStatistics) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthStats
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthStats
 			}
 			if (iNdEx + skippy) > l {
@@ -2297,10 +2296,7 @@ func (m *VirtualMachineStatistics) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthStats
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthStats
 			}
 			if (iNdEx + skippy) > l {
@@ -2370,10 +2366,7 @@ func (m *VirtualMachineProcessorStatistics) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthStats
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthStats
 			}
 			if (iNdEx + skippy) > l {
@@ -2498,10 +2491,7 @@ func (m *VirtualMachineMemoryStatistics) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthStats
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthStats
 			}
 			if (iNdEx + skippy) > l {
@@ -2688,10 +2678,7 @@ func (m *VirtualMachineMemory) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthStats
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthStats
 			}
 			if (iNdEx + skippy) > l {
@@ -2710,6 +2697,7 @@ func (m *VirtualMachineMemory) Unmarshal(dAtA []byte) error {
 func skipStats(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -2741,10 +2729,8 @@ func skipStats(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -2765,55 +2751,30 @@ func skipStats(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthStats
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthStats
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowStats
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipStats(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthStats
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupStats
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthStats
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthStats = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowStats   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthStats        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowStats          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupStats = fmt.Errorf("proto: unexpected end of group")
 )

--- a/vendor/github.com/Microsoft/hcsshim/internal/regstate/zsyscall_windows.go
+++ b/vendor/github.com/Microsoft/hcsshim/internal/regstate/zsyscall_windows.go
@@ -19,6 +19,7 @@ const (
 
 var (
 	errERROR_IO_PENDING error = syscall.Errno(errnoERROR_IO_PENDING)
+	errERROR_EINVAL     error = syscall.EINVAL
 )
 
 // errnoErr returns common boxed Errno values, to prevent
@@ -26,7 +27,7 @@ var (
 func errnoErr(e syscall.Errno) error {
 	switch e {
 	case 0:
-		return nil
+		return errERROR_EINVAL
 	case errnoERROR_IO_PENDING:
 		return errERROR_IO_PENDING
 	}

--- a/vendor/github.com/Microsoft/hcsshim/internal/winapi/winapi.go
+++ b/vendor/github.com/Microsoft/hcsshim/internal/winapi/winapi.go
@@ -2,4 +2,4 @@
 // be thought of as an extension to golang.org/x/sys/windows.
 package winapi
 
-//go:generate go run ..\..\mksyscall_windows.go -output zsyscall_windows.go user.go console.go system.go net.go path.go thread.go jobobject.go logon.go memory.go process.go processor.go devices.go filesystem.go errors.go
+//go:generate go run ..\..\mksyscall_windows.go -output zsyscall_windows.go console.go system.go net.go path.go thread.go jobobject.go logon.go memory.go process.go processor.go devices.go filesystem.go errors.go

--- a/vendor/github.com/Microsoft/hcsshim/pkg/go-runhcs/runhcs.go
+++ b/vendor/github.com/Microsoft/hcsshim/pkg/go-runhcs/runhcs.go
@@ -3,6 +3,7 @@ package runhcs
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -34,6 +35,11 @@ func getCommandPath() string {
 	pathi := runhcsPath.Load()
 	if pathi == nil {
 		path, err := exec.LookPath(command)
+		if err != nil {
+			if errors.Is(err, exec.ErrDot) {
+				err = nil
+			}
+		}
 		if err != nil {
 			// LookPath only finds current directory matches based on the
 			// callers current directory but the caller is not likely in the

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ dario.cat/mergo
 # github.com/AdaLogics/go-fuzz-headers v0.0.0-20210715213245-6c3934b029d8
 ## explicit; go 1.13
 github.com/AdaLogics/go-fuzz-headers
-# github.com/Microsoft/go-winio v0.5.2
+# github.com/Microsoft/go-winio v0.5.3
 ## explicit; go 1.13
 github.com/Microsoft/go-winio
 github.com/Microsoft/go-winio/backuptar

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -16,7 +16,7 @@ github.com/Microsoft/go-winio/pkg/fs
 github.com/Microsoft/go-winio/pkg/guid
 github.com/Microsoft/go-winio/pkg/security
 github.com/Microsoft/go-winio/vhd
-# github.com/Microsoft/hcsshim v0.9.10
+# github.com/Microsoft/hcsshim v0.9.11
 ## explicit; go 1.13
 github.com/Microsoft/hcsshim
 github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options


### PR DESCRIPTION
go-winio breaks on go1.22 (at runtime) due to alignment issues. This prevents an error while extracing layers:

  Invalid access to memory location

See:
- https://github.com/golang/go/issues/65069
- https://github.com/moby/moby/pull/47743
- https://github.com/microsoft/go-winio/pull/312

Related:
- https://github.com/kubernetes-sigs/cri-tools/pull/1387#issuecomment-2120481609
