### PR TITLE
[release/1.7 backport] testutil: avoid conflict with continuity/testutil

### DIFF
--- a/pkg/testutil/helpers.go
+++ b/pkg/testutil/helpers.go
@@ -33,7 +33,17 @@ const umountflags int = 0
 var rootEnabled bool
 
 func init() {
-	flag.BoolVar(&rootEnabled, "test.root", false, "enable tests that require root")
+	if flag.Lookup("test.root") == nil {
+		flag.BoolVar(&rootEnabled, "test.root", false, "enable tests that require root")
+	} else {
+		// The flag is already registered by continuity/testutil
+		for _, f := range os.Args {
+			if f == "-test.root" || f == "-test.root=true" {
+				rootEnabled = true
+				break
+			}
+		}
+	}
 }
 
 // DumpDir prints the contents of the directory to the testing logger.


### PR DESCRIPTION
Backports fix #10901 to release 1.7.

Currently any upstream consumers importing libraries both containerd 1.7 and the newest continuity (v0.4.4) will experience the same issue, so without this fix an upgrade is impossible.