### PR TITLE
ci:fix ci TestContainerExecLargeOutputWithTTY panic

### DIFF
--- a/integration/client/container_test.go
+++ b/integration/client/container_test.go
@@ -1986,6 +1986,9 @@ func TestContainerExecLargeOutputWithTTY(t *testing.T) {
 
 		const expectedSuffix = "999999 1000000"
 		stdoutString := stdout.String()
+		if len(stdoutString) == 0 {
+			t.Fatal(fmt.Errorf("len (stdoutString) is 0"))
+		}
 		if !strings.Contains(stdoutString, expectedSuffix) {
 			t.Fatalf("process output does not end with %q at iteration %d, here are the last 20 characters of the output:\n\n %q", expectedSuffix, i, stdoutString[len(stdoutString)-20:])
 		}


### PR DESCRIPTION
```
2025-06-21T04:06:35.2568615Z     default: === NAME  TestContainerExecLargeOutputWithTTY
2025-06-21T04:06:35.2569711Z     default:     container_test.go:1981: expected exec exit code 0 but received 129
2025-06-21T04:06:35.2615723Z     default: --- FAIL: TestContainerExecLargeOutputWithTTY (21.46s)
2025-06-21T04:06:35.2641056Z     default: panic: runtime error: slice bounds out of range [-20:] [recovered]
2025-06-21T04:06:35.2641837Z     default: 	panic: runtime error: slice bounds out of range [-20:]
2025-06-21T04:06:35.2642348Z     default: 
2025-06-21T04:06:35.2642687Z     default: goroutine 1469 [running]:
2025-06-21T04:06:35.2643204Z     default: testing.tRunner.func1.2({0x16b2400, 0xc000abe8a0})
2025-06-21T04:06:35.2643830Z     default: 	/usr/local/go/src/testing/testing.go:1734 +0x3eb
2025-06-21T04:06:35.2646097Z     default: testing.tRunner.func1()
2025-06-21T04:06:35.2648196Z     default: 	/usr/local/go/src/testing/testing.go:1737 +0x696
2025-06-21T04:06:35.2648772Z     default: panic({0x16b2400?, 0xc000abe8a0?})
2025-06-21T04:06:35.2649990Z     default: 	/usr/local/go/src/runtime/panic.go:792 +0x132
2025-06-21T04:06:35.2653718Z     default: github.com/containerd/containerd/v2/integration/client.TestContainerExecLargeOutputWithTTY(0xc0007b08c0)
2025-06-21T04:06:35.2655421Z     default: 	/vagrant/integration/client/container_test.go:1990 +0x153e
2025-06-21T04:06:35.2656340Z     default: testing.tRunner(0xc0007b08c0, 0x17784a8)
2025-06-21T04:06:35.2656901Z     default: 	/usr/local/go/src/testing/testing.go:1792 +0x226
2025-06-21T04:06:35.2657651Z     default: created by testing.(*T).Run in goroutine 1
2025-06-21T04:06:35.2658181Z     default: 	/usr/local/go/src/testing/testing.go:1851 +0x8f3
2025-06-21T04:06:35.2970680Z     default: exit status 2
2025-06-21T04:06:35.2979502Z     default: FAIL	github.com/containerd/containerd/v2/integration/client	133.529s
```