### PR TITLE
[release/1.7] services/snapshots: include name of snapshotter in debug logs

### DIFF
--- a/services/snapshots/service.go
+++ b/services/snapshots/service.go
@@ -98,7 +98,7 @@ func (s *service) Register(gs *grpc.Server) error {
 }
 
 func (s *service) Prepare(ctx context.Context, pr *snapshotsapi.PrepareSnapshotRequest) (*snapshotsapi.PrepareSnapshotResponse, error) {
-	log.G(ctx).WithField("parent", pr.Parent).WithField("key", pr.Key).Debugf("prepare snapshot")
+	log.G(ctx).WithFields(log.Fields{"parent": pr.Parent, "key": pr.Key, "snapshotter": pr.Snapshotter}).Debugf("prepare snapshot")
 	sn, err := s.getSnapshotter(pr.Snapshotter)
 	if err != nil {
 		return nil, err
@@ -119,7 +119,7 @@ func (s *service) Prepare(ctx context.Context, pr *snapshotsapi.PrepareSnapshotR
 }
 
 func (s *service) View(ctx context.Context, pr *snapshotsapi.ViewSnapshotRequest) (*snapshotsapi.ViewSnapshotResponse, error) {
-	log.G(ctx).WithField("parent", pr.Parent).WithField("key", pr.Key).Debugf("prepare view snapshot")
+	log.G(ctx).WithFields(log.Fields{"parent": pr.Parent, "key": pr.Key, "snapshotter": pr.Snapshotter}).Debugf("prepare view snapshot")
 	sn, err := s.getSnapshotter(pr.Snapshotter)
 	if err != nil {
 		return nil, err
@@ -138,7 +138,7 @@ func (s *service) View(ctx context.Context, pr *snapshotsapi.ViewSnapshotRequest
 }
 
 func (s *service) Mounts(ctx context.Context, mr *snapshotsapi.MountsRequest) (*snapshotsapi.MountsResponse, error) {
-	log.G(ctx).WithField("key", mr.Key).Debugf("get snapshot mounts")
+	log.G(ctx).WithFields(log.Fields{"key": mr.Key, "snapshotter": mr.Snapshotter}).Debugf("get snapshot mounts")
 	sn, err := s.getSnapshotter(mr.Snapshotter)
 	if err != nil {
 		return nil, err
@@ -154,7 +154,7 @@ func (s *service) Mounts(ctx context.Context, mr *snapshotsapi.MountsRequest) (*
 }
 
 func (s *service) Commit(ctx context.Context, cr *snapshotsapi.CommitSnapshotRequest) (*ptypes.Empty, error) {
-	log.G(ctx).WithField("key", cr.Key).WithField("name", cr.Name).Debugf("commit snapshot")
+	log.G(ctx).WithFields(log.Fields{"key": cr.Key, "snapshotter": cr.Snapshotter, "name": cr.Name}).Debugf("commit snapshot")
 	sn, err := s.getSnapshotter(cr.Snapshotter)
 	if err != nil {
 		return nil, err
@@ -173,7 +173,7 @@ func (s *service) Commit(ctx context.Context, cr *snapshotsapi.CommitSnapshotReq
 }
 
 func (s *service) Remove(ctx context.Context, rr *snapshotsapi.RemoveSnapshotRequest) (*ptypes.Empty, error) {
-	log.G(ctx).WithField("key", rr.Key).Debugf("remove snapshot")
+	log.G(ctx).WithFields(log.Fields{"key": rr.Key, "snapshotter": rr.Snapshotter}).Debugf("remove snapshot")
 	sn, err := s.getSnapshotter(rr.Snapshotter)
 	if err != nil {
 		return nil, err
@@ -187,7 +187,7 @@ func (s *service) Remove(ctx context.Context, rr *snapshotsapi.RemoveSnapshotReq
 }
 
 func (s *service) Stat(ctx context.Context, sr *snapshotsapi.StatSnapshotRequest) (*snapshotsapi.StatSnapshotResponse, error) {
-	log.G(ctx).WithField("key", sr.Key).Debugf("stat snapshot")
+	log.G(ctx).WithFields(log.Fields{"key": sr.Key, "snapshotter": sr.Snapshotter}).Debugf("stat snapshot")
 	sn, err := s.getSnapshotter(sr.Snapshotter)
 	if err != nil {
 		return nil, err
@@ -202,7 +202,7 @@ func (s *service) Stat(ctx context.Context, sr *snapshotsapi.StatSnapshotRequest
 }
 
 func (s *service) Update(ctx context.Context, sr *snapshotsapi.UpdateSnapshotRequest) (*snapshotsapi.UpdateSnapshotResponse, error) {
-	log.G(ctx).WithField("key", sr.Info.Name).Debugf("update snapshot")
+	log.G(ctx).WithFields(log.Fields{"key": sr.Info.Name, "snapshotter": sr.Snapshotter}).Debugf("update snapshot")
 	sn, err := s.getSnapshotter(sr.Snapshotter)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Backports https://github.com/containerd/containerd/pull/10919 to 1.7 branch

- combine consecutive "WithField" calls to "WithFields", as multiple calls is known to be expensive.
- include a "snapshotter" field in logs to allow correlating actions with specific snapshotters.


(cherry picked from commit 4594f5cac18f3d46b54666b20698b2aa7861c3f2)