### PR TITLE
[release/1.7] go.mod: keep minimum go version at go1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/containerd
 
-go 1.22
+go 1.21
 
 require (
 	dario.cat/mergo v1.0.0

--- a/integration/client/go.mod
+++ b/integration/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/containerd/integration/client
 
-go 1.22
+go 1.21
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24


### PR DESCRIPTION
- relates to https://github.com/containerd/containerd/pull/10596#discussion_r1721294997


Commit 3b263d082cb09a2911150135a760508527557a0e updated the version of Go used to build containerd to go1.22, but also updated the version in go.mod.

As there's currently not a requirement for go1.22, we can keep this at the minimum required version, and revert it to go1.21.