### PR TITLE
dependabot: enable in `/api` directory using `directories`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
-    directory: "/"
+    directories:
+      - "/"
+      - "/api"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10


### PR DESCRIPTION
This commit enables dependabot in `/api` directory using https://github.blog/changelog/2024-04-29-dependabot-multi-directory-configuration-public-beta-now-available/ 