### PR TITLE
[release/1.7] [Windows] Set stderr to empty string when using terminal on Windows.

### DIFF
--- a/cio/io.go
+++ b/cio/io.go
@@ -268,26 +268,6 @@ func BinaryIO(binary string, args map[string]string) Creator {
 	}
 }
 
-// TerminalBinaryIO forwards container STDOUT|STDERR directly to a logging binary
-// It also sets the terminal option to true
-func TerminalBinaryIO(binary string, args map[string]string) Creator {
-	return func(_ string) (IO, error) {
-		uri, err := LogURIGenerator("binary", binary, args)
-		if err != nil {
-			return nil, err
-		}
-
-		res := uri.String()
-		return &logURI{
-			config: Config{
-				Stdout:   res,
-				Stderr:   res,
-				Terminal: true,
-			},
-		}, nil
-	}
-}
-
 // LogFile creates a file on disk that logs the task's STDOUT,STDERR.
 // If the log file already exists, the logs will be appended to the file.
 func LogFile(path string) Creator {

--- a/cio/io_unix.go
+++ b/cio/io_unix.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sync"
@@ -157,4 +158,38 @@ func NewDirectIO(ctx context.Context, fifos *FIFOSet) (*DirectIO, error) {
 			cancel:  cancel,
 		},
 	}, err
+}
+
+// TerminalLogURI provides the raw logging URI
+// as well as sets the terminal option to true.
+func TerminalLogURI(uri *url.URL) Creator {
+	return func(_ string) (IO, error) {
+		return &logURI{
+			config: Config{
+				Stdout:   uri.String(),
+				Stderr:   uri.String(),
+				Terminal: true,
+			},
+		}, nil
+	}
+}
+
+// TerminalBinaryIO forwards container STDOUT|STDERR directly to a logging binary
+// It also sets the terminal option to true
+func TerminalBinaryIO(binary string, args map[string]string) Creator {
+	return func(_ string) (IO, error) {
+		uri, err := LogURIGenerator("binary", binary, args)
+		if err != nil {
+			return nil, err
+		}
+
+		res := uri.String()
+		return &logURI{
+			config: Config{
+				Stdout:   res,
+				Stderr:   res,
+				Terminal: true,
+			},
+		}, nil
+	}
 }


### PR DESCRIPTION
## PR Description

Windows requires that stderr is an empty string when running a container with TTY. In Containerd, [pkg/cio/io.go#L298:L302](https://github.com/containerd/containerd/blob/4a18adcfca4e37e829c0d3174bd04d4cbf222f9a/pkg/cio/io.go#L298:L302), the Stderr is set to a value, e.g.
```go
res = "binary:///C:/_xxx_/nerdctl.exe?_NERDCTL_INTERNAL_LOGGING=C%3A%5CProgramData%5Cnerdctl%5C052055e3"
``` 
which causes microsoft/hcsshim [service_internal.go#L127](https://github.com/microsoft/hcsshim/blob/8beabacfc2d21767a07c20f8dd5f9f3932dbf305/cmd/containerd-shim-runhcs-v1/service_internal.go#L127) to fail to create a new task.

To address this issue, we refactor `TerminalLogURI()` and `TerminalBinaryIO` functions by adding an optional parameter that specifies whether stderr should be set to an empty string when the terminal is used. This change will help avoid the "failed precondition" error when creating a new task on Windows.

**Bug reference:** 
#10415 : Refactor TerminalLogURI() to Support Optional Stderr Configuration for Terminal Compatibility on Windows 

**Related issues:**
nerdctl [bug #2966](https://github.com/containerd/nerdctl/issues/2966)