### PR TITLE
erofs-snapshotter: a fix for native image support and a performance tip

### DIFF
--- a/docs/snapshotters/erofs.md
+++ b/docs/snapshotters/erofs.md
@@ -86,7 +86,7 @@ loaded (Linux 5.4 or later is required): it can be loaded with `modprobe erofs`.
 The following configuration can be used in your containerd `config.toml`. Don't
 forget to restart containerd after changing the configuration.
 
-```
+``` toml
   [plugins."io.containerd.snapshotter.v1.erofs"]
       # Enable fsverity support for EROFS layers, default is false
       enable_fsverity = true
@@ -96,6 +96,15 @@ forget to restart containerd after changing the configuration.
 
   [plugins."io.containerd.service.v1.diff-service"]
     default = ["erofs","walking"]
+```
+
+Note that if erofs-utils is 1.8.2 or higher, it's preferred to add
+`--sort=none` to the differ's `mkfs_options` to avoid unnecessary tar data
+reordering for improved performance, as shown below:
+
+``` toml
+  [plugins."io.containerd.differ.v1.erofs"]
+    mkfs_options = ["--sort=none"]
 ```
 
 ### Running a container

--- a/plugins/diff/erofs/differ_linux.go
+++ b/plugins/diff/erofs/differ_linux.go
@@ -76,8 +76,8 @@ func NewErofsDiffer(store content.Store, mkfsExtraOpts []string) differ {
 // Since `images.DiffCompression` doesn't support arbitrary media types,
 // disallow non-empty suffixes for now.
 func isErofsMediaType(mt string) bool {
-	mediaType, ext, ok := strings.Cut(mt, "+")
-	if !ok || ext != "" {
+	mediaType, _, hasExt := strings.Cut(mt, "+")
+	if hasExt {
 		return false
 	}
 	return strings.HasSuffix(mediaType, ".erofs")


### PR DESCRIPTION
1.  erofs-differ: fix EROFS native image support

```
A dumb bug was just found after I worked out a usable native
converter [1], instead of relying on some prebuilt image..
[1] https://github.com/erofs/erofs-container-toolkit
```

2. docs/snapshotters/erofs.md: a tip for improved performance

```
It's preferred to use `--sort=none` (erofs-utils 1.8.2+) to avoid
tar data twice due to stricter data ordering.
See: https://git.kernel.org/xiang/erofs-utils/c/e97530622872
```