### PR TITLE
[release/1.6] test: added runc v1 support in vagrant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,9 +512,23 @@ jobs:
           # https://github.com/containerd/containerd/pull/10297
           - almalinux/8
           - almalinux/9
+        runtime:
+          - io.containerd.runc.v1
+          - io.containerd.runtime.v1.linux
+          - io.containerd.runc.v2
+        exclude:
+          - box: almalinux/9
+            runtime: io.containerd.runc.v1
+          - box: fedora/39-cloud-base
+            runtime: io.containerd.runc.v1
+          - box: almalinux/9
+            runtime: io.containerd.runtime.v1.linux
+          - box: fedora/39-cloud-base
+            runtime: io.containerd.runtime.v1.linux
     env:
       GOTEST: gotestsum --
       BOX: ${{ matrix.box }}
+      RUNTIME: ${{ matrix.runtime }}
 
     steps:
       - uses: actions/checkout@v4
@@ -547,21 +561,21 @@ jobs:
             # The latest version 5.0.0 seems 404 (as of March 30, 2022)
             export BOX_VERSION="4.0.0"
           fi
-          sudo BOX=$BOX vagrant up --no-tty
+          sudo RUNC_RUNTIME=$RUNTIME BOX=$BOX vagrant up --no-tty
 
       - name: Integration
         env:
           RUNC_FLAVOR: ${{ matrix.runc }}
           SELINUX: Enforcing
           GOTESTSUM_JUNITFILE: /tmp/test-integration-junit.xml
-        run: sudo BOX=$BOX vagrant up --provision-with=selinux,install-runc,install-gotestsum,test-integration
+        run: sudo RUNC_RUNTIME=$RUNTIME BOX=$BOX vagrant up --provision-with=selinux,install-runc,install-gotestsum,test-integration
 
       - name: CRI test
         env:
           RUNC_FLAVOR: ${{ matrix.runc }}
           SELINUX: Enforcing
           REPORT_DIR: /tmp/critestreport
-        run: sudo BOX=$BOX vagrant up --provision-with=selinux,install-runc,install-gotestsum,test-cri
+        run: sudo RUNC_RUNTIME=$RUNTIME BOX=$BOX vagrant up --provision-with=selinux,install-runc,install-gotestsum,test-cri
 
       - name: Get test reports
         if: always()

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -238,6 +238,7 @@ EOF
     sh.upload_path = "/tmp/test-integration"
     sh.env = {
         'RUNC_FLAVOR': ENV['RUNC_FLAVOR'] || "runc",
+        'RUNC_RUNTIME': ENV['RUNC_RUNTIME'] || "io.containerd.runc.v2",
         'GOTEST': ENV['GOTEST'] || "go test",
         'GOTESTSUM_JUNITFILE': ENV['GOTESTSUM_JUNITFILE'],
     }
@@ -249,7 +250,7 @@ EOF
         rm -rf /var/lib/containerd-test /run/containerd-test
         cd ${GOPATH}/src/github.com/containerd/containerd
         go test -v -count=1 -race ./metrics/cgroups
-        make integration EXTRA_TESTFLAGS="-timeout 15m -no-criu -test.v" TEST_RUNTIME=io.containerd.runc.v2 RUNC_FLAVOR=$RUNC_FLAVOR
+        make integration EXTRA_TESTFLAGS="-timeout 15m -no-criu -test.v" TEST_RUNTIME=$RUNC_RUNTIME RUNC_FLAVOR=$RUNC_FLAVOR
     SHELL
   end
 


### PR DESCRIPTION
fix: https://github.com/containerd/containerd/issues/11830

Added jobs to ci.yml to test runc v1 using vagrant
ping @akhilerm