### PR TITLE
contrib: Require CAP_SYS_ADMIN for lsm_set_self_attr

### DIFF
--- a/contrib/seccomp/seccomp_default.go
+++ b/contrib/seccomp/seccomp_default.go
@@ -212,7 +212,6 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				"lsetxattr",
 				"lsm_get_self_attr", // kernel v6.8, libseccomp v2.6.0
 				"lsm_list_modules",  // kernel v6.8, libseccomp v2.6.0
-				"lsm_set_self_attr", // kernel v6.8, libseccomp v2.6.0
 				"lstat",
 				"lstat64",
 				"madvise",
@@ -600,6 +599,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 					"fsopen",
 					"fspick",
 					"lookup_dcookie",
+					"lsm_set_self_attr", // kernel v6.8, libseccomp v2.6.0
 					"mount",
 					"mount_setattr",
 					"move_mount",


### PR DESCRIPTION
- https://github.com/containerd/containerd/pull/11839
- https://github.com/moby/moby/pull/50097

It may be potentially unsafe to allow these syscalls (`/proc/self/attr` may be guarded by other mechanisms like apparmor), so let's put them behind CAP_SYS_ADMIN.