### PR TITLE
metrics: Use UnmarshalTo instead of UnmarshalAny

### DIFF
--- a/core/metrics/cgroups/v1/metrics.go
+++ b/core/metrics/cgroups/v1/metrics.go
@@ -148,16 +148,12 @@ func (c *Collector) collect(entry entry, ch chan<- prometheus.Metric, block bool
 		return
 	}
 
-	data, err := typeurl.UnmarshalAny(stats)
-	if err != nil {
+	s := &v1.Metrics{}
+	if err := typeurl.UnmarshalTo(stats, s); err != nil {
 		log.L.WithError(err).Errorf("unmarshal stats for %s", t.ID())
 		return
 	}
-	s, ok := data.(*v1.Metrics)
-	if !ok {
-		log.L.WithError(err).Errorf("invalid metric type for %s", t.ID())
-		return
-	}
+
 	ns := entry.ns
 	if ns == nil {
 		ns = c.ns

--- a/core/metrics/cgroups/v2/metrics.go
+++ b/core/metrics/cgroups/v2/metrics.go
@@ -141,14 +141,9 @@ func (c *Collector) collect(entry entry, ch chan<- prometheus.Metric, block bool
 		return
 	}
 
-	data, err := typeurl.UnmarshalAny(stats)
-	if err != nil {
+	s := &v2.Metrics{}
+	if err := typeurl.UnmarshalTo(stats, s); err != nil {
 		log.L.WithError(err).Errorf("unmarshal stats for %s", t.ID())
-		return
-	}
-	s, ok := data.(*v2.Metrics)
-	if !ok {
-		log.L.WithError(err).Errorf("invalid metric type for %s", t.ID())
 		return
 	}
 	ns := entry.ns


### PR DESCRIPTION
This pr comes from not updating https://github.com/containerd/containerd/pull/9195.

Although this bug will only happen in 1.7, for the consistency of the code, the main will be updated first, and then cherry picked to 1.7

related pr for release/1.7: https://github.com/containerd/containerd/pull/10814