### PR TITLE
[release/1.7] Explicitly set release latest to true

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,7 @@ jobs:
         with:
           path: builds
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,3 +156,4 @@ jobs:
           body_path: ./builds/containerd-release-notes/release-notes.md
           files: |
             builds/release-tars-**/*
+          make_latest: true


### PR DESCRIPTION
### Issue
Partial #10262 

### Description
This change enables marking of containerd 1.7 releases as latest. This change backports https://github.com/containerd/containerd/commit/21d3fedf44335e1a971b9099e79eb0cba450d092 which updates the `action-gh-release` package from v1 to v2 which adds the `make_latest` functionality required by the change.