### PR TITLE
[KEP-4639] Support image volume mount subpath

### DIFF
--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -353,11 +353,11 @@ func WithIDMapVolumeMount(hostPath, containerPath string, uidMaps, gidMaps []*ru
 	}
 }
 
-func WithImageVolumeMount(image, containerPath string) ContainerOpts {
-	return WithIDMapImageVolumeMount(image, containerPath, nil, nil)
+func WithImageVolumeMount(image, imageSubPath, containerPath string) ContainerOpts {
+	return WithIDMapImageVolumeMount(image, imageSubPath, containerPath, nil, nil)
 }
 
-func WithIDMapImageVolumeMount(image string, containerPath string, uidMaps, gidMaps []*runtime.IDMapping) ContainerOpts {
+func WithIDMapImageVolumeMount(image, imageSubPath, containerPath string, uidMaps, gidMaps []*runtime.IDMapping) ContainerOpts {
 	return func(c *runtime.ContainerConfig) {
 		containerPath, _ = filepath.Abs(containerPath)
 		mount := &runtime.Mount{
@@ -367,6 +367,7 @@ func WithIDMapImageVolumeMount(image string, containerPath string, uidMaps, gidM
 			Image: &runtime.ImageSpec{
 				Image: image,
 			},
+			ImageSubPath:   imageSubPath,
 			Readonly:       true,
 			SelinuxRelabel: true,
 		}


### PR DESCRIPTION
Following up https://github.com/containerd/containerd/pull/10579, this PR adds the [`subpath`](https://kubernetes.io/docs/concepts/storage/volumes/#using-subpath) support for image volume mount.

Fix #11580

As discussed in https://github.com/containerd/containerd/pull/11533#issuecomment-2722862811, we don't want to bump up to go 1.24 in containerd 2.1, so it PR may not be merged before 2.1. But want to share it early so I can get some early feedback and iterate. :)