### PR TITLE
config: v1Migrate: support DisabledPlugins and RequiredPlugins

### DIFF
--- a/cmd/containerd/server/config/config.go
+++ b/cmd/containerd/server/config/config.go
@@ -149,9 +149,7 @@ func (c *Config) MigrateConfigTo(ctx context.Context, targetVersion int) error {
 	return nil
 }
 
-func v1Migrate(ctx context.Context, c *Config) error {
-	plugins := make(map[string]interface{}, len(c.Plugins))
-
+func v1MigratePluginName(ctx context.Context, plugin string) string {
 	// corePlugins is the list of used plugins before v1 was deprecated
 	corePlugins := map[string]string{
 		"cri":       "io.containerd.grpc.v1.cri",
@@ -171,28 +169,40 @@ func v1Migrate(ctx context.Context, c *Config) error {
 		"overlayfs": "io.containerd.snapshotter.v1.overlayfs",
 		"zfs":       "io.containerd.snapshotter.v1.zfs",
 	}
-	for plugin, value := range c.Plugins {
-		if !strings.ContainsAny(plugin, ".") {
-			var ambiguous string
-			if full, ok := corePlugins[plugin]; ok {
-				plugin = full
-			} else if strings.HasSuffix(plugin, "-service") {
-				plugin = "io.containerd.service.v1." + plugin
-			} else if plugin == "windows" || plugin == "windows-lcow" {
-				// runtime, differ, and snapshotter plugins do not have configs for v1
-				ambiguous = plugin
-				plugin = "io.containerd.snapshotter.v1." + plugin
-			} else {
-				ambiguous = plugin
-				plugin = "io.containerd.grpc.v1." + plugin
-			}
-			if ambiguous != "" {
-				log.G(ctx).Warnf("Ambiguous %s plugin in v1 config, treating as %s", ambiguous, plugin)
-			}
+	if !strings.ContainsAny(plugin, ".") {
+		var ambiguous string
+		if full, ok := corePlugins[plugin]; ok {
+			plugin = full
+		} else if strings.HasSuffix(plugin, "-service") {
+			plugin = "io.containerd.service.v1." + plugin
+		} else if plugin == "windows" || plugin == "windows-lcow" {
+			// runtime, differ, and snapshotter plugins do not have configs for v1
+			ambiguous = plugin
+			plugin = "io.containerd.snapshotter.v1." + plugin
+		} else {
+			ambiguous = plugin
+			plugin = "io.containerd.grpc.v1." + plugin
 		}
-		plugins[plugin] = value
+		if ambiguous != "" {
+			log.G(ctx).Warnf("Ambiguous %s plugin in v1 config, treating as %s", ambiguous, plugin)
+		}
+	}
+	return plugin
+}
+
+func v1Migrate(ctx context.Context, c *Config) error {
+	plugins := make(map[string]interface{}, len(c.Plugins))
+	for plugin, value := range c.Plugins {
+		plugins[v1MigratePluginName(ctx, plugin)] = value
 	}
 	c.Plugins = plugins
+	for i, plugin := range c.DisabledPlugins {
+		c.DisabledPlugins[i] = v1MigratePluginName(ctx, plugin)
+	}
+	for i, plugin := range c.RequiredPlugins {
+		c.RequiredPlugins[i] = v1MigratePluginName(ctx, plugin)
+	}
+	// No change in c.ProxyPlugins
 	return nil
 }
 

--- a/cmd/containerd/server/config/config_test.go
+++ b/cmd/containerd/server/config/config_test.go
@@ -214,6 +214,25 @@ imports = ["data1.toml", "data2.toml"]
 	}, out.Imports)
 }
 
+// https://github.com/containerd/containerd/issues/10905
+func TestLoadConfigWithDefaultConfigVersion(t *testing.T) {
+	data1 := `
+disabled_plugins=["cri"]
+`
+	tempDir := t.TempDir()
+
+	err := os.WriteFile(filepath.Join(tempDir, "data1.toml"), []byte(data1), 0o600)
+	assert.NoError(t, err)
+
+	var out Config
+	out.Version = version.ConfigVersion
+	err = LoadConfig(context.Background(), filepath.Join(tempDir, "data1.toml"), &out)
+	assert.NoError(t, err)
+
+	assert.Equal(t, version.ConfigVersion, out.Version)
+	assert.Equal(t, []string{"io.containerd.grpc.v1.cri"}, out.DisabledPlugins)
+}
+
 func TestDecodePlugin(t *testing.T) {
 	ctx := logtest.WithT(context.Background(), t)
 	data := `


### PR DESCRIPTION
Fix #10905

The following config is automatically migrated without raising an error.
```toml
disabled_plugins=["cri"]
```
↓
```toml
version = 3
disabled_plugins = ["io.containerd.grpc.v1.cri"]
```