### PR TITLE
replace "cleanup.Background" for "context.WithoutCancel"

### DIFF
--- a/core/metadata/db.go
+++ b/core/metadata/db.go
@@ -33,7 +33,6 @@ import (
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/events"
 	"github.com/containerd/containerd/v2/core/snapshots"
-	"github.com/containerd/containerd/v2/internal/cleanup"
 	"github.com/containerd/containerd/v2/pkg/gc"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 )
@@ -527,7 +526,7 @@ func (m *DB) getMarked(ctx context.Context, c *gcContext) (map[gc.Node]struct{},
 }
 
 func (m *DB) cleanupSnapshotter(ctx context.Context, name string) (time.Duration, error) {
-	ctx = cleanup.Background(ctx)
+	ctx = context.WithoutCancel(ctx)
 	sn, ok := m.ss[name]
 	if !ok {
 		return 0, nil
@@ -544,7 +543,7 @@ func (m *DB) cleanupSnapshotter(ctx context.Context, name string) (time.Duration
 }
 
 func (m *DB) cleanupContent(ctx context.Context) (time.Duration, error) {
-	ctx = cleanup.Background(ctx)
+	ctx = context.WithoutCancel(ctx)
 	if m.cs == nil {
 		return 0, nil
 	}

--- a/core/runtime/v2/shim_load.go
+++ b/core/runtime/v2/shim_load.go
@@ -27,7 +27,6 @@ import (
 	"github.com/containerd/log"
 
 	"github.com/containerd/containerd/v2/core/mount"
-	"github.com/containerd/containerd/v2/internal/cleanup"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/timeout"
 )
@@ -160,7 +159,7 @@ func (m *ShimManager) loadShim(ctx context.Context, bundle *Bundle) error {
 	shim, err := loadShimTask(ctx, bundle, func() {
 		log.G(ctx).WithField("id", id).Info("shim disconnected")
 
-		cleanupAfterDeadShim(cleanup.Background(ctx), id, m.shims, m.events, binaryCall)
+		cleanupAfterDeadShim(context.WithoutCancel(ctx), id, m.shims, m.events, binaryCall)
 		// Remove self from the runtime task list.
 		m.shims.Delete(ctx, id)
 	})

--- a/core/runtime/v2/task_manager.go
+++ b/core/runtime/v2/task_manager.go
@@ -37,7 +37,6 @@ import (
 	apitypes "github.com/containerd/containerd/api/types"
 
 	"github.com/containerd/containerd/v2/core/runtime"
-	"github.com/containerd/containerd/v2/internal/cleanup"
 	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
 	"github.com/containerd/containerd/v2/pkg/timeout"
 	"github.com/containerd/containerd/v2/plugins"
@@ -167,14 +166,14 @@ func (m *TaskManager) Create(ctx context.Context, taskID string, opts runtime.Cr
 		// NOTE: ctx contains required namespace information.
 		m.manager.shims.Delete(ctx, taskID)
 
-		dctx, cancel := timeout.WithContext(cleanup.Background(ctx), cleanupTimeout)
+		dctx, cancel := timeout.WithContext(context.WithoutCancel(ctx), cleanupTimeout)
 		defer cancel()
 
 		sandboxed := opts.SandboxID != ""
 		_, errShim := shimTask.delete(dctx, sandboxed, func(context.Context, string) {})
 		if errShim != nil {
 			if errdefs.IsDeadlineExceeded(errShim) {
-				dctx, cancel = timeout.WithContext(cleanup.Background(ctx), cleanupTimeout)
+				dctx, cancel = timeout.WithContext(context.WithoutCancel(ctx), cleanupTimeout)
 				defer cancel()
 			}
 

--- a/internal/cleanup/context.go
+++ b/internal/cleanup/context.go
@@ -22,11 +22,6 @@ import (
 	"time"
 )
 
-// Background creates a new context which clears out the parent errors
-func Background(ctx context.Context) context.Context {
-	return context.WithoutCancel(ctx)
-}
-
 // Do runs the provided function with a context in which the
 // errors are cleared out and will timeout after 10 seconds.
 func Do(ctx context.Context, do func(context.Context)) {

--- a/internal/cleanup/context.go
+++ b/internal/cleanup/context.go
@@ -22,31 +22,15 @@ import (
 	"time"
 )
 
-type clearCancel struct {
-	context.Context
-}
-
-func (cc clearCancel) Deadline() (deadline time.Time, ok bool) {
-	return
-}
-
-func (cc clearCancel) Done() <-chan struct{} {
-	return nil
-}
-
-func (cc clearCancel) Err() error {
-	return nil
-}
-
 // Background creates a new context which clears out the parent errors
 func Background(ctx context.Context) context.Context {
-	return clearCancel{ctx}
+	return context.WithoutCancel(ctx)
 }
 
 // Do runs the provided function with a context in which the
 // errors are cleared out and will timeout after 10 seconds.
 func Do(ctx context.Context, do func(context.Context)) {
-	ctx, cancel := context.WithTimeout(clearCancel{ctx}, 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 	do(ctx)
 	cancel()
 }

--- a/internal/cleanup/context.go
+++ b/internal/cleanup/context.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-// Package providing utilies to help cleanup
+// Package cleanup provides utilies to help cleanup.
 package cleanup
 
 import (


### PR DESCRIPTION
### replace "cleanup.Background" for "context.WithoutCancel"

the `cleanup.Background` utility was introduced in f606c4eba7386f64a8b4db9a5b2b88ef16e42657,
at which time the project used go1.19, and Go's stdlib context did not yet
have [`context.WithoutCancel`], which was introduced in go1.21.

This patch replaces `cleanup.Background` for `context.WithoutCancel`, which
is near-identical, and part of go stdlib;

`cleanup.Background`:

```go
type clearCancel struct {
	context.Context
}

func (cc clearCancel) Deadline() (deadline time.Time, ok bool) {
	return
}

func (cc clearCancel) Done() <-chan struct{} {
	return nil
}

func (cc clearCancel) Err() error {
	return nil
}

// Background creates a new context which clears out the parent errors
func Background(ctx context.Context) context.Context {
	return clearCancel{ctx}
}
```

`context.WithoutCancel`:

```go
// WithoutCancel returns a derived context that points to the parent context
// and is not canceled when parent is canceled.
// The returned context returns no Deadline or Err, and its Done channel is nil.
// Calling [Cause] on the returned context returns nil.
func WithoutCancel(parent Context) Context {
	if parent == nil {
		panic("cannot create context from nil parent")
	}
	return withoutCancelCtx{parent}
}

type withoutCancelCtx struct {
	c Context
}

func (withoutCancelCtx) Deadline() (deadline time.Time, ok bool) {
	return
}

func (withoutCancelCtx) Done() <-chan struct{} {
	return nil
}

func (withoutCancelCtx) Err() error {
	return nil
}

func (c withoutCancelCtx) Value(key any) any {
	return value(c, key)
}

func (c withoutCancelCtx) String() string {
	return contextName(c.c) + ".WithoutCancel"
}
```

[`context.WithoutCancel`]: https://pkg.go.dev/context@go1.21.0#WithoutCancel
