### PR TITLE
use lazyregexp to compile regexes on first use

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,6 +61,10 @@ issues:
     - linters:
         - revive
       text: "redefines-builtin-id"
+    - linters:
+        - forbidigo
+      text: 'use of `regexp.MustCompile` forbidden'
+      path: _test\.go
 
 linters-settings:
   depguard:
@@ -69,6 +73,11 @@ linters-settings:
         deny:
           - pkg: github.com/opencontainers/runc
             desc: We don't want to depend on runc (libcontainer), unless there is no other option; see https://github.com/opencontainers/runc/issues/3028.
+  forbidigo:
+    forbid:
+      - pkg: ^regexp$
+        p: ^regexp\.MustCompile
+        msg: Use internal/lazyregexp.New instead.
 
   gosec:
     # The following issues surfaced when `gosec` linter

--- a/internal/cri/bandwidth/linux.go
+++ b/internal/cri/bandwidth/linux.go
@@ -40,19 +40,19 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net"
-	"regexp"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/exec"
 
-	"k8s.io/klog/v2"
+	"github.com/containerd/containerd/v2/internal/lazyregexp"
 )
 
 var (
-	classShowMatcher      = regexp.MustCompile(`class htb (1:\d+)`)
-	classAndHandleMatcher = regexp.MustCompile(`filter parent 1:.*fh (\d+::\d+).*flowid (\d+:\d+)`)
+	classShowMatcher      = lazyregexp.New(`class htb (1:\d+)`)
+	classAndHandleMatcher = lazyregexp.New(`filter parent 1:.*fh (\d+::\d+).*flowid (\d+:\d+)`)
 )
 
 // tcShaper provides an implementation of the Shaper interface on Linux using the 'tc' tool.

--- a/internal/lazyregexp/lazyregexp.go
+++ b/internal/lazyregexp/lazyregexp.go
@@ -1,0 +1,86 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Code below was largely copied from golang.org/x/mod@v0.22;
+// https://github.com/golang/mod/blob/v0.22.0/internal/lazyregexp/lazyre.go
+// with some additional methods added.
+
+// Package lazyregexp is a thin wrapper over regexp, allowing the use of global
+// regexp variables without forcing them to be compiled at init.
+package lazyregexp
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// Regexp is a wrapper around [regexp.Regexp], where the underlying regexp will be
+// compiled the first time it is needed.
+type Regexp struct {
+	str  string
+	once sync.Once
+	rx   *regexp.Regexp
+}
+
+func (re *Regexp) re() *regexp.Regexp {
+	re.once.Do(re.build)
+	return re.rx
+}
+
+func (re *Regexp) build() {
+	re.rx = regexp.MustCompile(re.str)
+	re.str = ""
+}
+
+func (re *Regexp) FindStringIndex(s string) (loc []int) {
+	return re.re().FindStringIndex(s)
+}
+
+func (re *Regexp) FindStringSubmatch(s string) []string {
+	return re.re().FindStringSubmatch(s)
+}
+
+func (re *Regexp) MatchString(s string) bool {
+	return re.re().MatchString(s)
+}
+
+func (re *Regexp) ReplaceAll(src, repl []byte) []byte {
+	return re.re().ReplaceAll(src, repl)
+}
+
+func (re *Regexp) String() string {
+	return re.re().String()
+}
+
+var inTest = len(os.Args) > 0 && strings.HasSuffix(strings.TrimSuffix(os.Args[0], ".exe"), ".test")
+
+// New creates a new lazy regexp, delaying the compiling work until it is first
+// needed. If the code is being run as part of tests, the regexp compiling will
+// happen immediately.
+func New(str string) *Regexp {
+	lr := &Regexp{str: str}
+	if inTest {
+		// In tests, always compile the regexps early.
+		lr.re()
+	}
+	return lr
+}

--- a/internal/lazyregexp/lazyregexp_test.go
+++ b/internal/lazyregexp/lazyregexp_test.go
@@ -1,0 +1,39 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package lazyregexp
+
+import (
+	"testing"
+)
+
+func TestCompileOnce(t *testing.T) {
+	t.Run("invalid regexp", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("expected a panic")
+			}
+		}()
+		_ = New("[")
+	})
+	t.Run("valid regexp", func(t *testing.T) {
+		re := New("[a-z]")
+		ok := re.MatchString("hello")
+		if !ok {
+			t.Errorf("expected a match")
+		}
+	})
+}

--- a/pkg/identifiers/validate.go
+++ b/pkg/identifiers/validate.go
@@ -26,8 +26,8 @@ package identifiers
 
 import (
 	"fmt"
-	"regexp"
 
+	"github.com/containerd/containerd/v2/internal/lazyregexp"
 	"github.com/containerd/errdefs"
 )
 
@@ -39,7 +39,7 @@ const (
 
 var (
 	// identifierRe defines the pattern for valid identifiers.
-	identifierRe = regexp.MustCompile(reAnchor(alphanum + reGroup(separators+reGroup(alphanum)) + "*"))
+	identifierRe = lazyregexp.New(reAnchor(alphanum + reGroup(separators+reGroup(alphanum)) + "*"))
 )
 
 // Validate returns nil if the string s is a valid identifier.

--- a/pkg/progress/writer.go
+++ b/pkg/progress/writer.go
@@ -21,14 +21,14 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"regexp"
 	"strings"
 
 	"github.com/containerd/console"
+	"github.com/containerd/containerd/v2/internal/lazyregexp"
 )
 
 var (
-	regexCleanLine = regexp.MustCompile("\x1b\\[[0-9]+m[\x1b]?")
+	regexCleanLine = lazyregexp.New("\x1b\\[[0-9]+m[\x1b]?")
 )
 
 // Writer buffers writes until flush, at which time the last screen is cleared

--- a/pkg/reference/reference.go
+++ b/pkg/reference/reference.go
@@ -20,9 +20,9 @@ import (
 	"errors"
 	"net/url"
 	"path"
-	"regexp"
 	"strings"
 
+	"github.com/containerd/containerd/v2/internal/lazyregexp"
 	digest "github.com/opencontainers/go-digest"
 )
 
@@ -80,7 +80,7 @@ type Spec struct {
 	Object string
 }
 
-var splitRe = regexp.MustCompile(`[:@]`)
+var splitRe = lazyregexp.New(`[:@]`)
 
 // Parse parses the string into a structured ref.
 func Parse(s string) (Spec, error) {

--- a/pkg/sys/filesys_windows.go
+++ b/pkg/sys/filesys_windows.go
@@ -18,11 +18,12 @@ package sys
 
 import (
 	"os"
-	"regexp"
 	"syscall"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
+
+	"github.com/containerd/containerd/v2/internal/lazyregexp"
 )
 
 // SddlAdministratorsLocalSystem is local administrators plus NT AUTHORITY\System.
@@ -31,7 +32,7 @@ const SddlAdministratorsLocalSystem = "D:P(A;OICI;GA;;;BA)(A;OICI;GA;;;SY)"
 // volumePath is a regular expression to check if a path is a Windows
 // volume path (e.g., "\\?\Volume{4c1b02c1-d990-11dc-99ae-806e6f6e6963}"
 // or "\\?\Volume{4c1b02c1-d990-11dc-99ae-806e6f6e6963}\").
-var volumePath = regexp.MustCompile(`^\\\\\?\\Volume{[a-z0-9-]+}\\?$`)
+var volumePath = lazyregexp.New(`^\\\\\?\\Volume{[a-z0-9-]+}\\?$`)
 
 // MkdirAllWithACL is a custom version of os.MkdirAll modified for use on Windows
 // so that it is both volume path aware, and to create a directory


### PR DESCRIPTION
- similar to https://github.com/moby/moby/pull/48166

### implement lazyregexp package

Based on the "lazyregexp" package in golang.org/x/mod;
https://cs.opensource.google/go/x/mod/+/refs/tags/v0.19.0:internal/lazyregexp/lazyre.go;l=66-78

This package allows defining regular expressions that should not be
compiled until used, but still providing validation to prevent
invalid regular expressions from producing a panic at runtime.

The lazyregexp package provides a subset of the methods provided
by "regexp" and only implements the methods used in the codebase.
Additional methods can be added when needed.
