### PR TITLE
fix: call checkCopyShimLogError(shimCtx) to avoid expected error log flood

### DIFF
--- a/core/runtime/v2/shim.go
+++ b/core/runtime/v2/shim.go
@@ -91,9 +91,9 @@ func loadShim(ctx context.Context, bundle *Bundle, onClose func()) (_ ShimInstan
 		// To prevent flood of error messages, the expected error
 		// should be reset, like os.ErrClosed or os.ErrNotExist, which
 		// depends on platform.
-		err = checkCopyShimLogError(ctx, err)
+		err = checkCopyShimLogError(shimCtx, err)
 		if err != nil {
-			log.G(ctx).WithError(err).Error("copy shim log after reload")
+			log.G(shimCtx).WithError(err).Error("copy shim log after reload")
 		}
 	}()
 	onCloseWithShimLog := func() {


### PR DESCRIPTION
When containerd restarts and the shim connection is successfully restored, but stopping the container at this time will result in an error log due to using the wrong context

## reproduce

1 start pod 

```
crictl runp [pod.json]
crictl create [sandboxid] [container.json] [pod.json]
crictl start [containerid]
```

2 restart containerd.

3 stop pod by `crictl stop [containerid]

containerd log:

```
...
ERRO[2025-03-04T16:03:02.137448237+08:00] copy shim log after reload                    error="read /proc/self/fd/10: file already closed" namespace=k8s.io
...
```

Introduced by https://github.com/containerd/containerd/pull/5174
