### PR TITLE
core/runtime: Fix a typo in error message

### DIFF
--- a/core/runtime/v2/shim.go
+++ b/core/runtime/v2/shim.go
@@ -102,7 +102,7 @@ func loadShim(ctx context.Context, bundle *Bundle, onClose func()) (_ ShimInstan
 
 	params, err := restoreBootstrapParams(bundle.Path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read boostrap.json when restoring bundle %q: %w", bundle.ID, err)
+		return nil, fmt.Errorf("failed to read bootstrap.json when restoring bundle %q: %w", bundle.ID, err)
 	}
 
 	conn, err := makeConnection(ctx, bundle.ID, params, onCloseWithShimLog)


### PR DESCRIPTION
`boostrap.json` should be `bootstrap.json`