### PR TITLE
pkg/tracing: remove direct use of logrus, and fix some linting issues

### DIFF
--- a/pkg/tracing/helpers.go
+++ b/pkg/tracing/helpers.go
@@ -19,20 +19,11 @@ package tracing
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"go.opentelemetry.io/otel/attribute"
 )
 
-const (
-	spanDelimiter = "."
-)
-
-func makeSpanName(names ...string) string {
-	return strings.Join(names, spanDelimiter)
-}
-
-func any(k string, v interface{}) attribute.KeyValue {
+func keyValue(k string, v any) attribute.KeyValue {
 	if v == nil {
 		return attribute.String(k, "<nil>")
 	}

--- a/pkg/tracing/log.go
+++ b/pkg/tracing/log.go
@@ -59,7 +59,7 @@ func (h *LogrusHook) Fire(entry *log.Entry) error {
 		return nil
 	}
 
-	if !span.SpanContext().IsValid() || !span.IsRecording() {
+	if !span.IsRecording() || !span.SpanContext().IsValid() {
 		return nil
 	}
 

--- a/pkg/tracing/log.go
+++ b/pkg/tracing/log.go
@@ -17,27 +17,43 @@
 package tracing
 
 import (
-	"github.com/sirupsen/logrus"
+	"github.com/containerd/log"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
+
+// allLevels is the equivalent to [logrus.AllLevels].
+//
+// [logrus.AllLevels]: https://github.com/sirupsen/logrus/blob/v1.9.3/logrus.go#L80-L89
+var allLevels = []log.Level{
+	log.PanicLevel,
+	log.FatalLevel,
+	log.ErrorLevel,
+	log.WarnLevel,
+	log.InfoLevel,
+	log.DebugLevel,
+	log.TraceLevel,
+}
 
 // NewLogrusHook creates a new logrus hook
 func NewLogrusHook() *LogrusHook {
 	return &LogrusHook{}
 }
 
-// LogrusHook is a logrus hook which adds logrus events to active spans.
-// If the span is not recording or the span context is invalid, the hook is a no-op.
+// LogrusHook is a [logrus.Hook] which adds logrus events to active spans.
+// If the span is not recording or the span context is invalid, the hook
+// is a no-op.
+//
+// [logrus.Hook]: https://github.com/sirupsen/logrus/blob/v1.9.3/hooks.go#L3-L11
 type LogrusHook struct{}
 
 // Levels returns the logrus levels that this hook is interested in.
-func (h *LogrusHook) Levels() []logrus.Level {
-	return logrus.AllLevels
+func (h *LogrusHook) Levels() []log.Level {
+	return allLevels
 }
 
 // Fire is called when a log event occurs.
-func (h *LogrusHook) Fire(entry *logrus.Entry) error {
+func (h *LogrusHook) Fire(entry *log.Entry) error {
 	span := trace.SpanFromContext(entry.Context)
 	if span == nil {
 		return nil
@@ -57,7 +73,7 @@ func (h *LogrusHook) Fire(entry *logrus.Entry) error {
 	return nil
 }
 
-func logrusDataToAttrs(data logrus.Fields) []attribute.KeyValue {
+func logrusDataToAttrs(data map[string]any) []attribute.KeyValue {
 	attrs := make([]attribute.KeyValue, 0, len(data))
 	for k, v := range data {
 		attrs = append(attrs, keyValue(k, v))

--- a/pkg/tracing/log.go
+++ b/pkg/tracing/log.go
@@ -60,7 +60,7 @@ func (h *LogrusHook) Fire(entry *logrus.Entry) error {
 func logrusDataToAttrs(data logrus.Fields) []attribute.KeyValue {
 	attrs := make([]attribute.KeyValue, 0, len(data))
 	for k, v := range data {
-		attrs = append(attrs, any(k, v))
+		attrs = append(attrs, keyValue(k, v))
 	}
 	return attrs
 }

--- a/pkg/tracing/plugin/otlp.go
+++ b/pkg/tracing/plugin/otlp.go
@@ -96,14 +96,14 @@ func init() {
 				return nil, err
 			}
 
-			//get TracingProcessorPlugin which is a dependency
-			plugins, err := ic.GetByType(plugins.TracingProcessorPlugin)
+			// get TracingProcessorPlugin which is a dependency
+			tracingProcessors, err := ic.GetByType(plugins.TracingProcessorPlugin)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get tracing processors: %w", err)
 			}
 
-			procs := make([]trace.SpanProcessor, 0, len(plugins))
-			for _, p := range plugins {
+			procs := make([]trace.SpanProcessor, 0, len(tracingProcessors))
+			for _, p := range tracingProcessors {
 				procs = append(procs, p.(trace.SpanProcessor))
 			}
 

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -19,6 +19,7 @@ package tracing
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
@@ -99,14 +100,16 @@ func (s *Span) SetAttributes(kv ...attribute.KeyValue) {
 	s.otelSpan.SetAttributes(kv...)
 }
 
+const spanDelimiter = "."
+
 // Name sets the span name by joining a list of strings in dot separated format.
 func Name(names ...string) string {
-	return makeSpanName(names...)
+	return strings.Join(names, spanDelimiter)
 }
 
 // Attribute takes a key value pair and returns attribute.KeyValue type.
-func Attribute(k string, v interface{}) attribute.KeyValue {
-	return any(k, v)
+func Attribute(k string, v any) attribute.KeyValue {
+	return keyValue(k, v)
 }
 
 // HTTPStatusCodeAttributes generates attributes of the HTTP namespace as specified by the OpenTelemetry


### PR DESCRIPTION
### pkg/tracing: rename func that shadowed builtin, rm makeSpanNam


### pkg/tracing/plugin: rename var that collided with import

### pkg/tracing: remove direct use of github.com/sirupsen/logrus

While the hook is intended to be used with logrus, we don't need to have
the direct import; use the aliases provided by the containerd/log module
instead.


### pkg/tracing: LogrusHook.Fire: micro-optimisation

Check `span.IsRecording()` first, as it's a more lightweight check than
`span.SpanContext().IsValid()`
