### PR TITLE
pkg/oci: don't use var for WithPrivileged

### DIFF
--- a/pkg/oci/spec_opts.go
+++ b/pkg/oci/spec_opts.go
@@ -1308,16 +1308,18 @@ func WithDefaultUnixDevices(_ context.Context, _ Client, _ *containers.Container
 }
 
 // WithPrivileged sets up options for a privileged container
-var WithPrivileged = Compose(
-	WithAllCurrentCapabilities,
-	WithMaskedPaths(nil),
-	WithReadonlyPaths(nil),
-	WithWriteableSysfs,
-	WithWriteableCgroupfs,
-	WithSelinuxLabel(""),
-	WithApparmorProfile(""),
-	WithSeccompUnconfined,
-)
+func WithPrivileged(ctx context.Context, client Client, c *containers.Container, s *Spec) error {
+	return Compose(
+		WithAllCurrentCapabilities,
+		WithMaskedPaths(nil),
+		WithReadonlyPaths(nil),
+		WithWriteableSysfs,
+		WithWriteableCgroupfs,
+		WithSelinuxLabel(""),
+		WithApparmorProfile(""),
+		WithSeccompUnconfined,
+	)(ctx, client, c, s)
+}
 
 // WithWindowsHyperV sets the Windows.HyperV section for HyperV isolation of containers.
 func WithWindowsHyperV(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {


### PR DESCRIPTION
- relates to https://github.com/containerd/containerd/pull/2269

This variable was introduced in 062c3a00ef74222827399a013283650450e93c42, which didn't describe it as intentional to be able to override the option.

Based on the above, I assume the use of a variable was purely convenience, the there's no intent for packages to be able to override them, so this patch changes these to be a regular function.
