### PR TITLE
compression: improve performance by 3 to 5 times, use gzip level 1 by default

### DIFF
--- a/pkg/archive/compression/compression.go
+++ b/pkg/archive/compression/compression.go
@@ -242,7 +242,7 @@ func CompressStream(dest io.Writer, compression Compression) (io.WriteCloser, er
 	case Uncompressed:
 		return &writeCloserWrapper{dest, nil}, nil
 	case Gzip:
-		return gzip.NewWriter(dest), nil
+		return gzip.NewWriterLevel(dest, 1)
 	case Zstd:
 		return zstd.NewWriter(dest)
 	default:


### PR DESCRIPTION
Hello,

It seems you have inherited this compression bug that's been in docker for the last 11 years. See discussion in https://github.com/moby/moby/pull/48106

Could you correct the compression level?

Thank you.