### PR TITLE
cri:fix restart panic

### DIFF
--- a/integration/duplicate_name_linux_test.go
+++ b/integration/duplicate_name_linux_test.go
@@ -1,0 +1,95 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+
+	"github.com/containerd/containerd/v2/integration/images"
+	"github.com/containerd/containerd/v2/internal/cri/store/container"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+type versionedStatus struct {
+	// Version indicates the version of the versioned container status.
+	Version string
+	container.Status
+}
+
+// https://github.com/containerd/containerd/issues/7247
+func TestDuplicateNameIssue7247(t *testing.T) {
+	t.Logf("Create a sandbox")
+	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "duplicate-name7247")
+	t.Logf("Create the sandbox again should fail")
+	_, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
+	require.Error(t, err)
+	pauseImage := images.Get(images.Pause)
+	EnsureImageExists(t, pauseImage)
+	t.Logf("Create a container")
+	var (
+		testImage     = images.Get(images.BusyBox)
+		containerName = "test-container"
+	)
+	EnsureImageExists(t, testImage)
+	cnConfig := ContainerConfig(
+		containerName,
+		testImage,
+		WithCommand("sh", "-c", "sleep 1000"),
+	)
+	cID, err := runtimeService.CreateContainer(sb, cnConfig, sbConfig)
+	require.NoError(t, err)
+	err = runtimeService.StartContainer(cID)
+	require.NoError(t, err)
+	status, err := runtimeService.ContainerStatus(cID)
+	require.NoError(t, err)
+	assert.Equal(t, status.GetState(), runtime.ContainerState_CONTAINER_RUNNING)
+	cfg := criRuntimeInfo(t, runtimeService)
+	rootDir := cfg["rootDir"].(string)
+	containerDir := filepath.Join(rootDir, "containers", cID)
+	statusDir := filepath.Join(containerDir, "status")
+	versioned := &versionedStatus{}
+	data, err := os.ReadFile(statusDir)
+	require.NoError(t, err)
+	err = json.Unmarshal(data, versioned)
+	require.NoError(t, err)
+	pid := strconv.Itoa(int(versioned.Pid))
+	// make status file can't be changed
+	_, err = exec.Command("chattr", "+i", statusDir).CombinedOutput()
+	require.NoError(t, err)
+	StopContainerd(t, syscall.SIGTERM)
+
+	// kill pid to make sure the container status changed
+	_, err = exec.Command("kill", "-9", pid).CombinedOutput()
+	require.NoError(t, err)
+	// if can't update status info status file, containerd won't start.
+	StartContainerdFailed(t)
+	// make status file can  be changed.
+	_, err = exec.Command("chattr", "-i", statusDir).CombinedOutput()
+	require.NoError(t, err)
+	StartContainerd(t)
+	t.Logf("Create the container again should fail")
+	_, err = runtimeService.CreateContainer(sb, cnConfig, sbConfig)
+	require.Error(t, err)
+}

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -802,6 +802,32 @@ func RestartContainerd(t *testing.T, signal syscall.Signal) {
 	}, time.Second, 30*time.Second), "wait for containerd to be restarted")
 }
 
+func StopContainerd(t *testing.T, signal syscall.Signal) {
+	require.NoError(t, KillProcess(*containerdBin, signal))
+
+	// Use assert so that the 3rd wait always runs, this makes sure
+	// containerd is running before this function returns.
+	assert.NoError(t, Eventually(func() (bool, error) {
+		pid, err := PidOf(*containerdBin)
+		if err != nil {
+			return false, err
+		}
+		return pid == 0, nil
+	}, time.Second, 30*time.Second), "wait for containerd to be killed")
+}
+
+func StartContainerd(t *testing.T) {
+	require.NoError(t, Eventually(func() (bool, error) {
+		return ConnectDaemons() == nil, nil
+	}, time.Second, 30*time.Second), "wait for containerd to be restarted")
+}
+
+func StartContainerdFailed(t *testing.T) {
+	require.Error(t, Eventually(func() (bool, error) {
+		return ConnectDaemons() == nil, nil
+	}, time.Second, 30*time.Second), "wait for containerd to be restarted")
+}
+
 // EnsureImageExists pulls the given image, ensures that no error was encountered
 // while pulling it.
 func EnsureImageExists(t *testing.T, imageName string) string {

--- a/internal/cri/store/container/container.go
+++ b/internal/cri/store/container/container.go
@@ -17,6 +17,7 @@
 package container
 
 import (
+	"fmt"
 	"sync"
 
 	containerd "github.com/containerd/containerd/v2/client"
@@ -70,12 +71,20 @@ func WithContainerIO(io *cio.ContainerIO) Opts {
 	}
 }
 
+type StoreStatusError struct {
+	msg string
+}
+
+func (e StoreStatusError) Error() string {
+	return e.msg
+}
+
 // WithStatus adds status to the container.
 func WithStatus(status Status, root string) Opts {
 	return func(c *Container) error {
 		s, err := StoreStatus(root, c.ID, status)
 		if err != nil {
-			return err
+			return StoreStatusError{msg: fmt.Sprintf("store status:%v", err)}
 		}
 		c.Status = s
 		if s.Get().State() == runtime.ContainerState_CONTAINER_EXITED {


### PR DESCRIPTION
try to fix https://github.com/containerd/containerd/issues/7247
 we meet same isue today. because disk is full.
I don't understand why here ignore error.
 @fuweid  @mikebrow 

if err is skipped and k8s may create same name container.