### PR TITLE
Fix: the additional annotations are not passed to the snapshotter

### DIFF
--- a/core/images/image.go
+++ b/core/images/image.go
@@ -31,6 +31,9 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+// ManifestDigestLabel is a label which contains manifest digest.
+const ManifestDigestLabel = "io.containerd.manifest-digest"
+
 // Image provides the model for how containerd views container images.
 type Image struct {
 	// Name of the image.
@@ -189,6 +192,13 @@ func Manifest(ctx context.Context, provider content.Provider, image ocispec.Desc
 
 				}
 			}
+
+			// Given that manifest descriptor is not returned, we depend on two annotations to get the digest of this manifest.
+			annotations := manifest.Annotations
+			if annotations == nil {
+				annotations = make(map[string]string)
+			}
+			annotations[ManifestDigestLabel] = desc.Digest.String()
 
 			m = append(m, platformManifest{
 				p: desc.Platform,

--- a/internal/cri/opts/container.go
+++ b/internal/cri/opts/container.go
@@ -36,7 +36,7 @@ import (
 
 // WithNewSnapshot wraps `containerd.WithNewSnapshot` so that if creating the
 // snapshot fails we make sure the image is actually unpacked and retry.
-func WithNewSnapshot(id string, i containerd.Image, opts ...snapshots.Opt) containerd.NewContainerOpts {
+func WithNewSnapshot(id string, i containerd.Image, disableSnapshotAnnotations bool, opts ...snapshots.Opt) containerd.NewContainerOpts {
 	f := containerd.WithNewSnapshot(id, i, opts...)
 	return func(ctx context.Context, client *containerd.Client, c *containers.Container) error {
 		if err := f(ctx, client, c); err != nil {
@@ -44,7 +44,7 @@ func WithNewSnapshot(id string, i containerd.Image, opts ...snapshots.Opt) conta
 				return err
 			}
 
-			if err := i.Unpack(ctx, c.Snapshotter); err != nil {
+			if err := i.Unpack(ctx, c.Snapshotter, containerd.WithDisableSnapshotAnnotations(disableSnapshotAnnotations)); err != nil {
 				return fmt.Errorf("error unpacking image: %w", err)
 			}
 			return f(ctx, client, c)

--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -225,7 +225,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 		// the runtime (runc) a chance to modify (e.g. to create mount
 		// points corresponding to spec.Mounts) before making the
 		// rootfs readonly (requested by spec.Root.Readonly).
-		customopts.WithNewSnapshot(id, containerdImage, sOpts...),
+		customopts.WithNewSnapshot(id, containerdImage, c.ImageService.ImageConfig().DisableSnapshotAnnotations, sOpts...),
 	}
 	if len(volumeMounts) > 0 {
 		mountMap := make(map[string]string)

--- a/internal/cri/server/container_status_test.go
+++ b/internal/cri/server/container_status_test.go
@@ -293,6 +293,8 @@ func (s *fakeImageService) PullImage(context.Context, string, func(string) (stri
 	return "", errors.New("not implemented")
 }
 
+func (c *fakeImageService) ImageConfig() criconfig.ImageConfig { return criconfig.ImageConfig{} }
+
 func patchExceptedWithState(expected *runtime.ContainerStatus, state runtime.ContainerState) {
 	expected.State = state
 	switch state {

--- a/internal/cri/server/images/service.go
+++ b/internal/cri/server/images/service.go
@@ -191,3 +191,8 @@ func (c *CRIImageService) PinnedImage(name string) string {
 func (c *CRIImageService) GRPCService() runtime.ImageServiceServer {
 	return &GRPCCRIImageService{c}
 }
+
+// ImageConfig returns the image config.
+func (c *CRIImageService) ImageConfig() criconfig.ImageConfig {
+	return c.config
+}

--- a/internal/cri/server/podsandbox/controller.go
+++ b/internal/cri/server/podsandbox/controller.go
@@ -112,6 +112,7 @@ type ImageService interface {
 	PullImage(ctx context.Context, name string, creds func(string) (string, string, error), sc *runtime.PodSandboxConfig, runtimeHandler string) (string, error)
 	RuntimeSnapshotter(ctx context.Context, ociRuntime criconfig.Runtime) string
 	PinnedImage(string) string
+	ImageConfig() criconfig.ImageConfig
 }
 
 type Controller struct {

--- a/internal/cri/server/podsandbox/sandbox_run.go
+++ b/internal/cri/server/podsandbox/sandbox_run.go
@@ -141,7 +141,7 @@ func (c *Controller) Start(ctx context.Context, id string) (cin sandbox.Controll
 
 	opts := []containerd.NewContainerOpts{
 		containerd.WithSnapshotter(c.imageService.RuntimeSnapshotter(ctx, ociRuntime)),
-		customopts.WithNewSnapshot(id, containerdImage, snapshotterOpt...),
+		customopts.WithNewSnapshot(id, containerdImage, c.imageService.ImageConfig().DisableSnapshotAnnotations, snapshotterOpt...),
 		containerd.WithSpec(spec, specOpts...),
 		containerd.WithContainerLabels(sandboxLabels),
 		containerd.WithContainerExtension(crilabels.SandboxMetadataExtension, &metadata),

--- a/internal/cri/server/service.go
+++ b/internal/cri/server/service.go
@@ -107,6 +107,8 @@ type ImageService interface {
 	LocalResolve(refOrID string) (imagestore.Image, error)
 
 	ImageFSPaths() map[string]string
+
+	ImageConfig() criconfig.ImageConfig
 }
 
 // criService implements CRIService.


### PR DESCRIPTION
We develop a remote snapshotter which requires additional annotations (image related information), but the additional annotations are not passed to the snapshotter, when unpacking the local image. These annotations are only passed when pulling the image remotely. This pull request has fixed this problem.