### PR TITLE
[release/1.7] remove imports of errdefs package, and add depguard linter 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 linters:
   enable:
+    - depguard      # Checks for imports that shouldn't be used.
     - exportloopref # Checks for pointers to enclosing loop variables
     - gofmt
     - goimports
@@ -61,6 +62,16 @@ issues:
 
 
 linters-settings:
+  depguard:
+    rules:
+      main:
+        deny:
+          - pkg: "github.com/containerd/containerd/errdefs"
+            desc: The containerd errdefs package was migrated to a separate module. Use github.com/containerd/errdefs instead.
+          - pkg: "github.com/containerd/containerd/log"
+            desc: The containerd log package was migrated to a separate module. Use github.com/containerd/log instead.
+          - pkg: "github.com/containerd/containerd/platforms"
+            desc: The containerd log package was migrated to a separate module. Use github.com/containerd/platforms instead.
   gosec:
     # The following issues surfaced when `gosec` linter
     # was enabled. They are temporarily excluded to unblock

--- a/sandbox/bridge.go
+++ b/sandbox/bridge.go
@@ -24,7 +24,7 @@ import (
 	"google.golang.org/grpc"
 
 	api "github.com/containerd/containerd/api/runtime/sandbox/v1"
-	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/errdefs"
 )
 
 // NewClient returns a new sandbox client that handles both GRPC and TTRPC clients.

--- a/services/introspection/service.go
+++ b/services/introspection/service.go
@@ -17,16 +17,16 @@
 package introspection
 
 import (
-	context "context"
+	"context"
 	"errors"
 
 	"google.golang.org/grpc"
 
 	api "github.com/containerd/containerd/api/services/introspection/v1"
-	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/plugin"
 	ptypes "github.com/containerd/containerd/protobuf/types"
 	"github.com/containerd/containerd/services"
+	"github.com/containerd/errdefs"
 )
 
 func init() {


### PR DESCRIPTION
- relates to https://github.com/containerd/containerd/pull/10266
- relates to https://github.com/containerd/containerd/pull/10189


### remove imports of errdefs package

Use of the errdefs package was removed in 308341a4464bd723630d3df19a5df20aa252af9f but found their way back in through 3be919f3c023f776e5db1b162f642d79a36312a8

This patch removes the imports.


### golangci-lint: enable depguard for packages that moved

Prevent accidental imports of the packages that moved to a separate
module, but that are now an alias.
