### PR TITLE
[release/1.6] update build to go1.22.9, test go1.23.3

### DIFF
--- a/.github/actions/install-go/action.yml
+++ b/.github/actions/install-go/action.yml
@@ -3,7 +3,7 @@ description: "Reusable action to install Go, so there is one place to bump Go ve
 inputs:
   go-version:
     required: true
-    default: "1.22.8"
+    default: "1.22.9"
     description: "Go version to install"
 
 runs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, arm64-8core-32gb, macos-13, windows-2019, windows-2022]
-        go-version: ["1.22.8", "1.23.2"]
+        go-version: ["1.22.9", "1.23.3"]
         exclude:
           - os: ${{ github.repository != 'containerd/containerd' && 'arm64-8core-32gb' }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 name: Containerd Release
 
 env:
-  GO_VERSION: "1.22.8"
+  GO_VERSION: "1.22.9"
 
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -96,7 +96,7 @@ EOF
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.22.8",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.22.9",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -10,7 +10,7 @@
 #
 # docker build -t containerd-test --build-arg RUNC_VERSION=v1.0.0-rc94 -f Dockerfile.test ../
 
-ARG GOLANG_VERSION=1.22.8
+ARG GOLANG_VERSION=1.22.9
 ARG GOLANG_IMAGE=golang
 
 FROM ${GOLANG_IMAGE}:${GOLANG_VERSION} AS golang

--- a/script/setup/prepare_env_windows.ps1
+++ b/script/setup/prepare_env_windows.ps1
@@ -5,7 +5,7 @@
 # lived test environment.
 Set-MpPreference -DisableRealtimeMonitoring:$true
 
-$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.22.8"; make = ""; nssm = "" }
+$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.22.9"; make = ""; nssm = "" }
 
 Write-Host "Downloading chocolatey package"
 curl.exe -L "https://packages.chocolatey.org/chocolatey.0.10.15.nupkg" -o 'c:\choco.zip'


### PR DESCRIPTION
- go1.23.3 (released 2024-11-06) includes fixes to the linker, the runtime, and the net/http, os, and syscall packages. See the Go 1.23.3 milestone on our issue tracker for details.
  https://github.com/golang/go/issues?q=milestone%3AGo1.23.3+label%3ACherryPickApproved

- go1.22.9 (released 2024-11-06) includes fixes to the linker. See the Go 1.22.9 milestone on our issue tracker for details
  https://github.com/golang/go/issues?q=milestone%3AGo1.22.9+label%3ACherryPickApproved