### PR TITLE
Update configuration version references to v3

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -393,8 +393,7 @@ The daemon's configuration file, commonly located in `/etc/containerd/config.tom
 is versioned and backwards compatible.  The `version` field in the config
 file specifies the config's version.  If no version number is specified inside
 the config file then it is assumed to be a version `1` config and parsed as such.
-The latest version is `version = 2`. The `main` branch is being prepared to support
-the next config version `3`. The configuration is automatically migrated to the
+The latest version is `version = 3`. The configuration is automatically migrated to the
 latest version on each startup, leaving the configuration file unchanged. To avoid
 the migration and optimize the daemon startup time, use `containerd config migrate`
 to output the configuration as the latest version. Version `1` is no longer deprecated

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -63,7 +63,7 @@ refer to a local socket file which the containerd process has access to. The
 currently supported types are `snapshot`, `content`, and `diff`.
 
 ```toml
-version = 2
+version = 3
 
 [proxy_plugins]
   [proxy_plugins.customsnapshot]
@@ -250,10 +250,10 @@ Every plugin can have its own section using the pattern `[plugins."<plugin type>
 
 example configuration
 ```toml
-version = 2
+version = 3
 
 [plugins]
-  [plugins."io.containerd.monitor.v1.cgroups"]
+  [plugins."io.containerd.monitor.task.v1.cgroups"]
     no_prometheus = false
 ```
 

--- a/docs/man/containerd-config.toml.5.md
+++ b/docs/man/containerd-config.toml.5.md
@@ -1,4 +1,4 @@
-# /etc/containerd/config.toml 5 04/05/2022
+# /etc/containerd/config.toml 5 10/18/2024
 
 ## NAME
 
@@ -26,8 +26,9 @@ settings.
 **version**
 : The version field in the config file specifies the config’s version. If no
 version number is specified inside the config file then it is assumed to be a
-version 1 config and parsed as such. Please use version = 2 to enable version 2
-config as version 1 has been deprecated.
+version 1 config and parsed as such. Please use version = 3 to enable the latest
+configuration format. Previous configuration versions will result in migration
+penalties on startup.
 
 **root**
 : The root directory for containerd metadata. (Default: "/var/lib/containerd")
@@ -87,7 +88,7 @@ The following plugins are enabled by default and their settings are shown below.
 Plugins that are not enabled by default will provide their own configuration values
 documentation.
 
-- **[plugins."io.containerd.monitor.v1.cgroups"]** has one option __no_prometheus__ (Default: **false**)
+- **[plugins."io.containerd.monitor.task.v1.cgroups"]** has one option __no_prometheus__ (Default: **false**)
 - **[plugins."io.containerd.service.v1.diff-service"]** has one option __default__, a list by default set to **["walking"]**
 - **[plugins."io.containerd.gc.v1.scheduler"]** has several options that perform advanced tuning for the scheduler:
   - **pause_threshold** is the maximum amount of time GC should be scheduled (Default: **0.02**),
@@ -167,48 +168,242 @@ the main config.
 The following is a complete **config.toml** default configuration example:
 
 ```toml
-version = 2
-
-root = "/var/lib/containerd"
-state = "/run/containerd"
+version = 3
+root = '/var/lib/containerd'
+state = '/run/containerd'
+temp = ''
+plugin_dir = ''
+disabled_plugins = []
+required_plugins = []
 oom_score = 0
-imports = ["/etc/containerd/runtime_*.toml", "./debug.toml"]
+imports = []
 
 [grpc]
-  address = "/run/containerd/containerd.sock"
+  address = '/run/containerd/containerd.sock'
+  tcp_address = ''
+  tcp_tls_ca = ''
+  tcp_tls_cert = ''
+  tcp_tls_key = ''
+  uid = 0
+  gid = 0
+  max_recv_message_size = 16777216
+  max_send_message_size = 16777216
+
+[ttrpc]
+  address = ''
   uid = 0
   gid = 0
 
 [debug]
-  address = "/run/containerd/debug.sock"
+  address = ''
   uid = 0
   gid = 0
-  level = "info"
+  level = ''
+  format = ''
 
 [metrics]
-  address = ""
+  address = ''
   grpc_histogram = false
 
-[cgroup]
-  path = ""
-
 [plugins]
-  [plugins."io.containerd.monitor.v1.cgroups"]
-    no_prometheus = false
-  [plugins."io.containerd.service.v1.diff-service"]
-    default = ["walking"]
-  [plugins."io.containerd.gc.v1.scheduler"]
+  [plugins.'io.containerd.cri.v1.images']
+    snapshotter = 'overlayfs'
+    disable_snapshot_annotations = true
+    discard_unpacked_layers = false
+    max_concurrent_downloads = 3
+    image_pull_progress_timeout = '5m0s'
+    image_pull_with_sync_fs = false
+    stats_collect_period = 10
+
+    [plugins.'io.containerd.cri.v1.images'.pinned_images]
+      sandbox = 'registry.k8s.io/pause:3.10'
+
+    [plugins.'io.containerd.cri.v1.images'.registry]
+      config_path = ''
+
+    [plugins.'io.containerd.cri.v1.images'.image_decryption]
+      key_model = 'node'
+
+  [plugins.'io.containerd.cri.v1.runtime']
+    enable_selinux = false
+    selinux_category_range = 1024
+    max_container_log_line_size = 16384
+    disable_apparmor = false
+    restrict_oom_score_adj = false
+    disable_proc_mount = false
+    unset_seccomp_profile = ''
+    tolerate_missing_hugetlb_controller = true
+    disable_hugetlb_controller = true
+    device_ownership_from_security_context = false
+    ignore_image_defined_volumes = false
+    netns_mounts_under_state_dir = false
+    enable_unprivileged_ports = true
+    enable_unprivileged_icmp = true
+    enable_cdi = true
+    cdi_spec_dirs = ['/etc/cdi', '/var/run/cdi']
+    drain_exec_sync_io_timeout = '0s'
+    ignore_deprecation_warnings = []
+
+    [plugins.'io.containerd.cri.v1.runtime'.containerd]
+      default_runtime_name = 'runc'
+      ignore_blockio_not_enabled_errors = false
+      ignore_rdt_not_enabled_errors = false
+
+      [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes]
+        [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc]
+          runtime_type = 'io.containerd.runc.v2'
+          runtime_path = ''
+          pod_annotations = []
+          container_annotations = []
+          privileged_without_host_devices = false
+          privileged_without_host_devices_all_devices_allowed = false
+          base_runtime_spec = ''
+          cni_conf_dir = ''
+          cni_max_conf_num = 0
+          snapshotter = ''
+          sandboxer = 'podsandbox'
+          io_type = ''
+
+          [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc.options]
+            BinaryName = ''
+            CriuImagePath = ''
+            CriuWorkPath = ''
+            IoGid = 0
+            IoUid = 0
+            NoNewKeyring = false
+            Root = ''
+            ShimCgroup = ''
+
+    [plugins.'io.containerd.cri.v1.runtime'.cni]
+      bin_dir = '/opt/cni/bin'
+      conf_dir = '/etc/cni/net.d'
+      max_conf_num = 1
+      setup_serially = false
+      conf_template = ''
+      ip_pref = ''
+      use_internal_loopback = false
+
+  [plugins.'io.containerd.gc.v1.scheduler']
     pause_threshold = 0.02
     deletion_threshold = 0
     mutation_threshold = 100
-    schedule_delay = 0
-    startup_delay = "100ms"
-  [plugins."io.containerd.runtime.v2.task"]
-    platforms = ["linux/amd64"]
-    sched_core = true
-  [plugins."io.containerd.service.v1.tasks-service"]
-    blockio_config_file = ""
-    rdt_config_file = ""
+    schedule_delay = '0s'
+    startup_delay = '100ms'
+
+  [plugins.'io.containerd.grpc.v1.cri']
+    disable_tcp_service = true
+    stream_server_address = '127.0.0.1'
+    stream_server_port = '0'
+    stream_idle_timeout = '4h0m0s'
+    enable_tls_streaming = false
+
+    [plugins.'io.containerd.grpc.v1.cri'.x509_key_pair_streaming]
+      tls_cert_file = ''
+      tls_key_file = ''
+
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+    max_verifiers = 10
+    per_verifier_timeout = '10s'
+
+  [plugins.'io.containerd.internal.v1.opt']
+    path = '/opt/containerd'
+
+  [plugins.'io.containerd.internal.v1.tracing']
+
+  [plugins.'io.containerd.metadata.v1.bolt']
+    content_sharing_policy = 'shared'
+
+  [plugins.'io.containerd.monitor.container.v1.restart']
+    interval = '10s'
+
+  [plugins.'io.containerd.monitor.task.v1.cgroups']
+    no_prometheus = false
+
+  [plugins.'io.containerd.nri.v1.nri']
+    disable = false
+    socket_path = '/var/run/nri/nri.sock'
+    plugin_path = '/opt/nri/plugins'
+    plugin_config_path = '/etc/nri/conf.d'
+    plugin_registration_timeout = '5s'
+    plugin_request_timeout = '2s'
+    disable_connections = false
+
+  [plugins.'io.containerd.runtime.v2.task']
+    platforms = ['linux/arm64/v8']
+
+  [plugins.'io.containerd.service.v1.diff-service']
+    default = ['walking']
+    sync_fs = false
+
+  [plugins.'io.containerd.service.v1.tasks-service']
+    blockio_config_file = ''
+    rdt_config_file = ''
+
+  [plugins.'io.containerd.shim.v1.manager']
+    env = []
+
+  [plugins.'io.containerd.snapshotter.v1.blockfile']
+    root_path = ''
+    scratch_file = ''
+    fs_type = ''
+    mount_options = []
+    recreate_scratch = false
+
+  [plugins.'io.containerd.snapshotter.v1.btrfs']
+    root_path = ''
+
+  [plugins.'io.containerd.snapshotter.v1.devmapper']
+    root_path = ''
+    pool_name = ''
+    base_image_size = ''
+    async_remove = false
+    discard_blocks = false
+    fs_type = ''
+    fs_options = ''
+
+  [plugins.'io.containerd.snapshotter.v1.native']
+    root_path = ''
+
+  [plugins.'io.containerd.snapshotter.v1.overlayfs']
+    root_path = ''
+    upperdir_label = false
+    sync_remove = false
+    slow_chown = false
+    mount_options = []
+
+  [plugins.'io.containerd.tracing.processor.v1.otlp']
+
+  [plugins.'io.containerd.transfer.v1.local']
+    max_concurrent_downloads = 3
+    max_concurrent_uploaded_layers = 3
+    config_path = ''
+
+[cgroup]
+  path = ''
+
+[timeouts]
+  'io.containerd.timeout.bolt.open' = '0s'
+  'io.containerd.timeout.metrics.shimstats' = '2s'
+  'io.containerd.timeout.shim.cleanup' = '5s'
+  'io.containerd.timeout.shim.load' = '5s'
+  'io.containerd.timeout.shim.shutdown' = '3s'
+  'io.containerd.timeout.task.state' = '2s'
+
+[stream_processors]
+  [stream_processors.'io.containerd.ocicrypt.decoder.v1.tar']
+    accepts = ['application/vnd.oci.image.layer.v1.tar+encrypted']
+    returns = 'application/vnd.oci.image.layer.v1.tar'
+    path = 'ctd-decoder'
+    args = ['--decryption-keys-path', '/etc/containerd/ocicrypt/keys']
+    env = ['OCICRYPT_KEYPROVIDER_CONFIG=/etc/containerd/ocicrypt/ocicrypt_keyprovider.conf']
+
+  [stream_processors.'io.containerd.ocicrypt.decoder.v1.tar.gzip']
+    accepts = ['application/vnd.oci.image.layer.v1.tar+gzip+encrypted']
+    returns = 'application/vnd.oci.image.layer.v1.tar+gzip'
+    path = 'ctd-decoder'
+    args = ['--decryption-keys-path', '/etc/containerd/ocicrypt/keys']
+    env = ['OCICRYPT_KEYPROVIDER_CONFIG=/etc/containerd/ocicrypt/ocicrypt_keyprovider.conf']
 ```
 
 ### Multiple Runtimes

--- a/docs/managed-opt.md
+++ b/docs/managed-opt.md
@@ -11,7 +11,7 @@ Configuration:
 
 *containerd config:*
 ```toml
-version = 2
+version = 3
 
 [plugins."io.containerd.internal.v1.opt"]
 	path = "/opt/mypath"

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -171,7 +171,7 @@ They should not be tampered with as corruption and bugs can and will happen.
 External apps reading or watching changes in these directories have been known to cause `EBUSY` and stale file handles when containerd and/or its plugins try to cleanup resources.
 
 ```toml
-version = 2
+version = 3
 
 # persistent data location
 root = "/var/lib/containerd"
@@ -231,7 +231,7 @@ Both modes share backing data, while "shared" will reduce total bandwidth across
 The default is "shared". While this is largely the most desired policy, one can change to "isolated" mode with the following configuration:
 
 ```toml
-version = 2
+version = 3
 
 [plugins."io.containerd.metadata.v1.bolt"]
 	content_sharing_policy = "isolated"

--- a/docs/rootless.md
+++ b/docs/rootless.md
@@ -43,7 +43,7 @@ $ rootlesskit --net=slirp4netns --copy-up=/etc --copy-up=/run \
 * `--state-dir` is set to a random directory under `/tmp` if unset. RootlessKit writes the PID to a file named `child_pid` under this directory.
 * You need to provide `config.toml` with your own path configuration. e.g.
 ```toml
-version = 2
+version = 3
 root = "/home/penguin/.local/share/containerd"
 state = "/run/user/1001/containerd"
 

--- a/docs/snapshotters/blockfile.md
+++ b/docs/snapshotters/blockfile.md
@@ -108,8 +108,7 @@ To use it via the go client API, it is identical to using any other snapshotter:
 ```go
 import (
     "context"
-    "github.com/containerd/containerd"
-    "github.com/containerd/containerd/snapshots"
+    containerd "github.com/containerd/containerd/v2/client"
 )
 
 // create a new client

--- a/docs/snapshotters/devmapper.md
+++ b/docs/snapshotters/devmapper.md
@@ -12,7 +12,7 @@ This file is typically located at `/etc/containerd/config.toml`.
 Here's a minimal sample entry that can be made in the configuration file:
 
 ```toml
-version = 2
+version = 3
 
 [plugins]
   ...

--- a/docs/stream_processors.md
+++ b/docs/stream_processors.md
@@ -33,7 +33,7 @@ Processor Fields:
 * `args` - Arguments passed to the processor binary.
 
 ```toml
-version = 2
+version = 3
 
 [stream_processors]
   [stream_processors."io.containerd.processor.v1.pigz"]


### PR DESCRIPTION
This change updates the configuration version in samples to `version = 3` for containerd 2.0.