### PR TITLE
Avoid potential reallocs by pre-sizing some slices

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -268,9 +268,9 @@ func (c *Client) Containers(ctx context.Context, filters ...string) ([]Container
 	if err != nil {
 		return nil, err
 	}
-	var out []Container
-	for _, container := range r {
-		out = append(out, containerFromRecord(c, container))
+	out := make([]Container, len(r))
+	for i, container := range r {
+		out[i] = containerFromRecord(c, container)
 	}
 	return out, nil
 }
@@ -513,9 +513,9 @@ func (c *Client) Restore(ctx context.Context, id string, checkpoint Image, opts 
 	}
 	defer done(ctx)
 
-	copts := []NewContainerOpts{}
-	for _, o := range opts {
-		copts = append(copts, o(ctx, id, c, checkpoint, index))
+	copts := make([]NewContainerOpts, len(opts))
+	for i, o := range opts {
+		copts[i] = o(ctx, id, c, checkpoint, index)
 	}
 
 	ctr, err := c.NewContainer(ctx, id, copts...)

--- a/cmd/ctr/commands/images/export.go
+++ b/cmd/ctr/commands/images/export.go
@@ -119,9 +119,9 @@ When '--all-platforms' is given all images in a manifest list must be available.
 				exportOpts = append(exportOpts, tarchive.WithSkipNonDistributableBlobs)
 			}
 
-			storeOpts := []image.StoreOpt{}
-			for _, img := range images {
-				storeOpts = append(storeOpts, image.WithExtraReference(img))
+			storeOpts := make([]image.StoreOpt, len(images))
+			for i, img := range images {
+				storeOpts[i] = image.WithExtraReference(img)
 			}
 
 			return client.Transfer(ctx,

--- a/core/images/archive/importer.go
+++ b/core/images/archive/importer.go
@@ -256,8 +256,8 @@ func onUntarBlob(ctx context.Context, r io.Reader, store content.Ingester, size 
 
 func resolveLayers(ctx context.Context, store content.Store, layerFiles []string, blobs map[string]ocispec.Descriptor, compress bool) ([]ocispec.Descriptor, error) {
 	layers := make([]ocispec.Descriptor, len(layerFiles))
+	filters := make([]string, len(layerFiles))
 	descs := map[digest.Digest]*ocispec.Descriptor{}
-	filters := []string{}
 	for i, f := range layerFiles {
 		desc, ok := blobs[f]
 		if !ok {
@@ -265,7 +265,7 @@ func resolveLayers(ctx context.Context, store content.Store, layerFiles []string
 		}
 		layers[i] = desc
 		descs[desc.Digest] = &layers[i]
-		filters = append(filters, fmt.Sprintf("labels.\"%s\"==%s", labels.LabelUncompressed, desc.Digest.String()))
+		filters[i] = fmt.Sprintf("labels.\"%s\"==%s", labels.LabelUncompressed, desc.Digest.String())
 	}
 
 	err := store.Walk(ctx, func(info content.Info) error {

--- a/internal/nri/container.go
+++ b/internal/nri/container.go
@@ -64,9 +64,9 @@ func commonContainerToNRI(ctr Container) *nri.Container {
 }
 
 func containersToNRI(ctrList []Container) []*nri.Container {
-	ctrs := []*nri.Container{}
-	for _, ctr := range ctrList {
-		ctrs = append(ctrs, containerToNRI(ctr))
+	ctrs := make([]*nri.Container, len(ctrList))
+	for i, ctr := range ctrList {
+		ctrs[i] = containerToNRI(ctr)
 	}
 	return ctrs
 }

--- a/pkg/oci/spec_opts.go
+++ b/pkg/oci/spec_opts.go
@@ -1098,9 +1098,9 @@ func getSupplementalGroupsFromPath(root string, filter func(user.Group) bool) ([
 		// if there are no additional groups; just return an empty set
 		return []uint32{}, nil
 	}
-	addlGids := []uint32{}
-	for _, grp := range groups {
-		addlGids = append(addlGids, uint32(grp.Gid))
+	addlGids := make([]uint32, len(groups))
+	for i, grp := range groups {
+		addlGids[i] = uint32(grp.Gid)
 	}
 	return addlGids, nil
 }


### PR DESCRIPTION
There's a couple spots where we know exactly how large the destination buffer should be, so pre-size these to avoid any reallocs to a higher capacity.