### PR TITLE
[release/1.7] Move rockylinux 9.4 to almalinux/9 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -550,7 +550,7 @@ jobs:
           # as the former one no longer works:
           # https://github.com/containerd/containerd/pull/10297
           - almalinux/8
-          - rockylinux/9@4.0.0
+          - almalinux/9
     env:
       BOX: ${{ matrix.box }}
 


### PR DESCRIPTION
similar to https://github.com/containerd/containerd/pull/11050.

Since the current `ci.yml` has some refactor (matrix.box -> matrix.include.box|cgroup_driver|runc), the original commit cannot be cherry picked directly, so just made the change directly here.