### PR TITLE
local: avoid writing to content root on readonly store

### DIFF
--- a/plugins/content/local/store_test.go
+++ b/plugins/content/local/store_test.go
@@ -108,16 +108,16 @@ func TestContentWriter(t *testing.T) {
 	defer cleanup()
 	defer testutil.DumpDirOnFailure(t, tmpdir)
 
-	if _, err := os.Stat(filepath.Join(tmpdir, "ingest")); os.IsNotExist(err) {
-		t.Fatal("ingest dir should be created", err)
-	}
-
 	cw, err := cs.Writer(ctx, content.WithRef("myref"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if err := cw.Close(); err != nil {
 		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(tmpdir, "ingest")); os.IsNotExist(err) {
+		t.Fatal("ingest dir should be created", err)
 	}
 
 	// reopen, so we can test things


### PR DESCRIPTION
A contentstore can be created on top of readonly path and should not fail unless there is an attempt to write into it.

Currently this fails because new ingest directory is created always, meaning for example that you can't create a store to read blobs from OCI layout without it contaminating the OCI layout files.
