### PR TITLE
Update sample `go test` commands in BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -270,25 +270,25 @@ name and also how to use the flag directly against `go test` to run root-requiri
 
 ```sh
 # run the test <TEST_NAME>:
-go test	-v -run "<TEST_NAME>" .
+go test	-v -run "<TEST_NAME>" ./path/to/package
 # enable the root-requiring tests:
-go test -v -run . -test.root
+go test -v -run ./path/to/package -test.root
 ```
 
 Example output from directly running `go test` to execute the `TestContainerList` test:
 
 ```sh
-sudo go test -v -run "TestContainerList" . -test.root
-INFO[0000] running tests against containerd revision=f2ae8a020a985a8d9862c9eb5ab66902c2888361 version=v1.0.0-beta.2-49-gf2ae8a0
+sudo go test -v -run "TestContainerList" ./integration/client -test.root
 === RUN   TestContainerList
 --- PASS: TestContainerList (0.00s)
 PASS
-ok  	github.com/containerd/containerd	4.778s
+
+ok      github.com/containerd/containerd/v2/integration/client  2.584s
 ```
 
 > *Note*: in order to run `sudo go` you need to
 > - either keep user PATH environment variable. ex: `sudo "PATH=$PATH" env go test <args>`
-> - or use `go test -exec` ex: `go test -exec sudo -v -run "TestTarWithXattr" ./archive/ -test.root`
+> - or use `go test -exec` ex: `go test -exec sudo -v -run "TestTarWithXattr" ./pkg/archive -test.root`
 
 ## Additional tools
 


### PR DESCRIPTION
I was getting the following error when running the sample `go test` commands.

```
no Go files in /tmp/containerd
```

Also the example `sudo go test -v -run "TestContainerList" ./integration/client -test.root` outputted a lot of logs, so I excluded them from the example.

<details>
<summary>Test Output</summary>

```shell
$ sudo go test -v -run "TestContainerList" ./integration/client -test.root
time="2024-10-08T00:18:58Z" level=info msg="Using the following image list: {Alpine:ghcr.io/containerd/alpine:3.14.0 BusyBox:ghcr.io/containerd/busybox:1.36 Pause:registry.k8s.io/pause:3.10 ResourceConsumer:registry.k8s.io/e2e-test-images/resource-consumer:1.10 VolumeCopyUp:ghcr.io/containerd/volume-copy-up:2.2 VolumeOwnership:ghcr.io/containerd/volume-ownership:2.1 ArgsEscaped:cplatpublic.azurecr.io/args-escaped-test-image-ns:1.0 DockerSchema1:registry.k8s.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff}"
time="2024-10-08T00:18:58Z" level=info msg="running tests against containerd" revision=8701137695fac3ec8061347e5882ba00d0afa14a runtime= snapshotter= version=v2.0.0-rc.5-22-g870113769
time="2024-10-08T00:18:58Z" level=info msg="start to pull seed image" image="ghcr.io/containerd/busybox:1.36"
=== RUN   TestContainerList
--- PASS: TestContainerList (0.00s)
PASS
time="2024-10-08T00:18:58.415235452Z" level=info msg="starting containerd" revision=8701137695fac3ec8061347e5882ba00d0afa14a version=v2.0.0-rc.5-22-g870113769
time="2024-10-08T00:18:58.420355199Z" level=warning msg="Configuration migrated from version 2, use `containerd config migrate` to avoid migration" t="2.75µs"
time="2024-10-08T00:18:58.420371283Z" level=info msg="loading plugin" id=io.containerd.image-verifier.v1.bindir type=io.containerd.image-verifier.v1
time="2024-10-08T00:18:58.420381324Z" level=info msg="loading plugin" id=io.containerd.internal.v1.opt type=io.containerd.internal.v1
time="2024-10-08T00:18:58.420416741Z" level=info msg="loading plugin" id=io.containerd.warning.v1.deprecations type=io.containerd.warning.v1
time="2024-10-08T00:18:58.420424616Z" level=info msg="loading plugin" id=io.containerd.content.v1.content type=io.containerd.content.v1
time="2024-10-08T00:18:58.420577741Z" level=info msg="loading plugin" id=io.containerd.snapshotter.v1.blockfile type=io.containerd.snapshotter.v1
time="2024-10-08T00:18:58.420616533Z" level=info msg="skip loading plugin" error="no scratch file generator: skip plugin" id=io.containerd.snapshotter.v1.blockfile type=io.containerd.snapshotter.v1
time="2024-10-08T00:18:58.420621783Z" level=info msg="loading plugin" id=io.containerd.snapshotter.v1.btrfs type=io.containerd.snapshotter.v1
time="2024-10-08T00:18:58.420803699Z" level=info msg="skip loading plugin" error="path /var/lib/containerd-test/io.containerd.snapshotter.v1.btrfs (overlay) must be a btrfs filesystem to be used with the btrfs snapshotter: skip plugin" id=io.containerd.snapshotter.v1.btrfs type=io.containerd.snapshotter.v1
time="2024-10-08T00:18:58.420812824Z" level=info msg="loading plugin" id=io.containerd.snapshotter.v1.devmapper type=io.containerd.snapshotter.v1
time="2024-10-08T00:18:58.420817491Z" level=info msg="skip loading plugin" error="devmapper not configured: skip plugin" id=io.containerd.snapshotter.v1.devmapper type=io.containerd.snapshotter.v1
time="2024-10-08T00:18:58.420831616Z" level=info msg="loading plugin" id=io.containerd.snapshotter.v1.native type=io.containerd.snapshotter.v1
time="2024-10-08T00:18:58.420885408Z" level=info msg="loading plugin" id=io.containerd.snapshotter.v1.overlayfs type=io.containerd.snapshotter.v1
time="2024-10-08T00:18:58.421073324Z" level=info msg="loading plugin" id=io.containerd.event.v1.exchange type=io.containerd.event.v1
time="2024-10-08T00:18:58.421103074Z" level=info msg="loading plugin" id=io.containerd.monitor.task.v1.cgroups type=io.containerd.monitor.task.v1
time="2024-10-08T00:18:58.421237157Z" level=info msg="loading plugin" id=io.containerd.metadata.v1.bolt type=io.containerd.metadata.v1
time="2024-10-08T00:18:58.421275491Z" level=info msg="metadata content store policy set" policy=shared
time="2024-10-08T00:18:58.439157440Z" level=info msg="loading plugin" id=io.containerd.gc.v1.scheduler type=io.containerd.gc.v1
time="2024-10-08T00:18:58.439200940Z" level=info msg="loading plugin" id=io.containerd.differ.v1.walking type=io.containerd.differ.v1
time="2024-10-08T00:18:58.439208523Z" level=info msg="loading plugin" id=io.containerd.lease.v1.manager type=io.containerd.lease.v1
time="2024-10-08T00:18:58.439213815Z" level=info msg="loading plugin" id=io.containerd.service.v1.containers-service type=io.containerd.service.v1
time="2024-10-08T00:18:58.439225898Z" level=info msg="loading plugin" id=io.containerd.service.v1.content-service type=io.containerd.service.v1
time="2024-10-08T00:18:58.439232148Z" level=info msg="loading plugin" id=io.containerd.service.v1.diff-service type=io.containerd.service.v1
time="2024-10-08T00:18:58.439240190Z" level=info msg="loading plugin" id=io.containerd.service.v1.images-service type=io.containerd.service.v1
time="2024-10-08T00:18:58.439245857Z" level=info msg="loading plugin" id=io.containerd.service.v1.introspection-service type=io.containerd.service.v1
time="2024-10-08T00:18:58.439257482Z" level=info msg="loading plugin" id=io.containerd.service.v1.namespaces-service type=io.containerd.service.v1
time="2024-10-08T00:18:58.439262815Z" level=info msg="loading plugin" id=io.containerd.service.v1.snapshots-service type=io.containerd.service.v1
time="2024-10-08T00:18:58.439271982Z" level=info msg="loading plugin" id=io.containerd.shim.v1.manager type=io.containerd.shim.v1
time="2024-10-08T00:18:58.439277398Z" level=info msg="loading plugin" id=io.containerd.runtime.v2.task type=io.containerd.runtime.v2
time="2024-10-08T00:18:58.439360482Z" level=info msg="loading plugin" id=io.containerd.service.v1.tasks-service type=io.containerd.service.v1
time="2024-10-08T00:18:58.439374107Z" level=debug msg="No blockio config file specified, blockio not configured"
time="2024-10-08T00:18:58.439376815Z" level=debug msg="No RDT config file specified, RDT not configured"
time="2024-10-08T00:18:58.439380523Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.containers type=io.containerd.grpc.v1
time="2024-10-08T00:18:58.439385565Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.content type=io.containerd.grpc.v1
time="2024-10-08T00:18:58.439391357Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.diff type=io.containerd.grpc.v1
time="2024-10-08T00:18:58.439399148Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.events type=io.containerd.grpc.v1
time="2024-10-08T00:18:58.439405023Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.images type=io.containerd.grpc.v1
time="2024-10-08T00:18:58.439414815Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.introspection type=io.containerd.grpc.v1
time="2024-10-08T00:18:58.439419565Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.leases type=io.containerd.grpc.v1
time="2024-10-08T00:18:58.439423690Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.namespaces type=io.containerd.grpc.v1
time="2024-10-08T00:18:58.439429023Z" level=info msg="loading plugin" id=io.containerd.sandbox.controller.v1.shim type=io.containerd.sandbox.controller.v1
time="2024-10-08T00:18:58.439471773Z" level=info msg="loading plugin" id=io.containerd.sandbox.store.v1.local type=io.containerd.sandbox.store.v1
time="2024-10-08T00:18:58.439481232Z" level=info msg="loading plugin" id=io.containerd.cri.v1.images type=io.containerd.cri.v1
time="2024-10-08T00:18:58.439509773Z" level=info msg="Get image filesystem path \"/var/lib/containerd-test/io.containerd.snapshotter.v1.overlayfs\" for snapshotter \"overlayfs\""
time="2024-10-08T00:18:58.439519815Z" level=info msg="Start snapshots syncer"
time="2024-10-08T00:18:58.439535773Z" level=info msg="loading plugin" id=io.containerd.cri.v1.runtime type=io.containerd.cri.v1
time="2024-10-08T00:18:58.439636982Z" level=info msg="starting cri plugin" config="{\"containerd\":{\"defaultRuntimeName\":\"runc\",\"runtimes\":{\"runc\":{\"runtimeType\":\"io.containerd.runc.v2\",\"runtimePath\":\"\",\"PodAnnotations\":null,\"ContainerAnnotations\":null,\"options\":{\"BinaryName\":\"\",\"CriuImagePath\":\"\",\"CriuWorkPath\":\"\",\"IoGid\":0,\"IoUid\":0,\"NoNewKeyring\":false,\"Root\":\"\",\"ShimCgroup\":\"\"},\"privileged_without_host_devices\":false,\"privileged_without_host_devices_all_devices_allowed\":false,\"baseRuntimeSpec\":\"\",\"cniConfDir\":\"\",\"cniMaxConfNum\":0,\"snapshotter\":\"\",\"sandboxer\":\"podsandbox\",\"io_type\":\"\"}},\"ignoreBlockIONotEnabledErrors\":false,\"ignoreRdtNotEnabledErrors\":false},\"cni\":{\"binDir\":\"/opt/cni/bin\",\"confDir\":\"/etc/cni/net.d\",\"maxConfNum\":1,\"setupSerially\":false,\"confTemplate\":\"\",\"ipPref\":\"\",\"useInternalLoopback\":false},\"enableSelinux\":false,\"selinuxCategoryRange\":1024,\"maxContainerLogSize\":16384,\"disableApparmor\":false,\"restrictOOMScoreAdj\":false,\"disableProcMount\":false,\"unsetSeccompProfile\":\"\",\"tolerateMissingHugetlbController\":true,\"disableHugetlbController\":true,\"device_ownership_from_security_context\":false,\"ignoreImageDefinedVolumes\":false,\"netnsMountsUnderStateDir\":false,\"enableUnprivilegedPorts\":true,\"enableUnprivilegedICMP\":true,\"enableCDI\":true,\"cdiSpecDirs\":[\"/etc/cdi\",\"/var/run/cdi\"],\"drainExecSyncIOTimeout\":\"0s\",\"ignoreDeprecationWarnings\":null,\"containerdRootDir\":\"/var/lib/containerd-test\",\"containerdEndpoint\":\"/run/containerd-test/containerd.sock\",\"rootDir\":\"/var/lib/containerd-test/io.containerd.grpc.v1.cri\",\"stateDir\":\"/run/containerd-test/io.containerd.grpc.v1.cri\"}"
time="2024-10-08T00:18:58.439672482Z" level=info msg="loading plugin" id=io.containerd.sandbox.controller.v1.podsandbox type=io.containerd.sandbox.controller.v1
time="2024-10-08T00:18:58.439710732Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.sandbox-controllers type=io.containerd.grpc.v1
time="2024-10-08T00:18:58.439721690Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.sandboxes type=io.containerd.grpc.v1
time="2024-10-08T00:18:58.439726273Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.snapshots type=io.containerd.grpc.v1
time="2024-10-08T00:18:58.439731023Z" level=info msg="loading plugin" id=io.containerd.streaming.v1.manager type=io.containerd.streaming.v1
time="2024-10-08T00:18:58.439739231Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.streaming type=io.containerd.grpc.v1
time="2024-10-08T00:18:58.439743856Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.tasks type=io.containerd.grpc.v1
time="2024-10-08T00:18:58.439753398Z" level=info msg="loading plugin" id=io.containerd.transfer.v1.local type=io.containerd.transfer.v1
time="2024-10-08T00:18:58.439765315Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.transfer type=io.containerd.grpc.v1
time="2024-10-08T00:18:58.439777648Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.version type=io.containerd.grpc.v1
time="2024-10-08T00:18:58.439781940Z" level=info msg="loading plugin" id=io.containerd.monitor.container.v1.restart type=io.containerd.monitor.container.v1
time="2024-10-08T00:18:58.439799523Z" level=info msg="loading plugin" id=io.containerd.tracing.processor.v1.otlp type=io.containerd.tracing.processor.v1
time="2024-10-08T00:18:58.439808940Z" level=info msg="skip loading plugin" error="skip plugin: tracing endpoint not configured" id=io.containerd.tracing.processor.v1.otlp type=io.containerd.tracing.processor.v1
time="2024-10-08T00:18:58.439812731Z" level=info msg="loading plugin" id=io.containerd.internal.v1.tracing type=io.containerd.internal.v1
time="2024-10-08T00:18:58.439816690Z" level=info msg="skip loading plugin" error="skip plugin: tracing endpoint not configured" id=io.containerd.internal.v1.tracing type=io.containerd.internal.v1
time="2024-10-08T00:18:58.439830315Z" level=info msg="loading plugin" id=io.containerd.ttrpc.v1.otelttrpc type=io.containerd.ttrpc.v1
time="2024-10-08T00:18:58.439836190Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.healthcheck type=io.containerd.grpc.v1
time="2024-10-08T00:18:58.439842190Z" level=info msg="loading plugin" id=io.containerd.nri.v1.nri type=io.containerd.nri.v1
time="2024-10-08T00:18:58.439849190Z" level=info msg="runtime interface created"
time="2024-10-08T00:18:58.439853731Z" level=info msg="created NRI interface"
time="2024-10-08T00:18:58.439859481Z" level=info msg="loading plugin" id=io.containerd.grpc.v1.cri type=io.containerd.grpc.v1
time="2024-10-08T00:18:58.439862940Z" level=info msg="Connect containerd service"
time="2024-10-08T00:18:58.439880148Z" level=info msg="using experimental NRI integration - disable nri plugin to prevent this"
time="2024-10-08T00:18:58.439901440Z" level=warning msg="Running CRI plugin in a user namespace typically requires disable_apparmor and restrict_oom_score_adj to be true"
time="2024-10-08T00:18:58.440119148Z" level=error msg="failed to load cni during init, please check CRI plugin status before setting up network for pods" error="cni config load failed: no network config found in /etc/cni/net.d: cni plugin not initialized: failed to load cni config"
time="2024-10-08T00:18:58.444643896Z" level=debug msg="runtime \"runc\" supports recursive read-only mounts"
time="2024-10-08T00:18:58.444657729Z" level=debug msg="runtime \"runc\" supports CRI userns: false"
time="2024-10-08T00:18:58.444759187Z" level=info msg="Start subscribing containerd event"
time="2024-10-08T00:18:58.444785312Z" level=info msg="Start recovering state"
time="2024-10-08T00:18:58.444844646Z" level=info msg="Start event monitor"
time="2024-10-08T00:18:58.444861229Z" level=info msg="Start cni network conf syncer for default"
time="2024-10-08T00:18:58.444865604Z" level=info msg="Start streaming server"
time="2024-10-08T00:18:58.444870646Z" level=info msg="Registered namespace \"k8s.io\" with NRI"
time="2024-10-08T00:18:58.444873812Z" level=info msg="runtime interface starting up..."
time="2024-10-08T00:18:58.444876062Z" level=info msg="starting plugins..."
time="2024-10-08T00:18:58.444921479Z" level=info msg=serving... address=/run/containerd-test/containerd.sock.ttrpc
time="2024-10-08T00:18:58.444973562Z" level=info msg=serving... address=/run/containerd-test/containerd.sock
time="2024-10-08T00:18:58.444993437Z" level=debug msg="sd notification" notified=false state="READY=1"
time="2024-10-08T00:18:58.445006937Z" level=info msg="containerd successfully booted in 0.030407s"
time="2024-10-08T00:18:59.446680315Z" level=debug msg="(*service).Write started" expected="sha256:7b3ccabffc97de872a30dfd234fd972a66d247c8cfc69b0550f276481852627c" ref="index-sha256:7b3ccabffc97de872a30dfd234fd972a66d247c8cfc69b0550f276481852627c" total=2295
time="2024-10-08T00:18:59.565113923Z" level=debug msg="(*service).Write started" expected="sha256:5e42fbc46b177f10319e8937dd39702e7891ce6d8a42d60c1b4f433f94200bd2" ref="manifest-sha256:5e42fbc46b177f10319e8937dd39702e7891ce6d8a42d60c1b4f433f94200bd2" total=528
time="2024-10-08T00:18:59.658396335Z" level=debug msg="(*service).Write started" expected="sha256:abaa813f94fdeebd3b8e6aeea861ab474a5c4724d16f1158755ff1e3a4fde8b0" ref="config-sha256:abaa813f94fdeebd3b8e6aeea861ab474a5c4724d16f1158755ff1e3a4fde8b0" total=1472
time="2024-10-08T00:19:00.043003394Z" level=debug msg="prepare snapshot" key="extract-41989644-4Q4l sha256:869e6058ea58994b7c023f0f0a80f6dbb672ffc1cc61ef6c272f8dd573a76cc9" parent=
time="2024-10-08T00:19:00.052295556Z" level=debug msg="(*service).Write started" expected="sha256:f78e6840ded1aafb6c9f265f52c2fc7c0a990813ccf96702df84a7dcdbe48bea" ref="layer-sha256:f78e6840ded1aafb6c9f265f52c2fc7c0a990813ccf96702df84a7dcdbe48bea" total=2001136
time="2024-10-08T00:19:01.595768331Z" level=debug msg=" not found" error="exec: \"igzip\": executable file not found in $PATH"
time="2024-10-08T00:19:01.595836414Z" level=debug msg=" not found" error="exec: \"unpigz\": executable file not found in $PATH"
time="2024-10-08T00:19:01.644503681Z" level=debug msg="diff applied" d=48.830101ms digest="sha256:f78e6840ded1aafb6c9f265f52c2fc7c0a990813ccf96702df84a7dcdbe48bea" media=application/vnd.docker.image.rootfs.diff.tar.gzip size=2001136
time="2024-10-08T00:19:01.644756348Z" level=debug msg="commit snapshot" key="extract-41989644-4Q4l sha256:869e6058ea58994b7c023f0f0a80f6dbb672ffc1cc61ef6c272f8dd573a76cc9" name="sha256:869e6058ea58994b7c023f0f0a80f6dbb672ffc1cc61ef6c272f8dd573a76cc9"
time="2024-10-08T00:19:01.651115345Z" level=debug msg="create image" name="ghcr.io/containerd/busybox:1.36" target="sha256:7b3ccabffc97de872a30dfd234fd972a66d247c8cfc69b0550f276481852627c"
time="2024-10-08T00:19:01.651511636Z" level=debug msg="Received containerd event timestamp - 2024-10-08 00:19:01.651467178 +0000 UTC, namespace - \"testing\", topic - \"/images/create\""
time="2024-10-08T00:19:01.651533595Z" level=debug msg="Ignoring events in namespace - \"testing\""
time="2024-10-08T00:19:01.652677761Z" level=debug msg="received signal" signal=terminated
time="2024-10-08T00:19:01.652709552Z" level=debug msg="sd notification" notified=false state="STOPPING=1"
time="2024-10-08T00:19:01.652762344Z" level=info msg="Stop CRI service"
time="2024-10-08T00:19:01.652897136Z" level=debug msg="cni watcher channel is closed"
time="2024-10-08T00:19:01.652919802Z" level=info msg="Stop CRI service"
time="2024-10-08T00:19:01.652938261Z" level=info msg="Event monitor stopped"
time="2024-10-08T00:19:01.652940469Z" level=info msg="Stream server stopped"

ok      github.com/containerd/containerd/v2/integration/client  3.256s
```
</details>