### PR TITLE
bump up ttrpc to use its MD.Clone

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/containerd/otelttrpc v0.0.0-20240305015340-ea5083fda723
 	github.com/containerd/platforms v1.0.0-rc.0
 	github.com/containerd/plugin v1.0.0
-	github.com/containerd/ttrpc v1.2.6
+	github.com/containerd/ttrpc v1.2.7
 	github.com/containerd/typeurl/v2 v2.2.3
 	github.com/containerd/zfs/v2 v2.0.0-rc.0
 	github.com/containernetworking/cni v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -696,8 +696,8 @@ github.com/containerd/platforms v1.0.0-rc.0/go.mod h1:T1XAzzOdYs3it7l073MNXyxRwQ
 github.com/containerd/plugin v1.0.0 h1:c8Kf1TNl6+e2TtMHZt+39yAPDbouRH9WAToRjex483Y=
 github.com/containerd/plugin v1.0.0/go.mod h1:hQfJe5nmWfImiqT1q8Si3jLv3ynMUIBB47bQ+KexvO8=
 github.com/containerd/ttrpc v1.2.2/go.mod h1:sIT6l32Ph/H9cvnJsfXM5drIVzTr5A2flTf1G5tYZak=
-github.com/containerd/ttrpc v1.2.6 h1:zG+Kn5EZ6MUYCS1t2Hmt2J4tMVaLSFEJVOraDQwNPC4=
-github.com/containerd/ttrpc v1.2.6/go.mod h1:YCXHsb32f+Sq5/72xHubdiJRQY9inL4a4ZQrAbN1q9o=
+github.com/containerd/ttrpc v1.2.7 h1:qIrroQvuOL9HQ1X6KHe2ohc7p+HP/0VE6XPU7elJRqQ=
+github.com/containerd/ttrpc v1.2.7/go.mod h1:YCXHsb32f+Sq5/72xHubdiJRQY9inL4a4ZQrAbN1q9o=
 github.com/containerd/typeurl/v2 v2.2.3 h1:yNA/94zxWdvYACdYO8zofhrTVuQY73fFU1y++dYSw40=
 github.com/containerd/typeurl/v2 v2.2.3/go.mod h1:95ljDnPfD3bAbDJRugOiShd/DlAAsxGtUBhJxIn7SCk=
 github.com/containerd/zfs/v2 v2.0.0-rc.0 h1:0dRlgpoaepW7HuovtcvYQMF7NlpceQVdn7+3Udeth4M=

--- a/pkg/namespaces/ttrpc.go
+++ b/pkg/namespaces/ttrpc.go
@@ -27,20 +27,12 @@ const (
 	TTRPCHeader = "containerd-namespace-ttrpc"
 )
 
-func copyMetadata(src ttrpc.MD) ttrpc.MD {
-	md := ttrpc.MD{}
-	for k, v := range src {
-		md[k] = append(md[k], v...)
-	}
-	return md
-}
-
 func withTTRPCNamespaceHeader(ctx context.Context, namespace string) context.Context {
 	md, ok := ttrpc.GetMetadata(ctx)
 	if !ok {
 		md = ttrpc.MD{}
 	} else {
-		md = copyMetadata(md)
+		md = md.Clone()
 	}
 	md.Set(TTRPCHeader, namespace)
 	return ttrpc.WithMetadata(ctx, md)

--- a/pkg/namespaces/ttrpc_test.go
+++ b/pkg/namespaces/ttrpc_test.go
@@ -27,7 +27,7 @@ import (
 func TestCopyTTRPCMetadata(t *testing.T) {
 	src := ttrpc.MD{}
 	src.Set("key", "a", "b", "c", "d")
-	md := copyMetadata(src)
+	md := src.Clone()
 
 	if !reflect.DeepEqual(src, md) {
 		t.Fatalf("metadata is copied incorrectly")

--- a/vendor/github.com/containerd/ttrpc/metadata.go
+++ b/vendor/github.com/containerd/ttrpc/metadata.go
@@ -62,6 +62,34 @@ func (m MD) Append(key string, values ...string) {
 	}
 }
 
+// Clone returns a copy of MD or nil if it's nil.
+// It's copied from golang's `http.Header.Clone` implementation:
+// https://cs.opensource.google/go/go/+/refs/tags/go1.23.4:src/net/http/header.go;l=94
+func (m MD) Clone() MD {
+	if m == nil {
+		return nil
+	}
+
+	// Find total number of values.
+	nv := 0
+	for _, vv := range m {
+		nv += len(vv)
+	}
+	sv := make([]string, nv) // shared backing array for headers' values
+	m2 := make(MD, len(m))
+	for k, vv := range m {
+		if vv == nil {
+			// Preserve nil values.
+			m2[k] = nil
+			continue
+		}
+		n := copy(sv, vv)
+		m2[k] = sv[:n:n]
+		sv = sv[n:]
+	}
+	return m2
+}
+
 func (m MD) setRequest(r *Request) {
 	for k, values := range m {
 		for _, v := range values {

--- a/vendor/github.com/containerd/ttrpc/server.go
+++ b/vendor/github.com/containerd/ttrpc/server.go
@@ -74,8 +74,17 @@ func (s *Server) RegisterService(name string, desc *ServiceDesc) {
 }
 
 func (s *Server) Serve(ctx context.Context, l net.Listener) error {
-	s.addListener(l)
+	s.mu.Lock()
+	s.addListenerLocked(l)
 	defer s.closeListener(l)
+
+	select {
+	case <-s.done:
+		s.mu.Unlock()
+		return ErrServerClosed
+	default:
+	}
+	s.mu.Unlock()
 
 	var (
 		backoff    time.Duration
@@ -188,9 +197,7 @@ func (s *Server) Close() error {
 	return err
 }
 
-func (s *Server) addListener(l net.Listener) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+func (s *Server) addListenerLocked(l net.Listener) {
 	s.listeners[l] = struct{}{}
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -193,7 +193,7 @@ github.com/containerd/platforms
 github.com/containerd/plugin
 github.com/containerd/plugin/dynamic
 github.com/containerd/plugin/registry
-# github.com/containerd/ttrpc v1.2.6
+# github.com/containerd/ttrpc v1.2.7
 ## explicit; go 1.19
 github.com/containerd/ttrpc
 # github.com/containerd/typeurl/v2 v2.2.3


### PR DESCRIPTION
ttrpc 1.2.7 adds a new `MD.Clone` method, which is based on golang's `http.Header.Clone` and more efficient (https://github.com/containerd/ttrpc/pull/177).

This PR upgrades ttrpc to 1.2.7 and replace `copyMetadata` with `MD.Clone`.