### PR TITLE
Make `StopPodSandbox` RPC idempotent

### DIFF
--- a/internal/cri/server/sandbox_stop.go
+++ b/internal/cri/server/sandbox_stop.go
@@ -34,8 +34,15 @@ import (
 func (c *criService) StopPodSandbox(ctx context.Context, r *runtime.StopPodSandboxRequest) (*runtime.StopPodSandboxResponse, error) {
 	sandbox, err := c.sandboxStore.Get(r.GetPodSandboxId())
 	if err != nil {
-		return nil, fmt.Errorf("an error occurred when try to find sandbox %q: %w",
-			r.GetPodSandboxId(), err)
+		if !errdefs.IsNotFound(err) {
+			return nil, fmt.Errorf("an error occurred when try to find sandbox %q: %w",
+				r.GetPodSandboxId(), err)
+		}
+
+		// The StopPodSandbox RPC is idempotent, and must not return an error
+		// if all relevant resources have already been reclaimed. Ref:
+		// https://github.com/kubernetes/cri-api/blob/c20fa40/pkg/apis/runtime/v1/api.proto#L45-L46
+		return &runtime.StopPodSandboxResponse{}, nil
 	}
 
 	if err := c.stopPodSandbox(ctx, sandbox); err != nil {


### PR DESCRIPTION
Similar to sandbox removal, the stop of a sandbox should be a noop if the sandbox has not been found.

Found during: https://github.com/kubernetes-sigs/cri-tools/pull/1535