### PR TITLE
[release/1.7] Ensure the CRIAPIV1Alpha2 warning's lastOccurrence is accurate

### DIFF
--- a/pkg/cri/instrument/instrumented_service.go
+++ b/pkg/cri/instrument/instrumented_service.go
@@ -105,13 +105,13 @@ func (in *instrumentedAlphaService) checkInitialized(ctx context.Context) error 
 
 // emitUsageWarning emits a warning when v1alpha2 cri-api is called.
 func (in *instrumentedAlphaService) emitUsageWarning(ctx context.Context) {
-	// Only emit the warning the first time an v1alpha2 api is called
+	// Only log the warning the first time an v1alpha2 api is called
 	in.emitWarning.Do(func() {
 		log.G(ctx).Warning("CRI API v1alpha2 is deprecated since containerd v1.7 and removed in containerd v2.0. Use CRI API v1 instead.")
-		if in.warn != nil {
-			in.warn.Emit(ctx, deprecation.CRIAPIV1Alpha2)
-		}
 	})
+	if in.warn != nil {
+		in.warn.Emit(ctx, deprecation.CRIAPIV1Alpha2)
+	}
 }
 
 func (in *instrumentedService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandboxRequest) (res *runtime.RunPodSandboxResponse, err error) {

--- a/pkg/cri/server/service_test.go
+++ b/pkg/cri/server/service_test.go
@@ -101,8 +101,9 @@ func TestAlphaCRIWarning(t *testing.T) {
 	c.Version(ctx, &v1alpha2.VersionRequest{})
 	c.Status(ctx, &v1alpha2.StatusRequest{})
 
-	// Only emit the warning the first time an v1alpha2 api is called.
+	// Emit warnings both times an v1alpha2 api is called.
 	expectedWarnings := []deprecation.Warning{
+		deprecation.CRIAPIV1Alpha2,
 		deprecation.CRIAPIV1Alpha2,
 	}
 	assert.Equal(t, expectedWarnings, ws.GetWarnings())


### PR DESCRIPTION
This helps gather more accurate API usage data that informs efforts on how to safely migrate containerd clients to 2.0.

/cc @samuelkarp @tallclair 

Tested manually on workstation.
```shell
# No output.
15:28:17 $ sudo bin/ctr -a /tmp/containerd.sock deprecations list --format=json

# Test client using v1alpha2 CRI API.
15:29:13 $ go run main.go

15:29:52 $ sudo bin/ctr -a /tmp/containerd.sock deprecations list --format=json
[
    {
        "id": "io.containerd.deprecation/cri-api-v1alpha2",
        "message": "CRI API v1alpha2 is deprecated since containerd v1.7 and removed in containerd v2.0. Use CRI API v1 instead.",
        "lastOccurrence": "2024-08-09T22:29:15.605544912Z"
    }
]

# Issued another v1alpha2 CRI API call.
15:30:38 $ go run main.go

# Last occurrence is updated.
15:31:02 $ sudo bin/ctr -a /tmp/containerd.sock deprecations list --format=json
[
    {
        "id": "io.containerd.deprecation/cri-api-v1alpha2",
        "message": "CRI API v1alpha2 is deprecated since containerd v1.7 and removed in containerd v2.0. Use CRI API v1 instead.",
        "lastOccurrence": "2024-08-09T22:30:40.515385572Z"
    }
]
```