### PR TITLE
Prepare v2.0.0-rc.3 release

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd/v2"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "2.0.0-rc.2+unknown"
+	Version = "2.0.0-rc.3+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated notes

----

Welcome to the v2.0.0-rc.3 release of containerd!  
*This is a pre-release of containerd*

The first major release of containerd 2.x focuses on the continued stability of
containerd's core feature set with an easy upgrade from containerd 1.x. This
release includes the stabilization of new features added in the last 1.x release
as well as the removal of features which were deprecated in 1.x. The goal is to
support the vast community of containerd users well into the future along with
their ever increasing deployment footprints and variety of use cases.

### Highlights

* Add type alias for event Envelope ([#10279](https://github.com/containerd/containerd/pull/10279))
* Preserve Unprivileged locked flags during remount of bind mounts ([#10200](https://github.com/containerd/containerd/pull/10200))
* Add api Go module and move all protos under api ([#10151](https://github.com/containerd/containerd/pull/10151))
* Configure otel from env instead of config.toml ([#8970](https://github.com/containerd/containerd/pull/8970))
* Fix config import relative path glob ([#9746](https://github.com/containerd/containerd/pull/9746))
* Enable NRI by default ([#9744](https://github.com/containerd/containerd/pull/9744))
* Add PluginInfo to introspection API ([#9442](https://github.com/containerd/containerd/pull/9442))
* Remove overlayfs volatile option on temp mounts ([#9555](https://github.com/containerd/containerd/pull/9555))
* Move packages based on contributing guide ([#9365](https://github.com/containerd/containerd/pull/9365))
* Expose usage of deprecated features ([#9258](https://github.com/containerd/containerd/pull/9258))
* Use Intel ISA-L's igzip if available ([#9200](https://github.com/containerd/containerd/pull/9200))
* Generalize plugin library ([#9214](https://github.com/containerd/containerd/pull/9214))
* Introduce top level config migration ([#9223](https://github.com/containerd/containerd/pull/9223))
* Add image delete target ([#8989](https://github.com/containerd/containerd/pull/8989))
* Remove `LimitNOFILE` from `containerd.service` ([#8924](https://github.com/containerd/containerd/pull/8924))
* Use github.com/containerd/log ([#9086](https://github.com/containerd/containerd/pull/9086))
* Add support for image expiration during garbage collection ([#9022](https://github.com/containerd/containerd/pull/9022))
* Reduce the contention between ref lock and boltdb lock in content store ([#8792](https://github.com/containerd/containerd/pull/8792))
* Remove "containerd.io/restart.logpath" label ([#8264](https://github.com/containerd/containerd/pull/8264))
* Remove `aufs` snapshotter ([#8263](https://github.com/containerd/containerd/pull/8263))
* Fix deadlock during NRI plugin registration ([containerd/nri#79](https://github.com/containerd/nri/pull/79))
* Fix deadlock when writing to pipe blocks ([containerd/ttrpc#168](https://github.com/containerd/ttrpc/pull/168))

#### Container Runtime Interface (CRI)

* Add support to set loopback to up ([#10238](https://github.com/containerd/containerd/pull/10238))
* Add support for multiple subscribers to CRI container events ([#9661](https://github.com/containerd/containerd/pull/9661))
* Enable CDI by default ([#9621](https://github.com/containerd/containerd/pull/9621))
* Remove non-sandboxed CRI implementation ([#9228](https://github.com/containerd/containerd/pull/9228))
* Add support for userns in stateless and stateful pods with idmap mounts (KEP-127, k8s >= 1.27) ([#8287](https://github.com/containerd/containerd/pull/8287))
* Use sandboxed CRI by default ([#8994](https://github.com/containerd/containerd/pull/8994))
* Implement RuntimeConfig CRI call ([#8722](https://github.com/containerd/containerd/pull/8722))
* Add support for user namespaces (KEP-127) ([#8803](https://github.com/containerd/containerd/pull/8803))
* Remove CRI v1alpha2 ([#8276](https://github.com/containerd/containerd/pull/8276))

#### Image Distribution

* Skip "unknown" in image platform listing ([#10257](https://github.com/containerd/containerd/pull/10257))
* Update unpacker to fetch all provided content ([#10202](https://github.com/containerd/containerd/pull/10202))
* Enable Transfer service API to support plain HTTP ([#10024](https://github.com/containerd/containerd/pull/10024))
* Enable Transfer service to use registry configuration directory ([#9908](https://github.com/containerd/containerd/pull/9908))
* Disable the support for Schema 1 images ([#9765](https://github.com/containerd/containerd/pull/9765))
* Update Transfer service to add OCI descriptors to Progress structure ([#9630](https://github.com/containerd/containerd/pull/9630))
* Update import and export to allow references to missing content  ([#9554](https://github.com/containerd/containerd/pull/9554))
* Add option to perform syncfs after pull ([#9401](https://github.com/containerd/containerd/pull/9401))
* Add image verifier transfer service plugin system based on a binary directory ([#8493](https://github.com/containerd/containerd/pull/8493))

#### Runtime

* Provide runtime options in plugin info ([#10251](https://github.com/containerd/containerd/pull/10251))
* Store bootstrap parameters in sandbox metadata ([#9736](https://github.com/containerd/containerd/pull/9736))
* Update apparmor to allow confined runc to kill containers ([#10123](https://github.com/containerd/containerd/pull/10123))
* Support vsock connection to task api ([#9738](https://github.com/containerd/containerd/pull/9738))
* Update RuntimeDefault seccomp profile to disallow io_uring related syscalls ([#9320](https://github.com/containerd/containerd/pull/9320))
* Switch runc shim to task service v3 and fix restore ([#9233](https://github.com/containerd/containerd/pull/9233))
* Add sandboxer configuration and move sandbox controllers to plugins ([#8268](https://github.com/containerd/containerd/pull/8268))
* Add annotations to CreateSandbox request ([#8960](https://github.com/containerd/containerd/pull/8960))
* Add SandboxMetrics ([#8680](https://github.com/containerd/containerd/pull/8680))
* Publish sandbox events ([#8602](https://github.com/containerd/containerd/pull/8602))
* Remove the CriuPath field from runc's options ([#8279](https://github.com/containerd/containerd/pull/8279))
* Remove support for config.toml `version = 1` ([#8275](https://github.com/containerd/containerd/pull/8275))
* Remove `io.containerd.runtime.v1.linux` and `io.containerd.runc.v1` ([#8262](https://github.com/containerd/containerd/pull/8262))

#### Security Advisories

* [medium] RAPL accessible to a container [GHSA-7ww5-4wqc-m92c](https://github.com/containerd/containerd/security/advisories/GHSA-7ww5-4wqc-m92c)

#### Breaking

* Disable the support for Schema 1 images ([#9765](https://github.com/containerd/containerd/pull/9765))
* Update RuntimeDefault seccomp profile to disallow io_uring related syscalls ([#9320](https://github.com/containerd/containerd/pull/9320))
* Move client to subpackage ([#9316](https://github.com/containerd/containerd/pull/9316))
* Remove `LimitNOFILE` from `containerd.service` ([#8924](https://github.com/containerd/containerd/pull/8924))
* Remove CRI v1alpha2 ([#8276](https://github.com/containerd/containerd/pull/8276))
* Remove `io.containerd.runtime.v1.linux` and `io.containerd.runc.v1` ([#8262](https://github.com/containerd/containerd/pull/8262))
* Remove "containerd.io/restart.logpath" label ([#8264](https://github.com/containerd/containerd/pull/8264))
* Remove `aufs` snapshotter ([#8263](https://github.com/containerd/containerd/pull/8263))

#### Deprecations

* Postpone removal of deprecated CRI config properties ([#9966](https://github.com/containerd/containerd/pull/9966))
* Deprecate go-plugin configuration option ([#9238](https://github.com/containerd/containerd/pull/9238))
* CNI conf_template in CRI is no longer deprecated ([#8637](https://github.com/containerd/containerd/pull/8637))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Derek McGowan
* Akihiro Suda
* Maksym Pavlenko
* Wei Fu
* Phil Estes
* Sebastiaan van Stijn
* Samuel Karp
* Stefan Berger
* Kazuyoshi Kato
* Rodrigo Campos
* Danny Canter
* Abel Feng
* Gabriel Adrian Samfira
* Kirtana Ashok
* Austin Vazquez
* Iceber Gu
* Kohei Tokunaga
* Krisztian Litkey
* Mike Brown
* Akhil Mohan
* Jin Dong
* Bjorn Neergaard
* rongfu.leng
* Justin Chadwell
* James Sturtevant
* Paul "TBBle" Hampson
* Davanum Srinivas
* Enrico Weigelt
* Brian Goff
* Henry Wang
* Paweł Gronowski
* Hsing-Yu (David) Chen
* Ilya Hanov
* Laura Brehm
* Marat Radchenko
* Cardy.Tang
* Aditi Sharma
* Bryant Biggs
* Evan Lezar
* Jordan Liggitt
* Kay Yan
* Markus Lehtonen
* Nashwan Azhari
* Shingo Omura
* Shuaiyi Zhang
* Vinayak Goyal
* helen
* Alexandru Matei
* Amit Barve
* Anthony Nandaa
* Charity Kathure
* Ed Bartosh
* Etienne Champetier
* James Jenkins
* Kevin Parsons
* Milas Bowman
* Swagat Bora
* yanggang
* Aditya Ramani
* Adrian Reber
* Amir M. Ghazanfari
* Artem Khramov
* Avi Deitcher
* Brad Davidson
* Chen Yiyang
* Christian Muehlhaeuser
* Cory Snider
* Djordje Lukic
* Edgar Lee
* Ethan Lowman
* Jiang Liu
* June Rhodes
* Lucas Rattz
* Mahamed Ali
* Maksim An
* Michael Crosby
* Peteris Rudzusiks
* Sam Edwards
* Samruddhi Khandale
* Steve Griffith
* Tony Fang
* VERNOU Cédric
* hang.jiang
* jerryzhuang
* lengrongfu
* ningmingxiao
* roman-kiselenko
* zhanluxianshen
* zounengren
* Aaron Lehmann
* Adrien Delorme
* Alex Couture-Beil
* Alex Ellis
* Alex Rodriguez
* Angelos Kolaitis
* Antonio Huete Jimenez
* Arash Haghighat
* Ben Foster
* Bin Tang
* Bin Xin
* BinBin He
* Brennan Kinney
* Changqing Li
* ChengenH
* ChengyuZhu6
* Christian Stewart
* Craig Ingram
* Daisy Rong
* David Porter
* Derek Nola
* Eng Zer Jun
* Fabiano Fidêncio
* Fahed Dorgaa
* Gary McDonald
* Iain Macdonald
* James Lakin
* Jan Dubois
* Jaroslav Jindrak
* Jiongchi Yu
* Julien Balestra
* Kern Walster
* Kirill A. Korinsky
* Konstantin Khlebnikov
* Michael Zappa
* Pan Yibo
* Qasim Sarfraz
* Qiutong Song
* Reinhard Tartler
* Robbie Buxton
* Robert-André Mauchin
* Ruihua Wen
* Shukui Yang
* Talon
* Tianon Gravi
* Tim Hockin
* Tobias Klauser
* Tomáš Virtus
* Tõnis Tiigi
* Wang Xinwen
* William Chen
* Xinyang Ge
* Yibo Zhuang
* Yury Gargay
* Zechun Chen
* Zhang Tianyang
* Zoe
* baijia
* bzsuni
* charles-chenzz
* chschumacher1994
* guangli.bao
* guangwu
* krglosse
* pigletfly
* rokkiter
* wangxiang
* zhangpeng
* zhaojizhuang
* 吴小白
* 张钰
* 沈陵
* 谭九鼎

### Dependency Changes

* **dario.cat/mergo**                                                              v1.0.0 **_new_**
* **github.com/AdaLogics/go-fuzz-headers**                                         1f10f66a31bf -> ced1acdcaa24
* **github.com/AdamKorcz/go-118-fuzz-build**                                       5330a85ea652 -> 8075edf89bb0
* **github.com/Masterminds/semver/v3**                                             v3.2.1 **_new_**
* **github.com/Microsoft/go-winio**                                                v0.6.0 -> v0.6.2
* **github.com/Microsoft/hcsshim**                                                 v0.10.0-rc.7 -> v0.12.4
* **github.com/cenkalti/backoff/v4**                                               v4.2.0 -> v4.3.0
* **github.com/checkpoint-restore/checkpointctl**                                  v1.2.0 **_new_**
* **github.com/checkpoint-restore/go-criu/v7**                                     v7.1.0 **_new_**
* **github.com/cilium/ebpf**                                                       v0.9.1 -> v0.11.0
* **github.com/containerd/cgroups/v3**                                             v3.0.1 -> v3.0.3
* **github.com/containerd/console**                                                v1.0.3 -> v1.0.4
* **github.com/containerd/containerd/api**                                         v1.8.0-rc.2 **_new_**
* **github.com/containerd/continuity**                                             v0.3.0 -> v0.4.3
* **github.com/containerd/errdefs**                                                v0.1.0 **_new_**
* **github.com/containerd/go-runc**                                                v1.0.0 -> v1.1.0
* **github.com/containerd/imgcrypt**                                               v1.1.7 -> 3ca09a2db5cd
* **github.com/containerd/log**                                                    v0.1.0 **_new_**
* **github.com/containerd/nri**                                                    v0.3.0 -> v0.6.1
* **github.com/containerd/platforms**                                              v0.2.1 **_new_**
* **github.com/containerd/plugin**                                                 v0.1.0 **_new_**
* **github.com/containerd/ttrpc**                                                  v1.2.1 -> v1.2.4
* **github.com/containerd/typeurl/v2**                                             v2.1.0 -> v2.1.1
* **github.com/containernetworking/cni**                                           v1.1.2 -> v1.2.0
* **github.com/containernetworking/plugins**                                       v1.2.0 -> v1.4.1
* **github.com/containers/ocicrypt**                                               v1.1.6 -> v1.1.10
* **github.com/cpuguy83/go-md2man/v2**                                             v2.0.2 -> v2.0.4
* **github.com/distribution/reference**                                            v0.6.0 **_new_**
* **github.com/emicklei/go-restful/v3**                                            v3.10.1 -> v3.11.0
* **github.com/felixge/httpsnoop**                                                 v1.0.4 **_new_**
* **github.com/fsnotify/fsnotify**                                                 v1.6.0 -> v1.7.0
* **github.com/go-jose/go-jose/v3**                                                v3.0.3 **_new_**
* **github.com/go-logr/logr**                                                      v1.2.3 -> v1.4.1
* **github.com/golang/protobuf**                                                   v1.5.2 -> v1.5.4
* **github.com/google/go-cmp**                                                     v0.5.9 -> v0.6.0
* **github.com/google/uuid**                                                       v1.3.0 -> v1.6.0
* **github.com/gorilla/websocket**                                                 v1.5.0 **_new_**
* **github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus**            v1.0.1 **_new_**
* **github.com/grpc-ecosystem/go-grpc-middleware/v2**                              v2.1.0 **_new_**
* **github.com/grpc-ecosystem/grpc-gateway/v2**                                    v2.7.0 -> v2.19.1
* **github.com/intel/goresctrl**                                                   v0.3.0 -> v0.7.0
* **github.com/klauspost/compress**                                                v1.16.0 -> v1.17.8
* **github.com/klauspost/cpuid/v2**                                                v2.0.4 -> v2.2.5
* **github.com/mdlayher/socket**                                                   v0.4.1 **_new_**
* **github.com/mdlayher/vsock**                                                    v1.2.1 **_new_**
* **github.com/minio/sha256-simd**                                                 v1.0.0 -> v1.0.1
* **github.com/moby/sys/mountinfo**                                                v0.6.2 -> v0.7.1
* **github.com/moby/sys/user**                                                     v0.1.0 **_new_**
* **github.com/mxk/go-flowrate**                                                   cca7078d478f **_new_**
* **github.com/opencontainers/image-spec**                                         3a7f492d3f1b -> v1.1.0
* **github.com/opencontainers/runtime-spec**                                       v1.1.0-rc.1 -> v1.2.0
* **github.com/opencontainers/runtime-tools**                                      946c877fa809 -> 2e043c6bd626
* **github.com/pelletier/go-toml/v2**                                              v2.2.2 **_new_**
* **github.com/prometheus/client_golang**                                          v1.14.0 -> v1.19.1
* **github.com/prometheus/client_model**                                           v0.3.0 -> v0.5.0
* **github.com/prometheus/common**                                                 v0.37.0 -> v0.48.0
* **github.com/prometheus/procfs**                                                 v0.8.0 -> v0.12.0
* **github.com/sirupsen/logrus**                                                   v1.9.0 -> v1.9.3
* **github.com/stretchr/testify**                                                  v1.8.2 -> v1.9.0
* **github.com/urfave/cli/v2**                                                     v2.27.2 **_new_**
* **github.com/vishvananda/netns**                                                 2eb08e3e575f -> v0.0.4
* **github.com/xrash/smetrics**                                                    5f08fbb34913 **_new_**
* **go.etcd.io/bbolt**                                                             v1.3.7 -> v1.3.10
* **go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc**  v0.40.0 -> v0.51.0
* **go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp**                v0.51.0 **_new_**
* **go.opentelemetry.io/otel**                                                     v1.14.0 -> v1.26.0
* **go.opentelemetry.io/otel/exporters/otlp/otlptrace**                            v1.14.0 -> v1.26.0
* **go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc**              v1.14.0 -> v1.26.0
* **go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp**              v1.14.0 -> v1.26.0
* **go.opentelemetry.io/otel/metric**                                              v0.37.0 -> v1.26.0
* **go.opentelemetry.io/otel/sdk**                                                 v1.14.0 -> v1.26.0
* **go.opentelemetry.io/otel/trace**                                               v1.14.0 -> v1.26.0
* **go.opentelemetry.io/proto/otlp**                                               v0.19.0 -> v1.2.0
* **golang.org/x/crypto**                                                          v0.1.0 -> v0.22.0
* **golang.org/x/exp**                                                             aacd6d4b4611 **_new_**
* **golang.org/x/mod**                                                             v0.7.0 -> v0.18.0
* **golang.org/x/net**                                                             v0.7.0 -> v0.24.0
* **golang.org/x/oauth2**                                                          v0.4.0 -> v0.17.0
* **golang.org/x/sync**                                                            v0.1.0 -> v0.7.0
* **golang.org/x/sys**                                                             v0.6.0 -> v0.21.0
* **golang.org/x/term**                                                            v0.5.0 -> v0.19.0
* **golang.org/x/text**                                                            v0.7.0 -> v0.14.0
* **golang.org/x/time**                                                            90d013bbcef8 -> v0.3.0
* **google.golang.org/appengine**                                                  v1.6.7 -> v1.6.8
* **google.golang.org/genproto/googleapis/api**                                    6ceb2ff114de **_new_**
* **google.golang.org/genproto/googleapis/rpc**                                    8c6c420018be **_new_**
* **google.golang.org/grpc**                                                       v1.53.0 -> v1.63.2
* **google.golang.org/protobuf**                                                   v1.28.1 -> v1.34.1
* **k8s.io/api**                                                                   v0.26.2 -> v0.30.0
* **k8s.io/apimachinery**                                                          v0.26.2 -> v0.30.0
* **k8s.io/apiserver**                                                             v0.26.2 -> v0.30.0
* **k8s.io/client-go**                                                             v0.26.2 -> v0.30.0
* **k8s.io/component-base**                                                        v0.26.2 -> v0.30.0
* **k8s.io/cri-api**                                                               v0.26.2 -> v0.30.0
* **k8s.io/klog/v2**                                                               v2.90.1 -> v2.120.1
* **k8s.io/kubelet**                                                               v0.30.0 **_new_**
* **k8s.io/utils**                                                                 a5ecb0141aa5 -> 3b25d923346b
* **sigs.k8s.io/json**                                                             f223a00ba0e2 -> bc3834ca7abd
* **sigs.k8s.io/structured-merge-diff/v4**                                         v4.2.3 -> v4.4.1
* **tags.cncf.io/container-device-interface**                                      v0.7.2 **_new_**
* **tags.cncf.io/container-device-interface/specs-go**                             v0.7.0 **_new_**

Previous release can be found at [v1.7.0](https://github.com/containerd/containerd/releases/tag/v1.7.0)
### Which file should I download?
* `containerd-<VERSION>-<OS>-<ARCH>.tar.gz`:         ✅Recommended. Dynamically linked with glibc 2.31 (Ubuntu 20.04).
* `containerd-static-<VERSION>-<OS>-<ARCH>.tar.gz`:  Statically linked. Expected to be used on non-glibc Linux distributions. Not position-independent.

In addition to containerd, typically you will have to install [runc](https://github.com/opencontainers/runc/releases)
and [CNI plugins](https://github.com/containernetworking/plugins/releases) from their official sites too.

See also the [Getting Started](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) documentation.
