### PR TITLE
fix restart containerd panic because leak container in store.

### DIFF
--- a/internal/cri/server/container_remove.go
+++ b/internal/cri/server/container_remove.go
@@ -108,6 +108,14 @@ func (c *criService) RemoveContainer(ctx context.Context, r *runtime.RemoveConta
 		if !errdefs.IsNotFound(err) {
 			return nil, fmt.Errorf("failed to delete containerd container %q: %w", id, err)
 		}
+		// If err is ErrNotFound, and can get container from store,delete it again.
+		_, err := c.client.ContainerService().Get(ctx, id)
+		if err == nil {
+			log.G(ctx).Infof("delete leak container %s", id)
+			if err := c.client.ContainerService().Delete(ctx, id); err != nil {
+				return nil, err
+			}
+		}
 		log.G(ctx).Tracef("Remove called for containerd container %q that does not exist", id)
 	}
 

--- a/pkg/sys/socket_unix.go
+++ b/pkg/sys/socket_unix.go
@@ -51,7 +51,7 @@ func GetLocalListener(path string, uid, gid int) (net.Listener, error) {
 
 	l, err := CreateUnixSocket(path)
 	if err != nil {
-		return l, err
+		return l, fmt.Errorf("failed to create unix socket on %s: %w", path, err)
 	}
 
 	if err := os.Chmod(path, 0660); err != nil {


### PR DESCRIPTION
```
containerd[1084063]: time="2025-04-03T12:48:50.243050220+08:00" level=warning msg="Failed to load container status for \"2664d51a384bf98e94aded002174845ed656c241b862c7248fa98424233a17ba\"" error="failed to read status from \"/paasdata/docker/io.containerd.grpc.v1.cri/containers/2664d51a384bf98e94aded002174845ed656c241b862c7248fa98424233a17ba/status\": open /paasdata/docker/io.containerd.grpc.v1.cri/containers/2664d51a384bf98e94aded002174845ed656c241b862c7248fa98424233a17ba/status: no such file or directory"
```