### PR TITLE
Implement io.ReaderAt on docker fetch reader

### DIFF
--- a/core/remotes/docker/httpreadseeker.go
+++ b/core/remotes/docker/httpreadseeker.go
@@ -102,6 +102,36 @@ func (hrs *httpReadSeeker) Close() error {
 	return nil
 }
 
+func (hrs *httpReadSeeker) ReadAt(p []byte, offset int64) (n int, err error) {
+	if hrs.closed {
+		return 0, fmt.Errorf("httpReadSeeker.ReadAt: closed: %w", errdefs.ErrUnavailable)
+	}
+
+	if offset < 0 {
+		return 0, fmt.Errorf("httpReadSeeker.ReadAt: negative offset: %w", errdefs.ErrInvalidArgument)
+	}
+
+	if hrs.size != -1 && offset >= hrs.size {
+		return 0, io.EOF
+	}
+
+	if hrs.open == nil {
+		return 0, fmt.Errorf("httpReadSeeker.ReadAt: cannot open: %w", errdefs.ErrNotImplemented)
+	}
+
+	rc, err := hrs.open(offset)
+	if err != nil {
+		return 0, fmt.Errorf("httpReadSeeker.ReadAt: failed to open at offset %d: %w", offset, err)
+	}
+	defer func() {
+		if closeErr := rc.Close(); closeErr != nil {
+			log.L.WithError(closeErr).Error("httpReadSeeker.ReadAt: failed to close ReadCloser")
+		}
+	}()
+
+	return io.ReadFull(rc, p)
+}
+
 func (hrs *httpReadSeeker) Seek(offset int64, whence int) (int64, error) {
 	if hrs.closed {
 		return 0, fmt.Errorf("Fetcher.Seek: closed: %w", errdefs.ErrUnavailable)


### PR DESCRIPTION
I was working on treating a remote as a content provider and ran into the stream backing the fetch only implementing io.Seeker. I shimmed an io.ReaderAt implementation by calling seek under the hood, but this is of course not a faithful io.ReaderAt implementation.

This just implements a correct io.ReaderAt implementation directly.