### PR TITLE
log: avoid using unsupported field by logrus

### DIFF
--- a/core/runtime/v2/binary.go
+++ b/core/runtime/v2/binary.go
@@ -195,7 +195,7 @@ func (b *binary) Delete(ctx context.Context) (*runtime.Exit, error) {
 	cmd.Stdout = out
 	cmd.Stderr = errb
 	if err := cmd.Run(); err != nil {
-		log.G(ctx).WithField("cmd", cmd).WithError(err).Error("failed to delete")
+		log.G(ctx).WithField("cmd", cmd.String()).WithError(err).Error("failed to delete")
 		return nil, fmt.Errorf("%s: %w", errb.String(), err)
 	}
 	s := errb.String()


### PR DESCRIPTION
fix: https://github.com/containerd/containerd/issues/9902

logrus doesn't support fields with functions which a new field Cancel was added to exec.Cmd from GO 1.20, which is of type func() error

```
Failed to obtain reader, failed to marshal fields to JSON, json: unsupported type: func() error
```