### PR TITLE
Fix the race condition during GC of snapshots when client retries

### DIFF
--- a/pkg/unpack/unpacker.go
+++ b/pkg/unpack/unpacker.go
@@ -298,13 +298,6 @@ func (u *Unpacker) unpack(
 		}
 		defer unlock()
 
-		if _, err := sn.Stat(ctx, chainID); err == nil {
-			// no need to handle
-			return nil
-		} else if !errdefs.IsNotFound(err) {
-			return fmt.Errorf("failed to stat snapshot %s: %w", chainID, err)
-		}
-
 		// inherits annotations which are provided as snapshot labels.
 		snapshotLabels := snapshots.FilterInheritedLabels(desc.Annotations)
 		if snapshotLabels == nil {


### PR DESCRIPTION
When an upstream client (e.g. kubelet) stops or restarts, the CRI connection to the containerd gets interrupted which is treated as a cancellation of context which subsequently cancels an ongoing operation, [including an image pull](https://github.com/containerd/containerd/blob/e82d201b3ffb87c15d2b7be2eb2e0c7bfa99d114/pkg/cri/server/image_pull.go#L150). This generally gets followed by containerd's GC routine that tries to delete the prepared snapshots for the image layer(s) corresponding to the image in the pull operation that got cancelled. However, if the upstream client immediately retries (or starts a new) image pull operation, containerd initiates a new image pull and starts unpacking the image layers into snapshots. This may create a race condition: the GC routine (corresponding to the failed image pull operation) trying to clean up the same snapshot that the new image pull operation is preparing, thus leading to the "parent snapshot does not exist: not found" error.

#### Race Condition Scenario
Assume an image consisting of 2 layers (L1 and L2, L1 being the bottom layer) that are supposed to get unpacked into snapshots S1 and S2 respectively.

During an image pull operation, containerd unpacks(L1) which involves [Stat()'ing the chainID](https://github.com/containerd/containerd/blob/e82d201b3ffb87c15d2b7be2eb2e0c7bfa99d114/pkg/unpack/unpacker.go#L301). This Stat() fails as the chainID does not exist and [Prepare(L1) gets called](https://github.com/containerd/containerd/blob/e82d201b3ffb87c15d2b7be2eb2e0c7bfa99d114/pkg/unpack/unpacker.go#L324). Once S1 gets prepared, containerd processes L2 - unpack(L2) which again involves Stat()'ing the chainID which fails as the chainID for S2 does not exist which results in the call to Prepare(L2). However, if the image pull operation gets cancelled before Prepare(L2) is called, then the GC routine tries to clean up S1.

When the image pull operation is retried by the upstream client, containerd follows the same series of operations. unpack(L1) gets called which then calls Stat(chainID) for L1. However, this time, Stat(L1) succeeds as S1 already exists (from the previous image pull operation) and thus containerd goes to the next iteration to unpack(L2). Now, GC cleans up S1 and when Prepare(L2) gets called, it returns back the ["parent snapshot does not exist: not found" error](https://github.com/containerd/containerd/blob/e82d201b3ffb87c15d2b7be2eb2e0c7bfa99d114/metadata/snapshot.go#L358).

#### Fix
Removing the "Stat() + early return" fixes the race condition. Now during the image pull operation corresponding to the client retry, although the chainID (for L1) already exists, containerd does not return early and goes on to Prepare(L1). Since L1 is already prepared, it [adds a new lease to S1 and then returns `ErrAlreadyExists`](https://github.com/containerd/containerd/blob/e82d201b3ffb87c15d2b7be2eb2e0c7bfa99d114/metadata/snapshot.go#L347-L353). This new lease prevents GC from cleaning up S1 when containerd processes L2 (unpack(L2) -> Prepare(L2)).

Fixes: https://github.com/containerd/containerd/issues/3787