### PR TITLE
Report an error when cni confDir removed

### DIFF
--- a/internal/cri/server/cni_conf_syncer.go
+++ b/internal/cri/server/cni_conf_syncer.go
@@ -97,6 +97,11 @@ func (syncer *cniNetConfSyncer) syncLoop() error {
 			}
 			log.L.Debugf("receiving change event from cni conf dir: %s", event)
 
+			// If the confDir is removed, stop watching.
+			if event.Name == syncer.confDir && (event.Has(fsnotify.Rename) || event.Has(fsnotify.Remove)) {
+				return fmt.Errorf("cni conf dir is removed, stop watching")
+			}
+
 			lerr := syncer.netPlugin.Load(syncer.loadOpts...)
 			if lerr != nil {
 				log.L.WithError(lerr).


### PR DESCRIPTION
xref: https://github.com/containerd/containerd/issues/6490
xref: https://github.com/containerd/containerd/pull/7224

Deleting and recreating confDir is an error that causes containerd to remain in the **cni plugin not initialized** state forever and will not work until containerd is restarted.

But instead of re-executing the '**newCNINetConfSyncer**' function here, I think it's better to simply throw an error. Specific decisions (such as stopping or restarting containerd or recreate the confDir) should be determined by external error handling:

```golang
	select {
	case eventMonitorErr = <-eventMonitorErrCh:
	case streamServerErr = <-streamServerErrCh:
	case cniNetConfMonitorErr = <-cniNetConfMonitorErrCh:
	}
	.......
	if cniNetConfMonitorErr != nil {
		return fmt.Errorf("cni network conf monitor error: %w", cniNetConfMonitorErr)
	}
```
```golang
if err := s.Run(ready); err != nil {
	log.G(ctx).WithError(err).Fatal("Failed to run CRI service")
}
// TODO(random-liu): Whether and how we can stop containerd.
```
Now, we can  see from the log that there is a problem with the configuration directory of CNI.
