### PR TITLE
pkg/reference: deprecate SplitObject, and remove for v2.0

### DIFF
--- a/pkg/reference/reference.go
+++ b/pkg/reference/reference.go
@@ -154,26 +154,3 @@ func (r Spec) String() string {
 
 	return r.Locator + ":" + r.Object
 }
-
-// SplitObject provides two parts of the object spec, delimited by an "@"
-// symbol. It does not perform any validation on correctness of the values
-// returned, and it's the callers' responsibility to validate the result.
-//
-// If an "@" delimiter is found, it returns the part *including* the "@"
-// delimiter as "tag", and the part after the "@" as digest.
-//
-// The example below produces "docker.io/library/ubuntu:latest@" and
-// "sha256:deadbeef";
-//
-//	t, d := SplitObject("docker.io/library/ubuntu:latest@sha256:deadbeef")
-//	fmt.Println(t) // docker.io/library/ubuntu:latest@
-//	fmt.Println(d) // sha256:deadbeef
-//
-// Deprecated: use [Parse] and [Spec.Digest] instead.
-func SplitObject(obj string) (tag string, dgst digest.Digest) {
-	if i := strings.Index(obj, "@"); i >= 0 {
-		// Offset by one so preserve the "@" in the tag returned.
-		return obj[:i+1], digest.Digest(obj[i+1:])
-	}
-	return obj, ""
-}

--- a/pkg/reference/reference.go
+++ b/pkg/reference/reference.go
@@ -168,6 +168,8 @@ func (r Spec) String() string {
 //	t, d := SplitObject("docker.io/library/ubuntu:latest@sha256:deadbeef")
 //	fmt.Println(t) // docker.io/library/ubuntu:latest@
 //	fmt.Println(d) // sha256:deadbeef
+//
+// Deprecated: use [Parse] and [Spec.Digest] instead.
 func SplitObject(obj string) (tag string, dgst digest.Digest) {
 	if i := strings.Index(obj, "@"); i >= 0 {
 		// Offset by one so preserve the "@" in the tag returned.

--- a/pkg/reference/reference_test.go
+++ b/pkg/reference/reference_test.go
@@ -192,33 +192,3 @@ func TestReferenceParser(t *testing.T) {
 		})
 	}
 }
-
-func BenchmarkSplitObject(b *testing.B) {
-	inputs := []string{
-		"",
-		"@",
-		"docker.io@",
-		"@digest",
-		"docker.io/library/redis:foo?fooo=asdf",
-		"docker.io/library/redis:foo@sha256:abcdef?fooo=asdf",
-		"docker.io/library/redis@sha256:abcdef?fooo=asdf",
-		"docker.io/library/redis:obj@abcdef?fooo=asdf",
-		"localhost:5000/library/redis:obj@abcdef?fooo=asdf",
-		"/docker.io/library/redis:obj@abcdef?fooo=asdf",
-		"docker.io/library/redis?fooo=asdf",
-		"sub-dom1.foo.com/bar/baz/quux:latest",
-		"sub-dom1.foo.com/bar/baz/quux:some-long-tag",
-		"b.gcr.io/test.example.com/my-app:test.example.com",
-		"xn--n3h.com/myimage:xn--n3h.com", // ☃.com in punycode
-		"xn--7o8h.com/myimage:xn--7o8h.com@sha512:fffffff",
-		"http://xn--7o8h.com/myimage:xn--7o8h.com@sha512:fffffff",
-	}
-
-	b.ReportAllocs()
-
-	for i := 0; i < b.N; i++ {
-		for _, input := range inputs {
-			_, _ = SplitObject(input)
-		}
-	}
-}


### PR DESCRIPTION
- follow-up to / stacked on https://github.com/containerd/containerd/pull/10393

### pkg/reference: deprecate SplitObject

The behavior of this function is quite counter-intuitive, as it preserves
the delimiter in the result, and its use for external consumers would be
very limited.

Spec.Digest no longer uses this function, and it appears that BuildKit is
currently the only (publicly visible) external consumer of it.

This patch deprecates the function.
