### PR TITLE
More shim imports cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,11 @@ GO_BUILDTAGS += ${DEBUG_TAGS}
 ifneq ($(STATIC),)
 	GO_BUILDTAGS += osusergo netgo static_build
 endif
+
+SHIM_GO_BUILDTAGS := $(GO_BUILDTAGS) no_grpc
+
 GO_TAGS=$(if $(GO_BUILDTAGS),-tags "$(strip $(GO_BUILDTAGS))",)
+SHIM_GO_TAGS=$(if $(SHIM_GO_BUILDTAGS),-tags "$(strip $(SHIM_GO_BUILDTAGS))",)
 
 GO_LDFLAGS=-ldflags '-X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PACKAGE) $(EXTRA_LDFLAGS)
 ifneq ($(STATIC),)
@@ -150,7 +154,6 @@ GOTEST ?= $(GO) test
 OUTPUTDIR = $(join $(ROOTDIR), _output)
 CRIDIR=$(OUTPUTDIR)/cri
 
-SHIM_GO_TAGS := --tags no_grpc
 
 .PHONY: clean all AUTHORS build binaries test integration generate protos check-protos coverage ci check help install uninstall vendor release static-release mandir install-man install-doc genman install-cri-deps cri-release cri-cni-release cri-integration install-deps bin/cri-integration.test remove-replace clean-vendor
 .DEFAULT: default
@@ -267,7 +270,7 @@ bin/gen-manpages: cmd/gen-manpages FORCE
 
 bin/containerd-shim-runc-v2: cmd/containerd-shim-runc-v2 FORCE # set !cgo and omit pie for a static shim build: https://github.com/golang/go/issues/17789#issuecomment-258542220
 	@echo "$(WHALE) $@"
-	CGO_ENABLED=${SHIM_CGO_ENABLED} $(GO) build ${GO_BUILD_FLAGS} -o $@ ${SHIM_GO_LDFLAGS} ${GO_TAGS} ${SHIM_GO_TAGS} ./cmd/containerd-shim-runc-v2
+	CGO_ENABLED=${SHIM_CGO_ENABLED} $(GO) build ${GO_BUILD_FLAGS} -o $@ ${SHIM_GO_LDFLAGS} ${SHIM_GO_TAGS} ./cmd/containerd-shim-runc-v2
 
 binaries: $(BINARIES) ## build binaries
 	@echo "$(WHALE) $@"

--- a/cmd/containerd-shim-runc-v2/main_tracing.go
+++ b/cmd/containerd-shim-runc-v2/main_tracing.go
@@ -18,4 +18,7 @@
 
 package main
 
-import _ "github.com/containerd/containerd/v2/pkg/tracing/plugin"
+import (
+	_ "github.com/containerd/containerd/v2/internal/pprof"
+	_ "github.com/containerd/containerd/v2/pkg/tracing/plugin"
+)

--- a/integration/failpoint/cmd/containerd-shim-runc-fp-v1/plugin_linux.go
+++ b/integration/failpoint/cmd/containerd-shim-runc-fp-v1/plugin_linux.go
@@ -74,7 +74,7 @@ func init() {
 }
 
 var (
-	_ = shim.TTRPCServerOptioner(&taskServiceWithFp{})
+	_ = shim.TTRPCServerUnaryOptioner(&taskServiceWithFp{})
 )
 
 type taskServiceWithFp struct {
@@ -87,7 +87,7 @@ func (s *taskServiceWithFp) RegisterTTRPC(server *ttrpc.Server) error {
 	return nil
 }
 
-func (s *taskServiceWithFp) UnaryInterceptor() ttrpc.UnaryServerInterceptor {
+func (s *taskServiceWithFp) UnaryServerInterceptor() ttrpc.UnaryServerInterceptor {
 	return func(ctx context.Context, unmarshal ttrpc.Unmarshaler, info *ttrpc.UnaryServerInfo, method ttrpc.Method) (interface{}, error) {
 		methodName := filepath.Base(info.FullMethod)
 		if fp, ok := s.fps[methodName]; ok {

--- a/internal/pprof/plugin.go
+++ b/internal/pprof/plugin.go
@@ -1,0 +1,55 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package pprof
+
+import (
+	"expvar"
+	"net/http"
+	"net/http/pprof"
+	"time"
+
+	"github.com/containerd/containerd/v2/plugins"
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
+)
+
+const pluginName = "pprof"
+
+func init() {
+	registry.Register(&plugin.Registration{
+		ID:   pluginName,
+		Type: plugins.HTTPHandler,
+		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
+			return newHandler(), nil
+		},
+	})
+}
+
+func newHandler() *http.Server {
+	m := http.NewServeMux()
+	m.Handle("/debug/vars", expvar.Handler())
+	m.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
+	m.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
+	m.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
+	m.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
+	m.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
+
+	return &http.Server{
+		Handler:           m,
+		ReadHeaderTimeout: 5 * time.Minute,
+	}
+}

--- a/pkg/tracing/plugin/ttrpc.go
+++ b/pkg/tracing/plugin/ttrpc.go
@@ -1,0 +1,47 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package plugin
+
+import (
+	"github.com/containerd/containerd/v2/plugins"
+	"github.com/containerd/otelttrpc"
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
+	"github.com/containerd/ttrpc"
+)
+
+func init() {
+	const pluginName = "otelttrpc"
+
+	registry.Register(&plugin.Registration{
+		ID:   pluginName,
+		Type: plugins.TTRPCPlugin,
+		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
+			return otelttrpcopts{}, nil
+		},
+	})
+}
+
+type otelttrpcopts struct{}
+
+func (otelttrpcopts) UnaryServerInterceptor() ttrpc.UnaryServerInterceptor {
+	return otelttrpc.UnaryServerInterceptor()
+}
+
+func (otelttrpcopts) UnaryClientInterceptor() ttrpc.UnaryClientInterceptor {
+	return otelttrpc.UnaryClientInterceptor()
+}

--- a/plugins/types.go
+++ b/plugins/types.go
@@ -73,6 +73,8 @@ const (
 	CRIServicePlugin plugin.Type = "io.containerd.cri.v1"
 	// ShimPlugin implements a shim service
 	ShimPlugin plugin.Type = "io.containerd.shim.v1"
+	// HTTPHandler implements an http handler
+	HTTPHandler plugin.Type = "io.containerd.http.v1"
 )
 
 const (


### PR DESCRIPTION
1. Makefile: shim tags so that adding `no_grpc` does not override other build tags
2. Move the shim pprof handler into a plugin and gate by the `shim_tracing` build tag (like we do the otel plugins)
3. Move the ttrpc otel interceptors into plugins so that we aren't directly importing the otelttrpc package even when we aren't building with shim_tracing.

On the plugin side, I figure there'd be some discussion on how to properly deal with plugin types/referencing in code.

This reduces the runc shim binary size to 7.1MB and RSS down to about 11.5MB.