### PR TITLE
Fix multipart fetch issue when the server does not return content length

### DIFF
--- a/core/content/helpers.go
+++ b/core/content/helpers.go
@@ -200,7 +200,7 @@ func Copy(ctx context.Context, cw Writer, or io.Reader, size int64, expected dig
 		}
 		if size != 0 && copied < size-ws.Offset {
 			// Short writes would return its own error, this indicates a read failure
-			return fmt.Errorf("failed to read expected number of bytes: %w", io.ErrUnexpectedEOF)
+			return fmt.Errorf("short read: expected %d bytes but got %d: %w", size-ws.Offset, copied, io.ErrUnexpectedEOF)
 		}
 		if err := cw.Commit(ctx, size, expected, opts...); err != nil {
 			if errors.Is(err, ErrReset) {

--- a/core/remotes/docker/fetcher.go
+++ b/core/remotes/docker/fetcher.go
@@ -480,6 +480,10 @@ func (r dockerFetcher) open(ctx context.Context, req *request, mediatype string,
 	})
 
 	remaining, _ := strconv.ParseInt(resp.Header.Get("Content-Length"), 10, 0)
+	if remaining <= chunkSize {
+		parallelism = 1
+	}
+
 	if parallelism > 1 {
 		// If we have a content length, we can use multiple requests to fetch
 		// the content in parallel. This will make download of bigger bodies


### PR DESCRIPTION
Before: ( mutipart fetching needs to be conf'ed )

```
ctr i pull public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v1.14.1
...
application/vnd.docker.distribution.manifest.list.v2+json sha256:e64728220f5cc60477e9dd5415b33a7bb0cc024dbf8fe25eba8397b9f30c3a62
Pulling from OCI Registry (public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v1.14.1) elapsed: 23.1s  total:   0.0 B  (0.0 B/s)
ERRO[0035] progress stream failed to recv                error="error reading from server: EOF"
ctr: error reading from server: EOF
```

It is worth noting that when we don't know the size of the file, multipart fetching will be disabled.