### PR TITLE
[release/2.0] Prepare release notes for v2.0.3

### DIFF
--- a/releases/v2.0.3.toml
+++ b/releases/v2.0.3.toml
@@ -1,0 +1,27 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+ignore_deps = [ "github.com/containerd/containerd" ]
+
+# previous release
+previous = "v2.0.2"
+
+pre_release = false
+
+preface = """\
+The third patch release for containerd 2.0 includes various bug fixes and updates.
+"""
+
+postface = """\
+### Which file should I download?
+* `containerd-<VERSION>-<OS>-<ARCH>.tar.gz`:         ✅Recommended. Dynamically linked with glibc 2.31 (Ubuntu 20.04).
+* `containerd-static-<VERSION>-<OS>-<ARCH>.tar.gz`:  Statically linked. Expected to be used on non-glibc Linux distributions. Not position-independent.
+
+In addition to containerd, typically you will have to install [runc](https://github.com/opencontainers/runc/releases)
+and [CNI plugins](https://github.com/containernetworking/plugins/releases) from their official sites too.
+
+See also the [Getting Started](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) documentation.
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd/v2"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "2.0.2+unknown"
+	Version = "2.0.3+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated notes

----

containerd 2.0.3

Welcome to the v2.0.3 release of containerd!

The third patch release for containerd 2.0 includes various bug fixes and updates.

### Highlights

* Update remote content to break up writes to avoid grpc message size limits ([#11457](https://github.com/containerd/containerd/pull/11457))
* Update runc binary to v1.2.5 ([#11394](https://github.com/containerd/containerd/pull/11394))

#### Container Runtime Interface (CRI)

* Fix privileged container sysfs can't be rw because pod is ro by default ([#11456](https://github.com/containerd/containerd/pull/11456))
* Fix recursive RLock() mutex acquisition ([containerd/go-cni#126](https://github.com/containerd/go-cni/pull/126))

#### Node Resource Interface (NRI)

* Fix initial sync race when registering NRI plugins ([#11329](https://github.com/containerd/containerd/pull/11329))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Akihiro Suda
* Derek McGowan
* Mike Brown
* Phil Estes
* Akhil Mohan
* Chifeng Cai
* Krisztian Litkey
* Wei Fu
* Andrey Smirnov
* Austin Vazquez
* Chris Henzie
* Jing Xu
* Jonathan A. Sternberg
* Jose Fernandez
* Kirtana Ashok
* Lei Liu
* Maksym Pavlenko
* Michael Zappa
* Samuel Karp
* fengwei0328
* zounengren

### Changes
<details><summary>41 commits</summary>
<p>

  * [`a34e218fb`](https://github.com/containerd/containerd/commit/a34e218fb51197e875e10f9a7d502992ad5d5a70) Prepare release notes for v2.0.3
* Update remote content to break up writes to avoid grpc message size limits ([#11457](https://github.com/containerd/containerd/pull/11457))
  * [`eaa7ca80d`](https://github.com/containerd/containerd/commit/eaa7ca80dcc1ea3e3dffe1382d96d77377720c30) proxy: break up writes from the remote writer to avoid grpc limits
* Fix privileged container sysfs can't be rw because pod is ro by default ([#11456](https://github.com/containerd/containerd/pull/11456))
  * [`c7f64196f`](https://github.com/containerd/containerd/commit/c7f64196fcbc792fd9383eb9aa8d43be0f9fa748) Fix privileged container sysfs can't be rw because pod is ro by default
* go.{mod,sum}: bump CDI deps to v.0.8.1. ([#11430](https://github.com/containerd/containerd/pull/11430))
  * [`92ae2951f`](https://github.com/containerd/containerd/commit/92ae2951ffd92e39a38aba2ab48b31a6cb49138e) Update CDI dependency to v0.8.1.
* Prefer runtime options for PluginInfo request ([#11446](https://github.com/containerd/containerd/pull/11446))
  * [`569af34cb`](https://github.com/containerd/containerd/commit/569af34cbb761f0507546457ffe376f4454c87ea) Prefer runtime options for PluginInfo request
* pkg: prevent oom watcher from depending on shim pkg ([#11439](https://github.com/containerd/containerd/pull/11439))
  * [`0ce93e16a`](https://github.com/containerd/containerd/commit/0ce93e16a9fd91c03a67150a6098d09f5258c300) prevent oom watcher depend on shim pkg.
* CI: arm64-8core-32gb -> ubuntu-24.04-arm ([#11436](https://github.com/containerd/containerd/pull/11436))
  * [`f3284aa68`](https://github.com/containerd/containerd/commit/f3284aa68f864f2303b42546b14f7af15eccd063) CI: arm64-8core-32gb -> ubuntu-24.04-arm
* Revert "Add timestamp to PodSandboxStatusResponse for kubernetes Evented PLEG" ([#11403](https://github.com/containerd/containerd/pull/11403))
  * [`b5313993c`](https://github.com/containerd/containerd/commit/b5313993c16f8ae9d4a053162a75bacced36e246) Revert "Add timestamp to PodSandboxStatusResponse for kubernetes Evented PLEG"
* move the device after the options when using mkfs.ext4 ([#11411](https://github.com/containerd/containerd/pull/11411))
  * [`f95a426b8`](https://github.com/containerd/containerd/commit/f95a426b83ec716feaab0a436d5e2280dc4e9d99) move the device after the options when using mkfs.ext4
* update build to go1.23.6, test go1.24.0 ([#11410](https://github.com/containerd/containerd/pull/11410))
  * [`4d19a6adf`](https://github.com/containerd/containerd/commit/4d19a6adfec9440d0806a1cc4633deaef3e5d53c) update build to go1.23.6, test go1.24.0
* build(deps): bump actions/cache from 4.1.2 to 4.2.0 ([#11405](https://github.com/containerd/containerd/pull/11405))
  * [`c738c3aab`](https://github.com/containerd/containerd/commit/c738c3aabc350ae67c5200de4c504c5038834e91) build(deps): bump actions/cache from 4.1.2 to 4.2.0
* Upgrade x/net to 0.33.0 to fix vulnerability GHSA-w32m-9786-jp63 ([#11387](https://github.com/containerd/containerd/pull/11387))
  * [`fcf64305c`](https://github.com/containerd/containerd/commit/fcf64305cef019c8bf135d7373e2b658e02019b3) Update vendor files to fix build failure
  * [`d3437eb29`](https://github.com/containerd/containerd/commit/d3437eb2918f6e266e97c5ee08737926519dc40d) Upgrade x/net to 0.33.0
* Update install-imgcrypt to allow change install repo ([#11357](https://github.com/containerd/containerd/pull/11357))
  * [`0785bd8cc`](https://github.com/containerd/containerd/commit/0785bd8cc6405b346a81025c983365825910e77f) Update install-imgcrypt to allow change install repo
* Update runc binary to v1.2.5 ([#11394](https://github.com/containerd/containerd/pull/11394))
  * [`697c59c63`](https://github.com/containerd/containerd/commit/697c59c63568a8d722e958e68ef52bbb25160b63) Update runc binary to v1.2.5
* Update go-cni version to fix Race Condition issue ([#11269](https://github.com/containerd/containerd/pull/11269))
  * [`06891f899`](https://github.com/containerd/containerd/commit/06891f899d25de9dd1cb5e5443ec099e17a57e00) fix go-cni race condition
* Fix initial sync race when registering NRI plugins ([#11329](https://github.com/containerd/containerd/pull/11329))
  * [`79cdbf61b`](https://github.com/containerd/containerd/commit/79cdbf61b6f7e4be2feb1bb2d631bdb1b9c5cd7f) cri,nri: block NRI plugin sync. during event processing.
* Update github.com/containerd/imgcrypt to v2.0.0 ([#11325](https://github.com/containerd/containerd/pull/11325))
  * [`9d5cfce83`](https://github.com/containerd/containerd/commit/9d5cfce833cf7dc98319390ce002bd4f6a20d423) Update github.com/containerd/imgcrypt to v2.0.0
* Move CDI device spec out of the OCI package ([#11265](https://github.com/containerd/containerd/pull/11265))
  * [`f58939c33`](https://github.com/containerd/containerd/commit/f58939c33d5777c3c813927831bc260cd94baf57) Remove deprecated WithCDIDevices in oci spec opts
  * [`3d53430fe`](https://github.com/containerd/containerd/commit/3d53430fe14eb76849a6c997d60b21a9f95c19ed) Move CDI device spec out of the OCI package
* update to go1.23.5 / go1.22.11 ([#11297](https://github.com/containerd/containerd/pull/11297))
  * [`1f4e5688e`](https://github.com/containerd/containerd/commit/1f4e5688efd71cb9db26158ed697d27ba26dd6b3) update to go1.23.5 / go1.22.11
* build(deps): bump google.golang.org/protobuf from 1.35.1 to 1.35.2 ([#11263](https://github.com/containerd/containerd/pull/11263))
  * [`3a6ab80d0`](https://github.com/containerd/containerd/commit/3a6ab80d0176e205bd9f6a958450f9dce4415091) build(deps): bump google.golang.org/protobuf from 1.35.1 to 1.35.2
</p>
</details>

### Changes from containerd/go-cni
<details><summary>2 commits</summary>
<p>

* Fix recursive RLock() mutex acquisition ([containerd/go-cni#126](https://github.com/containerd/go-cni/pull/126))
  * [`75a2440`](https://github.com/containerd/go-cni/commit/75a24409e8193fc64b0e9ed777ff884c338a21ca) fix: recursive RLock() mutex acquision
</p>
</details>

### Dependency Changes

* **github.com/containerd/go-cni**             v1.1.11 -> v1.1.12
* **github.com/containerd/imgcrypt/v2**        v2.0.0-rc.1 -> v2.0.0
* **github.com/containers/ocicrypt**           v1.2.0 -> v1.2.1
* **github.com/petermattis/goid**              4fcff4a6cae7 **_new_**
* **github.com/sasha-s/go-deadlock**           v0.3.5 **_new_**
* **github.com/smallstep/pkcs7**               v0.1.1 **_new_**
* **golang.org/x/crypto**                      v0.28.0 -> v0.31.0
* **golang.org/x/net**                         v0.30.0 -> v0.33.0
* **golang.org/x/oauth2**                      v0.22.0 -> v0.23.0
* **golang.org/x/sync**                        v0.8.0 -> v0.10.0
* **golang.org/x/sys**                         v0.26.0 -> v0.28.0
* **golang.org/x/term**                        v0.25.0 -> v0.27.0
* **golang.org/x/text**                        v0.19.0 -> v0.21.0
* **google.golang.org/grpc**                   v1.67.1 -> v1.68.1
* **google.golang.org/protobuf**               v1.35.1 -> v1.35.2
* **tags.cncf.io/container-device-interface**  v0.8.0 -> v0.8.1

Previous release can be found at [v2.0.2](https://github.com/containerd/containerd/releases/tag/v2.0.2)
### Which file should I download?
* `containerd-<VERSION>-<OS>-<ARCH>.tar.gz`:         ✅Recommended. Dynamically linked with glibc 2.31 (Ubuntu 20.04).
* `containerd-static-<VERSION>-<OS>-<ARCH>.tar.gz`:  Statically linked. Expected to be used on non-glibc Linux distributions. Not position-independent.

In addition to containerd, typically you will have to install [runc](https://github.com/opencontainers/runc/releases)
and [CNI plugins](https://github.com/containernetworking/plugins/releases) from their official sites too.

See also the [Getting Started](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) documentation.


