### PR TITLE
Prepare release notes for v2.0.0-rc.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/containerd/btrfs/v2 v2.0.0
 	github.com/containerd/cgroups/v3 v3.0.3
 	github.com/containerd/console v1.0.4
-	github.com/containerd/containerd/api v1.8.0-rc.3
+	github.com/containerd/containerd/api v1.8.0-rc.4
 	github.com/containerd/continuity v0.4.3
 	github.com/containerd/errdefs v0.3.0
 	github.com/containerd/errdefs/pkg v0.3.0
@@ -150,5 +150,3 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect
 )
-
-replace github.com/containerd/containerd/api => ./api

--- a/go.sum
+++ b/go.sum
@@ -671,6 +671,8 @@ github.com/containerd/console v1.0.4 h1:F2g4+oChYvBTsASRTz8NP6iIAi97J3TtSAsLbIFn
 github.com/containerd/console v1.0.4/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
 github.com/containerd/containerd v1.7.23 h1:H2CClyUkmpKAGlhQp95g2WXHfLYc7whAuvZGBNYOOwQ=
 github.com/containerd/containerd v1.7.23/go.mod h1:7QUzfURqZWCZV7RLNEn1XjUCQLEf0bkaK4GjUaZehxw=
+github.com/containerd/containerd/api v1.8.0-rc.4 h1:Z650GHP0OxsoTwwii5U2hyTt7eCRQvvDnRM7pEH/DE0=
+github.com/containerd/containerd/api v1.8.0-rc.4/go.mod h1:dFv4lt6S20wTu/hMcP4350RL87qPWLVa/OHOwmmdnYc=
 github.com/containerd/continuity v0.4.3 h1:6HVkalIp+2u1ZLH1J/pYX2oBVXlJZvh1X1A7bEZ9Su8=
 github.com/containerd/continuity v0.4.3/go.mod h1:F6PTNCKepoxEaXLQp3wDAjygEnImnZ/7o4JzpodfroQ=
 github.com/containerd/errdefs v0.3.0 h1:FSZgGOeK4yuT/+DnF07/Olde/q4KBoMsaamhXxIMDp4=

--- a/vendor/github.com/containerd/containerd/api/LICENSE
+++ b/vendor/github.com/containerd/containerd/api/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright The containerd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -108,7 +108,7 @@ github.com/containerd/console
 # github.com/containerd/containerd v1.7.23
 ## explicit; go 1.21
 github.com/containerd/containerd/errdefs
-# github.com/containerd/containerd/api v1.8.0-rc.3 => ./api
+# github.com/containerd/containerd/api v1.8.0-rc.4
 ## explicit; go 1.21
 github.com/containerd/containerd/api/events
 github.com/containerd/containerd/api/runtime/sandbox/v1
@@ -874,4 +874,3 @@ tags.cncf.io/container-device-interface/pkg/parser
 # tags.cncf.io/container-device-interface/specs-go v0.8.0
 ## explicit; go 1.19
 tags.cncf.io/container-device-interface/specs-go
-# github.com/containerd/containerd/api => ./api

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd/v2"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "2.0.0-rc.5+unknown"
+	Version = "2.0.0-rc.6+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated notes

----

Welcome to the v2.0.0-rc.6 release of containerd!  
*This is a pre-release of containerd*

The first major release of containerd 2.x focuses on the continued stability of
containerd's core feature set with an easy upgrade from containerd 1.x. This
release includes the stabilization of new features added in the last 1.x release
as well as the removal of features which were deprecated in 1.x. The goal is to
support the vast community of containerd users well into the future along with
their ever increasing deployment footprints and variety of use cases.

### Highlights

* Add Update API for sandbox controller ([#9903](https://github.com/containerd/containerd/pull/9903))
* Configure otel from env instead of config.toml ([#8970](https://github.com/containerd/containerd/pull/8970))
* Enable NRI by default ([#9744](https://github.com/containerd/containerd/pull/9744))
* Add PluginInfo to introspection API ([#9442](https://github.com/containerd/containerd/pull/9442))
* Remove overlayfs volatile option on temp mounts ([#9555](https://github.com/containerd/containerd/pull/9555))
* Expose usage of deprecated features ([#9258](https://github.com/containerd/containerd/pull/9258))
* Use Intel ISA-L's igzip if available ([#9200](https://github.com/containerd/containerd/pull/9200))
* Introduce top level config migration ([#9223](https://github.com/containerd/containerd/pull/9223))
* Add image delete target ([#8989](https://github.com/containerd/containerd/pull/8989))
* Remove `LimitNOFILE` from `containerd.service` ([#8924](https://github.com/containerd/containerd/pull/8924))
* Add support for image expiration during garbage collection ([#9022](https://github.com/containerd/containerd/pull/9022))
* Reduce the contention between ref lock and boltdb lock in content store ([#8792](https://github.com/containerd/containerd/pull/8792))
* Remove "containerd.io/restart.logpath" label ([#8264](https://github.com/containerd/containerd/pull/8264))
* Remove `aufs` snapshotter ([#8263](https://github.com/containerd/containerd/pull/8263))
* Fix deadlock during NRI plugin registration ([containerd/nri#79](https://github.com/containerd/nri/pull/79))
* Fix deadlock when writing to pipe blocks ([containerd/ttrpc#168](https://github.com/containerd/ttrpc/pull/168))

#### Build and Release Toolchain

* Generate attestation for artifacts during release ([#10543](https://github.com/containerd/containerd/pull/10543))
* Remove `cri-containerd-*.tar.gz` release bundles ([#9096](https://github.com/containerd/containerd/pull/9096))

#### Container Runtime Interface (CRI)

* Use 'UserSpecifiedImage' from CRI to set the image-name annotation ([#10747](https://github.com/containerd/containerd/pull/10747))
* KEP-3619: Fine-grained SupplementalGroups control ([#9737](https://github.com/containerd/containerd/pull/9737))
* Add support to set loopback to up ([#10238](https://github.com/containerd/containerd/pull/10238))
* Add support for multiple subscribers to CRI container events ([#9661](https://github.com/containerd/containerd/pull/9661))
* Enable CDI by default ([#9621](https://github.com/containerd/containerd/pull/9621))
* Remove non-sandboxed CRI implementation ([#9228](https://github.com/containerd/containerd/pull/9228))
* Add support for userns in stateless and stateful pods with idmap mounts (KEP-127, k8s >= 1.27) ([#8287](https://github.com/containerd/containerd/pull/8287))
* Use sandboxed CRI by default ([#8994](https://github.com/containerd/containerd/pull/8994))
* Implement RuntimeConfig CRI call ([#8722](https://github.com/containerd/containerd/pull/8722))
* Add support for user namespaces (KEP-127) ([#8803](https://github.com/containerd/containerd/pull/8803))
* Remove CRI v1alpha2 ([#8276](https://github.com/containerd/containerd/pull/8276))

#### Go client

* Add api Go module and move all protos under api ([#10151](https://github.com/containerd/containerd/pull/10151))
* Move packages based on contributing guide ([#9365](https://github.com/containerd/containerd/pull/9365))
* Generalize plugin library ([#9214](https://github.com/containerd/containerd/pull/9214))
* Use github.com/containerd/log ([#9086](https://github.com/containerd/containerd/pull/9086))

#### Image Distribution

* Support to syncfs after pull by using diff plugin ([#10284](https://github.com/containerd/containerd/pull/10284))
* Skip "unknown" in image platform listing ([#10257](https://github.com/containerd/containerd/pull/10257))
* Update unpacker to fetch all provided content ([#10202](https://github.com/containerd/containerd/pull/10202))
* Enable Transfer service API to support plain HTTP ([#10024](https://github.com/containerd/containerd/pull/10024))
* Enable Transfer service to use registry configuration directory ([#9908](https://github.com/containerd/containerd/pull/9908))
* Disable the support for Schema 1 images ([#9765](https://github.com/containerd/containerd/pull/9765))
* Update Transfer service to add OCI descriptors to Progress structure ([#9630](https://github.com/containerd/containerd/pull/9630))
* Update import and export to allow references to missing content  ([#9554](https://github.com/containerd/containerd/pull/9554))
* Add option to perform syncfs after pull ([#9401](https://github.com/containerd/containerd/pull/9401))
* Add image verifier transfer service plugin system based on a binary directory ([#8493](https://github.com/containerd/containerd/pull/8493))

#### Runtime

* Implement  RuntimeStatus.features.supplemental_groups_policy from KEP-3619 ([#10410](https://github.com/containerd/containerd/pull/10410))
* Add pprof to runc-shim ([#10242](https://github.com/containerd/containerd/pull/10242))
* Provide runtime options in plugin info ([#10251](https://github.com/containerd/containerd/pull/10251))
* Store bootstrap parameters in sandbox metadata ([#9736](https://github.com/containerd/containerd/pull/9736))
* Update apparmor to allow confined runc to kill containers ([#10123](https://github.com/containerd/containerd/pull/10123))
* Support vsock connection to task api ([#9738](https://github.com/containerd/containerd/pull/9738))
* Update RuntimeDefault seccomp profile to disallow io_uring related syscalls ([#9320](https://github.com/containerd/containerd/pull/9320))
* Switch runc shim to task service v3 and fix restore ([#9233](https://github.com/containerd/containerd/pull/9233))
* Add sandboxer configuration and move sandbox controllers to plugins ([#8268](https://github.com/containerd/containerd/pull/8268))
* Add annotations to CreateSandbox request ([#8960](https://github.com/containerd/containerd/pull/8960))
* Add SandboxMetrics ([#8680](https://github.com/containerd/containerd/pull/8680))
* Publish sandbox events ([#8602](https://github.com/containerd/containerd/pull/8602))
* Remove the CriuPath field from runc's options ([#8279](https://github.com/containerd/containerd/pull/8279))
* Remove `io.containerd.runtime.v1.linux` and `io.containerd.runc.v1` ([#8262](https://github.com/containerd/containerd/pull/8262))

#### Security Advisories

* [medium] RAPL accessible to a container [GHSA-7ww5-4wqc-m92c](https://github.com/containerd/containerd/security/advisories/GHSA-7ww5-4wqc-m92c)

#### Breaking

* Remove `disable_cgroup` from CRI config ([#10594](https://github.com/containerd/containerd/pull/10594))
* Disable the support for Schema 1 images ([#9765](https://github.com/containerd/containerd/pull/9765))
* Update RuntimeDefault seccomp profile to disallow io_uring related syscalls ([#9320](https://github.com/containerd/containerd/pull/9320))
* Move client to subpackage ([#9316](https://github.com/containerd/containerd/pull/9316))
* Remove `LimitNOFILE` from `containerd.service` ([#8924](https://github.com/containerd/containerd/pull/8924))
* Remove CRI v1alpha2 ([#8276](https://github.com/containerd/containerd/pull/8276))
* Remove `io.containerd.runtime.v1.linux` and `io.containerd.runc.v1` ([#8262](https://github.com/containerd/containerd/pull/8262))
* Remove "containerd.io/restart.logpath" label ([#8264](https://github.com/containerd/containerd/pull/8264))
* Remove `aufs` snapshotter ([#8263](https://github.com/containerd/containerd/pull/8263))

#### Deprecations

* Update warnings for deprecated CRI config fields ([#10509](https://github.com/containerd/containerd/pull/10509))
* Add type alias for event Envelope ([#10279](https://github.com/containerd/containerd/pull/10279))
* Postpone removal of deprecated CRI config properties ([#9966](https://github.com/containerd/containerd/pull/9966))
* Deprecate go-plugin configuration option ([#9238](https://github.com/containerd/containerd/pull/9238))
* CNI conf_template in CRI is no longer deprecated ([#8637](https://github.com/containerd/containerd/pull/8637))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

<details>
<summary>...</summary>
### Contributors

* Derek McGowan
* Akihiro Suda
* Maksym Pavlenko
* Wei Fu
* Phil Estes
* Sebastiaan van Stijn
* Samuel Karp
* Stefan Berger
* Krisztian Litkey
* Kazuyoshi Kato
* Rodrigo Campos
* Danny Canter
* Abel Feng
* Mike Brown
* Austin Vazquez
* Akhil Mohan
* Iceber Gu
* Kirtana Ashok
* Gabriel Adrian Samfira
* Kohei Tokunaga
* Jin Dong
* Bjorn Neergaard
* Brian Goff
* Justin Chadwell
* rongfu.leng
* James Sturtevant
* Davanum Srinivas
* Paul "TBBle" Hampson
* Henry Wang
* Enrico Weigelt
* Laura Brehm
* Marat Radchenko
* Paweł Gronowski
* Shingo Omura
* Hsing-Yu (David) Chen
* Ilya Hanov
* Cardy.Tang
* Swagat Bora
* Aditi Sharma
* Amit Barve
* Bryant Biggs
* Evan Lezar
* James Jenkins
* Jordan Liggitt
* Kay Yan
* Markus Lehtonen
* Nashwan Azhari
* Shuaiyi Zhang
* Vinayak Goyal
* helen
* Alexandru Matei
* Anthony Nandaa
* Avi Deitcher
* Charity Kathure
* Cory Snider
* Ed Bartosh
* Etienne Champetier
* Kevin Parsons
* Michael Zappa
* Milas Bowman
* lengrongfu
* ningmingxiao
* yanggang
* zounengren
* Aditya Ramani
* Adrian Reber
* Amir M. Ghazanfari
* Artem Khramov
* Brad Davidson
* Chen Yiyang
* Christian Muehlhaeuser
* Djordje Lukic
* Edgar Lee
* Eric Lin
* Ethan Lowman
* Jiang Liu
* June Rhodes
* Kern Walster
* Lei Jitang
* Lucas Rattz
* Mahamed Ali
* Maksim An
* Michael Crosby
* Peteris Rudzusiks
* Sam Edwards
* Samruddhi Khandale
* Sascha Grunert
* Steve Griffith
* Tony Fang
* VERNOU Cédric
* Vishal Reddy Gurrala
* Xiaojin Zhang
* hang.jiang
* harshitasao
* jerryzhuang
* roman-kiselenko
* zhanluxianshen
* Aaron Lehmann
* AbdelrahmanElawady
* Adrien Delorme
* Alex Couture-Beil
* Alex Ellis
* Alex Rodriguez
* Angelos Kolaitis
* Antonio Huete Jimenez
* Antonio Ojea
* Antti Kervinen
* Arash Haghighat
* Ben Foster
* Benjamin Peterson
* Bin Tang
* Bin Xin
* BinBin He
* Brennan Kinney
* Changqing Li
* ChengenH
* ChengyuZhu6
* Christian Stewart
* Colin O'Dell
* Craig Ingram
* Daisy Rong
* David Porter
* Derek Nola
* Eng Zer Jun
* Erikson Tung
* Fabiano Fidêncio
* Fahed Dorgaa
* Gabriela Cervantes
* Gary McDonald
* Iain Macdonald
* James Lakin
* Jan Dubois
* Jaroslav Jindrak
* Javier Maestro
* Jian Wang
* Jiongchi Yu
* Julien Balestra
* Kir Kolyshkin
* Kirill A. Korinsky
* Konstantin Khlebnikov
* Lei Liu
* Matteo Pulcini
* Mauri de Souza Meneguzzo
* Mike Baynton
* Pan Yibo
* Paul Meyer
* Qasim Sarfraz
* Qiutong Song
* Reinhard Tartler
* Robbie Buxton
* Robert-André Mauchin
* Ruihua Wen
* Saket Jajoo
* Sameer
* Shengjing Zhu
* Shiming Zhang
* Shukui Yang
* StepSecurity Bot
* Talon
* Tariq Ibrahim
* Tianon Gravi
* Tim Hockin
* TinaMor
* Tobias Klauser
* Tomáš Virtus
* Tõnis Tiigi
* Wang Xinwen
* William Chen
* Xinyang Ge
* Yang Yang
* Yibo Zhuang
* Yuhang Wei
* Yury Gargay
* Zechun Chen
* Zhang Tianyang
* Zoe
* baijia
* bo.jiang
* bzsuni
* charles-chenzz
* chschumacher1994
* guangli.bao
* guangwu
* jinda.ljd
* jingtao.liang
* krglosse
* pigletfly
* rokkiter
* wangxiang
* zhangpeng
* zhaojizhuang
* 吴小白
* 张钰
* 沈陵
* 谭九鼎

### Dependency Changes

* **dario.cat/mergo**                                                              v1.0.1 **_new_**
* **github.com/AdaLogics/go-fuzz-headers**                                         1f10f66a31bf -> ced1acdcaa24
* **github.com/AdamKorcz/go-118-fuzz-build**                                       5330a85ea652 -> 8075edf89bb0
* **github.com/Microsoft/go-winio**                                                v0.6.0 -> v0.6.2
* **github.com/Microsoft/hcsshim**                                                 v0.10.0-rc.7 -> v0.12.7
* **github.com/cenkalti/backoff/v4**                                               v4.2.0 -> v4.3.0
* **github.com/cespare/xxhash/v2**                                                 v2.2.0 -> v2.3.0
* **github.com/checkpoint-restore/checkpointctl**                                  v1.2.1 **_new_**
* **github.com/checkpoint-restore/go-criu/v7**                                     v7.2.0 **_new_**
* **github.com/cilium/ebpf**                                                       v0.9.1 -> v0.11.0
* **github.com/containerd/cgroups/v3**                                             v3.0.1 -> v3.0.3
* **github.com/containerd/console**                                                v1.0.3 -> v1.0.4
* **github.com/containerd/containerd/api**                                         v1.8.0-rc.4 **_new_**
* **github.com/containerd/continuity**                                             v0.3.0 -> v0.4.3
* **github.com/containerd/errdefs**                                                v0.1.0 **_new_**
* **github.com/containerd/go-cni**                                                 v1.1.9 -> v1.1.10
* **github.com/containerd/go-runc**                                                v1.0.0 -> v1.1.0
* **github.com/containerd/imgcrypt**                                               v1.1.7 -> v1.2.0-rc1
* **github.com/containerd/log**                                                    v0.1.0 **_new_**
* **github.com/containerd/nri**                                                    v0.3.0 -> 159f5754db39
* **github.com/containerd/otelttrpc**                                              ea5083fda723 **_new_**
* **github.com/containerd/platforms**                                              v0.2.1 **_new_**
* **github.com/containerd/plugin**                                                 v0.1.0 **_new_**
* **github.com/containerd/ttrpc**                                                  v1.2.1 -> b5cd6e4b3287
* **github.com/containerd/typeurl/v2**                                             v2.1.0 -> v2.2.0
* **github.com/containernetworking/cni**                                           v1.1.2 -> v1.2.3
* **github.com/containernetworking/plugins**                                       v1.2.0 -> v1.5.1
* **github.com/containers/ocicrypt**                                               v1.1.6 -> v1.2.0
* **github.com/cpuguy83/go-md2man/v2**                                             v2.0.2 -> v2.0.5
* **github.com/davecgh/go-spew**                                                   v1.1.1 -> d8f796af33cc
* **github.com/distribution/reference**                                            v0.6.0 **_new_**
* **github.com/emicklei/go-restful/v3**                                            v3.10.1 -> v3.11.0
* **github.com/felixge/httpsnoop**                                                 v1.0.4 **_new_**
* **github.com/fsnotify/fsnotify**                                                 v1.6.0 -> v1.7.0
* **github.com/fxamacker/cbor/v2**                                                 v2.7.0 **_new_**
* **github.com/go-jose/go-jose/v4**                                                v4.0.2 **_new_**
* **github.com/go-logr/logr**                                                      v1.2.3 -> v1.4.2
* **github.com/golang/protobuf**                                                   v1.5.2 -> v1.5.4
* **github.com/google/go-cmp**                                                     v0.5.9 -> v0.6.0
* **github.com/google/uuid**                                                       v1.3.0 -> v1.6.0
* **github.com/gorilla/websocket**                                                 v1.5.0 **_new_**
* **github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus**            v1.0.1 **_new_**
* **github.com/grpc-ecosystem/go-grpc-middleware/v2**                              v2.1.0 **_new_**
* **github.com/grpc-ecosystem/grpc-gateway/v2**                                    v2.7.0 -> v2.22.0
* **github.com/intel/goresctrl**                                                   v0.3.0 -> v0.8.0
* **github.com/klauspost/compress**                                                v1.16.0 -> v1.17.11
* **github.com/mdlayher/socket**                                                   v0.4.1 **_new_**
* **github.com/mdlayher/vsock**                                                    v1.2.1 **_new_**
* **github.com/moby/spdystream**                                                   v0.2.0 -> v0.4.0
* **github.com/moby/sys/mountinfo**                                                v0.6.2 -> v0.7.2
* **github.com/moby/sys/sequential**                                               v0.5.0 -> v0.6.0
* **github.com/moby/sys/signal**                                                   v0.7.0 -> v0.7.1
* **github.com/moby/sys/symlink**                                                  v0.2.0 -> v0.3.0
* **github.com/moby/sys/user**                                                     v0.3.0 **_new_**
* **github.com/moby/sys/userns**                                                   v0.1.0 **_new_**
* **github.com/munnerz/goautoneg**                                                 a7dc8b61c822 **_new_**
* **github.com/mxk/go-flowrate**                                                   cca7078d478f **_new_**
* **github.com/opencontainers/image-spec**                                         3a7f492d3f1b -> v1.1.0
* **github.com/opencontainers/runtime-spec**                                       v1.1.0-rc.1 -> v1.2.0
* **github.com/opencontainers/runtime-tools**                                      946c877fa809 -> 2e043c6bd626
* **github.com/pelletier/go-toml/v2**                                              v2.2.3 **_new_**
* **github.com/pmezard/go-difflib**                                                v1.0.0 -> 5d4384ee4fb2
* **github.com/prometheus/client_golang**                                          v1.14.0 -> v1.20.4
* **github.com/prometheus/client_model**                                           v0.3.0 -> v0.6.1
* **github.com/prometheus/common**                                                 v0.37.0 -> v0.55.0
* **github.com/prometheus/procfs**                                                 v0.8.0 -> v0.15.1
* **github.com/sirupsen/logrus**                                                   v1.9.0 -> v1.9.3
* **github.com/stretchr/testify**                                                  v1.8.2 -> v1.9.0
* **github.com/urfave/cli/v2**                                                     v2.27.5 **_new_**
* **github.com/vishvananda/netlink**                                               v1.2.1-beta.2 -> v1.3.0
* **github.com/vishvananda/netns**                                                 2eb08e3e575f -> v0.0.4
* **github.com/x448/float16**                                                      v0.8.4 **_new_**
* **github.com/xrash/smetrics**                                                    686a1a2994c1 **_new_**
* **go.etcd.io/bbolt**                                                             v1.3.7 -> v1.3.11
* **go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc**  v0.40.0 -> v0.56.0
* **go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp**                v0.56.0 **_new_**
* **go.opentelemetry.io/otel**                                                     v1.14.0 -> v1.31.0
* **go.opentelemetry.io/otel/exporters/otlp/otlptrace**                            v1.14.0 -> v1.31.0
* **go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc**              v1.14.0 -> v1.31.0
* **go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp**              v1.14.0 -> v1.31.0
* **go.opentelemetry.io/otel/metric**                                              v0.37.0 -> v1.31.0
* **go.opentelemetry.io/otel/sdk**                                                 v1.14.0 -> v1.31.0
* **go.opentelemetry.io/otel/trace**                                               v1.14.0 -> v1.31.0
* **go.opentelemetry.io/proto/otlp**                                               v0.19.0 -> v1.3.1
* **golang.org/x/crypto**                                                          v0.1.0 -> v0.28.0
* **golang.org/x/exp**                                                             aacd6d4b4611 **_new_**
* **golang.org/x/mod**                                                             v0.7.0 -> v0.21.0
* **golang.org/x/net**                                                             v0.7.0 -> v0.30.0
* **golang.org/x/oauth2**                                                          v0.4.0 -> v0.22.0
* **golang.org/x/sync**                                                            v0.1.0 -> v0.8.0
* **golang.org/x/sys**                                                             v0.6.0 -> v0.26.0
* **golang.org/x/term**                                                            v0.5.0 -> v0.25.0
* **golang.org/x/text**                                                            v0.7.0 -> v0.19.0
* **golang.org/x/time**                                                            90d013bbcef8 -> v0.3.0
* **google.golang.org/genproto/googleapis/api**                                    5fefd90f89a9 **_new_**
* **google.golang.org/genproto/googleapis/rpc**                                    5fefd90f89a9 **_new_**
* **google.golang.org/grpc**                                                       v1.53.0 -> v1.67.1
* **google.golang.org/protobuf**                                                   v1.28.1 -> v1.35.1
* **k8s.io/api**                                                                   v0.26.2 -> v0.31.1
* **k8s.io/apimachinery**                                                          v0.26.2 -> v0.31.1
* **k8s.io/apiserver**                                                             v0.26.2 -> v0.31.1
* **k8s.io/client-go**                                                             v0.26.2 -> v0.31.1
* **k8s.io/component-base**                                                        v0.26.2 -> v0.31.1
* **k8s.io/cri-api**                                                               v0.26.2 -> v0.32.0-alpha.0
* **k8s.io/klog/v2**                                                               v2.90.1 -> v2.130.1
* **k8s.io/kubelet**                                                               v0.31.1 **_new_**
* **k8s.io/utils**                                                                 a5ecb0141aa5 -> 18e509b52bc8
* **sigs.k8s.io/json**                                                             f223a00ba0e2 -> bc3834ca7abd
* **sigs.k8s.io/structured-merge-diff/v4**                                         v4.2.3 -> v4.4.1
* **sigs.k8s.io/yaml**                                                             v1.3.0 -> v1.4.0
* **tags.cncf.io/container-device-interface**                                      v0.8.0 **_new_**
* **tags.cncf.io/container-device-interface/specs-go**                             v0.8.0 **_new_**

Previous release can be found at [v1.7.0](https://github.com/containerd/containerd/releases/tag/v1.7.0)
### Which file should I download?
* `containerd-<VERSION>-<OS>-<ARCH>.tar.gz`:         ✅Recommended. Dynamically linked with glibc 2.31 (Ubuntu 20.04).
* `containerd-static-<VERSION>-<OS>-<ARCH>.tar.gz`:  Statically linked. Expected to be used on non-glibc Linux distributions. Not position-independent.

In addition to containerd, typically you will have to install [runc](https://github.com/opencontainers/runc/releases)
and [CNI plugins](https://github.com/containernetworking/plugins/releases) from their official sites too.

See also the [Getting Started](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) documentation.
</details>
