### PR TITLE
[release/1.7] add go1.23.0, drop go1.21.x

### DIFF
--- a/.github/actions/install-go/action.yml
+++ b/.github/actions/install-go/action.yml
@@ -3,7 +3,7 @@ description: "Reusable action to install Go, so there is one place to bump Go ve
 inputs:
   go-version:
     required: true
-    default: "1.21.13"
+    default: "1.22.6"
     description: "Go version to install"
 
 runs:

--- a/.github/workflows/api-release.yml
+++ b/.github/workflows/api-release.yml
@@ -6,7 +6,7 @@ on:
 name: API Release
 
 env:
-  GO_VERSION: "1.21.13"
+  GO_VERSION: "1.22.6"
 
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, actuated-arm64-4cpu-16gb, macos-12, windows-2019, windows-2022]
-        go-version: ["1.21.13", "1.22.6"]
+        go-version: ["1.22.6", "1.23.0"]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: golangci/golangci-lint-action@v4
         with:
           only-new-issues: true
-          version: v1.56.1
+          version: v1.60.1
           skip-cache: true
           args: --timeout=8m
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 name: Release
 
 env:
-  GO_VERSION: "1.21.13"
+  GO_VERSION: "1.22.6"
 
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -15,7 +15,7 @@ This doc includes:
 To build the `containerd` daemon, and the `ctr` simple test client, the following build system dependencies are required:
 
 
-* Go 1.21.x or above
+* Go 1.22.x or above
 * Protoc 3.x compiler and headers (download at the [Google protobuf releases page](https://github.com/protocolbuffers/protobuf/releases))
 * Btrfs headers and libraries for your distribution. Note that building the btrfs driver can be disabled via the build tag `no_btrfs`, removing this dependency.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -104,7 +104,7 @@ EOF
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.21.13",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.22.6",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -29,7 +29,7 @@
 #   docker run --privileged containerd-test
 # ------------------------------------------------------------------------------
 
-ARG GOLANG_VERSION=1.21.13
+ARG GOLANG_VERSION=1.22.6
 ARG GOLANG_IMAGE=golang
 
 FROM ${GOLANG_IMAGE}:${GOLANG_VERSION} AS golang

--- a/contrib/fuzz/oss_fuzz_build.sh
+++ b/contrib/fuzz/oss_fuzz_build.sh
@@ -43,11 +43,11 @@ go run main.go --target_dir $SRC/containerd/images
 
 apt-get update && apt-get install -y wget
 cd $SRC
-wget --quiet https://go.dev/dl/go1.21.13.linux-amd64.tar.gz
+wget --quiet https://go.dev/dl/go1.22.6.linux-amd64.tar.gz
 
 mkdir temp-go
 rm -rf /root/.go/*
-tar -C temp-go/ -xzf go1.21.13.linux-amd64.tar.gz
+tar -C temp-go/ -xzf go1.22.6.linux-amd64.tar.gz
 mv temp-go/go/* /root/.go/
 cd $SRC/containerd
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/containerd
 
-go 1.21
+go 1.22
 
 require (
 	dario.cat/mergo v1.0.0

--- a/integration/client/go.mod
+++ b/integration/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/containerd/integration/client
 
-go 1.21
+go 1.22
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24

--- a/script/setup/prepare_env_windows.ps1
+++ b/script/setup/prepare_env_windows.ps1
@@ -5,7 +5,7 @@
 # lived test environment.
 Set-MpPreference -DisableRealtimeMonitoring:$true
 
-$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.21.13"; make = ""; nssm = "" }
+$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.22.6"; make = ""; nssm = "" }
 
 Write-Host "Downloading chocolatey package"
 curl.exe -L "https://packages.chocolatey.org/chocolatey.0.10.15.nupkg" -o 'c:\choco.zip'


### PR DESCRIPTION
- add go1.23.0, drop go1.21.x
- update golangci-lint to 1.60.1

Release binaries will be now built with go1.22.6