### PR TITLE
update to ubuntu-22.04 for release runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,25 +64,22 @@ jobs:
 
   build:
     name: Build Release Binaries
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
       matrix:
         include:
-          # Ubuntu 22.04 can't be used until we drop support for binary compatibility with dynamically-linked glibc 2.17 (CentOS 7).
-          # https://github.com/containerd/containerd/issues/7255
-          # https://github.com/containerd/containerd/issues/7961
-          - dockerfile-ubuntu: 20.04
+          - dockerfile-ubuntu: 22.04
             dockerfile-platform: linux/amd64
-          - dockerfile-ubuntu: 20.04
+          - dockerfile-ubuntu: 22.04
             dockerfile-platform: linux/arm64
-          - dockerfile-ubuntu: 20.04
+          - dockerfile-ubuntu: 22.04
             dockerfile-platform: linux/ppc64le
-          - dockerfile-ubuntu: 20.04
+          - dockerfile-ubuntu: 22.04
             dockerfile-platform: linux/s390x
-          - dockerfile-ubuntu: 20.04
+          - dockerfile-ubuntu: 22.04
             dockerfile-platform: linux/riscv64
-          - dockerfile-ubuntu: 20.04
+          - dockerfile-ubuntu: 22.04
             dockerfile-platform: windows/amd64
     steps:
       - name: Set RELEASE_VER

--- a/.github/workflows/release/Dockerfile
+++ b/.github/workflows/release/Dockerfile
@@ -13,7 +13,7 @@
 #   limitations under the License.
 
 # UBUNTU_VERSION can be set to 18.04 (bionic, DEPRECATED), 20.04 (focal), or 22.04 (jammy)
-ARG UBUNTU_VERSION=20.04
+ARG UBUNTU_VERSION=22.04
 ARG BASE_IMAGE=ubuntu:${UBUNTU_VERSION}
 ARG GO_VERSION
 ARG GO_IMAGE=golang:${GO_VERSION}


### PR DESCRIPTION
containerd release binaries were compiled in ubuntu-20.04 so as to keep glibc compatibility with CentOS 7. As of June 30, 2024, CentOS 7 is EOL. Hence updating the release runners to ubuntu 22.04

Ref: https://github.com/containerd/containerd/issues/7961