### PR TITLE
client: Respect `client.WithTimeout` option

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -129,7 +129,8 @@ func New(address string, opts ...Opt) (*Client, error) {
 		backoffConfig := backoff.DefaultConfig
 		backoffConfig.MaxDelay = copts.timeout
 		connParams := grpc.ConnectParams{
-			Backoff: backoffConfig,
+			Backoff:           backoffConfig,
+			MinConnectTimeout: copts.timeout,
 		}
 		gopts := []grpc.DialOption{
 			grpc.WithTransportCredentials(insecure.NewCredentials()),


### PR DESCRIPTION
- related to: https://github.com/containerd/containerd/issues/11507

Fix the gRPC client dialer not using the timeout passed by the containerd client timeout option.

Commit 63b4688175 replaced the usage of deprecated `grpc.DialContext` with `grpc.NewClient`.

However, the `dialer.ContextDialer` relied on the context deadline to propagate the timeout:

https://github.com/containerd/containerd/blob/388fb336b0a458e2cf64212072743e622a3f44c7/vendor/google.golang.org/grpc/clientconn.go#L216

This assumption is now broken, because `grpc.NewClient` doesn't do any initial connection and defers it to the first RPC usage.

This commit passes the timeout to the connection dialer, so the timeout will be applied to **every** connection attempt (not just the first).

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>