### PR TITLE
script/setup/install-runc: Add trap statement to clean up tmp files

### DIFF
--- a/script/setup/install-runc
+++ b/script/setup/install-runc
@@ -34,13 +34,13 @@ function install_runc() {
 	: "${RUNC_REPO:=https://github.com/opencontainers/runc.git}"
 
 	TMPROOT=$(mktemp -d)
+	trap "rm -fR ${TMPROOT}" EXIT
 	git clone "${RUNC_REPO}" "${TMPROOT}"/runc
 	pushd "${TMPROOT}"/runc
 	git checkout "${RUNC_VERSION}"
 	env -u VERSION make BUILDTAGS='seccomp' runc
 	$SUDO make install
 	popd
-	rm -fR "${TMPROOT}"
 }
 
 function install_crun() {


### PR DESCRIPTION
This PR adds the trap statement in the install runc script to clean up the temporary files and ensure we are not leaving them.