### PR TITLE
[release/1.7] bump golangci/golangci-lint-action from 4 to 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-go
-      - uses: golangci/golangci-lint-action@v4
+      - uses: golangci/golangci-lint-action@v6
         with:
           only-new-issues: true
           version: v1.60.1


### PR DESCRIPTION
fix: https://github.com/containerd/containerd/issues/10812

xref: https://github.com/golangci/golangci-lint-action/pull/1029