### PR TITLE
[release/2.0] Enable CIs to run on WS2022 and WS2025

### DIFF
--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -9,7 +9,7 @@ on:
       azure_windows_image_id:
         description: Windows image URN to deploy
         required: true
-        default: MicrosoftWindowsServer:WindowsServer:2022-datacenter:latest
+        default: MicrosoftWindowsServer:WindowsServer:2025-datacenter:latest
       azure_vm_size:
         description: Windows image builder VM size
         required: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-13, windows-2019]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-13, windows-2025]
 
 
     steps:
@@ -188,7 +188,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm, macos-13, windows-2019, windows-2022]
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm, macos-13, windows-2022, windows-2025]
         go-version: ["1.24.2", "1.23.8"]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -214,7 +214,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, windows-2019]
+        os: [windows-2025, windows-2022]
         cgroup_driver: [cgroupfs]
 
     defaults:
@@ -243,17 +243,6 @@ jobs:
           echo "${{ github.workspace }}/src/github.com/kubernetes-sigs/cri-tools/build/bin/windows/amd64" >> $GITHUB_PATH
 
       - run: script/setup/install-dev-tools
-
-      # needs to be a separate step since terminal reload is required to bring in new env variables and PATH
-      - name: Upgrade Chocolaty on Windows 2019
-        if: matrix.os == 'windows-2019'
-        shell: powershell
-        run: .\script\setup\upgrade_chocolaty_windows_2019.ps1
-
-      - name: Upgrade MinGW on Windows 2019
-        if: matrix.os == 'windows-2019'
-        shell: powershell
-        run: .\script\setup\upgrade_mingw_windows_2019.ps1
 
       - name: Binaries
         shell: bash

--- a/.github/workflows/windows-hyperv-periodic.yml
+++ b/.github/workflows/windows-hyperv-periodic.yml
@@ -43,16 +43,16 @@ jobs:
       # (e.g. hitting resource limits in the `AZTestVMCreate` task)
       fail-fast: false
       matrix:
-        win_ver: [ltsc2019, ltsc2022]
+        win_ver: [ltsc2022, ltsc2025]
         include:
-        - win_ver: ltsc2019
-          AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2019-Datacenter:latest"
-          AZURE_RESOURCE_GROUP: ctrd-integration-ltsc2019-${{ github.run_id }}
-          GOOGLE_BUCKET: "containerd-integration/logs/windows-ltsc2019-hyperv/"
         - win_ver: ltsc2022
           AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2022-datacenter-smalldisk-g2:latest"
           AZURE_RESOURCE_GROUP: ctrd-integration-ltsc2022-${{ github.run_id }}
           GOOGLE_BUCKET: "containerd-integration/logs/windows-ltsc2022-hyperv/"
+        - win_ver: ltsc2025
+          AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2025-Datacenter:latest"
+          AZURE_RESOURCE_GROUP: ctrd-integration-ltsc2025-${{ github.run_id }}
+          GOOGLE_BUCKET: "containerd-integration/logs/windows-ltsc2025-hyperv/"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -42,16 +42,16 @@ jobs:
       # (e.g. hitting resource limits in the `AZTestVMCreate` task)
       fail-fast: false
       matrix:
-        win_ver: [ltsc2019, ltsc2022]
+        win_ver: [ltsc2022, ltsc2025]
         include:
-        - win_ver: ltsc2019
-          AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2019-Datacenter:latest"
-          AZURE_RESOURCE_GROUP: ctrd-integration-ltsc2019-${{ github.run_id }}
-          GOOGLE_BUCKET: "containerd-integration/logs/windows-ltsc2019/"
         - win_ver: ltsc2022
           AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2022-datacenter-smalldisk-g2:latest"
           AZURE_RESOURCE_GROUP: ctrd-integration-ltsc2022-${{ github.run_id }}
           GOOGLE_BUCKET: "containerd-integration/logs/windows-ltsc2022/"
+        - win_ver: ltsc2025
+          AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2025-Datacenter:latest"
+          AZURE_RESOURCE_GROUP: ctrd-integration-ltsc2025-${{ github.run_id }}
+          GOOGLE_BUCKET: "containerd-integration/logs/windows-ltsc2025/"
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:

--- a/integration/client/helpers_unix.go
+++ b/integration/client/helpers_unix.go
@@ -24,3 +24,8 @@ import "os"
 func forceRemoveAll(path string) error {
 	return os.RemoveAll(path)
 }
+
+// Used only on Windows to skip tests for certain host OS versions.
+func SkipTestOnHost() bool {
+	return false
+}

--- a/integration/client/helpers_windows.go
+++ b/integration/client/helpers_windows.go
@@ -26,6 +26,7 @@ import (
 	"syscall"
 
 	"github.com/Microsoft/hcsshim"
+	"github.com/Microsoft/hcsshim/osversion"
 	"golang.org/x/sys/windows"
 )
 
@@ -113,4 +114,17 @@ func cleanupWCOWLayer(layerPath string) error {
 	}
 
 	return nil
+}
+
+// Temporarily used on windows to skip failing test on WS2025.
+func SkipTestOnHost() bool {
+	const (
+		// Copied from https://github.com/microsoft/hcsshim/blob/9b2e94f544990ce7e8f3ccdb60f1a9abd7debe05/osversion/windowsbuilds.go#L88-L90
+		// Windows Server 2025 build 26100
+		// The Windows Server 2025 constant was added in Microsoft/hcsshim@v0.13.0.
+		// Copied here to avoid updating the hcsshim dependency which requires breaking changes in the archive package.
+		V25H1Server = 26100
+		LTSC2025    = V25H1Server
+	)
+	return osversion.Build() == LTSC2025
 }

--- a/integration/image_load_test.go
+++ b/integration/image_load_test.go
@@ -19,9 +19,11 @@ package integration
 import (
 	"os/exec"
 	"path/filepath"
+	goruntime "runtime"
 	"testing"
 	"time"
 
+	"github.com/containerd/containerd/v2/integration/client"
 	"github.com/containerd/containerd/v2/integration/images"
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -29,6 +31,14 @@ import (
 
 // Test to load an image from tarball.
 func TestImageLoad(t *testing.T) {
+	// TODO(kiashok): Docker is not able to pull the right
+	// image manifest of `testImage` on WS2025 host. Temporarily
+	// skipping this test for WS2025 while its fixed on docker.
+	// This test is validated on WS2022 anyway.
+	if goruntime.GOOS == "windows" && client.SkipTestOnHost() {
+		t.Skip("Temporarily skip validating on WS2025")
+	}
+
 	testImage := images.Get(images.BusyBox)
 	loadedImage := testImage
 	_, err := exec.LookPath("docker")

--- a/integration/images/volume-copy-up/Makefile
+++ b/integration/images/volume-copy-up/Makefile
@@ -33,8 +33,8 @@ endif
 OS ?= linux
 # Architectures supported: amd64, arm64
 ARCH ?= amd64
-# OS Version for the Windows images: 1809, 20H2, ltsc2022
-OSVERSION ?= 1809
+# OS Version for the Windows images: ltsc2022, ltsc2025
+OSVERSION ?= ltsc2022
 
 # The output type could either be docker (local), or registry.
 # If it is registry, it will also allow us to push the Windows images.
@@ -46,7 +46,7 @@ ALL_OS_ARCH.linux = $(foreach arch, ${ALL_ARCH.linux}, linux-$(arch))
 
 ifneq ($(REMOTE_DOCKER_URL),)
 ALL_OS += windows
-ALL_OSVERSIONS.windows := 1809 20H2 ltsc2022
+ALL_OSVERSIONS.windows := ltsc2022 ltsc2025
 ALL_OS_ARCH.windows = $(foreach osversion, ${ALL_OSVERSIONS.windows}, windows-amd64-${osversion})
 BASE.windows := mcr.microsoft.com/windows/nanoserver
 endif

--- a/integration/images/volume-ownership/Makefile
+++ b/integration/images/volume-ownership/Makefile
@@ -33,8 +33,8 @@ endif
 OS ?= linux
 # Architectures supported: amd64, arm64
 ARCH ?= amd64
-# OS Version for the Windows images: 1809, 20H2, ltsc2022
-OSVERSION ?= 1809
+# OS Version for the Windows images: ltsc2022, lts2025
+OSVERSION ?= ltsc2022
 
 # The output type could either be docker (local), or registry.
 # If it is registry, it will also allow us to push the Windows images.
@@ -46,7 +46,7 @@ ALL_OS_ARCH.linux = $(foreach arch, ${ALL_ARCH.linux}, linux-$(arch))
 
 ifneq ($(REMOTE_DOCKER_URL),)
 ALL_OS += windows
-ALL_OSVERSIONS.windows := 1809 20H2 ltsc2022
+ALL_OSVERSIONS.windows := ltsc2022 ltsc2025
 ALL_OS_ARCH.windows = $(foreach osversion, ${ALL_OSVERSIONS.windows}, windows-amd64-${osversion})
 BASE.windows := mcr.microsoft.com/windows/nanoserver
 endif


### PR DESCRIPTION
This change backports the Windows runner image updates for Windows 2019 deprecation to release/2.0.

(cherry picked from commit 2f1948a503fbd7c3d053c3a19b2b06045fdeea4b)

Note: not a clean cherry-pick; edited to include a copy of Windows 2025 constant copied from Microsoft/hcsshim@v0.13.0