### PR TITLE
Explicitly set release latest to false

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,3 +156,4 @@ jobs:
           body_path: ./builds/containerd-release-notes/release-notes.md
           files: |
             builds/release-tars-**/*
+          make_latest: false


### PR DESCRIPTION
### Issue
Partial #10262 

### Description
This change disables marking of containerd mainline releases as latest.