### PR TITLE
[Feat] cri: prevent paused state from being reset to Unknown on restart

### DIFF
--- a/internal/cri/server/restart.go
+++ b/internal/cri/server/restart.go
@@ -357,7 +357,7 @@ func (c *criService) loadContainer(ctx context.Context, cntr containerd.Containe
 				if status.State() != runtime.ContainerState_CONTAINER_CREATED {
 					return fmt.Errorf("unexpected container state for created task: %q", status.State())
 				}
-			case containerd.Running:
+			case containerd.Running, containerd.Paused:
 				// Task is running. Container must be in `RUNNING` state, based on our assumption that
 				// "task should not be started when containerd is down".
 				switch status.State() {


### PR DESCRIPTION
Prevent tasks that are in a paused state due to nerdctl commit operations from being marked as Unknown upon containerd restart. This misidentification leads to kubelet stopping the containers and creating new ones, which should be avoided.

This change ensures that the paused state is maintained correctly, preventing unnecessary container recreation by kubelet and maintaining the expected behavior of paused tasks.

example:
T1:  nerdctl commit xxxx(container ID). xxxx status is `Running`
T2: nerdctl:  pause task xxxx
T3: containerd restart
T4: xxxx status becomes `Unknown`
T5: kubelet recreate container (Stop xxxx, Create yyyyy)