### PR TITLE
cri: support dynamic runtime configs

### DIFF
--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -159,6 +159,10 @@ spec:
 
 See also [the Kubernetes documentation](https://kubernetes.io/docs/concepts/containers/runtime-class/).
 
+Starting with containerd 2.1 runtime configurations can also be added to the config dir at
+`/etc/containerd/runtimes/<runtime_name>/config.toml`.
+This allows for a more dynamic configuration of runtimes without the need to restart containerd.
+
 ## Full configuration
 The explanation and default value of each configuration item are as follows:
 + In containerd 2.x

--- a/docs/cri/config.md
+++ b/docs/cri/config.md
@@ -223,6 +223,7 @@ version = 3
 
     [plugins.'io.containerd.cri.v1.runtime'.containerd]
       default_runtime_name = 'runc'
+      runtime_config_dir = '/etc/containerd/runtimes'
       ignore_blockio_not_enabled_errors = false
       ignore_rdt_not_enabled_errors = false
 

--- a/integration/runtime_handler_linux_test.go
+++ b/integration/runtime_handler_linux_test.go
@@ -1,0 +1,79 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/containerd/containerd/v2/defaults"
+	"github.com/containerd/containerd/v2/plugins"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+// TODO(chrisfegly): add/update test(s) to allow testing of multiple runtimes at the same time
+func TestRuntimeHandler_Dynamic(t *testing.T) {
+	if *runtimeHandler != plugins.RuntimeRuncV2 {
+		t.Skipf("Only running test when runtime handler is set to %s", plugins.RuntimeRuncV2)
+	}
+
+	runtimeHandler := "test-dynamic-runtime-handler"
+	dir := t.TempDir()
+
+	shimPath, err := exec.LookPath("containerd-shim-runc-v2")
+	require.NoError(t, err)
+
+	toml := `
+runtime_type = "` + plugins.RuntimeRuncV2 + `"
+runtime_path = "` + shimPath + `"
+`
+	err = os.WriteFile(filepath.Join(dir, "config.toml"), []byte(toml), 0644)
+	require.NoError(t, err)
+	err = os.MkdirAll(filepath.Join(defaults.DefaultConfigDir, "runtimes"), 0755)
+	require.NoError(t, err)
+
+	handlerPath := filepath.Join(defaults.DefaultConfigDir, "runtimes", runtimeHandler)
+	t.Cleanup(func() { os.RemoveAll(handlerPath) })
+
+	err = os.Rename(dir, handlerPath)
+	require.NoError(t, err)
+
+	t.Logf("Create a sandbox with runtimeHandler %s", runtimeHandler)
+
+	sbConfig := PodSandboxConfig("sandbox2", "test-runtime-handler")
+	sb, err := runtimeService.RunPodSandbox(sbConfig, runtimeHandler)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, runtimeService.StopPodSandbox(sb))
+		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
+	})
+
+	t.Logf("Verify runtimeService.PodSandboxStatus() returns previously set runtimeHandler")
+	sbStatus, err := runtimeService.PodSandboxStatus(sb)
+
+	require.NoError(t, err)
+	assert.Equal(t, runtimeHandler, sbStatus.RuntimeHandler)
+
+	t.Logf("Verify runtimeService.ListPodSandbox() returns previously set runtimeHandler")
+	sandboxes, err := runtimeService.ListPodSandbox(&runtime.PodSandboxFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, runtimeHandler, sandboxes[0].RuntimeHandler)
+}

--- a/internal/cri/config/config.go
+++ b/internal/cri/config/config.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
+	"path/filepath"
 	gruntime "runtime"
 	"slices"
 	"time"
@@ -33,6 +35,7 @@ import (
 	runhcsoptions "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
 	runcoptions "github.com/containerd/containerd/api/types/runc/options"
 	runtimeoptions "github.com/containerd/containerd/api/types/runtimeoptions/v1"
+	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/internal/cri/annotations"
 	"github.com/containerd/containerd/v2/internal/cri/opts"
 	"github.com/containerd/containerd/v2/pkg/deprecation"
@@ -132,6 +135,13 @@ type Runtime struct {
 	IOType string `toml:"io_type" json:"io_type"`
 }
 
+func (r *Runtime) setDefaults() {
+	// If empty, use default podSandbox mode
+	if len(r.Sandboxer) == 0 {
+		r.Sandboxer = string(ModePodSandbox)
+	}
+}
+
 // ContainerdConfig contains toml config related to containerd
 type ContainerdConfig struct {
 	// DefaultRuntimeName is the default runtime name to use from the runtimes table.
@@ -139,6 +149,7 @@ type ContainerdConfig struct {
 
 	// Runtimes is a map from CRI RuntimeHandler strings, which specify types of runtime
 	// configurations, to the matching configurations.
+	// Runtimes specified here that conflict with runtimes in the RuntimeConfigPath will cause an error.
 	Runtimes map[string]Runtime `toml:"runtimes" json:"runtimes"`
 
 	// IgnoreBlockIONotEnabledErrors is a boolean flag to ignore
@@ -611,7 +622,10 @@ func ValidateRuntimeConfig(ctx context.Context, c *RuntimeConfig) ([]deprecation
 		return warnings, errors.New("`default_runtime_name` is empty")
 	}
 	if _, ok := c.ContainerdConfig.Runtimes[c.ContainerdConfig.DefaultRuntimeName]; !ok {
-		return warnings, fmt.Errorf("no corresponding runtime configured in `containerd.runtimes` for `containerd` `default_runtime_name = \"%s\"", c.ContainerdConfig.DefaultRuntimeName)
+		_, err := c.loadRuntime(c.ContainerdConfig.DefaultRuntimeName)
+		if err != nil {
+			return warnings, fmt.Errorf("no corresponding runtime configured in `containerd.runtimes` for `containerd` `default_runtime_name = \"%s\"", c.ContainerdConfig.DefaultRuntimeName)
+		}
 	}
 
 	// Validation for CNI config
@@ -644,15 +658,14 @@ func ValidateRuntimeConfig(ctx context.Context, c *RuntimeConfig) ([]deprecation
 		if !r.PrivilegedWithoutHostDevices && r.PrivilegedWithoutHostDevicesAllDevicesAllowed {
 			return warnings, errors.New("`privileged_without_host_devices_all_devices_allowed` requires `privileged_without_host_devices` to be enabled")
 		}
-		// If empty, use default podSandbox mode
-		if len(r.Sandboxer) == 0 {
-			r.Sandboxer = string(ModePodSandbox)
-			c.ContainerdConfig.Runtimes[k] = r
-		}
+
+		r.setDefaults()
+		c.ContainerdConfig.Runtimes[k] = r
 
 		if len(r.IOType) == 0 {
 			r.IOType = IOTypeFifo
 		}
+
 		if r.IOType != IOTypeStreaming && r.IOType != IOTypeFifo {
 			return warnings, errors.New("`io_type` can only be `streaming` or `named_pipe`")
 		}
@@ -682,6 +695,87 @@ func ValidateServerConfig(ctx context.Context, c *ServerConfig) ([]deprecation.W
 	return warnings, nil
 }
 
+func (config *ContainerdConfig) loadRuntime(handler string) (Runtime, error) {
+	r, ok := config.Runtimes[handler]
+	if ok {
+		return r, nil
+	}
+
+	if !filepath.IsLocal(handler) {
+		return Runtime{}, fmt.Errorf("invalid runtime handler %q, it should be a local path", handler)
+	}
+	if strings.Contains(handler, string(filepath.Separator)) {
+		return Runtime{}, fmt.Errorf("invalid runtime handler %q, it should not contain path separator", handler)
+	}
+	dt, err := os.ReadFile(p)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return Runtime{}, fmt.Errorf("no runtime for %q is configured", handler)
+		}
+		return Runtime{}, fmt.Errorf("failed to read runtime config for %q: %w", handler, err)
+	}
+
+	var rt Runtime
+	if err := toml.Unmarshal(dt, &rt); err != nil {
+		return Runtime{}, fmt.Errorf("failed to unmarshal runtime config for %q from path %s: %w", handler, p, err)
+	}
+
+	rt.setDefaults()
+	return rt, nil
+}
+
+func (config *ContainerdConfig) LoadRuntime(ctx context.Context, name string) (Runtime, bool) {
+	r, ok := config.Runtimes[name]
+	if ok {
+		return r, true
+	}
+
+	r, err := config.loadRuntime(name)
+	if err != nil {
+		log.G(ctx).WithError(err).WithField("runtime", name).Warn("Failed to load runtime handler")
+		return Runtime{}, false
+	}
+	return r, true
+}
+
+func (config *ContainerdConfig) LoadRuntimes(ctx context.Context) map[string]Runtime {
+	runtimes := make(map[string]Runtime, len(config.Runtimes))
+	for name, runtime := range config.Runtimes {
+		runtimes[name] = runtime
+	}
+
+	runtimesDir := filepath.Join(defaults.DefaultConfigDir, "runtimes")
+	entries, err := os.ReadDir(runtimesDir)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			log.G(ctx).WithError(err).Warn("failed to read runtimes directory")
+		}
+		return runtimes
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			log.G(ctx).WithField("entry", entry.Name()).Debug("Skipping non-directory entry in runtimes directory")
+			continue
+		}
+
+		if _, ok := runtimes[entry.Name()]; ok {
+			log.G(ctx).WithField("handler", entry.Name()).Warn("Runtime handler already exists from config, skipping dynamic runtime handler")
+			continue
+		}
+
+		rt, err := config.loadRuntime(entry.Name())
+		if err != nil {
+			log.G(ctx).WithError(err).WithField("handler", entry.Name()).Warn("Failed to load runtime handler")
+			continue
+		}
+
+		runtimes[entry.Name()] = rt
+	}
+
+	return runtimes
+}
+
 func (config *Config) GetSandboxRuntime(podSandboxConfig *runtime.PodSandboxConfig, runtimeHandler string) (Runtime, error) {
 	if untrustedWorkload(podSandboxConfig) {
 		// If the untrusted annotation is provided, runtimeHandler MUST be empty.
@@ -705,13 +799,7 @@ func (config *Config) GetSandboxRuntime(podSandboxConfig *runtime.PodSandboxConf
 	if runtimeHandler == "" {
 		runtimeHandler = config.DefaultRuntimeName
 	}
-
-	r, ok := config.Runtimes[runtimeHandler]
-	if !ok {
-		return Runtime{}, fmt.Errorf("no runtime for %q is configured", runtimeHandler)
-	}
-	return r, nil
-
+	return config.loadRuntime(runtimeHandler)
 }
 
 // untrustedWorkload returns true if the sandbox contains untrusted workload.

--- a/internal/cri/config/config.go
+++ b/internal/cri/config/config.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	gruntime "runtime"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/containerd/log"
@@ -151,6 +152,11 @@ type ContainerdConfig struct {
 	// configurations, to the matching configurations.
 	// Runtimes specified here that conflict with runtimes in the RuntimeConfigPath will cause an error.
 	Runtimes map[string]Runtime `toml:"runtimes" json:"runtimes"`
+
+	// RuntimeConfigDir is the directory to load dynamic runtime configurations from.
+	// These should be in the format of:
+	// <RuntimeConfigDir>/<runtime_name>/config.toml
+	RuntimeConfigDir string `toml:"runtime_config_dir" json:"runtimeConfigDir"`
 
 	// IgnoreBlockIONotEnabledErrors is a boolean flag to ignore
 	// blockio related errors when blockio support has not been
@@ -707,6 +713,7 @@ func (config *ContainerdConfig) loadRuntime(handler string) (Runtime, error) {
 	if strings.Contains(handler, string(filepath.Separator)) {
 		return Runtime{}, fmt.Errorf("invalid runtime handler %q, it should not contain path separator", handler)
 	}
+	p := filepath.Join(config.RuntimeConfigDir, handler, "config.toml")
 	dt, err := os.ReadFile(p)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {

--- a/internal/cri/config/config_unix.go
+++ b/internal/cri/config/config_unix.go
@@ -19,6 +19,8 @@
 package config
 
 import (
+	"path/filepath"
+
 	"github.com/containerd/containerd/v2/defaults"
 	"github.com/pelletier/go-toml/v2"
 )
@@ -85,6 +87,7 @@ func DefaultRuntimeConfig() RuntimeConfig {
 		},
 		ContainerdConfig: ContainerdConfig{
 			DefaultRuntimeName: "runc",
+			RuntimeConfigDir:   filepath.Join(defaults.DefaultConfigDir, "runtimes"),
 			Runtimes: map[string]Runtime{
 				"runc": {
 					Type:      "io.containerd.runc.v2",

--- a/internal/cri/server/runtime_config_linux.go
+++ b/internal/cri/server/runtime_config_linux.go
@@ -32,10 +32,12 @@ func (c *criService) getLinuxRuntimeConfig(ctx context.Context) *runtime.LinuxRu
 }
 
 func (c *criService) getCgroupDriver(ctx context.Context) runtime.CgroupDriver {
+	runtimes := c.config.ContainerdConfig.LoadRuntimes(ctx)
+
 	// Go through the runtime handlers in a predictable order, starting from the
 	// default handler, others sorted in alphabetical order
-	handlerNames := make([]string, 0, len(c.config.ContainerdConfig.Runtimes))
-	for n := range c.config.ContainerdConfig.Runtimes {
+	handlerNames := make([]string, 0, len(runtimes))
+	for n := range runtimes {
 		handlerNames = append(handlerNames, n)
 	}
 	sort.Slice(handlerNames, func(i, j int) bool {
@@ -49,7 +51,7 @@ func (c *criService) getCgroupDriver(ctx context.Context) runtime.CgroupDriver {
 	})
 
 	for _, handler := range handlerNames {
-		opts, err := criconfig.GenerateRuntimeOptions(c.config.ContainerdConfig.Runtimes[handler])
+		opts, err := criconfig.GenerateRuntimeOptions(runtimes[handler])
 		if err != nil {
 			log.G(ctx).Debugf("failed to parse runtime handler options for %q", handler)
 			continue

--- a/internal/cri/server/service.go
+++ b/internal/cri/server/service.go
@@ -227,7 +227,8 @@ func NewCRIService(options *CRIServiceOptions) (CRIService, runtime.RuntimeServi
 	for name, i := range c.netPlugin {
 		path := c.config.NetworkPluginConfDir
 		if name != defaultNetworkPlugin {
-			if rc, ok := c.config.Runtimes[name]; ok {
+			rc, ok := c.config.LoadRuntime(ctx, name)
+			if ok {
 				path = rc.NetworkPluginConfDir
 			}
 		}
@@ -243,7 +244,7 @@ func NewCRIService(options *CRIServiceOptions) (CRIService, runtime.RuntimeServi
 	c.nri = nri.NewAPI(options.NRI, &criImplementation{c})
 
 	intro := c.client.IntrospectionService()
-	for name, r := range c.config.Runtimes {
+	for name, r := range c.config.LoadRuntimes(ctx) {
 		if err := c.introspectRuntimeHandler(ctx, intro, name, r); err != nil {
 			return nil, nil, fmt.Errorf("failed to introspect runtime %s: %w", name, err)
 		}

--- a/internal/cri/server/service_linux.go
+++ b/internal/cri/server/service_linux.go
@@ -17,6 +17,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/moby/sys/userns"
@@ -59,7 +60,8 @@ func (c *criService) initPlatform() (err error) {
 	pluginDirs := map[string]string{
 		defaultNetworkPlugin: c.config.NetworkPluginConfDir,
 	}
-	for name, conf := range c.config.Runtimes {
+	runtimes := c.config.LoadRuntimes(context.TODO())
+	for name, conf := range runtimes {
 		if conf.NetworkPluginConfDir != "" {
 			pluginDirs[name] = conf.NetworkPluginConfDir
 		}
@@ -75,7 +77,7 @@ func (c *criService) initPlatform() (err error) {
 	for name, dir := range pluginDirs {
 		max := c.config.NetworkPluginMaxConfNum
 		if name != defaultNetworkPlugin {
-			if m := c.config.Runtimes[name].NetworkPluginMaxConfNum; m != 0 {
+			if m := runtimes[name].NetworkPluginMaxConfNum; m != 0 {
 				max = m
 			}
 		}

--- a/plugins/cri/runtime/plugin.go
+++ b/plugins/cri/runtime/plugin.go
@@ -36,7 +36,6 @@ import (
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/containerd/v2/plugins/services/warning"
 	"github.com/containerd/containerd/v2/version"
-	"github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
 )
 
@@ -121,8 +120,11 @@ func (r *runtime) Config() criconfig.Config {
 func (r *runtime) LoadOCISpec(filename string) (*oci.Spec, error) {
 	spec, ok := r.baseOCISpecs[filename]
 	if !ok {
-		// TODO: Load here or only allow preloading...
-		return nil, errdefs.ErrNotFound
+		spec, err := loadOCISpec(filename)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load OCI spec: %s: %w", filename, err)
+		}
+		return spec, nil
 	}
 	return spec, nil
 }


### PR DESCRIPTION
This allows admins to drop in a runtime config at
/etc/containerd/cri.runtimes/handler_name/config.toml which can be used immediately after without restarting containerd.