### PR TITLE
core/runtime/v2: cleanup shim-cleanup logs

### DIFF
--- a/core/runtime/v2/shim.go
+++ b/core/runtime/v2/shim.go
@@ -138,7 +138,7 @@ func cleanupAfterDeadShim(ctx context.Context, id string, rt *runtime.NSMap[Shim
 	ctx, cancel := timeout.WithContext(ctx, cleanupTimeout)
 	defer cancel()
 
-	log.G(ctx).WithField("id", id).Warn("cleaning up after shim disconnected")
+	log.G(ctx).WithField("id", id).Info("cleaning up after shim disconnected")
 	response, err := binaryCall.Delete(ctx)
 	if err != nil {
 		log.G(ctx).WithError(err).WithField("id", id).Warn("failed to clean up after shim disconnected")


### PR DESCRIPTION
I noticed that the "cleaning up after shim disconnected" was logged as a warning, but I couldn't find a reason why it was considered a warning ( and didn't see an error attached to the log);

    INFO[2025-05-07T08:57:56.576773500Z] ignoring event                                container=589c33c88591a9936cb8fd64453e4b0c1357ae2f79d975c34645ff8f0aa10485 module=libcontainerd namespace=moby topic=/tasks/delete type="*events.TaskDelete"
    INFO[2025-05-07T08:57:56.576938958Z] shim disconnected                             id=589c33c88591a9936cb8fd64453e4b0c1357ae2f79d975c34645ff8f0aa10485 namespace=moby
    WARN[2025-05-07T08:57:56.577356208Z] cleaning up after shim disconnected           id=589c33c88591a9936cb8fd64453e4b0c1357ae2f79d975c34645ff8f0aa10485 namespace=moby
    INFO[2025-05-07T08:57:56.577393417Z] cleaning up dead shim                         namespace=moby

I think this must've been set as a warning by acccident, so changing this log to an "info" log as it seems part of the normal flow or operations.

While updating, also updating related logs, such as the "cleaning up dead shim" log, to include the id, so that these logs can more easily be correlated.