### PR TITLE
Update golangci-lint version in dev tools script

### DIFF
--- a/script/setup/install-dev-tools
+++ b/script/setup/install-dev-tools
@@ -23,7 +23,7 @@ set -eu -o pipefail
 go install github.com/containerd/protobuild@v0.3.0
 go install github.com/containerd/protobuild/cmd/go-fix-acronym@v0.3.0
 go install github.com/cpuguy83/go-md2man/v2@v2.0.2
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.1
 go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.1
 go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2.0
 go install github.com/containerd/ttrpc/cmd/protoc-gen-go-ttrpc@v1.2.5


### PR DESCRIPTION
`script/setup/install-dev-tools` currently installs v1.54.2, which cannot be built with `GOPROXY=direct` as it takes a dependency on `go.tmz.dev/musttag` which no longer exists. This is fixed in [v1.56.0](https://github.com/golangci/golangci-lint/releases/tag/v1.56.0) where the dependency was replaced with `go-simpler.org/musttag`.

```bash
$ go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
go: downloading go.tmz.dev/musttag v0.7.2
../go/pkg/mod/github.com/golangci/golangci-lint@v1.54.2/pkg/golinters/musttag.go:4:2: unrecognized import path "go.tmz.dev/musttag": https fetch: Get "https://go.tmz.dev/musttag?go-get=1": dial tcp: lookup go.tmz.dev on 127.0.0.1:53: no such host
```

This PR updates the script to match the version of the linter used in the [CI](https://github.com/containerd/containerd/blob/a5aaa403b8a5aee1e98c5dcdf00cdb62b153b123/.github/workflows/ci.yml#L36) at the time of this PR.