### PR TITLE
Prepare release notes for v1.6.34

### DIFF
--- a/releases/v1.6.34.toml
+++ b/releases/v1.6.34.toml
@@ -1,0 +1,27 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.6.33"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The thirty-fourth patch release for containerd 1.6 contains various fixes
+and updates.
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.33+unknown"
+	Version = "1.6.34+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated notes

----

Welcome to the v1.6.34 release of containerd!

The thirty-fourth patch release for containerd 1.6 contains various fixes
and updates.

### Highlights

* Remove overlayfs volatile option on temp mounts ([#10333](https://github.com/containerd/containerd/pull/10333))
* Update runc binary to v1.1.13 ([#10335](https://github.com/containerd/containerd/pull/10335))

#### Container Runtime Interface (CRI)

* Handle empty DNSConfig differently than unspecified ([#10463](https://github.com/containerd/containerd/pull/10463))
* Fix HPC working directory in pkg/cri/server code ([#10361](https://github.com/containerd/containerd/pull/10361))

#### Runtime

* Support for dropping inheritable capabilities ([#10470](https://github.com/containerd/containerd/pull/10470))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Derek McGowan
* Akihiro Suda
* Sebastiaan van Stijn
* Wei Fu
* Akhil Mohan
* Maksim An
* Maksym Pavlenko
* Mike Brown
* Phil Estes
* Samuel Karp
* Tim Hockin
* Yuanyuan Lei
* krglosse

### Changes
<details><summary>25 commits</summary>
<p>

  * [`b2863e9e7`](https://github.com/containerd/containerd/commit/b2863e9e712c07af8141aefddc052dc9e9a90bf6) Prepare release notes for v1.6.34
* Handle empty DNSConfig differently than unspecified ([#10463](https://github.com/containerd/containerd/pull/10463))
  * [`b7d06a619`](https://github.com/containerd/containerd/commit/b7d06a619215bd1972ef19c4870e8e7f81c6dc6f) CRI: An empty DNSConfig != unspecified
* Support for dropping inheritable capabilities ([#10470](https://github.com/containerd/containerd/pull/10470))
  * [`8d2739857`](https://github.com/containerd/containerd/commit/8d27398577471912762bb1aa53d68c6e315bbe54) Support for dropping inheritable capabilities
* errdefs: denote deprecation as a godoc comment ([#10425](https://github.com/containerd/containerd/pull/10425))
  * [`ce685376f`](https://github.com/containerd/containerd/commit/ce685376f06d6bd6c9ba9c1581f4487930964dff) errdefs: denote deprecation as a godoc comment
* update to go1.21.12 / go1.22.5 ([#10427](https://github.com/containerd/containerd/pull/10427))
  * [`634ae543d`](https://github.com/containerd/containerd/commit/634ae543d4df4a0fd73cc5d6a4163027be220010) update to go1.21.12 / go1.22.5
* Updating hcsshim vendoring to 0.9.12 to include an important backported fix ([#10398](https://github.com/containerd/containerd/pull/10398))
  * [`a0adb2933`](https://github.com/containerd/containerd/commit/a0adb29333f7d2b4b5afe389105b35a4cfcf946a) Updating hcsshim to 0.9.12
* golangci-lint: enable depguard for packages that moved ([#10368](https://github.com/containerd/containerd/pull/10368))
  * [`3ea0c4983`](https://github.com/containerd/containerd/commit/3ea0c498361e40a23b5e5c3781efe4cc7baf1725) golangci-lint: enable depguard for packages that moved
* Fix HPC working directory in pkg/cri/server code ([#10361](https://github.com/containerd/containerd/pull/10361))
  * [`086e1f56e`](https://github.com/containerd/containerd/commit/086e1f56e446740466b113a04f201e2040ae5a22) [release/1.7]: HPC working directory fix in pkg/cri/server code
* Remove overlayfs volatile option on temp mounts ([#10333](https://github.com/containerd/containerd/pull/10333))
  * [`166283a34`](https://github.com/containerd/containerd/commit/166283a34d6060d9c569673423440a2b1cf0ad85) integration: backport upgrade testsuite's utils
  * [`990a05d0a`](https://github.com/containerd/containerd/commit/990a05d0a851f2b188d97a884554b809e0361462) *: export RemoveVolatileOption for CRI image volumes
  * [`a894b5f81`](https://github.com/containerd/containerd/commit/a894b5f810756a3cbcc6d5d2b544a2a5e836e954) strip-volatile-option-tmp-mounts
* Update runc binary to v1.1.13 ([#10335](https://github.com/containerd/containerd/pull/10335))
  * [`f6ef0071b`](https://github.com/containerd/containerd/commit/f6ef0071b487e3db7ad8c1ebc4ca0c50ac4698f4) update runc binary to v1.1.13
* Update Fedora and EL linux version in vagrant ([#10339](https://github.com/containerd/containerd/pull/10339))
  * [`89bb437f8`](https://github.com/containerd/containerd/commit/89bb437f8b25840a2efbd2278d0f0b1b06025b13) Remove rocklinux 9
  * [`01fa3d0d7`](https://github.com/containerd/containerd/commit/01fa3d0d77f487e64a1a3f9760277fd16fa0289b) Backport version from box string in Vagrantfile
  * [`0be3788f5`](https://github.com/containerd/containerd/commit/0be3788f52f8e5889a018006b002f00cca63e4dd) Update Fedora and EL linux version
</p>
</details>

### Dependency Changes

* **github.com/Microsoft/hcsshim**  v0.9.11 -> v0.9.12

Previous release can be found at [v1.6.33](https://github.com/containerd/containerd/releases/tag/v1.6.33)
