### PR TITLE
ci: temporarily disable portmap critest in ubuntu-22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,8 +486,12 @@ jobs:
           TEST_RUNTIME: ${{ matrix.runtime }}
           CGROUP_DRIVER: ${{ matrix.cgroup_driver }}
         run: |
+          # skipping the ipv6 test till https://github.com/actions/runner-images/issues/11985 is fixed
+          if [[ ${{matrix.os}} == "ubuntu-22.04" ]]; then
+            skip_test="runtime should support port mapping with host port and container port"
+          fi
           env
-          sudo -E PATH=$PATH ./script/critest.sh "${{github.workspace}}/report"
+          sudo -E PATH=$PATH SKIP_TEST="$skip_test" ./script/critest.sh "${{github.workspace}}/report"
 
       - name: Install tools
         # The GitHub Actions image already has buildah and podman included. Not the

--- a/script/critest.sh
+++ b/script/critest.sh
@@ -70,6 +70,11 @@ if [ ! -z "$CGROUP_DRIVER" ] && [ "$CGROUP_DRIVER" = "systemd" ];then
 EOF
 fi
 
+GINKGO_SKIP_TEST=()
+if [ ! -z "$SKIP_TEST" ]; then
+  GINKGO_SKIP_TEST+=("--ginkgo.skip" "$SKIP_TEST")
+fi
+
 ls /etc/cni/net.d
 
 /usr/local/bin/containerd \
@@ -85,4 +90,4 @@ do
     crictl --runtime-endpoint ${BDIR}/c.sock info && break || sleep 1
 done
 
-critest --report-dir "$report_dir" --runtime-endpoint=unix:///${BDIR}/c.sock --parallel=8 "${EXTRA_CRITEST_OPTIONS:-""}"
+critest --report-dir "$report_dir" --runtime-endpoint=unix:///${BDIR}/c.sock --parallel=8 "${GINKGO_SKIP_TEST[@]}" "${EXTRA_CRITEST_OPTIONS:-""}"


### PR DESCRIPTION
Because of [issue](https://github.com/actions/runner-images/issues/11985) with ubuntu-22 runner image related to ipv6 tests, temporarily skip these tests.

Changes in this patch:
- add support for skipping tests in critest.sh
- disable portmap test in  critest