### PR TITLE
Update api minimum Go version to 1.21

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/containerd/api
 
-go 1.22.0
+go 1.21
 
 require (
 	github.com/containerd/ttrpc v1.2.3


### PR DESCRIPTION
A higher go build version is not required for the API and this will help some [downstream projects test the change which are currently blocked on 1.22 upgrade](https://github.com/moby/moby/pull/46982).