### PR TITLE
[release/2.0] ci: enable marking 2.0 releases as latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
           body_path: ./builds/containerd-release-notes/release-notes.md
           files: |
             builds/release-tars-**/*
-          make_latest: false
+          make_latest: true
       - name: Attest Artifacts
         uses: actions/attest-build-provenance@1c608d11d69870c2092266b3f9a6f3abbf17002c # v1.4.3
         with:


### PR DESCRIPTION
This change makes it so 2.0 tags are marked as latest releases.