### PR TITLE
introspection: regenerate UUID if state is empty

### DIFF
--- a/plugins/services/introspection/local.go
+++ b/plugins/services/introspection/local.go
@@ -153,6 +153,9 @@ func (l *Local) getUUID() (string, error) {
 		}
 		return "", err
 	}
+	if len(data) == 0 {
+		return l.generateUUID()
+	}
 	u := string(data)
 	if _, err := uuid.Parse(u); err != nil {
 		return "", err


### PR DESCRIPTION
The /var/lib/containerd/io.containerd.grpc.v1.introspection/uuid file stores a UUID to identify the particular containerd daemon responding to requests.  The file should either exist with a UUID, or not exist. However, it has been observed that the file can be truncated with 0 bytes, which will then fail to be parsed as a valid UUID.

As a defensive practice, detect a 0-length file and overwrite with a new UUID rather than failing.

Fixes: https://github.com/containerd/containerd/issues/10491