### PR TITLE
Update rockylinux vagrant build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -528,7 +528,7 @@ jobs:
       matrix:
         box:
           - fedora/39-cloud-base
-          - rockylinux/8@9.0.0
+          - rockylinux/9@4.0.0
     env:
       BOX: ${{ matrix.box }}
 


### PR DESCRIPTION
Update to latest rockylinux version.

The rockylinux/8 link is broken in vagrant cloud as the URL it points to was moved from their pub repository (https://dl.rockylinux.org/pub/rocky/8.9/images/x86_64/Rocky-8-Vagrant-Libvirt-8.9-20231119.0.x86_64.box gives us 404 during CI) to vault (https://dl.rockylinux.org/vault/rocky/8.9/images/x86_64/Rocky-8-Vagrant-Libvirt-8.9-20231119.0.x86_64.box is new link but not redirected to).