### PR TITLE
cgroupv2: set max_user_instances at least 1024

### DIFF
--- a/containerd.service
+++ b/containerd.service
@@ -18,6 +18,8 @@ Documentation=https://containerd.io
 After=network.target dbus.service
 
 [Service]
+Environment="INOTIFY_INSTANCES_LIMIT=1024"
+ExecStartPre=/bin/sh -c 'current=$(cat /proc/sys/fs/inotify/max_user_instances); [ "$current" -lt ${INOTIFY_INSTANCES_LIMIT} ] && echo ${INOTIFY_INSTANCES_LIMIT} > /proc/sys/fs/inotify/max_user_instances || true'
 ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/local/bin/containerd
 


### PR DESCRIPTION
fix:https://github.com/containerd/containerd/issues/10468

now every  shim have to create at least an Inotify instance. but  default /proc/sys/fs/inotify/max_user_instances is 128.
when we create many containers it will cause error "too many open files"
```
func (c *Manager) MemoryEventFD() (int, uint32, error) {
	fpath := filepath.Join(c.path, "memory.events")
	fd, err := unix.InotifyInit()
	if err != nil {
		return 0, 0, fmt.Errorf("failed to create inotify fd: %w", err)
	}
```