### PR TITLE
Clean up lingering image refs in CRI RemoveImage

### DIFF
--- a/internal/cri/store/image/image.go
+++ b/internal/cri/store/image/image.go
@@ -112,7 +112,13 @@ func (s *Store) Update(ctx context.Context, ref string) error {
 			return fmt.Errorf("get image info from containerd: %w", err)
 		}
 	}
-	return s.update(ref, img)
+
+	parsed, err := docker.ParseAnyReference(ref)
+	if err != nil {
+		return fmt.Errorf("failed to parse image reference %q: %w", ref, err)
+	}
+
+	return s.update(parsed.String(), img)
 }
 
 // update updates the internal cache. img == nil means that
@@ -179,7 +185,7 @@ func (s *Store) getImage(ctx context.Context, i images.Image) (*Image, error) {
 
 	return &Image{
 		ID:         id,
-		References: []string{i.Name},
+		References: docker.Sort([]string{i.Name}),
 		ChainID:    chainID.String(),
 		Size:       size,
 		ImageSpec:  spec,


### PR DESCRIPTION
## Background
The `image.References` on images in the CRI image store contain normalized refs (containing the Docker registry prefix).
https://github.com/containerd/containerd/blob/cb1076646aa3740577fafbf3d914198b7fe8e3f7/internal/cri/store/image/image.go#L258

However the `refCache` in the image store (used for looking up digests from refs) may not contain normalized refs because it is populated from refs that come from the core image service.
https://github.com/containerd/containerd/blob/cb1076646aa3740577fafbf3d914198b7fe8e3f7/internal/cri/store/image/image.go#L66-L67

Additionally, when the CRI server loads images into the image store (during a restart), the `image.References` on the imported image may not be normalized since it's using the refs that come from the core image service.
https://github.com/containerd/containerd/blob/cb1076646aa3740577fafbf3d914198b7fe8e3f7/internal/cri/store/image/image.go#L182

These issues cause RemoveImages to not fully clean up all image refs from the `refCache` nor delete images from the core image service.

Fixes these issues by ensuring the `refCache` and `image.References` always contain normalized refs, and by updating RemoveImage to attempt to remove images (from the core image service) for both the normalized and not normalized image refs.

Fixes #8848 

## Future work
To simplify and avoid future bugs with maintaining multiple sources of truth, it may be better to remove the `refCache` and rely on the core image service as much as possible.

## Repro
```sh
# Pull an image to test
$ sudo ctr -a /tmp/containerd.sock -n k8s.io images pull registry.k8s.io/busybox:1.27
registry.k8s.io/busybox:1.27                    saved

# Verifying the image service shows it
$ sudo crictl -r unix:///tmp/containerd.sock images
IMAGE                     TAG                 IMAGE ID            SIZE
registry.k8s.io/busybox   1.27                54511612f1c4d       694kB

# Tag the image without specifying the Docker registry prefix 
$ sudo ctr -a /tmp/containerd.sock -n k8s.io images tag registry.k8s.io/busybox:1.27 busybox:fixed
busybox:fixed

# Verifying the image services shows both images (including the registry prefix on the tagged image)
$ sudo crictl -r unix:///tmp/containerd.sock images
IMAGE                       TAG                 IMAGE ID            SIZE
docker.io/library/busybox   fixed               54511612f1c4d       694kB
registry.k8s.io/busybox     1.27                54511612f1c4d       694kB

# Removing the image without specifying the registry prefix now works
$ sudo crictl -r unix:///tmp/containerd.sock rmi busybox:fixed
Deleted: docker.io/library/busybox:fixed
Deleted: registry.k8s.io/busybox:1.27

# And the images service no longer lists the image
$ sudo crictl -r unix:///tmp/containerd.sock images
IMAGE               TAG                 IMAGE ID            SIZE
```

/cc @samuelkarp