### PR TITLE
Prepare release notes for api/v1.9.0

### DIFF
--- a/api/releases/v1.9.0.toml
+++ b/api/releases/v1.9.0.toml
@@ -9,7 +9,7 @@ ignore_deps = [ "github.com/containerd/containerd" ]
 # previous release
 previous = "api/v1.8.0"
 
-pre_release = true
+pre_release = false
 
 preface = """\
 The 10th release for the containerd 1.x API aligns with the containerd 2.1 release.


### PR DESCRIPTION
Start of the 2.1 release process

----

Welcome to the api/v1.9.0 release of containerd!

The 10th release for the containerd 1.x API aligns with the containerd 2.1 release.

### Highlights

* Add content create event ([#11006](https://github.com/containerd/containerd/pull/11006))

#### Container Runtime Interface (CRI)

* Support container restore through CRI/Kubernetes ([#10365](https://github.com/containerd/containerd/pull/10365))

#### Image Distribution

* Enable HTTP debug and trace for transfer based puller ([#10762](https://github.com/containerd/containerd/pull/10762))

Please try out the release binaries and report any issues at
https://github.com/containerd/containerd/issues.

### Contributors

* Derek McGowan
* Maksym Pavlenko
* Akihiro Suda
* Davanum Srinivas
* Phil Estes
* Adrian Reber
* Jin Dong
* Philip Laine

### Changes
<details><summary>17 commits</summary>
<p>

  * [`145175bf4`](https://github.com/containerd/containerd/commit/145175bf4fb1a21be4c686115f0d83ba19e9fe92) Prepare release notes for api/v1.9.0
* Add release notes for api v1.9.0-rc.0 ([#11751](https://github.com/containerd/containerd/pull/11751))
  * [`c0ce618a1`](https://github.com/containerd/containerd/commit/c0ce618a10541b5e1d2979c2d70e971b23c8a16b) Add release notes for api v1.9.0-rc.0
* Enable HTTP debug and trace for transfer based puller ([#10762](https://github.com/containerd/containerd/pull/10762))
  * [`17b6e1ef8`](https://github.com/containerd/containerd/commit/17b6e1ef85098c532bae0e9544f288ebe530b3fe) Allow streaming to client
  * [`40eb2fdbb`](https://github.com/containerd/containerd/commit/40eb2fdbbb66aa6ef51422e6f62d8f3fb48ab35e) Fix protos
  * [`1d436803d`](https://github.com/containerd/containerd/commit/1d436803dc532c8fd40735c92fd1041dc2cc2868) Add http debug fields to OCI registry protos
* Add content create event ([#11006](https://github.com/containerd/containerd/pull/11006))
  * [`752914b5b`](https://github.com/containerd/containerd/commit/752914b5bfaa4e28d1231901c37bf8d3b47ca73c) Add content create event to api
* bump golang.org/x/net from 0.33.0 to 0.37.0 ([#11574](https://github.com/containerd/containerd/pull/11574))
  * [`7fe5c4123`](https://github.com/containerd/containerd/commit/7fe5c41237b8da120ab45b30ea3f02d64b71a68b) go.mod: golang.org/x/net v0.37.0
* Support container restore through CRI/Kubernetes ([#10365](https://github.com/containerd/containerd/pull/10365))
  * [`9e6beafd5`](https://github.com/containerd/containerd/commit/9e6beafd53919eecd1fb650a76332002cf4c84dd) Support container restore through CRI/Kubernetes
* build(deps): bump golang.org/x/net from 0.23.0 to 0.33.0 in /api ([#11472](https://github.com/containerd/containerd/pull/11472))
  * [`37fe1e8b4`](https://github.com/containerd/containerd/commit/37fe1e8b42f8746944c5d9b4a8bf2b3dcfc99984) build(deps): bump golang.org/x/net from 0.23.0 to 0.33.0 in /api
* Bump to newer opencontainers/image-spec @ v1.1.1 ([#11461](https://github.com/containerd/containerd/pull/11461))
  * [`d37ea6977`](https://github.com/containerd/containerd/commit/d37ea6977d7e096e9221cbbba9a0282e97709acd) Bump to newer opencontainers/image-spec @ v1.1.1
</p>
</details>

### Dependency Changes

* **github.com/opencontainers/image-spec**  v1.1.0 -> v1.1.1
* **golang.org/x/net**                      v0.23.0 -> v0.37.0
* **golang.org/x/sys**                      v0.18.0 -> v0.31.0
* **golang.org/x/text**                     v0.14.0 -> v0.23.0
* **gopkg.in/yaml.v3**                      v3.0.1 **_new_**

Previous release can be found at [api/v1.8.0](https://github.com/containerd/containerd/releases/tag/api/v1.8.0)

