### PR TITLE
Fix state/root bug in shim sandbox controller

### DIFF
--- a/plugins/sandbox/controller.go
+++ b/plugins/sandbox/controller.go
@@ -73,7 +73,7 @@ func init() {
 				}
 			}
 
-			if err := shims.LoadExistingShims(ic.Context, root, state); err != nil {
+			if err := shims.LoadExistingShims(ic.Context, state, root); err != nil {
 				return nil, fmt.Errorf("failed to load existing shim sandboxes, %v", err)
 			}
 


### PR DESCRIPTION
Fix https://github.com/containerd/containerd/issues/11320

This is a shim-sandbox-controller side bug other than `LoadExistingShims`, as that function is also used in `TaskManager` and it passes the dirs correctly:

https://github.com/containerd/containerd/blob/8efbc01b9689ff254b7078fd59747a72f522b4db/core/runtime/v2/task_manager.go#L75

https://github.com/containerd/containerd/blob/8efbc01b9689ff254b7078fd59747a72f522b4db/core/runtime/v2/task_manager.go#L81

https://github.com/containerd/containerd/blob/8efbc01b9689ff254b7078fd59747a72f522b4db/core/runtime/v2/task_manager.go#L97-L98

