### PR TITLE
Log "container event discarded" as Info

### DIFF
--- a/internal/cri/server/service.go
+++ b/internal/cri/server/service.go
@@ -207,7 +207,7 @@ func NewCRIService(options *CRIServiceOptions) (CRIService, runtime.RuntimeServi
 			log.Fields{
 				"container": event.ContainerId,
 				"type":      event.ContainerEventType,
-			}).Warn("container event discarded")
+			}).Info("container event discarded")
 	})
 
 	if err := c.initPlatform(); err != nil {


### PR DESCRIPTION
As 'Kubelet Evented PLEG' is still alpha not having any subscribers to CRI events is pretty normal, so lower the log level.

Fixes #11108 
CC @dmcgowan 