### PR TITLE
[release/1.7] Prepare release notes for v1.7.18

### DIFF
--- a/releases/v1.7.18.toml
+++ b/releases/v1.7.18.toml
@@ -1,0 +1,30 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.7.17"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The eighteenth patch release for containerd 1.7 contains various updates along
+with an updated version of Go. Go 1.22.4 and 1.21.11 include a fix for a symlink
+time of check to time of use race condition during directory removal.
+"""
+
+override_deps."github.com/containerd/errdefs".previous = "e0d1732a5c38bb3b899832b4e66e7bbb2216559f"

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.7.17+unknown"
+	Version = "1.7.18+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Depends on #10298

Generated notes...

----

Welcome to the v1.7.18 release of containerd!

The eighteenth patch release for containerd 1.7 contains various updates along
with an updated version of Go. Go 1.22.4 and 1.21.11 include a fix for a symlink
time of check to time of use race condition during directory removal.

### Highlights

* Update Go version to 1.21.11 ([#10298](https://github.com/containerd/containerd/pull/10298))
* Remove uses of `platforms.Platform` alias ([#10277](https://github.com/containerd/containerd/pull/10277))
* Migrate log imports to `github.com/containerd/log` ([#10269](https://github.com/containerd/containerd/pull/10269))
* Migrate errdefs package to `github.com/containerd/errdefs` ([#10266](https://github.com/containerd/containerd/pull/10266))
* Fix usage of "unknown" platform ([#10261](https://github.com/containerd/containerd/pull/10261))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Derek McGowan
* Sebastiaan van Stijn
* Akhil Mohan
* Austin Vazquez
* Phil Estes

### Changes
<details><summary>15 commits</summary>
<p>

  * [`9426aab62`](https://github.com/containerd/containerd/commit/9426aab62b6496ad93edb7e08b8655bb92d3a84b) Prepare release notes for v1.7.18
* Update Go version to 1.21.11 ([#10298](https://github.com/containerd/containerd/pull/10298))
  * [`cdd3ea913`](https://github.com/containerd/containerd/commit/cdd3ea913586c6e3d1098416a5cded136d761456) Update Go version to 1.21.11
* Remove uses of `platforms.Platform` alias ([#10277](https://github.com/containerd/containerd/pull/10277))
  * [`1e3c662d6`](https://github.com/containerd/containerd/commit/1e3c662d6c2bd0eafdcd402a32324e84d5f0498b) [release/1.7] remove uses of platforms.Platform alias
* Migrate log imports to `github.com/containerd/log` ([#10269](https://github.com/containerd/containerd/pull/10269))
  * [`0af6825b1`](https://github.com/containerd/containerd/commit/0af6825b1e64d56ffd72f801c4fb1224f888c367) migrate logs imports to github.com/containerd/log module
* Migrate errdefs package to `github.com/containerd/errdefs` ([#10266](https://github.com/containerd/containerd/pull/10266))
  * [`308341a44`](https://github.com/containerd/containerd/commit/308341a4464bd723630d3df19a5df20aa252af9f) replace uses of github.com/containerd/containerd/errdefs
  * [`47ff8cfce`](https://github.com/containerd/containerd/commit/47ff8cfce0768d4f4c98ad05bd72e8f9ad8dfb5c) migrate errdefs package to github.com/containerd/errdefs module
* Fix usage of "unknown" platform ([#10261](https://github.com/containerd/containerd/pull/10261))
  * [`f4d11912a`](https://github.com/containerd/containerd/commit/f4d11912a77c1e15db200aed7481d45bd12b5eb1) core/image: fix usage of "unknown" platform
* Explicitly set release latest to true ([#10265](https://github.com/containerd/containerd/pull/10265))
  * [`5b0480009`](https://github.com/containerd/containerd/commit/5b0480009c5f4ee1f8a80cbe7aae22642867ee25) Explicitly set release latest to true
  * [`d669b100d`](https://github.com/containerd/containerd/commit/d669b100d5337150d7f9a170de55ac7d2d7ec24c) build(deps): bump softprops/action-gh-release from 1 to 2
</p>
</details>

### Changes from containerd/errdefs
<details><summary>6 commits</summary>
<p>

* Add common files ([containerd/errdefs#1](https://github.com/containerd/errdefs/pull/1))
  * [`78f3494`](https://github.com/containerd/errdefs/commit/78f3494a77384f066cd3457e1dfa1bda180f180d) Add Github actions configuration
  * [`46f1770`](https://github.com/containerd/errdefs/commit/46f1770bd5e80699a13fa107e0d5b195d1db9db4) Add go.mod configuration
  * [`959121a`](https://github.com/containerd/errdefs/commit/959121a299905905fed65b533f72a7ee36786301) Add README.md
* Add LICENSE ([containerd/errdefs#2](https://github.com/containerd/errdefs/pull/2))
  * [`33a2275`](https://github.com/containerd/errdefs/commit/33a2275efb9a92237b9a8e7f41c31672f3293ccb) Add LICENSE
</p>
</details>

### Dependency Changes

* **github.com/containerd/errdefs**              v0.1.0 **_new_**
* **google.golang.org/genproto**                 b8732ec3820d -> e6e6cdab5c13
* **google.golang.org/genproto/googleapis/api**  b8732ec3820d -> 007df8e322eb
* **google.golang.org/genproto/googleapis/rpc**  b8732ec3820d -> d307bd883b97

Previous release can be found at [v1.7.17](https://github.com/containerd/containerd/releases/tag/v1.7.17)

