### PR TITLE
[release/2.0] core/runtime: should invoke shim binary if it doesn't support Sandbox API 

### DIFF
--- a/core/runtime/v2/shim.go
+++ b/core/runtime/v2/shim.go
@@ -199,6 +199,23 @@ type ShimInstance interface {
 	Endpoint() (string, int)
 }
 
+type clientVersionDowngrader interface {
+	// Downgrade is to lower shim's client version.
+	//
+	// Assume there is a running pod created by containerd-shim-runc-v2 from v1.7.x.
+	// After upgrading to v2.x, the containerd-shim-runc-v2 binary will support the
+	// sandbox API, and calling `shim start` for the existing running pod will return
+	// a version=3 address. However, that pod shim does not support the streaming IO API,
+	// so we should downgrade the shim version.
+	//
+	// Additionally, if a container record was created with v1.7.x, it will not have
+	// a SandboxID field in the metadata store. In the CRI case, this will cause
+	// the new shim client to use the v3 protocol to send requests to a running shim
+	// that still uses the v2 protocol, resulting in a failure to start.
+	// In this case, we should also downgrade the shim version and retry.
+	Downgrade() error
+}
+
 func parseStartResponse(response []byte) (client.BootstrapParams, error) {
 	var params client.BootstrapParams
 
@@ -377,6 +394,7 @@ type shim struct {
 }
 
 var _ ShimInstance = (*shim)(nil)
+var _ clientVersionDowngrader = (*shim)(nil)
 
 // ID of the shim/task
 func (s *shim) ID() string {
@@ -385,6 +403,15 @@ func (s *shim) ID() string {
 
 func (s *shim) Endpoint() (string, int) {
 	return s.address, s.version
+}
+
+func (s *shim) Downgrade() error {
+	if s.version >= CurrentShimVersion {
+		s.version--
+		return nil
+	}
+	return fmt.Errorf("unable to downgrade because shim version (%d) is lower than CurrentShimVersion (%d)",
+		s.version, CurrentShimVersion)
 }
 
 func (s *shim) Namespace() string {

--- a/core/runtime/v2/shim.go
+++ b/core/runtime/v2/shim.go
@@ -553,6 +553,11 @@ func (s *shimTask) delete(ctx context.Context, sandboxed bool, removeTask func(c
 		removeTask(ctx, s.ID())
 	}
 
+	const supportSandboxAPIVersion = 3
+	if _, apiVer := s.ShimInstance.Endpoint(); apiVer < supportSandboxAPIVersion {
+		sandboxed = false
+	}
+
 	// Don't shutdown sandbox as there may be other containers running.
 	// Let controller decide when to shutdown.
 	if !sandboxed {

--- a/core/runtime/v2/shim_load.go
+++ b/core/runtime/v2/shim_load.go
@@ -206,7 +206,26 @@ func loadShimTask(ctx context.Context, bundle *Bundle, onClose func()) (_ *shimT
 	defer cancel()
 
 	if _, err := s.PID(ctx); err != nil {
-		return nil, err
+		if !errdefs.IsNotImplemented(err) {
+			return nil, err
+		}
+
+		downgrader, ok := shim.(clientVersionDowngrader)
+		if ok {
+			if derr := downgrader.Downgrade(); derr == nil {
+				log.G(ctx).WithError(err).WithField("id", shim.ID()).
+					Warning("failed to call task.PID, downgrading client API version to try again")
+
+				s, err = newShimTask(shim)
+				if err != nil {
+					return nil, fmt.Errorf("failed to create shim task after downgrading: %w", err)
+				}
+				_, err = s.PID(ctx)
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
 	}
 	return s, nil
 }

--- a/core/runtime/v2/shim_manager.go
+++ b/core/runtime/v2/shim_manager.go
@@ -37,6 +37,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/timeout"
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/containerd/v2/version"
+	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
@@ -163,37 +164,68 @@ func (m *ShimManager) ID() string {
 
 // Start launches a new shim instance
 func (m *ShimManager) Start(ctx context.Context, id string, bundle *Bundle, opts runtime.CreateOpts) (_ ShimInstance, retErr error) {
-	// This container belongs to sandbox which supposed to be already started via sandbox API.
-	if opts.SandboxID != "" {
-		var params shimbinary.BootstrapParams
-		if opts.Address != "" {
-			// The address returned from sandbox controller should be in the form like ttrpc+unix://<uds-path>
-			// or grpc+vsock://<cid>:<port>, we should get the protocol from the url first.
-			protocol, address, ok := strings.Cut(opts.Address, "+")
-			if !ok {
-				return nil, fmt.Errorf("the scheme of sandbox address should be in " +
-					" the form of <protocol>+<unix|vsock|tcp>, i.e. ttrpc+unix or grpc+vsock")
-			}
-			params = shimbinary.BootstrapParams{
-				Version:  int(opts.Version),
-				Protocol: protocol,
-				Address:  address,
-			}
-		} else {
-			// For those sandbox we can not get endpoint,
-			// fallback to legacy implementation
-			process, err := m.Get(ctx, opts.SandboxID)
-			if err != nil {
-				return nil, fmt.Errorf("can't find sandbox %s", opts.SandboxID)
-			}
-			p, restoreErr := restoreBootstrapParams(process.Bundle())
-			if restoreErr != nil {
-				return nil, fmt.Errorf("failed to get bootstrap "+
-					"params of sandbox %s, %v, legacy restore error %v", opts.SandboxID, err, restoreErr)
-			}
-			params = p
-		}
+	shouldInvokeShimBinary := false
 
+	var params shimbinary.BootstrapParams
+	if opts.SandboxID != "" {
+		_, sbErr := m.sandboxStore.Get(ctx, opts.SandboxID)
+		if sbErr != nil {
+			if !errors.Is(sbErr, errdefs.ErrNotFound) {
+				return nil, sbErr
+			}
+
+			log.G(ctx).WithField("id", id).Warningf("sandbox (id=%s) not found, maybe created from v1.x", opts.SandboxID)
+			// NOTE: If sandbox container, like pause, is created by
+			// v1.6.x or v1.7.x, the shim may be not able to group
+			// multiple containers. We should invoke shim binary and
+			// establish new connection based on returned address.
+			shouldInvokeShimBinary = true
+		} else {
+			if opts.Address != "" {
+				// The address returned from sandbox controller should
+				// be in the form like ttrpc+unix://<uds-path> or grpc+vsock://<cid>:<port>,
+				// we should get the protocol from the url first.
+				protocol, address, ok := strings.Cut(opts.Address, "+")
+				if !ok {
+					return nil, fmt.Errorf("the scheme of sandbox address should be in " +
+						" the form of <protocol>+<unix|vsock|tcp>, i.e. ttrpc+unix or grpc+vsock")
+				}
+				params = shimbinary.BootstrapParams{
+					Version:  int(opts.Version),
+					Protocol: protocol,
+					Address:  address,
+				}
+			} else {
+				process, err := m.Get(ctx, opts.SandboxID)
+				if err != nil {
+					return nil, fmt.Errorf("can't find shim for sandbox %s: %w", opts.SandboxID, err)
+				}
+
+				p, err := restoreBootstrapParams(process.Bundle())
+				if err != nil {
+					return nil, fmt.Errorf("failed to get bootstrap "+
+						"params of sandbox %s: %w", opts.SandboxID, err)
+				}
+				params = p
+			}
+		}
+	}
+	// Even though one shim can be able to group multiple containers,
+	// it doesn't mean it supports sandbox API. The old shim implementation
+	// still requires containerd to invoke `shim delete` to cleanup
+	// container's resource when each container exits. So, if the
+	// shim version is not higher than 3, we should fallback to invoke
+	// shim binary.
+	//
+	// NOTE: The shim version indicates that the shim supports streaming I/O.
+	// It's rolled out together with the sandbox API and can be used
+	// to determine whether we should invoke the shim binary.
+	const supportSandboxAPIVersion = 3
+	if params.Version < supportSandboxAPIVersion {
+		shouldInvokeShimBinary = true
+	}
+
+	if !shouldInvokeShimBinary {
 		// Write sandbox ID this task belongs to.
 		if err := os.WriteFile(filepath.Join(bundle.Path, "sandbox"), []byte(opts.SandboxID), 0600); err != nil {
 			return nil, err

--- a/core/runtime/v2/task_manager.go
+++ b/core/runtime/v2/task_manager.go
@@ -26,6 +26,7 @@ import (
 	"slices"
 
 	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
 	"github.com/containerd/platforms"
 	"github.com/containerd/plugin"
 	"github.com/containerd/plugin/registry"
@@ -141,7 +142,27 @@ func (m *TaskManager) Create(ctx context.Context, taskID string, opts runtime.Cr
 		return nil, fmt.Errorf("failed to validate OCI runtime features: %w", err)
 	}
 
-	t, err := shimTask.Create(ctx, opts)
+	t, err := func() (runtime.Task, error) {
+		t, err := shimTask.Create(ctx, opts)
+		if err == nil || !errdefs.IsNotImplemented(err) {
+			return t, err
+		}
+
+		downgrader, ok := shim.(clientVersionDowngrader)
+		if ok {
+			if derr := downgrader.Downgrade(); derr == nil {
+				log.G(ctx).WithError(err).WithField("id", taskID).
+					Warning("failed to call task.Create, downgrading client API version to try again")
+
+				shimTask, err = newShimTask(shim)
+				if err != nil {
+					return nil, fmt.Errorf("failed to create shim task after downgrading: %w", err)
+				}
+				return shimTask.Create(ctx, opts)
+			}
+		}
+		return t, err
+	}()
 	if err != nil {
 		// NOTE: ctx contains required namespace information.
 		m.manager.shims.Delete(ctx, taskID)

--- a/integration/issue10467_linux_test.go
+++ b/integration/issue10467_linux_test.go
@@ -37,7 +37,7 @@ func TestIssue10467(t *testing.T) {
 
 	t.Logf("Install config for release %s", latestVersion)
 	workDir := t.TempDir()
-	previousReleaseCtrdConfig(t, releaseBinDir, workDir)
+	oneSevenCtrdConfig(t, releaseBinDir, workDir)
 
 	t.Log("Starting the previous release's containerd")
 	previousCtrdBinPath := filepath.Join(releaseBinDir, "bin", "containerd")
@@ -63,7 +63,7 @@ func TestIssue10467(t *testing.T) {
 	})
 
 	t.Log("Prepare pods for current release")
-	upgradeCaseFunc, hookFunc := shouldManipulateContainersInPodAfterUpgrade(t, previousProc.criRuntimeService(t), previousProc.criImageService(t))
+	upgradeCaseFunc, hookFunc := shouldManipulateContainersInPodAfterUpgrade(t, 2, previousProc.criRuntimeService(t), previousProc.criImageService(t))
 	needToCleanup = false
 	require.Nil(t, hookFunc)
 

--- a/integration/issue10467_linux_test.go
+++ b/integration/issue10467_linux_test.go
@@ -63,7 +63,7 @@ func TestIssue10467(t *testing.T) {
 	})
 
 	t.Log("Prepare pods for current release")
-	upgradeCaseFunc, hookFunc := shouldManipulateContainersInPodAfterUpgrade(t, 2, previousProc.criRuntimeService(t), previousProc.criImageService(t))
+	upgradeCaseFunc, hookFunc := shouldManipulateContainersInPodAfterUpgrade("")(t, 2, previousProc.criRuntimeService(t), previousProc.criImageService(t))
 	needToCleanup = false
 	require.Nil(t, hookFunc)
 

--- a/integration/issue10467_linux_test.go
+++ b/integration/issue10467_linux_test.go
@@ -63,7 +63,8 @@ func TestIssue10467(t *testing.T) {
 	})
 
 	t.Log("Prepare pods for current release")
-	upgradeCaseFunc, hookFunc := shouldManipulateContainersInPodAfterUpgrade("")(t, 2, previousProc.criRuntimeService(t), previousProc.criImageService(t))
+	upgradeCaseFuncs, hookFunc := shouldManipulateContainersInPodAfterUpgrade("")(t, 2, previousProc.criRuntimeService(t), previousProc.criImageService(t))
+	upgradeCaseFunc := upgradeCaseFuncs[0]
 	needToCleanup = false
 	require.Nil(t, hookFunc)
 

--- a/integration/release_upgrade_linux_test.go
+++ b/integration/release_upgrade_linux_test.go
@@ -546,8 +546,7 @@ func (pCtx *podTCtx) shimPid() uint32 {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	// NOTE: use version 2 to be compatible with previous release
-	shimCli := connectToShim(ctx, t, cfg["containerdEndpoint"].(string), 2, pCtx.id)
+	shimCli := connectToShim(ctx, t, cfg["containerdEndpoint"].(string), 3, pCtx.id)
 	return shimPid(ctx, t, shimCli)
 }
 
@@ -634,7 +633,8 @@ func previousReleaseCtrdConfig(t *testing.T, previousReleaseBinDir, targetDir st
 version = 2
 
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
-  runtime_type = "%s/bin/containerd-shim-runc-v2"
+  runtime_type = "io.containerd.runc.v2"
+  runtime_path = "%s/bin/containerd-shim-runc-v2"
 `,
 		previousReleaseBinDir)
 

--- a/integration/release_upgrade_linux_test.go
+++ b/integration/release_upgrade_linux_test.go
@@ -49,19 +49,23 @@ type beforeUpgradeHookFunc func(*testing.T)
 
 // TODO: Support Windows
 func TestUpgrade(t *testing.T) {
-	previousReleaseBinDir := t.TempDir()
-	downloadPreviousLatestReleaseBinary(t, previousReleaseBinDir)
-
-	t.Run("recover", runUpgradeTestCase(previousReleaseBinDir, shouldRecoverAllThePodsAfterUpgrade))
-	t.Run("exec", runUpgradeTestCase(previousReleaseBinDir, execToExistingContainer))
-	t.Run("manipulate", runUpgradeTestCase(previousReleaseBinDir, shouldManipulateContainersInPodAfterUpgrade))
-	t.Run("recover-images", runUpgradeTestCase(previousReleaseBinDir, shouldRecoverExistingImages))
-	t.Run("metrics", runUpgradeTestCase(previousReleaseBinDir, shouldParseMetricDataCorrectly))
+	for _, version := range []string{"1.7"} {
+		t.Run(version, func(t *testing.T) {
+			previousReleaseBinDir := t.TempDir()
+			downloadPreviousLatestReleaseBinary(t, version, previousReleaseBinDir)
+			t.Run("recover", runUpgradeTestCase(version, previousReleaseBinDir, shouldRecoverAllThePodsAfterUpgrade))
+			t.Run("exec", runUpgradeTestCase(version, previousReleaseBinDir, execToExistingContainer))
+			t.Run("manipulate", runUpgradeTestCase(version, previousReleaseBinDir, shouldManipulateContainersInPodAfterUpgrade))
+			t.Run("recover-images", runUpgradeTestCase(version, previousReleaseBinDir, shouldRecoverExistingImages))
+			t.Run("metrics", runUpgradeTestCase(version, previousReleaseBinDir, shouldParseMetricDataCorrectly))
+		})
+	}
 }
 
 func runUpgradeTestCase(
+	previousVersion string,
 	previousReleaseBinDir string,
-	setupUpgradeVerifyCase func(*testing.T, cri.RuntimeService, cri.ImageManagerService) (upgradeVerifyCaseFunc, beforeUpgradeHookFunc),
+	setupUpgradeVerifyCase func(*testing.T, int, cri.RuntimeService, cri.ImageManagerService) (upgradeVerifyCaseFunc, beforeUpgradeHookFunc),
 ) func(t *testing.T) {
 	return func(t *testing.T) {
 		// NOTE: Using t.TempDir() here is to ensure there are no leaky
@@ -69,7 +73,14 @@ func runUpgradeTestCase(
 		workDir := t.TempDir()
 
 		t.Log("Install config for previous release")
-		previousReleaseCtrdConfig(t, previousReleaseBinDir, workDir)
+		var taskVersion int
+		if previousVersion == "1.7" {
+			oneSevenCtrdConfig(t, previousReleaseBinDir, workDir)
+			taskVersion = 2
+		} else {
+			previousReleaseCtrdConfig(t, previousReleaseBinDir, workDir)
+			taskVersion = 3
+		}
 
 		t.Log("Starting the previous release's containerd")
 		previousCtrdBinPath := filepath.Join(previousReleaseBinDir, "bin", "containerd")
@@ -91,7 +102,7 @@ func runUpgradeTestCase(
 		})
 
 		t.Log("Prepare pods for current release")
-		upgradeCaseFunc, hookFunc := setupUpgradeVerifyCase(t, previousProc.criRuntimeService(t), previousProc.criImageService(t))
+		upgradeCaseFunc, hookFunc := setupUpgradeVerifyCase(t, taskVersion, previousProc.criRuntimeService(t), previousProc.criImageService(t))
 		needToCleanup = false
 
 		t.Log("Gracefully stop previous release's containerd process")
@@ -123,7 +134,7 @@ func runUpgradeTestCase(
 	}
 }
 
-func shouldRecoverAllThePodsAfterUpgrade(t *testing.T,
+func shouldRecoverAllThePodsAfterUpgrade(t *testing.T, taskVersion int,
 	rSvc cri.RuntimeService, iSvc cri.ImageManagerService) (upgradeVerifyCaseFunc, beforeUpgradeHookFunc) {
 
 	var busyboxImage = images.Get(images.BusyBox)
@@ -152,7 +163,8 @@ func shouldRecoverAllThePodsAfterUpgrade(t *testing.T,
 		criruntime.ContainerState_CONTAINER_RUNNING,
 		WithCommand("sleep", "3d"))
 
-	thirdPodShimPid := int(thirdPodCtx.shimPid())
+	// TODO: Need to pass in task version
+	thirdPodShimPid := int(thirdPodCtx.shimPid(taskVersion))
 
 	hookFunc := func(t *testing.T) {
 		// Kill the shim after stop previous containerd process
@@ -211,7 +223,7 @@ func shouldRecoverAllThePodsAfterUpgrade(t *testing.T,
 	}, hookFunc
 }
 
-func execToExistingContainer(t *testing.T,
+func execToExistingContainer(t *testing.T, _ int,
 	rSvc cri.RuntimeService, iSvc cri.ImageManagerService) (upgradeVerifyCaseFunc, beforeUpgradeHookFunc) {
 
 	var busyboxImage = images.Get(images.BusyBox)
@@ -276,7 +288,7 @@ func getFileSize(t *testing.T, filePath string) int64 {
 	return st.Size()
 }
 
-func shouldManipulateContainersInPodAfterUpgrade(t *testing.T,
+func shouldManipulateContainersInPodAfterUpgrade(t *testing.T, _ int,
 	rSvc cri.RuntimeService, iSvc cri.ImageManagerService) (upgradeVerifyCaseFunc, beforeUpgradeHookFunc) {
 
 	var busyboxImage = images.Get(images.BusyBox)
@@ -375,7 +387,7 @@ func shouldManipulateContainersInPodAfterUpgrade(t *testing.T,
 	}, nil
 }
 
-func shouldRecoverExistingImages(t *testing.T,
+func shouldRecoverExistingImages(t *testing.T, _ int,
 	_ cri.RuntimeService, iSvc cri.ImageManagerService) (upgradeVerifyCaseFunc, beforeUpgradeHookFunc) {
 
 	images := []string{images.Get(images.BusyBox), images.Get(images.Alpine)}
@@ -398,7 +410,7 @@ func shouldRecoverExistingImages(t *testing.T,
 
 // shouldParseMetricDataCorrectly is to check new release containerd can parse
 // metric data from existing shim created by previous release.
-func shouldParseMetricDataCorrectly(t *testing.T,
+func shouldParseMetricDataCorrectly(t *testing.T, _ int,
 	rSvc cri.RuntimeService, iSvc cri.ImageManagerService) (upgradeVerifyCaseFunc, beforeUpgradeHookFunc) {
 
 	imageName := images.Get(images.BusyBox)
@@ -537,7 +549,7 @@ func (pCtx *podTCtx) containerDataDir(cntrID string) string {
 }
 
 // shimPid returns shim's pid.
-func (pCtx *podTCtx) shimPid() uint32 {
+func (pCtx *podTCtx) shimPid(version int) uint32 {
 	t := pCtx.t
 	cfg := criRuntimeInfo(t, pCtx.rSvc)
 
@@ -546,7 +558,7 @@ func (pCtx *podTCtx) shimPid() uint32 {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	shimCli := connectToShim(ctx, t, cfg["containerdEndpoint"].(string), 3, pCtx.id)
+	shimCli := connectToShim(ctx, t, cfg["containerdEndpoint"].(string), version, pCtx.id)
 	return shimPid(ctx, t, shimCli)
 }
 
@@ -637,6 +649,25 @@ version = 2
   runtime_path = "%s/bin/containerd-shim-runc-v2"
 `,
 		previousReleaseBinDir)
+
+	fileName := filepath.Join(targetDir, "config.toml")
+	err := os.WriteFile(fileName, []byte(rawCfg), 0600)
+	require.NoError(t, err, "failed to create config for previous release")
+}
+
+// previousReleaseCtrdConfig generates containerd config with previous release
+// shim binary.
+func oneSevenCtrdConfig(t *testing.T, previousReleaseBinDir, targetDir string) {
+	// TODO(fuweid):
+	//
+	// We should choose correct config version based on previous release.
+	// Currently, we're focusing on v1.x -> v2.0 so we use version = 2 here.
+	rawCfg := fmt.Sprintf(`
+version = 2
+
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+  runtime_type = "%s/bin/containerd-shim-runc-v2"
+`, previousReleaseBinDir)
 
 	fileName := filepath.Join(targetDir, "config.toml")
 	err := os.WriteFile(fileName, []byte(rawCfg), 0600)

--- a/integration/release_upgrade_linux_test.go
+++ b/integration/release_upgrade_linux_test.go
@@ -47,6 +47,8 @@ type upgradeVerifyCaseFunc func(*testing.T, cri.RuntimeService, cri.ImageManager
 // beforeUpgradeHookFunc is a hook before upgrade.
 type beforeUpgradeHookFunc func(*testing.T)
 
+type setupUpgradeVerifyCase func(*testing.T, int, cri.RuntimeService, cri.ImageManagerService) (upgradeVerifyCaseFunc, beforeUpgradeHookFunc)
+
 // TODO: Support Windows
 func TestUpgrade(t *testing.T) {
 	for _, version := range []string{"1.7"} {
@@ -55,9 +57,15 @@ func TestUpgrade(t *testing.T) {
 			downloadPreviousLatestReleaseBinary(t, version, previousReleaseBinDir)
 			t.Run("recover", runUpgradeTestCase(version, previousReleaseBinDir, shouldRecoverAllThePodsAfterUpgrade))
 			t.Run("exec", runUpgradeTestCase(version, previousReleaseBinDir, execToExistingContainer))
-			t.Run("manipulate", runUpgradeTestCase(version, previousReleaseBinDir, shouldManipulateContainersInPodAfterUpgrade))
+			t.Run("manipulate", runUpgradeTestCase(version, previousReleaseBinDir, shouldManipulateContainersInPodAfterUpgrade("" /* default runtime */)))
+
 			t.Run("recover-images", runUpgradeTestCase(version, previousReleaseBinDir, shouldRecoverExistingImages))
 			t.Run("metrics", runUpgradeTestCase(version, previousReleaseBinDir, shouldParseMetricDataCorrectly))
+
+			if version == "1.7" {
+				t.Run("recover-ungroupable-shim", runUpgradeTestCaseWithExistingConfig(version,
+					previousReleaseBinDir, true, shouldManipulateContainersInPodAfterUpgrade("runcv1")))
+			}
 		})
 	}
 }
@@ -65,6 +73,22 @@ func TestUpgrade(t *testing.T) {
 func runUpgradeTestCase(
 	previousVersion string,
 	previousReleaseBinDir string,
+	setupUpgradeVerifyCase func(*testing.T, int, cri.RuntimeService, cri.ImageManagerService) (upgradeVerifyCaseFunc, beforeUpgradeHookFunc),
+) func(t *testing.T) {
+	return runUpgradeTestCaseWithExistingConfig(
+		previousVersion,
+		previousReleaseBinDir,
+		// use new empty configuration so that we could use new shim
+		// binary to cleanup resources created by old shim binary
+		false,
+		setupUpgradeVerifyCase,
+	)
+}
+
+func runUpgradeTestCaseWithExistingConfig(
+	previousVersion string,
+	previousReleaseBinDir string,
+	usingExistingConfig bool,
 	setupUpgradeVerifyCase func(*testing.T, int, cri.RuntimeService, cri.ImageManagerService) (upgradeVerifyCaseFunc, beforeUpgradeHookFunc),
 ) func(t *testing.T) {
 	return func(t *testing.T) {
@@ -114,8 +138,10 @@ func runUpgradeTestCase(
 			hookFunc(t)
 		}
 
-		t.Log("Install default config for current release")
-		currentReleaseCtrdDefaultConfig(t, workDir)
+		if !usingExistingConfig {
+			t.Log("Install default config for current release")
+			currentReleaseCtrdDefaultConfig(t, workDir)
+		}
 
 		t.Log("Starting the current release's containerd")
 		currentProc := newCtrdProc(t, "containerd", workDir, nil)
@@ -288,103 +314,105 @@ func getFileSize(t *testing.T, filePath string) int64 {
 	return st.Size()
 }
 
-func shouldManipulateContainersInPodAfterUpgrade(t *testing.T, _ int,
-	rSvc cri.RuntimeService, iSvc cri.ImageManagerService) (upgradeVerifyCaseFunc, beforeUpgradeHookFunc) {
+func shouldManipulateContainersInPodAfterUpgrade(runtimeHandler string) setupUpgradeVerifyCase {
+	return func(t *testing.T, _ int, rSvc cri.RuntimeService, iSvc cri.ImageManagerService) (upgradeVerifyCaseFunc, beforeUpgradeHookFunc) {
+		var busyboxImage = images.Get(images.BusyBox)
 
-	var busyboxImage = images.Get(images.BusyBox)
+		pullImagesByCRI(t, iSvc, busyboxImage)
 
-	pullImagesByCRI(t, iSvc, busyboxImage)
+		podCtx := newPodTCtxWithRuntimeHandler(t, rSvc, "running-pod", "sandbox", runtimeHandler)
 
-	podCtx := newPodTCtx(t, rSvc, "running-pod", "sandbox")
+		cntr1 := podCtx.createContainer("running", busyboxImage,
+			criruntime.ContainerState_CONTAINER_RUNNING,
+			WithCommand("sleep", "1d"))
 
-	cntr1 := podCtx.createContainer("running", busyboxImage,
-		criruntime.ContainerState_CONTAINER_RUNNING,
-		WithCommand("sleep", "1d"))
+		cntr2 := podCtx.createContainer("created", busyboxImage,
+			criruntime.ContainerState_CONTAINER_CREATED,
+			WithCommand("sleep", "1d"))
 
-	cntr2 := podCtx.createContainer("created", busyboxImage,
-		criruntime.ContainerState_CONTAINER_CREATED,
-		WithCommand("sleep", "1d"))
-
-	cntr3 := podCtx.createContainer("stopped", busyboxImage,
-		criruntime.ContainerState_CONTAINER_EXITED,
-		WithCommand("sleep", "1d"))
-
-	return func(t *testing.T, rSvc cri.RuntimeService, _ cri.ImageManagerService) {
-		// TODO(fuweid): make svc re-connect to new socket
-		podCtx.rSvc = rSvc
-
-		t.Log("Manipulating containers in the previous pod")
-
-		// For the running container, we get status and stats of it,
-		// exec and execsync in it, stop and remove it
-		checkContainerState(t, rSvc, cntr1, criruntime.ContainerState_CONTAINER_RUNNING)
-
-		t.Logf("Checking container %s's stats", cntr1)
-		stats, err := rSvc.ContainerStats(cntr1)
-		require.NoError(t, err)
-		require.True(t, stats.GetMemory().GetWorkingSetBytes().GetValue() > 0)
-
-		t.Logf("Preparing attachable exec for container %s", cntr1)
-		_, err = rSvc.Exec(&criruntime.ExecRequest{
-			ContainerId: cntr1,
-			Cmd:         []string{"/bin/sh"},
-			Stderr:      false,
-			Stdout:      true,
-			Stdin:       true,
-			Tty:         true,
-		})
-		require.NoError(t, err)
-
-		t.Logf("Stopping container %s", cntr1)
-		require.NoError(t, rSvc.StopContainer(cntr1, 0))
-		checkContainerState(t, rSvc, cntr1, criruntime.ContainerState_CONTAINER_EXITED)
-
-		cntr1DataDir := podCtx.containerDataDir(cntr1)
-		t.Logf("Container %s's data dir %s should be remained until RemoveContainer", cntr1, cntr1DataDir)
-		_, err = os.Stat(cntr1DataDir)
-		require.NoError(t, err)
-
-		t.Logf("Starting created container %s", cntr2)
-		checkContainerState(t, rSvc, cntr2, criruntime.ContainerState_CONTAINER_CREATED)
-
-		require.NoError(t, rSvc.StartContainer(cntr2))
-		checkContainerState(t, rSvc, cntr2, criruntime.ContainerState_CONTAINER_RUNNING)
-
-		t.Logf("Stopping running container %s", cntr2)
-		require.NoError(t, rSvc.StopContainer(cntr2, 0))
-		checkContainerState(t, rSvc, cntr2, criruntime.ContainerState_CONTAINER_EXITED)
-
-		t.Logf("Removing exited container %s", cntr3)
-		checkContainerState(t, rSvc, cntr3, criruntime.ContainerState_CONTAINER_EXITED)
-
-		cntr3DataDir := podCtx.containerDataDir(cntr3)
-		_, err = os.Stat(cntr3DataDir)
-		require.NoError(t, err)
-
-		require.NoError(t, rSvc.RemoveContainer(cntr3))
-
-		t.Logf("Container %s's data dir %s should be deleted after RemoveContainer", cntr3, cntr3DataDir)
-		_, err = os.Stat(cntr3DataDir)
-		require.True(t, os.IsNotExist(err))
-
-		// Create a new container in the previous pod, start, stop, and remove it
-		podCtx.createContainer("runinpreviouspod", busyboxImage,
+		cntr3 := podCtx.createContainer("stopped", busyboxImage,
 			criruntime.ContainerState_CONTAINER_EXITED,
 			WithCommand("sleep", "1d"))
 
-		podCtx.stop(true)
-		podDataDir := podCtx.dataDir()
+		return func(t *testing.T, rSvc cri.RuntimeService, _ cri.ImageManagerService) {
+			// TODO(fuweid): make svc re-connect to new socket
+			podCtx.rSvc = rSvc
 
-		t.Logf("Pod %s's data dir %s should be deleted", podCtx.id, podDataDir)
-		_, err = os.Stat(podDataDir)
-		require.True(t, os.IsNotExist(err))
+			t.Log("Manipulating containers in the previous pod")
 
-		cntrDataDir := filepath.Dir(cntr3DataDir)
-		t.Logf("Containers data dir %s should be empty", cntrDataDir)
-		ents, err := os.ReadDir(cntrDataDir)
-		require.NoError(t, err)
-		require.Len(t, ents, 0, cntrDataDir)
-	}, nil
+			// For the running container, we get status and stats of it,
+			// exec and execsync in it, stop and remove it
+			checkContainerState(t, rSvc, cntr1, criruntime.ContainerState_CONTAINER_RUNNING)
+
+			t.Logf("Preparing attachable exec for container %s", cntr1)
+			_, err := rSvc.Exec(&criruntime.ExecRequest{
+				ContainerId: cntr1,
+				Cmd:         []string{"/bin/sh"},
+				Stderr:      false,
+				Stdout:      true,
+				Stdin:       true,
+				Tty:         true,
+			})
+			require.NoError(t, err)
+
+			t.Logf("Stopping container %s", cntr1)
+			require.NoError(t, rSvc.StopContainer(cntr1, 0))
+			checkContainerState(t, rSvc, cntr1, criruntime.ContainerState_CONTAINER_EXITED)
+
+			cntr1DataDir := podCtx.containerDataDir(cntr1)
+			t.Logf("Container %s's data dir %s should be remained until RemoveContainer", cntr1, cntr1DataDir)
+			_, err = os.Stat(cntr1DataDir)
+			require.NoError(t, err)
+
+			t.Logf("Starting created container %s", cntr2)
+			checkContainerState(t, rSvc, cntr2, criruntime.ContainerState_CONTAINER_CREATED)
+
+			require.NoError(t, rSvc.StartContainer(cntr2))
+			checkContainerState(t, rSvc, cntr2, criruntime.ContainerState_CONTAINER_RUNNING)
+
+			t.Logf("Stopping running container %s", cntr2)
+			require.NoError(t, rSvc.StopContainer(cntr2, 0))
+			checkContainerState(t, rSvc, cntr2, criruntime.ContainerState_CONTAINER_EXITED)
+
+			t.Logf("Removing exited container %s", cntr3)
+			checkContainerState(t, rSvc, cntr3, criruntime.ContainerState_CONTAINER_EXITED)
+
+			cntr3DataDir := podCtx.containerDataDir(cntr3)
+			_, err = os.Stat(cntr3DataDir)
+			require.NoError(t, err)
+
+			require.NoError(t, rSvc.RemoveContainer(cntr3))
+
+			t.Logf("Container %s's data dir %s should be deleted after RemoveContainer", cntr3, cntr3DataDir)
+			_, err = os.Stat(cntr3DataDir)
+			require.True(t, os.IsNotExist(err))
+
+			// Create a new container in the previous pod, start, stop, and remove it
+			podCtx.createContainer("runinpreviouspod", busyboxImage,
+				criruntime.ContainerState_CONTAINER_EXITED,
+				WithCommand("sleep", "1d"))
+
+			podCtx.stop(true)
+			podDataDir := podCtx.dataDir()
+
+			t.Logf("Pod %s's data dir %s should be deleted", podCtx.id, podDataDir)
+			_, err = os.Stat(podDataDir)
+			require.True(t, os.IsNotExist(err))
+
+			cntrDataDir := filepath.Dir(cntr3DataDir)
+			t.Logf("Containers data dir %s should be empty", cntrDataDir)
+			ents, err := os.ReadDir(cntrDataDir)
+			require.NoError(t, err)
+			require.Len(t, ents, 0, cntrDataDir)
+
+			t.Log("Creating new running container in new pod")
+			pod2Ctx := newPodTCtxWithRuntimeHandler(t, rSvc, "running-pod-2", "sandbox", runtimeHandler)
+			pod2Ctx.createContainer("running", busyboxImage,
+				criruntime.ContainerState_CONTAINER_RUNNING,
+				WithCommand("sleep", "1d"))
+
+		}, nil
+	}
 }
 
 func shouldRecoverExistingImages(t *testing.T, _ int,
@@ -486,9 +514,15 @@ done
 func newPodTCtx(t *testing.T, rSvc cri.RuntimeService,
 	name, ns string, opts ...PodSandboxOpts) *podTCtx {
 
-	t.Logf("Run a sandbox %s in namespace %s", name, ns)
+	return newPodTCtxWithRuntimeHandler(t, rSvc, name, ns, "", opts...)
+}
+
+func newPodTCtxWithRuntimeHandler(t *testing.T, rSvc cri.RuntimeService,
+	name, ns, runtimeHandler string, opts ...PodSandboxOpts) *podTCtx {
+
+	t.Logf("Run a sandbox %s in namespace %s with runtimeHandler %s", name, ns, runtimeHandler)
 	sbConfig := PodSandboxConfig(name, ns, opts...)
-	sbID, err := rSvc.RunPodSandbox(sbConfig, "")
+	sbID, err := rSvc.RunPodSandbox(sbConfig, runtimeHandler)
 	require.NoError(t, err)
 
 	return &podTCtx{
@@ -666,8 +700,14 @@ func oneSevenCtrdConfig(t *testing.T, previousReleaseBinDir, targetDir string) {
 version = 2
 
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
-  runtime_type = "%s/bin/containerd-shim-runc-v2"
-`, previousReleaseBinDir)
+  runtime_type = "io.containerd.runc.v2"
+  runtime_path = "%s/bin/containerd-shim-runc-v2"
+
+
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runcv1]
+  runtime_type = "io.containerd.runc.v2"
+  runtime_path = "%s/bin/containerd-shim-runc-v1"
+`, previousReleaseBinDir, previousReleaseBinDir)
 
 	fileName := filepath.Join(targetDir, "config.toml")
 	err := os.WriteFile(fileName, []byte(rawCfg), 0600)

--- a/integration/release_upgrade_utils_linux_test.go
+++ b/integration/release_upgrade_utils_linux_test.go
@@ -30,13 +30,12 @@ import (
 	"golang.org/x/mod/semver"
 
 	"github.com/containerd/containerd/v2/pkg/archive"
-	"github.com/containerd/containerd/v2/version"
 )
 
 // downloadPreviousLatestReleaseBinary downloads the latest version of previous
 // release into the target dir.
-func downloadPreviousLatestReleaseBinary(t *testing.T, targetDir string) {
-	ver := previousReleaseVersion(t)
+func downloadPreviousLatestReleaseBinary(t *testing.T, version, targetDir string) {
+	ver := previousReleaseVersion(t, version)
 
 	downloadReleaseBinary(t, targetDir, ver)
 }
@@ -62,33 +61,13 @@ func downloadReleaseBinary(t *testing.T, targetDir string, ver string) {
 }
 
 // previousReleaseVersion returns the latest version of previous release.
-func previousReleaseVersion(t *testing.T) string {
-	majorMinor := ctrdPreviousMajorMinor(t)
-
-	tags := gitLsRemoteCtrdTags(t, fmt.Sprintf("refs/tags/%s.*", majorMinor))
+func previousReleaseVersion(t *testing.T, version string) string {
+	tags := gitLsRemoteCtrdTags(t, fmt.Sprintf("refs/tags/v%s.*", version))
 	require.True(t, len(tags) >= 1)
 
 	// sort them and get the latest version
 	semver.Sort(tags)
 	return tags[len(tags)-1]
-}
-
-// ctrdPreviousMajorMinor gets the current version of running containerd.
-//
-// TODO(fuweid): We should parse containerd --version to get the result.
-func ctrdPreviousMajorMinor(t *testing.T) string {
-	currentVer := "v" + version.Version
-
-	version := semver.MajorMinor(currentVer)
-	switch version {
-	case "v2.0":
-		return "v1.7"
-	case "v1.7":
-		return "v1.6"
-	default:
-		t.Fatalf("unexpected containerd version: %s", currentVer)
-		panic("unreachable")
-	}
 }
 
 // gitLsRemoteTags lists containerd tags based on pattern.

--- a/internal/cri/server/container_create.go
+++ b/internal/cri/server/container_create.go
@@ -41,7 +41,6 @@ import (
 	cio "github.com/containerd/containerd/v2/internal/cri/io"
 	crilabels "github.com/containerd/containerd/v2/internal/cri/labels"
 	customopts "github.com/containerd/containerd/v2/internal/cri/opts"
-	podsandboxtypes "github.com/containerd/containerd/v2/internal/cri/server/podsandbox/types"
 	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
 	"github.com/containerd/containerd/v2/internal/cri/util"
 	"github.com/containerd/containerd/v2/pkg/blockio"
@@ -303,9 +302,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 		containerd.WithContainerExtension(crilabels.ContainerMetadataExtension, &meta),
 	)
 
-	if sandbox.Sandboxer != podsandboxtypes.InternalSandboxID {
-		opts = append(opts, containerd.WithSandbox(sandboxID))
-	}
+	opts = append(opts, containerd.WithSandbox(sandboxID))
 
 	opts = append(opts, c.nri.WithContainerAdjustment())
 	defer func() {

--- a/internal/cri/server/podsandbox/controller.go
+++ b/internal/cri/server/podsandbox/controller.go
@@ -47,7 +47,7 @@ import (
 func init() {
 	registry.Register(&plugin.Registration{
 		Type: plugins.PodSandboxPlugin,
-		ID:   types.InternalSandboxID,
+		ID:   "podsandbox",
 		Requires: []plugin.Type{
 			plugins.EventPlugin,
 			plugins.LeasePlugin,

--- a/internal/cri/server/podsandbox/types/podsandbox.go
+++ b/internal/cri/server/podsandbox/types/podsandbox.go
@@ -26,10 +26,6 @@ import (
 	sandboxstore "github.com/containerd/containerd/v2/internal/cri/store/sandbox"
 )
 
-const (
-	InternalSandboxID = "podsandbox"
-)
-
 type PodSandbox struct {
 	ID        string
 	Container containerd.Container


### PR DESCRIPTION
Backport following pull requests:

* part of https://github.com/containerd/containerd/pull/11510
* https://github.com/containerd/containerd/pull/11793
* https://github.com/containerd/containerd/pull/11916

Closes: #11828