### PR TITLE
downgrade cni version in CI test

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -18,7 +18,7 @@ set -eux
 
 script/setup/install-seccomp
 script/setup/install-runc
-script/setup/install-cni $(grep containernetworking/plugins go.mod | awk '{print $2}')
+script/setup/install-cni
 script/setup/install-critools
 script/setup/install-failpoint-binaries
 script/setup/install-gotestsum

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,7 +401,7 @@ jobs:
           sudo apt-get install -y gperf dmsetup strace xfsprogs
           script/setup/install-seccomp
           script/setup/install-runc
-          script/setup/install-cni $(grep containernetworking/plugins go.mod | awk '{print $2}')
+          script/setup/install-cni
           script/setup/install-critools
           script/setup/install-failpoint-binaries
 

--- a/script/setup/install-cni
+++ b/script/setup/install-cni
@@ -21,7 +21,8 @@
 #
 set -eu -o pipefail
 
-CNI_COMMIT=${1:-$(go list -f "{{.Version}}" -m github.com/containernetworking/plugins)}
+# FIXME: when https://github.com/containernetworking/plugins/issues/1121 is resolved and released
+CNI_COMMIT=${1:-v1.5.1}
 CNI_DIR=${DESTDIR:=''}/opt/cni
 CNI_CONFIG_DIR=${DESTDIR}/etc/cni/net.d
 : "${CNI_REPO:=https://github.com/containernetworking/plugins.git}"


### PR DESCRIPTION
Many PRs have been blocked, especially some with label `cherry-pick/2.0`

The [issue](https://github.com/containernetworking/plugins/issues/1121) had been over 4 months

`CNI plugins` is not the focus in e2e test, and updates and releases here should also not be blocked by `CNI plugins`


cc @AkihiroSuda 