### PR TITLE
[release/2.0] Prepare release notes for v2.0.1

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -116,6 +116,7 @@ Mathis Michel <mathis.michel@outlook.de>
 Michael Crosby <crosbymichael@gmail.com> <michael@thepasture.io>
 Michael Katsoulis <michaelkatsoulis88@gmail.com>
 Michael Zappa <michael.zappa@gmail.com> <michaelzappa@microsoft.com>
+Michael Zappa <michael.zappa@gmail.com> <michaelzappa@Michaels-MacBook-Pro-8.local>
 Mike Brown <brownwm@us.ibm.com> <mikebrow@users.noreply.github.com>
 Mohammad Asif Siddiqui <mohammad.asif.siddiqui1@huawei.com>
 Nabeel Rana <nabeelnrana@gmail.com>

--- a/releases/v2.0.1.toml
+++ b/releases/v2.0.1.toml
@@ -1,0 +1,27 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+ignore_deps = [ "github.com/containerd/containerd" ]
+
+# previous release
+previous = "v2.0.0"
+
+pre_release = false
+
+preface = """\
+The first patch release for containerd 2.0 includes a number of bug fixes and improvements.
+"""
+
+postface = """\
+### Which file should I download?
+* `containerd-<VERSION>-<OS>-<ARCH>.tar.gz`:         ✅Recommended. Dynamically linked with glibc 2.31 (Ubuntu 20.04).
+* `containerd-static-<VERSION>-<OS>-<ARCH>.tar.gz`:  Statically linked. Expected to be used on non-glibc Linux distributions. Not position-independent.
+
+In addition to containerd, typically you will have to install [runc](https://github.com/opencontainers/runc/releases)
+and [CNI plugins](https://github.com/containernetworking/plugins/releases) from their official sites too.
+
+See also the [Getting Started](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) documentation.
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd/v2"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "2.0.0+unknown"
+	Version = "2.0.1+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated release notes

----

Welcome to the v2.0.1 release of containerd!

The first patch release for containerd 2.0 includes a number of bug fixes and improvements.

### Highlights

#### Container Runtime Interface (CRI)

* Fix apply IoOwner options when not in user namespace ([#11151](https://github.com/containerd/containerd/pull/11151))
* Fix cri grpc plugin config migration ([#11140](https://github.com/containerd/containerd/pull/11140))
* Support CNI STATUS Verb ([containerd/go-cni#123](https://github.com/containerd/go-cni/pull/123))

#### Image Distribution

* Update differ to handle zstd media types ([#11068](https://github.com/containerd/containerd/pull/11068))

#### Runtime

* Update runc binary to v1.2.3 ([#11142](https://github.com/containerd/containerd/pull/11142))
* Fix panic due to nil dereference cgroups v2 ([#11098](https://github.com/containerd/containerd/pull/11098))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Derek McGowan
* Wei Fu
* Archit Kulkarni
* Jin Dong
* Phil Estes
* Akhil Mohan
* Akihiro Suda
* Alexey Lunev
* Austin Vazquez
* Maksym Pavlenko
* Mike Brown
* Michael Zappa
* Samuel Karp
* Sebastiaan van Stijn
* Andrey Smirnov
* Davanum Srinivas

### Changes
<details><summary>49 commits</summary>
<p>

  * [`b0ece5dc5`](https://github.com/containerd/containerd/commit/b0ece5dc55f93493c2d94f4c19139f0dc49d8f38) Prepare release notes for v2.0.1
* build(deps): bump actions/attest-build-provenance from 1.4.4 to 2.1.0 ([#11154](https://github.com/containerd/containerd/pull/11154))
  * [`fe6957084`](https://github.com/containerd/containerd/commit/fe695708499661af965e068bc4c458b868cc2229) build(deps): bump actions/attest-build-provenance from 1.4.4 to 2.1.0
* update xx to v1.6.1 for compatibility with alpine 3.21 and file 5.46+ ([#11153](https://github.com/containerd/containerd/pull/11153))
  * [`eb2ce6882`](https://github.com/containerd/containerd/commit/eb2ce688293bdb1914ffa2928bb6f3fd88bae114) update xx to v1.6.1 for compatibility with alpine 3.21 and file 5.46+
* ctr pull should unpack for default platform when transfer service is used ([#11139](https://github.com/containerd/containerd/pull/11139))
  * [`44cdca68b`](https://github.com/containerd/containerd/commit/44cdca68b5f97f85386eea305c14c08ed3e93520) ctr pull unpack for default platform using transfer service
* Fix apply IoOwner options when not in user namespace ([#11151](https://github.com/containerd/containerd/pull/11151))
  * [`018d83650`](https://github.com/containerd/containerd/commit/018d83650fd4b23d61cd7af381ea5123935005c6) internal/cri: should not apply IoOwner options
* Update go-cni for CNI STATUS ([#11146](https://github.com/containerd/containerd/pull/11146))
  * [`5eb7995a9`](https://github.com/containerd/containerd/commit/5eb7995a9ae16deb23af0b320a91de633dae0ce0) feat: update go-cni version for CNI STATUS
* Fix cri grpc plugin config migration ([#11140](https://github.com/containerd/containerd/pull/11140))
  * [`a2302ea89`](https://github.com/containerd/containerd/commit/a2302ea89f90cb8ef2cafea3ca4ed20933d5d8b5) Add integration test for custom configuration
  * [`be5eda069`](https://github.com/containerd/containerd/commit/be5eda069f1055d934b40815d0ee30eeeda3771e) complete cri grpc config migration
* Update runc binary to v1.2.3 ([#11142](https://github.com/containerd/containerd/pull/11142))
  * [`a53eff53d`](https://github.com/containerd/containerd/commit/a53eff53d9ad0ed99ae3b48473c5fcb90c930aa4) update runc binary to v1.2.3
* Update differ to handle zstd media types ([#11068](https://github.com/containerd/containerd/pull/11068))
  * [`73f57acb0`](https://github.com/containerd/containerd/commit/73f57acb0da8dd4cff5f9dab2fd8685d7bd0048b) Update differ to handle zstd media types
* update to go1.23.4 / go1.22.10 ([#11109](https://github.com/containerd/containerd/pull/11109))
  * [`290e8bc70`](https://github.com/containerd/containerd/commit/290e8bc70405718e6f61c91415e08affc3ed1056) update to go1.23.4 / go1.22.10
* CI: update Fedora to 41 ([#11110](https://github.com/containerd/containerd/pull/11110))
  * [`62b790bfa`](https://github.com/containerd/containerd/commit/62b790bfac2aa5e4825bb37b93dcc75286ae2a09) CI: update Fedora to 41
* Fix panic due to nil dereference cgroups v2 ([#11098](https://github.com/containerd/containerd/pull/11098))
  * [`3ba2df924`](https://github.com/containerd/containerd/commit/3ba2df924a3f23419b7e8fe2626fa55cd934eb16) fix panic due to nil dereference cgroups v2
* Publish attestation as release artifact ([#11067](https://github.com/containerd/containerd/pull/11067))
  * [`34a45cab2`](https://github.com/containerd/containerd/commit/34a45cab2a573a589415d8d83fc00c3b6114bfff) Publish attestation as release artifact
* Move rockylinux 9.4 to almalinux/9 in CI ([#11053](https://github.com/containerd/containerd/pull/11053))
  * [`7dec6b460`](https://github.com/containerd/containerd/commit/7dec6b460752fb77b4754ef527c5ce492ac3c0ac) move rocky 9.4 to almalinux/9 in CI
* *: should align pipe's owner with init process ([#11035](https://github.com/containerd/containerd/pull/11035))
  * [`cf07f28ee`](https://github.com/containerd/containerd/commit/cf07f28ee22a6df79177b55751902b24548105ad) *: should align pipe's owner with init process
* fix: set the credentials even if not provided ([#11031](https://github.com/containerd/containerd/pull/11031))
  * [`986088866`](https://github.com/containerd/containerd/commit/9860888666f7e96a37d0a412ee80be065ea74903) fix: set the credentials even if not provided
* fsverity_test.go: fix nil pointer derefence, fix test fail, fix minor/major device numbers resolving ([#10978](https://github.com/containerd/containerd/pull/10978))
  * [`30b929ece`](https://github.com/containerd/containerd/commit/30b929ece7e79e030a710de13a58d73b79853e7c) fsverity_test.go: fix major/minor device number resolving
  * [`10996a334`](https://github.com/containerd/containerd/commit/10996a334b2d507e919244fd60be09f62384e3c0) fsverity_test.go: fix nil pointer dereference, fix test fail
* update runc binary to 1.2.2 ([#11023](https://github.com/containerd/containerd/pull/11023))
  * [`9081e979f`](https://github.com/containerd/containerd/commit/9081e979f7c8e6c0628fd1796cccb5d08d714f11) update runc binary to 1.2.2
* Revert "Disable vagrant strict dependency checking" ([#11009](https://github.com/containerd/containerd/pull/11009))
  * [`6399c936f`](https://github.com/containerd/containerd/commit/6399c936fa46999d893fb2309f9a9453c9f7951a) Revert "Disable vagrant strict dependency checking"
* fsverity_linux.go: Fix fsverity.IsEnabled() for big endian systems ([#11005](https://github.com/containerd/containerd/pull/11005))
  * [`a7f2b562f`](https://github.com/containerd/containerd/commit/a7f2b562f3b6f87733ae4e3e4fd04afad3b24816) fsverity_linux.go: Fix fsverity.IsEnabled() for big endian systems
* bump github.com/containerd/typeurl/v2 from 2.2.2 to 2.2.3 ([#10997](https://github.com/containerd/containerd/pull/10997))
  * [`389e781ea`](https://github.com/containerd/containerd/commit/389e781ea10b81d97093eee94e7dba55620f844f) build(deps): bump github.com/containerd/typeurl/v2 from 2.2.2 to 2.2.3
* update to go1.23.3 / go1.22.9 ([#10973](https://github.com/containerd/containerd/pull/10973))
  * [`5b879f30c`](https://github.com/containerd/containerd/commit/5b879f30c05d88f98455dc76f4fe296cb9771b56) update to go1.23.3 / go1.22.9
* ci: enable marking 2.0 releases as latest ([#10963](https://github.com/containerd/containerd/pull/10963))
  * [`458215f6c`](https://github.com/containerd/containerd/commit/458215f6cf256d644239eed9ff40db1b2eceaeb6) ci: enable marking 2.0 releases as latest
* Avoid arch info in the sed/replace when building cri-cni-containerd.tar.gz ([#10968](https://github.com/containerd/containerd/pull/10968))
  * [`e99c2b55c`](https://github.com/containerd/containerd/commit/e99c2b55c3fcbb2e04e0bc2fed37b0c2d7fe9245) Avoid arch info in the sed/replace when building cri-cni-containerd.tar.gz
</p>
</details>

### Changes from containerd/go-cni
<details><summary>7 commits</summary>
<p>

* Support CNI STATUS Verb ([containerd/go-cni#123](https://github.com/containerd/go-cni/pull/123))
  * [`208eca9`](https://github.com/containerd/go-cni/commit/208eca91c33bb793f471831a0abaf6cebe9676a4) support CNI status verb
* Bump github actions dependencies to match containerd CI repo and fix lint ([containerd/go-cni#122](https://github.com/containerd/go-cni/pull/122))
  * [`386f475`](https://github.com/containerd/go-cni/commit/386f4757e63914b2589b8abe6098bfa23f83fa8b) Fix ci.yml indent
  * [`a9b0675`](https://github.com/containerd/go-cni/commit/a9b0675fc9b8b5ce52d84f91a4fc049501853862) Another doc commit to trigger lint?
  * [`14af454`](https://github.com/containerd/go-cni/commit/14af4542b76fa694f2e1853b35554f23c6829f5d) Bump github actions dependency versions
  * [`9e0d096`](https://github.com/containerd/go-cni/commit/9e0d096d58145757809ddce8b8650efc07e19916) Trivial doc commit to trigger lint
</p>
</details>

### Dependency Changes

* **github.com/containerd/go-cni**      v1.1.10 -> v1.1.11
* **github.com/containerd/typeurl/v2**  v2.2.2 -> v2.2.3

Previous release can be found at [v2.0.0](https://github.com/containerd/containerd/releases/tag/v2.0.0)
### Which file should I download?
* `containerd-<VERSION>-<OS>-<ARCH>.tar.gz`:         ✅Recommended. Dynamically linked with glibc 2.31 (Ubuntu 20.04).
* `containerd-static-<VERSION>-<OS>-<ARCH>.tar.gz`:  Statically linked. Expected to be used on non-glibc Linux distributions. Not position-independent.

In addition to containerd, typically you will have to install [runc](https://github.com/opencontainers/runc/releases)
and [CNI plugins](https://github.com/containernetworking/plugins/releases) from their official sites too.

See also the [Getting Started](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) documentation.

