### PR TITLE
Move rockylinux 9.4 to almalinux/9 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,10 +556,10 @@ jobs:
           - box: almalinux/8
             cgroup_driver: systemd
             runc: runc
-          - box: rockylinux/9@4.0.0
+          - box: almalinux/9
             cgroup_driver: cgroupfs
             runc: runc
-          - box: rockylinux/9@4.0.0
+          - box: almalinux/9
             cgroup_driver: systemd
             runc: runc
     env:


### PR DESCRIPTION
Vagrant integration (rockylinux/9@4.0.0) CIs are failing because the box download URL link no longer works.

https://github.com/containerd/containerd/actions/runs/12002473354/job/33454590732

The link (https://vagrantcloud.com/rockylinux/boxes/9/versions/4.0.0/providers/libvirt/amd64/vagrant.box) redirects to (https://dl.rockylinux.org/pub/rocky/9.4/images/x86_64/Rocky-9-Vagrant-Libvirt-9.4-20240509.0.x86_64.box) which was moved to (https://dl.rockylinux.org/vault/rocky/9.4/images/x86_64/Rocky-9-Vagrant-Libvirt-9.4-20240509.0.x86_64.box)
(`dl.rockylinux.org/pub` -> `dl.rockylinux.org/vault`, similar to https://github.com/containerd/containerd/pull/10297).

https://github.com/containerd/containerd/pull/10304 changes rocky8.9 to almalinux/8,
similarly, this one changes rocky9.4 to almalinux/9.

cc @AkihiroSuda  @dmcgowan 