### PR TITLE
ctr:make sure containerd socket exist before create client

### DIFF
--- a/cmd/ctr/commands/client.go
+++ b/cmd/ctr/commands/client.go
@@ -18,6 +18,7 @@ package commands
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strconv"
 
@@ -59,7 +60,11 @@ func AppContext(cliContext *cli.Context) (context.Context, context.CancelFunc) {
 func NewClient(cliContext *cli.Context, opts ...containerd.Opt) (*containerd.Client, context.Context, context.CancelFunc, error) {
 	timeoutOpt := containerd.WithTimeout(cliContext.Duration("connect-timeout"))
 	opts = append(opts, timeoutOpt)
-	client, err := containerd.New(cliContext.String("address"), opts...)
+	socketPath := cliContext.String("address")
+	if _, err := os.Stat(socketPath); err != nil {
+		return nil, nil, nil, fmt.Errorf("cannot access socket %s: %w", socketPath, err)
+	}
+	client, err := containerd.New(socketPath, opts...)
 	if err != nil {
 		return nil, nil, nil, err
 	}


### PR DESCRIPTION
if containerd is not running.
old version
```
 time ctr t ls
WARN[0010] Failed to check deprecations                  error="connection error: desc = \"transport: Error while dialing: dial unix:///run/containerd/containerd.sock: timeout\""
ctr: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial unix:///run/containerd/containerd.sock: timeout"

real    0m10.020s
user    0m0.154s
sys     0m0.171s
```

```
❯ time nerdctl  ps
FATA[0000] cannot access containerd socket "/run/containerd/containerd.sock": no such file or directory 

real    0m0.020s
user    0m0.008s
sys     0m0.015s
```