### PR TITLE
Ensure /run/containerd gets created with correct perms

### DIFF
--- a/cmd/containerd/server/server.go
+++ b/cmd/containerd/server/server.go
@@ -88,6 +88,15 @@ func CreateTopLevelDirectories(config *srvconfig.Config) error {
 	if err := sys.MkdirAllWithACL(config.State, 0o711); err != nil {
 		return err
 	}
+	if config.State != defaults.DefaultStateDir {
+		// XXX: socketRoot in pkg/shim is hard-coded to the default state directory.
+		// See https://github.com/containerd/containerd/issues/10502#issuecomment-2249268582 for why it's set up that way.
+		// The default fifo directory in pkg/cio is also configured separately and defaults to the default state directory instead of the configured state directory.
+		// Make sure the default state directory is created with the correct permissions.
+		if err := sys.MkdirAllWithACL(defaults.DefaultStateDir, 0o711); err != nil {
+			return err
+		}
+	}
 
 	if config.TempDir != "" {
 		if err := sys.MkdirAllWithACL(config.TempDir, 0o711); err != nil {


### PR DESCRIPTION
**Issue:** https://github.com/containerd/containerd/issues/10502 (specifically [this comment](https://github.com/containerd/containerd/issues/10502#issuecomment-2251896725) about fixing the default state dir creation with expected perms 0711)

There are a couple directories that get created under the default
state directory ("/run/containerd") even when containerd is configured
to use a different location for its state directory. Create the default
state directory even if containerd is configured to use a different
state directory location. This ensure pkg/shim and pkg/fifo won't create
the default state directory with incorrect permissions when calling
os.MkdirAll for their respective subdirectories.