### PR TITLE
use ctx object from cliContext instead of a creating a new one

### DIFF
--- a/cmd/containerd/command/config.go
+++ b/cmd/containerd/command/config.go
@@ -87,7 +87,8 @@ var configCommand = &cli.Command{
 			Name:  "default",
 			Usage: "See the output of the default config",
 			Action: func(cliContext *cli.Context) error {
-				return outputConfig(context.Background(), defaultConfig())
+				ctx := cliContext.Context
+				return outputConfig(ctx, defaultConfig())
 			},
 		},
 		{
@@ -95,7 +96,7 @@ var configCommand = &cli.Command{
 			Usage: "See the output of the final main config with imported in subconfig files",
 			Action: func(cliContext *cli.Context) error {
 				config := defaultConfig()
-				ctx := context.Background()
+				ctx := cliContext.Context
 				if err := srvconfig.LoadConfig(ctx, cliContext.String("config"), config); err != nil && !os.IsNotExist(err) {
 					return err
 				}
@@ -108,7 +109,7 @@ var configCommand = &cli.Command{
 			Usage: "Migrate the current configuration file to the latest version (does not migrate subconfig files)",
 			Action: func(cliContext *cli.Context) error {
 				config := defaultConfig()
-				ctx := context.Background()
+				ctx := cliContext.Context
 				if err := srvconfig.LoadConfig(ctx, cliContext.String("config"), config); err != nil && !os.IsNotExist(err) {
 					return err
 				}

--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -123,7 +123,7 @@ can be used and modified as necessary as a custom configuration.`
 			start       = time.Now()
 			signals     = make(chan os.Signal, 2048)
 			serverC     = make(chan *server.Server, 1)
-			ctx, cancel = context.WithCancel(context.Background())
+			ctx, cancel = context.WithCancel(cliContext.Context)
 			config      = defaultConfig()
 		)
 

--- a/cmd/containerd/command/publish.go
+++ b/cmd/containerd/command/publish.go
@@ -50,7 +50,7 @@ var publishCommand = &cli.Command{
 		},
 	},
 	Action: func(cliContext *cli.Context) error {
-		ctx := namespaces.WithNamespace(context.Background(), cliContext.String("namespace"))
+		ctx := namespaces.WithNamespace(cliContext.Context, cliContext.String("namespace"))
 		topic := cliContext.String("topic")
 		if topic == "" {
 			return fmt.Errorf("topic required to publish event: %w", errdefs.ErrInvalidArgument)

--- a/cmd/ctr/commands/client.go
+++ b/cmd/ctr/commands/client.go
@@ -35,7 +35,7 @@ import (
 // defined.
 func AppContext(cliContext *cli.Context) (context.Context, context.CancelFunc) {
 	var (
-		ctx       = context.Background()
+		ctx       = cliContext.Context
 		timeout   = cliContext.Duration("timeout")
 		namespace = cliContext.String("namespace")
 		cancel    context.CancelFunc


### PR DESCRIPTION
The `Context` struct from `urfave/cli` nests the `context.Context` struct. We should pass that context object as the parameter instead of instantiating a new one