### PR TITLE
[release/1.7] metrics: Use UnmarshalTo instead of UnmarshalAny

### DIFF
--- a/metrics/cgroups/v1/metrics.go
+++ b/metrics/cgroups/v1/metrics.go
@@ -148,16 +148,12 @@ func (c *Collector) collect(entry entry, ch chan<- prometheus.Metric, block bool
 		return
 	}
 
-	data, err := typeurl.UnmarshalAny(stats)
-	if err != nil {
+	s := &v1.Metrics{}
+	if err := typeurl.UnmarshalTo(stats, s); err != nil {
 		log.L.WithError(err).Errorf("unmarshal stats for %s", t.ID())
 		return
 	}
-	s, ok := data.(*v1.Metrics)
-	if !ok {
-		log.L.WithError(err).Errorf("invalid metric type for %s", t.ID())
-		return
-	}
+
 	ns := entry.ns
 	if ns == nil {
 		ns = c.ns

--- a/metrics/cgroups/v2/metrics.go
+++ b/metrics/cgroups/v2/metrics.go
@@ -141,16 +141,12 @@ func (c *Collector) collect(entry entry, ch chan<- prometheus.Metric, block bool
 		return
 	}
 
-	data, err := typeurl.UnmarshalAny(stats)
-	if err != nil {
+	s := &v2.Metrics{}
+	if err := typeurl.UnmarshalTo(stats, s); err != nil {
 		log.L.WithError(err).Errorf("unmarshal stats for %s", t.ID())
 		return
 	}
-	s, ok := data.(*v2.Metrics)
-	if !ok {
-		log.L.WithError(err).Errorf("invalid metric type for %s", t.ID())
-		return
-	}
+
 	ns := entry.ns
 	if ns == nil {
 		ns = c.ns


### PR DESCRIPTION
This pr comes from not updating https://github.com/containerd/containerd/pull/9195, and it only works for release/1.7, it didn't have this problem in 1.6 on 2.x

---

Unmarshal `io.containerd.cgroups.v1.Metrics` with `UnmarshalAny` in 1.7+ (don't track which version it started with, but the latest version still has this issue) will first be parsed as [github.com/containerd/cgroups/stats/v1.Metrics](https://github.com/containerd/containerd/blob/923bb1f33d018b9c0cc8a2ef6c89f02517246e86/vendor/github.com/containerd/cgroups/stats/v1/metrics.pb.go#L705).
> If UnmarshalAny in a unit test it shouldn't have this problem because it's not importing the wrong Metrics

This is due to hcsshim causing the dependency to have both [github.com/containerd/cgroups/stats/v1/](https://github.com/containerd/containerd/tree/release/1.7/vendor/github.com/containerd/cgroups/stats/v1) and . [/vendor/github.com/containerd/cgroups/v3/cgroup1/stats](https://github.com/containerd/containerd/tree/release/1.7/vendor/github.com/containerd/cgroups/v3/cgroup1)

**How to reproduce this issue**:
**env:**
* containerd release/1.7 or 1.7.19
* **cgroup v1**

**steps:**
1. configure /etc/containerd/config.toml to enable metrics
```bash
[metrics]
  address = "127.0.0.1:7000"
```

3. curl 127.0.0.1:7000/v1/metrics | grep ^container_
4. You will notice that there is no container_* indicator.
5. Check the logs of containerd, error log -> `{"error":null,"level":"error","msg":"invalid metric type for ...`

Copy from https://github.com/containerd/containerd/pull/9195#issuecomment-2222233256