### PR TITLE
Prepare release notes for v1.7.22

### DIFF
--- a/releases/v1.7.22.toml
+++ b/releases/v1.7.22.toml
@@ -1,0 +1,27 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.7.21"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The twenty-second patch release for containerd 1.7 contains various fixes
+and updates.
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.7.21+unknown"
+	Version = "1.7.22+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
containerd 1.7.22

Welcome to the v1.7.22 release of containerd!

The twenty-second patch release for containerd 1.7 contains various fixes
and updates.

### Highlights

#### Build and Release Toolchain

* Update to go1.22.7, go1.23.1 ([#10679](https://github.com/containerd/containerd/pull/10679))

#### Container Runtime Interface (CRI)

* Cumulative stats can't decrease ([#10670](https://github.com/containerd/containerd/pull/10670))

#### Runtime

* Fix bug where init exits were being dropped ([#10675](https://github.com/containerd/containerd/pull/10675))
* Update runc binary to 1.1.14 ([#10668](https://github.com/containerd/containerd/pull/10668))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Samuel Karp
* James Sturtevant
* Laura Brehm
* Maksym Pavlenko
* Akhil Mohan
* Akihiro Suda
* Cory Snider
* Sebastiaan van Stijn

### Changes
<details><summary>14 commits</summary>
<p>

* integration: regression test for issue 10589 ([#10682](https://github.com/containerd/containerd/pull/10682))
  * [`0c4ba21d8`](https://github.com/containerd/containerd/commit/0c4ba21d855ce81b2b946d2f6779c1dc529da506) integration: regression test for issue 10589
  * [`1cc2cfa4b`](https://github.com/containerd/containerd/commit/1cc2cfa4bf042e8c202f44903a6445bd1f432a5b) fifosync: cross-process synchronization
* Fix bug where init exits were being dropped ([#10675](https://github.com/containerd/containerd/pull/10675))
  * [`f338717ed`](https://github.com/containerd/containerd/commit/f338717ed4fdc06d289b8d6e2862eeb3035b32da) runc-shim: handle pending execs as running
  * [`686c69490`](https://github.com/containerd/containerd/commit/686c69490d0bb9ed6513b3ed2f2502ec65b11d75) runc-shim: refuse to start execs after init exits
  * [`760935e52`](https://github.com/containerd/containerd/commit/760935e5211df1b6681fcf14d62804710fe512cd) runc-shim: remove misleading comment
* Update to go1.22.7, go1.23.1 ([#10679](https://github.com/containerd/containerd/pull/10679))
  * [`19d678f73`](https://github.com/containerd/containerd/commit/19d678f732da9fcf9445a65ece4ad5ad3e993580) update to go1.22.7, go1.23.1
* Cumulative stats can't decrease ([#10670](https://github.com/containerd/containerd/pull/10670))
  * [`3658d5b40`](https://github.com/containerd/containerd/commit/3658d5b403bbcb92f994cfdcd03b6fca1acb87aa) Include change in cri server
  * [`88d001c74`](https://github.com/containerd/containerd/commit/88d001c749a8b90416460c776196c88f0fc26977) Cumulative stats can't decrease
* Update runc binary to 1.1.14 ([#10668](https://github.com/containerd/containerd/pull/10668))
  * [`33e8a2005`](https://github.com/containerd/containerd/commit/33e8a20050808a9d9300269d2ce705ec934154e3) update runc binary to 1.1.14
</p>
</details>

### Dependency Changes

This release has no dependency changes

Previous release can be found at [v1.7.21](https://github.com/containerd/containerd/releases/tag/v1.7.21)

--------

Generated by:

```
~/go/bin/release-tool -g -r -d -n --cache ~/.cache/release-tool -t v1.7.22 ./releases/v1.7.22.toml
```