### PR TITLE
Move `linters-settings.exclude-dirs` to `issues.exclude-dirs` in golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,14 @@ issues:
   max-issues-per-linter: 0
   max-same-issues: 0
 
+  exclude-dirs:
+    - api
+    - cluster
+    - docs
+    - docs/man
+    - releases
+    - test # e2e scripts
+
   # Only using / doesn't work due to https://github.com/golangci/golangci-lint/issues/1398.
   exclude-rules:
     - path: 'cmd[\\/]containerd[\\/]builtins[\\/]'
@@ -76,14 +84,6 @@ linters-settings:
       - G115
   nolintlint:
     allow-unused: true
-
-  exclude-dirs:
-    - api
-    - cluster
-    - docs
-    - docs/man
-    - releases
-    - test # e2e scripts
 
 run:
   timeout: 8m


### PR DESCRIPTION
The new golangci-lint action upgrade enabled golangci-lint config verification (from release note in https://github.com/containerd/containerd/pull/11397):


> v6.5.0
> What's Changed
> Changes
> feat: verify with the JSONSchema by default by [@​ldez](https://github.com/ldez) in [golangci/golangci-lint-action#1171]

That exposed a bug in our config where `issues.exclude-dirs` was put as `linters-settings.exclude-dirs` by accident:
https://github.com/containerd/containerd/actions/runs/13380233408/job/37367383920?pr=11397

```
jsonschema: "linters-settings" does not validate with "/properties/linters-settings/additionalProperties": additional properties 'exclude-dirs' not allowed
Failed executing command with error: the configuration contains invalid elements
```

The change was initially introduced in https://github.com/containerd/containerd/pull/10188 which also mentioned `issues.exclude-dirs` should be the correct path:

```
WARN [config_reader] The configuration option `run.skip-dirs` is deprecated, please use `issues.exclude-dirs`.
```