### PR TITLE
*: export RemoveVolatileOption for CRI image volumes

### DIFF
--- a/core/mount/mount_test.go
+++ b/core/mount/mount_test.go
@@ -250,7 +250,7 @@ func TestRemoveVolatileTempMount(t *testing.T) {
 
 	for _, tc := range testCases {
 		original := copyMounts(tc.input)
-		actual := removeVolatileTempMount(tc.input)
+		actual := RemoveVolatileOption(tc.input)
 		if !reflect.DeepEqual(actual, tc.expected) {
 			t.Fatalf("incorrectly modified mounts: %s.\n\n Expected: %v\n\n, Actual: %v", tc.desc, tc.expected, actual)
 		}

--- a/integration/container_volume_linux_test.go
+++ b/integration/container_volume_linux_test.go
@@ -1,0 +1,78 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/v2/integration/images"
+	"github.com/containerd/containerd/v2/pkg/kernelversion"
+	"github.com/stretchr/testify/require"
+	criruntime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+func TestRunContainerWithVolatileOption(t *testing.T) {
+	if ok, err := kernelversion.GreaterEqualThan(kernelversion.KernelVersion{
+		Kernel: 5,
+		Major:  10,
+	}); !ok {
+		t.Skipf("Only test it when kernel >= 5.10: %v", err)
+	}
+
+	workDir := t.TempDir()
+
+	t.Log("Prepare containerd config with volatile option")
+	cfgPath := filepath.Join(workDir, "config.toml")
+	err := os.WriteFile(
+		cfgPath,
+		[]byte(`
+version = 3
+
+[plugins.'io.containerd.internal.v1.cri']
+  ignore_image_defined_volumes = false
+
+[plugins."io.containerd.snapshotter.v1.overlayfs"]
+    mount_options = ["volatile"]
+`),
+		0600)
+	require.NoError(t, err)
+
+	t.Logf("Starting containerd")
+	currentProc := newCtrdProc(t, "containerd", workDir)
+	require.NoError(t, currentProc.isReady())
+	t.Cleanup(func() {
+		t.Log("Cleanup all the pods")
+		cleanupPods(t, currentProc.criRuntimeService(t))
+
+		t.Log("Stopping containerd process")
+		require.NoError(t, currentProc.kill(syscall.SIGTERM))
+		require.NoError(t, currentProc.wait(5*time.Minute))
+	})
+
+	imageName := images.Get(images.VolumeOwnership)
+	pullImagesByCRI(t, currentProc.criImageService(t), imageName)
+
+	podCtx := newPodTCtx(t, currentProc.criRuntimeService(t), "running-pod", "sandbox")
+
+	podCtx.createContainer("running", imageName,
+		criruntime.ContainerState_CONTAINER_RUNNING,
+		WithCommand("sleep", "1d"))
+}

--- a/integration/images/volume-ownership/Dockerfile
+++ b/integration/images/volume-ownership/Dockerfile
@@ -15,4 +15,5 @@
 FROM ubuntu
 RUN mkdir -p /test_dir && \
     chown -R nobody:nogroup /test_dir
+# NOTE: The volume is required by ../../container_volume_linux_test.go#TestRunContainerWithVolatileOption.
 VOLUME /test_dir

--- a/internal/cri/opts/container.go
+++ b/internal/cri/opts/container.go
@@ -74,6 +74,7 @@ func WithVolumes(volumeMounts map[string]string, platform imagespec.Platform) co
 		if len(mounts) == 1 && mounts[0].Type == "overlay" {
 			mounts[0].Options = append(mounts[0].Options, "ro")
 		}
+		mounts = mount.RemoveVolatileOption(mounts)
 
 		root, err := os.MkdirTemp("", "ctd-volume")
 		if err != nil {


### PR DESCRIPTION
Remove volatile option when CRI prepares image volumes.

Fixes: #10228 