### PR TITLE
ci: fix the issue of config_file unset

### DIFF
--- a/script/test/utils.sh
+++ b/script/test/utils.sh
@@ -364,6 +364,6 @@ readiness_check() {
   done
   set -x
   cat "${report_dir}/containerd.log"
-  cat "${config_file}"
+  cat "${CONTAINERD_CONFIG_FILE}"
   set +x
 }


### PR DESCRIPTION
The config_file var wasn't set when CONTAINERD_CONFIG_FILE env was passed, thus it should use  CONTAINERD_CONFIG_FILE instead of config_file to access the containerd conf file.