### PR TITLE
[release/1.7 backport] Fix retry logic and concurrency issue with http fallback

### DIFF
--- a/remotes/docker/config/hosts.go
+++ b/remotes/docker/config/hosts.go
@@ -254,7 +254,7 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
 			// the request twice or consuming the request body.
 			if host.scheme == "http" && explicitTLS {
 				_, port, _ := net.SplitHostPort(host.host)
-				if port != "" && port != "80" {
+				if port != "80" {
 					log.G(ctx).WithField("host", host.host).Info("host will try HTTPS first since it is configured for HTTP with a TLS configuration, consider changing host to HTTPS or removing unused TLS configuration")
 					host.scheme = "https"
 					rhosts[i].Client.Transport = docker.NewHTTPFallback(rhosts[i].Client.Transport)

--- a/remotes/docker/config/hosts_test.go
+++ b/remotes/docker/config/hosts_test.go
@@ -351,8 +351,8 @@ func TestHTTPFallback(t *testing.T) {
 					InsecureSkipVerify: true,
 				},
 			},
-			expectedScheme: "http",
-			usesFallback:   false,
+			expectedScheme: "https",
+			usesFallback:   true,
 		},
 		{
 			host: "localhost",
@@ -392,8 +392,8 @@ func TestHTTPFallback(t *testing.T) {
 					InsecureSkipVerify: true,
 				},
 			},
-			expectedScheme: "http",
-			usesFallback:   false,
+			expectedScheme: "https",
+			usesFallback:   true,
 		},
 		{
 			host: "example.com:5000",

--- a/remotes/docker/resolver.go
+++ b/remotes/docker/resolver.go
@@ -28,7 +28,6 @@ import (
 	"os"
 	"path"
 	"strings"
-	"syscall"
 
 	"github.com/containerd/log"
 	"github.com/opencontainers/go-digest"
@@ -768,7 +767,7 @@ func isTLSError(err error) bool {
 }
 
 func isPortError(err error, host string) bool {
-	if errors.Is(err, syscall.ECONNREFUSED) || os.IsTimeout(err) {
+	if isConnError(err) || os.IsTimeout(err) {
 		if _, port, _ := net.SplitHostPort(host); port != "" {
 			// Port is specified, will not retry on different port with scheme change
 			return false

--- a/remotes/docker/resolver_test.go
+++ b/remotes/docker/resolver_test.go
@@ -36,8 +36,8 @@ import (
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker/auth"
 	remoteerrors "github.com/containerd/containerd/remotes/errors"
-	digest "github.com/opencontainers/go-digest"
-	specs "github.com/opencontainers/image-spec/specs-go"
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -477,6 +477,34 @@ func TestHTTPFallbackTimeoutResolver(t *testing.T) {
 	}
 
 	runBasicTest(t, "testname", sf)
+}
+
+func TestHTTPFallbackPortError(t *testing.T) {
+	// This test only checks the isPortError since testing the whole http fallback would
+	// require listening on 80 and making sure nothing is listening on 443.
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	host := l.Addr().String()
+	err = l.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = net.Dial("tcp", host)
+	if err == nil {
+		t.Fatal("Dial should fail after close")
+	}
+
+	if isPortError(err, host) {
+		t.Fatalf("Expected no port error for %s with %v", host, err)
+	}
+	if !isPortError(err, "127.0.0.1") {
+		t.Fatalf("Expected port error for 127.0.0.1 with %v", err)
+	}
+
 }
 
 func TestResolveProxy(t *testing.T) {

--- a/remotes/docker/resolver_unix.go
+++ b/remotes/docker/resolver_unix.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package docker
+
+import (
+	"errors"
+	"syscall"
+)
+
+func isConnError(err error) bool {
+	return errors.Is(err, syscall.ECONNREFUSED)
+}

--- a/remotes/docker/resolver_windows.go
+++ b/remotes/docker/resolver_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package docker
+
+import (
+	"errors"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+func isConnError(err error) bool {
+	return errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, windows.WSAECONNREFUSED)
+}


### PR DESCRIPTION
- backport: https://github.com/containerd/containerd/pull/10286

### Allow fallback across default ports 
When no port is specified in host, allow falling back from 443 to 80 when http is specified along with a TLS configuration. This increases the cases when https can be preferred and fixes a case where fallback does not happen after a connection refused where previously Docker would have fallen back.

- backport: https://github.com/containerd/containerd/pull/10342
### Adds a mutex to protect fallback host 
Fixes an issue with race detector complaining about concurrent access such as with Dispatch on push.