### PR TITLE
doc: Fix ctr command at user-namespaces docs

### DIFF
--- a/docs/user-namespaces/README.md
+++ b/docs/user-namespaces/README.md
@@ -169,7 +169,7 @@ absolute path to the rootfs you just chowned.
 Then create and start the container with:
 
 ```
-sudo ctr create --config <path>/config.json userns-test
+sudo ctr run --config <path>/config.json userns-test
 sudo ctr t start userns-test
 ```
 

--- a/docs/user-namespaces/config.json
+++ b/docs/user-namespaces/config.json
@@ -7,7 +7,7 @@
 			"gid": 0
 		},
 		"args": [
-			"bash"
+			"sh"
 		],
 		"env": [
 			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",


### PR DESCRIPTION
* Replaced the deprecated `ctr create` command with `ctr run` in the documentation.
* Updated `config.json` to use `sh` instead of `bash` for container startup, as `bash` was unavailable in the container.

Here my results:
```bash
user@host:/mycontainer$ sudo ctr run --config /mycontainer/config.json userns-test
user@host:/mycontainer$ sudo ctr containers list
CONTAINER      IMAGE    RUNTIME
userns-test    -        io.containerd.runc.v2 user@host:/mycontainer$ sudo ctr task start userns-test

/ # cat /proc/self/uid_map
         0      65536      65536
```

Let me know if that works!