### PR TITLE
[release 1.7] remotes/docker/authorizer.go: invalidate auth tokens when they expire.

### DIFF
--- a/remotes/docker/auth/fetch.go
+++ b/remotes/docker/auth/fetch.go
@@ -86,11 +86,11 @@ type TokenOptions struct {
 
 // OAuthTokenResponse is response from fetching token with a OAuth POST request
 type OAuthTokenResponse struct {
-	AccessToken  string    `json:"access_token"`
-	RefreshToken string    `json:"refresh_token"`
-	ExpiresIn    int       `json:"expires_in"`
-	IssuedAt     time.Time `json:"issued_at"`
-	Scope        string    `json:"scope"`
+	AccessToken      string    `json:"access_token"`
+	RefreshToken     string    `json:"refresh_token"`
+	ExpiresInSeconds int       `json:"expires_in"`
+	IssuedAt         time.Time `json:"issued_at"`
+	Scope            string    `json:"scope"`
 }
 
 // FetchTokenWithOAuth fetches a token using a POST request
@@ -152,11 +152,11 @@ func FetchTokenWithOAuth(ctx context.Context, client *http.Client, headers http.
 
 // FetchTokenResponse is response from fetching token with GET request
 type FetchTokenResponse struct {
-	Token        string    `json:"token"`
-	AccessToken  string    `json:"access_token"`
-	ExpiresIn    int       `json:"expires_in"`
-	IssuedAt     time.Time `json:"issued_at"`
-	RefreshToken string    `json:"refresh_token"`
+	Token            string    `json:"token"`
+	AccessToken      string    `json:"access_token"`
+	ExpiresInSeconds int       `json:"expires_in"`
+	IssuedAt         time.Time `json:"issued_at"`
+	RefreshToken     string    `json:"refresh_token"`
 }
 
 // FetchToken fetches a token using a GET request


### PR DESCRIPTION
Cherry-pick  https://github.com/containerd/containerd/pull/8735 to 1.7
Got bitten by this on our workloads when pulling large container images. It'd great to have this patch in current LTS.

(depends on CI changes in https://github.com/containerd/containerd/pull/11722)