### PR TITLE
Improve gc tricolor by avoiding revisiting nodes

### DIFF
--- a/pkg/gc/gc.go
+++ b/pkg/gc/gc.go
@@ -69,12 +69,14 @@ func Tricolor(roots []Node, refs func(ref Node) ([]Node, error)) (map[Node]struc
 	)
 
 	grays = append(grays, roots...)
+	for _, root := range roots {
+		seen[root] = struct{}{} // pre-mark this as not-white
+	}
 
 	for len(grays) > 0 {
 		// Pick any gray object
 		id := grays[len(grays)-1] // effectively "depth first" because first element
 		grays = grays[:len(grays)-1]
-		seen[id] = struct{}{} // post-mark this as not-white
 		rs, err := refs(id)
 		if err != nil {
 			return nil, err
@@ -84,6 +86,7 @@ func Tricolor(roots []Node, refs func(ref Node) ([]Node, error)) (map[Node]struc
 		for _, target := range rs {
 			if _, ok := seen[target]; !ok {
 				grays = append(grays, target)
+				seen[target] = struct{}{}
 			}
 		}
 

--- a/pkg/gc/gc_test.go
+++ b/pkg/gc/gc_test.go
@@ -18,6 +18,7 @@ package gc
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -49,6 +50,28 @@ func TestTricolorBasic(t *testing.T) {
 
 	if !reflect.DeepEqual(sweeped, expected) {
 		t.Fatalf("incorrect unreachable set: %v != %v", sweeped, expected)
+	}
+}
+
+func BenchmarkTricolor(b *testing.B) {
+	roots := []string{"A", "C"}
+	refs := map[string][]string{
+		"A": {"B", "C"},
+		"B": {"A", "C"},
+		"C": {"D", "F", "B"},
+		"E": {"F", "G", "C"},
+		"F": {"H", "C"},
+	}
+	// assume 100 nodes can reach D.
+	for i := 0; i < 100; i++ {
+		ref := fmt.Sprintf("X%d", i)
+		refs["A"] = append(refs["A"], ref)
+		refs[ref] = []string{"D"}
+	}
+
+	// Run the Add function b.N times to benchmark it.
+	for i := 0; i < b.N; i++ {
+		Tricolor(toNodes(roots), lookup(refs))
 	}
 }
 


### PR DESCRIPTION
If a node can be reached by, e.g., 100 nodes, then it will be added to `grays` 100 times (and `refs` will be called 100 times for this node). This PR avoids this by **pre-marking** a node as non-white right after it's added to `grays`.

My understanding from the code is we can/should avoid such duplications in `grays` (and duplicated `refs(node)` calls within a `Tricolor` call).

1. `Tricolor` is single-thread GC, and only called once by `DB.getMarked`
https://github.com/containerd/containerd/blob/4cfeb7b19ea3127a936048705b2ed3cda2d7f13d/core/metadata/db.go#L516
2. `getMarked` is only called once by `DB.GarbageCollect` which holds a write lock to `DB`: https://github.com/containerd/containerd/blob/4cfeb7b19ea3127a936048705b2ed3cda2d7f13d/core/metadata/db.go#L372-L376
3. So there should be no concurrent writes during a `Tricolor` call, and repeated `refs(node)` calls will return the same results and thus should be avoided.

---

The added benchmark on my macbook:

```shell
# before the change
$ go test -bench=. -benchmem -count 5 ./pkg/gc/...
BenchmarkTricolor-8        40724             26680 ns/op           75641 B/op        134 allocs/op
BenchmarkTricolor-8        45002             26666 ns/op           75646 B/op        134 allocs/op
BenchmarkTricolor-8        44790             26622 ns/op           75636 B/op        134 allocs/op
BenchmarkTricolor-8        45115             26654 ns/op           75639 B/op        134 allocs/op
BenchmarkTricolor-8        44782             26682 ns/op           75643 B/op        134 allocs/op
# after the change
$ go test -bench=. -benchmem -count 5 ./pkg/gc/...
BenchmarkTricolor-8        48979             22379 ns/op           71538 B/op        133 allocs/op
BenchmarkTricolor-8        53335             22484 ns/op           71541 B/op        133 allocs/op
BenchmarkTricolor-8        53569             22260 ns/op           71550 B/op        133 allocs/op
BenchmarkTricolor-8        53278             22312 ns/op           71545 B/op        133 allocs/op
BenchmarkTricolor-8        53372             22421 ns/op           71547 B/op        133 allocs/op
```

By creating a graph where A -> [X1, X100] -> D, it shows the GC latency has a ~16% improvement (22260/26622=84%). Memory also has  ~6% reduction  (71550/75636=94%). (the actual improvement will depend on the cost of calling `refs` and number of duplicated nodes).

Appreciate any feedback/concern, thanks!