### PR TITLE
core/runtime/v2: shimManager.cleanupWorkDirs ignore non-existing path

### DIFF
--- a/core/runtime/v2/shim_load.go
+++ b/core/runtime/v2/shim_load.go
@@ -237,6 +237,9 @@ func (m *ShimManager) cleanupWorkDirs(ctx context.Context, rootDir string) error
 
 	f, err := os.Open(filepath.Join(rootDir, ns))
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
 		return err
 	}
 	defer f.Close()


### PR DESCRIPTION
While testing some things in moby, which involved removing storage paths, I noticed some errors being printed for non-existing paths. As this function is meant to delete the directories, it should probably be fine to consider it idempotent (as further processing in the function also does).