### PR TITLE
debug: add disk space usage logs for failed snapshotter tests

### DIFF
--- a/core/snapshots/testsuite/testsuite.go
+++ b/core/snapshots/testsuite/testsuite.go
@@ -18,6 +18,7 @@ package testsuite
 
 import (
 	"context"
+
 	//nolint:revive // go-digest needs the blank import. See https://github.com/opencontainers/go-digest#usage.
 	_ "crypto/sha256"
 	"fmt"
@@ -101,6 +102,13 @@ func makeTest(
 		if err := os.MkdirAll(root, 0777); err != nil {
 			t.Fatal(err)
 		}
+
+		t.Cleanup(func() {
+			if t.Failed() {
+				debugDiskUsage(t, tmpDir)
+				debugDiskUsage(t, root)
+			}
+		})
 
 		snapshotter, cleanup, err := snapshotterFn(ctx, root)
 		if err != nil {

--- a/core/snapshots/testsuite/testsuite_unix.go
+++ b/core/snapshots/testsuite/testsuite_unix.go
@@ -20,11 +20,23 @@ package testsuite
 
 import (
 	"syscall"
+	"testing"
 )
 
 func clearMask() func() {
 	oldumask := syscall.Umask(0)
 	return func() {
 		syscall.Umask(oldumask)
+	}
+}
+
+func debugDiskUsage(t *testing.T, root string) {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(root, &stat); err == nil {
+		t.Logf("Disk space for %s: blocks: %d, bfree: %d, bavail: %d, bsize: %d, free: %d MB, avail: %d MB",
+			root, stat.Blocks, stat.Bfree, stat.Bavail, stat.Bsize,
+			(uint64(stat.Bfree)*uint64(stat.Bsize))/(1024*1024),
+			(uint64(stat.Bavail)*uint64(stat.Bsize))/(1024*1024),
+		)
 	}
 }

--- a/core/snapshots/testsuite/testsuite_windows.go
+++ b/core/snapshots/testsuite/testsuite_windows.go
@@ -16,6 +16,12 @@
 
 package testsuite
 
+import "testing"
+
 func clearMask() func() {
 	return func() {}
+}
+
+func debugDiskUsage(_ *testing.T, _ string) {
+	// No-op for Windows.
 }


### PR DESCRIPTION
This change adds some debug logs to help root cause #12055