### PR TITLE
Create a custom NameBased sampler to filter down traces that are unneeded

### DIFF
--- a/pkg/tracing/plugin/otlp.go
+++ b/pkg/tracing/plugin/otlp.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/containerd/containerd/v2/pkg/deprecation"
@@ -50,8 +51,10 @@ const (
 	otlpProtocolEnv       = "OTEL_EXPORTER_OTLP_PROTOCOL"
 	otlpTracesProtocolEnv = "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"
 
-	otelTracesExporterEnv = "OTEL_TRACES_EXPORTER"
-	otelServiceNameEnv    = "OTEL_SERVICE_NAME"
+	otelTracesExporterEnv   = "OTEL_TRACES_EXPORTER"
+	otelServiceNameEnv      = "OTEL_SERVICE_NAME"
+	otelTracesSamplerEnv    = "OTEL_TRACES_SAMPLER"
+	otelTracesSamplerArgEnv = "OTEL_TRACES_SAMPLER_ARG"
 )
 
 func init() {
@@ -188,6 +191,15 @@ func newTracer(ctx context.Context, procs []trace.SpanProcessor) (io.Closer, err
 	for _, proc := range procs {
 		opts = append(opts, trace.WithSpanProcessor(proc))
 	}
+
+	// Configure custom NameBased sampler if specified in the env
+	if nameSampler := nameSamplerFromEnv(); nameSampler != nil {
+		opts = append(opts, trace.WithSampler(nameSampler))
+		// Unset the env vars so that otel sdk does not attempt to configure the sampler automatically
+		os.Unsetenv(otelTracesSamplerEnv)
+		os.Unsetenv(otelTracesSamplerArgEnv)
+	}
+
 	provider := trace.NewTracerProvider(opts...)
 	otel.SetTracerProvider(provider)
 
@@ -195,6 +207,25 @@ func newTracer(ctx context.Context, procs []trace.SpanProcessor) (io.Closer, err
 		return provider.Shutdown(ctx)
 	}), nil
 
+}
+
+func nameSamplerFromEnv() trace.Sampler {
+	sampler, ok := os.LookupEnv(otelTracesSamplerEnv)
+	if !ok {
+		return nil
+	}
+
+	sampler = strings.ToLower(strings.TrimSpace(sampler))
+	allowedNames := strings.Split(strings.TrimSpace(os.Getenv(otelTracesSamplerArgEnv)), ",")
+
+	switch sampler {
+	case samplerNameBased:
+		return NameBased(allowedNames)
+	case samplerParentBasedName:
+		return trace.ParentBased(NameBased(allowedNames))
+	default:
+		return nil
+	}
 }
 
 func warnTraceConfig(ic *plugin.InitContext) error {

--- a/pkg/tracing/plugin/sampler.go
+++ b/pkg/tracing/plugin/sampler.go
@@ -1,0 +1,67 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package plugin
+
+import (
+	"fmt"
+
+	sdkTrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	samplerNameBased       = "namebased"
+	samplerParentBasedName = "parentbased_name"
+)
+
+type NameSampler struct {
+	// allow is a set of names that should be sampled.
+	// Uses a map of empty structs for O(1) lookups and no memory overhead.
+	allow map[string]struct{}
+}
+
+// NameBased returns a Sampler that samples every span having a certain name.
+// It should be used in conjunction with the ParentBased sampler so that the child spans are also sampled.
+func NameBased(allowedNames []string) NameSampler {
+	allowedNamesMap := make(map[string]struct{}, len(allowedNames))
+	for _, name := range allowedNames {
+		allowedNamesMap[name] = struct{}{}
+	}
+	return NameSampler{
+		allow: allowedNamesMap,
+	}
+}
+
+func (ns NameSampler) ShouldSample(parameters sdkTrace.SamplingParameters) sdkTrace.SamplingResult {
+	psc := trace.SpanContextFromContext(parameters.ParentContext)
+
+	if _, ok := ns.allow[parameters.Name]; ok {
+		return sdkTrace.SamplingResult{
+			Decision:   sdkTrace.RecordAndSample,
+			Tracestate: psc.TraceState(),
+		}
+	}
+
+	return sdkTrace.SamplingResult{
+		Decision:   sdkTrace.Drop,
+		Tracestate: psc.TraceState(),
+	}
+}
+
+func (ns NameSampler) Description() string {
+	return fmt.Sprintf("NameBased:{%v}", ns.allow)
+}


### PR DESCRIPTION
## What is this?

Aims to solve #9896

Containerd tracing can be incredibly useful to understand bottlenecks during the lifecycle of container applications like image pull times. However as mentioned in #9896, the tracing can be quite overwhelming on a large amount of nodes with almost a million traces generated over a week (each containing dozens spans). This amount of traces can put some heavy pressure on a trace intake endpoint and upon analyzing the traces repartition, it appears that the most noisy traces are not the most interesting ones. The `Read`, `Get` and `Info` traces represent more than 2/3 of the traces while not really being helpful to track down the bottlenecks. And the default samplers available with OTEL won't help as having a very aggressive ratio sampling strategy simply risk hiding the interesting traces even more.

## How it works

As such this PR aims to solve the above issue by implementing a new custom sampler called `NameBased` will only allow certain traces based on an allow list that can be configured with env variables. 
The sampler was implemented similarly to the [default samplers](https://github.com/open-telemetry/opentelemetry-go/blob/main/sdk/trace/sampling.go) defined in the otel sdk.
It leverages the regular env variables common to every OTEL samplers for configuration. Also, the sampler works best in combination with a parent based sampler (`parentbased_name`) so that the allow list only has to specify the root spans for all the children to be sampled as well.
The allow list of traces to be kept should be passed as a comma separated list to the `OTEL_TRACES_SAMPLER_ARG` env var.

## Result

With containerd started with the following config:
```
OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317 OTEL_EXPORTER_OTLP_PROTOCOL=grpc OTEL_TRACES_SAMPLER=parentbased_name OTEL_TRACES_SAMPLER_ARG="runtime.v1.ImageService/PullImage" containerd
```

From the initial traces repartition
![image](https://github.com/user-attachments/assets/de4238ec-cee7-4a81-b92f-a4d089a71969)

We now only keep the traces that we want 
![image](https://github.com/user-attachments/assets/dc295092-ea7f-48ea-9d52-a0473ce8e8a4)
