### PR TITLE
CI:  bump up golangci-lint to v1.59.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: ./.github/actions/install-go
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.58.0
+          version: v1.59.1
           skip-cache: true
           args: --timeout=8m
 


### PR DESCRIPTION
golangci-lint v1.59.1: https://github.com/golangci/golangci-lint/releases/tag/v1.59.1