### PR TITLE
Prepare release notes for v1.6.36

### DIFF
--- a/releases/v1.6.36.toml
+++ b/releases/v1.6.36.toml
@@ -1,0 +1,27 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.6.35"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The thirty-sixth patch release for containerd 1.6 contains various fixes
+and updates.
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.35+unknown"
+	Version = "1.6.36+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
containerd 1.6.36

Welcome to the v1.6.36 release of containerd!

The thirty-sixth patch release for containerd 1.6 contains various fixes
and updates.

### Highlights

* Ensure the CRIAPIV1Alpha2 warning's lastOccurrence is accurate ([#10582](https://github.com/containerd/containerd/pull/10582))

#### Build and Release Toolchain

* Update to go1.22.7, go1.23.1 ([#10680](https://github.com/containerd/containerd/pull/10680))

#### Container Runtime Interface (CRI)

* Cumulative stats can't decrease ([#10671](https://github.com/containerd/containerd/pull/10671))
* Fix memory leak with `kubectl exec` >= 1.30.0 ([#10574](https://github.com/containerd/containerd/pull/10574))

#### Runtime

* Fix bug where init exits were being dropped ([#10676](https://github.com/containerd/containerd/pull/10676))
* Update runc binary to 1.1.14 ([#10667](https://github.com/containerd/containerd/pull/10667))

#### Deprecations

* Ensure the CRIAPIV1Alpha2 warning's lastOccurrence is accurate ([#10582](https://github.com/containerd/containerd/pull/10582))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Samuel Karp
* Davanum Srinivas
* Akhil Mohan
* Akihiro Suda
* Laura Brehm
* Sebastiaan van Stijn
* Chris Henzie
* Cory Snider
* James Sturtevant
* Maksym Pavlenko
* Mike Brown
* Phil Estes
* Shengjing Zhu

### Changes
<details><summary>31 commits</summary>
<p>

  * [`77eba0908`](https://github.com/containerd/containerd/commit/77eba0908b7272bccb7deeb6ef8e1aa5733beaa7) Prepare release notes for v1.6.36
* integration: regression test for issue 10589 ([#10683](https://github.com/containerd/containerd/pull/10683))
  * [`ab9fedde2`](https://github.com/containerd/containerd/commit/ab9fedde2888c382e8eeec875622620a5b90b027) integration: regression test for issue 10589
  * [`d0989e952`](https://github.com/containerd/containerd/commit/d0989e952d28dfcbe94f64b1ea40897fc7834e93) fifosync: cross-process synchronization
* Fix bug where init exits were being dropped ([#10676](https://github.com/containerd/containerd/pull/10676))
  * [`c9617c321`](https://github.com/containerd/containerd/commit/c9617c321f016fef7678f5333075542e6e565cbb) runc-shim: handle pending execs as running
  * [`15ad6ac67`](https://github.com/containerd/containerd/commit/15ad6ac67216a04fcf5c996e0e10b79d9a3bff6d) runc-shim: refuse to start execs after init exits
  * [`7e6a18c24`](https://github.com/containerd/containerd/commit/7e6a18c2472b036eefbb8be6301447391722cc55) runc-shim: remove misleading comment
* Update to go1.22.7, go1.23.1 ([#10680](https://github.com/containerd/containerd/pull/10680))
  * [`951af274c`](https://github.com/containerd/containerd/commit/951af274c4154f353a624b8004c400d6aed13088) update to go1.22.7, go1.23.1
* Cumulative stats can't decrease ([#10671](https://github.com/containerd/containerd/pull/10671))
  * [`c8e5b1eb6`](https://github.com/containerd/containerd/commit/c8e5b1eb692dbe1439d668f31caebf7c77f08cff) Cumulative stats can't decrease
* move builds to go1.22 and testing to go1.23 ([#10595](https://github.com/containerd/containerd/pull/10595))
  * [`0bbc90aee`](https://github.com/containerd/containerd/commit/0bbc90aee447736b2cdc9e79bbb447442971e2d7) use git clone to install gogo/protobuf
  * [`383b2dcd1`](https://github.com/containerd/containerd/commit/383b2dcd1f3f55c46d388e6c0f116740e01b61c4) move builds to go1.22 and testing to go1.23
* Update runc binary to 1.1.14 ([#10667](https://github.com/containerd/containerd/pull/10667))
  * [`fd70da38b`](https://github.com/containerd/containerd/commit/fd70da38ba59bed7476e05aca59f51f130149f51) update runc binary to 1.1.14
* Fix TestNewBinaryIOCleanup on Go 1.23 and Linux 5.4 ([#10591](https://github.com/containerd/containerd/pull/10591))
  * [`4fd7d4eef`](https://github.com/containerd/containerd/commit/4fd7d4eef143baadfad5f37080692bada83d7702) Fix TestNewBinaryIOCleanup on Go 1.23 and Linux 5.4
* Fix memory leak with `kubectl exec` >= 1.30.0 ([#10574](https://github.com/containerd/containerd/pull/10574))
  * [`6f9efd3a9`](https://github.com/containerd/containerd/commit/6f9efd3a909dbdaed4edbdb5392861379f39cb0d) hide wsstream under internal/ to prevent external use
  * [`4694b84e8`](https://github.com/containerd/containerd/commit/4694b84e825cb33c82a6fa752844a4211e09b351) golangci-lint should only look for problems in new code
  * [`05c2b1413`](https://github.com/containerd/containerd/commit/05c2b141386d5cb59aabcae1aee9d45297056436) Run go mod tidy
  * [`a7b0c015d`](https://github.com/containerd/containerd/commit/a7b0c015d20695cfdcc125c961a1900ba0ee5a84) Add copyright headers
  * [`78f079926`](https://github.com/containerd/containerd/commit/78f079926886632c77ac642f69f92b0cec90365a) switch over references to the new package
  * [`64430d636`](https://github.com/containerd/containerd/commit/64430d63666514900bdfabb96c912a1920278367) Fix up some constant references
  * [`a37b08102`](https://github.com/containerd/containerd/commit/a37b081023f06258a9b314366e1df9acbcaadcb8) Copy over wsstream from k8s v1.31.0-rc.1 release
* Ensure the CRIAPIV1Alpha2 warning's lastOccurrence is accurate ([#10582](https://github.com/containerd/containerd/pull/10582))
  * [`d727961d2`](https://github.com/containerd/containerd/commit/d727961d2ded6843c66eb52c5c6efcc7a9b9a9ff) Update CRIAPIV1Alpha2 warning lastOccurrence every call
* update to go1.21.13 / go1.22.6 ([#10577](https://github.com/containerd/containerd/pull/10577))
  * [`be0f0db07`](https://github.com/containerd/containerd/commit/be0f0db070cdc71344403634177f6c57f88510ca) update to go1.21.13 / go1.22.6
</p>
</details>

### Dependency Changes

This release has no dependency changes

Previous release can be found at [v1.6.35](https://github.com/containerd/containerd/releases/tag/v1.6.35)

----

Generated by:

```
$ ~/go/bin/release-tool -g -r -d -n --cache ~/.cache/release-tool -t v1.6.36 ./releases/v1.6.36.toml
```