### PR TITLE
ctr: return explicit errors for flags unsupported by transfer service

### DIFF
--- a/cmd/ctr/commands/images/import.go
+++ b/cmd/ctr/commands/images/import.go
@@ -115,6 +115,12 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 		defer cancel()
 
 		if !context.Bool("local") {
+			unsupportedFlags := []string{"discard-unpacked-layers"}
+			for _, s := range unsupportedFlags {
+				if context.IsSet(s) {
+					return fmt.Errorf("\"--%s\" requires \"--local\" flag", s)
+				}
+			}
 			var opts []image.StoreOpt
 			prefix := context.String("base-name")
 			var overwrite bool

--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -100,6 +100,15 @@ command. As part of this process, we do the following:
 		defer cancel()
 
 		if !context.Bool("local") {
+			unsupportedFlags := []string{"max-concurrent-downloads", "print-chainid",
+				"skip-verify", "tlscacert", "tlscert", "tlskey", "http-dump", "http-trace", // RegistryFlags
+			}
+			for _, s := range unsupportedFlags {
+				if context.IsSet(s) {
+					return fmt.Errorf("\"--%s\" requires \"--local\" flag", s)
+				}
+			}
+
 			ch, err := commands.NewStaticCredentials(ctx, context, ref)
 			if err != nil {
 				return err

--- a/cmd/ctr/commands/images/push.go
+++ b/cmd/ctr/commands/images/push.go
@@ -96,6 +96,16 @@ var pushCommand = &cli.Command{
 		defer cancel()
 
 		if !context.Bool("local") {
+			unsupportedFlags := []string{
+				"manifest", "manifest-type", "max-concurrent-uploaded-layers", "allow-non-distributable-blobs",
+				"skip-verify", "tlscacert", "tlscert", "tlskey", "http-dump", "http-trace", // RegistryFlags
+			}
+			for _, s := range unsupportedFlags {
+				if context.IsSet(s) {
+					return fmt.Errorf("\"--%s\" requires \"--local\" flag", s)
+				}
+			}
+
 			ch, err := commands.NewStaticCredentials(ctx, context, ref)
 			if err != nil {
 				return err


### PR DESCRIPTION
Following up: https://github.com/containerd/containerd/pull/10318#issuecomment-2159573558

ctr currently silently ignores several flags by default (without --local) and the user can't know which flags are supported until they see the code. This commit fixes ctr to return an explicit error when it finds an unsupported flag.