### PR TITLE
[release/1.7 backport] Update runner images to macOS13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, actuated-arm64-4cpu-16gb, macos-12, windows-2019]
+        os: [ubuntu-20.04, actuated-arm64-4cpu-16gb, macos-13, windows-2019]
 
     steps:
       - uses: actions/checkout@v4
@@ -191,7 +191,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, actuated-arm64-4cpu-16gb, macos-12, windows-2019, windows-2022]
+        os: [ubuntu-20.04, actuated-arm64-4cpu-16gb, macos-13, windows-2019, windows-2022]
         go-version: ["1.22.7", "1.23.1"]
     steps:
       - uses: actions/checkout@v4
@@ -610,7 +610,7 @@ jobs:
 
   tests-mac-os:
     name: MacOS unit tests
-    runs-on: macos-12
+    runs-on: macos-13
     timeout-minutes: 10
     needs: [project, linters, protos, man]
     env:


### PR DESCRIPTION
* Backports https://github.com/containerd/containerd/pull/10781 to release/1.7

This change upgrades the runner images in CI to macOS 13. macOS 12 runners are being deprecated.

See https://github.com/actions/runner-images/issues/10721 for more information.


(cherry picked from commit 7b1809851348d33b0b06729aa50b82a343ea8c80)