### PR TITLE
Prepare release notes for  v2.0.0-rc.4

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -115,6 +115,7 @@ Marvin Giessing <marvin.giessing@gmail.com>
 Mathis Michel <mathis.michel@outlook.de>
 Michael Crosby <crosbymichael@gmail.com> <michael@thepasture.io>
 Michael Katsoulis <michaelkatsoulis88@gmail.com>
+Michael Zappa <michael.zappa@gmail.com> <michaelzappa@microsoft.com>
 Mike Brown <brownwm@us.ibm.com> <mikebrow@users.noreply.github.com>
 Mohammad Asif Siddiqui <mohammad.asif.siddiqui1@huawei.com>
 Nabeel Rana <nabeelnrana@gmail.com>

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/containerd/btrfs/v2 v2.0.0
 	github.com/containerd/cgroups/v3 v3.0.3
 	github.com/containerd/console v1.0.4
-	github.com/containerd/containerd/api v1.8.0-rc.2
+	github.com/containerd/containerd/api v1.8.0-rc.3
 	github.com/containerd/continuity v0.4.3
 	github.com/containerd/errdefs v0.1.0
 	github.com/containerd/fifo v1.1.0
@@ -148,5 +148,3 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect
 )
-
-replace github.com/containerd/containerd/api => ./api

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/containerd/cgroups/v3 v3.0.3 h1:S5ByHZ/h9PMe5IOQoN7E+nMc2UcLEM/V48DGD
 github.com/containerd/cgroups/v3 v3.0.3/go.mod h1:8HBe7V3aWGLFPd/k03swSIsGjZhHI2WzJmticMgVuz0=
 github.com/containerd/console v1.0.4 h1:F2g4+oChYvBTsASRTz8NP6iIAi97J3TtSAsLbIFn4ro=
 github.com/containerd/console v1.0.4/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
+github.com/containerd/containerd/api v1.8.0-rc.3 h1:q9MyeXmuAGEyKmUGYvvFftNX1RQhfTLsAvYK+SQHQso=
+github.com/containerd/containerd/api v1.8.0-rc.3/go.mod h1:dFv4lt6S20wTu/hMcP4350RL87qPWLVa/OHOwmmdnYc=
 github.com/containerd/continuity v0.4.3 h1:6HVkalIp+2u1ZLH1J/pYX2oBVXlJZvh1X1A7bEZ9Su8=
 github.com/containerd/continuity v0.4.3/go.mod h1:F6PTNCKepoxEaXLQp3wDAjygEnImnZ/7o4JzpodfroQ=
 github.com/containerd/errdefs v0.1.0 h1:m0wCRBiu1WJT/Fr+iOoQHMQS/eP5myQ8lCv4Dz5ZURM=

--- a/vendor/github.com/containerd/containerd/api/LICENSE
+++ b/vendor/github.com/containerd/containerd/api/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright The containerd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -105,7 +105,7 @@ github.com/containerd/cgroups/v3/cgroup2/stats
 # github.com/containerd/console v1.0.4
 ## explicit; go 1.13
 github.com/containerd/console
-# github.com/containerd/containerd/api v1.8.0-rc.2 => ./api
+# github.com/containerd/containerd/api v1.8.0-rc.3
 ## explicit; go 1.21
 github.com/containerd/containerd/api/events
 github.com/containerd/containerd/api/runtime/sandbox/v1
@@ -860,4 +860,3 @@ tags.cncf.io/container-device-interface/pkg/parser
 # tags.cncf.io/container-device-interface/specs-go v0.8.0
 ## explicit; go 1.19
 tags.cncf.io/container-device-interface/specs-go
-# github.com/containerd/containerd/api => ./api

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd/v2"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "2.0.0-rc.3+unknown"
+	Version = "2.0.0-rc.4+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated notes

----


Welcome to the v2.0.0-rc.4 release of containerd!  
*This is a pre-release of containerd*

The first major release of containerd 2.x focuses on the continued stability of
containerd's core feature set with an easy upgrade from containerd 1.x. This
release includes the stabilization of new features added in the last 1.x release
as well as the removal of features which were deprecated in 1.x. The goal is to
support the vast community of containerd users well into the future along with
their ever increasing deployment footprints and variety of use cases.

### Highlights

* Add Update API for sandbox controller ([#9903](https://github.com/containerd/containerd/pull/9903))
* Preserve Unprivileged locked flags during remount of bind mounts ([#10200](https://github.com/containerd/containerd/pull/10200))
* Configure otel from env instead of config.toml ([#8970](https://github.com/containerd/containerd/pull/8970))
* Fix config import relative path glob ([#9746](https://github.com/containerd/containerd/pull/9746))
* Enable NRI by default ([#9744](https://github.com/containerd/containerd/pull/9744))
* Add PluginInfo to introspection API ([#9442](https://github.com/containerd/containerd/pull/9442))
* Remove overlayfs volatile option on temp mounts ([#9555](https://github.com/containerd/containerd/pull/9555))
* Expose usage of deprecated features ([#9258](https://github.com/containerd/containerd/pull/9258))
* Use Intel ISA-L's igzip if available ([#9200](https://github.com/containerd/containerd/pull/9200))
* Introduce top level config migration ([#9223](https://github.com/containerd/containerd/pull/9223))
* Add image delete target ([#8989](https://github.com/containerd/containerd/pull/8989))
* Remove `LimitNOFILE` from `containerd.service` ([#8924](https://github.com/containerd/containerd/pull/8924))
* Add support for image expiration during garbage collection ([#9022](https://github.com/containerd/containerd/pull/9022))
* Reduce the contention between ref lock and boltdb lock in content store ([#8792](https://github.com/containerd/containerd/pull/8792))
* Remove "containerd.io/restart.logpath" label ([#8264](https://github.com/containerd/containerd/pull/8264))
* Remove `aufs` snapshotter ([#8263](https://github.com/containerd/containerd/pull/8263))
* Fix deadlock during NRI plugin registration ([containerd/nri#79](https://github.com/containerd/nri/pull/79))
* Fix deadlock when writing to pipe blocks ([containerd/ttrpc#168](https://github.com/containerd/ttrpc/pull/168))

#### Build and Release Toolchain

* Generate attestation for artifacts during release ([#10543](https://github.com/containerd/containerd/pull/10543))

#### Container Runtime Interface (CRI)

* Add support to set loopback to up ([#10238](https://github.com/containerd/containerd/pull/10238))
* Add support for multiple subscribers to CRI container events ([#9661](https://github.com/containerd/containerd/pull/9661))
* Enable CDI by default ([#9621](https://github.com/containerd/containerd/pull/9621))
* Remove non-sandboxed CRI implementation ([#9228](https://github.com/containerd/containerd/pull/9228))
* Add support for userns in stateless and stateful pods with idmap mounts (KEP-127, k8s >= 1.27) ([#8287](https://github.com/containerd/containerd/pull/8287))
* Use sandboxed CRI by default ([#8994](https://github.com/containerd/containerd/pull/8994))
* Implement RuntimeConfig CRI call ([#8722](https://github.com/containerd/containerd/pull/8722))
* Add support for user namespaces (KEP-127) ([#8803](https://github.com/containerd/containerd/pull/8803))
* Remove CRI v1alpha2 ([#8276](https://github.com/containerd/containerd/pull/8276))

#### Go client

* Add api Go module and move all protos under api ([#10151](https://github.com/containerd/containerd/pull/10151))
* Move packages based on contributing guide ([#9365](https://github.com/containerd/containerd/pull/9365))
* Generalize plugin library ([#9214](https://github.com/containerd/containerd/pull/9214))
* Use github.com/containerd/log ([#9086](https://github.com/containerd/containerd/pull/9086))

#### Image Distribution

* Support to syncfs after pull by using diff plugin ([#10284](https://github.com/containerd/containerd/pull/10284))
* Skip "unknown" in image platform listing ([#10257](https://github.com/containerd/containerd/pull/10257))
* Update unpacker to fetch all provided content ([#10202](https://github.com/containerd/containerd/pull/10202))
* Enable Transfer service API to support plain HTTP ([#10024](https://github.com/containerd/containerd/pull/10024))
* Enable Transfer service to use registry configuration directory ([#9908](https://github.com/containerd/containerd/pull/9908))
* Disable the support for Schema 1 images ([#9765](https://github.com/containerd/containerd/pull/9765))
* Update Transfer service to add OCI descriptors to Progress structure ([#9630](https://github.com/containerd/containerd/pull/9630))
* Update import and export to allow references to missing content  ([#9554](https://github.com/containerd/containerd/pull/9554))
* Add option to perform syncfs after pull ([#9401](https://github.com/containerd/containerd/pull/9401))
* Add image verifier transfer service plugin system based on a binary directory ([#8493](https://github.com/containerd/containerd/pull/8493))

#### Runtime

* Implement  RuntimeStatus.features.supplemental_groups_policy from KEP-3619 ([#10410](https://github.com/containerd/containerd/pull/10410))
* Add pprof to runc-shim ([#10242](https://github.com/containerd/containerd/pull/10242))
* Provide runtime options in plugin info ([#10251](https://github.com/containerd/containerd/pull/10251))
* Store bootstrap parameters in sandbox metadata ([#9736](https://github.com/containerd/containerd/pull/9736))
* Update apparmor to allow confined runc to kill containers ([#10123](https://github.com/containerd/containerd/pull/10123))
* Support vsock connection to task api ([#9738](https://github.com/containerd/containerd/pull/9738))
* Update RuntimeDefault seccomp profile to disallow io_uring related syscalls ([#9320](https://github.com/containerd/containerd/pull/9320))
* Switch runc shim to task service v3 and fix restore ([#9233](https://github.com/containerd/containerd/pull/9233))
* Add sandboxer configuration and move sandbox controllers to plugins ([#8268](https://github.com/containerd/containerd/pull/8268))
* Add annotations to CreateSandbox request ([#8960](https://github.com/containerd/containerd/pull/8960))
* Add SandboxMetrics ([#8680](https://github.com/containerd/containerd/pull/8680))
* Publish sandbox events ([#8602](https://github.com/containerd/containerd/pull/8602))
* Remove the CriuPath field from runc's options ([#8279](https://github.com/containerd/containerd/pull/8279))
* Remove support for config.toml `version = 1` ([#8275](https://github.com/containerd/containerd/pull/8275))
* Remove `io.containerd.runtime.v1.linux` and `io.containerd.runc.v1` ([#8262](https://github.com/containerd/containerd/pull/8262))

#### Security Advisories

* [medium] RAPL accessible to a container [GHSA-7ww5-4wqc-m92c](https://github.com/containerd/containerd/security/advisories/GHSA-7ww5-4wqc-m92c)

#### Breaking

* Disable the support for Schema 1 images ([#9765](https://github.com/containerd/containerd/pull/9765))
* Update RuntimeDefault seccomp profile to disallow io_uring related syscalls ([#9320](https://github.com/containerd/containerd/pull/9320))
* Move client to subpackage ([#9316](https://github.com/containerd/containerd/pull/9316))
* Remove `LimitNOFILE` from `containerd.service` ([#8924](https://github.com/containerd/containerd/pull/8924))
* Remove CRI v1alpha2 ([#8276](https://github.com/containerd/containerd/pull/8276))
* Remove `io.containerd.runtime.v1.linux` and `io.containerd.runc.v1` ([#8262](https://github.com/containerd/containerd/pull/8262))
* Remove "containerd.io/restart.logpath" label ([#8264](https://github.com/containerd/containerd/pull/8264))
* Remove `aufs` snapshotter ([#8263](https://github.com/containerd/containerd/pull/8263))

----

Full version at https://gist.github.com/dmcgowan/68f63519848bb0838623f6edf4e8ee28
