### PR TITLE
Add reference to `/etc/cni/net.d` to getting-started doc

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -90,57 +90,7 @@ $ tar Cxzvf /opt/cni/bin cni-plugins-linux-amd64-v1.1.1.tgz
 
 The binaries are built statically and should work on any Linux distribution.
 
-In order for containerd to use them, you need to create a conflist file in /etc/cni/net.d. See [install-cni](https://github.com/containerd/containerd/blob/main/script/setup/install-cni).
-```bash
-#!/usr/bin/env bash
-#   Copyright The containerd Authors.
-
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
-
-#       http://www.apache.org/licenses/LICENSE-2.0
-
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
-cat << EOF | sudo tee /etc/cni/net.d/10-containerd-net.conflist
-{
-  "cniVersion": "1.0.0",
-  "name": "containerd-net",
-  "plugins": [
-    {
-      "type": "bridge",
-      "bridge": "cni0",
-      "isGateway": true,
-      "ipMasq": true,
-      "promiscMode": true,
-      "ipam": {
-        "type": "host-local",
-        "ranges": [
-          [{
-            "subnet": "10.88.0.0/16"
-          }],
-          [{
-            "subnet": "2001:4860:4860::/64"
-          }]
-        ],
-        "routes": [
-          { "dst": "0.0.0.0/0" },
-          { "dst": "::/0" }
-        ]
-      }
-    },
-    {
-      "type": "portmap",
-      "capabilities": {"portMappings": true}
-    }
-  ]
-}
-EOF
-```
+In order for containerd to use them, you need to create a `.conflist` file in `/etc/cni/net.d`. See [install-cni](https://github.com/containerd/containerd/blob/main/script/setup/install-cni) for a basic config.
 
 ### Option 2: From `apt-get` or `dnf`
 


### PR DESCRIPTION
Proposing a documentation addition.

## Scenario
I was installing a Kubernetes cluster from scratch on top of containerd, following the k8s wiki which links here.

Following the instructions here and at the [Kubernetes wiki](https://kubernetes.io/docs/setup/production-environment/container-runtimes/) produced a cluster that starts but cannot schedule pods, and cycles on "NetworkReady=False". Looking further there was another log message in container, "cni plugin not initialized". Reading through systemd and pod traces over, I eventually rootcaused it down to to the fact my containerd install was broken and the CNI extension code was cycling looking for /etc/cni/net.d.

> no network config found in /etc/cni/net.d

This seems to be a somewhat common misconfiguration.
https://github.com/search?q=%22no+network+config+found+in+%2Fetc%2Fcni%2Fnet.d%22&type=code

<img width="1263" alt="Screenshot 2025-03-15 at 2 48 53 AM" src="https://github.com/user-attachments/assets/c39c30be-0894-4d06-8ad3-3413c2232eb0" />


## Proposal
I think it would be a nice improvement to mention this directory and the install script in this wiki.

This PR is a first and naive attempt. I'm not sure what many of the options from the install-cni script do, and I know this wiki covers non-k8s scenarios as well.

Is this addition relevant enough to include? And can I get your help to make the proposed addition more precise?