### PR TITLE
[release/1.6] Fix panic due to nil dereference cgroups v2

### DIFF
--- a/runtime/v2/runc/container.go
+++ b/runtime/v2/runc/container.go
@@ -139,24 +139,9 @@ func NewContainer(ctx context.Context, platform stdio.Platform, r *task.CreateTa
 	}
 	pid := p.Pid()
 	if pid > 0 {
-		var cg interface{}
-		if cgroups.Mode() == cgroups.Unified {
-			g, err := cgroupsv2.PidGroupPath(pid)
-			if err != nil {
-				logrus.WithError(err).Errorf("loading cgroup2 for %d", pid)
-				return container, nil
-			}
-			cg, err = cgroupsv2.LoadManager("/sys/fs/cgroup", g)
-			if err != nil {
-				logrus.WithError(err).Errorf("loading cgroup2 for %d", pid)
-			}
-		} else {
-			cg, err = cgroups.Load(cgroups.V1, cgroups.PidPath(pid))
-			if err != nil {
-				logrus.WithError(err).Errorf("loading cgroup for %d", pid)
-			}
+		if cg, err := loadProcessCgroup(ctx, pid); err == nil {
+			container.cgroup = cg
 		}
-		container.cgroup = cg
 	}
 	return container, nil
 }
@@ -360,23 +345,9 @@ func (c *Container) Start(ctx context.Context, r *task.StartRequest) (process.Pr
 		return p, err
 	}
 	if c.Cgroup() == nil && p.Pid() > 0 {
-		var cg interface{}
-		if cgroups.Mode() == cgroups.Unified {
-			g, err := cgroupsv2.PidGroupPath(p.Pid())
-			if err != nil {
-				logrus.WithError(err).Errorf("loading cgroup2 for %d", p.Pid())
-			}
-			cg, err = cgroupsv2.LoadManager("/sys/fs/cgroup", g)
-			if err != nil {
-				logrus.WithError(err).Errorf("loading cgroup2 for %d", p.Pid())
-			}
-		} else {
-			cg, err = cgroups.Load(cgroups.V1, cgroups.PidPath(p.Pid()))
-			if err != nil {
-				logrus.WithError(err).Errorf("loading cgroup for %d", p.Pid())
-			}
+		if cg, err := loadProcessCgroup(ctx, p.Pid()); err == nil {
+			c.cgroup = cg
 		}
-		c.cgroup = cg
 	}
 	return p, nil
 }
@@ -505,4 +476,26 @@ func (c *Container) HasPid(pid int) bool {
 		}
 	}
 	return false
+}
+
+func loadProcessCgroup(_ context.Context, pid int) (cg interface{}, err error) {
+	if cgroups.Mode() == cgroups.Unified {
+		g, err := cgroupsv2.PidGroupPath(pid)
+		if err != nil {
+			logrus.WithError(err).Errorf("loading cgroup2 for %d", pid)
+			return nil, err
+		}
+		cg, err = cgroupsv2.LoadManager("/sys/fs/cgroup", g)
+		if err != nil {
+			logrus.WithError(err).Errorf("loading cgroup2 for %d", pid)
+			return nil, err
+		}
+	} else {
+		cg, err = cgroups.Load(cgroups.V1, cgroups.PidPath(pid))
+		if err != nil {
+			logrus.WithError(err).Errorf("loading cgroup for %d", pid)
+			return nil, err
+		}
+	}
+	return cg, nil
 }


### PR DESCRIPTION
This PR ports #11069 to release/1.6 (with minor modification due to that 1.6 uses logrus and containerd/cgroups v1.0.4).