### PR TITLE
[release/1.7] ci: disable marking 1.7 releases as latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,4 +156,4 @@ jobs:
           body_path: ./builds/containerd-release-notes/release-notes.md
           files: |
             builds/release-tars-**/*
-          make_latest: true
+          make_latest: false


### PR DESCRIPTION
This change makes it so new tags of 1.7.x are not marked as latest over 2.0 releases.