### PR TITLE
Plumb windows CPU affinity values to runtime spec

### DIFF
--- a/internal/cri/opts/spec_opts.go
+++ b/internal/cri/opts/spec_opts.go
@@ -118,6 +118,33 @@ func WithAnnotation(k, v string) oci.SpecOpts {
 	}
 }
 
+// WithWindowsAffinityCPUs sets the CPU affinity values in runtime spec for windows.
+func WithWindowsAffinityCPUs(config *runtime.WindowsContainerConfig) oci.SpecOpts {
+	return func(_ context.Context, _ oci.Client, c *containers.Container, s *runtimespec.Spec) error {
+		if s.Windows == nil || config.Resources == nil || config.Resources.AffinityCpus == nil {
+			return nil
+		}
+
+		if s.Windows.Resources == nil {
+			s.Windows.Resources = &runtimespec.WindowsResources{}
+		}
+
+		if s.Windows.Resources.CPU == nil {
+			s.Windows.Resources.CPU = &runtimespec.WindowsCPUResources{}
+		}
+
+		affinities := make([]runtimespec.WindowsCPUGroupAffinity, 0, len(config.Resources.AffinityCpus))
+		for _, affinity := range config.Resources.AffinityCpus {
+			affinities = append(affinities, runtimespec.WindowsCPUGroupAffinity{
+				Mask:  affinity.CpuMask,
+				Group: affinity.CpuGroup,
+			})
+		}
+		s.Windows.Resources.CPU.Affinity = affinities
+		return nil
+	}
+}
+
 // WithAdditionalGIDs adds any additional groups listed for a particular user in the
 // /etc/groups file of the image's root filesystem to the OCI spec's additionalGids array.
 func WithAdditionalGIDs(userstr string) oci.SpecOpts {

--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -1027,6 +1027,10 @@ func (c *criService) buildWindowsSpec(
 		annotations.DefaultCRIAnnotations(sandboxID, containerName, imageName, sandboxConfig, false)...,
 	)
 
+	if config.Windows != nil {
+		specOpts = append(specOpts, customopts.WithWindowsAffinityCPUs(config.Windows))
+	}
+
 	return specOpts, nil
 }
 

--- a/internal/cri/server/container_create_windows_test.go
+++ b/internal/cri/server/container_create_windows_test.go
@@ -84,6 +84,12 @@ func getCreateContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandbox
 				CpuCount:           200,
 				CpuMaximum:         300,
 				MemoryLimitInBytes: 400,
+				AffinityCpus: []*runtime.WindowsCpuGroupAffinity{
+					{
+						CpuMask:  192,
+						CpuGroup: 0,
+					},
+				},
 			},
 			SecurityContext: &runtime.WindowsContainerSecurityContext{
 				RunAsUsername:  "test-user",
@@ -118,6 +124,8 @@ func getCreateContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandbox
 		assert.EqualValues(t, *spec.Windows.Resources.CPU.Maximum, 300)
 		assert.EqualValues(t, *spec.Windows.Resources.CPU.Maximum, 300)
 		assert.EqualValues(t, *spec.Windows.Resources.Memory.Limit, 400)
+		assert.EqualValues(t, spec.Windows.Resources.CPU.Affinity[0].Mask, 192)
+		assert.EqualValues(t, spec.Windows.Resources.CPU.Affinity[0].Group, 0)
 
 		// Also checks if override of the image configs user is behaving.
 		t.Logf("Check username")


### PR DESCRIPTION
Commit passes the CPU affinity values namely cpu mask and group to runtime spec from container config.