### PR TITLE
Fix data loss in rootfs overlayfs when unmount of tmp dirs fail with idmap mounts

### DIFF
--- a/core/mount/mount_linux.go
+++ b/core/mount/mount_linux.go
@@ -256,9 +256,16 @@ func doPrepareIDMappedOverlay(lowerDirs []string, usernsFd int) (tmpLowerDirs []
 			if err := unix.Unmount(lowerDir, unix.MNT_DETACH); err != nil {
 				log.L.WithError(err).Warnf("failed to unmount temp lowerdir %s", lowerDir)
 			}
+			// Using os.Remove() so if it's not empty, we don't delete files in the
+			// rootfs.
+			if err := os.Remove(lowerDir); err != nil {
+				log.L.WithError(err).Warnf("failed to remove temporary overlay lowerdir's")
+			}
 		}
-		if terr := os.RemoveAll(filepath.Clean(filepath.Join(tmpLowerDirs[0], ".."))); terr != nil {
-			log.L.WithError(terr).Warnf("failed to remove temporary overlay lowerdir's")
+
+		// This dir should be empty now. Otherwise, we don't do anything.
+		if err := os.Remove(filepath.Join(tmpLowerDirs[0], "..")); err != nil {
+			log.L.WithError(err).Infof("failed to remove temporary overlay dir")
 		}
 	}
 	for i, lowerDir := range lowerDirs {

--- a/core/mount/mount_linux.go
+++ b/core/mount/mount_linux.go
@@ -251,7 +251,9 @@ func doPrepareIDMappedOverlay(lowerDirs []string, usernsFd int) (tmpLowerDirs []
 	}
 	cleanUp := func() {
 		for _, lowerDir := range tmpLowerDirs {
-			if err := unix.Unmount(lowerDir, 0); err != nil {
+			// Do a detached unmount so even if the resource is busy, the mount will be
+			// gone (eventually) and we can safely delete the directory too.
+			if err := unix.Unmount(lowerDir, unix.MNT_DETACH); err != nil {
 				log.L.WithError(err).Warnf("failed to unmount temp lowerdir %s", lowerDir)
 			}
 		}

--- a/core/mount/mount_linux.go
+++ b/core/mount/mount_linux.go
@@ -255,6 +255,7 @@ func doPrepareIDMappedOverlay(lowerDirs []string, usernsFd int) (tmpLowerDirs []
 			// gone (eventually) and we can safely delete the directory too.
 			if err := unix.Unmount(lowerDir, unix.MNT_DETACH); err != nil {
 				log.L.WithError(err).Warnf("failed to unmount temp lowerdir %s", lowerDir)
+				continue
 			}
 			// Using os.Remove() so if it's not empty, we don't delete files in the
 			// rootfs.


### PR DESCRIPTION
This fixes #10704 . Big kudos to @mbaynton for reporting this issue with lot of details, nailing it down to containerd lines of code and showing all the log lines to understand the big picture of what was happening.

PR #5890 added code to unmount and delete the tmp directories for each layer of the overlayfs that is idmapped (idmap support for overlayfs needs to idmap each layer). The thing is, it was using os.RemoveAll() which will remove all recursively and not skipping it if the unmount failed. Therefore, if the unmount fails this is removing the rootfs of the container.

This PR just changes this to:
1. Do the mount detached: this means if the mount is busy (as reported in issue #10704), it will work just fine, make the mount unavailable for new accesses and the actual unmount is done when it stops being busy.
1. Don't use os.RemoveAll(), as that can erase the rootfs. Let's just use os.Remove() that only deletes empty directories (or single files). To use it, I'm making sure the directories should be empty.
1. Skip some of the steps if the unmount fails, as it is pointless to remove the directories if the unmount failed.

There is a repro for this issue and I've confirmed that if the unmount fails, we are not handling it correctly and we cause data-loss, which is horrible. Of course, this PR fixes the issue for the repro too.

I'll also open a follow-up PR to add tests for this and maybe some other small fixes and improvements. But let's fix this data-loss ASAP, I'll follow-up with the other changes.

Fixes #10704 

cc @fuweid @AkihiroSuda 