### PR TITLE
Fix CI lint error

### DIFF
--- a/pkg/oci/spec_opts.go
+++ b/pkg/oci/spec_opts.go
@@ -595,13 +595,13 @@ func WithUser(userstr string) SpecOpts {
 		setProcess(s)
 		s.Process.User.AdditionalGids = nil
 		// While the Linux kernel allows the max UID to be MaxUint32 - 2,
-                // and the OCI Runtime Spec has no definition about the max UID,
-                // the runc implementation is known to require the UID to be <= MaxInt32.
-                //
-                // containerd follows runc's limitation here.
-                //
-                // In future we may relax this limitation to allow MaxUint32 - 2,
-                // or, amend the OCI Runtime Spec to codify the implementation limitation.
+		// and the OCI Runtime Spec has no definition about the max UID,
+		// the runc implementation is known to require the UID to be <= MaxInt32.
+		//
+		// containerd follows runc's limitation here.
+		//
+		// In future we may relax this limitation to allow MaxUint32 - 2,
+		// or, amend the OCI Runtime Spec to codify the implementation limitation.
 		const (
 			minUserID  = 0
 			maxUserID  = math.MaxInt32

--- a/pkg/oci/spec_opts_linux_test.go
+++ b/pkg/oci/spec_opts_linux_test.go
@@ -105,7 +105,6 @@ guest:x:100:guest
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.user, func(t *testing.T) {
 			t.Parallel()
 			s := Spec{


### PR DESCRIPTION
- duplicated by / closes https://github.com/containerd/containerd/pull/11559


https://github.com/containerd/containerd/actions/runs/13911860592/job/38927588065?pr=11554

```
  Error: pkg/oci/spec_opts_linux_test.go:108:3: The copy of the 'for' variable "testCase" can be deleted (Go 1.22+) (copyloopvar)
  		testCase := testCase
  		^
  Error: pkg/oci/spec_opts.go:598:1: File is not properly formatted (gofmt)
                  // and the OCI Runtime Spec has no definition about the max UID,
  ^
```