### PR TITLE
Add read permission limit on link workflow

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - ".github/workflows/links.yml"
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/contrib/ansible/README.md
+++ b/contrib/ansible/README.md
@@ -1,9 +1,4 @@
 # Kubernetes Cluster with Containerd
-<p align="center">
-<img src="https://kubernetes.io/images/favicon.png" width="50" height="50">
-<img src="https://containerd.io/img/logos/icon/black/containerd-icon-black.png" width="50" >
-</p>
-
 
 This document provides the steps to bring up a Kubernetes cluster using ansible and kubeadm tools.
 


### PR DESCRIPTION
All our Github actions should have top level read permission to explicitly limit scope.

Related to #10338