### PR TITLE
Update golangci to 1.60.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: ./.github/actions/install-go
       - uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
         with:
-          version: v1.60.1
+          version: v1.60.3
           skip-cache: true
           args: --timeout=8m
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 linters:
   enable:
     - depguard # Checks for dependencies that should not be (re)introduced. See "linter-settings" for further details.
-    - exportloopref # Checks for pointers to enclosing loop variables
+    # - copyloopvar # Checks for loop variable copies in Go 1.22+
     - gofmt
     - goimports
     - gosec
@@ -73,6 +73,7 @@ linters-settings:
       - G306
       - G402
       - G404
+      - G115
   nolintlint:
     allow-unused: true
 


### PR DESCRIPTION
Updates to the latest golangci 1.60. This will can backported, separately we can move ahead to latest release.

The exportloopref is deprecated for copyloopvar with Go 1.22+. We can enable this separately, it requires changes in over 100 places.