### PR TITLE
*: should align pipe's owner with init process

### DIFF
--- a/integration/images/image_list.go
+++ b/integration/images/image_list.go
@@ -38,6 +38,7 @@ type ImageList struct {
 	VolumeOwnership  string
 	ArgsEscaped      string
 	DockerSchema1    string
+	Nginx            string
 }
 
 var (
@@ -57,6 +58,7 @@ func initImages(imageListFile string) {
 		VolumeOwnership:  "ghcr.io/containerd/volume-ownership:2.1",
 		ArgsEscaped:      "cplatpublic.azurecr.io/args-escaped-test-image-ns:1.0",
 		DockerSchema1:    "registry.k8s.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff",
+		Nginx:            "ghcr.io/containerd/nginx:1.27.0",
 	}
 
 	if imageListFile != "" {
@@ -96,6 +98,8 @@ const (
 	ArgsEscaped
 	// DockerSchema1 image with docker schema 1
 	DockerSchema1
+	// Nginx image
+	Nginx
 )
 
 func initImageMap(imageList ImageList) map[int]string {
@@ -108,6 +112,7 @@ func initImageMap(imageList ImageList) map[int]string {
 	images[VolumeOwnership] = imageList.VolumeOwnership
 	images[ArgsEscaped] = imageList.ArgsEscaped
 	images[DockerSchema1] = imageList.DockerSchema1
+	images[Nginx] = imageList.Nginx
 	return images
 }
 

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -471,6 +471,24 @@ func WithDevice(containerPath, hostPath, permissions string) ContainerOpts {
 	}
 }
 
+// WithSELinuxOptions allows to set SELinux option for container.
+func WithSELinuxOptions(user, role, typ, level string) ContainerOpts {
+	return func(c *runtime.ContainerConfig) {
+		if c.Linux == nil {
+			c.Linux = &runtime.LinuxContainerConfig{}
+		}
+		if c.Linux.SecurityContext == nil {
+			c.Linux.SecurityContext = &runtime.LinuxContainerSecurityContext{}
+		}
+		c.Linux.SecurityContext.SelinuxOptions = &runtime.SELinuxOption{
+			User:  user,
+			Role:  role,
+			Type:  typ,
+			Level: level,
+		}
+	}
+}
+
 // ContainerConfig creates a container config given a name and image name
 // and additional container config options
 func ContainerConfig(name, image string, opts ...ContainerOpts) *runtime.ContainerConfig {

--- a/internal/cri/server/container_start.go
+++ b/internal/cri/server/container_start.go
@@ -129,6 +129,12 @@ func (c *criService) StartContainer(ctx context.Context, r *runtime.StartContain
 			containerd.WithTaskAPIEndpoint(endpoint.Address, endpoint.Version))
 	}
 
+	ioOwnerTaskOpts, err := updateContainerIOOwner(ctx, container, config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update container IO owner: %w", err)
+	}
+	taskOpts = append(taskOpts, ioOwnerTaskOpts...)
+
 	task, err := container.NewTask(ctx, ioCreation, taskOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create containerd task: %w", err)

--- a/internal/cri/server/container_start_linux.go
+++ b/internal/cri/server/container_start_linux.go
@@ -1,0 +1,66 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"fmt"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/internal/userns"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+// updateContainerIOOwner updates I/O files' owner to align with initial processe's UID/GID.
+func updateContainerIOOwner(ctx context.Context, cntr containerd.Container, config *runtime.ContainerConfig) ([]containerd.NewTaskOpts, error) {
+	if config.GetLinux() == nil {
+		return nil, nil
+	}
+
+	// FIXME(fuweid): Ideally, the pipe owner should be aligned with process owner.
+	// No matter what user namespace container uses, it should work well. However,
+	// it breaks the sig-node conformance case - [when querying /stats/summary should report resource usage through the stats api].
+	// In order to keep compatible, the change should apply to user namespace only.
+	if config.GetLinux().GetSecurityContext().GetNamespaceOptions().GetUsernsOptions() == nil {
+		return nil, nil
+	}
+
+	spec, err := cntr.Spec(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get spec: %w", err)
+	}
+
+	if spec.Linux == nil || spec.Process == nil {
+		return nil, fmt.Errorf("invalid linux platform oci runtime spec")
+	}
+
+	hostID, err := userns.IDMap{
+		UidMap: spec.Linux.UIDMappings,
+		GidMap: spec.Linux.GIDMappings,
+	}.ToHost(userns.User{
+		Uid: spec.Process.User.UID,
+		Gid: spec.Process.User.GID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to do idmap to get host ID: %w", err)
+	}
+
+	return []containerd.NewTaskOpts{
+		containerd.WithUIDOwner(hostID.Uid),
+		containerd.WithGIDOwner(hostID.Gid),
+	}, nil
+}

--- a/internal/cri/server/container_start_other.go
+++ b/internal/cri/server/container_start_other.go
@@ -1,0 +1,31 @@
+//go:build !linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+// updateContainerIOOwner updates I/O files' owner to align with initial processe's UID/GID.
+func updateContainerIOOwner(ctx context.Context, cntr containerd.Container, config *runtime.ContainerConfig) ([]containerd.NewTaskOpts, error) {
+	return nil, nil
+}


### PR DESCRIPTION
The containerd-shim creates pipes and passes them to the init container as stdin, stdout, and stderr for logging purposes. By default, these pipes are owned by the root user (UID/GID: 0/0). The init container can access them directly through inheritance.

However, if the init container attempts to open any files pointing to these pipes (e.g., /proc/1/fd/2, /dev/stderr), it will encounter a permission issue since it is not the owner. To avoid this, we need to align the ownership of the pipes with the init process.

Fixes: #10598