### PR TITLE
removes direct use of k8s apimachinery from this repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,13 +73,13 @@ require (
 	go.opentelemetry.io/otel/sdk v1.35.0
 	go.opentelemetry.io/otel/trace v1.35.0
 	golang.org/x/mod v0.24.0
+	golang.org/x/net v0.38.0
 	golang.org/x/sync v0.14.0
 	golang.org/x/sys v0.33.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250218202821-56aae31c358a
 	google.golang.org/grpc v1.72.0
 	google.golang.org/protobuf v1.36.6
 	gopkg.in/inf.v0 v0.9.1
-	k8s.io/apimachinery v0.32.3
 	k8s.io/client-go v0.32.3
 	k8s.io/cri-api v0.32.3
 	k8s.io/klog/v2 v2.130.1
@@ -137,7 +137,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/exp v0.0.0-20241108190413-2d47ceb2692f // indirect
-	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/term v0.30.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
@@ -145,6 +144,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20250218202821-56aae31c358a // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.32.3 // indirect
+	k8s.io/apimachinery v0.32.3 // indirect
 	k8s.io/apiserver v0.32.3 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect

--- a/internal/cri/config/streaming.go
+++ b/internal/cri/config/streaming.go
@@ -24,9 +24,8 @@ import (
 	"os"
 	"time"
 
-	k8snet "k8s.io/apimachinery/pkg/util/net"
+	netutil "github.com/containerd/containerd/v2/internal/cri/netutil"
 	k8scert "k8s.io/client-go/util/cert"
-
 	"k8s.io/kubelet/pkg/cri/streaming"
 )
 
@@ -67,7 +66,7 @@ func (c *ServerConfig) StreamingConfig() (streaming.Config, error) {
 		streamIdleTimeout = c.StreamIdleTimeout
 	)
 	if addr == "" {
-		a, err := k8snet.ResolveBindAddress(nil)
+		a, err := netutil.ResolveBindAddress(nil)
 		if err != nil {
 			return streaming.Config{}, fmt.Errorf("failed to get stream server address: %w", err)
 		}

--- a/internal/cri/netutil/doc.go
+++ b/internal/cri/netutil/doc.go
@@ -1,0 +1,34 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package net has various tools useful for implementing networking in a CRI runtime.
+package net // cloned from "k8s.io/apimachinery/pkg/util/net" and "k8s.io/utils/net"

--- a/internal/cri/netutil/http.go
+++ b/internal/cri/netutil/http.go
@@ -1,0 +1,708 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/containerd/log"
+	"golang.org/x/net/http2"
+)
+
+// JoinPreservingTrailingSlash does a path.Join of the specified elements,
+// preserving any trailing slash on the last non-empty segment
+func JoinPreservingTrailingSlash(elem ...string) string {
+	// do the basic path join
+	result := path.Join(elem...)
+
+	// find the last non-empty segment
+	for i := len(elem) - 1; i >= 0; i-- {
+		if len(elem[i]) > 0 {
+			// if the last segment ended in a slash, ensure our result does as well
+			if strings.HasSuffix(elem[i], "/") && !strings.HasSuffix(result, "/") {
+				result += "/"
+			}
+			break
+		}
+	}
+
+	return result
+}
+
+// IsTimeout returns true if the given error is a network timeout error
+func IsTimeout(err error) bool {
+	var neterr net.Error
+	if errors.As(err, &neterr) {
+		return neterr != nil && neterr.Timeout()
+	}
+	return false
+}
+
+// IsProbableEOF returns true if the given error resembles a connection termination
+// scenario that would justify assuming that the watch is empty.
+// These errors are what the Go http stack returns back to us which are general
+// connection closure errors (strongly correlated) and callers that need to
+// differentiate probable errors in connection behavior between normal "this is
+// disconnected" should use the method.
+func IsProbableEOF(err error) bool {
+	if err == nil {
+		return false
+	}
+	var uerr *url.Error
+	if errors.As(err, &uerr) {
+		err = uerr.Err
+	}
+	msg := err.Error()
+	switch {
+	case err == io.EOF:
+		return true
+	case err == io.ErrUnexpectedEOF:
+		return true
+	case msg == "http: can't write HTTP request on broken connection":
+		return true
+	case strings.Contains(msg, "http2: server sent GOAWAY and closed the connection"):
+		return true
+	case strings.Contains(msg, "connection reset by peer"):
+		return true
+	case strings.Contains(strings.ToLower(msg), "use of closed network connection"):
+		return true
+	}
+	return false
+}
+
+var defaultTransport = http.DefaultTransport.(*http.Transport)
+
+// SetOldTransportDefaults applies the defaults from http.DefaultTransport
+// for the Proxy, Dial, and TLSHandshakeTimeout fields if unset
+func SetOldTransportDefaults(t *http.Transport) *http.Transport {
+	if t.Proxy == nil || isDefault(t.Proxy) {
+		// http.ProxyFromEnvironment doesn't respect CIDRs and that makes it impossible to exclude things like pod and service IPs from proxy settings
+		// ProxierWithNoProxyCIDR allows CIDR rules in NO_PROXY
+		t.Proxy = NewProxierWithNoProxyCIDR(http.ProxyFromEnvironment)
+	}
+	// If no custom dialer is set, use the default context dialer
+	//lint:file-ignore SA1019 Keep supporting deprecated Dial method of custom transports
+	if t.DialContext == nil {
+		t.DialContext = defaultTransport.DialContext
+	}
+	if t.TLSHandshakeTimeout == 0 {
+		t.TLSHandshakeTimeout = defaultTransport.TLSHandshakeTimeout
+	}
+	if t.IdleConnTimeout == 0 {
+		t.IdleConnTimeout = defaultTransport.IdleConnTimeout
+	}
+	return t
+}
+
+// SetTransportDefaults applies the defaults from http.DefaultTransport
+// for the Proxy, Dial, and TLSHandshakeTimeout fields if unset
+func SetTransportDefaults(t *http.Transport) *http.Transport {
+	t = SetOldTransportDefaults(t)
+	// Allow clients to disable http2 if needed.
+	if s := os.Getenv("DISABLE_HTTP2"); len(s) > 0 {
+		log.L.Info("HTTP2 has been explicitly disabled")
+	} else if allowsHTTP2(t) {
+		if err := configureHTTP2Transport(t); err != nil {
+			log.L.WithError(err).Warningf("Transport failed http2 configuration")
+		}
+	}
+	return t
+}
+
+func readIdleTimeoutSeconds() int {
+	ret := 30
+	// User can set the readIdleTimeout to 0 to disable the HTTP/2
+	// connection health check.
+	if s := os.Getenv("HTTP2_READ_IDLE_TIMEOUT_SECONDS"); len(s) > 0 {
+		i, err := strconv.Atoi(s)
+		if err != nil {
+			log.L.Warningf("Illegal HTTP2_READ_IDLE_TIMEOUT_SECONDS(%q): %v."+
+				" Default value %d is used", s, err, ret)
+			return ret
+		}
+		ret = i
+	}
+	return ret
+}
+
+func pingTimeoutSeconds() int {
+	ret := 15
+	if s := os.Getenv("HTTP2_PING_TIMEOUT_SECONDS"); len(s) > 0 {
+		i, err := strconv.Atoi(s)
+		if err != nil {
+			log.L.Warningf("Illegal HTTP2_PING_TIMEOUT_SECONDS(%q): %v."+
+				" Default value %d is used", s, err, ret)
+			return ret
+		}
+		ret = i
+	}
+	return ret
+}
+
+func configureHTTP2Transport(t *http.Transport) error {
+	t2, err := http2.ConfigureTransports(t)
+	if err != nil {
+		return err
+	}
+	// The following enables the HTTP/2 connection health check added in
+	// https://github.com/golang/net/pull/55. The health check detects and
+	// closes broken transport layer connections. Without the health check,
+	// a broken connection can linger too long, e.g., a broken TCP
+	// connection will be closed by the Linux kernel after 13 to 30 minutes
+	// by default, which caused
+	// https://github.com/kubernetes/client-go/issues/374 and
+	// https://github.com/kubernetes/kubernetes/issues/87615.
+	t2.ReadIdleTimeout = time.Duration(readIdleTimeoutSeconds()) * time.Second
+	t2.PingTimeout = time.Duration(pingTimeoutSeconds()) * time.Second
+	return nil
+}
+
+func allowsHTTP2(t *http.Transport) bool {
+	if t.TLSClientConfig == nil || len(t.TLSClientConfig.NextProtos) == 0 {
+		// the transport expressed no NextProto preference, allow
+		return true
+	}
+	for _, p := range t.TLSClientConfig.NextProtos {
+		if p == http2.NextProtoTLS {
+			// the transport explicitly allowed http/2
+			return true
+		}
+	}
+	// the transport explicitly set NextProtos and excluded http/2
+	return false
+}
+
+type RoundTripperWrapper interface {
+	http.RoundTripper
+	WrappedRoundTripper() http.RoundTripper
+}
+
+type DialFunc func(ctx context.Context, net, addr string) (net.Conn, error)
+
+func DialerFor(transport http.RoundTripper) (DialFunc, error) {
+	if transport == nil {
+		return nil, nil
+	}
+
+	switch transport := transport.(type) {
+	case *http.Transport:
+		// transport.DialContext replaced deprecated transport.Dial
+		if transport.DialContext != nil {
+			return transport.DialContext, nil
+		}
+		// otherwise return nil
+		return nil, nil
+	case RoundTripperWrapper:
+		return DialerFor(transport.WrappedRoundTripper())
+	default:
+		return nil, fmt.Errorf("unknown transport type: %T", transport)
+	}
+}
+
+// CloseIdleConnectionsFor close idles connections for the Transport.
+// If the Transport is wrapped it iterates over the wrapped round trippers
+// until it finds one that implements the CloseIdleConnections method.
+// If the Transport does not have a CloseIdleConnections method
+// then this function does nothing.
+func CloseIdleConnectionsFor(transport http.RoundTripper) {
+	if transport == nil {
+		return
+	}
+	type closeIdler interface {
+		CloseIdleConnections()
+	}
+
+	switch transport := transport.(type) {
+	case closeIdler:
+		transport.CloseIdleConnections()
+	case RoundTripperWrapper:
+		CloseIdleConnectionsFor(transport.WrappedRoundTripper())
+	default:
+		log.L.Warningf("unknown transport type: %T", transport)
+	}
+}
+
+type TLSClientConfigHolder interface {
+	TLSClientConfig() *tls.Config
+}
+
+func TLSClientConfig(transport http.RoundTripper) (*tls.Config, error) {
+	if transport == nil {
+		return nil, nil
+	}
+
+	switch transport := transport.(type) {
+	case *http.Transport:
+		return transport.TLSClientConfig, nil
+	case TLSClientConfigHolder:
+		return transport.TLSClientConfig(), nil
+	case RoundTripperWrapper:
+		return TLSClientConfig(transport.WrappedRoundTripper())
+	default:
+		return nil, fmt.Errorf("unknown transport type: %T", transport)
+	}
+}
+
+func FormatURL(scheme string, host string, port int, path string) *url.URL {
+	return &url.URL{
+		Scheme: scheme,
+		Host:   net.JoinHostPort(host, strconv.Itoa(port)),
+		Path:   path,
+	}
+}
+
+func GetHTTPClient(req *http.Request) string {
+	if ua := req.UserAgent(); len(ua) != 0 {
+		return ua
+	}
+	return "unknown"
+}
+
+// SourceIPs splits the comma separated X-Forwarded-For header and joins it with
+// the X-Real-Ip header and/or req.RemoteAddr, ignoring invalid IPs.
+// The X-Real-Ip is omitted if it's already present in the X-Forwarded-For chain.
+// The req.RemoteAddr is always the last IP in the returned list.
+// It returns nil if all of these are empty or invalid.
+func SourceIPs(req *http.Request) []net.IP {
+	var srcIPs []net.IP
+
+	hdr := req.Header
+	// First check the X-Forwarded-For header for requests via proxy.
+	hdrForwardedFor := hdr.Get("X-Forwarded-For")
+	if hdrForwardedFor != "" {
+		// X-Forwarded-For can be a csv of IPs in case of multiple proxies.
+		// Use the first valid one.
+		parts := strings.Split(hdrForwardedFor, ",")
+		for _, part := range parts {
+			ip := net.ParseIP(strings.TrimSpace(part))
+			if ip != nil {
+				srcIPs = append(srcIPs, ip)
+			}
+		}
+	}
+
+	// Try the X-Real-Ip header.
+	hdrRealIP := hdr.Get("X-Real-Ip")
+	if hdrRealIP != "" {
+		ip := net.ParseIP(hdrRealIP)
+		// Only append the X-Real-Ip if it's not already contained in the X-Forwarded-For chain.
+		if ip != nil && !containsIP(srcIPs, ip) {
+			srcIPs = append(srcIPs, ip)
+		}
+	}
+
+	// Always include the request Remote Address as it cannot be easily spoofed.
+	var remoteIP net.IP
+	// Remote Address in Go's HTTP server is in the form host:port so we need to split that first.
+	host, _, err := net.SplitHostPort(req.RemoteAddr)
+	if err == nil {
+		remoteIP = net.ParseIP(host)
+	}
+	// Fallback if Remote Address was just IP.
+	if remoteIP == nil {
+		remoteIP = net.ParseIP(req.RemoteAddr)
+	}
+
+	// Don't duplicate remote IP if it's already the last address in the chain.
+	if remoteIP != nil && (len(srcIPs) == 0 || !remoteIP.Equal(srcIPs[len(srcIPs)-1])) {
+		srcIPs = append(srcIPs, remoteIP)
+	}
+
+	return srcIPs
+}
+
+// Checks whether the given IP address is contained in the list of IPs.
+func containsIP(ips []net.IP, ip net.IP) bool {
+	for _, v := range ips {
+		if v.Equal(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// Extracts and returns the clients IP from the given request.
+// Looks at X-Forwarded-For header, X-Real-Ip header and request.RemoteAddr in that order.
+// Returns nil if none of them are set or is set to an invalid value.
+func GetClientIP(req *http.Request) net.IP {
+	ips := SourceIPs(req)
+	if len(ips) == 0 {
+		return nil
+	}
+	return ips[0]
+}
+
+// Prepares the X-Forwarded-For header for another forwarding hop by appending the previous sender's
+// IP address to the X-Forwarded-For chain.
+func AppendForwardedForHeader(req *http.Request) {
+	// Copied from net/http/httputil/reverseproxy.go:
+	if clientIP, _, err := net.SplitHostPort(req.RemoteAddr); err == nil {
+		// If we aren't the first proxy retain prior
+		// X-Forwarded-For information as a comma+space
+		// separated list and fold multiple headers into one.
+		if prior, ok := req.Header["X-Forwarded-For"]; ok {
+			clientIP = strings.Join(prior, ", ") + ", " + clientIP
+		}
+		req.Header.Set("X-Forwarded-For", clientIP)
+	}
+}
+
+var defaultProxyFuncPointer = fmt.Sprintf("%p", http.ProxyFromEnvironment)
+
+// isDefault checks to see if the transportProxierFunc is pointing to the default one
+func isDefault(transportProxier func(*http.Request) (*url.URL, error)) bool {
+	transportProxierPointer := fmt.Sprintf("%p", transportProxier)
+	return transportProxierPointer == defaultProxyFuncPointer
+}
+
+// NewProxierWithNoProxyCIDR constructs a Proxier function that respects CIDRs in NO_PROXY and delegates if
+// no matching CIDRs are found
+func NewProxierWithNoProxyCIDR(delegate func(req *http.Request) (*url.URL, error)) func(req *http.Request) (*url.URL, error) {
+	// we wrap the default method, so we only need to perform our check if the NO_PROXY (or no_proxy) envvar has a CIDR in it
+	noProxyEnv := os.Getenv("NO_PROXY")
+	if noProxyEnv == "" {
+		noProxyEnv = os.Getenv("no_proxy")
+	}
+	noProxyRules := strings.Split(noProxyEnv, ",")
+
+	cidrs := []*net.IPNet{}
+	for _, noProxyRule := range noProxyRules {
+		_, cidr, _ := net.ParseCIDR(noProxyRule)
+		if cidr != nil {
+			cidrs = append(cidrs, cidr)
+		}
+	}
+
+	if len(cidrs) == 0 {
+		return delegate
+	}
+
+	return func(req *http.Request) (*url.URL, error) {
+		ip := net.ParseIP(req.URL.Hostname())
+		if ip == nil {
+			return delegate(req)
+		}
+
+		for _, cidr := range cidrs {
+			if cidr.Contains(ip) {
+				return nil, nil
+			}
+		}
+
+		return delegate(req)
+	}
+}
+
+// DialerFunc implements Dialer for the provided function.
+type DialerFunc func(req *http.Request) (net.Conn, error)
+
+func (fn DialerFunc) Dial(req *http.Request) (net.Conn, error) {
+	return fn(req)
+}
+
+// Dialer dials a host and writes a request to it.
+type Dialer interface {
+	// Dial connects to the host specified by req's URL, writes the request to the connection, and
+	// returns the opened net.Conn.
+	Dial(req *http.Request) (net.Conn, error)
+}
+
+// CloneRequest creates a shallow copy of the request along with a deep copy of the Headers.
+func CloneRequest(req *http.Request) *http.Request {
+	r := new(http.Request)
+
+	// shallow clone
+	*r = *req
+
+	// deep copy headers
+	r.Header = CloneHeader(req.Header)
+
+	return r
+}
+
+// CloneHeader creates a deep copy of an http.Header.
+func CloneHeader(in http.Header) http.Header {
+	out := make(http.Header, len(in))
+	for key, values := range in {
+		newValues := make([]string, len(values))
+		copy(newValues, values)
+		out[key] = newValues
+	}
+	return out
+}
+
+// WarningHeader contains a single RFC2616 14.46 warnings header
+type WarningHeader struct {
+	// Codeindicates the type of warning. 299 is a miscellaneous persistent warning
+	Code int
+	// Agent contains the name or pseudonym of the server adding the Warning header.
+	// A single "-" is recommended when agent is unknown.
+	Agent string
+	// Warning text
+	Text string
+}
+
+// ParseWarningHeaders extract RFC2616 14.46 warnings headers from the specified set of header values.
+// Multiple comma-separated warnings per header are supported.
+// If errors are encountered on a header, the remainder of that header are skipped and subsequent headers are parsed.
+// Returns successfully parsed warnings and any errors encountered.
+func ParseWarningHeaders(headers []string) ([]WarningHeader, []error) {
+	var (
+		results []WarningHeader
+		errs    []error
+	)
+	for _, header := range headers {
+		for len(header) > 0 {
+			result, remainder, err := ParseWarningHeader(header)
+			if err != nil {
+				errs = append(errs, err)
+				break
+			}
+			results = append(results, result)
+			header = remainder
+		}
+	}
+	return results, errs
+}
+
+var (
+	codeMatcher = regexp.MustCompile(`^[0-9]{3}$`)
+	wordDecoder = &mime.WordDecoder{}
+)
+
+// ParseWarningHeader extracts one RFC2616 14.46 warning from the specified header,
+// returning an error if the header does not contain a correctly formatted warning.
+// Any remaining content in the header is returned.
+func ParseWarningHeader(header string) (result WarningHeader, remainder string, err error) {
+	// https://tools.ietf.org/html/rfc2616#section-14.46
+	//   updated by
+	// https://tools.ietf.org/html/rfc7234#section-5.5
+	//   https://tools.ietf.org/html/rfc7234#appendix-A
+	//     Some requirements regarding production and processing of the Warning
+	//     header fields have been relaxed, as it is not widely implemented.
+	//     Furthermore, the Warning header field no longer uses RFC 2047
+	//     encoding, nor does it allow multiple languages, as these aspects were
+	//     not implemented.
+	//
+	// Format is one of:
+	// warn-code warn-agent "warn-text"
+	// warn-code warn-agent "warn-text" "warn-date"
+	//
+	// warn-code is a three digit number
+	// warn-agent is unquoted and contains no spaces
+	// warn-text is quoted with backslash escaping (RFC2047-encoded according to RFC2616, not encoded according to RFC7234)
+	// warn-date is optional, quoted, and in HTTP-date format (no embedded or escaped quotes)
+	//
+	// additional warnings can optionally be included in the same header by comma-separating them:
+	// warn-code warn-agent "warn-text" "warn-date"[, warn-code warn-agent "warn-text" "warn-date", ...]
+
+	// tolerate leading whitespace
+	header = strings.TrimSpace(header)
+
+	parts := strings.SplitN(header, " ", 3)
+	if len(parts) != 3 {
+		return WarningHeader{}, "", errors.New("invalid warning header: fewer than 3 segments")
+	}
+	code, agent, textDateRemainder := parts[0], parts[1], parts[2]
+
+	// verify code format
+	if !codeMatcher.Match([]byte(code)) {
+		return WarningHeader{}, "", errors.New("invalid warning header: code segment is not 3 digits between 100-299")
+	}
+	codeInt, _ := strconv.ParseInt(code, 10, 32)
+
+	// verify agent presence
+	if len(agent) == 0 {
+		return WarningHeader{}, "", errors.New("invalid warning header: empty agent segment")
+	}
+	if !utf8.ValidString(agent) || hasAnyRunes(agent, unicode.IsControl) {
+		return WarningHeader{}, "", errors.New("invalid warning header: invalid agent")
+	}
+
+	// verify textDateRemainder presence
+	if len(textDateRemainder) == 0 {
+		return WarningHeader{}, "", errors.New("invalid warning header: empty text segment")
+	}
+
+	// extract text
+	text, dateAndRemainder, err := parseQuotedString(textDateRemainder)
+	if err != nil {
+		return WarningHeader{}, "", fmt.Errorf("invalid warning header: %v", err)
+	}
+	// tolerate RFC2047-encoded text from warnings produced according to RFC2616
+	if decodedText, err := wordDecoder.DecodeHeader(text); err == nil {
+		text = decodedText
+	}
+	if !utf8.ValidString(text) || hasAnyRunes(text, unicode.IsControl) {
+		return WarningHeader{}, "", errors.New("invalid warning header: invalid text")
+	}
+	result = WarningHeader{Code: int(codeInt), Agent: agent, Text: text}
+
+	if len(dateAndRemainder) > 0 {
+		if dateAndRemainder[0] == '"' {
+			// consume date
+			foundEndQuote := false
+			for i := 1; i < len(dateAndRemainder); i++ {
+				if dateAndRemainder[i] == '"' {
+					foundEndQuote = true
+					remainder = strings.TrimSpace(dateAndRemainder[i+1:])
+					break
+				}
+			}
+			if !foundEndQuote {
+				return WarningHeader{}, "", errors.New("invalid warning header: unterminated date segment")
+			}
+		} else {
+			remainder = dateAndRemainder
+		}
+	}
+	if len(remainder) > 0 {
+		if remainder[0] == ',' {
+			// consume comma if present
+			remainder = strings.TrimSpace(remainder[1:])
+		} else {
+			return WarningHeader{}, "", errors.New("invalid warning header: unexpected token after warn-date")
+		}
+	}
+
+	return result, remainder, nil
+}
+
+func parseQuotedString(quotedString string) (string, string, error) {
+	if len(quotedString) == 0 {
+		return "", "", errors.New("invalid quoted string: 0-length")
+	}
+
+	if quotedString[0] != '"' {
+		return "", "", errors.New("invalid quoted string: missing initial quote")
+	}
+
+	quotedString = quotedString[1:]
+	var remainder string
+	escaping := false
+	closedQuote := false
+	result := &strings.Builder{}
+loop:
+	for i := 0; i < len(quotedString); i++ {
+		b := quotedString[i]
+		switch b {
+		case '"':
+			if escaping {
+				result.WriteByte(b)
+				escaping = false
+			} else {
+				closedQuote = true
+				remainder = strings.TrimSpace(quotedString[i+1:])
+				break loop
+			}
+		case '\\':
+			if escaping {
+				result.WriteByte(b)
+				escaping = false
+			} else {
+				escaping = true
+			}
+		default:
+			result.WriteByte(b)
+			escaping = false
+		}
+	}
+
+	if !closedQuote {
+		return "", "", errors.New("invalid quoted string: missing closing quote")
+	}
+	return result.String(), remainder, nil
+}
+
+func NewWarningHeader(code int, agent, text string) (string, error) {
+	if code < 0 || code > 999 {
+		return "", errors.New("code must be between 0 and 999")
+	}
+	if len(agent) == 0 {
+		agent = "-"
+	} else if !utf8.ValidString(agent) || strings.ContainsAny(agent, `\"`) || hasAnyRunes(agent, unicode.IsSpace, unicode.IsControl) {
+		return "", errors.New("agent must be valid UTF-8 and must not contain spaces, quotes, backslashes, or control characters")
+	}
+	if !utf8.ValidString(text) || hasAnyRunes(text, unicode.IsControl) {
+		return "", errors.New("text must be valid UTF-8 and must not contain control characters")
+	}
+	return fmt.Sprintf("%03d %s %s", code, agent, makeQuotedString(text)), nil
+}
+
+func hasAnyRunes(s string, runeCheckers ...func(rune) bool) bool {
+	for _, r := range s {
+		for _, checker := range runeCheckers {
+			if checker(r) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func makeQuotedString(s string) string {
+	result := &bytes.Buffer{}
+	// opening quote
+	result.WriteRune('"')
+	for _, c := range s {
+		switch c {
+		case '"', '\\':
+			// escape " and \
+			result.WriteRune('\\')
+			result.WriteRune(c)
+		default:
+			// write everything else as-is
+			result.WriteRune(c)
+		}
+	}
+	// closing quote
+	result.WriteRune('"')
+	return result.String()
+}

--- a/internal/cri/netutil/http_test.go
+++ b/internal/cri/netutil/http_test.go
@@ -1,0 +1,971 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetClientIP(t *testing.T) {
+	ipString := "10.0.0.1"
+	ip := net.ParseIP(ipString)
+	invalidIPString := "invalidIPString"
+	testCases := []struct {
+		Request    http.Request
+		ExpectedIP net.IP
+	}{
+		{
+			Request: http.Request{},
+		},
+		{
+			Request: http.Request{
+				Header: map[string][]string{
+					"X-Real-Ip": {ipString},
+				},
+			},
+			ExpectedIP: ip,
+		},
+		{
+			Request: http.Request{
+				Header: map[string][]string{
+					"X-Real-Ip": {invalidIPString},
+				},
+			},
+		},
+		{
+			Request: http.Request{
+				Header: map[string][]string{
+					"X-Forwarded-For": {ipString},
+				},
+			},
+			ExpectedIP: ip,
+		},
+		{
+			Request: http.Request{
+				Header: map[string][]string{
+					"X-Forwarded-For": {invalidIPString},
+				},
+			},
+		},
+		{
+			Request: http.Request{
+				Header: map[string][]string{
+					"X-Forwarded-For": {invalidIPString + "," + ipString},
+				},
+			},
+			ExpectedIP: ip,
+		},
+		{
+			Request: http.Request{
+				// RemoteAddr is in the form host:port
+				RemoteAddr: ipString + ":1234",
+			},
+			ExpectedIP: ip,
+		},
+		{
+			Request: http.Request{
+				RemoteAddr: invalidIPString,
+			},
+		},
+		{
+			Request: http.Request{
+				Header: map[string][]string{
+					"X-Forwarded-For": {invalidIPString},
+				},
+				// RemoteAddr is in the form host:port
+				RemoteAddr: ipString,
+			},
+			ExpectedIP: ip,
+		},
+	}
+
+	for i, test := range testCases {
+		if a, e := GetClientIP(&test.Request), test.ExpectedIP; reflect.DeepEqual(e, a) != true {
+			t.Fatalf("test case %d failed. expected: %v, actual: %v", i, e, a)
+		}
+	}
+}
+
+func TestAppendForwardedForHeader(t *testing.T) {
+	testCases := []struct {
+		addr, forwarded, expected string
+	}{
+		{"1.2.3.4:8000", "", "1.2.3.4"},
+		{"1.2.3.4:8000", "8.8.8.8", "8.8.8.8, 1.2.3.4"},
+		{"1.2.3.4:8000", "8.8.8.8, 1.2.3.4", "8.8.8.8, 1.2.3.4, 1.2.3.4"},
+		{"1.2.3.4:8000", "foo,bar", "foo,bar, 1.2.3.4"},
+	}
+	for i, test := range testCases {
+		req := &http.Request{
+			RemoteAddr: test.addr,
+			Header:     make(http.Header),
+		}
+		if test.forwarded != "" {
+			req.Header.Set("X-Forwarded-For", test.forwarded)
+		}
+
+		AppendForwardedForHeader(req)
+		actual := req.Header.Get("X-Forwarded-For")
+		if actual != test.expected {
+			t.Errorf("[%d] Expected %q, Got %q", i, test.expected, actual)
+		}
+	}
+}
+
+func TestProxierWithNoProxyCIDR(t *testing.T) {
+	testCases := []struct {
+		name    string
+		noProxy string
+		url     string
+
+		expectedDelegated bool
+	}{
+		{
+			name:              "no env",
+			url:               "https://192.168.143.1/api",
+			expectedDelegated: true,
+		},
+		{
+			name:              "no cidr",
+			noProxy:           "192.168.63.1",
+			url:               "https://192.168.143.1/api",
+			expectedDelegated: true,
+		},
+		{
+			name:              "hostname",
+			noProxy:           "192.168.63.0/24,192.168.143.0/24",
+			url:               "https://my-hostname/api",
+			expectedDelegated: true,
+		},
+		{
+			name:              "match second cidr",
+			noProxy:           "192.168.63.0/24,192.168.143.0/24",
+			url:               "https://192.168.143.1/api",
+			expectedDelegated: false,
+		},
+		{
+			name:              "match second cidr with host:port",
+			noProxy:           "192.168.63.0/24,192.168.143.0/24",
+			url:               "https://192.168.143.1:8443/api",
+			expectedDelegated: false,
+		},
+		{
+			name:              "IPv6 cidr",
+			noProxy:           "2001:db8::/48",
+			url:               "https://[2001:db8::1]/api",
+			expectedDelegated: false,
+		},
+		{
+			name:              "IPv6+port cidr",
+			noProxy:           "2001:db8::/48",
+			url:               "https://[2001:db8::1]:8443/api",
+			expectedDelegated: false,
+		},
+		{
+			name:              "IPv6, not matching cidr",
+			noProxy:           "2001:db8::/48",
+			url:               "https://[2001:db8:1::1]/api",
+			expectedDelegated: true,
+		},
+		{
+			name:              "IPv6+port, not matching cidr",
+			noProxy:           "2001:db8::/48",
+			url:               "https://[2001:db8:1::1]:8443/api",
+			expectedDelegated: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Setenv("NO_PROXY", test.noProxy)
+		actualDelegated := false
+		proxyFunc := NewProxierWithNoProxyCIDR(func(req *http.Request) (*url.URL, error) {
+			actualDelegated = true
+			return nil, nil
+		})
+
+		req, err := http.NewRequest("GET", test.url, nil)
+		if err != nil {
+			t.Errorf("%s: unexpected err: %v", test.name, err)
+			continue
+		}
+		if _, err := proxyFunc(req); err != nil {
+			t.Errorf("%s: unexpected err: %v", test.name, err)
+			continue
+		}
+
+		if test.expectedDelegated != actualDelegated {
+			t.Errorf("%s: expected %v, got %v", test.name, test.expectedDelegated, actualDelegated)
+			continue
+		}
+	}
+}
+
+type fakeTLSClientConfigHolder struct {
+	called bool
+}
+
+func (f *fakeTLSClientConfigHolder) TLSClientConfig() *tls.Config {
+	f.called = true
+	return nil
+}
+func (f *fakeTLSClientConfigHolder) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestTLSClientConfigHolder(t *testing.T) {
+	rt := &fakeTLSClientConfigHolder{}
+	TLSClientConfig(rt)
+
+	if !rt.called {
+		t.Errorf("didn't find tls config")
+	}
+}
+
+func TestJoinPreservingTrailingSlash(t *testing.T) {
+	tests := []struct {
+		a    string
+		b    string
+		want string
+	}{
+		// All empty
+		{"", "", ""},
+
+		// Empty a
+		{"", "/", "/"},
+		{"", "foo", "foo"},
+		{"", "/foo", "/foo"},
+		{"", "/foo/", "/foo/"},
+
+		// Empty b
+		{"/", "", "/"},
+		{"foo", "", "foo"},
+		{"/foo", "", "/foo"},
+		{"/foo/", "", "/foo/"},
+
+		// Both populated
+		{"/", "/", "/"},
+		{"foo", "foo", "foo/foo"},
+		{"/foo", "/foo", "/foo/foo"},
+		{"/foo/", "/foo/", "/foo/foo/"},
+	}
+	for _, tt := range tests {
+		name := fmt.Sprintf("%q+%q=%q", tt.a, tt.b, tt.want)
+		t.Run(name, func(t *testing.T) {
+			if got := JoinPreservingTrailingSlash(tt.a, tt.b); got != tt.want {
+				t.Errorf("JoinPreservingTrailingSlash() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAllowsHTTP2(t *testing.T) {
+	testcases := []struct {
+		Name         string
+		Transport    *http.Transport
+		ExpectAllows bool
+	}{
+		{
+			Name:         "empty",
+			Transport:    &http.Transport{},
+			ExpectAllows: true,
+		},
+		{
+			Name:         "empty tlsconfig",
+			Transport:    &http.Transport{TLSClientConfig: &tls.Config{}},
+			ExpectAllows: true,
+		},
+		{
+			Name:         "zero-length NextProtos",
+			Transport:    &http.Transport{TLSClientConfig: &tls.Config{NextProtos: []string{}}},
+			ExpectAllows: true,
+		},
+		{
+			Name:         "includes h2 in NextProtos after",
+			Transport:    &http.Transport{TLSClientConfig: &tls.Config{NextProtos: []string{"http/1.1", "h2"}}},
+			ExpectAllows: true,
+		},
+		{
+			Name:         "includes h2 in NextProtos before",
+			Transport:    &http.Transport{TLSClientConfig: &tls.Config{NextProtos: []string{"h2", "http/1.1"}}},
+			ExpectAllows: true,
+		},
+		{
+			Name:         "includes h2 in NextProtos between",
+			Transport:    &http.Transport{TLSClientConfig: &tls.Config{NextProtos: []string{"http/1.1", "h2", "h3"}}},
+			ExpectAllows: true,
+		},
+		{
+			Name:         "excludes h2 in NextProtos",
+			Transport:    &http.Transport{TLSClientConfig: &tls.Config{NextProtos: []string{"http/1.1"}}},
+			ExpectAllows: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			allows := allowsHTTP2(tc.Transport)
+			if allows != tc.ExpectAllows {
+				t.Errorf("expected %v, got %v", tc.ExpectAllows, allows)
+			}
+		})
+	}
+}
+
+func TestSourceIPs(t *testing.T) {
+	tests := []struct {
+		name         string
+		realIP       string
+		forwardedFor string
+		remoteAddr   string
+		expected     []string
+	}{{
+		name:     "no headers, missing remoteAddr",
+		expected: []string{},
+	}, {
+		name:       "no headers, just remoteAddr host:port",
+		remoteAddr: "1.2.3.4:555",
+		expected:   []string{"1.2.3.4"},
+	}, {
+		name:       "no headers, just remoteAddr host",
+		remoteAddr: "1.2.3.4",
+		expected:   []string{"1.2.3.4"},
+	}, {
+		name:         "empty forwarded-for chain",
+		forwardedFor: " ",
+		remoteAddr:   "1.2.3.4",
+		expected:     []string{"1.2.3.4"},
+	}, {
+		name:         "invalid forwarded-for chain",
+		forwardedFor: "garbage yeah garbage values!",
+		remoteAddr:   "1.2.3.4",
+		expected:     []string{"1.2.3.4"},
+	}, {
+		name:         "partially invalid forwarded-for chain",
+		forwardedFor: "garbage yeah garbage values!,4.5.6.7",
+		remoteAddr:   "1.2.3.4",
+		expected:     []string{"4.5.6.7", "1.2.3.4"},
+	}, {
+		name:         "valid forwarded-for chain",
+		forwardedFor: "120.120.120.126,2.2.2.2,4.5.6.7",
+		remoteAddr:   "1.2.3.4",
+		expected:     []string{"120.120.120.126", "2.2.2.2", "4.5.6.7", "1.2.3.4"},
+	}, {
+		name:         "valid forwarded-for chain with redundant remoteAddr",
+		forwardedFor: "2.2.2.2,1.2.3.4",
+		remoteAddr:   "1.2.3.4",
+		expected:     []string{"2.2.2.2", "1.2.3.4"},
+	}, {
+		name:       "invalid Real-Ip",
+		realIP:     "garbage, just garbage!",
+		remoteAddr: "1.2.3.4",
+		expected:   []string{"1.2.3.4"},
+	}, {
+		name:         "invalid Real-Ip with forwarded-for",
+		realIP:       "garbage, just garbage!",
+		forwardedFor: "2.2.2.2",
+		remoteAddr:   "1.2.3.4",
+		expected:     []string{"2.2.2.2", "1.2.3.4"},
+	}, {
+		name:       "valid Real-Ip",
+		realIP:     "2.2.2.2",
+		remoteAddr: "1.2.3.4",
+		expected:   []string{"2.2.2.2", "1.2.3.4"},
+	}, {
+		name:       "redundant Real-Ip",
+		realIP:     "1.2.3.4",
+		remoteAddr: "1.2.3.4",
+		expected:   []string{"1.2.3.4"},
+	}, {
+		name:         "valid Real-Ip with forwarded-for",
+		realIP:       "2.2.2.2",
+		forwardedFor: "120.120.120.126,4.5.6.7",
+		remoteAddr:   "1.2.3.4",
+		expected:     []string{"120.120.120.126", "4.5.6.7", "2.2.2.2", "1.2.3.4"},
+	}, {
+		name:         "redundant Real-Ip with forwarded-for",
+		realIP:       "2.2.2.2",
+		forwardedFor: "120.120.120.126,2.2.2.2,4.5.6.7",
+		remoteAddr:   "1.2.3.4",
+		expected:     []string{"120.120.120.126", "2.2.2.2", "4.5.6.7", "1.2.3.4"},
+	}, {
+		name:         "full redundancy",
+		realIP:       "1.2.3.4",
+		forwardedFor: "1.2.3.4",
+		remoteAddr:   "1.2.3.4",
+		expected:     []string{"1.2.3.4"},
+	}, {
+		name:         "full ipv6",
+		realIP:       "abcd:ef01:2345:6789:abcd:ef01:2345:6789",
+		forwardedFor: "aaaa:bbbb:cccc:dddd:eeee:ffff:0:1111,0:1111:2222:3333:4444:5555:6666:7777",
+		remoteAddr:   "aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:aaaa",
+		expected: []string{
+			"aaaa:bbbb:cccc:dddd:eeee:ffff:0:1111",
+			"0:1111:2222:3333:4444:5555:6666:7777",
+			"abcd:ef01:2345:6789:abcd:ef01:2345:6789",
+			"aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:aaaa",
+		},
+	}, {
+		name:         "mixed ipv4 ipv6",
+		forwardedFor: "aaaa:bbbb:cccc:dddd:eeee:ffff:0:1111,1.2.3.4",
+		remoteAddr:   "0:0:0:0:0:ffff:102:304", // ipv6 equivalent to 1.2.3.4
+		expected: []string{
+			"aaaa:bbbb:cccc:dddd:eeee:ffff:0:1111",
+			"1.2.3.4",
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "https://cluster.k8s.io/apis/foobars/v1/foo/bar", nil)
+			req.RemoteAddr = test.remoteAddr
+			if test.forwardedFor != "" {
+				req.Header.Set("X-Forwarded-For", test.forwardedFor)
+			}
+			if test.realIP != "" {
+				req.Header.Set("X-Real-Ip", test.realIP)
+			}
+
+			actualIPs := SourceIPs(req)
+			actual := make([]string, len(actualIPs))
+			for i, ip := range actualIPs {
+				actual[i] = ip.String()
+			}
+
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestParseWarningHeader(t *testing.T) {
+	tests := []struct {
+		name string
+
+		header string
+
+		wantResult    WarningHeader
+		wantRemainder string
+		wantErr       string
+	}{
+		// invalid cases
+		{
+			name:    "empty",
+			header:  ``,
+			wantErr: "fewer than 3 segments",
+		},
+		{
+			name:    "bad code",
+			header:  `A B`,
+			wantErr: "fewer than 3 segments",
+		},
+		{
+			name:    "short code",
+			header:  `1 - "text"`,
+			wantErr: "not 3 digits",
+		},
+		{
+			name:    "bad code",
+			header:  `A - "text"`,
+			wantErr: "not 3 digits",
+		},
+		{
+			name:    "invalid date quoting",
+			header:  `  299 - "text\"\\\a\b\c"  "Tue, 15 Nov 1994 08:12:31 GMT `,
+			wantErr: "unterminated date segment",
+		},
+		{
+			name:    "invalid post-date",
+			header:  `  299 - "text\"\\\a\b\c"  "Tue, 15 Nov 1994 08:12:31 GMT" other`,
+			wantErr: "unexpected token after warn-date",
+		},
+		{
+			name:    "agent control character",
+			header:  "  299 agent\u0000name \"text\"",
+			wantErr: "invalid agent",
+		},
+		{
+			name:    "agent non-utf8 character",
+			header:  "  299 agent\xc5name \"text\"",
+			wantErr: "invalid agent",
+		},
+		{
+			name:    "text control character",
+			header:  "  299 - \"text\u0000\"content",
+			wantErr: "invalid text",
+		},
+		{
+			name:    "text non-utf8 character",
+			header:  "  299 - \"text\xc5\"content",
+			wantErr: "invalid text",
+		},
+
+		// valid cases
+		{
+			name:       "ok",
+			header:     `299 - "text"`,
+			wantResult: WarningHeader{Code: 299, Agent: `-`, Text: `text`},
+		},
+		{
+			name:       "ok",
+			header:     `299 - "text\"\\\a\b\c"`,
+			wantResult: WarningHeader{Code: 299, Agent: `-`, Text: `text"\abc`},
+		},
+		// big code
+		{
+			name:       "big code",
+			header:     `321 - "text"`,
+			wantResult: WarningHeader{Code: 321, Agent: "-", Text: "text"},
+		},
+		// RFC 2047 decoding
+		{
+			name:       "ok, rfc 2047, iso-8859-1, q",
+			header:     `299 - "=?iso-8859-1?q?this=20is=20some=20text?="`,
+			wantResult: WarningHeader{Code: 299, Agent: `-`, Text: `this is some text`},
+		},
+		{
+			name:       "ok, rfc 2047, utf-8, b",
+			header:     `299 - "=?UTF-8?B?VGhpcyBpcyBhIGhvcnNleTog8J+Qjg==?= And =?UTF-8?B?VGhpcyBpcyBhIGhvcnNleTog8J+Qjg==?="`,
+			wantResult: WarningHeader{Code: 299, Agent: `-`, Text: `This is a horsey: 🐎 And This is a horsey: 🐎`},
+		},
+		{
+			name:       "ok, rfc 2047, utf-8, q",
+			header:     `299 - "=?UTF-8?Q?This is a \"horsey\": =F0=9F=90=8E?="`,
+			wantResult: WarningHeader{Code: 299, Agent: `-`, Text: `This is a "horsey": 🐎`},
+		},
+		{
+			name:       "ok, rfc 2047, unknown charset",
+			header:     `299 - "=?UTF-9?Q?This is a horsey: =F0=9F=90=8E?="`,
+			wantResult: WarningHeader{Code: 299, Agent: "-", Text: `=?UTF-9?Q?This is a horsey: =F0=9F=90=8E?=`},
+		},
+		{
+			name:       "ok with spaces",
+			header:     `  299 - "text\"\\\a\b\c"  `,
+			wantResult: WarningHeader{Code: 299, Agent: `-`, Text: `text"\abc`},
+		},
+		{
+			name:       "ok with date",
+			header:     `  299 - "text\"\\\a\b\c"  "Tue, 15 Nov 1994 08:12:31 GMT" `,
+			wantResult: WarningHeader{Code: 299, Agent: `-`, Text: `text"\abc`},
+		},
+		{
+			name:       "ok with date and comma",
+			header:     `  299 - "text\"\\\a\b\c"  "Tue, 15 Nov 1994 08:12:31 GMT" , `,
+			wantResult: WarningHeader{Code: 299, Agent: `-`, Text: `text"\abc`},
+		},
+		{
+			name:       "ok with comma",
+			header:     `  299 - "text\"\\\a\b\c"  , `,
+			wantResult: WarningHeader{Code: 299, Agent: `-`, Text: `text"\abc`},
+		},
+		{
+			name:          "ok with date and comma and remainder",
+			header:        `  299 - "text\"\\\a\b\c"  "Tue, 15 Nov 1994 08:12:31 GMT" , remainder `,
+			wantResult:    WarningHeader{Code: 299, Agent: `-`, Text: `text"\abc`},
+			wantRemainder: "remainder",
+		},
+		{
+			name:          "ok with comma and remainder",
+			header:        `  299 - "text\"\\\a\b\c"  ,remainder text,second remainder`,
+			wantResult:    WarningHeader{Code: 299, Agent: `-`, Text: `text"\abc`},
+			wantRemainder: "remainder text,second remainder",
+		},
+		{
+			name:       "ok with utf-8 content directly in warn-text",
+			header:     ` 299 - "Test of Iñtërnâtiônàlizætiøn,💝🐹🌇⛔" `,
+			wantResult: WarningHeader{Code: 299, Agent: `-`, Text: `Test of Iñtërnâtiônàlizætiøn,💝🐹🌇⛔`},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotResult, gotRemainder, err := ParseWarningHeader(tt.header)
+			switch {
+			case err == nil && len(tt.wantErr) > 0:
+				t.Errorf("ParseWarningHeader() no error, expected error %q", tt.wantErr)
+				return
+			case err != nil && len(tt.wantErr) == 0:
+				t.Errorf("ParseWarningHeader() error %q, expected no error", err)
+				return
+			case err != nil && len(tt.wantErr) > 0 && !strings.Contains(err.Error(), tt.wantErr):
+				t.Errorf("ParseWarningHeader() error %q, expected error %q", err, tt.wantErr)
+				return
+			}
+			if err != nil {
+				return
+			}
+			if !reflect.DeepEqual(gotResult, tt.wantResult) {
+				t.Errorf("ParseWarningHeader() gotResult = %#v, want %#v", gotResult, tt.wantResult)
+			}
+			if gotRemainder != tt.wantRemainder {
+				t.Errorf("ParseWarningHeader() gotRemainder = %v, want %v", gotRemainder, tt.wantRemainder)
+			}
+		})
+	}
+}
+
+func TestNewWarningHeader(t *testing.T) {
+	tests := []struct {
+		name string
+
+		code  int
+		agent string
+		text  string
+
+		want    string
+		wantErr string
+	}{
+		// invalid cases
+		{
+			name:    "code too low",
+			code:    -1,
+			agent:   `-`,
+			text:    `example warning`,
+			wantErr: "between 0 and 999",
+		},
+		{
+			name:    "code too high",
+			code:    1000,
+			agent:   `-`,
+			text:    `example warning`,
+			wantErr: "between 0 and 999",
+		},
+		{
+			name:    "agent with space",
+			code:    299,
+			agent:   `test agent`,
+			text:    `example warning`,
+			wantErr: `agent must be valid`,
+		},
+		{
+			name:    "agent with newline",
+			code:    299,
+			agent:   "test\nagent",
+			text:    `example warning`,
+			wantErr: `agent must be valid`,
+		},
+		{
+			name:    "agent with backslash",
+			code:    299,
+			agent:   `test\agent`,
+			text:    `example warning`,
+			wantErr: `agent must be valid`,
+		},
+		{
+			name:    "agent with quote",
+			code:    299,
+			agent:   `test"agent"`,
+			text:    `example warning`,
+			wantErr: `agent must be valid`,
+		},
+		{
+			name:    "agent with control character",
+			code:    299,
+			agent:   "test\u0000agent",
+			text:    `example warning`,
+			wantErr: `agent must be valid`,
+		},
+		{
+			name:    "agent with non-UTF8",
+			code:    299,
+			agent:   "test\xc5agent",
+			text:    `example warning`,
+			wantErr: `agent must be valid`,
+		},
+		{
+			name:    "text with newline",
+			code:    299,
+			agent:   `-`,
+			text:    "Test of new\nline",
+			wantErr: "text must be valid",
+		},
+		{
+			name:    "text with control character",
+			code:    299,
+			agent:   `-`,
+			text:    "Test of control\u0000character",
+			wantErr: "text must be valid",
+		},
+		{
+			name:    "text with non-UTF8",
+			code:    299,
+			agent:   `-`,
+			text:    "Test of control\xc5character",
+			wantErr: "text must be valid",
+		},
+
+		{
+			name:  "valid empty text",
+			code:  299,
+			agent: `-`,
+			text:  ``,
+			want:  `299 - ""`,
+		},
+		{
+			name:  "valid empty agent",
+			code:  299,
+			agent: ``,
+			text:  `example warning`,
+			want:  `299 - "example warning"`,
+		},
+		{
+			name:  "valid low code",
+			code:  1,
+			agent: `-`,
+			text:  `example warning`,
+			want:  `001 - "example warning"`,
+		},
+		{
+			name:  "valid high code",
+			code:  999,
+			agent: `-`,
+			text:  `example warning`,
+			want:  `999 - "example warning"`,
+		},
+		{
+			name:  "valid utf-8",
+			code:  299,
+			agent: `-`,
+			text:  `Test of "Iñtërnâtiônàlizætiøn,💝🐹🌇⛔"`,
+			want:  `299 - "Test of \"Iñtërnâtiônàlizætiøn,💝🐹🌇⛔\""`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewWarningHeader(tt.code, tt.agent, tt.text)
+
+			switch {
+			case err == nil && len(tt.wantErr) > 0:
+				t.Fatalf("ParseWarningHeader() no error, expected error %q", tt.wantErr)
+			case err != nil && len(tt.wantErr) == 0:
+				t.Fatalf("ParseWarningHeader() error %q, expected no error", err)
+			case err != nil && len(tt.wantErr) > 0 && !strings.Contains(err.Error(), tt.wantErr):
+				t.Fatalf("ParseWarningHeader() error %q, expected error %q", err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+
+			if got != tt.want {
+				t.Fatalf("NewWarningHeader() = %v, want %v", got, tt.want)
+			}
+
+			roundTrip, remaining, err := ParseWarningHeader(got)
+			if err != nil {
+				t.Fatalf("error roundtripping: %v", err)
+			}
+			if len(remaining) > 0 {
+				t.Fatalf("unexpected remainder roundtripping: %s", remaining)
+			}
+			agent := tt.agent
+			if len(agent) == 0 {
+				agent = "-"
+			}
+			expect := WarningHeader{Code: tt.code, Agent: agent, Text: tt.text}
+			if roundTrip != expect {
+				t.Fatalf("after round trip, want:\n%#v\ngot\n%#v", expect, roundTrip)
+			}
+		})
+	}
+}
+
+func TestParseWarningHeaders(t *testing.T) {
+	tests := []struct {
+		name string
+
+		headers []string
+
+		want     []WarningHeader
+		wantErrs []string
+	}{
+		{
+			name:     "empty",
+			headers:  []string{},
+			want:     nil,
+			wantErrs: []string{},
+		},
+		{
+			name: "multi-header with error",
+			headers: []string{
+				`299 - "warning 1.1",299 - "warning 1.2"`,
+				`299 - "warning 2", 299 - "warning unquoted`,
+				` 299 - "warning 3.1" ,  299 - "warning 3.2" `,
+			},
+			want: []WarningHeader{
+				{Code: 299, Agent: "-", Text: "warning 1.1"},
+				{Code: 299, Agent: "-", Text: "warning 1.2"},
+				{Code: 299, Agent: "-", Text: "warning 2"},
+				{Code: 299, Agent: "-", Text: "warning 3.1"},
+				{Code: 299, Agent: "-", Text: "warning 3.2"},
+			},
+			wantErrs: []string{"invalid warning header: invalid quoted string: missing closing quote"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotErrs := ParseWarningHeaders(tt.headers)
+
+			switch {
+			case len(gotErrs) != len(tt.wantErrs):
+				t.Fatalf("ParseWarningHeader() got %v, expected %v", gotErrs, tt.wantErrs)
+			case len(gotErrs) == len(tt.wantErrs) && len(gotErrs) > 0:
+				gotErrStrings := []string{}
+				for _, err := range gotErrs {
+					gotErrStrings = append(gotErrStrings, err.Error())
+				}
+				if !reflect.DeepEqual(gotErrStrings, tt.wantErrs) {
+					t.Fatalf("ParseWarningHeader() got %v, expected %v", gotErrs, tt.wantErrs)
+				}
+			}
+			if len(gotErrs) > 0 {
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseWarningHeaders() got %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsProbableEOF(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "with no error",
+			expected: false,
+		},
+		{
+			name:     "with EOF error",
+			err:      io.EOF,
+			expected: true,
+		},
+		{
+			name:     "with unexpected EOF error",
+			err:      io.ErrUnexpectedEOF,
+			expected: true,
+		},
+		{
+			name:     "with broken connection error",
+			err:      fmt.Errorf("http: can't write HTTP request on broken connection"),
+			expected: true,
+		},
+		{
+			name:     "with server sent GOAWAY error",
+			err:      fmt.Errorf("error foo - http2: server sent GOAWAY and closed the connection - error bar"),
+			expected: true,
+		},
+		{
+			name:     "with connection reset by peer error",
+			err:      fmt.Errorf("error foo - connection reset by peer - error bar"),
+			expected: true,
+		},
+		{
+			name:     "with use of closed network connection error",
+			err:      fmt.Errorf("error foo - Use of closed network connection - error bar"),
+			expected: true,
+		},
+		{
+			name: "with url error",
+			err: &url.Error{
+				Err: io.ErrUnexpectedEOF,
+			},
+			expected: true,
+		},
+		{
+			name:     "with unrecognized error",
+			err:      fmt.Errorf("error foo"),
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := IsProbableEOF(test.err)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestReadIdleTimeoutSeconds(t *testing.T) {
+	t.Setenv("HTTP2_READ_IDLE_TIMEOUT_SECONDS", "60")
+	if e, a := 60, readIdleTimeoutSeconds(); e != a {
+		t.Errorf("expected %d, got %d", e, a)
+	}
+
+	t.Setenv("HTTP2_READ_IDLE_TIMEOUT_SECONDS", "illegal value")
+	if e, a := 30, readIdleTimeoutSeconds(); e != a {
+		t.Errorf("expected %d, got %d", e, a)
+	}
+}
+
+func TestPingTimeoutSeconds(t *testing.T) {
+	t.Setenv("HTTP2_PING_TIMEOUT_SECONDS", "60")
+	if e, a := 60, pingTimeoutSeconds(); e != a {
+		t.Errorf("expected %d, got %d", e, a)
+	}
+
+	t.Setenv("HTTP2_PING_TIMEOUT_SECONDS", "illegal value")
+	if e, a := 15, pingTimeoutSeconds(); e != a {
+		t.Errorf("expected %d, got %d", e, a)
+	}
+}
+
+func Benchmark_ParseQuotedString(b *testing.B) {
+	str := `"The quick brown" fox jumps over the lazy dog`
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		quoted, remainder, err := parseQuotedString(str)
+		if err != nil {
+			b.Errorf("Unexpected error %s", err)
+		}
+		if quoted != "The quick brown" {
+			b.Errorf("Unexpected quoted string %s", quoted)
+		}
+		if remainder != "fox jumps over the lazy dog" {
+			b.Errorf("Unexpected remainder string %s", quoted)
+		}
+	}
+}

--- a/internal/cri/netutil/interface.go
+++ b/internal/cri/netutil/interface.go
@@ -1,0 +1,512 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"bufio"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strings"
+
+	"github.com/containerd/log"
+)
+
+type AddressFamily uint
+
+const (
+	familyIPv4 AddressFamily = 4
+	familyIPv6 AddressFamily = 6
+)
+
+type AddressFamilyPreference []AddressFamily
+
+var (
+	preferIPv4 = AddressFamilyPreference{familyIPv4, familyIPv6}
+	preferIPv6 = AddressFamilyPreference{familyIPv6, familyIPv4}
+)
+
+const (
+	// LoopbackInterfaceName is the default name of the loopback interface
+	LoopbackInterfaceName = "lo"
+)
+
+const (
+	ipv4RouteFile = "/proc/net/route"
+	ipv6RouteFile = "/proc/net/ipv6_route"
+)
+
+type Route struct {
+	Interface   string
+	Destination net.IP
+	Gateway     net.IP
+	Family      AddressFamily
+}
+
+type RouteFile struct {
+	name  string
+	parse func(input io.Reader) ([]Route, error)
+}
+
+// noRoutesError can be returned in case of no routes
+type noRoutesError struct {
+	message string
+}
+
+func (e noRoutesError) Error() string {
+	return e.message
+}
+
+// IsNoRoutesError checks if an error is of type noRoutesError
+func IsNoRoutesError(err error) bool {
+	if err == nil {
+		return false
+	}
+	switch err.(type) {
+	case noRoutesError:
+		return true
+	default:
+		return false
+	}
+}
+
+var (
+	v4File = RouteFile{name: ipv4RouteFile, parse: getIPv4DefaultRoutes}
+	v6File = RouteFile{name: ipv6RouteFile, parse: getIPv6DefaultRoutes}
+)
+
+func (rf RouteFile) extract() ([]Route, error) {
+	file, err := os.Open(rf.name)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	return rf.parse(file)
+}
+
+// getIPv4DefaultRoutes obtains the IPv4 routes, and filters out non-default routes.
+func getIPv4DefaultRoutes(input io.Reader) ([]Route, error) {
+	routes := []Route{}
+	scanner := bufio.NewReader(input)
+	for {
+		line, err := scanner.ReadString('\n')
+		if err == io.EOF {
+			break
+		}
+		//ignore the headers in the route info
+		if strings.HasPrefix(line, "Iface") {
+			continue
+		}
+		fields := strings.Fields(line)
+		// Interested in fields:
+		//  0 - interface name
+		//  1 - destination address
+		//  2 - gateway
+		dest, err := parseIP(fields[1], familyIPv4)
+		if err != nil {
+			return nil, err
+		}
+		gw, err := parseIP(fields[2], familyIPv4)
+		if err != nil {
+			return nil, err
+		}
+		if !dest.Equal(net.IPv4zero) {
+			continue
+		}
+		routes = append(routes, Route{
+			Interface:   fields[0],
+			Destination: dest,
+			Gateway:     gw,
+			Family:      familyIPv4,
+		})
+	}
+	return routes, nil
+}
+
+func getIPv6DefaultRoutes(input io.Reader) ([]Route, error) {
+	routes := []Route{}
+	scanner := bufio.NewReader(input)
+	for {
+		line, err := scanner.ReadString('\n')
+		if err == io.EOF {
+			break
+		}
+		fields := strings.Fields(line)
+		// Interested in fields:
+		//  0 - destination address
+		//  4 - gateway
+		//  9 - interface name
+		dest, err := parseIP(fields[0], familyIPv6)
+		if err != nil {
+			return nil, err
+		}
+		gw, err := parseIP(fields[4], familyIPv6)
+		if err != nil {
+			return nil, err
+		}
+		if !dest.Equal(net.IPv6zero) {
+			continue
+		}
+		if gw.Equal(net.IPv6zero) {
+			continue // loopback
+		}
+		routes = append(routes, Route{
+			Interface:   fields[9],
+			Destination: dest,
+			Gateway:     gw,
+			Family:      familyIPv6,
+		})
+	}
+	return routes, nil
+}
+
+// parseIP takes the hex IP address string from route file and converts it
+// to a net.IP address. For IPv4, the value must be converted to big endian.
+func parseIP(str string, family AddressFamily) (net.IP, error) {
+	if str == "" {
+		return nil, fmt.Errorf("input is nil")
+	}
+	bytes, err := hex.DecodeString(str)
+	if err != nil {
+		return nil, err
+	}
+	if family == familyIPv4 {
+		if len(bytes) != net.IPv4len {
+			return nil, fmt.Errorf("invalid IPv4 address in route")
+		}
+		return net.IP([]byte{bytes[3], bytes[2], bytes[1], bytes[0]}), nil
+	}
+	// Must be IPv6
+	if len(bytes) != net.IPv6len {
+		return nil, fmt.Errorf("invalid IPv6 address in route")
+	}
+	return net.IP(bytes), nil
+}
+
+func isInterfaceUp(intf *net.Interface) bool {
+	if intf == nil {
+		return false
+	}
+	if intf.Flags&net.FlagUp != 0 {
+		log.L.Infof("Interface %v is up", intf.Name)
+		return true
+	}
+	return false
+}
+
+func isLoopbackOrPointToPoint(intf *net.Interface) bool {
+	return intf.Flags&(net.FlagLoopback|net.FlagPointToPoint) != 0
+}
+
+// getMatchingGlobalIP returns the first valid global unicast address of the given
+// 'family' from the list of 'addrs'.
+func getMatchingGlobalIP(addrs []net.Addr, family AddressFamily) (net.IP, error) {
+	if len(addrs) > 0 {
+		for i := range addrs {
+			log.L.Infof("Checking addr  %s.", addrs[i].String())
+			ip, _, err := net.ParseCIDR(addrs[i].String())
+			if err != nil {
+				return nil, err
+			}
+			if memberOf(ip, family) {
+				if ip.IsGlobalUnicast() {
+					log.L.Infof("IP found %v", ip)
+					return ip, nil
+				}
+				log.L.Infof("Non-global unicast address found %v", ip)
+			} else {
+				log.L.Infof("%v is not an IPv%d address", ip, int(family))
+			}
+
+		}
+	}
+	return nil, nil
+}
+
+// getIPFromInterface gets the IPs on an interface and returns a global unicast address, if any. The
+// interface must be up, the IP must in the family requested, and the IP must be a global unicast address.
+func getIPFromInterface(intfName string, forFamily AddressFamily, nw networkInterfacer) (net.IP, error) {
+	intf, err := nw.InterfaceByName(intfName)
+	if err != nil {
+		return nil, err
+	}
+	if isInterfaceUp(intf) {
+		addrs, err := nw.Addrs(intf)
+		if err != nil {
+			return nil, err
+		}
+		log.L.Infof("Interface %q has %d addresses :%v.", intfName, len(addrs), addrs)
+		matchingIP, err := getMatchingGlobalIP(addrs, forFamily)
+		if err != nil {
+			return nil, err
+		}
+		if matchingIP != nil {
+			log.L.Infof("Found valid IPv%d address %v for interface %q.", int(forFamily), matchingIP, intfName)
+			return matchingIP, nil
+		}
+	}
+	return nil, nil
+}
+
+// getIPFromLoopbackInterface gets the IPs on a loopback interface and returns a global unicast address, if any.
+// The loopback interface must be up, the IP must in the family requested, and the IP must be a global unicast address.
+func getIPFromLoopbackInterface(forFamily AddressFamily, nw networkInterfacer) (net.IP, error) {
+	intfs, err := nw.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+	for _, intf := range intfs {
+		if !isInterfaceUp(&intf) {
+			continue
+		}
+		if intf.Flags&(net.FlagLoopback) != 0 {
+			addrs, err := nw.Addrs(&intf)
+			if err != nil {
+				return nil, err
+			}
+			log.L.Infof("Interface %q has %d addresses :%v.", intf.Name, len(addrs), addrs)
+			matchingIP, err := getMatchingGlobalIP(addrs, forFamily)
+			if err != nil {
+				return nil, err
+			}
+			if matchingIP != nil {
+				log.L.Infof("Found valid IPv%d address %v for interface %q.", int(forFamily), matchingIP, intf.Name)
+				return matchingIP, nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+// memberOf tells if the IP is of the desired family. Used for checking interface addresses.
+func memberOf(ip net.IP, family AddressFamily) bool {
+	if ip.To4() != nil {
+		return family == familyIPv4
+	}
+	return family == familyIPv6
+}
+
+// chooseIPFromHostInterfaces looks at all system interfaces, trying to find one that is up that
+// has a global unicast address (non-loopback, non-link local, non-point2point), and returns the IP.
+// addressFamilies determines whether it prefers IPv4 or IPv6
+func chooseIPFromHostInterfaces(nw networkInterfacer, addressFamilies AddressFamilyPreference) (net.IP, error) {
+	intfs, err := nw.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+	if len(intfs) == 0 {
+		return nil, fmt.Errorf("no interfaces found on host")
+	}
+	for _, family := range addressFamilies {
+		log.L.Infof("Looking for system interface with a global IPv%d address", uint(family))
+		for _, intf := range intfs {
+			if !isInterfaceUp(&intf) {
+				log.L.Infof("Skipping: down interface %q", intf.Name)
+				continue
+			}
+			if isLoopbackOrPointToPoint(&intf) {
+				log.L.Infof("Skipping: LB or P2P interface %q", intf.Name)
+				continue
+			}
+			addrs, err := nw.Addrs(&intf)
+			if err != nil {
+				return nil, err
+			}
+			if len(addrs) == 0 {
+				log.L.Infof("Skipping: no addresses on interface %q", intf.Name)
+				continue
+			}
+			for _, addr := range addrs {
+				ip, _, err := net.ParseCIDR(addr.String())
+				if err != nil {
+					return nil, fmt.Errorf("unable to parse CIDR for interface %q: %s", intf.Name, err)
+				}
+				if !memberOf(ip, family) {
+					log.L.Infof("Skipping: no address family match for %q on interface %q.", ip, intf.Name)
+					continue
+				}
+				// TODO: Decide if should open up to allow IPv6 LLAs in future.
+				if !ip.IsGlobalUnicast() {
+					log.L.Infof("Skipping: non-global address %q on interface %q.", ip, intf.Name)
+					continue
+				}
+				log.L.Infof("Found global unicast address %q on interface %q.", ip, intf.Name)
+				return ip, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("no acceptable interface with global unicast address found on host")
+}
+
+// ChooseHostInterface is a method used fetch an IP for a daemon.
+// If there is no routing info file, it will choose a global IP from the system
+// interfaces. Otherwise, it will use IPv4 and IPv6 route information to return the
+// IP of the interface with a gateway on it (with priority given to IPv4). For a node
+// with no internet connection, it returns error.
+func ChooseHostInterface() (net.IP, error) {
+	return chooseHostInterface(preferIPv4)
+}
+
+func chooseHostInterface(addressFamilies AddressFamilyPreference) (net.IP, error) {
+	var nw networkInterfacer = networkInterface{}
+	if _, err := os.Stat(ipv4RouteFile); os.IsNotExist(err) {
+		return chooseIPFromHostInterfaces(nw, addressFamilies)
+	}
+	routes, err := getAllDefaultRoutes()
+	if err != nil {
+		return nil, err
+	}
+	return chooseHostInterfaceFromRoute(routes, nw, addressFamilies)
+}
+
+// networkInterfacer defines an interface for several net library functions. Production
+// code will forward to net library functions, and unit tests will override the methods
+// for testing purposes.
+type networkInterfacer interface {
+	InterfaceByName(intfName string) (*net.Interface, error)
+	Addrs(intf *net.Interface) ([]net.Addr, error)
+	Interfaces() ([]net.Interface, error)
+}
+
+// networkInterface implements the networkInterfacer interface for production code, just
+// wrapping the underlying net library function calls.
+type networkInterface struct{}
+
+func (n networkInterface) InterfaceByName(intfName string) (*net.Interface, error) {
+	return net.InterfaceByName(intfName)
+}
+
+func (n networkInterface) Addrs(intf *net.Interface) ([]net.Addr, error) {
+	return intf.Addrs()
+}
+
+func (n networkInterface) Interfaces() ([]net.Interface, error) {
+	return net.Interfaces()
+}
+
+// getAllDefaultRoutes obtains IPv4 and IPv6 default routes on the node. If unable
+// to read the IPv4 routing info file, we return an error. If unable to read the IPv6
+// routing info file (which is optional), we'll just use the IPv4 route information.
+// Using all the routing info, if no default routes are found, an error is returned.
+func getAllDefaultRoutes() ([]Route, error) {
+	routes, err := v4File.extract()
+	if err != nil {
+		return nil, err
+	}
+	v6Routes, _ := v6File.extract()
+	routes = append(routes, v6Routes...)
+	if len(routes) == 0 {
+		return nil, noRoutesError{
+			message: fmt.Sprintf("no default routes found in %q or %q", v4File.name, v6File.name),
+		}
+	}
+	return routes, nil
+}
+
+// chooseHostInterfaceFromRoute cycles through each default route provided, looking for a
+// global IP address from the interface for the route. If there are routes but no global
+// address is obtained from the interfaces, it checks if the loopback interface has a global address.
+// addressFamilies determines whether it prefers IPv4 or IPv6
+func chooseHostInterfaceFromRoute(routes []Route, nw networkInterfacer, addressFamilies AddressFamilyPreference) (net.IP, error) {
+	for _, family := range addressFamilies {
+		log.L.Infof("Looking for default routes with IPv%d addresses", uint(family))
+		for _, route := range routes {
+			if route.Family != family {
+				continue
+			}
+			log.L.Infof("Default route transits interface %q", route.Interface)
+			finalIP, err := getIPFromInterface(route.Interface, family, nw)
+			if err != nil {
+				return nil, err
+			}
+			if finalIP != nil {
+				log.L.Infof("Found active IP %v ", finalIP)
+				return finalIP, nil
+			}
+			// In case of network setups where default routes are present, but network
+			// interfaces use only link-local addresses (e.g. as described in RFC5549).
+			// the global IP is assigned to the loopback interface, and we should use it
+			loopbackIP, err := getIPFromLoopbackInterface(family, nw)
+			if err != nil {
+				return nil, err
+			}
+			if loopbackIP != nil {
+				log.L.Infof("Found active IP %v on Loopback interface", loopbackIP)
+				return loopbackIP, nil
+			}
+		}
+	}
+	log.L.Infof("No active IP found by looking at default routes")
+	return nil, fmt.Errorf("unable to select an IP from default routes")
+}
+
+// ResolveBindAddress returns the IP address of a daemon, based on the given bindAddress:
+// If bindAddress is unset, it returns the host's default IP, as with ChooseHostInterface().
+// If bindAddress is unspecified or loopback, it returns the default IP of the same
+// address family as bindAddress.
+// Otherwise, it just returns bindAddress.
+func ResolveBindAddress(bindAddress net.IP) (net.IP, error) {
+	addressFamilies := preferIPv4
+	if bindAddress != nil && memberOf(bindAddress, familyIPv6) {
+		addressFamilies = preferIPv6
+	}
+
+	if bindAddress == nil || bindAddress.IsUnspecified() || bindAddress.IsLoopback() {
+		hostIP, err := chooseHostInterface(addressFamilies)
+		if err != nil {
+			return nil, err
+		}
+		bindAddress = hostIP
+	}
+	return bindAddress, nil
+}
+
+// ChooseBindAddressForInterface choose a global IP for a specific interface, with priority given to IPv4.
+// This is required in case of network setups where default routes are present, but network
+// interfaces use only link-local addresses (e.g. as described in RFC5549).
+// e.g when using BGP to announce a host IP over link-local ip addresses and this ip address is attached to the lo interface.
+func ChooseBindAddressForInterface(intfName string) (net.IP, error) {
+	var nw networkInterfacer = networkInterface{}
+	for _, family := range preferIPv4 {
+		ip, err := getIPFromInterface(intfName, family, nw)
+		if err != nil {
+			return nil, err
+		}
+		if ip != nil {
+			return ip, nil
+		}
+	}
+	return nil, fmt.Errorf("unable to select an IP from %s network interface", intfName)
+}

--- a/internal/cri/netutil/interface_test.go
+++ b/internal/cri/netutil/interface_test.go
@@ -1,0 +1,840 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"fmt"
+	"net"
+	"os"
+	goruntime "runtime"
+	"strings"
+	"testing"
+)
+
+const gatewayfirst = `Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT
+eth3	00000000	0100FE0A	0003	0	0	1024	00000000	0	0	0
+eth3	0000FE0A	00000000	0001	0	0	0	0080FFFF	0	0	0
+docker0	000011AC	00000000	0001	0	0	0	0000FFFF	0	0	0
+virbr0	007AA8C0	00000000	0001	0	0	0	00FFFFFF	0	0	0
+`
+const gatewaylast = `Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT
+docker0	000011AC	00000000	0001	0	0	0	0000FFFF	0	0	0
+virbr0	007AA8C0	00000000	0001	0	0	0	00FFFFFF	0	0	0
+eth3	0000FE0A	00000000	0001	0	0	0	0080FFFF	0	0	0
+eth3	00000000	0100FE0A	0003	0	0	1024	00000000	0	0	0
+`
+const gatewaymiddle = `Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT
+eth3	0000FE0A	00000000	0001	0	0	0	0080FFFF	0	0	0
+docker0	000011AC	00000000	0001	0	0	0	0000FFFF	0	0	0
+eth3	00000000	0100FE0A	0003	0	0	1024	00000000	0	0	0
+virbr0	007AA8C0	00000000	0001	0	0	0	00FFFFFF	0	0	0
+`
+const noInternetConnection = `Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT
+docker0	000011AC	00000000	0001	0	0	0	0000FFFF	0	0	0
+virbr0	007AA8C0	00000000	0001	0	0	0	00FFFFFF	0	0	0
+`
+const nothing = `Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT
+`
+const badDestination = `Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT
+eth3	00000000	0100FE0A	0003	0	0	1024	00000000	0	0	0
+eth3	0000FE0AA1	00000000	0001	0	0	0	0080FFFF	0	0	0
+docker0	000011AC	00000000	0001	0	0	0	0000FFFF	0	0	0
+virbr0	007AA8C0	00000000	0001	0	0	0	00FFFFFF	0	0	0
+`
+const badGateway = `Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT
+eth3	00000000	0100FE0AA1	0003	0	0	1024	00000000	0	0	0
+eth3	0000FE0A	00000000	0001	0	0	0	0080FFFF	0	0	0
+docker0	000011AC	00000000	0001	0	0	0	0000FFFF	0	0	0
+virbr0	007AA8C0	00000000	0001	0	0	0	00FFFFFF	0	0	0
+`
+const routeInvalidhex = `Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT
+eth3	00000000	0100FE0AA	0003	0	0	1024	00000000	0	0	0
+eth3	0000FE0A	00000000	0001	0	0	0	0080FFFF	0	0	0
+docker0	000011AC	00000000	0001	0	0	0	0000FFFF	0	0	0
+virbr0	007AA8C0	00000000	0001	0	0	0	00FFFFFF	0	0	0
+`
+
+const v6gatewayfirst = `00000000000000000000000000000000 00 00000000000000000000000000000000 00 20010001000000000000000000000001 00000064 00000000 00000000 00000003 eth3
+20010002000000000000000000000000 40 00000000000000000000000000000000 00 00000000000000000000000000000000 00000100 00000000 00000000 00000001 eth3
+00000000000000000000000000000000 60 00000000000000000000000000000000 00 00000000000000000000000000000000 00000400 00000000 00000000 00200200       lo
+`
+const v6gatewaylast = `20010002000000000000000000000000 40 00000000000000000000000000000000 00 00000000000000000000000000000000 00000100 00000000 00000000 00000001 eth3
+00000000000000000000000000000000 60 00000000000000000000000000000000 00 00000000000000000000000000000000 00000400 00000000 00000000 00200200       lo
+00000000000000000000000000000000 00 00000000000000000000000000000000 00 20010001000000000000000000000001 00000064 00000000 00000000 00000003 eth3
+`
+const v6gatewaymiddle = `20010002000000000000000000000000 40 00000000000000000000000000000000 00 00000000000000000000000000000000 00000100 00000000 00000000 00000001 eth3
+00000000000000000000000000000000 00 00000000000000000000000000000000 00 20010001000000000000000000000001 00000064 00000000 00000000 00000003 eth3
+00000000000000000000000000000000 60 00000000000000000000000000000000 00 00000000000000000000000000000000 00000400 00000000 00000000 00200200       lo
+`
+const v6noDefaultRoutes = `00000000000000000000000000000000 60 00000000000000000000000000000000 00 00000000000000000000000000000000 00000400 00000000 00000000 00200200       lo
+20010001000000000000000000000000 40 00000000000000000000000000000000 00 00000000000000000000000000000000 00000400 00000000 00000000 00000001  docker0
+20010002000000000000000000000000 40 00000000000000000000000000000000 00 00000000000000000000000000000000 00000100 00000000 00000000 00000001   eth3
+fe800000000000000000000000000000 40 00000000000000000000000000000000 00 00000000000000000000000000000000 00000100 00000000 00000000 00000001   eth3
+`
+const v6nothing = ``
+const v6badDestination = `2001000200000000 7a 00000000000000000000000000000000 00 00000000000000000000000000000000 00000400 00000000 00000000 00200200       lo
+`
+const v6badGateway = `00000000000000000000000000000000 00 00000000000000000000000000000000 00 200100010000000000000000000000000012 00000064 00000000 00000000 00000003 eth3
+`
+const v6routeInvalidhex = `000000000000000000000000000000000 00 00000000000000000000000000000000 00 fe80000000000000021fcafffea0ec00 00000064 00000000 00000000 00000003 enp1s0f0
+
+`
+
+const (
+	flagUp       = net.FlagUp | net.FlagBroadcast | net.FlagMulticast
+	flagDown     = net.FlagBroadcast | net.FlagMulticast
+	flagLoopback = net.FlagUp | net.FlagLoopback
+	flagP2P      = net.FlagUp | net.FlagPointToPoint
+)
+
+func makeIntf(index int, name string, flags net.Flags) net.Interface {
+	mac := net.HardwareAddr{0, 0x32, 0x7d, 0x69, 0xf7, byte(0x30 + index)}
+	return net.Interface{
+		Index:        index,
+		MTU:          1500,
+		Name:         name,
+		HardwareAddr: mac,
+		Flags:        flags}
+}
+
+var (
+	downIntf     = makeIntf(1, "eth3", flagDown)
+	loopbackIntf = makeIntf(1, "lo", flagLoopback)
+	p2pIntf      = makeIntf(1, "lo", flagP2P)
+	upIntf       = makeIntf(1, "eth3", flagUp)
+)
+
+var (
+	ipv4Route = Route{Interface: "eth3", Destination: net.ParseIP("0.0.0.0"), Gateway: net.ParseIP("10.254.0.1"), Family: familyIPv4}
+	ipv6Route = Route{Interface: "eth3", Destination: net.ParseIP("::"), Gateway: net.ParseIP("2001:1::1"), Family: familyIPv6}
+)
+
+var (
+	noRoutes   = []Route{}
+	routeV4    = []Route{ipv4Route}
+	routeV6    = []Route{ipv6Route}
+	bothRoutes = []Route{ipv4Route, ipv6Route}
+)
+
+func TestGetIPv4Routes(t *testing.T) {
+	testCases := []struct {
+		tcase      string
+		route      string
+		count      int
+		expected   *Route
+		errStrFrag string
+	}{
+		{"gatewayfirst", gatewayfirst, 1, &ipv4Route, ""},
+		{"gatewaymiddle", gatewaymiddle, 1, &ipv4Route, ""},
+		{"gatewaylast", gatewaylast, 1, &ipv4Route, ""},
+		{"no routes", nothing, 0, nil, ""},
+		{"badDestination", badDestination, 0, nil, "invalid IPv4"},
+		{"badGateway", badGateway, 0, nil, "invalid IPv4"},
+		{"route_Invalidhex", routeInvalidhex, 0, nil, "odd length hex string"},
+		{"no default routes", noInternetConnection, 0, nil, ""},
+	}
+	for _, tc := range testCases {
+		r := strings.NewReader(tc.route)
+		routes, err := getIPv4DefaultRoutes(r)
+		if err != nil {
+			if !strings.Contains(err.Error(), tc.errStrFrag) {
+				t.Errorf("case[%s]: Error string %q does not contain %q", tc.tcase, err, tc.errStrFrag)
+			}
+		} else if tc.errStrFrag != "" {
+			t.Errorf("case[%s]: Error %q expected, but not seen", tc.tcase, tc.errStrFrag)
+		} else {
+			if tc.count != len(routes) {
+				t.Errorf("case[%s]: expected %d routes, have %v", tc.tcase, tc.count, routes)
+			} else if tc.count == 1 {
+				if !tc.expected.Gateway.Equal(routes[0].Gateway) {
+					t.Errorf("case[%s]: expected %v, got %v .err : %v", tc.tcase, tc.expected, routes, err)
+				}
+				if !routes[0].Destination.Equal(net.IPv4zero) {
+					t.Errorf("case[%s}: destination is not for default route (not zero)", tc.tcase)
+				}
+
+			}
+		}
+	}
+}
+
+func TestGetIPv6Routes(t *testing.T) {
+	testCases := []struct {
+		tcase      string
+		route      string
+		count      int
+		expected   *Route
+		errStrFrag string
+	}{
+		{"v6 gatewayfirst", v6gatewayfirst, 1, &ipv6Route, ""},
+		{"v6 gatewaymiddle", v6gatewaymiddle, 1, &ipv6Route, ""},
+		{"v6 gatewaylast", v6gatewaylast, 1, &ipv6Route, ""},
+		{"v6 no routes", v6nothing, 0, nil, ""},
+		{"v6 badDestination", v6badDestination, 0, nil, "invalid IPv6"},
+		{"v6 badGateway", v6badGateway, 0, nil, "invalid IPv6"},
+		{"v6 routeInvalidhex", v6routeInvalidhex, 0, nil, "odd length hex string"},
+		{"v6 no default routes", v6noDefaultRoutes, 0, nil, ""},
+	}
+	for _, tc := range testCases {
+		r := strings.NewReader(tc.route)
+		routes, err := getIPv6DefaultRoutes(r)
+		if err != nil {
+			if !strings.Contains(err.Error(), tc.errStrFrag) {
+				t.Errorf("case[%s]: Error string %q does not contain %q", tc.tcase, err, tc.errStrFrag)
+			}
+		} else if tc.errStrFrag != "" {
+			t.Errorf("case[%s]: Error %q expected, but not seen", tc.tcase, tc.errStrFrag)
+		} else {
+			if tc.count != len(routes) {
+				t.Errorf("case[%s]: expected %d routes, have %v", tc.tcase, tc.count, routes)
+			} else if tc.count == 1 {
+				if !tc.expected.Gateway.Equal(routes[0].Gateway) {
+					t.Errorf("case[%s]: expected %v, got %v .err : %v", tc.tcase, tc.expected, routes, err)
+				}
+				if !routes[0].Destination.Equal(net.IPv6zero) {
+					t.Errorf("case[%s}: destination is not for default route (not zero)", tc.tcase)
+				}
+			}
+		}
+	}
+}
+
+func TestParseIP(t *testing.T) {
+	testCases := []struct {
+		tcase    string
+		ip       string
+		family   AddressFamily
+		success  bool
+		expected net.IP
+	}{
+		{"empty", "", familyIPv4, false, nil},
+		{"too short", "AA", familyIPv4, false, nil},
+		{"too long", "0011223344", familyIPv4, false, nil},
+		{"invalid", "invalid!", familyIPv4, false, nil},
+		{"zero", "00000000", familyIPv4, true, net.IP{0, 0, 0, 0}},
+		{"ffff", "FFFFFFFF", familyIPv4, true, net.IP{0xff, 0xff, 0xff, 0xff}},
+		{"valid v4", "12345678", familyIPv4, true, net.IP{120, 86, 52, 18}},
+		{"valid v6", "fe800000000000000000000000000000", familyIPv6, true, net.IP{0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
+		{"v6 too short", "fe80000000000000021fcafffea0ec0", familyIPv6, false, nil},
+		{"v6 too long", "fe80000000000000021fcafffea0ec002", familyIPv6, false, nil},
+	}
+	for _, tc := range testCases {
+		ip, err := parseIP(tc.ip, tc.family)
+		if !ip.Equal(tc.expected) {
+			t.Errorf("case[%v]: expected %q, got %q . err : %v", tc.tcase, tc.expected, ip, err)
+		}
+	}
+}
+
+func TestIsInterfaceUp(t *testing.T) {
+	testCases := []struct {
+		tcase    string
+		intf     *net.Interface
+		expected bool
+	}{
+		{"up", &net.Interface{Index: 0, MTU: 0, Name: "eth3", HardwareAddr: nil, Flags: net.FlagUp}, true},
+		{"down", &net.Interface{Index: 0, MTU: 0, Name: "eth3", HardwareAddr: nil, Flags: 0}, false},
+		{"no interface", nil, false},
+	}
+	for _, tc := range testCases {
+		it := isInterfaceUp(tc.intf)
+		if it != tc.expected {
+			t.Errorf("case[%v]: expected %v, got %v .", tc.tcase, tc.expected, it)
+		}
+	}
+}
+
+type addrStruct struct{ val string }
+
+func (a addrStruct) Network() string {
+	return a.val
+}
+func (a addrStruct) String() string {
+	return a.val
+}
+
+func TestFinalIP(t *testing.T) {
+	testCases := []struct {
+		tcase    string
+		addr     []net.Addr
+		family   AddressFamily
+		expected net.IP
+	}{
+		{"no ipv4", []net.Addr{addrStruct{val: "2001::5/64"}}, familyIPv4, nil},
+		{"no ipv6", []net.Addr{addrStruct{val: "10.128.0.4/32"}}, familyIPv6, nil},
+		{"invalidV4CIDR", []net.Addr{addrStruct{val: "10.20.30.40.50/24"}}, familyIPv4, nil},
+		{"invalidV6CIDR", []net.Addr{addrStruct{val: "fe80::2f7:67fff:fe6e:2956/64"}}, familyIPv6, nil},
+		{"loopback", []net.Addr{addrStruct{val: "127.0.0.1/24"}}, familyIPv4, nil},
+		{"loopbackv6", []net.Addr{addrStruct{val: "::1/128"}}, familyIPv6, nil},
+		{"link local v4", []net.Addr{addrStruct{val: "169.254.1.10/16"}}, familyIPv4, nil},
+		{"link local v6", []net.Addr{addrStruct{val: "fe80::2f7:6fff:fe6e:2956/64"}}, familyIPv6, nil},
+		{"ip4", []net.Addr{addrStruct{val: "10.254.12.132/17"}}, familyIPv4, net.ParseIP("10.254.12.132")},
+		{"ip6", []net.Addr{addrStruct{val: "2001::5/64"}}, familyIPv6, net.ParseIP("2001::5")},
+
+		{"no addresses", []net.Addr{}, familyIPv4, nil},
+	}
+	for _, tc := range testCases {
+		ip, err := getMatchingGlobalIP(tc.addr, tc.family)
+		if !ip.Equal(tc.expected) {
+			t.Errorf("case[%v]: expected %v, got %v .err : %v", tc.tcase, tc.expected, ip, err)
+		}
+	}
+}
+
+func TestAddrs(t *testing.T) {
+	var nw networkInterfacer = validNetworkInterface{}
+	intf := net.Interface{Index: 0, MTU: 0, Name: "eth3", HardwareAddr: nil, Flags: 0}
+	addrs, err := nw.Addrs(&intf)
+	if err != nil {
+		t.Errorf("expected no error got : %v", err)
+	}
+	if len(addrs) != 2 {
+		t.Errorf("expected addrs: 2 got null")
+	}
+}
+
+// Has a valid IPv4 address (IPv6 is LLA)
+type validNetworkInterface struct {
+}
+
+func (n validNetworkInterface) InterfaceByName(intfName string) (*net.Interface, error) {
+	return &upIntf, nil
+}
+func (n validNetworkInterface) Addrs(intf *net.Interface) ([]net.Addr, error) {
+	var ifat []net.Addr = []net.Addr{
+		addrStruct{val: "fe80::2f7:6fff:fe6e:2956/64"}, addrStruct{val: "10.254.71.145/17"}}
+	return ifat, nil
+}
+func (n validNetworkInterface) Interfaces() ([]net.Interface, error) {
+	return []net.Interface{upIntf}, nil
+}
+
+// Both IPv4 and IPv6 addresses (expecting IPv4 to be used)
+type v4v6NetworkInterface struct {
+}
+
+func (n v4v6NetworkInterface) InterfaceByName(intfName string) (*net.Interface, error) {
+	return &upIntf, nil
+}
+func (n v4v6NetworkInterface) Addrs(intf *net.Interface) ([]net.Addr, error) {
+	var ifat []net.Addr = []net.Addr{
+		addrStruct{val: "2001::10/64"}, addrStruct{val: "10.254.71.145/17"}}
+	return ifat, nil
+}
+func (n v4v6NetworkInterface) Interfaces() ([]net.Interface, error) {
+	return []net.Interface{upIntf}, nil
+}
+
+// Interface with only IPv6 address
+type ipv6NetworkInterface struct {
+}
+
+func (n ipv6NetworkInterface) InterfaceByName(intfName string) (*net.Interface, error) {
+	return &upIntf, nil
+}
+func (n ipv6NetworkInterface) Addrs(intf *net.Interface) ([]net.Addr, error) {
+	var ifat []net.Addr = []net.Addr{addrStruct{val: "2001::200/64"}}
+	return ifat, nil
+}
+
+func (n ipv6NetworkInterface) Interfaces() ([]net.Interface, error) {
+	return []net.Interface{upIntf}, nil
+}
+
+// Only with link local addresses
+type networkInterfaceWithOnlyLinkLocals struct {
+}
+
+func (n networkInterfaceWithOnlyLinkLocals) InterfaceByName(intfName string) (*net.Interface, error) {
+	return &upIntf, nil
+}
+func (n networkInterfaceWithOnlyLinkLocals) Addrs(intf *net.Interface) ([]net.Addr, error) {
+	var ifat []net.Addr = []net.Addr{addrStruct{val: "169.254.162.166/16"}, addrStruct{val: "fe80::200/10"}}
+	return ifat, nil
+}
+func (n networkInterfaceWithOnlyLinkLocals) Interfaces() ([]net.Interface, error) {
+	return []net.Interface{upIntf}, nil
+}
+
+// Unable to get interface(s)
+type failGettingNetworkInterface struct {
+}
+
+func (n failGettingNetworkInterface) InterfaceByName(intfName string) (*net.Interface, error) {
+	return nil, fmt.Errorf("unable get Interface")
+}
+func (n failGettingNetworkInterface) Addrs(intf *net.Interface) ([]net.Addr, error) {
+	return nil, nil
+}
+func (n failGettingNetworkInterface) Interfaces() ([]net.Interface, error) {
+	return nil, fmt.Errorf("mock failed getting all interfaces")
+}
+
+// No interfaces
+type noNetworkInterface struct {
+}
+
+func (n noNetworkInterface) InterfaceByName(intfName string) (*net.Interface, error) {
+	return nil, fmt.Errorf("no such network interface")
+}
+func (n noNetworkInterface) Addrs(intf *net.Interface) ([]net.Addr, error) {
+	return nil, nil
+}
+func (n noNetworkInterface) Interfaces() ([]net.Interface, error) {
+	return []net.Interface{}, nil
+}
+
+// Interface is down
+type downNetworkInterface struct {
+}
+
+func (n downNetworkInterface) InterfaceByName(intfName string) (*net.Interface, error) {
+	return &downIntf, nil
+}
+func (n downNetworkInterface) Addrs(intf *net.Interface) ([]net.Addr, error) {
+	var ifat []net.Addr = []net.Addr{
+		addrStruct{val: "fe80::2f7:6fff:fe6e:2956/64"}, addrStruct{val: "10.254.71.145/17"}}
+	return ifat, nil
+}
+func (n downNetworkInterface) Interfaces() ([]net.Interface, error) {
+	return []net.Interface{downIntf}, nil
+}
+
+// Loopback interface
+type loopbackNetworkInterface struct {
+}
+
+func (n loopbackNetworkInterface) InterfaceByName(intfName string) (*net.Interface, error) {
+	return &loopbackIntf, nil
+}
+func (n loopbackNetworkInterface) Addrs(intf *net.Interface) ([]net.Addr, error) {
+	var ifat []net.Addr = []net.Addr{
+		addrStruct{val: "::1/128"}, addrStruct{val: "127.0.0.1/8"}}
+	return ifat, nil
+}
+func (n loopbackNetworkInterface) Interfaces() ([]net.Interface, error) {
+	return []net.Interface{loopbackIntf}, nil
+}
+
+// Point to point interface
+type p2pNetworkInterface struct {
+}
+
+func (n p2pNetworkInterface) InterfaceByName(intfName string) (*net.Interface, error) {
+	return &p2pIntf, nil
+}
+func (n p2pNetworkInterface) Addrs(intf *net.Interface) ([]net.Addr, error) {
+	var ifat []net.Addr = []net.Addr{
+		addrStruct{val: "::1/128"}, addrStruct{val: "127.0.0.1/8"}}
+	return ifat, nil
+}
+func (n p2pNetworkInterface) Interfaces() ([]net.Interface, error) {
+	return []net.Interface{p2pIntf}, nil
+}
+
+// Interface with link locals and loopback interface with global addresses
+type linkLocalLoopbackNetworkInterface struct {
+}
+
+func (n linkLocalLoopbackNetworkInterface) InterfaceByName(intfName string) (*net.Interface, error) {
+	if intfName == LoopbackInterfaceName {
+		return &loopbackIntf, nil
+	}
+	return &upIntf, nil
+}
+func (n linkLocalLoopbackNetworkInterface) Addrs(intf *net.Interface) ([]net.Addr, error) {
+	var ifat []net.Addr
+	ifat = []net.Addr{addrStruct{val: "169.254.162.166/16"}, addrStruct{val: "fe80::200/10"}}
+	if intf.Name == LoopbackInterfaceName {
+		ifat = []net.Addr{addrStruct{val: "::1/128"}, addrStruct{val: "127.0.0.1/8"},
+			// global addresses on loopback interface
+			addrStruct{val: "10.1.1.1/32"}, addrStruct{val: "fd00:1:1::1/128"}}
+	}
+	return ifat, nil
+}
+func (n linkLocalLoopbackNetworkInterface) Interfaces() ([]net.Interface, error) {
+	return []net.Interface{upIntf, loopbackIntf}, nil
+}
+
+// Interface and loopback interface with global addresses
+type globalsNetworkInterface struct {
+}
+
+func (n globalsNetworkInterface) InterfaceByName(intfName string) (*net.Interface, error) {
+	if intfName == LoopbackInterfaceName {
+		return &loopbackIntf, nil
+	}
+	return &upIntf, nil
+}
+func (n globalsNetworkInterface) Addrs(intf *net.Interface) ([]net.Addr, error) {
+	var ifat []net.Addr
+	ifat = []net.Addr{addrStruct{val: "169.254.162.166/16"}, addrStruct{val: "fe80::200/10"},
+		addrStruct{val: "192.168.1.1/31"}, addrStruct{val: "fd00::200/127"}}
+	if intf.Name == LoopbackInterfaceName {
+		ifat = []net.Addr{addrStruct{val: "::1/128"}, addrStruct{val: "127.0.0.1/8"},
+			// global addresses on loopback interface
+			addrStruct{val: "10.1.1.1/32"}, addrStruct{val: "fd00:1:1::1/128"}}
+	}
+	return ifat, nil
+}
+func (n globalsNetworkInterface) Interfaces() ([]net.Interface, error) {
+	return []net.Interface{upIntf, loopbackIntf}, nil
+}
+
+// Unable to get IP addresses for interface
+type networkInterfaceFailGetAddrs struct {
+}
+
+func (n networkInterfaceFailGetAddrs) InterfaceByName(intfName string) (*net.Interface, error) {
+	return &upIntf, nil
+}
+func (n networkInterfaceFailGetAddrs) Addrs(intf *net.Interface) ([]net.Addr, error) {
+	return nil, fmt.Errorf("unable to get Addrs")
+}
+func (n networkInterfaceFailGetAddrs) Interfaces() ([]net.Interface, error) {
+	return []net.Interface{upIntf}, nil
+}
+
+// No addresses for interface
+type networkInterfaceWithNoAddrs struct {
+}
+
+func (n networkInterfaceWithNoAddrs) InterfaceByName(intfName string) (*net.Interface, error) {
+	return &upIntf, nil
+}
+func (n networkInterfaceWithNoAddrs) Addrs(intf *net.Interface) ([]net.Addr, error) {
+	ifat := []net.Addr{}
+	return ifat, nil
+}
+func (n networkInterfaceWithNoAddrs) Interfaces() ([]net.Interface, error) {
+	return []net.Interface{upIntf}, nil
+}
+
+// Invalid addresses for interface
+type networkInterfaceWithInvalidAddr struct {
+}
+
+func (n networkInterfaceWithInvalidAddr) InterfaceByName(intfName string) (*net.Interface, error) {
+	return &upIntf, nil
+}
+func (n networkInterfaceWithInvalidAddr) Addrs(intf *net.Interface) ([]net.Addr, error) {
+	var ifat []net.Addr = []net.Addr{addrStruct{val: "10.20.30.40.50/24"}}
+	return ifat, nil
+}
+func (n networkInterfaceWithInvalidAddr) Interfaces() ([]net.Interface, error) {
+	return []net.Interface{upIntf}, nil
+}
+
+func TestGetIPFromInterface(t *testing.T) {
+	testCases := []struct {
+		tcase      string
+		nwname     string
+		family     AddressFamily
+		nw         networkInterfacer
+		expected   net.IP
+		errStrFrag string
+	}{
+		{"ipv4", "eth3", familyIPv4, validNetworkInterface{}, net.ParseIP("10.254.71.145"), ""},
+		{"ipv6", "eth3", familyIPv6, ipv6NetworkInterface{}, net.ParseIP("2001::200"), ""},
+		{"no ipv4", "eth3", familyIPv4, ipv6NetworkInterface{}, nil, ""},
+		{"no ipv6", "eth3", familyIPv6, validNetworkInterface{}, nil, ""},
+		{"I/F down", "eth3", familyIPv4, downNetworkInterface{}, nil, ""},
+		{"I/F get fail", "eth3", familyIPv4, noNetworkInterface{}, nil, "no such network interface"},
+		{"fail get addr", "eth3", familyIPv4, networkInterfaceFailGetAddrs{}, nil, "unable to get Addrs"},
+		{"bad addr", "eth3", familyIPv4, networkInterfaceWithInvalidAddr{}, nil, "invalid CIDR"},
+	}
+	for _, tc := range testCases {
+		ip, err := getIPFromInterface(tc.nwname, tc.family, tc.nw)
+		if err != nil {
+			if !strings.Contains(err.Error(), tc.errStrFrag) {
+				t.Errorf("case[%s]: Error string %q does not contain %q", tc.tcase, err, tc.errStrFrag)
+			}
+		} else if tc.errStrFrag != "" {
+			t.Errorf("case[%s]: Error %q expected, but not seen", tc.tcase, tc.errStrFrag)
+		} else if !ip.Equal(tc.expected) {
+			t.Errorf("case[%v]: expected %v, got %+v .err : %v", tc.tcase, tc.expected, ip, err)
+		}
+	}
+}
+
+func TestGetIPFromLoopbackInterface(t *testing.T) {
+	testCases := []struct {
+		tcase      string
+		family     AddressFamily
+		nw         networkInterfacer
+		expected   net.IP
+		errStrFrag string
+	}{
+		{"ipv4", familyIPv4, linkLocalLoopbackNetworkInterface{}, net.ParseIP("10.1.1.1"), ""},
+		{"ipv6", familyIPv6, linkLocalLoopbackNetworkInterface{}, net.ParseIP("fd00:1:1::1"), ""},
+		{"no global ipv4", familyIPv4, loopbackNetworkInterface{}, nil, ""},
+		{"no global ipv6", familyIPv6, loopbackNetworkInterface{}, nil, ""},
+	}
+	for _, tc := range testCases {
+		ip, err := getIPFromLoopbackInterface(tc.family, tc.nw)
+		if err != nil {
+			if !strings.Contains(err.Error(), tc.errStrFrag) {
+				t.Errorf("case[%s]: Error string %q does not contain %q", tc.tcase, err, tc.errStrFrag)
+			}
+		} else if tc.errStrFrag != "" {
+			t.Errorf("case[%s]: Error %q expected, but seen %v", tc.tcase, tc.errStrFrag, err)
+		} else if !ip.Equal(tc.expected) {
+			t.Errorf("case[%v]: expected %v, got %+v .err : %v", tc.tcase, tc.expected, ip, err)
+		}
+	}
+}
+
+func TestChooseHostInterfaceFromRoute(t *testing.T) {
+	testCases := []struct {
+		tcase    string
+		routes   []Route
+		nw       networkInterfacer
+		order    AddressFamilyPreference
+		expected net.IP
+	}{
+		{"single-stack ipv4", routeV4, validNetworkInterface{}, preferIPv4, net.ParseIP("10.254.71.145")},
+		{"single-stack ipv4, prefer v6", routeV4, validNetworkInterface{}, preferIPv6, net.ParseIP("10.254.71.145")},
+		{"single-stack ipv6", routeV6, ipv6NetworkInterface{}, preferIPv4, net.ParseIP("2001::200")},
+		{"single-stack ipv6, prefer v6", routeV6, ipv6NetworkInterface{}, preferIPv6, net.ParseIP("2001::200")},
+		{"dual stack", bothRoutes, v4v6NetworkInterface{}, preferIPv4, net.ParseIP("10.254.71.145")},
+		{"dual stack, prefer v6", bothRoutes, v4v6NetworkInterface{}, preferIPv6, net.ParseIP("2001::10")},
+		{"LLA and loopback with global, IPv4", routeV4, linkLocalLoopbackNetworkInterface{}, preferIPv4, net.ParseIP("10.1.1.1")},
+		{"LLA and loopback with global, IPv6", routeV6, linkLocalLoopbackNetworkInterface{}, preferIPv6, net.ParseIP("fd00:1:1::1")},
+		{"LLA and loopback with global, dual stack prefer IPv4", bothRoutes, linkLocalLoopbackNetworkInterface{}, preferIPv4, net.ParseIP("10.1.1.1")},
+		{"LLA and loopback with global, dual stack prefer IPv6", bothRoutes, linkLocalLoopbackNetworkInterface{}, preferIPv6, net.ParseIP("fd00:1:1::1")},
+		{"LLA and loopback with global, no routes", noRoutes, linkLocalLoopbackNetworkInterface{}, preferIPv6, nil},
+		{"interface and loopback with global, IPv4", routeV4, globalsNetworkInterface{}, preferIPv4, net.ParseIP("192.168.1.1")},
+		{"interface and loopback with global, IPv6", routeV6, globalsNetworkInterface{}, preferIPv6, net.ParseIP("fd00::200")},
+		{"interface and loopback with global, dual stack prefer IPv4", bothRoutes, globalsNetworkInterface{}, preferIPv4, net.ParseIP("192.168.1.1")},
+		{"interface and loopback with global, dual stack prefer IPv6", bothRoutes, globalsNetworkInterface{}, preferIPv6, net.ParseIP("fd00::200")},
+		{"interface and loopback with global, no routes", noRoutes, globalsNetworkInterface{}, preferIPv6, nil},
+		{"all LLA", routeV4, networkInterfaceWithOnlyLinkLocals{}, preferIPv4, nil},
+		{"no routes", noRoutes, validNetworkInterface{}, preferIPv4, nil},
+		{"fail get IP", routeV4, networkInterfaceFailGetAddrs{}, preferIPv4, nil},
+	}
+	for _, tc := range testCases {
+		ip, err := chooseHostInterfaceFromRoute(tc.routes, tc.nw, tc.order)
+		if !ip.Equal(tc.expected) {
+			t.Errorf("case[%v]: expected %v, got %+v .err : %v", tc.tcase, tc.expected, ip, err)
+		}
+	}
+}
+
+func TestMemberOf(t *testing.T) {
+	testCases := []struct {
+		tcase    string
+		ip       net.IP
+		family   AddressFamily
+		expected bool
+	}{
+		{"ipv4 is 4", net.ParseIP("10.20.30.40"), familyIPv4, true},
+		{"ipv4 is 6", net.ParseIP("10.10.10.10"), familyIPv6, false},
+		{"ipv6 is 4", net.ParseIP("2001::100"), familyIPv4, false},
+		{"ipv6 is 6", net.ParseIP("2001::100"), familyIPv6, true},
+	}
+	for _, tc := range testCases {
+		if memberOf(tc.ip, tc.family) != tc.expected {
+			t.Errorf("case[%s]: expected %+v", tc.tcase, tc.expected)
+		}
+	}
+}
+
+func TestGetIPFromHostInterfaces(t *testing.T) {
+	testCases := []struct {
+		tcase      string
+		nw         networkInterfacer
+		order      AddressFamilyPreference
+		expected   net.IP
+		errStrFrag string
+	}{
+		{"fail get I/Fs", failGettingNetworkInterface{}, preferIPv4, nil, "failed getting all interfaces"},
+		{"no interfaces", noNetworkInterface{}, preferIPv4, nil, "no interfaces"},
+		{"I/F not up", downNetworkInterface{}, preferIPv4, nil, "no acceptable"},
+		{"loopback only", loopbackNetworkInterface{}, preferIPv4, nil, "no acceptable"},
+		{"P2P I/F only", p2pNetworkInterface{}, preferIPv4, nil, "no acceptable"},
+		{"fail get addrs", networkInterfaceFailGetAddrs{}, preferIPv4, nil, "unable to get Addrs"},
+		{"no addresses", networkInterfaceWithNoAddrs{}, preferIPv4, nil, "no acceptable"},
+		{"invalid addr", networkInterfaceWithInvalidAddr{}, preferIPv4, nil, "invalid CIDR"},
+		{"no matches", networkInterfaceWithOnlyLinkLocals{}, preferIPv4, nil, "no acceptable"},
+		{"single-stack ipv4", validNetworkInterface{}, preferIPv4, net.ParseIP("10.254.71.145"), ""},
+		{"single-stack ipv4, prefer ipv6", validNetworkInterface{}, preferIPv6, net.ParseIP("10.254.71.145"), ""},
+		{"single-stack ipv6", ipv6NetworkInterface{}, preferIPv4, net.ParseIP("2001::200"), ""},
+		{"single-stack ipv6, prefer ipv6", ipv6NetworkInterface{}, preferIPv6, net.ParseIP("2001::200"), ""},
+		{"dual stack", v4v6NetworkInterface{}, preferIPv4, net.ParseIP("10.254.71.145"), ""},
+		{"dual stack, prefer ipv6", v4v6NetworkInterface{}, preferIPv6, net.ParseIP("2001::10"), ""},
+	}
+
+	for _, tc := range testCases {
+		ip, err := chooseIPFromHostInterfaces(tc.nw, tc.order)
+		if !ip.Equal(tc.expected) {
+			t.Errorf("case[%s]: expected %+v, got %+v with err : %v", tc.tcase, tc.expected, ip, err)
+		}
+		if err != nil && !strings.Contains(err.Error(), tc.errStrFrag) {
+			t.Errorf("case[%s]: unable to find %q in error string %q", tc.tcase, tc.errStrFrag, err.Error())
+		}
+	}
+}
+
+func makeRouteFile(content string) (*os.File, error) {
+	routeFile, err := os.CreateTemp("", "route")
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := routeFile.Write([]byte(content)); err != nil {
+		return routeFile, err
+	}
+	err = routeFile.Close()
+	return routeFile, err
+}
+
+func TestFailGettingIPv4Routes(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("Skipped on Windows.")
+	}
+
+	defer func() { v4File.name = ipv4RouteFile }()
+
+	// Try failure to open file (should not occur, as caller ensures we have IPv4 route file, but being thorough)
+	v4File.name = "no-such-file"
+	errStrFrag := "no such file"
+	_, err := v4File.extract()
+	if err == nil {
+		t.Errorf("Expected error trying to read non-existent v4 route file")
+	}
+	if !strings.Contains(err.Error(), errStrFrag) {
+		t.Errorf("Unable to find %q in error string %q", errStrFrag, err.Error())
+	}
+}
+
+func TestFailGettingIPv6Routes(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("Skipped on Windows.")
+	}
+
+	defer func() { v6File.name = ipv6RouteFile }()
+
+	// Try failure to open file (this would be ignored by caller)
+	v6File.name = "no-such-file"
+	errStrFrag := "no such file"
+	_, err := v6File.extract()
+	if err == nil {
+		t.Errorf("Expected error trying to read non-existent v6 route file")
+	}
+	if !strings.Contains(err.Error(), errStrFrag) {
+		t.Errorf("Unable to find %q in error string %q", errStrFrag, err.Error())
+	}
+}
+
+func TestGetAllDefaultRoutesFailNoV4RouteFile(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("Skipped on Windows.")
+	}
+
+	defer func() { v4File.name = ipv4RouteFile }()
+
+	// Should not occur, as caller ensures we have IPv4 route file, but being thorough
+	v4File.name = "no-such-file"
+	errStrFrag := "no such file"
+	_, err := getAllDefaultRoutes()
+	if err == nil {
+		t.Errorf("Expected error trying to read non-existent v4 route file")
+	}
+	if !strings.Contains(err.Error(), errStrFrag) {
+		t.Errorf("Unable to find %q in error string %q", errStrFrag, err.Error())
+	}
+}
+
+func TestGetAllDefaultRoutes(t *testing.T) {
+	testCases := []struct {
+		tcase      string
+		v4Info     string
+		v6Info     string
+		count      int
+		expected   []Route
+		errStrFrag string
+	}{
+		{"no routes", noInternetConnection, v6noDefaultRoutes, 0, nil, "no default routes"},
+		{"only v4 route", gatewayfirst, v6noDefaultRoutes, 1, routeV4, ""},
+		{"only v6 route", noInternetConnection, v6gatewayfirst, 1, routeV6, ""},
+		{"v4 and v6 routes", gatewayfirst, v6gatewayfirst, 2, bothRoutes, ""},
+	}
+	defer func() {
+		v4File.name = ipv4RouteFile
+		v6File.name = ipv6RouteFile
+	}()
+
+	for _, tc := range testCases {
+		routeFile, err := makeRouteFile(tc.v4Info)
+		if routeFile != nil {
+			defer os.Remove(routeFile.Name())
+		}
+		if err != nil {
+			t.Errorf("case[%s]: test setup failure for IPv4 route file: %v", tc.tcase, err)
+		}
+		v4File.name = routeFile.Name()
+		v6routeFile, err := makeRouteFile(tc.v6Info)
+		if v6routeFile != nil {
+			defer os.Remove(v6routeFile.Name())
+		}
+		if err != nil {
+			t.Errorf("case[%s]: test setup failure for IPv6 route file: %v", tc.tcase, err)
+		}
+		v6File.name = v6routeFile.Name()
+
+		routes, err := getAllDefaultRoutes()
+		if err != nil {
+			if !strings.Contains(err.Error(), tc.errStrFrag) {
+				t.Errorf("case[%s]: Error string %q does not contain %q", tc.tcase, err, tc.errStrFrag)
+			}
+		} else if tc.errStrFrag != "" {
+			t.Errorf("case[%s]: Error %q expected, but not seen", tc.tcase, tc.errStrFrag)
+		} else {
+			if tc.count != len(routes) {
+				t.Errorf("case[%s]: expected %d routes, have %v", tc.tcase, tc.count, routes)
+			}
+			for i, expected := range tc.expected {
+				if !expected.Gateway.Equal(routes[i].Gateway) {
+					t.Errorf("case[%s]: at %d expected %v, got %v .err : %v", tc.tcase, i, tc.expected, routes, err)
+				}
+				zeroIP := net.IPv4zero
+				if expected.Family == familyIPv6 {
+					zeroIP = net.IPv6zero
+				}
+				if !routes[i].Destination.Equal(zeroIP) {
+					t.Errorf("case[%s}: at %d destination is not for default route (not %v)", tc.tcase, i, zeroIP)
+				}
+			}
+		}
+	}
+}

--- a/internal/cri/netutil/ipfamily.go
+++ b/internal/cri/netutil/ipfamily.go
@@ -1,0 +1,197 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"fmt"
+	"net"
+)
+
+// IPFamily refers to a specific family if not empty, i.e. "4" or "6".
+type IPFamily string
+
+// Constants for valid IPFamilys:
+const (
+	IPFamilyUnknown IPFamily = ""
+
+	IPv4 IPFamily = "4"
+	IPv6 IPFamily = "6"
+)
+
+// IsDualStackIPs returns true if:
+// - all elements of ips are valid
+// - at least one IP from each family (v4 and v6) is present
+func IsDualStackIPs(ips []net.IP) (bool, error) {
+	v4Found := false
+	v6Found := false
+	for i, ip := range ips {
+		switch IPFamilyOf(ip) {
+		case IPv4:
+			v4Found = true
+		case IPv6:
+			v6Found = true
+		default:
+			return false, fmt.Errorf("invalid IP[%d]: %v", i, ip)
+		}
+	}
+
+	return (v4Found && v6Found), nil
+}
+
+// IsDualStackIPStrings returns true if:
+// - all elements of ips can be parsed as IPs
+// - at least one IP from each family (v4 and v6) is present
+func IsDualStackIPStrings(ips []string) (bool, error) {
+	parsedIPs := make([]net.IP, 0, len(ips))
+	for i, ip := range ips {
+		parsedIP := net.ParseIP(ip)
+		if parsedIP == nil {
+			return false, fmt.Errorf("invalid IP[%d]: %v", i, ip)
+		}
+		parsedIPs = append(parsedIPs, parsedIP)
+	}
+	return IsDualStackIPs(parsedIPs)
+}
+
+// IsDualStackCIDRs returns true if:
+// - all elements of cidrs are non-nil
+// - at least one CIDR from each family (v4 and v6) is present
+func IsDualStackCIDRs(cidrs []*net.IPNet) (bool, error) {
+	v4Found := false
+	v6Found := false
+	for i, cidr := range cidrs {
+		switch IPFamilyOfCIDR(cidr) {
+		case IPv4:
+			v4Found = true
+		case IPv6:
+			v6Found = true
+		default:
+			return false, fmt.Errorf("invalid CIDR[%d]: %v", i, cidr)
+		}
+	}
+
+	return (v4Found && v6Found), nil
+}
+
+// IsDualStackCIDRStrings returns if
+// - all elements of cidrs can be parsed as CIDRs
+// - at least one CIDR from each family (v4 and v6) is present
+func IsDualStackCIDRStrings(cidrs []string) (bool, error) {
+	parsedCIDRs, err := ParseCIDRs(cidrs)
+	if err != nil {
+		return false, err
+	}
+	return IsDualStackCIDRs(parsedCIDRs)
+}
+
+// IPFamilyOf returns the IP family of ip, or IPFamilyUnknown if it is invalid.
+func IPFamilyOf(ip net.IP) IPFamily {
+	switch {
+	case ip.To4() != nil:
+		return IPv4
+	case ip.To16() != nil:
+		return IPv6
+	default:
+		return IPFamilyUnknown
+	}
+}
+
+// IPFamilyOfString returns the IP family of ip, or IPFamilyUnknown if ip cannot
+// be parsed as an IP.
+func IPFamilyOfString(ip string) IPFamily {
+	return IPFamilyOf(net.ParseIP(ip))
+}
+
+// IPFamilyOfCIDR returns the IP family of cidr.
+func IPFamilyOfCIDR(cidr *net.IPNet) IPFamily {
+	if cidr == nil {
+		return IPFamilyUnknown
+	}
+	return IPFamilyOf(cidr.IP)
+}
+
+// IPFamilyOfCIDRString returns the IP family of cidr.
+func IPFamilyOfCIDRString(cidr string) IPFamily {
+	ip, _, _ := net.ParseCIDR(cidr)
+	return IPFamilyOf(ip)
+}
+
+// IsIPv6 returns true if netIP is IPv6 (and false if it is IPv4, nil, or invalid).
+func IsIPv6(netIP net.IP) bool {
+	return IPFamilyOf(netIP) == IPv6
+}
+
+// IsIPv6String returns true if ip contains a single IPv6 address and nothing else. It
+// returns false if ip is an empty string, an IPv4 address, or anything else that is not a
+// single IPv6 address.
+func IsIPv6String(ip string) bool {
+	return IPFamilyOfString(ip) == IPv6
+}
+
+// IsIPv6CIDR returns true if a cidr is a valid IPv6 CIDR. It returns false if cidr is
+// nil or an IPv4 CIDR. Its behavior is not defined if cidr is invalid.
+func IsIPv6CIDR(cidr *net.IPNet) bool {
+	return IPFamilyOfCIDR(cidr) == IPv6
+}
+
+// IsIPv6CIDRString returns true if cidr contains a single IPv6 CIDR and nothing else. It
+// returns false if cidr is an empty string, an IPv4 CIDR, or anything else that is not a
+// single valid IPv6 CIDR.
+func IsIPv6CIDRString(cidr string) bool {
+	return IPFamilyOfCIDRString(cidr) == IPv6
+}
+
+// IsIPv4 returns true if netIP is IPv4 (and false if it is IPv6, nil, or invalid).
+func IsIPv4(netIP net.IP) bool {
+	return IPFamilyOf(netIP) == IPv4
+}
+
+// IsIPv4String returns true if ip contains a single IPv4 address and nothing else. It
+// returns false if ip is an empty string, an IPv6 address, or anything else that is not a
+// single IPv4 address.
+func IsIPv4String(ip string) bool {
+	return IPFamilyOfString(ip) == IPv4
+}
+
+// IsIPv4CIDR returns true if cidr is a valid IPv4 CIDR. It returns false if cidr is nil
+// or an IPv6 CIDR. Its behavior is not defined if cidr is invalid.
+func IsIPv4CIDR(cidr *net.IPNet) bool {
+	return IPFamilyOfCIDR(cidr) == IPv4
+}
+
+// IsIPv4CIDRString returns true if cidr contains a single IPv4 CIDR and nothing else. It
+// returns false if cidr is an empty string, an IPv6 CIDR, or anything else that is not a
+// single valid IPv4 CIDR.
+func IsIPv4CIDRString(cidr string) bool {
+	return IPFamilyOfCIDRString(cidr) == IPv4
+}

--- a/internal/cri/netutil/ipfamily_test.go
+++ b/internal/cri/netutil/ipfamily_test.go
@@ -1,0 +1,675 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"fmt"
+	"net"
+	"testing"
+)
+
+func TestDualStackIPs(t *testing.T) {
+	testCases := []struct {
+		ips            []string
+		errMessage     string
+		expectedResult bool
+		expectError    bool
+	}{
+		{
+			ips:            []string{"1.1.1.1"},
+			errMessage:     "should fail because length is not at least 2",
+			expectedResult: false,
+			expectError:    false,
+		},
+		{
+			ips:            []string{},
+			errMessage:     "should fail because length is not at least 2",
+			expectedResult: false,
+			expectError:    false,
+		},
+		{
+			ips:            []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"},
+			errMessage:     "should fail because all are v4",
+			expectedResult: false,
+			expectError:    false,
+		},
+		{
+			ips:            []string{"fd92:20ba:ca:34f7:ffff:ffff:ffff:ffff", "fd92:20ba:ca:34f7:ffff:ffff:ffff:fff0", "fd92:20ba:ca:34f7:ffff:ffff:ffff:fff1"},
+			errMessage:     "should fail because all are v6",
+			expectedResult: false,
+			expectError:    false,
+		},
+		{
+			ips:            []string{"1.1.1.1", "not-a-valid-ip"},
+			errMessage:     "should fail because 2nd ip is invalid",
+			expectedResult: false,
+			expectError:    true,
+		},
+		{
+			ips:            []string{"not-a-valid-ip", "fd92:20ba:ca:34f7:ffff:ffff:ffff:ffff"},
+			errMessage:     "should fail because 1st ip is invalid",
+			expectedResult: false,
+			expectError:    true,
+		},
+		{
+			ips:            []string{"1.1.1.1", "fd92:20ba:ca:34f7:ffff:ffff:ffff:ffff"},
+			errMessage:     "expected success, but found failure",
+			expectedResult: true,
+			expectError:    false,
+		},
+		{
+			ips:            []string{"fd92:20ba:ca:34f7:ffff:ffff:ffff:ffff", "1.1.1.1", "fd92:20ba:ca:34f7:ffff:ffff:ffff:fff0"},
+			errMessage:     "expected success, but found failure",
+			expectedResult: true,
+			expectError:    false,
+		},
+		{
+			ips:            []string{"1.1.1.1", "fd92:20ba:ca:34f7:ffff:ffff:ffff:ffff", "10.0.0.0"},
+			errMessage:     "expected success, but found failure",
+			expectedResult: true,
+			expectError:    false,
+		},
+		{
+			ips:            []string{"fd92:20ba:ca:34f7:ffff:ffff:ffff:ffff", "1.1.1.1"},
+			errMessage:     "expected success, but found failure",
+			expectedResult: true,
+			expectError:    false,
+		},
+	}
+	// for each test case, test the regular func and the string func
+	for _, tc := range testCases {
+		dualStack, err := IsDualStackIPStrings(tc.ips)
+		if err == nil && tc.expectError {
+			t.Errorf("%s", tc.errMessage)
+			continue
+		}
+		if err != nil && !tc.expectError {
+			t.Errorf("failed to run test case for %v, error: %v", tc.ips, err)
+			continue
+		}
+		if dualStack != tc.expectedResult {
+			t.Errorf("%v for %v", tc.errMessage, tc.ips)
+		}
+	}
+
+	for _, tc := range testCases {
+		ips := make([]net.IP, 0, len(tc.ips))
+		for _, ip := range tc.ips {
+			parsedIP := net.ParseIP(ip)
+			ips = append(ips, parsedIP)
+		}
+		dualStack, err := IsDualStackIPs(ips)
+		if err == nil && tc.expectError {
+			t.Errorf("%s", tc.errMessage)
+			continue
+		}
+		if err != nil && !tc.expectError {
+			t.Errorf("failed to run test case for %v, error: %v", tc.ips, err)
+			continue
+		}
+		if dualStack != tc.expectedResult {
+			t.Errorf("%v for %v", tc.errMessage, tc.ips)
+		}
+	}
+}
+
+func TestDualStackCIDRs(t *testing.T) {
+	testCases := []struct {
+		cidrs          []string
+		errMessage     string
+		expectedResult bool
+		expectError    bool
+	}{
+		{
+			cidrs:          []string{"10.10.10.10/8"},
+			errMessage:     "should fail because length is not at least 2",
+			expectedResult: false,
+			expectError:    false,
+		},
+		{
+			cidrs:          []string{},
+			errMessage:     "should fail because length is not at least 2",
+			expectedResult: false,
+			expectError:    false,
+		},
+		{
+			cidrs:          []string{"10.10.10.10/8", "20.20.20.20/8", "30.30.30.30/8"},
+			errMessage:     "should fail because all cidrs are v4",
+			expectedResult: false,
+			expectError:    false,
+		},
+		{
+			cidrs:          []string{"2000::/10", "3000::/10"},
+			errMessage:     "should fail because all cidrs are v6",
+			expectedResult: false,
+			expectError:    false,
+		},
+		{
+			cidrs:          []string{"10.10.10.10/8", "not-a-valid-cidr"},
+			errMessage:     "should fail because 2nd cidr is invalid",
+			expectedResult: false,
+			expectError:    true,
+		},
+		{
+			cidrs:          []string{"not-a-valid-ip", "2000::/10"},
+			errMessage:     "should fail because 1st cidr is invalid",
+			expectedResult: false,
+			expectError:    true,
+		},
+		{
+			cidrs:          []string{"10.10.10.10/8", "2000::/10"},
+			errMessage:     "expected success, but found failure",
+			expectedResult: true,
+			expectError:    false,
+		},
+		{
+			cidrs:          []string{"2000::/10", "10.10.10.10/8"},
+			errMessage:     "expected success, but found failure",
+			expectedResult: true,
+			expectError:    false,
+		},
+		{
+			cidrs:          []string{"2000::/10", "10.10.10.10/8", "3000::/10"},
+			errMessage:     "expected success, but found failure",
+			expectedResult: true,
+			expectError:    false,
+		},
+	}
+
+	// for each test case, test the regular func and the string func
+	for _, tc := range testCases {
+		dualStack, err := IsDualStackCIDRStrings(tc.cidrs)
+		if err == nil && tc.expectError {
+			t.Errorf("%s", tc.errMessage)
+			continue
+		}
+		if err != nil && !tc.expectError {
+			t.Errorf("failed to run test case for %v, error: %v", tc.cidrs, err)
+			continue
+		}
+		if dualStack != tc.expectedResult {
+			t.Errorf("%v for %v", tc.errMessage, tc.cidrs)
+		}
+	}
+
+	for _, tc := range testCases {
+		cidrs := make([]*net.IPNet, 0, len(tc.cidrs))
+		for _, cidr := range tc.cidrs {
+			_, parsedCIDR, _ := net.ParseCIDR(cidr)
+			cidrs = append(cidrs, parsedCIDR)
+		}
+
+		dualStack, err := IsDualStackCIDRs(cidrs)
+		if err == nil && tc.expectError {
+			t.Errorf("%s", tc.errMessage)
+			continue
+		}
+		if err != nil && !tc.expectError {
+			t.Errorf("failed to run test case for %v, error: %v", tc.cidrs, err)
+			continue
+		}
+		if dualStack != tc.expectedResult {
+			t.Errorf("%v for %v", tc.errMessage, tc.cidrs)
+		}
+	}
+}
+
+func TestIPFamilyOfString(t *testing.T) {
+	testCases := []struct {
+		desc   string
+		ip     string
+		family IPFamily
+	}{
+		{
+			desc:   "IPv4 1",
+			ip:     "127.0.0.1",
+			family: IPv4,
+		},
+		{
+			desc:   "IPv4 2",
+			ip:     "192.168.0.0",
+			family: IPv4,
+		},
+		{
+			desc:   "IPv4 3",
+			ip:     "1.2.3.4",
+			family: IPv4,
+		},
+		//{ // TODO: mikebrow work with networking team to establish if this divert from golang is nec.
+		//	desc:   "IPv4 with leading 0s is accepted",
+		//	ip:     "001.002.003.004",
+		//	family: IPv4,
+		//},
+		{
+			desc:   "IPv4 encoded as IPv6 is IPv4",
+			ip:     "::FFFF:1.2.3.4",
+			family: IPv4,
+		},
+		{
+			desc:   "IPv6 1",
+			ip:     "::1",
+			family: IPv6,
+		},
+		{
+			desc:   "IPv6 2",
+			ip:     "fd00::600d:f00d",
+			family: IPv6,
+		},
+		{
+			desc:   "IPv6 3",
+			ip:     "2001:db8::5",
+			family: IPv6,
+		},
+		{
+			desc:   "IPv4 with out-of-range octets is not accepted",
+			ip:     "1.2.3.400",
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "IPv6 with out-of-range segment is not accepted",
+			ip:     "2001:db8::10005",
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "IPv4 with empty octet is not accepted",
+			ip:     "1.2..4",
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "IPv6 with multiple empty segments is not accepted",
+			ip:     "2001::db8::5",
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "IPv4 CIDR is not accepted",
+			ip:     "1.2.3.4/32",
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "IPv6 CIDR is not accepted",
+			ip:     "2001:db8::/64",
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "IPv4:port is not accepted",
+			ip:     "1.2.3.4:80",
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "[IPv6] with brackets is not accepted",
+			ip:     "[2001:db8::5]",
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "[IPv6]:port is not accepted",
+			ip:     "[2001:db8::5]:80",
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "IPv6%zone is not accepted",
+			ip:     "fe80::1234%eth0",
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "IPv4 with leading whitespace is not accepted",
+			ip:     " 1.2.3.4",
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "IPv4 with trailing whitespace is not accepted",
+			ip:     "1.2.3.4 ",
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "IPv6 with leading whitespace is not accepted",
+			ip:     " 2001:db8::5",
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "IPv6 with trailing whitespace is not accepted",
+			ip:     " 2001:db8::5",
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "random unparseable string",
+			ip:     "bad ip",
+			family: IPFamilyUnknown,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			family := IPFamilyOfString(tc.ip)
+			isIPv4 := IsIPv4String(tc.ip)
+			isIPv6 := IsIPv6String(tc.ip)
+
+			if family != tc.family {
+				t.Errorf("Expect %q family %q, got %q", tc.ip, tc.family, family)
+			}
+			if isIPv4 != (tc.family == IPv4) {
+				t.Errorf("Expect %q ipv4 %v, got %v", tc.ip, tc.family == IPv4, isIPv6)
+			}
+			if isIPv6 != (tc.family == IPv6) {
+				t.Errorf("Expect %q ipv6 %v, got %v", tc.ip, tc.family == IPv6, isIPv6)
+			}
+		})
+	}
+}
+
+// This is specifically for testing "the kinds of net.IP values returned by net.ParseCIDR()"
+func mustParseCIDRIP(cidrstr string) net.IP {
+	ip, _, err := net.ParseCIDR(cidrstr)
+	if ip == nil {
+		panic(fmt.Sprintf("bad test case: %q should have been parseable: %v", cidrstr, err))
+	}
+	return ip
+}
+
+// This is specifically for testing "the kinds of net.IP values returned by net.ParseCIDR()"
+func mustParseCIDRBase(cidrstr string) net.IP {
+	_, cidr, err := net.ParseCIDR(cidrstr)
+	if cidr == nil {
+		panic(fmt.Sprintf("bad test case: %q should have been parseable: %v", cidrstr, err))
+	}
+	return cidr.IP
+}
+
+// This is specifically for testing "the kinds of net.IP values returned by net.ParseCIDR()"
+func mustParseCIDRMask(cidrstr string) net.IPMask {
+	_, cidr, err := net.ParseCIDR(cidrstr)
+	if cidr == nil {
+		panic(fmt.Sprintf("bad test case: %q should have been parseable: %v", cidrstr, err))
+	}
+	return cidr.Mask
+}
+
+func TestIsIPFamilyOf(t *testing.T) {
+	testCases := []struct {
+		desc   string
+		ip     net.IP
+		family IPFamily
+	}{
+		{
+			desc:   "IPv4 all-zeros",
+			ip:     net.IPv4zero,
+			family: IPv4,
+		},
+		{
+			desc:   "IPv6 all-zeros",
+			ip:     net.IPv6zero,
+			family: IPv6,
+		},
+		{
+			desc:   "IPv4 broadcast",
+			ip:     net.IPv4bcast,
+			family: IPv4,
+		},
+		{
+			desc:   "IPv4 loopback",
+			ip:     net.ParseIP("127.0.0.1"),
+			family: IPv4,
+		},
+		{
+			desc:   "IPv6 loopback",
+			ip:     net.IPv6loopback,
+			family: IPv6,
+		},
+		{
+			desc:   "IPv4 1",
+			ip:     net.ParseIP("10.20.40.40"),
+			family: IPv4,
+		},
+		{
+			desc:   "IPv4 2",
+			ip:     net.ParseIP("172.17.3.0"),
+			family: IPv4,
+		},
+		{
+			desc:   "IPv4 encoded as IPv6 is IPv4",
+			ip:     net.ParseIP("::FFFF:1.2.3.4"),
+			family: IPv4,
+		},
+		{
+			desc:   "IPv6 1",
+			ip:     net.ParseIP("fd00::600d:f00d"),
+			family: IPv6,
+		},
+		{
+			desc:   "IPv6 2",
+			ip:     net.ParseIP("2001:db8::5"),
+			family: IPv6,
+		},
+		{
+			desc:   "IP from IPv4 CIDR is IPv4",
+			ip:     mustParseCIDRIP("192.168.1.1/24"),
+			family: IPv4,
+		},
+		{
+			desc:   "CIDR base IP from IPv4 CIDR is IPv4",
+			ip:     mustParseCIDRBase("192.168.1.1/24"),
+			family: IPv4,
+		},
+		{
+			desc:   "CIDR mask from IPv4 CIDR is IPv4",
+			ip:     net.IP(mustParseCIDRMask("192.168.1.1/24")),
+			family: IPv4,
+		},
+		{
+			desc:   "IP from IPv6 CIDR is IPv6",
+			ip:     mustParseCIDRIP("2001:db8::5/64"),
+			family: IPv6,
+		},
+		{
+			desc:   "CIDR base IP from IPv6 CIDR is IPv6",
+			ip:     mustParseCIDRBase("2001:db8::5/64"),
+			family: IPv6,
+		},
+		{
+			desc:   "CIDR mask from IPv6 CIDR is IPv6",
+			ip:     net.IP(mustParseCIDRMask("2001:db8::5/64")),
+			family: IPv6,
+		},
+		{
+			desc:   "nil is accepted, but is neither IPv4 nor IPv6",
+			ip:     nil,
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "invalid empty binary net.IP",
+			ip:     net.IP([]byte{}),
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "invalid short binary net.IP",
+			ip:     net.IP([]byte{1, 2, 3}),
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "invalid medium-length binary net.IP",
+			ip:     net.IP([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "invalid long binary net.IP",
+			ip:     net.IP([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18}),
+			family: IPFamilyUnknown,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			family := IPFamilyOf(tc.ip)
+			isIPv4 := IsIPv4(tc.ip)
+			isIPv6 := IsIPv6(tc.ip)
+
+			if family != tc.family {
+				t.Errorf("Expect family %q, got %q", tc.family, family)
+			}
+			if isIPv4 != (tc.family == IPv4) {
+				t.Errorf("Expect ipv4 %v, got %v", tc.family == IPv4, isIPv6)
+			}
+			if isIPv6 != (tc.family == IPv6) {
+				t.Errorf("Expect ipv6 %v, got %v", tc.family == IPv6, isIPv6)
+			}
+		})
+	}
+}
+
+func TestIPFamilyOfCIDR(t *testing.T) {
+	testCases := []struct {
+		desc   string
+		cidr   string
+		family IPFamily
+	}{
+		{
+			desc:   "IPv4 CIDR 1",
+			cidr:   "10.0.0.0/8",
+			family: IPv4,
+		},
+		{
+			desc:   "IPv4 CIDR 2",
+			cidr:   "192.168.0.0/16",
+			family: IPv4,
+		},
+		{
+			desc:   "IPv6 CIDR 1",
+			cidr:   "::/1",
+			family: IPv6,
+		},
+		{
+			desc:   "IPv6 CIDR 2",
+			cidr:   "2000::/10",
+			family: IPv6,
+		},
+		{
+			desc:   "IPv6 CIDR 3",
+			cidr:   "2001:db8::/32",
+			family: IPv6,
+		},
+		{
+			desc:   "bad CIDR",
+			cidr:   "foo",
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "IPv4 with out-of-range octets is not accepted",
+			cidr:   "1.2.3.400/32",
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "IPv6 with out-of-range segment is not accepted",
+			cidr:   "2001:db8::10005/64",
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "IPv4 with out-of-range mask length is not accepted",
+			cidr:   "1.2.3.4/64",
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "IPv6 with out-of-range mask length is not accepted",
+			cidr:   "2001:db8::5/192",
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "IPv4 with empty octet is not accepted",
+			cidr:   "1.2..4/32",
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "IPv6 with multiple empty segments is not accepted",
+			cidr:   "2001::db8::5/64",
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "IPv4 IP is not CIDR",
+			cidr:   "192.168.0.0",
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "IPv6 IP is not CIDR",
+			cidr:   "2001:db8::",
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "IPv4 CIDR with leading whitespace is not accepted",
+			cidr:   " 1.2.3.4/32",
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "IPv4 CIDR with trailing whitespace is not accepted",
+			cidr:   "1.2.3.4/32 ",
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "IPv6 CIDR with leading whitespace is not accepted",
+			cidr:   " 2001:db8::5/64",
+			family: IPFamilyUnknown,
+		},
+		{
+			desc:   "IPv6 CIDR with trailing whitespace is not accepted",
+			cidr:   " 2001:db8::5/64",
+			family: IPFamilyUnknown,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			family := IPFamilyOfCIDRString(tc.cidr)
+			isIPv4 := IsIPv4CIDRString(tc.cidr)
+			isIPv6 := IsIPv6CIDRString(tc.cidr)
+
+			if family != tc.family {
+				t.Errorf("Expect family %v, got %v", tc.family, family)
+			}
+			if isIPv4 != (tc.family == IPv4) {
+				t.Errorf("Expect %q ipv4 %v, got %v", tc.cidr, tc.family == IPv4, isIPv6)
+			}
+			if isIPv6 != (tc.family == IPv6) {
+				t.Errorf("Expect %q ipv6 %v, got %v", tc.cidr, tc.family == IPv6, isIPv6)
+			}
+
+			_, parsed, _ := net.ParseCIDR(tc.cidr)
+			familyParsed := IPFamilyOfCIDR(parsed)
+			isIPv4Parsed := IsIPv4CIDR(parsed)
+			isIPv6Parsed := IsIPv6CIDR(parsed)
+			if familyParsed != family {
+				t.Errorf("%q gives different results for IPFamilyOfCIDR (%v) and IPFamilyOfCIDRString (%v)", tc.cidr, familyParsed, family)
+			}
+			if isIPv4Parsed != isIPv4 {
+				t.Errorf("%q gives different results for IsIPv4CIDR (%v) and IsIPv4CIDRString (%v)", tc.cidr, isIPv4Parsed, isIPv4)
+			}
+			if isIPv6Parsed != isIPv6 {
+				t.Errorf("%q gives different results for IsIPv6CIDR (%v) and IsIPv6CIDRString (%v)", tc.cidr, isIPv6Parsed, isIPv6)
+			}
+		})
+	}
+}

--- a/internal/cri/netutil/ipnet.go
+++ b/internal/cri/netutil/ipnet.go
@@ -1,0 +1,237 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// IPNetSet maps string to net.IPNet.
+type IPNetSet map[string]*net.IPNet
+
+// ParseIPNets parses string slice to IPNetSet.
+func ParseIPNets(specs ...string) (IPNetSet, error) {
+	ipnetset := make(IPNetSet)
+	for _, spec := range specs {
+		spec = strings.TrimSpace(spec)
+		_, ipnet, err := net.ParseCIDR(spec)
+		if err != nil {
+			return nil, err
+		}
+		k := ipnet.String() // In case of normalization
+		ipnetset[k] = ipnet
+	}
+	return ipnetset, nil
+}
+
+// Insert adds items to the set.
+func (s IPNetSet) Insert(items ...*net.IPNet) {
+	for _, item := range items {
+		s[item.String()] = item
+	}
+}
+
+// Delete removes all items from the set.
+func (s IPNetSet) Delete(items ...*net.IPNet) {
+	for _, item := range items {
+		delete(s, item.String())
+	}
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s IPNetSet) Has(item *net.IPNet) bool {
+	_, contained := s[item.String()]
+	return contained
+}
+
+// HasAll returns true if and only if all items are contained in the set.
+func (s IPNetSet) HasAll(items ...*net.IPNet) bool {
+	for _, item := range items {
+		if !s.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// Difference returns a set of objects that are not in s2
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s IPNetSet) Difference(s2 IPNetSet) IPNetSet {
+	result := make(IPNetSet)
+	for k, i := range s {
+		_, found := s2[k]
+		if found {
+			continue
+		}
+		result[k] = i
+	}
+	return result
+}
+
+// StringSlice returns a []string with the String representation of each element in the set.
+// Order is undefined.
+func (s IPNetSet) StringSlice() []string {
+	a := make([]string, 0, len(s))
+	for k := range s {
+		a = append(a, k)
+	}
+	return a
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s IPNetSet) IsSuperset(s2 IPNetSet) bool {
+	for k := range s2 {
+		_, found := s[k]
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s IPNetSet) Equal(s2 IPNetSet) bool {
+	return len(s) == len(s2) && s.IsSuperset(s2)
+}
+
+// Len returns the size of the set.
+func (s IPNetSet) Len() int {
+	return len(s)
+}
+
+// IPSet maps string to net.IP
+type IPSet map[string]net.IP
+
+// ParseIPSet parses string slice to IPSet
+func ParseIPSet(items ...string) (IPSet, error) {
+	ipset := make(IPSet)
+	for _, item := range items {
+		ip := net.ParseIP(strings.TrimSpace(item))
+		if ip == nil {
+			return nil, fmt.Errorf("error parsing IP %q", item)
+		}
+
+		ipset[ip.String()] = ip
+	}
+
+	return ipset, nil
+}
+
+// Insert adds items to the set.
+func (s IPSet) Insert(items ...net.IP) {
+	for _, item := range items {
+		s[item.String()] = item
+	}
+}
+
+// Delete removes all items from the set.
+func (s IPSet) Delete(items ...net.IP) {
+	for _, item := range items {
+		delete(s, item.String())
+	}
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s IPSet) Has(item net.IP) bool {
+	_, contained := s[item.String()]
+	return contained
+}
+
+// HasAll returns true if and only if all items are contained in the set.
+func (s IPSet) HasAll(items ...net.IP) bool {
+	for _, item := range items {
+		if !s.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// Difference returns a set of objects that are not in s2
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s IPSet) Difference(s2 IPSet) IPSet {
+	result := make(IPSet)
+	for k, i := range s {
+		_, found := s2[k]
+		if found {
+			continue
+		}
+		result[k] = i
+	}
+	return result
+}
+
+// StringSlice returns a []string with the String representation of each element in the set.
+// Order is undefined.
+func (s IPSet) StringSlice() []string {
+	a := make([]string, 0, len(s))
+	for k := range s {
+		a = append(a, k)
+	}
+	return a
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s IPSet) IsSuperset(s2 IPSet) bool {
+	for k := range s2 {
+		_, found := s[k]
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s IPSet) Equal(s2 IPSet) bool {
+	return len(s) == len(s2) && s.IsSuperset(s2)
+}
+
+// Len returns the size of the set.
+func (s IPSet) Len() int {
+	return len(s)
+}

--- a/internal/cri/netutil/ipnet_test.go
+++ b/internal/cri/netutil/ipnet_test.go
@@ -1,0 +1,330 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"net"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func parseIPNet(s string) *net.IPNet {
+	_, net, err := net.ParseCIDR(s)
+	if err != nil {
+		panic(err)
+	}
+	return net
+}
+
+func TestIPNets(t *testing.T) {
+	s := IPNetSet{}
+	s2 := IPNetSet{}
+	if len(s) != 0 {
+		t.Errorf("Expected len=0: %d", len(s))
+	}
+	a := parseIPNet("1.0.0.0/8")
+	b := parseIPNet("2.0.0.0/8")
+	c := parseIPNet("3.0.0.0/8")
+	d := parseIPNet("4.0.0.0/8")
+
+	s.Insert(a, b)
+	if len(s) != 2 {
+		t.Errorf("Expected len=2: %d", len(s))
+	}
+	s.Insert(c)
+	if s.Has(d) {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	if !s.Has(a) {
+		t.Errorf("Missing contents: %#v", s)
+	}
+	s.Delete(a)
+	if s.Has(a) {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	s.Insert(a)
+	if s.HasAll(a, b, d) {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	if !s.HasAll(a, b) {
+		t.Errorf("Missing contents: %#v", s)
+	}
+	s2.Insert(a, b, d)
+	if s.IsSuperset(s2) {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	s2.Delete(d)
+	if !s.IsSuperset(s2) {
+		t.Errorf("Missing contents: %#v", s)
+	}
+}
+
+func TestIPNetSetDeleteMultiples(t *testing.T) {
+	s := IPNetSet{}
+	a := parseIPNet("1.0.0.0/8")
+	b := parseIPNet("2.0.0.0/8")
+	c := parseIPNet("3.0.0.0/8")
+
+	s.Insert(a, b, c)
+	if len(s) != 3 {
+		t.Errorf("Expected len=3: %d", len(s))
+	}
+
+	s.Delete(a, c)
+	if len(s) != 1 {
+		t.Errorf("Expected len=1: %d", len(s))
+	}
+	if s.Has(a) {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	if s.Has(c) {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	if !s.Has(b) {
+		t.Errorf("Missing contents: %#v", s)
+	}
+}
+
+func TestNewIPNetSet(t *testing.T) {
+	s, err := ParseIPNets("1.0.0.0/8", "2.0.0.0/8", "3.0.0.0/8")
+	if err != nil {
+		t.Errorf("error parsing IPNets: %v", err)
+	}
+	if len(s) != 3 {
+		t.Errorf("Expected len=3: %d", len(s))
+	}
+	a := parseIPNet("1.0.0.0/8")
+	b := parseIPNet("2.0.0.0/8")
+	c := parseIPNet("3.0.0.0/8")
+
+	if !s.Has(a) || !s.Has(b) || !s.Has(c) {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+}
+
+func TestIPNetSetDifference(t *testing.T) {
+	l, err := ParseIPNets("1.0.0.0/8", "2.0.0.0/8", "3.0.0.0/8")
+	if err != nil {
+		t.Errorf("error parsing IPNets: %v", err)
+	}
+	r, err := ParseIPNets("1.0.0.0/8", "2.0.0.0/8", "4.0.0.0/8", "5.0.0.0/8")
+	if err != nil {
+		t.Errorf("error parsing IPNets: %v", err)
+	}
+	c := l.Difference(r)
+	d := r.Difference(l)
+	if len(c) != 1 {
+		t.Errorf("Expected len=1: %d", len(c))
+	}
+	if !c.Has(parseIPNet("3.0.0.0/8")) {
+		t.Errorf("Unexpected contents: %#v", c)
+	}
+	if len(d) != 2 {
+		t.Errorf("Expected len=2: %d", len(d))
+	}
+	if !d.Has(parseIPNet("4.0.0.0/8")) || !d.Has(parseIPNet("5.0.0.0/8")) {
+		t.Errorf("Unexpected contents: %#v", d)
+	}
+}
+
+func TestIPNetSetList(t *testing.T) {
+	s, err := ParseIPNets("3.0.0.0/8", "1.0.0.0/8", "2.0.0.0/8")
+	if err != nil {
+		t.Errorf("error parsing IPNets: %v", err)
+	}
+	l := s.StringSlice()
+	sort.Strings(l)
+	if !reflect.DeepEqual(l, []string{"1.0.0.0/8", "2.0.0.0/8", "3.0.0.0/8"}) {
+		t.Errorf("List gave unexpected result: %#v", l)
+	}
+}
+
+func TestIPSet(t *testing.T) {
+	s := IPSet{}
+	s2 := IPSet{}
+
+	a := net.ParseIP("1.0.0.0")
+	b := net.ParseIP("2.0.0.0")
+	c := net.ParseIP("3.0.0.0")
+	d := net.ParseIP("4.0.0.0")
+
+	s.Insert(a, b)
+	if len(s) != 2 {
+		t.Errorf("Expected len=2: %d", len(s))
+	}
+	if !s.Has(a) {
+		t.Errorf("Missing contents: %#v", s)
+	}
+
+	s.Insert(c)
+	if s.Has(d) {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+
+	s.Delete(a)
+	if s.Has(a) {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	s.Insert(a)
+	if s.HasAll(a, b, d) {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	if !s.HasAll(a, b) {
+		t.Errorf("Missing contents: %#v", s)
+	}
+	s2.Insert(a, b, d)
+	if s.IsSuperset(s2) {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	s2.Delete(d)
+	if !s.IsSuperset(s2) {
+		t.Errorf("Missing contents: %#v", s)
+	}
+}
+
+func TestIPSetDeleteMultiples(t *testing.T) {
+	s := IPSet{}
+	a := net.ParseIP("1.0.0.0")
+	b := net.ParseIP("2.0.0.0")
+	c := net.ParseIP("3.0.0.0")
+
+	s.Insert(a, b, c)
+	if len(s) != 3 {
+		t.Errorf("Expected len=3: %d", len(s))
+	}
+
+	s.Delete(a, c)
+	if len(s) != 1 {
+		t.Errorf("Expected len=1: %d", len(s))
+	}
+	if s.Has(a) {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	if s.Has(c) {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	if !s.Has(b) {
+		t.Errorf("Missing contents: %#v", s)
+	}
+}
+
+func TestParseIPSet(t *testing.T) {
+	s, err := ParseIPSet("1.0.0.0", "2.0.0.0", "3.0.0.0", "::ffff:4.0.0.0")
+	if err != nil {
+		t.Errorf("error parsing IPSet: %v", err)
+	}
+	if len(s) != 4 {
+		t.Errorf("Expected len=3: %d", len(s))
+	}
+	a := net.ParseIP("1.0.0.0")
+	b := net.ParseIP("2.0.0.0")
+	c := net.ParseIP("3.0.0.0")
+	d := net.ParseIP("::ffff:4.0.0.0")
+	e := net.ParseIP("4.0.0.0")
+
+	if !s.Has(a) || !s.Has(b) || !s.Has(c) || !s.Has(d) || !s.Has(e) {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+}
+
+func TestIPSetDifference(t *testing.T) {
+	l, err := ParseIPSet("1.0.0.0", "2.0.0.0", "3.0.0.0")
+	if err != nil {
+		t.Errorf("error parsing IPSet: %v", err)
+	}
+	r, err := ParseIPSet("1.0.0.0", "2.0.0.0", "4.0.0.0", "5.0.0.0")
+	if err != nil {
+		t.Errorf("error parsing IPSet: %v", err)
+	}
+	c := l.Difference(r)
+	d := r.Difference(l)
+	if len(c) != 1 {
+		t.Errorf("Expected len=1: %d", len(c))
+	}
+	if !c.Has(net.ParseIP("3.0.0.0")) {
+		t.Errorf("Unexpected contents: %#v", c)
+	}
+	if len(d) != 2 {
+		t.Errorf("Expected len=2: %d", len(d))
+	}
+	if !d.Has(net.ParseIP("4.0.0.0")) || !d.Has(net.ParseIP("5.0.0.0")) {
+		t.Errorf("Unexpected contents: %#v", d)
+	}
+}
+
+func TestIPSetList(t *testing.T) {
+	// NOTE: IPv4-in-IPv6 addresses are represented as IPv4 in its string value
+	s, err := ParseIPSet("3.0.0.0", "1.0.0.0", "2.0.0.0", "::ffff:1.2.3.4")
+	if err != nil {
+		t.Errorf("error parsing IPSet: %v", err)
+	}
+
+	l := s.StringSlice()
+	sort.Strings(l)
+	if !reflect.DeepEqual(l, []string{"1.0.0.0", "1.2.3.4", "2.0.0.0", "3.0.0.0"}) {
+		t.Errorf("List gave unexpected result: %#v", l)
+	}
+}
+
+func TestIPSetEqual(t *testing.T) {
+	// IPv4-in-IPv6 addresses are equal to their IPv4 equivalents
+	set1, err := ParseIPSet("1.0.0.0", "2.0.0.0", "3.0.0.0", "::ffff:4.0.0.0")
+	if err != nil {
+		t.Errorf("error parsing IPSet: %v", err)
+	}
+
+	set2, err := ParseIPSet("1.0.0.0", "2.0.0.0", "3.0.0.0", "4.0.0.0")
+	if err != nil {
+		t.Errorf("error parsing IPSet: %v", err)
+	}
+
+	if !set1.Equal(set2) {
+		t.Errorf("sets %v and %v are not equal", set1, set2)
+	}
+
+	// order shouldn't matter
+	set1, err = ParseIPSet("1.0.0.0", "2.0.0.0", "3.0.0.0")
+	if err != nil {
+		t.Errorf("error parsing IPSet: %v", err)
+	}
+
+	set2, err = ParseIPSet("3.0.0.0", "1.0.0.0", "2.0.0.0")
+	if err != nil {
+		t.Errorf("error parsing IPSet: %v", err)
+	}
+
+	if !set1.Equal(set2) {
+		t.Errorf("sets %v and %v are not equal", set1, set2)
+	}
+}

--- a/internal/cri/netutil/multi_listen.go
+++ b/internal/cri/netutil/multi_listen.go
@@ -1,0 +1,211 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+)
+
+// connErrPair pairs conn and error which is returned by accept on sub-listeners.
+type connErrPair struct {
+	conn net.Conn
+	err  error
+}
+
+// multiListener implements net.Listener
+type multiListener struct {
+	listeners []net.Listener
+	wg        sync.WaitGroup
+
+	// connCh passes accepted connections, from child listeners to parent.
+	connCh chan connErrPair
+	// stopCh communicates from parent to child listeners.
+	stopCh chan struct{}
+}
+
+// compile time check to ensure *multiListener implements net.Listener
+var _ net.Listener = &multiListener{}
+
+// MultiListen returns net.Listener which can listen on and accept connections for
+// the given network on multiple addresses. Internally it uses stdlib to create
+// sub-listener and multiplexes connection requests using go-routines.
+// The network must be "tcp", "tcp4" or "tcp6".
+// It follows the semantics of net.Listen that primarily means:
+//  1. If the host is an unspecified/zero IP address with "tcp" network, MultiListen
+//     listens on all available unicast and anycast IP addresses of the local system.
+//  2. Use "tcp4" or "tcp6" to exclusively listen on IPv4 or IPv6 family, respectively.
+//  3. The host can accept names (e.g, localhost) and it will create a listener for at
+//     most one of the host's IP.
+func MultiListen(ctx context.Context, network string, addrs ...string) (net.Listener, error) {
+	var lc net.ListenConfig
+	return multiListen(
+		ctx,
+		network,
+		addrs,
+		func(ctx context.Context, network, address string) (net.Listener, error) {
+			return lc.Listen(ctx, network, address)
+		})
+}
+
+// multiListen implements MultiListen by consuming stdlib functions as dependency allowing
+// mocking for unit-testing.
+func multiListen(
+	ctx context.Context,
+	network string,
+	addrs []string,
+	listenFunc func(ctx context.Context, network, address string) (net.Listener, error),
+) (net.Listener, error) {
+	if !(network == "tcp" || network == "tcp4" || network == "tcp6") {
+		return nil, fmt.Errorf("network %q not supported", network)
+	}
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("no address provided to listen on")
+	}
+
+	ml := &multiListener{
+		connCh: make(chan connErrPair),
+		stopCh: make(chan struct{}),
+	}
+	for _, addr := range addrs {
+		l, err := listenFunc(ctx, network, addr)
+		if err != nil {
+			// close all the sub-listeners and exit
+			_ = ml.Close()
+			return nil, err
+		}
+		ml.listeners = append(ml.listeners, l)
+	}
+
+	for _, l := range ml.listeners {
+		ml.wg.Add(1)
+		go func(l net.Listener) {
+			defer ml.wg.Done()
+			for {
+				// Accept() is blocking, unless ml.Close() is called, in which
+				// case it will return immediately with an error.
+				conn, err := l.Accept()
+				// This assumes that ANY error from Accept() will terminate the
+				// sub-listener. We could maybe be more precise, but it
+				// doesn't seem necessary.
+				terminate := err != nil
+
+				select {
+				case ml.connCh <- connErrPair{conn: conn, err: err}:
+				case <-ml.stopCh:
+					// In case we accepted a connection AND were stopped, and
+					// this select-case was chosen, just throw away the
+					// connection.  This avoids potentially blocking on connCh
+					// or leaking a connection.
+					if conn != nil {
+						_ = conn.Close()
+					}
+					terminate = true
+				}
+				// Make sure we don't loop on Accept() returning an error and
+				// the select choosing the channel case.
+				if terminate {
+					return
+				}
+			}
+		}(l)
+	}
+	return ml, nil
+}
+
+// Accept implements net.Listener. It waits for and returns a connection from
+// any of the sub-listener.
+func (ml *multiListener) Accept() (net.Conn, error) {
+	// wait for any sub-listener to enqueue an accepted connection
+	connErr, ok := <-ml.connCh
+	if !ok {
+		// The channel will be closed only when Close() is called on the
+		// multiListener. Closing of this channel implies that all
+		// sub-listeners are also closed, which causes a "use of closed
+		// network connection" error on their Accept() calls. We return the
+		// same error for multiListener.Accept() if multiListener.Close()
+		// has already been called.
+		return nil, fmt.Errorf("use of closed network connection")
+	}
+	return connErr.conn, connErr.err
+}
+
+// Close implements net.Listener. It will close all sub-listeners and wait for
+// the go-routines to exit.
+func (ml *multiListener) Close() error {
+	// Make sure this can be called repeatedly without explosions.
+	select {
+	case <-ml.stopCh:
+		return fmt.Errorf("use of closed network connection")
+	default:
+	}
+
+	// Tell all sub-listeners to stop.
+	close(ml.stopCh)
+
+	// Closing the listeners causes Accept() to immediately return an error in
+	// the sub-listener go-routines.
+	for _, l := range ml.listeners {
+		_ = l.Close()
+	}
+
+	// Wait for all the sub-listener go-routines to exit.
+	ml.wg.Wait()
+	close(ml.connCh)
+
+	// Drain any already-queued connections.
+	for connErr := range ml.connCh {
+		if connErr.conn != nil {
+			_ = connErr.conn.Close()
+		}
+	}
+	return nil
+}
+
+// Addr is an implementation of the net.Listener interface.  It always returns
+// the address of the first listener.  Callers should  use conn.LocalAddr() to
+// obtain the actual local address of the sub-listener.
+func (ml *multiListener) Addr() net.Addr {
+	return ml.listeners[0].Addr()
+}
+
+// Addrs is like Addr, but returns the address for all registered listeners.
+func (ml *multiListener) Addrs() []net.Addr {
+	var ret []net.Addr
+	for _, l := range ml.listeners {
+		ret = append(ret, l.Addr())
+	}
+	return ret
+}

--- a/internal/cri/netutil/multi_listen_test.go
+++ b/internal/cri/netutil/multi_listen_test.go
@@ -1,0 +1,560 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type fakeCon struct {
+	remoteAddr net.Addr
+}
+
+func (f *fakeCon) Read(_ []byte) (n int, err error) {
+	return 0, nil
+}
+
+func (f *fakeCon) Write(_ []byte) (n int, err error) {
+	return 0, nil
+}
+
+func (f *fakeCon) Close() error {
+	return nil
+}
+
+func (f *fakeCon) LocalAddr() net.Addr {
+	return nil
+}
+
+func (f *fakeCon) RemoteAddr() net.Addr {
+	return f.remoteAddr
+}
+
+func (f *fakeCon) SetDeadline(_ time.Time) error {
+	return nil
+}
+
+func (f *fakeCon) SetReadDeadline(_ time.Time) error {
+	return nil
+}
+
+func (f *fakeCon) SetWriteDeadline(_ time.Time) error {
+	return nil
+}
+
+var _ net.Conn = &fakeCon{}
+
+type fakeListener struct {
+	addr         net.Addr
+	index        int
+	err          error
+	closed       atomic.Bool
+	connErrPairs []connErrPair
+}
+
+func (f *fakeListener) Accept() (net.Conn, error) {
+	if f.index < len(f.connErrPairs) {
+		index := f.index
+		connErr := f.connErrPairs[index]
+		f.index++
+		return connErr.conn, connErr.err
+	}
+	for {
+		if f.closed.Load() {
+			return nil, fmt.Errorf("use of closed network connection")
+		}
+	}
+}
+
+func (f *fakeListener) Close() error {
+	f.closed.Store(true)
+	return nil
+}
+
+func (f *fakeListener) Addr() net.Addr {
+	return f.addr
+}
+
+var _ net.Listener = &fakeListener{}
+
+func listenFuncFactory(listeners []*fakeListener) func(_ context.Context, network string, address string) (net.Listener, error) {
+	index := 0
+	return func(_ context.Context, network string, address string) (net.Listener, error) {
+		if index < len(listeners) {
+			host, portStr, err := net.SplitHostPort(address)
+			if err != nil {
+				return nil, err
+			}
+			port, err := strconv.Atoi(portStr)
+			if err != nil {
+				return nil, err
+			}
+			listener := listeners[index]
+			addr := &net.TCPAddr{
+				IP:   net.ParseIP(host),
+				Port: port,
+			}
+
+			listener.addr = addr
+			index++
+
+			if listener.err != nil {
+				return nil, listener.err
+			}
+			return listener, nil
+		}
+		return nil, nil
+	}
+}
+
+func TestMultiListen(t *testing.T) {
+	testCases := []struct {
+		name          string
+		network       string
+		addrs         []string
+		fakeListeners []*fakeListener
+		errString     string
+	}{
+		{
+			name:      "unsupported network",
+			network:   "udp",
+			errString: "network \"udp\" not supported",
+		},
+		{
+			name:      "no host",
+			network:   "tcp",
+			errString: "no address provided to listen on",
+		},
+		{
+			name:          "valid",
+			network:       "tcp",
+			addrs:         []string{"127.0.0.1:12345"},
+			fakeListeners: []*fakeListener{{connErrPairs: []connErrPair{}}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.TODO()
+			ml, err := multiListen(ctx, tc.network, tc.addrs, listenFuncFactory(tc.fakeListeners))
+
+			if tc.errString != "" {
+				assertError(t, tc.errString, err)
+			} else {
+				assertNoError(t, err)
+			}
+			if ml != nil {
+				err = ml.Close()
+				if err != nil {
+					t.Errorf("Did not expect error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestMultiListen_Addr(t *testing.T) {
+	ctx := context.TODO()
+	ml, err := multiListen(ctx, "tcp", []string{"10.10.10.10:5000", "192.168.1.10:5000", "127.0.0.1:5000"}, listenFuncFactory(
+		[]*fakeListener{{}, {}, {}},
+	))
+	if err != nil {
+		t.Errorf("Did not expect error: %v", err)
+	}
+
+	if ml.Addr().String() != "10.10.10.10:5000" {
+		t.Errorf("Expected '10.10.10.10:5000' but got '%s'", ml.Addr().String())
+	}
+
+	err = ml.Close()
+	if err != nil {
+		t.Errorf("Did not expect error: %v", err)
+	}
+}
+
+func TestMultiListen_Addrs(t *testing.T) {
+	ctx := context.TODO()
+	addrs := []string{"10.10.10.10:5000", "192.168.1.10:5000", "127.0.0.1:5000"}
+	ml, err := multiListen(ctx, "tcp", addrs, listenFuncFactory(
+		[]*fakeListener{{}, {}, {}},
+	))
+	if err != nil {
+		t.Errorf("Did not expect error: %v", err)
+	}
+
+	gotAddrs := ml.(*multiListener).Addrs()
+	for i := range gotAddrs {
+		if gotAddrs[i].String() != addrs[i] {
+			t.Errorf("expected %q; got %q", addrs[i], gotAddrs[i].String())
+		}
+
+	}
+
+	err = ml.Close()
+	if err != nil {
+		t.Errorf("Did not expect error: %v", err)
+	}
+}
+
+func TestMultiListen_Close(t *testing.T) {
+	testCases := []struct {
+		name          string
+		addrs         []string
+		runner        func(listener net.Listener, acceptCalls int) error
+		fakeListeners []*fakeListener
+		acceptCalls   int
+		errString     string
+	}{
+		{
+			name:  "close",
+			addrs: []string{"10.10.10.10:5000", "192.168.1.10:5000", "127.0.0.1:5000"},
+			runner: func(ml net.Listener, acceptCalls int) error {
+				for i := 0; i < acceptCalls; i++ {
+					_, err := ml.Accept()
+					if err != nil {
+						return err
+					}
+				}
+				err := ml.Close()
+				if err != nil {
+					return err
+				}
+				return nil
+			},
+			fakeListeners: []*fakeListener{{}, {}, {}},
+		},
+		{
+			name:  "close with pending connections",
+			addrs: []string{"10.10.10.10:5001", "192.168.1.10:5002", "127.0.0.1:5003"},
+			runner: func(ml net.Listener, acceptCalls int) error {
+				for i := 0; i < acceptCalls; i++ {
+					_, err := ml.Accept()
+					if err != nil {
+						return err
+					}
+				}
+				err := ml.Close()
+				if err != nil {
+					return err
+				}
+				return nil
+			},
+			fakeListeners: []*fakeListener{{
+				connErrPairs: []connErrPair{{
+					conn: &fakeCon{remoteAddr: &net.TCPAddr{IP: net.ParseIP("10.10.10.10"), Port: 50001}},
+				}}}, {
+				connErrPairs: []connErrPair{{
+					conn: &fakeCon{remoteAddr: &net.TCPAddr{IP: net.ParseIP("192.168.1.10"), Port: 50002}},
+				},
+				}}, {
+				connErrPairs: []connErrPair{{
+					conn: &fakeCon{remoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 50003}},
+				}},
+			}},
+		},
+		{
+			name:  "close with no pending connections",
+			addrs: []string{"10.10.10.10:3001", "192.168.1.10:3002", "127.0.0.1:3003"},
+			runner: func(ml net.Listener, acceptCalls int) error {
+				for i := 0; i < acceptCalls; i++ {
+					_, err := ml.Accept()
+					if err != nil {
+						return err
+					}
+				}
+				err := ml.Close()
+				if err != nil {
+					return err
+				}
+				return nil
+			},
+			fakeListeners: []*fakeListener{{
+				connErrPairs: []connErrPair{
+					{conn: &fakeCon{remoteAddr: &net.TCPAddr{IP: net.ParseIP("10.10.10.10"), Port: 50001}}},
+				}}, {
+				connErrPairs: []connErrPair{
+					{conn: &fakeCon{remoteAddr: &net.TCPAddr{IP: net.ParseIP("192.168.1.10"), Port: 50002}}},
+				}}, {
+				connErrPairs: []connErrPair{
+					{conn: &fakeCon{remoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 50003}}},
+				},
+			}},
+			acceptCalls: 3,
+		},
+		{
+			name:  "close on close",
+			addrs: []string{"10.10.10.10:5000", "192.168.1.10:5000", "127.0.0.1:5000"},
+			runner: func(ml net.Listener, acceptCalls int) error {
+				for i := 0; i < acceptCalls; i++ {
+					_, err := ml.Accept()
+					if err != nil {
+						return err
+					}
+				}
+				err := ml.Close()
+				if err != nil {
+					return err
+				}
+
+				err = ml.Close()
+				if err != nil {
+					return err
+				}
+				return nil
+			},
+			fakeListeners: []*fakeListener{{}, {}, {}},
+			errString:     "use of closed network connection",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.TODO()
+			ml, err := multiListen(ctx, "tcp", tc.addrs, listenFuncFactory(tc.fakeListeners))
+			if err != nil {
+				t.Errorf("Did not expect error: %v", err)
+			}
+			err = tc.runner(ml, tc.acceptCalls)
+			if tc.errString != "" {
+				assertError(t, tc.errString, err)
+			} else {
+				assertNoError(t, err)
+			}
+
+			for _, f := range tc.fakeListeners {
+				if !f.closed.Load() {
+					t.Errorf("Expeted sub-listener to be closed")
+				}
+			}
+		})
+	}
+}
+
+func TestMultiListen_Accept(t *testing.T) {
+	testCases := []struct {
+		name          string
+		addrs         []string
+		runner        func(listener net.Listener, acceptCalls int) error
+		fakeListeners []*fakeListener
+		acceptCalls   int
+		errString     string
+	}{
+		{
+			name:  "accept all connections",
+			addrs: []string{"10.10.10.10:3000", "192.168.1.103:4000", "127.0.0.1:5000"},
+			runner: func(ml net.Listener, acceptCalls int) error {
+				for i := 0; i < acceptCalls; i++ {
+					_, err := ml.Accept()
+					if err != nil {
+						return err
+					}
+				}
+				err := ml.Close()
+				if err != nil {
+					return err
+				}
+				return nil
+			},
+			fakeListeners: []*fakeListener{{
+				connErrPairs: []connErrPair{
+					{conn: &fakeCon{remoteAddr: &net.TCPAddr{IP: net.ParseIP("10.10.10.10"), Port: 50001}}},
+				}}, {
+				connErrPairs: []connErrPair{
+					{conn: &fakeCon{remoteAddr: &net.TCPAddr{IP: net.ParseIP("192.168.1.10"), Port: 50002}}},
+				}}, {
+				connErrPairs: []connErrPair{
+					{conn: &fakeCon{remoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 50003}}},
+				},
+			}},
+			acceptCalls: 3,
+		},
+		{
+			name:  "accept some connections",
+			addrs: []string{"10.10.10.10:3000", "192.168.1.103:4000", "172.16.20.10:5000", "127.0.0.1:6000"},
+			runner: func(ml net.Listener, acceptCalls int) error {
+
+				for i := 0; i < acceptCalls; i++ {
+					_, err := ml.Accept()
+					if err != nil {
+						return err
+					}
+
+				}
+				err := ml.Close()
+				if err != nil {
+					return err
+				}
+				return nil
+			},
+			fakeListeners: []*fakeListener{{
+				connErrPairs: []connErrPair{
+					{conn: &fakeCon{remoteAddr: &net.TCPAddr{IP: net.ParseIP("10.10.10.10"), Port: 30001}}},
+				}}, {
+				connErrPairs: []connErrPair{
+					{conn: &fakeCon{remoteAddr: &net.TCPAddr{IP: net.ParseIP("192.168.1.10"), Port: 40001}}},
+					{conn: &fakeCon{remoteAddr: &net.TCPAddr{IP: net.ParseIP("192.168.1.10"), Port: 40002}}},
+				}}, {
+				connErrPairs: []connErrPair{
+					{conn: &fakeCon{remoteAddr: &net.TCPAddr{IP: net.ParseIP("172.16.20.10"), Port: 50001}}},
+					{conn: &fakeCon{remoteAddr: &net.TCPAddr{IP: net.ParseIP("172.16.20.10"), Port: 50002}}},
+					{conn: &fakeCon{remoteAddr: &net.TCPAddr{IP: net.ParseIP("172.16.20.10"), Port: 50003}}},
+					{conn: &fakeCon{remoteAddr: &net.TCPAddr{IP: net.ParseIP("172.16.20.10"), Port: 50004}}},
+				}}, {
+				connErrPairs: []connErrPair{
+					{conn: &fakeCon{remoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 60001}}},
+					{conn: &fakeCon{remoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 60002}}},
+					{conn: &fakeCon{remoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 60003}}},
+					{conn: &fakeCon{remoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 60004}}},
+					{conn: &fakeCon{remoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 60005}}},
+				},
+			}},
+			acceptCalls: 3,
+		},
+		{
+			name:  "accept on closed listener",
+			addrs: []string{"10.10.10.10:3001", "192.168.1.10:3002", "127.0.0.1:3003"},
+			runner: func(ml net.Listener, acceptCalls int) error {
+				err := ml.Close()
+				if err != nil {
+					return err
+				}
+				for i := 0; i < acceptCalls; i++ {
+					_, err := ml.Accept()
+					if err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+			fakeListeners: []*fakeListener{{
+				connErrPairs: []connErrPair{
+					{conn: &fakeCon{remoteAddr: &net.TCPAddr{IP: net.ParseIP("10.10.10.10"), Port: 50001}}},
+				}}, {
+				connErrPairs: []connErrPair{
+					{conn: &fakeCon{remoteAddr: &net.TCPAddr{IP: net.ParseIP("192.168.1.10"), Port: 50002}}},
+				}}, {
+				connErrPairs: []connErrPair{
+					{conn: &fakeCon{remoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 50003}}},
+				},
+			}},
+			acceptCalls: 1,
+			errString:   "use of closed network connection",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.TODO()
+			ml, err := multiListen(ctx, "tcp", tc.addrs, listenFuncFactory(tc.fakeListeners))
+			if err != nil {
+				t.Errorf("Did not expect error: %v", err)
+			}
+
+			err = tc.runner(ml, tc.acceptCalls)
+			if tc.errString != "" {
+				assertError(t, tc.errString, err)
+			} else {
+				assertNoError(t, err)
+			}
+		})
+	}
+}
+
+func TestMultiListen_HTTP(t *testing.T) {
+	ctx := context.TODO()
+	ml, err := MultiListen(ctx, "tcp", ":0", ":0", ":0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	addrs := ml.(*multiListener).Addrs()
+	if len(addrs) != 3 {
+		t.Fatalf("expected 3 listeners, got %v", addrs)
+	}
+
+	// serve http on multi-listener
+	handler := func(w http.ResponseWriter, _ *http.Request) {
+		io.WriteString(w, "hello")
+	}
+	server := http.Server{
+		Handler:           http.HandlerFunc(handler),
+		ReadHeaderTimeout: 0,
+	}
+	go func() { _ = server.Serve(ml) }()
+	defer server.Close()
+
+	// Wait for server
+	awake := false
+	for i := 0; i < 5; i++ {
+		_, err = http.Get("http://" + addrs[0].String())
+		if err == nil {
+			awake = true
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !awake {
+		t.Fatalf("http server did not respond in time")
+	}
+
+	// HTTP GET on each address.
+	for _, addr := range addrs {
+		_, err = http.Get("http://" + addr.String())
+		if err != nil {
+			t.Errorf("error connecting to %q: %v", addr.String(), err)
+		}
+	}
+}
+
+func assertError(t *testing.T, errString string, err error) {
+	if err == nil {
+		t.Errorf("Expected error '%s' but got none", errString)
+	}
+	if err.Error() != errString {
+		t.Errorf("Expected error '%s' but got '%s'", errString, err.Error())
+	}
+}
+
+func assertNoError(t *testing.T, err error) {
+	if err != nil {
+		t.Errorf("Did not expect error: %v", err)
+	}
+}

--- a/internal/cri/netutil/net.go
+++ b/internal/cri/netutil/net.go
@@ -1,0 +1,107 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+	"net"
+	"strconv"
+)
+
+// ParseCIDRs parses a list of cidrs and return error if any is invalid.
+// order is maintained
+func ParseCIDRs(cidrsString []string) ([]*net.IPNet, error) {
+	cidrs := make([]*net.IPNet, 0, len(cidrsString))
+	for i, cidrString := range cidrsString {
+		_, cidr, err := net.ParseCIDR(cidrString)
+		if err != nil {
+			return nil, fmt.Errorf("invalid CIDR[%d]: %v (%v)", i, cidr, err)
+		}
+		cidrs = append(cidrs, cidr)
+	}
+	return cidrs, nil
+}
+
+// ParsePort parses a string representing an IP port.  If the string is not a
+// valid port number, this returns an error.
+func ParsePort(port string, allowZero bool) (int, error) {
+	portInt, err := strconv.ParseUint(port, 10, 16)
+	if err != nil {
+		return 0, err
+	}
+	if portInt == 0 && !allowZero {
+		return 0, errors.New("0 is not a valid port number")
+	}
+	return int(portInt), nil
+}
+
+// BigForIP creates a big.Int based on the provided net.IP
+func BigForIP(ip net.IP) *big.Int {
+	// NOTE: Convert to 16-byte representation so we can
+	// handle v4 and v6 values the same way.
+	return big.NewInt(0).SetBytes(ip.To16())
+}
+
+// AddIPOffset adds the provided integer offset to a base big.Int representing a net.IP
+// NOTE: If you started with a v4 address and overflow it, you get a v6 result.
+func AddIPOffset(base *big.Int, offset int) net.IP {
+	r := big.NewInt(0).Add(base, big.NewInt(int64(offset))).Bytes()
+	r = append(make([]byte, 16), r...)
+	return net.IP(r[len(r)-16:])
+}
+
+// RangeSize returns the size of a range in valid addresses.
+// returns the size of the subnet (or math.MaxInt64 if the range size would overflow int64)
+func RangeSize(subnet *net.IPNet) int64 {
+	ones, bits := subnet.Mask.Size()
+	if bits == 32 && (bits-ones) >= 31 || bits == 128 && (bits-ones) >= 127 {
+		return 0
+	}
+	// this checks that we are not overflowing an int64
+	if bits-ones >= 63 {
+		return math.MaxInt64
+	}
+	return int64(1) << uint(bits-ones)
+}
+
+// GetIndexedIP returns a net.IP that is subnet.IP + index in the contiguous IP space.
+func GetIndexedIP(subnet *net.IPNet, index int) (net.IP, error) {
+	ip := AddIPOffset(BigForIP(subnet.IP), index)
+	if !subnet.Contains(ip) {
+		return nil, fmt.Errorf("can't generate IP with index %d from subnet. subnet too small. subnet: %q", index, subnet)
+	}
+	return ip, nil
+}

--- a/internal/cri/netutil/net_test.go
+++ b/internal/cri/netutil/net_test.go
@@ -1,0 +1,267 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"net"
+	"testing"
+)
+
+func TestParseCIDRs(t *testing.T) {
+	testCases := []struct {
+		cidrs         []string
+		errString     string
+		errorExpected bool
+	}{
+		{
+			cidrs:         []string{},
+			errString:     "should not return an error for an empty slice",
+			errorExpected: false,
+		},
+		{
+			cidrs:         []string{"10.0.0.0/8", "not-a-valid-cidr", "2000::/10"},
+			errString:     "should return error for bad cidr",
+			errorExpected: true,
+		},
+		{
+			cidrs:         []string{"10.0.0.0/8", "2000::/10"},
+			errString:     "should not return error for good  cidrs",
+			errorExpected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		cidrs, err := ParseCIDRs(tc.cidrs)
+		if tc.errorExpected {
+			if err == nil {
+				t.Errorf("%v", tc.errString)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%v error:%v", tc.errString, err)
+		}
+
+		// validate lengths
+		if len(cidrs) != len(tc.cidrs) {
+			t.Errorf("cidrs should be of the same lengths %v != %v", len(cidrs), len(tc.cidrs))
+		}
+
+	}
+}
+
+func TestParsePort(t *testing.T) {
+	var tests = []struct {
+		name          string
+		port          string
+		allowZero     bool
+		expectedPort  int
+		expectedError bool
+	}{
+		{
+			name:         "valid port: 1",
+			port:         "1",
+			expectedPort: 1,
+		},
+		{
+			name:         "valid port: 1234",
+			port:         "1234",
+			expectedPort: 1234,
+		},
+		{
+			name:         "valid port: 65535",
+			port:         "65535",
+			expectedPort: 65535,
+		},
+		{
+			name:          "invalid port: not a number",
+			port:          "a",
+			expectedError: true,
+			allowZero:     false,
+		},
+		{
+			name:          "invalid port: too small",
+			port:          "0",
+			expectedError: true,
+		},
+		{
+			name:          "invalid port: negative",
+			port:          "-10",
+			expectedError: true,
+		},
+		{
+			name:          "invalid port: too big",
+			port:          "65536",
+			expectedError: true,
+		},
+		{
+			name:      "zero port: allowed",
+			port:      "0",
+			allowZero: true,
+		},
+		{
+			name:          "zero port: not allowed",
+			port:          "0",
+			expectedError: true,
+		},
+	}
+
+	for _, rt := range tests {
+		t.Run(rt.name, func(t *testing.T) {
+			actualPort, actualError := ParsePort(rt.port, rt.allowZero)
+
+			if actualError != nil && !rt.expectedError {
+				t.Errorf("%s unexpected failure: %v", rt.name, actualError)
+				return
+			}
+			if actualError == nil && rt.expectedError {
+				t.Errorf("%s passed when expected to fail", rt.name)
+				return
+			}
+			if actualPort != rt.expectedPort {
+				t.Errorf("%s returned wrong port: got %d, expected %d", rt.name, actualPort, rt.expectedPort)
+			}
+		})
+	}
+}
+
+func TestRangeSize(t *testing.T) {
+	testCases := []struct {
+		name  string
+		cidr  string
+		addrs int64
+	}{
+		{
+			name:  "supported IPv4 cidr",
+			cidr:  "192.168.1.0/24",
+			addrs: 256,
+		},
+		{
+			name:  "unsupported IPv4 cidr",
+			cidr:  "192.168.1.0/1",
+			addrs: 0,
+		},
+		{
+			name:  "unsupported IPv6 mask",
+			cidr:  "2001:db8::/1",
+			addrs: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		_, cidr, err := net.ParseCIDR(tc.cidr)
+		if err != nil {
+			t.Errorf("failed to parse cidr for test %s, unexpected error: '%s'", tc.name, err)
+		}
+		if size := RangeSize(cidr); size != tc.addrs {
+			t.Errorf("test %s failed. %s should have a range size of %d, got %d",
+				tc.name, tc.cidr, tc.addrs, size)
+		}
+	}
+}
+
+func TestGetIndexedIP(t *testing.T) {
+	testCases := []struct {
+		cidr        string
+		index       int
+		expectError bool
+		expectedIP  string
+	}{
+		{
+			cidr:        "192.168.1.0/24",
+			index:       20,
+			expectError: false,
+			expectedIP:  "192.168.1.20",
+		},
+		{
+			cidr:        "192.168.1.0/30",
+			index:       10,
+			expectError: true,
+		},
+		{
+			cidr:        "192.168.1.0/24",
+			index:       255,
+			expectError: false,
+			expectedIP:  "192.168.1.255",
+		},
+		{
+			cidr:        "255.255.255.0/24",
+			index:       256,
+			expectError: true,
+		},
+		{
+			cidr:        "fd:11:b2:be::/120",
+			index:       20,
+			expectError: false,
+			expectedIP:  "fd:11:b2:be::14",
+		},
+		{
+			cidr:        "fd:11:b2:be::/126",
+			index:       10,
+			expectError: true,
+		},
+		{
+			cidr:        "fd:11:b2:be::/120",
+			index:       255,
+			expectError: false,
+			expectedIP:  "fd:11:b2:be::ff",
+		},
+		{
+			cidr:        "00:00:00:be::/120",
+			index:       255,
+			expectError: false,
+			expectedIP:  "::be:0:0:0:ff",
+		},
+	}
+
+	for _, tc := range testCases {
+		_, subnet, err := net.ParseCIDR(tc.cidr)
+		if err != nil {
+			t.Errorf("failed to parse cidr %s, unexpected error: '%s'", tc.cidr, err)
+		}
+
+		ip, err := GetIndexedIP(subnet, tc.index)
+		if err == nil && tc.expectError || err != nil && !tc.expectError {
+			t.Errorf("expectedError is %v and err is %s", tc.expectError, err)
+			continue
+		}
+
+		if err == nil {
+			ipString := ip.String()
+			if ipString != tc.expectedIP {
+				t.Errorf("expected %s but instead got %s", tc.expectedIP, ipString)
+			}
+		}
+
+	}
+}

--- a/internal/cri/netutil/port.go
+++ b/internal/cri/netutil/port.go
@@ -1,0 +1,145 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+)
+
+// Protocol is a network protocol support by LocalPort.
+type Protocol string
+
+// Constants for valid protocols:
+const (
+	TCP Protocol = "TCP"
+	UDP Protocol = "UDP"
+)
+
+// LocalPort represents an IP address and port pair along with a protocol
+// and potentially a specific IP family.
+// A LocalPort can be opened and subsequently closed.
+type LocalPort struct {
+	// Description is an arbitrary string.
+	Description string
+	// IP is the IP address part of a given local port.
+	// If this string is empty, the port binds to all local IP addresses.
+	IP string
+	// If IPFamily is not empty, the port binds only to addresses of this
+	// family.
+	// IF empty along with IP, bind to local addresses of any family.
+	IPFamily IPFamily
+	// Port is the port number.
+	// A value of 0 causes a port to be automatically chosen.
+	Port int
+	// Protocol is the protocol, e.g. TCP
+	Protocol Protocol
+}
+
+// NewLocalPort returns a LocalPort instance and ensures IPFamily and IP are
+// consistent and that the given protocol is valid.
+func NewLocalPort(desc, ip string, ipFamily IPFamily, port int, protocol Protocol) (*LocalPort, error) {
+	if protocol != TCP && protocol != UDP {
+		return nil, fmt.Errorf("unsupported protocol %s", protocol)
+	}
+	if ipFamily != IPFamilyUnknown && ipFamily != IPv4 && ipFamily != IPv6 {
+		return nil, fmt.Errorf("invalid IP family %s", ipFamily)
+	}
+	if ip != "" {
+		parsedIP := net.ParseIP(ip)
+		if parsedIP == nil {
+			return nil, fmt.Errorf("invalid ip address %s", ip)
+		}
+		if ipFamily != IPFamilyUnknown {
+			if IPFamily(parsedIP) != ipFamily {
+				return nil, fmt.Errorf("ip address and family mismatch %s, %s", ip, ipFamily)
+			}
+		}
+	}
+	return &LocalPort{Description: desc, IP: ip, IPFamily: ipFamily, Port: port, Protocol: protocol}, nil
+}
+
+func (lp *LocalPort) String() string {
+	ipPort := net.JoinHostPort(lp.IP, strconv.Itoa(lp.Port))
+	return fmt.Sprintf("%q (%s/%s%s)", lp.Description, ipPort, strings.ToLower(string(lp.Protocol)), lp.IPFamily)
+}
+
+// Closeable closes an opened LocalPort.
+type Closeable interface {
+	Close() error
+}
+
+// PortOpener can open a LocalPort and allows later closing it.
+type PortOpener interface {
+	OpenLocalPort(lp *LocalPort) (Closeable, error)
+}
+
+type listenPortOpener struct{}
+
+// ListenPortOpener opens ports by calling bind() and listen().
+var ListenPortOpener listenPortOpener
+
+// OpenLocalPort holds the given local port open.
+func (l *listenPortOpener) OpenLocalPort(lp *LocalPort) (Closeable, error) {
+	return openLocalPort(lp)
+}
+
+func openLocalPort(lp *LocalPort) (Closeable, error) {
+	var socket Closeable
+	hostPort := net.JoinHostPort(lp.IP, strconv.Itoa(lp.Port))
+	switch lp.Protocol {
+	case TCP:
+		network := "tcp" + string(lp.IPFamily)
+		listener, err := net.Listen(network, hostPort)
+		if err != nil {
+			return nil, err
+		}
+		socket = listener
+	case UDP:
+		network := "udp" + string(lp.IPFamily)
+		addr, err := net.ResolveUDPAddr(network, hostPort)
+		if err != nil {
+			return nil, err
+		}
+		conn, err := net.ListenUDP(network, addr)
+		if err != nil {
+			return nil, err
+		}
+		socket = conn
+	default:
+		return nil, fmt.Errorf("unknown protocol %q", lp.Protocol)
+	}
+	return socket, nil
+}

--- a/internal/cri/netutil/port_range.go
+++ b/internal/cri/netutil/port_range.go
@@ -1,0 +1,165 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// PortRange represents a range of TCP/UDP ports.  To represent a single port,
+// set Size to 1.
+type PortRange struct {
+	Base int
+	Size int
+}
+
+// Contains tests whether a given port falls within the PortRange.
+func (pr *PortRange) Contains(p int) bool {
+	return (p >= pr.Base) && ((p - pr.Base) < pr.Size)
+}
+
+// String converts the PortRange to a string representation, which can be
+// parsed by PortRange.Set or ParsePortRange.
+func (pr PortRange) String() string {
+	if pr.Size == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d-%d", pr.Base, pr.Base+pr.Size-1)
+}
+
+// Set parses a string of the form "value", "min-max", or "min+offset", inclusive at both ends, and
+// sets the PortRange from it.  This is part of the flag.Value and pflag.Value
+// interfaces.
+func (pr *PortRange) Set(value string) error {
+	const (
+		SinglePortNotation = 1 << iota
+		HyphenNotation
+		PlusNotation
+	)
+
+	value = strings.TrimSpace(value)
+	hyphenIndex := strings.Index(value, "-")
+	plusIndex := strings.Index(value, "+")
+
+	if value == "" {
+		pr.Base = 0
+		pr.Size = 0
+		return nil
+	}
+
+	var err error
+	var low, high int
+	var notation int
+
+	if plusIndex == -1 && hyphenIndex == -1 {
+		notation |= SinglePortNotation
+	}
+	if hyphenIndex != -1 {
+		notation |= HyphenNotation
+	}
+	if plusIndex != -1 {
+		notation |= PlusNotation
+	}
+
+	switch notation {
+	case SinglePortNotation:
+		var port int
+		port, err = strconv.Atoi(value)
+		if err != nil {
+			return err
+		}
+		low = port
+		high = port
+	case HyphenNotation:
+		low, err = strconv.Atoi(value[:hyphenIndex])
+		if err != nil {
+			return err
+		}
+		high, err = strconv.Atoi(value[hyphenIndex+1:])
+		if err != nil {
+			return err
+		}
+	case PlusNotation:
+		var offset int
+		low, err = strconv.Atoi(value[:plusIndex])
+		if err != nil {
+			return err
+		}
+		offset, err = strconv.Atoi(value[plusIndex+1:])
+		if err != nil {
+			return err
+		}
+		high = low + offset
+	default:
+		return fmt.Errorf("unable to parse port range: %s", value)
+	}
+
+	if low > 65535 || high > 65535 {
+		return fmt.Errorf("the port range cannot be greater than 65535: %s", value)
+	}
+
+	if high < low {
+		return fmt.Errorf("end port cannot be less than start port: %s", value)
+	}
+
+	pr.Base = low
+	pr.Size = 1 + high - low
+	return nil
+}
+
+// Type returns a descriptive string about this type.  This is part of the
+// pflag.Value interface.
+func (*PortRange) Type() string {
+	return "portRange"
+}
+
+// ParsePortRange parses a string of the form "min-max", inclusive at both
+// ends, and initializes a new PortRange from it.
+func ParsePortRange(value string) (*PortRange, error) {
+	pr := &PortRange{}
+	err := pr.Set(value)
+	if err != nil {
+		return nil, err
+	}
+	return pr, nil
+}
+
+func ParsePortRangeOrDie(value string) *PortRange {
+	pr, err := ParsePortRange(value)
+	if err != nil {
+		panic(fmt.Sprintf("couldn't parse port range %q: %v", value, err))
+	}
+	return pr
+}

--- a/internal/cri/netutil/port_range_test.go
+++ b/internal/cri/netutil/port_range_test.go
@@ -1,0 +1,92 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"flag"
+	"testing"
+)
+
+func TestPortRange(t *testing.T) {
+	testCases := []struct {
+		input    string
+		success  bool
+		expected string
+		included int
+		excluded int
+	}{
+		{"100-200", true, "100-200", 200, 201},
+		{" 100-200 ", true, "100-200", 200, 201},
+		{"0-0", true, "0-0", 0, 1},
+		{"", true, "", -1, 0},
+		{"100", true, "100-100", 100, 101},
+		{"100 - 200", false, "", -1, -1},
+		{"-100", false, "", -1, -1},
+		{"100-", false, "", -1, -1},
+		{"200-100", false, "", -1, -1},
+		{"60000-70000", false, "", -1, -1},
+		{"70000-80000", false, "", -1, -1},
+		{"70000+80000", false, "", -1, -1},
+		{"1+0", true, "1-1", 1, 2},
+		{"0+0", true, "0-0", 0, 1},
+		{"1+-1", false, "", -1, -1},
+		{"1-+1", false, "", -1, -1},
+		{"100+200", true, "100-300", 300, 301},
+		{"1+65535", false, "", -1, -1},
+		{"0+65535", true, "0-65535", 65535, 65536},
+	}
+
+	for i := range testCases {
+		tc := &testCases[i]
+		pr := &PortRange{}
+		var f flag.Value = pr
+		err := f.Set(tc.input)
+		if err != nil && tc.success {
+			t.Errorf("expected success, got %q", err)
+			continue
+		} else if err == nil && !tc.success {
+			t.Errorf("expected failure %#v", testCases[i])
+			continue
+		} else if tc.success {
+			if f.String() != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, f.String())
+			}
+			if tc.included >= 0 && !pr.Contains(tc.included) {
+				t.Errorf("expected %q to include %d", f.String(), tc.included)
+			}
+			if tc.excluded >= 0 && pr.Contains(tc.excluded) {
+				t.Errorf("expected %q to exclude %d", f.String(), tc.excluded)
+			}
+		}
+	}
+}

--- a/internal/cri/netutil/port_split.go
+++ b/internal/cri/netutil/port_split.go
@@ -1,0 +1,93 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"strings"
+
+	"github.com/containerd/containerd/v2/internal/cri/setutils"
+)
+
+var validSchemes = setutils.NewString("http", "https", "")
+
+// SplitSchemeNamePort takes a string of the following forms:
+//   - "<name>",                 returns "",        "<name>","",      true
+//   - "<name>:<port>",          returns "",        "<name>","<port>",true
+//   - "<scheme>:<name>:<port>", returns "<scheme>","<name>","<port>",true
+//
+// Name must be non-empty or valid will be returned false.
+// Scheme must be "http" or "https" if specified
+// Port is returned as a string, and it is not required to be numeric (could be
+// used for a named port, for example).
+func SplitSchemeNamePort(id string) (scheme, name, port string, valid bool) {
+	parts := strings.Split(id, ":")
+	switch len(parts) {
+	case 1:
+		name = parts[0]
+	case 2:
+		name = parts[0]
+		port = parts[1]
+	case 3:
+		scheme = parts[0]
+		name = parts[1]
+		port = parts[2]
+	default:
+		return "", "", "", false
+	}
+
+	if len(name) > 0 && validSchemes.Has(scheme) {
+		return scheme, name, port, true
+	}
+	return "", "", "", false
+}
+
+// JoinSchemeNamePort returns a string that specifies the scheme, name, and port:
+//   - "<name>"
+//   - "<name>:<port>"
+//   - "<scheme>:<name>:<port>"
+//
+// None of the parameters may contain a ':' character
+// Name is required
+// Scheme must be "", "http", or "https"
+func JoinSchemeNamePort(scheme, name, port string) string {
+	if len(scheme) > 0 {
+		// Must include three segments to specify scheme
+		return scheme + ":" + name + ":" + port
+	}
+	if len(port) > 0 {
+		// Must include two segments to specify port
+		return name + ":" + port
+	}
+	// Return name alone
+	return name
+}

--- a/internal/cri/netutil/port_split_test.go
+++ b/internal/cri/netutil/port_split_test.go
@@ -1,0 +1,137 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"testing"
+)
+
+func TestSplitSchemeNamePort(t *testing.T) {
+	table := []struct {
+		in                 string
+		name, port, scheme string
+		valid              bool
+		normalized         bool
+	}{
+		{
+			in:         "aoeu:asdf",
+			name:       "aoeu",
+			port:       "asdf",
+			valid:      true,
+			normalized: true,
+		}, {
+			in:         "http:aoeu:asdf",
+			scheme:     "http",
+			name:       "aoeu",
+			port:       "asdf",
+			valid:      true,
+			normalized: true,
+		}, {
+			in:         "https:aoeu:",
+			scheme:     "https",
+			name:       "aoeu",
+			port:       "",
+			valid:      true,
+			normalized: false,
+		}, {
+			in:         "https:aoeu:asdf",
+			scheme:     "https",
+			name:       "aoeu",
+			port:       "asdf",
+			valid:      true,
+			normalized: true,
+		}, {
+			in:         "aoeu:",
+			name:       "aoeu",
+			valid:      true,
+			normalized: false,
+		}, {
+			in:         "aoeu",
+			name:       "aoeu",
+			valid:      true,
+			normalized: true,
+		}, {
+			in:    ":asdf",
+			valid: false,
+		}, {
+			in:    "aoeu:asdf:htns",
+			valid: false,
+		}, {
+			in:    "http::asdf",
+			valid: false,
+		}, {
+			in:    "http::",
+			valid: false,
+		}, {
+			in:    "",
+			valid: false,
+		},
+	}
+
+	for _, item := range table {
+		scheme, name, port, valid := SplitSchemeNamePort(item.in)
+		if e, a := item.scheme, scheme; e != a {
+			t.Errorf("%q: Wanted %q, got %q", item.in, e, a)
+		}
+		if e, a := item.name, name; e != a {
+			t.Errorf("%q: Wanted %q, got %q", item.in, e, a)
+		}
+		if e, a := item.port, port; e != a {
+			t.Errorf("%q: Wanted %q, got %q", item.in, e, a)
+		}
+		if e, a := item.valid, valid; e != a {
+			t.Errorf("%q: Wanted %t, got %t", item.in, e, a)
+		}
+
+		// Make sure valid items round trip through JoinSchemeNamePort
+		if item.valid {
+			out := JoinSchemeNamePort(scheme, name, port)
+			if item.normalized && out != item.in {
+				t.Errorf("%q: Wanted %s, got %s", item.in, item.in, out)
+			}
+			scheme, name, port, valid := SplitSchemeNamePort(out)
+			if e, a := item.scheme, scheme; e != a {
+				t.Errorf("%q: Wanted %q, got %q", item.in, e, a)
+			}
+			if e, a := item.name, name; e != a {
+				t.Errorf("%q: Wanted %q, got %q", item.in, e, a)
+			}
+			if e, a := item.port, port; e != a {
+				t.Errorf("%q: Wanted %q, got %q", item.in, e, a)
+			}
+			if e, a := item.valid, valid; e != a {
+				t.Errorf("%q: Wanted %t, got %t", item.in, e, a)
+			}
+		}
+	}
+}

--- a/internal/cri/netutil/port_test.go
+++ b/internal/cri/netutil/port_test.go
@@ -1,0 +1,103 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"testing"
+)
+
+func ExampleLocalPort() {
+	lp, err := NewLocalPort(
+		"TCP port",
+		"",
+		IPv4,
+		443,
+		TCP,
+	)
+	if err != nil {
+		panic(err)
+	}
+	port, err := ListenPortOpener.OpenLocalPort(lp)
+	if err != nil {
+		panic(err)
+	}
+	port.Close()
+}
+
+func TestLocalPortString(t *testing.T) {
+	testCases := []struct {
+		description string
+		ip          string
+		family      IPFamily
+		port        int
+		protocol    Protocol
+		expectedStr string
+		expectedErr bool
+	}{
+		{"IPv4 UDP", "1.2.3.4", "", 9999, UDP, `"IPv4 UDP" (1.2.3.4:9999/udp)`, false},
+		{"IPv4 TCP", "5.6.7.8", "", 1053, TCP, `"IPv4 TCP" (5.6.7.8:1053/tcp)`, false},
+		{"IPv6 TCP", "2001:db8::1", "", 80, TCP, `"IPv6 TCP" ([2001:db8::1]:80/tcp)`, false},
+		{"IPv4 TCP, all addresses", "", IPv4, 1053, TCP, `"IPv4 TCP, all addresses" (:1053/tcp4)`, false},
+		{"IPv6 TCP, all addresses", "", IPv6, 80, TCP, `"IPv6 TCP, all addresses" (:80/tcp6)`, false},
+		{"No ip family TCP, all addresses", "", "", 80, TCP, `"No ip family TCP, all addresses" (:80/tcp)`, false},
+		{"IP family mismatch", "2001:db8::2", IPv4, 80, TCP, "", true},
+		{"IP family mismatch", "1.2.3.4", IPv6, 80, TCP, "", true},
+		{"Unsupported protocol", "2001:db8::2", "", 80, "http", "", true},
+		{"Invalid IP", "300", "", 80, TCP, "", true},
+		{"Invalid ip family", "", "5", 80, TCP, "", true},
+	}
+
+	for _, tc := range testCases {
+		lp, err := NewLocalPort(
+			tc.description,
+			tc.ip,
+			tc.family,
+			tc.port,
+			tc.protocol,
+		)
+		if tc.expectedErr {
+			if err == nil {
+				t.Errorf("Expected err when creating LocalPort %v", tc)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("Unexpected err when creating LocalPort %s", err)
+			continue
+		}
+		str := lp.String()
+		if str != tc.expectedStr {
+			t.Errorf("Unexpected output for %s, expected: %s, got: %s", tc.description, tc.expectedStr, str)
+		}
+	}
+}

--- a/internal/cri/netutil/util.go
+++ b/internal/cri/netutil/util.go
@@ -1,0 +1,79 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"errors"
+	"net"
+	"reflect"
+	"strings"
+	"syscall"
+)
+
+// IPNetEqual checks if the two input IPNets are representing the same subnet.
+// For example,
+//
+//	10.0.0.1/24 and 10.0.0.0/24 are the same subnet.
+//	10.0.0.1/24 and 10.0.0.0/25 are not the same subnet.
+func IPNetEqual(ipnet1, ipnet2 *net.IPNet) bool {
+	if ipnet1 == nil || ipnet2 == nil {
+		return false
+	}
+	if reflect.DeepEqual(ipnet1.Mask, ipnet2.Mask) && ipnet1.Contains(ipnet2.IP) && ipnet2.Contains(ipnet1.IP) {
+		return true
+	}
+	return false
+}
+
+// Returns if the given err is "connection reset by peer" error.
+func IsConnectionReset(err error) bool {
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return errno == syscall.ECONNRESET
+	}
+	return false
+}
+
+// Returns if the given err is "http2: client connection lost" error.
+func IsHTTP2ConnectionLost(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "http2: client connection lost")
+}
+
+// Returns if the given err is "connection refused" error
+func IsConnectionRefused(err error) bool {
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return errno == syscall.ECONNREFUSED
+	}
+	return false
+}

--- a/internal/cri/netutil/util_test.go
+++ b/internal/cri/netutil/util_test.go
@@ -1,0 +1,112 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"net"
+	"net/url"
+	"os"
+	"syscall"
+	"testing"
+)
+
+func getIPNet(cidr string) *net.IPNet {
+	_, ipnet, _ := net.ParseCIDR(cidr)
+	return ipnet
+}
+
+func TestIPNetEqual(t *testing.T) {
+	testCases := []struct {
+		ipnet1 *net.IPNet
+		ipnet2 *net.IPNet
+		expect bool
+	}{
+		// null case
+		{
+			getIPNet("10.0.0.1/24"),
+			getIPNet(""),
+			false,
+		},
+		{
+			getIPNet("10.0.0.0/24"),
+			getIPNet("10.0.0.0/24"),
+			true,
+		},
+		{
+			getIPNet("10.0.0.0/24"),
+			getIPNet("10.0.0.1/24"),
+			true,
+		},
+		{
+			getIPNet("10.0.0.0/25"),
+			getIPNet("10.0.0.0/24"),
+			false,
+		},
+		{
+			getIPNet("10.0.1.0/24"),
+			getIPNet("10.0.0.0/24"),
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		if tc.expect != IPNetEqual(tc.ipnet1, tc.ipnet2) {
+			t.Errorf("Expect equality of %s and %s be to %v", tc.ipnet1.String(), tc.ipnet2.String(), tc.expect)
+		}
+	}
+}
+
+func TestIsConnectionRefused(t *testing.T) {
+	testCases := []struct {
+		err    error
+		expect bool
+	}{
+		{
+			&url.Error{Err: &net.OpError{Err: syscall.ECONNRESET}},
+			false,
+		},
+		{
+			&url.Error{Err: &net.OpError{Err: syscall.ECONNREFUSED}},
+			true,
+		},
+		{&url.Error{Err: &net.OpError{Err: &os.SyscallError{Err: syscall.ECONNREFUSED}}},
+			true,
+		},
+	}
+
+	for _, tc := range testCases {
+		if result := IsConnectionRefused(tc.err); result != tc.expect {
+			t.Errorf("Expect to be %v, but actual is %v", tc.expect, result)
+		}
+	}
+}

--- a/internal/cri/server/streaming.go
+++ b/internal/cri/server/streaming.go
@@ -21,12 +21,16 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net/http"
+	"runtime"
+	"sync"
+	"time"
 
-	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/utils/exec"
 
 	ctrdutil "github.com/containerd/containerd/v2/internal/cri/util"
+	"github.com/containerd/log"
 	"k8s.io/kubelet/pkg/cri/streaming"
 )
 
@@ -83,7 +87,7 @@ func handleResizing(ctx context.Context, resize <-chan remotecommand.TerminalSiz
 	}
 
 	go func() {
-		defer runtime.HandleCrash()
+		defer HandleCrash()
 
 		for {
 			select {
@@ -100,4 +104,235 @@ func handleResizing(ctx context.Context, resize <-chan remotecommand.TerminalSiz
 			}
 		}
 	}()
+}
+
+var (
+	// ReallyCrash controls the behavior of HandleCrash and defaults to
+	// true. It's exposed so components can optionally set to false
+	// to restore prior behavior. This flag is mostly used for tests to validate
+	// crash conditions.
+	ReallyCrash = true
+)
+
+// PanicHandlers is a list of functions which will be invoked when a panic happens.
+var PanicHandlers = []func(context.Context, interface{}){logPanic}
+
+// HandleCrash simply catches a crash and logs an error. Meant to be called via
+// defer.  Additional context-specific handlers can be provided, and will be
+// called in case of panic.  HandleCrash actually crashes, after calling the
+// handlers and logging the panic message.
+//
+// E.g., you can provide one or more additional handlers for something like shutting down go routines gracefully.
+//
+// Contextual logging: HandleCrashWithContext should be used instead of HandleCrash in code which supports contextual logging.
+func HandleCrash(additionalHandlers ...func(interface{})) {
+	if r := recover(); r != nil {
+		additionalHandlersWithContext := make([]func(context.Context, interface{}), len(additionalHandlers))
+		for i, handler := range additionalHandlers {
+			chandler := handler // capture loop variable
+			additionalHandlersWithContext[i] = func(_ context.Context, r interface{}) {
+				chandler(r)
+			}
+		}
+
+		handleCrash(context.Background(), r, additionalHandlersWithContext...)
+	}
+}
+
+// HandleCrashWithContext simply catches a crash and logs an error. Meant to be called via
+// defer.  Additional context-specific handlers can be provided, and will be
+// called in case of panic.  HandleCrash actually crashes, after calling the
+// handlers and logging the panic message.
+//
+// E.g., you can provide one or more additional handlers for something like shutting down go routines gracefully.
+//
+// The context is used to determine how to log.
+func HandleCrashWithContext(ctx context.Context, additionalHandlers ...func(context.Context, interface{})) {
+	if r := recover(); r != nil {
+		handleCrash(ctx, r, additionalHandlers...)
+	}
+}
+
+// handleCrash is the common implementation of HandleCrash and HandleCrash.
+// Having those call a common implementation ensures that the stack depth
+// is the same regardless through which path the handlers get invoked.
+func handleCrash(ctx context.Context, r any, additionalHandlers ...func(context.Context, interface{})) {
+	for _, fn := range PanicHandlers {
+		fn(ctx, r)
+	}
+	for _, fn := range additionalHandlers {
+		fn(ctx, r)
+	}
+	if ReallyCrash {
+		// Actually proceed to panic.
+		panic(r)
+	}
+}
+
+// logPanic logs the caller tree when a panic occurs (except in the special case of http.ErrAbortHandler).
+func logPanic(ctx context.Context, r interface{}) {
+	if r == http.ErrAbortHandler {
+		// honor the http.ErrAbortHandler sentinel panic value:
+		//   ErrAbortHandler is a sentinel panic value to abort a handler.
+		//   While any panic from ServeHTTP aborts the response to the client,
+		//   panicking with ErrAbortHandler also suppresses logging of a stack trace to the server's error log.
+		return
+	}
+
+	// Same as stdlib http server code. Manually allocate stack trace buffer size
+	// to prevent excessively large logs
+	const size = 64 << 10
+	stacktrace := make([]byte, size)
+	stacktrace = stacktrace[:runtime.Stack(stacktrace, false)]
+
+	// We don't really know how many call frames to skip because the Go
+	// panic handler is between us and the code where the panic occurred.
+	// If it's one function (as in Go 1.21), then skipping four levels
+	// gets us to the function which called the `defer HandleCrashWithontext(...)`.
+	logger := log.GetLogger(ctx)
+
+	// For backwards compatibility, conversion to string
+	// is handled here instead of defering to the logging
+	// backend.
+	if _, ok := r.(string); ok {
+		logger.Error(nil, "Observed a panic", "panic", r, "stacktrace", string(stacktrace))
+	} else {
+		logger.Error(nil, "Observed a panic", "panic", fmt.Sprintf("%v", r), "panicGoValue", fmt.Sprintf("%#v", r), "stacktrace", string(stacktrace))
+	}
+}
+
+// ErrorHandlers is a list of functions which will be invoked when a nonreturnable
+// error occurs.
+// TODO(lavalamp): for testability, this and the below HandleError function
+// should be packaged up into a testable and reusable object.
+var ErrorHandlers = []ErrorHandler{
+	logError,
+	func(_ context.Context, _ error, _ string, _ ...interface{}) {
+		(&rudimentaryErrorBackoff{
+			lastErrorTime: time.Now(),
+			// 1ms was the number folks were able to stomach as a global rate limit.
+			// If you need to log errors more than 1000 times a second you
+			// should probably consider fixing your code instead. :)
+			minPeriod: time.Millisecond,
+		}).OnError()
+	},
+}
+
+type ErrorHandler func(ctx context.Context, err error, msg string, keysAndValues ...interface{})
+
+// HandlerError is a method to invoke when a non-user facing piece of code cannot
+// return an error and needs to indicate it has been ignored. Invoking this method
+// is preferable to logging the error - the default behavior is to log but the
+// errors may be sent to a remote server for analysis.
+//
+// Contextual logging: HandleErrorWithContext should be used instead of HandleError in code which supports contextual logging.
+func HandleError(err error) {
+	// this is sometimes called with a nil error.  We probably shouldn't fail and should do nothing instead
+	if err == nil {
+		return
+	}
+
+	handleError(context.Background(), err, "Unhandled Error")
+}
+
+// HandlerErrorWithContext is a method to invoke when a non-user facing piece of code cannot
+// return an error and needs to indicate it has been ignored. Invoking this method
+// is preferable to logging the error - the default behavior is to log but the
+// errors may be sent to a remote server for analysis. The context is used to
+// determine how to log the error.
+//
+// If contextual logging is enabled, the default log output is equivalent to
+//
+//	logr.FromContext(ctx).WithName("UnhandledError").Error(err, msg, keysAndValues...)
+//
+// Without contextual logging, it is equivalent to:
+//
+//	klog.ErrorS(err, msg, keysAndValues...)
+//
+// In contrast to HandleError, passing nil for the error is still going to
+// trigger a log entry. Don't construct a new error or wrap an error
+// with fmt.Errorf. Instead, add additional information via the mssage
+// and key/value pairs.
+//
+// This variant should be used instead of HandleError because it supports
+// structured, contextual logging.
+func HandleErrorWithContext(ctx context.Context, err error, msg string, keysAndValues ...interface{}) {
+	handleError(ctx, err, msg, keysAndValues...)
+}
+
+// handleError is the common implementation of HandleError and HandleErrorWithContext.
+// Using this common implementation ensures that the stack depth
+// is the same regardless through which path the handlers get invoked.
+func handleError(ctx context.Context, err error, msg string, keysAndValues ...interface{}) {
+	for _, fn := range ErrorHandlers {
+		fn(ctx, err, msg, keysAndValues...)
+	}
+}
+
+// logError prints an error with the call stack of the location it was reported.
+// It expects to be called as <caller> -> HandleError[WithContext] -> handleError -> logError.
+func logError(ctx context.Context, err error, msg string, keysAndValues ...interface{}) {
+	logger := log.GetLogger(ctx)
+	logger.WithError(err).Errorf(msg, keysAndValues...) //nolint:logcheck // logcheck complains about unknown key/value pairs.
+}
+
+type rudimentaryErrorBackoff struct {
+	minPeriod time.Duration // immutable
+	// TODO(lavalamp): use the clock for testability. Need to move that
+	// package for that to be accessible here.
+	lastErrorTimeLock sync.Mutex
+	lastErrorTime     time.Time
+}
+
+// OnError will block if it is called more often than the embedded period time.
+// This will prevent overly tight hot error loops.
+func (r *rudimentaryErrorBackoff) OnError() {
+	now := time.Now() // start the timer before acquiring the lock
+	r.lastErrorTimeLock.Lock()
+	d := now.Sub(r.lastErrorTime)
+	r.lastErrorTime = time.Now()
+	r.lastErrorTimeLock.Unlock()
+
+	// Do not sleep with the lock held because that causes all callers of HandleError to block.
+	// We only want the current goroutine to block.
+	// A negative or zero duration causes time.Sleep to return immediately.
+	// If the time moves backwards for any reason, do nothing.
+	time.Sleep(r.minPeriod - d)
+}
+
+// GetCaller returns the caller of the function that calls it.
+func GetCaller() string {
+	var pc [1]uintptr
+	runtime.Callers(3, pc[:])
+	f := runtime.FuncForPC(pc[0])
+	if f == nil {
+		return "Unable to find caller"
+	}
+	return f.Name()
+}
+
+// RecoverFromPanic replaces the specified error with an error containing the
+// original error, and  the call tree when a panic occurs. This enables error
+// handlers to handle errors and panics the same way.
+func RecoverFromPanic(err *error) {
+	if r := recover(); r != nil {
+		// Same as stdlib http server code. Manually allocate stack trace buffer size
+		// to prevent excessively large logs
+		const size = 64 << 10
+		stacktrace := make([]byte, size)
+		stacktrace = stacktrace[:runtime.Stack(stacktrace, false)]
+
+		*err = fmt.Errorf(
+			"recovered from panic %q. (err=%v) Call stack:\n%s",
+			r,
+			*err,
+			stacktrace)
+	}
+}
+
+// Must panics on non-nil errors. Useful to handling programmer level errors.
+func Must(err error) {
+	if err != nil {
+		panic(err)
+	}
 }


### PR DESCRIPTION
one of N PRs to clean up / eliminate our k8s.io vendor impact to only external apis that carry no k8s.io internal baggage like the min golang version definition in go.mod

After this PR k8s.io/apimachinery is no longer directly imported by this repo.

This one is a part of the streaming exec/probe/portforword/... bucket of changes This is the next of the PRs that were necessary before moving over the k8s.io/kubelet/pkg/cri/streaming that will build on this.

addressing issue: https://github.com/kubernetes/kubernetes/issues/130799

This one merges and clones "k8s.io/utils/net" and "k8s.io/apimachinery/pkg/util/net" into internal/cri/netutil
- removes golang 1.17 hack that added "sloppy" versions of net ParseIP and ParseCIDR
- replaces use of klog and k8s.io/apimachinery/pkg/util/sets from the cloned packages with our internal logging and internal/cri/setutils
