### PR TITLE
chore: fix broken links to https://docs.docker.com/registry

### DIFF
--- a/core/remotes/docker/auth/fetch.go
+++ b/core/remotes/docker/auth/fetch.go
@@ -78,10 +78,10 @@ type TokenOptions struct {
 	// FetchRefreshToken enables fetching a refresh token (aka "identity token", "offline token") along with the bearer token.
 	//
 	// For HTTP GET mode (FetchToken), FetchRefreshToken sets `offline_token=true` in the request.
-	// https://docs.docker.com/registry/spec/auth/token/#requesting-a-token
+	// https://distribution.github.io/distribution/spec/auth/token/#requesting-a-token
 	//
 	// For HTTP POST mode (FetchTokenWithOAuth), FetchRefreshToken sets `access_type=offline` in the request.
-	// https://docs.docker.com/registry/spec/auth/oauth/#getting-a-token
+	// https://distribution.github.io/distribution/spec/auth/oauth/#getting-a-token
 	FetchRefreshToken bool
 }
 

--- a/core/remotes/docker/authorizer.go
+++ b/core/remotes/docker/authorizer.go
@@ -88,7 +88,7 @@ func WithFetchRefreshToken(f OnFetchRefreshToken) AuthorizerOpt {
 
 // NewDockerAuthorizer creates an authorizer using Docker's registry
 // authentication spec.
-// See https://docs.docker.com/registry/spec/auth/
+// See https://distribution.github.io/distribution/spec/auth/
 func NewDockerAuthorizer(opts ...AuthorizerOpt) Authorizer {
 	var ao authorizerConfig
 	for _, opt := range opts {
@@ -269,7 +269,7 @@ func (ah *authHandler) doBearerAuth(ctx context.Context) (token, refreshToken st
 
 	to.Scopes = GetTokenScopes(ctx, to.Scopes)
 
-	// Docs: https://docs.docker.com/registry/spec/auth/scope
+	// Docs: https://distribution.github.io/distribution/spec/auth/scope/
 	scoped := strings.Join(to.Scopes, " ")
 
 	// Keep track of the expiration time of cached bearer tokens so they can be

--- a/core/remotes/docker/resolver_test.go
+++ b/core/remotes/docker/resolver_test.go
@@ -1011,7 +1011,7 @@ func (srv *refreshTokenServer) BasicTestFunc() func(h http.Handler) (string, Res
 				return
 			}
 			switch r.Method {
-			case http.MethodGet: // https://docs.docker.com/registry/spec/auth/token/#requesting-a-token
+			case http.MethodGet: // https://distribution.github.io/distribution/spec/auth/token/#requesting-a-token
 				u, p, ok := r.BasicAuth()
 				if !ok || u != srv.Username || p != srv.Password {
 					rw.WriteHeader(http.StatusForbidden)
@@ -1038,7 +1038,7 @@ func (srv *refreshTokenServer) BasicTestFunc() func(h http.Handler) (string, Res
 				rw.Header().Set("Content-Type", "application/json")
 				t.Logf("GET mode: returning JSON %q, for query %+v", string(b), query)
 				rw.Write(b)
-			case http.MethodPost: // https://docs.docker.com/registry/spec/auth/oauth/#getting-a-token
+			case http.MethodPost: // https://distribution.github.io/distribution/spec/auth/oauth/#getting-a-token
 				if srv.DisablePOST {
 					rw.WriteHeader(http.StatusMethodNotAllowed)
 					return

--- a/core/remotes/docker/scope.go
+++ b/core/remotes/docker/scope.go
@@ -88,7 +88,7 @@ func GetTokenScopes(ctx context.Context, common []string) []string {
 
 	l := 0
 	for idx := 1; idx < len(scopes); idx++ {
-		// Note: this comparison is unaware of the scope grammar (https://docs.docker.com/registry/spec/auth/scope/)
+		// Note: this comparison is unaware of the scope grammar (https://distribution.github.io/distribution/spec/auth/scope/)
 		// So, "repository:foo/bar:pull,push" != "repository:foo/bar:push,pull", although semantically they are equal.
 		if scopes[l] == scopes[idx] {
 			continue


### PR DESCRIPTION
https://docs.docker.com/registry is deprecated and doesn't have that content
anymore, link to https://distribution.github.io/distribution instead.

Signed-off-by: Alberto Garcia Hierro <damaso.hierro@docker.com>
