### PR TITLE
Remove duplicated sandbox <-> proto conversion functions

### DIFF
--- a/plugins/sandbox/controller.go
+++ b/plugins/sandbox/controller.go
@@ -26,8 +26,8 @@ import (
 	"github.com/containerd/log"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
+	"github.com/containerd/typeurl/v2"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
-	"google.golang.org/protobuf/types/known/anypb"
 
 	runtimeAPI "github.com/containerd/containerd/api/runtime/sandbox/v1"
 	"github.com/containerd/containerd/api/types"
@@ -150,19 +150,11 @@ func (c *controllerLocal) Create(ctx context.Context, info sandbox.Sandbox, opts
 		return err
 	}
 
-	var options *anypb.Any
-	if coptions.Options != nil {
-		options = &anypb.Any{
-			TypeUrl: coptions.Options.GetTypeUrl(),
-			Value:   coptions.Options.GetValue(),
-		}
-	}
-
 	if _, err := svc.CreateSandbox(ctx, &runtimeAPI.CreateSandboxRequest{
 		SandboxID:  sandboxID,
 		BundlePath: shim.Bundle(),
 		Rootfs:     mount.ToProto(coptions.Rootfs),
-		Options:    options,
+		Options:    typeurl.MarshalProto(coptions.Options),
 		NetnsPath:  coptions.NetNSPath,
 	}); err != nil {
 		c.cleanupShim(ctx, sandboxID, svc)

--- a/plugins/services/images/helpers.go
+++ b/plugins/services/images/helpers.go
@@ -18,11 +18,9 @@ package images
 
 import (
 	imagesapi "github.com/containerd/containerd/api/services/images/v1"
-	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/containerd/v2/pkg/protobuf"
-	"github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func imagesToProto(images []images.Image) []*imagesapi.Image {
@@ -40,7 +38,7 @@ func imageToProto(image *images.Image) *imagesapi.Image {
 	return &imagesapi.Image{
 		Name:      image.Name,
 		Labels:    image.Labels,
-		Target:    descToProto(&image.Target),
+		Target:    oci.DescriptorToProto(image.Target),
 		CreatedAt: protobuf.ToTimestamp(image.CreatedAt),
 		UpdatedAt: protobuf.ToTimestamp(image.UpdatedAt),
 	}
@@ -50,26 +48,8 @@ func imageFromProto(imagepb *imagesapi.Image) images.Image {
 	return images.Image{
 		Name:      imagepb.Name,
 		Labels:    imagepb.Labels,
-		Target:    descFromProto(imagepb.Target),
+		Target:    oci.DescriptorFromProto(imagepb.Target),
 		CreatedAt: protobuf.FromTimestamp(imagepb.CreatedAt),
 		UpdatedAt: protobuf.FromTimestamp(imagepb.UpdatedAt),
-	}
-}
-
-func descFromProto(desc *types.Descriptor) ocispec.Descriptor {
-	return ocispec.Descriptor{
-		MediaType:   desc.MediaType,
-		Size:        desc.Size,
-		Digest:      digest.Digest(desc.Digest),
-		Annotations: desc.Annotations,
-	}
-}
-
-func descToProto(desc *ocispec.Descriptor) *types.Descriptor {
-	return &types.Descriptor{
-		MediaType:   desc.MediaType,
-		Size:        desc.Size,
-		Digest:      desc.Digest.String(),
-		Annotations: desc.Annotations,
 	}
 }

--- a/plugins/services/images/local.go
+++ b/plugins/services/images/local.go
@@ -30,6 +30,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/deprecation"
 	"github.com/containerd/containerd/v2/pkg/epoch"
 	"github.com/containerd/containerd/v2/pkg/gc"
+	"github.com/containerd/containerd/v2/pkg/oci"
 	ptypes "github.com/containerd/containerd/v2/pkg/protobuf/types"
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/containerd/v2/plugins/services"
@@ -168,7 +169,7 @@ func (l *local) Delete(ctx context.Context, req *imagesapi.DeleteImageRequest, _
 
 	var opts []images.DeleteOpt
 	if req.Target != nil {
-		desc := descFromProto(req.Target)
+		desc := oci.DescriptorFromProto(req.Target)
 		opts = append(opts, images.DeleteTarget(&desc))
 	}
 


### PR DESCRIPTION
The sandbox <-> proto conversions functions already exists at

https://github.com/containerd/containerd/blob/26d6fd0c3fe505ad3bb1525c4514ef21c19c24d4/core/sandbox/helpers.go#L27

Also removed a duplicated desc <-> proto conversion functions in a separate commit.
