### PR TITLE
move the device after the options when using mkfs.ext4

### DIFF
--- a/plugins/snapshots/devmapper/pool_device_test.go
+++ b/plugins/snapshots/devmapper/pool_device_test.go
@@ -235,9 +235,9 @@ func testCreateThinDevice(t *testing.T, pool *PoolDevice) {
 func testMakeFileSystem(t *testing.T, pool *PoolDevice) {
 	devicePath := dmsetup.GetFullDevicePath(thinDevice1)
 	args := []string{
-		devicePath,
 		"-E",
 		"nodiscard,lazy_itable_init=0,lazy_journal_init=0",
+		devicePath,
 	}
 
 	output, err := exec.Command("mkfs.ext4", args...).CombinedOutput()


### PR DESCRIPTION
fix: https://github.com/containerd/containerd/issues/11347

/cc @deitch