### PR TITLE
Use a order-only-prerequisite for mandir creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,7 +280,7 @@ bin/containerd-shim-runc-v2: cmd/containerd-shim-runc-v2 FORCE # set !cgo and om
 binaries: $(BINARIES) ## build binaries
 	@echo "$(WHALE) $@"
 
-man: mandir $(addprefix man/,$(MANPAGES))
+man: $(addprefix man/,$(MANPAGES))
 	@echo "$(WHALE) $@"
 
 mandir:
@@ -289,15 +289,15 @@ mandir:
 # Kept for backwards compatibility
 genman: man/containerd.8 man/ctr.8
 
-man/containerd.8: bin/gen-manpages FORCE
+man/containerd.8: bin/gen-manpages FORCE | mandir
 	@echo "$(WHALE) $@"
 	$< $(@F) $(@D)
 
-man/ctr.8: bin/gen-manpages FORCE
+man/ctr.8: bin/gen-manpages FORCE | mandir
 	@echo "$(WHALE) $@"
 	$< $(@F) $(@D)
 
-man/%: docs/man/%.md FORCE
+man/%: docs/man/%.md FORCE | mandir
 	@echo "$(WHALE) $@"
 	go-md2man -in "$<" -out "$@"
 


### PR DESCRIPTION
Otherwise its a matter of luck that the man directory is created before man page generation.

Bug: https://bugs.gentoo.org/880057

This is GNU Make syntax as I'm under the impression that GNU Make is the chosen flavour of make.

```
$ make --shuffle=3620861772 man -j1
+ man/containerd-config.toml.5
go-md2man -in "docs/man/containerd-config.toml.5.md" -out "man/containerd-config.toml.5"
open man/containerd-config.toml.5: no such file or directory
make: *** [Makefile:302: man/containerd-config.toml.5] Error 1 shuffle=3620861772
```