### PR TITLE
Update namespaces.md

### DIFF
--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -77,5 +77,5 @@ You can also use the `CONTAINERD_NAMESPACE` environment variable to specify the 
 any of the `ctr` client commands.  
 >To know more about different Namespaces packages click below links :  
 >[`containerd Namespaces`](https://pkg.go.dev/github.com/containerd/containerd/v2/pkg/namespaces).  
->[`kubernetes Namespaces`](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/).  
+>[`Kubernetes Namespaces`](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/).  
 >[`Moby(Docker) Namespaces`](https://docs.docker.com/engine/security/userns-remap/).

--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -12,7 +12,7 @@ It is trivial for clients to switch namespaces.
 ## Who specifies the namespace?
 
 The client specifies the namespace via the `context`.
-There is a `github.com/containerd/containerd/v2/namespaces` package that allows a user to get and set the namespace on a context.
+There is a [`github.com/containerd/containerd/v2/pkg/namespaces`](https://pkg.go.dev/github.com/containerd/containerd/v2/pkg/namespaces) package that allows a user to get and set the namespace on a context.
 
 ```go
 // set a namespace

--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -76,6 +76,6 @@ will all use the default namespace, which is simply named "`default`".
 You can also use the `CONTAINERD_NAMESPACE` environment variable to specify the default namespace to use for
 any of the `ctr` client commands.  
 >To know more about different Namespaces packages click below links :  
->[`Containerd Namespaces Pkg`](https://pkg.go.dev/github.com/containerd/containerd/v2/pkg/namespaces).  
->[`kubernetes Namespaces Pkg`](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/).  
->[`Moby(Docker) Namespaces Pkg`](https://docs.docker.com/engine/security/userns-remap/).
+>[`Containerd Namespaces`](https://pkg.go.dev/github.com/containerd/containerd/v2/pkg/namespaces).  
+>[`kubernetes Namespaces`](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/).  
+>[`Moby(Docker) Namespaces`](https://docs.docker.com/engine/security/userns-remap/).

--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -74,4 +74,4 @@ will all use the default namespace, which is simply named "`default`".
 ```
 
 You can also use the `CONTAINERD_NAMESPACE` environment variable to specify the default namespace to use for
-any of the `ctr` client commands.  
+any of the `ctr` client commands.

--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -12,7 +12,7 @@ It is trivial for clients to switch namespaces.
 ## Who specifies the namespace?
 
 The client specifies the namespace via the `context`.
-There is a `github.com/containerd/containerd/v2/pkg/namespaces` package that allows a user to get and set the namespace on a context.  
+There is a `github.com/containerd/containerd/v2/pkg/namespaces` package that allows a user to get and set the namespace on a context.
 
 ```go
 // set a namespace
@@ -24,8 +24,7 @@ ns, ok := namespaces.Namespace(ctx)
 
 Because the client calls containerd's gRPC API to interact with the daemon, all API calls require a context with a namespace set.
 
-> Note that a namespace cannot be named `"version"` ([#6944](https://github.com/containerd/containerd/issues/6944)).  
-
+> Note that a namespace cannot be named `"version"` ([#6944](https://github.com/containerd/containerd/issues/6944)).
 
 ## How low level is the implementation?
 
@@ -76,4 +75,4 @@ will all use the default namespace, which is simply named "`default`".
 
 You can also use the `CONTAINERD_NAMESPACE` environment variable to specify the default namespace to use for
 any of the `ctr` client commands.  
->To know more about namespace package click here [`namespaces`](https://pkg.go.dev/github.com/containerd/containerd/v2/pkg/namespaces).
+>To know more about Namespaces package click here [`Namespaces`](https://pkg.go.dev/github.com/containerd/containerd/v2/pkg/namespaces).

--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -12,7 +12,7 @@ It is trivial for clients to switch namespaces.
 ## Who specifies the namespace?
 
 The client specifies the namespace via the `context`.
-There is a [`github.com/containerd/containerd/v2/pkg/namespaces`](https://pkg.go.dev/github.com/containerd/containerd/v2/pkg/namespaces) package that allows a user to get and set the namespace on a context.
+There is a `github.com/containerd/containerd/v2/pkg/namespaces` package that allows a user to get and set the namespace on a context.  
 
 ```go
 // set a namespace
@@ -24,7 +24,8 @@ ns, ok := namespaces.Namespace(ctx)
 
 Because the client calls containerd's gRPC API to interact with the daemon, all API calls require a context with a namespace set.
 
-> Note that a namespace cannot be named `"version"` ([#6944](https://github.com/containerd/containerd/issues/6944)).
+> Note that a namespace cannot be named `"version"` ([#6944](https://github.com/containerd/containerd/issues/6944)).  
+
 
 ## How low level is the implementation?
 
@@ -74,4 +75,5 @@ will all use the default namespace, which is simply named "`default`".
 ```
 
 You can also use the `CONTAINERD_NAMESPACE` environment variable to specify the default namespace to use for
-any of the `ctr` client commands.
+any of the `ctr` client commands.  
+>To know more about namespace package click here [`namespaces`](https://pkg.go.dev/github.com/containerd/containerd/v2/pkg/namespaces).

--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -75,7 +75,3 @@ will all use the default namespace, which is simply named "`default`".
 
 You can also use the `CONTAINERD_NAMESPACE` environment variable to specify the default namespace to use for
 any of the `ctr` client commands.  
->To know more about different Namespaces packages click below links :  
->[`containerd Namespaces`](https://pkg.go.dev/github.com/containerd/containerd/v2/pkg/namespaces).  
->[`Kubernetes Namespaces`](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/).  
->[`Moby(Docker) Namespaces`](https://docs.docker.com/engine/security/userns-remap/).

--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -75,4 +75,7 @@ will all use the default namespace, which is simply named "`default`".
 
 You can also use the `CONTAINERD_NAMESPACE` environment variable to specify the default namespace to use for
 any of the `ctr` client commands.  
->To know more about Namespaces package click here [`Namespaces`](https://pkg.go.dev/github.com/containerd/containerd/v2/pkg/namespaces).
+>To know more about different Namespaces packages click below links :  
+>[`Containerd Namespaces Pkg`](https://pkg.go.dev/github.com/containerd/containerd/v2/pkg/namespaces).  
+>[`kubernetes Namespaces Pkg`](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/).  
+>[`Moby(Docker) Namespaces Pkg`](https://docs.docker.com/engine/security/userns-remap/).

--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -76,6 +76,6 @@ will all use the default namespace, which is simply named "`default`".
 You can also use the `CONTAINERD_NAMESPACE` environment variable to specify the default namespace to use for
 any of the `ctr` client commands.  
 >To know more about different Namespaces packages click below links :  
->[`Containerd Namespaces`](https://pkg.go.dev/github.com/containerd/containerd/v2/pkg/namespaces).  
+>[`containerd Namespaces`](https://pkg.go.dev/github.com/containerd/containerd/v2/pkg/namespaces).  
 >[`kubernetes Namespaces`](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/).  
 >[`Moby(Docker) Namespaces`](https://docs.docker.com/engine/security/userns-remap/).


### PR DESCRIPTION
Fix: update package import path for namespaces

- Updated the import path for the namespaces package from 
 'github.com/containerd/containerd/v2/namespaces' to  'github.com/containerd/containerd/v2/pkg/namespaces'. 
- Also added a Namespaces doc link in the end 

> Please let me know if you require a link to the relevant documentation, or if the path change alone is sufficient.