### PR TITLE
client: add WithExtraDialOpts option

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -139,6 +139,8 @@ func New(address string, opts ...Opt) (*Client, error) {
 		if len(copts.dialOptions) > 0 {
 			gopts = copts.dialOptions
 		}
+		gopts = append(gopts, copts.extraDialOpts...)
+
 		gopts = append(gopts, grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(defaults.DefaultMaxRecvMsgSize),
 			grpc.MaxCallSendMsgSize(defaults.DefaultMaxSendMsgSize)))

--- a/client/client_opts.go
+++ b/client/client_opts.go
@@ -34,6 +34,7 @@ type clientOpts struct {
 	defaultPlatform platforms.MatchComparer
 	services        *services
 	dialOptions     []grpc.DialOption
+	extraDialOpts   []grpc.DialOption
 	callOptions     []grpc.CallOption
 	timeout         time.Duration
 }
@@ -72,6 +73,19 @@ func WithDefaultPlatform(platform platforms.MatchComparer) Opt {
 func WithDialOpts(opts []grpc.DialOption) Opt {
 	return func(c *clientOpts) error {
 		c.dialOptions = opts
+		return nil
+	}
+}
+
+// WithExtraDialOpts allows additional grpc.DialOptions to be set on the
+// connection. Unlike [WithDialOpts], options set here are appended to,
+// instead of overriding previous options, which allows setting options
+// to extend containerd client's defaults.
+//
+// This option can be used multiple times to set additional dial options.
+func WithExtraDialOpts(opts []grpc.DialOption) Opt {
+	return func(c *clientOpts) error {
+		c.extraDialOpts = append(c.extraDialOpts, opts...)
 		return nil
 	}
 }


### PR DESCRIPTION
the client package provides a WithDialOpts option, however, dial-options passed to override all defaults that are set in containerd. This makes it difficult to expand the defaults with custom options, as this requires copying the defaults, and trying to keep those in sync (e.g. see [moby#48617]).

This patch introduces a new `WithExtraDialOpts` option which, unlike `WithDialOpts` are appended to, instead of overriding, previous options. This allows setting custom options, while maintaining containerd's defaults.

Also unlike `WithDialOpts`, this option can be used multiple times to allow additional options to be set.

[moby#48617]: https://github.com/moby/moby/pull/48617
