### PR TITLE
Prefer runtime options for PluginInfo request

### DIFF
--- a/core/runtime/v2/task_manager.go
+++ b/core/runtime/v2/task_manager.go
@@ -266,12 +266,12 @@ func (m *TaskManager) validateRuntimeFeatures(ctx context.Context, opts runtime.
 		return nil
 	}
 
-	topts := opts.TaskOptions
-	if topts == nil || topts.GetValue() == nil {
-		topts = opts.RuntimeOptions
+	ropts := opts.RuntimeOptions
+	if ropts == nil || ropts.GetValue() == nil {
+		ropts = opts.TaskOptions
 	}
 
-	pInfo, err := m.PluginInfo(ctx, &apitypes.RuntimeRequest{RuntimePath: opts.Runtime, Options: typeurl.MarshalProto(topts)})
+	pInfo, err := m.PluginInfo(ctx, &apitypes.RuntimeRequest{RuntimePath: opts.Runtime, Options: typeurl.MarshalProto(ropts)})
 	if err != nil {
 		return fmt.Errorf("runtime info: %w", err)
 	}


### PR DESCRIPTION
Previously, PluginInfo was called with task options as the primary value, resulting in opts.BinaryName being omitted. Consequently, the containerd-shim-runc-v2 fell back to the system's runc binary in the PATH rather than the explicitly specified one. This change inverts the option fallback by preferring runtime options over task options, ensuring the correct binary is used for the PluginInfo request.

At Netflix, we maintain runc in both /usr/bin (which lacks support for user namespaces) and at a custom path. This issue surfaced when enabling user namespaces and encountering the error:

    Error: failed to create containerd task: failed to validate OCI runtime
           features: idmap mounts not supported: missing `mountExtensions.idmap`
           entry in the `features` command

Although the `features` command for runc at our custom path confirmed that mountExtensions.idmap was enabled, the issue arose because opts.BinaryName was blank in the shim code (see:
https://github.com/containerd/containerd/blob/main/cmd/containerd-shim-runc-v2/manager/manager_linux.go#L345), triggering a fallback to the default runc binary at /usr/bin.

Closes: https://github.com/containerd/containerd/issues/11169