### PR TITLE
[release/1.6] Revert "[release/1.7]: HPC working directory fix in pkg/cri/server code"

### DIFF
--- a/pkg/cri/server/container_create_windows.go
+++ b/pkg/cri/server/container_create_windows.go
@@ -64,8 +64,6 @@ func (c *criService) containerSpec(
 		specOpts = append(specOpts, oci.WithProcessCwd(config.GetWorkingDir()))
 	} else if imageConfig.WorkingDir != "" {
 		specOpts = append(specOpts, oci.WithProcessCwd(imageConfig.WorkingDir))
-	} else if cntrHpc {
-		specOpts = append(specOpts, oci.WithProcessCwd(`C:\hpc`))
 	}
 
 	if config.GetTty() {


### PR DESCRIPTION
This reverts commit 086e1f56e446740466b113a04f201e2040ae5a22 because HPCs in containerd/release/1.6 use Job objects and do not expect the default working directory to be `C:\hpc`.