### PR TITLE
[release/1.7] Fix parsing hosts.toml without any host tree

### DIFF
--- a/remotes/docker/config/hosts.go
+++ b/remotes/docker/config/hosts.go
@@ -528,7 +528,11 @@ func parseHostConfig(server string, baseDir string, config hostFileConfig) (host
 
 // getSortedHosts returns the list of hosts as they defined in the file.
 func getSortedHosts(root *toml.Tree) ([]string, error) {
-	iter, ok := root.Get("host").(*toml.Tree)
+	tree := root.Get("host")
+	if tree == nil {
+		return nil, nil
+	}
+	iter, ok := tree.(*toml.Tree)
 	if !ok {
 		return nil, errors.New("invalid `host` tree")
 	}

--- a/remotes/docker/config/hosts_test.go
+++ b/remotes/docker/config/hosts_test.go
@@ -208,6 +208,43 @@ ca = "/etc/path/default"
 	}
 }
 
+func TestParseHostFileWithoutHostTree(t *testing.T) {
+	const testtoml = `
+server = "https://test-default.registry"
+ca = "/etc/path/default"
+host = "test"
+`
+
+	expected := []hostConfig{{
+		scheme:       "https",
+		path:         "/v2",
+		capabilities: allCaps,
+		host:         "test-default.registry",
+		caCerts:      []string{"/etc/path/default"},
+	}}
+
+	hosts, err := parseHostsFile("", []byte(testtoml))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		if t.Failed() {
+			t.Log("HostConfigs...\nActual:\n" + printHostConfig(hosts) + "Expected:\n" + printHostConfig(expected))
+		}
+	}()
+
+	if len(hosts) != len(expected) {
+		t.Fatalf("Unexpected number of hosts %d, expected %d", len(hosts), len(expected))
+	}
+
+	for i := range hosts {
+		if !compareHostConfig(hosts[i], expected[i]) {
+			t.Fatalf("Mismatch at host %d", i)
+		}
+	}
+}
+
 func TestLoadCertFiles(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
### Summary

Closes #10027

### Changes

- `(*toml.Tree).Get()` returns nil if there is not tree for a given key. return an empty list of hosts in that case
- Add a unit test