### PR TITLE
Add After=dbus.service to containerd.service

### DIFF
--- a/containerd.service
+++ b/containerd.service
@@ -15,7 +15,7 @@
 [Unit]
 Description=containerd container runtime
 Documentation=https://containerd.io
-After=network.target local-fs.target
+After=network.target local-fs.target dbus.service
 
 [Service]
 ExecStartPre=-/sbin/modprobe overlay


### PR DESCRIPTION
containerd launches runc, which communicates via dbus with systemd to start transient units. Thus, containerd should have an `After` dependency on `dbus.service` to prevent dbus from being shut down concurrently with containerd.