### PR TITLE
[release/1.7 backport] reference: deprecate SplitObject

### DIFF
--- a/reference/reference.go
+++ b/reference/reference.go
@@ -168,6 +168,8 @@ func (r Spec) String() string {
 //	t, d := SplitObject("docker.io/library/ubuntu:latest@sha256:deadbeef")
 //	fmt.Println(t) // docker.io/library/ubuntu:latest@
 //	fmt.Println(d) // sha256:deadbeef
+//
+// Deprecated: use [Parse] and [Spec.Digest] instead.
 func SplitObject(obj string) (tag string, dgst digest.Digest) {
 	if i := strings.Index(obj, "@"); i >= 0 {
 		// Offset by one so preserve the "@" in the tag returned.


### PR DESCRIPTION
- backport https://github.com/containerd/containerd/pull/10394
- depends on / stacked on https://github.com/containerd/containerd/pull/10395


### pkg/reference: deprecate SplitObject

The behavior of this function is quite counter-intuitive, as it preserves
the delimiter in the result, and its use for external consumers would be
very limited.

Spec.Digest no longer uses this function, and it appears that BuildKit is
currently the only (publicly visible) external consumer of it.

This patch deprecates the function.
