### PR TITLE
Set default differ for the default unpack config of transfer service

### DIFF
--- a/defaults/defaults_linux.go
+++ b/defaults/defaults_linux.go
@@ -33,4 +33,6 @@ const (
 	// DefaultStateDir is the default location used by containerd to store
 	// transient data
 	DefaultStateDir = "/run/containerd"
+	// DefaultDiffer will set the default differ for the platform.
+	DefaultDiffer = "walking"
 )

--- a/defaults/defaults_unix_nolinux.go
+++ b/defaults/defaults_unix_nolinux.go
@@ -33,4 +33,6 @@ const (
 	// DefaultStateDir is the default location used by containerd to store
 	// transient data
 	DefaultStateDir = "/var/run/containerd"
+	// DefaultDiffer will set the default differ for the platform.
+	DefaultDiffer = "walking"
 )

--- a/plugins/transfer/plugin_defaults_other.go
+++ b/plugins/transfer/plugin_defaults_other.go
@@ -28,6 +28,7 @@ func defaultUnpackConfig() []unpackConfiguration {
 		{
 			Platform:    platforms.Format(platforms.DefaultSpec()),
 			Snapshotter: defaults.DefaultSnapshotter,
+			Differ:      defaults.DefaultDiffer,
 		},
 	}
 }


### PR DESCRIPTION
Set default differ for the default unpack config of transfer service.

Without explicit "unpack_config" configuration for the Transfer plugin, the plugin will pick the first Diff plugin that matches the platform. In my tests it selected the "erofs" diff plugin.

Without this change:
```
$ sudo ctr i pull docker.io/library/hello-world:latest
....
application/vnd.oci.image.index.v1+json sha256:7e1a4e2d11e2ac7a8c3f768d4166c2defeb09d2a750b010412b6ea13de1efb19
Pulling from OCI Registry (docker.io/library/hello-world:latest)        elapsed: 3.3 s  total:  41.2 K  (12.6 KiB/s)
ctr: rpc error: code = Unimplemented desc = method Transfer not implemented for containerd.types.transfer.OCIRegistry to containerd.types.transfer.ImageStore
```

Error logs shows:
```
Apr 01 21:23:33 ip-172-31-63-131 containerd[70526]: time="2025-04-01T21:23:33.341048713Z" level=error msg="transfer failed" error="failed to extract layer sha256:72e830a4dff5f0d5225cdc0a320e85ab1ce06ea5673acfe8d83a7645cbd0e9cf: mount layer type must be erofs-layer: not implemented"
```

After this change:
```
$ sudo ctr i pull docker.io/library/hello-world:latest
...
application/vnd.oci.image.index.v1+json sha256:7e1a4e2d11e2ac7a8c3f768d4166c2defeb09d2a750b010412b6ea13de1efb19
Pulling from OCI Registry (docker.io/library/hello-world:latest)        elapsed: 3.3 s  total:  43.5 K  (13.3 KiB/s)
```