### PR TITLE
cri: get pid count from container metrics

### DIFF
--- a/internal/cri/server/container_stats.go
+++ b/internal/cri/server/container_stats.go
@@ -49,5 +49,5 @@ func (c *criService) ContainerStats(ctx context.Context, in *runtime.ContainerSt
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode container metrics: %w", err)
 	}
-	return &runtime.ContainerStatsResponse{Stats: cs}, nil
+	return &runtime.ContainerStatsResponse{Stats: cs.stats}, nil
 }

--- a/internal/cri/server/container_stats_list_test.go
+++ b/internal/cri/server/container_stats_list_test.go
@@ -420,13 +420,17 @@ func TestListContainerStats(t *testing.T) {
 			if tt.before != nil {
 				tt.before()
 			}
-			got, err := c.toCRIContainerStats(tt.args.ctx, tt.args.stats, tt.args.containers)
+			css, err := c.toContainerStats(tt.args.ctx, tt.args.stats, tt.args.containers)
 			if tt.after != nil {
 				tt.after()
 			}
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ListContainerStats() error = %v, wantErr %v", err, tt.wantErr)
 				return
+			}
+			var got *runtime.ListContainerStatsResponse
+			if err == nil {
+				got = c.toCRIContainerStats(css)
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ListContainerStats() = %v, want %v", got, tt.want)


### PR DESCRIPTION
This reduces latency of ListPodSandboxStats() by avoiding calling shim API Task().

Prior to this commit, the latency of calling ListPodSandboxStats() with 35 sandboxes (one container per sandbox) took 450ms. Mostly it was due to calling Task() to each container's shim, which took 10ms.

However, the pid count has already been present in collected cgroup metrics so this commit reuses that info to improve performance. It also means Windows platform would still need to call Task().

After this commit, the latency of ListPodSandboxStats() is about 120ms.