### PR TITLE
[release/1.7]  cherry-pick Update differ to handle zstd media types

### DIFF
--- a/archive/compression/compression.go
+++ b/archive/compression/compression.go
@@ -45,6 +45,8 @@ const (
 	Gzip
 	// Zstd is zstd compression algorithm.
 	Zstd
+	// Unknown is used when a plugin handles the algorithm.
+	Unknown
 )
 
 const disablePigzEnv = "CONTAINERD_DISABLE_PIGZ"
@@ -254,6 +256,8 @@ func (compression *Compression) Extension() string {
 		return "gz"
 	case Zstd:
 		return "zst"
+	case Unknown:
+		return "unknown"
 	}
 	return ""
 }

--- a/diff/walking/differ.go
+++ b/diff/walking/differ.go
@@ -75,12 +75,12 @@ func (s *walkingDiff) Compare(ctx context.Context, lower, upper []mount.Mount, o
 		writeDiffOpts = append(writeDiffOpts, archive.WithSourceDateEpoch(config.SourceDateEpoch))
 	}
 
-	var isCompressed bool
+	compressionType := compression.Uncompressed
 	if config.Compressor != nil {
 		if config.MediaType == "" {
 			return emptyDesc, errors.New("media type must be explicitly specified when using custom compressor")
 		}
-		isCompressed = true
+		compressionType = compression.Unknown
 	} else {
 		if config.MediaType == "" {
 			config.MediaType = ocispec.MediaTypeImageLayerGzip
@@ -89,7 +89,9 @@ func (s *walkingDiff) Compare(ctx context.Context, lower, upper []mount.Mount, o
 		switch config.MediaType {
 		case ocispec.MediaTypeImageLayer:
 		case ocispec.MediaTypeImageLayerGzip:
-			isCompressed = true
+			compressionType = compression.Gzip
+		case ocispec.MediaTypeImageLayerZstd:
+			compressionType = compression.Zstd
 		default:
 			return emptyDesc, fmt.Errorf("unsupported diff media type: %v: %w", config.MediaType, errdefs.ErrNotImplemented)
 		}
@@ -132,7 +134,7 @@ func (s *walkingDiff) Compare(ctx context.Context, lower, upper []mount.Mount, o
 				}
 			}
 
-			if isCompressed {
+			if compressionType != compression.Uncompressed {
 				dgstr := digest.SHA256.Digester()
 				var compressed io.WriteCloser
 				if config.Compressor != nil {
@@ -141,7 +143,7 @@ func (s *walkingDiff) Compare(ctx context.Context, lower, upper []mount.Mount, o
 						return fmt.Errorf("failed to get compressed stream: %w", errOpen)
 					}
 				} else {
-					compressed, errOpen = compression.CompressStream(cw, compression.Gzip)
+					compressed, errOpen = compression.CompressStream(cw, compressionType)
 					if errOpen != nil {
 						return fmt.Errorf("failed to get compressed stream: %w", errOpen)
 					}


### PR DESCRIPTION
The differ should be able to generate zstd compressed layers when provided with the zstd media type.


(cherry picked from commit 17f7858b4e2e31b447410f66d0100b816c1fe6b3)