### PR TITLE
[release/1.7] Prepare release notes for v1.7.27

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -70,6 +70,7 @@ Lorenz Brun <lorenz@brun.one> <lorenz@nexantic.com>
 Luc Perkins <lucperkins@gmail.com>
 James Sturtevant <jsturtevant@gmail.com> <jstur@microsoft.com>
 Jiajun Jiang <levinxo@gmail.com>
+Jin Dong <djdongjin95@gmail.com> <jin.dong@databricks.com>
 Julien Balestra <julien.balestra@datadoghq.com>
 Jun Lin Chen <webmaster@mc256.com> <1913688+mc256@users.noreply.github.com>
 Justin Cormack <justin.cormack@docker.com> <justin@specialbusservice.com>

--- a/releases/v1.7.27.toml
+++ b/releases/v1.7.27.toml
@@ -1,0 +1,27 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+# project_name is used to refer to the project in the notes
+project_name = "containerd"
+
+# github_repo is the github project, only github is currently supported
+github_repo = "containerd/containerd"
+
+# match_deps is a pattern to determine which dependencies should be included
+# as part of this release. The changelog will also include changes for these
+# dependencies based on the change in the dependency's version.
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous release of this project for determining changes
+previous = "v1.7.26"
+
+# pre_release is whether to include a disclaimer about being a pre-release
+pre_release = false
+
+# preface is the description of the release which precedes the author list
+# and changelog. This description could include highlights as well as any
+# description of changes. Use markdown formatting.
+preface = """\
+The twenty-seventh patch release for containerd 1.7 contains various fixes
+and updates.
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.7.26+unknown"
+	Version = "1.7.27+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated notes

----

containerd 1.7.27

Welcome to the v1.7.27 release of containerd!

The twenty-seventh patch release for containerd 1.7 contains various fixes
and updates.

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Akhil Mohan
* Jin Dong
* Phil Estes
* Akihiro Suda
* Krisztian Litkey
* Maksym Pavlenko
* Samuel Karp

### Changes
<details><summary>13 commits</summary>
<p>

* update build to go1.23.7, test go1.24.1 ([#11515](https://github.com/containerd/containerd/pull/11515))
  * [`a39863c9f`](https://github.com/containerd/containerd/commit/a39863c9fd52abb50895a4b6f653cf501a2e3388) update build to go1.23.7, test go1.24.1
* Remove hashicorp/go-multierror dependency and fix CI ([#11499](https://github.com/containerd/containerd/pull/11499))
  * [`49537b3a7`](https://github.com/containerd/containerd/commit/49537b3a75bdcd982e7e26855779b346bb363a54) e2e: use the shim bundled with containerd artifact
  * [`fe490b76f`](https://github.com/containerd/containerd/commit/fe490b76fd78cc1461f20aab89951be5f88fc454) Bump up github.com/intel/goresctrl to 0.5.0
  * [`13fc9d313`](https://github.com/containerd/containerd/commit/13fc9d3132fc4c77f6533551049d2d865d4e4b45) update containerd/project-checks to 1.2.1
  * [`585699c94`](https://github.com/containerd/containerd/commit/585699c94f68649a89b0af46d675d6e998d67ccd) Remove unnecessary joinError unwrap
  * [`4b9df59be`](https://github.com/containerd/containerd/commit/4b9df59be202a011c4f65604bbeab75eeb85ab46) Remove hashicorp/go-multierror
* go.{mod,sum}: bump CDI deps to v0.8.1. ([#11422](https://github.com/containerd/containerd/pull/11422))
  * [`5ba28f8dc`](https://github.com/containerd/containerd/commit/5ba28f8dc1d007059ed3eb1a7b55025e72abd525) go.{mod,sum}: bump CDI deps to v0.8.1, re-vendor.
* CI: arm64-8core-32gb -> ubuntu-24.04-arm ([#11437](https://github.com/containerd/containerd/pull/11437))
  * [`85f10bd92`](https://github.com/containerd/containerd/commit/85f10bd9221f35ef1c2b8ec2d67520f461aa51a0) CI: arm64-8core-32gb -> ubuntu-24.04-arm
  * [`561ed520e`](https://github.com/containerd/containerd/commit/561ed520eaef2974aa8008b7a18a0944e6f90872) increase xfs base image size to 300Mb
</p>
</details>

### Dependency Changes

* **github.com/intel/goresctrl**                        v0.3.0 -> v0.5.0
* **github.com/prometheus/client_golang**               v1.14.0 -> v1.16.0
* **github.com/prometheus/common**                      v0.37.0 -> v0.42.0
* **github.com/prometheus/procfs**                      v0.8.0 -> v0.10.1
* **k8s.io/apimachinery**                               v0.26.2 -> v0.27.4
* **sigs.k8s.io/json**                                  f223a00ba0e2 -> bc3834ca7abd
* **tags.cncf.io/container-device-interface**           v0.7.2 -> v0.8.1
* **tags.cncf.io/container-device-interface/specs-go**  v0.7.0 -> v0.8.0

Previous release can be found at [v1.7.26](https://github.com/containerd/containerd/releases/tag/v1.7.26)

