### PR TITLE
client: fix returned error in the defer function

### DIFF
--- a/client/container.go
+++ b/client/container.go
@@ -224,7 +224,7 @@ func (c *container) Image(ctx context.Context) (Image, error) {
 	return NewImage(c.client, i), nil
 }
 
-func (c *container) NewTask(ctx context.Context, ioCreate cio.Creator, opts ...NewTaskOpts) (_ Task, err error) {
+func (c *container) NewTask(ctx context.Context, ioCreate cio.Creator, opts ...NewTaskOpts) (_ Task, retErr error) {
 	ctx, span := tracing.StartSpan(ctx, "container.NewTask")
 	defer span.End()
 	i, err := ioCreate(c.id)
@@ -232,7 +232,7 @@ func (c *container) NewTask(ctx context.Context, ioCreate cio.Creator, opts ...N
 		return nil, err
 	}
 	defer func() {
-		if err != nil && i != nil {
+		if retErr != nil && i != nil {
 			i.Cancel()
 			i.Close()
 		}
@@ -366,14 +366,14 @@ func (c *container) handleMounts(ctx context.Context, request *tasks.CreateTaskR
 	return nil
 }
 
-func (c *container) Restore(ctx context.Context, ioCreate cio.Creator, rootDir string) (int, error) {
+func (c *container) Restore(ctx context.Context, ioCreate cio.Creator, rootDir string) (_ int, retErr error) {
 	errorPid := -1
 	i, err := ioCreate(c.id)
 	if err != nil {
 		return errorPid, err
 	}
 	defer func() {
-		if err != nil && i != nil {
+		if retErr != nil && i != nil {
 			i.Cancel()
 			i.Close()
 		}

--- a/client/task.go
+++ b/client/task.go
@@ -416,7 +416,7 @@ func (t *task) Delete(ctx context.Context, opts ...ProcessDeleteOpts) (*ExitStat
 	return &ExitStatus{code: r.ExitStatus, exitedAt: protobuf.FromTimestamp(r.ExitedAt)}, nil
 }
 
-func (t *task) Exec(ctx context.Context, id string, spec *specs.Process, ioCreate cio.Creator) (_ Process, err error) {
+func (t *task) Exec(ctx context.Context, id string, spec *specs.Process, ioCreate cio.Creator) (_ Process, retErr error) {
 	ctx, span := tracing.StartSpan(ctx, "task.Exec",
 		tracing.WithAttribute("task.id", t.ID()),
 	)
@@ -430,7 +430,7 @@ func (t *task) Exec(ctx context.Context, id string, spec *specs.Process, ioCreat
 		return nil, err
 	}
 	defer func() {
-		if err != nil && i != nil {
+		if retErr != nil && i != nil {
 			i.Cancel()
 			i.Close()
 		}


### PR DESCRIPTION
1. Fix the error variable used in the defer function within the `Restore` method.
2. Ensure consistent variable naming in the same context for the other two locations in *./client*