### PR TITLE
Allow proxy plugins to have capabilities

### DIFF
--- a/cmd/containerd/server/config/config.go
+++ b/cmd/containerd/server/config/config.go
@@ -234,10 +234,11 @@ type CgroupConfig struct {
 
 // ProxyPlugin provides a proxy plugin configuration
 type ProxyPlugin struct {
-	Type     string            `toml:"type"`
-	Address  string            `toml:"address"`
-	Platform string            `toml:"platform"`
-	Exports  map[string]string `toml:"exports"`
+	Type         string            `toml:"type"`
+	Address      string            `toml:"address"`
+	Platform     string            `toml:"platform"`
+	Exports      map[string]string `toml:"exports"`
+	Capabilities []string          `toml:"capabilities"`
 }
 
 // Decode unmarshals a plugin specific configuration by plugin id

--- a/cmd/containerd/server/server.go
+++ b/cmd/containerd/server/server.go
@@ -542,6 +542,7 @@ func LoadPlugins(ctx context.Context, config *srvconfig.Config) ([]plugin.Regist
 			InitFn: func(ic *plugin.InitContext) (interface{}, error) {
 				ic.Meta.Exports = exports
 				ic.Meta.Platforms = append(ic.Meta.Platforms, p)
+				ic.Meta.Capabilities = pp.Capabilities
 				conn, err := clients.getClient(address)
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
fixes #10313 

This change allows proxy plugins to declare capabilities that get registered with the plugin.

For example, a remote snapshotter can declare that it supports native idmapping like:

```
[proxy_plugins.soci]
type=snapshot
address=/run/soci-snapshotter-grpc/soci-snapshotter-grpc.sock
capabilities=["id-map"]
```