### PR TITLE
Add go 1.23.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"ghcr.io/devcontainers/features/go:1": {
-			"version": "1.22.6"
+			"version": "1.23.0"
 		}
 	},
 

--- a/.github/actions/install-go/action.yml
+++ b/.github/actions/install-go/action.yml
@@ -3,7 +3,7 @@ description: "Reusable action to install Go, so there is one place to bump Go ve
 inputs:
   go-version:
     required: true
-    default: "1.22.6"
+    default: "1.23.0"
     description: "Go version to install"
 
 runs:

--- a/.github/workflows/api-release.yml
+++ b/.github/workflows/api-release.yml
@@ -6,7 +6,7 @@ on:
 name: API Release
 
 env:
-  GO_VERSION: "1.22.6"
+  GO_VERSION: "1.23.0"
 
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, actuated-arm64-4cpu-16gb, macos-12, windows-2019, windows-2022]
-        go-version: ["1.22.6"]
+        go-version: ["1.22.6", "1.23.0"]
         exclude:
           - os: ${{ github.repository != 'containerd/containerd' && 'actuated-arm64-4cpu-16gb' }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: ./.github/actions/install-go
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.59.1
+          version: v1.60.1
           skip-cache: true
           args: --timeout=8m
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 name: Release
 
 env:
-  GO_VERSION: "1.22.6"
+  GO_VERSION: "1.23.0"
 
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -104,7 +104,7 @@ EOF
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.22.6",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.23.0",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -29,7 +29,7 @@
 #   docker run --privileged containerd-test
 # ------------------------------------------------------------------------------
 
-ARG GOLANG_VERSION=1.22.6
+ARG GOLANG_VERSION=1.23.0
 ARG GOLANG_IMAGE=golang
 
 FROM ${GOLANG_IMAGE}:${GOLANG_VERSION} AS golang

--- a/contrib/fuzz/oss_fuzz_build.sh
+++ b/contrib/fuzz/oss_fuzz_build.sh
@@ -43,11 +43,11 @@ go run main.go --target_dir $SRC/containerd/images
 
 apt-get update && apt-get install -y wget
 cd $SRC
-wget --quiet https://go.dev/dl/go1.22.6.linux-amd64.tar.gz
+wget --quiet https://go.dev/dl/go1.23.0.linux-amd64.tar.gz
 
 mkdir temp-go
 rm -rf /root/.go/*
-tar -C temp-go/ -xzf go1.22.6.linux-amd64.tar.gz
+tar -C temp-go/ -xzf go1.23.0.linux-amd64.tar.gz
 mv temp-go/go/* /root/.go/
 cd $SRC/containerd
 

--- a/core/remotes/docker/fetcher_test.go
+++ b/core/remotes/docker/fetcher_test.go
@@ -22,6 +22,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -290,14 +291,14 @@ func TestDockerFetcherOpen(t *testing.T) {
 		{
 			name:           "should return just status if the registry request fails and does not return a docker error",
 			mockedStatus:   500,
-			mockedErr:      fmt.Errorf("Non-docker error"),
+			mockedErr:      errors.New("Non-docker error"),
 			want:           nil,
 			wantErr:        true,
 			wantPlainError: true,
 		}, {
 			name:           "should return StatusRequestTimeout after 5 retries",
 			mockedStatus:   http.StatusRequestTimeout,
-			mockedErr:      fmt.Errorf(http.StatusText(http.StatusRequestTimeout)),
+			mockedErr:      errors.New(http.StatusText(http.StatusRequestTimeout)),
 			want:           nil,
 			wantErr:        true,
 			wantPlainError: true,
@@ -305,7 +306,7 @@ func TestDockerFetcherOpen(t *testing.T) {
 		}, {
 			name:           "should return StatusTooManyRequests after 5 retries",
 			mockedStatus:   http.StatusTooManyRequests,
-			mockedErr:      fmt.Errorf(http.StatusText(http.StatusTooManyRequests)),
+			mockedErr:      errors.New(http.StatusText(http.StatusTooManyRequests)),
 			want:           nil,
 			wantErr:        true,
 			wantPlainError: true,

--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -488,13 +487,6 @@ func getLogDirPath(runtimeVersion, id string) string {
 func TestContainerAttach(t *testing.T) {
 	t.Parallel()
 
-	if runtime.GOOS == "windows" {
-		// On windows, closing the write side of the pipe closes the read
-		// side, sending an EOF to it and preventing reopening it.
-		// Hence this test will always fails on windows
-		t.Skip("invalid logic on windows")
-	}
-
 	client, err := newClient(t, address)
 	if err != nil {
 		t.Fatal(err)
@@ -667,13 +659,6 @@ func testContainerUser(t *testing.T, userstr, expectedOutput string) {
 func TestContainerAttachProcess(t *testing.T) {
 	t.Parallel()
 
-	if runtime.GOOS == "windows" {
-		// On windows, closing the write side of the pipe closes the read
-		// side, sending an EOF to it and preventing reopening it.
-		// Hence this test will always fails on windows
-		t.Skip("invalid logic on windows")
-	}
-
 	client, err := newClient(t, address)
 	if err != nil {
 		t.Fatal(err)
@@ -790,13 +775,6 @@ func TestContainerAttachProcess(t *testing.T) {
 
 func TestContainerLoadUnexistingProcess(t *testing.T) {
 	t.Parallel()
-
-	if runtime.GOOS == "windows" {
-		// On windows, closing the write side of the pipe closes the read
-		// side, sending an EOF to it and preventing reopening it.
-		// Hence this test will always fails on windows
-		t.Skip("invalid logic on windows")
-	}
 
 	client, err := newClient(t, address)
 	if err != nil {

--- a/internal/cleanup/context_test.go
+++ b/internal/cleanup/context_test.go
@@ -27,7 +27,7 @@ func TestBackground(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	var k struct{}
 	v := "incontext"
-	ctx = context.WithValue(ctx, k, v)
+	ctx = context.WithValue(ctx, k, v) //nolint:staticcheck
 
 	assert.Nil(t, contextError(ctx))
 	assert.Equal(t, ctx.Value(k), v)

--- a/internal/cri/server/container_checkpoint_linux.go
+++ b/internal/cri/server/container_checkpoint_linux.go
@@ -76,7 +76,7 @@ func (c *criService) CheckpointContainer(ctx context.Context, r *runtime.Checkpo
 			podCriuVersion,
 			r.GetContainerId(),
 		)
-		log.G(ctx).WithError(err).Errorf(errorMessage)
+		log.G(ctx).WithError(err).Error(errorMessage)
 		return nil, fmt.Errorf(
 			"%s: %w",
 			errorMessage,

--- a/pkg/filters/parser.go
+++ b/pkg/filters/parser.go
@@ -208,7 +208,7 @@ func (p *parser) field() (string, error) {
 	case tokenQuoted:
 		return p.unquote(pos, s, false)
 	case tokenIllegal:
-		return "", p.mkerr(pos, p.scanner.err)
+		return "", p.mkerr(pos, "%s", p.scanner.err)
 	}
 
 	return "", p.mkerr(pos, "expected field or quoted")
@@ -229,7 +229,7 @@ func (p *parser) operator() (operator, error) {
 			return 0, p.mkerr(pos, "unsupported operator %q", s)
 		}
 	case tokenIllegal:
-		return 0, p.mkerr(pos, p.scanner.err)
+		return 0, p.mkerr(pos, "%s", p.scanner.err)
 	}
 
 	return 0, p.mkerr(pos, `expected an operator ("=="|"!="|"~=")`)
@@ -244,7 +244,7 @@ func (p *parser) value(allowAltQuotes bool) (string, error) {
 	case tokenQuoted:
 		return p.unquote(pos, s, allowAltQuotes)
 	case tokenIllegal:
-		return "", p.mkerr(pos, p.scanner.err)
+		return "", p.mkerr(pos, "%s", p.scanner.err)
 	}
 
 	return "", p.mkerr(pos, "expected value or quoted")

--- a/plugins/services/content/contentserver/contentserver.go
+++ b/plugins/services/content/contentserver/contentserver.go
@@ -133,7 +133,7 @@ func (s *service) Delete(ctx context.Context, req *api.DeleteContentRequest) (*p
 	log.G(ctx).WithField("digest", req.Digest).Debugf("delete content")
 	dg, err := digest.Parse(req.Digest)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	if err := s.store.Delete(ctx, dg); err != nil {

--- a/script/setup/prepare_env_windows.ps1
+++ b/script/setup/prepare_env_windows.ps1
@@ -5,7 +5,7 @@
 # lived test environment.
 Set-MpPreference -DisableRealtimeMonitoring:$true
 
-$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.22.6"; make = ""; nssm = "" }
+$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.23.0"; make = ""; nssm = "" }
 
 Write-Host "Downloading chocolatey package"
 curl.exe -L "https://packages.chocolatey.org/chocolatey.0.10.15.nupkg" -o 'c:\choco.zip'


### PR DESCRIPTION
- add go1.23.0 to build and test matrix
- fix lint errors reported due to https://github.com/golang/go/issues/60529