### PR TITLE
Added stop signal to container termination logic and container status

### DIFF
--- a/integration/container_stop_signal_test.go
+++ b/integration/container_stop_signal_test.go
@@ -1,0 +1,197 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	goruntime "runtime"
+	"testing"
+
+	"github.com/containerd/containerd/v2/integration/images"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+func TestContainerStopSignals(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("Skipped on Windows.")
+	}
+
+	testCases := []struct {
+		name           string
+		stopSignal     runtime.Signal
+		expectedSignal runtime.Signal
+		trapSignal     string
+	}{
+		{
+			name:           "SIGUSR1 stop signal",
+			stopSignal:     runtime.Signal_SIGUSR1,
+			expectedSignal: runtime.Signal_SIGUSR1,
+			trapSignal:     "USR1",
+		},
+		{
+			name:           "SIGUSR2 stop signal",
+			stopSignal:     runtime.Signal_SIGUSR2,
+			expectedSignal: runtime.Signal_SIGUSR2,
+			trapSignal:     "USR2",
+		},
+		{
+			name:           "SIGHUP stop signal",
+			stopSignal:     runtime.Signal_SIGHUP,
+			expectedSignal: runtime.Signal_SIGHUP,
+			trapSignal:     "HUP",
+		},
+		{
+			name:           "SIGINT stop signal",
+			stopSignal:     runtime.Signal_SIGINT,
+			expectedSignal: runtime.Signal_SIGINT,
+			trapSignal:     "INT",
+		},
+		{
+			name:           "SIGTERM stop signal (default)",
+			stopSignal:     runtime.Signal_SIGTERM,
+			expectedSignal: runtime.Signal_SIGTERM,
+			trapSignal:     "TERM",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testPodLogDir := t.TempDir()
+
+			t.Log("Create a pod sandbox")
+			sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "custom-stop-signal-"+tc.name, WithHostNetwork, WithPodLogDirectory(testPodLogDir))
+
+			var (
+				testImage     = images.Get(images.BusyBox)
+				containerName = "test-container"
+			)
+
+			EnsureImageExists(t, testImage)
+
+			t.Log("Create a container with custom stop signal")
+			scriptDir := writeStopSignalScript(t)
+			cnConfig := ContainerConfig(
+				containerName,
+				testImage,
+				WithCommand("sh", "/stop-signal/stop-signal.sh", tc.trapSignal),
+				WithVolumeMount(scriptDir, "/stop-signal"),
+				WithLogPath(containerName),
+				WithStopSignal(tc.stopSignal),
+			)
+			cn, err := runtimeService.CreateContainer(sb, cnConfig, sbConfig)
+			require.NoError(t, err)
+			defer func() {
+				assert.NoError(t, runtimeService.RemoveContainer(cn))
+			}()
+
+			require.NoError(t, runtimeService.StartContainer(cn))
+
+			status, err := runtimeService.ContainerStatus(cn)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedSignal, status.GetStopSignal(), "Container status should return the configured stop signal")
+			assert.Equal(t, runtime.ContainerState_CONTAINER_RUNNING, status.GetState())
+
+			require.NoError(t, runtimeService.StopContainer(cn, 10))
+
+			status, err = runtimeService.ContainerStatus(cn)
+			require.NoError(t, err)
+			require.Equal(t, runtime.ContainerState_CONTAINER_EXITED, status.GetState())
+			assert.Equal(t, int32(0), status.GetExitCode(), "container should exit from the configured stop signal trap")
+
+			t.Log("Check container log")
+			content, err := os.ReadFile(filepath.Join(testPodLogDir, containerName))
+			require.NoError(t, err)
+			checkContainerLog(t, string(content), []string{
+				fmt.Sprintf("%s %s Received %s", runtime.Stdout, runtime.LogTagFull, tc.trapSignal),
+			})
+		})
+	}
+}
+
+func TestDefaultContainerStopSignal(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("Skipped on Windows.")
+	}
+
+	t.Logf("Create a pod config")
+	sb, sbConfig := PodSandboxConfigWithCleanup(t, "sandbox", "default-stop-signal", WithHostNetwork)
+
+	var (
+		testImage     = images.Get(images.BusyBox)
+		containerName = "test-container"
+	)
+
+	EnsureImageExists(t, testImage)
+
+	t.Log("Create a container without custom stop signal")
+	cnConfig := ContainerConfig(
+		containerName,
+		testImage,
+		WithCommand("sh", "-c", "sleep 1000"),
+	)
+	cn, err := runtimeService.CreateContainer(sb, cnConfig, sbConfig)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, runtimeService.RemoveContainer(cn))
+	}()
+
+	require.NoError(t, runtimeService.StartContainer(cn))
+
+	status, err := runtimeService.ContainerStatus(cn)
+	require.NoError(t, err)
+
+	assert.Equal(t, runtime.Signal_SIGTERM, status.GetStopSignal())
+
+	require.NoError(t, runtimeService.StopContainer(cn, 10))
+
+	status, err = runtimeService.ContainerStatus(cn)
+	require.NoError(t, err)
+	assert.Equal(t, runtime.ContainerState_CONTAINER_EXITED, status.GetState())
+}
+
+func writeStopSignalScript(t *testing.T) string {
+	t.Helper()
+
+	scriptDir := t.TempDir()
+	scriptPath := filepath.Join(scriptDir, "stop-signal.sh")
+	script := `#!/bin/sh
+set -eu
+
+signal="$1"
+child=""
+
+cleanup() {
+	echo "Received ${signal}"
+	if [ -n "${child}" ]; then
+		kill "${child}" 2>/dev/null || true
+	fi
+	exit 0
+}
+
+trap cleanup "${signal}"
+
+sleep 5000 &
+child="$!"
+wait "${child}"
+`
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0644))
+	return scriptDir
+}

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -350,6 +350,12 @@ func WithTestAnnotations() ContainerOpts {
 	}
 }
 
+func WithStopSignal(signal runtime.Signal) ContainerOpts {
+	return func(c *runtime.ContainerConfig) {
+		c.StopSignal = signal
+	}
+}
+
 // Add container resource limits.
 func WithResources(r *runtime.LinuxContainerResources) ContainerOpts {
 	return func(c *runtime.ContainerConfig) {

--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -95,6 +95,9 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	containerName := metadata.Name
 	name := makeContainerName(metadata, sandboxMetadata)
 	log.G(ctx).Debugf("Generated id %q for container %q", id, name)
+	if _, err := criSignalToOCIStopSignal(config.GetStopSignal()); err != nil {
+		return nil, err
+	}
 	if err = c.containerNameIndex.Reserve(name, id); err != nil {
 		var resErr *registrar.ReservedErr
 		if errors.As(err, &resErr) {
@@ -367,7 +370,15 @@ func (c *criService) createContainer(r *createContainerRequest) (_ string, retEr
 		opts = append(opts, customopts.WithVolumes(mountMap, platform))
 	}
 	r.meta.ImageRef = r.imageID
-	r.meta.StopSignal = r.imageConfig.StopSignal
+	if signal := r.containerConfig.GetStopSignal(); signal != runtime.Signal_RUNTIME_DEFAULT {
+		stopSignal, err := criSignalToOCIStopSignal(signal)
+		if err != nil {
+			return "", err
+		}
+		r.meta.StopSignal = stopSignal
+	} else if r.imageConfig.StopSignal != "" {
+		r.meta.StopSignal = r.imageConfig.StopSignal
+	}
 
 	// Validate log paths and compose full container log path.
 	if r.podSandboxConfig.GetLogDirectory() != "" && r.containerConfig.GetLogPath() != "" {

--- a/internal/cri/server/container_status.go
+++ b/internal/cri/server/container_status.go
@@ -124,6 +124,19 @@ func toCRIContainerStatus(ctx context.Context, container containerstore.Containe
 		runtimeUser = &runtime.ContainerUser{}
 	}
 
+	var statusStopSignal runtime.Signal
+	stopsignal := container.Config.GetStopSignal()
+
+	if stopsignal == runtime.Signal_RUNTIME_DEFAULT {
+		if container.Metadata.StopSignal != "" {
+			statusStopSignal = toCRISignal(container.Metadata.StopSignal)
+		} else {
+			statusStopSignal = runtime.Signal_SIGTERM
+		}
+	} else {
+		statusStopSignal = stopsignal
+	}
+
 	return &runtime.ContainerStatus{
 		Id:          meta.ID,
 		Metadata:    meta.Config.GetMetadata(),
@@ -143,6 +156,7 @@ func toCRIContainerStatus(ctx context.Context, container containerstore.Containe
 		LogPath:     meta.LogPath,
 		Resources:   status.Resources,
 		User:        runtimeUser,
+		StopSignal:  statusStopSignal,
 	}, nil
 }
 

--- a/internal/cri/server/container_status_test.go
+++ b/internal/cri/server/container_status_test.go
@@ -168,6 +168,7 @@ func TestToCRIContainerStatus(t *testing.T) {
 			expected.FinishedAt = test.finishedAt
 			expected.ExitCode = test.exitCode
 			expected.Message = test.message
+			expected.StopSignal = runtime.Signal_SIGTERM
 			patchExceptedWithState(expected, test.expectedState)
 			containerStatus, err := toCRIContainerStatus(context.Background(),
 				container,
@@ -273,8 +274,88 @@ func TestContainerStatus(t *testing.T) {
 			expected.StartedAt = test.startedAt
 			expected.FinishedAt = test.finishedAt
 			expected.Reason = test.reason
+			expected.StopSignal = runtime.Signal_SIGTERM
 			patchExceptedWithState(expected, test.expectedState)
 			assert.Equal(t, expected, resp.GetStatus())
+		})
+	}
+}
+
+func TestToCRISignal(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected runtime.Signal
+	}{
+		{input: "SIGABRT", expected: runtime.Signal_SIGABRT},
+		{input: "SIGALRM", expected: runtime.Signal_SIGALRM},
+		{input: "SIGBUS", expected: runtime.Signal_SIGBUS},
+		{input: "SIGCHLD", expected: runtime.Signal_SIGCHLD},
+		{input: "SIGCLD", expected: runtime.Signal_SIGCLD},
+		{input: "SIGCONT", expected: runtime.Signal_SIGCONT},
+		{input: "SIGFPE", expected: runtime.Signal_SIGFPE},
+		{input: "SIGHUP", expected: runtime.Signal_SIGHUP},
+		{input: "SIGILL", expected: runtime.Signal_SIGILL},
+		{input: "SIGINT", expected: runtime.Signal_SIGINT},
+		{input: "SIGIO", expected: runtime.Signal_SIGIO},
+		{input: "SIGIOT", expected: runtime.Signal_SIGIOT},
+		{input: "SIGKILL", expected: runtime.Signal_SIGKILL},
+		{input: "SIGPIPE", expected: runtime.Signal_SIGPIPE},
+		{input: "SIGPOLL", expected: runtime.Signal_SIGPOLL},
+		{input: "SIGPROF", expected: runtime.Signal_SIGPROF},
+		{input: "SIGPWR", expected: runtime.Signal_SIGPWR},
+		{input: "SIGQUIT", expected: runtime.Signal_SIGQUIT},
+		{input: "SIGSEGV", expected: runtime.Signal_SIGSEGV},
+		{input: "SIGSTKFLT", expected: runtime.Signal_SIGSTKFLT},
+		{input: "SIGSTOP", expected: runtime.Signal_SIGSTOP},
+		{input: "SIGSYS", expected: runtime.Signal_SIGSYS},
+		{input: "SIGTERM", expected: runtime.Signal_SIGTERM},
+		{input: "SIGTRAP", expected: runtime.Signal_SIGTRAP},
+		{input: "SIGTSTP", expected: runtime.Signal_SIGTSTP},
+		{input: "SIGTTIN", expected: runtime.Signal_SIGTTIN},
+		{input: "SIGTTOU", expected: runtime.Signal_SIGTTOU},
+		{input: "SIGURG", expected: runtime.Signal_SIGURG},
+		{input: "SIGUSR1", expected: runtime.Signal_SIGUSR1},
+		{input: "SIGUSR2", expected: runtime.Signal_SIGUSR2},
+		{input: "SIGVTALRM", expected: runtime.Signal_SIGVTALRM},
+		{input: "SIGWINCH", expected: runtime.Signal_SIGWINCH},
+		{input: "SIGXCPU", expected: runtime.Signal_SIGXCPU},
+		{input: "SIGXFSZ", expected: runtime.Signal_SIGXFSZ},
+		{input: "SIGRTMIN", expected: runtime.Signal_SIGRTMIN},
+		{input: "SIGRTMIN+1", expected: runtime.Signal_SIGRTMINPLUS1},
+		{input: "SIGRTMIN+2", expected: runtime.Signal_SIGRTMINPLUS2},
+		{input: "SIGRTMIN+3", expected: runtime.Signal_SIGRTMINPLUS3},
+		{input: "SIGRTMIN+4", expected: runtime.Signal_SIGRTMINPLUS4},
+		{input: "SIGRTMIN+5", expected: runtime.Signal_SIGRTMINPLUS5},
+		{input: "SIGRTMIN+6", expected: runtime.Signal_SIGRTMINPLUS6},
+		{input: "SIGRTMIN+7", expected: runtime.Signal_SIGRTMINPLUS7},
+		{input: "SIGRTMIN+8", expected: runtime.Signal_SIGRTMINPLUS8},
+		{input: "SIGRTMIN+9", expected: runtime.Signal_SIGRTMINPLUS9},
+		{input: "SIGRTMIN+10", expected: runtime.Signal_SIGRTMINPLUS10},
+		{input: "SIGRTMIN+11", expected: runtime.Signal_SIGRTMINPLUS11},
+		{input: "SIGRTMIN+12", expected: runtime.Signal_SIGRTMINPLUS12},
+		{input: "SIGRTMIN+13", expected: runtime.Signal_SIGRTMINPLUS13},
+		{input: "SIGRTMIN+14", expected: runtime.Signal_SIGRTMINPLUS14},
+		{input: "SIGRTMIN+15", expected: runtime.Signal_SIGRTMINPLUS15},
+		{input: "SIGRTMAX-14", expected: runtime.Signal_SIGRTMAXMINUS14},
+		{input: "SIGRTMAX-13", expected: runtime.Signal_SIGRTMAXMINUS13},
+		{input: "SIGRTMAX-12", expected: runtime.Signal_SIGRTMAXMINUS12},
+		{input: "SIGRTMAX-11", expected: runtime.Signal_SIGRTMAXMINUS11},
+		{input: "SIGRTMAX-10", expected: runtime.Signal_SIGRTMAXMINUS10},
+		{input: "SIGRTMAX-9", expected: runtime.Signal_SIGRTMAXMINUS9},
+		{input: "SIGRTMAX-8", expected: runtime.Signal_SIGRTMAXMINUS8},
+		{input: "SIGRTMAX-7", expected: runtime.Signal_SIGRTMAXMINUS7},
+		{input: "SIGRTMAX-6", expected: runtime.Signal_SIGRTMAXMINUS6},
+		{input: "SIGRTMAX-5", expected: runtime.Signal_SIGRTMAXMINUS5},
+		{input: "SIGRTMAX-4", expected: runtime.Signal_SIGRTMAXMINUS4},
+		{input: "SIGRTMAX-3", expected: runtime.Signal_SIGRTMAXMINUS3},
+		{input: "SIGRTMAX-2", expected: runtime.Signal_SIGRTMAXMINUS2},
+		{input: "SIGRTMAX-1", expected: runtime.Signal_SIGRTMAXMINUS1},
+		{input: "SIGRTMAX", expected: runtime.Signal_SIGRTMAX},
+		{input: "SIGNOPE", expected: runtime.Signal_RUNTIME_DEFAULT},
+	}
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			assert.Equal(t, test.expected, toCRISignal(test.input))
 		})
 	}
 }

--- a/internal/cri/server/container_stop.go
+++ b/internal/cri/server/container_stop.go
@@ -164,7 +164,12 @@ func (c *criService) stopContainer(ctx context.Context, container containerstore
 	// task from containerd after it handles the Exited event.
 	if timeout > 0 {
 		stopSignal := "SIGTERM"
-		if container.StopSignal != "" {
+		if signal := container.Config.GetStopSignal(); signal != runtime.Signal_RUNTIME_DEFAULT {
+			stopSignal, err = criSignalToOCIStopSignal(signal)
+			if err != nil {
+				return err
+			}
+		} else if container.StopSignal != "" {
 			stopSignal = container.StopSignal
 		} else {
 			// The image may have been deleted, and the `StopSignal` field is

--- a/internal/cri/server/container_stop_signal.go
+++ b/internal/cri/server/container_stop_signal.go
@@ -1,0 +1,54 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/containerd/errdefs"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+func criSignalToOCIStopSignal(signal runtime.Signal) (string, error) {
+	if signal == runtime.Signal_RUNTIME_DEFAULT {
+		return "", nil
+	}
+
+	name, ok := runtime.Signal_name[int32(signal)]
+	if !ok {
+		return "", fmt.Errorf("unknown CRI stop signal %d: %w", signal, errdefs.ErrInvalidArgument)
+	}
+	return convertFromCRISignal(name), nil
+}
+
+func convertFromCRISignal(criSignal string) string {
+	normalized := strings.Replace(criSignal, "PLUS", "+", 1)
+	normalized = strings.Replace(normalized, "MINUS", "-", 1)
+	return normalized
+}
+
+func toCRISignal(stopsignal string) runtime.Signal {
+	stopsignal = strings.Replace(stopsignal, "+", "PLUS", 1)
+	stopsignal = strings.Replace(stopsignal, "-", "MINUS", 1)
+
+	signalValue, ok := runtime.Signal_value[stopsignal]
+	if !ok {
+		return runtime.Signal_RUNTIME_DEFAULT
+	}
+	return runtime.Signal(signalValue)
+}

--- a/internal/cri/server/container_stop_test.go
+++ b/internal/cri/server/container_stop_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 )
@@ -86,6 +87,47 @@ func TestWaitContainerStop(t *testing.T) {
 			}
 			err = c.waitContainerStop(ctx, container)
 			assert.Equal(t, test.expectErr, err != nil, test.desc)
+		})
+	}
+}
+
+func TestCRISignalToOCIStopSignal(t *testing.T) {
+	tests := []struct {
+		name           string
+		signal         runtime.Signal
+		expectedSignal string
+		expectErr      bool
+	}{
+		{name: "runtime default", signal: runtime.Signal_RUNTIME_DEFAULT, expectedSignal: ""},
+		{name: "standard signal", signal: runtime.Signal_SIGTERM, expectedSignal: "SIGTERM"},
+		{name: "rtmin plus", signal: runtime.Signal_SIGRTMINPLUS1, expectedSignal: "SIGRTMIN+1"},
+		{name: "rtmax minus", signal: runtime.Signal_SIGRTMAXMINUS1, expectedSignal: "SIGRTMAX-1"},
+		{name: "unknown signal", signal: runtime.Signal(999), expectErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stopSignal, err := criSignalToOCIStopSignal(test.signal)
+			assert.Equal(t, test.expectErr, err != nil)
+			assert.Equal(t, test.expectedSignal, stopSignal)
+		})
+	}
+}
+
+func TestConvertFromCRISignal(t *testing.T) {
+	tests := []struct {
+		name           string
+		signal         string
+		expectedSignal string
+	}{
+		{name: "standard signal", signal: "SIGTERM", expectedSignal: "SIGTERM"},
+		{name: "rtmin plus", signal: "SIGRTMINPLUS1", expectedSignal: "SIGRTMIN+1"},
+		{name: "rtmax minus", signal: "SIGRTMAXMINUS1", expectedSignal: "SIGRTMAX-1"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expectedSignal, convertFromCRISignal(test.signal))
 		})
 	}
 }


### PR DESCRIPTION
PR for https://github.com/containerd/containerd/issues/11617. Tests would fail since cri-api is not bumped to the latest version which has the API changes for stop signals in `ContainerConfig` and `ContainerStatus`.

Waiting for https://github.com/containerd/containerd/pull/11763 to be merged so that I can rebase the cri-api update into this PR.