### PR TITLE
migrate golangci-lint to v2.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,9 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/install-go
-      - uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+      - uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
-          version: v1.64.2
+          version: v2.0.2
           skip-cache: true
           args: --timeout=8m
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,89 +1,102 @@
+version: "2"
 linters:
   enable:
-    - depguard # Checks for dependencies that should not be (re)introduced. See "linter-settings" for further details.
-    - copyloopvar # Checks for loop variable copies in Go 1.22+
-    - gofmt
-    - goimports
+    - copyloopvar
+    - depguard
+    - dupword
     - gosec
-    - ineffassign
     - misspell
     - nolintlint
     - revive
-    - staticcheck
-    - tenv # Detects using os.Setenv instead of t.Setenv since Go 1.17
     - unconvert
-    - unused
-    - govet
-    - dupword # Checks for duplicate words in the source code
   disable:
     - errcheck
+  settings:
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: github.com/opencontainers/runc
+              desc: We don't want to depend on runc (libcontainer), unless there is no other option; see https://github.com/opencontainers/runc/issues/3028.
+    gosec:
+      excludes:
+        - G204
+        - G305
+        - G306
+        - G402
+        - G404
+        - G115
+    nolintlint:
+      allow-unused: true
+    staticcheck:
+      checks:
+        - '-QF1003'
+        - '-QF1004'
+        - '-QF1008'
+        - '-ST1013'
+        - '-ST1015'
+        - '-ST1019'
 
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - path: cmd[\\/]containerd[\\/]builtins[\\/]
+        text: 'blank-imports:'
+      - path: contrib[\\/]fuzz[\\/]
+        text: 'exported: func name will be used as fuzz.Fuzz'
+      - path: archive[\\/]tarheader[\\/]
+        text: unnecessary conversion
+      - path: integration[\\/]client
+        text: 'dot-imports:'
+      - linters:
+          - revive
+        text: if-return
+      - linters:
+          - revive
+        text: empty-block
+      - linters:
+          - revive
+        text: superfluous-else
+      - linters:
+          - revive
+        text: unused-parameter
+      - linters:
+          - revive
+        text: unreachable-code
+      - linters:
+          - revive
+        text: redefines-builtin-id
+    paths:
+      - api
+      - cluster
+      - docs
+      - docs/man
+      - releases
+      - test
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  include:
-    - EXC0002
   max-issues-per-linter: 0
   max-same-issues: 0
-
-  exclude-dirs:
-    - api
-    - cluster
-    - docs
-    - docs/man
-    - releases
-    - test # e2e scripts
-
-  # Only using / doesn't work due to https://github.com/golangci/golangci-lint/issues/1398.
-  exclude-rules:
-    - path: 'cmd[\\/]containerd[\\/]builtins[\\/]'
-      text: "blank-imports:"
-    - path: 'contrib[\\/]fuzz[\\/]'
-      text: "exported: func name will be used as fuzz.Fuzz"
-    - path: 'archive[\\/]tarheader[\\/]'
-      # conversion is necessary on Linux, unnecessary on macOS
-      text: "unnecessary conversion"
-    - path: 'integration[\\/]client'
-      text: "dot-imports:"
-    - linters:
-        - revive
-      text: "if-return"
-    - linters:
-        - revive
-      text: "empty-block"
-    - linters:
-        - revive
-      text: "superfluous-else"
-    - linters:
-        - revive
-      text: "unused-parameter"
-    - linters:
-        - revive
-      text: "unreachable-code"
-    - linters:
-        - revive
-      text: "redefines-builtin-id"
-
-linters-settings:
-  depguard:
-    rules:
-      main:
-        deny:
-          - pkg: github.com/opencontainers/runc
-            desc: We don't want to depend on runc (libcontainer), unless there is no other option; see https://github.com/opencontainers/runc/issues/3028.
-
-  gosec:
-    # The following issues surfaced when `gosec` linter
-    # was enabled. They are temporarily excluded to unblock
-    # the existing workflow, but still to be addressed by
-    # future works.
-    excludes:
-      - G204
-      - G305
-      - G306
-      - G402
-      - G404
-      - G115
-  nolintlint:
-    allow-unused: true
-
-run:
-  timeout: 8m
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - api
+      - cluster
+      - docs
+      - docs/man
+      - releases
+      - test
+      - third_party$
+      - builtin$
+      - examples$

--- a/core/mount/mount_idmapped_linux.go
+++ b/core/mount/mount_idmapped_linux.go
@@ -95,16 +95,16 @@ func IDMapMountWithAttrs(source, target string, usernsFd int, attrSet uint64, at
 
 	dFd, err := unix.OpenTree(-int(unix.EBADF), source, uint(unix.OPEN_TREE_CLONE|unix.OPEN_TREE_CLOEXEC|unix.AT_EMPTY_PATH))
 	if err != nil {
-		return fmt.Errorf("Unable to open tree for %s: %w", target, err)
+		return fmt.Errorf("unable to open tree for %s: %w", target, err)
 	}
 
 	defer unix.Close(dFd)
 	if err = unix.MountSetattr(dFd, "", unix.AT_EMPTY_PATH, &attr); err != nil {
-		return fmt.Errorf("Unable to shift GID/UID or set mount attrs for %s: %w", target, err)
+		return fmt.Errorf("unable to shift GID/UID or set mount attrs for %s: %w", target, err)
 	}
 
 	if err = unix.MoveMount(dFd, "", -int(unix.EBADF), target, unix.MOVE_MOUNT_F_EMPTY_PATH); err != nil {
-		return fmt.Errorf("Unable to attach mount tree to %s: %w", target, err)
+		return fmt.Errorf("unable to attach mount tree to %s: %w", target, err)
 	}
 	return nil
 }

--- a/internal/cri/bandwidth/linux.go
+++ b/internal/cri/bandwidth/linux.go
@@ -305,7 +305,7 @@ func (t *tcShaper) Reset(cidr string) error {
 		return err
 	}
 	if !found {
-		return fmt.Errorf("Failed to find cidr: %s on interface: %s", cidr, t.iface)
+		return fmt.Errorf("failed to find cidr: %s on interface: %s", cidr, t.iface)
 	}
 	for i := 0; i < len(classAndHandle); i++ {
 		if err := t.execAndLog("tc", "filter", "del",

--- a/script/setup/install-dev-tools
+++ b/script/setup/install-dev-tools
@@ -23,7 +23,7 @@ set -eu -o pipefail
 go install github.com/containerd/protobuild@v0.3.0
 go install github.com/containerd/protobuild/cmd/go-fix-acronym@v0.3.0
 go install github.com/cpuguy83/go-md2man/v2@v2.0.2
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.1
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.0.2
 go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.1
 go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2.0
 go install github.com/containerd/ttrpc/cmd/protoc-gen-go-ttrpc@v1.2.5


### PR DESCRIPTION
 golangci-lint v2 config automatically generated through the `golangci-lint migrate` command 