### PR TITLE
cri: support passing annotations when updating container resources

### DIFF
--- a/internal/cri/server/container_update_resources.go
+++ b/internal/cri/server/container_update_resources.go
@@ -131,8 +131,13 @@ func (c *criService) updateContainerResources(ctx context.Context,
 		}
 		return newStatus, fmt.Errorf("failed to get task: %w", err)
 	}
+
+	opts := []containerd.UpdateTaskOpts{
+		containerd.WithResources(getResources(newSpec)),
+		containerd.WithAnnotations(r.GetAnnotations()),
+	}
 	// newSpec.Linux / newSpec.Windows won't be nil
-	if err := task.Update(ctx, containerd.WithResources(getResources(newSpec))); err != nil {
+	if err := task.Update(ctx, opts...); err != nil {
 		if errdefs.IsNotFound(err) {
 			// Task exited already.
 			return newStatus, nil


### PR DESCRIPTION
We identified scenarios where annotations need to be passed to the runtime during container resource updates. While the request contains annotations and the runtime is capable of processing them, the propagation step was  previously missing in the workflow.
This change completes the pipeline by forwarding annotations from UpdateContainerResourcesRequest to the underlying runtime through containerd's task update mechanism.
Add `containerd.WithAnnotations(r.GetAnnotations())` to the task update options when handling `UpdateContainerResourcesRequest`, allowing annotations to be passed down to the runtime during container resource updates.