### PR TITLE
[release/1.6] Fix TestNewBinaryIOCleanup on Go 1.23 and Linux 5.4

### DIFF
--- a/pkg/process/io_test.go
+++ b/pkg/process/io_test.go
@@ -89,7 +89,8 @@ func descriptorCount(t *testing.T) int {
 			continue
 		}
 
-		if strings.HasPrefix(sym, "pidfd:") {
+		if strings.Contains(sym, "pidfd") {
+			// Either pidfd:[70517] or anon_inode:[pidfd] (on Linux 5.4)
 			files = append(files[:i], files[i+1:]...)
 		}
 	}


### PR DESCRIPTION
When running the test on Ubuntu focal (kernel version 5.4), the symlink for pidfd is anon_inode:[pidfd].

Updates: #10345, #10555


(cherry picked from commit 8ef73c5dd50e89a7c2fdb92343e11be77660510a)

Backport #10562