### PR TITLE
[release/1.7] errdefs: denote deprecation as a godoc comment

### DIFF
--- a/errdefs/errdefs_deprecated.go
+++ b/errdefs/errdefs_deprecated.go
@@ -24,6 +24,8 @@
 //
 // The functions ToGRPC and FromGRPC can be used to map server-side and
 // client-side errors to the correct types.
+//
+// Deprecated: use [github.com/containerd/errdefs].
 package errdefs
 
 import (


### PR DESCRIPTION
golangci-lint can now raise an error when the deprecated errdefs package is used:

> SA1019: "github.com/containerd/containerd/errdefs" is deprecated:
> use [github.com/containerd/errdefs]. (staticcheck)