### PR TITLE
Transfer Service: enable remote snapshotters to use transfer service for registry authentication

### DIFF
--- a/cmd/ctr/commands/resolver.go
+++ b/cmd/ctr/commands/resolver.go
@@ -34,7 +34,8 @@ import (
 	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/containerd/containerd/v2/core/remotes/docker"
 	"github.com/containerd/containerd/v2/core/remotes/docker/config"
-	"github.com/containerd/containerd/v2/core/transfer/registry"
+	"github.com/containerd/containerd/v2/core/transfer"
+	registryauth "github.com/containerd/containerd/v2/core/transfer/registry/auth"
 	"github.com/containerd/log"
 	"github.com/urfave/cli/v2"
 )
@@ -223,7 +224,7 @@ type staticCredentials struct {
 }
 
 // NewStaticCredentials gets credentials from passing in cli context
-func NewStaticCredentials(ctx context.Context, cliContext *cli.Context, ref string) (registry.CredentialHelper, error) {
+func NewStaticCredentials(ctx context.Context, cliContext *cli.Context, ref string) (registryauth.CredentialHelper, error) {
 	username := cliContext.String("user")
 	var secret string
 	if i := strings.IndexByte(username, ':'); i > 0 {
@@ -253,12 +254,12 @@ func NewStaticCredentials(ctx context.Context, cliContext *cli.Context, ref stri
 	}, nil
 }
 
-func (sc *staticCredentials) GetCredentials(ctx context.Context, ref, host string) (registry.Credentials, error) {
+func (sc *staticCredentials) GetCredentials(ctx context.Context, ref, host string) (transfer.Credentials, error) {
 	if ref == sc.ref {
-		return registry.Credentials{
+		return transfer.Credentials{
 			Username: sc.username,
 			Secret:   sc.secret,
 		}, nil
 	}
-	return registry.Credentials{}, nil
+	return transfer.Credentials{}, nil
 }

--- a/core/transfer/local/pull.go
+++ b/core/transfer/local/pull.go
@@ -27,6 +27,7 @@ import (
 	"github.com/containerd/containerd/v2/core/transfer"
 	"github.com/containerd/containerd/v2/core/unpack"
 	"github.com/containerd/containerd/v2/defaults"
+	snpkg "github.com/containerd/containerd/v2/pkg/snapshotters"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -201,6 +202,9 @@ func (ts *localTransferService) pull(ctx context.Context, ir transfer.ImageFetch
 			unpacker, err = unpack.NewUnpacker(ctx, ts.content, uopts...)
 			if err != nil {
 				return fmt.Errorf("unable to initialize unpacker: %w", err)
+			}
+			if ts.config.EnableRemoteSnapshotAnnotations {
+				handler = snpkg.AppendInfoHandlerWrapper(name)(handler)
 			}
 			handler = unpacker.Unpack(handler)
 		}

--- a/core/transfer/local/transfer.go
+++ b/core/transfer/local/transfer.go
@@ -189,4 +189,8 @@ type TransferConfig struct {
 
 	// RegistryConfigPath is a path to the root directory containing registry-specific configurations
 	RegistryConfigPath string
+
+	// EnableRemoteSnapshotAnnotations enables remote snapshotter annotations to be passed
+	// to the snapshotter.
+	EnableRemoteSnapshotAnnotations bool
 }

--- a/core/transfer/registry/auth/auth.go
+++ b/core/transfer/registry/auth/auth.go
@@ -1,0 +1,136 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+
+	transfertypes "github.com/containerd/containerd/api/types/transfer"
+	"github.com/containerd/containerd/v2/core/streaming"
+	"github.com/containerd/containerd/v2/core/transfer"
+	"github.com/containerd/log"
+	"github.com/containerd/typeurl/v2"
+)
+
+// From stream
+type CredentialHelper interface {
+	GetCredentials(ctx context.Context, ref, host string) (transfer.Credentials, error)
+}
+
+type credentialHelper struct {
+	sync.Mutex
+	stream streaming.Stream
+}
+
+func NewCredentialHelper(stream streaming.Stream) CredentialHelper {
+	return &credentialHelper{stream: stream}
+}
+
+func (cc *credentialHelper) GetCredentials(ctx context.Context, ref, host string) (transfer.Credentials, error) {
+	cc.Lock()
+	defer cc.Unlock()
+
+	ar := &transfertypes.AuthRequest{
+		Host:      host,
+		Reference: ref,
+	}
+	anyType, err := typeurl.MarshalAny(ar)
+	if err != nil {
+		return transfer.Credentials{}, err
+	}
+	if err := cc.stream.Send(anyType); err != nil {
+		return transfer.Credentials{}, err
+	}
+	resp, err := cc.stream.Recv()
+	if err != nil {
+		return transfer.Credentials{}, err
+	}
+	var s transfertypes.AuthResponse
+	if err := typeurl.UnmarshalTo(resp, &s); err != nil {
+		return transfer.Credentials{}, err
+	}
+	creds := transfer.Credentials{
+		Host: host,
+	}
+	switch s.AuthType {
+	case transfertypes.AuthType_CREDENTIALS:
+		creds.Username = s.Username
+		creds.Secret = s.Secret
+	case transfertypes.AuthType_REFRESH:
+		creds.Secret = s.Secret
+	case transfertypes.AuthType_HEADER:
+		creds.Header = s.Secret
+	}
+
+	return creds, nil
+}
+
+func ServeAuthStream(ctx context.Context, stream streaming.Stream, getCredentials func(ctx context.Context, ref, host string) (transfer.Credentials, error)) {
+	// Check for context cancellation as well
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		req, err := stream.Recv()
+		if err != nil {
+			// If not EOF, log error
+			return
+		}
+
+		var s transfertypes.AuthRequest
+		if err := typeurl.UnmarshalTo(req, &s); err != nil {
+			log.G(ctx).WithError(err).Error("failed to unmarshal credential request")
+			continue
+		}
+		creds, err := getCredentials(ctx, s.Reference, s.Host)
+		if err != nil {
+			log.G(ctx).WithError(err).Error("failed to get credentials")
+			continue
+		}
+		var resp transfertypes.AuthResponse
+		if creds.Header != "" {
+			resp.AuthType = transfertypes.AuthType_HEADER
+			resp.Secret = creds.Header
+		} else if creds.Username != "" {
+			resp.AuthType = transfertypes.AuthType_CREDENTIALS
+			resp.Username = creds.Username
+			resp.Secret = creds.Secret
+		} else {
+			resp.AuthType = transfertypes.AuthType_REFRESH
+			resp.Secret = creds.Secret
+		}
+
+		a, err := typeurl.MarshalAny(&resp)
+		if err != nil {
+			log.G(ctx).WithError(err).Error("failed to marshal credential response")
+			continue
+		}
+
+		if err := stream.Send(a); err != nil {
+			if !errors.Is(err, io.EOF) {
+				log.G(ctx).WithError(err).Error("unexpected send failure")
+			}
+			return
+		}
+	}
+}

--- a/core/transfer/transfer.go
+++ b/core/transfer/transfer.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/streaming"
 )
 
 type Transferrer interface {
@@ -100,6 +101,17 @@ type ImageUnpacker interface {
 	UnpackPlatforms() []UnpackConfiguration
 }
 
+type Credentials struct {
+	Host     string
+	Username string
+	Secret   string
+	Header   string
+}
+
+type ImageCredsProvider interface {
+	GetCredentials(ctx context.Context, ref, host string) (Credentials, error)
+}
+
 // ImagePlatformsGetter is type which returns configured platforms.
 type ImagePlatformsGetter interface {
 	Platforms() []ocispec.Platform
@@ -116,7 +128,8 @@ type UnpackConfiguration struct {
 type ProgressFunc func(Progress)
 
 type Config struct {
-	Progress ProgressFunc
+	Progress      ProgressFunc
+	StreamManager streaming.StreamManager
 }
 
 type Opt func(*Config)
@@ -124,6 +137,12 @@ type Opt func(*Config)
 func WithProgress(f ProgressFunc) Opt {
 	return func(opts *Config) {
 		opts.Progress = f
+	}
+}
+
+func WithStreamManager(sm streaming.StreamManager) Opt {
+	return func(opts *Config) {
+		opts.StreamManager = sm
 	}
 }
 

--- a/plugins/services/transfer/service.go
+++ b/plugins/services/transfer/service.go
@@ -89,6 +89,7 @@ func (s *service) Register(gs *grpc.Server) error {
 
 func (s *service) Transfer(ctx context.Context, req *transferapi.TransferRequest) (*emptypb.Empty, error) {
 	var transferOpts []transfer.Opt
+	transferOpts = append(transferOpts, transfer.WithStreamManager(s.streamManager))
 	if req.Options != nil {
 		if req.Options.ProgressStream != "" {
 			stream, err := s.streamManager.Get(ctx, req.Options.ProgressStream)

--- a/plugins/transfer/plugin.go
+++ b/plugins/transfer/plugin.go
@@ -143,6 +143,7 @@ func init() {
 				lc.UnpackPlatforms = append(lc.UnpackPlatforms, up)
 			}
 			lc.RegistryConfigPath = config.RegistryConfigPath
+			lc.EnableRemoteSnapshotAnnotations = config.EnableRemoteSnapshotAnnotations
 
 			return local.NewTransferService(ms.ContentStore(), metadata.NewImageStore(ms), lc), nil
 		},
@@ -161,6 +162,10 @@ type transferConfig struct {
 
 	// RegistryConfigPath is a path to the root directory containing registry-specific configurations
 	RegistryConfigPath string `toml:"config_path"`
+
+	// EnableRemoteSnapshotAnnotations enables remote snapshotter annotations to be passed
+	// to the snapshotter.
+	EnableRemoteSnapshotAnnotations bool `toml:"enable_remote_snapshot_annotations"`
 }
 
 type unpackConfiguration struct {


### PR DESCRIPTION
- Proposal: #9931
- Depends on #11195

This PR enables to use the transfer service's auth stream from remote snapshotters. This allow registry creds to be used by remote snapshotters. This PR implements the logic described in #9931:

> 1. For each pulling, the transfer service reserves a stream ID, passes this ID to the snapshotter (via annotations) and waits for that stream to be created by the snapshotter.
> 1. Snapshotter accesses to the stream API and creates a stream with that ID.
> 1. The transfer service starts sharing creds over that stream for the snapshotter.

## Additional context

- PoC patch for stargz-snapshotter: https://github.com/ktock/stargz-snapshotter/tree/transfer-auth-poc

