### PR TITLE
Remove After=local-fs.target from containerd.service

### DIFF
--- a/containerd.service
+++ b/containerd.service
@@ -15,7 +15,7 @@
 [Unit]
 Description=containerd container runtime
 Documentation=https://containerd.io
-After=network.target local-fs.target dbus.service
+After=network.target dbus.service
 
 [Service]
 ExecStartPre=-/sbin/modprobe overlay


### PR DESCRIPTION
As we are not setting `DefaultDependencies=no`, containerd.service
'will have dependencies of type Requires= and After= on sysinit.target'
https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Default%20Dependencies
and sysinit.target already has After=local-fs.target
https://www.freedesktop.org/software/systemd/man/latest/bootup.html#System%20Manager%20Bootup

Reported-by: @VannTen (https://github.com/containerd/containerd/pull/10798#issuecomment-2519644335)