### PR TITLE
[release/2.0] Add a build tag to disable std `plugin` import

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -122,6 +122,7 @@ make generate
 >   * `no_zfs`: A build tag disables building the ZFS snapshot driver.
 > * platform
 >   * `no_systemd`: disables any systemd specific code
+>   * `no_dynamic_plugins`: A build tag disables dynamic plugins.
 >
 > For example, adding `BUILDTAGS=no_btrfs` to your environment before calling the **binaries**
 > Makefile target will disable the btrfs driver within the containerd Go build.

--- a/cmd/containerd/server/server.go
+++ b/cmd/containerd/server/server.go
@@ -51,7 +51,6 @@ import (
 	ssapi "github.com/containerd/containerd/api/services/snapshots/v1"
 	"github.com/containerd/platforms"
 	"github.com/containerd/plugin"
-	"github.com/containerd/plugin/dynamic"
 	"github.com/containerd/plugin/registry"
 
 	srvconfig "github.com/containerd/containerd/v2/cmd/containerd/server/config"
@@ -476,7 +475,7 @@ func LoadPlugins(ctx context.Context, config *srvconfig.Config) ([]plugin.Regist
 	if path == "" {
 		path = filepath.Join(config.Root, "plugins")
 	}
-	if count, err := dynamic.Load(path); err != nil {
+	if count, err := loadDynamic(path); err != nil {
 		return nil, err
 	} else if count > 0 || config.PluginDir != "" { //nolint:staticcheck
 		config.PluginDir = path //nolint:staticcheck

--- a/cmd/containerd/server/server_no_plugins.go
+++ b/cmd/containerd/server/server_no_plugins.go
@@ -1,0 +1,24 @@
+//go:build no_dynamic_plugins
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+func loadDynamic(string) (loaded int, _ error) {
+	// dynamic plugins disabled through no_dynamic_plugins build-tag
+	return 0, nil
+}

--- a/cmd/containerd/server/server_plugins.go
+++ b/cmd/containerd/server/server_plugins.go
@@ -1,0 +1,25 @@
+//go:build !no_dynamic_plugins
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import "github.com/containerd/plugin/dynamic"
+
+func loadDynamic(path string) (loaded int, _ error) {
+	return dynamic.Load(path)
+}


### PR DESCRIPTION
Add a `no_dynamic_plugins` build tag to disable `plugins` in containerd, which makes it significantly smaller when used.

Similar to https://github.com/containerd/containerd/pull/11203 but for v2.0. See https://github.com/containerd/containerd/issues/11202 for context.

[Plugins are deprecated in v2.0 and will be removed in v2.1](https://github.com/containerd/containerd/blob/v2.0.1/RELEASES.md#deprecated-features) so this PR targets `release/2.0`, and it shouldn't be necessary to do a similar one for `main`.