### PR TITLE
[release/1.7]: HPC working directory fix in pkg/cri/server code

### DIFF
--- a/pkg/cri/server/container_create_windows.go
+++ b/pkg/cri/server/container_create_windows.go
@@ -67,6 +67,8 @@ func (c *criService) containerSpec(
 		specOpts = append(specOpts, oci.WithProcessCwd(config.GetWorkingDir()))
 	} else if imageConfig.WorkingDir != "" {
 		specOpts = append(specOpts, oci.WithProcessCwd(imageConfig.WorkingDir))
+	} else if cntrHpc {
+		specOpts = append(specOpts, oci.WithProcessCwd(`C:\hpc`))
 	}
 
 	if config.GetTty() {


### PR DESCRIPTION
Change in 989f1ec54f6764020447b03020b97592312c5f85 assumed a single
place (pkg/cri/sbserver) where this had to be fixed.

Commit in main branch for reference:
(cherry picked from commit c7ea06a69bdf9147758353b4eb12bb78240fbda8)