### PR TITLE
[release/1.6] Prepare release notes for v1.6.38

### DIFF
--- a/releases/v1.6.38.toml
+++ b/releases/v1.6.38.toml
@@ -1,0 +1,27 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.6.37"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The thirty-eighth patch release for containerd 1.6 contains various fixes
+and updates.
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.37+unknown"
+	Version = "1.6.38+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated notes

----

containerd 1.6.38

Welcome to the v1.6.38 release of containerd!

The thirty-eighth patch release for containerd 1.6 contains various fixes
and updates.

### Highlights

#### Container Runtime Interface (CRI)

* Fix fatal map concurrency error in httpstream ([#11319](https://github.com/containerd/containerd/pull/11319))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Jin Dong
* Akhil Mohan
* Phil Estes
* Akihiro Suda
* Derek McGowan
* Kohei Tokunaga
* Maksym Pavlenko
* Samuel Karp
* ningmingxiao

### Changes
<details><summary>16 commits</summary>
<p>

  * [`eee34bac2`](https://github.com/containerd/containerd/commit/eee34bac2c401b3e4381594e99f6220bf8258c9c) Prepare release notes for v1.6.38
* update build to go1.23.7, test go1.24.1 ([#11421](https://github.com/containerd/containerd/pull/11421))
  * [`b67a35baf`](https://github.com/containerd/containerd/commit/b67a35baf0a97c87033f1a6c9bdf97630fe4e9e8) move exclude-dirs to issues.exclude-dirs
  * [`2104a41ef`](https://github.com/containerd/containerd/commit/2104a41efece4a12a34e03f00d780e905b95b5a5) update golangci-lint to 1.60.1
  * [`820e81adc`](https://github.com/containerd/containerd/commit/820e81adccbf3819d282a6597db98bd4df49c12c) update build to go1.23.7, test go1.24.1
* Remove hashicorp/go-multierror dependency and fix CI ([#11500](https://github.com/containerd/containerd/pull/11500))
  * [`7cc3b3dce`](https://github.com/containerd/containerd/commit/7cc3b3dcec509f1ce2e5d52887520baa48201c54) e2e: use the shim bundled with containerd artifact
  * [`0733895f3`](https://github.com/containerd/containerd/commit/0733895f3de3df51fe4e14563ee94a98df1be8dd) Remove unnecessary joinError unwrap
  * [`054c4cc79`](https://github.com/containerd/containerd/commit/054c4cc79c929eecfb9724fd1c3e9f13a4cd5701) Remove hashicorp/go-multierror
  * [`ff21be0ee`](https://github.com/containerd/containerd/commit/ff21be0ee8b274c05a542a096c1042ef63857f09) Update go to 1.20 to use its multi error support
  * [`f63b5fd3f`](https://github.com/containerd/containerd/commit/f63b5fd3f9b4b809d94d4a3053c4d76a7753072c) update containerd/project-checks to 1.2.1
* Fix fatal map concurrency error in httpstream ([#11319](https://github.com/containerd/containerd/pull/11319))
  * [`abd1692cf`](https://github.com/containerd/containerd/commit/abd1692cf27bcff4590207bdd8a827b06657c446) fix fatal error: concurrent map iteration and map write
* CI: arm64-8core-32gb -> ubuntu-24.04-arm ([#11438](https://github.com/containerd/containerd/pull/11438))
  * [`f5ab73c0a`](https://github.com/containerd/containerd/commit/f5ab73c0a776ad2462198725b8d522e820dc690a) CI: arm64-8core-32gb -> ubuntu-24.04-arm
  * [`2cc6b5b0a`](https://github.com/containerd/containerd/commit/2cc6b5b0af07563d2c6a0b183a32e342b7ce86d2) increase xfs base image size to 300Mb
</p>
</details>

### Dependency Changes

This release has no dependency changes

Previous release can be found at [v1.6.37](https://github.com/containerd/containerd/releases/tag/v1.6.37)

