### PR TITLE
[release/1.6] build(deps): bump containerd/project-checks from 1.1.0 to 1.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
 
       - uses: ./src/github.com/containerd/containerd/.github/actions/install-go
 
-      - uses: containerd/project-checks@v1.1.0
+      - uses: containerd/project-checks@v1.2.1
         if: github.repository == 'containerd/containerd'
         with:
           working-directory: src/github.com/containerd/containerd


### PR DESCRIPTION
(cherry picked from commit c1bfb8e3d15509d8830b0df7b8464d93f970dcee)