### PR TITLE
Retry registry operations once on 50x if last host

### DIFF
--- a/core/remotes/docker/fetcher.go
+++ b/core/remotes/docker/fetcher.go
@@ -30,13 +30,14 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/containerd/containerd/v2/core/images"
-	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/klauspost/compress/zstd"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/remotes"
 )
 
 type bufferPool struct {
@@ -259,7 +260,7 @@ func (r dockerFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.R
 				req.path = req.path + "?" + u.RawQuery
 			}
 
-			rc, err := r.open(ctx, req, desc.MediaType, offset)
+			rc, err := r.open(ctx, req, desc.MediaType, offset, false)
 			if err != nil {
 				if errdefs.IsNotFound(err) {
 					continue // try one of the other urls.
@@ -275,13 +276,13 @@ func (r dockerFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.R
 		if images.IsManifestType(desc.MediaType) || images.IsIndexType(desc.MediaType) {
 
 			var firstErr error
-			for _, host := range r.hosts {
+			for i, host := range r.hosts {
 				req := r.request(host, http.MethodGet, "manifests", desc.Digest.String())
 				if err := req.addNamespace(r.refspec.Hostname()); err != nil {
 					return nil, err
 				}
 
-				rc, err := r.open(ctx, req, desc.MediaType, offset)
+				rc, err := r.open(ctx, req, desc.MediaType, offset, i == len(r.hosts)-1)
 				if err != nil {
 					// Store the error for referencing later
 					if firstErr == nil {
@@ -298,13 +299,13 @@ func (r dockerFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.R
 
 		// Finally use blobs endpoints
 		var firstErr error
-		for _, host := range r.hosts {
+		for i, host := range r.hosts {
 			req := r.request(host, http.MethodGet, "blobs", desc.Digest.String())
 			if err := req.addNamespace(r.refspec.Hostname()); err != nil {
 				return nil, err
 			}
 
-			rc, err := r.open(ctx, req, desc.MediaType, offset)
+			rc, err := r.open(ctx, req, desc.MediaType, offset, i == len(r.hosts)-1)
 			if err != nil {
 				// Store the error for referencing later
 				if firstErr == nil {
@@ -327,7 +328,7 @@ func (r dockerFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.R
 	})
 }
 
-func (r dockerFetcher) createGetReq(ctx context.Context, host RegistryHost, mediatype string, ps ...string) (*request, int64, error) {
+func (r dockerFetcher) createGetReq(ctx context.Context, host RegistryHost, lastHost bool, mediatype string, ps ...string) (*request, int64, error) {
 	headReq := r.request(host, http.MethodHead, ps...)
 	if err := headReq.addNamespace(r.refspec.Hostname()); err != nil {
 		return nil, 0, err
@@ -339,7 +340,7 @@ func (r dockerFetcher) createGetReq(ctx context.Context, host RegistryHost, medi
 		headReq.header.Set("Accept", strings.Join([]string{mediatype, `*/*`}, ", "))
 	}
 
-	headResp, err := headReq.doWithRetries(ctx)
+	headResp, err := headReq.doWithRetries(ctx, lastHost)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -383,8 +384,8 @@ func (r dockerFetcher) FetchByDigest(ctx context.Context, dgst digest.Digest, op
 		firstErr error
 	)
 
-	for _, host := range r.hosts {
-		getReq, sz, err = r.createGetReq(ctx, host, config.Mediatype, "blobs", dgst.String())
+	for i, host := range r.hosts {
+		getReq, sz, err = r.createGetReq(ctx, host, i == len(r.hosts)-1, config.Mediatype, "blobs", dgst.String())
 		if err == nil {
 			break
 		}
@@ -396,8 +397,8 @@ func (r dockerFetcher) FetchByDigest(ctx context.Context, dgst digest.Digest, op
 
 	if getReq == nil {
 		// Fall back to the "manifests" endpoint
-		for _, host := range r.hosts {
-			getReq, sz, err = r.createGetReq(ctx, host, config.Mediatype, "manifests", dgst.String())
+		for i, host := range r.hosts {
+			getReq, sz, err = r.createGetReq(ctx, host, i == len(r.hosts)-1, config.Mediatype, "manifests", dgst.String())
 			if err == nil {
 				break
 			}
@@ -419,7 +420,7 @@ func (r dockerFetcher) FetchByDigest(ctx context.Context, dgst digest.Digest, op
 	}
 
 	seeker, err := newHTTPReadSeeker(sz, func(offset int64) (io.ReadCloser, error) {
-		return r.open(ctx, getReq, config.Mediatype, offset)
+		return r.open(ctx, getReq, config.Mediatype, offset, true)
 	})
 	if err != nil {
 		return nil, desc, err
@@ -436,7 +437,7 @@ func (r dockerFetcher) FetchByDigest(ctx context.Context, dgst digest.Digest, op
 	return seeker, desc, nil
 }
 
-func (r dockerFetcher) open(ctx context.Context, req *request, mediatype string, offset int64) (_ io.ReadCloser, retErr error) {
+func (r dockerFetcher) open(ctx context.Context, req *request, mediatype string, offset int64, lastHost bool) (_ io.ReadCloser, retErr error) {
 	const minChunkSize = 512
 
 	chunkSize := int64(r.performances.ConcurrentLayerFetchBuffer)
@@ -455,7 +456,7 @@ func (r dockerFetcher) open(ctx context.Context, req *request, mediatype string,
 	if err := r.Acquire(ctx, 1); err != nil {
 		return nil, err
 	}
-	resp, err := req.doWithRetries(ctx, withErrorCheck, withOffsetCheck(offset))
+	resp, err := req.doWithRetries(ctx, lastHost, withErrorCheck, withOffsetCheck(offset))
 	switch err {
 	case nil:
 		// all good
@@ -522,9 +523,7 @@ func (r dockerFetcher) open(ctx context.Context, req *request, mediatype string,
 						} else {
 							reqClone := req.clone()
 							reqClone.setOffset(offset + i*chunkSize)
-							nresp, err := reqClone.doWithRetries(ctx,
-								withErrorCheck,
-							)
+							nresp, err := reqClone.doWithRetries(ctx, lastHost, withErrorCheck)
 							if err != nil {
 								_ = writers[i].CloseWithError(err)
 								select {

--- a/core/remotes/docker/fetcher_fuzz_test.go
+++ b/core/remotes/docker/fetcher_fuzz_test.go
@@ -58,7 +58,7 @@ func FuzzFetcher(f *testing.F) {
 
 		ctx := context.Background()
 		req := f.request(host, http.MethodGet)
-		rc, err := f.open(ctx, req, "", 0)
+		rc, err := f.open(ctx, req, "", 0, true)
 		if err != nil {
 			return
 		}

--- a/core/remotes/docker/pusher.go
+++ b/core/remotes/docker/pusher.go
@@ -28,14 +28,15 @@ import (
 	"sync"
 	"time"
 
-	"github.com/containerd/containerd/v2/core/content"
-	"github.com/containerd/containerd/v2/core/images"
-	"github.com/containerd/containerd/v2/core/remotes"
-	remoteserrors "github.com/containerd/containerd/v2/core/remotes/errors"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/remotes"
+	remoteserrors "github.com/containerd/containerd/v2/core/remotes/errors"
 )
 
 type dockerPusher struct {
@@ -115,7 +116,7 @@ func (p dockerPusher) push(ctx context.Context, desc ocispec.Descriptor, ref str
 
 	log.G(ctx).WithField("url", req.String()).Debugf("checking and pushing to")
 
-	resp, err := req.doWithRetries(ctx)
+	resp, err := req.doWithRetries(ctx, true)
 	if err != nil {
 		if !errors.Is(err, ErrInvalidAuthorization) {
 			return nil, err
@@ -176,7 +177,7 @@ func (p dockerPusher) push(ctx context.Context, desc ocispec.Descriptor, ref str
 			//
 			// for the private repo, we should remove mount-from
 			// query and send the request again.
-			resp, err = preq.doWithRetries(pctx)
+			resp, err = preq.doWithRetries(pctx, true)
 			if err != nil {
 				if !errors.Is(err, ErrInvalidAuthorization) {
 					return nil, fmt.Errorf("pushing with mount from %s: %w", fromRepo, err)
@@ -197,7 +198,7 @@ func (p dockerPusher) push(ctx context.Context, desc ocispec.Descriptor, ref str
 		}
 
 		if resp == nil {
-			resp, err = req.doWithRetries(ctx)
+			resp, err = req.doWithRetries(ctx, true)
 			if err != nil {
 				if errors.Is(err, ErrInvalidAuthorization) {
 					return nil, fmt.Errorf("push access denied, repository does not exist or may require authorization: %w", err)
@@ -289,7 +290,7 @@ func (p dockerPusher) push(ctx context.Context, desc ocispec.Descriptor, ref str
 	req.size = desc.Size
 
 	go func() {
-		resp, err := req.doWithRetries(ctx)
+		resp, err := req.doWithRetries(ctx, true)
 		if err != nil {
 			pushw.setError(err)
 			return


### PR DESCRIPTION
Add a retry on 500, 503, 504 errors when there are no remaining hosts and the previous request did have the same 50x error.

This is still a more conservative approach to retry on 50x and will not apply to mirrors. Previously there was concerns about too aggressively retrying mirrors rather than quickly moving to the next host. We can try the last host more aggressively as well with the same logic not applying to the mirrors.