### PR TITLE
removing/cloning vendor of kubelet pod label definitions

### DIFF
--- a/internal/cri/server/container_checkpoint_linux.go
+++ b/internal/cri/server/container_checkpoint_linux.go
@@ -42,6 +42,7 @@ import (
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 	imagestore "github.com/containerd/containerd/v2/internal/cri/store/image"
 	"github.com/containerd/containerd/v2/internal/cri/store/sandbox"
+	critypes "github.com/containerd/containerd/v2/internal/cri/types"
 	"github.com/containerd/containerd/v2/pkg/archive"
 	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
 	ptypes "github.com/containerd/containerd/v2/pkg/protobuf/types"
@@ -56,7 +57,6 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
-	kubetypes "k8s.io/kubelet/pkg/types"
 )
 
 // checkIfCheckpointOCIImage returns checks if the input refers to a checkpoint image.
@@ -258,11 +258,11 @@ func (c *criService) CRImportCheckpoint(
 	sandboxUID := sandboxConfig.GetMetadata().GetUid()
 
 	if sandboxUID != "" {
-		if _, ok := originalLabels[kubetypes.KubernetesPodUIDLabel]; ok {
-			originalLabels[kubetypes.KubernetesPodUIDLabel] = sandboxUID
+		if _, ok := originalLabels[critypes.KubernetesPodUIDLabel]; ok {
+			originalLabels[critypes.KubernetesPodUIDLabel] = sandboxUID
 		}
-		if _, ok := originalAnnotations[kubetypes.KubernetesPodUIDLabel]; ok {
-			originalAnnotations[kubetypes.KubernetesPodUIDLabel] = sandboxUID
+		if _, ok := originalAnnotations[critypes.KubernetesPodUIDLabel]; ok {
+			originalAnnotations[critypes.KubernetesPodUIDLabel] = sandboxUID
 		}
 	}
 
@@ -270,11 +270,11 @@ func (c *criService) CRImportCheckpoint(
 		fixupLabels := []string{
 			// Update the container name. It has already been update in metadata.Name.
 			// It also needs to be updated in the container labels.
-			kubetypes.KubernetesContainerNameLabel,
+			critypes.KubernetesContainerNameLabel,
 			// Update pod name in the labels.
-			kubetypes.KubernetesPodNameLabel,
+			critypes.KubernetesPodNameLabel,
 			// Also update namespace.
-			kubetypes.KubernetesPodNamespaceLabel,
+			critypes.KubernetesPodNamespaceLabel,
 		}
 
 		for _, annotation := range fixupLabels {

--- a/internal/cri/types/labels.go
+++ b/internal/cri/types/labels.go
@@ -1,4 +1,20 @@
 /*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
 Copyright 2016 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -872,7 +872,6 @@ k8s.io/klog/v2/internal/sloghandler
 k8s.io/kubelet/pkg/cri/streaming
 k8s.io/kubelet/pkg/cri/streaming/portforward
 k8s.io/kubelet/pkg/cri/streaming/remotecommand
-k8s.io/kubelet/pkg/types
 # k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 ## explicit; go 1.18
 k8s.io/utils/clock


### PR DESCRIPTION
one of N PRs to clean up / eliminate our k8s.io vendor impact to only external apis that carry no k8s.io internal baggage like the min golang version definition in go.mod

https://github.com/kubernetes/kubernetes/issues/130799