### PR TITLE
Update GHA runners to use latest image for most jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-13, windows-2025]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
 
 
     steps:
@@ -40,7 +40,7 @@ jobs:
   #
   project:
     name: Project Checks
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
@@ -68,7 +68,7 @@ jobs:
   #
   protos:
     name: Protobuf
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     defaults:
@@ -102,7 +102,7 @@ jobs:
 
   man:
     name: Manpages
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
@@ -116,7 +116,7 @@ jobs:
   crossbuild:
     name: Crossbuild Binaries
     needs: [project, linters, protos, man]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -524,7 +524,7 @@ jobs:
 
   integration-vagrant:
     name: Vagrant integration
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [project, linters, protos, man]
 
@@ -612,7 +612,7 @@ jobs:
   tests-cri-in-userns:
     name: "CRI-in-UserNS"
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     timeout-minutes: 40
     needs: [project, linters, protos, man]
 
@@ -664,7 +664,7 @@ jobs:
 
   tests-mac-os:
     name: MacOS unit tests
-    runs-on: macos-13
+    runs-on: macos-latest
     timeout-minutes: 10
     needs: [project, linters, protos, man]
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
   check:
     name: Check Signed Tag
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       stringver: ${{ steps.contentrel.outputs.stringver }}
@@ -64,7 +64,7 @@ jobs:
 
   build:
     name: Build Release Binaries
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       matrix:
@@ -136,7 +136,7 @@ jobs:
       contents: write
       id-token: write
       attestations: write
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [build, check]
     steps:


### PR DESCRIPTION
For jobs which do not require a version matrix, such as some testing runs, use the latest runner image. Pinning the images unnecessarily causes more work later on when deciding when to upgrade and may cause more issues when older images brownout. It is preferable to catch issues when the latest is updated for jobs that should not be version dependent. 