### PR TITLE
Add tests for CNI v2 loopback options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,6 +248,11 @@ bin/runc-fp: integration/failpoint/cmd/runc-fp FORCE
 	@echo "$(WHALE) $@"
 	@$(GO) build ${GO_BUILD_FLAGS} -o $@ ./integration/failpoint/cmd/runc-fp
 
+# build loopback-v2 with failpoint support, only used by integration test
+bin/loopback-v2: integration/failpoint/cmd/loopback-v2 FORCE
+	@echo "$(WHALE) $@"
+	@CGO_ENABLED=${SHIM_CGO_ENABLED} $(GO) build ${GO_BUILD_FLAGS} -o $@ ./integration/failpoint/cmd/loopback-v2
+
 benchmark: ## run benchmarks tests
 	@echo "$(WHALE) $@"
 	@$(GO) test ${TESTFLAGS} -bench . -run Benchmark -test.root

--- a/integration/failpoint/cmd/loopback-v2/main.go
+++ b/integration/failpoint/cmd/loopback-v2/main.go
@@ -1,0 +1,42 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"net"
+
+	"github.com/vishvananda/netlink"
+)
+
+// isLoInterfaceUp validates whether the lo interface is up
+func isLoInterfaceUp() (bool, error) {
+	link, err := netlink.LinkByName("lo")
+	if err != nil {
+		return false, fmt.Errorf("could not find interface lo: %w", err)
+	}
+	return link.Attrs().Flags&net.FlagUp != 0, nil
+}
+
+func main() {
+	up, err := isLoInterfaceUp()
+	if err != nil {
+		log.Fatalf("could not check lo interface status: %v", err)
+	}
+	fmt.Printf("Loopback interface is %s\n", map[bool]string{true: "UP", false: "DOWN"}[up])
+}

--- a/integration/issue10244_loopback_linux_test.go
+++ b/integration/issue10244_loopback_linux_test.go
@@ -1,0 +1,102 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/v2/integration/images"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+func TestIssue10244LoopbackV2(t *testing.T) {
+	testCases := []struct {
+		name  string
+		value bool
+	}{
+		{name: "use_internal_loopback=false", value: false},
+		{name: "use_internal_loopback=true", value: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.True(t, checkLoopbackResult(t, tc.value))
+		})
+	}
+}
+
+// checkLoopbackResult validates whether the loopback interface status within a container is UP
+func checkLoopbackResult(t *testing.T, useInternalLoopback bool) bool {
+	t.Logf("Create containerd config with 'use_internal_loopback' set to '%t'", useInternalLoopback)
+	workDir := t.TempDir()
+	configPath := filepath.Join(workDir, "config.toml")
+	ctrdConfig := fmt.Sprintf(`
+	version = 3
+
+	[plugins]
+	[plugins.'io.containerd.cri.v1.runtime']
+	  [plugins.'io.containerd.cri.v1.runtime'.cni]
+		use_internal_loopback = %t`,
+		useInternalLoopback)
+
+	err := os.WriteFile(configPath, []byte(ctrdConfig), 0600)
+	require.NoError(t, err)
+
+	t.Logf("Start containerd")
+	currentProc := newCtrdProc(t, "containerd", workDir, nil)
+	require.NoError(t, currentProc.isReady())
+
+	t.Cleanup(func() {
+		t.Log("Cleanup all the pods")
+		cleanupPods(t, currentProc.criRuntimeService(t))
+
+		t.Log("Stop containerd process")
+		require.NoError(t, currentProc.kill(syscall.SIGTERM))
+		require.NoError(t, currentProc.wait(5*time.Minute))
+	})
+
+	var (
+		testImage     = images.Get(images.BusyBox)
+		containerName = "test-container-loopback-v2"
+	)
+
+	pullImagesByCRI(t, currentProc.criImageService(t), testImage)
+
+	t.Log("Create a pod with a container that checks the loopback status")
+	podCtx := newPodTCtx(t, currentProc.criRuntimeService(t), "container-exec-lo-test", "sandbox")
+	cnID := podCtx.createContainer(
+		containerName,
+		testImage,
+		runtime.ContainerState_CONTAINER_RUNNING,
+		WithCommand("sleep", "1d"),
+		WithVolumeMount("/usr/local/bin/loopback-v2", "/loopback-v2"),
+	)
+
+	t.Logf("Check loopback status - should be UP (not DOWN) when 'use_internal_loopback' is '%t'", useInternalLoopback)
+	stdout, _, err := podCtx.rSvc.ExecSync(cnID, []string{"/loopback-v2"}, 5*time.Second)
+	require.NoError(t, err, "")
+	t.Logf("%s", stdout)
+
+	return assert.Contains(t, string(stdout), "UP")
+}

--- a/script/setup/install-failpoint-binaries
+++ b/script/setup/install-failpoint-binaries
@@ -37,3 +37,7 @@ sudo install bin/containerd-shim-runc-fp-v1 "${SHIM_BIN_DIR}"
 RUNCFP_BIN_DIR=${RUNCFP_BIN_DIR:-"/usr/local/bin"}
 make bin/runc-fp
 sudo install bin/runc-fp "${RUNCFP_BIN_DIR}"
+
+LOOPBACKV2_BIN_DIR=${LOOPBACKV2_BIN_DIR:-"/usr/local/bin"}
+make bin/loopback-v2
+sudo install bin/loopback-v2 "${LOOPBACKV2_BIN_DIR}"


### PR DESCRIPTION
Adding test cases to cover CNI v2 loopback options, as mentioned in issue #10244 

Loopback (lo) is expected to be set to on for localhost in all containers of a pod, regardless of whether the `use_internal_loopback` option is set to `true` or `false` within containerd config (`/etc/containerd/config.toml`)

Two tests have been added in `integration/issue10244_container_exec_test.go` - one to validate the above for when the `use_internal_loopback` property is set to `false` (default value), and one for when it is set to `true`
