### PR TITLE
Tar unpack progress through transfer service

### DIFF
--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -265,9 +265,14 @@ func ProgressHandler(ctx context.Context, out io.Writer) (transfer.ProgressFunc,
 		statuses = map[string]*progressNode{}
 		roots    = []*progressNode{}
 		progress transfer.ProgressFunc
-		pc       = make(chan transfer.Progress, 1)
-		status   string
-		closeC   = make(chan struct{})
+		// Use a buffered channel for progress to allow multiple completed
+		// progress updates to be processed before shutting down the progress
+		// handler. Currently the progress stream does not have an explicit
+		// end, however, done indicates the server has already commpleted
+		// sending all progress.
+		pc     = make(chan transfer.Progress, 5)
+		status string
+		closeC = make(chan struct{})
 	)
 
 	progress = func(p transfer.Progress) {
@@ -409,7 +414,7 @@ func displayNode(w io.Writer, prefix string, nodes []*progressNode) int64 {
 		name := prefix + pf + displayName(status.Name)
 
 		switch status.Event {
-		case "downloading", "uploading":
+		case "downloading", "uploading", "extracting":
 			var bar progress.Bar
 			if status.Total > 0.0 {
 				bar = progress.Bar(float64(status.Progress) / float64(status.Total))
@@ -425,7 +430,7 @@ func displayNode(w io.Writer, prefix string, nodes []*progressNode) int64 {
 				name,
 				status.Event,
 				bar)
-		case "complete":
+		case "complete", "extracted":
 			bar := progress.Bar(1.0)
 			fmt.Fprintf(w, "%-40.40s\t%-11s\t%40r\t\n",
 				name,

--- a/core/diff/diff.go
+++ b/core/diff/diff.go
@@ -69,6 +69,8 @@ type ApplyConfig struct {
 	ProcessorPayloads map[string]typeurl.Any
 	// SyncFs is to synchronize the underlying filesystem containing files
 	SyncFs bool
+	// Progress is a function which reports status of processed read data
+	Progress func(int64)
 }
 
 // ApplyOpt is used to configure an Apply operation
@@ -131,6 +133,18 @@ func WithPayloads(payloads map[string]typeurl.Any) ApplyOpt {
 func WithSyncFs(sync bool) ApplyOpt {
 	return func(_ context.Context, _ ocispec.Descriptor, c *ApplyConfig) error {
 		c.SyncFs = sync
+		return nil
+	}
+}
+
+// WithProgress is used to indicate process of the apply operation, should
+// atleast expect a progress of 0 and of the final size. It is up to the applier
+// how much progress it reports in between.
+func WithProgress(f func(ocispec.Descriptor, int64)) ApplyOpt {
+	return func(_ context.Context, desc ocispec.Descriptor, c *ApplyConfig) error {
+		c.Progress = func(state int64) {
+			f(desc, state)
+		}
 		return nil
 	}
 }

--- a/core/diff/proxy/differ.go
+++ b/core/diff/proxy/differ.go
@@ -56,7 +56,9 @@ func (r *diffRemote) Apply(ctx context.Context, desc ocispec.Descriptor, mounts 
 	for k, v := range config.ProcessorPayloads {
 		payloads[k] = typeurl.MarshalProto(v)
 	}
-
+	if config.Progress != nil {
+		config.Progress(0)
+	}
 	req := &diffapi.ApplyRequest{
 		Diff:     oci.DescriptorToProto(desc),
 		Mounts:   mount.ToProto(mounts),
@@ -66,6 +68,9 @@ func (r *diffRemote) Apply(ctx context.Context, desc ocispec.Descriptor, mounts 
 	resp, err := r.client.Apply(ctx, req)
 	if err != nil {
 		return ocispec.Descriptor{}, errgrpc.ToNative(err)
+	}
+	if config.Progress != nil {
+		config.Progress(desc.Size)
 	}
 	return oci.DescriptorFromProto(resp.Applied), nil
 }

--- a/core/transfer/local/pull.go
+++ b/core/transfer/local/pull.go
@@ -26,6 +26,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/diff"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/containerd/containerd/v2/core/remotes/docker"
@@ -199,6 +200,9 @@ func (ts *localTransferService) pull(ctx context.Context, ir transfer.ImageFetch
 				if matched {
 					if v, ok := mu.SnapshotterExports["enable_remote_snapshot_annotations"]; ok && v == "true" {
 						enableRemoteSnapshotAnnotations = true
+					}
+					if progressTracker != nil {
+						mu.ApplyOpts = append(mu.ApplyOpts, diff.WithProgress(progressTracker.ExtractProgress))
 					}
 					uopts = append(uopts, unpack.WithUnpackPlatform(mu))
 				} else {


### PR DESCRIPTION
Adds unpack to transfer service.

See https://asciinema.org/a/6bJRKKKuqkAVV51GjN8SBSeYu

A few notes...
- we could order the progress lines better to make it easier to follow
- remote differ will not have the progress but the proxy will at least send start and end progress