### PR TITLE
Enable DuplicationSuppressor in transfer service

### DIFF
--- a/plugins/transfer/plugin.go
+++ b/plugins/transfer/plugin.go
@@ -30,6 +30,7 @@ import (
 	"github.com/containerd/containerd/v2/core/metadata"
 	"github.com/containerd/containerd/v2/core/transfer/local"
 	"github.com/containerd/containerd/v2/core/unpack"
+	"github.com/containerd/containerd/v2/internal/kmutex"
 	"github.com/containerd/containerd/v2/pkg/imageverifier"
 	"github.com/containerd/containerd/v2/plugins"
 
@@ -159,6 +160,7 @@ func init() {
 				lc.UnpackPlatforms = append(lc.UnpackPlatforms, up)
 			}
 			lc.RegistryConfigPath = config.RegistryConfigPath
+			lc.DuplicationSuppressor = kmutex.New()
 
 			return local.NewTransferService(ms.ContentStore(), metadata.NewImageStore(ms), lc), nil
 		},


### PR DESCRIPTION
This patch enables `DuplicationSuppressor` in transfer service.

#6702 introduced "DuplicationSuppressor" capability and [enabled it](https://github.com/containerd/containerd/blob/main/internal/cri/server/images/image_pull.go#L261) by default in CRI. But the object value in transfer service config [remained nil](https://github.com/containerd/containerd/blob/main/core/transfer/local/pull.go#L206-L208) and never been effective.

Given CRI defaults to transfer service in 2.1, I think we should enable this capability to match the "local pull" behavior.

I did not introduce a new config in transfer service to toggle this capability because I don't see a use case where such behavior isn't desirable. But I'm also open to make it configurable if it's suggested otherwise.