### PR TITLE
Prepare release notes for v1.7.20

### DIFF
--- a/releases/v1.7.20.toml
+++ b/releases/v1.7.20.toml
@@ -1,0 +1,27 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.7.19"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The twentieth patch release for containerd 1.7 contains various fixes
+and updates.
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.7.19+unknown"
+	Version = "1.7.20+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated notes

----

Welcome to the v1.7.20 release of containerd!

The twentieth patch release for containerd 1.7 contains various fixes
and updates.

### Highlights

* Support for dropping inheritable capabilities ([#10469](https://github.com/containerd/containerd/pull/10469))

#### Container Runtime Interface (CRI)

* Make PodSandboxStatus friendlier to shim crashes ([#10461](https://github.com/containerd/containerd/pull/10461))
* Handle empty DNSConfig differently than unspecified ([#10462](https://github.com/containerd/containerd/pull/10462))
* Fix for `[cri] ttrpc: closed` during ListPodSandboxStats ([#10423](https://github.com/containerd/containerd/pull/10423))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Akihiro Suda
* Derek McGowan
* Phil Estes
* Akhil Mohan
* Bryant Biggs
* Danny Canter
* Davanum Srinivas
* Mike Brown
* Samuel Karp
* Tim Hockin

### Changes
<details><summary>15 commits</summary>
<p>

  * [`7f2d4cd97`](https://github.com/containerd/containerd/commit/7f2d4cd978f602bc5f68c3a3f7123a834150fe1d) Prepare release notes for v1.7.20
* deps: Update otelgrpc ([#10413](https://github.com/containerd/containerd/pull/10413))
  * [`3a02c523d`](https://github.com/containerd/containerd/commit/3a02c523d07fd8636b72ba8de6fd21d6c3ffa042) deps: Update otelgrpc
* Make PodSandboxStatus friendlier to shim crashes ([#10461](https://github.com/containerd/containerd/pull/10461))
  * [`df86bdd5d`](https://github.com/containerd/containerd/commit/df86bdd5dc6a9948e65fe8a8a296052b19734286) CRI Sbserver: Make PodSandboxStatus friendlier to shim crashes
* Handle empty DNSConfig differently than unspecified ([#10462](https://github.com/containerd/containerd/pull/10462))
  * [`209ee4f10`](https://github.com/containerd/containerd/commit/209ee4f107af61f1385bb77770c9ae0568add13e) CRI: An empty DNSConfig != unspecified
* Support for dropping inheritable capabilities ([#10469](https://github.com/containerd/containerd/pull/10469))
  * [`ce65228af`](https://github.com/containerd/containerd/commit/ce65228afd0b0fce6f5ef3dd0d7ec312b2c552b0) Support for dropping inheritable capabilities
* Fix for `[cri] ttrpc: closed` during ListPodSandboxStats ([#10423](https://github.com/containerd/containerd/pull/10423))
  * [`610498df7`](https://github.com/containerd/containerd/commit/610498df750c3b30b137ddb4ab236e5b0a84ceda) Fix for `[cri] ttrpc: closed` during ListPodSandboxStats
* update to go1.21.12 / go1.22.5 ([#10426](https://github.com/containerd/containerd/pull/10426))
  * [`e61c7932e`](https://github.com/containerd/containerd/commit/e61c7932efc40f7246eaffb00b19fd697c0447f8) update to go1.21.12 / go1.22.5
* errdefs: denote deprecation as a godoc comment ([#10424](https://github.com/containerd/containerd/pull/10424))
  * [`c7d5e430a`](https://github.com/containerd/containerd/commit/c7d5e430a4dc9e7fb3a0241adfb5477466f09c59) errdefs: denote deprecation as a godoc comment
</p>
</details>

### Dependency Changes

* **github.com/go-logr/logr**                                                      v1.2.4 -> v1.3.0
* **github.com/google/go-cmp**                                                     v0.5.9 -> v0.6.0
* **github.com/google/uuid**                                                       v1.3.1 -> v1.4.0
* **go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc**  v0.45.0 -> v0.46.1
* **go.opentelemetry.io/otel**                                                     v1.19.0 -> v1.21.0
* **go.opentelemetry.io/otel/metric**                                              v1.19.0 -> v1.21.0
* **go.opentelemetry.io/otel/sdk**                                                 v1.19.0 -> v1.21.0
* **go.opentelemetry.io/otel/trace**                                               v1.19.0 -> v1.21.0
* **google.golang.org/genproto**                                                   e6e6cdab5c13 -> 989df2bf70f3
* **google.golang.org/genproto/googleapis/api**                                    007df8e322eb -> 83a465c0220f
* **google.golang.org/genproto/googleapis/rpc**                                    d307bd883b97 -> 995d672761c0

Previous release can be found at [v1.7.19](https://github.com/containerd/containerd/releases/tag/v1.7.19)



