### PR TITLE
[cri] use 'UserSpecifiedImage' to set the image-name annotation

### DIFF
--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -183,6 +183,10 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	}
 	log.G(ctx).Debugf("Use OCI runtime %+v for sandbox %q and container %q", ociRuntime, sandboxID, id)
 
+	imageName := containerdImage.Name()
+	if name := config.GetImage().GetUserSpecifiedImage(); name != "" {
+		imageName = name
+	}
 	spec, err := c.buildContainerSpec(
 		platform,
 		id,
@@ -190,7 +194,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 		sandboxPid,
 		sandbox.NetNSPath,
 		containerName,
-		containerdImage.Name(),
+		imageName,
 		config,
 		sandboxConfig,
 		&image.ImageSpec.Config,


### PR DESCRIPTION
#5002 image annotation can helpful for debugging and auditing the workload. However, when an image has multiple tags, the image originally obtained may not be the one actually specified by the user. Starting from cri-api v0.28.0, a UserSpecifiedImage field is added to ImageSpec. It is more appropriate to use UserSpecifiedImage.