### PR TITLE
Support multiple uid/gid mappings [2/2]

### DIFF
--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -175,11 +175,7 @@ func NewContainer(ctx context.Context, client *containerd.Client, cliContext *cl
 				// fuse-overlayfs - https://github.com/containerd/fuse-overlayfs-snapshotter
 				// overlay - in case of idmapped mount points are supported by host kernel (Linux kernel 5.19)
 				if cliContext.Bool("remap-labels") {
-					// TODO: the optimization code path on id mapped mounts only supports single mapping entry today.
-					if len(uidSpec) > 1 || len(gidSpec) > 1 {
-						return nil, errors.New("'remap-labels' option does not support multiple mappings")
-					}
-					cOpts = append(cOpts, containerd.WithNewSnapshot(id, image, containerd.WithRemapperLabels(0, uidSpec[0].HostID, 0, gidSpec[0].HostID, uidSpec[0].Size)))
+					cOpts = append(cOpts, containerd.WithNewSnapshot(id, image, containerd.WithUserNSRemapperLabels(uidSpec, gidSpec)))
 				} else {
 					cOpts = append(cOpts, containerd.WithUserNSRemappedSnapshot(id, image, uidSpec, gidSpec))
 				}

--- a/core/mount/mount_idmapped_linux.go
+++ b/core/mount/mount_idmapped_linux.go
@@ -26,39 +26,55 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// TODO: Support multiple mappings in future
-func parseIDMapping(mapping string) ([]syscall.SysProcIDMap, error) {
+func parseIDMapping(mapping string) (syscall.SysProcIDMap, error) {
+	var retval syscall.SysProcIDMap
+
 	parts := strings.Split(mapping, ":")
 	if len(parts) != 3 {
-		return nil, fmt.Errorf("user namespace mappings require the format `container-id:host-id:size`")
+		return retval, fmt.Errorf("user namespace mappings require the format `container-id:host-id:size`")
 	}
 
 	cID, err := strconv.Atoi(parts[0])
 	if err != nil {
-		return nil, fmt.Errorf("invalid container id for user namespace remapping, %w", err)
+		return retval, fmt.Errorf("invalid container id for user namespace remapping, %w", err)
 	}
 
 	hID, err := strconv.Atoi(parts[1])
 	if err != nil {
-		return nil, fmt.Errorf("invalid host id for user namespace remapping, %w", err)
+		return retval, fmt.Errorf("invalid host id for user namespace remapping, %w", err)
 	}
 
 	size, err := strconv.Atoi(parts[2])
 	if err != nil {
-		return nil, fmt.Errorf("invalid size for user namespace remapping, %w", err)
+		return retval, fmt.Errorf("invalid size for user namespace remapping, %w", err)
 	}
 
 	if cID < 0 || hID < 0 || size < 0 {
-		return nil, fmt.Errorf("invalid mapping %s, all IDs and size must be positive integers", mapping)
+		return retval, fmt.Errorf("invalid mapping %s, all IDs and size must be positive integers", mapping)
 	}
 
-	return []syscall.SysProcIDMap{
-		{
-			ContainerID: cID,
-			HostID:      hID,
-			Size:        size,
-		},
-	}, nil
+	retval = syscall.SysProcIDMap{
+		ContainerID: cID,
+		HostID:      hID,
+		Size:        size,
+	}
+
+	return retval, nil
+}
+
+func parseIDMappingList(mappings string) ([]syscall.SysProcIDMap, error) {
+	var (
+		res     []syscall.SysProcIDMap
+		maplist = strings.Split(mappings, ",")
+	)
+	for _, m := range maplist {
+		r, err := parseIDMapping(m)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, r)
+	}
+	return res, nil
 }
 
 // IDMapMount applies GID/UID shift according to gidmap/uidmap for target path
@@ -88,15 +104,15 @@ func IDMapMount(source, target string, usernsFd int) (err error) {
 	return nil
 }
 
-// GetUsernsFD forks the current process and creates a user namespace using
-// the specified mappings.
+// GetUsernsFD forks the current process and creates a user namespace using the specified mappings.
+// Expected syntax of ID mapping parameter is "%d:%d:%d[,%d:%d:%d,...]"
 func GetUsernsFD(uidmap, gidmap string) (_usernsFD *os.File, _ error) {
-	uidMaps, err := parseIDMapping(uidmap)
+	uidMaps, err := parseIDMappingList(uidmap)
 	if err != nil {
 		return nil, err
 	}
 
-	gidMaps, err := parseIDMapping(gidmap)
+	gidMaps, err := parseIDMappingList(gidmap)
 	if err != nil {
 		return nil, err
 	}

--- a/core/mount/mount_idmapped_linux_test.go
+++ b/core/mount/mount_idmapped_linux_test.go
@@ -98,6 +98,11 @@ func testGetUsernsFD(t *testing.T) {
 			hasErr:  false,
 		},
 		{
+			uidMaps: "0:1000:100,100:2000:200",
+			gidMaps: "0:1000:100,100:2000:200",
+			hasErr:  false,
+		},
+		{
 			uidMaps: "100:1000:100",
 			gidMaps: "0:-1:100",
 			hasErr:  true,
@@ -110,6 +115,11 @@ func testGetUsernsFD(t *testing.T) {
 		{
 			uidMaps: "100:1000:100",
 			gidMaps: "0:1000:-1",
+			hasErr:  true,
+		},
+		{
+			uidMaps: "100:1000:100",
+			gidMaps: "0:1000:-1,100:1000:100",
 			hasErr:  true,
 		},
 	} {

--- a/integration/client/container_idmapped_linux_test.go
+++ b/integration/client/container_idmapped_linux_test.go
@@ -23,101 +23,157 @@ import (
 	"testing"
 
 	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/internal/userns"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/containerd/v2/plugins/snapshots/overlay/overlayutils"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 func TestIDMappedOverlay(t *testing.T) {
-	var (
-		upperPath   string
-		lowerPaths  []string
-		snapshotter = "overlayfs"
-		ctx, cancel = testContext(t)
-		id          = t.Name()
-	)
-	defer cancel()
-
 	if ok, err := overlayutils.SupportsIDMappedMounts(); err != nil || !ok {
 		t.Skip("overlayfs doesn't support idmapped mounts")
 	}
 
-	client, err := newClient(t, address)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer client.Close()
+	for name, test := range map[string]struct {
+		idMap   userns.IDMap
+		snapOpt func(idMap userns.IDMap) snapshots.Opt
+		expUID  uint32
+		expGID  uint32
+	}{
+		"TestIDMappedOverlay-SingleMapping": {
+			idMap: userns.IDMap{
+				UidMap: []specs.LinuxIDMapping{
+					{
+						ContainerID: 0,
+						HostID:      33,
+						Size:        65535,
+					},
+				},
+				GidMap: []specs.LinuxIDMapping{
+					{
+						ContainerID: 0,
+						HostID:      33,
+						Size:        65535,
+					},
+				},
+			},
+			snapOpt: func(idMap userns.IDMap) snapshots.Opt {
+				return containerd.WithRemapperLabels(
+					idMap.UidMap[0].ContainerID, idMap.UidMap[0].HostID,
+					idMap.GidMap[0].ContainerID, idMap.GidMap[0].HostID,
+					idMap.UidMap[0].Size)
+			},
+			expUID: 33,
+			expGID: 33,
+		},
+		"TestIDMappedOverlay-MultiMapping": {
+			idMap: userns.IDMap{
+				UidMap: []specs.LinuxIDMapping{
+					{
+						ContainerID: 0,
+						HostID:      33,
+						Size:        100,
+					},
+					{
+						ContainerID: 100,
+						HostID:      333,
+						Size:        65536,
+					},
+				},
+				GidMap: []specs.LinuxIDMapping{
+					{
+						ContainerID: 0,
+						HostID:      66,
+						Size:        100,
+					},
+					{
+						ContainerID: 100,
+						HostID:      666,
+						Size:        65536,
+					},
+				},
+			},
+			snapOpt: func(idMap userns.IDMap) snapshots.Opt {
+				return containerd.WithUserNSRemapperLabels(idMap.UidMap, idMap.GidMap)
+			},
+			expUID: 33,
+			expGID: 66,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var (
+				upperPath   string
+				lowerPaths  []string
+				snapshotter = "overlayfs"
+				ctx, cancel = testContext(t)
+				id          = name
+			)
+			defer cancel()
 
-	image, err := client.Pull(ctx, testMultiLayeredImage, containerd.WithPullUnpack)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Logf("image %s pulled!", testMultiLayeredImage)
+			client, err := newClient(t, address)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer client.Close()
 
-	hostID := uint32(33)
-	contID := uint32(0)
-	length := uint32(65536)
+			image, err := client.Pull(ctx, testMultiLayeredImage, containerd.WithPullUnpack)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("image %s pulled!", testMultiLayeredImage)
 
-	uidMap := specs.LinuxIDMapping{
-		ContainerID: contID,
-		HostID:      hostID,
-		Size:        length,
-	}
-	gidMap := specs.LinuxIDMapping{
-		ContainerID: contID,
-		HostID:      hostID,
-		Size:        length,
-	}
+			container, err := client.NewContainer(ctx, id,
+				containerd.WithImage(image),
+				containerd.WithImageConfigLabels(image),
+				containerd.WithSnapshotter(snapshotter),
+				containerd.WithNewSnapshot(id, image, test.snapOpt(test.idMap)),
+				containerd.WithNewSpec(oci.WithImageConfig(image),
+					oci.WithUserNamespace(test.idMap.UidMap, test.idMap.GidMap),
+					longCommand))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer container.Delete(ctx, containerd.WithSnapshotCleanup)
 
-	container, err := client.NewContainer(ctx, id,
-		containerd.WithImage(image),
-		containerd.WithImageConfigLabels(image),
-		containerd.WithSnapshotter(snapshotter),
-		containerd.WithNewSnapshot(id, image, containerd.WithRemapperLabels(uidMap.ContainerID, uidMap.HostID, gidMap.ContainerID, gidMap.HostID, length)),
-		containerd.WithNewSpec(oci.WithImageConfig(image),
-			oci.WithUserNamespace([]specs.LinuxIDMapping{uidMap}, []specs.LinuxIDMapping{gidMap}),
-			longCommand))
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer container.Delete(ctx, containerd.WithSnapshotCleanup)
+			t.Logf("container %s created!", id)
+			o := client.SnapshotService(snapshotter)
+			mounts, err := o.Mounts(ctx, id)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	t.Logf("container %s created!", id)
-	o := client.SnapshotService(snapshotter)
-	mounts, err := o.Mounts(ctx, id)
-	if err != nil {
-		t.Fatal(err)
-	}
+			m := mounts[0]
+			if m.Type != "overlay" {
+				t.Fatalf("invalid mount -- %s; expected %s", m.Type, snapshotter)
+			}
 
-	m := mounts[0]
-	if m.Type != "overlay" {
-		t.Fatalf("invalid mount -- %s; expected %s", m.Type, snapshotter)
-	}
+			for _, o := range m.Options {
+				if strings.HasPrefix(o, "upperdir=") {
+					upperPath = strings.TrimPrefix(o, "upperdir=")
+				} else if strings.HasPrefix(o, "lowerdir=") {
+					lowerPaths = strings.Split(strings.TrimPrefix(o, "lowerdir="), ",")
+				}
+			}
 
-	for _, o := range m.Options {
-		if strings.HasPrefix(o, "upperdir=") {
-			upperPath = strings.TrimPrefix(o, "upperdir=")
-		} else if strings.HasPrefix(o, "lowerdir=") {
-			lowerPaths = strings.Split(strings.TrimPrefix(o, "lowerdir="), ",")
-		}
-	}
+			t.Log("check lowerdirs")
+			for _, l := range lowerPaths {
+				if _, err := os.Stat(l); err == nil {
+					t.Fatalf("lowerdir=%s should not exist", l)
+				}
+			}
 
-	t.Log("check lowerdirs")
-	for _, l := range lowerPaths {
-		if _, err := os.Stat(l); err == nil {
-			t.Fatalf("lowerdir=%s should not exist", l)
-		}
-	}
+			t.Logf("check stats of uppedir=%s", upperPath)
+			st, err := os.Stat(upperPath)
+			if err != nil {
+				t.Fatalf("failed to stat %s", upperPath)
+			}
 
-	t.Logf("check stats of uppedir=%s", upperPath)
-	st, err := os.Stat(upperPath)
-	if err != nil {
-		t.Fatalf("failed to stat %s", upperPath)
-	}
-
-	if stat, ok := st.Sys().(*syscall.Stat_t); !ok {
-		t.Fatalf("incompatible types after stat call: *syscall.Stat_t expected")
-	} else if stat.Uid != uidMap.HostID || stat.Gid != gidMap.HostID {
-		t.Fatalf("bad mapping: expected {uid: %d, gid: %d}; real {uid: %d, gid: %d}", uidMap.HostID, gidMap.HostID, int(stat.Uid), int(stat.Gid))
+			if stat, ok := st.Sys().(*syscall.Stat_t); !ok {
+				t.Fatalf("incompatible types after stat call: *syscall.Stat_t expected")
+			} else if stat.Uid != test.expUID || stat.Gid != test.expGID {
+				t.Fatalf("bad mapping: expected {uid: %d, gid: %d}; real {uid: %d, gid: %d}", test.expUID, test.expGID, int(stat.Uid), int(stat.Gid))
+			}
+		})
 	}
 }

--- a/internal/cri/server/container_start_linux.go
+++ b/internal/cri/server/container_start_linux.go
@@ -48,10 +48,11 @@ func updateContainerIOOwner(ctx context.Context, cntr containerd.Container, conf
 		return nil, fmt.Errorf("invalid linux platform oci runtime spec")
 	}
 
-	hostID, err := userns.IDMap{
+	idMap := userns.IDMap{
 		UidMap: spec.Linux.UIDMappings,
 		GidMap: spec.Linux.GIDMappings,
-	}.ToHost(userns.User{
+	}
+	hostID, err := idMap.ToHost(userns.User{
 		Uid: spec.Process.User.UID,
 		Gid: spec.Process.User.GID,
 	})

--- a/plugins/snapshots/overlay/overlay_test.go
+++ b/plugins/snapshots/overlay/overlay_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/containerd/v2/core/snapshots/storage"
 	"github.com/containerd/containerd/v2/core/snapshots/testsuite"
+	"github.com/containerd/containerd/v2/internal/userns"
 	"github.com/containerd/containerd/v2/pkg/testutil"
 	"github.com/containerd/containerd/v2/plugins/snapshots/overlay/overlayutils"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -199,68 +200,280 @@ func testOverlayOverlayMount(t *testing.T, newSnapshotter testsuite.SnapshotterF
 }
 
 func testOverlayRemappedBind(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
-	var (
-		opts   []snapshots.Opt
-		mounts []mount.Mount
-	)
+	for _, test := range []struct {
+		idMap        userns.IDMap
+		snapOpt      func(idMap userns.IDMap) snapshots.Opt
+		expUID       uint32
+		expGID       uint32
+		expUIDMntOpt string
+		expGIDMntOpt string
+	}{
+		{
+			idMap: userns.IDMap{
+				UidMap: []specs.LinuxIDMapping{
+					{
+						ContainerID: 0,
+						HostID:      666,
+						Size:        65536,
+					},
+				},
+				GidMap: []specs.LinuxIDMapping{
+					{
+						ContainerID: 0,
+						HostID:      666,
+						Size:        65536,
+					},
+				},
+			},
+			snapOpt: func(idMap userns.IDMap) snapshots.Opt {
+				return containerd.WithRemapperLabels(
+					idMap.UidMap[0].ContainerID, idMap.UidMap[0].HostID,
+					idMap.GidMap[0].ContainerID, idMap.GidMap[0].HostID,
+					idMap.UidMap[0].Size,
+				)
+			},
+			expUID:       666,
+			expGID:       666,
+			expUIDMntOpt: "uidmap=0:666:65536",
+			expGIDMntOpt: "gidmap=0:666:65536",
+		},
+		{
+			idMap: userns.IDMap{
+				UidMap: []specs.LinuxIDMapping{
+					{
+						ContainerID: 0,
+						HostID:      666,
+						Size:        1000,
+					},
+					{
+						ContainerID: 1000,
+						HostID:      6666,
+						Size:        64536,
+					},
+				},
+				GidMap: []specs.LinuxIDMapping{
+					{
+						ContainerID: 0,
+						HostID:      888,
+						Size:        1000,
+					},
+					{
+						ContainerID: 1000,
+						HostID:      8888,
+						Size:        64536,
+					},
+				},
+			},
+			snapOpt: func(idMap userns.IDMap) snapshots.Opt {
+				return containerd.WithUserNSRemapperLabels(idMap.UidMap, idMap.GidMap)
+			},
+			expUID:       666,
+			expGID:       888,
+			expUIDMntOpt: "uidmap=0:666:1000,1000:6666:64536",
+			expGIDMntOpt: "gidmap=0:888:1000,1000:8888:64536",
+		},
+	} {
+		var (
+			opts   []snapshots.Opt
+			mounts []mount.Mount
+		)
 
-	ctx := context.TODO()
-	root := t.TempDir()
-	o, _, err := newSnapshotter(ctx, root)
-	if err != nil {
-		t.Fatal(err)
+		ctx := context.TODO()
+		root := t.TempDir()
+		o, _, err := newSnapshotter(ctx, root)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if sn, ok := o.(*snapshotter); !ok || !sn.remapIDs {
+			t.Skip("overlayfs doesn't support idmapped mounts")
+		}
+
+		opts = append(opts, test.snapOpt(test.idMap))
+
+		key := "/tmp/test"
+		if mounts, err = o.Prepare(ctx, key, "", opts...); err != nil {
+			t.Fatal(err)
+		}
+
+		bp := getBasePath(ctx, o, root, key)
+		expected := []string{test.expUIDMntOpt, test.expGIDMntOpt, "rw", "rbind"}
+
+		checkMountOpts := func() {
+			if len(mounts) != 1 {
+				t.Errorf("should only have 1 mount but received %d", len(mounts))
+			}
+
+			if len(mounts[0].Options) != len(expected) {
+				t.Errorf("expected %d options, but received %d", len(expected), len(mounts[0].Options))
+			}
+
+			m := mounts[0]
+			for i, v := range expected {
+				if m.Options[i] != v {
+					t.Errorf("mount option %q is not valid, expected %q", m.Options[i], v)
+				}
+			}
+
+			st, err := os.Stat(filepath.Join(bp, "fs"))
+			if err != nil {
+				t.Errorf("failed to stat %s", filepath.Join(bp, "fs"))
+			}
+
+			if stat, ok := st.Sys().(*syscall.Stat_t); !ok {
+				t.Errorf("incompatible types after stat call: *syscall.Stat_t expected")
+			} else if stat.Uid != test.expUID || stat.Gid != test.expGID {
+				t.Errorf("bad mapping: expected {uid: %d, gid: %d}; real {uid: %d, gid: %d}", test.expUID, test.expGID, int(stat.Uid), int(stat.Gid))
+			}
+		}
+		checkMountOpts()
+
+		expected[2] = "ro"
+		if err = o.Commit(ctx, "base", key, opts...); err != nil {
+			t.Fatal(err)
+		}
+		if mounts, err = o.View(ctx, key, "base", opts...); err != nil {
+			t.Fatal(err)
+		}
+		bp = getBasePath(ctx, o, root, key)
+		checkMountOpts()
+
+		key = "/tmp/test1"
+		if mounts, err = o.Prepare(ctx, key, ""); err != nil {
+			t.Fatal(err)
+		}
+
+		bp = getBasePath(ctx, o, root, key)
+
+		expected = expected[2:]
+		expected[0] = "rw"
+
+		test.expUID = 0
+		test.expGID = 0
+
+		checkMountOpts()
 	}
+}
 
-	if sn, ok := o.(*snapshotter); !ok || !sn.remapIDs {
-		t.Skip("overlayfs doesn't support idmapped mounts")
-	}
+func testOverlayRemappedActive(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
+	for _, test := range []struct {
+		idMap        userns.IDMap
+		snapOpt      func(idMap userns.IDMap) snapshots.Opt
+		expUID       uint32
+		expGID       uint32
+		expUIDMntOpt string
+		expGIDMntOpt string
+	}{
+		{
+			idMap: userns.IDMap{
+				UidMap: []specs.LinuxIDMapping{
+					{
+						ContainerID: 0,
+						HostID:      666,
+						Size:        65536,
+					},
+				},
+				GidMap: []specs.LinuxIDMapping{
+					{
+						ContainerID: 0,
+						HostID:      666,
+						Size:        65536,
+					},
+				},
+			},
+			snapOpt: func(idMap userns.IDMap) snapshots.Opt {
+				return containerd.WithRemapperLabels(
+					idMap.UidMap[0].ContainerID, idMap.UidMap[0].HostID,
+					idMap.GidMap[0].ContainerID, idMap.GidMap[0].HostID,
+					idMap.UidMap[0].Size,
+				)
+			},
+			expUID:       666,
+			expGID:       666,
+			expUIDMntOpt: "uidmap=0:666:65536",
+			expGIDMntOpt: "gidmap=0:666:65536",
+		},
+		{
+			idMap: userns.IDMap{
+				UidMap: []specs.LinuxIDMapping{
+					{
+						ContainerID: 0,
+						HostID:      666,
+						Size:        1000,
+					},
+					{
+						ContainerID: 1000,
+						HostID:      6666,
+						Size:        64536,
+					},
+				},
+				GidMap: []specs.LinuxIDMapping{
+					{
+						ContainerID: 0,
+						HostID:      888,
+						Size:        1000,
+					},
+					{
+						ContainerID: 1000,
+						HostID:      8888,
+						Size:        64536,
+					},
+				},
+			},
+			snapOpt: func(idMap userns.IDMap) snapshots.Opt {
+				return containerd.WithUserNSRemapperLabels(idMap.UidMap, idMap.GidMap)
+			},
+			expUID:       666,
+			expGID:       888,
+			expUIDMntOpt: "uidmap=0:666:1000,1000:6666:64536",
+			expGIDMntOpt: "gidmap=0:888:1000,1000:8888:64536",
+		},
+	} {
+		var (
+			opts   []snapshots.Opt
+			mounts []mount.Mount
+		)
 
-	hostID := uint32(666)
-	contID := uint32(0)
-	length := uint32(65536)
+		ctx := context.TODO()
+		root := t.TempDir()
+		o, _, err := newSnapshotter(ctx, root)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	uidMap := specs.LinuxIDMapping{
-		ContainerID: contID,
-		HostID:      hostID,
-		Size:        length,
-	}
-	gidMap := specs.LinuxIDMapping{
-		ContainerID: contID,
-		HostID:      hostID,
-		Size:        length,
-	}
-	opts = append(opts, containerd.WithRemapperLabels(
-		uidMap.ContainerID, uidMap.HostID,
-		gidMap.ContainerID, gidMap.HostID,
-		length),
-	)
+		if sn, ok := o.(*snapshotter); !ok || !sn.remapIDs {
+			t.Skip("overlayfs doesn't support idmapped mounts")
+		}
 
-	key := "/tmp/test"
-	if mounts, err = o.Prepare(ctx, key, "", opts...); err != nil {
-		t.Fatal(err)
-	}
+		opts = append(opts, test.snapOpt(test.idMap))
 
-	bp := getBasePath(ctx, o, root, key)
-	expected := []string{
-		fmt.Sprintf("uidmap=%d:%d:%d", uidMap.ContainerID, uidMap.HostID, uidMap.Size),
-		fmt.Sprintf("gidmap=%d:%d:%d", gidMap.ContainerID, gidMap.HostID, gidMap.Size),
-		"rw",
-		"rbind",
-	}
+		key := "/tmp/test"
+		if _, err = o.Prepare(ctx, key, "", opts...); err != nil {
+			t.Fatal(err)
+		}
+		if err = o.Commit(ctx, "base", key, opts...); err != nil {
+			t.Fatal(err)
+		}
+		if mounts, err = o.Prepare(ctx, key, "base", opts...); err != nil {
+			t.Fatal(err)
+		}
 
-	checkMountOpts := func() {
 		if len(mounts) != 1 {
 			t.Errorf("should only have 1 mount but received %d", len(mounts))
 		}
 
-		if len(mounts[0].Options) != len(expected) {
-			t.Errorf("expected %d options, but received %d", len(expected), len(mounts[0].Options))
+		bp := getBasePath(ctx, o, root, key)
+		expected := []string{
+			test.expUIDMntOpt, test.expGIDMntOpt,
+			fmt.Sprintf("workdir=%s", filepath.Join(bp, "work")),
+			fmt.Sprintf("upperdir=%s", filepath.Join(bp, "fs")),
+			fmt.Sprintf("lowerdir=%s", getParents(ctx, o, root, key)[0]),
 		}
 
 		m := mounts[0]
 		for i, v := range expected {
 			if m.Options[i] != v {
-				t.Errorf("mount option %q is not valid, expected %q", m.Options[i], v)
+				t.Errorf("mount option %q is invalid, expected %q", m.Options[i], v)
 			}
 		}
 
@@ -268,117 +481,11 @@ func testOverlayRemappedBind(t *testing.T, newSnapshotter testsuite.SnapshotterF
 		if err != nil {
 			t.Errorf("failed to stat %s", filepath.Join(bp, "fs"))
 		}
-
 		if stat, ok := st.Sys().(*syscall.Stat_t); !ok {
 			t.Errorf("incompatible types after stat call: *syscall.Stat_t expected")
-		} else if stat.Uid != uidMap.HostID || stat.Gid != gidMap.HostID {
-			t.Errorf("bad mapping: expected {uid: %d, gid: %d}; real {uid: %d, gid: %d}", uidMap.HostID, gidMap.HostID, int(stat.Uid), int(stat.Gid))
+		} else if stat.Uid != test.expUID || stat.Gid != test.expGID {
+			t.Errorf("bad mapping: expected {uid: %d, gid: %d}; received {uid: %d, gid: %d}", test.expUID, test.expGID, int(stat.Uid), int(stat.Gid))
 		}
-	}
-	checkMountOpts()
-
-	expected[2] = "ro"
-	if err = o.Commit(ctx, "base", key, opts...); err != nil {
-		t.Fatal(err)
-	}
-	if mounts, err = o.View(ctx, key, "base", opts...); err != nil {
-		t.Fatal(err)
-	}
-	bp = getBasePath(ctx, o, root, key)
-	checkMountOpts()
-
-	key = "/tmp/test1"
-	if mounts, err = o.Prepare(ctx, key, ""); err != nil {
-		t.Fatal(err)
-	}
-
-	bp = getBasePath(ctx, o, root, key)
-
-	expected = expected[2:]
-	expected[0] = "rw"
-
-	uidMap.HostID = 0
-	gidMap.HostID = 0
-
-	checkMountOpts()
-}
-
-func testOverlayRemappedActive(t *testing.T, newSnapshotter testsuite.SnapshotterFunc) {
-	var (
-		opts   []snapshots.Opt
-		mounts []mount.Mount
-	)
-
-	ctx := context.TODO()
-	root := t.TempDir()
-	o, _, err := newSnapshotter(ctx, root)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if sn, ok := o.(*snapshotter); !ok || !sn.remapIDs {
-		t.Skip("overlayfs doesn't support idmapped mounts")
-	}
-
-	hostID := uint32(666)
-	contID := uint32(0)
-	length := uint32(65536)
-
-	uidMap := specs.LinuxIDMapping{
-		ContainerID: contID,
-		HostID:      hostID,
-		Size:        length,
-	}
-	gidMap := specs.LinuxIDMapping{
-		ContainerID: contID,
-		HostID:      hostID,
-		Size:        length,
-	}
-	opts = append(opts, containerd.WithRemapperLabels(
-		uidMap.ContainerID, uidMap.HostID,
-		gidMap.ContainerID, gidMap.HostID,
-		length),
-	)
-
-	key := "/tmp/test"
-	if _, err = o.Prepare(ctx, key, "", opts...); err != nil {
-		t.Fatal(err)
-	}
-	if err = o.Commit(ctx, "base", key, opts...); err != nil {
-		t.Fatal(err)
-	}
-	if mounts, err = o.Prepare(ctx, key, "base", opts...); err != nil {
-		t.Fatal(err)
-	}
-
-	if len(mounts) != 1 {
-		t.Errorf("should only have 1 mount but received %d", len(mounts))
-	}
-
-	bp := getBasePath(ctx, o, root, key)
-	expected := []string{
-		fmt.Sprintf("uidmap=%d:%d:%d", uidMap.ContainerID, uidMap.HostID, uidMap.Size),
-		fmt.Sprintf("gidmap=%d:%d:%d", gidMap.ContainerID, gidMap.HostID, gidMap.Size),
-		fmt.Sprintf("workdir=%s", filepath.Join(bp, "work")),
-		fmt.Sprintf("upperdir=%s", filepath.Join(bp, "fs")),
-		fmt.Sprintf("lowerdir=%s", getParents(ctx, o, root, key)[0]),
-	}
-
-	m := mounts[0]
-	for i, v := range expected {
-		if m.Options[i] != v {
-			t.Errorf("mount option %q is invalid, expected %q", m.Options[i], v)
-		}
-	}
-
-	st, err := os.Stat(filepath.Join(bp, "fs"))
-	if err != nil {
-		t.Errorf("failed to stat %s", filepath.Join(bp, "fs"))
-	}
-	if stat, ok := st.Sys().(*syscall.Stat_t); !ok {
-		t.Errorf("incompatible types after stat call: *syscall.Stat_t expected")
-	} else if stat.Uid != uidMap.HostID || stat.Gid != gidMap.HostID {
-		t.Errorf("bad mapping: expected {uid: %d, gid: %d}; received {uid: %d, gid: %d}", uidMap.HostID, gidMap.HostID, int(stat.Uid), int(stat.Gid))
 	}
 }
 
@@ -414,6 +521,24 @@ func testOverlayRemappedInvalidMapping(t *testing.T, newSnapshotter testsuite.Sn
 				snapshots.LabelSnapshotGIDMapping: "-666:-666:-666",
 			}),
 		},
+		"WithLabels: negative UID in multiple mappings must fail": {
+			snapshots.WithLabels(map[string]string{
+				snapshots.LabelSnapshotUIDMapping: "1:1:1,-1:-1:-2",
+				snapshots.LabelSnapshotGIDMapping: "0:0:66666",
+			}),
+		},
+		"WithLabels: negative GID in multiple mappings must fail": {
+			snapshots.WithLabels(map[string]string{
+				snapshots.LabelSnapshotUIDMapping: "0:0:66666",
+				snapshots.LabelSnapshotGIDMapping: "-1:-1:-2,6:6:6",
+			}),
+		},
+		"WithLabels: negative GID/UID in multiple mappings must fail": {
+			snapshots.WithLabels(map[string]string{
+				snapshots.LabelSnapshotUIDMapping: "-666:-666:-666,1:1:1",
+				snapshots.LabelSnapshotGIDMapping: "-666:-666:-666,2:2:2",
+			}),
+		},
 		"WithRemapperLabels: container ID (GID/UID) other than 0 must fail": {
 			containerd.WithRemapperLabels(666, 666, 666, 666, 666),
 		},
@@ -422,6 +547,24 @@ func testOverlayRemappedInvalidMapping(t *testing.T, newSnapshotter testsuite.Sn
 		},
 		"WithRemapperLabels: container ID (GID) other than 0 must fail": {
 			containerd.WithRemapperLabels(0, 0, 666, 0, 4294967295),
+		},
+		"WithUserNSRemapperLabels: container ID (GID/UID) other than 0 must fail": {
+			containerd.WithUserNSRemapperLabels(
+				[]specs.LinuxIDMapping{{ContainerID: 666, HostID: 666, Size: 666}},
+				[]specs.LinuxIDMapping{{ContainerID: 666, HostID: 666, Size: 666}},
+			),
+		},
+		"WithUserNSRemapperLabels: container ID (UID) other than 0 must fail": {
+			containerd.WithUserNSRemapperLabels(
+				[]specs.LinuxIDMapping{{ContainerID: 666, HostID: 0, Size: 65536}},
+				[]specs.LinuxIDMapping{{ContainerID: 0, HostID: 0, Size: 65536}},
+			),
+		},
+		"WithUserNSRemapperLabels: container ID (GID) other than 0 must fail": {
+			containerd.WithUserNSRemapperLabels(
+				[]specs.LinuxIDMapping{{ContainerID: 0, HostID: 0, Size: 4294967295}},
+				[]specs.LinuxIDMapping{{ContainerID: 666, HostID: 0, Size: 4294967295}},
+			),
 		},
 	} {
 		t.Log(desc)


### PR DESCRIPTION
This is a follow-up PR of the previous #10307 to support multiple id mappings for ID mapped mounts.

#### What's changed
* Added 'WithUserNSRemapperLabels()' to take multiple uid/gid mappings
* Updated 'ctr' to call the new func in case of '--remap-labels'
* Updated built-in overlay SN to handle labels with multiple mappings. It's also updated to create mount options for multiple mappings, e.g. 'uidmap=0:666:1000,1000:6666:64536'
* Updated 'GetUsernsFD()' to parse a string of multiple mappings

#### What's not changed
* CRI code is not changed
  * It still calls 'WithRemapperLabels()' which takes a single mapping entry
  * I believe it's okay because kubelet currently only passes a single mapping entry to the runtime
  * If required, CRI just needs to call 'WithUserNSRemapperLabels()' to handle multiple mappings