### PR TITLE
Move content delete event to garbage collection

### DIFF
--- a/core/metadata/content.go
+++ b/core/metadata/content.go
@@ -231,14 +231,6 @@ func (cs *contentStore) Delete(ctx context.Context, dgst digest.Digest) error {
 	}); err != nil {
 		return err
 	}
-
-	if publisher := cs.db.Publisher(ctx); publisher != nil {
-		if err := publisher.Publish(ctx, "/content/delete", &eventstypes.ContentDelete{
-			Digest: dgst.String(),
-		}); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 
@@ -900,6 +892,13 @@ func (cs *contentStore) garbageCollect(ctx context.Context) (d time.Duration, er
 		if _, ok := contentSeen[info.Digest.String()]; !ok {
 			if err := cs.Store.Delete(ctx, info.Digest); err != nil {
 				return err
+			}
+			if publisher := cs.db.Publisher(ctx); publisher != nil {
+				if err := publisher.Publish(ctx, "/content/delete", &eventstypes.ContentDelete{
+					Digest: info.Digest.String(),
+				}); err != nil {
+					return err
+				}
 			}
 			log.G(ctx).WithField("digest", info.Digest).Debug("removed content")
 		}


### PR DESCRIPTION
Changes in #11013 moved the content delete event to the content metadata store. This meant the event would only be published when specific content was explicitly removed, but now when content was removed as part of an image delete event. As the actual delete function in the content store relies on the garbage collection logic to actually delete content it seems more appropriate to publish the event when the content is garbage collected.

Relates to #10508 