### PR TITLE
[release/1.7] prow: allow ENABLE_CRI_SANDBOXES to be configured

### DIFF
--- a/contrib/gce/configure.sh
+++ b/contrib/gce/configure.sh
@@ -235,6 +235,15 @@ disabled_plugins = ["io.containerd.internal.v1.restart"]
 EOF
 chmod 644 "${config_path}"
 
+cri_sandboxes="${CONTAINERD_ENABLE_CRI_SANDBOXES:-}"
+containerd_env_path="${CONTAINERD_ENV_PATH:-"/etc/containerd/env"}"
+touch "${containerd_env_path}"
+if [[ -n "${cri_sandboxes}" ]]; then
+  cat > ${containerd_env_path} <<EOF
+ENABLE_CRI_SANDBOXES="${cri_sandboxes}"
+EOF
+fi
+
 # containerd_extra_runtime_handler is the extra runtime handler to install.
 containerd_extra_runtime_handler=${CONTAINERD_EXTRA_RUNTIME_HANDLER:-""}
 if [[ -n "${containerd_extra_runtime_handler}" ]]; then

--- a/test/e2e_node/init.yaml
+++ b/test/e2e_node/init.yaml
@@ -45,6 +45,7 @@ write_files:
       LimitNPROC=infinity
       LimitCORE=infinity
       TasksMax=infinity
+      EnvironmentFile=/etc/containerd/env
       ExecStartPre=/sbin/modprobe overlay
       ExecStart=/home/containerd/usr/local/bin/containerd
 


### PR DESCRIPTION
The pull-containerd-node-e2e-1-7-sandboxed job will set ENABLE_CRI_SANDBOXES for containerd 1.7 and enable us to validate that the sbserver backend works with e2e tests.