### PR TITLE
Register local content plugin from separate package

### DIFF
--- a/cmd/containerd/builtins/builtins.go
+++ b/cmd/containerd/builtins/builtins.go
@@ -19,6 +19,7 @@ package builtins
 // register containerd builtins here
 import (
 	_ "github.com/containerd/containerd/v2/core/runtime/v2"
+	_ "github.com/containerd/containerd/v2/plugins/content/local/plugin"
 	_ "github.com/containerd/containerd/v2/plugins/events"
 	_ "github.com/containerd/containerd/v2/plugins/gc"
 	_ "github.com/containerd/containerd/v2/plugins/imageverifier"

--- a/cmd/containerd/server/server.go
+++ b/cmd/containerd/server/server.go
@@ -49,6 +49,11 @@ import (
 	diffapi "github.com/containerd/containerd/api/services/diff/v1"
 	sbapi "github.com/containerd/containerd/api/services/sandbox/v1"
 	ssapi "github.com/containerd/containerd/api/services/snapshots/v1"
+	"github.com/containerd/platforms"
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/dynamic"
+	"github.com/containerd/plugin/registry"
+
 	srvconfig "github.com/containerd/containerd/v2/cmd/containerd/server/config"
 	csproxy "github.com/containerd/containerd/v2/core/content/proxy"
 	"github.com/containerd/containerd/v2/core/diff"
@@ -61,13 +66,8 @@ import (
 	"github.com/containerd/containerd/v2/pkg/sys"
 	"github.com/containerd/containerd/v2/pkg/timeout"
 	"github.com/containerd/containerd/v2/plugins"
-	"github.com/containerd/containerd/v2/plugins/content/local"
 	"github.com/containerd/containerd/v2/plugins/services/warning"
 	"github.com/containerd/containerd/v2/version"
-	"github.com/containerd/platforms"
-	"github.com/containerd/plugin"
-	"github.com/containerd/plugin/dynamic"
-	"github.com/containerd/plugin/registry"
 )
 
 // CreateTopLevelDirectories creates the top-level root and state directories.
@@ -482,16 +482,6 @@ func LoadPlugins(ctx context.Context, config *srvconfig.Config) ([]plugin.Regist
 		config.PluginDir = path //nolint:staticcheck
 		log.G(ctx).Warningf("loaded %d dynamic plugins. `go_plugin` is deprecated, please use `external plugins` instead", count)
 	}
-	// load additional plugins that don't automatically register themselves
-	registry.Register(&plugin.Registration{
-		Type: plugins.ContentPlugin,
-		ID:   "content",
-		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
-			root := ic.Properties[plugins.PropertyRootDir]
-			ic.Meta.Exports["root"] = root
-			return local.NewStore(root)
-		},
-	})
 
 	clients := &proxyClients{}
 	for name, pp := range config.ProxyPlugins {

--- a/integration/build_local_containerd_helper_test.go
+++ b/integration/build_local_containerd_helper_test.go
@@ -36,6 +36,7 @@ import (
 
 	_ "github.com/containerd/containerd/api/types/runc/options"
 	_ "github.com/containerd/containerd/v2/core/runtime/v2"
+	_ "github.com/containerd/containerd/v2/plugins/content/local/plugin"
 	_ "github.com/containerd/containerd/v2/plugins/cri/images"
 	_ "github.com/containerd/containerd/v2/plugins/cri/runtime"
 	_ "github.com/containerd/containerd/v2/plugins/diff/walking/plugin"

--- a/plugins/content/local/plugin/plugin.go
+++ b/plugins/content/local/plugin/plugin.go
@@ -1,0 +1,37 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package plugin
+
+import (
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
+
+	"github.com/containerd/containerd/v2/plugins"
+	"github.com/containerd/containerd/v2/plugins/content/local"
+)
+
+func init() {
+	registry.Register(&plugin.Registration{
+		Type: plugins.ContentPlugin,
+		ID:   "content",
+		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
+			root := ic.Properties[plugins.PropertyRootDir]
+			ic.Meta.Exports["root"] = root
+			return local.NewStore(root)
+		},
+	})
+}


### PR DESCRIPTION
Update the local content plugin to register itself in a consistent way as other plugins. This also allows the separate package to define its own configuration more cleanly.

Not sure why this one didn't get updated with the other plugins. We will want the local content plugin to have its own configuration for verity though, it will be cleaner in its own package like everything else.