### PR TITLE
change criService.runtimeHandlers slice to a map

### DIFF
--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -283,12 +283,9 @@ func (c *criService) createContainer(r *createContainerRequest) (_ string, retEr
 		log.G(r.ctx).Debugf("Ignoring volumes defined in image %v because IgnoreImageDefinedVolumes is set", r.imageID)
 	}
 
-	var runtimeHandler *runtime.RuntimeHandler
-	for _, f := range c.runtimeHandlers {
-		if f.Name == r.sandboxRuntimeHandler {
-			runtimeHandler = f
-			break
-		}
+	runtimeHandler, ok := c.runtimeHandlers[r.sandboxRuntimeHandler]
+	if !ok {
+		return "", fmt.Errorf("failed to find runtime handler %q", r.sandboxRuntimeHandler)
 	}
 	log.G(r.ctx).Debugf("Use OCI runtime %+v for sandbox %q and container %q", ociRuntime, r.sandboxID, r.containerID)
 

--- a/internal/cri/server/status.go
+++ b/internal/cri/server/status.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	goruntime "runtime"
+	"slices"
 
 	"github.com/containerd/containerd/api/services/introspection/v1"
 	"github.com/containerd/log"
@@ -57,7 +59,7 @@ func (c *criService) Status(ctx context.Context, r *runtime.StatusRequest) (*run
 			runtimeCondition,
 			networkCondition,
 		}},
-		RuntimeHandlers: c.runtimeHandlers,
+		RuntimeHandlers: slices.Collect(maps.Values(c.runtimeHandlers)),
 		Features:        c.runtimeFeatures,
 	}
 	if r.Verbose {


### PR DESCRIPTION
This patch changes `criService.runtimeHandlers` from
a slice to a map, so we don't need to for-loop slice
in `createContainer`.

It also refactors `introspectRuntimeHandler` a bit
so it can be called given a single `config.Runtime`.
This will help implement extracting runtime config
to separate files (https://github.com/containerd/containerd/issues/9296).