### PR TITLE
correct kep template - remove render type

### DIFF
--- a/.github/ISSUE_TEMPLATE/cri_kep.yaml
+++ b/.github/ISSUE_TEMPLATE/cri_kep.yaml
@@ -31,7 +31,6 @@ body:
           - KEP-Owner:
           - SIG-Node member liason:
           - KEP-Shepherd:
-    render: markdown
     validations:
       required: false
 


### PR DESCRIPTION
render type not supported for text area