### PR TITLE
[WIP] [release/1.7] migrate to github.com/containerd/plugin module

### DIFF
--- a/cmd/ctr/commands/plugins/plugins.go
+++ b/cmd/ctr/commands/plugins/plugins.go
@@ -26,7 +26,7 @@ import (
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/platforms"
-	pluginutils "github.com/containerd/containerd/plugin"
+	pluginutils "github.com/containerd/plugin"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/urfave/cli"
 	"google.golang.org/grpc/codes"

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/containerd/imgcrypt v1.1.8
 	github.com/containerd/log v0.1.0
 	github.com/containerd/nri v0.6.1
+	github.com/containerd/plugin v0.1.0
 	github.com/containerd/ttrpc v1.2.4
 	github.com/containerd/typeurl/v2 v2.1.1
 	github.com/containerd/zfs v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -194,6 +194,8 @@ github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3
 github.com/containerd/nri v0.0.0-20201007170849-eb1350a75164/go.mod h1:+2wGSDGFYfE5+So4M5syatU0N0f0LbWpuqyMi4/BE8c=
 github.com/containerd/nri v0.6.1 h1:xSQ6elnQ4Ynidm9u49ARK9wRKHs80HCUI+bkXOxV4mA=
 github.com/containerd/nri v0.6.1/go.mod h1:7+sX3wNx+LR7RzhjnJiUkFDhn18P5Bg/0VnJ/uXpRJM=
+github.com/containerd/plugin v0.1.0 h1:CYMyZk9beRAIe1FEKItbMLLAz/z16aXrGc+B+nv0fU4=
+github.com/containerd/plugin v0.1.0/go.mod h1:j6HlpMtkiZMgT4UsfVNxPBUkwdw9KQGU6nCLfRxnq+w=
 github.com/containerd/ttrpc v0.0.0-20190828154514-0e0f228740de/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
 github.com/containerd/ttrpc v0.0.0-20190828172938-92c8520ef9f8/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
 github.com/containerd/ttrpc v0.0.0-20191028202541-4f1b8fe65a5c/go.mod h1:LPm1u0xBw8r8NOKoOdNMeVHSawSsltak+Ihv+etqsE8=

--- a/integration/client/go.mod
+++ b/integration/client/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/containerd/cgroups v1.1.0 // indirect
 	github.com/containerd/console v1.0.3 // indirect
 	github.com/containerd/fifo v1.1.0 // indirect
+	github.com/containerd/plugin v0.1.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect

--- a/integration/client/go.sum
+++ b/integration/client/go.sum
@@ -963,6 +963,8 @@ github.com/containerd/imgcrypt v1.1.8/go.mod h1:x6QvFIkMyO2qGIY2zXc88ivEzcbgvLdW
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/containerd/nri v0.6.1/go.mod h1:7+sX3wNx+LR7RzhjnJiUkFDhn18P5Bg/0VnJ/uXpRJM=
+github.com/containerd/plugin v0.1.0 h1:CYMyZk9beRAIe1FEKItbMLLAz/z16aXrGc+B+nv0fU4=
+github.com/containerd/plugin v0.1.0/go.mod h1:j6HlpMtkiZMgT4UsfVNxPBUkwdw9KQGU6nCLfRxnq+w=
 github.com/containerd/stargz-snapshotter/estargz v0.4.1/go.mod h1:x7Q9dg9QYb4+ELgxmo4gBUeJB0tl5dqH1Sdz0nJU1QM=
 github.com/containerd/stargz-snapshotter/estargz v0.14.3/go.mod h1:KY//uOCIkSuNAHhJogcZtrNHdKrA99/FCCRjE3HD36o=
 github.com/containerd/ttrpc v1.0.2/go.mod h1:UAxOpgT9ziI0gJrmKvgcZivgxOp8iFPSk8httJEt98Y=
@@ -1512,6 +1514,7 @@ github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zM
 github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.1.0-rc2/go.mod h1:3OVijpioIKYWTqjiG0zfF6wvoJ4fAXGbjdZuI2NgsRQ=
 github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b/go.mod h1:3OVijpioIKYWTqjiG0zfF6wvoJ4fAXGbjdZuI2NgsRQ=
+github.com/opencontainers/image-spec v1.1.0-rc5/go.mod h1:X4pATf0uXsnn3g5aiGIsVnJBR4mxhKzfwmvK/B2NTm8=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
 github.com/opencontainers/runc v1.0.2/go.mod h1:aTaHFFwQXuA71CiyxOdFFIorAoemI04suvGRQFzWTD0=

--- a/plugin/context.go
+++ b/plugin/context.go
@@ -21,11 +21,9 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/containerd/plugin"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-
 	"github.com/containerd/containerd/events/exchange"
 	"github.com/containerd/errdefs"
+	"github.com/containerd/plugin"
 )
 
 // InitContext is used for plugin initialization
@@ -41,7 +39,7 @@ type InitContext struct {
 	// deprecated: will be removed in 2.0, use plugin.EventType
 	Events *exchange.Exchange
 
-	Meta *Meta // plugins can fill in metadata at init.
+	Meta *plugin.Meta // plugins can fill in metadata at init.
 
 	plugins *Set
 }
@@ -52,7 +50,7 @@ func NewContext(ctx context.Context, r *Registration, plugins *Set, root, state 
 		Context: ctx,
 		Root:    filepath.Join(root, r.URI()),
 		State:   filepath.Join(state, r.URI()),
-		Meta: &Meta{
+		Meta: &plugin.Meta{
 			Exports: map[string]string{},
 		},
 		plugins: plugins,
@@ -64,19 +62,11 @@ func (i *InitContext) Get(t plugin.Type) (interface{}, error) {
 	return i.plugins.Get(t)
 }
 
-// Meta contains information gathered from the registration and initialization
-// process.
-type Meta struct {
-	Platforms    []ocispec.Platform // platforms supported by plugin
-	Exports      map[string]string  // values exported by plugin
-	Capabilities []string           // feature switches for plugin
-}
-
 // Plugin represents an initialized plugin, used with an init context.
 type Plugin struct {
 	Registration *Registration // registration, as initialized
 	Config       interface{}   // config, as initialized
-	Meta         *Meta
+	Meta         *plugin.Meta
 
 	instance interface{}
 	err      error // will be set if there was an error initializing the plugin

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -17,34 +17,11 @@
 package plugin
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 
 	"github.com/containerd/plugin"
 )
-
-var (
-	// ErrNoType is returned when no type is specified
-	ErrNoType = errors.New("plugin: no type")
-	// ErrNoPluginID is returned when no id is specified
-	ErrNoPluginID = errors.New("plugin: no id")
-	// ErrIDRegistered is returned when a duplicate id is already registered
-	ErrIDRegistered = errors.New("plugin: id already registered")
-	// ErrSkipPlugin is used when a plugin is not initialized and should not be loaded,
-	// this allows the plugin loader differentiate between a plugin which is configured
-	// not to load and one that fails to load.
-	ErrSkipPlugin = errors.New("skip plugin")
-
-	// ErrInvalidRequires will be thrown if the requirements for a plugin are
-	// defined in an invalid manner.
-	ErrInvalidRequires = errors.New("invalid requires")
-)
-
-// IsSkipPlugin returns true if the error is skipping the plugin
-func IsSkipPlugin(err error) bool {
-	return errors.Is(err, ErrSkipPlugin)
-}
 
 // Registration contains information for registering a plugin
 type Registration struct {
@@ -93,10 +70,10 @@ func Register(r *Registration) {
 	defer register.Unlock()
 
 	if r.Type == "" {
-		panic(ErrNoType)
+		panic(plugin.ErrNoType)
 	}
 	if r.ID == "" {
-		panic(ErrNoPluginID)
+		panic(plugin.ErrNoPluginID)
 	}
 	if err := checkUnique(r); err != nil {
 		panic(err)
@@ -104,7 +81,7 @@ func Register(r *Registration) {
 
 	for _, requires := range r.Requires {
 		if requires == "*" && len(r.Requires) != 1 {
-			panic(ErrInvalidRequires)
+			panic(plugin.ErrInvalidRequires)
 		}
 	}
 
@@ -114,7 +91,7 @@ func Register(r *Registration) {
 func checkUnique(r *Registration) error {
 	for _, registered := range register.r {
 		if r.URI() == registered.URI() {
-			return fmt.Errorf("%s: %w", r.URI(), ErrIDRegistered)
+			return fmt.Errorf("%s: %w", r.URI(), plugin.ErrIDRegistered)
 		}
 	}
 	return nil

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -49,65 +49,6 @@ type Type string
 
 func (t Type) String() string { return string(t) }
 
-const (
-	// InternalPlugin implements an internal plugin to containerd
-	InternalPlugin Type = "io.containerd.internal.v1"
-	// RuntimePlugin implements a runtime
-	RuntimePlugin Type = "io.containerd.runtime.v1"
-	// RuntimePluginV2 implements a runtime v2
-	RuntimePluginV2 Type = "io.containerd.runtime.v2"
-	// ServicePlugin implements a internal service
-	ServicePlugin Type = "io.containerd.service.v1"
-	// GRPCPlugin implements a grpc service
-	GRPCPlugin Type = "io.containerd.grpc.v1"
-	// TTRPCPlugin implements a ttrpc shim service
-	TTRPCPlugin Type = "io.containerd.ttrpc.v1"
-	// SnapshotPlugin implements a snapshotter
-	SnapshotPlugin Type = "io.containerd.snapshotter.v1"
-	// TaskMonitorPlugin implements a task monitor
-	TaskMonitorPlugin Type = "io.containerd.monitor.v1"
-	// DiffPlugin implements a differ
-	DiffPlugin Type = "io.containerd.differ.v1"
-	// MetadataPlugin implements a metadata store
-	MetadataPlugin Type = "io.containerd.metadata.v1"
-	// ContentPlugin implements a content store
-	ContentPlugin Type = "io.containerd.content.v1"
-	// GCPlugin implements garbage collection policy
-	GCPlugin Type = "io.containerd.gc.v1"
-	// EventPlugin implements event handling
-	EventPlugin Type = "io.containerd.event.v1"
-	// LeasePlugin implements lease manager
-	LeasePlugin Type = "io.containerd.lease.v1"
-	// Streaming implements a stream manager
-	StreamingPlugin Type = "io.containerd.streaming.v1"
-	// TracingProcessorPlugin implements a open telemetry span processor
-	TracingProcessorPlugin Type = "io.containerd.tracing.processor.v1"
-	// NRIApiPlugin implements the NRI adaptation interface for containerd.
-	NRIApiPlugin Type = "io.containerd.nri.v1"
-	// TransferPlugin implements a transfer service
-	TransferPlugin Type = "io.containerd.transfer.v1"
-	// SandboxStorePlugin implements a sandbox store
-	SandboxStorePlugin Type = "io.containerd.sandbox.store.v1"
-	// SandboxControllerPlugin implements a sandbox controller
-	SandboxControllerPlugin Type = "io.containerd.sandbox.controller.v1"
-	// WarningPlugin implements a warning service
-	WarningPlugin Type = "io.containerd.warning.v1"
-)
-
-const (
-	// RuntimeLinuxV1 is the legacy linux runtime
-	RuntimeLinuxV1 = "io.containerd.runtime.v1.linux"
-	// RuntimeRuncV1 is the runc runtime that supports a single container
-	RuntimeRuncV1 = "io.containerd.runc.v1"
-	// RuntimeRuncV2 is the runc runtime that supports multiple containers per shim
-	RuntimeRuncV2      = "io.containerd.runc.v2"
-	DeprecationsPlugin = "deprecations"
-)
-
-const (
-	SnapshotterRootDir = "root"
-)
-
 // Registration contains information for registering a plugin
 type Registration struct {
 	// Type of the plugin

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -149,7 +149,11 @@ var register = struct {
 	r []*Registration
 }{}
 
-// Load loads all plugins at the provided path into containerd
+// Load loads all plugins at the provided path into containerd.
+//
+// Load is currently only implemented on non-static, non-gccgo builds for amd64
+// and arm64, and plugins must be built with the exact same version of Go as
+// containerd itself.
 func Load(path string) (count int, err error) {
 	defer func() {
 		if v := recover(); v != nil {

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -149,24 +149,6 @@ var register = struct {
 	r []*Registration
 }{}
 
-// Load loads all plugins at the provided path into containerd.
-//
-// Load is currently only implemented on non-static, non-gccgo builds for amd64
-// and arm64, and plugins must be built with the exact same version of Go as
-// containerd itself.
-func Load(path string) (count int, err error) {
-	defer func() {
-		if v := recover(); v != nil {
-			rerr, ok := v.(error)
-			if !ok {
-				rerr = fmt.Errorf("%s", v)
-			}
-			err = rerr
-		}
-	}()
-	return loadPlugins(path)
-}
-
 // Register allows plugins to register
 func Register(r *Registration) {
 	register.Lock()

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+
+	"github.com/containerd/plugin"
 )
 
 var (
@@ -44,21 +46,16 @@ func IsSkipPlugin(err error) bool {
 	return errors.Is(err, ErrSkipPlugin)
 }
 
-// Type is the type of the plugin
-type Type string
-
-func (t Type) String() string { return string(t) }
-
 // Registration contains information for registering a plugin
 type Registration struct {
 	// Type of the plugin
-	Type Type
+	Type plugin.Type
 	// ID of the plugin
 	ID string
 	// Config specific to the plugin
 	Config interface{}
 	// Requires is a list of plugins that the registered plugin requires to be available
-	Requires []Type
+	Requires []plugin.Type
 
 	// InitFn is called when initializing a plugin. The registration and
 	// context are passed in. The init function may modify the registration to

--- a/plugin/plugin_deprecated.go
+++ b/plugin/plugin_deprecated.go
@@ -46,6 +46,10 @@ func IsSkipPlugin(err error) bool {
 // Type is the type of the plugin
 type Type = plugin.Type
 
+// Meta contains information gathered from the registration and initialization
+// process.
+type Meta = plugin.Meta
+
 // Load loads all plugins at the provided path into containerd.
 //
 // Load is currently only implemented on non-static, non-gccgo builds for amd64

--- a/plugin/plugin_deprecated.go
+++ b/plugin/plugin_deprecated.go
@@ -1,0 +1,30 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package plugin
+
+import (
+	"github.com/containerd/plugin/dynamic"
+)
+
+// Load loads all plugins at the provided path into containerd.
+//
+// Load is currently only implemented on non-static, non-gccgo builds for amd64
+// and arm64, and plugins must be built with the exact same version of Go as
+// containerd itself.
+func Load(path string) (count int, err error) {
+	return dynamic.Load(path)
+}

--- a/plugin/plugin_deprecated.go
+++ b/plugin/plugin_deprecated.go
@@ -21,6 +21,28 @@ import (
 	"github.com/containerd/plugin/dynamic"
 )
 
+var (
+	// ErrNoType is returned when no type is specified
+	ErrNoType = plugin.ErrNoType
+	// ErrNoPluginID is returned when no id is specified
+	ErrNoPluginID = plugin.ErrNoPluginID
+	// ErrIDRegistered is returned when a duplicate id is already registered
+	ErrIDRegistered = plugin.ErrIDRegistered
+	// ErrSkipPlugin is used when a plugin is not initialized and should not be loaded,
+	// this allows the plugin loader differentiate between a plugin which is configured
+	// not to load and one that fails to load.
+	ErrSkipPlugin = plugin.ErrSkipPlugin
+
+	// ErrInvalidRequires will be thrown if the requirements for a plugin are
+	// defined in an invalid manner.
+	ErrInvalidRequires = plugin.ErrInvalidRequires
+)
+
+// IsSkipPlugin returns true if the error is skipping the plugin
+func IsSkipPlugin(err error) bool {
+	return plugin.IsSkipPlugin(err)
+}
+
 // Type is the type of the plugin
 type Type = plugin.Type
 

--- a/plugin/plugin_deprecated.go
+++ b/plugin/plugin_deprecated.go
@@ -17,8 +17,12 @@
 package plugin
 
 import (
+	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/dynamic"
 )
+
+// Type is the type of the plugin
+type Type = plugin.Type
 
 // Load loads all plugins at the provided path into containerd.
 //

--- a/plugin/plugin_supported.go
+++ b/plugin/plugin_supported.go
@@ -1,4 +1,4 @@
-//go:build go1.8 && !windows && amd64 && !static_build && !gccgo
+//go:build (amd64 || arm64) && !static_build && !gccgo
 
 /*
    Copyright The containerd Authors.

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/containerd/containerd/services"
+	"github.com/containerd/plugin"
 )
 
 func registerClear() {
@@ -32,7 +33,7 @@ func mockPluginFilter(*Registration) bool {
 	return false
 }
 
-var tasksServiceRequires = []Type{
+var tasksServiceRequires = []plugin.Type{
 	RuntimePlugin,
 	RuntimePluginV2,
 	MetadataPlugin,
@@ -58,35 +59,35 @@ func TestContainerdPlugin(t *testing.T) {
 	Register(&Registration{
 		Type: ServicePlugin,
 		ID:   services.NamespacesService,
-		Requires: []Type{
+		Requires: []plugin.Type{
 			MetadataPlugin,
 		},
 	})
 	Register(&Registration{
 		Type: GRPCPlugin,
 		ID:   "namespaces",
-		Requires: []Type{
+		Requires: []plugin.Type{
 			ServicePlugin,
 		},
 	})
 	Register(&Registration{
 		Type: GRPCPlugin,
 		ID:   "content",
-		Requires: []Type{
+		Requires: []plugin.Type{
 			ServicePlugin,
 		},
 	})
 	Register(&Registration{
 		Type: GRPCPlugin,
 		ID:   "containers",
-		Requires: []Type{
+		Requires: []plugin.Type{
 			ServicePlugin,
 		},
 	})
 	Register(&Registration{
 		Type: ServicePlugin,
 		ID:   services.ContainersService,
-		Requires: []Type{
+		Requires: []plugin.Type{
 			MetadataPlugin,
 		},
 	})
@@ -97,42 +98,42 @@ func TestContainerdPlugin(t *testing.T) {
 	Register(&Registration{
 		Type: GRPCPlugin,
 		ID:   "leases",
-		Requires: []Type{
+		Requires: []plugin.Type{
 			LeasePlugin,
 		},
 	})
 	Register(&Registration{
 		Type: LeasePlugin,
 		ID:   "manager",
-		Requires: []Type{
+		Requires: []plugin.Type{
 			MetadataPlugin,
 		},
 	})
 	Register(&Registration{
 		Type: GRPCPlugin,
 		ID:   "diff",
-		Requires: []Type{
+		Requires: []plugin.Type{
 			ServicePlugin,
 		},
 	})
 	Register(&Registration{
 		Type: ServicePlugin,
 		ID:   services.DiffService,
-		Requires: []Type{
+		Requires: []plugin.Type{
 			DiffPlugin,
 		},
 	})
 	Register(&Registration{
 		Type: ServicePlugin,
 		ID:   services.SnapshotsService,
-		Requires: []Type{
+		Requires: []plugin.Type{
 			MetadataPlugin,
 		},
 	})
 	Register(&Registration{
 		Type: GRPCPlugin,
 		ID:   "snapshots",
-		Requires: []Type{
+		Requires: []plugin.Type{
 			ServicePlugin,
 		},
 	})
@@ -143,40 +144,40 @@ func TestContainerdPlugin(t *testing.T) {
 	Register(&Registration{
 		Type: GRPCPlugin,
 		ID:   "images",
-		Requires: []Type{
+		Requires: []plugin.Type{
 			ServicePlugin,
 		},
 	})
 	Register(&Registration{
 		Type: GCPlugin,
 		ID:   "scheduler",
-		Requires: []Type{
+		Requires: []plugin.Type{
 			MetadataPlugin,
 		},
 	})
 	Register(&Registration{
 		Type: RuntimePluginV2,
 		ID:   "task",
-		Requires: []Type{
+		Requires: []plugin.Type{
 			MetadataPlugin,
 		},
 	})
 	Register(&Registration{
 		Type: GRPCPlugin,
 		ID:   "tasks",
-		Requires: []Type{
+		Requires: []plugin.Type{
 			ServicePlugin,
 		},
 	})
 	Register(&Registration{
 		Type:     GRPCPlugin,
 		ID:       "introspection",
-		Requires: []Type{"*"},
+		Requires: []plugin.Type{"*"},
 	})
 	Register(&Registration{
 		Type: ServicePlugin,
 		ID:   services.ContentService,
-		Requires: []Type{
+		Requires: []plugin.Type{
 			MetadataPlugin,
 		},
 	})
@@ -191,20 +192,20 @@ func TestContainerdPlugin(t *testing.T) {
 	Register(&Registration{
 		Type: GRPCPlugin,
 		ID:   "cri",
-		Requires: []Type{
+		Requires: []plugin.Type{
 			ServicePlugin,
 		},
 	})
 	Register(&Registration{
 		Type: RuntimePlugin,
 		ID:   "linux",
-		Requires: []Type{
+		Requires: []plugin.Type{
 			MetadataPlugin,
 		},
 	})
 	Register(&Registration{
 		Type: InternalPlugin,
-		Requires: []Type{
+		Requires: []plugin.Type{
 			ServicePlugin,
 		},
 		ID: "restart",
@@ -212,7 +213,7 @@ func TestContainerdPlugin(t *testing.T) {
 	Register(&Registration{
 		Type: DiffPlugin,
 		ID:   "walking",
-		Requires: []Type{
+		Requires: []plugin.Type{
 			MetadataPlugin,
 		},
 	})
@@ -231,7 +232,7 @@ func TestContainerdPlugin(t *testing.T) {
 	Register(&Registration{
 		Type: MetadataPlugin,
 		ID:   "bolt",
-		Requires: []Type{
+		Requires: []plugin.Type{
 			ContentPlugin,
 			SnapshotPlugin,
 		},
@@ -245,7 +246,7 @@ func TestContainerdPlugin(t *testing.T) {
 	Register(&Registration{
 		Type: InternalPlugin,
 		ID:   "tracing",
-		Requires: []Type{
+		Requires: []plugin.Type{
 			TracingProcessorPlugin,
 		},
 	})
@@ -313,7 +314,7 @@ func TestPluginGraph(t *testing.T) {
 				{
 					Type: "grpc",
 					ID:   "introspection",
-					Requires: []Type{
+					Requires: []plugin.Type{
 						"*",
 					},
 				},
@@ -333,7 +334,7 @@ func TestPluginGraph(t *testing.T) {
 				{
 					Type: "service",
 					ID:   "container",
-					Requires: []Type{
+					Requires: []plugin.Type{
 						"metadata",
 					},
 				},
@@ -352,7 +353,7 @@ func TestPluginGraph(t *testing.T) {
 				{
 					Type: "metadata",
 					ID:   "bolt",
-					Requires: []Type{
+					Requires: []plugin.Type{
 						"content",
 						"snapshotter",
 					},

--- a/plugin/plugin_unsupported.go
+++ b/plugin/plugin_unsupported.go
@@ -1,4 +1,4 @@
-//go:build !go1.8 || windows || !amd64 || static_build || gccgo
+//go:build (!amd64 && !arm64) || static_build || gccgo
 
 /*
    Copyright The containerd Authors.
@@ -18,7 +18,11 @@
 
 package plugin
 
+// loadPlugins is not supported;
+//
+// - with gccgo: gccgo has no plugin support golang/go#36403
+// - on static builds; https://github.com/containerd/containerd/commit/0d682e24a1ba8e93e5e54a73d64f7d256f87492f
+// - on architectures other than amd64 and arm64 (other architectures need to be tested)
 func loadPlugins(path string) (int, error) {
-	// plugins not supported until 1.8
 	return 0, nil
 }

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -1,0 +1,76 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package plugin
+
+const (
+	// InternalPlugin implements an internal plugin to containerd
+	InternalPlugin Type = "io.containerd.internal.v1"
+	// RuntimePlugin implements a runtime
+	RuntimePlugin Type = "io.containerd.runtime.v1"
+	// RuntimePluginV2 implements a runtime v2
+	RuntimePluginV2 Type = "io.containerd.runtime.v2"
+	// ServicePlugin implements a internal service
+	ServicePlugin Type = "io.containerd.service.v1"
+	// GRPCPlugin implements a grpc service
+	GRPCPlugin Type = "io.containerd.grpc.v1"
+	// TTRPCPlugin implements a ttrpc shim service
+	TTRPCPlugin Type = "io.containerd.ttrpc.v1"
+	// SnapshotPlugin implements a snapshotter
+	SnapshotPlugin Type = "io.containerd.snapshotter.v1"
+	// TaskMonitorPlugin implements a task monitor
+	TaskMonitorPlugin Type = "io.containerd.monitor.v1"
+	// DiffPlugin implements a differ
+	DiffPlugin Type = "io.containerd.differ.v1"
+	// MetadataPlugin implements a metadata store
+	MetadataPlugin Type = "io.containerd.metadata.v1"
+	// ContentPlugin implements a content store
+	ContentPlugin Type = "io.containerd.content.v1"
+	// GCPlugin implements garbage collection policy
+	GCPlugin Type = "io.containerd.gc.v1"
+	// EventPlugin implements event handling
+	EventPlugin Type = "io.containerd.event.v1"
+	// LeasePlugin implements lease manager
+	LeasePlugin Type = "io.containerd.lease.v1"
+	// Streaming implements a stream manager
+	StreamingPlugin Type = "io.containerd.streaming.v1"
+	// TracingProcessorPlugin implements a open telemetry span processor
+	TracingProcessorPlugin Type = "io.containerd.tracing.processor.v1"
+	// NRIApiPlugin implements the NRI adaptation interface for containerd.
+	NRIApiPlugin Type = "io.containerd.nri.v1"
+	// TransferPlugin implements a transfer service
+	TransferPlugin Type = "io.containerd.transfer.v1"
+	// SandboxStorePlugin implements a sandbox store
+	SandboxStorePlugin Type = "io.containerd.sandbox.store.v1"
+	// SandboxControllerPlugin implements a sandbox controller
+	SandboxControllerPlugin Type = "io.containerd.sandbox.controller.v1"
+	// WarningPlugin implements a warning service
+	WarningPlugin Type = "io.containerd.warning.v1"
+)
+
+const (
+	// RuntimeLinuxV1 is the legacy linux runtime
+	RuntimeLinuxV1 = "io.containerd.runtime.v1.linux"
+	// RuntimeRuncV1 is the runc runtime that supports a single container
+	RuntimeRuncV1 = "io.containerd.runc.v1"
+	// RuntimeRuncV2 is the runc runtime that supports multiple containers per shim
+	RuntimeRuncV2      = "io.containerd.runc.v2"
+	DeprecationsPlugin = "deprecations"
+)
+
+const (
+	SnapshotterRootDir = "root"
+)

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -16,49 +16,51 @@
 
 package plugin
 
+import "github.com/containerd/plugin"
+
 const (
 	// InternalPlugin implements an internal plugin to containerd
-	InternalPlugin Type = "io.containerd.internal.v1"
+	InternalPlugin plugin.Type = "io.containerd.internal.v1"
 	// RuntimePlugin implements a runtime
-	RuntimePlugin Type = "io.containerd.runtime.v1"
+	RuntimePlugin plugin.Type = "io.containerd.runtime.v1"
 	// RuntimePluginV2 implements a runtime v2
-	RuntimePluginV2 Type = "io.containerd.runtime.v2"
+	RuntimePluginV2 plugin.Type = "io.containerd.runtime.v2"
 	// ServicePlugin implements a internal service
-	ServicePlugin Type = "io.containerd.service.v1"
+	ServicePlugin plugin.Type = "io.containerd.service.v1"
 	// GRPCPlugin implements a grpc service
-	GRPCPlugin Type = "io.containerd.grpc.v1"
+	GRPCPlugin plugin.Type = "io.containerd.grpc.v1"
 	// TTRPCPlugin implements a ttrpc shim service
-	TTRPCPlugin Type = "io.containerd.ttrpc.v1"
+	TTRPCPlugin plugin.Type = "io.containerd.ttrpc.v1"
 	// SnapshotPlugin implements a snapshotter
-	SnapshotPlugin Type = "io.containerd.snapshotter.v1"
+	SnapshotPlugin plugin.Type = "io.containerd.snapshotter.v1"
 	// TaskMonitorPlugin implements a task monitor
-	TaskMonitorPlugin Type = "io.containerd.monitor.v1"
+	TaskMonitorPlugin plugin.Type = "io.containerd.monitor.v1"
 	// DiffPlugin implements a differ
-	DiffPlugin Type = "io.containerd.differ.v1"
+	DiffPlugin plugin.Type = "io.containerd.differ.v1"
 	// MetadataPlugin implements a metadata store
-	MetadataPlugin Type = "io.containerd.metadata.v1"
+	MetadataPlugin plugin.Type = "io.containerd.metadata.v1"
 	// ContentPlugin implements a content store
-	ContentPlugin Type = "io.containerd.content.v1"
+	ContentPlugin plugin.Type = "io.containerd.content.v1"
 	// GCPlugin implements garbage collection policy
-	GCPlugin Type = "io.containerd.gc.v1"
+	GCPlugin plugin.Type = "io.containerd.gc.v1"
 	// EventPlugin implements event handling
-	EventPlugin Type = "io.containerd.event.v1"
+	EventPlugin plugin.Type = "io.containerd.event.v1"
 	// LeasePlugin implements lease manager
-	LeasePlugin Type = "io.containerd.lease.v1"
+	LeasePlugin plugin.Type = "io.containerd.lease.v1"
 	// Streaming implements a stream manager
-	StreamingPlugin Type = "io.containerd.streaming.v1"
+	StreamingPlugin plugin.Type = "io.containerd.streaming.v1"
 	// TracingProcessorPlugin implements a open telemetry span processor
-	TracingProcessorPlugin Type = "io.containerd.tracing.processor.v1"
+	TracingProcessorPlugin plugin.Type = "io.containerd.tracing.processor.v1"
 	// NRIApiPlugin implements the NRI adaptation interface for containerd.
-	NRIApiPlugin Type = "io.containerd.nri.v1"
+	NRIApiPlugin plugin.Type = "io.containerd.nri.v1"
 	// TransferPlugin implements a transfer service
-	TransferPlugin Type = "io.containerd.transfer.v1"
+	TransferPlugin plugin.Type = "io.containerd.transfer.v1"
 	// SandboxStorePlugin implements a sandbox store
-	SandboxStorePlugin Type = "io.containerd.sandbox.store.v1"
+	SandboxStorePlugin plugin.Type = "io.containerd.sandbox.store.v1"
 	// SandboxControllerPlugin implements a sandbox controller
-	SandboxControllerPlugin Type = "io.containerd.sandbox.controller.v1"
+	SandboxControllerPlugin plugin.Type = "io.containerd.sandbox.controller.v1"
 	// WarningPlugin implements a warning service
-	WarningPlugin Type = "io.containerd.warning.v1"
+	WarningPlugin plugin.Type = "io.containerd.warning.v1"
 )
 
 const (

--- a/services/server/server.go
+++ b/services/server/server.go
@@ -34,6 +34,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/containerd/plugin/dynamic"
 	"github.com/containerd/ttrpc"
 	"github.com/docker/go-metrics"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
@@ -432,7 +433,7 @@ func LoadPlugins(ctx context.Context, config *srvconfig.Config) ([]*plugin.Regis
 	if path == "" {
 		path = filepath.Join(config.Root, "plugins")
 	}
-	if count, err := plugin.Load(path); err != nil {
+	if count, err := dynamic.Load(path); err != nil {
 		return nil, err
 	} else if count > 0 || config.PluginDir != "" {
 		config.PluginDir = path

--- a/snapshots/blockfile/blockfile.go
+++ b/snapshots/blockfile/blockfile.go
@@ -25,11 +25,11 @@ import (
 	"runtime"
 
 	"github.com/containerd/containerd/mount"
-	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/containerd/snapshots/storage"
 	"github.com/containerd/continuity/fs"
 	"github.com/containerd/log"
+	"github.com/containerd/plugin"
 )
 
 // viewHookHelper is only used in test for recover the filesystem.

--- a/snapshots/btrfs/btrfs.go
+++ b/snapshots/btrfs/btrfs.go
@@ -29,10 +29,10 @@ import (
 	"github.com/containerd/continuity/fs"
 
 	"github.com/containerd/containerd/mount"
-	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/containerd/snapshots/storage"
 	"github.com/containerd/log"
+	"github.com/containerd/plugin"
 
 	"github.com/sirupsen/logrus"
 )

--- a/snapshots/btrfs/btrfs_test.go
+++ b/snapshots/btrfs/btrfs_test.go
@@ -32,10 +32,10 @@ import (
 
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/pkg/testutil"
-	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/containerd/snapshots/testsuite"
 	"github.com/containerd/continuity/testutil/loopback"
+	"github.com/containerd/plugin"
 	"golang.org/x/sys/unix"
 )
 

--- a/vendor/github.com/containerd/plugin/.golangci.yml
+++ b/vendor/github.com/containerd/plugin/.golangci.yml
@@ -1,0 +1,30 @@
+linters:
+  enable:
+    - exportloopref # Checks for pointers to enclosing loop variables
+    - gofmt
+    - goimports
+    - gosec
+    - ineffassign
+    - misspell
+    - nolintlint
+    - revive
+    - staticcheck
+    - tenv # Detects using os.Setenv instead of t.Setenv since Go 1.17
+    - unconvert
+    - unused
+    - vet
+    - dupword # Checks for duplicate words in the source code
+  disable:
+    - errcheck
+
+run:
+  timeout: 5m
+  skip-dirs:
+    - api
+    - cluster
+    - design
+    - docs
+    - docs/man
+    - releases
+    - reports
+    - test # e2e scripts

--- a/vendor/github.com/containerd/plugin/LICENSE
+++ b/vendor/github.com/containerd/plugin/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright The containerd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/containerd/plugin/README.md
+++ b/vendor/github.com/containerd/plugin/README.md
@@ -1,0 +1,19 @@
+# plugin
+
+A Go package providing a common plugin interface across containerd repositories.
+
+This package is intended to be imported by the main containerd repository as well as plugin implementations.
+By sharing a common implementations, plugins can register themselves without needing to import the main containerd repository.
+This plugin is intended to provide an interface and common functionality, but is not intended to define plugin types used by containerd.
+Plugins should copy plugin type strings to avoid creating unintended depdenencies.
+
+## Project details
+
+**plugin** is a containerd sub-project, licensed under the [Apache 2.0 license](./LICENSE).
+As a containerd sub-project, you will find the:
+ * [Project governance](https://github.com/containerd/project/blob/main/GOVERNANCE.md),
+ * [Maintainers](https://github.com/containerd/project/blob/main/MAINTAINERS),
+ * and [Contributing guidelines](https://github.com/containerd/project/blob/main/CONTRIBUTING.md)
+
+information in our [`containerd/project`](https://github.com/containerd/project) repository.
+

--- a/vendor/github.com/containerd/plugin/dynamic/dynamic.go
+++ b/vendor/github.com/containerd/plugin/dynamic/dynamic.go
@@ -1,0 +1,37 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package dynamic
+
+import "fmt"
+
+// Load loads all plugins at the provided path into containerd.
+//
+// Load is currently only implemented on non-static, non-gccgo builds for amd64
+// and arm64, and plugins must be built with the exact same version of Go as
+// containerd itself.
+func Load(path string) (loaded int, err error) {
+	defer func() {
+		if v := recover(); v != nil {
+			rerr, ok := v.(error)
+			if !ok {
+				rerr = fmt.Errorf("%s", v)
+			}
+			err = rerr
+		}
+	}()
+	return loadPlugins(path)
+}

--- a/vendor/github.com/containerd/plugin/dynamic/dynamic_supported.go
+++ b/vendor/github.com/containerd/plugin/dynamic/dynamic_supported.go
@@ -16,7 +16,7 @@
    limitations under the License.
 */
 
-package plugin
+package dynamic
 
 import (
 	"fmt"
@@ -25,9 +25,8 @@ import (
 	"runtime"
 )
 
-// loadPlugins loads all plugins for the OS and Arch that containerd is built
-// for inside the provided path and returns the count of successfully-loaded
-// plugins
+// loadPlugins loads all plugins for the OS and Arch
+// that containerd is built for inside the provided path
 func loadPlugins(path string) (int, error) {
 	abs, err := filepath.Abs(path)
 	if err != nil {

--- a/vendor/github.com/containerd/plugin/dynamic/dynamic_unsupported.go
+++ b/vendor/github.com/containerd/plugin/dynamic/dynamic_unsupported.go
@@ -16,7 +16,7 @@
    limitations under the License.
 */
 
-package plugin
+package dynamic
 
 // loadPlugins is not supported;
 //

--- a/vendor/github.com/containerd/plugin/plugin.go
+++ b/vendor/github.com/containerd/plugin/plugin.go
@@ -1,0 +1,178 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package plugin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrNoType is returned when no type is specified
+	ErrNoType = errors.New("plugin: no type")
+	// ErrNoPluginID is returned when no id is specified
+	ErrNoPluginID = errors.New("plugin: no id")
+	// ErrIDRegistered is returned when a duplicate id is already registered
+	ErrIDRegistered = errors.New("plugin: id already registered")
+	// ErrSkipPlugin is used when a plugin is not initialized and should not be loaded,
+	// this allows the plugin loader differentiate between a plugin which is configured
+	// not to load and one that fails to load.
+	ErrSkipPlugin = errors.New("skip plugin")
+	// ErrPluginInitialized is used when a plugin is already initialized
+	ErrPluginInitialized = errors.New("plugin: already initialized")
+	// ErrPluginNotFound is used when a plugin is looked up but not found
+	ErrPluginNotFound = errors.New("plugin: not found")
+	// ErrPluginMultipleInstances is used when a plugin is expected a single instance but has multiple
+	ErrPluginMultipleInstances = errors.New("plugin: multiple instances")
+
+	// ErrInvalidRequires will be thrown if the requirements for a plugin are
+	// defined in an invalid manner.
+	ErrInvalidRequires = errors.New("invalid requires")
+)
+
+// IsSkipPlugin returns true if the error is skipping the plugin
+func IsSkipPlugin(err error) bool {
+	return errors.Is(err, ErrSkipPlugin)
+}
+
+// Type is the type of the plugin
+type Type string
+
+func (t Type) String() string { return string(t) }
+
+// Registration contains information for registering a plugin
+type Registration struct {
+	// Type of the plugin
+	Type Type
+	// ID of the plugin
+	ID string
+	// Config specific to the plugin
+	Config interface{}
+	// Requires is a list of plugins that the registered plugin requires to be available
+	Requires []Type
+
+	// InitFn is called when initializing a plugin. The registration and
+	// context are passed in. The init function may modify the registration to
+	// add exports, capabilities and platform support declarations.
+	InitFn func(*InitContext) (interface{}, error)
+
+	// ConfigMigration allows a plugin to migrate configurations from an older
+	// version to handle plugin renames or moving of features from one plugin
+	// to another in a later version.
+	// The configuration map is keyed off the plugin name and the value
+	// is the configuration for that objects, with the structure defined
+	// for the plugin. No validation is done on the value before performing
+	// the migration.
+	ConfigMigration func(context.Context, int, map[string]interface{}) error
+}
+
+// Init the registered plugin
+func (r Registration) Init(ic *InitContext) *Plugin {
+	p, err := r.InitFn(ic)
+	return &Plugin{
+		Registration: r,
+		Config:       ic.Config,
+		Meta:         *ic.Meta,
+		instance:     p,
+		err:          err,
+	}
+}
+
+// URI returns the full plugin URI
+func (r *Registration) URI() string {
+	return r.Type.String() + "." + r.ID
+}
+
+// DisableFilter filters out disabled plugins
+type DisableFilter func(r *Registration) bool
+
+// Registry is list of registrations which can be registered to and
+// produce a filtered and ordered output.
+// The Registry itself is immutable and the list will be copied
+// and appeneded to a new registry when new items are registered.
+type Registry []*Registration
+
+// Graph computes the ordered list of registrations based on their dependencies,
+// filtering out any plugins which match the provided filter.
+func (registry Registry) Graph(filter DisableFilter) []Registration {
+	disabled := map[*Registration]bool{}
+	for _, r := range registry {
+		if filter(r) {
+			disabled[r] = true
+		}
+	}
+
+	ordered := make([]Registration, 0, len(registry)-len(disabled))
+	added := map[*Registration]bool{}
+	for _, r := range registry {
+		if disabled[r] {
+			continue
+		}
+		children(r, registry, added, disabled, &ordered)
+		if !added[r] {
+			ordered = append(ordered, *r)
+			added[r] = true
+		}
+	}
+	return ordered
+}
+
+func children(reg *Registration, registry []*Registration, added, disabled map[*Registration]bool, ordered *[]Registration) {
+	for _, t := range reg.Requires {
+		for _, r := range registry {
+			if !disabled[r] && r.URI() != reg.URI() && (t == "*" || r.Type == t) {
+				children(r, registry, added, disabled, ordered)
+				if !added[r] {
+					*ordered = append(*ordered, *r)
+					added[r] = true
+				}
+			}
+		}
+	}
+}
+
+// Register adds the registration to a Registry and returns the
+// updated Registry, panicking if registration could not succeed.
+func (registry Registry) Register(r *Registration) Registry {
+	if r.Type == "" {
+		panic(ErrNoType)
+	}
+	if r.ID == "" {
+		panic(ErrNoPluginID)
+	}
+	if err := checkUnique(registry, r); err != nil {
+		panic(err)
+	}
+
+	for _, requires := range r.Requires {
+		if requires == "*" && len(r.Requires) != 1 {
+			panic(ErrInvalidRequires)
+		}
+	}
+
+	return append(registry, r)
+}
+
+func checkUnique(registry Registry, r *Registration) error {
+	for _, registered := range registry {
+		if r.URI() == registered.URI() {
+			return fmt.Errorf("%s: %w", r.URI(), ErrIDRegistered)
+		}
+	}
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -144,6 +144,9 @@ github.com/containerd/nri/pkg/net/multiplex
 github.com/containerd/nri/pkg/runtime-tools/generate
 github.com/containerd/nri/pkg/stub
 github.com/containerd/nri/types/v1
+# github.com/containerd/plugin v0.1.0
+## explicit; go 1.20
+github.com/containerd/plugin/dynamic
 # github.com/containerd/ttrpc v1.2.4
 ## explicit; go 1.19
 github.com/containerd/ttrpc

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -146,6 +146,7 @@ github.com/containerd/nri/pkg/stub
 github.com/containerd/nri/types/v1
 # github.com/containerd/plugin v0.1.0
 ## explicit; go 1.20
+github.com/containerd/plugin
 github.com/containerd/plugin/dynamic
 # github.com/containerd/ttrpc v1.2.4
 ## explicit; go 1.19


### PR DESCRIPTION
- backport 717169bb88910551dfe63cdca01c8335ff73193e / https://github.com/containerd/containerd/pull/7316 to make the package more aligned with the new module

### plugin: switch loading dynamic plugins to plugin module

Migrate to use the new module.

### plugin: move types to separate file

Similar to a80606bc2da5cb83ad80421cf52c19062d7a711a, but keeping the types
in the plugin package for now.

### plugin: alias Type to github.com/containerd/plugin.Type

Create an alias so that the type is equal to the one in the module. Also
replace uses of the alias within the plugin package, but not yet replacing
uses elsewhere, because not all types in the plugin package have been
aliased to the new module.

### plugin: alias error-types to those in github.com/containerd/plugin

Create an alias so that the types are equal to the one in the module. Also
replace uses of the alias in most places; some places are not yet updated,
as they depend on other types from the pluigin package that have not yet
been aliased / migrated.

### plugin: alias Meta to github.com/containerd/plugin.Meta

Create an alias so that the types are equal to the one in the module. Also
replace uses of the alias.


### :warning: not yet changed, due to breaking changes

Unfortunately, some types cannot currently be aliased;

- Registration: the Registration.Disabled field was removed
- Registration: a new ConfigMigration field was added (but this may be optional)
- Plugin: the Registration field changed from a pointer to a non-pointer, but
  also uses the new Registration type (see above).
- Set: uses Plugin, see above
- NewPluginSet(): returns Set: see above
- InitContext: uses Set: see above
- DisableFilter: uses "v2" Registration

It looks like most of those changes happened in https://github.com/containerd/plugin/commit/602343a0f10d43fa79151f38158e183274e7cb74

From the changes above;

- plugin.Register is used by plugin modules
- plugin.Registration is used by plugin modules
- plugin.InitContext is used by plugin modules

Should we;

- Re-introduce the `.Disable` field for backward compatibility? (This may need some compatibility-code in the registration package)
- Is the `Plugin` change (using pointers) problematic, or could we switch to the new implementation? (Don't think it's used in plugins, only in containerd itself?)

