### PR TITLE
KEP 4216: Implement support for image pull per runtime class

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -450,6 +450,11 @@ func (c *Client) Fetch(ctx context.Context, ref string, opts ...RemoteOpt) (imag
 	if err != nil {
 		return images.Image{}, err
 	}
+
+	return c.createNewImage(ctx, img)
+}
+
+func (c *Client) CreateImageInContainerd(ctx context.Context, img images.Image) (images.Image, error) {
 	return c.createNewImage(ctx, img)
 }
 
@@ -520,6 +525,9 @@ func (c *Client) GetImageWithPlatform(ctx context.Context, ref string, platform 
 	i, err := c.ImageService().Get(ctx, ref)
 	if err != nil {
 		return nil, err
+	}
+	if platform.OS == "" && platform.Architecture == "" {
+		platform = platforms.DefaultSpec()
 	}
 	return NewImageWithPlatform(c, i, platforms.Only(platform)), nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -64,6 +64,7 @@ import (
 	"github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
 	"github.com/containerd/typeurl/v2"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-spec/specs-go/features"
@@ -505,12 +506,22 @@ func (c *Client) Push(ctx context.Context, ref string, desc ocispec.Descriptor, 
 }
 
 // GetImage returns an existing image
+// TODO(kep 4216): Change function to use NewImageWithPlatform() as NewImage() always
+// uses host platform matcher
 func (c *Client) GetImage(ctx context.Context, ref string) (Image, error) {
 	i, err := c.ImageService().Get(ctx, ref)
 	if err != nil {
 		return nil, err
 	}
 	return NewImage(c, i), nil
+}
+
+func (c *Client) GetImageWithPlatform(ctx context.Context, ref string, platform imagespec.Platform) (Image, error) {
+	i, err := c.ImageService().Get(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	return NewImageWithPlatform(c, i, platforms.Only(platform)), nil
 }
 
 // ListImages returns all existing images

--- a/cmd/ctr/commands/images/import.go
+++ b/cmd/ctr/commands/images/import.go
@@ -243,9 +243,11 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 			}
 			platformMatcher = platforms.OnlyStrict(platSpec)
 			opts = append(opts, containerd.WithImportPlatform(platformMatcher))
+		} else if cliContext.Bool("all-platforms") {
+			opts = append(opts, containerd.WithAllPlatforms(cliContext.Bool("all-platforms")))
+		} else {
+			opts = append(opts, containerd.WithImportPlatform(platforms.Only(platforms.DefaultSpec())))
 		}
-
-		opts = append(opts, containerd.WithAllPlatforms(cliContext.Bool("all-platforms")))
 
 		if cliContext.Bool("discard-unpacked-layers") {
 			if cliContext.Bool("no-unpack") {

--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -222,6 +222,7 @@ command. As part of this process, we do the following:
 				fmt.Printf("image chain ID: %s\n", chainID)
 			}
 		}
+
 		_, err = client.CreateImageInContainerd(ctx, img)
 		if err != nil {
 			return fmt.Errorf("failed to create image entries in containerd")

--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -222,6 +222,11 @@ command. As part of this process, we do the following:
 				fmt.Printf("image chain ID: %s\n", chainID)
 			}
 		}
+		_, err = client.CreateImageInContainerd(ctx, img)
+		if err != nil {
+			return fmt.Errorf("failed to create image entries in containerd")
+		}
+
 		fmt.Printf("done: %s\t\n", time.Since(start))
 		return nil
 	},

--- a/integration/addition_gids_test.go
+++ b/integration/addition_gids_test.go
@@ -34,7 +34,7 @@ import (
 
 func TestAdditionalGids(t *testing.T) {
 	testImage := images.Get(images.BusyBox)
-	EnsureImageExists(t, testImage, "")
+	EnsureImageExists(t, testImage, *runtimeHandler)
 	type testCase struct {
 		description string
 		opts        []ContainerOpts

--- a/integration/addition_gids_test.go
+++ b/integration/addition_gids_test.go
@@ -34,7 +34,7 @@ import (
 
 func TestAdditionalGids(t *testing.T) {
 	testImage := images.Get(images.BusyBox)
-	EnsureImageExists(t, testImage)
+	EnsureImageExists(t, testImage, "")
 	type testCase struct {
 		description string
 		opts        []ContainerOpts

--- a/integration/container_event_test.go
+++ b/integration/container_event_test.go
@@ -79,7 +79,7 @@ func TestContainerEvents(t *testing.T) {
 
 	t.Logf("Step 2: CreateContainer and check events")
 	pauseImage := images.Get(images.Pause)
-	EnsureImageExists(t, pauseImage)
+	EnsureImageExists(t, pauseImage, "")
 	containerConfig := ContainerConfig(
 		"container1",
 		pauseImage,

--- a/integration/container_event_test.go
+++ b/integration/container_event_test.go
@@ -79,7 +79,7 @@ func TestContainerEvents(t *testing.T) {
 
 	t.Logf("Step 2: CreateContainer and check events")
 	pauseImage := images.Get(images.Pause)
-	EnsureImageExists(t, pauseImage, "")
+	EnsureImageExists(t, pauseImage, *runtimeHandler)
 	containerConfig := ContainerConfig(
 		"container1",
 		pauseImage,

--- a/integration/container_exec_test.go
+++ b/integration/container_exec_test.go
@@ -41,7 +41,7 @@ func TestContainerDrainExecIOAfterExit(t *testing.T) {
 		containerName = "test-container-exec"
 	)
 
-	EnsureImageExists(t, testImage, "")
+	EnsureImageExists(t, testImage, *runtimeHandler)
 
 	t.Log("Create a container")
 	cnConfig := ContainerConfig(

--- a/integration/container_exec_test.go
+++ b/integration/container_exec_test.go
@@ -41,7 +41,7 @@ func TestContainerDrainExecIOAfterExit(t *testing.T) {
 		containerName = "test-container-exec"
 	)
 
-	EnsureImageExists(t, testImage)
+	EnsureImageExists(t, testImage, "")
 
 	t.Log("Create a container")
 	cnConfig := ContainerConfig(

--- a/integration/container_log_test.go
+++ b/integration/container_log_test.go
@@ -44,7 +44,7 @@ func TestContainerLogWithoutTailingNewLine(t *testing.T) {
 		containerName = "test-container"
 	)
 
-	EnsureImageExists(t, testImage, "")
+	EnsureImageExists(t, testImage, *runtimeHandler)
 
 	t.Log("Create a container with log path")
 	cnConfig := ContainerConfig(
@@ -92,7 +92,7 @@ func TestLongContainerLog(t *testing.T) {
 		containerName = "test-container"
 	)
 
-	EnsureImageExists(t, testImage, "")
+	EnsureImageExists(t, testImage, *runtimeHandler)
 
 	t.Log("Create a container with log path")
 	config, err := CRIConfig()

--- a/integration/container_log_test.go
+++ b/integration/container_log_test.go
@@ -44,7 +44,7 @@ func TestContainerLogWithoutTailingNewLine(t *testing.T) {
 		containerName = "test-container"
 	)
 
-	EnsureImageExists(t, testImage)
+	EnsureImageExists(t, testImage, "")
 
 	t.Log("Create a container with log path")
 	cnConfig := ContainerConfig(
@@ -92,7 +92,7 @@ func TestLongContainerLog(t *testing.T) {
 		containerName = "test-container"
 	)
 
-	EnsureImageExists(t, testImage)
+	EnsureImageExists(t, testImage, "")
 
 	t.Log("Create a container with log path")
 	config, err := CRIConfig()

--- a/integration/container_restart_test.go
+++ b/integration/container_restart_test.go
@@ -30,7 +30,7 @@ func TestContainerRestart(t *testing.T) {
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox1", "restart")
 
 	pauseImage := images.Get(images.Pause)
-	EnsureImageExists(t, pauseImage)
+	EnsureImageExists(t, pauseImage, "")
 
 	t.Logf("Create a container config and run container in a pod")
 	containerConfig := ContainerConfig(
@@ -65,7 +65,7 @@ func TestFailedContainerRestart(t *testing.T) {
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox1", "restart")
 
 	pauseImage := images.Get(images.Pause)
-	EnsureImageExists(t, pauseImage)
+	EnsureImageExists(t, pauseImage, "")
 
 	t.Logf("Create a container config in a pod with a command that fails")
 	containerConfig := ContainerConfig(

--- a/integration/container_restart_test.go
+++ b/integration/container_restart_test.go
@@ -30,7 +30,7 @@ func TestContainerRestart(t *testing.T) {
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox1", "restart")
 
 	pauseImage := images.Get(images.Pause)
-	EnsureImageExists(t, pauseImage, "")
+	EnsureImageExists(t, pauseImage, *runtimeHandler)
 
 	t.Logf("Create a container config and run container in a pod")
 	containerConfig := ContainerConfig(
@@ -65,7 +65,7 @@ func TestFailedContainerRestart(t *testing.T) {
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox1", "restart")
 
 	pauseImage := images.Get(images.Pause)
-	EnsureImageExists(t, pauseImage, "")
+	EnsureImageExists(t, pauseImage, *runtimeHandler)
 
 	t.Logf("Create a container config in a pod with a command that fails")
 	containerConfig := ContainerConfig(

--- a/integration/container_stats_test.go
+++ b/integration/container_stats_test.go
@@ -35,7 +35,7 @@ func TestContainerStats(t *testing.T) {
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox1", "stats")
 
 	pauseImage := images.Get(images.Pause)
-	EnsureImageExists(t, pauseImage, "")
+	EnsureImageExists(t, pauseImage, *runtimeHandler)
 
 	t.Logf("Create a container config and run container in a pod")
 	containerConfig := ContainerConfig(
@@ -77,7 +77,7 @@ func TestContainerConsumedStats(t *testing.T) {
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox1", "stats")
 
 	testImage := images.Get(images.ResourceConsumer)
-	EnsureImageExists(t, testImage, "")
+	EnsureImageExists(t, testImage, *runtimeHandler)
 
 	t.Logf("Create a container config and run container in a pod")
 	containerConfig := ContainerConfig(
@@ -154,7 +154,7 @@ func TestContainerListStats(t *testing.T) {
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "running-pod", "statsls")
 
 	pauseImage := images.Get(images.Pause)
-	EnsureImageExists(t, pauseImage, "")
+	EnsureImageExists(t, pauseImage, *runtimeHandler)
 
 	t.Logf("Create a container config and run containers in a pod")
 	containerConfigMap := make(map[string]*runtime.ContainerConfig)
@@ -209,7 +209,7 @@ func TestContainerListStatsWithIdFilter(t *testing.T) {
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "running-pod", "statsls")
 
 	pauseImage := images.Get(images.Pause)
-	EnsureImageExists(t, pauseImage, "")
+	EnsureImageExists(t, pauseImage, *runtimeHandler)
 
 	t.Logf("Create a container config and run containers in a pod")
 	containerConfigMap := make(map[string]*runtime.ContainerConfig)
@@ -269,7 +269,7 @@ func TestContainerListStatsWithSandboxIdFilter(t *testing.T) {
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "running-pod", "statsls")
 
 	pauseImage := images.Get(images.Pause)
-	EnsureImageExists(t, pauseImage, "")
+	EnsureImageExists(t, pauseImage, *runtimeHandler)
 
 	t.Logf("Create a container config and run containers in a pod")
 	containerConfigMap := make(map[string]*runtime.ContainerConfig)
@@ -330,7 +330,7 @@ func TestContainerListStatsWithIdSandboxIdFilter(t *testing.T) {
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "running-pod", "statsls")
 
 	pauseImage := images.Get(images.Pause)
-	EnsureImageExists(t, pauseImage, "")
+	EnsureImageExists(t, pauseImage, *runtimeHandler)
 
 	t.Logf("Create container config and run containers in a pod")
 	containerConfigMap := make(map[string]*runtime.ContainerConfig)

--- a/integration/container_stats_test.go
+++ b/integration/container_stats_test.go
@@ -35,7 +35,7 @@ func TestContainerStats(t *testing.T) {
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox1", "stats")
 
 	pauseImage := images.Get(images.Pause)
-	EnsureImageExists(t, pauseImage)
+	EnsureImageExists(t, pauseImage, "")
 
 	t.Logf("Create a container config and run container in a pod")
 	containerConfig := ContainerConfig(
@@ -77,7 +77,7 @@ func TestContainerConsumedStats(t *testing.T) {
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox1", "stats")
 
 	testImage := images.Get(images.ResourceConsumer)
-	EnsureImageExists(t, testImage)
+	EnsureImageExists(t, testImage, "")
 
 	t.Logf("Create a container config and run container in a pod")
 	containerConfig := ContainerConfig(
@@ -154,7 +154,7 @@ func TestContainerListStats(t *testing.T) {
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "running-pod", "statsls")
 
 	pauseImage := images.Get(images.Pause)
-	EnsureImageExists(t, pauseImage)
+	EnsureImageExists(t, pauseImage, "")
 
 	t.Logf("Create a container config and run containers in a pod")
 	containerConfigMap := make(map[string]*runtime.ContainerConfig)
@@ -209,7 +209,7 @@ func TestContainerListStatsWithIdFilter(t *testing.T) {
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "running-pod", "statsls")
 
 	pauseImage := images.Get(images.Pause)
-	EnsureImageExists(t, pauseImage)
+	EnsureImageExists(t, pauseImage, "")
 
 	t.Logf("Create a container config and run containers in a pod")
 	containerConfigMap := make(map[string]*runtime.ContainerConfig)
@@ -269,7 +269,7 @@ func TestContainerListStatsWithSandboxIdFilter(t *testing.T) {
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "running-pod", "statsls")
 
 	pauseImage := images.Get(images.Pause)
-	EnsureImageExists(t, pauseImage)
+	EnsureImageExists(t, pauseImage, "")
 
 	t.Logf("Create a container config and run containers in a pod")
 	containerConfigMap := make(map[string]*runtime.ContainerConfig)
@@ -330,7 +330,7 @@ func TestContainerListStatsWithIdSandboxIdFilter(t *testing.T) {
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "running-pod", "statsls")
 
 	pauseImage := images.Get(images.Pause)
-	EnsureImageExists(t, pauseImage)
+	EnsureImageExists(t, pauseImage, "")
 
 	t.Logf("Create container config and run containers in a pod")
 	containerConfigMap := make(map[string]*runtime.ContainerConfig)

--- a/integration/container_stop_test.go
+++ b/integration/container_stop_test.go
@@ -47,7 +47,7 @@ func TestSharedPidMultiProcessContainerStop(t *testing.T) {
 				containerName = "test-container"
 			)
 
-			EnsureImageExists(t, testImage)
+			EnsureImageExists(t, testImage, "")
 
 			t.Log("Create a multi-process container")
 			cnConfig := ContainerConfig(
@@ -84,7 +84,7 @@ func TestContainerStopCancellation(t *testing.T) {
 		containerName = "test-container"
 	)
 
-	EnsureImageExists(t, testImage)
+	EnsureImageExists(t, testImage, "")
 
 	t.Log("Create a container which traps sigterm")
 	cnConfig := ContainerConfig(

--- a/integration/container_stop_test.go
+++ b/integration/container_stop_test.go
@@ -47,7 +47,7 @@ func TestSharedPidMultiProcessContainerStop(t *testing.T) {
 				containerName = "test-container"
 			)
 
-			EnsureImageExists(t, testImage, "")
+			EnsureImageExists(t, testImage, *runtimeHandler)
 
 			t.Log("Create a multi-process container")
 			cnConfig := ContainerConfig(
@@ -84,7 +84,7 @@ func TestContainerStopCancellation(t *testing.T) {
 		containerName = "test-container"
 	)
 
-	EnsureImageExists(t, testImage, "")
+	EnsureImageExists(t, testImage, *runtimeHandler)
 
 	t.Log("Create a container which traps sigterm")
 	cnConfig := ContainerConfig(

--- a/integration/container_update_resources_test.go
+++ b/integration/container_update_resources_test.go
@@ -163,7 +163,7 @@ func TestUpdateContainerResources_MemorySwap(t *testing.T) {
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "update-container-swap-resources")
 
 	pauseImage := images.Get(images.Pause)
-	EnsureImageExists(t, pauseImage)
+	EnsureImageExists(t, pauseImage, "")
 
 	memoryLimit := int64(128 * 1024 * 1024)
 	baseSwapLimit := int64(200 * 1024 * 1024)
@@ -230,7 +230,7 @@ func TestUpdateContainerResources_MemoryLimit(t *testing.T) {
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "update-container-resources")
 
 	pauseImage := images.Get(images.Pause)
-	EnsureImageExists(t, pauseImage)
+	EnsureImageExists(t, pauseImage, "")
 
 	expectedSwapLimit := func(memoryLimit int64) *int64 {
 		if criopts.SwapControllerAvailable() {
@@ -310,7 +310,7 @@ func TestUpdateContainerResources_StatusUpdated(t *testing.T) {
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "update-container-resources")
 
 	pauseImage := images.Get(images.Pause)
-	EnsureImageExists(t, pauseImage)
+	EnsureImageExists(t, pauseImage, "")
 
 	t.Log("Create a container with memory limit")
 	cnConfig := ContainerConfig(

--- a/integration/container_update_resources_test.go
+++ b/integration/container_update_resources_test.go
@@ -163,7 +163,7 @@ func TestUpdateContainerResources_MemorySwap(t *testing.T) {
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "update-container-swap-resources")
 
 	pauseImage := images.Get(images.Pause)
-	EnsureImageExists(t, pauseImage, "")
+	EnsureImageExists(t, pauseImage, *runtimeHandler)
 
 	memoryLimit := int64(128 * 1024 * 1024)
 	baseSwapLimit := int64(200 * 1024 * 1024)
@@ -230,7 +230,7 @@ func TestUpdateContainerResources_MemoryLimit(t *testing.T) {
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "update-container-resources")
 
 	pauseImage := images.Get(images.Pause)
-	EnsureImageExists(t, pauseImage, "")
+	EnsureImageExists(t, pauseImage, *runtimeHandler)
 
 	expectedSwapLimit := func(memoryLimit int64) *int64 {
 		if criopts.SwapControllerAvailable() {
@@ -310,7 +310,7 @@ func TestUpdateContainerResources_StatusUpdated(t *testing.T) {
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "update-container-resources")
 
 	pauseImage := images.Get(images.Pause)
-	EnsureImageExists(t, pauseImage, "")
+	EnsureImageExists(t, pauseImage, *runtimeHandler)
 
 	t.Log("Create a container with memory limit")
 	cnConfig := ContainerConfig(

--- a/integration/container_volume_test.go
+++ b/integration/container_volume_test.go
@@ -109,7 +109,7 @@ func TestContainerSymlinkVolumes(t *testing.T) {
 				containerMountPath = filepath.Clean("C:" + containerMountPath)
 			}
 
-			EnsureImageExists(t, testImage, "")
+			EnsureImageExists(t, testImage, *runtimeHandler)
 
 			t.Log("Create a container with a symlink volume mount")
 			cnConfig := ContainerConfig(

--- a/integration/container_volume_test.go
+++ b/integration/container_volume_test.go
@@ -109,7 +109,7 @@ func TestContainerSymlinkVolumes(t *testing.T) {
 				containerMountPath = filepath.Clean("C:" + containerMountPath)
 			}
 
-			EnsureImageExists(t, testImage)
+			EnsureImageExists(t, testImage, "")
 
 			t.Log("Create a container with a symlink volume mount")
 			cnConfig := ContainerConfig(

--- a/integration/container_without_image_ref_test.go
+++ b/integration/container_without_image_ref_test.go
@@ -35,7 +35,7 @@ func TestContainerLifecycleWithoutImageRef(t *testing.T) {
 		containerName = "test-container"
 	)
 
-	img := EnsureImageExists(t, testImage, "")
+	img := EnsureImageExists(t, testImage, *runtimeHandler)
 
 	t.Log("Create test container")
 	cnConfig := ContainerConfig(

--- a/integration/container_without_image_ref_test.go
+++ b/integration/container_without_image_ref_test.go
@@ -35,7 +35,7 @@ func TestContainerLifecycleWithoutImageRef(t *testing.T) {
 		containerName = "test-container"
 	)
 
-	img := EnsureImageExists(t, testImage)
+	img := EnsureImageExists(t, testImage, "")
 
 	t.Log("Create test container")
 	cnConfig := ContainerConfig(

--- a/integration/containerd_image_test.go
+++ b/integration/containerd_image_test.go
@@ -199,7 +199,7 @@ func TestContainerdImageInOtherNamespaces(t *testing.T) {
 	require.NoError(t, Consistently(checkImage, 100*time.Millisecond, time.Second))
 
 	PodSandboxConfigWithCleanup(t, "sandbox", "test")
-	EnsureImageExists(t, testImage)
+	EnsureImageExists(t, testImage, "")
 
 	t.Logf("cri plugin should see the image now")
 	img, err := imageService.ImageStatus(&runtime.ImageSpec{Image: testImage})

--- a/integration/containerd_image_test.go
+++ b/integration/containerd_image_test.go
@@ -199,7 +199,7 @@ func TestContainerdImageInOtherNamespaces(t *testing.T) {
 	require.NoError(t, Consistently(checkImage, 100*time.Millisecond, time.Second))
 
 	PodSandboxConfigWithCleanup(t, "sandbox", "test")
-	EnsureImageExists(t, testImage, "")
+	EnsureImageExists(t, testImage, *runtimeHandler)
 
 	t.Logf("cri plugin should see the image now")
 	img, err := imageService.ImageStatus(&runtime.ImageSpec{Image: testImage})
@@ -254,7 +254,7 @@ func TestContainerdSandboxImagePulledOutsideCRI(t *testing.T) {
 	require.NoError(t, Eventually(func() (bool, error) {
 		pimg, err = imageService.ImageStatus(&runtime.ImageSpec{Image: pauseImage})
 		return pimg != nil, err
-	}, time.Second, 10*time.Second))
+	}, time.Second, 20*time.Second))
 
 	t.Log("verify pinned field is set for pause image")
 	assert.True(t, pimg.Pinned)

--- a/integration/duplicate_name_test.go
+++ b/integration/duplicate_name_test.go
@@ -32,7 +32,7 @@ func TestDuplicateName(t *testing.T) {
 	require.Error(t, err)
 
 	pauseImage := images.Get(images.Pause)
-	EnsureImageExists(t, pauseImage, "")
+	EnsureImageExists(t, pauseImage, *runtimeHandler)
 
 	t.Logf("Create a container")
 	cnConfig := ContainerConfig(

--- a/integration/duplicate_name_test.go
+++ b/integration/duplicate_name_test.go
@@ -32,7 +32,7 @@ func TestDuplicateName(t *testing.T) {
 	require.Error(t, err)
 
 	pauseImage := images.Get(images.Pause)
-	EnsureImageExists(t, pauseImage)
+	EnsureImageExists(t, pauseImage, "")
 
 	t.Logf("Create a container")
 	cnConfig := ContainerConfig(

--- a/integration/image_load_test.go
+++ b/integration/image_load_test.go
@@ -70,7 +70,7 @@ func TestImageLoad(t *testing.T) {
 			return false, err
 		}
 		return img != nil, nil
-	}, 100*time.Millisecond, 10*time.Second))
+	}, 100*time.Millisecond, 20*time.Second))
 	require.Equal(t, []string{loadedImage}, img.RepoTags)
 
 	t.Logf("create a container with the loaded image")

--- a/integration/imagefs_info_test.go
+++ b/integration/imagefs_info_test.go
@@ -33,7 +33,7 @@ func TestImageFSInfo(t *testing.T) {
 	PodSandboxConfigWithCleanup(t, "running-pod", "imagefs")
 
 	t.Logf("Pull an image to make sure image fs is not empty")
-	EnsureImageExists(t, images.Get(images.BusyBox), "")
+	EnsureImageExists(t, images.Get(images.BusyBox), *runtimeHandler)
 
 	// It takes time to populate imagefs stats. Use eventually
 	// to check for a period of time.

--- a/integration/imagefs_info_test.go
+++ b/integration/imagefs_info_test.go
@@ -33,7 +33,7 @@ func TestImageFSInfo(t *testing.T) {
 	PodSandboxConfigWithCleanup(t, "running-pod", "imagefs")
 
 	t.Logf("Pull an image to make sure image fs is not empty")
-	EnsureImageExists(t, images.Get(images.BusyBox))
+	EnsureImageExists(t, images.Get(images.BusyBox), "")
 
 	// It takes time to populate imagefs stats. Use eventually
 	// to check for a period of time.

--- a/integration/issue7496_linux_test.go
+++ b/integration/issue7496_linux_test.go
@@ -61,7 +61,7 @@ func TestIssue7496(t *testing.T) {
 
 	t.Logf("Create a container config and run container in a pod")
 	pauseImage := images.Get(images.Pause)
-	EnsureImageExists(t, pauseImage, "")
+	EnsureImageExists(t, pauseImage, *runtimeHandler)
 
 	containerConfig := ContainerConfig("pausecontainer", pauseImage)
 	cnID, err := runtimeService.CreateContainer(sbID, containerConfig, sbConfig)

--- a/integration/issue7496_linux_test.go
+++ b/integration/issue7496_linux_test.go
@@ -61,7 +61,7 @@ func TestIssue7496(t *testing.T) {
 
 	t.Logf("Create a container config and run container in a pod")
 	pauseImage := images.Get(images.Pause)
-	EnsureImageExists(t, pauseImage)
+	EnsureImageExists(t, pauseImage, "")
 
 	containerConfig := ContainerConfig("pausecontainer", pauseImage)
 	cnID, err := runtimeService.CreateContainer(sbID, containerConfig, sbConfig)

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -751,7 +751,7 @@ func EnsureImageExists(t *testing.T, imageName string, runtimeHandler string) st
 	}
 
 	t.Logf("Pull test image %q", imageName)
-	imgID, err := imageService.PullImage(&runtime.ImageSpec{Image: imageName}, nil, nil, "")
+	imgID, err := imageService.PullImage(&runtime.ImageSpec{Image: imageName, RuntimeHandler: runtimeHandler}, nil, nil, "")
 	require.NoError(t, err)
 
 	return imgID

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -742,8 +742,8 @@ func RestartContainerd(t *testing.T, signal syscall.Signal) {
 
 // EnsureImageExists pulls the given image, ensures that no error was encountered
 // while pulling it.
-func EnsureImageExists(t *testing.T, imageName string) string {
-	img, err := imageService.ImageStatus(&runtime.ImageSpec{Image: imageName})
+func EnsureImageExists(t *testing.T, imageName string, runtimeHandler string) string {
+	img, err := imageService.ImageStatus(&runtime.ImageSpec{Image: imageName, RuntimeHandler: runtimeHandler})
 	require.NoError(t, err)
 	if img != nil {
 		t.Logf("Image %q already exists, not pulling.", imageName)

--- a/integration/nri_test.go
+++ b/integration/nri_test.go
@@ -667,7 +667,7 @@ func (tc *nriTest) startContainer(podID, name string, opts ...ContainerOpts) str
 	ctrCfg := ContainerConfig(name, "", opts...)
 	if ctrCfg.Image.Image == "" {
 		image := images.Get(images.BusyBox)
-		EnsureImageExists(tc.t, image)
+		EnsureImageExists(tc.t, image, "")
 		ctrCfg.Image.Image = image
 	}
 

--- a/integration/pod_dualstack_test.go
+++ b/integration/pod_dualstack_test.go
@@ -42,7 +42,7 @@ func TestPodDualStack(t *testing.T) {
 		containerName = "test-container"
 	)
 
-	EnsureImageExists(t, testImage)
+	EnsureImageExists(t, testImage, "")
 
 	t.Log("Create a container to print env")
 	var command ContainerOpts

--- a/integration/pod_dualstack_test.go
+++ b/integration/pod_dualstack_test.go
@@ -42,7 +42,7 @@ func TestPodDualStack(t *testing.T) {
 		containerName = "test-container"
 	)
 
-	EnsureImageExists(t, testImage, "")
+	EnsureImageExists(t, testImage, *runtimeHandler)
 
 	t.Log("Create a container to print env")
 	var command ContainerOpts

--- a/integration/pod_hostname_test.go
+++ b/integration/pod_hostname_test.go
@@ -91,7 +91,7 @@ func TestPodHostname(t *testing.T) {
 				containerName = "test-container"
 			)
 
-			EnsureImageExists(t, testImage, "")
+			EnsureImageExists(t, testImage, *runtimeHandler)
 
 			t.Log("Create a container to print env")
 			cnConfig := ContainerConfig(

--- a/integration/pod_hostname_test.go
+++ b/integration/pod_hostname_test.go
@@ -91,7 +91,7 @@ func TestPodHostname(t *testing.T) {
 				containerName = "test-container"
 			)
 
-			EnsureImageExists(t, testImage)
+			EnsureImageExists(t, testImage, "")
 
 			t.Log("Create a container to print env")
 			cnConfig := ContainerConfig(

--- a/integration/pod_userns_linux_test.go
+++ b/integration/pod_userns_linux_test.go
@@ -266,7 +266,7 @@ func TestPodUserNS(t *testing.T) {
 				containerName = "test-container"
 			)
 
-			EnsureImageExists(t, testImage, "")
+			EnsureImageExists(t, testImage, *runtimeHandler)
 
 			containerOpts := append(test.containerOpts,
 				WithLogPath(containerName),
@@ -368,7 +368,7 @@ func TestIssue10598(t *testing.T) {
 	containerName := "nginx-userns"
 	testImage := images.Get(images.Nginx)
 
-	EnsureImageExists(t, testImage, "")
+	EnsureImageExists(t, testImage, *runtimeHandler)
 
 	containerOpts := []ContainerOpts{
 		WithUserNamespace(containerID, hostID, size),

--- a/integration/pod_userns_linux_test.go
+++ b/integration/pod_userns_linux_test.go
@@ -266,7 +266,7 @@ func TestPodUserNS(t *testing.T) {
 				containerName = "test-container"
 			)
 
-			EnsureImageExists(t, testImage)
+			EnsureImageExists(t, testImage, "")
 
 			containerOpts := append(test.containerOpts,
 				WithLogPath(containerName),
@@ -368,7 +368,7 @@ func TestIssue10598(t *testing.T) {
 	containerName := "nginx-userns"
 	testImage := images.Get(images.Nginx)
 
-	EnsureImageExists(t, testImage)
+	EnsureImageExists(t, testImage, "")
 
 	containerOpts := []ContainerOpts{
 		WithUserNamespace(containerID, hostID, size),

--- a/integration/restart_test.go
+++ b/integration/restart_test.go
@@ -109,7 +109,7 @@ func TestContainerdRestart(t *testing.T) {
 		}()
 
 		pauseImage := images.Get(images.Pause)
-		EnsureImageExists(t, pauseImage, "")
+		EnsureImageExists(t, pauseImage, *runtimeHandler)
 
 		s.id = sid
 		for j := range s.containers {
@@ -159,7 +159,7 @@ func TestContainerdRestart(t *testing.T) {
 
 	t.Logf("Pull test images")
 	for _, image := range []string{images.Get(images.BusyBox), images.Get(images.Pause)} {
-		EnsureImageExists(t, image, "")
+		EnsureImageExists(t, image, *runtimeHandler)
 	}
 	imagesBeforeRestart, err := imageService.ListImages(nil)
 	assert.NoError(t, err)
@@ -221,7 +221,7 @@ func TestContainerdRestart(t *testing.T) {
 	for _, i1 := range imagesBeforeRestart {
 		found := false
 		for _, i2 := range imagesAfterRestart {
-			if i1.Id == i2.Id {
+			if i1.Id == i2.Id && i1.Spec.RuntimeHandler == i2.Spec.RuntimeHandler {
 				sort.Strings(i1.RepoTags)
 				sort.Strings(i1.RepoDigests)
 				sort.Strings(i2.RepoTags)

--- a/integration/restart_test.go
+++ b/integration/restart_test.go
@@ -109,7 +109,7 @@ func TestContainerdRestart(t *testing.T) {
 		}()
 
 		pauseImage := images.Get(images.Pause)
-		EnsureImageExists(t, pauseImage)
+		EnsureImageExists(t, pauseImage, "")
 
 		s.id = sid
 		for j := range s.containers {
@@ -159,7 +159,7 @@ func TestContainerdRestart(t *testing.T) {
 
 	t.Logf("Pull test images")
 	for _, image := range []string{images.Get(images.BusyBox), images.Get(images.Pause)} {
-		EnsureImageExists(t, image)
+		EnsureImageExists(t, image, "")
 	}
 	imagesBeforeRestart, err := imageService.ListImages(nil)
 	assert.NoError(t, err)

--- a/integration/sandbox_clean_remove_windows_test.go
+++ b/integration/sandbox_clean_remove_windows_test.go
@@ -236,6 +236,7 @@ func removeContainer(ctx context.Context, t *testing.T, client runtime.RuntimeSe
 
 // This test checks if create/stop and remove pods and containers work as expected
 func TestCreateContainer(t *testing.T) {
+	// time.Sleep(30 * time.Second)
 	testImage, err := getTestImage()
 	if err != nil {
 		t.Skip("skipping test, error: ", err)
@@ -261,7 +262,7 @@ func TestCreateContainer(t *testing.T) {
 	t.Cleanup(func() { removePodSandbox(ctx, t, client, sandBoxResponse.PodSandboxId) })
 	t.Cleanup(func() { stopPodSandbox(ctx, t, client, sandBoxResponse.PodSandboxId) })
 
-	EnsureImageExists(t, testImage)
+	EnsureImageExists(t, testImage, "")
 
 	t.Log("Create a container")
 	createCtrRequest := &runtime.CreateContainerRequest{

--- a/integration/sandbox_clean_remove_windows_test.go
+++ b/integration/sandbox_clean_remove_windows_test.go
@@ -262,7 +262,7 @@ func TestCreateContainer(t *testing.T) {
 	t.Cleanup(func() { removePodSandbox(ctx, t, client, sandBoxResponse.PodSandboxId) })
 	t.Cleanup(func() { stopPodSandbox(ctx, t, client, sandBoxResponse.PodSandboxId) })
 
-	EnsureImageExists(t, testImage, "")
+	EnsureImageExists(t, testImage, "runhcs-wcow-process")
 
 	t.Log("Create a container")
 	createCtrRequest := &runtime.CreateContainerRequest{

--- a/integration/truncindex_test.go
+++ b/integration/truncindex_test.go
@@ -36,7 +36,7 @@ func TestTruncIndex(t *testing.T) {
 	t.Logf("Pull an image")
 	var appImage = images.Get(images.BusyBox)
 
-	imgID := EnsureImageExists(t, appImage, "")
+	imgID := EnsureImageExists(t, appImage, *runtimeHandler)
 	imgTruncID := genTruncIndex(imgID)
 
 	t.Logf("Get image status by truncindex, truncID: %s", imgTruncID)

--- a/integration/truncindex_test.go
+++ b/integration/truncindex_test.go
@@ -36,7 +36,7 @@ func TestTruncIndex(t *testing.T) {
 	t.Logf("Pull an image")
 	var appImage = images.Get(images.BusyBox)
 
-	imgID := EnsureImageExists(t, appImage)
+	imgID := EnsureImageExists(t, appImage, "")
 	imgTruncID := genTruncIndex(imgID)
 
 	t.Logf("Get image status by truncindex, truncID: %s", imgTruncID)

--- a/integration/volume_copy_up_test.go
+++ b/integration/volume_copy_up_test.go
@@ -59,7 +59,7 @@ func TestVolumeCopyUp(t *testing.T) {
 	t.Logf("Create a sandbox")
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "volume-copy-up")
 
-	EnsureImageExists(t, testImage)
+	EnsureImageExists(t, testImage, "")
 
 	t.Logf("Create a container with volume-copy-up test image")
 	cnConfig := ContainerConfig(
@@ -179,7 +179,7 @@ func TestVolumeOwnership(t *testing.T) {
 	t.Logf("Create a sandbox")
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "volume-ownership")
 
-	EnsureImageExists(t, testImage)
+	EnsureImageExists(t, testImage, "")
 
 	t.Logf("Create a container with volume-ownership test image")
 	cnConfig := ContainerConfig(

--- a/integration/volume_copy_up_test.go
+++ b/integration/volume_copy_up_test.go
@@ -59,7 +59,7 @@ func TestVolumeCopyUp(t *testing.T) {
 	t.Logf("Create a sandbox")
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "volume-copy-up")
 
-	EnsureImageExists(t, testImage, "")
+	EnsureImageExists(t, testImage, *runtimeHandler)
 
 	t.Logf("Create a container with volume-copy-up test image")
 	cnConfig := ContainerConfig(
@@ -179,7 +179,7 @@ func TestVolumeOwnership(t *testing.T) {
 	t.Logf("Create a sandbox")
 	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "volume-ownership")
 
-	EnsureImageExists(t, testImage, "")
+	EnsureImageExists(t, testImage, *runtimeHandler)
 
 	t.Logf("Create a container with volume-ownership test image")
 	cnConfig := ContainerConfig(

--- a/integration/windows_device_test.go
+++ b/integration/windows_device_test.go
@@ -51,7 +51,7 @@ func TestWindowsDevice(t *testing.T) {
 		GUID_DEVINTERFACE_DISPLAY_ADAPTER = "5B45201D-F2F2-4F3B-85BB-30FF1F953599" //nolint:revive
 	)
 
-	EnsureImageExists(t, testImage, "")
+	EnsureImageExists(t, testImage, *runtimeHandler)
 
 	t.Log("Create a container to run the device test")
 	cnConfig := ContainerConfig(

--- a/integration/windows_device_test.go
+++ b/integration/windows_device_test.go
@@ -51,7 +51,7 @@ func TestWindowsDevice(t *testing.T) {
 		GUID_DEVINTERFACE_DISPLAY_ADAPTER = "5B45201D-F2F2-4F3B-85BB-30FF1F953599" //nolint:revive
 	)
 
-	EnsureImageExists(t, testImage)
+	EnsureImageExists(t, testImage, "")
 
 	t.Log("Create a container to run the device test")
 	cnConfig := ContainerConfig(

--- a/integration/windows_hostprocess_test.go
+++ b/integration/windows_hostprocess_test.go
@@ -179,7 +179,7 @@ func TestArgsEscapedImagesOnWindows(t *testing.T) {
 		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
 	})
 
-	EnsureImageExists(t, testImage, "")
+	EnsureImageExists(t, testImage, *runtimeHandler)
 
 	cnConfigWithCtrCmd := ContainerConfig(
 		containerName,

--- a/integration/windows_hostprocess_test.go
+++ b/integration/windows_hostprocess_test.go
@@ -47,7 +47,7 @@ var (
 // Tests to verify the Windows HostProcess
 func TestWindowsHostProcess(t *testing.T) {
 	pauseImage := images.Get(images.Pause)
-	EnsureImageExists(t, pauseImage, "")
+	EnsureImageExists(t, pauseImage, *runtimeHandler)
 
 	t.Run("run as Local Service", func(t *testing.T) {
 		runHostProcess(t, false, pauseImage, defaultAction, hpcContainerOpt, localServiceUsername, defaultCommand)
@@ -70,7 +70,7 @@ func TestWindowsHostProcess(t *testing.T) {
 	})
 	t.Run("run with a different os.version image", func(t *testing.T) {
 		image := "docker.io/e2eteam/busybox:1.29-windows-amd64-1909"
-		EnsureImageExists(t, image, "")
+		EnsureImageExists(t, image, *runtimeHandler)
 		runHostProcess(t, false, image, defaultAction, hpcContainerOpt, localServiceUsername, defaultCommand)
 	})
 	t.Run("run and check stats", func(t *testing.T) {

--- a/integration/windows_hostprocess_test.go
+++ b/integration/windows_hostprocess_test.go
@@ -47,7 +47,7 @@ var (
 // Tests to verify the Windows HostProcess
 func TestWindowsHostProcess(t *testing.T) {
 	pauseImage := images.Get(images.Pause)
-	EnsureImageExists(t, pauseImage)
+	EnsureImageExists(t, pauseImage, "")
 
 	t.Run("run as Local Service", func(t *testing.T) {
 		runHostProcess(t, false, pauseImage, defaultAction, hpcContainerOpt, localServiceUsername, defaultCommand)
@@ -70,7 +70,7 @@ func TestWindowsHostProcess(t *testing.T) {
 	})
 	t.Run("run with a different os.version image", func(t *testing.T) {
 		image := "docker.io/e2eteam/busybox:1.29-windows-amd64-1909"
-		EnsureImageExists(t, image)
+		EnsureImageExists(t, image, "")
 		runHostProcess(t, false, image, defaultAction, hpcContainerOpt, localServiceUsername, defaultCommand)
 	})
 	t.Run("run and check stats", func(t *testing.T) {
@@ -179,7 +179,7 @@ func TestArgsEscapedImagesOnWindows(t *testing.T) {
 		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
 	})
 
-	EnsureImageExists(t, testImage)
+	EnsureImageExists(t, testImage, "")
 
 	cnConfigWithCtrCmd := ContainerConfig(
 		containerName,

--- a/integration/windows_rootfs_size_test.go
+++ b/integration/windows_rootfs_size_test.go
@@ -46,7 +46,7 @@ func TestWindowsRootfsSize(t *testing.T) {
 		containerName = "test-container"
 	)
 
-	EnsureImageExists(t, testImage, "")
+	EnsureImageExists(t, testImage, *runtimeHandler)
 
 	t.Log("Create a container to run the rootfs size test")
 

--- a/integration/windows_rootfs_size_test.go
+++ b/integration/windows_rootfs_size_test.go
@@ -46,7 +46,7 @@ func TestWindowsRootfsSize(t *testing.T) {
 		containerName = "test-container"
 	)
 
-	EnsureImageExists(t, testImage)
+	EnsureImageExists(t, testImage, "")
 
 	t.Log("Create a container to run the rootfs size test")
 

--- a/internal/cri/server/container_checkpoint_linux.go
+++ b/internal/cri/server/container_checkpoint_linux.go
@@ -100,7 +100,7 @@ func (c *criService) CheckpointContainer(ctx context.Context, r *runtime.Checkpo
 	}
 
 	imageRef := container.ImageRef
-	image, err := c.GetImage(imageRef)
+	image, err := c.GetImage(imageRef, c.config.DefaultRuntimeName)
 	if err != nil {
 		return nil, fmt.Errorf("getting container image failed: %w", err)
 	}

--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -113,13 +113,13 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 
 	// Prepare container image snapshot. For container, the image should have
 	// been pulled before creating the container, so do not ensure the image.
-	image, err := c.LocalResolve(config.GetImage().GetImage())
+	image, err := c.LocalResolve(config.GetImage().GetImage(), sandbox.RuntimeHandler)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve image %q: %w", config.GetImage().GetImage(), err)
 	}
 	containerdImage, err := c.toContainerdImage(ctx, image)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get image from containerd %q: %w", image.ID, err)
+		return nil, fmt.Errorf("failed to get image from containerd %q: %w", image.Key.ID, err)
 	}
 	span.SetAttributes(
 		tracing.Attribute("container.image.ref", containerdImage.Name()),
@@ -166,7 +166,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 		// Create container image volumes mounts.
 		volumeMounts = c.volumeMounts(platform, containerRootDir, config, &image.ImageSpec.Config)
 	} else if len(image.ImageSpec.Config.Volumes) != 0 {
-		log.G(ctx).Debugf("Ignoring volumes defined in image %v because IgnoreImageDefinedVolumes is set", image.ID)
+		log.G(ctx).Debugf("Ignoring volumes defined in image %v because IgnoreImageDefinedVolumes is set", image.Key.ID)
 	}
 
 	ociRuntime, err := c.config.GetSandboxRuntime(sandboxConfig, sandbox.Metadata.RuntimeHandler)
@@ -249,7 +249,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 		}
 		opts = append(opts, customopts.WithVolumes(mountMap, platform))
 	}
-	meta.ImageRef = image.ID
+	meta.ImageRef = image.Key.ID
 	meta.StopSignal = image.ImageSpec.Config.StopSignal
 
 	// Validate log paths and compose full container log path.

--- a/internal/cri/server/container_status.go
+++ b/internal/cri/server/container_status.go
@@ -36,6 +36,10 @@ func (c *criService) ContainerStatus(ctx context.Context, r *runtime.ContainerSt
 	if err != nil {
 		return nil, fmt.Errorf("an error occurred when try to find container %q: %w", r.GetContainerId(), err)
 	}
+	sandbox, err := c.sandboxStore.Get(container.SandboxID)
+	if err != nil {
+		return nil, fmt.Errorf("an error occurred when try to find container's sandbox %q: %w", r.GetContainerId(), err)
+	}
 
 	// TODO(random-liu): Clean up the following logic in CRI.
 	// Current assumption:
@@ -44,7 +48,7 @@ func (c *criService) ContainerStatus(ctx context.Context, r *runtime.ContainerSt
 	// * ImageRef in container status is repo digest.
 	spec := container.Config.GetImage()
 	imageRef := container.ImageRef
-	image, err := c.GetImage(imageRef)
+	image, err := c.GetImage(imageRef, sandbox.RuntimeHandler)
 	if err != nil {
 		if !errdefs.IsNotFound(err) {
 			return nil, fmt.Errorf("failed to get image %q: %w", imageRef, err)

--- a/internal/cri/server/container_status_test.go
+++ b/internal/cri/server/container_status_test.go
@@ -70,7 +70,7 @@ func getContainerStatusTestData(t *testing.T) (*containerstore.Metadata, contain
 		CreatedAt: createdAt,
 	}
 	image := &imagestore.Image{
-		ID: imageID,
+		Key: imagestore.ImageIDKey{ID: imageID, RuntimeHandler: ""},
 		References: []string{
 			"gcr.io/library/busybox:latest",
 			"gcr.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",

--- a/internal/cri/server/container_status_test.go
+++ b/internal/cri/server/container_status_test.go
@@ -28,6 +28,7 @@ import (
 	snapshotstore "github.com/containerd/containerd/v2/internal/cri/store/snapshot"
 	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/typeurl/v2"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -290,17 +291,23 @@ func (s *fakeImageService) UpdateImage(ctx context.Context, r string) error { re
 
 func (s *fakeImageService) CheckImages(ctx context.Context) error { return nil }
 
-func (s *fakeImageService) GetImage(id string) (imagestore.Image, error) { return s.imageStore.Get(id) }
+func (s *fakeImageService) GetImage(id string, runtimeHandler string) (imagestore.Image, error) {
+	return s.imageStore.Get(id, runtimeHandler)
+}
 
 func (s *fakeImageService) GetSnapshot(key, snapshotter string) (snapshotstore.Snapshot, error) {
 	return snapshotstore.Snapshot{}, errors.New("not implemented")
 }
 
-func (s *fakeImageService) LocalResolve(refOrID string) (imagestore.Image, error) {
+func (s *fakeImageService) LocalResolve(refOrID string, runtimeHandler string) (imagestore.Image, error) {
 	return imagestore.Image{}, errors.New("not implemented")
 }
 
 func (s *fakeImageService) ImageFSPaths() map[string]string { return make(map[string]string) }
+
+func (s *fakeImageService) PlatformForRuntimeHandler(runtimeHandler string) imagespec.Platform {
+	return imagespec.Platform{}
+}
 
 func (s *fakeImageService) PullImage(context.Context, string, func(string) (string, string, error), *runtime.PodSandboxConfig, string) (string, error) {
 	return "", errors.New("not implemented")

--- a/internal/cri/server/container_stop.go
+++ b/internal/cri/server/container_stop.go
@@ -82,6 +82,10 @@ func (c *criService) stopContainer(ctx context.Context, container containerstore
 	start := time.Now()
 	id := container.ID
 	sandboxID := container.SandboxID
+	sandbox, err := c.sandboxStore.Get(sandboxID)
+	if err != nil {
+		return fmt.Errorf("an error occurred when try to find container's sandbox %q: %w", id, err)
+	}
 
 	// Return without error if container is not running. This makes sure that
 	// stop only takes real action after the container is started.
@@ -144,7 +148,7 @@ func (c *criService) stopContainer(ctx context.Context, container containerstore
 			// default SIGTERM is still better than returning error and leaving
 			// the container unstoppable. (See issue #990)
 			// TODO(random-liu): Remove this logic when containerd 1.2 is deprecated.
-			image, err := c.GetImage(container.ImageRef)
+			image, err := c.GetImage(container.ImageRef, sandbox.RuntimeHandler)
 			if err != nil {
 				if !errdefs.IsNotFound(err) {
 					return fmt.Errorf("failed to get image %q: %w", container.ImageRef, err)

--- a/internal/cri/server/helpers.go
+++ b/internal/cri/server/helpers.go
@@ -154,9 +154,10 @@ func criContainerStateToString(state runtime.ContainerState) string {
 func (c *criService) toContainerdImage(ctx context.Context, image imagestore.Image) (containerd.Image, error) {
 	// image should always have at least one reference.
 	if len(image.References) == 0 {
-		return nil, fmt.Errorf("invalid image with no reference %q", image.ID)
+		return nil, fmt.Errorf("invalid image with no reference %q", image.Key.ID)
 	}
-	return c.client.GetImage(ctx, image.References[0])
+	platform := c.PlatformForRuntimeHandler(image.Key.RuntimeHandler)
+	return c.client.GetImageWithPlatform(ctx, image.References[0], platform)
 }
 
 // getUserFromImage gets uid or user name of the image user.

--- a/internal/cri/server/images/check.go
+++ b/internal/cri/server/images/check.go
@@ -45,10 +45,6 @@ func (c *CRIImageService) CheckImages(ctx context.Context) error {
 			// Check if image name is a tuple of (ref, runtimeHandler). If it is not,
 			// use the default runtime handler
 			ref, runtimeHandler := RuntimeHandlerFromImageName(i.Name)
-			if runtimeHandler == "" {
-				// do nothing for root images
-				return
-			}
 			platformForRuntimeHandler := platforms.DefaultSpec()
 			if runtimeHandler != "" && c.config.RuntimePlatforms != nil {
 				if runtimePlatform, ok := c.config.RuntimePlatforms[runtimeHandler]; ok {

--- a/internal/cri/server/images/image_list_test.go
+++ b/internal/cri/server/images/image_list_test.go
@@ -32,7 +32,7 @@ func TestListImages(t *testing.T) {
 	_, c := newTestCRIService()
 	imagesInStore := []imagestore.Image{
 		{
-			ID:      "sha256:1123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			Key:     imagestore.ImageIDKey{ID: "sha256:1123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", RuntimeHandler: ""},
 			ChainID: "test-chainid-1",
 			References: []string{
 				"gcr.io/library/busybox:latest",
@@ -46,7 +46,7 @@ func TestListImages(t *testing.T) {
 			},
 		},
 		{
-			ID:      "sha256:2123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			Key:     imagestore.ImageIDKey{ID: "sha256:2123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", RuntimeHandler: ""},
 			ChainID: "test-chainid-2",
 			References: []string{
 				"gcr.io/library/alpine:latest",
@@ -60,7 +60,7 @@ func TestListImages(t *testing.T) {
 			},
 		},
 		{
-			ID:      "sha256:3123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			Key:     imagestore.ImageIDKey{ID: "sha256:3123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", RuntimeHandler: ""},
 			ChainID: "test-chainid-3",
 			References: []string{
 				"gcr.io/library/ubuntu:latest",

--- a/internal/cri/server/images/image_list_test.go
+++ b/internal/cri/server/images/image_list_test.go
@@ -81,6 +81,7 @@ func TestListImages(t *testing.T) {
 			RepoDigests: []string{"gcr.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582"},
 			Size_:       uint64(1000),
 			Username:    "root",
+			Spec:        &runtime.ImageSpec{Image: "sha256:1123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", RuntimeHandler: ""},
 		},
 		{
 			Id:          "sha256:2123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
@@ -88,6 +89,7 @@ func TestListImages(t *testing.T) {
 			RepoDigests: []string{"gcr.io/library/alpine@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582"},
 			Size_:       uint64(2000),
 			Uid:         &runtime.Int64Value{Value: 1234},
+			Spec:        &runtime.ImageSpec{Image: "sha256:2123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", RuntimeHandler: ""},
 		},
 		{
 			Id:          "sha256:3123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
@@ -95,6 +97,7 @@ func TestListImages(t *testing.T) {
 			RepoDigests: []string{"gcr.io/library/ubuntu@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582"},
 			Size_:       uint64(3000),
 			Username:    "nobody",
+			Spec:        &runtime.ImageSpec{Image: "sha256:3123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", RuntimeHandler: ""},
 		},
 	}
 

--- a/internal/cri/server/images/image_pull.go
+++ b/internal/cri/server/images/image_pull.go
@@ -193,7 +193,7 @@ func (c *CRIImageService) PullImage(ctx context.Context, name string, credential
 	)
 
 	defer pcancel()
-	snapshotter, platformForImagePull, err := c.snapshotterFromPodSandboxConfig(ctx, ref, sandboxConfig, runtimeHandler)
+	snapshotter, platformForImagePull, err := c.snapshotterFromPodSandboxConfig(ctx, sandboxConfig, runtimeHandler)
 	if err != nil {
 		return "", err
 	}
@@ -999,7 +999,7 @@ func (c *CRIImageService) getInfoFromRuntimePlatforms(ctx context.Context, criRu
 		return defaultSnapshotter, defaultPlatform, nil
 	}
 	if _, ok := c.runtimePlatforms[criRuntimeHandler]; !ok {
-		log.G(ctx).Debugf("invalid CRI runtimehandler %v", criRuntimeHandler)
+		log.G(ctx).Debugf("CRI runtimehandler %v not found in CRI image config. Falling back to default runtime %v", criRuntimeHandler, c.defaultRuntimeName)
 		return defaultSnapshotter, defaultPlatform, nil
 	}
 	imagePlatform := c.runtimePlatforms[criRuntimeHandler]
@@ -1010,7 +1010,7 @@ func (c *CRIImageService) getInfoFromRuntimePlatforms(ctx context.Context, criRu
 // Therefore, attempt to read the snapshot and runtimeHandler information from PullImageRequest
 // and if one was not specified, try to look for appropriate annotation key. If none are found,
 // return default values for snapshotter and runtime handler.
-func (c *CRIImageService) snapshotterFromPodSandboxConfig(ctx context.Context, imageRef string,
+func (c *CRIImageService) snapshotterFromPodSandboxConfig(ctx context.Context,
 	s *runtime.PodSandboxConfig, runtimeHandlerFromCRI string) (string, imagespec.Platform, error) {
 	snapshotter := c.config.Snapshotter
 	platform := platforms.DefaultSpec()

--- a/internal/cri/server/images/image_pull.go
+++ b/internal/cri/server/images/image_pull.go
@@ -36,12 +36,14 @@ import (
 	"github.com/containerd/imgcrypt/v2"
 	"github.com/containerd/imgcrypt/v2/images/encryption"
 	"github.com/containerd/log"
+	"github.com/containerd/platforms"
 	distribution "github.com/distribution/reference"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/diff"
+	"github.com/containerd/containerd/v2/core/images"
 	containerdimages "github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/remotes/docker"
 	"github.com/containerd/containerd/v2/core/remotes/docker/config"
@@ -52,6 +54,16 @@ import (
 	snpkg "github.com/containerd/containerd/v2/pkg/snapshotters"
 	"github.com/containerd/containerd/v2/pkg/tracing"
 )
+
+const (
+	gcExpirationLabel string = "containerd.io/gc.expire"
+	gcSnapshotLabel   string = "containerd.io/gc.ref.snapshot"
+	gcImageLabel      string = "containerd.io/gc.ref.image"
+	rootImageLabel    string = "containerd.io/root-image"
+	snapshotInfoLabel string = "containerd.io/snapshot-info"
+)
+
+var CtrdImageNameWithRuntimeHandler string = "%s,%s"
 
 // For image management:
 // 1) We have an in-memory metadata index to:
@@ -181,17 +193,25 @@ func (c *CRIImageService) PullImage(ctx context.Context, name string, credential
 	)
 
 	defer pcancel()
-	snapshotter, err := c.snapshotterFromPodSandboxConfig(ctx, ref, sandboxConfig)
+	snapshotter, err := c.snapshotterFromPodSandboxConfig(ctx, ref, sandboxConfig, runtimeHandler)
 	if err != nil {
 		return "", err
 	}
+
+	// Get which platform the image needs to be pulled for
+	platformForImagePull, err := c.platformForImagePullFromPodSandboxConfig(ctx, ref, sandboxConfig, runtimeHandler)
+	if err != nil {
+		return "", fmt.Errorf("failed to get platform information for pulling %v", ref)
+	}
+
 	log.G(ctx).Debugf("PullImage %q with snapshotter %s", ref, snapshotter)
 	span.SetAttributes(
 		tracing.Attribute("image.ref", ref),
 		tracing.Attribute("snapshotter.name", snapshotter),
+		tracing.Attribute("platformForImagePull", platformForImagePull),
 	)
 
-	labels := c.getLabels(ctx, ref)
+	labels := c.getLabels(ref)
 
 	pullOpts := []containerd.RemoteOpt{
 		containerd.WithSchema1Conversion, //nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
@@ -205,6 +225,7 @@ func (c *CRIImageService) PullImage(ctx context.Context, name string, credential
 			containerd.WithUnpackDuplicationSuppressor(c.unpackDuplicationSuppressor),
 			containerd.WithUnpackApplyOpts(diff.WithSyncFs(c.config.ImagePullWithSyncFs)),
 		}),
+		containerd.WithPlatformMatcher(platforms.Only(platformForImagePull)),
 	}
 
 	// Temporarily removed for v2 upgrade
@@ -246,7 +267,7 @@ func (c *CRIImageService) PullImage(ctx context.Context, name string, credential
 		// No need to use `updateImage`, because the image reference must
 		// have been managed by the cri plugin.
 		// TODO: Use image service directly
-		if err := c.imageStore.Update(ctx, r); err != nil {
+		if err := c.imageStore.Update(ctx, r, runtimeHandler); err != nil {
 			return "", fmt.Errorf("failed to update image store %q: %w", r, err)
 		}
 	}
@@ -316,6 +337,7 @@ func (c *CRIImageService) createOrUpdateImageReference(ctx context.Context, name
 		// Add a label to indicate that the image is managed by the cri plugin.
 		Labels: labels,
 	}
+
 	// TODO(random-liu): Figure out which is the more performant sequence create then update or
 	// update then create.
 	// TODO: Call CRIImageService directly
@@ -327,7 +349,7 @@ func (c *CRIImageService) createOrUpdateImageReference(ctx context.Context, name
 	}
 	// Retrieve oldImg from image store here because Create routine returns an
 	// empty image on ErrAlreadyExists
-	oldImg, err := c.images.Get(ctx, name)
+	oldImg, err := c.images.Get(ctx, img.Name)
 	if err != nil {
 		return err
 	}
@@ -347,7 +369,7 @@ func (c *CRIImageService) createOrUpdateImageReference(ctx context.Context, name
 }
 
 // getLabels get image labels to be added on CRI image
-func (c *CRIImageService) getLabels(ctx context.Context, name string) map[string]string {
+func (c *CRIImageService) getLabels(name string) map[string]string {
 	labels := map[string]string{crilabels.ImageLabelKey: crilabels.ImageLabelValue}
 	for _, pinned := range c.config.PinnedImages {
 		if pinned == name {
@@ -357,50 +379,204 @@ func (c *CRIImageService) getLabels(ctx context.Context, name string) map[string
 	return labels
 }
 
-// updateImage updates image store to reflect the newest state of an image reference
+// findMatchingRuntimeHandlers finds all the matching RuntimePlatforms with identical platform and snapshot strings
+func findMatchingRuntimeHandlers(platform imagespec.Platform, snapshot string, runtimePlatforms map[string]ImagePlatform) []string {
+	listOfRuntimeHandlers := []string{}
+	for runtimeHandler, runtimePlatform := range runtimePlatforms {
+		if runtimePlatform.Platform.Architecture == platform.Architecture &&
+			strings.Contains(platform.OSVersion, runtimePlatform.Platform.OSVersion) &&
+			runtimePlatform.Platform.OS == platform.OS &&
+			runtimePlatform.Snapshotter == snapshot {
+			listOfRuntimeHandlers = append(listOfRuntimeHandlers, runtimeHandler)
+		}
+	}
+	return listOfRuntimeHandlers
+}
+
+// updateCacheWithValidRuntimeHandlers finds all the matching runtimehandlers for a given image ref, adds new image labels and updates the containerd
+// metadata store with an entry each for (ref, runtimeHandler) tuple.
+// For every matching runtime handler, the following two new image labels are created:
+// a. New snapshot label to point to the unpacked image
+// b. New image label to point to the root image of this ref
+func (c *CRIImageService) updateCacheWithValidRuntimeHandlers(ctx context.Context, ref string, rootImg containerdimages.Image) error {
+	// 1. Walk the image from the root and record the corresponding platform, snapshot and snapshotID that the image has been unpacked for.
+	configDesc, platform, snapshot, snapshotID, err := images.FindImagePlatformAndSnapshotter(ctx, c.content, rootImg.Target)
+	if err != nil {
+		return fmt.Errorf("error finding platform/snapshot for image: %v. Err: %v, platform %v snapshot %v", ref, err, platform, snapshot)
+	}
+
+	// 2. Use the info from above to find all matching runtime handlers with identical platform and snapshot values defined in CRIImageService
+	// If there are no matching runtime handlers found, use default runtime handler defined.
+	runtimeHandlers := findMatchingRuntimeHandlers(platform, snapshot, c.runtimePlatforms)
+	if len(runtimeHandlers) == 0 {
+		runtimeHandlers = append(runtimeHandlers, c.defaultRuntimeName)
+	}
+
+	// Append new cri, snapshot and rootImgID labels as necessary.
+	newLabels := map[string]string{}
+	for key, val := range rootImg.Labels {
+		newLabels[key] = val
+	}
+	criLabels := c.getLabels(ref)
+	for key, value := range criLabels {
+		if newLabels[key] != value {
+			newLabels = criLabels
+			// labels of the rootImg are also updated
+			if rootImg.Labels == nil {
+				rootImg.Labels = map[string]string{}
+				rootImg.Labels = criLabels
+			}
+			break
+		}
+	}
+
+	// Construct additional image labels. The snapshot and rootImgID labels help to add references to
+	// the unpacked image and the root image entry's imageID. This prevents garbage collection from cleaning
+	// up the root image before all the image entries referencing it are removed.
+	snapshotLabel := fmt.Sprintf("%s.%s", gcSnapshotLabel, snapshot)
+	newLabels[snapshotLabel] = snapshotID
+	newLabels[gcImageLabel] = ref
+
+	for _, runtimeHandler := range runtimeHandlers {
+		if ref == "" {
+			continue
+		}
+
+		refNameWithRuntimeHandler := fmt.Sprintf(CtrdImageNameWithRuntimeHandler, ref, runtimeHandler)
+		_, err := c.client.GetImage(ctx, refNameWithRuntimeHandler)
+		if err != nil {
+			if !errdefs.IsNotFound(err) {
+				return fmt.Errorf("error getting containerd image by reference: %w", err)
+			}
+		} else {
+			continue
+		}
+
+		if err := c.createOrUpdateImageReference(ctx, refNameWithRuntimeHandler, rootImg.Target, newLabels); err != nil {
+			return fmt.Errorf("failed to create image reference %q: %w", refNameWithRuntimeHandler, err)
+		}
+		// Update image store to reflect the newest state in containerd.
+		// No need to use `updateImage`, because the image reference must
+		// have been managed by the cri plugin.
+		err = c.imageStore.Update(ctx, ref, runtimeHandler)
+		if err != nil {
+			return fmt.Errorf("failed to update CRI cache store for image %v: %w", refNameWithRuntimeHandler, err)
+		}
+	}
+
+	// On root image, add gc expiration label to facilitate GC
+	// to cleanup root image after all references to it have been removed.
+	fieldpaths := []string{"labels"}
+	if rootImg.Labels == nil {
+		rootImg.Labels = map[string]string{}
+	}
+	rootImg.Labels[gcExpirationLabel] = time.Now().Format(time.RFC3339)
+	// This label is used to mark the root image. Used in UpdateImage()
+	rootImg.Labels[rootImageLabel] = "nil"
+
+	_, err = c.images.Update(ctx, rootImg, fieldpaths...)
+	if err != nil {
+		return fmt.Errorf("failed to update labels on root image %v", rootImg.Name)
+	}
+
+	// Add a snapshot info label to the config to help subsequent calls identify snapshotID.
+	// Add label, update content store and then get rid of snapshot gc to avoid losing
+	// information as gc could kick in immediately.
+	// If GC snapshot label is removed without the snapshot info label, we will lose
+	// info to snapshot while walking image manifest/index.
+	cs := c.content
+	contentInfo, err := cs.Info(ctx, configDesc)
+	if err != nil {
+		return fmt.Errorf("error getting content store for image %v", configDesc.String())
+	}
+
+	csLabels := contentInfo.Labels
+	if csLabels != nil {
+		csLabels[fmt.Sprintf("%s.%s", snapshotInfoLabel, snapshot)] = snapshotID
+	}
+	_, err = cs.Update(ctx, contentInfo, fieldpaths...)
+	if err != nil {
+		return fmt.Errorf("error update content store labels for image %v", configDesc.String())
+	}
+
+	delete(csLabels, snapshotLabel)
+	_, err = cs.Update(ctx, contentInfo, fieldpaths...)
+	if err != nil {
+		return fmt.Errorf("error update content store labels for image %v", configDesc.String())
+	}
+
+	return nil
+}
+
+// RuntimeHandlerFromImageName returns the ref and runtimehandler if specified.
+// ref could be a tuple of (imageRef, runtimeHandler).
+// If no tuple was specified, "" is returned for runtimehandler.
+func RuntimeHandlerFromImageName(ref string) (string, string) {
+	strs := strings.Split(ref, ",")
+	if len(strs) == 2 && strs[1] != "" {
+		imageName := strs[0]
+		runtimeHandler := strs[1]
+		return imageName, runtimeHandler
+	}
+	return ref, ""
+}
+
+// UpdateImage updates image store to reflect the newest state of an image reference
 // in containerd. If the reference is not managed by the cri plugin, the function also
 // generates necessary metadata for the image and make it managed.
 func (c *CRIImageService) UpdateImage(ctx context.Context, r string) error {
+	// Check if this ref has runtimehandler associated with it
+	ref, runtimeHandler := RuntimeHandlerFromImageName(r)
+	if runtimeHandler != "" {
+		// TODO: Use image service
+		_, err := c.images.Get(ctx, r)
+		if err != nil {
+			if !errdefs.IsNotFound(err) {
+				return fmt.Errorf("get image by reference: %w", err)
+			}
+			// If the image is not found, we should continue updating the cache,
+			// so that all the image, runtimeHandler entries can be removed from the cri cache.
+			if err := c.imageStore.Update(ctx, ref, runtimeHandler); err != nil {
+				return fmt.Errorf("update image store for %q: %w", r, err)
+			}
+			return nil
+		}
+		// If entry for this tuple (ref, runtimehandler) was not found in containerd
+		// metadata store, then update CRI's image cache accordingly too.
+		err = c.imageStore.Update(ctx, ref, runtimeHandler)
+		if err != nil {
+			return fmt.Errorf("failed to update CRI image cache for image %q: %w", r, err)
+		}
+		return nil
+	}
+
 	// TODO: Use image service
-	img, err := c.client.GetImage(ctx, r)
+	rootImg, err := c.images.Get(ctx, r)
 	if err != nil {
 		if !errdefs.IsNotFound(err) {
 			return fmt.Errorf("get image by reference: %w", err)
 		}
-		// If the image is not found, we should continue updating the cache,
-		// so that the image can be removed from the cache.
-		if err := c.imageStore.Update(ctx, r); err != nil {
+		log.G(ctx).Debugf("Root image not found. Clean up CRI image cache")
+		// If the root image is not found, we are in a bad state. Remove all references
+		// for this image from CRI cache and return error
+		if err := c.imageStore.RemoveAllReferences(ctx, r); err != nil {
 			return fmt.Errorf("update image store for %q: %w", r, err)
 		}
 		return nil
 	}
 
-	labels := img.Labels()
-	criLabels := c.getLabels(ctx, r)
-	for key, value := range criLabels {
-		if labels[key] != value {
-			// Make sure the image has the image id as its unique
-			// identifier that references the image in its lifetime.
-			configDesc, err := img.Config(ctx)
-			if err != nil {
-				return fmt.Errorf("get image id: %w", err)
-			}
-			id := configDesc.Digest.String()
-			if err := c.createOrUpdateImageReference(ctx, id, img.Target(), criLabels); err != nil {
-				return fmt.Errorf("create image id reference %q: %w", id, err)
-			}
-			if err := c.imageStore.Update(ctx, id); err != nil {
-				return fmt.Errorf("update image store for %q: %w", id, err)
-			}
-			// The image id is ready, add the label to mark the image as managed.
-			if err := c.createOrUpdateImageReference(ctx, r, img.Target(), criLabels); err != nil {
-				return fmt.Errorf("create managed label: %w", err)
-			}
-			break
+	// If it has rootImage label set, do not continue as containerd image store
+	// would have already been updated with all the matching runtime handlers previously.
+	if rootImg.Labels != nil {
+		if _, ok := rootImg.Labels[rootImageLabel]; ok {
+			return nil
 		}
 	}
-	if err := c.imageStore.Update(ctx, r); err != nil {
-		return fmt.Errorf("update image store for %q: %w", r, err)
+
+	// Update containerd image store and CRI image cache for all valid runtimehandlers.
+	err = c.updateCacheWithValidRuntimeHandlers(ctx, r, rootImg)
+	if err != nil {
+		return fmt.Errorf("failed to update containerd and CRI image store for valid runtimehandlers: %v", err)
 	}
 	return nil
 }
@@ -775,7 +951,7 @@ func (rt *pullRequestReporterRoundTripper) RoundTrip(req *http.Request) (*http.R
 // Once we know the runtime, try to override default snapshotter if it is set for this runtime.
 // See https://github.com/containerd/containerd/issues/6657
 func (c *CRIImageService) snapshotterFromPodSandboxConfig(ctx context.Context, imageRef string,
-	s *runtime.PodSandboxConfig) (string, error) {
+	s *runtime.PodSandboxConfig, runtimeHandler string) (string, error) {
 	snapshotter := c.config.Snapshotter
 	if s == nil || s.Annotations == nil {
 		return snapshotter, nil
@@ -783,6 +959,14 @@ func (c *CRIImageService) snapshotterFromPodSandboxConfig(ctx context.Context, i
 
 	// TODO(kiashok): honor the new CRI runtime handler field added to v0.29.0
 	// for image pull per runtime class support.
+	if runtimeHandler != "" {
+		if imagePlatform, ok := c.runtimePlatforms[runtimeHandler]; ok && imagePlatform.Snapshotter != snapshotter {
+			return imagePlatform.Snapshotter, nil
+		} else {
+			return "", fmt.Errorf("invalid runtime handler %v", runtimeHandler)
+		}
+	}
+	// runtimeHandler from CRI was "", attempt to read runtimeHandler from annotations
 	runtimeHandler, ok := s.Annotations[annotations.RuntimeHandler]
 	if !ok {
 		return snapshotter, nil
@@ -797,4 +981,37 @@ func (c *CRIImageService) snapshotterFromPodSandboxConfig(ctx context.Context, i
 	}
 
 	return snapshotter, nil
+}
+
+// Gets the platform to use for image pull based on runtimeHandler passed from CRI.
+// If CRI runtime handler is empty, we attempt to check if annotations.RuntimeHandler
+// annotation was set for the pod. Else, the default platform for the host is returned.
+func (c *CRIImageService) platformForImagePullFromPodSandboxConfig(ctx context.Context, imageRef string,
+	s *runtime.PodSandboxConfig, runtimeHandler string) (imagespec.Platform, error) {
+	platform := platforms.DefaultSpec()
+
+	if runtimeHandler != "" {
+		if imagePlatform, ok := c.runtimePlatforms[runtimeHandler]; ok {
+			return imagePlatform.Platform, nil
+		} else {
+			return imagespec.Platform{}, fmt.Errorf("invalid runtime handler %v", runtimeHandler)
+		}
+	}
+
+	// runtimeHandler from CRI was "", attempt to read runtimeHandler from annotations
+	if s == nil || s.Annotations == nil {
+		return platform, nil
+	}
+
+	runtimeHandler, ok := s.Annotations[annotations.RuntimeHandler]
+	if !ok {
+		return platform, nil
+	}
+
+	if c.runtimePlatforms != nil {
+		if imagePlatform, ok := c.runtimePlatforms[runtimeHandler]; ok {
+			return imagePlatform.Platform, nil
+		}
+	}
+	return platform, nil
 }

--- a/internal/cri/server/images/image_pull.go
+++ b/internal/cri/server/images/image_pull.go
@@ -999,8 +999,8 @@ func (c *CRIImageService) getInfoFromRuntimePlatforms(ctx context.Context, criRu
 		return defaultSnapshotter, defaultPlatform, nil
 	}
 	if _, ok := c.runtimePlatforms[criRuntimeHandler]; !ok {
-		log.G(ctx).Debugf("CRI runtimehandler %v not found in CRI image config. Falling back to default runtime %v", criRuntimeHandler, c.defaultRuntimeName)
-		return defaultSnapshotter, defaultPlatform, nil
+		log.G(ctx).Debugf("CRI runtimehandler %v not found in CRI image config", criRuntimeHandler)
+		return defaultSnapshotter, defaultPlatform, fmt.Errorf("CRI runtimehandler %v not found in CRI image config", criRuntimeHandler)
 	}
 	imagePlatform := c.runtimePlatforms[criRuntimeHandler]
 	return imagePlatform.Snapshotter, imagePlatform.Platform, nil

--- a/internal/cri/server/images/image_pull_test.go
+++ b/internal/cri/server/images/image_pull_test.go
@@ -488,7 +488,7 @@ func TestImageGetLabels(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			criService.config.PinnedImages = tt.pinnedImages
-			labels := criService.getLabels(context.Background(), tt.pullImageName)
+			labels := criService.getLabels(tt.pullImageName)
 			assert.Equal(t, tt.expectedLabel, labels)
 
 		})

--- a/internal/cri/server/images/image_pull_test.go
+++ b/internal/cri/server/images/image_pull_test.go
@@ -429,7 +429,7 @@ func TestSnapshotterFromPodSandboxConfig(t *testing.T) {
 				Platform:    platforms.DefaultSpec(),
 				Snapshotter: runtimeSnapshotter,
 			}
-			snapshotter, _, err := cri.snapshotterFromPodSandboxConfig(context.Background(), "test-image", tt.podSandboxConfig, "")
+			snapshotter, _, err := cri.snapshotterFromPodSandboxConfig(context.Background(), tt.podSandboxConfig, "")
 			assert.Equal(t, tt.expectedSnapshotter, snapshotter)
 			if tt.expectedErr {
 				assert.Error(t, err)

--- a/internal/cri/server/images/image_pull_test.go
+++ b/internal/cri/server/images/image_pull_test.go
@@ -429,7 +429,7 @@ func TestSnapshotterFromPodSandboxConfig(t *testing.T) {
 				Platform:    platforms.DefaultSpec(),
 				Snapshotter: runtimeSnapshotter,
 			}
-			snapshotter, err := cri.snapshotterFromPodSandboxConfig(context.Background(), "test-image", tt.podSandboxConfig)
+			snapshotter, _, err := cri.snapshotterFromPodSandboxConfig(context.Background(), "test-image", tt.podSandboxConfig, "")
 			assert.Equal(t, tt.expectedSnapshotter, snapshotter)
 			if tt.expectedErr {
 				assert.Error(t, err)

--- a/internal/cri/server/images/image_remove.go
+++ b/internal/cri/server/images/image_remove.go
@@ -44,7 +44,13 @@ func (c *GRPCCRIImageService) RemoveImage(ctx context.Context, r *runtime.Remove
 func (c *CRIImageService) RemoveImage(ctx context.Context, imageSpec *runtime.ImageSpec) error {
 	span := tracing.SpanFromContext(ctx)
 
-	image, err := c.LocalResolve(imageSpec.GetImage())
+	// Use default runtime handler if none was passed
+	runtimeHandler := c.defaultRuntimeName
+	if imageSpec.GetRuntimeHandler() != "" {
+		runtimeHandler = imageSpec.GetRuntimeHandler()
+	}
+	// Find entry from CRI cache store
+	image, err := c.LocalResolve(imageSpec.GetImage(), runtimeHandler)
 	if err != nil {
 		if errdefs.IsNotFound(err) {
 			span.AddEvent(err.Error())
@@ -53,7 +59,7 @@ func (c *CRIImageService) RemoveImage(ctx context.Context, imageSpec *runtime.Im
 		}
 		return fmt.Errorf("can not resolve %q locally: %w", imageSpec.GetImage(), err)
 	}
-	span.SetAttributes(tracing.Attribute("image.id", image.ID))
+	span.SetAttributes(tracing.Attribute("image.id", image.Key.ID))
 	// Remove all image references.
 	for i, ref := range image.References {
 		var opts []images.DeleteOpt
@@ -63,15 +69,16 @@ func (c *CRIImageService) RemoveImage(ctx context.Context, imageSpec *runtime.Im
 			// someone else before this point.
 			opts = []images.DeleteOpt{images.SynchronousDelete()}
 		}
-		err = c.images.Delete(ctx, ref, opts...)
+		refNameWithRuntimeHandler := fmt.Sprintf(CtrdImageNameWithRuntimeHandler, ref, runtimeHandler)
+		err = c.images.Delete(ctx, refNameWithRuntimeHandler, opts...)
 		if err == nil || errdefs.IsNotFound(err) {
 			// Update image store to reflect the newest state in containerd.
-			if err := c.imageStore.Update(ctx, ref); err != nil {
-				return fmt.Errorf("failed to update image reference %q for %q: %w", ref, image.ID, err)
+			if err := c.imageStore.Update(ctx, ref, runtimeHandler); err != nil {
+				return fmt.Errorf("failed to update image reference %q for %q: %w", ref, image.Key.ID, err)
 			}
 			continue
 		}
-		return fmt.Errorf("failed to delete image reference %q for %q: %w", ref, image.ID, err)
+		return fmt.Errorf("failed to delete image reference %q for %q: %w", ref, image.Key.ID, err)
 	}
 	return nil
 }

--- a/internal/cri/server/images/image_remove.go
+++ b/internal/cri/server/images/image_remove.go
@@ -69,7 +69,7 @@ func (c *CRIImageService) RemoveImage(ctx context.Context, imageSpec *runtime.Im
 			// someone else before this point.
 			opts = []images.DeleteOpt{images.SynchronousDelete()}
 		}
-		refNameWithRuntimeHandler := fmt.Sprintf(CtrdImageNameWithRuntimeHandler, ref, runtimeHandler)
+		refNameWithRuntimeHandler := fmt.Sprintf(ctrdImageNameWithRuntimeHandler, ref, runtimeHandler)
 		err = c.images.Delete(ctx, refNameWithRuntimeHandler, opts...)
 		if err == nil || errdefs.IsNotFound(err) {
 			// Update image store to reflect the newest state in containerd.

--- a/internal/cri/server/images/image_status_test.go
+++ b/internal/cri/server/images/image_status_test.go
@@ -31,7 +31,7 @@ import (
 func TestImageStatus(t *testing.T) {
 	testID := "sha256:d848ce12891bf78792cda4a23c58984033b0c397a55e93a1556202222ecc5ed4" // #nosec G101
 	image := imagestore.Image{
-		ID:      testID,
+		Key:     imagestore.ImageIDKey{ID: testID, RuntimeHandler: ""},
 		ChainID: "test-chain-id",
 		References: []string{
 			"gcr.io/library/busybox:latest",

--- a/internal/cri/server/images/image_status_test.go
+++ b/internal/cri/server/images/image_status_test.go
@@ -49,6 +49,7 @@ func TestImageStatus(t *testing.T) {
 		RepoTags:    []string{"gcr.io/library/busybox:latest"},
 		RepoDigests: []string{"gcr.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582"},
 		Size_:       uint64(1234),
+		Spec:        &runtime.ImageSpec{Image: testID, RuntimeHandler: ""},
 		Username:    "user",
 	}
 

--- a/internal/cri/server/images/service.go
+++ b/internal/cri/server/images/service.go
@@ -54,6 +54,8 @@ type CRIImageService struct {
 	// images is the lower level image store used for raw storage,
 	// no event publishing should currently be assumed
 	images images.Store
+	// contentStore stores content information
+	content content.Store
 	// client is a subset of the containerd client
 	// and will be replaced by image store and transfer service
 	client imageClient
@@ -61,6 +63,8 @@ type CRIImageService struct {
 	imageFSPaths map[string]string
 	// runtimePlatforms are the platforms configured for a runtime.
 	runtimePlatforms map[string]ImagePlatform
+	// defaultRuntimeName is the default runtime handler name.
+	defaultRuntimeName string
 	// imageStore stores all resources associated with images.
 	imageStore *imagestore.Store
 	// snapshotStore stores information of all snapshots.
@@ -84,6 +88,8 @@ type CRIImageServiceOptions struct {
 
 	RuntimePlatforms map[string]ImagePlatform
 
+	DefaultRuntimeName string
+
 	Snapshotters map[string]snapshots.Snapshotter
 
 	Client imageClient
@@ -100,13 +106,19 @@ type CRIImageServiceOptions struct {
 //     - Content store (from metadata)
 //  3. Separate image cache and snapshot cache to first class plugins, make the snapshot cache much more efficient and intelligent
 func NewService(config criconfig.ImageConfig, options *CRIImageServiceOptions) (*CRIImageService, error) {
+	platformList := map[string]imagespec.Platform{}
+	for key, value := range config.RuntimePlatforms {
+		platformList[key], _ = platforms.Parse(value.Platform)
+	}
 	svc := CRIImageService{
 		config:                      config,
 		images:                      options.Images,
+		content:                     options.Content,
 		client:                      options.Client,
-		imageStore:                  imagestore.NewStore(options.Images, options.Content, platforms.Default()),
+		imageStore:                  imagestore.NewStore(options.Images, options.Content, options.DefaultRuntimeName, platformList),
 		imageFSPaths:                options.ImageFSPaths,
 		runtimePlatforms:            options.RuntimePlatforms,
+		defaultRuntimeName:          options.DefaultRuntimeName,
 		snapshotStore:               snapshotstore.NewStore(),
 		unpackDuplicationSuppressor: kmutex.New(),
 	}
@@ -124,7 +136,10 @@ func NewService(config criconfig.ImageConfig, options *CRIImageServiceOptions) (
 
 // LocalResolve resolves image reference locally and returns corresponding image metadata. It
 // returns errdefs.ErrNotFound if the reference doesn't exist.
-func (c *CRIImageService) LocalResolve(refOrID string) (imagestore.Image, error) {
+func (c *CRIImageService) LocalResolve(refOrID string, runtimeHandler string) (imagestore.Image, error) {
+	if runtimeHandler == "" {
+		runtimeHandler = c.defaultRuntimeName
+	}
 	getImageID := func(refOrId string) string {
 		if _, err := imagedigest.Parse(refOrID); err == nil {
 			return refOrID
@@ -136,7 +151,7 @@ func (c *CRIImageService) LocalResolve(refOrID string) (imagestore.Image, error)
 			if err != nil {
 				return ""
 			}
-			id, err := c.imageStore.Resolve(normalized.String())
+			id, err := c.imageStore.Resolve(normalized.String(), runtimeHandler)
 			if err != nil {
 				return ""
 			}
@@ -149,7 +164,7 @@ func (c *CRIImageService) LocalResolve(refOrID string) (imagestore.Image, error)
 		// Try to treat ref as imageID
 		imageID = refOrID
 	}
-	return c.imageStore.Get(imageID)
+	return c.imageStore.Get(imageID, runtimeHandler)
 }
 
 // RuntimeSnapshotter overrides the default snapshotter if Snapshotter is set for this runtime.
@@ -165,8 +180,12 @@ func (c *CRIImageService) RuntimeSnapshotter(ctx context.Context, ociRuntime cri
 }
 
 // GetImage gets image metadata by image id.
-func (c *CRIImageService) GetImage(id string) (imagestore.Image, error) {
-	return c.imageStore.Get(id)
+func (c *CRIImageService) GetImage(id string, runtimeHandler string) (imagestore.Image, error) {
+	// get platform that this image is wanted for
+	if runtimeHandler == "" {
+		runtimeHandler = c.defaultRuntimeName
+	}
+	return c.imageStore.Get(id, runtimeHandler)
 }
 
 // GetSnapshot returns the snapshot with specified key.
@@ -180,6 +199,16 @@ func (c *CRIImageService) GetSnapshot(key, snapshotter string) (snapshotstore.Sn
 
 func (c *CRIImageService) ImageFSPaths() map[string]string {
 	return c.imageFSPaths
+}
+
+func (c *CRIImageService) PlatformForRuntimeHandler(runtimeHandler string) imagespec.Platform {
+	platform := platforms.DefaultSpec()
+	if runtimeHandler != "" {
+		if imagePlatform, ok := c.config.RuntimePlatforms[runtimeHandler]; ok {
+			return platforms.MustParse(imagePlatform.Platform)
+		}
+	}
+	return platform
 }
 
 // PinnedImage is used to lookup a pinned image by name.

--- a/internal/cri/server/images/service_test.go
+++ b/internal/cri/server/images/service_test.go
@@ -58,9 +58,9 @@ var testImageConfig = criconfig.ImageConfig{
 	},
 }
 
-var defaultRuntimeNameForTest string = "test-runtime"
+var defaultRuntimeName = "test-runtime"
 var testContainerdConfig = criconfig.ContainerdConfig{
-	DefaultRuntimeName: defaultRuntimeNameForTest,
+	DefaultRuntimeName: defaultRuntimeName,
 }
 
 func TestLocalResolve(t *testing.T) {

--- a/internal/cri/server/images/service_test.go
+++ b/internal/cri/server/images/service_test.go
@@ -24,6 +24,8 @@ import (
 	imagestore "github.com/containerd/containerd/v2/internal/cri/store/image"
 	snapshotstore "github.com/containerd/containerd/v2/internal/cri/store/snapshot"
 	"github.com/containerd/errdefs"
+	"github.com/containerd/platforms"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -37,11 +39,13 @@ const (
 
 // newTestCRIService creates a fake criService for test.
 func newTestCRIService() (*CRIImageService, *GRPCCRIImageService) {
+	platformList := map[string]imagespec.Platform{}
+	platformList[testContainerdConfig.DefaultRuntimeName] = platforms.DefaultSpec()
 	service := &CRIImageService{
 		config:           testImageConfig,
 		runtimePlatforms: map[string]ImagePlatform{},
 		imageFSPaths:     map[string]string{"overlayfs": testImageFSPath},
-		imageStore:       imagestore.NewStore(nil, nil, "", nil),
+		imageStore:       imagestore.NewStore(nil, nil, testContainerdConfig.DefaultRuntimeName, platformList),
 		snapshotStore:    snapshotstore.NewStore(),
 	}
 
@@ -54,9 +58,14 @@ var testImageConfig = criconfig.ImageConfig{
 	},
 }
 
+var defaultRuntimeNameForTest string = "test-runtime"
+var testContainerdConfig = criconfig.ContainerdConfig{
+	DefaultRuntimeName: defaultRuntimeNameForTest,
+}
+
 func TestLocalResolve(t *testing.T) {
 	image := imagestore.Image{
-		ID:      "sha256:c75bebcdd211f41b3a460c7bf82970ed6c75acaab9cd4c9a4e125b03ca113799",
+		Key:     imagestore.ImageIDKey{ID: "sha256:c75bebcdd211f41b3a460c7bf82970ed6c75acaab9cd4c9a4e125b03ca113799", RuntimeHandler: ""},
 		ChainID: "test-chain-id-1",
 		References: []string{
 			"docker.io/library/busybox:latest",
@@ -84,11 +93,11 @@ func TestLocalResolve(t *testing.T) {
 		"docker.io/library/busybox:latest",
 		"docker.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
 	} {
-		img, err := c.LocalResolve(ref)
+		img, err := c.LocalResolve(ref, "")
 		assert.NoError(t, err)
 		assert.Equal(t, image, img)
 	}
-	img, err := c.LocalResolve("randomid")
+	img, err := c.LocalResolve("randomid", "")
 	assert.Equal(t, errdefs.IsNotFound(err), true)
 	assert.Equal(t, imagestore.Image{}, img)
 }

--- a/internal/cri/server/images/service_test.go
+++ b/internal/cri/server/images/service_test.go
@@ -24,7 +24,6 @@ import (
 	imagestore "github.com/containerd/containerd/v2/internal/cri/store/image"
 	snapshotstore "github.com/containerd/containerd/v2/internal/cri/store/snapshot"
 	"github.com/containerd/errdefs"
-	"github.com/containerd/platforms"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -42,7 +41,7 @@ func newTestCRIService() (*CRIImageService, *GRPCCRIImageService) {
 		config:           testImageConfig,
 		runtimePlatforms: map[string]ImagePlatform{},
 		imageFSPaths:     map[string]string{"overlayfs": testImageFSPath},
-		imageStore:       imagestore.NewStore(nil, nil, platforms.Default()),
+		imageStore:       imagestore.NewStore(nil, nil, "", nil),
 		snapshotStore:    snapshotstore.NewStore(),
 	}
 

--- a/internal/cri/server/podsandbox/controller.go
+++ b/internal/cri/server/podsandbox/controller.go
@@ -108,8 +108,8 @@ type RuntimeService interface {
 
 // ImageService specifies dependencies to CRI image service.
 type ImageService interface {
-	LocalResolve(refOrID string) (imagestore.Image, error)
-	GetImage(id string) (imagestore.Image, error)
+	LocalResolve(refOrID string, runtimeHandler string) (imagestore.Image, error)
+	GetImage(id string, runtimeHandler string) (imagestore.Image, error)
 	PullImage(ctx context.Context, name string, creds func(string) (string, string, error), sc *runtime.PodSandboxConfig, runtimeHandler string) (string, error)
 	RuntimeSnapshotter(ctx context.Context, ociRuntime criconfig.Runtime) string
 	PinnedImage(string) string

--- a/internal/cri/server/podsandbox/helpers.go
+++ b/internal/cri/server/podsandbox/helpers.go
@@ -64,7 +64,7 @@ func (c *Controller) getVolatileSandboxRootDir(id string) string {
 func (c *Controller) toContainerdImage(ctx context.Context, image imagestore.Image) (containerd.Image, error) {
 	// image should always have at least one reference.
 	if len(image.References) == 0 {
-		return nil, fmt.Errorf("invalid image with no reference %q", image.ID)
+		return nil, fmt.Errorf("invalid image with no reference %q", image.Key.ID)
 	}
 	return c.client.GetImage(ctx, image.References[0])
 }

--- a/internal/cri/server/podsandbox/sandbox_run.go
+++ b/internal/cri/server/podsandbox/sandbox_run.go
@@ -77,9 +77,10 @@ func (c *Controller) Start(ctx context.Context, id string) (cin sandbox.Controll
 
 	sandboxImage := c.getSandboxImageName()
 	// Ensure sandbox container image snapshot.
+	log.G(ctx).Debugf("sandbox runtimeHandler: %v", metadata.RuntimeHandler)
 	image, err := c.ensureImageExists(ctx, sandboxImage, config, metadata.RuntimeHandler)
 	if err != nil {
-		return cin, fmt.Errorf("failed to get sandbox image %q: %w", sandboxImage, err)
+		return cin, fmt.Errorf("failed to get sandbox image %q for runtimeHandler %v: %w", sandboxImage, metadata.RuntimeHandler, err)
 	}
 
 	containerdImage, err := c.toContainerdImage(ctx, *image)

--- a/internal/cri/server/podsandbox/sandbox_run.go
+++ b/internal/cri/server/podsandbox/sandbox_run.go
@@ -84,7 +84,7 @@ func (c *Controller) Start(ctx context.Context, id string) (cin sandbox.Controll
 
 	containerdImage, err := c.toContainerdImage(ctx, *image)
 	if err != nil {
-		return cin, fmt.Errorf("failed to get image from containerd %q: %w", image.ID, err)
+		return cin, fmt.Errorf("failed to get image from containerd %q: %w", image.Key.ID, err)
 	}
 
 	ociRuntime, err := c.config.GetSandboxRuntime(config, metadata.RuntimeHandler)
@@ -300,7 +300,7 @@ func (c *Controller) Create(_ctx context.Context, info sandbox.Sandbox, opts ...
 }
 
 func (c *Controller) ensureImageExists(ctx context.Context, ref string, config *runtime.PodSandboxConfig, runtimeHandler string) (*imagestore.Image, error) {
-	image, err := c.imageService.LocalResolve(ref)
+	image, err := c.imageService.LocalResolve(ref, runtimeHandler)
 	if err != nil && !errdefs.IsNotFound(err) {
 		return nil, fmt.Errorf("failed to get image %q: %w", ref, err)
 	}
@@ -313,7 +313,7 @@ func (c *Controller) ensureImageExists(ctx context.Context, ref string, config *
 	if err != nil {
 		return nil, fmt.Errorf("failed to pull image %q: %w", ref, err)
 	}
-	newImage, err := c.imageService.GetImage(imageID)
+	newImage, err := c.imageService.GetImage(imageID, runtimeHandler)
 	if err != nil {
 		// It's still possible that someone removed the image right after it is pulled.
 		return nil, fmt.Errorf("failed to get image %q after pulling: %w", imageID, err)

--- a/internal/cri/server/service.go
+++ b/internal/cri/server/service.go
@@ -102,12 +102,14 @@ type ImageService interface {
 
 	CheckImages(ctx context.Context) error
 
-	GetImage(id string) (imagestore.Image, error)
+	GetImage(id string, runtimeHandler string) (imagestore.Image, error)
 	GetSnapshot(key, snapshotter string) (snapshotstore.Snapshot, error)
 
-	LocalResolve(refOrID string) (imagestore.Image, error)
+	LocalResolve(refOrID string, runtimeHandler string) (imagestore.Image, error)
 
 	ImageFSPaths() map[string]string
+
+	PlatformForRuntimeHandler(runtimeHandler string) imagespec.Platform
 }
 
 // criService implements CRIService.

--- a/internal/cri/store/image/fake_image.go
+++ b/internal/cri/store/image/fake_image.go
@@ -20,15 +20,22 @@ import (
 	"fmt"
 
 	"github.com/containerd/platforms"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // NewFakeStore returns an image store with predefined images.
 // Update is not allowed for this fake store.
 func NewFakeStore(images []Image) (*Store, error) {
-	s := NewStore(nil, nil, platforms.Default())
+	s := NewStore(nil, nil, "", nil)
+	if s.platforms == nil {
+		s.platforms = make(map[string]imagespec.Platform)
+		s.platforms[s.defaultRuntimeName] = platforms.DefaultSpec()
+	}
 	for _, i := range images {
 		for _, ref := range i.References {
-			s.refCache[ref] = i.ID
+			refKey := RefKey{Ref: ref, RuntimeHandler: i.Key.RuntimeHandler}
+			imageIDKey := ImageIDKey{ID: i.Key.ID, RuntimeHandler: i.Key.RuntimeHandler}
+			s.refCache[refKey] = imageIDKey
 		}
 		if err := s.store.add(i); err != nil {
 			return nil, fmt.Errorf("add image %+v: %w", i, err)

--- a/internal/cri/store/image/image.go
+++ b/internal/cri/store/image/image.go
@@ -38,11 +38,26 @@ import (
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+type RefKey struct {
+	// Ref of the image
+	Ref string
+	// RuntimeHandler used for pulling this image
+	RuntimeHandler string
+}
+
+type ImageIDKey struct {
+	// Id of the image. Normally the digest of image config.
+	ID string
+	// RuntimeHandler used for pulling this image
+	RuntimeHandler string
+}
+
 // Image contains all resources associated with the image. All fields
 // MUST not be mutated directly after created.
 type Image struct {
 	// Id of the image. Normally the digest of image config.
-	ID string
+	// Key of the image - (ID, RuntimeHandler)
+	Key ImageIDKey
 	// References are references to the image, e.g. RepoTag and RepoDigest.
 	References []string
 	// ChainID is the chainID of the image.
@@ -63,8 +78,9 @@ type Getter interface {
 // Store stores all images.
 type Store struct {
 	lock sync.RWMutex
-	// refCache is a containerd image reference to image id cache.
-	refCache map[string]string
+
+	// refCache is a map of containerd image RefKey to ImageID key.
+	refCache map[RefKey]ImageIDKey
 
 	// images is the local image store
 	images Getter
@@ -72,94 +88,146 @@ type Store struct {
 	// content provider
 	provider content.InfoReaderProvider
 
-	// platform represents the currently supported platform for images
-	// TODO: Make this store multi-platform
-	platform platforms.MatchComparer
+	// platform is a map of platforms for each runtimehandler
+	platforms map[string]imagespec.Platform
+
+	// defaultRuntimeName is the default runtime handler name
+	defaultRuntimeName string
 
 	// store is the internal image store indexed by image id.
 	store *store
 }
 
+type store struct {
+	lock      sync.RWMutex
+	images    map[ImageIDKey]Image
+	digestSet *digestset.Set
+	// With image pull per runtime class, same image could now be
+	// pulled for different platforms. digestReferences keeps track
+	// of the list of imageIDKeys that are referencing this image.
+	// Images from CRI store are removed only if there are no
+	// more images references the image.
+	// digestReferences is map if image digest -> imageIDKey referencing the image.
+	digestReferences map[string]sets.Set[ImageIDKey]
+	// image digest -> RefKey
+	pinnedRefs map[string]sets.Set[RefKey]
+}
+
+var newImageNameFormat string = "%s,%s"
+
 // NewStore creates an image store.
-func NewStore(img Getter, provider content.InfoReaderProvider, platform platforms.MatchComparer) *Store {
+func NewStore(img Getter, provider content.InfoReaderProvider, defaultRuntimeName string, platforms map[string]imagespec.Platform) *Store {
 	return &Store{
-		refCache: make(map[string]string),
-		images:   img,
-		provider: provider,
-		platform: platform,
+		refCache:           make(map[RefKey]ImageIDKey),
+		images:             img,
+		provider:           provider,
+		defaultRuntimeName: defaultRuntimeName,
+		platforms:          platforms,
 		store: &store{
-			images:     make(map[string]Image),
-			digestSet:  digestset.NewSet(),
-			pinnedRefs: make(map[string]sets.Set[string]),
+			images:           make(map[ImageIDKey]Image),
+			digestSet:        digestset.NewSet(),
+			digestReferences: make(map[string]sets.Set[ImageIDKey]),
+			pinnedRefs:       make(map[string]sets.Set[RefKey]),
 		},
 	}
 }
 
 // Update updates cache for a reference.
-func (s *Store) Update(ctx context.Context, ref string) error {
+func (s *Store) Update(ctx context.Context, ref string, runtimeHandler string) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	i, err := s.images.Get(ctx, ref)
+	// Use default runtime handler is one was not specified
+	if runtimeHandler == "" {
+		runtimeHandler = s.defaultRuntimeName
+	}
+	imageNameWithRuntimeHandler := fmt.Sprintf(newImageNameFormat, ref, runtimeHandler)
+	_, err := s.images.Get(ctx, imageNameWithRuntimeHandler)
+	// If tuple (ref, runtimeHandler) is not found in containerd metadata store,
+	// just remove the entry from CRI cache.
+	if err != nil && errdefs.IsNotFound(err) {
+		refKey := RefKey{Ref: ref, RuntimeHandler: runtimeHandler}
+		return s.update(refKey, nil)
+	}
+
+	rootImg, err := s.images.Get(ctx, ref)
 	if err != nil && !errdefs.IsNotFound(err) {
-		return fmt.Errorf("get image from containerd: %w", err)
+		return fmt.Errorf("failed to get root image for ref %v, runtimeHandler %v with err: %v", ref, runtimeHandler, err)
 	}
 
 	var img *Image
 	if err == nil {
-		img, err = s.getImage(ctx, i)
+		img, err = s.getImage(ctx, rootImg, runtimeHandler)
 		if err != nil {
 			return fmt.Errorf("get image info from containerd: %w", err)
 		}
 	}
-	return s.update(ref, img)
+	refKey := RefKey{Ref: ref, RuntimeHandler: runtimeHandler}
+	return s.update(refKey, img)
+}
+
+// Remove all references from CRI image store cache, if the image was not
+// found in containerd image store.
+func (s *Store) RemoveAllReferences(ctx context.Context, ref string) error {
+	for refKey, imageIDKey := range s.refCache {
+		if refKey.Ref == ref {
+			// Remove the reference from the store.
+			s.store.delete(imageIDKey.ID, refKey)
+			delete(s.refCache, refKey)
+		}
+	}
+	return nil
 }
 
 // update updates the internal cache. img == nil means that
 // the image does not exist in containerd.
-func (s *Store) update(ref string, img *Image) error {
-	oldID, oldExist := s.refCache[ref]
+func (s *Store) update(refKey RefKey, img *Image) error {
+	oldImageIDKey, oldExist := s.refCache[refKey]
 	if img == nil {
 		// The image reference doesn't exist in containerd.
 		if oldExist {
 			// Remove the reference from the store.
-			s.store.delete(oldID, ref)
-			delete(s.refCache, ref)
+			s.store.delete(oldImageIDKey.ID, refKey)
+			delete(s.refCache, refKey)
 		}
 		return nil
 	}
 	if oldExist {
-		if oldID == img.ID {
-			if s.store.isPinned(img.ID, ref) == img.Pinned {
+		if oldImageIDKey.ID == img.Key.ID {
+			if s.store.isPinned(img.Key.ID, refKey) == img.Pinned {
 				return nil
 			}
 			if img.Pinned {
-				return s.store.pin(img.ID, ref)
+				return s.store.pin(img.Key.ID, refKey)
 			}
-			return s.store.unpin(img.ID, ref)
+			return s.store.unpin(img.Key.ID, refKey)
 		}
 		// Updated. Remove tag from old image.
-		s.store.delete(oldID, ref)
+		s.store.delete(oldImageIDKey.ID, refKey)
 	}
 	// New image. Add new image.
-	s.refCache[ref] = img.ID
+	s.refCache[refKey] = img.Key
 	return s.store.add(*img)
 }
 
-// getImage gets image information from containerd for current platform.
-func (s *Store) getImage(ctx context.Context, i images.Image) (*Image, error) {
-	diffIDs, err := i.RootFS(ctx, s.provider, s.platform)
+// getImage gets image information from containerd for current runtimeHandler.
+func (s *Store) getImage(ctx context.Context, i images.Image, runtimeHandler string) (*Image, error) {
+	if runtimeHandler == "" {
+		runtimeHandler = s.defaultRuntimeName
+	}
+	platformMatcher := platforms.Only(s.platforms[runtimeHandler])
+	diffIDs, err := i.RootFS(ctx, s.provider, platformMatcher)
 	if err != nil {
 		return nil, fmt.Errorf("get image diffIDs: %w", err)
 	}
 	chainID := imageidentity.ChainID(diffIDs)
 
-	size, err := usage.CalculateImageUsage(ctx, i, s.provider, usage.WithManifestLimit(s.platform, 1), usage.WithManifestUsage())
+	size, err := usage.CalculateImageUsage(ctx, i, s.provider, usage.WithManifestLimit(platformMatcher, 1), usage.WithManifestUsage())
 	if err != nil {
 		return nil, fmt.Errorf("get image compressed resource size: %w", err)
 	}
 
-	desc, err := i.Config(ctx, s.provider, s.platform)
+	desc, err := i.Config(ctx, s.provider, platformMatcher)
 	if err != nil {
 		return nil, fmt.Errorf("get image config descriptor: %w", err)
 	}
@@ -178,7 +246,7 @@ func (s *Store) getImage(ctx context.Context, i images.Image) (*Image, error) {
 	pinned := i.Labels[labels.PinnedImageLabelKey] == labels.PinnedImageLabelValue
 
 	return &Image{
-		ID:         id,
+		Key:        ImageIDKey{ID: id, RuntimeHandler: runtimeHandler},
 		References: []string{i.Name},
 		ChainID:    chainID.String(),
 		Size:       size,
@@ -189,33 +257,34 @@ func (s *Store) getImage(ctx context.Context, i images.Image) (*Image, error) {
 }
 
 // Resolve resolves a image reference to image id.
-func (s *Store) Resolve(ref string) (string, error) {
+func (s *Store) Resolve(ref string, runtimeHandler string) (string, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
-	id, ok := s.refCache[ref]
+
+	if runtimeHandler == "" {
+		runtimeHandler = s.defaultRuntimeName
+	}
+	refKey := RefKey{Ref: ref, RuntimeHandler: runtimeHandler}
+	imageIDKey, ok := s.refCache[refKey]
 	if !ok {
 		return "", errdefs.ErrNotFound
 	}
-	return id, nil
+	return imageIDKey.ID, nil
 }
 
 // Get gets image metadata by image id. The id can be truncated.
 // Returns various validation errors if the image id is invalid.
 // Returns errdefs.ErrNotFound if the image doesn't exist.
-func (s *Store) Get(id string) (Image, error) {
-	return s.store.get(id)
+func (s *Store) Get(imageID string, runtimeHandler string) (Image, error) {
+	if runtimeHandler == "" {
+		runtimeHandler = s.defaultRuntimeName
+	}
+	return s.store.get(imageID, runtimeHandler)
 }
 
 // List lists all images.
 func (s *Store) List() []Image {
 	return s.store.list()
-}
-
-type store struct {
-	lock       sync.RWMutex
-	images     map[string]Image
-	digestSet  *digestset.Set
-	pinnedRefs map[string]sets.Set[string]
 }
 
 func (s *store) list() []Image {
@@ -231,83 +300,96 @@ func (s *store) list() []Image {
 func (s *store) add(img Image) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	if _, err := s.digestSet.Lookup(img.ID); err != nil {
+	if _, err := s.digestSet.Lookup(img.Key.ID); err != nil {
 		if err != digestset.ErrDigestNotFound {
 			return err
 		}
-		if err := s.digestSet.Add(imagedigest.Digest(img.ID)); err != nil {
+		if err := s.digestSet.Add(imagedigest.Digest(img.Key.ID)); err != nil {
 			return err
 		}
 	}
 
+	if len(s.digestReferences[img.Key.ID]) == 0 {
+		s.digestReferences[img.Key.ID] = sets.New(img.Key)
+	} else {
+		s.digestReferences[img.Key.ID].Insert(img.Key)
+	}
+
 	if img.Pinned {
-		if refs := s.pinnedRefs[img.ID]; refs == nil {
-			s.pinnedRefs[img.ID] = sets.New(img.References...)
+		var refCacheKeys []RefKey
+		for _, references := range img.References {
+			refCacheKeys = append(refCacheKeys, RefKey{Ref: references, RuntimeHandler: img.Key.RuntimeHandler})
+		}
+
+		if refs := s.pinnedRefs[img.Key.ID]; refs == nil {
+			s.pinnedRefs[img.Key.ID] = sets.New(refCacheKeys...)
 		} else {
-			refs.Insert(img.References...)
+			refs.Insert(refCacheKeys...)
 		}
 	}
 
-	i, ok := s.images[img.ID]
+	i, ok := s.images[img.Key]
 	if !ok {
 		// If the image doesn't exist, add it.
-		s.images[img.ID] = img
+		s.images[img.Key] = img
 		return nil
 	}
 	// Or else, merge and sort the references.
 	i.References = docker.Sort(util.MergeStringSlices(i.References, img.References))
 	i.Pinned = i.Pinned || img.Pinned
-	s.images[img.ID] = i
+	s.images[img.Key] = i
 	return nil
 }
 
-func (s *store) isPinned(id, ref string) bool {
+func (s *store) isPinned(imageID string, refKey RefKey) bool {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
-	digest, err := s.digestSet.Lookup(id)
+	digest, err := s.digestSet.Lookup(imageID)
 	if err != nil {
 		return false
 	}
 	refs := s.pinnedRefs[digest.String()]
-	return refs != nil && refs.Has(ref)
+	return refs != nil && refs.Has(refKey)
 }
 
-func (s *store) pin(id, ref string) error {
+func (s *store) pin(imageID string, refKey RefKey) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	digest, err := s.digestSet.Lookup(id)
+	digest, err := s.digestSet.Lookup(imageID)
 	if err != nil {
 		if err == digestset.ErrDigestNotFound {
 			err = errdefs.ErrNotFound
 		}
 		return err
 	}
-	i, ok := s.images[digest.String()]
+	imageIDKey := ImageIDKey{ID: digest.String(), RuntimeHandler: refKey.RuntimeHandler}
+	i, ok := s.images[imageIDKey]
 	if !ok {
 		return errdefs.ErrNotFound
 	}
 
 	if refs := s.pinnedRefs[digest.String()]; refs == nil {
-		s.pinnedRefs[digest.String()] = sets.New(ref)
+		s.pinnedRefs[digest.String()] = sets.New(refKey)
 	} else {
-		refs.Insert(ref)
+		refs.Insert(refKey)
 	}
 	i.Pinned = true
-	s.images[digest.String()] = i
+	s.images[imageIDKey] = i
 	return nil
 }
 
-func (s *store) unpin(id, ref string) error {
+func (s *store) unpin(imageID string, refKey RefKey) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	digest, err := s.digestSet.Lookup(id)
+	digest, err := s.digestSet.Lookup(imageID)
 	if err != nil {
 		if err == digestset.ErrDigestNotFound {
 			err = errdefs.ErrNotFound
 		}
 		return err
 	}
-	i, ok := s.images[digest.String()]
+	imageIDKey := ImageIDKey{ID: digest.String(), RuntimeHandler: refKey.RuntimeHandler}
+	i, ok := s.images[imageIDKey]
 	if !ok {
 		return errdefs.ErrNotFound
 	}
@@ -316,63 +398,78 @@ func (s *store) unpin(id, ref string) error {
 	if refs == nil {
 		return nil
 	}
-	if refs.Delete(ref); len(refs) > 0 {
-		return nil
-	}
+	refs.Delete(refKey)
 
 	// delete unpinned image, we only need to keep the pinned
-	// entries in the map
-	delete(s.pinnedRefs, digest.String())
+	// entries in the map. Since an image digest can now be
+	// referenced by multiple platforms, we need to check that
+	// there are no more entries left before deleting.
+	if len(refs) == 0 {
+		delete(s.pinnedRefs, digest.String())
+	}
 	i.Pinned = false
-	s.images[digest.String()] = i
+	s.images[imageIDKey] = i
 	return nil
 }
 
-func (s *store) get(id string) (Image, error) {
+func (s *store) get(imageID string, runtimeHandler string) (Image, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
-	digest, err := s.digestSet.Lookup(id)
+	digest, err := s.digestSet.Lookup(imageID)
 	if err != nil {
 		if err == digestset.ErrDigestNotFound {
 			err = errdefs.ErrNotFound
 		}
 		return Image{}, err
 	}
-	if i, ok := s.images[digest.String()]; ok {
+	imageIDKey := ImageIDKey{ID: digest.String(), RuntimeHandler: runtimeHandler}
+	if i, ok := s.images[imageIDKey]; ok {
 		return i, nil
 	}
 	return Image{}, errdefs.ErrNotFound
 }
 
-func (s *store) delete(id, ref string) {
+func (s *store) delete(imageID string, refKey RefKey) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	digest, err := s.digestSet.Lookup(id)
+	digest, err := s.digestSet.Lookup(imageID)
 	if err != nil {
 		// Note: The idIndex.Delete and delete doesn't handle truncated index.
 		// So we need to return if there are error.
 		return
 	}
-	i, ok := s.images[digest.String()]
+	imageIDKey := ImageIDKey{ID: digest.String(), RuntimeHandler: refKey.RuntimeHandler}
+	i, ok := s.images[imageIDKey]
 	if !ok {
 		return
 	}
-	i.References = util.SubtractStringSlice(i.References, ref)
+	i.References = util.SubtractStringSlice(i.References, refKey.Ref)
 	if len(i.References) != 0 {
 		if refs := s.pinnedRefs[digest.String()]; refs != nil {
-			if refs.Delete(ref); len(refs) == 0 {
+			if refs.Delete(refKey); len(refs) == 0 {
+				// we are deleting the last ref for this platform, so
+				// set i.Pinned to false
 				i.Pinned = false
 				// delete unpinned image, we only need to keep the pinned
 				// entries in the map
 				delete(s.pinnedRefs, digest.String())
 			}
 		}
-
-		s.images[digest.String()] = i
+		s.images[imageIDKey] = i
 		return
 	}
+
+	// if i.References == 0, this is the last reference of this imageIdKey.
+	// Therefore, remove it from the list of digestReferences as well
+	delete(s.digestReferences[digest.String()], imageIDKey)
+	delete(s.images, imageIDKey)
+
 	// Remove the image if it is not referenced any more.
-	s.digestSet.Remove(digest)
-	delete(s.images, digest.String())
-	delete(s.pinnedRefs, digest.String())
+	if len(s.digestReferences[digest.String()]) == 0 {
+		s.digestSet.Remove(digest)
+	}
+
+	if len(s.pinnedRefs[digest.String()]) == 0 {
+		delete(s.pinnedRefs, digest.String())
+	}
 }

--- a/internal/cri/store/image/image.go
+++ b/internal/cri/store/image/image.go
@@ -45,7 +45,7 @@ type RefKey struct {
 	RuntimeHandler string
 }
 
-type ImageIDKey struct {
+type ImageIDKey struct { //revive:disable // type name will be used as image.ImageIDKey by other packages, and that stutters
 	// Id of the image. Normally the digest of image config.
 	ID string
 	// RuntimeHandler used for pulling this image
@@ -113,7 +113,7 @@ type store struct {
 	pinnedRefs map[string]sets.Set[RefKey]
 }
 
-var newImageNameFormat string = "%s,%s"
+var newImageNameFormat = "%s,%s"
 
 // NewStore creates an image store.
 func NewStore(img Getter, provider content.InfoReaderProvider, defaultRuntimeName string, platforms map[string]imagespec.Platform) *Store {
@@ -309,7 +309,11 @@ func (s *store) add(img Image) error {
 		}
 	}
 
-	if len(s.digestReferences[img.Key.ID]) == 0 {
+	if s.digestReferences == nil {
+		s.digestReferences = make(map[string]sets.Set[ImageIDKey])
+	}
+
+	if refs := (s.digestReferences[img.Key.ID]); refs == nil {
 		s.digestReferences[img.Key.ID] = sets.New(img.Key)
 	} else {
 		s.digestReferences[img.Key.ID].Insert(img.Key)

--- a/plugins/cri/images/plugin.go
+++ b/plugins/cri/images/plugin.go
@@ -104,6 +104,7 @@ func init() {
 				// Try a root in the same parent as this plugin
 				snapshotRoot = filepath.Join(filepath.Dir(ic.Properties[plugins.PropertyRootDir]), plugins.SnapshotPlugin.String()+"."+defaultSnapshotter)
 			}
+			options.DefaultRuntimeName = criconfig.DefaultRuntimeConfig().ContainerdConfig.DefaultRuntimeName
 			options.ImageFSPaths[defaultSnapshotter] = snapshotRoot
 			log.L.Infof("Get image filesystem path %q for snapshotter %q", snapshotRoot, defaultSnapshotter)
 

--- a/plugins/cri/images/plugin.go
+++ b/plugins/cri/images/plugin.go
@@ -133,7 +133,8 @@ func init() {
 				platform := platforms.DefaultSpec()
 				if rp.Platform != "" {
 					p, err := platforms.Parse(rp.Platform)
-					if err != nil {
+					// Platform specified for a specific runtime should have minimum of OS and arch specified.
+					if err != nil && isValidPlatformSpec(p) {
 						return nil, fmt.Errorf("unable to parse platform %q: %w", rp.Platform, err)
 					}
 					platform = p

--- a/plugins/cri/images/plugin_other.go
+++ b/plugins/cri/images/plugin_other.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package images
+
+import (
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func isValidPlatformSpec(platform specs.Platform) bool {
+	return platform.OS != "" && platform.Architecture != ""
+}

--- a/plugins/cri/images/plugin_windows.go
+++ b/plugins/cri/images/plugin_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package images
+
+import (
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func isValidPlatformSpec(platform specs.Platform) bool {
+	return platform.OS != "" && platform.Architecture != "" && platform.OSVersion != ""
+}

--- a/script/test/utils.sh
+++ b/script/test/utils.sh
@@ -103,6 +103,11 @@ if [ $IS_WINDOWS -eq 0 ]; then
 
   # Add runtime with failpoint
   cat << EOF | tee -a "${CONTAINERD_CONFIG_FILE}"
+# Needed to pull image for a given runtime class. See KEP4216
+[plugins."io.containerd.grpc.v1.images"]
+  [plugins."io.containerd.grpc.v1.images".runtime_platforms]
+    [plugins."io.containerd.cri.v1.images".runtime_platforms.runc-fp]
+      platform = "linux/amd64"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc-fp]
   cni_conf_dir = "${FAILPOINT_CNI_CONF_DIR}"
   cni_max_conf_num = 1

--- a/script/test/utils.sh
+++ b/script/test/utils.sh
@@ -23,6 +23,9 @@ if [ -v "OS" ] && [ "${OS}" == "Windows_NT" ]; then
   IS_WINDOWS=1
 fi
 
+GOARCH=$(go env GOARCH)
+GOOS=$(go env GOOS)
+
 # RESTART_WAIT_PERIOD is the period to wait before restarting containerd.
 RESTART_WAIT_PERIOD=${RESTART_WAIT_PERIOD:-10}
 
@@ -107,7 +110,11 @@ if [ $IS_WINDOWS -eq 0 ]; then
 [plugins."io.containerd.grpc.v1.images"]
   [plugins."io.containerd.grpc.v1.images".runtime_platforms]
     [plugins."io.containerd.cri.v1.images".runtime_platforms.runc-fp]
-      platform = "linux/amd64"
+      platform = "$GOOS/$GOARCH"
+    [plugins."io.containerd.cri.v1.images".runtime_platforms.runc]
+      platform = "$GOOS/$GOARCH"
+    [plugins."io.containerd.cri.v1.images".runtime_platforms.test]
+      platform = "$GOOS/$GOARCH"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc-fp]
   cni_conf_dir = "${FAILPOINT_CNI_CONF_DIR}"
   cni_max_conf_num = 1


### PR DESCRIPTION
Adds support for image pull per runtime class with the help of gc labels.
The image pull code path remains the same but during UpdateImage() call, the image index or manifest is walked to find the appropriate platform, snapshot the image was unpacked for. If such a match if found, find all matching runtime handlers with identical platform and snapshotter from CriConfig.RuntimePlatforms and update containerd and cri image stores appropriately.
New entry for tuple (ref,runtimehandler) is made in containerd metadata store and snapshot gc labels are added to take reference on unpacked snapshot. Further, image gc labels are also added to the root image to ensure appropriate resource cleanup.
This approach also makes the image delete and reload code paths simple.


P.S.: This PR is missing unit tests for the logic being added. If the general approach looks good, will add another commit to this PR with unit tests. 