### PR TITLE
Fix for `[cri] ttrpc: closed` during ListPodSandboxStats

### DIFF
--- a/pkg/cri/server/sandbox_stats_list.go
+++ b/pkg/cri/server/sandbox_stats_list.go
@@ -18,11 +18,13 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	sandboxstore "github.com/containerd/containerd/pkg/cri/store/sandbox"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+	"github.com/containerd/ttrpc"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/hashicorp/go-multierror"
@@ -42,6 +44,8 @@ func (c *criService) ListPodSandboxStats(
 		switch {
 		case errdefs.IsUnavailable(err), errdefs.IsNotFound(err):
 			log.G(ctx).WithField("podsandboxid", sandbox.ID).Debugf("failed to get pod sandbox stats, this is likely a transient error: %v", err)
+		case errors.Is(err, ttrpc.ErrClosed):
+			log.G(ctx).WithField("podsandboxid", sandbox.ID).Debugf("failed to get pod sandbox stats, connection closed: %v", err)
 		case err != nil:
 			errs = multierror.Append(errs, fmt.Errorf("failed to decode sandbox container metrics for sandbox %q: %w", sandbox.ID, err))
 		default:


### PR DESCRIPTION
Similar to https://github.com/containerd/containerd/pull/10023 we have another symptom that shows up in k8s CI job(s)

![image](https://github.com/containerd/containerd/assets/23304/71572abf-422f-48ef-bba1-ef96accee2f2)

Some example CI runs are: (click on `Kubernetes e2e suite: [It] [sig-node] NodeProblemDetector [NodeFeature:NodeProblemDetector] should run without error` to expand to see the error, you click on `Archive` link to get to the kubelet and containerd logs as well)
- https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-alpha-enabled-default/1808526993558343680
- https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-alpha-enabled-default/1808495031716155392
- https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-alpha-enabled-default/1808464328827867136
- https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-alpha-enabled-default/1808381029463887872
- https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-alpha-enabled-default/1808351836457930752


