### PR TITLE
Remove additional fuzzers from instrumentation repo

### DIFF
--- a/contrib/fuzz/oss_fuzz_build.sh
+++ b/contrib/fuzz/oss_fuzz_build.sh
@@ -37,10 +37,6 @@ compile_fuzzers() {
     done
 }
 
-# This is from https://github.com/AdamKorcz/instrumentation
-cd $SRC/instrumentation
-go run main.go --target_dir $SRC/containerd/images
-
 apt-get update && apt-get install -y wget
 cd $SRC
 wget --quiet https://go.dev/dl/go1.24.4.linux-amd64.tar.gz


### PR DESCRIPTION
Related to #12007 

This change removes the additional fuzzers from AdamKorcz/instrumentation repository. This is to unblock changes in containerd release/1.7 stable branch where the fuzzing workflow is failing due to compilation issues caused by higher Go toolchain requirement in mainline.