### PR TITLE
[release/1.7] backport: Disable vagrant strict dependency checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -575,7 +575,10 @@ jobs:
           echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
           sudo sed -i 's/^# deb-src/deb-src/' /etc/apt/sources.list
           sudo apt-get update
-          sudo apt-get install -y libvirt-daemon libvirt-daemon-system vagrant
+          # Pinned to 2.4.1-1 until https://github.com/hashicorp/vagrant/pull/13532 in released version
+          sudo apt-get install -y libvirt-daemon libvirt-daemon-system vagrant=2.4.1-1 ovmf
+          # https://github.com/vagrant-libvirt/vagrant-libvirt/issues/1725#issuecomment-1454058646
+          sudo cp /usr/share/OVMF/OVMF_VARS_4M.fd /var/lib/libvirt/qemu/nvram/
           sudo systemctl enable --now libvirtd
           sudo apt-get build-dep -y vagrant ruby-libvirt
           sudo apt-get install -y --no-install-recommends libxslt-dev libxml2-dev libvirt-dev ruby-bundler ruby-dev zlib1g-dev


### PR DESCRIPTION
Fixes broken vagrant builds

From #10950 
(cherry picked from commit ae73e30130811fba51716b9e70ea86cb0dd42193)