### PR TITLE
Move content events to metadata

### DIFF
--- a/core/metadata/content.go
+++ b/core/metadata/content.go
@@ -25,6 +25,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	eventstypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	digest "github.com/opencontainers/go-digest"
@@ -209,7 +210,7 @@ func (cs *contentStore) Delete(ctx context.Context, dgst digest.Digest) error {
 	cs.l.RLock()
 	defer cs.l.RUnlock()
 
-	return update(ctx, cs.db, func(tx *bolt.Tx) error {
+	if err := update(ctx, cs.db, func(tx *bolt.Tx) error {
 		bkt := getBlobBucket(tx, ns, dgst)
 		if bkt == nil {
 			return fmt.Errorf("content digest %v: %w", dgst, errdefs.ErrNotFound)
@@ -227,7 +228,18 @@ func (cs *contentStore) Delete(ctx context.Context, dgst digest.Digest) error {
 		cs.db.dirtyCS = true
 
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+
+	if publisher := cs.db.Publisher(ctx); publisher != nil {
+		if err := publisher.Publish(ctx, "/content/delete", &eventstypes.ContentDelete{
+			Digest: dgst.String(),
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (cs *contentStore) ListStatuses(ctx context.Context, fs ...string) ([]content.Status, error) {


### PR DESCRIPTION
Other similar events were already moved to the metadata store. The metadata store has more information that can be used for a future content created event.

Will be needed to fully implement #10508