### PR TITLE
cri: check container status before execsync like exec

### DIFF
--- a/internal/cri/server/container_execsync.go
+++ b/internal/cri/server/container_execsync.go
@@ -73,6 +73,15 @@ func (cw *cappedWriter) isFull() bool {
 // ExecSync executes a command in the container, and returns the stdout output.
 // If command exits with a non-zero exit code, an error is returned.
 func (c *criService) ExecSync(ctx context.Context, r *runtime.ExecSyncRequest) (*runtime.ExecSyncResponse, error) {
+	cntr, err := c.containerStore.Get(r.GetContainerId())
+	if err != nil {
+		return nil, fmt.Errorf("failed to find container %q in store: %w", r.GetContainerId(), err)
+	}
+	state := cntr.Status.Get().State()
+	if state != runtime.ContainerState_CONTAINER_RUNNING {
+		return nil, fmt.Errorf("container is in %s state", criContainerStateToString(state))
+	}
+
 	const maxStreamSize = 1024 * 1024 * 16
 
 	var stdout, stderr bytes.Buffer


### PR DESCRIPTION
check container status before execsync if container is not running. It is not necessary to call shim exec. @dmcgowan  @AkihiroSuda  @mxpv 