### PR TITLE
Use Go 1.19 atomic wrappers everywhere

### DIFF
--- a/core/content/testsuite/testsuite.go
+++ b/core/content/testsuite/testsuite.go
@@ -1161,13 +1161,13 @@ func checkContent(ctx context.Context, cs content.Store, d digest.Digest, expect
 	return nil
 }
 
-var contentSeed int64
+var contentSeed atomic.Int64
 
 func createContent(size int64) ([]byte, digest.Digest) {
 	// each time we call this, we want to get a different seed, but it should
 	// be related to the initialization order and fairly consistent between
 	// test runs. An atomic integer works just good enough for this.
-	seed := atomic.AddInt64(&contentSeed, 1)
+	seed := contentSeed.Add(1)
 
 	b, err := io.ReadAll(io.LimitReader(rand.New(rand.NewSource(seed)), size))
 	if err != nil {

--- a/core/images/usage/calculator.go
+++ b/core/images/usage/calculator.go
@@ -85,7 +85,7 @@ func CalculateImageUsage(ctx context.Context, i images.Image, provider content.I
 
 	var (
 		handler   = images.ChildrenHandler(provider)
-		size      int64
+		size      atomic.Int64
 		mustExist bool
 	)
 
@@ -153,7 +153,7 @@ func CalculateImageUsage(ctx context.Context, i images.Image, provider content.I
 			usage += desc.Size
 		}
 
-		atomic.AddInt64(&size, usage)
+		size.Add(usage)
 
 		return children, nil
 	}
@@ -163,5 +163,5 @@ func CalculateImageUsage(ctx context.Context, i images.Image, provider content.I
 		return 0, err
 	}
 
-	return size, nil
+	return size.Load(), nil
 }

--- a/core/metadata/containers.go
+++ b/core/metadata/containers.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/containerd/containerd/v2/core/containers"
@@ -301,7 +300,7 @@ func (s *containerStore) Delete(ctx context.Context, id string) error {
 			return err
 		}
 
-		atomic.AddUint32(&s.db.dirty, 1)
+		s.db.dirty.Add(1)
 
 		return nil
 	})

--- a/core/metadata/content.go
+++ b/core/metadata/content.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	eventstypes "github.com/containerd/containerd/api/events"
@@ -225,7 +224,7 @@ func (cs *contentStore) Delete(ctx context.Context, dgst digest.Digest) error {
 		}
 
 		// Mark content store as dirty for triggering garbage collection
-		atomic.AddUint32(&cs.db.dirty, 1)
+		cs.db.dirty.Add(1)
 		cs.db.dirtyCS = true
 
 		return nil

--- a/core/metadata/content_test.go
+++ b/core/metadata/content_test.go
@@ -50,11 +50,11 @@ func createContentStore(ctx context.Context, root string, opts ...DBOpt) (contex
 	}
 
 	var (
-		count uint64
+		count atomic.Uint64
 		name  = testsuite.Name(ctx)
 	)
 	wrap := func(ctx context.Context, sharedNS bool) (context.Context, func(context.Context) error, error) {
-		n := atomic.AddUint64(&count, 1)
+		n := count.Add(1)
 		ctx2 := namespaces.WithNamespace(ctx, fmt.Sprintf("%s-n%d", name, n))
 		if sharedNS {
 			db.Update(func(tx *bolt.Tx) error {

--- a/core/metadata/images.go
+++ b/core/metadata/images.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	eventstypes "github.com/containerd/containerd/api/events"
@@ -326,7 +325,7 @@ func (s *imageStore) Delete(ctx context.Context, name string, opts ...images.Del
 			return err
 		}
 
-		atomic.AddUint32(&s.db.dirty, 1)
+		s.db.dirty.Add(1)
 
 		return nil
 	})

--- a/core/metadata/leases.go
+++ b/core/metadata/leases.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/containerd/containerd/v2/core/leases"
@@ -121,7 +120,7 @@ func (lm *leaseManager) Delete(ctx context.Context, lease leases.Lease, _ ...lea
 			return err
 		}
 
-		atomic.AddUint32(&lm.db.dirty, 1)
+		lm.db.dirty.Add(1)
 
 		return nil
 	})
@@ -244,7 +243,7 @@ func (lm *leaseManager) DeleteResource(ctx context.Context, lease leases.Lease, 
 			}
 		}
 
-		atomic.AddUint32(&lm.db.dirty, 1)
+		lm.db.dirty.Add(1)
 
 		return nil
 	})

--- a/core/metadata/snapshot.go
+++ b/core/metadata/snapshot.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	eventstypes "github.com/containerd/containerd/api/events"
@@ -715,7 +714,7 @@ func (s *snapshotter) Remove(ctx context.Context, key string) error {
 		}
 
 		// Mark snapshotter as dirty for triggering garbage collection
-		atomic.AddUint32(&s.db.dirty, 1)
+		s.db.dirty.Add(1)
 		s.db.dirtySS[s.name] = struct{}{}
 
 		return nil

--- a/core/snapshots/benchsuite/benchmark_test.go
+++ b/core/snapshots/benchsuite/benchmark_test.go
@@ -146,7 +146,7 @@ func benchmarkSnapshotter(b *testing.B, snapshotter snapshots.Snapshotter) {
 	var (
 		total      = 0
 		layers     = make([]fstest.Applier, 0, layerCount)
-		layerIndex = int64(0)
+		layerIndex = atomic.Int64{}
 	)
 
 	for i := 1; i <= layerCount; i++ {
@@ -181,7 +181,7 @@ func benchmarkSnapshotter(b *testing.B, snapshotter snapshots.Snapshotter) {
 		var timer time.Time
 		for i := 0; i < b.N; i++ {
 			for l := 0; l < layerCount; l++ {
-				current = fmt.Sprintf("prepare-layer-%d", atomic.AddInt64(&layerIndex, 1))
+				current = fmt.Sprintf("prepare-layer-%d", layerIndex.Add(1))
 
 				timer = time.Now()
 				mounts, err := snapshotter.Prepare(ctx, current, parent)
@@ -193,7 +193,7 @@ func benchmarkSnapshotter(b *testing.B, snapshotter snapshots.Snapshotter) {
 				assert.Nil(b, err)
 				writeDuration += time.Since(timer)
 
-				parent = fmt.Sprintf("committed-%d", atomic.AddInt64(&layerIndex, 1))
+				parent = fmt.Sprintf("committed-%d", layerIndex.Add(1))
 
 				timer = time.Now()
 				err = snapshotter.Commit(ctx, parent, current)

--- a/core/unpack/unpacker.go
+++ b/core/unpack/unpacker.go
@@ -135,7 +135,7 @@ func WithDuplicationSuppressor(d kmutex.KeyedLocker) UnpackerOpt {
 type Unpacker struct {
 	unpackerConfig
 
-	unpacks int32
+	unpacks atomic.Int32
 	ctx     context.Context
 	eg      *errgroup.Group
 }
@@ -253,7 +253,7 @@ func (u *Unpacker) Wait() (Result, error) {
 		return Result{}, err
 	}
 	return Result{
-		Unpacks: int(u.unpacks),
+		Unpacks: int(u.unpacks.Load()),
 	}, nil
 }
 
@@ -314,7 +314,7 @@ func (u *Unpacker) unpack(
 		return u.fetch(ctx, h, layers, nil)
 	}
 
-	atomic.AddInt32(&u.unpacks, 1)
+	u.unpacks.Add(1)
 
 	var (
 		sn = unpack.Snapshotter

--- a/internal/cri/server/images/image_pull.go
+++ b/internal/cri/server/images/image_pull.go
@@ -759,27 +759,27 @@ func (r *countingReadCloser) Close() error {
 type pullRequestReporter struct {
 	// activeReqs indicates that current number of active pulling requests,
 	// including auth requests.
-	activeReqs int32
+	activeReqs atomic.Int32
 	// totalBytesRead indicates that the total bytes has been read from
 	// remote registry.
-	totalBytesRead uint64
+	totalBytesRead atomic.Uint64
 }
 
 func (reporter *pullRequestReporter) incRequest() {
-	atomic.AddInt32(&reporter.activeReqs, 1)
+	reporter.activeReqs.Add(1)
 }
 
 func (reporter *pullRequestReporter) decRequest() {
-	atomic.AddInt32(&reporter.activeReqs, -1)
+	reporter.activeReqs.Add(-1)
 }
 
 func (reporter *pullRequestReporter) incByteRead(nr uint64) {
-	atomic.AddUint64(&reporter.totalBytesRead, nr)
+	reporter.totalBytesRead.Add(nr)
 }
 
 func (reporter *pullRequestReporter) status() (currentReqs int32, totalBytesRead uint64) {
-	currentReqs = atomic.LoadInt32(&reporter.activeReqs)
-	totalBytesRead = atomic.LoadUint64(&reporter.totalBytesRead)
+	currentReqs = reporter.activeReqs.Load()
+	totalBytesRead = reporter.totalBytesRead.Load()
 	return currentReqs, totalBytesRead
 }
 

--- a/internal/cri/server/images/image_pull_test.go
+++ b/internal/cri/server/images/image_pull_test.go
@@ -577,8 +577,8 @@ func TestTransferProgressReporter(t *testing.T) {
 				},
 			},
 			check: func(t *testing.T, r *transferProgressReporter, cancelCalled <-chan struct{}) {
-				assert.Equal(t, int32(0), r.reqReporter.activeReqs, "Expected zero active request")
-				assert.Equal(t, uint64(0), r.reqReporter.totalBytesRead, "Expected zero bytes read")
+				assert.Equal(t, int32(0), r.reqReporter.activeReqs.Load(), "Expected zero active request")
+				assert.Equal(t, uint64(0), r.reqReporter.totalBytesRead.Load(), "Expected zero bytes read")
 			},
 		},
 		{


### PR DESCRIPTION
We've long been able to use these and they have a couple great benefits:

1. Forces you to always access them atomically. With the pointer variants it's completely valid to access the regular ol' int64/uint32 etc. without using the atomic.* methods. These wrappers don't provide access to the underlying value so it forces correct usage always.

2. Conveys intent much better. Seeing the type be atomic.Int32 immediately lets the reader know that this var will be used in a concurrent context, and we no longer need comments like "this MUST be accessed atomically" or similar.