### PR TITLE
Prepare release notes for v1.6.37

### DIFF
--- a/releases/v1.6.37.toml
+++ b/releases/v1.6.37.toml
@@ -1,0 +1,27 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.6.36"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The thirty-seventh patch release for containerd 1.6 contains various fixes
+and updates.
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.36+unknown"
+	Version = "1.6.37+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated notes
----

containerd 1.6.37

Welcome to the v1.6.37 release of containerd!

The thirty-seventh patch release for containerd 1.6 contains various fixes
and updates.

### Highlights

* Update runc binary to v1.2.5 ([#11396](https://github.com/containerd/containerd/pull/11396))
* Fix the race condition during GC of snapshots when client retries ([#10764](https://github.com/containerd/containerd/pull/10764))

#### Container Runtime Interface (CRI)

* Update the container exit log to info level ([#11008](https://github.com/containerd/containerd/pull/11008))
* Handle teardown failure to avoid blocking cleanup ([#10778](https://github.com/containerd/containerd/pull/10778))
* Add check for CNI plugins before tearing down pod network ([#10766](https://github.com/containerd/containerd/pull/10766))

#### Runtime

* Fix console TTY leak in runc shim ([#11359](https://github.com/containerd/containerd/pull/11359))
* Fix panic due to nil dereference cgroups v2 ([#11100](https://github.com/containerd/containerd/pull/11100))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Phil Estes
* Akihiro Suda
* Maksym Pavlenko
* Akhil Mohan
* Austin Vazquez
* Samuel Karp
* Derek McGowan
* Henry Wang
* Jin Dong
* Jing Xu
* Sebastiaan van Stijn
* Wei Fu
* Benjamin Peterson
* Kazuyoshi Kato
* Saket Jajoo
* Sameer
* Zou Nengren
* bo.jiang
* jinda.ljd
* ningmingxiao
* root

### Changes
<details><summary>58 commits</summary>
<p>

  * [`16ba72ad9`](https://github.com/containerd/containerd/commit/16ba72ad97f44da68569409bacea2b63bf04b314) Prepare release notes for v1.6.37
* Fix console TTY leak in runc shim ([#11359](https://github.com/containerd/containerd/pull/11359))
  * [`3e6f219d7`](https://github.com/containerd/containerd/commit/3e6f219d7337db04b9d471c0d3dea22abf083748) Add integ test to check tty leak
  * [`bc20f7457`](https://github.com/containerd/containerd/commit/bc20f74574b55fc6f7540e7ddcf491fa65ac4e0b) fix master tty leak due to leaking init container object
* Update install-imgcrypt to allow change install repo ([#11418](https://github.com/containerd/containerd/pull/11418))
  * [`cbd44298c`](https://github.com/containerd/containerd/commit/cbd44298c1a92ffb31a238a52cc732c408ddd5d5) Update install-imgcrypt to allow change install repo
* Update runc binary to v1.2.5 ([#11396](https://github.com/containerd/containerd/pull/11396))
  * [`9918dc4e3`](https://github.com/containerd/containerd/commit/9918dc4e3a726c3c006f0d6a1bfb037de3176d70) Update runc binary to v1.2.5
* Update vagrant host OS to fix Vagrant CI runs ([#11348](https://github.com/containerd/containerd/pull/11348))
  * [`d92457c71`](https://github.com/containerd/containerd/commit/d92457c71d825faf02ca0c0f58e5971bbd215c82) Remove vagrant scp from the install list
* update runc binary to v1.2.4 ([#11237](https://github.com/containerd/containerd/pull/11237))
  * [`315a23dd9`](https://github.com/containerd/containerd/commit/315a23dd975e3aab1db5391c557ad1415b605220) update runc binary to v1.2.4
* update runc binary to v1.2.3 ([#11144](https://github.com/containerd/containerd/pull/11144))
  * [`79f6df6f4`](https://github.com/containerd/containerd/commit/79f6df6f4ff0c547aaffd51eb693d57679336f66) update runc binary to v1.2.3
* update build to go1.22.10, test go1.23.4 ([#11112](https://github.com/containerd/containerd/pull/11112))
  * [`bf89950f5`](https://github.com/containerd/containerd/commit/bf89950f5fde4d5b22ad50357ba24255b6b47f8b) update build to go1.22.10, test go1.23.4
* Fix panic due to nil dereference cgroups v2 ([#11100](https://github.com/containerd/containerd/pull/11100))
  * [`db096794f`](https://github.com/containerd/containerd/commit/db096794f71ee9729c4cd1fce999c43a25e8e1e3) fix panic due to nil dereference cgroups v2
* Add almalinux/9 in CI ([#11055](https://github.com/containerd/containerd/pull/11055))
  * [`3a0f138b0`](https://github.com/containerd/containerd/commit/3a0f138b044a218c1e1dcdccdc83b275a7951be9) add almalinux/9 in CI
* Update the container exit log to info level ([#11008](https://github.com/containerd/containerd/pull/11008))
  * [`aca1ca440`](https://github.com/containerd/containerd/commit/aca1ca44060500f76804b6378d28a9ba4a648a34) add info of exited event
* update runc binary to 1.2.2 ([#11028](https://github.com/containerd/containerd/pull/11028))
  * [`4eaef56a2`](https://github.com/containerd/containerd/commit/4eaef56a21b12ac7a51daddc1957957fea21c886) update runc binary to 1.2.2
* Revert "Disable vagrant strict dependency checking" ([#11010](https://github.com/containerd/containerd/pull/11010))
  * [`f42035a21`](https://github.com/containerd/containerd/commit/f42035a21318848e7efed49ab227ea8f6b83e8bc) Revert "Disable vagrant strict dependency checking"
* update build to go1.22.9, test go1.23.3 ([#10975](https://github.com/containerd/containerd/pull/10975))
  * [`20958cbb0`](https://github.com/containerd/containerd/commit/20958cbb0fb6237549dff06c1485527d8ef9ea8d) update build to go1.22.9, test go1.23.3
* backport: Disable vagrant strict dependency checking ([#10966](https://github.com/containerd/containerd/pull/10966))
  * [`edb3df5ab`](https://github.com/containerd/containerd/commit/edb3df5ab099bf97fafc3880e207003c072c86f4) Disable vagrant strict dependency checking
* Update critools-version to 1.29 ([#10929](https://github.com/containerd/containerd/pull/10929))
  * [`9eca374a4`](https://github.com/containerd/containerd/commit/9eca374a407732487338b672c726ffdfe779c65a) Update critools-version to 1.29 in release 1.6
* update runc binary to 1.2.1 ([#10941](https://github.com/containerd/containerd/pull/10941))
  * [`6134f736d`](https://github.com/containerd/containerd/commit/6134f736d43ecd997fa4646f3d91f1a40481ad06) update runc binary to 1.2.1
* services/snapshots: include name of snapshotter in debug logs ([#10932](https://github.com/containerd/containerd/pull/10932))
  * [`4e54972f0`](https://github.com/containerd/containerd/commit/4e54972f085e61fc04575f1fd44cad79b033cb27) services/snapshots: include name of snapshotter in debug logs
* Make TestContainerPids more resilient ([#10937](https://github.com/containerd/containerd/pull/10937))
  * [`d7c7a12f3`](https://github.com/containerd/containerd/commit/d7c7a12f36c7f4f89b0f87162e481088c865a267) Make TestContainerPids more resilient
* Add After=dbus.service to containerd.service ([#10860](https://github.com/containerd/containerd/pull/10860))
  * [`e6d8e5e9c`](https://github.com/containerd/containerd/commit/e6d8e5e9c7625ea07dc50025d673004c6d2ee80e) Add After=dbus.service to containerd.service
* Handle teardown failure to avoid blocking cleanup ([#10778](https://github.com/containerd/containerd/pull/10778))
  * [`b1f8b03e7`](https://github.com/containerd/containerd/commit/b1f8b03e7bc9a6e59e0de3cf54fd0d814e5ef79a) Handle teardown failure to avoid blocking cleanup
* Switch from actuated.dev to GH Action runners for arm64 ([#10823](https://github.com/containerd/containerd/pull/10823))
  * [`ba411483a`](https://github.com/containerd/containerd/commit/ba411483a4b523824f9273781a1ad5a84e72ffcc) Switch from actuated.dev to GH Action runners for arm64
  * [`8c58f78c2`](https://github.com/containerd/containerd/commit/8c58f78c2088fe473aa03f184a8a2907e4a44840) Update github actions ci to run on forks
* bump golangci/golangci-lint-action from 4 to 6 ([#10819](https://github.com/containerd/containerd/pull/10819))
  * [`e4211a530`](https://github.com/containerd/containerd/commit/e4211a530c48c08847f75cd84082c738a5879173) bump golangci/golangci-lint-action from 4 to 6
* update to go1.23.2,go1.22.8 ([#10809](https://github.com/containerd/containerd/pull/10809))
  * [`1ca261fe4`](https://github.com/containerd/containerd/commit/1ca261fe466739e27d737d23533c3ae67239eed3) update to go1.23.2,go1.22.8
* Update runner images to macOS13 ([#10784](https://github.com/containerd/containerd/pull/10784))
  * [`1c96f2391`](https://github.com/containerd/containerd/commit/1c96f23918b6d1f76edf0adae94eba1f5a54e19f) Update runner images to macOS13
* Bump crun to 1.16.1 ([#10775](https://github.com/containerd/containerd/pull/10775))
  * [`1ba7381cf`](https://github.com/containerd/containerd/commit/1ba7381cfd7759e27935cc6a03b28985db0f5e3a) Bump crun to 1.16
  * [`afc84d092`](https://github.com/containerd/containerd/commit/afc84d09269254c162c65fdf7cb5b042ec25f610) CI: bump up crun to 1.15
* Fix the race condition during GC of snapshots when client retries ([#10764](https://github.com/containerd/containerd/pull/10764))
  * [`74951d6cf`](https://github.com/containerd/containerd/commit/74951d6cf22eb1f21522229cd8e22b9c4480923d) Fix the race condition during GC of snapshots when client retries
* Add check for CNI plugins before tearing down pod network ([#10766](https://github.com/containerd/containerd/pull/10766))
  * [`ca6516ee8`](https://github.com/containerd/containerd/commit/ca6516ee85cd1f8765b10127c5694bb3fae1dab2) [release/1.6] Add check for CNI plugins before tearing down pod network
</p>
</details>

### Dependency Changes

This release has no dependency changes

Previous release can be found at [v1.6.36](https://github.com/containerd/containerd/releases/tag/v1.6.36)

