### PR TITLE
Ignore defunct verifier procs in test

### DIFF
--- a/pkg/imageverifier/bindir/bindir_test.go
+++ b/pkg/imageverifier/bindir/bindir_test.go
@@ -367,8 +367,13 @@ func TestBinDirVerifyImage(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if strings.Contains(string(b), "verifier-") {
-			t.Fatalf("killing the verifier binary didn't kill all its children:\n%v", string(b))
+		lines := strings.Split(string(b), "\n")
+		for _, l := range lines {
+			// Ignore defunct (zombie) verifier processes if PID 1 hasn't reaped them.
+			// TODO: Remove defunct check once containerd serves as subreaper for verifier processes.
+			if strings.Contains(l, "verifier-") && !strings.Contains(l, "<defunct>") {
+				t.Fatalf("killing the verifier binary didn't kill all its children:\n%v", string(b))
+			}
 		}
 	})
 


### PR DESCRIPTION
Fixes https://github.com/containerd/containerd/issues/11417

This test produces zombies when PID 1 does not properly reap child processes. Modifies the test to ignore these processes in the meantime.

@samuelkarp @lalitc375