### PR TITLE
add content layer gc ref in snapshot

### DIFF
--- a/core/unpack/unpacker.go
+++ b/core/unpack/unpacker.go
@@ -49,8 +49,9 @@ import (
 )
 
 const (
-	labelSnapshotRef = "containerd.io/snapshot.ref"
-	unpackSpanPrefix = "pkg.unpack.unpacker"
+	labelSnapshotRef  = "containerd.io/snapshot.ref"
+	labelGCContentRef = "containerd.io/gc.ref.content.l"
+	unpackSpanPrefix  = "pkg.unpack.unpacker"
 )
 
 // Result returns information about the unpacks which were completed.
@@ -309,6 +310,7 @@ func (u *Unpacker) unpack(
 			snapshotLabels = make(map[string]string)
 		}
 		snapshotLabels[labelSnapshotRef] = chainID
+		snapshotLabels[labelGCContentRef] = desc.Digest.String()
 
 		var (
 			key    string


### PR DESCRIPTION
Fix #8973

The GC logic is to scan `container` and `image` in metadata, Continue scanning the `snapshot`  from the `container`, and `content` from the `image`.

If a snapshot to content connection can be established, it should be possible to avoid deleting the content corresponding to the snapshot being used


cc @dmcgowan 