### PR TITLE
runc-shim: publish init exit after all processes have exited

### DIFF
--- a/cmd/containerd-shim-runc-v2/task/service.go
+++ b/cmd/containerd-shim-runc-v2/task/service.go
@@ -118,6 +118,12 @@ type service struct {
 	lifecycleMu  sync.Mutex
 	running      map[int][]containerProcess // pid -> running process, guarded by lifecycleMu
 	pendingExecs map[*runc.Container]int    // container -> num pending execs, guarded by lifecycleMu
+	// container -> execs can be started, guarded by lifecycleMu.
+	// Execs can be started if the container's init process (read: pid, not [process.Init])
+	// has been started and not yet reaped by the shim.
+	// Note that this flag gets updated before the container's [process.Init.Status]
+	// is transitioned to "stopped".
+	execable map[*runc.Container]bool
 	// Subscriptions to exits for PIDs. Adding/deleting subscriptions and
 	// dereferencing the subscription pointers must only be done while holding
 	// lifecycleMu.
@@ -231,6 +237,9 @@ func (s *service) preStart(c *runc.Container) (handleStarted func(*runc.Containe
 				Container: c,
 				Process:   p,
 			})
+			if init {
+				s.execable[c] = true
+			}
 			s.lifecycleMu.Unlock()
 		}
 	}
@@ -305,6 +314,10 @@ func (s *service) Start(ctx context.Context, r *taskAPI.StartRequest) (*taskAPI.
 	if r.ExecID == "" {
 		cinit = container
 	} else {
+		if !s.execable[container] {
+			s.lifecycleMu.Unlock()
+			return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container %s init process is not running", container.ID)
+		}
 		s.pendingExecs[container]++
 	}
 	handleStarted, cleanup := s.preStart(cinit)
@@ -680,6 +693,9 @@ func (s *service) processExits() {
 		var cps, skipped []containerProcess
 		for _, cp := range s.running[e.Pid] {
 			_, init := cp.Process.(*process.Init)
+			if init {
+				delete(s.execable, cp.Container)
+			}
 			if init && s.pendingExecs[cp.Container] != 0 {
 				// This exit relates to a container for which we have pending execs. In
 				// order to ensure order between execs and the init process for a given

--- a/cmd/containerd-shim-runc-v2/task/service.go
+++ b/cmd/containerd-shim-runc-v2/task/service.go
@@ -830,7 +830,6 @@ func (s *service) handleInitExit(e runcC.Exit, c *runc.Container, p *process.Ini
 	}()
 }
 
-// s.mu must be locked when calling handleProcessExit
 func (s *service) handleProcessExit(e runcC.Exit, c *runc.Container, p process.Process) {
 	p.SetExited(e.Status)
 	s.send(&eventstypes.TaskExit{


### PR DESCRIPTION
Building off of https://github.com/containerd/containerd/pull/10634, took a stab at an implementation of what we discussed in slack, namely:

```
1. process the init exit, squirrel away its exit event and block new exec starts
2. wait for all pending execs to settle to running or early-exit
3. kill all container processes
4. wait for the running count to drop to zero, with a time bound
5. wipe out the running list (so we don't publish exit events for late-reaped execs) and publish the squirreled-away init event
```

This implementation in particular launches a goroutine per-container init exit. I did write another implementation which doesn't require that, but it was a bit more complex, and I wasn't sure it was worth the payoff.

However, I'm sure others (cc @corhere) have better ideas, so I'd be happy to hear them.