### PR TITLE
[release/1.7] Prepare release notes for v1.7.19

### DIFF
--- a/releases/v1.7.19.toml
+++ b/releases/v1.7.19.toml
@@ -1,0 +1,33 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.7.18"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The nineteenth patch release for containerd 1.7 contains various updates and
+splits the main module from the api module in preparation for the same change
+in containerd 2.0. Splitting the modules will allow 1.7 and 2.x to both exist
+as transitive dependencies without running into API registration errors.
+Projects should use this version as the minimum 1.7 version in preparing to
+use containerd 2.0 or to be imported alongside it.
+"""
+
+override_deps."github.com/containerd/platforms".previous = "f18f3c661f7de73d5569f61ff72d98dae1c1700a"

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.7.18+unknown"
+	Version = "1.7.19+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated notes...

----

Welcome to the v1.7.19 release of containerd!

The nineteenth patch release for containerd 1.7 contains various updates and
splits the main module from the api module in preparation for the same change
in containerd 2.0. Splitting the modules will allow 1.7 and 2.x to both exist
as transitive dependencies without running into API registration errors.
Projects should use this version as the minimum 1.7 version in preparing to
use containerd 2.0 or to be imported alongside it.

### Highlights

* Fix support for OTLP config ([#10360](https://github.com/containerd/containerd/pull/10360))
* Add API go module ([#10189](https://github.com/containerd/containerd/pull/10189))
* Remove overlayfs volatile option on temp mounts ([#10332](https://github.com/containerd/containerd/pull/10332))
* Migrate platforms package to github.com/containerd/platforms ([#10292](https://github.com/containerd/containerd/pull/10292))

#### Container Runtime Interface (CRI)

* Fix Windows HPC working directory ([#10306](https://github.com/containerd/containerd/pull/10306))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Derek McGowan
* Sebastiaan van Stijn
* Wei Fu
* Phil Estes
* Akhil Mohan
* Akihiro Suda
* Brian Goff
* Kirtana Ashok
* Maksym Pavlenko
* Austin Vazquez
* Kazuyoshi Kato
* Maksim An
* krglosse

### Changes
<details><summary>53 commits</summary>
<p>

  * [`092f48077`](https://github.com/containerd/containerd/commit/092f48077d3ed4623aae236483de5f72007bcdd6) Prepare release notes for v1.7.19
* Prepare release notes for api v1.7.19 ([#10386](https://github.com/containerd/containerd/pull/10386))
  * [`436feeb0d`](https://github.com/containerd/containerd/commit/436feeb0ddcf8188c84c616b97b34cc8acd1aa9f) Prepare api release for v1.7.19
  * [`83822d144`](https://github.com/containerd/containerd/commit/83822d144695458892cc04c237132653e54ca183) Add api release action
* : api: update github.com/containerd/ttrpc v1.2.5 to align with containerd 1.7 module ([#10364](https://github.com/containerd/containerd/pull/10364))
  * [`2a6aa6ddf`](https://github.com/containerd/containerd/commit/2a6aa6ddf1f09bedc8b86f33a277f2cf6852eedd) [release/1.7] api: update github.com/containerd/ttrpc v1.2.5
* vendor: github.com/containerd/ttrpc v1.2.5 ([#10373](https://github.com/containerd/containerd/pull/10373))
  * [`37926b10d`](https://github.com/containerd/containerd/commit/37926b10d0dc14cd068dc35dd18190bd38ef9a01) vendor: github.com/containerd/ttrpc v1.2.5
* golangci-lint fix typo in depguard message ([#10371](https://github.com/containerd/containerd/pull/10371))
  * [`a522e267e`](https://github.com/containerd/containerd/commit/a522e267e8b3312fa1a8679a7dee0c28b208a474) golangci-lint fix typo in depguard message
* Fix support for OTLP config ([#10360](https://github.com/containerd/containerd/pull/10360))
  * [`1ce1c8f3e`](https://github.com/containerd/containerd/commit/1ce1c8f3e6d36202dab28fe910bf9282fafc2aab) 1.7: Add back support for OTLP config from toml
* remove imports of errdefs package, and add depguard linter ([#10367](https://github.com/containerd/containerd/pull/10367))
  * [`136e1b72d`](https://github.com/containerd/containerd/commit/136e1b72d8330d43b9cedf051a0b745cf70df9ee) golangci-lint: enable depguard for packages that moved
  * [`f5ce2f204`](https://github.com/containerd/containerd/commit/f5ce2f2049204e1792756b156299eb3470379692) remove imports of errdefs package
* Add API go module ([#10189](https://github.com/containerd/containerd/pull/10189))
  * [`3be919f3c`](https://github.com/containerd/containerd/commit/3be919f3c023f776e5db1b162f642d79a36312a8) Add support for 1.8 interfaces
  * [`5b87eb502`](https://github.com/containerd/containerd/commit/5b87eb502c705dba767a203b64dfdc3ad0bda109) Add go mod replace when proto changes happen
  * [`a3a7431bc`](https://github.com/containerd/containerd/commit/a3a7431bc3151a5d0a8c6d9e36a6430a76418f81) Add api go submodule
  * [`61b3e2261`](https://github.com/containerd/containerd/commit/61b3e226104ccb52aff9230617750bddd046b76d) Alias protobuf plugin to new api types package
  * [`4b82470f6`](https://github.com/containerd/containerd/commit/4b82470f6939ab951334105cf0b10ca9167964ea) refactor: move plugin/fieldpath to api/types/
* Remove overlayfs volatile option on temp mounts ([#10332](https://github.com/containerd/containerd/pull/10332))
  * [`24ce9e431`](https://github.com/containerd/containerd/commit/24ce9e4315aa0b1215d1ed0c52df13691e7ff523) integration: backport upgrade testsuite's utils
  * [`79500d5cb`](https://github.com/containerd/containerd/commit/79500d5cb24d2ce7189857ec3322970ff61817c7) *: export RemoveVolatileOption for CRI image volumes
  * [`bb80bd768`](https://github.com/containerd/containerd/commit/bb80bd7681ce22e8bd11aa5aa285a61ef1ac19c2) strip-volatile-option-tmp-mounts
* update runc binary to v1.1.13 ([#10336](https://github.com/containerd/containerd/pull/10336))
  * [`6dce90b15`](https://github.com/containerd/containerd/commit/6dce90b1586903a60d84028c7b4a643ac5472fbb) update runc binary to v1.1.13
* Fail integration test early when a plugin load fails ([#10311](https://github.com/containerd/containerd/pull/10311))
  * [`884094be8`](https://github.com/containerd/containerd/commit/884094be857fd0d72edc716f0791b44b14861a53) devmapper plugin: skip plugin when not configured
  * [`40012b644`](https://github.com/containerd/containerd/commit/40012b6445f6275aabf10be78f2a7a9b6ec6b927) Fail integration test early when a plugin load fails
* Migrate platforms package to github.com/containerd/platforms ([#10292](https://github.com/containerd/containerd/pull/10292))
  * [`869b78677`](https://github.com/containerd/containerd/commit/869b7867724e10f285f2f26f358b98d4ef0bd310) vendor: github.com/containerd/platforms v0.2.1
  * [`6ccdf6977`](https://github.com/containerd/containerd/commit/6ccdf697711dc9c8915e2c1c8da5f60c2472df5e) platforms: mark aliases as deprecated
  * [`19a056163`](https://github.com/containerd/containerd/commit/19a056163cc37077c33f4e11f8c60d52c14d9a8f) adjust default platform for backward-compatibility
  * [`6ff3e09d2`](https://github.com/containerd/containerd/commit/6ff3e09d201c82839be50f176895656d2bbcffec) migrate platforms package to github.com/containerd/platforms
* go.mod: github.com/klauspost/compress v1.16.7 ([#10326](https://github.com/containerd/containerd/pull/10326))
  * [`327a3ac61`](https://github.com/containerd/containerd/commit/327a3ac61d9eb30a37a8227ca19fa3ce9ab26545) go.mod: github.com/klauspost/compress v1.16.7
  * [`d0d1264a6`](https://github.com/containerd/containerd/commit/d0d1264a65c522283b938179ab0d9b529952125b) vendor: github.com/klauspost/compress v1.16.5
* Use Github Actions to run Vagrant CI ([#10325](https://github.com/containerd/containerd/pull/10325))
  * [`02b8dd5ff`](https://github.com/containerd/containerd/commit/02b8dd5ffcb552521d1e6589a488cdf401845a40) Remove cirrus configuration
  * [`31d951bf5`](https://github.com/containerd/containerd/commit/31d951bf5b6a2fc0cd0ee2d7388e52e6b73aba8f) Run vagrant integration tests as github actions
* replace reference/docker for github.com/distribution/reference v0.6.0 ([#10316](https://github.com/containerd/containerd/pull/10316))
  * [`97abbe9cb`](https://github.com/containerd/containerd/commit/97abbe9cba96592987e5accc4951c89059ced51b) build(deps): bump github.com/distribution/reference from 0.5.0 to 0.6.0
  * [`a00a2d20a`](https://github.com/containerd/containerd/commit/a00a2d20a367cf6b906b63cef18dbbbf4157bfb8) reference/docker: remove deprecated SplitHostname
  * [`b38c0f2ef`](https://github.com/containerd/containerd/commit/b38c0f2ef8c887ba2ebdaf186d94115934a2bbbb) replace reference/docker for github.com/distribution/reference v0.5.0
* build(deps): bump go.etcd.io/bbolt from 1.3.9 to 1.3.10 ([#10315](https://github.com/containerd/containerd/pull/10315))
  * [`fef432bfe`](https://github.com/containerd/containerd/commit/fef432bfebd3e0ce813e4f05230649ba22af99e6) build(deps): bump go.etcd.io/bbolt from 1.3.9 to 1.3.10
  * [`487c61bfb`](https://github.com/containerd/containerd/commit/487c61bfbbbaccce4154a335c6a5cb97d1f08381) vendor: go.etcd.io/bbolt v1.3.9
  * [`7211f87c4`](https://github.com/containerd/containerd/commit/7211f87c4874b9d09af4545c7c9570a0f406b79c) build(deps): bump golang.org/x/sync from 0.4.0 to 0.5.0
  * [`e908c3e6f`](https://github.com/containerd/containerd/commit/e908c3e6fcc5e23d44fd9581bdcdd33868c5cd5b) vendor: golang.org/x/sync v0.4.0
  * [`d814be5ce`](https://github.com/containerd/containerd/commit/d814be5ce8194934b12e87fe2c50223bf8f38e60) build(deps): bump go.etcd.io/bbolt from 1.3.7 to 1.3.8
* Fix Windows HPC working directory ([#10306](https://github.com/containerd/containerd/pull/10306))
  * [`33b62936e`](https://github.com/containerd/containerd/commit/33b62936ea56c85183331ad2b1d9cb3c76dce8da) [release/1.7]: HPC working directory fix in pkg/cri/server code
</p>
</details>

### Changes from containerd/platforms
<details><summary>21 commits</summary>
<p>

* Remove hcsshim import from repo ([containerd/platforms#10](https://github.com/containerd/platforms/pull/10))
  * [`f680838`](https://github.com/containerd/platforms/commit/f6808384daf3b725b61bc23fd40fac5e3a85168f) Remove hcsshim import from repo
* Fix windows matching when os version is empty ([containerd/platforms#11](https://github.com/containerd/platforms/pull/11))
  * [`983ba15`](https://github.com/containerd/platforms/commit/983ba156b67be3c9597b773bd1f509f0ba693c3d) Update windows matcher to not compare empty os version
  * [`17c859f`](https://github.com/containerd/platforms/commit/17c859f02e8008cc3a4fba44314aa35c947e3f7f) Add tests for osversion matching with no version
* Add format for platform string ([containerd/platforms#6](https://github.com/containerd/platforms/pull/6))
  * [`38a74d2`](https://github.com/containerd/platforms/commit/38a74d209d3bd4091fa83db35061ce32da31b5c3) Add grammar for platform string
* downgrade minimum required version of hcsshim to v0.10.0 ([containerd/platforms#5](https://github.com/containerd/platforms/pull/5))
  * [`724b9f8`](https://github.com/containerd/platforms/commit/724b9f89557de4d6e70a9d68882afb1b27e5ac57) downgrade minimum required version of hcsshim to v0.10.0
* enable linter on windows ([containerd/platforms#4](https://github.com/containerd/platforms/pull/4))
  * [`f6dd384`](https://github.com/containerd/platforms/commit/f6dd3842706b19a665ff27854f12bc8a7f808eb6) enable linter on windows
* fix grammar and highlights in README ([containerd/platforms#3](https://github.com/containerd/platforms/pull/3))
  * [`cb03428`](https://github.com/containerd/platforms/commit/cb034281bd28d792528b116680b2bbabac7bef75) fix grammar and highlights in README
* Fix link in README ([containerd/platforms#1](https://github.com/containerd/platforms/pull/1))
  * [`5b937b0`](https://github.com/containerd/platforms/commit/5b937b0167e6bbe5c715dc03e0d37a00f6e833f2) Fix link in README
* Update Windows linter version ([containerd/platforms#2](https://github.com/containerd/platforms/pull/2))
  * [`129b256`](https://github.com/containerd/platforms/commit/129b256bd216ea5f2fe6f6a78be0ec548c51c9ee) Update linter to skip Windows
  * [`18e3da6`](https://github.com/containerd/platforms/commit/18e3da61205bc54fe188a5a78c0cb83070c48a2c) Add Github actions CI
  * [`ed29dfd`](https://github.com/containerd/platforms/commit/ed29dfd2f71167ddc59cbb096fc28b173023f2ea) Remove space at end of readme
  * [`b3f80ee`](https://github.com/containerd/platforms/commit/b3f80ee8ee3f73aac75070feb14614cdfc2f8be4) Add go module
  * [`8ff004c`](https://github.com/containerd/platforms/commit/8ff004cf820d1b3fbe8d100fef3adb0e50ded133) Add license and readme
</p>
</details>

### Changes from containerd/ttrpc
<details><summary>4 commits</summary>
<p>

* switch to github.com/containerd/log for logs ([containerd/ttrpc#169](https://github.com/containerd/ttrpc/pull/169))
  * [`4785c70`](https://github.com/containerd/ttrpc/commit/4785c70883bf1729151379b3b5c4674ed2101c61) switch to github.com/containerd/log for logs
* Fix CI build status badge in readme ([containerd/ttrpc#162](https://github.com/containerd/ttrpc/pull/162))
  * [`e0f3ead`](https://github.com/containerd/ttrpc/commit/e0f3eadca58efdd8f24904d02ba8e1d8a561ec37) Fix CI build status badge in readme
</p>
</details>

### Dependency Changes

* **github.com/containerd/platforms**    v0.2.1 **_new_**
* **github.com/containerd/ttrpc**        v1.2.4 -> v1.2.5
* **github.com/distribution/reference**  v0.6.0 **_new_**
* **github.com/klauspost/compress**      v1.16.0 -> v1.16.7
* **go.etcd.io/bbolt**                   v1.3.7 -> v1.3.10
* **golang.org/x/sync**                  v0.3.0 -> v0.5.0

Previous release can be found at [v1.7.18](https://github.com/containerd/containerd/releases/tag/v1.7.18)

