### PR TITLE
Prepare release notes for api/v1.8.0

### DIFF
--- a/api/releases/v1.8.0.toml
+++ b/api/releases/v1.8.0.toml
@@ -9,7 +9,7 @@ ignore_deps = [ "github.com/containerd/containerd" ]
 # previous release
 previous = "v1.7.0"
 
-pre_release = true
+pre_release = false
 
 preface = """\
 The first dedicated release for the containerd API. This release continues the 1.x


### PR DESCRIPTION
No more API changes are being considered for api/v1.8.0 and containerd v2.0.0

Relevant to #10858