### PR TITLE
[release/1.6] Prepare release notes for v1.6.35

### DIFF
--- a/releases/v1.6.35.toml
+++ b/releases/v1.6.35.toml
@@ -1,0 +1,27 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.6.34"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The thirty-fifth patch release for containerd 1.6 contains various fixes
+and updates.
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.34+unknown"
+	Version = "1.6.35+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated notes

----

Welcome to the v1.6.35 release of containerd!

The thirty-fifth patch release for containerd 1.6 contains various fixes
and updates.

### Highlights

#### Deprecations

* deprecation: update warnings for CRI config fields ([#10525](https://github.com/containerd/containerd/pull/10525))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Phil Estes
* Samuel Karp
* Kazuyoshi Kato
* Kirtana Ashok
* Sascha Grunert
* Akihiro Suda
* Erikson Tung
* Iceber Gu
* Maksym Pavlenko
* Mauri de Souza Meneguzzo
* Sebastiaan van Stijn
* TinaMor
* Wei Fu
* rongfu.leng

### Changes
<details><summary>23 commits</summary>
<p>

  * [`849650ab7`](https://github.com/containerd/containerd/commit/849650ab7268ae16d659492d6f942eaca67ecbd3) Prepare release notes for v1.6.35
* Fix TestNewBinaryIOCleanup failing with gotip ([#10555](https://github.com/containerd/containerd/pull/10555))
  * [`4ec5cd6bd`](https://github.com/containerd/containerd/commit/4ec5cd6bd0c8d9a87ecade3812007b32e66232b2) Fix TestNewBinaryIOCleanup failing with gotip
* script/setup/install-runc: fix runc using incorrect version ([#10558](https://github.com/containerd/containerd/pull/10558))
  * [`9539b9b7b`](https://github.com/containerd/containerd/commit/9539b9b7b459dd01a1de6694639abd12dfe53361) script/setup/install-runc: fix runc using incorrect version
* Revert "[release/1.7]: HPC working directory fix in pkg/cri/server code" ([#10549](https://github.com/containerd/containerd/pull/10549))
  * [`c3c2b4eec`](https://github.com/containerd/containerd/commit/c3c2b4eec17844c3f3cbd7db9d9d03288ec36252) Revert "[release/1.7]: HPC working directory fix in pkg/cri/server code"
* update auths code comment ([#10537](https://github.com/containerd/containerd/pull/10537))
  * [`65cf37bcb`](https://github.com/containerd/containerd/commit/65cf37bcb49de11c2fd20fd21f76809739cb788d) update auths code comment
* Ensure /run/containerd gets created with correct perms ([#10535](https://github.com/containerd/containerd/pull/10535))
  * [`b1ef73e76`](https://github.com/containerd/containerd/commit/b1ef73e76a8913ae5347985647d576ea07873b9c) Ensure /run/containerd is created with correct perms
* Make `StopContainer` RPC idempotent ([#10530](https://github.com/containerd/containerd/pull/10530))
  * [`7134b03ba`](https://github.com/containerd/containerd/commit/7134b03ba546a9183bd7daf03ae5de56aeaad202) Make `StopContainer` RPC idempotent
* Make `StopPodSandbox` RPC idempotent ([#10531](https://github.com/containerd/containerd/pull/10531))
  * [`18ea8f288`](https://github.com/containerd/containerd/commit/18ea8f288ec87e3137d429adfc90c3a23e7277db) Make `StopPodSandbox` RPC idempotent
* deprecation: update warnings for CRI config fields ([#10525](https://github.com/containerd/containerd/pull/10525))
  * [`ed87e4787`](https://github.com/containerd/containerd/commit/ed87e47878e8cbcc3bc6df1cfd362ba18201f772) deprecation: update warnings for CRI config fields
* client: fix tasks with PID 0 cannot be forced to delete ([#10524](https://github.com/containerd/containerd/pull/10524))
  * [`5c8818782`](https://github.com/containerd/containerd/commit/5c8818782363935285f09b9ced3933c15baadfd8) client: fix tasks with PID 0 cannot be forced to delete
* introspection: regenerate UUID if state is empty ([#10511](https://github.com/containerd/containerd/pull/10511))
  * [`a4846fc0d`](https://github.com/containerd/containerd/commit/a4846fc0d30878e2869cccdd7d46693df474bd65) introspection: regenerate UUID if state is empty
* [Windows] Set stderr to empty string when using terminal on Windows ([#10500](https://github.com/containerd/containerd/pull/10500))
  * [`484705c62`](https://github.com/containerd/containerd/commit/484705c62156ed058e27f6f66d6bf77d13c65198) Set stderr to empty string when using terminal on Windows.
</p>
</details>

### Dependency Changes

This release has no dependency changes

Previous release can be found at [v1.6.34](https://github.com/containerd/containerd/releases/tag/v1.6.34)