### PR TITLE
erofs-differ: fix filesystem UUID for tar-converted layers

### DIFF
--- a/docs/snapshotters/erofs.md
+++ b/docs/snapshotters/erofs.md
@@ -98,13 +98,22 @@ forget to restart containerd after changing the configuration.
     default = ["erofs","walking"]
 ```
 
-Note that if erofs-utils is 1.8.2 or higher, it's preferred to add
-`--sort=none` to the differ's `mkfs_options` to avoid unnecessary tar data
-reordering for improved performance, as shown below:
+Note that if erofs-utils is version 1.8 or higher, you can add
+`-T0 --mkfs-time` to the differ's `mkfs_options` to enable reproducible
+builds, as shown below:
 
 ``` toml
   [plugins."io.containerd.differ.v1.erofs"]
-    mkfs_options = ["--sort=none"]
+    mkfs_options = ["-T0 --mkfs-time"]
+```
+
+If erofs-utils is 1.8.2 or higher, it's preferred to append `--sort=none` to
+the differ's `mkfs_options` to avoid unnecessary tar data reordering for
+improved performance, as shown below:
+
+``` toml
+  [plugins."io.containerd.differ.v1.erofs"]
+    mkfs_options = ["-T0 --mkfs-time --sort=none"]
 ```
 
 ### Running a container

--- a/internal/erofsutils/mount_linux.go
+++ b/internal/erofsutils/mount_linux.go
@@ -30,8 +30,11 @@ import (
 	"github.com/containerd/log"
 )
 
-func ConvertTarErofs(ctx context.Context, r io.Reader, layerPath string, mkfsExtraOpts []string) error {
+func ConvertTarErofs(ctx context.Context, r io.Reader, layerPath, uuid string, mkfsExtraOpts []string) error {
 	args := append([]string{"--tar=f", "--aufs", "--quiet", "-Enoinline_data"}, mkfsExtraOpts...)
+	if uuid != "" {
+		args = append(args, []string{"-U", uuid}...)
+	}
 	args = append(args, layerPath)
 	cmd := exec.CommandContext(ctx, "mkfs.erofs", args...)
 	cmd.Stdin = r

--- a/plugins/diff/erofs/differ_linux.go
+++ b/plugins/diff/erofs/differ_linux.go
@@ -43,6 +43,8 @@ import (
 	"github.com/containerd/containerd/v2/pkg/archive/compression"
 	"github.com/containerd/containerd/v2/pkg/epoch"
 	"github.com/containerd/containerd/v2/pkg/labels"
+
+	"github.com/google/uuid"
 )
 
 var emptyDesc = ocispec.Descriptor{}
@@ -299,7 +301,8 @@ func (s erofsDiff) Apply(ctx context.Context, desc ocispec.Descriptor, mounts []
 		r: io.TeeReader(processor, digester.Hash()),
 	}
 
-	err = erofsutils.ConvertTarErofs(ctx, rc, layerBlobPath, s.mkfsExtraOpts)
+	u := uuid.NewSHA1(uuid.NameSpaceURL, []byte("erofs:blobs/"+desc.Digest))
+	err = erofsutils.ConvertTarErofs(ctx, rc, layerBlobPath, u.String(), s.mkfsExtraOpts)
 	if err != nil {
 		return emptyDesc, fmt.Errorf("failed to convert erofs: %w", err)
 	}


### PR DESCRIPTION
Derive filesystem UUIDs (`lsblk -o +UUID`) from the OCI layer digests (although diffIDs are better in principle, but they're unavailable by differs in advance) rather than generating a random one.

This allows EROFS to uniquely identify each layer using the content-addressable filesystem UUID.

Note: currently **uuid.NewSHA1(uuid.NameSpaceURL, []byte("erofs:blobs/"+desc.Digest))** is used to generate filesystem UUIDs.