### PR TITLE
Export compatibility config.sandboxImage in CRI

### DIFF
--- a/internal/cri/server/container_status_test.go
+++ b/internal/cri/server/container_status_test.go
@@ -294,6 +294,8 @@ func (s *fakeImageService) GetSnapshot(key, snapshotter string) (snapshotstore.S
 	return snapshotstore.Snapshot{}, errors.New("not implemented")
 }
 
+func (s *fakeImageService) PinnedImage(name string) string { return "" }
+
 func (s *fakeImageService) LocalResolve(refOrID string) (imagestore.Image, error) {
 	return imagestore.Image{}, errors.New("not implemented")
 }

--- a/internal/cri/server/container_status_test.go
+++ b/internal/cri/server/container_status_test.go
@@ -277,7 +277,8 @@ func TestContainerStatus(t *testing.T) {
 }
 
 type fakeImageService struct {
-	imageStore *imagestore.Store
+	imageStore   *imagestore.Store
+	pinnedImages map[string]string
 }
 
 func (s *fakeImageService) RuntimeSnapshotter(ctx context.Context, ociRuntime criconfig.Runtime) string {
@@ -294,7 +295,7 @@ func (s *fakeImageService) GetSnapshot(key, snapshotter string) (snapshotstore.S
 	return snapshotstore.Snapshot{}, errors.New("not implemented")
 }
 
-func (s *fakeImageService) PinnedImage(name string) string { return "" }
+func (s *fakeImageService) PinnedImage(name string) string { return s.pinnedImages[name] }
 
 func (s *fakeImageService) LocalResolve(refOrID string) (imagestore.Image, error) {
 	return imagestore.Image{}, errors.New("not implemented")

--- a/internal/cri/server/service.go
+++ b/internal/cri/server/service.go
@@ -104,6 +104,8 @@ type ImageService interface {
 	GetImage(id string) (imagestore.Image, error)
 	GetSnapshot(key, snapshotter string) (snapshotstore.Snapshot, error)
 
+	PinnedImage(name string) string
+
 	LocalResolve(refOrID string) (imagestore.Image, error)
 
 	ImageFSPaths() map[string]string

--- a/internal/cri/server/service_test.go
+++ b/internal/cri/server/service_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/containerd/containerd/api/types"
 	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/core/introspection"
 	"github.com/containerd/containerd/v2/core/sandbox"
 	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
@@ -134,6 +135,13 @@ type testOpt func(*criService)
 func withRuntimeService(rs RuntimeService) testOpt {
 	return func(service *criService) {
 		service.RuntimeService = rs
+	}
+}
+
+func withClientIntrospectionService(is introspection.Service) testOpt {
+	return func(service *criService) {
+		client, _ := containerd.New("", containerd.WithServices(containerd.WithIntrospectionService(is)))
+		service.client = client
 	}
 }
 

--- a/internal/cri/server/status.go
+++ b/internal/cri/server/status.go
@@ -26,6 +26,7 @@ import (
 	"sort"
 
 	"github.com/containerd/containerd/api/services/introspection/v1"
+	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
 	"github.com/containerd/log"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
@@ -70,7 +71,17 @@ func (c *criService) Status(ctx context.Context, r *runtime.StatusRequest) (*run
 	})
 
 	if r.Verbose {
-		configByt, err := json.Marshal(c.config)
+		type compatConfig struct {
+			criconfig.Config
+			// kubeadm hardcodes config.sandboxImage
+			SandboxImage string `json:"sandboxImage"`
+		}
+		sandboxImage := c.ImageService.PinnedImage("sandbox")
+		if sandboxImage == "" {
+			sandboxImage = criconfig.DefaultSandboxImage
+		}
+		config := compatConfig{Config: c.config, SandboxImage: sandboxImage}
+		configByt, err := json.Marshal(config)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
- fixes https://github.com/containerd/containerd/issues/11117

The kubeadm preflight checks for config.sandboxImage in CRI,
make sure that this value is present in the exported "config".

Fixes the issue that was previously always shown by kubeadm:
`detected that the sandbox image "" of the container runtime is inconsistent with that used by kubeadm`

https://github.com/kubernetes/kubernetes/commit/d12b4d4c6772bc7735c3765d79ecc46c69595088

Note that this key (`config.sandboxImage`) is also being used by other runtimes, such as CRI-O and Docker.
Even though they don't _have_ such a config, it still has to be added to the CRI status because compatibility.

https://github.com/cri-o/cri-o/commit/875c3a2b155c95572982771dc05149ec5f445fc5

---

It is part of the CRI API from Kubernetes 1.27

But it only works with raw maps and strings...

```go
        type config struct {
                SandboxImage string `json:"sandboxImage,omitempty"`
        }
```

cmd/kubeadm/app/util/runtime/runtime.go