### PR TITLE
fix(metrics): correct image pull throughput calculation

### DIFF
--- a/internal/cri/server/images/image_pull.go
+++ b/internal/cri/server/images/image_pull.go
@@ -235,13 +235,12 @@ func (c *CRIImageService) PullImage(ctx context.Context, name string, credential
 		}
 	}
 
-	const mbToByte = 1024 * 1024
-	size, _ := image.Size(ctx)
-	imagePullingSpeed := float64(size) / mbToByte / time.Since(startTime).Seconds()
+	sizeByte, _ := image.Size(ctx)
+	imagePullingSpeed := float64(sizeByte) / time.Since(startTime).Seconds()
 	imagePullThroughput.Observe(imagePullingSpeed)
 
 	log.G(ctx).Infof("Pulled image %q with image id %q, repo tag %q, repo digest %q, size %q in %s", name, imageID,
-		repoTag, repoDigest, strconv.FormatInt(size, 10), time.Since(startTime))
+		repoTag, repoDigest, strconv.FormatInt(sizeByte, 10), time.Since(startTime))
 	// NOTE(random-liu): the actual state in containerd is the source of truth, even we maintain
 	// in-memory image store, it's only for in-memory indexing. The image could be removed
 	// by someone else anytime, before/during/after we create the metadata. We should always


### PR DESCRIPTION
Hello there,

If I'm correct, `image.Size()` returns an addition of blob sizes that are already in bytes, so the division is not needed here.

https://github.com/containerd/containerd/blob/504bd152732dfa1dd162f3c7543ce24a22b734f0/client/image.go#L176-L178

https://github.com/containerd/containerd/blob/504bd152732dfa1dd162f3c7543ce24a22b734f0/core/images/usage/calculator.go#L142

https://github.com/containerd/containerd/blob/504bd152732dfa1dd162f3c7543ce24a22b734f0/core/snapshots/snapshotter.go#L175