### PR TITLE
Make ovl idmap mounts read-only

### DIFF
--- a/plugins/snapshots/overlay/overlayutils/check.go
+++ b/plugins/snapshots/overlay/overlayutils/check.go
@@ -261,7 +261,8 @@ func SupportsIDMappedMounts() (bool, error) {
 	}
 	defer usernsFd.Close()
 
-	if err = mount.IDMapMount(lowerDir, lowerDir, int(usernsFd.Fd())); err != nil {
+	// MOUNT_ATTR_RDONLY to replicate our actual construction of overlayfs
+	if err = mount.IDMapMountWithAttrs(lowerDir, lowerDir, int(usernsFd.Fd()), unix.MOUNT_ATTR_RDONLY, 0); err != nil {
 		return false, fmt.Errorf("failed to remap lowerdir %s: %w", lowerDir, err)
 	}
 	defer func() {


### PR DESCRIPTION
This is an additional safeguard against inadvertent data modification or deletion as a follow-up from #10721.

Tests covering the lifecycle of the temporary idmap mounts and integrity of the underlying lower layer data is also included in the normal and failed-unmount case.

Fixes #10704

From the discussion in #10721 I had three goals:
 * @fuweid's request to add the read-only flag to the temporary mounts by adjusting `IdMapMount`'s signature to accept mount options.
 * Add tests
 * One way to simplify the logic determining the path to remove during cleanup, we already have the path to remove so no need to use `filepath.Dir` / `filepath.Join` on a particular layer's path. Not sure if this is exactly what @AkihiroSuda had in mind with [comment](https://github.com/containerd/containerd/pull/10721/files/30f28933513e62a3243b88420e00af0e1b912b13#r1775341750)