### PR TITLE
Cleanup metadata godoc

### DIFF
--- a/core/metadata/buckets.go
+++ b/core/metadata/buckets.go
@@ -28,113 +28,114 @@
 //
 //	<version>/<namespace>/<object>/<key> -> <field>
 //
-// version: Currently, this is "v1". Additions can be made to v1 in a backwards
-// compatible way. If the layout changes, a new version must be made, along
-// with a migration.
+//	version
+//	           Currently, this is "v1". Additions can be made to v1 in a backwards
+//	           compatible way. If the layout changes, a new version must be made,
+//	           along with a migration.
 //
-// namespace: the namespace to which this object belongs.
+//	namespace
+//	           The namespace to which this object belongs.
 //
-// object: defines which object set is stored in the bucket. There are two
-// special objects, "labels" and "indexes". The "labels" bucket stores the
-// labels for the parent namespace. The "indexes" object is reserved for
-// indexing objects, if we require in the future.
+//	object
+//	           Defines which object set is stored in the bucket. There are two
+//	           special objects, "labels" and "indexes". The "labels" bucket
+//	           stores the labels for the parent namespace. The "indexes" object
+//	           is reserved for indexing objects, if we require in the future.
 //
-// key: object-specific key identifying the storage bucket for the objects
-// contents.
+//	key
+//	           Object-specific key identifying the storage bucket for the
+//	           object's contents.
 //
 // Below is the current database schema. This should be updated each time
 // the structure is changed in addition to adding a migration and incrementing
 // the database version.
-// Notes:
 //
-//   - `╘══*...*` refers to maps with arbitrary keys
+//	Notes
+//	   • `╘══*...*` refers to maps with arbitrary keys
+//	   • `version` is a key to a numeric value identifying the minor revisions
+//	     of schema version
+//	   • a namespace in a schema bucket cannot be named "version"
 //
-//   - `version` is a key to a numeric value identifying the minor revisions
-//     of schema version
-//
-//   - a namespace in a schema bucket cannot be named "version"
-//
-/*
- └──v1                                        - Schema version bucket
-    ├──version : <varint>                     - Latest version, see migrations
-    ╘══*namespace*
-	  ├──labels
-	  │  ╘══*key* : <string>                 - Label value
-	  ├──image
-	  │  ╘══*image name*
-	  │     ├──createdat : <binary time>     - Created at
-	  │     ├──updatedat : <binary time>     - Updated at
-	  │     ├──target
-	  │     │  ├──digest : <digest>          - Descriptor digest
-	  │     │  ├──mediatype : <string>       - Descriptor media type
-	  │     │  └──size : <varint>            - Descriptor size
-	  │     └──labels
-	  │        ╘══*key* : <string>           - Label value
-	  ├──containers
-	  │  ╘══*container id*
-	  │     ├──createdat : <binary time>     - Created at
-	  │     ├──updatedat : <binary time>     - Updated at
-	  │     ├──spec : <binary>               - Proto marshaled spec
-	  │     ├──image : <string>              - Image name
-	  │     ├──snapshotter : <string>        - Snapshotter name
-	  │     ├──snapshotKey : <string>        - Snapshot key
-	  │     ├──runtime
-	  │     │  ├──name : <string>            - Runtime name
-	  │     │  └──options : <binary>         - Proto marshaled options
-	  │     ├──extensions
-	  │     │     ╘══*name* : <binary>       - Proto marshaled extension
-	  │     └──labels
-	  │        ╘══*key* : <string>           - Label value
-	  ├──snapshots
-	  │  ╘══*snapshotter*
-	  │     ╘══*snapshot key*
-	  │        ├──name : <string>            - Snapshot name in backend
-	  │        ├──createdat : <binary time>  - Created at
-	  │        ├──updatedat : <binary time>  - Updated at
-	  │        ├──parent : <string>          - Parent snapshot name
-	  │        ├──children
-	  │        │  ╘══*snapshot key* : <nil>  - Child snapshot reference
-	  │        └──labels
-	  │           ╘══*key* : <string>        - Label value
-	  ├──content
-	  │  ├──blob
-	  │  │  ╘══*blob digest*
-	  │  │     ├──createdat : <binary time>  - Created at
-	  │  │     ├──updatedat : <binary time>  - Updated at
-	  │  │     ├──size : <varint>            - Blob size
-	  │  │     └──labels
-	  │  │        ╘══*key* : <string>        - Label value
-	  │  └──ingests
-	  │     ╘══*ingest reference*
-	  │        ├──ref : <string>             - Ingest reference in backend
-	  │        ├──expireat : <binary time>   - Time to expire ingest
-	  │        └──expected : <digest>        - Expected commit digest
-	  ├──sandboxes
-	  │  ╘══*sandbox id*
-	  │     ├──createdat : <binary time>     - Created at
-	  │     ├──updatedat : <binary time>     - Updated at
-	  │     ├──spec : <binary>               - Proto marshaled spec
-	  │     ├──sandboxer : <string>          - Sandboxer name
-	  │     ├──runtime
-	  │     │  ├──name : <string>            - Runtime name
-	  │     │  └──options : <binary>         - Proto marshaled options
-	  │     ├──extensions
-	  │     │  ╘══*name* : <binary>       - Proto marshaled extension
-	  │     └──labels
-	  │        ╘══*key* : <string>           - Label value
-	  └──leases
-	     ╘══*lease id*
-	         ├──createdat : <binary time>     - Created at
-	         ├──labels
-	         │  ╘══*key* : <string>           - Label value
-	         ├──snapshots
-	         │  ╘══*snapshotter*
-	         │     ╘══*snapshot key* : <nil>  - Snapshot reference
-	         ├──content
-	         │  ╘══*blob digest* : <nil>      - Content blob reference
-	         └─────ingests
-	               ╘══*ingest reference* : <nil> - Content ingest reference
-*/
+//	Schema
+//	└──v1                                             - Schema version bucket
+//	   ├──version : <varint>                          - Latest version, see migrations
+//	   ╘══*namespace*
+//	      ├──labels
+//	      │  ╘══*key* : <string>                      - Label value
+//	      ├──image
+//	      │  ╘══*image name*
+//	      │     ├──createdat : <binary time>          - Created at
+//	      │     ├──updatedat : <binary time>          - Updated at
+//	      │     ├──target
+//	      │     │  ├──digest : <digest>               - Descriptor digest
+//	      │     │  ├──mediatype : <string>            - Descriptor media type
+//	      │     │  └──size : <varint>                 - Descriptor size
+//	      │     └──labels
+//	      │        ╘══*key* : <string>                - Label value
+//	      ├──containers
+//	      │  ╘══*container id*
+//	      │     ├──createdat : <binary time>          - Created at
+//	      │     ├──updatedat : <binary time>          - Updated at
+//	      │     ├──spec : <binary>                    - Proto marshaled spec
+//	      │     ├──image : <string>                   - Image name
+//	      │     ├──snapshotter : <string>             - Snapshotter name
+//	      │     ├──snapshotKey : <string>             - Snapshot key
+//	      │     ├──runtime
+//	      │     │  ├──name : <string>                 - Runtime name
+//	      │     │  └──options : <binary>              - Proto marshaled options
+//	      │     ├──extensions
+//	      │     │     ╘══*name* : <binary>            - Proto marshaled extension
+//	      │     └──labels
+//	      │        ╘══*key* : <string>                - Label value
+//	      ├──snapshots
+//	      │  ╘══*snapshotter*
+//	      │     ╘══*snapshot key*
+//	      │        ├──name : <string>                 - Snapshot name in backend
+//	      │        ├──createdat : <binary time>       - Created at
+//	      │        ├──updatedat : <binary time>       - Updated at
+//	      │        ├──parent : <string>               - Parent snapshot name
+//	      │        ├──children
+//	      │        │  ╘══*snapshot key* : <nil>       - Child snapshot reference
+//	      │        └──labels
+//	      │           ╘══*key* : <string>             - Label value
+//	      ├──content
+//	      │  ├──blob
+//	      │  │  ╘══*blob digest*
+//	      │  │     ├──createdat : <binary time>       - Created at
+//	      │  │     ├──updatedat : <binary time>       - Updated at
+//	      │  │     ├──size : <varint>                 - Blob size
+//	      │  │     └──labels
+//	      │  │        ╘══*key* : <string>             - Label value
+//	      │  └──ingests
+//	      │     ╘══*ingest reference*
+//	      │        ├──ref : <string>                  - Ingest reference in backend
+//	      │        ├──expireat : <binary time>        - Time to expire ingest
+//	      │        └──expected : <digest>             - Expected commit digest
+//	      ├──sandboxes
+//	      │  ╘══*sandbox id*
+//	      │     ├──createdat : <binary time>          - Created at
+//	      │     ├──updatedat : <binary time>          - Updated at
+//	      │     ├──spec : <binary>                    - Proto marshaled spec
+//	      │     ├──sandboxer : <string>               - Sandboxer name
+//	      │     ├──runtime
+//	      │     │  ├──name : <string>                 - Runtime name
+//	      │     │  └──options : <binary>              - Proto marshaled options
+//	      │     ├──extensions
+//	      │     │  ╘══*name* : <binary>               - Proto marshaled extension
+//	      │     └──labels
+//	      │        ╘══*key* : <string>                - Label value
+//	      └──leases
+//	         ╘══*lease id*
+//	             ├──createdat : <binary time>         - Created at
+//	             ├──labels
+//	             │  ╘══*key* : <string>               - Label value
+//	             ├──snapshots
+//	             │  ╘══*snapshotter*
+//	             │     ╘══*snapshot key* : <nil>      - Snapshot reference
+//	             ├──content
+//	             │  ╘══*blob digest* : <nil>          - Content blob reference
+//	             └─────ingests
+//	                   ╘══*ingest reference* : <nil> - Content ingest reference
 package metadata
 
 import (


### PR DESCRIPTION
The godoc should properly show the formatting of the database structure and sections explaining it.

How it looks today...
https://pkg.go.dev/github.com/containerd/containerd/v2@v2.0.0-rc.3/core/metadatamisformatted
![image](https://github.com/containerd/containerd/assets/169601/ce847262-08f1-4d18-ae65-d1ec8d3a6475)

Now from godoc with this change...
![image](https://github.com/containerd/containerd/assets/169601/f75e8cec-acdc-438a-a1e2-7272a0d6624f)
