### PR TITLE
feat: pass snapshot ref and layer annotations to snapshotter.Prepare

### DIFF
--- a/client/image.go
+++ b/client/image.go
@@ -38,6 +38,8 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+const labelSnapshotRef = "containerd.io/snapshot.ref"
+
 // Image describes an image used by containers
 type Image interface {
 	// Name of the image
@@ -333,7 +335,16 @@ func (i *image) Unpack(ctx context.Context, snapshotterName string, opts ...Unpa
 	}
 
 	for _, layer := range layers {
-		unpacked, err = rootfs.ApplyLayerWithOpts(ctx, layer, chain, sn, a, config.SnapshotOpts, config.ApplyOpts)
+		chainID := identity.ChainID(append(chain, layer.Diff.Digest)).String()
+		snLabels := snapshots.FilterInheritedLabels(layer.Blob.Annotations)
+		if snLabels == nil {
+			snLabels = make(map[string]string)
+		}
+		snLabels[labelSnapshotRef] = chainID
+
+		unpacked, err = rootfs.ApplyLayerWithOpts(ctx, layer, chain, sn, a,
+			append(config.SnapshotOpts, snapshots.WithLabels(snLabels)),
+			config.ApplyOpts)
 		if err != nil {
 			return fmt.Errorf("apply layer error for %q: %w", i.Name(), err)
 		}


### PR DESCRIPTION
When pulling an image, containerd passes the layer annotations and snapshot.ref to the Labels of the snapshot, which are then provided to the snapshotter's Prepare function. However, when creating a container, if containerd finds that the image's snapshot does not exist, it decompresses from content without passing these data. This leads to inconsistent behavior of the snapshotter's Prepare in the two scenarios.

This commit aims to ensure consistent behavior of the snapshotter's Prepare function during both the image pull and container creation processes.

