### PR TITLE
cri:fix containerd panic because container is nill in sandbox

### DIFF
--- a/internal/cri/server/podsandbox/controller.go
+++ b/internal/cri/server/podsandbox/controller.go
@@ -189,6 +189,10 @@ func (c *Controller) waitSandboxExit(ctx context.Context, p *types.PodSandbox, e
 // handleSandboxTaskExit handles TaskExit event for sandbox.
 func handleSandboxTaskExit(ctx context.Context, sb *types.PodSandbox, e *eventtypes.TaskExit) error {
 	// No stream attached to sandbox container.
+	if sb.Container == nil {
+		log.G(ctx).Warnf("sb container is nill in sandbox %s", sb.ID)
+		return nil
+	}
 	task, err := sb.Container.Task(ctx, nil)
 	if err != nil {
 		if !errdefs.IsNotFound(err) {


### PR DESCRIPTION
```
func (c *Controller) Start(ctx context.Context, id string) (cin sandbox.ControllerInstance, retErr error) {
	defer func() {
		if retErr != nil && cleanupErr == nil {
			deferCtx, deferCancel := ctrdutil.DeferContext()
			defer deferCancel()
			if cleanupErr = container.Delete(deferCtx, containerd.WithSnapshotCleanup); cleanupErr != nil {
				log.G(ctx).WithError(cleanupErr).Errorf("Failed to delete containerd container %q", id)
			}
	A:		podSandbox.Container = nil
		}
	}()
...
//     it later.
B: func (em *EventMonitor) Start() <-chan error {
   em.eventHandler.HandleEvent(evt)

```
if A is run before B it will happen