### PR TITLE
[release/1.6] move builds to go1.22 and testing to go1.23

### DIFF
--- a/.github/actions/install-go/action.yml
+++ b/.github/actions/install-go/action.yml
@@ -3,7 +3,7 @@ description: "Reusable action to install Go, so there is one place to bump Go ve
 inputs:
   go-version:
     required: true
-    default: "1.21.13"
+    default: "1.22.6"
     description: "Go version to install"
 
 runs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, actuated-arm64-4cpu-16gb, macos-12, windows-2019, windows-2022]
-        go-version: ["1.21.13", "1.22.6"]
+        go-version: ["1.22.6", "1.23.0"]
     steps:
       - name: Install dependencies
         if: matrix.os == 'ubuntu-20.04' || matrix.os == 'actuated-arm64-4cpu-16gb'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 name: Containerd Release
 
 env:
-  GO_VERSION: "1.21.13"
+  GO_VERSION: "1.22.6"
 
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -14,7 +14,7 @@ This doc includes:
 
 To build the `containerd` daemon, and the `ctr` simple test client, the following build system dependencies are required:
 
-* Go 1.19.x or above
+* Go 1.22.x or above
 * Protoc 3.x compiler and headers (download at the [Google protobuf releases page](https://github.com/protocolbuffers/protobuf/releases))
 * Btrfs headers and libraries for your distribution. Note that building the btrfs driver can be disabled via the build tag `no_btrfs`, removing this dependency.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -96,7 +96,7 @@ EOF
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.21.13",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.22.6",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -10,7 +10,7 @@
 #
 # docker build -t containerd-test --build-arg RUNC_VERSION=v1.0.0-rc94 -f Dockerfile.test ../
 
-ARG GOLANG_VERSION=1.21.13
+ARG GOLANG_VERSION=1.22.6
 ARG GOLANG_IMAGE=golang
 
 FROM ${GOLANG_IMAGE}:${GOLANG_VERSION} AS golang

--- a/script/setup/install-dev-tools
+++ b/script/setup/install-dev-tools
@@ -26,7 +26,11 @@ go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
 
 # the following packages need to exist in $GOPATH so we can't use
 # go modules-aware mode of `go get` for these includes used during
-# proto building
-cd "$GOPATH"
-GO111MODULE=off go get -d github.com/gogo/googleapis || true
-GO111MODULE=off go get -d github.com/gogo/protobuf || true
+# proto building. From go1.22 `go get` is no longer supported
+# outside of a module in the legacy GOPATH mode, hence we manually
+# clone the packages in the $GOPATH
+GOGO_DIR="$GOPATH/src/github.com/gogo"
+mkdir -p "$GOGO_DIR"
+cd "$GOGO_DIR"
+git clone https://github.com/gogo/googleapis
+git clone https://github.com/gogo/protobuf

--- a/script/setup/prepare_env_windows.ps1
+++ b/script/setup/prepare_env_windows.ps1
@@ -5,7 +5,7 @@
 # lived test environment.
 Set-MpPreference -DisableRealtimeMonitoring:$true
 
-$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.21.13"; make = ""; nssm = "" }
+$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.22.6"; make = ""; nssm = "" }
 
 Write-Host "Downloading chocolatey package"
 curl.exe -L "https://packages.chocolatey.org/chocolatey.0.10.15.nupkg" -o 'c:\choco.zip'


### PR DESCRIPTION
- add go1.23.0 to testing matrix and move builds and releases to go1.22.6
- update golangci-lint to 1.60.1

Release binaries will be now built with go1.22.6