### PR TITLE
script/setup/install-dev-tools: update protoc-gen-go-ttrpc to v1.2.5, specify patch versions

### DIFF
--- a/script/setup/install-dev-tools
+++ b/script/setup/install-dev-tools
@@ -26,4 +26,4 @@ go install github.com/cpuguy83/go-md2man/v2@v2.0.2
 go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
 go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28
 go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
-go install github.com/containerd/ttrpc/cmd/protoc-gen-go-ttrpc@faba5896a9c4d7b65495cb9b2c02531feb1434d6
+go install github.com/containerd/ttrpc/cmd/protoc-gen-go-ttrpc@v1.2.5

--- a/script/setup/install-dev-tools
+++ b/script/setup/install-dev-tools
@@ -24,6 +24,6 @@ go install github.com/containerd/protobuild@v0.3.0
 go install github.com/containerd/protobuild/cmd/go-fix-acronym@v0.3.0
 go install github.com/cpuguy83/go-md2man/v2@v2.0.2
 go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
-go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28
-go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
+go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.1
+go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2.0
 go install github.com/containerd/ttrpc/cmd/protoc-gen-go-ttrpc@v1.2.5


### PR DESCRIPTION
- relates to https://github.com/containerd/containerd/pull/10338

### script/setup/install-dev-tools: update protoc-gen-go-ttrpc to v1.2.5

The current version was updated in 65031eadec262d783db25456a8bbca1eed1956b7,
and looks to be

- 1 commit ahead of v1.2.3; https://github.com/containerd/ttrpc/compare/v1.2.3...faba5896a9c4d7b65495cb9b2c02531feb1434d6
- slightly behind of v1.2.4; https://github.com/containerd/ttrpc/compare/faba5896a9c4d7b65495cb9b2c02531feb1434d6...v1.2.4

This patch upstreas it to the current (v1.2.5) version, aligning it with
the version used in `go.mod`;
https://github.com/containerd/ttrpc/compare/faba5896a9c4d7b65495cb9b2c02531feb1434d6...v1.2.5


### script/setup/install-dev-tools: include patch version in versions

The OpenSSF scorecard is complaining about these two dependencies being
installed without a patch version specified;

    Warn: goCommand not pinned by hash: script/setup/install-dev-tools:27
    Warn: goCommand not pinned by hash: script/setup/install-dev-tools:28

While the error indicates it expects a hash, it looks like it's fine
with other modules in the same file, the difference being that those
specify a full version, including path version, e.g.;
https://github.com/containerd/containerd/blob/919beb1cf7d4edda26a3b95bf1b0d83b178e995e/script/setup/install-dev-tools#L26

This patch updates `protoc-gen-go` and `protoc-gen-go-grpc` to the latest
patch release for the specified versions.
