### PR TITLE
Lock store writer per digest and writer.

### DIFF
--- a/plugins/content/local/locks_test.go
+++ b/plugins/content/local/locks_test.go
@@ -24,11 +24,13 @@ import (
 )
 
 func TestTryLock(t *testing.T) {
-	err := tryLock("testref")
-	assert.NoError(t, err)
-	defer unlock("testref")
+	s := &store{locks: map[string]*lock{}}
 
-	err = tryLock("testref")
+	err := s.tryLock("testref")
+	assert.NoError(t, err)
+	defer s.unlock("testref")
+
+	err = s.tryLock("testref")
 	require.NotNil(t, err)
 	assert.Contains(t, err.Error(), "ref testref locked for ")
 }

--- a/plugins/content/local/writer.go
+++ b/plugins/content/local/writer.go
@@ -78,7 +78,7 @@ func (w *writer) Write(p []byte) (n int, err error) {
 
 func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest, opts ...content.Opt) error {
 	// Ensure even on error the writer is fully closed
-	defer unlock(w.ref)
+	defer w.s.unlock(w.ref)
 
 	var base content.Info
 	for _, opt := range opts {
@@ -198,7 +198,7 @@ func (w *writer) Close() (err error) {
 		err = w.fp.Close()
 		writeTimestampFile(filepath.Join(w.path, "updatedat"), w.updatedAt)
 		w.fp = nil
-		unlock(w.ref)
+		w.s.unlock(w.ref)
 		return
 	}
 


### PR DESCRIPTION
This allows multiple writers to not lock if they operate in different roots.

See also https://github.com/moby/buildkit/issues/3270#issuecomment-1323606958