### PR TITLE
fsverity_linux.go: Fix fsverity.IsEnabled() for big endian systems

### DIFF
--- a/internal/fsverity/fsverity_linux.go
+++ b/internal/fsverity/fsverity_linux.go
@@ -80,7 +80,7 @@ func IsEnabled(path string) (bool, error) {
 	}
 	defer f.Close()
 
-	var attr int
+	var attr int32
 
 	_, _, flagErr := unix.Syscall(syscall.SYS_IOCTL, f.Fd(), uintptr(unix.FS_IOC_GETFLAGS), uintptr(unsafe.Pointer(&attr)))
 	if flagErr != 0 {


### PR DESCRIPTION
I found out that `unix.Syscall(..., uintptr(unsafe.Pointer(&return_value)))` returns very big value.
If syscall returns `128` (not verity, just example) on other systems, it returns `549755813888` on `s390x`, so `fsverity.IsEnabled` is almost incorrect. Note that `128 << 32 == 549755813888`. 

This happens because `s390x` is Big Endian, whereas other ones are Little Endian.
One fix is to change `attr` variable type to `int32` , but this won't work if containerd is compiled against or used on system where C `int` is not 4 bytes wide.

This PR includes change of `attr` variable type to `int32`.