### PR TITLE
[release/1.7] Move `run.skip-dirs` to `issues.exclude-dirs` in golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,16 @@ issues:
   max-issues-per-linter: 0
   max-same-issues: 0
 
+  exclude-dirs:
+    - api
+    - cluster
+    - design
+    - docs
+    - docs/man
+    - releases
+    - reports
+    - test # e2e scripts
+
   # Only using / doesn't work due to https://github.com/golangci/golangci-lint/issues/1398.
   exclude-rules:
     - path: 'cmd[\\/]containerd[\\/]builtins[\\/]'
@@ -85,12 +95,3 @@ linters-settings:
 
 run:
   timeout: 8m
-  skip-dirs:
-    - api
-    - cluster
-    - design
-    - docs
-    - docs/man
-    - releases
-    - reports
-    - test # e2e scripts


### PR DESCRIPTION
The latest golangci-lint-action enabled config schema check:
https://github.com/golangci/golangci-lint-action/releases/tag/v6.5.0

> Changes
feat: verify with the JSONSchema by default by @ldez in https://github.com/golangci/golangci-lint-action/pull/1171

On 1.7 release branch we are using golangci-lint version 1.60.3, which has removed the deprecated `skip-dirs` field ([see its json schema](https://github.com/golangci/golangci-lint/blob/master/jsonschema/golangci.v1.60.jsonschema.json)), thus failing the 1.7 CI.

It doesn't fail on 1.6 because we use version 1.55.0.