### PR TITLE
e2e: add upgrade to make sure compatiliblity with 1.x 

### DIFF
--- a/integration/compatibility_linux_test.go
+++ b/integration/compatibility_linux_test.go
@@ -1,0 +1,199 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/containerd/containerd/v2/integration/images"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+	runtimev1 "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+func TestCompatibilityWith17(t *testing.T) {
+	var (
+		latestVersion = "v1.7.27"
+		workDir       = t.TempDir()
+		defaultrt     = "runc"
+		v1rt          = "runcv1"
+	)
+
+	downloadReleaseBinary(t, workDir, latestVersion)
+	t.Cleanup(func() {
+		_ = os.RemoveAll(workDir)
+	})
+	t.Logf("Install config for release %s", latestVersion)
+	ctrdcfg := newCtrdConfig(t, workDir, 2)
+	ctrdcfg.setRuntime(runtimeConfig{
+		name:        defaultrt,
+		runtimeType: "io.containerd.runc.v2",
+		runtimePath: filepath.Join(workDir, "bin", "containerd-shim-runc-v2"),
+	}, runtimeConfig{
+		name:        v1rt,
+		runtimeType: "io.containerd.runc.v1",
+		runtimePath: filepath.Join(workDir, "bin", "containerd-shim-runc-v1"),
+	})
+
+	t.Log("Starting the previous release's containerd")
+	previousCtrdBinPath := filepath.Join(workDir, "bin", "containerd")
+	previousProc := newCtrdProc(t, previousCtrdBinPath, workDir, []string{})
+	require.NoError(t, previousProc.isReady())
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			dumpFileContent(t, previousProc.logPath())
+		}
+	})
+	type sbcnt struct {
+		sbconfig *runtimev1.PodSandboxConfig
+		sbid     string
+		cntid    []string
+	}
+	var (
+		testImage = images.Get(images.BusyBox)
+		cnConfig  = ContainerConfig(
+			"test",
+			testImage,
+			WithCommand("sh", "-c", "sleep 1d"),
+		)
+		sbmap = map[string]*sbcnt{defaultrt: nil, v1rt: nil}
+	)
+	_, err := previousProc.criImageService(t).PullImage(&runtime.ImageSpec{Image: testImage}, nil, nil, "")
+	require.NoError(t, err)
+
+	for name := range sbmap {
+		t.Logf("Running sandbox with runtime %s", name)
+		v2sbc := PodSandboxConfig(name, "")
+		v2sbid, err := previousProc.criRuntimeService(t).RunPodSandbox(v2sbc, name)
+		require.NoError(t, err)
+		t.Logf("Create and start container with sandbox id %s", v2sbid)
+		cn, err := previousProc.criRuntimeService(t).CreateContainer(v2sbid, cnConfig, v2sbc)
+		require.NoError(t, err)
+		require.NoError(t, previousProc.criRuntimeService(t).StartContainer(cn))
+		sbmap[name] = &sbcnt{
+			sbconfig: v2sbc,
+			sbid:     v2sbid,
+			cntid:    []string{cn},
+		}
+	}
+	t.Log("Gracefully stop previous release's containerd process")
+	require.NoError(t, previousProc.kill(syscall.SIGTERM))
+
+	t.Logf("Install config for current containerd, containerd-shim-runc-v2, and old containerd-shim-runc-v1")
+	ctrdcfg.reset(3)
+	ctrdcfg.setRuntime(runtimeConfig{
+		name:        defaultrt,
+		runtimeType: "io.containerd.runc.v2",
+		runtimePath: "",
+	}, runtimeConfig{
+		name:        v1rt,
+		runtimeType: "io.containerd.runc.v2", // version 2.x not support runtime type: "io.containerd.runc.v1"
+		runtimePath: filepath.Join(workDir, "bin", "containerd-shim-runc-v1"),
+	})
+
+	secondConfig := ContainerConfig(
+		"test2",
+		testImage,
+		WithCommand("sh", "-c", "sleep 1d"),
+	)
+
+	t.Log("Starting the current release's containerd")
+	currentProc := newCtrdProc(t, "containerd", workDir, nil)
+	require.NoError(t, currentProc.isReady())
+	_, err = currentProc.criImageService(t).PullImage(&runtime.ImageSpec{Image: testImage}, nil, nil, "")
+	require.NoError(t, err)
+
+	for _, sb := range sbmap {
+		t.Logf("Create and start new container by current containerd process in sandbox %s", sb.sbid)
+		cn, err := currentProc.criRuntimeService(t).CreateContainer(sb.sbid, secondConfig, sb.sbconfig)
+		require.NoError(t, err)
+		require.NoError(t, currentProc.criRuntimeService(t).StartContainer(cn))
+		sb.cntid = append(sb.cntid, cn)
+	}
+
+	for _, sb := range sbmap {
+		for _, cnid := range sb.cntid {
+			t.Logf("Stop and remove container %s", cnid)
+			require.NoError(t, currentProc.criRuntimeService(t).StopContainer(cnid, 10))
+			require.NoError(t, currentProc.criRuntimeService(t).RemoveContainer(cnid))
+			t.Logf("check container %s status dir, should not exist", cnid)
+			_, err = os.Stat(path.Join(currentProc.rootPath(), "io.containerd.grpc.v1.cri", "containers", cnid))
+			require.True(t, os.IsNotExist(err))
+		}
+		t.Logf("Stop and remove sandbox %s", sb.sbid)
+		require.NoError(t, currentProc.criRuntimeService(t).StopPodSandbox(sb.sbid))
+		require.NoError(t, currentProc.criRuntimeService(t).RemovePodSandbox(sb.sbid))
+	}
+	require.NoError(t, currentProc.kill(syscall.SIGTERM))
+}
+
+type ctrdConfig struct {
+	t       *testing.T
+	workdir string
+	ver     int
+}
+
+type runtimeConfig struct {
+	name        string
+	runtimeType string
+	runtimePath string
+}
+
+func newCtrdConfig(t *testing.T, ctrdWorkDir string, version int) *ctrdConfig {
+	cc := &ctrdConfig{
+		t:       t,
+		workdir: ctrdWorkDir,
+		ver:     version,
+	}
+	cc.reset(version)
+	return cc
+}
+
+func (c *ctrdConfig) reset(version int) {
+	fileName := filepath.Join(c.workdir, "config.toml")
+	err := os.WriteFile(fileName, []byte(fmt.Sprintf("version = %d\n", version)), 0600)
+	require.NoError(c.t, err, "failed to write config")
+	c.ver = version
+}
+
+func (c *ctrdConfig) setRuntime(rcs ...runtimeConfig) {
+	plugin := "io.containerd.grpc.v1.cri"
+	temp := `
+
+[plugins."%s".containerd.runtimes.%s]
+  runtime_type = "%s"
+  runtime_path = "%s"
+
+	`
+	if c.ver == 3 {
+		plugin = "io.containerd.cri.v1.runtime"
+	}
+	f, err := os.OpenFile(filepath.Join(c.workdir, "config.toml"), os.O_APPEND|os.O_WRONLY, 0600)
+	require.NoError(c.t, err, "failed to open config")
+	for _, rc := range rcs {
+		_, err = f.WriteString(fmt.Sprintf(temp, plugin, rc.name, rc.runtimeType, rc.runtimePath))
+		require.NoError(c.t, err, "failed to write runtime config")
+	}
+	err = f.Close()
+	require.NoError(c.t, err, "failed to close config")
+}

--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -32,7 +32,6 @@ import (
 	cio "github.com/containerd/containerd/v2/internal/cri/io"
 	crilabels "github.com/containerd/containerd/v2/internal/cri/labels"
 	customopts "github.com/containerd/containerd/v2/internal/cri/opts"
-	podsandboxtypes "github.com/containerd/containerd/v2/internal/cri/server/podsandbox/types"
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 	"github.com/containerd/containerd/v2/internal/cri/store/sandbox"
 	"github.com/containerd/containerd/v2/internal/cri/util"
@@ -408,11 +407,8 @@ func (c *criService) createContainer(r *createContainerRequest) (_ string, retEr
 		containerd.WithRuntime(runtimeName, runtimeOption),
 		containerd.WithContainerLabels(containerLabels),
 		containerd.WithContainerExtension(crilabels.ContainerMetadataExtension, r.meta),
+		containerd.WithSandbox(r.sandboxID),
 	)
-
-	if r.sandbox.Sandboxer != podsandboxtypes.InternalSandboxID {
-		opts = append(opts, containerd.WithSandbox(r.sandboxID))
-	}
 
 	opts = append(opts, c.nri.WithContainerAdjustment())
 	defer func() {

--- a/internal/cri/server/podsandbox/controller.go
+++ b/internal/cri/server/podsandbox/controller.go
@@ -47,7 +47,7 @@ import (
 func init() {
 	registry.Register(&plugin.Registration{
 		Type: plugins.PodSandboxPlugin,
-		ID:   types.InternalSandboxID,
+		ID:   string(criconfig.ModePodSandbox),
 		Requires: []plugin.Type{
 			plugins.EventPlugin,
 			plugins.LeasePlugin,

--- a/internal/cri/server/podsandbox/types/podsandbox.go
+++ b/internal/cri/server/podsandbox/types/podsandbox.go
@@ -26,10 +26,6 @@ import (
 	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
 )
 
-const (
-	InternalSandboxID = "podsandbox"
-)
-
 type PodSandbox struct {
 	ID        string
 	Container containerd.Container


### PR DESCRIPTION
Fix #11535 

Add e2e testing, mainly including the following

1. Use 1.7.27 to create containers based on `containerd-shim runc-v2` and `containerd-shim runc-v1`
2. Upgrade to current(2.x) and create a new container on the previously created one to ensure successful creation
3. Use the current(2.x)  to stop and delete the above containers, ensuring success and no resource leaks, such as root  file



To ensure the success of e2e, some modifications have been made, roughly as follows

1 rewrite the https://github.com/containerd/containerd/pull/11735, as the [comment](https://github.com/containerd/containerd/pull/11735#issuecomment-2821866740) describe, it is also follow-up
2 use clientv2 which the corresponding sandbox is created by 1.x. 

