### PR TITLE
[release/1.7] golangci-lint fix typo in depguard message

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -71,7 +71,7 @@ linters-settings:
           - pkg: "github.com/containerd/containerd/log"
             desc: The containerd log package was migrated to a separate module. Use github.com/containerd/log instead.
           - pkg: "github.com/containerd/containerd/platforms"
-            desc: The containerd log package was migrated to a separate module. Use github.com/containerd/platforms instead.
+            desc: The containerd platforms package was migrated to a separate module. Use github.com/containerd/platforms instead.
   gosec:
     # The following issues surfaced when `gosec` linter
     # was enabled. They are temporarily excluded to unblock


### PR DESCRIPTION
- relates to https://github.com/containerd/containerd/pull/10368#discussion_r1646854987
- relates to https://github.com/containerd/containerd/pull/10367

This was introduced in 136e1b72d8330d43b9cedf051a0b745cf70df9ee, but missed during review.
