### PR TITLE
Fix incorrect comment about ordering of parent layers

### DIFF
--- a/core/snapshots/storage/metastore.go
+++ b/core/snapshots/storage/metastore.go
@@ -48,10 +48,10 @@ type Transactor interface {
 
 // Snapshot hold the metadata for an active or view snapshot transaction. The
 // ParentIDs hold the snapshot identifiers for the committed snapshots this
-// active or view is based on. The ParentIDs are ordered from the lowest base
-// to highest, meaning they should be applied in order from the first index to
-// the last index. The last index should always be considered the active
-// snapshots immediate parent.
+// active or view is based on. The ParentIDs are ordered from the highest to the
+// lowest base, meaning they should be applied in order from the last index to
+// the first index. The first index should always be considered the active
+// snapshot's immediate parent.
 type Snapshot struct {
 	Kind      snapshots.Kind
 	ID        string


### PR DESCRIPTION
The ParentIDs array in the Snapshot type is populated in the reverse order i.e the immediate parent is at the 0th index and the oldest parent is at the last index. It can be seen here:
https://github.com/containerd/containerd/blob/main/core/snapshots/storage/bolt.go#L492 When applying these layers, the parent layer at the last index should be applied first and the parent layer at the 0th index should be applied last. However, the comment above the Snapshot type says the exact opposite thing.  This commit fixes that comment.