### PR TITLE
RELEASES.md: k8s: fix CRI v1alpha2 removal release, remove old releases

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -140,25 +140,23 @@ of containerd for every supported version of Kubernetes.
 
 | Kubernetes Version | containerd Version            | CRI Version     |
 |--------------------|-------------------------------|-----------------|
-| 1.26               | 1.7.0+, 1.6.15+               | v1, v1alpha2 ** |
-| 1.27               | 1.7.0+, 1.6.15+               | v1              |
-| 1.28               | 1.7.0+, 1.6.15+               | v1              |
 | 1.29               | 1.7.11+, 1.6.27+              | v1              |
 | 1.30               | 2.0(wip), 1.7.13+, 1.6.28+    | v1              |
 | 1.31               | 2.0(wip), 1.7.20+, 1.6.34+    | v1              |
 
-** Note: containerd v1.6.*, and v1.7.* support CRI v1 and v1alpha2 through EOL as those releases continue to support older versions of k8s, cloud providers, and other clients using CRI v1alpha2. CRI v1alpha2 is deprecated in v1.7 and will be removed in containerd v2.0.
-
 Deprecated containerd and kubernetes versions
 
-| Containerd Version       | Kubernetes Version | CRI Version          |
-|--------------------------|--------------------|----------------------|
-| v1.0 (w/ cri-containerd) | 1.7, 1.8, 1.9      | v1alpha1             |
-| v1.1                     | 1.10+              | v1alpha2             |
-| v1.2                     | 1.10+              | v1alpha2             |
-| v1.3                     | 1.12+              | v1alpha2             |
-| v1.4                     | 1.19+              | v1alpha2             |
-| v1.5                     | 1.20+              | v1 (1.23+), v1alpha2 |
+| Containerd Version       | Kubernetes Version | CRI Version                          |
+|--------------------------|--------------------|--------------------------------------|
+| v1.0 (w/ cri-containerd) | 1.7, 1.8, 1.9      | v1alpha1                             |
+| v1.1                     | 1.10+              | v1alpha2                             |
+| v1.2                     | 1.10+              | v1alpha2                             |
+| v1.3                     | 1.12+              | v1alpha2                             |
+| v1.4                     | 1.19+              | v1alpha2                             |
+| v1.5                     | 1.20+              | v1 (1.23+), v1alpha2 (until 1.25) ** |
+| v1.6.15+, v1.7.0+        | 1.26+              | v1                                   |
+
+** Note: containerd v1.6.*, and v1.7.* support CRI v1 and v1alpha2 through EOL as those releases continue to support older versions of k8s, cloud providers, and other clients using CRI v1alpha2. CRI v1alpha2 is deprecated in v1.7 and will be removed in containerd v2.0.
 
 ### Backporting
 


### PR DESCRIPTION
* CRI v1alpha2 was removed in v1.26, not in v1.27 https://github.com/kubernetes/kubernetes/blob/v1.26.0/CHANGELOG/CHANGELOG-1.26.md?plain=1#L482

* Kubernetes releases prior to v1.29 have already reached their EOL: https://kubernetes.io/releases/