### PR TITLE
fix bind /dev to container and enable tty cause failed to create container

### DIFF
--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -639,6 +639,14 @@ func (c *criService) buildLinuxSpec(
 	specOpts := []oci.SpecOpts{
 		oci.WithoutRunMount,
 	}
+	if config.GetTty() {
+		for _, mount := range config.GetMounts() {
+			if mount.ContainerPath == "/dev" {
+				specOpts = append(specOpts, oci.WithDevConsole)
+			}
+		}
+	}
+
 	// only clear the default security settings if the runtime does not have a custom
 	// base runtime spec spec.  Admins can use this functionality to define
 	// default ulimits, seccomp, or other default settings.

--- a/pkg/oci/spec_opts.go
+++ b/pkg/oci/spec_opts.go
@@ -1292,6 +1292,27 @@ func WithDefaultUnixDevices(_ context.Context, _ Client, _ *containers.Container
 	return nil
 }
 
+func WithDevConsole(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
+	setLinux(s)
+	if s.Linux.Resources == nil {
+		s.Linux.Resources = &specs.LinuxResources{}
+	}
+	intptr := func(i int64) *int64 {
+		return &i
+	}
+	s.Linux.Resources.Devices = append(s.Linux.Resources.Devices, []specs.LinuxDeviceCgroup{
+		{
+			// "/dev/console",
+			Type:   "c",
+			Major:  intptr(5),
+			Minor:  intptr(1),
+			Access: rwm,
+			Allow:  true,
+		},
+	}...)
+	return nil
+}
+
 // WithPrivileged sets up options for a privileged container
 var WithPrivileged = Compose(
 	WithAllCurrentCapabilities,


### PR DESCRIPTION
❯ cat container.json
{
        "metadata": {
                "name": "busybox"
        },
        "image": {
                "image": "docker.io/library/busybox:1.28"
        },
        "command": [
               "sh","-c","while true; do sleep 5;date; done"
        ],
        "mounts": [{
                        "container_path": "/dev",
                        "host_path": "/dev"
                }
        ],
        "tty": true,
        "log_path": "busybox.1.log",
        "linux": {}
}

root in /home/nmx/pods via 🐹 v1.21.13 
❯ cat pod.json 
{
    "metadata": {
        "name": "sandbox-b03090193de",
        "namespace": "default",
        "attempt": 1,
        "uid": "hdishd83djaidwnduwk28bcsb"
    },
    "log_directory": "/tmp",
    "linux": {
    }
}


```
crictl  run    --no-pull container.json  pod.json

E0113 10:21:02.778746 1545977 remote_runtime.go:343] "StartContainer from runtime service failed" err="rpc error: code = Unknown desc = failed to create containerd task: failed to create shim task: Others(\"Other: OCI runtime create failed: runc create failed: unable to start container process: error during container init: open /dev/console: operation not permitted\"): unknown" containerID="90a35e32a8c838ba4daf5dcd7e291ff1a66cf081fac8e5fd0daeeddf61c98ef6"
FATA[0000] running container: starting the container "90a35e32a8c838ba4daf5dcd7e291ff1a66cf081fac8e5fd0daeeddf61c98ef6": rpc error: code = Unknown desc = failed to create containerd task: failed to create shim task: Others("Other: OCI runtime create failed: runc create failed: unable to start container process: error during container init: open /dev/console: operation not permitted"): unknown 
```
nerdctl run -v  -it /dev:/dev -d  registry.openanolis.cn/openanolis/anolisos:23.2 sh   works well 
but cri failed.