### PR TITLE
Add snapshotter exports to unpack platform

### DIFF
--- a/core/transfer/local/pull.go
+++ b/core/transfer/local/pull.go
@@ -20,6 +20,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/remotes"
@@ -27,9 +31,6 @@ import (
 	"github.com/containerd/containerd/v2/core/transfer"
 	"github.com/containerd/containerd/v2/core/unpack"
 	"github.com/containerd/containerd/v2/defaults"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/log"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func (ts *localTransferService) pull(ctx context.Context, ir transfer.ImageFetcher, is transfer.ImageStorer, tops *transfer.Config) error {

--- a/core/unpack/unpacker.go
+++ b/core/unpack/unpacker.go
@@ -28,6 +28,15 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
+	"github.com/containerd/platforms"
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/identity"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/semaphore"
+
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/diff"
 	"github.com/containerd/containerd/v2/core/images"
@@ -37,14 +46,6 @@ import (
 	"github.com/containerd/containerd/v2/internal/kmutex"
 	"github.com/containerd/containerd/v2/pkg/labels"
 	"github.com/containerd/containerd/v2/pkg/tracing"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/log"
-	"github.com/containerd/platforms"
-	"github.com/opencontainers/go-digest"
-	"github.com/opencontainers/image-spec/identity"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"golang.org/x/sync/errgroup"
-	"golang.org/x/sync/semaphore"
 )
 
 const (
@@ -71,9 +72,10 @@ type unpackerConfig struct {
 type Platform struct {
 	Platform platforms.Matcher
 
-	SnapshotterKey string
-	Snapshotter    snapshots.Snapshotter
-	SnapshotOpts   []snapshots.Opt
+	SnapshotterKey     string
+	Snapshotter        snapshots.Snapshotter
+	SnapshotOpts       []snapshots.Opt
+	SnapshotterExports map[string]string
 
 	Applier   diff.Applier
 	ApplyOpts []diff.ApplyOpt


### PR DESCRIPTION
Allows the unpack operation to be optimized based on the specific snapshotter configuration.

For example, this could be used to indicate that additional annotations are needed for remote snapshotters.
This could also indicate support for alternative filesystems or formats which do not need traditional unpacking, such as erofs.