### PR TITLE
Fix "config dump" with custom config file path

### DIFF
--- a/cmd/containerd/command/config.go
+++ b/cmd/containerd/command/config.go
@@ -94,6 +94,12 @@ var configCommand = &cli.Command{
 		{
 			Name:  "dump",
 			Usage: "See the output of the final main config with imported in subconfig files",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:  "config",
+					Usage: "Path to configuration file on disk",
+				},
+			},
 			Action: func(cliContext *cli.Context) error {
 				config := defaultConfig()
 				ctx := cliContext.Context
@@ -107,6 +113,12 @@ var configCommand = &cli.Command{
 		{
 			Name:  "migrate",
 			Usage: "Migrate the current configuration file to the latest version (does not migrate subconfig files)",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:  "config",
+					Usage: "Path to configuration file on disk",
+				},
+			},
 			Action: func(cliContext *cli.Context) error {
 				config := defaultConfig()
 				ctx := cliContext.Context


### PR DESCRIPTION
Looks like this got broken at some point:

```bash
❯ ./bin/containerd config dump --config /tmp/containerd/config.toml
Incorrect Usage: flag provided but not defined: -config
```

After PR:

```bash
❯ ./bin/containerd config dump --config /tmp/containerd/config.toml
version = 3
root = '/var/lib/containerd'
state = '/var/run/containerd'
...
```