### PR TITLE
internal: In case of abnormal power outage. Causing recovery failure and inability to restart containerd for recovery.

### DIFF
--- a/internal/cri/server/restart.go
+++ b/internal/cri/server/restart.go
@@ -173,8 +173,7 @@ func (c *criService) recover(ctx context.Context) error {
 				log.G(ctx2).
 					WithError(err).
 					WithField("container", container.ID()).
-					Error("Failed to load container")
-
+					Error("Failed to load container, and try to delete damaged container")
 				return nil
 			}
 			log.G(ctx2).Debugf("Loaded container %+v", cntr)
@@ -363,6 +362,14 @@ func (c *criService) loadContainer(ctx context.Context, cntr containerd.Containe
 				switch status.State() {
 				case runtime.ContainerState_CONTAINER_EXITED:
 					return fmt.Errorf("unexpected container state for running task: %q", status.State())
+				// task is running but the cri status is unknown,try to recover the status to unknown
+				case runtime.ContainerState_CONTAINER_UNKNOWN:
+					log.G(ctx).Warnf("Container %q is in unknown state, but task is running,try to recover", id)
+					status.Message = "Status recover to unknown"
+					if _, err := containerstore.StoreStatus(containerDir, id, status); err != nil {
+						return fmt.Errorf("failed to recover container status: %w", err)
+					}
+					log.G(ctx).Debugf("Container %q recover successful", id)
 				case runtime.ContainerState_CONTAINER_RUNNING:
 				default:
 					// This may happen if containerd gets restarted after task is started, but

--- a/internal/cri/store/container/status.go
+++ b/internal/cri/store/container/status.go
@@ -169,6 +169,12 @@ func StoreStatus(root, id string, status Status) (StatusStorage, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode status: %w", err)
 	}
+	// if root not exist, create it
+	if _, err := os.Stat(root); err != nil {
+		if err := os.MkdirAll(root, 0600); err != nil {
+			return nil, err
+		}
+	}
 	path := filepath.Join(root, "status")
 	if err := continuity.AtomicWriteFile(path, data, 0600); err != nil {
 		return nil, fmt.Errorf("failed to checkpoint status to %q: %w", path, err)


### PR DESCRIPTION
“\*/containerd/io.containerd.grpc.v1.cri/containers/\*/status” file is missing However, the container information still exists in the database, causing containerd to start continuously 
"Failed to load container status"
Try to recover the status file.

A simple way to reproduce:
After starting the sandbox and container using crictl. delete the dir 
"rm -rf /*/containerd/io.containerd.grpc.v1.cri/containers/{id}/"