### PR TITLE
Fix transfer differ selection

### DIFF
--- a/core/unpack/unpacker.go
+++ b/core/unpack/unpacker.go
@@ -441,7 +441,7 @@ func (u *Unpacker) unpack(
 		diff, err := a.Apply(ctx, desc, mounts, unpack.ApplyOpts...)
 		if err != nil {
 			cleanup.Do(ctx, abort)
-			return fmt.Errorf("failed to extract layer %s: %w", diffIDs[i], err)
+			return fmt.Errorf("failed to extract layer (%s %s) to %s as %q: %w", desc.MediaType, desc.Digest, unpack.SnapshotterKey, key, err)
 		}
 		if diff.Digest != diffIDs[i] {
 			cleanup.Do(ctx, abort)

--- a/plugins/services/transfer/service.go
+++ b/plugins/services/transfer/service.go
@@ -138,6 +138,7 @@ func (s *service) Transfer(ctx context.Context, req *transferapi.TransferRequest
 		} else if !errdefs.IsNotImplemented(err) {
 			return nil, errgrpc.ToGRPC(err)
 		}
+		log.G(ctx).WithError(err).Debugf("transfer not implemented for %T to %T", src, dst)
 	}
 	return nil, status.Errorf(codes.Unimplemented, "method Transfer not implemented for %s to %s", req.Source.GetTypeUrl(), req.Destination.GetTypeUrl())
 }


### PR DESCRIPTION
1. Update differ selection in transfer service to prefer default

    Currently the erofs differ will be chosen and cause pulls to fail with not implemented errors.

    We should also consider whether the differ should have an export configuration which limits which snapshotters it should be used with

2. Add debug log when transfer returns not implemented

    Currently the error details are not included in the output error and there is no log. One of the reasons a the transferer was skipped could be do to a specific component which is not implemented (such as trying to use erofs differ) or unsupported image (pulling schema1). This information is useful to find a bad configuration.
   
    We could also consider returning this error detail to the caller, it could be relevant in in the schema 1 case to indicate the image is not supported.

3. Add more error details when unpack fails to extract
