### PR TITLE
CRI: attempt to fetch discarded image layers during unpack

### DIFF
--- a/image.go
+++ b/image.go
@@ -344,6 +344,8 @@ func WithUnpackApplyOpts(opts ...diff.ApplyOpt) UnpackOpt {
 	}
 }
 
+type DiscardUnpackedLayersKey struct{}
+
 func (i *image) Unpack(ctx context.Context, snapshotterName string, opts ...UnpackOpt) error {
 	ctx, done, err := i.client.WithLease(ctx)
 	if err != nil {
@@ -392,7 +394,24 @@ func (i *image) Unpack(ctx context.Context, snapshotterName string, opts ...Unpa
 	for _, layer := range layers {
 		unpacked, err = rootfs.ApplyLayerWithOpts(ctx, layer, chain, sn, a, config.SnapshotOpts, config.ApplyOpts)
 		if err != nil {
-			return err
+			// layer not found in content, try to fetch layer and retry unpack
+			if errdefs.IsNotFound(err) {
+				pullOpts := []RemoteOpt{}
+				if discardUnpackedLayers, ok := ctx.Value(DiscardUnpackedLayersKey{}).(bool); ok && discardUnpackedLayers {
+					pullOpts = append(pullOpts, WithChildLabelMap(images.ChildGCLabelsFilterLayers))
+				}
+
+				if _, err2 := i.client.Pull(ctx, i.Name(), pullOpts...); err2 != nil {
+					return fmt.Errorf("fetch lost layer failed: %w : %w", err2, err)
+				}
+				// retry
+				unpacked, err = rootfs.ApplyLayerWithOpts(ctx, layer, chain, sn, a, config.SnapshotOpts, config.ApplyOpts)
+				if err != nil {
+					return err
+				}
+			} else {
+				return err
+			}
 		}
 
 		if unpacked {

--- a/pkg/cri/server/container_create.go
+++ b/pkg/cri/server/container_create.go
@@ -260,6 +260,9 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	}()
 
 	var cntr containerd.Container
+	if c.config.ContainerdConfig.DiscardUnpackedLayers {
+		ctx = context.WithValue(ctx, containerd.DiscardUnpackedLayersKey{}, true)
+	}
 	if cntr, err = c.client.NewContainer(ctx, id, opts...); err != nil {
 		return nil, fmt.Errorf("failed to create containerd container: %w", err)
 	}

--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -174,6 +174,9 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		containerd.WithContainerExtension(sandboxMetadataExtension, &sandbox.Metadata),
 		containerd.WithRuntime(ociRuntime.Type, runtimeOpts)}
 
+	if c.config.ContainerdConfig.DiscardUnpackedLayers {
+		ctx = context.WithValue(ctx, containerd.DiscardUnpackedLayersKey{}, true)
+	}
 	container, err := c.client.NewContainer(ctx, id, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create containerd container: %w", err)


### PR DESCRIPTION
Ref: https://github.com/containerd/containerd/issues/8674  and https://github.com/containerd/containerd/pull/8878

This commit addresses two key scenarios where image unpacking may fail due to missing layers when the discard_unpacked_layers configuration is enabled.

# Problem 1: Inconsistent Metadata
In some cases, the image metadata in memory might indicate that an image exists, even if the underlying content or snapshot has been removed (e.g., if bypassing the CRI plugin). This inconsistency causes issues when creating a sandbox or container, as the snapshot cannot be found. The unpack process needs to fetch the missing image layers to resolve this.

# Problem 2: Snapshotter Switching
When using overlayfs as the default snapshotter with discard_unpacked_layers enabled, the image layers are discarded after unpacking. If the snapshotter is switched to a different backend (e.g., nydus or estargz), attempts to create pods with previously pulled images will fail because the new snapshotter cannot access the discarded layers.

# Solution
To solve both cases, this fix introduces logic to attempt fetching discarded image layers if they are missing during unpack. This ensures that sandbox or container creation can proceed even after the layers have been discarded.