### PR TITLE
ci:fix container must be created error on shimv1

### DIFF
--- a/pkg/cri/sbserver/events.go
+++ b/pkg/cri/sbserver/events.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -443,7 +444,7 @@ func handleContainerExit(ctx context.Context, e *eventtypes.TaskExit, cntr conta
 		_, err = c.client.TaskService().Delete(ctx, &apitasks.DeleteTaskRequest{ContainerID: cntr.Container.ID()})
 		if err != nil {
 			err = errdefs.FromGRPC(err)
-			if !errdefs.IsNotFound(err) {
+			if !errdefs.IsNotFound(err) && !strings.Contains(err.Error(), "container must be created") {
 				return fmt.Errorf("failed to cleanup container %s in task-service: %w", cntr.Container.ID(), err)
 			}
 		}

--- a/pkg/cri/sbserver/podsandbox/sandbox_delete.go
+++ b/pkg/cri/sbserver/podsandbox/sandbox_delete.go
@@ -19,6 +19,7 @@ package podsandbox
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/containerd/log"
 
@@ -117,7 +118,7 @@ func (c *Controller) cleanupSandboxTask(ctx context.Context, sbCntr containerd.C
 		_, err = c.client.TaskService().Delete(ctx, &apitasks.DeleteTaskRequest{ContainerID: sbCntr.ID()})
 		if err != nil {
 			err = errdefs.FromGRPC(err)
-			if !errdefs.IsNotFound(err) {
+			if !errdefs.IsNotFound(err) && !strings.Contains(err.Error(), "container must be created") {
 				return fmt.Errorf("failed to cleanup sandbox %s in task-service: %w", sbCntr.ID(), err)
 			}
 		}

--- a/pkg/cri/server/events.go
+++ b/pkg/cri/server/events.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -427,11 +428,11 @@ func handleContainerExit(ctx context.Context, e *eventtypes.TaskExit, cntr conta
 	// REF:
 	// 1. https://github.com/containerd/containerd/issues/7496#issuecomment-1671100968
 	// 2. https://github.com/containerd/containerd/issues/8931
-	if errdefs.IsNotFound(err) {
+	if errdefs.IsNotFound(err) && !strings.Contains(err.Error(), "container must be created") {
 		_, err = c.client.TaskService().Delete(ctx, &apitasks.DeleteTaskRequest{ContainerID: cntr.Container.ID()})
 		if err != nil {
 			err = errdefs.FromGRPC(err)
-			if !errdefs.IsNotFound(err) {
+			if !errdefs.IsNotFound(err) && !strings.Contains(err.Error(), "container must be created") {
 				return fmt.Errorf("failed to cleanup container %s in task-service: %w", cntr.Container.ID(), err)
 			}
 		}
@@ -517,7 +518,7 @@ func handleSandboxExit(ctx context.Context, e *eventtypes.TaskExit, sb sandboxst
 		_, err = c.client.TaskService().Delete(ctx, &apitasks.DeleteTaskRequest{ContainerID: sb.Container.ID()})
 		if err != nil {
 			err = errdefs.FromGRPC(err)
-			if !errdefs.IsNotFound(err) {
+			if !errdefs.IsNotFound(err) && !strings.Contains(err.Error(), "container must be created") {
 				return fmt.Errorf("failed to cleanup sandbox %s in task-service: %w", sb.Container.ID(), err)
 			}
 		}


### PR DESCRIPTION
fix 1.7 ci error when use shimv1
```
2025-04-01T05:08:12.7620705Z     restart_test.go:211: Should be able to stop and remove sandbox after restart
2025-04-01T05:08:13.0699136Z E0401 05:08:13.069402   82918 remote_runtime.go:182] RemovePodSandbox "29a1a2870c23894c1d0c2a507a8a45d64a49c7f6a167756a61bdb407a747a4ce" from runtime service failed: rpc error: code = FailedPrecondition desc = failed to delete sandbox "29a1a2870c23894c1d0c2a507a8a45d64a49c7f6a167756a61bdb407a747a4ce": failed to delete sandbox task "29a1a2870c23894c1d0c2a507a8a45d64a49c7f6a167756a61bdb407a747a4ce": failed to cleanup sandbox 29a1a2870c23894c1d0c2a507a8a45d64a49c7f6a167756a61bdb407a747a4ce in task-service: container must be created: failed precondition
2025-04-01T05:08:13.0702963Z     restart_test.go:214: 
2025-04-01T05:08:13.0704077Z         	Error Trace:	/home/runner/work/containerd/containerd/integration/restart_test.go:214
2025-04-01T05:08:13.0705112Z         	Error:      	Received unexpected error:
2025-04-01T05:08:13.0710105Z         	            	rpc error: code = FailedPrecondition desc = failed to delete sandbox "29a1a2870c23894c1d0c2a507a8a45d64a49c7f6a167756a61bdb407a747a4ce": failed to delete sandbox task "29a1a2870c23894c1d0c2a507a8a45d64a49c7f6a167756a61bdb407a747a4ce": failed to cleanup sandbox 29a1a2870c23894c1d0c2a507a8a45d64a49c7f6a167756a61bdb407a747a4ce in task-service: container must be created: failed precondition
2025-04-01T05:08:13.0712133Z         	Test:       	TestContainerdRestart
2025-04-01T05:08:13.0712515Z     restart_test.go:217: Should recover all images
2025-04-01T05:08:13.0943512Z --- FAIL: TestContainerdRestart (11.83s)
```