### PR TITLE
cri:use debug level when receive exec process exited events

### DIFF
--- a/internal/cri/server/podsandbox/events.go
+++ b/internal/cri/server/podsandbox/events.go
@@ -43,7 +43,7 @@ type podSandboxEventHandler struct {
 func (p *podSandboxEventHandler) HandleEvent(any interface{}) error {
 	switch e := any.(type) {
 	case *eventtypes.TaskExit:
-		log.L.Infof("TaskExit event in podsandbox handler %+v", e)
+		log.L.Debugf("TaskExit event in podsandbox handler %+v", e)
 		// Use ID instead of ContainerID to rule out TaskExit event for exec.
 		sb := p.controller.store.Get(e.ID)
 		if sb == nil || sb.Container == nil {


### PR DESCRIPTION
if use exec to do some health check will generate many exec exited events log.
fix:https://github.com/containerd/containerd/issues/11836
@AkihiroSuda  @mxpv  can you review this pr ? It is easily to review. Thanks.