### PR TITLE
internal/cri: simplify netns setup with pinned userns

### DIFF
--- a/internal/cri/opts/spec_opts.go
+++ b/internal/cri/opts/spec_opts.go
@@ -301,6 +301,23 @@ func WithoutNamespace(t runtimespec.LinuxNamespaceType) oci.SpecOpts {
 	}
 }
 
+// WithNamespacePath updates namespace with existing path.
+func WithNamespacePath(t runtimespec.LinuxNamespaceType, nsPath string) oci.SpecOpts {
+	return func(ctx context.Context, client oci.Client, c *containers.Container, s *runtimespec.Spec) error {
+		if s.Linux == nil {
+			return fmt.Errorf("Linux spec is required")
+		}
+
+		for i, ns := range s.Linux.Namespaces {
+			if ns.Type == t {
+				s.Linux.Namespaces[i].Path = nsPath
+				return nil
+			}
+		}
+		return fmt.Errorf("no such namespace %s", t)
+	}
+}
+
 // WithPodNamespaces sets the pod namespaces for the container
 func WithPodNamespaces(config *runtime.LinuxContainerSecurityContext, sandboxPid uint32, targetPid uint32, uids, gids []runtimespec.LinuxIDMapping) oci.SpecOpts {
 	namespaces := config.GetNamespaceOptions()

--- a/internal/cri/server/podsandbox/sandbox_run_linux.go
+++ b/internal/cri/server/podsandbox/sandbox_run_linux.go
@@ -103,6 +103,11 @@ func (c *Controller) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 		case runtime.NamespaceMode_POD:
 			specOpts = append(specOpts, oci.WithUserNamespace(uids, gids))
 			usernsEnabled = true
+
+			if err := c.pinUserNamespace(id, nsPath); err != nil {
+				return nil, fmt.Errorf("failed to pin user namespace: %w", err)
+			}
+			specOpts = append(specOpts, customopts.WithNamespacePath(runtimespec.UserNamespace, c.getSandboxPinnedUserNamespace(id)))
 		default:
 			return nil, fmt.Errorf("unsupported user namespace mode: %q", mode)
 		}

--- a/internal/cri/server/podsandbox/sandbox_run_other_test.go
+++ b/internal/cri/server/podsandbox/sandbox_run_other_test.go
@@ -21,12 +21,13 @@ package podsandbox
 import (
 	"testing"
 
+	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
-func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConfig, func(*testing.T, string, *runtimespec.Spec)) {
+func getRunPodSandboxTestData(_ criconfig.Config) (*runtime.PodSandboxConfig, *imagespec.ImageConfig, func(*testing.T, string, *runtimespec.Spec)) {
 	config := &runtime.PodSandboxConfig{}
 	imageConfig := &imagespec.ImageConfig{}
 	specCheck := func(t *testing.T, id string, spec *runtimespec.Spec) {

--- a/internal/cri/server/podsandbox/sandbox_run_test.go
+++ b/internal/cri/server/podsandbox/sandbox_run_test.go
@@ -27,7 +27,13 @@ import (
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
+	"github.com/containerd/containerd/v2/pkg/testutil"
 )
+
+func TestEmpty(t *testing.T) {
+	// NOTE: It's used to register -test.root for all platforms.
+	testutil.RequiresRoot(t)
+}
 
 func TestSandboxContainerSpec(t *testing.T) {
 	switch goruntime.GOOS {
@@ -97,7 +103,7 @@ func TestSandboxContainerSpec(t *testing.T) {
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			c := newControllerService()
-			config, imageConfig, specCheck := getRunPodSandboxTestData()
+			config, imageConfig, specCheck := getRunPodSandboxTestData(c.config)
 			if test.configChange != nil {
 				test.configChange(config)
 			}
@@ -154,7 +160,9 @@ func TestTypeurlMarshalUnmarshalSandboxMeta(t *testing.T) {
 				Name:      "sandbox_1",
 				NetNSPath: "/home/cloud",
 			}
-			meta.Config, _, _ = getRunPodSandboxTestData()
+
+			c := newControllerService()
+			meta.Config, _, _ = getRunPodSandboxTestData(c.config)
 			if test.configChange != nil {
 				test.configChange(meta.Config)
 			}

--- a/internal/cri/server/podsandbox/sandbox_run_windows_test.go
+++ b/internal/cri/server/podsandbox/sandbox_run_windows_test.go
@@ -25,10 +25,11 @@ import (
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	"github.com/containerd/containerd/v2/internal/cri/annotations"
+	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
 	"github.com/containerd/containerd/v2/internal/cri/opts"
 )
 
-func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConfig, func(*testing.T, string, *runtimespec.Spec)) {
+func getRunPodSandboxTestData(criCfg criconfig.Config) (*runtime.PodSandboxConfig, *imagespec.ImageConfig, func(*testing.T, string, *runtimespec.Spec)) {
 	config := &runtime.PodSandboxConfig{
 		Metadata: &runtime.PodSandboxMetadata{
 			Name:      "test-name",
@@ -100,7 +101,7 @@ func TestSandboxWindowsNetworkNamespace(t *testing.T) {
 	nsPath := "test-cni"
 	c := newControllerService()
 
-	config, imageConfig, specCheck := getRunPodSandboxTestData()
+	config, imageConfig, specCheck := getRunPodSandboxTestData(c.config)
 	spec, err := c.sandboxContainerSpec(testID, config, imageConfig, nsPath, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, spec)

--- a/internal/cri/server/sandbox_run_linux.go
+++ b/internal/cri/server/sandbox_run_linux.go
@@ -18,9 +18,14 @@ package server
 
 import (
 	"fmt"
+	"syscall"
+
+	"github.com/containerd/containerd/v2/pkg/netns"
+	"github.com/containerd/containerd/v2/pkg/sys"
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func (c *criService) bringUpLoopback(netns string) error {
@@ -34,4 +39,45 @@ func (c *criService) bringUpLoopback(netns string) error {
 		return fmt.Errorf("error setting loopback interface up: %w", err)
 	}
 	return nil
+}
+
+func (c *criService) setupNetnsWithinUserns(netnsMountDir string, opt *runtime.UserNamespace) (*netns.NetNS, error) {
+	if opt.GetMode() != runtime.NamespaceMode_POD {
+		return nil, fmt.Errorf("required pod-level user namespace setting")
+	}
+
+	uidMaps := opt.GetUids()
+	if len(uidMaps) != 1 {
+		return nil, fmt.Errorf("required only one uid mapping, but got %d uid mapping(s)", len(uidMaps))
+	}
+	if uidMaps[0] == nil {
+		return nil, fmt.Errorf("required only one uid mapping, but got empty uid mapping")
+	}
+
+	gidMaps := opt.GetGids()
+	if len(gidMaps) != 1 {
+		return nil, fmt.Errorf("required only one gid mapping, but got %d gid mapping(s)", len(gidMaps))
+	}
+	if gidMaps[0] == nil {
+		return nil, fmt.Errorf("required only one gid mapping, but got empty gid mapping")
+	}
+
+	var netNs *netns.NetNS
+	var err error
+	uerr := sys.UnshareAfterEnterUserns(
+		fmt.Sprintf("%d:%d:%d", uidMaps[0].ContainerId, uidMaps[0].HostId, uidMaps[0].Length),
+		fmt.Sprintf("%d:%d:%d", gidMaps[0].ContainerId, gidMaps[0].HostId, gidMaps[0].Length),
+		syscall.CLONE_NEWNET,
+		func(pid int) error {
+			netNs, err = netns.NewNetNSFromPID(netnsMountDir, uint32(pid))
+			if err != nil {
+				return fmt.Errorf("failed to mount netns from pid %d: %w", pid, err)
+			}
+			return nil
+		},
+	)
+	if uerr != nil {
+		return nil, uerr
+	}
+	return netNs, nil
 }

--- a/internal/cri/server/sandbox_run_other.go
+++ b/internal/cri/server/sandbox_run_other.go
@@ -18,6 +18,17 @@
 
 package server
 
+import (
+	"fmt"
+
+	"github.com/containerd/containerd/v2/pkg/netns"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
 func (c *criService) bringUpLoopback(string) error {
 	return nil
+}
+
+func (c *criService) setupNetnsWithinUserns(basedir string, cfg *runtime.UserNamespace) (*netns.NetNS, error) {
+	return nil, fmt.Errorf("unsupported to setup netns within userns on unix platform")
 }

--- a/internal/cri/server/sandbox_run_windows.go
+++ b/internal/cri/server/sandbox_run_windows.go
@@ -16,6 +16,17 @@
 
 package server
 
+import (
+	"fmt"
+
+	"github.com/containerd/containerd/v2/pkg/netns"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
 func (c *criService) bringUpLoopback(string) error {
 	return nil
+}
+
+func (c *criService) setupNetnsWithinUserns(basedir string, cfg *runtime.UserNamespace) (*netns.NetNS, error) {
+	return nil, fmt.Errorf("unsupported to setup netns within userns on windows platform")
 }

--- a/pkg/sys/namespace_linux.go
+++ b/pkg/sys/namespace_linux.go
@@ -1,0 +1,38 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package sys
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// GetUsernsForNamespace returns a file descriptor that refers to the owning
+// user namespace for the namespace referred to by fd.
+//
+// REF: https://man7.org/linux/man-pages/man2/ioctl_ns.2.html
+func GetUsernsForNamespace(fd uintptr) (*os.File, error) {
+	fd, _, errno := unix.Syscall(syscall.SYS_IOCTL, fd, uintptr(unix.NS_GET_USERNS), 0)
+	if errno != 0 {
+		return nil, fmt.Errorf("failed to get user namespace fd: %w", errno)
+	}
+
+	return os.NewFile(fd, fmt.Sprintf("/proc/%d/fd/%d", os.Getpid(), fd)), nil
+}

--- a/pkg/sys/namespace_linux_test.go
+++ b/pkg/sys/namespace_linux_test.go
@@ -1,0 +1,106 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package sys
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"testing"
+
+	kernel "github.com/containerd/containerd/v2/pkg/kernelversion"
+	"github.com/containerd/continuity/testutil"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+func TestGetUsernsForNamespace(t *testing.T) {
+	testutil.RequiresRoot(t)
+
+	t.Parallel()
+
+	k409 := kernel.KernelVersion{Kernel: 4, Major: 9}
+	ok, err := kernel.GreaterEqualThan(k409)
+	require.NoError(t, err)
+	if !ok {
+		t.Skip("Requires kernel >= 4.9")
+	}
+
+	tmpDir := t.TempDir()
+
+	f, err := os.CreateTemp(tmpDir, "netns")
+	require.NoError(t, err)
+
+	netnsPath := f.Name()
+	f.Close()
+
+	defer testutil.Unmount(t, netnsPath)
+
+	currentUsernsIno, err := getNamespaceInode(os.Getpid(), "user")
+	require.NoError(t, err)
+
+	usernsIno := uint64(0)
+	uerr := UnshareAfterEnterUserns("0:1000:10", "0:1000:10", syscall.CLONE_NEWNET, func(pid int) error {
+		err := unix.Mount(
+			fmt.Sprintf("/proc/%d/ns/net", pid),
+			netnsPath,
+			"",
+			unix.MS_BIND|unix.MS_RDONLY,
+			"",
+		)
+		if err != nil {
+			return err
+		}
+
+		usernsIno, err = getNamespaceInode(pid, "user")
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	require.NoError(t, uerr)
+
+	require.NotEqual(t, currentUsernsIno, usernsIno)
+	t.Logf("Current user namespace [%d], new user namespace [%d]", currentUsernsIno, usernsIno)
+
+	netnsFd, err := os.Open(netnsPath)
+	require.NoError(t, err)
+	defer netnsFd.Close()
+
+	usernsFd, err := GetUsernsForNamespace(netnsFd.Fd())
+	require.NoError(t, err)
+	defer usernsFd.Close()
+
+	usernsInoFromNetnsFd := getInode(t, usernsFd)
+
+	t.Logf("Fetch netns namespace %s' user namespace owner %d", netnsPath, usernsInoFromNetnsFd)
+	require.Equal(t, usernsIno, usernsInoFromNetnsFd)
+
+	parentUsernsFd, err := GetUsernsForNamespace(usernsFd.Fd())
+	require.NoError(t, err)
+	defer parentUsernsFd.Close()
+
+	parentUsernsIno := getInode(t, parentUsernsFd)
+	t.Logf("User namespace %d's parent %d", usernsInoFromNetnsFd, parentUsernsIno)
+	require.Equal(t, currentUsernsIno, parentUsernsIno)
+}
+
+func getInode(t *testing.T, f *os.File) uint64 {
+	info, err := f.Stat()
+	require.NoError(t, err)
+	return info.Sys().(*syscall.Stat_t).Ino
+}

--- a/pkg/sys/unshare_linux.go
+++ b/pkg/sys/unshare_linux.go
@@ -1,0 +1,153 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package sys
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// UnshareAfterEnterUserns allows to disassociate parts of its execution context
+// within a user namespace.
+func UnshareAfterEnterUserns(uidMap, gidMap string, unshareFlags uintptr, f func(pid int) error) (retErr error) {
+	if unshareFlags&syscall.CLONE_NEWUSER == syscall.CLONE_NEWUSER {
+		return fmt.Errorf("unshare flags should not include user namespace")
+	}
+
+	uidMaps, err := parseIDMapping(uidMap)
+	if err != nil {
+		return err
+	}
+
+	gidMaps, err := parseIDMapping(gidMap)
+	if err != nil {
+		return err
+	}
+
+	var pidfd int
+	proc, err := os.StartProcess("/proc/self/exe", []string{"UnshareAfterEnterUserns"}, &os.ProcAttr{
+		Sys: &syscall.SysProcAttr{
+			// clone new user namespace first and then unshare
+			Cloneflags:   unix.CLONE_NEWUSER,
+			Unshareflags: unshareFlags,
+			UidMappings:  uidMaps,
+			GidMappings:  gidMaps,
+			// NOTE: It's reexec but it's not heavy because subprocess
+			// be in PTRACE_TRACEME mode before performing execve.
+			Ptrace:    true,
+			Pdeathsig: syscall.SIGKILL,
+			PidFD:     &pidfd,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to start noop process for unshare: %w", err)
+	}
+
+	if pidfd == -1 || !SupportsPidFD() {
+		proc.Kill()
+		proc.Wait()
+		return fmt.Errorf("kernel doesn't support CLONE_PIDFD")
+	}
+
+	// Since go1.23.{0,1} has double close issue, we should dup it before using it.
+	//
+	// References:
+	// - https://github.com/golang/go/issues/68984
+	// - https://github.com/golang/go/milestone/371
+	if goVer := runtime.Version(); goVer == "go1.23.0" || goVer == "go1.23.1" {
+		dupPidfd, dupErr := unix.FcntlInt(uintptr(pidfd), syscall.F_DUPFD_CLOEXEC, 0)
+		if dupErr != nil {
+			proc.Kill()
+			proc.Wait()
+			return fmt.Errorf("failed to dupfd: %w", err)
+		}
+		pidfd = dupPidfd
+	}
+
+	defer func() {
+		derr := unix.PidfdSendSignal(pidfd, unix.SIGKILL, nil, 0)
+		if derr != nil {
+			if !errors.Is(derr, unix.ESRCH) {
+				retErr = derr
+			}
+			return
+		}
+		pidfdWaitid(pidfd)
+	}()
+
+	if f != nil {
+		if err := f(proc.Pid); err != nil {
+			return err
+		}
+	}
+
+	// Ensure the child process is still alive. If the err is ESRCH, we
+	// should return error because the pid could be reused. It's safe to
+	// return error and retry.
+	if err := unix.PidfdSendSignal(pidfd, 0, nil, 0); err != nil {
+		return fmt.Errorf("failed to ensure child process is alive: %w", err)
+	}
+	return nil
+}
+
+// TODO: Support multiple mappings in future
+func parseIDMapping(mapping string) ([]syscall.SysProcIDMap, error) {
+	parts := strings.Split(mapping, ":")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("user namespace mappings require the format `container-id:host-id:size`")
+	}
+
+	cID, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("invalid container id for user namespace remapping, %w", err)
+	}
+
+	hID, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("invalid host id for user namespace remapping, %w", err)
+	}
+
+	size, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return nil, fmt.Errorf("invalid size for user namespace remapping, %w", err)
+	}
+
+	if cID < 0 || hID < 0 || size < 0 {
+		return nil, fmt.Errorf("invalid mapping %s, all IDs and size must be positive integers", mapping)
+	}
+
+	return []syscall.SysProcIDMap{
+		{
+			ContainerID: cID,
+			HostID:      hID,
+			Size:        size,
+		},
+	}, nil
+}
+
+func pidfdWaitid(pidfd int) error {
+	return IgnoringEINTR(func() error {
+		return unix.Waitid(unix.P_PIDFD, pidfd, nil, unix.WEXITED, nil)
+	})
+}

--- a/pkg/sys/unshare_linux_test.go
+++ b/pkg/sys/unshare_linux_test.go
@@ -1,0 +1,149 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package sys
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"testing"
+
+	kernel "github.com/containerd/containerd/v2/pkg/kernelversion"
+	"github.com/containerd/continuity/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnshareAfterEnterUserns(t *testing.T) {
+	testutil.RequiresRoot(t)
+
+	k510 := kernel.KernelVersion{Kernel: 5, Major: 10}
+	ok, err := kernel.GreaterEqualThan(k510)
+	require.NoError(t, err)
+	if !ok {
+		t.Skip("Requires kernel >= 5.10")
+	}
+
+	err = UnshareAfterEnterUserns("0:1000:1", "0:1000:1", syscall.CLONE_NEWUSER|syscall.CLONE_NEWIPC, nil)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "unshare flags should not include user namespace")
+
+	t.Run("should work", testUnshareAfterEnterUsernsShouldWork)
+	t.Run("killpid", testUnshareAfterEnterUsernsKillPid)
+	t.Run("invalid unshare flags", testUnshareAfterEnterUsernsInvalidFlags)
+}
+
+func testUnshareAfterEnterUsernsShouldWork(t *testing.T) {
+	t.Parallel()
+
+	currentNetNs, err := getNamespaceInode(os.Getpid(), "net")
+	require.NoError(t, err)
+
+	currentUserNs, err := getNamespaceInode(os.Getpid(), "user")
+	require.NoError(t, err)
+
+	currentIpcNs, err := getNamespaceInode(os.Getpid(), "ipc")
+	require.NoError(t, err)
+
+	currentPidNs, err := getNamespaceInode(os.Getpid(), "pid")
+	require.NoError(t, err)
+
+	uerr := UnshareAfterEnterUserns("0:1000:10", "0:1000:10", syscall.CLONE_NEWIPC|syscall.CLONE_NEWNET, func(pid int) error {
+		netNs, err := getNamespaceInode(pid, "net")
+		require.NoError(t, err)
+		require.NotEqual(t, currentNetNs, netNs)
+
+		userNs, err := getNamespaceInode(pid, "user")
+		require.NoError(t, err)
+		require.NotEqual(t, currentUserNs, userNs)
+
+		ipcNs, err := getNamespaceInode(pid, "ipc")
+		require.NoError(t, err)
+		require.NotEqual(t, currentIpcNs, ipcNs)
+
+		pidNs, err := getNamespaceInode(pid, "pid")
+		require.NoError(t, err)
+		require.Equal(t, currentPidNs, pidNs)
+
+		data, err := os.ReadFile(fmt.Sprintf("/proc/%d/uid_map", pid))
+		require.NoError(t, err)
+		require.Equal(t, "         0       1000         10\n", string(data))
+
+		data, err = os.ReadFile(fmt.Sprintf("/proc/%d/gid_map", pid))
+		require.NoError(t, err)
+		require.Equal(t, "         0       1000         10\n", string(data))
+		return nil
+	})
+	require.NoError(t, uerr)
+}
+
+func testUnshareAfterEnterUsernsKillPid(t *testing.T) {
+	t.Parallel()
+
+	uerr := UnshareAfterEnterUserns("0:1000:1", "0:1000:1", syscall.CLONE_NEWIPC|syscall.CLONE_NEWNET, func(pid int) error {
+		proc, err := os.FindProcess(pid)
+		if err != nil {
+			return fmt.Errorf("failed to find process: %w", err)
+		}
+
+		if err := proc.Kill(); err != nil {
+			return fmt.Errorf("failed to kill process: %w", err)
+		}
+
+		proc.Wait()
+
+		_, err = os.OpenFile(fmt.Sprintf("/proc/%d/ns/net", pid), os.O_RDONLY, 0600)
+		require.Error(t, err)
+		require.ErrorIs(t, err, os.ErrNotExist)
+		return err
+	})
+	require.Error(t, uerr)
+	require.ErrorIs(t, uerr, os.ErrNotExist)
+
+	uerr = UnshareAfterEnterUserns("0:1000:1", "0:1000:1", syscall.CLONE_NEWIPC|syscall.CLONE_NEWNET, func(pid int) error {
+		proc, err := os.FindProcess(pid)
+		if err != nil {
+			return fmt.Errorf("failed to find process: %w", err)
+		}
+
+		if err := proc.Kill(); err != nil {
+			return fmt.Errorf("failed to kill process: %w", err)
+		}
+
+		proc.Wait()
+
+		return nil
+	})
+	require.Error(t, uerr)
+	require.ErrorContains(t, uerr, "failed to ensure child process is alive: no such process")
+}
+
+func testUnshareAfterEnterUsernsInvalidFlags(t *testing.T) {
+	t.Parallel()
+
+	uerr := UnshareAfterEnterUserns("0:1000:1", "0:1000:1", syscall.CLONE_IO, nil)
+	require.Error(t, uerr)
+	require.ErrorContains(t, uerr, "fork/exec /proc/self/exe: invalid argument")
+}
+
+func getNamespaceInode(pid int, typ string) (uint64, error) {
+	info, err := os.Stat(fmt.Sprintf("/proc/%d/ns/%s", pid, typ))
+	if err != nil {
+		return 0, err
+	}
+
+	return info.Sys().(*syscall.Stat_t).Ino, nil
+}


### PR DESCRIPTION
## Motivation:

For pod-level user namespaces, it's impossible to force the container runtime
to join an existing network namespace after creating a new user namespace.

According to the capabilities section in [user_namespaces(7)][1], a network
namespace created by containerd is owned by the root user namespace. When the
container runtime (like runc or crun) creates a new user namespace, it becomes
a child of the root user namespace. Processes within this child user namespace
are not permitted to access resources owned by the parent user namespace.

If the network namespace is not owned by the new user namespace, the container
runtime will fail to mount /sys due to the [sysfs: Restrict mounting sysfs][2]
patch.

Referencing the [cap_capable][3] function in Linux, a process can access a
resource if:

* The resource is owned by the process's user namespace, and the process has
the required capability.

* The resource is owned by a child of the process's user namespace, and the
owner's user namespace was created by the process's UID.

In the context of pod-level user namespaces, the CRI plugin delegates the
creation of the network namespace to the container runtime when running the
pause container. After the pause container is initialized, the CRI plugin pins
the pause container's network namespace into `/run/netns` and then executes
the `CNI_ADD` command over it.

However, if the pause container is terminated during the pinning process, the
CRI plugin might encounter a PID cycle, leading to the `CNI_ADD` command
operating on an incorrect network namespace.

Moreover, rolling back the `RunPodSandbox` API is complex due to the delegation
of network namespace creation. As highlighted in issue https://github.com/containerd/containerd/issues/10363, the CRI plugin
can lose IP information after a containerd restart, making it challenging to
maintain robustness in the RunPodSandbox API.

## Solution:

Allow containerd to create a new user namespace and then create the network
namespace within that user namespace. This way, the CRI plugin can force the
container runtime to join both the user namespace and the network namespace.
Since the network namespace is owned by the newly created user namespace,
the container runtime will have the necessary permissions to mount `/sys` on
the container's root filesystem. As a result, delegation of network namespace
creation is no longer needed.

## NOTE:

* The CRI plugin does not need to pin the newly created user namespace as it
does with the network namespace, because the kernel allows retrieving a user
namespace reference via [ioctl_ns(2)][4]. As a result, the podsandbox
implementation can obtain the user namespace using the `netnsPath` parameter.

* The `pkg/sys` package continues to use go:linkname to handle fork operations
due to efficiency, despite being a notable member of [hall of shame][5]. If https://github.com/containerd/containerd/pull/10611 can work, I will switch it back.

[1]: <https://man7.org/linux/man-pages/man7/user_namespaces.7.html>
[2]: <https://github.com/torvalds/linux/commit/7dc5dbc879bd0779924b5132a48b731a0bc04a1e>
[3]: <https://github.com/torvalds/linux/blob/2c85ebc57b3e1817b6ce1a6b703928e113a90442/security/commoncap.c#L65>
[4]: <https://man7.org/linux/man-pages/man2/ioctl_ns.2.html>
[5]: <https://github.com/golang/go/blob/release-branch.go1.23/src/runtime/proc.go#L4820>

Signed-off-by: Wei Fu <fuweid89@gmail.com>


