### PR TITLE
Do not pass context to runc create.

### DIFF
--- a/cmd/containerd-shim-runc-v2/process/init.go
+++ b/cmd/containerd-shim-runc-v2/process/init.go
@@ -141,9 +141,18 @@ func (p *Init) Create(ctx context.Context, r *CreateConfig) error {
 		opts.ConsoleSocket = socket
 	}
 
-	if err := p.runtime.Create(ctx, r.ID, r.Bundle, opts); err != nil {
+	createCtx, createCancel := context.WithTimeout(
+		context.WithoutCancel(ctx),
+		30*time.Second)
+	defer createCancel()
+	if err := p.runtime.Create(createCtx, r.ID, r.Bundle, opts); err != nil {
 		return p.runtimeError(err, "OCI runtime create failed")
 	}
+
+	if ctx.Err() != nil {
+		return fmt.Errorf("container creation interrupted: %w", createCtx.Err())
+	}
+
 	if r.Stdin != "" {
 		if err := p.openStdin(r.Stdin); err != nil {
 			return err


### PR DESCRIPTION
Fixes #11674, I have detailed the context of this issue in #11674.

When executing the runc create command using `exec.CommandContext`, if the context is canceled, the runc init process is left behind. The reasons are as follows:

1. The runc create command spawns a child process, runc init, which runs in the container's namespace, severing its relationship with the original runc create process.
2. When the context is canceled, Go's `exec.CommandContext` only sends a **SIGKILL** signal to the direct child process (i.e., `runc create`). This signal is not automatically propagated to the runc init process. Additionally, **SIGKILL** is a forceful signal that cannot be caught, blocked, or handled by the process, so `runc create` cannot clean up the spawned `runc init` process.

For containerd, the execution of `runc create` should be atomic and should not be interrupted for any reason. If interrupted at an inopportune moment, it may prevent us from using `runc delete` to clean up residual processes. Therefore, a more reasonable approach is to ensure that the `runc create` process is not interrupted and, in the case of context cancellation, returns an error while cleaning up any created containers (we have already implemented cleanup logic for creation failures).

In this PR, we created a separate context for the `runc create` command and set a timeout of 30 seconds.

It should be noted that under no circumstances should the creation process of `p.runtime.Create` be canceled. As mentioned earlier, the consequences of canceling the context are unpredictable, and we cannot properly handle the cancellation scenario. I added the 30-second timeout solely to prevent the container creation process from being blocked due to issues like insufficient CPU/IO resources.

-----

I've opened a PR in the runc repository to address this issue as well: 
https://github.com/opencontainers/runc/pull/4757
  * This PR ensures that if  `SIGKILL` signal is received at any point during `runc create`, the created container can still be removed by subsequently executing `runc delete`.


However, since the runc create operation spawns a new process (to initialize the container), and this process cannot guarantee proper cleanup after the main process receives a SIGKILL signal (as there is no connection between the spawned process and the main process), the current PR may still have some value. If the containerd maintainers believe this PR is no longer needed, feel free to close it.
