### PR TITLE
support cni config path to be delete and recreate

### DIFF
--- a/integration/rename_cni_dir_linux_test.go
+++ b/integration/rename_cni_dir_linux_test.go
@@ -1,0 +1,44 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// test issue https://github.com/containerd/containerd/issues/11209
+func TestCniDirRename(t *testing.T) {
+	err := os.Rename("/etc/cni/net.d", "/etc/cni/net.d1")
+	require.NoError(t, err)
+	time.Sleep(time.Second * 3)
+	status, err := runtimeService.Status()
+	require.NoError(t, err)
+	info := status.GetInfo()
+	require.Equal(t, true, strings.Contains(info["lastCNILoadStatus"], "cni config load failed"))
+	err = os.Rename("/etc/cni/net.d1", "/etc/cni/net.d")
+	require.NoError(t, err)
+	time.Sleep(time.Second * 6)
+	status, err = runtimeService.Status()
+	require.NoError(t, err)
+	info = status.GetInfo()
+	require.Equal(t, "OK", info["lastCNILoadStatus"])
+}


### PR DESCRIPTION
try to fix https://github.com/containerd/containerd/issues/11209

https://github.com/containerd/containerd/commit/0c2805a6e452dba5e42b3723b6ba069b811f7c9a
this pr will make containerd exited when delete /etc/cni/net.d
It is unfriendly.

```
time="2024-12-31T10:50:32.263769055+08:00" level=debug msg="receiving change event from cni conf dir: REMOVE        \"/etc/cni/net.d/10-containerd-net.conflist\""
time="2024-12-31T10:50:32.263998609+08:00" level=error msg="failed to reload cni configuration after receiving fs change event(REMOVE        \"/etc/cni/net.d/10-containerd-net.conflist\")" error="cni config load failed: no network config found in /etc/cni/net.d: cni plugin not initialized: failed to load cni config"
time="2024-12-31T10:50:32.264050064+08:00" level=debug msg="receiving change event from cni conf dir: REMOVE        \"/etc/cni/net.d/nerdctl-bridge.conflist\""
time="2024-12-31T10:50:32.264092318+08:00" level=error msg="failed to reload cni configuration after receiving fs change event(REMOVE        \"/etc/cni/net.d/nerdctl-bridge.conflist\")" error="cni config load failed: no network config found in /etc/cni/net.d: cni plugin not initialized: failed to load cni config"
time="2024-12-31T10:50:32.264140537+08:00" level=debug msg="receiving change event from cni conf dir: REMOVE        \"/etc/cni/net.d\""
time="2024-12-31T10:50:32.264183298+08:00" level=info msg="Stop CRI service"
time="2024-12-31T10:50:32.264442209+08:00" level=info msg="Event monitor stopped"
time="2024-12-31T10:50:32.264469735+08:00" level=info msg="Stream server stopped"
time="2024-12-31T10:50:32.264488865+08:00" level=fatal msg="Failed to run CRI service" error="cni network conf monitor error: cni conf dir is removed, stop watching"
exit status 1
```