### PR TITLE
client: fix tasks with PID 0 cannot be forced to delete

### DIFF
--- a/client/task_opts.go
+++ b/client/task_opts.go
@@ -151,6 +151,12 @@ type ProcessDeleteOpts func(context.Context, Process) error
 
 // WithProcessKill will forcefully kill and delete a process
 func WithProcessKill(ctx context.Context, p Process) error {
+	// Skip killing tasks with PID 0
+	// https://github.com/containerd/containerd/issues/10441
+	if p.Pid() == 0 {
+		return nil
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	// ignore errors to wait and kill as we are forcefully killing


### PR DESCRIPTION
fix: https://github.com/containerd/containerd/issues/10441

Using a simpler way, tasks with a PID of 0 are treated as the special kind of tasks.