### PR TITLE
Fix the panic caused by the failure of RunPodSandbox

### DIFF
--- a/internal/cri/server/podsandbox/events.go
+++ b/internal/cri/server/podsandbox/events.go
@@ -46,7 +46,7 @@ func (p *podSandboxEventHandler) HandleEvent(any interface{}) error {
 		log.L.Infof("TaskExit event in podsandbox handler %+v", e)
 		// Use ID instead of ContainerID to rule out TaskExit event for exec.
 		sb := p.controller.store.Get(e.ID)
-		if sb == nil {
+		if sb == nil || sb.Container == nil {
 			return nil
 		}
 		ctx := ctrdutil.NamespacedContext()


### PR DESCRIPTION
When the RunPodSandbox interface fails due to an upstream context cancellation or other reasons, HandleEvent encounters a nil pointer because the PodSandbox.Container field is nil, resulting in a panic.

I discovered this issue in the kubernetes/kubernetes repository.

PR https://github.com/kubernetes/kubernetes/pull/127122 aims to address this by passing the context to the container runtime, resolving the issue where container creation and image pulling actions cannot be canceled.

Previously, the tests in this PR worked fine, but after the CI in the k/k repository switched to containerd 2.0, many tests in this PR started failing.

While investigating the error, I captured the following error in the containerd logs:
```
Mar 23 14:25:14 kind-worker containerd[15009]: time="2025-03-23T14:25:14.978696862Z" level=error msg="RunPodSandbox for &PodSandboxMetadata{Name:pod-terminate-status-1-4,Uid:ee88607b-7c0e-4c4b-899b-f26c423d7ea1,Namespace:pods-6426,Attempt:0,} failed, error" error="rpc error: code = Unknown desc = failed to start sandbox \"14688f874e1d01af706ebe5dca7e38b1d3678bf6a444bd29a35d5a8cee022541\": failed to create containerd task: failed to create shim task: context canceled"
Mar 23 14:25:14 kind-worker containerd[15009]: time="2025-03-23T14:25:14.980825885Z" level=info msg="TaskExit event in podsandbox handler container_id:\"14688f874e1d01af706ebe5dca7e38b1d3678bf6a444bd29a35d5a8cee022541\"  id:\"14688f874e1d01af706ebe5dca7e38b1d3678bf6a444bd29a35d5a8cee022541\"  pid:196281  exit_status:137  exited_at:{seconds:1742739914  nanos:726692665}"
Mar 23 14:25:14 kind-worker containerd[15009]: time="2025-03-23T14:25:14.981209111Z" level=info msg="received exit event sandbox_id:\"9e49cf94f1b270f368e72a76c249a226623cc959522293f36bc2b65f5272a310\"  exit_status:137  exited_at:{seconds:1742739914  nanos:687639430}"
Mar 23 14:25:14 kind-worker containerd[15009]: panic: runtime error: invalid memory address or nil pointer dereference
Mar 23 14:25:14 kind-worker containerd[15009]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x68 pc=0x55f4396c71fa]
Mar 23 14:25:14 kind-worker containerd[15009]: goroutine 373 [running]:
Mar 23 14:25:14 kind-worker containerd[15009]: github.com/containerd/containerd/v2/internal/cri/server/podsandbox.handleSandboxTaskExit({0x55f439ff5db0, 0xc00042eee0}, 0xc002da8a80, 0xc003d33860)
Mar 23 14:25:14 kind-worker containerd[15009]:         /containerd/internal/cri/server/podsandbox/controller.go:192 +0x3a
Mar 23 14:25:14 kind-worker containerd[15009]: github.com/containerd/containerd/v2/internal/cri/server/podsandbox.(*podSandboxEventHandler).HandleEvent(0xc00007a8c0, {0x55f439ef9e80?, 0xc003d33860})
Mar 23 14:25:14 kind-worker containerd[15009]:         /containerd/internal/cri/server/podsandbox/events.go:55 +0x149
Mar 23 14:25:14 kind-worker containerd[15009]: github.com/containerd/containerd/v2/internal/cri/server/events.(*EventMonitor).Start.func1()
Mar 23 14:25:14 kind-worker containerd[15009]:         /containerd/internal/cri/server/events/events.go:155 +0x422
Mar 23 14:25:14 kind-worker containerd[15009]: created by github.com/containerd/containerd/v2/internal/cri/server/events.(*EventMonitor).Start in goroutine 10
Mar 23 14:25:14 kind-worker containerd[15009]:         /containerd/internal/cri/server/events/events.go:135 +0xb2
Mar 23 14:25:15 kind-worker systemd[1]: containerd.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
```