### PR TITLE
[release/1.7 backport] Switch from actuated.dev to GH Action runners for arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, actuated-arm64-4cpu-16gb, macos-13, windows-2019]
+        os: [ubuntu-20.04, arm64-8core-32gb, macos-13, windows-2019]
         exclude:
-          - os: ${{ github.repository != 'containerd/containerd' && 'actuated-arm64-4cpu-16gb' }}
+          - os: ${{ github.repository != 'containerd/containerd' && 'arm64-8core-32gb' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -193,10 +193,10 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, actuated-arm64-4cpu-16gb, macos-13, windows-2019, windows-2022]
+        os: [ubuntu-20.04, arm64-8core-32gb, macos-13, windows-2019, windows-2022]
         go-version: ["1.22.8", "1.23.2"]
         exclude:
-          - os: ${{ github.repository != 'containerd/containerd' && 'actuated-arm64-4cpu-16gb' }}
+          - os: ${{ github.repository != 'containerd/containerd' && 'arm64-8core-32gb' }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-go
@@ -396,17 +396,17 @@ jobs:
           - io.containerd.runc.v2
         runc: [runc, crun]
         enable_cri_sandboxes: ["", "sandboxed"]
-        os: [ubuntu-20.04, actuated-arm64-4cpu-16gb]
+        os: [ubuntu-20.04, arm64-8core-32gb]
         exclude:
-          - os: ${{ github.repository != 'containerd/containerd' && 'actuated-arm64-4cpu-16gb' }}
+          - os: ${{ github.repository != 'containerd/containerd' && 'arm64-8core-32gb' }}
           - runtime: io.containerd.runc.v1
             runc: crun
           - runtime: io.containerd.runtime.v1.linux
             runc: crun
           - runtime: io.containerd.runc.v1
-            os: actuated-arm64-4cpu-16gb
+            os: arm64-8core-32gb
           - runtime: io.containerd.runtime.v1.linux
-            os: actuated-arm64-4cpu-16gb
+            os: arm64-8core-32gb
 
     env:
       GOTEST: gotestsum --
@@ -427,10 +427,10 @@ jobs:
           script/setup/install-failpoint-binaries
 
       - name: Install criu
-        # NOTE: Required actuated enable CONFIG_CHECKPOINT_RESTORE
+        # NOTE: Required arm64 enable CONFIG_CHECKPOINT_RESTORE (need to confirm GitHub action runners config)
         #
         # REF: https://criu.org/Linux_kernel
-        if: matrix.os != 'actuated-arm64-4cpu-16gb'
+        if: matrix.os != 'arm64-8core-32gb'
         run: |
           sudo add-apt-repository -y ppa:criu/ppa
           sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, actuated-arm64-4cpu-16gb, macos-13, windows-2019]
+        exclude:
+          - os: ${{ github.repository != 'containerd/containerd' && 'actuated-arm64-4cpu-16gb' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -43,7 +45,6 @@ jobs:
   #
   project:
     name: Project Checks
-    if: github.repository == 'containerd/containerd'
     runs-on: ubuntu-20.04
     timeout-minutes: 5
 
@@ -56,6 +57,7 @@ jobs:
       - uses: ./src/github.com/containerd/containerd/.github/actions/install-go
 
       - uses: containerd/project-checks@v1.1.0
+        if: github.repository == 'containerd/containerd'
         with:
           working-directory: src/github.com/containerd/containerd
           repo-access-token: ${{ secrets.GITHUB_TOKEN }}
@@ -193,6 +195,8 @@ jobs:
       matrix:
         os: [ubuntu-20.04, actuated-arm64-4cpu-16gb, macos-13, windows-2019, windows-2022]
         go-version: ["1.22.8", "1.23.2"]
+        exclude:
+          - os: ${{ github.repository != 'containerd/containerd' && 'actuated-arm64-4cpu-16gb' }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-go
@@ -394,6 +398,7 @@ jobs:
         enable_cri_sandboxes: ["", "sandboxed"]
         os: [ubuntu-20.04, actuated-arm64-4cpu-16gb]
         exclude:
+          - os: ${{ github.repository != 'containerd/containerd' && 'actuated-arm64-4cpu-16gb' }}
           - runtime: io.containerd.runc.v1
             runc: crun
           - runtime: io.containerd.runtime.v1.linux


### PR DESCRIPTION
* Backports https://github.com/containerd/containerd/pull/9963 to 1.7
* Backports https://github.com/containerd/containerd/pull/10821 to 1.7