### PR TITLE
Added the OpenSSF Scorecard Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Nightlies](https://github.com/containerd/containerd/workflows/Nightly/badge.svg)](https://github.com/containerd/containerd/actions?query=workflow%3ANightly)
 [![Go Report Card](https://goreportcard.com/badge/github.com/containerd/containerd/v2)](https://goreportcard.com/report/github.com/containerd/containerd/v2)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1271/badge)](https://bestpractices.coreinfrastructure.org/projects/1271)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/containerd/containerd/badge)](https://api.securityscorecards.dev/projects/github.com/containerd/containerd)
 [![Check Links](https://github.com/containerd/containerd/actions/workflows/links.yml/badge.svg)](https://github.com/containerd/containerd/actions/workflows/links.yml)
 
 containerd is an industry-standard container runtime with an emphasis on simplicity, robustness, and portability. It is available as a daemon for Linux and Windows, which can manage the complete container lifecycle of its host system: image transfer and storage, container execution and supervision, low-level storage and network attachments, etc.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Nightlies](https://github.com/containerd/containerd/workflows/Nightly/badge.svg)](https://github.com/containerd/containerd/actions?query=workflow%3ANightly)
 [![Go Report Card](https://goreportcard.com/badge/github.com/containerd/containerd/v2)](https://goreportcard.com/report/github.com/containerd/containerd/v2)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1271/badge)](https://bestpractices.coreinfrastructure.org/projects/1271)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/containerd/containerd/badge)](https://api.securityscorecards.dev/projects/github.com/containerd/containerd)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/containerd/containerd/badge)](https://scorecard.dev/viewer/?uri=github.com/containerd/containerd)
 [![Check Links](https://github.com/containerd/containerd/actions/workflows/links.yml/badge.svg)](https://github.com/containerd/containerd/actions/workflows/links.yml)
 
 containerd is an industry-standard container runtime with an emphasis on simplicity, robustness, and portability. It is available as a daemon for Linux and Windows, which can manage the complete container lifecycle of its host system: image transfer and storage, container execution and supervision, low-level storage and network attachments, etc.


### PR DESCRIPTION
This PR adds OpenSSF Scorecard Badge in the README file.

Hi, I'm Harshita. I’m working with [CNCF and the Google Open Source Security Team for the GSoC 2024 term](https://github.com/cncf/mentoring/issues/1196). We are collaborating to enhance security practices across various CNCF projects. The goal is to improve security for all CNCF projects by both using OpenSSF Scorecards and implementing its security improvements.

The project already has the Scorecard GitHub Action running, so adding the scorecard badge would be quite handy. So that the results can be shown as a badge in the repository's README. This badge serves as a quick indicator of the project's security posture, helping users and contributors evaluate the project's security practices quickly.