### PR TITLE
update to go1.23.7 / go1.24.1

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"ghcr.io/devcontainers/features/go:1": {
-			"version": "1.24.0"
+			"version": "1.24.1"
 		}
 	},
 

--- a/.github/actions/install-go/action.yml
+++ b/.github/actions/install-go/action.yml
@@ -3,7 +3,7 @@ description: "Reusable action to install Go, so there is one place to bump Go ve
 inputs:
   go-version:
     required: true
-    default: "1.24.0"
+    default: "1.24.1"
     description: "Go version to install"
 
 runs:

--- a/.github/workflows/api-release.yml
+++ b/.github/workflows/api-release.yml
@@ -6,7 +6,7 @@ on:
 name: API Release
 
 env:
-  GO_VERSION: "1.24.0"
+  GO_VERSION: "1.24.1"
 
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm, macos-13, windows-2019, windows-2022]
-        go-version: ["1.23.6", "1.24.0"]
+        go-version: ["1.23.7", "1.24.1"]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 name: Release
 
 env:
-  GO_VERSION: "1.24.0"
+  GO_VERSION: "1.24.1"
 
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -107,7 +107,7 @@ EOF
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.24.0",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.24.1",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -34,7 +34,7 @@
 #   docker run --privileged --group-add keep-groups -v ./critest_exit_code.txt:/tmp/critest_exit_code.txt containerd-test
 # ------------------------------------------------------------------------------
 
-ARG GOLANG_VERSION=1.24.0
+ARG GOLANG_VERSION=1.24.1
 ARG GOLANG_IMAGE=golang
 
 FROM ${GOLANG_IMAGE}:${GOLANG_VERSION} AS golang

--- a/contrib/fuzz/oss_fuzz_build.sh
+++ b/contrib/fuzz/oss_fuzz_build.sh
@@ -43,11 +43,11 @@ go run main.go --target_dir $SRC/containerd/images
 
 apt-get update && apt-get install -y wget
 cd $SRC
-wget --quiet https://go.dev/dl/go1.24.0.linux-amd64.tar.gz
+wget --quiet https://go.dev/dl/go1.24.1.linux-amd64.tar.gz
 
 mkdir temp-go
 rm -rf /root/.go/*
-tar -C temp-go/ -xzf go1.24.0.linux-amd64.tar.gz
+tar -C temp-go/ -xzf go1.24.1.linux-amd64.tar.gz
 mv temp-go/go/* /root/.go/
 cd $SRC/containerd
 

--- a/script/setup/prepare_env_windows.ps1
+++ b/script/setup/prepare_env_windows.ps1
@@ -5,7 +5,7 @@
 # lived test environment.
 Set-MpPreference -DisableRealtimeMonitoring:$true
 
-$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.24.0"; make = ""; nssm = "" }
+$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.24.1"; make = ""; nssm = "" }
 
 Write-Host "Downloading chocolatey package"
 curl.exe -L "https://packages.chocolatey.org/chocolatey.0.10.15.nupkg" -o 'c:\choco.zip'


### PR DESCRIPTION
- go1.23.7 (released 2025-03-04) includes security fixes to the net/http package, as well as bug fixes to cgo, the compiler, and the reflect, runtime, and syscall packages. See the [Go 1.23.7 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.23.7+label%3ACherryPickApproved) on our issue tracker for details

- go1.24.1 (released 2025-03-04) includes security fixes to the net/http package, as well as bug fixes to cgo, the compiler, the go command, and the reflect, runtime, and syscall packages. See the [Go 1.24.1 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.24.1+label%3ACherryPickApproved) on our issue tracker for details.