### PR TITLE
[CI] Fix vagrant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -606,7 +606,7 @@ jobs:
           sudo systemctl enable --now libvirtd
           sudo apt-get build-dep -y ruby-libvirt
           sudo apt-get install -y --no-install-recommends libxslt-dev libxml2-dev libvirt-dev ruby-bundler ruby-dev zlib1g-dev
-          sudo vagrant plugin install vagrant-libvirt
+          sudo env VAGRANT_DISABLE_STRICT_DEPENDENCY_ENFORCEMENT=1 vagrant plugin install vagrant-libvirt
       - name: Boot VM
         run: |
           sudo BOX=$BOX RUNC_FLAVOR=$RUNC_FLAVOR vagrant up --no-tty


### PR DESCRIPTION
Vagrant setup is broken in all branches due to dependency resolution conflict:

```bash
$ vagrant plugin install vagrant-libvirt
...
Installing the 'vagrant-libvirt' plugin. This can take a few minutes...
Vagrant failed to properly resolve required dependencies. These
errors can commonly be caused by misconfigured plugin installations
or transient network issues. The reported error is:

conflicting dependencies csv (= 3.2.8) and csv (= 3.3.4)
  Activated csv-3.3.4
  which does not match conflicting dependency (= 3.2.8)

  Conflicting dependency chains:
    csv (= 3.3.4), 3.3.4 activated

  versus:
    csv (= 3.2.8)

  Gems matching csv (= 3.2.8):
    csv-3.2.8
```

The workaround suggested in https://github.com/hashicorp/vagrant/issues/13510#issuecomment-2431163553 seems to work.
