### PR TITLE
config: add default RuntimePlatforms configuration support

### DIFF
--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -186,6 +186,11 @@ version = 3
     image_pull_with_sync_fs = false
     stats_collect_period = 10
 
+    [plugins."io.containerd.cri.v1.images".runtime_platforms]
+      [plugins."io.containerd.cri.v1.images".runtime_platforms.runc]
+        platform = ''
+        snapshotter = ''
+
     [plugins.'io.containerd.cri.v1.images'.pinned_images]
       sandbox = 'registry.k8s.io/pause:3.10'
 

--- a/internal/cri/config/config_unix.go
+++ b/internal/cri/config/config_unix.go
@@ -35,6 +35,9 @@ func DefaultImageConfig() ImageConfig {
 		ImageDecryption: ImageDecryption{
 			KeyModel: KeyModelNode,
 		},
+		RuntimePlatforms: map[string]ImagePlatform{
+			"runc": {},
+		},
 		PinnedImages: map[string]string{
 			"sandbox": DefaultSandboxImage,
 		},

--- a/internal/cri/config/config_windows.go
+++ b/internal/cri/config/config_windows.go
@@ -35,6 +35,9 @@ func DefaultImageConfig() ImageConfig {
 		ImageDecryption: ImageDecryption{
 			KeyModel: KeyModelNode,
 		},
+		RuntimePlatforms: map[string]ImagePlatform{
+			"runhcs-wcow-process": {},
+		},
 		PinnedImages: map[string]string{
 			"sandbox": DefaultSandboxImage,
 		},


### PR DESCRIPTION
Added support for default RuntimePlatforms configurations. 
This enhancement provides a streamlined reference implementation for users who need to dynamically assign different snapshotters to various workloads while migrating from version 2 to version 3 configuration.