### PR TITLE
Reduce scope of permissions in stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,13 +6,16 @@ on:
     paths:
       - '.github/workflows/stale.yml'
 
-permissions:
-  issues: write
-  pull-requests: write
+permissions: read-all
 
 jobs:
   stale:
     runs-on: ubuntu-latest
+
+    permissions:
+      issues: write
+      pull-requests: write
+
     steps:
       - uses: actions/stale@v9
         # All stale bot options: https://github.com/actions/stale#all-options


### PR DESCRIPTION
Following guidance from https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#example-setting-the-github_token-permissions-for-one-job-in-a-workflow