### PR TITLE
Add support for unpacking custom media types 

### DIFF
--- a/core/unpack/unpacker.go
+++ b/core/unpack/unpacker.go
@@ -229,6 +229,16 @@ func (u *Unpacker) Wait() (Result, error) {
 	}, nil
 }
 
+// unpackConfig is a subset of the OCI config for resolving rootfs and platform,
+// any config type which supports the platform and rootfs field can be supported.
+type unpackConfig struct {
+	// Platform describes the platform which the image in the manifest runs on.
+	ocispec.Platform
+
+	// RootFS references the layer content addresses used by the image.
+	RootFS ocispec.RootFS `json:"rootfs"`
+}
+
 func (u *Unpacker) unpack(
 	h images.Handler,
 	config ocispec.Descriptor,
@@ -243,10 +253,11 @@ func (u *Unpacker) unpack(
 		return err
 	}
 
-	var i ocispec.Image
+	var i unpackConfig
 	if err := json.Unmarshal(p, &i); err != nil {
 		return fmt.Errorf("unmarshal image config: %w", err)
 	}
+
 	diffIDs := i.RootFS.DiffIDs
 	if len(layers) != len(diffIDs) {
 		return fmt.Errorf("number of layers and diffIDs don't match: %d != %d", len(layers), len(diffIDs))

--- a/plugins/transfer/plugin.go
+++ b/plugins/transfer/plugin.go
@@ -146,6 +146,8 @@ func init() {
 					Snapshotter:        sn,
 					SnapshotterExports: snExports,
 					Applier:            applier,
+					ConfigType:         uc.ConfigType,
+					LayerTypes:         uc.LayerTypes,
 				}
 				lc.UnpackPlatforms = append(lc.UnpackPlatforms, up)
 			}
@@ -179,6 +181,12 @@ type unpackConfiguration struct {
 
 	// Differ is the diff plugin to be used for apply
 	Differ string `toml:"differ"`
+
+	// ConfigType is the config types for this unpack configuration
+	ConfigType string `toml:"config_type"`
+
+	// LayerTypes are the allowed layer types for this unpack configuration
+	LayerTypes []string `toml:"layer_types"`
 }
 
 func defaultConfig() *transferConfig {


### PR DESCRIPTION
The snapshotter and differ are fully plug-able today, however experimentation can be limited by the media types supported by unpack. This change allows specifying the config and layer media types to use for a platform unpack configuration alongside the snapshotter and differ.

Experimentation for new types is still limited to using the platform and rootfs keys defined by OCI. Anything beyond that would need something much different than the current unpacker anyway. This adds stricter checks for the rootfs field type when unpacking an OCI image. OCI requires this value to be set to "layers", however we should also consider an empty value the same as layers to avoid breaking. Any non-"layers" value can be used for experimentation though.