### PR TITLE
e2e: use the shim bundled with containerd artifact

### DIFF
--- a/contrib/gce/configure.sh
+++ b/contrib/gce/configure.sh
@@ -230,6 +230,7 @@ disabled_plugins = ["io.containerd.internal.v1.restart"]
   default_runtime_name = "${CONTAINERD_DEFAULT_RUNTIME:-"runc"}"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
   runtime_type = "io.containerd.runc.v2"
+  runtime_path = "${CONTAINERD_HOME}/usr/local/bin/containerd-shim-runc-v2"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
   BinaryName = "${CONTAINERD_HOME}/usr/local/sbin/runc"
   SystemdCgroup = ${systemdCgroup}


### PR DESCRIPTION
use the shim bundled with cri-cni-containerd tar rather than using the shim present on the host machine for running e2e

Fixes: https://github.com/kubernetes/kubernetes/issues/130590