### PR TITLE
test: prevent segfault in imageverifier test

### DIFF
--- a/pkg/imageverifier/bindir/bindir_test.go
+++ b/pkg/imageverifier/bindir/bindir_test.go
@@ -175,7 +175,7 @@ func TestBinDirVerifyImage(t *testing.T) {
 		})
 
 		j, err := v.VerifyImage(ctx, "registry.example.com/image:abc", ocispec.Descriptor{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, j.OK, "expected OK, got not OK with reason: %v", j.Reason)
 		assert.Less(t, len(j.Reason), len(bins)*(outputLimitBytes+1024), "reason is: %v", j.Reason) // 1024 leaves margin for the formatting around the reason.
 	})


### PR DESCRIPTION
When VeriftImage returns an error, the first return value may be set to nil (this is the case for timeouts). When that is the case, it makes no point trying to access its fields later in the test. Let's use testify/require instead of testify/assert here to ensure the test halts upon failure. 