### PR TITLE
[release/1.7] Prepare release notes for v1.7.23

### DIFF
--- a/releases/v1.7.23.toml
+++ b/releases/v1.7.23.toml
@@ -1,0 +1,27 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.7.22"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The twenty-third patch release for containerd 1.7 contains various fixes
+and updates.
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.7.22+unknown"
+	Version = "1.7.23+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated release notes

----

Welcome to the v1.7.23 release of containerd!

The twenty-third patch release for containerd 1.7 contains various fixes
and updates.

### Highlights

* Add errdefs aliases ([#10792](https://github.com/containerd/containerd/pull/10792))
* Allow proxy plugins to have capabilities ([#10731](https://github.com/containerd/containerd/pull/10731))
* Revert errdefs package migration ([#10712](https://github.com/containerd/containerd/pull/10712))

#### Container Runtime Interface (CRI)

* Add check for CNI plugins before tearing down pod network ([#10767](https://github.com/containerd/containerd/pull/10767))

#### Image Distribution

* Fix the race condition during GC of snapshots when client retries ([#10763](https://github.com/containerd/containerd/pull/10763))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Derek McGowan
* Austin Vazquez
* Phil Estes
* Akihiro Suda
* Samuel Karp
* Maksym Pavlenko
* Kern Walster
* Kir Kolyshkin
* Saket Jajoo
* Sameer
* Wei Fu
* Zou Nengren
* bo.jiang

### Changes
<details><summary>36 commits</summary>
<p>

  * [`921f554af`](https://github.com/containerd/containerd/commit/921f554af99d32ff867f45499acdaf5f72444da6) Prepare release notes for v1.7.23
* Revert "update runc binary to 1.1.15" ([#10826](https://github.com/containerd/containerd/pull/10826))
  * [`8f16d6588`](https://github.com/containerd/containerd/commit/8f16d6588a79c4b639e6473dfca0cb899028e575) Revert "update runc binary to 1.1.15"
* Switch from actuated.dev to GH Action runners for arm64 ([#10822](https://github.com/containerd/containerd/pull/10822))
  * [`41e8f24cd`](https://github.com/containerd/containerd/commit/41e8f24cd1d8de2360e6bb35a3f7e11c2330d23b) Switch from actuated.dev to GH Action runners for arm64
  * [`dd811f224`](https://github.com/containerd/containerd/commit/dd811f224a327e9647fc3ff8fd30fb5c61322898) Update github actions ci to run on forks
* bump golangci/golangci-lint-action from 4 to 6 ([#10813](https://github.com/containerd/containerd/pull/10813))
  * [`284484af4`](https://github.com/containerd/containerd/commit/284484af449cd09d1708ff446489e0aa22730ec6) bump golangci/golangci-lint-action from 4 to 6
* update to go1.23.2,go1.22.8 ([#10808](https://github.com/containerd/containerd/pull/10808))
  * [`814c59ba5`](https://github.com/containerd/containerd/commit/814c59ba56bfb2342350c034d791c9933014e657) update to go1.23.2,go1.22.8
* prow: allow ENABLE_CRI_SANDBOXES to be configured ([#10801](https://github.com/containerd/containerd/pull/10801))
  * [`ae11176fa`](https://github.com/containerd/containerd/commit/ae11176facd42ab7cca86a3a04b1468c1dae4b9a) prow: allow ENABLE_CRI_SANDBOXES to be configured
* TestNewBinaryIOCleanup: fix a comment, minor rewrite ([#10776](https://github.com/containerd/containerd/pull/10776))
  * [`7fd794a7c`](https://github.com/containerd/containerd/commit/7fd794a7cd9ce246d1792842f2c6c0c16d9bdd76) TestNewBinaryIOCleanup: fix a comment, minor rewrite
* Add errdefs aliases ([#10792](https://github.com/containerd/containerd/pull/10792))
  * [`0714a2952`](https://github.com/containerd/containerd/commit/0714a2952af68dc83c41b46d50413a344af68521) Add errdefs aliases
* Update runc binary to 1.1.15 ([#10794](https://github.com/containerd/containerd/pull/10794))
  * [`113a9f1fc`](https://github.com/containerd/containerd/commit/113a9f1fc9aa47ed622bcd0eb954ef8cf84551e3) update runc binary to 1.1.15
* Update runner images to macOS13 ([#10783](https://github.com/containerd/containerd/pull/10783))
  * [`5305b03f2`](https://github.com/containerd/containerd/commit/5305b03f2c374fb54edcbbd3f1f07e413460d79e) Update runner images to macOS13
* Allow proxy plugins to have capabilities ([#10731](https://github.com/containerd/containerd/pull/10731))
  * [`950740390`](https://github.com/containerd/containerd/commit/9507403907c62536c97277bcd8ebffa7f357adae) Allow proxy plugins to have capabilities
* Bump crun to 1.16.1 ([#10774](https://github.com/containerd/containerd/pull/10774))
  * [`e8aae7824`](https://github.com/containerd/containerd/commit/e8aae7824420c2c6673aeba640d168db6332099b) Bump crun to 1.16
  * [`ee1c39b79`](https://github.com/containerd/containerd/commit/ee1c39b79972102da15abab87f130fa1ab08f059) CI: bump up crun to 1.15
* Fix the race condition during GC of snapshots when client retries ([#10763](https://github.com/containerd/containerd/pull/10763))
  * [`cb5e6a01a`](https://github.com/containerd/containerd/commit/cb5e6a01a30dd6a34d4f7c25d8d429a5173bc541) Fix the race condition during GC of snapshots when client retries
* Add check for CNI plugins before tearing down pod network ([#10767](https://github.com/containerd/containerd/pull/10767))
  * [`278bd0f72`](https://github.com/containerd/containerd/commit/278bd0f7251eb58583f0cd52a18c16c537ae967b) [release/1.7] Add check for CNI plugins before tearing down pod network
* Revert errdefs package migration ([#10712](https://github.com/containerd/containerd/pull/10712))
  * [`18403239e`](https://github.com/containerd/containerd/commit/18403239e8cf0c040d28bf98e434198fd4852f88) Synchronize 1.7 error package with errdefs
  * [`d8d27205b`](https://github.com/containerd/containerd/commit/d8d27205b50bf4933a60cd9e6ddf3aaa2b56c469) Revert "migrate errdefs package to github.com/containerd/errdefs module"
  * [`e82d201b3`](https://github.com/containerd/containerd/commit/e82d201b3ffb87c15d2b7be2eb2e0c7bfa99d114) Revert "replace uses of github.com/containerd/containerd/errdefs"
  * [`51939238f`](https://github.com/containerd/containerd/commit/51939238f648806330c67a0294b5b75c79956d75) Revert "errdefs: denote deprecation as a godoc comment"
  * [`ae80077e8`](https://github.com/containerd/containerd/commit/ae80077e80712ba27c162d85498bc7180710c210) Revert "golangci-lint: enable depguard for packages that moved"
  * [`32675f983`](https://github.com/containerd/containerd/commit/32675f9837d585d957849cabf72a4afd83cbd19c) Revert "remove imports of errdefs package"
</p>
</details>

### Changes from containerd/errdefs
<details><summary>29 commits</summary>
<p>

* Add errdefs/pkg package ([containerd/errdefs#19](https://github.com/containerd/errdefs/pull/19))
  * [`46a6522`](https://github.com/containerd/errdefs/commit/46a6522eb15b62d58e2eb429682318d5700b3123) Add errdefs/pkg package
* Update GitHub Actions packages and runners ([containerd/errdefs#20](https://github.com/containerd/errdefs/pull/20))
  * [`303a6ea`](https://github.com/containerd/errdefs/commit/303a6ea6abfdcbc4ba2b8bf44c1af25a5831caea) Update to Go 1.22.8 in CI
  * [`e70104e`](https://github.com/containerd/errdefs/commit/e70104e29d6783e914cbe12e7aeb6c6600d0d0a2) Upgrade to golangci-lint@v1.61.0
  * [`ffe5586`](https://github.com/containerd/errdefs/commit/ffe5586c0581f6744ddebe87a82ca6f75bb0da78) Upgrade to golangci/golangci-lint-action@v6
  * [`908b04b`](https://github.com/containerd/errdefs/commit/908b04b90d2a8dd2127469ebb66fb9dd60a780c5) Upgrade to actions/checkout@v4
  * [`608b83c`](https://github.com/containerd/errdefs/commit/608b83c69071e34c689a7174d439a700a5b10aa8) Upgrade to actions/setup-go@v5
  * [`8e82ae4`](https://github.com/containerd/errdefs/commit/8e82ae46fd7eecc2425ed55cd06c6738d31ab1ef) Upgrade macOS runner image to macOS 13
* Complete interface definitions for errors ([containerd/errdefs#18](https://github.com/containerd/errdefs/pull/18))
  * [`41d12e1`](https://github.com/containerd/errdefs/commit/41d12e1db5cf9452436122e3c648e761453a112c) Complete interface definitions for errors
* Add support for grpc error details and multiple errors ([containerd/errdefs#7](https://github.com/containerd/errdefs/pull/7))
  * [`b9dce4d`](https://github.com/containerd/errdefs/commit/b9dce4d7bd5a514f38c0b47bcc4397b7ad7930f4) Add support for grpc error details
  * [`ffb0349`](https://github.com/containerd/errdefs/commit/ffb0349b41b940e9415587a6e12d571cd9a55fbe) Update Resolve function to support Is interface
* Add support for custom error messages ([containerd/errdefs#10](https://github.com/containerd/errdefs/pull/10))
  * [`dc9b20e`](https://github.com/containerd/errdefs/commit/dc9b20ea99092223cac03215dcaf6cd96f190a7c) Add support for custom error messages
* Add a resolve error function to return first error ([containerd/errdefs#9](https://github.com/containerd/errdefs/pull/9))
  * [`9f87502`](https://github.com/containerd/errdefs/commit/9f87502f13ad5c2758b225ff9bc10f3d9f932010) Add a resolve error function to return first error
* Add stack support ([containerd/errdefs#8](https://github.com/containerd/errdefs/pull/8))
  * [`f96dfda`](https://github.com/containerd/errdefs/commit/f96dfdab01b66580d2451fee46e05f002c9ea157) Add stack package for managing error stack traces
  * [`70fd2d7`](https://github.com/containerd/errdefs/commit/70fd2d7ff216659f37f286c42cf827f450d9d074) Add collapsible error type
  * [`6022faf`](https://github.com/containerd/errdefs/commit/6022faf38302b354934727fbe5a34851f9fb95b6) Add typeurl to go mod
* Fix Cancelled interface typo ([containerd/errdefs#6](https://github.com/containerd/errdefs/pull/6))
  * [`9564d8f`](https://github.com/containerd/errdefs/commit/9564d8ff88294257499cd16f16b8814ef78021b6) Fix Cancelled interface typo
* Split gRPC and HTTP error utility into seperate packages ([containerd/errdefs#5](https://github.com/containerd/errdefs/pull/5))
  * [`fd0e482`](https://github.com/containerd/errdefs/commit/fd0e4826e7aee061a8d584680686a8fade5bccc9) Split gRPC and HTTP error utility into seperate packages
* Add more grpc types ([containerd/errdefs#3](https://github.com/containerd/errdefs/pull/3))
  * [`f727cdb`](https://github.com/containerd/errdefs/commit/f727cdba81f149bab695a0d5cfb9a240e8f03ae9) Add HTTP status code and error type conversion
  * [`9854dc7`](https://github.com/containerd/errdefs/commit/9854dc7575de563e298661aec4079fe1766d9f43) Add more grpc error types
</p>
</details>

### Dependency Changes

* **github.com/containerd/errdefs**  v0.1.0 -> v0.3.0

Previous release can be found at [v1.7.22](https://github.com/containerd/containerd/releases/tag/v1.7.22)
