### PR TITLE
[release/1.6] backport windows runner and golang toolchain updates

### DIFF
--- a/.github/actions/install-go/action.yml
+++ b/.github/actions/install-go/action.yml
@@ -3,7 +3,7 @@ description: "Reusable action to install Go, so there is one place to bump Go ve
 inputs:
   go-version:
     required: true
-    default: "1.23.8"
+    default: "1.23.9"
     description: "Go version to install"
 
 runs:

--- a/.github/actions/install-go/action.yml
+++ b/.github/actions/install-go/action.yml
@@ -3,7 +3,7 @@ description: "Reusable action to install Go, so there is one place to bump Go ve
 inputs:
   go-version:
     required: true
-    default: "1.23.9"
+    default: "1.23.10"
     description: "Go version to install"
 
 runs:

--- a/.github/actions/install-go/action.yml
+++ b/.github/actions/install-go/action.yml
@@ -3,7 +3,7 @@ description: "Reusable action to install Go, so there is one place to bump Go ve
 inputs:
   go-version:
     required: true
-    default: "1.24.2"
+    default: "1.23.8"
     description: "Go version to install"
 
 runs:

--- a/.github/actions/install-go/action.yml
+++ b/.github/actions/install-go/action.yml
@@ -3,7 +3,7 @@ description: "Reusable action to install Go, so there is one place to bump Go ve
 inputs:
   go-version:
     required: true
-    default: "1.23.7"
+    default: "1.24.2"
     description: "Go version to install"
 
 runs:

--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -9,7 +9,7 @@ on:
       azure_windows_image_id:
         description: Windows image URN to deploy
         required: true
-        default: MicrosoftWindowsServer:WindowsServer:2022-datacenter:20348.350.2111030009
+        default: MicrosoftWindowsServer:WindowsServer:2025-datacenter:latest
       azure_vm_size:
         description: Windows image builder VM size
         required: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, ubuntu-24.04-arm, macos-13, windows-2022, windows-2025]
-        go-version: ["1.23.7", "1.24.1"]
+        go-version: ["1.23.8", "1.24.2"]
     steps:
       - name: Install dependencies
         if: matrix.os == 'ubuntu-24.04' || matrix.os == 'ubuntu-24.04-arm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-13, windows-2019]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-13, windows-2025]
 
     steps:
       - name: Install dependencies
@@ -217,7 +217,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-13, windows-2019, windows-2022]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-13, windows-2022, windows-2025]
         go-version: ["1.23.7", "1.24.1"]
     steps:
       - name: Install dependencies
@@ -260,7 +260,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022]
+        os: [windows-2022, windows-2025]
 
     defaults:
       run:
@@ -286,17 +286,6 @@ jobs:
           echo "${{ github.workspace }}/src/github.com/containerd/containerd/bin" >> $GITHUB_PATH
 
       - run: script/setup/install-dev-tools
-
-      # needs to be a separate step since terminal reload is required to bring in new env variables and PATH
-      - name: Upgrade Chocolaty on Windows 2019
-        if: matrix.os == 'windows-2019'
-        shell: powershell
-        run: .\script\setup\upgrade_chocolaty_windows_2019.ps1
-
-      - name: Upgrade MinGW on Windows 2019
-        if: matrix.os == 'windows-2019'
-        shell: powershell
-        run: .\script\setup\upgrade_mingw_windows_2019.ps1
 
       - name: Binaries
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, ubuntu-24.04-arm, macos-13, windows-2022, windows-2025]
-        go-version: ["1.23.9", "1.24.3"]
+        go-version: ["1.23.10", "1.24.4"]
     steps:
       - name: Install dependencies
         if: matrix.os == 'ubuntu-24.04' || matrix.os == 'ubuntu-24.04-arm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, ubuntu-24.04-arm, macos-13, windows-2022, windows-2025]
-        go-version: ["1.23.8", "1.24.2"]
+        go-version: ["1.23.9", "1.24.3"]
     steps:
       - name: Install dependencies
         if: matrix.os == 'ubuntu-24.04' || matrix.os == 'ubuntu-24.04-arm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 name: Containerd Release
 
 env:
-  GO_VERSION: "1.23.8"
+  GO_VERSION: "1.23.9"
 
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 name: Containerd Release
 
 env:
-  GO_VERSION: "1.23.9"
+  GO_VERSION: "1.23.10"
 
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 name: Containerd Release
 
 env:
-  GO_VERSION: "1.23.7"
+  GO_VERSION: "1.24.2"
 
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 name: Containerd Release
 
 env:
-  GO_VERSION: "1.24.2"
+  GO_VERSION: "1.23.8"
 
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/.github/workflows/windows-periodic.yml
+++ b/.github/workflows/windows-periodic.yml
@@ -38,16 +38,16 @@ jobs:
       id-token: 'write'
     strategy:
       matrix:
-        win_ver: [ltsc2019, ltsc2022]
+        win_ver: [ltsc2022, ltsc2025]
         include:
-        - win_ver: ltsc2019
-          AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2019-Datacenter-with-Containers-smalldisk:17763.1935.2105080716"
-          AZURE_RESOURCE_GROUP: ctrd-integration-ltsc2019-${{ github.run_id }}
-          GOOGLE_BUCKET: "containerd-integration/logs/windows-ltsc2019/"
         - win_ver: ltsc2022
           AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2022-datacenter-smalldisk-g2:20348.169.2108120020"
           AZURE_RESOURCE_GROUP: ctrd-integration-ltsc2022-${{ github.run_id }}
           GOOGLE_BUCKET: "containerd-integration/logs/windows-ltsc2022/"
+        - win_ver: ltsc2025
+          AZURE_IMG: "MicrosoftWindowsServer:WindowsServer:2025-Datacenter:latest"
+          AZURE_RESOURCE_GROUP: ctrd-integration-ltsc2025-${{ github.run_id }}
+          GOOGLE_BUCKET: "containerd-integration/logs/windows-ltsc2025/"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -96,7 +96,7 @@ EOF
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.23.8",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.23.9",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -96,7 +96,7 @@ EOF
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.23.9",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.23.10",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -96,7 +96,7 @@ EOF
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.23.7",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.23.8",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -10,7 +10,7 @@
 #
 # docker build -t containerd-test --build-arg RUNC_VERSION=v1.0.0-rc94 -f Dockerfile.test ../
 
-ARG GOLANG_VERSION=1.23.8
+ARG GOLANG_VERSION=1.23.9
 ARG GOLANG_IMAGE=golang
 
 FROM ${GOLANG_IMAGE}:${GOLANG_VERSION} AS golang

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -10,7 +10,7 @@
 #
 # docker build -t containerd-test --build-arg RUNC_VERSION=v1.0.0-rc94 -f Dockerfile.test ../
 
-ARG GOLANG_VERSION=1.23.7
+ARG GOLANG_VERSION=1.24.2
 ARG GOLANG_IMAGE=golang
 
 FROM ${GOLANG_IMAGE}:${GOLANG_VERSION} AS golang

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -10,7 +10,7 @@
 #
 # docker build -t containerd-test --build-arg RUNC_VERSION=v1.0.0-rc94 -f Dockerfile.test ../
 
-ARG GOLANG_VERSION=1.24.2
+ARG GOLANG_VERSION=1.23.8
 ARG GOLANG_IMAGE=golang
 
 FROM ${GOLANG_IMAGE}:${GOLANG_VERSION} AS golang

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -10,7 +10,7 @@
 #
 # docker build -t containerd-test --build-arg RUNC_VERSION=v1.0.0-rc94 -f Dockerfile.test ../
 
-ARG GOLANG_VERSION=1.23.9
+ARG GOLANG_VERSION=1.23.10
 ARG GOLANG_IMAGE=golang
 
 FROM ${GOLANG_IMAGE}:${GOLANG_VERSION} AS golang

--- a/integration/image_load_test.go
+++ b/integration/image_load_test.go
@@ -18,9 +18,11 @@ package integration
 
 import (
 	"path/filepath"
+	goruntime "runtime"
 	"testing"
 	"time"
 
+	"github.com/containerd/containerd/integration/platform"
 	"github.com/stretchr/testify/require"
 	exec "golang.org/x/sys/execabs"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -28,6 +30,14 @@ import (
 
 // Test to load an image from tarball.
 func TestImageLoad(t *testing.T) {
+	// TODO(kiashok): Docker is not able to pull the right
+	// image manifest of `testImage` on WS2025 host. Temporarily
+	// skipping this test for WS2025 while its fixed on docker.
+	// This test is validated on WS2022 anyway.
+	if goruntime.GOOS == "windows" && platform.SkipTestOnHost() {
+		t.Skip("Temporarily skip validating on WS2025")
+	}
+
 	testImage := GetImage(BusyBox)
 	loadedImage := testImage
 	_, err := exec.LookPath("docker")

--- a/integration/images/volume-copy-up/Makefile
+++ b/integration/images/volume-copy-up/Makefile
@@ -33,8 +33,8 @@ endif
 OS ?= linux
 # Architectures supported: amd64, arm64
 ARCH ?= amd64
-# OS Version for the Windows images: 1809, 20H2, ltsc2022
-OSVERSION ?= 1809
+# OS Version for the Windows images: ltsc2022, ltsc2025
+OSVERSION ?= ltsc2022
 
 # The output type could either be docker (local), or registry.
 # If it is registry, it will also allow us to push the Windows images.
@@ -46,7 +46,7 @@ ALL_OS_ARCH.linux = $(foreach arch, ${ALL_ARCH.linux}, linux-$(arch))
 
 ifneq ($(REMOTE_DOCKER_URL),)
 ALL_OS += windows
-ALL_OSVERSIONS.windows := 1809 20H2 ltsc2022
+ALL_OSVERSIONS.windows := ltsc2022 ltsc2025
 ALL_OS_ARCH.windows = $(foreach osversion, ${ALL_OSVERSIONS.windows}, windows-amd64-${osversion})
 BASE.windows := mcr.microsoft.com/windows/nanoserver
 endif

--- a/integration/images/volume-ownership/Makefile
+++ b/integration/images/volume-ownership/Makefile
@@ -33,8 +33,8 @@ endif
 OS ?= linux
 # Architectures supported: amd64, arm64
 ARCH ?= amd64
-# OS Version for the Windows images: 1809, 20H2, ltsc2022
-OSVERSION ?= 1809
+# OS Version for the Windows images: ltsc2022, lts2025
+OSVERSION ?= ltsc2022
 
 # The output type could either be docker (local), or registry.
 # If it is registry, it will also allow us to push the Windows images.
@@ -46,7 +46,7 @@ ALL_OS_ARCH.linux = $(foreach arch, ${ALL_ARCH.linux}, linux-$(arch))
 
 ifneq ($(REMOTE_DOCKER_URL),)
 ALL_OS += windows
-ALL_OSVERSIONS.windows := 1809 20H2 ltsc2022
+ALL_OSVERSIONS.windows := ltsc2022 ltsc2025
 ALL_OS_ARCH.windows = $(foreach osversion, ${ALL_OSVERSIONS.windows}, windows-amd64-${osversion})
 BASE.windows := mcr.microsoft.com/windows/nanoserver
 endif

--- a/integration/platform/doc.go
+++ b/integration/platform/doc.go
@@ -1,6 +1,3 @@
-//go:build !windows
-// +build !windows
-
 /*
    Copyright The containerd Authors.
 
@@ -17,18 +14,6 @@
    limitations under the License.
 */
 
-package testsuite
-
-import "syscall"
-
-func clearMask() func() {
-	oldumask := syscall.Umask(0)
-	return func() {
-		syscall.Umask(oldumask)
-	}
-}
-
-// Used only on Windows to skip tests for certain host OS versions.
-func SkipTestOnHost() bool {
-	return false
-}
+// The platform package contains integration test helpers for
+// platform specific behaviors.
+package platform

--- a/integration/platform/helper_unix.go
+++ b/integration/platform/helper_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.
@@ -17,18 +16,8 @@
    limitations under the License.
 */
 
-package testsuite
+package platform
 
-import "syscall"
-
-func clearMask() func() {
-	oldumask := syscall.Umask(0)
-	return func() {
-		syscall.Umask(oldumask)
-	}
-}
-
-// Used only on Windows to skip tests for certain host OS versions.
 func SkipTestOnHost() bool {
 	return false
 }

--- a/integration/platform/helper_windows.go
+++ b/integration/platform/helper_windows.go
@@ -1,0 +1,56 @@
+//go:build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package platform
+
+import (
+	"sync"
+
+	"github.com/Microsoft/hcsshim/osversion"
+	"golang.org/x/sys/windows"
+)
+
+var (
+	osv  osversion.OSVersion
+	once sync.Once
+)
+
+// Temporarily used on windows to skip failing tests on WS2025.
+func SkipTestOnHost() bool {
+	const (
+		// Copied from https://github.com/microsoft/hcsshim/blob/9b2e94f544990ce7e8f3ccdb60f1a9abd7debe05/osversion/windowsbuilds.go#L88-L90
+		// Windows Server 2025 build 26100
+		// The Windows Server 2025 constant was added in Microsoft/hcsshim@v0.13.0.
+		// Copied here to avoid updating the hcsshim dependency which requires breaking changes in the archive package.
+		V25H1Server = 26100
+		LTSC2025    = V25H1Server
+	)
+
+	// Copied from https://github.com/microsoft/hcsshim/commit/1e6fc28c2f57d666f91269fc82d7b66c7d0d9093 (added in v0.13.0)
+	// Pre Microsoft/hcsshim@v0.13.0, the osversion.Get() function required the calling application to be
+	// manifested to get the correct version information. This is not the case anymore.
+	once.Do(func() {
+		v := windows.RtlGetVersion()
+		osv = osversion.OSVersion{}
+		osv.MajorVersion = uint8(v.MajorVersion)
+		osv.MinorVersion = uint8(v.MinorVersion)
+		osv.Build = uint16(v.BuildNumber)
+	})
+
+	return osv.Build == LTSC2025
+}

--- a/script/setup/prepare_env_windows.ps1
+++ b/script/setup/prepare_env_windows.ps1
@@ -5,7 +5,7 @@
 # lived test environment.
 Set-MpPreference -DisableRealtimeMonitoring:$true
 
-$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.23.8"; make = ""; nssm = "" }
+$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.23.9"; make = ""; nssm = "" }
 
 Write-Host "Downloading chocolatey package"
 curl.exe -L "https://packages.chocolatey.org/chocolatey.0.10.15.nupkg" -o 'c:\choco.zip'

--- a/script/setup/prepare_env_windows.ps1
+++ b/script/setup/prepare_env_windows.ps1
@@ -5,7 +5,7 @@
 # lived test environment.
 Set-MpPreference -DisableRealtimeMonitoring:$true
 
-$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.23.9"; make = ""; nssm = "" }
+$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.23.10"; make = ""; nssm = "" }
 
 Write-Host "Downloading chocolatey package"
 curl.exe -L "https://packages.chocolatey.org/chocolatey.0.10.15.nupkg" -o 'c:\choco.zip'

--- a/script/setup/prepare_env_windows.ps1
+++ b/script/setup/prepare_env_windows.ps1
@@ -5,7 +5,7 @@
 # lived test environment.
 Set-MpPreference -DisableRealtimeMonitoring:$true
 
-$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.23.7"; make = ""; nssm = "" }
+$PACKAGES= @{ mingw = "10.2.0"; git = ""; golang = "1.23.8"; make = ""; nssm = "" }
 
 Write-Host "Downloading chocolatey package"
 curl.exe -L "https://packages.chocolatey.org/chocolatey.0.10.15.nupkg" -o 'c:\choco.zip'


### PR DESCRIPTION
This change backports a few CI updates for to release/1.6 branch.

1. Updates Windows runners to run on Windows 2022 and Windows 2025 (Windows 2019 runners are deprecated)
3. Updates Golang toolchain in build and release CI to latest Go 1.23.x and Go 1.24.x.

Note: cherry-picks were not clean as 1) unlike the release branches main no longer supports Go 1.23 2) the integration test help function for skipping tests on Windows 2025 runners moved from `integration/client` to `integration/platform` due to `integration/client` being a module in release/1.6 branch 3) the pre- 0.13.0 hcsshim library for osversion required the application to be manifested with the OS version, so this change copies the version code added to 0.13.0 which no longer requires the manifest.