### PR TITLE
[release/2.0] Prepare release notes for v2.0.5

### DIFF
--- a/releases/v2.0.5.toml
+++ b/releases/v2.0.5.toml
@@ -1,0 +1,27 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+ignore_deps = [ "github.com/containerd/containerd" ]
+
+# previous release
+previous = "v2.0.4"
+
+pre_release = false
+
+preface = """\
+The fifth patch release for containerd 2.0 includes various bug fixes and updates.
+"""
+
+postface = """\
+### Which file should I download?
+* `containerd-<VERSION>-<OS>-<ARCH>.tar.gz`:         ✅Recommended. Dynamically linked with glibc 2.31 (Ubuntu 20.04).
+* `containerd-static-<VERSION>-<OS>-<ARCH>.tar.gz`:  Statically linked. Expected to be used on non-glibc Linux distributions. Not position-independent.
+
+In addition to containerd, typically you will have to install [runc](https://github.com/opencontainers/runc/releases)
+and [CNI plugins](https://github.com/containernetworking/plugins/releases) from their official sites too.
+
+See also the [Getting Started](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) documentation.
+"""

--- a/version/version.go
+++ b/version/version.go
@@ -24,7 +24,7 @@ var (
 	Package = "github.com/containerd/containerd/v2"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "2.0.4+unknown"
+	Version = "2.0.5+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
Changes to release script tested at https://github.com/dmcgowan/containerd/actions/runs/14508353681

----

containerd 2.0.5

Welcome to the v2.0.5 release of containerd!

The fifth patch release for containerd 2.0 includes various bug fixes and updates.

### Highlights

#### Container Runtime Interface (CRI)

* Update ImageService to delete images synchronously ([#11599](https://github.com/containerd/containerd/pull/11599))

#### Image Distribution

* Prevent panic on zero length push ([#11698](https://github.com/containerd/containerd/pull/11698))
* Set default differ for the default unpack config of transfer service ([#11688](https://github.com/containerd/containerd/pull/11688))

#### Runtime

* Update taskOptions based on runtimeOptions when creating a task ([#11618](https://github.com/containerd/containerd/pull/11618))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Akihiro Suda
* Derek McGowan
* Phil Estes
* Wei Fu
* Iceber Gu
* Akhil Mohan
* Austin Vazquez
* Cesar Talledo
* Henry Wang
* Jin Dong
* Krisztian Litkey
* Yang Yang

### Changes
<details><summary>29 commits</summary>
<p>

  * [`a8082cd60`](https://github.com/containerd/containerd/commit/a8082cd60df5843b19710e832c653d4cfa6cfd88) Prepare release notes for v2.0.5
* Disable criu test on arm64 ([#11710](https://github.com/containerd/containerd/pull/11710))
  * [`58b715ad8`](https://github.com/containerd/containerd/commit/58b715ad8dd372472f91dec84aec581d35b417c0) Disable arm64 criu testing in GH Actions
  * [`b4a53e826`](https://github.com/containerd/containerd/commit/b4a53e8264dd6cc93573630c0e59902eaa822886) disable portmap test in ubuntu-22 to make CI happy
  * [`4bcf472de`](https://github.com/containerd/containerd/commit/4bcf472de6ccf12b9f17ea095d8257fd7d7c1d18) add option to skip tests in critest
* Prevent panic on zero length push ([#11698](https://github.com/containerd/containerd/pull/11698))
  * [`8a638b71a`](https://github.com/containerd/containerd/commit/8a638b71aef45e16b7dcf86bd5267229d715a2e9) Prevent panic in Docker pusher.
* Set default differ for the default unpack config of transfer service ([#11688](https://github.com/containerd/containerd/pull/11688))
  * [`84d9658c3`](https://github.com/containerd/containerd/commit/84d9658c36c73ba4ae87471dd760ef3539b26c2b) Set default differ for the default unpack config of transfer service
* ci: update GitHub Actions release runner to ubuntu-24.04 ([#11703](https://github.com/containerd/containerd/pull/11703))
  * [`b184a97d3`](https://github.com/containerd/containerd/commit/b184a97d304a6397758810695ca3fb245a66993f) ci: update GitHub Actions release runner to ubuntu-24.04
* fix: call checkCopyShimLogError(shimCtx) to avoid expected error log flood ([#11621](https://github.com/containerd/containerd/pull/11621))
  * [`e04543db0`](https://github.com/containerd/containerd/commit/e04543db09ce872a06bbd3aa751bbd6c3a7531c5) use shimCtx for fifo copy
* Update taskOptions based on runtimeOptions when creating a task ([#11618](https://github.com/containerd/containerd/pull/11618))
  * [`9f46e7a44`](https://github.com/containerd/containerd/commit/9f46e7a449a06934bfb4a9b4b9718c1f625b1693) integration/client: add tests for TaskOptions is not empty
  * [`8a16a6a04`](https://github.com/containerd/containerd/commit/8a16a6a04ad081deac2f4907adda2326e62e5182) prefer task options for PluginInfo request
  * [`a183b2d23`](https://github.com/containerd/containerd/commit/a183b2d232fd3c0ca7cf4903b2392cce639ca7c5) update taskOptions based on runtimeOptions when creating a task
* Update ImageService to delete images synchronously ([#11599](https://github.com/containerd/containerd/pull/11599))
  * [`091143135`](https://github.com/containerd/containerd/commit/091143135ba903808c76fbdd10316975dcf4b0f1) *: CRIImageService should delete image synchronously
* Update runc binary to v1.2.6 ([#11583](https://github.com/containerd/containerd/pull/11583))
  * [`c2372c072`](https://github.com/containerd/containerd/commit/c2372c072cb41e9c4217c345c22189cb139820c6) Update runc binary to v1.2.6
* go.{mod,sum}: bump CDI deps to stable v1.0.0. ([#11566](https://github.com/containerd/containerd/pull/11566))
  * [`e8506511b`](https://github.com/containerd/containerd/commit/e8506511b28fb5343d037e0e56b6a36f7d4a70da) go.{mod,sum}: bump CDI deps to stable v1.0.0.
* silence govulncheck false positives ([#11571](https://github.com/containerd/containerd/pull/11571))
  * [`4cfb89430`](https://github.com/containerd/containerd/commit/4cfb89430cefd30fb2855721176e1b03a227d3b0) go.mod: github.com/go-jose/go-jose/v4
  * [`2b9e6a29d`](https://github.com/containerd/containerd/commit/2b9e6a29d7ba23fea935bfc7fa6613978d0ca45a) go.mod: golang.org/x/oauth2 v0.28.0
  * [`6df1ea0d9`](https://github.com/containerd/containerd/commit/6df1ea0d9e1743d7d2b5ffe049a68b4d279f2dbd) go.mod: golang.org/x/net v0.37.0
* Fix CI lint error (cherry-picked #11555) ([#11567](https://github.com/containerd/containerd/pull/11567))
  * [`16f20abdf`](https://github.com/containerd/containerd/commit/16f20abdffa6041382660f1374f25eb9fdfd2fc7) Fix CI lint error
</p>
</details>

### Dependency Changes

* **github.com/go-jose/go-jose/v4**                     v4.0.4 -> v4.0.5
* **golang.org/x/crypto**                               v0.31.0 -> v0.36.0
* **golang.org/x/net**                                  v0.33.0 -> v0.37.0
* **golang.org/x/oauth2**                               v0.23.0 -> v0.28.0
* **golang.org/x/sync**                                 v0.10.0 -> v0.12.0
* **golang.org/x/sys**                                  v0.28.0 -> v0.31.0
* **golang.org/x/term**                                 v0.27.0 -> v0.30.0
* **golang.org/x/text**                                 v0.21.0 -> v0.23.0
* **tags.cncf.io/container-device-interface**           v0.8.1 -> v1.0.0
* **tags.cncf.io/container-device-interface/specs-go**  v0.8.0 -> v1.0.0

Previous release can be found at [v2.0.4](https://github.com/containerd/containerd/releases/tag/v2.0.4)
### Which file should I download?
* `containerd-<VERSION>-<OS>-<ARCH>.tar.gz`:         ✅Recommended. Dynamically linked with glibc 2.31 (Ubuntu 20.04).
* `containerd-static-<VERSION>-<OS>-<ARCH>.tar.gz`:  Statically linked. Expected to be used on non-glibc Linux distributions. Not position-independent.

In addition to containerd, typically you will have to install [runc](https://github.com/opencontainers/runc/releases)
and [CNI plugins](https://github.com/containernetworking/plugins/releases) from their official sites too.

See also the [Getting Started](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) documentation.
