### PR TITLE
[release/1.7] Remove overlayfs volatile option on temp mounts 

### DIFF
--- a/integration/container_volume_linux_test.go
+++ b/integration/container_volume_linux_test.go
@@ -1,0 +1,78 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/contrib/seccomp/kernelversion"
+	"github.com/containerd/containerd/integration/images"
+	"github.com/stretchr/testify/require"
+	criruntime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+func TestRunContainerWithVolatileOption(t *testing.T) {
+	if ok, err := kernelversion.GreaterEqualThan(kernelversion.KernelVersion{
+		Kernel: 5,
+		Major:  10,
+	}); !ok {
+		t.Skipf("Only test it when kernel >= 5.10: %v", err)
+	}
+
+	workDir := t.TempDir()
+
+	t.Log("Prepare containerd config with volatile option")
+	cfgPath := filepath.Join(workDir, "config.toml")
+	err := os.WriteFile(
+		cfgPath,
+		[]byte(`
+version = 2
+
+[plugins."io.containerd.grpc.v1.cri"]
+  ignore_image_defined_volumes = false
+
+[plugins."io.containerd.snapshotter.v1.overlayfs"]
+    mount_options = ["volatile"]
+`),
+		0600)
+	require.NoError(t, err)
+
+	t.Logf("Starting containerd")
+	currentProc := newCtrdProc(t, "containerd", workDir)
+	require.NoError(t, currentProc.isReady())
+	t.Cleanup(func() {
+		t.Log("Cleanup all the pods")
+		cleanupPods(t, currentProc.criRuntimeService(t))
+
+		t.Log("Stopping containerd process")
+		require.NoError(t, currentProc.kill(syscall.SIGTERM))
+		require.NoError(t, currentProc.wait(5*time.Minute))
+	})
+
+	imageName := images.Get(images.VolumeOwnership)
+	pullImagesByCRI(t, currentProc.criImageService(t), imageName)
+
+	podCtx := newPodTCtx(t, currentProc.criRuntimeService(t), "running-pod", "sandbox")
+
+	podCtx.createContainer("running", imageName,
+		criruntime.ContainerState_CONTAINER_RUNNING,
+		WithCommand("sleep", "1d"))
+}

--- a/integration/images/volume-ownership/Dockerfile
+++ b/integration/images/volume-ownership/Dockerfile
@@ -15,4 +15,5 @@
 FROM ubuntu
 RUN mkdir -p /test_dir && \
     chown -R nobody:nogroup /test_dir
+# NOTE: The volume is required by ../../container_volume_linux_test.go#TestRunContainerWithVolatileOption.
 VOLUME /test_dir

--- a/integration/utils_linux_test.go
+++ b/integration/utils_linux_test.go
@@ -1,0 +1,255 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"testing"
+	"time"
+
+	cri "github.com/containerd/containerd/integration/cri-api/pkg/apis"
+	"github.com/containerd/containerd/integration/remote"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	criruntime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+func newPodTCtx(t *testing.T, rSvc cri.RuntimeService,
+	name, ns string, opts ...PodSandboxOpts) *podTCtx {
+
+	t.Logf("Run a sandbox %s in namespace %s", name, ns)
+	sbConfig := PodSandboxConfig(name, ns, opts...)
+	sbID, err := rSvc.RunPodSandbox(sbConfig, "")
+	require.NoError(t, err)
+
+	return &podTCtx{
+		t:    t,
+		id:   sbID,
+		name: name,
+		ns:   ns,
+		cfg:  sbConfig,
+		rSvc: rSvc,
+	}
+}
+
+// podTCtx is used to construct pod.
+type podTCtx struct {
+	t    *testing.T
+	id   string
+	name string
+	ns   string
+	cfg  *criruntime.PodSandboxConfig
+	rSvc cri.RuntimeService
+}
+
+// createContainer creates a container in that pod.
+func (pCtx *podTCtx) createContainer(name, imageRef string, wantedState criruntime.ContainerState, opts ...ContainerOpts) string {
+	t := pCtx.t
+
+	t.Logf("Create a container %s (wantedState: %s) in pod %s", name, wantedState, pCtx.name)
+	cfg := ContainerConfig(name, imageRef, opts...)
+	cnID, err := pCtx.rSvc.CreateContainer(pCtx.id, cfg, pCtx.cfg)
+	require.NoError(t, err)
+
+	switch wantedState {
+	case criruntime.ContainerState_CONTAINER_CREATED:
+		// no-op
+	case criruntime.ContainerState_CONTAINER_RUNNING:
+		require.NoError(t, pCtx.rSvc.StartContainer(cnID))
+	case criruntime.ContainerState_CONTAINER_EXITED:
+		require.NoError(t, pCtx.rSvc.StartContainer(cnID))
+		require.NoError(t, pCtx.rSvc.StopContainer(cnID, 0))
+	default:
+		t.Fatalf("unsupport state %s", wantedState)
+	}
+	return cnID
+}
+
+// pullImagesByCRI pulls images by CRI.
+func pullImagesByCRI(t *testing.T, svc cri.ImageManagerService, images ...string) []string {
+	expectedRefs := make([]string, 0, len(images))
+
+	for _, image := range images {
+		t.Logf("Pulling image %q", image)
+		imgRef, err := svc.PullImage(&criruntime.ImageSpec{Image: image}, nil, nil)
+		require.NoError(t, err)
+		expectedRefs = append(expectedRefs, imgRef)
+	}
+	return expectedRefs
+}
+
+// cleanupPods deletes all the pods based on the cri.RuntimeService connection.
+func cleanupPods(t *testing.T, criRuntimeService cri.RuntimeService) {
+	pods, err := criRuntimeService.ListPodSandbox(nil)
+	require.NoError(t, err)
+
+	for _, pod := range pods {
+		assert.NoError(t, criRuntimeService.StopPodSandbox(pod.Id))
+		assert.NoError(t, criRuntimeService.RemovePodSandbox(pod.Id))
+	}
+}
+
+// criRuntimeService returns cri.RuntimeService based on the grpc address.
+func (p *ctrdProc) criRuntimeService(t *testing.T) cri.RuntimeService {
+	service, err := remote.NewRuntimeService(p.grpcAddress(), 1*time.Minute)
+	require.NoError(t, err)
+	return service
+}
+
+// criImageService returns cri.ImageManagerService based on the grpc address.
+func (p *ctrdProc) criImageService(t *testing.T) cri.ImageManagerService {
+	service, err := remote.NewImageService(p.grpcAddress(), 1*time.Minute)
+	require.NoError(t, err)
+	return service
+}
+
+// newCtrdProc is to start containerd process.
+func newCtrdProc(t *testing.T, ctrdBin string, ctrdWorkDir string) *ctrdProc {
+	p := &ctrdProc{workDir: ctrdWorkDir}
+
+	var args []string
+	args = append(args, "--root", p.rootPath())
+	args = append(args, "--state", p.statePath())
+	args = append(args, "--address", p.grpcAddress())
+	args = append(args, "--config", p.configPath())
+	args = append(args, "--log-level", "debug")
+
+	f, err := os.OpenFile(p.logPath(), os.O_RDWR|os.O_CREATE|os.O_APPEND, 0600)
+	require.NoError(t, err, "open log file %s", p.logPath())
+	t.Cleanup(func() { f.Close() })
+
+	cmd := exec.Command(ctrdBin, args...)
+	cmd.Stdout = f
+	cmd.Stderr = f
+	cmd.SysProcAttr = &syscall.SysProcAttr{Pdeathsig: syscall.SIGKILL}
+
+	p.cmd = cmd
+	p.waitBlock = make(chan struct{})
+	go func() {
+		// The PDeathSIG is based on the thread which forks the child
+		// process instead of the leader of thread group. Lock the
+		// thread just in case that the thread exits and causes unexpected
+		// SIGKILL to containerd.
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+
+		defer close(p.waitBlock)
+
+		require.NoError(t, p.cmd.Start(), "start containerd(%s)", ctrdBin)
+		assert.NoError(t, p.cmd.Wait())
+	}()
+	return p
+}
+
+// ctrdProc is used to control the containerd process's lifecycle.
+type ctrdProc struct {
+	// workDir has the following layout:
+	//
+	// - root  (dir)
+	// - state (dir)
+	// - containerd.sock (sock file)
+	// - config.toml (toml file, required)
+	// - containerd.log (log file, always open with O_APPEND)
+	workDir   string
+	cmd       *exec.Cmd
+	waitBlock chan struct{}
+}
+
+// kill is to send the signal to containerd process.
+func (p *ctrdProc) kill(sig syscall.Signal) error {
+	return p.cmd.Process.Signal(sig)
+}
+
+// wait is to wait for exit event of containerd process.
+func (p *ctrdProc) wait(to time.Duration) error {
+	var ctx = context.Background()
+	var cancel context.CancelFunc
+
+	if to > 0 {
+		ctx, cancel = context.WithTimeout(ctx, to)
+		defer cancel()
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-p.waitBlock:
+		return nil
+	}
+}
+
+// grpcAddress is to return containerd's address.
+func (p *ctrdProc) grpcAddress() string {
+	return filepath.Join(p.workDir, "containerd.sock")
+}
+
+// configPath is to return containerd's config file.
+func (p *ctrdProc) configPath() string {
+	return filepath.Join(p.workDir, "config.toml")
+}
+
+// rootPath is to return containerd's root path.
+func (p *ctrdProc) rootPath() string {
+	return filepath.Join(p.workDir, "root")
+}
+
+// statePath is to return containerd's state path.
+func (p *ctrdProc) statePath() string {
+	return filepath.Join(p.workDir, "state")
+}
+
+// logPath is to return containerd's log path.
+func (p *ctrdProc) logPath() string {
+	return filepath.Join(p.workDir, "containerd.log")
+}
+
+// isReady checks the containerd is ready or not.
+func (p *ctrdProc) isReady() error {
+	var (
+		service     cri.RuntimeService
+		err         error
+		ticker      = time.NewTicker(1 * time.Second)
+		ctx, cancel = context.WithTimeout(context.Background(), 2*time.Minute)
+	)
+	defer func() {
+		cancel()
+		ticker.Stop()
+	}()
+
+	for {
+		select {
+		case <-ticker.C:
+			service, err = remote.NewRuntimeService(p.grpcAddress(), 5*time.Second)
+			if err != nil {
+				continue
+			}
+
+			if _, err = service.Status(); err != nil {
+				continue
+			}
+			return nil
+		case <-ctx.Done():
+			return fmt.Errorf("context deadline exceeded: %w", err)
+		}
+	}
+}

--- a/mount/mount_test.go
+++ b/mount/mount_test.go
@@ -250,7 +250,7 @@ func TestRemoveVolatileTempMount(t *testing.T) {
 
 	for _, tc := range testCases {
 		original := copyMounts(tc.input)
-		actual := removeVolatileTempMount(tc.input)
+		actual := RemoveVolatileOption(tc.input)
 		if !reflect.DeepEqual(actual, tc.expected) {
 			t.Fatalf("incorrectly modified mounts: %s.\n\n Expected: %v\n\n, Actual: %v", tc.desc, tc.expected, actual)
 		}

--- a/mount/temp.go
+++ b/mount/temp.go
@@ -28,6 +28,7 @@ var tempMountLocation = getTempDir()
 
 // WithTempMount mounts the provided mounts to a temp dir, and pass the temp dir to f.
 // The mounts are valid during the call to the f.
+// The volatile option of overlayfs doesn't allow to mount again using the same upper / work dirs. Since it's a temp mount, avoid using that option here if found.
 // Finally we will unmount and remove the temp dir regardless of the result of f.
 func WithTempMount(ctx context.Context, mounts []Mount, f func(root string) error) (err error) {
 	root, uerr := os.MkdirTemp(tempMountLocation, "containerd-mount")
@@ -58,13 +59,50 @@ func WithTempMount(ctx context.Context, mounts []Mount, f func(root string) erro
 			}
 		}
 	}()
-	if uerr = All(mounts, root); uerr != nil {
+
+	if uerr = All(removeVolatileTempMount(mounts), root); uerr != nil {
 		return fmt.Errorf("failed to mount %s: %w", root, uerr)
 	}
 	if err := f(root); err != nil {
 		return fmt.Errorf("mount callback failed on %s: %w", root, err)
 	}
 	return nil
+}
+
+// removeVolatileTempMount The volatile option of overlayfs doesn't allow to mount again using the
+// same upper / work dirs. Since it's a temp mount, avoid using that
+// option here. Reference: https://docs.kernel.org/filesystems/overlayfs.html#volatile-mount
+// TODO: Make this logic conditional once the kernel supports reusing
+// overlayfs volatile mounts.
+func removeVolatileTempMount(mounts []Mount) []Mount {
+	var out []Mount
+	for i, m := range mounts {
+		if m.Type != "overlay" {
+			continue
+		}
+		for j, opt := range m.Options {
+			if opt == "volatile" {
+				if out == nil {
+					out = copyMounts(mounts)
+				}
+				out[i].Options = append(out[i].Options[:j], out[i].Options[j+1:]...)
+				break
+			}
+		}
+	}
+
+	if out != nil {
+		return out
+	}
+
+	return mounts
+}
+
+// copyMounts creates a copy of the original slice to allow for modification and not altering the original
+func copyMounts(in []Mount) []Mount {
+	out := make([]Mount, len(in))
+	copy(out, in)
+	return out
 }
 
 // WithReadonlyTempMount mounts the provided mounts to a temp dir as readonly,

--- a/pkg/cri/opts/container.go
+++ b/pkg/cri/opts/container.go
@@ -73,6 +73,7 @@ func WithVolumes(volumeMounts map[string]string) containerd.NewContainerOpts {
 		if len(mounts) == 1 && mounts[0].Type == "overlay" {
 			mounts[0].Options = append(mounts[0].Options, "ro")
 		}
+		mounts = mount.RemoveVolatileOption(mounts)
 
 		root, err := os.MkdirTemp("", "ctd-volume")
 		if err != nil {


### PR DESCRIPTION
backports:

* https://github.com/containerd/containerd/pull/10274
* https://github.com/containerd/containerd/pull/9555
* part of https://github.com/containerd/containerd/pull/9262 (about how to setup individual containerd)