### PR TITLE
[carry-11761] core/runtime: should invoke shim binary if it doesn't support Sandbox API

### DIFF
--- a/core/runtime/v2/task_manager.go
+++ b/core/runtime/v2/task_manager.go
@@ -26,6 +26,7 @@ import (
 	"slices"
 
 	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
 	"github.com/containerd/platforms"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
@@ -141,7 +142,27 @@ func (m *TaskManager) Create(ctx context.Context, taskID string, opts runtime.Cr
 		return nil, fmt.Errorf("failed to validate OCI runtime features: %w", err)
 	}
 
-	t, err := shimTask.Create(ctx, opts)
+	t, err := func() (runtime.Task, error) {
+		t, err := shimTask.Create(ctx, opts)
+		if err == nil || !errdefs.IsNotImplemented(err) {
+			return t, err
+		}
+
+		downgrader, ok := shim.(clientVersionDowngrader)
+		if ok {
+			if derr := downgrader.Downgrade(); derr == nil {
+				log.G(ctx).WithError(err).WithField("id", taskID).
+					Warning("failed to call task.Create, downgrading client API version to try again")
+
+				shimTask, err = newShimTask(shim)
+				if err != nil {
+					return nil, fmt.Errorf("failed to create shim task after downgrading: %w", err)
+				}
+				return shimTask.Create(ctx, opts)
+			}
+		}
+		return t, err
+	}()
 	if err != nil {
 		// NOTE: ctx contains required namespace information.
 		m.manager.shims.Delete(ctx, taskID)

--- a/integration/issue10467_linux_test.go
+++ b/integration/issue10467_linux_test.go
@@ -66,7 +66,7 @@ func TestIssue10467(t *testing.T) {
 	})
 
 	t.Log("Prepare pods for current release")
-	upgradeCaseFunc, hookFunc := shouldManipulateContainersInPodAfterUpgrade(t, 2, previousProc.criRuntimeService(t), previousProc.criImageService(t))
+	upgradeCaseFunc, hookFunc := shouldManipulateContainersInPodAfterUpgrade("")(t, 2, previousProc.criRuntimeService(t), previousProc.criImageService(t))
 	needToCleanup = false
 	require.Nil(t, hookFunc)
 

--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -32,7 +32,6 @@ import (
 	cio "github.com/containerd/containerd/v2/internal/cri/io"
 	crilabels "github.com/containerd/containerd/v2/internal/cri/labels"
 	customopts "github.com/containerd/containerd/v2/internal/cri/opts"
-	podsandboxtypes "github.com/containerd/containerd/v2/internal/cri/server/podsandbox/types"
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 	"github.com/containerd/containerd/v2/internal/cri/store/sandbox"
 	"github.com/containerd/containerd/v2/internal/cri/util"
@@ -410,9 +409,7 @@ func (c *criService) createContainer(r *createContainerRequest) (_ string, retEr
 		containerd.WithContainerExtension(crilabels.ContainerMetadataExtension, r.meta),
 	)
 
-	if r.sandbox.Sandboxer != podsandboxtypes.InternalSandboxID {
-		opts = append(opts, containerd.WithSandbox(r.sandboxID))
-	}
+	opts = append(opts, containerd.WithSandbox(r.sandboxID))
 
 	opts = append(opts, c.nri.WithContainerAdjustment())
 	defer func() {

--- a/internal/cri/server/podsandbox/controller.go
+++ b/internal/cri/server/podsandbox/controller.go
@@ -47,7 +47,7 @@ import (
 func init() {
 	registry.Register(&plugin.Registration{
 		Type: plugins.PodSandboxPlugin,
-		ID:   types.InternalSandboxID,
+		ID:   "podsandbox",
 		Requires: []plugin.Type{
 			plugins.EventPlugin,
 			plugins.LeasePlugin,

--- a/internal/cri/server/podsandbox/types/podsandbox.go
+++ b/internal/cri/server/podsandbox/types/podsandbox.go
@@ -26,10 +26,6 @@ import (
 	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
 )
 
-const (
-	InternalSandboxID = "podsandbox"
-)
-
 type PodSandbox struct {
 	ID        string
 	Container containerd.Container


### PR DESCRIPTION
Since the v2.0.0 release, the shim manager has attempted to use a single ttrpc connection to manage multiple containers through one shim server. However, this approach may introduce compatibility issues with older shims. According to the [current documentation](https://github.com/containerd/containerd/blob/main/core/runtime/v2/README.md?plain=1#L227), container resources are cleaned up via the `shim delete` binary call, which is triggered as a callback when the connection is closed. To ensure compatibility, containerd should always invoke the shim start binary to establish a new connection—regardless of the shim type—if the shim version is lower than `3`.

This patch enables containerd to invoke the shim start binary call, but doing so reveals another issue:

* A running pod is using an older containerd-shim-runc-v2 version (v1.7.x).
* After upgrading to v2.x.y, the new containerd instance attempts to take over the running pod.
* The old containerd-shim-runc-v2 binary has been replaced by the newer v2.x.y version.
    * The shim start call for the running pod now returns `{ "version": 3, "protocol": "ttrpc", "address": "EXISTING-SOCKET" }`.
* If a container in the pod exits and kubelet tries to recreate it, the shim manager attempts to connect using a version: 3 task client (containerd.io.v3.Task), which is not implemented in the old shim.

To address this, this patch also introduces a `clientVersionDowngrader` on shim, allowing the shim manager to retry with a lower client version for compatibility with older shims.

----

Closes: #11761 
Closes: #9137
Closes: #11535
We should revert this change: https://github.com/containerd/containerd/pull/11741 from release/2.0

@dmcgowan @mikebrow @mxpv @samuelkarp 
cc @yylt @chrishenzie 