### PR TITLE
Add package.go to include makefiles when importing v2

### DIFF
--- a/package.go
+++ b/package.go
@@ -1,0 +1,17 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package containerd


### PR DESCRIPTION
When using Containerd dependencies within our project, we need to ensure our binaries match the libraries being used.

In the past we have built off of the `vendor` directory as the makefiles were helpfully included. This enabled us to build the binaries that were in line with our project's `go.mod` files.

In v2 of Containerd the `cmd/*` imports are separated from their makefiles, which results in a bit of a challenge for us.

By including the `package.go` file we can now vendor in all the resources we need to build binaries that match our `go.mod` version

A brief example below:

In a tools.go file local to the project:

```
package main

import (
	_ "github.com/containerd/containerd/v2/"
	_ "github.com/containerd/containerd/v2/cmd/containerd"
)
```

Followed by a bash script:

```
pushd vendor/github.com/containerd/containerd
  make ./bin/containerd
popd
```