### PR TITLE
Add --image-path option for ctr container checkpoint and restore command

### DIFF
--- a/client/container_checkpoint_opts.go
+++ b/client/container_checkpoint_opts.go
@@ -52,6 +52,14 @@ func WithCheckpointImage(ctx context.Context, client *Client, c *containers.Cont
 	return nil
 }
 
+// WithCheckpointCriuImagePath includes the CRIU image path in the checkpoint
+func WithCheckpointCriuImagePath(imagePath string) CheckpointOpts {
+	return func(ctx context.Context, client *Client, c *containers.Container, index *imagespec.Index, copts *options.CheckpointOptions) error {
+		copts.ImagePath = imagePath
+		return nil
+	}
+}
+
 // WithCheckpointTask includes the running task
 func WithCheckpointTask(ctx context.Context, client *Client, c *containers.Container, index *imagespec.Index, copts *options.CheckpointOptions) error {
 	opt, err := typeurl.MarshalAnyToProto(copts)

--- a/cmd/ctr/commands/containers/checkpoint.go
+++ b/cmd/ctr/commands/containers/checkpoint.go
@@ -43,6 +43,10 @@ var checkpointCommand = &cli.Command{
 			Name:  "task",
 			Usage: "Checkpoint container task",
 		},
+		&cli.StringFlag{
+			Name:  "image-path",
+			Usage: "Path to criu image files",
+		},
 	},
 	Action: func(cliContext *cli.Context) error {
 		id := cliContext.Args().First()
@@ -62,6 +66,10 @@ var checkpointCommand = &cli.Command{
 			containerd.WithCheckpointRuntime,
 		}
 
+		imagePath := cliContext.String("image-path")
+		if imagePath != "" {
+			opts = append(opts, containerd.WithCheckpointCriuImagePath(imagePath))
+		}
 		if cliContext.Bool("image") {
 			opts = append(opts, containerd.WithCheckpointImage)
 		}

--- a/cmd/ctr/commands/containers/restore.go
+++ b/cmd/ctr/commands/containers/restore.go
@@ -42,6 +42,10 @@ var restoreCommand = &cli.Command{
 			Name:  "live",
 			Usage: "Restore the runtime and memory data from the checkpoint",
 		},
+		&cli.StringFlag{
+			Name:  "image-path",
+			Usage: "Path to criu image files",
+		},
 	},
 	Action: func(cliContext *cli.Context) error {
 		id := cliContext.Args().First()
@@ -85,8 +89,18 @@ var restoreCommand = &cli.Command{
 			return err
 		}
 		topts := []containerd.NewTaskOpts{}
-		if cliContext.Bool("live") {
-			topts = append(topts, containerd.WithTaskCheckpoint(checkpoint))
+		imagePath := cliContext.String("image-path")
+		switch cliContext.Bool("live") {
+		case true:
+			if imagePath == "" {
+				topts = append(topts, containerd.WithTaskCheckpoint(checkpoint))
+			} else {
+				return errors.New("live and image-path must not be both provided")
+			}
+		case false:
+			if imagePath != "" {
+				topts = append(topts, containerd.WithRestoreImagePath(imagePath))
+			}
 		}
 		spec, err := ctr.Spec(ctx)
 		if err != nil {


### PR DESCRIPTION
In some cases, we want to checkpoint container process to custom criu image path and restore from it.
This also can **greatly reduce checkpoint time** from minutes to seconds for big images.

Before:
```
[root@localhost containerd]# time ctr c checkpoint --rw --task test checkpoint/test

real    1m57.343s
user    0m0.015s
sys     0m0.010s
```
After:
```
[root@localhost containerd]# time ctr c checkpoint  --image-path /tmp/testxxx --rw --task test checkpoint/test

real    0m18.766s
user    0m0.021s
sys     0m0.000s

[root@localhost containerd]# du -sh /tmp/testxxx
8.6G    /tmp/testxxx
```