### PR TITLE
doc:add explanation for containerd config dump

### DIFF
--- a/cmd/containerd/command/config.go
+++ b/cmd/containerd/command/config.go
@@ -93,7 +93,7 @@ var configCommand = &cli.Command{
 		},
 		{
 			Name:   "dump",
-			Usage:  "See the output of the final main config with imported in subconfig files",
+			Usage:  "See the output of the final main config with imported in subconfig files(to validate the config file are correct,doesn't represent the configuration currently used for containerd)",
 			Action: dumpConfig,
 		},
 		{


### PR DESCRIPTION
add some doc for containerd config dump
containerd config dump was designed as a helper tool to validate config imports are correct (to address things like https://github.com/containerd/containerd/issues/3776). The ultimate goal is to validate the configuration before launching the daemon.
ref：https://github.com/containerd/containerd/issues/9417#issuecomment-1826586008

@mxpv  @fuweid 