### PR TITLE
core/mount: Export `ReadonlyMounts` and `ReadonlyOverlay`

### DIFF
--- a/core/mount/mount.go
+++ b/core/mount/mount.go
@@ -106,12 +106,12 @@ func (m *Mount) Mount(target string) error {
 	return m.mount(target)
 }
 
-// readonlyMounts modifies the received mount options
+// MakeReadonly modifies the received mount options
 // to make them readonly
-func readonlyMounts(mounts []Mount) []Mount {
+func MakeReadonly(mounts []Mount) []Mount {
 	for i, m := range mounts {
 		if m.Type == "overlay" {
-			mounts[i].Options = readonlyOverlay(m.Options)
+			mounts[i].Options = ReadonlyOverlay(m.Options)
 			continue
 		}
 		opts := make([]string, 0, len(m.Options))
@@ -126,10 +126,10 @@ func readonlyMounts(mounts []Mount) []Mount {
 	return mounts
 }
 
-// readonlyOverlay takes mount options for overlay mounts and makes them readonly by
+// ReadonlyOverlay takes mount options for overlay mounts and makes them readonly by
 // removing workdir and upperdir (and appending the upperdir layer to lowerdir) - see:
 // https://www.kernel.org/doc/html/latest/filesystems/overlayfs.html#multiple-lower-layers
-func readonlyOverlay(opt []string) []string {
+func ReadonlyOverlay(opt []string) []string {
 	out := make([]string, 0, len(opt))
 	upper := ""
 	for _, o := range opt {

--- a/core/mount/mount_test.go
+++ b/core/mount/mount_test.go
@@ -143,7 +143,7 @@ func TestReadonlyMounts(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		if !reflect.DeepEqual(readonlyMounts(tc.input), tc.expected) {
+		if !reflect.DeepEqual(MakeReadonly(tc.input), tc.expected) {
 			t.Fatalf("incorrectly modified mounts: %s", tc.desc)
 		}
 	}

--- a/core/mount/temp.go
+++ b/core/mount/temp.go
@@ -115,7 +115,7 @@ func copyMounts(in []Mount) []Mount {
 // and pass the temp dir to f. The mounts are valid during the call to the f.
 // Finally we will unmount and remove the temp dir regardless of the result of f.
 func WithReadonlyTempMount(ctx context.Context, mounts []Mount, f func(root string) error) (err error) {
-	return WithTempMount(ctx, readonlyMounts(mounts), f)
+	return WithTempMount(ctx, MakeReadonly(mounts), f)
 }
 
 func getTempDir() string {


### PR DESCRIPTION
These utilities are used by `WithReadonlyTempMount` which is not applicable for mounts with longer lifetime.