### PR TITLE
device mapper:fix sometimes blkdiscard doesn't have --version flags

### DIFF
--- a/plugins/snapshots/devmapper/blkdiscard/blkdiscard.go
+++ b/plugins/snapshots/devmapper/blkdiscard/blkdiscard.go
@@ -25,6 +25,15 @@ func Version() (string, error) {
 	return blkdiscard("--version")
 }
 
+// Search blkdiscard binary.
+func CheckBinary() error {
+	_, err := exec.LookPath("blkdiscard")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // BlkDiscard discards all blocks of a device.
 // devicePath is expected to be a fully qualified path.
 // BlkDiscard expects the caller to verify that the device is not in use.

--- a/plugins/snapshots/devmapper/pool_device.go
+++ b/plugins/snapshots/devmapper/pool_device.go
@@ -54,12 +54,11 @@ func NewPoolDevice(ctx context.Context, config *Config) (*PoolDevice, error) {
 	log.G(ctx).Infof("using dmsetup:\n%s", version)
 
 	if config.DiscardBlocks {
-		blkdiscardVersion, err := blkdiscard.Version()
+		err := blkdiscard.CheckBinary()
 		if err != nil {
-			log.G(ctx).Error("blkdiscard is not available")
+			log.G(ctx).Errorf("blkdiscard is not available:%v", err)
 			return nil, err
 		}
-		log.G(ctx).Infof("using blkdiscard:\n%s", blkdiscardVersion)
 	}
 
 	dbpath := filepath.Join(config.RootPath, config.PoolName+".db")


### PR DESCRIPTION
fix:https://github.com/containerd/containerd/issues/11328

busybox image 
```
/ # blkdiscard --version
blkdiscard: unrecognized option '--version'
BusyBox v1.36.1 (2023-12-04 19:44:32 UTC) multi-call binary.

Usage: blkdiscard [-o OFS] [-l LEN] [-s] DEVICE

Discard sectors on DEVICE

        -o OFS  Byte offset into device
        -l LEN  Number of bytes to discard
        -s      Perform a secure discard

```