### PR TITLE
content: optimize writer and commit

### DIFF
--- a/plugins/content/local/store.go
+++ b/plugins/content/local/store.go
@@ -383,6 +383,26 @@ func (s *store) WalkStatusRefs(ctx context.Context, fn func(string) error) error
 
 // status works like stat above except uses the path to the ingest.
 func (s *store) status(ingestPath string) (content.Status, error) {
+	refp := filepath.Join(ingestPath, "ref")
+	ref, err := readFileString(refp)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return content.Status{}, errdefs.ErrNotFound.WithMessage(fmt.Sprintf("ingest path %s not found", ingestPath))
+		}
+		return content.Status{}, fmt.Errorf("could not read ingest ref %s: %w", refp, err)
+	}
+
+	reffi, err := os.Stat(refp)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return content.Status{}, errdefs.ErrNotFound.WithMessage(fmt.Sprintf("ingest path %s not found", ingestPath))
+		}
+
+		return content.Status{}, fmt.Errorf("could not stat ingest ref %s: %w", ingestPath, err)
+	}
+
+	startedAt := reffi.ModTime() // use modtime of ingest directory for startedAt time.
+
 	dp := filepath.Join(ingestPath, "data")
 	fi, err := os.Stat(dp)
 	if err != nil {
@@ -392,29 +412,7 @@ func (s *store) status(ingestPath string) (content.Status, error) {
 		return content.Status{}, err
 	}
 
-	ref, err := readFileString(filepath.Join(ingestPath, "ref"))
-	if err != nil {
-		if os.IsNotExist(err) {
-			err = fmt.Errorf("%s: %w", err.Error(), errdefs.ErrNotFound)
-		}
-		return content.Status{}, err
-	}
-
-	startedAt, err := readFileTimestamp(filepath.Join(ingestPath, "startedat"))
-	if err != nil {
-		return content.Status{}, fmt.Errorf("could not read startedat: %w", err)
-	}
-
-	updatedAt, err := readFileTimestamp(filepath.Join(ingestPath, "updatedat"))
-	if err != nil {
-		return content.Status{}, fmt.Errorf("could not read updatedat: %w", err)
-	}
-
-	// because we don't write updatedat on every write, the mod time may
-	// actually be more up to date.
-	if fi.ModTime().After(updatedAt) {
-		updatedAt = fi.ModTime()
-	}
+	updatedAt := fi.ModTime() // use modtime of data file for updatedAt time.
 
 	return content.Status{
 		Ref:       ref,
@@ -547,7 +545,7 @@ func (s *store) writer(ctx context.Context, ref string, total int64, expected di
 	}
 
 	// ensure that the ingest path has been created.
-	if err := os.Mkdir(path, 0755); err != nil {
+	if err := os.Mkdir(path, 0o755); err != nil {
 		if !os.IsExist(err) {
 			return nil, err
 		}
@@ -569,33 +567,20 @@ func (s *store) writer(ctx context.Context, ref string, total int64, expected di
 
 		// the ingest is new, we need to setup the target location.
 		// write the ref to a file for later use
-		if err := os.WriteFile(refp, []byte(ref), 0666); err != nil {
-			return nil, err
-		}
-
-		if err := writeTimestampFile(filepath.Join(path, "startedat"), startedAt); err != nil {
-			return nil, err
-		}
-
-		if err := writeTimestampFile(filepath.Join(path, "updatedat"), startedAt); err != nil {
+		if err := os.WriteFile(refp, []byte(ref), 0o666); err != nil {
 			return nil, err
 		}
 
 		if total > 0 {
-			if err := os.WriteFile(filepath.Join(path, "total"), []byte(fmt.Sprint(total)), 0666); err != nil {
+			if err := os.WriteFile(filepath.Join(path, "total"), []byte(fmt.Sprint(total)), 0o666); err != nil {
 				return nil, err
 			}
 		}
 	}
 
-	fp, err := os.OpenFile(data, os.O_WRONLY|os.O_CREATE, 0666)
+	fp, err := os.OpenFile(data, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o666)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open data file: %w", err)
-	}
-
-	if _, err := fp.Seek(offset, io.SeekStart); err != nil {
-		fp.Close()
-		return nil, fmt.Errorf("could not seek to current write offset: %w", err)
 	}
 
 	return &writer{
@@ -657,54 +642,10 @@ func (s *store) ingestPaths(ref string) (string, string, string) {
 }
 
 func (s *store) ensureIngestRoot() error {
-	return os.MkdirAll(filepath.Join(s.root, "ingest"), 0777)
+	return os.MkdirAll(filepath.Join(s.root, "ingest"), 0o777)
 }
 
 func readFileString(path string) (string, error) {
 	p, err := os.ReadFile(path)
 	return string(p), err
-}
-
-// readFileTimestamp reads a file with just a timestamp present.
-func readFileTimestamp(p string) (time.Time, error) {
-	b, err := os.ReadFile(p)
-	if err != nil {
-		if os.IsNotExist(err) {
-			err = fmt.Errorf("%s: %w", err.Error(), errdefs.ErrNotFound)
-		}
-		return time.Time{}, err
-	}
-
-	var t time.Time
-	if err := t.UnmarshalText(b); err != nil {
-		return time.Time{}, fmt.Errorf("could not parse timestamp file %v: %w", p, err)
-	}
-
-	return t, nil
-}
-
-func writeTimestampFile(p string, t time.Time) error {
-	b, err := t.MarshalText()
-	if err != nil {
-		return err
-	}
-	return writeToCompletion(p, b, 0666)
-}
-
-func writeToCompletion(path string, data []byte, mode os.FileMode) error {
-	tmp := fmt.Sprintf("%s.tmp", path)
-	f, err := os.OpenFile(tmp, os.O_RDWR|os.O_CREATE|os.O_TRUNC|os.O_SYNC, mode)
-	if err != nil {
-		return fmt.Errorf("create tmp file: %w", err)
-	}
-	_, err = f.Write(data)
-	f.Close()
-	if err != nil {
-		return fmt.Errorf("write tmp file: %w", err)
-	}
-	err = os.Rename(tmp, path)
-	if err != nil {
-		return fmt.Errorf("rename tmp file: %w", err)
-	}
-	return nil
 }

--- a/plugins/content/local/store_test.go
+++ b/plugins/content/local/store_test.go
@@ -206,7 +206,6 @@ func TestContentWriter(t *testing.T) {
 	if !ok || err != nil {
 		t.Fatal(err)
 	}
-
 }
 
 func TestWalkBlobs(t *testing.T) {
@@ -333,7 +332,7 @@ func checkBlobPath(t *testing.T, cs content.Store, dgst digest.Digest) string {
 
 	if runtime.GOOS != "windows" {
 		// ensure that only read bits are set.
-		if ((fi.Mode() & os.ModePerm) & 0333) != 0 {
+		if ((fi.Mode() & os.ModePerm) & 0o333) != 0 {
 			t.Fatalf("incorrect permissions: %v", fi.Mode())
 		}
 	}
@@ -383,21 +382,4 @@ func setupIncompleteWrite(ctx context.Context, t *testing.T, cs content.Store, r
 	assert.NoError(t, err)
 
 	assert.Nil(t, writer.Close())
-}
-
-func TestWriteReadEmptyFileTimestamp(t *testing.T) {
-	root := t.TempDir()
-
-	emptyFile := filepath.Join(root, "updatedat")
-	if err := writeTimestampFile(emptyFile, time.Time{}); err != nil {
-		t.Errorf("failed to write Zero Time to file: %v", err)
-	}
-
-	timestamp, err := readFileTimestamp(emptyFile)
-	if err != nil {
-		t.Errorf("read empty timestamp file should success, but got error: %v", err)
-	}
-	if !timestamp.IsZero() {
-		t.Errorf("read empty timestamp file should return time.Time{}, but got: %v", timestamp)
-	}
 }

--- a/plugins/content/local/writer.go
+++ b/plugins/content/local/writer.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"syscall"
 	"time"
 
 	"github.com/containerd/errdefs"
@@ -76,7 +77,7 @@ func (w *writer) Write(p []byte) (n int, err error) {
 	return n, err
 }
 
-func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest, opts ...content.Opt) error {
+func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest, opts ...content.Opt) (rerr error) {
 	// Ensure even on error the writer is fully closed
 	defer w.s.unlock(w.ref)
 
@@ -86,6 +87,11 @@ func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest,
 			return err
 		}
 	}
+	defer func() {
+		if err := w.removeAll(); err != nil {
+			log.G(ctx).WithField("ref", w.ref).WithField("path", w.path).Error("failed to remove ingest directory")
+		}
+	}()
 
 	fp := w.fp
 	w.fp = nil
@@ -93,19 +99,20 @@ func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest,
 	if fp == nil {
 		return fmt.Errorf("cannot commit on closed writer: %w", errdefs.ErrFailedPrecondition)
 	}
+	defer func() {
+		// always close the file but only return the error if there isn't one already.
+		if err := fp.Close(); rerr == nil && err != nil {
+			rerr = fmt.Errorf("failed to close ingest file: %w", err)
+		}
+	}()
 
 	if err := fp.Sync(); err != nil {
-		fp.Close()
 		return fmt.Errorf("sync failed: %w", err)
 	}
 
 	fi, err := fp.Stat()
-	closeErr := fp.Close()
 	if err != nil {
 		return fmt.Errorf("stat on ingest file failed: %w", err)
-	}
-	if closeErr != nil {
-		return fmt.Errorf("failed to close ingest file: %w", closeErr)
 	}
 
 	if size > 0 && size != fi.Size() {
@@ -123,15 +130,12 @@ func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest,
 	)
 
 	// make sure parent directories of blob exist
-	if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 		return err
 	}
 
 	if _, err := os.Stat(target); err == nil {
 		// collision with the target file!
-		if err := os.RemoveAll(w.path); err != nil {
-			log.G(ctx).WithField("ref", w.ref).WithField("path", w.path).Error("failed to remove ingest directory")
-		}
 		return fmt.Errorf("content %v: %w", dgst, errdefs.ErrAlreadyExists)
 	}
 
@@ -140,7 +144,6 @@ func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest,
 	}
 
 	// Enable content blob integrity verification if supported
-
 	if w.s.integritySupported {
 		if err := fsverity.Enable(target); err != nil {
 			log.G(ctx).Warnf("failed to enable integrity for blob %v: %s", target, err.Error())
@@ -154,11 +157,6 @@ func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest,
 	commitTime := time.Now()
 	if err := os.Chtimes(target, commitTime, commitTime); err != nil {
 		log.G(ctx).WithField("digest", dgst).Error("failed to change file time to commit time")
-	}
-
-	// clean up!!
-	if err := os.RemoveAll(w.path); err != nil {
-		log.G(ctx).WithField("ref", w.ref).WithField("path", w.path).Error("failed to remove ingest directory")
 	}
 
 	if w.s.ls != nil && base.Labels != nil {
@@ -175,7 +173,7 @@ func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest,
 	//
 	// NOTE: Windows does not support this operation
 	if runtime.GOOS != "windows" {
-		if err := os.Chmod(target, (fi.Mode()&os.ModePerm)&^0333); err != nil {
+		if err := os.Chmod(target, (fi.Mode()&os.ModePerm)&^0o333); err != nil {
 			log.G(ctx).WithField("ref", w.ref).Error("failed to make readonly")
 		}
 	}
@@ -196,7 +194,6 @@ func (w *writer) Close() (err error) {
 	if w.fp != nil {
 		w.fp.Sync()
 		err = w.fp.Close()
-		writeTimestampFile(filepath.Join(w.path, "updatedat"), w.updatedAt)
 		w.fp = nil
 		w.s.unlock(w.ref)
 		return
@@ -223,4 +220,65 @@ func (w *writer) Sync() error {
 	}
 
 	return nil
+}
+
+// removeAll does a more efficient removal of the ingest directory, since we
+// don't have to be as defensive as os.RemoveAll.
+//
+// For example, we don't need to check if something is a directory or a file,
+// since we already know.
+//
+// If the logic fails somewhere, we fallback to os.RemoveAll.
+func (w *writer) removeAll() (rerr error) {
+	defer func() {
+		// fallback to os.RemoveAll if we encounter an error
+		if rerr != nil {
+			if err := os.RemoveAll(w.path); err != nil {
+				if os.IsNotExist(err) {
+					return
+				}
+				rerr = fmt.Errorf("failed to remove ingest directory %v: %w", w.path, err)
+			}
+		}
+	}()
+
+	for _, child := range []string{"data", "ref", "total"} {
+		path := filepath.Join(w.path, child)
+		if err := unlink(path); err != nil {
+			if os.IsNotExist(err) {
+				continue // not clear that this works for errno.
+			}
+
+			return fmt.Errorf("failed to remove ingest directory child %v: %w", path, err)
+		}
+	}
+
+	// remove the directory itself.
+	if err := rmdir(w.path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove ingest directory %v: %w", w.path, err)
+	}
+
+	return nil
+}
+
+// TODO(sjd): Need to move these to os specific implementations.
+
+func unlink(path string) error {
+	return ignoringEINTR(func() error { return syscall.Unlink(path) })
+}
+
+func rmdir(path string) error {
+	return ignoringEINTR(func() error { return syscall.Rmdir(path) })
+}
+
+// ignoringEINTR is a helper function to ignore EINTR errors, wrapping syscalls that may return them.
+//
+// According to os package, these functions are not guaranteed to be restarted on EINTR.
+func ignoringEINTR(fn func() error) error {
+	for {
+		err := fn()
+		if err != syscall.EINTR {
+			return err
+		}
+	}
 }


### PR DESCRIPTION
For small files, the performance of the content store is quite poor. For an empty content store, there is a 1-2ms to start a new ingest process and up to 8ms of latency for the commit. This is almost entirely dominated by syscalls to manage small files, such as those for timestamps and storing ref information.

This PR attempts to optimize the content store while preserving as much of the on disk format as possible and keeping backwards compatibility. This is done by removing unnecessary files, like the updatedat and startedat and opting for some tricks with ModTime on the leftover files. We also optimize the removal path to avoid the os.RemoveAll call that generates a large number of extra syscalls.

The result is about a 25% performance improvement for imports of large numbers of small files. More testing is required to make sure we have hit all correct points but we should be good. This PR is missing both testing and a benchmark to ensure we are making an improvement. I'm making this available early to gather feedback.

Putting together a todo list to get this into a mergeable shape:
- [ ] Post before and after pprof traces for a historical record
- [ ] Address test failures (lots of these are because we no longer write files)
- [ ] Confirm existing test coverage is adequite
- [ ] Add compatibility test case for old version of ingest layout