### PR TITLE
fix pinnedImages image config json name

### DIFF
--- a/internal/cri/config/config.go
+++ b/internal/cri/config/config.go
@@ -291,7 +291,7 @@ type ImageConfig struct {
 	//   "base": "docker.io/library/ubuntu:latest"
 	// Migrated from:
 	// (PluginConfig).SandboxImage string `toml:"sandbox_image" json:"sandboxImage"`
-	PinnedImages map[string]string `toml:"pinned_images" json:"pinned_images"`
+	PinnedImages map[string]string `toml:"pinned_images" json:"pinnedImages"`
 
 	// RuntimePlatforms is map between the runtime and the image platform to
 	// use for that runtime. When resolving an image for a runtime, this


### PR DESCRIPTION
This is introduced in https://github.com/containerd/containerd/pull/9617/files#diff-e8d6dbb2c75752c173c570eabb9961d5b0f3273b682788f2d7eab2f5ffd5d7d6R280.

It seems to be a typo. 

cc @fuweid @dmcgowan 

BTW, I saw this when looking into https://github.com/kubernetes/kubernetes/issues/129479. In containerd v2.0, `crictl info` will not include image related configurations, including the sandbox image. Is this intended?