### PR TITLE
support to syncfs after pull by using diff plugin

### DIFF
--- a/plugins/services/diff/service_unix.go
+++ b/plugins/services/diff/service_unix.go
@@ -19,5 +19,6 @@
 package diff
 
 var defaultDifferConfig = &config{
-	Order: []string{"walking"},
+	Order:  []string{"walking"},
+	SyncFs: false,
 }

--- a/plugins/services/diff/service_windows.go
+++ b/plugins/services/diff/service_windows.go
@@ -17,5 +17,6 @@
 package diff
 
 var defaultDifferConfig = &config{
-	Order: []string{"windows", "windows-lcow"},
+	Order:  []string{"windows", "windows-lcow"},
+	SyncFs: false,
 }


### PR DESCRIPTION
this commit  https://github.com/containerd/containerd/pull/9401 just support for cri interface,I want a global config to pull with syncfs.
because ctr and nerdctl pull or load need this feature.
I think let diff plugin do this is better than cri .
@fuweid 