### PR TITLE
Fix port forward error logger to not cause concurrent write

### DIFF
--- a/internal/cri/streamingserver/portforward/httpstream.go
+++ b/internal/cri/streamingserver/portforward/httpstream.go
@@ -155,7 +155,7 @@ func (h *httpStreamHandler) getStreamPair(requestID string) (*httpStreamPair, bo
 func (h *httpStreamHandler) monitorStreamPair(p *httpStreamPair, timeout <-chan time.Time) {
 	select {
 	case <-timeout:
-		err := fmt.Errorf("(conn=%v, request=%s) timed out waiting for streams", h.conn, p.requestID)
+		err := fmt.Errorf("(conn=%p, request=%s) timed out waiting for streams", h.conn, p.requestID)
 		utilruntime.HandleError(err)
 		p.printError(err.Error())
 	case <-p.complete:


### PR DESCRIPTION
Fixes: #12033 

Change the logging output of a struct to only list the pointer value to remove the traversal of a map that is not thread safe and can at times generate a concurrent map write error.

Related to a similar fix in 1.7.x via #11302.

Will backport to `release/2.1` as-is; to fix `release/2.0` we will have to submit a PR to upstream k/k because this streaming code was still in the vendored kubelet code