### PR TITLE
Update transfer supported platforms logic

### DIFF
--- a/core/transfer/local/import.go
+++ b/core/transfer/local/import.go
@@ -23,12 +23,13 @@ import (
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
+
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/transfer"
 	"github.com/containerd/containerd/v2/core/unpack"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/log"
 )
 
 func (ts *localTransferService) importStream(ctx context.Context, i transfer.ImageImporter, is transfer.ImageStorer, tops *transfer.Config) error {
@@ -95,7 +96,7 @@ func (ts *localTransferService) importStream(ctx context.Context, i transfer.Ima
 		if len(unpacks) > 0 {
 			uopts := []unpack.UnpackerOpt{}
 			for _, u := range unpacks {
-				matched, mu := getSupportedPlatform(u, ts.config.UnpackPlatforms)
+				matched, mu := getSupportedPlatform(ctx, u, ts.config.UnpackPlatforms)
 				if matched {
 					uopts = append(uopts, unpack.WithUnpackPlatform(mu))
 				}

--- a/core/transfer/local/pull_test.go
+++ b/core/transfer/local/pull_test.go
@@ -19,10 +19,11 @@ package local
 import (
 	"testing"
 
+	"github.com/containerd/platforms"
+
 	"github.com/containerd/containerd/v2/core/transfer"
 	"github.com/containerd/containerd/v2/core/unpack"
 	"github.com/containerd/containerd/v2/defaults"
-	"github.com/containerd/platforms"
 )
 
 func TestGetSupportedPlatform(t *testing.T) {
@@ -121,7 +122,7 @@ func TestGetSupportedPlatform(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.Name, func(t *testing.T) {
-			m, sp := getSupportedPlatform(testCase.UnpackConfig, testCase.SupportedPlatforms)
+			m, sp := getSupportedPlatform(t.Context(), testCase.UnpackConfig, testCase.SupportedPlatforms)
 
 			// Match result should match expected
 			if m != testCase.Match {


### PR DESCRIPTION
Allow selection of a non-default snapshotter when no unpack snapshotter is specified.

Add more logging to help figure out why an unpack configuration is not used.