### PR TITLE
[release/2.0] Fix incorrect runtime name being passed to NRI

### DIFF
--- a/internal/nri/nri.go
+++ b/internal/nri/nri.go
@@ -19,7 +19,6 @@ package nri
 import (
 	"context"
 	"fmt"
-	"path"
 	"sync"
 
 	"github.com/containerd/log"
@@ -117,7 +116,7 @@ func New(cfg *Config) (API, error) {
 	}
 
 	var (
-		name     = path.Base(version.Package)
+		name     = version.Name
 		version  = version.Version
 		opts     = cfg.toOptions()
 		syncFn   = l.syncPlugin

--- a/version/version.go
+++ b/version/version.go
@@ -19,6 +19,7 @@ package version
 import "runtime"
 
 var (
+	Name = "containerd"
 	// Package is filled at linking time
 	Package = "github.com/containerd/containerd/v2"
 


### PR DESCRIPTION
cherry-pick from https://github.com/containerd/containerd/pull/11518/commits