### PR TITLE
cri:optimize the granularity of locks when update container resources

### DIFF
--- a/integration/container_update_linux_test.go
+++ b/integration/container_update_linux_test.go
@@ -1,0 +1,109 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/v2/integration/images"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+func TestCriContainerUpdate(t *testing.T) {
+	if f := os.Getenv("RUNC_FLAVOR"); f != "" && f != "runc" {
+		t.Skip("test requires runc")
+	}
+
+	workDir := t.TempDir()
+
+	t.Log("Prepare containerd config with volatile option")
+	cfgPath := filepath.Join(workDir, "config.toml")
+	err := os.WriteFile(
+		cfgPath,
+		[]byte(`
+version = 3
+
+      [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes]
+          [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc.options]
+            BinaryName = '/usr/local/bin/runc-fp'
+`),
+		0600)
+	require.NoError(t, err)
+
+	currentProc := newCtrdProc(t, "containerd", workDir, nil)
+	require.NoError(t, currentProc.isReady())
+	t.Cleanup(func() {
+		t.Log("Cleanup all the pods")
+		cleanupPods(t, currentProc.criRuntimeService(t))
+		t.Log("Stopping containerd process")
+		require.NoError(t, currentProc.kill(syscall.SIGTERM))
+		require.NoError(t, currentProc.wait(5*time.Minute))
+	})
+	cruntimeService := currentProc.criRuntimeService(t)
+
+	var testImage = images.Get(images.BusyBox)
+	pullImagesByCRI(t, currentProc.criImageService(t), testImage)
+
+	t.Log("Create a sandbox")
+	podCtx := newPodTCtx(t, currentProc.criRuntimeService(t), "sandbox-1", "sandbox")
+	cnID := podCtx.createContainer(
+		"container-1",
+		testImage,
+		runtime.ContainerState_CONTAINER_RUNNING,
+		WithCommand("sleep", "1d"),
+	)
+
+	failPoint := "/tmp/failpoint_profile.json"
+	err = os.WriteFile(
+		failPoint,
+		[]byte(`
+{
+  "failpoint": "delayUpdate"
+}
+`), 0600)
+	require.NoError(t, err)
+	defer func() {
+		os.Remove(failPoint)
+	}()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func(t *testing.T) {
+		t0 := time.Now()
+		cruntimeService.UpdateContainerResources(cnID, &runtime.LinuxContainerResources{
+			MemoryLimitInBytes: int64(256 * 1024 * 1024),
+		}, nil)
+		t.Logf("update container use %v", time.Since(t0))
+		wg.Done()
+	}(t)
+	// make sure go func running
+	time.Sleep(time.Millisecond * 500)
+	t1 := time.Now()
+	_, err = cruntimeService.ContainerStatus(cnID)
+	assert.NoError(t, err)
+	duration := time.Since(t1)
+	wg.Wait()
+	if duration > 1*time.Second {
+		t.Fatalf("get container  status use %v", duration)
+	}
+}

--- a/integration/failpoint/cmd/runc-fp/delayexec.go
+++ b/integration/failpoint/cmd/runc-fp/delayexec.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
@@ -49,6 +50,29 @@ func delayExec(ctx context.Context, method invoker) error {
 	if err := delay(); err != nil {
 		return err
 	}
+	if err := method(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func delayUpdate(ctx context.Context, method invoker) error {
+	isUpdate := strings.Contains(strings.Join(os.Args, ","), ",update,")
+	if !isUpdate {
+		if err := method(ctx); err != nil {
+			return err
+		}
+		return nil
+	}
+	logrus.Debug("UPDATE!")
+	time.Sleep(time.Second * 3)
+	if err := method(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func doNothing(ctx context.Context, method invoker) error {
 	if err := method(ctx); err != nil {
 		return err
 	}

--- a/internal/cri/server/container_update_resources.go
+++ b/internal/cri/server/container_update_resources.go
@@ -35,6 +35,24 @@ import (
 	ctrdutil "github.com/containerd/containerd/v2/internal/cri/util"
 )
 
+// updateResource prevent concurrent updates for the same container.
+func (c *criService) updateResource(ctx context.Context, container containerstore.Container, r *runtime.UpdateContainerResourcesRequest) error {
+	c.locker.Lock(r.GetContainerId())
+	defer c.locker.Unlock(r.GetContainerId())
+	newStatus, err := c.updateContainerResources(ctx, container, r, container.Status.Get())
+	if err != nil {
+		return fmt.Errorf("failed to update resources: %w", err)
+	}
+	update := func(status containerstore.Status) (containerstore.Status, error) {
+		return newStatus, nil
+	}
+	// Just update the container status' resources and ignore other fields.
+	if err := container.Status.UpdateResource(update); err != nil {
+		return err
+	}
+	return nil
+}
+
 // UpdateContainerResources updates ContainerConfig of the container.
 func (c *criService) UpdateContainerResources(ctx context.Context, r *runtime.UpdateContainerResourcesRequest) (retRes *runtime.UpdateContainerResourcesResponse, retErr error) {
 	container, err := c.containerStore.Get(r.GetContainerId())
@@ -61,10 +79,9 @@ func (c *criService) UpdateContainerResources(ctx context.Context, r *runtime.Up
 	// Update resources in status update transaction, so that:
 	// 1) There won't be race condition with container start.
 	// 2) There won't be concurrent resource update to the same container.
-	if err := container.Status.UpdateSync(func(status containerstore.Status) (containerstore.Status, error) {
-		return c.updateContainerResources(ctx, container, r, status)
-	}); err != nil {
-		return nil, fmt.Errorf("failed to update resources: %w", err)
+	err = c.updateResource(ctx, container, r)
+	if err != nil {
+		return nil, err
 	}
 
 	err = c.nri.PostUpdateContainerResources(ctx, &sandbox, &container)

--- a/internal/cri/server/service.go
+++ b/internal/cri/server/service.go
@@ -57,6 +57,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/oci"
 	osinterface "github.com/containerd/containerd/v2/pkg/os"
 	"github.com/containerd/containerd/v2/plugins"
+	"github.com/moby/locker"
 )
 
 var kernelSupportsRRO bool
@@ -169,6 +170,7 @@ type criService struct {
 	runtimeFeatures *runtime.RuntimeFeatures
 	// statsCollector collects CPU stats in background for UsageNanoCores calculation
 	statsCollector *StatsCollector
+	locker         *locker.Locker
 }
 
 type CRIServiceOptions struct {
@@ -214,6 +216,7 @@ func NewCRIService(options *CRIServiceOptions) (CRIService, runtime.RuntimeServi
 		sandboxService:     newCriSandboxService(&config, options.SandboxControllers),
 		runtimeHandlers:    make(map[string]*runtime.RuntimeHandler),
 		statsCollector:     statsCollector,
+		locker:             locker.New(),
 	}
 
 	// TODO: Make discard time configurable

--- a/internal/cri/store/container/fake_status.go
+++ b/internal/cri/store/container/fake_status.go
@@ -57,6 +57,18 @@ func (f *fakeStatusStorage) Update(u UpdateFunc) error {
 	return nil
 }
 
+// Update the container resources.
+func (f *fakeStatusStorage) UpdateResource(u UpdateFunc) error {
+	f.Lock()
+	defer f.Unlock()
+	newStatus, err := u(f.status)
+	if err != nil {
+		return err
+	}
+	f.status.Resources = newStatus.Resources
+	return nil
+}
+
 func (f *fakeStatusStorage) Delete() error {
 	return nil
 }

--- a/internal/cri/store/container/status.go
+++ b/internal/cri/store/container/status.go
@@ -97,7 +97,8 @@ type Status struct {
 	// This field doesn't need to be checkpointed.
 	Unknown bool `json:"-"`
 	// Resources has container runtime resource constraints
-	Resources *runtime.ContainerResources
+	// This field doesn't need to be checkpointed.
+	Resources *runtime.ContainerResources `json:"-"`
 	// Restore marks this container as a container to be restored from a
 	// checkpoint and not started.
 	Restore bool
@@ -157,6 +158,9 @@ type StatusStorage interface {
 	// Update the container status. Note that the update MUST be applied
 	// in one transaction.
 	Update(UpdateFunc) error
+	// Update the container resources. Note that the update MUST be applied
+	// in one transaction.
+	UpdateResource(UpdateFunc) error
 	// Delete the container status.
 	// Note:
 	// * Delete should be idempotent.
@@ -298,6 +302,18 @@ func (s *statusStorage) Update(u UpdateFunc) error {
 		return err
 	}
 	s.status = newStatus
+	return nil
+}
+
+// Update the container resources.
+func (s *statusStorage) UpdateResource(u UpdateFunc) error {
+	s.Lock()
+	defer s.Unlock()
+	newStatus, err := u(s.status)
+	if err != nil {
+		return err
+	}
+	s.status.Resources = newStatus.Resources
 	return nil
 }
 


### PR DESCRIPTION
try to fix fix:https://github.com/containerd/containerd/issues/9770  and https://github.com/containerd/containerd/discussions/11488

root reason:
when update container resources will call runc --update sometimes may use long time when system is busy.
during this time will hold a statusStorage lock (s.Lock()), so it is necessary let func c.updateContainerResources don't hold the   lock.

```
	if err := container.Status.UpdateSync(func(status containerstore.Status) (containerstore.Status, error) {
		return c.updateContainerResources(ctx, container, r, status)
	}); err != nil {
		return nil, fmt.Errorf("failed to update resources: %w", err)
	}

```

```
func (s *statusStorage) UpdateSync(u UpdateFunc) error {
	s.Lock()
	defer s.Unlock()
	newStatus, err := u(s.status)
	if err != nil {
		return err
	}
	data, err := newStatus.encode()
	if err != nil {
		return fmt.Errorf("failed to encode status: %w", err)
	}
	if err := continuity.AtomicWriteFile(s.path, data, 0600); err != nil {
		return fmt.Errorf("failed to checkpoint status to %q: %w", s.path, err)
	}
	s.status = newStatus
	return nil
}
```
what I did:
1.skip save resources into checkpoint (status) file. so we don't need  use updateSync to save status'  resources into checkpoint file.
2.add a safeUpdate func  to prevent concurrent updates for the same container.
3.reduce the holding time of locks
```
	update := func(status containerstore.Status) (containerstore.Status, error) {
		return newStatus, nil
	}
	if err := container.Status.Update(update); err != nil {
		return err
	}
```

@mikebrow  @fuweid @mxpv  @djdongjin 