### PR TITLE
[release/2.0] .github: do not mark 2.0 releases as latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,4 +166,4 @@ jobs:
           files: |
             builds/release-tars-**/*
             containerd-*-attestation.intoto.jsonl
-          make_latest: true
+          make_latest: false


### PR DESCRIPTION
We just released 2.1, these are now the latest.