### PR TITLE
[release/1.7] Prepare release notes for v1.7.21

### DIFF
--- a/releases/v1.7.21.toml
+++ b/releases/v1.7.21.toml
@@ -1,0 +1,27 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.7.20"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The twenty-first patch release for containerd 1.7 contains various fixes
+and updates.
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.7.20+unknown"
+	Version = "1.7.21+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated notes

---
Welcome to the v1.7.21 release of containerd!

The twenty-first patch release for containerd 1.7 contains various fixes
and updates.

### Highlights

* Fix failed force deletion for tasks with PID 0 ([#10523](https://github.com/containerd/containerd/pull/10523))
* Regenerate introspection UUID if state is empty ([#10510](https://github.com/containerd/containerd/pull/10510))
* Set stderr to empty string when using terminal on Windows. ([#10499](https://github.com/containerd/containerd/pull/10499))

#### Build and Release Toolchain

* Move builds to Go 1.22 and add support for testing with 1.23 ([#10596](https://github.com/containerd/containerd/pull/10596))

#### Container Runtime Interface (CRI)

* Borrow latest wsstream from k8s v1.31.x to 1.7 ([#10575](https://github.com/containerd/containerd/pull/10575))
* Ensure the CRIAPIV1Alpha2 warning's lastOccurrence is accurate ([#10571](https://github.com/containerd/containerd/pull/10571))
* Make `StopContainer` RPC idempotent ([#10528](https://github.com/containerd/containerd/pull/10528))
* Make `StopPodSandbox` idempotent ([#10527](https://github.com/containerd/containerd/pull/10527))

#### Runtime

* Fix packaged runc reporting incorrect version ([#10559](https://github.com/containerd/containerd/pull/10559))
* Ensure `/run/containerd` gets created with correct perms ([#10534](https://github.com/containerd/containerd/pull/10534))

#### Deprecations

* Ensure the CRIAPIV1Alpha2 warning's lastOccurrence is accurate ([#10571](https://github.com/containerd/containerd/pull/10571))
* Update warnings for deprecated CRI config fields ([#10512](https://github.com/containerd/containerd/pull/10512))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Davanum Srinivas
* Samuel Karp
* Sebastiaan van Stijn
* Phil Estes
* Maksym Pavlenko
* Akhil Mohan
* Chris Henzie
* Kazuyoshi Kato
* Sascha Grunert
* Akihiro Suda
* Derek McGowan
* Erikson Tung
* Iceber Gu
* Mauri de Souza Meneguzzo
* Mike Brown
* Shengjing Zhu
* TinaMor
* rongfu.leng

### Changes
<details><summary>44 commits</summary>
<p>

  * [`975f279ee`](https://github.com/containerd/containerd/commit/975f279eeb3033d05e1b1089b11bd678cc73efd7) Prepare release notes for v1.7.21
* go.mod: keep minimum go version at go1.21 ([#10633](https://github.com/containerd/containerd/pull/10633))
  * [`d63bd8464`](https://github.com/containerd/containerd/commit/d63bd846458b7c504dc0efe59f275fee8e29322d) go.mod: keep minimum go version at go1.21
* Move builds to Go 1.22 and add support for testing with 1.23 ([#10596](https://github.com/containerd/containerd/pull/10596))
  * [`c76028088`](https://github.com/containerd/containerd/commit/c7602808814d6ca235d37323ff37cde9bdf9d6bb) update golangci-lint to 1.60.1
  * [`3b263d082`](https://github.com/containerd/containerd/commit/3b263d082cb09a2911150135a760508527557a0e) add go1.23.0, drop go1.21.x
* Fix TestNewBinaryIOCleanup on Go 1.23 and Linux 5.4 ([#10590](https://github.com/containerd/containerd/pull/10590))
  * [`09ca004de`](https://github.com/containerd/containerd/commit/09ca004dee1fe7752a652f474661e23d7e3489d4) Fix TestNewBinaryIOCleanup on Go 1.23 and Linux 5.4
* Borrow latest wsstream from k8s v1.31.x to 1.7 ([#10575](https://github.com/containerd/containerd/pull/10575))
  * [`9269d97b1`](https://github.com/containerd/containerd/commit/9269d97b1d3c08afba0914028a1ae73220aaa6e4) hide wsstream under internal/ to prevent external use
  * [`59815fa44`](https://github.com/containerd/containerd/commit/59815fa44be5f20954e4acf02c91590f78c053f6) golangci-lint should only look for problems in new code
  * [`1c431dc6f`](https://github.com/containerd/containerd/commit/1c431dc6ff7bb928ad3656c318a24548026f560f) Run go mod tidy
  * [`226f93d92`](https://github.com/containerd/containerd/commit/226f93d928723e1cc14d07d84f774e77d4d1bb61) Add copyright headers
  * [`6f3252733`](https://github.com/containerd/containerd/commit/6f3252733c4f5dd13048096fdf08799ad5733893) switch over references to the new package
  * [`0a85d476a`](https://github.com/containerd/containerd/commit/0a85d476a1c2dd9b0ee562a8a3e295744a6f9685) Fix up some constant references
  * [`82bfa44d0`](https://github.com/containerd/containerd/commit/82bfa44d0fedef27c2b74af49866d74d5317359b) Copy over wsstream from k8s v1.31.0-rc.1 release
* Ensure the CRIAPIV1Alpha2 warning's lastOccurrence is accurate ([#10571](https://github.com/containerd/containerd/pull/10571))
  * [`52b79f337`](https://github.com/containerd/containerd/commit/52b79f3377af7c0003abe85e3d93d7d679d8418f) Update CRIAPIV1Alpha2 warning lastOccurrence every call
* pkg/userns: deprecate and migrate to github.com/moby/sys/userns ([#10564](https://github.com/containerd/containerd/pull/10564))
  * [`dce0b5a6d`](https://github.com/containerd/containerd/commit/dce0b5a6d338900f33ff44808483ebf63dced65a) migrate to github.com/moby/sys/userns
  * [`65f7d0740`](https://github.com/containerd/containerd/commit/65f7d07409562252aaab84da481ca4e9334a5810) pkg/userns: deprecate and migrate to github.com/moby/sys/user/userns
  * [`f21675c27`](https://github.com/containerd/containerd/commit/f21675c2731774c54412b3855a9eb43a757f69c4) vendor: github.com/moby/sys/user v0.2.0
* update to go1.21.13 / go1.22.6 ([#10570](https://github.com/containerd/containerd/pull/10570))
  * [`228914a5e`](https://github.com/containerd/containerd/commit/228914a5e533db62f2637267c26b0093b6e8625e) update to go1.21.13 / go1.22.6
* Fix TestNewBinaryIOCleanup failing with gotip ([#10554](https://github.com/containerd/containerd/pull/10554))
  * [`3ff82ba0f`](https://github.com/containerd/containerd/commit/3ff82ba0f007e0fb856f7b2b174f5bc1ab1237cd) Fix TestNewBinaryIOCleanup failing with gotip
* Fix packaged runc reporting incorrect version ([#10559](https://github.com/containerd/containerd/pull/10559))
  * [`d51143f6f`](https://github.com/containerd/containerd/commit/d51143f6fad370fce2c2f5b0507365fb0a229372) script/setup/install-runc: fix runc using incorrect version
* update auths code comment ([#10536](https://github.com/containerd/containerd/pull/10536))
  * [`7bb1455d8`](https://github.com/containerd/containerd/commit/7bb1455d88aef5c558125c8c3b08230dc78fbdcb) update auths code comment
* Ensure `/run/containerd` gets created with correct perms ([#10534](https://github.com/containerd/containerd/pull/10534))
  * [`16c5fc768`](https://github.com/containerd/containerd/commit/16c5fc7689d8c9d715b2387c2844b22bb7a8e76e) Ensure /run/containerd is created with correct perms
* Make `StopContainer` RPC idempotent ([#10528](https://github.com/containerd/containerd/pull/10528))
  * [`6da4e40b2`](https://github.com/containerd/containerd/commit/6da4e40b22ce2beb3cbb88dcdb8c7ede279e5b14) Make `StopContainer` RPC idempotent
* Make `StopPodSandbox` idempotent ([#10527](https://github.com/containerd/containerd/pull/10527))
  * [`b3b6f1507`](https://github.com/containerd/containerd/commit/b3b6f15075e1ecd07ca49d667e6dedd94bf4145a) Make `StopPodSandbox` RPC idempotent
* Fix failed force deletion for tasks with PID 0 ([#10523](https://github.com/containerd/containerd/pull/10523))
  * [`0db46f664`](https://github.com/containerd/containerd/commit/0db46f664ab1394add6c813b764121a5f12d6ef3) client: fix tasks with PID 0 cannot be forced to delete
* Update warnings for deprecated CRI config fields ([#10512](https://github.com/containerd/containerd/pull/10512))
  * [`9afb8dcdf`](https://github.com/containerd/containerd/commit/9afb8dcdfecfdc37297ab110548214e4954bb2ab) deprecation: update warnings for CRI config fields
* Regenerate introspection UUID if state is empty ([#10510](https://github.com/containerd/containerd/pull/10510))
  * [`b140792e4`](https://github.com/containerd/containerd/commit/b140792e46e962d8a5c6aafaf0012cf572bdacb3) introspection: regenerate UUID if state is empty
* Set stderr to empty string when using terminal on Windows. ([#10499](https://github.com/containerd/containerd/pull/10499))
  * [`f9beac3db`](https://github.com/containerd/containerd/commit/f9beac3db8e9345b9acfc1cbe5126ff0c7e8c9eb) Set stderr to empty string when using terminal on Windows.
</p>
</details>

### Dependency Changes

* **github.com/moby/sys/userns**  v0.1.0 **_new_**

Previous release can be found at [v1.7.20](https://github.com/containerd/containerd/releases/tag/v1.7.20)