### PR TITLE
ctr pull should unpack for default platform when transfer service is used

### DIFF
--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -119,19 +119,20 @@ command. As part of this process, we do the following:
 			if err != nil {
 				return err
 			}
-
-			// Set unpack configuration
+			allPlatforms := cliContext.Bool("all-platforms")
+			if len(p) > 0 && allPlatforms {
+				return errors.New("cannot specify both --platform and --all-platforms")
+			}
+			if len(p) == 0 && !allPlatforms {
+				p = append(p, platforms.DefaultSpec())
+			}
+			// we use an empty `Platform` slice to indicate that we want to pull all platforms
+			sopts = append(sopts, image.WithPlatforms(p...))
+			// TODO: Support unpack for all platforms..?
+			// Pass in a *?
 			for _, platform := range p {
 				sopts = append(sopts, image.WithUnpack(platform, cliContext.String("snapshotter")))
 			}
-			if !cliContext.Bool("all-platforms") {
-				if len(p) == 0 {
-					p = append(p, platforms.DefaultSpec())
-				}
-				sopts = append(sopts, image.WithPlatforms(p...))
-			}
-			// TODO: Support unpack for all platforms..?
-			// Pass in a *?
 
 			if cliContext.Bool("metadata-only") {
 				sopts = append(sopts, image.WithAllMetadata)


### PR DESCRIPTION
Currently if neither `--all-platforms` nor `--platform` is specified in `ctr i pull`, it will pull using the default platform, but skip the unpack step (if using transfer service). However, we should apply the `default platform` to unpack as well.

```shell
# in main branch, no any snapshot is generated
containerd [main]  ➜ sudo ctr i pull --snapshotter=overlayfs docker.io/library/alpine:latest
...
containerd [main]  ➜ sudo ctr snapshot ls
KEY PARENT KIND
# with this fix, default platform is used for pull and unpack.
containerd [ctr-pull-transfer-service]  ➜ sudo ctr i pull --snapshotter=overlayfs docker.io/library/alpine:latest
...
containerd [ctr-pull-transfer-service]  ➜ sudo ctr snapshot ls
KEY                                                                     PARENT KIND
sha256:75654b8eeebd3beae97271a102f57cdeb794cc91e442648544963a7e951e9558        Committed
```