### PR TITLE
erofs-snapshotter: two bug-fixes

### DIFF
--- a/docs/snapshotters/erofs.md
+++ b/docs/snapshotters/erofs.md
@@ -64,20 +64,22 @@ io.containerd.snapshotter.v1           erofs                    linux/amd64    o
 io.containerd.differ.v1                erofs                    linux/amd64    ok
 ```
 
-### Ensure that EROFS is available
+### Ensure that EROFS filesystem is available
 
-On newer Ubuntu/Debian systems, it can be installed directly using the apt
-command, and on Fedora it can be installed directly using the dnf command.
+On newer Ubuntu/Debian systems, erofs-utils can be installed directly using the
+apt command, and on Fedora it can be installed directly using the dnf command.
 
+```bash
 # Debian/Ubuntu
 $ apt install erofs-utils
 # Fedora
 $ dnf install erofs-utils
+```
 
 Make sure that erofs-utils version is 1.7 or higher.
 
 Before using EROFS snapshotter, also make sure the _EROFS kernel module_ is
-loaded: it can be loaded with `modprobe erofs`.
+loaded (Linux 5.4 or later is required): it can be loaded with `modprobe erofs`.
 
 ### Configuration
 

--- a/plugins/snapshots/erofs/erofs_linux.go
+++ b/plugins/snapshots/erofs/erofs_linux.go
@@ -247,6 +247,8 @@ func (s *snapshotter) mounts(snap storage.Snapshot, info snapshots.Info) ([]moun
 		if err != nil {
 			return nil, err
 		}
+		// We have to force a loop device here too since mount[] is static.
+		m.Options = append(m.Options, "loop")
 		return []mount.Mount{m}, nil
 	}
 

--- a/plugins/snapshots/erofs/erofs_linux.go
+++ b/plugins/snapshots/erofs/erofs_linux.go
@@ -528,7 +528,9 @@ func (s *snapshotter) Remove(ctx context.Context, key string) (err error) {
 		}
 	}()
 	return s.ms.WithTransaction(ctx, true, func(ctx context.Context) error {
-		id, _, err = storage.Remove(ctx, key)
+		var k snapshots.Kind
+
+		id, k, err = storage.Remove(ctx, key)
 		if err != nil {
 			return fmt.Errorf("failed to remove snapshot %s: %w", key, err)
 		}
@@ -537,10 +539,13 @@ func (s *snapshotter) Remove(ctx context.Context, key string) (err error) {
 		if err != nil {
 			return fmt.Errorf("unable to get directories for removal: %w", err)
 		}
-		// Clear IMMUTABLE_FL before removal, since this flag avoids it.
-		err = setImmutable(s.layerBlobPath(id), false)
-		if err != nil {
-			return fmt.Errorf("failed to clear IMMUTABLE_FL: %w", err)
+		// The layer blob is only persisted for committed snapshots.
+		if k == snapshots.KindCommitted {
+			// Clear IMMUTABLE_FL before removal, since this flag avoids it.
+			err = setImmutable(s.layerBlobPath(id), false)
+			if err != nil {
+				return fmt.Errorf("failed to clear IMMUTABLE_FL: %w", err)
+			}
 		}
 		return nil
 	})


### PR DESCRIPTION
1. force the use of loop devices for single-layer images
```
    Currently, containerd cannot dynamically select between EROFS block
    or file-based mounting approaches based on the specific runtime (or
    the Linux kernel version of the runtime) due to its static mount
    structure.

    For example, the EROFS snapshotter fails on Linux 5.4 (Ubuntu 20.04)
    with `bin/nerdctl run --net=host --snapshotter=erofs busybox:latest`:

    FATA[0005] failed to mount {Type:erofs Source:/var/lib/containerd/
    io.containerd.snapshotter.v1.erofs/snapshots/1/layer.erofs Target:
    Options:[ro]} on "/tmp/initialC1374142795": block device required

    Temporarily fix this by appending `-oloop` for single-layer images.
    The upcoming mount manager will make it better.
```

2. clear IMMUTABLE_FL only for committed snapshots
```
    Otherwise, the following error avoids snapshot GC:
    level=warning msg="snapshot garbage collection failed" error="failed
    to clear IMMUTABLE_FL: failed to open: open /var/lib/containerd/io.
    containerd.snapshotter.v1.erofs/snapshots/2/layer.erofs: no such file
    or directory
```

This fixes https://github.com/containerd/containerd/pull/11431#discussion_r1970373024 since if we check the error code, we need to ignore the non-existing active snapshots too.