### PR TITLE
[release/1.7 backport] cri: ensure NRI API never has nil CRI

### DIFF
--- a/pkg/cri/cri.go
+++ b/pkg/cri/cri.go
@@ -28,7 +28,6 @@ import (
 	"github.com/containerd/containerd"
 	criconfig "github.com/containerd/containerd/pkg/cri/config"
 	"github.com/containerd/containerd/pkg/cri/constants"
-	"github.com/containerd/containerd/pkg/cri/nri"
 	"github.com/containerd/containerd/pkg/cri/sbserver"
 	"github.com/containerd/containerd/pkg/cri/server"
 	nriservice "github.com/containerd/containerd/pkg/nri"
@@ -145,7 +144,7 @@ func setGLogLevel() error {
 }
 
 // Get the NRI plugin, and set up our NRI API for it.
-func getNRIAPI(ic *plugin.InitContext) *nri.API {
+func getNRIAPI(ic *plugin.InitContext) nriservice.API {
 	const (
 		pluginType = plugin.NRIApiPlugin
 		pluginName = "nri"
@@ -168,5 +167,5 @@ func getNRIAPI(ic *plugin.InitContext) *nri.API {
 
 	log.G(ctx).Info("using experimental NRI integration - disable nri plugin to prevent this")
 
-	return nri.NewAPI(api)
+	return api
 }

--- a/pkg/cri/nri/nri_api_linux.go
+++ b/pkg/cri/nri/nri_api_linux.go
@@ -47,9 +47,10 @@ type API struct {
 	nri nri.API
 }
 
-func NewAPI(nri nri.API) *API {
+func NewAPI(nri nri.API, cri CRIImplementation) *API {
 	return &API{
 		nri: nri,
+		cri: cri,
 	}
 }
 
@@ -59,12 +60,11 @@ func (a *API) IsDisabled() bool {
 
 func (a *API) IsEnabled() bool { return !a.IsDisabled() }
 
-func (a *API) Register(cri CRIImplementation) error {
+func (a *API) Register() error {
 	if a.IsDisabled() {
 		return nil
 	}
 
-	a.cri = cri
 	nri.RegisterDomain(a)
 
 	return a.nri.Start()

--- a/pkg/cri/nri/nri_api_other.go
+++ b/pkg/cri/nri/nri_api_other.go
@@ -37,11 +37,11 @@ import (
 type API struct {
 }
 
-func NewAPI(nri.API) *API {
+func NewAPI(nri.API, CRIImplementation) *API {
 	return nil
 }
 
-func (a *API) Register(CRIImplementation) error {
+func (a *API) Register() error {
 	return nil
 }
 

--- a/pkg/nri/nri.go
+++ b/pkg/nri/nri.go
@@ -39,7 +39,7 @@ type API interface {
 	// IsEnabled returns true if the NRI interface is enabled and initialized.
 	IsEnabled() bool
 
-	// Start start the NRI interface, allowing external NRI plugins to
+	// Start starts the NRI interface, allowing external NRI plugins to
 	// connect, register, and hook themselves into the lifecycle events
 	// of pods and containers.
 	Start() error


### PR DESCRIPTION
(Backport of https://github.com/containerd/containerd/pull/10401)

A nil CRIImplementation field can cause a nil pointer dereference and panic during startup recovery.

Prior to this change, the nri.API struct would have a nil cri (CRIImplementation) field after nri.NewAPI until nri.Register was called.  Register is called mid-way through initialization of the CRI plugin, but recovery for containers occurs prior to that.  Container recovery includes establishing new exit monitors for existing containers that were discovered.  When a container exits, NRI plugins are given the opportunity to be notified about the lifecycle event, and this is done by accessing that CRIImplementation field inside the nri.API.  If a container exits prior to nri.Register being called, access to the CRIImplementation field can cause a panic.

Here's the call-path:

* The CRI plugin starts running [here](https://github.com/containerd/containerd/blob/ae71819c4f5e67bb4d5ae76a6b735f29cc25774e/pkg/cri/server/service.go#L222)
* It then [calls into](https://github.com/containerd/containerd/blob/ae71819c4f5e67bb4d5ae76a6b735f29cc25774e/pkg/cri/server/service.go#L227) `recover()` to recover state from previous runs of containerd
* `recover()` then attempts to recover all containers through [`loadContainer()`](https://github.com/containerd/containerd/blob/ae7d74b9e21bd08260586db104a1fe04af754545/internal/cri/server/restart.go#L175)
* When `loadContainer()` finds a container that is still running, it waits for the task (internal containerd object) to exit and sets up [exit monitoring](https://github.com/containerd/containerd/blob/ae7d74b9e21bd08260586db104a1fe04af754545/internal/cri/server/restart.go#L391)
* Any exit that then happens must be [handled](https://github.com/containerd/containerd/blob/ae7d74b9e21bd08260586db104a1fe04af754545/internal/cri/server/events.go#L145)
* Handling an exit includes [deleting the Task](https://github.com/containerd/containerd/blob/ae7d74b9e21bd08260586db104a1fe04af754545/internal/cri/server/events.go#L188) and specifying [`nri.WithContainerExit`](https://github.com/containerd/containerd/blob/ae7d74b9e21bd08260586db104a1fe04af754545/internal/cri/nri/nri_api_linux.go#L348) to [notify](https://github.com/containerd/containerd/blob/ae7d74b9e21bd08260586db104a1fe04af754545/internal/cri/nri/nri_api_linux.go#L356) any subscribed NRI plugins
* NRI plugins need to know information about the pod (not just the sandbox), so before a plugin is notified the NRI API package [queries the Sandbox Store](https://github.com/containerd/containerd/blob/ae7d74b9e21bd08260586db104a1fe04af754545/internal/cri/nri/nri_api_linux.go#L232) through the CRI implementation
* The `cri` implementation member field in the `nri.API` struct is set as part of the [`Register()`](https://github.com/containerd/containerd/blob/ae7d74b9e21bd08260586db104a1fe04af754545/internal/cri/nri/nri_api_linux.go#L66) method
* The `nri.Register()` method is only called [much further down in the CRI `Run()` method](https://github.com/containerd/containerd/blob/ae71819c4f5e67bb4d5ae76a6b735f29cc25774e/pkg/cri/server/service.go#L279)

(manually backported from commit 10aec359a04367895ff2a0ca634a6eb6771db615)