### PR TITLE
erofs-differ: implement fast differ with DiffDirChanges()

### DIFF
--- a/plugins/diff/erofs/differ_linux.go
+++ b/plugins/diff/erofs/differ_linux.go
@@ -18,16 +18,24 @@ package erofs
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/diff"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/containerd/containerd/v2/pkg/archive"
+	"github.com/containerd/containerd/v2/pkg/archive/compression"
+	"github.com/containerd/containerd/v2/pkg/epoch"
+	"github.com/containerd/containerd/v2/pkg/labels"
 	"github.com/containerd/containerd/v2/plugins/snapshots/erofs/erofsutils"
+	"github.com/containerd/continuity/fs"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	digest "github.com/opencontainers/go-digest"
@@ -54,10 +62,152 @@ func NewErofsDiffer(store content.Store, mkfsExtraOpts []string) differ {
 	}
 }
 
+func writeDiff(ctx context.Context, w io.Writer, lower []mount.Mount, upperRoot string) error {
+	var opts []archive.ChangeWriterOpt
+
+	return mount.WithTempMount(ctx, lower, func(lowerRoot string) error {
+		cw := archive.NewChangeWriter(w, upperRoot, opts...)
+		err := fs.DiffDirChanges(ctx, lowerRoot, upperRoot, fs.DiffSourceOverlayFS, cw.HandleChange)
+		if err != nil {
+			return fmt.Errorf("failed to create diff tar stream: %w", err)
+		}
+		return cw.Close()
+	})
+}
+
 // Compare creates a diff between the given mounts and uploads the result
 // to the content store.
 func (s erofsDiff) Compare(ctx context.Context, lower, upper []mount.Mount, opts ...diff.Opt) (d ocispec.Descriptor, err error) {
-	return emptyDesc, fmt.Errorf("erofsDiff does not implement Compare method: %w", errdefs.ErrNotImplemented)
+	layer, err := erofsutils.MountsToLayer(upper)
+	if err != nil {
+		return emptyDesc, fmt.Errorf("unsupported layer for erofsDiff Compare method: %w", err)
+	}
+
+	var config diff.Config
+	for _, opt := range opts {
+		if err := opt(&config); err != nil {
+			return emptyDesc, err
+		}
+	}
+	if tm := epoch.FromContext(ctx); tm != nil && config.SourceDateEpoch == nil {
+		config.SourceDateEpoch = tm
+	}
+
+	if config.MediaType == "" {
+		config.MediaType = ocispec.MediaTypeImageLayerGzip
+	}
+
+	var compressionType compression.Compression
+	switch config.MediaType {
+	case ocispec.MediaTypeImageLayer:
+		compressionType = compression.Uncompressed
+	case ocispec.MediaTypeImageLayerGzip:
+		compressionType = compression.Gzip
+	case ocispec.MediaTypeImageLayerZstd:
+		compressionType = compression.Zstd
+	default:
+		return emptyDesc, fmt.Errorf("unsupported diff media type: %v: %w", config.MediaType, errdefs.ErrNotImplemented)
+	}
+
+	var newReference bool
+	if config.Reference == "" {
+		newReference = true
+		config.Reference = uniqueRef()
+	}
+
+	cw, err := s.store.Writer(ctx,
+		content.WithRef(config.Reference),
+		content.WithDescriptor(ocispec.Descriptor{
+			MediaType: config.MediaType, // most contentstore implementations just ignore this
+		}))
+	if err != nil {
+		return emptyDesc, fmt.Errorf("failed to open writer: %w", err)
+	}
+
+	// errOpen is set when an error occurs while the content writer has not been
+	// committed or closed yet to force a cleanup
+	var errOpen error
+	defer func() {
+		if errOpen != nil {
+			cw.Close()
+			if newReference {
+				if abortErr := s.store.Abort(ctx, config.Reference); abortErr != nil {
+					log.G(ctx).WithError(abortErr).WithField("ref", config.Reference).Warnf("failed to delete diff upload")
+				}
+			}
+		}
+	}()
+	if !newReference {
+		if errOpen = cw.Truncate(0); errOpen != nil {
+			return emptyDesc, errOpen
+		}
+	}
+
+	upperRoot := filepath.Join(layer, "fs")
+	if compressionType != compression.Uncompressed {
+		dgstr := digest.SHA256.Digester()
+		var compressed io.WriteCloser
+		if config.Compressor != nil {
+			compressed, errOpen = config.Compressor(cw, config.MediaType)
+			if errOpen != nil {
+				return emptyDesc, fmt.Errorf("failed to get compressed stream: %w", errOpen)
+			}
+		} else {
+			compressed, errOpen = compression.CompressStream(cw, compressionType)
+			if errOpen != nil {
+				return emptyDesc, fmt.Errorf("failed to get compressed stream: %w", errOpen)
+			}
+		}
+		errOpen = writeDiff(ctx, io.MultiWriter(compressed, dgstr.Hash()), lower, upperRoot)
+		compressed.Close()
+		if errOpen != nil {
+			return emptyDesc, fmt.Errorf("failed to write compressed diff: %w", errOpen)
+		}
+
+		if config.Labels == nil {
+			config.Labels = map[string]string{}
+		}
+		config.Labels[labels.LabelUncompressed] = dgstr.Digest().String()
+	} else {
+		err := writeDiff(ctx, cw, lower, upperRoot)
+		if err != nil {
+			return emptyDesc, fmt.Errorf("failed to create diff tar stream: %w", err)
+		}
+	}
+
+	var commitopts []content.Opt
+	if config.Labels != nil {
+		commitopts = append(commitopts, content.WithLabels(config.Labels))
+	}
+
+	dgst := cw.Digest()
+	if errOpen = cw.Commit(ctx, 0, dgst, commitopts...); errOpen != nil {
+		if !errdefs.IsAlreadyExists(errOpen) {
+			return emptyDesc, fmt.Errorf("failed to commit: %w", errOpen)
+		}
+		errOpen = nil
+	}
+
+	info, err := s.store.Info(ctx, dgst)
+	if err != nil {
+		return emptyDesc, fmt.Errorf("failed to get info from content store: %w", err)
+	}
+	if info.Labels == nil {
+		info.Labels = make(map[string]string)
+	}
+	// Set "containerd.io/uncompressed" label if digest already existed without label
+	if _, ok := info.Labels[labels.LabelUncompressed]; !ok {
+		info.Labels[labels.LabelUncompressed] = config.Labels[labels.LabelUncompressed]
+		if _, err := s.store.Update(ctx, info, "labels."+labels.LabelUncompressed); err != nil {
+			return emptyDesc, fmt.Errorf("error setting uncompressed label: %w", err)
+		}
+	}
+
+	return ocispec.Descriptor{
+		MediaType: config.MediaType,
+		Size:      info.Size,
+		Digest:    info.Digest,
+	}, nil
 }
 
 func (s erofsDiff) Apply(ctx context.Context, desc ocispec.Descriptor, mounts []mount.Mount, opts ...diff.ApplyOpt) (d ocispec.Descriptor, err error) {
@@ -138,4 +288,12 @@ func (rc *readCounter) Read(p []byte) (n int, err error) {
 	n, err = rc.r.Read(p)
 	rc.c += int64(n)
 	return
+}
+
+func uniqueRef() string {
+	t := time.Now()
+	var b [3]byte
+	// Ignore read failures, just decreases uniqueness
+	rand.Read(b[:])
+	return fmt.Sprintf("%d-%s", t.UnixNano(), base64.URLEncoding.EncodeToString(b[:]))
 }

--- a/plugins/snapshots/erofs/erofsutils/mount_linux.go
+++ b/plugins/snapshots/erofs/erofsutils/mount_linux.go
@@ -68,14 +68,19 @@ func MountsToLayer(mounts []mount.Mount) (string, error) {
 	if mnt.Type == "bind" || mnt.Type == "erofs" {
 		layer = filepath.Dir(mnt.Source)
 	} else if mnt.Type == "overlay" {
-		layer = ""
+		toplower := ""
 		for _, o := range mnt.Options {
 			if strings.HasPrefix(o, "upperdir=") {
 				layer = filepath.Dir(strings.TrimPrefix(o, "upperdir="))
+			} else if strings.HasPrefix(o, "lowerdir=") {
+				toplower = filepath.Dir(strings.Split(strings.TrimPrefix(o, "lowerdir="), ":")[0])
 			}
 		}
 		if layer == "" {
-			return "", fmt.Errorf("unsupported overlay layer for erofs differ: %w", errdefs.ErrNotImplemented)
+			if toplower == "" {
+				return "", fmt.Errorf("unsupported overlay layer for erofs differ: %w", errdefs.ErrNotImplemented)
+			}
+			layer = toplower
 		}
 	} else {
 		return "", fmt.Errorf("invalid filesystem type for erofs differ: %w", errdefs.ErrNotImplemented)


### PR DESCRIPTION
Unlike the walking differ, which implements a generic method to accommodate all kinds of snapshotters, the EROFS differ is just implemented for EROFS and EROFS snapshotter so it can utilize the recent [DiffDirChanges()](https://github.com/containerd/continuity/pull/145) to avoid traversing the entire rootfs directory in order to improve `nerdctl commit` performance.

Additionally, I think `baseDir` is unnecessary too (in principle, only `upperdir` is useful for OCI format convention).  However, addressing this requires more work, so left as is for now.

It's also useful to implement a customized Compare() method for EROFS differ so that we can dump the native EROFS-formatted blob to the content store later.