### PR TITLE
[release/1.7 backport] script/setup/install-runc: fix runc using incorrect version

### DIFF
--- a/script/setup/install-runc
+++ b/script/setup/install-runc
@@ -37,7 +37,7 @@ function install_runc() {
 	git clone "${RUNC_REPO}" "${TMPROOT}"/runc
 	pushd "${TMPROOT}"/runc
 	git checkout "${RUNC_VERSION}"
-	make BUILDTAGS='seccomp' runc
+	env -u VERSION make BUILDTAGS='seccomp' runc
 	$SUDO make install
 	popd
 	rm -fR "${TMPROOT}"


### PR DESCRIPTION
- backport https://github.com/containerd/containerd/pull/10556
- fixes https://github.com/containerd/containerd/issues/10553




runc v1.1.13 introduced an option to customize the version (as printed by the `--version` flag) through a `VERSION` Make variable / environment variable (see [1]).

This variable collided with the `VERSION` environment variable used by containerd for the same purpose, which lead to `runc` binaries built using the version of containerd;

    runc --version
    runc version 1.7.20
    commit: v1.1.13-0-g58aa9203
    ...

This patch unsets the `VERSION` variable to bring prevent it from being inherited and to bring back the previous behavior.

Before this patch:

    docker build -t containerd-test -f contrib/Dockerfile.test .
    docker run -it --rm --env VERSION=1.7.20 containerd-test sh -c 'script/setup/install-runc && /usr/local/sbin/runc --version'
    # ....
    HEAD is now at 58aa9203 VERSION: release 1.1.13
    go build -trimpath "-buildmode=pie"  -tags "seccomp" -ldflags "-X main.gitCommit=v1.1.13-0-g58aa9203 -X main.version=1.7.20 " -o runc .
    install -D -m0755 runc /usr/local/sbin/runc
    /go/src/github.com/containerd/containerd
    runc version 1.7.20
    commit: v1.1.13-0-g58aa9203
    spec: 1.0.2-dev
    go: go1.22.5
    libseccomp: 2.5.4

With this patch:

    docker build -t containerd-test -f contrib/Dockerfile.test .
    docker run -it --rm --env VERSION=1.7.20 containerd-test sh -c 'script/setup/install-runc && /usr/local/sbin/runc --version'
    # ....
    HEAD is now at 58aa9203 VERSION: release 1.1.13
    go build -trimpath "-buildmode=pie"  -tags "seccomp" -ldflags "-X main.gitCommit=v1.1.13-0-g58aa9203 -X main.version=v1.1.13 " -o runc .
    install -D -m0755 runc /usr/local/sbin/runc
    /go/src/github.com/containerd/containerd
    runc version v1.1.13
    commit: v1.1.13-0-g58aa9203
    spec: 1.0.2-dev
    go: go1.22.5
    libseccomp: 2.5.4

[1]: https://github.com/opencontainers/runc/commit/6f4d975c402d7848f5097f53c18000aa42581def


(cherry picked from commit 349d2b5c151fc5fda830b76a42767fb869fffe02)