### PR TITLE
docs: add k8s 1.31 to support matrix

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -144,7 +144,8 @@ of containerd for every supported version of Kubernetes.
 | 1.27               | 1.7.0+, 1.6.15+               | v1              |
 | 1.28               | 1.7.0+, 1.6.15+               | v1              |
 | 1.29               | 1.7.11+, 1.6.27+              | v1              |
-| 1.30(wip)          | 2.0(wip), 1.7.13+, 1.6.28+    | v1              |
+| 1.30               | 2.0(wip), 1.7.13+, 1.6.28+    | v1              |
+| 1.31               | 2.0(wip), 1.7.20+, 1.6.34+    | v1              |
 
 ** Note: containerd v1.6.*, and v1.7.* support CRI v1 and v1alpha2 through EOL as those releases continue to support older versions of k8s, cloud providers, and other clients using CRI v1alpha2. CRI v1alpha2 is deprecated in v1.7 and will be removed in containerd v2.0.
 


### PR DESCRIPTION
add k8s 1.31 to the supported version for containerd. 

NOTES:
- containerd 1.7.20+ is added since it is tested as part of release-branch-jobs [here](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-release/release-branch-jobs/1.31.yaml#L772)
- the corresponding version in 1.6 series is also used for the LTS version