### PR TITLE
image export: don't fail if host platform image variant is not present.

### DIFF
--- a/core/images/archive/exporter.go
+++ b/core/images/archive/exporter.go
@@ -276,11 +276,18 @@ func Export(ctx context.Context, store content.InfoReaderProvider, writer io.Wri
 					return err
 				}
 
-				var manifests []ocispec.Descriptor
+				type manifestStatus struct {
+					manifest  ocispec.Descriptor
+					hasRecord bool
+				}
+
+				manifests := make(map[digest.Digest]manifestStatus)
+
 				for _, m := range index.Manifests {
 					if eo.platform != nil {
+						// process manifests for desired platform only
 						if m.Platform == nil || eo.platform.Match(*m.Platform) {
-							manifests = append(manifests, m)
+							manifests[m.Digest] = manifestStatus{manifest: m, hasRecord: false}
 						} else if !eo.allPlatforms {
 							continue
 						}
@@ -291,24 +298,38 @@ func Export(ctx context.Context, store content.InfoReaderProvider, writer io.Wri
 						return err
 					}
 
+					if r != nil {
+						// manifest has a record, mark it as such
+						if _, ok := manifests[m.Digest]; ok {
+							manifests[m.Digest] = manifestStatus{manifest: m, hasRecord: true}
+						}
+					}
+
 					records = append(records, r...)
 				}
 
-				if len(manifests) >= 1 {
-					if len(manifests) > 1 {
-						sort.SliceStable(manifests, func(i, j int) bool {
-							if manifests[i].Platform == nil {
+				var manifestsWithRecord []ocispec.Descriptor
+				for _, v := range manifests {
+					if v.hasRecord {
+						manifestsWithRecord = append(manifestsWithRecord, v.manifest)
+					}
+				}
+
+				if len(manifestsWithRecord) >= 1 {
+					if len(manifestsWithRecord) > 1 {
+						sort.SliceStable(manifestsWithRecord, func(i, j int) bool {
+							if manifestsWithRecord[i].Platform == nil {
 								return false
 							}
-							if manifests[j].Platform == nil {
+							if manifestsWithRecord[j].Platform == nil {
 								return true
 							}
-							return eo.platform.Less(*manifests[i].Platform, *manifests[j].Platform)
+							return eo.platform.Less(*manifestsWithRecord[i].Platform, *manifestsWithRecord[j].Platform)
 						})
 					}
-					d = manifests[0].Digest
+					d = manifestsWithRecord[0].Digest
 					dManifests[d] = &exportManifest{
-						manifest: manifests[0],
+						manifest: manifestsWithRecord[0],
 					}
 				} else if eo.platform != nil {
 					return fmt.Errorf("no manifest found for platform: %w", errdefs.ErrNotFound)


### PR DESCRIPTION
Prior to this change, when exporting an image to a Tar archive, the export would fail if the image platform corresponding to the host's platform was not present.

E.g., on a linux/amd64 host:

```
$ docker image pull --platform linux/arm64/v8 alpine:latest 
$ docker save -o b.tar alpine:latest
Error response from daemon: unable to create manifests file: NotFound: content digest sha256:08001109a7d679fe33b04fa51d681bd40b975d8f5cea8c3ef6c0eccb6a7338ce: not found
```

See Moby 50173 (https://github.com/moby/moby/issues/50173).

This commit fixes this.