### PR TITLE
cri:use less lock when update resources

### DIFF
--- a/internal/cri/server/restart.go
+++ b/internal/cri/server/restart.go
@@ -276,6 +276,12 @@ func (c *criService) loadContainer(ctx context.Context, cntr containerd.Containe
 		status = unknownContainerStatus()
 	}
 
+	spec, err := cntr.Spec(ctx)
+	if err != nil {
+		return container, fmt.Errorf("failed to get container spec %w for %q", err, id)
+	}
+	status = copyResourcesToStatus(spec, status)
+
 	var containerIO *cio.ContainerIO
 	err = func() error {
 		// Load up-to-date status from containerd.

--- a/internal/cri/store/container/fake_status.go
+++ b/internal/cri/store/container/fake_status.go
@@ -16,7 +16,11 @@
 
 package container
 
-import "sync"
+import (
+	"sync"
+
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
 
 // WithFakeStatus adds fake status to the container.
 func WithFakeStatus(status Status) Opts {
@@ -58,5 +62,9 @@ func (f *fakeStatusStorage) Update(u UpdateFunc) error {
 }
 
 func (f *fakeStatusStorage) Delete() error {
+	return nil
+}
+
+func (f *fakeStatusStorage) UpdateResource(resource *runtime.ContainerResources) error {
 	return nil
 }


### PR DESCRIPTION
try to fix https://github.com/containerd/containerd/issues/9770
because container status doesn't change  when update resource so we don't need to use UpdateSync.( UpdateSync will hold a lock)

@fuweid  @dmcgowan  @jiusanzhou 