### PR TITLE
ignore update status file when no space

### DIFF
--- a/integration/issue7247_linux_test.go
+++ b/integration/issue7247_linux_test.go
@@ -1,0 +1,139 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/v2/integration/images"
+	"github.com/containerd/containerd/v2/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+// As described in issue 7247, when the disk is full, restarting containerd will result in inconsistent data between cri and metadata.
+// This e2e is ensuring data consistency even if the disk is full.
+func TestIssue7247(t *testing.T) {
+	var (
+		busyboxImage = images.Get(images.BusyBox)
+		pauseImage   = images.Get(images.Pause)
+		err          error
+	)
+	testutil.RequiresRoot(t)
+
+	workDir, err := prepareWorkDir(t, 1<<30) //1GB
+	require.NoError(t, err)
+
+	newContainerdProc := newCtrdProc(t, "containerd", workDir.Dir(), nil)
+	require.NoError(t, newContainerdProc.isReady())
+
+	t.Cleanup(func() {
+		t.Log("Cleanup all the pods")
+		cleanupPods(t, newContainerdProc.criRuntimeService(t))
+
+		t.Log("Stopping current release's containerd process")
+		require.NoError(t, newContainerdProc.kill(syscall.SIGTERM))
+		require.NoError(t, newContainerdProc.wait(5*time.Minute))
+
+		t.Log("Unmount workdir and remove")
+		workDir.Close()
+	})
+
+	_, err = newContainerdProc.criImageService(t).PullImage(&runtime.ImageSpec{Image: busyboxImage}, nil, nil, "")
+	require.NoError(t, err)
+	_, err = newContainerdProc.criImageService(t).PullImage(&runtime.ImageSpec{Image: pauseImage}, nil, nil, "")
+	require.NoError(t, err)
+
+	// Create a sandbox
+	sbConfig := PodSandboxConfig("sandbox", "sandbox")
+	sbID, err := newContainerdProc.criRuntimeService(t).RunPodSandbox(sbConfig, *runtimeHandler)
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, runtimeService.StopPodSandbox(sbID))
+		assert.NoError(t, runtimeService.RemovePodSandbox(sbID))
+	}()
+	stateIDs := map[runtime.ContainerState]string{}
+	for _, cnt := range []struct {
+		name        string
+		commands    []string
+		execs       [][]string
+		expectState runtime.ContainerState
+	}{
+		{
+			name:        "created",
+			expectState: runtime.ContainerState_CONTAINER_CREATED,
+		},
+		{
+			name:        "exited",
+			commands:    []string{"-c", "echo", "exited"},
+			expectState: runtime.ContainerState_CONTAINER_EXITED,
+		},
+		{
+			name:     "running",
+			commands: []string{"-c", "sleep", "1d"},
+			execs: [][]string{
+				{"dd", "if=/dev/zero", "of=/1g", "bs=1M", "count=1024"},
+				{"dd", "if=/dev/zero", "of=/1m", "bs=1k", "count=1024"},
+			},
+			expectState: runtime.ContainerState_CONTAINER_RUNNING,
+		},
+	} {
+		containerConfig := ContainerConfig(cnt.name, busyboxImage,
+			WithCommand("/bin/sh", cnt.commands...),
+		)
+		// Create the container
+		containerID, err := newContainerdProc.criRuntimeService(t).CreateContainer(sbID, containerConfig, sbConfig)
+		assert.NoError(t, err)
+		if cnt.expectState != runtime.ContainerState_CONTAINER_CREATED {
+			// Start the container
+			err = newContainerdProc.criRuntimeService(t).StartContainer(containerID)
+			assert.NoError(t, err)
+			if len(cnt.execs) > 0 {
+				for _, exec := range cnt.execs {
+					newContainerdProc.criRuntimeService(t).ExecSync(containerID, exec, 60*time.Second)
+				}
+			}
+		}
+		stateIDs[cnt.expectState] = containerID
+	}
+	defer func() {
+		for state, id := range stateIDs {
+			if state != runtime.ContainerState_CONTAINER_CREATED {
+				// Stop the container
+				err = newContainerdProc.criRuntimeService(t).StopContainer(id, 10)
+				assert.NoError(t, err)
+			}
+			// Remove the container
+			err = newContainerdProc.criRuntimeService(t).RemoveContainer(id)
+			assert.NoError(t, err)
+		}
+	}()
+	// Restart containerd
+	err = newContainerdProc.restart(t)
+	assert.NoError(t, err)
+
+	// Check if the container state is correct
+	containers, err := newContainerdProc.criRuntimeService(t).ListContainers(&runtime.ContainerFilter{})
+	assert.NoError(t, err)
+	assert.Equal(t, len(stateIDs), len(containers))
+	for _, cnt := range containers {
+		assert.Equal(t, stateIDs[cnt.State], cnt.Id)
+	}
+}

--- a/integration/release_upgrade_linux_test.go
+++ b/integration/release_upgrade_linux_test.go
@@ -668,8 +668,35 @@ func (p *ctrdProc) criImageService(t *testing.T) cri.ImageManagerService {
 
 // newCtrdProc is to start containerd process.
 func newCtrdProc(t *testing.T, ctrdBin string, ctrdWorkDir string, envs []string) *ctrdProc {
-	p := &ctrdProc{workDir: ctrdWorkDir}
+	p := &ctrdProc{
+		workDir: ctrdWorkDir,
+		ctrdBin: ctrdBin,
+		envs:    envs,
+	}
 
+	p.start(t)
+	return p
+}
+
+// ctrdProc is used to control the containerd process's lifecycle.
+type ctrdProc struct {
+	// containerd binary name
+	ctrdBin string
+
+	envs []string
+	// workDir has the following layout:
+	//
+	// - root  (dir)
+	// - state (dir)
+	// - containerd.sock (sock file)
+	// - config.toml (toml file, required)
+	// - containerd.log (log file, always open with O_APPEND)
+	workDir   string
+	cmd       *exec.Cmd
+	waitBlock chan struct{}
+}
+
+func (p *ctrdProc) start(t *testing.T) error {
 	var args []string
 	args = append(args, "--root", p.rootPath())
 	args = append(args, "--state", p.statePath())
@@ -681,8 +708,8 @@ func newCtrdProc(t *testing.T, ctrdBin string, ctrdWorkDir string, envs []string
 	require.NoError(t, err, "open log file %s", p.logPath())
 	t.Cleanup(func() { f.Close() })
 
-	cmd := exec.Command(ctrdBin, args...)
-	cmd.Env = append(os.Environ(), envs...)
+	cmd := exec.Command(p.ctrdBin, args...)
+	cmd.Env = append(os.Environ(), p.envs...)
 	cmd.Stdout = f
 	cmd.Stderr = f
 	cmd.SysProcAttr = &syscall.SysProcAttr{Pdeathsig: syscall.SIGKILL}
@@ -699,24 +726,10 @@ func newCtrdProc(t *testing.T, ctrdBin string, ctrdWorkDir string, envs []string
 
 		defer close(p.waitBlock)
 
-		require.NoError(t, p.cmd.Start(), "start containerd(%s)", ctrdBin)
+		require.NoError(t, p.cmd.Start(), "start containerd(%s)", p.ctrdBin)
 		assert.NoError(t, p.cmd.Wait())
 	}()
-	return p
-}
-
-// ctrdProc is used to control the containerd process's lifecycle.
-type ctrdProc struct {
-	// workDir has the following layout:
-	//
-	// - root  (dir)
-	// - state (dir)
-	// - containerd.sock (sock file)
-	// - config.toml (toml file, required)
-	// - containerd.log (log file, always open with O_APPEND)
-	workDir   string
-	cmd       *exec.Cmd
-	waitBlock chan struct{}
+	return nil
 }
 
 // kill is to send the signal to containerd process.
@@ -796,6 +809,19 @@ func (p *ctrdProc) isReady() error {
 			return fmt.Errorf("context deadline exceeded: %w", err)
 		}
 	}
+}
+
+// restart containerd rerun.
+func (p *ctrdProc) restart(t *testing.T) error {
+	err := p.kill(syscall.SIGTERM)
+	if err != nil {
+		return err
+	}
+	err = p.wait(5 * time.Minute)
+	if err != nil {
+		return err
+	}
+	return p.start(t)
 }
 
 // dumpFileContent dumps file content into t.Log.

--- a/integration/tempdir_linux_test.go
+++ b/integration/tempdir_linux_test.go
@@ -1,0 +1,74 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/containerd/continuity/testutil/loopback"
+)
+
+type workDir struct {
+	loopFile *loopback.Loopback
+	mntDir   string
+}
+
+// prepareWorkDir creates a loop device, formats it, and mounts it to a temporary directory.
+// sizeMB specifies the size of the loop device in megabytes.
+func prepareWorkDir(t *testing.T, bytezise int64) (*workDir, error) {
+	loop, err := loopback.New(bytezise)
+	if err != nil {
+		return nil, fmt.Errorf("could not create loop device: %v", err)
+	}
+
+	if out, err := exec.Command("mkfs.xfs", "-m", "crc=0", "-n", "ftype=1", loop.Device).CombinedOutput(); err != nil {
+		// not fatal
+		loop.Close()
+		return nil, fmt.Errorf("could not mkfs %s: %v (out: %q)", loop.Device, err, string(out))
+	}
+	mntDir := t.TempDir()
+
+	if out, err := exec.Command("mount", loop.Device, mntDir).CombinedOutput(); err != nil {
+		// not fatal
+		loop.Close()
+		os.RemoveAll(mntDir)
+		return nil, fmt.Errorf("could not mount %s: %v (out: %q)", loop.Device, err, string(out))
+	}
+
+	return &workDir{
+		loopFile: loop,
+		mntDir:   mntDir,
+	}, nil
+}
+
+// Dir returns the path to the mounted temporary directory.
+func (wd *workDir) Dir() string {
+	return wd.mntDir
+}
+
+// Close unmounts the loop device and deletes the loop file and mount directory.
+func (wd *workDir) Close() error {
+	// Unmount the mount point.
+	umountCmd := exec.Command("umount", wd.mntDir)
+	if err := umountCmd.Run(); err != nil {
+		return fmt.Errorf("umount command failed: %w", err)
+	}
+	return wd.loopFile.Close()
+}


### PR DESCRIPTION
Fix #7247 

Failed to start recovre, the root cause is inconsistent data between `cri` and `container in metadata`

Ensure consistency, the following manual recovery could be resolve.

```
  - stop containerd service, like `systemctl stop containerd`
  - disable cri plugin in config.toml and start containerd service
  - find container and task which reversed, and stop task, delete container to release disk, which most like 
    - `ctr -n k8s.io t stop [id]`
    - `ctr -n k8s.io c rm [id]`
  - enable cri plugin in config.toml
  - restart containerd service, `systemctl restart containerd`

```

As described in [here](https://github.com/containerd/containerd/issues/11504), ignoring noSpace error is a more convenient way to handle such issues 
