### PR TITLE
[release/2.0] Move rockylinux 9.4 to almalinux/9 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,10 +556,10 @@ jobs:
           - box: almalinux/8
             cgroup_driver: systemd
             runc: runc
-          - box: rockylinux/9@4.0.0
+          - box: almalinux/9
             cgroup_driver: cgroupfs
             runc: runc
-          - box: rockylinux/9@4.0.0
+          - box: almalinux/9
             cgroup_driver: systemd
             runc: runc
     env:


### PR DESCRIPTION
Cherry pick https://github.com/containerd/containerd/pull/11050

(cherry picked from commit 288001f68c5fd34cfbdc7284f14375a3762b8ff4)