### PR TITLE
cri: do not set sandbox id when using podsandbox type

### DIFF
--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -32,6 +32,7 @@ import (
 	cio "github.com/containerd/containerd/v2/internal/cri/io"
 	crilabels "github.com/containerd/containerd/v2/internal/cri/labels"
 	customopts "github.com/containerd/containerd/v2/internal/cri/opts"
+	podsandboxtypes "github.com/containerd/containerd/v2/internal/cri/server/podsandbox/types"
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 	"github.com/containerd/containerd/v2/internal/cri/store/sandbox"
 	"github.com/containerd/containerd/v2/internal/cri/util"
@@ -409,7 +410,9 @@ func (c *criService) createContainer(r *createContainerRequest) (_ string, retEr
 		containerd.WithContainerExtension(crilabels.ContainerMetadataExtension, r.meta),
 	)
 
-	opts = append(opts, containerd.WithSandbox(r.sandboxID))
+	if r.sandbox.Sandboxer != podsandboxtypes.InternalSandboxID {
+		opts = append(opts, containerd.WithSandbox(r.sandboxID))
+	}
 
 	opts = append(opts, c.nri.WithContainerAdjustment())
 	defer func() {

--- a/internal/cri/server/podsandbox/controller.go
+++ b/internal/cri/server/podsandbox/controller.go
@@ -47,7 +47,7 @@ import (
 func init() {
 	registry.Register(&plugin.Registration{
 		Type: plugins.PodSandboxPlugin,
-		ID:   "podsandbox",
+		ID:   types.InternalSandboxID,
 		Requires: []plugin.Type{
 			plugins.EventPlugin,
 			plugins.LeasePlugin,

--- a/internal/cri/server/podsandbox/types/podsandbox.go
+++ b/internal/cri/server/podsandbox/types/podsandbox.go
@@ -26,6 +26,10 @@ import (
 	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
 )
 
+const (
+	InternalSandboxID = "podsandbox"
+)
+
 type PodSandbox struct {
 	ID        string
 	Container containerd.Container


### PR DESCRIPTION
Fix #11708 

The exit of the `work container` will call `shutdown` at 1.7, but only call `shutdown` when the sandbox exits at 2.0.

```
// some processes about shim.Task

kill    ->    delete    ->   shutdown     
            ( callback by backoff by wait )

// https://github.com/containerd/containerd/blob/fb4c30d4ede3531652d86197bf3fc9515e5276d9/core/runtime/v2/shim.go#L529-L532C46
	// Don't shutdown sandbox as there may be other containers running.
	// Let controller decide when to shutdown.
	if !sandboxed {
		if err := s.waitShutdown(ctx); err != nil {
```

Based on the above code, it seems to be an issue with gvisor, and the shim connection (write close at shim side) should be closed when call `delete` rpc.

Above, could solve problem #11708, but not sure it's worth.

If there were clearer documentation about the shim API, I think it would be more helpful for this issue


cc @mxpv 
