### PR TITLE
The task_dir successfully cleans when the file is absent.

### DIFF
--- a/cmd/containerd-shim-runc-v2/manager/manager_linux.go
+++ b/cmd/containerd-shim-runc-v2/manager/manager_linux.go
@@ -294,7 +294,7 @@ func (manager) Stop(ctx context.Context, id string) (shim.StopStatus, error) {
 		return shim.StopStatus{}, err
 	}
 	runtime, err := runc.ReadRuntime(path)
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		return shim.StopStatus{}, err
 	}
 	opts, err := runc.ReadOptions(path)


### PR DESCRIPTION
fix #11071