### PR TITLE
version: add separate UserAgent variable for default User-Agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,13 +102,18 @@ SHIM_GO_BUILDTAGS := $(GO_BUILDTAGS) no_grpc
 GO_TAGS=$(if $(GO_BUILDTAGS),-tags "$(strip $(GO_BUILDTAGS))",)
 SHIM_GO_TAGS=$(if $(SHIM_GO_BUILDTAGS),-tags "$(strip $(SHIM_GO_BUILDTAGS))",)
 
-GO_LDFLAGS=-ldflags '-X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PACKAGE) $(EXTRA_LDFLAGS)
+GO_LD_X = \
+	-X $(PKG)/version.Version=$(VERSION) \
+	-X $(PKG)/version.Revision=$(REVISION) \
+	-X $(PKG)/version.Package=$(PACKAGE)
+
+GO_LDFLAGS=-ldflags '$(GO_LD_X) $(EXTRA_LDFLAGS)
 ifneq ($(STATIC),)
 	GO_LDFLAGS += -extldflags "-static"
 endif
 GO_LDFLAGS+='
 
-SHIM_GO_LDFLAGS=-ldflags '-X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PACKAGE) -extldflags "-static" $(EXTRA_LDFLAGS)'
+SHIM_GO_LDFLAGS=-ldflags '$(GO_LD_X) -extldflags "-static" $(EXTRA_LDFLAGS)'
 
 # Project packages.
 PACKAGES=$(shell $(GO) list ${GO_TAGS} ./... | grep -v /vendor/ | grep -v /integration)

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,9 @@ PKG=github.com/containerd/containerd/v2
 COMMANDS=ctr containerd containerd-stress
 MANPAGES=ctr.8 containerd.8 containerd-config.8 containerd-config.toml.5
 
+# Optional override for the User-Agent. Leave empty to use the default ("containerd/<Version>").
+CONTAINERD_USER_AGENT ?=
+
 ifdef BUILDTAGS
     GO_BUILDTAGS = ${BUILDTAGS}
 endif
@@ -106,6 +109,10 @@ GO_LD_X = \
 	-X $(PKG)/version.Version=$(VERSION) \
 	-X $(PKG)/version.Revision=$(REVISION) \
 	-X $(PKG)/version.Package=$(PACKAGE)
+
+ifneq ($(strip $(CONTAINERD_USER_AGENT)),)
+GO_LD_X += -X "$(PKG)/version.UserAgentOverride=$(CONTAINERD_USER_AGENT)"
+endif
 
 GO_LDFLAGS=-ldflags '$(GO_LD_X) $(EXTRA_LDFLAGS)
 ifneq ($(STATIC),)

--- a/core/remotes/docker/auth/fetch.go
+++ b/core/remotes/docker/auth/fetch.go
@@ -128,7 +128,7 @@ func FetchTokenWithOAuth(ctx context.Context, client *http.Client, headers http.
 		req.Header[k] = append(req.Header[k], v...)
 	}
 	if len(req.Header.Get("User-Agent")) == 0 {
-		req.Header.Set("User-Agent", version.UserAgent)
+		req.Header.Set("User-Agent", version.UserAgent())
 	}
 
 	resp, err := client.Do(req)
@@ -179,7 +179,7 @@ func FetchToken(ctx context.Context, client *http.Client, headers http.Header, t
 		req.Header[k] = append(req.Header[k], v...)
 	}
 	if len(req.Header.Get("User-Agent")) == 0 {
-		req.Header.Set("User-Agent", version.UserAgent)
+		req.Header.Set("User-Agent", version.UserAgent())
 	}
 
 	reqParams := req.URL.Query()

--- a/core/remotes/docker/auth/fetch.go
+++ b/core/remotes/docker/auth/fetch.go
@@ -128,7 +128,7 @@ func FetchTokenWithOAuth(ctx context.Context, client *http.Client, headers http.
 		req.Header[k] = append(req.Header[k], v...)
 	}
 	if len(req.Header.Get("User-Agent")) == 0 {
-		req.Header.Set("User-Agent", "containerd/"+version.Version)
+		req.Header.Set("User-Agent", version.UserAgent)
 	}
 
 	resp, err := client.Do(req)
@@ -179,7 +179,7 @@ func FetchToken(ctx context.Context, client *http.Client, headers http.Header, t
 		req.Header[k] = append(req.Header[k], v...)
 	}
 	if len(req.Header.Get("User-Agent")) == 0 {
-		req.Header.Set("User-Agent", "containerd/"+version.Version)
+		req.Header.Set("User-Agent", version.UserAgent)
 	}
 
 	reqParams := req.URL.Query()

--- a/core/remotes/docker/resolver.go
+++ b/core/remotes/docker/resolver.go
@@ -523,7 +523,7 @@ func (r *dockerBase) request(host RegistryHost, method string, ps ...string) *re
 	}
 
 	if len(header.Get("User-Agent")) == 0 {
-		header.Set("User-Agent", version.UserAgent)
+		header.Set("User-Agent", version.UserAgent())
 	}
 
 	parts := append([]string{"/", host.Path, r.repository}, ps...)

--- a/core/remotes/docker/resolver.go
+++ b/core/remotes/docker/resolver.go
@@ -523,7 +523,7 @@ func (r *dockerBase) request(host RegistryHost, method string, ps ...string) *re
 	}
 
 	if len(header.Get("User-Agent")) == 0 {
-		header.Set("User-Agent", "containerd/"+version.Version)
+		header.Set("User-Agent", version.UserAgent)
 	}
 
 	parts := append([]string{"/", host.Path, r.repository}, ps...)

--- a/version/version.go
+++ b/version/version.go
@@ -33,16 +33,19 @@ var (
 	// GoVersion is Go tree's version.
 	GoVersion = runtime.Version()
 
-	// UserAgent is the default User-Agent header for http-requests such as
-	// authenticating and pulling images from registries using the
-	// core/remotes/docker package. This variable is filled in at linking
-	// time, and users of containerd as a go module must set this variable
-	// to a value matching their product, following the guidelines outlined
-	// in [RFC9110, section 10.1.5], or to configure the User-Agent header
-	// through other means.
+	// UserAgentOverride overrides the default User-Agent header for HTTP
+	// requests such as authenticating and pulling images from registries
+	// using the core/remotes/docker package. This variable is filled in
+	// at linking time, and users of containerd as a go module must set this
+	// variable to a value matching their product, following the guidelines
+	// outlined in [RFC9110, section 10.1.5], or to configure the User-Agent
+	// header through other means.
+	//
+	// If this variable is empty, a generic User-Agent is used, based on [Name]
+	// and [Version].
 	//
 	// [RFC9110, section 10.1.5]: https://httpwg.org/specs/rfc9110.html#field.user-agent
-	UserAgent = "containerd/2.0.0-rc.3+unknown"
+	UserAgentOverride = ""
 )
 
 // ConfigVersion is the current highest supported configuration version.
@@ -50,3 +53,20 @@ var (
 // Any configuration less than this version which has structural changes
 // should migrate the configuration structures used by this version.
 const ConfigVersion = 3
+
+// UserAgent returns the default User-Agent header ([RFC9110, section 10.1.5])
+// to use for HTTP requests such as authenticating and pulling images from
+// registries using the core/remotes/docker package.
+//
+// The User-Agent can be set at linking time through the [UserAgentOverride]
+// variable, and users of containerd as a Go module must set this variable to
+// a value matching their product. If [UserAgentOverride] is empty, a generic
+// User-Agent is used, based on [Name] and [Version].
+//
+// [RFC9110, section 10.1.5]: https://httpwg.org/specs/rfc9110.html#field.user-agent
+func UserAgent() string {
+	if UserAgentOverride != "" {
+		return UserAgentOverride
+	}
+	return Name + "/" + Version
+}

--- a/version/version.go
+++ b/version/version.go
@@ -32,6 +32,17 @@ var (
 
 	// GoVersion is Go tree's version.
 	GoVersion = runtime.Version()
+
+	// UserAgent is the default User-Agent header for http-requests such as
+	// authenticating and pulling images from registries using the
+	// core/remotes/docker package. This variable is filled in at linking
+	// time, and users of containerd as a go module must set this variable
+	// to a value matching their product, following the guidelines outlined
+	// in [RFC9110, section 10.1.5], or to configure the User-Agent header
+	// through other means.
+	//
+	// [RFC9110, section 10.1.5]: https://httpwg.org/specs/rfc9110.html#field.user-agent
+	UserAgent = "containerd/2.0.0-rc.3+unknown"
 )
 
 // ConfigVersion is the current highest supported configuration version.


### PR DESCRIPTION
### version: add separate UserAgent variable for default User-Agent

The default User-Agent as used by containerd to perform requests to
registries is using a hard-coded `containerd/` prefix; this can be
problematic in situations where containerd is used as a module.

In cases where the consuming code does not explicitly set a User-Agent header
(therefore falling back to the default), it may either identify itself as
containerd or, when overriding the `Version` variable at linking time, as
`containerd/<unrelated version>`.

This patch introduces a separate `UserAgent` variable to allow setting the
user-agent separate from other variables that can be set at linking time.
It currently defaults to the existing default (using `containerd` as prefix
(product name)), but this could be changed to distinguish containerd builds
from products using containerd as a module.

The variable is added to the `version` package, as this is where other
compile / linking-time variables reside, but given it's a default value,
could be considered for inclusion in teh `defaults` package instead.

### Makefile: add CONTAINERD_USER_AGENT var for overriding default user-agent

With this patch, the default user-agent can be overridden when compiling;

    # setting the make variable
    make CONTAINERD_USER_AGENT="my-product/1.2.3 os/linux arch/arm64" binaries

    # through an environment variable
    CONTAINERD_USER_AGENT="my-product/1.2.3 os/linux arch/arm64" make binaries

The `CONTAINERD_` prefix is used to reduce risk of collisions when setting
through an environment-variable.