### PR TITLE
erofs-snapshotter: protect layer blobs with FS_IMMUTABLE_FL

### DIFF
--- a/docs/snapshotters/erofs.md
+++ b/docs/snapshotters/erofs.md
@@ -28,9 +28,12 @@ on the backing filesystem, it applies OCI layers into EROFS blobs, therefore:
  - Improved image unpacking performance (~14% for WordPress image with the
    latest erofs-utils 1.8.2) due to reduced metadata overhead;
 
- - Full data protection for each snapshot using the S_IMMUTABLE file attribute
-   or fsverity. Currently, fsverity can only protect blob data in the content
-   store;
+ - Full data protection for each snapshot using the FS_IMMUTABLE_FL file
+   attribute and fsverity.  EROFS uses FS_IMMUTABLE_FL and fsverity to protect
+   each EROFS layer blob, ensuring the mounted tree remains immutable.  However,
+   since FS_IMMUTABLE_FL and fsverity protect individual files rather than a
+   sub-filesystem tree, other snapshotter implementations like the overlayfs
+   snapshotter are not quite applicable due to less efficiency at least;
 
  - Parallel unpacking can be supported in a more reliable way (fsync) compared
    to the overlayfs snapshotter (syncfs);


### PR DESCRIPTION
As documented in ioctl_iflags(2):
```
 FS_IMMUTABLE_FL
  The file is immutable: no changes are permitted to the file contents
  or metadata (permissions, timestamps, ownership, link count, and so
  on).  (This restriction applies even to the superuser.)
```

For example, any user cannot delete/move layer blobs when FS_IMMUTABLE_FL is set:
``` sh
 # cd /var/lib/containerd/io.containerd.snapshotter.v1.erofs/snapshots/4
 # mv layer{,1}.erofs
 mv: cannot move 'layer.erofs' to 'layer1.erofs': Operation not permitted
 # rm layer.erofs
 rm: cannot remove 'layer.erofs': Operation not permitted
```

Note that it's a best-effort approach for data loss prevention(e.g. https://github.com/containerd/containerd/issues/10655).  IOWs, just warn out if FS_IMMUTABLE_FL cannot be set anyway (e.g., due to lack of support in the underlying filesystem.)