### PR TITLE
[release/1.6]: Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,6 +371,7 @@ jobs:
           script/setup/install-failpoint-binaries
 
       - name: Install criu
+        if: matrix.os != 'ubuntu-24.04-arm'
         run: |
           sudo add-apt-repository ppa:criu/ppa
           sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,20 +348,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runtime: [io.containerd.runtime.v1.linux, io.containerd.runc.v1, io.containerd.runc.v2]
+        runtime:
+          - io.containerd.runc.v2
         runc: [runc, crun]
         os: [ubuntu-24.04, ubuntu-24.04-arm]
-        exclude:
-          - runtime: io.containerd.runc.v1
-            runc: crun
-          - runtime: io.containerd.runtime.v1.linux
-            runc: crun
-          # runc.v1 doesn't support cgroupv2
-          - runtime: io.containerd.runc.v1
-            os: ubuntu-24.04-arm
-          # shim.v1 doesn't support cgroupv2
-          - runtime: io.containerd.runtime.v1.linux
-            os: ubuntu-24.04-arm
 
     env:
       GOTEST: gotestsum --

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,11 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-24.04-arm, macos-13, windows-2019]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-13, windows-2019]
 
     steps:
       - name: Install dependencies
-        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'ubuntu-24.04-arm'
+        if: matrix.os == 'ubuntu-24.04' || matrix.os == 'ubuntu-24.04-arm'
         run: |
           sudo apt-get update
           sudo apt-get install -y libbtrfs-dev
@@ -49,7 +49,7 @@ jobs:
   #
   project:
     name: Project Checks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
 
     steps:
@@ -77,7 +77,7 @@ jobs:
   #
   protos:
     name: Protobuf
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
 
     defaults:
@@ -111,7 +111,7 @@ jobs:
 
   man:
     name: Manpages
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
 
     steps:
@@ -124,7 +124,7 @@ jobs:
   crossbuild:
     name: Crossbuild Binaries
     needs: [linters, protos, man]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -217,11 +217,11 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-24.04-arm, macos-13, windows-2019, windows-2022]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-13, windows-2019, windows-2022]
         go-version: ["1.23.7", "1.24.1"]
     steps:
       - name: Install dependencies
-        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'ubuntu-24.04-arm'
+        if: matrix.os == 'ubuntu-24.04' || matrix.os == 'ubuntu-24.04-arm'
         run: |
           sudo apt-get update
           sudo apt-get install -y libbtrfs-dev
@@ -350,7 +350,7 @@ jobs:
       matrix:
         runtime: [io.containerd.runtime.v1.linux, io.containerd.runc.v1, io.containerd.runc.v2]
         runc: [runc, crun]
-        os: [ubuntu-20.04, ubuntu-24.04-arm]
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
         exclude:
           - runtime: io.containerd.runc.v1
             runc: crun

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
   check:
     name: Check Signed Tag
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
       stringver: ${{ steps.contentrel.outputs.stringver }}
@@ -64,7 +64,7 @@ jobs:
 
   build:
     name: Build Release Binaries
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
       matrix:
@@ -138,7 +138,7 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: [build, check]
     steps:


### PR DESCRIPTION
- update CI runners to ubuntu 24.04
- remove integration testing for v1 shim because neither ubuntu 22 or 24 enables cgroupv1 and the shimv1 tests fail on those runners