### PR TITLE
pkg/oci: don't use vars for WithAllKnownCapabilities, WithAllCurrentCapabilities

### DIFF
--- a/pkg/oci/spec_opts_linux.go
+++ b/pkg/oci/spec_opts_linux.go
@@ -61,8 +61,8 @@ func WithDevices(devicePath, containerPath, permissions string) SpecOpts {
 }
 
 // WithAllCurrentCapabilities propagates the effective capabilities of the caller process to the container process.
-// The capability set may differ from WithAllKnownCapabilities when running in a container.
-var WithAllCurrentCapabilities = func(ctx context.Context, client Client, c *containers.Container, s *Spec) error {
+// The capability set may differ from [WithAllKnownCapabilities] when running in a container.
+func WithAllCurrentCapabilities(ctx context.Context, client Client, c *containers.Container, s *Spec) error {
 	caps, err := cap.Current()
 	if err != nil {
 		return err
@@ -70,10 +70,9 @@ var WithAllCurrentCapabilities = func(ctx context.Context, client Client, c *con
 	return WithCapabilities(caps)(ctx, client, c, s)
 }
 
-// WithAllKnownCapabilities sets all the known linux capabilities for the container process
-var WithAllKnownCapabilities = func(ctx context.Context, client Client, c *containers.Container, s *Spec) error {
-	caps := cap.Known()
-	return WithCapabilities(caps)(ctx, client, c, s)
+// WithAllKnownCapabilities sets all the known linux capabilities for the container process.
+func WithAllKnownCapabilities(ctx context.Context, client Client, c *containers.Container, s *Spec) error {
+	return WithCapabilities(cap.Known())(ctx, client, c, s)
 }
 
 func escapeAndCombineArgs(args []string) string {

--- a/pkg/oci/spec_opts_nonlinux.go
+++ b/pkg/oci/spec_opts_nonlinux.go
@@ -25,12 +25,12 @@ import (
 )
 
 // WithAllCurrentCapabilities propagates the effective capabilities of the caller process to the container process.
-// The capability set may differ from WithAllKnownCapabilities when running in a container.
-var WithAllCurrentCapabilities = func(ctx context.Context, client Client, c *containers.Container, s *Spec) error {
+// The capability set may differ from [WithAllKnownCapabilities] when running in a container.
+func WithAllCurrentCapabilities(ctx context.Context, client Client, c *containers.Container, s *Spec) error {
 	return WithCapabilities(nil)(ctx, client, c, s)
 }
 
-// WithAllKnownCapabilities sets all the known linux capabilities for the container process
-var WithAllKnownCapabilities = func(ctx context.Context, client Client, c *containers.Container, s *Spec) error {
+// WithAllKnownCapabilities sets all the known linux capabilities for the container process.
+func WithAllKnownCapabilities(ctx context.Context, client Client, c *containers.Container, s *Spec) error {
 	return WithCapabilities(nil)(ctx, client, c, s)
 }


### PR DESCRIPTION
These were introduced in c818a6b13dae8af18fc1a2f6209524450aef56ba, refactored in 808b223536e6553ddee2944d7ec6bc6d86e0da88 and bdd84abf056b153b3e37883884e91c52f98e15b9, and moved in a2d1a8a8653fd5cfe97a9860a5f8ce8a600c2b01, but none provided a motivation for using a variable / alias for these.

Based on the above, I assume the use of a variable was purely convenience, the there's no intent for packages to be able to override them, so this patch changes these to be a regular function.
