### PR TITLE
Add check for CNI plugins before tearing down pod network

### DIFF
--- a/internal/cri/server/sandbox_stop.go
+++ b/internal/cri/server/sandbox_stop.go
@@ -111,8 +111,10 @@ func (c *criService) stopPodSandbox(ctx context.Context, sandbox sandboxstore.Sa
 		} else if closed {
 			sandbox.NetNSPath = ""
 		}
-		if err := c.teardownPodNetwork(ctx, sandbox); err != nil {
-			return fmt.Errorf("failed to destroy network for sandbox %q: %w", id, err)
+		if sandbox.CNIResult != nil {
+			if err := c.teardownPodNetwork(ctx, sandbox); err != nil {
+				return fmt.Errorf("failed to destroy network for sandbox %q: %w", id, err)
+			}
 		}
 		if err := sandbox.NetNS.Remove(); err != nil {
 			return fmt.Errorf("failed to remove network namespace for sandbox %q: %w", id, err)


### PR DESCRIPTION
Currently, locking behavior occurs if a user creates a sandbox pod and then tries to remove / delete it without having any CNI plugins initialized on their system.

## **Sample flow**

**pod-config.json:**, per [crictl docs](https://github.com/sameersaeed/cri-tools/blob/master/docs/crictl.md#run-pod-sandbox-with-config-file)
```
{
  "metadata": {
    "name": "nginx-sandbox",
    "namespace": "default",
    "attempt": 1,
    "uid": "65fb5845de97d8a4"
  },
  "log_directory": "/tmp",
  "linux": {
  }
}
```

**Running sandbox pod - receive CNI plugin error:**
```
root@3cd5ffda91af:~# crictl runp pod-config.json 
WARN[0000] runtime connect using default endpoints: [unix:///run/containerd/containerd.sock unix:///run/crio/crio.sock unix:///var/run/cri-dockerd.sock]. As the default settings are now deprecated, you should set the endpoint instead. 
E0922 01:07:22.941363     315 log.go:32] "RunPodSandbox from runtime service failed" err="rpc error: code = Unknown desc = failed to setup network for sandbox \"c4c57d078fc28ae83f4fd22167a23aa62e5ca77a09e9e1e62de72bc0135031ef\": cni plugin not initialized"
FATA[0003] run pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "c4c57d078fc28ae83f4fd22167a23aa62e5ca77a09e9e1e62de72bc0135031ef": cni plugin not initialized 
```

**Pod shows up as NotReady:**
```
root@3cd5ffda91af:~# crictl pods
WARN[0000] runtime connect using default endpoints: [unix:///run/containerd/containerd.sock unix:///run/crio/crio.sock unix:///var/run/cri-dockerd.sock]. As the default settings are now deprecated, you should set the endpoint instead. 
POD ID              CREATED             STATE               NAME                NAMESPACE           ATTEMPT             RUNTIME
c4c57d078fc28       270 years ago       NotReady            nginx-sandbox       default             1                   (default)
```

**Locking behavior - cannot stop / remove pod due to CNI plugin error:**
```
root@3cd5ffda91af:~# crictl stopp c4
WARN[0000] runtime connect using default endpoints: [unix:///run/containerd/containerd.sock unix:///run/crio/crio.sock unix:///var/run/cri-dockerd.sock]. As the default settings are now deprecated, you should set the endpoint instead. 
E0922 01:07:43.024652     335 log.go:32] "StopPodSandbox from runtime service failed" err="rpc error: code = Unknown desc = failed to destroy network for sandbox \"c4c57d078fc28ae83f4fd22167a23aa62e5ca77a09e9e1e62de72bc0135031ef\": cni plugin not initialized" podSandboxID="c4"
FATA[0000] stopping the pod sandbox "c4": rpc error: code = Unknown desc = failed to destroy network for sandbox "c4c57d078fc28ae83f4fd22167a23aa62e5ca77a09e9e1e62de72bc0135031ef": cni plugin not initialized 
```

```
root@3cd5ffda91af:~# crictl rmp c4
WARN[0000] runtime connect using default endpoints: [unix:///run/containerd/containerd.sock unix:///run/crio/crio.sock unix:///var/run/cri-dockerd.sock]. As the default settings are now deprecated, you should set the endpoint instead. 
E0922 01:07:48.578086     345 log.go:32] "RemovePodSandbox from runtime service failed" err="rpc error: code = Unknown desc = failed to forcibly stop sandbox \"c4c57d078fc28ae83f4fd22167a23aa62e5ca77a09e9e1e62de72bc0135031ef\": failed to destroy network for sandbox \"c4c57d078fc28ae83f4fd22167a23aa62e5ca77a09e9e1e62de72bc0135031ef\": cni plugin not initialized" podSandboxID="c4"
removing the pod sandbox "c4": rpc error: code = Unknown desc = failed to forcibly stop sandbox "c4c57d078fc28ae83f4fd22167a23aa62e5ca77a09e9e1e62de72bc0135031ef": failed to destroy network for sandbox "c4c57d078fc28ae83f4fd22167a23aa62e5ca77a09e9e1e62de72bc0135031ef": cni plugin not initialized
```

## Changes made 
Current code:
https://github.com/containerd/containerd/blob/db974495988697929521bc4f1c97d7e41f7ff648/internal/cri/server/sandbox_stop.go#L114-L116

Added a minor change to the above `sandbox_stop.go` code so that the pod network teardown will only be performed if CNIResult returns a valid value:
```
if sandbox.CNIResult != nil {
	if err := c.teardownPodNetwork(ctx, sandbox); err != nil {
		return fmt.Errorf("failed to destroy network for sandbox %q: %w", id, err)
	}	
}
```

This avoids the locking behavior, so the pods are able to be stopped and / or removed as expected:
```
root@03195a9aecb5:/src# crictl rmp c4
DEBU[0000] get runtime connection                       
Stopped sandbox c4
```
```
root@03195a9aecb5:/src# crictl rmp c4
DEBU[0000] get runtime connection                       
Removed sandbox c4
```
```
root@03195a9aecb5:/src# crictl pods
DEBU[0000] get runtime connection                       
DEBU[0000] ListPodSandboxRequest: &ListPodSandboxRequest{Filter:&PodSandboxFilter{Id:,State:nil,LabelSelector:map[string]string{},},} 
DEBU[0000] ListPodSandboxResponse: []                   
POD ID              CREATED             STATE               NAME                NAMESPACE           ATTEMPT             RUNTIME
``