### PR TITLE
[release/1.7] Fail integration test early when a plugin load fails

### DIFF
--- a/integration/client/daemon.go
+++ b/integration/client/daemon.go
@@ -23,11 +23,13 @@ import (
 	"io"
 	"os/exec"
 	"runtime"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
 
 	. "github.com/containerd/containerd"
+	"github.com/containerd/containerd/plugin"
 )
 
 type daemon struct {
@@ -79,6 +81,21 @@ func (d *daemon) waitForStart(ctx context.Context) (*Client, error) {
 				}
 				continue
 			}
+			resp, perr := client.IntrospectionService().Plugins(ctx, nil)
+			if perr != nil {
+				return nil, fmt.Errorf("failed to get plugin list: %w", perr)
+			}
+			var loadErr error
+			for _, p := range resp.Plugins {
+				if p.InitErr != nil && !strings.Contains(p.InitErr.Message, plugin.ErrSkipPlugin.Error()) {
+					pluginErr := fmt.Errorf("failed to load %s.%s: %s", p.Type, p.ID, p.InitErr.Message)
+					loadErr = errors.Join(loadErr, pluginErr)
+				}
+			}
+			if loadErr != nil {
+				return nil, loadErr
+			}
+
 			return client, err
 		case <-ctx.Done():
 			return nil, fmt.Errorf("context deadline exceeded: %w", err)

--- a/snapshots/devmapper/plugin/plugin.go
+++ b/snapshots/devmapper/plugin/plugin.go
@@ -20,6 +20,7 @@ package plugin
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/plugin"
@@ -40,7 +41,7 @@ func init() {
 			}
 
 			if config.PoolName == "" {
-				return nil, errors.New("devmapper not configured")
+				return nil, fmt.Errorf("devmapper not configured: %w", plugin.ErrSkipPlugin)
 			}
 
 			if config.RootPath == "" {


### PR DESCRIPTION
Checks plugin load success and fixes devmapper always failing when not configured