### PR TITLE
remotes: support blob chunked push

### DIFF
--- a/core/remotes/docker/registry.go
+++ b/core/remotes/docker/registry.go
@@ -76,6 +76,7 @@ type RegistryHost struct {
 	Path         string
 	Capabilities HostCapabilities
 	Header       http.Header
+	ChunkSize    int64
 }
 
 func (h RegistryHost) isProxy(refhost string) bool {
@@ -117,6 +118,7 @@ type registryOpts struct {
 	plainHTTP  func(string) (bool, error)
 	host       func(string) (string, error)
 	client     *http.Client
+	chunkSize  int64
 }
 
 // RegistryOpt defines a registry default option
@@ -151,6 +153,14 @@ func WithClient(c *http.Client) RegistryOpt {
 	}
 }
 
+// WithChunkSize configures the chunk size on pushing a blob in chunked,
+// it only works on Pusher.
+func WithChunkSize(cz int64) RegistryOpt {
+	return func(opts *registryOpts) {
+		opts.chunkSize = cz
+	}
+}
+
 // ConfigureDefaultRegistries is used to create a default configuration for
 // registries. For more advanced configurations or per-domain setups,
 // the RegistryHosts interface should be used directly.
@@ -169,6 +179,7 @@ func ConfigureDefaultRegistries(ropts ...RegistryOpt) RegistryHosts {
 			Scheme:       "https",
 			Path:         "/v2",
 			Capabilities: HostCapabilityPull | HostCapabilityResolve | HostCapabilityPush,
+			ChunkSize:    opts.chunkSize,
 		}
 
 		if config.Client == nil {

--- a/core/remotes/docker/resolver.go
+++ b/core/remotes/docker/resolver.go
@@ -458,6 +458,19 @@ func (r *dockerResolver) Pusher(ctx context.Context, ref string) (remotes.Pusher
 	}, nil
 }
 
+func (r *dockerResolver) PusherInChunked(ctx context.Context, ref string) (remotes.PusherInChunked, error) {
+	base, err := r.resolveDockerBase(ref)
+	if err != nil {
+		return nil, err
+	}
+
+	return dockerPusher{
+		dockerBase: base,
+		object:     base.refspec.Object,
+		tracker:    r.tracker,
+	}, nil
+}
+
 func (r *dockerResolver) resolveDockerBase(ref string) (*dockerBase, error) {
 	refspec, err := reference.Parse(ref)
 	if err != nil {

--- a/core/remotes/resolver.go
+++ b/core/remotes/resolver.go
@@ -50,6 +50,10 @@ type Resolver interface {
 	// The returned Pusher should satisfy content.Ingester and concurrent attempts
 	// to push the same blob using the Ingester API should result in ErrUnavailable.
 	Pusher(ctx context.Context, ref string) (Pusher, error)
+
+	// PusherInChunked returns a new pusher for the provided reference
+	// The returned PusherInChunked can push content in chunked.
+	PusherInChunked(ctx context.Context, ref string) (PusherInChunked, error)
 }
 
 // ResolverWithOptions is a Resolver that also supports setting options.
@@ -80,6 +84,17 @@ type Pusher interface {
 	// Push returns a content writer for the given resource identified
 	// by the descriptor.
 	Push(ctx context.Context, d ocispec.Descriptor) (content.Writer, error)
+}
+
+// RangeReadCloser fetches a range of content.
+type RangeReadCloser interface {
+	Reader(offset int64, size int64) (io.ReadCloser, error)
+}
+
+// PusherInChunked pushes content in chunked.
+type PusherInChunked interface {
+	Pusher
+	PushInChunked(ctx context.Context, d ocispec.Descriptor, rr RangeReadCloser) error
 }
 
 // FetcherFunc allows package users to implement a Fetcher with just a


### PR DESCRIPTION
Add PushInChunked method for Pusher to support pushing blob in specified chunk size.

This method is useful if the registry's HTTP gateway limits the maximum payload size per HTTP request.

It's a basic implementation of https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pushing-a-blob-in-chunks