### PR TITLE
Update runner images to macOS13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-24.04, actuated-arm64-4cpu-16gb, macos-12, windows-2019]
+        os: [ubuntu-24.04, actuated-arm64-4cpu-16gb, macos-13, windows-2019]
         exclude:
           - os: ${{ github.repository != 'containerd/containerd' && 'actuated-arm64-4cpu-16gb' }}
 
@@ -190,7 +190,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, actuated-arm64-4cpu-16gb, macos-12, windows-2019, windows-2022]
+        os: [ubuntu-22.04, ubuntu-24.04, actuated-arm64-4cpu-16gb, macos-13, windows-2019, windows-2022]
         go-version: ["1.22.7", "1.23.1"]
         exclude:
           - os: ${{ github.repository != 'containerd/containerd' && 'actuated-arm64-4cpu-16gb' }}
@@ -659,7 +659,7 @@ jobs:
 
   tests-mac-os:
     name: MacOS unit tests
-    runs-on: macos-12
+    runs-on: macos-13
     timeout-minutes: 10
     needs: [project, linters, protos, man]
     env:


### PR DESCRIPTION
This change upgrades the runner images in CI to macOS 13. macOS 12 runners are being deprecated.

See https://github.com/actions/runner-images/issues/10721 for more information.