### PR TITLE
ci: update GitHub Actions release runner to ubuntu-24.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
 
   build:
     name: Build Release Binaries
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
       matrix:


### PR DESCRIPTION
Ubuntu 20.04 GitHub Actions runners are deprecated. This change updates the release runner to use Ubuntu 24.04.

https://github.com/actions/runner-images/issues/11101

Signed-off-by: Austin Vazquez <macedonv@amazon.com>