### PR TITLE
[release/2.0] Fix issue preventing some v2 shims from shutting down properly

### DIFF
--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -41,6 +41,7 @@ import (
 	cio "github.com/containerd/containerd/v2/internal/cri/io"
 	crilabels "github.com/containerd/containerd/v2/internal/cri/labels"
 	customopts "github.com/containerd/containerd/v2/internal/cri/opts"
+	podsandboxtypes "github.com/containerd/containerd/v2/internal/cri/server/podsandbox/types"
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 	"github.com/containerd/containerd/v2/internal/cri/util"
 	"github.com/containerd/containerd/v2/pkg/blockio"
@@ -302,7 +303,9 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 		containerd.WithContainerExtension(crilabels.ContainerMetadataExtension, &meta),
 	)
 
-	opts = append(opts, containerd.WithSandbox(sandboxID))
+	if sandbox.Sandboxer != podsandboxtypes.InternalSandboxID {
+		opts = append(opts, containerd.WithSandbox(sandboxID))
+	}
 
 	opts = append(opts, c.nri.WithContainerAdjustment())
 	defer func() {

--- a/internal/cri/server/podsandbox/controller.go
+++ b/internal/cri/server/podsandbox/controller.go
@@ -47,7 +47,7 @@ import (
 func init() {
 	registry.Register(&plugin.Registration{
 		Type: plugins.PodSandboxPlugin,
-		ID:   "podsandbox",
+		ID:   types.InternalSandboxID,
 		Requires: []plugin.Type{
 			plugins.EventPlugin,
 			plugins.LeasePlugin,

--- a/internal/cri/server/podsandbox/types/podsandbox.go
+++ b/internal/cri/server/podsandbox/types/podsandbox.go
@@ -26,6 +26,10 @@ import (
 	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
 )
 
+const (
+	InternalSandboxID = "podsandbox"
+)
+
 type PodSandbox struct {
 	ID        string
 	Container containerd.Container


### PR DESCRIPTION
(cherry picked from commit 4b4e6f7c693e3739deed20ed5832ede137b41b3e)

This is a manual cherry-pick of https://github.com/containerd/containerd/pull/11735 since there were merge conflicts.  Opening as a draft until https://github.com/containerd/containerd/pull/11735 is merged.