### PR TITLE
Update runtime-spec to v1.2.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/moby/sys/userns v0.1.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
-	github.com/opencontainers/runtime-spec v1.2.0
+	github.com/opencontainers/runtime-spec v1.2.1
 	github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626
 	github.com/opencontainers/selinux v1.11.1
 	github.com/pelletier/go-toml/v2 v2.2.3

--- a/go.sum
+++ b/go.sum
@@ -258,8 +258,8 @@ github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3I
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/opencontainers/runtime-spec v1.0.3-0.20220825212826-86290f6a00fb/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
-github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE7dzrbT927iTk=
-github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
+github.com/opencontainers/runtime-spec v1.2.1 h1:S4k4ryNgEpxW1dzyqffOmhI1BHYcjzU8lpJfSlR0xww=
+github.com/opencontainers/runtime-spec v1.2.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626 h1:DmNGcqH3WDbV5k8OJ+esPWbqUOX5rMLR2PMvziDMJi0=
 github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626/go.mod h1:BRHJJd0E+cx42OybVYSgUvZmU0B8P9gZuRXlZUP7TKI=
 github.com/opencontainers/selinux v1.9.1/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
@@ -83,7 +83,7 @@ type Process struct {
 	// Rlimits specifies rlimit options to apply to the process.
 	Rlimits []POSIXRlimit `json:"rlimits,omitempty" platform:"linux,solaris,zos"`
 	// NoNewPrivileges controls whether additional privileges could be gained by processes in the container.
-	NoNewPrivileges bool `json:"noNewPrivileges,omitempty" platform:"linux"`
+	NoNewPrivileges bool `json:"noNewPrivileges,omitempty" platform:"linux,zos"`
 	// ApparmorProfile specifies the apparmor profile for the container.
 	ApparmorProfile string `json:"apparmorProfile,omitempty" platform:"linux"`
 	// Specify an oom_score_adj for the container.
@@ -94,10 +94,12 @@ type Process struct {
 	SelinuxLabel string `json:"selinuxLabel,omitempty" platform:"linux"`
 	// IOPriority contains the I/O priority settings for the cgroup.
 	IOPriority *LinuxIOPriority `json:"ioPriority,omitempty" platform:"linux"`
+	// ExecCPUAffinity specifies CPU affinity for exec processes.
+	ExecCPUAffinity *CPUAffinity `json:"execCPUAffinity,omitempty" platform:"linux"`
 }
 
 // LinuxCapabilities specifies the list of allowed capabilities that are kept for a process.
-// http://man7.org/linux/man-pages/man7/capabilities.7.html
+// https://man7.org/linux/man-pages/man7/capabilities.7.html
 type LinuxCapabilities struct {
 	// Bounding is the set of capabilities checked by the kernel.
 	Bounding []string `json:"bounding,omitempty" platform:"linux"`
@@ -126,6 +128,12 @@ const (
 	IOPRIO_CLASS_BE   IOPriorityClass = "IOPRIO_CLASS_BE"
 	IOPRIO_CLASS_IDLE IOPriorityClass = "IOPRIO_CLASS_IDLE"
 )
+
+// CPUAffinity specifies process' CPU affinity.
+type CPUAffinity struct {
+	Initial string `json:"initial,omitempty"`
+	Final   string `json:"final,omitempty"`
+}
 
 // Box specifies dimensions of a rectangle. Used for specifying the size of a console.
 type Box struct {
@@ -627,6 +635,17 @@ type WindowsCPUResources struct {
 	// cycles per 10,000 cycles. Set processor `maximum` to a percentage times
 	// 100.
 	Maximum *uint16 `json:"maximum,omitempty"`
+	// Set of CPUs to affinitize for this container.
+	Affinity []WindowsCPUGroupAffinity `json:"affinity,omitempty"`
+}
+
+// Similar to _GROUP_AFFINITY struct defined in
+// https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/miniport/ns-miniport-_group_affinity
+type WindowsCPUGroupAffinity struct {
+	// CPU mask relative to this CPU group.
+	Mask uint64 `json:"mask,omitempty"`
+	// Processor group the mask refers to, as returned by GetLogicalProcessorInformationEx.
+	Group uint32 `json:"group,omitempty"`
 }
 
 // WindowsStorageResources contains storage resource management settings.
@@ -751,6 +770,10 @@ const (
 	ArchPARISC      Arch = "SCMP_ARCH_PARISC"
 	ArchPARISC64    Arch = "SCMP_ARCH_PARISC64"
 	ArchRISCV64     Arch = "SCMP_ARCH_RISCV64"
+	ArchLOONGARCH64 Arch = "SCMP_ARCH_LOONGARCH64"
+	ArchM68K        Arch = "SCMP_ARCH_M68K"
+	ArchSH          Arch = "SCMP_ARCH_SH"
+	ArchSHEB        Arch = "SCMP_ARCH_SHEB"
 )
 
 // LinuxSeccompAction taken upon Seccomp rule match
@@ -826,27 +849,32 @@ type LinuxIntelRdt struct {
 
 // ZOS contains platform-specific configuration for z/OS based containers.
 type ZOS struct {
-	// Devices are a list of device nodes that are created for the container
-	Devices []ZOSDevice `json:"devices,omitempty"`
+	// Namespaces contains the namespaces that are created and/or joined by the container
+	Namespaces []ZOSNamespace `json:"namespaces,omitempty"`
 }
 
-// ZOSDevice represents the mknod information for a z/OS special device file
-type ZOSDevice struct {
-	// Path to the device.
-	Path string `json:"path"`
-	// Device type, block, char, etc.
-	Type string `json:"type"`
-	// Major is the device's major number.
-	Major int64 `json:"major"`
-	// Minor is the device's minor number.
-	Minor int64 `json:"minor"`
-	// FileMode permission bits for the device.
-	FileMode *os.FileMode `json:"fileMode,omitempty"`
-	// UID of the device.
-	UID *uint32 `json:"uid,omitempty"`
-	// Gid of the device.
-	GID *uint32 `json:"gid,omitempty"`
+// ZOSNamespace is the configuration for a z/OS namespace
+type ZOSNamespace struct {
+	// Type is the type of namespace
+	Type ZOSNamespaceType `json:"type"`
+	// Path is a path to an existing namespace persisted on disk that can be joined
+	// and is of the same type
+	Path string `json:"path,omitempty"`
 }
+
+// ZOSNamespaceType is one of the z/OS namespaces
+type ZOSNamespaceType string
+
+const (
+	// PIDNamespace for isolating process IDs
+	ZOSPIDNamespace ZOSNamespaceType = "pid"
+	// MountNamespace for isolating mount points
+	ZOSMountNamespace ZOSNamespaceType = "mount"
+	// IPCNamespace for isolating System V IPC, POSIX message queues
+	ZOSIPCNamespace ZOSNamespaceType = "ipc"
+	// UTSNamespace for isolating hostname and NIS domain name
+	ZOSUTSNamespace ZOSNamespaceType = "uts"
+)
 
 // LinuxSchedulerPolicy represents different scheduling policies used with the Linux Scheduler
 type LinuxSchedulerPolicy string

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
@@ -8,7 +8,7 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 2
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 0
+	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
 	VersionDev = ""

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -402,7 +402,7 @@ github.com/opencontainers/go-digest/digestset
 github.com/opencontainers/image-spec/identity
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
-# github.com/opencontainers/runtime-spec v1.2.0
+# github.com/opencontainers/runtime-spec v1.2.1
 ## explicit
 github.com/opencontainers/runtime-spec/specs-go
 github.com/opencontainers/runtime-spec/specs-go/features


### PR DESCRIPTION
Update runtime-spec to v1.2.1

Full changelist can be found here: https://github.com/opencontainers/runtime-spec/compare/v1.2.0...v1.2.1