### PR TITLE
[release/1.6] Prepare release notes for v1.6.32

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -146,6 +146,7 @@ Zhongming Chang<zhongming.chang@daocloud.io>
 Zhoulin Xie <zhoulin.xie@daocloud.io>
 Zhoulin Xie <zhoulin.xie@daocloud.io> <42261994+JoeWrightss@users.noreply.github.com>
 zounengren <zouyee1989@gmail.com> <zounengren@cmss.chinamobile.com>
+张钰 <zhang.yu58@zte.com.cn>
 张潇 <xiaozhang0210@hotmail.com>
 Kazuyoshi Kato <kaz@fly.io> <katokazu@amazon.com>
 Andrey Epifanov <epifanov.andrey@gmail.com> <aepifanov@mirantis.com>

--- a/releases/v1.6.32.toml
+++ b/releases/v1.6.32.toml
@@ -1,0 +1,26 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.6.31"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The thirty-second patch release for containerd 1.6 contains various fixes and updates.
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.31+unknown"
+	Version = "1.6.32+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated notes...

---

Welcome to the v1.6.32 release of containerd!

The thirty-second patch release for containerd 1.6 contains various fixes and updates.

### Highlights

* Handle unsupported config versions ([#10234](https://github.com/containerd/containerd/pull/10234))
* Preserve CL_UNPRIVILEGED locked flags during remount of bind mounts ([#10212](https://github.com/containerd/containerd/pull/10212))
* Update metadata snapshotter to lease on already exists ([#10199](https://github.com/containerd/containerd/pull/10199))
* Update apparmor template to allow confined runc to kill containers ([#10130](https://github.com/containerd/containerd/pull/10130))
* Prevent GC from schedule itself with 0 period. ([#10103](https://github.com/containerd/containerd/pull/10103))
* Configure otel from env instead of config.toml ([#9993](https://github.com/containerd/containerd/pull/9993))

#### Container Runtime Interface (CRI)

* Fix snapshotter root path when not under containerd root ([#10127](https://github.com/containerd/containerd/pull/10127))
* Fix CreatedAt time set to 269 years ago if create network failed ([#10119](https://github.com/containerd/containerd/pull/10119))
* Fix unexpected order of mounts ([#10045](https://github.com/containerd/containerd/pull/10045))

#### Image Distribution

* Update HTTP fallback to better account for TLS timeout and previous attempts ([#10113](https://github.com/containerd/containerd/pull/10113))
* Fix use of invalid token on retry fetching layer ([#10064](https://github.com/containerd/containerd/pull/10064))

#### Deprecations

* Configure otel from env instead of config.toml ([#9993](https://github.com/containerd/containerd/pull/9993))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Stefan Berger
* Derek McGowan
* Austin Vazquez
* Kazuyoshi Kato
* Phil Estes
* Akihiro Suda
* Maksym Pavlenko
* Brian Goff
* Danny Canter
* Samuel Karp
* Alexandru Matei
* Bin Tang
* Brandon Lum
* Bryant Biggs
* Jimmy Hsiao
* Kirill A. Korinsky
* Paweł Gronowski
* Sebastiaan van Stijn
* Swagat Bora
* Tomáš Virtus
* Tony Fang
* 张钰
* 沈陵

### Changes
<details><summary>48 commits</summary>
<p>

* Handle unsupported config versions ([#10234](https://github.com/containerd/containerd/pull/10234))
  * [`38607b59c`](https://github.com/containerd/containerd/commit/38607b59c1a308b406c2bdfe4520a302cf65ef9e) Add check for unsupported config versions
* Preserve CL_UNPRIVILEGED locked flags during remount of bind mounts ([#10212](https://github.com/containerd/containerd/pull/10212))
  * [`c65da6997`](https://github.com/containerd/containerd/commit/c65da69970d3747fa6bc22c2bc1fce2fb7d48905) Preserve CL_UNPRIVILEGED locked flags during remount of bind mounts
* vendor: github.com/containerd/imgcrypt@v1.1.8 ([#10216](https://github.com/containerd/containerd/pull/10216))
  * [`6951203b1`](https://github.com/containerd/containerd/commit/6951203b18499c792062578d391bd6711787f68f) vendor: github.com/containerd/imgcrypt@v1.1.8
* vendor: golang.org/x/net@v0.23.0 ([#10214](https://github.com/containerd/containerd/pull/10214))
  * [`a14e5ec8b`](https://github.com/containerd/containerd/commit/a14e5ec8b8bc2f80d145daab997faae2daac00f6) vendor: golang.org/x/net@v0.23.0
  * [`fd21d7818`](https://github.com/containerd/containerd/commit/fd21d781876f761a32fa4c41d0f5997a03dbde79) vendor: golang.org/x/net@v0.21.0
  * [`d276debb0`](https://github.com/containerd/containerd/commit/d276debb01cccc17ce15298996fe7340b0f2d58b) vendor: golang.org/x/net@v0.20.0
  * [`f82033dcf`](https://github.com/containerd/containerd/commit/f82033dcf434ddef4ce052e831aee82e1757193a) vendor: golang.org/x/net@v0.19.0
  * [`411c5e5e5`](https://github.com/containerd/containerd/commit/411c5e5e5d325ffc1a2f1f01b18b745766cd081a) vendor: golang.org/x/term@v0.17.0
  * [`6f053bd1f`](https://github.com/containerd/containerd/commit/6f053bd1f08e60db3c390a05752edbc49c7d1c6e) vendor: golang.org/x/sys@v0.18.0
  * [`cfd8443cb`](https://github.com/containerd/containerd/commit/cfd8443cb113e4536cec4b99e1431d0a8b55dab9) vendor: golang.org/x/sys@v0.17.0
* Update tooling to Go 1.21.10, 1.22.3 for net/http bug fixes ([#10208](https://github.com/containerd/containerd/pull/10208))
  * [`5b4facbd6`](https://github.com/containerd/containerd/commit/5b4facbd663a5ead60f20cc914014edc2a6d5a2a) Update toolchain to Go 1.21.10 and 1.22.3
* Update metadata snapshotter to lease on already exists ([#10199](https://github.com/containerd/containerd/pull/10199))
  * [`57860c1b6`](https://github.com/containerd/containerd/commit/57860c1b617852b0b60993035ec8a6d4798a720c) Add lease test for metadata snapshotter
  * [`b095401df`](https://github.com/containerd/containerd/commit/b095401dfb6c846117c219ff2d1e4add7ea392a1) Update metadata snapshotter to lease on exists
* Update image-spec ([#10185](https://github.com/containerd/containerd/pull/10185))
  * [`fd8d35752`](https://github.com/containerd/containerd/commit/fd8d35752b1a86d251aa9464f94a83750494a68d) Update image-spec to v1.1.0
  * [`89b975d81`](https://github.com/containerd/containerd/commit/89b975d8146d01415b1f5da0036fdd6587e8fe8b) go.mod: github.com/opencontainers/image-spec v1.1.0-rc3
* Fix snapshotter root path when not under containerd root ([#10127](https://github.com/containerd/containerd/pull/10127))
  * [`f3e8b2ca1`](https://github.com/containerd/containerd/commit/f3e8b2ca199ea760e5f574544ab0ec7da89c9484) CRI: "Fix" imageFSPath behavior
  * [`68db74d19`](https://github.com/containerd/containerd/commit/68db74d191f0bb6d8bb279c6d8c336a5683f19c0) Snapshotters: Export the root path
  * [`cd9b74640`](https://github.com/containerd/containerd/commit/cd9b7464045eb7bad9506b6579caa558c868dc95) Add exports to proxy plugin config
  * [`83cf026b2`](https://github.com/containerd/containerd/commit/83cf026b261e83b10c1c724991669d6d298997b4) Add platform config to proxy plugins
* Update apparmor template to allow confined runc to kill containers ([#10130](https://github.com/containerd/containerd/pull/10130))
  * [`63c41d003`](https://github.com/containerd/containerd/commit/63c41d0038a7120dbb6e664c6b3dee0220977c4a) apparmor: Allow confined runc to kill containers
* Update HTTP fallback to better account for TLS timeout and previous attempts ([#10113](https://github.com/containerd/containerd/pull/10113))
  * [`b12c3b0c8`](https://github.com/containerd/containerd/commit/b12c3b0c8b4885fb200619f99dd716aff330c6a3) Add deprecated HTTPFallback for package compatibility
  * [`239955890`](https://github.com/containerd/containerd/commit/2399558900d9836b1a7cabb97e17901fb85c566a) Update HTTPFallback to handle tls handshake timeout
  * [`b2a0ac0b4`](https://github.com/containerd/containerd/commit/b2a0ac0b480afd2f9eb7a43f1c5234e22fb5cc9b) Remove empty default tls configuration in ctr
* update to go1.21.9, go1.22.2 ([#10117](https://github.com/containerd/containerd/pull/10117))
  * [`ea9a8c608`](https://github.com/containerd/containerd/commit/ea9a8c608404d421c481d9bddd4f9a56c20762f0) update to go1.21.9, go1.22.2
* Fix CreatedAt time set to 269 years ago if create network failed ([#10119](https://github.com/containerd/containerd/pull/10119))
  * [`c809fa268`](https://github.com/containerd/containerd/commit/c809fa26864cf14b0ae2b4c842e57832c115b541) pod: CreatedAt time will be 269 years ago while creating cri network failed.
* Prevent GC from schedule itself with 0 period. ([#10103](https://github.com/containerd/containerd/pull/10103))
  * [`6ddec44bd`](https://github.com/containerd/containerd/commit/6ddec44bd25708281e1717cf0dfae86dcc1f4710) Prevent GC from schedule itself with 0 period.
* Configure otel from env instead of config.toml ([#9993](https://github.com/containerd/containerd/pull/9993))
  * [`86a1a3a82`](https://github.com/containerd/containerd/commit/86a1a3a828afeb281a266171e4090d12d6c26f06) vendor: revendor OTEL
  * [`e15d4a8b8`](https://github.com/containerd/containerd/commit/e15d4a8b8c9c3edcf6754520c64c7419e9aa57d3) Changes to configuring otel from env only
  * [`2fda262a9`](https://github.com/containerd/containerd/commit/2fda262a943f7a86b13e52c47b6e70a553cf422a) Deprecate otel configs
  * [`c80347ec5`](https://github.com/containerd/containerd/commit/c80347ec5839b45259d57bd544cd38bf69d30095) Adding unit tests to opentelemetry tracing
* Fix use of invalid token on retry fetching layer ([#10064](https://github.com/containerd/containerd/pull/10064))
  * [`f1a14a12a`](https://github.com/containerd/containerd/commit/f1a14a12ac5574095a3d81bb9941971a5af0ffd2) fix bug that using invalid token to retry fetching layer
* Fix unexpected order of mounts ([#10045](https://github.com/containerd/containerd/pull/10045))
  * [`9701cf998`](https://github.com/containerd/containerd/commit/9701cf998f6f86d14072a44bc922e4c82aee4684) fix(cri): fix unexpected order of mounts since go 1.19
</p>
</details>

### Changes from containerd/imgcrypt
<details><summary>89 commits</summary>
<p>

* CHANGES: Updated CHANGES document for 1.1.8 release ([containerd/imgcrypt#122](https://github.com/containerd/imgcrypt/pull/122))
  * [`956b4d3`](https://github.com/containerd/imgcrypt/commit/956b4d3fe3ed647032725bf1585f68b2a38b2b13) CHANGES: Updated CHANGES document for 1.1.8 release
* Synchronize enc-ctr with upstream ctr from containerd v1.6.23 and use containerd v1.6.23 in dependency ([containerd/imgcrypt#120](https://github.com/containerd/imgcrypt/pull/120))
  * [`9e8e1c1`](https://github.com/containerd/imgcrypt/commit/9e8e1c1df3660f869c7fbd49135a8cd6bf91fe7c) ctr: Sync code with containerd v1.6.23 ctr
  * [`7d2cca5`](https://github.com/containerd/imgcrypt/commit/7d2cca5efde78e5c5bce11e831d61077cf9166e1) build(deps): bump containerd from 1.6.20 to 1.6.23
* Synchronize enc-ctr with upstream ctr from containerd v1.6.20 ([containerd/imgcrypt#119](https://github.com/containerd/imgcrypt/pull/119))
  * [`0f2559e`](https://github.com/containerd/imgcrypt/commit/0f2559e3c9bb4c80ea422560af2bdb1334d70f88) ctr: Sync code with containerd v1.6.20 ctr
  * [`c48dd78`](https://github.com/containerd/imgcrypt/commit/c48dd787005e197c12e924727ea2b0be75a6e66b) cmd: Copy IntToInt32Array into img package and use it
* Update to ocicrypt 1.1.8 and minimum go 1.20 ([containerd/imgcrypt#118](https://github.com/containerd/imgcrypt/pull/118))
  * [`6d48a4e`](https://github.com/containerd/imgcrypt/commit/6d48a4ecc325e1aaf531110b5aa9beece4eafc4c) build(deps): bump ocicrypt from 1.1.7 to 1.1.8
  * [`1bc94a2`](https://github.com/containerd/imgcrypt/commit/1bc94a206e90d4f79dbb137c922b32b71662c78b) github: Use golangci-lint v1.54.1 and adjust config file
  * [`9065f1d`](https://github.com/containerd/imgcrypt/commit/9065f1da9e4f607df34eff64d6e24530f7b3a136) github: Test with go 1.21 and go 1.20
  * [`74986f3`](https://github.com/containerd/imgcrypt/commit/74986f3687f84523a4612bd7c6975463b68b3b10) go.mod: Require go 1.20
* build(deps): bump google.golang.org/grpc from 1.47.0 to 1.53.0 ([containerd/imgcrypt#117](https://github.com/containerd/imgcrypt/pull/117))
  * [`a2a8273`](https://github.com/containerd/imgcrypt/commit/a2a82731875004f0dd33dff929201456e3f702e1) build(deps): bump google.golang.org/grpc from 1.47.0 to 1.53.0
* test: Test creating and running of container with key file missing ([containerd/imgcrypt#116](https://github.com/containerd/imgcrypt/pull/116))
  * [`286470a`](https://github.com/containerd/imgcrypt/commit/286470a95699ac0cb19a3de79a7a215cafc8f2c7) test: Test creating and running of container with key file missing
* Fix some issues in the test script ([containerd/imgcrypt#115](https://github.com/containerd/imgcrypt/pull/115))
  * [`aa517cc`](https://github.com/containerd/imgcrypt/commit/aa517cc77654cf517cc7bba5529b07da92f033dc) test: Fix order of parameters and remove unnecessary key parameter
  * [`ec72311`](https://github.com/containerd/imgcrypt/commit/ec7231185e276feb10f5b4b974ade62a81d5e9ad) test: Add comments to test case
  * [`2959ec0`](https://github.com/containerd/imgcrypt/commit/2959ec0ec47786956223715812f40eb9e7301786) test: To be able to run testLocalKeys alone add missing env variable
* build(deps): upgrade github.com/containerd/containerd from 1.6.18 to … ([containerd/imgcrypt#112](https://github.com/containerd/imgcrypt/pull/112))
  * [`a7f2760`](https://github.com/containerd/imgcrypt/commit/a7f2760c719863cc015e4638090db4ef23daecd1) build(deps): upgrade github.com/containerd/containerd from 1.6.18 to 1.6.20
* ci: Update golangci-lint to v1.52.2 ([containerd/imgcrypt#113](https://github.com/containerd/imgcrypt/pull/113))
  * [`002abac`](https://github.com/containerd/imgcrypt/commit/002abac5a58aebef74a13bb7e30302b01f07b419) images: Change 'any' to 'anything' to avoid clash with built-in type 'any'
  * [`5780ecc`](https://github.com/containerd/imgcrypt/commit/5780ecc88b4b08c4f1d8e6372869e39ab1fcbf35) images: Replace unused function parameters with '_'
  * [`7dc8592`](https://github.com/containerd/imgcrypt/commit/7dc85928e244990cb3371c63d2a8caae5189b757) ci: Update golangci-lint to v1.52.2
* build(deps): bump github.com/opencontainers/runc from 1.1.2 to 1.1.5 ([containerd/imgcrypt#109](https://github.com/containerd/imgcrypt/pull/109))
  * [`90e4f77`](https://github.com/containerd/imgcrypt/commit/90e4f77bdc085a6f6d426380fa7cf0227ea03173) build(deps): bump github.com/opencontainers/runc from 1.1.2 to 1.1.5
* Abandon go 1.18 (end-of-life) and use 1.19 and 1.20 in tests ([containerd/imgcrypt#110](https://github.com/containerd/imgcrypt/pull/110))
  * [`8fc037f`](https://github.com/containerd/imgcrypt/commit/8fc037fd2de0e6106a3e8da655be22a1d4da719c) tests: Upgrade toml written by test case to version 2
  * [`0b31beb`](https://github.com/containerd/imgcrypt/commit/0b31beb1c7b6391b50ff44d9a71bed452bcebf2d) ci: Run tests with go 1.19 and 1.20 (abandon 1.18)
  * [`523674c`](https://github.com/containerd/imgcrypt/commit/523674c781c15e461afe52d8086deb4dd0d61466) build(deps): Update to minimum required go v1.19
* Update to golang.org/x/net@v0.7.0 and github.com/containers/ocicrypt@v1.1.7 ([containerd/imgcrypt#107](https://github.com/containerd/imgcrypt/pull/107))
  * [`96a2314`](https://github.com/containerd/imgcrypt/commit/96a2314e83ba412568800a7dd84789f59f1310ec) build(deps): Upgrade to github.com/containers/ocicrypt@v1.1.7
  * [`1c50555`](https://github.com/containerd/imgcrypt/commit/1c5055514add4b6715cb4da0a127f8200d0d190a) bulid(deps): Update to golang.org/x/net@v0.7.0
  * [`9645d39`](https://github.com/containerd/imgcrypt/commit/9645d39f070c7f6728ec4e1831fbede7ebd512ec) build(deps): Update to minimum required go v1.18
* build(deps): bump github.com/containerd/containerd from 1.6.12 to 1.6.18 ([containerd/imgcrypt#106](https://github.com/containerd/imgcrypt/pull/106))
  * [`8daaa45`](https://github.com/containerd/imgcrypt/commit/8daaa45a63100dc95430fc22eb2b5e95772b245f) build(deps): bump github.com/containerd/containerd from 1.6.12 to 1.6.18
* README: Fix a typo ([containerd/imgcrypt#105](https://github.com/containerd/imgcrypt/pull/105))
  * [`12e84f5`](https://github.com/containerd/imgcrypt/commit/12e84f51fb70e1fb2bcc624206f707b48671b352) README: Fix a typo
* build(deps): bump github.com/containerd/containerd from 1.6.8 to 1.6.12 ([containerd/imgcrypt#103](https://github.com/containerd/imgcrypt/pull/103))
  * [`4e5a73e`](https://github.com/containerd/imgcrypt/commit/4e5a73e393254df6091fc9b3bf54371be778060f) build(deps): bump github.com/containerd/containerd from 1.6.8 to 1.6.12
* Update golangci-lint to v1.50.1 ([containerd/imgcrypt#101](https://github.com/containerd/imgcrypt/pull/101))
  * [`16a071b`](https://github.com/containerd/imgcrypt/commit/16a071b983f1777ff6391be0d44e80370fd58bf9) Update golangci-lint to v1.50.1
* Remove references to package io/ioutil ([containerd/imgcrypt#100](https://github.com/containerd/imgcrypt/pull/100))
  * [`981a3fd`](https://github.com/containerd/imgcrypt/commit/981a3fdd5a755a1521337010bec47874753508cb) Remove references to package io/ioutil
* Update GitHub actions CI workflow ([containerd/imgcrypt#99](https://github.com/containerd/imgcrypt/pull/99))
  * [`06827a1`](https://github.com/containerd/imgcrypt/commit/06827a1d8664a277fed24a41cd1566c197f58814) Update containerd project checks package in CI
  * [`f6a39e1`](https://github.com/containerd/imgcrypt/commit/f6a39e1bcd21af406254aa5da1e7f89f26e914cd) Update GitHub actions packages in CI workflow
  * [`6383351`](https://github.com/containerd/imgcrypt/commit/6383351756ec706b0f6aeea1a9dfc737c71bece7) Update GitHub actions CI workflow OS runner images
* CI/CD: Run CodeQL on PRs and once a month ([containerd/imgcrypt#98](https://github.com/containerd/imgcrypt/pull/98))
  * [`b6e16db`](https://github.com/containerd/imgcrypt/commit/b6e16db881eef08e0bb58d0885bfad8339c97f2f) CI/CD: Run CodeQL on PRs and once a month
* CHANGES: Updated CHANGES document for 1.1.7 release ([containerd/imgcrypt#97](https://github.com/containerd/imgcrypt/pull/97))
  * [`17e5e7f`](https://github.com/containerd/imgcrypt/commit/17e5e7f7909b4e6a295e2dbef7b534339df84707) CHANGES: Updated CHANGES document for 1.1.7 release
* Update to ocicrypt 1.1.6 and add support for zstd type of compressed layers  ([containerd/imgcrypt#96](https://github.com/containerd/imgcrypt/pull/96))
  * [`06da359`](https://github.com/containerd/imgcrypt/commit/06da359b7360e9b70590cf25998511774b3f375c) Add support for zstd type of compressed layers
  * [`4a51045`](https://github.com/containerd/imgcrypt/commit/4a51045e4c2c4aeacad5915c8dcc9b2dc5076495) build(deps): Update to ocicrypt 1.1.6
  * [`2c93cef`](https://github.com/containerd/imgcrypt/commit/2c93cef1eb0b48263d16f5f2289a1a3f49a17d39) ctr: Document that import of encrypted image requires decryption key
  * [`44f4e18`](https://github.com/containerd/imgcrypt/commit/44f4e187e213680151e657fcd9924de800dac356) ctr: Add support for --all-platforms to encrypt command
  * [`d9fccdc`](https://github.com/containerd/imgcrypt/commit/d9fccdc4639f4a309e23adaf17ed5460ad385c2c) ctr: Sync with upstream ctr and add --skip-digest-for-named opt to import
  * [`b8f807f`](https://github.com/containerd/imgcrypt/commit/b8f807f68aefbd292ab45f855b6905c77272d521) ctr: Sync with upstream ctr and add --platform option to import
* build(deps): Update to containerd 1.6.8 ([containerd/imgcrypt#92](https://github.com/containerd/imgcrypt/pull/92))
  * [`07dd48d`](https://github.com/containerd/imgcrypt/commit/07dd48dc69766f965c9d73d5c257c05c869be71d) build(deps): Update to containerd 1.6.8
* tests: Add -traditional to OpenSSL command line when OSSL v3 is used ([containerd/imgcrypt#90](https://github.com/containerd/imgcrypt/pull/90))
  * [`67b7b5d`](https://github.com/containerd/imgcrypt/commit/67b7b5dd3b2783cdfefcb483bf8718b4df305f5e) tests: Add -traditional to OpenSSL command line when OSSL v3 is used
* chore: fix readme typo ([containerd/imgcrypt#87](https://github.com/containerd/imgcrypt/pull/87))
  * [`98e43be`](https://github.com/containerd/imgcrypt/commit/98e43be32177a4dbfce2d4ecaab8bb301f311d20) chore: fix readme typo
* Update to min golang 1.18 ([containerd/imgcrypt#88](https://github.com/containerd/imgcrypt/pull/88))
  * [`554ec9b`](https://github.com/containerd/imgcrypt/commit/554ec9bc51ae03a8f7226677ae543630942ee3b9) Update to min golang 1.18
* CHANGES: Updated CHANGES document for 1.1.6 release ([containerd/imgcrypt#85](https://github.com/containerd/imgcrypt/pull/85))
  * [`ec7aae5`](https://github.com/containerd/imgcrypt/commit/ec7aae54455d172bc155a226234cb849c559e6a7) CHANGES: Updated CHANGES document for 1.1.6 release
* build(deps): bump github.com/containerd/containerd from 1.6.1 to 1.6.6 ([containerd/imgcrypt#83](https://github.com/containerd/imgcrypt/pull/83))
  * [`5959e8c`](https://github.com/containerd/imgcrypt/commit/5959e8cf6db81b1be0bc112f10a9bebcf7cd5980) build(deps): bump github.com/containerd/containerd from 1.6.1 to 1.6.6
* CI: Upgrade to golangci-lint v1.46.2 ([containerd/imgcrypt#84](https://github.com/containerd/imgcrypt/pull/84))
  * [`ef8596e`](https://github.com/containerd/imgcrypt/commit/ef8596ecba1f5e9e815ea6b86159da4acd2f7f80) CI: Upgrade to golangci-lint v1.46.2
  * [`715ba8c`](https://github.com/containerd/imgcrypt/commit/715ba8c513d753e96afc0bb2f13a2eeede1b1def) Update to ocicrypt 1.1.5 to get yaml.v3
  * [`4f79bd6`](https://github.com/containerd/imgcrypt/commit/4f79bd6774334325ef7ed534721a7475ce9c5d4c) CHANGES: Updated CHANGES document for 1.1.5 release
  * [`4c38f10`](https://github.com/containerd/imgcrypt/commit/4c38f1094be27e56b0856eded996a021ccc82fcf) Bump ocicrypt to 1.1.4
* CICD: Rename master branch to main ([containerd/imgcrypt#79](https://github.com/containerd/imgcrypt/pull/79))
  * [`8abd19d`](https://github.com/containerd/imgcrypt/commit/8abd19d902ec878d0fe6f53daa20ceccbacb842d) CICD: Rename master branch to main
* Rename any to pbAny ([containerd/imgcrypt#78](https://github.com/containerd/imgcrypt/pull/78))
  * [`0e5d997`](https://github.com/containerd/imgcrypt/commit/0e5d9970419eb2300438bc62a5f9ae0282aa5b1d) Rename any to pbAny
  * [`cb14b45`](https://github.com/containerd/imgcrypt/commit/cb14b455fec922ba2d70083d3b498748ff37f708) Test with Go 1.18
* Use reflect to support diff.ApplyConfig with/without gogo's types.Any ([containerd/imgcrypt#75](https://github.com/containerd/imgcrypt/pull/75))
  * [`9f08722`](https://github.com/containerd/imgcrypt/commit/9f08722adedb188e4ad6e482c0641203f8e04334) Use reflect to support diff.ApplyConfig with/without gogo's types.Any
* Upgrade golangci-lint-action and golangci-lint ([containerd/imgcrypt#76](https://github.com/containerd/imgcrypt/pull/76))
  * [`6eaeb4a`](https://github.com/containerd/imgcrypt/commit/6eaeb4a586fe906fe9dff943c68b9ced0d16619d) Add build tags to make gofmt happy
  * [`9cba55f`](https://github.com/containerd/imgcrypt/commit/9cba55fc43560a29686864ad6eb00c815593c890) Upgrade golangci-lint-action and golangci-lint
</p>
</details>

### Dependency Changes

* **github.com/containerd/imgcrypt**        v1.1.4 -> v1.1.8
* **github.com/containers/ocicrypt**        v1.1.3 -> v1.1.10
* **github.com/go-jose/go-jose/v3**         v3.0.3 **_new_**
* **github.com/opencontainers/image-spec**  3a7f492d3f1b -> v1.1.0
* **github.com/stefanberger/go-pkcs11uri**  78d3cae3a980 -> 78284954bff6
* **golang.org/x/crypto**                   v0.18.0 -> v0.21.0
* **golang.org/x/net**                      v0.18.0 -> v0.23.0
* **golang.org/x/sys**                      v0.16.0 -> v0.18.0
* **golang.org/x/term**                     v0.16.0 -> v0.18.0

Previous release can be found at [v1.6.31](https://github.com/containerd/containerd/releases/tag/v1.6.31)

