### PR TITLE
fix: allow non-OCI layers

### DIFF
--- a/client/image.go
+++ b/client/image.go
@@ -391,9 +391,7 @@ func (i *image) getLayers(ctx context.Context, manifest ocispec.Manifest) ([]roo
 	// parse out the image layers from oci artifact layers
 	imageLayers := []ocispec.Descriptor{}
 	for _, ociLayer := range manifest.Layers {
-		if images.IsLayerType(ociLayer.MediaType) {
-			imageLayers = append(imageLayers, ociLayer)
-		}
+		imageLayers = append(imageLayers, ociLayer)
 	}
 	if len(diffIDs) != len(imageLayers) {
 		return nil, errors.New("mismatched image rootfs and manifest layers")


### PR DESCRIPTION
https://github.com/opencontainers/image-spec/issues/1190 
https://www.cyphar.com/blog/post/20190121-ociv2-images-i-tar

As part of improving handling large images and also broadly considering building layers as full mountable filesystems, relax the layer type check.

This allows containerd clients to pull and produce rootfs simply by mounting them.