### PR TITLE
Fix TestNewBinaryIOCleanup on Go 1.23 and Linux 5.4

### DIFF
--- a/cmd/containerd-shim-runc-v2/process/io_test.go
+++ b/cmd/containerd-shim-runc-v2/process/io_test.go
@@ -88,7 +88,8 @@ func descriptorCount(t *testing.T) int {
 			continue
 		}
 
-		if strings.HasPrefix(sym, "pidfd:") {
+		if strings.Contains(sym, "pidfd") {
+			// Either pidfd:[70517] or anon_inode:[pidfd] (on Linux 5.4)
 			files = append(files[:i], files[i+1:]...)
 		}
 	}


### PR DESCRIPTION
When running the test on Ubuntu focal (kernel version 5.4), the symlink for pidfd is anon_inode:[pidfd].

Updates: #10345