### PR TITLE
Prepare release notes for v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ containerd is designed to be embedded into a larger system, rather than being us
 
 ## Announcements
 
-### containerd v2.0 is coming soon
+### containerd v2.0 is now released!
 See [`docs/containerd-2.0.md`](docs/containerd-2.0.md).
 
 ### Now Recruiting

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -117,9 +117,10 @@ The current state is available in the following tables:
 | [1.3](https://github.com/containerd/containerd/releases/tag/v1.3.10) | End of Life   | September 26, 2019 | March 4, 2021                                           |
 | [1.4](https://github.com/containerd/containerd/releases/tag/v1.4.13) | End of Life   | August 17, 2020    | March 3, 2022                                           |
 | [1.5](https://github.com/containerd/containerd/releases/tag/v1.5.18) | End of Life   | May 3, 2021        | February 28, 2023                                       |
-| [1.6](https://github.com/containerd/containerd/releases/tag/v1.6.23) | LTS           | February 15, 2022  | max(February 15, 2025 or next LTS + 6 months)           |
-| [1.7](https://github.com/containerd/containerd/releases/tag/v1.7.3)  | Active        | March 10, 2023     | active(release of 2.0 + 6 months), extended(EOL of 1.6) |
-| [2.0](https://github.com/containerd/containerd/milestone/35)         | Next          | TBD                | TBD                                                     |
+| [1.6](https://github.com/containerd/containerd/releases/tag/v1.6.36) | LTS           | February 15, 2022  | next LTS + 6 months                                     |
+| [1.7](https://github.com/containerd/containerd/releases/tag/v1.7.23) | Active        | March 10, 2023     | active(May 5, 2025), extended(EOL of 1.6)               |
+| [2.0](https://github.com/containerd/containerd/releases/tag/v2.0.0)  | Active        | November 5, 2024   | max(November 5, 2025 or release of 2.1 + 6 months)      |
+| [2.1](https://github.com/containerd/containerd/milestone/48)         | Next          | TBD                | TBD                                                     |
 
 > **_NOTE_** containerd v1.7 will end of life at the same time as v1.6 LTS. Due to
 > [Minimal Version Selection](https://go.dev/ref/mod#minimal-version-selection) used
@@ -141,8 +142,8 @@ of containerd for every supported version of Kubernetes.
 | Kubernetes Version | containerd Version            | CRI Version     |
 |--------------------|-------------------------------|-----------------|
 | 1.29               | 1.7.11+, 1.6.27+              | v1              |
-| 1.30               | 2.0(wip), 1.7.13+, 1.6.28+    | v1              |
-| 1.31               | 2.0(wip), 1.7.20+, 1.6.34+    | v1              |
+| 1.30               | 2.0.0+, 1.7.13+, 1.6.28+      | v1              |
+| 1.31               | 2.0.0+, 1.7.20+, 1.6.34+      | v1              |
 
 Deprecated containerd and kubernetes versions
 

--- a/releases/cri-containerd.DEPRECATED.txt
+++ b/releases/cri-containerd.DEPRECATED.txt
@@ -1,5 +1,5 @@
 The "cri-containerd-(cni-)-VERSION-OS-ARCH.tar.gz" release bundle has been deprecated since containerd 1.6,
-does not work on some Linux distributions, and will be removed in containerd 2.0.
+does not work on some Linux distributions, and has been removed in containerd 2.0.
 
 Instead of this, install the following components separately, either from the binary or from the source:
 * containerd:  https://github.com/containerd/containerd/releases

--- a/releases/v2.0.0.toml
+++ b/releases/v2.0.0.toml
@@ -9,7 +9,7 @@ ignore_deps = [ "github.com/containerd/containerd" ]
 # previous release
 previous = "v1.7.0"
 
-pre_release = true
+pre_release = false
 
 preface = """\
 The first major release of containerd 2.x focuses on the continued stability of
@@ -18,6 +18,8 @@ release includes the stabilization of new features added in the last 1.x release
 as well as the removal of features which were deprecated in 1.x. The goal is to
 support the vast community of containerd users well into the future along with
 their ever increasing deployment footprints and variety of use cases.
+
+See [containerd 2.0](https://github.com/containerd/containerd/blob/main/docs/containerd-2.0.md) documentation for details on what is new and has changed in this release.
 """
 
 postface = """\

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd/v2"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "2.0.0-rc.6+unknown"
+	Version = "2.0.0+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
containerd 2.0.0

Welcome to the v2.0.0 release of containerd!

The first major release of containerd 2.x focuses on the continued stability of
containerd's core feature set with an easy upgrade from containerd 1.x. This
release includes the stabilization of new features added in the last 1.x release
as well as the removal of features which were deprecated in 1.x. The goal is to
support the vast community of containerd users well into the future along with
their ever increasing deployment footprints and variety of use cases.

See [containerd 2.0](https://github.com/containerd/containerd/blob/main/docs/containerd-2.0.md) documentation for details on what is new and has changed in this release.

### Highlights

* Allow sections of Plugins to be merged, and not overwritten as entire sections. ([#9982](https://github.com/containerd/containerd/pull/9982))
* Add Update API for sandbox controller ([#9903](https://github.com/containerd/containerd/pull/9903))
* Configure otel from env instead of config.toml ([#8970](https://github.com/containerd/containerd/pull/8970))
* Enable NRI by default ([#9744](https://github.com/containerd/containerd/pull/9744))
* Add PluginInfo to introspection API ([#9442](https://github.com/containerd/containerd/pull/9442))
* Remove overlayfs volatile option on temp mounts ([#9555](https://github.com/containerd/containerd/pull/9555))
* Expose usage of deprecated features ([#9258](https://github.com/containerd/containerd/pull/9258))
* Use Intel ISA-L's igzip if available ([#9200](https://github.com/containerd/containerd/pull/9200))
* Introduce top level config migration ([#9223](https://github.com/containerd/containerd/pull/9223))
* Add image delete target ([#8989](https://github.com/containerd/containerd/pull/8989))
* Remove `LimitNOFILE` from `containerd.service` ([#8924](https://github.com/containerd/containerd/pull/8924))
* Add support for image expiration during garbage collection ([#9022](https://github.com/containerd/containerd/pull/9022))
* Reduce the contention between ref lock and boltdb lock in content store ([#8792](https://github.com/containerd/containerd/pull/8792))
* Remove "containerd.io/restart.logpath" label ([#8264](https://github.com/containerd/containerd/pull/8264))
* Remove `aufs` snapshotter ([#8263](https://github.com/containerd/containerd/pull/8263))
* Fix deadlock during NRI plugin registration ([containerd/nri#79](https://github.com/containerd/nri/pull/79))
* Support arm64/v9 and minor variants ([containerd/platforms#8](https://github.com/containerd/platforms/pull/8))
* Fix deadlock when writing to pipe blocks ([containerd/ttrpc#168](https://github.com/containerd/ttrpc/pull/168))

#### Build and Release Toolchain

* Generate attestation for artifacts during release ([#10543](https://github.com/containerd/containerd/pull/10543))
* Remove `cri-containerd-*.tar.gz` release bundles ([#9096](https://github.com/containerd/containerd/pull/9096))

#### Container Runtime Interface (CRI)

* Use 'UserSpecifiedImage' from CRI to set the image-name annotation ([#10747](https://github.com/containerd/containerd/pull/10747))
* Fine-grained SupplementalGroups control ([#9737](https://github.com/containerd/containerd/pull/9737))
* Add support to set loopback to up ([#10238](https://github.com/containerd/containerd/pull/10238))
* KEP-3857: Recursive Read-only (RRO) mounts ([#9787](https://github.com/containerd/containerd/pull/9787))
* Add support for multiple subscribers to CRI container events ([#9661](https://github.com/containerd/containerd/pull/9661))
* Enable CDI by default ([#9621](https://github.com/containerd/containerd/pull/9621))
* Remove non-sandboxed CRI implementation ([#9228](https://github.com/containerd/containerd/pull/9228))
* Add support for userns in stateless and stateful pods with idmap mounts (KEP-127, k8s >= 1.27) ([#8287](https://github.com/containerd/containerd/pull/8287))
* Use sandboxed CRI by default ([#8994](https://github.com/containerd/containerd/pull/8994))
* Implement RuntimeConfig CRI call ([#8722](https://github.com/containerd/containerd/pull/8722))
* Add support for user namespaces (KEP-127) ([#8803](https://github.com/containerd/containerd/pull/8803))
* Remove CRI v1alpha2 ([#8276](https://github.com/containerd/containerd/pull/8276))

#### Go client

* Add api Go module and move all protos under api ([#10151](https://github.com/containerd/containerd/pull/10151))
* Move packages based on contributing guide ([#9365](https://github.com/containerd/containerd/pull/9365))
* Generalize plugin library ([#9214](https://github.com/containerd/containerd/pull/9214))
* Use github.com/containerd/log ([#9086](https://github.com/containerd/containerd/pull/9086))

#### Image Distribution

* Support to syncfs after pull by using diff plugin ([#10284](https://github.com/containerd/containerd/pull/10284))
* Skip "unknown" in image platform listing ([#10257](https://github.com/containerd/containerd/pull/10257))
* Update unpacker to fetch all provided content ([#10202](https://github.com/containerd/containerd/pull/10202))
* Enable Transfer service API to support plain HTTP ([#10024](https://github.com/containerd/containerd/pull/10024))
* Enable Transfer service to use registry configuration directory ([#9908](https://github.com/containerd/containerd/pull/9908))
* Disable the support for Schema 1 images ([#9765](https://github.com/containerd/containerd/pull/9765))
* Update Transfer service to add OCI descriptors to Progress structure ([#9630](https://github.com/containerd/containerd/pull/9630))
* Update import and export to allow references to missing content  ([#9554](https://github.com/containerd/containerd/pull/9554))
* Add option to perform syncfs after pull ([#9401](https://github.com/containerd/containerd/pull/9401))
* Add image verifier transfer service plugin system based on a binary directory ([#8493](https://github.com/containerd/containerd/pull/8493))

#### Runtime

* Implement  RuntimeStatus.features.supplemental_groups_policy from KEP-3619 ([#10410](https://github.com/containerd/containerd/pull/10410))
* Add pprof to runc-shim ([#10242](https://github.com/containerd/containerd/pull/10242))
* Provide runtime options in plugin info ([#10251](https://github.com/containerd/containerd/pull/10251))
* Store bootstrap parameters in sandbox metadata ([#9736](https://github.com/containerd/containerd/pull/9736))
* Update apparmor to allow confined runc to kill containers ([#10123](https://github.com/containerd/containerd/pull/10123))
* Support vsock connection to task api ([#9738](https://github.com/containerd/containerd/pull/9738))
* Update RuntimeDefault seccomp profile to disallow io_uring related syscalls ([#9320](https://github.com/containerd/containerd/pull/9320))
* Switch runc shim to task service v3 and fix restore ([#9233](https://github.com/containerd/containerd/pull/9233))
* Add sandboxer configuration and move sandbox controllers to plugins ([#8268](https://github.com/containerd/containerd/pull/8268))
* Add annotations to CreateSandbox request ([#8960](https://github.com/containerd/containerd/pull/8960))
* Add SandboxMetrics ([#8680](https://github.com/containerd/containerd/pull/8680))
* Publish sandbox events ([#8602](https://github.com/containerd/containerd/pull/8602))
* Remove the CriuPath field from runc's options ([#8279](https://github.com/containerd/containerd/pull/8279))
* Remove `io.containerd.runtime.v1.linux` and `io.containerd.runc.v1` ([#8262](https://github.com/containerd/containerd/pull/8262))

#### Security Advisories

* [medium] RAPL accessible to a container [GHSA-7ww5-4wqc-m92c](https://github.com/containerd/containerd/security/advisories/GHSA-7ww5-4wqc-m92c)

#### Breaking

* Remove `disable_cgroup` from CRI config ([#10594](https://github.com/containerd/containerd/pull/10594))
* Disable the support for Schema 1 images ([#9765](https://github.com/containerd/containerd/pull/9765))
* Update RuntimeDefault seccomp profile to disallow io_uring related syscalls ([#9320](https://github.com/containerd/containerd/pull/9320))
* Move client to subpackage ([#9316](https://github.com/containerd/containerd/pull/9316))
* Remove `LimitNOFILE` from `containerd.service` ([#8924](https://github.com/containerd/containerd/pull/8924))
* Remove CRI v1alpha2 ([#8276](https://github.com/containerd/containerd/pull/8276))
* Remove `io.containerd.runtime.v1.linux` and `io.containerd.runc.v1` ([#8262](https://github.com/containerd/containerd/pull/8262))
* Remove "containerd.io/restart.logpath" label ([#8264](https://github.com/containerd/containerd/pull/8264))
* Remove `aufs` snapshotter ([#8263](https://github.com/containerd/containerd/pull/8263))

#### Deprecations

* Update warnings for deprecated CRI config fields ([#10509](https://github.com/containerd/containerd/pull/10509))
* Add type alias for event Envelope ([#10279](https://github.com/containerd/containerd/pull/10279))
* Postpone removal of deprecated CRI config properties ([#9966](https://github.com/containerd/containerd/pull/9966))
* Deprecate go-plugin configuration option ([#9238](https://github.com/containerd/containerd/pull/9238))
* CNI conf_template in CRI is no longer deprecated ([#8637](https://github.com/containerd/containerd/pull/8637))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

<details>
<summary>...</summary>

### Contributors

* Derek McGowan
* Akihiro Suda
* Maksym Pavlenko
* Wei Fu
* Phil Estes
* Sebastiaan van Stijn
* Samuel Karp
* Krisztian Litkey
* Kazuyoshi Kato
* Austin Vazquez
* Rodrigo Campos
* Danny Canter
* Abel Feng
* Mike Brown
* Kirtana Ashok
* Akhil Mohan
* Iceber Gu
* Gabriel Adrian Samfira
* Jin Dong
* Kohei Tokunaga
* Bjorn Neergaard
* Brian Goff
* Justin Chadwell
* rongfu.leng
* James Sturtevant
* Davanum Srinivas
* Paul "TBBle" Hampson
* Henry Wang
* Enrico Weigelt
* Laura Brehm
* Marat Radchenko
* Paweł Gronowski
* Shingo Omura
* Hsing-Yu (David) Chen
* Ilya Hanov
* Cardy.Tang
* Swagat Bora
* Aditi Sharma
* Amit Barve
* Bryant Biggs
* Evan Lezar
* James Jenkins
* Jordan Liggitt
* Kay Yan
* Markus Lehtonen
* Nashwan Azhari
* Shuaiyi Zhang
* Vinayak Goyal
* helen
* Alexandru Matei
* Anthony Nandaa
* Avi Deitcher
* Charity Kathure
* Cory Snider
* Ed Bartosh
* Etienne Champetier
* Kevin Parsons
* Michael Zappa
* Milas Bowman
* lengrongfu
* ningmingxiao
* yanggang
* zounengren
* Aditya Ramani
* Adrian Reber
* Amir M. Ghazanfari
* Artem Khramov
* Brad Davidson
* Chen Yiyang
* Chongyi Zheng
* Christian Muehlhaeuser
* Djordje Lukic
* Edgar Lee
* Eric Lin
* Ethan Lowman
* Jiang Liu
* June Rhodes
* Kern Walster
* Lei Jitang
* Lucas Rattz
* Mahamed Ali
* Maksim An
* Michael Crosby
* Peteris Rudzusiks
* Ray Burgemeestre
* Sam Edwards
* Samruddhi Khandale
* Sascha Grunert
* Steve Griffith
* Tony Fang
* Tõnis Tiigi
* VERNOU Cédric
* Vishal Reddy Gurrala
* Xiaojin Zhang
* Yang Yang
* hang.jiang
* harshitasao
* jerryzhuang
* roman-kiselenko
* zhanluxianshen
* Aaron Lehmann
* AbdelrahmanElawady
* Adrien Delorme
* Alex Couture-Beil
* Alex Ellis
* Alex Rodriguez
* Angelos Kolaitis
* Antonio Huete Jimenez
* Antonio Ojea
* Antti Kervinen
* Arash Haghighat
* Arkin Modi
* Ben Foster
* Benjamin Peterson
* Bin Tang
* Bin Xin
* BinBin He
* Brennan Kinney
* Changqing Li
* ChengenH
* ChengyuZhu6
* Christian Stewart
* Colin O'Dell
* Craig Ingram
* Daisy Rong
* David Porter
* David Son
* Derek Nola
* Eng Zer Jun
* Erikson Tung
* Fabiano Fidêncio
* Fahed Dorgaa
* Gabriela Cervantes
* Gary McDonald
* Iain Macdonald
* James Lakin
* Jan Dubois
* Jaroslav Jindrak
* Javier Maestro
* Jian Wang
* Jiongchi Yu
* Julien Balestra
* Kir Kolyshkin
* Kirill A. Korinsky
* Konstantin Khlebnikov
* Lei Liu
* Matteo Pulcini
* Mauri de Souza Meneguzzo
* Mike Baynton
* Niklas Gehlen
* Pan Yibo
* Paul Meyer
* Qasim Sarfraz
* Qiutong Song
* Reinhard Tartler
* Robbie Buxton
* Robert-André Mauchin
* Ruihua Wen
* Saket Jajoo
* Sameer
* Shengjing Zhu
* Shiming Zhang
* Shukui Yang
* StepSecurity Bot
* Talon
* Tariq Ibrahim
* Tianon Gravi
* Tim Hockin
* TinaMor
* Tobias Klauser
* Tomáš Virtus
* Wang Xinwen
* William Chen
* Xinyang Ge
* Yibo Zhuang
* Yuhang Wei
* Yury Gargay
* Zechun Chen
* Zhang Tianyang
* Zoe
* baijia
* bo.jiang
* bzsuni
* charles-chenzz
* chschumacher1994
* cormick
* guangli.bao
* guangwu
* jinda.ljd
* jingtao.liang
* krglosse
* pigletfly
* rokkiter
* wangxiang
* zhangpeng
* zhaojizhuang
* 吴小白
* 张钰
* 沈陵
* 谭九鼎

### Dependency Changes

* **dario.cat/mergo**                                                              v1.0.1 **_new_**
* **github.com/AdaLogics/go-fuzz-headers**                                         1f10f66a31bf -> e8a1dd7889d6
* **github.com/AdamKorcz/go-118-fuzz-build**                                       5330a85ea652 -> 2b5cbb29f3e2
* **github.com/Microsoft/go-winio**                                                v0.6.0 -> v0.6.2
* **github.com/Microsoft/hcsshim**                                                 v0.10.0-rc.7 -> v0.12.9
* **github.com/cenkalti/backoff/v4**                                               v4.2.0 -> v4.3.0
* **github.com/cespare/xxhash/v2**                                                 v2.2.0 -> v2.3.0
* **github.com/checkpoint-restore/checkpointctl**                                  v1.3.0 **_new_**
* **github.com/checkpoint-restore/go-criu/v7**                                     v7.2.0 **_new_**
* **github.com/cilium/ebpf**                                                       v0.9.1 -> v0.11.0
* **github.com/containerd/cgroups/v3**                                             v3.0.1 -> v3.0.3
* **github.com/containerd/console**                                                v1.0.3 -> v1.0.4
* **github.com/containerd/containerd/api**                                         v1.8.0 **_new_**
* **github.com/containerd/continuity**                                             v0.3.0 -> v0.4.4
* **github.com/containerd/errdefs**                                                v1.0.0 **_new_**
* **github.com/containerd/errdefs/pkg**                                            v0.3.0 **_new_**
* **github.com/containerd/go-cni**                                                 v1.1.9 -> v1.1.10
* **github.com/containerd/go-runc**                                                v1.0.0 -> v1.1.0
* **github.com/containerd/imgcrypt/v2**                                            v2.0.0-rc.1 **_new_**
* **github.com/containerd/log**                                                    v0.1.0 **_new_**
* **github.com/containerd/nri**                                                    v0.3.0 -> v0.7.0
* **github.com/containerd/otelttrpc**                                              ea5083fda723 **_new_**
* **github.com/containerd/platforms**                                              v1.0.0-rc.0 **_new_**
* **github.com/containerd/plugin**                                                 v1.0.0 **_new_**
* **github.com/containerd/ttrpc**                                                  v1.2.1 -> v1.2.6
* **github.com/containerd/typeurl/v2**                                             v2.1.0 -> v2.2.0
* **github.com/containerd/zfs/v2**                                                 v2.0.0-rc.0 **_new_**
* **github.com/containernetworking/cni**                                           v1.1.2 -> v1.2.3
* **github.com/containernetworking/plugins**                                       v1.2.0 -> v1.5.1
* **github.com/containers/ocicrypt**                                               v1.1.6 -> v1.2.0
* **github.com/cpuguy83/go-md2man/v2**                                             v2.0.2 -> v2.0.5
* **github.com/davecgh/go-spew**                                                   v1.1.1 -> d8f796af33cc
* **github.com/distribution/reference**                                            v0.6.0 **_new_**
* **github.com/emicklei/go-restful/v3**                                            v3.10.1 -> v3.11.0
* **github.com/felixge/httpsnoop**                                                 v1.0.4 **_new_**
* **github.com/fsnotify/fsnotify**                                                 v1.6.0 -> v1.7.0
* **github.com/fxamacker/cbor/v2**                                                 v2.7.0 **_new_**
* **github.com/go-jose/go-jose/v4**                                                v4.0.4 **_new_**
* **github.com/go-logr/logr**                                                      v1.2.3 -> v1.4.2
* **github.com/golang/protobuf**                                                   v1.5.2 -> v1.5.4
* **github.com/google/go-cmp**                                                     v0.5.9 -> v0.6.0
* **github.com/google/uuid**                                                       v1.3.0 -> v1.6.0
* **github.com/gorilla/websocket**                                                 v1.5.0 **_new_**
* **github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus**            v1.0.1 **_new_**
* **github.com/grpc-ecosystem/go-grpc-middleware/v2**                              v2.1.0 **_new_**
* **github.com/grpc-ecosystem/grpc-gateway/v2**                                    v2.7.0 -> v2.22.0
* **github.com/intel/goresctrl**                                                   v0.3.0 -> v0.8.0
* **github.com/klauspost/compress**                                                v1.16.0 -> v1.17.11
* **github.com/mdlayher/socket**                                                   v0.4.1 **_new_**
* **github.com/mdlayher/vsock**                                                    v1.2.1 **_new_**
* **github.com/mistifyio/go-zfs/v3**                                               v3.0.1 **_new_**
* **github.com/moby/spdystream**                                                   v0.2.0 -> v0.4.0
* **github.com/moby/sys/mountinfo**                                                v0.6.2 -> v0.7.2
* **github.com/moby/sys/sequential**                                               v0.5.0 -> v0.6.0
* **github.com/moby/sys/signal**                                                   v0.7.0 -> v0.7.1
* **github.com/moby/sys/symlink**                                                  v0.2.0 -> v0.3.0
* **github.com/moby/sys/user**                                                     v0.3.0 **_new_**
* **github.com/moby/sys/userns**                                                   v0.1.0 **_new_**
* **github.com/munnerz/goautoneg**                                                 a7dc8b61c822 **_new_**
* **github.com/mxk/go-flowrate**                                                   cca7078d478f **_new_**
* **github.com/opencontainers/image-spec**                                         3a7f492d3f1b -> v1.1.0
* **github.com/opencontainers/runtime-spec**                                       v1.1.0-rc.1 -> v1.2.0
* **github.com/opencontainers/runtime-tools**                                      946c877fa809 -> 2e043c6bd626
* **github.com/opencontainers/selinux**                                            v1.11.0 -> v1.11.1
* **github.com/pelletier/go-toml/v2**                                              v2.2.3 **_new_**
* **github.com/pmezard/go-difflib**                                                v1.0.0 -> 5d4384ee4fb2
* **github.com/prometheus/client_golang**                                          v1.14.0 -> v1.20.5
* **github.com/prometheus/client_model**                                           v0.3.0 -> v0.6.1
* **github.com/prometheus/common**                                                 v0.37.0 -> v0.55.0
* **github.com/prometheus/procfs**                                                 v0.8.0 -> v0.15.1
* **github.com/sirupsen/logrus**                                                   v1.9.0 -> v1.9.3
* **github.com/stefanberger/go-pkcs11uri**                                         78d3cae3a980 -> 78284954bff6
* **github.com/stretchr/testify**                                                  v1.8.2 -> v1.9.0
* **github.com/urfave/cli/v2**                                                     v2.27.5 **_new_**
* **github.com/vishvananda/netlink**                                               v1.2.1-beta.2 -> v1.3.0
* **github.com/vishvananda/netns**                                                 2eb08e3e575f -> v0.0.4
* **github.com/x448/float16**                                                      v0.8.4 **_new_**
* **github.com/xrash/smetrics**                                                    686a1a2994c1 **_new_**
* **go.etcd.io/bbolt**                                                             v1.3.7 -> v1.3.11
* **go.mozilla.org/pkcs7**                                                         432b2356ecb1 -> v0.9.0
* **go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc**  v0.40.0 -> v0.56.0
* **go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp**                v0.56.0 **_new_**
* **go.opentelemetry.io/otel**                                                     v1.14.0 -> v1.31.0
* **go.opentelemetry.io/otel/exporters/otlp/otlptrace**                            v1.14.0 -> v1.31.0
* **go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc**              v1.14.0 -> v1.31.0
* **go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp**              v1.14.0 -> v1.31.0
* **go.opentelemetry.io/otel/metric**                                              v0.37.0 -> v1.31.0
* **go.opentelemetry.io/otel/sdk**                                                 v1.14.0 -> v1.31.0
* **go.opentelemetry.io/otel/trace**                                               v1.14.0 -> v1.31.0
* **go.opentelemetry.io/proto/otlp**                                               v0.19.0 -> v1.3.1
* **golang.org/x/crypto**                                                          v0.1.0 -> v0.28.0
* **golang.org/x/exp**                                                             aacd6d4b4611 **_new_**
* **golang.org/x/mod**                                                             v0.7.0 -> v0.21.0
* **golang.org/x/net**                                                             v0.7.0 -> v0.30.0
* **golang.org/x/oauth2**                                                          v0.4.0 -> v0.22.0
* **golang.org/x/sync**                                                            v0.1.0 -> v0.8.0
* **golang.org/x/sys**                                                             v0.6.0 -> v0.26.0
* **golang.org/x/term**                                                            v0.5.0 -> v0.25.0
* **golang.org/x/text**                                                            v0.7.0 -> v0.19.0
* **golang.org/x/time**                                                            90d013bbcef8 -> v0.3.0
* **google.golang.org/genproto/googleapis/api**                                    5fefd90f89a9 **_new_**
* **google.golang.org/genproto/googleapis/rpc**                                    324edc3d5d38 **_new_**
* **google.golang.org/grpc**                                                       v1.53.0 -> v1.67.1
* **google.golang.org/protobuf**                                                   v1.28.1 -> v1.35.1
* **k8s.io/api**                                                                   v0.26.2 -> v0.31.1
* **k8s.io/apimachinery**                                                          v0.26.2 -> v0.31.1
* **k8s.io/apiserver**                                                             v0.26.2 -> v0.31.1
* **k8s.io/client-go**                                                             v0.26.2 -> v0.31.1
* **k8s.io/component-base**                                                        v0.26.2 -> v0.31.1
* **k8s.io/cri-api**                                                               v0.26.2 -> v0.32.0-alpha.0
* **k8s.io/klog/v2**                                                               v2.90.1 -> v2.130.1
* **k8s.io/kubelet**                                                               v0.31.1 **_new_**
* **k8s.io/utils**                                                                 a5ecb0141aa5 -> 18e509b52bc8
* **sigs.k8s.io/json**                                                             f223a00ba0e2 -> bc3834ca7abd
* **sigs.k8s.io/structured-merge-diff/v4**                                         v4.2.3 -> v4.4.1
* **sigs.k8s.io/yaml**                                                             v1.3.0 -> v1.4.0
* **tags.cncf.io/container-device-interface**                                      v0.8.0 **_new_**
* **tags.cncf.io/container-device-interface/specs-go**                             v0.8.0 **_new_**

Previous release can be found at [v1.7.0](https://github.com/containerd/containerd/releases/tag/v1.7.0)
### Which file should I download?
* `containerd-<VERSION>-<OS>-<ARCH>.tar.gz`:         ✅Recommended. Dynamically linked with glibc 2.31 (Ubuntu 20.04).
* `containerd-static-<VERSION>-<OS>-<ARCH>.tar.gz`:  Statically linked. Expected to be used on non-glibc Linux distributions. Not position-independent.

In addition to containerd, typically you will have to install [runc](https://github.com/opencontainers/runc/releases)
and [CNI plugins](https://github.com/containernetworking/plugins/releases) from their official sites too.

See also the [Getting Started](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) documentation.
</details>
