### PR TITLE
Extend fsverity functionality to malicious corruption

### DIFF
--- a/cmd/containerd/builtins/builtins.go
+++ b/cmd/containerd/builtins/builtins.go
@@ -23,6 +23,7 @@ import (
 	_ "github.com/containerd/containerd/v2/plugins/events"
 	_ "github.com/containerd/containerd/v2/plugins/gc"
 	_ "github.com/containerd/containerd/v2/plugins/imageverifier"
+	_ "github.com/containerd/containerd/v2/plugins/integrityverifier"
 	_ "github.com/containerd/containerd/v2/plugins/leases"
 	_ "github.com/containerd/containerd/v2/plugins/metadata"
 	_ "github.com/containerd/containerd/v2/plugins/mount"

--- a/contrib/fuzz/archive_fuzz_test.go
+++ b/contrib/fuzz/archive_fuzz_test.go
@@ -129,7 +129,7 @@ func FuzzImportIndex(f *testing.F) {
 			}
 		}
 		tmpDir := t.TempDir()
-		cs, err := local.NewStore(tmpDir)
+		cs, err := local.NewStore(tmpDir, nil)
 		if err != nil {
 			return
 		}

--- a/contrib/fuzz/content_fuzz_test.go
+++ b/contrib/fuzz/content_fuzz_test.go
@@ -100,7 +100,7 @@ func FuzzCSWalk(f *testing.F) {
 		expected := map[digest.Digest]struct{}{}
 		found := map[digest.Digest]struct{}{}
 		tmpDir := t.TempDir()
-		cs, err := local.NewStore(tmpDir)
+		cs, err := local.NewStore(tmpDir, nil)
 		if err != nil {
 			return
 		}
@@ -140,7 +140,7 @@ func FuzzArchiveExport(f *testing.F) {
 		}
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		cs, err := local.NewStore(tmpDir)
+		cs, err := local.NewStore(tmpDir, nil)
 		if err != nil {
 			return
 		}

--- a/contrib/fuzz/diff_fuzz_test.go
+++ b/contrib/fuzz/diff_fuzz_test.go
@@ -51,7 +51,7 @@ func FuzzDiffApply(f *testing.F) {
 			return
 		}
 		tmpDir := t.TempDir()
-		cs, err := local.NewStore(tmpDir)
+		cs, err := local.NewStore(tmpDir, nil)
 		if err != nil {
 			return
 		}
@@ -94,7 +94,7 @@ func FuzzDiffCompare(f *testing.F) {
 
 		ctx := context.Background()
 		tmpDir := t.TempDir()
-		cs, err := local.NewStore(tmpDir)
+		cs, err := local.NewStore(tmpDir, nil)
 		if err != nil {
 			return
 		}

--- a/contrib/fuzz/images_fuzz_test.go
+++ b/contrib/fuzz/images_fuzz_test.go
@@ -36,7 +36,7 @@ func FuzzImagesCheck(f *testing.F) {
 			return
 		}
 		tmpDir := t.TempDir()
-		cs, err := local.NewStore(tmpDir)
+		cs, err := local.NewStore(tmpDir, nil)
 		if err != nil {
 			return
 		}

--- a/contrib/fuzz/metadata_fuzz_test.go
+++ b/contrib/fuzz/metadata_fuzz_test.go
@@ -303,7 +303,7 @@ func testDB(t *testing.T, opt ...testOpt) (context.Context, *metadata.DB, func()
 		snapshotters[name] = snapshotter
 	}
 
-	cs, err := local.NewStore(filepath.Join(dirname, "content"))
+	cs, err := local.NewStore(filepath.Join(dirname, "content"), nil)
 	if err != nil {
 		return ctx, nil, func() { cancel() }, err
 	}

--- a/core/images/imagetest/content.go
+++ b/core/images/imagetest/content.go
@@ -54,7 +54,7 @@ type ContentStore struct {
 
 // NewContentStore creates a new content store in the testing's temporary directory
 func NewContentStore(ctx context.Context, t *testing.T) ContentStore {
-	cs, err := local.NewLabeledStore(t.TempDir(), newMemoryLabelStore())
+	cs, err := local.NewLabeledStore(t.TempDir(), newMemoryLabelStore(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/metadata/content_test.go
+++ b/core/metadata/content_test.go
@@ -39,7 +39,7 @@ import (
 
 func createContentStore(ctx context.Context, root string, opts ...DBOpt) (context.Context, content.Store, func() error, error) {
 	// TODO: Use mocked or in-memory store
-	cs, err := local.NewStore(root)
+	cs, err := local.NewStore(root, nil)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/core/metadata/db_test.go
+++ b/core/metadata/db_test.go
@@ -93,7 +93,7 @@ func testDB(t *testing.T, opt ...testOpt) (context.Context, *DB) {
 		snapshotters[name] = snapshotter
 	}
 
-	cs, err := local.NewStore(filepath.Join(dirname, "content"))
+	cs, err := local.NewStore(filepath.Join(dirname, "content"), nil)
 	require.NoError(t, err)
 
 	bdb, err := bolt.Open(filepath.Join(dirname, "metadata.db"), 0644, nil)
@@ -895,7 +895,7 @@ func newStores(t testing.TB) (*DB, content.Store, snapshots.Snapshotter, func())
 		t.Fatal(err)
 	}
 
-	lcs, err := local.NewStore(filepath.Join(td, "content"))
+	lcs, err := local.NewStore(filepath.Join(td, "content"), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/remotes/docker/converter_fuzz_test.go
+++ b/core/remotes/docker/converter_fuzz_test.go
@@ -41,7 +41,7 @@ func FuzzConvertManifest(f *testing.F) {
 			return
 		}
 		tmpdir := t.TempDir()
-		cs, err := local.NewStore(tmpdir)
+		cs, err := local.NewStore(tmpdir, nil)
 		if err != nil {
 			return
 		}

--- a/core/remotes/handlers_test.go
+++ b/core/remotes/handlers_test.go
@@ -104,7 +104,7 @@ func TestSkipNonDistributableBlobs(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	cs, err := local.NewLabeledStore(dir, newMemoryLabelStore())
+	cs, err := local.NewLabeledStore(dir, newMemoryLabelStore(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/fsverity/fsverity_linux.go
+++ b/internal/fsverity/fsverity_linux.go
@@ -139,13 +139,13 @@ func Measure(path string) (string, error) {
 	var verityDigest string
 	f, err := os.Open(path)
 	if err != nil {
-		return verityDigest, fmt.Errorf("Error opening file: %s\n", err.Error())
+		return verityDigest, fmt.Errorf("error opening file: %s", err.Error())
 	}
 
-	var d *fsverityDigest = &fsverityDigest{digestSize: maxDigestSize}
+	d := &fsverityDigest{digetsSize: maxDigetSize}
 	_, _, errno := unix.Syscall(syscall.SYS_IOCTL, f.Fd(), uintptr(unix.FS_IOC_MEASURE_VERITY), uintptr(unsafe.Pointer(d)))
 	if errno != 0 {
-		return verityDigest, fmt.Errorf("Measure fsverity failed: %w\n", errno)
+		return verityDigest, fmt.Errorf("measure fsverity failed: %w", errno)
 	}
 
 	var i uint16

--- a/internal/fsverity/fsverity_linux.go
+++ b/internal/fsverity/fsverity_linux.go
@@ -39,6 +39,12 @@ type fsverityEnableArg struct {
 	reserved2     [11]uint64
 }
 
+type fsverityDigest struct {
+	digestAlgorithm uint16
+	digestSize      uint16
+	digest          [64]uint8
+}
+
 const (
 	defaultBlockSize int    = 4096
 	maxDigestSize    uint16 = 64
@@ -127,4 +133,25 @@ func Enable(path string) error {
 	}
 
 	return nil
+}
+
+func Measure(path string) (string, error) {
+	var verityDigest string
+	f, err := os.Open(path)
+	if err != nil {
+		return verityDigest, fmt.Errorf("Error opening file: %s\n", err.Error())
+	}
+
+	var d *fsverityDigest = &fsverityDigest{digestSize: maxDigestSize}
+	_, _, errno := unix.Syscall(syscall.SYS_IOCTL, f.Fd(), uintptr(unix.FS_IOC_MEASURE_VERITY), uintptr(unsafe.Pointer(d)))
+	if errno != 0 {
+		return verityDigest, fmt.Errorf("Measure fsverity failed: %w\n", errno)
+	}
+
+	var i uint16
+	for i = 0; i < (*d).digestSize; i++ {
+		verityDigest = fmt.Sprintf("%s%x", verityDigest, (*d).digest[i])
+	}
+
+	return verityDigest, nil
 }

--- a/internal/fsverity/fsverity_linux.go
+++ b/internal/fsverity/fsverity_linux.go
@@ -142,7 +142,7 @@ func Measure(path string) (string, error) {
 		return verityDigest, fmt.Errorf("error opening file: %s", err.Error())
 	}
 
-	d := &fsverityDigest{digetsSize: maxDigetSize}
+	d := &fsverityDigest{digestSize: maxDigestSize}
 	_, _, errno := unix.Syscall(syscall.SYS_IOCTL, f.Fd(), uintptr(unix.FS_IOC_MEASURE_VERITY), uintptr(unsafe.Pointer(d)))
 	if errno != 0 {
 		return verityDigest, fmt.Errorf("measure fsverity failed: %w", errno)

--- a/internal/fsverity/fsverity_other.go
+++ b/internal/fsverity/fsverity_other.go
@@ -31,3 +31,7 @@ func IsEnabled(path string) (bool, error) {
 func Enable(_ string) error {
 	return fmt.Errorf("fsverity is only supported on Linux systems")
 }
+
+func Measure(_ string) (string, error) {
+	return "", fmt.Errorf("fsverity is only supported on Linux systems")
+}

--- a/pkg/integrity/doc.go
+++ b/pkg/integrity/doc.go
@@ -1,3 +1,19 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 // Package integrity provides an interface for validating the integrity
 // of content stored in the containerd content store.
 package integrity

--- a/pkg/integrity/doc.go
+++ b/pkg/integrity/doc.go
@@ -1,0 +1,3 @@
+// Package integrity provides an interface for validating the integrity
+// of content stored in the containerd content store.
+package integrity

--- a/pkg/integrity/fsverity/fsverity.go
+++ b/pkg/integrity/fsverity/fsverity.go
@@ -35,9 +35,7 @@ type Config struct {
 	StorePath string `toml:"store_path"`
 }
 
-var _ integrity.Verifier = validator{}
-
-func NewValidator(config Config) validator {
+func NewValidator(config Config) integrity.Verifier {
 	return validator{integrityStorePath: config.StorePath}
 }
 

--- a/pkg/integrity/fsverity/fsverity.go
+++ b/pkg/integrity/fsverity/fsverity.go
@@ -1,0 +1,125 @@
+package fsverity
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	fsv "github.com/containerd/containerd/v2/internal/fsverity"
+	"github.com/containerd/containerd/v2/pkg/integrity"
+	"github.com/containerd/errdefs"
+)
+
+type validator struct {
+	integrityStorePath string
+}
+
+type Config struct {
+	StorePath string `toml:"store_path"`
+}
+
+var _ integrity.Verifier = validator{}
+
+func NewValidator(config Config) validator {
+	return validator{integrityStorePath: config.StorePath}
+}
+
+// Enable validation on the blob by taking an initial measurement
+// and storing it for later comparison.
+func (v validator) Register(blob string) (string, error) {
+	var verityDigest string
+	// Enable fsverity digest verification on the blob
+	if err := fsv.Enable(blob); err != nil {
+		return verityDigest, fmt.Errorf("failed to enable fsverity verification: %s", err.Error())
+	}
+
+	verityDigest, merr := fsv.Measure(blob)
+	if merr != nil {
+		return verityDigest, fmt.Errorf("failed to take fsverity measurement of blob: %s", merr.Error())
+	}
+
+	digest := filepath.Base(blob)
+
+	if err := os.MkdirAll(v.integrityStorePath, 0755); err != nil {
+		return verityDigest, fmt.Errorf("Failed to create integrity store: %w", err)
+	}
+
+	integrityFilePath := filepath.Join(v.integrityStorePath, digest)
+	integrityFile, err := os.Create(integrityFilePath)
+	if err != nil {
+		return verityDigest, fmt.Errorf("Failed to register blob integrity: %w", err)
+	}
+	defer integrityFile.Close()
+
+	_, err = integrityFile.Write([]byte(verityDigest))
+	if err != nil {
+		return verityDigest, fmt.Errorf("Failed to register blob integrity: %w", err)
+	}
+
+	return verityDigest, nil
+}
+
+// Validate the blob by measuring the content and comparing it to
+// the stored digest.
+func (v validator) IsValid(blob string) (bool, error) {
+	measure := func() (string, error) {
+		var verityDigest string
+		// check that fsverity is enabled on the blob before reading
+		// if not, it may not be trustworthy
+		enabled, err := fsv.IsEnabled(blob)
+		if err != nil {
+			return verityDigest, fmt.Errorf("Error checking fsverity status of blob %s: %s", blob, err.Error())
+		}
+		if !enabled {
+			return verityDigest, fmt.Errorf("fsverity not enabled on blob %s", blob)
+		}
+
+		verityDigest, merr := fsv.Measure(blob)
+		if merr != nil {
+			return verityDigest, fmt.Errorf("failed to take fsverity measurement of blob: %s", merr.Error())
+		}
+		return verityDigest, nil
+	}
+
+	verityDigest, err := measure()
+	if err != nil {
+		return false, fmt.Errorf("failed to measure blob: %w", err)
+	}
+
+	var expectedDigest string
+	digest := filepath.Base(blob)
+	integrityFile := filepath.Join(v.integrityStorePath, digest)
+	ifd, err := os.Open(integrityFile) // TODO: validate the signed digest next?
+	defer ifd.Close()
+
+	if err != nil {
+		return false, fmt.Errorf("could not read expected integrity value of %s", blob)
+	}
+	b, err := io.ReadAll(ifd)
+	if err == nil {
+		expectedDigest = string(b)
+	}
+
+	// compare the digest to the known "good" value
+	if verityDigest != expectedDigest {
+		return false, fmt.Errorf("blob not trusted: fsverity digest does not match the expected digest value, expected: %s; got: %s", expectedDigest, verityDigest)
+	}
+
+	return true, nil
+}
+
+// Remove the stored digest when no longer needed
+func (v validator) Unregister(blob string) error {
+	digest := filepath.Base(blob)
+	integrityFile := filepath.Join(v.integrityStorePath, digest)
+
+	if err := os.RemoveAll(integrityFile); err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+
+		return fmt.Errorf("integrity file %v: %w", digest, errdefs.ErrNotFound)
+	}
+	return nil
+}

--- a/pkg/integrity/fsverity/fsverity.go
+++ b/pkg/integrity/fsverity/fsverity.go
@@ -1,3 +1,19 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package fsverity
 
 import (
@@ -90,7 +106,7 @@ func (v validator) IsValid(blob string) (bool, error) {
 	var expectedDigest string
 	digest := filepath.Base(blob)
 	integrityFile := filepath.Join(v.integrityStorePath, digest)
-	ifd, err := os.Open(integrityFile) // TODO: validate the signed digest next?
+	ifd, err := os.Open(integrityFile)
 	if err != nil {
 		return false, fmt.Errorf("could not read expected integrity value of %s", blob)
 	}

--- a/pkg/integrity/fsverity/fsverity.go
+++ b/pkg/integrity/fsverity/fsverity.go
@@ -91,11 +91,11 @@ func (v validator) IsValid(blob string) (bool, error) {
 	digest := filepath.Base(blob)
 	integrityFile := filepath.Join(v.integrityStorePath, digest)
 	ifd, err := os.Open(integrityFile) // TODO: validate the signed digest next?
-	defer ifd.Close()
-
 	if err != nil {
 		return false, fmt.Errorf("could not read expected integrity value of %s", blob)
 	}
+	defer ifd.Close()
+
 	b, err := io.ReadAll(ifd)
 	if err == nil {
 		expectedDigest = string(b)

--- a/pkg/integrity/fsverity/fsverity.go
+++ b/pkg/integrity/fsverity/fsverity.go
@@ -56,19 +56,19 @@ func (v validator) Register(blob string) (string, error) {
 	digest := filepath.Base(blob)
 
 	if err := os.MkdirAll(v.integrityStorePath, 0755); err != nil {
-		return verityDigest, fmt.Errorf("Failed to create integrity store: %w", err)
+		return verityDigest, fmt.Errorf("failed to create integrity store: %w", err)
 	}
 
 	integrityFilePath := filepath.Join(v.integrityStorePath, digest)
 	integrityFile, err := os.Create(integrityFilePath)
 	if err != nil {
-		return verityDigest, fmt.Errorf("Failed to register blob integrity: %w", err)
+		return verityDigest, fmt.Errorf("failed to register blob integrity: %w", err)
 	}
 	defer integrityFile.Close()
 
 	_, err = integrityFile.Write([]byte(verityDigest))
 	if err != nil {
-		return verityDigest, fmt.Errorf("Failed to register blob integrity: %w", err)
+		return verityDigest, fmt.Errorf("failed to register blob integrity: %w", err)
 	}
 
 	return verityDigest, nil
@@ -83,7 +83,7 @@ func (v validator) IsValid(blob string) (bool, error) {
 		// if not, it may not be trustworthy
 		enabled, err := fsv.IsEnabled(blob)
 		if err != nil {
-			return verityDigest, fmt.Errorf("Error checking fsverity status of blob %s: %s", blob, err.Error())
+			return verityDigest, fmt.Errorf("error checking fsverity status of blob %s: %s", blob, err.Error())
 		}
 		if !enabled {
 			return verityDigest, fmt.Errorf("fsverity not enabled on blob %s", blob)

--- a/pkg/integrity/validator.go
+++ b/pkg/integrity/validator.go
@@ -1,3 +1,19 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package integrity
 
 type Verifier interface {

--- a/pkg/integrity/validator.go
+++ b/pkg/integrity/validator.go
@@ -1,0 +1,7 @@
+package integrity
+
+type Verifier interface {
+	Register(blob string) (string, error)
+	IsValid(blob string) (bool, error)
+	Unregister(blob string) error
+}

--- a/plugins/content/local/content_local_fuzz_test.go
+++ b/plugins/content/local/content_local_fuzz_test.go
@@ -32,7 +32,7 @@ import (
 
 func FuzzContentStoreWriter(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
-		cs, err := NewStore(t.TempDir())
+		cs, err := NewStore(t.TempDir(), nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/plugins/content/local/helper_test.go
+++ b/plugins/content/local/helper_test.go
@@ -26,7 +26,7 @@ import (
 func contentStoreEnv(t testing.TB) (context.Context, string, content.Store, func()) {
 	tmpdir := t.TempDir()
 
-	cs, err := NewStore(tmpdir)
+	cs, err := NewStore(tmpdir, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/content/local/store.go
+++ b/plugins/content/local/store.go
@@ -29,12 +29,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/containerd/errdefs"
-	"github.com/containerd/log"
-
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/internal/fsverity"
 	"github.com/containerd/containerd/v2/pkg/filters"
+	"github.com/containerd/containerd/v2/pkg/integrity"
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -69,6 +69,7 @@ type store struct {
 	root               string
 	ls                 LabelStore
 	integritySupported bool
+	iv                 integrity.Verifier
 
 	locksMu              sync.Mutex
 	locks                map[string]*lock
@@ -76,8 +77,8 @@ type store struct {
 }
 
 // NewStore returns a local content store
-func NewStore(root string) (content.Store, error) {
-	return NewLabeledStore(root, nil)
+func NewStore(root string, iv integrity.Verifier) (content.Store, error) {
+	return NewLabeledStore(root, nil, iv)
 }
 
 // NewLabeledStore returns a new content store using the provided label store
@@ -85,7 +86,7 @@ func NewStore(root string) (content.Store, error) {
 // Note: content stores which are used underneath a metadata store may not
 // require labels and should use `NewStore`. `NewLabeledStore` is primarily
 // useful for tests or standalone implementations.
-func NewLabeledStore(root string, ls LabelStore) (content.Store, error) {
+func NewLabeledStore(root string, ls LabelStore, iv integrity.Verifier) (content.Store, error) {
 	if _, err := os.Stat(root); err != nil {
 		if !errors.Is(err, fs.ErrNotExist) {
 			return nil, fmt.Errorf("failed to stat %q: %w", root, err)
@@ -102,6 +103,7 @@ func NewLabeledStore(root string, ls LabelStore) (content.Store, error) {
 		root:               root,
 		ls:                 ls,
 		integritySupported: supported,
+		iv:                 iv,
 		locks:              map[string]*lock{},
 	}
 	s.ensureIngestRootOnce = sync.OnceValue(s.ensureIngestRoot)
@@ -149,6 +151,12 @@ func (s *store) ReaderAt(ctx context.Context, desc ocispec.Descriptor) (content.
 		return nil, fmt.Errorf("calculating blob path for ReaderAt: %w", err)
 	}
 
+	// check blob integrity before openning for reading
+	valid, err := s.iv.IsValid(p)
+	if err != nil || !valid {
+		return nil, fmt.Errorf("blob integrity verification failed: %w", err)
+	}
+
 	reader, err := OpenReader(p)
 	if err != nil {
 		return nil, fmt.Errorf("blob %s expected at %s: %w", desc.Digest, p, err)
@@ -173,6 +181,10 @@ func (s *store) Delete(ctx context.Context, dgst digest.Digest) error {
 		}
 
 		return fmt.Errorf("content %v: %w", dgst, errdefs.ErrNotFound)
+	}
+
+	if err := s.iv.Unregister(bp); err != nil {
+		return fmt.Errorf("failed to unregister blob integrity verification: %w", err)
 	}
 
 	return nil

--- a/plugins/content/local/store_test.go
+++ b/plugins/content/local/store_test.go
@@ -33,13 +33,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/errdefs"
-
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/content/testsuite"
 	"github.com/containerd/containerd/v2/internal/fsverity"
 	"github.com/containerd/containerd/v2/internal/randutil"
 	"github.com/containerd/containerd/v2/pkg/testutil"
+	"github.com/containerd/errdefs"
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"

--- a/plugins/content/local/store_test.go
+++ b/plugins/content/local/store_test.go
@@ -104,11 +104,11 @@ func TestContent(t *testing.T) {
 func TestContentRootDir(t *testing.T) {
 	// test dir exist
 	dirExist := t.TempDir()
-	_, err := NewLabeledStore(dirExist, newMemoryLabelStore())
+	_, err := NewLabeledStore(dirExist, newMemoryLabelStore(), nil)
 	assert.NoError(t, err)
 	// test dir doesn't exist
 	dir := filepath.Join(t.TempDir(), "test_dir001")
-	_, err = NewLabeledStore(dir, newMemoryLabelStore())
+	_, err = NewLabeledStore(dir, newMemoryLabelStore(), nil)
 	assert.NoError(t, err)
 	_, err = os.Stat(dir)
 	assert.NoError(t, err)

--- a/plugins/content/local/store_test.go
+++ b/plugins/content/local/store_test.go
@@ -93,7 +93,7 @@ func (mls *memoryLabelStore) Update(d digest.Digest, update map[string]string) (
 
 func TestContent(t *testing.T) {
 	testsuite.ContentSuite(t, "fs", func(ctx context.Context, root string) (context.Context, content.Store, func() error, error) {
-		cs, err := NewLabeledStore(root, newMemoryLabelStore())
+		cs, err := NewLabeledStore(root, newMemoryLabelStore(), nil)
 		assert.NoError(t, err)
 		return ctx, cs, func() error {
 			return nil
@@ -385,7 +385,7 @@ func checkWrite(ctx context.Context, t checker, cs content.Store, dgst digest.Di
 }
 
 func TestWriterTruncateRecoversFromIncompleteWrite(t *testing.T) {
-	cs, err := NewStore(t.TempDir())
+	cs, err := NewStore(t.TempDir(), nil)
 	assert.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/plugins/content/local/writer.go
+++ b/plugins/content/local/writer.go
@@ -26,12 +26,10 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/opencontainers/go-digest"
-
-	"github.com/containerd/containerd/v2/core/content"
-	"github.com/containerd/containerd/v2/internal/fsverity"
 )
 
 // writer represents a write transaction against the blob store.
@@ -144,10 +142,9 @@ func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest,
 	}
 	// Enable content blob integrity verification if supported
 
-	if w.s.integritySupported {
-		if err := fsverity.Enable(target); err != nil {
-			log.G(ctx).Warnf("failed to enable integrity for blob %v: %s", target, err.Error())
-		}
+	_, err = w.s.iv.Register(target)
+	if err != nil {
+		return fmt.Errorf("failed to enable integrity verification on blob: %v: %w", target, err)
 	}
 
 	// Ingest has now been made available in the content store, attempt to complete

--- a/plugins/content/local/writer.go
+++ b/plugins/content/local/writer.go
@@ -142,9 +142,11 @@ func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest,
 	}
 	// Enable content blob integrity verification if supported
 
-	_, err = w.s.iv.Register(target)
-	if err != nil {
-		return fmt.Errorf("failed to enable integrity verification on blob: %v: %w", target, err)
+	if w.s.integritySupported {
+		_, err = w.s.iv.Register(target)
+		if err != nil {
+			return fmt.Errorf("failed to enable integrity verification on blob: %v: %w", target, err)
+		}
 	}
 
 	// Ingest has now been made available in the content store, attempt to complete

--- a/plugins/integrityverifier/verifier.go
+++ b/plugins/integrityverifier/verifier.go
@@ -1,3 +1,19 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package integrityverifier
 
 import (

--- a/plugins/integrityverifier/verifier.go
+++ b/plugins/integrityverifier/verifier.go
@@ -1,0 +1,23 @@
+package integrityverifier
+
+import (
+	"github.com/containerd/containerd/v2/pkg/integrity/fsverity"
+	"github.com/containerd/containerd/v2/plugins"
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
+)
+
+// TODO: see if 'root' directory value can be derived from elsewhere
+const defaultIntegrityPath = "/var/lib/containerd/io.containerd.content.v1.content/integrity/"
+
+func init() {
+	registry.Register(&plugin.Registration{
+		Type:   plugins.IntegrityVerifierPlugin,
+		ID:     "fsverity",
+		Config: &fsverity.Config{StorePath: defaultIntegrityPath},
+		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
+			cfg := ic.Config.(*fsverity.Config)
+			return fsverity.NewValidator(*cfg), nil
+		},
+	})
+}

--- a/plugins/snapshots/erofs/erofs_linux_test.go
+++ b/plugins/snapshots/erofs/erofs_linux_test.go
@@ -193,7 +193,7 @@ func TestErofsDifferWithTarIndexMode(t *testing.T) {
 	tempDir := t.TempDir()
 
 	// Create content store for the differ
-	contentStore, err := local.NewStore(filepath.Join(tempDir, "content"))
+	contentStore, err := local.NewStore(filepath.Join(tempDir, "content"), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/types.go
+++ b/plugins/types.go
@@ -69,6 +69,8 @@ const (
 	SandboxControllerPlugin plugin.Type = "io.containerd.sandbox.controller.v1"
 	// ImageVerifierPlugin implements an image verifier service
 	ImageVerifierPlugin plugin.Type = "io.containerd.image-verifier.v1"
+	// IntegrityVerifier implements a content integrity verifier
+	IntegrityVerifierPlugin plugin.Type = "io.containerd.integrity-verifier.v1"
 	// WarningPlugin implements a warning service
 	WarningPlugin plugin.Type = "io.containerd.warning.v1"
 	// CRIServicePlugin implements a cri service


### PR DESCRIPTION
Refactor fsverity integrity verification as a plugin and extend fsverity verification such that it checks content digests against a known "good" value, protecting content from malicious corruption.

This is currently accomplished by measuring the fsverity digest value of the content when it is first written to the disk and storing it in the `var/lib/containerd/io.containerd.content.v1.content/integrity/fsverity/` directory in a file which is named with the sha256 digest of the content (similar to the content store). 
When the content is read, the fsverity digest of the content is measured and compared to the stored value to ensure authenticity.

Since this extension is meant to protect against a malicious user that can corrupt data in the content store, I would not consider the directory above to be a "secure" place to permanently store the trusted digest values (as a malicious user may be able to corrupt those files too).

Would it be possible/reasonable to instead add an immutable "integrity" field to the content metadata store (similar to how Digest, Size, and CreatedAt are immutable)?

Any suggestions are welcome.

