### PR TITLE
Reduce file permissions

### DIFF
--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -128,7 +128,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 
 	// Create container root directory.
 	containerRootDir := c.getContainerRootDir(id)
-	if err = c.os.MkdirAll(containerRootDir, 0755); err != nil {
+	if err = c.os.MkdirAll(containerRootDir, 0700); err != nil {
 		return nil, fmt.Errorf("failed to create container root directory %q: %w",
 			containerRootDir, err)
 	}
@@ -142,7 +142,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 		}
 	}()
 	volatileContainerRootDir := c.getVolatileContainerRootDir(id)
-	if err = c.os.MkdirAll(volatileContainerRootDir, 0755); err != nil {
+	if err = c.os.MkdirAll(volatileContainerRootDir, 0700); err != nil {
 		return nil, fmt.Errorf("failed to create volatile container root directory %q: %w",
 			volatileContainerRootDir, err)
 	}

--- a/internal/cri/server/podsandbox/sandbox_run.go
+++ b/internal/cri/server/podsandbox/sandbox_run.go
@@ -97,7 +97,7 @@ func (c *Controller) Start(ctx context.Context, id string) (cin sandbox.Controll
 
 	// Create sandbox container root directories.
 	sandboxRootDir := c.getSandboxRootDir(id)
-	if err := c.os.MkdirAll(sandboxRootDir, 0755); err != nil {
+	if err := c.os.MkdirAll(sandboxRootDir, 0700); err != nil {
 		return cin, fmt.Errorf("failed to create sandbox root directory %q: %w",
 			sandboxRootDir, err)
 	}
@@ -112,7 +112,7 @@ func (c *Controller) Start(ctx context.Context, id string) (cin sandbox.Controll
 	}()
 
 	volatileSandboxRootDir := c.getVolatileSandboxRootDir(id)
-	if err := c.os.MkdirAll(volatileSandboxRootDir, 0755); err != nil {
+	if err := c.os.MkdirAll(volatileSandboxRootDir, 0700); err != nil {
 		return cin, fmt.Errorf("failed to create volatile sandbox root directory %q: %w",
 			volatileSandboxRootDir, err)
 	}

--- a/plugins/content/local/store.go
+++ b/plugins/content/local/store.go
@@ -547,7 +547,7 @@ func (s *store) writer(ctx context.Context, ref string, total int64, expected di
 	}
 
 	// ensure that the ingest path has been created.
-	if err := os.Mkdir(path, 0755); err != nil {
+	if err := os.Mkdir(path, 0700); err != nil {
 		if !os.IsExist(err) {
 			return nil, err
 		}
@@ -657,7 +657,7 @@ func (s *store) ingestPaths(ref string) (string, string, string) {
 }
 
 func (s *store) ensureIngestRoot() error {
-	return os.MkdirAll(filepath.Join(s.root, "ingest"), 0777)
+	return os.MkdirAll(filepath.Join(s.root, "ingest"), 0700)
 }
 
 func readFileString(path string) (string, error) {

--- a/plugins/content/local/writer.go
+++ b/plugins/content/local/writer.go
@@ -123,7 +123,7 @@ func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest,
 	)
 
 	// make sure parent directories of blob exist
-	if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(target), 0700); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
/var/lib/containerd
```
containerd                                                                                  drwx--x--x.
├── io.containerd.content.v1.content                                                        drwxr-xr-x.    //755 -> 700
│   ├── blobs                                                                               drwxr-xr-x.    //755 -> 700
│   │   └── sha256                                                                          drwxr-xr-x.    //755 -> 700
│   │       ├── 0968e31df05b727234888883ba43ccaa4ec75566113c75065af5a6124b62d93c            -r--r--r--.
│   │       ├── 0b16ab2571f4b3e0d5a96b66a00e5016ddc0d268e8bc45dc612948c4c95b94cd            -r--r--r--.
│   │       ├── 194fdd7e97b357a66bf462d13404702e429c9be14ae1f824f6d233a156b122d7            -r--r--r--.
│   │       ├── da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e            -r--r--r--.
│   │       ├── e17133b79956ad6f69ae7f775badd1c11bad2fc64f0529cab863b9d12fbaa5c4            -r--r--r--.
│   │       └── ff4a8eb070e12018233797e865841d877a7835c4c6d5cfc52e5481995da6b2f7            -r--r--r--.
│   └── ingest                                                                              drwxr-xr-x.    //755 -> 700
├── io.containerd.grpc.v1.cri                                                               drwxr-xr-x.    //755 -> 700
│   ├── containers                                                                          drwxr-xr-x.    //755 -> 700
│   │   └── 0a7565a2b82508a2b088d6aaa4ba88ae966319cc097159ee4ac377b7258a6c9b                drwxr-xr-x.    //755 -> 700
│   │       └── status                                                                      -rw-------.
│   └── sandboxes                                                                           drwxr-xr-x.    //755 -> 700
│       └── 02602d4ea2123e45724138006e986bbcb4f0d7211b5a9c4aaf8697486819a9c4                drwxr-xr-x.    //755 -> 700
│           ├── hostname                                                                    -rw-r--r--.
│           ├── hosts                                                                       -rw-r--r--.
│           └── resolv.conf                                                                 -rw-r--r--.
├── io.containerd.metadata.v1.bolt                                                          drwx--x--x.
│   └── meta.db                                                                             -rw-r--r--.
├── io.containerd.runtime.v1.linux                                                          drwx--x--x.
├── io.containerd.runtime.v2.task                                                           drwx--x--x.
│   └── k8s.io                                                                              drwx--x--x.
│       ├── 02602d4ea2123e45724138006e986bbcb4f0d7211b5a9c4aaf8697486819a9c4                drwx--x--x.
│       ├── 0a7565a2b82508a2b088d6aaa4ba88ae966319cc097159ee4ac377b7258a6c9b                drwx--x--x.
│       └── 1b0eced10dea9fddab7c66631f0920170121bd996d2845b48468ff119fe40826                drwx--x--x.
├── io.containerd.snapshotter.v1.blockfile                                                  drwx------.
├── io.containerd.snapshotter.v1.native                                                     drwx------.
│   └── snapshots                                                                           drwx------.
├── io.containerd.snapshotter.v1.overlayfs                                                  drwx------.
│   ├── metadata.db                                                                         -rw-------.
│   └── snapshots                                                                           drwx------.
│       ├── 1                                                                               drwx------.
│       │   ├── fs                                                                          drwxr-xr-x.    //755       // The mirror real layer does not need to be modified
│       │   └── work                                                                        drwx--x--x.    //711
└── tmpmounts                                                           
```

/run/containerd
```
containerd                                                                                  drwx--x--x.
├── containerd.sock                                                                         srw-rw----.
├── containerd.sock.ttrpc                                                                   srw-rw----.
├── io.containerd.grpc.v1.cri                                                               drwxr-xr-x.    //755 -> 700
│     ├── containers                                                                        drwxr-xr-x.    //755 -> 700
│     │     └── 0a7565a2b82508a2b088d6aaa4ba88ae966319cc097159ee4ac377b7258a6c9b            drwxr-xr-x.    //755 -> 700
│     │         └── io                  drwx------.
│     │             └── 149561824       drwx------.
│     │                 ├── 0a7565a2b82508a2b088d6aaa4ba88ae966319cc097159ee4ac377b7258a6c9b-stderr     prwx------.
│     │                 ├── 0a7565a2b82508a2b088d6aaa4ba88ae966319cc097159ee4ac377b7258a6c9b-stdin      prwx------.
│     │                 └── 0a7565a2b82508a2b088d6aaa4ba88ae966319cc097159ee4ac377b7258a6c9b-stdout     prwx------.
│     └── sandboxes                                                                         drwxr-xr-x.    //755 -> 700
│         └── 02602d4ea2123e45724138006e986bbcb4f0d7211b5a9c4aaf8697486819a9c4              drwxr-xr-x.    755 -> 700
│             └── shm                                                                       drwxrwxrwt.
├── io.containerd.runtime.v1.linux                                                          drwx--x--x.
├── io.containerd.runtime.v2.task                                                           drwx--x--x.
│     └── k8s.io                                                                            drwx--x--x.
│         ├── 02602d4ea2123e45724138006e986bbcb4f0d7211b5a9c4aaf8697486819a9c4              drwx------.
│         │     ├── address                                                                 -rw-rw-rw-.    //666
│         │     ├── config.json                                                             -rw-r--r--.    //644
│         │     ├── init.pid                                                                -rw-r--r--.    //644
│         │     ├── log                                                                     prwx------.
│         │     ├── log.json                                                                -rw-r--r--.    //644    //moby is also 644, consistent
│         │     ├── options.json                                                            -rw-------.
│         │     ├── rootfs                                                                  drwxr-xr-x.    //755    //rootfs does not need
│         │     ├── runtime                                                                 -rw-------.
│         │     ├── shim-binary-path                                                        -rw-------.
│         │     └── work > /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io/02602d4ea2123e45724138006e986bbcb4f0d7211b5a9c4aaf8697486819a9c4       lrwxrwxrwx
├── runc                                                                                    drwx------.
│     └── k8s.io                                                                            drwx------.
│         ├── 02602d4ea2123e45724138006e986bbcb4f0d7211b5a9c4aaf8697486819a9c4              drwx--x--x.
│         │     └── state.json                                                              -rw-------.
└── s                                                                                       drwx------.
├── 04b3d1385fb38cef9c81753c21b55621fdcddad6775f21613e526263acb14ad7                        srw-------.
└── a8ed90f4e10f762eeaa786a339301cdd0f4864a1cbabff8c1d213837676ad1ba                        srw-------.
```