### PR TITLE
core/image: fix usage of "unknown" platform

### DIFF
--- a/core/images/image.go
+++ b/core/images/image.go
@@ -272,6 +272,9 @@ func Platforms(ctx context.Context, provider content.Provider, image ocispec.Des
 	var platformSpecs []ocispec.Platform
 	return platformSpecs, Walk(ctx, Handlers(HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 		if desc.Platform != nil {
+			if desc.Platform.OS == "unknown" || desc.Platform.Architecture == "unknown" {
+				return nil, ErrSkipDesc
+			}
 			platformSpecs = append(platformSpecs, *desc.Platform)
 			return nil, ErrSkipDesc
 		}


### PR DESCRIPTION
"unknown" platform should not be returned from `Platforms()` as a valid platform type for an image.

Fixes: #10196 