### PR TITLE
Integrate with systemd watchdog for daemon health

### DIFF
--- a/cmd/containerd/builtins/builtins.go
+++ b/cmd/containerd/builtins/builtins.go
@@ -47,4 +47,5 @@ import (
 	_ "github.com/containerd/containerd/v2/plugins/services/warning"
 	_ "github.com/containerd/containerd/v2/plugins/streaming"
 	_ "github.com/containerd/containerd/v2/plugins/transfer"
+	_ "github.com/containerd/containerd/v2/plugins/watchdog"
 )

--- a/containerd.service
+++ b/containerd.service
@@ -26,6 +26,7 @@ Delegate=yes
 KillMode=process
 Restart=always
 RestartSec=5
+WatchdogSec=60s
 
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.

--- a/plugins/types.go
+++ b/plugins/types.go
@@ -77,6 +77,8 @@ const (
 	ShimPlugin plugin.Type = "io.containerd.shim.v1"
 	// HTTPHandler implements an http handler
 	HTTPHandler plugin.Type = "io.containerd.http.v1"
+	// WatchdogPlugin implements a watchdog service
+	WatchdogPlugin plugin.Type = "io.containerd.watchdog.v1"
 )
 
 const (

--- a/plugins/watchdog/plugin.go
+++ b/plugins/watchdog/plugin.go
@@ -1,0 +1,161 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package watchdog
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/containerd/containerd/v2/plugins"
+	"github.com/containerd/containerd/v2/plugins/services/healthcheck"
+	"github.com/containerd/log"
+	"github.com/containerd/plugin"
+	"github.com/containerd/plugin/registry"
+	"github.com/coreos/go-systemd/v22/daemon"
+)
+
+type service struct {
+	wb *watchdogNotifier
+}
+
+func init() {
+	registry.Register(&plugin.Registration{
+		Type: plugins.WatchdogPlugin,
+		ID:   "watchdog",
+		Requires: []plugin.Type{
+			plugins.GRPCPlugin,
+		},
+		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
+			hcp, err := ic.GetByID(plugins.GRPCPlugin, "healthcheck")
+			if err != nil {
+				return nil, err
+			}
+			hc := hcp.(*healthcheck.Service)
+			wn, err := newWatchdogNotifier(hc.IsServing)
+			if err != nil {
+				return nil, fmt.Errorf("cannot init watchdog plugin: %v: %w", err, plugin.ErrSkipPlugin)
+			}
+			// start notifying
+			go wn.Notify(ic.Context)
+			return &service{wn}, nil
+		},
+	})
+}
+
+type watchdogNotifier struct {
+	wc       watchdogClient
+	interval time.Duration
+	healthy  func(ctx context.Context) (bool, error)
+	done     chan struct{}
+}
+
+// option defines optional parameters for initializing the healthChecker
+// structure.
+type option func(*watchdogNotifier)
+
+func withWatchdogClient(wc watchdogClient) option {
+	return func(wn *watchdogNotifier) {
+		wn.wc = wc
+	}
+}
+
+// newWatchdogNotifier creates a new watchogNotifier.
+//
+// If the watchdog is not enabled, the function returns an error.
+func newWatchdogNotifier(healthy func(ctx context.Context) (bool, error), opts ...option) (*watchdogNotifier, error) {
+	wn := &watchdogNotifier{
+		healthy: healthy,
+		wc:      &defaultWatchdogClient{},
+		done:    make(chan struct{}),
+	}
+	for _, o := range opts {
+		o(wn)
+	}
+
+	watchdogVal, err := wn.wc.sdWatchdogEnabled()
+	switch {
+	case err != nil:
+		return nil, fmt.Errorf("cannot determine if watchdog is enabled: %v", err)
+	case watchdogVal == 0:
+		return nil, fmt.Errorf("systemd watchdog not enabled for this PID")
+	}
+	// It is recommended that a daemon sends a keep-alive notification
+	// message to the service manager every half of the time of
+	// WATCHDOG_USEC. See:
+	// https://www.freedesktop.org/software/systemd/man/latest/sd_watchdog_enabled.html
+	wn.interval = watchdogVal / 2
+	return wn, nil
+}
+
+func (wn *watchdogNotifier) Notify(ctx context.Context) {
+	ticker := time.NewTicker(wn.interval)
+	defer ticker.Stop()
+loop:
+	for {
+		select {
+		case <-ticker.C:
+			isServing, err := wn.healthy(ctx)
+			if err != nil {
+				log.G(ctx).WithError(err).Error("cannot determine if the daemon is healthy")
+				break loop
+			}
+			if !isServing {
+				log.G(ctx).Warn("daemon detected as unhealthy")
+				break loop
+			}
+			ack, err := wn.wc.sdNotify()
+			if err != nil {
+				// Notification not supported. This should never happen.
+				log.G(ctx).WithError(err).Errorf("cannot notify systemd watchdog: %v", err)
+				break loop
+			}
+			if !ack {
+				log.G(ctx).Warn("cannot notify systemd watchdog. retrying")
+				// let some time pass to let systemd recover
+				const p = int64(5)
+				time.Sleep(time.Duration(int64(wn.interval) / p))
+			}
+		case <-ctx.Done():
+			break loop
+		}
+	}
+	log.G(ctx).Warn("terminating watchdog notifier")
+	close(wn.done)
+}
+
+func (wn *watchdogNotifier) Wait() {
+	<-wn.done
+}
+
+// watchdogClient represents the interaction with systemd watchdog.
+type watchdogClient interface {
+	sdWatchdogEnabled() (time.Duration, error)
+	sdNotify() (bool, error)
+}
+
+type defaultWatchdogClient struct{}
+
+var _ watchdogClient = &defaultWatchdogClient{}
+
+func (d *defaultWatchdogClient) sdWatchdogEnabled() (time.Duration, error) {
+	return daemon.SdWatchdogEnabled(false)
+}
+
+func (d *defaultWatchdogClient) sdNotify() (bool, error) {
+	return daemon.SdNotify(false, daemon.SdNotifyWatchdog)
+}

--- a/plugins/watchdog/plugin_test.go
+++ b/plugins/watchdog/plugin_test.go
@@ -1,0 +1,219 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package watchdog
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockWatchdogClient struct {
+	enabledVal time.Duration
+	enabledErr error
+	notifyAck  bool
+	notifyErr  error
+
+	notifyCounter int
+}
+
+func (m *mockWatchdogClient) sdWatchdogEnabled() (time.Duration, error) {
+	return m.enabledVal, m.enabledErr
+}
+
+func (m *mockWatchdogClient) sdNotify() (bool, error) {
+	m.notifyCounter++
+	return m.notifyAck, m.notifyErr
+}
+
+func TestNewWatchdogNotifier(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		wc   *mockWatchdogClient
+		err  *string
+	}{{
+		name: "Watchdog enabled",
+		wc:   &mockWatchdogClient{enabledVal: 5},
+		err:  nil,
+	}, {
+		name: "Watchdog not enabled",
+		wc:   &mockWatchdogClient{enabledVal: 0},
+		err:  ptr("systemd watchdog not enabled for this PID"),
+	}, {
+		name: "Watchdog enabled with error",
+		wc: &mockWatchdogClient{
+			enabledVal: 6,
+			enabledErr: errors.New("mock error"),
+		},
+		err: ptr("cannot determine if watchdog is enabled:"),
+	}} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := newWatchdogNotifier(nil, withWatchdogClient(tt.wc))
+			if tt.err != nil {
+				assert.ErrorContains(t, err, *tt.err)
+			}
+		})
+	}
+}
+
+type mockHealthy struct {
+	// Number of times it will be healthy
+	healthyLimit int
+	err          error
+	delay        time.Duration
+
+	counter int
+}
+
+func (h *mockHealthy) healthy(ctx context.Context) (bool, error) {
+	h.counter++
+	h.healthyLimit--
+	select {
+	case <-ctx.Done():
+		return false, errors.New("context done")
+	case <-time.After(h.delay):
+	}
+	if h.healthyLimit <= 0 {
+		return false, h.err
+	}
+	return true, nil
+}
+
+func TestWatchdogNotify(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		wc      *mockWatchdogClient
+		healthy *mockHealthy
+		check   func(t *testing.T, h *mockHealthy, wc *mockWatchdogClient)
+	}{
+		{
+			name: "ok",
+			wc: &mockWatchdogClient{
+				enabledVal: 2 * time.Second,
+				notifyAck:  true,
+			},
+			healthy: &mockHealthy{
+				healthyLimit: 100,
+				delay:        100 * time.Millisecond,
+			},
+			check: func(t *testing.T, h *mockHealthy, wc *mockWatchdogClient) {
+				limit := int(2 * time.Second / 100 / time.Millisecond)
+				assert.GreaterOrEqual(t, h.counter, 2)
+				assert.LessOrEqual(t, h.counter, limit)
+				assert.GreaterOrEqual(t, wc.notifyCounter, 2)
+				assert.LessOrEqual(t, wc.notifyCounter, limit)
+			},
+		}, {
+			name: "not healthy",
+			wc: &mockWatchdogClient{
+				enabledVal: 300 * time.Millisecond,
+				notifyAck:  true,
+			},
+			healthy: &mockHealthy{
+				healthyLimit: 2,
+				delay:        100 * time.Millisecond,
+			},
+			check: func(t *testing.T, h *mockHealthy, wc *mockWatchdogClient) {
+				assert.GreaterOrEqual(t, h.counter, 1)
+				assert.LessOrEqual(t, h.counter, 2)
+				assert.GreaterOrEqual(t, wc.notifyCounter, 1)
+				assert.LessOrEqual(t, wc.notifyCounter, 2)
+			},
+		}, {
+			name: "not healthy with error",
+			wc: &mockWatchdogClient{
+				enabledVal: 300 * time.Millisecond,
+				notifyAck:  true,
+			},
+			healthy: &mockHealthy{
+				healthyLimit: 2,
+				err:          errors.New("healthy error"),
+				delay:        100 * time.Millisecond,
+			},
+			check: func(t *testing.T, h *mockHealthy, wc *mockWatchdogClient) {
+				assert.Equal(t, h.counter, 2)
+				assert.Equal(t, wc.notifyCounter, 1)
+			},
+		}, {
+			name: "not ack'ed retries",
+			wc: &mockWatchdogClient{
+				enabledVal: 1000 * time.Millisecond,
+				notifyAck:  false,
+			},
+			healthy: &mockHealthy{
+				healthyLimit: 100,
+				delay:        50 * time.Millisecond,
+			},
+			check: func(t *testing.T, h *mockHealthy, wc *mockWatchdogClient) {
+				assert.GreaterOrEqual(t, h.counter, 2)
+				assert.LessOrEqual(t, h.counter, 5)
+				assert.GreaterOrEqual(t, wc.notifyCounter, 2)
+				assert.LessOrEqual(t, wc.notifyCounter, 5)
+			},
+		}, {
+			name: "ack error",
+			wc: &mockWatchdogClient{
+				enabledVal: 100 * time.Millisecond,
+				notifyAck:  false,
+				notifyErr:  errors.New("sdnotify error"),
+			},
+			healthy: &mockHealthy{
+				healthyLimit: 100,
+				delay:        5 * time.Millisecond,
+			},
+			check: func(t *testing.T, h *mockHealthy, wc *mockWatchdogClient) {
+				assert.Equal(t, h.counter, 1)
+				assert.Equal(t, wc.notifyCounter, 1)
+			},
+		}, {
+			name: "slow health",
+			wc: &mockWatchdogClient{
+				enabledVal: 100 * time.Millisecond,
+				notifyAck:  true,
+			},
+			healthy: &mockHealthy{
+				healthyLimit: 100,
+				delay:        300 * time.Millisecond,
+			},
+			check: func(t *testing.T, h *mockHealthy, wc *mockWatchdogClient) {
+				assert.Equal(t, h.counter, 1)
+				assert.Equal(t, wc.notifyCounter, 0)
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			wn, err := newWatchdogNotifier(tt.healthy.healthy, withWatchdogClient(tt.wc))
+			assert.NoError(t, err)
+
+			ctx := context.Background()
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			go wn.Notify(ctx)
+
+			<-time.After(tt.wc.enabledVal * 2)
+			cancel()
+			wn.Wait()
+			tt.check(t, tt.healthy, tt.wc)
+		})
+	}
+}
+
+func ptr[T any](t T) *T { return &t }


### PR DESCRIPTION
Implement a new watchdog plugin performing health checks using the healthcheck plugin and reporting it to systemd watchdog.

Add WatchdogSec=60s directive to containerd.service.

Fixes #10329