### PR TITLE
[release/1.7] Prepare release notes for api v1.7.19

### DIFF
--- a/.github/workflows/api-release.yml
+++ b/.github/workflows/api-release.yml
@@ -1,0 +1,80 @@
+on:
+  push:
+    tags:
+      - "api/v*" # Push events to matching api/v*, i.e. api/v1.0, api/v20.15.10
+
+name: API Release
+
+env:
+  GO_VERSION: "1.21.11"
+
+permissions: # added using https://github.com/step-security/secure-workflows
+  contents: read
+
+jobs:
+  check:
+    name: Check Signed Tag
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/api/v')
+    runs-on: ubuntu-20.04
+    timeout-minutes: 5
+    outputs:
+      stringver: ${{ steps.contentrel.outputs.stringver }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          path: src/github.com/containerd/containerd
+
+      - name: Check signature
+        run: |
+          releasever=${{ github.ref }}
+          releasever="${releasever#refs/tags/}"
+          TAGCHECK=$(git tag -v ${releasever} 2>&1 >/dev/null) ||
+          echo "${TAGCHECK}" | grep -q "error" && {
+              echo "::error::tag ${releasever} is not a signed tag. Failing release process."
+              exit 1
+          } || {
+              echo "Tag ${releasever} is signed."
+              exit 0
+          }
+        working-directory: src/github.com/containerd/containerd
+
+      - name: Release content
+        id: contentrel
+        run: |
+          RELEASEVER=${{ github.ref }}
+          echo "stringver=${RELEASEVER#refs/tags/api/v}" >> $GITHUB_OUTPUT
+          git tag -l ${RELEASEVER#refs/tags/} -n20000 | tail -n +3 | cut -c 5- >release-notes.md
+        working-directory: src/github.com/containerd/containerd
+
+      - name: Save release notes
+        uses: actions/upload-artifact@v4
+        with:
+          name: containerd-release-notes
+          path: src/github.com/containerd/containerd/release-notes.md
+
+  release:
+    name: Create containerd Release
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/api/v')
+    permissions:
+      contents: write
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    needs: [check]
+    steps:
+      - name: Download release notes
+        uses: actions/download-artifact@v4
+        with:
+          path: builds
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fail_on_unmatched_files: true
+          name: containerd API ${{ needs.check.outputs.stringver }}
+          draft: false
+          make_latest: false
+          prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
+          body_path: ./builds/containerd-release-notes/release-notes.md

--- a/api/releases/v1.7.19.toml
+++ b/api/releases/v1.7.19.toml
@@ -1,0 +1,18 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+sub_path = "api"
+ignore_deps = [ "github.com/containerd/containerd" ]
+
+# previous release
+previous = "v1.7.18"
+
+pre_release = false
+
+preface = """\
+The first dedicated release for the containerd 1.7 API. This release is
+separately tagged from the main 1.7.x releases after the v1.7.18
+release but follows the versioning.
+"""


### PR DESCRIPTION
Like in the main branch, the API module must be tagged first and go.mod updated before a release which includes api changes.

Test run: https://github.com/dmcgowan/containerd/releases/tag/api%2Fv1.7.19-rc.0

----

Welcome to the api/v1.7.19 release of containerd!

The first dedicated release for the containerd 1.7 API. This release is
separately tagged from the main 1.7.x releases after the v1.7.18
release but follows the versioning.

### Highlights

* Add API go module ([#10189](https://github.com/containerd/containerd/pull/10189))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Derek McGowan
* Akhil Mohan
* Phil Estes
* Sebastiaan van Stijn

### Changes
<details><summary>7 commits</summary>
<p>

  * [`436feeb0d`](https://github.com/containerd/containerd/commit/436feeb0ddcf8188c84c616b97b34cc8acd1aa9f) Prepare api release for v1.7.19
* : api: update github.com/containerd/ttrpc v1.2.5 to align with containerd 1.7 module ([#10364](https://github.com/containerd/containerd/pull/10364))
  * [`2a6aa6ddf`](https://github.com/containerd/containerd/commit/2a6aa6ddf1f09bedc8b86f33a277f2cf6852eedd) [release/1.7] api: update github.com/containerd/ttrpc v1.2.5
* Add API go module ([#10189](https://github.com/containerd/containerd/pull/10189))
  * [`3be919f3c`](https://github.com/containerd/containerd/commit/3be919f3c023f776e5db1b162f642d79a36312a8) Add support for 1.8 interfaces
  * [`a3a7431bc`](https://github.com/containerd/containerd/commit/a3a7431bc3151a5d0a8c6d9e36a6430a76418f81) Add api go submodule
  * [`4b82470f6`](https://github.com/containerd/containerd/commit/4b82470f6939ab951334105cf0b10ca9167964ea) refactor: move plugin/fieldpath to api/types/
</p>
</details>

### Dependency Changes

* **github.com/containerd/ttrpc**                v1.2.4 -> v1.2.5
* **github.com/golang/protobuf**                 v1.5.4 -> v1.5.3
* **google.golang.org/genproto/googleapis/rpc**  d307bd883b97 -> b8732ec3820d

Previous release can be found at [v1.7.18](https://github.com/containerd/containerd/releases/tag/v1.7.18)