### PR TITLE
Fix async deletion in Convert

### DIFF
--- a/core/images/converter/converter.go
+++ b/core/images/converter/converter.go
@@ -116,11 +116,10 @@ func Convert(ctx context.Context, client Client, dstRef, srcRef string, opts ...
 		dstImg.Target = *dstDesc
 	}
 	var res images.Image
-	if dstRef != srcRef {
-		_ = is.Delete(ctx, dstRef)
+
+	if res, err = is.Update(ctx, dstImg); err != nil {
 		res, err = is.Create(ctx, dstImg)
-	} else {
-		res, err = is.Update(ctx, dstImg)
 	}
+
 	return &res, err
 }


### PR DESCRIPTION
nerdctl has struggled with a large number of occurrences of a racy issue, documented in: https://github.com/containerd/nerdctl/issues/3513

more specifically in the context of a (simple) call to Convert:
https://github.com/containerd/nerdctl/issues/3509

where an image we just created would sometimes disappear immediately.

It looks to me like this here is the root cause?

cc @AkihiroSuda and @lingdie