### PR TITLE
using primary and slave DBs to solve the panic problem caused by DB conflicts

### DIFF
--- a/pkg/msdb/msbucket.go
+++ b/pkg/msdb/msbucket.go
@@ -1,0 +1,63 @@
+package msdb
+
+import (
+	bolt "go.etcd.io/bbolt"
+)
+
+type BucketAlias bolt.Bucket
+
+type MsBucket struct {
+	master *bolt.Bucket
+	slave  *bolt.Bucket
+}
+
+func (b *MsBucket) Master() *bolt.Bucket {
+	return b.master
+}
+
+func (b *MsBucket) MasterSlave() []*bolt.Bucket {
+	rslt := make([]*bolt.Bucket, 2)
+	rslt[0] = b.master
+	rslt[1] = b.slave
+	return rslt
+}
+
+func (b *MsBucket) CreateBucketIfNotExists(key []byte) (*MsBucket, error) {
+	var masterBucket, salveBucket *bolt.Bucket
+	var err error
+
+	masterBucket, err = b.master.CreateBucketIfNotExists(key)
+
+	if err == nil {
+		salveBucket, err = b.slave.CreateBucketIfNotExists(key)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &MsBucket{
+		master: masterBucket,
+		slave:  salveBucket,
+	}, nil
+}
+
+func (b *MsBucket) Bucket(name []byte) *MsBucket {
+	var masterBucket, salveBucket *bolt.Bucket
+
+	masterBucket = b.master.Bucket(name)
+
+	if masterBucket == nil {
+		return nil
+	}
+
+	salveBucket = b.slave.Bucket(name)
+	if salveBucket == nil {
+		return nil
+	}
+
+	return &MsBucket{
+		master: masterBucket,
+		slave:  salveBucket,
+	}
+}

--- a/pkg/msdb/msdb.go
+++ b/pkg/msdb/msdb.go
@@ -1,0 +1,144 @@
+package msdb
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+type MsDb struct {
+	master *bolt.DB
+	slave  *bolt.DB
+}
+
+func Open(path string, mode os.FileMode, options *bolt.Options) (msdb *MsDb, err error) {
+	var masterDb *bolt.DB
+
+	masterDb, err = tryOpenMasterDB(path, 0644, options)
+	if err != nil {
+		return nil, err
+	}
+
+	slaveDbPath := path + ".slave"
+	err = copyFile(path, slaveDbPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var slaveDb *bolt.DB
+	slaveDb, err = bolt.Open(slaveDbPath, 0644, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return &MsDb{
+		master: masterDb,
+		slave:  slaveDb,
+	}, nil
+}
+
+func (db *MsDb) Master() *bolt.DB {
+	return db.master
+}
+
+func (db *MsDb) Close() error {
+	err := db.master.Close()
+
+	if err == nil {
+		err = db.slave.Close()
+	}
+
+	return err
+}
+
+func (db *MsDb) Begin(writable bool) (*MsTx, error) {
+	var masterTx, salveTx *bolt.Tx
+	var err error
+
+	masterTx, err = db.master.Begin(writable)
+
+	if err == nil {
+		salveTx, err = db.slave.Begin(writable)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &MsTx{
+		master: masterTx,
+		slave:  salveTx,
+	}, nil
+}
+
+func (db *MsDb) Update(fn func(*bolt.Tx) error) error {
+	err := db.master.Update(fn)
+
+	if err == nil {
+		err = db.slave.Update(fn)
+	}
+
+	return err
+}
+
+func (db *MsDb) View(fn func(*bolt.Tx) error) error {
+	return db.master.View(fn)
+}
+
+func tryOpenMasterDB(path string, mode os.FileMode, options *bolt.Options) (db *bolt.DB, err error) {
+	slaveDbPath := path + ".slave"
+	pathBackup := path + ".backup"
+
+	defer func() {
+		if e := recover(); e != nil {
+			if _, err := os.Stat(slaveDbPath); err == nil {
+				if err := os.Rename(slaveDbPath, pathBackup); err != nil {
+					panic(fmt.Sprintf("rename %s-%s err %v: failed (%v)", slaveDbPath, pathBackup, err, e))
+				}
+			} else {
+				panic(fmt.Sprintf("slave db path %s err %v, by open db %s failed (%v)", slaveDbPath, err, path, e))
+			}
+
+			panic(fmt.Sprintf("open db %s failed (%v),rename %s-%s success", path, e, slaveDbPath, pathBackup))
+		}
+	}()
+
+	if _, err := os.Stat(pathBackup); err == nil {
+		if err := os.Rename(pathBackup, path); err != nil {
+			return nil, err
+		}
+	}
+
+	db, err = bolt.Open(path, 0644, options)
+
+	return
+}
+
+func copyFile(src, dst string) error {
+	os.RemoveAll(dst)
+
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+
+	dstFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer dstFile.Close()
+
+	_, err = io.Copy(dstFile, srcFile)
+	if err != nil {
+		return err
+	}
+
+	if err := dstFile.Sync(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/msdb/mstx.go
+++ b/pkg/msdb/mstx.go
@@ -1,0 +1,74 @@
+package msdb
+
+import (
+	bolt "go.etcd.io/bbolt"
+)
+
+type MsTx struct {
+	master *bolt.Tx
+	slave  *bolt.Tx
+}
+
+func (b *MsTx) Master() *bolt.Tx {
+	return b.master
+}
+
+func (tx *MsTx) CreateBucketIfNotExists(name []byte) (*MsBucket, error) {
+	var masterBucket, salveBucket *bolt.Bucket
+	var err error
+
+	masterBucket, err = tx.master.CreateBucketIfNotExists(name)
+
+	if err == nil {
+		salveBucket, err = tx.slave.CreateBucketIfNotExists(name)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &MsBucket{
+		master: masterBucket,
+		slave:  salveBucket,
+	}, nil
+}
+
+func (tx *MsTx) Bucket(name []byte) *MsBucket {
+	var masterBucket, salveBucket *bolt.Bucket
+
+	masterBucket = tx.master.Bucket(name)
+
+	if masterBucket == nil {
+		return nil
+	}
+
+	salveBucket = tx.slave.Bucket(name)
+	if salveBucket == nil {
+		return nil
+	}
+
+	return &MsBucket{
+		master: masterBucket,
+		slave:  salveBucket,
+	}
+}
+
+func (tx *MsTx) Commit() error {
+	err := tx.master.Commit()
+
+	if err == nil {
+		err = tx.slave.Commit()
+	}
+
+	return err
+}
+
+func (tx *MsTx) Rollback() error {
+	err := tx.master.Rollback()
+
+	if err == nil {
+		err = tx.slave.Rollback()
+	}
+
+	return err
+}

--- a/plugins/metadata/plugin.go
+++ b/plugins/metadata/plugin.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containerd/containerd/v2/core/events"
 	"github.com/containerd/containerd/v2/core/metadata"
 	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/pkg/msdb"
 	"github.com/containerd/containerd/v2/pkg/timeout"
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/errdefs"
@@ -158,7 +159,7 @@ func init() {
 					return
 				}
 			}()
-			db, err := bolt.Open(path, 0644, &options)
+			db, err := msdb.Open(path, 0644, &options)
 			close(doneCh)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
When the system is powered off and reset, containerd experiences a panic:
panic: freepages: failed to get all reachable pages (key[0]=(hex)** on leaf page(1229) needs to be < than key of the next element in ancestor(hex)**. Pages stack: [1974,1229])

The main steps for using primary and slave DBs to solve the panic problem caused by DB conflicts are as follows:
1. When opening db, if successful, it will be opened as master db and copied as slave db. Otherwise, open slave db as master db and copy master db as slave db.
2. Combining master db and slave db as primary and backup db objects, overloading the Begin method of bolt DB to create MsTx objects (primary and backup Tx objects)
3. Overload the CreateBucketIfNotExists method of Tx to create MsBucket objects (primary and backup Bucket objects)
4. The metadata plugin and snapshot MetaStore use MsDb, with write operations starting with the master db and then the slave db

When the system is powered off, if writing to master db causes a master db conflict, containerd will use slave db after panic. If you are writing a slave db, containerd will create a new slave db.

kind: bug