### PR TITLE
runtime: fix clean task dir error caused by "directory not empty"

### DIFF
--- a/core/runtime/v2/bundle.go
+++ b/core/runtime/v2/bundle.go
@@ -131,7 +131,7 @@ func (b *Bundle) Delete() error {
 	if err := mount.UnmountRecursive(rootfs, 0); err != nil {
 		return fmt.Errorf("unmount rootfs %s: %w", rootfs, err)
 	}
-	if err := os.Remove(rootfs); err != nil && !os.IsNotExist(err) {
+	if err := os.RemoveAll(rootfs); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to remove bundle rootfs: %w", err)
 	}
 	err := atomicDelete(b.Path)


### PR DESCRIPTION
My containerd version:
v1.7.5
When I start the Container, the process exits due to my own code. At this point I get the following error:
![image](https://github.com/user-attachments/assets/7dce980c-cf03-4859-8cb2-936ab6125845)
So I committed this code to fix the above error