### PR TITLE
Use flush to accelerate in-memory big data write to storage.

### DIFF
--- a/plugins/content/local/writer.go
+++ b/plugins/content/local/writer.go
@@ -94,11 +94,6 @@ func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest,
 		return fmt.Errorf("cannot commit on closed writer: %w", errdefs.ErrFailedPrecondition)
 	}
 
-	if err := fp.Sync(); err != nil {
-		fp.Close()
-		return fmt.Errorf("sync failed: %w", err)
-	}
-
 	fi, err := fp.Stat()
 	closeErr := fp.Close()
 	if err != nil {


### PR DESCRIPTION
`fp.Sync()` may take serval minutes to write in-memory big data to storage.
Use `Flush` method instead to accelarate it.