### PR TITLE
Draft: ctr support print plugin config

### DIFF
--- a/plugins/cri/runtime/plugin.go
+++ b/plugins/cri/runtime/plugin.go
@@ -40,13 +40,15 @@ import (
 	"github.com/containerd/platforms"
 )
 
+const containerdRuntime string = "runtime"
+
 func init() {
 	config := criconfig.DefaultRuntimeConfig()
 
 	// Base plugin that other CRI services depend on.
 	registry.Register(&plugin.Registration{
 		Type:   plugins.CRIServicePlugin,
-		ID:     "runtime",
+		ID:     containerdRuntime,
 		Config: &config,
 		Requires: []plugin.Type{
 			plugins.WarningPlugin,
@@ -94,6 +96,12 @@ func initCRIRuntime(ic *plugin.InitContext) (interface{}, error) {
 	if err := setGLogLevel(); err != nil {
 		return nil, fmt.Errorf("failed to set glog level: %w", err)
 	}
+
+	configData, err := json.Marshal(c)
+	if err != nil {
+		return nil, err
+	}
+	ic.Meta.Exports[containerdRuntime] = string(configData)
 
 	ociSpec, err := loadBaseOCISpecs(&c)
 	if err != nil {


### PR DESCRIPTION
```
bin/ctr plugin inspect runtime 
{
    "cdiSpecDirs": [
        "/etc/cdi",
        "/var/run/cdi"
    ],
    "cni": {
        "binDir": "/opt/cni/bin",
        "confDir": "/etc/cni/net.d",
        "confTemplate": "",
        "ipPref": "",
        "maxConfNum": 1,
        "setupSerially": false,
        "useInternalLoopback": false
    },
    "containerd": {
        "defaultRuntimeName": "runc",
        "ignoreBlockIONotEnabledErrors": false,
        "ignoreRdtNotEnabledErrors": false,
        "runtimes": {
            "runc": {
                "ContainerAnnotations": [],
                "PodAnnotations": [],
                "baseRuntimeSpec": "",
                "cgroupWritable": false,
                "cniConfDir": "",
                "cniMaxConfNum": 0,
                "io_type": "",
                "options": {
                    "BinaryName": "",
                    "CriuImagePath": "",
                    "CriuPath": "",
                    "CriuWorkPath": "",
                    "IoGid": 0,
                    "IoUid": 0,
                    "NoNewKeyring": false,
                    "NoPivotRoot": false,
                    "Root": "",
                    "ShimCgroup": "",
                    "SystemdCgroup": false
                },
                "privileged_without_host_devices": false,
                "privileged_without_host_devices_all_devices_allowed": false,
                "runtimePath": "",
                "runtimeType": "io.containerd.runc.v2",
                "sandboxer": "podsandbox",
                "snapshotter": ""
            }
        }
    },
    "containerdEndpoint": "/run/containerd/containerd.sock",
    "containerdRootDir": "/var/lib/containerd",
    "device_ownership_from_security_context": false,
    "disableApparmor": false,
    "disableHugetlbController": true,
    "disableProcMount": false,
    "drainExecSyncIOTimeout": "0s",
    "enableCDI": false,
    "enableSelinux": true,
    "enableUnprivilegedICMP": false,
    "enableUnprivilegedPorts": false,
    "ignoreDeprecationWarnings": null,
    "ignoreImageDefinedVolumes": false,
    "maxContainerLogSize": 16384,
    "netnsMountsUnderStateDir": false,
    "restrictOOMScoreAdj": false,
    "rootDir": "/var/lib/containerd/io.containerd.grpc.v1.cri",
    "selinuxCategoryRange": 1024,
    "stateDir": "/run/containerd/io.containerd.grpc.v1.cri",
    "tolerateMissingHugetlbController": true,
    "unsetSeccompProfile": ""
}
```