### PR TITLE
Switch to go 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/containerd/v2
 
-go 1.23.0
+go 1.24
 
 require (
 	dario.cat/mergo v1.0.1


### PR DESCRIPTION
The latest NRI wasm support will require go 1.24. Means we switch to the latest golang minor ahead of time to allow seamless upgrades.

Refers to https://github.com/containerd/nri/pull/148