### PR TITLE
Fix panic due to nil dereference cgroups v2

### DIFF
--- a/cmd/containerd-shim-runc-v2/runc/container.go
+++ b/cmd/containerd-shim-runc-v2/runc/container.go
@@ -146,24 +146,9 @@ func NewContainer(ctx context.Context, platform stdio.Platform, r *task.CreateTa
 	}
 	pid := p.Pid()
 	if pid > 0 {
-		var cg interface{}
-		if cgroups.Mode() == cgroups.Unified {
-			g, err := cgroupsv2.PidGroupPath(pid)
-			if err != nil {
-				log.G(ctx).WithError(err).Errorf("loading cgroup2 for %d", pid)
-				return container, nil
-			}
-			cg, err = cgroupsv2.Load(g)
-			if err != nil {
-				log.G(ctx).WithError(err).Errorf("loading cgroup2 for %d", pid)
-			}
-		} else {
-			cg, err = cgroup1.Load(cgroup1.PidPath(pid))
-			if err != nil {
-				log.G(ctx).WithError(err).Errorf("loading cgroup for %d", pid)
-			}
+		if cg, err := loadProcessCgroup(ctx, pid); err == nil {
+			container.cgroup = cg
 		}
-		container.cgroup = cg
 	}
 	return container, nil
 }
@@ -367,23 +352,9 @@ func (c *Container) Start(ctx context.Context, r *task.StartRequest) (process.Pr
 		return p, err
 	}
 	if c.Cgroup() == nil && p.Pid() > 0 {
-		var cg interface{}
-		if cgroups.Mode() == cgroups.Unified {
-			g, err := cgroupsv2.PidGroupPath(p.Pid())
-			if err != nil {
-				log.G(ctx).WithError(err).Errorf("loading cgroup2 for %d", p.Pid())
-			}
-			cg, err = cgroupsv2.Load(g)
-			if err != nil {
-				log.G(ctx).WithError(err).Errorf("loading cgroup2 for %d", p.Pid())
-			}
-		} else {
-			cg, err = cgroup1.Load(cgroup1.PidPath(p.Pid()))
-			if err != nil {
-				log.G(ctx).WithError(err).Errorf("loading cgroup for %d", p.Pid())
-			}
+		if cg, err := loadProcessCgroup(ctx, p.Pid()); err == nil {
+			c.cgroup = cg
 		}
-		c.cgroup = cg
 	}
 	return p, nil
 }
@@ -511,4 +482,26 @@ func (c *Container) HasPid(pid int) bool {
 		}
 	}
 	return false
+}
+
+func loadProcessCgroup(ctx context.Context, pid int) (cg interface{}, err error) {
+	if cgroups.Mode() == cgroups.Unified {
+		g, err := cgroupsv2.PidGroupPath(pid)
+		if err != nil {
+			log.G(ctx).WithError(err).Errorf("loading cgroup2 for %d", pid)
+			return nil, err
+		}
+		cg, err = cgroupsv2.Load(g)
+		if err != nil {
+			log.G(ctx).WithError(err).Errorf("loading cgroup2 for %d", pid)
+			return nil, err
+		}
+	} else {
+		cg, err = cgroup1.Load(cgroup1.PidPath(pid))
+		if err != nil {
+			log.G(ctx).WithError(err).Errorf("loading cgroup for %d", pid)
+			return nil, err
+		}
+	}
+	return cg, nil
 }


### PR DESCRIPTION
Fix #11001

When the shim creates a container within `NewContainer`, the cgroups v1/v2 may be nil due to errors.

https://github.com/containerd/containerd/blob/566f9f48db6f6bc7dbd76d70aa425afbee7b0d0a/cmd/containerd-shim-runc-v2/runc/container.go#L149-L166

However, a `nil` pointer of `*cgroupsv2.Manager` type *is not* an `nil` interface{}. And it can be converted back to `*cgroupsv2.Manager` type (the resulted var will be `nil`) which causes nil deference panic in `Start` in the above issue. (sample: https://go.dev/play/p/ZThwvj1n3g8)

https://github.com/containerd/containerd/blob/566f9f48db6f6bc7dbd76d70aa425afbee7b0d0a/cmd/containerd-shim-runc-v2/task/service.go#L316-L317

The fix is to return directly on error (to avoid `container.cgroup = cg `), so the switch in `Start` will match neither `cgroup1.Cgroup` (interface) nor `*cgroupsv2.Manager`.