### PR TITLE
Add gc label to treat leases as non-root objects

### DIFF
--- a/core/metadata/db_test.go
+++ b/core/metadata/db_test.go
@@ -498,6 +498,30 @@ func TestMetadataCollector(t *testing.T) {
 					Type: "content",
 				},
 			}, false),
+
+			// Test non-root lease
+			newSnapshot("10", "", false, false),
+			newSnapshot("11", "10", false, false),
+			lease("lease-4", []leases.Resource{
+				{
+					ID:   "11",
+					Type: "snapshots/native",
+				},
+			}, false, "containerd.io/gc.nonroot", time.Now().Format(time.RFC3339)),
+			image("image-2", digestFor(20), "containerd.io/gc.ref.lease", "lease-4"),
+			newSnapshot("12", "", false, true),
+			newSnapshot("13", "12", false, true),
+			blob(bytesFor(13), true),
+			lease("lease-5", []leases.Resource{
+				{
+					ID:   digestFor(13).String(),
+					Type: "content",
+				},
+				{
+					ID:   "13",
+					Type: "snapshots/native",
+				},
+			}, true, "containerd.io/gc.nonroot", time.Now().Format(time.RFC3339)),
 		}
 
 		testResource = gc.ResourceType(0x10)
@@ -506,6 +530,7 @@ func TestMetadataCollector(t *testing.T) {
 			gcnode(testResource, "test", "test1"),
 			gcnode(testResource, "test", "test3"),
 			gcnode(testResource, "test", "test4"),
+			gcnode(testResource, "test", "test5"),
 		}
 
 		collector = &testCollector{
@@ -515,6 +540,8 @@ func TestMetadataCollector(t *testing.T) {
 				gcnode(testResource, "test", "test2"),
 				gcnode(testResource, "test", "test3"),
 				gcnode(testResource, "test", "test4"),
+				gcnode(testResource, "test", "test5"),
+				gcnode(testResource, "test", "test6"),
 			},
 			active: []gc.Node{
 				gcnode(testResource, "test", "test4"),
@@ -522,6 +549,12 @@ func TestMetadataCollector(t *testing.T) {
 			leased: map[string][]gc.Node{
 				"lease-3": {
 					gcnode(testResource, "test", "test3"),
+				},
+				"lease-4": {
+					gcnode(testResource, "test", "test5"),
+				},
+				"lease-5": {
+					gcnode(testResource, "test", "test6"),
 				},
 			},
 		}

--- a/docs/garbage-collection.md
+++ b/docs/garbage-collection.md
@@ -102,6 +102,7 @@ The supported garbage collection labels are:
 | Label key | Label value | Supported Resources | Description |
 |---|---|---|---|
 | `containerd.io/gc.root` | _nonempty_ | Content, Snapshots | Keep this object and anything it references. (Clients may set this to a [rfc3339](https://tools.ietf.org/html/rfc3339) timestamp to indicate when this value was set, however, the garbage collector does not parse the value) |
+| `containerd.io/gc.nonroot` | _timestamp_ formatted as [rfc3339](https://tools.ietf.org/html/rfc3339) | Leases | When to no longer treat a lease as a root object, allowing it to be garbage collected if it is not referenced |
 | `containerd.io/gc.ref.snapshot.<snapshotter>` | `<identifier>` | Content, Snapshots | Resource references the given snapshot `<identifier>` for the snapshotter `<snapshotter>` |
 | `containerd.io/gc.ref.content` | _digest_ | Content, Snapshots, Images, Containers | Resource references the given content blob |
 | `containerd.io/gc.ref.content.<user defined>` | _digest_ | Content, Snapshots, Images, Containers | Resource references the given content blob with a `<user defined>` label key |


### PR DESCRIPTION
Allows leases to be referenced as non-root objects to act as ephemeral links. The expiration flag is still respected but a lease which is not a root may be GC'ed before the expiration if it is not referenced.

An example use case is for delaying the GC of content or snapshots for an image after a pull. This could also give clients a chance to refresh frequently used content/snapshots while letting less commonly used objects get GC'ed.