### PR TITLE
[release/1.7] Handle teardown failure to avoid blocking cleanup

### DIFF
--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -323,6 +323,11 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 				// Teardown network if an error is returned.
 				if cleanupErr = c.teardownPodNetwork(deferCtx, sandbox); cleanupErr != nil {
 					log.G(ctx).WithError(cleanupErr).Errorf("Failed to destroy network for sandbox %q", id)
+
+					// ignoring failed to destroy networks when we failed to setup networks
+					if sandbox.CNIResult == nil {
+						cleanupErr = nil
+					}
 				}
 			}
 		}()
@@ -444,6 +449,11 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 				// Teardown network if an error is returned.
 				if cleanupErr = c.teardownPodNetwork(deferCtx, sandbox); cleanupErr != nil {
 					log.G(ctx).WithError(cleanupErr).Errorf("Failed to destroy network for sandbox %q", id)
+
+					// ignoring failed to destroy networks when we failed to setup networks
+					if sandbox.CNIResult == nil {
+						cleanupErr = nil
+					}
 				}
 			}
 		}()


### PR DESCRIPTION
Follow up to https://github.com/containerd/containerd/pull/10744#issuecomment-2383182556 

MIke: `The scenario here is CNI is not configured / installed .. there are no plugins.. cni setup fails.. returns error and CNIResult is nil...  While processing the defer chain to clean up the partially created pod.. cni tear down will also fail because.. Subsequently netns is not destroyed and then because netns is not destroyed the pod is created in the not cleaned up state.  The user must manually attempt stop at this point.  In the case where cni is not configured, we should not require it to be configured to clean up.`
