### PR TITLE
Add no_sync option to boost boltDB performance on ephemeral environments

### DIFF
--- a/plugins/metadata/plugin.go
+++ b/plugins/metadata/plugin.go
@@ -46,9 +46,9 @@ func init() {
 
 // BoltOptions replicates bolt.Options struct, but excludes function fields and adds tags to allow TOML marshalling.
 type BoltOptions struct {
-	// Sets the DB.NoGrowSync flag before memory mapping the file.
+	//  NoGrowSync sets the DB.NoGrowSync flag before memory mapping the file.
 	NoGrowSync bool `toml:"no_grow_sync"`
-	// Do not sync freelist to disk. This improves the database write performance
+	// NoFreelistSync disables sync freelist to disk. This improves the database write performance
 	// under normal operation, but requires a full database re-sync during recovery.
 	NoFreelistSync bool `toml:"no_freelist_sync"`
 	// PreLoadFreelist sets whether to load the free pages when opening
@@ -63,7 +63,7 @@ type BoltOptions struct {
 	// It prevents potential page faults, however
 	// used memory can't be reclaimed. (UNIX only)
 	Mlock bool `toml:"mlock"`
-	// Sets the DB.MmapFlags flag before memory mapping the file.
+	// MmapFlags sets the DB.MmapFlags flag before memory mapping the file.
 	MmapFlags int `toml:"mmap_flags"`
 	// InitialMmapSize is the initial mmap size of the database
 	// in bytes. Read transactions won't block write transaction

--- a/plugins/metadata/plugin.go
+++ b/plugins/metadata/plugin.go
@@ -155,10 +155,11 @@ func init() {
 					if cfg.NoSync {
 						options.NoSync = true
 						options.NoGrowSync = true
+
+						log.G(ic.Context).Warn("using async mode for boltdb")
 					}
 				}
 			}
-			log.G(ic.Context).WithField("plugin", "bolt").Infof("bolt config: %+v", options)
 
 			path := filepath.Join(root, "meta.db")
 			ic.Meta.Exports["path"] = path


### PR DESCRIPTION
This PR exposes BoltDB options via TOML configuration.
On certain ephemeral environments its possible to squeeze a significant performance gains via more precise boltDB configuration by going async.
In our case we were able to reduce pull time under certain (heavy) conditions from 30s to just a few seconds.

Additionally this PR introduces optional args in `MetaStore` to allow (external) snapshotters configure boltDB options for same reasons.

```toml
bin/containerd config default

  [plugins.'io.containerd.metadata.v1.bolt']
    content_sharing_policy = 'shared'
    no_sync = true

```

Troubleshooting and research credits belong to @xinyangge-db 


> We found that the checkpoint image pull timeout is due to frequent lock contentions on containerd’s metadata db, and the lock contention occurs because synchronized file writes are performed while holding the metadata db lock.
> 
> Containerd uses a metadata db (backed by [BoltDB](https://github.com/etcd-io/bbolt)) to maintain container objects such as created/running containers, pulled container images, created snapshots, etc. Updates to the metadata db are wrapped inside an exclusive transaction such that only one update can be performed at a time. For example, [snapshotter.Commit](https://github.com/databricks-eng/containerd/blob/c71036f7e84acd67ffcc957ff40f68e9d1d5edec/metadata/snapshot.go#L494) updates the metadata db within a [transaction](https://github.com/databricks-eng/containerd/blob/c71036f7e84acd67ffcc957ff40f68e9d1d5edec/metadata/snapshot.go#L515) during which concurrent container creation and/or image pulls can be blocked briefly.
> 
>
> When committing a transaction, the BoltDB implementation performs a [synchronous write](https://github.com/etcd-io/bbolt/blob/c9752be29475fe60b811473798f59aa9bf04e051/tx.go#L524-L530) to the metadata db, which can incur a delay of several seconds as this is susceptible to the remote disk write latency.
> 
> We can reduce the lock contention by converting the above synchronous writes to asynchronous. The implication is that, if a VM loses power or crashes, then the metadata db can be in a corrupted state coming out of a reboot (as the in-memory writes were not flushed to the disk). Fortunately, this is not a concern when VMs are ephemeral.