### PR TITLE
Remove deprecated cri SandboxInfo RuntimeHandler

### DIFF
--- a/internal/cri/server/podsandbox/sandbox_status.go
+++ b/internal/cri/server/podsandbox/sandbox_status.go
@@ -61,11 +61,10 @@ func (c *Controller) Status(ctx context.Context, sandboxID string, verbose bool)
 // toCRISandboxInfo converts internal container object information to CRI sandbox status response info map.
 func toCRISandboxInfo(ctx context.Context, sb *types.PodSandbox) (map[string]string, error) {
 	si := &critypes.SandboxInfo{
-		Pid:            sb.Status.Get().Pid,
-		Config:         sb.Metadata.Config,
-		RuntimeHandler: sb.Metadata.RuntimeHandler,
-		CNIResult:      sb.Metadata.CNIResult,
-		Metadata:       &sb.Metadata,
+		Pid:       sb.Status.Get().Pid,
+		Config:    sb.Metadata.Config,
+		CNIResult: sb.Metadata.CNIResult,
+		Metadata:  &sb.Metadata,
 	}
 
 	if container := sb.Container; container != nil {

--- a/internal/cri/server/sandbox_status.go
+++ b/internal/cri/server/sandbox_status.go
@@ -144,10 +144,9 @@ func toCRISandboxStatus(meta sandboxstore.Metadata, status string, createdAt tim
 // we should fallback to get SandboxInfo from cached sandbox itself.
 func toDeletedCRISandboxInfo(sandbox sandboxstore.Sandbox) (map[string]string, error) {
 	si := &types.SandboxInfo{
-		Pid:            sandbox.Status.Get().Pid,
-		Config:         sandbox.Config,
-		RuntimeHandler: sandbox.RuntimeHandler,
-		CNIResult:      sandbox.CNIResult,
+		Pid:       sandbox.Status.Get().Pid,
+		Config:    sandbox.Config,
+		CNIResult: sandbox.CNIResult,
 	}
 
 	// If processStatus is empty, it means that the task is deleted. Apply "deleted"

--- a/internal/cri/types/sandbox_info.go
+++ b/internal/cri/types/sandbox_info.go
@@ -27,16 +27,12 @@ import (
 // SandboxInfo is extra information for sandbox.
 // TODO (mikebrow): discuss predefining constants structures for some or all of these field names in CRI
 type SandboxInfo struct {
-	Pid         uint32 `json:"pid"`
-	Status      string `json:"processStatus"`
-	NetNSClosed bool   `json:"netNamespaceClosed"`
-	Image       string `json:"image"`
-	SnapshotKey string `json:"snapshotKey"`
-	Snapshotter string `json:"snapshotter"`
-	// Note: a new field `RuntimeHandler` has been added into the CRI PodSandboxStatus struct, and
-	// should be set. This `RuntimeHandler` field will be deprecated after containerd 1.3 (tracked
-	// in https://github.com/containerd/cri/issues/1064).
-	RuntimeHandler string                    `json:"runtimeHandler"` // see the Note above
+	Pid            uint32                    `json:"pid"`
+	Status         string                    `json:"processStatus"`
+	NetNSClosed    bool                      `json:"netNamespaceClosed"`
+	Image          string                    `json:"image"`
+	SnapshotKey    string                    `json:"snapshotKey"`
+	Snapshotter    string                    `json:"snapshotter"`
 	RuntimeType    string                    `json:"runtimeType"`
 	RuntimeOptions interface{}               `json:"runtimeOptions"`
 	Config         *runtime.PodSandboxConfig `json:"config"`


### PR DESCRIPTION
This field has been deprecated since 1.3. I think we can remove it as part of 2.0 deprecation?

The tracking issue mentioned in the code comment: https://github.com/containerd/cri/issues/1064

The release note mentioning the deprecation of this field:

https://github.com/containerd/containerd/pull/3492#:~:text=runtimeHandler%20field%20is%20moved%20from%20the%20sandbox%20info%20into%20status

