### PR TITLE
Prepare release notes for v2.0.2

### DIFF
--- a/releases/v2.0.2.toml
+++ b/releases/v2.0.2.toml
@@ -1,0 +1,27 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+ignore_deps = [ "github.com/containerd/containerd" ]
+
+# previous release
+previous = "v2.0.1"
+
+pre_release = false
+
+preface = """\
+The second patch release for containerd 2.0 includes a number of bug fixes and improvements.
+"""
+
+postface = """\
+### Which file should I download?
+* `containerd-<VERSION>-<OS>-<ARCH>.tar.gz`:         ✅Recommended. Dynamically linked with glibc 2.31 (Ubuntu 20.04).
+* `containerd-static-<VERSION>-<OS>-<ARCH>.tar.gz`:  Statically linked. Expected to be used on non-glibc Linux distributions. Not position-independent.
+
+In addition to containerd, typically you will have to install [runc](https://github.com/opencontainers/runc/releases)
+and [CNI plugins](https://github.com/containernetworking/plugins/releases) from their official sites too.
+
+See also the [Getting Started](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) documentation.
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd/v2"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "2.0.1+unknown"
+	Version = "2.0.2+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated release note
- - -
containerd 2.0.2

Welcome to the v2.0.2 release of containerd!

The second patch release for containerd 2.0 includes a number of bug fixes and improvements.

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Jin Dong
* Akihiro Suda
* Derek McGowan
* Kazuyoshi Kato
* Henry Wang
* Krisztian Litkey
* Phil Estes
* Samuel Karp
* Sebastiaan van Stijn
* Akhil Mohan
* Brian Goff
* Chongyi Zheng
* Maksym Pavlenko
* Mike Brown
* Pierre Gimalac
* Wei Fu

### Changes
<details><summary>22 commits</summary>
<p>

  * * cdaf4dfb4 Prepare release notes for v2.0.2
  * * 0d9aa65eb Merge pull request #11259 from k8s-infra-cherrypick-robot/cherry-pick-11257-to-release/2.0
  * * eb125e1dd Update platforms to latest rc
  * * c334ae68b Merge pull request #11256 from k8s-infra-cherrypick-robot/cherry-pick-10980-to-release/2.0
  * * 468079c5c Remove confusing warning in cri runtime config migration
  * * b48e1080c Merge pull request #11248 from k8s-infra-cherrypick-robot/cherry-pick-11165-to-release/2.0
  * * a2d9d4fd5 Fix runtime platform loading in cri image plugin init
  * * e1b0bb601 Merge pull request #11246 from k8s-infra-cherrypick-robot/cherry-pick-11161-to-release/2.0
  * * 184ffad01 Add integ test to check tty leak
  * * 17181ed33 fix master tty leak due to leaking init container object
  * * 1698a5958 Merge pull request #11242 from djdongjin/bump-otelttrpc-release-20
  * * 8666e7422 Bump up otelttrpc to 0.1.0
  * * 6f98bd9ed Merge pull request #11236 from k8s-infra-cherrypick-robot/cherry-pick-11229-to-release/2.0
  * * c4270430d ctr: `ctr images import --all-platforms`: fix unpack
  * * 584ec4840 Merge pull request #11239 from k8s-infra-cherrypick-robot/cherry-pick-11230-to-release/2.0
  * * 7373ddd70 update runc binary to v1.2.4
  * * ce560bb24 Merge pull request #11222 from k8s-infra-cherrypick-robot/cherry-pick-11220-to-release/2.0
  * * f34147772 downgrade go-difflib and go-spew to tagged releases
  * * 0d91d8e5e Merge pull request #11213 from pgimalac/pgimalac/containerd-no-plugin-v2.0
  * * dca769485 chore: add a build tag to disable containerd plugin import
  * * fb61c901d Merge pull request #11187 from k8s-infra-cherrypick-robot/cherry-pick-11185-to-release/2.0
  * * 5942b3fcb Update golangci to 1.60.3
</p>
</details>

### Changes from containerd/otelttrpc
<details><summary>6 commits</summary>
<p>

  * * fa91caf Merge pull request #3 from djdongjin/add-dependabot-ci
  * * 2d46141 upgrade golang, deps, CI versions
  * * 64922e7 Add dependabot CI
  * * ef43615 Merge pull request #2 from djdongjin/fix-concurrent-map-write-panic
  * * 2ba3be1 Fix concurrent map panic on inject metadata
  * * f50a922 UT for concurrent inject/extract metadata
</p>
</details>

### Changes from containerd/platforms
<details><summary>6 commits</summary>
<p>

  * * e3566b8 Merge pull request #22 from cpuguy83/windows_everywhere
  * * 7c58292 Move windows matcher logic so all platforms can use
  * * 9ada2e3 Merge pull request #21 from thaJeztah/stdlib_testing
  * * 86a86b7 replace testify with stdlib in tests
  * * 458d3b7 Merge pull request #18 from harryzcy/arm64-lookup
  * * 364665a Replace arm64 minor variant logic with lookup table
</p>
</details>

### Changes from containerd/ttrpc
<details><summary>5 commits</summary>
<p>

  * * 3b8c8b7 Merge pull request #177 from djdongjin/metadata-clone
  * * 430f734 Add MD.Clone
  * * b71d9de Merge pull request #175 from klihub/fixes/serve-listen-shutdown-race
  * * c4d96d5 server: fix Serve() vs. immediate Shutdown() race.
  * * ed6c3ba server_test: add Serve()/Shutdown() race test.
</p>
</details>

### Dependency Changes

* **github.com/containerd/otelttrpc**  ea5083fda723 -> v0.1.0
* **github.com/containerd/platforms**  v1.0.0-rc.0 -> v1.0.0-rc.1
* **github.com/containerd/ttrpc**      v1.2.6 -> v1.2.7
* **github.com/davecgh/go-spew**       d8f796af33cc -> v1.1.1
* **github.com/pmezard/go-difflib**    5d4384ee4fb2 -> v1.0.0
* **github.com/stretchr/testify**      v1.9.0 -> v1.10.0

Previous release can be found at [v2.0.1](https://github.com/containerd/containerd/releases/tag/v2.0.1)
### Which file should I download?
* `containerd-<VERSION>-<OS>-<ARCH>.tar.gz`:         ✅Recommended. Dynamically linked with glibc 2.31 (Ubuntu 20.04).
* `containerd-static-<VERSION>-<OS>-<ARCH>.tar.gz`:  Statically linked. Expected to be used on non-glibc Linux distributions. Not position-independent.

In addition to containerd, typically you will have to install [runc](https://github.com/opencontainers/runc/releases)
and [CNI plugins](https://github.com/containernetworking/plugins/releases) from their official sites too.

See also the [Getting Started](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) documentation.