### PR TITLE
Revert "disable portmap test in ubuntu-22 to make CI happy"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -488,12 +488,8 @@ jobs:
           TEST_RUNTIME: ${{ matrix.runtime }}
           CGROUP_DRIVER: ${{ matrix.cgroup_driver }}
         run: |
-          # skipping the ipv6 test till https://github.com/actions/runner-images/issues/11985 is fixed
-          if [[ ${{matrix.os}} == "ubuntu-22.04" ]]; then
-            skip_test="runtime should support port mapping with host port and container port"
-          fi
           env
-          sudo -E PATH=$PATH SKIP_TEST="$skip_test" ./script/critest.sh "${{github.workspace}}/report"
+          sudo -E PATH=$PATH ./script/critest.sh "${{github.workspace}}/report"
 
       - name: Install tools
         # The GitHub Actions image already has buildah and podman included. Not the

--- a/script/critest.sh
+++ b/script/critest.sh
@@ -71,7 +71,7 @@ EOF
 fi
 
 GINKGO_SKIP_TEST=()
-if [ ! -z "$SKIP_TEST" ]; then
+if [ -n "${SKIP_TEST:-}" ]; then
   GINKGO_SKIP_TEST+=("--ginkgo.skip" "$SKIP_TEST")
 fi
 


### PR DESCRIPTION
The kernel in the latest ubuntu 22.04 runner image has been updated to 6.8.0-1027-azure, which has the fix for the ipv6 MARK bug. The runner image 20250427.1.0 with this has been now completely rolled out to github actions runners. Hence reverting the change to disable the IPv6 test.

Ref: https://github.com/actions/runner-images/blob/84a341f3224f622b1724b2c3511eab85de1ca40c/images/ubuntu/Ubuntu2204-Readme.md

This reverts commit 70db1bd00fb5db7c3958da4aefac0c41c89bb654.