### PR TITLE
Don't produce unnecessary logs when encountering attestations

### DIFF
--- a/core/images/image.go
+++ b/core/images/image.go
@@ -369,8 +369,8 @@ func Children(ctx context.Context, provider content.Provider, desc ocispec.Descr
 		}
 
 		return append([]ocispec.Descriptor{}, index.Manifests...), nil
-	} else if !IsLayerType(desc.MediaType) && !IsKnownConfig(desc.MediaType) {
-		// Layers and configs are childless data types and should not be logged.
+	} else if !IsLayerType(desc.MediaType) && !IsKnownConfig(desc.MediaType) && !IsAttestationType(desc.MediaType) {
+		// Layers, configs, and attestations are childless data types and should not be logged.
 		log.G(ctx).Debugf("encountered unknown type %v; children may not be fetched", desc.MediaType)
 	}
 	return nil, nil

--- a/core/images/mediatypes.go
+++ b/core/images/mediatypes.go
@@ -58,6 +58,9 @@ const (
 
 	MediaTypeImageLayerEncrypted     = ocispec.MediaTypeImageLayer + "+encrypted"
 	MediaTypeImageLayerGzipEncrypted = ocispec.MediaTypeImageLayerGzip + "+encrypted"
+
+	// In-toto attestation
+	MediaTypeInToto = "application/vnd.in-toto+json"
 )
 
 // DiffCompression returns the compression as defined by the layer diff media
@@ -191,6 +194,16 @@ func IsKnownConfig(mt string) bool {
 		return true
 	}
 	return false
+}
+
+// IsAttestationType returns true if the media type is an attestation type
+func IsAttestationType(mt string) bool {
+	switch mt {
+	case MediaTypeInToto:
+		return true
+	default:
+		return false
+	}
 }
 
 // ChildGCLabels returns the label for a given descriptor to reference it

--- a/core/remotes/handlers.go
+++ b/core/remotes/handlers.go
@@ -80,6 +80,8 @@ func MakeRefKey(ctx context.Context, desc ocispec.Descriptor) string {
 		return "layer-" + key
 	case images.IsKnownConfig(desc.MediaType):
 		return "config-" + key
+	case images.IsAttestationType(desc.MediaType):
+		return "attestation-" + key
 	default:
 		log.G(ctx).Warnf("reference for unknown type: %s", desc.MediaType)
 		return "unknown-" + key


### PR DESCRIPTION
- fixes: https://github.com/moby/moby/issues/49042

Fix unnecessary log spam when dealing with BuildKit images containing attestation manifests.

### core/images: Ignore attestations when traversing children

Before this patch, calling `image.Children` on an image built with BuildKit would produce unnecessary `encountered unknown type application/vnd.in-toto+json; children may not be fetched` debug logs, because the media type is neither a known layer or config type.

Make the `image.Children` aware of the attestation layers and don't attempt to traverse them.


### core/remotes: Handle attestations in MakeRefKey
Don't produce `reference for unknown type: application/vnd.in-toto+json` warning logs when pushing/fetching an image containing the attestation manifests.
