### PR TITLE
Use fully qualified image names when tagging

### DIFF
--- a/cmd/ctr/commands/images/tag.go
+++ b/cmd/ctr/commands/images/tag.go
@@ -67,9 +67,11 @@ var tagCommand = &cli.Command{
 		if !cliContext.Bool("local") {
 			for _, targetRef := range cliContext.Args().Slice()[1:] {
 				if !cliContext.Bool("skip-reference-check") {
-					if _, err := reference.ParseAnyReference(targetRef); err != nil {
+					parsedRef, err := reference.ParseAnyReference(targetRef)
+					if err != nil {
 						return fmt.Errorf("error parsing reference: %q is not a valid repository/tag %v", targetRef, err)
 					}
+					targetRef = parsedRef.String()
 				}
 				err = client.Transfer(ctx, image.NewStore(ref), image.NewStore(targetRef))
 				if err != nil {
@@ -94,9 +96,11 @@ var tagCommand = &cli.Command{
 		// Support multiple references for one command run
 		for _, targetRef := range cliContext.Args().Slice()[1:] {
 			if !cliContext.Bool("skip-reference-check") {
-				if _, err := reference.ParseAnyReference(targetRef); err != nil {
+				parsedRef, err := reference.ParseAnyReference(targetRef)
+				if err != nil {
 					return fmt.Errorf("error parsing reference: %q is not a valid repository/tag %v", targetRef, err)
 				}
+				targetRef = parsedRef.String()
 			}
 			image.Name = targetRef
 			// Attempt to create the image first


### PR DESCRIPTION
Utilize the parsed reference (including domain) from `reference.ParseAnyReference()` when tagging images. This ensures tags are stored with their canonical name, resolving issues where images tagged with a short name (e.g. "busybox:latest") could not be removed using their fully qualified name.

Fixes #8848

Tested by running repro in issue above:
```shell
$ sudo bin/ctr -a /tmp/containerd.sock -n k8s.io images pull docker.io/library/busybox:1.36
... pull output

$ sudo bin/ctr -a /tmp/containerd.sock -n k8s.io images tag docker.io/library/busybox:1.36 busybox:fixed
docker.io/library/busybox:fixed

$ sudo /usr/local/bin/crictl -r unix:///tmp/containerd.sock images | grep busy
docker.io/library/busybox   1.36                2d61ae04c2b80       2.15MB
docker.io/library/busybox   fixed               2d61ae04c2b80       2.15MB

# Doesn't error with image not found
$ sudo bin/ctr -a /tmp/containerd.sock -n k8s.io run --rm docker.io/library/busybox:fixed 1234
```