### PR TITLE
ctr: created task can't be deleted even if the process does not exist

### DIFF
--- a/client/task.go
+++ b/client/task.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	goruntime "runtime"
 	"strings"
 	"syscall"
@@ -385,6 +386,13 @@ func (t *task) Delete(ctx context.Context, opts ...ProcessDeleteOpts) (*ExitStat
 			// https://github.com/containerd/containerd/issues/7357
 			break
 		}
+		if _, err := os.Stat(fmt.Sprintf("/proc/%d", t.pid)); err != nil {
+			if os.IsNotExist(err) {
+				break
+			}
+			return nil, fmt.Errorf("failed to check process %d: %v", t.pid, err)
+		}
+
 		fallthrough
 	default:
 		return nil, fmt.Errorf("task must be stopped before deletion: %s: %w", status.Status, errdefs.ErrFailedPrecondition)


### PR DESCRIPTION
**Description**

Try to fix [#10581](https://github.com/containerd/containerd/issues/10581)
Task must be stopped before deletion: running: failed precondition.
However, even if we delete the process via 'kill -9 <task.pid>', the created task cannot be deleted because the pid is non-zero .

**Describe the results you received and expected**
Created task with non-zero can be deleted. 

What version of containerd are you using?
1.6.23

Any other relevant information
No response

Show configuration if it is related to CRI plugin.
No response