### PR TITLE
Allow running test in usernamespace

### DIFF
--- a/internal/cri/server/podsandbox/sandbox_run_linux_test.go
+++ b/internal/cri/server/podsandbox/sandbox_run_linux_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/containerd/containerd/v2/internal/cri/annotations"
 	"github.com/containerd/containerd/v2/internal/cri/opts"
 	ostesting "github.com/containerd/containerd/v2/pkg/os/testing"
+	"github.com/containerd/containerd/v2/pkg/userns"
 )
 
 func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConfig, func(*testing.T, string, *runtimespec.Spec)) {
@@ -142,7 +143,10 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 					Type: runtimespec.IPCNamespace,
 				})
 				assert.Contains(t, spec.Linux.Sysctl["net.ipv4.ip_unprivileged_port_start"], "0")
-				assert.Contains(t, spec.Linux.Sysctl["net.ipv4.ping_group_range"], "0 2147483647")
+				if !userns.RunningInUserNS() {
+					assert.Contains(t, spec.Linux.Sysctl["net.ipv4.ping_group_range"], "0 2147483647")
+				}
+
 			},
 		},
 		{


### PR DESCRIPTION
Debian has started building packages with usernamespaces
to disable network access and similar isolation features. The
containerd package executes a unit test that fails in that
scenario, see https://bugs.debian.org/1070411

The code contains a conditional on whether it is running in
usernamepsace. This commit expands the unit test to cover
this behavior; it was previously untested.

The easiest way to reproduce this issue is to prefix the test
invocaiton with 'unshare -nr go test [...]'

Signed-off-by: Reinhard Tartler <siretart@gmail.com>