### PR TITLE
bugfix: don't skip error when delete from store.

### DIFF
--- a/internal/cri/server/container_remove.go
+++ b/internal/cri/server/container_remove.go
@@ -55,7 +55,7 @@ func (c *criService) RemoveContainer(ctx context.Context, r *runtime.RemoveConta
 		// we should try to recover from this state by removing entry for this container
 		// from the container store as well and return successfully.
 		log.G(ctx).WithError(err).Warn("get container info failed")
-		c.containerStore.Delete(ctrID)
+		c.containerStore.Delete(ctx, ctrID)
 		c.containerNameIndex.ReleaseByKey(ctrID)
 		return &runtime.RemoveContainerResponse{}, nil
 	}
@@ -124,7 +124,7 @@ func (c *criService) RemoveContainer(ctx context.Context, r *runtime.RemoveConta
 			volatileContainerRootDir, err)
 	}
 
-	c.containerStore.Delete(id)
+	c.containerStore.Delete(ctx, id)
 
 	c.containerNameIndex.ReleaseByKey(id)
 

--- a/internal/cri/server/sandbox_remove.go
+++ b/internal/cri/server/sandbox_remove.go
@@ -99,7 +99,7 @@ func (c *criService) RemovePodSandbox(ctx context.Context, r *runtime.RemovePodS
 	// 1) ListPodSandbox will not include this sandbox.
 	// 2) PodSandboxStatus and StopPodSandbox will return error.
 	// 3) On-going operations which have held the reference will not be affected.
-	c.sandboxStore.Delete(id)
+	c.sandboxStore.Delete(ctx, id)
 
 	if err := c.client.SandboxStore().Delete(ctx, id); err != nil {
 		if !errdefs.IsNotFound(err) {

--- a/internal/cri/store/container/container_test.go
+++ b/internal/cri/store/container/container_test.go
@@ -17,6 +17,7 @@
 package container
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -220,7 +221,7 @@ func TestContainerStore(t *testing.T) {
 		assert.Equal(errdefs.ErrAlreadyExists, s.Add(v))
 
 		t.Logf("should be able to delete container")
-		s.Delete(truncID)
+		s.Delete(context.Background(), truncID)
 		cntrNum--
 		cs = s.List()
 		assert.Len(cs, cntrNum)

--- a/internal/cri/store/sandbox/sandbox_test.go
+++ b/internal/cri/store/sandbox/sandbox_test.go
@@ -17,6 +17,7 @@
 package sandbox
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -176,7 +177,7 @@ func TestSandboxStore(t *testing.T) {
 		assert.Equal(errdefs.ErrAlreadyExists, s.Add(v))
 
 		t.Logf("should be able to delete sandbox")
-		s.Delete(truncID)
+		s.Delete(context.Background(), truncID)
 		sbNum--
 		sbs = s.List()
 		assert.Len(sbs, sbNum)


### PR DESCRIPTION
I find some errors are dropped  will cause container's io failed to be closed,we should print or return these error.