### PR TITLE
isolate uts namespace for hostnetwork pods 

### DIFF
--- a/internal/cri/server/podsandbox/sandbox_run_linux.go
+++ b/internal/cri/server/podsandbox/sandbox_run_linux.go
@@ -75,7 +75,6 @@ func (c *Controller) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 	)
 	if nsOptions.GetNetwork() == runtime.NamespaceMode_NODE {
 		specOpts = append(specOpts, customopts.WithoutNamespace(runtimespec.NetworkNamespace))
-		specOpts = append(specOpts, customopts.WithoutNamespace(runtimespec.UTSNamespace))
 	} else {
 		specOpts = append(specOpts, oci.WithLinuxNamespace(
 			runtimespec.LinuxNamespace{

--- a/internal/cri/server/podsandbox/sandbox_run_linux_test.go
+++ b/internal/cri/server/podsandbox/sandbox_run_linux_test.go
@@ -211,7 +211,7 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 				assert.NotContains(t, spec.Linux.Namespaces, runtimespec.LinuxNamespace{
 					Type: runtimespec.NetworkNamespace,
 				})
-				assert.NotContains(t, spec.Linux.Namespaces, runtimespec.LinuxNamespace{
+				assert.Contains(t, spec.Linux.Namespaces, runtimespec.LinuxNamespace{
 					Type: runtimespec.UTSNamespace,
 				})
 				assert.NotContains(t, spec.Linux.Namespaces, runtimespec.LinuxNamespace{


### PR DESCRIPTION
For pods in host-network mode,  there's no specification whether pods should share uts namespace with host in kubernetes community. It's commonly believed that the namespaces of containers are isolated from host, and docker containers with hostnetwork mode indeed don't share uts namespace with host.  Thus this pr is proposed to change the default uts namespace mode for pods in host-network mode. 

I've searched for a while, but I did not find valuable notes about this, hoping someone can explain why pods in host network mode use host uts namespace as well.  