### PR TITLE
Update differ to handle zstd media types

### DIFF
--- a/pkg/archive/compression/compression.go
+++ b/pkg/archive/compression/compression.go
@@ -45,6 +45,8 @@ const (
 	Gzip
 	// Zstd is zstd compression algorithm.
 	Zstd
+	// Unknown is used when a plugin handles the algorithm.
+	Unknown
 )
 
 const (
@@ -257,6 +259,8 @@ func (compression *Compression) Extension() string {
 		return "gz"
 	case Zstd:
 		return "zst"
+	case Unknown:
+		return "unknown"
 	}
 	return ""
 }


### PR DESCRIPTION
The differ should be able to generate zstd compressed layers when provided with the zstd media type.

Added the unknown compression type to handle cases when compression is done via a plugin but should be differentiated from no compression.