### PR TITLE
[release/2.0] Prepare release notes for v2.0.4

### DIFF
--- a/releases/v2.0.4.toml
+++ b/releases/v2.0.4.toml
@@ -1,0 +1,27 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+ignore_deps = [ "github.com/containerd/containerd" ]
+
+# previous release
+previous = "v2.0.3"
+
+pre_release = false
+
+preface = """\
+The fourth patch release for containerd 2.0 includes various bug fixes and updates.
+"""
+
+postface = """\
+### Which file should I download?
+* `containerd-<VERSION>-<OS>-<ARCH>.tar.gz`:         ✅Recommended. Dynamically linked with glibc 2.31 (Ubuntu 20.04).
+* `containerd-static-<VERSION>-<OS>-<ARCH>.tar.gz`:  Statically linked. Expected to be used on non-glibc Linux distributions. Not position-independent.
+
+In addition to containerd, typically you will have to install [runc](https://github.com/opencontainers/runc/releases)
+and [CNI plugins](https://github.com/containernetworking/plugins/releases) from their official sites too.
+
+See also the [Getting Started](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) documentation.
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -24,7 +24,7 @@ var (
 	Package = "github.com/containerd/containerd/v2"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "2.0.3+unknown"
+	Version = "2.0.4+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Generated notes

----

containerd 2.0.4

Welcome to the v2.0.4 release of containerd!

The fourth patch release for containerd 2.0 includes various bug fixes and updates.

### Highlights

* Respect `client.WithTimeout` option on connect ([#11536](https://github.com/containerd/containerd/pull/11536))
* Update image type checks to avoid unnecessary logs for attestations ([#11537](https://github.com/containerd/containerd/pull/11537))

#### Node Resource Interface (NRI)

* Fix incorrect runtime name being passed to NRI ([#11529](https://github.com/containerd/containerd/pull/11529))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Akihiro Suda
* Paweł Gronowski
* Akhil Mohan
* Derek McGowan
* Phil Estes
* Samuel Karp
* ningmingxiao

### Changes
<details><summary>16 commits</summary>
<p>

  * [`06a886a8e`](https://github.com/containerd/containerd/commit/06a886a8e49a02bc15895c093e0519db27415548) Prepare release notes for v2.0.4
* Respect `client.WithTimeout` option on connect ([#11536](https://github.com/containerd/containerd/pull/11536))
  * [`6b5efba83`](https://github.com/containerd/containerd/commit/6b5efba83b2aa68b522ebfe73d3fed8e18a59429) client: Respect `client.WithTimeout` option
* Update image type checks to avoid unnecessary logs for attestations ([#11537](https://github.com/containerd/containerd/pull/11537))
  * [`916d48722`](https://github.com/containerd/containerd/commit/916d4872262eed04fb6626183c2306320d14e965) core/remotes: Handle attestations in MakeRefKey
  * [`df4d905a6`](https://github.com/containerd/containerd/commit/df4d905a6f0d9e74a0aff2514030c343d56ba86d) core/images: Ignore attestations when traversing children
* Fix incorrect runtime name being passed to NRI ([#11529](https://github.com/containerd/containerd/pull/11529))
  * [`4f037050c`](https://github.com/containerd/containerd/commit/4f037050ce83224d79e8b65e270222abb9ce6ab0) add name in package version
* update build to go1.23.7, test go1.24.1 ([#11514](https://github.com/containerd/containerd/pull/11514))
  * [`e5ad0d0a0`](https://github.com/containerd/containerd/commit/e5ad0d0a0e212bc8cd5b8b7169f6b10873e2e6fe) update build to go1.23.7, test go1.24.1
* docs: include note about unprivileged sysctls ([#11506](https://github.com/containerd/containerd/pull/11506))
  * [`a39f1146b`](https://github.com/containerd/containerd/commit/a39f1146b065a0ef054933f912ede0476586fa83) docs: include note about unprivileged sysctls
* e2e: use the shim bundled with containerd artifact ([#11503](https://github.com/containerd/containerd/pull/11503))
  * [`81b3384a0`](https://github.com/containerd/containerd/commit/81b3384a0d6c0f58d36884bbd24bf9f7a965b008) e2e: use the shim bundled with containerd artifact
* build(deps): bump containerd/project-checks from 1.1.0 to 1.2.1 ([#11497](https://github.com/containerd/containerd/pull/11497))
  * [`7215a7d2c`](https://github.com/containerd/containerd/commit/7215a7d2caa73cd8ca2de50435fa3a5f1df36d75) build(deps): bump containerd/project-checks from 1.1.0 to 1.2.1
</p>
</details>

### Dependency Changes

This release has no dependency changes

Previous release can be found at [v2.0.3](https://github.com/containerd/containerd/releases/tag/v2.0.3)
### Which file should I download?
* `containerd-<VERSION>-<OS>-<ARCH>.tar.gz`:         ✅Recommended. Dynamically linked with glibc 2.31 (Ubuntu 20.04).
* `containerd-static-<VERSION>-<OS>-<ARCH>.tar.gz`:  Statically linked. Expected to be used on non-glibc Linux distributions. Not position-independent.

In addition to containerd, typically you will have to install [runc](https://github.com/opencontainers/runc/releases)
and [CNI plugins](https://github.com/containernetworking/plugins/releases) from their official sites too.

See also the [Getting Started](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) documentation.
