### PR TITLE
perf(zstd): deactivate the low mem decoder

### DIFF
--- a/core/remotes/docker/fetcher.go
+++ b/core/remotes/docker/fetcher.go
@@ -335,7 +335,9 @@ func (r dockerFetcher) open(ctx context.Context, req *request, mediatype string,
 		algorithm := strings.ToLower(encoding[i])
 		switch algorithm {
 		case "zstd":
-			r, err := zstd.NewReader(body)
+			r, err := zstd.NewReader(body,
+				zstd.WithDecoderLowmem(false),
+			)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/archive/compression/compression.go
+++ b/pkg/archive/compression/compression.go
@@ -220,7 +220,9 @@ func DecompressStream(archive io.Reader) (DecompressReadCloser, error) {
 			},
 		}, nil
 	case Zstd:
-		zstdReader, err := zstd.NewReader(buf)
+		zstdReader, err := zstd.NewReader(buf,
+			zstd.WithDecoderLowmem(false),
+		)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Hello there, with @co42, we found that decompressing zstd files with `zstd.WithDecoderLowmem(false),` improved unpacking performances for zstd blobs.

On the main branch the effect on total pull time is very limited, because we download a bit slowly. But this PR compounds greatly with #10177, we could lower download time by 14s ( from ~2min (with gzip, without #10177 and without #11337 ) to around ~30s (with zstd rebuild, #10177, with #11337 and this PR)  for a version of `ghcr.io/huggingface/text-generation-inference:3.0.2` that was rebuilt with `force-compression=true`.

| baseline WithDecoderLowmem(true)  (`time -v containerd`)                                             | after WithDecoderLowmem(false) (`time -v containerd`)                                               |   |
|------------------------------------------------------|------------------------------------------------------|---|
| Command being timed: "./bin/containerd"              | Command being timed: "./bin/containerd"              |   |
| User time (seconds): 53.70                           | User time (seconds): 38.70                           |   |
| System time (seconds): 14.93                         | System time (seconds): 14.43                         |   |
| Percent of CPU this job got: 75%                     | Percent of CPU this job got: 60%                     |   |
| Elapsed (wall clock) time (h:mm:ss or m:ss): 1:30.46 | Elapsed (wall clock) time (h:mm:ss or m:ss): 1:27.28 |   |
| Average shared text size (kbytes): 0                 | Average shared text size (kbytes): 0                 |   |
| Average unshared data size (kbytes): 0               | Average unshared data size (kbytes): 0               |   |
| Average stack size (kbytes): 0                       | Average stack size (kbytes): 0                       |   |
| Average total size (kbytes): 0                       | Average total size (kbytes): 0                       |   |
| Maximum resident set size (kbytes): 147272           | Maximum resident set size (kbytes): 169480           |   |
| Average resident set size (kbytes): 0                | Average resident set size (kbytes): 0                |   |
| Major (requiring I/O) page faults: 0                 | Major (requiring I/O) page faults: 0                 |   |
| Minor (reclaiming a frame) page faults: 75310        | Minor (reclaiming a frame) page faults: 103613       |   |
| Voluntary context switches: 722340                   | Voluntary context switches: 594468                   |   |
| Involuntary context switches: 258                    | Involuntary context switches: 389                    |   |
| Swaps: 0                                             | Swaps: 0                                             |   |
| File system inputs: 0                                | File system inputs: 0                                |   |
| File system outputs: 33194360                        | File system outputs: 33194360                        |   |
| Socket messages sent: 0                              | Socket messages sent: 0                              |   |
| Socket messages received: 0                          | Socket messages received: 0                          |   |
| Signals delivered: 0                                 | Signals delivered: 0                                 |   |
| Page size (bytes): 4096                              | Page size (bytes): 4096                              |   |
| Exit status: 0                                       | Exit status: 0                                       |   |

On the following pprof dumps, you can see that the time spent mem-moving things is much much lesser.
We also tried changing the CPU count but it has no effect. ( Lib defaults to 4, if the machine has more than 4 )
We tested on a r6id.8xlarge in its nvme.

![Screenshot 2025-02-05 at 14 44 07](https://github.com/user-attachments/assets/5a0377c2-ab7a-4320-bc75-190f297b0432)

