### PR TITLE
Re-expose image config in cri status api

### DIFF
--- a/plugins/cri/images/plugin.go
+++ b/plugins/cri/images/plugin.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strconv"
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/metadata"
@@ -142,6 +143,11 @@ func init() {
 					Snapshotter: snapshotter,
 					Platform:    platform,
 				}
+			}
+
+			ic.Meta.Exports = map[string]string{
+				"registry.configPath":   config.Registry.ConfigPath,
+				"discardUnpackedLayers": strconv.FormatBool(config.DiscardUnpackedLayers),
 			}
 
 			service, err := images.NewService(*config, options)

--- a/plugins/cri/images/plugin.go
+++ b/plugins/cri/images/plugin.go
@@ -58,7 +58,8 @@ func init() {
 			}
 			mdb := m.(*metadata.DB)
 
-			if warnings, err := criconfig.ValidateImageConfig(ic.Context, &config); err != nil {
+			config := ic.Config.(*criconfig.ImageConfig)
+			if warnings, err := criconfig.ValidateImageConfig(ic.Context, config); err != nil {
 				return nil, fmt.Errorf("invalid cri image config: %w", err)
 			} else if len(warnings) > 0 {
 				ws, err := ic.GetSingle(plugins.WarningPlugin)
@@ -143,7 +144,7 @@ func init() {
 				}
 			}
 
-			service, err := images.NewService(config, options)
+			service, err := images.NewService(*config, options)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create image service: %w", err)
 			}


### PR DESCRIPTION
Fix #10780

Commit 1 fixes a bug in cri image service plugin where the `InitFn` is not using `config` from `ic.Config.(*criconfig.ImageConfig)`.

Commit 2 adds 2 plugin exports to CRI image service. Previously they were included as part of CRI config and retrievable via CRI status request. But it was removed when we decouple cri image service and runtime. This PR only re-exposes 2 fields used by spegel as a starting point.

The exports can be retrieved by getting the cri image service plugin via the introspection svc. 

<img width="1003" alt="image" src="https://github.com/user-attachments/assets/234a2ff0-aef8-4571-8b80-b1e099182f09">


