### PR TITLE
[release/2.0] bump github.com/containerd/typeurl/v2 from 2.2.2 to 2.2.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/containerd/platforms v1.0.0-rc.0
 	github.com/containerd/plugin v1.0.0
 	github.com/containerd/ttrpc v1.2.6
-	github.com/containerd/typeurl/v2 v2.2.2
+	github.com/containerd/typeurl/v2 v2.2.3
 	github.com/containerd/zfs/v2 v2.0.0-rc.0
 	github.com/containernetworking/cni v1.2.3
 	github.com/containernetworking/plugins v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -698,8 +698,8 @@ github.com/containerd/plugin v1.0.0/go.mod h1:hQfJe5nmWfImiqT1q8Si3jLv3ynMUIBB47
 github.com/containerd/ttrpc v1.2.2/go.mod h1:sIT6l32Ph/H9cvnJsfXM5drIVzTr5A2flTf1G5tYZak=
 github.com/containerd/ttrpc v1.2.6 h1:zG+Kn5EZ6MUYCS1t2Hmt2J4tMVaLSFEJVOraDQwNPC4=
 github.com/containerd/ttrpc v1.2.6/go.mod h1:YCXHsb32f+Sq5/72xHubdiJRQY9inL4a4ZQrAbN1q9o=
-github.com/containerd/typeurl/v2 v2.2.2 h1:3jN/k2ysKuPCsln5Qv8bzR9cxal8XjkxPogJfSNO31k=
-github.com/containerd/typeurl/v2 v2.2.2/go.mod h1:95ljDnPfD3bAbDJRugOiShd/DlAAsxGtUBhJxIn7SCk=
+github.com/containerd/typeurl/v2 v2.2.3 h1:yNA/94zxWdvYACdYO8zofhrTVuQY73fFU1y++dYSw40=
+github.com/containerd/typeurl/v2 v2.2.3/go.mod h1:95ljDnPfD3bAbDJRugOiShd/DlAAsxGtUBhJxIn7SCk=
 github.com/containerd/zfs/v2 v2.0.0-rc.0 h1:0dRlgpoaepW7HuovtcvYQMF7NlpceQVdn7+3Udeth4M=
 github.com/containerd/zfs/v2 v2.0.0-rc.0/go.mod h1:g36g/XCEGDRxUXIFdM3oWAEvmTvhfz/eKWElqg4Secw=
 github.com/containernetworking/cni v1.2.3 h1:hhOcjNVUQTnzdRJ6alC5XF+wd9mfGIUaj8FuJbEslXM=

--- a/vendor/github.com/containerd/typeurl/v2/types_gogo.go
+++ b/vendor/github.com/containerd/typeurl/v2/types_gogo.go
@@ -59,10 +59,10 @@ func (gogoHandler) TypeURL(v interface{}) string {
 	return gogoproto.MessageName(pm)
 }
 
-func (gogoHandler) GetType(url string) reflect.Type {
+func (gogoHandler) GetType(url string) (reflect.Type, bool) {
 	t := gogoproto.MessageType(url)
 	if t == nil {
-		return nil
+		return nil, false
 	}
-	return t.Elem()
+	return t.Elem(), true
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -194,7 +194,7 @@ github.com/containerd/plugin/registry
 # github.com/containerd/ttrpc v1.2.6
 ## explicit; go 1.19
 github.com/containerd/ttrpc
-# github.com/containerd/typeurl/v2 v2.2.2
+# github.com/containerd/typeurl/v2 v2.2.3
 ## explicit; go 1.21
 github.com/containerd/typeurl/v2
 # github.com/containerd/zfs/v2 v2.0.0-rc.0


### PR DESCRIPTION
Backport of #10992

Includes fix for unmarshaling of registered types

Bumps [github.com/containerd/typeurl/v2](https://github.com/containerd/typeurl) from 2.2.2 to 2.2.3.
- [Release notes](https://github.com/containerd/typeurl/releases)
- [Commits](https://github.com/containerd/typeurl/compare/v2.2.2...v2.2.3)



---
updated-dependencies:
- dependency-name: github.com/containerd/typeurl/v2 dependency-type: direct:production update-type: version-update:semver-patch ...


(cherry picked from commit 01c489141c37e27b71370ab26ab28347b17f4284)