### PR TITLE
pkg/oci: fix minor linting issues

### DIFF
--- a/pkg/oci/mounts.go
+++ b/pkg/oci/mounts.go
@@ -19,7 +19,7 @@
 package oci
 
 import (
-	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 func defaultMounts() []specs.Mount {

--- a/pkg/oci/mounts_freebsd.go
+++ b/pkg/oci/mounts_freebsd.go
@@ -17,7 +17,7 @@
 package oci
 
 import (
-	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 func defaultMounts() []specs.Mount {

--- a/pkg/oci/spec_opts_linux.go
+++ b/pkg/oci/spec_opts_linux.go
@@ -76,6 +76,6 @@ var WithAllKnownCapabilities = func(ctx context.Context, client Client, c *conta
 	return WithCapabilities(caps)(ctx, client, c, s)
 }
 
-func escapeAndCombineArgs(args []string) string {
+func escapeAndCombineArgs([]string) string {
 	panic("not supported")
 }

--- a/pkg/oci/spec_opts_linux_test.go
+++ b/pkg/oci/spec_opts_linux_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/cap"
 	"github.com/containerd/containerd/v2/pkg/testutil"
 	"github.com/containerd/continuity/fs/fstest"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"

--- a/pkg/oci/spec_opts_nonwindows_test.go
+++ b/pkg/oci/spec_opts_nonwindows_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	"github.com/containerd/containerd/v2/pkg/namespaces"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 func TestWithDefaultPathEnv(t *testing.T) {

--- a/pkg/oci/spec_opts_test.go
+++ b/pkg/oci/spec_opts_test.go
@@ -719,7 +719,7 @@ func TestDevShmSize(t *testing.T) {
 	expected := "1024k"
 	for _, s := range ss {
 		if err := WithDevShmSize(1024)(nil, nil, nil, &s); err != nil {
-			if err != ErrNoShmMount {
+			if !errors.Is(err, ErrNoShmMount) {
 				t.Fatal(err)
 			}
 

--- a/pkg/oci/spec_opts_unix_test.go
+++ b/pkg/oci/spec_opts_unix_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 func TestWithImageConfigNoEnv(t *testing.T) {

--- a/pkg/oci/utils_unix.go
+++ b/pkg/oci/utils_unix.go
@@ -25,7 +25,7 @@ import (
 	"path/filepath"
 
 	"github.com/moby/sys/userns"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
 )
 
@@ -55,7 +55,7 @@ func getDevices(path, containerPath string) ([]specs.LinuxDevice, error) {
 		dev, err := DeviceFromPath(path)
 		if err != nil {
 			// wrap error with detailed path and container path when it is ErrNotADevice
-			if err == ErrNotADevice {
+			if errors.Is(err, ErrNotADevice) {
 				return nil, fmt.Errorf("get device path: %q containerPath: %q error: %w", path, containerPath, err)
 			}
 			return nil, err
@@ -103,7 +103,7 @@ func getDevices(path, containerPath string) ([]specs.LinuxDevice, error) {
 		default:
 			device, err := DeviceFromPath(filepath.Join(path, f.Name()))
 			if err != nil {
-				if err == ErrNotADevice {
+				if errors.Is(err, ErrNotADevice) {
 					continue
 				}
 				if os.IsNotExist(err) {


### PR DESCRIPTION
- remove redundant aliases for imports
- rename variables that shadowed imports
- use errors.Is instead of straight error comparing
