### PR TITLE
[release/1.6] Add almalinux/9 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -529,6 +529,7 @@ jobs:
           # as the former one no longer works:
           # https://github.com/containerd/containerd/pull/10297
           - almalinux/8
+          - almalinux/9
     env:
       GOTEST: gotestsum --
       BOX: ${{ matrix.box }}


### PR DESCRIPTION
Similar to https://github.com/containerd/containerd/pull/11050.

The CI in 1.6 branch actually doesn't have rocky9, but since it's still being supported, we probably should add it (almalinux/9) to its CI.