### PR TITLE
cri:delete timeout for container/sandbox recover

### DIFF
--- a/internal/cri/server/podsandbox/recover.go
+++ b/internal/cri/server/podsandbox/recover.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	goruntime "runtime"
-	"time"
 
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
@@ -35,22 +34,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/netns"
 )
 
-// loadContainerTimeout is the default timeout for loading a container/sandbox.
-// One container/sandbox hangs (e.g. containerd#2438) should not affect other
-// containers/sandboxes.
-// Most CRI container/sandbox related operations are per container, the ones
-// which handle multiple containers at a time are:
-// * ListPodSandboxes: Don't talk with containerd services.
-// * ListContainers: Don't talk with containerd services.
-// * ListContainerStats: Not in critical code path, a default timeout will
-// be applied at CRI level.
-// * Recovery logic: We should set a time for each container/sandbox recovery.
-// * Event monitor: We should set a timeout for each container/sandbox event handling.
-const loadContainerTimeout = 10 * time.Second
-
 func (c *Controller) RecoverContainer(ctx context.Context, cntr containerd.Container) (sandboxstore.Sandbox, error) {
-	ctx, cancel := context.WithTimeout(ctx, loadContainerTimeout)
-	defer cancel()
 	var sandbox sandboxstore.Sandbox
 	meta, err := getMetadata(ctx, cntr)
 	if err != nil {

--- a/internal/cri/server/restart.go
+++ b/internal/cri/server/restart.go
@@ -237,25 +237,10 @@ func (c *criService) recover(ctx context.Context) error {
 	return nil
 }
 
-// loadContainerTimeout is the default timeout for loading a container/sandbox.
-// One container/sandbox hangs (e.g. containerd#2438) should not affect other
-// containers/sandboxes.
-// Most CRI container/sandbox related operations are per container, the ones
-// which handle multiple containers at a time are:
-// * ListPodSandboxes: Don't talk with containerd services.
-// * ListContainers: Don't talk with containerd services.
-// * ListContainerStats: Not in critical code path, a default timeout will
-// be applied at CRI level.
-// * Recovery logic: We should set a time for each container/sandbox recovery.
-// * Event monitor: We should set a timeout for each container/sandbox event handling.
-const loadContainerTimeout = 10 * time.Second
-
 // loadContainer loads container from containerd and status checkpoint.
 func (c *criService) loadContainer(ctx context.Context, cntr containerd.Container) (containerstore.Container, <-chan containerd.ExitStatus, uint32, error) {
 	var exitCh <-chan containerd.ExitStatus
 	var statusPid uint32
-	ctx, cancel := context.WithTimeout(ctx, loadContainerTimeout)
-	defer cancel()
 	id := cntr.ID()
 	containerDir := c.getContainerRootDir(id)
 	var container containerstore.Container


### PR DESCRIPTION
introduce by this pr https://github.com/containerd/containerd/commit/963a01735bb1c94d95807f5e2ffc1f9e7a5854e2 
we have already set "io.containerd.timeout.task.state= 2s" https://github.com/containerd/containerd/issues/2438 may not happen.