### PR TITLE
[release/1.7] internal/cri: log ctr's exit event on info level

### DIFF
--- a/pkg/cri/sbserver/events.go
+++ b/pkg/cri/sbserver/events.go
@@ -127,7 +127,7 @@ func (em *eventMonitor) startSandboxExitMonitor(ctx context.Context, id string, 
 				ExitedAt:   protobuf.ToTimestamp(exitedAt),
 			}
 
-			logrus.Debugf("received exit event %+v", e)
+			logrus.Infof("received exit event %+v", e)
 
 			err = func() error {
 				dctx := ctrdutil.NamespacedContext()
@@ -178,7 +178,7 @@ func (em *eventMonitor) startContainerExitMonitor(ctx context.Context, id string
 				ExitedAt:    protobuf.ToTimestamp(exitedAt),
 			}
 
-			logrus.Debugf("received exit event %+v", e)
+			logrus.Infof("received exit event %+v", e)
 
 			err = func() error {
 				dctx := ctrdutil.NamespacedContext()

--- a/pkg/cri/server/events.go
+++ b/pkg/cri/server/events.go
@@ -129,7 +129,7 @@ func (em *eventMonitor) startSandboxExitMonitor(ctx context.Context, id string, 
 				ExitedAt:    protobuf.ToTimestamp(exitedAt),
 			}
 
-			logrus.Debugf("received exit event %+v", e)
+			logrus.Infof("received exit event %+v", e)
 
 			err = func() error {
 				dctx := ctrdutil.NamespacedContext()
@@ -180,7 +180,7 @@ func (em *eventMonitor) startContainerExitMonitor(ctx context.Context, id string
 				ExitedAt:    protobuf.ToTimestamp(exitedAt),
 			}
 
-			logrus.Debugf("received exit event %+v", e)
+			logrus.Infof("received exit event %+v", e)
 
 			err = func() error {
 				dctx := ctrdutil.NamespacedContext()


### PR DESCRIPTION
cherry pick from main , if container is exited log exited event is necessary.