### PR TITLE
Assign values for the containerStatuses and timestamp fields in the PodSandboxStatus interface

### DIFF
--- a/internal/cri/server/sandbox_status.go
+++ b/internal/cri/server/sandbox_status.go
@@ -72,6 +72,12 @@ func (c *criService) PodSandboxStatus(ctx context.Context, r *runtime.PodSandbox
 		info = cstatus.Info
 	}
 
+	containerStatuses, err := c.getContainerStatuses(ctx, r.GetPodSandboxId())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get container statuses for sandboxID %q: %w", r.GetPodSandboxId(), err)
+	}
+	timestamp := time.Now().UnixNano()
+
 	status := toCRISandboxStatus(sandbox.Metadata, state, createdAt, ip, additionalIPs)
 	if status.GetCreatedAt() == 0 {
 		// CRI doesn't allow CreatedAt == 0.
@@ -83,8 +89,10 @@ func (c *criService) PodSandboxStatus(ctx context.Context, r *runtime.PodSandbox
 	}
 
 	return &runtime.PodSandboxStatusResponse{
-		Status: status,
-		Info:   info,
+		Status:             status,
+		Info:               info,
+		Timestamp:          timestamp,
+		ContainersStatuses: containerStatuses,
 	}, nil
 }
 


### PR DESCRIPTION
In the [KEP for evented PLEG](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/3386-kubelet-evented-pleg/README.md#runtime-service-changes), we required the `PodSandboxStatus` interface to return these two fields (`containerStatuses` and `timestamp`) with assigned values. 

However, in the [PR implementing evented PLEG support](https://github.com/containerd/containerd/pull/7073), we did not address this part, and I couldn't find any context related to these two fields in the PR comments. I'm uncertain whether this was an unintentional oversight or an intentional decision.

If we deliberately chose not to assign values to these fields, please feel free to close this PR.