### PR TITLE
[release/1.7] Prepare release notes for v1.7.25

### DIFF
--- a/releases/v1.7.25.toml
+++ b/releases/v1.7.25.toml
@@ -1,0 +1,27 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.7.24"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The twenty-fifth patch release for containerd 1.7 contains various fixes
+and updates.
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.7.24+unknown"
+	Version = "1.7.25+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated notes

----

Welcome to the v1.7.25 release of containerd!

The twenty-fifth patch release for containerd 1.7 contains various fixes
and updates.

### Highlights

* Update runc binary to v1.2.4 ([#11238](https://github.com/containerd/containerd/pull/11238))
* Fix proto conflicts and update to 1.8 API ([#11184](https://github.com/containerd/containerd/pull/11184))

#### Container Runtime Interface (CRI)

* Fix `ip_pref` configuration option ([#11223](https://github.com/containerd/containerd/pull/11223))

#### Runtime

* Fix panic due to nil dereference cgroups v2 ([#11099](https://github.com/containerd/containerd/pull/11099))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Akihiro Suda
* Sebastiaan van Stijn
* Derek McGowan
* Wei Fu
* Maksym Pavlenko
* Akhil Mohan
* Henry Wang
* Jin Dong
* Phil Estes
* Sam Edwards
* Samuel Karp
* Brian Goff
* David Son
* Kohei Tokunaga
* Pierre Gimalac
* Yang Yang
* bo.jiang

### Changes
<details><summary>31 commits</summary>
<p>

  * [`bda53fc60`](https://github.com/containerd/containerd/commit/bda53fc604cbba571db1daca3827b82dde72a0b8) Prepare release notes for v1.7.25
* Update runc binary to v1.2.4 ([#11238](https://github.com/containerd/containerd/pull/11238))
  * [`d4a649130`](https://github.com/containerd/containerd/commit/d4a649130e65a95808cd6a9dfa3a4128c03f4c98) update runc binary to v1.2.4
* Reduce shim plugin log level ([#11224](https://github.com/containerd/containerd/pull/11224))
  * [`99c973791`](https://github.com/containerd/containerd/commit/99c97379135b175862e594d32b421d24655b6920) runtime/v2: reduce shim plugin log
* Fix `ip_pref` configuration option ([#11223](https://github.com/containerd/containerd/pull/11223))
  * [`0cfc1edf3`](https://github.com/containerd/containerd/commit/0cfc1edf34648807bd02caf1835fe2c6fddf46fa) Fix "even if IPv4 comes first" test to have IPv4 first
  * [`53d1fd0d9`](https://github.com/containerd/containerd/commit/53d1fd0d96c2c1f3c4997c2fb376203f6491c7d9) Don't use `To16() != nil` to detect IPv6 addresses
* Add a build tag to disable std `plugin` import (#11202) ([#11203](https://github.com/containerd/containerd/pull/11203))
  * [`2b12ef2f4`](https://github.com/containerd/containerd/commit/2b12ef2f421f141805f8afcd72d1315698b2582c) chore: add a build tag to disable containerd plugin import
* bump github.com/containerd/continuity from 0.4.2 to 0.4.4 ([#11216](https://github.com/containerd/containerd/pull/11216))
  * [`b99091838`](https://github.com/containerd/containerd/commit/b99091838db961b2c06cea388c70466f5ca0a067) build(deps): bump github.com/containerd/continuity from 0.4.3 to 0.4.4
  * [`9f48f7af0`](https://github.com/containerd/containerd/commit/9f48f7af05f1b19c0500eaae78e605ec45e03ab5) build(deps): bump google.golang.org/protobuf from 1.33.0 to 1.35.2
  * [`79172ba16`](https://github.com/containerd/containerd/commit/79172ba1624d21263a236a37909f33b8ba639c61) go.mod: github.com/containerd/continuity v0.4.3
* deps: update golang.org/x/ ([#11178](https://github.com/containerd/containerd/pull/11178))
  * [`2dfbe2c7c`](https://github.com/containerd/containerd/commit/2dfbe2c7c1de9c8a45e1500d09e79652a5a3d416) vendor: update golang.org/x/crypto dependencies
* Fix proto conflicts and update to 1.8 API ([#11184](https://github.com/containerd/containerd/pull/11184))
  * [`3d7a50749`](https://github.com/containerd/containerd/commit/3d7a50749b58d84ae32afaf84a475cb25f0eb327) Replace use of deprecated api Envelope
  * [`929e7bde6`](https://github.com/containerd/containerd/commit/929e7bde6d686e8d694852258762e144d92bc38f) Use api types over deprecated alias
  * [`5a42503d1`](https://github.com/containerd/containerd/commit/5a42503d19e4e17e15af9155830cc1e808f1362b) Remove end of life api directory
  * [`c4069878e`](https://github.com/containerd/containerd/commit/c4069878e1c2587434b303b27e7f114a5426fc81) Update runtime/v2/runc/options to alias api type
  * [`4d955223a`](https://github.com/containerd/containerd/commit/4d955223a4cfa047e8f8ea58efc275d2771c0e0a) Update to containerd api 1.8
  * [`efacd2ac7`](https://github.com/containerd/containerd/commit/efacd2ac7b099e875619df184a4f695719a4ec3b) Fix lint failures
* update runc binary to v1.2.3 ([#11143](https://github.com/containerd/containerd/pull/11143))
  * [`957c31895`](https://github.com/containerd/containerd/commit/957c31895ab1f84f7c33696a931bde628e79086c) update runc binary to v1.2.3
* update build to go1.22.10, test go1.23.4 ([#11111](https://github.com/containerd/containerd/pull/11111))
  * [`4c0db6ad6`](https://github.com/containerd/containerd/commit/4c0db6ad60aa549ed3be557150f263e09cac7061) update build to go1.22.10, test go1.23.4
* Fix panic due to nil dereference cgroups v2 ([#11099](https://github.com/containerd/containerd/pull/11099))
  * [`a40aa60a5`](https://github.com/containerd/containerd/commit/a40aa60a5452f92338e252f047871fee2ddd8727) fix panic due to nil dereference cgroups v2
* Move rockylinux 9.4 to almalinux/9 in CI ([#11054](https://github.com/containerd/containerd/pull/11054))
  * [`b1ef1dda7`](https://github.com/containerd/containerd/commit/b1ef1dda758185d6709b3e4869dded4dd11dee40) move rocky 9.4 to almalinux/9 in CI
</p>
</details>

### Changes from containerd/continuity
<details><summary>40 commits</summary>
<p>

* go.mod: bump up ([containerd/continuity#257](https://github.com/containerd/continuity/pull/257))
  * [`8ae2b5e`](https://github.com/containerd/continuity/commit/8ae2b5ed00ea2ce911d163c19b85de58ffeaee10) Disable FUSE for FreeBSD
  * [`ef3b6f4`](https://github.com/containerd/continuity/commit/ef3b6f490ced58b82bf25ffd3ca5c242bedf06ef) go.mod: bump up
* cmd/continuity/commands: MountCmd: remove macOS remnants ([containerd/continuity#254](https://github.com/containerd/continuity/pull/254))
  * [`327ebdd`](https://github.com/containerd/continuity/commit/327ebdd9c1ddcbfd517279a3602efa286dfe5cdc) cmd/continuity/commands: MountCmd: remove macOS remnants
* kind.String(): fix missing case statements for iota consts in switch ([containerd/continuity#256](https://github.com/containerd/continuity/pull/256))
  * [`7d074e7`](https://github.com/containerd/continuity/commit/7d074e72420162b4e873d4699f2518c02fcb983f) kind.String(): fix missing case statements for iota consts in switch
* go-fix: remove pre-go1.17 build-tags ([containerd/continuity#252](https://github.com/containerd/continuity/pull/252))
  * [`433b975`](https://github.com/containerd/continuity/commit/433b9755fb2e7489793942d7e7d795c91ded249a) go-fix: remove pre-go1.17 build-tags
* fs: properly handle ENOTSUP in copyXAttrs ([containerd/continuity#245](https://github.com/containerd/continuity/pull/245))
  * [`c494f3d`](https://github.com/containerd/continuity/commit/c494f3d90ac521345eed00be6784fe5e798d0bbc) fs: properly handle ENOTSUP in copyXAttrs
* gha: update CodeQL action to v3, run on go1.22 ([containerd/continuity#251](https://github.com/containerd/continuity/pull/251))
  * [`3ca0c62`](https://github.com/containerd/continuity/commit/3ca0c6254f9a9238cf8b27f94e6004d14ebcaf58) gha: update CodeQL action to v3, as v2 is deprecated
  * [`1d06b76`](https://github.com/containerd/continuity/commit/1d06b761601826b507eaa06055f18961c85d8afa) gha: update CodeQL action to run on go1.22
* go.mod: prune indirect gopkg.in/yaml.v3 ([containerd/continuity#250](https://github.com/containerd/continuity/pull/250))
  * [`3eb1ef4`](https://github.com/containerd/continuity/commit/3eb1ef4c2469f3c8e4b557a4f4ddcbd76682e784) cmd/continuity: tidy go.mod, go.sum
  * [`f0775b0`](https://github.com/containerd/continuity/commit/f0775b0cefc909012eab90c1ff60653bc4ddba08) go.mod: prune indirect gopkg.in/yaml.v3
* gha: run CI on go1.22 ([containerd/continuity#242](https://github.com/containerd/continuity/pull/242))
  * [`f0f6869`](https://github.com/containerd/continuity/commit/f0f6869d0dfa7a977b939b91e47fe36bf9c6bbc1) gha: run CI on go1.22
* switch to github.com/containerd/log module ([containerd/continuity#243](https://github.com/containerd/continuity/pull/243))
  * [`7d07d28`](https://github.com/containerd/continuity/commit/7d07d28ec16c8b8bacc7638feef10fc4e15536f4) switch to github.com/containerd/log module
* Fix TestDiffDirChangeWithOverlayfs (also updates the CI to use Ubuntu 24.04) ([containerd/continuity#249](https://github.com/containerd/continuity/pull/249))
  * [`97eff17`](https://github.com/containerd/continuity/commit/97eff17e2d69acf3724a694badf7eedb1c59684f) Fix TestDiffDirChangeWithOverlayfs
  * [`d934057`](https://github.com/containerd/continuity/commit/d93405730daf33f10e26855303a94e126378c90f) CI: use ubuntu-24.04
* fs: implement Atime for Windows ([containerd/continuity#241](https://github.com/containerd/continuity/pull/241))
  * [`3cbda8c`](https://github.com/containerd/continuity/commit/3cbda8c24bde1ce635ff5dc3417a481a3b6b6e07) fs: implement Atime for Windows
* build(deps): bump google.golang.org/protobuf from 1.26.0 to 1.33.0 ([containerd/continuity#238](https://github.com/containerd/continuity/pull/238))
  * [`31a50de`](https://github.com/containerd/continuity/commit/31a50def4bb28692365be8f56c64f71d676b81d1) build(deps): bump google.golang.org/protobuf from 1.26.0 to 1.33.0
* build(deps): bump google.golang.org/protobuf from 1.26.0 to 1.33.0 in /cmd/continuity ([containerd/continuity#237](https://github.com/containerd/continuity/pull/237))
  * [`b3e10e6`](https://github.com/containerd/continuity/commit/b3e10e6650ecac26b241e41c65e58e6199b4a3f7) build(deps): bump google.golang.org/protobuf in /cmd/continuity
* support filesystem magic for linux ([containerd/continuity#239](https://github.com/containerd/continuity/pull/239))
  * [`8df9930`](https://github.com/containerd/continuity/commit/8df993081e4942a06a3de2e78c3171198641f9f8) support filesystem magic for linux
* fs: add DiffDirChanges function to get changeset fast ([containerd/continuity#145](https://github.com/containerd/continuity/pull/145))
  * [`8b312bd`](https://github.com/containerd/continuity/commit/8b312bddbe566d249b9f3962119a20e415f574be) fs: add DiffDirChanges function to get changeset fast
* update golangci-lint to vl.55.0 ([containerd/continuity#233](https://github.com/containerd/continuity/pull/233))
  * [`e08b7e4`](https://github.com/containerd/continuity/commit/e08b7e4a95b607784ce68c7f1216531c51bd375e) update golangci-lint to vl.55.0 , matching the version used by containerd
* Add type to iterate directory ([containerd/continuity#229](https://github.com/containerd/continuity/pull/229))
  * [`5c2d1b4`](https://github.com/containerd/continuity/commit/5c2d1b465b6a874f3e534f844d9ba3b6699f5ce5) Add type to itterate directory
* Substitute deprecated rand.Seed() in Go 1.20 ([containerd/continuity#231](https://github.com/containerd/continuity/pull/231))
  * [`242e29e`](https://github.com/containerd/continuity/commit/242e29e108631f355e3f442f3cc07a05109aabd2) Substitute deprecated rand.Seed() in Go 1.20
</p>
</details>

### Dependency Changes

* **github.com/containerd/containerd/api**       v1.7.19 -> v1.8.0
* **github.com/containerd/continuity**           v0.4.2 -> v0.4.4
* **golang.org/x/crypto**                        v0.21.0 -> v0.31.0
* **golang.org/x/mod**                           v0.12.0 -> v0.17.0
* **golang.org/x/net**                           v0.23.0 -> v0.25.0
* **golang.org/x/sync**                          v0.5.0 -> v0.10.0
* **golang.org/x/sys**                           v0.18.0 -> v0.28.0
* **golang.org/x/term**                          v0.18.0 -> v0.27.0
* **golang.org/x/text**                          v0.14.0 -> v0.21.0
* **google.golang.org/genproto/googleapis/rpc**  995d672761c0 -> c3f982113cda
* **google.golang.org/protobuf**                 v1.33.0 -> v1.35.2

Previous release can be found at [v1.7.24](https://github.com/containerd/containerd/releases/tag/v1.7.24)

