### PR TITLE
Add coverage support for CRI integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /bin/
 /man/
 coverage.txt
+cri-integration-coverage.txt
 profile.out
 containerd.test
 _site/

--- a/script/test/cri-integration.sh
+++ b/script/test/cri-integration.sh
@@ -51,7 +51,7 @@ ${CMD} --test.run="${FOCUS}" --test.v \
   --cri-endpoint="${CONTAINERD_SOCK}" \
   --runtime-handler="${RUNTIME}" \
   --containerd-bin="${CONTAINERD_BIN}" \
-  --image-list="${TEST_IMAGE_LIST:-}" && test_exit_code=$? || test_exit_code=$?
+  --image-list="${TEST_IMAGE_LIST:-}" "@" && test_exit_code=$? || test_exit_code=$?
 
 if [[ "$test_exit_code" -ne 0 ]]; then
   if [[ -e "$GITHUB_WORKSPACE" ]]; then

--- a/script/test/utils.sh
+++ b/script/test/utils.sh
@@ -166,8 +166,10 @@ version = 2
           SandboxIsolation = 1
 EOF
 fi
-
-if [ $IS_WINDOWS -eq 0 ] && [ ! -z "$CGROUP_DRIVER" ] && [ "$CGROUP_DRIVER" = "systemd" ];then
+# To allow the cri-integration test to run via CLI without explicitly setting CGROUP_DRIVER
+if [ $IS_WINDOWS -eq 0 ] && [ ! -v CGROUP_DRIVER ]; then
+  echo "CGROUP_DRIVER is unset"
+elif [ "$CGROUP_DRIVER" = "systemd" ]; then
   cat >> ${CONTAINERD_CONFIG_FILE} << EOF
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
    SystemdCgroup = true


### PR DESCRIPTION
Adds support for creating coverage report for the target `make cri-integration`, the output of the coverage report is as follows

```
mode: atomic
github.com/containerd/containerd/v2/client/client.go:80.13,90.31 8 1
github.com/containerd/containerd/v2/client/client.go:90.31,96.3 1 0
github.com/containerd/containerd/v2/client/client.go:101.56,103.25 2 22
github.com/containerd/containerd/v2/client/client.go:103.25,104.35 1 58
github.com/containerd/containerd/v2/client/client.go:104.35,106.4 1 0
github.com/containerd/containerd/v2/client/client.go:108.2,108.24 1 22
github.com/containerd/containerd/v2/client/client.go:108.24,110.3 1 22
github.com/containerd/containerd/v2/client/client.go:112.2,116.32 2 22
github.com/containerd/containerd/v2/client/client.go:116.32,118.3 1 0
```
![Screenshot 2025-06-19 at 7 57 24 PM](https://github.com/user-attachments/assets/696df210-5a10-4f12-bec9-5ee643a6078e)

