### PR TITLE
Avoid repeated ptypes.Empty creation by predefining it as a var

### DIFF
--- a/plugins/services/containers/local.go
+++ b/plugins/services/containers/local.go
@@ -38,6 +38,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+var empty = &ptypes.Empty{}
+
 func init() {
 	registry.Register(&plugin.Registration{
 		Type: plugins.ServicePlugin,
@@ -188,16 +190,16 @@ func (l *local) Delete(ctx context.Context, req *api.DeleteContainerRequest, _ .
 	if err := l.withStoreUpdate(ctx, func(ctx context.Context) error {
 		return l.Store.Delete(ctx, req.ID)
 	}); err != nil {
-		return &ptypes.Empty{}, errdefs.ToGRPC(err)
+		return empty, errdefs.ToGRPC(err)
 	}
 
 	if err := l.publisher.Publish(ctx, "/containers/delete", &eventstypes.ContainerDelete{
 		ID: req.ID,
 	}); err != nil {
-		return &ptypes.Empty{}, err
+		return empty, err
 	}
 
-	return &ptypes.Empty{}, nil
+	return empty, nil
 }
 
 func (l *local) withStore(ctx context.Context, fn func(ctx context.Context) error) func(tx *bolt.Tx) error {

--- a/plugins/services/events/service.go
+++ b/plugins/services/events/service.go
@@ -36,6 +36,8 @@ import (
 	"google.golang.org/grpc"
 )
 
+var empty = &ptypes.Empty{}
+
 func init() {
 	registry.Register(&plugin.Registration{
 		Type: plugins.GRPCPlugin,
@@ -84,7 +86,7 @@ func (s *service) Publish(ctx context.Context, r *api.PublishRequest) (*ptypes.E
 		return nil, errdefs.ToGRPC(err)
 	}
 
-	return &ptypes.Empty{}, nil
+	return empty, nil
 }
 
 func (s *service) Forward(ctx context.Context, r *api.ForwardRequest) (*ptypes.Empty, error) {
@@ -92,7 +94,7 @@ func (s *service) Forward(ctx context.Context, r *api.ForwardRequest) (*ptypes.E
 		return nil, errdefs.ToGRPC(err)
 	}
 
-	return &ptypes.Empty{}, nil
+	return empty, nil
 }
 
 func (s *service) Subscribe(req *api.SubscribeRequest, srv api.Events_SubscribeServer) error {

--- a/plugins/services/events/ttrpc.go
+++ b/plugins/services/events/ttrpc.go
@@ -37,7 +37,7 @@ func (s *ttrpcService) Forward(ctx context.Context, r *api.ForwardRequest) (*pty
 		return nil, errdefs.ToGRPC(err)
 	}
 
-	return &ptypes.Empty{}, nil
+	return empty, nil
 }
 
 func fromTProto(env *types.Envelope) *events.Envelope {

--- a/plugins/services/images/local.go
+++ b/plugins/services/images/local.go
@@ -39,6 +39,8 @@ import (
 	"github.com/containerd/plugin/registry"
 )
 
+var empty = &ptypes.Empty{}
+
 func init() {
 	registry.Register(&plugin.Registration{
 		Type: plugins.ServicePlugin,
@@ -183,7 +185,7 @@ func (l *local) Delete(ctx context.Context, req *imagesapi.DeleteImageRequest, _
 		}
 	}
 
-	return &ptypes.Empty{}, nil
+	return empty, nil
 }
 
 func (l *local) emitSchema1DeprecationWarning(ctx context.Context, image *images.Image) {

--- a/plugins/services/leases/service.go
+++ b/plugins/services/leases/service.go
@@ -30,6 +30,8 @@ import (
 	"google.golang.org/grpc"
 )
 
+var empty = &ptypes.Empty{}
+
 func init() {
 	registry.Register(&plugin.Registration{
 		Type: plugins.GRPCPlugin,
@@ -87,7 +89,7 @@ func (s *service) Delete(ctx context.Context, r *api.DeleteRequest) (*ptypes.Emp
 	}, opts...); err != nil {
 		return nil, errdefs.ToGRPC(err)
 	}
-	return &ptypes.Empty{}, nil
+	return empty, nil
 }
 
 func (s *service) List(ctx context.Context, r *api.ListRequest) (*api.ListResponse, error) {
@@ -117,7 +119,7 @@ func (s *service) AddResource(ctx context.Context, r *api.AddResourceRequest) (*
 	}); err != nil {
 		return nil, errdefs.ToGRPC(err)
 	}
-	return &ptypes.Empty{}, nil
+	return empty, nil
 }
 
 func (s *service) DeleteResource(ctx context.Context, r *api.DeleteResourceRequest) (*ptypes.Empty, error) {
@@ -131,7 +133,7 @@ func (s *service) DeleteResource(ctx context.Context, r *api.DeleteResourceReque
 	}); err != nil {
 		return nil, errdefs.ToGRPC(err)
 	}
-	return &ptypes.Empty{}, nil
+	return empty, nil
 }
 
 func (s *service) ListResources(ctx context.Context, r *api.ListResourcesRequest) (*api.ListResourcesResponse, error) {

--- a/plugins/services/namespaces/local.go
+++ b/plugins/services/namespaces/local.go
@@ -37,6 +37,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+var empty = &ptypes.Empty{}
+
 func init() {
 	registry.Register(&plugin.Registration{
 		Type: plugins.ServicePlugin,
@@ -206,17 +208,17 @@ func (l *local) Delete(ctx context.Context, req *api.DeleteNamespaceRequest, _ .
 	if err := l.withStoreUpdate(ctx, func(ctx context.Context, store namespaces.Store) error {
 		return errdefs.ToGRPC(store.Delete(ctx, req.Name))
 	}); err != nil {
-		return &ptypes.Empty{}, err
+		return empty, err
 	}
 	// set the namespace in the context before publishing the event
 	ctx = namespaces.WithNamespace(ctx, req.Name)
 	if err := l.publisher.Publish(ctx, "/namespaces/delete", &eventstypes.NamespaceDelete{
 		Name: req.Name,
 	}); err != nil {
-		return &ptypes.Empty{}, err
+		return empty, err
 	}
 
-	return &ptypes.Empty{}, nil
+	return empty, nil
 }
 
 func (l *local) withStore(ctx context.Context, fn func(ctx context.Context, store namespaces.Store) error) func(tx *bolt.Tx) error {

--- a/plugins/services/transfer/service.go
+++ b/plugins/services/transfer/service.go
@@ -39,6 +39,8 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
+var empty = &ptypes.Empty{}
+
 func init() {
 	registry.Register(&plugin.Registration{
 		Type: plugins.GRPCPlugin,
@@ -130,7 +132,7 @@ func (s *service) Transfer(ctx context.Context, req *transferapi.TransferRequest
 
 	for _, t := range s.transferrers {
 		if err := t.Transfer(ctx, src, dst, transferOpts...); err == nil {
-			return &ptypes.Empty{}, nil
+			return empty, nil
 		} else if !errdefs.IsNotImplemented(err) {
 			return nil, errdefs.ToGRPC(err)
 		}


### PR DESCRIPTION
Some services create a new `ptypes.Empty` pointer for every request. An improvement is to pre-define a pointer var and reuse the same one, which should reduce some heap allocation/gc/etc.

The pattern is already used in some other services; this PR just makes it consistent in all services.

https://github.com/containerd/containerd/blob/300fd770a019f09d65622b006a234a995870c0d3/plugins/services/tasks/local.go#L64

https://github.com/containerd/containerd/blob/2ac2b9c909fb64f4d06958a0ca2f556bec348d05/plugins/services/snapshots/service.go#L46

https://github.com/containerd/containerd/blob/300fd770a019f09d65622b006a234a995870c0d3/plugins/services/content/contentserver/contentserver.go#L44