### PR TITLE
[release/1.6] Handle teardown failure to avoid blocking cleanup

### DIFF
--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -311,6 +311,11 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 				// Teardown network if an error is returned.
 				if cleanupErr = c.teardownPodNetwork(deferCtx, sandbox); cleanupErr != nil {
 					log.G(ctx).WithError(cleanupErr).Errorf("Failed to destroy network for sandbox %q", id)
+
+					// ignoring failed to destroy networks when we failed to setup networks
+					if sandbox.CNIResult == nil {
+						cleanupErr = nil
+					}
 				}
 			}
 		}()


### PR DESCRIPTION
Cherry-pick of #10770 for release 1.6

---

Created pod-config.json as per crictl docs


```
root@7611fd8b15fd:/src# create pod-config.json
  echo "{
      \"metadata\": {
          \"name\": \"nginx-sandbox\",
          \"namespace\": \"default\",
          \"attempt\": 1,
          \"uid\": \"65fb5845de97d8a4\"
      },
      \"log_directory\": \"/tmp\",
      \"linux\": {
      }
  }
  " | tee pod-config.json
```

```
root@2f8f343b8881:/src# crictl runp pod-config.json
E1005 18:00:26.719186   23199 remote_runtime.go:176] "RunPodSandbox from runtime service failed" err="rpc error: code = Unknown desc = failed to setup network for sandbox \"df615a04a1ba1eef496b5e64f8a7a4a2eb8b188e35f2442a8ba1f5f54a169b8c\": cni plugin not initialized"
FATA[0001] run pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "df615a04a1ba1eef496b5e64f8a7a4a2eb8b188e35f2442a8ba1f5f54a169b8c": cni plugin not initialized 
```

The pod has still been created, although CNI has not been installed.



```
root@2f8f343b8881:/src# crictl pods
POD ID              CREATED             STATE               NAME                NAMESPACE           ATTEMPT             RUNTIME
df615a04a1ba1       5 seconds ago       NotReady            nginx-sandbox       default             1                   (default)

```

Reset cleanupErr variable to prevent further defer functions from being blocked  
  
```
// ignoring failed to destroy networks when we failed to setup networks
if sandbox.CNIResult == nil {
cleanupErr = nil
}
```

Re-build code with changes ... 

The pod isn't created ... 

```
root@7611fd8b15fd:/src# crictl pods
POD ID              CREATED             STATE               NAME                NAMESPACE           ATTEMPT             RUNTIME

```