### PR TITLE
Remove loop variable copies

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 linters:
   enable:
     - depguard # Checks for dependencies that should not be (re)introduced. See "linter-settings" for further details.
-    # - copyloopvar # Checks for loop variable copies in Go 1.22+
+    - copyloopvar # Checks for loop variable copies in Go 1.22+
     - gofmt
     - goimports
     - gosec

--- a/client/containerstore.go
+++ b/client/containerstore.go
@@ -181,7 +181,6 @@ func containerFromProto(containerpb *containersapi.Container) containers.Contain
 	}
 	extensions := make(map[string]typeurl.Any)
 	for k, v := range containerpb.Extensions {
-		v := v
 		extensions[k] = v
 	}
 	return containers.Container{
@@ -203,7 +202,6 @@ func containersFromProto(containerspb []*containersapi.Container) []containers.C
 	var containers []containers.Container
 
 	for _, container := range containerspb {
-		container := container
 		containers = append(containers, containerFromProto(container))
 	}
 

--- a/client/image_store.go
+++ b/client/image_store.go
@@ -142,7 +142,6 @@ func imagesFromProto(imagespb []*imagesapi.Image) []images.Image {
 	var images []images.Image
 
 	for _, image := range imagespb {
-		image := image
 		images = append(images, imageFromProto(image))
 	}
 

--- a/core/content/helpers_test.go
+++ b/core/content/helpers_test.go
@@ -172,7 +172,6 @@ func TestCopy(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			err := Copy(context.Background(),
 				&testcase.writer,

--- a/core/images/converter/default.go
+++ b/core/images/converter/default.go
@@ -165,8 +165,6 @@ func (c *defaultConverter) convertManifest(ctx context.Context, cs content.Store
 	var mu sync.Mutex
 	eg, ctx2 := errgroup.WithContext(ctx)
 	for i, l := range manifest.Layers {
-		i := i
-		l := l
 		oldDiffID, err := images.GetDiffID(ctx, cs, l)
 		if err != nil {
 			return nil, err
@@ -249,8 +247,6 @@ func (c *defaultConverter) convertIndex(ctx context.Context, cs content.Store, d
 	var mu sync.Mutex
 	eg, ctx2 := errgroup.WithContext(ctx)
 	for i, mani := range index.Manifests {
-		i := i
-		mani := mani
 		labelKey := fmt.Sprintf("containerd.io/gc.ref.content.m.%d", i)
 		eg.Go(func() error {
 			if mani.Platform != nil && !c.platformMC.Match(*mani.Platform) {

--- a/core/images/handlers.go
+++ b/core/images/handlers.go
@@ -154,8 +154,6 @@ func WalkNotEmpty(ctx context.Context, handler Handler, descs ...ocispec.Descrip
 func Dispatch(ctx context.Context, handler Handler, limiter *semaphore.Weighted, descs ...ocispec.Descriptor) error {
 	eg, ctx2 := errgroup.WithContext(ctx)
 	for _, desc := range descs {
-		desc := desc
-
 		if limiter != nil {
 			if err := limiter.Acquire(ctx, 1); err != nil {
 				return err

--- a/core/images/usage/calculator_test.go
+++ b/core/images/usage/calculator_test.go
@@ -72,7 +72,6 @@ func TestUsageCalculation(t *testing.T) {
 		},
 		// TODO: Add test with snapshot
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := logtest.WithT(context.Background(), t)
 

--- a/core/leases/lease_test.go
+++ b/core/leases/lease_test.go
@@ -57,7 +57,6 @@ func TestWithLabels(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			lease := newLease(tc.initialLabels)
 			err := WithLabels(tc.labels)(lease)
@@ -66,7 +65,6 @@ func TestWithLabels(t *testing.T) {
 		})
 	}
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.name+"-WithLabel", func(t *testing.T) {
 			lease := newLease(tc.initialLabels)
 			for k, v := range tc.labels {

--- a/core/metadata/containers_test.go
+++ b/core/metadata/containers_test.go
@@ -148,7 +148,6 @@ func TestContainersList(t *testing.T) {
 			}
 
 			for _, result := range results {
-				result := result
 				checkContainersEqual(t, &result, testset[result.ID], "list results did not match")
 			}
 		})
@@ -618,7 +617,6 @@ func TestContainersCreateUpdateDelete(t *testing.T) {
 			},
 		},
 	} {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			testcase.original.ID = testcase.name
 			if testcase.input.ID == "" {

--- a/core/metadata/gc.go
+++ b/core/metadata/gc.go
@@ -171,7 +171,6 @@ func startGCContext(ctx context.Context, collectors map[gc.ResourceType]Collecto
 	if len(collectors) > 0 {
 		contexts = map[gc.ResourceType]CollectionContext{}
 		for rt, collector := range collectors {
-			rt := rt
 			c, err := collector.StartCollection(ctx)
 			if err != nil {
 				// Only skipping this resource this round

--- a/core/metadata/images_test.go
+++ b/core/metadata/images_test.go
@@ -128,7 +128,6 @@ func TestImagesList(t *testing.T) {
 			}
 
 			for _, result := range results {
-				result := result
 				checkImagesEqual(t, &result, testset[result.Name], "list results did not match")
 			}
 		})
@@ -531,7 +530,6 @@ func TestImagesCreateUpdateDelete(t *testing.T) {
 			cause: errdefs.ErrNotFound,
 		},
 	} {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			testcase.original.Name = testcase.name
 			if testcase.input.Name == "" {

--- a/core/metrics/cgroups/v1/oom.go
+++ b/core/metrics/cgroups/v1/oom.go
@@ -99,7 +99,6 @@ func (o *oomCollector) Collect(ch chan<- prometheus.Metric) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	for _, t := range o.set {
-		t := t
 		c := atomic.LoadInt64(&t.count)
 		ch <- prometheus.MustNewConstMetric(o.desc, prometheus.CounterValue, float64(c), t.id, t.namespace)
 	}

--- a/core/remotes/docker/fetcher_test.go
+++ b/core/remotes/docker/fetcher_test.go
@@ -207,7 +207,6 @@ func TestContentEncoding(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.encodingHeader, func(t *testing.T) {
 			t.Parallel()
 			content := make([]byte, 128)

--- a/core/remotes/docker/pusher_test.go
+++ b/core/remotes/docker/pusher_test.go
@@ -525,7 +525,6 @@ func Test_dockerPusher_push(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			desc := ocispec.Descriptor{
 				MediaType:   test.args.mediatype,

--- a/core/sandbox/helpers.go
+++ b/core/sandbox/helpers.go
@@ -53,7 +53,6 @@ func FromProto(sandboxpb *types.Sandbox) Sandbox {
 
 	extensions := make(map[string]typeurl.Any)
 	for k, v := range sandboxpb.Extensions {
-		v := v
 		extensions[k] = v
 	}
 

--- a/core/transfer/image/imagestore_test.go
+++ b/core/transfer/image/imagestore_test.go
@@ -198,7 +198,6 @@ func TestStore(t *testing.T) {
 			Images:      []string{"registry.test/index:latest"},
 		},
 	} {
-		testCase := testCase
 		for _, a := range testCase.Annotations {
 			name := testCase.Name + "_" + a
 			dgst := digest.Canonical.FromString(name)

--- a/core/transfer/local/import.go
+++ b/core/transfer/local/import.go
@@ -128,7 +128,6 @@ func (ts *localTransferService) importStream(ctx context.Context, i transfer.Ima
 	}
 
 	for _, desc := range descriptors {
-		desc := desc
 		imgs, err := is.Store(ctx, desc, ts.images)
 		if err != nil {
 			if errdefs.IsNotFound(err) {

--- a/core/transfer/local/pull_test.go
+++ b/core/transfer/local/pull_test.go
@@ -120,7 +120,6 @@ func TestGetSupportedPlatform(t *testing.T) {
 			},
 		},
 	} {
-		testCase := testCase
 		t.Run(testCase.Name, func(t *testing.T) {
 			m, sp := getSupportedPlatform(testCase.UnpackConfig, testCase.SupportedPlatforms)
 

--- a/core/unpack/unpacker.go
+++ b/core/unpack/unpacker.go
@@ -453,7 +453,6 @@ func (u *Unpacker) fetch(ctx context.Context, h images.Handler, layers []ocispec
 			tracing.Attribute("layer.media.size", desc.Size),
 			tracing.Attribute("layer.media.digest", desc.Digest.String()),
 		)
-		desc := desc
 		var ch chan struct{}
 		if done != nil {
 			ch = done[i]

--- a/integration/addition_gids_test.go
+++ b/integration/addition_gids_test.go
@@ -80,7 +80,6 @@ func TestAdditionalGids(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		i, tc := i, tc
 		tBasename := fmt.Sprintf("case-%d", i)
 		t.Run(tBasename, func(t *testing.T) {
 			t.Log(tc.description)

--- a/integration/client/container_linux_test.go
+++ b/integration/client/container_linux_test.go
@@ -1583,7 +1583,6 @@ func TestIssue9103(t *testing.T) {
 			expectedStatus: Stopped,
 		},
 	} {
-		tc := tc
 		tName := fmt.Sprintf("%s%d", id, idx)
 		t.Run(tc.desc, func(t *testing.T) {
 			container, err := client.NewContainer(ctx, tName,

--- a/integration/client/export_test.go
+++ b/integration/client/export_test.go
@@ -234,7 +234,6 @@ func TestExportAllCases(t *testing.T) {
 			},
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ctx, cancel := testContext(t)

--- a/integration/client/import_test.go
+++ b/integration/client/import_test.go
@@ -674,7 +674,6 @@ func TestTransferImport(t *testing.T) {
 			Opts:   []image.StoreOpt{image.WithDigestRef("registry.test/basename", true, false)},
 		},
 	} {
-		testCase := testCase
 		t.Run(testCase.Name, func(t *testing.T) {
 			tc := tartest.TarContext{}
 			files := []tartest.WriterToTar{

--- a/integration/client/migration_test.go
+++ b/integration/client/migration_test.go
@@ -79,7 +79,6 @@ func TestMigration(t *testing.T) {
 	}
 
 	for _, tc := range migrationTests {
-		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			buf := bytes.NewBuffer(nil)
 			cmd := exec.Command("containerd", "-c", tc.File, "config", "migrate")

--- a/integration/container_volume_test.go
+++ b/integration/container_volume_test.go
@@ -82,7 +82,6 @@ func TestContainerSymlinkVolumes(t *testing.T) {
 			createFileFn: symlinkedFileInSymlinkedFolder,
 		},
 	} {
-		testCase := testCase // capture range variable
 		t.Run(name, func(t *testing.T) {
 			testPodLogDir := t.TempDir()
 			testVolDir := t.TempDir()

--- a/internal/cri/config/config.go
+++ b/internal/cri/config/config.go
@@ -487,7 +487,6 @@ func ValidateImageConfig(ctx context.Context, c *ImageConfig) ([]deprecation.War
 			c.Registry.Configs = make(map[string]RegistryConfig)
 		}
 		for endpoint, auth := range c.Registry.Auths {
-			auth := auth
 			u, err := url.Parse(endpoint)
 			if err != nil {
 				return warnings, fmt.Errorf("failed to parse registry url %q from `registry.auths`: %w", endpoint, err)

--- a/internal/cri/config/config_test.go
+++ b/internal/cri/config/config_test.go
@@ -299,7 +299,6 @@ func TestHostAccessingSandbox(t *testing.T) {
 		{"Security Context namespace host access", hostNamespace, true},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if got := hostAccessingSandbox(tt.config); got != tt.want {
 				t.Errorf("hostAccessingSandbox() = %v, want %v", got, tt.want)

--- a/internal/cri/config/streaming_test.go
+++ b/internal/cri/config/streaming_test.go
@@ -116,7 +116,6 @@ func TestValidateStreamServer(t *testing.T) {
 			expectErr: true,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			tlsMode, err := getStreamListenerMode(&test.config)
 			if test.expectErr {

--- a/internal/cri/nri/nri_api_linux.go
+++ b/internal/cri/nri/nri_api_linux.go
@@ -394,7 +394,6 @@ func (a *API) ListContainers() []nri.Container {
 		case cri.ContainerState_CONTAINER_UNKNOWN:
 			continue
 		}
-		ctr := ctr
 		containers = append(containers, a.nriContainer(&ctr, nil))
 	}
 	return containers

--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -175,7 +175,6 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	}
 	var runtimeHandler *runtime.RuntimeHandler
 	for _, f := range c.runtimeHandlers {
-		f := f
 		if f.Name == sandbox.Metadata.RuntimeHandler {
 			runtimeHandler = f
 			break

--- a/internal/cri/server/container_create_linux_test.go
+++ b/internal/cri/server/container_create_linux_test.go
@@ -247,7 +247,6 @@ func TestContainerCapabilities(t *testing.T) {
 			excludes: util.SubtractStringSlice(allCaps, "CAP_SYS_ADMIN"),
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			containerConfig, sandboxConfig, imageConfig, specCheck := getCreateContainerTestData()
 			ociRuntime := config.Runtime{}
@@ -429,7 +428,6 @@ func TestContainerAndSandboxPrivileged(t *testing.T) {
 			expectError:         false,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			containerConfig.Linux.SecurityContext.Privileged = test.containerPrivileged
 			sandboxConfig.Linux.SecurityContext = &runtime.LinuxSandboxSecurityContext{
@@ -471,7 +469,6 @@ func TestPrivilegedBindMount(t *testing.T) {
 			expectedCgroupFSRO: false,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			containerConfig.Linux.SecurityContext.Privileged = test.privileged
 			sandboxConfig.Linux.SecurityContext.Privileged = test.privileged
@@ -588,7 +585,6 @@ func TestMountPropagation(t *testing.T) {
 			expectErr:         true,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			c := newTestCRIService()
 			c.os.(*ostesting.FakeOS).LookupMountFn = test.fakeLookupMountFn
@@ -645,7 +641,6 @@ func TestPidNamespace(t *testing.T) {
 			},
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			containerConfig.Linux.SecurityContext.NamespaceOptions = &runtime.NamespaceOption{Pid: test.pidNS}
 			spec, err := c.buildContainerSpec(currentPlatform, testID, testSandboxID, testPid, "", testContainerName, testImageName, containerConfig, sandboxConfig, imageConfig, nil, ociRuntime, nil)
@@ -811,7 +806,6 @@ func TestUserNamespace(t *testing.T) {
 			err: true,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			containerConfig.Linux.SecurityContext.NamespaceOptions = &runtime.NamespaceOption{UsernsOptions: test.userNS}
 			// By default, set sandbox and container config to the same (this is
@@ -991,7 +985,6 @@ func TestGenerateSeccompSecurityProfileSpecOpts(t *testing.T) {
 			},
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			cri := &criService{}
 			cri.config.UnsetSeccompProfile = test.defaultProfile
@@ -1167,7 +1160,6 @@ func TestGenerateApparmorSpecOpts(t *testing.T) {
 			},
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			asp := test.sp
 			csp, err := generateApparmorSecurityProfile(test.profile)
@@ -1273,7 +1265,6 @@ func TestMaskedAndReadonlyPaths(t *testing.T) {
 			privileged:       true,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			c.config.DisableProcMount = test.disableProcMount
 			containerConfig.Linux.SecurityContext.MaskedPaths = test.masked
@@ -1329,7 +1320,6 @@ func TestHostname(t *testing.T) {
 			expectedEnv: "HOSTNAME=real-hostname",
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			sandboxConfig.Hostname = test.hostname
 			sandboxConfig.Linux.SecurityContext = &runtime.LinuxSandboxSecurityContext{
@@ -1510,7 +1500,6 @@ additional-group-for-root:x:22222:root
 			expected: runtimespec.User{UID: 1000, GID: 2000, AdditionalGids: []uint32{2000, 3333}},
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			containerConfig, sandboxConfig, imageConfig, _ := getCreateContainerTestData()
 			containerConfig.Linux.SecurityContext = test.securityContext
@@ -1579,7 +1568,6 @@ func TestNonRootUserAndDevices(t *testing.T) {
 			expectedDeviceGID:                  *testDevice.GID,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			c.config.DeviceOwnershipFromSecurityContext = test.deviceOwnershipFromSecurityContext
 			containerConfig.Linux.SecurityContext.RunAsUser = test.uid
@@ -1657,7 +1645,6 @@ func TestPrivilegedDevices(t *testing.T) {
 			expectAllDevicesAllowed: true,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			containerConfig.Linux.SecurityContext.Privileged = test.privileged
 			sandboxConfig.Linux.SecurityContext.Privileged = test.privileged

--- a/internal/cri/server/container_create_test.go
+++ b/internal/cri/server/container_create_test.go
@@ -135,7 +135,6 @@ func TestPodAnnotationPassthroughContainerSpec(t *testing.T) {
 			},
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			c := newTestCRIService()
 			containerConfig, sandboxConfig, imageConfig, specCheck := getCreateContainerTestData()
@@ -209,7 +208,6 @@ func TestContainerSpecCommand(t *testing.T) {
 			expectErr: true,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			config, _, imageConfig, _ := getCreateContainerTestData()
 			config.Command = test.criEntrypoint
@@ -351,7 +349,6 @@ func TestVolumeMounts(t *testing.T) {
 			expectedMappings: idmap,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			config := &imagespec.ImageConfig{
 				Volumes: test.imageVolumes,
@@ -497,7 +494,6 @@ func TestContainerAnnotationPassthroughContainerSpec(t *testing.T) {
 			},
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			c := newTestCRIService()
 			containerConfig, sandboxConfig, imageConfig, specCheck := getCreateContainerTestData()
@@ -750,7 +746,6 @@ func TestLinuxContainerMounts(t *testing.T) {
 			expectedMounts:  nil,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			config := &runtime.ContainerConfig{
 				Metadata: &runtime.ContainerMetadata{

--- a/internal/cri/server/container_create_windows_test.go
+++ b/internal/cri/server/container_create_windows_test.go
@@ -245,7 +245,6 @@ func TestHostProcessRequirements(t *testing.T) {
 			expectError:          false,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			containerConfig.Windows.SecurityContext.HostProcess = test.containerHostProcess
 			sandboxConfig.Windows.SecurityContext = &runtime.WindowsSandboxSecurityContext{

--- a/internal/cri/server/container_list_test.go
+++ b/internal/cri/server/container_list_test.go
@@ -157,7 +157,6 @@ func TestFilterContainers(t *testing.T) {
 			expect: []*runtime.Container{testContainers[2]},
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			filtered := c.filterCRIContainers(testContainers, test.filter)
 			assert.Equal(t, test.expect, filtered, test.desc)
@@ -351,7 +350,6 @@ func TestListContainers(t *testing.T) {
 			expect: expectedContainers[:1],
 		},
 	} {
-		testdata := testdata
 		t.Run(testdata.desc, func(t *testing.T) {
 			resp, err := c.ListContainers(context.Background(), &runtime.ListContainersRequest{Filter: testdata.filter})
 			assert.NoError(t, err)

--- a/internal/cri/server/container_remove_test.go
+++ b/internal/cri/server/container_remove_test.go
@@ -70,7 +70,6 @@ func TestSetContainerRemoving(t *testing.T) {
 			expectErr: false,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			container, err := containerstore.NewContainer(
 				containerstore.Metadata{ID: testID},

--- a/internal/cri/server/container_start_test.go
+++ b/internal/cri/server/container_start_test.go
@@ -84,7 +84,6 @@ func TestSetContainerStarting(t *testing.T) {
 			expectErr: true,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			container, err := containerstore.NewContainer(
 				containerstore.Metadata{ID: testID},

--- a/internal/cri/server/container_stats_list_test.go
+++ b/internal/cri/server/container_stats_list_test.go
@@ -68,7 +68,6 @@ func TestContainerMetricsCPUNanoCoreUsage(t *testing.T) {
 			expectedNanoCoreUsageSecond: 0,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			container, err := containerstore.NewContainer(
 				containerstore.Metadata{ID: test.id},
@@ -126,7 +125,6 @@ func TestGetWorkingSet(t *testing.T) {
 			expected: 0,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			got := getWorkingSet(test.memory)
 			assert.Equal(t, test.expected, got)
@@ -162,7 +160,6 @@ func TestGetWorkingSetV2(t *testing.T) {
 			expected: 0,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			got := getWorkingSetV2(test.memory)
 			assert.Equal(t, test.expected, got)
@@ -200,7 +197,6 @@ func TestGetAvailableBytes(t *testing.T) {
 			expected:        5000 - 500,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			got := getAvailableBytes(test.memory, test.workingSetBytes)
 			assert.Equal(t, test.expected, got)
@@ -234,7 +230,6 @@ func TestGetAvailableBytesV2(t *testing.T) {
 			expected:        5000 - 500,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			got := getAvailableBytesV2(test.memory, test.workingSetBytes)
 			assert.Equal(t, test.expected, got)
@@ -342,7 +337,6 @@ func TestContainerMetricsMemory(t *testing.T) {
 			},
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			got, err := c.memoryContainerStats("ID", test.metrics, timestamp)
 			assert.NoError(t, err)

--- a/internal/cri/server/container_status_test.go
+++ b/internal/cri/server/container_status_test.go
@@ -145,7 +145,6 @@ func TestToCRIContainerStatus(t *testing.T) {
 			expectedReason: errorExitReason,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 
 			metadata, ctnr, status, _, expected := getContainerStatusTestData(t)
@@ -240,7 +239,6 @@ func TestContainerStatus(t *testing.T) {
 			expectErr:  true,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			c := newTestCRIService()
 			metadata, ctnr, status, image, expected := getContainerStatusTestData(t)

--- a/internal/cri/server/container_stop_test.go
+++ b/internal/cri/server/container_stop_test.go
@@ -65,7 +65,6 @@ func TestWaitContainerStop(t *testing.T) {
 			expectErr: false,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			c := newTestCRIService()
 			container, err := containerstore.NewContainer(

--- a/internal/cri/server/container_update_resources_linux_test.go
+++ b/internal/cri/server/container_update_resources_linux_test.go
@@ -236,7 +236,6 @@ func TestUpdateOCILinuxResource(t *testing.T) {
 			},
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			config := criconfig.Config{
 				RuntimeConfig: criconfig.RuntimeConfig{

--- a/internal/cri/server/helpers_test.go
+++ b/internal/cri/server/helpers_test.go
@@ -79,7 +79,6 @@ func TestGetUserFromImage(t *testing.T) {
 			name: "test",
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			actualUID, actualName := getUserFromImage(test.user)
 			assert.Equal(t, test.uid, actualUID)
@@ -148,7 +147,6 @@ systemd_cgroup = true
 			},
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			opts, err := criconfig.GenerateRuntimeOptions(test.r)
 			assert.NoError(t, err)
@@ -221,7 +219,6 @@ func TestEnvDeduplication(t *testing.T) {
 			},
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			var spec runtimespec.Spec
 			if len(test.existing) > 0 {
@@ -344,7 +341,6 @@ func TestValidateTargetContainer(t *testing.T) {
 			expectError:       true,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			targetContainer, err := c.validateTargetContainer(testSandboxID, test.targetContainerID)
 			if test.expectError {
@@ -408,7 +404,6 @@ func TestHostNetwork(t *testing.T) {
 			t.Skip()
 		}
 
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if hostNetwork(tt.c) != tt.expected {
 				t.Errorf("failed hostNetwork got %t expected %t", hostNetwork(tt.c), tt.expected)

--- a/internal/cri/server/images/check.go
+++ b/internal/cri/server/images/check.go
@@ -41,7 +41,6 @@ func (c *CRIImageService) CheckImages(ctx context.Context) error {
 	var wg sync.WaitGroup
 	for _, i := range cImages {
 		wg.Add(1)
-		i := i
 		go func() {
 			defer wg.Done()
 			// TODO: Check platform/snapshot combination. Snapshot check should come first

--- a/internal/cri/server/images/image_pull_test.go
+++ b/internal/cri/server/images/image_pull_test.go
@@ -113,7 +113,6 @@ func TestParseAuth(t *testing.T) {
 			expectedSecret: testPasswd,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			u, s, err := ParseAuth(test.auth, test.host)
 			assert.Equal(t, test.expectErr, err != nil)
@@ -272,7 +271,6 @@ func TestRegistryEndpoints(t *testing.T) {
 			},
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			c, _ := newTestCRIService()
 			c.config.Registry.Mirrors = test.mirrors
@@ -340,7 +338,6 @@ func TestDefaultScheme(t *testing.T) {
 			expected: "https",
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			got := defaultScheme(test.host)
 			assert.Equal(t, test.expected, got)
@@ -366,7 +363,6 @@ func TestEncryptedImagePullOpts(t *testing.T) {
 			expectedOpts: 0,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			c, _ := newTestCRIService()
 			c.config.ImageDecryption.KeyModel = test.keyModel

--- a/internal/cri/server/images/image_status_test.go
+++ b/internal/cri/server/images/image_status_test.go
@@ -112,7 +112,6 @@ func TestGetUserFromImage(t *testing.T) {
 			name: "test",
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			actualUID, actualName := getUserFromImage(test.user)
 			assert.Equal(t, test.uid, actualUID)

--- a/internal/cri/server/images/service_test.go
+++ b/internal/cri/server/images/service_test.go
@@ -119,7 +119,6 @@ func TestRuntimeSnapshotter(t *testing.T) {
 			expectSnapshotter: "devmapper",
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			cri, _ := newTestCRIService()
 			cri.config = criconfig.DefaultImageConfig()

--- a/internal/cri/server/podsandbox/helpers_linux_test.go
+++ b/internal/cri/server/podsandbox/helpers_linux_test.go
@@ -60,7 +60,6 @@ func TestGetCgroupsPath(t *testing.T) {
 			expected:      "/test-id",
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			got := getCgroupsPath(test.cgroupsParent, testID)
 			assert.Equal(t, test.expected, got)

--- a/internal/cri/server/podsandbox/helpers_selinux_linux_test.go
+++ b/internal/cri/server/podsandbox/helpers_selinux_linux_test.go
@@ -86,7 +86,6 @@ func TestInitSelinuxOpts(t *testing.T) {
 			expectErr: true,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			processLabel, mountLabel, err := initLabelsFromOpt(test.selinuxOpt)
 			if test.expectErr {
@@ -167,7 +166,6 @@ func TestCheckSelinuxLevel(t *testing.T) {
 			expectNoMatch: true,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			err := checkSelinuxLevel(test.level)
 			if test.expectNoMatch {

--- a/internal/cri/server/podsandbox/helpers_test.go
+++ b/internal/cri/server/podsandbox/helpers_test.go
@@ -90,7 +90,6 @@ func TestEnvDeduplication(t *testing.T) {
 			},
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			var spec runtimespec.Spec
 			if len(test.existing) > 0 {

--- a/internal/cri/server/podsandbox/sandbox_run_linux_test.go
+++ b/internal/cri/server/podsandbox/sandbox_run_linux_test.go
@@ -422,7 +422,6 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 			},
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			c := newControllerService()
 			c.config.RootDir = t.TempDir()
@@ -704,7 +703,6 @@ options timeout:1
 			},
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			c := newControllerService()
 			c.os.(*ostesting.FakeOS).HostnameFn = func() (string, error) {
@@ -778,7 +776,6 @@ options timeout:1
 `,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			resolvContent, err := parseDNSOptions(test.servers, test.searches, test.options)
 			if test.expectErr {

--- a/internal/cri/server/podsandbox/sandbox_run_test.go
+++ b/internal/cri/server/podsandbox/sandbox_run_test.go
@@ -100,7 +100,6 @@ func TestSandboxContainerSpec(t *testing.T) {
 			},
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			c := newControllerService()
 			config, imageConfig, specCheck := getRunPodSandboxTestData(c.config)
@@ -153,7 +152,6 @@ func TestTypeurlMarshalUnmarshalSandboxMeta(t *testing.T) {
 			},
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			meta := &sandboxstore.Metadata{
 				ID:        "1",

--- a/internal/cri/server/restart.go
+++ b/internal/cri/server/restart.go
@@ -69,7 +69,6 @@ func (c *criService) recover(ctx context.Context) error {
 
 	eg, ctx2 := errgroup.WithContext(ctx)
 	for _, sandbox := range sandboxes {
-		sandbox := sandbox
 		eg.Go(func() error {
 			sb, err := podSandboxLoader.RecoverContainer(ctx2, sandbox)
 			if err != nil {
@@ -150,7 +149,6 @@ func (c *criService) recover(ctx context.Context) error {
 	}
 
 	for _, sb := range c.sandboxStore.List() {
-		sb := sb
 		status := sb.Status.Get()
 		if status.State == sandboxstore.StateNotReady {
 			continue
@@ -169,7 +167,6 @@ func (c *criService) recover(ctx context.Context) error {
 	}
 	eg, ctx2 = errgroup.WithContext(ctx)
 	for _, container := range containers {
-		container := container
 		eg.Go(func() error {
 			cntr, err := c.loadContainer(ctx2, container)
 			if err != nil {

--- a/internal/cri/server/runtime_config_linux_test.go
+++ b/internal/cri/server/runtime_config_linux_test.go
@@ -91,7 +91,6 @@ func TestRuntimeConfig(t *testing.T) {
 			expectedCgroupDriver: runtime.CgroupDriver_SYSTEMD,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			c := newTestCRIService()
 			c.config.RuntimeConfig.ContainerdConfig.DefaultRuntimeName = test.defaultRuntime

--- a/internal/cri/server/sandbox_list_test.go
+++ b/internal/cri/server/sandbox_list_test.go
@@ -74,7 +74,6 @@ func TestToCRISandbox(t *testing.T) {
 			expectedState: runtime.PodSandboxState_SANDBOX_NOTREADY,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			status := sandboxstore.Status{
 				CreatedAt: createdAt,
@@ -216,7 +215,6 @@ func TestFilterSandboxes(t *testing.T) {
 			expect: []*runtime.PodSandbox{testSandboxes[2]},
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			filtered := c.filterCRISandboxes(testSandboxes, test.filter)
 			assert.Equal(t, test.expect, filtered, test.desc)

--- a/internal/cri/server/sandbox_run_test.go
+++ b/internal/cri/server/sandbox_run_test.go
@@ -122,7 +122,6 @@ func TestToCNIPortMappings(t *testing.T) {
 			},
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			assert.Equal(t, test.cniPortMappings, toCNIPortMappings(test.criPortMappings))
 		})
@@ -176,7 +175,6 @@ func TestSelectPodIP(t *testing.T) {
 			expectedAdditionalIPs: []string{"2001:db8:85a3::8a2e:370:7334", "2001:db8:85a3::8a2e:370:7335", "192.168.17.45"},
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			var ipConfigs []*cni.IPConfig
 			for _, ip := range test.ips {

--- a/internal/cri/server/sandbox_stats_list.go
+++ b/internal/cri/server/sandbox_stats_list.go
@@ -39,7 +39,6 @@ func (c *criService) ListPodSandboxStats(
 
 	var wg sync.WaitGroup
 	for i, sandbox := range sandboxes {
-		i, sandbox := i, sandbox
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/internal/cri/server/sandbox_stats_windows_test.go
+++ b/internal/cri/server/sandbox_stats_windows_test.go
@@ -49,7 +49,6 @@ func TestGetUsageNanoCores(t *testing.T) {
 			expectedNanoCoreUsageSecond: 450,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			container, err := containerstore.NewContainer(
 				containerstore.Metadata{ID: ID},
@@ -362,7 +361,6 @@ func Test_criService_podSandboxStats(t *testing.T) {
 			expectError:            true,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			actualPodStats, actualContainerStats, err := c.toPodSandboxStats(test.sandbox, test.metrics, test.containers, currentStatsTimestamp)
 			if test.expectError {
@@ -567,7 +565,6 @@ func Test_criService_saveSandBoxMetrics(t *testing.T) {
 			},
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			c := newTestCRIService()
 			c.sandboxStore.Add(sandboxstore.Sandbox{

--- a/internal/cri/server/sandbox_status_test.go
+++ b/internal/cri/server/sandbox_status_test.go
@@ -125,7 +125,6 @@ func TestPodSandboxStatus(t *testing.T) {
 			expectedState: runtime.PodSandboxState_SANDBOX_NOTREADY,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			expected.State = test.expectedState
 			got := toCRISandboxStatus(metadata, test.state, createdAt, ip, additionalIPs)

--- a/internal/cri/server/sandbox_stop_test.go
+++ b/internal/cri/server/sandbox_stop_test.go
@@ -55,7 +55,6 @@ func TestWaitSandboxStop(t *testing.T) {
 			expectErr: false,
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			c := newTestCRIService()
 			sandbox := sandboxstore.NewSandbox(

--- a/internal/cri/server/update_runtime_config_test.go
+++ b/internal/cri/server/update_runtime_config_test.go
@@ -97,7 +97,6 @@ func TestUpdateRuntimeConfig(t *testing.T) {
 			expectCNIConfig: true,
 		},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			testDir := t.TempDir()
 			templateName := filepath.Join(testDir, "template")

--- a/internal/cri/util/references_test.go
+++ b/internal/cri/util/references_test.go
@@ -76,7 +76,6 @@ func TestGetRepoDigestAndTag(t *testing.T) {
 			expectedRepoTag:    "",
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			named, err := reference.ParseDockerRef(test.ref)
 			assert.NoError(t, err)

--- a/internal/cri/util/util_test.go
+++ b/internal/cri/util/util_test.go
@@ -131,7 +131,6 @@ func TestPassThroughAnnotationsFilter(t *testing.T) {
 			},
 		},
 	} {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			passthroughAnnotations := GetPassthroughAnnotations(test.podAnnotations, test.runtimePodAnnotations)
 			assert.Equal(t, test.passthroughAnnotations, passthroughAnnotations)

--- a/pkg/kernelversion/kernel_linux_test.go
+++ b/pkg/kernelversion/kernel_linux_test.go
@@ -70,7 +70,6 @@ func TestParseRelease(t *testing.T) {
 		{in: "3.-8", expectedErr: fmt.Errorf(`failed to parse kernel version "3.-8": expected integer`)},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.in, func(t *testing.T) {
 			version, err := parseRelease(tc.in)
 			if tc.expectedErr != nil {
@@ -129,7 +128,6 @@ func TestGreaterEqualThan(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.doc+": "+tc.in.String(), func(t *testing.T) {
 			ok, err := GreaterEqualThan(tc.in)
 			if err != nil {

--- a/pkg/oci/spec_opts_linux_test.go
+++ b/pkg/oci/spec_opts_linux_test.go
@@ -71,7 +71,6 @@ guest:x:405:100:guest:/dev/null:/sbin/nologin
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(fmt.Sprintf("user %d", testCase.userID), func(t *testing.T) {
 			t.Parallel()
 			s := Spec{
@@ -131,7 +130,6 @@ guest:x:405:100:guest:/dev/null:/sbin/nologin
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.user, func(t *testing.T) {
 			t.Parallel()
 			s := Spec{
@@ -201,7 +199,6 @@ sys:x:3:root,bin,adm
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.user, func(t *testing.T) {
 			t.Parallel()
 			s := Spec{
@@ -605,7 +602,6 @@ daemon:x:2:root,bin,daemon
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			s := Spec{
@@ -663,7 +659,6 @@ func TestWithAppendAdditionalGroupsNoEtcGroup(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			s := Spec{

--- a/pkg/oci/spec_opts_test.go
+++ b/pkg/oci/spec_opts_test.go
@@ -587,7 +587,6 @@ func TestDevShmSize(t *testing.T) {
 
 	expected := "1024k"
 	for _, s := range ss {
-		s := s
 		if err := WithDevShmSize(1024)(nil, nil, nil, &s); err != nil {
 			if err != ErrNoShmMount {
 				t.Fatal(err)

--- a/pkg/snapshotters/annotations_test.go
+++ b/pkg/snapshotters/annotations_test.go
@@ -57,7 +57,6 @@ func TestImageLayersLabel(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			sampleLayers := make([]imagespec.Descriptor, 0, tt.layersNum)
 			for i := 0; i < tt.layersNum; i++ {

--- a/plugins/content/local/store_test.go
+++ b/plugins/content/local/store_test.go
@@ -255,7 +255,6 @@ func BenchmarkIngests(b *testing.B) {
 		512 << 10,
 		1 << 20,
 	} {
-		size := size
 		b.Run(fmt.Sprint(size), func(b *testing.B) {
 			b.StopTimer()
 			blobs := generateBlobs(b, int64(b.N), size)

--- a/plugins/restart/monitor.go
+++ b/plugins/restart/monitor.go
@@ -106,7 +106,6 @@ func (m *monitor) reconcile(ctx context.Context) error {
 	}
 	var wgNSLoop sync.WaitGroup
 	for _, name := range ns {
-		name := name
 		wgNSLoop.Add(1)
 		go func() {
 			defer wgNSLoop.Done()
@@ -118,7 +117,6 @@ func (m *monitor) reconcile(ctx context.Context) error {
 			}
 			var wgChangesLoop sync.WaitGroup
 			for _, c := range changes {
-				c := c
 				wgChangesLoop.Add(1)
 				go func() {
 					defer wgChangesLoop.Done()

--- a/plugins/services/containers/helpers.go
+++ b/plugins/services/containers/helpers.go
@@ -28,7 +28,6 @@ func containersToProto(containers []containers.Container) []*api.Container {
 	var containerspb []*api.Container
 
 	for _, image := range containers {
-		image := image
 		containerspb = append(containerspb, containerToProto(&image))
 	}
 
@@ -68,7 +67,6 @@ func containerFromProto(containerpb *api.Container) containers.Container {
 	}
 	extensions := make(map[string]typeurl.Any)
 	for k, v := range containerpb.Extensions {
-		v := v
 		extensions[k] = v
 	}
 	return containers.Container{

--- a/plugins/services/images/helpers.go
+++ b/plugins/services/images/helpers.go
@@ -27,7 +27,6 @@ func imagesToProto(images []images.Image) []*imagesapi.Image {
 	var imagespb []*imagesapi.Image
 
 	for _, image := range images {
-		image := image
 		imagespb = append(imagespb, imageToProto(&image))
 	}
 

--- a/plugins/services/introspection/local.go
+++ b/plugins/services/introspection/local.go
@@ -101,7 +101,6 @@ func (l *Local) Plugins(ctx context.Context, fs ...string) (*api.PluginsResponse
 	var plugins []*api.Plugin
 	allPlugins := l.getPlugins()
 	for _, p := range allPlugins {
-		p := p
 		if filter.Match(adaptPlugin(p)) {
 			plugins = append(plugins, p)
 		}


### PR DESCRIPTION
This change removes loop variable copies which is no longer an issue with Go1.22+ semantics.