### PR TITLE
fix: preserve nsPath on mount failure to ensure cleanup

### DIFF
--- a/pkg/netns/netns_linux.go
+++ b/pkg/netns/netns_linux.go
@@ -76,12 +76,12 @@ func newNS(baseDir string, pid uint32) (nsPath string, err error) {
 	}
 	mountPointFd.Close()
 
-	defer func() {
+	defer func(targetPath string) {
 		// Ensure the mount point is cleaned up on errors
 		if err != nil {
-			os.RemoveAll(nsPath)
+			os.RemoveAll(targetPath)
 		}
-	}()
+	}(nsPath)
 
 	if pid != 0 {
 		procNsPath := getNetNSPathFromPID(pid)


### PR DESCRIPTION
fix: https://github.com/containerd/containerd/issues/11958

Previously, when unix.Mount failed, the returned nsPath was set to "", causing the deferred cleanup (os.RemoveAll(nsPath)) to silently fail and leave behind orphaned netns mount point files.

This commit changes the return statement to preserve the actual nsPath value even on error, ensuring that the cleanup logic in the deferred function works as intended.