### PR TITLE
Switch from actuated.dev to GH Action runners for arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-24.04, actuated-arm64-4cpu-16gb, macos-13, windows-2019]
+        os: [ubuntu-24.04, arm64-8core-32gb, macos-13, windows-2019]
         exclude:
-          - os: ${{ github.repository != 'containerd/containerd' && 'actuated-arm64-4cpu-16gb' }}
+          - os: ${{ github.repository != 'containerd/containerd' && 'arm64-8core-32gb' }}
 
 
     steps:
@@ -190,10 +190,10 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, actuated-arm64-4cpu-16gb, macos-13, windows-2019, windows-2022]
+        os: [ubuntu-22.04, ubuntu-24.04, arm64-8core-32gb, macos-13, windows-2019, windows-2022]
         go-version: ["1.22.8", "1.23.2"]
         exclude:
-          - os: ${{ github.repository != 'containerd/containerd' && 'actuated-arm64-4cpu-16gb' }}
+          - os: ${{ github.repository != 'containerd/containerd' && 'arm64-8core-32gb' }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-go
@@ -388,9 +388,9 @@ jobs:
         runtime:
           - io.containerd.runc.v2
         runc: [runc, crun]
-        os: [ubuntu-22.04, ubuntu-24.04, actuated-arm64-4cpu-16gb]
+        os: [ubuntu-22.04, ubuntu-24.04, arm64-8core-32gb]
         exclude:
-          - os: ${{ github.repository != 'containerd/containerd' && 'actuated-arm64-4cpu-16gb' }}
+          - os: ${{ github.repository != 'containerd/containerd' && 'arm64-8core-32gb' }}
         cgroup_driver: [cgroupfs, systemd]
 
     env:
@@ -412,10 +412,10 @@ jobs:
           script/setup/install-failpoint-binaries
 
       - name: Install criu
-        # NOTE: Required actuated enable CONFIG_CHECKPOINT_RESTORE
+        # NOTE: Required arm64 enable CONFIG_CHECKPOINT_RESTORE (need to confirm GitHub action runners config)
         #
         # REF: https://criu.org/Linux_kernel
-        if: matrix.os != 'actuated-arm64-4cpu-16gb'
+        if: matrix.os != 'arm64-8core-32gb'
         run: |
           sudo add-apt-repository -y ppa:criu/ppa
           sudo apt-get update
@@ -490,12 +490,6 @@ jobs:
           }
           runc --version
           CONTAINERD_RUNTIME=$TEST_RUNTIME make cri-integration
-
-      - name: Fix up for actuated
-        # https://github.com/containerd/containerd/pull/9920#issuecomment-2024823587
-        if: ${{ (matrix.os == 'actuated-arm64-4cpu-16gb') && (matrix.runc == 'crun') }}
-        run: |
-          echo "EXTRA_CRITEST_OPTIONS=--ginkgo.skip=runtime should support NamespaceMode_POD" >> $GITHUB_ENV
 
       - name: cri-tools critest
         env:


### PR DESCRIPTION
Informed that "the sponsored subscription from the CNCF and Ampere is running out at the end of the month."; testing a GH actions arm64 runner now that we have access via the CNCF enterprise plan.