### PR TITLE
fix: repeat args from sub-func call

### DIFF
--- a/integration/client/export_test.go
+++ b/integration/client/export_test.go
@@ -109,7 +109,7 @@ func TestExportAllCases(t *testing.T) {
 				return img
 			},
 			check: func(ctx context.Context, t *testing.T, client *Client, dstFile *os.File, img images.Image) {
-				err := client.Export(ctx, dstFile, archive.WithImage(client.ImageService(), testImage), archive.WithPlatform(platforms.All), archive.WithImage(client.ImageService(), testImage))
+				err := client.Export(ctx, dstFile, archive.WithImage(client.ImageService(), testImage), archive.WithPlatform(platforms.All))
 				if err != nil {
 					t.Fatal(err)
 				}


### PR DESCRIPTION
I am verifying some lint idea in my project see https://github.com/alingse/sundrylint/pull/10
it report the function call with repeat args from a sub-function call.

we think the sub-function call is heavy, so the repeat args probably a copy-and-paste mistake.

I check the top 200 github repos, and found this repo has this case.