### PR TITLE
[release/1.7 backport] Add After=dbus.service to containerd.service

### DIFF
--- a/containerd.service
+++ b/containerd.service
@@ -15,7 +15,7 @@
 [Unit]
 Description=containerd container runtime
 Documentation=https://containerd.io
-After=network.target local-fs.target
+After=network.target local-fs.target dbus.service
 
 [Service]
 #uncomment to enable the experimental sbservice (sandboxed) version of containerd/cri integration


### PR DESCRIPTION
Backports https://github.com/containerd/containerd/pull/10798

containerd launches runc, which communicates via dbus with systemd to start transient units. Thus, containerd should have an `After` dependency on `dbus.service` to prevent dbus from being shut down concurrently with containerd.

(cherry picked from commit 18e4ea9a6c5378a175e5090ca4052d0b2ff742df)