### PR TITLE
Update fetcher errors to include full registry error

### DIFF
--- a/core/remotes/docker/errcode.go
+++ b/core/remotes/docker/errcode.go
@@ -18,8 +18,12 @@ package docker
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
 	"strings"
+
+	remoteerrors "github.com/containerd/containerd/v2/core/remotes/errors"
 )
 
 // ErrorCoder is the base interface for ErrorCode and Error allowing
@@ -280,4 +284,22 @@ func (errs *Errors) UnmarshalJSON(data []byte) error {
 
 	*errs = newErrs
 	return nil
+}
+
+func unexpectedResponseErr(resp *http.Response) (retErr error) {
+	retErr = remoteerrors.NewUnexpectedStatusErr(resp)
+
+	// Decode registry error if provided
+	if rerr := retErr.(remoteerrors.ErrUnexpectedStatus); len(rerr.Body) > 0 {
+		var registryErr Errors
+		if err := json.Unmarshal(rerr.Body, &registryErr); err == nil && registryErr.Len() > 0 {
+			// Join the unexpected error with the typed errors, when printed it will
+			// show the unexpected error message and the registry errors. The body
+			// is always excluded from the unexpected error message. This also allows
+			// clients to decode into either type.
+			retErr = errors.Join(rerr, registryErr)
+		}
+	}
+
+	return
 }

--- a/core/remotes/docker/fetcher_test.go
+++ b/core/remotes/docker/fetcher_test.go
@@ -534,13 +534,11 @@ func TestDockerFetcherOpen(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 			assert.Equal(t, 0, tt.retries)
 			if tt.wantErr {
-				var expectedError error
+				expectedError := fmt.Sprintf("unexpected status from GET request to %s/ns: %v %s", s.URL, tt.mockedStatus, http.StatusText(tt.mockedStatus))
 				if tt.wantServerMessageError {
-					expectedError = fmt.Errorf("unexpected status code %v/ns: %v %s - Server message: %s", s.URL, tt.mockedStatus, http.StatusText(tt.mockedStatus), tt.mockedErr.Error())
-				} else if tt.wantPlainError {
-					expectedError = fmt.Errorf("unexpected status code %v/ns: %v %s", s.URL, tt.mockedStatus, http.StatusText(tt.mockedStatus))
+					expectedError += "\n" + tt.mockedErr.Error()
 				}
-				assert.Equal(t, expectedError.Error(), err.Error())
+				assert.Equal(t, expectedError, err.Error())
 
 			}
 


### PR DESCRIPTION
Currently the registry error does not include details or allow the caller access to the original error body.