### PR TITLE
[release/2.0]  cri:fix lost container exit events if they arrive before info is cached

### DIFF
--- a/internal/cri/server/restart.go
+++ b/internal/cri/server/restart.go
@@ -171,7 +171,7 @@ func (c *criService) recover(ctx context.Context) error {
 	for _, container := range containers {
 		container := container
 		eg.Go(func() error {
-			cntr, err := c.loadContainer(ctx2, container)
+			cntr, exitCh, pid, err := c.loadContainer(ctx2, container)
 			if err != nil {
 				log.G(ctx2).
 					WithError(err).
@@ -184,6 +184,10 @@ func (c *criService) recover(ctx context.Context) error {
 			if err := c.containerStore.Add(cntr); err != nil {
 				return fmt.Errorf("failed to add container %q to store: %w", container.ID(), err)
 			}
+			if exitCh != nil {
+				// Start the exit monitor. This should run after that container has been added to the container store.
+				c.startContainerExitMonitor(context.Background(), cntr.ID, pid, exitCh)
+			}
 			if err := c.containerNameIndex.Reserve(cntr.Name, cntr.ID); err != nil {
 				return fmt.Errorf("failed to reserve container name %q: %w", cntr.Name, err)
 			}
@@ -193,7 +197,6 @@ func (c *criService) recover(ctx context.Context) error {
 	if err := eg.Wait(); err != nil {
 		return err
 	}
-
 	// Recover all images.
 	if err := c.ImageService.CheckImages(ctx); err != nil {
 		return fmt.Errorf("failed to check images: %w", err)
@@ -251,7 +254,9 @@ func (c *criService) recover(ctx context.Context) error {
 const loadContainerTimeout = 10 * time.Second
 
 // loadContainer loads container from containerd and status checkpoint.
-func (c *criService) loadContainer(ctx context.Context, cntr containerd.Container) (containerstore.Container, error) {
+func (c *criService) loadContainer(ctx context.Context, cntr containerd.Container) (containerstore.Container, <-chan containerd.ExitStatus, uint32, error) {
+	var exitCh <-chan containerd.ExitStatus
+	var statusPid uint32
 	ctx, cancel := context.WithTimeout(ctx, loadContainerTimeout)
 	defer cancel()
 	id := cntr.ID()
@@ -260,15 +265,15 @@ func (c *criService) loadContainer(ctx context.Context, cntr containerd.Containe
 	// Load container metadata.
 	exts, err := cntr.Extensions(ctx)
 	if err != nil {
-		return container, fmt.Errorf("failed to get container extensions: %w", err)
+		return container, nil, 0, fmt.Errorf("failed to get container extensions: %w", err)
 	}
 	ext, ok := exts[crilabels.ContainerMetadataExtension]
 	if !ok {
-		return container, fmt.Errorf("metadata extension %q not found", crilabels.ContainerMetadataExtension)
+		return container, nil, 0, fmt.Errorf("metadata extension %q not found", crilabels.ContainerMetadataExtension)
 	}
 	data, err := typeurl.UnmarshalAny(ext)
 	if err != nil {
-		return container, fmt.Errorf("failed to unmarshal metadata extension %q: %w", ext, err)
+		return container, nil, 0, fmt.Errorf("failed to unmarshal metadata extension %q: %w", ext, err)
 	}
 	meta := data.(*containerstore.Metadata)
 
@@ -372,11 +377,13 @@ func (c *criService) loadContainer(ctx context.Context, cntr containerd.Containe
 					// before status is checkpointed.
 					status.StartedAt = time.Now().UnixNano()
 					status.Pid = t.Pid()
+					statusPid = t.Pid()
 				}
 				// Wait for the task for exit monitor.
 				// wait is a long running background request, no timeout needed.
-				exitCh, err := t.Wait(ctrdutil.NamespacedContext())
+				exitCh, err = t.Wait(ctrdutil.NamespacedContext())
 				if err != nil {
+					exitCh = nil
 					if !errdefs.IsNotFound(err) {
 						return fmt.Errorf("failed to wait for task: %w", err)
 					}
@@ -385,9 +392,6 @@ func (c *criService) loadContainer(ctx context.Context, cntr containerd.Containe
 					status.FinishedAt = time.Now().UnixNano()
 					status.ExitCode = unknownExitCode
 					status.Reason = unknownExitReason
-				} else {
-					// Start exit monitor.
-					c.startContainerExitMonitor(context.Background(), id, status.Pid, exitCh)
 				}
 			case containerd.Stopped:
 				// Task is stopped. Update status and delete the task.
@@ -416,7 +420,8 @@ func (c *criService) loadContainer(ctx context.Context, cntr containerd.Containe
 	if containerIO != nil {
 		opts = append(opts, containerstore.WithContainerIO(containerIO))
 	}
-	return containerstore.NewContainer(*meta, opts...)
+	container, err = containerstore.NewContainer(*meta, opts...)
+	return container, exitCh, statusPid, err
 }
 
 // podSandboxRecover is an additional interface implemented by podsandbox/ controller to handle


### PR DESCRIPTION
cherry-pick from https://github.com/containerd/containerd/pull/11579/commits/ead5c1ee6573c698b3776581f744a8e752e75770

```release-note
Ensure container exit events are not lost during containerd restart
```