### PR TITLE
reduce runc log to fix log.json of a container may grow to burst,if run a non exist executable command in a container many times.

### DIFF
--- a/cmd/containerd-shim-runc-v2/process/init.go
+++ b/cmd/containerd-shim-runc-v2/process/init.go
@@ -79,13 +79,13 @@ type Init struct {
 }
 
 // NewRunc returns a new runc instance for a process
-func NewRunc(root, path, namespace, runtime string, systemd bool) *runc.Runc {
+func NewRunc(root, file, namespace, runtime string, systemd bool) *runc.Runc {
 	if root == "" {
 		root = RuncRoot
 	}
 	return &runc.Runc{
 		Command:       runtime,
-		Log:           filepath.Join(path, "log.json"),
+		Log:           file,
 		LogFormat:     runc.JSON,
 		PdeathSignal:  unix.SIGKILL,
 		Root:          filepath.Join(root, namespace),
@@ -476,8 +476,7 @@ func (p *Init) runtimeError(rErr error, msg string) error {
 	if rErr == nil {
 		return nil
 	}
-
-	rMsg, err := getLastRuntimeError(p.runtime)
+	rMsg, err := getLastRuntimeError(filepath.Join(p.Bundle, "log.json"))
 	switch {
 	case err != nil:
 		return fmt.Errorf("%s: %s (%s): %w", msg, "unable to retrieve OCI runtime error", err.Error(), rErr)

--- a/cmd/containerd-shim-runc-v2/process/utils.go
+++ b/cmd/containerd-shim-runc-v2/process/utils.go
@@ -54,12 +54,12 @@ func (s *safePid) get() int {
 }
 
 // TODO(mlaventure): move to runc package?
-func getLastRuntimeError(r *runc.Runc) (string, error) {
-	if r.Log == "" {
+func getLastRuntimeError(logFile string) (string, error) {
+	if logFile == "" {
 		return "", nil
 	}
 
-	f, err := os.OpenFile(r.Log, os.O_RDONLY, 0400)
+	f, err := os.OpenFile(logFile, os.O_RDONLY, 0400)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/containerd-shim-runc-v2/runc/container.go
+++ b/cmd/containerd-shim-runc-v2/runc/container.go
@@ -22,9 +22,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/containerd/cgroups/v3"
 	"github.com/containerd/cgroups/v3/cgroup1"
@@ -37,9 +39,17 @@ import (
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/stdio"
 	"github.com/containerd/errdefs"
+	"github.com/containerd/fifo"
 	"github.com/containerd/log"
 	"github.com/containerd/typeurl/v2"
+	"golang.org/x/sys/unix"
 )
+
+type RuntimeLog struct {
+	Level string
+	Msg   string
+	Time  time.Time
+}
 
 // NewContainer returns a new runc container
 func NewContainer(ctx context.Context, platform stdio.Platform, r *task.CreateTaskRequest) (_ *Container, retErr error) {
@@ -119,9 +129,10 @@ func NewContainer(ctx context.Context, platform stdio.Platform, r *task.CreateTa
 		return nil, fmt.Errorf("failed to mount rootfs component: %w", err)
 	}
 
+	runtimeLog := filepath.Join(r.Bundle, "log.fifo")
 	p, err := newInit(
 		ctx,
-		r.Bundle,
+		runtimeLog,
 		filepath.Join(r.Bundle, "work"),
 		ns,
 		platform,
@@ -132,6 +143,32 @@ func NewContainer(ctx context.Context, platform stdio.Platform, r *task.CreateTa
 	if err != nil {
 		return nil, errdefs.ToGRPC(err)
 	}
+
+	f, err := fifo.OpenFifo(ctx, runtimeLog, unix.O_RDWR|unix.O_CREAT|unix.O_NONBLOCK, 0700)
+	if err != nil {
+		return nil, fmt.Errorf("open runc shim log pipe: %v", err)
+	}
+	go func() {
+		defer f.Close()
+		var runtimeLog RuntimeLog
+		dec := json.NewDecoder(f)
+		for err = nil; err == nil; {
+			if err = dec.Decode(&runtimeLog); err != nil && err != io.EOF {
+				log.G(ctx).Errorf("decode err:%v", err)
+				break
+			}
+			if runtimeLog.Level == "error" {
+				log.G(ctx).Errorf("runtime msg:%s", runtimeLog.Msg)
+				//generate the last runtime error log for func getLastRuntimeError to read
+				err := writeFile(runtimeLog, filepath.Join(r.Bundle, "log.json"))
+				if err != nil {
+					log.G(ctx).WithError(err).Error("write runtime log")
+				}
+			} else {
+				log.G(ctx).Debugf("runtime msg:%s", runtimeLog.Msg)
+			}
+		}
+	}()
 	if err := p.Create(ctx, config); err != nil {
 		return nil, errdefs.ToGRPC(err)
 	}
@@ -213,9 +250,9 @@ func WriteRuntime(path, runtime string) error {
 	return os.WriteFile(filepath.Join(path, "runtime"), []byte(runtime), 0600)
 }
 
-func newInit(ctx context.Context, path, workDir, namespace string, platform stdio.Platform,
+func newInit(ctx context.Context, file, workDir, namespace string, platform stdio.Platform,
 	r *process.CreateConfig, options *options.Options, rootfs string) (*process.Init, error) {
-	runtime := process.NewRunc(options.Root, path, namespace, options.BinaryName, options.SystemdCgroup)
+	runtime := process.NewRunc(options.Root, file, namespace, options.BinaryName, options.SystemdCgroup)
 	p := process.New(r.ID, runtime, stdio.Stdio{
 		Stdin:    r.Stdin,
 		Stdout:   r.Stdout,
@@ -509,4 +546,17 @@ func (c *Container) HasPid(pid int) bool {
 		}
 	}
 	return false
+}
+
+func writeFile(log RuntimeLog, path string) error {
+	logFile, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("Error open file %s %w", path, err)
+	}
+	defer logFile.Close()
+	encoder := json.NewEncoder(logFile)
+	if err := encoder.Encode(log); err != nil {
+		return fmt.Errorf("Error writing to file %s %w", path, err)
+	}
+	return nil
 }


### PR DESCRIPTION
fix https://github.com/containerd/containerd/issues/8972
@abel-von 