### PR TITLE
Avoid duplicated chain ID calculation in unpack

### DIFF
--- a/core/unpack/unpacker_test.go
+++ b/core/unpack/unpacker_test.go
@@ -1,0 +1,93 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package unpack
+
+import (
+	"crypto/rand"
+	"fmt"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/identity"
+)
+
+func generateRandomDiffIDs(t testing.TB, num int) []digest.Digest {
+	const size = 10
+	diffIDs := make([]digest.Digest, 0, num)
+	for i := 0; i < num; i++ {
+		b := make([]byte, size)
+		_, err := rand.Read(b)
+		if err != nil {
+			t.Fatalf("failed to generate random bytes: %v", err)
+		}
+		diffIDs = append(diffIDs, digest.FromBytes(b))
+	}
+	return diffIDs
+}
+
+func BenchmarkUnpackWithChainID(b *testing.B) {
+	// This simulates the old way of repeatedly calculating per-layer chainID
+	// as we unpack every layers, by calling `identity.ChainID`.
+	unpackWithChainID := func(diffIDs []digest.Digest) {
+		var chain []digest.Digest
+		for i := 0; i < len(diffIDs); i++ {
+			_ = identity.ChainID(chain) // parent layer chainID
+			chain = append(chain, diffIDs[i])
+			_ = identity.ChainID(chain).String() // current layer chainID
+		}
+		_ = identity.ChainID(chain).String()
+	}
+
+	numLayers := []int{5, 10, 25, 50}
+	for _, sz := range numLayers {
+		b.Run(fmt.Sprintf("num of layers: %d", sz), func(b *testing.B) {
+			diffIDs := generateRandomDiffIDs(b, sz)
+			for i := 0; i < b.N; i++ {
+				unpackWithChainID(diffIDs)
+			}
+		})
+	}
+}
+
+func BenchmarkUnpackWithChainIDs(b *testing.B) {
+	// This simulates the new way of pre-calculating all chainIDs for every layer
+	// by calling `identity.ChainIDs` once.
+	unpackWithChainIDs := func(diffIDs []digest.Digest) {
+		chainIDs := make([]digest.Digest, len(diffIDs))
+		copy(chainIDs, diffIDs)
+		chainIDs = identity.ChainIDs(chainIDs)
+		for i := 0; i < len(diffIDs); i++ {
+			if i > 0 {
+				_ = chainIDs[i-1].String() // parent layer chainID
+			}
+			_ = chainIDs[i].String() // current layer chainID
+		}
+		if len(chainIDs) > 0 {
+			_ = chainIDs[len(chainIDs)-1].String()
+		}
+	}
+
+	numLayers := []int{5, 10, 25, 50}
+	for _, sz := range numLayers {
+		b.Run(fmt.Sprintf("num of layers: %d", sz), func(b *testing.B) {
+			diffIDs := generateRandomDiffIDs(b, sz)
+			for i := 0; i < b.N; i++ {
+				unpackWithChainIDs(diffIDs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR optimizes the chain ID calculation in unpack so we only (pre-)calculate the chain ID for every layer **exactly once**, by calling `identity.ChainIDs(diffIDs)` with the full list of diffIDs.

Currently in `unpack` for every layer_i, we calculate the chain id of its parent layer_i-1 and layer_i *repeatedly*, by calling `identity.ChainID(diffIDs)` with diffIDs till layer_i. This involves:

1. Copy `diffIDs` to a new slice
2. Calculate chain ID for every index (by calling `ChainIDs`)
3. Return the final one as result of `identity.ChainID(diffIDs)`.

Also added a benchmark test showing that `identity.ChainIDs` is 5-50x faster than `identity.ChainID`, and 5-50x less allocations.

```shell
$ go test -bench=. -benchmem ./core/unpack
goos: linux
goarch: amd64
pkg: github.com/containerd/containerd/v2/core/unpack
cpu: Intel(R) Xeon(R) CPU @ 2.20GHz
BenchmarkUnpackWithChainID/num_of_layers:_5-4              24355             49402 ns/op           13683 B/op        194 allocs/op
BenchmarkUnpackWithChainID/num_of_layers:_10-4              5210            215237 ns/op           60592 B/op        835 allocs/op
BenchmarkUnpackWithChainID/num_of_layers:_25-4               850           1456219 ns/op          400479 B/op       5456 allocs/op
BenchmarkUnpackWithChainID/num_of_layers:_50-4               198           5971048 ns/op         1633152 B/op      22162 allocs/op
BenchmarkUnpackWithChainIDs/num_of_layers:_5-4            117663              9595 ns/op            2672 B/op         37 allocs/op
BenchmarkUnpackWithChainIDs/num_of_layers:_10-4            55521             21504 ns/op            5993 B/op         82 allocs/op
BenchmarkUnpackWithChainIDs/num_of_layers:_25-4            20600             57425 ns/op           15972 B/op        217 allocs/op
BenchmarkUnpackWithChainIDs/num_of_layers:_50-4            10345            117006 ns/op           32658 B/op        442 allocs/op
PASS
ok      github.com/containerd/containerd/v2/core/unpack 12.605s
```

ref: `identity.ChainID` logic that calculates chain id for every index and return the last one: https://github.com/opencontainers/image-spec/blob/5325ec48851022d6ded604199a3566254e72842a/identity/chainid.go#L30-L33