### PR TITLE
[release/1.6] Prepare release notes for v1.6.33

### DIFF
--- a/releases/v1.6.33.toml
+++ b/releases/v1.6.33.toml
@@ -1,0 +1,30 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.6.32"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The thirty-third patch release for containerd 1.6 contains various updates along
+with an updated version of Go. Go 1.22.4 and 1.21.11 include a fix for a symlink
+time of check to time of use race condition during directory removal.
+"""
+
+override_deps."github.com/containerd/errdefs".previous = "e0d1732a5c38bb3b899832b4e66e7bbb2216559f"

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.32+unknown"
+	Version = "1.6.33+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Depends on #10299

Generated notes...

----

Welcome to the v1.6.33 release of containerd!

The thirty-third patch release for containerd 1.6 contains various updates along
with an updated version of Go. Go 1.22.4 and 1.21.11 include a fix for a symlink
time of check to time of use race condition during directory removal.

### Highlights

* Update Go version to 1.21.11 ([#10299](https://github.com/containerd/containerd/pull/10299))
* Migrate log imports to `github.com/containerd/log` ([#10271](https://github.com/containerd/containerd/pull/10271))
* Migrate `errdefs` package to `github.com/containerd/errdefs` ([#10267](https://github.com/containerd/containerd/pull/10267))
* Fix usage of "unknown" platform ([#10268](https://github.com/containerd/containerd/pull/10268))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Derek McGowan
* Phil Estes
* Sebastiaan van Stijn
* Akhil Mohan
* Austin Vazquez
* Samuel Karp

### Changes
<details><summary>13 commits</summary>
<p>

  * [`97e059626`](https://github.com/containerd/containerd/commit/97e0596267dd50cce08d9d4238557b345794197b) Prepare release notes for v1.6.33
* Update Go version to 1.21.11 ([#10299](https://github.com/containerd/containerd/pull/10299))
  * [`da9a04e54`](https://github.com/containerd/containerd/commit/da9a04e54cac42438c459fda6ec8f2c772c50441) Includes fix for a symlink race on remove
* Migrate log imports to `github.com/containerd/log` ([#10271](https://github.com/containerd/containerd/pull/10271))
  * [`a389bb305`](https://github.com/containerd/containerd/commit/a389bb3051aa217bf72905ca4544d6661840fc03) migrate logs imports to github.com/containerd/log module
* Migrate `errdefs` package to `github.com/containerd/errdefs` ([#10267](https://github.com/containerd/containerd/pull/10267))
  * [`615fb03e4`](https://github.com/containerd/containerd/commit/615fb03e4721cae0ca7630f66c21e3d148e0fb57) replace uses of github.com/containerd/containerd/errdefs
  * [`c83be1b9e`](https://github.com/containerd/containerd/commit/c83be1b9ecc5df733c038a596af42bdff445ad7f) migrate errdefs package to github.com/containerd/errdefs module
* Fix usage of "unknown" platform ([#10268](https://github.com/containerd/containerd/pull/10268))
  * [`d4d489496`](https://github.com/containerd/containerd/commit/d4d489496305e9ebab9deb78f718658d1c17579f) core/image: fix usage of "unknown" platform
* Explicitly set release latest to false ([#10263](https://github.com/containerd/containerd/pull/10263))
  * [`5eaf5f881`](https://github.com/containerd/containerd/commit/5eaf5f88144bf71725b161a47c7e6af2d2b16331) Explicitly set release latest to false
  * [`b51f7445d`](https://github.com/containerd/containerd/commit/b51f7445d353c9ce18b8614a26756f145f5e19b0) build(deps): bump softprops/action-gh-release from 1 to 2
</p>
</details>

### Changes from containerd/errdefs
<details><summary>6 commits</summary>
<p>

* Add common files ([containerd/errdefs#1](https://github.com/containerd/errdefs/pull/1))
  * [`78f3494`](https://github.com/containerd/errdefs/commit/78f3494a77384f066cd3457e1dfa1bda180f180d) Add Github actions configuration
  * [`46f1770`](https://github.com/containerd/errdefs/commit/46f1770bd5e80699a13fa107e0d5b195d1db9db4) Add go.mod configuration
  * [`959121a`](https://github.com/containerd/errdefs/commit/959121a299905905fed65b533f72a7ee36786301) Add README.md
* Add LICENSE ([containerd/errdefs#2](https://github.com/containerd/errdefs/pull/2))
  * [`33a2275`](https://github.com/containerd/errdefs/commit/33a2275efb9a92237b9a8e7f41c31672f3293ccb) Add LICENSE
</p>
</details>

### Dependency Changes

* **github.com/containerd/errdefs**  v0.1.0 **_new_**

Previous release can be found at [v1.6.32](https://github.com/containerd/containerd/releases/tag/v1.6.32)
