### PR TITLE
runc-shim: add TLA+ spec!

### DIFF
--- a/cmd/containerd-shim-runc-v2/spec/.gitignore
+++ b/cmd/containerd-shim-runc-v2/spec/.gitignore
@@ -1,0 +1,3 @@
+.metadir
+states/
+*.out

--- a/cmd/containerd-shim-runc-v2/spec/Environment.tla
+++ b/cmd/containerd-shim-runc-v2/spec/Environment.tla
@@ -1,0 +1,194 @@
+-------------------------------- MODULE Environment --------------------------------
+
+EXTENDS Integers, FiniteSets, Sequences, Naturals, TLC, Types
+
+
+--------------------------------- MODULE User ---------------------------------
+\* Actions performed by the user
+
+LOCAL TasksToStart ==
+    TaskID \ { t.id : t \in tasks }
+
+LOCAL HaveReceivedInitExit ==
+    /\ Len(SelectSeq(events, 
+        LAMBDA e: e.type = taskExit /\ e.pid = 1 )) # 0
+
+CreateInitTask ==
+    /\ { t \in tasks: t.type = init } = { }
+    /\ \E tsk \in TasksToStart :
+        /\ AddTask(NewTask(tsk, init, unstarted))
+
+CreateExecTask == 
+    /\ { t \in tasks: t.type = init } # { }
+    /\ ~HaveReceivedInitExit
+    /\ \E tsk \in TasksToStart :
+        /\ AddTask(NewTask(tsk, exec, unstarted))
+
+User ==
+    /\ UNCHANGED << exits, events, processes >>
+    /\  \/ CreateInitTask
+        \/ CreateExecTask
+
+=============================================================================
+
+
+------------------------------- MODULE Kernel -------------------------------
+\* Actions performed by the kernel
+
+(* RunProcess picks up a process in `processes' whose state is `starting' and
+    runs it. The process is either successfully started - and has a pid assigned
+    to it - or fails to start, and gets updated to the `failed' state.
+    This allows the shim to finish handling this process's start *)
+RunProcess ==
+    /\ UNCHANGED exits
+    /\ { p \in processes : p.type = init /\ (p.state = reaped \/ p.state = exited) } = { }
+    /\ \E p \in { q \in processes: q.state = starting } :
+        /\  LET pid == NewPid
+            IN \* process starts successfully, gets a pid
+               \/ UpdateProcesses(p :> [ id |-> p.id, state |-> running, pid |-> pid, type |-> p.type ])
+               \* process fails to start
+               \/ UpdateProcesses(p :> [ p EXCEPT !.state = failed ])
+
+(* A process might fail to start. This is guaranteed to happen if 
+    the process was added after the init process exited, or if it's added concurrently. *)
+RejectProcessStart ==
+    /\ UNCHANGED exits
+    /\ { p \in processes : p.type = init /\ (p.state = reaped \/ p.state = exited) } # { }
+    /\ \E p \in { q \in processes: q.state = starting } :
+        \* start the process, and update the shim start with a pid
+        /\ UpdateProcesses(p :> [ p EXCEPT !.state = failed ])
+
+(* Reap processes that have exited. In a given namespace, the init pid will
+    always be reaped last. *)
+ReapProcesses ==
+    /\ ExitedProcesses # { }
+    /\  IF Processes(exited, exec) # { } THEN
+            /\ \E processToExit \in Processes(exited, exec) : 
+                    /\ AddExit(processToExit.pid)
+                    /\ UpdateProcesses(processToExit :> [processToExit EXCEPT !.state = reaped])
+        ELSE
+            /\  \E processToExit \in ExitedProcesses :
+                    /\ AddExit(processToExit.pid)
+                    /\ UpdateProcesses(processToExit :> [processToExit EXCEPT !.state = reaped])
+
+(* Tear down the pid namespace - all processes in this 
+    namespace will exit, and processes starting concurrently will fail. *)
+TeardownNamespace ==
+    /\ UNCHANGED exits
+    /\ Processes(exited, init) # { }
+    /\ { p \in processes : p.state = running \/ p.state = starting } # { }
+    /\ UpdateProcesses([p \in { q \in processes : q.state # reaped /\ q.state # failed } |-> 
+                            IF p.state # starting THEN
+                                [p EXCEPT !.state = exited] 
+                            ELSE
+                                [p EXCEPT !.state = failed]
+                        ])
+                            
+(* If an init process has exited and there
+    are running execs, the pid ns needs to be torn down. *)
+ShouldTeardown ==
+    /\ Processes(exited, init) # { }
+    /\ { p \in processes : p.type = exec /\ (p.state = running \/ p.state = starting) } # { }
+
+(* Tearing down a namespace needs to happen immediately after an init process exits.
+    Otherwise, reap dead processes. *)
+Kernel ==
+    /\ UNCHANGED << tasks, events >>
+    /\ IF ShouldTeardown THEN
+            /\ TeardownNamespace
+        ELSE
+            \/ ReapProcesses
+            \/ RunProcess
+            \/ RejectProcessStart
+
+=============================================================================
+
+
+-------------------------------------------------------------------------------
+\* The System
+
+INSTANCE Kernel
+INSTANCE User 
+
+\* At any step in the system, a process might exit.
+ProcessDies ==
+    /\ UNCHANGED << exits, tasks, events >>
+    /\ \E p \in RunningProcesses :
+            \/ UpdateProcesses(p :> [p EXCEPT !.state = exited])
+
+Environment ==
+    \/ User
+    \/ Kernel
+    \/ ProcessDies
+
+
+-------------------------------------------------------------------------------
+\* Invariants
+
+(* Invariant that events are never published out-of-order, i.e. a 
+    TaskExit before a TaskStart (for the same pid). *)
+ShimEventsNoStartBeforeExit ==
+    \A i, j \in 1..Len(events): 
+        i < j /\ events[i].pid = events[j].pid => 
+            events[i].type = taskStart /\ events[j].type = taskExit
+
+(* Invariant that if an init process has been reaped, no other processes are
+    are running. *)
+KernelProcessesInit ==
+    Cardinality({ p \in processes : p.state = reaped /\ p.type = init }) = 1 =>
+        \A q \in processes: 
+            /\ q.state # running 
+
+(* Invariant that, for every task in the `exited' state, there will be two
+    (ordered) events - a `TaskStart' and `TaskExit' event. *)
+ExitForEveryTask == 
+    \A task \in {t \in tasks: t.state = exited}:
+        \E p \in processes:
+            /\ p.id = task.id
+            /\ \E i, j \in 1..Len(events):
+                /\ events[i].pid = p.pid /\ events[i].type = taskStart
+                /\ events[j].pid = p.pid /\ events[j].type = taskExit
+
+Invariants ==
+    /\ ShimEventsNoStartBeforeExit
+    /\ KernelProcessesInit
+    /\ ExitForEveryTask
+
+-------------------------------------------------------------------------------
+\* Temporal Properties
+
+(*  We're most interested in making assertions about the behaviour of the shim over time, that
+    is, we want to verify statements such as "eventually, the shim will publish all exit events".
+
+    In TLA+, these are so-called "Temporal Properties", and we define them using the following
+    operators:
+    
+        `P~>Q' - meaning that every state which satisfies P "leads to" a state that satisfies Q 
+            (this can be the same state, or a future state).
+
+        `[]P' - meaning "always" P, i.e. for a behavior, every state will satisfy P.
+        `<>P' - meaning "eventually" P, i.e. for a behavior, at least one state will satisfy P.
+    
+    We can use these last two together, to assert:
+
+        `[]<>P' - meaning "always, eventually" P, i.e. for a behavior, every state either satisfies P
+    or a future state will satisfy P, and
+
+        `<>[]P' - meaning "eventually, always" P, i.e. for a behavior, eventually a state will satisfy P
+    and every state thereafter that will satisfy P.  *)
+
+(* Predicate that the init task is in the `failed' state. *)
+InitFailed ==
+    Cardinality({t \in tasks: t.state = failed /\ t.type = init }) # 0
+
+(* Predicate that there is at least one event, and the last event published is
+    a `TaskExit' event for the init pid. *)
+InitExitPublishedLast ==
+    /\ Len(events) > 0
+    /\ events[Len(events)].pid = 1 /\ events[Len(events)].type = taskExit
+
+InitExitAlwaysPublished ==
+    \/ <>[]InitFailed               \* either the init task is eventually-always in the failed state, or
+    \/ <>[]InitExitPublishedLast    \* the last event published is eventually-always a `TaskExit' for the init task
+
+=============================================================================

--- a/cmd/containerd-shim-runc-v2/spec/Makefile
+++ b/cmd/containerd-shim-runc-v2/spec/Makefile
@@ -1,0 +1,18 @@
+WORKERS := 4
+
+TLA := docker run --rm -it --workdir /mnt -v ${PWD}:/mnt talex5/tla
+
+.PHONY: all check pdfs
+
+all: check pdfs
+
+# Run the TLC model checker
+check:
+	${TLA} tlc -workers ${WORKERS} Shim.tla -config Shim.cfg
+
+# Generate a PDF file from a .tla file
+%.pdf: %.tla
+	[ -d .metadir ] || mkdir .metadir
+	${TLA} java tla2tex.TLA -shade -latexCommand pdflatex -latexOutputExt pdf -metadir .metadir $<
+
+pdfs: Shim.pdf Environment.pdf Types.pdf 

--- a/cmd/containerd-shim-runc-v2/spec/Shim.cfg
+++ b/cmd/containerd-shim-runc-v2/spec/Shim.cfg
@@ -1,0 +1,10 @@
+SPECIFICATION Spec
+
+CONSTANT TaskID = { t1, t2, t3 }
+
+INVARIANTS
+    EnvironmentInvariants
+    TypeOK
+
+PROPERTIES
+    InitExitAlwaysPublished

--- a/cmd/containerd-shim-runc-v2/spec/Shim.tla
+++ b/cmd/containerd-shim-runc-v2/spec/Shim.tla
@@ -1,0 +1,249 @@
+---------------------------- MODULE Shim ----------------------------------
+
+EXTENDS FiniteSets, Naturals, Sequences, TLC, Types
+
+
+-------------------------------------------------------------------------------
+\* Utils for managing the shim's state
+
+VARIABLE shimState
+
+AddRunning(shim, pid) == [ shim EXCEPT 
+        !.running = shim.running \cup { pid }
+    ]
+
+RemoveRunning(shim, pid) == [ shim EXCEPT 
+        !.running = shim.running \ { pid }
+    ]
+
+AddSubscriber(shim, id) == [ shim EXCEPT 
+        !.exitSubscribers = shim.exitSubscribers \cup { [ id |-> id, exits |-> {} ] } 
+    ]
+
+RemoveSubscriber(shim, id) == [ shim EXCEPT 
+        !.exitSubscribers = { s \in shim.exitSubscribers : s.id # id }
+    ]
+
+BroadcastExit(shim, exitPid) == [ shim EXCEPT 
+        !.exitSubscribers = { [ s EXCEPT !.exits = s.exits \cup { exitPid }  ] : s \in shim.exitSubscribers }
+    ]
+
+AddStartingProcess(shim, id) == [ shim EXCEPT 
+        !.startingProcesses = shim.startingProcesses \cup { id }
+    ]
+
+RemoveStartingProcess(shim, id) == [ shim EXCEPT
+        !.startingProcesses = { t \in shim.startingProcesses : t # id }
+    ]
+
+StartNewTask(shim, taskId) ==
+    AddSubscriber(AddStartingProcess(shim, taskId), taskId)
+
+IncPendingExecs(shim) == [ shim EXCEPT 
+        !.pendingExecs = shim.pendingExecs+1
+    ]
+
+DecPendingExecs(shim) == [ shim EXCEPT 
+        !.pendingExecs = shim.pendingExecs-1
+    ]
+-------------------------------------------------------------------------------
+
+
+------------------------------- MODULE RuncShim -------------------------------
+\* Actions performed by the Shim
+
+InitStart ==
+    /\ UNCHANGED << events, exits >>
+    /\ \E task \in { t \in tasks : t.type = init /\ t.state = unstarted } :
+        /\ UpdateTasks(task :> [task EXCEPT !.state = starting])
+        /\ AddProcess(NewProcess(task.id, init))
+        /\ shimState' = StartNewTask(shimState, task.id)
+
+(* Start a new exec. Concurrent starts are modelled in this specification by adding
+    starting tasks to `startingProcesses', and separately picking up `starting' 
+    threads -after they have a pid/have failed to start- and processing them in
+    `handleStarted',with no ordering guarantee. 
+    This matches the behaviour in the shim, since there is no lock enforcing ordered
+    processing of concurrent starts. *)
+ExecStart ==
+    /\ UNCHANGED << events, exits >>
+    /\ { t \in tasks : t.type = init /\ t.state = running } # { }
+    /\ \E tsk \in { t \in tasks : t.state = unstarted } :
+        /\ UpdateTasks(tsk :> [tsk EXCEPT !.state = starting])
+        /\ AddProcess(NewProcess(tsk.id, exec))
+        /\ shimState' = StartNewTask(IncPendingExecs(shimState), tsk.id)
+
+(* After a process has started, it either:
+    - failed to start, in which case we update `tasks' 
+    - succeeded, in which case the shim publishes a `TaskStart' event, and checks
+        the `exitSubscriber' for exits: 
+        - if there is an exit for it's pid, we publish a `TaskExit' event, and, don't add it to `running'.
+        - if there isn't, we add it to `running'.
+    In all cases, we remove it's subscriber from `exitSubscribers' *)
+HandleStarted(startingProcess) == 
+    /\ UNCHANGED << processes, exits >>
+    /\  LET process == CHOOSE p \in processes : p.id = startingProcess
+            task == CHOOSE t \in tasks : t.id = startingProcess
+        IN
+            IF task.type = init THEN
+                /\ \E subscriber \in { s \in shimState.exitSubscribers : s.id = process.id }:
+                    /\  IF process.state = failed
+                        THEN \* process failed to start
+                            /\ UNCHANGED events
+                            /\ shimState' = RemoveStartingProcess(
+                                RemoveSubscriber(shimState, process.id), process.id)
+                            /\ UpdateTasks(task :> [task EXCEPT !.state = failed])
+                        ELSE \* start was successful and we have a pid
+                            /\  IF Cardinality({ exit \in subscriber.exits : exit = process.pid }) > 0
+                                THEN \* we received an exit in the meantime for this pid
+                                    /\ PublishEvents(<<NewEvent(process.pid, taskStart), NewEvent(process.pid, taskExit)>>)
+                                    /\ shimState' = RemoveStartingProcess(
+                                        RemoveSubscriber(shimState, process.id), process.id)
+                                    /\ UpdateTasks(task :> [task EXCEPT !.state = exited ])
+                                ELSE \* no exit received, add to running
+                                    /\ PublishEvents(<<NewEvent(process.pid, taskStart)>>)
+                                    /\ shimState' = RemoveStartingProcess(
+                                            RemoveSubscriber(AddRunning(shimState, process.pid), process.id), process.id)
+                                    /\ UpdateTasks(task :> [task EXCEPT !.state = running ])
+            ELSE 
+                /\  LET newShimState == DecPendingExecs(shimState)
+                    IN  /\ \E subscriber \in { s \in shimState.exitSubscribers : s.id = process.id }:
+                            /\  IF process.state = failed
+                                THEN \* process failed to start
+                                    /\ shimState' = RemoveStartingProcess(
+                                        RemoveSubscriber(newShimState, process.id), process.id)
+                                    /\ UpdateTasks(task :> [task EXCEPT !.state = failed])
+                                    /\  IF Cardinality({ exit \in subscriber.exits : exit = 1}) # 0 /\ shimState.pendingExecs = 1 
+                                        THEN /\ PublishEvents(<<NewEvent(1, taskExit)>>)
+                                        ELSE /\ UNCHANGED events
+                                ELSE \* start was successful and we have a pid
+                                    /\  IF Cardinality({ exit \in subscriber.exits : exit = process.pid }) > 0
+                                        THEN \* we received an exit in the meantime for this pid
+                                            /\  IF Cardinality({ exit \in subscriber.exits : exit = 1}) # 0 /\ shimState.pendingExecs = 1 THEN
+                                                    /\ PublishEvents(<<
+                                                        NewEvent(process.pid, taskStart), 
+                                                        NewEvent(process.pid, taskExit),
+                                                        NewEvent(1, taskExit)>>)
+                                                ELSE
+                                                    /\ PublishEvents(<<NewEvent(process.pid, taskStart), NewEvent(process.pid, taskExit)>>)
+                                            /\ shimState' = RemoveStartingProcess(RemoveSubscriber(shimState, process.id), process.id)
+                                            /\ UpdateTasks(task :> [task EXCEPT !.state = exited ])
+                                        ELSE \* no exit received, add to running
+                                            /\ PublishEvents(<<NewEvent(process.pid, taskStart)>>)
+                                            /\ shimState' = RemoveStartingProcess(RemoveSubscriber(
+                                                AddRunning(newShimState, process.pid), process.id), process.id)
+                                            /\ UpdateTasks(task :> [task EXCEPT !.state = running ])
+
+HandleProcessExit(exit, task) ==
+    /\ UpdateTasks(task :> [ task EXCEPT !.state = exited ])
+    /\ PublishEvents(<<NewEvent(exit, taskExit)>>)
+
+HandleExit(exit) ==
+    /\ UNCHANGED << processes >>
+    /\  IF { p \in shimState.running : p = exit } = { } THEN
+            /\ UNCHANGED << events, tasks >>
+            /\ shimState' = BroadcastExit(shimState, exit)
+        ELSE 
+            \E p \in { q \in processes : q.pid = exit }:
+                    \E tsk \in { q \in tasks: q.id = p.id }:
+                        IF tsk.type = exec THEN
+                            /\ shimState' = BroadcastExit(RemoveRunning(shimState, exit), exit)
+                            /\ HandleProcessExit(exit, tsk)
+                        ELSE
+                            /\ IF shimState.pendingExecs = 0 THEN
+                                    /\ shimState' = BroadcastExit(
+                                        RemoveRunning(shimState, exit), exit)
+                                    /\ HandleProcessExit(exit, tsk)
+                                ELSE
+                                    /\ UNCHANGED << events, tasks >>
+                                    /\ shimState' = BroadcastExit(RemoveRunning(
+                                        shimState, exit), exit)
+
+\* Processes that have been started, and we can now call `HandleStarted' for:
+LOCAL startedProcesses ==
+    { p.id : p \in { q \in processes: q.state # starting}} 
+        \intersect shimState.startingProcesses
+
+\* Whenever the shim steps, it might do either of these:
+ShimService == 
+    \/ InitStart
+    \/ ExecStart
+    \/ \E startingProcess \in startedProcesses:
+        /\ HandleStarted(startingProcess)
+    \/ NextExit(HandleExit)
+
+
+=============================================================================
+
+Shim == INSTANCE RuncShim 
+
+(* A model of the rest of the system (kernel, user, etc.) *)
+Environment == INSTANCE Environment
+
+(* We could alias
+       Env == Environment!Env /\ UNCHANGED shimState
+   but that causes TLC to report all issues with it
+   as `Env' issues. This provides better diagnostics: *)
+EnvTLC ==
+  \/ (Environment!User          /\ UNCHANGED shimState)
+  \/ (Environment!Kernel        /\ UNCHANGED shimState)
+  \/ (Environment!ProcessDies   /\ UNCHANGED shimState)
+
+-------------------------------------------------------------------------------
+\* A complete system
+
+vars == << processes, exits, tasks, events, shimState >>
+
+Init ==
+  /\ processes = {}
+  /\ exits = <<>>
+  /\ tasks = {}
+  /\ events = <<>>
+  /\ shimState = [ 
+        running |-> {},
+        startingProcesses |-> {},
+        exitSubscribers |-> {},
+        pendingExecs |-> 0
+    ]
+
+Next ==
+    \/  \/ EnvTLC               \* Either the environment steps, or
+        \/ Shim!ShimService     \* the shim steps
+    \/  UNCHANGED vars
+
+(* The specification for our shim. This looks like any other property we would want to verify -
+    the difference being that contraints defined in the specification define what counts as a 
+    valid trace, i.e. how our system is allowed to behave.  On the other hand, invariants/properties
+    define constraints that we expect to follow if our system behaves as described in the specification. *)
+Spec == 
+    /\ Init                 \* Valid initial states
+    /\ [][Next]_vars        \* every action should satisfy Next
+    (* Some actions are required to happen eventually. For example, a behaviour in
+       which the shim stops doing anything forever, even though it could advance 
+       some task from the `unstarted' state, isn't a valid behaviour of the system.
+       This property is called `weak fairness'. *)
+    /\ WF_vars(Shim!ShimService)
+    /\ WF_vars(Environment!Kernel /\ UNCHANGED << tasks, events, shimState >>)
+    (* We do not require fairness of:
+       - `User' (we don't control them),
+       - `ProcessDies' (we don't know if/when a process will exit) *)
+
+-------------------------------------------------------------------------------
+\* Properties to verify
+
+(* These are properties that should follow automatically if the system behaves as
+   described by `Spec' in the previous section. They can be verified by TLC by
+   configuring the `INVARIANTS' section of Shim.cfg *)
+
+\* Import this definition from the Enviromment module:
+EnvironmentInvariants == Environment!Invariants 
+
+InitExitAlwaysPublished == 
+    (* Either `ProcessDies' is eventually-always enabled, i.e. processes are running forever *)
+    \/ []<>ENABLED <<Environment!ProcessDies /\ UNCHANGED shimState>>_vars      
+    (* Or `User' is eventually-always enabled, i.e. the user won't run all the tasks *)
+    \/ []<>ENABLED <<Environment!User /\ UNCHANGED shimState>>_vars     
+    (* Or the init exit is eventually published *)
+    \/ Environment!InitExitAlwaysPublished       
+
+=============================================================================

--- a/cmd/containerd-shim-runc-v2/spec/Types.tla
+++ b/cmd/containerd-shim-runc-v2/spec/Types.tla
@@ -1,0 +1,193 @@
+------------------------------ MODULE Types ------------------------------
+
+EXTENDS Integers, FiniteSets, Naturals, Sequences, TLC
+
+CONSTANT TaskID
+
+-------------------------------------------------------------------------------
+\* Processes
+
+VARIABLE processes
+
+unstarted == "unstarted"
+starting == "starting"
+running == "running"
+exited == "exited"
+failed == "failed"
+reaped == "reaped"
+
+(* Every state has a rank. It is only possible for a task to change
+   state to a state with a higher rank (later in this sequence). *)
+states == << unstarted, starting, running, exited, failed, reaped >>
+
+(* Maps a state to its position in `order' (e.g. StateRank(new) = 1): *)
+StateRank(s) == CHOOSE i \in DOMAIN states : states[i] = s
+
+(* Convenient notation for comparing states: *)
+s1 \prec s2   == StateRank(s1) < StateRank(s2)
+s1 \preceq s2 == StateRank(s1) <= StateRank(s2)
+
+(* A generic operator to get the range of a function (the set of values in a map): *)
+Range(S) == { S[i] : i \in DOMAIN S }
+
+(* The set of possible states ({unstarted, starting, ...}): *)
+ProcessState == Range(states)
+
+init == "init"
+exec == "exec"
+
+ProcessTypes == {
+    init,
+    exec
+} 
+
+Process == [
+    id : TaskID,
+    pid : Int,
+    state : ProcessState,
+    type : ProcessTypes
+]
+
+RunningProcesses == { p \in processes : p.state = running }
+ExitedProcesses == { p \in processes : p.state = exited }
+
+pids == {p.pid : p \in processes}
+
+Processes(state, type) == { p \in processes : p.state = state /\ p.type = type }
+
+NewPid ==
+    CHOOSE n \in 1..100 : n \notin pids
+
+NewProcess(id, type) == 
+    [   id |-> id,
+        pid |-> -1,
+        state |-> starting,
+        type |-> type ]
+
+AddProcess(p) ==
+    /\ Assert(p.id \notin { o.id : o \in processes}, "process with this pid already exists")
+    /\ Assert(p \in Process, "does not satisfy the Process type invariant")
+    /\ processes' = processes \cup { p }
+
+(* Update `processes' by performing each update in `f', which is a function
+   mapping old processes to new ones. *)
+UpdateProcesses(f) ==
+    /\ Assert(\A p \in DOMAIN f : p \in processes, "An old process does not exist!")
+    /\ Assert(\A p \in DOMAIN f :
+                LET p2 == f[p]
+                IN                                  \* The updated version of `p' must have
+                /\ p.id      = p2.id,               \* the same process ID
+            "An update changes a task's identity!")
+    /\ Assert(\A p \in DOMAIN f :
+                LET p2 == f[p]
+                IN                                  \* The updated date version of `p' must represent
+                /\ p.state \preceq p2.state,        \* a valid state transition
+            "An update does an invalid process state transition!")
+  \* Remove all the old processes and add the new ones:
+  /\ processes' = (processes \ DOMAIN f) \union Range(f)
+
+
+-------------------------------------------------------------------------------
+\* Tasks
+
+VARIABLE tasks
+
+Task == [
+    id: TaskID,
+    type: ProcessTypes,
+    state: ProcessState
+]
+
+NewTask(id, type, state) == 
+    [ 
+        id |-> id,
+        type |-> type,
+        state |-> state
+    ]
+
+AddTask(t) ==
+    /\ Assert(t.id \notin { r.id : r \in tasks}, "task with this id already exists")
+    /\ Assert(t \in Task, "does not satisfy the Task type invariant")
+    /\ tasks' = tasks \cup { t }
+
+(* Update `tasks' by performing each update in `f', which is a function
+   mapping old tasks to new ones. *)
+UpdateTasks(f) ==
+    /\ Assert(\A t \in DOMAIN f : t \in tasks, "task to update does not exist")
+    /\ Assert(\A t \in Range(f) : t \in Task, "an updated task does not satisfy the Task type invariant")
+    /\ Assert(\A t \in DOMAIN f :
+                LET t2 == f[t]
+                IN                          \* The updated version of `t' must have
+                /\ t.id      = t2.id        \* the same task ID, and
+                /\ t.type = t2.type,        \* the same task type.
+            "an update changes a task's identity")
+  \* Remove all the old tasks and add the new ones:
+  /\ tasks' = (tasks \ DOMAIN f) \union Range(f)
+
+
+-------------------------------------------------------------------------------
+\* Exits
+
+VARIABLE exits
+
+Exit == Nat
+
+AddExit(exit) ==
+    /\ Assert(exit \in Exit, "does not satisfy Exit type invariant")
+    /\ exits' = Append(exits, exit)
+
+NextExit(f(_)) ==
+    /\ Len(exits) > 0
+    /\ LET exit == Head(exits)
+        IN 
+            /\ f(exit) 
+            /\ exits' = Tail(exits)
+
+
+-------------------------------------------------------------------------------
+\* Events
+
+(* TODO:
+        - TaskCreate
+        - TaskExecStarted
+        - TaskExecAdded *)
+
+VARIABLE events
+
+taskStart == "taskStart"
+taskExit == "taskExit"
+
+eventTypes == << taskStart, taskExit >>
+
+(* Maps a state to its position in `order` (e.g. StateRank(new) = 1): *)
+TypeRank(s) == CHOOSE i \in DOMAIN eventTypes : eventTypes[i] = s
+
+(* The set of possible event types ({taskStart, taskExit, ...}): *)
+EventType == Range(eventTypes)
+
+Event == [
+    pid : Nat,
+    type : EventType
+]
+
+NewEvent(pid, type) == [
+    pid |-> pid,
+    type |-> type
+]
+
+PublishEvents(es) ==
+  /\ Assert(\A i \in 1..Len(es) : es[i] \in Event, "An event is not an event!")
+  /\ events' = events \o es
+
+-------------------------------------------------------------------------------
+\* Invariants
+
+TypeOK ==
+    /\ tasks \in SUBSET Task
+    /\ processes \in SUBSET Process
+    /\ \A i \in 1..Len(events):
+        events[i] \in Event
+    /\ \A i \in 1..Len(exits):
+        exits[i] \in Exit
+
+=============================================================================


### PR DESCRIPTION
**TLDR**: Following up on some of the runc-shim-related-shenanigans – see: [all](https://github.com/containerd/containerd/issues/9719) [of](https://github.com/containerd/containerd/pull/8617) [these](https://github.com/containerd/containerd/issues/10589) [issues](https://github.com/containerd/containerd/pull/10651) - and some conversations with folks (thanks @corhere, @samuelkarp, and others!) - I decided to model the runc-shim's concurrency system in a [TLA+](https://lamport.azurewebsites.net/tla/tla.html) specification!

----------------------

### Context:

After identifying a performance issue in the shim's exit processing logic, we made substantial changes (in 5cd6210ad055ec3a0fc263fdde382191c52c40ce) to reduce lock contention between the exit processing/task start logic (the root cause of these performance issues). In effect, this was a tradeoff between performance and complexity - the initial code, while unable to handle concurrent execs, was easy to understand+verify it's correctness, while it's replacement requires keeping track of running pids, subscribing to exits, etc.

Since then, we've ran into a few issues introduced by the new code - 

### What I did:

Taking a lot of inspiration from the work done on [SwarmKit](https://github.com/moby/swarmkit/blob/8c19597365549f6966a5021d2ea46810099aae28/design/tla/SwarmKit.tla), I wrote a TLA+ model for the new shim logic, which can be used to verify it behaves as expected, and that there's no set of steps that would lead us to violate one of our invariants (such as [this one](https://github.com/containerd/containerd/issues/10589), caused by allowing execs to "start" after we've received an exit for the init pid).

The Spec is split into an `Environment` module, which models actions external to the shim, and a `Shim` module that contains all the shim-specific state and logic. This also (hopefully) makes it easy to expand/reuse for other shims, since other modules could be added and import the shared parts. It also includes some simple invariants/properties to check, and some basic instructions on configuring the TLC to check these properties.

**This is a work in progress** : there's plenty of work to do still - currently, the specification does not model shared pid-ns usecases, and likely misses other possible issues.

### Instructions:

- `make check` runs the model checker
- `make pdfs` generates LaTeX-style pdfs from the spec (example: [Shim.pdf](https://github.com/user-attachments/files/19468107/Shim.pdf) [Environment.pdf](https://github.com/user-attachments/files/19468109/Environment.pdf)).

----------------------

As a bonus, the first commit models the shim as it was before https://github.com/containerd/containerd/issues/10589 – and running the model checker, we can clearly see the issue we ended up identifying.
```tla
13: <ExecStart line 69, col 5 to line 74, col 72 of module Shim>
/\ events = <<[pid |-> 1, type |-> "taskStart"]>>
/\ tasks = { [id |-> t1, type |-> "exec", state |-> "starting"],
  [id |-> t2, type |-> "exec", state |-> "starting"],
  [id |-> t3, type |-> "init", state |-> "running"] }
/\ exits = <<>>
/\ processes = { [pid |-> -1, id |-> t1, type |-> "exec", state |-> "starting"],
  [pid |-> -1, id |-> t2, type |-> "exec", state |-> "failed"],
  [pid |-> 1, id |-> t3, type |-> "init", state |-> "reaped"] }
/\ shimState = [ running |-> {},
  exitSubscribers |-> {[id |-> t1, exits |-> {}], [id |-> t2, exits |-> {1}]},		<--- init exit
  startingProcesses |-> {t1, t2},
  pendingExecs |-> 2 ]
14: <Shim!ShimService line 171, col 8 to line 172, col 41 of module Shim>
/\ events = <<[pid |-> 1, type |-> "taskStart"]>>
/\ tasks = { [id |-> t1, type |-> "exec", state |-> "starting"],
  [id |-> t2, type |-> "exec", state |-> "failed"],
  [id |-> t3, type |-> "init", state |-> "running"] }
/\ exits = <<>>
/\ processes = { [pid |-> -1, id |-> t1, type |-> "exec", state |-> "starting"],
  [pid |-> -1, id |-> t2, type |-> "exec", state |-> "failed"],
  [pid |-> 1, id |-> t3, type |-> "init", state |-> "reaped"] }
/\ shimState = [ running |-> {},
  exitSubscribers |-> {[id |-> t1, exits |-> {}]},									<--- init exit dropped
  startingProcesses |-> {t1},
  pendingExecs |-> 1 ]
15: <EnvTLC line 189, col 7 to line 189, col 54 of module Shim>
/\ events = <<[pid |-> 1, type |-> "taskStart"]>>
/\ tasks = { [id |-> t1, type |-> "exec", state |-> "starting"],
  [id |-> t2, type |-> "exec", state |-> "failed"],
  [id |-> t3, type |-> "init", state |-> "running"] }
/\ exits = <<>>
/\ processes = { [pid |-> -1, id |-> t1, type |-> "exec", state |-> "failed"],
  [pid |-> -1, id |-> t2, type |-> "exec", state |-> "failed"],
  [pid |-> 1, id |-> t3, type |-> "init", state |-> "reaped"] }
/\ shimState = [ running |-> {},
  exitSubscribers |-> {[id |-> t1, exits |-> {}]},
  startingProcesses |-> {t1},
  pendingExecs |-> 1 ]
```