### PR TITLE
Replace deprecated `tenv` linter with `usetesting`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,7 @@ linters:
     - nolintlint
     - revive
     - staticcheck
-    - tenv # Detects using os.Setenv instead of t.Setenv since Go 1.17
+    - usetesting # Detects using os.Setenv instead of t.Setenv since Go 1.17
     - unconvert
     - unused
     - govet
@@ -69,6 +69,8 @@ linters-settings:
         deny:
           - pkg: github.com/opencontainers/runc
             desc: We don't want to depend on runc (libcontainer), unless there is no other option; see https://github.com/opencontainers/runc/issues/3028.
+  usetesting:
+    os-mkdir-temp: false
 
   gosec:
     # The following issues surfaced when `gosec` linter

--- a/core/mount/losetup_linux_test.go
+++ b/core/mount/losetup_linux_test.go
@@ -29,7 +29,7 @@ var randomData = []byte("randomdata")
 func createTempFile(t *testing.T) string {
 	t.Helper()
 
-	f, err := os.CreateTemp("", "losetup")
+	f, err := os.CreateTemp(t.TempDir(), "losetup")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/client/container_fuzz_test.go
+++ b/integration/client/container_fuzz_test.go
@@ -112,9 +112,7 @@ func initInSteps(t *testing.T) bool {
 	if !haveChangedDownloadPATH {
 		oldPathEnv := os.Getenv("PATH")
 		newPathEnv := fmt.Sprintf("%s:%s", filepath.Join(downloadBinDir, "bin"), oldPathEnv)
-		if err := os.Setenv("PATH", newPathEnv); err != nil {
-			return true
-		}
+		t.Setenv("PATH", newPathEnv)
 		haveChangedDownloadPATH = true
 		return true
 	}

--- a/integration/client/export_test.go
+++ b/integration/client/export_test.go
@@ -250,7 +250,7 @@ func TestExportAllCases(t *testing.T) {
 
 			img := tc.prepare(ctx, t, client)
 
-			dstFile, err := os.CreateTemp("", "export-test")
+			dstFile, err := os.CreateTemp(t.TempDir(), "export-test")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/integration/client/import_test.go
+++ b/integration/client/import_test.go
@@ -84,7 +84,7 @@ func testExportImport(t *testing.T, imageName string) {
 		t.Fatal(err)
 	}
 
-	dstFile, err := os.CreateTemp("", "export-import-test")
+	dstFile, err := os.CreateTemp(t.TempDir(), "export-import-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cri/server/helpers_test.go
+++ b/internal/cri/server/helpers_test.go
@@ -249,7 +249,7 @@ func TestEnsureRemoveAllWithDir(t *testing.T) {
 }
 
 func TestEnsureRemoveAllWithFile(t *testing.T) {
-	tmp, err := os.CreateTemp("", "test-ensure-removeall-with-dir")
+	tmp, err := os.CreateTemp(t.TempDir(), "test-ensure-removeall-with-dir")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cri/server/podsandbox/helpers_test.go
+++ b/internal/cri/server/podsandbox/helpers_test.go
@@ -120,7 +120,7 @@ func TestEnsureRemoveAllWithDir(t *testing.T) {
 }
 
 func TestEnsureRemoveAllWithFile(t *testing.T) {
-	tmp, err := os.CreateTemp("", "test-ensure-removeall-with-dir")
+	tmp, err := os.CreateTemp(t.TempDir(), "test-ensure-removeall-with-dir")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/ioutil/write_closer_test.go
+++ b/pkg/ioutil/write_closer_test.go
@@ -68,7 +68,7 @@ func TestSerialWriteCloser(t *testing.T) {
 			testData[i] = []byte(repeatNumber(i, dataLen) + "\n")
 		}
 
-		f, err := os.CreateTemp("", "serial-write-closer")
+		f, err := os.CreateTemp(t.TempDir(), "serial-write-closer")
 		require.NoError(t, err)
 		defer os.RemoveAll(f.Name())
 		defer f.Close()

--- a/pkg/oci/spec_opts_test.go
+++ b/pkg/oci/spec_opts_test.go
@@ -320,7 +320,7 @@ func TestWithSpecFromFile(t *testing.T) {
 		ctx = namespaces.WithNamespace(context.Background(), "test")
 	)
 
-	fp, err := os.CreateTemp("", "testwithdefaultspec.json")
+	fp, err := os.CreateTemp(t.TempDir(), "testwithdefaultspec.json")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/cri/runtime/load_test.go
+++ b/plugins/cri/runtime/load_test.go
@@ -31,7 +31,7 @@ import (
 func TestLoadBaseOCISpec(t *testing.T) {
 	spec := oci.Spec{Version: "1.0.2", Hostname: "default"}
 
-	file, err := os.CreateTemp("", "spec-test-")
+	file, err := os.CreateTemp(t.TempDir(), "spec-test-")
 	require.NoError(t, err)
 
 	defer func() {

--- a/plugins/snapshots/devmapper/config_test.go
+++ b/plugins/snapshots/devmapper/config_test.go
@@ -33,7 +33,7 @@ func TestLoadConfig(t *testing.T) {
 		BaseImageSize: "128Mb",
 	}
 
-	file, err := os.CreateTemp("", "devmapper-config-")
+	file, err := os.CreateTemp(t.TempDir(), "devmapper-config-")
 	assert.NoError(t, err)
 
 	encoder := toml.NewEncoder(file)


### PR DESCRIPTION
## Changes
1. Replace deprecated `tenv` linter with recommended `usetesting` linter
3. Optimize test code following linter recommendations:
   - Replace `os.CreateTemp("", ...)` with `os.CreateTemp(t.TempDir(), ...)`
   - Replace `os.Setenv()` with `t.Setenv()`

## Rationale
- `tenv` linter has been deprecated since golangci-lint v1.64.0
- Using `t.TempDir()` and `t.Setenv()` ensures proper cleanup of temporary resources
