### PR TITLE
cri: log an error if a CRI request has CDI devices but CDI is disabled.

### DIFF
--- a/internal/cri/server/container_create_linux.go
+++ b/internal/cri/server/container_create_linux.go
@@ -21,6 +21,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/containerd/log"
+
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 
@@ -102,6 +104,10 @@ func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageCon
 	}
 	if c.config.EnableCDI {
 		specOpts = append(specOpts, customopts.WithCDI(config.Annotations, config.CDIDevices))
+	} else {
+		if len(config.CDIDevices) > 0 {
+			log.L.Error("create container request config includes a request for CDI device injection, but CDI is disabled in the runtime configuration")
+		}
 	}
 	return specOpts, nil
 }


### PR DESCRIPTION
Currently if a container creation requests CDI device injection using the dedicated CRI message field, the request is processed normally but with the CDI devices silently dropped. The in-line request usually indicates that a DRA driver requested injection of the devices. Silent failure to honour the request can result in hard to understand/debug problems later if the container can start up.

This PR addresses this by explicitly checking for this and logging a warning if CDI devices are requested but CDI support is disabled. Moreover, the PR deprecates disabling CDI in the configuration. 