### PR TITLE
Transfer: Push: Enable to specify platforms

### DIFF
--- a/cmd/ctr/commands/images/push.go
+++ b/cmd/ctr/commands/images/push.go
@@ -112,7 +112,14 @@ var pushCommand = &cli.Command{
 			if err != nil {
 				return err
 			}
-			is := image.NewStore(local)
+			var p []ocispec.Platform
+			if pss := context.StringSlice("platform"); len(pss) > 0 {
+				p, err = platforms.ParseAll(pss)
+				if err != nil {
+					return fmt.Errorf("invalid platform %v: %w", pss, err)
+				}
+			}
+			is := image.NewStore(local, image.WithPlatforms(p...))
 
 			pf, done := ProgressHandler(ctx, os.Stdout)
 			defer done()

--- a/core/transfer/image/imagestore.go
+++ b/core/transfer/image/imagestore.go
@@ -348,6 +348,10 @@ func (is *Store) Lookup(ctx context.Context, store images.Store) ([]images.Image
 	return imgs, nil
 }
 
+func (is *Store) Platforms() []ocispec.Platform {
+	return is.platforms
+}
+
 func (is *Store) UnpackPlatforms() []transfer.UnpackConfiguration {
 	unpacks := make([]transfer.UnpackConfiguration, len(is.unpacks))
 	for i, uc := range is.unpacks {

--- a/core/transfer/local/push.go
+++ b/core/transfer/local/push.go
@@ -33,22 +33,12 @@ import (
 )
 
 func (ts *localTransferService) push(ctx context.Context, ig transfer.ImageGetter, p transfer.ImagePusher, tops *transfer.Config) error {
-	/*
-		// TODO: Platform matching
-		if pushCtx.PlatformMatcher == nil {
-			if len(pushCtx.Platforms) > 0 {
-				ps, err := platforms.ParseAll(pushCtx.Platforms)
-				if err != nil {
-					return err
-				}
-				pushCtx.PlatformMatcher = platforms.Any(ps...)
-			} else {
-				pushCtx.PlatformMatcher = platforms.All
-			}
-		}
-	*/
 	matcher := platforms.All
-	// Filter push
+	if ipg, ok := ig.(transfer.ImagePlatformsGetter); ok {
+		if ps := ipg.Platforms(); len(ps) > 0 {
+			matcher = platforms.Any(ps...)
+		}
+	}
 
 	img, err := ig.Get(ctx, ts.images)
 	if err != nil {

--- a/core/transfer/transfer.go
+++ b/core/transfer/transfer.go
@@ -100,6 +100,11 @@ type ImageUnpacker interface {
 	UnpackPlatforms() []UnpackConfiguration
 }
 
+// ImagePlatformsGetter is type which returns configured platforms.
+type ImagePlatformsGetter interface {
+	Platforms() []ocispec.Platform
+}
+
 // UnpackConfiguration specifies the platform and snapshotter to use for resolving
 // the unpack Platform, if snapshotter is not specified the platform default will
 // be used.


### PR DESCRIPTION
This commit enables to specify platforms for pushing images using the transfer service, which was one of the commented TODOs. This also fixes `ctr i push` to pass platform flags to the transfer service.