### PR TITLE
Fix panics in CI fuzz integration tests

### DIFF
--- a/integration/client/container_fuzz_test.go
+++ b/integration/client/container_fuzz_test.go
@@ -223,10 +223,21 @@ func updatePathEnv() error {
 
 	oldPathEnv := os.Getenv("PATH")
 	newPathEnv := oldPathEnv + ":" + fuzzBinDir
+
+	if ghWorkspace := os.Getenv("GITHUB_WORKSPACE"); ghWorkspace != "" {
+		// In `oss_fuzz_build.sh`, we build and install containerd binaries to
+		// `$OUT/containerd-binaries`, where `OUT=/out` in oss-fuzz environment.
+		// However in GitHub Actions, oss-fuzz maps `OUT` to `$GITHUB_WORKSPACE/build-out`.
+		// So here we add this to `$PATH` at the end of `PATH` so the fuzz works on
+		// both environments.
+		newPathEnv = newPathEnv + ":" + filepath.Join(ghWorkspace, "build-out", "containerd-binaries")
+	}
+
 	err = os.Setenv("PATH", newPathEnv)
 	if err != nil {
 		return err
 	}
+
 	haveChangedOSSFuzzPATH = true
 	return nil
 }


### PR DESCRIPTION
Several Fuzz integration tests on Github Action panic due to unable to find containerd binary in `PATH`.

https://github.com/containerd/containerd/actions/runs/12719253904/job/35459145214
```
2025-01-11 00:37:14,414 - root - INFO - Running fuzzer: fuzz_FuzzIntegCreateContainerNoTearDown.
...
================== Job 1 exited with exit code 77 ============
...
failed to start daemon: failed to start daemon: exec: "containerd": executable file not found in $PATH:
panic: fatal [recovered]
	panic: fatal
```

After this fix:
https://github.com/containerd/containerd/actions/runs/12720677667/job/35462684827?pr=11249
```
2025-01-11 03:33:44,550 - root - INFO - Running fuzzer: fuzz_FuzzIntegCreateContainerNoTearDown.
...
================== Job 0 exited with exit code 0 ============
...
INFO:        2 files found in /github/workspace/cifuzz-corpus/fuzz_FuzzIntegCreateContainerNoTearDown
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
INFO: seed corpus: files: 2 min: 1b max: 1b total: 2b rss: 61Mb
#3	INITED cov: 48 ft: 48 corp: 1/1b exec/s: 0 rss: 61Mb
...
```
---
The panic is because fuzz builder in CI maps `$OUT` to `/github/workspace/build-out` instead of `/out` as in oss-fuzz environment.

My reading of oss-fuzz code on how it makes `OUT=/github/workspace/build-out` in CI:

1. When it launches oss-fuzz builder, it modifies `OUT` to `workspace.out`: https://github.com/google/oss-fuzz/blob/1a0c648239a67c5a82e069253297aa1ef7749462/infra/cifuzz/docker.py#L88
2. `workspace.out` = `$workspace/build-out`: https://github.com/google/oss-fuzz/blob/1a0c648239a67c5a82e069253297aa1ef7749462/infra/cifuzz/workspace_utils.py#L40-L41
3. on Github, `workspace` = `$GITHUB_WORKSPACE`: https://github.com/google/oss-fuzz/blob/1a0c648239a67c5a82e069253297aa1ef7749462/infra/cifuzz/platform_config/github.py#L43

From the CI Fuzz log (Build Fuzzers), it has this line which matches ^ (-e OUT=/github/workspace/build-out)

`2025-01-11 02:19:04,574 - helper - INFO - Running: docker run --privileged --shm-size=2g --platform linux/amd64 --rm -e FUZZING_ENGINE=libfuzzer -e CIFUZZ=True -e SANITIZER=address -e ARCHITECTURE=x86_64 -e FUZZING_LANGUAGE=go -e OUT=/github/workspace/build-out --volumes-from ba3f2cc957e3 gcr.io/oss-fuzz/containerd /bin/bash -c 'cd / && rm -rf /src/containerd/* && cp -r /github/workspace/storage/containerd /src && cd - && compile'.
2025-01-11T02:19:05.7704530Z /src/containerd
`