### PR TITLE
ctr: shim state for secondary tasks & shim state query for old shims

### DIFF
--- a/cmd/ctr/commands/shim/shim.go
+++ b/cmd/ctr/commands/shim/shim.go
@@ -28,7 +28,8 @@ import (
 	"strings"
 
 	"github.com/containerd/console"
-	"github.com/containerd/containerd/api/runtime/task/v3"
+	taskv2 "github.com/containerd/containerd/api/runtime/task/v2"
+	task "github.com/containerd/containerd/api/runtime/task/v3"
 	"github.com/containerd/containerd/v2/cmd/ctr/commands"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	ptypes "github.com/containerd/containerd/v2/pkg/protobuf/types"
@@ -122,22 +123,48 @@ var stateCommand = &cli.Command{
 			Aliases: []string{"t"},
 			Usage:   "task ID",
 		},
+		&cli.IntFlag{
+			Name:  "api-version",
+			Usage: "shim API version {2,3}",
+			Value: 3,
+			Action: func(c *cli.Context, v int) error {
+				if v != 2 && v != 3 {
+					return fmt.Errorf("api-version must be 2 or 3")
+				}
+				return nil
+			},
+		},
 	},
 	Action: func(cliContext *cli.Context) error {
-		service, err := getTaskService(cliContext)
-		if err != nil {
-			return err
-		}
 		id := cliContext.String("task-id")
 		if id == "" {
 			id = cliContext.String("id")
 		}
 
-		r, err := service.State(context.Background(), &task.StateRequest{
-			ID: id,
-		})
-		if err != nil {
-			return err
+		var r any
+		switch cliContext.Int("api-version") {
+		case 2:
+			service, err := getTaskServiceV2(cliContext)
+			if err != nil {
+				return err
+			}
+			r, err = service.State(context.Background(), &taskv2.StateRequest{
+				ID: id,
+			})
+			if err != nil {
+				return err
+			}
+		default:
+			service, err := getTaskService(cliContext)
+			if err != nil {
+				return err
+			}
+			r, err = service.State(context.Background(), &task.StateRequest{
+				ID: id,
+			})
+			if err != nil {
+				return err
+			}
 		}
 		commands.PrintAsJSON(r)
 		return nil
@@ -246,6 +273,21 @@ var execCommand = &cli.Command{
 }
 
 func getTaskService(cliContext *cli.Context) (task.TTRPCTaskService, error) {
+	client, err := getTTRPCClient(cliContext)
+	if err != nil {
+		return nil, err
+	}
+	return task.NewTTRPCTaskClient(client), nil
+}
+func getTaskServiceV2(cliContext *cli.Context) (taskv2.TaskService, error) {
+	client, err := getTTRPCClient(cliContext)
+	if err != nil {
+		return nil, err
+	}
+	return taskv2.NewTaskClient(client), nil
+}
+
+func getTTRPCClient(cliContext *cli.Context) (*ttrpc.Client, error) {
 	id := cliContext.String("id")
 	if id == "" {
 		return nil, fmt.Errorf("container id must be specified")
@@ -268,7 +310,7 @@ func getTaskService(cliContext *cli.Context) (task.TTRPCTaskService, error) {
 			// TODO(stevvooe): This actually leaks the connection. We were leaking it
 			// before, so may not be a huge deal.
 
-			return task.NewTTRPCTaskClient(client), nil
+			return client, nil
 		}
 	}
 

--- a/cmd/ctr/commands/shim/shim.go
+++ b/cmd/ctr/commands/shim/shim.go
@@ -67,7 +67,7 @@ var Command = &cli.Command{
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:  "id",
-			Usage: "Container id",
+			Usage: "shim ID",
 		},
 	},
 	Subcommands: []*cli.Command{
@@ -115,14 +115,26 @@ var deleteCommand = &cli.Command{
 
 var stateCommand = &cli.Command{
 	Name:  "state",
-	Usage: "Get the state of all the processes of the task",
+	Usage: "Get the state of all main process of the task",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "task-id",
+			Aliases: []string{"t"},
+			Usage:   "task ID",
+		},
+	},
 	Action: func(cliContext *cli.Context) error {
 		service, err := getTaskService(cliContext)
 		if err != nil {
 			return err
 		}
+		id := cliContext.String("task-id")
+		if id == "" {
+			id = cliContext.String("id")
+		}
+
 		r, err := service.State(context.Background(), &task.StateRequest{
-			ID: cliContext.String("id"),
+			ID: id,
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
`shim state` is useful for querying the state of a shim, but:

* non-primary tasks cannot be queried for shims that have grouping enabled
* the new `containerd.task.v3.Task` is not supported by old shims

These two commits make it possible to do this:

```
$ sudo ./ctr -n k8s.io shim --id 3b550a5e0de89fa884b3ff67c20e25fbf7c27ec993573396bc311d2d410b4679 state -t 202761c5d8438602627f6ef90919950601c43695684166ee6168937a014f935d --api-version 2
{
    "id": "202761c5d8438602627f6ef90919950601c43695684166ee6168937a014f935d",
    "bundle": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/202761c5d8438602627f6ef90919950601c43695684166ee6168937a014f935d",
    "pid": 57518,
    "status": 2,
    "stdout": "/run/containerd/io.containerd.grpc.v1.cri/containers/202761c5d8438602627f6ef90919950601c43695684166ee6168937a014f935d/io/673279966/202761c5d8438602627f6ef90919950601c43695684166ee6168937a014f935d-stdout",
    "stderr": "/run/containerd/io.containerd.grpc.v1.cri/containers/202761c5d8438602627f6ef90919950601c43695684166ee6168937a014f935d/io/673279966/202761c5d8438602627f6ef90919950601c43695684166ee6168937a014f935d-stderr",
    "exited_at": {
        "seconds": -62135596800
    }

```