### PR TITLE
Add release notes for api v1.9.0-rc.0

### DIFF
--- a/api/releases/v1.9.0-rc.toml
+++ b/api/releases/v1.9.0-rc.toml
@@ -1,0 +1,16 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "containerd"
+github_repo = "containerd/containerd"
+sub_path = "api"
+ignore_deps = [ "github.com/containerd/containerd" ]
+
+# previous release
+previous = "api/v1.8.0"
+
+pre_release = true
+
+preface = """\
+The 10th release for the containerd 1.x API aligns with the containerd 2.1 release.
+"""


### PR DESCRIPTION
Relatively small release. The first rc will begin the 2.1 freeze.

Items to merge before rc.0

- [x] #10762

---

containerd api/v1.9.0-rc.0

Welcome to the api/v1.9.0-rc.0 release of containerd!  
*This is a pre-release of containerd*

The 10th release for the containerd 1.x API aligns with the containerd 2.1 release.

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Akihiro Suda
* Davanum Srinivas
* Phil Estes
* Adrian Reber
* Derek McGowan
* Jin Dong
* Philip Laine

### Changes
<details><summary>11 commits</summary>
<p>

  * [`ac594cec3`](https://github.com/containerd/containerd/commit/ac594cec33654a733191aff46416e2979cf46068) Add release notes for api v1.9.0-rc.0
* Add content create event ([#11006](https://github.com/containerd/containerd/pull/11006))
  * [`752914b5b`](https://github.com/containerd/containerd/commit/752914b5bfaa4e28d1231901c37bf8d3b47ca73c) Add content create event to api
* bump golang.org/x/net from 0.33.0 to 0.37.0 ([#11574](https://github.com/containerd/containerd/pull/11574))
  * [`7fe5c4123`](https://github.com/containerd/containerd/commit/7fe5c41237b8da120ab45b30ea3f02d64b71a68b) go.mod: golang.org/x/net v0.37.0
* Support container restore through CRI/Kubernetes ([#10365](https://github.com/containerd/containerd/pull/10365))
  * [`9e6beafd5`](https://github.com/containerd/containerd/commit/9e6beafd53919eecd1fb650a76332002cf4c84dd) Support container restore through CRI/Kubernetes
* build(deps): bump golang.org/x/net from 0.23.0 to 0.33.0 in /api ([#11472](https://github.com/containerd/containerd/pull/11472))
  * [`37fe1e8b4`](https://github.com/containerd/containerd/commit/37fe1e8b42f8746944c5d9b4a8bf2b3dcfc99984) build(deps): bump golang.org/x/net from 0.23.0 to 0.33.0 in /api
* Bump to newer opencontainers/image-spec @ v1.1.1 ([#11461](https://github.com/containerd/containerd/pull/11461))
  * [`d37ea6977`](https://github.com/containerd/containerd/commit/d37ea6977d7e096e9221cbbba9a0282e97709acd) Bump to newer opencontainers/image-spec @ v1.1.1
</p>
</details>

### Dependency Changes

* **github.com/opencontainers/image-spec**  v1.1.0 -> v1.1.1
* **golang.org/x/net**                      v0.23.0 -> v0.37.0
* **golang.org/x/sys**                      v0.18.0 -> v0.31.0
* **golang.org/x/text**                     v0.14.0 -> v0.23.0
* **gopkg.in/yaml.v3**                      v3.0.1 **_new_**

Previous release can be found at [api/v1.8.0](https://github.com/containerd/containerd/releases/tag/api/v1.8.0)

