### PR TITLE
cmd: don't alias context package, and use cliContext for cli.Context

### DIFF
--- a/cmd/containerd-stress/main.go
+++ b/cmd/containerd-stress/main.go
@@ -187,13 +187,13 @@ func main() {
 			Value: "overlayfs",
 		},
 	}
-	app.Before = func(context *cli.Context) error {
-		if context.Bool("json") {
+	app.Before = func(cliContext *cli.Context) error {
+		if cliContext.Bool("json") {
 			if err := log.SetLevel("warn"); err != nil {
 				return err
 			}
 		}
-		if context.Bool("debug") {
+		if cliContext.Bool("debug") {
 			if err := log.SetLevel("debug"); err != nil {
 				return err
 			}
@@ -203,18 +203,18 @@ func main() {
 	app.Commands = []*cli.Command{
 		densityCommand,
 	}
-	app.Action = func(context *cli.Context) error {
+	app.Action = func(cliContext *cli.Context) error {
 		config := config{
-			Address:     context.String("address"),
-			Duration:    context.Duration("duration"),
-			Concurrency: context.Int("concurrent"),
-			CRI:         context.Bool("cri"),
-			Exec:        context.Bool("exec"),
-			Image:       context.String("image"),
-			JSON:        context.Bool("json"),
-			Metrics:     context.String("metrics"),
-			Runtime:     context.String("runtime"),
-			Snapshotter: context.String("snapshotter"),
+			Address:     cliContext.String("address"),
+			Duration:    cliContext.Duration("duration"),
+			Concurrency: cliContext.Int("concurrent"),
+			CRI:         cliContext.Bool("cri"),
+			Exec:        cliContext.Bool("exec"),
+			Image:       cliContext.String("image"),
+			JSON:        cliContext.Bool("json"),
+			Metrics:     cliContext.String("metrics"),
+			Runtime:     cliContext.String("runtime"),
+			Snapshotter: cliContext.String("snapshotter"),
 		}
 		if config.Metrics != "" {
 			return serve(config)

--- a/cmd/containerd/command/config.go
+++ b/cmd/containerd/command/config.go
@@ -17,7 +17,7 @@
 package command
 
 import (
-	gocontext "context"
+	"context"
 	"os"
 	"path/filepath"
 
@@ -33,7 +33,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func outputConfig(ctx gocontext.Context, config *srvconfig.Config) error {
+func outputConfig(ctx context.Context, config *srvconfig.Config) error {
 	plugins, err := server.LoadPlugins(ctx, config)
 	if err != nil {
 		return err
@@ -86,17 +86,17 @@ var configCommand = &cli.Command{
 		{
 			Name:  "default",
 			Usage: "See the output of the default config",
-			Action: func(context *cli.Context) error {
-				return outputConfig(gocontext.Background(), defaultConfig())
+			Action: func(cliContext *cli.Context) error {
+				return outputConfig(context.Background(), defaultConfig())
 			},
 		},
 		{
 			Name:  "dump",
 			Usage: "See the output of the final main config with imported in subconfig files",
-			Action: func(context *cli.Context) error {
+			Action: func(cliContext *cli.Context) error {
 				config := defaultConfig()
-				ctx := gocontext.Background()
-				if err := srvconfig.LoadConfig(ctx, context.String("config"), config); err != nil && !os.IsNotExist(err) {
+				ctx := context.Background()
+				if err := srvconfig.LoadConfig(ctx, cliContext.String("config"), config); err != nil && !os.IsNotExist(err) {
 					return err
 				}
 
@@ -106,10 +106,10 @@ var configCommand = &cli.Command{
 		{
 			Name:  "migrate",
 			Usage: "Migrate the current configuration file to the latest version (does not migrate subconfig files)",
-			Action: func(context *cli.Context) error {
+			Action: func(cliContext *cli.Context) error {
 				config := defaultConfig()
-				ctx := gocontext.Background()
-				if err := srvconfig.LoadConfig(ctx, context.String("config"), config); err != nil && !os.IsNotExist(err) {
+				ctx := context.Background()
+				if err := srvconfig.LoadConfig(ctx, cliContext.String("config"), config); err != nil && !os.IsNotExist(err) {
 					return err
 				}
 

--- a/cmd/containerd/command/oci-hook.go
+++ b/cmd/containerd/command/oci-hook.go
@@ -33,7 +33,7 @@ import (
 var ociHook = &cli.Command{
 	Name:  "oci-hook",
 	Usage: "Provides a base for OCI runtime hooks to allow arguments to be injected.",
-	Action: func(context *cli.Context) error {
+	Action: func(cliContext *cli.Context) error {
 		state, err := loadHookState(os.Stdin)
 		if err != nil {
 			return err
@@ -45,7 +45,7 @@ var ociHook = &cli.Command{
 		}
 		var (
 			ctx  = newTemplateContext(state, spec)
-			args = context.Args().Slice()
+			args = cliContext.Args().Slice()
 			env  = os.Environ()
 		)
 		if err := newList(&args).render(ctx); err != nil {

--- a/cmd/containerd/command/publish.go
+++ b/cmd/containerd/command/publish.go
@@ -17,7 +17,7 @@
 package command
 
 import (
-	gocontext "context"
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -49,9 +49,9 @@ var publishCommand = &cli.Command{
 			Usage: "Topic of the event",
 		},
 	},
-	Action: func(context *cli.Context) error {
-		ctx := namespaces.WithNamespace(gocontext.Background(), context.String("namespace"))
-		topic := context.String("topic")
+	Action: func(cliContext *cli.Context) error {
+		ctx := namespaces.WithNamespace(context.Background(), cliContext.String("namespace"))
+		topic := cliContext.String("topic")
 		if topic == "" {
 			return fmt.Errorf("topic required to publish event: %w", errdefs.ErrInvalidArgument)
 		}
@@ -59,7 +59,7 @@ var publishCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
-		client, err := connectEvents(context.String("address"))
+		client, err := connectEvents(cliContext.String("address"))
 		if err != nil {
 			return err
 		}
@@ -93,7 +93,7 @@ func connectEvents(address string) (eventsapi.EventsClient, error) {
 	return eventsapi.NewEventsClient(conn), nil
 }
 
-func connect(address string, d func(gocontext.Context, string) (net.Conn, error)) (*grpc.ClientConn, error) {
+func connect(address string, d func(context.Context, string) (net.Conn, error)) (*grpc.ClientConn, error) {
 	backoffConfig := backoff.DefaultConfig
 	backoffConfig.MaxDelay = 3 * time.Second
 	connParams := grpc.ConnectParams{
@@ -106,7 +106,7 @@ func connect(address string, d func(gocontext.Context, string) (net.Conn, error)
 		grpc.FailOnNonTempDialError(true),
 		grpc.WithConnectParams(connParams),
 	}
-	ctx, cancel := gocontext.WithTimeout(gocontext.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	conn, err := grpc.DialContext(ctx, dialer.DialAddress(address), gopts...)
 	if err != nil {

--- a/cmd/containerd/command/service_unsupported.go
+++ b/cmd/containerd/command/service_unsupported.go
@@ -30,7 +30,7 @@ func serviceFlags() []cli.Flag {
 }
 
 // applyPlatformFlags applies platform-specific flags.
-func applyPlatformFlags(context *cli.Context) {
+func applyPlatformFlags(cliContext *cli.Context) {
 }
 
 // registerUnregisterService is only relevant on Windows.

--- a/cmd/containerd/command/service_windows.go
+++ b/cmd/containerd/command/service_windows.go
@@ -79,8 +79,8 @@ func serviceFlags() []cli.Flag {
 }
 
 // applyPlatformFlags applies platform-specific flags.
-func applyPlatformFlags(context *cli.Context) {
-	serviceNameFlag = context.String("service-name")
+func applyPlatformFlags(cliContext *cli.Context) {
+	serviceNameFlag = cliContext.String("service-name")
 	if serviceNameFlag == "" {
 		serviceNameFlag = defaultServiceName
 	}
@@ -101,9 +101,9 @@ func applyPlatformFlags(context *cli.Context) {
 			d:    &runServiceFlag,
 		},
 	} {
-		*v.d = context.Bool(v.name)
+		*v.d = cliContext.Bool(v.name)
 	}
-	logFileFlag = context.String("log-file")
+	logFileFlag = cliContext.String("log-file")
 }
 
 type handler struct {

--- a/cmd/ctr/app/main.go
+++ b/cmd/ctr/app/main.go
@@ -52,8 +52,8 @@ func init() {
 	// Discard grpc logs so that they don't mess with our stdio
 	grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, io.Discard))
 
-	cli.VersionPrinter = func(c *cli.Context) {
-		fmt.Println(c.App.Name, version.Package, c.App.Version)
+	cli.VersionPrinter = func(cliContext *cli.Context) {
+		fmt.Println(cliContext.App.Name, version.Package, cliContext.App.Version)
 	}
 	cli.VersionFlag = &cli.BoolFlag{
 		Name:    "version",
@@ -135,8 +135,8 @@ containerd CLI
 		info.Command,
 		deprecations.Command,
 	}, extraCmds...)
-	app.Before = func(context *cli.Context) error {
-		if context.Bool("debug") {
+	app.Before = func(cliContext *cli.Context) error {
+		if cliContext.Bool("debug") {
 			return log.SetLevel("debug")
 		}
 		return nil

--- a/cmd/ctr/commands/client.go
+++ b/cmd/ctr/commands/client.go
@@ -17,7 +17,7 @@
 package commands
 
 import (
-	gocontext "context"
+	"context"
 	"os"
 	"strconv"
 
@@ -33,18 +33,18 @@ import (
 //
 // This will ensure the namespace is picked up and set the timeout, if one is
 // defined.
-func AppContext(context *cli.Context) (gocontext.Context, gocontext.CancelFunc) {
+func AppContext(cliContext *cli.Context) (context.Context, context.CancelFunc) {
 	var (
-		ctx       = gocontext.Background()
-		timeout   = context.Duration("timeout")
-		namespace = context.String("namespace")
-		cancel    gocontext.CancelFunc
+		ctx       = context.Background()
+		timeout   = cliContext.Duration("timeout")
+		namespace = cliContext.String("namespace")
+		cancel    context.CancelFunc
 	)
 	ctx = namespaces.WithNamespace(ctx, namespace)
 	if timeout > 0 {
-		ctx, cancel = gocontext.WithTimeout(ctx, timeout)
+		ctx, cancel = context.WithTimeout(ctx, timeout)
 	} else {
-		ctx, cancel = gocontext.WithCancel(ctx)
+		ctx, cancel = context.WithCancel(ctx)
 	}
 	if tm, err := epoch.SourceDateEpoch(); err != nil {
 		log.L.WithError(err).Warn("Failed to read SOURCE_DATE_EPOCH")
@@ -56,14 +56,14 @@ func AppContext(context *cli.Context) (gocontext.Context, gocontext.CancelFunc) 
 }
 
 // NewClient returns a new containerd client
-func NewClient(context *cli.Context, opts ...containerd.Opt) (*containerd.Client, gocontext.Context, gocontext.CancelFunc, error) {
-	timeoutOpt := containerd.WithTimeout(context.Duration("connect-timeout"))
+func NewClient(cliContext *cli.Context, opts ...containerd.Opt) (*containerd.Client, context.Context, context.CancelFunc, error) {
+	timeoutOpt := containerd.WithTimeout(cliContext.Duration("connect-timeout"))
 	opts = append(opts, timeoutOpt)
-	client, err := containerd.New(context.String("address"), opts...)
+	client, err := containerd.New(cliContext.String("address"), opts...)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	ctx, cancel := AppContext(context)
+	ctx, cancel := AppContext(cliContext)
 	var suppressDeprecationWarnings bool
 	if s := os.Getenv("CONTAINERD_SUPPRESS_DEPRECATION_WARNINGS"); s != "" {
 		suppressDeprecationWarnings, err = strconv.ParseBool(s)

--- a/cmd/ctr/commands/commands.go
+++ b/cmd/ctr/commands/commands.go
@@ -232,10 +232,10 @@ var (
 )
 
 // ObjectWithLabelArgs returns the first arg and a LabelArgs object
-func ObjectWithLabelArgs(clicontext *cli.Context) (string, map[string]string) {
+func ObjectWithLabelArgs(cliContext *cli.Context) (string, map[string]string) {
 	var (
-		first        = clicontext.Args().First()
-		labelStrings = clicontext.Args().Tail()
+		first        = cliContext.Args().First()
+		labelStrings = cliContext.Args().Tail()
 	)
 
 	return first, LabelArgs(labelStrings)

--- a/cmd/ctr/commands/commands_unix.go
+++ b/cmd/ctr/commands/commands_unix.go
@@ -59,37 +59,37 @@ func init() {
 	})
 }
 
-func getRuncOptions(context *cli.Context) (*options.Options, error) {
+func getRuncOptions(cliContext *cli.Context) (*options.Options, error) {
 	runtimeOpts := &options.Options{}
-	if runcBinary := context.String("runc-binary"); runcBinary != "" {
+	if runcBinary := cliContext.String("runc-binary"); runcBinary != "" {
 		runtimeOpts.BinaryName = runcBinary
 	}
-	if context.Bool("runc-systemd-cgroup") {
-		if context.String("cgroup") == "" {
+	if cliContext.Bool("runc-systemd-cgroup") {
+		if cliContext.String("cgroup") == "" {
 			// runc maps "machine.slice:foo:deadbeef" to "/machine.slice/foo-deadbeef.scope"
 			return nil, errors.New("option --runc-systemd-cgroup requires --cgroup to be set, e.g. \"machine.slice:foo:deadbeef\"")
 		}
 		runtimeOpts.SystemdCgroup = true
 	}
-	if root := context.String("runc-root"); root != "" {
+	if root := cliContext.String("runc-root"); root != "" {
 		runtimeOpts.Root = root
 	}
 
 	return runtimeOpts, nil
 }
 
-func RuntimeOptions(context *cli.Context) (interface{}, error) {
+func RuntimeOptions(cliContext *cli.Context) (interface{}, error) {
 	// validate first
-	if (context.String("runc-binary") != "" || context.Bool("runc-systemd-cgroup")) &&
-		context.String("runtime") != "io.containerd.runc.v2" {
+	if (cliContext.String("runc-binary") != "" || cliContext.Bool("runc-systemd-cgroup")) &&
+		cliContext.String("runtime") != "io.containerd.runc.v2" {
 		return nil, errors.New("specifying runc-binary and runc-systemd-cgroup is only supported for \"io.containerd.runc.v2\" runtime")
 	}
 
-	if context.String("runtime") == "io.containerd.runc.v2" {
-		return getRuncOptions(context)
+	if cliContext.String("runtime") == "io.containerd.runc.v2" {
+		return getRuncOptions(cliContext)
 	}
 
-	if configPath := context.String("runtime-config-path"); configPath != "" {
+	if configPath := cliContext.String("runtime-config-path"); configPath != "" {
 		return &runtimeoptions.Options{
 			ConfigPath: configPath,
 		}, nil

--- a/cmd/ctr/commands/commands_windows.go
+++ b/cmd/ctr/commands/commands_windows.go
@@ -37,6 +37,6 @@ func init() {
 		})
 }
 
-func RuntimeOptions(context *cli.Context) (interface{}, error) {
+func RuntimeOptions(cliContext *cli.Context) (interface{}, error) {
 	return nil, nil
 }

--- a/cmd/ctr/commands/containers/checkpoint.go
+++ b/cmd/ctr/commands/containers/checkpoint.go
@@ -44,16 +44,16 @@ var checkpointCommand = &cli.Command{
 			Usage: "Checkpoint container task",
 		},
 	},
-	Action: func(context *cli.Context) error {
-		id := context.Args().First()
+	Action: func(cliContext *cli.Context) error {
+		id := cliContext.Args().First()
 		if id == "" {
 			return errors.New("container id must be provided")
 		}
-		ref := context.Args().Get(1)
+		ref := cliContext.Args().Get(1)
 		if ref == "" {
 			return errors.New("ref must be provided")
 		}
-		client, ctx, cancel, err := commands.NewClient(context)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
@@ -62,13 +62,13 @@ var checkpointCommand = &cli.Command{
 			containerd.WithCheckpointRuntime,
 		}
 
-		if context.Bool("image") {
+		if cliContext.Bool("image") {
 			opts = append(opts, containerd.WithCheckpointImage)
 		}
-		if context.Bool("rw") {
+		if cliContext.Bool("rw") {
 			opts = append(opts, containerd.WithCheckpointRW)
 		}
-		if context.Bool("task") {
+		if cliContext.Bool("task") {
 			opts = append(opts, containerd.WithCheckpointTask)
 		}
 		container, err := client.LoadContainer(ctx, id)

--- a/cmd/ctr/commands/containers/restore.go
+++ b/cmd/ctr/commands/containers/restore.go
@@ -43,16 +43,16 @@ var restoreCommand = &cli.Command{
 			Usage: "Restore the runtime and memory data from the checkpoint",
 		},
 	},
-	Action: func(context *cli.Context) error {
-		id := context.Args().First()
+	Action: func(cliContext *cli.Context) error {
+		id := cliContext.Args().First()
 		if id == "" {
 			return errors.New("container id must be provided")
 		}
-		ref := context.Args().Get(1)
+		ref := cliContext.Args().Get(1)
 		if ref == "" {
 			return errors.New("ref must be provided")
 		}
-		client, ctx, cancel, err := commands.NewClient(context)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
@@ -76,7 +76,7 @@ var restoreCommand = &cli.Command{
 			containerd.WithRestoreSpec,
 			containerd.WithRestoreRuntime,
 		}
-		if context.Bool("rw") {
+		if cliContext.Bool("rw") {
 			opts = append(opts, containerd.WithRestoreRW)
 		}
 
@@ -85,7 +85,7 @@ var restoreCommand = &cli.Command{
 			return err
 		}
 		topts := []containerd.NewTaskOpts{}
-		if context.Bool("live") {
+		if cliContext.Bool("live") {
 			topts = append(topts, containerd.WithTaskCheckpoint(checkpoint))
 		}
 		spec, err := ctr.Spec(ctx)

--- a/cmd/ctr/commands/content/content.go
+++ b/cmd/ctr/commands/content/content.go
@@ -64,12 +64,12 @@ var (
 		Usage:       "Get the data for an object",
 		ArgsUsage:   "[<digest>, ...]",
 		Description: "display the image object",
-		Action: func(context *cli.Context) error {
-			dgst, err := digest.Parse(context.Args().First())
+		Action: func(cliContext *cli.Context) error {
+			dgst, err := digest.Parse(cliContext.Args().First())
 			if err != nil {
 				return err
 			}
-			client, ctx, cancel, err := commands.NewClient(context)
+			client, ctx, cancel, err := commands.NewClient(cliContext)
 			if err != nil {
 				return err
 			}
@@ -103,11 +103,11 @@ var (
 				Usage: "Verify content against expected digest",
 			},
 		},
-		Action: func(context *cli.Context) error {
+		Action: func(cliContext *cli.Context) error {
 			var (
-				ref            = context.Args().First()
-				expectedSize   = context.Int64("expected-size")
-				expectedDigest = digest.Digest(context.String("expected-digest"))
+				ref            = cliContext.Args().First()
+				expectedSize   = cliContext.Int64("expected-size")
+				expectedDigest = digest.Digest(cliContext.String("expected-digest"))
 			)
 			if err := expectedDigest.Validate(); expectedDigest != "" && err != nil {
 				return err
@@ -115,7 +115,7 @@ var (
 			if ref == "" {
 				return errors.New("must specify a transaction reference")
 			}
-			client, ctx, cancel, err := commands.NewClient(context)
+			client, ctx, cancel, err := commands.NewClient(cliContext)
 			if err != nil {
 				return err
 			}
@@ -148,9 +148,9 @@ var (
 				Value: "/tmp/content", // TODO(stevvooe): for now, just use the PWD/.content
 			},
 		},
-		Action: func(context *cli.Context) error {
-			match := context.Args().First()
-			client, ctx, cancel, err := commands.NewClient(context)
+		Action: func(cliContext *cli.Context) error {
+			match := cliContext.Args().First()
+			client, ctx, cancel, err := commands.NewClient(cliContext)
 			if err != nil {
 				return err
 			}
@@ -186,12 +186,12 @@ var (
 				Usage:   "Print only the blob digest",
 			},
 		},
-		Action: func(context *cli.Context) error {
+		Action: func(cliContext *cli.Context) error {
 			var (
-				quiet = context.Bool("quiet")
-				args  = context.Args().Slice()
+				quiet = cliContext.Bool("quiet")
+				args  = cliContext.Args().Slice()
 			)
-			client, ctx, cancel, err := commands.NewClient(context)
+			client, ctx, cancel, err := commands.NewClient(cliContext)
 			if err != nil {
 				return err
 			}
@@ -239,9 +239,9 @@ var (
 		Usage:       "Add labels to content",
 		ArgsUsage:   "<digest> [<label>=<value> ...]",
 		Description: "labels blobs in the content store",
-		Action: func(context *cli.Context) error {
-			object, labels := commands.ObjectWithLabelArgs(context)
-			client, ctx, cancel, err := commands.NewClient(context)
+		Action: func(cliContext *cli.Context) error {
+			object, labels := commands.ObjectWithLabelArgs(cliContext)
+			client, ctx, cancel, err := commands.NewClient(cliContext)
 			if err != nil {
 				return err
 			}
@@ -304,10 +304,10 @@ var (
 				EnvVars: []string{"EDITOR"},
 			},
 		},
-		Action: func(context *cli.Context) error {
+		Action: func(cliContext *cli.Context) error {
 			var (
-				validate = context.String("validate")
-				object   = context.Args().First()
+				validate = cliContext.String("validate")
+				object   = cliContext.Args().First()
 			)
 
 			if validate != "" {
@@ -321,7 +321,7 @@ var (
 			if err != nil {
 				return err
 			}
-			client, ctx, cancel, err := commands.NewClient(context)
+			client, ctx, cancel, err := commands.NewClient(cliContext)
 			if err != nil {
 				return err
 			}
@@ -333,7 +333,7 @@ var (
 			}
 			defer ra.Close()
 
-			nrc, err := edit(context, content.NewReader(ra))
+			nrc, err := edit(cliContext, content.NewReader(ra))
 			if err != nil {
 				return err
 			}
@@ -364,12 +364,12 @@ var (
 		ArgsUsage: "[<digest>, ...]",
 		Description: `Delete one or more blobs permanently. Successfully deleted
 	blobs are printed to stdout.`,
-		Action: func(context *cli.Context) error {
+		Action: func(cliContext *cli.Context) error {
 			var (
-				args      = context.Args().Slice()
+				args      = cliContext.Args().Slice()
 				exitError error
 			)
-			client, ctx, cancel, err := commands.NewClient(context)
+			client, ctx, cancel, err := commands.NewClient(cliContext)
 			if err != nil {
 				return err
 			}
@@ -412,14 +412,14 @@ var (
 		ArgsUsage:   "[flags] <remote> <object> [<hint>, ...]",
 		Description: `Fetch objects by identifier from a remote.`,
 		Flags:       commands.RegistryFlags,
-		Action: func(context *cli.Context) error {
+		Action: func(cliContext *cli.Context) error {
 			var (
-				ref = context.Args().First()
+				ref = cliContext.Args().First()
 			)
-			ctx, cancel := commands.AppContext(context)
+			ctx, cancel := commands.AppContext(cliContext)
 			defer cancel()
 
-			resolver, err := commands.GetResolver(ctx, context)
+			resolver, err := commands.GetResolver(ctx, cliContext)
 			if err != nil {
 				return err
 			}
@@ -459,18 +459,18 @@ var (
 				Usage: "Specify target mediatype for request header",
 			},
 		}...),
-		Action: func(context *cli.Context) error {
+		Action: func(cliContext *cli.Context) error {
 			var (
-				ref     = context.Args().First()
-				digests = context.Args().Tail()
+				ref     = cliContext.Args().First()
+				digests = cliContext.Args().Tail()
 			)
 			if len(digests) == 0 {
 				return errors.New("must specify digests")
 			}
-			ctx, cancel := commands.AppContext(context)
+			ctx, cancel := commands.AppContext(cliContext)
 			defer cancel()
 
-			resolver, err := commands.GetResolver(ctx, context)
+			resolver, err := commands.GetResolver(ctx, cliContext)
 			if err != nil {
 				return err
 			}
@@ -493,7 +493,7 @@ var (
 				if err != nil {
 					return err
 				}
-				rc, desc, err := fetcherByDigest.FetchByDigest(ctx, dgst, remotes.WithMediaType(context.String("media-type")))
+				rc, desc, err := fetcherByDigest.FetchByDigest(ctx, dgst, remotes.WithMediaType(cliContext.String("media-type")))
 				if err != nil {
 					return err
 				}
@@ -514,23 +514,23 @@ var (
 		ArgsUsage:   "[flags] <remote> <object> <type>",
 		Description: `Push objects by identifier to a remote.`,
 		Flags:       commands.RegistryFlags,
-		Action: func(context *cli.Context) error {
+		Action: func(cliContext *cli.Context) error {
 			var (
-				ref    = context.Args().Get(0)
-				object = context.Args().Get(1)
-				media  = context.Args().Get(2)
+				ref    = cliContext.Args().Get(0)
+				object = cliContext.Args().Get(1)
+				media  = cliContext.Args().Get(2)
 			)
 			dgst, err := digest.Parse(object)
 			if err != nil {
 				return err
 			}
-			client, ctx, cancel, err := commands.NewClient(context)
+			client, ctx, cancel, err := commands.NewClient(cliContext)
 			if err != nil {
 				return err
 			}
 			defer cancel()
 
-			resolver, err := commands.GetResolver(ctx, context)
+			resolver, err := commands.GetResolver(ctx, cliContext)
 			if err != nil {
 				return err
 			}
@@ -578,8 +578,8 @@ var (
 	}
 )
 
-func edit(context *cli.Context, rd io.Reader) (_ io.ReadCloser, retErr error) {
-	editor := context.String("editor")
+func edit(cliContext *cli.Context, rd io.Reader) (_ io.ReadCloser, retErr error) {
+	editor := cliContext.String("editor")
 	if editor == "" {
 		return nil, errors.New("editor is required")
 	}

--- a/cmd/ctr/commands/content/fetch.go
+++ b/cmd/ctr/commands/content/fetch.go
@@ -81,16 +81,16 @@ Most of this is experimental and there are few leaps to make this work.`,
 			Usage: "Pull all metadata including manifests and configs",
 		},
 	),
-	Action: func(clicontext *cli.Context) error {
+	Action: func(cliContext *cli.Context) error {
 		var (
-			ref = clicontext.Args().First()
+			ref = cliContext.Args().First()
 		)
-		client, ctx, cancel, err := commands.NewClient(clicontext)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
 		defer cancel()
-		config, err := NewFetchConfig(ctx, clicontext)
+		config, err := NewFetchConfig(ctx, cliContext)
 		if err != nil {
 			return err
 		}
@@ -121,42 +121,42 @@ type FetchConfig struct {
 }
 
 // NewFetchConfig returns the default FetchConfig from cli flags
-func NewFetchConfig(ctx context.Context, clicontext *cli.Context) (*FetchConfig, error) {
-	resolver, err := commands.GetResolver(ctx, clicontext)
+func NewFetchConfig(ctx context.Context, cliContext *cli.Context) (*FetchConfig, error) {
+	resolver, err := commands.GetResolver(ctx, cliContext)
 	if err != nil {
 		return nil, err
 	}
 	config := &FetchConfig{
 		Resolver:  resolver,
-		Labels:    clicontext.StringSlice("label"),
-		TraceHTTP: clicontext.Bool("http-trace"),
+		Labels:    cliContext.StringSlice("label"),
+		TraceHTTP: cliContext.Bool("http-trace"),
 	}
-	if !clicontext.Bool("debug") {
+	if !cliContext.Bool("debug") {
 		config.ProgressOutput = os.Stdout
 	}
-	if !clicontext.Bool("all-platforms") {
-		p := clicontext.StringSlice("platform")
+	if !cliContext.Bool("all-platforms") {
+		p := cliContext.StringSlice("platform")
 		if len(p) == 0 {
 			p = append(p, platforms.DefaultString())
 		}
 		config.Platforms = p
 	}
 
-	if clicontext.Bool("metadata-only") {
+	if cliContext.Bool("metadata-only") {
 		config.AllMetadata = true
 		// Any with an empty set is None
 		config.PlatformMatcher = platforms.Any()
-	} else if !clicontext.Bool("skip-metadata") {
+	} else if !cliContext.Bool("skip-metadata") {
 		config.AllMetadata = true
 	}
 
-	if clicontext.IsSet("max-concurrent-downloads") {
-		mcd := clicontext.Int("max-concurrent-downloads")
+	if cliContext.IsSet("max-concurrent-downloads") {
+		mcd := cliContext.Int("max-concurrent-downloads")
 		config.RemoteOpts = append(config.RemoteOpts, containerd.WithMaxConcurrentDownloads(mcd))
 	}
 
-	if clicontext.IsSet("max-concurrent-uploaded-layers") {
-		mcu := clicontext.Int("max-concurrent-uploaded-layers")
+	if cliContext.IsSet("max-concurrent-uploaded-layers") {
+		mcu := cliContext.Int("max-concurrent-uploaded-layers")
 		config.RemoteOpts = append(config.RemoteOpts, containerd.WithMaxConcurrentUploadedLayers(mcu))
 	}
 

--- a/cmd/ctr/commands/content/prune.go
+++ b/cmd/ctr/commands/content/prune.go
@@ -56,21 +56,21 @@ var pruneReferencesCommand = &cli.Command{
 	Name:  "references",
 	Usage: "Prunes preference labels from the content store (layers only by default)",
 	Flags: pruneFlags,
-	Action: func(clicontext *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(clicontext)
+	Action: func(cliContext *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 
-		dryRun := clicontext.Bool("dry")
+		dryRun := cliContext.Bool("dry")
 		if dryRun {
 			log.G(ctx).Logger.SetLevel(log.DebugLevel)
 			log.G(ctx).Debug("dry run, no changes will be applied")
 		}
 
 		var deleteOpts []leases.DeleteOpt
-		if !clicontext.Bool("async") {
+		if !cliContext.Bool("async") {
 			deleteOpts = append(deleteOpts, leases.SynchronousDelete)
 		}
 

--- a/cmd/ctr/commands/deprecations/deprecations.go
+++ b/cmd/ctr/commands/deprecations/deprecations.go
@@ -45,11 +45,11 @@ var listCommand = &cli.Command{
 			Usage: "output format to use (Examples: 'default', 'json')",
 		},
 	},
-	Action: func(context *cli.Context) error {
+	Action: func(cliContext *cli.Context) error {
 		// Suppress automatic warnings, since we print the warnings by ourselves.
 		os.Setenv("CONTAINERD_SUPPRESS_DEPRECATION_WARNINGS", "1")
 
-		client, ctx, cancel, err := commands.NewClient(context)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
@@ -61,7 +61,7 @@ var listCommand = &cli.Command{
 		}
 		wrn := warnings(resp)
 		if len(wrn) > 0 {
-			switch context.String("format") {
+			switch cliContext.String("format") {
 			case "json":
 				commands.PrintAsJSON(warnings(resp))
 				return nil

--- a/cmd/ctr/commands/events/events.go
+++ b/cmd/ctr/commands/events/events.go
@@ -35,14 +35,14 @@ var Command = &cli.Command{
 	Name:    "events",
 	Aliases: []string{"event"},
 	Usage:   "Display containerd events",
-	Action: func(context *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(context)
+	Action: func(cliContext *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 		eventsClient := client.EventService()
-		eventsCh, errCh := eventsClient.Subscribe(ctx, context.Args().Slice()...)
+		eventsCh, errCh := eventsClient.Subscribe(ctx, cliContext.Args().Slice()...)
 		for {
 			var e *events.Envelope
 			select {

--- a/cmd/ctr/commands/images/convert.go
+++ b/cmd/ctr/commands/images/convert.go
@@ -59,16 +59,16 @@ When '--all-platforms' is given all images in a manifest list must be available.
 			Usage: "Exports content from all platforms",
 		},
 	},
-	Action: func(context *cli.Context) error {
+	Action: func(cliContext *cli.Context) error {
 		var convertOpts []converter.Opt
-		srcRef := context.Args().Get(0)
-		targetRef := context.Args().Get(1)
+		srcRef := cliContext.Args().Get(0)
+		targetRef := cliContext.Args().Get(1)
 		if srcRef == "" || targetRef == "" {
 			return errors.New("src and target image need to be specified")
 		}
 
-		if !context.Bool("all-platforms") {
-			if pss := context.StringSlice("platform"); len(pss) > 0 {
+		if !cliContext.Bool("all-platforms") {
+			if pss := cliContext.StringSlice("platform"); len(pss) > 0 {
 				all, err := platforms.ParseAll(pss)
 				if err != nil {
 					return err
@@ -79,15 +79,15 @@ When '--all-platforms' is given all images in a manifest list must be available.
 			}
 		}
 
-		if context.Bool("uncompress") {
+		if cliContext.Bool("uncompress") {
 			convertOpts = append(convertOpts, converter.WithLayerConvertFunc(uncompress.LayerConvertFunc))
 		}
 
-		if context.Bool("oci") {
+		if cliContext.Bool("oci") {
 			convertOpts = append(convertOpts, converter.WithDockerToOCI(true))
 		}
 
-		client, ctx, cancel, err := commands.NewClient(context)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
@@ -97,7 +97,7 @@ When '--all-platforms' is given all images in a manifest list must be available.
 		if err != nil {
 			return err
 		}
-		fmt.Fprintln(context.App.Writer, newImg.Target.Digest.String())
+		fmt.Fprintln(cliContext.App.Writer, newImg.Target.Digest.String())
 		return nil
 	},
 }

--- a/cmd/ctr/commands/images/export.go
+++ b/cmd/ctr/commands/images/export.go
@@ -66,17 +66,17 @@ When '--all-platforms' is given all images in a manifest list must be available.
 			Usage: "Run export locally rather than through transfer API",
 		},
 	},
-	Action: func(context *cli.Context) error {
+	Action: func(cliContext *cli.Context) error {
 		var (
-			out        = context.Args().First()
-			images     = context.Args().Tail()
+			out        = cliContext.Args().First()
+			images     = cliContext.Args().Tail()
 			exportOpts = []archive.ExportOpt{}
 		)
 		if out == "" || len(images) == 0 {
 			return errors.New("please provide both an output filename and an image reference to export")
 		}
 
-		client, ctx, cancel, err := commands.NewClient(context)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
@@ -93,12 +93,12 @@ When '--all-platforms' is given all images in a manifest list must be available.
 		}
 		defer w.Close()
 
-		if !context.Bool("local") {
+		if !cliContext.Bool("local") {
 			pf, done := ProgressHandler(ctx, os.Stdout)
 			defer done()
 
 			exportOpts := []tarchive.ExportOpt{}
-			if pss := context.StringSlice("platform"); len(pss) > 0 {
+			if pss := cliContext.StringSlice("platform"); len(pss) > 0 {
 				for _, ps := range pss {
 					p, err := platforms.Parse(ps)
 					if err != nil {
@@ -107,15 +107,15 @@ When '--all-platforms' is given all images in a manifest list must be available.
 					exportOpts = append(exportOpts, tarchive.WithPlatform(p))
 				}
 			}
-			if context.Bool("all-platforms") {
+			if cliContext.Bool("all-platforms") {
 				exportOpts = append(exportOpts, tarchive.WithAllPlatforms)
 			}
 
-			if context.Bool("skip-manifest-json") {
+			if cliContext.Bool("skip-manifest-json") {
 				exportOpts = append(exportOpts, tarchive.WithSkipCompatibilityManifest)
 			}
 
-			if context.Bool("skip-non-distributable") {
+			if cliContext.Bool("skip-non-distributable") {
 				exportOpts = append(exportOpts, tarchive.WithSkipNonDistributableBlobs)
 			}
 
@@ -131,7 +131,7 @@ When '--all-platforms' is given all images in a manifest list must be available.
 			)
 		}
 
-		if pss := context.StringSlice("platform"); len(pss) > 0 {
+		if pss := cliContext.StringSlice("platform"); len(pss) > 0 {
 			all, err := platforms.ParseAll(pss)
 			if err != nil {
 				return err
@@ -141,15 +141,15 @@ When '--all-platforms' is given all images in a manifest list must be available.
 			exportOpts = append(exportOpts, archive.WithPlatform(platforms.DefaultStrict()))
 		}
 
-		if context.Bool("all-platforms") {
+		if cliContext.Bool("all-platforms") {
 			exportOpts = append(exportOpts, archive.WithAllPlatforms())
 		}
 
-		if context.Bool("skip-manifest-json") {
+		if cliContext.Bool("skip-manifest-json") {
 			exportOpts = append(exportOpts, archive.WithSkipDockerManifest())
 		}
 
-		if context.Bool("skip-non-distributable") {
+		if cliContext.Bool("skip-non-distributable") {
 			exportOpts = append(exportOpts, archive.WithSkipNonDistributableBlobs())
 		}
 

--- a/cmd/ctr/commands/images/images.go
+++ b/cmd/ctr/commands/images/images.go
@@ -70,12 +70,12 @@ var listCommand = &cli.Command{
 			Usage:   "Print only the image refs",
 		},
 	},
-	Action: func(context *cli.Context) error {
+	Action: func(cliContext *cli.Context) error {
 		var (
-			filters = context.Args().Slice()
-			quiet   = context.Bool("quiet")
+			filters = cliContext.Args().Slice()
+			quiet   = cliContext.Bool("quiet")
 		)
-		client, ctx, cancel, err := commands.NewClient(context)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
@@ -154,12 +154,12 @@ var setLabelsCommand = &cli.Command{
 			Usage:   "Replace all labels",
 		},
 	},
-	Action: func(context *cli.Context) error {
+	Action: func(cliContext *cli.Context) error {
 		var (
-			replaceAll   = context.Bool("replace-all")
-			name, labels = commands.ObjectWithLabelArgs(context)
+			replaceAll   = cliContext.Bool("replace-all")
+			name, labels = commands.ObjectWithLabelArgs(cliContext)
 		)
-		client, ctx, cancel, err := commands.NewClient(context)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
@@ -214,12 +214,12 @@ var checkCommand = &cli.Command{
 			Usage:   "Print only the ready image refs (fully downloaded and unpacked)",
 		},
 	}, commands.SnapshotterFlags...),
-	Action: func(context *cli.Context) error {
+	Action: func(cliContext *cli.Context) error {
 		var (
 			exitErr error
-			quiet   = context.Bool("quiet")
+			quiet   = cliContext.Bool("quiet")
 		)
-		client, ctx, cancel, err := commands.NewClient(context)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
@@ -227,7 +227,7 @@ var checkCommand = &cli.Command{
 
 		var contentStore = client.ContentStore()
 
-		args := context.Args().Slice()
+		args := cliContext.Args().Slice()
 		imageList, err := client.ListImages(ctx, args...)
 		if err != nil {
 			return fmt.Errorf("failed listing images: %w", err)
@@ -287,7 +287,7 @@ var checkCommand = &cli.Command{
 				size = "-"
 			}
 
-			unpacked, err := image.IsUnpacked(ctx, context.String("snapshotter"))
+			unpacked, err := image.IsUnpacked(ctx, cliContext.String("snapshotter"))
 			if err != nil {
 				if exitErr == nil {
 					exitErr = fmt.Errorf("unable to check unpack for %v: %w", image.Name(), err)
@@ -328,8 +328,8 @@ var removeCommand = &cli.Command{
 			Usage: "Synchronously remove image and all associated resources",
 		},
 	},
-	Action: func(context *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(context)
+	Action: func(cliContext *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
@@ -338,9 +338,9 @@ var removeCommand = &cli.Command{
 			exitErr    error
 			imageStore = client.ImageService()
 		)
-		for i, target := range context.Args().Slice() {
+		for i, target := range cliContext.Args().Slice() {
 			var opts []images.DeleteOpt
-			if context.Bool("sync") && i == context.NArg()-1 {
+			if cliContext.Bool("sync") && i == cliContext.NArg()-1 {
 				opts = append(opts, images.SynchronousDelete())
 			}
 			if err := imageStore.Delete(ctx, target, opts...); err != nil {
@@ -373,14 +373,14 @@ var pruneCommand = &cli.Command{
 	},
 	// adapted from `nerdctl`:
 	// https://github.com/containerd/nerdctl/blob/272dc9c29fc1434839d3ec63194d7efa24d7c0ef/cmd/nerdctl/image_prune.go#L86
-	Action: func(context *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(context)
+	Action: func(cliContext *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 
-		all := context.Bool("all")
+		all := cliContext.Bool("all")
 		if !all {
 			log.G(ctx).Warn("No images pruned. `image prune` requires --all to be specified.")
 			// NOP

--- a/cmd/ctr/commands/images/inspect.go
+++ b/cmd/ctr/commands/images/inspect.go
@@ -36,14 +36,14 @@ var inspectCommand = &cli.Command{
 			Usage: "Show JSON content",
 		},
 	},
-	Action: func(clicontext *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(clicontext)
+	Action: func(cliContext *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 		var (
-			ref        = clicontext.Args().First()
+			ref        = cliContext.Args().First()
 			imageStore = client.ImageService()
 			cs         = client.ContentStore()
 		)
@@ -56,7 +56,7 @@ var inspectCommand = &cli.Command{
 		opts := []display.PrintOpt{
 			display.WithWriter(os.Stdout),
 		}
-		if clicontext.Bool("content") {
+		if cliContext.Bool("content") {
 			opts = append(opts, display.Verbose)
 		}
 

--- a/cmd/ctr/commands/images/mount.go
+++ b/cmd/ctr/commands/images/mount.go
@@ -51,10 +51,10 @@ When you are done, use the unmount command.
 			Value: platforms.DefaultString(),
 		},
 	),
-	Action: func(context *cli.Context) (retErr error) {
+	Action: func(cliContext *cli.Context) (retErr error) {
 		var (
-			ref    = context.Args().First()
-			target = context.Args().Get(1)
+			ref    = cliContext.Args().First()
+			target = cliContext.Args().Get(1)
 		)
 		if ref == "" {
 			return errors.New("please provide an image reference to mount")
@@ -63,13 +63,13 @@ When you are done, use the unmount command.
 			return errors.New("please provide a target path to mount to")
 		}
 
-		client, ctx, cancel, err := commands.NewClient(context)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 
-		snapshotter := context.String("snapshotter")
+		snapshotter := cliContext.String("snapshotter")
 		if snapshotter == "" {
 			snapshotter = defaults.DefaultSnapshotter
 		}
@@ -89,7 +89,7 @@ When you are done, use the unmount command.
 			}
 		}()
 
-		ps := context.String("platform")
+		ps := cliContext.String("platform")
 		p, err := platforms.Parse(ps)
 		if err != nil {
 			return fmt.Errorf("unable to parse platform %s: %w", ps, err)
@@ -115,7 +115,7 @@ When you are done, use the unmount command.
 		s := client.SnapshotService(snapshotter)
 
 		var mounts []mount.Mount
-		if context.Bool("rw") {
+		if cliContext.Bool("rw") {
 			mounts, err = s.Prepare(ctx, target, chainID)
 		} else {
 			mounts, err = s.View(ctx, target, chainID)
@@ -131,12 +131,12 @@ When you are done, use the unmount command.
 
 		if err := mount.All(mounts, target); err != nil {
 			if err := s.Remove(ctx, target); err != nil && !errdefs.IsNotFound(err) {
-				fmt.Fprintln(context.App.ErrWriter, "Error cleaning up snapshot after mount error:", err)
+				fmt.Fprintln(cliContext.App.ErrWriter, "Error cleaning up snapshot after mount error:", err)
 			}
 			return err
 		}
 
-		fmt.Fprintln(context.App.Writer, target)
+		fmt.Fprintln(cliContext.App.Writer, target)
 		return nil
 	},
 }

--- a/cmd/ctr/commands/images/tag.go
+++ b/cmd/ctr/commands/images/tag.go
@@ -47,26 +47,26 @@ var tagCommand = &cli.Command{
 			Usage: "Skip the strict check for reference names",
 		},
 	},
-	Action: func(context *cli.Context) error {
+	Action: func(cliContext *cli.Context) error {
 		var (
-			ref = context.Args().First()
+			ref = cliContext.Args().First()
 		)
 		if ref == "" {
 			return errors.New("please provide an image reference to tag from")
 		}
-		if context.NArg() <= 1 {
+		if cliContext.NArg() <= 1 {
 			return errors.New("please provide an image reference to tag to")
 		}
 
-		client, ctx, cancel, err := commands.NewClient(context)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 
-		if !context.Bool("local") {
-			for _, targetRef := range context.Args().Slice()[1:] {
-				if !context.Bool("skip-reference-check") {
+		if !cliContext.Bool("local") {
+			for _, targetRef := range cliContext.Args().Slice()[1:] {
+				if !cliContext.Bool("skip-reference-check") {
 					if _, err := reference.ParseAnyReference(targetRef); err != nil {
 						return fmt.Errorf("error parsing reference: %q is not a valid repository/tag %v", targetRef, err)
 					}
@@ -92,8 +92,8 @@ var tagCommand = &cli.Command{
 			return err
 		}
 		// Support multiple references for one command run
-		for _, targetRef := range context.Args().Slice()[1:] {
-			if !context.Bool("skip-reference-check") {
+		for _, targetRef := range cliContext.Args().Slice()[1:] {
+			if !cliContext.Bool("skip-reference-check") {
 				if _, err := reference.ParseAnyReference(targetRef); err != nil {
 					return fmt.Errorf("error parsing reference: %q is not a valid repository/tag %v", targetRef, err)
 				}
@@ -103,7 +103,7 @@ var tagCommand = &cli.Command{
 			if _, err = imageService.Create(ctx, image); err != nil {
 				// If user has specified force and the image already exists then
 				// delete the original image and attempt to create the new one
-				if errdefs.IsAlreadyExists(err) && context.Bool("force") {
+				if errdefs.IsAlreadyExists(err) && cliContext.Bool("force") {
 					if err = imageService.Delete(ctx, targetRef); err != nil {
 						return err
 					}

--- a/cmd/ctr/commands/images/unmount.go
+++ b/cmd/ctr/commands/images/unmount.go
@@ -38,15 +38,15 @@ var unmountCommand = &cli.Command{
 			Usage: "Remove the snapshot after a successful unmount",
 		},
 	),
-	Action: func(context *cli.Context) error {
+	Action: func(cliContext *cli.Context) error {
 		var (
-			target = context.Args().First()
+			target = cliContext.Args().First()
 		)
 		if target == "" {
 			return errors.New("please provide a target path to unmount from")
 		}
 
-		client, ctx, cancel, err := commands.NewClient(context)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
@@ -56,8 +56,8 @@ var unmountCommand = &cli.Command{
 			return err
 		}
 
-		if context.Bool("rm") {
-			snapshotter := context.String("snapshotter")
+		if cliContext.Bool("rm") {
+			snapshotter := cliContext.String("snapshotter")
 			s := client.SnapshotService(snapshotter)
 			if err := client.LeasesService().Delete(ctx, leases.Lease{ID: target}); err != nil && !errdefs.IsNotFound(err) {
 				return fmt.Errorf("error deleting lease: %w", err)
@@ -67,7 +67,7 @@ var unmountCommand = &cli.Command{
 			}
 		}
 
-		fmt.Fprintln(context.App.Writer, target)
+		fmt.Fprintln(cliContext.App.Writer, target)
 		return nil
 	},
 }

--- a/cmd/ctr/commands/images/usage.go
+++ b/cmd/ctr/commands/images/usage.go
@@ -36,19 +36,19 @@ var usageCommand = &cli.Command{
 	Usage:     "Display usage of snapshots for a given image ref",
 	ArgsUsage: "[flags] <ref>",
 	Flags:     commands.SnapshotterFlags,
-	Action: func(context *cli.Context) error {
-		var ref = context.Args().First()
+	Action: func(cliContext *cli.Context) error {
+		var ref = cliContext.Args().First()
 		if ref == "" {
 			return errors.New("please provide an image reference to mount")
 		}
 
-		client, ctx, cancel, err := commands.NewClient(context)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 
-		snapshotter := context.String("snapshotter")
+		snapshotter := cliContext.String("snapshotter")
 		if snapshotter == "" {
 			snapshotter = defaults.DefaultSnapshotter
 		}

--- a/cmd/ctr/commands/info/info.go
+++ b/cmd/ctr/commands/info/info.go
@@ -30,8 +30,8 @@ type Info struct {
 var Command = &cli.Command{
 	Name:  "info",
 	Usage: "Print the server info",
-	Action: func(context *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(context)
+	Action: func(cliContext *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/install/install.go
+++ b/cmd/ctr/commands/install/install.go
@@ -44,25 +44,25 @@ var Command = &cli.Command{
 			Usage: "Set an optional install path other than the managed opt directory",
 		},
 	},
-	Action: func(context *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(context)
+	Action: func(cliContext *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
 		defer cancel()
-		ref := context.Args().First()
+		ref := cliContext.Args().First()
 		image, err := client.GetImage(ctx, ref)
 		if err != nil {
 			return err
 		}
 		var opts []containerd.InstallOpts
-		if context.Bool("libs") {
+		if cliContext.Bool("libs") {
 			opts = append(opts, containerd.WithInstallLibs)
 		}
-		if context.Bool("replace") {
+		if cliContext.Bool("replace") {
 			opts = append(opts, containerd.WithInstallReplace)
 		}
-		if path := context.String("path"); path != "" {
+		if path := cliContext.String("path"); path != "" {
 			opts = append(opts, containerd.WithInstallPath(path))
 		}
 		return client.Install(ctx, image, opts...)

--- a/cmd/ctr/commands/leases/leases.go
+++ b/cmd/ctr/commands/leases/leases.go
@@ -54,12 +54,12 @@ var listCommand = &cli.Command{
 			Usage:   "Print only the blob digest",
 		},
 	},
-	Action: func(context *cli.Context) error {
+	Action: func(cliContext *cli.Context) error {
 		var (
-			filters = context.Args().Slice()
-			quiet   = context.Bool("quiet")
+			filters = cliContext.Args().Slice()
+			quiet   = cliContext.Bool("quiet")
 		)
-		client, ctx, cancel, err := commands.NewClient(context)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
@@ -117,9 +117,9 @@ var createCommand = &cli.Command{
 			Value:   24 * time.Hour,
 		},
 	},
-	Action: func(context *cli.Context) error {
-		var labelstr = context.Args().Slice()
-		client, ctx, cancel, err := commands.NewClient(context)
+	Action: func(cliContext *cli.Context) error {
+		var labelstr = cliContext.Args().Slice()
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
@@ -136,10 +136,10 @@ var createCommand = &cli.Command{
 			opts = append(opts, leases.WithLabels(labels))
 		}
 
-		if id := context.String("id"); id != "" {
+		if id := cliContext.String("id"); id != "" {
 			opts = append(opts, leases.WithID(id))
 		}
-		if exp := context.Duration("expires"); exp > 0 {
+		if exp := cliContext.Duration("expires"); exp > 0 {
 			opts = append(opts, leases.WithExpiration(exp))
 		}
 
@@ -166,19 +166,19 @@ var deleteCommand = &cli.Command{
 			Usage: "Synchronously remove leases and all unreferenced resources",
 		},
 	},
-	Action: func(context *cli.Context) error {
-		var lids = context.Args().Slice()
+	Action: func(cliContext *cli.Context) error {
+		var lids = cliContext.Args().Slice()
 		if len(lids) == 0 {
-			return cli.ShowSubcommandHelp(context)
+			return cli.ShowSubcommandHelp(cliContext)
 		}
-		client, ctx, cancel, err := commands.NewClient(context)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 
 		ls := client.LeasesService()
-		sync := context.Bool("sync")
+		sync := cliContext.Bool("sync")
 		for i, lid := range lids {
 			var opts []leases.DeleteOpt
 			if sync && i == len(lids)-1 {

--- a/cmd/ctr/commands/namespaces/namespaces.go
+++ b/cmd/ctr/commands/namespaces/namespaces.go
@@ -49,12 +49,12 @@ var createCommand = &cli.Command{
 	Usage:       "Create a new namespace",
 	ArgsUsage:   "<name> [<key>=<value>]",
 	Description: "create a new namespace. it must be unique",
-	Action: func(context *cli.Context) error {
-		namespace, labels := commands.ObjectWithLabelArgs(context)
+	Action: func(cliContext *cli.Context) error {
+		namespace, labels := commands.ObjectWithLabelArgs(cliContext)
 		if namespace == "" {
 			return errors.New("please specify a namespace")
 		}
-		client, ctx, cancel, err := commands.NewClient(context)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
@@ -69,12 +69,12 @@ var setLabelsCommand = &cli.Command{
 	Usage:       "Set and clear labels for a namespace",
 	ArgsUsage:   "<name> [<key>=<value>, ...]",
 	Description: "set and clear labels for a namespace. empty value clears the label",
-	Action: func(context *cli.Context) error {
-		namespace, labels := commands.ObjectWithLabelArgs(context)
+	Action: func(cliContext *cli.Context) error {
+		namespace, labels := commands.ObjectWithLabelArgs(cliContext)
 		if namespace == "" {
 			return errors.New("please specify a namespace")
 		}
-		client, ctx, cancel, err := commands.NewClient(context)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
@@ -102,9 +102,9 @@ var listCommand = &cli.Command{
 			Usage:   "Print only the namespace name",
 		},
 	},
-	Action: func(context *cli.Context) error {
-		quiet := context.Bool("quiet")
-		client, ctx, cancel, err := commands.NewClient(context)
+	Action: func(cliContext *cli.Context) error {
+		quiet := cliContext.Bool("quiet")
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
@@ -155,17 +155,17 @@ var removeCommand = &cli.Command{
 			Usage:   "Delete the namespace's cgroup",
 		},
 	},
-	Action: func(context *cli.Context) error {
+	Action: func(cliContext *cli.Context) error {
 		var exitErr error
-		client, ctx, cancel, err := commands.NewClient(context)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 
-		opts := deleteOpts(context)
+		opts := deleteOpts(cliContext)
 		namespaces := client.NamespaceService()
-		for _, target := range context.Args().Slice() {
+		for _, target := range cliContext.Args().Slice() {
 			if err := namespaces.Delete(ctx, target, opts...); err != nil {
 				if !errdefs.IsNotFound(err) {
 					if exitErr == nil {

--- a/cmd/ctr/commands/namespaces/namespaces_linux.go
+++ b/cmd/ctr/commands/namespaces/namespaces_linux.go
@@ -22,9 +22,9 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func deleteOpts(context *cli.Context) []namespaces.DeleteOpts {
+func deleteOpts(cliContext *cli.Context) []namespaces.DeleteOpts {
 	var delOpts []namespaces.DeleteOpts
-	if context.Bool("cgroup") {
+	if cliContext.Bool("cgroup") {
 		delOpts = append(delOpts, opts.WithNamespaceCgroupDeletion)
 	}
 	return delOpts

--- a/cmd/ctr/commands/namespaces/namespaces_other.go
+++ b/cmd/ctr/commands/namespaces/namespaces_other.go
@@ -23,6 +23,6 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func deleteOpts(context *cli.Context) []namespaces.DeleteOpts {
+func deleteOpts(cliContext *cli.Context) []namespaces.DeleteOpts {
 	return nil
 }

--- a/cmd/ctr/commands/oci/oci.go
+++ b/cmd/ctr/commands/oci/oci.go
@@ -45,12 +45,12 @@ var defaultSpecCommand = &cli.Command{
 			Usage: "Platform of the spec to print (Examples: 'linux/arm64', 'windows/amd64')",
 		},
 	},
-	Action: func(context *cli.Context) error {
-		ctx, cancel := commands.AppContext(context)
+	Action: func(cliContext *cli.Context) error {
+		ctx, cancel := commands.AppContext(cliContext)
 		defer cancel()
 
 		platform := platforms.DefaultString()
-		if plat := context.String("platform"); plat != "" {
+		if plat := cliContext.String("platform"); plat != "" {
 			platform = plat
 		}
 

--- a/cmd/ctr/commands/plugins/plugins.go
+++ b/cmd/ctr/commands/plugins/plugins.go
@@ -60,18 +60,18 @@ var listCommand = &cli.Command{
 			Usage:   "Print detailed information about each plugin",
 		},
 	},
-	Action: func(context *cli.Context) error {
+	Action: func(cliContext *cli.Context) error {
 		var (
-			quiet    = context.Bool("quiet")
-			detailed = context.Bool("detailed")
+			quiet    = cliContext.Bool("quiet")
+			detailed = cliContext.Bool("detailed")
 		)
-		client, ctx, cancel, err := commands.NewClient(context)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 		ps := client.IntrospectionService()
-		response, err := ps.Plugins(ctx, context.Args().Slice()...)
+		response, err := ps.Plugins(ctx, cliContext.Args().Slice()...)
 		if err != nil {
 			return err
 		}
@@ -172,13 +172,13 @@ var inspectRuntimeCommand = &cli.Command{
 	Usage:     "Display runtime info",
 	ArgsUsage: "[flags]",
 	Flags:     commands.RuntimeFlags,
-	Action: func(context *cli.Context) error {
-		rt := context.String("runtime")
-		rtOptions, err := commands.RuntimeOptions(context)
+	Action: func(cliContext *cli.Context) error {
+		rt := cliContext.String("runtime")
+		rtOptions, err := commands.RuntimeOptions(cliContext)
 		if err != nil {
 			return err
 		}
-		client, ctx, cancel, err := commands.NewClient(context)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
@@ -191,7 +191,7 @@ var inspectRuntimeCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
-		_, err = fmt.Fprintln(context.App.Writer, string(j))
+		_, err = fmt.Fprintln(cliContext.App.Writer, string(j))
 		return err
 	},
 }

--- a/cmd/ctr/commands/pprof/pprof.go
+++ b/cmd/ctr/commands/pprof/pprof.go
@@ -64,10 +64,10 @@ var pprofGoroutinesCommand = &cli.Command{
 			Value: 2,
 		},
 	},
-	Action: func(context *cli.Context) error {
-		client := getPProfClient(context)
+	Action: func(cliContext *cli.Context) error {
+		client := getPProfClient(cliContext)
 
-		debug := context.Uint("debug")
+		debug := cliContext.Uint("debug")
 		output, err := httpGetRequest(client, fmt.Sprintf("/debug/pprof/goroutine?debug=%d", debug))
 		if err != nil {
 			return err
@@ -88,10 +88,10 @@ var pprofHeapCommand = &cli.Command{
 			Value: 0,
 		},
 	},
-	Action: func(context *cli.Context) error {
-		client := getPProfClient(context)
+	Action: func(cliContext *cli.Context) error {
+		client := getPProfClient(cliContext)
 
-		debug := context.Uint("debug")
+		debug := cliContext.Uint("debug")
 		output, err := httpGetRequest(client, fmt.Sprintf("/debug/pprof/heap?debug=%d", debug))
 		if err != nil {
 			return err
@@ -118,11 +118,11 @@ var pprofProfileCommand = &cli.Command{
 			Value: 0,
 		},
 	},
-	Action: func(context *cli.Context) error {
-		client := getPProfClient(context)
+	Action: func(cliContext *cli.Context) error {
+		client := getPProfClient(cliContext)
 
-		seconds := context.Duration("seconds").Seconds()
-		debug := context.Uint("debug")
+		seconds := cliContext.Duration("seconds").Seconds()
+		debug := cliContext.Uint("debug")
 		output, err := httpGetRequest(client, fmt.Sprintf("/debug/pprof/profile?seconds=%v&debug=%d", seconds, debug))
 		if err != nil {
 			return err
@@ -149,11 +149,11 @@ var pprofTraceCommand = &cli.Command{
 			Value: 0,
 		},
 	},
-	Action: func(context *cli.Context) error {
-		client := getPProfClient(context)
+	Action: func(cliContext *cli.Context) error {
+		client := getPProfClient(cliContext)
 
-		seconds := context.Duration("seconds").Seconds()
-		debug := context.Uint("debug")
+		seconds := cliContext.Duration("seconds").Seconds()
+		debug := cliContext.Uint("debug")
 		uri := fmt.Sprintf("/debug/pprof/trace?seconds=%v&debug=%d", seconds, debug)
 		output, err := httpGetRequest(client, uri)
 		if err != nil {
@@ -175,10 +175,10 @@ var pprofBlockCommand = &cli.Command{
 			Value: 0,
 		},
 	},
-	Action: func(context *cli.Context) error {
-		client := getPProfClient(context)
+	Action: func(cliContext *cli.Context) error {
+		client := getPProfClient(cliContext)
 
-		debug := context.Uint("debug")
+		debug := cliContext.Uint("debug")
 		output, err := httpGetRequest(client, fmt.Sprintf("/debug/pprof/block?debug=%d", debug))
 		if err != nil {
 			return err
@@ -199,10 +199,10 @@ var pprofThreadcreateCommand = &cli.Command{
 			Value: 0,
 		},
 	},
-	Action: func(context *cli.Context) error {
-		client := getPProfClient(context)
+	Action: func(cliContext *cli.Context) error {
+		client := getPProfClient(cliContext)
 
-		debug := context.Uint("debug")
+		debug := cliContext.Uint("debug")
 		output, err := httpGetRequest(client, fmt.Sprintf("/debug/pprof/threadcreate?debug=%d", debug))
 		if err != nil {
 			return err
@@ -213,8 +213,8 @@ var pprofThreadcreateCommand = &cli.Command{
 	},
 }
 
-func getPProfClient(context *cli.Context) *http.Client {
-	dialer := getPProfDialer(context.String("debug-socket"))
+func getPProfClient(cliContext *cli.Context) *http.Client {
+	dialer := getPProfDialer(cliContext.String("debug-socket"))
 
 	tr := &http.Transport{
 		Dial: dialer.pprofDial,

--- a/cmd/ctr/commands/sandboxes/sandboxes.go
+++ b/cmd/ctr/commands/sandboxes/sandboxes.go
@@ -54,16 +54,16 @@ var runCommand = &cli.Command{
 			Value: defaults.DefaultRuntime,
 		},
 	},
-	Action: func(context *cli.Context) error {
-		if context.NArg() != 2 {
-			return cli.ShowSubcommandHelp(context)
+	Action: func(cliContext *cli.Context) error {
+		if cliContext.NArg() != 2 {
+			return cli.ShowSubcommandHelp(cliContext)
 		}
 		var (
-			id      = context.Args().Get(1)
-			runtime = context.String("runtime")
+			id      = cliContext.Args().Get(1)
+			runtime = cliContext.String("runtime")
 		)
 
-		spec, err := os.ReadFile(context.Args().First())
+		spec, err := os.ReadFile(cliContext.Args().First())
 		if err != nil {
 			return fmt.Errorf("failed to read sandbox config: %w", err)
 		}
@@ -73,7 +73,7 @@ var runCommand = &cli.Command{
 			return fmt.Errorf("failed to parse sandbox config: %w", err)
 		}
 
-		client, ctx, cancel, err := commands.NewClient(context)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
@@ -107,8 +107,8 @@ var listCommand = &cli.Command{
 			Usage: "The list of filters to apply when querying sandboxes from the store",
 		},
 	},
-	Action: func(context *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(context)
+	Action: func(cliContext *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
@@ -116,7 +116,7 @@ var listCommand = &cli.Command{
 
 		var (
 			writer  = tabwriter.NewWriter(os.Stdout, 1, 8, 1, ' ', 0)
-			filters = context.StringSlice("filters")
+			filters = cliContext.StringSlice("filters")
 		)
 
 		defer func() {
@@ -155,16 +155,16 @@ var removeCommand = &cli.Command{
 			Usage:   "Ignore shutdown errors when removing sandbox",
 		},
 	},
-	Action: func(context *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(context)
+	Action: func(cliContext *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
 		defer cancel()
 
-		force := context.Bool("force")
+		force := cliContext.Bool("force")
 
-		for _, id := range context.Args().Slice() {
+		for _, id := range cliContext.Args().Slice() {
 			sandbox, err := client.LoadSandbox(ctx, id)
 			if err != nil {
 				log.G(ctx).WithError(err).Errorf("failed to load sandbox %s", id)

--- a/cmd/ctr/commands/shim/io_unix.go
+++ b/cmd/ctr/commands/shim/io_unix.go
@@ -19,7 +19,7 @@
 package shim
 
 import (
-	gocontext "context"
+	"context"
 	"io"
 	"os"
 	"sync"
@@ -37,7 +37,7 @@ var bufPool = sync.Pool{
 
 func prepareStdio(stdin, stdout, stderr string, console bool) (wg *sync.WaitGroup, err error) {
 	wg = &sync.WaitGroup{}
-	ctx := gocontext.Background()
+	ctx := context.Background()
 
 	f, err := fifo.OpenFifo(ctx, stdin, unix.O_WRONLY|unix.O_CREAT|unix.O_NONBLOCK, 0700)
 	if err != nil {

--- a/cmd/ctr/commands/shim/shim.go
+++ b/cmd/ctr/commands/shim/shim.go
@@ -19,7 +19,7 @@
 package shim
 
 import (
-	gocontext "context"
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -81,13 +81,13 @@ var Command = &cli.Command{
 var startCommand = &cli.Command{
 	Name:  "start",
 	Usage: "Start a container with a task",
-	Action: func(context *cli.Context) error {
-		service, err := getTaskService(context)
+	Action: func(cliContext *cli.Context) error {
+		service, err := getTaskService(cliContext)
 		if err != nil {
 			return err
 		}
-		_, err = service.Start(gocontext.Background(), &task.StartRequest{
-			ID: context.Args().First(),
+		_, err = service.Start(context.Background(), &task.StartRequest{
+			ID: cliContext.Args().First(),
 		})
 		return err
 	},
@@ -96,13 +96,13 @@ var startCommand = &cli.Command{
 var deleteCommand = &cli.Command{
 	Name:  "delete",
 	Usage: "Delete a container with a task",
-	Action: func(context *cli.Context) error {
-		service, err := getTaskService(context)
+	Action: func(cliContext *cli.Context) error {
+		service, err := getTaskService(cliContext)
 		if err != nil {
 			return err
 		}
-		r, err := service.Delete(gocontext.Background(), &task.DeleteRequest{
-			ID: context.Args().First(),
+		r, err := service.Delete(context.Background(), &task.DeleteRequest{
+			ID: cliContext.Args().First(),
 		})
 		if err != nil {
 			return err
@@ -115,13 +115,13 @@ var deleteCommand = &cli.Command{
 var stateCommand = &cli.Command{
 	Name:  "state",
 	Usage: "Get the state of all the processes of the task",
-	Action: func(context *cli.Context) error {
-		service, err := getTaskService(context)
+	Action: func(cliContext *cli.Context) error {
+		service, err := getTaskService(cliContext)
 		if err != nil {
 			return err
 		}
-		r, err := service.State(gocontext.Background(), &task.StateRequest{
-			ID: context.String("id"),
+		r, err := service.State(context.Background(), &task.StateRequest{
+			ID: cliContext.String("id"),
 		})
 		if err != nil {
 			return err
@@ -155,28 +155,28 @@ var execCommand = &cli.Command{
 			Usage: "Runtime spec",
 		},
 	),
-	Action: func(context *cli.Context) error {
-		service, err := getTaskService(context)
+	Action: func(cliContext *cli.Context) error {
+		service, err := getTaskService(cliContext)
 		if err != nil {
 			return err
 		}
 		var (
-			id  = context.Args().First()
-			ctx = gocontext.Background()
+			id  = cliContext.Args().First()
+			ctx = context.Background()
 		)
 
 		if id == "" {
 			return errors.New("exec id must be provided")
 		}
 
-		tty := context.Bool("tty")
-		wg, err := prepareStdio(context.String("stdin"), context.String("stdout"), context.String("stderr"), tty)
+		tty := cliContext.Bool("tty")
+		wg, err := prepareStdio(cliContext.String("stdin"), cliContext.String("stdout"), cliContext.String("stderr"), tty)
 		if err != nil {
 			return err
 		}
 
 		// read spec file and extract Any object
-		spec, err := os.ReadFile(context.String("spec"))
+		spec, err := os.ReadFile(cliContext.String("spec"))
 		if err != nil {
 			return err
 		}
@@ -191,9 +191,9 @@ var execCommand = &cli.Command{
 				TypeUrl: url,
 				Value:   spec,
 			},
-			Stdin:    context.String("stdin"),
-			Stdout:   context.String("stdout"),
-			Stderr:   context.String("stderr"),
+			Stdin:    cliContext.String("stdin"),
+			Stdout:   cliContext.String("stdout"),
+			Stderr:   cliContext.String("stderr"),
 			Terminal: tty,
 		}
 		if _, err := service.Exec(ctx, rq); err != nil {
@@ -206,7 +206,7 @@ var execCommand = &cli.Command{
 			return err
 		}
 		fmt.Printf("exec running with pid %d\n", r.Pid)
-		if context.Bool("attach") {
+		if cliContext.Bool("attach") {
 			log.L.Info("attaching")
 			if tty {
 				current := console.Current()
@@ -232,19 +232,19 @@ var execCommand = &cli.Command{
 	},
 }
 
-func getTaskService(context *cli.Context) (task.TTRPCTaskService, error) {
-	id := context.String("id")
+func getTaskService(cliContext *cli.Context) (task.TTRPCTaskService, error) {
+	id := cliContext.String("id")
 	if id == "" {
 		return nil, fmt.Errorf("container id must be specified")
 	}
-	ns := context.String("namespace")
+	ns := cliContext.String("namespace")
 
 	// /containerd-shim/ns/id/shim.sock is the old way to generate shim socket,
 	// compatible it
 	s1 := filepath.Join(string(filepath.Separator), "containerd-shim", ns, id, "shim.sock")
 	// this should not error, ctr always get a default ns
-	ctx := namespaces.WithNamespace(gocontext.Background(), ns)
-	s2, _ := shim.SocketAddress(ctx, context.String("address"), id)
+	ctx := namespaces.WithNamespace(context.Background(), ns)
+	s2, _ := shim.SocketAddress(ctx, cliContext.String("address"), id)
 	s2 = strings.TrimPrefix(s2, "unix://")
 
 	for _, socket := range []string{s2, "\x00" + s1} {

--- a/cmd/ctr/commands/signals.go
+++ b/cmd/ctr/commands/signals.go
@@ -17,7 +17,7 @@
 package commands
 
 import (
-	gocontext "context"
+	"context"
 	"os"
 	"os/signal"
 	"syscall"
@@ -28,11 +28,11 @@ import (
 )
 
 type killer interface {
-	Kill(gocontext.Context, syscall.Signal, ...containerd.KillOpts) error
+	Kill(context.Context, syscall.Signal, ...containerd.KillOpts) error
 }
 
 // ForwardAllSignals forwards signals
-func ForwardAllSignals(ctx gocontext.Context, task killer) chan os.Signal {
+func ForwardAllSignals(ctx context.Context, task killer) chan os.Signal {
 	sigc := make(chan os.Signal, 128)
 	signal.Notify(sigc)
 	go func() {

--- a/cmd/ctr/commands/tasks/attach.go
+++ b/cmd/ctr/commands/tasks/attach.go
@@ -28,13 +28,13 @@ var attachCommand = &cli.Command{
 	Name:      "attach",
 	Usage:     "Attach to the IO of a running container",
 	ArgsUsage: "CONTAINER",
-	Action: func(context *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(context)
+	Action: func(cliContext *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
 		defer cancel()
-		container, err := client.LoadContainer(ctx, context.Args().First())
+		container, err := client.LoadContainer(ctx, cliContext.Args().First())
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/tasks/checkpoint.go
+++ b/cmd/ctr/commands/tasks/checkpoint.go
@@ -44,12 +44,12 @@ var checkpointCommand = &cli.Command{
 			Usage: "Path to criu work files and logs",
 		},
 	},
-	Action: func(context *cli.Context) error {
-		id := context.Args().First()
+	Action: func(cliContext *cli.Context) error {
+		id := cliContext.Args().First()
 		if id == "" {
 			return errors.New("container id must be provided")
 		}
-		client, ctx, cancel, err := commands.NewClient(context, containerd.WithDefaultRuntime(context.String("runtime")))
+		client, ctx, cancel, err := commands.NewClient(cliContext, containerd.WithDefaultRuntime(cliContext.String("runtime")))
 		if err != nil {
 			return err
 		}
@@ -66,12 +66,12 @@ var checkpointCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
-		opts := []containerd.CheckpointTaskOpts{withCheckpointOpts(info.Runtime.Name, context)}
+		opts := []containerd.CheckpointTaskOpts{withCheckpointOpts(info.Runtime.Name, cliContext)}
 		checkpoint, err := task.Checkpoint(ctx, opts...)
 		if err != nil {
 			return err
 		}
-		if context.String("image-path") == "" {
+		if cliContext.String("image-path") == "" {
 			fmt.Println(checkpoint.Name())
 		}
 		return nil
@@ -79,17 +79,17 @@ var checkpointCommand = &cli.Command{
 }
 
 // withCheckpointOpts only suitable for runc runtime now
-func withCheckpointOpts(rt string, context *cli.Context) containerd.CheckpointTaskOpts {
+func withCheckpointOpts(rt string, cliContext *cli.Context) containerd.CheckpointTaskOpts {
 	return func(r *containerd.CheckpointTaskInfo) error {
-		imagePath := context.String("image-path")
-		workPath := context.String("work-path")
+		imagePath := cliContext.String("image-path")
+		workPath := cliContext.String("work-path")
 
 		if r.Options == nil {
 			r.Options = &options.CheckpointOptions{}
 		}
 		opts, _ := r.Options.(*options.CheckpointOptions)
 
-		if context.Bool("exit") {
+		if cliContext.Bool("exit") {
 			opts.Exit = true
 		}
 		if imagePath != "" {

--- a/cmd/ctr/commands/tasks/delete.go
+++ b/cmd/ctr/commands/tasks/delete.go
@@ -17,7 +17,7 @@
 package tasks
 
 import (
-	gocontext "context"
+	"context"
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
@@ -42,12 +42,12 @@ var deleteCommand = &cli.Command{
 			Usage: "Process ID to kill",
 		},
 	},
-	Action: func(context *cli.Context) error {
+	Action: func(cliContext *cli.Context) error {
 		var (
-			execID = context.String("exec-id")
-			force  = context.Bool("force")
+			execID = cliContext.String("exec-id")
+			force  = cliContext.Bool("force")
 		)
-		client, ctx, cancel, err := commands.NewClient(context)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
@@ -58,7 +58,7 @@ var deleteCommand = &cli.Command{
 		}
 		var exitErr error
 		if execID != "" {
-			task, err := loadTask(ctx, client, context.Args().First())
+			task, err := loadTask(ctx, client, cliContext.Args().First())
 			if err != nil {
 				return err
 			}
@@ -74,7 +74,7 @@ var deleteCommand = &cli.Command{
 				return cli.Exit("", int(ec))
 			}
 		} else {
-			for _, target := range context.Args().Slice() {
+			for _, target := range cliContext.Args().Slice() {
 				task, err := loadTask(ctx, client, target)
 				if err != nil {
 					if exitErr == nil {
@@ -100,7 +100,7 @@ var deleteCommand = &cli.Command{
 	},
 }
 
-func loadTask(ctx gocontext.Context, client *containerd.Client, containerID string) (containerd.Task, error) {
+func loadTask(ctx context.Context, client *containerd.Client, containerID string) (containerd.Task, error) {
 	container, err := client.LoadContainer(ctx, containerID)
 	if err != nil {
 		return nil, err

--- a/cmd/ctr/commands/tasks/exec.go
+++ b/cmd/ctr/commands/tasks/exec.go
@@ -68,17 +68,17 @@ var execCommand = &cli.Command{
 			Usage: "User id or name",
 		},
 	},
-	Action: func(context *cli.Context) error {
+	Action: func(cliContext *cli.Context) error {
 		var (
-			id     = context.Args().First()
-			args   = context.Args().Tail()
-			tty    = context.Bool("tty")
-			detach = context.Bool("detach")
+			id     = cliContext.Args().First()
+			args   = cliContext.Args().Tail()
+			tty    = cliContext.Bool("tty")
+			detach = cliContext.Bool("detach")
 		)
 		if id == "" {
 			return errors.New("container id must be provided")
 		}
-		client, ctx, cancel, err := commands.NewClient(context)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
@@ -91,7 +91,7 @@ var execCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
-		if user := context.String("user"); user != "" {
+		if user := cliContext.String("user"); user != "" {
 			c, err := container.Info(ctx)
 			if err != nil {
 				return err
@@ -105,7 +105,7 @@ var execCommand = &cli.Command{
 		pspec.Terminal = tty
 		pspec.Args = args
 
-		if cwd := context.String("cwd"); cwd != "" {
+		if cwd := cliContext.String("cwd"); cwd != "" {
 			pspec.Cwd = cwd
 		}
 
@@ -122,8 +122,8 @@ var execCommand = &cli.Command{
 			con console.Console
 		)
 
-		fifoDir := context.String("fifo-dir")
-		logURI := context.String("log-uri")
+		fifoDir := cliContext.String("fifo-dir")
+		logURI := cliContext.String("log-uri")
 		ioOpts := []cio.Opt{cio.WithFIFODir(fifoDir)}
 		switch {
 		case tty && logURI != "":
@@ -150,7 +150,7 @@ var execCommand = &cli.Command{
 			ioCreator = cio.NewCreator(append([]cio.Opt{cio.WithStreams(stdinC, os.Stdout, os.Stderr)}, ioOpts...)...)
 		}
 
-		process, err := task.Exec(ctx, context.String("exec-id"), pspec, ioCreator)
+		process, err := task.Exec(ctx, cliContext.String("exec-id"), pspec, ioCreator)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/tasks/kill.go
+++ b/cmd/ctr/commands/tasks/kill.go
@@ -82,8 +82,8 @@ var killCommand = &cli.Command{
 			Usage:   "Send signal to all processes inside the container",
 		},
 	},
-	Action: func(context *cli.Context) error {
-		id := context.Args().First()
+	Action: func(cliContext *cli.Context) error {
+		id := cliContext.Args().First()
 		if id == "" {
 			return errors.New("container id must be provided")
 		}
@@ -92,14 +92,14 @@ var killCommand = &cli.Command{
 			return err
 		}
 		var (
-			all    = context.Bool("all")
-			execID = context.String("exec-id")
+			all    = cliContext.Bool("all")
+			execID = cliContext.String("exec-id")
 			opts   []containerd.KillOpts
 		)
 		if all && execID != "" {
 			return errors.New("specify an exec-id or all; not both")
 		}
-		client, ctx, cancel, err := commands.NewClient(context)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
@@ -114,8 +114,8 @@ var killCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
-		if context.String("signal") != "" {
-			sig, err = signal.ParseSignal(context.String("signal"))
+		if cliContext.String("signal") != "" {
+			sig, err = signal.ParseSignal(cliContext.String("signal"))
 			if err != nil {
 				return err
 			}

--- a/cmd/ctr/commands/tasks/list.go
+++ b/cmd/ctr/commands/tasks/list.go
@@ -38,9 +38,9 @@ var listCommand = &cli.Command{
 			Usage:   "Print only the task id",
 		},
 	},
-	Action: func(context *cli.Context) error {
-		quiet := context.Bool("quiet")
-		client, ctx, cancel, err := commands.NewClient(context)
+	Action: func(cliContext *cli.Context) error {
+		quiet := cliContext.Bool("quiet")
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/tasks/metrics.go
+++ b/cmd/ctr/commands/tasks/metrics.go
@@ -49,13 +49,13 @@ var metricsCommand = &cli.Command{
 			Value: formatTable,
 		},
 	},
-	Action: func(context *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(context)
+	Action: func(cliContext *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
 		defer cancel()
-		container, err := client.LoadContainer(ctx, context.Args().First())
+		container, err := client.LoadContainer(ctx, cliContext.Args().First())
 		if err != nil {
 			return err
 		}
@@ -83,7 +83,7 @@ var metricsCommand = &cli.Command{
 			return err
 		}
 
-		switch context.String(formatFlag) {
+		switch cliContext.String(formatFlag) {
 		case formatTable:
 			w := tabwriter.NewWriter(os.Stdout, 1, 8, 4, ' ', 0)
 			fmt.Fprintf(w, "ID\tTIMESTAMP\t\n")

--- a/cmd/ctr/commands/tasks/pause.go
+++ b/cmd/ctr/commands/tasks/pause.go
@@ -25,13 +25,13 @@ var pauseCommand = &cli.Command{
 	Name:      "pause",
 	Usage:     "Pause an existing container",
 	ArgsUsage: "CONTAINER",
-	Action: func(context *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(context)
+	Action: func(cliContext *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
 		defer cancel()
-		container, err := client.LoadContainer(ctx, context.Args().First())
+		container, err := client.LoadContainer(ctx, cliContext.Args().First())
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/tasks/ps.go
+++ b/cmd/ctr/commands/tasks/ps.go
@@ -31,12 +31,12 @@ var psCommand = &cli.Command{
 	Name:      "ps",
 	Usage:     "List processes for container",
 	ArgsUsage: "CONTAINER",
-	Action: func(context *cli.Context) error {
-		id := context.Args().First()
+	Action: func(cliContext *cli.Context) error {
+		id := cliContext.Args().First()
 		if id == "" {
 			return errors.New("container id must be provided")
 		}
-		client, ctx, cancel, err := commands.NewClient(context)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/tasks/resume.go
+++ b/cmd/ctr/commands/tasks/resume.go
@@ -25,13 +25,13 @@ var resumeCommand = &cli.Command{
 	Name:      "resume",
 	Usage:     "Resume a paused container",
 	ArgsUsage: "CONTAINER",
-	Action: func(context *cli.Context) error {
-		client, ctx, cancel, err := commands.NewClient(context)
+	Action: func(cliContext *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
 		defer cancel()
-		container, err := client.LoadContainer(ctx, context.Args().First())
+		container, err := client.LoadContainer(ctx, cliContext.Args().First())
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/tasks/start.go
+++ b/cmd/ctr/commands/tasks/start.go
@@ -55,16 +55,16 @@ var startCommand = &cli.Command{
 			Usage:   "Detach from the task after it has started execution",
 		},
 	}...),
-	Action: func(context *cli.Context) error {
+	Action: func(cliContext *cli.Context) error {
 		var (
 			err    error
-			id     = context.Args().Get(0)
-			detach = context.Bool("detach")
+			id     = cliContext.Args().Get(0)
+			detach = cliContext.Bool("detach")
 		)
 		if id == "" {
 			return errors.New("container id must be provided")
 		}
-		client, ctx, cancel, err := commands.NewClient(context)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
@@ -80,8 +80,8 @@ var startCommand = &cli.Command{
 		}
 		var (
 			tty    = spec.Process.Terminal
-			opts   = GetNewTaskOpts(context)
-			ioOpts = []cio.Opt{cio.WithFIFODir(context.String("fifo-dir"))}
+			opts   = GetNewTaskOpts(cliContext)
+			ioOpts = []cio.Opt{cio.WithFIFODir(cliContext.String("fifo-dir"))}
 		)
 		var con console.Console
 		if tty {
@@ -92,7 +92,7 @@ var startCommand = &cli.Command{
 			}
 		}
 
-		task, err := NewTask(ctx, client, container, "", con, context.Bool("null-io"), context.String("log-uri"), ioOpts, opts...)
+		task, err := NewTask(ctx, client, container, "", con, cliContext.Bool("null-io"), cliContext.String("log-uri"), ioOpts, opts...)
 		if err != nil {
 			return err
 		}
@@ -108,8 +108,8 @@ var startCommand = &cli.Command{
 				return err
 			}
 		}
-		if context.IsSet("pid-file") {
-			if err := commands.WritePidFile(context.String("pid-file"), int(task.Pid())); err != nil {
+		if cliContext.IsSet("pid-file") {
+			if err := commands.WritePidFile(cliContext.String("pid-file"), int(task.Pid())); err != nil {
 				return err
 			}
 		}

--- a/cmd/ctr/commands/tasks/tasks.go
+++ b/cmd/ctr/commands/tasks/tasks.go
@@ -17,13 +17,13 @@
 package tasks
 
 import (
-	gocontext "context"
+	"context"
 
 	"github.com/urfave/cli/v2"
 )
 
 type resizer interface {
-	Resize(ctx gocontext.Context, w, h uint32) error
+	Resize(ctx context.Context, w, h uint32) error
 }
 
 // Command is the cli command for managing tasks

--- a/cmd/ctr/commands/tasks/tasks_unix.go
+++ b/cmd/ctr/commands/tasks/tasks_unix.go
@@ -19,7 +19,7 @@
 package tasks
 
 import (
-	gocontext "context"
+	"context"
 	"errors"
 	"net/url"
 	"os"
@@ -41,7 +41,7 @@ var platformStartFlags = []cli.Flag{
 }
 
 // HandleConsoleResize resizes the console
-func HandleConsoleResize(ctx gocontext.Context, task resizer, con console.Console) error {
+func HandleConsoleResize(ctx context.Context, task resizer, con console.Console) error {
 	// do an initial resize of the console
 	size, err := con.Size()
 	if err != nil {
@@ -68,7 +68,7 @@ func HandleConsoleResize(ctx gocontext.Context, task resizer, con console.Consol
 }
 
 // NewTask creates a new task
-func NewTask(ctx gocontext.Context, client *containerd.Client, container containerd.Container, checkpoint string, con console.Console, nullIO bool, logURI string, ioOpts []cio.Opt, opts ...containerd.NewTaskOpts) (containerd.Task, error) {
+func NewTask(ctx context.Context, client *containerd.Client, container containerd.Container, checkpoint string, con console.Console, nullIO bool, logURI string, ioOpts []cio.Opt, opts ...containerd.NewTaskOpts) (containerd.Task, error) {
 	stdinC := &stdinCloser{
 		stdin: os.Stdin,
 	}
@@ -121,8 +121,8 @@ func NewTask(ctx gocontext.Context, client *containerd.Client, container contain
 }
 
 // GetNewTaskOpts resolves containerd.NewTaskOpts from cli.Context
-func GetNewTaskOpts(context *cli.Context) []containerd.NewTaskOpts {
-	if context.Bool("no-pivot") {
+func GetNewTaskOpts(cliContext *cli.Context) []containerd.NewTaskOpts {
+	if cliContext.Bool("no-pivot") {
 		return []containerd.NewTaskOpts{containerd.WithNoPivotRoot}
 	}
 	return nil

--- a/cmd/ctr/commands/tasks/tasks_windows.go
+++ b/cmd/ctr/commands/tasks/tasks_windows.go
@@ -17,7 +17,7 @@
 package tasks
 
 import (
-	gocontext "context"
+	"context"
 	"errors"
 	"net/url"
 	"time"
@@ -32,7 +32,7 @@ import (
 var platformStartFlags = []cli.Flag{}
 
 // HandleConsoleResize resizes the console
-func HandleConsoleResize(ctx gocontext.Context, task resizer, con console.Console) error {
+func HandleConsoleResize(ctx context.Context, task resizer, con console.Console) error {
 	// do an initial resize of the console
 	size, err := con.Size()
 	if err != nil {
@@ -61,7 +61,7 @@ func HandleConsoleResize(ctx gocontext.Context, task resizer, con console.Consol
 }
 
 // NewTask creates a new task
-func NewTask(ctx gocontext.Context, client *containerd.Client, container containerd.Container, _ string, con console.Console, nullIO bool, logURI string, ioOpts []cio.Opt, opts ...containerd.NewTaskOpts) (containerd.Task, error) {
+func NewTask(ctx context.Context, client *containerd.Client, container containerd.Container, _ string, con console.Console, nullIO bool, logURI string, ioOpts []cio.Opt, opts ...containerd.NewTaskOpts) (containerd.Task, error) {
 	var ioCreator cio.Creator
 	if con != nil {
 		if nullIO {

--- a/cmd/ctr/commands/version/version.go
+++ b/cmd/ctr/commands/version/version.go
@@ -29,9 +29,9 @@ import (
 var Command = &cli.Command{
 	Name:  "version",
 	Usage: "Print the client and server versions",
-	Action: func(context *cli.Context) error {
-		if context.NArg() != 0 {
-			return fmt.Errorf("extra arguments: %v", context.Args())
+	Action: func(cliContext *cli.Context) error {
+		if cliContext.NArg() != 0 {
+			return fmt.Errorf("extra arguments: %v", cliContext.Args())
 		}
 
 		fmt.Println("Client:")
@@ -39,7 +39,7 @@ var Command = &cli.Command{
 		fmt.Println("  Revision:", version.Revision)
 		fmt.Println("  Go version:", version.GoVersion)
 		fmt.Println("")
-		client, ctx, cancel, err := commands.NewClient(context)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}

--- a/internal/cri/server/container_update_resources.go
+++ b/internal/cri/server/container_update_resources.go
@@ -20,7 +20,6 @@ package server
 
 import (
 	"context"
-	gocontext "context"
 	"fmt"
 
 	"github.com/containerd/typeurl/v2"
@@ -147,7 +146,7 @@ func updateContainerSpec(ctx context.Context, cntr containerd.Container, spec *r
 	if err != nil {
 		return fmt.Errorf("failed to marshal spec %+v: %w", spec, err)
 	}
-	if err := cntr.Update(ctx, func(ctx gocontext.Context, client *containerd.Client, c *containers.Container) error {
+	if err := cntr.Update(ctx, func(ctx context.Context, client *containerd.Client, c *containers.Container) error {
 		c.Spec = s
 		return nil
 	}); err != nil {


### PR DESCRIPTION
Unfortunately, this is a rather large diff, but perhaps worth a one-time "rip off the bandaid" for v2. This patch removes the use of "gocontext" as alias for stdLib's "context", and uses "cliContext" for uses of cli.context.