### PR TITLE
Support rewrite registry mirror repository.

### DIFF
--- a/pkg/cri/config/config.go
+++ b/pkg/cri/config/config.go
@@ -199,6 +199,23 @@ type Mirror struct {
 	// with host specified.
 	// The scheme, host and path from the endpoint URL will be used.
 	Endpoints []string `toml:"endpoint" json:"endpoint"`
+
+	// Rewrites are repository rewrite rules for a namespace. When fetching image resources
+	// from an endpoint and a key matches the repository via regular expression matching
+	// it will be replaced with the corresponding value from the map in the resource request.
+	//
+	// This example configures CRI to pull docker.io/library/* images from docker.io/my-org/*:
+	//
+	// [plugins]
+	//   [plugins."io.containerd.grpc.v1.cri"]
+	//     [plugins."io.containerd.grpc.v1.cri".registry]
+	//       [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+	//         [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+	//           endpoint = ["https://registry-1.docker.io/v2"]
+	//           [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io".rewrite]
+	//             "^library/(.*)" = "my-org/$1"
+	//
+	Rewrites map[string]string `toml:"rewrite" json:"rewrite"`
 }
 
 // AuthConfig contains the config related to authentication to a specific registry

--- a/remotes/docker/config/hosts.go
+++ b/remotes/docker/config/hosts.go
@@ -52,6 +52,7 @@ type hostConfig struct {
 	caCerts     []string
 	clientPairs [][2]string
 	skipVerify  *bool
+	rewrite     map[string]string
 
 	header http.Header
 
@@ -266,6 +267,7 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
 			rhosts[i].Path = host.path
 			rhosts[i].Capabilities = host.capabilities
 			rhosts[i].Header = host.header
+			rhosts[i].Rewrites = host.rewrite
 		}
 
 		return rhosts, nil
@@ -355,6 +357,10 @@ type hostFileConfig struct {
 	// API root endpoint.
 	OverridePath bool `toml:"override_path"`
 
+	// Rewrite rules for repository paths
+	// Example: {"^library/(.*)" = "my-org/$1"}
+	Rewrite map[string]string `toml:"rewrite"`
+
 	// TODO: Credentials: helper? name? username? alternate domain? token?
 }
 
@@ -439,6 +445,9 @@ func parseHostConfig(server string, baseDir string, config hostFileConfig) (host
 	}
 
 	result.skipVerify = config.SkipVerify
+
+	// Rewrite rules for repository paths
+	result.rewrite = config.Rewrite
 
 	if len(config.Capabilities) > 0 {
 		for _, c := range config.Capabilities {

--- a/remotes/docker/registry.go
+++ b/remotes/docker/registry.go
@@ -74,6 +74,7 @@ type RegistryHost struct {
 	Path         string
 	Capabilities HostCapabilities
 	Header       http.Header
+	Rewrites     map[string]string
 }
 
 func (h RegistryHost) isProxy(refhost string) bool {


### PR DESCRIPTION
Support CRI and CTR configuration to allow for request-time rewrite rules applicable only to the repository portion of resource paths when pulling images.

refer: https://github.com/containerd/containerd/pull/5171

CTR configuration example:
```
$ tree /etc/containerd/certs.d
/etc/containerd/certs.d
└── docker.io
    └── hosts.toml

$ cat /etc/containerd/certs.d/docker.io/hosts.toml
server = "https://docker.io"

[host."https://registry-1.docker.io"]
  capabilities = ["pull", "resolve"]
  rewrite = {
    "^library/(.*)" = "my-org/$1"
  }
```

CRI configuration example:
```
[plugins]
  [plugins."io.containerd.grpc.v1.cri"]
    [plugins."io.containerd.grpc.v1.cri".registry]
      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
          endpoint = ["https://registry-1.docker.io/v2"]
       	  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io".rewrite]
            "^library/(.*)" = "my-org/$1"
```