### PR TITLE
fsverity_test.go: fix nil pointer derefence, fix test fail, fix minor/major device numbers resolving

### DIFF
--- a/internal/fsverity/fsverity_test.go
+++ b/internal/fsverity/fsverity_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 
 	"github.com/containerd/containerd/v2/pkg/testutil"
+	"golang.org/x/sys/unix"
 )
 
 type superblockROFeatures struct {
@@ -143,8 +144,7 @@ func resolveDevicePath(path string) (_ string, e error) {
 	}
 
 	// resolve to device path
-	maj := (stat.Dev >> 8) & 0xff
-	min := stat.Dev & 0xff
+	major, minor := unix.Major(stat.Dev), unix.Minor(stat.Dev)
 
 	m, err := os.Open("/proc/self/mountinfo")
 	if err != nil {
@@ -162,7 +162,7 @@ func resolveDevicePath(path string) (_ string, e error) {
 	scanner := bufio.NewScanner(m)
 
 	var entry string
-	sub := fmt.Sprintf("%d:%d", maj, min)
+	sub := fmt.Sprintf("%d:%d", major, minor)
 	for scanner.Scan() {
 		if strings.Contains(scanner.Text(), sub) {
 			entry = scanner.Text()

--- a/internal/fsverity/fsverity_test.go
+++ b/internal/fsverity/fsverity_test.go
@@ -123,8 +123,8 @@ func TestIsEnabled(t *testing.T) {
 		t.Errorf("fsverity Enable failed: %s", err.Error())
 	}
 
-	if enabled, err := IsEnabled(verityFile); !enabled || err != nil {
-		t.Errorf("expected fsverity to be enabled on file, received enabled: %t; error: %s", enabled, err.Error())
+	if enabled, err := IsEnabled(verityFile); !enabled && err != nil {
+		t.Errorf("expected fsverity to be enabled on file, received enabled: %t; error: %v", enabled, err)
 	}
 }
 


### PR DESCRIPTION
1. Fix nil pointer dereference:

Nil pointer deference happens when `IsEnabled` returns `false, nil` and `err.Error()` is called on nil value.

2. Fix test fail

Currently test fails when `IsEnabled` returns `false, nil`, i don't think it's fine (plus it only happens on one architecture, `s390x`), so i changed it to only accept `false, err`, or this test should also report `false, nil`?

3. Fix minor/major device numbers resolving:

Taken from https://tip.golang.org/src/cmd/vendor/golang.org/x/sys/unix/dev_linux.go

Current formulas for resolving major/minor device numbers is incorrect, which leads to warnings like this:
```
=== RUN   TestEnable
    fsverity_test.go:51: invalid device: device mount not found for device id 3:0
--- SKIP: TestEnable (0.04s)
=== RUN   TestIsEnabled
--- PASS: TestIsEnabled (0.05s)
PASS
```
I also renamed variables a bit to fix conflict with built-in identifier `min`.

Tested on `x86_64` and `s390x` (virtual machine) architectures.

Should fix #10971 too.