### PR TITLE
ci:fix ci timeout on almalinux

### DIFF
--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -55,7 +55,7 @@ import (
 )
 
 const (
-	timeout                    = 1 * time.Minute
+	timeout                    = 3 * time.Minute
 	k8sNamespace               = constants.K8sContainerdNamespace
 	defaultCgroupSystemdParent = "/containerd-test.slice"
 )


### PR DESCRIPTION
many ci error because of time out on almalinux

```
    default:     sandbox_clean_remove_test.go:108:
    default:         	Error Trace:	/root/go/src/github.com/containerd/containerd/integration/sandbox_clean_remove_test.go:108
    default:         	Error:      	Received unexpected error:
    default:         	            	timeout exceeded
    default:         	Test:       	TestSandboxRemoveWithoutIPLeakage
    default:         	Messages:   	sandbox state should become NOTREADY
    default:     sandbox_clean_remove_test.go:116: Should still be able to find the pod ip in host-local checkpoint
    default:     sandbox_clean_remove_test.go:119: Should be able to stop and remove the sandbox
    default: time="2025-05-08T02:00:25Z" level=info msg="[RuntimeService] StopPodSandbox (podSandboxID=3d9dfe25eea40268e3f1fdfb1d7764e97b960828d7b8dec3c6022b982bc293c3, timeout=1m0s)"
    default: time="2025-05-08T02:00:25Z" level=info msg="[RuntimeService] StopPodSandbox Response (podSandboxID=3d9dfe25eea40268e3f1fdfb1d7764e97b960828d7b8dec3c6022b982bc293c3)"
    default: time="2025-05-08T02:00:25Z" level=info msg="[RuntimeService] RemovePodSandbox (podSandboxID=3d9dfe25eea40268e3f1fdfb1d7764e97b960828d7b8dec3c6022b982bc293c3, timeout=1m0s)"
    default: time="2025-05-08T02:00:25Z" level=info msg="[RuntimeService] RemovePodSandbox Response (podSandboxID=3d9dfe25eea40268e3f1fdfb1d7764e97b960828d7b8dec3c6022b982bc293c3)"
    default:     sandbox_clean_remove_test.go:123: Should not be able to find the pod ip in host-local checkpoint
    default: time="2025-05-08T02:00:25Z" level=info msg="[RuntimeService] StopPodSandbox (podSandboxID=3d9dfe25eea40268e3f1fdfb1d7764e97b960828d7b8dec3c6022b982bc293c3, timeout=1m0s)"
    default: time="2025-05-08T02:00:25Z" level=info msg="[RuntimeService] StopPodSandbox Response (podSandboxID=3d9dfe25eea40268e3f1fdfb1d7764e97b960828d7b8dec3c6022b982bc293c3)"
    default: time="2025-05-08T02:00:25Z" level=info msg="[RuntimeService] RemovePodSandbox (podSandboxID=3d9dfe25eea40268e3f1fdfb1d7764e97b960828d7b8dec3c6022b982bc293c3, timeout=1m0s)"
    default: time="2025-05-08T02:00:25Z" level=info msg="[RuntimeService] RemovePodSandbox Response (podSandboxID=3d9dfe25eea40268e3f1fdfb1d7764e97b960828d7b8dec3c6022b982bc293c3)"
    default: --- FAIL: TestSandboxRemoveWithoutIPLeakage (30.85s)
```