### PR TITLE
Remove noinline in seccomp/apparmor SpecOpts

### DIFF
--- a/contrib/apparmor/apparmor.go
+++ b/contrib/apparmor/apparmor.go
@@ -39,11 +39,6 @@ func WithProfile(profile string) oci.SpecOpts {
 
 // WithDefaultProfile will generate a default apparmor profile under the provided name
 // for the container.  It is only generated if a profile under that name does not exist.
-//
-// FIXME: pkg/cri/[sb]server/container_create_linux_test.go depends on go:noinline
-// since Go 1.21.
-//
-//go:noinline
 func WithDefaultProfile(name string) oci.SpecOpts {
 	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {
 		if err := LoadDefaultProfile(name); err != nil {

--- a/contrib/seccomp/seccomp.go
+++ b/contrib/seccomp/seccomp.go
@@ -30,11 +30,6 @@ import (
 // WithProfile receives the name of a file stored on disk comprising a json
 // formatted seccomp profile, as specified by the opencontainers/runtime-spec.
 // The profile is read from the file, unmarshaled, and set to the spec.
-//
-// FIXME: pkg/cri/[sb]server/container_create_linux_test.go depends on go:noinline
-// since Go 1.21.
-//
-//go:noinline
 func WithProfile(profile string) oci.SpecOpts {
 	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {
 		s.Linux.Seccomp = &specs.LinuxSeccomp{}
@@ -51,11 +46,6 @@ func WithProfile(profile string) oci.SpecOpts {
 
 // WithDefaultProfile sets the default seccomp profile to the spec.
 // Note: must follow the setting of process capabilities
-//
-// FIXME: pkg/cri/[sb]server/container_create_linux_test.go depends on go:noinline
-// since Go 1.21.
-//
-//go:noinline
 func WithDefaultProfile() oci.SpecOpts {
 	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {
 		s.Linux.Seccomp = DefaultProfile(s)

--- a/internal/cri/server/container_create_linux_test.go
+++ b/internal/cri/server/container_create_linux_test.go
@@ -1003,13 +1003,49 @@ func TestGenerateSeccompSecurityProfileSpecOpts(t *testing.T) {
 					ssp = csp
 				}
 				specOpts, err := cri.generateSeccompSpecOpts(ssp, test.privileged, !test.disable)
-				assert.Equal(t,
-					reflect.ValueOf(test.specOpts).Pointer(),
-					reflect.ValueOf(specOpts).Pointer())
 				if test.expectErr {
 					assert.Error(t, err)
 				} else {
 					assert.NoError(t, err)
+					if test.specOpts == nil && specOpts == nil {
+						return
+					}
+					if test.specOpts == nil || specOpts == nil {
+						t.Fatalf("unexpected nil specOpts, expected nil: %t, actual nil: %t", test.specOpts == nil, specOpts == nil)
+					}
+					// `specOpts` for seccomp only uses/modifies `*specs.Spec`, not
+					// `oci.Client` or `*containers.Container`, so let's construct a
+					// `*specs.Spec` and compare if the results are the same.
+					expected := runtimespec.Spec{
+						Linux: &runtimespec.Linux{},
+						Process: &runtimespec.Process{
+							Capabilities: &runtimespec.LinuxCapabilities{
+								Bounding: []string{
+									"CAP_DAC_READ_SEARCH",
+									"CAP_SYS_ADMIN",
+									"CAP_SYS_BOOT",
+									"CAP_SYS_CHROOT",
+									"CAP_SYS_MODULE",
+									"CAP_SYS_PACCT",
+									"CAP_SYS_PTRACE",
+									"CAP_SYS_RAWIO",
+									"CAP_SYS_TIME",
+									"CAP_SYS_TTY_CONFIG",
+									"CAP_SYS_NICE",
+									"CAP_SYSLOG",
+									"CAP_BPF",
+									"CAP_PERFMON",
+								},
+							},
+						},
+					}
+					var actual runtimespec.Spec
+					err := util.DeepCopy(&actual, &expected)
+					assert.NoError(t, err)
+
+					test.specOpts(context.TODO(), nil, nil, &expected)
+					specOpts(context.TODO(), nil, nil, &actual)
+					assert.Equal(t, expected, actual)
 				}
 			}
 		})


### PR DESCRIPTION
go:noinline was added in https://github.com/containerd/containerd/pull/8957#issuecomment-1678829933 to workaround go func inline in go 1.21.

This PR removes the restriction by constructing a `sepcs.Spec`, calling the resulted `oci.SpecOpts`, comparing if the final `specs.Spec`s are still the same.