### PR TITLE
fix: check option['BinaryName'] for runtime absolute path

### DIFF
--- a/client/task_opts.go
+++ b/client/task_opts.go
@@ -50,6 +50,21 @@ func WithRuntimePath(absRuntimePath string) NewTaskOpts {
 	}
 }
 
+// WithRuntimeBinaryName will force task service to use a custom binary name
+func WithRuntimeBinaryName(absBinaryName string) NewTaskOpts {
+	return func(ctx context.Context, client *Client, info *TaskInfo) error {
+		if info.Options == nil {
+			info.Options = &options.Options{}
+		}
+		opts, ok := info.Options.(*options.Options)
+		if !ok {
+			return errors.New("invalid runtime v2 options format")
+		}
+		opts.BinaryName = absBinaryName
+		return nil
+	}
+}
+
 // WithTaskAPIEndpoint allow task service to manage a task through a given endpoint,
 // usually it is served inside a sandbox, and we can get it from sandbox status.
 func WithTaskAPIEndpoint(address string, version uint32) NewTaskOpts {

--- a/internal/cri/server/container_start.go
+++ b/internal/cri/server/container_start.go
@@ -201,6 +201,10 @@ func (c *criService) StartContainer(ctx context.Context, r *runtime.StartContain
 		taskOpts = append(taskOpts, containerd.WithRuntimePath(ociRuntime.Path))
 	}
 
+	if ociRuntime.Options["BinaryName"] != "" {
+		taskOpts = append(taskOpts, containerd.WithRuntimeBinaryName(ociRuntime.Options["BinaryName"].(string)))
+	}
+
 	// append endpoint to the options so that task manager can get task api endpoint directly
 	endpoint := sandbox.Endpoint
 	if endpoint.IsValid() {


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/34510#issuecomment-2731658868

> I0316 15:41:39.203539   26072 util.go:259] Event(v1.ObjectReference{Kind:"Pod", Namespace:"localstorage-quota-monitoring-test-8965", Name:"emptydir-concealed-disk-over-sizelimit-quotas-false-pod", UID:"bcafa216-1bf4-4ee7-8d1d-af225b9e2872", APIVersion:"v1", ResourceVersion:"3505", FieldPath:"spec.containers{emptydir-concealed-disk-over-sizelimit-quotas-false-container}"}): type: 'Warning' reason: 'Failed' Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: unable to retrieve OCI runtime error (open /run/containerd/io.containerd.runtime.v2.task/k8s.io/emptydir-concealed-disk-over-sizelimit-quotas-false-container/log.json: no such file or directory): exec: "runc": executable file not found in $PATH

When running pod with usernamespace enabled, there is a failure of runc not found like above.

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-cgroupv2-containerd-node-arm64-e2e-serial-ec2/1901281724340375552

This is a fix try: I am not sure if this is a proper way to check options[binaryname].

@fuweid 