### PR TITLE
[release/1.7] Prepare release notes for v1.7.26

### DIFF
--- a/releases/v1.7.26.toml
+++ b/releases/v1.7.26.toml
@@ -1,0 +1,27 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.7.25"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The twenty-sixth patch release for containerd 1.7 contains various fixes
+and updates.
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.7.25+unknown"
+	Version = "1.7.26+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated notes
--

containerd 1.7.26

Welcome to the v1.7.26 release of containerd!

The twenty-sixth patch release for containerd 1.7 contains various fixes
and updates.

### Highlights

* Add support for syncfs after unpack ([#11267](https://github.com/containerd/containerd/pull/11267))
* Update runc binary to v1.2.5 ([#11395](https://github.com/containerd/containerd/pull/11395))
* Fix race between serve and immediate shutdown on the server ([containerd/ttrpc#175](https://github.com/containerd/ttrpc/pull/175))
* Reject oversized messages from the sender ([containerd/ttrpc#171](https://github.com/containerd/ttrpc/pull/171))

#### Container Runtime Interface (CRI)

* Fix fatal concurrency error in port forwarding ([#11306](https://github.com/containerd/containerd/pull/11306))

#### Node Resource Interface (NRI)

* Fix initial sync race when registering NRI plugins ([#11326](https://github.com/containerd/containerd/pull/11326))
* Add API support for reading Pod IPs ([containerd/nri#119](https://github.com/containerd/nri/pull/119))
* Fix plugin sync to use multiple messages if ttrpc max message limit is hit ([containerd/nri#111](https://github.com/containerd/nri/pull/111))
* Update API to pass configured timeouts to plugins. ([containerd/nri#109](https://github.com/containerd/nri/pull/109))
* Fix mount removal in adjustments ([containerd/nri#107](https://github.com/containerd/nri/pull/107))
* Close plugin if initial synchronization fails ([containerd/nri#103](https://github.com/containerd/nri/pull/103))
* Add support for adjusting OOM score ([containerd/nri#94](https://github.com/containerd/nri/pull/94))
* Add API support for NRI-native CDI injection ([containerd/nri#98](https://github.com/containerd/nri/pull/98))
* Add support for pids cgroup ([containerd/nri#76](https://github.com/containerd/nri/pull/76))

#### Runtime

* Fix console TTY leak in runc shim ([#11250](https://github.com/containerd/containerd/pull/11250))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Krisztian Litkey
* Mike Brown
* Samuel Karp
* Wei Fu
* Phil Estes
* Derek McGowan
* Iceber Gu
* Akhil Mohan
* Antonio Ojea
* Austin Vazquez
* Henry Wang
* Jin Dong
* Xiaojin Zhang
* ningmingxiao
* AbdelrahmanElawady
* Akihiro Suda
* Antti Kervinen
* Jing Xu
* Jitang Lei
* Justin Alvarez
* Lei Liu
* Maksym Pavlenko
* Yang Yang
* Yuhang Wei
* cormick
* jingtao.liang

### Changes
<details><summary>23 commits</summary>
<p>

  * [`ef2c2daf5`](https://github.com/containerd/containerd/commit/ef2c2daf5a12412600a6303a0e52df5dd3faa4bf) Prepare release notes for v1.7.26
* Upgrade x/net to 0.33.0 to fix vulnerability GHSA-w32m-9786-jp63 ([#11434](https://github.com/containerd/containerd/pull/11434))
  * [`3486bc8dd`](https://github.com/containerd/containerd/commit/3486bc8dd19acbde278ed6c4c4fa42c7299e1278) Upgrade x/net to 0.33.0
* update build to go1.23.6, test go1.24.0 ([#11419](https://github.com/containerd/containerd/pull/11419))
  * [`9025d3075`](https://github.com/containerd/containerd/commit/9025d3075b91b0806ff15f27f28bbce8af4f1a76) update build to go1.23.6, test go1.24.0
* Update install-imgcrypt to allow change install repo ([#11358](https://github.com/containerd/containerd/pull/11358))
  * [`83eaab482`](https://github.com/containerd/containerd/commit/83eaab4822188e019efe68c29a6d77f37f099d6e) Update install-imgcrypt to allow change install repo
* Add support for syncfs after unpack ([#11267](https://github.com/containerd/containerd/pull/11267))
  * [`8bc21cba7`](https://github.com/containerd/containerd/commit/8bc21cba7516727b294d4dd6a3e8859cbdd146a8) support to syncfs after pull by using diff plugin
* Update runc binary to v1.2.5 ([#11395](https://github.com/containerd/containerd/pull/11395))
  * [`27c472acf`](https://github.com/containerd/containerd/commit/27c472acf59c4d86e2b446ae554691149ac43661) Update runc binary to v1.2.5
* Move `run.skip-dirs` to `issues.exclude-dirs` in golangci-lint config ([#11400](https://github.com/containerd/containerd/pull/11400))
  * [`8d8034b66`](https://github.com/containerd/containerd/commit/8d8034b66e2790ef0149207acb7c92a033d7f1f8) move skip-dirs to issues.exclude-dirs
* Fix initial sync race when registering NRI plugins ([#11326](https://github.com/containerd/containerd/pull/11326))
  * [`11af05177`](https://github.com/containerd/containerd/commit/11af05177545dbb97d87aa861b15d70ab911307c) cri,nri: block NRI plugin sync. during event processing.
  * [`d4036cd3d`](https://github.com/containerd/containerd/commit/d4036cd3d1eb174ea379c8e1d139c25cfe9f18d8) go.{mod,sum}: bump NRI to v0.8.0, re-vendor.
* Fix console TTY leak in runc shim ([#11250](https://github.com/containerd/containerd/pull/11250))
  * [`c3e24e024`](https://github.com/containerd/containerd/commit/c3e24e0248f0ca83d0bfbb0262862c2a06a632e2) Add integ test to check tty leak
  * [`4e45a463d`](https://github.com/containerd/containerd/commit/4e45a463d90fd44f6b92978721779d7b09045cee) fix master tty leak due to leaking init container object
* Fix fatal concurrency error in port forwarding ([#11306](https://github.com/containerd/containerd/pull/11306))
  * [`0fe9f0b52`](https://github.com/containerd/containerd/commit/0fe9f0b52f7b700689df46d13de36e67b62486e1) fix fatal error: concurrent map iteration and map write
* update build to go1.22.11, test go1.23.5 ([#11298](https://github.com/containerd/containerd/pull/11298))
  * [`441b92636`](https://github.com/containerd/containerd/commit/441b92636a806d71655945137210126de723e4fe) update build to go1.22.11, test go1.23.5
</p>
</details>

### Changes from containerd/nri
<details><summary>77 commits</summary>
<p>

* Add API support for reading Pod IPs ([containerd/nri#119](https://github.com/containerd/nri/pull/119))
  * [`eaf78a9`](https://github.com/containerd/nri/commit/eaf78a9afe9ebac28a68d1163dd00183525801a3) api: support Pod IPs
*  generate: do not set OOMScoreAdj if no adjustment ([containerd/nri#116](https://github.com/containerd/nri/pull/116))
  * [`07bfc18`](https://github.com/containerd/nri/commit/07bfc18129a3cc9c4b44e1aced9972279a50ddb5) wip: generate: add test for oom score adj
  * [`b5fc359`](https://github.com/containerd/nri/commit/b5fc359973c0e8c599b12c1d118546c267894b3b) generate: do not set OOMScoreAdj if no adjustment
* device-injector: remove unreachable code. ([containerd/nri#115](https://github.com/containerd/nri/pull/115))
  * [`235aa11`](https://github.com/containerd/nri/commit/235aa114dffc784073ec8b2f88fbd4ecfba06450) chore: remove unreachable code and fmt files
* Fix plugin sync to use multiple messages if ttrpc max message limit is hit ([containerd/nri#111](https://github.com/containerd/nri/pull/111))
  * [`159f575`](https://github.com/containerd/nri/commit/159f5754db397e32ce886cd07985ffd95f1bd823) template: dump pod/container count in sync message.
  * [`bf267e3`](https://github.com/containerd/nri/commit/bf267e336f2ec2f5045fd396fb68f9853d2b5db9) stub: collect/handle split sync messages.
  * [`ed78ae9`](https://github.com/containerd/nri/commit/ed78ae9231cb603031f66921559ca6f38ef77bb5) adaptation: use multiple sync messages if necessary.
  * [`6fd59d6`](https://github.com/containerd/nri/commit/6fd59d6d7701cdadeae4db0058b3fde84c02e94b) api: add support for multiple sync messages.
  * [`a7fcccc`](https://github.com/containerd/nri/commit/a7fcccc4ba35f69ea2af790b6cb4b46385c50ce4) mux: split oversized messages.
  * [`5fe9b06`](https://github.com/containerd/nri/commit/5fe9b06401fb7fce78c41b95df04e05dffc22e5b) mux: fix maximum allowed message size.
  * [`693d64e`](https://github.com/containerd/nri/commit/693d64e2565cc14c00fae2de904ffc030fc2b894) go.{mod,sum}, plugins: update ttrpc and NRI deps.
* Update API to pass configured timeouts to plugins. ([containerd/nri#109](https://github.com/containerd/nri/pull/109))
  * [`320e4e7`](https://github.com/containerd/nri/commit/320e4e7e52a856b119cfa1c06a4a135ab5f88f56) adaptation: tests for runtime version, timeouts.
  * [`f86d982`](https://github.com/containerd/nri/commit/f86d98210749556ef562776fde784d2250d1190e) api,adaptation,stub: let plugin know configured timeouts.
  * [`cfcd2af`](https://github.com/containerd/nri/commit/cfcd2af3c80db6667f2d1a291225cc616b6049c3) Makefile: fix ginkgo-tests target.
  * [`8cd9504`](https://github.com/containerd/nri/commit/8cd9504a48e1b79625ff5fce3d058c6662bc34d6) adaptation: block plugin sync/registration in test suite.
  * [`966ac92`](https://github.com/containerd/nri/commit/966ac92b01fca271373e2088695538dcef0edb2b) adaptation: implement plugin synchronization blocks.
* ci: verify that code generation works and results match ([containerd/nri#113](https://github.com/containerd/nri/pull/113))
  * [`f74ce31`](https://github.com/containerd/nri/commit/f74ce31ef9b048d69702b954912122a0597598a8) ci: verify code generation and generated files in repo
* deps: bump gingko to v2.19.1, golang to v1.21.x.  ([containerd/nri#110](https://github.com/containerd/nri/pull/110))
  * [`e4d5c36`](https://github.com/containerd/nri/commit/e4d5c36429c495c5d61d0183ba1c1a908ed598f4) ci: stop testing with golang 1.20.x.
  * [`6578149`](https://github.com/containerd/nri/commit/65781492cc1b0cf5a6a6166a81ba638e45b7f93f) go.{mod,sum}: bump golang requirement to 1.21.
  * [`442e812`](https://github.com/containerd/nri/commit/442e81239436c53689e14d9a641099a4aeec7cbe) go.{mod,sum}: update to ginkgo v2.19.1.
* sync sandboxes and containers after starting the pre-installed plugins ([containerd/nri#43](https://github.com/containerd/nri/pull/43))
  * [`eada085`](https://github.com/containerd/nri/commit/eada085db3965057686def58fd8993c70030dd7f) ignore pre-installed plugins that did not sync successfully
  * [`b881bc4`](https://github.com/containerd/nri/commit/b881bc4ba69e3bfe718939d97f327f3c72670fad) sync sandboxes and containers after starting the pre-installed plugins
* Fix mount removal in adjustments ([containerd/nri#107](https://github.com/containerd/nri/pull/107))
  * [`3880f1d`](https://github.com/containerd/nri/commit/3880f1df504f4b3ceedd3a36172162c886a00564) adaptation: add test case for mount removal.
  * [`0d3b376`](https://github.com/containerd/nri/commit/0d3b37631b9fb913e95a9a0efd31b27117208e40) adaptation: fix mount removal in adjustments.
* codespell: add codespell config, workflow, fix spelling errors. ([containerd/nri#105](https://github.com/containerd/nri/pull/105))
  * [`df84c47`](https://github.com/containerd/nri/commit/df84c475025e3fc536701aa99f6ca6d14dbea648) .github: add codespell workflow.
  * [`a03dc93`](https://github.com/containerd/nri/commit/a03dc9359c2d526924e56a9d167445a69588d3ae) pkg,plugins,.codespellrc: add codespellrc, fix spelling.
* Close plugin if initial synchronization fails ([containerd/nri#103](https://github.com/containerd/nri/pull/103))
  * [`4aec208`](https://github.com/containerd/nri/commit/4aec208281ac3630b02d737005778527aec8abae) adaptation: log plugin as connected and synchronized.
  * [`4e60cd0`](https://github.com/containerd/nri/commit/4e60cd0fb845ffefa9590084bb5261a113ad6858) adaptation: close plugin if initial synchronization fails.
* Reset source path of api.pb.go to pkg/api/api.proto ([containerd/nri#104](https://github.com/containerd/nri/pull/104))
  * [`1cc026f`](https://github.com/containerd/nri/commit/1cc026f8a3773b9e0d4ca80f9c3e978ef7d54bef) Reset source path of api.pb.go to pkg/api/api.proto
* Add support for adjusting OOM score ([containerd/nri#94](https://github.com/containerd/nri/pull/94))
  * [`efcb2da`](https://github.com/containerd/nri/commit/efcb2dad664293bd3fbad1557cac2dcfd15a86dc) NRI plugins support adjust oom_score_adj
* Add API support for NRI-native CDI injection ([containerd/nri#98](https://github.com/containerd/nri/pull/98))
  * [`8783973`](https://github.com/containerd/nri/commit/87839736588c90995cd7d8a19beb47076efd3319) device-injector: clarify precedence of annotations.
  * [`4eb7075`](https://github.com/containerd/nri/commit/4eb70757f7095a9928d6a34a9e8f28eaac066a42) pkg/adaptation: fix grammatical mistakes in comments.
  * [`4bd8da8`](https://github.com/containerd/nri/commit/4bd8da8cf7128f9ac88ebed28f2e3afd73d0fab1) device-injector: add support for CDI injection.
  * [`44773bd`](https://github.com/containerd/nri/commit/44773bdd8b2fc5ed0e193975f54cfdf7153f708c) runtime-tools/generate: add support CDI injection.
  * [`65282fe`](https://github.com/containerd/nri/commit/65282fe079414600930b9fa084a46fb0bd0e0c8b) adaptation: add CDI device injection unit test.
  * [`01f3b7a`](https://github.com/containerd/nri/commit/01f3b7a6681de5961920091f88e71335778ecc21) adaptation: add support for native CDI injection.
  * [`f1aa58f`](https://github.com/containerd/nri/commit/f1aa58f8157aacbdda3826316c77e4e96914235a) api: add support for native CDI device injection.
* types: Fix a typo ([containerd/nri#101](https://github.com/containerd/nri/pull/101))
  * [`8434439`](https://github.com/containerd/nri/commit/8434439b76e0b4c8dad1c5e2b1fadc4bbfea4b1a) types: Fix a typo
* Add support for pids cgroup ([containerd/nri#76](https://github.com/containerd/nri/pull/76))
  * [`1719502`](https://github.com/containerd/nri/commit/1719502ed2a62bb99e561f759278f3e6628ae191) support pids cgroup
* stub: support restart after stub stopped ([containerd/nri#91](https://github.com/containerd/nri/pull/91))
  * [`242661f`](https://github.com/containerd/nri/commit/242661fd7ab841358dc0cc53b8fe34dd7878b6c8) stub: support re-start after stub stopped
* stop closed plugins that will be removed ([containerd/nri#89](https://github.com/containerd/nri/pull/89))
  * [`ba398fa`](https://github.com/containerd/nri/commit/ba398fa866f5f8a2d51e92eedcde2ea6aacce2b1) stop closed plugins that will be removed
* plugins/device-injector: fix a small typo in README.md. ([containerd/nri#97](https://github.com/containerd/nri/pull/97))
  * [`f96a550`](https://github.com/containerd/nri/commit/f96a550770396c0e83763d2ff1a48c74facbbff7) device-injector: small grammar fix in README.md.
* plugins/template: fix a typo in a comment. ([containerd/nri#96](https://github.com/containerd/nri/pull/96))
  * [`5680921`](https://github.com/containerd/nri/commit/5680921a7acdd967fc72317b63380b278c3a447c) plugins/template: fix typo in a comment.
* go.{mod,sum}, .github: bump minimum golang version to 1.20. ([containerd/nri#88](https://github.com/containerd/nri/pull/88))
  * [`2c3608d`](https://github.com/containerd/nri/commit/2c3608db37a03ff3d7b02fc86d2a763976a830ea) .golangci.yml: silence dot-import errors for tests.
  * [`8f56974`](https://github.com/containerd/nri/commit/8f56974eb755a4a09d1013a82f30d9593fc50b9a) pkg/{adaptation,api,net,stub}: fix linter errors.
  * [`e863892`](https://github.com/containerd/nri/commit/e863892df021fc7ac5f5d9302132fb4a82c54394) .github: bump golangci-lint to v1.58.0.
  * [`674cb41`](https://github.com/containerd/nri/commit/674cb4149fc21a25e35e82b3b7baec2c9ac4404a) .github: bump setup-go to v5.
  * [`9106283`](https://github.com/containerd/nri/commit/9106283b2ebbad9f0c3374113a2b93c1cd0ab304) .github: test with golang 1.20.x, 1.21.x, 1.22.3 in CI.
  * [`a9778ad`](https://github.com/containerd/nri/commit/a9778ad8bf138b27289e2d12d84b81420f6709b2) plugins: bump golang version to 1.20.
  * [`8e86065`](https://github.com/containerd/nri/commit/8e860654df09f8aebac99b6738c2cbffefd8f8b8) go.{mod.sum}: bump golang version to 1.20.
* network device injector plugin ([containerd/nri#82](https://github.com/containerd/nri/pull/82))
  * [`ff774e6`](https://github.com/containerd/nri/commit/ff774e6e62a652d4473e2398110ff796aa1e420b) network device injector plugin
* Modify hook-injector plugin to monitor directories to match cri-o ([containerd/nri#84](https://github.com/containerd/nri/pull/84))
  * [`06841c2`](https://github.com/containerd/nri/commit/06841c28928f8f0c21ddb7511cb2b464f8c08139) Modify hook-injector plugin to monitor directories to match cri-o
* docs: fix broken link to sample plugins in README.md ([containerd/nri#81](https://github.com/containerd/nri/pull/81))
  * [`2791e93`](https://github.com/containerd/nri/commit/2791e932d71d3bff0bed040a17b5d4f9afc549be) docs: fix broken link to sample plugins in README.md
</p>
</details>

### Changes from containerd/ttrpc
<details><summary>11 commits</summary>
<p>

* Add MD.Clone function ([containerd/ttrpc#177](https://github.com/containerd/ttrpc/pull/177))
  * [`430f734`](https://github.com/containerd/ttrpc/commit/430f7347915993a5543bfb00858ac337274528ba) Add MD.Clone
* Fix race between serve and immediate shutdown on the server ([containerd/ttrpc#175](https://github.com/containerd/ttrpc/pull/175))
  * [`c4d96d5`](https://github.com/containerd/ttrpc/commit/c4d96d55ad9c4f4cf6036c70a5b18ba80655d648) server: fix Serve() vs. immediate Shutdown() race.
  * [`ed6c3ba`](https://github.com/containerd/ttrpc/commit/ed6c3ba082bdbc82284c198d93ca5f07ad9900dd) server_test: add Serve()/Shutdown() race test.
* Reject oversized messages from the sender ([containerd/ttrpc#171](https://github.com/containerd/ttrpc/pull/171))
  * [`b5cd6e4`](https://github.com/containerd/ttrpc/commit/b5cd6e4b32878158dc44b7854a7d14b454f75daf) channel: allow discovery of overflown message size.
  * [`d8c00df`](https://github.com/containerd/ttrpc/commit/d8c00dfec306c305efef44aa526f2acf8ebd165b) channel_test: update oversize message test.
  * [`de273bf`](https://github.com/containerd/ttrpc/commit/de273bf7511de4710934b92415a00d471a6118cb) channel: reject oversized messages on the sender side.
* server_test: fix error message in TestOversizeCall. ([containerd/ttrpc#170](https://github.com/containerd/ttrpc/pull/170))
  * [`84e1784`](https://github.com/containerd/ttrpc/commit/84e1784f340651f94891fbd091cbb3d5bfdf9e62) server_test: fix error message in TestOversizeCall.
</p>
</details>

### Dependency Changes

* **github.com/containerd/nri**    v0.6.1 -> v0.8.0
* **github.com/containerd/ttrpc**  v1.2.5 -> v1.2.7
* **github.com/go-logr/logr**      v1.3.0 -> v1.4.2
* **golang.org/x/net**             v0.25.0 -> v0.33.0

Previous release can be found at [v1.7.25](https://github.com/containerd/containerd/releases/tag/v1.7.25)

