### PR TITLE
docs(ansible): fix the folder in step1

### DIFF
--- a/contrib/ansible/README.md
+++ b/contrib/ansible/README.md
@@ -22,7 +22,7 @@ $ cat hosts
 At this point, the ansible playbook should be able to ssh into the machines in the hosts file.
 ```console
 git clone https://github.com/containerd/containerd
-cd ./contrib/ansible
+cd ./containerd/contrib/ansible
 ansible-playbook -i hosts cri-containerd.yaml
 ```
 A typical cloud login might have a username and private key file, in which case the following can be used:


### PR DESCRIPTION
In the step1 of the documentation, after the git clone, it is necessary to move in the folder of the source of the git clone