### PR TITLE
intrenal/cri: optimize stdio create procedure

### DIFF
--- a/internal/cri/store/container/container.go
+++ b/internal/cri/store/container/container.go
@@ -193,6 +193,27 @@ func (s *Store) UpdateContainerStats(id string, newContainerStats *stats.Contain
 	return nil
 }
 
+func (s *Store) UpdateContainerStdio(id string, io *cio.ContainerIO) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	id, err := s.idIndex.Get(id)
+	if err != nil {
+		if err == truncindex.ErrNotExist {
+			err = errdefs.ErrNotFound
+		}
+		return err
+	}
+
+	if _, ok := s.containers[id]; !ok {
+		return errdefs.ErrNotFound
+	}
+
+	c := s.containers[id]
+	c.IO = io
+	s.containers[id] = c
+	return nil
+}
+
 // Delete deletes the container from store with specified id.
 func (s *Store) Delete(id string) {
 	s.lock.Lock()


### PR DESCRIPTION
Continuously creating containers without starting them will result in the containerd process exiting.
Analyzing the exit stack of containerd and discovering:

runtime: program exceeds 10000-thread limit
fatal error: thread exhaustion
...
syscall.Syscall6(0xc0148b8750?, 0x13?, 0x0?, 0x1000?, 0x0?, 0x674d2a23?, 0x14533f40?)
        /usr/local/go/src/syscall/syscall_linux.go:91 +0x36 fp=0xc005481e08 sp=0xc005481d80 pc=0x559c1bfb1236
syscall.openat(0x559c1d7bb240?, {0xc0148b8750?, 0xc000000005?}, 0x559c1d23970a?, 0x0)
        /usr/local/go/src/syscall/zsyscall_linux_amd64.go:83 +0x94 fp=0xc005481e80 sp=0xc005481e08 pc=0x559c1bfad814
syscall.Open(...)
        /usr/local/go/src/syscall/syscall_linux.go:272
os.openFileNolog({0xc0148b8750, 0x13}, 0x0, 0x0)
        /usr/local/go/src/os/file_unix.go:245 +0x9b fp=0xc005481ec8 sp=0xc005481e80 pc=0x559c1bfde7fb
os.OpenFile({0xc0148b8750, 0x13}, 0x0, 0x12000000?)
        /usr/local/go/src/os/file.go:326 +0x45 fp=0xc005481f00 sp=0xc005481ec8 pc=0x559c1bfdc165
...
		
And the above number of stacks is:
$ cat containerd.stack.log |grep  openFileNolog |wc -l 
9954

It could be seen that about 9954 threads are blocked on openFileNolog in the contaienrd process. 


When each container is created, the containerd process will create three new threads and open fifos.stdin/fifo.stdout/fifo.stderr. The three threads in the fifos pipeline file will be blocked, and these blocked threads will only return from the Fifos pipeline file is opened after the corresponding shim process of the container is started. If the container remains in a state of creation without being started, the above three threads will be permanently blocked, and each created container will consume three threads. The default number of containerd threads is 10000. In extreme scenarios, creating only the container without starting it will reach the upper limit of containerd threads, ultimately causing containerd threads to exit.

Move the operation of opening the fifos.stdin/fifos.stdout/fifos.stderr for each container to the StartContainer function, so that no new threads are created in CreateContainer function. And these new threads are not constantly blocked in opening fifos.stdin/fifos.stdout/fifos.stderr file process due to the immediate start of the shim process. Thus reducing the consumption of containerd threads in this way. Prevent containerd processes from exiting due to reaching the maximum number of threads.