### PR TITLE
[release/1.7] remove uses of platforms.Platform alias

### DIFF
--- a/pkg/cri/sbserver/container_create.go
+++ b/pkg/cri/sbserver/container_create.go
@@ -338,7 +338,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 // volumeMounts sets up image volumes for container. Rely on the removal of container
 // root directory to do cleanup. Note that image volume will be skipped, if there is criMounts
 // specified with the same destination.
-func (c *criService) volumeMounts(platform platforms.Platform, containerRootDir string, criMounts []*runtime.Mount, config *imagespec.ImageConfig) []*runtime.Mount {
+func (c *criService) volumeMounts(platform imagespec.Platform, containerRootDir string, criMounts []*runtime.Mount, config *imagespec.ImageConfig) []*runtime.Mount {
 	if len(config.Volumes) == 0 {
 		return nil
 	}
@@ -374,7 +374,7 @@ func (c *criService) volumeMounts(platform platforms.Platform, containerRootDir 
 }
 
 // runtimeSpec returns a default runtime spec used in cri-containerd.
-func (c *criService) runtimeSpec(id string, platform platforms.Platform, baseSpecFile string, opts ...oci.SpecOpts) (*runtimespec.Spec, error) {
+func (c *criService) runtimeSpec(id string, platform imagespec.Platform, baseSpecFile string, opts ...oci.SpecOpts) (*runtimespec.Spec, error) {
 	// GenerateSpec needs namespace.
 	ctx := util.NamespacedContext()
 	container := &containers.Container{ID: id}
@@ -468,7 +468,7 @@ func generateUserString(username string, uid, gid *runtime.Int64Value) (string, 
 // runtime information (rootfs mounted), or platform specific checks with
 // no defined workaround (yet) to specify for other platforms.
 func (c *criService) platformSpecOpts(
-	platform platforms.Platform,
+	platform imagespec.Platform,
 	config *runtime.ContainerConfig,
 	imageConfig *imagespec.ImageConfig,
 ) ([]oci.SpecOpts, error) {
@@ -515,7 +515,7 @@ func (c *criService) platformSpecOpts(
 
 // buildContainerSpec build container's OCI spec depending on controller's target platform OS.
 func (c *criService) buildContainerSpec(
-	platform platforms.Platform,
+	platform imagespec.Platform,
 	id string,
 	sandboxID string,
 	sandboxPid uint32,

--- a/pkg/cri/sbserver/container_create_test.go
+++ b/pkg/cri/sbserver/container_create_test.go
@@ -220,7 +220,7 @@ func TestVolumeMounts(t *testing.T) {
 	testContainerRootDir := "test-container-root"
 	for desc, test := range map[string]struct {
 		criMounts         []*runtime.Mount
-		platform          platforms.Platform
+		platform          imagespec.Platform
 		imageVolumes      map[string]struct{}
 		expectedMountDest []string
 	}{
@@ -265,7 +265,7 @@ func TestVolumeMounts(t *testing.T) {
 			},
 		},
 		"should make relative paths absolute on Linux": {
-			platform: platforms.Platform{OS: "linux"},
+			platform: imagespec.Platform{OS: "linux"},
 			imageVolumes: map[string]struct{}{
 				"./test-volume-1":     {},
 				"C:/test-volume-2":    {},

--- a/pkg/cri/sbserver/podsandbox/controller.go
+++ b/pkg/cri/sbserver/podsandbox/controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
@@ -85,7 +86,7 @@ func New(
 
 var _ sandbox.Controller = (*Controller)(nil)
 
-func (c *Controller) Platform(_ctx context.Context, _sandboxID string) (platforms.Platform, error) {
+func (c *Controller) Platform(_ctx context.Context, _sandboxID string) (imagespec.Platform, error) {
 	return platforms.DefaultSpec(), nil
 }
 

--- a/plugins/sandbox/controller.go
+++ b/plugins/sandbox/controller.go
@@ -24,7 +24,6 @@ import (
 	runtimeAPI "github.com/containerd/containerd/api/runtime/sandbox/v1"
 	"github.com/containerd/containerd/events"
 	"github.com/containerd/containerd/events/exchange"
-	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/runtime"
 	v2 "github.com/containerd/containerd/runtime/v2"
@@ -32,6 +31,7 @@ import (
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
@@ -178,18 +178,18 @@ func (c *controllerLocal) Start(ctx context.Context, sandboxID string) (sandbox.
 	}, nil
 }
 
-func (c *controllerLocal) Platform(ctx context.Context, sandboxID string) (platforms.Platform, error) {
+func (c *controllerLocal) Platform(ctx context.Context, sandboxID string) (imagespec.Platform, error) {
 	svc, err := c.getSandbox(ctx, sandboxID)
 	if err != nil {
-		return platforms.Platform{}, err
+		return imagespec.Platform{}, err
 	}
 
 	response, err := svc.Platform(ctx, &runtimeAPI.PlatformRequest{SandboxID: sandboxID})
 	if err != nil {
-		return platforms.Platform{}, fmt.Errorf("failed to get sandbox platform: %w", errdefs.FromGRPC(err))
+		return imagespec.Platform{}, fmt.Errorf("failed to get sandbox platform: %w", errdefs.FromGRPC(err))
 	}
 
-	var platform platforms.Platform
+	var platform imagespec.Platform
 	if p := response.GetPlatform(); p != nil {
 		platform.OS = p.OS
 		platform.Architecture = p.Architecture

--- a/sandbox/controller.go
+++ b/sandbox/controller.go
@@ -22,8 +22,8 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/api/types"
-	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/typeurl/v2"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 type CreateOptions struct {
@@ -90,7 +90,7 @@ type Controller interface {
 	Start(ctx context.Context, sandboxID string) (ControllerInstance, error)
 	// Platform returns target sandbox OS that will be used by Controller.
 	// containerd will rely on this to generate proper OCI spec.
-	Platform(_ctx context.Context, _sandboxID string) (platforms.Platform, error)
+	Platform(_ctx context.Context, _sandboxID string) (imagespec.Platform, error)
 	// Stop will stop sandbox instance
 	Stop(ctx context.Context, sandboxID string, opts ...StopOpt) error
 	// Wait blocks until sandbox process exits.

--- a/sandbox/proxy/controller.go
+++ b/sandbox/proxy/controller.go
@@ -20,9 +20,9 @@ import (
 	"context"
 
 	api "github.com/containerd/containerd/api/services/sandbox/v1"
-	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/sandbox"
 	"github.com/containerd/errdefs"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
@@ -73,14 +73,14 @@ func (s *remoteSandboxController) Start(ctx context.Context, sandboxID string) (
 	}, nil
 }
 
-func (s *remoteSandboxController) Platform(ctx context.Context, sandboxID string) (platforms.Platform, error) {
+func (s *remoteSandboxController) Platform(ctx context.Context, sandboxID string) (imagespec.Platform, error) {
 	resp, err := s.client.Platform(ctx, &api.ControllerPlatformRequest{SandboxID: sandboxID})
 	if err != nil {
-		return platforms.Platform{}, errdefs.FromGRPC(err)
+		return imagespec.Platform{}, errdefs.FromGRPC(err)
 	}
 
 	platform := resp.GetPlatform()
-	return platforms.Platform{
+	return imagespec.Platform{
 		Architecture: platform.GetArchitecture(),
 		OS:           platform.GetOS(),
 		Variant:      platform.GetVariant(),


### PR DESCRIPTION
Commit 3c8469a78269d9ba2ead4798d4469d95f8c3cdd5 removed uses of the api types.Platform type from public interfaces, instead using the type from the OCI image spec.

For convenience, it also introduced an alias in the platforms package. While this alias allows packages that already import containerd's platforms package (now a separate module), it may also cause confusion (it's not clear that it's an alias for the OCI type), and for packages that do not depend on containerd's platforms package / module may now be resulting in an extra dependency.

Let's remove the use of this alias, and instead use the OCI type directly.

Equivalent of 446e63579cba6d375b229305e113ea4ed756822b (https://github.com/containerd/containerd/pull/10273) in main.