### PR TITLE
Revert "Add timestamp to PodSandboxStatusResponse for kubernetes Evented PLEG"

### DIFF
--- a/internal/cri/server/sandbox_status.go
+++ b/internal/cri/server/sandbox_status.go
@@ -46,7 +46,6 @@ func (c *criService) PodSandboxStatus(ctx context.Context, r *runtime.PodSandbox
 		state     string
 		info      map[string]string
 	)
-	timestamp := time.Now().UnixNano()
 	cstatus, err := c.sandboxService.SandboxStatus(ctx, sandbox.Sandboxer, sandbox.ID, r.GetVerbose())
 	if err != nil {
 		// If the shim died unexpectedly (segfault etc.) let's set the state as
@@ -84,9 +83,8 @@ func (c *criService) PodSandboxStatus(ctx context.Context, r *runtime.PodSandbox
 	}
 
 	return &runtime.PodSandboxStatusResponse{
-		Status:    status,
-		Info:      info,
-		Timestamp: timestamp,
+		Status: status,
+		Info:   info,
 	}, nil
 }
 


### PR DESCRIPTION
This reverts commit b5290726d2bfac0245de6d685dfd37ec9c1f4647.

Fixes: https://github.com/containerd/containerd/issues/11312