### PR TITLE
Consolidate CNI initialization / creation / conf monitor in CRI

### DIFF
--- a/internal/cri/server/cni_net_plugin.go
+++ b/internal/cri/server/cni_net_plugin.go
@@ -1,0 +1,169 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/containerd/go-cni"
+	"github.com/containerd/log"
+)
+
+type cniNetPlugin struct {
+	sync.RWMutex
+
+	// plugins is used to setup and teardown network when run/stop pod sandbox.
+	plugins map[string]cni.CNI
+	// confMonitor is used to reload cni network conf if there is
+	// any valid fs change events from cni network conf dir.
+	confMonitor map[string]*cniNetConfSyncer
+	// confSyncWG tracks running conf syncers.
+	confSyncWG sync.WaitGroup
+	// confSyncErrCh reports errors from CNI conf syncers. This channel is initialized
+	// when `start()` is called and closed when all syncers have exited.
+	confSyncErrCh chan error
+	// started indicates if `start()` has been called.
+	started bool
+	// confSyncWaitCreated indicates if we've created a goroutine to wait for
+	// all conf sync stop.
+	confSyncWaitCreated bool
+}
+
+func newCNINetPlugin() *cniNetPlugin {
+	return &cniNetPlugin{
+		plugins:     make(map[string]cni.CNI),
+		confMonitor: make(map[string]*cniNetConfSyncer),
+	}
+}
+
+// add adds a new CNI plugin and creates conf syncer for it.
+func (c *cniNetPlugin) add(name, confDir string, i cni.CNI, loadOpts []cni.Opt) error {
+	c.Lock()
+	defer c.Unlock()
+	if _, ok := c.plugins[name]; ok {
+		return fmt.Errorf("CNI plugin %s already exists", name)
+	}
+
+	c.plugins[name] = i
+	if confDir != "" {
+		m, err := newCNINetConfSyncer(confDir, i, loadOpts)
+		if err != nil {
+			return fmt.Errorf("failed to create cni conf monitor for %s: %w", name, err)
+		}
+		c.confMonitor[name] = m
+		// If `start()` has been called, we need to start the syncloop directly.
+		if c.started {
+			log.L.Infof("Start cni network conf monitor for %s", name)
+			c.confSyncWG.Go(func() {
+				c.confSyncErrCh <- m.syncLoop()
+			})
+		}
+	}
+	c.waitForConfSyncStop()
+	return nil
+}
+
+// get returns the CNI plugin associated with `name`.
+func (c *cniNetPlugin) get(name string) cni.CNI {
+	c.RLock()
+	defer c.RUnlock()
+	if netPlugin, ok := c.plugins[name]; ok {
+		return netPlugin
+	}
+	return nil
+}
+
+// start starts all CNI conf syncers and returns a channel to report conf sync errors.
+// If a new CNI is added after `start()`, its syncer will start automatically.
+func (c *cniNetPlugin) start() <-chan error {
+	c.Lock()
+	defer c.Unlock()
+	if !c.started {
+		c.started = true
+		c.confSyncErrCh = make(chan error, len(c.confMonitor))
+		for name, syncer := range c.confMonitor {
+			log.L.Infof("Start cni network conf monitor for %s", name)
+			c.confSyncWG.Go(func() {
+				c.confSyncErrCh <- syncer.syncLoop()
+			})
+		}
+		c.waitForConfSyncStop()
+	}
+	return c.confSyncErrCh
+}
+
+// close closes all CNI conf syncers.
+func (c *cniNetPlugin) close() error {
+	var errs []error
+	c.Lock()
+	defer c.Unlock()
+	for name, syncer := range c.confMonitor {
+		if err := syncer.stop(); err != nil {
+			errs = append(errs, fmt.Errorf("failed to close cni conf monitor for %s: %w", name, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// status returns CNI load statuses for all CNI plugins.
+// This is used in a verbose CRI `Status` call.
+func (c *cniNetPlugin) status() map[string]string {
+	c.RLock()
+	defer c.RUnlock()
+	res := make(map[string]string, len(c.confMonitor)+1)
+
+	defaultStatus := "OK"
+	for name, h := range c.confMonitor {
+		s := "OK"
+		if h == nil {
+			continue
+		}
+		if lerr := h.lastStatus(); lerr != nil {
+			s = lerr.Error()
+		}
+		res[fmt.Sprintf("lastCNILoadStatus.%s", name)] = s
+		if name == defaultNetworkPlugin {
+			defaultStatus = s
+		}
+	}
+	res["lastCNILoadStatus"] = defaultStatus
+	return res
+}
+
+func (c *cniNetPlugin) waitForConfSyncStop() {
+	// For platforms that may not support CNI (darwin etc.) there's no
+	// use in launching this as `Wait` will return immediately. Further
+	// down we select on this channel along with some others to determine
+	// if we should Close() the CRI service, so closing this preemptively
+	// isn't good.
+	if c.started && len(c.confMonitor) > 0 && !c.confSyncWaitCreated {
+		c.confSyncWaitCreated = true
+		go func() {
+			for err := range c.confSyncErrCh {
+				if err != nil {
+					log.L.Errorf("CNI conf syncer error: %v", err)
+				}
+			}
+		}()
+		go func() {
+			c.confSyncWG.Wait()
+			close(c.confSyncErrCh)
+		}()
+	}
+}

--- a/internal/cri/server/cni_net_plugin_test.go
+++ b/internal/cri/server/cni_net_plugin_test.go
@@ -1,0 +1,71 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/containerd/go-cni"
+	"github.com/stretchr/testify/assert"
+
+	servertesting "github.com/containerd/containerd/v2/internal/cri/testing"
+)
+
+func TestCNINetPluginLifecycle(t *testing.T) {
+	cniNetPlugin := newCNINetPlugin()
+	assert.NotNil(t, cniNetPlugin)
+
+	count := 5
+	for i := range count {
+		err := cniNetPlugin.add(fmt.Sprintf("cni-%d", i), t.TempDir(), servertesting.NewFakeCNIPlugin(), []cni.Opt{})
+		assert.NoError(t, err)
+	}
+
+	errCh := cniNetPlugin.start()
+
+	originalConfDir := cniNetPlugin.confMonitor["cni-0"].confDir
+	duplicateConfDir := t.TempDir()
+	err := cniNetPlugin.add("cni-0", duplicateConfDir, servertesting.NewFakeCNIPlugin(), []cni.Opt{})
+	assert.Error(t, err)
+	assert.Equal(t, count, len(cniNetPlugin.plugins))
+	assert.Equal(t, count, len(cniNetPlugin.confMonitor))
+	assert.Equal(t, originalConfDir, cniNetPlugin.confMonitor["cni-0"].confDir)
+
+	assert.NoError(t, cniNetPlugin.close())
+	select {
+	case err := <-errCh:
+		assert.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for cniNetPlugin to close syncers")
+	}
+}
+
+func TestCNINetPluginAddBeforeStart(t *testing.T) {
+	cniNetPlugin := newCNINetPlugin()
+
+	firstPlugin := servertesting.NewFakeCNIPlugin()
+	err := cniNetPlugin.add(defaultNetworkPlugin, t.TempDir(), firstPlugin, []cni.Opt{})
+	assert.NoError(t, err)
+
+	err = cniNetPlugin.add(defaultNetworkPlugin, t.TempDir(), servertesting.NewFakeCNIPlugin(), []cni.Opt{})
+	assert.Error(t, err)
+	assert.True(t, firstPlugin == cniNetPlugin.get(defaultNetworkPlugin))
+	assert.Nil(t, cniNetPlugin.confSyncErrCh)
+	assert.False(t, cniNetPlugin.confSyncWaitCreated)
+}

--- a/internal/cri/server/sandbox_run.go
+++ b/internal/cri/server/sandbox_run.go
@@ -429,16 +429,16 @@ func (c *criService) ensurePauseImageExists(ctx context.Context, config *runtime
 // getNetworkPlugin returns the network plugin to be used by the runtime class
 // defaults to the global CNI options in the CRI config
 func (c *criService) getNetworkPlugin(runtimeClass string) cni.CNI {
-	if c.netPlugin == nil {
+	if c.cniNetPlugin == nil {
 		return nil
 	}
-	i, ok := c.netPlugin[runtimeClass]
-	if !ok {
-		if i, ok = c.netPlugin[defaultNetworkPlugin]; !ok {
-			return nil
-		}
+	if cni := c.cniNetPlugin.get(runtimeClass); cni != nil {
+		return cni
 	}
-	return i
+	if cni := c.cniNetPlugin.get(defaultNetworkPlugin); cni != nil {
+		return cni
+	}
+	return nil
 }
 
 // setupPodNetwork setups up the network for a pod

--- a/internal/cri/server/service.go
+++ b/internal/cri/server/service.go
@@ -22,11 +22,9 @@ import (
 	"io"
 	"net/http"
 	"slices"
-	"sync"
 	"sync/atomic"
 	"time"
 
-	"github.com/containerd/go-cni"
 	"github.com/containerd/log"
 	"github.com/containerd/typeurl/v2"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -139,8 +137,10 @@ type criService struct {
 	// containerNameIndex stores all container names and make sure each
 	// name is unique.
 	containerNameIndex *registrar.Registrar
-	// netPlugin is used to setup and teardown network when run/stop pod sandbox.
-	netPlugin map[string]cni.CNI
+	// cniNetPlugin is used to setup and teardown network when run/stop pod sandbox.
+	// It also reloads cni network conf if there is any valid fs change events
+	// from cni network conf dir.
+	cniNetPlugin *cniNetPlugin
 	// client is an instance of the containerd client
 	client *containerd.Client
 	// streamServer is the streaming server serves container streaming request.
@@ -150,9 +150,6 @@ type criService struct {
 	// initialized indicates whether the server is initialized. All GRPC services
 	// should return error before the server is initialized.
 	initialized atomic.Bool
-	// cniNetConfMonitor is used to reload cni network conf if there is
-	// any valid fs change events from cni network conf dir.
-	cniNetConfMonitor map[string]*cniNetConfSyncer
 	// allCaps is the list of the capabilities.
 	// When nil, parsed from CapEff of /proc/self/status.
 	allCaps []string //nolint:nolintlint,unused // Ignore on non-Linux
@@ -210,7 +207,7 @@ func NewCRIService(options *CRIServiceOptions) (CRIService, runtime.RuntimeServi
 		containerStore:     containerstore.NewStore(labels, statsCollector),
 		sandboxNameIndex:   registrar.NewRegistrar(),
 		containerNameIndex: registrar.NewRegistrar(),
-		netPlugin:          make(map[string]cni.CNI),
+		cniNetPlugin:       newCNINetPlugin(),
 		sandboxService:     newCriSandboxService(&config, options.SandboxControllers),
 		runtimeHandlers:    make(map[string]*runtime.RuntimeHandler),
 		statsCollector:     statsCollector,
@@ -237,23 +234,6 @@ func NewCRIService(options *CRIServiceOptions) (CRIService, runtime.RuntimeServi
 	}
 
 	c.eventMonitor = events.NewEventMonitor(&criEventHandler{c: c})
-
-	c.cniNetConfMonitor = make(map[string]*cniNetConfSyncer)
-	for name, i := range c.netPlugin {
-		path := c.config.NetworkPluginConfDir
-		if name != defaultNetworkPlugin {
-			if rc, ok := c.config.Runtimes[name]; ok {
-				path = rc.NetworkPluginConfDir
-			}
-		}
-		if path != "" {
-			m, err := newCNINetConfSyncer(path, i, c.cniLoadOptions())
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to create cni conf monitor for %s: %w", name, err)
-			}
-			c.cniNetConfMonitor[name] = m
-		}
-	}
 
 	c.nri = nri.NewAPI(options.NRI, &criImplementation{c})
 
@@ -299,34 +279,12 @@ func (c *criService) Run(ready func()) error {
 		return fmt.Errorf("failed to recover state: %w", err)
 	}
 
-	// Start event handler.
 	log.L.Info("Start event monitor")
 	eventMonitorErrCh := c.eventMonitor.Start()
 
-	// Start CNI network conf syncers
-	cniNetConfMonitorErrCh := make(chan error, len(c.cniNetConfMonitor))
-	var netSyncGroup sync.WaitGroup
-	for name, h := range c.cniNetConfMonitor {
-		netSyncGroup.Add(1)
-		log.L.Infof("Start cni network conf syncer for %s", name)
-		go func(h *cniNetConfSyncer) {
-			cniNetConfMonitorErrCh <- h.syncLoop()
-			netSyncGroup.Done()
-		}(h)
-	}
-	// For platforms that may not support CNI (darwin etc.) there's no
-	// use in launching this as `Wait` will return immediately. Further
-	// down we select on this channel along with some others to determine
-	// if we should Close() the CRI service, so closing this preemptively
-	// isn't good.
-	if len(c.cniNetConfMonitor) > 0 {
-		go func() {
-			netSyncGroup.Wait()
-			close(cniNetConfMonitorErrCh)
-		}()
-	}
+	log.L.Info("Start CNI network conf monitor")
+	cniNetConfMonitorErrCh := c.cniNetPlugin.start()
 
-	// Start streaming server.
 	log.L.Info("Start streaming server")
 	streamServerErrCh := make(chan error)
 	go func() {
@@ -382,11 +340,10 @@ func (c *criService) Run(ready func()) error {
 // TODO(random-liu): Make close synchronous.
 func (c *criService) Close() error {
 	log.L.Info("Stop CRI service")
-	for name, h := range c.cniNetConfMonitor {
-		if err := h.stop(); err != nil {
-			log.L.WithError(err).Errorf("failed to stop cni network conf monitor for %s", name)
-		}
+	if err := c.cniNetPlugin.close(); err != nil {
+		log.L.WithError(err).Errorf("failed to stop cni network conf monitor")
 	}
+
 	c.eventMonitor.Stop()
 	if c.statsCollector != nil {
 		c.statsCollector.Stop()

--- a/internal/cri/server/service_linux.go
+++ b/internal/cri/server/service_linux.go
@@ -56,6 +56,29 @@ func (c *criService) initPlatform() (err error) {
 		selinux.SetDisabled()
 	}
 
+	if err := c.initCNIPlugins(); err != nil {
+		return err
+	}
+
+	if c.allCaps == nil {
+		c.allCaps, err = cap.Current()
+		if err != nil {
+			return fmt.Errorf("failed to get caps: %w", err)
+		}
+	}
+
+	if c.config.EnableCDI == nil || *c.config.EnableCDI {
+		err := cdi.Configure(cdi.WithSpecDirs(c.config.CDISpecDirs...))
+		if err != nil {
+			return fmt.Errorf("failed to configure CDI registry")
+		}
+	}
+
+	return nil
+}
+
+// initCNIPlugins handles linux specific CNI plugin initializations.
+func (c *criService) initCNIPlugins() error {
 	pluginDirs := map[string]string{
 		defaultNetworkPlugin: c.config.NetworkPluginConfDir,
 	}
@@ -71,7 +94,6 @@ func (c *criService) initPlatform() (err error) {
 		networkAttachCount = 1
 	}
 
-	c.netPlugin = make(map[string]cni.CNI)
 	for name, dir := range pluginDirs {
 		max := c.config.NetworkPluginMaxConfNum
 		if name != defaultNetworkPlugin {
@@ -91,23 +113,10 @@ func (c *criService) initPlatform() (err error) {
 		if err != nil {
 			return fmt.Errorf("failed to initialize cni: %w", err)
 		}
-		c.netPlugin[name] = i
-	}
-
-	if c.allCaps == nil {
-		c.allCaps, err = cap.Current()
-		if err != nil {
-			return fmt.Errorf("failed to get caps: %w", err)
+		if err := c.cniNetPlugin.add(name, dir, i, c.cniLoadOptions()); err != nil {
+			return err
 		}
 	}
-
-	if c.config.EnableCDI == nil || *c.config.EnableCDI {
-		err := cdi.Configure(cdi.WithSpecDirs(c.config.CDISpecDirs...))
-		if err != nil {
-			return fmt.Errorf("failed to configure CDI registry")
-		}
-	}
-
 	return nil
 }
 

--- a/internal/cri/server/service_test.go
+++ b/internal/cri/server/service_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	"github.com/containerd/errdefs"
-	"github.com/containerd/go-cni"
 	"github.com/containerd/platforms"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 
@@ -151,10 +150,12 @@ func newTestCRIService(opts ...testOpt) *criService {
 		sandboxNameIndex:   registrar.NewRegistrar(),
 		containerStore:     containerstore.NewStore(labels, nil),
 		containerNameIndex: registrar.NewRegistrar(),
-		netPlugin: map[string]cni.CNI{
-			defaultNetworkPlugin: servertesting.NewFakeCNIPlugin(),
-		},
-		sandboxService: &fakeSandboxService{},
+		cniNetPlugin:       newCNINetPlugin(),
+		sandboxService:     &fakeSandboxService{},
+	}
+	err := service.cniNetPlugin.add(defaultNetworkPlugin, "", servertesting.NewFakeCNIPlugin(), service.cniLoadOptions())
+	if err != nil {
+		panic(err)
 	}
 	for _, opt := range opts {
 		opt(service)

--- a/internal/cri/server/service_windows.go
+++ b/internal/cri/server/service_windows.go
@@ -28,6 +28,11 @@ const windowsNetworkAttachCount = 1
 
 // initPlatform handles windows specific initialization for the CRI service.
 func (c *criService) initPlatform() error {
+	return c.initCNIPlugins()
+}
+
+// initCNIPlugins handles windows specific CNI plugin initializations.
+func (c *criService) initCNIPlugins() error {
 	pluginDirs := map[string]string{
 		defaultNetworkPlugin: c.config.NetworkPluginConfDir,
 	}
@@ -37,7 +42,6 @@ func (c *criService) initPlatform() error {
 		}
 	}
 
-	c.netPlugin = make(map[string]cni.CNI)
 	for name, dir := range pluginDirs {
 		max := c.config.NetworkPluginMaxConfNum
 		if name != defaultNetworkPlugin {
@@ -57,7 +61,9 @@ func (c *criService) initPlatform() error {
 		if err != nil {
 			return fmt.Errorf("failed to initialize cni: %w", err)
 		}
-		c.netPlugin[name] = i
+		if err := c.cniNetPlugin.add(name, dir, i, c.cniLoadOptions()); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/internal/cri/server/status_test.go
+++ b/internal/cri/server/status_test.go
@@ -97,6 +97,7 @@ func newFakeContainerdClient() *containerd.Client {
 func newStatusTestCRIService() *criService {
 	return &criService{
 		client:          newFakeContainerdClient(),
+		cniNetPlugin:    newCNINetPlugin(),
 		runtimeHandlers: make(map[string]*runtime.RuntimeHandler),
 	}
 }

--- a/internal/cri/server/update_runtime_config.go
+++ b/internal/cri/server/update_runtime_config.go
@@ -72,7 +72,7 @@ func (c *criService) UpdateRuntimeConfig(ctx context.Context, r *runtime.UpdateR
 		log.G(ctx).Info("No cni config template is specified, wait for other system components to drop the config.")
 		return &runtime.UpdateRuntimeConfigResponse{}, nil
 	}
-	netPlugin := c.netPlugin[defaultNetworkPlugin]
+	netPlugin := c.cniNetPlugin.get(defaultNetworkPlugin)
 	if netPlugin == nil {
 		log.G(ctx).Infof("Network plugin is ready, skip generating cni config from template %q", confTemplate)
 		return &runtime.UpdateRuntimeConfigResponse{}, nil

--- a/internal/cri/server/update_runtime_config_test.go
+++ b/internal/cri/server/update_runtime_config_test.go
@@ -124,8 +124,8 @@ func TestUpdateRuntimeConfig(t *testing.T) {
 				req.RuntimeConfig.NetworkConfig.PodCidr = ""
 			}
 			if !test.networkReady {
-				c.netPlugin[defaultNetworkPlugin].(*servertesting.FakeCNIPlugin).StatusErr = errors.New("random error")
-				c.netPlugin[defaultNetworkPlugin].(*servertesting.FakeCNIPlugin).LoadErr = errors.New("random error")
+				c.cniNetPlugin.get(defaultNetworkPlugin).(*servertesting.FakeCNIPlugin).StatusErr = errors.New("random error")
+				c.cniNetPlugin.get(defaultNetworkPlugin).(*servertesting.FakeCNIPlugin).LoadErr = errors.New("random error")
 			}
 			_, err = c.UpdateRuntimeConfig(context.Background(), req)
 			assert.NoError(t, err)


### PR DESCRIPTION
This PR moves CNI related logics in CRI to a single struct.

This brings a few benefits:

1. Consolidate CNI init to a single `add` func. Previously
the CNI and the syncer are inited in `initPlatform` and
`NewCRIService` separately.

2. More modularized CNI logic. Previously most logic is
hardcoded in different places (`initPlatform`/`NewCRIService`/`Run`).

3. Enables adding new CNI/syncer **after** CRI start. Previously
you cannot add a new one because of the hardcode logic in CRI startup.
This will help implement extracting runtime config to separate files (https://github.com/containerd/containerd/issues/9296)
