### PR TITLE
Add option to control ownership of containerd socket

### DIFF
--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -104,6 +104,11 @@ can be used and modified as necessary as a custom configuration.`
 			Usage:   "Address for containerd's GRPC server",
 		},
 		&cli.StringFlag{
+			Name:    "group",
+			Aliases: []string{"g"},
+			Usage:   "Group for containerd's GRPC server",
+		},
+		&cli.StringFlag{
 			Name:  "root",
 			Usage: "containerd root directory",
 		},
@@ -342,6 +347,10 @@ func applyFlags(cliContext *cli.Context, config *srvconfig.Config) error {
 			name: "address",
 			d:    &config.GRPC.Address,
 		},
+		{
+			name: "group",
+			d:    &config.GRPC.Group,
+		},
 	} {
 		if s := cliContext.String(v.name); s != "" {
 			*v.d = s
@@ -351,6 +360,8 @@ func applyFlags(cliContext *cli.Context, config *srvconfig.Config) error {
 					return err
 				}
 				*v.d = absPath
+			} else if v.name == "group" {
+				config.GRPC.GID = 0
 			}
 		}
 	}

--- a/cmd/containerd/command/main.go
+++ b/cmd/containerd/command/main.go
@@ -151,7 +151,9 @@ can be used and modified as necessary as a custom configuration.`
 			// If TTRPC was not explicitly configured, use defaults based on GRPC.
 			config.TTRPC.Address = config.GRPC.Address + ".ttrpc"
 			config.TTRPC.UID = config.GRPC.UID
+			config.TTRPC.User = config.GRPC.User
 			config.TTRPC.GID = config.GRPC.GID
+			config.TTRPC.Group = config.GRPC.Group
 		}
 
 		// Make sure top-level directories are created early.
@@ -245,7 +247,7 @@ can be used and modified as necessary as a custom configuration.`
 		if config.Debug.Address != "" {
 			var l net.Listener
 			if isLocalAddress(config.Debug.Address) {
-				if l, err = sys.GetLocalListener(config.Debug.Address, config.Debug.UID, config.Debug.GID); err != nil {
+				if l, err = sys.GetLocalListener(config.Debug.Address, config.Debug.UID, config.Debug.GID, config.Debug.User, config.Debug.Group); err != nil {
 					return fmt.Errorf("failed to get listener for debug endpoint: %w", err)
 				}
 			} else {
@@ -263,7 +265,7 @@ can be used and modified as necessary as a custom configuration.`
 			serve(ctx, l, server.ServeMetrics)
 		}
 		// setup the ttrpc endpoint
-		tl, err := sys.GetLocalListener(config.TTRPC.Address, config.TTRPC.UID, config.TTRPC.GID)
+		tl, err := sys.GetLocalListener(config.TTRPC.Address, config.TTRPC.UID, config.TTRPC.GID, config.TTRPC.User, config.TTRPC.Group)
 		if err != nil {
 			return fmt.Errorf("failed to get listener for main ttrpc endpoint: %w", err)
 		}
@@ -277,7 +279,7 @@ can be used and modified as necessary as a custom configuration.`
 			serve(ctx, l, server.ServeTCP)
 		}
 		// setup the main grpc endpoint
-		l, err := sys.GetLocalListener(config.GRPC.Address, config.GRPC.UID, config.GRPC.GID)
+		l, err := sys.GetLocalListener(config.GRPC.Address, config.GRPC.UID, config.GRPC.GID, config.GRPC.User, config.GRPC.Group)
 		if err != nil {
 			return fmt.Errorf("failed to get listener for main endpoint: %w", err)
 		}

--- a/cmd/containerd/server/config/config.go
+++ b/cmd/containerd/server/config/config.go
@@ -210,7 +210,9 @@ type GRPCConfig struct {
 	TCPTLSCert     string `toml:"tcp_tls_cert"`
 	TCPTLSKey      string `toml:"tcp_tls_key"`
 	UID            int    `toml:"uid"`
+	User           string `toml:"user"`
 	GID            int    `toml:"gid"`
+	Group          string `toml:"group"`
 	MaxRecvMsgSize int    `toml:"max_recv_message_size"`
 	MaxSendMsgSize int    `toml:"max_send_message_size"`
 }
@@ -219,14 +221,18 @@ type GRPCConfig struct {
 type TTRPCConfig struct {
 	Address string `toml:"address"`
 	UID     int    `toml:"uid"`
+	User    string `toml:"user"`
 	GID     int    `toml:"gid"`
+	Group   string `toml:"group"`
 }
 
 // Debug provides debug configuration
 type Debug struct {
 	Address string `toml:"address"`
 	UID     int    `toml:"uid"`
+	User    string `toml:"user"`
 	GID     int    `toml:"gid"`
+	Group   string `toml:"group"`
 	Level   string `toml:"level"`
 	// Format represents the logging format. Supported values are 'text' and 'json'.
 	Format string `toml:"format"`

--- a/contrib/fuzz/daemon.go
+++ b/contrib/fuzz/daemon.go
@@ -71,7 +71,7 @@ func startDaemon() {
 			return
 		}
 
-		l, err := sys.GetLocalListener(srvconfig.GRPC.Address, srvconfig.GRPC.UID, srvconfig.GRPC.GID)
+		l, err := sys.GetLocalListener(srvconfig.GRPC.Address, srvconfig.GRPC.UID, srvconfig.GRPC.GID, srvconfig.GRPC.User, srvconfig.GRPC.Group)
 		if err != nil {
 			errC <- err
 			return

--- a/docs/man/containerd-config.toml.5.md
+++ b/docs/man/containerd-config.toml.5.md
@@ -46,7 +46,9 @@ config as version 1 has been deprecated.
 - **tcp_tls_cert**
 - **tcp_tls_key**
 - **uid** (Default: 0)
+- **user**
 - **gid** (Default: 0)
+- **group**
 - **max_recv_message_size**
 - **max_send_message_size**
 
@@ -55,14 +57,18 @@ config as version 1 has been deprecated.
 
 - **address** (Default: "")
 - **uid** (Default: 0)
+- **user**
 - **gid** (Default: 0)
+- **group**
 
 **[debug]**
 : Section to enable and configure a debug socket listener. Contains four properties:
 
 - **address** (Default: "/run/containerd/debug.sock")
 - **uid** (Default: 0)
+- **user**
 - **gid** (Default: 0)
+- **group**
 - **level** (Default: "info") sets the debug log level. Supported levels are:
   "trace", "debug", "info", "warn", "error", "fatal", "panic"
 - **format** (Default: "text") sets log format. Supported formats are "text" and "json"

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -44,6 +44,7 @@ GLOBAL OPTIONS:
    --config value, -c value     Path to the configuration file (default: "/etc/containerd/config.toml")
    --log-level value, -l value  Set the logging level [trace, debug, info, warn, error, fatal, panic]
    --address value, -a value    Address for containerd's GRPC server
+   --group value, -g value      Group for containerd's GRPC server
    --root value                 containerd root directory
    --state value                containerd state directory
    --help, -h                   Show help


### PR DESCRIPTION
Adds support for setting the ownership (for Unix) or access rights (for Windows) for containerd's sockets using user and group names. Also adds a `--group` flag to containerd, similar to buildkitd.

Would close #10454.

## ACL for Windows named pipe

The named pipe is accessible to Administrators and Local System, in addition to a user or group specified by the configuration or on the command line. This [matches what buildkit does](https://github.com/moby/buildkit/blob/94f3b378d96ef6e4d53da19658ed8df3e5e6bcf2/cmd/buildkitd/main_windows.go#L45) and also Windows' default ACL for named pipes. Windows' default also adds read access for all authenticated and anonymous users (see below), but I didn't think that'd be appropriate here.

### Discovering default ACL

I got the default ACL for named pipes using the following Go program:

```go
package main

import (
	"fmt"

	"golang.org/x/sys/windows"
)

func main() {
	var err error
	var acl *windows.ACL
	var sd *windows.SECURITY_DESCRIPTOR

	if err = windows.RtlDefaultNpAcl(&acl); err != nil {
		fmt.Errorf("RtlDefaultNpAcl failed: %w", err)
		return
	}

	if sd, err = windows.NewSecurityDescriptor(); err != nil {
		fmt.Errorf("NewSecurityDescriptor failed: %w", err)
		return
	}

	if err = sd.SetDACL(acl, true, true); err != nil {
		fmt.Errorf("SetDACL failed: %w", err)
		return
	}

	fmt.Println(sd)
}
```

And parsed it using [winsddl](https://github.com/mtth-bfft/winsddl):

```console
$ python winsddl/sd.py -t namedpipe "D:(A;;GA;;;SY)(A;;GA;;;BA)(A;;GA;;;<OWNER>)(A;;GR;;;WD)(A;;GR;;;AN)"
D:(A;;GA;;;SY)(A;;GA;;;BA)(A;;GA;;;<OWNER>)(A;;GR;;;WD)(A;;GR;;;AN)
    Discretionary ACL: (A;;GA;;;SY)(A;;GA;;;BA)(A;;GA;;;<OWNER>)(A;;GR;;;WD)(A;;GR;;;AN)

        ACE 1: A;;GA;;;SY
            Type: A (ACCESS_ALLOWED_ACE_TYPE)
            Access rights: GA   (0x10000000)
                0x10000000 GENERIC_ALL  (Generic right mapped to every other existing right)
            Trustee: SY (S-1-5-18) (Local System)

        ACE 2: A;;GA;;;BA
            Type: A (ACCESS_ALLOWED_ACE_TYPE)
            Access rights: GA   (0x10000000)
                0x10000000 GENERIC_ALL  (Generic right mapped to every other existing right)
            Trustee: BA (S-1-5-32-544) (Administrators)

        ACE 3: A;;GA;;;<OWNER>
            Type: A (ACCESS_ALLOWED_ACE_TYPE)
            Access rights: GA   (0x10000000)
                0x10000000 GENERIC_ALL  (Generic right mapped to every other existing right)
            Trustee: <OWNER>

        ACE 4: A;;GR;;;WD
            Type: A (ACCESS_ALLOWED_ACE_TYPE)
            Access rights: GR   (0x80000000)
                0x80000000 FILE_GENERIC_READ    (Generic right to read (mapped to FILE_READ_ATTRIBUTES | FILE_READ_DATA | FILE_READ_EA | SYNCHRONIZE | READ_CONTROL))
            Trustee: WD (S-1-1-0) (Everyone) (Authenticated users, Guests, and Anonymous remote users in XP SP1 and earlier, or if EveryoneIncludesAnonymous=1)

        ACE 5: A;;GR;;;AN
            Type: A (ACCESS_ALLOWED_ACE_TYPE)
            Access rights: GR   (0x80000000)
                0x80000000 FILE_GENERIC_READ    (Generic right to read (mapped to FILE_READ_ATTRIBUTES | FILE_READ_DATA | FILE_READ_EA | SYNCHRONIZE | READ_CONTROL))
            Trustee: AN (S-1-5-7) (Anonymous Logon) (Group that includes all users who have logged on anonymously, maintained by the system)
```