### PR TITLE
fix: return Deleted status on 'not found' when fetching task process state

### DIFF
--- a/plugins/services/tasks/local.go
+++ b/plugins/services/tasks/local.go
@@ -337,7 +337,11 @@ func getProcessState(ctx context.Context, p runtime.Process) (*task.Process, err
 
 	state, err := p.State(ctx)
 	if err != nil {
-		if errdefs.IsNotFound(err) || errdefs.IsUnavailable(err) {
+		if errdefs.IsNotFound(err) {
+			state = runtime.State{
+				Status: runtime.DeletedStatus,
+			}
+		} else if errdefs.IsUnavailable(err) {
 			return nil, err
 		}
 		log.G(ctx).WithError(err).Errorf("get state for %s", p.ID())


### PR DESCRIPTION
fix: [11392](https://github.com/containerd/containerd/issues/11392)