### PR TITLE
erofs-snapshotter: add fsverity support

### DIFF
--- a/docs/snapshotters/erofs.md
+++ b/docs/snapshotters/erofs.md
@@ -82,6 +82,13 @@ The following configuration can be used in your containerd `config.toml`. Don't
 forget to restart containerd after changing the configuration.
 
 ```
+  [plugins."io.containerd.snapshotter.v1.erofs"]
+      # Enable fsverity support for EROFS layers, default is false
+      enable_fsverity = true
+
+      # Optional: Additional mount options for overlayfs
+      ovl_mount_options = []
+
   [plugins."io.containerd.service.v1.diff-service"]
     default = ["erofs","walking"]
 ```
@@ -135,6 +142,13 @@ In other words, the EROFS differ can only be used with the EROFS snapshotter;
 otherwise, it will skip to the next differ.  The EROFS snapshotter can work
 with or without the EROFS differ.
 
+## Data Integrity with fsverity
+
+The EROFS snapshotter supports fsverity for data integrity verification of EROFS layers.
+When enabled via `enable_fsverity = true`, the snapshotter will:
+- Enable fsverity on EROFS layers during commit
+- Verify fsverity status before mounting layers
+- Skip fsverity if the filesystem or kernel does not support it
 
 ## TODO
 

--- a/plugins/snapshots/erofs/plugin/plugin_linux.go
+++ b/plugins/snapshots/erofs/plugin/plugin_linux.go
@@ -33,6 +33,9 @@ type Config struct {
 
 	// MountOptions are options used for the EROFS overlayfs mount
 	OvlOptions []string `toml:"ovl_mount_options"`
+
+	// EnableFsverity enables fsverity for EROFS layers
+	EnableFsverity bool `toml:"enable_fsverity"`
 }
 
 func init() {
@@ -56,6 +59,10 @@ func init() {
 
 			if len(config.OvlOptions) > 0 {
 				opts = append(opts, erofs.WithOvlOptions(config.OvlOptions))
+			}
+
+			if config.EnableFsverity {
+				opts = append(opts, erofs.WithFsverity())
 			}
 
 			ic.Meta.Exports[plugins.SnapshotterRootDir] = root


### PR DESCRIPTION
Add fsverity support to erofs snapshotter to enable data integrity verification for erofs layers:

- Add an config option `EnableFsverity` for erofs snapshotter
- Add fsverity verification during mount operations
- Enable fsverity on erofs layers during commit

The feature can be enabled via config.toml, such as:
```toml
[plugins.'io.containerd.snapshotter.v1.erofs']
    root_path = ''
    ovl_mount_options = []
    enable_fsverity = true
```