### PR TITLE
seccomp: kernel v6.13 (libseccomp v2.6.0)

### DIFF
--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -201,12 +201,16 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				"link",
 				"linkat",
 				"listen",
+				"listmount", // kernel v6.8, libseccomp v2.6.0
 				"listxattr",
 				"llistxattr",
 				"_llseek",
 				"lremovexattr",
 				"lseek",
 				"lsetxattr",
+				"lsm_get_self_attr", // kernel v6.8, libseccomp v2.6.0
+				"lsm_list_modules",  // kernel v6.8, libseccomp v2.6.0
+				"lsm_set_self_attr", // kernel v6.8, libseccomp v2.6.0
 				"lstat",
 				"lstat64",
 				"madvise",
@@ -234,6 +238,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				"mq_timedsend_time64",
 				"mq_unlink",
 				"mremap",
+				"mseal", // kernel v6.10, libseccomp v2.6.0
 				"msgctl",
 				"msgget",
 				"msgrcv",
@@ -369,6 +374,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				"stat64",
 				"statfs",
 				"statfs64",
+				"statmount", // kernel v6.8, libseccomp v2.6.0
 				"statx",
 				"symlink",
 				"symlinkat",
@@ -400,6 +406,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				"uname",
 				"unlink",
 				"unlinkat",
+				"uretprobe", // kernel v6.11, libseccomp v2.6.0
 				"utime",
 				"utimensat",
 				"utimensat_time64",
@@ -560,6 +567,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 		s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
 			Names: []string{
 				"riscv_flush_icache",
+				"riscv_hwprobe", // kernel v6.12, libseccomp v2.6.0
 			},
 			Action: specs.ActAllow,
 			Args:   []specs.LinuxSeccompArg{},

--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -176,6 +176,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				"getuid",
 				"getuid32",
 				"getxattr",
+				"getxattrat", // kernel v6.13, libseccomp v2.6.0
 				"inotify_add_watch",
 				"inotify_init",
 				"inotify_init1",
@@ -203,6 +204,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				"listen",
 				"listmount", // kernel v6.8, libseccomp v2.6.0
 				"listxattr",
+				"listxattrat", // kernel v6.13, libseccomp v2.6.0
 				"llistxattr",
 				"_llseek",
 				"lremovexattr",
@@ -288,6 +290,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				"recvmsg",
 				"remap_file_pages",
 				"removexattr",
+				"removexattrat", // kernel v6.13, libseccomp v2.6.0
 				"rename",
 				"renameat",
 				"renameat2",
@@ -357,6 +360,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				"setuid",
 				"setuid32",
 				"setxattr",
+				"setxattrat", // kernel v6.13, libseccomp v2.6.0
 				"shmat",
 				"shmctl",
 				"shmdt",


### PR DESCRIPTION
## seccomp: kernel v6.12
reference: https://github.com/seccomp/libseccomp/commit/f01e67509e45c672f4bdd643d94d90867cc19d90 (libseccomp v2.6.0)

- v6.8:
  * listmount (https://github.com/torvalds/linux/commit/b4c2bea8ceaa50cd42a8f73667389d801a3ecf2d)
  * lsm_get_self_attr, lsm_set_self_attrs (https://github.com/torvalds/linux/commit/a04a1198088a1378d0389c250cc684f649bcc91e)
  * lsm_list_modules (https://github.com/torvalds/linux/commit/ad4aff9ec25f400608283c10d634cc4eeda83a02)
  * statmount (https://github.com/torvalds/linux/commit/46eae99ef73302f9fb3dddcd67c374b3dffe8fd6)

- v6.9:
  * mseal (https://github.com/torvalds/linux/commit/8be7258aad44b5e25977a98db136f677fa6f4370)

- v6.11:
  * uretprobe (https://github.com/torvalds/linux/commit/190fec72df4a5d4d98b1e783c333f471e5e5f344)

- v6.12:
  * riscv_hwprobe (https://github.com/torvalds/linux/commit/3db80c999debbadd5d627fb30f8b06fee331ffb6)


## seccomp: kernel v6.13
reference: https://github.com/seccomp/libseccomp/commit/42b596818635bf9d1cae54fa87e8c7b2e16869d3 (libseccomp v2.6.0)

- v6.13:
  * getxattrat, listxattrat, removexattrat, setxattrat (https://github.com/torvalds/linux/commit/6140be90ec70c39fa844741ca3cc807dd0866394)