### PR TITLE
Include file path in tar copy errors

### DIFF
--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -666,7 +666,7 @@ func (cw *ChangeWriter) HandleChange(k fs.ChangeKind, p string, f os.FileInfo, e
 
 			n, err := copyBuffered(context.TODO(), cw.tw, file)
 			if err != nil {
-				return fmt.Errorf("failed to copy: %w", err)
+				return fmt.Errorf("failed to copy: %v: %w", source, err)
 			}
 			if n != hdr.Size {
 				return errors.New("short write copying file")


### PR DESCRIPTION
This PR includes the name of the affected file in the error, just like the error a few lines above does.

This change makes it *much* easier to identify the cause of race conditions where the size of a copied file changes during the execution of `HandleChange()`.

---

In my case, I was building a Docker image which had a `RUN` command that inadvertantly kept a process running in the background, constantly writing to a log file.  This caused a race condition in `copyBuffered()` where the header size determined here:

https://github.com/containerd/containerd/blob/ca6a8a56a5155013d1118f703f188021c3ec949d/pkg/archive/tar.go#L584-L585

was smaller than the number of bytes written via `copyBuffered()` later in the function:

https://github.com/containerd/containerd/blob/ca6a8a56a5155013d1118f703f188021c3ec949d/pkg/archive/tar.go#L667-L670


Thus causing this very generic error due to `tar.ErrWriteTooLong`:

> ERROR: failed to solve: mount callback failed on /run/user/1000/containerd-mount3394128618: mount callback failed on /run/user/1000/containerd-mount203702630: failed to write compressed diff: failed to create diff tar stream: failed to copy: archive/tar: write too long

Neither buildkit nor containerd provide any output tell help users find the source of this error.  But if we include the relevant file name it becomes much more obvious what happened and what needs to be fixed:

> ERROR: failed to solve: mount callback failed on /run/user/1000/containerd-mount3394128618: mount callback failed on /run/user/1000/containerd-mount203702630: failed to write compressed diff: failed to create diff tar stream: failed to copy: /run/user/1000/containerd-mount203702630/var/log/datadog/dotnet/dotnet-tracer-managed-dotnet-20240716_005.log: archive/tar: write too long