### PR TITLE
[release/1.7] Allow sections of Plugins to be merged, and not overwritten as entire sections

### DIFF
--- a/services/server/config/config.go
+++ b/services/server/config/config.go
@@ -303,10 +303,6 @@ func mergeConfig(to, from *Config) error {
 	}
 
 	// Replace entire sections instead of merging map's values.
-	for k, v := range from.Plugins {
-		to.Plugins[k] = v
-	}
-
 	for k, v := range from.StreamProcessors {
 		to.StreamProcessors[k] = v
 	}


### PR DESCRIPTION
This may be a little bit controversial for a backport, but I'm proposing it as it helps **a ton** the projects that are not yet switching to 2.0 (such as k3s, rke2, and even distro packages).

The backport was trivial, but I totally understand if folks consider this one too intrusive to get into the release-1.7 branch.