### PR TITLE
Fix upgrade tests for 1.7

### DIFF
--- a/integration/issue10467_linux_test.go
+++ b/integration/issue10467_linux_test.go
@@ -1,0 +1,117 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"fmt"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/containerd/continuity/fs"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+)
+
+func TestIssue10467(t *testing.T) {
+	latestVersion := "v1.7.20"
+
+	releaseBinDir := t.TempDir()
+
+	downloadReleaseBinary(t, releaseBinDir, latestVersion)
+
+	t.Logf("Install config for release %s", latestVersion)
+	workDir := t.TempDir()
+	previousReleaseCtrdConfig(t, releaseBinDir, workDir)
+
+	t.Log("Starting the previous release's containerd")
+	previousCtrdBinPath := filepath.Join(releaseBinDir, "bin", "containerd")
+	previousProc := newCtrdProc(t, previousCtrdBinPath, workDir, []string{"ENABLE_CRI_SANDBOXES=yes"})
+
+	boltdbPath := filepath.Join(workDir, "root", "io.containerd.metadata.v1.bolt", "meta.db")
+
+	ctrdLogPath := previousProc.logPath()
+	t.Cleanup(func() {
+		if t.Failed() {
+			dumpFileContent(t, ctrdLogPath)
+		}
+	})
+
+	require.NoError(t, previousProc.isReady())
+
+	needToCleanup := true
+	t.Cleanup(func() {
+		if t.Failed() && needToCleanup {
+			t.Logf("Try to cleanup leaky pods")
+			cleanupPods(t, previousProc.criRuntimeService(t))
+		}
+	})
+
+	t.Log("Prepare pods for current release")
+	upgradeCaseFunc, hookFunc := shouldManipulateContainersInPodAfterUpgrade(t, previousProc.criRuntimeService(t), previousProc.criImageService(t))
+	needToCleanup = false
+	require.Nil(t, hookFunc)
+
+	t.Log("Gracefully stop previous release's containerd process")
+	require.NoError(t, previousProc.kill(syscall.SIGTERM))
+	require.NoError(t, previousProc.wait(5*time.Minute))
+
+	t.Logf("%s should have bucket k8s.io in root", boltdbPath)
+	db, err := bbolt.Open(boltdbPath, 0600, &bbolt.Options{ReadOnly: true})
+	require.NoError(t, err)
+	require.NoError(t, db.View(func(tx *bbolt.Tx) error {
+		if tx.Bucket([]byte("k8s.io")) == nil {
+			return fmt.Errorf("expected k8s.io bucket")
+		}
+		return nil
+	}))
+	require.NoError(t, db.Close())
+
+	t.Log("Install default config for current release")
+	currentReleaseCtrdDefaultConfig(t, workDir)
+
+	t.Log("Starting the current release's containerd")
+	currentProc := newCtrdProc(t, "containerd", workDir, nil)
+	require.NoError(t, currentProc.isReady())
+
+	t.Cleanup(func() {
+		t.Log("Cleanup all the pods")
+		cleanupPods(t, currentProc.criRuntimeService(t))
+
+		t.Log("Stopping current release's containerd process")
+		require.NoError(t, currentProc.kill(syscall.SIGTERM))
+		require.NoError(t, currentProc.wait(5*time.Minute))
+	})
+
+	t.Logf("%s should not have bucket k8s.io in root after restart", boltdbPath)
+	copiedBoltdbPath := filepath.Join(t.TempDir(), "meta.db.new")
+	require.NoError(t, fs.CopyFile(copiedBoltdbPath, boltdbPath))
+
+	db, err = bbolt.Open(copiedBoltdbPath, 0600, &bbolt.Options{ReadOnly: true})
+	require.NoError(t, err)
+	require.NoError(t, db.View(func(tx *bbolt.Tx) error {
+		if tx.Bucket([]byte("k8s.io")) != nil {
+			return fmt.Errorf("unexpected k8s.io bucket")
+		}
+		return nil
+	}))
+	require.NoError(t, db.Close())
+
+	t.Log("Verifing")
+	upgradeCaseFunc(t, currentProc.criRuntimeService(t), currentProc.criImageService(t))
+}

--- a/integration/issue10467_linux_test.go
+++ b/integration/issue10467_linux_test.go
@@ -37,7 +37,7 @@ func TestIssue10467(t *testing.T) {
 
 	t.Logf("Install config for release %s", latestVersion)
 	workDir := t.TempDir()
-	previousReleaseCtrdConfig(t, releaseBinDir, workDir)
+	oneSevenCtrdConfig(t, releaseBinDir, workDir)
 
 	t.Log("Starting the previous release's containerd")
 	previousCtrdBinPath := filepath.Join(releaseBinDir, "bin", "containerd")
@@ -63,7 +63,7 @@ func TestIssue10467(t *testing.T) {
 	})
 
 	t.Log("Prepare pods for current release")
-	upgradeCaseFunc, hookFunc := shouldManipulateContainersInPodAfterUpgrade(t, previousProc.criRuntimeService(t), previousProc.criImageService(t))
+	upgradeCaseFunc, hookFunc := shouldManipulateContainersInPodAfterUpgrade(t, 2, previousProc.criRuntimeService(t), previousProc.criImageService(t))
 	needToCleanup = false
 	require.Nil(t, hookFunc)
 

--- a/integration/issue10467_linux_test.go
+++ b/integration/issue10467_linux_test.go
@@ -28,6 +28,9 @@ import (
 	"go.etcd.io/bbolt"
 )
 
+// TestIssue10467 tests the migration of sandboxes into the proper bucket. Prior to v1.7.21, the
+// sandboxes were stored incorrectly in the root bucket. In order to verify the migration, a v1.7.20
+// must run and create a sandbox, then check the migration after upgrading to a newer version.
 func TestIssue10467(t *testing.T) {
 	latestVersion := "v1.7.20"
 

--- a/integration/release_upgrade_utils_linux_test.go
+++ b/integration/release_upgrade_utils_linux_test.go
@@ -30,13 +30,12 @@ import (
 	"golang.org/x/mod/semver"
 
 	"github.com/containerd/containerd/v2/pkg/archive"
-	"github.com/containerd/containerd/v2/version"
 )
 
 // downloadPreviousLatestReleaseBinary downloads the latest version of previous
 // release into the target dir.
-func downloadPreviousLatestReleaseBinary(t *testing.T, targetDir string) {
-	ver := previousReleaseVersion(t)
+func downloadPreviousLatestReleaseBinary(t *testing.T, version, targetDir string) {
+	ver := previousReleaseVersion(t, version)
 
 	downloadReleaseBinary(t, targetDir, ver)
 }
@@ -62,35 +61,13 @@ func downloadReleaseBinary(t *testing.T, targetDir string, ver string) {
 }
 
 // previousReleaseVersion returns the latest version of previous release.
-func previousReleaseVersion(t *testing.T) string {
-	majorMinor := ctrdPreviousMajorMinor(t)
-
-	tags := gitLsRemoteCtrdTags(t, fmt.Sprintf("refs/tags/%s.*", majorMinor))
+func previousReleaseVersion(t *testing.T, version string) string {
+	tags := gitLsRemoteCtrdTags(t, fmt.Sprintf("refs/tags/v%s.*", version))
 	require.True(t, len(tags) >= 1)
 
 	// sort them and get the latest version
 	semver.Sort(tags)
 	return tags[len(tags)-1]
-}
-
-// ctrdPreviousMajorMinor gets the current version of running containerd.
-//
-// TODO(fuweid): We should parse containerd --version to get the result.
-func ctrdPreviousMajorMinor(t *testing.T) string {
-	currentVer := "v" + version.Version
-
-	version := semver.MajorMinor(currentVer)
-	switch version {
-	case "v2.1":
-		return "v2.0"
-	case "v2.0":
-		return "v1.7"
-	case "v1.7":
-		return "v1.6"
-	default:
-		t.Fatalf("unexpected containerd version: %s", currentVer)
-		panic("unreachable")
-	}
 }
 
 // gitLsRemoteTags lists containerd tags based on pattern.


### PR DESCRIPTION
Update release upgrade tests to test 1.7 and 2.0

Fix 1.7 config to match previous version which allowed upgrade to 2.x.


NOTE: 
I might be slightly misunderstanding how the shim load will work after upgrade, but it seems there is still valid configurations for 1.7 that would not load, although possibly cases that a normal user would not run into. It seems the `runtime_path` for 1.7 will not be respected after upgrade and it will fallback to resolving based on the runtime type. This needs to be investigated more but was not previously covered by these tests. The issues manifests as the shim manager attempting to connect to the older shim with task v3.