### PR TITLE
Fix registry errors with transfer service

### DIFF
--- a/core/remotes/errors/errors.go
+++ b/core/remotes/errors/errors.go
@@ -20,16 +20,23 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+
+	"github.com/containerd/typeurl/v2"
 )
 
 var _ error = ErrUnexpectedStatus{}
 
+func init() {
+	typeurl.Register(&ErrUnexpectedStatus{}, "github.com/containerd/containerd/v2/core/remotes/errors", "ErrUnexpectedStatus")
+}
+
 // ErrUnexpectedStatus is returned if a registry API request returned with unexpected HTTP status
 type ErrUnexpectedStatus struct {
-	Status                    string
-	StatusCode                int
-	Body                      []byte
-	RequestURL, RequestMethod string
+	Status        string `json:"status"`
+	StatusCode    int    `json:"statusCode"`
+	Body          []byte `json:"body,omitempty"`
+	RequestURL    string `json:"requestURL,omitempty"`
+	RequestMethod string `json:"requestMethod,omitempty"`
 }
 
 func (e ErrUnexpectedStatus) Error() string {

--- a/core/transfer/proxy/transfer.go
+++ b/core/transfer/proxy/transfer.go
@@ -28,15 +28,17 @@ import (
 
 	transferapi "github.com/containerd/containerd/api/services/transfer/v1"
 	transfertypes "github.com/containerd/containerd/api/types/transfer"
-	"github.com/containerd/containerd/v2/core/streaming"
-	"github.com/containerd/containerd/v2/core/transfer"
-	tstreaming "github.com/containerd/containerd/v2/core/transfer/streaming"
-	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/errdefs"
+	"github.com/containerd/errdefs/pkg/errgrpc"
 	"github.com/containerd/log"
 	"github.com/containerd/ttrpc"
 	"github.com/containerd/typeurl/v2"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/streaming"
+	"github.com/containerd/containerd/v2/core/transfer"
+	tstreaming "github.com/containerd/containerd/v2/core/transfer/streaming"
+	"github.com/containerd/containerd/v2/pkg/oci"
 )
 
 type proxyTransferrer struct {
@@ -150,7 +152,7 @@ func (p *proxyTransferrer) Transfer(ctx context.Context, src interface{}, dst in
 		Options: apiOpts,
 	}
 	_, err = p.client.Transfer(ctx, req)
-	return err
+	return errgrpc.ToNative(err)
 }
 func (p *proxyTransferrer) marshalAny(ctx context.Context, i interface{}) (typeurl.Any, error) {
 	switch m := i.(type) {


### PR DESCRIPTION
Currently when using the transfer service the registry error type is not returned to the client over grpc, with this change the client can access the full body to decode the registry error message.