### PR TITLE
pkg/oci: add WithAppendAdditionalGIDs option, add fast-path to WithAppendAdditionalGroups

### DIFF
--- a/pkg/oci/spec_opts.go
+++ b/pkg/oci/spec_opts.go
@@ -980,6 +980,33 @@ func withReadonlyFS(ctx context.Context, client Client, mounts []mount.Mount, fn
 	})
 }
 
+// WithAppendAdditionalGIDs appends supplemental groups for the process. It
+// is a no-op if the spec is a Windows spec.
+//
+// If the list of additional GIDs is non-empty, it makes sure that the process
+// user's primary group is included, appends the additional GIDs, and removes
+// duplicates.
+func WithAppendAdditionalGIDs(gids []uint32) SpecOpts {
+	return func(ctx context.Context, client Client, c *containers.Container, s *Spec) error {
+		if s == nil {
+			return errors.New("nil spec")
+		}
+		if s.Windows != nil {
+			return nil
+		}
+		if len(gids) == 0 {
+			// prevent modifying the spec, and adding the default (0) gid
+			// if no args were given.
+			return nil
+		}
+		ensureAdditionalGids(s)
+		merged := append(s.Process.User.AdditionalGids, gids...)
+		slices.Sort(merged)
+		s.Process.User.AdditionalGids = slices.Compact(merged)
+		return nil
+	}
+}
+
 // WithAppendAdditionalGroups append additional groups within the container.
 // The passed in groups can be either a gid or a groupname.
 func WithAppendAdditionalGroups(groups ...string) SpecOpts {

--- a/pkg/oci/spec_opts.go
+++ b/pkg/oci/spec_opts.go
@@ -1008,13 +1008,39 @@ func WithAppendAdditionalGIDs(gids []uint32) SpecOpts {
 }
 
 // WithAppendAdditionalGroups append additional groups within the container.
-// The passed in groups can be either a gid or a groupname.
+// It is a no-op if the spec is a Windows spec.
+// The passed in groups can be either a gid or a group-name. The given groups
+// are resolved to their numeric GID through the "/etc/groups" file in the
+// container's filesystem. It skips group-name resolution if all groups are
+// numeric values (GIDs), in which case it uses [WithAppendAdditionalGIDs]
+// under the hood.
 func WithAppendAdditionalGroups(groups ...string) SpecOpts {
 	return func(ctx context.Context, client Client, c *containers.Container, s *Spec) (err error) {
 		// For LCOW additional GID's are not supported
 		if s.Windows != nil {
 			return nil
 		}
+
+		// Fast path: skip looking up groups if all groups are already numeric.
+		var gids []uint32
+		allNumeric := true
+
+		for _, g := range groups {
+			id, err := strconv.ParseUint(g, 10, 32)
+			if err != nil {
+				allNumeric = false
+				break
+			}
+			gids = append(gids, uint32(id))
+		}
+
+		if allNumeric {
+			// Unlike WithAppendAdditionalGIDs, WithAppendAdditionalGroups expects
+			// the default group to be added, even if no groups were passed.
+			defer ensureAdditionalGids(s)
+			return WithAppendAdditionalGIDs(gids)(ctx, client, c, s)
+		}
+
 		setProcess(s)
 		setAdditionalGids := func(root fs.FS) error {
 			defer ensureAdditionalGids(s)

--- a/pkg/oci/spec_opts_test.go
+++ b/pkg/oci/spec_opts_test.go
@@ -770,6 +770,98 @@ func TestWithoutMounts(t *testing.T) {
 	}
 }
 
+func TestWithAppendAdditionalGIDs(t *testing.T) {
+	t.Parallel()
+	c := containers.Container{ID: t.Name()}
+
+	testCases := []struct {
+		user      string
+		spec      *specs.Spec
+		extraGIDs []uint32
+		expProc   *specs.Process
+		expErr    string
+	}{
+		{
+			user:   "nil",
+			expErr: "nil spec",
+		},
+		{
+			user: "empty",
+			spec: &specs.Spec{},
+		},
+		{
+			user: "windows-spec",
+			spec: &specs.Spec{Windows: &specs.Windows{}},
+		},
+
+		{
+			user: "no additional GIDs",
+			spec: &specs.Spec{Process: &specs.Process{
+				User: specs.User{GID: 123},
+			}},
+			expProc: &specs.Process{
+				User: specs.User{GID: 123},
+			},
+		},
+		{
+			user: "keep existing",
+			spec: &specs.Spec{Process: &specs.Process{
+				User: specs.User{GID: 123, AdditionalGids: []uint32{123}},
+			}},
+			expProc: &specs.Process{
+				User: specs.User{GID: 123, AdditionalGids: []uint32{123}},
+			},
+		},
+		{
+			user: "only default",
+			spec: &specs.Spec{Process: &specs.Process{
+				User: specs.User{GID: 123, AdditionalGids: []uint32{123}},
+			}},
+			extraGIDs: []uint32{123},
+			expProc: &specs.Process{
+				User: specs.User{GID: 123, AdditionalGids: []uint32{123}},
+			},
+		},
+		{
+			user: "add to default",
+			spec: &specs.Spec{Process: &specs.Process{
+				User: specs.User{GID: 123},
+			}},
+			extraGIDs: []uint32{2, 1},
+			expProc: &specs.Process{
+				User: specs.User{GID: 123, AdditionalGids: []uint32{1, 2, 123}},
+			},
+		},
+		{
+			user: "add to existing",
+			spec: &specs.Spec{Process: &specs.Process{
+				User: specs.User{
+					GID:            123,
+					AdditionalGids: []uint32{2, 1},
+				},
+			}},
+			extraGIDs: []uint32{1, 2, 3, 3},
+			expProc: &specs.Process{
+				User: specs.User{GID: 123, AdditionalGids: []uint32{1, 2, 3, 123}},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.user, func(t *testing.T) {
+			t.Parallel()
+			s := tc.spec
+			err := WithAppendAdditionalGIDs(tc.extraGIDs)(context.Background(), nil, &c, s)
+			if tc.expErr != "" {
+				assert.EqualError(t, err, tc.expErr)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, s)
+				assert.Equal(t, tc.expProc, s.Process)
+			}
+		})
+	}
+}
+
 func TestWithParentCgroupDevices(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### pkg/oci: add WithAppendAdditionalGIDs option

This option allows setting additional GIDs for the process, similar to
WithAppendAdditionalGroups, but without involving resolving group-name
to GIDs. This allows adding additional groups in situations where the
GIDs have already been resolved.

### pkg/oci: add fast-path to WithAppendAdditionalGroups option

WithAppendAdditionalGroups was unconditionally resolving group-names and,
because of that, requiring `/etc/group` to be present (and a read-only
mount to be created).

In situations where all groups passed are numeric IDs, we can skip those
steps, and add the GIDs directly without performing a lookup.