### PR TITLE
Publish attestation as release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,13 @@ jobs:
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           path: builds
+      - name: Attest Artifacts
+        id: attest
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4
+        with:
+          subject-path: ./builds/release-tars-**/*.tar.gz
+      - name: Rename attestation artifact
+        run: mv ${{ steps.attest.outputs.bundle-path }} containerd-${{ needs.check.outputs.stringver }}-attestation.intoto.jsonl
       - name: Create Release
         uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
         with:
@@ -158,8 +165,5 @@ jobs:
           body_path: ./builds/containerd-release-notes/release-notes.md
           files: |
             builds/release-tars-**/*
+            containerd-*-attestation.intoto.jsonl
           make_latest: false
-      - name: Attest Artifacts
-        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4
-        with:
-          subject-path: ./builds/release-tars-**/*.tar.gz


### PR DESCRIPTION
Followup to https://github.com/containerd/containerd/pull/10543#pullrequestreview-2261825978 to attest artifacts prior to creating the release. This also should address containerd project's signed releases action item in CNCF CLO monitor Reference: [containerd CLO monitor](https://clomonitor.io/projects/cncf/containerd), [scorecard checks doc](https://github.com/ossf/scorecard/blob/main/docs/checks.md#signed-releases)

This allows the attestation to be published with the release artifacts. The trade-off is if create release were to fail (potentially due to GitHub outage), then artifacts have already been attested and published to GitHub attestations. This should be an acceptable trade-off as maintainers with write access can manually upload the containerd tarballs to GitHub or roll forward release.

Tested in fork, see https://github.com/austinvazquez/containerd/actions/runs/12002403717