### PR TITLE
Fetch image with default platform only in TestExportAndImportMultiLayer

### DIFF
--- a/integration/client/import_test.go
+++ b/integration/client/import_test.go
@@ -79,7 +79,7 @@ func testExportImport(t *testing.T, imageName string) {
 	}
 	defer client.Close()
 
-	_, err = client.Fetch(ctx, imageName)
+	_, err = client.Fetch(ctx, imageName, WithPlatformMatcher(platforms.Default()))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
`TestExportAndImportMultiLayer` has been very flaky due to upstream registry throttling/unavailability. E.g.,

https://github.com/containerd/containerd/actions/runs/15168768477/job/42653479864

```shell
    log_hook.go:47: time="2025-05-21T17:42:37.345336659Z" level=debug msg="fetch failed" func=docker.dockerFetcher.open file="/home/runner/work/containerd/containerd/core/remotes/docker/fetcher.go:470" digest="sha256:5178da1ca6af8a14a235f58eb31955ca5f4c72f950d35f9bb67a8bd20232d840" error="unexpected status code https://mcr.microsoft.com/v2/windows/nanoserver/blobs/sha256:5178da1ca6af8a14a235f58eb31955ca5f4c72f950d35f9bb67a8bd20232d840: 503 Service Unavailable" mediatype=application/vnd.docker.image.rootfs.foreign.diff.tar.gzip size=116254563 testcase=TestExportAndImportMultiLayer url="https://mcr.microsoft.com/v2/windows/nanoserver/blobs/sha256:5178da1ca6af8a14a235f58eb31955ca5f4c72f950d35f9bb67a8bd20232d840"
```

Notice this test fetches all platform images which is unnecessary I think. E.g., the 503 from mcr above caused Linux test failures. This change should reduce requests to `mcr.microsoft.com`.